### PR TITLE
debug deleted sichains

### DIFF
--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -198,6 +198,9 @@ func (p CommandLine) IsMobileExtension() (bool, bool) {
 func (p CommandLine) GetSlowGregorConn() (bool, bool) {
 	return p.GetBool("slow-gregor-conn", true)
 }
+func (p CommandLine) GetReadDeletedSigChain() (bool, bool) {
+	return p.GetBool("read-deleted-sigchain", true)
+}
 func (p CommandLine) GetGString(s string) string {
 	return p.ctx.GlobalString(s)
 }
@@ -589,6 +592,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.BoolFlag{
 			Name:  "slow-gregor-conn",
 			Usage: "Slow responses from gregor for testing",
+		},
+		cli.BoolFlag{
+			Name:  "read-deleted-sigchain",
+			Usage: "Allow admins to read deleted sigchains for debugging.",
 		},
 		cli.StringFlag{
 			Name:  "socket-file",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -829,6 +829,10 @@ func (f *JSONConfigFile) GetSlowGregorConn() (bool, bool) {
 	return f.GetBoolAtPath("slow_gregor_conn")
 }
 
+func (f *JSONConfigFile) GetReadDeletedSigChain() (bool, bool) {
+	return f.GetBoolAtPath("read_deleted_sigchain")
+}
+
 func (f *JSONConfigFile) SetRememberPassphrase(remember bool) error {
 	return f.SetBoolAtPath("remember_passphrase", remember)
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -102,6 +102,7 @@ func (n NullConfiguration) GetFeatureFlags() (FeatureFlags, error)          { re
 func (n NullConfiguration) GetAppType() AppType                             { return NoAppType }
 func (n NullConfiguration) IsMobileExtension() (bool, bool)                 { return false, false }
 func (n NullConfiguration) GetSlowGregorConn() (bool, bool)                 { return false, false }
+func (n NullConfiguration) GetReadDeletedSigChain() (bool, bool)            { return false, false }
 func (n NullConfiguration) GetRememberPassphrase() (bool, bool)             { return false, false }
 func (n NullConfiguration) GetLevelDBNumFiles() (int, bool)                 { return 0, false }
 func (n NullConfiguration) GetChatInboxSourceLocalizeThreads() (int, bool)  { return 1, false }
@@ -1042,6 +1043,14 @@ func (e *Env) GetSlowGregorConn() bool {
 	)
 }
 
+func (e *Env) GetReadDeletedSigChain() bool {
+	return e.GetBool(false,
+		func() (bool, bool) { return e.cmd.GetReadDeletedSigChain() },
+		func() (bool, bool) { return e.getEnvBool("KEYBASE_READ_DELETED_SIGCHAIN") },
+		func() (bool, bool) { return e.GetConfig().GetReadDeletedSigChain() },
+	)
+}
+
 func (e *Env) GetFeatureFlags() FeatureFlags {
 	var ret FeatureFlags
 	pick := func(f FeatureFlags, err error) {
@@ -1370,6 +1379,10 @@ func (c AppConfig) IsMobileExtension() (bool, bool) {
 }
 
 func (c AppConfig) GetSlowGregorConn() (bool, bool) {
+	return false, false
+}
+
+func (c AppConfig) GetReadDeletedSigChain() (bool, bool) {
 	return false, false
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -35,6 +35,7 @@ type configGetter interface {
 	GetAppType() AppType
 	IsMobileExtension() (bool, bool)
 	GetSlowGregorConn() (bool, bool)
+	GetReadDeletedSigChain() (bool, bool)
 	GetAutoFork() (bool, bool)
 	GetChatDbFilename() string
 	GetPvlKitFilename() string

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -226,6 +226,10 @@ func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keyba
 	m.CDebugf("+ Load SigChain from server (uid=%s, low=%d)", sc.uid, low)
 	defer func() { m.CDebugf("- Loaded SigChain -> %s", ErrToOk(err)) }()
 
+	// Signal if you want to read deleted sig chains for debugging, requires
+	// admin permissions to be honored on the server.
+	readDeleted := m.G().Env.GetReadDeletedSigChain()
+
 	resp, finisher, err := sc.G().API.GetResp(APIArg{
 		Endpoint:    "sig/get",
 		SessionType: APISessionTypeOPTIONAL,
@@ -233,6 +237,7 @@ func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keyba
 			"uid":           UIDArg(sc.uid),
 			"low":           I{int(low)},
 			"v2_compressed": B{true},
+			"read_deleted":  B{readDeleted},
 		},
 		MetaContext: m,
 	})


### PR DESCRIPTION
allows admin to debug deleted sigchains via an env flag. needs the server pr https://github.com/keybase/keybase/pull/2952 to check the flag/admin perms of the user

running service with the flag: 
```
$ kb id ta2
▶ INFO Identifying ta2
ta2 hasn't proven their identity yet.
```

without:
```
$ kb id ta2
▶ ERROR User deleted
```