### PR TITLE
audit perf: feature-flag audits off during testing period

### DIFF
--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -51,7 +51,8 @@ type FeatureFlagSet struct {
 }
 
 const (
-	FeatureFTL = Feature("ftl")
+	FeatureFTL   = Feature("ftl")
+	FeatureAudit = Feature("audit")
 )
 
 // NewFeatureFlagSet makes a new set of feature flags.

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -103,6 +103,11 @@ func (a *Auditor) AuditTeam(m libkb.MetaContext, id keybase1.TeamID, isPublic bo
 		return NewBadPublicError(id, isPublic)
 	}
 
+	if !m.G().FeatureFlags.Enabled(m, libkb.FeatureAudit) {
+		m.CInfof("Audits are feature-flagged off during a brief testing period")
+		return nil
+	}
+
 	// Single-flight lock by team ID.
 	lock := a.locktab.AcquireOnName(m.Ctx(), m.G(), id.String())
 	defer lock.Release(m.Ctx())


### PR DESCRIPTION
We had a load problem caused by team audits today, and we'd like the
ability to toggle them off from the server-side while we load-test the
feature. We'll remove this feature flag shortly