### PR TITLE
Padding for line code snippets

### DIFF
--- a/shared/common-adapters/markdown.desktop.js
+++ b/shared/common-adapters/markdown.desktop.js
@@ -27,6 +27,7 @@ const codeSnippetStyle = {
   fontSize: 12,
   paddingLeft: globalMargins.xtiny,
   paddingRight: globalMargins.xtiny,
+  paddingTop: globalMargins.xxxtiny,
 }
 
 const codeSnippetBlockStyle = platformStyles({

--- a/shared/common-adapters/markdown.desktop.js
+++ b/shared/common-adapters/markdown.desktop.js
@@ -28,6 +28,7 @@ const codeSnippetStyle = {
   paddingLeft: globalMargins.xtiny,
   paddingRight: globalMargins.xtiny,
   paddingTop: globalMargins.xxxtiny,
+  paddingBottom: globalMargins.xxxtiny,
 }
 
 const codeSnippetBlockStyle = platformStyles({

--- a/shared/styles/shared.js
+++ b/shared/styles/shared.js
@@ -5,6 +5,7 @@ import type {_StylesCrossPlatform, _StylesMobile, _StylesDesktop} from './css'
 
 /* eslint-disable sort-keys */
 export const globalMargins = {
+  xxxtiny: 1,
   xxtiny: 2,
   xtiny: 4,
   tiny: 8,


### PR DESCRIPTION
Before:
![2018-10-03-101753_372x158_scrot](https://user-images.githubusercontent.com/28712558/46416670-0ac90200-c6f6-11e8-861d-1dfa1a163ebb.png)


After:
![2018-10-03-102507_367x153_scrot](https://user-images.githubusercontent.com/28712558/46416947-9e023780-c6f6-11e8-8cb5-5c37d99cf113.png)


`foo`
`bar`