### PR TITLE
dont' log error for invalid sig hint

### DIFF
--- a/go/libkb/sig_hints.go
+++ b/go/libkb/sig_hints.go
@@ -26,6 +26,9 @@ func (sh SigHint) GetAPIURL() string    { return sh.apiURL }
 func (sh SigHint) GetCheckText() string { return sh.checkText }
 
 func NewSigHint(jw *jsonw.Wrapper) (sh *SigHint, err error) {
+	if jw == nil {
+		return nil, nil
+	}
 	sh = &SigHint{}
 	sh.sigID, err = GetSigID(jw.AtKey("sig_id"), true)
 	sh.remoteID, _ = jw.AtKey("remote_id").GetString()


### PR DESCRIPTION
prevents `ERROR Bad cached CheckResult for ...`  from showing when the `VerifiedSigHint` is missing from cache. 

should we also change some of these `Errorf` calls to `Debug` so they don't show up if they're not critical? https://github.com/keybase/client/blob/master/go/libkb/proof_cache.go#L240