### PR TITLE
Sort accounts by primary,name

### DIFF
--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -365,7 +365,7 @@ func (s *Server) WalletGetAccountsCLILocal(ctx context.Context) (ret []stellar1.
 		ret = append(ret, acc)
 	}
 
-	// Put the primary account first
+	// Put the primary account first, then sort by name, then by account ID
 	sort.SliceStable(ret, func(i, j int) bool {
 		if ret[i].IsPrimary {
 			return true
@@ -373,7 +373,10 @@ func (s *Server) WalletGetAccountsCLILocal(ctx context.Context) (ret []stellar1.
 		if ret[j].IsPrimary {
 			return false
 		}
-		return i < j
+		if ret[i].Name == ret[j].Name {
+			return ret[i].AccountID < ret[j].AccountID
+		}
+		return ret[i].Name < ret[j].Name
 	})
 
 	return ret, accountError

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -157,7 +157,7 @@ export type Request = I.RecordOf<_Request>
 export type ValidationState = 'none' | 'waiting' | 'error' | 'valid'
 
 export type _State = {
-  accountMap: I.Map<AccountID, Account>,
+  accountMap: I.OrderedMap<AccountID, Account>,
   accountName: string,
   accountNameError: string,
   accountNameValidationState: ValidationState,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -45,7 +45,7 @@ const makeBuiltPayment: I.RecordFactory<Types._BuiltPayment> = I.Record({
 })
 
 const makeState: I.RecordFactory<Types._State> = I.Record({
-  accountMap: I.Map(),
+  accountMap: I.OrderedMap(),
   accountName: '',
   accountNameError: '',
   accountNameValidationState: 'none',

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -12,7 +12,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.resetStore:
       return initialState
     case WalletsGen.accountsReceived:
-      const accountMap = I.Map(action.payload.accounts.map(account => [account.accountID, account]))
+      const accountMap = I.OrderedMap(action.payload.accounts.map(account => [account.accountID, account]))
       return state.set('accountMap', accountMap)
     case WalletsGen.assetsReceived:
       return state.setIn(['assetsMap', action.payload.accountID], I.List(action.payload.assets))


### PR DESCRIPTION
Wallet accounts are sorted alphabetically by name but with the primary account first. Gui uses service's ordering. If OrderedMap is going to be a performance hit can do something more complicated cc @buoyad  