### PR TITLE
use service temp file for implementing share action CORE-9060

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -101,13 +101,11 @@ export const updateTypers = 'chat2:updateTypers'
 type _AttachmentDownloadPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
   ordinal: Types.Ordinal,
-  forShare?: boolean,
 |}>
 type _AttachmentDownloadedPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,
   ordinal: Types.Ordinal,
   path?: string,
-  forShare?: boolean,
 |}>
 type _AttachmentLoadingPayload = $ReadOnly<{|
   conversationIDKey: Types.ConversationIDKey,

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -30,7 +30,7 @@ import {isMobile} from '../../constants/platform'
 import {getPath} from '../../route-tree'
 import {switchTo} from '../route-tree'
 import {NotifyPopup} from '../../native/notifications'
-import {saveAttachmentToCameraRoll, downloadAndShowShareActionSheet} from '../platform-specific'
+import {saveAttachmentToCameraRoll, showShareActionSheetFromFile} from '../platform-specific'
 import {downloadFilePath} from '../../util/file'
 import {privateFolderWithUsers, teamFolder} from '../../constants/config'
 import flags from '../../util/feature-flags'
@@ -2057,19 +2057,8 @@ function* mobileMessageAttachmentShare(action: Chat2Gen.MessageAttachmentNativeS
   if (!message || message.type !== 'attachment') {
     throw new Error('Invalid share message')
   }
-  if (!message.fileURLCached) {
-    yield Saga.put(
-      Chat2Gen.createAttachmentDownload({
-        conversationIDKey: message.conversationIDKey,
-        ordinal: message.ordinal,
-      })
-    )
-  }
-  yield Saga.sequentially([
-    Saga.put(Chat2Gen.createAttachmentDownload({conversationIDKey, ordinal, forShare: true})),
-    Saga.call(downloadAndShowShareActionSheet, message.fileURL, message.fileType),
-    Saga.put(Chat2Gen.createAttachmentDownloaded({conversationIDKey, ordinal, forShare: true})),
-  ])
+  const fileName = yield Saga.call(downloadAttachment, '', conversationIDKey, message, message.ordinal)
+  yield Saga.call(showShareActionSheetFromFile, fileName, message.fileType)
 }
 
 // Native save to camera roll

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2052,7 +2052,11 @@ function* mobileMessageAttachmentShare(action: Chat2Gen.MessageAttachmentNativeS
     throw new Error('Invalid share message')
   }
   const fileName = yield Saga.call(downloadAttachment, '', conversationIDKey, message, message.ordinal)
-  yield Saga.call(showShareActionSheetFromFile, fileName, message.fileType)
+  try {
+    yield Saga.call(showShareActionSheetFromFile, fileName, message.fileType)
+  } catch (e) {
+    logger.error('Failed to share attachment: ' + JSON.stringify(e))
+  }
 }
 
 // Native save to camera roll

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1694,14 +1694,8 @@ function* downloadAttachment(fileName: string, conversationIDKey: any, message: 
 
 // Download an attachment to your device
 function* attachmentDownload(action: Chat2Gen.AttachmentDownloadPayload) {
-  const {conversationIDKey, forShare, ordinal} = action.payload
-  if (forShare) {
-    // We are sharing an attachment on mobile,
-    // the reducer handles setting the appropriate
-    // flags in this case
-    // TODO DESKTOP-6562 refactor this logic
-    return
-  }
+  const {conversationIDKey, ordinal} = action.payload
+
   const state: TypedState = yield Saga.select()
   let message = Constants.getMessage(state, conversationIDKey, ordinal)
 

--- a/shared/actions/fs/platform-specific.android.js
+++ b/shared/actions/fs/platform-specific.android.js
@@ -7,7 +7,7 @@ import RNFetchBlob from 'rn-fetch-blob'
 import {copy, unlink} from '../../util/file'
 import {PermissionsAndroid} from 'react-native'
 import {pickAndUploadToPromise} from './common.native'
-import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
+import {saveAttachmentDialog, showShareActionSheetFromURL} from '../platform-specific'
 
 function copyToDownloadDir(path: string, mimeType: string) {
   const fileName = path.substring(path.lastIndexOf('/') + 1)
@@ -55,7 +55,7 @@ const downloadSuccessToAction = (state: TypedState, action: FsGen.DownloadSucces
       ])
     case 'share':
       return Saga.sequentially([
-        Saga.call(showShareActionSheet, {url: localPath, mimeType}),
+        Saga.call(showShareActionSheetFromURL, {url: localPath, mimeType}),
         Saga.put(FsGen.createDismissDownload({key})),
       ])
     case 'none':

--- a/shared/actions/fs/platform-specific.ios.js
+++ b/shared/actions/fs/platform-specific.ios.js
@@ -4,7 +4,7 @@ import * as Saga from '../../util/saga'
 import * as FsGen from '../fs-gen'
 import {type TypedState} from '../../util/container'
 import {pickAndUploadToPromise} from './common.native'
-import {saveAttachmentDialog, showShareActionSheet} from '../platform-specific'
+import {saveAttachmentDialog, showShareActionSheetFromURL} from '../platform-specific'
 
 const downloadSuccessToAction = (state: TypedState, action: FsGen.DownloadSuccessPayload) => {
   const {key, mimeType} = action.payload
@@ -22,7 +22,7 @@ const downloadSuccessToAction = (state: TypedState, action: FsGen.DownloadSucces
       ])
     case 'share':
       return Saga.sequentially([
-        Saga.call(showShareActionSheet, {url: localPath, mimeType}),
+        Saga.call(showShareActionSheetFromURL, {url: localPath, mimeType}),
         Saga.put(FsGen.createDismissDownload({key})),
       ])
     case 'none':

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -292,8 +292,7 @@
     // We want to save an attachment to the local disk
     "attachmentDownload": {
       "conversationIDKey": "Types.ConversationIDKey",
-      "ordinal": "Types.Ordinal",
-      "forShare?": "boolean"
+      "ordinal": "Types.Ordinal"
     },
     // Saving an attachment to mobile storage
     "attachmentMobileSave": {
@@ -316,8 +315,7 @@
     "attachmentDownloaded": {
       "conversationIDKey": "Types.ConversationIDKey",
       "ordinal": "Types.Ordinal",
-      "path?": "string",
-      "forShare?": "boolean"
+      "path?": "string"
     },
     // We want to upload some attachments
     "attachmentsUpload": {

--- a/shared/actions/platform-specific/index.js.flow
+++ b/shared/actions/platform-specific/index.js.flow
@@ -1,10 +1,10 @@
 // @flow
 import * as Saga from '../../util/saga'
-declare export function showShareActionSheet(options: {url?: ?any, message?: ?any}): Promise<{
+declare export function showShareActionSheetFromURL(options: {url?: ?any, message?: ?any}): Promise<{
   completed: boolean,
   method: string,
 }>
-declare export function downloadAndShowShareActionSheet(fileURL: string): Promise<void>
+declare export function showShareActionSheetFromFile(fileURL: string): Promise<void>
 
 type NextURI = string
 declare export function saveAttachmentDialog(filePath: string): Promise<NextURI>

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -255,9 +255,6 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
         return message.set('transferState', null)
       })
     case Chat2Gen.attachmentDownload:
-      if (!action.payload.forShare) {
-        return messageMap
-      }
       return messageMap.updateIn([action.payload.conversationIDKey, action.payload.ordinal], message => {
         if (!message || message.type !== 'attachment') {
           return message
@@ -268,9 +265,6 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
       return messageMap.updateIn([action.payload.conversationIDKey, action.payload.ordinal], message => {
         if (!message || message.type !== 'attachment') {
           return message
-        }
-        if (action.payload.forShare) {
-          return message.set('transferState', null)
         }
         const path = action.error ? '' : action.payload.path
         return message


### PR DESCRIPTION
@keybase/react-hackers 

This does the same thing we did for 'Save' for attachments, uses the service to create the temp file before sharing it. Also cleans up some of this code. 