### PR TITLE
don't force refresh when using FTL to lookup team names

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -114,6 +114,13 @@ func (g *gregorTestConnection) BroadcastMessage(ctx context.Context, m gregor1.M
 					return err
 				}
 				teams.HandleSBSRequest(ctx, g.G().ExternalG(), msg)
+			case "team.change":
+				var msg []keybase1.TeamChangeRow
+				if err := json.Unmarshal(creation.Body().Bytes(), &msg); err != nil {
+					g.G().Log.CDebugf(ctx, "error unmarshaling team.change items: %s", err)
+					return err
+				}
+				teams.HandleChangeNotification(ctx, g.G().ExternalG(), msg, keybase1.TeamChangeSet{})
 			}
 		}
 	}

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -338,9 +338,8 @@ func (t *TeamsNameInfoSource) LookupName(ctx context.Context, tlfID chat1.TLFID,
 
 	m := libkb.NewMetaContext(ctx, t.G().ExternalG())
 	loadRes, err := m.G().GetFastTeamLoader().Load(m, keybase1.FastTeamLoadArg{
-		ID:           teamID,
-		Public:       teamID.IsPublic(),
-		ForceRefresh: true,
+		ID:     teamID,
+		Public: teamID.IsPublic(),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- The sticking point here was CI, which we hacked to pass
- Hack CI by just polling for the right update