### PR TITLE
lower wait time for service check

### DIFF
--- a/go/launchd/launchd.go
+++ b/go/launchd/launchd.go
@@ -103,7 +103,7 @@ func (s Service) Start(wait time.Duration) error {
 	}
 
 	if wait > 0 {
-		status, waitErr := s.WaitForStatus(wait, 500*time.Millisecond)
+		status, waitErr := s.WaitForStatus(wait, 100*time.Millisecond)
 		if waitErr != nil {
 			return waitErr
 		}

--- a/go/libkb/service_info.go
+++ b/go/libkb/service_info.go
@@ -102,7 +102,7 @@ func WaitForServiceInfoFile(path string, label string, pid string, timeout time.
 	}
 
 	log.Debug("Looking for service info file (timeout=%s)", timeout)
-	serviceInfo, err := waitForServiceInfo(timeout, time.Millisecond*400, lookForServiceInfo)
+	serviceInfo, err := waitForServiceInfo(timeout, time.Millisecond*100, lookForServiceInfo)
 
 	// If no service info was found, let's return an error
 	if serviceInfo == nil {


### PR DESCRIPTION
These wait times guarantee we sit around for 900ms on every startup, we can lower it and likely be fine. 