### PR TITLE
fix bad cache result

### DIFF
--- a/go/libkb/sig_hints.go
+++ b/go/libkb/sig_hints.go
@@ -26,7 +26,7 @@ func (sh SigHint) GetAPIURL() string    { return sh.apiURL }
 func (sh SigHint) GetCheckText() string { return sh.checkText }
 
 func NewSigHint(jw *jsonw.Wrapper) (sh *SigHint, err error) {
-	if jw == nil {
+	if jw == nil || !jw.IsOk() {
 		return nil, nil
 	}
 	sh = &SigHint{}


### PR DESCRIPTION
this wasn't fixed initially but is now, was still getting: `*jsonw.Error=<root>.verified_hint: no such key: verified_hint`