### PR TITLE
Stellar: only show user avatar on default account, not secondaries

### DIFF
--- a/shared/wallets/common/account-entry/index.js
+++ b/shared/wallets/common/account-entry/index.js
@@ -7,6 +7,7 @@ type AccountEntryProps = {|
   center?: boolean,
   fullWidth?: boolean,
   contents: string,
+  isDefault?: boolean,
   keybaseUser: string,
   name: string,
   showWalletIcon: boolean,
@@ -16,46 +17,45 @@ type AccountEntryProps = {|
 // A row display of an account, used by the participants components.
 // TODO AccountEntry is mostly copied from WalletRow, with some row specific
 // properties removed. WalletRow could probably be a wrapper around AccountEntry.
-const AccountEntry = (props: AccountEntryProps) => {
-  return (
-    <Kb.Box2
-      style={Styles.collapseStyles([styles.containerBox, props.style])}
-      direction="horizontal"
-      gap="tiny"
-      centerChildren={props.center}
-      fullWidth={props.fullWidth}
-    >
-      {props.showWalletIcon && (
-        <Kb.Icon
-          type={Styles.isMobile ? 'icon-wallet-32' : 'icon-wallet-64'}
-          color={Styles.globalColors.black_75}
-          style={Kb.iconCastPlatformStyles(styles.icon)}
-        />
-      )}
-      <Kb.Box2 direction="vertical" style={styles.rightColumn}>
-        <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.user}>
-          {props.keybaseUser && (
+const AccountEntry = (props: AccountEntryProps) => (
+  <Kb.Box2
+    style={Styles.collapseStyles([styles.containerBox, props.style])}
+    direction="horizontal"
+    gap="tiny"
+    centerChildren={props.center}
+    fullWidth={props.fullWidth}
+  >
+    {props.showWalletIcon && (
+      <Kb.Icon
+        type={Styles.isMobile ? 'icon-wallet-32' : 'icon-wallet-64'}
+        color={Styles.globalColors.black_75}
+        style={Kb.iconCastPlatformStyles(styles.icon)}
+      />
+    )}
+    <Kb.Box2 direction="vertical" style={styles.rightColumn}>
+      <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.user}>
+        {props.keybaseUser &&
+          props.isDefault && (
             <Kb.Avatar
               size={16}
               style={Kb.avatarCastPlatformStyles(styles.avatar)}
               username={props.keybaseUser}
             />
           )}
-          <Kb.Text type="BodySemibold" style={styles.title}>
-            {props.name}
-          </Kb.Text>
-        </Kb.Box2>
-        <Kb.Text
-          type="BodySmall"
-          selectable={true}
-          style={Styles.collapseStyles([styles.amount, props.center ? {textAlign: 'center'} : {}])}
-        >
-          {props.contents}
+        <Kb.Text type="BodySemibold" style={styles.title}>
+          {props.name}
         </Kb.Text>
       </Kb.Box2>
+      <Kb.Text
+        type="BodySmall"
+        selectable={true}
+        style={Styles.collapseStyles([styles.amount, props.center ? {textAlign: 'center'} : {}])}
+      >
+        {props.contents}
+      </Kb.Text>
     </Kb.Box2>
-  )
-}
+  </Kb.Box2>
+)
 
 AccountEntry.defaultProps = {
   showWalletIcon: true,

--- a/shared/wallets/common/account-entry/index.stories.js
+++ b/shared/wallets/common/account-entry/index.stories.js
@@ -13,7 +13,7 @@ const load = () => {
   Sb.storiesOf('Wallets/Common/Account Entry', module)
     .add('Default', () => <AccountEntry {...account} />)
     .add('Centered with no wallet icon', () => (
-      <AccountEntry {...account} center={true} showWalletIcon={false} />
+      <AccountEntry {...account} isDefault={true} center={true} showWalletIcon={false} />
     ))
 }
 

--- a/shared/wallets/confirm-form/participants/container.js
+++ b/shared/wallets/confirm-form/participants/container.js
@@ -14,18 +14,21 @@ const mapStateToProps = (state: TypedState) => {
   const recipientFullName = userInfo ? userInfo.fullname : ''
   const fromAccount = getAccount(state, stringToAccountID(built.from))
   const recipientAccount = getAccount(state, stringToAccountID(build.to))
+  const recipientAccountIsDefault = recipientAccount.isDefault
   const recipientStellarAddress = build.to
 
   return {
     recipientType,
     yourUsername: state.config.username,
     fromAccountAssets: fromAccount.balanceDescription,
+    fromAccountIsDefault: fromAccount.isDefault,
     fromAccountName: fromAccount.name || fromAccount.accountID,
     recipientAccountAssets: recipientAccount.balanceDescription,
     recipientAccountName: recipientAccount.name || recipientAccount.accountID,
-    recipientUsername,
+    recipientAccountIsDefault,
     recipientFullName,
     recipientStellarAddress,
+    recipientUsername,
   }
 }
 

--- a/shared/wallets/confirm-form/participants/index.js
+++ b/shared/wallets/confirm-form/participants/index.js
@@ -8,6 +8,7 @@ import type {CounterpartyType} from '../../../constants/types/wallets'
 export type ParticipantsProps = {|
   recipientType: CounterpartyType,
   yourUsername: string,
+  fromAccountIsDefault: boolean,
   fromAccountName: string,
   fromAccountAssets: string,
   // Must have a recipient user, stellar address, or account
@@ -15,6 +16,7 @@ export type ParticipantsProps = {|
   recipientFullName?: string,
   recipientStellarAddress?: string,
   recipientAccountName?: string,
+  recipientAccountIsDefault?: boolean,
   recipientAccountAssets?: string,
 |}
 
@@ -58,9 +60,10 @@ const Participants = (props: ParticipantsProps) => {
       }
       toFieldContent = (
         <AccountEntry
+          contents={props.recipientAccountAssets}
+          isDefault={props.recipientAccountIsDefault}
           keybaseUser={props.yourUsername}
           name={props.recipientAccountName}
-          contents={props.recipientAccountAssets}
         />
       )
       break
@@ -70,9 +73,10 @@ const Participants = (props: ParticipantsProps) => {
     <Kb.Box2 direction="vertical" fullWidth={true}>
       <ParticipantsRow heading="From">
         <AccountEntry
+          contents={props.fromAccountAssets}
+          isDefault={props.fromAccountIsDefault}
           keybaseUser={props.yourUsername}
           name={props.fromAccountName}
-          contents={props.fromAccountAssets}
         />
       </ParticipantsRow>
       <ParticipantsRow heading="To" bottomDivider={false}>

--- a/shared/wallets/confirm-form/participants/index.stories.js
+++ b/shared/wallets/confirm-form/participants/index.stories.js
@@ -7,8 +7,10 @@ const provider = Sb.createPropProviderWithCommon()
 
 const defaultProps = {
   fromAccountAssets: '2000 XLM',
+  fromAccountIsDefault: true,
   fromAccountName: 'Primary Account',
   recipientAccountAssets: '123 XLM',
+  recipientAccountIsDefault: false,
   recipientAccountName: 'Secondary Account',
   recipientFullName: 'Addie Stokes',
   recipientStellarAddress: 'GBQTE2V7Y356TFBZL6YZ2PA3KIILNSAAQRV5C7MVWS22KQTS4EMK7I4',

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -63,6 +63,7 @@ const ConnectedParticipantsStellarPublicKey = compose(
 const makeAccount = (stateAccount: StateAccount) => ({
   contents: stateAccount.balanceDescription,
   id: stateAccount.accountID,
+  isDefault: stateAccount.isDefault,
   name: stateAccount.name || stateAccount.accountID,
 })
 
@@ -77,10 +78,10 @@ const mapStateToPropsOtherAccount = (state: TypedState) => {
     .toArray()
 
   return {
-    user: state.config.username,
+    allAccounts,
     fromAccount,
     toAccount,
-    allAccounts,
+    user: state.config.username,
   }
 }
 
@@ -91,21 +92,21 @@ const mapDispatchToPropsOtherAccount = (dispatch: Dispatch) => ({
   onChangeRecipient: (to: string) => {
     dispatch(WalletsGen.createSetBuildingTo({to}))
   },
-  onLinkAccount: () =>
-    dispatch(
-      RouteTree.navigateAppend([
-        {
-          props: {backButton: true},
-          selected: 'linkExisting',
-        },
-      ])
-    ),
   onCreateNewAccount: () =>
     dispatch(
       RouteTree.navigateAppend([
         {
           props: {backButton: true},
           selected: 'createNewAccount',
+        },
+      ])
+    ),
+  onLinkAccount: () =>
+    dispatch(
+      RouteTree.navigateAppend([
+        {
+          props: {backButton: true},
+          selected: 'linkExisting',
         },
       ])
     ),

--- a/shared/wallets/send-form/participants/dropdown.js
+++ b/shared/wallets/send-form/participants/dropdown.js
@@ -24,7 +24,7 @@ type SelectedEntryProps = {
 // The display of the selected account in the dropdown.
 export const SelectedEntry = ({account, user, ...props}: SelectedEntryProps) => (
   <Kb.Box2 {...props} direction="horizontal" centerChildren={true} gap="tiny" fullWidth={true}>
-    <Kb.Avatar size={16} username={user} />
+    {account.isDefault && <Kb.Avatar size={16} username={user} />}
     <Kb.Text type="BodySemibold" style={styles.text}>
       {account.name}
     </Kb.Text>
@@ -42,6 +42,7 @@ export const DropdownEntry = (props: DropdownEntryProps) => (
     keybaseUser={props.user}
     name={props.account.name}
     contents={props.account.contents}
+    isDefault={props.account.isDefault}
     showWalletIcon={false}
     center={true}
     fullWidth={true}

--- a/shared/wallets/send-form/participants/index.js
+++ b/shared/wallets/send-form/participants/index.js
@@ -27,6 +27,7 @@ export type Account = {|
   contents: string,
   name: string,
   id: AccountID,
+  isDefault: boolean,
 |}
 
 type ParticipantsOtherAccountProps = {|

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -80,6 +80,7 @@ const primaryAccount: Account = {
   name: 'Primary Account',
   contents: '2000 XLM',
   id: stringToAccountID('fakeaccountID'),
+  isDefault: true,
 }
 
 const accounts = [
@@ -88,11 +89,13 @@ const accounts = [
     name: 'Secondary Account',
     contents: '6435 XLM',
     id: stringToAccountID('fakeaccountID2'),
+    isDefault: false,
   },
   {
     name: 'third Account',
     contents: '10 XLM',
     id: stringToAccountID('fakeaccountID3'),
+    isDefault: false,
   },
 ]
 


### PR DESCRIPTION
@keybase/react-hackers 

All the non-default accounts are anonymous (not linked to the Keybase identity) so they shouldn't show the avatar in the account picker.