### PR TITLE
Provisioning fixes

### DIFF
--- a/shared/actions/__tests__/provision.test.js
+++ b/shared/actions/__tests__/provision.test.js
@@ -88,7 +88,7 @@ describe('provisioningManagerProvisioning', () => {
       callMap[k]((undefined: any), response)
       expect(response.result).not.toHaveBeenCalled()
       expect(response.error).toHaveBeenCalledWith({
-        code: RPCTypes.constantsStatusCode.scgeneric,
+        code: RPCTypes.constantsStatusCode.scinputcanceled,
         desc: Constants.cancelDesc,
       })
     })
@@ -609,7 +609,7 @@ describe('canceling provision', () => {
     dispatch(RouteTree.navigateUp())
     expect(response.result).not.toHaveBeenCalled()
     expect(response.error).toHaveBeenCalledWith({
-      code: RPCTypes.constantsStatusCode.scgeneric,
+      code: RPCTypes.constantsStatusCode.scinputcanceled,
       desc: Constants.cancelDesc,
     })
     expect(manager._stashedResponse).toEqual(null)
@@ -667,7 +667,7 @@ describe('final errors show', () => {
 
   it('ignore cancel', () => {
     const {getState, dispatch, getRoutePath} = startReduxSaga()
-    const error = new RPCError(Constants.cancelDesc, RPCTypes.constantsStatusCode.scgeneric)
+    const error = new RPCError(Constants.cancelDesc, RPCTypes.constantsStatusCode.scinputcanceled)
     dispatch(ProvisionGen.createShowFinalErrorPage({finalError: error}))
     expect(getState().provision.finalError).toEqual(null)
     expect(getRoutePath()).toEqual(I.List([Tabs.loginTab]))

--- a/shared/actions/provision.js
+++ b/shared/actions/provision.js
@@ -30,7 +30,7 @@ type ValidCallback =
   | 'keybase.1.secretUi.getPassphrase'
 
 const cancelOnCallback = (_: any, response: CommonResponseHandler) => {
-  response.error({code: RPCTypes.constantsStatusCode.scgeneric, desc: Constants.cancelDesc})
+  response.error({code: RPCTypes.constantsStatusCode.scinputcanceled, desc: Constants.cancelDesc})
 }
 const ignoreCallback = (_: any) => {}
 

--- a/shared/constants/provision.js
+++ b/shared/constants/provision.js
@@ -8,7 +8,7 @@ import HiddenString from '../util/hidden-string'
 export const waitingKey = 'provision:waiting'
 
 // Do NOT change this. This is the value used by the daemon also so this way we can ignore it when they do it / when we do
-export const cancelDesc = 'kex canceled by caller'
+export const cancelDesc = 'Input canceled'
 
 export const makeState: I.RecordFactory<Types._State> = I.Record({
   codePageIncomingTextCode: new HiddenString(''),

--- a/shared/engine/transport-shared.js
+++ b/shared/engine/transport-shared.js
@@ -132,7 +132,7 @@ class TransportShared extends RobustTransport {
       calls.forEach(call => {
         payload.response[call] = _wrap({
           enforceOnlyOnce: true,
-          extra: payload,
+          extra: response => ({response, payload}),
           handler: (...args) => {
             oldResponse[call](...args)
           },


### PR DESCRIPTION
- [x] better logging of responses
- [x] maybeCancelProvision used to submit a cancel and wait, but now it'll nav you all the way back
- [x] better logging when initial provision call finishes, marking singleton as done
- [x] final error page is always layered on top of root and not appended to so clicking back puts you back to the right place
- [x] use better cancel method. fixes clicking back on paperkey screen not exiting login flow