### PR TITLE
Use getBalanceChangeColor in message menu

### DIFF
--- a/shared/chat/conversation/messages/message-popup/payment/container.js
+++ b/shared/chat/conversation/messages/message-popup/payment/container.js
@@ -3,10 +3,10 @@ import * as React from 'react'
 import * as Container from '../../../../../util/container'
 import * as Constants from '../../../../../constants/chat2'
 import * as Types from '../../../../../constants/types/chat2'
+import * as WalletConstants from '../../../../../constants/wallets'
 import * as WalletTypes from '../../../../../constants/types/wallets'
 import * as WalletGen from '../../../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
-import * as Styles from '../../../../../styles'
 import {walletsTab} from '../../../../../constants/tabs'
 import {formatTimeForMessages} from '../../../../../util/timestamp'
 import PaymentPopup from '.'
@@ -81,12 +81,15 @@ const sendMergeProps = (stateProps, dispatchProps, ownProps: SendOwnProps) => {
     }
   }
   const {_you: you} = stateProps
+  let sign = ''
+  if (paymentInfo.delta !== 'none') {
+    sign = paymentInfo.delta === 'increase' ? '+' : '-'
+  }
   return {
     amountNominal: paymentInfo.worth || paymentInfo.amountDescription,
     attachTo: ownProps.attachTo,
-    balanceChange: `${paymentInfo.delta === 'increase' ? '+' : '-'}${paymentInfo.amountDescription}`,
-    balanceChangeColor:
-      paymentInfo.delta === 'increase' ? Styles.globalColors.green : Styles.globalColors.red,
+    balanceChange: `${sign}${paymentInfo.amountDescription}`,
+    balanceChangeColor: WalletConstants.getBalanceChangeColor(paymentInfo.delta, paymentInfo.status),
     bottomLine: '', // TODO on asset support in payment
     icon: paymentInfo.delta === 'increase' ? 'receiving' : 'sending',
     loading: false,


### PR DESCRIPTION
This is also calculated in `Transaction`, but that component uses `Role` and `pending` to figure it out. Those props are also used elsewhere and are derived from the same info `getBalanceChangeColor` uses, so I didn't think it was necessary to switch over. r? @keybase/react-hackers  