### PR TITLE
fix hover jump on inbox row

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper-timestamp/index.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-timestamp/index.js
@@ -182,7 +182,7 @@ const menuButtons = (props: MenuButtonsProps) => (
               />
               <Box ref={props.setAttachmentRef}>
                 {popupableMessageTypes.includes(props.message.type) && (
-                  <Icon type="iconfont-ellipsis" onClick={props.toggleShowingMenu} fontSize={16} />
+                  <Icon type="iconfont-ellipsis" onClick={props.toggleShowingMenu} fontSize={14} />
                 )}
               </Box>
             </Box>

--- a/shared/chat/inbox/row/small-team/top-line.js
+++ b/shared/chat/inbox/row/small-team/top-line.js
@@ -133,7 +133,8 @@ class _SimpleTopLine extends React.Component<Props> {
             ref={this.props.setAttachmentRef}
             color={this.props.subColor}
             hoverColor={this.props.iconHoverColor}
-            style={{fontSize: 14, position: 'relative', right: globalMargins.xtiny}}
+            fontSize={14}
+            style={{position: 'relative', right: globalMargins.xtiny}}
           />
         )}
         {this.props.hasBadge ? <Box key="1" style={unreadDotStyle} /> : null}

--- a/shared/chat/inbox/row/small-team/top-line.js
+++ b/shared/chat/inbox/row/small-team/top-line.js
@@ -133,7 +133,7 @@ class _SimpleTopLine extends React.Component<Props> {
             ref={this.props.setAttachmentRef}
             color={this.props.subColor}
             hoverColor={this.props.iconHoverColor}
-            style={{position: 'relative', right: globalMargins.xtiny}}
+            style={{fontSize: 14, position: 'relative', right: globalMargins.xtiny}}
           />
         )}
         {this.props.hasBadge ? <Box key="1" style={unreadDotStyle} /> : null}


### PR DESCRIPTION
@keybase/react-hackers this fixes icon jump on inbox row. the old font size was much bigger than the text it replaces so it pushes things around which causes the jump

cc: @cecileboucheron @adamjspooner just fyi

we could keep the icon size but we'd have to do more layout fixes to stop this problem