### PR TITLE
Remove input type="number" and fix NewInput typing

### DIFF
--- a/shared/common-adapters/new-input.js
+++ b/shared/common-adapters/new-input.js
@@ -12,6 +12,7 @@ import {
   platformStyles,
   styleSheetCreate,
 } from '../styles'
+import {forwardRef} from '../util/react'
 
 export type _Props = {
   containerStyle?: StylesCrossPlatform,
@@ -88,8 +89,7 @@ class ReflessNewInput extends React.Component<DefaultProps & Props, State> {
     )
   }
 }
-// $FlowIssue doesn't know about forwardRef (https://github.com/facebook/flow/issues/6103)
-const NewInput = React.forwardRef((props, ref) => <ReflessNewInput {...props} forwardedRef={ref} />)
+const NewInput = forwardRef((props, ref) => <ReflessNewInput {...props} forwardedRef={ref} />)
 
 const styles = styleSheetCreate({
   container: platformStyles({

--- a/shared/common-adapters/plain-input.js.flow
+++ b/shared/common-adapters/plain-input.js.flow
@@ -37,7 +37,7 @@ export type Props = {|
   rowsMax?: number,
   style?: StylesCrossPlatform,
   textType?: TextType,
-  type?: 'password' | 'text' | 'number',
+  type?: 'password' | 'text',
   value?: string, // Makes this a controlled input when passed. Also disables mutating value via `transformText`, see note at component API
 
   /* Platform discrepancies */

--- a/shared/common-adapters/plain-input.stories.js
+++ b/shared/common-adapters/plain-input.stories.js
@@ -118,13 +118,6 @@ class ControlledInputPlayground extends React.Component<{multiline: boolean}, Co
           type="password"
           placeholder={`type="password"`}
         />
-        <PlainInput
-          {...common}
-          value={this.state.value3 || ''}
-          onChangeText={this._onChangeText('value3')}
-          type="number"
-          placeholder={`type="number" (desktop only)`}
-        />
         <Box2 direction="vertical" fullWidth={true} gap="small">
           <Text type="Body">Live mutations</Text>
           <PlainInput
@@ -156,7 +149,6 @@ const load = () => {
     .add('Basic', () => <PlainInput {...commonProps} />)
     .add('Different text type', () => <PlainInput {...commonProps} textType="BodyExtrabold" />)
     .add('Larger text type', () => <PlainInput {...commonProps} textType="HeaderBig" />)
-    .add('Number', () => <PlainInput {...commonProps} type="number" />)
     .add('Password', () => <PlainInput {...commonProps} type="password" />)
     .add('Multiline', () => <PlainInput {...commonProps} multiline={true} />)
     .add('Multiline with row constraints', () => (

--- a/shared/util/react.js
+++ b/shared/util/react.js
@@ -5,8 +5,9 @@ import * as React from 'react'
 
 // Flow is missing a type for React.ForwardRef. See https://github.com/facebook/flow/issues/6103
 // Taken from https://github.com/facebook/flow/pull/6510
-declare export function forwardRef<Props, ElementType: React$ElementType>(
+export function forwardRef<Props, ElementType: React$ElementType>(
   render: (props: Props, ref: React$Ref<ElementType>) => React$Node
-): React$ComponentType<Props>
-// $FlowIssue
-export const forwardRef = React.forwardRef // eslint-disable-line no-redeclare
+): React$ComponentType<Props> {
+  // $FlowIssue
+  return React.forwardRef(render)
+}

--- a/shared/util/react.js
+++ b/shared/util/react.js
@@ -1,0 +1,12 @@
+// @flow
+import * as React from 'react'
+
+// React related utilities
+
+// Flow is missing a type for React.ForwardRef. See https://github.com/facebook/flow/issues/6103
+// Taken from https://github.com/facebook/flow/pull/6510
+declare export function forwardRef<Props, ElementType: React$ElementType>(
+  render: (props: Props, ref: React$Ref<ElementType>) => React$Node
+): React$ComponentType<Props>
+// $FlowIssue
+export const forwardRef = React.forwardRef // eslint-disable-line no-redeclare

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -24,8 +24,7 @@ const AssetInput = (props: Props) => (
       </Kb.Text>
     )}
     <Kb.NewInput
-      type="number"
-      hello="goodbye"
+      type="text"
       decoration={
         <Kb.Box2 direction="vertical" style={styles.flexEnd}>
           <Kb.Text type="HeaderBigExtrabold" style={styles.unit}>
@@ -38,7 +37,11 @@ const AssetInput = (props: Props) => (
       }
       containerStyle={styles.inputContainer}
       style={styles.input}
-      onChangeText={props.onChangeAmount}
+      onChangeText={t => {
+        if (!isNaN(+t) || t === '.') {
+          props.onChangeAmount(t)
+        }
+      }}
       textType="HeaderBigExtrabold"
       placeholder={props.inputPlaceholder}
       placeholderColor={Styles.globalColors.purple2_40}

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -25,6 +25,7 @@ const AssetInput = (props: Props) => (
     )}
     <Kb.NewInput
       type="number"
+      hello="goodbye"
       decoration={
         <Kb.Box2 direction="vertical" style={styles.flexEnd}>
           <Kb.Text type="HeaderBigExtrabold" style={styles.unit}>

--- a/shared/wallets/send-form/asset-input/index.stories.js
+++ b/shared/wallets/send-form/asset-input/index.stories.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {action, storiesOf} from '../../../stories/storybook'
 import {Box} from '../../../common-adapters'
+import {withStateHandlers} from '../../../util/container'
 import AssetInput from '.'
 
 const common = {
@@ -22,16 +23,18 @@ const props1 = {
 
 const props2 = {
   ...common,
-  bottomLabel: 'Issuer: Abc.def',
-  displayUnit: 'BTC',
+  bottomLabel: '1 XLM = $0.2303',
+  displayUnit: 'XLM',
   inputPlaceholder: '0.0000000',
+  value: '129',
 }
 
 const props3 = {
   ...common,
-  bottomLabel: '1 XLM = $0.2303',
-  displayUnit: 'XLM',
+  bottomLabel: 'Issuer: Stronghold.com',
+  displayUnit: 'BTC',
   inputPlaceholder: '0.0000000',
+  value: '0.08',
 }
 
 // Exported for use in main send form story
@@ -56,16 +59,29 @@ const warning3 = {
   warningPayee: 'russel',
 }
 
+const StatefulAssetInput: any = withStateHandlers(
+  props => ({
+    value: props.value,
+  }),
+  {
+    onChangeAmount: (_, props) => (value: string) => {
+      props.onChangeAmount(value)
+      return {value}
+    },
+  }
+)(AssetInput)
+
 const load = () => {
   storiesOf('Wallets/SendForm/Asset input', module)
     .addDecorator(story => <Box style={{maxWidth: 500, padding: 20}}>{story()}</Box>)
     .add('XLM worth USD', () => <AssetInput {...props1} />)
-    .add('XLM', () => <AssetInput {...props3} />)
-    .add('Asset', () => <AssetInput {...props2} />)
+    .add('XLM', () => <AssetInput {...props2} />)
+    .add('Asset', () => <AssetInput {...props3} />)
     .add('Prefilled XLM', () => <AssetInput {...props4} />)
     .add('USD over warning', () => <AssetInput {...props1} {...warning1} />)
     .add('XLM over warning', () => <AssetInput {...props2} {...warning2} />)
     .add('asset type warning', () => <AssetInput {...props3} {...warning3} />)
+    .add('Input validation', () => <StatefulAssetInput {...props2} />)
 }
 
 export default load


### PR DESCRIPTION
This removes type `"number"` from `PlainInput`. It also adds some simple number validation on `AssetInput` so we'll still only allow numbers to be input:
```js
onChangeText={t => {
  if (!isNaN(+t) || t === '.') {
    props.onChangeAmount(t)
  }
}}
```
See [this story](http://localhost:6006/?selectedKind=Wallets%2FSendForm%2FAsset%20input&selectedStory=Input%20validation&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) to try it out.

Also, this line turned `NewInput` into a type black hole:
```js
// $FlowIssue doesn't know about forwardRef (https://github.com/facebook/flow/issues/6103)
const NewInput = React.forwardRef((props, ref) => <ReflessNewInput {...props} forwardedRef={ref} />)
```
I added `util/react.js` with a typed version of `forwardRef` to fix this. r? @keybase/react-hackers  