### PR TITLE
android can pass null back

### DIFF
--- a/shared/actions/platform-specific/push.native.js
+++ b/shared/actions/platform-specific/push.native.js
@@ -278,7 +278,7 @@ const requestPermissions = () =>
       logger.info('[PushRequesting] asking native')
       const permissions = yield Saga.call(requestPermissionsFromNative)
       logger.info('[PushRequesting] after prompt:', permissions)
-      if (permissions.alert || permissions.badge) {
+      if (permissions?.alert || permissions?.badge) {
         logger.info('[PushRequesting] enabled')
         yield Saga.put(PushGen.createUpdateHasPermissions({hasPermissions: true}))
       } else {


### PR DESCRIPTION
@keybase/react-hackers we got some logs where android crashes out here because permissions is a null object