### PR TITLE
Send "encrypted note" input to request

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -92,7 +92,7 @@ const requestPayment = (state: TypedState) =>
       asset: {type: 'native', code: '', issuer: ''},
       recipient: state.wallets.buildingPayment.to,
       // TODO -- support currency
-      note: state.wallets.buildingPayment.publicMemo.stringValue(),
+      note: state.wallets.buildingPayment.secretNote.stringValue(),
     },
     Constants.requestPaymentWaitingKey
   ).then(kbRqID => WalletsGen.createRequestedPayment({kbRqID: new HiddenString(kbRqID)}))


### PR DESCRIPTION
Fixes the issue where the "public memo" input was sent with requests. r? @keybase/react-hackers 