### PR TITLE
lint errors on windows api names

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -27,6 +27,7 @@ lint:
 		| grep -v prot.go \
 		| grep -v "redundant if ...; err != nil check, just return error instead" \
 		| grep -v "don't use ALL_CAPS in Go names; use CamelCase" \
+		| grep -v runquiet.go \
 		&& exit 1 \
 		|| echo "Lint-free!" \
 	)


### PR DESCRIPTION
sorry about CI messing up. 
I believe this lint error should be skipped because that is the actual name of the windows API:
```
[client\go] Running shell script
+ make -s lint
tools\runquiet\runquiet.go:34:2: var procGetWindowThreadProcessId should be procGetWindowThreadProcessID
tools\runquiet\runquiet.go:38:6: func GetWindowThreadProcessId should be GetWindowThreadProcessID
make: *** [lint] Error 1
```
