### PR TITLE
Fix blackbar when hitting back on device add

### DIFF
--- a/shared/actions/__tests__/provision.test.js
+++ b/shared/actions/__tests__/provision.test.js
@@ -89,7 +89,7 @@ describe('provisioningManagerProvisioning', () => {
       expect(response.result).not.toHaveBeenCalled()
       expect(response.error).toHaveBeenCalledWith({
         code: RPCTypes.constantsStatusCode.scinputcanceled,
-        desc: Constants.cancelDesc,
+        desc: 'Input canceled',
       })
     })
   })
@@ -610,7 +610,7 @@ describe('canceling provision', () => {
     expect(response.result).not.toHaveBeenCalled()
     expect(response.error).toHaveBeenCalledWith({
       code: RPCTypes.constantsStatusCode.scinputcanceled,
-      desc: Constants.cancelDesc,
+      desc: 'Input canceled',
     })
     expect(manager._stashedResponse).toEqual(null)
     expect(manager._stashedResponseKey).toEqual(null)
@@ -667,7 +667,7 @@ describe('final errors show', () => {
 
   it('ignore cancel', () => {
     const {getState, dispatch, getRoutePath} = startReduxSaga()
-    const error = new RPCError(Constants.cancelDesc, RPCTypes.constantsStatusCode.scinputcanceled)
+    const error = new RPCError('Input canceled', RPCTypes.constantsStatusCode.scinputcanceled)
     dispatch(ProvisionGen.createShowFinalErrorPage({finalError: error}))
     expect(getState().provision.finalError).toEqual(null)
     expect(getRoutePath()).toEqual(I.List([Tabs.loginTab]))

--- a/shared/actions/provision.js
+++ b/shared/actions/provision.js
@@ -436,7 +436,7 @@ const addNewDevice = (state: TypedState) =>
     } catch (e) {
       ProvisioningManager.getSingleton().done(e.message)
       // If we're canceling then ignore the error
-      if (e.desc !== Constants.cancelDesc) {
+      if (!errorCausedByUsCanceling(e)) {
         logger.error(`Provision -> Add device error: ${e.message}`)
         yield Saga.put(RouteTreeGen.createNavigateTo({path: [], parentPath: devicesRoot}))
         // show black bar
@@ -484,7 +484,7 @@ const showPaperkeyPage = (state: TypedState) =>
   Saga.put(RouteTreeGen.createNavigateAppend({path: ['paperkey'], parentPath: [Tabs.loginTab]}))
 
 const showFinalErrorPage = (state: TypedState) => {
-  if (state.provision.finalError && state.provision.finalError.desc !== Constants.cancelDesc) {
+  if (state.provision.finalError && !Constants.errorCausedByUsCanceling(state.provision.finalError)) {
     return Saga.put(RouteTreeGen.createNavigateTo({path: ['error'], parentPath: [Tabs.loginTab]}))
   } else {
     return Saga.put(RouteTreeGen.createNavigateTo({path: [], parentPath: [Tabs.loginTab]}))

--- a/shared/constants/provision.js
+++ b/shared/constants/provision.js
@@ -4,11 +4,16 @@ import * as DeviceTypes from './types/devices'
 import * as Types from './types/provision'
 import * as RPCTypes from './types/rpc-gen'
 import HiddenString from '../util/hidden-string'
+import type {CommonResponseHandler, RPCError} from '../engine/types'
 
 export const waitingKey = 'provision:waiting'
 
 // Do NOT change this. These values are used by the daemon also so this way we can ignore it when they do it / when we do
-export const errorCausedByUsCanceling = (e: Error) => e?.desc === 'Input canceled' || e?.desc ===  'kex canceled by caller'
+export const errorCausedByUsCanceling = (e: ?RPCError) =>
+  e?.desc === 'Input canceled' || e?.desc === 'kex canceled by caller'
+export const cancelOnCallback = (_: any, response: CommonResponseHandler) => {
+  response.error({code: RPCTypes.constantsStatusCode.scinputcanceled, desc: 'Input canceled'})
+}
 
 export const makeState: I.RecordFactory<Types._State> = I.Record({
   codePageIncomingTextCode: new HiddenString(''),

--- a/shared/constants/provision.js
+++ b/shared/constants/provision.js
@@ -7,8 +7,8 @@ import HiddenString from '../util/hidden-string'
 
 export const waitingKey = 'provision:waiting'
 
-// Do NOT change this. This is the value used by the daemon also so this way we can ignore it when they do it / when we do
-export const cancelDesc = 'Input canceled'
+// Do NOT change this. These values are used by the daemon also so this way we can ignore it when they do it / when we do
+export const errorCausedByUsCanceling = (e: Error) => e?.desc === 'Input canceled' || e?.desc ===  'kex canceled by caller'
 
 export const makeState: I.RecordFactory<Types._State> = I.Record({
   codePageIncomingTextCode: new HiddenString(''),

--- a/shared/reducers/provision.js
+++ b/shared/reducers/provision.js
@@ -21,7 +21,7 @@ export default function(state: Types.State = initialState, action: ProvisionGen.
       return state.merge({error: initialState.error})
     case ProvisionGen.showFinalErrorPage:
       // Ignore cancels
-      if (action.payload.finalError && action.payload.finalError.desc === Constants.cancelDesc) {
+      if (Constants.errorCausedByUsCanceling(action.payload.finalError)) {
         return state
       }
       return state.merge({finalError: action.payload.finalError})


### PR DESCRIPTION
this fixes clicking back when adding a new device. 
Core sends us back 2 possible error values when we cancel so we need to ignore both. previously we ignored one, then switched to the other, now we handle both