### PR TITLE
dont merge messages if their type and id dont match

### DIFF
--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -981,6 +981,11 @@ export const mergeMessage = (old: ?Types.Message, m: Types.Message) => {
     return m
   }
 
+  // only merge if its the same id and type
+  if (old.id !== m.id || old.type !== m.type) {
+    return m
+  }
+
   // $FlowIssue doens't understand mergeWith
   return old.mergeWith((oldVal, newVal, key) => {
     if (key === 'mentionsAt' || key === 'reactions' || key === 'mentionsChannelName') {


### PR DESCRIPTION
this should fix those react 'undefined stringValue' errors. 
a recent optimization was to try and merge messages on top of existing ones. in some circumstances we get deletes and those were getting mixed into text messages. instead we only merge if the type and id are the same for a message, otherwise we take the new message w/o a merge

to repro this you can turn on the network link conditioner and try and send and edit and edit a bunch (aka hit up arrow type, enter, up arrow type enter, a whole bunch)

@keybase/react-hackers 