### PR TITLE
Refresh unread count on markAsRead, payment status notifications

### DIFF
--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1359,3 +1359,14 @@ func AccountExchangeRate(mctx libkb.MetaContext, remoter remote.Remoter, account
 
 	return remoter.ExchangeRate(mctx.Ctx(), string(currency.Code))
 }
+
+func RefreshUnreadCount(g *libkb.GlobalContext, accountID stellar1.AccountID) {
+	s := getGlobal(g)
+	ctx := context.Background()
+	details, err := s.remoter.Details(ctx, accountID)
+	if err != nil {
+		return // details, err
+	}
+
+	s.UpdateUnreadCount(ctx, accountID, details.UnreadPayments)
+}

--- a/go/stellar/stellargregor/stellargregor.go
+++ b/go/stellar/stellargregor/stellargregor.go
@@ -74,6 +74,7 @@ func (h *Handler) paymentStatus(mctx libkb.MetaContext, cli gregor1.IncomingInte
 		return err
 	}
 
+	stellar.RefreshUnreadCount(h.G(), msg.AccountID)
 	paymentID := stellar1.NewPaymentID(msg.TxID)
 	h.G().NotifyRouter.HandleWalletPaymentStatusNotification(mctx.Ctx(), msg.AccountID, paymentID)
 	stellar.DefaultLoader(h.G()).UpdatePayment(mctx.Ctx(), paymentID)
@@ -94,6 +95,7 @@ func (h *Handler) paymentNotification(mctx libkb.MetaContext, cli gregor1.Incomi
 		return err
 	}
 
+	stellar.RefreshUnreadCount(h.G(), msg.AccountID)
 	h.G().NotifyRouter.HandleWalletPaymentNotification(mctx.Ctx(), msg.AccountID, msg.PaymentID)
 	stellar.DefaultLoader(h.G()).UpdatePayment(mctx.Ctx(), msg.PaymentID)
 

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -1312,7 +1312,14 @@ func (s *Server) MarkAsReadLocal(ctx context.Context, arg stellar1.MarkAsReadLoc
 		return err
 	}
 
-	return s.remoter.MarkAsRead(ctx, arg.AccountID, stellar1.TransactionIDFromPaymentID(arg.MostRecentID))
+	err = s.remoter.MarkAsRead(ctx, arg.AccountID, stellar1.TransactionIDFromPaymentID(arg.MostRecentID))
+	if err != nil {
+		return err
+	}
+
+	go stellar.RefreshUnreadCount(s.G(), arg.AccountID)
+
+	return nil
 }
 
 func (s *Server) IsAccountMobileOnlyLocal(ctx context.Context, arg stellar1.IsAccountMobileOnlyLocalArg) (mobileOnly bool, err error) {


### PR DESCRIPTION
This refreshes the unread payment count for an account when a payment notification happens or markAsRead.

It's a bit of a sledgehammer, but should be fine for now.