### PR TITLE
Stellar: integrate account badges in the nav and account rows

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -7,8 +7,7 @@
   ],
   "actions": {
     "abandonPayment": {
-      "_description":
-        "Signal that a payment being built is abandoned and reset the form fields to their initial states."
+      "_description": "Signal that a payment being built is abandoned and reset the form fields to their initial states."
     },
     "accountsReceived": {
       "_description": "Update our store of account data",
@@ -18,6 +17,10 @@
       "_description": "Update our store of assets data",
       "accountID": "Types.AccountID",
       "assets": "Array<Types.Assets>"
+    },
+    "badgesUpdated": {
+      "_description": "Update badges in the nav",
+      "accounts": "Array<any>"
     },
     "buildPayment": {
       "_description": "Prepare a payment for sending"
@@ -50,8 +53,7 @@
       "setBuildingTo?": "boolean"
     },
     "createdNewAccount": {
-      "_description":
-        "The service responded with an error or that the create new account operation succeeded",
+      "_description": "The service responded with an error or that the create new account operation succeeded",
       "accountID": "Types.AccountID",
       "showOnCreation?": "boolean",
       "setBuildingTo?": "boolean",
@@ -225,8 +227,7 @@
       "setBuildingTo?": "boolean"
     },
     "linkedExistingAccount": {
-      "_description":
-        "The service responded with an error or that the link existing operation succeeded",
+      "_description": "The service responded with an error or that the link existing operation succeeded",
       "accountID": "Types.AccountID",
       "showOnCreation?": "boolean",
       "setBuildingTo?": "boolean",

--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -20,7 +20,7 @@
     },
     "badgesUpdated": {
       "_description": "Update badges in the nav",
-      "accounts": "Array<any>"
+      "accounts": "Types.BadgesUpdate"
     },
     "buildPayment": {
       "_description": "Prepare a payment for sending"

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -15,6 +15,7 @@ export const typePrefix = 'wallets:'
 export const abandonPayment = 'wallets:abandonPayment'
 export const accountsReceived = 'wallets:accountsReceived'
 export const assetsReceived = 'wallets:assetsReceived'
+export const badgesUpdated = 'wallets:badgesUpdated'
 export const buildPayment = 'wallets:buildPayment'
 export const builtPaymentReceived = 'wallets:builtPaymentReceived'
 export const cancelPayment = 'wallets:cancelPayment'
@@ -75,6 +76,7 @@ type _AssetsReceivedPayload = $ReadOnly<{|
   accountID: Types.AccountID,
   assets: Array<Types.Assets>,
 |}>
+type _BadgesUpdatedPayload = $ReadOnly<{|accounts: Array<any>|}>
 type _BuildPaymentPayload = void
 type _BuiltPaymentReceivedPayload = $ReadOnly<{|
   build: Types.BuiltPayment,
@@ -398,6 +400,10 @@ export const createValidatedSecretKeyError = (payload: _ValidatedSecretKeyPayloa
  */
 export const createPaymentDetailReceived = (payload: _PaymentDetailReceivedPayload) => ({error: false, payload, type: paymentDetailReceived})
 /**
+ * Update badges in the nav
+ */
+export const createBadgesUpdated = (payload: _BadgesUpdatedPayload) => ({error: false, payload, type: badgesUpdated})
+/**
  * Update display currency for a certain account
  */
 export const createDisplayCurrencyReceived = (payload: _DisplayCurrencyReceivedPayload) => ({error: false, payload, type: displayCurrencyReceived})
@@ -430,6 +436,7 @@ export const createDisplayCurrenciesReceived = (payload: _DisplayCurrenciesRecei
 export type AbandonPaymentPayload = $Call<typeof createAbandonPayment, _AbandonPaymentPayload>
 export type AccountsReceivedPayload = $Call<typeof createAccountsReceived, _AccountsReceivedPayload>
 export type AssetsReceivedPayload = $Call<typeof createAssetsReceived, _AssetsReceivedPayload>
+export type BadgesUpdatedPayload = $Call<typeof createBadgesUpdated, _BadgesUpdatedPayload>
 export type BuildPaymentPayload = $Call<typeof createBuildPayment, _BuildPaymentPayload>
 export type BuiltPaymentReceivedPayload = $Call<typeof createBuiltPaymentReceived, _BuiltPaymentReceivedPayload>
 export type CancelPaymentPayload = $Call<typeof createCancelPayment, _CancelPaymentPayload>
@@ -494,6 +501,7 @@ export type Actions =
   | AbandonPaymentPayload
   | AccountsReceivedPayload
   | AssetsReceivedPayload
+  | BadgesUpdatedPayload
   | BuildPaymentPayload
   | BuiltPaymentReceivedPayload
   | CancelPaymentPayload

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -7,6 +7,7 @@ import * as Saga from '../util/saga'
 import * as WalletsGen from './wallets-gen'
 import * as Chat2Gen from './chat2-gen'
 import * as ConfigGen from './config-gen'
+import * as NotificationsGen from './notifications-gen'
 import * as RouteTreeGen from './route-tree-gen'
 import HiddenString from '../util/hidden-string'
 import * as Route from './route-tree'
@@ -428,6 +429,9 @@ const maybeClearErrors = (state: TypedState) => {
   }
 }
 
+const receivedBadgeState = (state: TypedState, action: NotificationsGen.ReceivedBadgeStatePayload) =>
+  Saga.put(WalletsGen.createBadgesUpdated({accounts: action.payload.badgeState.unreadWalletAccounts || []}))
+
 function* walletsSaga(): Saga.SagaGenerator<any, any> {
   if (!flags.walletsEnabled) {
     console.log('Wallets saga disabled')
@@ -526,6 +530,8 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
 
   // Clear some errors on navigateUp.
   yield Saga.actionToAction(RouteTreeGen.navigateUp, maybeClearErrors)
+
+  yield Saga.actionToAction(NotificationsGen.receivedBadgeState, receivedBadgeState)
 }
 
 export default walletsSaga

--- a/shared/constants/notifications.js
+++ b/shared/constants/notifications.js
@@ -17,6 +17,7 @@ export const badgeStateToBadges = (bs: RPCTypes.BadgeState, state: TypedState) =
     newTeamAccessRequests,
     teamsWithResetUsers,
     inboxVers,
+    unreadWalletAccounts,
   } = bs
 
   if (state.notifications.badgeVersion >= inboxVers) {
@@ -28,6 +29,8 @@ export const badgeStateToBadges = (bs: RPCTypes.BadgeState, state: TypedState) =
     (total, c) => (c.badgeCounts ? total + c.badgeCounts[`${deviceType}`] : total),
     0
   )
+  const totalPayments = (unreadWalletAccounts || []).reduce((total, a) => total + parseInt(a.numUnread), 0)
+
   const newGit = (newGitRepoGlobalUniqueIDs || []).length
   const newTeams =
     (newTeamNames || []).length + (newTeamAccessRequests || []).length + (teamsWithResetUsers || []).length
@@ -39,12 +42,13 @@ export const badgeStateToBadges = (bs: RPCTypes.BadgeState, state: TypedState) =
     [Tabs.gitTab, newGit],
     [Tabs.teamsTab, newTeams],
     [Tabs.peopleTab, homeTodoItems],
+    [Tabs.walletsTab, totalPayments],
   ])
 
   return {
     desktopAppBadgeCount: navBadges.reduce((total, val) => total + val, 0),
     mobileAppBadgeCount: totalMessages,
-    navBadges: navBadges,
+    navBadges,
   }
 }
 

--- a/shared/constants/notifications.js
+++ b/shared/constants/notifications.js
@@ -29,7 +29,7 @@ export const badgeStateToBadges = (bs: RPCTypes.BadgeState, state: TypedState) =
     (total, c) => (c.badgeCounts ? total + c.badgeCounts[`${deviceType}`] : total),
     0
   )
-  const totalPayments = (unreadWalletAccounts || []).reduce((total, a) => total + parseInt(a.numUnread), 0)
+  const totalPayments = (unreadWalletAccounts || []).reduce((total, a) => total + a.numUnread, 0)
 
   const newGit = (newGitRepoGlobalUniqueIDs || []).length
   const newTeams =

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -150,6 +150,8 @@ export type Account = I.RecordOf<_Account>
 
 export type Assets = I.RecordOf<_Assets>
 
+export type BadgesUpdate = Array<{accountID: AccountID, numUnread: number}>
+
 export type BannerBackground = 'Announcements' | 'HighRisk' | 'Information'
 
 export type Banner = {|
@@ -173,6 +175,7 @@ export type _State = {
   accountName: string,
   accountNameError: string,
   accountNameValidationState: ValidationState,
+  assetsMap: I.Map<AccountID, I.List<Assets>>,
   buildingPayment: BuildingPayment,
   builtPayment: BuiltPayment,
   createNewAccountError: string,
@@ -181,19 +184,17 @@ export type _State = {
   exportedSecretKey: HiddenString,
   exportedSecretKeyAccountID: AccountID,
   linkExistingAccountError: string,
-  requests: I.Map<StellarRPCTypes.KeybaseRequestID, Request>,
-  secretKey: HiddenString,
-  secretKeyError: string,
-  secretKeyValidationState: ValidationState,
-  selectedAccount: AccountID,
-  sentPaymentError: string,
-  assetsMap: I.Map<AccountID, I.List<Assets>>,
   paymentsMap: I.Map<AccountID, I.Map<PaymentID, Payment>>,
   paymentCursorMap: I.Map<AccountID, ?StellarRPCTypes.PageCursor>,
   paymentLoadingMoreMap: I.Map<AccountID, boolean>,
+  requests: I.Map<StellarRPCTypes.KeybaseRequestID, Request>,
+  secretKey: HiddenString,
+  secretKeyError: string,
   secretKeyMap: I.Map<AccountID, HiddenString>,
+  secretKeyValidationState: ValidationState,
   selectedAccount: AccountID,
-  unreadPaymentsMap: I.Map<AccountID, boolean>,
+  sentPaymentError: string,
+  unreadPaymentsMap: I.Map<AccountID, number>,
 }
 
 export type State = I.RecordOf<_State>

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -176,6 +176,8 @@ export type _State = {
   buildingPayment: BuildingPayment,
   builtPayment: BuiltPayment,
   createNewAccountError: string,
+  currencies: I.List<Currency>,
+  currencyMap: I.Map<AccountID, Currency>,
   exportedSecretKey: HiddenString,
   exportedSecretKeyAccountID: AccountID,
   linkExistingAccountError: string,
@@ -191,8 +193,7 @@ export type _State = {
   paymentLoadingMoreMap: I.Map<AccountID, boolean>,
   secretKeyMap: I.Map<AccountID, HiddenString>,
   selectedAccount: AccountID,
-  currencies: I.List<Currency>,
-  currencyMap: I.Map<AccountID, Currency>,
+  unreadPaymentsMap: I.Map<AccountID, boolean>,
 }
 
 export type State = I.RecordOf<_State>

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -69,6 +69,7 @@ const makeState: I.RecordFactory<Types._State> = I.Record({
   secretKeyValidationState: 'none',
   selectedAccount: Types.noAccountID,
   sentPaymentError: '',
+  unreadPaymentsMap: I.Map(),
 })
 
 const buildPaymentResultToBuiltPayment = (b: RPCTypes.BuildPaymentResLocal) =>

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -164,6 +164,11 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
       return state.paymentCursorMap.get(action.payload.accountID)
         ? state.setIn(['paymentLoadingMoreMap', action.payload.accountID], true)
         : state
+    case WalletsGen.badgesUpdated:
+      return state.set(
+        'unreadPaymentsMap',
+        I.Map(action.payload.accounts.map(({accountID, numUnread}) => [accountID, numUnread]))
+      )
     // Saga only actions
     case WalletsGen.didSetAccountAsDefault:
     case WalletsGen.buildPayment:

--- a/shared/wallets/wallet-list/wallet-row/container.js
+++ b/shared/wallets/wallet-list/wallet-row/container.js
@@ -11,11 +11,11 @@ const mapStateToProps = (state: TypedState, ownProps: {accountID: AccountID}) =>
   const me = state.config.username || ''
   const keybaseUser = account.isDefault ? me : ''
   return {
-    hasBadge: state.wallets.unreadPaymentsMap.get(ownProps.accountID) > 0,
-    isSelected: getSelectedAccount(state) === ownProps.accountID,
-    name,
-    keybaseUser,
     contents: account.balanceDescription,
+    isSelected: getSelectedAccount(state) === ownProps.accountID,
+    keybaseUser,
+    name,
+    unreadPayments: state.wallets.unreadPaymentsMap.get(ownProps.accountID, 0),
   }
 }
 
@@ -26,12 +26,12 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps): Props => ({
-  hasBadge: stateProps.hasBadge,
-  isSelected: !isMobile && stateProps.isSelected,
-  name: stateProps.name,
-  keybaseUser: stateProps.keybaseUser,
   contents: stateProps.contents,
+  isSelected: !isMobile && stateProps.isSelected,
+  keybaseUser: stateProps.keybaseUser,
+  name: stateProps.name,
   onSelect: () => dispatchProps._onSelectAccount(ownProps.accountID),
+  unreadPayments: stateProps.unreadPayments,
 })
 
 export default connect(

--- a/shared/wallets/wallet-list/wallet-row/container.js
+++ b/shared/wallets/wallet-list/wallet-row/container.js
@@ -11,6 +11,7 @@ const mapStateToProps = (state: TypedState, ownProps: {accountID: AccountID}) =>
   const me = state.config.username || ''
   const keybaseUser = account.isDefault ? me : ''
   return {
+    hasBadge: state.wallets.unreadPaymentsMap.get(ownProps.accountID) > 0,
     isSelected: getSelectedAccount(state) === ownProps.accountID,
     name,
     keybaseUser,
@@ -25,6 +26,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps): Props => ({
+  hasBadge: stateProps.hasBadge,
   isSelected: !isMobile && stateProps.isSelected,
   name: stateProps.name,
   keybaseUser: stateProps.keybaseUser,

--- a/shared/wallets/wallet-list/wallet-row/index.js
+++ b/shared/wallets/wallet-list/wallet-row/index.js
@@ -5,11 +5,11 @@ import * as Styles from '../../../styles'
 
 type Props = {|
   contents: string,
-  hasBadge: boolean,
   isSelected: boolean,
   keybaseUser: string,
   name: string,
   onSelect: () => void,
+  unreadPayments: number,
 |}
 
 const rightColumnStyle = Styles.platformStyles({
@@ -29,6 +29,9 @@ const styles = Styles.styleSheetCreate({
     color: Styles.globalColors.white,
   },
   avatar: {marginRight: Styles.globalMargins.xtiny},
+  badge: {
+    marginLeft: 6,
+  },
   containerBox: {
     height: Styles.isMobile ? 56 : 48,
   },
@@ -105,18 +108,20 @@ const WalletRow = (props: Props) => {
             {props.contents}
           </Kb.Text>
         </Kb.Box2>
-        {props.hasBadge && <UnreadIcon />}
+        {props.unreadPayments && (
+          <Kb.Box2 direction="horizontal" style={styles.unreadContainer}>
+            {Styles.isMobile ? (
+              <Kb.Badge badgeNumber={props.unreadPayments} badgeStyle={styles.badge} />
+            ) : (
+              <Kb.Box2 direction="vertical" style={styles.unread} />
+            )}
+          </Kb.Box2>
+        )}
       </HoverBox>
       <Kb.Divider />
     </Kb.ClickableBox>
   )
 }
-
-const UnreadIcon = () => (
-  <Kb.Box2 direction="horizontal" style={styles.unreadContainer}>
-    <Kb.Box2 direction="vertical" style={styles.unread} />
-  </Kb.Box2>
-)
 
 export type {Props}
 export {WalletRow}

--- a/shared/wallets/wallet-list/wallet-row/index.js
+++ b/shared/wallets/wallet-list/wallet-row/index.js
@@ -108,7 +108,7 @@ const WalletRow = (props: Props) => {
             {props.contents}
           </Kb.Text>
         </Kb.Box2>
-        {props.unreadPayments && <UnreadIcon unreadPayments={props.unreadPayments} />}
+        {!!props.unreadPayments && <UnreadIcon unreadPayments={props.unreadPayments} />}
       </HoverBox>
       <Kb.Divider />
     </Kb.ClickableBox>

--- a/shared/wallets/wallet-list/wallet-row/index.js
+++ b/shared/wallets/wallet-list/wallet-row/index.js
@@ -4,10 +4,11 @@ import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 
 type Props = {|
-  isSelected: boolean,
-  name: string,
-  keybaseUser: string,
   contents: string,
+  hasBadge: boolean,
+  isSelected: boolean,
+  keybaseUser: string,
+  name: string,
   onSelect: () => void,
 |}
 
@@ -20,6 +21,13 @@ const rightColumnStyle = Styles.platformStyles({
 })
 
 const styles = Styles.styleSheetCreate({
+  amount: {
+    ...rightColumnStyle,
+  },
+  amountSelected: {
+    ...rightColumnStyle,
+    color: Styles.globalColors.white,
+  },
   avatar: {marginRight: Styles.globalMargins.xtiny},
   containerBox: {
     height: Styles.isMobile ? 56 : 48,
@@ -42,13 +50,19 @@ const styles = Styles.styleSheetCreate({
     ...rightColumnStyle,
     color: Styles.globalColors.white,
   },
-
-  amount: {
-    ...rightColumnStyle,
+  unread: {
+    backgroundColor: Styles.globalColors.orange,
+    borderRadius: 6,
+    flexShrink: 0,
+    height: Styles.globalMargins.tiny,
+    width: Styles.globalMargins.tiny,
   },
-  amountSelected: {
-    ...rightColumnStyle,
-    color: Styles.globalColors.white,
+  unreadContainer: {
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    flex: 1,
+    justifyContent: 'flex-end',
+    paddingRight: Styles.globalMargins.tiny,
   },
 })
 
@@ -91,11 +105,18 @@ const WalletRow = (props: Props) => {
             {props.contents}
           </Kb.Text>
         </Kb.Box2>
+        {props.hasBadge && <UnreadIcon />}
       </HoverBox>
       <Kb.Divider />
     </Kb.ClickableBox>
   )
 }
+
+const UnreadIcon = () => (
+  <Kb.Box2 direction="horizontal" style={styles.unreadContainer}>
+    <Kb.Box2 direction="vertical" style={styles.unread} />
+  </Kb.Box2>
+)
 
 export type {Props}
 export {WalletRow}

--- a/shared/wallets/wallet-list/wallet-row/index.js
+++ b/shared/wallets/wallet-list/wallet-row/index.js
@@ -108,20 +108,21 @@ const WalletRow = (props: Props) => {
             {props.contents}
           </Kb.Text>
         </Kb.Box2>
-        {props.unreadPayments && (
-          <Kb.Box2 direction="horizontal" style={styles.unreadContainer}>
-            {Styles.isMobile ? (
-              <Kb.Badge badgeNumber={props.unreadPayments} badgeStyle={styles.badge} />
-            ) : (
-              <Kb.Box2 direction="vertical" style={styles.unread} />
-            )}
-          </Kb.Box2>
-        )}
+        {props.unreadPayments && <UnreadIcon unreadPayments={props.unreadPayments} />}
       </HoverBox>
       <Kb.Divider />
     </Kb.ClickableBox>
   )
 }
 
+const UnreadIcon = (props: {unreadPayments: number}) => (
+  <Kb.Box2 direction="horizontal" style={styles.unreadContainer}>
+    {Styles.isMobile ? (
+      <Kb.Badge badgeNumber={props.unreadPayments} badgeStyle={styles.badge} />
+    ) : (
+      <Kb.Box2 direction="vertical" style={styles.unread} />
+    )}
+  </Kb.Box2>
+)
 export type {Props}
 export {WalletRow}

--- a/shared/wallets/wallet-list/wallet-row/index.stories.js
+++ b/shared/wallets/wallet-list/wallet-row/index.stories.js
@@ -15,6 +15,7 @@ const load = () => {
     ))
     .add('Default', () => (
       <WalletRow
+        hasBadge={false}
         keybaseUser="cecileb"
         name="cecileb's account"
         contents="280.0871234 XLM + more"
@@ -24,6 +25,17 @@ const load = () => {
     ))
     .add('Secondary', () => (
       <WalletRow
+        hasBadge={false}
+        keybaseUser=""
+        name="Second account"
+        contents="56.9618203 XLM"
+        isSelected={false}
+        onSelect={onSelect}
+      />
+    ))
+    .add('Badged', () => (
+      <WalletRow
+        hasBadge={true}
         keybaseUser=""
         name="Second account"
         contents="56.9618203 XLM"
@@ -33,6 +45,7 @@ const load = () => {
     ))
     .add('Long', () => (
       <WalletRow
+        hasBadge={false}
         keybaseUser=""
         name="G43289XXXXX34OPMG43289XXXXX34OPM"
         contents="56.9618203 XLM"

--- a/shared/wallets/wallet-list/wallet-row/index.stories.js
+++ b/shared/wallets/wallet-list/wallet-row/index.stories.js
@@ -15,42 +15,42 @@ const load = () => {
     ))
     .add('Default', () => (
       <WalletRow
-        hasBadge={false}
-        keybaseUser="cecileb"
-        name="cecileb's account"
         contents="280.0871234 XLM + more"
         isSelected={true}
+        keybaseUser="cecileb"
+        name="cecileb's account"
         onSelect={onSelect}
+        unreadPayments={0}
       />
     ))
     .add('Secondary', () => (
       <WalletRow
-        hasBadge={false}
-        keybaseUser=""
-        name="Second account"
         contents="56.9618203 XLM"
         isSelected={false}
+        keybaseUser=""
+        name="Second account"
         onSelect={onSelect}
+        unreadPayments={0}
       />
     ))
     .add('Badged', () => (
       <WalletRow
-        hasBadge={true}
-        keybaseUser=""
-        name="Second account"
         contents="56.9618203 XLM"
         isSelected={false}
+        keybaseUser=""
+        name="Second account"
         onSelect={onSelect}
+        unreadPayments={2}
       />
     ))
     .add('Long', () => (
       <WalletRow
-        hasBadge={false}
-        keybaseUser=""
-        name="G43289XXXXX34OPMG43289XXXXX34OPM"
         contents="56.9618203 XLM"
         isSelected={false}
+        keybaseUser=""
+        name="G43289XXXXX34OPMG43289XXXXX34OPM"
         onSelect={onSelect}
+        unreadPayments={0}
       />
     ))
 }


### PR DESCRIPTION
@keybase/react-hackers 

This links up with @akalin-keybase's PR #14120 -- this PR handles displaying account badges (badgeState written to a new `store.wallets.unreadPaymentsMap`), and that PR provides the mechanism for clearing them (`markAsRead` on the badged payments).

There's a difference in display between desktop and mobile: desktop uses an orange dot, while mobile badges the row with the number of unread payments.  The app itself is badged (on desktop only) with the total number of unread payments, plus the total number of chat messages etc.

Also some attribute alphabetizing.