### PR TITLE
validate username against config

### DIFF
--- a/go/externals/proof_service_generic_social.go
+++ b/go/externals/proof_service_generic_social.go
@@ -236,10 +236,9 @@ func NewGenericSocialProofServiceType(config *GenericSocialProofConfig) GenericS
 func (t GenericSocialProofServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 func (t GenericSocialProofServiceType) NormalizeUsername(s string) (string, error) {
-	if !t.config.usernameRe.MatchString(s) {
-		return "", libkb.NewBadUsernameError(s)
+	if err := t.config.validateRemoteUsername(s); err != nil {
+		return "", err
 	}
-	// TODO always normalize ToLower? See CORE-8984
 	return strings.ToLower(s), nil
 }
 


### PR DESCRIPTION
enforces the length constraints as well as the regexp