### PR TITLE
Fix stale build-actions on master

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -20,7 +20,7 @@
     },
     "badgesUpdated": {
       "_description": "Update badges in the nav",
-      "accounts": "Types.BadgesUpdate"
+      "accounts": "Array<RPCTypes.WalletAccountInfo>"
     },
     "buildPayment": {
       "_description": "Prepare a payment for sending"

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -77,7 +77,7 @@ type _AssetsReceivedPayload = $ReadOnly<{|
   accountID: Types.AccountID,
   assets: Array<Types.Assets>,
 |}>
-type _BadgesUpdatedPayload = $ReadOnly<{|accounts: Array<any>|}>
+type _BadgesUpdatedPayload = $ReadOnly<{|accounts: Array<RPCTypes.WalletAccountInfo>|}>
 type _BuildPaymentPayload = void
 type _BuiltPaymentReceivedPayload = $ReadOnly<{|
   build: Types.BuiltPayment,

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -156,8 +156,6 @@ export type Account = I.RecordOf<_Account>
 
 export type Assets = I.RecordOf<_Assets>
 
-export type BadgesUpdate = Array<{accountID: AccountID, numUnread: number}>
-
 export type BannerBackground = 'Announcements' | 'HighRisk' | 'Information'
 
 export type Banner = {|
@@ -200,7 +198,7 @@ export type _State = {
   secretKeyValidationState: ValidationState,
   selectedAccount: AccountID,
   sentPaymentError: string,
-  unreadPaymentsMap: I.Map<AccountID, number>,
+  unreadPaymentsMap: I.Map<string, number>,
 }
 
 export type State = I.RecordOf<_State>


### PR DESCRIPTION
@keybase/react-hackers CC @songgao 

Forgot to re-run build-actions after changing types in wallets.json, expecting that flow would be checking them without rebuilding, oops.

(We could add a new CI check that build-actions does not produce any diff in the built JS.)