### PR TITLE
add more chat permanent errors for missing keys CORE-9134

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -139,6 +139,8 @@ func (b *Boxer) detectPermanentError(err error, tlfName string) UnboxingError {
 		}
 		return NewPermanentUnboxingError(err)
 	case teams.TeamDoesNotExistError,
+		teams.KBFSKeyGenerationError,
+		libkb.KeyMaskNotFoundError,
 		DecryptionKeyNotFoundError,
 		NotAuthenticatedForThisDeviceError,
 		InvalidMACError:

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -441,3 +441,18 @@ func NewAuditError(format string, args ...interface{}) error {
 func (e AuditError) Error() string {
 	return fmt.Sprintf("Audit error: %s", e.Msg)
 }
+
+type KBFSKeyGenerationError struct {
+	Required, Exists int
+}
+
+func NewKBFSKeyGenerationError(required, exists int) KBFSKeyGenerationError {
+	return KBFSKeyGenerationError{
+		Required: required,
+		Exists:   exists,
+	}
+}
+
+func (e KBFSKeyGenerationError) Error() string {
+	return fmt.Sprintf("KBFS key generation too low: %v < %v", e.Exists, e.Required)
+}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -1119,7 +1119,7 @@ func (l *TeamLoader) satisfiesNeedsKBFSKeyGeneration(ctx context.Context,
 		return err
 	}
 	if kbfs.Generation > gen {
-		return fmt.Errorf("KBFS key generation too low: %v < %v", gen, kbfs.Generation)
+		return NewKBFSKeyGenerationError(kbfs.Generation, gen)
 	}
 	return nil
 }


### PR DESCRIPTION
This can happen in some bizarre upgrade scenarios, so let's not error out the whole thread with a "transient" error and label these key errors as permanent.