### PR TITLE
Stellar: Move wallet tab between Teams and Devices in desktop's main nav

### DIFF
--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -11,7 +11,6 @@ import * as Tabs from '../constants/tabs'
 import {switchTo} from '../actions/route-tree'
 import {connect, type TypedState} from '../util/container'
 import {globalStyles} from '../styles'
-import flags from '../util/feature-flags'
 import RpcStats from './rpc-stats'
 
 type Props = {
@@ -22,16 +21,11 @@ type Props = {
   routePath: I.List<string>,
 }
 
-const hotkeyTabMap: {[string]: Tabs.Tab} = {
-  '1': Tabs.peopleTab,
-  '2': Tabs.chatTab,
-  '3': Tabs.fsTab,
-  '4': Tabs.teamsTab,
-  '5': Tabs.devicesTab,
-  '6': Tabs.gitTab,
-  '7': Tabs.settingsTab,
-  ...(flags.walletsEnabled ? {'8': Tabs.walletsTab} : {}),
-}
+
+const hotkeyTabMap = Tabs.desktopTabOrder.reduce((tabMap, tab, index) => {
+  tabMap[index + 1] = tab
+  return tabMap
+}, {})
 
 const hotkeys = Object.keys(hotkeyTabMap).map(key => `${isDarwin ? 'command' : 'ctrl'}+${key}`)
 

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -21,7 +21,6 @@ type Props = {
   routePath: I.List<string>,
 }
 
-
 const hotkeyTabMap = Tabs.desktopTabOrder.reduce((tabMap, tab, index) => {
   tabMap[index + 1] = tab
   return tabMap

--- a/shared/app/tab-bar/index.desktop.js
+++ b/shared/app/tab-bar/index.desktop.js
@@ -1,7 +1,6 @@
 // @flow
 import * as Tabs from '../../constants/tabs'
 import * as React from 'react'
-import flags from '../../util/feature-flags'
 import {Box} from '../../common-adapters'
 import {TabBarButton} from '../../common-adapters/tab-bar'
 import {globalStyles, globalColors, globalMargins} from '../../styles'
@@ -10,41 +9,30 @@ import type {Props} from './index.types'
 const _icons = {
   [Tabs.chatTab]: 'iconfont-nav-chat',
   [Tabs.devicesTab]: 'iconfont-nav-devices',
+  [Tabs.fsTab]: 'iconfont-nav-files',
+  [Tabs.gitTab]: 'iconfont-nav-git',
   [Tabs.peopleTab]: 'iconfont-nav-people',
   [Tabs.profileTab]: 'iconfont-nav-people',
   [Tabs.settingsTab]: 'iconfont-nav-settings',
   [Tabs.teamsTab]: 'iconfont-nav-teams',
-  [Tabs.gitTab]: 'iconfont-nav-git',
-  [Tabs.fsTab]: 'iconfont-nav-files',
   [Tabs.walletsTab]: 'iconfont-nav-wallets',
 }
 
 const _labels = {
   [Tabs.chatTab]: 'Chat',
   [Tabs.devicesTab]: 'Devices',
+  [Tabs.fsTab]: 'Files',
+  [Tabs.gitTab]: 'Git',
   [Tabs.peopleTab]: 'People',
   [Tabs.profileTab]: 'People',
   [Tabs.settingsTab]: 'Settings',
   [Tabs.teamsTab]: 'Teams',
-  [Tabs.gitTab]: 'Git',
-  [Tabs.fsTab]: 'Files',
   [Tabs.walletsTab]: 'Wallet',
 }
 
-const _tabs = [
-  Tabs.peopleTab,
-  Tabs.chatTab,
-  Tabs.fsTab,
-  Tabs.teamsTab,
-  Tabs.devicesTab,
-  Tabs.gitTab,
-  Tabs.settingsTab,
-  ...(flags.walletsEnabled ? [Tabs.walletsTab] : []),
-].filter(Boolean)
-
 const TabBarRender = ({onTabClick, selectedTab, username, badgeNumbers}: Props) => (
   <Box style={stylesTabBar}>
-    {_tabs.map(tab => (
+    {Tabs.desktopTabOrder.map(tab => (
       <TabBarButton
         className="keybase-nav"
         badgeNumber={badgeNumbers[tab]}

--- a/shared/constants/tabs.js
+++ b/shared/constants/tabs.js
@@ -1,5 +1,6 @@
 // @flow strict
 import {isMobile} from './platform'
+import flags from '../util/feature-flags'
 
 const chatTab = 'tabs:chatTab'
 const devicesTab = 'tabs:devicesTab'
@@ -41,6 +42,18 @@ export type Tab =
   | FsTab
   | WalletsTab
 
+// Canonical ordering for desktop tabs, used visually and for hotkeys
+const desktopTabOrder = [
+  peopleTab,
+  chatTab,
+  fsTab,
+  teamsTab,
+  flags.walletsEnabled ? walletsTab : null,
+  devicesTab,
+  gitTab,
+  settingsTab,
+].filter(Boolean)
+
 function isValidInitialTab(tab: ?Tab) {
   return isValidInitialTabString(tab)
 }
@@ -57,6 +70,7 @@ function isValidInitialTabString(tab: ?string) {
 
 export {
   chatTab,
+  desktopTabOrder,
   devicesTab,
   folderTab,
   fsTab,

--- a/shared/util/feature-flags.js.flow
+++ b/shared/util/feature-flags.js.flow
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 export type FeatureFlags = {|
   admin: boolean,
   avatarUploadsEnabled: boolean,


### PR DESCRIPTION
@keybase/react-hackers 

* Use one source of truth instead of two (render, hotkeys) for desktop tab order
* Calculate the hotkey instead of hardcode, since we're no longer just adding one to the end for wallets
* Move the Wallets tab inbetween Teams and Devices