### PR TITLE
remove typed state

### DIFF
--- a/shared/app/main.desktop.js
+++ b/shared/app/main.desktop.js
@@ -2,7 +2,7 @@
 import {hot} from 'react-hot-loader'
 import React, {Component} from 'react'
 import RenderRoute from '../route-tree/render-route'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 import * as SafeElectron from '../util/safe-electron.desktop'
 import {isWindows} from '../constants/platform'
 import {resolveImage} from '../desktop/app/resolve-root.desktop'
@@ -61,7 +61,7 @@ class Main extends Component<Props> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   return {
     desktopAppBadgeCount: state.notifications.get('desktopAppBadgeCount'),
     routeDef: state.routeTree.routeDef,

--- a/shared/app/main.native.js
+++ b/shared/app/main.native.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import PushPrompt from './push-prompt.native'
 import RenderRoute from '../route-tree/render-route'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 import {navigateUp, setRouteState} from '../actions/route-tree'
 import {GatewayDest} from 'react-gateway'
 import {NativeBackHandler} from '../common-adapters/mobile.native'
@@ -56,7 +56,7 @@ class Main extends React.Component<Props> {
 }
 const ViewForGatewayDest = (props: any) => <View {...props} />
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   routeDef: state.routeTree.routeDef,
   routeState: state.routeTree.routeState,
   showPushPrompt: state.config.loggedIn && state.push.showPushPrompt,

--- a/shared/app/nav.desktop.js
+++ b/shared/app/nav.desktop.js
@@ -9,7 +9,7 @@ import {isDarwin} from '../constants/platform'
 import {Box, ErrorBoundary} from '../common-adapters'
 import * as Tabs from '../constants/tabs'
 import {switchTo} from '../actions/route-tree'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 import {globalStyles} from '../styles'
 import flags from '../util/feature-flags'
 import RpcStats from './rpc-stats'
@@ -73,7 +73,7 @@ const stylesTabsContainer = {
   flex: 1,
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _username: state.config.username,
 })
 

--- a/shared/app/nav.native.js
+++ b/shared/app/nav.native.js
@@ -13,7 +13,7 @@ import {
 } from '../common-adapters/mobile.native'
 import {NavigationActions, type NavigationAction} from 'react-navigation'
 import {chatTab, loginTab} from '../constants/tabs'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 import {globalColors, globalStyles, statusBarHeight, styleSheetCreate} from '../styles'
 import {addSizeListener} from '../styles/status-bar'
 import * as I from 'immutable'
@@ -360,7 +360,7 @@ class Nav extends Component<Props, {keyboardShowing: boolean}> {
   }
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
+const mapStateToProps = (state, ownProps: OwnProps) => ({
   _me: state.config.username,
   hideNav: ownProps.routeSelected === loginTab,
 })

--- a/shared/app/push-prompt.native.js
+++ b/shared/app/push-prompt.native.js
@@ -72,7 +72,7 @@ const styles = Styles.styleSheetCreate({
 })
 
 const mapStateToProps = () => ({})
-const mapDispatchToProps = (dispatch: Container.Dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onNoPermissions: () => dispatch(PushGen.createRejectPermissions()),
   onRequestPermissions: () => dispatch(PushGen.createRequestPermissions()),
 })

--- a/shared/app/tab-bar/container.js
+++ b/shared/app/tab-bar/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {connect, type TypedState, isMobile} from '../../util/container'
+import {connect, isMobile} from '../../util/container'
 import TabBarRender from '.'
 import {chatTab, peopleTab, profileTab, type Tab} from '../../constants/tabs'
 import {navigateTo, switchTo} from '../../actions/route-tree'
@@ -10,7 +10,7 @@ if (!isMobile) {
   KeyHandler = require('../../util/key-handler.desktop').default
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _badgeNumbers: state.notifications.get('navBadges'),
   username: state.config.username,
 })

--- a/shared/chat/conversation/attachment-fullscreen/container.js
+++ b/shared/chat/conversation/attachment-fullscreen/container.js
@@ -4,14 +4,14 @@ import * as Constants from '../../../constants/chat2'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as FsGen from '../../../actions/fs-gen'
 import Fullscreen from './'
-import {compose, withStateHandlers, connect, type TypedState} from '../../../util/container'
+import {compose, withStateHandlers, connect} from '../../../util/container'
 import {type RouteProps} from '../../../route-tree/render-route'
 
 type OwnProps = RouteProps<{conversationIDKey: Types.ConversationIDKey, ordinal: Types.Ordinal}, {}>
 
 const blankMessage = Constants.makeMessageAttachment({})
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const conversationIDKey = ownProps.routeProps.get('conversationIDKey')
   const ordinal = ownProps.routeProps.get('ordinal')
   const message = Constants.getMessage(state, conversationIDKey, ordinal) || blankMessage

--- a/shared/chat/conversation/attachment-get-titles/container.js
+++ b/shared/chat/conversation/attachment-get-titles/container.js
@@ -4,14 +4,14 @@ import * as Constants from '../../../constants/chat2'
 import * as Types from '../../../constants/types/chat2'
 import * as FsTypes from '../../../constants/types/fs'
 import GetTitles from './'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {navigateUp} from '../../../actions/route-tree'
 import {type RouteProps} from '../../../route-tree/render-route'
 import type {PathToInfo} from '.'
 
 type OwnProps = RouteProps<{paths: Array<string>, conversationIDKey: Types.ConversationIDKey}, {}>
 
-const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => ({
+const mapStateToProps = (state, {routeProps}: OwnProps) => ({
   _conversationIDKey: routeProps.get('conversationIDKey'),
   paths: routeProps.get('paths'),
 })

--- a/shared/chat/conversation/attachment-video-fullscreen/container.js
+++ b/shared/chat/conversation/attachment-video-fullscreen/container.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Types from '../../../constants/types/chat2'
 import * as Constants from '../../../constants/chat2'
-import {compose, connect, type TypedState} from '../../../util/container'
+import {compose, connect} from '../../../util/container'
 import {type RouteProps} from '../../../route-tree/render-route'
 import VideoFullscreen from './'
 
@@ -9,7 +9,7 @@ type OwnProps = RouteProps<{conversationIDKey: Types.ConversationIDKey, ordinal:
 
 const blankMessage = Constants.makeMessageAttachment({})
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const conversationIDKey = ownProps.routeProps.get('conversationIDKey')
   const ordinal = ownProps.routeProps.get('ordinal')
   const message = Constants.getMessage(state, conversationIDKey, ordinal) || blankMessage

--- a/shared/chat/conversation/block-conversation-warning/container.js
+++ b/shared/chat/conversation/block-conversation-warning/container.js
@@ -2,7 +2,7 @@
 import RenderBlockConversationWarning from './'
 import * as Constants from '../../../constants/chat2'
 import * as Chat2Gen from '../../../actions/chat2-gen'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {navigateUp} from '../../../actions/route-tree'
 import {type RouteProps} from '../../../route-tree/render-route'
 import {type ConversationIDKey} from '../../../constants/types/chat2'
@@ -10,7 +10,7 @@ import {type ConversationIDKey} from '../../../constants/types/chat2'
 type RenderBlockConversationWarningRouteProps = RouteProps<{conversationIDKey: ConversationIDKey}, {}>
 type OwnProps = RenderBlockConversationWarningRouteProps
 
-const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
+const mapStateToProps = (state, {routeProps}: OwnProps) => {
   const conversationIDKey = routeProps.get('conversationIDKey')
   const participants = Constants.getMeta(state, conversationIDKey).participants.join(',')
   return {

--- a/shared/chat/conversation/bottom-banner/container.js
+++ b/shared/chat/conversation/bottom-banner/container.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as Constants from '../../../constants/chat2'
 import {BrokenTrackerBanner, InviteBanner} from '.'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {createGetProfile} from '../../../actions/tracker-gen'
 import {isMobile} from '../../../constants/platform'
 import {createShowUserProfile} from '../../../actions/profile-gen'
@@ -27,7 +27,7 @@ class BannerContainer extends React.PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey}) => {
   const _following = state.config.following
   const _meta = Constants.getMeta(state, conversationIDKey)
   const _users = state.users

--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as Constants from '../../constants/chat2'
 import * as Types from '../../constants/types/chat2'
 import {isMobile} from '../../styles'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import Normal from './normal/container'
 import NoConversation from './no-conversation'
 import Error from './error/container'
@@ -53,7 +53,7 @@ class Conversation extends React.PureComponent<SwitchProps> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   let conversationIDKey = Constants.getSelectedConversation(state)
   let _meta = Constants.getMeta(state, conversationIDKey)
 

--- a/shared/chat/conversation/create-team-header/container.js
+++ b/shared/chat/conversation/create-team-header/container.js
@@ -1,17 +1,17 @@
 // @flow
 import * as Types from '../../../constants/types/chat2'
 import CreateTeamHeader from '.'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {navigateAppend} from '../../../actions/route-tree'
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey,
 }
-const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => ({
+const mapStateToProps = (state, {conversationIDKey}: OwnProps) => ({
   conversationIDKey,
 })
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   _onShowNewTeamDialog: (conversationIDKey: Types.ConversationIDKey) => {
     dispatch(
       navigateAppend([

--- a/shared/chat/conversation/error/container.js
+++ b/shared/chat/conversation/error/container.js
@@ -2,18 +2,18 @@
 import * as Types from '../../../constants/types/chat2'
 import * as Constants from '../../../constants/chat2'
 import * as Route from '../../../actions/route-tree'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import Error from '.'
 
 type OwnProps = {|
   conversationIDKey: Types.ConversationIDKey,
 |}
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => ({
+const mapStateToProps = (state, {conversationIDKey}: OwnProps) => ({
   text: Constants.getMeta(state, conversationIDKey).snippet,
 })
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onBack: () => dispatch(Route.navigateUp()),
 })
 

--- a/shared/chat/conversation/header-area/container.js
+++ b/shared/chat/conversation/header-area/container.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as Types from '../../../constants/types/chat2'
 import * as Constants from '../../../constants/chat2'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import ConversationHeader from './normal/container'
 import Search from './search'
 import CreateTeamHeader from '../create-team-header/container'
@@ -36,7 +36,7 @@ class HeaderArea extends React.PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => {
+const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
   const isSearching =
     state.chat2.pendingMode === 'searchingForUsers' &&
     conversationIDKey === Constants.pendingConversationIDKey

--- a/shared/chat/conversation/header-area/normal/container.js
+++ b/shared/chat/conversation/header-area/normal/container.js
@@ -4,10 +4,10 @@ import * as Constants from '../../../../constants/chat2'
 import * as RouteTree from '../../../../actions/route-tree'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import {ChannelHeader, UsernameHeader} from '.'
-import {branch, compose, renderComponent, connect, type TypedState} from '../../../../util/container'
+import {branch, compose, renderComponent, connect} from '../../../../util/container'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
 
-const mapStateToProps = (state: TypedState, {infoPanelOpen, conversationIDKey}) => {
+const mapStateToProps = (state, {infoPanelOpen, conversationIDKey}) => {
   const _isPending = conversationIDKey === Constants.pendingConversationIDKey
   let meta = Constants.getMeta(state, conversationIDKey)
   if (_isPending) {

--- a/shared/chat/conversation/header-area/search.js
+++ b/shared/chat/conversation/header-area/search.js
@@ -8,10 +8,9 @@ import {
   withStateHandlers,
   lifecycle,
   withProps,
-  type TypedState,
 } from '../../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   pendingConversationUsers: Constants.getMeta(state, Constants.pendingConversationIDKey).participants,
 })
 

--- a/shared/chat/conversation/info-panel/menu/container.js
+++ b/shared/chat/conversation/info-panel/menu/container.js
@@ -6,7 +6,6 @@ import {
   compose,
   connect,
   setDisplayName,
-  type TypedState,
   createCachedSelector,
 } from '../../../../util/container'
 import {InfoPanelMenu} from '.'
@@ -37,7 +36,7 @@ const moreThanOneSubscribedChannel = createCachedSelector(
   }
 )((_: any, teamname: string) => teamname)
 
-const mapStateToProps = (state: TypedState, {teamname, isSmallTeam}: OwnProps) => {
+const mapStateToProps = (state, {teamname, isSmallTeam}: OwnProps) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   // We can get here without loading canPerform
   const hasCanPerform = Constants.hasCanPerform(state, teamname)

--- a/shared/chat/conversation/info-panel/notifications/container.js
+++ b/shared/chat/conversation/info-panel/notifications/container.js
@@ -9,14 +9,13 @@ import {
   lifecycle,
   setDisplayName,
   withStateHandlers,
-  type TypedState,
 } from '../../../../util/container'
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey,
 }
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => {
+const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
   const meta = Constants.getMeta(state, conversationIDKey)
 
   return {

--- a/shared/chat/conversation/input-area/channel-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/channel-mention-hud/mention-hud-container.js
@@ -1,9 +1,9 @@
 // @flow
 import {MentionHud} from '.'
-import {compose, connect, type TypedState, setDisplayName} from '../../../../util/container'
+import {compose, connect, setDisplayName} from '../../../../util/container'
 import * as Constants from '../../../../constants/chat2'
 
-const mapStateToProps = (state: TypedState, {filter, conversationIDKey}) => {
+const mapStateToProps = (state, {filter, conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
   return {
     _metaMap: state.chat2.metaMap,

--- a/shared/chat/conversation/input-area/container.js
+++ b/shared/chat/conversation/input-area/container.js
@@ -5,7 +5,6 @@ import * as Constants from '../../../constants/chat2'
 import Normal from './normal/container'
 import Preview from './preview/container'
 import {connect} from '../../../util/container'
-import type {TypedState} from '../../../util/container'
 
 type OwnProps = {|
   conversationIDKey: Types.ConversationIDKey,
@@ -18,7 +17,7 @@ type Props = {|
   noInput: boolean,
 |}
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => {
+const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
   const meta = Constants.getMeta(state, conversationIDKey)
   let noInput = !meta.resetParticipants.isEmpty() || !!meta.wasFinalizedBy
   let conversationIDKeyToShow = conversationIDKey

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -4,7 +4,7 @@ import * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as RouteTree from '../../../../actions/route-tree'
 import HiddenString from '../../../../util/hidden-string'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 import Input, {type Props} from '.'
 
 type OwnProps = {
@@ -24,7 +24,7 @@ const setUnsentText = (conversationIDKey: Types.ConversationIDKey, text: string)
   unsentText[conversationIDKey] = text
 }
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => {
+const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
   const editInfo = Constants.getEditInfo(state, conversationIDKey)
   const quoteInfo = Constants.getQuoteInfo(state, conversationIDKey)
 

--- a/shared/chat/conversation/input-area/preview/container.js
+++ b/shared/chat/conversation/input-area/preview/container.js
@@ -3,9 +3,9 @@ import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import ChannelPreview from '.'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey}) => {
   const _meta = Constants.getMeta(state, conversationIDKey)
   return {
     _conversationIDKey: conversationIDKey,
@@ -13,7 +13,7 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   _onJoinChannel: (conversationIDKey: Types.ConversationIDKey) =>
     dispatch(Chat2Gen.createJoinConversation({conversationIDKey})),
   _onLeaveChannel: (conversationIDKey: Types.ConversationIDKey) =>

--- a/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
@@ -4,12 +4,12 @@ import * as Types from '../../../../constants/types/chat2'
 import * as Constants from '../../../../constants/chat2'
 import {MentionHud} from '.'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
-import {compose, connect, type TypedState, setDisplayName} from '../../../../util/container'
+import {compose, connect, setDisplayName} from '../../../../util/container'
 import * as I from 'immutable'
 import logger from '../../../../logger'
 import type {MentionHudProps} from '.'
 
-const mapStateToProps = (state: TypedState, {filter, conversationIDKey}) => {
+const mapStateToProps = (state, {filter, conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
   const teamType = meta.teamType
   return {

--- a/shared/chat/conversation/list-area/container.js
+++ b/shared/chat/conversation/list-area/container.js
@@ -7,7 +7,7 @@ import * as ProfileGen from '../../../actions/profile-gen'
 import * as TrackerGen from '../../../actions/tracker-gen'
 import Normal from './normal/container'
 import SearchResultsList from '../../../search/results-list/container'
-import {connect, type TypedState, isMobile} from '../../../util/container'
+import {connect, isMobile} from '../../../util/container'
 import {desktopStyles} from '../../../styles'
 import StartConversation from './start-conversation/container'
 import Waiting from './waiting'
@@ -55,7 +55,7 @@ class ListArea extends React.PureComponent<Props> {
 
 const searchResultStyle = {...desktopStyles.scrollable, flexGrow: 1}
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey}) => {
   let type
   let conversationIDKeyToShow = conversationIDKey
   if (
@@ -100,7 +100,7 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onShowTracker: (username: string) =>
     isMobile
       ? dispatch(ProfileGen.createShowUserProfile({username}))

--- a/shared/chat/conversation/list-area/normal/container.js
+++ b/shared/chat/conversation/list-area/normal/container.js
@@ -4,7 +4,7 @@ import * as Constants from '../../../../constants/chat2'
 import * as ConfigGen from '../../../../actions/config-gen'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import ListComponent from '.'
-import {connect, type TypedState, compose, lifecycle, withStateHandlers} from '../../../../util/container'
+import {connect, compose, lifecycle, withStateHandlers} from '../../../../util/container'
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey,
@@ -12,7 +12,7 @@ type OwnProps = {
   onFocusInput: () => void,
 }
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}: OwnProps) => {
+const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
   const messageOrdinals = Constants.getMessageOrdinals(state, conversationIDKey)
   const lastOrdinal = messageOrdinals.last()
   let lastMessageIsOurs = false

--- a/shared/chat/conversation/list-area/start-conversation/container.js
+++ b/shared/chat/conversation/list-area/start-conversation/container.js
@@ -3,9 +3,9 @@ import * as Constants from '../../../../constants/chat2'
 import * as WaitingConstants from '../../../../constants/waiting'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import StartConversation from '.'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => ({
+const mapStateToProps = (state, {conversationIDKey}) => ({
   _meta: Constants.getMeta(state, conversationIDKey),
   isLoading: WaitingConstants.anyWaiting(state, Constants.waitingKeyCreating),
   showAddParticipants: state.chat2.pendingMode === 'searchingForUsers',

--- a/shared/chat/conversation/messages/attachment/file/container.js
+++ b/shared/chat/conversation/messages/attachment/file/container.js
@@ -2,11 +2,11 @@
 import * as Types from '../../../../../constants/types/chat2'
 import * as FsGen from '../../../../../actions/fs-gen'
 import * as Chat2Gen from '../../../../../actions/chat2-gen'
-import {connect, type TypedState, isMobile} from '../../../../../util/container'
+import {connect, isMobile} from '../../../../../util/container'
 import {globalColors} from '../../../../../styles'
 import File from '.'
 
-const mapStateToProps = (state: TypedState) => ({})
+const mapStateToProps = state => ({})
 type OwnProps = {
   message: Types.MessageAttachment,
 }

--- a/shared/chat/conversation/messages/attachment/image/container.js
+++ b/shared/chat/conversation/messages/attachment/image/container.js
@@ -2,7 +2,7 @@
 import * as Types from '../../../../../constants/types/chat2'
 import * as FsGen from '../../../../../actions/fs-gen'
 import * as Chat2Gen from '../../../../../actions/chat2-gen'
-import {connect, type TypedState, isMobile} from '../../../../../util/container'
+import {connect, isMobile} from '../../../../../util/container'
 import {globalColors} from '../../../../../styles'
 import ImageAttachment from '.'
 import {imgMaxWidth} from './image-render'
@@ -12,9 +12,9 @@ type OwnProps = {
   toggleMessageMenu: () => void,
 }
 
-const mapStateToProps = (state: TypedState) => ({})
+const mapStateToProps = state => ({})
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   _onClick: (message: Types.MessageAttachment) => {
     dispatch(
       Chat2Gen.createAttachmentPreviewSelect({

--- a/shared/chat/conversation/messages/index.js
+++ b/shared/chat/conversation/messages/index.js
@@ -13,7 +13,7 @@ import SetDescription from './set-description/container'
 import SetChannelname from './set-channelname/container'
 import Placeholder from './placeholder/container'
 import WrapperTimestamp from './wrapper/wrapper-timestamp/container'
-import {setDisplayName, connect, compose, lifecycle, type TypedState} from '../../../util/container'
+import {setDisplayName, connect, compose, lifecycle} from '../../../util/container'
 
 type Props = {
   message: Types.Message,
@@ -118,7 +118,7 @@ class MessageFactory extends React.PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state: TypedState, {ordinal, previous, conversationIDKey}) => {
+const mapStateToProps = (state, {ordinal, previous, conversationIDKey}) => {
   const message: ?Types.Message = Constants.getMessage(state, conversationIDKey, ordinal)
   const editInfo = Constants.getEditInfo(state, conversationIDKey)
   const isEditing = !!(message && editInfo && editInfo.ordinal === message.ordinal)

--- a/shared/chat/conversation/messages/message-popup/attachment/container.js
+++ b/shared/chat/conversation/messages/message-popup/attachment/container.js
@@ -6,7 +6,7 @@ import * as Constants from '../../../../../constants/chat2'
 import * as Types from '../../../../../constants/types/chat2'
 import * as Route from '../../../../../actions/route-tree'
 import {getCanPerform} from '../../../../../constants/teams'
-import {connect, type TypedState} from '../../../../../util/container'
+import {connect} from '../../../../../util/container'
 import {isMobile, isIOS} from '../../../../../constants/platform'
 import type {Position} from '../../../../../common-adapters/relative-popup-hoc'
 import Attachment from '.'
@@ -19,7 +19,7 @@ type OwnProps = {
   visible: boolean,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const message = ownProps.message
   const meta = Constants.getMeta(state, message.conversationIDKey)
   const yourOperations = getCanPerform(state, meta.teamname)

--- a/shared/chat/conversation/messages/message-popup/exploding/container.js
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.js
@@ -7,7 +7,7 @@ import * as ConfigGen from '../../../../../actions/config-gen'
 import * as Chat2Gen from '../../../../../actions/chat2-gen'
 import * as FsGen from '../../../../../actions/fs-gen'
 import * as Route from '../../../../../actions/route-tree'
-import {compose, connect, isMobile, setDisplayName, type TypedState} from '../../../../../util/container'
+import {compose, connect, isMobile, setDisplayName} from '../../../../../util/container'
 import {isIOS} from '../../../../../constants/platform'
 
 import type {Position} from '../../../../../common-adapters/relative-popup-hoc'
@@ -21,7 +21,7 @@ export type OwnProps = {
   visible: boolean,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const yourMessage = ownProps.message.author === state.config.username
   const meta = Constants.getMeta(state, ownProps.message.conversationIDKey)
   const _canDeleteHistory =

--- a/shared/chat/conversation/messages/message-popup/payment/container.js
+++ b/shared/chat/conversation/messages/message-popup/payment/container.js
@@ -50,7 +50,7 @@ const commonLoadingProps = {
 }
 
 // MessageSendPayment ===================================
-const sendMapStateToProps = (state: Container.TypedState, ownProps: SendOwnProps) => ({
+const sendMapStateToProps = (state, ownProps: SendOwnProps) => ({
   paymentInfo: Constants.getPaymentMessageInfo(state, ownProps.message),
   _you: state.config.username,
 })
@@ -111,7 +111,7 @@ const SendPaymentPopup = Container.connect(
 )(PaymentPopup)
 
 // MessageRequestPayment ================================
-const requestMapStateToProps = (state: Container.TypedState, ownProps: RequestOwnProps) => ({
+const requestMapStateToProps = (state, ownProps: RequestOwnProps) => ({
   requestInfo: Constants.getRequestMessageInfo(state, ownProps.message),
   _you: state.config.username,
 })

--- a/shared/chat/conversation/messages/message-popup/text/container.js
+++ b/shared/chat/conversation/messages/message-popup/text/container.js
@@ -19,7 +19,7 @@ type OwnProps = {
   visible: boolean,
 }
 
-const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const message = ownProps.message
   const meta = Constants.getMeta(state, message.conversationIDKey)
   const yourOperations = getCanPerform(state, meta.teamname)
@@ -32,7 +32,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   _onAddReaction: (message: Types.Message) => {
     dispatch(
       Route.navigateAppend([

--- a/shared/chat/conversation/messages/react-button/container.js
+++ b/shared/chat/conversation/messages/react-button/container.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {compose, connect, setDisplayName, type TypedState} from '../../../../util/container'
+import {compose, connect, setDisplayName} from '../../../../util/container'
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
@@ -61,7 +61,7 @@ const noEmoji = {
   emoji: '',
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const me = state.config.username || ''
   const message = Constants.getMessage(state, ownProps.conversationIDKey, ownProps.ordinal)
   if (!message || message.type === 'placeholder' || message.type === 'deleted') {

--- a/shared/chat/conversation/messages/reaction-tooltip/container.js
+++ b/shared/chat/conversation/messages/reaction-tooltip/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {compose, connect, isMobile, setDisplayName, type TypedState} from '../../../../util/container'
+import {compose, connect, isMobile, setDisplayName} from '../../../../util/container'
 import * as React from 'react'
 import * as I from 'immutable'
 import * as Constants from '../../../../constants/chat2'
@@ -29,7 +29,7 @@ const emptyStateProps = {
   _usersInfo: I.Map(),
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const message = Constants.getMessage(state, ownProps.conversationIDKey, ownProps.ordinal)
   if (!message || message.type === 'placeholder' || message.type === 'deleted') {
     return emptyStateProps

--- a/shared/chat/conversation/messages/reactions-row/container.js
+++ b/shared/chat/conversation/messages/reactions-row/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {compose, connect, setDisplayName, type TypedState} from '../../../../util/container'
+import {compose, connect, setDisplayName} from '../../../../util/container'
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import ReactionsRow from '.'
@@ -22,7 +22,7 @@ export type OwnProps = {|
   ordinal: Types.Ordinal,
 |}
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const message = Constants.getMessage(state, ownProps.conversationIDKey, ownProps.ordinal)
   if (!message || message.type === 'placeholder' || message.type === 'deleted') {
     // nothing to see here

--- a/shared/chat/conversation/messages/reset-user/container.js
+++ b/shared/chat/conversation/messages/reset-user/container.js
@@ -4,9 +4,9 @@ import * as Constants from '../../../../constants/chat2'
 import * as TrackerGen from '../../../../actions/profile-gen'
 import * as Types from '../../../../constants/types/chat2'
 import ResetUser from '.'
-import {compose, connect, type TypedState} from '../../../../util/container'
+import {compose, connect} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
   const username = meta.resetParticipants.first() || ''
   const nonResetUsers = meta.participants.toSet().subtract(meta.resetParticipants)

--- a/shared/chat/conversation/messages/retention-notice/container.js
+++ b/shared/chat/conversation/messages/retention-notice/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {compose, connect, lifecycle, type TypedState} from '../../../../util/container'
+import {compose, connect, lifecycle} from '../../../../util/container'
 import * as ChatTypes from '../../../../constants/types/chat2'
 import {getMeta} from '../../../../constants/chat2'
 import {makeRetentionNotice} from '../../../../util/teams'
@@ -13,7 +13,7 @@ type OwnProps = {
   measure: ?() => void,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const meta = getMeta(state, ownProps.conversationIDKey)
   let canChange = true
   // We almost definitely already have the permissions, but check just in case something changes

--- a/shared/chat/conversation/messages/set-channelname/container.js
+++ b/shared/chat/conversation/messages/set-channelname/container.js
@@ -1,10 +1,10 @@
 // @flow
-import {connect, isMobile, type TypedState} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
 import {createGetProfile} from '../../../../actions/tracker-gen'
 import SetChannelname from '.'
 
-const mapStateToProps = (state: TypedState, {message}) => ({
+const mapStateToProps = (state, {message}) => ({
   author: message.author,
   channelname: message.newChannelname,
   setUsernameBlack: message.author === state.config.username,

--- a/shared/chat/conversation/messages/set-description/container.js
+++ b/shared/chat/conversation/messages/set-description/container.js
@@ -1,10 +1,10 @@
 // @flow
-import {connect, isMobile, type TypedState} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
 import {createGetProfile} from '../../../../actions/tracker-gen'
 import SetDescription from '.'
 
-const mapStateToProps = (state: TypedState, {message}) => ({
+const mapStateToProps = (state, {message}) => ({
   author: message.author,
   description: message.newDescription.stringValue(),
   setUsernameBlack: message.author === state.config.username,

--- a/shared/chat/conversation/messages/set-explode-popup/container.js
+++ b/shared/chat/conversation/messages/set-explode-popup/container.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 import * as Constants from '../../../../constants/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Types from '../../../../constants/types/chat2'
@@ -15,7 +15,7 @@ type OwnProps = {
   visible: boolean,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
+const mapStateToProps = (state, ownProps: OwnProps) => ({
   isNew: Constants.getIsExplodingNew(state),
   items: Constants.messageExplodeDescriptions,
   selected: Constants.getConversationExplodingMode(state, ownProps.conversationIDKey),

--- a/shared/chat/conversation/messages/special-bottom-message.js
+++ b/shared/chat/conversation/messages/special-bottom-message.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import * as Types from '../../../constants/types/chat2'
 import OldProfileReset from './system-old-profile-reset-notice/container'
 import ResetUser from './reset-user/container'
-import {compose, connect, type TypedState, setDisplayName} from '../../../util/container'
+import {compose, connect, setDisplayName} from '../../../util/container'
 
 type Props = {
   showResetParticipants: Types.ConversationIDKey | null,
@@ -38,7 +38,7 @@ type OwnProps = {
   measure: ?() => void,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const meta = Constants.getMeta(state, ownProps.conversationIDKey)
   const showResetParticipants = !meta.resetParticipants.isEmpty() ? ownProps.conversationIDKey : null
   const showSuperseded =

--- a/shared/chat/conversation/messages/special-top-message.js
+++ b/shared/chat/conversation/messages/special-top-message.js
@@ -7,7 +7,7 @@ import ProfileResetNotice from './system-profile-reset-notice/container'
 import RetentionNotice from './retention-notice/container'
 import shallowEqual from 'shallowequal'
 import {Text, Box, Icon} from '../../../common-adapters'
-import {compose, setDisplayName, connect, type TypedState} from '../../../util/container'
+import {compose, setDisplayName, connect} from '../../../util/container'
 import {globalStyles, globalMargins, isMobile} from '../../../styles'
 
 type Props = {
@@ -78,7 +78,7 @@ type OwnProps = {
   measure: ?() => void,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const hasLoadedEver = state.chat2.messageOrdinals.get(ownProps.conversationIDKey) !== undefined
   const meta = Constants.getMeta(state, ownProps.conversationIDKey)
   const loadMoreType = state.chat2.moreToLoadMap.get(ownProps.conversationIDKey)

--- a/shared/chat/conversation/messages/system-added-to-team/container.js
+++ b/shared/chat/conversation/messages/system-added-to-team/container.js
@@ -6,9 +6,9 @@ import {getMeta} from '../../../../constants/chat2/'
 import {getRole, isAdmin} from '../../../../constants/teams'
 import SystemAddedToTeam from '.'
 import {teamsTab} from '../../../../constants/tabs'
-import {connect, type TypedState, isMobile} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState, ownProps) => {
+const mapStateToProps = (state, ownProps) => {
   const teamname = getMeta(state, ownProps.message.conversationIDKey).teamname
   return {
     isAdmin: isAdmin(getRole(state, teamname)),

--- a/shared/chat/conversation/messages/system-create-team-notice/container.js
+++ b/shared/chat/conversation/messages/system-create-team-notice/container.js
@@ -2,10 +2,10 @@
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import CreateTeamNotice from '.'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 import {navigateAppend} from '../../../../actions/route-tree'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const selectedConversationIDKey = Constants.getSelectedConversation(state)
   if (!selectedConversationIDKey) {
     throw new Error('no selected conversation')

--- a/shared/chat/conversation/messages/system-invite-accepted/container.js
+++ b/shared/chat/conversation/messages/system-invite-accepted/container.js
@@ -5,9 +5,9 @@ import * as TrackerGen from '../../../../actions/tracker-gen'
 import * as Route from '../../../../actions/route-tree'
 import {getMeta} from '../../../../constants/chat2/'
 import {teamsTab} from '../../../../constants/tabs'
-import {connect, type TypedState, isMobile} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState, ownProps) => ({
+const mapStateToProps = (state, ownProps) => ({
   teamname: getMeta(state, ownProps.message.conversationIDKey).teamname,
   you: state.config.username,
 })

--- a/shared/chat/conversation/messages/system-joined/container.js
+++ b/shared/chat/conversation/messages/system-joined/container.js
@@ -2,12 +2,12 @@
 import * as Constants from '../../../../constants/chat2'
 import * as RouteTree from '../../../../actions/route-tree'
 import Joined from '.'
-import {connect, type TypedState, isMobile} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
 import {createGetProfile} from '../../../../actions/tracker-gen'
 import {chatTab} from '../../../../constants/tabs'
 
-const mapStateToProps = (state: TypedState, {message}) => ({
+const mapStateToProps = (state, {message}) => ({
   _meta: Constants.getMeta(state, message.conversationIDKey),
   you: state.config.username || '',
 })

--- a/shared/chat/conversation/messages/system-left/container.js
+++ b/shared/chat/conversation/messages/system-left/container.js
@@ -1,11 +1,11 @@
 // @flow
 import * as Constants from '../../../../constants/chat2'
 import Joined from '.'
-import {connect, type TypedState, isMobile} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
 import {createGetProfile} from '../../../../actions/tracker-gen'
 
-const mapStateToProps = (state: TypedState, {message}) => ({
+const mapStateToProps = (state, {message}) => ({
   _meta: Constants.getMeta(state, message.conversationIDKey),
   you: state.config.username,
 })

--- a/shared/chat/conversation/messages/system-old-profile-reset-notice/container.js
+++ b/shared/chat/conversation/messages/system-old-profile-reset-notice/container.js
@@ -3,9 +3,9 @@ import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import OldProfileResetNotice from '.'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
   return {
     _participants: meta.participants,

--- a/shared/chat/conversation/messages/system-profile-reset-notice/container.js
+++ b/shared/chat/conversation/messages/system-profile-reset-notice/container.js
@@ -3,9 +3,9 @@ import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import ProfileResetNotice from '.'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey}) => {
   const meta = Constants.getMeta(state, conversationIDKey)
   return {
     prevConversationIDKey: meta.supersedes,

--- a/shared/chat/conversation/messages/system-simple-to-complex/container.js
+++ b/shared/chat/conversation/messages/system-simple-to-complex/container.js
@@ -2,9 +2,9 @@
 import * as Route from '../../../../actions/route-tree'
 import {teamsTab} from '../../../../constants/tabs'
 import SystemSimpleToComplex from '.'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   you: state.config.username || '',
 })
 

--- a/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
@@ -6,7 +6,7 @@ import * as Types from '../../../../../constants/types/chat2'
 import * as Constants from '../../../../../constants/chat2'
 import * as MessageConstants from '../../../../../constants/chat2/message'
 import WrapperAuthor from '.'
-import {setDisplayName, compose, connect, type TypedState} from '../../../../../util/container'
+import {setDisplayName, compose, connect} from '../../../../../util/container'
 import {isMobile} from '../../../../../constants/platform'
 
 type OwnProps = {|
@@ -17,7 +17,7 @@ type OwnProps = {|
   toggleMessageMenu: () => void,
 |}
 
-const mapStateToProps = (state: TypedState, {message, previous, isEditing}: OwnProps) => {
+const mapStateToProps = (state, {message, previous, isEditing}: OwnProps) => {
   const isYou = state.config.username === message.author
   const isFollowing = state.config.following.has(message.author)
   const isBroken = state.users.infoMap.getIn([message.author, 'broken'], false)

--- a/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-timestamp/container.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {WrapperTimestamp} from '../'
 import * as Constants from '../../../../../constants/chat2'
 import * as Types from '../../../../../constants/types/chat2'
-import {setDisplayName, compose, connect, type TypedState} from '../../../../../util/container'
+import {setDisplayName, compose, connect} from '../../../../../util/container'
 import {formatTimeForMessages} from '../../../../../util/timestamp'
 
 export type OwnProps = {|
@@ -28,7 +28,7 @@ const shouldDecorateMessage = (message: Types.Message, you: string) => {
   return Constants.decoratedMessageTypes.includes(message.type)
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const messageIDWithOrangeLine = state.chat2.orangeLineMap.get(ownProps.message.conversationIDKey)
   return {
     _you: state.config.username || '',

--- a/shared/chat/conversation/normal/container.js
+++ b/shared/chat/conversation/normal/container.js
@@ -6,10 +6,10 @@ import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as TrackerGen from '../../../actions/tracker-gen'
 import * as RouteTree from '../../../actions/route-tree'
 import Normal from '.'
-import {compose, connect, withStateHandlers, type TypedState} from '../../../util/container'
+import {compose, connect, withStateHandlers} from '../../../util/container'
 import {chatTab} from '../../../constants/tabs'
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey}) => {
   const showLoader = WaitingConstants.anyWaiting(state, Constants.waitingKeyThreadLoad(conversationIDKey))
   const meta = Constants.getMeta(state, conversationIDKey)
   const infoPanelOpen = Constants.isInfoPanelOpen(state)
@@ -19,7 +19,7 @@ const mapStateToProps = (state: TypedState, {conversationIDKey}) => {
   return {conversationIDKey, infoPanelOpen, isSearching, showLoader, threadLoadedOffline: meta.offline}
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   _onAttach: (conversationIDKey: Types.ConversationIDKey, paths: Array<string>) =>
     dispatch(
       RouteTree.navigateAppend([{props: {conversationIDKey, paths}, selected: 'attachmentGetTitles'}])

--- a/shared/chat/conversation/rekey/container.js
+++ b/shared/chat/conversation/rekey/container.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as Constants from '../../../constants/chat2'
 import ParticipantRekey from './participant-rekey'
 import YouRekey from './you-rekey'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {navigateAppend, navigateUp} from '../../../actions/route-tree'
 import {createShowUserProfile} from '../../../actions/profile-gen'
 import {createOpenPopup} from '../../../actions/unlock-folders-gen'
@@ -17,12 +17,12 @@ type Props = {
   youRekey: boolean,
 }
 
-const mapStateToProps = (state: TypedState, {conversationIDKey}) => ({
+const mapStateToProps = (state, {conversationIDKey}) => ({
   _you: state.config.username || '',
   rekeyers: Constants.getMeta(state, conversationIDKey).rekeyers,
 })
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onBack: () => dispatch(navigateUp()),
   onEnterPaperkey: () => dispatch(navigateAppend(['enterPaperkey'])),
   onRekey: () => dispatch(createOpenPopup()),

--- a/shared/chat/create-channel/container.js
+++ b/shared/chat/create-channel/container.js
@@ -7,12 +7,11 @@ import {
   lifecycle,
   withStateHandlers,
   connect,
-  type TypedState,
 } from '../../util/container'
 import {navigateTo} from '../../actions/route-tree'
 import {upperFirst} from 'lodash-es'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   return {
     errorText: upperFirst(state.teams.channelCreationError),
     teamname: routeProps.get('teamname'),

--- a/shared/chat/delete-history-warning/container.js
+++ b/shared/chat/delete-history-warning/container.js
@@ -3,12 +3,12 @@ import * as Types from '../../constants/types/chat2'
 import * as Chat2Gen from '../../actions/chat2-gen'
 import DeleteHistoryWarning from '.'
 import {type RouteProps} from '../../route-tree/render-route'
-import {compose, connect, type TypedState} from '../../util/container'
+import {compose, connect} from '../../util/container'
 import {isMobile} from '../../constants/platform'
 
 type OwnProps = RouteProps<{conversationIDKey: Types.ConversationIDKey}, {}>
 
-const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => ({})
+const mapStateToProps = (state, {routeProps}: OwnProps) => ({})
 
 const mapDispatchToProps = (dispatch, {navigateUp, routeProps}: OwnProps) => ({
   onBack: isMobile ? null : () => dispatch(navigateUp()),

--- a/shared/chat/inbox/container/index.js
+++ b/shared/chat/inbox/container/index.js
@@ -5,13 +5,12 @@ import * as Types from '../../../constants/types/chat2'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as Inbox from '..'
 import {connect, compose, setDisplayName} from '../../../util/container'
-import type {TypedState} from '../../../util/container'
 import type {Props as _Props, RowItemSmall, RowItemBig} from '../index.types'
 import normalRowData from './normal'
 import filteredRowData from './filtered'
 import ff from '../../../util/feature-flags'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _metaMap: state.chat2.metaMap,
   _selectedConversationIDKey: Constants.getSelectedConversation(state),
   _smallTeamsExpanded: state.chat2.smallTeamsExpanded,

--- a/shared/chat/inbox/new-conversation/container.js
+++ b/shared/chat/inbox/new-conversation/container.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as Constants from '../../../constants/chat2'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import NewConversation from '.'
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
   users: Array<string>,
 }
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const _you = state.config.username
   const conversationIDKey = Constants.getSelectedConversation(state)
   const meta = Constants.getMeta(state, Constants.pendingConversationIDKey)

--- a/shared/chat/inbox/row/big-team-channel/container.js
+++ b/shared/chat/inbox/row/big-team-channel/container.js
@@ -2,9 +2,9 @@
 import * as Constants from '../../../../constants/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import {BigTeamChannel} from '.'
-import {connect, type TypedState, isMobile} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 
-const mapStateToProps = (state: TypedState, ownProps) => {
+const mapStateToProps = (state, ownProps) => {
   const _conversationIDKey = ownProps.conversationIDKey
 
   return {

--- a/shared/chat/inbox/row/big-team-header/container.js
+++ b/shared/chat/inbox/row/big-team-header/container.js
@@ -1,11 +1,11 @@
 // @flow
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 import {isTeamWithChosenChannels} from '../../../../constants/teams'
 import {navigateTo} from '../../../../actions/route-tree'
 import {teamsTab} from '../../../../constants/tabs'
 import {BigTeamHeader} from '.'
 
-const mapStateToProps = (state: TypedState, {teamname}) => ({
+const mapStateToProps = (state, {teamname}) => ({
   badgeSubscribe: !isTeamWithChosenChannels(state, teamname),
   teamname,
 })

--- a/shared/chat/inbox/row/build-team/container.js
+++ b/shared/chat/inbox/row/build-team/container.js
@@ -2,10 +2,9 @@
 import * as Route from '../../../../actions/route-tree'
 import {teamsTab} from '../../../../constants/tabs'
 import {compose, connect, setDisplayName} from '../../../../util/container'
-import type {TypedState} from '../../../../util/container'
 import BuildTeam from '.'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   metaMap: state.chat2.metaMap,
 })
 

--- a/shared/chat/inbox/row/chat-filter-row/container.js
+++ b/shared/chat/inbox/row/chat-filter-row/container.js
@@ -3,7 +3,6 @@ import * as Constants from '../../../../constants/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import {isDarwin} from '../../../../constants/platform'
 import {connect, compose, setDisplayName, withProps} from '../../../../util/container'
-import type {TypedState} from '../../../../util/container'
 import ChatFilterRow from '.'
 
 type OwnProps = {
@@ -14,7 +13,7 @@ type OwnProps = {
   onSelectDown: () => void,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const filter = state.chat2.inboxFilter
   return {
     filter,

--- a/shared/chat/inbox/row/chat-inbox-header/container.js
+++ b/shared/chat/inbox/row/chat-inbox-header/container.js
@@ -1,7 +1,6 @@
 // @flow
 import * as Constants from '../../../../constants/chat2'
 import {connect, compose, setDisplayName} from '../../../../util/container'
-import type {TypedState} from '../../../../util/container'
 import ChatInboxHeader from '.'
 
 type OwnProps = {
@@ -10,7 +9,7 @@ type OwnProps = {
   focusFilter: () => void,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
+const mapStateToProps = (state, ownProps: OwnProps) => ({
   showNewChat:
     !state.chat2.inboxFilter &&
     state.chat2.inboxHasLoaded &&

--- a/shared/chat/inbox/row/filter-small-team/container.js
+++ b/shared/chat/inbox/row/filter-small-team/container.js
@@ -3,11 +3,11 @@ import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import {FilterSmallTeam} from '.'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 
 type OwnProps = {conversationIDKey: Types.ConversationIDKey}
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const conversationIDKey = ownProps.conversationIDKey
 
   return {

--- a/shared/chat/inbox/row/small-team/container.js
+++ b/shared/chat/inbox/row/small-team/container.js
@@ -3,11 +3,11 @@ import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import {SmallTeam} from '.'
-import {connect, type TypedState, isMobile} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 
 type OwnProps = {conversationIDKey: Types.ConversationIDKey}
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const _conversationIDKey = ownProps.conversationIDKey
   const _meta = Constants.getMeta(state, _conversationIDKey)
   const youAreReset = _meta.membershipType === 'youAreReset'

--- a/shared/chat/manage-channels/container.js
+++ b/shared/chat/manage-channels/container.js
@@ -9,7 +9,6 @@ import {
   connect,
   compose,
   lifecycle,
-  type TypedState,
   withHandlers,
   withStateHandlers,
   withPropsOnChange,
@@ -18,7 +17,7 @@ import {navigateTo, navigateAppend} from '../../actions/route-tree'
 import {anyWaiting} from '../../constants/waiting'
 import {getChannelsWaitingKey, getCanPerform, getTeamChannelInfos, hasCanPerform} from '../../constants/teams'
 
-const mapStateToProps = (state: TypedState, {routeProps, routeState}) => {
+const mapStateToProps = (state, {routeProps, routeState}) => {
   const teamname = routeProps.get('teamname')
   const waitingKey = getChannelsWaitingKey(teamname)
   const waitingForGet = anyWaiting(state, waitingKey)

--- a/shared/chat/manage-channels/edit-channel-container.js
+++ b/shared/chat/manage-channels/edit-channel-container.js
@@ -5,8 +5,8 @@ import * as Constants from '../../constants/teams'
 import * as TeamsGen from '../../actions/teams-gen'
 import {type ConversationIDKey} from '../../constants/types/chat2'
 import EditChannel, {type Props} from './edit-channel'
-import {connect, compose, lifecycle, type TypedState} from '../../util/container'
-const mapStateToProps = (state: TypedState, {navigateUp, routePath, routeProps}) => {
+import {connect, compose, lifecycle} from '../../util/container'
+const mapStateToProps = (state, {navigateUp, routePath, routeProps}) => {
   const conversationIDKey = routeProps.get('conversationIDKey')
   if (!conversationIDKey) {
     throw new Error('conversationIDKey unexpectedly empty')

--- a/shared/chat/new-team-dialog-container.js
+++ b/shared/chat/new-team-dialog-container.js
@@ -3,9 +3,9 @@ import * as TeamsGen from '../actions/teams-gen'
 import * as Chat2Gen from '../actions/chat2-gen'
 import NewTeamDialog from '../teams/new-team'
 import {upperFirst} from 'lodash-es'
-import {connect, lifecycle, type TypedState, compose, withStateHandlers} from '../util/container'
+import {connect, lifecycle, compose, withStateHandlers} from '../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   baseTeam: '',
   errorText: upperFirst(state.teams.teamCreationError),
   isSubteam: false,

--- a/shared/common-adapters/avatar.js
+++ b/shared/common-adapters/avatar.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import Render from './avatar.render'
 import {throttle} from 'lodash-es'
 import {iconTypeToImgSet, urlsToImgSet, type IconType, type Props as IconProps} from './icon'
-import {setDisplayName, connect, type TypedState, compose} from '../util/container'
+import {setDisplayName, connect, compose} from '../util/container'
 import {
   platformStyles,
   desktopStyles,
@@ -164,7 +164,7 @@ class SharedAskForUserData {
 }
 const _sharedAskForUserData = new SharedAskForUserData()
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const name = ownProps.username || ownProps.teamname
   _sharedAskForUserData._checkLoggedIn(state.config.username)
   return {

--- a/shared/common-adapters/channel-container.js
+++ b/shared/common-adapters/channel-container.js
@@ -2,7 +2,7 @@
 import * as Types from '../constants/types/chat2'
 import * as Chat2Gen from '../actions/chat2-gen'
 import {Channel} from './channel'
-import {connect, compose, setDisplayName, type TypedState} from '../util/container'
+import {connect, compose, setDisplayName} from '../util/container'
 import type {StylesCrossPlatform} from '../styles'
 
 type OwnProps = {|
@@ -12,7 +12,7 @@ type OwnProps = {|
   allowFontScaling?: ?boolean,
 |}
 
-const mapStateToProps = (state: TypedState) => ({})
+const mapStateToProps = state => ({})
 
 const mapDispatchToProps = dispatch => ({
   _onClick: (name, convID) =>

--- a/shared/common-adapters/usernames/container.js
+++ b/shared/common-adapters/usernames/container.js
@@ -1,6 +1,5 @@
 // @flow
 import {compose, connect, setDisplayName} from '../../util/container'
-import {type TypedState} from '../../constants/reducer'
 import * as I from 'immutable'
 import * as ProfileGen from '../../actions/profile-gen'
 import * as TrackerGen from '../../actions/tracker-gen'
@@ -60,7 +59,7 @@ export const connectedPropsToProps = (
 
 // Connected username component
 // instead of username objects supply array of username strings & this will fill in the rest
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const _following = state.config.following
   const _broken = state.tracker.userTrackers
   const _you = state.config.username

--- a/shared/common-adapters/waiting-button.js
+++ b/shared/common-adapters/waiting-button.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import Button, {type Props as ButtonProps} from './button'
-import {connect, type TypedState, setDisplayName} from '../util/container'
+import {connect, setDisplayName} from '../util/container'
 import * as WaitingConstants from '../constants/waiting'
 
 export type OwnProps = ButtonProps & {
@@ -53,7 +53,7 @@ class WaitingButton extends React.Component<Props, {localWaiting: boolean}> {
   }
 }
 
-const mapStateToProps = (state: TypedState, ownProps) => {
+const mapStateToProps = (state, ownProps) => {
   const waitingKey = ownProps.waitingKey || ''
   return {
     storeWaiting: WaitingConstants.anyWaiting(state, waitingKey),

--- a/shared/desktop/remote/sync-avatar-props.desktop.js
+++ b/shared/desktop/remote/sync-avatar-props.desktop.js
@@ -5,7 +5,7 @@ import * as ConfigGen from '../../actions/config-gen'
 import * as I from 'immutable'
 import * as React from 'react'
 import * as SafeElectron from '../../util/safe-electron.desktop'
-import {compose, connect, withStateHandlers, type TypedState} from '../../util/container'
+import {compose, connect, withStateHandlers} from '../../util/container'
 import memoize from 'memoize-one'
 
 type Props = {
@@ -93,7 +93,7 @@ function SyncAvatarProps(ComposedComponent: any) {
     }
   }
 
-  const mapStateToProps = (state: TypedState, ownProps) => ({
+  const mapStateToProps = (state, ownProps) => ({
     avatars: getRemoteAvatars(state.config.avatars, ownProps.usernames),
     followers: getRemoteFollowers(state.config.followers, ownProps.usernames),
     following: getRemoteFollowing(state.config.following, ownProps.usernames),

--- a/shared/devices/device-page/container.js
+++ b/shared/devices/device-page/container.js
@@ -3,10 +3,10 @@ import * as Types from '../../constants/types/devices'
 import * as Constants from '../../constants/devices'
 import * as DevicesGen from '../../actions/devices-gen'
 import DevicePage from '.'
-import {compose, connect, type TypedState, setDisplayName} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import {navigateUp} from '../../actions/route-tree'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   device: Constants.getDevice(state, state.devices.selectedDeviceID),
 })
 

--- a/shared/devices/device-revoke/container.js
+++ b/shared/devices/device-revoke/container.js
@@ -4,10 +4,10 @@ import * as Types from '../../constants/types/devices'
 import * as Constants from '../../constants/devices'
 import * as DevicesGen from '../../actions/devices-gen'
 import DeviceRevoke from '.'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import {navigateUp} from '../../actions/route-tree'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _endangeredTLFs: Constants.getEndangeredTLFs(state, state.devices.selectedDeviceID),
   device: Constants.getDevice(state, state.devices.selectedDeviceID),
   waiting: WaitingConstants.anyWaiting(state, Constants.waitingKey),

--- a/shared/devices/paper-key/container.js
+++ b/shared/devices/paper-key/container.js
@@ -5,12 +5,12 @@ import * as Constants from '../../constants/devices'
 import PaperKey from '.'
 import {navigateUp} from '../../actions/route-tree'
 
-const mapStateToProps = (state: Container.TypedState) => ({
+const mapStateToProps = state => ({
   paperkey: state.devices.newPaperkey.stringValue(),
   waiting: WaitingConstants.anyWaiting(state, Constants.waitingKey),
 })
 
-const mapDispatchToProps = (dispatch: Container.Dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onBack: () => dispatch(navigateUp()),
 })
 

--- a/shared/devices/row/container.js
+++ b/shared/devices/row/container.js
@@ -2,12 +2,12 @@
 import * as Constants from '../../constants/devices'
 import * as DevicesGen from '../../actions/devices-gen'
 import * as Types from '../../constants/types/devices'
-import {connect, compose, type TypedState, setDisplayName} from '../../util/container'
+import {connect, compose, setDisplayName} from '../../util/container'
 import DeviceRow from '.'
 
 type OwnProps = {deviceID: Types.DeviceID, firstItem: boolean}
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const device = Constants.getDevice(state, ownProps.deviceID)
   return {
     isCurrentDevice: device.currentDevice,
@@ -17,7 +17,7 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   _showExistingDevicePage: (deviceID: Types.DeviceID) =>
     dispatch(DevicesGen.createShowDevicePage({deviceID})),
 })

--- a/shared/fs/banner/container.js
+++ b/shared/fs/banner/container.js
@@ -1,9 +1,9 @@
 // @flow
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import Banner from '.'
 
-const mapStateToProps = (state: TypedState, {path}) => {
+const mapStateToProps = (state, {path}) => {
   const _pathItem = state.fs.pathItems.get(path, Constants.unknownPathItem)
   return {
     path,

--- a/shared/fs/banner/fileui-banner/container.js
+++ b/shared/fs/banner/fileui-banner/container.js
@@ -3,14 +3,14 @@ import Banner from './index'
 import * as FsGen from '../../../actions/fs-gen'
 import * as Types from '../../../constants/types/fs'
 import * as Constants from '../../../constants/fs'
-import {connect, compose, lifecycle, setDisplayName, type TypedState} from '../../../util/container'
+import {connect, compose, lifecycle, setDisplayName} from '../../../util/container'
 import {isMobile} from '../../../constants/platform'
 
 type OwnProps = {
   path?: Types.Path,
 }
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const kbfsEnabled = Constants.kbfsEnabled(state)
   const kbfsOutdated = Constants.kbfsOutdated(state)
   return {

--- a/shared/fs/banner/reset-banner/container.js
+++ b/shared/fs/banner/reset-banner/container.js
@@ -3,7 +3,7 @@ import * as Constants from '../../../constants/fs'
 import * as Types from '../../../constants/types/fs'
 import * as FsGen from '../../../actions/fs-gen'
 import * as RPCTypes from '../../../constants/types/rpc-gen'
-import {compose, connect, setDisplayName, type TypedState} from '../../../util/container'
+import {compose, connect, setDisplayName} from '../../../util/container'
 import {isMobile} from '../../../constants/platform'
 import {fsTab} from '../../../constants/tabs'
 import {navigateTo} from '../../../actions/route-tree'
@@ -12,7 +12,7 @@ import {createGetProfile} from '../../../actions/tracker-gen'
 import {folderNameWithoutUsers} from '../../../util/kbfs'
 import Banner from '.'
 
-const mapStateToProps = (state: TypedState, {path}) => ({
+const mapStateToProps = (state, {path}) => ({
   _tlf: Constants.getTlfFromPath(state.fs.tlfs, path),
   _username: state.config.username,
 })

--- a/shared/fs/common/download-tracking-hoc.js
+++ b/shared/fs/common/download-tracking-hoc.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as FsGen from '../../actions/fs-gen'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 
 type OwnProps = {
   trackingPath: Types.Path,
@@ -12,7 +12,7 @@ type OwnProps = {
   cancelOnUnmount?: boolean,
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _downloads: state.fs.downloads,
 })
 

--- a/shared/fs/common/open-in-system-file-manager-container.desktop.js
+++ b/shared/fs/common/open-in-system-file-manager-container.desktop.js
@@ -1,11 +1,11 @@
 // @flow
 import * as FsGen from '../../actions/fs-gen'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import {type OpenInSystemFileManagerProps as OwnProps} from './open-in-system-file-manager-container'
 import OpenInSystemFileManager from './open-in-system-file-manager.desktop'
 
-const mapStateToProps = (state: TypedState, {path}: OwnProps) => ({
+const mapStateToProps = (state, {path}: OwnProps) => ({
   kbfsEnabled: Constants.kbfsEnabled(state),
 })
 

--- a/shared/fs/common/path-item-action-container.js
+++ b/shared/fs/common/path-item-action-container.js
@@ -22,7 +22,7 @@ type OwnProps = {
   actionIconWhite?: boolean,
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _pathItems: state.fs.pathItems,
   _tlfs: state.fs.tlfs,
   _username: state.config.username,

--- a/shared/fs/common/security-prefs-container.desktop.js
+++ b/shared/fs/common/security-prefs-container.desktop.js
@@ -1,11 +1,11 @@
 // @flow
-import {connect, compose, lifecycle, type TypedState} from '../../util/container'
+import {connect, compose, lifecycle} from '../../util/container'
 import * as FsGen from '../../actions/fs-gen'
 import InstallSecurityPrefs from './security-prefs.desktop'
 import {navigateUp} from '../../actions/route-tree'
 import {isLinux} from '../../constants/platform'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const kbfsEnabled = isLinux || (state.fs.fuseStatus && state.fs.fuseStatus.kextStarted)
   return {
     appFocusedCount: state.config.appFocusedCount,
@@ -13,7 +13,7 @@ const mapStateToProps = (state: TypedState) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   back: () => dispatch(navigateUp()),
   openSecurityPrefs: () => dispatch(FsGen.createOpenSecurityPreferences()),
   _getFuseStatus: () => dispatch(FsGen.createFuseStatus()),

--- a/shared/fs/common/security-prefs-prompting-hoc.js
+++ b/shared/fs/common/security-prefs-prompting-hoc.js
@@ -1,5 +1,5 @@
 // @flow
-import {branch, compose, connect, renderNothing, type TypedState} from '../../util/container'
+import {branch, compose, connect, renderNothing} from '../../util/container'
 import {isLinux, isMobile} from '../../constants/platform'
 import * as FsGen from '../../actions/fs-gen'
 import {navigateAppend} from '../../actions/route-tree'
@@ -12,7 +12,7 @@ import {navigateAppend} from '../../actions/route-tree'
 // spamming the user.  We have a link in the Settings page so if the user wants
 // they can still find the instructions.
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const {securityPrefsPropmted, kextPermissionError} = state.fs.flags
   const kbfsEnabled = isLinux || (state.fs.fuseStatus && state.fs.fuseStatus.kextStarted)
   return {

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -1,6 +1,6 @@
 // @flow
 import * as I from 'immutable'
-import {compose, connect, setDisplayName, type TypedState} from '../util/container'
+import {compose, connect, setDisplayName} from '../util/container'
 import Files from '.'
 import * as Types from '../constants/types/fs'
 import * as Constants from '../constants/fs'
@@ -14,7 +14,7 @@ import {
 import SecurityPrefsPromptingHoc from './common/security-prefs-prompting-hoc'
 import FilesLoadingHoc from './files-loading-hoc'
 
-const mapStateToProps = (state: TypedState, {path}) => ({
+const mapStateToProps = (state, {path}) => ({
   _edits: state.fs.edits,
   _pathItems: state.fs.pathItems,
   _sortSetting: state.fs.pathUserSettings.get(path, Constants.makePathUserSetting()).get('sort'),

--- a/shared/fs/filepreview/bare-preview.native.js
+++ b/shared/fs/filepreview/bare-preview.native.js
@@ -6,12 +6,12 @@ import * as Constants from '../../constants/fs'
 import * as Styles from '../../styles'
 import {Box, ClickableBox, Text, ProgressIndicator} from '../../common-adapters'
 import {navigateUp} from '../../actions/route-tree'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import {type BarePreviewProps} from './bare-preview'
 import View from './view-container'
 import PathItemAction from '../common/path-item-action-container'
 
-const mapStateToProps = (state: TypedState, {routeProps}: BarePreviewProps) => {
+const mapStateToProps = (state, {routeProps}: BarePreviewProps) => {
   const path = Types.stringToPath(routeProps.get('path', Constants.defaultPath))
   return {
     path,

--- a/shared/fs/filepreview/default-view-container.js
+++ b/shared/fs/filepreview/default-view-container.js
@@ -1,11 +1,11 @@
 // @flow
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import * as FsGen from '../../actions/fs-gen'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import DefaultView from './default-view'
 
-const mapStateToProps = (state: TypedState, {path}) => {
+const mapStateToProps = (state, {path}) => {
   const pathItem = state.fs.pathItems.get(path, Constants.unknownPathItem)
   const _username = state.config.username || undefined
   return {

--- a/shared/fs/filepreview/header-container.js
+++ b/shared/fs/filepreview/header-container.js
@@ -1,12 +1,12 @@
 // @flow
-import {compose, connect, lifecycle, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, lifecycle, setDisplayName} from '../../util/container'
 import * as FsGen from '../../actions/fs-gen'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import {navigateUp} from '../../actions/route-tree'
 import Header from './header'
 
-const mapStateToProps = (state: TypedState, {path}) => {
+const mapStateToProps = (state, {path}) => {
   const pathItem = state.fs.pathItems.get(path, Constants.unknownPathItem)
   return {
     path,

--- a/shared/fs/filepreview/view-container.js
+++ b/shared/fs/filepreview/view-container.js
@@ -1,6 +1,6 @@
 // @flow
 import * as I from 'immutable'
-import {compose, connect, lifecycle, type TypedState, setDisplayName} from '../../util/container'
+import {compose, connect, lifecycle, setDisplayName} from '../../util/container'
 import * as Constants from '../../constants/fs'
 import * as FsGen from '../../actions/fs-gen'
 import * as React from 'react'
@@ -18,7 +18,7 @@ type Props = {
   onLoadingStateChange: (isLoading: boolean) => void,
 }
 
-const mapStateToProps = (state: TypedState, {path}: Props) => {
+const mapStateToProps = (state, {path}: Props) => {
   return {
     _serverInfo: state.fs.localHTTPServerInfo,
     _pathItem: state.fs.pathItems.get(path, Constants.makeFile()),

--- a/shared/fs/files-loading-hoc.js
+++ b/shared/fs/files-loading-hoc.js
@@ -1,12 +1,12 @@
 // @flow
 import * as I from 'immutable'
 import * as React from 'react'
-import {compose, connect, type TypedState} from '../util/container'
+import {compose, connect} from '../util/container'
 import * as FsGen from '../actions/fs-gen'
 import * as Types from '../constants/types/fs'
 import * as Constants from '../constants/fs'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   syncingPaths: state.fs.uploads.syncingPaths,
 })
 

--- a/shared/fs/footer/download-container.js
+++ b/shared/fs/footer/download-container.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import Download, {type DownloadProps} from './download'
 import * as FsGen from '../../actions/fs-gen'
 import {formatDurationFromNowTo} from '../../util/timestamp'
@@ -10,7 +10,7 @@ type OwnProps = {
   downloadKey: string,
 }
 
-const mapStateToProps = (state: TypedState, {downloadKey}: OwnProps) => ({
+const mapStateToProps = (state, {downloadKey}: OwnProps) => ({
   _download: state.fs.downloads.get(downloadKey, Constants.makeDownload()),
 })
 

--- a/shared/fs/footer/downloads-container.js
+++ b/shared/fs/footer/downloads-container.js
@@ -1,11 +1,11 @@
 // @flow
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import * as FsGen from '../../actions/fs-gen'
 import Downloads, {type DownloadsProps} from './downloads'
 import {isMobile} from '../../constants/platform'
 import {downloadFolder} from '../../util/file'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _downloads: state.fs.downloads,
 })
 

--- a/shared/fs/footer/upload-container.js
+++ b/shared/fs/footer/upload-container.js
@@ -1,12 +1,12 @@
 // @flow
 import * as FsGen from '../../actions/fs-gen'
 import * as Types from '../../constants/types/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import Upload from './upload'
 import UploadCountdownHOC, {type UploadCountdownHOCProps} from './upload-countdown-hoc'
 import {unknownPathItem} from '../../constants/fs'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _edits: state.fs.edits,
   _pathItems: state.fs.pathItems,
   _uploads: state.fs.uploads,

--- a/shared/fs/header/add-new-container.js
+++ b/shared/fs/header/add-new-container.js
@@ -2,11 +2,11 @@
 import * as Constants from '../../constants/fs'
 import * as Types from '../../constants/types/fs'
 import * as FsGen from '../../actions/fs-gen'
-import {compose, setDisplayName, connect, type TypedState} from '../../util/container'
+import {compose, setDisplayName, connect} from '../../util/container'
 import AddNew from './add-new'
 import {isDarwin, isMobile, isIOS} from '../../constants/platform'
 
-const mapStateToProps = (state: TypedState, {path}) => ({
+const mapStateToProps = (state, {path}) => ({
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
 })
 

--- a/shared/fs/header/breadcrumb-container.desktop.js
+++ b/shared/fs/header/breadcrumb-container.desktop.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import {fsTab} from '../../constants/tabs'
 import {navigateTo} from '../../actions/route-tree'
 import Breadcrumb from './breadcrumb.desktop'
@@ -10,7 +10,7 @@ type OwnProps = {
   path: Types.Path,
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _username: state.config.username,
 })
 

--- a/shared/fs/row/editing-container.js
+++ b/shared/fs/row/editing-container.js
@@ -3,7 +3,7 @@ import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as FsGen from '../../actions/fs-gen'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import Editing from './editing'
 
 type OwnProps = {
@@ -11,7 +11,7 @@ type OwnProps = {
   routePath: I.List<string>,
 }
 
-const mapStateToProps = (state: TypedState, {editID}: OwnProps) => {
+const mapStateToProps = (state, {editID}: OwnProps) => {
   const _edit = state.fs.edits.get(editID, Constants.makeNewFolder()) // TODO make missing get better
   const _username = state.config.username
   return {

--- a/shared/fs/row/still-container.js
+++ b/shared/fs/row/still-container.js
@@ -2,7 +2,7 @@
 import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import OpenHOC from '../common/open-hoc'
 import Still from './still'
 
@@ -10,7 +10,7 @@ type OwnProps = $Diff<Types.StillRowItem, {rowType: 'still'}> & {
   routePath: I.List<string>,
 }
 
-const mapStateToProps = (state: TypedState, {path}: OwnProps) => ({
+const mapStateToProps = (state, {path}: OwnProps) => ({
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
   _username: state.config.username,
   _downloads: state.fs.downloads,

--- a/shared/fs/row/tlf-container.js
+++ b/shared/fs/row/tlf-container.js
@@ -2,7 +2,7 @@
 import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import OpenHOC from '../common/open-hoc'
 import Tlf from './tlf'
 
@@ -10,7 +10,7 @@ type OwnProps = $Diff<Types.TlfRowItem, {rowType: 'tlf'}> & {
   routePath: I.List<string>,
 }
 
-const mapStateToProps = (state: TypedState, {tlfType, name}: OwnProps) => ({
+const mapStateToProps = (state, {tlfType, name}: OwnProps) => ({
   _tlf: Constants.getTlfFromTlfs(state.fs.tlfs, tlfType, name),
   _username: state.config.username,
 })

--- a/shared/fs/row/tlf-type-container.js
+++ b/shared/fs/row/tlf-type-container.js
@@ -2,7 +2,7 @@
 import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import OpenHOC from '../common/open-hoc'
 import TlfType from './tlf-type'
 
@@ -10,7 +10,7 @@ type OwnProps = $Diff<Types.TlfTypeRowItem, {rowType: 'tlf-type'}> & {
   routePath: I.List<string>,
 }
 
-const mapStateToProps = (state: TypedState, {name}: OwnProps) => ({
+const mapStateToProps = (state, {name}: OwnProps) => ({
   _tlfList: Constants.getTlfListFromType(state.fs.tlfs, name),
 })
 

--- a/shared/fs/row/uploading-container.js
+++ b/shared/fs/row/uploading-container.js
@@ -1,14 +1,14 @@
 // @flow
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import Uploading from './uploading'
 
 type OwnProps = {
   path: Types.Path,
 }
 
-const mapStateToProps = (state: TypedState, {path}: OwnProps) => {
+const mapStateToProps = (state, {path}: OwnProps) => {
   const _pathItem = state.fs.pathItems.get(path, Constants.unknownPathItem)
   const _uploads = state.fs.uploads
   const _username = state.config.username

--- a/shared/fs/sortbar/container.js
+++ b/shared/fs/sortbar/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {compose, connect, setDisplayName, type TypedState} from '../../util/container'
+import {compose, connect, setDisplayName} from '../../util/container'
 import SortBar from './sortbar'
 import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
@@ -10,7 +10,7 @@ type OwnProps = {
   path: Types.Path,
 }
 
-const mapStateToProps = (state: TypedState, {path}: OwnProps) => ({
+const mapStateToProps = (state, {path}: OwnProps) => ({
   sortSetting: state.fs.pathUserSettings.get(path, Constants.makePathUserSetting()).get('sort'),
   _loadingPaths: state.fs.loadingPaths,
 })

--- a/shared/git/container.js
+++ b/shared/git/container.js
@@ -5,7 +5,7 @@ import * as GitGen from '../actions/git-gen'
 import * as Types from '../constants/types/git'
 import * as Constants from '../constants/git'
 import {anyWaiting} from '../constants/waiting'
-import {compose, lifecycle, connect, type TypedState} from '../util/container'
+import {compose, lifecycle, connect} from '../util/container'
 import {createSelector} from 'reselect'
 import {sortBy, partition} from 'lodash-es'
 
@@ -26,7 +26,7 @@ const getRepos = createSelector([Constants.getIdToGit], (git: ?I.Map<string, Typ
   }
 })
 
-const mapStateToProps = (state: TypedState, {routeState}) => {
+const mapStateToProps = (state, {routeState}) => {
   return {
     ...getRepos(state),
     expandedSet: routeState.get('expandedSet'),

--- a/shared/git/delete-repo/container.js
+++ b/shared/git/delete-repo/container.js
@@ -2,9 +2,9 @@
 import * as GitGen from '../../actions/git-gen'
 import * as Constants from '../../constants/git'
 import DeleteRepo from '.'
-import {compose, renderNothing, branch, connect, type TypedState} from '../../util/container'
+import {compose, renderNothing, branch, connect} from '../../util/container'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const gitMap = Constants.getIdToGit(state)
   const git = gitMap ? gitMap.get(routeProps.get('id')) : null
 

--- a/shared/git/new-repo/container.js
+++ b/shared/git/new-repo/container.js
@@ -3,12 +3,12 @@ import * as GitGen from '../../actions/git-gen'
 import * as Constants from '../../constants/git'
 import * as TeamsGen from '../../actions/teams-gen'
 import NewRepo from '.'
-import {compose, lifecycle, connect, type TypedState} from '../../util/container'
+import {compose, lifecycle, connect} from '../../util/container'
 import {navigateTo} from '../../actions/route-tree'
 import {teamsTab} from '../../constants/tabs'
 import {getSortedTeamnames} from '../../constants/teams'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => ({
+const mapStateToProps = (state, {routeProps}) => ({
   teams: getSortedTeamnames(state),
   error: Constants.getError(state),
   isTeam: routeProps.get('isTeam'),

--- a/shared/git/row/container.js
+++ b/shared/git/row/container.js
@@ -4,7 +4,7 @@ import * as Constants from '../../constants/git'
 import * as ConfigGen from '../../actions/config-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as GitGen from '../../actions/git-gen'
-import {connect, type TypedState, compose, withHandlers, isMobile, setDisplayName} from '../../util/container'
+import {connect, compose, withHandlers, isMobile, setDisplayName} from '../../util/container'
 import * as TrackerGen from '../../actions/tracker-gen'
 import {gitTab, settingsTab} from '../../constants/tabs'
 import {gitTab as settingsGitTab} from '../../constants/settings'
@@ -17,7 +17,7 @@ type OwnProps = {
   onToggleExpand: string => void,
 }
 
-const mapStateToProps = (state: TypedState, {id, expanded}: OwnProps) => {
+const mapStateToProps = (state, {id, expanded}: OwnProps) => {
   const git = state.git.getIn(['idToInfo', id], Constants.makeGitInfo())
   return {
     git,

--- a/shared/git/select-channel/container.js
+++ b/shared/git/select-channel/container.js
@@ -10,7 +10,6 @@ import {
   lifecycle,
   withHandlers,
   withStateHandlers,
-  type TypedState,
 } from '../../util/container'
 import SelectChannel from '.'
 
@@ -20,7 +19,7 @@ export type SelectChannelProps = {
   selected: string,
 }
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const teamname = routeProps.get('teamname')
   const selected = routeProps.get('selected')
   const _channelInfos = getTeamChannelInfos(state, teamname)

--- a/shared/login/join-or-login/container.js
+++ b/shared/login/join-or-login/container.js
@@ -2,13 +2,13 @@
 import * as ProvisionGen from '../../actions/provision-gen'
 import * as SignupGen from '../../actions/signup-gen'
 import Intro from '.'
-import {connect, type TypedState, isMobile} from '../../util/container'
+import {connect, isMobile} from '../../util/container'
 
 type OwnProps = {
   navigateAppend: (...Array<any>) => any,
 }
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   let bannerMessage = null
 
   if (state.config.justDeletedSelf) {

--- a/shared/login/loading/container.js
+++ b/shared/login/loading/container.js
@@ -2,9 +2,9 @@
 import * as Constants from '../../constants/config'
 import * as ConfigGen from '../../actions/config-gen'
 import Splash from '.'
-import {connect, type TypedState, isMobile} from '../../util/container'
+import {connect, isMobile} from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _failedReason: state.config.daemonHandshakeFailedReason,
   _retriesLeft: state.config.daemonHandshakeRetriesLeft,
 })

--- a/shared/login/relogin/container.js
+++ b/shared/login/relogin/container.js
@@ -5,13 +5,13 @@ import * as ProvisionGen from '../../actions/provision-gen'
 import * as SignupGen from '../../actions/signup-gen'
 import HiddenString from '../../util/hidden-string'
 import Login from '.'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 
 type OwnProps = {|
   navigateAppend: (...Array<any>) => any,
 |}
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _users: state.config.configuredAccounts,
   error: state.login.error.stringValue(),
   selectedUser: state.config.defaultUsername,

--- a/shared/login/routes.js
+++ b/shared/login/routes.js
@@ -7,10 +7,10 @@ import Loading from './loading/container'
 import Relogin from './relogin/container'
 import provisonRoutes from '../provision/routes'
 import signupRoutes from './signup/routes'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const showLoading = state.config.daemonHandshakeState !== 'done'
   const showRelogin = !showLoading && state.config.configuredAccounts.size > 0
   return {showLoading, showRelogin}

--- a/shared/login/signup/device-name/container.js
+++ b/shared/login/signup/device-name/container.js
@@ -1,9 +1,9 @@
 // @flow
 import * as SignupGen from '../../../actions/signup-gen'
 import DeviceName from '.'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   devicename: state.signup.devicename,
   error: state.signup.devicenameError,
 })

--- a/shared/login/signup/error/container.js
+++ b/shared/login/signup/error/container.js
@@ -1,9 +1,9 @@
 // @flow
 import Error from '.'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import * as SignupGen from '../../../actions/signup-gen'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.signup.signupError.stringValue(),
 })
 

--- a/shared/login/signup/invite-code/container.js
+++ b/shared/login/signup/invite-code/container.js
@@ -1,10 +1,10 @@
 // @flow
 import * as SignupGen from '../../../actions/signup-gen'
 import InviteCode from '.'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {navigateAppend} from '../../../actions/route-tree'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.signup.inviteCodeError,
   inviteCode: state.signup.inviteCode,
 })

--- a/shared/login/signup/passphrase/container.js
+++ b/shared/login/signup/passphrase/container.js
@@ -1,10 +1,10 @@
 // @flow
 import * as SignupGen from '../../../actions/signup-gen'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import HiddenString from '../../../util/hidden-string'
 import Passphrase from '.'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.signup.passphraseError.stringValue(),
   passphrase: state.signup.passphrase.stringValue(),
 })

--- a/shared/login/signup/request-invite/container.js
+++ b/shared/login/signup/request-invite/container.js
@@ -1,9 +1,9 @@
 // @flow
 import * as SignupGen from '../../../actions/signup-gen'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import RequestInvite from '.'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   emailError: state.signup.emailError,
   usernameError: state.signup.nameError,
 })

--- a/shared/login/signup/username-email/container.js
+++ b/shared/login/signup/username-email/container.js
@@ -1,9 +1,9 @@
 // @flow
 import * as SignupGen from '../../../actions/signup-gen'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import UsernameEmail from '.'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   email: state.signup.email,
   emailError: state.signup.emailError,
   username: state.signup.username,

--- a/shared/menubar/remote-proxy.desktop.js
+++ b/shared/menubar/remote-proxy.desktop.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import SyncAvatarProps from '../desktop/remote/sync-avatar-props.desktop'
 import SyncProps from '../desktop/remote/sync-props.desktop'
 import {sendLoad} from '../desktop/remote/sync-browser-window.desktop'
-import {NullComponent, connect, type TypedState, compose, renderNothing, branch} from '../util/container'
+import {NullComponent, connect, compose, renderNothing, branch} from '../util/container'
 import * as SafeElectron from '../util/safe-electron.desktop'
 import {conversationsToSend} from '../chat/inbox/container/remote'
 import {serialize} from './remote-serializer.desktop'
@@ -52,7 +52,7 @@ function RemoteMenubarWindow(ComposedComponent: any) {
   return RemoteWindowComponent
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _badgeInfo: state.notifications.navBadges,
   _edits: state.fs.edits,
   _externalRemoteWindowID: state.config.menubarWindowID,

--- a/shared/offline/container.js
+++ b/shared/offline/container.js
@@ -1,8 +1,8 @@
 // @flow
 import Offline from '.'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   appFocused: state.config.appFocused,
   reachable: state.gregor.reachable,
 })

--- a/shared/people/container.js
+++ b/shared/people/container.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import People from './'
 import * as PeopleGen from '../actions/people-gen'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 import {createSearchSuggestions} from '../actions/search-gen'
 import {navigateAppend} from '../actions/route-tree'
 import {createShowUserProfile} from '../actions/profile-gen'
@@ -20,7 +20,7 @@ class LoadOnMount extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _newItems: state.people.newItems,
   _oldItems: state.people.oldItems,
   followSuggestions: state.people.followSuggestions,

--- a/shared/people/task/container.js
+++ b/shared/people/task/container.js
@@ -6,7 +6,6 @@ import * as Tabs from '../../constants/tabs'
 import * as SettingsTabs from '../../constants/settings'
 import {todoTypes} from '../../constants/people'
 import {connect, branch, compose, renderNothing} from '../../util/container'
-import {type TypedState} from '../../constants/reducer'
 import {createGetMyProfile} from '../../actions/tracker-gen'
 import {navigateAppend, switchTo, navigateTo} from '../../actions/route-tree'
 import {createShowUserProfile} from '../../actions/profile-gen'
@@ -17,7 +16,7 @@ const installLinkURL = 'https://keybase.io/download'
 
 const onSkipTodo = (type: Types.TodoType, dispatch) => () => dispatch(PeopleGen.createSkipTodo({type}))
 
-const mapStateToProps = (state: TypedState) => ({myUsername: state.config.username || ''})
+const mapStateToProps = state => ({myUsername: state.config.username || ''})
 
 // ----- AVATAR TEAM ----- //
 const avatarTeamConnector = connect(
@@ -177,7 +176,7 @@ const gitRepoConnector = connect(
 // ----- TEAMSHOWCASE ----- //
 const teamShowcaseConnector = connect(
   () => ({}),
-  (dispatch) => ({
+  dispatch => ({
     onConfirm: () => {
       // TODO find a team that the current user is an admin of and nav there?
       dispatch(navigateTo([], [Tabs.teamsTab]))

--- a/shared/pinentry/remote-proxy.desktop.js
+++ b/shared/pinentry/remote-proxy.desktop.js
@@ -7,7 +7,7 @@ import * as React from 'react'
 import * as Types from '../constants/types/pinentry'
 import SyncProps from '../desktop/remote/sync-props.desktop'
 import SyncBrowserWindow from '../desktop/remote/sync-browser-window.desktop'
-import {NullComponent, connect, mapProps, type TypedState, compose} from '../util/container'
+import {NullComponent, connect, mapProps, compose} from '../util/container'
 import {serialize} from './remote-serializer.desktop'
 
 const dataToProps = mapProps(({data}: {data: Types.PinentryState}) => ({
@@ -49,7 +49,7 @@ class RemotePinentrys extends React.PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   sessionIDToPinentry: state.pinentry.sessionIDToPinentry,
 })
 

--- a/shared/profile/add-to-team/container.js
+++ b/shared/profile/add-to-team/container.js
@@ -7,7 +7,6 @@ import {
   lifecycle,
   withHandlers,
   withStateHandlers,
-  type TypedState,
 } from '../../util/container'
 import {mapValues, zipObject} from 'lodash-es'
 import * as TeamsGen from '../../actions/teams-gen'
@@ -16,7 +15,7 @@ import {getSortedTeamnames} from '../../constants/teams'
 import {navigateAppend} from '../../actions/route-tree'
 import type {TeamRoleType} from '../../constants/types/teams'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   return {
     _teamNameToIsOpen: state.teams.get('teamNameToIsOpen', I.Map()),
     _teamNameToCanPerform: state.teams.get('teamNameToCanPerform', I.Map()),

--- a/shared/profile/confirm-or-pending/container.js
+++ b/shared/profile/confirm-or-pending/container.js
@@ -4,9 +4,8 @@ import ConfirmOrPending from '.'
 import {proveCommonProofStatus} from '../../constants/types/rpc-gen'
 import {globalColors} from '../../styles'
 import {connect} from '../../util/container'
-import {type TypedState} from '../../constants/reducer'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const profile = state.profile
   const isGood = profile.proofFound && profile.proofStatus === proveCommonProofStatus.ok
   const isPending =

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -21,7 +21,7 @@ import {createSearchSuggestions} from '../actions/search-gen'
 import {isTesting} from '../local-debug'
 import {navigateAppend, navigateUp} from '../actions/route-tree'
 import {peopleTab} from '../constants/tabs'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 import flags from '../util/feature-flags'
 
 import type {Response} from 'react-native-image-picker'
@@ -54,7 +54,7 @@ class ProfileContainer extends React.PureComponent<EitherProps<Props>> {
   }
 }
 
-const mapStateToProps = (state: TypedState, {routeProps, routeState, routePath}: OwnProps) => {
+const mapStateToProps = (state, {routeProps, routeState, routePath}: OwnProps) => {
   const myUsername = state.config.username
   const username = (routeProps.get('username') ? routeProps.get('username') : myUsername) || ''
   if (username && username !== username.toLowerCase()) {

--- a/shared/profile/edit-avatar-placeholder/container.js
+++ b/shared/profile/edit-avatar-placeholder/container.js
@@ -1,9 +1,9 @@
 // @flow
 import EditAvatar from '.'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import {navigateUp} from '../../actions/route-tree'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const username = state.config.username
   if (!username) {
     throw new Error('Not logged in')

--- a/shared/profile/edit-profile/container.js
+++ b/shared/profile/edit-profile/container.js
@@ -1,20 +1,13 @@
 // @flow
 import Render from '.'
-import {
-  compose,
-  withHandlers,
-  withPropsOnChange,
-  withStateHandlers,
-  connect,
-  type TypedState,
-} from '../../util/container'
+import {compose, withHandlers, withPropsOnChange, withStateHandlers, connect} from '../../util/container'
 import {createEditProfile} from '../../actions/profile-gen'
 import {maxProfileBioChars} from '../../constants/profile'
 import {navigateUp} from '../../actions/route-tree'
 import {HeaderOnMobile} from '../../common-adapters'
 import {isMobile} from '../../constants/platform'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   if (!state.config.username) {
     throw new Error("Didn't get username")
   }
@@ -27,7 +20,7 @@ const mapStateToProps = (state: TypedState) => {
   return {bio, fullname, location, title: 'Edit Profile'}
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onBack: () => dispatch(navigateUp()),
   onEditProfile: (bio: string, fullname: string, location: string) =>
     dispatch(createEditProfile({bio, fullname, location})),

--- a/shared/profile/non-user-profile/container.js
+++ b/shared/profile/non-user-profile/container.js
@@ -2,11 +2,11 @@
 import * as FsGen from '../../actions/fs-gen'
 import * as FsTypes from '../../constants/types/fs'
 import * as Chat2Gen from '../../actions/chat2-gen'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import {privateFolderWithUsers} from '../../constants/config'
 import NonUserProfile from '.'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const {avatar, fullname, fullUsername, profileUrl, serviceName, username} = routeProps.toObject()
   const myUsername = state.config.username
   const title = routeProps.get('username')

--- a/shared/profile/post-proof/container.js
+++ b/shared/profile/post-proof/container.js
@@ -2,10 +2,10 @@
 import * as ConfigGen from '../../actions/config-gen'
 import * as ProfileGen from '../../actions/profile-gen'
 import PostProof from '.'
-import {compose, connect, lifecycle, withStateHandlers, type TypedState} from '../../util/container'
+import {compose, connect, lifecycle, withStateHandlers} from '../../util/container'
 import {type ProvablePlatformsType} from '../../constants/types/more'
 
-const mapStateToProps = (state: TypedState, {onAllowProofCheck}) => {
+const mapStateToProps = (state, {onAllowProofCheck}) => {
   const profile = state.profile
 
   if (

--- a/shared/profile/prove-enter-username/container.js
+++ b/shared/profile/prove-enter-username/container.js
@@ -2,7 +2,7 @@
 import * as ProfileGen from '../../actions/profile-gen'
 import React, {Component} from 'react'
 import ProveEnterUsername from '.'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 
 type State = {
   username: ?string,
@@ -24,7 +24,7 @@ class ProveEnterUsernameContainer extends Component<any, State> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const profile = state.profile
 
   if (!profile.platform) {

--- a/shared/profile/prove-website-choice/container.js
+++ b/shared/profile/prove-website-choice/container.js
@@ -1,11 +1,11 @@
 // @flow
 import * as ProfileGen from '../../actions/profile-gen'
 import ProveWebsiteChoice from '.'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({})
+const mapStateToProps = state => ({})
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onCancel: () => dispatch(ProfileGen.createCancelAddProof()),
   onOptionClick: choice => dispatch(ProfileGen.createAddProof({platform: choice === 'file' ? 'web' : 'dns'})),
 })

--- a/shared/profile/revoke/container.js
+++ b/shared/profile/revoke/container.js
@@ -1,9 +1,9 @@
 // @flow
 import * as ProfileGen from '../../actions/profile-gen'
 import Revoke from '.'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => ({
+const mapStateToProps = (state, {routeProps}) => ({
   errorMessage: state.profile.revoke.error,
   isWaiting: state.profile.revoke.waiting,
   platform: routeProps.get('platform'),

--- a/shared/profile/showcase-team-offer/container.js
+++ b/shared/profile/showcase-team-offer/container.js
@@ -1,12 +1,12 @@
 // @flow
 import * as I from 'immutable'
 import Render from './index'
-import {compose, connect, lifecycle, type TypedState} from '../../util/container'
+import {compose, connect, lifecycle} from '../../util/container'
 import * as TeamsGen from '../../actions/teams-gen'
 import {HeaderOnMobile} from '../../common-adapters'
 import {getSortedTeamnames} from '../../constants/teams'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   return {
     _teamNameToIsOpen: state.teams.getIn(['teamNameToIsOpen'], I.Map()),
     _teammembercounts: state.teams.getIn(['teammembercounts'], I.Map()),

--- a/shared/profile/showcased-team-info/container.js
+++ b/shared/profile/showcased-team-info/container.js
@@ -6,8 +6,7 @@ import * as ProfileGen from '../../actions/profile-gen'
 import {parsePublicAdmins} from '../../util/teams'
 import {isInTeam, isAccessRequestPending} from '../../constants/teams'
 import {type UserTeamShowcase} from '../../constants/types/rpc-gen'
-
-import {connect, compose, lifecycle, type TypedState} from '../../util/container'
+import {connect, compose, lifecycle} from '../../util/container'
 
 type OwnProps = {
   attachTo: () => ?React.Component<any>,
@@ -16,7 +15,7 @@ type OwnProps = {
   visible: boolean,
 }
 
-const mapStateToProps = (state: TypedState, {team}: OwnProps) => {
+const mapStateToProps = (state, {team}: OwnProps) => {
   const username = state.config.username
   const following = state.config.following.toObject()
   if (!username || !following) {

--- a/shared/provision/code-page/container.js
+++ b/shared/provision/code-page/container.js
@@ -1,13 +1,13 @@
 // @flow
 import * as ProvisionGen from '../../actions/provision-gen'
 import CodePage2 from '.'
-import {compose, connect, type TypedState, isMobile, safeSubmit} from '../../util/container'
+import {compose, connect, isMobile, safeSubmit} from '../../util/container'
 import HiddenString from '../../util/hidden-string'
 import {type RouteProps} from '../../route-tree/render-route'
 
 type OwnProps = RouteProps<{}, {}>
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const currentDeviceAlreadyProvisioned = !!state.config.deviceName
   return {
     currentDeviceAlreadyProvisioned,

--- a/shared/provision/code-page/qr-scan/container.js
+++ b/shared/provision/code-page/qr-scan/container.js
@@ -11,11 +11,10 @@ import {
   withStateHandlers,
   connect,
   safeSubmit,
-  type TypedState,
 } from '../../../util/container'
 import HiddenString from '../../../util/hidden-string'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.provision.error.stringValue(),
   waiting: WaitingConstants.anyWaiting(state, Constants.waitingKey),
 })

--- a/shared/provision/error/container.js
+++ b/shared/provision/error/container.js
@@ -1,12 +1,12 @@
 // @flow
 import RenderError from '.'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import {type RouteProps} from '../../route-tree/render-route'
 import openURL from '../../util/open-url'
 
 type OwnProps = RouteProps<{}, {}>
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.provision.finalError,
 })
 

--- a/shared/provision/gpg-sign/container.js
+++ b/shared/provision/gpg-sign/container.js
@@ -2,12 +2,11 @@
 import * as ProvisionGen from '../../actions/provision-gen'
 import {connect} from '../../util/container'
 import {type RouteProps} from '../../route-tree/render-route'
-import type {TypedState} from '../../constants/reducer'
 import GPGSign from '.'
 
 type OwnProps = RouteProps<{}, {}>
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   importError: state.provision.gpgImportError,
 })
 

--- a/shared/provision/paper-key/container.js
+++ b/shared/provision/paper-key/container.js
@@ -1,13 +1,13 @@
 // @flow
 import * as ProvisionGen from '../../actions/provision-gen'
 import PaperKey from '.'
-import {compose, withStateHandlers, connect, type TypedState} from '../../util/container'
+import {compose, withStateHandlers, connect} from '../../util/container'
 import HiddenString from '../../util/hidden-string'
 import {type RouteProps} from '../../route-tree/render-route'
 
 type OwnProps = {paperKey: string} & RouteProps<{}, {}>
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.provision.error.stringValue(),
   hint: `${state.provision.codePageOtherDeviceName || ''}...`,
 })

--- a/shared/provision/passphrase/container.js
+++ b/shared/provision/passphrase/container.js
@@ -5,7 +5,7 @@ import * as Constants from '../../constants/provision'
 import HiddenString from '../../util/hidden-string'
 import Passphrase from '.'
 import React, {Component} from 'react'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import {type RouteProps} from '../../route-tree/render-route'
 import * as WaitingConstants from '../../constants/waiting'
 
@@ -61,7 +61,7 @@ class _Passphrase extends Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.provision.error.stringValue(),
   waitingForResponse: WaitingConstants.anyWaiting(state, Constants.waitingKey),
 })

--- a/shared/provision/select-other-device/container.js
+++ b/shared/provision/select-other-device/container.js
@@ -2,12 +2,12 @@
 import * as ProvisionGen from '../../actions/provision-gen'
 import * as LoginGen from '../../actions/login-gen'
 import SelectOtherDevice from '.'
-import {connect, type TypedState, compose, safeSubmitPerMount} from '../../util/container'
+import {connect, compose, safeSubmitPerMount} from '../../util/container'
 import {type RouteProps} from '../../route-tree/render-route'
 
 type OwnProps = RouteProps<{}, {}>
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   devices: state.provision.devices,
 })
 const mapDispatchToProps = (dispatch, ownProps: OwnProps) => ({

--- a/shared/provision/set-public-name/container.js
+++ b/shared/provision/set-public-name/container.js
@@ -2,12 +2,12 @@
 import * as ProvisionGen from '../../actions/provision-gen'
 import * as Constants from '../../constants/provision'
 import SetPublicName from '.'
-import {connect, type TypedState, withStateHandlers, compose, safeSubmit} from '../../util/container'
+import {connect, withStateHandlers, compose, safeSubmit} from '../../util/container'
 import {type RouteProps} from '../../route-tree/render-route'
 
 type OwnProps = {deviceName: string, onChange: (text: string) => void} & RouteProps<{}, {}>
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _existingDevices: state.provision.existingDevices,
   error: state.provision.error.stringValue(),
 })

--- a/shared/provision/username-or-email/container.js
+++ b/shared/provision/username-or-email/container.js
@@ -1,12 +1,12 @@
 // @flow
 import * as ProvisionGen from '../../actions/provision-gen'
 import UsernameOrEmail from '.'
-import {compose, connect, type TypedState, safeSubmit} from '../../util/container'
+import {compose, connect, safeSubmit} from '../../util/container'
 import {type RouteProps} from '../../route-tree/render-route'
 
 type OwnProps = RouteProps<{}, {}>
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.provision.error.stringValue(),
   // So we can clear the error if the name is changed
   submittedUsernameOrEmail: state.provision.usernameOrEmail,

--- a/shared/search/result-row/container.js
+++ b/shared/search/result-row/container.js
@@ -4,7 +4,7 @@ import {userIsActiveInTeamHelper} from '../../constants/teams'
 import {followStateHelper, getUserInputItemIds, makeSearchResult} from '../../constants/search'
 import {type SearchResultId} from '../../constants/types/search'
 import {parseUserId} from '../../util/platforms'
-import {connect, type TypedState, setDisplayName, compose} from '../../util/container'
+import {connect, setDisplayName, compose} from '../../util/container'
 import {some} from 'lodash-es'
 
 export type OwnProps = {|
@@ -19,7 +19,7 @@ export type OwnProps = {|
 
 const emptySearch = makeSearchResult()
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const result = state.entities.search.searchResults.get(ownProps.id, emptySearch)
   const {searchKey} = ownProps
   const leftFollowingState = followStateHelper(state, result.leftUsername, result.leftService)

--- a/shared/search/results-list/container.js
+++ b/shared/search/results-list/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {connect, compose, setDisplayName, type TypedState} from '../../util/container'
+import {connect, compose, setDisplayName} from '../../util/container'
 import React from 'react'
 import {ProgressIndicator, Box} from '../../common-adapters'
 import SearchResultsList, {type Props as _Props} from '.'
@@ -15,7 +15,7 @@ export type OwnProps = {|
   style?: any,
 |}
 
-const mapStateToProps = ({entities}: TypedState, {disableIfInTeamName, searchKey}: OwnProps) => {
+const mapStateToProps = ({entities}, {disableIfInTeamName, searchKey}: OwnProps) => {
   const searchResultIds = entities.search.searchKeyToResults.get(searchKey)
   const pending = entities.search.searchKeyToPending.get(searchKey, false)
   const showSearchSuggestions = entities.search.searchKeyToShowSearchSuggestion.get(searchKey, false)

--- a/shared/search/user-input/container.js
+++ b/shared/search/user-input/container.js
@@ -119,7 +119,7 @@ const getUserItems = createShallowEqualSelector(
     })
 )
 
-const mapStateToProps = (state: TypedState, {searchKey, showServiceFilter}: OwnProps) => {
+const mapStateToProps = (state, {searchKey, showServiceFilter}: OwnProps) => {
   const {entities} = state
   const searchResultTerm = getSearchResultTerm(state, {searchKey})
   const searchResultIds = Constants.getSearchResultIdsArray(state, {searchKey})

--- a/shared/settings/about-container.js
+++ b/shared/settings/about-container.js
@@ -5,7 +5,7 @@ import {HeaderHoc} from '../common-adapters'
 import {version} from '../constants/platform'
 
 const mapStateToProps = () => ({version})
-const mapDispatchToProps = (dispatch: Container.Dispatch, {navigateUp, navigateAppend}) => ({
+const mapDispatchToProps = (dispatch, {navigateUp, navigateAppend}) => ({
   onBack: () => dispatch(navigateUp()),
   onShowPrivacyPolicy: () =>
     dispatch(

--- a/shared/settings/advanced/container.js
+++ b/shared/settings/advanced/container.js
@@ -11,9 +11,9 @@ import {HeaderHoc} from '../../common-adapters'
 import * as Constants from '../../constants/settings'
 import {compose} from 'recompose'
 import Advanced from './index'
-import {connect, lifecycle, type TypedState} from '../../util/container'
+import {connect, lifecycle} from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   openAtLogin: state.config.openAtLogin,
   lockdownModeEnabled: state.settings.lockdownModeEnabled,
   processorProfileInProgress: Constants.processorProfileInProgress(state),

--- a/shared/settings/delete-confirm/container.js
+++ b/shared/settings/delete-confirm/container.js
@@ -4,7 +4,7 @@ import DeleteConfirm, {type Props} from '.'
 import React, {Component} from 'react'
 import {navigateUp} from '../../actions/route-tree'
 import {HOCTimers, type PropsWithTimer} from '../../common-adapters'
-import {compose, connect, type TypedState} from '../../util/container'
+import {compose, connect} from '../../util/container'
 
 class DeleteConfirmContainer extends Component<PropsWithTimer<Props>> {
   componentDidMount() {
@@ -23,7 +23,7 @@ class DeleteConfirmContainer extends Component<PropsWithTimer<Props>> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   if (!state.config.username) {
     throw new Error('No current username for delete confirm container')
   }

--- a/shared/settings/email/container.js
+++ b/shared/settings/email/container.js
@@ -2,9 +2,9 @@
 import * as SettingsGen from '../../actions/settings-gen'
 import UpdateEmail from './index'
 import {navigateUp} from '../../actions/route-tree'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const {waitingForResponse} = state.settings
   const {emails, error} = state.settings.email
   let email = ''
@@ -21,7 +21,7 @@ const mapStateToProps = (state: TypedState) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onBack: () => dispatch(navigateUp()),
   onSave: email => {
     dispatch(SettingsGen.createOnChangeNewEmail({email}))

--- a/shared/settings/feedback-container.native.js
+++ b/shared/settings/feedback-container.native.js
@@ -6,7 +6,7 @@ import React, {Component} from 'react'
 import {HeaderHoc, HOCTimers, type PropsWithTimer} from '../common-adapters'
 import Feedback from './feedback.native'
 import logSend from '../native/log-send'
-import {compose, connect, type TypedState} from '../util/container'
+import {compose, connect} from '../util/container'
 import {
   isAndroid,
   appVersionName,
@@ -122,7 +122,7 @@ class FeedbackContainer extends Component<Props, State> {
   }
 }
 
-const extraChatLogs = (state: TypedState) => {
+const extraChatLogs = state => {
   const chat = state.chat2
   const c = state.chat2.selectedConversation
   if (c) {
@@ -176,7 +176,7 @@ const extraChatLogs = (state: TypedState) => {
 }
 
 // TODO really shouldn't be doing this in connect, should do this with an action
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   return {
     chat: extraChatLogs(state),
     heading: routeProps.get('heading') || 'Your feedback is welcomed!',

--- a/shared/settings/files/container.js
+++ b/shared/settings/files/container.js
@@ -2,11 +2,11 @@
 import Files from './index'
 import * as FsGen from '../../actions/fs-gen'
 import * as Constants from '../../constants/fs'
-import {connect, compose, lifecycle, type TypedState} from '../../util/container'
+import {connect, compose, lifecycle} from '../../util/container'
 import SecurityPrefsPromptingHoc from '../../fs/common/security-prefs-prompting-hoc'
 import {navigateAppend} from '../../actions/route-tree'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const kbfsEnabled = Constants.kbfsEnabled(state)
   return {
     kbfsEnabled,

--- a/shared/settings/index.js
+++ b/shared/settings/index.js
@@ -2,13 +2,13 @@
 import * as ConfigGen from '../actions/config-gen'
 import * as Types from '../constants/types/settings'
 import SettingsContainer from './render'
-import {connect, type TypedState} from '../util/container'
+import {connect} from '../util/container'
 import {switchTo} from '../actions/route-tree'
 import {type RouteProps} from '../route-tree/render-route'
 
 type OwnProps = RouteProps<{}, {}>
 
-const mapStateToProps = (state: TypedState, {routeLeafTags, routeSelected}: OwnProps) => ({
+const mapStateToProps = (state, {routeLeafTags, routeSelected}: OwnProps) => ({
   _badgeNumbers: state.notifications.get('navBadges'),
   badgeNotifications: !state.push.hasPermissions,
   isModal: routeLeafTags.modal,

--- a/shared/settings/invites/container.js
+++ b/shared/settings/invites/container.js
@@ -4,9 +4,9 @@ import * as Types from '../../constants/types/settings'
 import Invites from '.'
 import {createShowUserProfile} from '../../actions/profile-gen'
 import {navigateAppend} from '../../actions/route-tree'
-import {connect, type TypedState, lifecycle, compose} from '../../util/container'
+import {connect, lifecycle, compose} from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   ...state.settings.invites,
   inviteEmail: '',
   inviteMessage: '',

--- a/shared/settings/landing/container.js
+++ b/shared/settings/landing/container.js
@@ -3,10 +3,10 @@ import logger from '../../logger'
 import * as SettingsGen from '../../actions/settings-gen'
 import Bootstrapable from '../../util/bootstrapable'
 import Landing from '.'
-import {connect, type TypedState, compose} from '../../util/container'
+import {connect, compose} from '../../util/container'
 import {navigateAppend} from '../../actions/route-tree'
 
-const mapStateToProps = (state: TypedState, ownProps: {}) => {
+const mapStateToProps = (state, ownProps: {}) => {
   const {emails} = state.settings.email
   const {rememberPassphrase} = state.settings.passphrase
   let accountProps

--- a/shared/settings/notifications/container.js
+++ b/shared/settings/notifications/container.js
@@ -1,12 +1,12 @@
 // @flow
 import * as SettingsGen from '../../actions/settings-gen'
 import * as Types from '../../constants/types/settings'
-import {connect, type TypedState, lifecycle, compose} from '../../util/container'
+import {connect, lifecycle, compose} from '../../util/container'
 import Notifications from './index'
 import {navigateUp} from '../../actions/route-tree'
 import * as ConfigGen from '../../actions/config-gen'
 
-const mapStateToProps = (state: TypedState, ownProps: {}) => ({
+const mapStateToProps = (state, ownProps: {}) => ({
   ...state.settings.notifications,
   mobileHasPermissions: state.push.hasPermissions,
   waitingForResponse: state.settings.waitingForResponse,

--- a/shared/settings/passphrase/container.js
+++ b/shared/settings/passphrase/container.js
@@ -1,10 +1,10 @@
 // @flow
 import * as SettingsGen from '../../actions/settings-gen'
 import UpdatePassphrase from '.'
-import {compose, lifecycle, connect, type TypedState} from '../../util/container'
+import {compose, lifecycle, connect} from '../../util/container'
 import HiddenString from '../../util/hidden-string'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   error: state.settings.passphrase.error,
   hasPGPKeyOnServer: !!state.settings.passphrase.hasPGPKeyOnServer,
   newPassphraseConfirmError: state.settings.passphrase.newPassphraseConfirmError

--- a/shared/settings/screenprotector-container.native.js
+++ b/shared/settings/screenprotector-container.native.js
@@ -5,7 +5,7 @@ import * as Container from '../util/container'
 const mapStateToProps = () => ({
   title: 'Screen Protector',
 })
-const mapDispatchToProps = (dispatch: Container.Dispatch, {navigateUp}) => ({
+const mapDispatchToProps = (dispatch, {navigateUp}) => ({
   onBack: () => dispatch(navigateUp()),
 })
 

--- a/shared/settings/web-links.native.js
+++ b/shared/settings/web-links.native.js
@@ -1,8 +1,8 @@
 // @flow
 import {HeaderHoc, NativeWebView} from '../common-adapters/mobile.native'
-import {connect, compose, defaultProps, type TypedState} from '../util/container'
+import {connect, compose, defaultProps} from '../util/container'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => ({
+const mapStateToProps = (state, {routeProps}) => ({
   source: routeProps.get('source'),
   title: routeProps.get('title'),
 })

--- a/shared/team-building/container.js
+++ b/shared/team-building/container.js
@@ -5,7 +5,7 @@ import * as I from 'immutable'
 import {debounce, trim} from 'lodash-es'
 import TeamBuilding from '.'
 import * as TeamBuildingGen from '../actions/team-building-gen'
-import {type TypedState, compose, connect, setDisplayName} from '../util/container'
+import {compose, connect, setDisplayName} from '../util/container'
 import {PopupDialogHoc} from '../common-adapters'
 import {parseUserId} from '../util/platforms'
 import {followStateHelperWithId} from '../constants/team-building'
@@ -86,7 +86,7 @@ const deriveUserFromUserIdFn = memoizeOne((searchResults: ?Array<User>) => (user
   (searchResults || []).filter(u => u.id === userId)[0] || null
 )
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   const userResults = state.chat2.teamBuildingSearchResults.getIn([
     trim(ownProps.searchString),
     ownProps.selectedService,
@@ -227,7 +227,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
 }
 
 const Connected = compose(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    mergeProps
+  ),
   setDisplayName('TeamBuilding'),
   PopupDialogHoc
 )(TeamBuilding)

--- a/shared/teams/add-people/container.js
+++ b/shared/teams/add-people/container.js
@@ -14,10 +14,9 @@ import {
   withHandlers,
   withPropsOnChange,
   withStateHandlers,
-  type TypedState,
 } from '../../util/container'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const teamname = routeProps.get('teamname')
   return {
     numberOfUsersSelected: SearchConstants.getUserInputItemIds(state, {searchKey: 'addToTeamSearch'}).length,

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -7,11 +7,11 @@ import * as TeamsGen from '../actions/teams-gen'
 import Teams from './main'
 import openURL from '../util/open-url'
 import {navigateAppend} from '../actions/route-tree'
-import {compose, lifecycle, type TypedState, connect} from '../util/container'
+import {compose, lifecycle, connect} from '../util/container'
 import {getSortedTeamnames} from '../constants/teams'
 import {type Teamname} from '../constants/types/teams'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _newTeamRequests: state.teams.getIn(['newTeamRequests'], I.List()),
   _newTeams: state.teams.getIn(['newTeams'], I.Set()),
   _teamNameToIsOpen: state.teams.getIn(['teamNameToIsOpen'], I.Map()),

--- a/shared/teams/edit-team-description/container.js
+++ b/shared/teams/edit-team-description/container.js
@@ -7,11 +7,10 @@ import {
   withHandlers,
   withProps,
   withStateHandlers,
-  type TypedState,
 } from '../../util/container'
 import * as Constants from '../../constants/teams'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const teamname = routeProps.get('teamname')
   if (!teamname) {
     throw new Error('There was a problem loading the description page, please report this error.')

--- a/shared/teams/invite-by-email/container.desktop.js
+++ b/shared/teams/invite-by-email/container.desktop.js
@@ -4,10 +4,10 @@ import * as Constants from '../../constants/teams'
 import * as Types from '../../constants/types/teams'
 import {InviteByEmailDesktop} from '.'
 import {navigateAppend} from '../../actions/route-tree'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import {type OwnProps} from './container'
 
-const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
+const mapStateToProps = (state, {routeProps}: OwnProps) => {
   const inviteError = Constants.getEmailInviteError(state)
   return {
     errorMessage: inviteError.message,

--- a/shared/teams/invite-by-email/container.native.js
+++ b/shared/teams/invite-by-email/container.native.js
@@ -14,7 +14,6 @@ import {
   withPropsOnChange,
   withStateHandlers,
   lifecycle,
-  type TypedState,
 } from '../../util/container'
 import {type OwnProps} from './container'
 import {isAndroid} from '../../constants/platform'
@@ -30,7 +29,7 @@ const extractPhoneNumber: string => ?string = (name: string) => {
   return (matches && matches[1] && cleanPhoneNumber(matches[1])) || ''
 }
 
-const mapStateToProps = (state: TypedState, {routeProps}: OwnProps) => {
+const mapStateToProps = (state, {routeProps}: OwnProps) => {
   const teamname = routeProps.get('teamname')
   const inviteError = Constants.getEmailInviteError(state)
   return {

--- a/shared/teams/join-team/container.js
+++ b/shared/teams/join-team/container.js
@@ -8,13 +8,12 @@ import {
   lifecycle,
   withStateHandlers,
   withHandlers,
-  type TypedState,
 } from '../../util/container'
 import {type RouteProps} from '../../route-tree/render-route'
 
 type OwnProps = RouteProps<void, void>
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   errorText: upperFirst(state.teams.teamJoinError),
   success: state.teams.teamJoinSuccess,
   successTeamName: state.teams.teamJoinSuccessTeamName,

--- a/shared/teams/new-team/container.js
+++ b/shared/teams/new-team/container.js
@@ -8,10 +8,9 @@ import {
   lifecycle,
   withStateHandlers,
   withHandlers,
-  type TypedState,
 } from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   errorText: upperFirst(state.teams.teamCreationError),
   pending: state.teams.teamCreationPending,
 })

--- a/shared/teams/really-leave-team/container-chat.js
+++ b/shared/teams/really-leave-team/container-chat.js
@@ -16,7 +16,7 @@ type Props = {|
   _loaded: boolean,
 |}
 
-const mapStateToProps = (state: Container.TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const name = routeProps.get('teamname')
   const canPerform = getCanPerform(state, name)
   const _canLeaveTeam = canPerform.leaveTeam

--- a/shared/teams/really-leave-team/container.js
+++ b/shared/teams/really-leave-team/container.js
@@ -7,7 +7,7 @@ import LastOwnerDialog from './last-owner'
 import {getTeamMemberCount, isSubteam, leaveTeamWaitingKey} from '../../constants/teams'
 import {anyWaiting} from '../../constants/waiting'
 
-const mapStateToProps = (state: Container.TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const name = routeProps.get('teamname')
   const memberCount = getTeamMemberCount(state, name)
   const _lastOwner = memberCount <= 1 && !isSubteam(name)

--- a/shared/teams/role-picker/container.js
+++ b/shared/teams/role-picker/container.js
@@ -7,8 +7,6 @@ import {compose, withStateHandlers} from 'recompose'
 import RolePicker from '.'
 import {getTeamMembers, getRole, isOwner} from '../../constants/teams'
 
-import type {TypedState} from '../../constants/reducer'
-
 type StateProps = {
   _memberInfo: I.Map<string, Types.MemberInfo>,
   you: ?string,
@@ -17,7 +15,7 @@ type StateProps = {
   yourRole: Types.MaybeTeamRoleType,
 }
 
-const mapStateToProps = (state: TypedState, {routeProps}): StateProps => {
+const mapStateToProps = (state, {routeProps}): StateProps => {
   const teamname = routeProps.get('teamname')
   const username = routeProps.get('username')
   return {

--- a/shared/teams/role-picker/controlled-container.js
+++ b/shared/teams/role-picker/controlled-container.js
@@ -3,7 +3,6 @@ import React from 'react'
 import {RoleOptions} from '.'
 import {connect, compose, withHandlers, withStateHandlers} from '../../util/container'
 import {HeaderOrPopup, ScrollView} from '../../common-adapters/index'
-import {type TypedState} from '../../constants/reducer'
 import {type TeamRoleType} from '../../constants/types/teams'
 
 /*
@@ -26,7 +25,7 @@ export type ControlledRolePickerProps = {
   styleCover?: Object,
 }
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const currentType = routeProps.get('selectedRole')
   const _onComplete = routeProps.get('onComplete')
   const addButtonLabel = routeProps.get('addButtonLabel')

--- a/shared/teams/team/container.js
+++ b/shared/teams/team/container.js
@@ -4,7 +4,7 @@ import * as TeamsGen from '../../actions/teams-gen'
 import Team from '.'
 import CustomTitle from './custom-title/container'
 import {HeaderHoc} from '../../common-adapters'
-import {connect, lifecycle, compose, type TypedState} from '../../util/container'
+import {connect, lifecycle, compose} from '../../util/container'
 import {mapStateHelper as invitesMapStateHelper, getRows as getInviteRows} from './invites-tab/helper'
 import {mapStateHelper as memberMapStateHelper, getRows as getMemberRows} from './members-tab/helper'
 import {mapStateHelper as subteamsMapStateHelper, getRows as getSubteamsRows} from './subteams-tab/helper'
@@ -12,7 +12,7 @@ import type {RouteProps} from '../../route-tree/render-route'
 
 type OwnProps = RouteProps<{teamname: string}, {selectedTab: ?string}>
 
-const mapStateToProps = (state: TypedState, {routeProps, routeState}: OwnProps) => {
+const mapStateToProps = (state, {routeProps, routeState}: OwnProps) => {
   const teamname = routeProps.get('teamname')
   if (!teamname) {
     throw new Error('There was a problem loading the team page, please report this error.')

--- a/shared/teams/team/custom-title/container.js
+++ b/shared/teams/team/custom-title/container.js
@@ -4,10 +4,10 @@ import * as FsGen from '../../../actions/fs-gen'
 import * as FsTypes from '../../../constants/types/fs'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import Title from '.'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {anyWaiting} from '../../../constants/waiting'
 
-const mapStateToProps = (state: TypedState, {teamname}) => {
+const mapStateToProps = (state, {teamname}) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   return {
     canChat: !yourOperations.joinTeam,

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import * as Constants from '../../../constants/teams'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as Types from '../../../constants/types/teams'
@@ -12,7 +12,7 @@ export type OwnProps = {
   teamname: Types.Teamname,
 }
 
-const mapStateToProps = (state: TypedState, {teamname}: OwnProps) => {
+const mapStateToProps = (state, {teamname}: OwnProps) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   return {
     _you: state.config.username,

--- a/shared/teams/team/invites-tab/invite-row/container.js
+++ b/shared/teams/team/invites-tab/invite-row/container.js
@@ -2,21 +2,21 @@
 import * as TeamsGen from '../../../../actions/teams-gen'
 import {getTeamInvites, getTeamMembers} from '../../../../constants/teams'
 import {TeamInviteRow} from '.'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 
 type OwnProps = {
   id: string,
   teamname: string,
 }
 
-const mapStateToProps = (state: TypedState, {teamname, id}: OwnProps) => {
+const mapStateToProps = (state, {teamname, id}: OwnProps) => {
   return {
     _invites: getTeamInvites(state, teamname),
     _members: getTeamMembers(state, teamname),
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   _onCancelInvite: ({email, teamname, username, inviteID}) => {
     dispatch(TeamsGen.createRemoveMemberOrPendingInvite({email, inviteID, teamname, username}))
   },

--- a/shared/teams/team/invites-tab/request-row/container.js
+++ b/shared/teams/team/invites-tab/request-row/container.js
@@ -4,16 +4,16 @@ import * as Chat2Gen from '../../../../actions/chat2-gen'
 import {TeamRequestRow} from '.'
 import {navigateAppend} from '../../../../actions/route-tree'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 
 type OwnProps = {
   username: string,
   teamname: string,
 }
 
-const mapStateToProps = (state: TypedState) => ({})
+const mapStateToProps = state => ({})
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   _onAccept: (name: string, username: string) =>
     dispatch(
       navigateAppend([

--- a/shared/teams/team/member/container.js
+++ b/shared/teams/team/member/container.js
@@ -8,7 +8,6 @@ import {compose} from 'recompose'
 import {HeaderHoc} from '../../../common-adapters'
 import {createShowUserProfile} from '../../../actions/profile-gen'
 import {TeamMember} from '.'
-import {type TypedState} from '../../../constants/reducer'
 import {getCanPerform, getTeamMembers, teamWaitingKey} from '../../../constants/teams'
 import {anyWaiting} from '../../../constants/waiting'
 import * as RPCTypes from '../../../constants/types/rpc-gen'
@@ -24,7 +23,7 @@ type StateProps = {
   loading: boolean,
 }
 
-const mapStateToProps = (state: TypedState, {routeProps}): StateProps => {
+const mapStateToProps = (state, {routeProps}): StateProps => {
   const username = routeProps.get('username')
   const teamname = routeProps.get('teamname')
 

--- a/shared/teams/team/members-tab/member-row/container.js
+++ b/shared/teams/team/members-tab/member-row/container.js
@@ -8,7 +8,7 @@ import * as ProfileGen from '../../../../actions/profile-gen'
 import {TeamMemberRow} from '.'
 import {amIFollowing} from '../../../../constants/selectors'
 import {navigateAppend} from '../../../../actions/route-tree'
-import {connect, isMobile, type TypedState} from '../../../../util/container'
+import {connect, isMobile} from '../../../../util/container'
 import {anyWaiting} from '../../../../constants/waiting'
 
 type OwnProps = {
@@ -18,7 +18,7 @@ type OwnProps = {
 
 const blankInfo = Constants.makeMemberInfo()
 
-const mapStateToProps = (state: TypedState, {teamname, username}: OwnProps) => {
+const mapStateToProps = (state, {teamname, username}: OwnProps) => {
   const map = Constants.getTeamMembers(state, teamname)
   const info = map.get(username, blankInfo)
 

--- a/shared/teams/team/menu-container.js
+++ b/shared/teams/team/menu-container.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import * as Constants from '../../constants/teams'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import {navigateTo} from '../../actions/route-tree'
 import {type MenuItem} from '../../common-adapters/floating-menu/menu-layout'
 import {FloatingMenu} from '../../common-adapters'
@@ -14,7 +14,7 @@ type OwnProps = {
   visible: boolean,
 }
 
-const mapStateToProps = (state: TypedState, {teamname}: OwnProps) => {
+const mapStateToProps = (state, {teamname}: OwnProps) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   const isBigTeam = Constants.isBigTeam(state, teamname)
   return {

--- a/shared/teams/team/really-remove-member/container.js
+++ b/shared/teams/team/really-remove-member/container.js
@@ -1,11 +1,11 @@
 // @flow
 import * as TeamsGen from '../../../actions/teams-gen'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import ReallyLeaveTeam from '.'
 import {navigateTo} from '../../../actions/route-tree'
 import {teamsTab} from '../../../constants/tabs'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => ({
+const mapStateToProps = (state, {routeProps}) => ({
   member: routeProps.get('username') || routeProps.get('email'),
   name: routeProps.get('teamname'),
 })

--- a/shared/teams/team/settings-tab/container.js
+++ b/shared/teams/team/settings-tab/container.js
@@ -3,7 +3,7 @@ import * as Constants from '../../../constants/teams'
 import * as Types from '../../../constants/types/teams'
 import type {RetentionPolicy} from '../../../constants/types/retention-policy'
 import * as TeamsGen from '../../../actions/teams-gen'
-import {type TypedState, connect} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {Settings} from '.'
 import {anyWaiting} from '../../../constants/waiting'
 import {navigateAppend} from '../../../actions/route-tree'
@@ -12,7 +12,7 @@ export type OwnProps = {
   teamname: string,
 }
 
-const mapStateToProps = (state: TypedState, {teamname}: OwnProps) => {
+const mapStateToProps = (state, {teamname}: OwnProps) => {
   const publicitySettings = Constants.getTeamPublicitySettings(state, teamname)
   const publicityAnyMember = publicitySettings.anyMemberShowcase
   const publicityMember = publicitySettings.member

--- a/shared/teams/team/settings-tab/retention/container.js
+++ b/shared/teams/team/settings-tab/retention/container.js
@@ -8,7 +8,6 @@ import {
   setDisplayName,
   withStateHandlers,
   withHandlers,
-  type TypedState,
 } from '../../../../util/container'
 import {
   getTeamRetentionPolicy,
@@ -35,7 +34,7 @@ export type OwnProps = {
   onSelect?: (policy: RetentionPolicy, changed: boolean, decreased: boolean) => void,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
+const mapStateToProps = (state, ownProps: OwnProps) => {
   let policy: RetentionPolicy = retentionPolicies.policyRetain
   let teamPolicy: ?RetentionPolicy
   let showInheritOption = false

--- a/shared/teams/team/settings-tab/retention/warning/container.js
+++ b/shared/teams/team/settings-tab/retention/warning/container.js
@@ -1,8 +1,8 @@
 // @flow
-import {connect, compose, withStateHandlers, type TypedState} from '../../../../../util/container'
+import {connect, compose, withStateHandlers} from '../../../../../util/container'
 import RetentionWarning from '.'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   return {
     days: routeProps.get('days'),
     entityType: routeProps.get('entityType'),

--- a/shared/teams/team/subteams-tab/team-row/container.js
+++ b/shared/teams/team/subteams-tab/team-row/container.js
@@ -4,7 +4,7 @@ import * as Types from '../../../../constants/types/teams'
 import * as FsTypes from '../../../../constants/types/fs'
 import * as Constants from '../../../../constants/teams'
 import {TeamRow} from '../../../main/team-list'
-import {connect, type TypedState} from '../../../../util/container'
+import {connect} from '../../../../util/container'
 import {navigateAppend} from '../../../../actions/route-tree'
 import * as FsGen from '../../../../actions/fs-gen'
 
@@ -12,7 +12,7 @@ type OwnProps = {
   teamname: string,
 }
 
-const mapStateToProps = (state: TypedState, {teamname}: OwnProps) => ({
+const mapStateToProps = (state, {teamname}: OwnProps) => ({
   _newTeamRequests: state.teams.getIn(['newTeamRequests'], I.List()),
   _teamNameToIsOpen: state.teams.getIn(['teamNameToIsOpen'], I.Map()),
   members: Constants.getTeamMemberCount(state, teamname),

--- a/shared/teams/team/tabs/container.js
+++ b/shared/teams/team/tabs/container.js
@@ -2,10 +2,10 @@
 import * as Constants from '../../../constants/teams'
 import * as I from 'immutable'
 import Tabs from '.'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {anyWaiting} from '../../../constants/waiting'
 
-const mapStateToProps = (state: TypedState, {teamname, selectedTab, setSelectedTab}) => {
+const mapStateToProps = (state, {teamname, selectedTab, setSelectedTab}) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   return {
     _newTeamRequests: state.teams.getIn(['newTeamRequests'], I.List()),
@@ -23,7 +23,7 @@ const mapStateToProps = (state: TypedState, {teamname, selectedTab, setSelectedT
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({})
+const mapDispatchToProps = dispatch => ({})
 
 const mergeProps = (stateProps, dispatchProps) => {
   return {

--- a/shared/tracker/remote-proxy.desktop.js
+++ b/shared/tracker/remote-proxy.desktop.js
@@ -10,13 +10,13 @@ import {parsePublicAdmins} from '../util/teams'
 import SyncAvatarProps from '../desktop/remote/sync-avatar-props.desktop'
 import SyncProps from '../desktop/remote/sync-props.desktop'
 import SyncBrowserWindow from '../desktop/remote/sync-browser-window.desktop'
-import {connect, type TypedState, compose} from '../util/container'
+import {connect, compose} from '../util/container'
 import {serialize} from './remote-serializer.desktop'
 
 const MAX_TRACKERS = 5
 const windowOpts = {height: 470, width: 320}
 
-const trackerMapStateToProps = (state: TypedState, {name}) => {
+const trackerMapStateToProps = (state, {name}) => {
   const _trackerState = state.tracker.userTrackers[name] || state.tracker.nonUserTrackers[name]
   const selectedTeam = _trackerState.selectedTeam
   const showTeam =
@@ -121,7 +121,7 @@ class RemoteTrackers extends React.PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   _nonUserTrackers: state.tracker.nonUserTrackers,
   _trackers: state.tracker.userTrackers,
 })

--- a/shared/unlock-folders/remote-proxy.desktop.js
+++ b/shared/unlock-folders/remote-proxy.desktop.js
@@ -2,12 +2,12 @@
 import * as React from 'react'
 import SyncProps from '../desktop/remote/sync-props.desktop'
 import SyncBrowserWindow from '../desktop/remote/sync-browser-window.desktop'
-import {NullComponent, connect, type TypedState, compose} from '../util/container'
+import {NullComponent, connect, compose} from '../util/container'
 import {serialize} from './remote-serializer.desktop'
 
 const windowOpts = {height: 300, width: 500}
 
-const unlockFolderMapPropsToState = (state: TypedState) => {
+const unlockFolderMapPropsToState = state => {
   const {devices, phase, paperkeyError, waiting} = state.unlockFolders
   return {
     devices,
@@ -53,7 +53,7 @@ class UnlockFolders extends React.PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   show: state.unlockFolders.popupOpen,
 })
 

--- a/shared/wallets/asset/container.js
+++ b/shared/wallets/asset/container.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Types from '../../constants/types/wallets'
 import * as Constants from '../../constants/wallets'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import Asset from '.'
 
 type OwnProps = {
@@ -9,7 +9,7 @@ type OwnProps = {
   index: number,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
+const mapStateToProps = (state, ownProps: OwnProps) => ({
   _asset: Constants.getAssets(state, ownProps.accountID).get(ownProps.index, Constants.makeAssets()),
 })
 

--- a/shared/wallets/confirm-form/container.js
+++ b/shared/wallets/confirm-form/container.js
@@ -2,9 +2,9 @@
 import ConfirmSend from '.'
 import * as Constants from '../../constants/wallets'
 import * as WalletsGen from '../../actions/wallets-gen'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const build = state.wallets.buildingPayment
   const built = state.wallets.builtPayment
   const banners = (state.wallets.sentPaymentError

--- a/shared/wallets/confirm-form/participants/container.js
+++ b/shared/wallets/confirm-form/participants/container.js
@@ -1,10 +1,10 @@
 // @flow
 import ConfirmSend from '.'
-import {connect, type TypedState} from '../../../util/container'
+import {connect} from '../../../util/container'
 import {getAccount} from '../../../constants/wallets'
 import {stringToAccountID} from '../../../constants/types/wallets'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const build = state.wallets.buildingPayment
   const built = state.wallets.builtPayment
 

--- a/shared/wallets/create-account/container.js
+++ b/shared/wallets/create-account/container.js
@@ -1,12 +1,12 @@
 // @flow
 import {capitalize} from 'lodash-es'
-import {connect, compose, withStateHandlers, type TypedState} from '../../util/container'
+import {connect, compose, withStateHandlers} from '../../util/container'
 import * as Constants from '../../constants/wallets'
 import * as WalletsGen from '../../actions/wallets-gen'
 import {anyWaiting} from '../../constants/waiting'
 import CreateAccount from '.'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => ({
+const mapStateToProps = (state, {routeProps}) => ({
   createNewAccountError: state.wallets.createNewAccountError,
   error: state.wallets.accountNameError,
   nameValidationState: state.wallets.accountNameValidationState,

--- a/shared/wallets/export-secret-key/container.js
+++ b/shared/wallets/export-secret-key/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import * as Constants from '../../constants/wallets'
 import * as Types from '../../constants/types/wallets'
 import * as WalletsGen from '../../actions/wallets-gen'
@@ -9,7 +9,7 @@ export type OwnProps = {
   accountID: Types.AccountID,
 }
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const accountID = routeProps.get('accountID')
   const walletName = routeProps.get('walletName')
   const secretKey = Constants.getSecretKey(state, accountID).stringValue()

--- a/shared/wallets/link-existing/container.js
+++ b/shared/wallets/link-existing/container.js
@@ -1,12 +1,12 @@
 // @flow
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as Constants from '../../constants/wallets'
 import {anyWaiting} from '../../constants/waiting'
 import HiddenString from '../../util/hidden-string'
 import {Wrapper as LinkExisting} from '.'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   keyError: state.wallets.secretKeyError,
   linkExistingAccountError: state.wallets.linkExistingAccountError,
   nameError: state.wallets.accountNameError,

--- a/shared/wallets/receive-modal/container.js
+++ b/shared/wallets/receive-modal/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import * as Constants from '../../constants/wallets'
 import * as Types from '../../constants/types/wallets'
 import Receive from '.'
@@ -8,7 +8,7 @@ export type OwnProps = {
   accountID: Types.AccountID,
 }
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const accountID = routeProps.get('accountID')
   return {
     federatedAddress: Constants.getFederatedAddress(state, accountID),

--- a/shared/wallets/send-form/asset-input/container.js
+++ b/shared/wallets/send-form/asset-input/container.js
@@ -1,9 +1,9 @@
 // @flow
 import AssetInput from '.'
 import * as WalletsGen from '../../../actions/wallets-gen'
-import {compose, connect, setDisplayName, type TypedState} from '../../../util/container'
+import {compose, connect, setDisplayName} from '../../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   displayUnit: state.wallets.buildingPayment.currency,
   inputPlaceholder: '0.00',
   bottomLabel: '', // TODO

--- a/shared/wallets/send-form/available/container.js
+++ b/shared/wallets/send-form/available/container.js
@@ -1,12 +1,12 @@
 // @flow
 import Available from '.'
-import {compose, connect, setDisplayName, type TypedState} from '../../../util/container'
+import {compose, connect, setDisplayName} from '../../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   amountErrMsg: state.wallets.builtPayment.amountErrMsg,
 })
 
-const mapDispatchToProps = (dispatch) => ({})
+const mapDispatchToProps = dispatch => ({})
 
 export default compose(
   connect(

--- a/shared/wallets/send-form/body/container.js
+++ b/shared/wallets/send-form/body/container.js
@@ -1,9 +1,9 @@
 // @flow
 import Body from '.'
-import {compose, connect, setDisplayName, type TypedState} from '../../../util/container'
+import {compose, connect, setDisplayName} from '../../../util/container'
 import {bannerLevelToBackground} from '../../../constants/wallets'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   banners: state.wallets.builtPayment.banners,
 })
 

--- a/shared/wallets/send-form/container.js
+++ b/shared/wallets/send-form/container.js
@@ -1,9 +1,9 @@
 // @flow
 import SendForm from '.'
 import * as WalletsGen from '../../actions/wallets-gen'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({})
+const mapStateToProps = state => ({})
 
 const mapDispatchToProps = (dispatch, {navigateUp}) => ({
   onClose: () => dispatch(WalletsGen.createAbandonPayment()),

--- a/shared/wallets/send-form/footer/container.js
+++ b/shared/wallets/send-form/footer/container.js
@@ -3,9 +3,9 @@ import Footer from '.'
 import * as Route from '../../../actions/route-tree'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import * as Constants from '../../../constants/wallets'
-import {compose, connect, setDisplayName, type TypedState} from '../../../util/container'
+import {compose, connect, setDisplayName} from '../../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   disabled: !state.wallets.builtPayment.readyToSend,
   worthDescription: state.wallets.builtPayment.worthDescription,
 })

--- a/shared/wallets/send-form/note-and-memo/container.js
+++ b/shared/wallets/send-form/note-and-memo/container.js
@@ -1,10 +1,10 @@
 // @flow
 import NoteAndMemo from '.'
 import * as WalletsGen from '../../../actions/wallets-gen'
-import {compose, connect, setDisplayName, type TypedState} from '../../../util/container'
+import {compose, connect, setDisplayName} from '../../../util/container'
 import HiddenString from '../../../util/hidden-string'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const recipientType = state.wallets.buildingPayment.recipientType
   const built = state.wallets.builtPayment
   const building = state.wallets.buildingPayment

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -14,9 +14,9 @@ import {
 } from '../../../constants/wallets'
 import {stringToAccountID, type Account as StateAccount} from '../../../constants/types/wallets'
 import {anyWaiting} from '../../../constants/waiting'
-import {compose, connect, setDisplayName, type TypedState} from '../../../util/container'
+import {compose, connect, setDisplayName} from '../../../util/container'
 
-const mapStateToPropsKeybaseUser = (state: TypedState) => {
+const mapStateToPropsKeybaseUser = state => {
   const build = state.wallets.buildingPayment
   const built = state.wallets.builtPayment
 
@@ -46,7 +46,7 @@ const ConnectedParticipantsKeybaseUser = compose(
   setDisplayName('ParticipantsKeybaseUser')
 )(ParticipantsKeybaseUser)
 
-const mapStateToPropsStellarPublicKey = (state: TypedState) => {
+const mapStateToPropsStellarPublicKey = state => {
   const build = state.wallets.buildingPayment
   const built = state.wallets.builtPayment
 
@@ -83,7 +83,7 @@ const makeAccount = (stateAccount: StateAccount) => ({
   unknown: stateAccount === unknownAccount,
 })
 
-const mapStateToPropsOtherAccount = (state: TypedState) => {
+const mapStateToPropsOtherAccount = state => {
   const build = state.wallets.buildingPayment
 
   const fromAccount = makeAccount(getAccount(state, stringToAccountID(build.from)))
@@ -123,7 +123,7 @@ const ConnectedParticipantsOtherAccount = compose(
   setDisplayName('ParticipantsOtherAccount')
 )(ParticipantsOtherAccount)
 
-const mapStateToPropsChooser = (state: TypedState) => {
+const mapStateToPropsChooser = state => {
   const recipientType = state.wallets.buildingPayment.recipientType
   return {recipientType}
 }

--- a/shared/wallets/send-form/root-container.js
+++ b/shared/wallets/send-form/root-container.js
@@ -1,8 +1,8 @@
 // @flow
 import Root from './root'
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 
-const mapStateToProps = (state: TypedState) => ({})
+const mapStateToProps = state => ({})
 
 const mapDispatchToProps = (dispatch, {navigateUp}) => ({})
 

--- a/shared/wallets/transaction-details/container.js
+++ b/shared/wallets/transaction-details/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {connect, compose, type TypedState} from '../../util/container'
+import {connect, compose} from '../../util/container'
 import {HeaderHoc} from '../../common-adapters'
 import * as Constants from '../../constants/wallets'
 import * as Types from '../../constants/types/wallets'
@@ -8,7 +8,7 @@ import * as WalletsGen from '../../actions/wallets-gen'
 import {getFullname} from '../../constants/users'
 import TransactionDetails from '.'
 
-const mapStateToProps = (state: TypedState, ownProps) => {
+const mapStateToProps = (state, ownProps) => {
   const you = state.config.username || ''
   const accountID = ownProps.routeProps.get('accountID')
   const paymentID = ownProps.routeProps.get('paymentID')

--- a/shared/wallets/transaction/container.js
+++ b/shared/wallets/transaction/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import * as Constants from '../../constants/wallets'
 import * as Types from '../../constants/types/wallets'
 import * as ProfileGen from '../../actions/profile-gen'
@@ -12,7 +12,7 @@ export type OwnProps = {
   paymentID: Types.PaymentID,
 }
 
-const mapStateToProps = (state: TypedState, ownProps: OwnProps) => ({
+const mapStateToProps = (state, ownProps: OwnProps) => ({
   _transaction: Constants.getPayment(state, ownProps.accountID, ownProps.paymentID),
   _you: state.config.username,
 })

--- a/shared/wallets/wallet-list/container.js
+++ b/shared/wallets/wallet-list/container.js
@@ -2,10 +2,10 @@
 import {WalletList, type Props} from '.'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as RouteTree from '../../actions/route-tree'
-import {connect, type TypedState, isMobile} from '../../util/container'
+import {connect, isMobile} from '../../util/container'
 import {getAccountIDs} from '../../constants/wallets'
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = state => ({
   accounts: getAccountIDs(state),
 })
 

--- a/shared/wallets/wallet-list/wallet-row/container.js
+++ b/shared/wallets/wallet-list/wallet-row/container.js
@@ -1,11 +1,11 @@
 // @flow
 import {WalletRow, type Props} from '.'
-import {connect, type TypedState, isMobile} from '../../../util/container'
+import {connect, isMobile} from '../../../util/container'
 import {getAccount, getSelectedAccount} from '../../../constants/wallets'
 import {createSelectAccount} from '../../../actions/wallets-gen'
 import {type AccountID} from '../../../constants/types/wallets'
 
-const mapStateToProps = (state: TypedState, ownProps: {accountID: AccountID}) => {
+const mapStateToProps = (state, ownProps: {accountID: AccountID}) => {
   const account = getAccount(state, ownProps.accountID)
   const name = account.name
   const me = state.config.username || ''

--- a/shared/wallets/wallet/container.js
+++ b/shared/wallets/wallet/container.js
@@ -1,12 +1,12 @@
 // @flow
-import {connect, type TypedState} from '../../util/container'
+import {connect} from '../../util/container'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as Constants from '../../constants/wallets'
 import * as Types from '../../constants/types/wallets'
 
 import Wallet from '.'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const accountID = Constants.getSelectedAccount(state)
   return {
     accountID,

--- a/shared/wallets/wallet/header/container.js
+++ b/shared/wallets/wallet/header/container.js
@@ -1,11 +1,11 @@
 // @flow
-import {connect, type TypedState, isMobile} from '../../../util/container'
+import {connect, isMobile} from '../../../util/container'
 import * as Constants from '../../../constants/wallets'
 import * as Types from '../../../constants/types/wallets'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import Header from '.'
 
-const mapStateToProps = (state: TypedState) => {
+const mapStateToProps = state => {
   const selectedAccount = Constants.getAccount(state)
   return {
     accountID: selectedAccount.accountID,

--- a/shared/wallets/wallet/settings/container.js
+++ b/shared/wallets/wallet/settings/container.js
@@ -6,14 +6,13 @@ import {
   lifecycle,
   setDisplayName,
   safeSubmit,
-  type TypedState,
 } from '../../../util/container'
 import {anyWaiting} from '../../../constants/waiting'
 import * as Constants from '../../../constants/wallets'
 import * as Types from '../../../constants/types/wallets'
 import * as WalletsGen from '../../../actions/wallets-gen'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const accountID = routeProps.get('accountID')
   const account = Constants.getAccount(state, accountID)
   const name = account.name || Constants.getAccountName(account) || accountID || account.accountID

--- a/shared/wallets/wallet/settings/popups/really-remove-account/container.js
+++ b/shared/wallets/wallet/settings/popups/really-remove-account/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {compose, connect, setDisplayName, type TypedState} from '../../../../../util/container'
+import {compose, connect, setDisplayName} from '../../../../../util/container'
 import * as Constants from '../../../../../constants/wallets'
 import * as ConfigGen from '../../../../../actions/config-gen'
 import * as WalletsGen from '../../../../../actions/wallets-gen'
@@ -7,7 +7,7 @@ import * as Types from '../../../../../constants/types/wallets'
 import {anyWaiting} from '../../../../../constants/waiting'
 import ReallyRemoveAccountPopup from '.'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const accountID = routeProps.get('accountID')
   const secretKey = Constants.getSecretKey(state, accountID).stringValue()
 

--- a/shared/wallets/wallet/settings/popups/remove-account/container.js
+++ b/shared/wallets/wallet/settings/popups/remove-account/container.js
@@ -4,13 +4,12 @@ import {
   connect,
   setDisplayName,
   safeSubmitPerMount,
-  type TypedState,
 } from '../../../../../util/container'
 import * as Constants from '../../../../../constants/wallets'
 import * as Types from '../../../../../constants/types/wallets'
 import RemoveAccountPopup from '.'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const accountID = routeProps.get('accountID')
   const account = Constants.getAccount(state, accountID)
 

--- a/shared/wallets/wallet/settings/popups/rename-account/container.js
+++ b/shared/wallets/wallet/settings/popups/rename-account/container.js
@@ -1,13 +1,13 @@
 // @flow
 import {capitalize} from 'lodash-es'
-import {connect, compose, withStateHandlers, type TypedState} from '../../../../../util/container'
+import {connect, compose, withStateHandlers} from '../../../../../util/container'
 import * as Constants from '../../../../../constants/wallets'
 import * as Types from '../../../../../constants/types/wallets'
 import * as WalletsGen from '../../../../../actions/wallets-gen'
 import {anyWaiting} from '../../../../../constants/waiting'
 import RenameAccount from '.'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const accountID = routeProps.get('accountID')
   const selectedAccount = Constants.getAccount(state, accountID)
   return {

--- a/shared/wallets/wallet/settings/popups/set-default/container.js
+++ b/shared/wallets/wallet/settings/popups/set-default/container.js
@@ -1,12 +1,12 @@
 // @flow
-import {compose, connect, setDisplayName, type TypedState} from '../../../../../util/container'
+import {compose, connect, setDisplayName} from '../../../../../util/container'
 import * as Constants from '../../../../../constants/wallets'
 import * as Types from '../../../../../constants/types/wallets'
 import * as WalletsGen from '../../../../../actions/wallets-gen'
 import {anyWaiting} from '../../../../../constants/waiting'
 import SetDefaultAccountPopup from '.'
 
-const mapStateToProps = (state: TypedState, {routeProps}) => {
+const mapStateToProps = (state, {routeProps}) => {
   const accountID = routeProps.get('accountID')
 
   return {


### PR DESCRIPTION
@keybase/react-hackers this removes typedstate from being a type we explicitly have to use in mapStateToProps. with the updated typing in our util/container this is the expected type of that function so it serves no purpose