### PR TITLE
format image/video attachments with title on the bottom

### DIFF
--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -219,7 +219,7 @@ func (r *AttachmentHTTPSrv) serveVideoHostPage(ctx context.Context, w http.Respo
 						  }
 					</script>
 				</head>
-				<body style="margin: 0px">
+				<body style="margin: 0px; background-color: rgba(0,0,0,0.05)">
 					<video id="vid" style="width: 100%%" poster="%s" src="%s" preload="none" playsinline webkit-playsinline />
 				</body>
 			</html>

--- a/shared/chat/conversation/messages/attachment/image/image-render.native.js
+++ b/shared/chat/conversation/messages/attachment/image/image-render.native.js
@@ -55,7 +55,7 @@ export class ImageRender extends React.Component<Props> {
         onLoad={this.props.onLoad}
         source={{uri: this.props.src}}
         style={this.props.style}
-        resizeMode="contain"
+        resizeMode="cover"
       />
     )
   }

--- a/shared/chat/conversation/messages/attachment/image/index.js
+++ b/shared/chat/conversation/messages/attachment/image/index.js
@@ -81,8 +81,7 @@ class ImageAttachment extends React.PureComponent<Props, State> {
           <Kb.Box
             style={Kb.iconCastPlatformStyles(
               Styles.collapseStyles([
-                styles.loading,
-                !this.state.loaded && styles.spinner,
+                styles.backgroundContainer,
                 {
                   width: this.props.width + 6,
                   minHeight: !this.state.loaded ? this.props.height : 0,
@@ -112,12 +111,19 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                     },
                   ])}
                 />
-                {this.state.loaded &&
-                  this.props.title.length > 0 && (
-                    <Kb.Text type="Body" style={styles.title}>
-                      {this.props.title}
-                    </Kb.Text>
-                  )}
+                {this.props.title.length > 0 && (
+                  <Kb.Text
+                    type="Body"
+                    style={Styles.collapseStyles([
+                      styles.title,
+                      {
+                        marginTop: !this.state.loaded && !isMobile ? this.props.height : undefined,
+                      },
+                    ])}
+                  >
+                    {this.props.title}
+                  </Kb.Text>
+                )}
               </React.Fragment>
             )}
             <Kb.Box
@@ -228,13 +234,14 @@ const styles = Styles.styleSheetCreate({
   imageContainer: {
     ...Styles.globalStyles.flexBoxColumn,
     alignItems: 'flex-start',
-    padding: Styles.globalMargins.xtiny,
+    paddingTop: Styles.globalMargins.xtiny,
+    paddingBottom: Styles.globalMargins.xtiny,
     width: '100%',
   },
   link: {
     color: Styles.globalColors.black_60,
   },
-  loading: {
+  backgroundContainer: {
     backgroundColor: Styles.globalColors.black_05,
     borderRadius: Styles.globalMargins.xtiny,
     maxWidth: 330,
@@ -271,18 +278,6 @@ const styles = Styles.styleSheetCreate({
     color: Styles.globalColors.black_40,
     marginRight: Styles.globalMargins.tiny,
   },
-  spinner: Styles.platformStyles({
-    isElectron: {
-      ...Styles.globalStyles.flexBoxColumn,
-      alignItems: 'center',
-    },
-    isMobile: {
-      ...Styles.globalStyles.flexBoxCenter,
-      alignItems: 'center',
-      flex: 1,
-      margin: 'auto',
-    },
-  }),
   title: Styles.platformStyles({
     isElectron: {
       wordBreak: 'break-word',

--- a/shared/chat/conversation/messages/attachment/image/index.js
+++ b/shared/chat/conversation/messages/attachment/image/index.js
@@ -85,8 +85,7 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                 !this.state.loaded && styles.spinner,
                 {
                   width: this.props.width + 6,
-                  maxWidth: this.props.width + 6,
-                  minHeight: 200,
+                  minHeight: !this.state.loaded ? 200 : 0,
                   borderRadius: 5,
                   backgroundColor: Styles.globalColors.lightGrey,
                 },
@@ -94,17 +93,7 @@ class ImageAttachment extends React.PureComponent<Props, State> {
             )}
           >
             {!!this.props.path && (
-              <Kb.Box
-                style={Styles.collapseStyles([
-                  styles.image,
-                  {
-                    opacity: this.state.loaded ? 1 : 0,
-                    width: this.props.width + 6,
-                    maxWidth: this.props.width + 6,
-                    minHeight: 200,
-                  },
-                ])}
-              >
+              <React.Fragment>
                 <ImageRender
                   ref={ref => {
                     this.imageRef = ref
@@ -118,61 +107,60 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                   style={Styles.collapseStyles([
                     styles.image,
                     {
-                      position: 'relative',
                       opacity: this.state.loaded ? 1 : 0,
                       borderRadius: 5,
-                      backgroundColor: this.state.loaded ? undefined : Styles.globalColors.fastBlank,
                       margin: 3,
                     },
                   ])}
                 />
-                {this.props.title.length > 0 && (
-                  <Kb.Text type="Body" style={styles.title}>
-                    {this.props.title}
-                  </Kb.Text>
-                )}
-                <Kb.Box
-                  style={Styles.collapseStyles([
-                    {
-                      position: 'absolute',
-                      top: 0,
-                      left: 0,
-                      width: this.props.width,
-                      height: this.props.height,
-                    },
-                  ])}
-                >
-                  {!!this.props.showButton &&
-                    !this.state.playingVideo && (
-                      <Kb.Icon
-                        type={this.props.showButton === 'play' ? 'icon-play-64' : 'icon-film-64'}
-                        style={Kb.iconCastPlatformStyles(styles.playButton)}
-                      />
-                    )}
-                  {this.props.videoDuration.length > 0 &&
-                    !this.state.playingVideo &&
-                    this.state.loaded && (
-                      <Kb.Box style={styles.durationContainer}>
-                        <Kb.Text type={'BodyTinyBold'} style={styles.durationText}>
-                          {this.props.videoDuration}
-                        </Kb.Text>
-                      </Kb.Box>
-                    )}
-                  {!!this.props.arrowColor && (
-                    <Kb.Box style={styles.downloadedIconWrapper}>
-                      <Kb.Icon
-                        type="iconfont-download"
-                        style={Kb.iconCastPlatformStyles(styles.downloadIcon)}
-                        color={this.props.arrowColor}
-                      />
-                    </Kb.Box>
+                {this.state.loaded &&
+                  this.props.title.length > 0 && (
+                    <Kb.Text type="Body" style={styles.title}>
+                      {this.props.title}
+                    </Kb.Text>
                   )}
-                  {(!this.state.loaded || this.state.loadingVideo === 'loading') && (
-                    <Kb.ProgressIndicator style={styles.progress} />
-                  )}
-                </Kb.Box>
-              </Kb.Box>
+              </React.Fragment>
             )}
+            <Kb.Box
+              style={Styles.collapseStyles([
+                {
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: this.props.width,
+                  height: this.props.height,
+                },
+              ])}
+            >
+              {!!this.props.showButton &&
+                !this.state.playingVideo && (
+                  <Kb.Icon
+                    type={this.props.showButton === 'play' ? 'icon-play-64' : 'icon-film-64'}
+                    style={Kb.iconCastPlatformStyles(styles.playButton)}
+                  />
+                )}
+              {this.props.videoDuration.length > 0 &&
+                !this.state.playingVideo &&
+                this.state.loaded && (
+                  <Kb.Box style={styles.durationContainer}>
+                    <Kb.Text type={'BodyTinyBold'} style={styles.durationText}>
+                      {this.props.videoDuration}
+                    </Kb.Text>
+                  </Kb.Box>
+                )}
+              {!!this.props.arrowColor && (
+                <Kb.Box style={styles.downloadedIconWrapper}>
+                  <Kb.Icon
+                    type="iconfont-download"
+                    style={Kb.iconCastPlatformStyles(styles.downloadIcon)}
+                    color={this.props.arrowColor}
+                  />
+                </Kb.Box>
+              )}
+              {(!this.state.loaded || this.state.loadingVideo === 'loading') && (
+                <Kb.ProgressIndicator style={styles.progress} />
+              )}
+            </Kb.Box>
           </Kb.Box>
           <Kb.Box style={styles.progressContainer}>
             {!this.props.onShowInFinder && (

--- a/shared/chat/conversation/messages/attachment/image/index.js
+++ b/shared/chat/conversation/messages/attachment/image/index.js
@@ -110,6 +110,9 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                       opacity: this.state.loaded ? 1 : 0,
                       borderRadius: 5,
                       margin: 3,
+                      width: this.props.width,
+                      height: this.props.height,
+                      backgroundColor: this.state.loaded ? undefined : Styles.globalColors.fastBlank,
                     },
                   ])}
                 />
@@ -123,10 +126,8 @@ class ImageAttachment extends React.PureComponent<Props, State> {
             )}
             <Kb.Box
               style={Styles.collapseStyles([
+                styles.absoluteContainer,
                 {
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
                   width: this.props.width,
                   height: this.props.height,
                 },
@@ -221,6 +222,11 @@ const styles = Styles.styleSheetCreate({
     maxWidth: 320,
     position: 'relative',
   },
+  absoluteContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+  },
   imageContainer: {
     ...Styles.globalStyles.flexBoxColumn,
     alignItems: 'flex-start',
@@ -247,25 +253,18 @@ const styles = Styles.styleSheetCreate({
     right: '50%',
     top: '50%',
   },
-  progress: Styles.platformStyles({
-    isElectron: {
-      bottom: '50%',
-      left: '50%',
-      marginBottom: -24,
-      marginLeft: -24,
-      marginRight: -24,
-      marginTop: -24,
-      position: 'absolute',
-      right: '50%',
-      top: '50%',
-      width: 48,
-    },
-    isMobile: {
-      margin: 'auto',
-      position: 'absolute',
-      width: 48,
-    },
-  }),
+  progress: {
+    bottom: '50%',
+    left: '50%',
+    marginBottom: -24,
+    marginLeft: -24,
+    marginRight: -24,
+    marginTop: -24,
+    position: 'absolute',
+    right: '50%',
+    top: '50%',
+    width: 48,
+  },
   progressContainer: {
     ...Styles.globalStyles.flexBoxRow,
     alignItems: 'center',
@@ -291,6 +290,9 @@ const styles = Styles.styleSheetCreate({
       wordBreak: 'break-word',
       padding: 5,
       display: 'block',
+    },
+    isMobile: {
+      padding: 5,
     },
   }),
 })

--- a/shared/chat/conversation/messages/attachment/image/index.js
+++ b/shared/chat/conversation/messages/attachment/image/index.js
@@ -85,9 +85,7 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                 !this.state.loaded && styles.spinner,
                 {
                   width: this.props.width + 6,
-                  minHeight: !this.state.loaded ? 200 : 0,
-                  borderRadius: 5,
-                  backgroundColor: Styles.globalColors.lightGrey,
+                  minHeight: !this.state.loaded ? this.props.height : 0,
                 },
               ])
             )}
@@ -108,8 +106,6 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                     styles.image,
                     {
                       opacity: this.state.loaded ? 1 : 0,
-                      borderRadius: 5,
-                      margin: 3,
                       width: this.props.width,
                       height: this.props.height,
                       backgroundColor: this.state.loaded ? undefined : Styles.globalColors.fastBlank,
@@ -221,6 +217,8 @@ const styles = Styles.styleSheetCreate({
     backgroundColor: Styles.globalColors.fastBlank,
     maxWidth: 320,
     position: 'relative',
+    borderRadius: Styles.globalMargins.xtiny,
+    margin: 3,
   },
   absoluteContainer: {
     position: 'absolute',
@@ -239,7 +237,7 @@ const styles = Styles.styleSheetCreate({
   loading: {
     backgroundColor: Styles.globalColors.black_05,
     borderRadius: Styles.globalMargins.xtiny,
-    maxWidth: 320,
+    maxWidth: 330,
     position: 'relative',
   },
   playButton: {

--- a/shared/chat/conversation/messages/attachment/image/index.js
+++ b/shared/chat/conversation/messages/attachment/image/index.js
@@ -78,68 +78,99 @@ class ImageAttachment extends React.PureComponent<Props, State> {
           onMouseEnter={this._onMouseEnter}
           onMouseLeave={this._onMouseLeave}
         >
-          <Kb.Text type="BodySemibold" style={styles.title}>
-            {this.props.title}
-          </Kb.Text>
           <Kb.Box
             style={Kb.iconCastPlatformStyles(
               Styles.collapseStyles([
                 styles.loading,
                 !this.state.loaded && styles.spinner,
                 {
-                  height: this.props.height,
-                  width: this.props.width,
+                  width: this.props.width + 6,
+                  maxWidth: this.props.width + 6,
+                  minHeight: 200,
+                  borderRadius: 5,
+                  backgroundColor: Styles.globalColors.lightGrey,
                 },
               ])
             )}
           >
             {!!this.props.path && (
-              <ImageRender
-                ref={ref => {
-                  this.imageRef = ref
-                }}
-                src={this.props.path}
-                videoSrc={this.props.fullPath}
-                onLoad={this._setLoaded}
-                onLoadedVideo={this._setVideoLoaded}
-                loaded={this.state.loaded}
-                inlineVideoPlayable={this.props.inlineVideoPlayable}
+              <Kb.Box
                 style={Styles.collapseStyles([
                   styles.image,
                   {
-                    height: this.props.height,
                     opacity: this.state.loaded ? 1 : 0,
-                    width: this.props.width,
+                    width: this.props.width + 6,
+                    maxWidth: this.props.width + 6,
+                    minHeight: 200,
                   },
                 ])}
-              />
-            )}
-            {(!this.state.loaded || this.state.loadingVideo === 'loading') && (
-              <Kb.ProgressIndicator style={styles.progress} />
-            )}
-            {!!this.props.showButton &&
-              !this.state.playingVideo && (
-                <Kb.Icon
-                  type={this.props.showButton === 'play' ? 'icon-play-64' : 'icon-film-64'}
-                  style={Kb.iconCastPlatformStyles(styles.playButton)}
+              >
+                <ImageRender
+                  ref={ref => {
+                    this.imageRef = ref
+                  }}
+                  src={this.props.path}
+                  videoSrc={this.props.fullPath}
+                  onLoad={this._setLoaded}
+                  onLoadedVideo={this._setVideoLoaded}
+                  loaded={this.state.loaded}
+                  inlineVideoPlayable={this.props.inlineVideoPlayable}
+                  style={Styles.collapseStyles([
+                    styles.image,
+                    {
+                      position: 'relative',
+                      opacity: this.state.loaded ? 1 : 0,
+                      borderRadius: 5,
+                      backgroundColor: this.state.loaded ? undefined : Styles.globalColors.fastBlank,
+                      margin: 3,
+                    },
+                  ])}
                 />
-              )}
-            {this.props.videoDuration.length > 0 &&
-              !this.state.playingVideo &&
-              this.state.loaded && (
-                <Kb.Box style={styles.durationContainer}>
-                  <Kb.Text type={'BodyTinyBold'} style={styles.durationText}>
-                    {this.props.videoDuration}
+                {this.props.title.length > 0 && (
+                  <Kb.Text type="Body" style={styles.title}>
+                    {this.props.title}
                   </Kb.Text>
+                )}
+                <Kb.Box
+                  style={Styles.collapseStyles([
+                    {
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: this.props.width,
+                      height: this.props.height,
+                    },
+                  ])}
+                >
+                  {!!this.props.showButton &&
+                    !this.state.playingVideo && (
+                      <Kb.Icon
+                        type={this.props.showButton === 'play' ? 'icon-play-64' : 'icon-film-64'}
+                        style={Kb.iconCastPlatformStyles(styles.playButton)}
+                      />
+                    )}
+                  {this.props.videoDuration.length > 0 &&
+                    !this.state.playingVideo &&
+                    this.state.loaded && (
+                      <Kb.Box style={styles.durationContainer}>
+                        <Kb.Text type={'BodyTinyBold'} style={styles.durationText}>
+                          {this.props.videoDuration}
+                        </Kb.Text>
+                      </Kb.Box>
+                    )}
+                  {!!this.props.arrowColor && (
+                    <Kb.Box style={styles.downloadedIconWrapper}>
+                      <Kb.Icon
+                        type="iconfont-download"
+                        style={Kb.iconCastPlatformStyles(styles.downloadIcon)}
+                        color={this.props.arrowColor}
+                      />
+                    </Kb.Box>
+                  )}
+                  {(!this.state.loaded || this.state.loadingVideo === 'loading') && (
+                    <Kb.ProgressIndicator style={styles.progress} />
+                  )}
                 </Kb.Box>
-              )}
-            {!!this.props.arrowColor && (
-              <Kb.Box style={styles.downloadedIconWrapper}>
-                <Kb.Icon
-                  type="iconfont-download"
-                  style={Kb.iconCastPlatformStyles(styles.downloadIcon)}
-                  color={this.props.arrowColor}
-                />
               </Kb.Box>
             )}
           </Kb.Box>
@@ -270,6 +301,8 @@ const styles = Styles.styleSheetCreate({
   title: Styles.platformStyles({
     isElectron: {
       wordBreak: 'break-word',
+      padding: 5,
+      display: 'block',
     },
   }),
 })

--- a/shared/chat/conversation/messages/attachment/image/index.js
+++ b/shared/chat/conversation/messages/attachment/image/index.js
@@ -83,6 +83,9 @@ class ImageAttachment extends React.PureComponent<Props, State> {
               Styles.collapseStyles([
                 styles.backgroundContainer,
                 {
+                  // Add 6 extra width to the background container to create the background
+                  // for the image. We use this in conjunction with the margin to reliaby
+                  // center the image in the background container.
                   width: this.props.width + 6,
                   minHeight: !this.state.loaded ? this.props.height : 0,
                 },
@@ -220,10 +223,10 @@ const styles = Styles.styleSheetCreate({
     paddingRight: 3,
   },
   image: {
+    ...Styles.globalStyles.rounded,
     backgroundColor: Styles.globalColors.fastBlank,
     maxWidth: 320,
     position: 'relative',
-    borderRadius: Styles.globalMargins.xtiny,
     margin: 3,
   },
   absoluteContainer: {
@@ -243,7 +246,7 @@ const styles = Styles.styleSheetCreate({
   },
   backgroundContainer: {
     backgroundColor: Styles.globalColors.black_05,
-    borderRadius: Styles.globalMargins.xtiny,
+    borderRadius: Styles.borderRadius,
     maxWidth: 330,
     position: 'relative',
   },
@@ -279,13 +282,12 @@ const styles = Styles.styleSheetCreate({
     marginRight: Styles.globalMargins.tiny,
   },
   title: Styles.platformStyles({
+    common: {
+      padding: 5,
+    },
     isElectron: {
       wordBreak: 'break-word',
-      padding: 5,
       display: 'block',
-    },
-    isMobile: {
-      padding: 5,
     },
   }),
 })

--- a/shared/react-native/ios/KeybaseShare/ShareViewController.m
+++ b/shared/react-native/ios/KeybaseShare/ShareViewController.m
@@ -170,7 +170,7 @@ const BOOL isSimulator = NO;
   AVAssetImageGenerator *generateImg = [[AVAssetImageGenerator alloc] initWithAsset:asset];
   [generateImg setAppliesPreferredTrackTransform:YES];
   CGImageRef cgOriginal = [generateImg copyCGImageAtTime:time actualTime:NULL error:&error];
-  [generateImg setMaximumSize:CGSizeMake(320, 320)];
+  [generateImg setMaximumSize:CGSizeMake(640, 640)];
   CGImageRef cgThumb = [generateImg copyCGImageAtTime:time actualTime:NULL error:&error];
   int duration = CMTimeGetSeconds([asset duration]);
   UIImage* original = [UIImage imageWithCGImage:cgOriginal];
@@ -204,7 +204,7 @@ const BOOL isSimulator = NO;
   NSDictionary* opts = [[NSDictionary alloc] initWithObjectsAndKeys:
                         (id)kCFBooleanTrue, (id)kCGImageSourceCreateThumbnailWithTransform,
                         (id)kCFBooleanTrue, (id)kCGImageSourceCreateThumbnailFromImageAlways,
-                        [NSNumber numberWithInt:320], (id)kCGImageSourceThumbnailMaxPixelSize,
+                        [NSNumber numberWithInt:640], (id)kCGImageSourceThumbnailMaxPixelSize,
                         nil];
   CGImageRef image = CGImageSourceCreateThumbnailAtIndex(is, 0, (CFDictionaryRef)opts);
   UIImage* scaled = [UIImage imageWithCGImage:image];

--- a/shared/react-native/ios/KeybaseShare/ShareViewController.m
+++ b/shared/react-native/ios/KeybaseShare/ShareViewController.m
@@ -170,7 +170,7 @@ const BOOL isSimulator = NO;
   AVAssetImageGenerator *generateImg = [[AVAssetImageGenerator alloc] initWithAsset:asset];
   [generateImg setAppliesPreferredTrackTransform:YES];
   CGImageRef cgOriginal = [generateImg copyCGImageAtTime:time actualTime:NULL error:&error];
-  [generateImg setMaximumSize:CGSizeMake(640, 640)];
+  [generateImg setMaximumSize:CGSizeMake(320, 320)];
   CGImageRef cgThumb = [generateImg copyCGImageAtTime:time actualTime:NULL error:&error];
   int duration = CMTimeGetSeconds([asset duration]);
   UIImage* original = [UIImage imageWithCGImage:cgOriginal];
@@ -204,7 +204,7 @@ const BOOL isSimulator = NO;
   NSDictionary* opts = [[NSDictionary alloc] initWithObjectsAndKeys:
                         (id)kCFBooleanTrue, (id)kCGImageSourceCreateThumbnailWithTransform,
                         (id)kCFBooleanTrue, (id)kCGImageSourceCreateThumbnailFromImageAlways,
-                        [NSNumber numberWithInt:640], (id)kCGImageSourceThumbnailMaxPixelSize,
+                        [NSNumber numberWithInt:320], (id)kCGImageSourceThumbnailMaxPixelSize,
                         nil];
   CGImageRef image = CGImageSourceCreateThumbnailAtIndex(is, 0, (CFDictionaryRef)opts);
   UIImage* scaled = [UIImage imageWithCGImage:image];


### PR DESCRIPTION
@cecileboucheron @adamjspooner @malgorithms 

So I brought up the idea of moving the caption of the image to the bottom of the preview in #design the other day, and I was just curious how it could play out. I put together this PR today to try it out, and I think it is a nice improvement. I attached a screenshot to this PR, but it would probably be most useful to just try out the branch and see what you think. This is more in the style of WhatsApp, which I think has a nice presentation for picture attachments. This also fixes up some of the absolute positioning elements (like the download button, which is in the screenshot being fixed). 

![image](https://user-images.githubusercontent.com/1250314/46920219-f5d35500-cfb8-11e8-860a-8d8e7bd39250.png)
