### PR TITLE
fix clickable area on screens with tooltips

### DIFF
--- a/shared/common-adapters/with-tooltip.desktop.js
+++ b/shared/common-adapters/with-tooltip.desktop.js
@@ -21,7 +21,7 @@ class WithTooltip extends React.Component<Props, State> {
     this.setState({mouseIn: true})
   }
   _onMouseLeave = () => {
-    this.setState({mouseIn: false})
+    this.setState({mouseIn: false, visible: false})
   }
   _setAttachmentRef = attachmentRef => (this._attachmentRef = attachmentRef)
   componentDidUpdate(prevProps: Props, prevState: State) {

--- a/shared/common-adapters/with-tooltip.desktop.js
+++ b/shared/common-adapters/with-tooltip.desktop.js
@@ -8,11 +8,13 @@ import {type Props} from './with-tooltip'
 
 type State = {
   mouseIn: boolean,
+  visible: boolean,
 }
 
 class WithTooltip extends React.Component<Props, State> {
   state = {
     mouseIn: false,
+    visible: false,
   }
   _attachmentRef: ?React.Component<any> = null
   _onMouseEnter = () => {
@@ -22,6 +24,16 @@ class WithTooltip extends React.Component<Props, State> {
     this.setState({mouseIn: false})
   }
   _setAttachmentRef = attachmentRef => (this._attachmentRef = attachmentRef)
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (!prevState.mouseIn && this.state.mouseIn) {
+      // Set visible after Toast is mounted, to trigger transition on opacity.
+      // Note that we aren't doing anything to make ease out work. We don't
+      // keep Toast mounted all the time (which would make this unnecessary)
+      // because in that case the position of the overlay can be messed up when
+      // not visible, causing ghost unclickable areas.
+      this.setState({visible: true})
+    }
+  }
   render() {
     return (
       <>
@@ -34,19 +46,21 @@ class WithTooltip extends React.Component<Props, State> {
         >
           {this.props.children}
         </Box>
-        <Toast
-          containerStyle={Styles.collapseStyles([
-            styles.container,
-            this.props.multiline && styles.containerMultiline,
-          ])}
-          visible={!!this.props.text && this.state.mouseIn}
-          attachTo={() => this._attachmentRef}
-          position={this.props.position || 'top center'}
-        >
-          <Text type="BodySmall" style={Styles.collapseStyles([styles.text, this.props.textStyle])}>
-            {this.props.text}
-          </Text>
-        </Toast>
+        {this.state.mouseIn && (
+          <Toast
+            containerStyle={Styles.collapseStyles([
+              styles.container,
+              this.props.multiline && styles.containerMultiline,
+            ])}
+            visible={!!this.props.text && this.state.visible}
+            attachTo={() => this._attachmentRef}
+            position={this.props.position || 'top center'}
+          >
+            <Text type="BodySmall" style={Styles.collapseStyles([styles.text, this.props.textStyle])}>
+              {this.props.text}
+            </Text>
+          </Toast>
+        )}
       </>
     )
   }


### PR DESCRIPTION
@buoyad I brought these back. Although they do follow scrolling now, it seems when they are not visible they still have weird positions, and block clickable areas in various places. Also even if their positions are correct, they'd still block some clickable area around the target that triggered. So it seems better to just not mount it when the mouse of out.

This fixes the bug where when user is at Files tab, tab buttons' clickable areas became smaller.