### PR TITLE
upak lite teamloader 2

### DIFF
--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -800,7 +800,16 @@ func (f failingUpak) LoadLite(arg libkb.LoadUserArg) (ret *keybase1.UPKLiteV1All
 	require.Fail(f.t, "LoadLite call")
 	return nil, nil
 }
-func (f failingUpak) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (*keybase1.UserPlusKeysV2, *keybase1.UserPlusKeysV2AllIncarnations, *keybase1.PublicKeyV2NaCl, error) {
+func (f failingUpak) LoadV2OrLite(arg libkb.LoadUserArg) (ret *keybase1.UPKLiteAllIncarnationsInterface, user *libkb.User, err error) {
+	require.Fail(f.t, "LoadV2OrLite call")
+	return nil, nil, nil
+}
+func (f failingUpak) LookupUsernameUPAKLite(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error) {
+	require.Fail(f.t, "LookupUsernameUPAKLite call")
+	return "", nil
+}
+func (f failingUpak) LoadKey(ctx context.Context, uid keybase1.UID, kid keybase1.KID, includeLowKeys bool) (ret *keybase1.UPKLiteInterface,
+	upak *keybase1.UPKLiteAllIncarnationsInterface, key *keybase1.PublicKeyV2NaCl, err error) {
 	require.Fail(f.t, "LoadKeyV2")
 	return nil, nil, nil, nil
 }

--- a/go/client/cmd_upak.go
+++ b/go/client/cmd_upak.go
@@ -82,7 +82,7 @@ func (c *cmdUPAK) Run() error {
 		if v != keybase1.UPAKVersion_V2 {
 			return fmt.Errorf("didn't get UPAK v2")
 		}
-		upk2, _ := res.V2().FindKID(c.kid)
+		upk2, _ := libkb.FindKID(res.V2(), c.kid)
 		if upk2 == nil {
 			return fmt.Errorf("key %s wasn't found", c.kid)
 		}

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -482,7 +482,7 @@ func TestLoadAfterAcctResetCORE6943(t *testing.T) {
 	fu.LoginOrBust(tc)
 
 	// Make sure that we can load the eldest key from the previous subchain
-	_, _, _, err = tc.G.GetUPAKLoader().LoadKey(context.TODO(), fu.UID(), upak1.Base.DeviceKeys[0].KID, false)
+	_, _, _, err = tc.G.GetUPAKLoader().LoadKey(context.TODO(), fu.UID(), upak1.Base.DeviceKeys[0].KID, true)
 
 	if err != nil {
 		t.Fatal("Failed to load a UID/KID combo from first incarnation")

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -482,7 +482,7 @@ func TestLoadAfterAcctResetCORE6943(t *testing.T) {
 	fu.LoginOrBust(tc)
 
 	// Make sure that we can load the eldest key from the previous subchain
-	_, _, _, err = tc.G.GetUPAKLoader().LoadKeyV2(context.TODO(), fu.UID(), upak1.Base.DeviceKeys[0].KID)
+	_, _, _, err = tc.G.GetUPAKLoader().LoadKey(context.TODO(), fu.UID(), upak1.Base.DeviceKeys[0].KID, false)
 
 	if err != nil {
 		t.Fatal("Failed to load a UID/KID combo from first incarnation")

--- a/go/libkb/upak_lite.go
+++ b/go/libkb/upak_lite.go
@@ -13,6 +13,10 @@ func LoadUPAKLite(arg LoadUserArg) (ret *keybase1.UPKLiteV1AllIncarnations, err 
 	uid := arg.uid
 	m := arg.m
 
+	if m.G().Env.GetRunMode() == ProductionRunMode {
+		return nil, fmt.Errorf("UPAK lites are currently disabled in production.")
+	}
+
 	user, err := LoadUserFromServer(m, uid, nil)
 	if err != nil {
 		return nil, err

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -20,14 +20,16 @@ type UPAKLoader interface {
 	Load(arg LoadUserArg) (ret *keybase1.UserPlusAllKeys, user *User, err error)
 	LoadV2(arg LoadUserArg) (ret *keybase1.UserPlusKeysV2AllIncarnations, user *User, err error)
 	LoadLite(arg LoadUserArg) (ret *keybase1.UPKLiteV1AllIncarnations, err error)
+	LoadV2OrLite(arg LoadUserArg) (ret *keybase1.UPKLiteAllIncarnationsInterface, user *User, err error)
 	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
 	LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID) (keybase1.UserPlusKeys, error)
-	LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (*keybase1.UserPlusKeysV2, *keybase1.UserPlusKeysV2AllIncarnations, *keybase1.PublicKeyV2NaCl, error)
+	LoadKey(ctx context.Context, uid keybase1.UID, kid keybase1.KID, includeLowKeys bool) (*keybase1.UPKLiteInterface, *keybase1.UPKLiteAllIncarnationsInterface, *keybase1.PublicKeyV2NaCl, error)
 	Invalidate(ctx context.Context, uid keybase1.UID)
 	LoadDeviceKey(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (upak *keybase1.UserPlusAllKeys, deviceKey *keybase1.PublicKey, revoked *keybase1.RevokedKey, err error)
 	LoadUPAKWithDeviceID(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (*keybase1.UserPlusKeysV2AllIncarnations, error)
 	LookupUsername(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error)
 	LookupUsernameUPAK(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error)
+	LookupUsernameUPAKLite(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error)
 	LookupUID(ctx context.Context, un NormalizedUsername) (keybase1.UID, error)
 	LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, did keybase1.DeviceID) (username NormalizedUsername, deviceName string, deviceType string, err error)
 	ListFollowedUIDs(ctx context.Context, uid keybase1.UID) ([]keybase1.UID, error)
@@ -252,6 +254,26 @@ func (u *CachedUPAKLoader) PutUserToCache(ctx context.Context, user *User) error
 	return err
 }
 
+func (u *CachedUPAKLoader) LoadV2OrLite(arg LoadUserArg) (*keybase1.UPKLiteAllIncarnationsInterface, *User, error) {
+	var upak keybase1.UPKLiteAllIncarnationsInterface
+	var user *User
+	if arg.upakLite {
+		upakLite, err := u.LoadLite(arg)
+		if err != nil || upakLite == nil {
+			return nil, nil, err
+		}
+		upak = *upakLite
+	} else {
+		upakV2, u, err := u.LoadV2(arg)
+		if err != nil || upakV2 == nil {
+			return nil, nil, err
+		}
+		upak = *upakV2
+		user = u
+	}
+	return &upak, user, nil
+}
+
 func (u *CachedUPAKLoader) LoadLite(arg LoadUserArg) (*keybase1.UPKLiteV1AllIncarnations, error) {
 	m, tbs := arg.m.WithTimeBuckets()
 	arg.m = m
@@ -471,6 +493,7 @@ func (u *CachedUPAKLoader) LoadV2(arg LoadUserArg) (*keybase1.UserPlusKeysV2AllI
 	m, tbs := arg.m.WithTimeBuckets()
 	arg.m = m
 	defer tbs.Record("CachedUPAKLoader.LoadV2")()
+
 	return u.loadWithInfo(arg, nil, nil, true)
 }
 
@@ -525,11 +548,14 @@ func (u *CachedUPAKLoader) LoadUserPlusKeys(ctx context.Context, uid keybase1.UI
 	return up, nil
 }
 
-// LoadKeyV2 looks through all incarnations for the user and returns the incarnation with the given
+// LoadKey looks through all incarnations for the user and returns the incarnation with the given
 // KID, as well as the Key data associated with that KID. It picks the latest such
 // incarnation if there are multiple.
-func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (ret *keybase1.UserPlusKeysV2,
-	upak *keybase1.UserPlusKeysV2AllIncarnations, key *keybase1.PublicKeyV2NaCl, err error) {
+// A high key is a key that can sign a link (so, device and PGP sibkeys). If you might be looking for a subkey, e.g.,
+// specify includeLowKeys=true. But if not, LoadKey will load the skipchain instead, which only contains high keys,
+// and consumes less bandwidth.
+func (u *CachedUPAKLoader) LoadKey(ctx context.Context, uid keybase1.UID, kid keybase1.KID, includeLowKeys bool) (ret *keybase1.UPKLiteInterface, upak *keybase1.UPKLiteAllIncarnationsInterface, key *keybase1.PublicKeyV2NaCl, err error) {
+
 	ctx = WithLogTag(ctx, "LK") // Load key
 	defer u.G().CVTraceTimed(ctx, VLog0, fmt.Sprintf("LoadKeyV2 uid:%s,kid:%s", uid, kid), func() error { return err })()
 	ctx, tbs := u.G().CTimeBuckets(ctx)
@@ -544,34 +570,64 @@ func (u *CachedUPAKLoader) LoadKeyV2(ctx context.Context, uid keybase1.UID, kid 
 	// It should be that a ForcePoll is good enough, but in some rare cases,
 	// people have cached values for previous pre-reset user incarnations that
 	// were incorrect. So clobber over that if it comes to it.
-	attempts := []LoadUserArg{
-		argBase,
-		argBase.WithForcePoll(true),
-		argBase.WithForceReload(),
+	var attempts []LoadUserArg
+	if includeLowKeys {
+		attempts = []LoadUserArg{
+			argBase,
+			argBase.WithForcePoll(true),
+			argBase.WithForceReload(),
+		}
+	} else {
+		attempts = []LoadUserArg{argBase.ForUPAKLite()}
 	}
 
 	for i, arg := range attempts {
-
 		if i > 0 {
 			u.G().VDL.CLogf(ctx, VLog0, "| reloading with arg: %s", arg.String())
 		}
 
-		upak, _, err := u.LoadV2(arg)
+		upak, _, err := u.LoadV2OrLite(arg)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 		if upak == nil {
 			return nil, nil, nil, fmt.Errorf("Nil user, nil error from LoadUser")
 		}
-
-		ret, key := upak.FindKID(kid)
+		ret, key := FindKID(*upak, kid)
 		if key != nil {
-			u.G().VDL.CLogf(ctx, VLog1, "- found kid in UPAK: %v", ret.Uid)
+			u.G().VDL.CLogf(ctx, VLog1, "- found kid in UPAK: %v", (*ret).GetUID())
 			return ret, upak, key, nil
 		}
 	}
 
-	return nil, nil, nil, NotFoundError{Msg: "Not found: Key for user"}
+	return nil, nil, nil, NotFoundError{Msg: "Not found during LoadKey: Key for user"}
+}
+
+// FindKID finds the Key and user incarnation that most recently used this KID.
+// It is possible for users to use the same KID across incarnations (though definitely
+// not condoned or encouraged). In that case, we'll give the most recent use.
+func FindKID(u keybase1.UPKLiteAllIncarnationsInterface, kid keybase1.KID) (*keybase1.UPKLiteInterface, *keybase1.PublicKeyV2NaCl) {
+	ret, ok := u.GetCurrent().GetDeviceKeys()[kid]
+	if ok {
+		current := u.GetCurrent()
+		return &current, &ret
+	}
+
+	for i := len(u.GetPastIncarnations()) - 1; i >= 0; i-- {
+		prev := u.GetPastIncarnations()[i]
+		ret, ok = prev.GetDeviceKeys()[kid]
+		if ok {
+			return &prev, &ret
+		}
+	}
+	return nil, nil
+}
+
+// HasKID returns true if u has the given KID in any of its incarnations.
+// Useful for deciding if we should repoll a stale UPAK in the UPAK loader.
+func HasKID(u keybase1.UPKLiteAllIncarnationsInterface, kid keybase1.KID) bool {
+	incarnation, _ := FindKID(u, kid)
+	return (incarnation != nil)
 }
 
 func (u *CachedUPAKLoader) Invalidate(ctx context.Context, uid keybase1.UID) {
@@ -682,6 +738,16 @@ func (u *CachedUPAKLoader) LookupUsernameUPAK(ctx context.Context, uid keybase1.
 	return ret, err
 }
 
+// LookupUsername should use a map later on when caching is done, but for now it doesn't.
+func (u *CachedUPAKLoader) LookupUsernameUPAKLite(ctx context.Context, uid keybase1.UID) (NormalizedUsername, error) {
+	arg := NewLoadUserByUIDArg(ctx, u.G(), uid).WithStaleOK(true).WithPublicKeyOptional().ForUPAKLite()
+	upak, err := u.G().GetUPAKLoader().LoadLite(arg)
+	if err != nil {
+		return "", nil
+	}
+	return NewNormalizedUsername(upak.Current.Username), nil
+}
+
 // LookupUID is a verified map of username -> UID. IT calls into the resolver, which gives un untrusted
 // UID, but verifies with the UPAK loader that the mapping UID -> username is correct.
 func (u *CachedUPAKLoader) LookupUID(ctx context.Context, un NormalizedUsername) (keybase1.UID, error) {
@@ -784,7 +850,7 @@ func (u *CachedUPAKLoader) loadUserWithKIDAndInfo(ctx context.Context, uid keyba
 	for _, arg := range attempts {
 		u.G().VDL.CLogf(ctx, VLog0, "| loadWithUserKIDAndInfo: loading with arg: %s", arg.String())
 		ret, _, err = u.loadWithInfo(arg, info, nil, false)
-		if err == nil && ret != nil && (kid.IsNil() || ret.HasKID(kid)) {
+		if err == nil && ret != nil && (kid.IsNil() || HasKID(ret, kid)) {
 			u.G().VDL.CLogf(ctx, VLog0, "| loadWithUserKIDAndInfo: UID/KID %s/%s found", uid, kid)
 			return ret, nil
 		}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2606,6 +2606,7 @@ func (se *SelectorEntry) UnmarshalJSON(b []byte) error {
 	}
 	ok1, ok2 = m["contents"]
 	if ok1 && ok2 {
+		se.IsContents = true
 		return nil
 	}
 	return fmt.Errorf("invalid selector (not recognized)")

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1473,31 +1473,6 @@ func (u UserPlusKeys) FindKID(needle KID) *PublicKey {
 	return nil
 }
 
-// FindKID finds the Key and user incarnation that most recently used this KID.
-// It is possible for users to use the same KID across incarnations (though definitely
-// not condoned or encouraged). In that case, we'll give the most recent use.
-func (u UserPlusKeysV2AllIncarnations) FindKID(kid KID) (*UserPlusKeysV2, *PublicKeyV2NaCl) {
-	ret, ok := u.Current.DeviceKeys[kid]
-	if ok {
-		return &u.Current, &ret
-	}
-	for i := len(u.PastIncarnations) - 1; i >= 0; i-- {
-		prev := u.PastIncarnations[i]
-		ret, ok = prev.DeviceKeys[kid]
-		if ok {
-			return &prev, &ret
-		}
-	}
-	return nil, nil
-}
-
-// HasKID returns true if u has the given KID in any of its incarnations.
-// Useful for deciding if we should repoll a stale UPAK in the UPAK loader.
-func (u UserPlusKeysV2AllIncarnations) HasKID(kid KID) bool {
-	incarnation, _ := u.FindKID(kid)
-	return (incarnation != nil)
-}
-
 func (u UserPlusKeysV2) FindDeviceKey(needle KID) *PublicKeyV2NaCl {
 	for _, k := range u.DeviceKeys {
 		if k.Base.Kid.Equal(needle) {
@@ -2174,6 +2149,17 @@ func (u UserPlusKeysV2AllIncarnations) ToUserVersion() UserVersion {
 	return u.Current.ToUserVersion()
 }
 
+func (u UPKLiteV1) ToUserVersion() UserVersion {
+	return UserVersion{
+		Uid:         u.Uid,
+		EldestSeqno: u.EldestSeqno,
+	}
+}
+
+func (u UPKLiteV1AllIncarnations) ToUserVersion() UserVersion {
+	return u.Current.ToUserVersion()
+}
+
 // Can return nil.
 func (u UserPlusKeysV2) GetLatestPerUserKey() *PerUserKey {
 	if len(u.PerUserKeys) > 0 {
@@ -2620,7 +2606,6 @@ func (se *SelectorEntry) UnmarshalJSON(b []byte) error {
 	}
 	ok1, ok2 = m["contents"]
 	if ok1 && ok2 {
-		se.IsContents = true
 		return nil
 	}
 	return fmt.Errorf("invalid selector (not recognized)")
@@ -2644,4 +2629,60 @@ func (d FastTeamData) ID() TeamID {
 
 func (d FastTeamData) IsPublic() bool {
 	return d.Chain.Public
+}
+
+type UPKLiteInterface interface {
+	GetUID() UID
+	GetDeviceKeys() map[KID]PublicKeyV2NaCl
+	ToUserVersion() UserVersion
+}
+
+type UPKLiteAllIncarnationsInterface interface {
+	GetCurrent() UPKLiteInterface
+	GetPastIncarnations() []UPKLiteInterface
+	GetSeqnoLinkIDs() map[Seqno]LinkID
+}
+
+func (u UPKLiteV1) GetDeviceKeys() map[KID]PublicKeyV2NaCl {
+	return u.DeviceKeys
+}
+
+func (u UPKLiteV1AllIncarnations) GetCurrent() UPKLiteInterface {
+	return u.Current
+}
+
+func (u UPKLiteV1AllIncarnations) GetPastIncarnations() []UPKLiteInterface {
+	ret := make([]UPKLiteInterface, len(u.PastIncarnations))
+	for idx, incarnation := range u.PastIncarnations {
+		ret[idx] = incarnation
+	}
+	return ret
+}
+
+func (u UPKLiteV1) GetUID() UID {
+	return u.Uid
+}
+
+func (u UPKLiteV1AllIncarnations) GetSeqnoLinkIDs() map[Seqno]LinkID {
+	return u.SeqnoLinkIDs
+}
+
+func (u UserPlusKeysV2) GetDeviceKeys() map[KID]PublicKeyV2NaCl {
+	return u.DeviceKeys
+}
+
+func (u UserPlusKeysV2AllIncarnations) GetCurrent() UPKLiteInterface {
+	return u.Current
+}
+
+func (u UserPlusKeysV2AllIncarnations) GetPastIncarnations() []UPKLiteInterface {
+	ret := make([]UPKLiteInterface, len(u.PastIncarnations))
+	for idx, incarnation := range u.PastIncarnations {
+		ret[idx] = incarnation
+	}
+	return ret
+}
+
+func (u UserPlusKeysV2AllIncarnations) GetSeqnoLinkIDs() map[Seqno]LinkID {
+	return u.SeqnoLinkIDs
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2633,6 +2633,7 @@ func (d FastTeamData) IsPublic() bool {
 
 type UPKLiteInterface interface {
 	GetUID() UID
+	GetEldestSeqno() Seqno
 	GetDeviceKeys() map[KID]PublicKeyV2NaCl
 	ToUserVersion() UserVersion
 }
@@ -2663,8 +2664,16 @@ func (u UPKLiteV1) GetUID() UID {
 	return u.Uid
 }
 
+func (u UPKLiteV1) GetEldestSeqno() Seqno {
+	return u.EldestSeqno
+}
+
 func (u UPKLiteV1AllIncarnations) GetSeqnoLinkIDs() map[Seqno]LinkID {
 	return u.SeqnoLinkIDs
+}
+
+func (u UserPlusKeysV2) GetEldestSeqno() Seqno {
+	return u.EldestSeqno
 }
 
 func (u UserPlusKeysV2) GetDeviceKeys() map[KID]PublicKeyV2NaCl {

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -76,7 +76,7 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 			return "", err
 		}
 		kid := keybase1.KIDFromString(args[1])
-		_, _, _, err = t.G().GetUPAKLoader().LoadKey(ctx, uid, kid, false)
+		_, _, _, err = t.G().GetUPAKLoader().LoadKey(ctx, uid, kid, true)
 		return "", err
 	case "eldest":
 		if len(args) != 1 {

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -76,7 +76,7 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 			return "", err
 		}
 		kid := keybase1.KIDFromString(args[1])
-		_, _, _, err = t.G().GetUPAKLoader().LoadKeyV2(ctx, uid, kid)
+		_, _, _, err = t.G().GetUPAKLoader().LoadKey(ctx, uid, kid, false)
 		return "", err
 	case "eldest":
 		if len(args) != 1 {

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1061,7 +1061,7 @@ func TestTeamSignedByRevokedDevice(t *testing.T) {
 
 	t.Logf("bob should see alice's key is revoked")
 	{
-		_, _, pubKey, err := bob.tc.G.GetUPAKLoader().LoadKeyV2(context.TODO(), alice.uid, revokedKID)
+		_, _, pubKey, err := bob.tc.G.GetUPAKLoader().LoadKey(context.TODO(), alice.uid, revokedKID, false)
 		require.NoError(t, err)
 		t.Logf("%v", spew.Sdump(pubKey))
 		require.NotNil(t, pubKey.Base.Revocation, "key should be revoked: %v", revokedKID)
@@ -1143,7 +1143,7 @@ func TestTeamSignedByRevokedDevice2(t *testing.T) {
 
 	t.Logf("bob should see alice's key is revoked")
 	{
-		_, _, pubKey, err := bob.tc.G.GetUPAKLoader().LoadKeyV2(context.TODO(), alice.uid, revokedKID)
+		_, _, pubKey, err := bob.tc.G.GetUPAKLoader().LoadKey(context.TODO(), alice.uid, revokedKID, false)
 		require.NoError(t, err)
 		t.Logf("%v", spew.Sdump(pubKey))
 		require.NotNil(t, pubKey.Base.Revocation, "key should be revoked: %v", revokedKID)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1061,7 +1061,7 @@ func TestTeamSignedByRevokedDevice(t *testing.T) {
 
 	t.Logf("bob should see alice's key is revoked")
 	{
-		_, _, pubKey, err := bob.tc.G.GetUPAKLoader().LoadKey(context.TODO(), alice.uid, revokedKID, false)
+		_, _, pubKey, err := bob.tc.G.GetUPAKLoader().LoadKey(context.TODO(), alice.uid, revokedKID, true)
 		require.NoError(t, err)
 		t.Logf("%v", spew.Sdump(pubKey))
 		require.NotNil(t, pubKey.Base.Revocation, "key should be revoked: %v", revokedKID)
@@ -1143,7 +1143,7 @@ func TestTeamSignedByRevokedDevice2(t *testing.T) {
 
 	t.Logf("bob should see alice's key is revoked")
 	{
-		_, _, pubKey, err := bob.tc.G.GetUPAKLoader().LoadKey(context.TODO(), alice.uid, revokedKID, false)
+		_, _, pubKey, err := bob.tc.G.GetUPAKLoader().LoadKey(context.TODO(), alice.uid, revokedKID, true)
 		require.NoError(t, err)
 		t.Logf("%v", spew.Sdump(pubKey))
 		require.NotNil(t, pubKey.Base.Revocation, "key should be revoked: %v", revokedKID)

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -272,7 +272,7 @@ func TestV2Compressed(t *testing.T) {
 	bob := tt.users[2]
 	bobG := bob.tc.G
 	for _, dk := range upk.DeviceKeys {
-		user, upak, _, err := bobG.GetUPAKLoader().LoadKeyV2(ctx, wong.uid, dk.KID)
+		user, upak, _, err := bobG.GetUPAKLoader().LoadKey(ctx, wong.uid, dk.KID, true)
 		require.NoError(t, err)
 		require.NotNil(t, user)
 		require.NotNil(t, upak)

--- a/go/teams/chatmessaging.go
+++ b/go/teams/chatmessaging.go
@@ -58,12 +58,12 @@ func SendChatInviteWelcomeMessage(ctx context.Context, g *libkb.GlobalContext, t
 		return false
 	}
 
-	inviterName, err := g.GetUPAKLoader().LookupUsername(ctx, inviter)
+	inviterName, err := g.GetUPAKLoader().LookupUsernameUPAKLite(ctx, inviter)
 	if err != nil {
 		g.Log.CDebugf(ctx, "sendChatInviteWelcomeMessage: failed to lookup inviter username: %s", err)
 		return false
 	}
-	inviteeName, err := g.GetUPAKLoader().LookupUsername(ctx, invitee)
+	inviteeName, err := g.GetUPAKLoader().LookupUsernameUPAKLite(ctx, invitee)
 	if err != nil {
 		g.Log.CDebugf(ctx, "sendChatInviteWelcomeMessage: failed to lookup invitee username: %s", err)
 		return false

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -100,7 +100,7 @@ func sweepOpenTeamResetAndDeletedMembers(ctx context.Context, g *libkb.GlobalCon
 			WithUID(u.Uid).
 			WithPublicKeyOptional().
 			WithForcePoll(true)
-		upak, _, err := g.GetUPAKLoader().LoadV2(arg)
+		upak, err := g.GetUPAKLoader().LoadLite(arg)
 		if err == nil {
 			resetUsers[u.Uid] = seqnoAndStatus{
 				eldestSeqno: upak.Current.EldestSeqno,

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -824,7 +824,7 @@ func (l *TeamLoader) userPreload(ctx context.Context, links []*ChainLinkUnpacked
 			for uid := range uidSet {
 				wg.Add(1)
 				go func(uid keybase1.UID) {
-					_, _, err := l.G().GetUPAKLoader().LoadV2(
+					_, err := l.G().GetUPAKLoader().LoadLite(
 						libkb.NewLoadUserArg(l.G()).WithUID(uid).WithPublicKeyOptional().WithNetContext(ctx))
 					if err != nil {
 						l.G().Log.CDebugf(ctx, "error preloading uid %v", uid)
@@ -837,7 +837,7 @@ func (l *TeamLoader) userPreload(ctx context.Context, links []*ChainLinkUnpacked
 			}
 		} else {
 			for uid := range uidSet {
-				_, _, err := l.G().GetUPAKLoader().LoadV2(
+				_, err := l.G().GetUPAKLoader().LoadLite(
 					libkb.NewLoadUserArg(l.G()).WithUID(uid).WithPublicKeyOptional().WithNetContext(ctx))
 				if err != nil {
 					l.G().Log.CDebugf(ctx, "error preloading uid %v", uid)

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -172,7 +172,7 @@ func (l *LoaderContextG) getMe(ctx context.Context) (res keybase1.UserVersion, e
 func (l *LoaderContextG) lookupEldestSeqno(ctx context.Context, uid keybase1.UID) (keybase1.Seqno, error) {
 	// Lookup the latest eldest seqno for that uid.
 	// This value may come from a cache.
-	upak, err := loadUPAK2(ctx, l.G(), uid, false /*forcePoll */)
+	upak, err := loadUPAKLite(ctx, l.G(), uid, false /*forcePoll */)
 	if err != nil {
 		return keybase1.Seqno(1), err
 	}
@@ -232,7 +232,7 @@ func (l *LoaderContextG) merkleLookupTripleAtHashMeta(ctx context.Context, isPub
 
 func (l *LoaderContextG) forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error) {
 	arg := libkb.NewLoadUserArg(l.G()).WithNetContext(ctx).WithUID(uid).WithForcePoll(true)
-	upak, _, err := l.G().GetUPAKLoader().LoadV2(arg)
+	upak, err := l.G().GetUPAKLoader().LoadLite(arg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/loadkeycache.go
+++ b/go/teams/loadkeycache.go
@@ -42,7 +42,7 @@ func (c *loadKeyCache) loadKeyV2(mctx libkb.MetaContext, uid keybase1.UID, kid k
 	}
 
 	// Load the user. LoadKeyV2 handles punching through the cache when needed.
-	user, upakPtr, _, err := mctx.G().GetUPAKLoader().LoadKey(mctx.Ctx(), uid, kid, false)
+	user, upakPtr, _, err := mctx.G().GetUPAKLoader().LoadKey(mctx.Ctx(), uid, kid, true)
 	if err != nil {
 		return uv, pubKey, linkMap, err
 	}

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -134,6 +134,17 @@ func loadUPAK2(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, fo
 	return upak, err
 }
 
+func loadUPAKLite(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, forcePoll bool) (ret *keybase1.UPKLiteV1AllIncarnations, err error) {
+	defer g.CTrace(ctx, fmt.Sprintf("loadUPAKLite(%s)", uid), func() error { return err })()
+
+	arg := libkb.NewLoadUserArg(g).WithNetContext(ctx).WithUID(uid).WithPublicKeyOptional()
+	if forcePoll {
+		arg = arg.WithForcePoll(true)
+	}
+	upak, err := g.GetUPAKLoader().LoadLite(arg)
+	return upak, err
+}
+
 func parseSocialAssertion(m libkb.MetaContext, username string) (typ string, name string, err error) {
 	assertion, err := libkb.ParseAssertionURL(m.G().MakeAssertionContext(), username, false)
 	if err != nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1658,7 +1658,7 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 	if err != nil {
 		return res, err
 	}
-	upak, _, err := mctx.G().GetUPAKLoader().LoadV2(libkb.NewLoadUserArgWithMetaContext(mctx).
+	upak, err := mctx.G().GetUPAKLoader().LoadLite(libkb.NewLoadUserArgWithMetaContext(mctx).
 		WithUID(arg.Uid).
 		WithPublicKeyOptional().
 		WithForcePoll(false))
@@ -1666,12 +1666,12 @@ func FindNextMerkleRootAfterRemoval(mctx libkb.MetaContext, arg keybase1.FindNex
 		return res, err
 	}
 
-	vers, _ := upak.FindKID(arg.SigningKey)
+	vers, _ := libkb.FindKID(upak, arg.SigningKey)
 	if vers == nil {
 		return res, libkb.NotFoundError{Msg: fmt.Sprintf("KID %s not found for %s", arg.SigningKey, arg.Uid)}
 	}
 
-	uv := vers.ToUserVersion()
+	uv := (*vers).ToUserVersion()
 	logPoints := team.chain().inner.UserLog[uv]
 	demotionPredicate := func(p keybase1.UserLogPoint) bool {
 		if arg.AnyRoleAllowed {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -284,7 +284,7 @@ func (t *Team) ImplicitTeamDisplayName(ctx context.Context) (res keybase1.Implic
 	}
 	// Add the keybase owners
 	for _, member := range members.Owners {
-		name, err := t.G().GetUPAKLoader().LookupUsername(ctx, member.Uid)
+		name, err := t.G().GetUPAKLoader().LookupUsernameUPAKLite(ctx, member.Uid)
 		if err != nil {
 			return res, err
 		}
@@ -292,7 +292,7 @@ func (t *Team) ImplicitTeamDisplayName(ctx context.Context) (res keybase1.Implic
 	}
 	// Add the keybase readers
 	for _, member := range members.Readers {
-		name, err := t.G().GetUPAKLoader().LookupUsername(ctx, member.Uid)
+		name, err := t.G().GetUPAKLoader().LookupUsernameUPAKLite(ctx, member.Uid)
 		if err != nil {
 			return res, err
 		}


### PR DESCRIPTION
Failing tests are due stellar testnet outage. The "disable upak lite in prod" commit shows the change I made since you last looked at it.