### PR TITLE
buildPaymentAmountHelper better handling on non-XLM asset

### DIFF
--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -1099,6 +1099,9 @@ func (s *Server) buildPaymentAmountHelper(ctx context.Context, bpc stellar.Build
 		}
 		return res
 	case arg.Currency == nil:
+		if arg.Asset != nil {
+			res.asset = *arg.Asset
+		}
 		// Amount is of asset.
 		useAmount := "0"
 		if arg.Amount != "" {
@@ -1110,6 +1113,10 @@ func (s *Server) buildPaymentAmountHelper(ctx context.Context, bpc stellar.Build
 			res.amountOfAsset = arg.Amount
 			res.haveAmount = true
 			useAmount = arg.Amount
+		}
+		if !res.asset.IsNativeXLM() {
+			// If sending non-XLM asset, don't try to show a worth.
+			return res
 		}
 		// Attempt to show the converted amount in outside currency.
 		// Unlike when sending based on outside currency, conversion is not critical.


### PR DESCRIPTION
This wasn't right. Brought up by @songgao's PR, but shouldn't cause a conflict. Calling build with a non-XLM asset would have (I suspect) acted like calling it with XLM but now it notices and errors out as intended.