### PR TITLE
Fix payments going to 'history' after loading tx details

### DIFF
--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -105,7 +105,7 @@ export type _BuiltPayment = {
 export type StatusSimplified = 'none' | 'pending' | 'cancelable' | 'completed' | 'error' | 'unknown'
 
 export type PaymentDelta = 'none' | 'increase' | 'decrease'
-export type PaymentSection = 'pending' | 'history' // where does the payment go on the wallet screen
+export type PaymentSection = 'pending' | 'history' | 'none' // where does the payment go on the wallet screen
 export type _Payment = {
   amountDescription: string,
   delta: PaymentDelta,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -161,7 +161,7 @@ const makePayment: I.RecordFactory<Types._Payment> = I.Record({
   publicMemo: new HiddenString(''),
   publicMemoType: '',
   readState: 'read',
-  section: 'pending',
+  section: 'none',
   source: '',
   sourceAccountID: '',
   sourceType: '',
@@ -224,7 +224,7 @@ const paymentResultToPayment = (
 
 const paymentDetailResultToPayment = (p: RPCTypes.PaymentDetailsLocal) =>
   makePayment({
-    ...rpcPaymentToPaymentCommon(p, 'history'),
+    ...rpcPaymentToPaymentCommon(p),
     // Payment details have no unread field.
     readState: 'read',
     publicMemo: new HiddenString(p.publicNote),
@@ -234,7 +234,7 @@ const paymentDetailResultToPayment = (p: RPCTypes.PaymentDetailsLocal) =>
 
 const rpcPaymentToPaymentCommon = (
   p: RPCTypes.PaymentLocal | RPCTypes.PaymentDetailsLocal,
-  section: Types.PaymentSection
+  section?: Types.PaymentSection
 ) => {
   const sourceType = partyTypeToString[p.fromType]
   const targetType = partyTypeToString[p.toType]
@@ -248,13 +248,13 @@ const rpcPaymentToPaymentCommon = (
   )
   const serviceStatusSimplfied = statusSimplifiedToString[p.statusSimplified]
   return {
+    ...(section ? {section} : null),
     amountDescription: p.amountDescription,
     delta: balanceDeltaToString[p.delta],
     error: '',
     id: Types.rpcPaymentIDToPaymentID(p.id),
     note: new HiddenString(p.note),
     noteErr: new HiddenString(p.noteErr),
-    section,
     source,
     sourceAccountID: p.fromAccountID,
     sourceType,


### PR DESCRIPTION
PR fixes the following:
1. See tx in `Pending` section
2. Nav into details for that tx
3. Nav back; tx is now in `History`

r? @keybase/react-hackers 