### PR TITLE
Autofocus asset input on opening send form

### DIFF
--- a/shared/actions/search.js
+++ b/shared/actions/search.js
@@ -276,14 +276,14 @@ function* searchSuggestions({payload: {maxUsers, searchKey}}: SearchGen.SearchSu
   yield Saga.sequentially([
     Saga.put(
       EntitiesGen.createReplaceEntity({
-        keyPath: ['search', 'searchKeyToResults'],
-        entities: I.Map({[searchKey]: I.List(ids)}),
+        keyPath: ['search', 'searchKeyToShowSearchSuggestion'],
+        entities: I.Map({[searchKey]: true}),
       })
     ),
     Saga.put(
       EntitiesGen.createReplaceEntity({
-        keyPath: ['search', 'searchKeyToShowSearchSuggestion'],
-        entities: I.Map({[searchKey]: true}),
+        keyPath: ['search', 'searchKeyToResults'],
+        entities: I.Map({[searchKey]: I.List(ids)}),
       })
     ),
   ])

--- a/shared/search/user-input/container.js
+++ b/shared/search/user-input/container.js
@@ -216,7 +216,7 @@ const ConnectedUserInput = compose(
         this.props.onFocusInput()
       }
 
-      if (this.props.searchResultIds !== prevProps.searchResultIds) {
+      if (this.props.searchResultIds !== prevProps.searchResultIds && !this.props.showingSearchSuggestions) {
         this.props.onUpdateSelectedSearchResult(
           (this.props.searchResultIds && this.props.searchResultIds[0]) || null
         )

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -30,6 +30,7 @@ export class AssetInput extends React.Component<Props> {
           </Kb.Text>
         )}
         <Kb.NewInput
+          autoFocus={true}
           type="text"
           keyboardType="numeric"
           decoration={


### PR DESCRIPTION
Had to switch around some `replaceEntity`s in search actions so we could use `showingSearchSuggestions` to cancel focusing the to field input.
r? @keybase/react-hackers 