### PR TITLE
fix "update now"; show "Updating ..."; check again after update

### DIFF
--- a/shared/actions/config-gen.js
+++ b/shared/actions/config-gen.js
@@ -16,6 +16,7 @@ export const _avatarQueue = 'config:_avatarQueue'
 export const bootstrapStatusLoaded = 'config:bootstrapStatusLoaded'
 export const changedActive = 'config:changedActive'
 export const changedFocus = 'config:changedFocus'
+export const checkForUpdate = 'config:checkForUpdate'
 export const copyToClipboard = 'config:copyToClipboard'
 export const daemonError = 'config:daemonError'
 export const daemonHandshake = 'config:daemonHandshake'
@@ -36,7 +37,6 @@ export const logoutHandshake = 'config:logoutHandshake'
 export const logoutHandshakeWait = 'config:logoutHandshakeWait'
 export const mobileAppState = 'config:mobileAppState'
 export const openAppSettings = 'config:openAppSettings'
-export const outOfDate = 'config:outOfDate'
 export const pushLoaded = 'config:pushLoaded'
 export const restartHandshake = 'config:restartHandshake'
 export const setAccounts = 'config:setAccounts'
@@ -48,6 +48,7 @@ export const setupEngineListeners = 'config:setupEngineListeners'
 export const showMain = 'config:showMain'
 export const startHandshake = 'config:startHandshake'
 export const updateFollowing = 'config:updateFollowing'
+export const updateInfo = 'config:updateInfo'
 export const updateMenubarWindowID = 'config:updateMenubarWindowID'
 export const updateNow = 'config:updateNow'
 
@@ -64,6 +65,7 @@ type _BootstrapStatusLoadedPayload = $ReadOnly<{|
 |}>
 type _ChangedActivePayload = $ReadOnly<{|userActive: boolean|}>
 type _ChangedFocusPayload = $ReadOnly<{|appFocused: boolean|}>
+type _CheckForUpdatePayload = void
 type _CopyToClipboardPayload = $ReadOnly<{|text: string|}>
 type _DaemonErrorPayload = $ReadOnly<{|daemonError: ?Error|}>
 type _DaemonHandshakeDonePayload = void
@@ -97,10 +99,6 @@ type _LogoutHandshakeWaitPayload = $ReadOnly<{|
 type _LogoutPayload = void
 type _MobileAppStatePayload = $ReadOnly<{|nextAppState: 'active' | 'background' | 'inactive'|}>
 type _OpenAppSettingsPayload = void
-type _OutOfDatePayload = $ReadOnly<{|
-  critical: boolean,
-  message?: string,
-|}>
 type _PushLoadedPayload = $ReadOnly<{|pushLoaded: boolean|}>
 type _RestartHandshakePayload = void
 type _SetAccountsPayload = $ReadOnly<{|
@@ -129,6 +127,11 @@ type _StartHandshakePayload = void
 type _UpdateFollowingPayload = $ReadOnly<{|
   username: string,
   isTracking: boolean,
+|}>
+type _UpdateInfoPayload = $ReadOnly<{|
+  isOutOfDate: boolean,
+  critical: boolean,
+  message?: string,
 |}>
 type _UpdateMenubarWindowIDPayload = $ReadOnly<{|id: number|}>
 type _UpdateNowPayload = void
@@ -182,6 +185,7 @@ export const createSetupEngineListeners = (payload: _SetupEngineListenersPayload
 export const createBootstrapStatusLoaded = (payload: _BootstrapStatusLoadedPayload) => ({error: false, payload, type: bootstrapStatusLoaded})
 export const createChangedActive = (payload: _ChangedActivePayload) => ({error: false, payload, type: changedActive})
 export const createChangedFocus = (payload: _ChangedFocusPayload) => ({error: false, payload, type: changedFocus})
+export const createCheckForUpdate = (payload: _CheckForUpdatePayload) => ({error: false, payload, type: checkForUpdate})
 export const createCopyToClipboard = (payload: _CopyToClipboardPayload) => ({error: false, payload, type: copyToClipboard})
 export const createDaemonError = (payload: _DaemonErrorPayload) => ({error: false, payload, type: daemonError})
 export const createDebugDump = (payload: _DebugDumpPayload) => ({error: false, payload, type: debugDump})
@@ -194,7 +198,6 @@ export const createLoadedAvatars = (payload: _LoadedAvatarsPayload) => ({error: 
 export const createLoggedIn = (payload: _LoggedInPayload) => ({error: false, payload, type: loggedIn})
 export const createLoggedOut = (payload: _LoggedOutPayload) => ({error: false, payload, type: loggedOut})
 export const createMobileAppState = (payload: _MobileAppStatePayload) => ({error: false, payload, type: mobileAppState})
-export const createOutOfDate = (payload: _OutOfDatePayload) => ({error: false, payload, type: outOfDate})
 export const createPushLoaded = (payload: _PushLoadedPayload) => ({error: false, payload, type: pushLoaded})
 export const createSetAccounts = (payload: _SetAccountsPayload) => ({error: false, payload, type: setAccounts})
 export const createSetDeletedSelf = (payload: _SetDeletedSelfPayload) => ({error: false, payload, type: setDeletedSelf})
@@ -203,6 +206,7 @@ export const createSetOpenAtLogin = (payload: _SetOpenAtLoginPayload) => ({error
 export const createSetStartupDetails = (payload: _SetStartupDetailsPayload) => ({error: false, payload, type: setStartupDetails})
 export const createShowMain = (payload: _ShowMainPayload) => ({error: false, payload, type: showMain})
 export const createUpdateFollowing = (payload: _UpdateFollowingPayload) => ({error: false, payload, type: updateFollowing})
+export const createUpdateInfo = (payload: _UpdateInfoPayload) => ({error: false, payload, type: updateInfo})
 export const createUpdateMenubarWindowID = (payload: _UpdateMenubarWindowIDPayload) => ({error: false, payload, type: updateMenubarWindowID})
 export const createUpdateNow = (payload: _UpdateNowPayload) => ({error: false, payload, type: updateNow})
 export const create_avatarQueue = (payload: __avatarQueuePayload) => ({error: false, payload, type: _avatarQueue})
@@ -211,6 +215,7 @@ export const create_avatarQueue = (payload: __avatarQueuePayload) => ({error: fa
 export type BootstrapStatusLoadedPayload = $Call<typeof createBootstrapStatusLoaded, _BootstrapStatusLoadedPayload>
 export type ChangedActivePayload = $Call<typeof createChangedActive, _ChangedActivePayload>
 export type ChangedFocusPayload = $Call<typeof createChangedFocus, _ChangedFocusPayload>
+export type CheckForUpdatePayload = $Call<typeof createCheckForUpdate, _CheckForUpdatePayload>
 export type CopyToClipboardPayload = $Call<typeof createCopyToClipboard, _CopyToClipboardPayload>
 export type DaemonErrorPayload = $Call<typeof createDaemonError, _DaemonErrorPayload>
 export type DaemonHandshakeDonePayload = $Call<typeof createDaemonHandshakeDone, _DaemonHandshakeDonePayload>
@@ -231,7 +236,6 @@ export type LogoutHandshakeWaitPayload = $Call<typeof createLogoutHandshakeWait,
 export type LogoutPayload = $Call<typeof createLogout, _LogoutPayload>
 export type MobileAppStatePayload = $Call<typeof createMobileAppState, _MobileAppStatePayload>
 export type OpenAppSettingsPayload = $Call<typeof createOpenAppSettings, _OpenAppSettingsPayload>
-export type OutOfDatePayload = $Call<typeof createOutOfDate, _OutOfDatePayload>
 export type PushLoadedPayload = $Call<typeof createPushLoaded, _PushLoadedPayload>
 export type RestartHandshakePayload = $Call<typeof createRestartHandshake, _RestartHandshakePayload>
 export type SetAccountsPayload = $Call<typeof createSetAccounts, _SetAccountsPayload>
@@ -243,6 +247,7 @@ export type SetupEngineListenersPayload = $Call<typeof createSetupEngineListener
 export type ShowMainPayload = $Call<typeof createShowMain, _ShowMainPayload>
 export type StartHandshakePayload = $Call<typeof createStartHandshake, _StartHandshakePayload>
 export type UpdateFollowingPayload = $Call<typeof createUpdateFollowing, _UpdateFollowingPayload>
+export type UpdateInfoPayload = $Call<typeof createUpdateInfo, _UpdateInfoPayload>
 export type UpdateMenubarWindowIDPayload = $Call<typeof createUpdateMenubarWindowID, _UpdateMenubarWindowIDPayload>
 export type UpdateNowPayload = $Call<typeof createUpdateNow, _UpdateNowPayload>
 export type _avatarQueuePayload = $Call<typeof create_avatarQueue, __avatarQueuePayload>
@@ -253,6 +258,7 @@ export type Actions =
   | BootstrapStatusLoadedPayload
   | ChangedActivePayload
   | ChangedFocusPayload
+  | CheckForUpdatePayload
   | CopyToClipboardPayload
   | DaemonErrorPayload
   | DaemonHandshakeDonePayload
@@ -273,7 +279,6 @@ export type Actions =
   | LogoutPayload
   | MobileAppStatePayload
   | OpenAppSettingsPayload
-  | OutOfDatePayload
   | PushLoadedPayload
   | RestartHandshakePayload
   | SetAccountsPayload
@@ -285,6 +290,7 @@ export type Actions =
   | ShowMainPayload
   | StartHandshakePayload
   | UpdateFollowingPayload
+  | UpdateInfoPayload
   | UpdateMenubarWindowIDPayload
   | UpdateNowPayload
   | _avatarQueuePayload

--- a/shared/actions/json/config.json
+++ b/shared/actions/json/config.json
@@ -7,8 +7,7 @@
   ],
   "actions": {
     "setupEngineListeners": {
-      "_description":
-        "when sagas should start creating their incoming handlers / onConnect handlers"
+      "_description": "when sagas should start creating their incoming handlers / onConnect handlers"
     },
     "startHandshake": {
       "_description": "internal to config. should start the handshake process"
@@ -17,14 +16,12 @@
       "_description": "internal to config. should restart the handshake process"
     },
     "daemonHandshake": {
-      "_description":
-        "starting the connect process. Things that need to happen before we see the app should call daemonHandshakeWait",
+      "_description": "starting the connect process. Things that need to happen before we see the app should call daemonHandshakeWait",
       "firstTimeConnecting": "boolean",
       "version": "number"
     },
     "daemonHandshakeWait": {
-      "_description":
-        "subsystems that need to do things during boot need to call this to register that we should wait.",
+      "_description": "subsystems that need to do things during boot need to call this to register that we should wait.",
       "name": "string",
       "version": "number",
       "increment": "boolean",
@@ -38,13 +35,11 @@
       "_description": "someone wants to log out"
     },
     "logoutHandshake": {
-      "_description":
-        "starting the logout process. Things that need to happen before we see the app should call logoutHandshakeWait",
+      "_description": "starting the logout process. Things that need to happen before we see the app should call logoutHandshakeWait",
       "version": "number"
     },
     "logoutHandshakeWait": {
-      "_description":
-        "subsystems that need to do things during logout need to call this to register that we should wait.",
+      "_description": "subsystems that need to do things during logout need to call this to register that we should wait.",
       "name": "string",
       "version": "number",
       "increment": "boolean"
@@ -107,7 +102,8 @@
     "updateMenubarWindowID": {"id": "number"},
     "copyToClipboard": {"text": "string"},
     "_avatarQueue": {},
-    "outOfDate": {"critical": "boolean", "message?": "string"},
+    "checkForUpdate": {},
+    "updateInfo": {"isOutOfDate": "boolean", "critical": "boolean", "message?": "string"},
     "updateNow": {}
   }
 }

--- a/shared/actions/platform-specific/index.desktop.js
+++ b/shared/actions/platform-specific/index.desktop.js
@@ -212,7 +212,7 @@ const setupEngineListeners = () => {
       NotifyPopup('Client out of date!', {body}, 60 * 60)
       // This is from the API server. Consider notifications from API server
       // always critical.
-      return Saga.put(ConfigGen.createOutOfDate({critical: true, message: upgradeMsg}))
+      return Saga.put(ConfigGen.createUpdateInfo({isOutOfDate: true, critical: true, message: upgradeMsg}))
     },
   })
 }
@@ -247,15 +247,8 @@ const startOutOfDateCheckLoop = () =>
   Saga.call(function*() {
     while (1) {
       try {
-        const {status, message} = yield Saga.call(RPCTypes.configGetUpdateInfoRpcPromise)
-        if (status !== RPCTypes.configUpdateInfoStatus.upToDate) {
-          yield Saga.put(
-            ConfigGen.createOutOfDate({
-              critical: status === RPCTypes.configUpdateInfoStatus.criticallyOutOfDate,
-              message,
-            })
-          )
-        }
+        const toPut = yield Saga.call(checkForUpdate)
+        yield Saga.put(toPut)
         yield Saga.delay(3600 * 1000) // 1 hr
       } catch (err) {
         logger.warn('error getting update info: ', err)
@@ -264,7 +257,17 @@ const startOutOfDateCheckLoop = () =>
     }
   })
 
-const updateNow = () => RPCTypes.configStartUpdateIfNeededRpcPromise()
+const checkForUpdate = () =>
+  RPCTypes.configGetUpdateInfoRpcPromise().then(({status, message}) =>
+    ConfigGen.createUpdateInfo({
+      isOutOfDate: status !== RPCTypes.configUpdateInfoStatus.upToDate,
+      critical: status === RPCTypes.configUpdateInfoStatus.criticallyOutOfDate,
+      message,
+    })
+  )
+
+const updateNow = () =>
+  RPCTypes.configStartUpdateIfNeededRpcPromise().then(() => ConfigGen.createCheckForUpdate())
 
 export function* platformConfigSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.actionToAction(ConfigGen.setOpenAtLogin, writeElectronSettingsOpenAtLogin)
@@ -276,6 +279,7 @@ export function* platformConfigSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.actionToAction(ConfigGen.setupEngineListeners, startOutOfDateCheckLoop)
   yield Saga.actionToAction(ConfigGen.copyToClipboard, copyToClipboard)
   yield Saga.actionToPromise(ConfigGen.updateNow, updateNow)
+  yield Saga.actionToPromise(ConfigGen.checkForUpdate, checkForUpdate)
   yield Saga.fork(initializeAppSettingsState)
   yield Saga.actionToAction(ConfigGen.daemonHandshakeWait, sendKBServiceCheck)
 

--- a/shared/constants/config.js
+++ b/shared/constants/config.js
@@ -21,6 +21,7 @@ export const teamFolder = (team: string) => `${defaultKBFSPath}${defaultTeamPref
 export const makeOutOfDate: I.RecordFactory<Types._OutOfDate> = I.Record({
   critical: false,
   message: undefined,
+  updating: false,
 })
 
 export const makeState: I.RecordFactory<Types._State> = I.Record({

--- a/shared/constants/types/config.js
+++ b/shared/constants/types/config.js
@@ -9,6 +9,7 @@ import {RPCError} from '../../util/errors'
 export type _OutOfDate = {
   critical: boolean,
   message?: string,
+  updating: boolean,
 }
 export type OutOfDate = I.RecordOf<_OutOfDate>
 
@@ -38,7 +39,7 @@ export type _State = {
   menubarWindowID: number,
   notifySound: boolean,
   openAtLogin: boolean,
-  outOfDate?: OutOfDate,
+  outOfDate?: ?OutOfDate,
   pushLoaded: boolean,
   registered: boolean,
   startupDetailsLoaded: boolean,

--- a/shared/menubar/out-of-date.js
+++ b/shared/menubar/out-of-date.js
@@ -30,23 +30,33 @@ const OutOfDate = ({outOfDate, updateNow}: Props) =>
       >
         {getOutOfDateText(outOfDate)}
       </Kb.Text>
-      <Kb.Text
-        backgroundMode="Information"
-        type="BodySmallSemibold"
-        style={outOfDate.critical ? styles.textCritical : undefined}
-      >
-        Please{' '}
+      {outOfDate.updating ? (
         <Kb.Text
           backgroundMode="Information"
           type="BodySmallSemibold"
-          underline={!!updateNow}
           style={outOfDate.critical ? styles.textCritical : undefined}
-          onClick={updateNow}
         >
-          update now
+          Updating ...
         </Kb.Text>
-        .
-      </Kb.Text>
+      ) : (
+        <Kb.Text
+          backgroundMode="Information"
+          type="BodySmallSemibold"
+          style={outOfDate.critical ? styles.textCritical : undefined}
+        >
+          Please{' '}
+          <Kb.Text
+            backgroundMode="Information"
+            type="BodySmallSemibold"
+            underline={!!updateNow}
+            style={outOfDate.critical ? styles.textCritical : undefined}
+            onClick={updateNow}
+          >
+            update now
+          </Kb.Text>
+          .
+        </Kb.Text>
+      )}
     </Kb.Box2>
   )
 

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -185,13 +185,17 @@ export default function(state: Types.State = initialState, action: ConfigGen.Act
       return state.merge({justDeletedSelf: action.payload.deletedUsername})
     case ConfigGen.daemonHandshakeDone:
       return state.merge({daemonHandshakeState: 'done'})
-    case ConfigGen.outOfDate:
+    case ConfigGen.updateNow:
+      return state.update('outOfDate', outOfDate => outOfDate && outOfDate.set('updating', true))
+    case ConfigGen.updateInfo:
       return state.set(
         'outOfDate',
-        Constants.makeOutOfDate({
-          critical: action.payload.critical,
-          message: action.payload.message,
-        })
+        action.payload.isOutOfDate
+          ? Constants.makeOutOfDate({
+              critical: action.payload.critical,
+              message: action.payload.message,
+            })
+          : null
       )
     // Saga only actions
     case ConfigGen.loadTeamAvatars:
@@ -206,7 +210,7 @@ export default function(state: Types.State = initialState, action: ConfigGen.Act
     case ConfigGen.installerRan:
     case ConfigGen.copyToClipboard:
     case ConfigGen._avatarQueue:
-    case ConfigGen.updateNow:
+    case ConfigGen.checkForUpdate:
       return state
     default:
       /*::


### PR DESCRIPTION
The "check again" part is because user could hit "Ignore", and nothing would get updated. In this case we should not show the out-of-date banner any more. So ask service again and eventually update the store to reflect the fact that no update is needed anymore.

Tagging @keybase/kbfs-hackers for the first commit in Go, and @keybase/react-hackers for the second commit in GUI.