### PR TITLE
Fix 'retry' not appearing on failed messages sometimes

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
@@ -88,7 +88,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
     failureDescription = message.errorReason
     if (stateProps.isYou && ['pending', 'failed'].includes(message.submitState)) {
       // This is a message still in the outbox, we can retry/edit to fix
-      failureDescription = stateProps.isYou ? `Failed to send: ${message.errorReason}` : message.errorReason
+      failureDescription = `Failed to send: ${message.errorReason}`
       isErrorFixable = true
     }
   }
@@ -147,6 +147,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
 }
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    mergeProps
+  ),
   setDisplayName('WrapperAuthor')
 )(WrapperAuthor)

--- a/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
@@ -147,6 +147,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
 }
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    mergeProps
+  ),
   setDisplayName('WrapperAuthor')
 )(WrapperAuthor)

--- a/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-author/container.js
@@ -86,7 +86,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
   let isErrorFixable = false
   if ((message.type === 'text' || message.type === 'attachment') && message.errorReason) {
     failureDescription = message.errorReason
-    if (stateProps.isYou && message.submitState === 'pending') {
+    if (stateProps.isYou && ['pending', 'failed'].includes(message.submitState)) {
       // This is a message still in the outbox, we can retry/edit to fix
       failureDescription = stateProps.isYou ? `Failed to send: ${message.errorReason}` : message.errorReason
       isErrorFixable = true
@@ -147,10 +147,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
 }
 
 export default compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    mergeProps
-  ),
+  connect(mapStateToProps, mapDispatchToProps, mergeProps),
   setDisplayName('WrapperAuthor')
 )(WrapperAuthor)


### PR DESCRIPTION
The submitState is:

* 'Pending' when the failed outbox record comes with a fresh thread load
* 'Failed' when the failure comes from a `ChatActivityType.failedMessage`

r? @keybase/react-hackers 