### PR TITLE
Stellar: make payment building more responsive/reliable

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -24,30 +24,36 @@ import {isMobile} from '../constants/platform'
 
 const build = (state: TypedState, action: any) =>
   (state.wallets.building.isRequest
-    ? RPCStellarTypes.localBuildRequestLocalRpcPromise({
-        amount: state.wallets.building.amount,
-        currency: state.wallets.building.currency === 'XLM' ? null : state.wallets.building.currency,
-        secretNote: state.wallets.building.secretNote.stringValue(),
-        to: state.wallets.building.to,
-      }).then(build =>
+    ? RPCStellarTypes.localBuildRequestLocalRpcPromise(
+        {
+          amount: state.wallets.building.amount,
+          currency: state.wallets.building.currency === 'XLM' ? null : state.wallets.building.currency,
+          secretNote: state.wallets.building.secretNote.stringValue(),
+          to: state.wallets.building.to,
+        },
+        Constants.buildPaymentWaitingKey
+      ).then(build =>
         WalletsGen.createBuiltRequestReceived({
           build: Constants.buildRequestResultToBuiltRequest(build),
           forBuilding: state.wallets.building,
         })
       )
-    : RPCStellarTypes.localBuildPaymentLocalRpcPromise({
-        amount: state.wallets.building.amount,
-        currency: state.wallets.building.currency === 'XLM' ? null : state.wallets.building.currency,
-        fromPrimaryAccount: state.wallets.building.from === Types.noAccountID,
-        from: state.wallets.building.from === Types.noAccountID ? '' : state.wallets.building.from,
-        fromSeqno: '',
-        publicMemo: state.wallets.building.publicMemo.stringValue(),
-        secretNote: state.wallets.building.secretNote.stringValue(),
-        to: state.wallets.building.to,
-        toIsAccountID:
-          state.wallets.building.recipientType !== 'keybaseUser' &&
-          !Constants.isFederatedAddress(state.wallets.building.to),
-      }).then(build =>
+    : RPCStellarTypes.localBuildPaymentLocalRpcPromise(
+        {
+          amount: state.wallets.building.amount,
+          currency: state.wallets.building.currency === 'XLM' ? null : state.wallets.building.currency,
+          fromPrimaryAccount: state.wallets.building.from === Types.noAccountID,
+          from: state.wallets.building.from === Types.noAccountID ? '' : state.wallets.building.from,
+          fromSeqno: '',
+          publicMemo: state.wallets.building.publicMemo.stringValue(),
+          secretNote: state.wallets.building.secretNote.stringValue(),
+          to: state.wallets.building.to,
+          toIsAccountID:
+            state.wallets.building.recipientType !== 'keybaseUser' &&
+            !Constants.isFederatedAddress(state.wallets.building.to),
+        },
+        Constants.buildPaymentWaitingKey
+      ).then(build =>
         WalletsGen.createBuiltPaymentReceived({
           build: Constants.buildPaymentResultToBuiltPayment(build),
           forBuilding: state.wallets.building,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -446,6 +446,7 @@ const createNewAccountWaitingKey = 'wallets:createNewAccount'
 const changeDisplayCurrencyWaitingKey = 'wallets:changeDisplayCurrency'
 const linkExistingWaitingKey = 'wallets:linkExisting'
 const loadEverythingWaitingKey = 'wallets:loadEverything'
+const buildPaymentWaitingKey = 'wallets:buildPayment'
 const sendPaymentWaitingKey = 'wallets:stellarSend'
 const requestPaymentWaitingKey = 'wallets:requestPayment'
 const setAccountAsDefaultWaitingKey = 'wallets:setAccountAsDefault'
@@ -537,6 +538,7 @@ export {
   bannerLevelToBackground,
   balanceChangeColor,
   balanceChangeSign,
+  buildPaymentWaitingKey,
   cancelPaymentWaitingKey,
   changeDisplayCurrencyWaitingKey,
   currenciesResultToCurrencies,

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -75,31 +75,61 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     }
     case WalletsGen.setBuildingAmount:
       const {amount} = action.payload
-      return state.set('building', state.get('building').merge({amount}))
+      return state
+        .set(
+          'builtPayment',
+          state
+            .get('builtPayment')
+            .merge({amountErrMsg: '', amountFormatted: '', worthDescription: '', worthInfo: ''})
+        )
+        .set(
+          'builtRequest',
+          state.get('builtRequest').merge({amountErrMsg: '', worthDescription: '', worthInfo: ''})
+        )
+        .set('building', state.get('building').merge({amount}))
     case WalletsGen.setBuildingCurrency:
       const {currency} = action.payload
-      return state.set('building', state.get('building').merge({currency}))
+      return state
+        .set('builtPayment', Constants.makeBuiltPayment())
+        .set('building', state.get('building').merge({currency}))
     case WalletsGen.setBuildingFrom:
       const {from} = action.payload
-      return state.set('building', state.get('building').merge({from}))
+      return state
+        .set('builtPayment', Constants.makeBuiltPayment())
+        .set('building', state.get('building').merge({from}))
     case WalletsGen.setBuildingIsRequest:
       const {isRequest} = action.payload
-      return state.set('building', state.get('building').merge({isRequest}))
+      return state
+        .set('builtPayment', Constants.makeBuiltPayment())
+        .set('builtRequest', Constants.makeBuiltRequest())
+        .set('building', state.get('building').merge({isRequest}))
     case WalletsGen.setBuildingPublicMemo:
       const {publicMemo} = action.payload
-      return state.set('building', state.get('building').merge({publicMemo}))
+      return state
+        .set('builtPayment', state.get('builtPayment').merge({publicMemoErrMsg: new HiddenString('')}))
+        .set('building', state.get('building').merge({publicMemo}))
     case WalletsGen.setBuildingRecipientType:
       const {recipientType} = action.payload
-      return state.set('building', state.get('building').merge({recipientType}))
+      return state
+        .set('builtPayment', Constants.makeBuiltPayment())
+        .set('building', state.get('building').merge({recipientType}))
     case WalletsGen.setBuildingSecretNote:
       const {secretNote} = action.payload
-      return state.set('building', state.get('building').merge({secretNote}))
+      return state
+        .set('builtPayment', state.get('builtPayment').merge({secretNoteErrMsg: new HiddenString('')}))
+        .set('builtRequest', state.get('builtRequest').merge({secretNoteErrMsg: new HiddenString('')}))
+        .set('building', state.get('building').merge({secretNote}))
     case WalletsGen.setBuildingTo:
       const {to} = action.payload
-      return state.set('building', state.get('building').merge({to}))
+      return state
+        .set('builtPayment', state.get('builtPayment').merge({toErrMsg: '', toUsername: ''}))
+        .set('builtRequest', state.get('builtRequest').merge({toErrMsg: ''}))
+        .set('building', state.get('building').merge({to}))
     case WalletsGen.sendAssetChoicesReceived:
       const {sendAssetChoices} = action.payload
-      return state.set('building', state.get('building').merge({sendAssetChoices}))
+      return state
+        .set('builtPayment', Constants.makeBuiltPayment())
+        .set('building', state.get('building').merge({sendAssetChoices}))
     case WalletsGen.validateAccountName:
       return state.merge({
         accountName: action.payload.name,

--- a/shared/wallets/receive-modal/container.js
+++ b/shared/wallets/receive-modal/container.js
@@ -28,11 +28,12 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
   onRequest: () => {
     const accountID = routeProps.get('accountID')
     dispatch(WalletsGen.createSetBuildingFrom({from: accountID}))
+    dispatch(WalletsGen.createSetBuildingIsRequest({isRequest: true}))
     // TODO DESKTOP-7961 navigate to separate receive form
     dispatch(
       RouteTreeGen.createNavigateTo({
         parentPath: [...(isMobile ? [settingsTab, walletsSettingsTab] : [walletsTab]), 'wallet'],
-        path: [{props: {isRequest: true}, selected: Constants.sendReceiveFormRouteKey}],
+        path: [{props: {}, selected: Constants.sendReceiveFormRouteKey}],
       })
     )
   },

--- a/shared/wallets/send-form/footer/container.js
+++ b/shared/wallets/send-form/footer/container.js
@@ -8,10 +8,11 @@ import {compose, connect, setDisplayName} from '../../../util/container'
 const mapStateToProps = state => {
   const {isRequest} = state.wallets.building
   return {
-    isRequest,
     disabled: !(isRequest
       ? state.wallets.builtRequest.readyToRequest
       : state.wallets.builtPayment.readyToSend),
+    isRequest,
+    waitingKey: Constants.buildPaymentWaitingKey,
     worthDescription: isRequest
       ? state.wallets.builtRequest.worthDescription
       : state.wallets.builtPayment.worthDescription,
@@ -36,9 +37,10 @@ const mapDispatchToProps = dispatch => ({
 
 const mergeProps = (s, d, o) => ({
   disabled: s.disabled,
-  worthDescription: s.worthDescription,
   onClickRequest: s.isRequest ? d.onClickRequest : undefined,
   onClickSend: s.isRequest ? undefined : d.onClickSend,
+  waitingKey: s.waitingKey,
+  worthDescription: s.worthDescription,
 })
 
 export default compose(

--- a/shared/wallets/send-form/footer/container.js
+++ b/shared/wallets/send-form/footer/container.js
@@ -8,6 +8,7 @@ import {compose, connect, setDisplayName} from '../../../util/container'
 const mapStateToProps = state => {
   const {isRequest} = state.wallets.building
   return {
+    calculating: !!state.wallets.building.amount,
     disabled: !(isRequest
       ? state.wallets.builtRequest.readyToRequest
       : state.wallets.builtPayment.readyToSend),
@@ -36,6 +37,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const mergeProps = (s, d, o) => ({
+  calculating: s.calculating,
   disabled: s.disabled,
   onClickRequest: s.isRequest ? d.onClickRequest : undefined,
   onClickSend: s.isRequest ? undefined : d.onClickSend,

--- a/shared/wallets/send-form/footer/index.js
+++ b/shared/wallets/send-form/footer/index.js
@@ -4,6 +4,7 @@ import * as Kb from '../../../common-adapters'
 import {globalColors, globalMargins, platformStyles, styleSheetCreate} from '../../../styles'
 
 type Props = {
+  calculating: boolean,
   disabled?: boolean,
   onClickRequest?: Function,
   onClickSend?: Function,
@@ -21,11 +22,17 @@ const Footer = (props: Props) => (
       fullWidth={true}
       style={styles.background}
     >
-      {!!props.worthDescription && (
+      {(!!props.worthDescription || props.calculating) && (
         <Kb.Box2 direction="horizontal">
-          <Kb.Text style={styles.worthDescription} type="BodySmall">
-            This is <Kb.Text type="BodySmallExtrabold">{props.worthDescription}</Kb.Text>.
-          </Kb.Text>
+          {props.worthDescription ? (
+            <Kb.Text style={styles.worthDescription} type="BodySmall">
+              This is <Kb.Text type="BodySmallExtrabold">{props.worthDescription}</Kb.Text>.
+            </Kb.Text>
+          ) : (
+            <Kb.Text style={styles.worthDescription} type="BodySmallItalic">
+              Calculating...
+            </Kb.Text>
+          )}
           {/* <Kb.Icon
             type="iconfont-question-mark"
             color={globalColors.black_20}

--- a/shared/wallets/send-form/footer/index.js
+++ b/shared/wallets/send-form/footer/index.js
@@ -7,6 +7,7 @@ type Props = {
   disabled?: boolean,
   onClickRequest?: Function,
   onClickSend?: Function,
+  waitingKey: string,
   worthDescription?: string,
 }
 
@@ -55,8 +56,9 @@ const Footer = (props: Props) => (
           />
         )}
         {!!props.onClickSend && (
-          <Kb.Button
+          <Kb.WaitingButton
             type="Wallet"
+            waitingKey={props.waitingKey}
             label="Send"
             onClick={props.onClickSend}
             disabled={props.disabled}

--- a/shared/wallets/send-form/footer/index.stories.js
+++ b/shared/wallets/send-form/footer/index.stories.js
@@ -11,8 +11,10 @@ const provider = Sb.createPropProviderWithCommon({
 })
 
 const common = {
+  calculating: false,
   disabled: false,
   onClickSend: Sb.action('onClickSend'),
+  waitingKey: 'wallets:buildPayment',
 }
 
 const onClickRequest = Sb.action('onClickRequest')


### PR DESCRIPTION
@keybase/react-hackers 

This PR adds a spinner to the Send button on the Send/Request screens any time we're recalculating a built payment, and clears out a built payment while this is happening, so that we're never showing incorrect calculated data alongside (new, not yet built) user-supplied payment data.

For example, on master, if you prepare a 9 XLM payment and then add another 9, until the build RPC has returned you'll still be seeing the 9 XLM currency equivalent rather than the one for 99 XLM.  Our new approach is to never show incorrect/conflicting data on the screen at the same time like this.

It's a little more complicated than just clearing out the built payment, because we don't blow away all of the built payment every time a field changes, just the built fields that could correspond to that field change.  So if you change a public memo, the only field that's preemptively cleared is `builtPayment.publicMemoErrMsg`.  If you change an amount, it's just the amount error and conversion fields.  These are the reducer changes in the PR -- you fire an action like `setBuildingPublicMemo`, the reducers runs and clears out the old `builtPayment.publicMemoErrMsg`, then the saga runs and creates a fully new `builtPayment`.

The reason to do this piecemeal clearing is to avoid the form growing and shrinking each time you hit a key: for example, if you are trying to send more XLM than you have, and have a warning up about this, we don't want to clear that warning just because you changed other fields like the To address or Memos.  It can stay until you change the amount via the `setBuildingAmount` action.

Also, I noticed that the Receive->Request form path is broken on master: it's bringing up the send form instead of the receive form.  That's fixed here too.