### PR TITLE
Remove lookup accountID->user (exception for ->self)

### DIFF
--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -259,6 +259,8 @@ func LookupSender(ctx context.Context, g *libkb.GlobalContext, accountID stellar
 	return entry, nil
 }
 
+// LookupRecipient finds a recipient.
+// `to` can be a username, social assertion, account ID, or federation address.
 func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput, isCLI bool) (res stellarcommon.Recipient, err error) {
 	defer m.CTraceTimed("Stellar.LookupRecipient", func() error { return err })()
 	res = stellarcommon.Recipient{
@@ -281,6 +283,7 @@ func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput, isCLI
 		return nil
 	}
 
+	// Federation address
 	if strings.Contains(string(to), stellarAddress.Separator) {
 		name, domain, err := stellarAddress.Split(string(to))
 		if err != nil {
@@ -315,27 +318,10 @@ func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput, isCLI
 		}
 	}
 
-	// A Stellar address
+	// Stellar account ID
 	if to[0] == 'G' && len(to) > 16 {
 		err := storeAddress(string(to))
-		if err != nil {
-			return res, err
-		}
-		uv, username, err := LookupUserByAccountID(m, stellar1.AccountID(to))
-		switch err.(type) {
-		case nil:
-			res.User = &stellarcommon.User{
-				UV:       uv,
-				Username: username,
-			}
-			return res, nil
-		case libkb.NotFoundError:
-			// common case
-		default:
-			m.CDebugf("LookupRecipient: lookup accountID->user accountID:%v err:%v", res.AccountID, err)
-			// log and ignore
-		}
-		return res, nil
+		return res, err
 	}
 
 	idRes, err := identifyRecipient(m, string(to), isCLI)
@@ -457,6 +443,25 @@ func sendPayment(m libkb.MetaContext, remoter remote.Remoter, sendArg SendPaymen
 		return sendRelayPayment(m, remoter,
 			senderSeed, sendArg.FromSeqno, recipient, sendArg.Amount, sendArg.DisplayBalance,
 			sendArg.SecretNote, sendArg.PublicMemo, sendArg.QuickReturn)
+	}
+
+	ownRecipient, err := OwnAccount(m.Ctx(), m.G(),
+		stellar1.AccountID(recipient.AccountID.String()))
+	if err != nil {
+		m.CDebugf("error determining if user own's recipient: %v", err)
+		return res, err
+	}
+	if ownRecipient {
+		// When sending to an account that we own, act as though sending to a user as opposed to just an account ID.
+		uv, un := m.G().ActiveDevice.GetUsernameAndUserVersionIfValid(m)
+		if uv.IsNil() || un.IsNil() {
+			m.CDebugf("error finding self: uv:%v un:%v", uv, un)
+			return res, fmt.Errorf("error getting logged-in user")
+		}
+		recipient.User = &stellarcommon.User{
+			UV:       uv,
+			Username: un,
+		}
 	}
 
 	senderSeed2, err := stellarnet.NewSeedStr(senderSeed.SecureNoLogString())

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -920,7 +920,7 @@ func TestGetPaymentsLocal(t *testing.T) {
 }
 
 func TestSendToSelf(t *testing.T) {
-	tcs, cleanup := setupNTests(t, 2)
+	tcs, cleanup := setupNTests(t, 1)
 	defer cleanup()
 
 	rm := tcs[0].Backend
@@ -1008,7 +1008,7 @@ func TestSendToSelf(t *testing.T) {
 	require.Equal(t, stellar1.ParticipantType_OWNACCOUNT, p.ToType)
 	require.Equal(t, accountID2, *p.ToAccountID)
 	require.Equal(t, "savings", p.ToAccountName)
-	require.Equal(t, "", p.ToUsername)
+	require.Equal(t, tcs[0].Fu.Username, p.ToUsername)
 	require.Equal(t, "", p.ToAssertion)
 
 	p = page.Payments[0].Payment
@@ -1020,7 +1020,7 @@ func TestSendToSelf(t *testing.T) {
 	require.Equal(t, stellar1.ParticipantType_OWNACCOUNT, p.ToType)
 	require.Equal(t, accountID1, *p.ToAccountID)
 	require.Equal(t, "office lunch money", p.ToAccountName)
-	require.Equal(t, tcs[0].Fu.Username, p.ToUsername) // the sender resolved the username before sending, so it's recorded
+	require.Equal(t, tcs[0].Fu.Username, p.ToUsername)
 	require.Equal(t, "", p.ToAssertion)
 
 	pd, err := tcs[0].Srv.GetPaymentDetailsLocal(context.Background(), stellar1.GetPaymentDetailsLocalArg{
@@ -1052,7 +1052,7 @@ func TestSendToSelf(t *testing.T) {
 	require.Equal(t, stellar1.ParticipantType_OWNACCOUNT, pd.ToType)
 	require.Equal(t, accountID2, *pd.ToAccountID)
 	require.Equal(t, "savings", pd.ToAccountName)
-	require.Equal(t, "", pd.ToUsername)
+	require.Equal(t, tcs[0].Fu.Username, pd.ToUsername)
 	require.Equal(t, "", pd.ToAssertion)
 
 	pd, err = tcs[0].Srv.GetPaymentDetailsLocal(context.Background(), stellar1.GetPaymentDetailsLocalArg{
@@ -1648,11 +1648,7 @@ func TestGetSendAssetChoices(t *testing.T) {
 
 	require.True(t, choices2[0].Asset.Eq(keys))
 	require.False(t, choices2[0].Enabled)
-	// Using AccountID should still resolve to user and we should see
-	// "*username* does not accept ..." subtext.
-	require.Contains(t, choices2[0].Subtext, tcs[1].Fu.Username)
-	require.Contains(t, choices2[0].Subtext, "does not accept")
-	require.Contains(t, choices2[0].Subtext, choices2[0].Asset.Code)
+	require.Equal(t, choices2[0].Subtext, fmt.Sprintf("Recipient does not accept %v", choices2[0].Asset.Code))
 
 	require.True(t, choices2[1].Asset.Eq(astro))
 	require.True(t, choices2[1].Enabled)

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -349,7 +349,7 @@ protocol local {
   BuildRequestResLocal buildRequestLocal(
     int sessionID,
 
-    // Requestee username.  Examples: "russel", "t_alice"
+    // Requestee username or assertion.  Examples: "russel", "t_alice", "bob@twitter"
     string to,
 
     string amount, // Amount of the asset OR outside currency being requested. Example: "3.005"


### PR DESCRIPTION
On top of https://github.com/keybase/client/pull/14266

Do not look up accountID -> user in the build and send flow. That lookup now exists as two special cases. When sending to one of your own account IDs. And in `keybase wallet lookup`.

Fixes the bad experience where you send to an account ID and the service surprises you by sending to the user including the encrypted note.