### PR TITLE
fix FTL bug with loading a parent team having been let in

### DIFF
--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -456,3 +456,15 @@ func NewKBFSKeyGenerationError(required, exists int) KBFSKeyGenerationError {
 func (e KBFSKeyGenerationError) Error() string {
 	return fmt.Sprintf("KBFS key generation too low: %v < %v", e.Exists, e.Required)
 }
+
+type FTLMissingSeedError struct {
+	gen keybase1.PerTeamKeyGeneration
+}
+
+func NewFTLMissingSeedError(g keybase1.PerTeamKeyGeneration) error {
+	return FTLMissingSeedError{gen: g}
+}
+
+func (e FTLMissingSeedError) Error() string {
+	return fmt.Sprintf("FTL Missing seed at generation: %d", e.gen)
+}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -1500,7 +1500,7 @@ func (l *TeamLoader) getHeadMerkleSeqno(mctx libkb.MetaContext, readSubteamID ke
 		return ret, NewInvalidLink(headLink, "wrong head seqno; wanted 1 but got something else")
 	}
 	if !headLink.LinkID().Eq(expectedLink) {
-		return ret, NewInvalidLink(headLink, "wrong head link hash: %s != %s", headLink.LinkID, expectedLink)
+		return ret, NewInvalidLink(headLink, "wrong head link hash: %s != %s", headLink.LinkID(), expectedLink)
 	}
 	if headLink.isStubbed() {
 		return ret, NewInvalidLink(headLink, "got a stubbed head link, but wasn't expecting that")


### PR DESCRIPTION
- the bug sequence we saw was: (1) user FTLs foo.bar; (2) gets
let into foo; and then (3) FTLs foo. This previously died with
a FastTeamError "no unverified key seed found at generation 1."
- fix by just doing a full reload in that case, setting ftl_low=0
- test that repros it