### PR TITLE
require .net 4.5.2 in the msi

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
@@ -52,6 +52,12 @@
     <Compile Include="gui.wxs" />
     <Compile Include="KeybaseApps.wxs" />
   </ItemGroup>
+  <ItemGroup>
+    <WixExtension Include="WixNetFxExtension">
+      <HintPath>$(WixExtDir)\WixNetFxExtension.dll</HintPath>
+      <Name>WixNetFxExtension</Name>
+    </WixExtension>
+  </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
   <PropertyGroup>
     <PostBuildEvent>if /I "$(ConfigurationName)" == "Release" "%25SIGNTOOL%25" sign /v /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 /i "%25CERTISSUER%25" /sha1 EB187C8CBF63D8CA0DFB3CBA97E8E310FC3FDE52 "$(TargetDir)$(TargetFileName)"</PostBuildEvent>

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
 	<Product Id="*" Name="Keybase" Language="1033" Version="$(env.KEYBASE_WINVER)" Manufacturer="Keybase, Inc." UpgradeCode="c118f7ec-9a1d-4ff1-91f5-15d208499d7b">
 		<Package InstallerVersion="500" Compressed="yes" InstallPrivileges="limited" InstallScope="perUser" />
     <MediaTemplate EmbedCab="yes"/>
@@ -10,9 +11,12 @@
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable"/>
     <Property Id="EXECUTABLETARGET" Value="bin"/>
     <Property Id="MsiLogging" Value="oicewarmup"/>
-
+    <PropertyRef Id="WIX_IS_NETFRAMEWORK_452_OR_LATER_INSTALLED"/>
     <MajorUpgrade DowngradeErrorMessage="A newer version of Keybase is already installed." AllowSameVersionUpgrades="yes"  />	
 
+    <Condition Message="This application requires .NET Framework 4.5.2. Please install the .NET Framework then run this installer again.">
+      <![CDATA[Installed OR WIX_IS_NETFRAMEWORK_452_OR_LATER_INSTALLED]]>
+    </Condition>
     <Feature Id="ProductFeature" Title="Keybase Application" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
       <ComponentGroupRef Id="GuiComps" />


### PR DESCRIPTION
Only an unpatched windows 7 machine will have this, but now they get a helpful message
![image](https://user-images.githubusercontent.com/862397/47047715-2cda6f80-d14d-11e8-9895-c1f86711f6d6.png)
