### PR TITLE
Add localhost to cleartext traffic

### DIFF
--- a/shared/react-native/android/app/src/main/res/xml/network_security_config.xml
+++ b/shared/react-native/android/app/src/main/res/xml/network_security_config.xml
@@ -2,5 +2,6 @@
 <network-security-config>
   <domain-config cleartextTrafficPermitted="true">
       <domain includeSubdomains="false">127.0.0.1</domain>
+      <domain includeSubdomains="false">localhost</domain>
   </domain-config>
 </network-security-config>


### PR DESCRIPTION
We already have 127.0.0.1, and I got stuck because I didn't realize it made a difference between 127.0.0.1 and localhost.

@keybase/react-hackers 