### PR TITLE
Handle payment results and payment details separately

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -168,15 +168,15 @@
     "paymentDetailReceived": {
       "_description": "Update a payment with additional detail",
       "accountID": "Types.AccountID",
-      "payment": "Types.Payment"
+      "payment": "Types.PaymentDetail"
     },
     "paymentsReceived": {
       "_description": "Update our store of payments data",
       "accountID": "Types.AccountID",
       "paymentCursor": "?StellarRPCTypes.PageCursor",
       "oldestUnread": "Types.PaymentID",
-      "payments": "Array<Types.Payment>",
-      "pending": "Array<Types.Payment>"
+      "payments": "Array<Types.PaymentResult>",
+      "pending": "Array<Types.PaymentResult>"
     },
     "requestDetailReceived": {
       "_description": "Store a request's details",

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -173,14 +173,14 @@ type _MarkAsReadPayload = $ReadOnly<{|
 |}>
 type _PaymentDetailReceivedPayload = $ReadOnly<{|
   accountID: Types.AccountID,
-  payment: Types.Payment,
+  payment: Types.PaymentDetail,
 |}>
 type _PaymentsReceivedPayload = $ReadOnly<{|
   accountID: Types.AccountID,
   paymentCursor: ?StellarRPCTypes.PageCursor,
   oldestUnread: Types.PaymentID,
-  payments: Array<Types.Payment>,
-  pending: Array<Types.Payment>,
+  payments: Array<Types.PaymentResult>,
+  pending: Array<Types.PaymentResult>,
 |}>
 type _RefreshPaymentsPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _RequestDetailReceivedPayload = $ReadOnly<{|request: StellarRPCTypes.RequestDetailsLocal|}>

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -183,9 +183,9 @@ const createPaymentsReceived = (accountID, payments, pending) => WalletsGen.crea
         : Types.noPaymentID,
       paymentCursor: payments.cursor,
       payments: (payments.payments || [])
-        .map(elem => Constants.paymentResultToPayment(elem, 'history'))
+        .map(elem => Constants.rpcPaymentResultToPaymentResult(elem, 'history'))
         .filter(Boolean),
-      pending: (pending || []).map(elem => Constants.paymentResultToPayment(elem, 'pending')).filter(Boolean),
+      pending: (pending || []).map(elem => Constants.rpcPaymentResultToPaymentResult(elem, 'pending')).filter(Boolean),
     })
 
 const loadPayments = (
@@ -280,7 +280,7 @@ const loadPaymentDetail = (state: TypedState, action: WalletsGen.LoadPaymentDeta
   }).then(res =>
     WalletsGen.createPaymentDetailReceived({
       accountID: action.payload.accountID,
-      payment: Constants.paymentDetailResultToPayment(res),
+      payment: Constants.rpcPaymentDetailToPaymentDetail(res),
     })
   )
 

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -196,6 +196,8 @@ export type BuiltPayment = I.RecordOf<_BuiltPayment>
 
 export type BuiltRequest = I.RecordOf<_BuiltRequest>
 
+export type PaymentResult = I.RecordOf<_PaymentResult>
+export type PaymentDetail = I.RecordOf<_PaymentDetail>
 export type Payment = I.RecordOf<_Payment>
 
 export type Currency = I.RecordOf<_LocalCurrency>

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -142,9 +142,11 @@ export type _PaymentCommon = {
 }
 
 export type _PaymentResult = _PaymentCommon & {
-  // The statusDescription is either "pending", "completed", or
-  // "error" so the section field can actually be moved to
-  // _PaymentCommon.
+  // Ideally the section field would be in _PaymentCommon. We can
+  // derive it from statusDescription, which is either "pending",
+  // "completed", or "error", or once
+  // https://keybase.atlassian.net/browse/CORE-9234 is fixed there
+  // might be a better way.
   section: PaymentSection,
   unread: boolean,
 }

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -115,15 +115,18 @@ export type StatusSimplified = 'none' | 'pending' | 'cancelable' | 'completed' |
 
 export type PaymentDelta = 'none' | 'increase' | 'decrease'
 export type PaymentSection = 'pending' | 'history' | 'none' // where does the payment go on the wallet screen
-export type _Payment = {
+
+// The various payment types below are awkward, but they reflect the
+// protocol. We can clean this up once
+// https://keybase.atlassian.net/browse/CORE-9234 is fixed.
+
+export type _PaymentCommon = {
   amountDescription: string,
   delta: PaymentDelta,
   error: ?string,
   id: PaymentID,
   note: HiddenString,
   noteErr: HiddenString,
-  publicMemo: HiddenString,
-  publicMemoType: string,
   section: PaymentSection,
   source: string,
   sourceAccountID: string,
@@ -135,11 +138,21 @@ export type _Payment = {
   targetAccountID: ?string,
   targetType: string,
   time: ?number,
-  txID: string,
-  unread: boolean,
   worth: string,
   worthCurrency: string,
 }
+
+export type _PaymentResult = _PaymentCommon & {
+  unread: boolean,
+}
+
+export type _PaymentDetail = _PaymentCommon & {
+  txID: string,
+  publicMemo: HiddenString,
+  publicMemoType: string,
+}
+
+export type _Payment = _PaymentResult & _PaymentDetail
 
 export type _AssetDescription = {
   code: string,

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -127,7 +127,6 @@ export type _PaymentCommon = {
   id: PaymentID,
   note: HiddenString,
   noteErr: HiddenString,
-  section: PaymentSection,
   source: string,
   sourceAccountID: string,
   sourceType: string,
@@ -143,6 +142,7 @@ export type _PaymentCommon = {
 }
 
 export type _PaymentResult = _PaymentCommon & {
+  section: PaymentSection,
   unread: boolean,
 }
 

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -142,6 +142,8 @@ export type _PaymentCommon = {
 }
 
 export type _PaymentResult = _PaymentCommon & {
+  // The section can be derived from statusDescription, so this can be
+  // moved to _PaymentCommon.
   section: PaymentSection,
   unread: boolean,
 }

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -147,9 +147,9 @@ export type _PaymentResult = _PaymentCommon & {
 }
 
 export type _PaymentDetail = _PaymentCommon & {
-  txID: string,
   publicMemo: HiddenString,
   publicMemoType: string,
+  txID: string,
 }
 
 export type _Payment = _PaymentResult & _PaymentDetail

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -142,8 +142,9 @@ export type _PaymentCommon = {
 }
 
 export type _PaymentResult = _PaymentCommon & {
-  // The section can be derived from statusDescription, so this can be
-  // moved to _PaymentCommon.
+  // The statusDescription is either "pending", "completed", or
+  // "error" so the section field can actually be moved to
+  // _PaymentCommon.
   section: PaymentSection,
   unread: boolean,
 }

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -414,8 +414,12 @@ const keys = emptyPayment
 const updatePayment = (oldPayment: Types.Payment, newPayment: Types.Payment): Types.Payment => {
   const res = oldPayment.withMutations(paymentMutable => {
     keys.forEach(
-      key =>
-        newPayment.get(key) === emptyPayment.get(key) ? null : paymentMutable.set(key, newPayment.get(key))
+      key => {
+        // TODO: Better fix?
+        if (key === 'unread' || newPayment.get(key) !== emptyPayment.get(key)) {
+          paymentMutable.set(key, newPayment.get(key))
+        }
+      }
     )
   })
   return res

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -424,14 +424,14 @@ const updatePaymentDetail = (
   map: I.Map<Types.PaymentID, Types.Payment>,
   paymentDetail: Types.PaymentDetail,
 ) => {
-  return map.withMutations(mapMutable => mapMutable.update(paymentDetail.id, makePayment(), oldPayment => oldPayment.merge(paymentDetail)))
+  return map.update(paymentDetail.id, (oldPayment = makePayment()) => oldPayment.merge(paymentDetail))
 }
 
 const updatePaymentsReceived = (
   map: I.Map<Types.PaymentID, Types.Payment>,
   paymentResults: Array<Types.PaymentResult>,
 ) => {
-  return map.withMutations(mapMutable => paymentResults.forEach(paymentResult => mapMutable.update(paymentResult.id, makePayment(), oldPayment => oldPayment.merge(paymentResult))))
+  return map.withMutations(mapMutable => paymentResults.forEach(paymentResult => mapMutable.update(paymentResult.id, (oldPayment = makePayment()) => oldPayment.merge(paymentResult))))
 }
 
 const changeAccountNameWaitingKey = 'wallets:changeAccountName'

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -425,20 +425,14 @@ const updatePaymentDetail = (
   map: I.Map<Types.PaymentID, Types.Payment>,
   paymentDetail: Types.PaymentDetail,
 ) => {
-  return map.withMutations(mapMutable =>
-                           mapMutable.update(paymentDetail.id, makePayment(), oldPayment => oldPayment.merge(paymentDetail))
-                          )
+  return map.withMutations(mapMutable => mapMutable.update(paymentDetail.id, makePayment(), oldPayment => oldPayment.merge(paymentDetail)))
 }
 
 const updatePaymentsReceived = (
   map: I.Map<Types.PaymentID, Types.Payment>,
   paymentResults: Array<Types.PaymentResult>,
 ) => {
-  return map.withMutations(mapMutable =>
-    paymentResults.forEach(paymentResult =>
-                        mapMutable.update(paymentResult.id, makePayment(), oldPayment => oldPayment.merge(paymentResult))
-                       )
-                          )
+  return map.withMutations(mapMutable => paymentResults.forEach(paymentResult => mapMutable.update(paymentResult.id, makePayment(), oldPayment => oldPayment.merge(paymentResult))))
 }
 
 const changeAccountNameWaitingKey = 'wallets:changeAccountName'

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -177,15 +177,13 @@ const currenciesResultToCurrencies = (w: RPCTypes.CurrencyLocal) =>
     name: w.name,
   })
 
-const makePayment: I.RecordFactory<Types._Payment> = I.Record({
+const _defaultPaymentCommon = {
   amountDescription: '',
   delta: 'none',
   error: '',
   id: Types.noPaymentID,
   note: new HiddenString(''),
   noteErr: new HiddenString(''),
-  publicMemo: new HiddenString(''),
-  publicMemoType: '',
   section: 'none',
   source: '',
   sourceAccountID: '',
@@ -197,11 +195,32 @@ const makePayment: I.RecordFactory<Types._Payment> = I.Record({
   targetAccountID: '',
   targetType: '',
   time: null,
-  txID: '',
-  unread: false,
   worth: '',
   worthCurrency: '',
-})
+}
+
+const _defaultPaymentResult = {
+  ..._defaultPaymentCommon,
+  unread: false,
+}
+
+const _defaultPaymentDetail = {
+  ..._defaultPaymentCommon,
+  publicMemo: new HiddenString(''),
+  publicMemoType: '',
+  txID: '',
+}
+
+const _defaultPayment = {
+  ..._defaultPaymentResult,
+  ..._defaultPaymentDetail,
+}
+
+const makePaymentResult: I.RecordFactory<Types._PaymentResult> = I.Record(_defaultPaymentResult)
+
+const makePaymentDetail: I.RecordFactory<Types._PaymentDetail> = I.Record(_defaultPaymentDetail)
+
+const makePayment: I.RecordFactory<Types._Payment> = I.Record(_defaultPayment)
 
 const makeCurrency: I.RecordFactory<Types._LocalCurrency> = I.Record({
   description: '',
@@ -243,8 +262,6 @@ const paymentDetailResultToPayment = (p: RPCTypes.PaymentDetailsLocal) =>
     publicMemo: new HiddenString(p.publicNote),
     publicMemoType: p.publicNoteType,
     txID: p.txID,
-    // Payment details have no unread field.
-    unread: false,
   })
 
 const rpcPaymentToPaymentCommon = (
@@ -576,6 +593,8 @@ export {
   makeBuilding,
   makeBuiltPayment,
   makeBuiltRequest,
+  makePaymentResult,
+  makePaymentDetail,
   makePayment,
   makeRequest,
   makeReserve,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -184,7 +184,6 @@ const _defaultPaymentCommon = {
   id: Types.noPaymentID,
   note: new HiddenString(''),
   noteErr: new HiddenString(''),
-  section: 'none',
   source: '',
   sourceAccountID: '',
   sourceType: '',
@@ -202,6 +201,7 @@ const _defaultPaymentCommon = {
 const _defaultPaymentResult = {
   ..._defaultPaymentCommon,
   unread: false,
+  section: 'none',
 }
 
 const _defaultPaymentDetail = {
@@ -251,7 +251,8 @@ const rpcPaymentResultToPaymentResult = (w: RPCTypes.PaymentOrErrorLocal, sectio
   }
   const unread = w.payment.unread
   return makePaymentResult({
-    ...rpcPaymentToPaymentCommon(w.payment, section),
+    ...rpcPaymentToPaymentCommon(w.payment),
+    section,
     unread,
   })
 }
@@ -266,7 +267,6 @@ const rpcPaymentDetailToPaymentDetail = (p: RPCTypes.PaymentDetailsLocal) =>
 
 const rpcPaymentToPaymentCommon = (
   p: RPCTypes.PaymentLocal | RPCTypes.PaymentDetailsLocal,
-  section?: Types.PaymentSection
 ) => {
   const sourceType = partyTypeToString[p.fromType]
   const targetType = partyTypeToString[p.toType]
@@ -280,7 +280,6 @@ const rpcPaymentToPaymentCommon = (
   )
   const serviceStatusSimplfied = statusSimplifiedToString[p.statusSimplified]
   return {
-    ...(section ? {section} : null),
     amountDescription: p.amountDescription,
     delta: balanceDeltaToString[p.delta],
     error: '',

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -37,13 +37,13 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.clearBuiltRequest:
       return state.set('builtRequest', Constants.makeBuiltRequest())
     case WalletsGen.paymentDetailReceived:
-      return state.updateIn(['paymentsMap', action.payload.accountID], (payments = I.Map()) =>
-        Constants.updatePaymentMap(payments, [action.payload.payment])
+      return state.updateIn(['paymentsMap', action.payload.accountID], (paymentsMap = I.Map()) =>
+        Constants.updatePaymentDetail(paymentsMap, action.payload.payment)
       )
     case WalletsGen.paymentsReceived:
       return state
         .updateIn(['paymentsMap', action.payload.accountID], (paymentsMap = I.Map()) =>
-          Constants.updatePaymentMap(paymentsMap, [...action.payload.payments, ...action.payload.pending])
+          Constants.updatePaymentsReceived(paymentsMap, [...action.payload.payments, ...action.payload.pending])
         )
         .setIn(['paymentCursorMap', action.payload.accountID], action.payload.paymentCursor)
         .setIn(['paymentLoadingMoreMap', action.payload.accountID], false)


### PR DESCRIPTION
This avoids bugs where we try to infer which fields to update.