### PR TITLE
whitelist known sig prefixes

### DIFF
--- a/go/kbcrypto/nacl_sig_info.go
+++ b/go/kbcrypto/nacl_sig_info.go
@@ -5,6 +5,7 @@ package kbcrypto
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -82,11 +83,14 @@ func (s NaclSigInfo) Verify() (*NaclSigningKeyPublic, error) {
 			return nil, VerificationError{}
 		}
 	case 2:
+		if !s.Prefix.IsWhitelisted() {
+			return nil, VerificationError{errors.New("unknown prefix")}
+		}
 		if !key.Verify(s.Prefix.Prefix(s.Payload), s.Sig) {
 			return nil, VerificationError{}
 		}
 	default:
-		return nil, UnhandledSignatureError{}
+		return nil, UnhandledSignatureError{s.Version}
 	}
 
 	return key, nil

--- a/go/kbcrypto/signature_prefix.go
+++ b/go/kbcrypto/signature_prefix.go
@@ -18,6 +18,16 @@ const (
 	SignaturePrefixChatMBv2 SignaturePrefix = "Keybase-Chat-2"
 )
 
+func (p SignaturePrefix) IsWhitelisted() bool {
+	switch p {
+	case SignaturePrefixKBFS, SignaturePrefixSigchain, SignaturePrefixChatAttachment,
+		SignaturePrefixTesting, SignaturePrefixNIST, SignaturePrefixChatMBv1, SignaturePrefixChatMBv2:
+		return true
+	default:
+		return false
+	}
+}
+
 func (p SignaturePrefix) HasNullByte() bool {
 	return bytes.IndexByte([]byte(p), byte(0)) != -1
 }

--- a/go/kbcrypto/signature_prefix.go
+++ b/go/kbcrypto/signature_prefix.go
@@ -23,7 +23,7 @@ func (p SignaturePrefix) IsWhitelisted() bool {
 	}
 	switch p {
 	case SignaturePrefixKBFS, SignaturePrefixSigchain, SignaturePrefixChatAttachment,
-		SignaturePrefixTesting, SignaturePrefixNIST, SignaturePrefixChatMBv1, SignaturePrefixChatMBv2:
+		SignaturePrefixNIST, SignaturePrefixChatMBv1, SignaturePrefixChatMBv2:
 		return true
 	default:
 		return false

--- a/go/kbcrypto/signature_prefix.go
+++ b/go/kbcrypto/signature_prefix.go
@@ -11,7 +11,6 @@ const (
 	SignaturePrefixKBFS           SignaturePrefix = "Keybase-KBFS-1"
 	SignaturePrefixSigchain       SignaturePrefix = "Keybase-Sigchain-1"
 	SignaturePrefixChatAttachment SignaturePrefix = "Keybase-Chat-Attachment-1"
-	SignaturePrefixTesting        SignaturePrefix = "Keybase-Testing-1"
 	SignaturePrefixNIST           SignaturePrefix = "Keybase-Auth-NIST-1"
 	// Chat prefixes for each MessageBoxedVersion.
 	SignaturePrefixChatMBv1 SignaturePrefix = "Keybase-Chat-1"
@@ -19,6 +18,9 @@ const (
 )
 
 func (p SignaturePrefix) IsWhitelisted() bool {
+	if p.IsWhitelistedTest() {
+		return true
+	}
 	switch p {
 	case SignaturePrefixKBFS, SignaturePrefixSigchain, SignaturePrefixChatAttachment,
 		SignaturePrefixTesting, SignaturePrefixNIST, SignaturePrefixChatMBv1, SignaturePrefixChatMBv2:

--- a/go/kbcrypto/signature_prefix_devel.go
+++ b/go/kbcrypto/signature_prefix_devel.go
@@ -1,0 +1,14 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !production
+
+package kbcrypto
+
+const (
+	SignaturePrefixTesting SignaturePrefix = "Keybase-Testing-1"
+)
+
+func (p SignaturePrefix) IsWhitelistedTest() bool {
+	return p == SignaturePrefixTesting
+}

--- a/go/kbcrypto/signature_prefix_production.go
+++ b/go/kbcrypto/signature_prefix_production.go
@@ -1,0 +1,10 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build production
+
+package kbcrypto
+
+func (p SignaturePrefix) IsWhitelistedTest() bool {
+	return false
+}

--- a/go/libkb/naclwrap_test.go
+++ b/go/libkb/naclwrap_test.go
@@ -282,6 +282,29 @@ func TestNaclPrefixedSigs(t *testing.T) {
 	}
 }
 
+func TestNaclBadPrefix(t *testing.T) {
+	keyPair, err := GenerateNaclSigningKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("keyPair: Public: %+v, Private: %+v", keyPair.Public, keyPair.Private)
+
+	msg := []byte("test message")
+
+	sig, err := keyPair.Sign(append([]byte("AA\x00"), msg...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig.Version = 2
+	sig.Prefix = kbcrypto.SignaturePrefix("AA")
+	sig.Payload = msg
+	_, err = sig.Verify()
+	if err == nil {
+		t.Fatal("expected a signature verification error")
+	}
+}
+
 func TestDeriveSymmetricKeyFromAsymmetricTooShort(t *testing.T) {
 	key1 := generateNaclDHKeyPrivate(t)
 	_, err := deriveSymmetricKeyFromAsymmetric(key1, EncryptionReason("x"))


### PR DESCRIPTION
- there are only a handful of allowed signature prefixes, so we should check the incoming prefixes against a white list.
- a test to make sure this works. tested that this doesn't error on master