### PR TITLE
Add openSendRequestForm action to prepare & navigate to the form

### DIFF
--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -798,8 +798,8 @@ type ChangeDisplayCurrencyLocalArg struct {
 }
 
 type GetDisplayCurrencyLocalArg struct {
-	SessionID int       `codec:"sessionID" json:"sessionID"`
-	AccountID AccountID `codec:"accountID" json:"accountID"`
+	SessionID int        `codec:"sessionID" json:"sessionID"`
+	AccountID *AccountID `codec:"accountID,omitempty" json:"accountID,omitempty"`
 }
 
 type GetWalletSettingsLocalArg struct {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -640,10 +640,15 @@ func (s *Server) GetDisplayCurrencyLocal(ctx context.Context, arg stellar1.GetDi
 	if err = s.assertLoggedIn(ctx); err != nil {
 		return res, err
 	}
-	if arg.AccountID.IsNil() {
-		return res, errors.New("passed empty AccountID")
+	accountID := arg.AccountID
+	if accountID == nil {
+		primaryAccountID, err := stellar.GetOwnPrimaryAccountID(ctx, s.G())
+		if err != nil {
+			return res, err
+		}
+		accountID = &primaryAccountID
 	}
-	return stellar.GetCurrencySetting(s.mctx(ctx), s.remoter, arg.AccountID)
+	return stellar.GetCurrencySetting(s.mctx(ctx), s.remoter, *accountID)
 }
 
 func (s *Server) GetWalletAccountPublicKeyLocal(ctx context.Context, arg stellar1.GetWalletAccountPublicKeyLocalArg) (res string, err error) {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -682,7 +682,7 @@ func TestDefaultCurrency(t *testing.T) {
 	// Should be "EUR" as well, inherited from primary account. Try to
 	// use RPC instead of remote endpoint directly this time.
 	currencyObj, err := tcs[0].Srv.GetDisplayCurrencyLocal(context.Background(), stellar1.GetDisplayCurrencyLocalArg{
-		AccountID: a1,
+		AccountID: &a1,
 	})
 	require.NoError(t, err)
 	require.IsType(t, stellar1.CurrencyLocal{}, currencyObj)

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -355,7 +355,7 @@ protocol local {
 
     string amount, // Amount of the asset OR outside currency being requested. Example: "3.005"
 
-    // Exactly one of `asset` and `currency` should be set.
+    // At most one of `asset` and `currency` should be set.
     union { null, Asset } asset,
     // Note: Requesting non-XLM assets is not yet supported. (Miles: It may
     // actually be supported, but that would be a weird asymmetry)

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -201,7 +201,8 @@ protocol local {
   // OutsideCurrencyCode examples: "USD", "EUR". Has to be one of
   // supported currencies, returned from getDisplayCurrenciesLocal.
   void changeDisplayCurrencyLocal(int sessionID, AccountID accountID, OutsideCurrencyCode currency);
-  CurrencyLocal getDisplayCurrencyLocal(int sessionID, AccountID accountID);
+  // Gets display currency for primary account if no accountID is given.
+  CurrencyLocal getDisplayCurrencyLocal(int sessionID, union { null, AccountID } accountID);
 
   record WalletSettings {
     boolean acceptedDisclaimer; // whether the user has accepted the usage disclaimer

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -1060,7 +1060,10 @@
         },
         {
           "name": "accountID",
-          "type": "AccountID"
+          "type": [
+            null,
+            "AccountID"
+          ]
         }
       ],
       "response": "CurrencyLocal"

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2586,7 +2586,7 @@ const prepareFulfillRequestForm = (state: TypedState, action: Chat2Gen.PrepareFu
   return Saga.put(
     WalletsGen.createOpenSendRequestForm({
       amount: requestInfo.amount,
-      currency: requestInfo.currencyCode,
+      currency: requestInfo.currencyCode || 'XLM',
       from: WalletTypes.noAccountID,
       recipientType: 'keybaseUser',
       to: message.author,

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -18,7 +18,6 @@ import * as TeamsGen from '../teams-gen'
 import * as Types from '../../constants/types/chat2'
 import * as FsTypes from '../../constants/types/fs'
 import * as WalletTypes from '../../constants/types/wallets'
-import * as WalletConstants from '../../constants/wallets'
 import * as UsersGen from '../users-gen'
 import * as WaitingGen from '../waiting-gen'
 import chatTeamBuildingSaga from './team-building'
@@ -2584,18 +2583,15 @@ const prepareFulfillRequestForm = (state: TypedState, action: Chat2Gen.PrepareFu
       )}`
     )
   }
-  return Saga.sequentially(
-    [
-      ...(requestInfo.currencyCode
-        ? [WalletsGen.createSetBuildingCurrency({currency: requestInfo.currencyCode})]
-        : []),
-      WalletsGen.createSetBuildingAmount({amount: requestInfo.amount}),
-      WalletsGen.createSetBuildingFrom({from: WalletTypes.noAccountID}), // Meaning default account
-      WalletsGen.createSetBuildingRecipientType({recipientType: 'keybaseUser'}),
-      WalletsGen.createSetBuildingTo({to: message.author}),
-      WalletsGen.createSetBuildingSecretNote({secretNote: message.note}),
-      RouteTreeGen.createNavigateAppend({path: [WalletConstants.sendReceiveFormRouteKey]}),
-    ].map(action => Saga.put(action))
+  return Saga.put(
+    WalletsGen.createOpenSendRequestForm({
+      amount: requestInfo.amount,
+      currency: requestInfo.currencyCode,
+      from: WalletTypes.noAccountID,
+      recipientType: 'keybaseUser',
+      to: message.author,
+      secretNote: message.note,
+    })
   )
 }
 

--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -7,7 +7,8 @@
   ],
   "actions": {
     "abandonPayment": {
-      "_description": "Signal that a payment being built is abandoned and reset the form fields to their initial states."
+      "_description":
+        "Signal that a payment being built is abandoned and reset the form fields to their initial states."
     },
     "accountsReceived": {
       "_description": "Update our store of account data",
@@ -58,7 +59,8 @@
       "setBuildingTo?": "boolean"
     },
     "createdNewAccount": {
-      "_description": "The service responded with an error or that the create new account operation succeeded",
+      "_description":
+        "The service responded with an error or that the create new account operation succeeded",
       "accountID": "Types.AccountID",
       "showOnCreation?": "boolean",
       "setBuildingTo?": "boolean",
@@ -110,7 +112,7 @@
     },
     "sendAssetChoicesReceived": {
       "_description": "Update valid send assets to choose from",
-      "sendAssetChoices": "Array<StellarRPCTypes.SendAssetChoiceLocal>",
+      "sendAssetChoices": "Array<StellarRPCTypes.SendAssetChoiceLocal>"
     },
     "changeAccountName": {
       "_description": "Change the name of an account",
@@ -142,12 +144,14 @@
     },
     "loadDisplayCurrency": {
       "_description": "Load display currency for an account",
-      "accountID": "Types.AccountID"
+      "accountID": "?Types.AccountID",
+      "setBuildingCurrency?": "boolean"
     },
     "displayCurrencyReceived": {
       "_description": "Update display currency for a certain account",
-      "accountID": "Types.AccountID",
-      "currency": "Types.Currency"
+      "accountID": "?Types.AccountID",
+      "currency": "Types.Currency",
+      "setBuildingCurrency?": "boolean"
     },
     "changeDisplayCurrency": {
       "_description": "Change display currency for an account",
@@ -243,6 +247,18 @@
       "_description": "Set building to -- depends on recipientType",
       "to": "string"
     },
+    "openSendRequestForm": {
+      "_description":
+        "Initialize and navigate to the send or request form. See docs for `setBuilding*` for param semantics.",
+      "amount?": "string",
+      "currency?": "string",
+      "from?": "Types.AccountID",
+      "isRequest?": "boolean",
+      "publicMemo?": "HiddenString",
+      "recipientType?": "Types.CounterpartyType",
+      "secretNote?": "HiddenString",
+      "to?": "string"
+    },
     "linkExistingAccount": {
       "_description": "Link an existing Stellar account with this Keybase user.",
       "name": "string",
@@ -251,7 +267,8 @@
       "setBuildingTo?": "boolean"
     },
     "linkedExistingAccount": {
-      "_description": "The service responded with an error or that the link existing operation succeeded",
+      "_description":
+        "The service responded with an error or that the link existing operation succeeded",
       "accountID": "Types.AccountID",
       "showOnCreation?": "boolean",
       "setBuildingTo?": "boolean",

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -47,6 +47,7 @@ export const loadPayments = 'wallets:loadPayments'
 export const loadRequestDetail = 'wallets:loadRequestDetail'
 export const loadSendAssetChoices = 'wallets:loadSendAssetChoices'
 export const markAsRead = 'wallets:markAsRead'
+export const openSendRequestForm = 'wallets:openSendRequestForm'
 export const paymentDetailReceived = 'wallets:paymentDetailReceived'
 export const paymentsReceived = 'wallets:paymentsReceived'
 export const refreshPayments = 'wallets:refreshPayments'
@@ -132,8 +133,9 @@ type _DeletedAccountPayload = void
 type _DidSetAccountAsDefaultPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _DisplayCurrenciesReceivedPayload = $ReadOnly<{|currencies: Array<Types.Currency>|}>
 type _DisplayCurrencyReceivedPayload = $ReadOnly<{|
-  accountID: Types.AccountID,
+  accountID: ?Types.AccountID,
   currency: Types.Currency,
+  setBuildingCurrency?: boolean,
 |}>
 type _ExportSecretKeyPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _LinkExistingAccountPayload = $ReadOnly<{|
@@ -155,7 +157,10 @@ type _LinkedExistingAccountPayloadError = $ReadOnly<{|
 type _LoadAccountsPayload = void
 type _LoadAssetsPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _LoadDisplayCurrenciesPayload = void
-type _LoadDisplayCurrencyPayload = $ReadOnly<{|accountID: Types.AccountID|}>
+type _LoadDisplayCurrencyPayload = $ReadOnly<{|
+  accountID: ?Types.AccountID,
+  setBuildingCurrency?: boolean,
+|}>
 type _LoadMorePaymentsPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _LoadPaymentDetailPayload = $ReadOnly<{|
   accountID: Types.AccountID,
@@ -170,6 +175,16 @@ type _LoadSendAssetChoicesPayload = $ReadOnly<{|
 type _MarkAsReadPayload = $ReadOnly<{|
   accountID: Types.AccountID,
   mostRecentID: Types.PaymentID,
+|}>
+type _OpenSendRequestFormPayload = $ReadOnly<{|
+  amount?: string,
+  currency?: string,
+  from?: Types.AccountID,
+  isRequest?: boolean,
+  publicMemo?: HiddenString,
+  recipientType?: Types.CounterpartyType,
+  secretNote?: HiddenString,
+  to?: string,
 |}>
 type _PaymentDetailReceivedPayload = $ReadOnly<{|
   accountID: Types.AccountID,
@@ -303,6 +318,10 @@ export const createSentPaymentError = (payload: _SentPaymentErrorPayload) => ({e
  * In response to a notification, resync payment info
  */
 export const createRefreshPayments = (payload: _RefreshPaymentsPayload) => ({error: false, payload, type: refreshPayments})
+/**
+ * Initialize and navigate to the send or request form. See docs for `setBuilding*` for param semantics.
+ */
+export const createOpenSendRequestForm = (payload: _OpenSendRequestFormPayload) => ({error: false, payload, type: openSendRequestForm})
 /**
  * Link an existing Stellar account with this Keybase user.
  */
@@ -511,6 +530,7 @@ export type LoadPaymentsPayload = $Call<typeof createLoadPayments, _LoadPayments
 export type LoadRequestDetailPayload = $Call<typeof createLoadRequestDetail, _LoadRequestDetailPayload>
 export type LoadSendAssetChoicesPayload = $Call<typeof createLoadSendAssetChoices, _LoadSendAssetChoicesPayload>
 export type MarkAsReadPayload = $Call<typeof createMarkAsRead, _MarkAsReadPayload>
+export type OpenSendRequestFormPayload = $Call<typeof createOpenSendRequestForm, _OpenSendRequestFormPayload>
 export type PaymentDetailReceivedPayload = $Call<typeof createPaymentDetailReceived, _PaymentDetailReceivedPayload>
 export type PaymentsReceivedPayload = $Call<typeof createPaymentsReceived, _PaymentsReceivedPayload>
 export type RefreshPaymentsPayload = $Call<typeof createRefreshPayments, _RefreshPaymentsPayload>
@@ -581,6 +601,7 @@ export type Actions =
   | LoadRequestDetailPayload
   | LoadSendAssetChoicesPayload
   | MarkAsReadPayload
+  | OpenSendRequestFormPayload
   | PaymentDetailReceivedPayload
   | PaymentsReceivedPayload
   | RefreshPaymentsPayload

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -67,28 +67,31 @@ const build = (state: TypedState, action: any) =>
     }
   })
 
-const openSendRequestForm = (state: TypedState, action: WalletsGen.OpenSendRequestFormPayload) => {
-  const arg = action.payload
-  return Saga.sequentially(
+const openSendRequestForm = (state: TypedState, action: WalletsGen.OpenSendRequestFormPayload) =>
+  Saga.sequentially(
     [
       WalletsGen.createClearBuilding(),
-      arg.isRequest ? WalletsGen.createClearBuiltRequest() : WalletsGen.createClearBuiltPayment(),
-      WalletsGen.createSetBuildingAmount({amount: arg.amount || ''}),
-      WalletsGen.createSetBuildingCurrency({currency: arg.currency || ''}),
+      action.payload.isRequest ? WalletsGen.createClearBuiltRequest() : WalletsGen.createClearBuiltPayment(),
+      WalletsGen.createSetBuildingAmount({amount: action.payload.amount || ''}),
+      WalletsGen.createSetBuildingCurrency({currency: action.payload.currency || 'XLM'}),
       WalletsGen.createLoadDisplayCurrency({
-        accountID: arg.from || Types.noAccountID,
-        setBuildingCurrency: !arg.currency,
+        accountID: action.payload.from || Types.noAccountID,
+        setBuildingCurrency: !action.payload.currency,
       }),
       WalletsGen.createLoadDisplayCurrencies(),
-      WalletsGen.createSetBuildingFrom({from: arg.from || Types.noAccountID}),
-      WalletsGen.createSetBuildingIsRequest({isRequest: !!arg.isRequest}),
-      WalletsGen.createSetBuildingPublicMemo({publicMemo: arg.publicMemo || new HiddenString('')}),
-      WalletsGen.createSetBuildingRecipientType({recipientType: arg.recipientType || 'keybaseUser'}),
-      WalletsGen.createSetBuildingSecretNote({secretNote: arg.secretNote || new HiddenString('')}),
-      WalletsGen.createSetBuildingTo({to: arg.to || ''}),
+      WalletsGen.createSetBuildingFrom({from: action.payload.from || Types.noAccountID}),
+      WalletsGen.createSetBuildingIsRequest({isRequest: !!action.payload.isRequest}),
+      WalletsGen.createSetBuildingPublicMemo({publicMemo: action.payload.publicMemo || new HiddenString('')}),
+      WalletsGen.createSetBuildingRecipientType({
+        recipientType: action.payload.recipientType || 'keybaseUser',
+      }),
+      WalletsGen.createSetBuildingSecretNote({secretNote: action.payload.secretNote || new HiddenString('')}),
+      WalletsGen.createSetBuildingTo({to: action.payload.to || ''}),
+      RouteTreeGen.createNavigateAppend({
+        path: [Constants.sendReceiveFormRouteKey],
+      }),
     ].map(a => Saga.put(a))
   )
-}
 
 const createNewAccount = (state: TypedState, action: WalletsGen.CreateNewAccountPayload) => {
   const {name} = action.payload

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -19,11 +19,13 @@ const mapDispatchToProps = dispatch => ({
     if (wasNew) {
       dispatch(Chat2Gen.createHandleSeeingWallets())
     }
-    dispatch(WalletsGen.createClearBuilding())
-    dispatch(isRequest ? WalletsGen.createClearBuiltRequest() : WalletsGen.createClearBuiltPayment())
-    dispatch(WalletsGen.createSetBuildingIsRequest({isRequest}))
-    dispatch(WalletsGen.createSetBuildingRecipientType({recipientType: 'keybaseUser'}))
-    dispatch(WalletsGen.createSetBuildingTo({to}))
+    dispatch(
+      WalletsGen.createOpenSendRequestForm({
+        isRequest,
+        recipientType: 'keybaseUser',
+        to,
+      })
+    )
     dispatch(
       RouteTreeGen.createNavigateAppend({
         path: [WalletConstants.sendReceiveFormRouteKey],

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -3,9 +3,7 @@ import * as React from 'react'
 import * as Container from '../../../../../util/container'
 import * as Chat2Gen from '../../../../../actions/chat2-gen'
 import * as WalletsGen from '../../../../../actions/wallets-gen'
-import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import * as Constants from '../../../../../constants/chat2'
-import * as WalletConstants from '../../../../../constants/wallets'
 import WalletsIconRender, {type WalletsIconProps as ViewProps} from '.'
 
 const mapStateToProps = state => ({
@@ -24,11 +22,6 @@ const mapDispatchToProps = dispatch => ({
         isRequest,
         recipientType: 'keybaseUser',
         to,
-      })
-    )
-    dispatch(
-      RouteTreeGen.createNavigateAppend({
-        path: [WalletConstants.sendReceiveFormRouteKey],
       })
     )
   },

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -60,7 +60,7 @@ export type MessageTypes = {|
     outParam: ?Array<CurrencyLocal>,
   |},
   'stellar.1.local.getDisplayCurrencyLocal': {|
-    inParam: $ReadOnly<{|accountID: AccountID|}>,
+    inParam: $ReadOnly<{|accountID?: ?AccountID|}>,
     outParam: CurrencyLocal,
   |},
   'stellar.1.local.getPaymentDetailsLocal': {|

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -10,8 +10,6 @@ import * as Constants from '../constants/tracker'
 import * as TrackerTypes from '../constants/types/tracker'
 import * as Types from '../constants/types/profile'
 import * as WalletsGen from '../actions/wallets-gen'
-import * as Route from '../actions/route-tree-gen'
-import * as WalletConstants from '../constants/wallets'
 import {noAccountID} from '../constants/types/wallets'
 import {isInSomeTeam} from '../constants/teams'
 import ErrorComponent from './error-profile'
@@ -117,14 +115,14 @@ const mapDispatchToProps = (dispatch, {setRouteState}: OwnProps) => ({
       )
     ),
   _onSendOrRequestLumens: (to: string, isRequest) => {
-    dispatch(WalletsGen.createClearBuilding())
-    dispatch(isRequest ? WalletsGen.createClearBuiltRequest() : WalletsGen.createClearBuiltPayment())
-    dispatch(WalletsGen.createClearErrors())
-    dispatch(WalletsGen.createSetBuildingRecipientType({recipientType: 'keybaseUser'}))
-    dispatch(WalletsGen.createSetBuildingFrom({from: noAccountID}))
-    dispatch(WalletsGen.createSetBuildingIsRequest({isRequest}))
-    dispatch(WalletsGen.createSetBuildingTo({to}))
-    dispatch(Route.createNavigateAppend({path: [WalletConstants.sendReceiveFormRouteKey]}))
+    dispatch(
+      WalletsGen.createOpenSendRequestForm({
+        from: noAccountID,
+        isRequest,
+        recipientType: 'keybaseUser',
+        to,
+      })
+    )
   },
   onSearch: () => {
     dispatch(createSearchSuggestions({searchKey: 'profileSearch'}))

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -51,9 +51,15 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.displayCurrenciesReceived:
       return state.set('currencies', I.List(action.payload.currencies))
     case WalletsGen.displayCurrencyReceived:
-      return state
-        .update('currencyMap', c => c.set(action.payload.accountID, action.payload.currency))
-        .update('building', b => b.merge({currency: action.payload.currency.code}))
+      // $FlowIssue thinks state is _State
+      return state.withMutations(stateMutable => {
+        if (action.payload.accountID) {
+          stateMutable.update('currencyMap', c => c.set(action.payload.accountID, action.payload.currency))
+        }
+        if (action.payload.setBuildingCurrency) {
+          stateMutable.update('building', b => b.merge({currency: action.payload.currency.code}))
+        }
+      })
     case WalletsGen.secretKeyReceived:
       return state
         .set('exportedSecretKey', action.payload.secretKey)
@@ -245,6 +251,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.requestedPayment:
     case WalletsGen.abandonPayment:
     case WalletsGen.loadSendAssetChoices:
+    case WalletsGen.openSendRequestForm:
       return state
     default:
       /*::

--- a/shared/wallets/receive-modal/container.js
+++ b/shared/wallets/receive-modal/container.js
@@ -1,11 +1,8 @@
 // @flow
-import {connect, isMobile} from '../../util/container'
+import {connect} from '../../util/container'
 import * as Constants from '../../constants/wallets'
 import * as Types from '../../constants/types/wallets'
 import * as WalletsGen from '../../actions/wallets-gen'
-import * as RouteTreeGen from '../../actions/route-tree-gen'
-import {walletsTab, settingsTab} from '../../constants/tabs'
-import {walletsTab as walletsSettingsTab} from '../../constants/settings'
 import Receive from '.'
 
 export type OwnProps = {
@@ -27,13 +24,11 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps}) => ({
   navigateUp: () => dispatch(navigateUp()),
   onRequest: () => {
     const accountID = routeProps.get('accountID')
-    dispatch(WalletsGen.createSetBuildingFrom({from: accountID}))
-    dispatch(WalletsGen.createSetBuildingIsRequest({isRequest: true}))
-    // TODO DESKTOP-7961 navigate to separate receive form
+    dispatch(navigateUp())
     dispatch(
-      RouteTreeGen.createNavigateTo({
-        parentPath: [...(isMobile ? [settingsTab, walletsSettingsTab] : [walletsTab]), 'wallet'],
-        path: [{props: {}, selected: Constants.sendReceiveFormRouteKey}],
+      WalletsGen.createOpenSendRequestForm({
+        from: accountID,
+        isRequest: true,
       })
     )
   },

--- a/shared/wallets/send-form/asset-input/container.js
+++ b/shared/wallets/send-form/asset-input/container.js
@@ -4,7 +4,6 @@ import * as WalletsGen from '../../../actions/wallets-gen'
 import {compose, connect, setDisplayName} from '../../../util/container'
 import * as Route from '../../../actions/route-tree'
 import * as Constants from '../../../constants/wallets'
-import * as Types from '../../../constants/types/wallets'
 
 const mapStateToProps = state => {
   const accountID = state.wallets.selectedAccount
@@ -22,10 +21,6 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = dispatch => ({
-  _refresh: (accountID: Types.AccountID) => {
-    dispatch(WalletsGen.createLoadDisplayCurrencies())
-    dispatch(WalletsGen.createLoadDisplayCurrency({accountID}))
-  },
   onChangeDisplayUnit: () => {
     dispatch(
       Route.navigateAppend([
@@ -46,7 +41,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   inputPlaceholder: stateProps.inputPlaceholder,
   onChangeAmount: dispatchProps.onChangeAmount,
   onChangeDisplayUnit: ownProps.onChooseAsset || dispatchProps.onChangeDisplayUnit,
-  refresh: () => dispatchProps._refresh(stateProps.accountID),
   topLabel: stateProps.topLabel,
   value: stateProps.value,
 })

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -14,70 +14,63 @@ type Props = {|
   value: string,
   warningAsset?: string,
   warningPayee?: string,
-  refresh: () => void,
 |}
 
-export default class AssetInput extends React.Component<Props> {
-  render() {
-    return (
-      <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true} style={styles.container}>
-        {!!this.props.topLabel && (
-          <Kb.Text
-            type="BodySmallSemibold"
-            style={Styles.collapseStyles([styles.topLabel, styles.labelMargin])}
-          >
-            {this.props.topLabel}
-          </Kb.Text>
-        )}
-        <Kb.NewInput
-          autoFocus={true}
-          type="text"
-          keyboardType="numeric"
-          decoration={
-            <Kb.Box2 direction="vertical" style={styles.flexEnd}>
-              <Kb.Text type="HeaderBigExtrabold" style={styles.unit}>
-                {this.props.displayUnit}
-              </Kb.Text>
-              <Kb.Text type="BodySmallPrimaryLink" onClick={this.props.onChangeDisplayUnit}>
-                Change
-              </Kb.Text>
-            </Kb.Box2>
-          }
-          containerStyle={styles.inputContainer}
-          style={styles.input}
-          onChangeText={t => {
-            if (!isNaN(+t) || t === '.') {
-              this.props.onChangeAmount(t)
-            }
-          }}
-          textType="HeaderBigExtrabold"
-          placeholder={this.props.inputPlaceholder}
-          placeholderColor={Styles.globalColors.purple2_40}
-          error={!!this.props.warningAsset}
-          value={this.props.value}
-        />
-        <Available />
-        {!!this.props.warningPayee && (
-          <Kb.Text type="BodySmallError">
-            {this.props.warningPayee} doesn't accept{' '}
-            <Kb.Text type="BodySmallSemibold" style={{color: Styles.globalColors.red}}>
-              {this.props.warningAsset}
+const AssetInput = (props: Props) => {
+  return (
+    <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true} style={styles.container}>
+      {!!props.topLabel && (
+        <Kb.Text
+          type="BodySmallSemibold"
+          style={Styles.collapseStyles([styles.topLabel, styles.labelMargin])}
+        >
+          {props.topLabel}
+        </Kb.Text>
+      )}
+      <Kb.NewInput
+        autoFocus={true}
+        type="text"
+        keyboardType="numeric"
+        decoration={
+          <Kb.Box2 direction="vertical" style={styles.flexEnd}>
+            <Kb.Text type="HeaderBigExtrabold" style={styles.unit}>
+              {props.displayUnit}
             </Kb.Text>
-            . Please pick another asset.
+            <Kb.Text type="BodySmallPrimaryLink" onClick={props.onChangeDisplayUnit}>
+              Change
+            </Kb.Text>
+          </Kb.Box2>
+        }
+        containerStyle={styles.inputContainer}
+        style={styles.input}
+        onChangeText={t => {
+          if (!isNaN(+t) || t === '.') {
+            props.onChangeAmount(t)
+          }
+        }}
+        textType="HeaderBigExtrabold"
+        placeholder={props.inputPlaceholder}
+        placeholderColor={Styles.globalColors.purple2_40}
+        error={!!props.warningAsset}
+        value={props.value}
+      />
+      <Available />
+      {!!props.warningPayee && (
+        <Kb.Text type="BodySmallError">
+          {props.warningPayee} doesn't accept{' '}
+          <Kb.Text type="BodySmallSemibold" style={{color: Styles.globalColors.red}}>
+            {props.warningAsset}
           </Kb.Text>
-        )}
-        <Kb.Box2 direction="horizontal" fullWidth={true} gap="xtiny">
-          <Kb.Text type="BodySmall" style={styles.labelMargin} selectable={true}>
-            {this.props.bottomLabel}
-          </Kb.Text>
-        </Kb.Box2>
+          . Please pick another asset.
+        </Kb.Text>
+      )}
+      <Kb.Box2 direction="horizontal" fullWidth={true} gap="xtiny">
+        <Kb.Text type="BodySmall" style={styles.labelMargin} selectable={true}>
+          {props.bottomLabel}
+        </Kb.Text>
       </Kb.Box2>
-    )
-  }
-
-  componentDidMount() {
-    this.props.refresh()
-  }
+    </Kb.Box2>
+  )
 }
 
 const styles = Styles.styleSheetCreate({
@@ -110,3 +103,5 @@ const styles = Styles.styleSheetCreate({
   },
   topLabel: {color: Styles.globalColors.blue},
 })
+
+export default AssetInput

--- a/shared/wallets/send-form/asset-input/index.stories.js
+++ b/shared/wallets/send-form/asset-input/index.stories.js
@@ -13,7 +13,6 @@ const provider = Sb.createPropProvider({
 const common = {
   onChangeAmount: Sb.action('onChangeAmount'),
   onChangeDisplayUnit: Sb.action('onChangeDisplayUnit'),
-  refresh: Sb.action('onRefresh'),
   topLabel: '',
   value: '',
 }

--- a/shared/wallets/wallet/header/container.js
+++ b/shared/wallets/wallet/header/container.js
@@ -18,18 +18,12 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   _onGoToSendReceive: (from: Types.AccountID, recipientType: Types.CounterpartyType, isRequest: boolean) => {
-    dispatch(WalletsGen.createClearBuilding())
-    dispatch(isRequest ? WalletsGen.createClearBuiltRequest() : WalletsGen.createClearBuiltPayment())
-    dispatch(WalletsGen.createClearErrors())
-    dispatch(WalletsGen.createSetBuildingIsRequest({isRequest}))
-    dispatch(WalletsGen.createSetBuildingRecipientType({recipientType}))
-    dispatch(WalletsGen.createSetBuildingFrom({from}))
     dispatch(
-      ownProps.navigateAppend([
-        {
-          selected: Constants.sendReceiveFormRouteKey,
-        },
-      ])
+      WalletsGen.createOpenSendRequestForm({
+        from,
+        isRequest,
+        recipientType,
+      })
     )
   },
   _onReceive: (accountID: Types.AccountID) =>


### PR DESCRIPTION
Requires #14326 

* Adds an action `openSendRequestForm` that takes all the possible `setBuilding*` params and dispatches the appropriate actions and load calls. Switches all places we nav to a send/request form to use that action.
* Makes `GetDisplayCurrencyLocal` param `accountID` optional and use the default accountID if none is given.

r? @keybase/react-hackers 