### PR TITLE
improve logging for desktop notifications

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1031,10 +1031,11 @@ const desktopNotify = (state: TypedState, action: Chat2Gen.DesktopNotificationPa
     Constants.isUserActivelyLookingAtThisThread(state, conversationIDKey) ||
     meta.isMuted // ignore muted convos
   ) {
+    logger.info('desktopNotify: not sending notification')
     return
   }
 
-  logger.info('Sending Chat notification')
+  logger.info('desktopNotify: sending chat notification')
   let title = ['small', 'big'].includes(meta.teamType) ? meta.teamname : author
   if (meta.teamType === 'big') {
     title += `#${meta.channelname}`
@@ -1061,6 +1062,7 @@ const desktopNotify = (state: TypedState, action: Chat2Gen.DesktopNotificationPa
           const onClose = () => {
             resolve()
           }
+          logger.info('desktopNotify: invoking NotifyPopup for chat notification')
           NotifyPopup(title, {body, sound: state.config.notifySound}, -1, author, onClick, onClose)
         })
     )

--- a/shared/native/notifications.desktop.js
+++ b/shared/native/notifications.desktop.js
@@ -1,5 +1,6 @@
 // @flow
 import {debounce} from 'lodash-es'
+import logger from '../logger'
 
 const rateLimit: {[key: string]: () => void} = {}
 const rateLimitPayloads: {[key: string]: {title: string, opts: ?Object, onClick: ?() => void}} = {}
@@ -35,6 +36,7 @@ export function NotifyPopup(
     }
   }
 
+  logger.info('NotifyPopup: creating notification')
   const notification: any = new window.Notification(title, {...opts, silent: !sound})
   notification.onclick = onClick
   notification.onclose = onClose


### PR DESCRIPTION
@keybase/react-hackers 

Improve the logging story around desktop notifications. Also, it seems like these are subtly broken. I have instances where I see the new log line:

```
logger.info('NotifyPopup: creating notification')
```

but no notification appears.
