### PR TITLE
run_keybase: prettify

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -179,7 +179,7 @@ run_redirector() {
 }
 
 start_systemd() {
-  echo Starting via systemd.
+  echo Starting via systemd...
   # This script is intended to be run after updates, so we need to reload
   # potentially changed unit files.
   systemctl --user daemon-reload


### PR DESCRIPTION
Match with other echos. `Starting via systemd` message while starting keybase UI looked out of place.

After this, the message will look like -
```
...
Starting via systemd...
```
Instead of -
```
...
Starting via systemd.
```