### PR TITLE
plumb through the resolved conversationIDkey and set an isPending flag

### DIFF
--- a/shared/chat/conversation/header-area/container.js
+++ b/shared/chat/conversation/header-area/container.js
@@ -9,6 +9,7 @@ import CreateTeamHeader from '../create-team-header/container'
 
 type OwnProps = {|
   conversationIDKey: Types.ConversationIDKey,
+  isPending: boolean,
   onToggleInfoPanel: () => void,
   infoPanelOpen: boolean,
 |}
@@ -28,6 +29,7 @@ class HeaderArea extends React.PureComponent<Props> {
       </React.Fragment>
     ) : (
       <ConversationHeader
+        isPending={this.props.isPending}
         infoPanelOpen={this.props.infoPanelOpen}
         onToggleInfoPanel={this.props.onToggleInfoPanel}
         conversationIDKey={this.props.conversationIDKey}
@@ -36,12 +38,11 @@ class HeaderArea extends React.PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
-  const isSearching =
-    state.chat2.pendingMode === 'searchingForUsers' &&
-    conversationIDKey === Constants.pendingConversationIDKey
+const mapStateToProps = (state, {conversationIDKey, isPending}: OwnProps) => {
+  const isSearching = state.chat2.pendingMode === 'searchingForUsers' && isPending
   const meta = Constants.getMeta(state, conversationIDKey)
   return {
+    isPending,
     isSearching,
     showTeamOffer: isSearching && meta.participants.size > 1,
   }

--- a/shared/chat/conversation/header-area/normal/container.js
+++ b/shared/chat/conversation/header-area/normal/container.js
@@ -7,10 +7,9 @@ import {ChannelHeader, UsernameHeader} from '.'
 import {branch, compose, renderComponent, connect} from '../../../../util/container'
 import {createShowUserProfile} from '../../../../actions/profile-gen'
 
-const mapStateToProps = (state, {infoPanelOpen, conversationIDKey}) => {
-  const _isPending = conversationIDKey === Constants.pendingConversationIDKey
+const mapStateToProps = (state, {infoPanelOpen, conversationIDKey, isPending}) => {
   let meta = Constants.getMeta(state, conversationIDKey)
-  if (_isPending) {
+  if (isPending) {
     const resolved = Constants.getResolvedPendingConversationIDKey(state)
     if (Constants.isValidConversationIDKey(resolved)) {
       meta = Constants.getMeta(state, resolved)
@@ -21,7 +20,7 @@ const mapStateToProps = (state, {infoPanelOpen, conversationIDKey}) => {
   return {
     _badgeMap: state.chat2.badgeMap,
     _conversationIDKey: conversationIDKey,
-    _isPending,
+    isPending,
     _participants,
     channelName: meta.channelname,
     infoPanelOpen,
@@ -47,13 +46,13 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
       currentConvID !== stateProps._conversationIDKey ? res + currentValue : res,
     0
   ),
-  canOpenInfoPanel: !stateProps._isPending,
+  canOpenInfoPanel: !stateProps.isPending,
   channelName: stateProps.channelName,
   infoPanelOpen: stateProps.infoPanelOpen,
   muted: stateProps.muted,
   onBack: dispatchProps.onBack,
-  onCancelPending: stateProps._isPending ? dispatchProps._onCancel : null,
-  onOpenFolder: stateProps._isPending ? null : dispatchProps._onOpenFolder,
+  onCancelPending: stateProps.isPending ? dispatchProps._onCancel : null,
+  onOpenFolder: stateProps.isPending ? null : dispatchProps._onOpenFolder,
   onShowProfile: dispatchProps.onShowProfile,
   onToggleInfoPanel: dispatchProps.onToggleInfoPanel,
   participants: stateProps._participants.toArray(),

--- a/shared/chat/conversation/input-area/container.js
+++ b/shared/chat/conversation/input-area/container.js
@@ -9,6 +9,7 @@ import {connect} from '../../../util/container'
 type OwnProps = {|
   conversationIDKey: Types.ConversationIDKey,
   focusInputCounter: number,
+  isPending: boolean,
   onScrollDown: () => void,
 |}
 type Props = {|
@@ -17,24 +18,20 @@ type Props = {|
   noInput: boolean,
 |}
 
-const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
+const mapStateToProps = (state, {conversationIDKey, isPending}: OwnProps) => {
   const meta = Constants.getMeta(state, conversationIDKey)
   let noInput = !meta.resetParticipants.isEmpty() || !!meta.wasFinalizedBy
-  let conversationIDKeyToShow = conversationIDKey
 
-  if (conversationIDKey === Constants.pendingConversationIDKey) {
-    const resolved = Constants.getResolvedPendingConversationIDKey(state)
-    if (!Constants.isValidConversationIDKey(resolved)) {
+  if (isPending) {
+    if (!Constants.isValidConversationIDKey(conversationIDKey)) {
       noInput = true
-    } else {
-      conversationIDKeyToShow = resolved
     }
   } else if (conversationIDKey === Constants.pendingWaitingConversationIDKey) {
     noInput = true
   }
 
   return {
-    conversationIDKey: conversationIDKeyToShow,
+    conversationIDKey,
     isPreview: meta.membershipType === 'youArePreviewing',
     noInput,
   }

--- a/shared/chat/conversation/list-area/container.js
+++ b/shared/chat/conversation/list-area/container.js
@@ -55,21 +55,20 @@ class ListArea extends React.PureComponent<Props> {
 
 const searchResultStyle = {...desktopStyles.scrollable, flexGrow: 1}
 
-const mapStateToProps = (state, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey, isPending}) => {
   let type
-  let conversationIDKeyToShow = conversationIDKey
   if (
-    conversationIDKey === Constants.pendingConversationIDKey &&
+    isPending &&
     state.chat2.pendingMode === 'searchingForUsers' &&
     !!SearchConstants.getSearchResultIdsArray(state, {searchKey: 'chatSearch'})
   ) {
     // There are search results; show list
     type = 'search'
   } else {
-    if (conversationIDKey === Constants.pendingConversationIDKey) {
-      const resolvedPendingConversationIDKey = Constants.getResolvedPendingConversationIDKey(state)
+    if (isPending) {
       const inputResults = SearchConstants.getUserInputItemIds(state, {searchKey: 'chatSearch'})
-      switch (resolvedPendingConversationIDKey) {
+      switch (conversationIDKey) {
+        case Constants.pendingConversationIDKey: // fallthrough
         case Constants.noConversationIDKey:
           if (state.chat2.pendingMode === 'searchingForUsers' && !inputResults.length) {
             // No search results + no users in input; show spinner
@@ -86,7 +85,6 @@ const mapStateToProps = (state, {conversationIDKey}) => {
         default:
           // No search results + convo exists; show thread
           type = 'normal'
-          conversationIDKeyToShow = resolvedPendingConversationIDKey
           break
       }
     } else {
@@ -95,7 +93,7 @@ const mapStateToProps = (state, {conversationIDKey}) => {
   }
 
   return {
-    conversationIDKey: conversationIDKeyToShow,
+    conversationIDKey,
     type,
   }
 }

--- a/shared/chat/conversation/normal/container.js
+++ b/shared/chat/conversation/normal/container.js
@@ -9,14 +9,19 @@ import Normal from '.'
 import {compose, connect, withStateHandlers} from '../../../util/container'
 import {chatTab} from '../../../constants/tabs'
 
-const mapStateToProps = (state, {conversationIDKey}) => {
+const mapStateToProps = (state, {conversationIDKey, isPending}) => {
   const showLoader = WaitingConstants.anyWaiting(state, Constants.waitingKeyThreadLoad(conversationIDKey))
   const meta = Constants.getMeta(state, conversationIDKey)
   const infoPanelOpen = Constants.isInfoPanelOpen(state)
-  const isSearching =
-    state.chat2.pendingMode === 'searchingForUsers' &&
-    conversationIDKey === Constants.pendingConversationIDKey
-  return {conversationIDKey, infoPanelOpen, isSearching, showLoader, threadLoadedOffline: meta.offline}
+  const isSearching = state.chat2.pendingMode === 'searchingForUsers' && isPending
+  return {
+    conversationIDKey,
+    infoPanelOpen,
+    isSearching,
+    showLoader,
+    threadLoadedOffline: meta.offline,
+    isPending,
+  }
 }
 
 const mapDispatchToProps = dispatch => ({
@@ -51,6 +56,7 @@ const mergeProps = (stateProps, dispatchProps) => {
     conversationIDKey: stateProps.conversationIDKey,
     infoPanelOpen: stateProps.infoPanelOpen,
     isSearching: stateProps.isSearching,
+    isPending: stateProps.isPending,
     onPaste: (data: Buffer) => dispatchProps._onPaste(stateProps.conversationIDKey, data),
     onAttach: (paths: Array<string>) => dispatchProps._onAttach(stateProps.conversationIDKey, paths),
     onCancelSearch: dispatchProps.onCancelSearch,

--- a/shared/chat/conversation/normal/index.desktop.js
+++ b/shared/chat/conversation/normal/index.desktop.js
@@ -114,18 +114,21 @@ class Conversation extends React.PureComponent<Props, State> {
       >
         {this.props.threadLoadedOffline && <Offline />}
         <HeaderArea
+          isPending={this.props.isPending}
           onToggleInfoPanel={this.props.onToggleInfoPanel}
           infoPanelOpen={this.props.infoPanelOpen}
           conversationIDKey={this.props.conversationIDKey}
         />
         {this.props.showLoader && <LoadingLine />}
         <ListArea
+          isPending={this.props.isPending}
           listScrollDownCounter={this.props.listScrollDownCounter}
           onFocusInput={this.props.onFocusInput}
           conversationIDKey={this.props.conversationIDKey}
         />
         <Banner conversationIDKey={this.props.conversationIDKey} />
         <InputArea
+          isPending={this.props.isPending}
           focusInputCounter={this.props.focusInputCounter}
           onScrollDown={this.props.onScrollDown}
           conversationIDKey={this.props.conversationIDKey}

--- a/shared/chat/conversation/normal/index.native.js
+++ b/shared/chat/conversation/normal/index.native.js
@@ -35,12 +35,14 @@ class Conversation extends React.PureComponent<Props> {
         )}
         {this.props.threadLoadedOffline && <Offline />}
         <HeaderArea
+          isPending={this.props.isPending}
           onToggleInfoPanel={this.props.onToggleInfoPanel}
           infoPanelOpen={false}
           conversationIDKey={this.props.conversationIDKey}
         />
         {this.props.showLoader && <LoadingLine />}
         <ListArea
+          isPending={this.props.isPending}
           onToggleInfoPanel={this.props.onToggleInfoPanel}
           listScrollDownCounter={this.props.listScrollDownCounter}
           onFocusInput={this.props.onFocusInput}
@@ -48,6 +50,7 @@ class Conversation extends React.PureComponent<Props> {
         />
         <Banner conversationIDKey={this.props.conversationIDKey} />
         <InputArea
+          isPending={this.props.isPending}
           focusInputCounter={this.props.focusInputCounter}
           onScrollDown={this.props.onScrollDown}
           conversationIDKey={this.props.conversationIDKey}

--- a/shared/chat/conversation/normal/index.types.js.flow
+++ b/shared/chat/conversation/normal/index.types.js.flow
@@ -1,6 +1,7 @@
 // @flow
 import * as Types from '../../../constants/types/chat2'
 export type Props = {
+  isPending: boolean,
   conversationIDKey: Types.ConversationIDKey,
   focusInputCounter: number,
   infoPanelOpen: boolean,


### PR DESCRIPTION
@keybase/react-hackers this fixes you trying drag/drop or paste an image into a conversation from the new convo flow.

Steps to repro:
1. create new convo
1. select a person who you have an existing convo with
1. drag file or paste image

nothing happens

The reason this happens is we do bookkeeping of the convo and we treat it as a special value PENDING if we're in the middle of building the convo. We also want previews to work so we have a way to resolve the pending to an existing conversation (if it exists)

So before the conversationIDKey in this case would flow down as PENDING, then all the consumers of it would have to check if its pending and act accordingly. But really only a few pieces are pending-aware (the header shows the search bar instead, the input bar does different things).

So now we pass the resolved conversationIDKey so most things act like you're in a regular convo and we additionally pass a new flag `isPending` which tells components it really is a search state