### PR TITLE
use DELETEHISTORY for FilterExploded

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -195,6 +195,10 @@ func (b *basicUnboxConversationInfo) GetExpunge() *chat1.Expunge {
 	return nil
 }
 
+func (b *basicUnboxConversationInfo) GetMaxDeletedUpTo() chat1.MessageID {
+	return 0
+}
+
 func (b *basicUnboxConversationInfo) IsPublic() bool {
 	return b.visibility == keybase1.TLFVisibility_PUBLIC
 }
@@ -230,6 +234,10 @@ func (p *extraInboxUnboxConversationInfo) GetFinalizeInfo() *chat1.ConversationF
 
 func (p *extraInboxUnboxConversationInfo) GetExpunge() *chat1.Expunge {
 	return nil
+}
+
+func (p *extraInboxUnboxConversationInfo) GetMaxDeletedUpTo() chat1.MessageID {
+	return 0
 }
 
 func (p *extraInboxUnboxConversationInfo) IsPublic() bool {

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -153,7 +153,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	s.Debug(ctx, "postProcessThread: thread messages after type filter: %d", len(thread.Messages))
 	// If we have exploded any messages while fetching them from cache, remove
 	// them now.
-	thread.Messages = utils.FilterExploded(conv.GetExpunge(), thread.Messages, s.boxer.clock.Now())
+	thread.Messages = utils.FilterExploded(conv, thread.Messages, s.boxer.clock.Now())
 	s.Debug(ctx, "postProcessThread: thread messages after explode filter: %d", len(thread.Messages))
 
 	// Fetch outbox and tack onto the result

--- a/go/chat/supersedes.go
+++ b/go/chat/supersedes.go
@@ -255,7 +255,7 @@ func (t *basicSupersedesTransform) Run(ctx context.Context,
 				// deleted by a delete-history, retention expunge, or was an
 				// exploding message.
 				mvalid := newMsg.Valid()
-				if !mvalid.IsEphemeral() || mvalid.HideExplosion(conv.GetExpunge(), time.Now()) {
+				if !mvalid.IsEphemeral() || mvalid.HideExplosion(conv.GetMaxDeletedUpTo(), time.Now()) {
 					t.Debug(ctx, "skipping: %d because not valid full", msg.GetMessageID())
 					xformDelete(msg.GetMessageID())
 					continue

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -56,6 +56,7 @@ type UnboxConversationInfo interface {
 	GetMembersType() chat1.ConversationMembersType
 	GetFinalizeInfo() *chat1.ConversationFinalizeInfo
 	GetExpunge() *chat1.Expunge
+	GetMaxDeletedUpTo() chat1.MessageID
 	IsPublic() bool
 }
 


### PR DESCRIPTION
use `DELETEHISTORY` in the snippet calculation so we show a blank snippet when this is the latest msg in the conversation, also hides the ash lines appropriately when a DELETEHISTORY is added to the conversation

depends on server changes: https://github.com/keybase/keybase/pull/3062