### PR TITLE
Swap devices and git tabs on desktop

### DIFF
--- a/shared/constants/tabs.js
+++ b/shared/constants/tabs.js
@@ -49,8 +49,8 @@ const desktopTabOrder = [
   fsTab,
   teamsTab,
   flags.walletsEnabled ? walletsTab : null,
-  devicesTab,
   gitTab,
+  devicesTab,
   settingsTab,
 ].filter(Boolean)
 


### PR DESCRIPTION
@keybase/react-hackers 

Tested that the hotkey order is still correct after the swap.