### PR TITLE
Make assets values clickable but not selectable

### DIFF
--- a/shared/wallets/asset/index.js
+++ b/shared/wallets/asset/index.js
@@ -52,8 +52,6 @@ export default class Asset extends React.Component<Props, State> {
               <Text
                 type="BodyExtrabold"
                 lineClamp={1}
-                onClick={event => event.stopPropagation()}
-                selectable={true}
                 style={{color: globalColors.purple2}}
               >
                 {this.props.balance} {this.props.code}
@@ -61,8 +59,6 @@ export default class Asset extends React.Component<Props, State> {
               <Text
                 type="BodySmall"
                 lineClamp={1}
-                onClick={event => event.stopPropagation()}
-                selectable={true}
               >
                 {this.props.equivBalance}
               </Text>


### PR DESCRIPTION
@keybase/react-hackers

Now clicks on expandable/navigateable rows don't use the text cursor and only perform the expand/navigate, and then once you're in to seeing more detail you can select numbers there.