### PR TITLE
Fix to field clearing out when you come back from currency selection

### DIFF
--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -92,6 +92,7 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps> {
             multiline={true}
             rowsMin={2}
             rowsMax={3}
+            value={this.props.recipientPublicKey}
           />
         </Kb.Box2>
         {!!this.props.errorMessage && (


### PR DESCRIPTION
@keybase/react-hackers 

We were unintentionally using it as an uncontrolled input.