### PR TITLE
Fix KEYBASE_FEATURES env for ui

### DIFF
--- a/shared/util/feature-flags.desktop.js
+++ b/shared/util/feature-flags.desktop.js
@@ -5,9 +5,10 @@ import type {FeatureFlags} from './feature-flags'
 // To enable a feature, include it in the environment variable KEYBASE_FEATURES.
 // For example, KEYBASE_FEATURES=tracker2,login,awesomefeature
 
-let features =
-  (featureFlagsOverride && featureFlagsOverride.split(',')) ||
-  (process.env['KEYBASE_FEATURES'] || '').split(',')
+let features = [
+  ...(featureFlagsOverride && featureFlagsOverride.split(',')),
+  ...(process.env['KEYBASE_FEATURES'] || '').split(','),
+]
 
 const featureOn = (key: $Keys<FeatureFlags>) => features.includes(key)
 


### PR DESCRIPTION
@keybase/react-hackers If anything is in the featureFlagsOverride it ignores the KEYBASE_FEATURES env. Which I'd imagine is not intentional