### PR TITLE
give the JS info about the type of avatar updated CORE-9208

### DIFF
--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -1666,16 +1666,16 @@ func (n *NotifyRouter) HandleNewTeamEK(ctx context.Context, teamID keybase1.Team
 	n.G().Log.CDebugf(ctx, "- Sent NewTeamEK notification")
 }
 
-func (n *NotifyRouter) HandleAvatarUpdated(ctx context.Context, name string, formats []keybase1.AvatarFormat) {
+func (n *NotifyRouter) HandleAvatarUpdated(ctx context.Context, name string, formats []keybase1.AvatarFormat,
+	typ keybase1.AvatarUpdateType) {
 	if n == nil {
 		return
 	}
-
 	arg := keybase1.AvatarUpdatedArg{
 		Name:    name,
 		Formats: formats,
+		Typ:     typ,
 	}
-
 	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
 		if n.getNotificationChannels(id).Team {
 			go func() {

--- a/go/protocol/keybase1/avatars.go
+++ b/go/protocol/keybase1/avatars.go
@@ -53,8 +53,9 @@ func (o LoadAvatarsRes) DeepCopy() LoadAvatarsRes {
 }
 
 type AvatarClearCacheMsg struct {
-	Name    string         `codec:"name" json:"name"`
-	Formats []AvatarFormat `codec:"formats" json:"formats"`
+	Name    string           `codec:"name" json:"name"`
+	Formats []AvatarFormat   `codec:"formats" json:"formats"`
+	Typ     AvatarUpdateType `codec:"typ" json:"typ"`
 }
 
 func (o AvatarClearCacheMsg) DeepCopy() AvatarClearCacheMsg {
@@ -71,6 +72,7 @@ func (o AvatarClearCacheMsg) DeepCopy() AvatarClearCacheMsg {
 			}
 			return ret
 		})(o.Formats),
+		Typ: o.Typ.DeepCopy(),
 	}
 }
 

--- a/go/protocol/keybase1/notify_team.go
+++ b/go/protocol/keybase1/notify_team.go
@@ -24,6 +24,35 @@ func (o TeamChangeSet) DeepCopy() TeamChangeSet {
 	}
 }
 
+type AvatarUpdateType int
+
+const (
+	AvatarUpdateType_NONE AvatarUpdateType = 0
+	AvatarUpdateType_USER AvatarUpdateType = 1
+	AvatarUpdateType_TEAM AvatarUpdateType = 2
+)
+
+func (o AvatarUpdateType) DeepCopy() AvatarUpdateType { return o }
+
+var AvatarUpdateTypeMap = map[string]AvatarUpdateType{
+	"NONE": 0,
+	"USER": 1,
+	"TEAM": 2,
+}
+
+var AvatarUpdateTypeRevMap = map[AvatarUpdateType]string{
+	0: "NONE",
+	1: "USER",
+	2: "TEAM",
+}
+
+func (e AvatarUpdateType) String() string {
+	if v, ok := AvatarUpdateTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type TeamChangedByIDArg struct {
 	TeamID       TeamID        `codec:"teamID" json:"teamID"`
 	LatestSeqno  Seqno         `codec:"latestSeqno" json:"latestSeqno"`
@@ -55,8 +84,9 @@ type NewlyAddedToTeamArg struct {
 }
 
 type AvatarUpdatedArg struct {
-	Name    string         `codec:"name" json:"name"`
-	Formats []AvatarFormat `codec:"formats" json:"formats"`
+	Name    string           `codec:"name" json:"name"`
+	Formats []AvatarFormat   `codec:"formats" json:"formats"`
+	Typ     AvatarUpdateType `codec:"typ" json:"typ"`
 }
 
 type NotifyTeamInterface interface {

--- a/go/service/avatars.go
+++ b/go/service/avatars.go
@@ -97,8 +97,7 @@ func (r *avatarGregorHandler) clearName(ctx context.Context, cli gregor1.Incomin
 		if err := r.source.ClearCacheForName(m, msg.Name, msg.Formats); err != nil {
 			return err
 		}
-
-		r.G().NotifyRouter.HandleAvatarUpdated(ctx, msg.Name, msg.Formats)
+		r.G().NotifyRouter.HandleAvatarUpdated(ctx, msg.Name, msg.Formats, msg.Typ)
 	}
 
 	return r.G().GregorDismisser.DismissItem(ctx, cli, item.Metadata().MsgID())

--- a/protocol/avdl/keybase1/avatars.avdl
+++ b/protocol/avdl/keybase1/avatars.avdl
@@ -17,5 +17,7 @@ protocol avatars {
         string name;
         @jsonkey("formats")
         array<AvatarFormat> formats;
+        @jsonkey("typ")
+        AvatarUpdateType typ;
     }
 }

--- a/protocol/avdl/keybase1/notify_team.avdl
+++ b/protocol/avdl/keybase1/notify_team.avdl
@@ -41,5 +41,10 @@ protocol NotifyTeam {
 
   void newlyAddedToTeam(TeamID teamID) oneway;
 
-  void avatarUpdated(string name, array<AvatarFormat> formats) oneway;
+  enum AvatarUpdateType {
+    NONE_0,
+    USER_1,
+    TEAM_2
+  }
+  void avatarUpdated(string name, array<AvatarFormat> formats, AvatarUpdateType typ) oneway;
 }

--- a/protocol/json/keybase1/avatars.json
+++ b/protocol/json/keybase1/avatars.json
@@ -53,6 +53,11 @@
           },
           "name": "formats",
           "jsonkey": "formats"
+        },
+        {
+          "type": "AvatarUpdateType",
+          "name": "typ",
+          "jsonkey": "typ"
         }
       ]
     }

--- a/protocol/json/keybase1/notify_team.json
+++ b/protocol/json/keybase1/notify_team.json
@@ -28,6 +28,15 @@
           "name": "misc"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "AvatarUpdateType",
+      "symbols": [
+        "NONE_0",
+        "USER_1",
+        "TEAM_2"
+      ]
     }
   ],
   "messages": {
@@ -127,6 +136,10 @@
             "type": "array",
             "items": "AvatarFormat"
           }
+        },
+        {
+          "name": "typ",
+          "type": "AvatarUpdateType"
         }
       ],
       "response": null,

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -1131,12 +1131,21 @@ const setupEngineListeners = () => {
         }
         yield arrayOfActionsToSequentially(getLoadCalls())
       }),
-    'keybase.1.NotifyTeam.avatarUpdated': ({name}) =>
+    'keybase.1.NotifyTeam.avatarUpdated': ({name, formats, typ}) =>
       Saga.call(function*() {
-        const state = yield Saga.select()
-        yield state.teams.teamnames.includes(name)
-          ? Saga.put(ConfigGen.createLoadTeamAvatars({teamnames: [name]}))
-          : Saga.put(ConfigGen.createLoadAvatars({usernames: [name]}))
+        switch (typ) {
+          case RPCTypes.notifyTeamAvatarUpdateType.none:
+            // don't know what it is, so try both
+            yield Saga.put(ConfigGen.createLoadTeamAvatars({teamnames: [name]}))
+            yield Saga.put(ConfigGen.createLoadAvatars({usernames: [name]}))
+            break
+          case RPCTypes.notifyTeamAvatarUpdateType.user:
+            yield Saga.put(ConfigGen.createLoadAvatars({usernames: [name]}))
+            break
+          case RPCTypes.notifyTeamAvatarUpdateType.team:
+            yield Saga.put(ConfigGen.createLoadTeamAvatars({teamnames: [name]}))
+            break
+        }
       }),
   })
 }

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -459,6 +459,12 @@ export const kbfsCommonFSStatusCode = {
   error: 2,
 }
 
+export const notifyTeamAvatarUpdateType = {
+  none: 0,
+  user: 1,
+  team: 2,
+}
+
 export const passphraseCommonPassphraseType = {
   none: 0,
   paperKey: 1,

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -104,7 +104,7 @@ export type MessageTypes = {|
     outParam: void,
   |},
   'keybase.1.NotifyTeam.avatarUpdated': {|
-    inParam: $ReadOnly<{|name: String, formats?: ?Array<AvatarFormat>|}>,
+    inParam: $ReadOnly<{|name: String, formats?: ?Array<AvatarFormat>, typ: AvatarUpdateType|}>,
     outParam: void,
   |},
   'keybase.1.NotifyTeam.newlyAddedToTeam': {|
@@ -1398,6 +1398,12 @@ export const kbfsCommonFSStatusCode = {
   error: 2,
 }
 
+export const notifyTeamAvatarUpdateType = {
+  none: 0,
+  user: 1,
+  team: 2,
+}
+
 export const passphraseCommonPassphraseType = {
   none: 0,
   paperKey: 1,
@@ -1751,8 +1757,13 @@ export type AuthenticityType =
   | 1 // REPUDIABLE_1
   | 2 // ANONYMOUS_2
 
-export type AvatarClearCacheMsg = $ReadOnly<{name: String, formats?: ?Array<AvatarFormat>}>
+export type AvatarClearCacheMsg = $ReadOnly<{name: String, formats?: ?Array<AvatarFormat>, typ: AvatarUpdateType}>
 export type AvatarFormat = String
+export type AvatarUpdateType =
+  | 0 // NONE_0
+  | 1 // USER_1
+  | 2 // TEAM_2
+
 export type AvatarUrl = String
 export type BadgeConversationInfo = $ReadOnly<{convID: ChatConversationID, badgeCounts: {[key: string]: Int}, unreadMessages: Int}>
 export type BadgeState = $ReadOnly<{newTlfs: Int, rekeysNeeded: Int, newFollowers: Int, inboxVers: Int, homeTodoItems: Int, newDevices?: ?Array<DeviceID>, revokedDevices?: ?Array<DeviceID>, conversations?: ?Array<BadgeConversationInfo>, newGitRepoGlobalUniqueIDs?: ?Array<String>, newTeamNames?: ?Array<String>, newTeamAccessRequests?: ?Array<String>, teamsWithResetUsers?: ?Array<TeamMemberOutReset>, unreadWalletAccounts?: ?Array<WalletAccountInfo>}>


### PR DESCRIPTION
The avatar updated message did not contain any information about whether or not the name corresponded to a user or team. Previously, the JS code attempt to figure it out by looking in the store to see if the name matched any known team names. However, the store is not kept up to date in this manner, so unless the user visited the teams tab before the avatar change was made, then it would fail. 

cc @chrisnojima 