### PR TITLE
always update if trusted state changes

### DIFF
--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -110,13 +110,15 @@ export const updateMeta = (
   meta: Types.ConversationMeta
 ): Types.ConversationMeta => {
   // Older/same version and same state?
-  if (meta.inboxVersion === old.inboxVersion) {
-    return old.merge({
-      snippet: meta.snippet,
-      snippetDecoration: meta.snippetDecoration,
-    })
-  } else if (meta.inboxVersion <= old.inboxVersion && meta.trustedState === old.trustedState) {
-    return old
+  if (meta.trustedState === old.trustedState) {
+    if (meta.inboxVersion === old.inboxVersion) {
+      return old.merge({
+        snippet: meta.snippet,
+        snippetDecoration: meta.snippetDecoration,
+      })
+    } else if (meta.inboxVersion < old.inboxVersion) {
+      return old
+    }
   }
 
   const participants = old.participants.equals(meta.participants) ? old.participants : meta.participants


### PR DESCRIPTION
cc @joshblum 

Always update to new meta payload if the trusted state changes. This fixes a problem where channel names don't load if the data doesn't come up in local metadata (recent regression noticed by @xgess). 