### PR TITLE
Gate showing generic social proofs

### DIFF
--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -110,6 +110,7 @@ func (p *proofServices) ListProofCheckers() []string {
 }
 
 func (p *proofServices) loadParamProofServices() {
+	// TODO Remove with CORE-8969
 	shouldRun := p.G().Env.GetFeatureFlags().Admin() || p.G().Env.GetRunMode() == libkb.DevelRunMode || p.G().Env.RunningInCI()
 
 	if !shouldRun {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -175,11 +175,8 @@ func (w *WebProofChainLink) GetProofType() keybase1.ProofType {
 
 func (w *WebProofChainLink) ToTrackingStatement(state keybase1.ProofState) (*jsonw.Wrapper, error) {
 	ret := w.BaseToTrackingStatement(state)
-	err := remoteProofToTrackingStatement(w, ret)
-	if err != nil {
-		ret = nil
-	}
-	return ret, err
+	remoteProofToTrackingStatement(w, ret)
+	return ret, nil
 }
 
 func (w *WebProofChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error {
@@ -257,9 +254,7 @@ func (s *SocialProofChainLink) GetService() string { return s.service }
 
 func (s *SocialProofChainLink) ToTrackingStatement(state keybase1.ProofState) (*jsonw.Wrapper, error) {
 	ret := s.BaseToTrackingStatement(state)
-	if err := remoteProofToTrackingStatement(s, ret); err != nil {
-		return nil, err
-	}
+	remoteProofToTrackingStatement(s, ret)
 	return ret, nil
 }
 
@@ -582,7 +577,7 @@ func convertTrackedProofToServiceBlock(g *GlobalContext, proof *jsonw.Wrapper, i
 		return nil
 	}
 	proofType := keybase1.ProofType(t)
-	if isProofTypeDefunct(proofType) {
+	if isProofTypeDefunct(g, proofType) {
 		g.Log.Debug("Ignoring now defunct proof type %q at index=%d", proofType, index)
 		return nil
 	}
@@ -1345,13 +1340,22 @@ func (idt *IdentityTable) populate(m MetaContext) (err error) {
 	return nil
 }
 
-func isProofTypeDefunct(typ keybase1.ProofType) bool {
-	return typ == keybase1.ProofType_COINBASE
+func isProofTypeDefunct(g *GlobalContext, typ keybase1.ProofType) bool {
+	switch typ {
+	case keybase1.ProofType_COINBASE:
+		return true
+	case keybase1.ProofType_GENERIC_SOCIAL:
+		// TODO Remove with CORE-8969
+		shouldRun := g.Env.GetFeatureFlags().Admin() || g.Env.GetRunMode() == DevelRunMode || g.Env.RunningInCI()
+		return !shouldRun
+	default:
+		return false
+	}
 }
 
 func (idt *IdentityTable) insertRemoteProof(link RemoteProofChainLink) {
 
-	if isProofTypeDefunct(link.GetProofType()) {
+	if isProofTypeDefunct(idt.G(), link.GetProofType()) {
 		idt.G().Log.Debug("Ignoring now-defunct proof: %s", link.ToDebugString())
 		return
 	}
@@ -1624,7 +1628,7 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 	// for the purposes of testing.
 	pc, res.err = MakeProofChecker(m.G().GetProofServices(), p)
 
-	if res.err != nil {
+	if res.err != nil || pc == nil {
 		return
 	}
 

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -229,13 +229,11 @@ func (g *GenericChainLink) BaseToTrackingStatement(state keybase1.ProofState) *j
 	return ret
 }
 
-func remoteProofToTrackingStatement(s RemoteProofChainLink, base *jsonw.Wrapper) error {
+func remoteProofToTrackingStatement(s RemoteProofChainLink, base *jsonw.Wrapper) {
 	proofType := s.GetProofType()
-
 	base.AtKey("remote_key_proof").SetKey("proof_type", jsonw.NewInt(int(proofType)))
 	base.AtKey("remote_key_proof").SetKey("check_data_json", s.CheckDataJSON())
 	base.SetKey("sig_type", jsonw.NewInt(SigTypeRemoteProof))
-	return nil
 }
 
 type HighSkip struct {


### PR DESCRIPTION
mark `GENERIC_SOCIAL` proofs as defunct to prevent rendering before we release. previously errors of the form:
```
$ kb id
▶ INFO Identifying tester
✔ public key fingerprint: B8F0 A75E A61B 6125 BAB6 CE7F A4EB 716A AADA 0E82
✔ "tester" on gubble.social failed: No proof service for type: gubble.social (code=305)
✔ "abc123" on colorbase.modalduality.org failed: No proof service for type: colorbase.modalduality.org (code=305)
✔ "tester" on rooter: http://localhost:3000/_/api/1.0/rooter/tester/e7168324024dfedcddee013b6d2cce03.json [cached 2018-10-29 10:47:43 EDT]
✔ "tester" on gubble.cloud failed: No proof service for type: gubble.cloud (code=305)
```
or 

![screen shot 2018-10-29 at 11 13 43 am](https://user-images.githubusercontent.com/1144020/47659629-bdf90f80-db6b-11e8-97db-46bb75e76136.png)
would show, but no more.