### PR TITLE
fix border on really remove account dialog

### DIFF
--- a/shared/wallets/wallet/settings/popups/really-remove-account/index.js
+++ b/shared/wallets/wallet/settings/popups/really-remove-account/index.js
@@ -41,8 +41,8 @@ class ReallyRemoveAccountPopup extends React.Component<Props, State> {
     return (
       <WalletPopup
         onClose={this.props.onCancel}
-        containerStyle={styles.backgroundColor}
-        headerStyle={Styles.collapseStyles([styles.backgroundColor, styles.header])}
+        containerStyle={styles.background}
+        headerStyle={Styles.collapseStyles([styles.background, styles.header])}
         bottomButtons={[
           <Kb.Button
             fullWidth={Styles.isMobile}
@@ -92,9 +92,14 @@ class ReallyRemoveAccountPopup extends React.Component<Props, State> {
 }
 
 const styles = Styles.styleSheetCreate({
-  backgroundColor: {
-    backgroundColor: Styles.globalColors.yellow,
-  },
+  background: Styles.platformStyles({
+    common: {
+      backgroundColor: Styles.globalColors.yellow,
+    },
+    isElectron: {
+      borderRadius: 4,
+    },
+  }),
   header: {
     borderBottomWidth: 0,
   },


### PR DESCRIPTION
@keybase/react-hackers should we add an `overflow: 'hidden'` on the dialog container? I think that'd knock out a bunch of these issues. Not sure if there are still any places where we need to render outside the dialog