### PR TITLE
Nix search package

### DIFF
--- a/go/chat/search_constants.go
+++ b/go/chat/search_constants.go
@@ -1,4 +1,4 @@
-package search
+package chat
 
 const defaultPageSize = 300
 const MaxAllowedSearchHits = 10000

--- a/go/chat/search_indexer.go
+++ b/go/chat/search_indexer.go
@@ -1,4 +1,4 @@
-package search
+package chat
 
 import (
 	"context"

--- a/go/chat/search_regexp.go
+++ b/go/chat/search_regexp.go
@@ -1,4 +1,4 @@
-package search
+package chat
 
 import (
 	"context"

--- a/go/chat/search_storage.go
+++ b/go/chat/search_storage.go
@@ -1,4 +1,4 @@
-package search
+package chat
 
 import (
 	"context"

--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/chat/search"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/stellar1"
@@ -346,14 +345,14 @@ func TestChatSearchInbox(t *testing.T) {
 		listener2 := newServerChatListener()
 		tc2.h.G().NotifyRouter.SetListener(listener2)
 
-		indexer1 := search.NewIndexer(g1)
+		indexer1 := NewIndexer(g1)
 		consumeCh1 := make(chan chat1.ConversationID, 100)
 		reindexCh1 := make(chan chat1.ConversationID, 100)
 		indexer1.SetConsumeCh(consumeCh1)
 		indexer1.SetReindexCh(reindexCh1)
 		g1.Indexer = indexer1
 
-		indexer2 := search.NewIndexer(g2)
+		indexer2 := NewIndexer(g2)
 		consumeCh2 := make(chan chat1.ConversationID, 100)
 		reindexCh2 := make(chan chat1.ConversationID, 100)
 		indexer2.SetConsumeCh(consumeCh2)
@@ -484,7 +483,7 @@ func TestChatSearchInbox(t *testing.T) {
 					1:      true, // tlf name
 					msgID1: true,
 				},
-				Version: search.IndexVersion,
+				Version: IndexVersion,
 			},
 		}
 		verifyIndex(expectedIndex)

--- a/go/chat/search_utils.go
+++ b/go/chat/search_utils.go
@@ -1,4 +1,4 @@
-package search
+package chat
 
 import (
 	"context"

--- a/go/chat/search_utils_test.go
+++ b/go/chat/search_utils_test.go
@@ -1,4 +1,4 @@
-package search
+package chat
 
 import (
 	"regexp"

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 
 	"github.com/keybase/client/go/chat/globals"
-	"github.com/keybase/client/go/chat/search"
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
@@ -268,11 +267,11 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	g.TeamChannelSource = NewCachingTeamChannelSource(g, getRI)
 	g.ActivityNotifier = NewNotifyRouterActivityRouter(g)
 
-	searcher := search.NewRegexpSearcher(g)
+	searcher := NewRegexpSearcher(g)
 	// Force small pages during tests to ensure we fetch context from new pages
 	searcher.SetPageSize(2)
 	g.RegexpSearcher = searcher
-	indexer := search.NewIndexer(g)
+	indexer := NewIndexer(g)
 	indexer.SetPageSize(2)
 	g.Indexer = indexer
 	g.AttachmentURLSrv = types.DummyAttachmentHTTPSrv{}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/msgchecker"
-	"github.com/keybase/client/go/chat/search"
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
@@ -339,11 +338,11 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	chatSyncer := NewSyncer(g)
 	g.Syncer = chatSyncer
 	g.ConnectivityMonitor = &libkb.NullConnectivityMonitor{}
-	searcher := search.NewRegexpSearcher(g)
+	searcher := NewRegexpSearcher(g)
 	// Force small pages during tests to ensure we fetch context from new pages
 	searcher.SetPageSize(2)
 	g.RegexpSearcher = searcher
-	indexer := search.NewIndexer(g)
+	indexer := NewIndexer(g)
 	indexer.SetPageSize(2)
 	g.Indexer = indexer
 

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/keybase/cli"
+	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/globals"
-	"github.com/keybase/client/go/chat/search"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -107,7 +107,7 @@ var chatSearchFlags = []cli.Flag{
 	cli.IntFlag{
 		Name:  "max-hits",
 		Value: 10,
-		Usage: fmt.Sprintf("Specify the maximum number of search hits to get. Maximum value is %d.", search.MaxAllowedSearchHits),
+		Usage: fmt.Sprintf("Specify the maximum number of search hits to get. Maximum value is %d.", chat.MaxAllowedSearchHits),
 	},
 	cli.StringFlag{
 		Name:  "sent-by",

--- a/go/client/cmd_chat_search_inbox.go
+++ b/go/client/cmd_chat_search_inbox.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/araddon/dateparse"
 	"github.com/keybase/cli"
-	"github.com/keybase/client/go/chat/search"
+	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -111,8 +111,8 @@ func (c *CmdChatSearchInbox) ParseArgv(ctx *cli.Context) (err error) {
 	}
 
 	c.opts.MaxHits = ctx.Int("max-hits")
-	if c.opts.MaxHits > search.MaxAllowedSearchHits {
-		return fmt.Errorf("max-hits cannot exceed %d.", search.MaxAllowedSearchHits)
+	if c.opts.MaxHits > chat.MaxAllowedSearchHits {
+		return fmt.Errorf("max-hits cannot exceed %d.", chat.MaxAllowedSearchHits)
 	}
 	c.opts.MaxConvs = ctx.Int("max-convs")
 

--- a/go/client/cmd_chat_search_regexp.go
+++ b/go/client/cmd_chat_search_regexp.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/araddon/dateparse"
 	"github.com/keybase/cli"
-	"github.com/keybase/client/go/chat/search"
+	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -54,7 +54,7 @@ func newCmdChatSearchRegexp(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 			cli.IntFlag{
 				Name:  "max-messages",
 				Value: 10000,
-				Usage: fmt.Sprintf("Specify the maximum number of messages to search. Maximum value is %d.", search.MaxAllowedSearchMessages),
+				Usage: fmt.Sprintf("Specify the maximum number of messages to search. Maximum value is %d.", chat.MaxAllowedSearchMessages),
 			},
 		),
 	}
@@ -152,12 +152,12 @@ func (c *CmdChatSearchRegexp) ParseArgv(ctx *cli.Context) (err error) {
 	}
 
 	c.opts.MaxHits = ctx.Int("max-hits")
-	if c.opts.MaxHits > search.MaxAllowedSearchHits {
-		return fmt.Errorf("max-hits cannot exceed %d.", search.MaxAllowedSearchHits)
+	if c.opts.MaxHits > chat.MaxAllowedSearchHits {
+		return fmt.Errorf("max-hits cannot exceed %d.", chat.MaxAllowedSearchHits)
 	}
 	c.opts.MaxMessages = ctx.Int("max-messages")
-	if c.opts.MaxMessages > search.MaxAllowedSearchMessages {
-		return fmt.Errorf("max-messages cannot exceed %d.", search.MaxAllowedSearchMessages)
+	if c.opts.MaxMessages > chat.MaxAllowedSearchMessages {
+		return fmt.Errorf("max-messages cannot exceed %d.", chat.MaxAllowedSearchMessages)
 	}
 
 	c.opts.AfterContext = ctx.Int("after-context")

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/attachments"
 	"github.com/keybase/client/go/chat/globals"
-	"github.com/keybase/client/go/chat/search"
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/ephemeral"
@@ -412,8 +411,8 @@ func (d *Service) SetupChatModules(ri func() chat1.RemoteInterface) {
 	g.ConvSource = chat.NewConversationSource(g, g.Env.GetConvSourceType(),
 		boxer, chatStorage, ri)
 	chatStorage.SetAssetDeleter(g.ConvSource)
-	g.RegexpSearcher = search.NewRegexpSearcher(g)
-	g.Indexer = search.NewIndexer(g)
+	g.RegexpSearcher = chat.NewRegexpSearcher(g)
+	g.Indexer = chat.NewIndexer(g)
 	g.ServerCacheVersions = storage.NewServerVersions(g)
 
 	// Syncer and retriers


### PR DESCRIPTION
refactors `search` package into the `chat` package in prep for index syncing.

a bunch of stuff is chat package specific `NewBlockingSender`, `NewBoxer`, `NewConversation` etc, seems easier to do this than hit import nightmare. separated so the diff is easier when we do the syncing