### PR TITLE
allow a single write to happen per JSONFile CORE-9350

### DIFF
--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -30,7 +30,7 @@ type JSONFile struct {
 	which    string
 	jw       *jsonw.Wrapper
 	exists   bool
-	setMutex sync.Mutex
+	setMutex sync.RWMutex
 
 	txMutex sync.Mutex
 	tx      *jsonFileTransaction
@@ -380,10 +380,14 @@ func (f *JSONFile) GetFilename() string {
 }
 
 func (f *JSONFile) GetInterfaceAtPath(p string) (i interface{}, err error) {
+	f.setMutex.RLock()
+	defer f.setMutex.RUnlock()
 	return f.jw.AtPath(p).GetInterface()
 }
 
 func (f *JSONFile) GetStringAtPath(p string) (ret string, isSet bool) {
+	f.setMutex.RLock()
+	defer f.setMutex.RUnlock()
 	i, isSet := f.getValueAtPath(p, getString)
 	if isSet {
 		ret = i.(string)
@@ -392,6 +396,8 @@ func (f *JSONFile) GetStringAtPath(p string) (ret string, isSet bool) {
 }
 
 func (f *JSONFile) GetBoolAtPath(p string) (ret bool, isSet bool) {
+	f.setMutex.RLock()
+	defer f.setMutex.RUnlock()
 	i, isSet := f.getValueAtPath(p, getBool)
 	if isSet {
 		ret = i.(bool)
@@ -400,6 +406,8 @@ func (f *JSONFile) GetBoolAtPath(p string) (ret bool, isSet bool) {
 }
 
 func (f *JSONFile) GetIntAtPath(p string) (ret int, isSet bool) {
+	f.setMutex.RLock()
+	defer f.setMutex.RUnlock()
 	i, isSet := f.getValueAtPath(p, getInt)
 	if isSet {
 		ret = i.(int)
@@ -408,6 +416,8 @@ func (f *JSONFile) GetIntAtPath(p string) (ret int, isSet bool) {
 }
 
 func (f *JSONFile) GetNullAtPath(p string) (isSet bool) {
+	f.setMutex.RLock()
+	defer f.setMutex.RUnlock()
 	w := f.jw.AtPath(p)
 	isSet = w.IsNil() && w.Error() == nil
 	return isSet

--- a/go/libkb/json.go
+++ b/go/libkb/json.go
@@ -30,6 +30,7 @@ type JSONFile struct {
 	which    string
 	jw       *jsonw.Wrapper
 	exists   bool
+	setMutex sync.Mutex
 
 	txMutex sync.Mutex
 	tx      *jsonFileTransaction
@@ -425,22 +426,32 @@ func (f *JSONFile) setValueAtPath(p string, getter valueGetter, v interface{}) e
 }
 
 func (f *JSONFile) SetStringAtPath(p string, v string) error {
+	f.setMutex.Lock()
+	defer f.setMutex.Unlock()
 	return f.setValueAtPath(p, getString, v)
 }
 
 func (f *JSONFile) SetBoolAtPath(p string, v bool) error {
+	f.setMutex.Lock()
+	defer f.setMutex.Unlock()
 	return f.setValueAtPath(p, getBool, v)
 }
 
 func (f *JSONFile) SetIntAtPath(p string, v int) error {
+	f.setMutex.Lock()
+	defer f.setMutex.Unlock()
 	return f.setValueAtPath(p, getInt, v)
 }
 
 func (f *JSONFile) SetInt64AtPath(p string, v int64) error {
+	f.setMutex.Lock()
+	defer f.setMutex.Unlock()
 	return f.setValueAtPath(p, getInt, v)
 }
 
 func (f *JSONFile) SetNullAtPath(p string) (err error) {
+	f.setMutex.Lock()
+	defer f.setMutex.Unlock()
 	existing := f.jw.AtPath(p)
 	if !existing.IsNil() || existing.Error() != nil {
 		err = f.jw.SetValueAtPath(p, jsonw.NewNil())


### PR DESCRIPTION
Otherwise we can have multiple threads trying to write on the same `JSONFile`, which will expose a map concurrent read/write in `jsonw`.