### PR TITLE
Use black_75_on_white so emojis don't become transparent

### DIFF
--- a/shared/wallets/send-form/note-and-memo/index.js
+++ b/shared/wallets/send-form/note-and-memo/index.js
@@ -213,7 +213,7 @@ const styles = Styles.styleSheetCreate({
     flex: 1,
   },
   input: {
-    color: Styles.globalColors.black_75,
+    color: Styles.globalColors.black_75_on_white,
     padding: 0,
   },
 })


### PR DESCRIPTION
@keybase/react-hackers @cecileboucheron 