### PR TITLE
routing fixes for moveOrCopy and gray out bad destinations

### DIFF
--- a/shared/actions/fs-gen.js
+++ b/shared/actions/fs-gen.js
@@ -10,7 +10,7 @@ import * as Types from '../constants/types/fs'
 export const resetStore = 'common:resetStore' // not a part of fs but is handled by every reducer. NEVER dispatch this
 export const typePrefix = 'fs:'
 export const cancelDownload = 'fs:cancelDownload'
-export const clearMoveOrCopy = 'fs:clearMoveOrCopy'
+export const cancelMoveOrCopy = 'fs:cancelMoveOrCopy'
 export const commitEdit = 'fs:commitEdit'
 export const copy = 'fs:copy'
 export const deleteFile = 'fs:deleteFile'
@@ -43,6 +43,7 @@ export const localHTTPServerInfo = 'fs:localHTTPServerInfo'
 export const mimeTypeLoad = 'fs:mimeTypeLoad'
 export const mimeTypeLoaded = 'fs:mimeTypeLoaded'
 export const move = 'fs:move'
+export const moveOrCopyOpen = 'fs:moveOrCopyOpen'
 export const newFolderName = 'fs:newFolderName'
 export const newFolderRow = 'fs:newFolderRow'
 export const notifySyncActivity = 'fs:notifySyncActivity'
@@ -59,9 +60,10 @@ export const placeholderAction = 'fs:placeholderAction'
 export const refreshLocalHTTPServerInfo = 'fs:refreshLocalHTTPServerInfo'
 export const saveMedia = 'fs:saveMedia'
 export const setFlags = 'fs:setFlags'
-export const setMoveOrCopyDestinationParent = 'fs:setMoveOrCopyDestinationParent'
+export const setMoveOrCopyDestinationParentPath = 'fs:setMoveOrCopyDestinationParentPath'
 export const setMoveOrCopySource = 'fs:setMoveOrCopySource'
 export const shareNative = 'fs:shareNative'
+export const showMoveOrCopy = 'fs:showMoveOrCopy'
 export const sortSetting = 'fs:sortSetting'
 export const uninstallKBFSConfirm = 'fs:uninstallKBFSConfirm'
 export const upload = 'fs:upload'
@@ -72,9 +74,9 @@ export const userFileEditsLoaded = 'fs:userFileEditsLoaded'
 
 // Payload Types
 type _CancelDownloadPayload = $ReadOnly<{|key: string|}>
-type _ClearMoveOrCopyPayload = void
+type _CancelMoveOrCopyPayload = void
 type _CommitEditPayload = $ReadOnly<{|editID: Types.EditID|}>
-type _CopyPayload = void
+type _CopyPayload = $ReadOnly<{|destinationParentPath: Types.Path|}>
 type _DeleteFilePayload = $ReadOnly<{|path: Types.Path|}>
 type _DiscardEditPayload = $ReadOnly<{|editID: Types.EditID|}>
 type _DismissDownloadPayload = $ReadOnly<{|key: string|}>
@@ -166,7 +168,12 @@ type _MimeTypeLoadedPayload = $ReadOnly<{|
   path: Types.Path,
   mimeType: Types.Mime,
 |}>
-type _MovePayload = void
+type _MoveOrCopyOpenPayload = $ReadOnly<{|
+  routePath: I.List<string>,
+  path: Types.Path,
+  currentIndex: number,
+|}>
+type _MovePayload = $ReadOnly<{|destinationParentPath: Types.Path|}>
 type _NewFolderNamePayload = $ReadOnly<{|
   editID: Types.EditID,
   name: string,
@@ -211,12 +218,16 @@ type _SetFlagsPayload = $ReadOnly<{|
   securityPrefsPropmted?: boolean,
   showBanner?: boolean,
 |}>
-type _SetMoveOrCopyDestinationParentPayload = $ReadOnly<{|path: Types.Path|}>
+type _SetMoveOrCopyDestinationParentPathPayload = $ReadOnly<{|
+  index: number,
+  path: Types.Path,
+|}>
 type _SetMoveOrCopySourcePayload = $ReadOnly<{|path: Types.Path|}>
 type _ShareNativePayload = $ReadOnly<{|
   path: Types.Path,
   key: string,
 |}>
+type _ShowMoveOrCopyPayload = $ReadOnly<{|initialDestinationParentPath: Types.Path|}>
 type _SortSettingPayload = $ReadOnly<{|
   path: Types.Path,
   sortSetting: Types.SortSetting,
@@ -233,7 +244,7 @@ type _UserFileEditsLoadedPayload = $ReadOnly<{|tlfUpdates: Types.UserTlfUpdates|
 
 // Action Creators
 export const createCancelDownload = (payload: _CancelDownloadPayload) => ({payload, type: cancelDownload})
-export const createClearMoveOrCopy = (payload: _ClearMoveOrCopyPayload) => ({payload, type: clearMoveOrCopy})
+export const createCancelMoveOrCopy = (payload: _CancelMoveOrCopyPayload) => ({payload, type: cancelMoveOrCopy})
 export const createCommitEdit = (payload: _CommitEditPayload) => ({payload, type: commitEdit})
 export const createCopy = (payload: _CopyPayload) => ({payload, type: copy})
 export const createDeleteFile = (payload: _DeleteFilePayload) => ({payload, type: deleteFile})
@@ -266,6 +277,7 @@ export const createLocalHTTPServerInfo = (payload: _LocalHTTPServerInfoPayload) 
 export const createMimeTypeLoad = (payload: _MimeTypeLoadPayload) => ({payload, type: mimeTypeLoad})
 export const createMimeTypeLoaded = (payload: _MimeTypeLoadedPayload) => ({payload, type: mimeTypeLoaded})
 export const createMove = (payload: _MovePayload) => ({payload, type: move})
+export const createMoveOrCopyOpen = (payload: _MoveOrCopyOpenPayload) => ({payload, type: moveOrCopyOpen})
 export const createNewFolderName = (payload: _NewFolderNamePayload) => ({payload, type: newFolderName})
 export const createNewFolderRow = (payload: _NewFolderRowPayload) => ({payload, type: newFolderRow})
 export const createNotifySyncActivity = (payload: _NotifySyncActivityPayload) => ({payload, type: notifySyncActivity})
@@ -282,9 +294,10 @@ export const createPlaceholderAction = (payload: _PlaceholderActionPayload) => (
 export const createRefreshLocalHTTPServerInfo = (payload: _RefreshLocalHTTPServerInfoPayload) => ({payload, type: refreshLocalHTTPServerInfo})
 export const createSaveMedia = (payload: _SaveMediaPayload) => ({payload, type: saveMedia})
 export const createSetFlags = (payload: _SetFlagsPayload) => ({payload, type: setFlags})
-export const createSetMoveOrCopyDestinationParent = (payload: _SetMoveOrCopyDestinationParentPayload) => ({payload, type: setMoveOrCopyDestinationParent})
+export const createSetMoveOrCopyDestinationParentPath = (payload: _SetMoveOrCopyDestinationParentPathPayload) => ({payload, type: setMoveOrCopyDestinationParentPath})
 export const createSetMoveOrCopySource = (payload: _SetMoveOrCopySourcePayload) => ({payload, type: setMoveOrCopySource})
 export const createShareNative = (payload: _ShareNativePayload) => ({payload, type: shareNative})
+export const createShowMoveOrCopy = (payload: _ShowMoveOrCopyPayload) => ({payload, type: showMoveOrCopy})
 export const createSortSetting = (payload: _SortSettingPayload) => ({payload, type: sortSetting})
 export const createUninstallKBFSConfirm = (payload: _UninstallKBFSConfirmPayload) => ({payload, type: uninstallKBFSConfirm})
 export const createUpload = (payload: _UploadPayload) => ({payload, type: upload})
@@ -295,7 +308,7 @@ export const createUserFileEditsLoaded = (payload: _UserFileEditsLoadedPayload) 
 
 // Action Payloads
 export type CancelDownloadPayload = $Call<typeof createCancelDownload, _CancelDownloadPayload>
-export type ClearMoveOrCopyPayload = $Call<typeof createClearMoveOrCopy, _ClearMoveOrCopyPayload>
+export type CancelMoveOrCopyPayload = $Call<typeof createCancelMoveOrCopy, _CancelMoveOrCopyPayload>
 export type CommitEditPayload = $Call<typeof createCommitEdit, _CommitEditPayload>
 export type CopyPayload = $Call<typeof createCopy, _CopyPayload>
 export type DeleteFilePayload = $Call<typeof createDeleteFile, _DeleteFilePayload>
@@ -327,6 +340,7 @@ export type LoadingPathPayload = $Call<typeof createLoadingPath, _LoadingPathPay
 export type LocalHTTPServerInfoPayload = $Call<typeof createLocalHTTPServerInfo, _LocalHTTPServerInfoPayload>
 export type MimeTypeLoadPayload = $Call<typeof createMimeTypeLoad, _MimeTypeLoadPayload>
 export type MimeTypeLoadedPayload = $Call<typeof createMimeTypeLoaded, _MimeTypeLoadedPayload>
+export type MoveOrCopyOpenPayload = $Call<typeof createMoveOrCopyOpen, _MoveOrCopyOpenPayload>
 export type MovePayload = $Call<typeof createMove, _MovePayload>
 export type NewFolderNamePayload = $Call<typeof createNewFolderName, _NewFolderNamePayload>
 export type NewFolderRowPayload = $Call<typeof createNewFolderRow, _NewFolderRowPayload>
@@ -344,9 +358,10 @@ export type PlaceholderActionPayload = $Call<typeof createPlaceholderAction, _Pl
 export type RefreshLocalHTTPServerInfoPayload = $Call<typeof createRefreshLocalHTTPServerInfo, _RefreshLocalHTTPServerInfoPayload>
 export type SaveMediaPayload = $Call<typeof createSaveMedia, _SaveMediaPayload>
 export type SetFlagsPayload = $Call<typeof createSetFlags, _SetFlagsPayload>
-export type SetMoveOrCopyDestinationParentPayload = $Call<typeof createSetMoveOrCopyDestinationParent, _SetMoveOrCopyDestinationParentPayload>
+export type SetMoveOrCopyDestinationParentPathPayload = $Call<typeof createSetMoveOrCopyDestinationParentPath, _SetMoveOrCopyDestinationParentPathPayload>
 export type SetMoveOrCopySourcePayload = $Call<typeof createSetMoveOrCopySource, _SetMoveOrCopySourcePayload>
 export type ShareNativePayload = $Call<typeof createShareNative, _ShareNativePayload>
+export type ShowMoveOrCopyPayload = $Call<typeof createShowMoveOrCopy, _ShowMoveOrCopyPayload>
 export type SortSettingPayload = $Call<typeof createSortSetting, _SortSettingPayload>
 export type UninstallKBFSConfirmPayload = $Call<typeof createUninstallKBFSConfirm, _UninstallKBFSConfirmPayload>
 export type UploadPayload = $Call<typeof createUpload, _UploadPayload>
@@ -359,7 +374,7 @@ export type UserFileEditsLoadedPayload = $Call<typeof createUserFileEditsLoaded,
 // prettier-ignore
 export type Actions =
   | CancelDownloadPayload
-  | ClearMoveOrCopyPayload
+  | CancelMoveOrCopyPayload
   | CommitEditPayload
   | CopyPayload
   | DeleteFilePayload
@@ -391,6 +406,7 @@ export type Actions =
   | LocalHTTPServerInfoPayload
   | MimeTypeLoadPayload
   | MimeTypeLoadedPayload
+  | MoveOrCopyOpenPayload
   | MovePayload
   | NewFolderNamePayload
   | NewFolderRowPayload
@@ -408,9 +424,10 @@ export type Actions =
   | RefreshLocalHTTPServerInfoPayload
   | SaveMediaPayload
   | SetFlagsPayload
-  | SetMoveOrCopyDestinationParentPayload
+  | SetMoveOrCopyDestinationParentPathPayload
   | SetMoveOrCopySourcePayload
   | ShareNativePayload
+  | ShowMoveOrCopyPayload
   | SortSettingPayload
   | UninstallKBFSConfirmPayload
   | UploadPayload

--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -725,29 +725,29 @@ const moveOrCopy = (state, action: FsGen.MovePayload | FsGen.CopyPayload) => {
   )
 }
 
-const moveOrCopyOpen = isMobile
-  ? (state, action) =>
-      Saga.all([
-        Saga.put(
-          FsGen.createSetMoveOrCopyDestinationParentPath({
-            index: action.payload.currentIndex + 1,
-            path: action.payload.path,
-          })
-        ),
-        Saga.put(
-          putActionIfOnPath(
-            action.payload.routePath,
-            navigateAppend([{props: {index: action.payload.currentIndex + 1}, selected: 'destinationPicker'}])
-          )
-        ),
-      ])
-  : (state, action) =>
-      Saga.put(
-        FsGen.createSetMoveOrCopyDestinationParentPath({
-          index: action.payload.currentIndex,
-          path: action.payload.path,
-        })
+const moveOrCopyOpenMobile = (state, action) =>
+  Saga.all([
+    Saga.put(
+      FsGen.createSetMoveOrCopyDestinationParentPath({
+        index: action.payload.currentIndex + 1,
+        path: action.payload.path,
+      })
+    ),
+    Saga.put(
+      putActionIfOnPath(
+        action.payload.routePath,
+        navigateAppend([{props: {index: action.payload.currentIndex + 1}, selected: 'destinationPicker'}])
       )
+    ),
+  ])
+
+const moveOrCopyOpenDesktop = (state, action) =>
+  Saga.put(
+    FsGen.createSetMoveOrCopyDestinationParentPath({
+      index: action.payload.currentIndex,
+      path: action.payload.path,
+    })
+  )
 
 const showMoveOrCopy = isMobile
   ? (state, action) =>
@@ -786,7 +786,7 @@ function* fsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.actionToAction([FsGen.openPathItem, FsGen.openPathInFilesTab], openPathItem)
   yield Saga.actionToAction(ConfigGen.setupEngineListeners, setupEngineListeners)
   yield Saga.actionToPromise([FsGen.move, FsGen.copy], moveOrCopy)
-  yield Saga.actionToAction(FsGen.moveOrCopyOpen, moveOrCopyOpen)
+  yield Saga.actionToAction(FsGen.moveOrCopyOpen, isMobile ? moveOrCopyOpenMobile : moveOrCopyOpenDesktop)
   yield Saga.actionToAction(FsGen.showMoveOrCopy, showMoveOrCopy)
   yield Saga.actionToAction(FsGen.cancelMoveOrCopy, cancelMoveOrCopy)
 

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -190,12 +190,19 @@
     "setMoveOrCopySource": {
       "path": "Types.Path"
     },
-    "setMoveOrCopyDestinationParent": {
+    "setMoveOrCopyDestinationParentPath": {
+      "index": "number",
       "path": "Types.Path"
     },
-    "clearMoveOrCopy": {},
-    "move": {},
-    "copy": {},
+    "showMoveOrCopy": {"initialDestinationParentPath": "Types.Path"},
+    "cancelMoveOrCopy": {},
+    "moveOrCopyOpen": {
+      "routePath": "I.List<string>",
+      "path": "Types.Path",
+      "currentIndex": "number"
+    },
+    "move": {"destinationParentPath": "Types.Path"},
+    "copy": {"destinationParentPath": "Types.Path"},
 
     "placeholderAction": {}
   }

--- a/shared/app/routes-app.js
+++ b/shared/app/routes-app.js
@@ -29,7 +29,6 @@ const appRouteTree = makeRouteDefNode({
   tags: makeLeafTags({title: appRouteTreeTitle}),
   children: {
     [chatTab]: chatRoutes,
-    [fsTab]: fsRoutes,
     [gitTab]: gitRoutes,
     [peopleTab]: peopleRoutes,
     [profileTab]: profileRoutes,
@@ -40,6 +39,7 @@ const appRouteTree = makeRouteDefNode({
       ? {}
       : {
           [devicesTab]: devicesRoutes, // not a top level route in mobile
+          [fsTab]: fsRoutes,
         }),
   },
   containerComponent: Nav,

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -12,6 +12,7 @@ import {downloadFilePath, downloadFilePathNoSearch} from '../util/file'
 import type {IconType} from '../common-adapters'
 import {tlfToPreferredOrder} from '../util/kbfs'
 import {memoize, findKey} from 'lodash-es'
+import {putActionIfOnPath, navigateAppend, navigateTo} from '../actions/route-tree'
 
 export const defaultPath = '/keybase'
 
@@ -173,7 +174,7 @@ export const makeError = (record?: {
 }
 
 export const makeMoveOrCopy: I.RecordFactory<Types._MoveOrCopy> = I.Record({
-  destinationParentPath: Types.stringToPath('/keybase'),
+  destinationParentPath: I.List(),
   sourceItemPath: Types.stringToPath(''),
 })
 
@@ -810,6 +811,14 @@ export const pathsInSameTlf = (a: Types.Path, b: Types.Path): boolean => {
   const elemsA = Types.getPathElements(a)
   const elemsB = Types.getPathElements(b)
   return elemsA.length >= 3 && elemsB.length >= 3 && elemsA[1] === elemsB[1] && elemsA[2] === elemsB[2]
+}
+
+export const destinationPickerGoToPathAction = (
+  routePath: I.List<string>,
+  destinationParentPath: Types.Path
+) => {
+  const to = {props: {destinationParentPath}, selected: 'destinationPicker'}
+  return putActionIfOnPath(routePath, isMobile ? navigateAppend([to]) : navigateTo([to]))
 }
 
 export const erroredActionToMessage = (action: FsGen.Actions): string => {

--- a/shared/constants/types/fs.js
+++ b/shared/constants/types/fs.js
@@ -226,8 +226,13 @@ export type PathItems = I.Map<Path, PathItem>
 export type Edits = I.Map<EditID, Edit>
 
 export type _MoveOrCopy = {
-  destinationParentPath: Path,
   sourceItemPath: Path,
+  // id -> Path mapping. This is useful for mobile when we have multiple layers
+  // stacked on top of each other, and we need to keep track of them for the
+  // back button. We don't put this in routeProps directly as that'd
+  // complicate stuff for desktop because we don't have something like a
+  // routeToSibling.
+  destinationParentPath: I.List<Path>,
 }
 export type MoveOrCopy = I.RecordOf<_MoveOrCopy>
 

--- a/shared/fs/common/open-hoc.js
+++ b/shared/fs/common/open-hoc.js
@@ -1,24 +1,51 @@
 // @flow
 import * as I from 'immutable'
 import * as FsGen from '../../actions/fs-gen'
+import * as Constants from '../../constants/fs'
 import * as Types from '../../constants/types/fs'
+import memoize from 'memoize-one'
 import {namedConnect} from '../../util/container'
 
 type OwnProps = {
   routePath: I.List<string>,
   path: Types.Path,
-  inDestinationPicker?: boolean,
+  destinationPickerIndex?: number,
 }
 
-const mapDispatchToProps = (dispatch, {path, routePath, inDestinationPicker}: OwnProps) => ({
-  onOpen: inDestinationPicker
-    ? () => dispatch(FsGen.createSetMoveOrCopyDestinationParent({path}))
-    : () => dispatch(FsGen.createOpenPathItem({path, routePath})),
+const mapStateToProps = state => ({
+  _pathItems: state.fs.pathItems,
+  _moveOrCopy: state.fs.moveOrCopy,
 })
 
-export default namedConnect(
-    () => ({}),
-    mapDispatchToProps,
-    (s, d, o) => ({...o, ...s, ...d}),
-  'ConnectedOpenHOC'
+const mapDispatchToProps = (dispatch, {path, destinationPickerIndex, routePath}: OwnProps) => ({
+  _destinationPickerGoTo: () =>
+    dispatch(
+      FsGen.createMoveOrCopyOpen({
+        path,
+        routePath,
+        currentIndex: destinationPickerIndex || 0 /* make flow happy */,
+      })
+    ),
+  _open: () => dispatch(FsGen.createOpenPathItem({path, routePath})),
+})
+
+const isFolder = (stateProps, ownProps) =>
+  Types.getPathLevel(ownProps.path) <= 3 ||
+  stateProps._pathItems.get(ownProps.path, Constants.unknownPathItem).type === 'folder'
+
+const canOpenInDestinationPicker = memoize(
+  (stateProps, ownProps) =>
+    !isFolder(stateProps, ownProps) || stateProps._moveOrCopy.sourceItemPath === ownProps.path
 )
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  onOpen:
+    typeof ownProps.destinationPickerIndex === 'number'
+      ? canOpenInDestinationPicker(stateProps, ownProps)
+        ? null
+        : dispatchProps._destinationPickerGoTo
+      : dispatchProps._open,
+  ...ownProps,
+})
+
+export default namedConnect(mapStateToProps, mapDispatchToProps, mergeProps, 'ConnectedOpenHOC')

--- a/shared/fs/common/path-item-action-container.js
+++ b/shared/fs/common/path-item-action-container.js
@@ -4,7 +4,6 @@ import * as Constants from '../../constants/fs'
 import * as ConfigGen from '../../actions/config-gen'
 import * as FsGen from '../../actions/fs-gen'
 import {compose, namedConnect, lifecycle, type TypedState, type Dispatch} from '../../util/container'
-import {navigateAppend} from '../../actions/route-tree'
 import PathItemAction from './path-item-action'
 import {isMobile, isIOS, isAndroid} from '../../constants/platform'
 import {OverlayParentHOC} from '../../common-adapters'
@@ -33,8 +32,11 @@ const mapDispatchToProps = (dispatch, {path}: OwnProps) => ({
   deleteFileOrFolder: () => dispatch(FsGen.createDeleteFile({path})),
   moveOrCopy: () => {
     dispatch(FsGen.createSetMoveOrCopySource({path}))
-    dispatch(FsGen.createSetMoveOrCopyDestinationParent({path: Types.getPathParent(path)}))
-    dispatch(navigateAppend(['destinationPicker']))
+    dispatch(
+      FsGen.createShowMoveOrCopy({
+        initialDestinationParentPath: Types.getPathParent(path),
+      })
+    )
   },
   ...(isMobile
     ? {

--- a/shared/fs/destination-picker/container.js
+++ b/shared/fs/destination-picker/container.js
@@ -5,56 +5,79 @@ import DestinationPicker from '.'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import * as FsGen from '../../actions/fs-gen'
-import {navigateUp} from '../../actions/route-tree'
 import {isMobile} from '../../constants/platform'
+import {navigateUp, putActionIfOnPath} from '../../actions/route-tree'
 
 const mapStateToProps = state => ({
   _moveOrCopy: state.fs.moveOrCopy,
   _pathItems: state.fs.pathItems,
 })
 
-const mapDispatchToProps = dispatch => ({
-  onCancel: () => dispatch(navigateUp()),
-  _onCopyHere: () => {
-    dispatch(FsGen.createCopy())
-    dispatch(navigateUp())
+const getDestinationParentPath = memoize((stateProps, ownProps) =>
+  stateProps._moveOrCopy.destinationParentPath.get(
+    ownProps.routeProps.get('index', 0),
+    Types.getPathParent(stateProps._moveOrCopy.sourceItemPath)
+  )
+)
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  onCancel: () => dispatch(FsGen.createCancelMoveOrCopy()),
+  _onCopyHere: destinationParentPath => {
+    dispatch(FsGen.createCopy({destinationParentPath}))
+    dispatch(FsGen.createCancelMoveOrCopy())
   },
-  _onMoveHere: () => {
-    dispatch(FsGen.createMove())
-    dispatch(navigateUp())
+  _onMoveHere: destinationParentPath => {
+    dispatch(FsGen.createMove({destinationParentPath}))
+    dispatch(FsGen.createCancelMoveOrCopy())
   },
-  _onNewFolder: (parentPath: Types.Path) => dispatch(FsGen.createNewFolderRow({parentPath})),
-  // TODO KBFS-3557 use routeTree
-  _onBackUp: (toParentOf: Types.Path) =>
-    dispatch(FsGen.createSetMoveOrCopyDestinationParent({path: Types.getPathParent(toParentOf)})),
+  _onNewFolder: destinationParentPath =>
+    dispatch(FsGen.createNewFolderRow({parentPath: destinationParentPath})),
+  _onBackUp: () => dispatch(putActionIfOnPath(ownProps.routePath, navigateUp())),
 })
 
-const destinationParentPathIsWritable = memoize(
-  stateProps =>
-    Types.getPathLevel(stateProps._moveOrCopy.destinationParentPath) > 2 &&
-    stateProps._pathItems.get(stateProps._moveOrCopy.destinationParentPath, Constants.unknownPathItem)
+const canWrite = memoize(
+  (stateProps, ownProps) =>
+    Types.getPathLevel(getDestinationParentPath(stateProps, ownProps)) > 2 &&
+    stateProps._pathItems.get(getDestinationParentPath(stateProps, ownProps), Constants.unknownPathItem)
       .writable
 )
 
-const mergeProps = (stateProps, dispatchProps) => ({
-  onCancel: dispatchProps.onCancel,
-  onCopyHere: destinationParentPathIsWritable(stateProps) ? dispatchProps._onCopyHere : null,
-  onMoveHere:
-    destinationParentPathIsWritable(stateProps) &&
+const canCopy = memoize(
+  (stateProps, ownProps) =>
+    canWrite(stateProps, ownProps) &&
+    getDestinationParentPath(stateProps, ownProps) !==
+      Types.getPathParent(stateProps._moveOrCopy.sourceItemPath)
+)
+
+const canMove = memoize(
+  (stateProps, ownProps) =>
+    canCopy(stateProps, ownProps) &&
     Constants.pathsInSameTlf(
       stateProps._moveOrCopy.sourceItemPath,
-      stateProps._moveOrCopy.destinationParentPath
+      getDestinationParentPath(stateProps, ownProps)
     )
-      ? dispatchProps._onMoveHere
-      : null,
-  onNewFolder: destinationParentPathIsWritable(stateProps)
-    ? () => dispatchProps._onNewFolder(stateProps._moveOrCopy.destinationParentPath)
+)
+
+const getIndex = memoize(ownProps => ownProps.routeProps.get('index', 0))
+const canBackUp = isMobile
+  ? memoize((stateProps, ownProps) => Types.getPathLevel(getDestinationParentPath(stateProps, ownProps)) > 1)
+  : (s, o) => false
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  index: getIndex(ownProps),
+  onCancel: dispatchProps.onCancel,
+  onCopyHere: canCopy(stateProps, ownProps)
+    ? () => dispatchProps._onCopyHere(getDestinationParentPath(stateProps, ownProps))
     : null,
-  onBackUp:
-    isMobile && Types.getPathLevel(stateProps._moveOrCopy.destinationParentPath) > 1
-      ? () => dispatchProps._onBackUp(stateProps._moveOrCopy.destinationParentPath)
-      : null,
-  path: stateProps._moveOrCopy.destinationParentPath,
+  onMoveHere: canMove(stateProps, ownProps)
+    ? () => dispatchProps._onMoveHere(getDestinationParentPath(stateProps, ownProps))
+    : null,
+  onNewFolder: canWrite(stateProps, ownProps)
+    ? () => dispatchProps._onNewFolder(getDestinationParentPath(stateProps, ownProps))
+    : null,
+  onBackUp: canBackUp(stateProps, ownProps) ? dispatchProps._onBackUp : null,
+  path: getDestinationParentPath(stateProps, ownProps),
+  routePath: ownProps.routePath,
   targetName: Types.getPathName(stateProps._moveOrCopy.sourceItemPath),
   targetIconSpec: Constants.getItemStyles(
     Types.getPathElements(stateProps._moveOrCopy.sourceItemPath),

--- a/shared/fs/destination-picker/index.js
+++ b/shared/fs/destination-picker/index.js
@@ -1,4 +1,5 @@
 // @flow
+import * as I from 'immutable'
 import * as React from 'react'
 import * as Constants from '../../constants/fs'
 import * as Types from '../../constants/types/fs'
@@ -12,7 +13,9 @@ import * as RowCommon from '../row/common'
 import Breadcrumb from '../header/breadcrumb-container.desktop.js'
 
 type Props = {
+  index: number,
   path: Types.Path,
+  routePath: I.List<string>,
   targetName: string,
   targetIconSpec: Types.PathItemIconSpec,
   onCancel: () => void,
@@ -46,7 +49,7 @@ const DesktopHeaders = (props: Props) => (
       </Kb.Text>
     </Kb.Box2>
     <Kb.Box2 direction="horizontal" fullWidth={true} centerChildren={true} style={styles.anotherHeader}>
-      <Breadcrumb path={props.path} inDestinationPicker={true} />
+      <Breadcrumb path={props.path} inDestinationPicker={true} routePath={props.routePath} />
       {!!props.onNewFolder && <NewFolder onNewFolder={props.onNewFolder} />}
     </Kb.Box2>
   </>
@@ -92,7 +95,12 @@ const DestinationPicker = (props: Props) => (
       </Kb.ClickableBox>
     )}
     <Kb.Box2 key="rows" direction="vertical" fullHeight={true} style={styles.rowsContainer}>
-      <Rows path={props.path} sortSetting={Constants.defaultSortSetting} inDestinationPicker={true} />
+      <Rows
+        path={props.path}
+        sortSetting={Constants.defaultSortSetting}
+        destinationPickerIndex={props.index}
+        routePath={props.routePath}
+      />
     </Kb.Box2>
     {isMobile && <Kb.Divider key="dfooter" />}
     <Kb.Box2 key="footer" direction="horizontal" centerChildren={true} fullWidth={true} style={styles.footer}>

--- a/shared/fs/destination-picker/index.stories.js
+++ b/shared/fs/destination-picker/index.stories.js
@@ -1,4 +1,5 @@
 // @flow
+import * as I from 'immutable'
 import React from 'react'
 import * as Sb from '../../stories/storybook'
 import * as Constants from '../../constants/fs'
@@ -23,11 +24,13 @@ const load = () =>
     .add('DestinationPicker', () => (
       <DestinationPicker
         path={Types.stringToPath('/keybase/private/meatball,songgao,xinyuzhao/yo')}
+        routePath={I.List([])}
         onCancel={Sb.action('onCancel')}
         targetName="Secret treat spot blasjeiofjawiefjksadjflaj"
         targetIconSpec={
           Constants.getItemStyles(['keybase', 'private', 'meatball', 'Secret treat spot'], 'folder').iconSpec
         }
+        index={0}
         onCopyHere={Sb.action('onCopyHere')}
         onMoveHere={Sb.action('onMoveHere')}
         onNewFolder={Sb.action('onNewFolder')}

--- a/shared/fs/header/breadcrumb-container.desktop.js
+++ b/shared/fs/header/breadcrumb-container.desktop.js
@@ -1,4 +1,5 @@
 // @flow
+import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import {namedConnect} from '../../util/container'
@@ -9,6 +10,7 @@ import Breadcrumb from './breadcrumb.desktop'
 
 type OwnProps = {
   path: Types.Path,
+  routePath: I.List<string>,
   inDestinationPicker?: boolean,
 }
 
@@ -16,9 +18,9 @@ const mapStateToProps = state => ({
   _username: state.config.username,
 })
 
-const mapDispatchToProps = (dispatch, {inDestinationPicker}: OwnProps) => ({
+const mapDispatchToProps = (dispatch, {inDestinationPicker, routePath}: OwnProps) => ({
   _navigateToPath: inDestinationPicker
-    ? (path: Types.Path) => dispatch(FsGen.createSetMoveOrCopyDestinationParent({path}))
+    ? (path: Types.Path) => dispatch(FsGen.createMoveOrCopyOpen({routePath, currentIndex: 0, path}))
     : (path: Types.Path) => dispatch(navigateTo([fsTab, {props: {path}, selected: 'folder'}])),
 })
 

--- a/shared/fs/header/container.js
+++ b/shared/fs/header/container.js
@@ -2,15 +2,13 @@
 import * as Types from '../../constants/types/fs'
 import * as Chat2Gen from '../../actions/chat2-gen'
 import * as Util from '../../util/kbfs'
-import {isMobile} from '../../constants/platform'
-import {navigateUp} from '../../actions/route-tree'
-import {compose, namedConnect} from '../../util/container'
-import OpenHOC from '../common/open-hoc'
+import {putActionIfOnPath, navigateUp} from '../../actions/route-tree'
+import {namedConnect} from '../../util/container'
 import FolderHeader from './header'
 
 const mapDispatchToProps = (dispatch, {path, routePath}) => ({
-  onBack: isMobile ? () => dispatch(navigateUp()) : undefined, // TODO: put if on route ...
-  onChat: () =>
+  onBack: () => dispatch(putActionIfOnPath(routePath, navigateUp())),
+  _onChat: () =>
     dispatch(
       Chat2Gen.createPreviewConversation({
         reason: 'files',
@@ -21,18 +19,15 @@ const mapDispatchToProps = (dispatch, {path, routePath}) => ({
     ),
 })
 
-const mergeProps = (_, {onBack, onChat}, {path, routePath}) => {
+const mergeProps = (_, {onBack, _onChat}, {path, routePath}) => {
   const elems = Types.getPathElements(path)
   return {
     path,
     title: elems.length > 1 ? elems[elems.length - 1] : 'Keybase Files',
     onBack,
-    onChat: elems.length > 2 ? onChat : undefined,
+    onChat: elems.length > 2 ? _onChat : undefined,
     routePath,
   }
 }
 
-export default compose(
-  namedConnect(() => ({}), mapDispatchToProps, mergeProps, 'FolderHeader'),
-  OpenHOC
-)(FolderHeader)
+export default namedConnect(() => ({}), mapDispatchToProps, mergeProps, 'FolderHeader')(FolderHeader)

--- a/shared/fs/header/header.desktop.js
+++ b/shared/fs/header/header.desktop.js
@@ -9,7 +9,7 @@ import Breadcrumb from './breadcrumb-container.desktop'
 import {type FolderHeaderProps} from './header'
 import {PathItemAction, OpenInSystemFileManager} from '../common'
 
-const FolderHeader = ({path, onChat}: FolderHeaderProps) => (
+const FolderHeader = ({path, onChat, routePath}: FolderHeaderProps) => (
   <Box style={styles.headerContainer}>
     <Box style={styles.folderHeader}>
       {Types.pathToString(path) === '/keybase' ? (
@@ -25,7 +25,7 @@ const FolderHeader = ({path, onChat}: FolderHeaderProps) => (
         </Box>
       ) : (
         <Box style={styles.folderHeaderContainer}>
-          <Breadcrumb path={path} />
+          <Breadcrumb path={path} routePath={routePath} />
           <Box style={styles.folderHeaderEnd}>
             <AddNew path={path} style={styles.addNew} />
             <WithTooltip text="Show in Finder">

--- a/shared/fs/header/header.js.flow
+++ b/shared/fs/header/header.js.flow
@@ -1,12 +1,14 @@
 // @flow
+import * as I from 'immutable'
 import * as React from 'react'
 import * as Types from '../../constants/types/fs'
 
 export type FolderHeaderProps = {
   path: Types.Path,
+  routePath: I.List<string>,
   title: string,
   onBack: () => void,
-  onChat: () => void,
+  onChat?: ?() => void,
 }
 
 declare export default class FolderHeader extends React.Component<FolderHeaderProps> {}

--- a/shared/fs/routes.js
+++ b/shared/fs/routes.js
@@ -7,44 +7,106 @@ import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import SecurityPrefs from './common/security-prefs-container'
 import DestinationPicker from './destination-picker/container'
 
+/*
+ * Example Fs routes:
+ *
+ *   Mobile:
+ *     /tabs:settings/settingsTab:fsTab/folder
+ *       /keybase folder view
+ *     /tabs:settings/settingsTab:fsTab/folder/folder/folder
+ *       /keybase/team/keybase folder view
+ *     /tabs:settings/settingsTab:fsTab/folder/folder/folder/preview
+ *       file preview of some file under /keybase/team/keybase
+ *     /tabs:settings/settingsTab:fsTab/destinationPicker/destinationPicker/destinationPicker
+ *       moveOrCopy dialog showing /keybase/team/keybase
+ *     /tabs:settings/settingsTab:fsTab/destinationPicker
+ *       moveOrCopy dialog showing /keybase
+ *
+ * Note that folder and destinationPicker are siblings on mobile. This is to
+ * make sure:
+ *   1) foler view keeps all component layers mounted, so user can swipe back;
+ *   2) moveOrCopy view keeps all layers mounted too, so user can swipe back to
+ *      go to parent folder;
+ *   3) we can use switchTo when user taps "Cancel" in the moveOrCopy dialog to
+ *      switch back to whatever folder route that user was on before initiating
+ *      moveOrCopy;
+ *
+ *   Desktop:
+ *     /tabs:fsTab/folder
+ *       /keybase folder view
+ *     /tabs:fsTab/folder/folder/folder
+ *       /keybase/team/keybase folder view
+ *     /tabs:fsTab/folder/folder/folder/preview
+ *       file preview of some file under /keybase/team/keybase
+ *     /tabs:fsTab/folder/folder/folder/destinationPicker
+ *       moveOrCopy dialog active when main view is in /keybase/team/keybase;
+ *       doesn't matter what folder moveOrCopy dialog is showing
+ *
+ * Unlike mobile, with desktop destinationPicker is just a subroute of any
+ * folder view. This is because:
+ *   1) there's no "back" behavior we need to support;
+ *   2) we need to go to arbitrary path without introducing another layer.
+ * So just make moveOrCopy a single layer of destinationPicker on top of the
+ * folder view, and use the redux store to bookkeep the currently showing path
+ * in moveOrCopy.
+ *
+ * Note that in either case, we only store an index in routeProps, and have
+ * container look for relevant information (destination's path, as well as
+ * moving/copying target's path.
+ *
+ */
+
+const _destinationPicker = {
+  children: isMobile
+    ? {
+        destinationPicker: () => makeRouteDefNode(_destinationPicker),
+      }
+    : undefined,
+  component: DestinationPicker,
+  tags: makeLeafTags({
+    title: 'Move or Copy',
+    layerOnTop: !isMobile,
+  }),
+}
+
 const _commonChildren = {
   securityPrefs: {
     component: SecurityPrefs,
   },
-  barePreview: () =>
-    makeRouteDefNode({
-      component: BarePreview,
-      children: _commonChildren,
-      tags: makeLeafTags({fullscreen: true, title: 'Preview'}),
-    }),
-  preview: () =>
-    makeRouteDefNode({
-      component: NormalPreview,
-      children: _commonChildren,
-      tags: makeLeafTags({
-        title: 'Preview',
-      }),
-    }),
-  destinationPicker: () =>
-    makeRouteDefNode({
-      component: DestinationPicker,
-      tags: makeLeafTags({
-        title: 'Move or Copy',
-        layerOnTop: !isMobile,
-      }),
-    }),
+  ...(isMobile ? {} : {destinationPicker: () => makeRouteDefNode(_destinationPicker)}),
 }
 
 const _folderRoute = {
   children: {
     ..._commonChildren,
+    barePreview: () =>
+      makeRouteDefNode({
+        component: BarePreview,
+        children: _commonChildren,
+        tags: makeLeafTags({
+          fullscreen: true,
+          title: 'Preview',
+        }),
+      }),
+    preview: () =>
+      makeRouteDefNode({
+        component: NormalPreview,
+        children: _commonChildren,
+        tags: makeLeafTags({
+          title: 'Preview',
+        }),
+      }),
     folder: () => makeRouteDefNode(_folderRoute),
   },
   component: Files,
 }
 
 const routeTree = makeRouteDefNode({
-  ..._folderRoute,
+  children: {
+    folder: () => makeRouteDefNode(_folderRoute),
+    ...(isMobile ? {destinationPicker: () => makeRouteDefNode(_destinationPicker)} : {}),
+  },
+  defaultSelected: 'folder',
   initialState: {expandedSet: I.Set()},
   tags: makeLeafTags({title: 'Files'}),
 })

--- a/shared/fs/row/common.js
+++ b/shared/fs/row/common.js
@@ -58,6 +58,11 @@ const leftBox = {
   flex: 1,
 }
 
+const leftBoxDisabled = {
+  ...leftBox,
+  opacity: 0.2,
+}
+
 const rightBox = {
   ...Styles.globalStyles.flexBoxRow,
   flexShrink: 1,
@@ -105,6 +110,7 @@ export const rowStyles = {
     pathItemIcon,
     pathItemIcon_30,
     leftBox,
+    leftBoxDisabled,
     rightBox,
     pathItemActionIcon,
     badgeContainer,
@@ -138,7 +144,7 @@ export type StillCommonProps = {
   name: string,
   path: Types.Path,
   inDestinationPicker?: boolean,
-  onOpen: () => void,
+  onOpen?: ?() => void,
 }
 
 export const StillCommon = (
@@ -147,7 +153,7 @@ export const StillCommon = (
   }
 ) => (
   <HoverBox style={rowStyles.rowBox}>
-    <ClickableBox onClick={props.onOpen} style={rowStyles.leftBox}>
+    <ClickableBox onClick={props.onOpen} style={props.onOpen ? rowStyles.leftBox : rowStyles.leftBoxDisabled}>
       <Box2 direction="vertical">
         <PathItemIcon spec={props.itemStyles.iconSpec} style={rowStyles.pathItemIcon} />
       </Box2>

--- a/shared/fs/row/index.stories.js
+++ b/shared/fs/row/index.stories.js
@@ -16,14 +16,20 @@ import UploadingRow from './uploading'
 import {commonProvider} from '../common/index.stories'
 
 export const rowsProvider = {
-  ConnectedStillRow: ({path, inDestinationPicker}: {path: Types.Path, inDestinationPicker?: boolean}) => {
+  ConnectedStillRow: ({
+    path,
+    destinationPickerIndex,
+  }: {
+    path: Types.Path,
+    destinationPickerIndex?: number,
+  }) => {
     const pathStr = Types.pathToString(path)
     return {
       name: Types.getPathName(path),
       type: 'folder',
       itemStyles: folderItemStyles,
       isEmpty: pathStr.includes('empty'),
-      inDestinationPicker,
+      destinationPickerIndex,
     }
   },
   ConnectedOpenHOC: (ownProps: any) => ({
@@ -52,7 +58,7 @@ export const rowsProvider = {
     ],
     routePath: I.List(),
     ifEmpty: o.ifEmpty,
-    inDestinationPicker: o.inDestinationPicker,
+    destinationPickerIndex: o.destinationPickerIndex,
   }),
   ConnectedFilesLoadingHoc: (o: any) => ({
     ...o,

--- a/shared/fs/row/rows-container.js
+++ b/shared/fs/row/rows-container.js
@@ -17,7 +17,7 @@ type OwnProps = {
   path: Types.Path, // path to the parent folder containering the rows
   sortSetting: Types.SortSetting,
   routePath: I.List<string>,
-  inDestinationPicker?: boolean,
+  destinationPickerIndex?: number,
 }
 
 const getEditingRows = (
@@ -177,7 +177,7 @@ const mapDispatchToProps = dispatch => ({})
 const mergeProps = (s, d, o: OwnProps) => ({
   items: getItemsFromStateProps(s, o.path, o.sortSetting),
   routePath: o.routePath,
-  inDestinationPicker: o.inDestinationPicker,
+  destinationPickerIndex: o.destinationPickerIndex,
 })
 
 export default compose(

--- a/shared/fs/row/rows.js
+++ b/shared/fs/row/rows.js
@@ -16,7 +16,7 @@ import {isMobile} from '../../constants/platform'
 type Props = {
   items: Array<Types.RowItem>,
   routePath: I.List<string>,
-  inDestinationPicker?: boolean,
+  destinationPickerIndex?: number,
 }
 
 export const WrapRow = ({children}: {children: React.Node}) => (
@@ -42,7 +42,7 @@ class Rows extends React.PureComponent<Props> {
           <WrapRow key={`still:${item.name}`}>
             <TlfType
               name={item.name}
-              inDestinationPicker={this.props.inDestinationPicker}
+              destinationPickerIndex={this.props.destinationPickerIndex}
               routePath={this.props.routePath}
             />
           </WrapRow>
@@ -53,7 +53,7 @@ class Rows extends React.PureComponent<Props> {
             <Tlf
               name={item.name}
               tlfType={item.tlfType}
-              inDestinationPicker={this.props.inDestinationPicker}
+              destinationPickerIndex={this.props.destinationPickerIndex}
               routePath={this.props.routePath}
             />
           </WrapRow>
@@ -64,7 +64,7 @@ class Rows extends React.PureComponent<Props> {
             <Still
               name={item.name}
               path={item.path}
-              inDestinationPicker={this.props.inDestinationPicker}
+              destinationPickerIndex={this.props.destinationPickerIndex}
               routePath={this.props.routePath}
             />
           </WrapRow>
@@ -104,7 +104,7 @@ class Rows extends React.PureComponent<Props> {
           // If we are in the destination picker, inject two empty rows so when
           // user scrolls to the bottom nothing is blocked by the
           // semi-transparent footer.
-          !isMobile && this.props.inDestinationPicker
+          !isMobile && this.props.destinationPickerIndex
             ? [...this.props.items, {rowType: 'empty', name: '/empty0'}, {rowType: 'empty', name: '/empty1'}]
             : this.props.items
         }

--- a/shared/fs/row/still-container.js
+++ b/shared/fs/row/still-container.js
@@ -8,7 +8,7 @@ import Still from './still'
 
 type OwnProps = $Diff<Types.StillRowItem, {rowType: 'still'}> & {
   routePath: I.List<string>,
-  inDestinationPicker?: boolean,
+  destinationPickerIndex?: number,
 }
 
 const mapStateToProps = (state, {path}: OwnProps) => ({
@@ -17,12 +17,12 @@ const mapStateToProps = (state, {path}: OwnProps) => ({
   _downloads: state.fs.downloads,
 })
 
-const mergeProps = (stateProps, dispatchProps, {name, path, routePath, inDestinationPicker}: OwnProps) => {
+const mergeProps = (stateProps, dispatchProps, {name, path, routePath, destinationPickerIndex}: OwnProps) => {
   const {_downloads, _pathItem, _username} = stateProps
   const {type, lastModifiedTimestamp, lastWriter} = _pathItem
   const download = _downloads.find(t => t.meta.path === path && !t.state.isDone)
   return {
-    inDestinationPicker,
+    destinationPickerIndex,
     intentIfDownloading: download && download.meta.intent,
     isEmpty: _pathItem.type === 'folder' && _pathItem.progress === 'loaded' && _pathItem.children.isEmpty(),
     itemStyles: Constants.getItemStyles(Types.getPathElements(path), type, _username),

--- a/shared/fs/row/tlf-container.js
+++ b/shared/fs/row/tlf-container.js
@@ -8,7 +8,7 @@ import Tlf from './tlf'
 
 type OwnProps = $Diff<Types.TlfRowItem, {rowType: 'tlf'}> & {
   routePath: I.List<string>,
-  inDestinationPicker?: boolean,
+  destinationPickerIndex?: number,
 }
 
 const mapStateToProps = (state, {tlfType, name}: OwnProps) => ({
@@ -16,12 +16,12 @@ const mapStateToProps = (state, {tlfType, name}: OwnProps) => ({
   _username: state.config.username,
 })
 
-const mergeProps = (stateProps, dispatchProps, {tlfType, name, routePath, inDestinationPicker}) => {
+const mergeProps = (stateProps, dispatchProps, {tlfType, name, routePath, destinationPickerIndex}) => {
   const shouldBadge = Constants.tlfIsBadged(stateProps._tlf)
   const resetParticipants = stateProps._tlf.resetParticipants.map(i => i.username)
   const path = Constants.tlfTypeAndNameToPath(tlfType, name)
   return {
-    inDestinationPicker,
+    destinationPickerIndex,
     isIgnored: stateProps._tlf.isIgnored,
     isNew: shouldBadge && stateProps._tlf.isNew,
     isUserReset: !!stateProps._username && resetParticipants.includes(stateProps._username),

--- a/shared/fs/row/tlf-type-container.js
+++ b/shared/fs/row/tlf-type-container.js
@@ -8,19 +8,19 @@ import TlfType from './tlf-type'
 
 type OwnProps = $Diff<Types.TlfTypeRowItem, {rowType: 'tlf-type'}> & {
   routePath: I.List<string>,
-  inDestinationPicker?: boolean,
+  destinationPickerIndex?: number,
 }
 
 const mapStateToProps = (state, {name}: OwnProps) => ({
   _tlfList: Constants.getTlfListFromType(state.fs.tlfs, name),
 })
 
-const mergeProps = (stateProps, dispatchProps, {name, routePath, inDestinationPicker}: OwnProps) => {
+const mergeProps = (stateProps, dispatchProps, {name, routePath, destinationPickerIndex}: OwnProps) => {
   const badgeCount = Constants.computeBadgeNumberForTlfList(stateProps._tlfList)
   const path = Types.stringToPath(`/keybase/${name}`)
   return {
     badgeCount,
-    inDestinationPicker,
+    destinationPickerIndex,
     itemStyles: Constants.getItemStyles(Types.getPathElements(path), 'folder', undefined),
     name,
     path,


### PR DESCRIPTION
There are some comments in `fs/routes.js`, but basically:

* split the root of fsTab (which was originally just folder view) into a bare route node without component, but with two children `folder` and `destinationPicker`. It has `defaultSelected: 'folder'` so when we go there it still shows the folder view;
* for `destinationPicker`, i.e. the moveOrCopy dialog, only store an index in `routeProps`, but bookkeep in `state.fs.moveOrCopy`, which has a `destinationParentPath: I.List<Path>` for current showing path in the moveOrCopy dialog, and a `sourceItemPath: Path` for the moving/copying target.
  * For desktop, since we only have one layer of `destinationPicker`, so `state.fs.moveOrCopy.destinationParentPath` always has at most one element inside, and `routeProps.get('index')` is always `0`. When user navigates in moveOrCopy dialog, we just dispatch actions that sets the element at index 0 in the `I.List` to different paths.
  * For mobile, since we need to make swipe actions work, different layers of `destinationPicker`s need to be mounted, with `routeProps.get('index')` being 0, 1, ... . `state.fs.moveOrCopy.destinationParentPath` keeps a `Path` for each mounted layer of `destinationPicker`.

With this setup, on mobile user can:

* swipe back (i.e. from left edge of screen to right) to go to parent folder;
* being deep inside folders, but still able to tap "Cancel" to go back to whatever folder they were viewing when they initiated "Move or Copy" from a menu.

depends on: https://github.com/keybase/client/pull/14430