### PR TITLE
Show a blue background around payments we've just been told about, until you tab away

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -7,8 +7,7 @@
   ],
   "actions": {
     "abandonPayment": {
-      "_description":
-        "Signal that a payment being built is abandoned and reset the form fields to their initial states."
+      "_description": "Signal that a payment being built is abandoned and reset the form fields to their initial states."
     },
     "acceptDisclaimer": {
       "_description": "Accept the Stellar account disclaimer",
@@ -17,6 +16,11 @@
     "accountsReceived": {
       "_description": "Update our store of account data",
       "accounts": "Array<Types.Account>"
+    },
+    "addNewPayment": {
+      "_description": "Mark a payment we were just notified about as being unseen",
+      "accountID": "Types.AccountID",
+      "paymentID": "Types.PaymentID"
     },
     "assetsReceived": {
       "_description": "Update our store of assets data",
@@ -46,6 +50,13 @@
     "clearBuiltRequest": {
       "_description": "Clear a prepared request once it has been sent or canceled"
     },
+    "clearErrors": {
+      "_description": "Clear errors from the store at times like opening or closing a form dialog."
+    },
+    "clearNewPayments": {
+      "_description": "Clear our idea of which payments have not been seen by the user yet",
+      "accountID": "Types.AccountID"
+    },
     "cancelRequest": {
       "_description": "Cancel a request. Optionally delete an associated message",
       "conversationIDKey?": "ChatTypes.ConversationIDKey",
@@ -64,8 +75,7 @@
       "setBuildingTo?": "boolean"
     },
     "createdNewAccount": {
-      "_description":
-        "The service responded with an error or that the create new account operation succeeded",
+      "_description": "The service responded with an error or that the create new account operation succeeded",
       "accountID": "Types.AccountID",
       "showOnCreation?": "boolean",
       "setBuildingTo?": "boolean",
@@ -98,13 +108,13 @@
       "accountID": "Types.AccountID",
       "paymentID": "Types.PaymentID"
     },
-	"loadWalletDisclaimer": {
-		"_description": "Load wallet disclaimer"
-	},
-	"walletDisclaimerReceived": {
-		"_description": "Received wallet disclaimer",
-		"accepted": "boolean"
-	},
+    "loadWalletDisclaimer": {
+      "_description": "Load wallet disclaimer"
+    },
+    "walletDisclaimerReceived": {
+      "_description": "Received wallet disclaimer",
+      "accepted": "boolean"
+    },
     "loadDisplayCurrencies": {
       "_description": "Load valid display currencies to choose from"
     },
@@ -215,7 +225,7 @@
     "refreshPayments": {
       "_description": "In response to a notification, resync payment info",
       "accountID": "Types.AccountID",
-      "paymentID": "Types.PaymentID",
+      "paymentID": "Types.PaymentID"
     },
     "buildPayment": {
       "_description": "Send a potential payment to the service for validation"
@@ -269,8 +279,7 @@
       "writeFile": "boolean"
     },
     "openSendRequestForm": {
-      "_description":
-        "Initialize and navigate to the send or request form. See docs for `setBuilding*` for param semantics.",
+      "_description": "Initialize and navigate to the send or request form. See docs for `setBuilding*` for param semantics.",
       "amount?": "string",
       "currency?": "string",
       "from?": "Types.AccountID",
@@ -288,8 +297,7 @@
       "setBuildingTo?": "boolean"
     },
     "linkedExistingAccount": {
-      "_description":
-        "The service responded with an error or that the link existing operation succeeded",
+      "_description": "The service responded with an error or that the link existing operation succeeded",
       "accountID": "Types.AccountID",
       "showOnCreation?": "boolean",
       "setBuildingTo?": "boolean",
@@ -325,9 +333,6 @@
         "secretKey": "HiddenString",
         "error": "string"
       }
-    },
-    "clearErrors": {
-      "_description": "Clear errors from the store at times like opening or closing a form dialog."
     }
   }
 }

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -15,6 +15,7 @@ export const typePrefix = 'wallets:'
 export const abandonPayment = 'wallets:abandonPayment'
 export const acceptDisclaimer = 'wallets:acceptDisclaimer'
 export const accountsReceived = 'wallets:accountsReceived'
+export const addNewPayment = 'wallets:addNewPayment'
 export const assetsReceived = 'wallets:assetsReceived'
 export const badgesUpdated = 'wallets:badgesUpdated'
 export const buildPayment = 'wallets:buildPayment'
@@ -29,6 +30,7 @@ export const clearBuilding = 'wallets:clearBuilding'
 export const clearBuiltPayment = 'wallets:clearBuiltPayment'
 export const clearBuiltRequest = 'wallets:clearBuiltRequest'
 export const clearErrors = 'wallets:clearErrors'
+export const clearNewPayments = 'wallets:clearNewPayments'
 export const createNewAccount = 'wallets:createNewAccount'
 export const createdNewAccount = 'wallets:createdNewAccount'
 export const deleteAccount = 'wallets:deleteAccount'
@@ -85,6 +87,10 @@ export const walletDisclaimerReceived = 'wallets:walletDisclaimerReceived'
 type _AbandonPaymentPayload = void
 type _AcceptDisclaimerPayload = $ReadOnly<{|nextScreen: Types.NextScreenAfterAcceptance|}>
 type _AccountsReceivedPayload = $ReadOnly<{|accounts: Array<Types.Account>|}>
+type _AddNewPaymentPayload = $ReadOnly<{|
+  accountID: Types.AccountID,
+  paymentID: Types.PaymentID,
+|}>
 type _AssetsReceivedPayload = $ReadOnly<{|
   accountID: Types.AccountID,
   assets: Array<Types.Assets>,
@@ -125,6 +131,7 @@ type _ClearBuildingPayload = void
 type _ClearBuiltPaymentPayload = void
 type _ClearBuiltRequestPayload = void
 type _ClearErrorsPayload = void
+type _ClearNewPaymentsPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _CreateNewAccountPayload = $ReadOnly<{|
   name: string,
   showOnCreation?: boolean,
@@ -331,6 +338,10 @@ export const createClearErrors = (payload: _ClearErrorsPayload) => ({payload, ty
  */
 export const createSecretKeySeen = (payload: _SecretKeySeenPayload) => ({payload, type: secretKeySeen})
 /**
+ * Clear our idea of which payments have not been seen by the user yet
+ */
+export const createClearNewPayments = (payload: _ClearNewPaymentsPayload) => ({payload, type: clearNewPayments})
+/**
  * Delete an account
  */
 export const createDeleteAccount = (payload: _DeleteAccountPayload) => ({payload, type: deleteAccount})
@@ -378,6 +389,10 @@ export const createLoadDisplayCurrencies = (payload: _LoadDisplayCurrenciesPaylo
  * Load wallet disclaimer
  */
 export const createLoadWalletDisclaimer = (payload: _LoadWalletDisclaimerPayload) => ({payload, type: loadWalletDisclaimer})
+/**
+ * Mark a payment we were just notified about as being unseen
+ */
+export const createAddNewPayment = (payload: _AddNewPaymentPayload) => ({payload, type: addNewPayment})
 /**
  * Mark the given payment ID and anything older as read.
  */
@@ -540,6 +555,7 @@ export const createSetLastSentXLM = (payload: _SetLastSentXLMPayload) => ({paylo
 export type AbandonPaymentPayload = $Call<typeof createAbandonPayment, _AbandonPaymentPayload>
 export type AcceptDisclaimerPayload = $Call<typeof createAcceptDisclaimer, _AcceptDisclaimerPayload>
 export type AccountsReceivedPayload = $Call<typeof createAccountsReceived, _AccountsReceivedPayload>
+export type AddNewPaymentPayload = $Call<typeof createAddNewPayment, _AddNewPaymentPayload>
 export type AssetsReceivedPayload = $Call<typeof createAssetsReceived, _AssetsReceivedPayload>
 export type BadgesUpdatedPayload = $Call<typeof createBadgesUpdated, _BadgesUpdatedPayload>
 export type BuildPaymentPayload = $Call<typeof createBuildPayment, _BuildPaymentPayload>
@@ -555,6 +571,7 @@ export type ClearBuildingPayload = $Call<typeof createClearBuilding, _ClearBuild
 export type ClearBuiltPaymentPayload = $Call<typeof createClearBuiltPayment, _ClearBuiltPaymentPayload>
 export type ClearBuiltRequestPayload = $Call<typeof createClearBuiltRequest, _ClearBuiltRequestPayload>
 export type ClearErrorsPayload = $Call<typeof createClearErrors, _ClearErrorsPayload>
+export type ClearNewPaymentsPayload = $Call<typeof createClearNewPayments, _ClearNewPaymentsPayload>
 export type CreateNewAccountPayload = $Call<typeof createCreateNewAccount, _CreateNewAccountPayload>
 export type CreatedNewAccountPayload = $Call<typeof createCreatedNewAccount, _CreatedNewAccountPayload>
 export type CreatedNewAccountPayloadError = $Call<typeof createCreatedNewAccountError, _CreatedNewAccountPayloadError>
@@ -617,6 +634,7 @@ export type Actions =
   | AbandonPaymentPayload
   | AcceptDisclaimerPayload
   | AccountsReceivedPayload
+  | AddNewPaymentPayload
   | AssetsReceivedPayload
   | BadgesUpdatedPayload
   | BuildPaymentPayload
@@ -632,6 +650,7 @@ export type Actions =
   | ClearBuiltPaymentPayload
   | ClearBuiltRequestPayload
   | ClearErrorsPayload
+  | ClearNewPaymentsPayload
   | CreateNewAccountPayload
   | CreatedNewAccountPayload
   | CreatedNewAccountPayloadError

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -569,23 +569,11 @@ const maybeClearErrors = (state: TypedState) => {
 }
 
 const maybeClearNewTxs = (action: RouteTreeGen.SwitchToPayload, state: TypedState) => {
-  const list = I.List(action.payload.path)
-  const root = list.first()
-  const settingsPath = getPath(state.routeTree.routeState, [Tabs.settingsTab])
-  const walletsPath = getPath(state.routeTree.routeState, [Tabs.walletsTab])
+  const rootTab = I.List(action.payload.path).first()
   // If we're leaving from the Wallets tab, and the Wallets tab route
   // was the main transaction list for an account, clear new txs.
   // FIXME: The hardcoded routes here are fragile if routes change.
-  if (
-    (!isMobile &&
-      root !== Tabs.walletsTab &&
-      state.routeTree.previousTab === Tabs.walletsTab &&
-      walletsPath.get(1) === 'wallet') ||
-    (isMobile &&
-      root !== Tabs.settingsTab &&
-      state.routeTree.previousTab === Tabs.settingsTab &&
-      settingsPath.get(2) === 'wallet')
-  ) {
+  if (rootTab !== Constants.rootWalletTab && Constants.isLookingAtWallet(state.routeTree.routeState)) {
     const accountID = state.wallets.selectedAccount
     if (accountID !== Types.noAccountID) {
       return Saga.put(WalletsGen.createClearNewPayments({accountID}))

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -16,6 +16,7 @@ import type {TypedState} from '../constants/reducer'
 import {getPath} from '../route-tree'
 import * as Tabs from '../constants/tabs'
 import * as SettingsConstants from '../constants/settings'
+import * as I from 'immutable'
 import flags from '../util/feature-flags'
 import {getEngine} from '../engine'
 import {anyWaiting} from '../constants/waiting'
@@ -545,19 +546,50 @@ const setupEngineListeners = () => {
   })
 }
 
-const refreshPayments = ({accountID, paymentID}) =>
-  Saga.put(
-    WalletsGen.createRefreshPayments({
-      accountID: Types.stringToAccountID(accountID),
-      paymentID: Types.rpcPaymentIDToPaymentID(paymentID),
-    })
-  )
+const refreshPayments = response => {
+  const accountID = Types.stringToAccountID(response.accountID)
+  const paymentID = Types.rpcPaymentIDToPaymentID(response.paymentID)
+  return Saga.all([
+    Saga.put(
+      WalletsGen.createRefreshPayments({
+        accountID,
+        paymentID,
+      })
+    ),
+    Saga.put(WalletsGen.createAddNewPayment({accountID, paymentID})),
+  ])
+}
 
 const maybeClearErrors = (state: TypedState) => {
   const routePath = getPath(state.routeTree.routeState)
   const selectedTab = routePath.first()
   if (selectedTab === Tabs.walletsTab) {
     return Saga.put(WalletsGen.createClearErrors())
+  }
+}
+
+const maybeClearNewTxs = (action: RouteTreeGen.SwitchToPayload, state: TypedState) => {
+  const list = I.List(action.payload.path)
+  const root = list.first()
+  const settingsPath = getPath(state.routeTree.routeState, [Tabs.settingsTab])
+  const walletsPath = getPath(state.routeTree.routeState, [Tabs.walletsTab])
+  // If we're leaving from the Wallets tab, and the Wallets tab route
+  // was the main transaction list for an account, clear new txs.
+  // FIXME: The hardcoded routes here are fragile if routes change.
+  if (
+    (!isMobile &&
+      root !== Tabs.walletsTab &&
+      state.routeTree.previousTab === Tabs.walletsTab &&
+      walletsPath.get(1) === 'wallet') ||
+    (isMobile &&
+      root !== Tabs.settingsTab &&
+      state.routeTree.previousTab === Tabs.settingsTab &&
+      settingsPath.get(2) === 'wallet')
+  ) {
+    const accountID = state.wallets.selectedAccount
+    if (accountID !== Types.noAccountID) {
+      return Saga.put(WalletsGen.createClearNewPayments({accountID}))
+    }
   }
 }
 
@@ -685,8 +717,9 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
 
   yield Saga.actionToAction(ConfigGen.setupEngineListeners, setupEngineListeners)
 
-  // Clear some errors on navigateUp.
+  // Clear some errors on navigateUp, clear new txs on switchTab
   yield Saga.actionToAction(RouteTreeGen.navigateUp, maybeClearErrors)
+  yield Saga.safeTakeEveryPure(RouteTreeGen.switchTo, maybeClearNewTxs)
 
   yield Saga.actionToAction(NotificationsGen.receivedBadgeState, receivedBadgeState)
 

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -244,6 +244,7 @@ export type _State = {
   exportedSecretKeyAccountID: AccountID,
   lastSentXLM: boolean,
   linkExistingAccountError: string,
+  newPayments: I.Map<AccountID, I.Set<PaymentID>>,
   paymentsMap: I.Map<AccountID, I.Map<PaymentID, Payment>>,
   paymentCursorMap: I.Map<AccountID, ?StellarRPCTypes.PageCursor>,
   paymentLoadingMoreMap: I.Map<AccountID, boolean>,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -3,9 +3,12 @@ import * as I from 'immutable'
 import * as Types from './types/wallets'
 import * as RPCTypes from './types/rpc-stellar-gen'
 import * as Styles from '../styles'
+import * as Tabs from './tabs'
+import {isMobile} from './platform'
 import {invert} from 'lodash-es'
 import {type TypedState} from './reducer'
 import HiddenString from '../util/hidden-string'
+import {getPath, type RouteStateNode} from '../route-tree'
 import logger from '../logger'
 
 const balanceDeltaToString: {[key: RPCTypes.BalanceDelta]: $Keys<typeof RPCTypes.localBalanceDelta>} = invert(
@@ -576,6 +579,11 @@ const balanceChangeSign = (delta: Types.PaymentDelta, balanceChange: string = ''
   return sign + balanceChange
 }
 
+const rootWalletTab = isMobile ? [Tabs.settingsTab] : [Tabs.walletsTab]
+
+const isLookingAtWallet = (routeState: ?RouteStateNode) =>
+  getPath(routeState, rootWalletTab).get(isMobile ? 2 : 1) === 'wallet'
+
 export {
   acceptDisclaimerWaitingKey,
   accountResultToAccount,
@@ -613,6 +621,7 @@ export {
   getSelectedAccount,
   isAccountLoaded,
   isFederatedAddress,
+  isLookingAtWallet,
   isPaymentUnread,
   linkExistingWaitingKey,
   loadAccountWaitingKey,
@@ -633,6 +642,7 @@ export {
   paymentToYourInfoAndCounterparty,
   requestResultToRequest,
   requestPaymentWaitingKey,
+  rootWalletTab,
   rpcPaymentDetailToPaymentDetail,
   rpcPaymentResultToPaymentResult,
   sendPaymentWaitingKey,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -91,6 +91,7 @@ const makeState: I.RecordFactory<Types._State> = I.Record({
   exportedSecretKeyAccountID: Types.noAccountID,
   lastSentXLM: false,
   linkExistingAccountError: '',
+  newPayments: I.Map(),
   paymentCursorMap: I.Map(),
   paymentLoadingMoreMap: I.Map(),
   paymentOldestUnreadMap: I.Map(),
@@ -541,6 +542,11 @@ const isAccountLoaded = (state: TypedState, accountID: Types.AccountID) =>
 
 const isFederatedAddress = (address: ?string) => (address ? address.includes('*') : false)
 
+const isPaymentUnread = (state: TypedState, accountID: Types.AccountID, paymentID: Types.PaymentID) => {
+  const newPaymentsForAccount = state.wallets.newPayments.get(accountID, false)
+  return newPaymentsForAccount && newPaymentsForAccount.has(paymentID)
+}
+
 const getCurrencyAndSymbol = (state: TypedState, code: string) => {
   if (!state.wallets.currencies || !code) {
     return 'XLM'
@@ -607,6 +613,7 @@ export {
   getSelectedAccount,
   isAccountLoaded,
   isFederatedAddress,
+  isPaymentUnread,
   linkExistingWaitingKey,
   loadAccountWaitingKey,
   loadEverythingWaitingKey,

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -176,6 +176,14 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         secretKeyError: action.error ? action.payload.error : '',
         secretKeyValidationState: action.error ? 'error' : 'valid',
       })
+    case WalletsGen.addNewPayment:
+      const {accountID, paymentID} = action.payload
+      return state.updateIn(
+        ['newPayments', accountID],
+        newTxs => (newTxs ? newTxs.add(paymentID) : I.Set([paymentID]))
+      )
+    case WalletsGen.clearNewPayments:
+      return state.setIn(['newPayments', action.payload.accountID], I.Set())
     case WalletsGen.clearErrors:
       return state.merge({
         accountName: '',

--- a/shared/wallets/transaction-details/index.js
+++ b/shared/wallets/transaction-details/index.js
@@ -248,6 +248,7 @@ const TransactionDetails = (props: NotLoadingProps) => {
           status={props.status}
           statusDetail={props.statusDetail}
           timestamp={props.timestamp}
+          unread={false}
           yourRole={props.yourRole}
         />
         <Kb.Divider />

--- a/shared/wallets/transaction/container.js
+++ b/shared/wallets/transaction/container.js
@@ -16,6 +16,7 @@ const mapStateToProps = (state, ownProps: OwnProps) => ({
   _oldestUnread: Constants.getOldestUnread(state, ownProps.accountID),
   _transaction: Constants.getPayment(state, ownProps.accountID, ownProps.paymentID),
   _you: state.config.username,
+  _unread: Constants.isPaymentUnread(state, ownProps.accountID, ownProps.paymentID),
 })
 
 const mapDispatchToProps = dispatch => ({
@@ -63,6 +64,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     status: tx.statusSimplified,
     statusDetail: tx.statusDetail,
     timestamp: tx.time ? new Date(tx.time) : null,
+    unread: stateProps._unread,
   }
 }
 

--- a/shared/wallets/transaction/index.js
+++ b/shared/wallets/transaction/index.js
@@ -298,6 +298,7 @@ export type Props = {|
   statusDetail: string,
   // A null timestamp means the transaction is still pending.
   timestamp: Date | null,
+  unread: boolean,
   yourRole: Types.Role,
 |}
 
@@ -325,8 +326,7 @@ export const Transaction = (props: Props) => {
       throw new Error(`Unexpected counterpartyType ${props.counterpartyType}`)
   }
   const pending = !props.timestamp || ['pending', 'cancelable'].includes(props.status)
-  const unread = props.readState === 'unread' || props.readState === 'oldestUnread'
-  const backgroundColor = pending || unread ? globalColors.blue4 : globalColors.white
+  const backgroundColor = props.unread ? globalColors.blue4 : globalColors.white
   return (
     <Box2 direction="vertical" fullWidth={true} style={{backgroundColor}}>
       <ClickableBox onClick={props.onSelectTransaction}>

--- a/shared/wallets/transaction/index.stories.js
+++ b/shared/wallets/transaction/index.stories.js
@@ -72,6 +72,7 @@ const addConfigs = (stories, namePrefix, storyFn) => {
                 onSelectTransaction: Sb.action('onSelectTransaction'),
                 onShowProfile: Sb.action('onShowProfile'),
                 selectableText: false,
+                unread: false,
               })
             )
           })


### PR DESCRIPTION
@keybase/react-hackers 

* When we're told about a new payment via the notifications hooks (such as `stellar.1.notify.paymentStatusNotification`), add it to a per-account `newPayments` map in the store.  
* When we're rendering the transaction list, use a blue background color for payments that are in this map -- this replaces the previous logic of "payment is pending or unread".
* When we leave the wallets tab for another tab, and we were on the transaction list for an account, remove any payments in the `newPayments` map for that account so they stop being blue.