### PR TITLE
sort after search in emoji

### DIFF
--- a/shared/chat/conversation/messages/react-button/emoji-picker/index.js
+++ b/shared/chat/conversation/messages/react-button/emoji-picker/index.js
@@ -30,9 +30,12 @@ const cacheSections = (width: number, sections: Array<Section>) => {
 
 // Get emoji results for a query and map
 // to full emoji data
-const getFilterResults = filter => {
-  return emojiIndex.search(filter, {maxResults: maxEmojiSearchResults}).map(res => emojiNameMap[res.id])
-}
+const getFilterResults = filter =>
+  emojiIndex
+    .search(filter, {maxResults: maxEmojiSearchResults})
+    .map(res => emojiNameMap[res.id])
+    // MUST sort this so its stable
+    .sort((a, b) => b.sort_order - a.sort_order)
 
 type Section = {
   category: string,


### PR DESCRIPTION
Due to a subtle difference in node 10/11 (i think this stems from sorting when you have non unique values) storyshots on node 10 vs 11 differ. This should fix that