### PR TITLE
fix public key 'to' field being hard to type in to

### DIFF
--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -60,8 +60,17 @@ type ToStellarPublicKeyProps = {|
   onChangeRecipient: string => void,
 |}
 
-class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps> {
-  _onChangeRecipient = debounce(this.props.onChangeRecipient, 1e3)
+type ToStellarPublicKeyState = {|
+  recipientPublicKey: string,
+|}
+
+class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStellarPublicKeyState> {
+  state = {recipientPublicKey: this.props.recipientPublicKey}
+  _propsOnChangeRecipient = debounce(this.props.onChangeRecipient, 1e3)
+  _onChangeRecipient = recipientPublicKey => {
+    this.setState({recipientPublicKey})
+    this._propsOnChangeRecipient(recipientPublicKey)
+  }
 
   render = () => (
     <ParticipantsRow
@@ -75,7 +84,7 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps> {
         <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputInner}>
           <Kb.Icon
             type={
-              this.props.recipientPublicKey.length === 0 || this.props.errorMessage
+              this.state.recipientPublicKey.length === 0 || this.props.errorMessage
                 ? 'icon-stellar-logo-grey-16'
                 : 'icon-stellar-logo-16'
             }
@@ -92,7 +101,7 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps> {
             multiline={true}
             rowsMin={2}
             rowsMax={3}
-            value={this.props.recipientPublicKey}
+            value={this.state.recipientPublicKey}
           />
         </Kb.Box2>
         {!!this.props.errorMessage && (


### PR DESCRIPTION
I noticed another bug while doing this. If you:

1. Have a valid key in the input and the send button enabled
2. Quickly type a few chars
3. Hit 'Send' before the debounce triggers

You can end up on a confirm screen like this:
<img width="352" alt="keybase_dev" src="https://user-images.githubusercontent.com/11968340/47813606-f0e50400-dd21-11e8-8fc4-e1ffb17b865c.png">

I briefly tried a couple things to fix this but I don't think this component can handle it alone. I'll make a ticket to look more.

r? @keybase/react-hackers 