### PR TITLE
Cap allowed decimal places in send form amount input

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -328,6 +328,12 @@ const loadDisplayCurrency = (state: TypedState, action: WalletsGen.LoadDisplayCu
   )
 }
 
+const displayCurrencyReceived = (state: TypedState, action: WalletsGen.DisplayCurrencyReceivedPayload) => {
+  if (action.payload.setBuildingCurrency) {
+    return Saga.put(WalletsGen.createSetBuildingCurrency({currency: action.payload.currency.code}))
+  }
+}
+
 const changeDisplayCurrency = (state: TypedState, action: WalletsGen.ChangeDisplayCurrencyPayload) =>
   RPCStellarTypes.localChangeDisplayCurrencyLocalRpcPromise(
     {
@@ -635,6 +641,7 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.actionToPromise(WalletsGen.loadDisplayCurrencies, loadDisplayCurrencies)
   yield Saga.actionToPromise(WalletsGen.loadSendAssetChoices, loadSendAssetChoices)
   yield Saga.actionToPromise(WalletsGen.loadDisplayCurrency, loadDisplayCurrency)
+  yield Saga.actionToAction(WalletsGen.displayCurrencyReceived, displayCurrencyReceived)
   yield Saga.actionToPromise(WalletsGen.changeDisplayCurrency, changeDisplayCurrency)
   yield Saga.actionToPromise(WalletsGen.setAccountAsDefault, setAccountAsDefault)
   yield Saga.actionToPromise(WalletsGen.changeAccountName, changeAccountName)

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -328,11 +328,9 @@ const loadDisplayCurrency = (state: TypedState, action: WalletsGen.LoadDisplayCu
   )
 }
 
-const displayCurrencyReceived = (state: TypedState, action: WalletsGen.DisplayCurrencyReceivedPayload) => {
-  if (action.payload.setBuildingCurrency) {
-    return Saga.put(WalletsGen.createSetBuildingCurrency({currency: action.payload.currency.code}))
-  }
-}
+const displayCurrencyReceived = (state: TypedState, action: WalletsGen.DisplayCurrencyReceivedPayload) =>
+  action.payload.setBuildingCurrency &&
+  Saga.put(WalletsGen.createSetBuildingCurrency({currency: action.payload.currency.code}))
 
 const changeDisplayCurrency = (state: TypedState, action: WalletsGen.ChangeDisplayCurrencyPayload) =>
   RPCStellarTypes.localChangeDisplayCurrencyLocalRpcPromise(

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -100,12 +100,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
       const {currency} = action.payload
       return state
         .set('builtPayment', Constants.makeBuiltPayment())
-        .set(
-          'building',
-          state
-            .get('building')
-            .merge({amount: currency === state.building.currency ? state.building.amount : '', currency})
-        )
+        .set('building', state.get('building').merge({currency}))
     case WalletsGen.setBuildingFrom:
       const {from} = action.payload
       return state

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -59,11 +59,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         if (action.payload.accountID) {
           stateMutable.update('currencyMap', c => c.set(action.payload.accountID, action.payload.currency))
         }
-        if (action.payload.setBuildingCurrency) {
-          stateMutable.update('building', b =>
-            b.merge({currency: state.lastSentXLM ? 'XLM' : action.payload.currency.code})
-          )
-        }
       })
     case WalletsGen.secretKeyReceived:
       return state
@@ -105,7 +100,12 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
       const {currency} = action.payload
       return state
         .set('builtPayment', Constants.makeBuiltPayment())
-        .set('building', state.get('building').merge({currency}))
+        .set(
+          'building',
+          state
+            .get('building')
+            .merge({amount: currency === state.building.currency ? state.building.amount : '', currency})
+        )
     case WalletsGen.setBuildingFrom:
       const {from} = action.payload
       return state

--- a/shared/wallets/send-form/asset-input/container.js
+++ b/shared/wallets/send-form/asset-input/container.js
@@ -14,7 +14,9 @@ const mapStateToProps = state => {
     accountID,
     bottomLabel: '', // TODO
     displayUnit,
+    // TODO differentiate between an asset (7 digits) and a display currency (2 digits) below
     inputPlaceholder: currency && currency !== 'XLM' ? '0.00' : '0.0000000',
+    numDecimalsAllowed: currency && currency !== 'XLM' ? 2 : 7,
     topLabel: '', // TODO
     value: state.wallets.building.amount,
   }
@@ -38,6 +40,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   bottomLabel: stateProps.bottomLabel,
   displayUnit: stateProps.displayUnit,
   inputPlaceholder: stateProps.inputPlaceholder,
+  numDecimalsAllowed: stateProps.numDecimalsAllowed,
   onChangeAmount: dispatchProps.onChangeAmount,
   onChangeDisplayUnit: ownProps.onChooseAsset || dispatchProps.onChangeDisplayUnit,
   topLabel: stateProps.topLabel,

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -4,6 +4,27 @@ import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 import Available from '../available/container'
 
+const isValidAmount = (amt, numDecimalsAllowed) => {
+  if (!isNaN(+amt) || amt === '.') {
+    // This is a valid number. Now check the number of decimal places
+    const split = amt.includes('.') && amt.split('.')
+    if (!split) {
+      // no decimal places
+      return true
+    }
+    const decimal = split[split.length - 1]
+    if (decimal.length <= numDecimalsAllowed) {
+      return true
+    }
+  }
+  return false
+}
+
+const truncateAmount = (amt, numDecimalsAllowed) => {
+  const num = +amt
+  return num.toFixed(numDecimalsAllowed).toString()
+}
+
 type Props = {|
   bottomLabel: string,
   displayUnit: string,
@@ -17,72 +38,80 @@ type Props = {|
   warningPayee?: string,
 |}
 
-const AssetInput = (props: Props) => {
-  const onChangeAmount = t => {
-    if (!isNaN(+t) || t === '.') {
-      // This is a valid number. Now check the number of decimal places
-      const split = t.includes('.') && t.split('.')
-      if (!split) {
-        // no decimal places
-        props.onChangeAmount(t)
-        return
-      }
-      const decimal = split[split.length - 1]
-      if (decimal.length <= props.numDecimalsAllowed) {
-        props.onChangeAmount(t)
-      }
+class AssetInput extends React.Component<Props> {
+  componentDidMount() {
+    if (!isValidAmount(this.props.value, this.props.numDecimalsAllowed)) {
+      this.props.onChangeAmount(truncateAmount(this.props.value, this.props.numDecimalsAllowed))
     }
   }
-  return (
-    <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true} style={styles.container}>
-      {!!props.topLabel && (
-        <Kb.Text
-          type="BodySmallSemibold"
-          style={Styles.collapseStyles([styles.topLabel, styles.labelMargin])}
-        >
-          {props.topLabel}
-        </Kb.Text>
-      )}
-      <Kb.NewInput
-        autoFocus={true}
-        type="text"
-        keyboardType="numeric"
-        decoration={
-          <Kb.Box2 direction="vertical" style={styles.flexEnd}>
-            <Kb.Text type="HeaderBigExtrabold" style={styles.unit}>
-              {props.displayUnit}
-            </Kb.Text>
-            <Kb.Text type="BodySmallPrimaryLink" onClick={props.onChangeDisplayUnit}>
-              Change
-            </Kb.Text>
-          </Kb.Box2>
-        }
-        containerStyle={styles.inputContainer}
-        style={styles.input}
-        onChangeText={onChangeAmount}
-        textType="HeaderBigExtrabold"
-        placeholder={props.inputPlaceholder}
-        placeholderColor={Styles.globalColors.purple2_40}
-        error={!!props.warningAsset}
-        value={props.value}
-      />
-      <Available />
-      {!!props.warningPayee && (
-        <Kb.Text type="BodySmallError">
-          {props.warningPayee} doesn't accept{' '}
-          <Kb.Text type="BodySmallSemibold" style={{color: Styles.globalColors.red}}>
-            {props.warningAsset}
+
+  componentDidUpdate(prevProps: Props) {
+    if (
+      this.props.numDecimalsAllowed !== prevProps.numDecimalsAllowed &&
+      !isValidAmount(this.props.value, this.props.numDecimalsAllowed)
+    ) {
+      this.props.onChangeAmount(truncateAmount(this.props.value, this.props.numDecimalsAllowed))
+    }
+  }
+
+  _onChangeAmount = t => {
+    if (isValidAmount(t, this.props.numDecimalsAllowed)) {
+      this.props.onChangeAmount(t)
+    }
+  }
+
+  render() {
+    return (
+      <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true} style={styles.container}>
+        {!!this.props.topLabel && (
+          <Kb.Text
+            type="BodySmallSemibold"
+            style={Styles.collapseStyles([styles.topLabel, styles.labelMargin])}
+          >
+            {this.props.topLabel}
           </Kb.Text>
-          . Please pick another asset.
-        </Kb.Text>
-      )}
-      <Kb.Box2 direction="horizontal" fullWidth={true} gap="xtiny">
-        <Kb.Text type="BodySmall" style={styles.labelMargin} selectable={true}>
-          {props.bottomLabel}
-        </Kb.Text>
+        )}
+        <Kb.NewInput
+          autoFocus={true}
+          type="text"
+          keyboardType="numeric"
+          decoration={
+            <Kb.Box2 direction="vertical" style={styles.flexEnd}>
+              <Kb.Text type="HeaderBigExtrabold" style={styles.unit}>
+                {this.props.displayUnit}
+              </Kb.Text>
+              <Kb.Text type="BodySmallPrimaryLink" onClick={this.props.onChangeDisplayUnit}>
+                Change
+              </Kb.Text>
+            </Kb.Box2>
+          }
+          containerStyle={styles.inputContainer}
+          style={styles.input}
+          onChangeText={this._onChangeAmount}
+          textType="HeaderBigExtrabold"
+          placeholder={this.props.inputPlaceholder}
+          placeholderColor={Styles.globalColors.purple2_40}
+          error={!!this.props.warningAsset}
+          value={this.props.value}
+        />
+        <Available />
+        {!!this.props.warningPayee && (
+          <Kb.Text type="BodySmallError">
+            {this.props.warningPayee} doesn't accept{' '}
+            <Kb.Text type="BodySmallSemibold" style={{color: Styles.globalColors.red}}>
+              {this.props.warningAsset}
+            </Kb.Text>
+            . Please pick another asset.
+          </Kb.Text>
+        )}
+        <Kb.Box2 direction="horizontal" fullWidth={true} gap="xtiny">
+          <Kb.Text type="BodySmall" style={styles.labelMargin} selectable={true}>
+            {this.props.bottomLabel}
+          </Kb.Text>
+        </Kb.Box2>
       </Kb.Box2>
-    </Kb.Box2>
-  )
+    )
+  }
 }
 
 const styles = Styles.styleSheetCreate({

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -8,6 +8,7 @@ type Props = {|
   bottomLabel: string,
   displayUnit: string,
   inputPlaceholder: string,
+  numDecimalsAllowed: number,
   onChangeAmount: string => void,
   onChangeDisplayUnit: () => void,
   topLabel: string,
@@ -17,6 +18,21 @@ type Props = {|
 |}
 
 const AssetInput = (props: Props) => {
+  const onChangeAmount = t => {
+    if (!isNaN(+t) || t === '.') {
+      // This is a valid number. Now check the number of decimal places
+      const split = t.includes('.') && t.split('.')
+      if (!split) {
+        // no decimal places
+        props.onChangeAmount(t)
+        return
+      }
+      const decimal = split[split.length - 1]
+      if (decimal.length <= props.numDecimalsAllowed) {
+        props.onChangeAmount(t)
+      }
+    }
+  }
   return (
     <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true} style={styles.container}>
       {!!props.topLabel && (
@@ -43,11 +59,7 @@ const AssetInput = (props: Props) => {
         }
         containerStyle={styles.inputContainer}
         style={styles.input}
-        onChangeText={t => {
-          if (!isNaN(+t) || t === '.') {
-            props.onChangeAmount(t)
-          }
-        }}
+        onChangeText={onChangeAmount}
         textType="HeaderBigExtrabold"
         placeholder={props.inputPlaceholder}
         placeholderColor={Styles.globalColors.purple2_40}

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -5,10 +5,10 @@ import * as Styles from '../../../styles'
 import Available from '../available/container'
 
 const isValidAmount = (amt, numDecimalsAllowed) => {
-  if (!isNaN(+amt) || amt === '.') {
+  if (!isNaN(Number(amt)) || amt === '.') {
     // This is a valid number. Now check the number of decimal places
-    const split = amt.includes('.') && amt.split('.')
-    if (!split) {
+    const split = amt.split('.')
+    if (split.length === 1) {
       // no decimal places
       return true
     }
@@ -21,7 +21,7 @@ const isValidAmount = (amt, numDecimalsAllowed) => {
 }
 
 const truncateAmount = (amt, numDecimalsAllowed) => {
-  const num = +amt
+  const num = Number(amt)
   return num.toFixed(numDecimalsAllowed).toString()
 }
 

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -22,7 +22,7 @@ const isValidAmount = (amt, numDecimalsAllowed) => {
 
 const truncateAmount = (amt, numDecimalsAllowed) => {
   const num = Number(amt)
-  return num.toFixed(numDecimalsAllowed).toString()
+  return num.toFixed(numDecimalsAllowed)
 }
 
 type Props = {|

--- a/shared/wallets/send-form/asset-input/index.stories.js
+++ b/shared/wallets/send-form/asset-input/index.stories.js
@@ -22,6 +22,7 @@ const props1 = {
   bottomLabel: '$1 = 5.0992345 XLM',
   displayUnit: 'USD ($)',
   inputPlaceholder: '0.00',
+  numDecimalsAllowed: 2,
   topLabel: 'XLM worth:',
 }
 
@@ -30,6 +31,7 @@ const props2 = {
   bottomLabel: '1 XLM = $0.2303',
   displayUnit: 'XLM',
   inputPlaceholder: '0.0000000',
+  numDecimalsAllowed: 7,
   value: '129',
 }
 
@@ -38,6 +40,7 @@ const props3 = {
   bottomLabel: 'Issuer: Stronghold.com',
   displayUnit: 'BTC',
   inputPlaceholder: '0.0000000',
+  numDecimalsAllowed: 7,
   value: '0.08',
 }
 
@@ -47,6 +50,7 @@ export const props4 = {
   bottomLabel: '1 XLM = $0.2303',
   displayUnit: 'XLM',
   inputPlaceholder: '0.0000000',
+  numDecimalsAllowed: 7,
   value: '3.4289000',
 }
 
@@ -86,7 +90,8 @@ const load = () => {
     .add('USD over warning', () => <AssetInput {...props1} {...warning1} />)
     .add('XLM over warning', () => <AssetInput {...props2} {...warning2} />)
     .add('asset type warning', () => <AssetInput {...props3} {...warning3} />)
-    .add('Input validation', () => <StatefulAssetInput {...props2} />)
+    .add('Input validation (XLM)', () => <StatefulAssetInput {...props2} />)
+    .add('Input validation (Currency)', () => <StatefulAssetInput {...props1} />)
 }
 
 export default load


### PR DESCRIPTION
Caps to 7 for XLM and 2 for anything else. There was a bug where if you've entered 7 decimals & then changed to a display currency, typing chars into the input was impossible because the value was always invalid. I fixed this by clearing out the amount when the display currency changes. Another option would be to truncate the input when this happens but I figured we might want to do this anyway (cc @malgorithms). r? @keybase/react-hackers 