### PR TITLE
better search err handling

### DIFF
--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -62,12 +62,7 @@ func (b *baseLocalizer) filterSelfFinalized(ctx context.Context, inbox types.Inb
 	res = inbox
 	res.ConvsUnverified = nil
 	for _, conv := range inbox.ConvsUnverified {
-		if conv.Conv.GetMembersType() == chat1.ConversationMembersType_KBFS &&
-			conv.Conv.GetFinalizeInfo() != nil &&
-			// If reset user is the current user, or is blank (only way such a thing could be in our
-			// inbox is if the current user is the one that reset)
-			(conv.Conv.GetFinalizeInfo().ResetUser == username ||
-				conv.Conv.GetFinalizeInfo().ResetUser == "") {
+		if conv.Conv.IsSelfFinalized(username) {
 			b.Debug(ctx, "baseLocalizer: skipping own finalized convo: %s name: %s", conv.GetConvID())
 			continue
 		}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -955,6 +955,12 @@ func (f *ConversationFinalizeInfo) BeforeSummary() string {
 	return fmt.Sprintf("(before %s account reset %s)", f.ResetUser, f.ResetDate)
 }
 
+func (f *ConversationFinalizeInfo) IsResetForUser(username string) bool {
+	// If reset user is the given user, or is blank (only way such a thing
+	// could be in our inbox is if the current user is the one that reset)
+	return f != nil && (f.ResetUser == username || f.ResetUser == "")
+}
+
 func (p *Pagination) Eq(other *Pagination) bool {
 	if p == nil && other == nil {
 		return true
@@ -1105,6 +1111,10 @@ func (c Conversation) GetMaxMessageID() MessageID {
 		}
 	}
 	return maxMsgID
+}
+
+func (c Conversation) IsSelfFinalized(username string) bool {
+	return c.GetMembersType() == ConversationMembersType_KBFS && c.GetFinalizeInfo().IsResetForUser(username)
 }
 
 func (m MessageSummary) GetMessageID() MessageID {


### PR DESCRIPTION
1. Filters SelfFinalized conversations entirely from search
2. Logs errors from `reindexConv` instead of returning