### PR TITLE
Don't try to load assets/payments for accounts we don't own

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -230,6 +230,7 @@ const loadAssets = (
     | WalletsGen.RefreshPaymentsPayload
 ) =>
   !actionHasError(action) &&
+  Constants.getAccount(state, action.payload.accountID).accountID !== Types.noAccountID &&
   RPCStellarTypes.localGetAccountAssetsLocalRpcPromise({accountID: action.payload.accountID}).then(res =>
     WalletsGen.createAssetsReceived({
       accountID: action.payload.accountID,
@@ -260,6 +261,7 @@ const loadPayments = (
     | WalletsGen.LinkedExistingAccountPayload
 ) =>
   !actionHasError(action) &&
+  Constants.getAccount(state, action.payload.accountID).accountID !== Types.noAccountID &&
   Promise.all([
     RPCStellarTypes.localGetPendingPaymentsLocalRpcPromise({accountID: action.payload.accountID}),
     RPCStellarTypes.localGetPaymentsLocalRpcPromise({accountID: action.payload.accountID}),
@@ -269,6 +271,7 @@ const loadPayments = (
 // fetch the single payment.
 const doRefreshPayments = (state: TypedState, action: WalletsGen.RefreshPaymentsPayload) =>
   !actionHasError(action) &&
+  Constants.getAccount(state, action.payload.accountID).accountID !== Types.noAccountID &&
   Promise.all([
     RPCStellarTypes.localGetPendingPaymentsLocalRpcPromise({accountID: action.payload.accountID}),
     RPCStellarTypes.localGetPaymentsLocalRpcPromise({accountID: action.payload.accountID}),


### PR DESCRIPTION
@keybase/react-hackers 

When we cancel a relay payment, we're given a `paymentStatusNotification(accountID, paymentID)` of the recipient's accountID, rather than ours.  Perhaps that's a Core bug -- seems like it could be our accountID instead of theirs, since the point is to tell us which accountID to refresh for new payments.  Another possible Core bug is that the recipient accountID showed up in my own badgeState.unreadPayments account list after this, too.

So, we were trying to load payments on the remote user's accountID, and black barring because we don't own it.

Either way, for now just ignore requests to load assets or payments for accounts that don't exist in our accountMap.