### PR TITLE
Always use the large row for account-to-account tx, instead of only when memo

### DIFF
--- a/shared/wallets/transaction/index.js
+++ b/shared/wallets/transaction/index.js
@@ -315,7 +315,7 @@ export const Transaction = (props: Props) => {
       showMemo = props.yourRole !== 'receiverOnly'
       break
     case 'otherAccount':
-      large = !!props.memo
+      large = true
       showMemo = !!props.memo
       break
     default:


### PR DESCRIPTION
@keybase/react-hackers 