### PR TITLE
fix bad trackbreak caching in identify2

### DIFF
--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -378,7 +378,7 @@ func (t *NameIdentifier) identifyUser(ctx context.Context, assertion string, pri
 			return keybase1.TLFIdentifyFailure{}, err
 		}
 	}
-	resp, err := eng.Result()
+	resp, err := eng.Result(m)
 	if err != nil {
 		return keybase1.TLFIdentifyFailure{}, err
 	}

--- a/go/engine/bg_identifier.go
+++ b/go/engine/bg_identifier.go
@@ -345,7 +345,7 @@ func (b *BackgroundIdentifier) runOne(m libkb.MetaContext, u keybase1.UID) (err 
 	if err != nil {
 		return err
 	}
-	res, err := eng.Result()
+	res, err := eng.Result(m)
 	if err != nil {
 		return err
 	}

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -33,7 +33,7 @@ func runIdentify(tc *libkb.TestContext, username string) (idUI *FakeIdentifyUI, 
 	if err != nil {
 		return idUI, nil, err
 	}
-	res, err = eng.Result()
+	res, err = eng.Result(m)
 	if err != nil {
 		return idUI, nil, err
 	}

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -10,6 +10,7 @@ import (
 
 	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	clockwork "github.com/keybase/clockwork"
 	jsonw "github.com/keybase/go-jsonw"
 	require "github.com/stretchr/testify/require"
 )
@@ -465,7 +466,8 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 		}
 
 		waiter := launchWaiter(t, tester.finishCh)
-		err := eng.Run(identify2MetaContext(tc, tester))
+		m := identify2MetaContext(tc, tester)
+		err := eng.Run(m)
 		// Since we threw away the test UI, we have to manually complete the UI here,
 		// otherwise the waiter() will block indefinitely.
 		origUI.Finish()
@@ -473,7 +475,7 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no ID2 error; got %v", err)
 		}
-		res, err := eng.Result()
+		res, err := eng.Result(m)
 		if err != nil {
 			t.Fatalf("unexpected export error: %s", err)
 		}
@@ -927,13 +929,14 @@ func TestIdentify2NoSigchain(t *testing.T) {
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
 	}
 	eng := NewResolveThenIdentify2(tc.G, arg)
-	err := eng.Run(identify2MetaContext(tc, i))
+	m := identify2MetaContext(tc, i)
+	err := eng.Run(m)
 	if err != nil {
 		t.Fatalf("identify2 failed on user with no keys: %s", err)
 	}
 
 	// kbfs would like to have some info about the user
-	result, err := eng.Result()
+	result, err := eng.Result(m)
 	if err != nil {
 		t.Fatalf("unexpeted export error: %s", err)
 	}
@@ -1140,6 +1143,57 @@ func TestResolveAndCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, upk.GetUID().Equal(fu.UID()))
 	require.Equal(t, upk.GetName(), fu.Username)
+}
+
+// TestTrackThenRevokeWithDifferentChatModes is described in CORE-9372. The scenario
+// is that: (1) bob proves rooter; (2) alice follows bob; (3) bob revokes rooter;
+// (4) alice ID's bob with CHAT_GUI, and that should work; (5)
+// alice ID's bob with CHAT_GUI_STRICT, and that should fail
+func TestTrackThenRevokeThenIdentifyWithDifferentChatModes(t *testing.T) {
+	tc := SetupEngineTest(t, "id")
+	defer tc.Cleanup()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	bob := CreateAndSignupFakeUser(tc, "b")
+	_, sigID, err := proveRooter(tc.G, bob, 2)
+	require.NoError(t, err)
+	alice := CreateAndSignupFakeUser(tc, "a")
+	trackUser(tc, alice, bob.NormalizedUsername(), 2)
+	Logout(tc)
+	bob.Login(tc.G)
+	err = doRevokeSig(tc, bob, sigID)
+	require.NoError(t, err)
+	Logout(tc)
+	alice.Login(tc.G)
+
+	// Blast through the cache
+	fakeClock.Advance(libkb.Identify2CacheLongTimeout + time.Minute)
+
+	runIdentify := func(idb keybase1.TLFIdentifyBehavior) (err error) {
+		idUI := &FakeIdentifyUI{}
+		arg := keybase1.Identify2Arg{
+			UserAssertion:    bob.Username,
+			UseDelegateUI:    false,
+			CanSuppressUI:    true,
+			IdentifyBehavior: idb,
+		}
+
+		uis := libkb.UIs{
+			LogUI:      tc.G.UI.GetLogUI(),
+			IdentifyUI: idUI,
+		}
+		eng := NewResolveThenIdentify2(tc.G, &arg)
+		m := NewMetaContextForTest(tc).WithUIs(uis)
+		err = RunEngine2(m, eng)
+		return err
+	}
+
+	err = runIdentify(keybase1.TLFIdentifyBehavior_CHAT_GUI)
+	require.NoError(t, err)
+	err = runIdentify(keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT)
+	require.Error(t, err)
 }
 
 var aliceUID = keybase1.UID("295a7eea607af32040647123732bc819")

--- a/go/engine/pgp_decrypt.go
+++ b/go/engine/pgp_decrypt.go
@@ -116,7 +116,7 @@ func (e *PGPDecrypt) Run(m libkb.MetaContext) (err error) {
 		if err := RunEngine2(m, eng); err != nil {
 			return err
 		}
-		res, err := eng.Result()
+		res, err := eng.Result(m)
 		if err != nil {
 			return err
 		}

--- a/go/engine/pgp_encrypt.go
+++ b/go/engine/pgp_encrypt.go
@@ -201,7 +201,7 @@ func (e *PGPEncrypt) verifyUsers(m libkb.MetaContext, assertions []string, logge
 		if err := RunEngine2(m, eng); err != nil {
 			return nil, libkb.IdentifyFailedError{Assertion: userAssert, Reason: err.Error()}
 		}
-		res, err := eng.Result()
+		res, err := eng.Result(m)
 		if err != nil {
 			return nil, err
 		}

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -169,7 +169,7 @@ func (e *PGPPullEngine) processUserWithIdentify(m libkb.MetaContext, u string) e
 		return nil
 	}
 
-	idRes, err := ieng.Result()
+	idRes, err := ieng.Result(m)
 	if err != nil {
 		return err
 	}

--- a/go/engine/pgp_verify.go
+++ b/go/engine/pgp_verify.go
@@ -258,7 +258,7 @@ func (e *PGPVerify) checkSignedBy(m libkb.MetaContext) error {
 	if err := RunEngine2(m, eng); err != nil {
 		return err
 	}
-	res, err := eng.Result()
+	res, err := eng.Result(m)
 	if err != nil {
 		return err
 	}

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -109,7 +109,7 @@ func (e *ResolveThenIdentify2) nameResolutionPostAssertion(m libkb.MetaContext) 
 	if e.queriedName.IsNil() {
 		return nil
 	}
-	res, err := e.Result()
+	res, err := e.Result(m)
 	if err != nil {
 		return err
 	}
@@ -146,11 +146,11 @@ func (e *ResolveThenIdentify2) Run(m libkb.MetaContext) (err error) {
 	return nil
 }
 
-func (e *ResolveThenIdentify2) Result() (*keybase1.Identify2ResUPK2, error) {
+func (e *ResolveThenIdentify2) Result(m libkb.MetaContext) (*keybase1.Identify2ResUPK2, error) {
 	if e.i2eng == nil {
 		return nil, errors.New("ResolveThenIdentify2#Result: no result available if the engine did not run")
 	}
-	return e.i2eng.Result()
+	return e.i2eng.Result(m)
 }
 
 func (e *ResolveThenIdentify2) SetResponsibleGregorItem(item gregor.Item) {
@@ -202,7 +202,7 @@ func ResolveAndCheck(m libkb.MetaContext, s string, useTracking bool) (ret keyba
 	if err = RunEngine2(m, eng); err != nil {
 		return ret, err
 	}
-	res, err := eng.Result()
+	res, err := eng.Result(m)
 	if err != nil {
 		return ret, err
 	}

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -42,6 +42,17 @@ func doRevokeKey(tc libkb.TestContext, u *FakeUser, kid keybase1.KID) error {
 	return err
 }
 
+func doRevokeSig(tc libkb.TestContext, u *FakeUser, sig keybase1.SigID) error {
+	revokeEngine := NewRevokeSigsEngine(tc.G, []string{sig.String()})
+	uis := libkb.UIs{
+		LogUI:    tc.G.UI.GetLogUI(),
+		SecretUI: u.NewSecretUI(),
+	}
+	m := NewMetaContextForTest(tc).WithUIs(uis)
+	err := RunEngine2(m, revokeEngine)
+	return err
+}
+
 func doRevokeDevice(tc libkb.TestContext, u *FakeUser, id keybase1.DeviceID, forceSelf, forceLast bool) error {
 	revokeEngine := NewRevokeDeviceEngine(tc.G, RevokeDeviceEngineArgs{ID: id, ForceSelf: forceSelf, ForceLast: forceLast})
 	uis := libkb.UIs{

--- a/go/engine/saltpack_user_keyfinder.go
+++ b/go/engine/saltpack_user_keyfinder.go
@@ -144,7 +144,7 @@ func (e *SaltpackUserKeyfinder) IdentifyUser(m libkb.MetaContext, user string) (
 		return nil, err
 	}
 
-	engRes, err := eng.Result()
+	engRes, err := eng.Result(m)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/track.go
+++ b/go/engine/track.go
@@ -80,7 +80,7 @@ func (e *TrackEngine) Run(m libkb.MetaContext) error {
 		return err
 	}
 
-	res, err := ieng.Result()
+	res, err := ieng.Result(m)
 	if err != nil {
 		return err
 	}

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -55,7 +55,7 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 		err := engine.RunEngine2(m, eng)
 		log("GetProofSet: %v", spew.Sdump(eng.GetProofSet()))
 		log("ConfirmResult: %v", spew.Sdump(eng.ConfirmResult()))
-		eres, eerr := eng.Result()
+		eres, eerr := eng.Result(m)
 		if eres != nil {
 			log("Result.Upk.Username: %v", spew.Sdump(eres.Upk.GetName()))
 			log("Result.IdentifiedAt: %v", spew.Sdump(eres.IdentifiedAt))

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -57,7 +57,7 @@ func (h *IdentifyHandler) Identify2(netCtx context.Context, arg keybase1.Identif
 	if err != nil {
 		return res, err
 	}
-	resp, err := eng.Result()
+	resp, err := eng.Result(m)
 	if err != nil {
 		return res, err
 	}
@@ -135,7 +135,7 @@ func (h *IdentifyHandler) identifyLiteUser(netCtx context.Context, arg keybase1.
 	if err != nil {
 		return res, err
 	}
-	resp, err := eng.Result()
+	resp, err := eng.Result(m)
 	if err != nil {
 		return res, err
 	}
@@ -301,7 +301,7 @@ func (h *IdentifyHandler) resolveIdentifyImplicitTeamDoIdentifies(ctx context.Co
 			eng := engine.NewIdentify2WithUID(h.G(), &id2arg)
 			m := libkb.NewMetaContext(subctx, h.G()).WithUIs(uis)
 			err := engine.RunEngine2(m, eng)
-			idRes, idErr := eng.Result()
+			idRes, idErr := eng.Result(m)
 			if err != nil {
 				h.G().Log.CDebugf(subctx, "identify failed (IDres %v, TrackBreaks %v): %v", idRes != nil, idRes != nil && idRes.TrackBreaks != nil, err)
 				if idRes != nil && idRes.TrackBreaks != nil && idErr == nil {

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -918,7 +918,7 @@ func identifyRecipient(m libkb.MetaContext, assertion string, isCLI bool) (keyba
 		return keybase1.TLFIdentifyFailure{}, err
 	}
 
-	resp, err := eng.Result()
+	resp, err := eng.Result(m)
 	if err != nil {
 		return keybase1.TLFIdentifyFailure{}, err
 	}

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -206,8 +206,8 @@ func verifyResolveResult(ctx context.Context, g *libkb.GlobalContext, resolvedAs
 	m := libkb.NewMetaContext(ctx, g).WithUIs(uis)
 	err = engine.RunEngine2(m, eng)
 	if err != nil {
-		idRes, _ := eng.Result()
-		g.Log.CDebugf(ctx, "identify failed (IDres %v, TrackBreaks %v): %v", idRes != nil, idRes != nil && idRes.TrackBreaks != nil, err)
+		idRes, _ := eng.Result(m)
+		m.CDebugf("identify failed (IDres %v, TrackBreaks %v): %v", idRes != nil, idRes != nil && idRes.TrackBreaks != nil, err)
 	}
 	return err
 }


### PR DESCRIPTION
- the issue was that if alice tracked bob, and bob revoked a proof, that failed track didn't make it into and out of the cache through some code paths
- repro test case, and bug fix