### PR TITLE
fix bug with nil decryption error cause panicking

### DIFF
--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -1920,7 +1920,7 @@ func (e DecryptionError) ToStatus() keybase1.Status {
 		Code: SCDecryptionError,
 		Name: "SC_DECRYPTION_ERROR",
 		Fields: []keybase1.StringKVPair{
-			{Key: "Cause", Value: e.Cause.Error()},
+			{Key: "Cause", Value: e.Error()},
 		},
 	}
 }


### PR DESCRIPTION
looks like this was introduced a few months ago with saltpack enhancements. the current `Error()` method delegates to `Cause` and handles the nil case anyway. 

```go
type DecryptionError struct {
	Cause error
}

func (e DecryptionError) Error() string {
	if e.Cause == nil {
		return "Decryption error"
	}
	return fmt.Sprintf("Decryption error: %v", e.Cause)
}
```
