### PR TITLE
Load deleted users in FindNextMerkleRootAfterRevoke

### DIFF
--- a/go/engine/merkle_client_historical_test.go
+++ b/go/engine/merkle_client_historical_test.go
@@ -111,4 +111,23 @@ func TestFindNextMerkleRootAfterRevoke(t *testing.T) {
 	require.True(t, after > before, "we got a > seqno")
 	t.Logf("Found merkle root %d > %d", after, before)
 
+	// Make sure we can find this after fu is deleted
+	err = libkb.DeleteAccount(m, fu.NormalizedUsername(), fu.Passphrase)
+	require.NoError(t, err)
+	err = tc.G.Logout()
+	require.NoError(t, err)
+
+	arg = keybase1.FindNextMerkleRootAfterRevokeArg{
+		Uid:  fu.UID(),
+		Kid:  revokedKey.Base.Kid,
+		Loc:  revokedKey.Base.Revocation.SigChainLocation,
+		Prev: revokedKey.Base.Revocation.PrevMerkleRootSigned,
+	}
+	res, err = libkb.FindNextMerkleRootAfterRevoke(m, arg)
+	require.NoError(t, err, "found the next root")
+	require.NotNil(t, res.Res, "we got a root back")
+	before = revokedKey.Base.Revocation.PrevMerkleRootSigned.Seqno
+	after = res.Res.Seqno
+	require.True(t, after > before, "we got a > seqno")
+	t.Logf("Found merkle root %d > %d", after, before)
 }

--- a/go/libkb/merkle_tools.go
+++ b/go/libkb/merkle_tools.go
@@ -130,15 +130,16 @@ func findFirstLeafWithComparer(m MetaContext, id keybase1.UserOrTeamID, comparat
 	return leaf, root, nil
 }
 
-// FindNextMerkleRootAfterRevoke loads the user for the given UID, and find the next merkle root
-// after the given key revocation happens. It uses the paremter arg.Prev to figure out where to start
-// looking and then keeps searching forward until finding a leaf that matches arg.Loc.
+// FindNextMerkleRootAfterRevoke loads the user for the given UID, and find the
+// next merkle root after the given key revocation happens. It uses the
+// parameter arg.Prev to figure out where to start looking and then keeps
+// searching forward until finding a leaf that matches arg.Loc.
 func FindNextMerkleRootAfterRevoke(m MetaContext, arg keybase1.FindNextMerkleRootAfterRevokeArg) (res keybase1.NextMerkleRootRes, err error) {
 
 	defer m.CTrace(fmt.Sprintf("FindNextMerkleRootAfterRevoke(%+v)", arg), func() error { return err })()
 
 	var u *User
-	u, err = LoadUser(NewLoadUserArgWithMetaContext(m).WithUID(arg.Uid))
+	u, err = LoadUser(NewLoadUserArgWithMetaContext(m).WithUID(arg.Uid).WithPublicKeyOptional())
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
Addresses https://github.com/keybase/client/issues/14525 by adding `WithPublicKeyOptional` to the `LoadUser` call

cc @strib 