### PR TITLE
Lower lvldb file limit to 48

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -127,8 +127,8 @@ const (
 	TeamMerkleFreshnessForAdmin = 30 * time.Second
 	EphemeralKeyMerkleFreshness = 30 * time.Second
 
-	// By default, only 64 files can be opened.
-	LevelDBNumFiles = 64
+	// By default, only 48 files can be opened.
+	LevelDBNumFiles = 48
 
 	HomeCacheTimeout       = (time.Hour - time.Minute)
 	HomePeopleCacheTimeout = 10 * time.Minute


### PR DESCRIPTION
Drops the max number of open files for levelDB so it's 96 across the chat/normal dbs. for OSX the default is 256 files so this gives us a little more headroom. if we do run out of files it's pretty fatal to the application running since errors start getting thrown everywhere. I tried picking through the log where this happened without finding any root culprit, wasn't able to reproduce locally either. saw a max of ~ 120 files with `lsof -p $kbpid`. 

cc @mmaxim 