### PR TITLE
gregorHandler: handle in-band KBFS favorites messages

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1224,8 +1224,6 @@ func (g *gregorHandler) handleOutOfBandMessage(ctx context.Context, obm gregor.O
 	}
 
 	switch obm.System().String() {
-	case "kbfs.favorites":
-		return g.kbfsFavorites(ctx, obm)
 	case "internal.reconnect":
 		g.G().Log.Debug("reconnected to push server")
 		return nil
@@ -1256,37 +1254,6 @@ func (g *gregorHandler) Reset() error {
 	g.Shutdown()
 	g.setFirstConnect(true)
 	return g.resetGregorClient(context.TODO())
-}
-
-func (g *gregorHandler) kbfsFavorites(ctx context.Context, m gregor.OutOfBandMessage) error {
-	if m.Body() == nil {
-		return errors.New("gregor handler for kbfs.favorites: nil message body")
-	}
-	body, err := jsonw.Unmarshal(m.Body().Bytes())
-	if err != nil {
-		return err
-	}
-
-	action, err := body.AtPath("action").GetString()
-	if err != nil {
-		return err
-	}
-
-	switch action {
-	case "create", "delete":
-		return g.notifyFavoritesChanged(ctx, m.UID())
-	default:
-		return fmt.Errorf("unhandled kbfs.favorites action %q", action)
-	}
-}
-
-func (g *gregorHandler) notifyFavoritesChanged(ctx context.Context, uid gregor.UID) error {
-	kbUID, err := keybase1.UIDFromString(hex.EncodeToString(uid.Bytes()))
-	if err != nil {
-		return err
-	}
-	g.G().NotifyRouter.HandleFavoritesChanged(kbUID)
-	return nil
 }
 
 type loggedInRes int

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -56,11 +56,20 @@ func TestGregorHandler(t *testing.T) {
 	kbUID := user.User.GetUID()
 	gUID := gregor1.UID(kbUID.ToBytes())
 
+	h.PushHandler(newKBFSFavoritesHandler(tc.G))
+
 	m := gregor1.Message{
-		Oobm_: &gregor1.OutOfBandMessage{
-			Uid_:    gUID,
-			System_: "kbfs.favorites",
-			Body_:   gregor1.Body(`{"action": "delete", "tlf":"/private/t_alice,t_bob"}`),
+		Ibm_: &gregor1.InBandMessage{
+			StateUpdate_: &gregor1.StateUpdateMessage{
+				Md_: gregor1.Metadata{
+					Uid_:   gUID,
+					MsgID_: newMsgID(),
+				},
+				Creation_: &gregor1.Item{
+					Category_: "kbfs.favorites",
+					Body_:     gregor1.Body(`{"action": "delete", "tlf":"/private/t_alice,t_bob"}`),
+				},
+			},
 		},
 	}
 

--- a/go/service/kbfs_favorites_handler.go
+++ b/go/service/kbfs_favorites_handler.go
@@ -1,0 +1,85 @@
+// Handlers for ephemeral-related gregor messages
+
+package service
+
+import (
+	"encoding/hex"
+	"fmt"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/client/go/gregor"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
+)
+
+const kbfsFavoritesHandlerName = "kbfsFavoritesHandler"
+
+type kbfsFavoritesHandler struct {
+	libkb.Contextified
+
+	// handled stores the set of requests that this client has processed so
+	// that we don't handle a request more than once.
+	handled map[string]bool
+}
+
+var _ libkb.GregorInBandMessageHandler = (*ekHandler)(nil)
+
+func newKBFSFavoritesHandler(g *libkb.GlobalContext) *kbfsFavoritesHandler {
+	return &kbfsFavoritesHandler{
+		Contextified: libkb.NewContextified(g),
+		handled:      make(map[string]bool),
+	}
+}
+
+func (r *kbfsFavoritesHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
+	category string, item gregor.Item) (bool, error) {
+	switch category {
+	case "kbfs.favorites":
+		return true, r.favoritesChanged(ctx, cli, item)
+	default:
+		if strings.HasPrefix(category, "kbfs.") {
+			return false, fmt.Errorf("unknown KBFS category: %q", category)
+		}
+		return false, nil
+	}
+}
+
+func (r *kbfsFavoritesHandler) Dismiss(ctx context.Context, cli gregor1.IncomingInterface, category string, item gregor.Item) (bool, error) {
+	return false, nil
+}
+
+func (r *kbfsFavoritesHandler) IsAlive() bool {
+	return true
+}
+
+func (r *kbfsFavoritesHandler) Name() string {
+	return kbfsFavoritesHandlerName
+}
+
+func (r *kbfsFavoritesHandler) favoritesChanged(ctx context.Context,
+	cli gregor1.IncomingInterface,
+	item gregor.Item) error {
+	r.G().Log.CDebugf(ctx, "kbfsFavoritesHandler: kbfs."+
+		"favorites received")
+
+	// check whether we have seen this message ID before.
+	// We can't dismiss the message even if we've handled it because we want
+	// all clients to see it.
+	msgID := item.Metadata().MsgID().String()
+	if _, ok := r.handled[msgID]; ok {
+		// we have already handled this message
+		return nil
+	}
+	r.handled[msgID] = true
+
+	kbUID, err := keybase1.UIDFromString(hex.EncodeToString(
+		item.Metadata().UID().Bytes()))
+	if err != nil {
+		return err
+	}
+	r.Contextified.G().NotifyRouter.HandleFavoritesChanged(kbUID)
+	return nil
+}

--- a/go/service/kbfs_favorites_handler.go
+++ b/go/service/kbfs_favorites_handler.go
@@ -23,7 +23,7 @@ type kbfsFavoritesHandler struct {
 	libkb.Contextified
 }
 
-var _ libkb.GregorInBandMessageHandler = (*ekHandler)(nil)
+var _ libkb.GregorInBandMessageHandler = (*kbfsFavoritesHandler)(nil)
 
 func newKBFSFavoritesHandler(g *libkb.GlobalContext) *kbfsFavoritesHandler {
 	return &kbfsFavoritesHandler{

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -560,6 +560,7 @@ func (d *Service) startupGregor() {
 		d.gregor.PushHandler(newEKHandler(d.G()))
 		d.gregor.PushHandler(newAvatarGregorHandler(d.G(), d.avatarLoader))
 		d.gregor.PushHandler(newPhoneNumbersGregorHandler(d.G()))
+		d.gregor.PushHandler(newKBFSFavoritesHandler(d.G()))
 
 		// Connect to gregord
 		if gcErr := d.tryGregordConnect(); gcErr != nil {


### PR DESCRIPTION
Changed favorites messages to be in-band on the server (see https://github.com/keybase/keybase/pull/3086 ) - this makes the corresponding changes in the service.

We now keep track of which messages we have seen, since we'll see them for a whole week until they expire.

As part of this change, we also invalidate the favorites cache in the client automatically after one week so that these messages can expire. A PR on the KBFS repo for that is forthcoming.