### PR TITLE
Fix FormatCurrencyWithCodeSuffix for CHF

### DIFF
--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -970,6 +970,20 @@ func FormatCurrencyWithCodeSuffix(ctx context.Context, g *libkb.GlobalContext, a
 	if err != nil {
 		return "", err
 	}
+
+	// some currencies have the same symbol as code (CHF)
+	conf, err := g.GetStellar().GetServerDefinitions(ctx)
+	if err != nil {
+		return "", err
+	}
+	currency, ok := conf.Currencies[code]
+	if !ok {
+		return "", fmt.Errorf("FormatCurrency error: cannot find curency code %q", code)
+	}
+	if currency.Symbol.Postfix && currency.Symbol.Symbol == code.String() {
+		return pre, nil
+	}
+
 	return fmt.Sprintf("%s %s", pre, code), nil
 }
 

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -497,6 +497,7 @@ type BackendMock struct {
 	requests map[stellar1.KeybaseRequestID]*stellar1.RequestDetails
 	txLog    *txlogger
 	exchRate string
+	currency string
 }
 
 func NewBackendMock(t testing.TB) *BackendMock {
@@ -507,6 +508,7 @@ func NewBackendMock(t testing.TB) *BackendMock {
 		requests: make(map[stellar1.KeybaseRequestID]*stellar1.RequestDetails),
 		txLog:    newTxLogger(t),
 		exchRate: defaultExchangeRate,
+		currency: "USD",
 	}
 }
 
@@ -914,10 +916,20 @@ func (r *BackendMock) AssertBalance(accountID stellar1.AccountID, amount string)
 }
 
 func (r *BackendMock) GetAccountDisplayCurrency(ctx context.Context, tc *TestContext, accountID stellar1.AccountID) (string, error) {
-	return "USD", nil
+	r.Lock()
+	defer r.Unlock()
+	return r.currency, nil
+}
+
+func (r *BackendMock) SetDisplayCurrency(currency string) {
+	r.Lock()
+	defer r.Unlock()
+	r.currency = currency
 }
 
 func (r *BackendMock) ExchangeRate(ctx context.Context, tc *TestContext, currency string) (stellar1.OutsideExchangeRate, error) {
+	r.Lock()
+	defer r.Unlock()
 	return stellar1.OutsideExchangeRate{
 		Currency: stellar1.OutsideCurrencyCode(currency),
 		Rate:     r.exchRate,


### PR DESCRIPTION
swiss francs has a postfix symbol of "CHF" as well as a currency code of "CHF".

Before this fix, this would get rendered as

    1,234 CHF CHF

This fixes it so it is

    1,234 CHF

I believe this is the only currency like this, but if any others are added in the future, this should take care of that as well.