### PR TITLE
Kick autoclaim runner after creating wallet

### DIFF
--- a/go/stellar/autoclaim.go
+++ b/go/stellar/autoclaim.go
@@ -131,8 +131,8 @@ func (r *AutoClaimRunner) step(mctx libkb.MetaContext, i int, trigger gregor.Msg
 				log("error dismissing gregor kick: %v", err)
 				return autoClaimLoopActionHibernate, err
 			}
+			log("successfully dismissed kick")
 		}
-		log("successfully dismissed kick")
 		return autoClaimLoopActionHibernate, nil
 	}
 	log("got next autoclaim: %v", ac.KbTxID)

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -113,6 +113,7 @@ func (s *Stellar) GetServerDefinitions(ctx context.Context) (ret stellar1.Stella
 	return s.cachedServerConf, nil
 }
 
+// `trigger` is optional, and is of the gregor message that caused the kick.
 func (s *Stellar) KickAutoClaimRunner(mctx libkb.MetaContext, trigger gregor.MsgID) {
 	// Create the ACR if one does not exist.
 	mctx.CDebugf("KickAutoClaimRunner(trigger:%v)", trigger)

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar/bundle"
@@ -60,6 +61,7 @@ func CreateWallet(ctx context.Context, g *libkb.GlobalContext) (created bool, er
 		return false, err
 	}
 	getGlobal(g).InformHasWallet(ctx, meUV)
+	go getGlobal(g).KickAutoClaimRunner(libkb.NewMetaContext(ctx, g), gregor1.MsgID{})
 	return true, nil
 }
 


### PR DESCRIPTION
After the client creates a wallet it starts running through autoclaims. This is not strictly necessary since, even without this, the server's should figure out to send a gregor message to the client to do this. But this might make it faster and more robust.