### PR TITLE
set LogForwardNone for chat commands

### DIFF
--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -40,6 +40,7 @@ func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli
 				Contextified: libkb.NewContextified(g),
 			}, "api-listen", c)
 			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: []cli.Flag{
 			cli.BoolFlag{

--- a/go/client/cmd_chat_createchannel.go
+++ b/go/client/cmd_chat_createchannel.go
@@ -30,6 +30,7 @@ func newCmdChatCreateChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 		ArgumentHelp: "<team name> <channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatCreateChannelRunner(g), "create-channel", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: mustGetChatFlags("topic-type"),
 	}

--- a/go/client/cmd_chat_delete_channel.go
+++ b/go/client/cmd_chat_delete_channel.go
@@ -32,6 +32,7 @@ func newCmdChatDeleteChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 		ArgumentHelp: "<team name> <channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatDeleteChannelRunner(g), "delete-channel", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: mustGetChatFlags("topic-type"),
 	}

--- a/go/client/cmd_chat_download.go
+++ b/go/client/cmd_chat_download.go
@@ -28,6 +28,7 @@ func newCmdChatDownload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 		Action: func(c *cli.Context) {
 			cmd := &CmdChatDownload{Contextified: libkb.NewContextified(g)}
 			cl.ChooseCommand(cmd, "download", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: []cli.Flag{
 			cli.BoolFlag{

--- a/go/client/cmd_chat_hide.go
+++ b/go/client/cmd_chat_hide.go
@@ -25,6 +25,7 @@ func newCmdChatHide(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 		Action: func(c *cli.Context) {
 			cmd := &CmdChatHide{Contextified: libkb.NewContextified(g)}
 			cl.ChooseCommand(cmd, "hide", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: append(getConversationResolverFlags(), mustGetChatFlags("block", "unhide")...),
 	}

--- a/go/client/cmd_chat_joinchannel.go
+++ b/go/client/cmd_chat_joinchannel.go
@@ -32,6 +32,7 @@ func newCmdChatJoinChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) c
 		ArgumentHelp: "<team name> <channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatJoinChannelRunner(g), "join-channel", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: mustGetChatFlags("topic-type"),
 	}

--- a/go/client/cmd_chat_kbfs_upgrade.go
+++ b/go/client/cmd_chat_kbfs_upgrade.go
@@ -24,6 +24,7 @@ func newCmdChatKBFSUpgrade(cl *libcmdline.CommandLine, g *libkb.GlobalContext) c
 		Action: func(c *cli.Context) {
 			cmd := &CmdChatKBFSUpgrade{Contextified: libkb.NewContextified(g)}
 			cl.ChooseCommand(cmd, "kbfs-upgrade", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: getConversationResolverFlags(),
 	}

--- a/go/client/cmd_chat_leavechannel.go
+++ b/go/client/cmd_chat_leavechannel.go
@@ -31,6 +31,7 @@ func newCmdChatLeaveChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 		ArgumentHelp: "<team name> <channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatLeaveChannelRunner(g), "leave-channel", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: mustGetChatFlags("topic-type"),
 	}

--- a/go/client/cmd_chat_list.go
+++ b/go/client/cmd_chat_list.go
@@ -26,6 +26,7 @@ func newCmdChatList(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&cmdChatList{Contextified: libkb.NewContextified(g)}, "list", c)
 			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: getInboxFetcherActivitySortedFlags(),
 	}

--- a/go/client/cmd_chat_list_unread.go
+++ b/go/client/cmd_chat_list_unread.go
@@ -27,6 +27,7 @@ func newCmdChatListUnread(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cl
 		ArgumentHelp: "",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&cmdChatListUnread{Contextified: libkb.NewContextified(g)}, "list-unread", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: getInboxFetcherUnreadFirstFlags(),
 	}

--- a/go/client/cmd_chat_listmembers.go
+++ b/go/client/cmd_chat_listmembers.go
@@ -31,6 +31,7 @@ func newCmdChatListMembers(cl *libcmdline.CommandLine, g *libkb.GlobalContext) c
 		ArgumentHelp: "[conversation [channel name]]",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatListMembersRunner(g), "list-members", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: mustGetChatFlags("topic-type"),
 	}

--- a/go/client/cmd_chat_mute.go
+++ b/go/client/cmd_chat_mute.go
@@ -25,6 +25,7 @@ func newCmdChatMute(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 		Action: func(c *cli.Context) {
 			cmd := &CmdChatMute{Contextified: libkb.NewContextified(g)}
 			cl.ChooseCommand(cmd, "mute", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: append(getConversationResolverFlags(), mustGetChatFlags("unmute")...),
 	}

--- a/go/client/cmd_chat_read.go
+++ b/go/client/cmd_chat_read.go
@@ -33,6 +33,7 @@ func newCmdChatRead(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 		ArgumentHelp: "<conversation>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatReadRunner(g), "read", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: getMessageFetcherFlags(),
 	}

--- a/go/client/cmd_chat_readdmember.go
+++ b/go/client/cmd_chat_readdmember.go
@@ -29,6 +29,7 @@ func newCmdChatReAddMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) c
 		ArgumentHelp: "<conversation> <username>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatReAddMemberRunner(g), "readd-member", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: mustGetChatFlags("topic-type"),
 	}

--- a/go/client/cmd_chat_renamechannel.go
+++ b/go/client/cmd_chat_renamechannel.go
@@ -29,6 +29,7 @@ func newCmdChatRenameChannel(cl *libcmdline.CommandLine, g *libkb.GlobalContext)
 		ArgumentHelp: "<team name> <old channel name> <new channel name>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatRenameChannelRunner(g), "rename-channel", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: mustGetChatFlags("topic-type"),
 	}

--- a/go/client/cmd_chat_retention.go
+++ b/go/client/cmd_chat_retention.go
@@ -58,6 +58,7 @@ Use the team policy for this channel:
 		ArgumentHelp: "[conversation]",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatSetRetentionRunner(g), "retention-policy", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: append(getConversationResolverFlags(), []cli.Flag{
 			cli.BoolFlag{

--- a/go/client/cmd_chat_retention_dev.go
+++ b/go/client/cmd_chat_retention_dev.go
@@ -43,6 +43,7 @@ Please don't actually use retention-policy-dev:
 		ArgumentHelp: "<conversation> <seconds>",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatSetRetentionDevRunner(g), "retention-policy-dev", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: getConversationResolverFlags(),
 	}

--- a/go/client/cmd_chat_search_inbox.go
+++ b/go/client/cmd_chat_search_inbox.go
@@ -42,6 +42,7 @@ func newCmdChatSearchInbox(cl *libcmdline.CommandLine, g *libkb.GlobalContext) c
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatSearchInboxRunner(g), "search", c)
 			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: append(chatSearchFlags,
 			cli.BoolFlag{

--- a/go/client/cmd_chat_search_profile.go
+++ b/go/client/cmd_chat_search_profile.go
@@ -37,6 +37,7 @@ func newCmdChatProfileSearchDev(cl *libcmdline.CommandLine, g *libkb.GlobalConte
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatProfileSearchRunner(g), "search-profile", c)
 			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: getConversationResolverFlags(),
 	}

--- a/go/client/cmd_chat_search_regexp.go
+++ b/go/client/cmd_chat_search_regexp.go
@@ -46,6 +46,7 @@ func newCmdChatSearchRegexp(cl *libcmdline.CommandLine, g *libkb.GlobalContext) 
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatSearchRegexpRunner(g), "search-regexp", c)
 			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: append(flags, cli.BoolFlag{
 			Name:  "r, regex",

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -67,6 +67,7 @@ func newCmdChatSend(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdChatSendRunner(g), "send", c)
 			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: flags,
 	}

--- a/go/client/cmd_chat_upload.go
+++ b/go/client/cmd_chat_upload.go
@@ -44,6 +44,7 @@ func newCmdChatUpload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 				done:         make(chan bool, 1),
 			}
 			cl.ChooseCommand(cmd, "upload", c)
+			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
 		Flags: flags,
 	}


### PR DESCRIPTION
nukes any logs from coming back from the service. alternate approach could be to set a desired log level instead so we can configure `GlobalContext` appropiately 
https://github.com/keybase/client/blob/master/go/keybase/main.go#L327