### PR TITLE
Resolve e-mail addresses and SBS

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -204,6 +204,7 @@ const (
 	SCReloginRequired                  = int(keybase1.StatusCode_SCReloginRequired)
 	SCResolutionFailed                 = int(keybase1.StatusCode_SCResolutionFailed)
 	SCProfileNotPublic                 = int(keybase1.StatusCode_SCProfileNotPublic)
+	SCRateLimit                        = int(keybase1.StatusCode_SCRateLimit)
 	SCBadSignupUsernameTaken           = int(keybase1.StatusCode_SCBadSignupUsernameTaken)
 	SCBadInvitationCode                = int(keybase1.StatusCode_SCBadInvitationCode)
 	SCFeatureFlag                      = int(keybase1.StatusCode_SCFeatureFlag)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1643,6 +1643,7 @@ const (
 	ResolutionErrorAmbiguous
 	ResolutionErrorRateLimited
 	ResolutionErrorInvalidInput
+	ResolutionErrorRequestFailed
 )
 
 type ResolutionError struct {

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -458,8 +458,7 @@ func (r *ResolverImpl) resolveServerTrustAssertion(m MetaContext, au AssertionUR
 			case SCInputError:
 				res.err = ResolutionError{Input: input, Msg: err.Error(), Kind: ResolutionErrorInvalidInput}
 				return res
-			case SCChatRateLimit: // with different error const!
-				// TODO: Phone number search rate limiting code goes here.
+			case SCRateLimit:
 				res.err = ResolutionError{Input: input, Msg: err.Error(), Kind: ResolutionErrorRateLimited}
 				return res
 			}

--- a/go/systests/phone_number_test.go
+++ b/go/systests/phone_number_test.go
@@ -207,8 +207,6 @@ func TestPhoneNumberNotifications(t *testing.T) {
 }
 
 func TestImplicitTeamWithEmail(t *testing.T) {
-	t.Skip("Skipping IMP TOFU because needs serverside support")
-
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -560,10 +560,20 @@ func TestInvalidPhoneNumberAssertion(t *testing.T) {
 	// to chat with invalid phone number assertion.
 	badNumbers := []string{"111", "12345678", "48111"}
 	for _, bad := range badNumbers {
-		displayName := fmt.Sprintf("%s@phone,%s", bad, fus[0].Username)
-		lookupName, err := ResolveImplicitTeamDisplayName(context.Background(), tcs[0].G, displayName, false)
-		require.NoError(t, err)
-		_, _, err = CreateImplicitTeam(context.Background(), tcs[0].G, lookupName)
+		displayName := keybase1.ImplicitTeamDisplayName{
+			IsPublic: false,
+			Writers: keybase1.ImplicitTeamUserSet{
+				KeybaseUsers: []string{fus[0].Username},
+				UnresolvedUsers: []keybase1.SocialAssertion{
+					keybase1.SocialAssertion{
+						User:    bad,
+						Service: keybase1.SocialAssertionService("phone"),
+					},
+				},
+			},
+		}
+		t.Logf("Trying name: %q", displayName.String())
+		_, _, err := CreateImplicitTeam(context.Background(), tcs[0].G, displayName)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "bad phone number given")
 	}

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -131,7 +131,7 @@ func ResolveImplicitTeamDisplayName(ctx context.Context, g *libkb.GlobalContext,
 // preventTeamCreationOnError checks if an error coming from resolver should
 // prevent us from creating a team. We don't want a team where we don't know if
 // SBS user is resolvable but we just were unable to get the answer.
-func preventTeamCreationOnError(err error) bool {
+func shouldPreventTeamCreation(err error) bool {
 	if resErr, ok := err.(libkb.ResolutionError); ok {
 		switch resErr.Kind {
 		case libkb.ResolutionErrorRateLimited, libkb.ResolutionErrorInvalidInput, libkb.ResolutionErrorRequestFailed:
@@ -155,7 +155,7 @@ func ResolveImplicitTeamSetUntrusted(ctx context.Context, g *libkb.GlobalContext
 		u, resolveRes, err := g.Resolver.ResolveUser(m, expr.String())
 		if err != nil {
 			// Resolution failed. Could still be an SBS assertion.
-			if preventTeamCreationOnError(err) {
+			if shouldPreventTeamCreation(err) {
 				// but if we are not sure, better to bail out
 				return err
 			}


### PR DESCRIPTION
SBS basically worked because we already had support for email invites and resolving them in normal teams.

This PR adds an email resolver for implicit team, and tests for all that, including parametrized chat sbs test in `chat/sbs_test.go`.

Needs serverside PR to pass CI.