### PR TITLE
Accept a styleOverride for markdown

### DIFF
--- a/shared/chat/conversation/info-panel/header.js
+++ b/shared/chat/conversation/info-panel/header.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {
   Box,
+  Box2,
   ClickableBox,
   Icon,
   Markdown,
@@ -79,7 +80,7 @@ const EditBox = isMobile
 
 const BigTeamHeader = (props: BigProps) => {
   return (
-    <Box className="header-row" style={styles.bigContainer}>
+    <Box2 direction={'vertical'} fullWidth={true} centerChildren={true} className="header-row">
       <Box style={styles.channelnameContainer}>
         <Text type="BodyBig">#{props.channelname}</Text>
         {props.canEditChannel && (
@@ -92,12 +93,11 @@ const BigTeamHeader = (props: BigProps) => {
         )}
       </Box>
       {!!props.description && <Markdown style={styles.description}>{props.description}</Markdown>}
-    </Box>
+    </Box2>
   )
 }
 
 const styles = styleSheetCreate({
-  bigContainer: {...globalStyles.flexBoxColumn, alignItems: 'stretch'},
   channelnameContainer: {
     alignSelf: 'center',
     marginTop: globalMargins.medium,

--- a/shared/chat/conversation/messages/text/index.js
+++ b/shared/chat/conversation/messages/text/index.js
@@ -2,8 +2,7 @@
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
 import {Markdown} from '../../../../common-adapters'
-import {isMobile} from '../../../../constants/platform'
-import {globalColors, globalMargins, platformStyles, styleSheetCreate} from '../../../../styles'
+import {globalColors, globalMargins, platformStyles, styleSheetCreate, isMobile} from '../../../../styles'
 
 export type Props = {
   text: string,

--- a/shared/chat/conversation/messages/text/index.js
+++ b/shared/chat/conversation/messages/text/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import * as Types from '../../../../constants/types/chat2'
 import {Markdown} from '../../../../common-adapters'
+import {isMobile} from '../../../../constants/platform'
 import {globalColors, globalMargins, platformStyles, styleSheetCreate} from '../../../../styles'
 
 export type Props = {
@@ -17,6 +18,7 @@ const MessageText = ({text, type, isEditing, mentionsAt, mentionsChannel, mentio
   <Markdown
     style={getStyle(type, isEditing)}
     meta={{mentionsAt, mentionsChannel, mentionsChannelName}}
+    styleOverride={isMobile ? {paragraph: getStyle(type, isEditing)} : undefined}
     allowFontScaling={true}
   >
     {text}
@@ -39,18 +41,13 @@ const editing = {
   paddingRight: globalMargins.tiny,
 }
 const sent = platformStyles({
-  common: {
-    width: '100%',
-  },
   isElectron: {
     // Make text selectable. On mobile we implement that differently.
     cursor: 'text',
     userSelect: 'text',
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
-  },
-  isMobile: {
-    color: globalColors.black_75,
+    width: '100%',
   },
 })
 const sentEditing = {

--- a/shared/common-adapters/markdown/index.js.flow
+++ b/shared/common-adapters/markdown/index.js.flow
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import * as Styles from '../../styles'
 import type {MentionsAt, MentionsChannel, MentionsChannelName} from '../../constants/types/chat2'
 
 type MarkdownComponentType =
@@ -30,10 +31,32 @@ export type MarkdownMeta = {
 export type Props = {
   children?: string,
   preview?: boolean, // if true render a simplified version
+  // Style only styles the top level container.
+  // This is only useful in desktop because of cascading styles and there is a top level wrapper.
+  // Mobile doesn't have this wrapper (on purpose), so if you want to style the container, do it
+  // at a higher level.
+  //
+  // You can also use this to style previews which has a single top level wrapper, but it's
+  // preferred to use the props.styleOverride.preview flag for this
+  //
+  // TODO(mm) when we kill the old markdown rmmove this style prop
   style?: any,
   allowFontScaling?: boolean,
   meta?: ?MarkdownMeta,
   simple?: boolean,
+  // This changes the specific style for specific types of text
+  // for example you may want to make paragraphs, italics, etc to be black_40
+  // but want blue_30 for the inline code
+  styleOverride?: {
+    paragraph?: Styles.StylesCrossPlatform,
+    fence?: Styles.StylesCrossPlatform,
+    inlineCode?: Styles.StylesCrossPlatform,
+    strong?: Styles.StylesCrossPlatform,
+    em?: Styles.StylesCrossPlatform,
+    del?: Styles.StylesCrossPlatform,
+    link?: Styles.StylesCrossPlatform,
+    preview?: Styles.StylesCrossPlatform,
+  },
 }
 
 export default class Markdown extends React.Component<Props> {}

--- a/shared/common-adapters/markdown/index.stories.js
+++ b/shared/common-adapters/markdown/index.stories.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import * as Sb from '../../stories/storybook'
 import * as Kb from '../index'
 import Markdown, {type MarkdownMeta} from '.'
-import {parserFromMeta} from './shared'
+import {simpleMarkdownParser} from './shared'
 import OriginalParser from '../../markdown/parser'
 
 const cases = {
@@ -246,15 +246,21 @@ class ShowAST extends React.Component<
 > {
   state = {visible: false}
   render = () => {
-    const parsed = this.props.simple
-      ? parserFromMeta(this.props.meta)((this.props.text || '').trim() + '\n', {
-          inline: false,
-          disableAutoBlockNewlines: true,
-        })
-      : OriginalParser.parse(this.props.text, {
-          channelNameToConvID: (channel: string) => null,
-          isValidMention: (mention: string) => false,
-        })
+    let parsed
+    try {
+      parsed = this.props.simple
+        ? simpleMarkdownParser((this.props.text || '').trim() + '\n', {
+            inline: false,
+            disableAutoBlockNewlines: true,
+            markdownMeta: this.props.meta,
+          })
+        : OriginalParser.parse(this.props.text, {
+            channelNameToConvID: (channel: string) => null,
+            isValidMention: (mention: string) => false,
+          })
+    } catch (error) {
+      parsed = {error}
+    }
 
     return (
       <Kb.Box2 direction="vertical">

--- a/shared/common-adapters/markdown/react.js
+++ b/shared/common-adapters/markdown/react.js
@@ -194,7 +194,7 @@ const reactComponentsForMarkdownType = {
       <Text
         type="Body"
         key={state.key}
-        style={Styles.collapseStyles([textBlockStyle, state.styleOverride?.paragraph])}
+        style={Styles.collapseStyles([textBlockStyle, state.styleOverride.paragraph])}
         allowFontScaling={state.allowFontScaling}
       >
         {'\n'}
@@ -205,7 +205,7 @@ const reactComponentsForMarkdownType = {
       <Box key={state.key} style={codeSnippetBlockStyle}>
         <Text
           type="Body"
-          style={Styles.collapseStyles([codeSnippetBlockTextStyle, state.styleOverride?.fence])}
+          style={Styles.collapseStyles([codeSnippetBlockTextStyle, state.styleOverride.fence])}
           allowFontScaling={state.allowFontScaling}
         >
           {node.content}
@@ -215,7 +215,7 @@ const reactComponentsForMarkdownType = {
       <Text
         key={state.key}
         type="Body"
-        style={Styles.collapseStyles([codeSnippetBlockStyle, state.styleOverride?.fence])}
+        style={Styles.collapseStyles([codeSnippetBlockStyle, state.styleOverride.fence])}
       >
         {node.content}
       </Text>
@@ -225,7 +225,7 @@ const reactComponentsForMarkdownType = {
       <Text
         type="Body"
         key={state.key}
-        style={Styles.collapseStyles([codeSnippetStyle, state.styleOverride?.inlineCode])}
+        style={Styles.collapseStyles([codeSnippetStyle, state.styleOverride.inlineCode])}
         allowFontScaling={state.allowFontScaling}
       >
         {node.content}
@@ -237,7 +237,7 @@ const reactComponentsForMarkdownType = {
       <Text
         type="Body"
         key={state.key}
-        style={Styles.collapseStyles([textBlockStyle, state.styleOverride?.paragraph])}
+        style={Styles.collapseStyles([textBlockStyle, state.styleOverride.paragraph])}
         allowFontScaling={state.allowFontScaling}
       >
         {output(node.content, {...state, inParagraph: true})}
@@ -249,7 +249,7 @@ const reactComponentsForMarkdownType = {
       <Text
         type="BodySemibold"
         key={state.key}
-        style={Styles.collapseStyles([boldStyle, state.styleOverride?.strong])}
+        style={Styles.collapseStyles([boldStyle, state.styleOverride.strong])}
         allowFontScaling={state.allowFontScaling}
       >
         {output(node.content, state)}
@@ -258,7 +258,7 @@ const reactComponentsForMarkdownType = {
   },
   em: (node, output, state) => {
     return (
-      <Text type="Body" key={state.key} style={Styles.collapseStyles([italicStyle, state.styleOverride?.em])}>
+      <Text type="Body" key={state.key} style={Styles.collapseStyles([italicStyle, state.styleOverride.em])}>
         {output(node.content, state)}
       </Text>
     )
@@ -268,7 +268,7 @@ const reactComponentsForMarkdownType = {
       <Text
         type="Body"
         key={state.key}
-        style={Styles.collapseStyles([strikeStyle, state.styleOverride?.del])}
+        style={Styles.collapseStyles([strikeStyle, state.styleOverride.del])}
         allowFontScaling={state.allowFontScaling}
       >
         {output(node.content, state)}
@@ -317,7 +317,7 @@ const reactComponentsForMarkdownType = {
           className="hover-underline"
           type="BodyPrimaryLink"
           key={state.key}
-          style={Styles.collapseStyles([linkStyle, state.styleOverride?.link])}
+          style={Styles.collapseStyles([linkStyle, state.styleOverride.link])}
           title={node.content}
           onClickURL={node.content}
           onLongPressURL={node.content}

--- a/shared/common-adapters/markdown/react.js
+++ b/shared/common-adapters/markdown/react.js
@@ -185,59 +185,92 @@ class EmojiIfExists extends PureComponent<
   }
 }
 
-const reactComponentsForMarkdownType = (allowFontScaling: boolean) => ({
+const reactComponentsForMarkdownType = {
   // On mobile we can't have raw text without a Text tag. So we make sure we are in a paragraph or we return a new text tag. If it's not mobile we can short circuit and just return the string
   newline: (node, outputFunc, state) =>
     !isMobile || state.inParagraph ? (
       '\n'
     ) : (
-      <Text type="Body" key={state.key} style={textBlockStyle} allowFontScaling={allowFontScaling}>
+      <Text
+        type="Body"
+        key={state.key}
+        style={Styles.collapseStyles([textBlockStyle, state.styleOverride?.paragraph])}
+        allowFontScaling={state.allowFontScaling}
+      >
         {'\n'}
       </Text>
     ),
   fence: (node, output, state) =>
     isMobile ? (
       <Box key={state.key} style={codeSnippetBlockStyle}>
-        <Text type="Body" style={codeSnippetBlockTextStyle} allowFontScaling={allowFontScaling}>
+        <Text
+          type="Body"
+          style={Styles.collapseStyles([codeSnippetBlockTextStyle, state.styleOverride?.fence])}
+          allowFontScaling={state.allowFontScaling}
+        >
           {node.content}
         </Text>
       </Box>
     ) : (
-      <Text key={state.key} type="Body" style={codeSnippetBlockStyle}>
+      <Text
+        key={state.key}
+        type="Body"
+        style={Styles.collapseStyles([codeSnippetBlockStyle, state.styleOverride?.fence])}
+      >
         {node.content}
       </Text>
     ),
   inlineCode: (node, output, state) => {
     return (
-      <Text type="Body" key={state.key} style={codeSnippetStyle} allowFontScaling={allowFontScaling}>
+      <Text
+        type="Body"
+        key={state.key}
+        style={Styles.collapseStyles([codeSnippetStyle, state.styleOverride?.inlineCode])}
+        allowFontScaling={state.allowFontScaling}
+      >
         {node.content}
       </Text>
     )
   },
   paragraph: (node, output, state) => {
     return (
-      <Text type="Body" key={state.key} style={textBlockStyle} allowFontScaling={allowFontScaling}>
+      <Text
+        type="Body"
+        key={state.key}
+        style={Styles.collapseStyles([textBlockStyle, state.styleOverride?.paragraph])}
+        allowFontScaling={state.allowFontScaling}
+      >
         {output(node.content, {...state, inParagraph: true})}
       </Text>
     )
   },
   strong: (node, output, state) => {
     return (
-      <Text type="BodySemibold" key={state.key} style={boldStyle} allowFontScaling={allowFontScaling}>
+      <Text
+        type="BodySemibold"
+        key={state.key}
+        style={Styles.collapseStyles([boldStyle, state.styleOverride?.strong])}
+        allowFontScaling={state.allowFontScaling}
+      >
         {output(node.content, state)}
       </Text>
     )
   },
   em: (node, output, state) => {
     return (
-      <Text type="Body" key={state.key} style={italicStyle}>
+      <Text type="Body" key={state.key} style={Styles.collapseStyles([italicStyle, state.styleOverride?.em])}>
         {output(node.content, state)}
       </Text>
     )
   },
   del: (node, output, state) => {
     return (
-      <Text type="Body" key={state.key} style={strikeStyle} allowFontScaling={allowFontScaling}>
+      <Text
+        type="Body"
+        key={state.key}
+        style={Styles.collapseStyles([strikeStyle, state.styleOverride?.del])}
+        allowFontScaling={state.allowFontScaling}
+      >
         {output(node.content, state)}
       </Text>
     )
@@ -258,7 +291,7 @@ const reactComponentsForMarkdownType = (allowFontScaling: boolean) => ({
         username={node.content}
         key={state.key}
         style={wrapStyle}
-        allowFontScaling={allowFontScaling}
+        allowFontScaling={state.allowFontScaling}
       />
     )
   },
@@ -284,7 +317,7 @@ const reactComponentsForMarkdownType = (allowFontScaling: boolean) => ({
           className="hover-underline"
           type="BodyPrimaryLink"
           key={state.key}
-          style={linkStyle}
+          style={Styles.collapseStyles([linkStyle, state.styleOverride?.link])}
           title={node.content}
           onClickURL={node.content}
           onLongPressURL={node.content}
@@ -294,7 +327,7 @@ const reactComponentsForMarkdownType = (allowFontScaling: boolean) => ({
       </React.Fragment>
     )
   },
-})
+}
 
 const ruleOutput = (rules: {[key: string]: (node: any, outputFunc: any, state: any) => any}) => (
   node,
@@ -302,27 +335,26 @@ const ruleOutput = (rules: {[key: string]: (node: any, outputFunc: any, state: a
   state
 ) => rules[node.type](node, output, state)
 
-const bigEmojiOutputForFontScaling = (allowFontScaling: boolean) =>
-  SimpleMarkdown.reactFor(
-    ruleOutput({
-      ...reactComponentsForMarkdownType(allowFontScaling),
-      paragraph: (node, output, state) => (
-        <Text type="Body" key={state.key} style={bigTextBlockStyle} allowFontScaling={allowFontScaling}>
-          {output(node.content, {...state, inParagraph: true})}
-        </Text>
-      ),
-      emoji: (node, output, state) => {
-        return (
-          <Emoji
-            emojiName={String(node.content)}
-            size={32}
-            key={state.key}
-            allowFontScaling={allowFontScaling}
-          />
-        )
-      },
-    })
-  )
+const bigEmojiOutput = SimpleMarkdown.reactFor(
+  ruleOutput({
+    ...reactComponentsForMarkdownType,
+    paragraph: (node, output, state) => (
+      <Text type="Body" key={state.key} style={bigTextBlockStyle} allowFontScaling={state.allowFontScaling}>
+        {output(node.content, {...state, inParagraph: true})}
+      </Text>
+    ),
+    emoji: (node, output, state) => {
+      return (
+        <Emoji
+          emojiName={String(node.content)}
+          size={32}
+          key={state.key}
+          allowFontScaling={state.allowFontScaling}
+        />
+      )
+    },
+  })
+)
 
 const previewOutput = SimpleMarkdown.reactFor(
   (ast: any, output: Function, state: any): any => {
@@ -333,7 +365,7 @@ const previewOutput = SimpleMarkdown.reactFor(
 
     switch (ast.type) {
       case 'emoji':
-        return reactComponentsForMarkdownType(false).emoji(ast, output, state)
+        return reactComponentsForMarkdownType.emoji(ast, output, state)
       case 'newline':
         return ' '
       case 'codeBlock':
@@ -344,16 +376,6 @@ const previewOutput = SimpleMarkdown.reactFor(
   }
 )
 
-const reactOutputForFontScaling = (allowFontScaling: boolean) =>
-  SimpleMarkdown.reactFor(ruleOutput(reactComponentsForMarkdownType(allowFontScaling)))
-const reactOutputNoFontScaling = reactOutputForFontScaling(false)
-const reactOutputFontScaling = reactOutputForFontScaling(true)
+const reactOutput = SimpleMarkdown.reactFor(ruleOutput(reactComponentsForMarkdownType))
 
-export {
-  EmojiIfExists,
-  bigEmojiOutputForFontScaling,
-  markdownStyles,
-  previewOutput,
-  reactOutputFontScaling,
-  reactOutputNoFontScaling,
-}
+export {EmojiIfExists, bigEmojiOutput, markdownStyles, previewOutput, reactOutput}

--- a/shared/common-adapters/markdown/react.js
+++ b/shared/common-adapters/markdown/react.js
@@ -85,6 +85,7 @@ const strikeStyle = Styles.platformStyles({
     textDecoration: 'line-through',
   },
 })
+
 const quoteStyle = Styles.platformStyles({
   common: {
     borderLeftWidth: 3,
@@ -275,16 +276,11 @@ const reactComponentsForMarkdownType = {
       </Text>
     )
   },
-  blockQuote: (node, output, state) =>
-    isMobile ? (
-      <Box key={state.key} style={quoteStyle}>
-        {output(node.content, {...state, inBlockQuote: true})}
-      </Box>
-    ) : (
-      <Box key={state.key} style={quoteStyle}>
-        {output(node.content, {...state, inBlockQuote: true})}
-      </Box>
-    ),
+  blockQuote: (node, output, state) => (
+    <Box key={state.key} style={quoteStyle}>
+      {output(node.content, {...state, inBlockQuote: true})}
+    </Box>
+  ),
   mention: (node, output, state) => {
     return (
       <Mention
@@ -310,6 +306,11 @@ const reactComponentsForMarkdownType = {
     return <Emoji emojiName={String(node.content).toLowerCase()} size={16} key={state.key} />
   },
   link: (node, output, state) => {
+    let url = node.content
+
+    if (!url.match(/^https?:\/\//)) {
+      url = `http://${node.content}`
+    }
     return (
       <React.Fragment key={state.key}>
         {node.spaceInFront}
@@ -319,8 +320,8 @@ const reactComponentsForMarkdownType = {
           key={state.key}
           style={Styles.collapseStyles([linkStyle, state.styleOverride.link])}
           title={node.content}
-          onClickURL={node.content}
-          onLongPressURL={node.content}
+          onClickURL={url}
+          onLongPressURL={url}
         >
           {node.content}
         </Text>
@@ -368,6 +369,8 @@ const previewOutput = SimpleMarkdown.reactFor(
         return reactComponentsForMarkdownType.emoji(ast, output, state)
       case 'newline':
         return ' '
+      case 'blockQuote':
+        return '> ' + output(ast.content, state)
       case 'codeBlock':
         return ' ' + output(ast.content, state)
       default:

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -4,13 +4,7 @@ import * as Styles from '../../styles'
 import React, {PureComponent} from 'react'
 import {isMobile} from '../../constants/platform'
 import Text from '../text'
-import {
-  reactOutputFontScaling,
-  reactOutputNoFontScaling,
-  previewOutput,
-  bigEmojiOutputForFontScaling,
-  markdownStyles,
-} from './react'
+import {reactOutput, previewOutput, bigEmojiOutput, markdownStyles} from './react'
 import {type ConversationIDKey} from '../../constants/types/chat2'
 import {isSpecialMention, specialMentions} from '../../constants/chat2'
 import parser, {isPlainText, emojiIndexByChar} from '../../markdown/parser'
@@ -373,7 +367,7 @@ const isAllEmoji = ast => {
 class SimpleMarkdownComponent extends PureComponent<MarkdownProps> {
   render() {
     const parser = parserFromMeta(this.props.meta)
-    const reactOutput = this.props.allowFontScaling ? reactOutputFontScaling : reactOutputNoFontScaling
+    const {allowFontScaling, styleOverride} = this.props
     const parseTree = parser((this.props.children || '').trim() + '\n', {
       inline: false,
       // This flag adds 2 new lines at the end of our input. One is necessary to parse the text as a paragraph, but the other isn't
@@ -383,15 +377,19 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps> {
     const inner = this.props.preview ? (
       <Text
         type={isMobile ? 'Body' : 'BodySmall'}
-        style={markdownStyles.neutralPreviewStyle}
+        style={Styles.collapseStyles([
+          markdownStyles.neutralPreviewStyle,
+          this.props.style,
+          styleOverride?.preview,
+        ])}
         lineClamp={isMobile ? 1 : undefined}
       >
         {previewOutput(parseTree)}
       </Text>
     ) : isAllEmoji(parseTree) ? (
-      bigEmojiOutputForFontScaling(!!this.props.allowFontScaling)(parseTree)
+      bigEmojiOutput(parseTree, {allowFontScaling, styleOverride})
     ) : (
-      reactOutput(parseTree)
+      reactOutput(parseTree, {allowFontScaling, styleOverride})
     )
 
     // Mobile doesn't use a wrapper

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -367,7 +367,7 @@ const isAllEmoji = ast => {
 class SimpleMarkdownComponent extends PureComponent<MarkdownProps> {
   render() {
     const parser = parserFromMeta(this.props.meta)
-    const {allowFontScaling, styleOverride} = this.props
+    const {allowFontScaling, styleOverride = {}} = this.props
     const parseTree = parser((this.props.children || '').trim() + '\n', {
       inline: false,
       // This flag adds 2 new lines at the end of our input. One is necessary to parse the text as a paragraph, but the other isn't
@@ -380,7 +380,7 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps> {
         style={Styles.collapseStyles([
           markdownStyles.neutralPreviewStyle,
           this.props.style,
-          styleOverride?.preview,
+          styleOverride.preview,
         ])}
         lineClamp={isMobile ? 1 : undefined}
       >

--- a/shared/wallets/common/markdown-memo.js
+++ b/shared/wallets/common/markdown-memo.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
+import {isMobile} from '../../constants/platform'
 
 type Props = {
   memo: string,
@@ -12,7 +13,11 @@ const MarkdownMemo = (props: Props) =>
   props.memo ? (
     <Kb.Box2 direction="horizontal" gap="small" fullWidth={true} style={props.style}>
       <Kb.Divider vertical={true} style={styles.quoteMarker} />
-      <Kb.Markdown style={styles.memo} allowFontScaling={true}>
+      <Kb.Markdown
+        style={styles.memo}
+        styleOverride={isMobile ? styleOverride : undefined}
+        allowFontScaling={true}
+      >
         {props.memo}
       </Kb.Markdown>
     </Kb.Box2>
@@ -34,11 +39,26 @@ const styles = Styles.styleSheetCreate({
       whiteSpace: 'pre-wrap',
       wordBreak: 'break-word',
     },
-    isMobile: {
-      color: Styles.globalColors.black_75,
-    },
   }),
   quoteMarker: {maxWidth: 3, minWidth: 3},
+})
+
+const styleOverride = Styles.styleSheetCreate({
+  paragraph: {
+    color: Styles.globalColors.black_75,
+  },
+  strong: {
+    color: Styles.globalColors.black_75,
+  },
+  em: {
+    color: Styles.globalColors.black_75,
+  },
+  del: {
+    color: Styles.globalColors.black_75,
+  },
+  link: {
+    color: Styles.globalColors.black_75,
+  },
 })
 
 export default MarkdownMemo


### PR DESCRIPTION
@keybase/react-hackers Lets the new markdown accept a `styleOverride` prop. Also adds _some_ support for passing in the `style` prop.

## Background:

The old markdown accepted a `style` prop which we used most visibly in the inbox on mobile to make the snippets bold or light (new vs read), and stellar txs memos. This `style` prop was a bit broken. On desktop it mostly works because of the cascading styles. On mobile styles don't cascade. We carried the styles to the text tags to have them display the style. It wouldn't apply to all text tags either (bold, italics, strike would not be affected)

Passing the `style` prop to the text tags for mobile is a bit wonky. Generally you expect the supplied `style` prop to only affect the top level and only appear once (like styling the top level div that contains the rest of the the tings). but in the case of mobile it would be reused for every text tag. It's also not a fine enough tool. If you wanted to make the text (including bold and italics) lighter without affecting emojis or inline code, you basically can't.

The old implementation of the `style` tag functioned differently on mobile vs desktop.

 ## New Stuff: `styleOverride`

`styleOverride` is meant to fix the ambiguity in what gets styles. It is a map of text types (e.g. `paragraph`, `fence`, `strong`, `em`) to styles. 
Benefits are:
* You can be more precise on what gets styled
* It's clear what will be styled
* Effects are consistent between mobile & desktop

## Deprecating `style`

Not now, but when we kill the old markdown we should also stop accepting the `style` prop.