### PR TITLE
don't try FindNextMerkleRootAfter with Seqnos < 835903

### DIFF
--- a/go/libkb/merkle_tools.go
+++ b/go/libkb/merkle_tools.go
@@ -54,7 +54,7 @@ func lookupMaxMerkleSeqno(m MetaContext) (ret keybase1.Seqno, err error) {
 func findFirstLeafWithComparer(m MetaContext, id keybase1.UserOrTeamID, comparator merkleSearchComparator, prevRootSeqno keybase1.Seqno) (leaf *MerkleGenericLeaf, root *MerkleRoot, err error) {
 	defer m.CTrace(fmt.Sprintf("findFirstLeafWithComparer(%s,%d)", id, prevRootSeqno), func() error { return err })()
 
-	if m.G().Env.GetRunMode() == ProductionRunMode && prevRootSeqno < FirstProdMerkleTreeWithModernShape {
+	if m.G().Env.GetRunMode() == ProductionRunMode && prevRootSeqno < FirstProdMerkleSeqnoWithSkips {
 		return nil, nil, MerkleClientError{"can't operate on old merkle sequence number", merkleErrorOldTree}
 	}
 


### PR DESCRIPTION
- We previous were using `var FirstProdMerkleTreeWithModernShape = keybase1.Seqno(531408)`
as a lefthand guard
- Now let's use `var FirstProdMerkleSeqnoWithSkips = keybase1.Seqno(835903)`
- fix #14586