### PR TITLE
[KBFS-3559] Fix styles for widget team items

### DIFF
--- a/shared/chat/inbox/row/small-team/top-line.js
+++ b/shared/chat/inbox/row/small-team/top-line.js
@@ -68,21 +68,13 @@ class _SimpleTopLine extends React.Component<Props> {
               <Kb.Box2 direction="horizontal" fullWidth={true}>
                 <Kb.Text
                   type="BodySemibold"
-                  style={{
-                    ...boldOverride,
-                    color: this.props.usernameColor,
-                  }}
+                  style={Styles.collapseStyles([
+                    styles.teamTextStyle,
+                    boldOverride,
+                    {color: this.props.usernameColor},
+                  ])}
                 >
-                  {this.props.teamname}
-                </Kb.Text>
-                <Kb.Text
-                  type="BodySemibold"
-                  style={{
-                    ...boldOverride,
-                    paddingRight: 7,
-                  }}
-                >
-                  {'#' + this.props.channelname}
+                  {this.props.teamname + '#' + this.props.channelname}
                 </Kb.Text>
               </Kb.Box2>
             ) : (
@@ -143,5 +135,15 @@ const unreadDotStyle = {
   marginLeft: 4,
   width: 8,
 }
+
+const styles = Styles.styleSheetCreate({
+  teamTextStyle: Styles.platformStyles({
+    isElectron: {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+  }),
+})
 
 export {SimpleTopLine}


### PR DESCRIPTION
Before:
<img width="342" alt="screen shot 2018-11-05 at 6 16 38 pm" src="https://user-images.githubusercontent.com/59594/48085028-0e94ec00-e1ae-11e8-86a4-cf1a7ede1c42.png">
After:
<img width="346" alt="screen shot 2018-11-05 at 6 16 15 pm" src="https://user-images.githubusercontent.com/59594/48085027-0e94ec00-e1ae-11e8-9919-22fe197c359b.png">
