### PR TITLE
Mark as read on reaction updates

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1939,6 +1939,7 @@ const markThreadAsRead = (
     | Chat2Gen.SelectConversationPayload
     | Chat2Gen.MessagesAddPayload
     | Chat2Gen.MarkInitiallyLoadedThreadAsReadPayload
+    | Chat2Gen.UpdateReactionsPayload
     | ConfigGen.ChangedFocusPayload
     | RouteTreeGen.Actions,
   state: TypedState
@@ -2737,6 +2738,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
       Chat2Gen.messagesAdd,
       Chat2Gen.selectConversation,
       Chat2Gen.markInitiallyLoadedThreadAsRead,
+      Chat2Gen.updateReactions,
       ConfigGen.changedFocus,
       a => typeof a.type === 'string' && a.type.startsWith(RouteTreeGen.typePrefix),
     ],


### PR DESCRIPTION
cc @mmaxim 

This marks convos as read if reactions come in when you're on the conversation view. Previously you could still get a notification on another device for these