### PR TITLE
Sort proof display 

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -83,10 +83,11 @@ func (i *Identify2WithUIDTester) AllStringKeys() []string     { return nil }
 func (i *Identify2WithUIDTester) CheckProofText(text string, id keybase1.SigID, sig string) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) DisplayName(n string) string { return n }
-func (i *Identify2WithUIDTester) GetPrompt() string           { return "" }
-func (i *Identify2WithUIDTester) GetProofType() string        { return "" }
-func (i *Identify2WithUIDTester) GetTypeName() string         { return "" }
+func (i *Identify2WithUIDTester) GetDisplayPriority(s string) int { return 0 }
+func (i *Identify2WithUIDTester) DisplayName(n string) string     { return n }
+func (i *Identify2WithUIDTester) GetPrompt() string               { return "" }
+func (i *Identify2WithUIDTester) GetProofType() string            { return "" }
+func (i *Identify2WithUIDTester) GetTypeName() string             { return "" }
 func (i *Identify2WithUIDTester) NormalizeRemoteName(_ libkb.MetaContext, name string) (string, error) {
 	return name, nil
 }

--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -54,6 +54,10 @@ func (p *staticProofServices) ListProofCheckers() []string {
 	return ret
 }
 
+func (p *staticProofServices) GetDisplayPriority(s string) int {
+	return 0
+}
+
 // Contains both the statically known services and loads the configurations for
 // known services from the server
 type proofServices struct {
@@ -109,6 +113,17 @@ func (p *proofServices) ListProofCheckers() []string {
 		ret = append(ret, k)
 	}
 	return ret
+}
+
+func (p *proofServices) GetDisplayPriority(s string) int {
+	p.Lock()
+	defer p.Unlock()
+	p.loadServiceConfigs()
+	displayConf, ok := p.displayConfigs[s]
+	if !ok {
+		return 0
+	}
+	return displayConf.Priority
 }
 
 func (p *proofServices) loadServiceConfigs() {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -416,6 +416,7 @@ var RemoteServiceTypes = map[string]keybase1.ProofType{
 	"generic_social": keybase1.ProofType_GENERIC_SOCIAL,
 }
 
+// TODO Remove with CORE-8969
 var RemoteServiceOrder = []keybase1.ProofType{
 	keybase1.ProofType_KEYBASE,
 	keybase1.ProofType_TWITTER,

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -128,6 +128,7 @@ func CanonicalProofName(t TypedChainLink) string {
 //
 type RemoteProofChainLink interface {
 	TypedChainLink
+	DisplayPriorityKey() string
 	TableKey() string
 	LastWriterWins() bool
 	GetRemoteUsername() string
@@ -157,6 +158,10 @@ type SocialProofChainLink struct {
 	proofText string
 	// signifies a GENERIC_SOCIAL link from a parameterized proof
 	isGeneric bool
+}
+
+func (w *WebProofChainLink) DisplayPriorityKey() string {
+	return w.protocol
 }
 
 func (w *WebProofChainLink) TableKey() string {
@@ -233,6 +238,9 @@ func (w *WebProofChainLink) ComputeTrackDiff(tl *TrackLookup) (res TrackDiff) {
 	return
 }
 
+func (s *SocialProofChainLink) DisplayPriorityKey() string {
+	return s.TableKey()
+}
 func (s *SocialProofChainLink) TableKey() string { return s.service }
 func (s *SocialProofChainLink) Type() string     { return "proof" }
 func (s *SocialProofChainLink) insertIntoTable(tab *IdentityTable) {
@@ -1142,12 +1150,13 @@ func (s *SelfSigChainLink) ToDisplayString() string { return s.unpacked.username
 func (s *SelfSigChainLink) insertIntoTable(tab *IdentityTable) {
 	tab.insertLink(s)
 }
-func (s *SelfSigChainLink) TableKey() string          { return "keybase" }
-func (s *SelfSigChainLink) LastWriterWins() bool      { return true }
-func (s *SelfSigChainLink) GetRemoteUsername() string { return s.GetUsername() }
-func (s *SelfSigChainLink) GetHostname() string       { return "" }
-func (s *SelfSigChainLink) GetProtocol() string       { return "" }
-func (s *SelfSigChainLink) ProofText() string         { return "" }
+func (s *SelfSigChainLink) DisplayPriorityKey() string { return s.TableKey() }
+func (s *SelfSigChainLink) TableKey() string           { return "keybase" }
+func (s *SelfSigChainLink) LastWriterWins() bool       { return true }
+func (s *SelfSigChainLink) GetRemoteUsername() string  { return s.GetUsername() }
+func (s *SelfSigChainLink) GetHostname() string        { return "" }
+func (s *SelfSigChainLink) GetProtocol() string        { return "" }
+func (s *SelfSigChainLink) ProofText() string          { return "" }
 
 func (s *SelfSigChainLink) GetPGPFullHash() string { return s.extractPGPFullHash("key") }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -589,6 +589,7 @@ type ServiceType interface {
 type ExternalServicesCollector interface {
 	GetServiceType(n string) ServiceType
 	ListProofCheckers() []string
+	GetDisplayPriority(n string) int
 }
 
 // Generic store for data that is hashed into the merkle root. Used by pvl and


### PR DESCRIPTION
These were the changes I made while trying to figure out how the CLI rendering works. Turns out the desktop also is unsorted async. Right now the changes affect the ordering in which the proofs are queued up for remote checks, but obviosuly the final ordering doesn't necessarily respect the `display_conf.Priority` value. We can merge these changes or close this out and only use the priority value for sorting yet-to-be-proven options in the GUI in the future. thoughts?