### PR TITLE
Boost search results with RegexpSearcher

### DIFF
--- a/go/chat/search/constants.go
+++ b/go/chat/search/constants.go
@@ -9,6 +9,19 @@ const MaxAllowedSearchMessages = 100000
 // Paging context around a search hit
 const MaxContext = 15
 
+const (
+	// max number of conversations to use regexp searcher to boost the search
+	// results on misses
+	maxBoostConvsDesktop = 500
+	maxBoostConvsMobile  = 250
+	// max number of messages the boost can use
+	maxBoostMsgsDesktop = 1000
+	maxBoostMsgsMobile  = 500
+	// max convs to sync in the background
+	maxSyncConvsDesktop = 10
+	maxSyncConvsMobile  = 5
+)
+
 // Bumped whenever there are tokenization or structural changes to building the
 // index
 const IndexVersion = 3

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -27,6 +27,10 @@ type Indexer struct {
 	stopCh   chan chan struct{}
 	started  bool
 
+	maxBoostConvs int
+	maxBoostMsgs  int
+	maxSyncConvs  int
+
 	// for testing
 	consumeCh chan chat1.ConversationID
 	reindexCh chan chat1.ConversationID
@@ -35,13 +39,48 @@ type Indexer struct {
 var _ types.Indexer = (*Indexer)(nil)
 
 func NewIndexer(g *globals.Context) *Indexer {
-	return &Indexer{
+	idx := &Indexer{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "Search.Indexer", false),
 		store:        newStore(g),
 		pageSize:     defaultPageSize,
 		stopCh:       make(chan chan struct{}),
 	}
+	switch idx.G().GetAppType() {
+	case libkb.MobileAppType:
+		idx.SetMaxBoostConvs(maxBoostConvsMobile)
+		idx.SetMaxBoostMsgs(maxBoostMsgsMobile)
+		idx.SetMaxSyncConvs(maxSyncConvsMobile)
+	default:
+		idx.SetMaxBoostConvs(maxBoostConvsDesktop)
+		idx.SetMaxBoostMsgs(maxBoostMsgsDesktop)
+		idx.SetMaxSyncConvs(maxSyncConvsDesktop)
+	}
+	return idx
+}
+
+func (idx *Indexer) SetMaxSyncConvs(x int) {
+	idx.maxSyncConvs = x
+}
+
+func (idx *Indexer) SetMaxBoostConvs(x int) {
+	idx.maxBoostConvs = x
+}
+
+func (idx *Indexer) SetMaxBoostMsgs(x int) {
+	idx.maxBoostMsgs = x
+}
+
+func (idx *Indexer) SetPageSize(pageSize int) {
+	idx.pageSize = pageSize
+}
+
+func (idx *Indexer) SetConsumeCh(ch chan chat1.ConversationID) {
+	idx.consumeCh = ch
+}
+
+func (idx *Indexer) SetReindexCh(ch chan chat1.ConversationID) {
+	idx.reindexCh = ch
 }
 
 func (idx *Indexer) Start(ctx context.Context, uid gregor1.UID) {
@@ -82,18 +121,6 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 		close(ch)
 	}
 	return ch
-}
-
-func (idx *Indexer) SetPageSize(pageSize int) {
-	idx.pageSize = pageSize
-}
-
-func (idx *Indexer) SetConsumeCh(ch chan chat1.ConversationID) {
-	idx.consumeCh = ch
-}
-
-func (idx *Indexer) SetReindexCh(ch chan chat1.ConversationID) {
-	idx.reindexCh = ch
 }
 
 func (idx *Indexer) GetConvIndex(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (*chat1.ConversationIndex, error) {
@@ -454,7 +481,10 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 		}
 	}()
 
-	// NOTE opts.MaxMessages is ignored
+	// NOTE opts.MaxMessages is only used by the regexp searcher for search
+	// boosting
+	opts.MaxMessages = idx.maxBoostMsgs
+
 	if opts.MaxHits > MaxAllowedSearchHits || opts.MaxHits < 0 {
 		opts.MaxHits = MaxAllowedSearchHits
 	}
@@ -472,7 +502,7 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 	if tokens == nil {
 		return nil, nil
 	}
-	queryRe, err := getQueryRe(query)
+	queryRe, err := utils.GetQueryRe(query)
 	if err != nil {
 		return nil, err
 	}
@@ -517,15 +547,13 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 		}
 	}
 
-	numConvs := 0
+	var numConvs, numBoostConvs int
 	hits := []chat1.ChatSearchInboxHit{}
 	for convIDStr, conv := range convMap {
-		convIdx := convIdxMap[convIDStr]
-		if convIdx == nil {
-			continue
-		}
 		numConvs++
-		msgIDs, err := idx.searchConv(ctx, conv.GetConvID(), convIdx, uid, tokens, opts)
+		convIdx := convIdxMap[convIDStr]
+		convID := conv.GetConvID()
+		msgIDs, err := idx.searchConv(ctx, convID, convIdx, uid, tokens, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -537,6 +565,23 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 			idx.Debug(ctx, "search hit mismatch, found %d msgIDs in index, %d hits in conv: %v",
 				len(msgIDs), convHits.Size(), conv.GetName())
 		}
+
+		// If we don't have any hits, try to boost the search results with the
+		// conversation based search.
+		if convHits == nil && numBoostConvs < idx.maxBoostConvs {
+			numBoostConvs++
+			hits, err := idx.G().RegexpSearcher.Search(ctx, uid, convID, queryRe, nil /* uiCh */, opts)
+			if err != nil {
+				return nil, err
+			} else if len(hits) > 0 {
+				convHits = &chat1.ChatSearchInboxHit{
+					ConvID:   convID,
+					ConvName: conv.GetName(),
+					Hits:     hits,
+				}
+			}
+		}
+
 		if convHits == nil {
 			continue
 		}
@@ -580,14 +625,6 @@ type convIdxWithPercent struct {
 func (idx *Indexer) SelectiveSync(ctx context.Context, uid gregor1.UID, forceReindex bool) {
 	defer idx.Trace(ctx, func() error { return nil }, "SelectiveSync")()
 
-	var totalCompletedJobs, maxJobs int
-	switch idx.G().GetAppType() {
-	case libkb.MobileAppType:
-		maxJobs = 5
-	default:
-		maxJobs = 10
-	}
-
 	convMap, err := idx.allConvs(ctx, uid)
 	if err != nil {
 		idx.Debug(ctx, "SelectiveSync: Unable to get convs: %v", err)
@@ -611,6 +648,9 @@ func (idx *Indexer) SelectiveSync(ctx context.Context, uid gregor1.UID, forceRei
 	sort.Slice(convIdxs, func(i, j int) bool {
 		return convIdxs[i].percentIndexed < convIdxs[j].percentIndexed
 	})
+
+	maxJobs := idx.maxSyncConvs
+	var totalCompletedJobs int
 	for _, idxInfo := range convIdxs {
 		conv := convMap[idxInfo.convID.String()].Conv
 		completedJobs, _, err := idx.reindexConv(ctx, conv, uid, idxInfo.idx, reindexOpts{

--- a/go/chat/search/utils.go
+++ b/go/chat/search/utils.go
@@ -68,12 +68,6 @@ func tokensFromMsg(msg chat1.MessageUnboxed) []string {
 	return tokenize(msg.SearchableText())
 }
 
-// getQueryRe returns a regex to match the query string on message text. This
-// is used for result highlighting.
-func getQueryRe(query string) (*regexp.Regexp, error) {
-	return regexp.Compile("(?i)" + regexp.QuoteMeta(query))
-}
-
 func msgIDsFromSet(set mapset.Set) []chat1.MessageID {
 	if set == nil {
 		return nil

--- a/go/chat/search/utils_test.go
+++ b/go/chat/search/utils_test.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -93,26 +92,4 @@ func TestTokenize(t *testing.T) {
 	}
 	// empty case
 	require.Nil(t, tokenize(""))
-}
-
-func TestGetQueryRe(t *testing.T) {
-	queries := []string{
-		"foo",
-		"foo bar",
-		"foo bar, baz? :+1:",
-	}
-	expectedRe := []string{
-		"foo",
-		"foo bar",
-		"foo bar, baz\\? :\\+1:",
-	}
-	for i, query := range queries {
-		re, err := getQueryRe(query)
-		require.NoError(t, err)
-		expected := regexp.MustCompile("(?i)" + expectedRe[i])
-		require.Equal(t, expected, re)
-		t.Logf("query: %v, expectedRe: %v, re: %v", query, expectedRe, re)
-		ok := re.MatchString(query)
-		require.True(t, ok)
-	}
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2179,7 +2179,7 @@ func (h *Server) SearchRegexp(ctx context.Context, arg chat1.SearchRegexpArg) (r
 		re, err = regexp.Compile(arg.Query)
 	} else {
 		// String queries are set case insensitive
-		re, err = regexp.Compile("(?i)" + regexp.QuoteMeta(arg.Query))
+		re, err = utils.GetQueryRe(arg.Query)
 	}
 
 	if err != nil {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1619,3 +1619,9 @@ func GetGregorConn(ctx context.Context, g *globals.Context, log DebugLabeler,
 	}
 	return conn, token, nil
 }
+
+// GetQueryRe returns a regex to match the query string on message text. This
+// is used for result highlighting.
+func GetQueryRe(query string) (*regexp.Regexp, error) {
+	return regexp.Compile("(?i)" + regexp.QuoteMeta(query))
+}

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -170,4 +171,26 @@ func TestFormatVideoDuration(t *testing.T) {
 	testCase(4500000, "1:15:00")
 	testCase(4536000, "1:15:36")
 	testCase(3906000, "1:05:06")
+}
+
+func TestGetQueryRe(t *testing.T) {
+	queries := []string{
+		"foo",
+		"foo bar",
+		"foo bar, baz? :+1:",
+	}
+	expectedRe := []string{
+		"foo",
+		"foo bar",
+		"foo bar, baz\\? :\\+1:",
+	}
+	for i, query := range queries {
+		re, err := GetQueryRe(query)
+		require.NoError(t, err)
+		expected := regexp.MustCompile("(?i)" + expectedRe[i])
+		require.Equal(t, expected, re)
+		t.Logf("query: %v, expectedRe: %v, re: %v", query, expectedRe, re)
+		ok := re.MatchString(query)
+		require.True(t, ok)
+	}
 }


### PR DESCRIPTION
uses the `RegexpSearcher` on a search misses (up to a max) with a small depth to catch queries we dont' index (substrings)