### PR TITLE
Remove \b from the url regex

### DIFF
--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -112,7 +112,7 @@ function parseMarkdown(
 // $FlowIssue treat this like a RegExp
 const linkRegex: RegExp = {
   exec: source => {
-    const r = /^( *)((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)\b/i
+    const r = /^( *)((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)/i
     const result = r.exec(source)
     if (result) {
       result.groups = {tld: result[4]}


### PR DESCRIPTION
The \b was matching before the final slash, so it didn't include it. I don't think it's necessary so I removed it.

@keybase/react-hackers 