### PR TITLE
Revert "Remove \b from the url regex"

### DIFF
--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -112,7 +112,7 @@ function parseMarkdown(
 // $FlowIssue treat this like a RegExp
 const linkRegex: RegExp = {
   exec: source => {
-    const r = /^( *)((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)/i
+    const r = /^( *)((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)\b/i
     const result = r.exec(source)
     if (result) {
       result.groups = {tld: result[4]}


### PR DESCRIPTION
Reverts keybase/client#14621 @chrisnojima actually I need to think about this a bit more. This matches the period if you write a link at the end of a sentence.