### PR TITLE
Fix black bar in choose-asset performing a request from chat

### DIFF
--- a/shared/wallets/send-form/choose-asset/container.js
+++ b/shared/wallets/send-form/choose-asset/container.js
@@ -28,7 +28,7 @@ const mapDispatchToProps = (dispatch, {navigateUp, onBack}: OwnProps) => ({
   },
   _onRefresh: (accountID: Types.AccountID, to: string) => {
     dispatch(WalletsGen.createLoadDisplayCurrencies())
-    dispatch(WalletsGen.createLoadSendAssetChoices({from: accountID, to}))
+    accountID !== Types.noAccountID && dispatch(WalletsGen.createLoadSendAssetChoices({from: accountID, to}))
   },
   onBack: () => dispatch(navigateUp()),
 })


### PR DESCRIPTION
@keybase/react-hackers 

When the choose-asset component's mounted, it calls its `refresh()` prop, which tries to load extra asset choices for the from account.  But if we got to choose-asset from a request in Chat, we haven't loaded accounts yet and there is no selected one.

Could fix this by adding an account load to when the request form is loaded, if they haven't been loaded yet.  Or do what this PR does, and just skip the call to learn about assets if we haven't loaded accounts yet.