### PR TITLE
show decrypting snippet if meta not in trusted state

### DIFF
--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -25,14 +25,15 @@ const valuesCached = memoize((badgeMap, unreadMap, metaMap) =>
       hasUnread: unreadMap.get(v.conversationIDKey, 0) > 0,
       conversation: v,
     }))
-    .sort((a, b) =>
-      a.hasBadge
-        ? b.hasBadge
-          ? b.conversation.timestamp - a.conversation.timestamp
-          : -1
-        : b.hasBadge
-          ? 1
-          : b.conversation.timestamp - a.conversation.timestamp
+    .sort(
+      (a, b) =>
+        a.hasBadge
+          ? b.hasBadge
+            ? b.conversation.timestamp - a.conversation.timestamp
+            : -1
+          : b.hasBadge
+            ? 1
+            : b.conversation.timestamp - a.conversation.timestamp
     )
     .take(maxShownConversations)
     .valueSeq()
@@ -43,11 +44,7 @@ const valuesCached = memoize((badgeMap, unreadMap, metaMap) =>
 let _username: string
 export const conversationsToSend = (state: TypedState) => {
   _username = state.config.username
-  return valuesCached(
-    state.chat2.badgeMap,
-    state.chat2.unreadMap,
-    state.chat2.metaMap,
-  )
+  return valuesCached(state.chat2.badgeMap, state.chat2.unreadMap, state.chat2.metaMap)
 }
 
 export const changeAffectsWidget = (
@@ -98,6 +95,7 @@ export const serialize = ({
       ? []
       : Constants.getRowParticipants(conversation, _username).toArray(),
     showBold: styles.showBold,
+    isDecryptingSnippet: false,
     snippet: conversation.snippet,
     snippetDecoration: conversation.snippetDecoration,
     subColor: styles.subColor,

--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -23,6 +23,7 @@ type Props = {
   youAreReset: boolean,
   hasResetUsers: boolean,
   isSelected: boolean,
+  isDecryptingSnippet: boolean,
 }
 
 class BottomLine extends PureComponent<Props> {
@@ -52,6 +53,8 @@ class BottomLine extends PureComponent<Props> {
           Waiting for participants to rekey
         </Text>
       )
+    } else if (this.props.isDecryptingSnippet) {
+      content = <Meta title="decrypting..." style={styles.alertMeta} backgroundColor={globalColors.blue} />
     } else if (this.props.snippet) {
       const style = collapseStyles([
         styles.bottomLine,

--- a/shared/chat/inbox/row/small-team/container.js
+++ b/shared/chat/inbox/row/small-team/container.js
@@ -39,6 +39,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     hasResetUsers: !stateProps._meta.resetParticipants.isEmpty(),
     hasUnread,
     iconHoverColor: styles.iconHoverColor,
+    isDecryptingSnippet: Constants.isDecryptingSnippet(stateProps._meta),
     isFinalized: !!stateProps._meta.wasFinalizedBy,
     isMuted: stateProps._meta.isMuted,
     isSelected,

--- a/shared/chat/inbox/row/small-team/index.js
+++ b/shared/chat/inbox/row/small-team/index.js
@@ -14,6 +14,7 @@ export type Props = {
   hasResetUsers: boolean,
   hasUnread: boolean,
   iconHoverColor: string,
+  isDecryptingSnippet: boolean,
   isFinalized: boolean,
   isMuted: boolean,
   isSelected: boolean,
@@ -135,6 +136,7 @@ class SmallTeam extends React.PureComponent<Props, State> {
                 hasResetUsers={props.hasResetUsers}
                 youNeedToRekey={props.youNeedToRekey}
                 isSelected={props.isSelected}
+                isDecryptingSnippet={props.isDecryptingSnippet}
               />
             </Kb.Box>
           </Kb.Box>

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -232,6 +232,7 @@ export {
   getRowParticipants,
   getRowStyles,
   inboxUIItemToConversationMeta,
+  isDecryptingSnippet,
   makeConversationMeta,
   timestampToString,
   unverifiedInboxUIItemToConversationMeta,

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -358,3 +358,6 @@ export const getConversationRetentionPolicy = (
   const conv = getMeta(state, conversationIDKey)
   return conv.retentionPolicy
 }
+
+export const isDecryptingSnippet = (meta: Types.ConversationMeta) =>
+  meta.trustedState === 'requesting' || meta.trustedState === 'untrusted'


### PR DESCRIPTION
@keybase/react-hackers 

Adds the new decrypting state for the inbox snippet if we are in the middle of unboxing a snippet. Just checks the state of the meta in the store when rendering the inbox row for a big or small team.

cc @malgorithms since you had a particular desire for this feature. Note this does not include the new loading bar, just the blue "Decrypting..." box in the snippet area.