### PR TITLE
forward xdg_download_dir in linux

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -204,6 +204,7 @@ start_systemd() {
       QT_IM_MODULE
       QT4_IM_MODULE
       XMODIFIERS
+      XDG_DOWNLOAD_DIR
   )
   forward_vars "$runtime_dir/keybase.gui.env" forwarded_gui_env_vars[@]
 


### PR DESCRIPTION
Problem is systemd (I think) doesn't forward env variables to its processes for security, so pass in `XDG_DOWNLOAD_DIR` explicitly. Jack says (in comment) it should be done by default on Arch but it wasn't working for me, and wouldn't work on older Ubuntus anyway.