### PR TITLE
Chat svc: convert System and Headline messages

### DIFF
--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -1007,7 +1007,9 @@ func (c *chatServiceHandler) convertMsgBody(mb chat1.MessageBody) MsgContent {
 		Reaction:           mb.Reaction__,
 		Delete:             mb.Delete__,
 		Metadata:           mb.Metadata__,
+		Headline:           mb.Headline__,
 		AttachmentUploaded: mb.Attachmentuploaded__,
+		System:             mb.System__,
 		SendPayment:        mb.Sendpayment__,
 		RequestPayment:     mb.Requestpayment__,
 		Unfurl:             mb.Unfurl__,
@@ -1131,7 +1133,9 @@ type MsgContent struct {
 	Reaction           *chat1.MessageReaction             `json:"reaction,omitempty"`
 	Delete             *chat1.MessageDelete               `json:"delete,omitempty"`
 	Metadata           *chat1.MessageConversationMetadata `json:"metadata,omitempty"`
+	Headline           *chat1.MessageHeadline             `json:"headline,omitempty"`
 	AttachmentUploaded *chat1.MessageAttachmentUploaded   `json:"attachment_uploaded,omitempty"`
+	System             *chat1.MessageSystem               `json:"system,omitempty"`
 	SendPayment        *chat1.MessageSendPayment          `json:"send_payment,omitempty"`
 	RequestPayment     *chat1.MessageRequestPayment       `json:"request_payment,omitempty"`
 	Unfurl             *chat1.MessageUnfurl               `json:"unfurl,omitempty"`


### PR DESCRIPTION
Support more messages in api, like:
```
    "content": {
      "type": "system",
      "system": {
        "systemType": 0,
        "addedtoteam": {
          "team": "tt20bf",
          "adder": "testuser20bf",
          "addee": "testuser0488",
          "owners": [
            "testuser20bf"
          ],
          "admins": null,
          "writers": [
            "testuser0488"
          ],
          "readers": null
        }
      }
    },
```
or
```
    "content": {
      "type": "system",
      "system": {
        "systemType": 5,
        "changeavatar": {
          "team": "tt20bf",
          "user": "testuser20bf"
        }
      }
    },
```