### PR TITLE
disable send button on each recipient change

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -275,8 +275,13 @@
       "to": "string"
     },
     "setLastSentXLM": {
+      "_description": "Set whether last currency used to send was XLM",
       "lastSentXLM": "boolean",
       "writeFile": "boolean"
+    },
+    "setReadyToSend": {
+      "_description": "Set whether the payment is ready to send",
+      "readyToSend": "boolean"
     },
     "openSendRequestForm": {
       "_description": "Initialize and navigate to the send or request form. See docs for `setBuilding*` for param semantics.",

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -77,6 +77,7 @@ export const setBuildingRecipientType = 'wallets:setBuildingRecipientType'
 export const setBuildingSecretNote = 'wallets:setBuildingSecretNote'
 export const setBuildingTo = 'wallets:setBuildingTo'
 export const setLastSentXLM = 'wallets:setLastSentXLM'
+export const setReadyToSend = 'wallets:setReadyToSend'
 export const validateAccountName = 'wallets:validateAccountName'
 export const validateSecretKey = 'wallets:validateSecretKey'
 export const validatedAccountName = 'wallets:validatedAccountName'
@@ -253,6 +254,7 @@ type _SetLastSentXLMPayload = $ReadOnly<{|
   lastSentXLM: boolean,
   writeFile: boolean,
 |}>
+type _SetReadyToSendPayload = $ReadOnly<{|readyToSend: boolean|}>
 type _ValidateAccountNamePayload = $ReadOnly<{|name: string|}>
 type _ValidateSecretKeyPayload = $ReadOnly<{|secretKey: HiddenString|}>
 type _ValidatedAccountNamePayload = $ReadOnly<{|name: string|}>
@@ -470,6 +472,14 @@ export const createSetBuildingSecretNote = (payload: _SetBuildingSecretNotePaylo
  */
 export const createSetBuildingTo = (payload: _SetBuildingToPayload) => ({payload, type: setBuildingTo})
 /**
+ * Set whether last currency used to send was XLM
+ */
+export const createSetLastSentXLM = (payload: _SetLastSentXLMPayload) => ({payload, type: setLastSentXLM})
+/**
+ * Set whether the payment is ready to send
+ */
+export const createSetReadyToSend = (payload: _SetReadyToSendPayload) => ({payload, type: setReadyToSend})
+/**
  * Signal that a payment being built is abandoned and reset the form fields to their initial states.
  */
 export const createAbandonPayment = (payload: _AbandonPaymentPayload) => ({payload, type: abandonPayment})
@@ -549,7 +559,6 @@ export const createDisplayCurrenciesReceived = (payload: _DisplayCurrenciesRecei
  * Update valid send assets to choose from
  */
 export const createSendAssetChoicesReceived = (payload: _SendAssetChoicesReceivedPayload) => ({payload, type: sendAssetChoicesReceived})
-export const createSetLastSentXLM = (payload: _SetLastSentXLMPayload) => ({payload, type: setLastSentXLM})
 
 // Action Payloads
 export type AbandonPaymentPayload = $Call<typeof createAbandonPayment, _AbandonPaymentPayload>
@@ -620,6 +629,7 @@ export type SetBuildingRecipientTypePayload = $Call<typeof createSetBuildingReci
 export type SetBuildingSecretNotePayload = $Call<typeof createSetBuildingSecretNote, _SetBuildingSecretNotePayload>
 export type SetBuildingToPayload = $Call<typeof createSetBuildingTo, _SetBuildingToPayload>
 export type SetLastSentXLMPayload = $Call<typeof createSetLastSentXLM, _SetLastSentXLMPayload>
+export type SetReadyToSendPayload = $Call<typeof createSetReadyToSend, _SetReadyToSendPayload>
 export type ValidateAccountNamePayload = $Call<typeof createValidateAccountName, _ValidateAccountNamePayload>
 export type ValidateSecretKeyPayload = $Call<typeof createValidateSecretKey, _ValidateSecretKeyPayload>
 export type ValidatedAccountNamePayload = $Call<typeof createValidatedAccountName, _ValidatedAccountNamePayload>
@@ -699,6 +709,7 @@ export type Actions =
   | SetBuildingSecretNotePayload
   | SetBuildingToPayload
   | SetLastSentXLMPayload
+  | SetReadyToSendPayload
   | ValidateAccountNamePayload
   | ValidateSecretKeyPayload
   | ValidatedAccountNamePayload

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -144,6 +144,11 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         .set('building', state.get('building').merge({sendAssetChoices}))
     case WalletsGen.setLastSentXLM:
       return state.merge({lastSentXLM: action.payload.lastSentXLM})
+    case WalletsGen.setReadyToSend:
+      return state.set(
+        'builtPayment',
+        state.get('builtPayment').merge({readyToSend: action.payload.readyToSend})
+      )
     case WalletsGen.validateAccountName:
       return state.merge({
         accountName: action.payload.name,

--- a/shared/wallets/send-form/participants/container.js
+++ b/shared/wallets/send-form/participants/container.js
@@ -78,6 +78,9 @@ const mapDispatchToPropsStellarPublicKey = dispatch => ({
   onChangeRecipient: (to: string) => {
     dispatch(WalletsGen.createSetBuildingTo({to}))
   },
+  setReadyToSend: (readyToSend: boolean) => {
+    dispatch(WalletsGen.createSetReadyToSend({readyToSend}))
+  },
 })
 
 const ConnectedParticipantsStellarPublicKey = namedConnect(

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -112,6 +112,7 @@ const keybaseUserProps = {
 const stellarPublicKeyProps = {
   recipientPublicKey: '',
   onChangeRecipient: Sb.action('onChangeRecipient'),
+  setReadyToSend: Sb.action('setReadyToSend'),
 }
 
 const otherAccountProps = {

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -72,6 +72,7 @@ type ToStellarPublicKeyProps = {|
   recipientPublicKey: string,
   errorMessage?: string,
   onChangeRecipient: string => void,
+  setReadyToSend: boolean => void,
 |}
 
 type ToStellarPublicKeyState = {|
@@ -83,6 +84,7 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStel
   _propsOnChangeRecipient = debounce(this.props.onChangeRecipient, 1e3)
   _onChangeRecipient = recipientPublicKey => {
     this.setState({recipientPublicKey})
+    this.props.setReadyToSend(false)
     this._propsOnChangeRecipient(recipientPublicKey)
   }
 


### PR DESCRIPTION
by resetting `readyToSend` in the built payment every change, outside the debounce