### PR TITLE
dont check foreground for mobile perm denied on keychain CORE-9411

### DIFF
--- a/go/libkb/secret_store_darwin.go
+++ b/go/libkb/secret_store_darwin.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"os"
 
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	keychain "github.com/keybase/go-keychain"
 )
 
@@ -59,14 +58,16 @@ func (k KeychainSecretStore) updateAccessibility(m MetaContext, accountName stri
 }
 
 func (k KeychainSecretStore) mobileKeychainPermissionDeniedCheck(m MetaContext, err error) {
-	if !isIOS || m.G().GetAppType() != MobileAppType ||
-		m.G().AppState.State() == keybase1.AppState_FOREGROUND {
+	m.G().Log.Debug("mobileKeychainPermissionDeniedCheck: checking for mobile permission denied")
+	if !isIOS || m.G().GetAppType() != MobileAppType {
+		m.G().Log.Debug("mobileKeychainPermissionDeniedCheck: not an iOS app")
 		return
 	}
 	if err != keychain.ErrorInteractionNotAllowed {
+		m.G().Log.Debug("mobileKeychainPermissionDeniedCheck: wrong kind of error: %s", err)
 		return
 	}
-	m.G().Log.Warning("keychain permission denied on mobile: %s", err)
+	m.G().Log.Warning("mobileKeychainPermissionDeniedCheck: keychain permission denied: %s", err)
 	os.Exit(4)
 }
 


### PR DESCRIPTION
Seems like this `FOREGROUND` test is flakey if the app is started fresh in the background (we think we are in the foreground and don't kill the app). I don't think this error can happen if the app is in the foreground, so don't bother checking it. Also add some more logging around the check.