### PR TITLE
Call buildPayment when we receive display currency for the send form

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -669,14 +669,16 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
   )
   yield Saga.safeTakeEveryPure(WalletsGen.accountsReceived, maybeSelectDefaultAccount)
   yield Saga.actionToPromise(
-    [
-      WalletsGen.buildPayment,
-      WalletsGen.setBuildingAmount,
-      WalletsGen.setBuildingCurrency,
-      WalletsGen.setBuildingFrom,
-      WalletsGen.setBuildingIsRequest,
-      WalletsGen.setBuildingTo,
-    ],
+    a =>
+      [
+        WalletsGen.buildPayment,
+        WalletsGen.setBuildingAmount,
+        WalletsGen.setBuildingCurrency,
+        WalletsGen.setBuildingFrom,
+        WalletsGen.setBuildingIsRequest,
+        WalletsGen.setBuildingTo,
+      ].includes(a.type) ||
+      (a.type === WalletsGen.displayCurrencyReceived && a.payload.setBuildingCurrency),
     buildPayment
   )
   yield Saga.actionToAction(WalletsGen.openSendRequestForm, openSendRequestForm)


### PR DESCRIPTION
Fixes the issue where the "You must send at least ..." banner doesn't show up until you start typing in the send form. We were already calling `buildPayment` on opening the send form. The banner wasn't showing because this case:

`a.type === WalletsGen.displayCurrencyReceived && a.payload.setBuildingCurrency`

was changing `state.wallets.building` without calling `buildPayment`. Then the reducer for `buildPayment` would get a payload with banners, but since `building` has changed we throw it out. So we need to make sure any mutations to `wallets.building` also goes through the `buildPayment` saga.

r? @keybase/react-hackers 