### PR TITLE
Fix 'link an existing account' option on the Stellar disclaimer

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -632,15 +632,14 @@ const acceptDisclaimer = (state: TypedState, action: WalletsGen.AcceptDisclaimer
       )
     )
     .then(
-      action.payload.nextScreen === 'linkExisting'
-        ? Saga.put(
-            Route.navigateTo(
+      _ =>
+        action.payload.nextScreen === 'linkExisting'
+          ? Route.navigateTo(
               isMobile
                 ? [Tabs.settingsTab, SettingsConstants.walletsTab, 'linkExisting']
                 : [Tabs.walletsTab, 'wallet', 'linkExisting']
             )
-          )
-        : undefined
+          : undefined
     )
 
 const rejectDisclaimer = (state: TypedState, action: WalletsGen.AcceptDisclaimerPayload) =>


### PR DESCRIPTION
@keybase/react-hackers 

Some action vs. promise confusion here, causing the navigateTo not to fire.