### PR TITLE
[KBFS-3596] Fix cannot set on an immutable record error

### DIFF
--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -116,10 +116,14 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     }
     case FsGen.downloadProgress: {
       const {key, completePortion, endEstimate} = action.payload
-      return state.updateIn(
-        ['downloads', key, 'state'],
-        original =>
-          original && original.set('completePortion', completePortion).set('endEstimate', endEstimate)
+      return state.withMutations(s => s
+        .updateIn(
+          ['downloads', key, 'state'],
+          original =>
+            original && original
+              .set('completePortion', completePortion)
+              .set('endEstimate', endEstimate)
+        )
       )
     }
     case FsGen.downloadSuccess: {
@@ -137,18 +141,21 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
       )
     case FsGen.uploadWritingSuccess: {
       const {path} = action.payload
-      return state
-        .removeIn(['uploads', 'errors', path])
-        .updateIn(['uploads', 'writingToJournal'], writingToJournal => writingToJournal.remove(path))
+      return (
+        state.withMutations(s => s
+          .removeIn(['uploads', 'errors', path])
+          .updateIn(['uploads', 'writingToJournal'], writingToJournal => writingToJournal.remove(path))
+        )
+      )
     }
     case FsGen.journalUpdate: {
       const {syncingPaths, totalSyncingBytes, endEstimate} = action.payload
       return (
-        state
-          // $FlowFixMe
+        state.withMutations(s => s
           .setIn(['uploads', 'syncingPaths'], I.Set(syncingPaths))
           .setIn(['uploads', 'totalSyncingBytes'], totalSyncingBytes)
           .setIn(['uploads', 'endEstimate'], endEstimate || undefined)
+        )
       )
     }
     case FsGen.fuseStatusResult:

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -116,11 +116,16 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     }
     case FsGen.downloadProgress: {
       const {key, completePortion, endEstimate} = action.payload
-      return state.withMutations(s =>
-        s.updateIn(
-          ['downloads', key, 'state'],
-          original =>
-            original && original.set('completePortion', completePortion).set('endEstimate', endEstimate)
+      return state.update('downloads', d =>
+        d.update(key, k =>
+          k.update(
+            'state',
+            original =>
+              original &&
+              original.withMutations(o =>
+                o.set('completePortion', completePortion).set('endEstimate', endEstimate)
+              )
+          )
         )
       )
     }
@@ -182,9 +187,9 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
         isIgnored: action.type === FsGen.favoriteIgnore,
       })
     case FsGen.mimeTypeLoaded:
-      return state.withMutations(s =>
-        s.updateIn(
-          ['pathItems', action.payload.path],
+      return state.update('pathItems', pis =>
+        pis.update(
+          action.payload.path,
           pathItem =>
             pathItem
               ? pathItem.type === 'file'
@@ -281,27 +286,30 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     case FsGen.dismissFsError:
       return state.removeIn(['errors', action.payload.key])
     case FsGen.showMoveOrCopy:
-      return state.update('moveOrCopy', mc => mc.set('destinationParentPath',
-        isMobile
-          ? I.List(
-              Types.getPathElements(action.payload.initialDestinationParentPath).reduce(
-                (list, elem) => [
-                  ...list,
-                  list.length
-                    ? Types.pathConcat(list[list.length - 1], elem)
-                    : Types.stringToPath(`/${elem}`),
-                ],
-                []
+      return state.update('moveOrCopy', mc =>
+        mc.set(
+          'destinationParentPath',
+          isMobile
+            ? I.List(
+                Types.getPathElements(action.payload.initialDestinationParentPath).reduce(
+                  (list, elem) => [
+                    ...list,
+                    list.length
+                      ? Types.pathConcat(list[list.length - 1], elem)
+                      : Types.stringToPath(`/${elem}`),
+                  ],
+                  []
+                )
               )
-            )
-          : I.List([action.payload.initialDestinationParentPath])
-      ))
+            : I.List([action.payload.initialDestinationParentPath])
+        )
+      )
     case FsGen.setMoveOrCopySource:
       return state.update('moveOrCopy', mc => mc.set('sourceItemPath', action.payload.path))
     case FsGen.setMoveOrCopyDestinationParentPath:
-      return state.update('moveOrCopy', mc => mc.update('destinationParentPath', list =>
-        list.set(action.payload.index, action.payload.path)
-      ))
+      return state.update('moveOrCopy', mc =>
+        mc.update('destinationParentPath', list => list.set(action.payload.index, action.payload.path))
+      )
     case FsGen.folderListLoad:
     case FsGen.placeholderAction:
     case FsGen.filePreviewLoad:

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -116,13 +116,11 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     }
     case FsGen.downloadProgress: {
       const {key, completePortion, endEstimate} = action.payload
-      return state.withMutations(s => s
-        .updateIn(
+      return state.withMutations(s =>
+        s.updateIn(
           ['downloads', key, 'state'],
           original =>
-            original && original
-              .set('completePortion', completePortion)
-              .set('endEstimate', endEstimate)
+            original && original.set('completePortion', completePortion).set('endEstimate', endEstimate)
         )
       )
     }
@@ -141,23 +139,23 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
       )
     case FsGen.uploadWritingSuccess: {
       const {path} = action.payload
-      return (
-        state.withMutations(s => s
+      return state.withMutations(s =>
+        s
           .removeIn(['uploads', 'errors', path])
           .updateIn(['uploads', 'writingToJournal'], writingToJournal => writingToJournal.remove(path))
-        )
       )
     }
     case FsGen.journalUpdate: {
       const {syncingPaths, totalSyncingBytes, endEstimate} = action.payload
-      return (
-        state.withMutations(s => s
-          // $FlowIssue no idea why this is broken
-          .setIn(['uploads', 'syncingPaths'], I.Set(syncingPaths))
-          .setIn(['uploads', 'totalSyncingBytes'], totalSyncingBytes)
-          .setIn(['uploads', 'endEstimate'], endEstimate || undefined)
-        )
-      )
+      return state.withMutations(s => {
+        s.setIn(['uploads', 'syncingPaths'], I.Set(syncingPaths))
+        s.setIn(['uploads', 'totalSyncingBytes'], totalSyncingBytes)
+        if (endEstimate) {
+          s.setIn(['uploads', 'endEstimate'], endEstimate)
+        } else {
+          s.deleteIn(['uploads', 'endEstimate'])
+        }
+      })
     }
     case FsGen.fuseStatusResult:
       return state.merge({fuseStatus: action.payload.status})
@@ -184,8 +182,8 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
         isIgnored: action.type === FsGen.favoriteIgnore,
       })
     case FsGen.mimeTypeLoaded:
-      return state.withMutations(s => s
-        .updateIn(
+      return state.withMutations(s =>
+        s.updateIn(
           ['pathItems', action.payload.path],
           pathItem =>
             pathItem
@@ -300,12 +298,11 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
           : I.List([action.payload.initialDestinationParentPath])
       )
     case FsGen.setMoveOrCopySource:
-      return state.setIn(['moveOrCopy', 'sourceItemPath'], action.payload.path)
+      return state.update('moveOrCopy', mc => mc.set('sourceItemPath', action.payload.path))
     case FsGen.setMoveOrCopyDestinationParentPath:
-      // $FlowFixMe
-      return state.updateIn(['moveOrCopy', 'destinationParentPath'], list =>
+      return state.update('moveOrCopy', mc => mc.update('destinationParentPath', list =>
         list.set(action.payload.index, action.payload.path)
-      )
+      ))
     case FsGen.folderListLoad:
     case FsGen.placeholderAction:
     case FsGen.filePreviewLoad:

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -152,6 +152,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
       const {syncingPaths, totalSyncingBytes, endEstimate} = action.payload
       return (
         state.withMutations(s => s
+          // $FlowIssue no idea why this is broken
           .setIn(['uploads', 'syncingPaths'], I.Set(syncingPaths))
           .setIn(['uploads', 'totalSyncingBytes'], totalSyncingBytes)
           .setIn(['uploads', 'endEstimate'], endEstimate || undefined)
@@ -183,17 +184,19 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
         isIgnored: action.type === FsGen.favoriteIgnore,
       })
     case FsGen.mimeTypeLoaded:
-      return state.updateIn(
-        ['pathItems', action.payload.path],
-        pathItem =>
-          pathItem
-            ? pathItem.type === 'file'
-              ? pathItem.set('mimeType', action.payload.mimeType)
-              : pathItem
-            : Constants.makeFile({
-                mimeType: action.payload.mimeType,
-                name: Types.getPathName(action.payload.path),
-              })
+      return state.withMutations(s => s
+        .updateIn(
+          ['pathItems', action.payload.path],
+          pathItem =>
+            pathItem
+              ? pathItem.type === 'file'
+                ? pathItem.set('mimeType', action.payload.mimeType)
+                : pathItem
+              : Constants.makeFile({
+                  mimeType: action.payload.mimeType,
+                  name: Types.getPathName(action.payload.path),
+                })
+        )
       )
     case FsGen.newFolderRow:
       const {parentPath} = action.payload

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -281,8 +281,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     case FsGen.dismissFsError:
       return state.removeIn(['errors', action.payload.key])
     case FsGen.showMoveOrCopy:
-      return state.setIn(
-        ['moveOrCopy', 'destinationParentPath'],
+      return state.update('moveOrCopy', mc => mc.set('destinationParentPath',
         isMobile
           ? I.List(
               Types.getPathElements(action.payload.initialDestinationParentPath).reduce(
@@ -296,7 +295,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
               )
             )
           : I.List([action.payload.initialDestinationParentPath])
-      )
+      ))
     case FsGen.setMoveOrCopySource:
       return state.update('moveOrCopy', mc => mc.set('sourceItemPath', action.payload.path))
     case FsGen.setMoveOrCopyDestinationParentPath:

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -121,10 +121,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
           k.update(
             'state',
             original =>
-              original &&
-              original.withMutations(o =>
-                o.set('completePortion', completePortion).set('endEstimate', endEstimate)
-              )
+              original && original.merge({completePortion, endEstimate})
           )
         )
       )


### PR DESCRIPTION
So I don't have a repro, but I went through the code, including Immutable, and it seems that this happens when an Immutable record doesn't have a clear `__ownerID`. It's not clear to me when that happens. But changing the mutability will cause it to be reset, and this error occurred after `_loadMimeType`. So it's likely happening in the reducer in `mimeTypeLoaded`. I have changed that to call `withMutations`, which should reset the mutability.