### PR TITLE
Fix multiline placeholder for mobile "to stellar address"

### DIFF
--- a/shared/common-adapters/clickable-box.native.js
+++ b/shared/common-adapters/clickable-box.native.js
@@ -22,7 +22,7 @@ class ClickableBox extends React.Component<Props> {
             pointerEvents={props.pointerEvents}
             style={clickStyle}
             underlayColor={props.underlayColor || globalColors.white}
-            activeOpacity={0.7}
+            activeOpacity={this.props.activeOpacity ?? 0.7}
           >
             {props.children}
           </TouchableOpacity>

--- a/shared/wallets/common/participants-row/index.js
+++ b/shared/wallets/common/participants-row/index.js
@@ -23,7 +23,7 @@ class ParticipantsRow extends React.PureComponent<Props> {
   render() {
     const props = this.props
     return (
-      <React.Fragment>
+      <>
         <Kb.Box2
           direction="horizontal"
           fullWidth={true}
@@ -46,7 +46,7 @@ class ParticipantsRow extends React.PureComponent<Props> {
         {props.bottomDivider && (
           <Kb.Divider style={props.dividerColor ? {backgroundColor: props.dividerColor} : {}} />
         )}
-      </React.Fragment>
+      </>
     )
   }
 }
@@ -57,7 +57,7 @@ const styles = Styles.styleSheetCreate({
       width: '100%',
     },
     isMobile: {
-      flexGrow: 1,
+      flex: 1,
       height: '100%',
       position: 'relative',
     },
@@ -71,7 +71,7 @@ const styles = Styles.styleSheetCreate({
       display: 'flex',
     },
     isMobile: {
-      ...Styles.globalStyles.fillAbsolute,
+      flex: 1,
     },
   }),
   headingText: {

--- a/shared/wallets/send-form/participants/search.js
+++ b/shared/wallets/send-form/participants/search.js
@@ -107,7 +107,10 @@ class Search extends React.Component<SearchProps, SearchState> {
 const styles = Styles.styleSheetCreate({
   resultsFloatingContainer: Styles.platformStyles({
     isElectron: {
+      borderBottomLeftRadius: 4,
+      borderBottomRightRadius: 4,
       height: 429,
+      overflow: 'hidden',
       width: 360,
     },
     isMobile: {

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -118,7 +118,7 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStel
                 : 'icon-stellar-logo-16'
             }
           />
-          <Kb.Box2 direction="horizontal" style={{flexShrink: 1, flexGrow: 1}}>
+          <Kb.Box2 direction="horizontal" style={styles.publicKeyInputContainer}>
             <Kb.NewInput
               type="text"
               onChangeText={this._onChangeRecipient}
@@ -136,25 +136,12 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStel
               <Kb.ClickableBox
                 activeOpacity={1}
                 onClick={this._onFocus}
-                style={Styles.collapseStyles([
-                  Styles.globalStyles.fillAbsolute,
-                  {
-                    cursor: 'text',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    paddingLeft: (Styles.isMobile ? 0 : 16) + 4,
-                  },
-                ])}
+                style={Styles.collapseStyles([Styles.globalStyles.fillAbsolute, styles.placeholderContainer])}
               >
-                <Kb.Text type="BodySemibold" style={{color: Styles.globalColors.black_20}}>
+                <Kb.Text type="BodySemibold" style={styles.colorBlack20}>
                   Stellar address
                 </Kb.Text>
-                <Kb.Text
-                  type="BodySemibold"
-                  style={{color: Styles.globalColors.black_20}}
-                  lineClamp={1}
-                  ellipsizeMode="middle"
-                >
+                <Kb.Text type="BodySemibold" style={styles.colorBlack20} lineClamp={1} ellipsizeMode="middle">
                   {placeholderExample}
                 </Kb.Text>
               </Kb.ClickableBox>
@@ -313,6 +300,17 @@ const styles = Styles.styleSheetCreate({
       paddingLeft: Styles.globalMargins.xtiny,
     },
   }),
+  placeholderContainer: Styles.platformStyles({
+    common: {
+      display: 'flex',
+      flexDirection: 'column',
+      paddingLeft: (Styles.isMobile ? 0 : 16) + 4,
+    },
+    isElectron: {
+      cursor: 'text',
+    },
+  }),
+  publicKeyInputContainer: {flexShrink: 1, flexGrow: 1},
   errorText: Styles.platformStyles({
     common: {
       color: Styles.globalColors.red,
@@ -343,6 +341,9 @@ const styles = Styles.styleSheetCreate({
     },
   }),
 
+  colorBlack20: {
+    color: Styles.globalColors.black_20,
+  },
   qrCode: {
     marginRight: Styles.globalMargins.tiny,
     marginTop: Styles.globalMargins.tiny,

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -86,11 +86,16 @@ type ToStellarPublicKeyState = {|
 
 class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStellarPublicKeyState> {
   state = {recipientPublicKey: this.props.recipientPublicKey}
+  _input: {current: React$ElementRef<typeof Kb.PlainInput> | null} = React.createRef()
   _propsOnChangeRecipient = debounce(this.props.onChangeRecipient, 1e3)
   _onChangeRecipient = recipientPublicKey => {
     this.setState({recipientPublicKey})
     this.props.setReadyToSend(false)
     this._propsOnChangeRecipient(recipientPublicKey)
+  }
+
+  _onFocus = () => {
+    this._input.current && this._input.current.focus()
   }
 
   render = () => (
@@ -115,15 +120,41 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStel
               type="text"
               onChangeText={this._onChangeRecipient}
               textType="BodySemibold"
-              placeholder={'Stellar address\nEx: G12345... or you*example.com'}
-              placeholderColor={Styles.globalColors.black_20}
               hideBorder={true}
               containerStyle={styles.input}
               multiline={true}
+              // $FlowIssue this is the right type
+              ref={this._input}
               rowsMin={2}
               rowsMax={3}
               value={this.state.recipientPublicKey}
             />
+            {!this.state.recipientPublicKey && (
+              <Kb.ClickableBox
+                onClick={this._onFocus}
+                style={Styles.collapseStyles([
+                  Styles.globalStyles.fillAbsolute,
+                  {
+                    cursor: 'text',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    paddingLeft: (Styles.isMobile ? 0 : 16) + 4,
+                  },
+                ])}
+              >
+                <Kb.Text type="BodySemibold" style={{color: Styles.globalColors.black_20}}>
+                  Stellar address
+                </Kb.Text>
+                <Kb.Text
+                  type="BodySemibold"
+                  style={{color: Styles.globalColors.black_20}}
+                  lineClamp={1}
+                  ellipsizeMode="middle"
+                >
+                  Ex: G12345... or you*example.com
+                </Kb.Text>
+              </Kb.ClickableBox>
+            )}
           </Kb.Box2>
           {!this.state.recipientPublicKey &&
             this.props.onScanQRCode && (
@@ -263,10 +294,16 @@ const styles = Styles.styleSheetCreate({
   inputInner: {
     alignItems: 'flex-start',
     flexShrink: 0,
+    position: 'relative',
   },
-  input: {
-    padding: 0,
-  },
+  input: Styles.platformStyles({
+    common: {
+      padding: 0,
+    },
+    isMobile: {
+      paddingLeft: Styles.globalMargins.xtiny,
+    },
+  }),
   errorText: Styles.platformStyles({
     common: {
       color: Styles.globalColors.red,

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 import {ParticipantsRow} from '../../common'
+import {isLargeScreen} from '../../../constants/platform'
 import {SelectedEntry, DropdownEntry, DropdownText} from './dropdown'
 import Search from './search'
 import type {Account} from '.'
@@ -18,6 +19,8 @@ type ToKeybaseUserProps = {|
   onChangeRecipient: string => void,
   onScanQRCode: ?() => void,
 |}
+
+const placeholderExample = isLargeScreen ? 'Ex: G12345... or you*example.com' : 'G12.. or you*example.com'
 
 const ToKeybaseUser = (props: ToKeybaseUserProps) => {
   if (props.recipientUsername) {
@@ -106,8 +109,8 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStel
       dividerColor={this.props.errorMessage ? Styles.globalColors.red : ''}
       style={styles.toStellarPublicKey}
     >
-      <Kb.Box2 direction="vertical" fullWidth={true} style={styles.inputBox}>
-        <Kb.Box2 direction="horizontal" gap="xxtiny" fullWidth={true} style={styles.inputInner}>
+      <Kb.Box2 direction="vertical" fullWidth={!Styles.isMobile} style={styles.inputBox}>
+        <Kb.Box2 direction="horizontal" gap="xxtiny" fullWidth={!Styles.isMobile} style={styles.inputInner}>
           <Kb.Icon
             type={
               this.state.recipientPublicKey.length === 0 || this.props.errorMessage
@@ -131,6 +134,7 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStel
             />
             {!this.state.recipientPublicKey && (
               <Kb.ClickableBox
+                activeOpacity={1}
                 onClick={this._onFocus}
                 style={Styles.collapseStyles([
                   Styles.globalStyles.fillAbsolute,
@@ -151,7 +155,7 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStel
                   lineClamp={1}
                   ellipsizeMode="middle"
                 >
-                  Ex: G12345... or you*example.com
+                  {placeholderExample}
                 </Kb.Text>
               </Kb.ClickableBox>
             )}
@@ -290,12 +294,17 @@ const styles = Styles.styleSheetCreate({
   heading: {
     alignSelf: 'flex-start',
   },
-  inputBox: {flexGrow: 1},
-  inputInner: {
-    alignItems: 'flex-start',
-    flexShrink: 0,
-    position: 'relative',
-  },
+  inputBox: Styles.platformStyles({isElectron: {flexGrow: 1}, isMobile: {flex: 1}}),
+  inputInner: Styles.platformStyles({
+    common: {
+      alignItems: 'flex-start',
+      flex: 1,
+      position: 'relative',
+    },
+    isElectron: {
+      flexShrink: 0,
+    },
+  }),
   input: Styles.platformStyles({
     common: {
       padding: 0,


### PR DESCRIPTION
Adds the placeholder as an overlay over the input field. Also makes it so the error message expands the box correctly on mobile. r? @keybase/react-hackers 