### PR TITLE
Don't log no such key errors in readLastSentXLM

### DIFF
--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -409,7 +409,12 @@ const readLastSentXLM = () => {
       logger.info(`Successfully read config stellar.lastSentXLM: ${String(value)}`)
       return createSetLastSentXLM({lastSentXLM: value, writeFile: false})
     })
-    .catch(err => logger.error(`Error reading config stellar.lastSentXLM: ${err.message}`))
+    .catch(
+      err =>
+        err.message.includes('no such key')
+          ? null
+          : logger.error(`Error reading config stellar.lastSentXLM: ${err.message}`)
+    )
 }
 
 function* configSaga(): Saga.SagaGenerator<any, any> {


### PR DESCRIPTION
Uses `string.includes` to figure out whether it's this "no such key" error, since it uses the generic error code. This is mostly to keep it from polluting our logs and bugging us during dev, cc @chrisnojima @keybase/react-hackers 