### PR TITLE
Fix disclaimer promises

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -588,22 +588,20 @@ const receivedBadgeState = (state: TypedState, action: NotificationsGen.Received
   Saga.put(WalletsGen.createBadgesUpdated({accounts: action.payload.badgeState.unreadWalletAccounts || []}))
 
 const acceptDisclaimer = (state: TypedState, action: WalletsGen.AcceptDisclaimerPayload) =>
-  RPCStellarTypes.localAcceptDisclaimerLocalRpcPromise(undefined, Constants.acceptDisclaimerWaitingKey)
-    .then(res =>
+  RPCStellarTypes.localAcceptDisclaimerLocalRpcPromise(undefined, Constants.acceptDisclaimerWaitingKey).then(
+    res =>
       RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise().then(accepted =>
         WalletsGen.createWalletDisclaimerReceived({accepted})
       )
-    )
-    .then(
-      _ =>
-        action.payload.nextScreen === 'linkExisting'
-          ? Route.navigateTo(
-              isMobile
-                ? [Tabs.settingsTab, SettingsConstants.walletsTab, 'linkExisting']
-                : [Tabs.walletsTab, 'wallet', 'linkExisting']
-            )
-          : undefined
-    )
+  )
+
+const maybeNavToLinkExisting = (state: TypedState, action: WalletsGen.AcceptDisclaimerPayload) =>
+  action.payload.nextScreen === 'linkExisting' &&
+  Route.navigateTo(
+    isMobile
+      ? [Tabs.settingsTab, SettingsConstants.walletsTab, 'linkExisting']
+      : [Tabs.walletsTab, 'wallet', 'linkExisting']
+  )
 
 const rejectDisclaimer = (state: TypedState, action: WalletsGen.AcceptDisclaimerPayload) =>
   Saga.put(
@@ -718,6 +716,7 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
     loadWalletDisclaimer
   )
   yield Saga.actionToPromise(WalletsGen.acceptDisclaimer, acceptDisclaimer)
+  yield Saga.actionToPromise(WalletsGen.acceptDisclaimer, maybeNavToLinkExisting)
   yield Saga.actionToAction(WalletsGen.rejectDisclaimer, rejectDisclaimer)
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

We had another bug here -- there were nested .then() calls, and we'd only perform one of them depending on whether WalletsGen.createWalletDisclaimerReceived({accepted}) or NavigateTo() fired first.  This led to people in the linkExisting flow getting stuck with us thinking they hadn't accepted the disclaimer.

Here's a rewrite to stop trying to do more than one thing per saga, which is what I should've done to start with.