### PR TITLE
Safe navigation in invite-by-email

### DIFF
--- a/shared/teams/invite-by-email/container.desktop.js
+++ b/shared/teams/invite-by-email/container.desktop.js
@@ -3,7 +3,6 @@ import * as TeamsGen from '../../actions/teams-gen'
 import * as Constants from '../../constants/teams'
 import * as Types from '../../constants/types/teams'
 import {InviteByEmailDesktop} from '.'
-import {navigateAppend} from '../../actions/route-tree'
 import {connect} from '../../util/container'
 import {type OwnProps} from './container'
 
@@ -17,7 +16,7 @@ const mapStateToProps = (state, {routeProps}: OwnProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch, {navigateUp, routePath, routeProps}) => ({
+const mapDispatchToProps = (dispatch, {navigateAppend, navigateUp, routePath, routeProps}) => ({
   onClearInviteError: () => dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''})), // should only be called on unmount
   onClose: () => dispatch(navigateUp()),
   onInvite: (invitees: string, role: Types.TeamRoleType) => {

--- a/shared/teams/invite-by-email/container.native.js
+++ b/shared/teams/invite-by-email/container.native.js
@@ -6,7 +6,6 @@ import * as Constants from '../../constants/teams'
 import * as I from 'immutable'
 import {InviteByEmailMobile, type ContactDisplayProps} from '.'
 import {HeaderHoc} from '../../common-adapters'
-import {navigateAppend} from '../../actions/route-tree'
 import {
   connect,
   compose,
@@ -40,7 +39,7 @@ const mapStateToProps = (state, {routeProps}: OwnProps) => {
   }
 }
 
-const mapDispatchToProps = (dispatch, {navigateUp, routePath, routeProps}) => ({
+const mapDispatchToProps = (dispatch, {navigateAppend, navigateUp, routePath, routeProps}) => ({
   openAppSettings: () => dispatch(ConfigGen.createOpenAppSettings()),
   onClearError: () => dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''})),
   onClose: () => {

--- a/shared/teams/invite-by-email/index.desktop.js
+++ b/shared/teams/invite-by-email/index.desktop.js
@@ -1,33 +1,24 @@
 // @flow
 import * as React from 'react'
 import * as I from 'immutable'
-import {
-  Box,
-  Box2,
-  ButtonBar,
-  DropdownButton,
-  Input,
-  PopupDialog,
-  Text,
-  WaitingButton,
-} from '../../common-adapters'
-import {globalStyles, globalMargins, globalColors} from '../../styles'
+import * as Kb from '../../common-adapters'
+import * as Styles from '../../styles'
 import {capitalize} from 'lodash-es'
 import {type TeamRoleType} from '../../constants/types/teams'
 import type {DesktopProps as Props} from '.'
 
 const _makeDropdownItem = (item: string) => (
-  <Box
+  <Kb.Box
     key={item}
     style={{
-      ...globalStyles.flexBoxRow,
+      ...Styles.globalStyles.flexBoxRow,
       alignItems: 'center',
-      paddingLeft: globalMargins.small,
-      paddingRight: globalMargins.small,
+      paddingLeft: Styles.globalMargins.small,
+      paddingRight: Styles.globalMargins.small,
     }}
   >
-    <Text type="BodyBig">{capitalize(item)}</Text>
-  </Box>
+    <Kb.Text type="BodyBig">{capitalize(item)}</Kb.Text>
+  </Kb.Box>
 )
 
 type State = {
@@ -37,7 +28,7 @@ type State = {
 }
 class InviteByEmailDesktop extends React.Component<Props, State> {
   state = {invitees: '', malformedEmails: I.Set(), role: 'reader'}
-  _input: ?Input
+  _input: ?Kb.Input
 
   componentDidUpdate(prevProps: Props, prevState: State) {
     // update contents of input box if we get a new list of malformed emails
@@ -66,46 +57,46 @@ class InviteByEmailDesktop extends React.Component<Props, State> {
   render() {
     const props = this.props
     return (
-      <PopupDialog onClose={props.onClose} styleCover={_styleCover} styleContainer={_styleContainer}>
-        <Box style={{...globalStyles.flexBoxColumn}}>
-          <Box
+      <Kb.PopupDialog onClose={props.onClose} styleCover={_styleCover} styleContainer={_styleContainer}>
+        <Kb.Box style={{...Styles.globalStyles.flexBoxColumn}}>
+          <Kb.Box
             style={{
-              ...globalStyles.flexBoxColumn,
+              ...Styles.globalStyles.flexBoxColumn,
               alignItems: 'center',
-              margin: globalMargins.medium,
+              margin: Styles.globalMargins.medium,
             }}
           >
-            <Text style={styleInside} type="Header">
+            <Kb.Text style={styleInside} type="Header">
               Invite by email
-            </Text>
-            <Box
+            </Kb.Text>
+            <Kb.Box
               style={{
-                ...globalStyles.flexBoxRow,
+                ...Styles.globalStyles.flexBoxRow,
                 alignItems: 'center',
-                margin: globalMargins.tiny,
+                margin: Styles.globalMargins.tiny,
               }}
             >
-              <Text style={{margin: globalMargins.tiny}} type="Body">
+              <Kb.Text style={{margin: Styles.globalMargins.tiny}} type="Body">
                 Add these team members to {props.name} as:
-              </Text>
-              <DropdownButton
+              </Kb.Text>
+              <Kb.DropdownButton
                 toggleOpen={() => props.onOpenRolePicker(this.state.role, this._setRole)}
                 selected={_makeDropdownItem(this.state.role)}
                 style={{width: 100}}
               />
-            </Box>
-            <Text type="BodySmallSemibold" style={{alignSelf: 'flex-start'}}>
+            </Kb.Box>
+            <Kb.Text type="BodySmallSemibold" style={{alignSelf: 'flex-start'}}>
               Enter multiple email addresses, separated by commas
-            </Text>
-            <Box2 direction="vertical" gap="xtiny" fullWidth={true} style={{alignItems: 'flex-start'}}>
-              <Box
+            </Kb.Text>
+            <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true} style={{alignItems: 'flex-start'}}>
+              <Kb.Box
                 style={{
-                  border: `1px solid ${globalColors.black_20}`,
+                  border: `1px solid ${Styles.globalColors.black_20}`,
                   borderRadius: 4,
                   width: '100%',
                 }}
               >
-                <Input
+                <Kb.Input
                   autoFocus={true}
                   multiline={true}
                   hideUnderline={true}
@@ -118,31 +109,31 @@ class InviteByEmailDesktop extends React.Component<Props, State> {
                   small={true}
                   inputStyle={styleInput}
                 />
-              </Box>
+              </Kb.Box>
               {props.errorMessage && (
-                <Text type="BodySmall" style={{color: globalColors.red}}>
+                <Kb.Text type="BodySmall" style={{color: Styles.globalColors.red}}>
                   {props.errorMessage}
-                </Text>
+                </Kb.Text>
               )}
-            </Box2>
+            </Kb.Box2>
 
-            <ButtonBar>
-              <WaitingButton
+            <Kb.ButtonBar>
+              <Kb.WaitingButton
                 label="Invite"
                 onClick={this._onInvite}
                 type="Primary"
                 waitingKey={props.waitingKey}
               />
-            </ButtonBar>
-          </Box>
-        </Box>
-      </PopupDialog>
+            </Kb.ButtonBar>
+          </Kb.Box>
+        </Kb.Box>
+      </Kb.PopupDialog>
     )
   }
 }
 
 const styleInside = {
-  padding: globalMargins.tiny,
+  padding: Styles.globalMargins.tiny,
   marginTop: 0,
   marginBottom: 0,
 }
@@ -155,16 +146,16 @@ const styleInput = {
 
 const _styleCover = {
   alignItems: 'center',
-  backgroundColor: globalColors.black_75,
+  backgroundColor: Styles.globalColors.black_75,
   justifyContent: 'center',
 }
 
 const _styleContainer = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignSelf: 'center',
-  backgroundColor: globalColors.white,
+  backgroundColor: Styles.globalColors.white,
   borderRadius: 5,
-  boxShadow: `0 2px 5px 0 ${globalColors.black_20}`,
+  boxShadow: `0 2px 5px 0 ${Styles.globalColors.black_20}`,
 }
 
 export {InviteByEmailDesktop}

--- a/shared/teams/invite-by-email/index.desktop.js
+++ b/shared/teams/invite-by-email/index.desktop.js
@@ -5,8 +5,7 @@ import {
   Box,
   Box2,
   ButtonBar,
-  ClickableBox,
-  Dropdown,
+  DropdownButton,
   Input,
   PopupDialog,
   Text,
@@ -14,7 +13,6 @@ import {
 } from '../../common-adapters'
 import {globalStyles, globalMargins, globalColors} from '../../styles'
 import {capitalize} from 'lodash-es'
-import {teamRoleTypes} from '../../constants/teams'
 import {type TeamRoleType} from '../../constants/types/teams'
 import type {DesktopProps as Props} from '.'
 
@@ -31,8 +29,6 @@ const _makeDropdownItem = (item: string) => (
     <Text type="BodyBig">{capitalize(item)}</Text>
   </Box>
 )
-
-const _makeDropdownItems = () => teamRoleTypes.map(item => _makeDropdownItem(item))
 
 type State = {
   invitees: string,
@@ -92,21 +88,11 @@ class InviteByEmailDesktop extends React.Component<Props, State> {
               <Text style={{margin: globalMargins.tiny}} type="Body">
                 Add these team members to {props.name} as:
               </Text>
-              <ClickableBox
-                onClick={() => props.onOpenRolePicker(this.state.role, this._setRole)}
-                underlayColor={globalColors.transparent}
-              >
-                <Dropdown
-                  items={_makeDropdownItems()}
-                  selected={_makeDropdownItem(this.state.role)}
-                  onChanged={(node: React.Node) => {
-                    // $FlowIssue doesn't understand key will be string
-                    const selectedRole: TeamRoleType = (node && node.key) || null
-                    this._setRole(selectedRole)
-                  }}
-                  style={{width: 100}}
-                />
-              </ClickableBox>
+              <DropdownButton
+                toggleOpen={() => props.onOpenRolePicker(this.state.role, this._setRole)}
+                selected={_makeDropdownItem(this.state.role)}
+                style={{width: 100}}
+              />
             </Box>
             <Text type="BodySmallSemibold" style={{alignSelf: 'flex-start'}}>
               Enter multiple email addresses, separated by commas


### PR DESCRIPTION
Changes some `navigateAppend`s to the one from `RouteProps`, and switches `Dropdown` for `DropdownButton` for the role picker so this doesn't happen:

<img width="575" alt="image" src="https://user-images.githubusercontent.com/11968340/48562453-3546d700-e8c0-11e8-94b5-e5dce0fc90d8.png">

The first three commits have the changes, the last is a `Kb`/`Styles` refactor

r? @keybase/react-hackers 