### PR TITLE
migrate to V2 bundles

### DIFF
--- a/go/client/cmd_wallet_dump.go
+++ b/go/client/cmd_wallet_dump.go
@@ -63,7 +63,8 @@ func (c *cmdWalletDump) Run() (err error) {
 			dui.Printf("Name: %v\n", account.Name)
 		}
 		dui.Printf("AccountID: %v\n", account.AccountID)
-		for j, signer := range account.Signers {
+		accountBundle := bundle.AccountBundles[account.AccountID]
+		for j, signer := range accountBundle.Signers {
 			dui.Printf("Signers[%v]: %v\n", j, signer.SecureNoLogString())
 		}
 		dui.Printf("Mode: %v\n", account.Mode)

--- a/go/client/cmd_wallet_dump.go
+++ b/go/client/cmd_wallet_dump.go
@@ -67,6 +67,9 @@ func (c *cmdWalletDump) Run() (err error) {
 		for j, signer := range accountBundle.Signers {
 			dui.Printf("Signers[%v]: %v\n", j, signer.SecureNoLogString())
 		}
+		if len(accountBundle.Signers) == 0 {
+			dui.Printf("Signers[0]: not present in bundle\n")
+		}
 		dui.Printf("Mode: %v\n", account.Mode)
 	}
 	return nil

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -312,6 +312,7 @@ const (
 	SCStellarNeedDisclaimer            = int(keybase1.StatusCode_SCStellarNeedDisclaimer)
 	SCStellarDeviceNotMobile           = int(keybase1.StatusCode_SCStellarDeviceNotMobile)
 	SCStellarMobileOnlyPurgatory       = int(keybase1.StatusCode_SCStellarMobileOnlyPurgatory)
+	SCStellarIncompatibleVersion       = int(keybase1.StatusCode_SCStellarIncompatibleVersion)
 )
 
 const (

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -313,6 +313,7 @@ const (
 	SCStellarDeviceNotMobile           = int(keybase1.StatusCode_SCStellarDeviceNotMobile)
 	SCStellarMobileOnlyPurgatory       = int(keybase1.StatusCode_SCStellarMobileOnlyPurgatory)
 	SCStellarIncompatibleVersion       = int(keybase1.StatusCode_SCStellarIncompatibleVersion)
+	SCStellarMissingAccount            = int(keybase1.StatusCode_SCStellarMissingAccount)
 )
 
 const (

--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -106,6 +106,13 @@ func (f *featureSlot) readFrom(m MetaContext, r rawFeatureSlot) {
 	f.cacheUntil = m.G().Clock().Now().Add(time.Duration(r.CacheSec) * time.Second)
 }
 
+func (s *FeatureFlagSet) InvalidateCache(m MetaContext, f Feature) {
+	featureSlot := s.features[f]
+	featureSlot.Lock()
+	defer featureSlot.Unlock()
+	featureSlot.cacheUntil = m.G().Clock().Now().Add(time.Duration(-1) * time.Second)
+}
+
 // EnabledWithError returns if the given feature is enabled, it will return true if it's
 // enabled, and an error if one occurred.
 func (s *FeatureFlagSet) EnabledWithError(m MetaContext, f Feature) (on bool, err error) {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -50,7 +50,6 @@ type GlobalContext struct {
 	VDL              *VDebugLog    // verbose debug log
 	Env              *Env          // Env variables, cmdline args & config
 	SKBKeyringMu     *sync.Mutex   // Protects all attempts to mutate the SKBKeyringFile
-	StellarBundleMu  *sync.Mutex   // Protects stellar bundle migration
 	Keyrings         *Keyrings     // Gpg Keychains holding keys
 	perUserKeyringMu *sync.Mutex
 	perUserKeyring   *PerUserKeyring      // Keyring holding per user keys
@@ -172,7 +171,6 @@ func NewGlobalContext() *GlobalContext {
 		Log:                log,
 		VDL:                NewVDebugLog(log),
 		SKBKeyringMu:       new(sync.Mutex),
-		StellarBundleMu:    new(sync.Mutex),
 		perUserKeyringMu:   new(sync.Mutex),
 		cacheMu:            new(sync.RWMutex),
 		socketWrapperMu:    new(sync.RWMutex),

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -50,6 +50,7 @@ type GlobalContext struct {
 	VDL              *VDebugLog    // verbose debug log
 	Env              *Env          // Env variables, cmdline args & config
 	SKBKeyringMu     *sync.Mutex   // Protects all attempts to mutate the SKBKeyringFile
+	StellarBundleMu  *sync.Mutex   // Protects stellar bundle migration
 	Keyrings         *Keyrings     // Gpg Keychains holding keys
 	perUserKeyringMu *sync.Mutex
 	perUserKeyring   *PerUserKeyring      // Keyring holding per user keys
@@ -171,6 +172,7 @@ func NewGlobalContext() *GlobalContext {
 		Log:                log,
 		VDL:                NewVDebugLog(log),
 		SKBKeyringMu:       new(sync.Mutex),
+		StellarBundleMu:    new(sync.Mutex),
 		perUserKeyringMu:   new(sync.Mutex),
 		cacheMu:            new(sync.RWMutex),
 		socketWrapperMu:    new(sync.RWMutex),

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -15,6 +15,7 @@ package libkb
 import (
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"golang.org/x/net/context"
@@ -661,6 +662,7 @@ type Stellar interface {
 	GetServerDefinitions(context.Context) (stellar1.StellarServerDefinitions, error)
 	KickAutoClaimRunner(MetaContext, gregor.MsgID)
 	UpdateUnreadCount(ctx context.Context, accountID stellar1.AccountID, unread int) error
+	GetMigrationLock() *sync.Mutex
 }
 
 type DeviceEKStorage interface {

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -861,9 +861,9 @@ func StellarProof(m MetaContext, me *User, walletAddress stellar1.AccountID,
 // Modifies the User `me` with a sigchain bump and key delegation.
 // Returns a JSONPayload ready for use in "sigs" in sig/multi.
 func StellarProofReverseSigned(m MetaContext, me *User, walletAddress stellar1.AccountID,
-	stellarSigner stellar1.SecretKey, signer GenericKey) (JSONPayload, error) {
+	stellarSigner stellar1.SecretKey, deviceSigner GenericKey) (JSONPayload, error) {
 	// Make reverse sig
-	jwRev, err := StellarProof(m, me, walletAddress, signer)
+	jwRev, err := StellarProof(m, me, walletAddress, deviceSigner)
 	if err != nil {
 		return nil, err
 	}
@@ -885,7 +885,7 @@ func StellarProofReverseSigned(m MetaContext, me *User, walletAddress stellar1.A
 	}
 	sig, sigID, linkID, err := MakeSig(
 		m,
-		signer,
+		deviceSigner,
 		LinkTypeWalletStellar,
 		innerJSON,
 		SigHasRevokes(false),
@@ -905,7 +905,7 @@ func StellarProofReverseSigned(m MetaContext, me *User, walletAddress stellar1.A
 	res := make(JSONPayload)
 	res["sig"] = sig
 	res["sig_inner"] = string(innerJSON)
-	res["signing_kid"] = signer.GetKID().String()
+	res["signing_kid"] = deviceSigner.GetKID().String()
 	res["public_key"] = stellarSignerKey.GetKID().String()
 	res["type"] = LinkTypeWalletStellar
 	return res, nil

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/keybase/client/go/gregor"
 	stellar1 "github.com/keybase/client/go/protocol/stellar1"
@@ -38,3 +39,5 @@ func (n *nullStellar) KickAutoClaimRunner(MetaContext, gregor.MsgID) {}
 func (n *nullStellar) UpdateUnreadCount(context.Context, stellar1.AccountID, int) error {
 	return errors.New("nullStellar UpdateUnreadCount")
 }
+
+func (n *nullStellar) GetMigrationLock() *sync.Mutex { return new(sync.Mutex) }

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -183,6 +183,7 @@ const (
 	StatusCode_SCStellarNeedDisclaimer            StatusCode = 3109
 	StatusCode_SCStellarDeviceNotMobile           StatusCode = 3110
 	StatusCode_SCStellarMobileOnlyPurgatory       StatusCode = 3111
+	StatusCode_SCStellarIncompatibleVersion       StatusCode = 3112
 	StatusCode_SCNISTWrongSize                    StatusCode = 3201
 	StatusCode_SCNISTBadMode                      StatusCode = 3202
 	StatusCode_SCNISTHashWrongSize                StatusCode = 3203
@@ -382,6 +383,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCStellarNeedDisclaimer":            3109,
 	"SCStellarDeviceNotMobile":           3110,
 	"SCStellarMobileOnlyPurgatory":       3111,
+	"SCStellarIncompatibleVersion":       3112,
 	"SCNISTWrongSize":                    3201,
 	"SCNISTBadMode":                      3202,
 	"SCNISTHashWrongSize":                3203,
@@ -579,6 +581,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	3109: "SCStellarNeedDisclaimer",
 	3110: "SCStellarDeviceNotMobile",
 	3111: "SCStellarMobileOnlyPurgatory",
+	3112: "SCStellarIncompatibleVersion",
 	3201: "SCNISTWrongSize",
 	3202: "SCNISTBadMode",
 	3203: "SCNISTHashWrongSize",

--- a/go/protocol/stellar1/bundle.go
+++ b/go/protocol/stellar1/bundle.go
@@ -1128,16 +1128,14 @@ func (o BundleEntryRestricted) DeepCopy() BundleEntryRestricted {
 }
 
 type AccountBundle struct {
-	Revision  BundleRevision `codec:"revision" json:"revision"`
-	Prev      Hash           `codec:"prev" json:"prev"`
-	OwnHash   Hash           `codec:"ownHash" json:"ownHash"`
-	AccountID AccountID      `codec:"accountID" json:"accountID"`
-	Signers   []SecretKey    `codec:"signers" json:"signers"`
+	Prev      Hash        `codec:"prev" json:"prev"`
+	OwnHash   Hash        `codec:"ownHash" json:"ownHash"`
+	AccountID AccountID   `codec:"accountID" json:"accountID"`
+	Signers   []SecretKey `codec:"signers" json:"signers"`
 }
 
 func (o AccountBundle) DeepCopy() AccountBundle {
 	return AccountBundle{
-		Revision:  o.Revision.DeepCopy(),
 		Prev:      o.Prev.DeepCopy(),
 		OwnHash:   o.OwnHash.DeepCopy(),
 		AccountID: o.AccountID.DeepCopy(),

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -192,6 +192,15 @@ func (s Bundle) PrimaryAccount() (BundleEntry, error) {
 	return BundleEntry{}, errors.New("primary stellar account not found")
 }
 
+func (s BundleRestricted) PrimaryAccount() (BundleEntryRestricted, error) {
+	for _, entry := range s.Accounts {
+		if entry.IsPrimary {
+			return entry, nil
+		}
+	}
+	return BundleEntryRestricted{}, errors.New("primary stellar account not found")
+}
+
 func (s Bundle) Lookup(acctID AccountID) (BundleEntry, error) {
 	for _, entry := range s.Accounts {
 		if entry.AccountID == acctID {
@@ -199,6 +208,15 @@ func (s Bundle) Lookup(acctID AccountID) (BundleEntry, error) {
 		}
 	}
 	return BundleEntry{}, errors.New("stellar account not found")
+}
+
+func (s BundleRestricted) Lookup(acctID AccountID) (BundleEntryRestricted, error) {
+	for _, entry := range s.Accounts {
+		if entry.AccountID == acctID {
+			return entry, nil
+		}
+	}
+	return BundleEntryRestricted{}, errors.New("stellar account not found")
 }
 
 // Eq compares assets strictly.

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -173,6 +173,9 @@ func (r BundleRestricted) CheckInvariants() error {
 		if entry.Mode == AccountMode_NONE {
 			return errors.New("account missing mode")
 		}
+		if entry.AcctBundleRevision < 1 {
+			return fmt.Errorf("account bundle revision %v < 1 for %v", entry.AcctBundleRevision, entry.AccountID)
+		}
 	}
 	if !foundPrimary && len(r.Accounts) > 0 {
 		return errors.New("missing primary account")
@@ -183,9 +186,6 @@ func (r BundleRestricted) CheckInvariants() error {
 	for accID, accBundle := range r.AccountBundles {
 		if accID != accBundle.AccountID {
 			return fmt.Errorf("account ID mismatch in bundle for %v", accID)
-		}
-		if accBundle.Revision < 1 {
-			return fmt.Errorf("account bundle revision %v < 1 for %v", r.Revision, accID)
 		}
 	}
 	return nil

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -141,7 +141,7 @@ func (s Bundle) CheckInvariants() error {
 			return errors.New("account missing mode")
 		}
 	}
-	if !foundPrimary && len(s.Accounts) > 0 {
+	if !foundPrimary {
 		return errors.New("missing primary account")
 	}
 	if s.Revision < 1 {
@@ -177,7 +177,7 @@ func (r BundleRestricted) CheckInvariants() error {
 			return fmt.Errorf("account bundle revision %v < 1 for %v", entry.AcctBundleRevision, entry.AccountID)
 		}
 	}
-	if !foundPrimary && len(r.Accounts) > 0 {
+	if !foundPrimary {
 		return errors.New("missing primary account")
 	}
 	if r.Revision < 1 {

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -120,7 +120,8 @@ func (s SecretKey) SecureNoLogString() string {
 
 // CheckInvariants checks that the bundle satisfies
 // 1. No duplicate account IDs
-// 2. At most one primary account
+// 2. Exactly one primary account
+// 3. Non-negative revision numbers
 func (s Bundle) CheckInvariants() error {
 	accountIDs := make(map[AccountID]bool)
 	var foundPrimary bool
@@ -140,6 +141,9 @@ func (s Bundle) CheckInvariants() error {
 			return errors.New("account missing mode")
 		}
 	}
+	if !foundPrimary && len(s.Accounts) > 0 {
+		return errors.New("missing primary account")
+	}
 	if s.Revision < 1 {
 		return fmt.Errorf("revision %v < 1", s.Revision)
 	}
@@ -148,8 +152,9 @@ func (s Bundle) CheckInvariants() error {
 
 // CheckInvariants checks that the BundleRestricted satisfies
 // 1. No duplicate account IDs
-// 2. At most one primary account
+// 2. Exactly one primary account
 // 3. Non-negative revision numbers
+// 4. Account Bundle maps to Accounts
 func (r BundleRestricted) CheckInvariants() error {
 	accountIDs := make(map[AccountID]bool)
 	var foundPrimary bool
@@ -168,6 +173,9 @@ func (r BundleRestricted) CheckInvariants() error {
 		if entry.Mode == AccountMode_NONE {
 			return errors.New("account missing mode")
 		}
+	}
+	if !foundPrimary && len(r.Accounts) > 0 {
+		return errors.New("missing primary account")
 	}
 	if r.Revision < 1 {
 		return fmt.Errorf("revision %v < 1", r.Revision)

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -1024,7 +1024,7 @@ type LocalInterface interface {
 	RecentPaymentsCLILocal(context.Context, *AccountID) ([]PaymentOrErrorCLILocal, error)
 	PaymentDetailCLILocal(context.Context, string) (PaymentCLILocal, error)
 	WalletInitLocal(context.Context) error
-	WalletDumpLocal(context.Context) (Bundle, error)
+	WalletDumpLocal(context.Context) (BundleRestricted, error)
 	WalletGetAccountsCLILocal(context.Context) ([]OwnAccountCLILocal, error)
 	OwnAccountLocal(context.Context, AccountID) (bool, error)
 	ImportSecretKeyLocal(context.Context, ImportSecretKeyLocalArg) error
@@ -1961,7 +1961,7 @@ func (c LocalClient) WalletInitLocal(ctx context.Context) (err error) {
 	return
 }
 
-func (c LocalClient) WalletDumpLocal(ctx context.Context) (res Bundle, err error) {
+func (c LocalClient) WalletDumpLocal(ctx context.Context) (res BundleRestricted, err error) {
 	err = c.Cli.Call(ctx, "stellar.1.local.walletDumpLocal", []interface{}{WalletDumpLocalArg{}}, &res)
 	return
 }

--- a/go/stellar/acctbundle/acctbundle.go
+++ b/go/stellar/acctbundle/acctbundle.go
@@ -24,7 +24,7 @@ func New(secret stellar1.SecretKey, name string) (*stellar1.BundleRestricted, er
 	return &stellar1.BundleRestricted{
 		Revision: 1,
 		Accounts: []stellar1.BundleEntryRestricted{
-			newEntry(accountID, name, false),
+			newEntry(accountID, name, false, stellar1.AccountMode_USER),
 		},
 		AccountBundles: map[stellar1.AccountID]stellar1.AccountBundle{
 			accountID: newAccountBundle(accountID, secretKey),
@@ -62,24 +62,56 @@ func NewFromBundle(bundle stellar1.Bundle) (*stellar1.BundleRestricted, error) {
 	}
 	r.Accounts = make([]stellar1.BundleEntryRestricted, len(bundle.Accounts))
 	for i, acct := range bundle.Accounts {
-		r.Accounts[i] = newEntry(acct.AccountID, acct.Name, acct.IsPrimary)
+		r.Accounts[i] = newEntry(acct.AccountID, acct.Name, acct.IsPrimary, acct.Mode)
 		r.AccountBundles[acct.AccountID] = stellar1.AccountBundle{
 			Revision:  1,
 			AccountID: acct.AccountID,
 			Signers:   acct.Signers,
 		}
 	}
+	if err := r.CheckInvariants(); err != nil {
+		return nil, err
+	}
 	return r, nil
 }
 
-func newEntry(accountID stellar1.AccountID, name string, isPrimary bool) stellar1.BundleEntryRestricted {
+func newEntry(accountID stellar1.AccountID, name string, isPrimary bool, mode stellar1.AccountMode) stellar1.BundleEntryRestricted {
 	return stellar1.BundleEntryRestricted{
 		AccountID:          accountID,
 		Name:               name,
-		Mode:               stellar1.AccountMode_USER,
+		Mode:               mode,
 		IsPrimary:          isPrimary,
 		AcctBundleRevision: 1,
 	}
+}
+
+// BundleFromBundleRestricted is part of the migration strategy to move from Bundles to
+// BundleRestricteds. This should only ever be used as close to the interface with the server
+// as possible: i.e. methods that start with `Post` or `Fetch`.
+func BundleFromBundleRestricted(br stellar1.BundleRestricted) (*stellar1.Bundle, error) {
+	bundle := &stellar1.Bundle{
+		Revision: br.Revision,
+		Prev:     br.Prev,
+		OwnHash:  br.OwnHash,
+	}
+	if bundle.Revision > 1 && (bundle.Prev == nil || len(bundle.Prev) == 0) {
+		return nil, fmt.Errorf("BundleFromBundleRestricted missing Prev: %+v", br)
+	}
+	bundle.Accounts = make([]stellar1.BundleEntry, len(br.Accounts))
+	for i, acct := range br.Accounts {
+		signers := br.AccountBundles[acct.AccountID].Signers
+		bundle.Accounts[i] = stellar1.BundleEntry{
+			AccountID: acct.AccountID,
+			Name:      acct.Name,
+			Mode:      acct.Mode,
+			IsPrimary: acct.IsPrimary,
+			Signers:   signers,
+		}
+	}
+	if err := bundle.CheckInvariants(); err != nil {
+		return nil, err
+	}
+	return bundle, nil
 }
 
 func newAccountBundle(accountID stellar1.AccountID, secretKey stellar1.SecretKey) stellar1.AccountBundle {
@@ -674,4 +706,104 @@ func merge(secret stellar1.BundleSecretV2, visible stellar1.BundleVisibleV2) (st
 		Prev:     visible.Prev,
 		Accounts: accounts,
 	}, nil
+}
+
+// AdvanceBundle only advances the revisions and hashes on the BundleRestricted
+// and not on the accounts. This is useful for adding and removing accounts
+// but not for changing them.
+func AdvanceBundle(prevBundle stellar1.BundleRestricted) stellar1.BundleRestricted {
+	nextBundle := prevBundle.DeepCopy()
+	nextBundle.Prev = nextBundle.OwnHash
+	nextBundle.OwnHash = nil
+	nextBundle.Revision++
+	return nextBundle
+}
+
+// advanceOneAccount mutates the passed in bundleRestricted in place
+func advanceOneAccount(b *stellar1.BundleRestricted, accountID stellar1.AccountID) error {
+	for _, account := range b.Accounts {
+		if account.AccountID.Eq(accountID) {
+			account.AcctBundleRevision++
+			return nil
+		}
+	}
+	return fmt.Errorf("account not found: %v", accountID)
+}
+
+// AdvanceAccounts advances the revisions and hashes on the BundleRestricted
+// as well as on the specified Accounts. This is useful for mutating one or more
+// of the accounts in the bundle, e.g. changing which one is Primary.
+func AdvanceAccounts(prevBundle stellar1.BundleRestricted, accountIDs []stellar1.AccountID) (stellar1.BundleRestricted, error) {
+	nextBundle := AdvanceBundle(prevBundle)
+	for _, accountID := range accountIDs {
+		err := advanceOneAccount(&nextBundle, accountID)
+		if err != nil {
+			return stellar1.BundleRestricted{}, err
+		}
+	}
+	return nextBundle, nil
+}
+
+// AdvanceAll advances the revisions and hashes on the BundleRestricted
+// as well as on all of the Accounts. This is useful for reencryption of
+// everything, e.g. Upkeep.
+func AdvanceAll(prevBundle stellar1.BundleRestricted) stellar1.BundleRestricted {
+	nextBundle := AdvanceBundle(prevBundle)
+	for _, account := range nextBundle.Accounts {
+		account.AcctBundleRevision++
+	}
+	return nextBundle
+}
+
+// AddAccount adds an account to the bundle. Mutates `bundle`.
+func AddAccount(bundle *stellar1.BundleRestricted, secretKey stellar1.SecretKey, name string, makePrimary bool) (err error) {
+	if bundle == nil {
+		return fmt.Errorf("nil bundle")
+	}
+	secretKey, accountID, _, err := libkb.ParseStellarSecretKey(string(secretKey))
+	if err != nil {
+		return err
+	}
+	if name == "" {
+		return fmt.Errorf("Name required for new account")
+	}
+	if makePrimary {
+		for i := range bundle.Accounts {
+			bundle.Accounts[i].IsPrimary = false
+		}
+	}
+	bundle.Accounts = append(bundle.Accounts, stellar1.BundleEntryRestricted{
+		AccountID:          accountID,
+		Mode:               stellar1.AccountMode_USER,
+		IsPrimary:          makePrimary,
+		AcctBundleRevision: 1,
+		Name:               name,
+	})
+	bundle.AccountBundles[accountID] = stellar1.AccountBundle{
+		Revision:  1,
+		AccountID: accountID,
+		Signers:   []stellar1.SecretKey{secretKey},
+	}
+	return bundle.CheckInvariants()
+}
+
+// CreateNewAccount generates a Stellar key pair and adds it to the
+// bundle. Mutates `bundle`.
+func CreateNewAccount(bundle *stellar1.BundleRestricted, name string, makePrimary bool) (pub stellar1.AccountID, err error) {
+	accountID, masterKey, err := randomStellarKeypair()
+	if err != nil {
+		return pub, err
+	}
+	if err := AddAccount(bundle, masterKey, name, makePrimary); err != nil {
+		return pub, err
+	}
+	return accountID, nil
+}
+
+func randomStellarKeypair() (pub stellar1.AccountID, sec stellar1.SecretKey, err error) {
+	full, err := keypair.Random()
+	if err != nil {
+		return pub, sec, err
+	}
+	return stellar1.AccountID(full.Address()), stellar1.SecretKey(full.Seed()), nil
 }

--- a/go/stellar/acctbundle/acctbundle.go
+++ b/go/stellar/acctbundle/acctbundle.go
@@ -314,28 +314,21 @@ var ErrNoChangeNecessary = errors.New("no account mode change is necessary")
 // bundle.  This advances the revision.  If it's already mobile-only,
 // this function will return ErrNoChangeNecessary.
 func MakeMobileOnly(a *stellar1.BundleRestricted, accountID stellar1.AccountID) error {
-	ws, err := AccountWithSecret(a, accountID)
-	if err != nil {
-		return err
-	}
-	if ws.Mode == stellar1.AccountMode_MOBILE {
-		return ErrNoChangeNecessary
-	}
-	a.Revision++
-	a.Prev = a.OwnHash
-	a.OwnHash = nil
-
-	for i, vis := range a.Accounts {
-		if vis.AccountID == accountID {
-			if vis.Mode == stellar1.AccountMode_MOBILE {
+	var found bool
+	for i, account := range a.Accounts {
+		if account.AccountID == accountID {
+			if account.Mode == stellar1.AccountMode_MOBILE {
 				return ErrNoChangeNecessary
 			}
-			vis.Mode = stellar1.AccountMode_MOBILE
-			vis.AcctBundleRevision++
-			a.Accounts[i] = vis
+			account.Mode = stellar1.AccountMode_MOBILE
+			a.Accounts[i] = account
+			found = true
+			break
 		}
 	}
-
+	if !found {
+		return libkb.NotFoundError{}
+	}
 	return nil
 }
 
@@ -343,28 +336,21 @@ func MakeMobileOnly(a *stellar1.BundleRestricted, accountID stellar1.AccountID) 
 // bundle.  This advances the revision.  If it's already all-device,
 // this function will return ErrNoChangeNecessary.
 func MakeAllDevices(a *stellar1.BundleRestricted, accountID stellar1.AccountID) error {
-	ws, err := AccountWithSecret(a, accountID)
-	if err != nil {
-		return err
-	}
-	if ws.Mode == stellar1.AccountMode_USER {
-		return ErrNoChangeNecessary
-	}
-	a.Revision++
-	a.Prev = a.OwnHash
-	a.OwnHash = nil
-
-	for i, vis := range a.Accounts {
-		if vis.AccountID == accountID {
-			if vis.Mode == stellar1.AccountMode_USER {
+	var found bool
+	for i, account := range a.Accounts {
+		if account.AccountID == accountID {
+			if account.Mode == stellar1.AccountMode_USER {
 				return ErrNoChangeNecessary
 			}
-			vis.Mode = stellar1.AccountMode_USER
-			vis.AcctBundleRevision++
-			a.Accounts[i] = vis
+			account.Mode = stellar1.AccountMode_USER
+			a.Accounts[i] = account
+			found = true
+			break
 		}
 	}
-
+	if !found {
+		return libkb.NotFoundError{}
+	}
 	return nil
 }
 

--- a/go/stellar/acctbundle/acctbundle.go
+++ b/go/stellar/acctbundle/acctbundle.go
@@ -64,7 +64,6 @@ func NewFromBundle(bundle stellar1.Bundle) (*stellar1.BundleRestricted, error) {
 	for i, acct := range bundle.Accounts {
 		r.Accounts[i] = newEntry(acct.AccountID, acct.Name, acct.IsPrimary, acct.Mode)
 		r.AccountBundles[acct.AccountID] = stellar1.AccountBundle{
-			Revision:  1,
 			AccountID: acct.AccountID,
 			Signers:   acct.Signers,
 		}
@@ -116,7 +115,6 @@ func BundleFromBundleRestricted(br stellar1.BundleRestricted) (*stellar1.Bundle,
 
 func newAccountBundle(accountID stellar1.AccountID, secretKey stellar1.SecretKey) stellar1.AccountBundle {
 	return stellar1.AccountBundle{
-		Revision:  1,
 		AccountID: accountID,
 		Signers:   []stellar1.SecretKey{secretKey},
 	}
@@ -416,7 +414,6 @@ func decodeAndUnboxAcctBundle(m libkb.MetaContext, finder PukFinder, encB64 stri
 	if ab.AccountID != parentEntry.AccountID {
 		return nil, errors.New("account bundle and parent entry account ID mismatch")
 	}
-	ab.Revision = parentEntry.AcctBundleRevision
 
 	return ab, nil
 }
@@ -774,7 +771,6 @@ func AddAccount(bundle *stellar1.BundleRestricted, secretKey stellar1.SecretKey,
 		Name:               name,
 	})
 	bundle.AccountBundles[accountID] = stellar1.AccountBundle{
-		Revision:  1,
 		AccountID: accountID,
 		Signers:   []stellar1.SecretKey{secretKey},
 	}

--- a/go/stellar/acctbundle/acctbundle.go
+++ b/go/stellar/acctbundle/acctbundle.go
@@ -99,6 +99,12 @@ func BundleFromBundleRestricted(br stellar1.BundleRestricted) (*stellar1.Bundle,
 	bundle.Accounts = make([]stellar1.BundleEntry, len(br.Accounts))
 	for i, acct := range br.Accounts {
 		signers := br.AccountBundles[acct.AccountID].Signers
+		if len(signers) != 1 {
+			return nil, fmt.Errorf("BundleFromBundleRestricted missing signer for %v", acct.AccountID)
+		}
+		if acct.Mode != stellar1.AccountMode_USER {
+			return nil, fmt.Errorf("BundleFromBundleRestricted account %v doesnt have mode USER", acct.AccountID)
+		}
 		bundle.Accounts[i] = stellar1.BundleEntry{
 			AccountID: acct.AccountID,
 			Name:      acct.Name,

--- a/go/stellar/acctbundle/acctbundle_test.go
+++ b/go/stellar/acctbundle/acctbundle_test.go
@@ -43,12 +43,13 @@ func TestBoxAccountBundle(t *testing.T) {
 	require.Len(t, boxed.AcctBundles, 1)
 
 	m := libkb.NewMetaContext(context.Background(), nil)
-	bundle, version, err := DecodeAndUnbox(m, ring, boxed.toBundleEncodedB64())
+	bundle, version, pukGen, err := DecodeAndUnbox(m, ring, boxed.toBundleEncodedB64())
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 	require.Equal(t, stellar1.BundleVersion_V2, version)
 	require.Len(t, bundle.Accounts, 1)
 	require.Equal(t, stellar1.AccountMode_USER, bundle.Accounts[0].Mode)
+	require.Equal(t, pukGen, keybase1.PerUserKeyGeneration(1))
 	acctBundle, ok := bundle.AccountBundles[bundle.Accounts[0].AccountID]
 	require.True(t, ok)
 	acctBundleOriginal, ok := b.AccountBundles[bundle.Accounts[0].AccountID]

--- a/go/stellar/bundle/boxer_test.go
+++ b/go/stellar/bundle/boxer_test.go
@@ -108,7 +108,7 @@ func TestBundlePrevs(t *testing.T) {
 
 	bundle3src := bundle1.DeepCopy()
 	bundle3src.Prev = bundle2.OwnHash
-	bundle3src.Accounts[0].IsPrimary = false
+	bundle3src.Accounts[0].Name = "pettycash"
 	res3, err := Box(bundle3src, pukGen2, puk2)
 	require.NoError(t, err)
 
@@ -116,7 +116,7 @@ func TestBundlePrevs(t *testing.T) {
 	require.NoError(t, err)
 	bundle3, _, err := Unbox(nil, enc3, res3.VisB64, puk2)
 	require.NoError(t, err)
-	require.False(t, bundle3.Accounts[0].IsPrimary, "account should not be primary")
+	require.Equal(t, bundle3.Accounts[0].Name, "pettycash")
 	require.Equal(t, bundle2.OwnHash, bundle3.Prev, "bundle 3 should prev bundle 2")
 }
 

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -44,6 +44,8 @@ type Stellar struct {
 	disclaimerLock     sync.Mutex
 	disclaimerAccepted *keybase1.UserVersion // A UV who has accepted the disclaimer.
 
+	migrationLock sync.Mutex
+
 	badger *badges.Badger
 }
 
@@ -93,6 +95,10 @@ func (s *Stellar) deleteDisclaimer() {
 	s.disclaimerLock.Lock()
 	defer s.disclaimerLock.Unlock()
 	s.disclaimerAccepted = nil
+}
+
+func (s *Stellar) GetMigrationLock() *sync.Mutex {
+	return &s.migrationLock
 }
 
 func (s *Stellar) GetServerDefinitions(ctx context.Context) (ret stellar1.StellarServerDefinitions, err error) {

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -37,6 +37,14 @@ func ShouldCreate(ctx context.Context, g *libkb.GlobalContext) (res ShouldCreate
 	return apiRes.ShouldCreateResult, err
 }
 
+func acctBundlesEnabled(m libkb.MetaContext) bool {
+	enabled := m.G().FeatureFlags.Enabled(m, libkb.FeatureStellarAcctBundles)
+	if enabled {
+		m.CDebugf("stellar account bundles enabled")
+	}
+	return enabled
+}
+
 // Post a bundle to the server with a chainlink.
 func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle stellar1.BundleRestricted) (err error) {
 	defer g.CTraceTimed(ctx, "Stellar.PostWithChainlink", func() error { return err })()
@@ -243,6 +251,9 @@ type fetchAcctRes struct {
 // Fetch and unbox the latest bundle from the server.
 func Fetch(ctx context.Context, g *libkb.GlobalContext) (res stellar1.BundleRestricted, pukGen keybase1.PerUserKeyGeneration, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.Fetch", func() error { return err })()
+
+	_ = acctBundlesEnabled(libkb.NewMetaContext(ctx, g))
+
 	arg := libkb.NewAPIArgWithNetContext(ctx, "stellar/bundle")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	var apiRes fetchRes

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -376,8 +376,8 @@ func postMigrationChecks(m libkb.MetaContext, preMigrationBundle stellar1.Bundle
 func MigrateBundleToAccountBundles(m libkb.MetaContext) (err error) {
 	defer m.CTrace(fmt.Sprintf("Stellar MigrateBundleToAccountBundles"), func() error { return err })()
 
-	defer m.G().StellarBundleMu.Unlock()
-	m.G().StellarBundleMu.Lock()
+	defer m.G().GetStellar().GetMigrationLock().Unlock()
+	m.G().GetStellar().GetMigrationLock().Lock()
 	m.CDebugf("| Acquired Stellar Bundle Migration mutex")
 
 	if err = preMigrationChecks(m); err != nil {

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -210,11 +210,7 @@ func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle 
 	return nil
 }
 
-// Post a bundle to the server.
-func Post(ctx context.Context, g *libkb.GlobalContext, clearBundle stellar1.BundleRestricted) (err error) {
-	defer g.CTraceTimed(ctx, "Stellar.Post", func() error { return err })()
-	v1Bundle, err := acctbundle.BundleFromBundleRestricted(clearBundle)
-
+func PostV1Bundle(ctx context.Context, g *libkb.GlobalContext, v1Bundle stellar1.Bundle) (err error) {
 	pukGen, pukSeed, err := getLatestPuk(ctx, g)
 	if err != nil {
 		return err
@@ -224,7 +220,7 @@ func Post(ctx context.Context, g *libkb.GlobalContext, clearBundle stellar1.Bund
 		return err
 	}
 	g.Log.CDebugf(ctx, "Stellar.Post: revision:%v", v1Bundle.Revision)
-	boxed, err := bundle.Box(*v1Bundle, pukGen, pukSeed)
+	boxed, err := bundle.Box(v1Bundle, pukGen, pukSeed)
 	if err != nil {
 		return err
 	}
@@ -237,6 +233,203 @@ func Post(ctx context.Context, g *libkb.GlobalContext, clearBundle stellar1.Bund
 		JSONPayload: payload,
 	})
 	return err
+}
+
+// Post a bundle to the server.
+func Post(ctx context.Context, g *libkb.GlobalContext, clearBundle stellar1.BundleRestricted) (err error) {
+	defer g.CTraceTimed(ctx, "Stellar.Post", func() error { return err })()
+	v1Bundle, err := acctbundle.BundleFromBundleRestricted(clearBundle)
+	return PostV1Bundle(ctx, g, *v1Bundle)
+}
+
+type AlreadyMigratedError struct{}
+
+func (e AlreadyMigratedError) Error() string {
+	return fmt.Sprintf("this bundle is already accessible from v2 endpoints")
+}
+
+type MissingFeatureFlagMigrationError struct{}
+
+func (e MissingFeatureFlagMigrationError) Error() string {
+	return fmt.Sprintf("need FeatureStellarAcctBundles to migrate")
+}
+
+func preMigrationChecks(m libkb.MetaContext) error {
+	// verify that the feature flag is enabled
+	if !acctBundlesEnabled(m) {
+		return MissingFeatureFlagMigrationError{}
+	}
+
+	// verify that fetching a v2 bundle raises an incompatibility error
+	// because there is a bundle to fetch but it has not been migrated
+	// this is what we're expecting for an account that has not yet
+	// been migrated
+	existingBundle, _, err := FetchSecretlessBundle(m.Ctx(), m.G())
+	expectedErrorStatus := keybase1.StatusCode_SCStellarIncompatibleVersion
+	if err == nil {
+		return AlreadyMigratedError{}
+	}
+	if appStatusError, ok := err.(libkb.AppStatusError); ok {
+		actualErrorStatus := keybase1.StatusCode(appStatusError.Code)
+		if actualErrorStatus != expectedErrorStatus {
+			return err
+		}
+	} else {
+		return err
+	}
+	if existingBundle != nil {
+		// this should never happen
+		return errors.New("non null v2 bundle accessible before migrating")
+	}
+	return nil
+}
+
+func postMigrationChecks(m libkb.MetaContext, preMigrationBundle stellar1.Bundle) (err error) {
+	defer m.CTrace(fmt.Sprintf("Stellar postMigrationChecks"), func() error { return err })()
+
+	// verify that the post-migration account bundle matches the
+	// pre-migration bundle for each account
+	for _, preMigrationAcct := range preMigrationBundle.Accounts {
+		acctBundle, _, err := FetchAccountBundle(m.Ctx(), m.G(), preMigrationAcct.AccountID)
+		if err != nil {
+			return err
+		}
+		var postMigrationAcct stellar1.BundleEntryRestricted
+		for _, acct := range acctBundle.Accounts {
+			if acct.AccountID == preMigrationAcct.AccountID {
+				postMigrationAcct = acct
+			}
+		}
+		if postMigrationAcct.AccountID != preMigrationAcct.AccountID {
+			err = fmt.Errorf("account_id mismatch. pre (%v) isnt post (%v)", preMigrationAcct.AccountID, postMigrationAcct.AccountID)
+			m.CErrorf("post migration check:", err)
+			return err
+		}
+		if postMigrationAcct.Mode != preMigrationAcct.Mode {
+			err = fmt.Errorf("mode mismatch for %v. pre (%v) isnt post (%v)", preMigrationAcct.AccountID, preMigrationAcct.Mode, postMigrationAcct.Mode)
+			m.CErrorf("post migration check:", err)
+			return err
+		}
+		if postMigrationAcct.Name != preMigrationAcct.Name {
+			err = fmt.Errorf("name mismatch for %v. pre (%v) isnt post (%v)", preMigrationAcct.AccountID, preMigrationAcct.Name, postMigrationAcct.Name)
+			m.CErrorf("post migration check:", err)
+			return err
+		}
+		postMigrationSigners := acctBundle.AccountBundles[postMigrationAcct.AccountID].Signers
+		if len(postMigrationSigners) != len(preMigrationAcct.Signers) {
+			err = fmt.Errorf("signers mismatch for %v", preMigrationAcct.AccountID)
+			m.CErrorf("post migration check:", err)
+			return err
+		}
+		for i, s := range postMigrationSigners {
+			if preMigrationAcct.Signers[i] != s {
+				err = fmt.Errorf("signers mismatch for %v", preMigrationAcct.AccountID)
+				m.CErrorf("post migration check:", err)
+				return err
+			}
+		}
+	}
+
+	// verify that fetching a v1 bundle raises an incompatibility error
+	_, _, err = FetchV1Bundle(m.Ctx(), m.G())
+	expectedErrorStatus := keybase1.StatusCode_SCStellarIncompatibleVersion
+	if err == nil {
+		err = fmt.Errorf("expected v1 endpoints to be inaccessible")
+		m.CErrorf("post migration check:", err)
+		return err
+	}
+	if appStatusError, ok := err.(libkb.AppStatusError); ok {
+		actualErrorStatus := keybase1.StatusCode(appStatusError.Code)
+		if actualErrorStatus != expectedErrorStatus {
+			m.CErrorf("post migration check fetching the v1 bundle:", err)
+			return err
+		}
+	} else {
+		m.CErrorf("post migration check fetching the v1 bundle:", err)
+		return err
+	}
+	return nil
+}
+
+// MigrateBundleToAccountBundles migrates the existing stellar bundle that
+// contains all secrets to separate account bundles for each account.
+func MigrateBundleToAccountBundles(m libkb.MetaContext) (err error) {
+	defer m.CTrace(fmt.Sprintf("Stellar MigrateBundleToAccountBundles"), func() error { return err })()
+
+	if err = preMigrationChecks(m); err != nil {
+		m.CErrorf("MIGRATION FAILED: failed premigration checks: %v\n", err)
+		return err
+	}
+	// fetch the v1 bundle
+	v1Bundle, _, err := FetchV1Bundle(m.Ctx(), m.G())
+	if err != nil {
+		m.CErrorf("MIGRATION FAILED: failed to fetch v1Bundle", err)
+		return err
+	}
+	m.CDebugf("fetched v1 bundle with %v accounts", len(v1Bundle.Accounts))
+
+	err = v1Bundle.CheckInvariants()
+	if err != nil {
+		m.CErrorf("MIGRATION FAILED: v1Bundle failed invariant checks", err)
+		return err
+	}
+	m.CDebugf("v1 bundle passed basic invariant check")
+
+	// convert it to a v2 bundle
+	// since this is an initial conversion, all of the accounts
+	// in this bundle should have signers
+	v2BundlePrev, err := acctbundle.NewFromBundle(v1Bundle)
+	if err != nil {
+		return err
+	}
+	m.CDebugf("v1 bundle mutated into v2 bundle with %v accounts", len(v2BundlePrev.Accounts))
+	err = v2BundlePrev.CheckInvariants()
+	if err != nil {
+		m.CErrorf("MIGRATION FAILED: v2BundlePrev failed invariant checks", err)
+		return err
+	}
+	m.CDebugf("v2 bundle passed basic invariant check")
+
+	// verify that all of the signers are part of this migratable bundle
+	for _, acct := range v2BundlePrev.Accounts {
+		accBundle, ok := v2BundlePrev.AccountBundles[acct.AccountID]
+		if !ok {
+			err = fmt.Errorf("in local conversion to a v2 bundle, account %v not found in account bundle map", acct.AccountID)
+			m.CErrorf("MIGRATION FAILED: %v\n", err)
+			return err
+		}
+		secretKey := accBundle.Signers[0]
+		if len(secretKey) == 0 {
+			err = fmt.Errorf("in local conversion to a v2 bundle, account %v missing signers", acct.AccountID)
+			m.CErrorf("MIGRATION FAILED: %v\n", err)
+			return err
+		}
+	}
+	m.CDebugf("v2 bundle passed other checks")
+
+	v2Bundle := acctbundle.AdvanceBundle(*v2BundlePrev)
+	err = v2Bundle.CheckInvariants()
+	if err != nil {
+		m.CErrorf("MIGRATION FAILED: v2Bundle failed invariant checks", err)
+		return err
+	}
+	m.CInfof("Passed all premigration checks. Posting the migrated bundle...")
+
+	err = PostBundleRestricted(m.Ctx(), m.G(), &v2Bundle)
+	if err != nil {
+		m.CErrorf("MIGRATION FAILED: posting v2 bundle %v\n", err)
+		return err
+	}
+	m.CInfof("v2 bundle has been posted and the migration might not be retryable")
+
+	// check if all the account bundles match the bundle entries
+	if err := postMigrationChecks(m, v1Bundle); err != nil {
+		m.CErrorf("MIGRATION FAILED: %v\n", err)
+		return err
+	}
+	m.CInfof("Passed all post-migration checks")
+
+	return nil
 }
 
 // PostBundleRestricted encrypts and uploads a restricted bundle to the server.
@@ -332,7 +525,7 @@ type fetchAcctRes struct {
 	acctbundle.BundleEncoded
 }
 
-func fetchV1Bundle(ctx context.Context, g *libkb.GlobalContext) (res stellar1.Bundle, pukGen keybase1.PerUserKeyGeneration, err error) {
+func FetchV1Bundle(ctx context.Context, g *libkb.GlobalContext) (res stellar1.Bundle, pukGen keybase1.PerUserKeyGeneration, err error) {
 	arg := libkb.NewAPIArgWithNetContext(ctx, "stellar/bundle")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	var apiRes fetchRes
@@ -344,6 +537,8 @@ func fetchV1Bundle(ctx context.Context, g *libkb.GlobalContext) (res stellar1.Bu
 		case keybase1.StatusCode_SCNotFound:
 			g.Log.CDebugf(ctx, "replacing error: %v", err)
 			return res, 0, UserHasNoAccountsError{}
+		default:
+			return res, 0, err
 		}
 	default:
 		return res, 0, err
@@ -374,7 +569,7 @@ func Fetch(ctx context.Context, g *libkb.GlobalContext) (res stellar1.BundleRest
 
 	_ = acctBundlesEnabled(libkb.NewMetaContext(ctx, g))
 
-	v1Bundle, pukGen, err := fetchV1Bundle(ctx, g)
+	v1Bundle, pukGen, err := FetchV1Bundle(ctx, g)
 	if err != nil {
 		return res, 0, err
 	}

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -242,10 +242,16 @@ func PostV1Bundle(ctx context.Context, g *libkb.GlobalContext, v1Bundle stellar1
 }
 
 // Post a bundle to the server.
-func Post(ctx context.Context, g *libkb.GlobalContext, clearBundle stellar1.BundleRestricted) (err error) {
+func Post(ctx context.Context, g *libkb.GlobalContext, clearBundle stellar1.BundleRestricted, version stellar1.BundleVersion) (err error) {
 	defer g.CTraceTimed(ctx, "Stellar.Post", func() error { return err })()
-	v1Bundle, err := acctbundle.BundleFromBundleRestricted(clearBundle)
-	return PostV1Bundle(ctx, g, *v1Bundle)
+	if version == stellar1.BundleVersion_V1 {
+		v1Bundle, err := acctbundle.BundleFromBundleRestricted(clearBundle)
+		if err != nil {
+			return err
+		}
+		return PostV1Bundle(ctx, g, *v1Bundle)
+	}
+	return PostBundleRestricted(ctx, g, &clearBundle)
 }
 
 type AlreadyMigratedError struct{}

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -546,7 +546,7 @@ func FetchSecretlessBundle(ctx context.Context, g *libkb.GlobalContext) (acctBun
 		newAccountBundles := make(map[stellar1.AccountID]stellar1.AccountBundle)
 		for accountID, ab := range acctBundle.AccountBundles {
 			newAb := ab.DeepCopy()
-			newAb.Signers = []stellar1.SecretKey{}
+			newAb.Signers = nil
 			newAccountBundles[accountID] = newAb
 		}
 		acctBundle.AccountBundles = newAccountBundles

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -505,6 +505,9 @@ func incompatibleVersionError(inputError error) bool {
 // but without any specified AccountID and therefore no secrets (signers)
 func FetchSecretlessBundle(ctx context.Context, g *libkb.GlobalContext) (acctBundle *stellar1.BundleRestricted, version stellar1.BundleVersion, pukGen keybase1.PerUserKeyGeneration, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.FetchSecretlessBundle", func() error { return err })()
+
+	_ = acctBundlesEnabled(libkb.NewMetaContext(ctx, g))
+
 	acctBundle, version, pukGen, err = FetchV2BundleWithArgs(ctx, g, libkb.HTTPArgs{})
 	if err != nil && incompatibleVersionError(err) {
 		g.Log.CDebugf(ctx, "requested v2 secretless bundle but not migrated yet. replacing with v1.")
@@ -530,6 +533,9 @@ func FetchSecretlessBundle(ctx context.Context, g *libkb.GlobalContext) (acctBun
 // to all of the accounts (e.g. a desktop after mobile-only)
 func FetchWholeBundle(ctx context.Context, g *libkb.GlobalContext) (acctBundle *stellar1.BundleRestricted, version stellar1.BundleVersion, pukGen keybase1.PerUserKeyGeneration, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.FetchWholeBundle", func() error { return err })()
+
+	_ = acctBundlesEnabled(libkb.NewMetaContext(ctx, g))
+
 	bundle, version, pukGen, err := FetchSecretlessBundle(ctx, g)
 	if err != nil {
 		return nil, 0, 0, err
@@ -550,6 +556,8 @@ func FetchWholeBundle(ctx context.Context, g *libkb.GlobalContext) (acctBundle *
 // FetchAccountBundle gets an account bundle from the server and decrypts it.
 func FetchAccountBundle(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (acctBundle *stellar1.BundleRestricted, version stellar1.BundleVersion, pukGen keybase1.PerUserKeyGeneration, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.FetchAccountBundle", func() error { return err })()
+
+	_ = acctBundlesEnabled(libkb.NewMetaContext(ctx, g))
 
 	fetchArgs := libkb.HTTPArgs{"account_id": libkb.S{Val: string(accountID)}}
 	acctBundle, version, pukGen, err = FetchV2BundleWithArgs(ctx, g, fetchArgs)
@@ -643,15 +651,6 @@ func fetchV1BundleAsV2Bundle(ctx context.Context, g *libkb.GlobalContext) (res *
 		return res, 0, 0, err
 	}
 	return accountBundle, version, pukGen, nil
-}
-
-// Fetch and unbox the latest bundle from the server.
-func Fetch(ctx context.Context, g *libkb.GlobalContext) (res *stellar1.BundleRestricted, version stellar1.BundleVersion, pukGen keybase1.PerUserKeyGeneration, err error) {
-	defer g.CTraceTimed(ctx, "Stellar.Fetch", func() error { return err })()
-
-	_ = acctBundlesEnabled(libkb.NewMetaContext(ctx, g))
-
-	return fetchV1BundleAsV2Bundle(ctx, g)
 }
 
 type seqnoResult struct {

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -45,7 +45,7 @@ func acctBundlesEnabled(m libkb.MetaContext) bool {
 	return enabled
 }
 
-func buildV2ChainLinkPayload(m libkb.MetaContext, bundle stellar1.BundleRestricted, me *libkb.User, pukGen keybase1.PerUserKeyGeneration, pukSeed libkb.PerUserKeySeed, sigKey libkb.GenericKey) (*libkb.JSONPayload, error) {
+func buildV2ChainLinkPayload(m libkb.MetaContext, bundle stellar1.BundleRestricted, me *libkb.User, pukGen keybase1.PerUserKeyGeneration, pukSeed libkb.PerUserKeySeed, deviceSigKey libkb.GenericKey) (*libkb.JSONPayload, error) {
 	err := bundle.CheckInvariants()
 	if err != nil {
 		return nil, err
@@ -75,13 +75,9 @@ func buildV2ChainLinkPayload(m libkb.MetaContext, bundle stellar1.BundleRestrict
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	m.CDebugf("Stellar.PostWithChainLink: make sigs")
 
-	sig, err := libkb.StellarProofReverseSigned(m, me, stellarAccount.AccountID, stellarAccountBundle.Signers[0], sigKey)
+	sig, err := libkb.StellarProofReverseSigned(m, me, stellarAccount.AccountID, stellarAccountBundle.Signers[0], deviceSigKey)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +97,7 @@ func buildV2ChainLinkPayload(m libkb.MetaContext, bundle stellar1.BundleRestrict
 	return &payload, nil
 }
 
-func buildV1ChainLinkPayload(m libkb.MetaContext, bundleRestricted stellar1.BundleRestricted, me *libkb.User, pukGen keybase1.PerUserKeyGeneration, pukSeed libkb.PerUserKeySeed, sigKey libkb.GenericKey) (*libkb.JSONPayload, error) {
+func buildV1ChainLinkPayload(m libkb.MetaContext, bundleRestricted stellar1.BundleRestricted, me *libkb.User, pukGen keybase1.PerUserKeyGeneration, pukSeed libkb.PerUserKeySeed, deviceSigKey libkb.GenericKey) (*libkb.JSONPayload, error) {
 	v1Bundle, err := acctbundle.BundleFromBundleRestricted(bundleRestricted)
 	if err != nil {
 		return nil, err
@@ -133,7 +129,7 @@ func buildV1ChainLinkPayload(m libkb.MetaContext, bundleRestricted stellar1.Bund
 
 	m.CDebugf("Stellar.PostWithChainLink: make sigs")
 
-	sig, err := libkb.StellarProofReverseSigned(m, me, stellarAccount.AccountID, stellarAccount.Signers[0], sigKey)
+	sig, err := libkb.StellarProofReverseSigned(m, me, stellarAccount.AccountID, stellarAccount.Signers[0], deviceSigKey)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +169,7 @@ func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle 
 		return err
 	}
 
-	sigKey, err := g.ActiveDevice.SigningKey()
+	deviceSigKey, err := g.ActiveDevice.SigningKey()
 	if err != nil {
 		return fmt.Errorf("signing key not found: (%v)", err)
 	}
@@ -184,12 +180,12 @@ func PostWithChainlink(ctx context.Context, g *libkb.GlobalContext, clearBundle 
 
 	var payload *libkb.JSONPayload
 	if v2Link {
-		payload, err = buildV2ChainLinkPayload(m, clearBundle, me, pukGen, pukSeed, sigKey)
+		payload, err = buildV2ChainLinkPayload(m, clearBundle, me, pukGen, pukSeed, deviceSigKey)
 		if err != nil {
 			return err
 		}
 	} else {
-		payload, err = buildV1ChainLinkPayload(m, clearBundle, me, pukGen, pukSeed, sigKey)
+		payload, err = buildV1ChainLinkPayload(m, clearBundle, me, pukGen, pukSeed, deviceSigKey)
 		if err != nil {
 			return err
 		}

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -251,7 +251,7 @@ func Post(ctx context.Context, g *libkb.GlobalContext, clearBundle stellar1.Bund
 		}
 		return PostV1Bundle(ctx, g, *v1Bundle)
 	}
-	return PostBundleRestricted(ctx, g, &clearBundle)
+	return postV2Bundle(ctx, g, &clearBundle)
 }
 
 type AlreadyMigratedError struct{}
@@ -427,7 +427,7 @@ func MigrateBundleToAccountBundles(m libkb.MetaContext) (err error) {
 	}
 	m.CInfof("Passed all premigration checks. Posting the migrated bundle...")
 
-	err = PostBundleRestricted(m.Ctx(), m.G(), &v2Bundle)
+	err = postV2Bundle(m.Ctx(), m.G(), &v2Bundle)
 	if err != nil {
 		m.CErrorf("MIGRATION FAILED: posting v2 bundle %v\n", err)
 		return err
@@ -444,9 +444,9 @@ func MigrateBundleToAccountBundles(m libkb.MetaContext) (err error) {
 	return nil
 }
 
-// PostBundleRestricted encrypts and uploads a restricted bundle to the server.
-func PostBundleRestricted(ctx context.Context, g *libkb.GlobalContext, bundle *stellar1.BundleRestricted) (err error) {
-	defer g.CTraceTimed(ctx, "Stellar.PostBundleRestricted", func() error { return err })()
+// postV2Bundle encrypts and uploads a restricted bundle to the server.
+func postV2Bundle(ctx context.Context, g *libkb.GlobalContext, bundle *stellar1.BundleRestricted) (err error) {
+	defer g.CTraceTimed(ctx, "Stellar.postV2Bundle", func() error { return err })()
 
 	pukGen, pukSeed, err := getLatestPuk(ctx, g)
 	if err != nil {
@@ -1113,8 +1113,8 @@ func SetAccountMobileOnly(ctx context.Context, g *libkb.GlobalContext, accountID
 	if err != nil {
 		return err
 	}
-	if err := PostBundleRestricted(ctx, g, bundle); err != nil {
-		g.Log.CDebugf(ctx, "SetAccountMobileOnly PostBundleRestricted error: %s", err)
+	if err := postV2Bundle(ctx, g, bundle); err != nil {
+		g.Log.CDebugf(ctx, "SetAccountMobileOnly postV2Bundle error: %s", err)
 		return err
 	}
 
@@ -1138,8 +1138,8 @@ func MakeAccountAllDevices(ctx context.Context, g *libkb.GlobalContext, accountI
 	if err != nil {
 		return err
 	}
-	if err := PostBundleRestricted(ctx, g, bundle); err != nil {
-		g.Log.CDebugf(ctx, "MakeAccountAllDevices PostBundleRestricted error: %s", err)
+	if err := postV2Bundle(ctx, g, bundle); err != nil {
+		g.Log.CDebugf(ctx, "MakeAccountAllDevices postV2Bundle error: %s", err)
 		return err
 	}
 

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -1088,11 +1088,6 @@ func MarkAsRead(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.
 	return g.API.PostDecode(apiArg, &res)
 }
 
-type isMobileResult struct {
-	libkb.AppStatusEmbed
-	MobileOnly int `json:"mobile_only"`
-}
-
 func IsAccountMobileOnly(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (bool, error) {
 	bundle, _, _, err := FetchSecretlessBundle(ctx, g)
 	if err != nil {

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -514,9 +514,11 @@ func incompatibleVersionError(inputError error) bool {
 }
 
 // FetchSecretlessBundle gets an account bundle from the server and decrypts it
-// but without any specified AccountID and therefore no secrets (signers)
-// if the FeatureStellarAcctBundles is true and the user is still on a v1 bundle,
-// this method will call `MigrateBundleToAccountBundles` and then fetch again.
+// but without any specified AccountID and therefore no secrets (signers).
+// This method is safe to call by any of a user's devices even if one or more of
+// the accounts is marked as being mobile only. If the FeatureStellarAcctBundles
+// is true and the user is still on a v1 bundle, this method will call
+// `MigrateBundleToAccountBundles` and then fetch again.
 func FetchSecretlessBundle(ctx context.Context, g *libkb.GlobalContext) (acctBundle *stellar1.BundleRestricted, version stellar1.BundleVersion, pukGen keybase1.PerUserKeyGeneration, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.FetchSecretlessBundle", func() error { return err })()
 
@@ -576,6 +578,9 @@ func FetchWholeBundle(ctx context.Context, g *libkb.GlobalContext) (acctBundle *
 }
 
 // FetchAccountBundle gets an account bundle from the server and decrypts it.
+// this method will bubble up an error if it's called by a Desktop device for
+// an account that is mobile only. If you don't need the secrets, use
+// FetchSecretlessBundle instead.
 func FetchAccountBundle(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (acctBundle *stellar1.BundleRestricted, version stellar1.BundleVersion, pukGen keybase1.PerUserKeyGeneration, err error) {
 	defer g.CTraceTimed(ctx, "Stellar.FetchAccountBundle", func() error { return err })()
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -150,7 +150,7 @@ func Upkeep(ctx context.Context, g *libkb.GlobalContext) (err error) {
 		g.Log.CDebugf(ctx, "Stellar.Upkeep: early out prevPukGen:%v < pukGen:%v", prevPukGen, pukGen)
 		return nil
 	}
-	nextBundle := acctbundle.AdvanceAll(prevBundle)
+	nextBundle := acctbundle.AdvanceAll(*prevBundle)
 	return remote.Post(ctx, g, nextBundle)
 }
 
@@ -159,7 +159,7 @@ func ImportSecretKey(ctx context.Context, g *libkb.GlobalContext, secretKey stel
 	if err != nil {
 		return err
 	}
-	nextBundle := acctbundle.AdvanceBundle(prevBundle)
+	nextBundle := acctbundle.AdvanceBundle(*prevBundle)
 	err = acctbundle.AddAccount(&nextBundle, secretKey, accountName, makePrimary)
 	if err != nil {
 		return err
@@ -235,7 +235,7 @@ func ImportSecretKeyAccountBundle(ctx context.Context, g *libkb.GlobalContext, s
 	if err != nil {
 		return err
 	}
-	nextBundle := acctbundle.AdvanceBundle(prevBundle)
+	nextBundle := acctbundle.AdvanceBundle(*prevBundle)
 	err = acctbundle.AddAccount(&nextBundle, secretKey, accountName, makePrimary)
 	if err != nil {
 		return err
@@ -1229,7 +1229,7 @@ func ChangeAccountName(m libkb.MetaContext, accountID stellar1.AccountID, newNam
 	if !found {
 		return fmt.Errorf("account not found: %v", accountID)
 	}
-	nextBundle := acctbundle.AdvanceAccounts(bundle, []stellar1.AccountID{accountID})
+	nextBundle := acctbundle.AdvanceAccounts(*bundle, []stellar1.AccountID{accountID})
 	return remote.Post(m.Ctx(), m.G(), nextBundle)
 }
 
@@ -1265,7 +1265,7 @@ func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err
 	if !foundAccID {
 		return fmt.Errorf("account not found: %v", accountID)
 	}
-	nextBundle := acctbundle.AdvanceAccounts(bundle, accountsToAdvance)
+	nextBundle := acctbundle.AdvanceAccounts(*bundle, accountsToAdvance)
 	return remote.PostWithChainlink(m.Ctx(), m.G(), nextBundle, false)
 }
 
@@ -1277,7 +1277,7 @@ func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {
 	if err != nil {
 		return err
 	}
-	nextBundle := acctbundle.AdvanceBundle(prevBundle)
+	nextBundle := acctbundle.AdvanceBundle(*prevBundle)
 	var found bool
 	for i, acc := range nextBundle.Accounts {
 		if acc.AccountID.Eq(accountID) {
@@ -1344,7 +1344,7 @@ func CreateNewAccount(m libkb.MetaContext, accountName string) (ret stellar1.Acc
 	if err != nil {
 		return ret, err
 	}
-	nextBundle := acctbundle.AdvanceBundle(prevBundle)
+	nextBundle := acctbundle.AdvanceBundle(*prevBundle)
 	ret, err = acctbundle.CreateNewAccount(&nextBundle, accountName, false /* makePrimary */)
 	if err != nil {
 		return ret, err

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1212,9 +1212,7 @@ func ChangeAccountName(m libkb.MetaContext, accountID stellar1.AccountID, newNam
 	if !found {
 		return fmt.Errorf("account not found: %v", accountID)
 	}
-	// NOTE: changing the name of an account does not advance its revision
-	// so only the bundle gets advanced here.
-	nextBundle := acctbundle.AdvanceBundle(*bundle)
+	nextBundle := acctbundle.AdvanceAccounts(*bundle, []stellar1.AccountID{accountID})
 	return remote.Post(m.Ctx(), m.G(), nextBundle, version)
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -240,7 +240,7 @@ func ExportSecretKey(ctx context.Context, g *libkb.GlobalContext, accountID stel
 		return res, err
 	}
 	for _, account := range prevBundle.Accounts {
-		if account.AccountID.Eq(accountID) && account.Mode == stellar1.AccountMode_USER {
+		if account.AccountID.Eq(accountID) {
 			signers := prevBundle.AccountBundles[account.AccountID].Signers
 			if len(signers) == 0 {
 				return res, fmt.Errorf("no secret keys found for account")

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1229,10 +1229,7 @@ func ChangeAccountName(m libkb.MetaContext, accountID stellar1.AccountID, newNam
 	if !found {
 		return fmt.Errorf("account not found: %v", accountID)
 	}
-	nextBundle, err := acctbundle.AdvanceAccounts(bundle, []stellar1.AccountID{accountID})
-	if err != nil {
-		return err
-	}
+	nextBundle := acctbundle.AdvanceAccounts(bundle, []stellar1.AccountID{accountID})
 	return remote.Post(m.Ctx(), m.G(), nextBundle)
 }
 
@@ -1268,10 +1265,7 @@ func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err
 	if !foundAccID {
 		return fmt.Errorf("account not found: %v", accountID)
 	}
-	nextBundle, err := acctbundle.AdvanceAccounts(bundle, accountsToAdvance)
-	if err != nil {
-		return err
-	}
+	nextBundle := acctbundle.AdvanceAccounts(bundle, accountsToAdvance)
 	return remote.PostWithChainlink(m.Ctx(), m.G(), nextBundle, false)
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -133,7 +133,7 @@ func CreateWalletSoft(ctx context.Context, g *libkb.GlobalContext) {
 // Upkeep makes sure the bundle is encrypted for the user's latest PUK.
 func Upkeep(ctx context.Context, g *libkb.GlobalContext) (err error) {
 	defer g.CTraceTimed(ctx, "Stellar.Upkeep", func() error { return err })()
-	prevBundle, prevPukGen, err := remote.Fetch(ctx, g)
+	prevBundle, _, prevPukGen, err := remote.Fetch(ctx, g)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func Upkeep(ctx context.Context, g *libkb.GlobalContext) (err error) {
 }
 
 func ImportSecretKey(ctx context.Context, g *libkb.GlobalContext, secretKey stellar1.SecretKey, makePrimary bool, accountName string) (err error) {
-	prevBundle, _, err := remote.Fetch(ctx, g)
+	prevBundle, _, _, err := remote.Fetch(ctx, g)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func ImportSecretKeyAccountBundle(ctx context.Context, g *libkb.GlobalContext, s
 		return errors.New("this doesn't work in production")
 	}
 
-	prevBundle, _, err := remote.Fetch(ctx, g)
+	prevBundle, _, _, err := remote.Fetch(ctx, g)
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func ImportSecretKeyAccountBundle(ctx context.Context, g *libkb.GlobalContext, s
 }
 
 func ExportSecretKey(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (res stellar1.SecretKey, err error) {
-	prevBundle, _, err := remote.Fetch(ctx, g)
+	prevBundle, _, _, err := remote.Fetch(ctx, g)
 	if err != nil {
 		return res, err
 	}
@@ -281,7 +281,7 @@ func ExportSecretKey(ctx context.Context, g *libkb.GlobalContext, accountID stel
 }
 
 func OwnAccount(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (own, isPrimary bool, err error) {
-	bundle, _, err := remote.Fetch(ctx, g)
+	bundle, _, _, err := remote.Fetch(ctx, g)
 	if err != nil {
 		return false, false, err
 	}
@@ -294,7 +294,7 @@ func OwnAccount(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.
 }
 
 func lookupSenderEntry(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (stellar1.BundleEntryRestricted, stellar1.AccountBundle, error) {
-	bundle, _, err := remote.Fetch(ctx, g)
+	bundle, _, _, err := remote.Fetch(ctx, g)
 	if err != nil {
 		return stellar1.BundleEntryRestricted{}, stellar1.AccountBundle{}, err
 	}
@@ -798,7 +798,7 @@ func isAccountFunded(ctx context.Context, remoter remote.Remoter, accountID stel
 }
 
 func GetOwnPrimaryAccountID(ctx context.Context, g *libkb.GlobalContext) (res stellar1.AccountID, err error) {
-	activeBundle, _, err := remote.Fetch(ctx, g)
+	activeBundle, _, _, err := remote.Fetch(ctx, g)
 	if err != nil {
 		return res, err
 	}
@@ -1212,7 +1212,7 @@ func ChangeAccountName(m libkb.MetaContext, accountID stellar1.AccountID, newNam
 	if runes > AccountNameMaxRunes {
 		return fmt.Errorf("account name can be %v characters at the longest but was %v", AccountNameMaxRunes, runes)
 	}
-	bundle, _, err := remote.Fetch(m.Ctx(), m.G())
+	bundle, _, _, err := remote.Fetch(m.Ctx(), m.G())
 	if err != nil {
 		return err
 	}
@@ -1237,7 +1237,7 @@ func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err
 	if accountID.IsNil() {
 		return errors.New("passed empty AccountID")
 	}
-	bundle, _, err := remote.Fetch(m.Ctx(), m.G())
+	bundle, _, _, err := remote.Fetch(m.Ctx(), m.G())
 	if err != nil {
 		return err
 	}
@@ -1273,7 +1273,7 @@ func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {
 	if accountID.IsNil() {
 		return errors.New("passed empty AccountID")
 	}
-	prevBundle, _, err := remote.Fetch(m.Ctx(), m.G())
+	prevBundle, _, _, err := remote.Fetch(m.Ctx(), m.G())
 	if err != nil {
 		return err
 	}
@@ -1340,7 +1340,7 @@ func accountIDFromSecretKey(skey stellar1.SecretKey) (stellar1.AccountID, error)
 }
 
 func CreateNewAccount(m libkb.MetaContext, accountName string) (ret stellar1.AccountID, err error) {
-	prevBundle, _, err := remote.Fetch(m.Ctx(), m.G())
+	prevBundle, _, _, err := remote.Fetch(m.Ctx(), m.G())
 	if err != nil {
 		return ret, err
 	}

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -234,38 +234,6 @@ func EnableMigrationFeatureFlag(ctx context.Context, g *libkb.GlobalContext) err
 	return err
 }
 
-// ImportSecretKeyAccountBundle is a temporary function.
-// This is just to check PostBundleRestricted.
-// It does not attempt to do a full migration from V1 to V2.
-func ImportSecretKeyAccountBundle(ctx context.Context, g *libkb.GlobalContext, secretKey stellar1.SecretKey, makePrimary bool, accountName string) error {
-	if g.GetRunMode() == libkb.ProductionRunMode {
-		return errors.New("this doesn't work in production")
-	}
-
-	prevBundle, _, _, err := remote.Fetch(ctx, g)
-	if err != nil {
-		return err
-	}
-	nextBundle := acctbundle.AdvanceBundle(*prevBundle)
-	err = acctbundle.AddAccount(&nextBundle, secretKey, accountName, makePrimary)
-	if err != nil {
-		return err
-	}
-
-	// turn on the feature flag for the v2 stellar account bundles
-	err = EnableMigrationFeatureFlag(ctx, g)
-	if err != nil {
-		return err
-	}
-
-	if err := remote.PostBundleRestricted(ctx, g, &nextBundle); err != nil {
-		g.Log.CDebugf(ctx, "ImportSecretKey PostAccountBundle error: %s", err)
-		return err
-	}
-
-	return nil
-}
-
 func ExportSecretKey(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID) (res stellar1.SecretKey, err error) {
 	prevBundle, _, _, err := remote.Fetch(ctx, g)
 	if err != nil {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -30,7 +30,7 @@ func (s *Server) GetWalletAccountsLocal(ctx context.Context, sessionID int) (acc
 		return nil, err
 	}
 
-	bundle, _, _, err := remote.Fetch(ctx, s.G())
+	bundle, _, _, err := remote.FetchSecretlessBundle(ctx, s.G())
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (s *Server) GetWalletAccountLocal(ctx context.Context, arg stellar1.GetWall
 		return acct, err
 	}
 
-	bundle, _, _, err := remote.Fetch(ctx, s.G())
+	bundle, _, _, err := remote.FetchSecretlessBundle(ctx, s.G())
 	if err != nil {
 		return acct, err
 	}
@@ -557,7 +557,7 @@ func (s *Server) ValidateAccountNameLocal(ctx context.Context, arg stellar1.Vali
 		return fmt.Errorf("account name can be %v characters at the longest but was %v", stellar.AccountNameMaxRunes, runes)
 	}
 	// If this becomes a bottleneck, cache non-critical wallet info on G.Stellar.
-	currentBundle, _, _, err := remote.Fetch(ctx, s.G())
+	currentBundle, _, _, err := remote.FetchSecretlessBundle(ctx, s.G())
 	if err != nil {
 		s.G().Log.CErrorf(ctx, "error fetching bundle: %v", err)
 		// Return nil since the name is probably fine.

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -85,7 +85,7 @@ func (s *Server) GetWalletAccountLocal(ctx context.Context, arg stellar1.GetWall
 	return s.accountLocal(ctx, entry)
 }
 
-func (s *Server) accountLocal(ctx context.Context, entry stellar1.BundleEntry) (stellar1.WalletAccountLocal, error) {
+func (s *Server) accountLocal(ctx context.Context, entry stellar1.BundleEntryRestricted) (stellar1.WalletAccountLocal, error) {
 	var empty stellar1.WalletAccountLocal
 	details, err := s.accountDetails(ctx, entry.AccountID)
 	if err != nil {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -30,7 +30,7 @@ func (s *Server) GetWalletAccountsLocal(ctx context.Context, sessionID int) (acc
 		return nil, err
 	}
 
-	bundle, _, err := remote.Fetch(ctx, s.G())
+	bundle, _, _, err := remote.Fetch(ctx, s.G())
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (s *Server) GetWalletAccountLocal(ctx context.Context, arg stellar1.GetWall
 		return acct, err
 	}
 
-	bundle, _, err := remote.Fetch(ctx, s.G())
+	bundle, _, _, err := remote.Fetch(ctx, s.G())
 	if err != nil {
 		return acct, err
 	}
@@ -557,7 +557,7 @@ func (s *Server) ValidateAccountNameLocal(ctx context.Context, arg stellar1.Vali
 		return fmt.Errorf("account name can be %v characters at the longest but was %v", stellar.AccountNameMaxRunes, runes)
 	}
 	// If this becomes a bottleneck, cache non-critical wallet info on G.Stellar.
-	currentBundle, _, err := remote.Fetch(ctx, s.G())
+	currentBundle, _, _, err := remote.Fetch(ctx, s.G())
 	if err != nil {
 		s.G().Log.CErrorf(ctx, "error fetching bundle: %v", err)
 		// Return nil since the name is probably fine.

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func acceptDisclaimer(tc *TestContext) {
+	// NOTE: this also creates a v1 wallet
 	err := tc.Srv.AcceptDisclaimerLocal(context.Background(), 0)
 	require.NoError(tc.T, err)
 }
@@ -545,7 +546,7 @@ func TestAcceptDisclaimer(t *testing.T) {
 	require.Equal(t, false, accepted)
 
 	t.Logf("can't create wallet before disclaimer")
-	_, err = stellar.CreateWallet(context.Background(), tcs[0].G)
+	_, err = stellar.CreateWallet(context.Background(), tcs[0].G, false)
 	require.Error(t, err)
 	require.True(t, libkb.IsAppStatusErrorCode(err, keybase1.StatusCode_SCStellarNeedDisclaimer))
 

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -316,7 +316,7 @@ func TestSetAccountAsDefault(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	bundle, _, _, err := remote.Fetch(context.Background(), tcs[0].G)
+	bundle, _, _, err := remote.FetchSecretlessBundle(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, bundle.Revision)
 

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -1920,7 +1920,9 @@ func TestSetMobileOnly(t *testing.T) {
 	tcs, cleanup := setupNTests(t, 1)
 	defer cleanup()
 
-	acceptDisclaimer(tcs[0])
+	// this only works with a v2 bundle now
+	setupWithNewBundle(t, tcs[0])
+
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
 	accountID := getPrimaryAccountID(tcs[0])
 
@@ -1935,9 +1937,7 @@ func TestSetMobileOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, mobileOnly)
 
-	// XXX note that the real test here will be that the secret bundle does not come
-	// back for desktop devices or mobile devices that are less than 7d old.
-	// This is just a basic test at this point...
+	// service_test verifies that `SetAccountMobileOnlyLocal` behaves correctly under the covers
 }
 
 type chatListener struct {

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -316,7 +316,7 @@ func TestSetAccountAsDefault(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	bundle, _, err := remote.Fetch(context.Background(), tcs[0].G)
+	bundle, _, _, err := remote.Fetch(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, bundle.Revision)
 

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -892,7 +892,7 @@ func (r *BackendMock) ImportAccountsForUser(tc *TestContext) (res []*FakeAccount
 			continue
 		}
 		acc := r.addAccountByID(account.AccountID, false /* funded */)
-		acc.secretKey = stellar1.SecretKey(account.Signers[0])
+		acc.secretKey = stellar1.SecretKey(bundle.AccountBundles[account.AccountID].Signers[0])
 		res = append(res, acc)
 	}
 	return res

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -885,7 +885,7 @@ func (r *BackendMock) ImportAccountsForUser(tc *TestContext) (res []*FakeAccount
 	defer tc.G.CTraceTimed(context.Background(), "BackendMock.ImportAccountsForUser", func() error { return nil })()
 	r.Lock()
 	defer r.Unlock()
-	bundle, _, _, err := remote.Fetch(context.Background(), tc.G)
+	bundle, _, _, err := remote.FetchWholeBundle(context.Background(), tc.G)
 	require.NoError(r.T, err)
 	for _, account := range bundle.Accounts {
 		if _, found := r.accounts[account.AccountID]; found {

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -885,7 +885,7 @@ func (r *BackendMock) ImportAccountsForUser(tc *TestContext) (res []*FakeAccount
 	defer tc.G.CTraceTimed(context.Background(), "BackendMock.ImportAccountsForUser", func() error { return nil })()
 	r.Lock()
 	defer r.Unlock()
-	bundle, _, err := remote.Fetch(context.Background(), tc.G)
+	bundle, _, _, err := remote.Fetch(context.Background(), tc.G)
 	require.NoError(r.T, err)
 	for _, account := range bundle.Accounts {
 		if _, found := r.accounts[account.AccountID]; found {

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -291,7 +291,7 @@ func (s *Server) WalletInitLocal(ctx context.Context) (err error) {
 		return err
 	}
 
-	_, err = stellar.CreateWallet(ctx, s.G())
+	_, err = stellar.CreateWallet(ctx, s.G(), false)
 	return err
 }
 

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -346,7 +346,7 @@ func (s *Server) WalletGetAccountsCLILocal(ctx context.Context) (ret []stellar1.
 
 	mctx := libkb.NewMetaContext(ctx, s.G())
 
-	currentBundle, _, _, err := remote.Fetch(ctx, s.G())
+	currentBundle, _, _, err := remote.FetchSecretlessBundle(ctx, s.G())
 	if err != nil {
 		return nil, err
 	}

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -346,7 +346,7 @@ func (s *Server) WalletGetAccountsCLILocal(ctx context.Context) (ret []stellar1.
 
 	mctx := libkb.NewMetaContext(ctx, s.G())
 
-	currentBundle, _, err := remote.Fetch(ctx, s.G())
+	currentBundle, _, _, err := remote.Fetch(ctx, s.G())
 	if err != nil {
 		return nil, err
 	}

--- a/go/stellar/stellarsvc/service_devel.go
+++ b/go/stellar/stellarsvc/service_devel.go
@@ -14,7 +14,7 @@ import (
 	"github.com/keybase/client/go/stellar/remote"
 )
 
-func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.Bundle, err error) {
+func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.BundleRestricted, err error) {
 	if s.G().Env.GetRunMode() != libkb.DevelRunMode {
 		return dump, errors.New("WalletDump only supported in devel run mode")
 	}

--- a/go/stellar/stellarsvc/service_devel.go
+++ b/go/stellar/stellarsvc/service_devel.go
@@ -43,7 +43,7 @@ func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.BundleRestr
 	if err != nil {
 		return dump, err
 	}
-	bundle, _, _, err := remote.Fetch(ctx, s.G())
+	bundle, _, _, err := remote.FetchWholeBundle(ctx, s.G())
 
 	return *bundle, err
 }

--- a/go/stellar/stellarsvc/service_devel.go
+++ b/go/stellar/stellarsvc/service_devel.go
@@ -43,7 +43,7 @@ func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.BundleRestr
 	if err != nil {
 		return dump, err
 	}
-	dump, _, _, err = remote.Fetch(ctx, s.G())
+	bundle, _, _, err := remote.Fetch(ctx, s.G())
 
-	return dump, err
+	return *bundle, err
 }

--- a/go/stellar/stellarsvc/service_devel.go
+++ b/go/stellar/stellarsvc/service_devel.go
@@ -43,7 +43,7 @@ func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.BundleRestr
 	if err != nil {
 		return dump, err
 	}
-	dump, _, err = remote.Fetch(ctx, s.G())
+	dump, _, _, err = remote.Fetch(ctx, s.G())
 
 	return dump, err
 }

--- a/go/stellar/stellarsvc/service_production.go
+++ b/go/stellar/stellarsvc/service_production.go
@@ -12,7 +12,7 @@ import (
 	"github.com/keybase/client/go/protocol/stellar1"
 )
 
-func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.Bundle, err error) {
+func (s *Server) WalletDumpLocal(ctx context.Context) (dump stellar1.BundleRestricted, err error) {
 	ctx, err, fin := s.Preamble(ctx, preambleArg{
 		RPCName:        "WalletDumpLocal",
 		Err:            &err,

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -913,19 +913,19 @@ func TestMakeAccountMobileOnlyOnDesktop(t *testing.T) {
 	require.Equal(t, libkb.SCStellarDeviceNotMobile, aerr.Code)
 
 	primaryAcctName := fmt.Sprintf("%s's account", tc.Fu.Username)
-	// can pull a secretless bundle though
-	rev3AcctBundle, _, err := remote.FetchAccountBundle(context.Background(), tc.G, stellar1.AccountID(""))
+	// can pull a secretless bundle though (not specifying an accountID)
+	rev3AcctBundle, _, err := remote.FetchSecretlessBundle(context.Background(), tc.G)
 	require.NoError(t, err)
 	require.Equal(t, stellar1.BundleVersion_V2, version)
 	require.Equal(t, stellar1.BundleRevision(3), rev3AcctBundle.Revision)
-	accountID_0 := rev3AcctBundle.Accounts[0].AccountID
+	accountID0 := rev3AcctBundle.Accounts[0].AccountID
 	require.Equal(t, primaryAcctName, rev3AcctBundle.Accounts[0].Name)
 	require.True(t, rev3AcctBundle.Accounts[0].IsPrimary)
-	require.Len(t, rev3AcctBundle.AccountBundles[accountID_0].Signers, 0)
-	accountID_1 := rev3AcctBundle.Accounts[1].AccountID
+	require.Len(t, rev3AcctBundle.AccountBundles[accountID0].Signers, 0)
+	accountID1 := rev3AcctBundle.Accounts[1].AccountID
 	require.Equal(t, stellar1.AccountMode_MOBILE, rev3AcctBundle.Accounts[1].Mode)
 	require.False(t, rev3AcctBundle.Accounts[1].IsPrimary)
-	require.Len(t, rev3AcctBundle.AccountBundles[accountID_1].Signers, 0)
+	require.Len(t, rev3AcctBundle.AccountBundles[accountID1].Signers, 0)
 	require.Equal(t, "vault", rev3AcctBundle.Accounts[1].Name)
 
 	// try posting an old bundle we got previously

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -888,6 +888,21 @@ func TestAccountBundleFlows(t *testing.T) {
 	require.NoError(t, err)
 
 	assertFetchAccountBundles(t, tcs[0], newPrimaryAccountID)
+
+	// FetchWholeBundle
+	fullBundle, version, _, err := remote.FetchWholeBundle(ctx, g)
+	require.NoError(t, err)
+	require.Equal(t, version, stellar1.BundleVersion_V2)
+	err = fullBundle.CheckInvariants()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(fullBundle.Accounts))
+	for _, acc := range fullBundle.Accounts {
+		ab := fullBundle.AccountBundles[acc.AccountID]
+		require.Equal(t, 1, len(ab.Signers))
+		_, parsedAccountID, _, err := libkb.ParseStellarSecretKey(string(ab.Signers[0]))
+		require.NoError(t, err)
+		require.Equal(t, parsedAccountID, acc.AccountID)
+	}
 }
 
 func assertFetchAccountBundles(t *testing.T, tc *TestContext, primaryAccountID stellar1.AccountID) {
@@ -1300,6 +1315,21 @@ func TestV2EndpointsAsV1(t *testing.T) {
 	require.Equal(t, version, stellar1.BundleVersion_V1)
 	ab := bundle.AccountBundles[primaryAccountID]
 	require.Equal(t, len(ab.Signers), 1)
+
+	// fetch whole bundle
+	fullBundle, version, _, err := remote.FetchWholeBundle(ctx, g)
+	require.NoError(t, err)
+	require.Equal(t, version, stellar1.BundleVersion_V1)
+	err = fullBundle.CheckInvariants()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(fullBundle.Accounts))
+	for _, acc := range fullBundle.Accounts {
+		ab := fullBundle.AccountBundles[acc.AccountID]
+		require.Equal(t, 1, len(ab.Signers))
+		_, parsedAccountID, _, err := libkb.ParseStellarSecretKey(string(ab.Signers[0]))
+		require.NoError(t, err)
+		require.Equal(t, parsedAccountID, acc.AccountID)
+	}
 }
 
 func TestMigrateBundleToAccountBundles(t *testing.T) {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -921,6 +921,7 @@ func TestAccountBundleFlows(t *testing.T) {
 		require.Equal(t, len(signers), 0)
 		accountIDs = append(accountIDs, acct.AccountID)
 	}
+	require.Equal(t, len(accountIDs), 1)
 	// add a new account non-primary account
 	a1, s1 := randomStellarKeypair()
 	err = tcs[0].Srv.ImportSecretKeyLocal(ctx, stellar1.ImportSecretKeyLocalArg{
@@ -1017,6 +1018,7 @@ func TestAccountBundleFlows(t *testing.T) {
 	})
 	require.NoError(t, err)
 	bundle, _, _, err = remote.FetchSecretlessBundle(ctx, g)
+	require.NoError(t, err)
 	found := false
 	for _, acc := range bundle.Accounts {
 		if acc.Name == "skittles" {
@@ -1572,6 +1574,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	// add a primary account
 	fetchArgs := libkb.HTTPArgs{"account_id": libkb.S{Val: string(primaryAccountID)}}
 	fetchedBundle, _, _, err := remote.FetchV2BundleWithArgs(ctx, g, fetchArgs)
+	require.NoError(t, err)
 	newPrimaryAccountID, newPrimarySecretKey := randomStellarKeypair()
 	err = acctbundle.AddAccount(fetchedBundle, newPrimarySecretKey, "newprimary", true /* make primary */)
 	require.NoError(t, err)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -1509,7 +1509,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 
 	// assert cannot use v2 endpoints before migrating
 	// fetch
-	_, _, _, err = remote.FetchV2BundleWithArgs(ctx, g, libkb.HTTPArgs{})
+	_, _, _, err = remote.FetchV2BundleForAccount(ctx, g, nil)
 	aerr := err.(libkb.AppStatusError)
 	actualStatus := keybase1.StatusCode(aerr.Code)
 	require.Equal(t, actualStatus, keybase1.StatusCode_SCStellarIncompatibleVersion)
@@ -1574,8 +1574,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	require.NoError(t, err)
 	assertFetchAccountBundles(t, tcs[0], primaryAccountID)
 	// add a primary account
-	fetchArgs := libkb.HTTPArgs{"account_id": libkb.S{Val: string(primaryAccountID)}}
-	fetchedBundle, _, _, err := remote.FetchV2BundleWithArgs(ctx, g, fetchArgs)
+	fetchedBundle, _, _, err := remote.FetchV2BundleForAccount(ctx, g, &primaryAccountID)
 	require.NoError(t, err)
 	newPrimaryAccountID, newPrimarySecretKey := randomStellarKeypair()
 	err = acctbundle.AddAccount(fetchedBundle, newPrimarySecretKey, "newprimary", true /* make primary */)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -1464,6 +1464,13 @@ func TestImplicitMigrationToAccountBundles(t *testing.T) {
 	m.G().FeatureFlags.InvalidateCache(m, libkb.FeatureStellarAcctBundles)
 
 	// the next bundle we pull should be v2
+	go func() {
+		// test concurrency
+		bundle, version, _, err = remote.FetchSecretlessBundle(ctx, g)
+		require.NoError(t, err)
+		require.Equal(t, version, stellar1.BundleVersion_V2)
+		require.Equal(t, len(bundle.Accounts), 1)
+	}()
 	bundle, version, _, err = remote.FetchSecretlessBundle(ctx, g)
 	require.NoError(t, err)
 	require.Equal(t, version, stellar1.BundleVersion_V2)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -1142,12 +1142,12 @@ func TestMakeAccountMobileOnlyOnDesktop(t *testing.T) {
 	require.Equal(t, "vault", rev3AcctBundle.Accounts[1].Name)
 
 	// try posting an old bundle we got previously
-	err = remote.PostBundleRestricted(ctx, g, rev2AcctBundle)
+	err = remote.Post(ctx, g, *rev2AcctBundle, version)
 	require.Error(t, err)
 
 	// tinker with it
 	rev2AcctBundle.Revision = 4
-	err = remote.PostBundleRestricted(ctx, g, rev2AcctBundle)
+	err = remote.Post(ctx, g, *rev2AcctBundle, version)
 	require.Error(t, err)
 }
 
@@ -1512,7 +1512,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	// post
 	throwawayV2Bundle0 := v2Bundle.DeepCopy()
 	throwawayV2Bundle1 := acctbundle.AdvanceAccounts(throwawayV2Bundle0, []stellar1.AccountID{primaryAccountID})
-	err = remote.PostBundleRestricted(ctx, g, &throwawayV2Bundle1)
+	err = remote.Post(ctx, g, throwawayV2Bundle1, stellar1.BundleVersion_V2)
 	require.Error(t, err, "cannot post v2 before migrating")
 	aerr = err.(libkb.AppStatusError)
 	actualStatus = keybase1.StatusCode(aerr.Code)
@@ -1559,7 +1559,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	require.NoError(t, err)
 	v2BundleNext := acctbundle.AdvanceBundle(*v2Bundle)
 	require.NoError(t, err)
-	err = remote.PostBundleRestricted(ctx, g, &v2BundleNext)
+	err = remote.Post(ctx, g, v2BundleNext, stellar1.BundleVersion_V2)
 	require.NoError(t, err)
 	assertFetchAccountBundles(t, tcs[0], primaryAccountID)
 	// add a primary account

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -1542,8 +1542,6 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	require.NoError(t, err)
 	err = remote.MigrateBundleToAccountBundles(m)
 	require.NoError(t, err)
-	v2Bundle, _, _, err = remote.FetchSecretlessBundle(ctx, g)
-	require.NoError(t, err)
 
 	// cannot use v1 endpoints after migration
 	_, _, _, err = remote.FetchV1Bundle(ctx, g)
@@ -1551,6 +1549,8 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	aerr = err.(libkb.AppStatusError)
 	actualStatus = keybase1.StatusCode(aerr.Code)
 	require.Equal(t, actualStatus, keybase1.StatusCode_SCStellarIncompatibleVersion)
+	v2Bundle, _, _, err = remote.FetchWholeBundle(ctx, g)
+	require.NoError(t, err)
 	v1BundlePrev, err := acctbundle.BundleFromBundleRestricted(*v2Bundle)
 	require.NoError(t, err)
 	v1Bundle = bundle.Advance(*v1BundlePrev)
@@ -1563,6 +1563,8 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	// can use v2 endpoints after migration
 	assertFetchAccountBundles(t, tcs[0], primaryAccountID)
 	// add a non-primary account
+	v2Bundle, _, _, err = remote.FetchSecretlessBundle(ctx, g)
+	require.NoError(t, err)
 	_, secretKey := randomStellarKeypair()
 	err = acctbundle.AddAccount(v2Bundle, secretKey, "shenanigans", false /* make primary */)
 	require.NoError(t, err)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -1103,7 +1103,9 @@ func TestMakeAccountMobileOnlyOnDesktop(t *testing.T) {
 	require.Equal(t, stellar1.BundleRevision(2), rev2AcctBundle.Revision)
 	// NOTE: we're using this rev2AcctBundle later...
 
-	err = remote.MakeAccountMobileOnly(ctx, g, a1)
+	err = tc.Srv.SetAccountMobileOnlyLocal(ctx, stellar1.SetAccountMobileOnlyLocalArg{
+		AccountID: a1,
+	})
 	require.NoError(t, err)
 
 	// this is a desktop device, so this should now fail
@@ -1175,7 +1177,9 @@ func TestMakeAccountMobileOnlyOnRecentMobile(t *testing.T) {
 	require.Equal(t, stellar1.BundleVersion_V2, version)
 	checker.assertBundle(t, acctBundle, 2, 1, stellar1.AccountMode_USER)
 
-	err = remote.MakeAccountMobileOnly(ctx, g, a1)
+	err = tc.Srv.SetAccountMobileOnlyLocal(ctx, stellar1.SetAccountMobileOnlyLocalArg{
+		AccountID: a1,
+	})
 	require.NoError(t, err)
 
 	// this is a recent mobile device, so this should now fail
@@ -1196,7 +1200,9 @@ func TestMakeAccountMobileOnlyOnRecentMobile(t *testing.T) {
 	checker.assertBundle(t, acctBundle, 3, 2, stellar1.AccountMode_MOBILE)
 
 	// this should not post a new bundle
-	err = remote.MakeAccountMobileOnly(ctx, g, a1)
+	err = tc.Srv.SetAccountMobileOnlyLocal(ctx, stellar1.SetAccountMobileOnlyLocalArg{
+		AccountID: a1,
+	})
 	require.NoError(t, err)
 	acctBundle, version, _, err = remote.FetchAccountBundle(ctx, g, a1)
 	require.NoError(t, err)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -62,7 +62,7 @@ func TestCreateWallet(t *testing.T) {
 	require.False(t, created)
 
 	t.Logf("Fetch the bundle")
-	bundle, _, err := remote.Fetch(context.Background(), tcs[0].G)
+	bundle, _, _, err := remote.Fetch(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.Equal(t, stellar1.BundleRevision(1), bundle.Revision)
 	require.Nil(t, bundle.Prev)
@@ -122,7 +122,7 @@ func TestUpkeep(t *testing.T) {
 
 	acceptDisclaimer(tcs[0])
 
-	bundle, pukGen, err := remote.Fetch(context.Background(), tcs[0].G)
+	bundle, _, pukGen, err := remote.Fetch(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	originalID := bundle.OwnHash
 	require.NotNil(t, originalID)
@@ -131,7 +131,7 @@ func TestUpkeep(t *testing.T) {
 	err = stellar.Upkeep(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 
-	bundle, pukGen, err = remote.Fetch(context.Background(), tcs[0].G)
+	bundle, _, pukGen, err = remote.Fetch(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.Equal(t, bundle.OwnHash, originalID, "bundle should be unchanged by no-op upkeep")
 	require.Equal(t, originalPukGen, pukGen)
@@ -147,7 +147,7 @@ func TestUpkeep(t *testing.T) {
 	err = stellar.Upkeep(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 
-	bundle, pukGen, err = remote.Fetch(context.Background(), tcs[0].G)
+	bundle, _, pukGen, err = remote.Fetch(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.NotEqual(t, bundle.OwnHash, originalID, "bundle should be new")
 	require.NotEqual(t, originalPukGen, pukGen, "bundle should be for new puk")
@@ -175,7 +175,7 @@ func TestImportExport(t *testing.T) {
 		require.Error(t, err, "export empty specifier")
 	})
 
-	bundle, _, err := remote.Fetch(context.Background(), tcs[0].G)
+	bundle, _, _, err := remote.Fetch(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 
 	mustAskForPassphrase(func() {
@@ -260,7 +260,7 @@ func TestImportExport(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, own)
 
-	bundle, _, err = remote.Fetch(context.Background(), tcs[0].G)
+	bundle, _, _, err = remote.Fetch(context.Background(), tcs[0].G)
 	require.NoError(t, err)
 	require.Len(t, bundle.Accounts, 3)
 }
@@ -1276,7 +1276,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	// create a v1 bundle with two accounts
 	_, err := stellar.CreateWallet(ctx, g, false)
 	require.NoError(t, err)
-	v1Bundle0, _, err := remote.FetchV1Bundle(ctx, g)
+	v1Bundle0, _, _, err := remote.FetchV1Bundle(ctx, g)
 	require.NoError(t, err)
 	primaryAccount, err := v1Bundle0.PrimaryAccount()
 	require.NoError(t, err)
@@ -1294,7 +1294,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	actualStatus := keybase1.StatusCode(aerr.Code)
 	require.Equal(t, actualStatus, keybase1.StatusCode_SCStellarIncompatibleVersion)
 	require.Error(t, err, "cannot fetch v2 before migrating")
-	v1Bundle, _, err = remote.FetchV1Bundle(ctx, g)
+	v1Bundle, _, _, err = remote.FetchV1Bundle(ctx, g)
 	require.NoError(t, err)
 	v2Bundle, err := acctbundle.NewFromBundle(v1Bundle)
 	require.NoError(t, err)
@@ -1326,7 +1326,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	require.NoError(t, err)
 
 	// cannot use v1 endpoints after migration
-	_, _, err = remote.FetchV1Bundle(ctx, g)
+	_, _, _, err = remote.FetchV1Bundle(ctx, g)
 	require.Error(t, err, "cannot fetch v1 after migrating")
 	aerr = err.(libkb.AppStatusError)
 	actualStatus = keybase1.StatusCode(aerr.Code)

--- a/go/stellar/util.go
+++ b/go/stellar/util.go
@@ -72,7 +72,7 @@ func (c *ownAccountLookupCacheImpl) fetch(ctx context.Context, g *libkb.GlobalCo
 	go func() {
 		ctx := libkb.CopyTagsToBackground(ctx)
 		defer c.Unlock()
-		bundle, _, _, err := remote.Fetch(ctx, g)
+		bundle, _, _, err := remote.FetchSecretlessBundle(ctx, g)
 		c.loadErr = err
 		if err != nil {
 			return

--- a/go/stellar/util.go
+++ b/go/stellar/util.go
@@ -72,7 +72,7 @@ func (c *ownAccountLookupCacheImpl) fetch(ctx context.Context, g *libkb.GlobalCo
 	go func() {
 		ctx := libkb.CopyTagsToBackground(ctx)
 		defer c.Unlock()
-		bundle, _, err := remote.Fetch(ctx, g)
+		bundle, _, _, err := remote.Fetch(ctx, g)
 		c.loadErr = err
 		if err != nil {
 			return

--- a/go/systests/stellar_client_test.go
+++ b/go/systests/stellar_client_test.go
@@ -360,7 +360,7 @@ func (s *stellarRetryClient) WalletInitLocal(ctx context.Context) (err error) {
 	return err
 }
 
-func (s *stellarRetryClient) WalletDumpLocal(ctx context.Context) (res stellar1.Bundle, err error) {
+func (s *stellarRetryClient) WalletDumpLocal(ctx context.Context) (res stellar1.BundleRestricted, err error) {
 	for i := 0; i < retryCount; i++ {
 		res, err = s.cli.WalletDumpLocal(ctx)
 		if err == nil {

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -175,6 +175,7 @@ protocol constants {
     SCStellarNeedDisclaimer_3109,
     SCStellarDeviceNotMobile_3110,
     SCStellarMobileOnlyPurgatory_3111,
+    SCStellarIncompatibleVersion_3112,
     SCNISTWrongSize_3201,
     SCNISTBadMode_3202,
     SCNISTHashWrongSize_3203,

--- a/protocol/avdl/stellar1/bundle.avdl
+++ b/protocol/avdl/stellar1/bundle.avdl
@@ -56,7 +56,7 @@ protocol bundle {
   // by BundleSecret's version field.
 
   // --------------------------------------------------------------------------
-  // V1 
+  // V1
   // --------------------------------------------------------------------------
 
   record BundleVisibleV1 {
@@ -93,7 +93,7 @@ protocol bundle {
     Hash prev; // SHA256 of previous msgpack(EncryptedBundle)
     array<BundleVisibleEntryV2> accounts;
   }
-  
+
   record BundleSecretV2 {
     Hash visibleHash; // SHA256 of msgpack(BundleVisibleV2)
     array<BundleSecretEntryV2> accounts;
@@ -107,7 +107,7 @@ protocol bundle {
     BundleRevision acctBundleRevision; // revision of AccountBundleSecret
     Hash encAcctBundleHash;   // SHA256 of msgpack(EncryptedAccountBundle) for this account
   }
-  
+
   // V2 Secret attributes of an account.
   record BundleSecretEntryV2 {
     AccountID accountID; // this is here to check that the bundle isn't corrupt
@@ -115,7 +115,7 @@ protocol bundle {
   }
 
   // --------------------------------------------------------------------------
-  // Unsupported 
+  // Unsupported
   // --------------------------------------------------------------------------
 
   record BundleSecretUnsupported {}
@@ -165,7 +165,7 @@ protocol bundle {
   }
 
   record AccountBundleSecretUnsupported {}
- 
+
   // ==========================================================================
   // Unversioned structs for local use only.
   // ==========================================================================
@@ -205,7 +205,7 @@ protocol bundle {
     // bundles containing secret keys
     map<AccountID, AccountBundle> accountBundles;
   }
-  
+
   // Combined account entry for local use only.
   record BundleEntryRestricted {
     AccountID accountID;
@@ -218,7 +218,6 @@ protocol bundle {
 
   // Unversioned struct for local use only.
   record AccountBundle {
-    BundleRevision revision;
     Hash prev;
     // SHA256 of this msgpack(EncryptedAccountBundle)
     // Not serialized. Only set if this bundle was decrypted.

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -11,7 +11,7 @@ protocol local {
     boolean isDefault;          // true if this is the default sending/receiving account
     string name;                // the user-given name for the account
     string balanceDescription;  // example: "56.0227002 XLM + more"
-    string seqno;               // the stellar sequence number for this account 
+    string seqno;               // the stellar sequence number for this account
   }
   array<WalletAccountLocal> getWalletAccountsLocal(int sessionID);
   WalletAccountLocal getWalletAccountLocal(int sessionID, AccountID accountID);
@@ -118,7 +118,7 @@ protocol local {
   PaymentsPageLocal getPaymentsLocal(int sessionID, AccountID accountID, union { null, PageCursor } cursor);
   array<PaymentOrErrorLocal> getPendingPaymentsLocal(int sessionID, AccountID accountID);
 
-  // markAsReadLocal will mark as "read" all the payments created at or before the time 
+  // markAsReadLocal will mark as "read" all the payments created at or before the time
   // of the payment referenced by `mostRecentID`.
   void markAsReadLocal(int sessionID, AccountID accountID, PaymentID mostRecentID);
 
@@ -284,7 +284,7 @@ protocol local {
     string publicMemoErrMsg;
 
     // All these worth fields are pretty confusing.
-    // Leaving them in, but adding fields below to simplify, then 
+    // Leaving them in, but adding fields below to simplify, then
     // perhaps we can clean some of these out.
 
     // Optional. Blank if non-native assets are being sent or if there is a global error.
@@ -428,7 +428,7 @@ protocol local {
   }
   RequestDetailsLocal getRequestDetailsLocal(int sessionID, KeybaseRequestID reqID);
   void cancelRequestLocal(int sessionID, KeybaseRequestID reqID);
-  KeybaseRequestID makeRequestLocal(int sessionID, string recipient, union { null, Asset } asset, 
+  KeybaseRequestID makeRequestLocal(int sessionID, string recipient, union { null, Asset } asset,
     union { null, OutsideCurrencyCode } currency, string amount, string note);
 
   void setAccountMobileOnlyLocal(int sessionID, AccountID accountID);
@@ -489,7 +489,7 @@ protocol local {
 
   void walletInitLocal();
 
-  Bundle walletDumpLocal();
+  BundleRestricted walletDumpLocal();
 
   // Account balance and its current value in selected currency.
   record OwnAccountCLILocal {
@@ -517,7 +517,7 @@ protocol local {
   map<OutsideCurrencyCode, OutsideCurrencyDefinition> getAvailableLocalCurrencies();
   string formatLocalCurrencyString(string amount, OutsideCurrencyCode code);
 
-  KeybaseRequestID makeRequestCLILocal(string recipient, union { null, Asset } asset, 
+  KeybaseRequestID makeRequestCLILocal(string recipient, union { null, Asset } asset,
     union { null, OutsideCurrencyCode } currency, string amount, string note);
 
   record LookupResultCLILocal {

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -179,6 +179,7 @@
         "SCStellarNeedDisclaimer_3109",
         "SCStellarDeviceNotMobile_3110",
         "SCStellarMobileOnlyPurgatory_3111",
+        "SCStellarIncompatibleVersion_3112",
         "SCNISTWrongSize_3201",
         "SCNISTBadMode_3202",
         "SCNISTHashWrongSize_3203",

--- a/protocol/json/stellar1/bundle.json
+++ b/protocol/json/stellar1/bundle.json
@@ -568,10 +568,6 @@
       "name": "AccountBundle",
       "fields": [
         {
-          "type": "BundleRevision",
-          "name": "revision"
-        },
-        {
           "type": "Hash",
           "name": "prev"
         },

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -1500,7 +1500,7 @@
     },
     "walletDumpLocal": {
       "request": [],
-      "response": "Bundle"
+      "response": "BundleRestricted"
     },
     "walletGetAccountsCLILocal": {
       "request": [],

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -274,6 +274,7 @@ export const constantsStatusCode = {
   scstellarneeddisclaimer: 3109,
   scstellardevicenotmobile: 3110,
   scstellarmobileonlypurgatory: 3111,
+  scstellarincompatibleversion: 3112,
   scnistwrongsize: 3201,
   scnistbadmode: 3202,
   scnisthashwrongsize: 3203,

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -1221,6 +1221,7 @@ export const constantsStatusCode = {
   scstellarneeddisclaimer: 3109,
   scstellardevicenotmobile: 3110,
   scstellarmobileonlypurgatory: 3111,
+  scstellarincompatibleversion: 3112,
   scnistwrongsize: 3201,
   scnistbadmode: 3202,
   scnisthashwrongsize: 3203,
@@ -2639,6 +2640,7 @@ export type StatusCode =
   | 3109 // SCStellarNeedDisclaimer_3109
   | 3110 // SCStellarDeviceNotMobile_3110
   | 3111 // SCStellarMobileOnlyPurgatory_3111
+  | 3112 // SCStellarIncompatibleVersion_3112
   | 3201 // SCNISTWrongSize_3201
   | 3202 // SCNISTBadMode_3202
   | 3203 // SCNISTHashWrongSize_3203

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -232,7 +232,7 @@ export const remotePaymentSummaryType = {
   relay: 3,
 }
 export type AccountAssetLocal = $ReadOnly<{name: String, assetCode: String, issuerName: String, issuerAccountID: String, issuerVerifiedDomain: String, balanceTotal: String, balanceAvailableToSend: String, worthCurrency: String, worth: String, availableToSendWorth: String, reserves?: ?Array<AccountReserve>}>
-export type AccountBundle = $ReadOnly<{revision: BundleRevision, prev: Hash, ownHash: Hash, accountID: AccountID, signers?: ?Array<SecretKey>}>
+export type AccountBundle = $ReadOnly<{prev: Hash, ownHash: Hash, accountID: AccountID, signers?: ?Array<SecretKey>}>
 export type AccountBundleSecretUnsupported = $ReadOnly<{}>
 export type AccountBundleSecretV1 = $ReadOnly<{accountID: AccountID, signers?: ?Array<SecretKey>}>
 export type AccountBundleSecretVersioned = {version: 1, v1: ?AccountBundleSecretV1} | {version: 2, v2: ?AccountBundleSecretUnsupported} | {version: 3, v3: ?AccountBundleSecretUnsupported} | {version: 4, v4: ?AccountBundleSecretUnsupported} | {version: 5, v5: ?AccountBundleSecretUnsupported} | {version: 6, v6: ?AccountBundleSecretUnsupported} | {version: 7, v7: ?AccountBundleSecretUnsupported} | {version: 8, v8: ?AccountBundleSecretUnsupported} | {version: 9, v9: ?AccountBundleSecretUnsupported} | {version: 10, v10: ?AccountBundleSecretUnsupported}


### PR DESCRIPTION
High level, the approach I took here was to make all `Fetch`ing be explicit about what's being requested (i.e. whether or not there are secrets) but implicit about which version it wants. Everything looks like the new objects, but they might actually be the old ones under the covers. And the version comes back with the bundle, so the calling code knows what it got. `Post` on the other hand is explicit about which version is being sent in, because we shouldn't ever be screwing that up. 
Whenever the client makes the wrong version request to the server, there's an `IncompatibleVersion` error that comes back. With this error and the feature flag, the migration to V2 bundles is conditionally triggered by one of the `Fetch`s. And since `Fetch`ing is implicit, we don't need to keep track of when it's done on the client, it'll hopefully happen once and then the triggering error won't get thrown again. 

Once this is merged, we should be able to test all of the behavior of v2 bundles (including mobile-only) by flipping the feature flag. 

- [x] 1. update the client in another PR (https://github.com/keybase/client/pull/14729) to be robust to changes that need to happen on the server.
- [x] 2. update the server https://github.com/keybase/keybase/pull/3130
- [x] 3. shim Fetch, Post, and PostWithChainLink (the interfaces to the server) to speak `BundleRestricted` to the rest of the client and `Bundle` to the server. Update everything else in the client for this change.
- [x] 4. bring the feature flag (`stellar_acct_bundles` from the server) into the client
- [x] 5. add the ability to post v2 bundles with a chain link from the client
- [x] 6. add some code to do a migration of bundle to bundle restricted (tl;dr fetch_v1, post_v2 per account, verify). 
- [x] 7. create a `FetchWholeBundle` for the situations where all the secrets are needed (e.g. Upkeep, dumping in development, some testing stuff)
- [x] 8. collapse the APIs of all the public facing Fetch methods to be the same: pointers, version and pukGen, ...
- [x] 9. make Post take a version argument (we always have it because we've just fetched) and delegate to v1 or v2. This allows us to keep the same public facing Post entry point but make it super explicit what's happening. and since every Post is preceded by a Fetch, this is reasonable.
- [x] 10. replace all uses of `Fetch` with `FetchSecretlessBundle` or `FetchAccountBundle` or `FetchWholeBundle` and do the version controlling logic inside `remote`.
- [x] 11. fix `SetAccountMobileOnly` (and `IsAccountMobileOnly` actually) so they use `MakeAccountMobileOnly`
- [x] 12. implement triggering the migration after the feature flag is flipped. 
