### PR TITLE
Red & green usernames using users store

### DIFF
--- a/shared/common-adapters/name-with-icon/index.js
+++ b/shared/common-adapters/name-with-icon/index.js
@@ -14,6 +14,7 @@ type Size = 'small' | 'default' | 'large'
 export type NameWithIconProps = {|
   avatarSize?: AvatarSize,
   avatarStyle?: Styles.StylesCrossPlatform,
+  colorBroken?: boolean,
   colorFollowing?: boolean,
   containerStyle?: Styles.StylesCrossPlatform,
   editableIcon?: boolean,
@@ -95,6 +96,7 @@ class NameWithIcon extends React.Component<NameWithIconProps> {
         inline={!this.props.horizontal}
         underline={this.props.underline}
         usernames={[this.props.username]}
+        colorBroken={this.props.colorBroken}
         colorFollowing={this.props.colorFollowing}
       />
     ) : (

--- a/shared/common-adapters/usernames/container.js
+++ b/shared/common-adapters/usernames/container.js
@@ -27,12 +27,12 @@ export type DispatchProps = {|
   onOpenTracker?: (username: string) => void,
 |}
 
-export const connectedPropsToProps = <T>(
+export function connectedPropsToProps<T>(
   stateProps: T,
   dispatchProps: DispatchProps,
   connectedProps: ConnectedProps,
   userDataFromState: (T, Array<string>) => UserList
-): Props => {
+): Props {
   const userData = userDataFromState(stateProps, connectedProps.usernames).filter(
     u => !connectedProps.skipSelf || !u.you
   )

--- a/shared/common-adapters/usernames/remote-container.js
+++ b/shared/common-adapters/usernames/remote-container.js
@@ -3,19 +3,19 @@ import * as ProfileGen from '../../actions/profile-gen'
 import {Usernames} from '.'
 import {remoteConnect, compose} from '../../util/container'
 import * as Container from './container'
-import * as TrackerTypes from '../../constants/types/tracker'
+import * as UsersTypes from '../../constants/types/users'
 
 type OwnProps = Container.ConnectedProps
 type State = {|
-  broken: {[key: string]: TrackerTypes.TrackerState},
   following: Set<string>,
+  userInfo: {[key: string]: UsersTypes._UserInfo},
   username: string,
 |}
 
 // Connected username component
 const mapStateToProps = props => ({
-  _broken: props.broken,
   _following: props.following,
+  _userInfo: props.userInfo,
   _you: props.username,
 })
 
@@ -23,11 +23,21 @@ const mapDispatchToProps = dispatch => ({
   _onUsernameClicked: (username: string) => dispatch(ProfileGen.createShowUserProfile({username})),
 })
 
+const userDatafromState = (stateProps, usernames) =>
+  usernames.map(username => ({
+    // $FlowIssue optional chain is needed
+    broken: stateProps._userInfo[username]?.broken || false,
+    following: stateProps._following.has(username),
+    username,
+    you: stateProps._you === username,
+  }))
+
 const mergeProps = (stateProps, dispatchProps, ownProps) =>
   Container.connectedPropsToProps(
     {...stateProps, _following: new Set(stateProps._following)},
     {},
-    {...ownProps, onUsernameClicked: dispatchProps._onUsernameClicked}
+    {...ownProps, onUsernameClicked: dispatchProps._onUsernameClicked},
+    userDatafromState
   )
 
 export default compose(

--- a/shared/common-adapters/usernames/remote-container.js
+++ b/shared/common-adapters/usernames/remote-container.js
@@ -25,8 +25,7 @@ const mapDispatchToProps = dispatch => ({
 
 const userDatafromState = (stateProps, usernames) =>
   usernames.map(username => ({
-    // $FlowIssue optional chain is needed
-    broken: stateProps._userInfo[username]?.broken || false,
+    broken: (stateProps._userInfo[username] && stateProps._userInfo[username].broken) || false,
     following: stateProps._following.has(username),
     username,
     you: stateProps._you === username,

--- a/shared/constants/types/users.js
+++ b/shared/constants/types/users.js
@@ -8,8 +8,10 @@ export type _UserInfo = {
 }
 type UserInfo = I.RecordOf<_UserInfo>
 
+export type InfoMap = I.Map<string, UserInfo>
+
 export type _State = {
-  infoMap: I.Map<string, UserInfo>,
+  infoMap: InfoMap,
 }
 
 export type State = I.RecordOf<_State>

--- a/shared/constants/users.js
+++ b/shared/constants/users.js
@@ -6,6 +6,9 @@ import {type TypedState} from './reducer'
 export const getFullname = (state: TypedState, username: string) =>
   state.users.infoMap.getIn([username, 'fullname'], null)
 
+export const getIsBroken = (infoMap: Types.InfoMap, username: string) =>
+  infoMap.getIn([username, 'broken'], null)
+
 export const makeUserInfo: I.RecordFactory<Types._UserInfo> = I.Record({
   broken: false,
   fullname: '',

--- a/shared/menubar/remote-proxy.desktop.js
+++ b/shared/menubar/remote-proxy.desktop.js
@@ -41,22 +41,15 @@ const mapStateToProps = state => ({
   _pathItems: state.fs.pathItems,
   _tlfUpdates: state.fs.tlfUpdates,
   _uploads: state.fs.uploads,
-  broken: state.tracker.userTrackers,
   conversationsToSend: conversationsToSend(state),
   loggedIn: state.config.loggedIn,
   outOfDate: state.config.outOfDate,
+  userInfo: state.users.infoMap,
   username: state.config.username,
 })
 
 // TODO we should just send a Set like structure over, for now just extract trackerState
-const getBrokenSubset = memoize1(userTrackers =>
-  Object.keys(userTrackers).reduce((map, name) => {
-    map[name] = {
-      trackerState: userTrackers[name].trackerState,
-    }
-    return map
-  }, {})
-)
+const getBrokenSubset = memoize1(userInfo => userInfo.filter(u => u.broken).toJS())
 
 let _lastUsername
 let _lastClearCacheTrigger = 0
@@ -68,7 +61,6 @@ const mergeProps = stateProps => {
   return {
     badgeKeys: stateProps._badgeInfo,
     badgeMap: stateProps._badgeInfo,
-    broken: getBrokenSubset(stateProps.broken),
     clearCacheTrigger: _lastClearCacheTrigger,
     conversationIDs: stateProps.conversationsToSend,
     conversationMap: stateProps.conversationsToSend,
@@ -79,6 +71,7 @@ const mergeProps = stateProps => {
     following: stateProps._following,
     loggedIn: stateProps.loggedIn,
     outOfDate: stateProps.outOfDate,
+    userInfo: getBrokenSubset(stateProps.userInfo),
     username: stateProps.username,
     windowComponent: 'menubar',
     windowOpts,

--- a/shared/menubar/remote-serializer.desktop.js
+++ b/shared/menubar/remote-serializer.desktop.js
@@ -19,7 +19,6 @@ export const serialize = {
         }
         return map
       }, {}),
-  broken: v => v,
   clearCacheTrigger: v => undefined,
   conversationIDs: v => v.map(v => v.conversation.conversationIDKey),
   conversationMap: (v, o) =>
@@ -48,6 +47,7 @@ export const serialize = {
   loggedIn: v => v,
   totalSyncingBytes: v => v,
   outOfDate: v => v,
+  userInfo: v => v,
   username: v => v,
   windowComponent: v => v,
   windowOpts: v => v,

--- a/shared/reducers/users.js
+++ b/shared/reducers/users.js
@@ -1,12 +1,16 @@
 // @flow
 import * as UsersGen from '../actions/users-gen'
+import * as TrackerGen from '../actions/tracker-gen'
 import * as Constants from '../constants/users'
 import * as Types from '../constants/types/users'
 
 const initialState: Types.State = Constants.makeState()
 const blankUserInfo = Constants.makeUserInfo()
 
-const reducer = (state: Types.State = initialState, action: UsersGen.Actions): Types.State => {
+const reducer = (
+  state: Types.State = initialState,
+  action: UsersGen.Actions | TrackerGen.UpdateUserInfoPayload
+): Types.State => {
   switch (action.type) {
     case UsersGen.resetStore:
       return initialState
@@ -33,6 +37,11 @@ const reducer = (state: Types.State = initialState, action: UsersGen.Actions): T
             m.update(user, info => (info || blankUserInfo).set('broken', true))
           })
         })
+      )
+    }
+    case TrackerGen.updateUserInfo: {
+      return state.updateIn(['infoMap', action.payload.username], (userInfo = blankUserInfo) =>
+        userInfo.set('fullname', action.payload.userCard.fullName)
       )
     }
     // Saga only actions


### PR DESCRIPTION
The tracker updates were already being piped through to the users store (I added the fullnames too). This adds `colorBroken` to `NameWithIcon` and makes ConnectedUsernames look into `state.users` instead of the tracker state. Remote code deserves a lot of scrutiny r? @keybase/react-hackers 