### PR TITLE
Remove `color: undefined` from wrapStyle

### DIFF
--- a/shared/common-adapters/markdown/react.js
+++ b/shared/common-adapters/markdown/react.js
@@ -17,9 +17,6 @@ const wrapStyle = Styles.platformStyles({
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
   },
-  isMobile: {
-    color: undefined,
-  },
 })
 
 const bigTextBlockStyle = Styles.platformStyles({


### PR DESCRIPTION
The new markdown uses fewer container components, so it doesn't need
this "neutral" style like the old markdown did. Having it there caused
the component to fallback to black_100.

@keybase/react-hackers 