### PR TITLE
Suspend inbox loading on sends

### DIFF
--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -680,6 +680,7 @@ func (s *BlockingSender) presentUIItem(conv *chat1.ConversationLocal) (res *chat
 func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 	msg chat1.MessagePlaintext, clientPrev chat1.MessageID, outboxID *chat1.OutboxID) (obid chat1.OutboxID, boxed *chat1.MessageBoxed, err error) {
 	defer s.Trace(ctx, func() error { return err }, fmt.Sprintf("Send(%s)", convID))()
+	defer utils.SuspendComponent(ctx, s.G(), s.G().InboxSource)()
 
 	// Record that this user is "active in chat", which we use to determine
 	// gregor reconnect backoffs.

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1125,8 +1125,6 @@ func (h *Server) PostLocal(ctx context.Context, arg chat1.PostLocalArg) (res cha
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostLocal")()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
-	defer h.suspendConvLoader(ctx)()
-	defer h.suspendInboxSource(ctx)()
 	uid, err := utils.AssertLoggedInUID(ctx, h.G())
 	if err != nil {
 		return res, err
@@ -1371,7 +1369,6 @@ func (h *Server) PostLocalNonblock(ctx context.Context, arg chat1.PostLocalNonbl
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostLocalNonblock")()
 	defer h.suspendConvLoader(ctx)()
-	defer h.suspendInboxSource(ctx)()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
 	uid, err := utils.AssertLoggedInUID(ctx, h.G())
 	if err != nil {
@@ -1446,7 +1443,6 @@ func (h *Server) PostFileAttachmentMessageLocalNonblock(ctx context.Context,
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostFileAttachmentMessageLocalNonblock")()
 	defer h.suspendConvLoader(ctx)()
-	defer h.suspendInboxSource(ctx)()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
 
 	// Create non block sender
@@ -1470,7 +1466,6 @@ func (h *Server) PostFileAttachmentUploadLocalNonblock(ctx context.Context,
 	defer h.Trace(ctx, func() error { return err },
 		fmt.Sprintf("PostFileAttachmentUploadLocalNonblock(%s)", arg.OutboxID))()
 	defer h.suspendConvLoader(ctx)()
-	defer h.suspendInboxSource(ctx)()
 
 	uid := h.getUID()
 	if _, err = h.G().AttachmentUploader.Register(ctx, uid, arg.ConvID, arg.OutboxID, arg.Title,
@@ -1486,7 +1481,6 @@ func (h *Server) PostFileAttachmentLocal(ctx context.Context, arg chat1.PostFile
 	ctx = Context(ctx, h.G(), arg.Arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostFileAttachmentLocal")()
 	defer h.suspendConvLoader(ctx)()
-	defer h.suspendInboxSource(ctx)()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
 
 	// Get base of message we are going to send

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1125,6 +1125,8 @@ func (h *Server) PostLocal(ctx context.Context, arg chat1.PostLocalArg) (res cha
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostLocal")()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
+	defer h.suspendConvLoader(ctx)()
+	defer h.suspendInboxSource(ctx)()
 	uid, err := utils.AssertLoggedInUID(ctx, h.G())
 	if err != nil {
 		return res, err
@@ -1369,6 +1371,7 @@ func (h *Server) PostLocalNonblock(ctx context.Context, arg chat1.PostLocalNonbl
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostLocalNonblock")()
 	defer h.suspendConvLoader(ctx)()
+	defer h.suspendInboxSource(ctx)()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
 	uid, err := utils.AssertLoggedInUID(ctx, h.G())
 	if err != nil {
@@ -1443,6 +1446,7 @@ func (h *Server) PostFileAttachmentMessageLocalNonblock(ctx context.Context,
 	ctx = Context(ctx, h.G(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostFileAttachmentMessageLocalNonblock")()
 	defer h.suspendConvLoader(ctx)()
+	defer h.suspendInboxSource(ctx)()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
 
 	// Create non block sender
@@ -1466,6 +1470,7 @@ func (h *Server) PostFileAttachmentUploadLocalNonblock(ctx context.Context,
 	defer h.Trace(ctx, func() error { return err },
 		fmt.Sprintf("PostFileAttachmentUploadLocalNonblock(%s)", arg.OutboxID))()
 	defer h.suspendConvLoader(ctx)()
+	defer h.suspendInboxSource(ctx)()
 
 	uid := h.getUID()
 	if _, err = h.G().AttachmentUploader.Register(ctx, uid, arg.ConvID, arg.OutboxID, arg.Title,
@@ -1481,6 +1486,7 @@ func (h *Server) PostFileAttachmentLocal(ctx context.Context, arg chat1.PostFile
 	ctx = Context(ctx, h.G(), arg.Arg.IdentifyBehavior, &identBreaks, h.identNotifier)
 	defer h.Trace(ctx, func() error { return err }, "PostFileAttachmentLocal")()
 	defer h.suspendConvLoader(ctx)()
+	defer h.suspendInboxSource(ctx)()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
 
 	// Get base of message we are going to send

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -131,24 +131,12 @@ func (h *Server) presentUnverifiedInbox(ctx context.Context, convs []types.Remot
 	return res, err
 }
 
-func (h *Server) suspendComponent(ctx context.Context, suspendable types.Suspendable) func() {
-	if canceled := suspendable.Suspend(ctx); canceled {
-		h.Debug(ctx, "suspendComponent: canceled background task")
-	}
-	return func() {
-		suspendable.Resume(ctx)
-	}
-}
-
-// suspendConvLoader will suspend the global ConvLoader until the return function is called. This allows
-// a succinct call like defer suspendConvLoader(ctx)() in RPC handlers wishing to lock out the
-// conv loader.
 func (h *Server) suspendConvLoader(ctx context.Context) func() {
-	return h.suspendComponent(ctx, h.G().ConvLoader)
+	return utils.SuspendComponent(ctx, h.G(), h.G().ConvLoader)
 }
 
 func (h *Server) suspendInboxSource(ctx context.Context) func() {
-	return h.suspendComponent(ctx, h.G().InboxSource)
+	return utils.SuspendComponent(ctx, h.G(), h.G().InboxSource)
 }
 
 func (h *Server) getUID() gregor1.UID {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1660,3 +1660,16 @@ func SetUnfurl(mvalid *chat1.MessageUnboxedValid, unfurlMessageID chat1.MessageI
 	}
 	mvalid.Unfurls[unfurlMessageID] = unfurl
 }
+
+// SuspendComponent will suspend the global ConvLoader until the return
+// function is called. This allows a succinct call like defer
+// SuspendComponent(ctx, g, g.ConvLoader)() in RPC handlers wishing to lock out
+// the conv loader.
+func SuspendComponent(ctx context.Context, g *globals.Context, suspendable types.Suspendable) func() {
+	if canceled := suspendable.Suspend(ctx); canceled {
+		g.Log.CDebugf(ctx, "SuspendComponent: canceled background task")
+	}
+	return func() {
+		suspendable.Resume(ctx)
+	}
+}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1661,10 +1661,9 @@ func SetUnfurl(mvalid *chat1.MessageUnboxedValid, unfurlMessageID chat1.MessageI
 	mvalid.Unfurls[unfurlMessageID] = unfurl
 }
 
-// SuspendComponent will suspend the global ConvLoader until the return
-// function is called. This allows a succinct call like defer
-// SuspendComponent(ctx, g, g.ConvLoader)() in RPC handlers wishing to lock out
-// the conv loader.
+// SuspendComponent will suspend a Suspendable type until the return function
+// is called. This allows a succinct call like defer SuspendComponent(ctx, g,
+// g.ConvLoader)() in RPC handlers wishing to lock out the conv loader.
 func SuspendComponent(ctx context.Context, g *globals.Context, suspendable types.Suspendable) func() {
 	if canceled := suspendable.Suspend(ctx); canceled {
 		g.Log.CDebugf(ctx, "SuspendComponent: canceled background task")


### PR DESCRIPTION
Suspend inbox loads when sending any messages as a potential optimization of the send path. It seems like the machinery was already in place, were there any other places we should be calling this?