### PR TITLE
Only cache team folders for kbfs favorites

### DIFF
--- a/go/engine/favorite_list.go
+++ b/go/engine/favorite_list.go
@@ -55,7 +55,7 @@ func (f *FavoritesAPIResult) GetAppStatus() *libkb.AppStatus {
 }
 
 func (e *FavoriteList) cacheFolder(m libkb.MetaContext, folder keybase1.Folder) {
-	if folder.TeamID == nil || folder.TeamID.IsNil() {
+	if folder.FolderType != keybase1.FolderType_TEAM || folder.TeamID == nil || folder.TeamID.IsNil() {
 		return
 	}
 	name, err := keybase1.TeamNameFromString(folder.Name)


### PR DESCRIPTION
Only cache `TeamID <> TeamName` resolutions for `TEAM` folders, squashes noisy error when trying to parse an imp team name as a team name