### PR TITLE
hide black bars from search endpoint error

### DIFF
--- a/shared/team-building/service-tab-bar.js
+++ b/shared/team-building/service-tab-bar.js
@@ -38,9 +38,9 @@ const ServiceIcon = (props: IconProps) => (
         ])}
       />
       {!!props.showCount &&
-        (props.count ? (
+        (Number.isInteger(props.count) ? (
           <Kb.Text type="BodyTinySemibold" style={styles.resultCount}>
-            {props.count > 10 ? '10+' : props.count}
+            {props.count && props.count > 10 ? '10+' : props.count}
           </Kb.Text>
         ) : (
           <Kb.Icon


### PR DESCRIPTION
There's an error with the search endpoint for certain queries. Instead of propagating a black bar, log it and return an empty set.

@keybase/react-hackers 