### PR TITLE
better read of libkb.ResolutionError

### DIFF
--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1661,6 +1661,14 @@ func IsResolutionError(err error) bool {
 	return ok
 }
 
+func IsResolutionNotFoundError(err error) bool {
+	rerr, ok := err.(ResolutionError)
+	if !ok {
+		return false
+	}
+	return rerr.Kind == ResolutionErrorNotFound
+}
+
 //=============================================================================
 
 type NoUIDError struct{}

--- a/go/saltpackkeys/saltpack_recipient_keyfinder_engine.go
+++ b/go/saltpackkeys/saltpack_recipient_keyfinder_engine.go
@@ -155,7 +155,7 @@ func (e *SaltpackRecipientKeyfinderEngine) identifyAndAddUserRecipient(m libkb.M
 		// nothing to do here
 	case libkb.IsIdentifyProofError(err):
 		return fmt.Errorf("Cannot encrypt for %v as their account has changed since you last followed them (it might have been compromised!): please review their identity (with `keybase follow %v`) and then try again (err = %v)", u, u, err)
-	case libkb.IsNotFoundError(err) || libkb.IsResolutionError(err):
+	case libkb.IsNotFoundError(err) || libkb.IsResolutionNotFoundError(err):
 		// recipient is not a keybase user
 
 		expr, err := externals.AssertionParse(m.G(), u)
@@ -178,7 +178,7 @@ func (e *SaltpackRecipientKeyfinderEngine) identifyAndAddUserRecipient(m libkb.M
 			return libkb.NewRecipientNotFoundError(fmt.Sprintf("Cannot encrypt for %v: it is not a registered user (you can remove `--no-self-encrypt` for users not yet on keybase)", u))
 		}
 
-		m.CDebugf("%v is not an existing user, trying to create an implicit team")
+		m.CDebugf("%q is not an existing user, trying to create an implicit team", u)
 		err = e.lookupAndAddImplicitTeamKeys(m, u)
 		return err
 	case libkb.IsNoKeyError(err):

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -984,8 +984,8 @@ func lookupRecipientAssertion(m libkb.MetaContext, assertion string, isCLI bool)
 			m.CDebugf("identifyRecipient: not found %s: %s", assertion, err)
 			return "", nil
 		}
-		if _, ok := err.(libkb.ResolutionError); ok {
-			m.CDebugf("identifyRecipient: resolution error %s: %s", assertion, err)
+		if libkb.IsResolutionNotFoundError(err) {
+			m.CDebugf("identifyRecipient: resolution not found error %s: %s", assertion, err)
 			return "", nil
 		}
 		return "", err


### PR DESCRIPTION
- if you want to do an SBS in the case of a resolution failure, you can't assume that SBS allows follows.
- in most error cases, it does not
- in ResolutionErrorNotFound, it does...
- Fix it in the two places I found issues, but there could be more