### PR TITLE
remove unfurls on explode

### DIFF
--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -362,6 +362,7 @@ const messageMapReducer = (messageMap, action, pendingOutboxToOrdinal) => {
                 .set('text', new HiddenString(''))
                 .set('mentionsAt', I.Set())
                 .set('reactions', I.Map())
+                .set('unfurls', I.Map())
             )
           )
         })


### PR DESCRIPTION
@keybase/react-hackers 

Remove the unfurled output when a message explodes.

cc @joshblum 