### PR TITLE
Handle subdomains after other text

### DIFF
--- a/shared/common-adapters/markdown/index.stories.js
+++ b/shared/common-adapters/markdown/index.stories.js
@@ -73,6 +73,7 @@ Include:
   keybase.io/~user/cool
   http://keybase.io/blah/../up-one/index.html
   keybase.io/)(,)?=56,78,910@123
+  abc subdomain.domain.com
 These should have the trailing punctuation outside the link:
   amazon.co.uk.
   keybase.io,

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -134,7 +134,7 @@ const textMatch = SimpleMarkdown.anyScopeRegex(
     //   | \w+:\S // OR there's letters before a : so stop here.
     //   | $ // OR we reach the end of the line
     // )
-    `^[\\s\\S]+?(?=[^0-9A-Za-z\\s]|[\\u00c0-\\uffff]|[\\w-_.]+@|\\w+\\.(${commonTlds.join(
+    `^[\\s\\S]+?(?=[^0-9A-Za-z\\s]|[\\u00c0-\\uffff]|[\\w-_.]+@|(\\w+\\.)+(${commonTlds.join(
       '|'
     )})|\\n|\\w+:\\S|$)`
   )

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -130,7 +130,7 @@ const textMatch = SimpleMarkdown.anyScopeRegex(
     //   [^0-9A-Za-z\s] not a character in this set. So don't terminate if there is still more normal chars to eat
     //   | [\u00c0-\uffff] OR any unicode char. If there is a weird unicode ahead, we terminate
     //   | [\w-_.]+@ // OR something that looks like it starts an email. If there is an email looking thing ahead stop here.
-    //   | \w+\.(${commonTlds.join('|')}) // OR there is a url with a common tld ahead. Stop if there's a common url ahead
+    //   | (\w+\.)+(${commonTlds.join('|')}) // OR there is a url with a common tld ahead. Stop if there's a common url ahead
     //   | \w+:\S // OR there's letters before a : so stop here.
     //   | $ // OR we reach the end of the line
     // )


### PR DESCRIPTION
Adds subdomains to the lookahead that decides where to end text
@keybase/react-hackers @MarcoPolo  