### PR TITLE
Only stop search on permanent errors

### DIFF
--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1373,7 +1373,7 @@ func modifyBoxerForTesting(t *testing.T, boxer *Boxer, canned *cannedMessage) {
 		require.Equal(t, canned.SenderDeviceID(t), did)
 		return canned.senderUsername, canned.senderDeviceName, canned.senderDeviceType
 	}
-	boxer.testingValidSenderKey = func(ctx context.Context, uid gregor1.UID, verifyKey []byte, ctime gregor1.Time) (found, validAtCTime bool, revoked *gregor1.Time, unboxingErr UnboxingError) {
+	boxer.testingValidSenderKey = func(ctx context.Context, uid gregor1.UID, verifyKey []byte, ctime gregor1.Time) (found, validAtCTime bool, revoked *gregor1.Time, unboxingErr types.UnboxingError) {
 		require.Equal(t, canned.SenderUID(t), uid)
 		require.Equal(t, canned.VerifyKey(t), verifyKey)
 		// ignore ctime, always report the key as still valid
@@ -1769,7 +1769,7 @@ func TestVersionError(t *testing.T) {
 	// chat1/extras.go#MessageUnboxedError.ParseableVersion to stay up to date
 	// for it's max accepted versions. Vx__ will also have to be updated in the
 	// checks below
-	assertErr := func(err UnboxingError) {
+	assertErr := func(err types.UnboxingError) {
 		require.Error(t, err)
 		typ := err.ExportType()
 		switch typ {

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -15,25 +16,7 @@ var ErrChatServerTimeout = errors.New("timeout calling chat server")
 var ErrDuplicateConnection = errors.New("error calling chat server")
 var ErrKeyServerTimeout = errors.New("timeout calling into key server")
 
-type InternalError interface {
-	// verbose error info for debugging but not user display
-	InternalError() string
-}
-
-type UnboxingError interface {
-	InternalError
-	Error() string
-	Inner() error
-	IsPermanent() bool
-	ExportType() chat1.MessageUnboxedErrorType
-	VersionKind() chat1.VersionKind
-	VersionNumber() int
-	IsCritical() bool
-}
-
-var _ error = (UnboxingError)(nil)
-
-func NewPermanentUnboxingError(inner error) UnboxingError {
+func NewPermanentUnboxingError(inner error) types.UnboxingError {
 	return PermanentUnboxingError{inner}
 }
 
@@ -89,7 +72,7 @@ func (e PermanentUnboxingError) IsCritical() bool {
 
 func (e PermanentUnboxingError) InternalError() string {
 	switch err := e.Inner().(type) {
-	case InternalError:
+	case types.InternalError:
 		return err.InternalError()
 	default:
 		return err.Error()
@@ -98,7 +81,7 @@ func (e PermanentUnboxingError) InternalError() string {
 
 //=============================================================================
 
-func NewTransientUnboxingError(inner error) UnboxingError {
+func NewTransientUnboxingError(inner error) types.UnboxingError {
 	return TransientUnboxingError{inner}
 }
 
@@ -130,7 +113,7 @@ func (e TransientUnboxingError) IsCritical() bool {
 
 func (e TransientUnboxingError) InternalError() string {
 	switch err := e.Inner().(type) {
-	case InternalError:
+	case types.InternalError:
 		return err.InternalError()
 	default:
 		return err.Error()

--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -532,7 +532,7 @@ func (s *localizerPipeline) localizeConversations(localizeJob *localizerPipeline
 }
 
 func (s *localizerPipeline) isErrPermanent(err error) bool {
-	if uberr, ok := err.(UnboxingError); ok {
+	if uberr, ok := err.(types.UnboxingError); ok {
 		return uberr.IsPermanent()
 	}
 	return false
@@ -898,7 +898,7 @@ func (s *localizerPipeline) checkRekeyErrorInner(ctx context.Context, fromErr er
 	var rekeyInfo *chat1.ConversationErrorRekey
 
 	switch fromErr := fromErr.(type) {
-	case UnboxingError:
+	case types.UnboxingError:
 		switch conversationRemote.GetMembersType() {
 		case chat1.ConversationMembersType_KBFS:
 			switch fromErr := fromErr.Inner().(type) {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -374,3 +374,21 @@ type Unfurler interface {
 	WhitelistRemove(ctx context.Context, uid gregor1.UID, domain string) error
 	SetMode(ctx context.Context, uid gregor1.UID, mode chat1.UnfurlMode) error
 }
+
+type InternalError interface {
+	// verbose error info for debugging but not user display
+	InternalError() string
+}
+
+type UnboxingError interface {
+	InternalError
+	Error() string
+	Inner() error
+	IsPermanent() bool
+	ExportType() chat1.MessageUnboxedErrorType
+	VersionKind() chat1.VersionKind
+	VersionNumber() int
+	IsCritical() bool
+}
+
+var _ error = (UnboxingError)(nil)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1672,3 +1672,10 @@ func SuspendComponent(ctx context.Context, g *globals.Context, suspendable types
 		suspendable.Resume(ctx)
 	}
 }
+
+func IsPermanentErr(err error) bool {
+	if uberr, ok := err.(types.UnboxingError); ok {
+		return uberr.IsPermanent()
+	}
+	return err != nil
+}


### PR DESCRIPTION
Prevents search from failing for transient errors