### PR TITLE
Fix crasher when 'Next' is tapped on send form

### DIFF
--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -1,6 +1,7 @@
 // @flow
 import {compose, withHandlers, withPropsOnChange} from 'recompose'
 import * as Types from '../constants/types/search'
+import {isMobile} from '../constants/platform'
 import {debounce} from 'lodash-es'
 
 const debounceTimeout = 1e3
@@ -77,7 +78,7 @@ const onChangeSelectedSearchResultHoc: any = compose(
             if (props.onSelectUser && props.selectedSearchId) {
               props.onSelectUser(props.selectedSearchId)
               props.onChangeSearchText && props.onChangeSearchText('')
-            } else {
+            } else if (isMobile) {
               props.onExitSearch()
             }
           } else {

--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -64,7 +64,8 @@ const onChangeSelectedSearchResultHoc: any = compose(
     let lastSearchTerm
     return {
       // onAddSelectedUser happens on desktop when tab, enter or comma
-      // is typed, so we expedite the current search, if any
+      // is typed, or on mobile when 'Enter' is tapped, so we expedite
+      // the current search, if any
       onAddSelectedUser: (props: OwnPropsWithSearchDebounced) => () => {
         props._searchDebounced.flush()
         // See whether the current search result term matches the last one submitted
@@ -72,13 +73,17 @@ const onChangeSelectedSearchResultHoc: any = compose(
         // $FlowIssue
         if (lastSearchTerm === props.searchResultTerm || props.showingSearchSuggestions) {
           // $FlowIssue
-          if (props.selectedSearchId && props.disableListBuilding) {
-            props.onSelectUser(props.selectedSearchId)
+          if (props.disableListBuilding) {
+            if (props.selectedSearchId) {
+              props.onSelectUser(props.selectedSearchId)
+              props.onChangeSearchText && props.onChangeSearchText('')
+            } else {
+              props.onExitSearch()
+            }
           } else {
-            // $FlowIssue
             props.onAddUser(props.selectedSearchId)
+            props.onChangeSearchText && props.onChangeSearchText('')
           }
-          props.onChangeSearchText && props.onChangeSearchText('')
         }
       },
       onMoveSelectUp: ({onMove}) => () => onMove('up'),

--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -74,7 +74,7 @@ const onChangeSelectedSearchResultHoc: any = compose(
         if (lastSearchTerm === props.searchResultTerm || props.showingSearchSuggestions) {
           // $FlowIssue
           if (props.disableListBuilding) {
-            if (props.selectedSearchId) {
+            if (props.onSelectUser && props.selectedSearchId) {
               props.onSelectUser(props.selectedSearchId)
               props.onChangeSearchText && props.onChangeSearchText('')
             } else {

--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -79,6 +79,8 @@ const onChangeSelectedSearchResultHoc: any = compose(
               props.onSelectUser(props.selectedSearchId)
               props.onChangeSearchText && props.onChangeSearchText('')
             } else if (isMobile) {
+              // On mobile, this function is called if the user taps
+              // enter, which means the keyboard is going away.
               props.onExitSearch()
             }
           } else {

--- a/shared/search/helpers.js
+++ b/shared/search/helpers.js
@@ -65,7 +65,7 @@ const onChangeSelectedSearchResultHoc: any = compose(
     let lastSearchTerm
     return {
       // onAddSelectedUser happens on desktop when tab, enter or comma
-      // is typed, or on mobile when 'Enter' is tapped, so we expedite
+      // is typed, or on mobile when 'Next' is tapped, so we expedite
       // the current search, if any
       onAddSelectedUser: (props: OwnPropsWithSearchDebounced) => () => {
         props._searchDebounced.flush()
@@ -80,7 +80,7 @@ const onChangeSelectedSearchResultHoc: any = compose(
               props.onChangeSearchText && props.onChangeSearchText('')
             } else if (isMobile) {
               // On mobile, this function is called if the user taps
-              // enter, which means the keyboard is going away.
+              // 'Next', which means the keyboard is going away.
               props.onExitSearch()
             }
           } else {

--- a/shared/wallets/send-form/participants/search.js
+++ b/shared/wallets/send-form/participants/search.js
@@ -9,7 +9,6 @@ import {searchKey} from '../../../constants/wallets'
 
 export type SearchProps = {|
   onClickResult: (username: string) => void,
-  onClose: () => void,
   onShowSuggestions: () => void,
   onShowTracker: (username: string) => void,
   onScanQRCode: ?() => void,

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -65,7 +65,6 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
   return (
     <Search
       onClickResult={props.onChangeRecipient}
-      onClose={() => {}}
       onShowSuggestions={props.onShowSuggestions}
       onShowTracker={props.onShowProfile}
       onScanQRCode={props.onScanQRCode}


### PR DESCRIPTION
Also exit search if no user is selected, to avoid stranding the app
with the results display portal open.