### PR TITLE
Add --dev to `api-listen` command

### DIFF
--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -27,7 +27,8 @@ type CmdChatAPIListen struct {
 	// of chat participants.
 	showExploding bool
 
-	showLocal bool
+	showLocal    bool
+	subscribeDev bool
 }
 
 func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -51,6 +52,10 @@ func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli
 				Name:  "local",
 				Usage: "Show local messages (skipped by default)",
 			},
+			cli.BoolFlag{
+				Name:  "dev",
+				Usage: "Also subscribe to notifications from dev channel",
+			},
 		},
 	}
 }
@@ -58,6 +63,7 @@ func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli
 func (c *CmdChatAPIListen) ParseArgv(ctx *cli.Context) error {
 	c.showExploding = ctx.Bool("exploding")
 	c.showLocal = ctx.Bool("local")
+	c.subscribeDev = ctx.Bool("dev")
 	return nil
 }
 
@@ -77,6 +83,9 @@ func (c *CmdChatAPIListen) Run() error {
 	}
 	channels := keybase1.NotificationChannels{
 		Chat: true,
+	}
+	if c.subscribeDev {
+		channels.Chatdev = true
 	}
 
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -82,10 +82,8 @@ func (c *CmdChatAPIListen) Run() error {
 		chat1.NotifyChatProtocol(display),
 	}
 	channels := keybase1.NotificationChannels{
-		Chat: true,
-	}
-	if c.subscribeDev {
-		channels.Chatdev = true
+		Chat:    true,
+		Chatdev: c.subscribeDev,
 	}
 
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {


### PR DESCRIPTION
This adds a new flag `--dev` to `chat api-listen` command that will make it subscribe to the dev channel. 

When a new message comes in, it's type (chat/dev) can be distinguished using `channel.topic_type` field:
```
"channel": {
    "name": "testuser79f4,testuser9181",
    "public": false,
    "members_type": "impteamnative",
    "topic_type": "dev"
},
```