### PR TITLE
Fix length validation on public memo / secret note

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -23,7 +23,6 @@ import {anyWaiting} from '../constants/waiting'
 import {RPCError} from '../util/errors'
 import {isMobile} from '../constants/platform'
 import {actionHasError} from '../util/container'
-import {debounce} from 'lodash-es'
 
 const buildPayment = (
   state: TypedState,
@@ -83,8 +82,6 @@ const buildPayment = (
     }
   })
 }
-
-const buildPaymentDebounced = debounce(buildPayment, 1000)
 
 const openSendRequestForm = (state: TypedState, action: WalletsGen.OpenSendRequestFormPayload) =>
   state.wallets.acceptedDisclaimer
@@ -730,6 +727,8 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(WalletsGen.accountsReceived, maybeSelectDefaultAccount)
   yield Saga.safeTakeEveryPure(WalletsGen.accountsReceived, loadDisplayCurrencyForAccounts)
 
+  // We don't call this for publicMemo/secretNote so the button doesn't
+  // spinner as you type
   yield Saga.actionToPromise(
     [
       WalletsGen.buildPayment,
@@ -741,10 +740,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
       WalletsGen.displayCurrencyReceived,
     ],
     buildPayment
-  )
-  yield Saga.actionToPromise(
-    [WalletsGen.setBuildingPublicMemo, WalletsGen.setBuildingSecretNote],
-    buildPaymentDebounced
   )
   yield Saga.actionToAction(WalletsGen.openSendRequestForm, openSendRequestForm)
 

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -23,6 +23,7 @@ import {anyWaiting} from '../constants/waiting'
 import {RPCError} from '../util/errors'
 import {isMobile} from '../constants/platform'
 import {actionHasError} from '../util/container'
+import {debounce} from 'lodash-es'
 
 const buildPayment = (
   state: TypedState,
@@ -82,6 +83,8 @@ const buildPayment = (
     }
   })
 }
+
+const buildPaymentDebounced = debounce(buildPayment, 1000)
 
 const openSendRequestForm = (state: TypedState, action: WalletsGen.OpenSendRequestFormPayload) =>
   state.wallets.acceptedDisclaimer
@@ -727,8 +730,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(WalletsGen.accountsReceived, maybeSelectDefaultAccount)
   yield Saga.safeTakeEveryPure(WalletsGen.accountsReceived, loadDisplayCurrencyForAccounts)
 
-  // We don't call this for publicMemo/secretNote so the button doesn't
-  // spinner as you type
   yield Saga.actionToPromise(
     [
       WalletsGen.buildPayment,
@@ -740,6 +741,10 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
       WalletsGen.displayCurrencyReceived,
     ],
     buildPayment
+  )
+  yield Saga.actionToPromise(
+    [WalletsGen.setBuildingPublicMemo, WalletsGen.setBuildingSecretNote],
+    buildPaymentDebounced
   )
   yield Saga.actionToAction(WalletsGen.openSendRequestForm, openSendRequestForm)
 

--- a/shared/common-adapters/plain-input.desktop.js
+++ b/shared/common-adapters/plain-input.desktop.js
@@ -9,18 +9,11 @@ import type {_StylesDesktop} from '../styles/css'
 import type {InternalProps, TextInfo, Selection} from './plain-input'
 import {checkTextInfo} from './input.shared'
 
-let encoder, decoder
-if (!__STORYSHOT__) {
-  encoder = new window.TextEncoder()
-  decoder = new window.TextDecoder('utf-8')
-}
-
 // A plain text input component. Handles callbacks, text styling, and auto resizing but
 // adds no styling.
 class PlainInput extends React.PureComponent<InternalProps> {
   _input: HTMLTextAreaElement | HTMLInputElement | null
   _isComposingIME: boolean = false
-  _lastOnChangeValue: string = this.props.value || ''
 
   static defaultProps = {
     textType: 'Body',
@@ -33,23 +26,14 @@ class PlainInput extends React.PureComponent<InternalProps> {
   // This is controlled if a value prop is passed
   _controlled = () => typeof this.props.value === 'string'
 
-  _onChange = ({target: {value: _value = ''}}) => {
-    let value = _value
+  _onChange = ({target: {value = ''}}) => {
     if (this.props.maxBytes) {
-      // check we haven't exceeded max bytes
       const {maxBytes} = this.props
-      const encoded = encoder.encode(value)
-      if (encoded.length > maxBytes) {
-        // truncate value, check against past onChangeValue, bail if unchanged
-        const truncated = decoder.decode(encoded.slice(0, maxBytes))
-        if (truncated === this._lastOnChangeValue) {
-          return
-        }
-        value = truncated
+      if (Buffer.byteLength(value) > maxBytes) {
+        return
       }
     }
 
-    this._lastOnChangeValue = value
     this.props.onChangeText && this.props.onChangeText(value)
     this._autoResize()
   }

--- a/shared/common-adapters/plain-input.desktop.js
+++ b/shared/common-adapters/plain-input.desktop.js
@@ -9,8 +9,11 @@ import type {_StylesDesktop} from '../styles/css'
 import type {InternalProps, TextInfo, Selection} from './plain-input'
 import {checkTextInfo} from './input.shared'
 
-const encoder = new window.TextEncoder()
-const decoder = new window.TextDecoder('utf-8')
+let encoder, decoder
+if (!__STORYSHOT__) {
+  encoder = new window.TextEncoder()
+  decoder = new window.TextDecoder('utf-8')
+}
 
 // A plain text input component. Handles callbacks, text styling, and auto resizing but
 // adds no styling.

--- a/shared/common-adapters/plain-input.js.flow
+++ b/shared/common-adapters/plain-input.js.flow
@@ -29,6 +29,10 @@ export type Props = {|
   // Resize in a flexbox-like fashion
   flexable?: boolean,
   maxLength?: number,
+  // doesn't fire onChangeText if value would exceed maxBytes (utf-8)
+  // i.e. can only have an effect if this is a controlled input
+  // doesn't enforce on longer `props.value`s coming in
+  maxBytes?: number,
   multiline?: boolean,
   onBlur?: () => void,
   onChangeText?: (text: string) => void,

--- a/shared/common-adapters/plain-input.native.js
+++ b/shared/common-adapters/plain-input.native.js
@@ -103,6 +103,12 @@ class PlainInput extends Component<InternalProps, State> {
   }
 
   _onChangeText = (t: string) => {
+    if (this.props.maxBytes) {
+      const {maxBytes} = this.props
+      if (Buffer.byteLength(t) > maxBytes) {
+        return
+      }
+    }
     this._lastNativeText = t
     this.props.onChangeText && this.props.onChangeText(t)
   }

--- a/shared/common-adapters/plain-input.stories.js
+++ b/shared/common-adapters/plain-input.stories.js
@@ -148,6 +148,7 @@ const load = () => {
     .addDecorator(scrollViewDecorator)
     .add('Basic', () => <PlainInput {...commonProps} />)
     .add('Max Length=10', () => <PlainInput {...commonProps} maxLength={10} />)
+    .add('Max Bytes=10', () => <PlainInput {...commonProps} maxBytes={10} />)
     .add('Different text type', () => <PlainInput {...commonProps} textType="BodyExtrabold" />)
     .add('Larger text type', () => <PlainInput {...commonProps} textType="HeaderBig" />)
     .add('Password', () => <PlainInput {...commonProps} type="password" />)

--- a/shared/common-adapters/plain-input.stories.js
+++ b/shared/common-adapters/plain-input.stories.js
@@ -147,6 +147,7 @@ const load = () => {
     .addDecorator(story => <Box style={{padding: 20}}>{story()}</Box>)
     .addDecorator(scrollViewDecorator)
     .add('Basic', () => <PlainInput {...commonProps} />)
+    .add('Max Length=10', () => <PlainInput {...commonProps} maxLength={10} />)
     .add('Different text type', () => <PlainInput {...commonProps} textType="BodyExtrabold" />)
     .add('Larger text type', () => <PlainInput {...commonProps} textType="HeaderBig" />)
     .add('Password', () => <PlainInput {...commonProps} type="password" />)

--- a/shared/common-adapters/plain-input.stories.js
+++ b/shared/common-adapters/plain-input.stories.js
@@ -19,7 +19,7 @@ const commonProps = {
   style: {borderWidth: 1, borderStyle: 'solid', borderColor: globalColors.black_10},
 }
 
-class TestInput extends React.Component<{multiline: boolean}, {value: string}> {
+class TestInput extends React.Component<{maxBytes?: number, multiline: boolean}, {value: string}> {
   state = {value: ''}
   _input: {current: React$ElementRef<typeof PlainInput> | null} = React.createRef()
 
@@ -53,6 +53,7 @@ class TestInput extends React.Component<{multiline: boolean}, {value: string}> {
           {...commonProps}
           ref={this._input}
           value={this.state.value}
+          maxBytes={this.props.maxBytes}
           multiline={this.props.multiline}
           onEnterKeyDown={() => this._insertText('foo')}
           onChangeText={v => this.setState(s => (s.value === v ? null : {value: v}))}
@@ -66,7 +67,10 @@ class TestInput extends React.Component<{multiline: boolean}, {value: string}> {
 }
 
 type ControlledInputState = {[key: string]: string}
-class ControlledInputPlayground extends React.Component<{multiline: boolean}, ControlledInputState> {
+class ControlledInputPlayground extends React.Component<
+  {maxBytes?: number, multiline: boolean},
+  ControlledInputState
+> {
   state = {}
   mutationTarget = React.createRef()
   _onChangeText = (valueKey: string) => (t: string) => this.setState({[valueKey]: t})
@@ -101,7 +105,7 @@ class ControlledInputPlayground extends React.Component<{multiline: boolean}, Co
     }
   }
   render() {
-    const common = {...commonProps, multiline: this.props.multiline}
+    const common = {...commonProps, maxBytes: this.props.maxBytes, multiline: this.props.multiline}
     return (
       <Box2 direction="vertical" fullWidth={true} gap="small" style={{padding: globalMargins.small}}>
         <Text type="Body">Basic controlled inputs</Text>
@@ -136,7 +140,7 @@ class ControlledInputPlayground extends React.Component<{multiline: boolean}, Co
             <Button type="Secondary" label="Run test" onClick={this._testCrossSelection} />
           </ButtonBar>
         </Box2>
-        <TestInput multiline={this.props.multiline} />
+        <TestInput maxBytes={this.props.maxBytes} multiline={this.props.multiline} />
       </Box2>
     )
   }
@@ -148,7 +152,6 @@ const load = () => {
     .addDecorator(scrollViewDecorator)
     .add('Basic', () => <PlainInput {...commonProps} />)
     .add('Max Length=10', () => <PlainInput {...commonProps} maxLength={10} />)
-    .add('Max Bytes=10', () => <PlainInput {...commonProps} maxBytes={10} />)
     .add('Different text type', () => <PlainInput {...commonProps} textType="BodyExtrabold" />)
     .add('Larger text type', () => <PlainInput {...commonProps} textType="HeaderBig" />)
     .add('Password', () => <PlainInput {...commonProps} type="password" />)
@@ -175,6 +178,9 @@ const load = () => {
     ))
     // Sandbox for testing controlled input bugginess
     .add('Controlled input playground', () => <ControlledInputPlayground multiline={false} />)
+    .add('Controlled input playground (maxBytes=10)', () => (
+      <ControlledInputPlayground multiline={false} maxBytes={10} />
+    ))
     .add('Controlled input playground (multiline)', () => <ControlledInputPlayground multiline={true} />)
 }
 

--- a/shared/react-native/ios/Keybase/Storybook.m
+++ b/shared/react-native/ios/Keybase/Storybook.m
@@ -24,7 +24,7 @@ RCT_EXPORT_MODULE(Storybook);
 - (NSDictionary *)constantsToExport
 {
   // Set this to true to enable storybook mode
-  return @{@"isStorybook": @false};
+  return @{@"isStorybook": @true};
 }
 
 @end

--- a/shared/react-native/ios/Keybase/Storybook.m
+++ b/shared/react-native/ios/Keybase/Storybook.m
@@ -24,7 +24,7 @@ RCT_EXPORT_MODULE(Storybook);
 - (NSDictionary *)constantsToExport
 {
   // Set this to true to enable storybook mode
-  return @{@"isStorybook": @true};
+  return @{@"isStorybook": @false};
 }
 
 @end

--- a/shared/wallets/send-form/note-and-memo/index.js
+++ b/shared/wallets/send-form/note-and-memo/index.js
@@ -21,7 +21,6 @@ type PublicMemoProps = {
 // TODO use wallet staticConfig to keep in sync with the service
 const secretNoteMaxLength = 500
 const publicMemoMaxLength = 28
-const getByteLength = s => Buffer.byteLength(s)
 
 type SecretNoteState = {
   emojiPickerOpen: boolean,
@@ -57,7 +56,7 @@ class SecretNote extends React.Component<SecretNoteProps, SecretNoteState> {
       }
       const secretNote =
         this.state.secretNote.slice(0, selection.start) + emoji + this.state.secretNote.slice(selection.end)
-      if (getByteLength(secretNote) > secretNoteMaxLength) {
+      if (Buffer.byteLength(secretNote) > secretNoteMaxLength) {
         return
       }
       const newSelection = {start: selection.start + emoji.length, end: selection.start + emoji.length}
@@ -124,7 +123,7 @@ class SecretNote extends React.Component<SecretNoteProps, SecretNoteState> {
             <Kb.Box2 direction="horizontal" style={styles.flexOne}>
               {!!this.state.secretNote && (
                 <Kb.Text type="BodySmall">
-                  {secretNoteMaxLength - getByteLength(this.state.secretNote)} characters left
+                  {secretNoteMaxLength - Buffer.byteLength(this.state.secretNote)} characters left
                 </Kb.Text>
               )}
             </Kb.Box2>
@@ -175,7 +174,7 @@ class PublicMemo extends React.Component<PublicMemoProps, PublicMemoState> {
           />
           {!!this.state.publicMemo && (
             <Kb.Text type="BodySmall">
-              {publicMemoMaxLength - getByteLength(this.state.publicMemo)} characters left
+              {publicMemoMaxLength - Buffer.byteLength(this.state.publicMemo)} characters left
             </Kb.Text>
           )}
           {!!this.props.publicMemoError && (

--- a/shared/wallets/send-form/note-and-memo/index.js
+++ b/shared/wallets/send-form/note-and-memo/index.js
@@ -21,6 +21,8 @@ type PublicMemoProps = {
 // TODO use wallet staticConfig to keep in sync with the service
 const secretNoteMaxLength = 500
 const publicMemoMaxLength = 28
+const encoder = new TextEncoder('utf-8')
+const getByteLength = s => encoder.encode(s).length
 
 type SecretNoteState = {
   emojiPickerOpen: boolean,
@@ -120,7 +122,7 @@ class SecretNote extends React.Component<SecretNoteProps, SecretNoteState> {
             <Kb.Box2 direction="horizontal" style={styles.flexOne}>
               {!!this.state.secretNote && (
                 <Kb.Text type="BodySmall">
-                  {secretNoteMaxLength - this.state.secretNote.length} characters left
+                  {secretNoteMaxLength - getByteLength(this.state.secretNote)} characters left
                 </Kb.Text>
               )}
             </Kb.Box2>
@@ -171,7 +173,7 @@ class PublicMemo extends React.Component<PublicMemoProps, PublicMemoState> {
           />
           {!!this.state.publicMemo && (
             <Kb.Text type="BodySmall">
-              {publicMemoMaxLength - this.state.publicMemo.length} characters left
+              {publicMemoMaxLength - getByteLength(this.state.publicMemo)} characters left
             </Kb.Text>
           )}
           {!!this.props.publicMemoError && (

--- a/shared/wallets/send-form/note-and-memo/index.js
+++ b/shared/wallets/send-form/note-and-memo/index.js
@@ -21,8 +21,7 @@ type PublicMemoProps = {
 // TODO use wallet staticConfig to keep in sync with the service
 const secretNoteMaxLength = 500
 const publicMemoMaxLength = 28
-const encoder = new TextEncoder('utf-8')
-const getByteLength = s => encoder.encode(s).length
+const getByteLength = s => Buffer.byteLength(s)
 
 type SecretNoteState = {
   emojiPickerOpen: boolean,
@@ -58,6 +57,9 @@ class SecretNote extends React.Component<SecretNoteProps, SecretNoteState> {
       }
       const secretNote =
         this.state.secretNote.slice(0, selection.start) + emoji + this.state.secretNote.slice(selection.end)
+      if (getByteLength(secretNote) > secretNoteMaxLength) {
+        return
+      }
       const newSelection = {start: selection.start + emoji.length, end: selection.start + emoji.length}
       this.props.onChangeSecretNote(secretNote)
       this.setState({secretNote}, () => {
@@ -100,7 +102,7 @@ class SecretNote extends React.Component<SecretNoteProps, SecretNoteState> {
               ref={!Styles.isMobile ? this._note : undefined}
               onChangeText={this._onChangeSecretNote}
               value={this.state.secretNote}
-              maxLength={secretNoteMaxLength}
+              maxBytes={secretNoteMaxLength}
             />
             {this.state.emojiPickerOpen && !Styles.isMobile && (
               <Kb.Overlay
@@ -169,7 +171,7 @@ class PublicMemo extends React.Component<PublicMemoProps, PublicMemoState> {
             rowsMax={6}
             onChangeText={this._onChangePublicMemo}
             value={this.state.publicMemo}
-            maxLength={publicMemoMaxLength}
+            maxBytes={publicMemoMaxLength}
           />
           {!!this.state.publicMemo && (
             <Kb.Text type="BodySmall">
@@ -209,6 +211,7 @@ const styles = Styles.styleSheetCreate({
   },
   emojiIcon: {
     alignSelf: 'flex-end',
+    marginTop: 1, // otherwise top is cut off w/ long note
   },
   flexOne: {
     flex: 1,


### PR DESCRIPTION
The length bounds we have are in _bytes_, so a `.length` check or `maxLength` prop don't do the trick. This adds a `maxBytes` prop to plain input and uses that to enforce the length. r? @keybase/react-hackers 