### PR TITLE
Make close behavior better for send attachment dialog

### DIFF
--- a/shared/chat/conversation/attachment-get-titles/container.js
+++ b/shared/chat/conversation/attachment-get-titles/container.js
@@ -36,11 +36,11 @@ const mapDispatchToProps = dispatch => ({
     )
     dispatch(navigateUp())
   },
-  onClose: () => dispatch(navigateUp()),
+  onCancel: () => dispatch(navigateUp()),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
-  onClose: dispatchProps.onClose,
+  onCancel: dispatchProps.onCancel,
   onSubmit: (pathToInfo: PathToInfo) => dispatchProps._onSubmit(stateProps._conversationIDKey, pathToInfo),
   pathToInfo: stateProps.pathAndOutboxIDs.reduce((map, {path, outboxID}) => {
     const filename = FsTypes.getLocalPathName(path)

--- a/shared/chat/conversation/attachment-get-titles/index.js
+++ b/shared/chat/conversation/attachment-get-titles/index.js
@@ -15,7 +15,7 @@ export type PathToInfo = {
 
 type Props = {
   pathToInfo: PathToInfo,
-  onClose: () => void,
+  onCancel: () => void,
   onSubmit: (pathToInfo: PathToInfo) => void,
 }
 type State = {
@@ -135,7 +135,7 @@ class GetTitles extends React.Component<Props, State> {
             selectTextOnFocus={true}
           />
           <Kb.ButtonBar style={{flexShrink: 0}}>
-            <Kb.Button type="Secondary" onClick={this.props.onClose} label="Cancel" />
+            <Kb.Button type="Secondary" onClick={this.props.onCancel} label="Cancel" />
             {this._isLast() ? (
               <Kb.WaitingButton type="Primary" waitingKey={null} onClick={this._onNext} label="Send" />
             ) : (


### PR DESCRIPTION
Also changes 'Close' -> 'Cancel' in mobile header for this page.
r? @keybase/react-hackers 