### PR TITLE
Fix another case for 'From' vs 'To' on the request screen

### DIFF
--- a/shared/wallets/send-form/participants/search.js
+++ b/shared/wallets/send-form/participants/search.js
@@ -8,6 +8,7 @@ import {ParticipantsRow} from '../../common'
 import {searchKey} from '../../../constants/wallets'
 
 export type SearchProps = {|
+  heading: 'To' | 'From',
   onClickResult: (username: string) => void,
   onClose: () => void,
   onShowSuggestions: () => void,
@@ -59,7 +60,12 @@ class Search extends React.Component<SearchProps, SearchState> {
   render() {
     return (
       <React.Fragment>
-        <ParticipantsRow ref={this._setRef} heading="To" style={styles.row} headingStyle={styles.rowHeading}>
+        <ParticipantsRow
+          ref={this._setRef}
+          heading={this.props.heading}
+          style={styles.row}
+          headingStyle={styles.rowHeading}
+        >
           <Kb.Box2 direction="horizontal" fullWidth={true}>
             <UserInput
               disableListBuilding={true}

--- a/shared/wallets/send-form/participants/to-field.js
+++ b/shared/wallets/send-form/participants/to-field.js
@@ -64,6 +64,7 @@ const ToKeybaseUser = (props: ToKeybaseUserProps) => {
   // No username, so show search box.
   return (
     <Search
+      heading={props.isRequest ? 'From' : 'To'}
       onClickResult={props.onChangeRecipient}
       onClose={() => {}}
       onShowSuggestions={props.onShowSuggestions}


### PR DESCRIPTION
@keybase/react-hackers 

We were still saying "To" instead of "From" in the case where you open the Request form from the wallets tab and haven't yet typed in a username.