### PR TITLE
fix for orange line below on mobile. fix for sending icon off the edge

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper-author/index.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-author/index.js
@@ -259,7 +259,7 @@ const styles = Styles.styleSheetCreate({
       top: -1,
     },
     isMobile: {
-      right: -14,
+      right: 0,
       top: 2,
     },
   }),

--- a/shared/chat/conversation/messages/wrapper/wrapper-message/index.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-message/index.js
@@ -141,13 +141,13 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
 
     return (
       <React.Fragment>
-        {orangeLine}
         <LongPressable
           direction="vertical"
           fullWidth={true}
           onMouseOver={this._onMouseOver}
           {...longPressProps}
         >
+          {orangeLine}
           <Kb.Box2 direction="horizontal" fullWidth={true}>
             {children}
             {wrapperAuthor}


### PR DESCRIPTION
@keybase/react-hackers fixes orange line being below on mobile and fixes send icon too far to the right