### PR TITLE
Handle unicode in urls

### DIFF
--- a/shared/common-adapters/markdown/index.stories.js
+++ b/shared/common-adapters/markdown/index.stories.js
@@ -8,9 +8,6 @@ import {simpleMarkdownParser} from './shared'
 import OriginalParser from '../../markdown/parser'
 
 const cases = {
-  nojima: `https://www.google.com/search?q=ebаy`,
-  nojima2: `http://ebаy.com`,
-  nojima3: `*http://cnn.io*`,
   debugging: `\` \` hi \` \``,
   inlineCodeWeirdness: `\` \` hi \` \``,
   inlineCodeWeirdness2: `\` \` hi \n\` \``,

--- a/shared/common-adapters/markdown/index.stories.js
+++ b/shared/common-adapters/markdown/index.stories.js
@@ -8,6 +8,9 @@ import {simpleMarkdownParser} from './shared'
 import OriginalParser from '../../markdown/parser'
 
 const cases = {
+  nojima: `https://www.google.com/search?q=ebаy`,
+  nojima2: `http://ebаy.com`,
+  nojima3: `*http://cnn.io*`,
   debugging: `\` \` hi \` \``,
   inlineCodeWeirdness: `\` \` hi \` \``,
   inlineCodeWeirdness2: `\` \` hi \n\` \``,
@@ -74,6 +77,9 @@ Include:
   http://keybase.io/blah/../up-one/index.html
   keybase.io/)(,)?=56,78,910@123
   abc subdomain.domain.com
+Internationalized Domain Names:
+  the 'a' in http://ebаy.com isn't an ascii 'a'
+  https://www.google.com/search?q=ebаy the params should be allowed
 These should have the trailing punctuation outside the link:
   amazon.co.uk.
   keybase.io,
@@ -178,7 +184,7 @@ this isn't@either
 
 and @this!
 
-this is the smallest username @aa and @a_ this is too small @a 
+this is the smallest username @aa and @a_ this is too small @a
 
 this is a @long_username
 

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -122,7 +122,7 @@ const linkRegex: RegExp = {
   },
 }
 // don't allow regular characters before a url
-const beforeLinkRegex = /[\s/]/
+const beforeLinkRegex = /[\s/(]/
 const inlineLinkMatch = SimpleMarkdown.inlineRegex(linkRegex)
 const textMatch = SimpleMarkdown.anyScopeRegex(
   new RegExp(
@@ -381,7 +381,12 @@ const rules = {
     match: (source, state, lookBehind) => {
       const matches = inlineLinkMatch(source, state, lookBehind)
       // If there is a match, let's also check if it's a valid tld
-      if (matches && beforeLinkRegex.exec(lookBehind) && matches.groups && tldExp.exec(matches.groups.tld)) {
+      if (
+        matches &&
+        (!lookBehind.length || beforeLinkRegex.exec(lookBehind)) &&
+        matches.groups &&
+        tldExp.exec(matches.groups.tld)
+      ) {
         return matches
       }
       return null

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -121,7 +121,7 @@ const linkRegex: RegExp = {
     return null
   },
 }
-// don't allow regular characters before a url
+// Only allow a small set of characters before a url
 const beforeLinkRegex = /[\s/(]/
 const inlineLinkMatch = SimpleMarkdown.inlineRegex(linkRegex)
 const textMatch = SimpleMarkdown.anyScopeRegex(

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -112,7 +112,7 @@ function parseMarkdown(
 // $FlowIssue treat this like a RegExp
 const linkRegex: RegExp = {
   exec: source => {
-    const r = /^( *)((https?:\/\/)?[\w-]+(\.[\w-]+)+(:\d+)?((?:\/|\?[\w=])(?:\/|[\w=#%~\-_~&(),:@+]|[.?]+[\w/=])*)?)/i
+    const r = /^( *)((https?:\/\/)?[\w-]+(\.[\w-]+)+(:\d+)?((?:\/|\?[\w=])(?:\/|[\w=#%~\-_~&(),:@+\u00c0-\uffff]|[.?]+[\w/=])*)?)/i
     const result = r.exec(source)
     if (result) {
       result.groups = {tld: result[4]}
@@ -121,6 +121,8 @@ const linkRegex: RegExp = {
     return null
   },
 }
+// don't allow regular characters before a url
+const beforeLinkRegex = /[\s/]/
 const inlineLinkMatch = SimpleMarkdown.inlineRegex(linkRegex)
 const textMatch = SimpleMarkdown.anyScopeRegex(
   new RegExp(
@@ -379,7 +381,7 @@ const rules = {
     match: (source, state, lookBehind) => {
       const matches = inlineLinkMatch(source, state, lookBehind)
       // If there is a match, let's also check if it's a valid tld
-      if (matches && matches.groups && tldExp.exec(matches.groups.tld)) {
+      if (matches && beforeLinkRegex.exec(lookBehind) && matches.groups && tldExp.exec(matches.groups.tld)) {
         return matches
       }
       return null


### PR DESCRIPTION
- [x] allow international chars in query strings (https://www.google.com/search?q=ebаy) (the a is actually unicode)
- [x] disallow international chars in the hostname (http://ebаy.com) (the a is actually unicode)
- [x] stricter boundary between urls and other characters (the original implementation made the above link into `y.com` with `ebа` directly in front of this. We likely don't want this behavior so we now look at the lookbehind and throw out the match if its not punctuation