### PR TITLE
be careful to not dupe outbox IDs when sprinkling CORE-9427

### DIFF
--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -515,8 +515,19 @@ func (o *Outbox) SprinkleIntoThread(ctx context.Context, convID chat1.Conversati
 	}
 
 	// Sprinkle each outbox message in
+	threadOutboxIDs := make(map[string]bool)
+	for _, m := range thread.Messages {
+		outboxID := m.GetOutboxID()
+		if outboxID != nil {
+			threadOutboxIDs[outboxID.String()] = true
+		}
+	}
 	for _, obr := range obox.Records {
 		if !obr.ConvID.Eq(convID) {
+			continue
+		}
+		if threadOutboxIDs[obr.OutboxID.String()] {
+			o.Debug(ctx, "skipping outbox item already in the thread: %s", obr.OutboxID)
 			continue
 		}
 		st, err := obr.State.State()


### PR DESCRIPTION
Turns out the rogue pending messages after regaining connection is a core bug. Make sure we don't add in a duplicate message when sprinkling in outbox items. We can dupe under the following circumstance:

1.) Queue up a message offline.
2.) Come online, and have `GetThreadNonblock` win the race for the conversation lock.
3.) `BlockingSender.Send` will successfully send to the server, but won't be able to return since it will be stuck in `Push` behind the lock from #2.
4.) `GetThreadNonblock` will pull the successful message and add it to the result. It will also sprinkle in the outbox item that has yet to be cleared.