### PR TITLE
Fix message failing to send if you type "#foo<enter>" or "@foo<enter>"

### DIFF
--- a/shared/chat/conversation/input-area/channel-mention-hud/index.js
+++ b/shared/chat/conversation/input-area/channel-mention-hud/index.js
@@ -70,6 +70,8 @@ const MentionHud = compose(
   }),
   lifecycle({
     componentDidUpdate(prevProps, prevState) {
+      this.props.setChannelMentionHudIsShowing(this.props.data.length > 0)
+
       if (this.props.data.length === 0) {
         if (prevProps.selectedIndex === 0) {
           // We've already done this, so just get out of here so we don't infinite loop

--- a/shared/chat/conversation/input-area/channel-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/channel-mention-hud/index.stories.js
@@ -67,6 +67,7 @@ const load = () => {
             onSelectChannel={action('onSelectChannel')}
             selectUpCounter={upCounter}
             selectDownCounter={downCounter}
+            setChannelMentionHudIsShowing={action('setChannelMentionHudIsShowing')}
             pickSelectedUserCounter={0}
             filter={filter}
             style={{flex: 1}}

--- a/shared/chat/conversation/input-area/channel-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/channel-mention-hud/mention-hud-container.js
@@ -13,6 +13,7 @@ type OwnProps = {|
   pickSelectedChannelCounter?: number,
   onPickChannel?: (c: string, options?: {notChannel: boolean}) => void,
   onSelectChannel?: (c: string) => void,
+  setChannelMentionHudIsShowing: boolean => void,
   style?: Styles.StylesCrossPlatform,
 |}
 

--- a/shared/chat/conversation/input-area/normal/mention-input.js
+++ b/shared/chat/conversation/input-area/normal/mention-input.js
@@ -8,8 +8,10 @@ import {isMobile} from '../../../../constants/platform'
 
 type MentionState = {|
   channelMentionFilter: string,
+  channelMentionHudIsShowing: boolean,
   channelMentionPopupOpen: boolean,
   mentionFilter: string,
+  mentionHudIsShowing: boolean,
   mentionPopupOpen: boolean,
   pickSelectedCounter: number,
 
@@ -23,8 +25,10 @@ type SelectionKey = 'Enter' | 'Tab' | ''
 class MentionInput extends React.Component<MentionInputProps, MentionState> {
   state: MentionState = {
     channelMentionFilter: '',
+    channelMentionHudIsShowing: false,
     channelMentionPopupOpen: false,
     mentionFilter: '',
+    mentionHudIsShowing: false,
     mentionPopupOpen: false,
     pickSelectedCounter: 0,
     downArrowCounter: 0,
@@ -44,8 +48,16 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
     this._lastSelectionKey = lastSelectionKey
   }
 
+  _setMentionHudIsShowing = (mentionHudIsShowing: boolean) => {
+    this.setState({mentionHudIsShowing})
+  }
+
   _setMentionPopupOpen = (mentionPopupOpen: boolean) => {
     this.setState({mentionPopupOpen})
+  }
+
+  _setChannelMentionHudIsShowing = (channelMentionHudIsShowing: boolean) => {
+    this.setState({channelMentionHudIsShowing})
   }
 
   _setChannelMentionPopupOpen = (channelMentionPopupOpen: boolean) => {
@@ -262,7 +274,9 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
         // popup is open we actually just want to pick whatever's
         // selected.
         this._triggerPickSelectedCounter('Enter')
-        return
+        if (this.state.mentionHudIsShowing || this.state.channelMentionHudIsShowing) {
+          return
+        }
       }
     }
 
@@ -286,7 +300,9 @@ class MentionInput extends React.Component<MentionInputProps, MentionState> {
       insertChannelMention={this.insertChannelMention}
       onChangeText={this._onChangeText}
       onSubmit={this._onSubmit}
+      setMentionHudIsShowing={this._setMentionHudIsShowing}
       setMentionPopupOpen={this._setMentionPopupOpen}
+      setChannelMentionHudIsShowing={this._setChannelMentionHudIsShowing}
       setChannelMentionPopupOpen={this._setChannelMentionPopupOpen}
       // Desktop only.
       switchMention={this.switchMention}

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -213,6 +213,7 @@ class PlatformInput extends React.Component<PlatformInputProps & Kb.OverlayParen
             onPickUser={this.props.insertMention}
             onSelectUser={this.props.switchMention}
             filter={this.props.mentionFilter}
+            setMentionHudIsShowing={this.props.setMentionHudIsShowing}
           />
         )}
         {this.props.channelMentionPopupOpen && <MentionCatcher onClick={this._channelMentionCatcherClick} />}
@@ -224,6 +225,7 @@ class PlatformInput extends React.Component<PlatformInputProps & Kb.OverlayParen
             pickSelectedChannelCounter={this.props.pickSelectedCounter}
             onPickChannel={this.props.insertChannelMention}
             onSelectChannel={this.props.switchChannelMention}
+            setChannelMentionHudIsShowing={this.props.setChannelMentionHudIsShowing}
             filter={this.props.channelMentionFilter}
           />
         )}

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -155,6 +155,7 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
             onPickUser={this.props.insertMention}
             onSelectUser={this.props.insertMention}
             filter={this.props.mentionFilter}
+            setMentionHudIsShowing={this.props.setMentionHudIsShowing}
           />
         )}
         {this.props.channelMentionPopupOpen && (
@@ -166,6 +167,7 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
             onPickChannel={this.props.insertChannelMention}
             onSelectChannel={this.props.insertChannelMention}
             filter={this.props.channelMentionFilter}
+            setChannelMentionHudIsShowing={this.props.setChannelMentionHudIsShowing}
           />
         )}
         {this.props.showingMenu && this._whichMenu === 'filepickerpopup' ? (

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -62,9 +62,11 @@ type MentionProps = {|
   pickSelectedCounter: number,
   channelMentionFilter: string,
   channelMentionPopupOpen: boolean,
+  setChannelMentionHudIsShowing: (channelMentionHudIsShowing: boolean) => void,
   setChannelMentionPopupOpen: (setOpen: boolean) => void,
   mentionFilter: string,
   mentionPopupOpen: boolean,
+  setMentionHudIsShowing: (mentionHudIsShowing: boolean) => void,
   setMentionPopupOpen: (setOpen: boolean) => void,
 |}
 

--- a/shared/chat/conversation/input-area/user-mention-hud/index.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js
@@ -100,6 +100,8 @@ class MentionHud extends React.Component<MentionHudProps, State> {
 type ImplProps = MentionHudProps & {|data: Array<Data>, fullList: Array<Data>|}
 class MentionHudImpl extends React.Component<ImplProps> {
   componentDidUpdate(prevProps: ImplProps) {
+    this.props.setMentionHudIsShowing(this.props.data.length > 0)
+
     if (this.props.filter !== prevProps.filter || this.props.data.length !== prevProps.data.length) {
       this._safeHoverTime = Date.now() + 500
     }

--- a/shared/chat/conversation/input-area/user-mention-hud/index.js.flow
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.js.flow
@@ -15,6 +15,7 @@ export type MentionHudProps = {
   selectDownCounter: number,
   selectUpCounter: number,
   selectedIndex: number,
+  setMentionHudIsShowing: boolean => void,
   setSelectedIndex: number => void,
   users: Array<{|fullName: string, username: string|}>,
   _generalChannelConversationIDKey: string,

--- a/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/index.stories.js
@@ -84,6 +84,7 @@ const load = () => {
             onSelectUser={Sb.action('onSelectUser')}
             selectUpCounter={upCounter}
             selectDownCounter={downCounter}
+            setMentionHudIsShowing={Sb.action('setMentionHudIsShowing')}
             pickSelectedUserCounter={0}
             filter={filter}
             style={{flex: 1}}

--- a/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
+++ b/shared/chat/conversation/input-area/user-mention-hud/mention-hud-container.js
@@ -20,6 +20,7 @@ type OwnProps = {|
   selectDownCounter?: number,
   selectUpCounter?: number,
   selectedIndex?: number,
+  setMentionHudIsShowing: boolean => void,
   style?: Styles.StylesCrossPlatform,
 |}
 


### PR DESCRIPTION
@keybase/react-hackers 

When you type `#foo<enter>` or `@foo<enter>` into a chat on desktop, nothing happens -- we should send the message but we don't.  The reason nothing happens is related to this comment:
```js
    if (this.state.mentionPopupOpen || this.state.channelMentionPopupOpen) {
      // On desktop, this is triggered on Enter, so if a mention
      // popup is open we actually just want to pick whatever's
      // selected.
      this._triggerPickSelectedCounter('Enter')
      return
    }
```
(The `return` prevents us from performing the message send.)

The comment makes sense -- we should suppress the message-send behavior of pressing enter if the mention hud's open, because the mention hud is going to act on the keypress instead and choose the selected hud item.  But the code doesn't work, because the mention popup is "open" even when it's not actually displaying anything.  That's because of this other comment:
```js
// We want to render Hud even if there's no data so we can still have lifecycle methods so we can still do things
// This is important if you type a filter that gives you no results and you press enter for instance
const Hud = ({style, data, loading, rowRenderer, selectedIndex}: HudProps<any>) =>
```

So any time your cursor's inside a word that starts with @ or #, the mention hud is considered open by the existing code.  To fix the logic, we need to consider not just whether the hud's mounted, but whether it's actually displaying results.  The simplest way I could think of to do this is to add a new `this.state.mentionHudIsShowing` test that the hud itself updates when it gets new rows, and that's what this PR does.