### PR TITLE
pass props down to touchable highlight

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper-message/long-pressable.native.js
+++ b/shared/chat/conversation/messages/wrapper/wrapper-message/long-pressable.native.js
@@ -3,9 +3,12 @@ import * as React from 'react'
 import {NativeTouchableHighlight, NativeView} from '../../../../../common-adapters/mobile.native'
 
 // See '.js.flow' for explanation
-const LongPressable = (props: {children: React.Node}) => (
-  <NativeTouchableHighlight>
-    <NativeView>{props.children}</NativeView>
-  </NativeTouchableHighlight>
-)
+const LongPressable = (props: any) => {
+  const {children, ...rest} = props
+  return (
+    <NativeTouchableHighlight {...rest}>
+      <NativeView>{children}</NativeView>
+    </NativeTouchableHighlight>
+  )
+}
 export default LongPressable


### PR DESCRIPTION
props for touchable highlight were being left on the floor. this fixes press and hold and keyboard dismissal
@keybase/react-hackers 