### PR TITLE
identify in the background for imp teams in GUI mode CORE-9513

### DIFF
--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -367,16 +367,6 @@ func (t *NameIdentifier) identifyUser(ctx context.Context, assertion string, pri
 		case libkb.NotFoundError, libkb.ResolutionError, libkb.DeletedError:
 			return keybase1.TLFIdentifyFailure{}, nil
 		}
-
-		// Special treatment is needed for GUI strict mode, since we need to
-		// simultaneously plumb identify breaks up to the UI, and make sure the
-		// overall process returns an error. Swallow the error here so the rest of
-		// the identify can proceed, but we will check later (in GetTLFCryptKeys) for breaks with this
-		// mode and return an error there.
-		if !(libkb.IsIdentifyProofError(err) &&
-			idBehavior == keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT) {
-			return keybase1.TLFIdentifyFailure{}, err
-		}
 	}
 	resp, err := eng.Result(m)
 	if err != nil {

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -547,10 +547,6 @@ func (t *ImplicitTeamsNameInfoSource) identify(ctx context.Context, tlfID chat1.
 	names = append(names, impTeamName.Readers.KeybaseUsers...)
 
 	// identify the members in the conversation
-	identBehavior, _, ok := IdentifyMode(ctx)
-	if !ok {
-		return res, errors.New("invalid context with no chat metadata")
-	}
 	res, err = t.Identify(ctx, names, true,
 		func() keybase1.TLFID {
 			return keybase1.TLFID(tlfID.String())
@@ -561,13 +557,6 @@ func (t *ImplicitTeamsNameInfoSource) identify(ctx context.Context, tlfID chat1.
 	if err != nil {
 		return res, err
 	}
-
-	// GUI Strict mode errors are swallowed earlier, return an error now (key is that it is
-	// after send to IdentifyNotifier)
-	if identBehavior == keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT && len(res) > 0 {
-		return res, libkb.NewIdentifySummaryError(res[0])
-	}
-
 	return res, nil
 }
 

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -231,14 +231,6 @@ func (t *KBFSNameInfoSource) CryptKeys(ctx context.Context, tlfName string) (res
 		return keybase1.GetTLFCryptKeysRes{}, err
 	}
 	res.NameIDBreaks.Breaks.Breaks = ib
-
-	// GUI Strict mode errors are swallowed earlier, return an error now (key is that it is
-	// after send to IdentifyNotifier)
-	if identBehavior == keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT &&
-		len(res.NameIDBreaks.Breaks.Breaks) > 0 {
-		return res, libkb.NewIdentifySummaryError(res.NameIDBreaks.Breaks.Breaks[0])
-	}
-
 	return res, nil
 }
 
@@ -299,13 +291,6 @@ func (t *KBFSNameInfoSource) PublicCanonicalTLFNameAndID(ctx context.Context, tl
 		return keybase1.CanonicalTLFNameAndIDWithBreaks{}, err
 	}
 	res.Breaks.Breaks = ib
-
-	// GUI Strict mode errors are swallowed earlier, return an error now (key is that it is
-	// after send to IdentifyNotifier)
-	if identBehavior == keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT && len(res.Breaks.Breaks) > 0 {
-		return res, libkb.NewIdentifySummaryError(res.Breaks.Breaks[0])
-	}
-
 	return res, nil
 }
 

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -1194,8 +1194,6 @@ func TestTrackThenRevokeThenIdentifyWithDifferentChatModes(t *testing.T) {
 
 	err = runIdentify(keybase1.TLFIdentifyBehavior_CHAT_GUI)
 	require.NoError(t, err)
-	err = runIdentify(keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT)
-	require.Error(t, err)
 }
 
 var aliceUID = keybase1.UID("295a7eea607af32040647123732bc819")

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1226,7 +1226,6 @@ func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_CLI,
 		TLFIdentifyBehavior_CHAT_GUI,
-		TLFIdentifyBehavior_CHAT_GUI_STRICT,
 		TLFIdentifyBehavior_SALTPACK,
 		TLFIdentifyBehavior_KBFS_CHAT:
 		return true
@@ -1238,7 +1237,6 @@ func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_GUI,
-		TLFIdentifyBehavior_CHAT_GUI_STRICT,
 		TLFIdentifyBehavior_SALTPACK,
 		TLFIdentifyBehavior_RESOLVE_AND_CHECK:
 		return true
@@ -1252,7 +1250,7 @@ func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_GUI:
-		// The chat GUI (in non-strict mode) is specifically exempted from broken
+		// The chat GUI is specifically exempted from broken
 		// track errors, because people need to be able to use it to ask each other
 		// about the fact that proofs are broken.
 		return true
@@ -1295,7 +1293,6 @@ func (b TLFIdentifyBehavior) AllowDeletedUsers() bool {
 func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_GUI,
-		TLFIdentifyBehavior_CHAT_GUI_STRICT,
 		TLFIdentifyBehavior_CHAT_CLI,
 		TLFIdentifyBehavior_KBFS_REKEY,
 		TLFIdentifyBehavior_KBFS_QR,

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -11,44 +11,44 @@ import (
 type TLFIdentifyBehavior int
 
 const (
-	TLFIdentifyBehavior_UNSET             TLFIdentifyBehavior = 0
-	TLFIdentifyBehavior_CHAT_CLI          TLFIdentifyBehavior = 1
-	TLFIdentifyBehavior_CHAT_GUI          TLFIdentifyBehavior = 2
-	TLFIdentifyBehavior_CHAT_GUI_STRICT   TLFIdentifyBehavior = 3
-	TLFIdentifyBehavior_KBFS_REKEY        TLFIdentifyBehavior = 4
-	TLFIdentifyBehavior_KBFS_QR           TLFIdentifyBehavior = 5
-	TLFIdentifyBehavior_CHAT_SKIP         TLFIdentifyBehavior = 6
-	TLFIdentifyBehavior_SALTPACK          TLFIdentifyBehavior = 7
-	TLFIdentifyBehavior_CLI               TLFIdentifyBehavior = 8
-	TLFIdentifyBehavior_GUI               TLFIdentifyBehavior = 9
-	TLFIdentifyBehavior_DEFAULT_KBFS      TLFIdentifyBehavior = 10
-	TLFIdentifyBehavior_KBFS_CHAT         TLFIdentifyBehavior = 11
-	TLFIdentifyBehavior_RESOLVE_AND_CHECK TLFIdentifyBehavior = 12
+	TLFIdentifyBehavior_UNSET              TLFIdentifyBehavior = 0
+	TLFIdentifyBehavior_CHAT_CLI           TLFIdentifyBehavior = 1
+	TLFIdentifyBehavior_CHAT_GUI           TLFIdentifyBehavior = 2
+	TLFIdentifyBehavior_REMOVED_AND_UNUSED TLFIdentifyBehavior = 3
+	TLFIdentifyBehavior_KBFS_REKEY         TLFIdentifyBehavior = 4
+	TLFIdentifyBehavior_KBFS_QR            TLFIdentifyBehavior = 5
+	TLFIdentifyBehavior_CHAT_SKIP          TLFIdentifyBehavior = 6
+	TLFIdentifyBehavior_SALTPACK           TLFIdentifyBehavior = 7
+	TLFIdentifyBehavior_CLI                TLFIdentifyBehavior = 8
+	TLFIdentifyBehavior_GUI                TLFIdentifyBehavior = 9
+	TLFIdentifyBehavior_DEFAULT_KBFS       TLFIdentifyBehavior = 10
+	TLFIdentifyBehavior_KBFS_CHAT          TLFIdentifyBehavior = 11
+	TLFIdentifyBehavior_RESOLVE_AND_CHECK  TLFIdentifyBehavior = 12
 )
 
 func (o TLFIdentifyBehavior) DeepCopy() TLFIdentifyBehavior { return o }
 
 var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
-	"UNSET":             0,
-	"CHAT_CLI":          1,
-	"CHAT_GUI":          2,
-	"CHAT_GUI_STRICT":   3,
-	"KBFS_REKEY":        4,
-	"KBFS_QR":           5,
-	"CHAT_SKIP":         6,
-	"SALTPACK":          7,
-	"CLI":               8,
-	"GUI":               9,
-	"DEFAULT_KBFS":      10,
-	"KBFS_CHAT":         11,
-	"RESOLVE_AND_CHECK": 12,
+	"UNSET":              0,
+	"CHAT_CLI":           1,
+	"CHAT_GUI":           2,
+	"REMOVED_AND_UNUSED": 3,
+	"KBFS_REKEY":         4,
+	"KBFS_QR":            5,
+	"CHAT_SKIP":          6,
+	"SALTPACK":           7,
+	"CLI":                8,
+	"GUI":                9,
+	"DEFAULT_KBFS":       10,
+	"KBFS_CHAT":          11,
+	"RESOLVE_AND_CHECK":  12,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
 	0:  "UNSET",
 	1:  "CHAT_CLI",
 	2:  "CHAT_GUI",
-	3:  "CHAT_GUI_STRICT",
+	3:  "REMOVED_AND_UNUSED",
 	4:  "KBFS_REKEY",
 	5:  "KBFS_QR",
 	6:  "CHAT_SKIP",

--- a/protocol/avdl/keybase1/tlf_keys.avdl
+++ b/protocol/avdl/keybase1/tlf_keys.avdl
@@ -10,7 +10,7 @@ protocol tlfKeys {
     UNSET_0,
     CHAT_CLI_1,
     CHAT_GUI_2,
-    CHAT_GUI_STRICT_3,
+    REMOVED_AND_UNUSED_3,
     KBFS_REKEY_4,
     KBFS_QR_5,
     CHAT_SKIP_6,

--- a/protocol/json/keybase1/tlf_keys.json
+++ b/protocol/json/keybase1/tlf_keys.json
@@ -18,7 +18,7 @@
         "UNSET_0",
         "CHAT_CLI_1",
         "CHAT_GUI_2",
-        "CHAT_GUI_STRICT_3",
+        "REMOVED_AND_UNUSED_3",
         "KBFS_REKEY_4",
         "KBFS_QR_5",
         "CHAT_SKIP_6",

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1167,16 +1167,8 @@ const clearMessageSetEditing = (action: Chat2Gen.MessageEditPayload) =>
     })
   )
 
-// We pass a special flag to tell the service if we're aware of any broken users. This is so we avoid
-// accidentally sending into a convo when there should be a red bar but we haven't seen it for some reason
 const getIdentifyBehavior = (state: TypedState, conversationIDKey: Types.ConversationIDKey) => {
-  const participants = Constants.getMeta(state, conversationIDKey).participants
-  const hasBroken = participants.some(p => state.users.infoMap.getIn([p, 'broken']))
-  // We send a flag to the daemon depending on if we know about a broken user or not. If not it'll check before sending and show
-  // the red banner
-  return hasBroken
-    ? RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui
-    : RPCTypes.tlfKeysTLFIdentifyBehavior.chatGuiStrict
+  return RPCTypes.tlfKeysTLFIdentifyBehavior.chatGui
 }
 
 const messageReplyPrivately = (state: TypedState, action: Chat2Gen.MessageReplyPrivatelyPayload) => {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -757,7 +757,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   unset: 0,
   chatCli: 1,
   chatGui: 2,
-  chatGuiStrict: 3,
+  removedAndUnused: 3,
   kbfsRekey: 4,
   kbfsQr: 5,
   chatSkip: 6,

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -1704,7 +1704,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   unset: 0,
   chatCli: 1,
   chatGui: 2,
-  chatGuiStrict: 3,
+  removedAndUnused: 3,
   kbfsRekey: 4,
   kbfsQr: 5,
   chatSkip: 6,
@@ -2669,7 +2669,7 @@ export type TLFIdentifyBehavior =
   | 0 // UNSET_0
   | 1 // CHAT_CLI_1
   | 2 // CHAT_GUI_2
-  | 3 // CHAT_GUI_STRICT_3
+  | 3 // REMOVED_AND_UNUSED_3
   | 4 // KBFS_REKEY_4
   | 5 // KBFS_QR_5
   | 6 // CHAT_SKIP_6


### PR DESCRIPTION
Patch does the following:
1.) Remove `CHAT_GUI_STRICT` identify mode.
2.) UI always sends `CHAT_GUI` mode in all cases.
3.) When in `CHAT_GUI` mode, do not wait for the result of identifying the participants in an imp team chat.