### PR TITLE
use proper keys for FS rows

### DIFF
--- a/shared/constants/types/fs.js
+++ b/shared/constants/types/fs.js
@@ -507,7 +507,6 @@ export type PlaceholderRowItem = {
 
 export type EmptyRowItem = {
   rowType: 'empty',
-  name: string,
 }
 
 export type RowItem =
@@ -518,6 +517,15 @@ export type RowItem =
   | UploadingRowItem
   | PlaceholderRowItem
   | EmptyRowItem
+
+export type RowItemWithKey =
+  | ({key: string} & TlfTypeRowItem)
+  | ({key: string} & TlfRowItem)
+  | ({key: string} & StillRowItem)
+  | ({key: string} & EditingRowItem)
+  | ({key: string} & UploadingRowItem)
+  | ({key: string} & PlaceholderRowItem)
+  | ({key: string} & EmptyRowItem)
 
 // RefreshTag is used by components in FsGen.folderListLoad and
 // FsGen.mimeTypeLoad actions, to indicate that it's interested in refreshing

--- a/shared/fs/row/rows-container.js
+++ b/shared/fs/row/rows-container.js
@@ -31,6 +31,7 @@ const getEditingRows = (
       rowType: 'editing',
       editID,
       name: edit.name,
+      key: `edit:${Types.editIDToString(editID)}`,
       // fields for sortable
       editType: edit.type,
       type: 'folder',
@@ -43,12 +44,14 @@ const getStillRows = (
 ): Array<SortableStillRowItem> =>
   names.reduce((items, name) => {
     const item = pathItems.get(Types.pathConcat(parentPath, name), Constants.unknownPathItem)
+    const path = Types.pathConcat(parentPath, item.name)
     return [
       ...items,
       {
         rowType: 'still',
-        path: Types.pathConcat(parentPath, item.name),
+        path,
         name: item.name,
+        key: `still:${name}`,
         // fields for sortable
         type: item.type,
         lastModifiedTimestamp: item.lastModifiedTimestamp,
@@ -75,15 +78,16 @@ const amendStillRows = (
       rowType: 'uploading',
       name,
       path,
+      key: `uploading:${name}`,
       // field for sortable
       type,
     }: SortableUploadingRowItem)
   })
 
 const getPlaceholderRows = type => [
-  {rowType: 'placeholder', name: '1', type},
-  {rowType: 'placeholder', name: '2', type},
-  {rowType: 'placeholder', name: '3', type},
+  {rowType: 'placeholder', name: '1', type, key: 'placeholder:1'},
+  {rowType: 'placeholder', name: '2', type, key: 'placeholder:2'},
+  {rowType: 'placeholder', name: '3', type, key: 'placeholder:3'},
 ]
 
 const getInTlfItemsFromStateProps = (stateProps, path: Types.Path, sortSetting) => {
@@ -109,9 +113,9 @@ const getInTlfItemsFromStateProps = (stateProps, path: Types.Path, sortSetting) 
 const getRootRows = (stateProps, sortSetting) =>
   sortRowItems(
     [
-      {rowType: 'tlf-type', name: 'private', type: 'folder'},
-      {rowType: 'tlf-type', name: 'public', type: 'folder'},
-      {rowType: 'tlf-type', name: 'team', type: 'folder'},
+      {rowType: 'tlf-type', name: 'private', type: 'folder', key: 'tlfType:private'},
+      {rowType: 'tlf-type', name: 'public', type: 'folder', key: 'tlfType:public'},
+      {rowType: 'tlf-type', name: 'team', type: 'folder', key: 'tlfType:team'},
     ],
     sortSetting,
     undefined
@@ -129,6 +133,7 @@ const getTlfRowsFromTlfs = (tlfs: I.Map<string, Types.Tlf>, tlfType: Types.TlfTy
               rowType: 'tlf',
               tlfType,
               name,
+              key: `tlf:${name}`,
               type: 'folder',
             },
           ],

--- a/shared/fs/row/rows.js
+++ b/shared/fs/row/rows.js
@@ -14,7 +14,7 @@ import {rowHeight} from './common'
 import {isMobile} from '../../constants/platform'
 
 type Props = {
-  items: Array<Types.RowItem>,
+  items: Array<Types.RowItemWithKey>,
   routePath: I.List<string>,
   destinationPickerIndex?: number,
 }
@@ -100,13 +100,12 @@ class Rows extends React.PureComponent<Props> {
     return this.props.items && this.props.items.length ? (
       <Kb.List
         fixedHeight={rowHeight}
-        indexAsKey={true}
         items={
           // If we are in the destination picker, inject two empty rows so when
           // user scrolls to the bottom nothing is blocked by the
           // semi-transparent footer.
           !isMobile && this.props.destinationPickerIndex
-            ? [...this.props.items, {rowType: 'empty', name: '/empty0'}, {rowType: 'empty', name: '/empty1'}]
+            ? [...this.props.items, {rowType: 'empty', key: 'empty:0'}, {rowType: 'empty', key: 'empty:1'}]
             : this.props.items
         }
         renderItem={this._rowRenderer}


### PR DESCRIPTION
When using index as key, if a file gets deleted while a PathItemAction popup is shown, the content shifts to the next file, along with the buttons associated to it. So instead, just use proper keys so mounted rows are moved properly when an item is removed, instead of shifting props for a bunch of them.

cc @chrisnojima 