### PR TITLE
fail attachments right way if Retry fails and remove from outbox earlier CORE-9549

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -417,17 +417,23 @@ func (e UnknownTLFNameError) Error() string {
 //=============================================================================
 
 type AttachmentUploadError struct {
-	Msg string
+	Msg  string
+	Perm bool
 }
 
-func NewAttachmentUploadError(msg string) AttachmentUploadError {
+func NewAttachmentUploadError(msg string, perm bool) AttachmentUploadError {
 	return AttachmentUploadError{
-		Msg: msg,
+		Msg:  msg,
+		Perm: perm,
 	}
 }
 
 func (e AttachmentUploadError) Error() string {
 	return fmt.Sprintf("attachment failed to upload; %s", e.Msg)
+}
+
+func (e AttachmentUploadError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
+	return chat1.OutboxErrorType_MISC, e.Perm
 }
 
 //=============================================================================


### PR DESCRIPTION
Patch does a couple things:
1.) Make it so that if we `Retry` an attachment message and get a hard error for it we immediate fail the message. This is the same as if we initially tried to `Register` and get an error, so it makes sense to fail right away.
2.) Remove from the `Outbox` in `BlockingSender.Send` after we get a success back from the server. Waiting for us to push into the caches is an unnecessary delay, and in the share extension can trigger the outbox giving bad data to the main app (since we die after `ConvSource.Push` succeeds).