### PR TITLE
handle exploded messages better with mark as read CORE-9443

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -315,10 +315,6 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 	// If the message is exploding, load the ephemeral key.
 	var ephemeralSeed *keybase1.TeamEk
 	if boxed.IsEphemeral() {
-		// Don't bother if the message is already expired.
-		if boxed.IsEphemeralExpired(b.clock.Now()) {
-			return b.makeErrorMessage(ctx, boxed, NewPermanentUnboxingError(NewEphemeralAlreadyExpiredError())), nil
-		}
 		ek, err := CtxKeyFinder(ctx, b.G()).EphemeralKeyForDecryption(
 			ctx, tlfName, boxed.ClientHeader.Conv.Tlfid, conv.GetMembersType(), boxed.ClientHeader.TlfPublic,
 			boxed.EphemeralMetadata().Generation)

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1982,7 +1982,8 @@ const markThreadAsRead = (
     return
   }
 
-  if (!state.chat2.metaMap.get(conversationIDKey)) {
+  const meta = state.chat2.metaMap.get(conversationIDKey)
+  if (!meta) {
     logger.info('marking read bail on not in meta list. preview?')
     return
   }
@@ -2010,15 +2011,11 @@ const markThreadAsRead = (
     message = mmap.get(ordinal)
   }
 
-  if (!message) {
-    logger.info('marking read bail on no messages')
-    return
-  }
-
-  logger.info(`marking read messages ${conversationIDKey} ${message.id}`)
+  const readMsgID = message ? (message.id > meta.maxMsgID ? message.id : meta.maxMsgID) : meta.maxMsgID
+  logger.info(`marking read messages ${conversationIDKey} ${readMsgID}`)
   return Saga.call(RPCChatTypes.localMarkAsReadLocalRpcPromise, {
     conversationID: Types.keyToConversationID(conversationIDKey),
-    msgID: message.id,
+    msgID: readMsgID,
   })
 }
 


### PR DESCRIPTION
Patch does the following:

1.) Don't mark boxed expired exploding messages as errors _a priori_. Otherwise, we never see ash for these (common case on mobile to miss them for short durations).
2.) Change JS mark as read to use the large of the max message it knows about, and the max msgID on the conversation.