### PR TITLE
Shorten chat input placeholder with wallets icon

### DIFF
--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -45,6 +45,7 @@ const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
     isExplodingNew: Constants.getIsExplodingNew(state),
     quoteCounter: quoteInfo ? quoteInfo.counter : 0,
     quoteText: quoteInfo ? quoteInfo.text : '',
+    showWalletsIcon: Constants.shouldShowWalletsIcon(Constants.getMeta(state, conversationIDKey), _you),
     typing: Constants.getTyping(state, conversationIDKey),
   }
 }
@@ -128,6 +129,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps): Props => ({
     }
     setUnsentText(stateProps.conversationIDKey, text)
   },
+  showWalletsIcon: stateProps.showWalletsIcon,
   typing: stateProps.typing,
 })
 

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -48,8 +48,8 @@ const provider = Sb.createPropProviderWithCommon({
   },
   WalletsIcon: ownProps => ({
     isNew: true,
-    onClick: Sb.action('onOpenWalletsForm'),
-    shouldRender: true,
+    onRequest: Sb.action('onRequestLumens'),
+    onSend: Sb.action('onSendLumens'),
     size: ownProps.size,
     style: ownProps.style,
   }),
@@ -100,6 +100,7 @@ const InputContainer = (props: Props) => {
     onSubmit: (text: string) => {
       Sb.action('onSubmit')(text)
     },
+    showWalletsIcon: !props.isEditing && props.typing.size <= 1,
     typing: props.typing,
 
     editText: '',

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -322,7 +322,7 @@ class PlatformInput extends React.Component<PlatformInputProps & Kb.OverlayParen
           {this.state.emojiPickerOpen && (
             <EmojiPicker emojiPickerToggle={this._emojiPickerToggle} onClick={this._pickerOnClick} />
           )}
-          {flags.walletsEnabled && <WalletsIcon size={16} style={styles.walletsIcon} />}
+          {this.props.showWalletsIcon && <WalletsIcon size={16} style={styles.walletsIcon} />}
           <Kb.Icon
             color={this.state.emojiPickerOpen ? Styles.globalColors.black_75 : null}
             onClick={this._emojiPickerToggle}

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -138,9 +138,10 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
 
   render = () => {
     let hintText = 'Write a message'
-    if (this.props.isExploding) {
-      hintText =
-        isLargeScreen && !this.props.showWalletsIcon ? 'Write an exploding message' : 'Exploding message'
+    if (this.props.isExploding && isLargeScreen) {
+      hintText = this.props.showWalletsIcon ? 'Exploding message' : 'Write an exploding message'
+    } else if (this.props.isExploding && !isLargeScreen) {
+      hintText = this.props.showWalletsIcon ? 'Exploding' : 'Exploding message'
     } else if (this.props.isEditing) {
       hintText = 'Edit your message'
     }

--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -139,7 +139,8 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
   render = () => {
     let hintText = 'Write a message'
     if (this.props.isExploding) {
-      hintText = isLargeScreen ? 'Write an exploding message' : 'Exploding message'
+      hintText =
+        isLargeScreen && !this.props.showWalletsIcon ? 'Write an exploding message' : 'Exploding message'
     } else if (this.props.isEditing) {
       hintText = 'Edit your message'
     }
@@ -224,6 +225,7 @@ class PlatformInput extends Component<PlatformInputProps & OverlayParentProps, S
             insertMentionMarker={this.props.insertMentionMarker}
             isExploding={this.props.isExploding}
             isExplodingNew={this.props.isExplodingNew}
+            showWalletsIcon={this.props.showWalletsIcon}
             explodingModeSeconds={this.props.explodingModeSeconds}
           />
         </Box>
@@ -249,15 +251,16 @@ const ChannelMentionHud = props => (
 )
 
 const Action = ({
+  explodingModeSeconds,
   hasText,
-  onSubmit,
-  isEditing,
-  openExplodingPicker,
-  openFilePicker,
   insertMentionMarker,
+  isEditing,
   isExploding,
   isExplodingNew,
-  explodingModeSeconds,
+  onSubmit,
+  openExplodingPicker,
+  openFilePicker,
+  showWalletsIcon,
 }) =>
   hasText ? (
     <Box2 direction="horizontal" gap="small" style={styles.actionText}>
@@ -286,7 +289,7 @@ const Action = ({
           {smallGap}
         </>
       )}
-      {flags.walletsEnabled && (
+      {showWalletsIcon && (
         <WalletsIcon size={22} style={collapseStyles([styles.actionButton, styles.marginRightSmall])} />
       )}
       <Icon

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -24,6 +24,7 @@ type CommonProps = {|
   onFilePickerError: (error: Error) => void,
   onSeenExplodingMessages: () => void,
   onSubmit: (text: string) => void,
+  showWalletsIcon: boolean, // used on mobile to determine placeholder
   typing: I.Set<string>,
 |}
 

--- a/shared/chat/conversation/input-area/normal/wallets-icon/container.js
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/container.js
@@ -1,11 +1,11 @@
 // @flow
-import * as React from 'react'
 import * as Container from '../../../../../util/container'
 import * as Chat2Gen from '../../../../../actions/chat2-gen'
 import * as WalletsGen from '../../../../../actions/wallets-gen'
 import * as Styles from '../../../../../styles'
 import * as Constants from '../../../../../constants/chat2'
-import WalletsIconRender, {type WalletsIconProps as ViewProps} from '.'
+import logger from '../../../../../logger'
+import WalletsIconRender from '.'
 
 type OwnProps = {|
   size: number,
@@ -33,35 +33,19 @@ const mapDispatchToProps = dispatch => ({
   },
 })
 
-const renderNothingProps = {shouldRender: false}
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  // Only show this for adhoc conversations.
-  if (stateProps._meta.teamType !== 'adhoc') {
-    return renderNothingProps
-  }
   const otherParticipants = stateProps._meta.participants.filter(u => u !== stateProps._you)
-  // Only show this for one-on-one conversations.
   if (otherParticipants.size !== 1) {
-    return renderNothingProps
+    logger.warn('WalletsIcon: conversation has more than 1 other user. selecting first')
   }
   const to = otherParticipants.first()
   return {
     isNew: stateProps.isNew,
-    onSend: () => dispatchProps._onClick(to, stateProps.isNew, false),
     onRequest: () => dispatchProps._onClick(to, stateProps.isNew, true),
-    shouldRender: true,
+    onSend: () => dispatchProps._onClick(to, stateProps.isNew, false),
     size: ownProps.size,
     style: ownProps.style,
   }
-}
-
-type WrapperProps = {|...ViewProps, shouldRender: true|} | {|shouldRender: false|}
-const Wrapper = (props: WrapperProps) => {
-  if (props.shouldRender) {
-    const {shouldRender, ...passThroughProps} = props
-    return <WalletsIconRender {...passThroughProps} />
-  }
-  return null
 }
 
 const WalletsIcon = Container.namedConnect<OwnProps, _, _, _, _>(
@@ -69,6 +53,6 @@ const WalletsIcon = Container.namedConnect<OwnProps, _, _, _, _>(
   mapDispatchToProps,
   mergeProps,
   'WalletsIcon'
-)(Wrapper)
+)(WalletsIconRender)
 
 export default WalletsIcon

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -238,6 +238,7 @@ export {
   inboxUIItemToConversationMeta,
   isDecryptingSnippet,
   makeConversationMeta,
+  shouldShowWalletsIcon,
   timestampToString,
   unverifiedInboxUIItemToConversationMeta,
   updateMeta,

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -11,6 +11,7 @@ import {formatTimeForConversationList} from '../../util/timestamp'
 import {globalColors} from '../../styles'
 import {isIOS, isAndroid} from '../platform'
 import {toByteArray} from 'base64-js'
+import flags from '../../util/feature-flags'
 import {noConversationIDKey, isValidConversationIDKey} from '../types/chat2/common'
 
 const conversationMemberStatusToMembershipType = (m: RPCChatTypes.ConversationMemberStatus) => {
@@ -305,6 +306,12 @@ export const makeConversationMeta: I.RecordFactory<_ConversationMeta> = I.Record
 const emptyMeta = makeConversationMeta()
 export const getMeta = (state: TypedState, id: Types.ConversationIDKey) =>
   state.chat2.metaMap.get(id, emptyMeta)
+
+// show wallets icon for one-on-one conversations
+export const shouldShowWalletsIcon = (meta: Types.ConversationMeta, yourUsername: string) =>
+  flags.walletsEnabled &&
+  meta.teamType === 'adhoc' &&
+  meta.participants.filter(u => u !== yourUsername).size === 1
 
 const bgPlatform = isIOS ? globalColors.white : isAndroid ? globalColors.transparent : globalColors.blueGrey
 export const getRowStyles = (meta: Types.ConversationMeta, isSelected: boolean, hasUnread: boolean) => {


### PR DESCRIPTION
`PlatformInput` needed to know whether the wallets icon was being rendered so it could show the shorter placeholder in that case. I moved the logic from `WalletsIcon`'s container into constants and use it in `PlatformInput` to decide both the placeholder and whether to render the icon. The problem existed on small screens too so I shortened the placeholder further to 'Exploding'.

#### Large screens
Before:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/11968340/49258795-9ce64180-f3eb-11e8-8bbd-5a69f3a26d61.png">

After:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/11968340/49258831-b8514c80-f3eb-11e8-8ed4-9adfbc9bc142.png">

#### Small screens
Before:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/11968340/49259365-f64f7000-f3ed-11e8-872e-25900bc7c2c1.png">

After:
<img width="356" alt="image" src="https://user-images.githubusercontent.com/11968340/49259412-1d0da680-f3ee-11e8-8b62-42b01fa9d000.png">

r? @keybase/react-hackers 