### PR TITLE
markdown URL regex changes

### DIFF
--- a/shared/common-adapters/markdown/index.stories.js
+++ b/shared/common-adapters/markdown/index.stories.js
@@ -80,6 +80,7 @@ Include:
   http://keybase.io/blah/../up-one/index.html
   keybase.io/)(,)?=56,78,910@123
   abc subdomain.domain.com
+  https://www.google.com/maps/place/85+Broad+St,+New+York,+NY+10004/@40.7040702,-74.0133343,17z/data=!3m1!4b1!4m5!3m4!1s0x89c25a141703be89:0x74c637bf3f5d8f7d!8m2!3d40.7040662!4d-74.0111456
 Internationalized Domain Names:
   the 'a' in http://ebаy.com isn't an ascii 'a'
   https://www.google.com/search?q=ebаy the params should be allowed

--- a/shared/common-adapters/markdown/index.stories.js
+++ b/shared/common-adapters/markdown/index.stories.js
@@ -87,9 +87,16 @@ These should have the trailing punctuation outside the link:
   amazon.co.uk.
   keybase.io,
   keybase.io.
+  http://keybase.io/mikem,
+  http://keybase.io/mikem;
+  http://keybase.io/mikem:
+  http://keybase.io/mikem!
   keybase.io?
   *http://keybase.io/*.
   *http://keybase.io/~_*
+Paranthesis stuff:
+  https://en.wikipedia.org/wiki/J/Z_(New_York_City_Subway_service)
+  (https://keybase.io/)
 `,
   Quotes: `> this is quoted
 > this is _italics_ inside of a quote. This is *bold* inside of a quote.

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -112,7 +112,13 @@ function parseMarkdown(
 // $FlowIssue treat this like a RegExp
 const linkRegex: RegExp = {
   exec: source => {
-    const r = /^( *)((https?:\/\/)?[\w-]+(\.[\w-]+)+(:\d+)?((?:\/|\?[\w=])(?:\/|[\w=#%~\-_~&(),:@+\u00c0-\uffff]|[.?]+[\w/=])*)?)/i
+    const valid = `[:,]*[\\w=#%~\\-_~&@+\\u00c0-\\uffff]`
+    const paranthesisPaired = `([(]${valid}+[)])`
+    const afterDomain = `(?:\\/|${paranthesisPaired}|${valid}|[.?]+[\\w/=])`
+    const r = new RegExp(
+      `^( *)((https?:\\/\\/)?[\\w-]+(\\.[\\w-]+)+(:\\d+)?((?:\\/|\\?[\\w=])${afterDomain}*)?)`,
+      'i'
+    )
     const result = r.exec(source)
     if (result) {
       result.groups = {tld: result[4]}

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -112,7 +112,7 @@ function parseMarkdown(
 // $FlowIssue treat this like a RegExp
 const linkRegex: RegExp = {
   exec: source => {
-    const valid = `[:,]*[\\w=#%~\\-_~&@+\\u00c0-\\uffff]`
+    const valid = `[:,!]*[\\w=#%~\\-_~&@+\\u00c0-\\uffff]`
     const paranthesisPaired = `([(]${valid}+[)])`
     const afterDomain = `(?:\\/|${paranthesisPaired}|${valid}|[.?]+[\\w/=])`
     const r = new RegExp(


### PR DESCRIPTION
Fixes:

* remove additional trailing punctuation: ,:
* Remove tariling paranthesis when they are not paired
* keep paried paranthesis working
* make `!` work

Breaks:

* BREAKS "keybase.io/)(,)?=56,78,910@123"

Screenshots / Good:

<img width="590" alt="screen shot 2018-11-30 at 12 59 00 pm" src="https://user-images.githubusercontent.com/255797/49314572-bc3ea680-f49f-11e8-8d4f-5a430d4408f4.png">

<img width="680" alt="screen shot 2018-11-30 at 1 24 23 pm" src="https://user-images.githubusercontent.com/255797/49315660-505e3d00-f4a3-11e8-8f9e-45964ad35a81.png">

Screenshot / Bad:

<img width="315" alt="screen shot 2018-11-30 at 12 59 25 pm" src="https://user-images.githubusercontent.com/255797/49314596-cc568600-f49f-11e8-8b95-cf140b254fad.png">
