### PR TITLE
Allow server to stop proof creation if a service blocks us

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -84,11 +84,10 @@ func (i *Identify2WithUIDTester) AllStringKeys() []string                   { re
 func (i *Identify2WithUIDTester) CheckProofText(text string, id keybase1.SigID, sig string) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) GetDisplayPriority(s string) int { return 0 }
-func (i *Identify2WithUIDTester) DisplayName(n string) string     { return n }
-func (i *Identify2WithUIDTester) GetPrompt() string               { return "" }
-func (i *Identify2WithUIDTester) GetProofType() string            { return "" }
-func (i *Identify2WithUIDTester) GetTypeName() string             { return "" }
+func (i *Identify2WithUIDTester) DisplayName(n string) string { return n }
+func (i *Identify2WithUIDTester) GetPrompt() string           { return "" }
+func (i *Identify2WithUIDTester) GetProofType() string        { return "" }
+func (i *Identify2WithUIDTester) GetTypeName() string         { return "" }
 func (i *Identify2WithUIDTester) NormalizeRemoteName(_ libkb.MetaContext, name string) (string, error) {
 	return name, nil
 }

--- a/go/externals/proof_checkers.go
+++ b/go/externals/proof_checkers.go
@@ -7,15 +7,15 @@ import libkb "github.com/keybase/client/go/libkb"
 
 func getStaticProofServices() []libkb.ServiceType {
 	services := []libkb.ServiceType{
-		DNSServiceType{},
-		FacebookServiceType{},
-		GithubServiceType{},
-		HackerNewsServiceType{},
-		RedditServiceType{},
-		TwitterServiceType{},
-		WebServiceType{},
-		WebServiceType{scheme: "http"},
-		WebServiceType{scheme: "https"},
+		&DNSServiceType{},
+		&FacebookServiceType{},
+		&GithubServiceType{},
+		&HackerNewsServiceType{},
+		&RedditServiceType{},
+		&TwitterServiceType{},
+		&WebServiceType{},
+		&WebServiceType{scheme: "http"},
+		&WebServiceType{scheme: "https"},
 	}
 	return append(services, getBuildSpecificStaticProofServices()...)
 }

--- a/go/externals/proof_checkers_devel.go
+++ b/go/externals/proof_checkers_devel.go
@@ -11,6 +11,6 @@ const useDevelProofCheckers = true
 
 func getBuildSpecificStaticProofServices() []libkb.ServiceType {
 	return []libkb.ServiceType{
-		RooterServiceType{},
+		&RooterServiceType{},
 	}
 }

--- a/go/externals/proof_service_dns.go
+++ b/go/externals/proof_service_dns.go
@@ -42,16 +42,16 @@ func (rc *DNSChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, pcm libk
 
 type DNSServiceType struct{ libkb.BaseServiceType }
 
-func (t DNSServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *DNSServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t DNSServiceType) NormalizeUsername(s string) (string, error) {
+func (t *DNSServiceType) NormalizeUsername(s string) (string, error) {
 	if !libkb.IsValidHostname(s) {
 		return "", libkb.NewInvalidHostnameError(s)
 	}
 	return strings.ToLower(s), nil
 }
 
-func (t DNSServiceType) NormalizeRemoteName(_ libkb.MetaContext, s string) (string, error) {
+func (t *DNSServiceType) NormalizeRemoteName(_ libkb.MetaContext, s string) (string, error) {
 	// Allow a leading 'dns://' and preserve case.
 	s = strings.TrimPrefix(s, "dns://")
 	if !libkb.IsValidHostname(s) {
@@ -60,45 +60,45 @@ func (t DNSServiceType) NormalizeRemoteName(_ libkb.MetaContext, s string) (stri
 	return s, nil
 }
 
-func (t DNSServiceType) GetPrompt() string {
+func (t *DNSServiceType) GetPrompt() string {
 	return "Your DNS domain"
 }
 
-func (t DNSServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
+func (t *DNSServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	ret := jsonw.NewDictionary()
 	ret.SetKey("protocol", jsonw.NewString("dns"))
 	ret.SetKey("domain", jsonw.NewString(un))
 	return ret
 }
 
-func (t DNSServiceType) FormatProofText(ctx libkb.MetaContext, ppr *libkb.PostProofRes,
+func (t *DNSServiceType) FormatProofText(ctx libkb.MetaContext, ppr *libkb.PostProofRes,
 	kbUsername string, sigID keybase1.SigID) (string, error) {
 	return (ppr.Text + "\n"), nil
 }
 
-func (t DNSServiceType) PostInstructions(un string) *libkb.Markup {
+func (t *DNSServiceType) PostInstructions(un string) *libkb.Markup {
 	return libkb.FmtMarkup(`Please save the following as a DNS TXT entry for
 <strong>` + un + `</strong> OR <strong>_keybase.` + un + `</strong>:`)
 }
 
-func (t DNSServiceType) DisplayName(un string) string { return "Dns" }
-func (t DNSServiceType) GetTypeName() string          { return "dns" }
+func (t *DNSServiceType) DisplayName(un string) string { return "Dns" }
+func (t *DNSServiceType) GetTypeName() string          { return "dns" }
 
-func (t DNSServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, dn string) (warning *libkb.Markup, err error) {
+func (t *DNSServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, dn string) (warning *libkb.Markup, err error) {
 	warning = libkb.FmtMarkup(`<p>We couldn't find a DNS proof for ` + dn + ` ... <strong>yet</strong></p>
 <p>DNS propagation can be slow; we'll keep trying and email you the result</p>`)
 	err = libkb.WaitForItError{}
 	return
 }
-func (t DNSServiceType) GetProofType() string { return t.BaseGetProofType(t) }
+func (t *DNSServiceType) GetProofType() string { return t.BaseGetProofType(t) }
 
-func (t DNSServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
+func (t *DNSServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
 	return t.BaseCheckProofTextShort(text, id, true)
 }
 
-func (t DNSServiceType) GetAPIArgKey() string { return "remote_host" }
-func (t DNSServiceType) LastWriterWins() bool { return false }
+func (t *DNSServiceType) GetAPIArgKey() string { return "remote_host" }
+func (t *DNSServiceType) LastWriterWins() bool { return false }
 
-func (t DNSServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *DNSServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &DNSChecker{l}
 }

--- a/go/externals/proof_service_facebook.go
+++ b/go/externals/proof_service_facebook.go
@@ -39,11 +39,11 @@ func (rc *FacebookChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, 
 
 type FacebookServiceType struct{ libkb.BaseServiceType }
 
-func (t FacebookServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *FacebookServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 var facebookUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9.]{1,50})$`)
 
-func (t FacebookServiceType) NormalizeUsername(s string) (string, error) {
+func (t *FacebookServiceType) NormalizeUsername(s string) (string, error) {
 	if !facebookUsernameRegexp.MatchString(s) {
 		return "", libkb.NewBadUsernameError(s)
 	}
@@ -52,7 +52,7 @@ func (t FacebookServiceType) NormalizeUsername(s string) (string, error) {
 	return strings.ToLower(s), nil
 }
 
-func (t FacebookServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (string, error) {
+func (t *FacebookServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (string, error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	if !facebookUsernameRegexp.MatchString(s) {
@@ -64,26 +64,28 @@ func (t FacebookServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s strin
 	return strings.ToLower(s), nil
 }
 
-func (t FacebookServiceType) GetPrompt() string {
+func (t *FacebookServiceType) GetPrompt() string {
 	return "Your username on Facebook"
 }
 
-func (t FacebookServiceType) CanMakeNewProofs() bool { return false }
+// TODO remove this in favor of server flag when server configs are enabled
+// with CORE-8969
+func (t *FacebookServiceType) CanMakeNewProofs() bool { return false }
 
-func (t FacebookServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
+func (t *FacebookServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)
 }
 
-func (t FacebookServiceType) PostInstructions(un string) *libkb.Markup {
+func (t *FacebookServiceType) PostInstructions(un string) *libkb.Markup {
 	return libkb.FmtMarkup(
 		`<p>Please follow this link and make a <strong>public</strong> Facebook post.</p>
 		 <p>The text can be whatever you want, but the post <strong>must be public</strong>.</p>`)
 }
 
-func (t FacebookServiceType) DisplayName(un string) string { return "Facebook" }
-func (t FacebookServiceType) GetTypeName() string          { return "facebook" }
+func (t *FacebookServiceType) DisplayName(un string) string { return "Facebook" }
+func (t *FacebookServiceType) GetTypeName() string          { return "facebook" }
 
-func (t FacebookServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
+func (t *FacebookServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
 	if status == keybase1.ProofStatus_PERMISSION_DENIED {
 		warning = libkb.FmtMarkup("Permission denied! We can't support <strong>private</strong> posts.")
 	} else {
@@ -91,9 +93,9 @@ func (t FacebookServiceType) RecheckProofPosting(tryNumber int, status keybase1.
 	}
 	return
 }
-func (t FacebookServiceType) GetProofType() string { return t.BaseGetProofType(t) }
+func (t *FacebookServiceType) GetProofType() string { return t.BaseGetProofType(t) }
 
-func (t FacebookServiceType) CheckProofText(text string, id keybase1.SigID, sig string) error {
+func (t *FacebookServiceType) CheckProofText(text string, id keybase1.SigID, sig string) error {
 	// The "proof" here is a Facebook link that the user clicks on to go
 	// through a post flow. The exact nature of the link tends to change (e.g.
 	// it used to not point to a login interstitial, but now it does), and
@@ -102,6 +104,6 @@ func (t FacebookServiceType) CheckProofText(text string, id keybase1.SigID, sig 
 	return nil
 }
 
-func (t FacebookServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *FacebookServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &FacebookChecker{l}
 }

--- a/go/externals/proof_service_generic_social.go
+++ b/go/externals/proof_service_generic_social.go
@@ -227,65 +227,65 @@ type GenericSocialProofServiceType struct {
 	config *GenericSocialProofConfig
 }
 
-func NewGenericSocialProofServiceType(config *GenericSocialProofConfig) GenericSocialProofServiceType {
-	return GenericSocialProofServiceType{
+func NewGenericSocialProofServiceType(config *GenericSocialProofConfig) *GenericSocialProofServiceType {
+	return &GenericSocialProofServiceType{
 		config: config,
 	}
 }
 
-func (t GenericSocialProofServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *GenericSocialProofServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
-func (t GenericSocialProofServiceType) NormalizeUsername(s string) (string, error) {
+func (t *GenericSocialProofServiceType) NormalizeUsername(s string) (string, error) {
 	if err := t.config.validateRemoteUsername(s); err != nil {
 		return "", err
 	}
 	return strings.ToLower(s), nil
 }
 
-func (t GenericSocialProofServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (ret string, err error) {
+func (t *GenericSocialProofServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (ret string, err error) {
 	return t.NormalizeUsername(s)
 }
 
-func (t GenericSocialProofServiceType) GetPrompt() string {
+func (t *GenericSocialProofServiceType) GetPrompt() string {
 	return fmt.Sprintf("Your username on %s", t.config.DisplayName)
 }
 
-func (t GenericSocialProofServiceType) ToServiceJSON(username string) *jsonw.Wrapper {
+func (t *GenericSocialProofServiceType) ToServiceJSON(username string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, username)
 }
 
-func (t GenericSocialProofServiceType) PostInstructions(username string) *libkb.Markup {
+func (t *GenericSocialProofServiceType) PostInstructions(username string) *libkb.Markup {
 	return libkb.FmtMarkup(`Please click on the following link to post to %v:`, t.config.DisplayName)
 }
 
-func (t GenericSocialProofServiceType) DisplayName(username string) string {
+func (t *GenericSocialProofServiceType) DisplayName(username string) string {
 	return t.config.DisplayName
 }
-func (t GenericSocialProofServiceType) GetTypeName() string { return t.config.Domain }
+func (t *GenericSocialProofServiceType) GetTypeName() string { return t.config.Domain }
 
-func (t GenericSocialProofServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
+func (t *GenericSocialProofServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
 	return t.BaseRecheckProofPosting(tryNumber, status)
 }
 
-func (t GenericSocialProofServiceType) GetProofType() string {
+func (t *GenericSocialProofServiceType) GetProofType() string {
 	return libkb.GenericSocialWebServiceBinding
 }
 
-func (t GenericSocialProofServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
+func (t *GenericSocialProofServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
 	// We don't rely only any server trust in FormatProofText so there is nothing to verify here.
 	return nil
 }
 
-func (t GenericSocialProofServiceType) FormatProofText(m libkb.MetaContext, ppr *libkb.PostProofRes,
+func (t *GenericSocialProofServiceType) FormatProofText(m libkb.MetaContext, ppr *libkb.PostProofRes,
 	kbUsername string, sigID keybase1.SigID) (string, error) {
 	return t.config.prefillURLWithValues(kbUsername, sigID)
 }
 
-func (t GenericSocialProofServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *GenericSocialProofServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &GenericSocialProofChecker{
 		proof:  l,
 		config: t.config,
 	}
 }
 
-func (t GenericSocialProofServiceType) IsDevelOnly() bool { return false }
+func (t *GenericSocialProofServiceType) IsDevelOnly() bool { return false }

--- a/go/externals/proof_service_github.go
+++ b/go/externals/proof_service_github.go
@@ -39,40 +39,40 @@ func (rc *GithubChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _ 
 
 type GithubServiceType struct{ libkb.BaseServiceType }
 
-func (t GithubServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *GithubServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 var githubUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9][a-z0-9-]{0,38})$`)
 
-func (t GithubServiceType) NormalizeUsername(s string) (string, error) {
+func (t *GithubServiceType) NormalizeUsername(s string) (string, error) {
 	if !githubUsernameRegexp.MatchString(s) {
 		return "", libkb.NewBadUsernameError(s)
 	}
 	return strings.ToLower(s), nil
 }
 
-func (t GithubServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (ret string, err error) {
+func (t *GithubServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (ret string, err error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	return t.NormalizeUsername(s)
 }
 
-func (t GithubServiceType) GetPrompt() string {
+func (t *GithubServiceType) GetPrompt() string {
 	return "Your username on Github"
 }
 
-func (t GithubServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
+func (t *GithubServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)
 }
 
-func (t GithubServiceType) PostInstructions(un string) *libkb.Markup {
+func (t *GithubServiceType) PostInstructions(un string) *libkb.Markup {
 	return libkb.FmtMarkup(`Please <strong>publicly</strong> post the following Gist,
 and name it <strong><color name="red">keybase.md</color></strong>`)
 }
 
-func (t GithubServiceType) DisplayName(un string) string { return "Github" }
-func (t GithubServiceType) GetTypeName() string          { return "github" }
+func (t *GithubServiceType) DisplayName(un string) string { return "Github" }
+func (t *GithubServiceType) GetTypeName() string          { return "github" }
 
-func (t GithubServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
+func (t *GithubServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
 	if status == keybase1.ProofStatus_PERMISSION_DENIED {
 		warning = libkb.FmtMarkup("Permission denied! Make sure your gist is <strong>public</strong>.")
 	} else {
@@ -80,12 +80,12 @@ func (t GithubServiceType) RecheckProofPosting(tryNumber int, status keybase1.Pr
 	}
 	return
 }
-func (t GithubServiceType) GetProofType() string { return t.BaseGetProofType(t) }
+func (t *GithubServiceType) GetProofType() string { return t.BaseGetProofType(t) }
 
-func (t GithubServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
+func (t *GithubServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
 	return t.BaseCheckProofTextFull(text, id, sig)
 }
 
-func (t GithubServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *GithubServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &GithubChecker{l}
 }

--- a/go/externals/proof_service_hackernews.go
+++ b/go/externals/proof_service_hackernews.go
@@ -57,11 +57,11 @@ func CheckKarma(mctx libkb.MetaContext, un string) (int, error) {
 
 type HackerNewsServiceType struct{ libkb.BaseServiceType }
 
-func (t HackerNewsServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *HackerNewsServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 var hackerNewsUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_-]{2,15})$`)
 
-func (t HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
+func (t *HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
 	if !hackerNewsUsernameRegexp.MatchString(s) {
 		return "", libkb.NewBadUsernameError(s)
 	}
@@ -69,29 +69,29 @@ func (t HackerNewsServiceType) NormalizeUsername(s string) (string, error) {
 	return s, nil
 }
 
-func (t HackerNewsServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (string, error) {
+func (t *HackerNewsServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (string, error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	return t.NormalizeUsername(s)
 }
 
-func (t HackerNewsServiceType) GetPrompt() string {
+func (t *HackerNewsServiceType) GetPrompt() string {
 	return "Your username on HackerNews (**case-sensitive**)"
 }
 
-func (t HackerNewsServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
+func (t *HackerNewsServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)
 }
 
-func (t HackerNewsServiceType) PostInstructions(un string) *libkb.Markup {
+func (t *HackerNewsServiceType) PostInstructions(un string) *libkb.Markup {
 	return libkb.FmtMarkup(`Please edit your HackerNews profile to contain the
 following text. Click here: https://news.ycombinator.com/user?id=` + un)
 }
 
-func (t HackerNewsServiceType) DisplayName(un string) string { return "HackerNews" }
-func (t HackerNewsServiceType) GetTypeName() string          { return "hackernews" }
+func (t *HackerNewsServiceType) DisplayName(un string) string { return "HackerNews" }
+func (t *HackerNewsServiceType) GetTypeName() string          { return "hackernews" }
 
-func (t HackerNewsServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
+func (t *HackerNewsServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
 	warning = libkb.FmtMarkup(`<p>We couldn't find a posted proof...<strong>yet</strong></p>`)
 	if tryNumber < 3 {
 		warning.Append(`<p>HackerNews's API is slow to update, so be patient...try again?</p>`)
@@ -101,13 +101,13 @@ func (t HackerNewsServiceType) RecheckProofPosting(tryNumber int, status keybase
 	}
 	return
 }
-func (t HackerNewsServiceType) GetProofType() string { return t.BaseGetProofType(t) }
+func (t *HackerNewsServiceType) GetProofType() string { return t.BaseGetProofType(t) }
 
-func (t HackerNewsServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
+func (t *HackerNewsServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
 	return t.BaseCheckProofForURL(text, id)
 }
 
-func (t HackerNewsServiceType) PreProofCheck(mctx libkb.MetaContext, un string) (markup *libkb.Markup, err error) {
+func (t *HackerNewsServiceType) PreProofCheck(mctx libkb.MetaContext, un string) (markup *libkb.Markup, err error) {
 	if _, e := CheckKarma(mctx, un); e != nil {
 		markup = libkb.FmtMarkup(`
 <p><strong>ATTENTION</strong>: HackerNews only publishes users to their API who
@@ -121,6 +121,6 @@ func (t HackerNewsServiceType) PreProofCheck(mctx libkb.MetaContext, un string) 
 	return
 }
 
-func (t HackerNewsServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *HackerNewsServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &HackerNewsChecker{l}
 }

--- a/go/externals/proof_service_reddit.go
+++ b/go/externals/proof_service_reddit.go
@@ -84,34 +84,34 @@ func urlReencode(s string) string {
 
 type RedditServiceType struct{ libkb.BaseServiceType }
 
-func (t RedditServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *RedditServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 var redditUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_-]{3,20})$`)
 
-func (t RedditServiceType) NormalizeUsername(s string) (string, error) {
+func (t *RedditServiceType) NormalizeUsername(s string) (string, error) {
 	if !redditUsernameRegexp.MatchString(s) {
 		return "", libkb.NewBadUsernameError(s)
 	}
 	return strings.ToLower(s), nil
 }
 
-func (t RedditServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (ret string, err error) {
+func (t *RedditServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (ret string, err error) {
 	return t.NormalizeUsername(s)
 }
 
-func (t RedditServiceType) GetTypeName() string { return "reddit" }
+func (t *RedditServiceType) GetTypeName() string { return "reddit" }
 
-func (t RedditServiceType) GetPrompt() string { return "Your username on Reddit" }
+func (t *RedditServiceType) GetPrompt() string { return "Your username on Reddit" }
 
-func (t RedditServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
+func (t *RedditServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)
 }
 
-func (t RedditServiceType) PostInstructions(un string) *libkb.Markup {
+func (t *RedditServiceType) PostInstructions(un string) *libkb.Markup {
 	return libkb.FmtMarkup(`Please click on the following link to post to Reddit:`)
 }
 
-func (t RedditServiceType) FormatProofText(mctx libkb.MetaContext, ppr *libkb.PostProofRes,
+func (t *RedditServiceType) FormatProofText(mctx libkb.MetaContext, ppr *libkb.PostProofRes,
 	kbUsername string, sigID keybase1.SigID) (res string, err error) {
 	var title string
 	if title, err = ppr.Metadata.AtKey("title").GetString(); err != nil {
@@ -170,20 +170,20 @@ func (t RedditServiceType) FormatProofText(mctx libkb.MetaContext, ppr *libkb.Po
 	return
 }
 
-func (t RedditServiceType) DisplayName(un string) string { return "Reddit" }
+func (t *RedditServiceType) DisplayName(un string) string { return "Reddit" }
 
-func (t RedditServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
+func (t *RedditServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
 	warning, err = t.BaseRecheckProofPosting(tryNumber, status)
 	return
 }
 
-func (t RedditServiceType) GetProofType() string { return t.BaseGetProofType(t) }
+func (t *RedditServiceType) GetProofType() string { return t.BaseGetProofType(t) }
 
-func (t RedditServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
+func (t *RedditServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
 	// Anything is fine. We might get rid of the body later.
 	return nil
 }
 
-func (t RedditServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *RedditServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &RedditChecker{l}
 }

--- a/go/externals/proof_service_rooter.go
+++ b/go/externals/proof_service_rooter.go
@@ -41,48 +41,48 @@ func (rc *RooterChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _ 
 
 type RooterServiceType struct{ libkb.BaseServiceType }
 
-func (t RooterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *RooterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 var rooterUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`)
 
-func (t RooterServiceType) NormalizeUsername(s string) (string, error) {
+func (t *RooterServiceType) NormalizeUsername(s string) (string, error) {
 	if !rooterUsernameRegexp.MatchString(s) {
 		return "", libkb.NewBadUsernameError(s)
 	}
 	return strings.ToLower(s), nil
 }
 
-func (t RooterServiceType) NormalizeRemoteName(_ libkb.MetaContext, s string) (string, error) {
+func (t *RooterServiceType) NormalizeRemoteName(_ libkb.MetaContext, s string) (string, error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	return t.NormalizeUsername(s)
 }
 
-func (t RooterServiceType) GetPrompt() string {
+func (t *RooterServiceType) GetPrompt() string {
 	return "Your username on Rooter"
 }
 
-func (t RooterServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
+func (t *RooterServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)
 }
 
-func (t RooterServiceType) PostInstructions(un string) *libkb.Markup {
+func (t *RooterServiceType) PostInstructions(un string) *libkb.Markup {
 	return libkb.FmtMarkup(`Please toot the following, and don't delete it:`)
 }
 
-func (t RooterServiceType) DisplayName(un string) string { return "Rooter" }
-func (t RooterServiceType) GetTypeName() string          { return "rooter" }
-func (t RooterServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
+func (t *RooterServiceType) DisplayName(un string) string { return "Rooter" }
+func (t *RooterServiceType) GetTypeName() string          { return "rooter" }
+func (t *RooterServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
 	return t.BaseRecheckProofPosting(tryNumber, status)
 }
-func (t RooterServiceType) GetProofType() string { return "test.web_service_binding.rooter" }
+func (t *RooterServiceType) GetProofType() string { return "test.web_service_binding.rooter" }
 
-func (t RooterServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
+func (t *RooterServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
 	return t.BaseCheckProofTextShort(text, id, true)
 }
 
-func (t RooterServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *RooterServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &RooterChecker{l}
 }
 
-func (t RooterServiceType) IsDevelOnly() bool { return true }
+func (t *RooterServiceType) IsDevelOnly() bool { return true }

--- a/go/externals/proof_service_twitter.go
+++ b/go/externals/proof_service_twitter.go
@@ -39,39 +39,39 @@ func (rc *TwitterChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _
 
 type TwitterServiceType struct{ libkb.BaseServiceType }
 
-func (t TwitterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *TwitterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
 
 var twitterUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`)
 
-func (t TwitterServiceType) NormalizeUsername(s string) (string, error) {
+func (t *TwitterServiceType) NormalizeUsername(s string) (string, error) {
 	if !twitterUsernameRegexp.MatchString(s) {
 		return "", libkb.NewBadUsernameError(s)
 	}
 	return strings.ToLower(s), nil
 }
 
-func (t TwitterServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (string, error) {
+func (t *TwitterServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (string, error) {
 	// Allow a leading '@'.
 	s = strings.TrimPrefix(s, "@")
 	return t.NormalizeUsername(s)
 }
 
-func (t TwitterServiceType) GetPrompt() string {
+func (t *TwitterServiceType) GetPrompt() string {
 	return "Your username on Twitter"
 }
 
-func (t TwitterServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
+func (t *TwitterServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)
 }
 
-func (t TwitterServiceType) PostInstructions(un string) *libkb.Markup {
+func (t *TwitterServiceType) PostInstructions(un string) *libkb.Markup {
 	return libkb.FmtMarkup(`Please <strong>publicly</strong> tweet the following, and don't delete it:`)
 }
 
-func (t TwitterServiceType) DisplayName(un string) string { return "Twitter" }
-func (t TwitterServiceType) GetTypeName() string          { return "twitter" }
+func (t *TwitterServiceType) DisplayName(un string) string { return "Twitter" }
+func (t *TwitterServiceType) GetTypeName() string          { return "twitter" }
 
-func (t TwitterServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
+func (t *TwitterServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
 	if status == keybase1.ProofStatus_PERMISSION_DENIED {
 		warning = libkb.FmtMarkup("Permission denied! We can't support <strong>private</strong> feeds.")
 	} else {
@@ -79,12 +79,12 @@ func (t TwitterServiceType) RecheckProofPosting(tryNumber int, status keybase1.P
 	}
 	return
 }
-func (t TwitterServiceType) GetProofType() string { return t.BaseGetProofType(t) }
+func (t *TwitterServiceType) GetProofType() string { return t.BaseGetProofType(t) }
 
-func (t TwitterServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
+func (t *TwitterServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
 	return t.BaseCheckProofTextShort(text, id, false)
 }
 
-func (t TwitterServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *TwitterServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &TwitterChecker{l}
 }

--- a/go/externals/proof_service_web.go
+++ b/go/externals/proof_service_web.go
@@ -59,14 +59,14 @@ type WebServiceType struct {
 	scheme string
 }
 
-func (t WebServiceType) AllStringKeys() []string {
+func (t *WebServiceType) AllStringKeys() []string {
 	if t.scheme == "" {
 		return []string{"web"}
 	}
 	return []string{t.scheme}
 }
 
-func (t WebServiceType) NormalizeUsername(s string) (ret string, err error) {
+func (t *WebServiceType) NormalizeUsername(s string) (ret string, err error) {
 	// The username is just the (lowercased) hostname.
 	if !libkb.IsValidHostname(s) {
 		return "", libkb.NewInvalidHostnameError(s)
@@ -88,7 +88,7 @@ func ParseWeb(s string) (hostname string, prot string, err error) {
 	return
 }
 
-func (t WebServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (ret string, err error) {
+func (t *WebServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (ret string, err error) {
 	// The remote name is a full (case-preserved) URL.
 	var prot, host string
 	if host, prot, err = ParseWeb(s); err != nil {
@@ -129,11 +129,11 @@ func (t WebServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (r
 	return
 }
 
-func (t WebServiceType) GetPrompt() string {
+func (t *WebServiceType) GetPrompt() string {
 	return "Web site to check"
 }
 
-func (t WebServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
+func (t *WebServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	h, p, _ := ParseWeb(un)
 	ret := jsonw.NewDictionary()
 	ret.SetKey("protocol", jsonw.NewString(p+":"))
@@ -141,7 +141,7 @@ func (t WebServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return ret
 }
 
-func (t WebServiceType) MarkupFilenames(un string, mkp *libkb.Markup) {
+func (t *WebServiceType) MarkupFilenames(un string, mkp *libkb.Markup) {
 	mkp.Append(`<ul>`)
 	first := true
 	for _, f := range webKeybaseFiles {
@@ -157,22 +157,22 @@ func (t WebServiceType) MarkupFilenames(un string, mkp *libkb.Markup) {
 	mkp.Append(`</ul>`)
 }
 
-func (t WebServiceType) PreProofWarning(un string) *libkb.Markup {
+func (t *WebServiceType) PreProofWarning(un string) *libkb.Markup {
 	mkp := libkb.FmtMarkup(`<p>You will be asked to post a file to:</p>`)
 	t.MarkupFilenames(un, mkp)
 	return mkp
 }
 
-func (t WebServiceType) PostInstructions(un string) *libkb.Markup {
+func (t *WebServiceType) PostInstructions(un string) *libkb.Markup {
 	mkp := libkb.FmtMarkup(`<p>Make the following file available at:</p>`)
 	t.MarkupFilenames(un, mkp)
 	return mkp
 }
 
-func (t WebServiceType) DisplayName(un string) string { return "Web" }
-func (t WebServiceType) GetTypeName() string          { return "web" }
+func (t *WebServiceType) DisplayName(un string) string { return "Web" }
+func (t *WebServiceType) GetTypeName() string          { return "web" }
 
-func (t WebServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
+func (t *WebServiceType) RecheckProofPosting(tryNumber int, status keybase1.ProofStatus, _ string) (warning *libkb.Markup, err error) {
 	if status == keybase1.ProofStatus_PERMISSION_DENIED {
 		warning = libkb.FmtMarkup("Permission denied! Make sure your proof page is <strong>public</strong>.")
 	} else {
@@ -180,16 +180,16 @@ func (t WebServiceType) RecheckProofPosting(tryNumber int, status keybase1.Proof
 	}
 	return
 }
-func (t WebServiceType) GetProofType() string { return "web_service_binding.generic" }
+func (t *WebServiceType) GetProofType() string { return "web_service_binding.generic" }
 
-func (t WebServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
+func (t *WebServiceType) CheckProofText(text string, id keybase1.SigID, sig string) (err error) {
 	return t.BaseCheckProofTextFull(text, id, sig)
 }
 
-func (t WebServiceType) GetAPIArgKey() string { return "remote_host" }
-func (t WebServiceType) LastWriterWins() bool { return false }
+func (t *WebServiceType) GetAPIArgKey() string { return "remote_host" }
+func (t *WebServiceType) LastWriterWins() bool { return false }
 
-func (t WebServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
+func (t *WebServiceType) MakeProofChecker(l libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return &WebChecker{l}
 }
 

--- a/go/externals/services_test.go
+++ b/go/externals/services_test.go
@@ -68,14 +68,25 @@ func TestLoadParamServices(t *testing.T) {
 		},
 	}, gubbleConf.CheckPath)
 
-	found := false
+	foundGubble := false
+	foundFacebook := false
 	for _, config := range displayConfigs {
 		if config.Key == "gubble.social" {
 			group := "gubble"
 			require.EqualValues(t, &group, config.Group)
-			found = true
-			break
+			require.False(t, config.CreationDisabled)
+			foundGubble = true
+			if foundFacebook {
+				break
+			}
+		}
+		if config.Key == "facebook" {
+			require.True(t, config.CreationDisabled)
+			foundFacebook = true
+			if foundGubble {
+				break
+			}
 		}
 	}
-	require.True(t, found)
+	require.True(t, foundGubble && foundFacebook)
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -226,6 +226,7 @@ const (
 	SCKeyRevoked                       = int(keybase1.StatusCode_SCKeyRevoked)
 	SCSigCannotVerify                  = int(keybase1.StatusCode_SCSigCannotVerify)
 	SCSibkeyAlreadyExists              = int(keybase1.StatusCode_SCSibkeyAlreadyExists)
+	SCSigCreationDisallowed            = int(keybase1.StatusCode_SCSigCreationDisallowed)
 	SCDecryptionKeyNotFound            = int(keybase1.StatusCode_SCDecryptionKeyNotFound)
 	SCBadTrackSession                  = int(keybase1.StatusCode_SCBadTrackSession)
 	SCDeviceBadName                    = int(keybase1.StatusCode_SCDeviceBadName)

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -920,7 +920,11 @@ type ServiceDoesNotSupportNewProofsError struct {
 }
 
 func (e ServiceDoesNotSupportNewProofsError) Error() string {
-	return fmt.Sprintf("New %q proofs are no longer supported", e.Service)
+	service := e.Service
+	if len(service) > 0 {
+		service = fmt.Sprintf("%q", service)
+	}
+	return fmt.Sprintf("New %s proofs are no longer supported", service)
 }
 
 //=============================================================================

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -107,10 +107,22 @@ func (i *IdentifyOutcome) proofChecksSortedByDisplayPriority() []*LinkCheckResul
 	pc := make([]*LinkCheckResult, len(i.ProofChecks))
 	copy(pc, i.ProofChecks)
 	proofServices := i.G().GetProofServices()
+	serviceTypes := map[string]int{}
+	for _, lcr := range pc {
+		key := lcr.link.DisplayPriorityKey()
+		if _, ok := serviceTypes[key]; !ok {
+			st := proofServices.GetServiceType(key)
+			displayPriority := 0
+			if st != nil {
+				displayPriority = st.DisplayPriority()
+			}
+			serviceTypes[key] = displayPriority
+		}
+	}
 	sort.Slice(pc, func(a, b int) bool {
 		keyA := pc[a].link.DisplayPriorityKey()
 		keyB := pc[b].link.DisplayPriorityKey()
-		return proofServices.GetDisplayPriority(keyA) > proofServices.GetDisplayPriority(keyB)
+		return serviceTypes[keyA] > serviceTypes[keyB]
 	})
 	return pc
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -585,13 +585,14 @@ type ServiceType interface {
 	IsDevelOnly() bool
 
 	MakeProofChecker(l RemoteProofChainLink) ProofChecker
+	SetDisplayConfig(*keybase1.ServiceDisplayConfig)
 	CanMakeNewProofs() bool
+	DisplayPriority() int
 }
 
 type ExternalServicesCollector interface {
 	GetServiceType(n string) ServiceType
 	ListProofCheckers() []string
-	GetDisplayPriority(n string) int
 	ListServicesThatAcceptNewProofs() []string
 }
 

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -304,6 +304,12 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 		return IdentifyDidNotCompleteError{}
 	case SCSibkeyAlreadyExists:
 		return SibkeyAlreadyExistsError{}
+	case SCSigCreationDisallowed:
+		service := ""
+		if len(s.Fields) > 0 && s.Fields[0].Key == "remote_service" {
+			service = s.Fields[0].Value
+		}
+		return ServiceDoesNotSupportNewProofsError{Service: service}
 	case SCNoUI:
 		return NoUIError{Which: s.Desc}
 	case SCNoUIDelegation:
@@ -1705,6 +1711,14 @@ func (e SibkeyAlreadyExistsError) ToStatus() keybase1.Status {
 	return keybase1.Status{
 		Code: SCSibkeyAlreadyExists,
 		Name: "SC_SIBKEY_ALREADY_EXISTS",
+		Desc: e.Error(),
+	}
+}
+
+func (e ServiceDoesNotSupportNewProofsError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Code: SCSigCreationDisallowed,
+		Name: "SC_SIG_CREATION_DISALLOWED",
 		Desc: e.Error(),
 	}
 }

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
@@ -35,9 +36,18 @@ func MakeProofChecker(c ExternalServicesCollector, l RemoteProofChainLink) (Proo
 
 //=============================================================================
 
-type BaseServiceType struct{}
+type BaseServiceType struct {
+	sync.Mutex
+	displayConf *keybase1.ServiceDisplayConfig
+}
 
-func (t BaseServiceType) BaseCheckProofTextShort(text string, id keybase1.SigID, med bool) error {
+func (t *BaseServiceType) SetDisplayConfig(displayConf *keybase1.ServiceDisplayConfig) {
+	t.Lock()
+	defer t.Unlock()
+	t.displayConf = displayConf
+}
+
+func (t *BaseServiceType) BaseCheckProofTextShort(text string, id keybase1.SigID, med bool) error {
 	blocks := FindBase64Snippets(text)
 	var target string
 	if med {
@@ -58,36 +68,36 @@ func (t BaseServiceType) BaseCheckProofTextShort(text string, id keybase1.SigID,
 	return NotFoundError{"Couldn't find signature ID " + target + " in text"}
 }
 
-func (t BaseServiceType) BaseRecheckProofPosting(tryNumber int, status keybase1.ProofStatus) (warning *Markup, err error) {
+func (t *BaseServiceType) BaseRecheckProofPosting(tryNumber int, status keybase1.ProofStatus) (warning *Markup, err error) {
 	warning = FmtMarkup("Couldn't find posted proof.")
 	return
 }
 
-func (t BaseServiceType) BaseToServiceJSON(st ServiceType, un string) *jsonw.Wrapper {
+func (t *BaseServiceType) BaseToServiceJSON(st ServiceType, un string) *jsonw.Wrapper {
 	ret := jsonw.NewDictionary()
 	ret.SetKey("name", jsonw.NewString(st.GetTypeName()))
 	ret.SetKey("username", jsonw.NewString(un))
 	return ret
 }
 
-func (t BaseServiceType) BaseGetProofType(st ServiceType) string {
+func (t *BaseServiceType) BaseGetProofType(st ServiceType) string {
 	return "web_service_binding." + st.GetTypeName()
 }
 
-func (t BaseServiceType) BaseAllStringKeys(st ServiceType) []string {
+func (t *BaseServiceType) BaseAllStringKeys(st ServiceType) []string {
 	return []string{st.GetTypeName()}
 }
 
-func (t BaseServiceType) LastWriterWins() bool                               { return true }
-func (t BaseServiceType) PreProofCheck(MetaContext, string) (*Markup, error) { return nil, nil }
-func (t BaseServiceType) PreProofWarning(remotename string) *Markup          { return nil }
+func (t *BaseServiceType) LastWriterWins() bool                               { return true }
+func (t *BaseServiceType) PreProofCheck(MetaContext, string) (*Markup, error) { return nil, nil }
+func (t *BaseServiceType) PreProofWarning(remotename string) *Markup          { return nil }
 
-func (t BaseServiceType) FormatProofText(m MetaContext, ppr *PostProofRes,
+func (t *BaseServiceType) FormatProofText(m MetaContext, ppr *PostProofRes,
 	kbUsername string, sigID keybase1.SigID) (string, error) {
 	return ppr.Text, nil
 }
 
-func (t BaseServiceType) BaseCheckProofTextFull(text string, id keybase1.SigID, sig string) (err error) {
+func (t *BaseServiceType) BaseCheckProofTextFull(text string, id keybase1.SigID, sig string) (err error) {
 	blocks := FindBase64Blocks(text)
 	target := FindFirstBase64Block(sig)
 	if len(target) == 0 {
@@ -113,7 +123,7 @@ func (t BaseServiceType) BaseCheckProofTextFull(text string, id keybase1.SigID, 
 
 var urlRxx = regexp.MustCompile(`https://(\S+)`)
 
-func (t BaseServiceType) BaseCheckProofForURL(text string, id keybase1.SigID) (err error) {
+func (t *BaseServiceType) BaseCheckProofForURL(text string, id keybase1.SigID) (err error) {
 	target := id.ToMediumID()
 	urls := urlRxx.FindAllString(text, -1)
 	found := false
@@ -128,13 +138,29 @@ func (t BaseServiceType) BaseCheckProofForURL(text string, id keybase1.SigID) (e
 	return
 }
 
-func (t BaseServiceType) GetAPIArgKey() string {
+func (t *BaseServiceType) GetAPIArgKey() string {
 	return "remote_username"
 }
 
-func (t BaseServiceType) IsDevelOnly() bool { return false }
+func (t *BaseServiceType) IsDevelOnly() bool { return false }
 
-func (t BaseServiceType) CanMakeNewProofs() bool { return true }
+func (t *BaseServiceType) DisplayPriority() int {
+	t.Lock()
+	defer t.Unlock()
+	if t.displayConf == nil {
+		return 0
+	}
+	return t.displayConf.Priority
+}
+
+func (t *BaseServiceType) CanMakeNewProofs() bool {
+	t.Lock()
+	defer t.Unlock()
+	if t.displayConf == nil {
+		return true
+	}
+	return !t.displayConf.CreationDisabled
+}
 
 //=============================================================================
 

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -65,6 +65,7 @@ const (
 	StatusCode_SCSigCannotVerify                  StatusCode = 1002
 	StatusCode_SCSigWrongKey                      StatusCode = 1008
 	StatusCode_SCSigOldSeqno                      StatusCode = 1010
+	StatusCode_SCSigCreationDisallowed            StatusCode = 1016
 	StatusCode_SCBadTrackSession                  StatusCode = 1301
 	StatusCode_SCDeviceBadName                    StatusCode = 1404
 	StatusCode_SCDeviceNameInUse                  StatusCode = 1408
@@ -263,6 +264,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCSigCannotVerify":                  1002,
 	"SCSigWrongKey":                      1008,
 	"SCSigOldSeqno":                      1010,
+	"SCSigCreationDisallowed":            1016,
 	"SCBadTrackSession":                  1301,
 	"SCDeviceBadName":                    1404,
 	"SCDeviceNameInUse":                  1408,
@@ -459,6 +461,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	1002: "SCSigCannotVerify",
 	1008: "SCSigWrongKey",
 	1010: "SCSigOldSeqno",
+	1016: "SCSigCreationDisallowed",
 	1301: "SCBadTrackSession",
 	1404: "SCDeviceBadName",
 	1408: "SCDeviceNameInUse",

--- a/go/protocol/keybase1/prove_common.go
+++ b/go/protocol/keybase1/prove_common.go
@@ -373,15 +373,17 @@ func (o ParamProofServiceConfig) DeepCopy() ParamProofServiceConfig {
 }
 
 type ServiceDisplayConfig struct {
-	Priority int     `codec:"priority" json:"priority"`
-	Key      string  `codec:"key" json:"key"`
-	Group    *string `codec:"group,omitempty" json:"group,omitempty"`
+	CreationDisabled bool    `codec:"creationDisabled" json:"creation_disabled"`
+	Priority         int     `codec:"priority" json:"priority"`
+	Key              string  `codec:"key" json:"key"`
+	Group            *string `codec:"group,omitempty" json:"group,omitempty"`
 }
 
 func (o ServiceDisplayConfig) DeepCopy() ServiceDisplayConfig {
 	return ServiceDisplayConfig{
-		Priority: o.Priority,
-		Key:      o.Key,
+		CreationDisabled: o.CreationDisabled,
+		Priority:         o.Priority,
+		Key:              o.Key,
 		Group: (func(x *string) *string {
 			if x == nil {
 				return nil

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -57,6 +57,7 @@ protocol constants {
     SCSigCannotVerify_1002,
     SCSigWrongKey_1008,
     SCSigOldSeqno_1010,
+    SCSigCreationDisallowed_1016,
     SCBadTrackSession_1301,
     SCDeviceBadName_1404,
     SCDeviceNameInUse_1408,

--- a/protocol/avdl/keybase1/prove_common.avdl
+++ b/protocol/avdl/keybase1/prove_common.avdl
@@ -139,6 +139,8 @@ protocol proveCommon {
   }
 
   record ServiceDisplayConfig {
+    @jsonkey("creation_disabled")
+    boolean creationDisabled;
     int priority;
     string key;
     union { null, string } group;

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -61,6 +61,7 @@
         "SCSigCannotVerify_1002",
         "SCSigWrongKey_1008",
         "SCSigOldSeqno_1010",
+        "SCSigCreationDisallowed_1016",
         "SCBadTrackSession_1301",
         "SCDeviceBadName_1404",
         "SCDeviceNameInUse_1408",

--- a/protocol/json/keybase1/prove_common.json
+++ b/protocol/json/keybase1/prove_common.json
@@ -233,6 +233,11 @@
       "name": "ServiceDisplayConfig",
       "fields": [
         {
+          "type": "boolean",
+          "name": "creationDisabled",
+          "jsonkey": "creation_disabled"
+        },
+        {
           "type": "int",
           "name": "priority"
         },

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -156,6 +156,7 @@ export const constantsStatusCode = {
   scsigcannotverify: 1002,
   scsigwrongkey: 1008,
   scsigoldseqno: 1010,
+  scsigcreationdisallowed: 1016,
   scbadtracksession: 1301,
   scdevicebadname: 1404,
   scdevicenameinuse: 1408,

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -1103,6 +1103,7 @@ export const constantsStatusCode = {
   scsigcannotverify: 1002,
   scsigwrongkey: 1008,
   scsigoldseqno: 1010,
+  scsigcreationdisallowed: 1016,
   scbadtracksession: 1301,
   scdevicebadname: 1404,
   scdevicenameinuse: 1408,
@@ -2520,6 +2521,7 @@ export type StatusCode =
   | 1002 // SCSigCannotVerify_1002
   | 1008 // SCSigWrongKey_1008
   | 1010 // SCSigOldSeqno_1010
+  | 1016 // SCSigCreationDisallowed_1016
   | 1301 // SCBadTrackSession_1301
   | 1404 // SCDeviceBadName_1404
   | 1408 // SCDeviceNameInUse_1408

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -2437,7 +2437,7 @@ export type SeqType =
   | 3 // SEMIPRIVATE_3
 
 export type Seqno = Int64
-export type ServiceDisplayConfig = $ReadOnly<{priority: Int, key: String, group?: ?String}>
+export type ServiceDisplayConfig = $ReadOnly<{creationDisabled: Boolean, priority: Int, key: String, group?: ?String}>
 export type ServiceStatus = $ReadOnly<{version: String, label: String, pid: String, lastExitStatus: String, bundleVersion: String, installStatus: InstallStatus, installAction: InstallAction, status: Status}>
 export type ServicesStatus = $ReadOnly<{service?: ?Array<ServiceStatus>, kbfs?: ?Array<ServiceStatus>, updater?: ?Array<ServiceStatus>}>
 export type Session = $ReadOnly<{uid: UID, username: String, token: String, deviceSubkeyKid: KID, deviceSibkeyKid: KID}>


### PR DESCRIPTION
Enables client support for a `creation_disabled` field so the server can stop proof creation of service if it suddenly dies/drops keybase support as facebook did. Stores the `ServiceDisplayConfig` within the `ServiceType` and moves the `DisplayPriority` function to `ServiceType`. depends on https://github.com/keybase/keybase/pull/3188