### PR TITLE
unfurling: process Giphy URLs custom to display the Gif inline (and no other metadata)

### DIFF
--- a/go/chat/unfurl/scrape_giphy.go
+++ b/go/chat/unfurl/scrape_giphy.go
@@ -21,9 +21,7 @@ func (s *Scraper) scrapeGiphy(ctx context.Context, uri string) (res chat1.Unfurl
 		s.Debug(ctx, "scrapeGiphy: failed to find an image, just returning generic unfurl")
 		return chat1.NewUnfurlRawWithGeneric(generic.UnfurlGenericRaw), nil
 	}
-	giphy.ImageURL = *generic.ImageUrl
-	if generic.FaviconUrl != nil {
-		giphy.FaviconURL = *generic.FaviconUrl
-	}
+	giphy.ImageUrl = *generic.ImageUrl
+	giphy.FaviconUrl = generic.FaviconUrl
 	return chat1.NewUnfurlRawWithGiphy(giphy), nil
 }

--- a/go/chat/unfurl/scrape_giphy.go
+++ b/go/chat/unfurl/scrape_giphy.go
@@ -1,0 +1,29 @@
+package unfurl
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/protocol/chat1"
+)
+
+func (s *Scraper) scrapeGiphy(ctx context.Context, uri string) (res chat1.UnfurlRaw, err error) {
+	c := s.makeCollector()
+	var giphy chat1.UnfurlGiphyRaw
+	generic := new(scoredGenericRaw)
+	if err = s.addGenericScraperToCollector(ctx, c, generic, uri, "giphy.com"); err != nil {
+		return res, err
+	}
+	if err := c.Visit(uri); err != nil {
+		return res, err
+	}
+	if generic.ImageUrl == nil {
+		// If we couldn't find an image, then just return the generic
+		s.Debug(ctx, "scrapeGiphy: failed to find an image, just returning generic unfurl")
+		return chat1.NewUnfurlRawWithGeneric(generic.UnfurlGenericRaw), nil
+	}
+	giphy.ImageURL = *generic.ImageUrl
+	if generic.FaviconUrl != nil {
+		giphy.FaviconURL = *generic.FaviconUrl
+	}
+	return chat1.NewUnfurlRawWithGiphy(giphy), nil
+}

--- a/go/chat/unfurl/scraper.go
+++ b/go/chat/unfurl/scraper.go
@@ -31,13 +31,19 @@ func (s *Scraper) makeCollector() *colly.Collector {
 	return c
 }
 
-func (s *Scraper) Scrape(ctx context.Context, uri string) (res chat1.UnfurlRaw, err error) {
+func (s *Scraper) Scrape(ctx context.Context, uri string, forceTyp *chat1.UnfurlType) (res chat1.UnfurlRaw, err error) {
 	defer s.Trace(ctx, func() error { return err }, "Scrape")()
-	typ, domain, err := ClassifyDomainFromURI(uri)
-	if err != nil {
-		return res, err
+	var unfurlTyp chat1.UnfurlType
+	var domain string
+	if forceTyp != nil {
+		unfurlTyp = *forceTyp
+	} else {
+		var err error
+		if unfurlTyp, domain, err = ClassifyDomainFromURI(uri); err != nil {
+			return res, err
+		}
 	}
-	switch typ {
+	switch unfurlTyp {
 	case chat1.UnfurlType_GENERIC:
 		return s.scrapeGeneric(ctx, uri, domain)
 	case chat1.UnfurlType_GIPHY:

--- a/go/chat/unfurl/scraper.go
+++ b/go/chat/unfurl/scraper.go
@@ -3,6 +3,7 @@ package unfurl
 import (
 	"context"
 
+	"github.com/gocolly/colly"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/logger"
 
@@ -19,6 +20,17 @@ func NewScraper(logger logger.Logger) *Scraper {
 	}
 }
 
+func (s *Scraper) makeCollector() *colly.Collector {
+	c := colly.NewCollector(
+		colly.UserAgent("Mozilla/5.0 (compatible; Keybase; +https://keybase.io)"),
+	)
+	c.OnRequest(func(r *colly.Request) {
+		r.Headers.Set("connection", "keep-alive")
+		r.Headers.Set("upgrade-insecure-requests", "1")
+	})
+	return c
+}
+
 func (s *Scraper) Scrape(ctx context.Context, uri string) (res chat1.UnfurlRaw, err error) {
 	defer s.Trace(ctx, func() error { return err }, "Scrape")()
 	typ, domain, err := ClassifyDomainFromURI(uri)
@@ -28,6 +40,8 @@ func (s *Scraper) Scrape(ctx context.Context, uri string) (res chat1.UnfurlRaw, 
 	switch typ {
 	case chat1.UnfurlType_GENERIC:
 		return s.scrapeGeneric(ctx, uri, domain)
+	case chat1.UnfurlType_GIPHY:
+		return s.scrapeGiphy(ctx, uri)
 	default:
 		return s.scrapeGeneric(ctx, uri, domain)
 	}

--- a/go/chat/unfurl/scraper/main.go
+++ b/go/chat/unfurl/scraper/main.go
@@ -23,7 +23,7 @@ func main() {
 	logging.Reset()
 	url := args[0]
 	scraper := unfurl.NewScraper(logger)
-	res, err := scraper.Scrape(context.TODO(), url)
+	res, err := scraper.Scrape(context.TODO(), url, nil)
 	if err != nil {
 		fmt.Printf("error scraping URL: %v\n", err)
 		os.Exit(3)

--- a/go/chat/unfurl/scraper_test.go
+++ b/go/chat/unfurl/scraper_test.go
@@ -84,8 +84,10 @@ func TestScraper(t *testing.T) {
 	srv := createTestCaseHTTPSrv(t)
 	addr := srv.Start()
 	defer srv.Stop()
-	testCase := func(name string, expected chat1.UnfurlRaw) {
-		res, err := scraper.Scrape(context.TODO(), "http://"+addr+"/?name="+name)
+	forceGiphy := new(chat1.UnfurlType)
+	*forceGiphy = chat1.UnfurlType_GIPHY
+	testCase := func(name string, expected chat1.UnfurlRaw, forceTyp *chat1.UnfurlType) {
+		res, err := scraper.Scrape(context.TODO(), "http://"+addr+"/?name="+name, forceTyp)
 		require.NoError(t, err)
 		etyp, err := expected.UnfurlType()
 		require.NoError(t, err)
@@ -117,6 +119,13 @@ func TestScraper(t *testing.T) {
 			if e.FaviconUrl != nil {
 				require.Equal(t, *e.FaviconUrl, *r.FaviconUrl)
 			}
+		case chat1.UnfurlType_GIPHY:
+			e := expected.Giphy()
+			r := res.Giphy()
+			require.Equal(t, e.ImageUrl, r.ImageUrl)
+			require.NotNil(t, r.FaviconUrl)
+			require.NotNil(t, e.FaviconUrl)
+			require.Equal(t, *e.FaviconUrl, *r.FaviconUrl)
 		default:
 			require.Fail(t, "unknown unfurl typ")
 		}
@@ -129,7 +138,7 @@ func TestScraper(t *testing.T) {
 		PublishTime: intPtr(1540941044),
 		ImageUrl:    strPtr("https://cdn.cnn.com/cnnnext/dam/assets/181011162312-11-week-in-photos-1011-super-tease.jpg"),
 		FaviconUrl:  strPtr("http://cdn.cnn.com/cnn/.e/img/3.0/global/misc/apple-touch-icon.png"),
-	}))
+	}), nil)
 	testCase("wsj0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "U.S. Stocks Jump as Tough Month Sets to Wrap",
 		Url:         "https://www.wsj.com/articles/global-stocks-rally-to-end-a-tough-month-1540976261",
@@ -138,7 +147,7 @@ func TestScraper(t *testing.T) {
 		PublishTime: intPtr(1541004540),
 		ImageUrl:    strPtr("https://images.wsj.net/im-33925/social"),
 		FaviconUrl:  strPtr("https://s.wsj.net/media/wsj_apple-touch-icon-180x180.png"),
-	}))
+	}), nil)
 	testCase("nytimes0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "First Up if Democrats Win: Campaign and Ethics Changes, Infrastructure and Drug Prices",
 		Url:         "https://www.nytimes.com/2018/10/31/us/politics/democrats-midterm-elections.html",
@@ -147,7 +156,7 @@ func TestScraper(t *testing.T) {
 		PublishTime: intPtr(1540990881),
 		ImageUrl:    strPtr("https://static01.nyt.com/images/2018/10/31/us/politics/31dc-dems/31dc-dems-facebookJumbo.jpg"),
 		FaviconUrl:  strPtr("http://127.0.0.1/vi-assets/static-assets/apple-touch-icon-319373aaf4524d94d38aa599c56b8655.png"),
-	}))
+	}), nil)
 	srv.shouldServeAppleTouchIcon = true
 	testCase("github0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "keybase/client",
@@ -156,7 +165,7 @@ func TestScraper(t *testing.T) {
 		Description: strPtr("Keybase Go Library, Client, Service, OS X, iOS, Android, Electron - keybase/client"),
 		ImageUrl:    strPtr("https://avatars1.githubusercontent.com/u/5400834?s=400&v=4"),
 		FaviconUrl:  strPtr(fmt.Sprintf("http://%s/apple-touch-icon.png", addr)),
-	}))
+	}), nil)
 	srv.shouldServeAppleTouchIcon = false
 	testCase("youtube0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "Mario Kart Wii: The History of the Ultra Shortcut",
@@ -165,7 +174,7 @@ func TestScraper(t *testing.T) {
 		Description: strPtr("https://www.twitch.tv/summoningsalt https://twitter.com/summoningsalt Music List- https://docs.google.com/document/d/1p2qV31ZhtNuP7AAXtRjGNZr2QwMSolzuz2wX6wu..."),
 		ImageUrl:    strPtr("https://i.ytimg.com/vi/mmJ_LT8bUj0/hqdefault.jpg"),
 		FaviconUrl:  strPtr("https://s.ytimg.com/yts/img/favicon-vfl8qSV2F.ico"),
-	}))
+	}), nil)
 	testCase("twitter0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "Ars Technica on Twitter",
 		Url:         "https://twitter.com/arstechnica/status/1057679097869094917",
@@ -173,7 +182,7 @@ func TestScraper(t *testing.T) {
 		Description: strPtr("“Nintendo recommits to “keep the business going” for 3DS https://t.co/wTIJxmGTJH by @KyleOrl”"),
 		ImageUrl:    strPtr("https://pbs.twimg.com/profile_images/2215576731/ars-logo_400x400.png"),
 		FaviconUrl:  strPtr("https://abs.twimg.com/icons/apple-touch-icon-192x192.png"),
-	}))
+	}), nil)
 	testCase("pinterest0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "Halloween",
 		Url:         "https://www.pinterest.com/pinterest/halloween/",
@@ -181,14 +190,14 @@ func TestScraper(t *testing.T) {
 		Description: strPtr("Dracula dentures, kitten costumes, no-carve pumpkins—find your next killer idea on Pinterest."),
 		ImageUrl:    strPtr("https://i.pinimg.com/custom_covers/200x150/424605139807203572_1414340303.jpg"),
 		FaviconUrl:  strPtr("https://s.pinimg.com/webapp/style/images/logo_trans_144x144-642179a1.png"),
-	}))
+	}), nil)
 	testCase("wikipedia0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "Merkle tree - Wikipedia",
 		SiteName:    "0.1",
 		Description: nil,
 		ImageUrl:    strPtr("https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/Hash_Tree.svg/1200px-Hash_Tree.svg.png"),
 		FaviconUrl:  strPtr("http://127.0.0.1/static/apple-touch/wikipedia.png"),
-	}))
+	}), nil)
 	testCase("reddit0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "r/Stellar",
 		Url:         "https://www.reddit.com/r/Stellar/",
@@ -196,7 +205,7 @@ func TestScraper(t *testing.T) {
 		Description: strPtr("r/Stellar: Stellar is a decentralized protocol that enables you to send money to anyone in the world, for fractions of a penny, instantly, and in any currency.  \n\n/r/Stellar is for news, announcements and discussion related to Stellar.\n\nPlease focus on community-oriented content, such as news and discussions, instead of individual-oriented content, such as questions and help. Follow the [Stellar Community Guidelines](https://www.stellar.org/community-guidelines/) ."),
 		ImageUrl:    strPtr("https://b.thumbs.redditmedia.com/D857u25iiE2ORpt8yVx7fCuiMlLVP-b5fwSUjaw4lVU.png"),
 		FaviconUrl:  strPtr("https://www.redditstatic.com/desktop2x/img/favicon/apple-icon-180x180.png"),
-	}))
+	}), nil)
 	testCase("etsy0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "The Beatles - Minimalist Poster - Sgt Pepper",
 		Url:         "https://www.etsy.com/listing/602032869/the-beatles-minimalist-poster-sgt-pepper?utm_source=OpenGraph&utm_medium=PageTools&utm_campaign=Share",
@@ -204,5 +213,9 @@ func TestScraper(t *testing.T) {
 		Description: strPtr("The Beatles Sgt Peppers Lonely Hearts Club Ban  Created using mixed media  Fits a 10 x 8 inch frame aperture - photograph shows item framed in a 12 x 10 inch frame  Choose from: high lustre paper - 210g which produces very vibrant colours; textured watercolour paper - 190g - which looks"),
 		ImageUrl:    strPtr("https://i.etsystatic.com/12686588/r/il/c3b4bc/1458062296/il_570xN.1458062296_rary.jpg"),
 		FaviconUrl:  strPtr("http://127.0.0.1/images/favicon.ico"),
-	}))
+	}), nil)
+	testCase("giphy0", chat1.NewUnfurlRawWithGiphy(chat1.UnfurlGiphyRaw{
+		ImageUrl:   "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-downsized-large.gif",
+		FaviconUrl: strPtr("https://giphy.com/static/img/icons/apple-touch-icon-180px.png"),
+	}), forceGiphy)
 }

--- a/go/chat/unfurl/testcases/giphy0.html
+++ b/go/chat/unfurl/testcases/giphy0.html
@@ -1,0 +1,298 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head >
+      <meta charset="utf-8" />
+      <title>Mesmerizing China GIF by Feliks Tomasz Konczakowski - Find &amp; Share on GIPHY</title>
+
+      
+          
+              <link rel="canonical" href="https://giphy.com/gifs/japan-money-usa-5C3Zrs5xUg5fHV4Kcf"/>
+          
+      
+
+      <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+      <meta name="google-site-verification" content="8mfne8CLOmysP4fUdGDJioWLEGbHMJY4tBsxsQT2eSY" />
+      <meta name="msvalidate.01" content="F8A7FDC3D369E857ACB67C4AB8EBD9A4" />
+      <meta name="alexaVerifyID" content="HMyPJIK-pLEheM5ACWFf6xvnA2U" />
+      <meta property="fb:admins" content="548288355" />
+      <meta name="p:domain_verify" content="61a9a962d47f10756a14a44c1b44d7c8"/>
+      <meta name="viewport" content="width=device-width, user-scalable=1, initial-scale=1.0">
+
+      
+
+      
+      
+      
+
+          <meta property="fb:app_id" content="406655189415060">
+    <meta property="og:site_name" content="GIPHY">
+    <meta property="og:url" content="https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-downsized-large.gif">
+    <meta property="og:title" content="Mesmerizing China GIF by Feliks Tomasz Konczakowski - Find &amp; Share on GIPHY">
+    <meta property="og:description" content="Discover &amp; share this Japan GIF with everyone you know. GIPHY is how you search, share, discover, and create GIFs.">
+
+    
+    <meta property="og:type" content="video.other">
+    <meta property="og:image" content="https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-downsized-large.gif">
+    <meta property="og:image:type" content="image/gif">
+    <meta property="og:image:width" content="287">
+    <meta property="og:image:height" content="287">
+    
+    <meta property="og:video" content="https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy.mp4">
+    <meta property="og:video:secure_url" content="https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy.mp4">
+    <meta property="og:video:type" content="video/mp4">
+    <meta property="og:video:width" content="480">
+    <meta property="og:video:height" content="480">
+
+    <meta name="twitter:account_id" content="1020383864" />
+    <meta name="twitter:card" content="player">
+    <meta name="twitter:title" content="Mesmerizing China GIF by Feliks Tomasz Konczakowski - Find &amp; Share on GIPHY">
+    <meta name="twitter:creator" content="@giphy">
+    <meta name="twitter:site" content="@giphy">
+    <meta name="twitter:description" content="Discover &amp; share this Japan GIF with everyone you know. GIPHY is how you search, share, discover, and create GIFs.">
+    <meta name="twitter:image:src" content="https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-facebook_s.jpg">
+    <meta name="twitter:image" content="https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-facebook_s.jpg">
+    <meta name="twitter:domain" content="giphy.com">
+
+    
+    <meta name="twitter:player" content="https://giphy.com/embed/5C3Zrs5xUg5fHV4Kcf/twitter/iframe">
+    <meta name="twitter:player:width" content="435">
+    <meta name="twitter:player:height" content="435">
+    
+
+    
+    <meta name="rating" content="general">
+    <meta name="image:rating" content="g">
+    
+
+    <!-- /twitter seo -->
+
+    <meta name="description" content="Discover &amp; share this Japan GIF with everyone you know. GIPHY is how you search, share, discover, and create GIFs."/>
+    <meta name="author" content="GIPHY"/>
+    <meta name="keywords" content="japan, money, usa, internet, power, digital, computer, gold, business, russia, bitcoin, cryptocurrency, china, energy, crypto, electronic, blockchain, rich, konczakowski, spiral, interweb, buy, virtual, coin, bit, spam, dollar, market, mesmerizing, computers, finance, bot, wallet, coins, pay, price, electronics, economy, mint, dollars, investment, cheap, ico, tax, taxes, computing, mb, expensive, mining, tb, scam, currency, millionaire, mesmerising, gb, purchase, payment, billionaire, financial, hash, internets, fad, cpu, wildcat, economic, asset, scammer, gpu, cryptography, assets, gigabyte, risky, miner, merchant, bitcoins, wallets, finances, interwebs, transaction, digital currency, decentralized, scams, regulation, bitcoin mining, imf, byte, volatility, cryptocoin, venture capital, hpc, richest, digital cash, dark web, satoshi nakamoto, digital asset, peer to peer, compute, ponzi scheme, peer-to-peer, hashes, megabyte, virtual currency, throughput, investmens, mining farm, cryptocurrency bubble, electronic wallet, network nodes, crypto-anarchism, collective delusion, cryptocurrency wallet, public distributed ledger, electronic currency, spamming, spammer, bit coin, unsound, crypto mining, gold standard, terabyte, new economy, crypto miner, high performance computing, cryptominer, digital economy, spam bot, high performance computer, bitcoing mining, bitcoing miner, riksy, GIF, Animated GIF">
+    <meta name="pinterest" content="nohover">
+
+
+      
+      <link rel="alternate" type="application/json+oembed" href="https://giphy.com/services/oembed?url=https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy.gif" title="Mesmerizing China GIF by Feliks Tomasz Konczakowski - Find &amp; Share on GIPHY oEmbed Lookup" />
+      
+
+      
+
+      <link rel="icon" type="image/png" href="https://giphy.com/static/img/favicon.png" />
+      <meta name="apple-mobile-web-app-title" content="GIPHY">
+      <link rel="apple-touch-icon" sizes="120x120" href="https://giphy.com/static/img/icons/apple-touch-icon-120px.png"/>
+      <link rel="apple-touch-icon" sizes="180x180" href="https://giphy.com/static/img/icons/apple-touch-icon-180px.png" />
+      <link rel="apple-touch-icon" sizes="152x152" href="https://giphy.com/static/img/icons/apple-touch-icon-152px.png" />
+      <link rel="apple-touch-icon" sizes="167x167" href="https://giphy.com/static/img/icons/apple-touch-icon-167px.png" />
+
+      <link rel="apple-touch-startup-image" media="(device-width: 320px)" href="https://giphy.com/static/img/icons/apple-touch-startup-image-320x460.png'">
+      <link rel="apple-touch-startup-image" media="(device-width: 320px) and (-webkit-device-pixel-ratio: 2)" href="https://giphy.com/static/img/icons/apple-touch-startup-image-640x920.png">
+
+      
+    <script type="application/ld+json" name="giphy-schema">
+      {
+        "@context": "http://schema.org",
+        "@type": "Article",
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://giphy.com/gifs/japan-money-usa-5C3Zrs5xUg5fHV4Kcf"
+        },
+        "headline": "Mesmerizing China GIF by Feliks Tomasz Konczakowski",
+        "image": {
+            "@type": "ImageObject",
+            "url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy.gif",
+            "height": "480",
+            "width": "480"
+        },
+        "datePublished": "2018-05-21T03:16:52+00:00",
+        "dateModified": "2018-05-31T16:28:33+00:00",
+        
+        "publisher": {
+            "@type": "Organization",
+            "name": "GIPHY",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://giphy.com/static/img/giphy_logo_square_social.png",
+                "width": "300",
+                "height": "300"
+            }
+        }
+      }
+    </script>
+
+
+      <style>body{background-color:#121212}.dots-loading-container{width:66px;-webkit-animation:expand .75s ease-in-out infinite alternate;-moz-animation:expand .75s ease-in-out infinite alternate;-ms-animation:expand .75s ease-in-out infinite alternate;animation:expand .75s ease-in-out infinite alternate;top:50%;left:50%;margin-left:-33px;margin-top:30px;position:absolute}.dot{width:13px;height:13px;border-radius:50%;position:absolute;}.dot.dot-a{-webkit-animation:scaleA 1.5s ease-in-out infinite;-moz-animation:scaleA 1.5s ease-in-out infinite;-ms-animation:scaleA 1.5s ease-in-out infinite;animation:scaleA 1.5s ease-in-out infinite;background-color:#f66;left:0%}.dot.dot-b{-webkit-animation:scaleB 1.5s ease-in-out infinite;-moz-animation:scaleB 1.5s ease-in-out infinite;-ms-animation:scaleB 1.5s ease-in-out infinite;animation:scaleB 1.5s ease-in-out infinite;background-color:#93f;left:33%}.dot.dot-c{-webkit-animation:scaleC 1.5s ease-in-out infinite;-moz-animation:scaleC 1.5s ease-in-out infinite;-ms-animation:scaleC 1.5s ease-in-out infinite;animation:scaleC 1.5s ease-in-out infinite;background-color:#0cf;left:66%}.dot.dot-d{-webkit-animation:scaleD 1.5s ease-in-out infinite;-moz-animation:scaleD 1.5s ease-in-out infinite;-ms-animation:scaleD 1.5s ease-in-out infinite;animation:scaleD 1.5s ease-in-out infinite;background-color:#0f9;left:100%}@-moz-keyframes scaleA{0%{transform:scale(1)}30%{transform:scale(1.5)}60%{transform:scale(1)}}@-webkit-keyframes scaleA{0%{transform:scale(1)}30%{transform:scale(1.5)}60%{transform:scale(1)}}@-o-keyframes scaleA{0%{transform:scale(1)}30%{transform:scale(1.5)}60%{transform:scale(1)}}@keyframes scaleA{0%{transform:scale(1)}30%{transform:scale(1.5)}60%{transform:scale(1)}}@-moz-keyframes scaleB{10%{transform:scale(1)}40%{transform:scale(1.5)}70%{transform:scale(1)}}@-webkit-keyframes scaleB{10%{transform:scale(1)}40%{transform:scale(1.5)}70%{transform:scale(1)}}@-o-keyframes scaleB{10%{transform:scale(1)}40%{transform:scale(1.5)}70%{transform:scale(1)}}@keyframes scaleB{10%{transform:scale(1)}40%{transform:scale(1.5)}70%{transform:scale(1)}}@-moz-keyframes scaleC{20%{transform:scale(1)}50%{transform:scale(1.5)}80%{transform:scale(1)}}@-webkit-keyframes scaleC{20%{transform:scale(1)}50%{transform:scale(1.5)}80%{transform:scale(1)}}@-o-keyframes scaleC{20%{transform:scale(1)}50%{transform:scale(1.5)}80%{transform:scale(1)}}@keyframes scaleC{20%{transform:scale(1)}50%{transform:scale(1.5)}80%{transform:scale(1)}}@-moz-keyframes scaleD{30%{transform:scale(1)}65%{transform:scale(1.5)}100%{transform:scale(1)}}@-webkit-keyframes scaleD{30%{transform:scale(1)}65%{transform:scale(1.5)}100%{transform:scale(1)}}@-o-keyframes scaleD{30%{transform:scale(1)}65%{transform:scale(1.5)}100%{transform:scale(1)}}@keyframes scaleD{30%{transform:scale(1)}65%{transform:scale(1.5)}100%{transform:scale(1)}}@-moz-keyframes expand{from{width:66px}to{width:100px;transform:translateX(-17px)}}@-webkit-keyframes expand{from{width:66px}to{width:100px;transform:translateX(-17px)}}@-o-keyframes expand{from{width:66px}to{width:100px;transform:translateX(-17px)}}@keyframes expand{from{width:66px}to{width:100px;transform:translateX(-17px)}}</style>
+
+      
+    
+    
+
+      
+    
+
+  </head>
+  <body  itemscope itemtype="http://schema.org/WebPage">
+      <script>
+        dataLayer = [];
+      </script>
+      
+    
+    
+<script type="text/javascript">
+    dataLayer.push({
+        'sitetype': 'Desktop',
+        'pageName': window.location.pathname === '/' ? '/homepage' : window.location.pathname,
+        'loggedInStatus': 'false',
+        
+    });
+</script>
+
+
+
+      <div id="dots-loader" class="dots-loading-container">
+          <div class="dot dot-a"></div>
+          <div class="dot dot-b"></div>
+          <div class="dot dot-c"></div>
+          <div class="dot dot-d"></div>
+      </div>
+
+      
+    <div id="metadata-example"></div>
+    <div id="messages">
+        
+    </div>
+
+      
+
+    
+    <div id="fb-root"></div>
+    <script>(function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s); js.id = id;
+      js.src = "//connect.facebook.net/en_US/sdk.js#version=v2.1&xfbml=1&appId=406655189415060";
+      fjs.parentNode.insertBefore(js, fjs);
+      }(document, 'script', 'facebook-jssdk'));
+    </script>
+
+    
+
+    
+
+    
+
+    <div id="content" class="container_12">
+        
+<div id="power-glove"></div>
+<div class="gif-detail-page"></div>
+
+
+    </div>
+    <div style="clear:both; margin-bottom: 80px;"></div>
+
+    
+
+
+      <!-- ANALYTICS -->
+      
+          <!-- Quantcast Tag -->
+<script type="text/javascript">
+    var _qevents = _qevents || [];
+    __qc = undefined;
+    (function() {
+        var elem = document.createElement('script');
+        elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+        elem.async = true;
+        elem.type = "text/javascript";
+        elem.id = "quantcast";
+        var scpt = document.getElementsByTagName('script')[0];
+        scpt.parentNode.insertBefore(elem, scpt);
+    })();
+    _qevents.push({
+        qacct:"p-PdxaRL3tyJt0S"
+    });
+</script>
+
+<noscript>
+    <div style="display:none;">
+        <img src="//pixel.quantserve.com/pixel/p-PdxaRL3tyJt0S.gif" border="0" height="1" width="1" alt="Quantcast"/>
+    </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+<!-- Start Alexa Certify Javascript -->
+<script type="text/javascript">
+_atrk_opts = { atrk_acct:"wlIjj1aAkN00Ei", domain:"giphy.com",dynamic: true};
+(function() { var as = document.createElement('script'); as.type = 'text/javascript'; as.async = true; as.src = "https://d31qbv1cthcecs.cloudfront.net/atrk.js"; var s = document.getElementsByTagName('script')[0];s.parentNode.insertBefore(as, s); })();
+</script>
+<noscript><img src="https://d5nxst8fruw4z.cloudfront.net/atrk.gif?account=wlIjj1aAkN00Ei" style="display:none" height="1" width="1" alt="" /></noscript>
+<!-- End Alexa Certify Javascript -->
+
+      
+      <!-- END ANALYTICS -->
+
+       <!-- Google Tag Manager -->
+      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-P5GCKB"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <script>
+      //Note: this will set window.ga at an unpredictible time
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-P5GCKB');</script>
+      <script>
+          if(!window.ga) {
+              (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+          }
+      </script>
+      <!-- End Google Tag Manager -->
+      <script>
+          var Giphy = Giphy || {};
+          window.STATIC_URL = "https://giphy.com/static/";
+          window.ASSET_DOMAIN = "giphy.com";
+          window.DOMAIN = "giphy.com";
+          window.HOSTNAME = "";
+          window.REAL_HOSTNAME = "giphy.com"
+          window.CURRENT_VERSION = "d9c00fa"
+          window.GIPHY_API_CREATE_BASE_URL = "https://api.giphy.com/v1/create/"
+      </script>
+      
+    <script src="/static/dist/runtime.9651b671.bundle.js"></script>
+    <script src="/static/dist/desktopVendor.4b0f6547.bundle.js"></script>
+    <script src="/static/dist/desktopCommon.1ce82f3e.bundle.js"></script>
+
+    
+
+      
+    
+    <script src="/static/dist/desktopEntry.5b16379e.bundle.js"></script>
+    <script>
+        Giphy.renderDesktop(document.querySelector('.gif-detail-page'), {
+            gif: {"rating": "g", "is_featured": false, "is_takedown": false, "source_post_url": "", "is_nsfw": false, "is_favorite": false, "images": {"fixed_width": {"width": 200, "mp4": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200w.mp4", "webp_size": 1573086, "mp4_size": 430080, "url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200w.gif", "size": 3701445, "webp": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200w.webp", "height": 200}, "downsized": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200w_d.gif", "width": 200, "size": 21552768, "height": 200}, "fixed_height_still": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200_s.gif", "width": 200, "height": 200}, "fixed_width_downsampled": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200w_d.gif", "height": 200, "width": 200, "webp": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200w_d.webp", "webp_size": 94664, "size": 224279}, "fixed_height_small_still": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/100_s.gif", "width": 100, "height": 100}, "downsized_large": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-downsized-large.gif", "width": 287, "size": 7497637, "height": 287}, "original": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy.gif", "webp": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy.webp", "height": 480, "width": 480, "mp4": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy.mp4", "frames": 100, "size": 21552768}, "original_still": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy_s.gif", "width": 480, "height": 480}, "looping": {"mp4": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-loop.mp4"}, "fixed_width_small": {"width": 100, "mp4": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/100w.mp4", "webp_size": 467654, "mp4_size": 47799, "url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/100w.gif", "size": 961605, "webp": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/100w.webp", "height": 100}, "fixed_height_downsampled": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200_d.gif", "height": 200, "width": 200, "webp": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200_d.webp", "webp_size": 94664, "size": 224279}, "source": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy.gif", "width": 480, "size": 21552768, "frames": 100, "height": 480}, "fixed_width_small_still": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/100w_s.gif", "width": 100, "height": 100}, "downsized_medium": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-downsized-medium.gif", "width": 255, "size": 4796415, "height": 255}, "fixed_height": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200.gif", "webp": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200.webp", "height": 200, "width": 200, "mp4": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200.mp4", "webp_size": 1573086, "size": 3701445}, "fixed_width_still": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/200w_s.gif", "width": 200, "height": 200}, "fixed_height_small": {"width": 100, "mp4": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/100.mp4", "webp_size": 467654, "mp4_size": 145175, "url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/100.gif", "size": 961605, "webp": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/100.webp", "height": 100}, "downsized_still": {"url": "https://media.giphy.com/media/5C3Zrs5xUg5fHV4Kcf/giphy-downsized_s.gif", "width": 192, "height": 192}}, "is_hidden": false, "id": "5C3Zrs5xUg5fHV4Kcf", "bitly_url": "https://gph.is/2LfwAe4", "title": "Mesmerizing China GIF by Feliks Tomasz Konczakowski", "external_media": null, "get_absolute_url": "/gifs/japan-money-usa-5C3Zrs5xUg5fHV4Kcf", "update_datetime": "2018-05-31T16:28:33+00:00", "search_datetime": null, "type": "gif", "source_body": "", "username": "konczakowski", "create_datetime": "2018-05-21T03:18:23+00:00", "embed_url": "https://giphy.com/embed/5C3Zrs5xUg5fHV4Kcf", "tags": ["japan", "money", "usa", "internet", "power", "digital", "computer", "gold", "business", "russia", "bitcoin", "cryptocurrency", "china", "energy", "crypto", "electronic", "blockchain", "rich", "konczakowski", "spiral", "interweb", "buy", "virtual", "coin", "bit", "spam", "dollar", "market", "mesmerizing", "computers", "finance", "bot", "wallet", "coins", "pay", "price", "electronics", "economy", "mint", "dollars", "investment", "cheap", "ico", "tax", "taxes", "computing", "mb", "expensive", "mining", "tb", "scam", "currency", "millionaire", "mesmerising", "gb", "purchase", "payment", "billionaire", "financial", "hash", "internets", "fad", "cpu", "wildcat", "economic", "asset", "scammer", "gpu", "cryptography", "assets", "gigabyte", "risky", "miner", "merchant", "bitcoins", "wallets", "finances", "interwebs", "transaction", "digital currency", "decentralized", "scams", "regulation", "bitcoin mining", "imf", "byte", "volatility", "cryptocoin", "venture capital", "hpc", "richest", "digital cash", "dark web", "satoshi nakamoto", "digital asset", "peer to peer", "compute", "ponzi scheme", "peer-to-peer", "hashes", "megabyte", "virtual currency", "throughput", "investmens", "mining farm", "cryptocurrency bubble", "electronic wallet", "network nodes", "crypto-anarchism", "collective delusion", "cryptocurrency wallet", "public distributed ledger", "electronic currency", "spamming", "spammer", "bit coin", "unsound", "crypto mining", "gold standard", "terabyte", "new economy", "crypto miner", "high performance computing", "cryptominer", "digital economy", "spam bot", "high performance computer", "bitcoing mining", "bitcoing miner", "riksy"], "source_tld": "", "edit_status": "", "source_domain": "", "trending_datetime": null, "featured_tags_string": "", "featured_tags": [], "is_indexable": null, "is_removed": false, "is_preserve_size": false, "slug": "japan-money-usa-5C3Zrs5xUg5fHV4Kcf", "source_image_url": "/tmp/5C3Zrs5xUg5fHV4Kcf.gif", "is_caption": false, "tags_string": "\ngiphyupload\njapan\nmoney\nusa\ninternet\npower\ndigital\ncomputer\ngold\nbusiness\nrussia\nchina\nbitcoin\ncryptocurrency\nenergy\nelectronic\nrich\ncrypto\nspiral\nkonczakowski\nbit\nblockchain\nspam\nvirtual\ncomputers\ninterweb\nmarket\nmesmerizing\ndollar\nbuy\ncoin\nfinance\nbot\nprice\npay\nwallet\nelectronics\neconomy\ndollars\ncoins\nmint\ntaxes\ncomputing\ncheap\ninvestment\nico\nexpensive\ntax\nmining\nmb\ntb\nscam\ncurrency\nmillionaire\ngb\ninternets\nfad\npayment\nhash\ncpu\nmesmerising\nbillionaire\npurchase\nasset\ncryptography\nfinancial\ngpu\nscammer\nwildcat\ngigabyte\nmerchant\nwallets\nrisky\ninterwebs\nbitcoins\nminer\nfinances\nassets\ndigital currency\nscams\neconomic\nregulation\nvolatility\ndecentralized\ncryptocoin\nbitcoin mining\nimf\nventure capital\ndigital cash\ntransaction\nrichest\nhpc\ndark web\nbyte\nsatoshi nakamoto\npeer to peer\npeer-to-peer\nponzi scheme\nhashes\ncompute\nvirtual currency\nthroughput\nmegabyte\ndigital asset\ncryptocurrency wallet\nmining farm\ninvestmens\nnetwork nodes\ncollective delusion\npublic distributed ledger\ncryptocurrency bubble\nelectronic wallet\ncrypto-anarchism\nelectronic currency\nspamming\nspammer\nunsound\nbit coin\ngold standard\nnew economy\nterabyte\ncrypto mining\ncrypto miner\ncryptominer\nhigh performance computing\ndigital economy\nspam bot\nhigh performance computer\nbitcoing mining\nriksy\nbitcoing miner", "is_anonymous": false, "is_community": false, "url": "https://giphy.com/gifs/japan-money-usa-5C3Zrs5xUg5fHV4Kcf", "source_content_url": "", "is_sticker": false, "search_id": "815244800e4a440e3885c3644e295ec1", "source_caption": "", "index_id": 62464732, "import_datetime": "2018-05-21T03:16:52+00:00", "is_realtime": false},
+            pageData: {
+                permissions: {},
+                pagination: {"next_url": "/gifs/5C3Zrs5xUg5fHV4Kcf/related/1"},
+                featured_channels: [{"id": 562, "slug": "giphystudios", "url": "/giphystudios", "display_name": "GIPHY Studios Originals", "avatar_image_url": "https://media.giphy.com/channel_assets/giphystudios/sXdnwI7AsTZp.jpg", "has_children": true, "breadcrumbs": []}, {"id": 621, "slug": "rihanna", "url": "/rihanna", "display_name": "Rihanna", "avatar_image_url": "https://media.giphy.com/channel_assets/rihannagifs/wy6vU239QWC2.jpg", "has_children": true, "breadcrumbs": []}, {"id": 681, "slug": "reactions", "url": "/reactions", "display_name": "Reaction GIFs", "avatar_image_url": "https://media.giphy.com/channel_assets/reactions/k2ybPvSfRQuK.gif", "has_children": true, "breadcrumbs": []}, {"id": 680, "slug": "entertainment", "url": "/entertainment", "display_name": "Entertainment GIFs", "avatar_image_url": "https://media.giphy.com/channel_assets/entertainment/h2UuV7nZZyrT.gif", "has_children": true, "breadcrumbs": []}, {"id": 679, "slug": "sports", "url": "/sports", "display_name": "Sports GIFs", "avatar_image_url": "https://media.giphy.com/channel_assets/sports/P658KMA9mwy4.gif", "has_children": true, "breadcrumbs": []}, {"id": 1119, "slug": "snl", "url": "/snl", "display_name": "Saturday Night Live", "avatar_image_url": "https://media.giphy.com/channel_assets/snl/FNmjSGabYyy5.jpg", "has_children": true, "breadcrumbs": []}, {"id": 675, "slug": "southpark", "url": "/southpark", "display_name": "South Park", "avatar_image_url": "https://media.giphy.com/channel_assets/southparkgifs/Yxjwn4anI9bQ.jpg", "has_children": true, "breadcrumbs": []}, {"id": 1103, "slug": "originals", "url": "/originals", "display_name": "Originals", "avatar_image_url": "https://media.giphy.com/channel_assets/originals/abFL0aLWuzrm.gif", "has_children": true, "breadcrumbs": []}, {"id": 1121, "slug": "nba", "url": "/nba", "display_name": "NBA", "avatar_image_url": "https://media.giphy.com/channel_assets/nba/HJGYzMQwjf6J.jpg", "has_children": true, "breadcrumbs": []}, {"id": 1206, "slug": "mlb", "url": "/mlb", "display_name": "MLB", "avatar_image_url": "https://media.giphy.com/channel_assets/mlb/jL0oCFBZsURo.png", "has_children": true, "breadcrumbs": []}, {"id": 1305, "slug": "nfl", "url": "/nfl", "display_name": "NFL", "avatar_image_url": "https://media.giphy.com/avatars/nfl/q4LREAkL1aHi.jpg", "has_children": true, "breadcrumbs": []}, {"id": 1437, "slug": "ladygaga", "url": "/ladygaga", "display_name": "Lady Gaga", "avatar_image_url": "https://media.giphy.com/channel_assets/ladygaga/mezRP5Hdh4kM.jpg", "has_children": true, "breadcrumbs": []}, {"id": 1607, "slug": "gilmoregirls", "url": "/gilmoregirls", "display_name": "Gilmore Girls ", "avatar_image_url": "https://media.giphy.com/channel_assets/gilmoregirls/Z7UIgXCANSoA.png", "has_children": true, "breadcrumbs": []}, {"id": 1631, "slug": "obama", "url": "/obama", "display_name": "Obama", "avatar_image_url": "https://media.giphy.com/channel_assets/obama/6d09hwbI3xkj.gif", "has_children": true, "breadcrumbs": []}, {"id": 1403, "slug": "nbc", "url": "/nbc", "display_name": "NBC", "avatar_image_url": "https://media.giphy.com/channel_assets/NBC/8VSbPmTWn4fM.png", "has_children": true, "breadcrumbs": []}, {"id": 2033, "slug": "workaholics", "url": "/workaholics", "display_name": "Workaholics", "avatar_image_url": "https://media.giphy.com/channel_assets/workaholics/78VdiiAz5Y22.jpg", "has_children": true, "breadcrumbs": []}, {"id": 2056, "slug": "signwithrobert", "url": "/signwithrobert", "display_name": "Sign with Robert", "avatar_image_url": "https://media.giphy.com/channel_assets/sign-robert/g4Od3TWg872c.jpg", "has_children": true, "breadcrumbs": []}, {"id": 2114, "slug": "lego", "url": "/lego", "display_name": "LEGO", "avatar_image_url": "https://media.giphy.com/channel_assets/lego/OZpuno6GstOM.png", "has_children": true, "breadcrumbs": []}, {"id": 2178, "slug": "Awards", "url": "/Awards", "display_name": "Awards", "avatar_image_url": "https://media.giphy.com/channel_assets/Awards/3IHxeerMG1Vu.gif", "has_children": true, "breadcrumbs": []}, {"id": 2225, "slug": "nhl", "url": "/nhl", "display_name": "NHL", "avatar_image_url": "https://media.giphy.com/channel_assets/nhl/sCDQY3KHSisL.jpg", "has_children": true, "breadcrumbs": []}, {"id": 2314, "slug": "oscars", "url": "/oscars", "display_name": "The Academy Awards", "avatar_image_url": "https://media.giphy.com/channel_assets/oscars/EG9RXGo42zQU.jpg", "has_children": true, "breadcrumbs": []}, {"id": 2571, "slug": "recordingacademy", "url": "/recordingacademy", "display_name": "Recording Academy / GRAMMYs", "avatar_image_url": "https://media.giphy.com/channel_assets/recordingacademy/I9j3yC8Sghag.jpg", "has_children": true, "breadcrumbs": []}, {"id": 2658, "slug": "twinpeaksonshowtime", "url": "/twinpeaksonshowtime", "display_name": "Twin Peaks on Showtime", "avatar_image_url": "https://media.giphy.com/channel_assets/twinpeaksonshowtime/WsI0iW0J9ryo.jpg", "has_children": true, "breadcrumbs": []}, {"id": 3197, "slug": "usopen", "url": "/usopen", "display_name": "US Open", "avatar_image_url": "https://media.giphy.com/channel_assets/usopen/fRHzbu3jToy7.jpg", "has_children": false, "breadcrumbs": []}, {"id": 3222, "slug": "a24", "url": "/a24", "display_name": "A24", "avatar_image_url": "https://media.giphy.com/channel_assets/a24/gUXthPuI6ZzO.jpg", "has_children": true, "breadcrumbs": []}],
+                trending_tags: [{"is_featured": false, "name": "happy birthday", "channel_slug": "greetings", "create_datetime": "2013-05-02T20:16:45+00:00", "id": 6697, "name_encoded": "happy-birthday"}, {"is_featured": false, "name": "boston red sox", "channel_slug": "sports", "create_datetime": "2013-06-28T11:38:49+00:00", "id": 108937, "name_encoded": "boston-red-sox"}, {"is_featured": false, "name": "snl", "channel_slug": "entertainment", "create_datetime": "2013-05-07T19:12:16+00:00", "id": 755, "name_encoded": "snl"}, {"is_featured": false, "name": "christmas", "channel_slug": "holidays", "create_datetime": "2013-05-05T20:39:03+00:00", "id": 90, "name_encoded": "christmas"}, {"is_featured": false, "name": "excited", "channel_slug": "reactions", "create_datetime": "2013-05-06T00:21:27+00:00", "id": 4753, "name_encoded": "excited"}, {"is_featured": false, "name": "nfl", "channel_slug": "sports", "create_datetime": "2013-04-25T00:04:18+00:00", "id": 13486, "name_encoded": "nfl"}, {"is_featured": false, "name": "happy fall", "channel_slug": "greetings", "create_datetime": "2015-09-11T06:08:03+00:00", "id": 819619, "name_encoded": "happy-fall"}, {"is_featured": false, "name": "rhonj", "channel_slug": "entertainment", "create_datetime": "2013-06-20T14:05:04+00:00", "id": 98562, "name_encoded": "rhonj"}, {"is_featured": false, "name": "hanukkah", "channel_slug": "holidays", "create_datetime": "2013-04-25T00:03:20+00:00", "id": 11, "name_encoded": "hanukkah"}, {"is_featured": false, "name": "facepalm", "channel_slug": "reactions", "create_datetime": "2013-05-05T20:14:23+00:00", "id": 494, "name_encoded": "facepalm"}, {"is_featured": false, "name": "i love you", "channel_slug": "greetings", "create_datetime": "2013-05-05T21:38:10+00:00", "id": 6864, "name_encoded": "i-love-you"}, {"is_featured": false, "name": "riverdale", "channel_slug": "entertainment", "create_datetime": "2016-03-20T07:39:19+00:00", "id": 1452042, "name_encoded": "riverdale"}, {"is_featured": false, "name": "lebron james", "channel_slug": "sports", "create_datetime": "2013-04-25T00:03:57+00:00", "id": 8018, "name_encoded": "lebron-james"}, {"is_featured": false, "name": "kwanzaa", "channel_slug": "holidays", "create_datetime": "2013-04-25T00:04:50+00:00", "id": 22499, "name_encoded": "kwanzaa"}, {"is_featured": false, "name": "omg", "channel_slug": "reactions", "create_datetime": "2013-05-07T19:14:20+00:00", "id": 1827, "name_encoded": "omg"}, {"is_featured": false, "name": "good morning", "channel_slug": "greetings", "create_datetime": "2013-05-05T21:05:22+00:00", "id": 4164, "name_encoded": "good-morning"}, {"is_featured": false, "name": "mlb", "channel_slug": "sports", "create_datetime": "2013-04-25T00:05:10+00:00", "id": 28203, "name_encoded": "mlb"}, {"is_featured": false, "name": "high five", "channel_slug": "reactions", "create_datetime": "2013-05-07T19:12:56+00:00", "id": 1151, "name_encoded": "high-five"}, {"is_featured": false, "name": "countdown to christmas", "channel_slug": "entertainment", "create_datetime": "2015-12-01T20:33:59+00:00", "id": 994350, "name_encoded": "countdown-to-christmas"}, {"is_featured": false, "name": "festivus", "channel_slug": "holidays", "create_datetime": "2013-07-31T11:57:21+00:00", "id": 130534, "name_encoded": "festivus"}, {"is_featured": false, "name": "good night", "channel_slug": "greetings", "create_datetime": "2013-05-05T21:05:21+00:00", "id": 12402, "name_encoded": "good-night"}, {"is_featured": false, "name": "nhl", "channel_slug": "sports", "create_datetime": "2013-04-25T00:05:01+00:00", "id": 25568, "name_encoded": "nhl"}, {"is_featured": false, "name": "blank stare", "channel_slug": "reactions", "create_datetime": "2013-04-25T00:03:59+00:00", "id": 8403, "name_encoded": "blank-stare"}, {"is_featured": false, "name": "the holiday calendar", "channel_slug": "entertainment", "create_datetime": "2018-11-02T02:32:15+00:00", "id": 168053908, "name_encoded": "the-holiday-calendar"}, {"is_featured": false, "name": "i miss you", "channel_slug": "greetings", "create_datetime": "2013-04-29T18:30:13+00:00", "id": 22763, "name_encoded": "i-miss-you"}, {"is_featured": false, "name": "love you", "channel_slug": "reactions", "create_datetime": "2013-05-02T21:04:33+00:00", "id": 7088, "name_encoded": "love-you"}, {"is_featured": false, "name": "whatever", "channel_slug": "reactions", "create_datetime": "2013-05-06T00:36:16+00:00", "id": 5750, "name_encoded": "whatever"}, {"is_featured": false, "name": "happy halloween", "channel_slug": "greetings", "create_datetime": "2013-04-25T00:06:56+00:00", "id": 59750, "name_encoded": "happy-halloween"}, {"is_featured": false, "name": "jaw drop", "channel_slug": "reactions", "create_datetime": "2013-04-25T00:07:55+00:00", "id": 77353, "name_encoded": "jaw-drop"}, {"is_featured": false, "name": "confused", "channel_slug": "reactions", "create_datetime": "2013-05-06T00:38:41+00:00", "id": 8473, "name_encoded": "confused"}, {"is_featured": false, "name": "lol", "channel_slug": "reactions", "create_datetime": "2013-05-07T19:09:38+00:00", "id": 15, "name_encoded": "lol"}, {"is_featured": false, "name": "aww", "channel_slug": "reactions", "create_datetime": "2013-05-05T18:39:44+00:00", "id": 4986, "name_encoded": "aww"}, {"is_featured": false, "name": "wow", "channel_slug": "reactions", "create_datetime": "2013-05-07T19:14:22+00:00", "id": 1829, "name_encoded": "wow"}, {"is_featured": false, "name": "yes", "channel_slug": "reactions", "create_datetime": "2013-05-05T23:28:17+00:00", "id": 2561, "name_encoded": "yes"}, {"is_featured": false, "name": "no", "channel_slug": "reactions", "create_datetime": "2013-05-05T18:25:10+00:00", "id": 4754, "name_encoded": "no"}, {"is_featured": false, "name": "crying", "channel_slug": "reactions", "create_datetime": "2013-05-07T19:12:59+00:00", "id": 1181, "name_encoded": "crying"}],
+                groupId: 'gif-detail'
+            },
+            showSearch: true,
+            showBrowse: true,
+            searchTerm: '',
+            user: null,
+        });
+    </script>
+
+      <script>
+          var dots = document.getElementById("dots-loader");
+          if (dots) {
+              dots.parentNode.removeChild(dots);
+          }
+      </script>
+  </body>
+</html>

--- a/go/chat/unfurl/unfurler.go
+++ b/go/chat/unfurl/unfurler.go
@@ -338,7 +338,7 @@ func (u *Unfurler) unfurl(ctx context.Context, outboxID chat1.OutboxID) {
 		if err := u.setStatus(ctx, outboxID, types.UnfurlerTaskStatusUnfurling); err != nil {
 			u.Debug(ctx, "unfurl: failed to set status: %s", err)
 		}
-		unfurlRaw, err := u.scraper.Scrape(ctx, task.URL)
+		unfurlRaw, err := u.scraper.Scrape(ctx, task.URL, nil)
 		if err != nil {
 			u.Debug(ctx, "unfurl: failed to scrape: %s(%T)", err, err)
 			return unfurl, err

--- a/go/chat/unfurl/utils.go
+++ b/go/chat/unfurl/utils.go
@@ -53,7 +53,7 @@ func IsDomain(domain, target string) bool {
 }
 
 func ClassifyDomain(domain string) chat1.UnfurlType {
-	if IsDomain(domain, "giphy") {
+	if IsDomain(domain, "giphy") || domain == "gph.is" {
 		return chat1.UnfurlType_GIPHY
 	}
 	return chat1.UnfurlType_GENERIC

--- a/go/chat/unfurl/utils.go
+++ b/go/chat/unfurl/utils.go
@@ -53,8 +53,8 @@ func IsDomain(domain, target string) bool {
 }
 
 func ClassifyDomain(domain string) chat1.UnfurlType {
-	if IsDomain(domain, "youtube") {
-		return chat1.UnfurlType_YOUTUBE
+	if IsDomain(domain, "giphy") {
+		return chat1.UnfurlType_GIPHY
 	}
 	return chat1.UnfurlType_GENERIC
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1888,13 +1888,15 @@ func (u UnfurlRaw) String() string {
 	return "<unknown>"
 }
 
-func (g UnfurlGenericRaw) String() string {
-	yield := func(s *string) string {
-		if s == nil {
-			return ""
-		}
-		return *s
+func yieldStr(s *string) string {
+	if s == nil {
+		return ""
 	}
+	return *s
+}
+
+func (g UnfurlGenericRaw) String() string {
+
 	publishTime := ""
 	if g.PublishTime != nil {
 		publishTime = fmt.Sprintf("%v", time.Unix(int64(*g.PublishTime), 0))
@@ -1905,14 +1907,15 @@ SiteName: %s
 PublishTime: %s
 Description: %s
 ImageUrl: %s
-FaviconUrl: %s`, g.Title, g.Url, g.SiteName, publishTime, yield(g.Description),
-		yield(g.ImageUrl), yield(g.FaviconUrl))
+FaviconUrl: %s`, g.Title, g.Url, g.SiteName, publishTime, yieldStr(g.Description),
+		yieldStr(g.ImageUrl), yieldStr(g.FaviconUrl))
 }
 
 func (g UnfurlGiphyRaw) String() string {
+
 	return fmt.Sprintf(`GIPHY SPECIAL
 FaviconUrl: %s
-ImageUrl: %s`, g.FaviconURL, g.ImageURL)
+ImageUrl: %s`, yieldStr(g.FaviconUrl), g.ImageUrl)
 }
 
 func NewUnfurlSettings() UnfurlSettings {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1882,6 +1882,8 @@ func (u UnfurlRaw) String() string {
 	switch typ {
 	case UnfurlType_GENERIC:
 		return u.Generic().String()
+	case UnfurlType_GIPHY:
+		return u.Giphy().String()
 	}
 	return "<unknown>"
 }
@@ -1905,6 +1907,12 @@ Description: %s
 ImageUrl: %s
 FaviconUrl: %s`, g.Title, g.Url, g.SiteName, publishTime, yield(g.Description),
 		yield(g.ImageUrl), yield(g.FaviconUrl))
+}
+
+func (g UnfurlGiphyRaw) String() string {
+	return fmt.Sprintf(`GIPHY SPECIAL
+FaviconUrl: %s
+ImageUrl: %s`, g.FaviconURL, g.ImageURL)
 }
 
 func NewUnfurlSettings() UnfurlSettings {

--- a/go/protocol/chat1/unfurl.go
+++ b/go/protocol/chat1/unfurl.go
@@ -91,14 +91,20 @@ func (o UnfurlYoutubeRaw) DeepCopy() UnfurlYoutubeRaw {
 }
 
 type UnfurlGiphyRaw struct {
-	FaviconURL string `codec:"faviconURL" json:"faviconURL"`
-	ImageURL   string `codec:"imageURL" json:"imageURL"`
+	FaviconUrl *string `codec:"faviconUrl,omitempty" json:"faviconUrl,omitempty"`
+	ImageUrl   string  `codec:"imageUrl" json:"imageUrl"`
 }
 
 func (o UnfurlGiphyRaw) DeepCopy() UnfurlGiphyRaw {
 	return UnfurlGiphyRaw{
-		FaviconURL: o.FaviconURL,
-		ImageURL:   o.ImageURL,
+		FaviconUrl: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.FaviconUrl),
+		ImageUrl: o.ImageUrl,
 	}
 }
 
@@ -262,14 +268,20 @@ func (o UnfurlYoutube) DeepCopy() UnfurlYoutube {
 }
 
 type UnfurlGiphy struct {
-	Favicon Asset `codec:"favicon" json:"favicon"`
-	Image   Asset `codec:"image" json:"image"`
+	Favicon *Asset `codec:"favicon,omitempty" json:"favicon,omitempty"`
+	Image   Asset  `codec:"image" json:"image"`
 }
 
 func (o UnfurlGiphy) DeepCopy() UnfurlGiphy {
 	return UnfurlGiphy{
-		Favicon: o.Favicon.DeepCopy(),
-		Image:   o.Image.DeepCopy(),
+		Favicon: (func(x *Asset) *Asset {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Favicon),
+		Image: o.Image.DeepCopy(),
 	}
 }
 
@@ -459,14 +471,20 @@ func (o UnfurlYoutubeDisplay) DeepCopy() UnfurlYoutubeDisplay {
 }
 
 type UnfurlGiphyDisplay struct {
-	Favicon UnfurlImageDisplay `codec:"favicon" json:"favicon"`
-	Image   UnfurlImageDisplay `codec:"image" json:"image"`
+	Favicon *UnfurlImageDisplay `codec:"favicon,omitempty" json:"favicon,omitempty"`
+	Image   UnfurlImageDisplay  `codec:"image" json:"image"`
 }
 
 func (o UnfurlGiphyDisplay) DeepCopy() UnfurlGiphyDisplay {
 	return UnfurlGiphyDisplay{
-		Favicon: o.Favicon.DeepCopy(),
-		Image:   o.Image.DeepCopy(),
+		Favicon: (func(x *UnfurlImageDisplay) *UnfurlImageDisplay {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Favicon),
+		Image: o.Image.DeepCopy(),
 	}
 }
 

--- a/go/protocol/chat1/unfurl.go
+++ b/go/protocol/chat1/unfurl.go
@@ -13,6 +13,7 @@ type UnfurlType int
 const (
 	UnfurlType_GENERIC UnfurlType = 0
 	UnfurlType_YOUTUBE UnfurlType = 1
+	UnfurlType_GIPHY   UnfurlType = 2
 )
 
 func (o UnfurlType) DeepCopy() UnfurlType { return o }
@@ -20,11 +21,13 @@ func (o UnfurlType) DeepCopy() UnfurlType { return o }
 var UnfurlTypeMap = map[string]UnfurlType{
 	"GENERIC": 0,
 	"YOUTUBE": 1,
+	"GIPHY":   2,
 }
 
 var UnfurlTypeRevMap = map[UnfurlType]string{
 	0: "GENERIC",
 	1: "YOUTUBE",
+	2: "GIPHY",
 }
 
 func (e UnfurlType) String() string {
@@ -87,10 +90,23 @@ func (o UnfurlYoutubeRaw) DeepCopy() UnfurlYoutubeRaw {
 	return UnfurlYoutubeRaw{}
 }
 
+type UnfurlGiphyRaw struct {
+	FaviconURL string `codec:"faviconURL" json:"faviconURL"`
+	ImageURL   string `codec:"imageURL" json:"imageURL"`
+}
+
+func (o UnfurlGiphyRaw) DeepCopy() UnfurlGiphyRaw {
+	return UnfurlGiphyRaw{
+		FaviconURL: o.FaviconURL,
+		ImageURL:   o.ImageURL,
+	}
+}
+
 type UnfurlRaw struct {
 	UnfurlType__ UnfurlType        `codec:"unfurlType" json:"unfurlType"`
 	Generic__    *UnfurlGenericRaw `codec:"generic,omitempty" json:"generic,omitempty"`
 	Youtube__    *UnfurlYoutubeRaw `codec:"youtube,omitempty" json:"youtube,omitempty"`
+	Giphy__      *UnfurlGiphyRaw   `codec:"giphy,omitempty" json:"giphy,omitempty"`
 }
 
 func (o *UnfurlRaw) UnfurlType() (ret UnfurlType, err error) {
@@ -103,6 +119,11 @@ func (o *UnfurlRaw) UnfurlType() (ret UnfurlType, err error) {
 	case UnfurlType_YOUTUBE:
 		if o.Youtube__ == nil {
 			err = errors.New("unexpected nil value for Youtube__")
+			return ret, err
+		}
+	case UnfurlType_GIPHY:
+		if o.Giphy__ == nil {
+			err = errors.New("unexpected nil value for Giphy__")
 			return ret, err
 		}
 	}
@@ -129,6 +150,16 @@ func (o UnfurlRaw) Youtube() (res UnfurlYoutubeRaw) {
 	return *o.Youtube__
 }
 
+func (o UnfurlRaw) Giphy() (res UnfurlGiphyRaw) {
+	if o.UnfurlType__ != UnfurlType_GIPHY {
+		panic("wrong case accessed")
+	}
+	if o.Giphy__ == nil {
+		return
+	}
+	return *o.Giphy__
+}
+
 func NewUnfurlRawWithGeneric(v UnfurlGenericRaw) UnfurlRaw {
 	return UnfurlRaw{
 		UnfurlType__: UnfurlType_GENERIC,
@@ -140,6 +171,13 @@ func NewUnfurlRawWithYoutube(v UnfurlYoutubeRaw) UnfurlRaw {
 	return UnfurlRaw{
 		UnfurlType__: UnfurlType_YOUTUBE,
 		Youtube__:    &v,
+	}
+}
+
+func NewUnfurlRawWithGiphy(v UnfurlGiphyRaw) UnfurlRaw {
+	return UnfurlRaw{
+		UnfurlType__: UnfurlType_GIPHY,
+		Giphy__:      &v,
 	}
 }
 
@@ -160,6 +198,13 @@ func (o UnfurlRaw) DeepCopy() UnfurlRaw {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Youtube__),
+		Giphy__: (func(x *UnfurlGiphyRaw) *UnfurlGiphyRaw {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Giphy__),
 	}
 }
 
@@ -216,10 +261,23 @@ func (o UnfurlYoutube) DeepCopy() UnfurlYoutube {
 	return UnfurlYoutube{}
 }
 
+type UnfurlGiphy struct {
+	Favicon Asset `codec:"favicon" json:"favicon"`
+	Image   Asset `codec:"image" json:"image"`
+}
+
+func (o UnfurlGiphy) DeepCopy() UnfurlGiphy {
+	return UnfurlGiphy{
+		Favicon: o.Favicon.DeepCopy(),
+		Image:   o.Image.DeepCopy(),
+	}
+}
+
 type Unfurl struct {
 	UnfurlType__ UnfurlType     `codec:"unfurlType" json:"unfurlType"`
 	Generic__    *UnfurlGeneric `codec:"generic,omitempty" json:"generic,omitempty"`
 	Youtube__    *UnfurlYoutube `codec:"youtube,omitempty" json:"youtube,omitempty"`
+	Giphy__      *UnfurlGiphy   `codec:"giphy,omitempty" json:"giphy,omitempty"`
 }
 
 func (o *Unfurl) UnfurlType() (ret UnfurlType, err error) {
@@ -232,6 +290,11 @@ func (o *Unfurl) UnfurlType() (ret UnfurlType, err error) {
 	case UnfurlType_YOUTUBE:
 		if o.Youtube__ == nil {
 			err = errors.New("unexpected nil value for Youtube__")
+			return ret, err
+		}
+	case UnfurlType_GIPHY:
+		if o.Giphy__ == nil {
+			err = errors.New("unexpected nil value for Giphy__")
 			return ret, err
 		}
 	}
@@ -258,6 +321,16 @@ func (o Unfurl) Youtube() (res UnfurlYoutube) {
 	return *o.Youtube__
 }
 
+func (o Unfurl) Giphy() (res UnfurlGiphy) {
+	if o.UnfurlType__ != UnfurlType_GIPHY {
+		panic("wrong case accessed")
+	}
+	if o.Giphy__ == nil {
+		return
+	}
+	return *o.Giphy__
+}
+
 func NewUnfurlWithGeneric(v UnfurlGeneric) Unfurl {
 	return Unfurl{
 		UnfurlType__: UnfurlType_GENERIC,
@@ -269,6 +342,13 @@ func NewUnfurlWithYoutube(v UnfurlYoutube) Unfurl {
 	return Unfurl{
 		UnfurlType__: UnfurlType_YOUTUBE,
 		Youtube__:    &v,
+	}
+}
+
+func NewUnfurlWithGiphy(v UnfurlGiphy) Unfurl {
+	return Unfurl{
+		UnfurlType__: UnfurlType_GIPHY,
+		Giphy__:      &v,
 	}
 }
 
@@ -289,6 +369,13 @@ func (o Unfurl) DeepCopy() Unfurl {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Youtube__),
+		Giphy__: (func(x *UnfurlGiphy) *UnfurlGiphy {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Giphy__),
 	}
 }
 
@@ -371,10 +458,23 @@ func (o UnfurlYoutubeDisplay) DeepCopy() UnfurlYoutubeDisplay {
 	return UnfurlYoutubeDisplay{}
 }
 
+type UnfurlGiphyDisplay struct {
+	Favicon UnfurlImageDisplay `codec:"favicon" json:"favicon"`
+	Image   UnfurlImageDisplay `codec:"image" json:"image"`
+}
+
+func (o UnfurlGiphyDisplay) DeepCopy() UnfurlGiphyDisplay {
+	return UnfurlGiphyDisplay{
+		Favicon: o.Favicon.DeepCopy(),
+		Image:   o.Image.DeepCopy(),
+	}
+}
+
 type UnfurlDisplay struct {
 	UnfurlType__ UnfurlType            `codec:"unfurlType" json:"unfurlType"`
 	Generic__    *UnfurlGenericDisplay `codec:"generic,omitempty" json:"generic,omitempty"`
 	Youtube__    *UnfurlYoutubeDisplay `codec:"youtube,omitempty" json:"youtube,omitempty"`
+	Giphy__      *UnfurlGiphyDisplay   `codec:"giphy,omitempty" json:"giphy,omitempty"`
 }
 
 func (o *UnfurlDisplay) UnfurlType() (ret UnfurlType, err error) {
@@ -387,6 +487,11 @@ func (o *UnfurlDisplay) UnfurlType() (ret UnfurlType, err error) {
 	case UnfurlType_YOUTUBE:
 		if o.Youtube__ == nil {
 			err = errors.New("unexpected nil value for Youtube__")
+			return ret, err
+		}
+	case UnfurlType_GIPHY:
+		if o.Giphy__ == nil {
+			err = errors.New("unexpected nil value for Giphy__")
 			return ret, err
 		}
 	}
@@ -413,6 +518,16 @@ func (o UnfurlDisplay) Youtube() (res UnfurlYoutubeDisplay) {
 	return *o.Youtube__
 }
 
+func (o UnfurlDisplay) Giphy() (res UnfurlGiphyDisplay) {
+	if o.UnfurlType__ != UnfurlType_GIPHY {
+		panic("wrong case accessed")
+	}
+	if o.Giphy__ == nil {
+		return
+	}
+	return *o.Giphy__
+}
+
 func NewUnfurlDisplayWithGeneric(v UnfurlGenericDisplay) UnfurlDisplay {
 	return UnfurlDisplay{
 		UnfurlType__: UnfurlType_GENERIC,
@@ -424,6 +539,13 @@ func NewUnfurlDisplayWithYoutube(v UnfurlYoutubeDisplay) UnfurlDisplay {
 	return UnfurlDisplay{
 		UnfurlType__: UnfurlType_YOUTUBE,
 		Youtube__:    &v,
+	}
+}
+
+func NewUnfurlDisplayWithGiphy(v UnfurlGiphyDisplay) UnfurlDisplay {
+	return UnfurlDisplay{
+		UnfurlType__: UnfurlType_GIPHY,
+		Giphy__:      &v,
 	}
 }
 
@@ -444,6 +566,13 @@ func (o UnfurlDisplay) DeepCopy() UnfurlDisplay {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Youtube__),
+		Giphy__: (func(x *UnfurlGiphyDisplay) *UnfurlGiphyDisplay {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Giphy__),
 	}
 }
 

--- a/protocol/avdl/chat1/unfurl.avdl
+++ b/protocol/avdl/chat1/unfurl.avdl
@@ -5,7 +5,8 @@ protocol unfurl {
 
     enum UnfurlType {
       GENERIC_0,
-      YOUTUBE_1
+      YOUTUBE_1,
+      GIPHY_2
     }
 
 
@@ -23,9 +24,15 @@ protocol unfurl {
         // TODO
     }
 
+    record UnfurlGiphyRaw {
+      string faviconURL;
+      string imageURL;
+    }
+
     variant UnfurlRaw switch (UnfurlType unfurlType) {
       case GENERIC: UnfurlGenericRaw;
       case YOUTUBE: UnfurlYoutubeRaw;
+      case GIPHY: UnfurlGiphyRaw;
     }
 
     record UnfurlGeneric {
@@ -42,39 +49,51 @@ protocol unfurl {
         // TODO
     }
 
+    record UnfurlGiphy {
+      Asset favicon;
+      Asset image;
+    }
+
     variant Unfurl switch (UnfurlType unfurlType) {
       case GENERIC: UnfurlGeneric;
       case YOUTUBE: UnfurlYoutube;
+      case GIPHY: UnfurlGiphy;
     }
 
     record UnfurlResult {
-        Unfurl unfurl;
-        string url;
+      Unfurl unfurl;
+      string url;
     }
 
     record UnfurlImageDisplay {
-        string url;
-        int height;
-        int width;
+      string url;
+      int height;
+      int width;
     }
 
     record UnfurlGenericDisplay {
-        string title;
-        string url;
-        string siteName;
-        union { null, UnfurlImageDisplay } favicon;
-        union { null, UnfurlImageDisplay } image;
-        union { null, int } publishTime;
-        union { null, string } description;
+      string title;
+      string url;
+      string siteName;
+      union { null, UnfurlImageDisplay } favicon;
+      union { null, UnfurlImageDisplay } image;
+      union { null, int } publishTime;
+      union { null, string } description;
     }
 
     record UnfurlYoutubeDisplay {
         // TODO
     }
 
+    record UnfurlGiphyDisplay {
+      UnfurlImageDisplay favicon;
+      UnfurlImageDisplay image;
+    }
+
     variant UnfurlDisplay switch (UnfurlType unfurlType) {
-        case GENERIC: UnfurlGenericDisplay;
-        case YOUTUBE: UnfurlYoutubeDisplay;
+      case GENERIC: UnfurlGenericDisplay;
+      case YOUTUBE: UnfurlYoutubeDisplay;
+      case GIPHY: UnfurlGiphyDisplay;
     }
 
     enum UnfurlMode {

--- a/protocol/avdl/chat1/unfurl.avdl
+++ b/protocol/avdl/chat1/unfurl.avdl
@@ -25,8 +25,8 @@ protocol unfurl {
     }
 
     record UnfurlGiphyRaw {
-      string faviconURL;
-      string imageURL;
+      union { null, string } faviconUrl;
+      string imageUrl;
     }
 
     variant UnfurlRaw switch (UnfurlType unfurlType) {
@@ -50,7 +50,7 @@ protocol unfurl {
     }
 
     record UnfurlGiphy {
-      Asset favicon;
+      union { null, Asset } favicon;
       Asset image;
     }
 
@@ -86,7 +86,7 @@ protocol unfurl {
     }
 
     record UnfurlGiphyDisplay {
-      UnfurlImageDisplay favicon;
+      union { null, UnfurlImageDisplay } favicon;
       UnfurlImageDisplay image;
     }
 

--- a/protocol/json/chat1/unfurl.json
+++ b/protocol/json/chat1/unfurl.json
@@ -72,12 +72,15 @@
       "name": "UnfurlGiphyRaw",
       "fields": [
         {
-          "type": "string",
-          "name": "faviconURL"
+          "type": [
+            null,
+            "string"
+          ],
+          "name": "faviconUrl"
         },
         {
           "type": "string",
-          "name": "imageURL"
+          "name": "imageUrl"
         }
       ]
     },
@@ -168,7 +171,10 @@
       "name": "UnfurlGiphy",
       "fields": [
         {
-          "type": "Asset",
+          "type": [
+            null,
+            "Asset"
+          ],
           "name": "favicon"
         },
         {
@@ -296,7 +302,10 @@
       "name": "UnfurlGiphyDisplay",
       "fields": [
         {
-          "type": "UnfurlImageDisplay",
+          "type": [
+            null,
+            "UnfurlImageDisplay"
+          ],
           "name": "favicon"
         },
         {

--- a/protocol/json/chat1/unfurl.json
+++ b/protocol/json/chat1/unfurl.json
@@ -12,7 +12,8 @@
       "name": "UnfurlType",
       "symbols": [
         "GENERIC_0",
-        "YOUTUBE_1"
+        "YOUTUBE_1",
+        "GIPHY_2"
       ]
     },
     {
@@ -67,6 +68,20 @@
       "fields": []
     },
     {
+      "type": "record",
+      "name": "UnfurlGiphyRaw",
+      "fields": [
+        {
+          "type": "string",
+          "name": "faviconURL"
+        },
+        {
+          "type": "string",
+          "name": "imageURL"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "UnfurlRaw",
       "switch": {
@@ -87,6 +102,13 @@
             "def": false
           },
           "body": "UnfurlYoutubeRaw"
+        },
+        {
+          "label": {
+            "name": "GIPHY",
+            "def": false
+          },
+          "body": "UnfurlGiphyRaw"
         }
       ]
     },
@@ -142,6 +164,20 @@
       "fields": []
     },
     {
+      "type": "record",
+      "name": "UnfurlGiphy",
+      "fields": [
+        {
+          "type": "Asset",
+          "name": "favicon"
+        },
+        {
+          "type": "Asset",
+          "name": "image"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "Unfurl",
       "switch": {
@@ -162,6 +198,13 @@
             "def": false
           },
           "body": "UnfurlYoutube"
+        },
+        {
+          "label": {
+            "name": "GIPHY",
+            "def": false
+          },
+          "body": "UnfurlGiphy"
         }
       ]
     },
@@ -249,6 +292,20 @@
       "fields": []
     },
     {
+      "type": "record",
+      "name": "UnfurlGiphyDisplay",
+      "fields": [
+        {
+          "type": "UnfurlImageDisplay",
+          "name": "favicon"
+        },
+        {
+          "type": "UnfurlImageDisplay",
+          "name": "image"
+        }
+      ]
+    },
+    {
       "type": "variant",
       "name": "UnfurlDisplay",
       "switch": {
@@ -269,6 +326,13 @@
             "def": false
           },
           "body": "UnfurlYoutubeDisplay"
+        },
+        {
+          "label": {
+            "name": "GIPHY",
+            "def": false
+          },
+          "body": "UnfurlGiphyDisplay"
         }
       ]
     },

--- a/shared/chat/conversation/messages/unfurl/generic/container.js
+++ b/shared/chat/conversation/messages/unfurl/generic/container.js
@@ -17,6 +17,8 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
     description: unfurl.description || undefined,
     publishTime: unfurl.publishTime ? unfurl.publishTime * 1000 : undefined,
     imageURL: unfurl.image ? unfurl.image.url : undefined,
+    imageHeight: unfurl.image ? unfurl.image.height : undefined,
+    imageWidth: unfurl.image ? unfurl.image.width : undefined,
     faviconURL: unfurl.favicon ? unfurl.favicon.url : undefined,
     showImageOnSide: unfurl.image ? unfurl.image.height >= unfurl.image.width : false,
     onClose,

--- a/shared/chat/conversation/messages/unfurl/generic/index.js
+++ b/shared/chat/conversation/messages/unfurl/generic/index.js
@@ -126,6 +126,7 @@ const styles = Styles.styleSheetCreate({
     common: {
       width: 16,
       height: 16,
+      borderRadius: Styles.borderRadius,
     },
   }),
 })

--- a/shared/chat/conversation/messages/unfurl/generic/index.js
+++ b/shared/chat/conversation/messages/unfurl/generic/index.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as Kb from '../../../../../common-adapters/index'
 import * as Styles from '../../../../../styles'
 import {formatTimeForMessages} from '../../../../../util/timestamp'
+import UnfurlImage from '../image'
 
 export type Props = {
   title: string,
@@ -11,6 +12,8 @@ export type Props = {
   description?: string,
   publishTime?: number,
   imageURL?: string,
+  imageHeight?: number,
+  imageWidth?: number,
   faviconURL?: string,
   onClose?: () => void,
   showImageOnSide: boolean,
@@ -49,9 +52,18 @@ class UnfurlGeneric extends React.Component<Props> {
             {this.props.title}
           </Kb.Text>
           {!!this.props.description && <Kb.Text type="Body">{this.props.description}</Kb.Text>}
-          {!!this.props.imageURL && !Styles.isMobile && !this.props.showImageOnSide && (
-            <Kb.Image src={this.props.imageURL} style={styles.bottomImage} />
-          )}
+          {!!this.props.imageURL &&
+            !!this.props.imageHeight &&
+            !!this.props.imageWidth &&
+            !Styles.isMobile &&
+            !this.props.showImageOnSide && (
+              <UnfurlImage
+                url={this.props.imageURL}
+                height={this.props.imageHeight}
+                width={this.props.imageWidth}
+                style={styles.bottomImage}
+              />
+            )}
         </Kb.Box2>
         {!!this.props.imageURL && !Styles.isMobile && this.props.showImageOnSide && (
           <Kb.Image src={this.props.imageURL} style={styles.sideImage} />
@@ -104,15 +116,9 @@ const styles = Styles.styleSheetCreate({
       alignSelf: 'flex-start',
     },
   }),
-  bottomImage: Styles.platformStyles({
-    common: {
-      marginTop: Styles.globalMargins.tiny,
-    },
-    isElectron: {
-      maxWidth: 320,
-      maxHeight: 180,
-    },
-  }),
+  bottomImage: {
+    marginTop: Styles.globalMargins.xtiny,
+  },
   sideImage: Styles.platformStyles({
     isElectron: {
       maxWidth: 80,

--- a/shared/chat/conversation/messages/unfurl/generic/index.stories.js
+++ b/shared/chat/conversation/messages/unfurl/generic/index.stories.js
@@ -15,6 +15,8 @@ const full = {
   onClose: Sb.action('onClose'),
   faviconURL: require('../../../../../images/mock/wsj.jpg'),
   imageURL: require('../../../../../images/mock/wsj_image.jpg'),
+  imageWidth: 900,
+  imageHeight: 471,
   showImageOnSide: false,
 }
 

--- a/shared/chat/conversation/messages/unfurl/giphy/container.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/container.js
@@ -1,0 +1,31 @@
+// @flow
+import * as RPCChatTypes from '../../../../../constants/types/rpc-chat-gen'
+import {namedConnect} from '../../../../../util/container'
+import UnfurlGiphy from '.'
+
+type OwnProps = {|
+  unfurl: RPCChatTypes.UnfurlGiphyDisplay,
+  onClose?: () => void,
+|}
+
+const mapStateToProps = (state, ownProps: OwnProps) => {
+  const {unfurl, onClose} = ownProps
+  return {
+    imageURL: unfurl.image.url,
+    faviconURL: unfurl.favicon ? unfurl.favicon.url : undefined,
+    onClose,
+  }
+}
+
+const mapDispatchToProps = (dispatch, ownProps: OwnProps) => ({})
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...stateProps,
+})
+
+export default namedConnect<OwnProps, _, _, _, _>(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+  'UnfurlGiphy'
+)(UnfurlGiphy)

--- a/shared/chat/conversation/messages/unfurl/giphy/container.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/container.js
@@ -1,8 +1,6 @@
 // @flow
 import * as RPCChatTypes from '../../../../../constants/types/rpc-chat-gen'
 import {namedConnect} from '../../../../../util/container'
-import {clamp} from 'lodash-es'
-import {imgMaxWidth} from '../../../../../chat/conversation/messages/attachment/image/image-render'
 import UnfurlGiphy from '.'
 
 type OwnProps = {|
@@ -10,26 +8,11 @@ type OwnProps = {|
   onClose?: () => void,
 |}
 
-const clampImageSize = ({width = 0, height = 0}, maxWidth, maxHeight) =>
-  height > width
-    ? {
-        height: clamp(height || 0, 0, maxSize),
-        width: (clamp(height || 0, 0, maxSize) * width) / (height || 1),
-      }
-    : {
-        height: (clamp(width || 0, 0, maxSize) * height) / (width || 1),
-        width: clamp(width || 0, 0, maxSize),
-      }
-
 const mapStateToProps = (state, ownProps: OwnProps) => {
   const {unfurl, onClose} = ownProps
-  const {height, width} = clampImageSize({
-    width: unfurl.image.width,
-    height: unfurl.image.height,
-  })
   return {
-    imageHeight: height,
-    imageWidth: Math.min(imgMaxWidth(), width),
+    imageHeight: unfurl.image.height,
+    imageWidth: unfurl.image.width,
     imageURL: unfurl.image.url,
     faviconURL: unfurl.favicon ? unfurl.favicon.url : undefined,
     onClose,

--- a/shared/chat/conversation/messages/unfurl/giphy/container.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/container.js
@@ -1,6 +1,8 @@
 // @flow
 import * as RPCChatTypes from '../../../../../constants/types/rpc-chat-gen'
 import {namedConnect} from '../../../../../util/container'
+import {clamp} from 'lodash-es'
+import {imgMaxWidth} from '../../../../../chat/conversation/messages/attachment/image/image-render'
 import UnfurlGiphy from '.'
 
 type OwnProps = {|
@@ -8,9 +10,26 @@ type OwnProps = {|
   onClose?: () => void,
 |}
 
+const clampImageSize = ({width = 0, height = 0}, maxWidth, maxHeight) =>
+  height > width
+    ? {
+        height: clamp(height || 0, 0, maxSize),
+        width: (clamp(height || 0, 0, maxSize) * width) / (height || 1),
+      }
+    : {
+        height: (clamp(width || 0, 0, maxSize) * height) / (width || 1),
+        width: clamp(width || 0, 0, maxSize),
+      }
+
 const mapStateToProps = (state, ownProps: OwnProps) => {
   const {unfurl, onClose} = ownProps
+  const {height, width} = clampImageSize({
+    width: unfurl.image.width,
+    height: unfurl.image.height,
+  })
   return {
+    imageHeight: height,
+    imageWidth: Math.min(imgMaxWidth(), width),
     imageURL: unfurl.image.url,
     faviconURL: unfurl.favicon ? unfurl.favicon.url : undefined,
     onClose,

--- a/shared/chat/conversation/messages/unfurl/giphy/index.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/index.js
@@ -1,0 +1,83 @@
+// @flow
+import * as React from 'react'
+import * as Kb from '../../../../../common-adapters/index'
+import * as Styles from '../../../../../styles'
+
+export type Props = {
+  imageURL: string,
+  faviconURL?: string,
+  onClose?: () => void,
+}
+
+class UnfurlGiphy extends React.Component<Props> {
+  render() {
+    return (
+      <Kb.Box2 style={styles.container} gap="tiny" direction="horizontal">
+        {!Styles.isMobile && <Kb.Box2 direction="horizontal" style={styles.quoteContainer} />}
+        <Kb.Box2 style={styles.innerContainer} gap="xtiny" direction="vertical">
+          <Kb.Box2 style={styles.siteNameContainer} gap="tiny" fullWidth={true} direction="horizontal">
+            <Kb.Box2 direction="horizontal" gap="tiny">
+              {!!this.props.faviconURL && <Kb.Image src={this.props.faviconURL} style={styles.favicon} />}
+              <Kb.Text type="BodySmall">Giphy</Kb.Text>
+            </Kb.Box2>
+            {!!this.props.onClose && (
+              <Kb.Icon
+                type="iconfont-close"
+                onClick={this.props.onClose}
+                className="unfurl-closebox"
+                fontSize={12}
+              />
+            )}
+          </Kb.Box2>
+          <Kb.Image src={this.props.imageURL} style={styles.image} />
+        </Kb.Box2>
+      </Kb.Box2>
+    )
+  }
+}
+
+const styles = Styles.styleSheetCreate({
+  container: Styles.platformStyles({
+    common: {
+      alignSelf: 'flex-start',
+    },
+    isElectron: {
+      maxWidth: 500,
+    },
+    isMobile: {
+      paddingRight: 66,
+    },
+  }),
+  favicon: {
+    width: 16,
+    height: 16,
+    borderRadius: Styles.borderRadius,
+  },
+  siteNameContainer: {
+    alignSelf: 'flex-start',
+    justifyContent: 'space-between',
+  },
+  image: {
+    maxWidth: 320,
+    maxHeight: 250,
+  },
+  quoteContainer: {
+    backgroundColor: Styles.globalColors.lightGrey,
+    paddingLeft: Styles.globalMargins.xtiny,
+    alignSelf: 'stretch',
+  },
+  innerContainer: Styles.platformStyles({
+    common: {
+      alignSelf: 'flex-start',
+      minWidth: 150,
+    },
+    isMobile: {
+      borderWidth: 1,
+      borderRadius: Styles.borderRadius,
+      borderColor: Styles.globalColors.lightGrey,
+      padding: Styles.globalMargins.tiny,
+    },
+  }),
+})
+
+export default UnfurlGiphy

--- a/shared/chat/conversation/messages/unfurl/giphy/index.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/index.js
@@ -4,6 +4,8 @@ import * as Kb from '../../../../../common-adapters/index'
 import * as Styles from '../../../../../styles'
 
 export type Props = {
+  imageHeight: number,
+  imageWidth: number,
   imageURL: string,
   faviconURL?: string,
   onClose?: () => void,
@@ -29,7 +31,16 @@ class UnfurlGiphy extends React.Component<Props> {
               />
             )}
           </Kb.Box2>
-          <Kb.Image src={this.props.imageURL} style={styles.image} />
+          <Kb.Image
+            src={this.props.imageURL}
+            style={Styles.collapseStyles([
+              {
+                width: this.props.imageWidth,
+                height: this.props.imageHeight,
+              },
+              styles.image,
+            ])}
+          />
         </Kb.Box2>
       </Kb.Box2>
     )
@@ -53,18 +64,22 @@ const styles = Styles.styleSheetCreate({
     height: 16,
     borderRadius: Styles.borderRadius,
   },
-  siteNameContainer: {
-    alignSelf: 'flex-start',
-    justifyContent: 'space-between',
-  },
-  image: {
-    maxWidth: 320,
-    maxHeight: 250,
-  },
+  siteNameContainer: Styles.platformStyles({
+    common: {
+      alignSelf: 'flex-start',
+      justifyContent: 'space-between',
+    },
+    isMobile: {
+      padding: Styles.globalMargins.tiny,
+    },
+  }),
   quoteContainer: {
     backgroundColor: Styles.globalColors.lightGrey,
     paddingLeft: Styles.globalMargins.xtiny,
     alignSelf: 'stretch',
+  },
+  image: {
+    borderRadius: Styles.borderRadius,
   },
   innerContainer: Styles.platformStyles({
     common: {
@@ -75,7 +90,6 @@ const styles = Styles.styleSheetCreate({
       borderWidth: 1,
       borderRadius: Styles.borderRadius,
       borderColor: Styles.globalColors.lightGrey,
-      padding: Styles.globalMargins.tiny,
     },
   }),
 })

--- a/shared/chat/conversation/messages/unfurl/giphy/index.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import * as Kb from '../../../../../common-adapters/index'
 import * as Styles from '../../../../../styles'
+import UnfurlImage from '../image'
 
 export type Props = {
   imageHeight: number,
@@ -31,16 +32,13 @@ class UnfurlGiphy extends React.Component<Props> {
               />
             )}
           </Kb.Box2>
-          <Kb.Image
-            src={this.props.imageURL}
-            style={Styles.collapseStyles([
-              {
-                width: this.props.imageWidth,
-                height: this.props.imageHeight,
-              },
-              styles.image,
-            ])}
-          />
+          <Kb.Box2 direction="horizontal" style={styles.imageContainer}>
+            <UnfurlImage
+              url={this.props.imageURL}
+              height={this.props.imageHeight}
+              width={this.props.imageWidth}
+            />
+          </Kb.Box2>
         </Kb.Box2>
       </Kb.Box2>
     )
@@ -70,7 +68,9 @@ const styles = Styles.styleSheetCreate({
       justifyContent: 'space-between',
     },
     isMobile: {
-      padding: Styles.globalMargins.tiny,
+      paddingLeft: Styles.globalMargins.tiny,
+      paddingTop: Styles.globalMargins.tiny,
+      paddingBottom: Styles.globalMargins.xxtiny,
     },
   }),
   quoteContainer: {
@@ -78,9 +78,11 @@ const styles = Styles.styleSheetCreate({
     paddingLeft: Styles.globalMargins.xtiny,
     alignSelf: 'stretch',
   },
-  image: {
-    borderRadius: Styles.borderRadius,
-  },
+  imageContainer: Styles.platformStyles({
+    isMobile: {
+      padding: Styles.globalMargins.xtiny,
+    },
+  }),
   innerContainer: Styles.platformStyles({
     common: {
       alignSelf: 'flex-start',

--- a/shared/chat/conversation/messages/unfurl/giphy/index.stories.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/index.stories.js
@@ -8,6 +8,8 @@ import UnfurlGiphy from '.'
 const full = {
   faviconURL: require('../../../../../images/mock/wsj.jpg'),
   imageURL: require('../../../../../images/mock/wsj_image.jpg'),
+  imageHeight: 640,
+  imageWidth: 640,
   onClose: Sb.action('onClose'),
 }
 

--- a/shared/chat/conversation/messages/unfurl/giphy/index.stories.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/index.stories.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react'
+import {Box} from '../../../../../common-adapters/index'
+import * as Sb from '../../../../../stories/storybook'
+
+import UnfurlGiphy from '.'
+
+const full = {
+  faviconURL: require('../../../../../images/mock/wsj.jpg'),
+  imageURL: require('../../../../../images/mock/wsj_image.jpg'),
+  onClose: Sb.action('onClose'),
+}
+
+const noClose = {
+  ...full,
+  onClose: undefined,
+}
+
+const load = () => {
+  Sb.storiesOf('Chat/Unfurl/Giphy', module)
+    .addDecorator(story => <Box style={{maxWidth: 1000, padding: 5}}>{story()}</Box>)
+    .add('Full', () => <UnfurlGiphy {...full} />)
+    .add('Full (no close)', () => <UnfurlGiphy {...noClose} />)
+}
+
+export default load

--- a/shared/chat/conversation/messages/unfurl/giphy/index.stories.js
+++ b/shared/chat/conversation/messages/unfurl/giphy/index.stories.js
@@ -8,8 +8,8 @@ import UnfurlGiphy from '.'
 const full = {
   faviconURL: require('../../../../../images/mock/wsj.jpg'),
   imageURL: require('../../../../../images/mock/wsj_image.jpg'),
-  imageHeight: 640,
-  imageWidth: 640,
+  imageHeight: 471,
+  imageWidth: 900,
   onClose: Sb.action('onClose'),
 }
 

--- a/shared/chat/conversation/messages/unfurl/image/index.js
+++ b/shared/chat/conversation/messages/unfurl/image/index.js
@@ -9,6 +9,7 @@ export type Props = {
   height: number,
   width: number,
   url: string,
+  style?: Object,
 }
 
 const clampImageSize = ({width = 0, height = 0}, maxSize) =>
@@ -35,7 +36,10 @@ class UnfurlImage extends React.Component<Props> {
   }
   render() {
     return (
-      <Kb.Image src={this.props.url} style={Styles.collapseStyles([this._getDimensions(), styles.image])} />
+      <Kb.Image
+        src={this.props.url}
+        style={Styles.collapseStyles([this._getDimensions(), styles.image, this.props.style])}
+      />
     )
   }
 }

--- a/shared/chat/conversation/messages/unfurl/image/index.js
+++ b/shared/chat/conversation/messages/unfurl/image/index.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react'
+import * as Kb from '../../../../../common-adapters/index'
+import * as Styles from '../../../../../styles'
+import {clamp} from 'lodash-es'
+import {imgMaxWidth} from '../../attachment/image/image-render'
+
+export type Props = {
+  height: number,
+  width: number,
+  url: string,
+}
+
+const clampImageSize = ({width = 0, height = 0}, maxSize) =>
+  height > width
+    ? {
+        height: clamp(height || 0, 0, maxSize),
+        width: (clamp(height || 0, 0, maxSize) * width) / (height || 1),
+      }
+    : {
+        height: (clamp(width || 0, 0, maxSize) * height) / (width || 1),
+        width: clamp(width || 0, 0, maxSize),
+      }
+
+class UnfurlImage extends React.Component<Props> {
+  _getDimensions() {
+    const maxSize = Math.min(imgMaxWidth(), 320)
+    return clampImageSize(
+      {
+        height: this.props.height,
+        width: this.props.width,
+      },
+      maxSize
+    )
+  }
+  render() {
+    return (
+      <Kb.Image src={this.props.url} style={Styles.collapseStyles([this._getDimensions(), styles.image])} />
+    )
+  }
+}
+
+const styles = Styles.styleSheetCreate({
+  image: {
+    borderRadius: Styles.borderRadius,
+  },
+})
+
+export default UnfurlImage

--- a/shared/chat/conversation/messages/unfurl/index.stories.js
+++ b/shared/chat/conversation/messages/unfurl/index.stories.js
@@ -2,12 +2,14 @@
 import prompt from './prompt/index.stories'
 import promptList from './prompt-list/index.stories'
 import generic from './generic/index.stories'
+import giphy from './giphy/index.stories'
 import unfurlList from './unfurl-list/index.stories'
 
 const load = () => {
   prompt()
   promptList()
   generic()
+  giphy()
   unfurlList()
 }
 

--- a/shared/chat/conversation/messages/unfurl/unfurl-list/index.js
+++ b/shared/chat/conversation/messages/unfurl/unfurl-list/index.js
@@ -4,6 +4,7 @@ import * as RPCChatTypes from '../../../../../constants/types/rpc-chat-gen'
 import * as Styles from '../../../../../styles'
 import {Box2} from '../../../../../common-adapters/index'
 import UnfurlGeneric from '../generic/container'
+import UnfurlGiphy from '../giphy/container'
 
 export type UnfurlListItem = {
   unfurl: RPCChatTypes.UnfurlDisplay,
@@ -26,6 +27,10 @@ class Unfurl extends React.PureComponent<UnfurlProps> {
       case RPCChatTypes.unfurlUnfurlType.generic:
         return this.props.unfurl.generic ? (
           <UnfurlGeneric unfurl={this.props.unfurl.generic} onClose={this.props.onClose} />
+        ) : null
+      case RPCChatTypes.unfurlUnfurlType.giphy:
+        return this.props.unfurl.giphy ? (
+          <UnfurlGiphy unfurl={this.props.unfurl.giphy} onClose={this.props.onClose} />
         ) : null
       default:
         return null

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -286,6 +286,7 @@ export const unfurlUnfurlMode = {
 export const unfurlUnfurlType = {
   generic: 0,
   youtube: 1,
+  giphy: 2,
 }
 export const localAddTeamMemberAfterResetRpcPromise = (params, waitingKey) => new Promise((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.addTeamMemberAfterReset', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localCancelPostRpcPromise = (params, waitingKey) => new Promise((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.CancelPost', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -629,6 +629,7 @@ export const unfurlUnfurlMode = {
 export const unfurlUnfurlType = {
   generic: 0,
   youtube: 1,
+  giphy: 2,
 }
 export type AppNotificationSettingLocal = $ReadOnly<{deviceType: Keybase1.DeviceType, kind: NotificationKind, enabled: Boolean}>
 export type Asset = $ReadOnly<{filename: String, region: String, endpoint: String, bucket: String, path: String, size: Long, mimeType: String, encHash: Hash, key: Bytes, verifyKey: Bytes, title: String, nonce: Bytes, metadata: AssetMetadata, tag: AssetTag}>
@@ -1086,11 +1087,14 @@ export type UIMessages = $ReadOnly<{messages?: ?Array<UIMessage>, pagination?: ?
 export type UIPagination = $ReadOnly<{next: String, previous: String, num: Int, last: Boolean}>
 export type UIPaymentInfo = $ReadOnly<{accountID?: ?Stellar1.AccountID, amountDescription: String, worth: String, delta: Stellar1.BalanceDelta, note: String, paymentID: Stellar1.PaymentID, status: Stellar1.PaymentStatus, statusDescription: String}>
 export type UIRequestInfo = $ReadOnly<{amount: String, amountDescription: String, asset?: ?Stellar1.Asset, currency?: ?Stellar1.OutsideCurrencyCode, status: Stellar1.RequestStatus}>
-export type Unfurl = {unfurlType: 0, generic: ?UnfurlGeneric} | {unfurlType: 1, youtube: ?UnfurlYoutube}
-export type UnfurlDisplay = {unfurlType: 0, generic: ?UnfurlGenericDisplay} | {unfurlType: 1, youtube: ?UnfurlYoutubeDisplay}
+export type Unfurl = {unfurlType: 0, generic: ?UnfurlGeneric} | {unfurlType: 1, youtube: ?UnfurlYoutube} | {unfurlType: 2, giphy: ?UnfurlGiphy}
+export type UnfurlDisplay = {unfurlType: 0, generic: ?UnfurlGenericDisplay} | {unfurlType: 1, youtube: ?UnfurlYoutubeDisplay} | {unfurlType: 2, giphy: ?UnfurlGiphyDisplay}
 export type UnfurlGeneric = $ReadOnly<{title: String, url: String, siteName: String, favicon?: ?Asset, image?: ?Asset, publishTime?: ?Int, description?: ?String}>
 export type UnfurlGenericDisplay = $ReadOnly<{title: String, url: String, siteName: String, favicon?: ?UnfurlImageDisplay, image?: ?UnfurlImageDisplay, publishTime?: ?Int, description?: ?String}>
 export type UnfurlGenericRaw = $ReadOnly<{title: String, url: String, siteName: String, faviconUrl?: ?String, imageUrl?: ?String, publishTime?: ?Int, description?: ?String}>
+export type UnfurlGiphy = $ReadOnly<{favicon?: ?Asset, image: Asset}>
+export type UnfurlGiphyDisplay = $ReadOnly<{favicon?: ?UnfurlImageDisplay, image: UnfurlImageDisplay}>
+export type UnfurlGiphyRaw = $ReadOnly<{faviconUrl?: ?String, imageUrl: String}>
 export type UnfurlImageDisplay = $ReadOnly<{url: String, height: Int, width: Int}>
 export type UnfurlMode =
   | 0 // ALWAYS_0
@@ -1105,13 +1109,14 @@ export type UnfurlPromptAction =
   | 4 // ONETIME_4
 
 export type UnfurlPromptResult = {actionType: 0} | {actionType: 1} | {actionType: 3} | {actionType: 2, accept: ?String} | {actionType: 4, onetime: ?String}
-export type UnfurlRaw = {unfurlType: 0, generic: ?UnfurlGenericRaw} | {unfurlType: 1, youtube: ?UnfurlYoutubeRaw}
+export type UnfurlRaw = {unfurlType: 0, generic: ?UnfurlGenericRaw} | {unfurlType: 1, youtube: ?UnfurlYoutubeRaw} | {unfurlType: 2, giphy: ?UnfurlGiphyRaw}
 export type UnfurlResult = $ReadOnly<{unfurl: Unfurl, url: String}>
 export type UnfurlSettings = $ReadOnly<{mode: UnfurlMode, whitelist: {[key: string]: Boolean}}>
 export type UnfurlSettingsDisplay = $ReadOnly<{mode: UnfurlMode, whitelist?: ?Array<String>}>
 export type UnfurlType =
   | 0 // GENERIC_0
   | 1 // YOUTUBE_1
+  | 2 // GIPHY_2
 
 export type UnfurlYoutube = $ReadOnly<{}>
 export type UnfurlYoutubeDisplay = $ReadOnly<{}>


### PR DESCRIPTION
Patch does the following:

**Go**
1. Add a new `UnfurlType`, `GIPHY`, which is triggered for domains either like `giphy.com` or `gph.is`. Add all the corresponding unfurl types that correspond to this.
2. Generalize `Scraper` a little so that specialized scrapers can still take advantage of things the generic scraper does (like find favicons). Build the Giphy unfurl from just the image in `head` and the favicon.
3. Package up `VIDEO` `Asset`'s that we find on the page as long as they are MIME type `image/gif`. Change the display code to get the height/width from the right place depending on the type.

**JS**
@keybase/react-hackers 
1. Add a new component for displaying Giphy unfurls called `UnfurlGiphy`. This is similar to `UnfurlGeneric` but is much simpler since we aren't displaying as much info.
2. Factor out the image display code into a new component called `UnfurlImage` which gets the dimensions of the displayed image correct. Use this in both `UnfurlGeneric` and `UnfurlGiphy`.
3. Hook everything up to the Giphy type coming up from the service.
4. Tested display on desktop and on iPhone XS real device and iPhone 5s sim and it all looks good. The display of the GIF is turned into a JPG if it is too big just like a chat attachment, but I found that Giphy gives a reasonably sized Gif for all the those I could find anyway.