### PR TITLE
Fix tapping outside of search suggestions on mobile send form

### DIFF
--- a/shared/common-adapters/floating-box/index.types.js.flow
+++ b/shared/common-adapters/floating-box/index.types.js.flow
@@ -11,7 +11,8 @@ export type Props = {
   // Desktop only - the node that we should aim for
   // optional because desktop only, return val nullable because refs always are
   attachTo?: () => ?React.ElementRef<any>,
-  // Desktop only - allow clicks outside the floating box to propagate
+  // Desktop only - allow clicks outside the floating box to propagate. On
+  // mobile you can control this by setting a margin in `containerStyle`.
   propagateOutsideClicks?: boolean,
   containerStyle?: StylesCrossPlatform,
   position?: Position,

--- a/shared/wallets/send-form/participants/index.stories.js
+++ b/shared/wallets/send-form/participants/index.stories.js
@@ -73,6 +73,7 @@ const connectPropsMap: RowConnectPropsMap = {
 const participantProviderProperties = {
   ...makeResultsListSelectorMap(connectPropsMap),
   ...makeUserInputSelectorMap([]),
+  SendFormParticipantsSearch: o => ({...o, onVisibleScreen: true}),
 }
 
 const provider = Sb.createPropProviderWithCommon(participantProviderProperties)

--- a/shared/wallets/send-form/participants/search.js
+++ b/shared/wallets/send-form/participants/search.js
@@ -115,14 +115,16 @@ class Search extends React.Component<SearchPropsInner, SearchState> {
             containerStyle={styles.resultsFloatingContainer}
             propagateOutsideClicks={true}
           >
-            <Kb.Box2 direction="vertical" style={styles.resultsContainer}>
-              <ResultsList
-                searchKey={searchKey}
-                onClick={this.props.onClickResult}
-                onShowTracker={this.props.onShowTracker}
-                disableListBuilding={true}
-                style={styles.list}
-              />
+            <Kb.Box2 direction="vertical" style={styles.resultsFloatingInnerContainer}>
+              <Kb.Box2 direction="vertical" style={styles.resultsContainer}>
+                <ResultsList
+                  searchKey={searchKey}
+                  onClick={this.props.onClickResult}
+                  onShowTracker={this.props.onShowTracker}
+                  disableListBuilding={true}
+                  style={styles.list}
+                />
+              </Kb.Box2>
             </Kb.Box2>
           </Kb.FloatingBox>
         )}
@@ -133,22 +135,18 @@ class Search extends React.Component<SearchPropsInner, SearchState> {
 
 const styles = Styles.styleSheetCreate({
   resultsFloatingContainer: Styles.platformStyles({
-    common: {
-      ...Styles.globalStyles.flexBoxColumn,
-      alignItems: 'stretch',
-      justifyContent: 'flex-start',
-    },
+    isMobile: {marginTop: 146},
+  }),
+  resultsFloatingInnerContainer: Styles.platformStyles({
     isElectron: {
       borderBottomLeftRadius: 4,
       borderBottomRightRadius: 4,
       height: 429,
-      maxHeight: 429,
       overflow: 'hidden',
       width: 360,
     },
     isMobile: {
       flexGrow: 1,
-      marginTop: 146,
       width: '100%',
     },
   }),

--- a/shared/wallets/send-form/participants/search.js
+++ b/shared/wallets/send-form/participants/search.js
@@ -2,10 +2,12 @@
 import * as React from 'react'
 import * as Styles from '../../../styles'
 import * as Kb from '../../../common-adapters'
+import * as Container from '../../../util/container'
 import ResultsList from '../../../search/results-list/container'
 import UserInput from '../../../search/user-input/container'
+import {getPath} from '../../../route-tree/index'
 import {ParticipantsRow} from '../../common'
-import {searchKey} from '../../../constants/wallets'
+import {searchKey, sendReceiveFormRouteKey} from '../../../constants/wallets'
 
 export type SearchProps = {|
   heading: 'To' | 'From',
@@ -13,6 +15,11 @@ export type SearchProps = {|
   onShowSuggestions: () => void,
   onShowTracker: (username: string) => void,
   onScanQRCode: ?() => void,
+|}
+
+type SearchPropsInner = {|
+  ...SearchProps,
+  onVisibleScreen: boolean, // true if we are topmost route
 |}
 
 type SearchState = {|
@@ -25,7 +32,7 @@ const placeholder = 'Search Keybase'
 
 // TODO: Once UserInput is cleaned up, we may be able to stretch it
 // properly horizontally without wrapping a vertical Box2 around it.
-class Search extends React.Component<SearchProps, SearchState> {
+class Search extends React.Component<SearchPropsInner, SearchState> {
   _row: ?ParticipantsRow
   state = {
     displayResultsList: false,
@@ -35,6 +42,19 @@ class Search extends React.Component<SearchProps, SearchState> {
 
   componentDidMount() {
     this.props.onShowSuggestions()
+  }
+
+  componentDidUpdate(prevProps: SearchPropsInner, prevState: SearchState) {
+    if (!this.props.onVisibleScreen && prevProps.onVisibleScreen && this.state.displayResultsList) {
+      // if we:
+      // 1. were on the visible screen
+      // 2. are not on the visible screen now
+      // 3. were showing the results list
+      // hide the results list.
+      // this is to avoid displaying the list on the wrong page because it's
+      // rendering in a gateway and may stay mounted
+      this.setState({displayResultsList: false})
+    }
   }
 
   onFocus = () => {
@@ -89,17 +109,20 @@ class Search extends React.Component<SearchProps, SearchState> {
           </Kb.Box2>
         </ParticipantsRow>
         {this.state.displayResultsList && (
-          <Kb.FloatingBox attachTo={this._getRef} position="top center" propagateOutsideClicks={true}>
-            <Kb.Box2 direction="vertical" style={styles.resultsFloatingContainer}>
-              <Kb.Box2 direction="vertical" style={styles.resultsContainer}>
-                <ResultsList
-                  searchKey={searchKey}
-                  onClick={this.props.onClickResult}
-                  onShowTracker={this.props.onShowTracker}
-                  disableListBuilding={true}
-                  style={styles.list}
-                />
-              </Kb.Box2>
+          <Kb.FloatingBox
+            attachTo={this._getRef}
+            position="top center"
+            containerStyle={styles.resultsFloatingContainer}
+            propagateOutsideClicks={true}
+          >
+            <Kb.Box2 direction="vertical" style={styles.resultsContainer}>
+              <ResultsList
+                searchKey={searchKey}
+                onClick={this.props.onClickResult}
+                onShowTracker={this.props.onShowTracker}
+                disableListBuilding={true}
+                style={styles.list}
+              />
             </Kb.Box2>
           </Kb.FloatingBox>
         )}
@@ -110,16 +133,22 @@ class Search extends React.Component<SearchProps, SearchState> {
 
 const styles = Styles.styleSheetCreate({
   resultsFloatingContainer: Styles.platformStyles({
+    common: {
+      ...Styles.globalStyles.flexBoxColumn,
+      alignItems: 'stretch',
+      justifyContent: 'flex-start',
+    },
     isElectron: {
       borderBottomLeftRadius: 4,
       borderBottomRightRadius: 4,
       height: 429,
+      maxHeight: 429,
       overflow: 'hidden',
       width: 360,
     },
     isMobile: {
       flexGrow: 1,
-      paddingTop: 98,
+      marginTop: 146,
       width: '100%',
     },
   }),
@@ -160,4 +189,11 @@ const styles = Styles.styleSheetCreate({
   },
 })
 
-export default Search
+export default Container.namedConnect<SearchProps, _, _, _, _>(
+  (state, ownProps) => ({
+    onVisibleScreen: getPath(state.routeTree.routeState).last() === sendReceiveFormRouteKey,
+  }),
+  () => ({}),
+  (s, d, o) => ({...o, ...s, ...d}),
+  'SendFormParticipantsSearch'
+)(Search)


### PR DESCRIPTION
1. Use margin in `FloatingBox containerStyle` to have a tappable area outside of the results floating box
2. Hide results list if we transition away from the visible screen so the list doesn't keep rendering in the gateway on the wrong screen

r? @keybase/react-hackers 