### PR TITLE
Add engine.reset on KeybaseEngine.destroy (droid)

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -93,6 +93,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
     public void destroy() {
         try {
             executor.shutdownNow();
+            Keybase.reset();
             // We often hit this timeout during app resume, e.g. hit the back
             // button to go to home screen and then tap Keybase app icon again.
             if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {


### PR DESCRIPTION
There's a subtle bug where if a thread is blocked on `readB64` from the engine when we call `shutdownNow` on the executor, the thread won't finish and we enter that timeout condition. This results in a broken app since the engine replied to a message, but it was dropped because this thread was orphaned and had no way to communicate back to JS.

With `Keybase.reset()` we finish the block `readB64` call so that this thread can propely shut down. And the new thread that comes up will get the message and be able to forward it properly to JS.

Now we never hit that timeout, so we should not see that error msg again.

@keybase/react-hackers 