### PR TITLE
show user card on team add error due to identiy issues

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -4,6 +4,7 @@ import {map, last} from 'lodash-es'
 import * as I from 'immutable'
 import * as SearchGen from './search-gen'
 import * as TeamsGen from './teams-gen'
+import * as ProfileGen from './profile-gen'
 import * as Types from '../constants/types/teams'
 import * as Constants from '../constants/teams'
 import * as ChatConstants from '../constants/chat2'
@@ -326,6 +327,14 @@ const _addToTeam = function*(action: TeamsGen.AddToTeamPayload) {
       role: role ? RPCTypes.teamsTeamRole[role] : RPCTypes.teamsTeamRole.none,
       sendChatNotification,
     })
+  } catch (e) {
+    // identify error
+    if (e.code === RPCTypes.constantsStatusCode.scidentifysummaryerror) {
+      if (isMobile) {
+        // show profile card on mobile
+        yield Saga.put(ProfileGen.createShowUserProfile({username}))
+      }
+    }
   } finally {
     // TODO handle error
     yield Saga.put(WaitingGen.createDecrementWaiting({key: waitingKeys}))

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -336,7 +336,6 @@ const _addToTeam = function*(action: TeamsGen.AddToTeamPayload) {
       }
     }
   } finally {
-    // TODO handle error
     yield Saga.put(WaitingGen.createDecrementWaiting({key: waitingKeys}))
   }
 }


### PR DESCRIPTION
@keybase/react-hackers if you follow someone and have them on a team, reset them, then try to re-add them it will fail with a black bar. on Desktop you'll get a tracker card and can figure out what happened but on mobile you don't. instead if we get this id error we push the profile screen (which will be red)