### PR TITLE
Make delete channel 'cancel' option work

### DIFF
--- a/shared/chat/manage-channels/delete-channel.js
+++ b/shared/chat/manage-channels/delete-channel.js
@@ -36,7 +36,7 @@ class _DeleteChannel extends React.Component<Props, State> {
     const items = [
       'Divider',
       {danger: true, onClick: this.props.onConfirmedDelete, title: 'Yes, delete channel'},
-      {onClick: this.props.toggleShowingMenu, title: 'Cancel'},
+      {title: 'Cancel'},
     ]
 
     return (


### PR DESCRIPTION
`onClick` + `closeOnSelect={true}` = double toggle so the menu stayed open. r? @keybase/react-hackers 