### PR TITLE
write to the inbox cache in the background CORE-9566

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -357,7 +357,7 @@ func (r *recentConversationParticipants) getActiveScore(ctx context.Context, con
 }
 
 func (r *recentConversationParticipants) get(ctx context.Context, myUID gregor1.UID) (res []gregor1.UID, err error) {
-	_, convs, err := storage.NewInbox(r.G()).ReadAll(ctx, myUID)
+	_, convs, err := storage.NewInbox(r.G()).ReadAll(ctx, myUID, true)
 	if err != nil {
 		if _, ok := err.(storage.MissError); ok {
 			r.Debug(ctx, "get: no inbox, returning blank results")

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -136,7 +136,7 @@ func (h *IdentifyChangedHandler) getTLFtoCrypt(ctx context.Context, uid gregor1.
 	}
 	inbox := storage.NewInbox(h.G())
 
-	_, allConvs, err := inbox.ReadAll(ctx, me.ToBytes())
+	_, allConvs, err := inbox.ReadAll(ctx, me.ToBytes(), true)
 	if err != nil {
 		return "", nil, err
 	}

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -373,10 +373,10 @@ type HybridInboxSource struct {
 	utils.DebugLabeler
 	*baseInboxSource
 
-	started    bool
-	stopCh     chan struct{}
-	flushDelay time.Duration
-	flushCh    chan struct{} // testing only
+	started     bool
+	stopCh      chan struct{}
+	flushDelay  time.Duration
+	testFlushCh chan struct{} // testing only
 }
 
 var _ types.InboxSource = (*HybridInboxSource)(nil)
@@ -417,7 +417,6 @@ func (s *HybridInboxSource) Stop(ctx context.Context) chan struct{} {
 	s.Debug(ctx, "Stop")
 	if s.started {
 		close(s.stopCh)
-		s.stopCh = make(chan struct{})
 		s.started = false
 	}
 	ch := make(chan struct{})
@@ -430,8 +429,8 @@ func (s *HybridInboxSource) inboxFlushLoop(uid gregor1.UID, stopCh chan struct{}
 	appState := s.G().AppState.State()
 	doFlush := func() {
 		s.createInbox().Flush(ctx, uid)
-		if s.flushCh != nil {
-			s.flushCh <- struct{}{}
+		if s.testFlushCh != nil {
+			s.testFlushCh <- struct{}{}
 		}
 	}
 	for {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -3,6 +3,8 @@ package chat
 import (
 	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/storage"
@@ -12,6 +14,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
 	context "golang.org/x/net/context"
 )
 
@@ -366,9 +369,15 @@ func (s *RemoteInboxSource) UpgradeKBFSToImpteam(ctx context.Context, uid gregor
 }
 
 type HybridInboxSource struct {
+	sync.Mutex
 	globals.Contextified
 	utils.DebugLabeler
 	*baseInboxSource
+
+	started    bool
+	stopCh     chan struct{}
+	clock      clockwork.Clock
+	flushDelay time.Duration
 }
 
 var _ types.InboxSource = (*HybridInboxSource)(nil)
@@ -379,9 +388,62 @@ func NewHybridInboxSource(g *globals.Context,
 	s := &HybridInboxSource{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: labeler,
+		clock:        clockwork.NewRealClock(),
+		flushDelay:   time.Minute,
 	}
 	s.baseInboxSource = newBaseInboxSource(g, s, getChatInterface)
 	return s
+}
+
+func (s *HybridInboxSource) createInbox() *storage.Inbox {
+	return storage.NewInbox(s.G(), storage.FlushMode(storage.InboxFlushModeDelegate))
+}
+
+func (s *HybridInboxSource) Start(ctx context.Context, uid gregor1.UID) {
+	s.baseInboxSource.Start(ctx, uid)
+	s.Lock()
+	defer s.Unlock()
+	s.Debug(ctx, "Start")
+	if s.started {
+		close(s.stopCh)
+		s.stopCh = make(chan struct{})
+	}
+	s.started = true
+	go s.inboxFlushLoop(uid, s.stopCh)
+}
+
+func (s *HybridInboxSource) Stop(ctx context.Context) chan struct{} {
+	<-s.baseInboxSource.Stop(ctx)
+	s.Lock()
+	defer s.Unlock()
+	s.Debug(ctx, "Start")
+	if s.started {
+		close(s.stopCh)
+		s.stopCh = make(chan struct{})
+		s.started = false
+	}
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+func (s *HybridInboxSource) inboxFlushLoop(uid gregor1.UID, stopCh chan struct{}) {
+	ctx := context.Background()
+	appState := s.G().AppState.State()
+	for {
+		select {
+		case <-s.clock.After(s.flushDelay):
+			s.createInbox().Flush(ctx, uid)
+		case appState = <-s.G().AppState.NextUpdate(&appState):
+			switch appState {
+			case keybase1.AppState_BACKGROUND:
+				s.createInbox().Flush(ctx, uid)
+			}
+		case <-stopCh:
+			s.createInbox().Flush(ctx, uid)
+			return
+		}
+	}
 }
 
 func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UID, query *chat1.GetInboxQuery,
@@ -473,7 +535,7 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	}
 
 	// Write metadata to the inbox cache
-	if err = storage.NewInbox(s.G()).MergeLocalMetadata(ctx, uid, inbox.Convs); err != nil {
+	if err = s.createInbox().MergeLocalMetadata(ctx, uid, inbox.Convs); err != nil {
 		// Don't abort the operation on this kind of error
 		s.Debug(ctx, "Read: unable to write inbox local metadata: %s", err)
 	}
@@ -486,7 +548,7 @@ func (s *HybridInboxSource) ReadUnverified(ctx context.Context, uid gregor1.UID,
 	defer s.Trace(ctx, func() error { return err }, "ReadUnverified")()
 
 	var cerr storage.Error
-	inboxStore := storage.NewInbox(s.G())
+	inboxStore := s.createInbox()
 
 	// Try local storage (if enabled)
 	if useLocalData {
@@ -537,7 +599,7 @@ func (s *HybridInboxSource) handleInboxError(ctx context.Context, err error, uid
 			// Only do this aggressive clear if the error we get is not some kind of network error
 			if IsOfflineError(ferr) == OfflineErrorKindOnline {
 				s.Debug(ctx, "handleInboxError: failed to recover from inbox error, clearing: %s", ferr)
-				storage.NewInbox(s.G()).Clear(ctx, uid)
+				s.createInbox().Clear(ctx, uid)
 			} else {
 				s.Debug(ctx, "handleInboxError: skipping inbox clear because of offline error: %s", ferr)
 			}
@@ -558,7 +620,7 @@ func (s *HybridInboxSource) handleInboxError(ctx context.Context, err error, uid
 func (s *HybridInboxSource) NewConversation(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	conv chat1.Conversation) (err error) {
 	defer s.Trace(ctx, func() error { return err }, "NewConversation")()
-	if cerr := storage.NewInbox(s.G()).NewConversation(ctx, uid, vers, conv); cerr != nil {
+	if cerr := s.createInbox().NewConversation(ctx, uid, vers, conv); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return err
 	}
@@ -597,7 +659,7 @@ func (s *HybridInboxSource) getConvsLocal(ctx context.Context, uid gregor1.UID,
 func (s *HybridInboxSource) NewMessage(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convID chat1.ConversationID, msg chat1.MessageBoxed, maxMsgs []chat1.MessageSummary) (conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "NewMessage")()
-	if cerr := storage.NewInbox(s.G()).NewMessage(ctx, uid, vers, convID, msg, maxMsgs); cerr != nil {
+	if cerr := s.createInbox().NewMessage(ctx, uid, vers, convID, msg, maxMsgs); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
 	}
@@ -611,7 +673,7 @@ func (s *HybridInboxSource) NewMessage(ctx context.Context, uid gregor1.UID, ver
 func (s *HybridInboxSource) ReadMessage(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convID chat1.ConversationID, msgID chat1.MessageID) (conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "ReadMessage")()
-	if cerr := storage.NewInbox(s.G()).ReadMessage(ctx, uid, vers, convID, msgID); cerr != nil {
+	if cerr := s.createInbox().ReadMessage(ctx, uid, vers, convID, msgID); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
 	}
@@ -626,7 +688,7 @@ func (s *HybridInboxSource) ReadMessage(ctx context.Context, uid gregor1.UID, ve
 func (s *HybridInboxSource) SetStatus(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convID chat1.ConversationID, status chat1.ConversationStatus) (conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "SetStatus")()
-	if cerr := storage.NewInbox(s.G()).SetStatus(ctx, uid, vers, convID, status); cerr != nil {
+	if cerr := s.createInbox().SetStatus(ctx, uid, vers, convID, status); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
 	}
@@ -640,7 +702,7 @@ func (s *HybridInboxSource) SetStatus(ctx context.Context, uid gregor1.UID, vers
 func (s *HybridInboxSource) SetAppNotificationSettings(ctx context.Context, uid gregor1.UID,
 	vers chat1.InboxVers, convID chat1.ConversationID, settings chat1.ConversationNotificationInfo) (conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "SetAppNotificationSettings")()
-	ib := storage.NewInbox(s.G())
+	ib := s.createInbox()
 	if cerr := ib.SetAppNotificationSettings(ctx, uid, vers, convID, settings); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
@@ -663,7 +725,7 @@ func (s *HybridInboxSource) TeamTypeChanged(ctx context.Context, uid gregor1.UID
 		s.Debug(ctx, "TeamTypeChanged: failed to read team type conv: %s", err.Error())
 		return nil, err
 	}
-	ib := storage.NewInbox(s.G())
+	ib := s.createInbox()
 	if cerr := ib.TeamTypeChanged(ctx, uid, vers, convID, teamType, remoteConv.Notifications); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
@@ -680,7 +742,7 @@ func (s *HybridInboxSource) UpgradeKBFSToImpteam(ctx context.Context, uid gregor
 	vers chat1.InboxVers, convID chat1.ConversationID) (conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "UpgradeKBFSToImpteam")()
 
-	ib := storage.NewInbox(s.G())
+	ib := s.createInbox()
 	if cerr := ib.UpgradeKBFSToImpteam(ctx, uid, vers, convID); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
@@ -697,7 +759,7 @@ func (s *HybridInboxSource) TlfFinalize(ctx context.Context, uid gregor1.UID, ve
 	convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) (convs []chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "TlfFinalize")()
 
-	if cerr := storage.NewInbox(s.G()).TlfFinalize(ctx, uid, vers, convIDs, finalizeInfo); cerr != nil {
+	if cerr := s.createInbox().TlfFinalize(ctx, uid, vers, convIDs, finalizeInfo); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return convs, err
 	}
@@ -770,7 +832,7 @@ func (s *HybridInboxSource) MembershipUpdate(ctx context.Context, uid gregor1.UI
 		}
 	}
 
-	ib := storage.NewInbox(s.G())
+	ib := s.createInbox()
 	if cerr := ib.MembershipUpdate(ctx, uid, vers, userJoinedConvs, res.UserRemovedConvs,
 		res.OthersJoinedConvs, res.OthersRemovedConvs, res.UserResetConvs, res.OthersResetConvs); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
@@ -797,7 +859,7 @@ func (s *HybridInboxSource) SetConvRetention(ctx context.Context, uid gregor1.UI
 func (s *HybridInboxSource) SetTeamRetention(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	teamID keybase1.TeamID, policy chat1.RetentionPolicy) (convs []chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "SetTeamRetention")()
-	ib := storage.NewInbox(s.G())
+	ib := s.createInbox()
 	convIDs, cerr := ib.SetTeamRetention(ctx, uid, vers, teamID, policy)
 	if cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
@@ -821,7 +883,7 @@ func (s *HybridInboxSource) SetConvSettings(ctx context.Context, uid gregor1.UID
 func (s *HybridInboxSource) SubteamRename(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 	convIDs []chat1.ConversationID) (convs []chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, "SubteamRename")()
-	ib := storage.NewInbox(s.G())
+	ib := s.createInbox()
 	if cerr := ib.SubteamRename(ctx, uid, vers, convIDs); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
@@ -838,7 +900,7 @@ func (s *HybridInboxSource) modConversation(ctx context.Context, debugLabel stri
 	mod func(context.Context, *storage.Inbox) error) (
 	conv *chat1.ConversationLocal, err error) {
 	defer s.Trace(ctx, func() error { return err }, debugLabel)()
-	ib := storage.NewInbox(s.G())
+	ib := s.createInbox()
 	if cerr := mod(ctx, ib); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -184,7 +184,7 @@ func TestInboxSourceFlushLoop(t *testing.T) {
 	require.NoError(t, err)
 	inbox := hbs.createInbox()
 	flushCh := make(chan struct{}, 10)
-	hbs.flushCh = flushCh
+	hbs.testFlushCh = flushCh
 	_, _, err = inbox.ReadAll(ctx, uid, false)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -200,14 +200,21 @@ func TestInboxSourceFlushLoop(t *testing.T) {
 	_, rc, err = inbox.ReadAll(ctx, uid, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rc))
+	_, rc, err = inbox.ReadAll(ctx, uid, true)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rc))
 
 	newBlankConv(ctx, t, tc, uid, ri, sender, u.Username+","+u2.Username)
 	_, rc, err = inbox.ReadAll(ctx, uid, false)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(rc))
+	_, rc, err = inbox.ReadAll(ctx, uid, true)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rc))
 	tc.Context().AppState.Update(keybase1.AppState_BACKGROUND)
 	select {
 	case <-flushCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(20 * time.Second):
 		require.Fail(t, "no flush")
 	}
 	_, rc, err = inbox.ReadAll(ctx, uid, false)

--- a/go/chat/storage/inbox_test.go
+++ b/go/chat/storage/inbox_test.go
@@ -759,7 +759,7 @@ func TestInboxServerVersion(t *testing.T) {
 	require.IsType(t, MissError{}, err)
 
 	require.NoError(t, inbox.Merge(context.TODO(), uid, 1, utils.PluckConvs(convs), nil, nil))
-	idata, err := inbox.readDiskInbox(context.TODO(), uid)
+	idata, err := inbox.readDiskInbox(context.TODO(), uid, true)
 	require.NoError(t, err)
 	require.Equal(t, 5, idata.ServerVersion)
 }
@@ -807,7 +807,7 @@ func TestMobileSharedInbox(t *testing.T) {
 		convs = append(convs, conv)
 	}
 	require.NoError(t, inbox.Merge(context.TODO(), uid, 1, utils.PluckConvs(convs), nil, nil))
-	diskIbox, err := inbox.readDiskInbox(context.TODO(), uid)
+	diskIbox, err := inbox.readDiskInbox(context.TODO(), uid, true)
 	require.NoError(t, err)
 	diskIbox.Conversations[4].LocalMetadata = &types.RemoteConversationMetadata{
 		TopicName: "mike",
@@ -848,7 +848,7 @@ func TestInboxMembershipDupUpdate(t *testing.T) {
 	require.NoError(t, inbox.MembershipUpdate(context.TODO(), uid, 2, []chat1.Conversation{conv.Conv},
 		nil, otherJoinedConvs, nil, nil, nil))
 
-	_, res, err := inbox.ReadAll(context.TODO(), uid)
+	_, res, err := inbox.ReadAll(context.TODO(), uid, true)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res))
 	require.Equal(t, 2, len(res[0].Conv.Metadata.AllList))
@@ -917,7 +917,7 @@ func TestInboxMembershipUpdate(t *testing.T) {
 		userRemovedConvs, otherJoinedConvs, otherRemovedConvs,
 		userResetConvs, otherResetConvs))
 
-	vers, res, err := inbox.ReadAll(context.TODO(), uid)
+	vers, res, err := inbox.ReadAll(context.TODO(), uid, true)
 	require.NoError(t, err)
 	require.Equal(t, chat1.InboxVers(2), vers)
 	for _, c := range res {

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -126,7 +126,7 @@ func TestSyncerConnected(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no inbox synced received")
 	}
-	_, _, err := ibox.ReadAll(ctx, uid)
+	_, _, err := ibox.ReadAll(ctx, uid, true)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
 
@@ -137,7 +137,7 @@ func TestSyncerConnected(t *testing.T) {
 	_, _, serr := tc.ChatG.InboxSource.Read(ctx, uid, types.ConversationLocalizerBlocking, true,
 		nil, nil, nil)
 	require.NoError(t, serr)
-	_, iconvs, err := ibox.ReadAll(ctx, uid)
+	_, iconvs, err := ibox.ReadAll(ctx, uid, true)
 	require.NoError(t, err)
 	require.Equal(t, len(convs), len(iconvs))
 
@@ -167,7 +167,7 @@ func TestSyncerConnected(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no background conv loaded")
 	}
-	vers, iconvs, err := ibox.ReadAll(context.TODO(), uid)
+	vers, iconvs, err := ibox.ReadAll(context.TODO(), uid, true)
 	require.NoError(t, err)
 	require.Equal(t, len(convs), len(iconvs))
 	for _, ic := range iconvs {
@@ -199,7 +199,7 @@ func TestSyncerConnected(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no inbox stale received")
 	}
-	_, _, err = ibox.ReadAll(ctx, uid)
+	_, _, err = ibox.ReadAll(ctx, uid, true)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
 	_, cerr = store.Fetch(ctx, mconv, uid, nil, nil, nil)
@@ -208,7 +208,7 @@ func TestSyncerConnected(t *testing.T) {
 	_, _, serr = tc.Context().InboxSource.Read(ctx, uid, types.ConversationLocalizerBlocking, true,
 		nil, nil, nil)
 	require.NoError(t, serr)
-	_, iconvs, err = ibox.ReadAll(ctx, uid)
+	_, iconvs, err = ibox.ReadAll(ctx, uid, true)
 	require.NoError(t, err)
 	require.Equal(t, len(convs), len(iconvs))
 	srvVers, err = ibox.ServerVersion(context.TODO(), uid)
@@ -480,7 +480,7 @@ func TestSyncerRetentionExpunge(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no background conv loaded")
 	}
-	_, iconvs, err := ibox.ReadAll(ctx, uid)
+	_, iconvs, err := ibox.ReadAll(ctx, uid, true)
 	require.NoError(t, err)
 	require.Len(t, iconvs, 1)
 	require.Equal(t, chat1.MessageID(2), iconvs[0].Conv.ReaderInfo.MaxMsgid)
@@ -517,7 +517,7 @@ func TestSyncerRetentionExpunge(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no background conv loaded")
 	}
-	_, iconvs, err = ibox.ReadAll(context.TODO(), uid)
+	_, iconvs, err = ibox.ReadAll(context.TODO(), uid, true)
 	require.NoError(t, err)
 	require.Len(t, iconvs, 1)
 	require.Equal(t, chat1.Expunge{Upto: 12}, iconvs[0].Conv.Expunge)
@@ -551,7 +551,7 @@ func TestSyncerTeamFilter(t *testing.T) {
 	_, _, err := tc.ChatG.InboxSource.Read(ctx, uid, types.ConversationLocalizerBlocking, true,
 		nil, nil, nil)
 	require.NoError(t, err)
-	_, iconvs, err := ibox.ReadAll(ctx, uid)
+	_, iconvs, err := ibox.ReadAll(ctx, uid, true)
 	require.NoError(t, err)
 	require.Len(t, iconvs, 2)
 	require.NoError(t, ibox.TeamTypeChanged(ctx, uid, 1, tconv.GetConvID(), chat1.TeamType_COMPLEX, nil))


### PR DESCRIPTION
Patch does the following:

1.) Adds a new `InboxFlushMode` to `storage.Inbox` which controls what `Inbox.writeDataInbox` does. The new `DELEGATE` mode means that something else other than `Inbox` is in control of flushing in memory inbox data.
2.) Add a new loop to `HybridInboxSource` to manage flushing the `Inbox` to LevelDB. Flushing fires either after 1 minute or when the app changes into `BACKGROUND`.