### PR TITLE
Alert instead of crash on permission errors

### DIFF
--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -29,7 +29,6 @@ export const badgesUpdated = 'chat2:badgesUpdated'
 export const blockConversation = 'chat2:blockConversation'
 export const createConversation = 'chat2:createConversation'
 export const desktopNotification = 'chat2:desktopNotification'
-export const filePickerError = 'chat2:filePickerError'
 export const handleSeeingExplodingMessages = 'chat2:handleSeeingExplodingMessages'
 export const handleSeeingWallets = 'chat2:handleSeeingWallets'
 export const inboxRefresh = 'chat2:inboxRefresh'
@@ -122,7 +121,6 @@ type _BadgesUpdatedPayload = $ReadOnly<{|conversations: Array<RPCTypes.BadgeConv
 type _BlockConversationPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey, reportUser: boolean|}>
 type _CreateConversationPayload = $ReadOnly<{|participants: Array<string>|}>
 type _DesktopNotificationPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey, author: string, body: string|}>
-type _FilePickerErrorPayload = $ReadOnly<{|error: Error|}>
 type _HandleSeeingExplodingMessagesPayload = void
 type _HandleSeeingWalletsPayload = void
 type _InboxRefreshPayload = $ReadOnly<{|reason: 'bootstrap' | 'componentNeverLoaded' | 'inboxStale' | 'inboxSyncedClear' | 'inboxSyncedUnknown' | 'joinedAConversation' | 'leftAConversation' | 'teamTypeChanged'|}>
@@ -238,10 +236,6 @@ export const createUnfurlRemove = (payload: _UnfurlRemovePayload) => ({payload, 
  * Response to an unfurl prompt
  */
 export const createUnfurlResolvePrompt = (payload: _UnfurlResolvePromptPayload) => ({payload, type: unfurlResolvePrompt})
-/**
- * Sent whenever the mobile file picker encounters an error.
- */
-export const createFilePickerError = (payload: _FilePickerErrorPayload) => ({payload, type: filePickerError})
 /**
  * Set a lock on the exploding mode for a conversation.
  */
@@ -392,7 +386,6 @@ export type BadgesUpdatedPayload = {|+payload: _BadgesUpdatedPayload, +type: 'ch
 export type BlockConversationPayload = {|+payload: _BlockConversationPayload, +type: 'chat2:blockConversation'|}
 export type CreateConversationPayload = {|+payload: _CreateConversationPayload, +type: 'chat2:createConversation'|}
 export type DesktopNotificationPayload = {|+payload: _DesktopNotificationPayload, +type: 'chat2:desktopNotification'|}
-export type FilePickerErrorPayload = {|+payload: _FilePickerErrorPayload, +type: 'chat2:filePickerError'|}
 export type HandleSeeingExplodingMessagesPayload = {|+payload: _HandleSeeingExplodingMessagesPayload, +type: 'chat2:handleSeeingExplodingMessages'|}
 export type HandleSeeingWalletsPayload = {|+payload: _HandleSeeingWalletsPayload, +type: 'chat2:handleSeeingWallets'|}
 export type InboxRefreshPayload = {|+payload: _InboxRefreshPayload, +type: 'chat2:inboxRefresh'|}
@@ -487,7 +480,6 @@ export type Actions =
   | BlockConversationPayload
   | CreateConversationPayload
   | DesktopNotificationPayload
-  | FilePickerErrorPayload
   | HandleSeeingExplodingMessagesPayload
   | HandleSeeingWalletsPayload
   | InboxRefreshPayload

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2615,11 +2615,6 @@ const toggleMessageReaction = (action: Chat2Gen.ToggleMessageReactionPayload, st
   ])
 }
 
-const handleFilePickerError = (action: Chat2Gen.FilePickerErrorPayload) => {
-  // Just show a black bar for now.
-  throw action.payload.error
-}
-
 const receivedBadgeState = (state: TypedState, action: NotificationsGen.ReceivedBadgeStatePayload) =>
   Saga.put(Chat2Gen.createBadgesUpdated({conversations: action.payload.badgeState.conversations || []}))
 
@@ -2925,7 +2920,6 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(Chat2Gen.toggleMessageReaction, toggleMessageReaction)
   yield Saga.actionToAction(ConfigGen.daemonHandshake, loadStaticConfig)
   yield Saga.actionToAction(ConfigGen.setupEngineListeners, setupEngineListeners)
-  yield Saga.safeTakeEveryPure(Chat2Gen.filePickerError, handleFilePickerError)
   yield Saga.actionToAction(NotificationsGen.receivedBadgeState, receivedBadgeState)
   yield Saga.safeTakeEveryPure(Chat2Gen.setMinWriterRole, setMinWriterRole)
   yield Saga.actionToAction(GregorGen.pushState, gregorPushState)

--- a/shared/actions/config-gen.js
+++ b/shared/actions/config-gen.js
@@ -23,6 +23,7 @@ export const daemonHandshake = 'config:daemonHandshake'
 export const daemonHandshakeDone = 'config:daemonHandshakeDone'
 export const daemonHandshakeWait = 'config:daemonHandshakeWait'
 export const dumpLogs = 'config:dumpLogs'
+export const filePickerError = 'config:filePickerError'
 export const globalError = 'config:globalError'
 export const installerRan = 'config:installerRan'
 export const link = 'config:link'
@@ -62,6 +63,7 @@ type _DaemonHandshakeDonePayload = void
 type _DaemonHandshakePayload = $ReadOnly<{|firstTimeConnecting: boolean, version: number|}>
 type _DaemonHandshakeWaitPayload = $ReadOnly<{|name: string, version: number, increment: boolean, failedReason?: ?string, failedFatal?: true|}>
 type _DumpLogsPayload = $ReadOnly<{|reason: 'quitting through menu'|}>
+type _FilePickerErrorPayload = $ReadOnly<{|error: Error|}>
 type _GlobalErrorPayload = $ReadOnly<{|globalError: null | Error | RPCError|}>
 type _InstallerRanPayload = void
 type _LinkPayload = $ReadOnly<{|link: string|}>
@@ -92,6 +94,10 @@ type _UpdateNowPayload = void
 type __avatarQueuePayload = void
 
 // Action Creators
+/**
+ * Sent whenever the mobile file picker encounters an error.
+ */
+export const createFilePickerError = (payload: _FilePickerErrorPayload) => ({payload, type: filePickerError})
 /**
  * desktop only: the installer ran and we can start up
  */
@@ -175,6 +181,7 @@ export type DaemonHandshakeDonePayload = {|+payload: _DaemonHandshakeDonePayload
 export type DaemonHandshakePayload = {|+payload: _DaemonHandshakePayload, +type: 'config:daemonHandshake'|}
 export type DaemonHandshakeWaitPayload = {|+payload: _DaemonHandshakeWaitPayload, +type: 'config:daemonHandshakeWait'|}
 export type DumpLogsPayload = {|+payload: _DumpLogsPayload, +type: 'config:dumpLogs'|}
+export type FilePickerErrorPayload = {|+payload: _FilePickerErrorPayload, +type: 'config:filePickerError'|}
 export type GlobalErrorPayload = {|+payload: _GlobalErrorPayload, +type: 'config:globalError'|}
 export type InstallerRanPayload = {|+payload: _InstallerRanPayload, +type: 'config:installerRan'|}
 export type LinkPayload = {|+payload: _LinkPayload, +type: 'config:link'|}
@@ -217,6 +224,7 @@ export type Actions =
   | DaemonHandshakePayload
   | DaemonHandshakeWaitPayload
   | DumpLogsPayload
+  | FilePickerErrorPayload
   | GlobalErrorPayload
   | InstallerRanPayload
   | LinkPayload

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -414,6 +414,11 @@ const readLastSentXLM = () => {
     )
 }
 
+const handleFilePickerError = (action: ConfigGen.FilePickerErrorPayload) => {
+  // Just show a black bar for now.
+  throw action.payload.error
+}
+
 function* configSaga(): Saga.SagaGenerator<any, any> {
   // Tell all other sagas to register for incoming engine calls
   yield Saga.actionToAction(ConfigGen.installerRan, dispatchSetupEngineListeners)
@@ -457,6 +462,7 @@ function* configSaga(): Saga.SagaGenerator<any, any> {
 
   yield Saga.actionToPromise(setLastSentXLM, writeLastSentXLM)
   yield Saga.actionToPromise(ConfigGen.daemonHandshakeDone, readLastSentXLM)
+  yield Saga.safeTakeEveryPure(ConfigGen.filePickerError, handleFilePickerError)
 
   // Kick off platform specific stuff
   yield Saga.spawn(PlatformSpecific.platformConfigSaga)

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -414,11 +414,6 @@ const readLastSentXLM = () => {
     )
 }
 
-const handleFilePickerError = (action: ConfigGen.FilePickerErrorPayload) => {
-  // Just show a black bar for now.
-  throw action.payload.error
-}
-
 function* configSaga(): Saga.SagaGenerator<any, any> {
   // Tell all other sagas to register for incoming engine calls
   yield Saga.actionToAction(ConfigGen.installerRan, dispatchSetupEngineListeners)
@@ -462,7 +457,6 @@ function* configSaga(): Saga.SagaGenerator<any, any> {
 
   yield Saga.actionToPromise(setLastSentXLM, writeLastSentXLM)
   yield Saga.actionToPromise(ConfigGen.daemonHandshakeDone, readLastSentXLM)
-  yield Saga.safeTakeEveryPure(ConfigGen.filePickerError, handleFilePickerError)
 
   // Kick off platform specific stuff
   yield Saga.spawn(PlatformSpecific.platformConfigSaga)

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -456,10 +456,6 @@
       "_description": "Static configuration info was loaded from the service.",
       "staticConfig": "Types.StaticConfig"
     },
-    "filePickerError": {
-      "_description": "Sent whenever the mobile file picker encounters an error.",
-      "error": "Error"
-    },
     "setMinWriterRole": {
       "_description": "Set the minimum role required to write into a conversation. Valid only for team conversations.",
       "conversationIDKey": "Types.ConversationIDKey",

--- a/shared/actions/json/config.json
+++ b/shared/actions/json/config.json
@@ -31,6 +31,10 @@
     "daemonHandshakeDone": {
       "_description": "ready to show the app"
     },
+    "filePickerError": {
+      "_description": "Sent whenever the mobile file picker encounters an error.",
+      "error": "Error"
+    },
     "logout": {
       "_description": "someone wants to log out"
     },

--- a/shared/actions/platform-specific/index.native.js
+++ b/shared/actions/platform-specific/index.native.js
@@ -11,6 +11,7 @@ import * as RouteTreeGen from '../route-tree-gen'
 import * as Saga from '../../util/saga'
 // this CANNOT be an import *, totally screws up the packager
 import {
+  Alert,
   NetInfo,
   Linking,
   NativeModules,
@@ -299,6 +300,10 @@ const copyToClipboard = (_: any, action: ConfigGen.CopyToClipboardPayload) => {
   Clipboard.setString(action.payload.text)
 }
 
+const handleFilePickerError = (state: TypedState, action: ConfigGen.FilePickerErrorPayload) => {
+  Alert.alert('Error', action.payload.error.message)
+}
+
 function* platformConfigSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.safeTakeEveryPure(ConfigGen.mobileAppState, updateChangedFocus)
   yield Saga.actionToAction(ConfigGen.loggedOut, clearRouteState)
@@ -308,6 +313,7 @@ function* platformConfigSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.actionToAction(ConfigGen.copyToClipboard, copyToClipboard)
 
   yield Saga.actionToAction(ConfigGen.daemonHandshake, waitForStartupDetails)
+  yield Saga.actionToAction(ConfigGen.filePickerError, handleFilePickerError)
   // Start this immediately instead of waiting so we can do more things in parallel
   yield Saga.spawn(loadStartupDetails)
 

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -2,6 +2,7 @@
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
+import * as ConfigGen from '../../../../actions/config-gen'
 import * as RouteTree from '../../../../actions/route-tree'
 import HiddenString from '../../../../util/hidden-string'
 import {connect} from '../../../../util/container'
@@ -87,7 +88,7 @@ const mapDispatchToProps = dispatch => ({
     conversationIDKey &&
     dispatch(Chat2Gen.createSendTyping({conversationIDKey, text: new HiddenString(text)})),
   clearInboxFilter: () => dispatch(Chat2Gen.createSetInboxFilter({filter: ''})),
-  onFilePickerError: (error: Error) => dispatch(Chat2Gen.createFilePickerError({error})),
+  onFilePickerError: (error: Error) => dispatch(ConfigGen.createFilePickerError({error})),
   onSeenExplodingMessages: () => dispatch(Chat2Gen.createHandleSeeingExplodingMessages()),
   onSetExplodingModeLock: (conversationIDKey: Types.ConversationIDKey, unset: boolean) =>
     dispatch(Chat2Gen.createSetExplodingModeLock({conversationIDKey, unset})),

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -27,7 +27,6 @@ import type {Response} from 'react-native-image-picker'
 import type {MissingProof} from '../common-adapters/user-proofs'
 import type {RouteProps} from '../route-tree/render-route'
 import type {Props} from '.'
-import * as ConfigGen from '../actions/config-gen'
 
 type OwnProps = RouteProps<{username: ?string}, {currentFriendshipsTab: Types.FriendshipsTab}>
 

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -111,6 +111,11 @@ const mapDispatchToProps = (dispatch, {setRouteState}: OwnProps) => ({
     flags.avatarUploadsEnabled
       ? dispatch(navigateAppend([{props: {image}, selected: 'editAvatar'}]))
       : dispatch(navigateAppend(['editAvatarPlaceholder'])),
+  onEditAvatarError: (error: string) => {
+    // TODO: Do something.
+    console.error(error)
+    throw new Error(error)
+  },
   onEditProfile: () => dispatch(navigateAppend(['editProfile'])),
   onFolderClick: folder =>
     dispatch(FsGen.createOpenPathInFilesTab({path: FsTypes.stringToPath(folder.path)})),

--- a/shared/profile/container.js
+++ b/shared/profile/container.js
@@ -4,6 +4,7 @@ import * as FsGen from '../actions/fs-gen'
 import * as FsTypes from '../constants/types/fs'
 import * as TrackerGen from '../actions/tracker-gen'
 import * as Chat2Gen from '../actions/chat2-gen'
+import * as ConfigGen from '../actions/config-gen'
 import * as ProfileGen from '../actions/profile-gen'
 import * as TeamsGen from '../actions/teams-gen'
 import * as Constants from '../constants/tracker'
@@ -111,12 +112,8 @@ const mapDispatchToProps = (dispatch, {setRouteState}: OwnProps) => ({
     flags.avatarUploadsEnabled
       ? dispatch(navigateAppend([{props: {image}, selected: 'editAvatar'}]))
       : dispatch(navigateAppend(['editAvatarPlaceholder'])),
-  onEditAvatarError: (error: string) => {
-    // TODO: Do something.
-    console.error(error)
-    throw new Error(error)
-  },
   onEditProfile: () => dispatch(navigateAppend(['editProfile'])),
+  onFilePickerError: (error: Error) => dispatch(ConfigGen.createFilePickerError({error})),
   onFolderClick: folder =>
     dispatch(FsGen.createOpenPathInFilesTab({path: FsTypes.stringToPath(folder.path)})),
   onMissingProofClick: (missingProof: MissingProof) =>

--- a/shared/profile/index.js.flow
+++ b/shared/profile/index.js.flow
@@ -49,6 +49,7 @@ export type Props = {
   stellarAddress?: string,
   error: ?string,
   onEditAvatar: (image?: any) => void,
+  onEditAvatarError: (error: string) => void,
   onClickAvatar: () => void,
   onClickFollowers: () => void,
   onClickFollowing: () => void,

--- a/shared/profile/index.js.flow
+++ b/shared/profile/index.js.flow
@@ -49,7 +49,7 @@ export type Props = {
   stellarAddress?: string,
   error: ?string,
   onEditAvatar: (image?: any) => void,
-  onEditAvatarError: (error: string) => void,
+  onFilePickerError: (error: Error) => void,
   onClickAvatar: () => void,
   onClickFollowers: () => void,
   onClickFollowing: () => void,

--- a/shared/profile/index.native.js
+++ b/shared/profile/index.native.js
@@ -152,8 +152,8 @@ class Profile extends Component<Props, State> {
             return
           }
           if (response.error) {
-            console.error(response.error)
-            throw new Error(response.error)
+            this.props.onEditAvatarError(response.error)
+            return
           }
           this.props.onEditAvatar(response)
         })

--- a/shared/profile/index.native.js
+++ b/shared/profile/index.native.js
@@ -152,7 +152,7 @@ class Profile extends Component<Props, State> {
             return
           }
           if (response.error) {
-            this.props.onEditAvatarError(response.error)
+            this.props.onFilePickerError(new Error(response.error))
             return
           }
           this.props.onEditAvatar(response)

--- a/shared/profile/profile.stories.js
+++ b/shared/profile/profile.stories.js
@@ -130,6 +130,7 @@ const props = {
   onClickShowcased: Sb.action('onClickShowcased'),
   onCopyStellarAddress: Sb.action('onCopyStellarAddress'),
   onEditAvatar: Sb.action('onEditAvatar'),
+  onEditAvatarError: Sb.action('onEditAvatarError'),
   onFolderClick: Sb.action('onFolderClick'),
   onFollow: Sb.action('onFollow'),
   onMissingProofClick: Sb.action(`Prove`),

--- a/shared/profile/profile.stories.js
+++ b/shared/profile/profile.stories.js
@@ -130,7 +130,7 @@ const props = {
   onClickShowcased: Sb.action('onClickShowcased'),
   onCopyStellarAddress: Sb.action('onCopyStellarAddress'),
   onEditAvatar: Sb.action('onEditAvatar'),
-  onEditAvatarError: Sb.action('onEditAvatarError'),
+  onFilePickerError: Sb.action('onFilePickerError'),
   onFolderClick: Sb.action('onFolderClick'),
   onFollow: Sb.action('onFollow'),
   onMissingProofClick: Sb.action(`Prove`),

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -979,7 +979,6 @@ const rootReducer = (
     case Chat2Gen.setConvExplodingMode:
     case Chat2Gen.handleSeeingExplodingMessages:
     case Chat2Gen.toggleMessageReaction:
-    case Chat2Gen.filePickerError:
     case Chat2Gen.setMinWriterRole:
     case Chat2Gen.openChatFromWidget:
     case Chat2Gen.prepareFulfillRequestForm:

--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -209,6 +209,7 @@ export default function(state: Types.State = initialState, action: ConfigGen.Act
     case ConfigGen.copyToClipboard:
     case ConfigGen._avatarQueue:
     case ConfigGen.checkForUpdate:
+    case ConfigGen.filePickerError:
       return state
     default:
      Flow.ifFlowComplainsAboutThisFunctionYouHaventHandledAllCasesInASwitch(action)

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -2,6 +2,7 @@
 import {connect} from '../../../util/container'
 import * as Constants from '../../../constants/teams'
 import * as Chat2Gen from '../../../actions/chat2-gen'
+import * as ConfigGen from '../../../actions/config-gen'
 import * as Types from '../../../constants/types/teams'
 import type {Response} from 'react-native-image-picker'
 import {createAddResultsToUserInput} from '../../../actions/search-gen'
@@ -41,10 +42,7 @@ const mapDispatchToProps = (dispatch, {teamname}: OwnProps) => ({
     dispatch(
       navigateAppend([{props: {image, sendChatNotification: true, teamname}, selected: 'editTeamAvatar'}])
     ),
-  onEditIconError: (error: string) => {
-    console.error(error)
-    throw new Error(error)
-  },
+  onFilePickerError: (error: Error) => dispatch(ConfigGen.createFilePickerError({error})),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
@@ -58,7 +56,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   onChat: dispatchProps.onChat,
   onEditDescription: dispatchProps.onEditDescription,
   onEditIcon: dispatchProps.onEditIcon,
-  onEditIconError: dispatchProps.onEditIconError,
+  onFilePickerError: dispatchProps.onFilePickerError,
   openTeam: stateProps.openTeam,
   role: stateProps.role,
   teamname: ownProps.teamname,

--- a/shared/teams/team/header/container.js
+++ b/shared/teams/team/header/container.js
@@ -41,6 +41,10 @@ const mapDispatchToProps = (dispatch, {teamname}: OwnProps) => ({
     dispatch(
       navigateAppend([{props: {image, sendChatNotification: true, teamname}, selected: 'editTeamAvatar'}])
     ),
+  onEditIconError: (error: string) => {
+    console.error(error)
+    throw new Error(error)
+  },
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
@@ -54,6 +58,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   onChat: dispatchProps.onChat,
   onEditDescription: dispatchProps.onEditDescription,
   onEditIcon: dispatchProps.onEditIcon,
+  onEditIconError: dispatchProps.onEditIconError,
   openTeam: stateProps.openTeam,
   role: stateProps.role,
   teamname: ownProps.teamname,

--- a/shared/teams/team/header/index.js
+++ b/shared/teams/team/header/index.js
@@ -24,6 +24,7 @@ export type Props = {
   onChat: () => void,
   onEditDescription: () => void,
   onEditIcon: (image?: Response) => void,
+  onEditIconError: (error: string) => void,
 } & Kb.OverlayParentProps
 
 const _TeamHeader = (props: Props) => (
@@ -49,6 +50,7 @@ const _TeamHeader = (props: Props) => (
       <NameWithIconWrapper
         canEditDescription={props.canEditDescription}
         onEditIcon={props.onEditIcon}
+        onEditIconError={props.onEditIconError}
         teamname={props.teamname}
         metaOne={
           <Kb.Box style={Styles.globalStyles.flexBoxRow}>

--- a/shared/teams/team/header/index.js
+++ b/shared/teams/team/header/index.js
@@ -24,7 +24,7 @@ export type Props = {
   onChat: () => void,
   onEditDescription: () => void,
   onEditIcon: (image?: Response) => void,
-  onEditIconError: (error: string) => void,
+  onFilePickerError: (error: Error) => void,
 } & Kb.OverlayParentProps
 
 const _TeamHeader = (props: Props) => (
@@ -50,7 +50,7 @@ const _TeamHeader = (props: Props) => (
       <NameWithIconWrapper
         canEditDescription={props.canEditDescription}
         onEditIcon={props.onEditIcon}
-        onEditIconError={props.onEditIconError}
+        onFilePickerError={props.onFilePickerError}
         teamname={props.teamname}
         metaOne={
           <Kb.Box style={Styles.globalStyles.flexBoxRow}>

--- a/shared/teams/team/header/name-with-icon-wrapper/index.js
+++ b/shared/teams/team/header/name-with-icon-wrapper/index.js
@@ -1,9 +1,11 @@
 // @flow
 import * as React from 'react'
+import type {Response} from 'react-native-image-picker'
 
 export type Props = {
   canEditDescription: boolean,
-  onEditIcon: any => void,
+  onEditIcon: (image?: Response) => void,
+  onEditIconError: (error: string) => void,
   teamname: string,
   metaOne: React.Node,
   metaTwo: string,

--- a/shared/teams/team/header/name-with-icon-wrapper/index.js
+++ b/shared/teams/team/header/name-with-icon-wrapper/index.js
@@ -5,7 +5,7 @@ import type {Response} from 'react-native-image-picker'
 export type Props = {
   canEditDescription: boolean,
   onEditIcon: (image?: Response) => void,
-  onEditIconError: (error: string) => void,
+  onFilePickerError: (error: Error) => void,
   teamname: string,
   metaOne: React.Node,
   metaTwo: string,

--- a/shared/teams/team/header/name-with-icon-wrapper/index.native.js
+++ b/shared/teams/team/header/name-with-icon-wrapper/index.native.js
@@ -13,7 +13,7 @@ const NameWithIconWrapper = (props: Props) => {
             return
           }
           if (response.error) {
-            props.onEditIconError(response.error)
+            props.onFilePickerError(new Error(response.error))
             return
           }
           props.onEditIcon(response)

--- a/shared/teams/team/header/name-with-icon-wrapper/index.native.js
+++ b/shared/teams/team/header/name-with-icon-wrapper/index.native.js
@@ -13,8 +13,8 @@ const NameWithIconWrapper = (props: Props) => {
             return
           }
           if (response.error) {
-            console.error(response.error)
-            throw new Error(response.error)
+            props.onEditIconError(response.error)
+            return
           }
           props.onEditIcon(response)
         })


### PR DESCRIPTION
We're already doing this for chat attachments and KBFS file uploads. Do it for
editing profile/team avatars, too.