### PR TITLE
Chat layout fixes

### DIFF
--- a/shared/chat/conversation/conversation.css
+++ b/shared/chat/conversation/conversation.css
@@ -1,6 +1,6 @@
 .WrapperMessage-hoverBox {
-  padding-bottom: 2px;
-  padding-top: 2px;
+  padding-bottom: 3px;
+  padding-top: 3px;
   padding-left: 56px;
   padding-right: 16px;
   display: flex;

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -440,11 +440,11 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               this._messageAndButtons(),
               this._isEdited(),
               this._isFailed(),
-              this._sendIndicator(),
               this._unfurlPrompts(),
               this._unfurlList(),
               this._reactionsRow(),
             ]),
+            this._sendIndicator(),
             this._orangeLine(),
           ],
         })}

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -139,8 +139,9 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
             Cancel
           </Kb.Text>
         )}
-        {!!this.props.onCancel &&
-          (!!this.props.onEdit || !!this.props.onRetry) && <Kb.Text type="BodySmall"> or </Kb.Text>}
+        {!!this.props.onCancel && (!!this.props.onEdit || !!this.props.onRetry) && (
+          <Kb.Text type="BodySmall"> or </Kb.Text>
+        )}
         {!!this.props.onEdit && (
           <Kb.Text type="BodySmall" style={styles.failUnderline} onClick={this.props.onEdit}>
             Edit
@@ -215,11 +216,14 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
         : props
     } else {
       return {
-        className: Styles.classNames('WrapperMessage-hoverBox', {
-          'WrapperMessage-author': this.props.showUsername,
-          'WrapperMessage-decorated': this.props.decorate,
-          active: this.props.showingMenu || this.state.showingPicker,
-        }),
+        className: Styles.classNames(
+          {
+            'WrapperMessage-author': this.props.showUsername,
+            'WrapperMessage-decorated': this.props.decorate,
+            active: this.props.showingMenu || this.state.showingPicker,
+          },
+          'WrapperMessage-hoverBox'
+        ),
         onMouseOver: this._onMouseOver,
         // attach popups to the message itself
         ref: this.props.setAttachmentRef,
@@ -482,7 +486,7 @@ const styles = Styles.styleSheetCreate({
   }),
   contentUnderAuthorContainer: Styles.platformStyles({
     isElectron: {
-      marginTop: -18,
+      marginTop: -16,
       paddingLeft:
         // Space for below the avatar
         Styles.globalMargins.tiny + // right margin

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -205,7 +205,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
 
   _containerProps = () => {
     if (Styles.isMobile) {
-      const props = this.props.showUsername ? {} : {style: styles.containerNoUsername}
+      const props = {style: this.props.showUsername ? null : styles.containerNoUsername}
       return this.props.decorate
         ? {
             ...props,
@@ -463,6 +463,7 @@ const styles = Styles.styleSheetCreate({
       alignSelf: 'flex-start',
       height: Styles.globalMargins.mediumLarge,
     },
+    isMobile: {marginTop: 8},
   }),
   avatar: Styles.platformStyles({
     isElectron: {
@@ -475,13 +476,14 @@ const styles = Styles.styleSheetCreate({
   }),
   containerNoUsername: Styles.platformStyles({
     isMobile: {
-      paddingBottom: 2,
+      paddingBottom: 3,
       paddingLeft:
         // Space for below the avatar
         Styles.globalMargins.tiny + // right margin
         Styles.globalMargins.tiny + // left margin
         Styles.globalMargins.mediumLarge, // avatar
       paddingRight: Styles.globalMargins.tiny,
+      paddingTop: 3,
     },
   }),
   contentUnderAuthorContainer: Styles.platformStyles({
@@ -519,15 +521,19 @@ const styles = Styles.styleSheetCreate({
     isMobile: {height: 21},
   }),
   menuButtonsWithAuthor: {marginTop: -16},
-  orangeLine: {
-    // don't push down content due to orange line
-    backgroundColor: Styles.globalColors.orange,
-    height: 1,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
+  orangeLine: Styles.platformStyles({
+    common: {
+      // don't push down content due to orange line
+      backgroundColor: Styles.globalColors.orange,
+      flexShrink: 0,
+      height: 1,
+      left: 0,
+      position: 'absolute',
+      right: 0,
+    },
+    isElectron: {top: 0},
+    isMobile: {top: -2},
+  }),
   reactButton: Styles.platformStyles({
     isElectron: {width: 16},
   }),


### PR DESCRIPTION
- [x] padding between lines 3
- [x] more space between avatar and hover box bottom
- [x] send indicator is wrapped and can render null, but still is in box2 so it'd make an extra gap when it goes away. its pos absolute anyways so just move it where orange line is
- [x] orange line fixes for mobile