### PR TITLE
fix caching bug in ID2, wherein the mem cache wasn't primed

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -545,11 +545,18 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
 
+	// The fast cached should have been primed with the slow cache, so we expected
+	// a fast cache hit
+	runChatGUI()
+	if !tester.fastStats.eq(2, 1, 2, 0, 1) || !tester.slowStats.eq(1, 0, 2, 0, 1) {
+		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
+	}
+
 	tester.incNow(time.Second + libkb.Identify2CacheBrokenTimeout)
 	runChatGUI()
 
 	// After the broken timeout passes, we should get timeouts on both caches
-	if !tester.fastStats.eq(1, 2, 2, 0, 1) || !tester.slowStats.eq(1, 1, 2, 0, 1) {
+	if !tester.fastStats.eq(2, 2, 2, 0, 1) || !tester.slowStats.eq(1, 1, 2, 0, 1) {
 		t.Fatalf("bad cache stats: %+v, %+v", tester.fastStats, tester.slowStats)
 	}
 }

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -1016,7 +1016,7 @@ func (e *Identify2WithUID) loadUsers(m libkb.MetaContext) (err error) {
 
 func (e *Identify2WithUID) checkFastCacheHit(m libkb.MetaContext) (hit bool) {
 	prfx := fmt.Sprintf("Identify2WithUID#checkFastCacheHit(%s)", e.arg.Uid)
-	defer e.G().ExitTraceOK(prfx, func() bool { return hit })()
+	defer m.CExitTraceOK(prfx, func() bool { return hit })()
 	if e.getCache() == nil {
 		return false
 	}
@@ -1031,6 +1031,7 @@ func (e *Identify2WithUID) checkFastCacheHit(m libkb.MetaContext) (hit bool) {
 		m.CDebugf("| fast cache error for %s: %s", e.arg.Uid, err)
 	}
 	if u == nil {
+		m.CDebugf("| fast cache returning false on nil output")
 		return false
 	}
 	e.cachedRes = u
@@ -1045,7 +1046,7 @@ func (e *Identify2WithUID) dbKey(them keybase1.UID) libkb.DbKey {
 }
 
 func (e *Identify2WithUID) loadSlowCacheFromDB(m libkb.MetaContext) (ret *keybase1.Identify2ResUPK2) {
-	defer e.G().ExitTraceOK("Identify2WithUID#loadSlowCacheFromDB", func() bool { return ret != nil })()
+	defer m.CExitTraceOK("Identify2WithUID#loadSlowCacheFromDB", func() bool { return ret != nil })()
 
 	if e.getCache() != nil && !e.getCache().UseDiskCache() {
 		m.CDebugf("| Disk cached disabled")
@@ -1113,7 +1114,7 @@ func (e *Identify2WithUID) removeSlowCacheFromDB(m libkb.MetaContext) (err error
 
 func (e *Identify2WithUID) checkSlowCacheHit(m libkb.MetaContext) (ret bool) {
 	prfx := fmt.Sprintf("Identify2WithUID#checkSlowCacheHit(%s)", e.them.GetUID())
-	defer e.G().ExitTraceOK(prfx, func() bool { return ret })()
+	defer m.CExitTraceOK(prfx, func() bool { return ret })()
 
 	if e.getCache() == nil {
 		return false
@@ -1159,6 +1160,7 @@ func (e *Identify2WithUID) checkSlowCacheHit(m libkb.MetaContext) (ret bool) {
 
 	// Update so that it hits the fast cache the next time
 	u.Upk.Uvv.CachedAt = keybase1.ToTime(e.getNow(m))
+	e.getCache().Insert(u)
 	return true
 }
 

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -101,6 +101,9 @@ func (m MetaContext) CErrorf(f string, args ...interface{}) {
 func (m MetaContext) CInfof(f string, args ...interface{}) {
 	m.g.Log.CloneWithAddedDepth(1).CInfof(m.ctx, f, args...)
 }
+func (m MetaContext) CExitTraceOK(msg string, f func() bool) func() {
+	return func() { m.CDebugf("| %s -> %v", msg, f()) }
+}
 
 func (m MetaContext) ActiveDevice() *ActiveDevice {
 	if m.activeDevice != nil {


### PR DESCRIPTION
- use the DB cache to populate the mem cache
- test that it works; this test breaks without the fix
- add some better logging with context