### PR TITLE
scraper cache

### DIFF
--- a/go/chat/unfurl/cache.go
+++ b/go/chat/unfurl/cache.go
@@ -1,0 +1,72 @@
+package unfurl
+
+import (
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/clockwork"
+)
+
+const defaultCacheLifetime = 10 * time.Minute
+const defaultCacheSize = 1000
+
+type cacheItem struct {
+	data  interface{}
+	err   error
+	ctime gregor1.Time
+}
+
+type unfurlCache struct {
+	sync.Mutex
+	cache *lru.Cache
+	clock clockwork.Clock
+}
+
+func newUnfurlCache() *unfurlCache {
+	cache, err := lru.New(defaultCacheSize)
+	if err != nil {
+		panic(err)
+	}
+	return &unfurlCache{
+		cache: cache,
+		clock: clockwork.NewRealClock(),
+	}
+}
+
+func (c *unfurlCache) setClock(clock clockwork.Clock) {
+	c.clock = clock
+}
+
+// get determines if the item is in the cache and newer than 10
+// minutes. We don't want to cache this value indefinitely in case the page
+// content changes.
+func (c *unfurlCache) get(key string) (res cacheItem, ok bool) {
+	c.Lock()
+	defer c.Unlock()
+
+	item, ok := c.cache.Get(key)
+	if !ok {
+		return res, false
+	}
+	cacheItem, ok := item.(cacheItem)
+	if !ok {
+		return res, false
+	}
+	valid := c.clock.Now().Sub(cacheItem.ctime.Time()) <= defaultCacheLifetime
+	if !valid {
+		c.cache.Remove(key)
+	}
+	return cacheItem, valid
+}
+
+func (c *unfurlCache) put(key string, data interface{}, err error) {
+	c.Lock()
+	defer c.Unlock()
+	c.cache.Add(key, cacheItem{
+		err:   err,
+		data:  data,
+		ctime: gregor1.ToTime(c.clock.Now()),
+	})
+}

--- a/go/chat/unfurl/packager.go
+++ b/go/chat/unfurl/packager.go
@@ -235,7 +235,15 @@ func (p *Packager) packageGiphy(ctx context.Context, uid gregor1.UID, convID cha
 }
 
 func (p *Packager) cacheKey(uid gregor1.UID, convID chat1.ConversationID, raw chat1.UnfurlRaw) string {
-	return fmt.Sprintf("%s-%s-%s", uid, convID, raw.GetUrl())
+	url := raw.GetUrl()
+	if url == "" {
+		return ""
+	}
+	typ, err := raw.UnfurlType()
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s-%s-%s", uid, convID, url, typ)
 }
 
 func (p *Packager) Package(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,

--- a/go/chat/unfurl/packager_test.go
+++ b/go/chat/unfurl/packager_test.go
@@ -70,6 +70,7 @@ func TestPackager(t *testing.T) {
 	imageURL := fmt.Sprintf("http://%s/?typ=image", addr)
 	faviconURL := fmt.Sprintf("http://%s/?typ=favicon", addr)
 	raw := chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
+		Url:        "https://example.com",
 		ImageUrl:   &imageURL,
 		FaviconUrl: &faviconURL,
 	})

--- a/go/chat/unfurl/scraper_test.go
+++ b/go/chat/unfurl/scraper_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,19 +82,25 @@ func createTestCaseHTTPSrv(t *testing.T) *dummyHTTPSrv {
 
 func TestScraper(t *testing.T) {
 	scraper := NewScraper(logger.NewTestLogger(t))
+
+	clock := clockwork.NewFakeClock()
+	scraper.cache.setClock(clock)
+
 	srv := createTestCaseHTTPSrv(t)
 	addr := srv.Start()
 	defer srv.Stop()
 	forceGiphy := new(chat1.UnfurlType)
 	*forceGiphy = chat1.UnfurlType_GIPHY
 	testCase := func(name string, expected chat1.UnfurlRaw, forceTyp *chat1.UnfurlType) {
-		res, err := scraper.Scrape(context.TODO(), "http://"+addr+"/?name="+name, forceTyp)
+		uri := fmt.Sprintf("http://%s/?name=%s", addr, name)
+		res, err := scraper.Scrape(context.TODO(), uri, forceTyp)
 		require.NoError(t, err)
 		etyp, err := expected.UnfurlType()
 		require.NoError(t, err)
 		rtyp, err := res.UnfurlType()
 		require.NoError(t, err)
 		require.Equal(t, etyp, rtyp)
+
 		t.Logf("expected:\n%v\n\nactual:\n%v", expected, res)
 		switch rtyp {
 		case chat1.UnfurlType_GENERIC:
@@ -134,7 +141,18 @@ func TestScraper(t *testing.T) {
 		default:
 			require.Fail(t, "unknown unfurl typ")
 		}
+
+		// test caching
+		cachedRes, valid := scraper.cache.get(uri)
+		require.True(t, valid)
+		require.NoError(t, cachedRes.err)
+		require.Equal(t, res, cachedRes.data.(chat1.UnfurlRaw))
+
+		clock.Advance(defaultCacheLifetime * 2)
+		cachedRes, valid = scraper.cache.get(uri)
+		require.False(t, valid)
 	}
+
 	testCase("cnn0", chat1.NewUnfurlRawWithGeneric(chat1.UnfurlGenericRaw{
 		Title:       "Kanye West seeks separation from politics",
 		Url:         "https://www.cnn.com/2018/10/30/entertainment/kanye-west-politics/index.html",

--- a/go/chat/unfurl/unfurler.go
+++ b/go/chat/unfurl/unfurler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/clockwork"
 )
 
 type unfurlTask struct {
@@ -67,6 +68,11 @@ func NewUnfurler(g *globals.Context, store attachments.Store, s3signer s3.Signer
 		settings:     settings,
 		sender:       sender,
 	}
+}
+
+func (u *Unfurler) SetClock(clock clockwork.Clock) {
+	u.scraper.cache.setClock(clock)
+	u.packager.cache.setClock(clock)
 }
 
 func (u *Unfurler) SetTestingRetryCh(ch chan struct{}) {

--- a/go/chat/unfurl/utils.go
+++ b/go/chat/unfurl/utils.go
@@ -58,10 +58,3 @@ func ClassifyDomain(domain string) chat1.UnfurlType {
 	}
 	return chat1.UnfurlType_GENERIC
 }
-
-func ClassifyDomainFromURI(uri string) (typ chat1.UnfurlType, domain string, err error) {
-	if domain, err = GetDomain(uri); err != nil {
-		return typ, domain, err
-	}
-	return ClassifyDomain(domain), domain, nil
-}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1874,6 +1874,20 @@ func (idx *ConversationIndex) PercentIndexed(conv Conversation) int {
 	return 100 * (1 - (len(missingIDs) / numMessages))
 }
 
+func (u UnfurlRaw) GetUrl() string {
+	typ, err := u.UnfurlType()
+	if err != nil {
+		return ""
+	}
+	switch typ {
+	case UnfurlType_GENERIC:
+		return u.Generic().Url
+	case UnfurlType_GIPHY:
+		return u.Giphy().ImageUrl
+	}
+	return ""
+}
+
 func (u UnfurlRaw) UnsafeDebugString() string {
 	typ, err := u.UnfurlType()
 	if err != nil {

--- a/protocol/avdl/chat1/unfurl.avdl
+++ b/protocol/avdl/chat1/unfurl.avdl
@@ -3,6 +3,8 @@
 protocol unfurl {
     import idl "common.avdl";
 
+    // NOTE if adding a new type here, also add the case to the
+    // `UnfurlRaw.GetURL` type since a URL is used as a key for caching
     enum UnfurlType {
       GENERIC_0,
       YOUTUBE_1,


### PR DESCRIPTION
caches the scraper and packager with a time based cache so we don't pump out stale values. prefetch mode up next so populate the cache during message compose