### PR TITLE
Use forked react-native-image-picker

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -157,7 +157,7 @@
     "react-native-camera": "1.4.3",
     "react-native-contacts": "2.2.4",
     "react-native-fast-image": "5.1.1",
-    "react-native-image-picker": "0.27.1",
+    "react-native-image-picker": "git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes",
     "react-native-mime-types": "2.2.1",
     "react-native-push-notification": "git://github.com/keybase/react-native-push-notification#keybase-fixes-off-311",
     "react-navigation": "git://github.com/keybase/react-navigation#keybase-fixes-off-beta-12",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -9710,11 +9710,6 @@ react-native-fast-image@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-5.1.1.tgz#2595323a926ade0b3a37bd627eb55e3ebf67598b"
 
-react-native-image-picker@^0.27.1:
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-0.27.1.tgz#32877c667e8c2713466fe178a6c7dd648e6cb5d3"
-  integrity sha512-LuEt5I9TFe3+lfN8E9geuN2OOgnld0QmeHRPTCV+mzkT5zASsoibNIUItt6WQBWG4nXC/90aufQYZn92i3lTxw==
-
 "react-native-image-picker@git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes":
   version "0.27.1"
   resolved "git://github.com/keybase/react-native-image-picker#389b4c1363babf0e2b059c9896836e8a934b468f"

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -9710,9 +9710,14 @@ react-native-fast-image@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-5.1.1.tgz#2595323a926ade0b3a37bd627eb55e3ebf67598b"
 
-react-native-image-picker@0.27.1:
+react-native-image-picker@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-0.27.1.tgz#32877c667e8c2713466fe178a6c7dd648e6cb5d3"
+  integrity sha512-LuEt5I9TFe3+lfN8E9geuN2OOgnld0QmeHRPTCV+mzkT5zASsoibNIUItt6WQBWG4nXC/90aufQYZn92i3lTxw==
+
+"react-native-image-picker@git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes":
+  version "0.27.1"
+  resolved "git://github.com/keybase/react-native-image-picker#389b4c1363babf0e2b059c9896836e8a934b468f"
 
 react-native-mime-types@2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This makes it ask for only camera or camera roll permissions.