### PR TITLE
More chat layout fixes

### DIFF
--- a/shared/chat/conversation/messages/reactions-row/index.js
+++ b/shared/chat/conversation/messages/reactions-row/index.js
@@ -100,7 +100,7 @@ class ReactionsRow extends React.Component<Props, State> {
 }
 
 const styles = styleSheetCreate({
-  button: {marginBottom: globalMargins.tiny},
+  button: {marginBottom: globalMargins.tiny, marginTop: globalMargins.tiny},
   container: {
     alignItems: 'flex-start',
     flexWrap: 'wrap',

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -109,7 +109,6 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
             direction="vertical"
             fullWidth={true}
             style={styles.contentUnderAuthorContainer}
-            gap="tiny"
           >
             {children}
           </Kb.Box2>
@@ -205,7 +204,9 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
 
   _containerProps = () => {
     if (Styles.isMobile) {
-      const props = {style: this.props.showUsername ? null : styles.containerNoUsername}
+      const props = {
+        style: this.props.showUsername ? null : styles.containerNoUsername,
+      }
       return this.props.decorate
         ? {
             ...props,
@@ -460,6 +461,7 @@ const fast = {backgroundColor: Styles.globalColors.fastBlank}
 const styles = Styles.styleSheetCreate({
   authorContainer: Styles.platformStyles({
     common: {
+      alignItems: 'flex-start',
       alignSelf: 'flex-start',
       height: Styles.globalMargins.mediumLarge,
     },
@@ -521,19 +523,16 @@ const styles = Styles.styleSheetCreate({
     isMobile: {height: 21},
   }),
   menuButtonsWithAuthor: {marginTop: -16},
-  orangeLine: Styles.platformStyles({
-    common: {
-      // don't push down content due to orange line
-      backgroundColor: Styles.globalColors.orange,
-      flexShrink: 0,
-      height: 1,
-      left: 0,
-      position: 'absolute',
-      right: 0,
-    },
-    isElectron: {top: 0},
-    isMobile: {top: -2},
-  }),
+  orangeLine: {
+    // don't push down content due to orange line
+    backgroundColor: Styles.globalColors.orange,
+    flexShrink: 0,
+    height: Styles.hairlineWidth,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
   reactButton: Styles.platformStyles({
     isElectron: {width: 16},
   }),

--- a/shared/chat/conversation/messages/wrapper/unfurl/generic/index.js
+++ b/shared/chat/conversation/messages/wrapper/unfurl/generic/index.js
@@ -26,9 +26,9 @@ class UnfurlGeneric extends React.Component<Props> {
         {!Styles.isMobile && <Kb.Box2 direction="horizontal" style={styles.quoteContainer} />}
         <Kb.Box2 style={styles.innerContainer} gap="xxtiny" direction="vertical">
           <Kb.Box2 style={styles.siteNameContainer} gap="tiny" fullWidth={true} direction="horizontal">
-            <Kb.Box2 direction="horizontal" gap="tiny">
-              {!!this.props.faviconURL && <Kb.Image src={this.props.faviconURL} style={styles.favicon} />}
-              <Kb.Text type="BodySmall">
+            {!!this.props.faviconURL && <Kb.Image src={this.props.faviconURL} style={styles.favicon} />}
+            <Kb.BoxGrow>
+              <Kb.Text type="BodySmall" lineClamp={1}>
                 {this.props.siteName}
                 {!!this.props.publishTime && (
                   <Kb.Text type="BodySmall">
@@ -37,7 +37,7 @@ class UnfurlGeneric extends React.Component<Props> {
                   </Kb.Text>
                 )}
               </Kb.Text>
-            </Kb.Box2>
+            </Kb.BoxGrow>
             {!!this.props.onClose && (
               <Kb.Icon
                 type="iconfont-close"
@@ -51,7 +51,11 @@ class UnfurlGeneric extends React.Component<Props> {
           <Kb.Text type="BodyPrimaryLink" style={styles.url} onClickURL={this.props.url}>
             {this.props.title}
           </Kb.Text>
-          {!!this.props.description && <Kb.Text type="Body" lineClamp={5}>{this.props.description}</Kb.Text>}
+          {!!this.props.description && (
+            <Kb.Text type="Body" lineClamp={5}>
+              {this.props.description}
+            </Kb.Text>
+          )}
           {!!this.props.imageURL &&
             !!this.props.imageHeight &&
             !!this.props.imageWidth &&
@@ -66,9 +70,9 @@ class UnfurlGeneric extends React.Component<Props> {
               />
             )}
         </Kb.Box2>
-        {!!this.props.imageURL &&
-          !Styles.isMobile &&
-          this.props.showImageOnSide && <Kb.Image src={this.props.imageURL} style={styles.sideImage} />}
+        {!!this.props.imageURL && !Styles.isMobile && this.props.showImageOnSide && (
+          <Kb.Image src={this.props.imageURL} style={styles.sideImage} />
+        )}
       </Kb.Box2>
     )
   }
@@ -90,9 +94,6 @@ const styles = Styles.styleSheetCreate({
     },
     isElectron: {
       maxWidth: 500,
-    },
-    isMobile: {
-      paddingRight: 66,
     },
   }),
   favicon: Styles.platformStyles({
@@ -130,7 +131,6 @@ const styles = Styles.styleSheetCreate({
   siteNameContainer: Styles.platformStyles({
     common: {
       alignSelf: 'flex-start',
-      justifyContent: 'space-between',
     },
   }),
   url: {

--- a/shared/chat/conversation/messages/wrapper/unfurl/giphy/index.js
+++ b/shared/chat/conversation/messages/wrapper/unfurl/giphy/index.js
@@ -53,9 +53,6 @@ const styles = Styles.styleSheetCreate({
     isElectron: {
       maxWidth: 500,
     },
-    isMobile: {
-      paddingRight: 0,
-    },
   }),
   favicon: {
     borderRadius: Styles.borderRadius,


### PR DESCRIPTION
- [x] fix orange line on mobile
- [x] remove extra padding on unfurls on mobile
- [x] remove gaps between children (edited etc)
- [x] clamp unfurl timestamps (goes outside on iphone 5s)

@keybase/react-hackers @cecileboucheron cc: @mmaxim 