### PR TITLE
Restart the six-second disclaimer timer after clicking away

### DIFF
--- a/shared/wallets/onboarding/disclaimer.js
+++ b/shared/wallets/onboarding/disclaimer.js
@@ -54,7 +54,7 @@ class Disclaimer extends React.Component<DisclaimerProps, DisclaimerState> {
   }
 
   componentDidUpdate(prevProps: DisclaimerProps) {
-    if (this.props.acceptingDisclaimerDelay && !prevProps.acceptingDisclaimerDelay) {
+    if (this.props.acceptingDisclaimerDelay && !this.afterTimer) {
       // Start the after countdown
       this.afterTimer = addTicker(this.afterTick)
     }


### PR DESCRIPTION
@keybase/react-hackers 

In the case where you start the six-second timer after accepting the Stellar disclaimer, then click to a different nav tab while it's running, then go back to the Stellar tab, you'd end up seeing "Opening your Wallet (6)" forever because the timer wasn't restarted the next time around.