### PR TITLE
Remove compression from gregor1.outgoing

### DIFF
--- a/go/protocol/gregor1/outgoing.go
+++ b/go/protocol/gregor1/outgoing.go
@@ -45,6 +45,6 @@ type OutgoingClient struct {
 
 func (c OutgoingClient) BroadcastMessage(ctx context.Context, m Message) (err error) {
 	__arg := BroadcastMessageArg{M: m}
-	err = c.Cli.CallCompressed(ctx, "gregor.1.outgoing.broadcastMessage", []interface{}{__arg}, nil, rpc.CompressionGzip)
+	err = c.Cli.Call(ctx, "gregor.1.outgoing.broadcastMessage", []interface{}{__arg}, nil)
 	return
 }

--- a/protocol/avdl/gregor1/outgoing.avdl
+++ b/protocol/avdl/gregor1/outgoing.avdl
@@ -1,5 +1,4 @@
 @namespace("gregor.1")
-@compression_type("gzip")
 protocol outgoing {
   void broadcastMessage(Message m);
 }

--- a/protocol/json/gregor1/outgoing.json
+++ b/protocol/json/gregor1/outgoing.json
@@ -13,6 +13,5 @@
       "response": null
     }
   },
-  "namespace": "gregor.1",
-  "compression_type": "gzip"
+  "namespace": "gregor.1"
 }


### PR DESCRIPTION
We need to let clients bake several release cycles with support for compression before enabling this on the server