### PR TITLE
add prereq to pgp import key for standardized and better error message

### DIFF
--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -110,7 +110,9 @@ func (e *PGPKeyImportEngine) Name() string {
 }
 
 func (e *PGPKeyImportEngine) Prereqs() Prereqs {
-	return Prereqs{}
+	return Prereqs{
+		Device: true,
+	}
 }
 
 func (e *PGPKeyImportEngine) RequiredUIs() []libkb.UIKind {

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -110,9 +110,7 @@ func (e *PGPKeyImportEngine) Name() string {
 }
 
 func (e *PGPKeyImportEngine) Prereqs() Prereqs {
-	return Prereqs{
-		Device: true,
-	}
+	return Prereqs{}
 }
 
 func (e *PGPKeyImportEngine) RequiredUIs() []libkb.UIKind {
@@ -158,6 +156,10 @@ func (e *PGPKeyImportEngine) Run(m libkb.MetaContext) (err error) {
 	}
 
 	if err = e.loadMe(m); err != nil {
+		switch err.(type) {
+		case libkb.SelfNotFoundError:
+			err = libkb.LoginRequiredError{}
+		}
 		return err
 	}
 
@@ -170,6 +172,10 @@ func (e *PGPKeyImportEngine) Run(m libkb.MetaContext) (err error) {
 			return err
 		}
 		if err = e.loadDelegator(m); err != nil {
+			switch err.(type) {
+			case libkb.NoUsernameError:
+				err = libkb.LoginRequiredError{}
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
`keybase pgp gen --multi` from a logged out device and from a deprovisioned device give weird error messages. adding in this prereq (like most of the other pgp engines) standardizes the error message with something a little more helpful: "Login required."