### PR TITLE
on deprovision ensure we ignore the just revoked name

### DIFF
--- a/shared/reducers/config.js
+++ b/shared/reducers/config.js
@@ -4,14 +4,25 @@ import * as I from 'immutable'
 import * as Types from '../constants/types/config'
 import * as Constants from '../constants/config'
 import * as ChatConstants from '../constants/chat2'
+import * as DevicesGen from '../actions/devices-gen'
 import * as ConfigGen from '../actions/config-gen'
 import * as Stats from '../engine/stats'
 import {isEOFError, isErrorTransient} from '../util/errors'
 
 const initialState = Constants.makeState()
 
-export default function(state: Types.State = initialState, action: ConfigGen.Actions): Types.State {
+export default function(
+  state: Types.State = initialState,
+  action: ConfigGen.Actions | DevicesGen.RevokedPayload
+): Types.State {
   switch (action.type) {
+    case DevicesGen.revoked:
+      return state.merge({
+        configuredAccounts: state.configuredAccounts,
+        defaultUsername: action.payload.wasCurrentDevice // if revoking self find another name if it exists
+          ? state.configuredAccounts.find(n => n !== state.defaultUsername) || ''
+          : state.defaultUsername,
+      })
     case ConfigGen.resetStore:
       return initialState.merge({
         appFocused: state.appFocused,
@@ -174,9 +185,15 @@ export default function(state: Types.State = initialState, action: ConfigGen.Act
     case ConfigGen.updateMenubarWindowID:
       return state.merge({menubarWindowID: action.payload.id})
     case ConfigGen.setAccounts:
+      // already have one?
+      let defaultUsername = state.defaultUsername
+      if (action.payload.usernames.indexOf(defaultUsername) === -1) {
+        defaultUsername = action.payload.defaultUsername
+      }
+
       return state.merge({
         configuredAccounts: I.List(action.payload.usernames),
-        defaultUsername: state.defaultUsername || action.payload.defaultUsername, // keep it if we have one
+        defaultUsername,
       })
     case ConfigGen.setDeletedSelf:
       return state.merge({justDeletedSelf: action.payload.deletedUsername})


### PR DESCRIPTION
@keybase/react-hackers 
to test just deprovision yourself. before your username would be in the dropdown and you'd have to change it, now it should select another name or be blank