### PR TITLE
Fix hint text placeholder on Android passphrase prompt

### DIFF
--- a/shared/provision/passphrase/index.native.js
+++ b/shared/provision/passphrase/index.native.js
@@ -25,7 +25,7 @@ class Passphrase extends Component<Props> {
             inputProps={{
               autoFocus: true,
               errorText: this.props.error,
-              floatingHintTextOverride: 'Passphrase',
+              hintText: 'Passphrase',
               onChangeText: t => this.props.onChange(t),
               onEnterKeyDown: this.props.onSubmit,
               type: showTyping ? 'passwordVisible' : 'password',


### PR DESCRIPTION
@keybase/react-hackers 

The placeholder when you haven't typed anything yet is keyed off `hintText`, which was missing here.  No need for the override if we're providing it.