### PR TITLE
dont cache scraper/packager errors

### DIFF
--- a/go/chat/unfurl/cache.go
+++ b/go/chat/unfurl/cache.go
@@ -14,7 +14,6 @@ const defaultCacheSize = 1000
 
 type cacheItem struct {
 	data  interface{}
-	err   error
 	ctime gregor1.Time
 }
 
@@ -61,11 +60,10 @@ func (c *unfurlCache) get(key string) (res cacheItem, ok bool) {
 	return cacheItem, valid
 }
 
-func (c *unfurlCache) put(key string, data interface{}, err error) {
+func (c *unfurlCache) put(key string, data interface{}) {
 	c.Lock()
 	defer c.Unlock()
 	c.cache.Add(key, cacheItem{
-		err:   err,
 		data:  data,
 		ctime: gregor1.ToTime(c.clock.Now()),
 	})

--- a/go/chat/unfurl/packager.go
+++ b/go/chat/unfurl/packager.go
@@ -253,11 +253,11 @@ func (p *Packager) Package(ctx context.Context, uid gregor1.UID, convID chat1.Co
 	cacheKey := p.cacheKey(uid, convID, raw)
 	if item, valid := p.cache.get(cacheKey); cacheKey != "" && valid {
 		p.Debug(ctx, "Package: using cached value")
-		return item.data.(chat1.Unfurl), item.err
+		return item.data.(chat1.Unfurl), nil
 	}
 	defer func() {
 		if cacheKey != "" {
-			p.cache.put(cacheKey, res, err)
+			p.cache.put(cacheKey, res)
 		}
 	}()
 

--- a/go/chat/unfurl/packager.go
+++ b/go/chat/unfurl/packager.go
@@ -256,7 +256,7 @@ func (p *Packager) Package(ctx context.Context, uid gregor1.UID, convID chat1.Co
 		return item.data.(chat1.Unfurl), nil
 	}
 	defer func() {
-		if cacheKey != "" && err != nil {
+		if cacheKey != "" && err == nil {
 			p.cache.put(cacheKey, res)
 		}
 	}()

--- a/go/chat/unfurl/packager.go
+++ b/go/chat/unfurl/packager.go
@@ -256,7 +256,7 @@ func (p *Packager) Package(ctx context.Context, uid gregor1.UID, convID chat1.Co
 		return item.data.(chat1.Unfurl), nil
 	}
 	defer func() {
-		if cacheKey != "" {
+		if cacheKey != "" && err != nil {
 			p.cache.put(cacheKey, res)
 		}
 	}()

--- a/go/chat/unfurl/packager_test.go
+++ b/go/chat/unfurl/packager_test.go
@@ -92,7 +92,6 @@ func TestPackager(t *testing.T) {
 	cacheKey := packager.cacheKey(uid, convID, raw)
 	cachedRes, valid := packager.cache.get(cacheKey)
 	require.True(t, valid)
-	require.NoError(t, cachedRes.err)
 	require.Equal(t, res, cachedRes.data.(chat1.Unfurl))
 
 	clock.Advance(defaultCacheLifetime * 2)

--- a/go/chat/unfurl/scraper.go
+++ b/go/chat/unfurl/scraper.go
@@ -41,7 +41,7 @@ func (s *Scraper) Scrape(ctx context.Context, uri string, forceTyp *chat1.Unfurl
 		return item.data.(chat1.UnfurlRaw), nil
 	}
 	defer func() {
-		if err != nil {
+		if err == nil {
 			s.cache.put(uri, res)
 		}
 	}()

--- a/go/chat/unfurl/scraper.go
+++ b/go/chat/unfurl/scraper.go
@@ -38,10 +38,10 @@ func (s *Scraper) Scrape(ctx context.Context, uri string, forceTyp *chat1.Unfurl
 	// Check if we have a cached valued
 	if item, valid := s.cache.get(uri); valid {
 		s.Debug(ctx, "Scape: using cached value")
-		return item.data.(chat1.UnfurlRaw), item.err
+		return item.data.(chat1.UnfurlRaw), nil
 	}
 	defer func() {
-		s.cache.put(uri, res, err)
+		s.cache.put(uri, res)
 	}()
 
 	domain, err := GetDomain(uri)

--- a/go/chat/unfurl/scraper.go
+++ b/go/chat/unfurl/scraper.go
@@ -41,7 +41,9 @@ func (s *Scraper) Scrape(ctx context.Context, uri string, forceTyp *chat1.Unfurl
 		return item.data.(chat1.UnfurlRaw), nil
 	}
 	defer func() {
-		s.cache.put(uri, res)
+		if err != nil {
+			s.cache.put(uri, res)
+		}
 	}()
 
 	domain, err := GetDomain(uri)

--- a/go/chat/unfurl/scraper_test.go
+++ b/go/chat/unfurl/scraper_test.go
@@ -145,7 +145,6 @@ func TestScraper(t *testing.T) {
 		// test caching
 		cachedRes, valid := scraper.cache.get(uri)
 		require.True(t, valid)
-		require.NoError(t, cachedRes.err)
 		require.Equal(t, res, cachedRes.data.(chat1.UnfurlRaw))
 
 		clock.Advance(defaultCacheLifetime * 2)


### PR DESCRIPTION
If we want to do this, we will need some system to detect "permanent" errors so we don't sabotage the unfurl retry process. For now let's just cache successes only.