### PR TITLE
Fix CircleCI by using forked versions of dependencies

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -152,7 +152,7 @@
     "react-measure": "2.1.3",
     "react-native": "0.57.7",
     "react-native-camera": "1.4.3",
-    "react-native-contacts": "2.2.4",
+    "react-native-contacts": "git://github.com/keybase/react-native-contacts#keybase-fixes-off-2.2.4",
     "react-native-fast-image": "5.1.1",
     "react-native-image-picker": "git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes",
     "react-native-mime-types": "2.2.1",

--- a/shared/package.json
+++ b/shared/package.json
@@ -166,7 +166,7 @@
     "recompose": "0.30.0",
     "redux": "4.0.1",
     "redux-saga": "0.16.2",
-    "rn-fetch-blob": "0.10.13",
+    "rn-fetch-blob": "git://github.com/keybase/rn-fetch-blob#v0.10.13-with-keybase-fixes",
     "shallowequal": "1.1.0",
     "simple-markdown": "0.4.2",
     "tlds": "1.203.1",

--- a/shared/package.json
+++ b/shared/package.json
@@ -153,7 +153,7 @@
     "react-native": "0.57.7",
     "react-native-camera": "1.4.3",
     "react-native-contacts": "git://github.com/keybase/react-native-contacts#keybase-fixes-off-2.2.4",
-    "react-native-fast-image": "5.1.1",
+    "react-native-fast-image": "git://github.com/keybase/react-native-fast-image#v5.1.1-with-keybase-fixes",
     "react-native-image-picker": "git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes",
     "react-native-mime-types": "2.2.1",
     "react-native-push-notification": "git://github.com/keybase/react-native-push-notification#keybase-fixes-off-311",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10847,9 +10847,9 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rn-fetch-blob@0.10.13:
+"rn-fetch-blob@git://github.com/keybase/rn-fetch-blob#v0.10.13-with-keybase-fixes":
   version "0.10.13"
-  resolved "https://registry.yarnpkg.com/rn-fetch-blob/-/rn-fetch-blob-0.10.13.tgz#e0fd5eac1a3a872563b35061353d96c4e51ae1cc"
+  resolved "git://github.com/keybase/rn-fetch-blob#77c376c8b7f357cf7fbc6559410076e6fb54b712"
   dependencies:
     base-64 "0.1.0"
     glob "7.0.6"

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10166,9 +10166,9 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
-react-native-fast-image@5.1.1:
+"react-native-fast-image@git://github.com/keybase/react-native-fast-image#v5.1.1-with-keybase-fixes":
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-5.1.1.tgz#2595323a926ade0b3a37bd627eb55e3ebf67598b"
+  resolved "git://github.com/keybase/react-native-fast-image#baeb432b220dd36fc03a30f9c0ea50a96a5ac8a9"
 
 "react-native-image-picker@git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes":
   version "0.27.1"

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10172,7 +10172,7 @@ react-native-fast-image@5.1.1:
 
 "react-native-image-picker@git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes":
   version "0.27.1"
-  resolved "git://github.com/keybase/react-native-image-picker#389b4c1363babf0e2b059c9896836e8a934b468f"
+  resolved "git://github.com/keybase/react-native-image-picker#ec2bac4e2d55571d7bce8b509de160b75e495e22"
 
 react-native-mime-types@2.2.1:
   version "2.2.1"

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10146,9 +10146,9 @@ react-native-camera@1.4.3:
     lodash "^4.17.10"
     prop-types "^15.6.2"
 
-react-native-contacts@2.2.4:
+"react-native-contacts@git://github.com/keybase/react-native-contacts#keybase-fixes-off-2.2.4":
   version "2.2.4"
-  resolved "https://registry.yarnpkg.com/react-native-contacts/-/react-native-contacts-2.2.4.tgz#6038aefdae6725073536e40bd350bcf255e48062"
+  resolved "git://github.com/keybase/react-native-contacts#31e64fab8ae66833d8171624a9e6a900d628a129"
 
 react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
These dependencies were using gradle 2.x, which disappeared from
jcenter.