### PR TITLE
cleanup tmp files when listing all keys

### DIFF
--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -234,7 +234,7 @@ func (s *DeviceEKStorage) getCache(ctx context.Context) (cache deviceEKCache, er
 	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#getCache", func() error { return err })()
 
 	if !s.indexed {
-		keys, err := s.storage.AllKeys(ctx)
+		keys, err := s.storage.AllKeys(ctx, deviceEKSuffix)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +335,7 @@ func (s *DeviceEKStorage) ListAllForUser(ctx context.Context) (all []string, err
 
 func (s *DeviceEKStorage) listAllForUser(ctx context.Context, username libkb.NormalizedUsername) (all []string, err error) {
 	// key in the sense of a key-value pair, not a crypto key!
-	keys, err := s.storage.AllKeys(ctx)
+	keys, err := s.storage.AllKeys(ctx, deviceEKSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +497,7 @@ func (s *DeviceEKStorage) getExpiredGenerations(ctx context.Context, keyMap keyE
 func (s *DeviceEKStorage) deletedWrongEldestSeqno(ctx context.Context) (err error) {
 	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#deletedWrongEldestSeqno", func() error { return err })()
 
-	keys, err := s.storage.AllKeys(ctx)
+	keys, err := s.storage.AllKeys(ctx, deviceEKSuffix)
 	if err != nil {
 		return err
 	}

--- a/go/erasablekv/erasable_kv_store_test.go
+++ b/go/erasablekv/erasable_kv_store_test.go
@@ -23,14 +23,13 @@ func TestErasableKVStore(t *testing.T) {
 	s := NewFileErasableKVStore(tc.G, subDir)
 	key := "test-key.key"
 	expected := "value"
-	var val string
-
 	err = s.Put(context.Background(), key, expected)
 	require.NoError(t, err)
 
-	err = s.Get(context.Background(), key, val)
-	require.Error(t, err)
-	require.NotEqual(t, expected, val)
+	var val string
+	err = s.Get(context.Background(), key, &val)
+	require.NoError(t, err)
+	require.Equal(t, expected, val)
 
 	// create a tmp file in the storage dir, ensure we clean it up when calling
 	// `AllKeys`
@@ -59,7 +58,7 @@ func TestErasableKVStore(t *testing.T) {
 	require.NoError(t, err)
 
 	var corrupt string
-	err = s.Get(context.Background(), key, corrupt)
+	err = s.Get(context.Background(), key, &corrupt)
 	require.Error(t, err)
 	uerr, ok := err.(UnboxError)
 	require.True(t, ok)

--- a/go/erasablekv/erasable_kv_store_test.go
+++ b/go/erasablekv/erasable_kv_store_test.go
@@ -35,12 +35,16 @@ func TestErasableKVStore(t *testing.T) {
 	// `AllKeys`
 	tmp, err := ioutil.TempFile(s.storageDir, key)
 	require.NoError(t, err)
-	keys, err := s.AllKeys(context.Background(), ".key")
-	require.NoError(t, err)
-	require.Equal(t, []string{key}, keys)
-	exists, err := libkb.FileExists(tmp.Name())
-	require.False(t, exists)
-	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		keys, err := s.AllKeys(context.Background(), ".key")
+		require.NoError(t, err)
+		require.Equal(t, []string{key}, keys)
+		exists, err := libkb.FileExists(tmp.Name())
+		require.NoError(t, err)
+		if !exists {
+			break
+		}
+	}
 
 	// Test noise file corruption
 	noiseName := fmt.Sprintf("%s%s", key, noiseSuffix)
@@ -68,7 +72,7 @@ func TestErasableKVStore(t *testing.T) {
 	err = s.Erase(context.Background(), key)
 	require.NoError(t, err)
 
-	keys, err = s.AllKeys(context.Background(), ".key")
+	keys, err := s.AllKeys(context.Background(), ".key")
 	require.NoError(t, err)
 	require.Equal(t, []string(nil), keys)
 }


### PR DESCRIPTION
Cleanup tmp files in `eraseablekv` storage if they happen to slip through (if the app is killed during a write). 