### PR TITLE
Surya/nil/linux changelog

### DIFF
--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -32,10 +32,13 @@ be corrupt repo metadata for everyone on Ubuntu/Deb/RPM.
 
 If you need to forcibly skip CI, set NOWAIT=1 in the environment.
 
-If you want to test the build without pushing live, set
-KEYBASE_DRY_RUN=1 in the environment. Be very careful not to typo that
-variable. You should see "This build+push is a DRY RUN." after all the
-git fetches in the build output, if you did this right.
+If you want to test the build without pushing live, set KEYBASE_DRY_RUN=1 in
+the environment. Be very careful not to typo that variable. You should see
+"This build+push is a DRY RUN." after all the git fetches in the build output,
+if you did this right. A dry run will push the package to the s3 bucket
+jack-testing.keybase.io, but this is not exposed on the internet.  You
+could copy the repo to somewhere in prerelease.keybase.io to test a `yum
+install`, for example.
 
 == Making changes ==
 

--- a/packaging/linux/build_and_push_packages.sh
+++ b/packaging/linux/build_and_push_packages.sh
@@ -18,7 +18,15 @@ kbfs_dir="$client_dir/../kbfs"
 
 if [ "${KEYBASE_DRY_RUN:-}" = 1 ] ; then
   default_bucket_name="jack-testing.keybase.io"
-  echo "This build+push is a DRY RUN."
+  echo
+  echo
+  echo "================================="
+  echo "================================="
+  echo "= This build+push is a DRY RUN. ="
+  echo "================================="
+  echo "================================="
+  echo
+  echo
 else
   default_bucket_name="prerelease.keybase.io"
 fi

--- a/packaging/linux/deb/changelog
+++ b/packaging/linux/deb/changelog
@@ -1,0 +1,4 @@
+keybase (2.11.0-20181115195458.06d3f3f3c4) stable; urgency=medium
+  * Chat. URL previews, performance improvement updates.
+    Other. Team creation flow UI upgrades, bugfixes.
+ -- Keybase Developers <code@keybase.io>  Tue, 04 Dec 2018 12:00:00 +0000

--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -53,6 +53,11 @@ build_one_architecture() {
   # folder. TODO: Something less wasteful of disk space?
   cp -r "$build_root"/binaries/"$debian_arch"/* "$dest/build"
 
+  # Copy changelog directly in, since this is a binary package.
+  doc_dir="$dest/build/usr/share/doc/keybase"
+  mkdir -p "$doc_dir"
+  gzip -c "$here/changelog" > "$doc_dir/changelog.Debian.gz"
+
   # Installed-Size is a required field in the control file. Without it Ubuntu
   # users will see warnings.
   size="$(du --summarize --block-size=1024 "$dest" | awk '{print $1}')"

--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -56,7 +56,7 @@ build_one_architecture() {
   # Copy changelog directly in, since this is a binary package.
   doc_dir="$dest/build/usr/share/doc/keybase"
   mkdir -p "$doc_dir"
-  gzip -c "$here/changelog" > "$doc_dir/changelog.Debian.gz"
+  gzip -cn "$here/changelog" > "$doc_dir/changelog.Debian.gz"
 
   # Installed-Size is a required field in the control file. Without it Ubuntu
   # users will see warnings.

--- a/packaging/linux/rpm/updateinfo.xml
+++ b/packaging/linux/rpm/updateinfo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<updates>
+  <update from="code@keybase.io" status="stable" type="feature" version="1">
+    <id>KEYBASE-RELEASE-2.11</id>
+    <title>Keybase 2.11</title>
+    <release>Keybase 2.11 Release</release>
+    <issued date="2018-12-04 12:00:00"/>
+    <description>Chat: URL previews, performance improvement updates. Other: team creation flow UI upgrades, bugfixes.</description>
+    <pkglist>
+      <collection>
+        <name>Keybase</name>
+        <package arch="x86_64" name="keybase" release="1" version="2.11.0.20181115195458.06d3f3f3c4"></package>
+        <package arch="i386" name="keybase" release="1" version="2.11.0.20181115195458.06d3f3f3c4"></package>
+      </collection>
+    </pkglist>
+  </update>
+</updates>

--- a/packaging/linux/test/README.md
+++ b/packaging/linux/test/README.md
@@ -56,6 +56,35 @@ After that you can upgrade it:
     cd /root/build/deb/amd64
     dpkg -i `ls -tr *.deb | tail -1`
 
+##### Local repo
+
+If you want to try upgrading with `apt-get`, you need to edit the apt list.
+Note that reinstalling will overwrite this change unless you `sudo touch
+/etc/default/keybase` first. Note that for this to work, you need to run
+`packaging/linux/deb/layout_repo.sh /root/build` to create the repo (and
+comment out codesigning while testing). You also need to `rm -r /root/build/deb
+/root/build/deb_repo` in between `layout_repo`s.
+
+```
+# before
+root@813a2fbff4a5:/# cat /etc/apt/sources.list.d/keybase.list
+### THIS FILE IS AUTOMATICALLY CONFIGURED ###
+# You may comment out this entry, but any other modifications may be lost.
+deb http://prerelease.keybase.io/deb stable main
+
+# after
+joot@813a2fbff4a5:/# cat /etc/apt/sources.list.d/keybase.list
+### THIS FILE IS AUTOMATICALLY CONFIGURED ###
+# You may comment out this entry, but any other modifications may be lost.
+deb [trusted=yes] file:/root/build/deb_repo/repo stable main
+
+root@813a2fbff4a5:/# apt-get update
+root@813a2fbff4a5:/# apt-get upgrade keybase
+...
+The following packages will be upgraded:
+  keybase
+```
+
 Ubuntu with systemd:
 =======
 
@@ -95,6 +124,49 @@ After that you can upgrade it:
     exit  # back to root
     cd /root/build/rpm/x86_64/RPMS/x86_64
     rpm -Uvh `ls -tr *.rpm | tail -1`
+
+##### Local repo
+
+The process is similar as in Debian.
+
+```
+# before
+bash-4.2# cat /etc/yum.repos.d/keybase.repo
+[keybase]
+name=keybase
+baseurl=http://prerelease.keybase.io/rpm/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://keybase.io/docs/server_security/code_signing_key.asc
+metadata_expire=60
+
+# after
+bash-4.2# cat /etc/yum.repos.d/keybase.repo
+[keybase]
+name=keybase
+baseurl=file:///root/build/rpm_repo/repo/x86_64/
+enabled=1
+metadata_expire=60
+
+# nogpgcheck needed in test
+bash-4.2# yum update keybase --nogpgcheck
+Loaded plugins: fastestmirror, ovl
+Loading mirror speeds from cached hostfile
+ * base: mirror.jaleco.com
+ * extras: mirror.atlanticmetro.net
+ * updates: mirror.metrocast.net
+keybase
+Resolving Dependencies
+--> Running transaction check
+---> Package keybase.x86_64 0:2.11.0.20181204152506.f11f4191e3-1 will be updated
+bash-4.2#
+```
+
+Note that reinstalling will overwrite this change unless you `sudo touch
+/etc/default/keybase` first. Note that for this to work, you need to run
+`packaging/linux/rpm/layout_repo.sh /root/build` to create the repo (and
+comment out codesigning while testing). You also need to `rm -r /root/build/rpm
+/root/build/rpm_repo` in between `layout_repo`s.
 
 Arch:
 =====

--- a/packaging/linux/test/README.md
+++ b/packaging/linux/test/README.md
@@ -4,9 +4,11 @@ Debian/Ubuntu:
 To build a package for debian from a local branch in client (on amd64):
 
     cd $GOPATH/src/github.com/keybase/client/packaging/linux
-    docker build -t keybase_packaging_v14 .
+    # Run the following on Arch: see https://github.com/docker/for-linux/issues/480
+    # echo N | sudo tee /sys/module/overlay/parameters/metacopy
+    docker build -t keybase_packaging_v16 .
     mkdir /var/tmp/keybase_build_work
-    docker run -v /var/tmp/keybase_build_work:/root -v $GOPATH/src/github.com/keybase/client:/CLIENT:ro -v $GOPATH/src/github.com/keybase/kbfs:/KBFS:ro  -e NOWAIT -ti keybase_packaging_v14 bash
+    docker run -v /var/tmp/keybase_build_work:/root -v $GOPATH/src/github.com/keybase/client:/CLIENT:ro -v $GOPATH/src/github.com/keybase/kbfs:/KBFS:ro  -e NOWAIT -ti keybase_packaging_v16 bash
 
 Then, from inside the docker environment:
 
@@ -15,6 +17,7 @@ Then, from inside the docker environment:
     git clone https://github.com/keybase/kbfs.git kbfs --reference /KBFS
     cd client
     git remote add localclient /CLIENT
+    git fetch localclient
     git checkout localclient/<NAME_OF_LOCAL_BRANCH_TO_TEST>
     KEYBASE_SKIP_32_BIT=1 packaging/linux/build_binaries.sh prerelease /root/build
     packaging/linux/deb/package_binaries.sh /root/build


### PR DESCRIPTION
Not so easy to test on rpm because the actual repodata is configured in layout_repo.sh, which needs gpg keys. I used this patch: https://github.com/keybase/client/commit/c05aaaa2a37aaf968c34614b898a1171bdb35279.patch to comment out 32 bit and code signing for testing. (There's a KEYBASE_DRY_RUN option but it still needs gpg keys)

cc @cjb 