### PR TITLE
WIP:  remove race engine saga

### DIFF
--- a/shared/engine/saga.js
+++ b/shared/engine/saga.js
@@ -105,8 +105,6 @@ function* call(p: CallParams): Generator<any, any, any> {
           }
         }
 
-        console.log('aaa channel', method)
-
         // Emit deferred
         setTimeout(() => {
           emitter({method, params, response})
@@ -161,7 +159,6 @@ function* call(p: CallParams): Generator<any, any, any> {
       // Take things that we put into the eventChannel above
       const r = yield RSE.take(eventChannel)
 
-      console.log('aaa take', r.method)
       if (r.method) {
         const res: EmittedCall = (r: EmittedCall)
         let actions


### PR DESCRIPTION
When mixing incomingCallMap / customIncomingCallMap the response object gets called in two different ways. This PR makes them always be called on the other side of the emitter so ordering is preserved