### PR TITLE
routing fixes for Files

### DIFF
--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -18,7 +18,8 @@ import platformSpecificSaga from './platform-specific'
 import {getContentTypeFromURL} from '../platform-specific'
 import {isMobile} from '../../constants/platform'
 import {type TypedState} from '../../util/container'
-import {putActionIfOnPath, navigateAppend, navigateTo, switchTo, navigateUp} from '../route-tree'
+import {putActionIfOnPath, navigateAppend, navigateTo} from '../route-tree'
+import {getPathProps} from '../../route-tree'
 import {makeRetriableErrorHandler, makeUnretriableErrorHandler} from './shared'
 
 const loadFavorites = (state: TypedState, action) =>
@@ -614,7 +615,7 @@ const _getRouteChangeForOpenPathInFilesTab = (action: FsGen.OpenPathInFilesTabPa
         // Construct all parent folders so back button works all the way back
         // to /keybase
         ...Types.getPathElements(action.payload.path)
-          .slice(0, -1)
+          .slice(1, -1) // fsTab default to /keybase, so we skip one here
           .reduce(
             (routes, elem) => [
               ...routes,
@@ -622,7 +623,7 @@ const _getRouteChangeForOpenPathInFilesTab = (action: FsGen.OpenPathInFilesTabPa
                 props: {
                   path: routes.length
                     ? Types.pathConcat(routes[routes.length - 1].props.path, elem)
-                    : Types.stringToPath(`/${elem}`),
+                    : Types.stringToPath(`/keybase/${elem}`),
                 },
                 selected: 'folder',
               },
@@ -763,7 +764,7 @@ const moveOrCopy = (state, action: FsGen.MovePayload | FsGen.CopyPayload) => {
   )
 }
 
-const moveOrCopyOpenMobile = (state, action) =>
+const moveOrCopyOpen = (state, action) =>
   Saga.all([
     Saga.put(
       FsGen.createSetMoveOrCopyDestinationParentPath({
@@ -779,35 +780,23 @@ const moveOrCopyOpenMobile = (state, action) =>
     ),
   ])
 
-const moveOrCopyOpenDesktop = (state, action) =>
-  Saga.put(
-    FsGen.createSetMoveOrCopyDestinationParentPath({
-      index: action.payload.currentIndex,
-      path: action.payload.path,
-    })
+const showMoveOrCopy = (state, action) =>
+  Saga.put(navigateAppend([{props: {index: 0}, selected: 'destinationPicker'}]))
+
+const cancelMoveOrCopy = (state, action) => {
+  const currentRoutes = getPathProps(state.routeTree.routeState)
+  const firstDestinationPickerIndex = currentRoutes.findIndex(({node}) => node === 'destinationPicker')
+  const newRoute = currentRoutes.reduce(
+    (routes, {node, props}, i) =>
+      // node is never null
+      i < firstDestinationPickerIndex ? [...routes, {props, selected: node || ''}] : routes,
+    []
   )
-
-const showMoveOrCopy = isMobile
-  ? (state, action) =>
-      Saga.put(
-        navigateTo([
-          Tabs.settingsTab,
-          SettingsConstants.fsTab,
-          ...state.fs.moveOrCopy.destinationParentPath.map((p, index) => ({
-            props: {index},
-            selected: 'destinationPicker',
-          })),
-        ])
-      )
-  : (state, action) => Saga.put(navigateAppend([{props: {index: 0}, selected: 'destinationPicker'}]))
-
-const cancelMoveOrCopy = (state, action) =>
-  Saga.all([
-    isMobile
-      ? Saga.put(switchTo([Tabs.settingsTab, SettingsConstants.fsTab, 'folder']))
-      : Saga.put(navigateUp()),
+  return Saga.all([
     Saga.put(FsGen.createClearRefreshTag({refreshTag: 'destination-picker'})),
+    Saga.put(navigateTo(newRoute)),
   ])
+}
 
 const showSendLinkToChat = (state, action) => {
   const elems = Types.getPathElements(state.fs.sendLinkToChat.path)
@@ -914,7 +903,7 @@ function* fsSaga(): Saga.SagaGenerator<any, any> {
   yield Saga.actionToAction([FsGen.openPathItem, FsGen.openPathInFilesTab], openPathItem)
   yield Saga.actionToAction(ConfigGen.setupEngineListeners, setupEngineListeners)
   yield Saga.actionToPromise([FsGen.move, FsGen.copy], moveOrCopy)
-  yield Saga.actionToAction(FsGen.moveOrCopyOpen, isMobile ? moveOrCopyOpenMobile : moveOrCopyOpenDesktop)
+  yield Saga.actionToAction(FsGen.moveOrCopyOpen, moveOrCopyOpen)
   yield Saga.actionToAction(FsGen.showMoveOrCopy, showMoveOrCopy)
   yield Saga.actionToAction(FsGen.cancelMoveOrCopy, cancelMoveOrCopy)
   yield Saga.actionToAction(FsGen.showSendLinkToChat, showSendLinkToChat)

--- a/shared/fs/destination-picker/container.js
+++ b/shared/fs/destination-picker/container.js
@@ -6,7 +6,6 @@ import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import * as FsGen from '../../actions/fs-gen'
 import {isMobile} from '../../constants/platform'
-import {navigateUp, putActionIfOnPath} from '../../actions/route-tree'
 
 type OwnProps = RouteProps<
   {|
@@ -28,7 +27,14 @@ const getDestinationParentPath = memoize2((stateProps, ownProps: OwnProps) =>
 )
 
 const mapDispatchToProps = (dispatch, ownProps: OwnProps) => ({
-  _onBackUp: () => dispatch(putActionIfOnPath(ownProps.routePath, navigateUp())),
+  _onBackUp: (currentPath: Types.Path) =>
+    dispatch(
+      FsGen.createMoveOrCopyOpen({
+        currentIndex: getIndex(ownProps),
+        path: Types.getPathParent(currentPath),
+        routePath: ownProps.routePath,
+      })
+    ),
   _onCopyHere: destinationParentPath => {
     dispatch(FsGen.createCopy({destinationParentPath}))
     dispatch(FsGen.createCancelMoveOrCopy())
@@ -75,7 +81,9 @@ const canBackUp = isMobile
 
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   index: getIndex(ownProps),
-  onBackUp: canBackUp(stateProps, ownProps) ? dispatchProps._onBackUp : null,
+  onBackUp: canBackUp(stateProps, ownProps)
+    ? () => dispatchProps._onBackUp(getDestinationParentPath(stateProps, ownProps))
+    : null,
   onCancel: dispatchProps.onCancel,
   onCopyHere: canCopy(stateProps, ownProps)
     ? () => dispatchProps._onCopyHere(getDestinationParentPath(stateProps, ownProps))

--- a/shared/fs/header/breadcrumb-container.desktop.js
+++ b/shared/fs/header/breadcrumb-container.desktop.js
@@ -3,8 +3,7 @@ import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import {namedConnect} from '../../util/container'
-import {fsTab} from '../../constants/tabs'
-import {navigateTo} from '../../actions/route-tree'
+import {navigateAppend} from '../../actions/route-tree'
 import * as FsGen from '../../actions/fs-gen'
 import Breadcrumb, {type Props as BreadcrumbProps} from './breadcrumb.desktop'
 
@@ -62,7 +61,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = (dispatch, {inDestinationPicker, routePath}: OwnProps) => ({
   _navigateToPath: inDestinationPicker
     ? (path: Types.Path) => dispatch(FsGen.createMoveOrCopyOpen({currentIndex: 0, path, routePath}))
-    : (path: Types.Path) => dispatch(navigateTo([fsTab, {props: {path}, selected: 'folder'}])),
+    : (path: Types.Path) => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
 })
 
 const mergeProps = ({_username}, {_navigateToPath}, {path}: OwnProps) =>

--- a/shared/fs/routes.js
+++ b/shared/fs/routes.js
@@ -8,7 +8,7 @@ import SecurityPrefs from './common/security-prefs-container'
 import DestinationPicker from './destination-picker/container'
 import SendLinkToChat from './send-link-to-chat/container'
 
-/*
+/* TODO: update examples here
  * Example Fs routes:
  *
  *   Mobile:
@@ -68,23 +68,22 @@ import SendLinkToChat from './send-link-to-chat/container'
  */
 
 const _destinationPicker = {
-  children: isMobile
-    ? {
-        destinationPicker: () => makeRouteDefNode(_destinationPicker),
-      }
-    : undefined,
+  children: {
+    destinationPicker: () => makeRouteDefNode(_destinationPicker),
+  },
   component: DestinationPicker,
   tags: makeLeafTags({
     layerOnTop: !isMobile,
+    renderTopmostOnly: !isMobile,
     title: 'Move or Copy',
   }),
 }
 
 const _commonChildren = {
+  destinationPicker: () => makeRouteDefNode(_destinationPicker),
   securityPrefs: {
     component: SecurityPrefs,
   },
-  ...(isMobile ? {} : {destinationPicker: () => makeRouteDefNode(_destinationPicker)}),
   sendLinkToChat: {
     component: SendLinkToChat,
   },
@@ -116,11 +115,7 @@ const _folderRoute = {
 }
 
 const routeTree = makeRouteDefNode({
-  children: {
-    folder: () => makeRouteDefNode(_folderRoute),
-    ...(isMobile ? {destinationPicker: () => makeRouteDefNode(_destinationPicker)} : {}),
-  },
-  defaultSelected: 'folder',
+  ..._folderRoute,
   initialState: {expandedSet: I.Set()},
   tags: makeLeafTags({title: 'Files'}),
 })

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -5,7 +5,6 @@ import * as FsGen from '../actions/fs-gen'
 import * as Constants from '../constants/fs'
 import * as Flow from '../util/flow'
 import * as Types from '../constants/types/fs'
-import {isMobile} from '../constants/platform'
 
 const initialState = Constants.makeState()
 
@@ -277,22 +276,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
       return state.removeIn(['errors', action.payload.key])
     case FsGen.showMoveOrCopy:
       return state.update('moveOrCopy', mc =>
-        mc.set(
-          'destinationParentPath',
-          isMobile
-            ? I.List(
-                Types.getPathElements(action.payload.initialDestinationParentPath).reduce(
-                  (list, elem) => [
-                    ...list,
-                    list.length
-                      ? Types.pathConcat(list[list.length - 1], elem)
-                      : Types.stringToPath(`/${elem}`),
-                  ],
-                  []
-                )
-              )
-            : I.List([action.payload.initialDestinationParentPath])
-        )
+        mc.set('destinationParentPath', I.List([action.payload.initialDestinationParentPath]))
       )
     case FsGen.setMoveOrCopySource:
       return state.update('moveOrCopy', mc => mc.set('sourceItemPath', action.payload.path))

--- a/shared/route-tree/index.js
+++ b/shared/route-tree/index.js
@@ -364,22 +364,24 @@ export function getPathState(routeState: ?RouteStateNode, parentPath?: Path): ?I
 // under the given parentPath
 export function getPathProps(
   routeState: ?RouteStateNode,
-  parentPath: Path
+  parentPath?: Path
 ): I.List<{node: ?string, props: I.Map<string, any>}> {
   const path = []
   let curState = routeState
 
-  for (const next of parentPath) {
-    // $FlowIssue
-    curState = curState && curState.getChild(next)
-    if (!curState) {
+  if (parentPath) {
+    for (const next of parentPath) {
       // $FlowIssue
-      return I.List(path)
+      curState = curState && curState.getChild(next)
+      if (!curState) {
+        // $FlowIssue
+        return I.List(path)
+      }
+      path.push({
+        node: next,
+        props: curState.props,
+      })
     }
-    path.push({
-      node: next,
-      props: curState.props,
-    })
   }
 
   while (curState && curState.selected !== null) {


### PR DESCRIPTION
Back button for "open in Files tab":

1. For files, we have a back button on both desktop and mobile. This PR fixes the routes so that the back button goes to the parent folder instead of /keybase as before.
2. For folders, it's a back button on mobile. This PR fixes the route by populating all its parent paths, so user can click back button folder by folder all the way to /keybase, instead of directly to /keybase.

Back button at the root of Files on mobile (previous/abandoned attempt [here](https://github.com/keybase/client/pull/15021)):

This was due to a routing hack that I did earlier where moveOrCopy was a sibling of the folder route rather than children. This PR removes the hack and just make it the children of the folder route. The hack was to solve a specific case where when user taps "Close" in moveOrCopy they'd need to be at the original folder where they initiated move or copy. So in this PR, when user closes, we just grab the path and route from the routeTree, and use `navigateTo`.