### PR TITLE
fix josh crash

### DIFF
--- a/shared/common-adapters/icon.shared.js
+++ b/shared/common-adapters/icon.shared.js
@@ -83,16 +83,16 @@ const idealSizeMultMap = {
 }
 
 const _getMultsMapCache = {}
-export function getMultsMap(imgMap: {[size: string]: any}, targetSize: number): any {
+export function getMultsMap(imgMap: {[size: string]: any}, targetSize: number): Object {
   let sizes: any = Object.keys(imgMap)
 
   if (!sizes.length) {
-    return null
+    return {}
   }
 
   const sizeKey = targetSize + ']' + sizes.join(':')
   if (_getMultsMapCache[sizeKey]) {
-    return _getMultsMapCache[sizeKey]
+    return _getMultsMapCache[sizeKey] || {}
   }
 
   sizes = sizes.map(s => parseInt(s, 10)).sort((a: number, b: number) => a - b)


### PR DESCRIPTION
Unclear why this is happening upstream but callers of this do Object.keys(foo) and foo can't be null

@keybase/react-hackers 
cc: @joshblum 