### PR TITLE
RelativePopupHOC push back into viewport and matchDimension prop

### DIFF
--- a/shared/chat/conversation/messages/message-popup/attachment/index.js
+++ b/shared/chat/conversation/messages/message-popup/attachment/index.js
@@ -77,6 +77,7 @@ const AttachmentPopupMenu = (props: Props) => {
       onHidden={props.onHidden}
       closeOnSelect={true}
       position={props.position}
+      positionFallbacks={[]}
       containerStyle={props.style}
       visible={props.visible}
     />

--- a/shared/chat/conversation/messages/message-popup/exploding/index.js
+++ b/shared/chat/conversation/messages/message-popup/exploding/index.js
@@ -172,6 +172,7 @@ const ExplodingPopupMenu = (props: PropsWithTimer<Props>) => {
       items={props.items}
       onHidden={props.onHidden}
       position={props.position}
+      positionFallbacks={[]}
       containerStyle={props.style}
       visible={props.visible}
     />

--- a/shared/chat/conversation/messages/message-popup/payment/index.js
+++ b/shared/chat/conversation/messages/message-popup/payment/index.js
@@ -144,6 +144,7 @@ const PaymentPopup = (props: Props) => {
       attachTo={props.attachTo}
       onHidden={props.onHidden}
       position={props.position}
+      positionFallbacks={[]}
       header={header}
       items={items}
       visible={props.visible}

--- a/shared/chat/conversation/messages/message-popup/text/index.js
+++ b/shared/chat/conversation/messages/message-popup/text/index.js
@@ -81,6 +81,7 @@ const TextPopupMenu = (props: Props) => {
       items={items}
       onHidden={props.onHidden}
       position={props.position}
+      positionFallbacks={[]}
       containerStyle={props.style}
       visible={props.visible}
     />

--- a/shared/common-adapters/floating-box/index.desktop.js
+++ b/shared/common-adapters/floating-box/index.desktop.js
@@ -74,6 +74,7 @@ class FloatingBox extends React.Component<Props, State> {
         position={this.props.position || 'bottom center'}
         positionFallbacks={this.props.positionFallbacks}
         targetRect={this.state.targetRect}
+        matchDimension={!!this.props.matchDimension}
         onClosePopup={this._onHidden}
         propagateOutsideClicks={this.props.propagateOutsideClicks}
         style={this.props.containerStyle}

--- a/shared/common-adapters/floating-box/index.types.js.flow
+++ b/shared/common-adapters/floating-box/index.types.js.flow
@@ -15,6 +15,7 @@ export type Props = {
   // mobile you can control this by setting a margin in `containerStyle`.
   propagateOutsideClicks?: boolean,
   containerStyle?: StylesCrossPlatform,
+  matchDimension?: boolean,
   position?: Position,
   positionFallbacks?: Position[],
 }

--- a/shared/common-adapters/overlay/index.desktop.js
+++ b/shared/common-adapters/overlay/index.desktop.js
@@ -11,6 +11,7 @@ const Overlay = (props: Props) => {
   return (
     <FloatingBox
       attachTo={props.attachTo}
+      matchDimension={!!props.matchDimension}
       onHidden={props.onHidden}
       position={props.position || 'top center'}
       positionFallbacks={props.positionFallbacks}

--- a/shared/common-adapters/overlay/index.js.flow
+++ b/shared/common-adapters/overlay/index.js.flow
@@ -19,6 +19,7 @@ export type Props = {|
   attachTo?: () => ?React.ElementRef<any>,
   children: React.Node,
   color?: string,
+  matchDimension?: boolean,
   onHidden: () => void,
   position?: Position,
   positionFallbacks?: Position[],

--- a/shared/common-adapters/relative-popup-hoc.desktop.js
+++ b/shared/common-adapters/relative-popup-hoc.desktop.js
@@ -80,6 +80,7 @@ function _computePopupStyle(
   position: Position,
   coords: ClientRect,
   popupCoords: ClientRect,
+  matchDimension: boolean,
   offset: ?number
 ): ComputedStyle {
   const style: ComputedStyle = {position: 'absolute', zIndex: 30}
@@ -93,6 +94,9 @@ function _computePopupStyle(
   } else if (includes(position, 'left')) {
     style.left = Math.round(coords.left + pageXOffset)
     style.right = 'auto'
+  } else if (matchDimension) {
+    style.left = Math.round(coords.left + pageXOffset)
+    style.right = Math.round(clientWidth - (coords.right + pageXOffset))
   } else {
     // if not left nor right, we are horizontally centering the element
     const xOffset = (coords.width - popupCoords.width) / 2
@@ -106,6 +110,9 @@ function _computePopupStyle(
   } else if (includes(position, 'bottom')) {
     style.top = Math.round(coords.bottom + pageYOffset)
     style.bottom = 'auto'
+  } else if (matchDimension) {
+    style.bottom = Math.round(clientHeight - (coords.top + pageYOffset))
+    style.top = Math.round(coords.bottom + pageYOffset)
   } else {
     // if not top nor bottom, we are vertically centering the element
     const yOffset = (coords.height + popupCoords.height) / 2
@@ -164,15 +171,16 @@ function computePopupStyle(
   position: Position,
   coords: ClientRect,
   popupCoords: ClientRect,
+  matchDimension: boolean,
   offset: ?number,
   // When specified, will only use the fallbacks regardless of visibility
   positionFallbacks?: Position[]
 ): ComputedStyle {
-  let style = _computePopupStyle(position, coords, popupCoords, offset)
+  let style = _computePopupStyle(position, coords, popupCoords, matchDimension, offset)
 
   const positionsShuffled = positionFallbacks || without(positions, position).concat([position])
   for (let i = 0; !isStyleInViewport(style, popupCoords) && i < positionsShuffled.length; i += 1) {
-    style = _computePopupStyle(positionsShuffled[i], coords, popupCoords, offset)
+    style = _computePopupStyle(positionsShuffled[i], coords, popupCoords, matchDimension, offset)
   }
   return style
 }
@@ -181,6 +189,7 @@ type ModalPositionRelativeProps<PP> = {
   targetRect: ?ClientRect,
   position: Position,
   positionFallbacks?: Position[],
+  matchDimension?: boolean,
   onClosePopup: () => void,
   propagateOutsideClicks?: boolean,
   style?: StylesCrossPlatform,
@@ -210,6 +219,7 @@ function ModalPositionRelative<PP>(
           this.props.position,
           targetRect,
           popupNode.getBoundingClientRect(),
+          !!this.props.matchDimension,
           null,
           this.props.positionFallbacks
         ),

--- a/shared/common-adapters/relative-popup-hoc.types.js.flow
+++ b/shared/common-adapters/relative-popup-hoc.types.js.flow
@@ -13,9 +13,13 @@ export type Position =
 
 export type Props<PP: {}> = {|
   ...PP,
-  targetRect: ?ClientRect,
+  // [desktop] if this is true, child will be positioned absolutely with a container the same
+  // width/height depending on position.
+  // e.g. position is 'left'/'right' -> same height; position is 'top'/'bottom' -> same width
+  matchDimension?: boolean,
   position: Position,
   style?: Object,
+  targetRect: ?ClientRect,
 |}
 
 export type RelativePopupHocType<PP> = (


### PR DESCRIPTION
Two additions to `RelativePopupHOC`
- Check if the final position is inside the viewport, and try to push it back in if it's not
- Add `matchDimension` prop, which will set styles to match the height / width of target depending on `position`

I add empty `positionFallbacks` to all the message menus, so they will always try to go `top right` and be pushed back in if they can't fit.

r? @keybase/react-hackers 