### PR TITLE
client: enable and disable partial paths for sync config

### DIFF
--- a/go/client/cmd_simplefs_sync_disable.go
+++ b/go/client/cmd_simplefs_sync_disable.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
@@ -68,12 +69,26 @@ func (c *CmdSimpleFSSyncDisable) Run() error {
 		}
 
 		found := false
+		parentFound := ""
 		for _, p := range res.Config.Paths {
 			if p == subpath {
 				found = true
 			} else {
+				toCheck := p
+				if !strings.HasSuffix(p, "/") {
+					toCheck = p + "/"
+				}
+				if strings.HasPrefix(subpath, toCheck) {
+					parentFound = p
+				}
 				arg.Config.Paths = append(arg.Config.Paths, p)
 			}
+		}
+
+		if parentFound != "" {
+			ui := c.G().UI.GetTerminalUI()
+			ui.Printf("%s will remain synced because its parent path (%s) "+
+				"is still synced\n", subpath, parentFound)
 		}
 
 		if !found {

--- a/go/client/cmd_simplefs_sync_enable.go
+++ b/go/client/cmd_simplefs_sync_enable.go
@@ -26,7 +26,7 @@ func NewCmdSimpleFSSyncEnable(
 	cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "enable",
-		ArgumentHelp: "[path-to-folder]",
+		ArgumentHelp: "[path-to-sync]",
 		Usage:        "syncs the given folder to local storage, for offline access",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdSimpleFSSyncEnable{
@@ -36,9 +36,20 @@ func NewCmdSimpleFSSyncEnable(
 	}
 }
 
+const minNumKeybasePathElems = 4
+
+func splitKeybasePath(p keybase1.Path) []string {
+	toSplit := p.String()
+	// Just in case the path isn't absolute.
+	if !strings.HasPrefix(toSplit, "/") {
+		toSplit = "/" + toSplit
+	}
+	return strings.SplitN(toSplit, "/", minNumKeybasePathElems)
+}
+
 func toTlfPath(p keybase1.Path) (keybase1.Path, error) {
-	split := strings.SplitN(p.String(), "/", 4)
-	if len(split) < 4 {
+	split := splitKeybasePath(p)
+	if len(split) < minNumKeybasePathElems {
 		return p, nil
 	}
 	return makeSimpleFSPath(
@@ -46,8 +57,8 @@ func toTlfPath(p keybase1.Path) (keybase1.Path, error) {
 }
 
 func pathMinusTlf(p keybase1.Path) string {
-	split := strings.SplitN(p.String(), "/", 4)
-	if len(split) < 4 {
+	split := splitKeybasePath(p)
+	if len(split) < minNumKeybasePathElems {
 		return ""
 	}
 	return split[3]

--- a/go/client/cmd_simplefs_sync_show.go
+++ b/go/client/cmd_simplefs_sync_show.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/keybase/cli"
@@ -35,6 +36,33 @@ func NewCmdSimpleFSSyncShow(
 	}
 }
 
+func printPrefetchStatus(
+	ui libkb.TerminalUI, status keybase1.PrefetchStatus,
+	progress keybase1.PrefetchProgress, tab string) {
+	switch status {
+	case keybase1.PrefetchStatus_COMPLETE:
+		ui.Printf("%sStatus: fully synced\n", tab)
+	case keybase1.PrefetchStatus_IN_PROGRESS:
+		ui.Printf("%sStatus: sync in progress\n", tab)
+		if progress.BytesTotal > 0 {
+			ui.Printf("%s%s/%s (%.2f%%)\n",
+				tab, humanizeBytes(progress.BytesFetched, false),
+				humanizeBytes(progress.BytesTotal, false),
+				100*float64(progress.BytesFetched)/
+					float64(progress.BytesTotal))
+		}
+		if progress.EndEstimate > 0 {
+			timeRemaining := time.Until(keybase1.FromTime(progress.EndEstimate))
+			ui.Printf("%sEstimated time remaining: %s\n",
+				tab, timeRemaining.Round(1*time.Second))
+		}
+	case keybase1.PrefetchStatus_NOT_STARTED:
+		ui.Printf("%sStatus: sync not yet started\n", tab)
+	default:
+		ui.Printf("%sStatus: unknown\n", tab)
+	}
+}
+
 // Run runs the command in client/server mode.
 func (c *CmdSimpleFSSyncShow) Run() error {
 	cli, err := GetSimpleFSClient(c.G())
@@ -54,35 +82,31 @@ func (c *CmdSimpleFSSyncShow) Run() error {
 		ui.Printf("Syncing disabled\n")
 	case keybase1.FolderSyncMode_ENABLED:
 		ui.Printf("Syncing enabled\n")
-		switch res.Status.PrefetchStatus {
-		case keybase1.PrefetchStatus_COMPLETE:
-			ui.Printf("Status: fully synced\n")
-		case keybase1.PrefetchStatus_IN_PROGRESS:
-			ui.Printf("Status: sync in progress\n")
-			if res.Status.PrefetchProgress.BytesTotal > 0 {
-				ui.Printf("%s/%s (%.2f%%)\n",
-					humanizeBytes(
-						res.Status.PrefetchProgress.BytesFetched, false),
-					humanizeBytes(
-						res.Status.PrefetchProgress.BytesTotal, false),
-					100*float64(res.Status.PrefetchProgress.BytesFetched)/
-						float64(res.Status.PrefetchProgress.BytesTotal))
-			}
-			if res.Status.PrefetchProgress.EndEstimate > 0 {
-				timeRemaining := time.Until(
-					keybase1.FromTime(res.Status.PrefetchProgress.EndEstimate))
-				ui.Printf("Estimated time remaining: %s\n",
-					timeRemaining.Round(1*time.Second))
-			}
-		case keybase1.PrefetchStatus_NOT_STARTED:
-			ui.Printf("Status: sync not yet started\n")
-		default:
-			ui.Printf("Status: unknown\n")
-		}
+		printPrefetchStatus(
+			ui, res.Status.PrefetchStatus, res.Status.PrefetchProgress, "")
 		a := res.Status.LocalDiskBytesAvailable
 		t := res.Status.LocalDiskBytesTotal
 		ui.Printf("%s (%.2f%%) of the local disk available for caching.\n",
 			humanizeBytes(a, false), float64(a)/float64(t)*100)
+	case keybase1.FolderSyncMode_PARTIAL:
+		paths := "these subpaths"
+		if len(res.Config.Paths) == 1 {
+			paths = "this subpath"
+		}
+		ui.Printf("Syncing configured for %s:\n", paths)
+		for _, p := range res.Config.Paths {
+			fullPath, err := makeSimpleFSPath(path.Join(c.path.String(), p))
+			e, err := cli.SimpleFSStat(
+				ctx, keybase1.SimpleFSStatArg{Path: fullPath})
+			if err != nil {
+				ui.Printf("\tError: %v", err)
+				continue
+			}
+
+			ui.Printf("\t%s\n", p)
+			printPrefetchStatus(
+				ui, e.PrefetchStatus, e.PrefetchProgress, "\t\t")
+		}
 	default:
 		return fmt.Errorf("Unknown sync mode: %s", res.Config.Mode)
 	}


### PR DESCRIPTION
Allows for the following awesome experience:

```sh
$ keybase fs sync show /keybase/team/foo
Syncing disabled
$ keybase fs sync enable /keybase/team/foo/bar
$ keybase fs sync show /keybase/team/foo
Syncing configured for this subpath:
	bar
		Status: fully synced
$ keybase fs stat /keybase/team/foo/bar
/team/foo/bar
2018-11-28 09:42:18 PST	DIR	496	bar	strib	COMPLETE
$ keybase fs sync enable /keybase/team/foo/baz
$ keybase fs sync show /keybase/team/foo
Syncing configured for these subpaths:
	bar
		Status: fully synced
	baz
		Status: sync in progress
$ keybase fs sync show /keybase/team/foo
Syncing configured for these subpaths:
	bar
		Status: fully synced
	baz
		Status: fully synced
$ keybase fs stat /keybase/team/foo/baz/a/photos/DSCF9511.JPG 
/team/foo/baz/photos/DSCF9511.JPG
2018-11-08 19:15:32 PST	EXEC	13870786	DSCF9511.JPG	jzila	COMPLETE
```

Note that the prefetch progress of each path will also show up once keybase/kbfs#1945 is merged.

Also, I won't merge this until keybase/kbfs#1963 is merged.