### PR TITLE
visualize logs w/ chrome tracing

### DIFF
--- a/shared/desktop/yarn-helper/log-to-trace.js
+++ b/shared/desktop/yarn-helper/log-to-trace.js
@@ -2,13 +2,8 @@
 const fs = require('fs')
 const data = fs.readFileSync(process.argv[2], 'utf8')
 const lines = data.split('\n')
-// const reg = /([^ ]+) ▶ \[DEBU keybase ([^:]+):(\d+)] ([0-9a-f]+) ([+-|]) ?([^[]+)(\[tags:([^\]]+)])?/
-// const reg = /([^ ]+) ▶ \[DEBU keybase ([^:]+):(\d+)] ([0-9a-f]+) ([+-|])\ ?([^ ]+)[^[]*(\[tags:([^\]]+)])?/
-// const reg = /([^ ]+) ▶ \[DEBU keybase ([^:]+):(\d+)] ([0-9a-f]+) ([+-|]) ?([^-[]+)[^[]*(\[tags:([^]]+)])?/
-// const reg = /([^ ]+) ▶ \[DEBU (?:keybase|kbfs) ([^:]+):(\d+)] ([0-9a-f]+) ([+-|])\ ?([^[]+)(\[tags:([^\]]+)])?/
 const reg = /([^ ]+) ▶ \[DEBU (?:keybase|kbfs) ([^:]+):(\d+)] ([0-9a-f]+) ([^[]+)(\[tags:([^\]]+)])?/
 const tagsReg = /\[tags:([^\]]+)]/
-// const methodPrefix = /^\W*/
 const methodPrefixReg = /^(\+\+Chat: )?/
 const methodResultReg = / -> .*$/
 const typeAndMethodReg = /^(\W*)/

--- a/shared/desktop/yarn-helper/log-to-trace.js
+++ b/shared/desktop/yarn-helper/log-to-trace.js
@@ -74,6 +74,12 @@ const output = {
 
 const buildGood = (old, info) => {
   const id = `${info.tags}:${info.method}`
+  const startTs = moment(old.time).valueOf() * 1000
+  const endTs = moment(info.time).valueOf() * 1000
+  if (endTs < startTs) {
+    console.log('bad start/end')
+    return []
+  }
   return [
     {
       args: {
@@ -86,7 +92,7 @@ const buildGood = (old, info) => {
       ph: 'B',
       pid: 0,
       tid: old.tags,
-      ts: moment(old.time).valueOf() * 1000,
+      ts: startTs,
     },
     {
       args: {
@@ -99,7 +105,7 @@ const buildGood = (old, info) => {
       ph: 'E',
       pid: 0,
       tid: info.tags,
-      ts: moment(info.time).valueOf() * 1000,
+      ts: endTs,
     },
   ]
 }

--- a/shared/desktop/yarn-helper/log-to-trace.js
+++ b/shared/desktop/yarn-helper/log-to-trace.js
@@ -3,7 +3,7 @@
 const [, , guiOrCore, logfile, outfile, ..._swimlanes] = process.argv
 // Good params?
 if (['gui', 'core'].indexOf(guiOrCore) === -1 || !logfile || !outfile) {
-  console.log('Usage: node log-to-trace (gui|core) logfile outfile')
+  console.log('Usage: node log-to-trace (gui|core) logfile outfile [filter1] [filter2]')
   process.exit(1)
 }
 

--- a/shared/desktop/yarn-helper/log-to-trace.js
+++ b/shared/desktop/yarn-helper/log-to-trace.js
@@ -17,8 +17,7 @@ if (process.argv.length !== 4) {
 const convertLine = line => {
   const e = reg.exec(line)
   if (!e) {
-    // TODO put back
-    // console.log('Skipping unparsed line:', line)
+    console.log('Skipping unparsed line:', line)
     return
   }
   const [, time, coreOrKbfs, file, fileline, counter, _typeAndMethod, _tags] = e
@@ -119,36 +118,31 @@ lines.forEach(line => {
     case '+':
       if (data[dataKey]) {
         output.collision.push(info)
-        // console.log('COLLISION: ', '\n', info, '\n', data[dataKey])
       }
-      // console.log('INJECT!', dataKey)
       data[dataKey] = info
       break
     case '-':
       if (data[dataKey]) {
-        // console.log('FOUND!', dataKey)
         output.good = output.good.concat(buildGood(data[dataKey], info))
         data[dataKey] = undefined
       } else {
-        // console.log('Unmatched -:', info)
         output.unmatched.push(info)
       }
       break
     default:
-    // TODO put back
     // console.log('Unknown line type:', info.type, ':', line)
   }
 })
 
-// if (output.unmatched.length) {
-// console.log('Unmatched lines:')
-// output.unmatched.forEach(u => console.log(u.line))
-// }
+if (output.unmatched.length) {
+  console.log('Unmatched lines:')
+  output.unmatched.forEach(u => console.log(u.line))
+}
 
-// if (output.collision.length) {
-// console.log('Lines with collisions:')
-// output.collision.forEach(c => console.log(c.line))
-// }
+if (output.collision.length) {
+  console.log('Lines with collisions:')
+  output.collision.forEach(c => console.log(c.line))
+}
 
 const format = {
   displaytimeUnit: 'ms',

--- a/shared/desktop/yarn-helper/log-to-trace.js
+++ b/shared/desktop/yarn-helper/log-to-trace.js
@@ -1,0 +1,37 @@
+// @flow
+const fs = require('fs')
+const data = fs.readFileSync(process.argv[2], 'utf8')
+const lines = data.split('\n')
+const reg = /([^ ]+) ▶ \[DEBU keybase ([^:]+):(\d+)] ([0-9a-f]+) ([+-|])([^[]+)(\[tags:([^\]]+)])?/
+const tagsReg = /\[tags:([^\]]+)]/
+
+const convertLine = line => {
+  const e = reg.exec(line)
+  if (!e) {
+    console.log('Skipping unparsed line:', line)
+    return
+  }
+  const [, time, file, fileline, counter, plusMinus, method, _tags] = e
+  let tags = _tags && tagsReg.exec(_tags)
+  tags =
+    tags &&
+    tags[1]
+      .split(',')
+      .sort()
+      .join(',')
+  return {
+    counter,
+    file,
+    fileline,
+    method,
+    plusMinus,
+    tags,
+    time,
+  }
+}
+
+const started = {}
+
+lines.forEach(line => {
+  const info = convertLine(line)
+})

--- a/shared/desktop/yarn-helper/log-to-trace.js
+++ b/shared/desktop/yarn-helper/log-to-trace.js
@@ -2,27 +2,61 @@
 const fs = require('fs')
 const data = fs.readFileSync(process.argv[2], 'utf8')
 const lines = data.split('\n')
-const reg = /([^ ]+) ▶ \[DEBU keybase ([^:]+):(\d+)] ([0-9a-f]+) ([+-|])([^[]+)(\[tags:([^\]]+)])?/
+// const reg = /([^ ]+) ▶ \[DEBU keybase ([^:]+):(\d+)] ([0-9a-f]+) ([+-|]) ?([^[]+)(\[tags:([^\]]+)])?/
+// const reg = /([^ ]+) ▶ \[DEBU keybase ([^:]+):(\d+)] ([0-9a-f]+) ([+-|])\ ?([^ ]+)[^[]*(\[tags:([^\]]+)])?/
+// const reg = /([^ ]+) ▶ \[DEBU keybase ([^:]+):(\d+)] ([0-9a-f]+) ([+-|]) ?([^-[]+)[^[]*(\[tags:([^]]+)])?/
+// const reg = /([^ ]+) ▶ \[DEBU (?:keybase|kbfs) ([^:]+):(\d+)] ([0-9a-f]+) ([+-|])\ ?([^[]+)(\[tags:([^\]]+)])?/
+const reg = /([^ ]+) ▶ \[DEBU (?:keybase|kbfs) ([^:]+):(\d+)] ([0-9a-f]+) ([^[]+)(\[tags:([^\]]+)])?/
 const tagsReg = /\[tags:([^\]]+)]/
+// const methodPrefix = /^\W*/
+const methodPrefixReg = /^(\+\+Chat: )?/
+const methodResultReg = / -> .*$/
+const typeAndMethodReg = /^(\W*)/
 
 const convertLine = line => {
   const e = reg.exec(line)
   if (!e) {
-    console.log('Skipping unparsed line:', line)
+    // TODO put back
+    // console.log('Skipping unparsed line:', line)
     return
   }
-  const [, time, file, fileline, counter, type, method, _tags] = e
-  let tags = _tags && tagsReg.exec(_tags)
-  tags =
-    tags &&
-    tags[1]
-      .split(',')
-      .sort()
-      .join(',')
+  const [, time, file, fileline, counter, _typeAndMethod, _tags] = e
+  let tags = 'NO_TAG'
+  if (_tags) {
+    const match = tagsReg.exec(_tags)
+    if (match && match[1]) {
+      tags = match[1]
+        .split(',')
+        .sort()
+        .join(',')
+    }
+  }
+
+  // if (tags === 'NO_TAG') {
+  // if (line.indexOf('[tag]') !== -1) {
+  // console.log('missing tag?', line)
+  // }
+  // }
+
+  const typeAndMethod = _typeAndMethod
+    .replace(methodResultReg, '')
+    .replace(methodPrefixReg, '')
+    .trim()
+
+  let type = ''
+  const _type = typeAndMethodReg.exec(typeAndMethod)
+  if (_type && _type[1]) {
+    type = _type[1].trim()
+  } else {
+    // console.log(_type)
+  }
+
+  const method = typeAndMethod.replace(typeAndMethodReg, '').trim()
   return {
     counter,
     file,
     fileline,
+    line, // TODO remove
     method,
     tags,
     time,
@@ -30,20 +64,46 @@ const convertLine = line => {
   }
 }
 
-const started = {}
+const tags = {}
 
 lines.forEach(line => {
   const info = convertLine(line)
+  // console.log(info.type, '**', info.method, '**', info.tags)
   if (!info) return
+
+  // ensure good
+  if (!tags[info.tags]) {
+    tags[info.tags] = {}
+  }
+  const data = tags[info.tags]
+  const dataKey = info.method
+  // const dataKey = `${info.file}:${info.method}`
+
+  // if (info.counter === '06c') {
+  // console.log(info)
+  // console.log(tags)
+  // process.exit()
+  // } else {
+  // }
 
   switch (info.type) {
     case '+':
-      console.log('START', info.method)
+      if (data[dataKey]) {
+        console.log('COLLISION: ', '\n', info, '\n', data[dataKey])
+      }
+      console.log('INJECT!', dataKey)
+      data[dataKey] = info
       break
     case '-':
-      console.log('END', info.method)
+      if (data[dataKey]) {
+        console.log('FOUND!', dataKey)
+        data[dataKey] = undefined
+      } else {
+        console.log('Unmatched -:', info)
+      }
       break
     default:
-      console.log('Unknown line type:', info.type, ':', line)
+    // TODO put back
+    // console.log('Unknown line type:', info.type, ':', line)
   }
 })

--- a/shared/desktop/yarn-helper/log-to-trace.js
+++ b/shared/desktop/yarn-helper/log-to-trace.js
@@ -1,26 +1,80 @@
 // @flow
+const [, , guiOrCore, logfile, outfile] = process.argv
+if (['gui', 'core'].indexOf(guiOrCore) === -1 || !logfile || !outfile) {
+  console.log('Usage: node log-to-trace (gui|core) logfile outfile')
+  process.exit(1)
+}
+const isGUI = guiOrCore === 'gui'
 const fs = require('fs')
-const data = fs.readFileSync(process.argv[2], 'utf8')
 const moment = require('moment')
-const lines = data.split('\n')
+// core regs
 const reg = /([^ ]+) ▶ \[DEBU (keybase|kbfs) ([^:]+):(\d+)] ([0-9a-f]+) ([^[]+)(\[tags:([^\]]+)])?/
 const tagsReg = /\[tags:([^\]]+)]/
 const methodPrefixReg = /^(\+\+Chat: )?/
 const methodResultReg = / -> .*$/
 const typeAndMethodReg = /^(\W*)/
+// gui regs
+const guiCountTypeTimeReg = /\["(Info|Warn|Action)","([^"]+)","(.*)"]/
+const actionReg = /type: ([^ ]+) (.*)/
+const actionPayloadReg = /\\"/g
 
-if (process.argv.length !== 4) {
-  console.log('Usage: node log-to-trace logfile outfile')
-  process.exit(1)
+const convertGuiLine = line => {
+  const e = guiCountTypeTimeReg.exec(line)
+  if (!e) {
+    console.log('Skipping unparsed line:', line)
+    return
+  }
+  const [, type, time, _data] = e
+  let name = ''
+  let args = {}
+  switch (type) {
+    case 'Warn':
+      name = `W: ${_data}`
+      break
+    case 'Info':
+      name = `I: ${_data}`
+      break
+    case 'Action':
+      {
+        const m = actionReg.exec(_data)
+        if (m) {
+          const [, actionType, payload] = m
+          name = actionType
+          try {
+            args = JSON.parse(payload.replace(actionPayloadReg, '"'))
+          } catch (e) {
+            console.log('throw e', e)
+          }
+        } else {
+          console.log('Unparsed action!', line, _data)
+          name = 'Unparsed action'
+        }
+      }
+      break
+    default:
+      console.log('Unknown inner type', type)
+      return
+  }
+  const app = 'gui'
+
+  return {
+    app,
+    args,
+    id: name,
+    line,
+    name,
+    time,
+    type: 'gui',
+  }
 }
 
-const convertLine = line => {
+const convertCoreLine = line => {
   const e = reg.exec(line)
   if (!e) {
     console.log('Skipping unparsed line:', line)
     return
   }
-  const [, time, coreOrKbfs, file, fileline, counter, _typeAndMethod, _tags] = e
+  const [, time, app, file, fileline, counter, _typeAndMethod, _tags] = e
   let tags = 'NO_TAG'
   if (_tags) {
     const match = tagsReg.exec(_tags)
@@ -44,20 +98,26 @@ const convertLine = line => {
   }
 
   const method = typeAndMethod.replace(typeAndMethodReg, '').trim()
+  const args = {
+    counter: counter,
+    file: file,
+    line: fileline,
+  }
+  const id = `${tags}:${method}`
+  const name = method
   return {
-    coreOrKbfs,
-    counter,
-    file,
-    fileline,
+    app,
+    args,
+    id,
     line,
-    method,
-    tags,
+    name,
     time,
     type,
   }
 }
 
-const tags = {}
+const convertLine = isGUI ? convertGuiLine : convertCoreLine
+
 const output = {
   // injecting a start and overwriting an unmatched one
   collision: [],
@@ -70,17 +130,13 @@ const output = {
 }
 
 const buildEvent = (info, ph) => ({
-  args: {
-    counter: info.counter,
-    file: info.file,
-    line: info.fileline,
-  },
-  id: `${info.tags}:${info.method}`,
-  name: info.method,
+  args: info.args,
+  id: info.id,
+  name: info.name,
   ph,
   pid: 0,
-  tid: info.coreOrKbfs,
-  ts: moment(info.time).valueOf() * 1000,
+  tid: info.app,
+  ts: moment(info.time).valueOf() * (isGUI ? 1 : 1000),
 })
 
 const buildGood = (old, info) => {
@@ -93,34 +149,36 @@ const buildGood = (old, info) => {
   return [s, e]
 }
 
+const lines = fs.readFileSync(logfile, 'utf8').split('\n')
+let lastGuiLine = null
+const knownIDs = {}
 lines.forEach(line => {
   const info = convertLine(line)
   if (!info) return
 
-  // ensure good
-  if (!tags[info.tags]) {
-    tags[info.tags] = {}
-  }
-
-  const data = tags[info.tags]
-  const dataKey = info.method
-
   switch (info.type) {
     case '+':
-      if (data[dataKey]) {
-        output.single = output.single.concat(buildEvent(data[dataKey], 'i'))
+      if (knownIDs[info.id]) {
+        output.single = output.single.concat(buildEvent(knownIDs[info.id], 'i'))
         output.collision.push(info)
       }
-      data[dataKey] = info
+      knownIDs[info.id] = info
       break
     case '-':
-      if (data[dataKey]) {
-        output.good = output.good.concat(buildGood(data[dataKey], info))
-        data[dataKey] = undefined
+      if (knownIDs[info.id]) {
+        output.good = output.good.concat(buildGood(knownIDs[info.id], info))
+        knownIDs[info.id] = undefined
       } else {
         output.single = output.single.concat(buildEvent(info, 'i'))
         output.unmatched.push(info)
       }
+      break
+    case 'gui':
+      // treat all these single fires as a span of time w/ the last item
+      if (lastGuiLine) {
+        output.good = output.good.concat(buildGood(lastGuiLine, {...info, id: lastGuiLine.id}))
+      }
+      lastGuiLine = info
       break
     default:
     // console.log('Unknown line type:', info.type, ':', line)
@@ -142,4 +200,4 @@ const format = {
   traceEvents: [...output.good, ...output.single],
 }
 const out = JSON.stringify(format, null, 2)
-fs.writeFileSync(process.argv[3], out, 'utf8')
+fs.writeFileSync(outfile, out, 'utf8')

--- a/shared/desktop/yarn-helper/log-to-trace.js
+++ b/shared/desktop/yarn-helper/log-to-trace.js
@@ -11,7 +11,7 @@ const convertLine = line => {
     console.log('Skipping unparsed line:', line)
     return
   }
-  const [, time, file, fileline, counter, plusMinus, method, _tags] = e
+  const [, time, file, fileline, counter, type, method, _tags] = e
   let tags = _tags && tagsReg.exec(_tags)
   tags =
     tags &&
@@ -24,9 +24,9 @@ const convertLine = line => {
     file,
     fileline,
     method,
-    plusMinus,
     tags,
     time,
+    type,
   }
 }
 
@@ -34,4 +34,16 @@ const started = {}
 
 lines.forEach(line => {
   const info = convertLine(line)
+  if (!info) return
+
+  switch (info.type) {
+    case '+':
+      console.log('START', info.method)
+      break
+    case '-':
+      console.log('END', info.method)
+      break
+    default:
+      console.log('Unknown line type:', info.type, ':', line)
+  }
 })

--- a/shared/package.json
+++ b/shared/package.json
@@ -50,7 +50,8 @@
     "build-storybook": "build-storybook",
     "modules": "yarn install --pure-lockfile --ignore-optional",
     "coverage-report": "flow-coverage-report --exclude-non-flow -o ./coverage -t text -t html",
-    "coverage": "flow coverage --color "
+    "coverage": "flow coverage --color ",
+    "log-to-trace": "node desktop/yarn-helper/log-to-trace.js"
   },
   "flow-coverage-report": {
     "concurrentFiles": 50,


### PR DESCRIPTION
Given a gui log:
```
yarn log-to-trace gui ~/Downloads/gu.log ~/Desktop/trace.txt
```

Given a core log:
```
yarn log-to-trace core ~/Downloads/keybase.log ~/Desktop/trace.txt
```

Then open chrome
```
chrome://tracing/
```
and click load