### PR TITLE
Add new rotation rules for open teams

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1551,6 +1551,9 @@ func (t *teamSigchainPlayer) addInnerLink(
 		err = enforce(LinkRules{
 			Admin:    TristateOptional,
 			Settings: TristateRequire,
+			// Allow key rotation in settings link. Closing an open team
+			// should rotate team key.
+			PerTeamKey: TristateOptional,
 			// At the moment the only team setting is banned in implicit teams.
 			// But in the future there could be allowed settings that also use this link type.
 			AllowInImplicitTeam: true,
@@ -1568,6 +1571,21 @@ func (t *teamSigchainPlayer) addInnerLink(
 		err = t.parseTeamSettings(team.Settings, &res.newState)
 		if err != nil {
 			return res, err
+		}
+
+		// When team is changed from open to closed, per-team-key should be rotated. But
+		// this is not enforced.
+		if team.PerTeamKey != nil {
+			lastKey, err := res.newState.GetLatestPerTeamKey()
+			if err != nil {
+				return res, fmt.Errorf("getting previous per-team-key: %s", err)
+			}
+			newKey, err := t.checkPerTeamKey(*link.source, *team.PerTeamKey, lastKey.Gen+keybase1.PerTeamKeyGeneration(1))
+			if err != nil {
+				return res, err
+			}
+			res.newState.inner.PerTeamKeys[newKey.Gen] = newKey
+			res.newState.inner.PerTeamKeyCTime = keybase1.UnixTime(payload.Ctime)
 		}
 	case libkb.LinkTypeDeleteRoot:
 		return res, NewTeamDeletedError()

--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -2,6 +2,7 @@ package teams
 
 import (
 	"context"
+	"encoding/hex"
 	"strings"
 	"testing"
 	"time"
@@ -650,4 +651,82 @@ func TestDowngradeImplicitAdminAfterReset(t *testing.T) {
 	// to bad team key coverage.
 	_, err = AddMember(context.TODO(), tc.G, sub, otherB.Username, keybase1.TeamRole_ADMIN)
 	require.NoError(t, err)
+}
+
+func TestRotationWhenClosingOpenTeam(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	defer tc.Cleanup()
+
+	_, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
+
+	tryCloseTeam := func(rotateWithSettings bool) {
+		t.Logf("tryCloseTeam(rotateWithSettings=%t)", rotateWithSettings)
+
+		b, err := libkb.RandBytes(4)
+		require.NoError(tc.T, err)
+
+		teamName := hex.EncodeToString(b)
+		_, err = CreateRootTeam(context.Background(), tc.G, teamName, keybase1.TeamSettings{
+			Open:   true,
+			JoinAs: keybase1.TeamRole_WRITER,
+		})
+		require.NoError(tc.T, err)
+
+		teamObj, err := GetForTestByStringName(context.Background(), tc.G, teamName)
+		require.NoError(t, err)
+
+		currentGen := teamObj.Generation()
+		if rotateWithSettings {
+			err = teamObj.PostTeamSettings(context.Background(), keybase1.TeamSettings{
+				Open: false,
+			}, true /* rotate */)
+			require.NoError(t, err)
+		} else {
+			err = ChangeTeamSettings(context.Background(), tc.G, teamName, keybase1.TeamSettings{
+				Open: false,
+			})
+			require.NoError(t, err)
+		}
+
+		teamObj, err = GetForTestByStringName(context.Background(), tc.G, teamName)
+		require.NoError(t, err)                              // ensures team settings link did not break loading
+		require.Equal(t, currentGen+1, teamObj.Generation()) // and we got new per team key
+	}
+
+	// Try to close team using PostTeamSettings(rotate=true) which posts
+	// TeamSettings link with per-team-key in it. So it closes team and rotates
+	// key in one link.
+	tryCloseTeam(true)
+
+	// Close team using ChangeTeamSettings service_helper API, which posts two
+	// links, to stay compatible with older clients sigchain parsers.
+	tryCloseTeam(false)
+}
+
+func TestRemoveFromOpenTeam(t *testing.T) {
+	// Removals from open teams should not cause rotation.
+	tc, _, otherA, _, name := memberSetupMultiple(t)
+	defer tc.Cleanup()
+
+	err := ChangeTeamSettings(context.Background(), tc.G, name, keybase1.TeamSettings{
+		Open:   true,
+		JoinAs: keybase1.TeamRole_WRITER,
+	})
+	require.NoError(t, err)
+
+	teamObj, err := GetForTestByStringName(context.Background(), tc.G, name)
+	require.NoError(t, err)
+
+	currentGen := teamObj.Generation()
+	err = SetRoleWriter(context.Background(), tc.G, name, otherA.Username)
+	require.NoError(t, err)
+
+	err = RemoveMember(context.Background(), tc.G, name, otherA.Username)
+	require.NoError(t, err)
+
+	// Expecting generation to stay the same after removal.
+	teamObj, err = GetForTestByStringName(context.Background(), tc.G, name)
+	require.NoError(t, err)
+	require.Equal(t, currentGen, teamObj.Generation())
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1196,7 +1196,10 @@ func GetRootID(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) 
 }
 
 func ChangeTeamSettings(ctx context.Context, g *libkb.GlobalContext, teamName string, settings keybase1.TeamSettings) error {
-	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
+	var rotateKey bool
+	var teamID keybase1.TeamID
+
+	err := RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
 		t, err := GetForTeamManagementByStringName(ctx, g, teamName, true)
 		if err != nil {
 			return err
@@ -1213,8 +1216,21 @@ func ChangeTeamSettings(ctx context.Context, g *libkb.GlobalContext, teamName st
 			return nil
 		}
 
-		return t.PostTeamSettings(ctx, settings)
+		teamID = t.ID
+		rotateKey = t.IsOpen() && !settings.Open
+		// Even if rotateKey is true, we are rotating as separate link right now.
+		// This is because rotation in TeamSettings link used to not be allowed,
+		// so not every client in the wild can parse a team with that.
+		return t.PostTeamSettings(ctx, settings, false /* rotate */)
 	})
+	if err != nil {
+		return err
+	}
+	if rotateKey {
+		g.Log.CDebugf(ctx, "ChangeTeamSettings will rotate key after posting settings (team ID: %s)", teamID)
+		err = RotateKey(ctx, g, teamID)
+	}
+	return err
 }
 
 func removeMemberInvite(ctx context.Context, g *libkb.GlobalContext, team *Team, username string, uv keybase1.UserVersion) error {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -55,6 +55,11 @@ func (t *Team) CanSkipKeyRotation() bool {
 		return false
 	}
 
+	if t.IsOpen() {
+		// Skip all rotations in open teams.
+		return true
+	}
+
 	// If cannot decide because of an error, return default false.
 	members, err := t.UsersWithRoleOrAbove(keybase1.TeamRole_READER)
 	if err != nil {
@@ -1679,7 +1684,7 @@ func (t *Team) loadAllTransitiveSubteams(ctx context.Context, forceRepoll bool) 
 	return subteams, nil
 }
 
-func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSettings) error {
+func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSettings, rotate bool) error {
 	if _, err := t.SharedSecret(ctx); err != nil {
 		return err
 	}
@@ -1702,12 +1707,36 @@ func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSetti
 		Public:   t.IsPublic(),
 	}
 
-	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeSettings, nil, sigPayloadArgs{})
+	payloadArgs := sigPayloadArgs{}
+	var maybeEKPayload *teamEKPayload
+	if rotate {
+		// Create empty Members section. We are not changing memberships, but
+		// it's needed for key rotation.
+		memSet := newMemberSet()
+		section.Members, err = memSet.Section()
+		if err != nil {
+			return err
+		}
+		secretBoxes, perTeamKeySection, teamEKPayload, err := t.rotateBoxes(ctx, memSet)
+		if err != nil {
+			return err
+		}
+		section.PerTeamKey = perTeamKeySection
+		payloadArgs.secretBoxes = secretBoxes
+		payloadArgs.teamEKPayload = teamEKPayload
+		maybeEKPayload = teamEKPayload // for storeTeamEKPayload, after post succeeds
+	}
+	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeSettings, nil, payloadArgs)
 	if err != nil {
 		return err
 	}
 
-	t.notify(ctx, keybase1.TeamChangeSet{Misc: true}, latestSeqno)
+	if rotate {
+		t.notify(ctx, keybase1.TeamChangeSet{KeyRotated: true, Misc: true}, latestSeqno)
+		t.storeTeamEKPayload(ctx, maybeEKPayload)
+	} else {
+		t.notify(ctx, keybase1.TeamChangeSet{Misc: true}, latestSeqno)
+	}
 	return nil
 }
 


### PR DESCRIPTION
- Make the client skip all rotations on open teams (e.g. when removing members).
- Allow `PerTeamKey` section in `TeamSettings` link.
- Rotate team key when setting team from open to closed.
    - This happens by a separate `RotateKey` link now (so two new links total), but there is code to make it happen in the same `TeamSettings` link. But teamchain parser change has to bake 🍞.