### PR TITLE
add new whitelist exemption for a single message CORE-9599

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2389,7 +2389,7 @@ func (h *Server) ResolveUnfurlPrompt(ctx context.Context, arg chat1.ResolveUnfur
 		}
 	case chat1.UnfurlPromptAction_ONETIME:
 		h.G().Unfurler.WhitelistAddExemption(ctx, uid,
-			unfurl.NewOneTimeWhitelistExemption(arg.ConvID, arg.MsgID, arg.Result.Onetime()))
+			unfurl.NewSingleMessageWhitelistExemption(arg.ConvID, arg.MsgID, arg.Result.Onetime()))
 		if err = fetchAndUnfurl(); err != nil {
 			return fmt.Errorf("failed to fetch and unfurl: %s", err)
 		}

--- a/go/chat/unfurl/exemption.go
+++ b/go/chat/unfurl/exemption.go
@@ -44,6 +44,40 @@ func (o *OneTimeWhitelistExemption) Domain() string {
 	return o.domain
 }
 
+type SingleMessageWhitelistExemption struct {
+	sync.Mutex
+	convID chat1.ConversationID
+	msgID  chat1.MessageID
+	domain string
+}
+
+var _ (types.WhitelistExemption) = (*SingleMessageWhitelistExemption)(nil)
+
+func NewSingleMessageWhitelistExemption(convID chat1.ConversationID, msgID chat1.MessageID, domain string) *SingleMessageWhitelistExemption {
+	return &SingleMessageWhitelistExemption{
+		convID: convID,
+		msgID:  msgID,
+		domain: domain,
+	}
+}
+
+func (o *SingleMessageWhitelistExemption) Use() bool {
+	o.Lock()
+	defer o.Unlock()
+	return true
+}
+
+func (o *SingleMessageWhitelistExemption) Matches(convID chat1.ConversationID, msgID chat1.MessageID,
+	domain string) bool {
+	return o.convID.Eq(convID) && o.msgID == msgID && o.domain == domain
+}
+
+func (o *SingleMessageWhitelistExemption) Domain() string {
+	o.Lock()
+	defer o.Unlock()
+	return o.domain
+}
+
 type WhitelistExemptionList struct {
 	sync.Mutex
 	exemptions []types.WhitelistExemption

--- a/go/chat/unfurl/extractor_test.go
+++ b/go/chat/unfurl/extractor_test.go
@@ -180,6 +180,21 @@ func TestExtractorExemptions(t *testing.T) {
 	require.Equal(t, 1, len(res))
 	require.Equal(t, ExtractorHitPrompt, res[0].Typ)
 
+	res, err = extractor.Extract(context.TODO(), uid, convID, msgID, "http://google.com", settingsMod)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, ExtractorHitPrompt, res[0].Typ)
+	extractor.AddWhitelistExemption(context.TODO(), uid,
+		NewSingleMessageWhitelistExemption(convID, msgID, "google.com"))
+	res, err = extractor.Extract(context.TODO(), uid, convID, msgID, "http://google.com", settingsMod)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, ExtractorHitUnfurl, res[0].Typ)
+	res, err = extractor.Extract(context.TODO(), uid, convID, msgID, "http://google.com", settingsMod)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, ExtractorHitUnfurl, res[0].Typ)
+
 	require.NoError(t, settingsMod.Set(context.TODO(), uid, settings))
 	res, err = extractor.Extract(context.TODO(), uid, convID, msgID, "http://amazon.com", settingsMod)
 	require.NoError(t, err)


### PR DESCRIPTION
This just needs to be pinned to the message so that if you have the same domain in there twice they will both get unfurled.