### PR TITLE
add displayCurrency to AccountDetails and WalletAccountLocal

### DIFF
--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -5,7 +5,6 @@ package chat1
 
 import (
 	"errors"
-
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"

--- a/go/protocol/stellar1/extras.go
+++ b/go/protocol/stellar1/extras.go
@@ -386,3 +386,9 @@ func NewChatConversationID(b []byte) *ChatConversationID {
 	cid := ChatConversationID(hex.EncodeToString(b))
 	return &cid
 }
+
+func (a *AccountDetails) SetDefaultDisplayCurrency() {
+	if a.DisplayCurrency == "" {
+		a.DisplayCurrency = "USD"
+	}
+}

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -9,11 +9,12 @@ import (
 )
 
 type WalletAccountLocal struct {
-	AccountID          AccountID `codec:"accountID" json:"accountID"`
-	IsDefault          bool      `codec:"isDefault" json:"isDefault"`
-	Name               string    `codec:"name" json:"name"`
-	BalanceDescription string    `codec:"balanceDescription" json:"balanceDescription"`
-	Seqno              string    `codec:"seqno" json:"seqno"`
+	AccountID          AccountID     `codec:"accountID" json:"accountID"`
+	IsDefault          bool          `codec:"isDefault" json:"isDefault"`
+	Name               string        `codec:"name" json:"name"`
+	BalanceDescription string        `codec:"balanceDescription" json:"balanceDescription"`
+	Seqno              string        `codec:"seqno" json:"seqno"`
+	CurrencyLocal      CurrencyLocal `codec:"currencyLocal" json:"currencyLocal"`
 }
 
 func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
@@ -23,6 +24,7 @@ func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
 		Name:               o.Name,
 		BalanceDescription: o.BalanceDescription,
 		Seqno:              o.Seqno,
+		CurrencyLocal:      o.CurrencyLocal.DeepCopy(),
 	}
 }
 

--- a/go/protocol/stellar1/remote.go
+++ b/go/protocol/stellar1/remote.go
@@ -453,6 +453,7 @@ type AccountDetails struct {
 	Reserves          []AccountReserve `codec:"reserves" json:"reserves"`
 	ReadTransactionID *TransactionID   `codec:"readTransactionID,omitempty" json:"readTransactionID,omitempty"`
 	UnreadPayments    int              `codec:"unreadPayments" json:"unreadPayments"`
+	DisplayCurrency   string           `codec:"displayCurrency" json:"displayCurrency"`
 }
 
 func (o AccountDetails) DeepCopy() AccountDetails {
@@ -490,7 +491,8 @@ func (o AccountDetails) DeepCopy() AccountDetails {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.ReadTransactionID),
-		UnreadPayments: o.UnreadPayments,
+		UnreadPayments:  o.UnreadPayments,
+		DisplayCurrency: o.DisplayCurrency,
 	}
 }
 

--- a/go/stellar/bpc.go
+++ b/go/stellar/bpc.go
@@ -122,6 +122,6 @@ func (c *buildPaymentCache) AvailableXLMToSend(mctx libkb.MetaContext,
 
 func (c *buildPaymentCache) GetOutsideCurrencyPreference(mctx libkb.MetaContext,
 	accountID stellar1.AccountID) (stellar1.OutsideCurrencyCode, error) {
-	cr, err := GetCurrencySetting(mctx, c.remoter, accountID)
+	cr, err := GetCurrencySetting(mctx, accountID)
 	return cr.Code, err
 }

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -766,6 +766,7 @@ func Details(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.Acc
 	if err := g.API.GetDecode(apiArg, &res); err != nil {
 		return stellar1.AccountDetails{}, err
 	}
+	res.Details.SetDefaultDisplayCurrency()
 
 	return res.Details, nil
 }
@@ -1012,6 +1013,14 @@ func GetAccountDisplayCurrency(ctx context.Context, g *libkb.GlobalContext, acco
 
 func SetAccountDefaultCurrency(ctx context.Context, g *libkb.GlobalContext, accountID stellar1.AccountID,
 	currency string) error {
+
+	conf, err := g.GetStellar().GetServerDefinitions(ctx)
+	if err != nil {
+		return err
+	}
+	if _, ok := conf.Currencies[stellar1.OutsideCurrencyCode(currency)]; !ok {
+		return fmt.Errorf("Unknown currency code: %q", currency)
+	}
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/accountcurrency",
 		SessionType: libkb.APISessionTypeREQUIRED,
@@ -1021,7 +1030,7 @@ func SetAccountDefaultCurrency(ctx context.Context, g *libkb.GlobalContext, acco
 		},
 		NetContext: ctx,
 	}
-	_, err := g.API.Post(apiArg)
+	_, err = g.API.Post(apiArg)
 	return err
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -665,7 +665,7 @@ func SpecMiniChatPayments(mctx libkb.MetaContext, walletState *WalletState, paym
 		return nil, err
 	}
 	senderAccountID := senderAccountBundle.AccountID
-	senderCurrency, err := GetCurrencySetting(mctx, walletState, senderAccountID)
+	senderCurrency, err := GetCurrencySetting(mctx, senderAccountID)
 	if err != nil {
 		return nil, err
 	}
@@ -1632,7 +1632,7 @@ func GetAccountDisplayCurrency(mctx libkb.MetaContext, accountID stellar1.Accoun
 	return codeStr, nil
 }
 
-func GetCurrencySetting(mctx libkb.MetaContext, remoter remote.Remoter, accountID stellar1.AccountID) (res stellar1.CurrencyLocal, err error) {
+func GetCurrencySetting(mctx libkb.MetaContext, accountID stellar1.AccountID) (res stellar1.CurrencyLocal, err error) {
 	codeStr, err := GetAccountDisplayCurrency(mctx, accountID)
 	if err != nil {
 		return res, err
@@ -1863,7 +1863,7 @@ func LookupUserByAccountID(m libkb.MetaContext, accountID stellar1.AccountID) (u
 // Note that it is possible that multiple users can own the same account and have
 // different display currency preferences.
 func AccountExchangeRate(mctx libkb.MetaContext, remoter remote.Remoter, accountID stellar1.AccountID) (stellar1.OutsideExchangeRate, error) {
-	currency, err := GetCurrencySetting(mctx, remoter, accountID)
+	currency, err := GetCurrencySetting(mctx, accountID)
 	if err != nil {
 		return stellar1.OutsideExchangeRate{}, err
 	}

--- a/go/stellar/stellarsvc/details.go
+++ b/go/stellar/stellarsvc/details.go
@@ -12,6 +12,7 @@ import (
 // stellar payment unread count for accountID.
 func (s *Server) accountDetails(ctx context.Context, accountID stellar1.AccountID) (stellar1.AccountDetails, error) {
 	details, err := s.remoter.Details(ctx, accountID)
+	details.SetDefaultDisplayCurrency()
 	if err != nil {
 		return details, err
 	}

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -86,6 +86,7 @@ func (s *Server) GetWalletAccountLocal(ctx context.Context, arg stellar1.GetWall
 }
 
 func (s *Server) accountLocal(ctx context.Context, entry stellar1.BundleEntryRestricted) (stellar1.WalletAccountLocal, error) {
+	mctx := libkb.NewMetaContext(ctx, s.G())
 	var empty stellar1.WalletAccountLocal
 	details, err := s.accountDetails(ctx, entry.AccountID)
 	if err != nil {
@@ -93,7 +94,7 @@ func (s *Server) accountLocal(ctx context.Context, entry stellar1.BundleEntryRes
 		return empty, err
 	}
 
-	return stellar.AccountDetailsToWalletAccountLocal(details, entry.IsPrimary, entry.Name)
+	return stellar.AccountDetailsToWalletAccountLocal(mctx, details, entry.IsPrimary, entry.Name)
 }
 
 func (s *Server) GetAccountAssetsLocal(ctx context.Context, arg stellar1.GetAccountAssetsLocalArg) (assets []stellar1.AccountAssetLocal, err error) {
@@ -587,13 +588,6 @@ func (s *Server) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.Ch
 	if arg.AccountID.IsNil() {
 		return errors.New("passed empty AccountID")
 	}
-	conf, err := s.G().GetStellar().GetServerDefinitions(ctx)
-	if err != nil {
-		return err
-	}
-	if _, ok := conf.Currencies[arg.Currency]; !ok {
-		return fmt.Errorf("Unknown currency code: %q", arg.Currency)
-	}
 	return remote.SetAccountDefaultCurrency(ctx, s.G(), arg.AccountID, string(arg.Currency))
 }
 
@@ -610,7 +604,7 @@ func (s *Server) GetDisplayCurrencyLocal(ctx context.Context, arg stellar1.GetDi
 		}
 		accountID = &primaryAccountID
 	}
-	return stellar.GetCurrencySetting(s.mctx(ctx), s.remoter, *accountID)
+	return stellar.GetCurrencySetting(s.mctx(ctx), *accountID)
 }
 
 func (s *Server) GetWalletAccountPublicKeyLocal(ctx context.Context, arg stellar1.GetWalletAccountPublicKeyLocalArg) (res string, err error) {

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -50,11 +50,18 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.True(t, accts[0].IsDefault)
 	require.Equal(t, "qq", accts[0].Name)
 	require.Equal(t, "10,000.00 XLM", accts[0].BalanceDescription)
+	currencyLocal := accts[0].CurrencyLocal
+	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
+	require.Equal(t, "US Dollar", currencyLocal.Name)
+	require.Equal(t, "USD ($)", currencyLocal.Description)
+	require.Equal(t, "$", currencyLocal.Symbol)
 	require.NotEmpty(t, accts[0].Seqno)
 
 	require.False(t, accts[1].IsDefault)
 	require.Equal(t, firstAccountName(t, tcs[0]), accts[1].Name)
 	require.Equal(t, "0 XLM", accts[1].BalanceDescription)
+	currencyLocal = accts[1].CurrencyLocal
+	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
 	require.NotEmpty(t, accts[1].Seqno)
 
 	// test the singular version as well
@@ -65,6 +72,8 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.True(t, details.IsDefault)
 	require.Equal(t, "10,000.00 XLM", details.BalanceDescription)
 	require.NotEmpty(t, details.Seqno)
+	currencyLocal = accts[1].CurrencyLocal
+	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
 
 	argDetails.AccountID = accts[1].AccountID
 	details, err = tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
@@ -73,6 +82,8 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.False(t, details.IsDefault)
 	require.Equal(t, "0 XLM", details.BalanceDescription)
 	require.NotEmpty(t, details.Seqno)
+	currencyLocal = accts[1].CurrencyLocal
+	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
 }
 
 func TestGetAccountAssetsLocalWithBalance(t *testing.T) {
@@ -143,6 +154,16 @@ func TestGetAccountAssetsLocalWithCHFBalance(t *testing.T) {
 	require.Equal(t, "CHF", assets[0].WorthCurrency)
 	require.Equal(t, "3,183.28 CHF", assets[0].Worth)
 	require.Equal(t, "3,182.96 CHF", assets[0].AvailableToSendWorth)
+
+	// changing currency also updates DisplayCurrency in GetWalletAccountLocal
+	argDetails := stellar1.GetWalletAccountLocalArg{AccountID: accountID}
+	details, err := tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
+	require.NoError(t, err)
+	currencyLocal := details.CurrencyLocal
+	require.Equal(t, stellar1.OutsideCurrencyCode("CHF"), currencyLocal.Code)
+	require.Equal(t, "Swiss Franc", currencyLocal.Name)
+	require.Equal(t, "CHF (CHF)", currencyLocal.Description)
+	require.Equal(t, "CHF", currencyLocal.Symbol)
 }
 
 func TestGetAccountAssetsLocalEmptyBalance(t *testing.T) {

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -458,10 +458,14 @@ func RemotePendingToLocal(mctx libkb.MetaContext, remoter remote.Remoter, accoun
 	return payments, nil
 }
 
-func AccountDetailsToWalletAccountLocal(details stellar1.AccountDetails, isPrimary bool, accountName string) (stellar1.WalletAccountLocal, error) {
+func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, details stellar1.AccountDetails, isPrimary bool, accountName string) (stellar1.WalletAccountLocal, error) {
 
 	var empty stellar1.WalletAccountLocal
 	balance, err := balanceList(details.Balances).balanceDescription()
+	if err != nil {
+		return empty, err
+	}
+	currencyLocal, err := GetCurrencySetting(mctx, details.AccountID)
 	if err != nil {
 		return empty, err
 	}
@@ -472,6 +476,7 @@ func AccountDetailsToWalletAccountLocal(details stellar1.AccountDetails, isPrima
 		Name:               accountName,
 		BalanceDescription: balance,
 		Seqno:              details.Seqno,
+		CurrencyLocal:      currencyLocal,
 	}
 
 	return acct, nil

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -414,7 +414,7 @@ func (a *AccountState) refresh(mctx libkb.MetaContext, router *libkb.NotifyRoute
 		a.Unlock()
 
 		if notify && router != nil {
-			accountLocal, err := AccountDetailsToWalletAccountLocal(details, isPrimary, name)
+			accountLocal, err := AccountDetailsToWalletAccountLocal(mctx, details, isPrimary, name)
 			if err == nil {
 				router.HandleWalletAccountDetailsUpdate(mctx.Ctx(), a.accountID, accountLocal)
 			}
@@ -580,6 +580,9 @@ func detailsChanged(a, b *stellar1.AccountDetails) bool {
 		}
 	}
 	if a.SubentryCount != b.SubentryCount {
+		return true
+	}
+	if a.DisplayCurrency != b.DisplayCurrency {
 		return true
 	}
 	if len(a.Balances) != len(b.Balances) {

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -12,6 +12,7 @@ protocol local {
     string name;                // the user-given name for the account
     string balanceDescription;  // example: "56.0227002 XLM + more"
     string seqno;               // the stellar sequence number for this account
+    CurrencyLocal currencyLocal;// user configurable, defaults to USD and related details
   }
   array<WalletAccountLocal> getWalletAccountsLocal(int sessionID);
   WalletAccountLocal getWalletAccountLocal(int sessionID, AccountID accountID);
@@ -83,7 +84,7 @@ protocol local {
     string currentWorth;            // "$379.12 USD" (worth at the current viewing time)
     string currentWorthCurrency;    // "USD", "CAD", of currentWorth
 
-    string issuerDescription;       // For non-XLM assets: either "Unknown issuer" or domain name 
+    string issuerDescription;       // For non-XLM assets: either "Unknown issuer" or domain name
                                     // ("example.com") if domain is verified by stellard.
     union{ null, AccountID } issuerAccountID;
 
@@ -148,7 +149,7 @@ protocol local {
     string currentWorth;            // "$379.12 CAD" (worth at the current viewing time)
     string currentWorthCurrency;    // "USD", "CAD", of currentWorth
 
-    string issuerDescription;       // For non-XLM assets: either "Unknown issuer" or domain name 
+    string issuerDescription;       // For non-XLM assets: either "Unknown issuer" or domain name
                                     // ("example.com") if domain is verified by stellard.
     union{ null, AccountID } issuerAccountID;
 

--- a/protocol/avdl/stellar1/remote.avdl
+++ b/protocol/avdl/stellar1/remote.avdl
@@ -144,19 +144,20 @@ protocol remote {
     array<AccountReserve> reserves;
     union { null, TransactionID } readTransactionID;
     int unreadPayments; // number of STELLAR payments that are "unread"
+    string displayCurrency; // user configurable, defaults to "USD"
   }
   AccountDetails details(keybase1.UserVersion caller, AccountID accountID);
 
   record PaymentsPage {
     array<PaymentSummary> payments;
     union { null, PageCursor } cursor;
-    union { null, TransactionID } oldestUnread;  
+    union { null, TransactionID } oldestUnread;
   }
   PaymentsPage recentPayments(keybase1.UserVersion caller, AccountID accountID, union { null, PageCursor } cursor, int limit, boolean skipPending);
 
   array<PaymentSummary> pendingPayments(keybase1.UserVersion caller, AccountID accountID, int limit);
 
-  // markAsRead will mark as "read" all the payments in an account created at or before the time 
+  // markAsRead will mark as "read" all the payments in an account created at or before the time
   // of the payment referenced by `mostRecentID`.
   void markAsRead(keybase1.UserVersion caller, AccountID accountID, TransactionID mostRecentID);
 

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -30,6 +30,10 @@
         {
           "type": "string",
           "name": "seqno"
+        },
+        {
+          "type": "CurrencyLocal",
+          "name": "currencyLocal"
         }
       ]
     },

--- a/protocol/json/stellar1/remote.json
+++ b/protocol/json/stellar1/remote.json
@@ -505,6 +505,10 @@
         {
           "type": "int",
           "name": "unreadPayments"
+        },
+        {
+          "type": "string",
+          "name": "displayCurrency"
         }
       ]
     },

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -277,7 +277,7 @@ export type AccountBundleVersion =
   | 9 // V9_9
   | 10 // V10_10
 
-export type AccountDetails = $ReadOnly<{accountID: AccountID, seqno: String, balances?: ?Array<Balance>, subentryCount: Int, available: String, reserves?: ?Array<AccountReserve>, readTransactionID?: ?TransactionID, unreadPayments: Int}>
+export type AccountDetails = $ReadOnly<{accountID: AccountID, seqno: String, balances?: ?Array<Balance>, subentryCount: Int, available: String, reserves?: ?Array<AccountReserve>, readTransactionID?: ?TransactionID, unreadPayments: Int, displayCurrency: String}>
 export type AccountID = String
 export type AccountMode =
   | 0 // NONE_0
@@ -419,7 +419,7 @@ export type TransactionStatus =
   | 4 // ERROR_PERMANENT_4
 
 export type UIPaymentReviewed = $ReadOnly<{bid: BuildPaymentID, seqno: Int, banners?: ?Array<SendBannerLocal>, nextButton: String}>
-export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String}>
+export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal}>
 
 export type IncomingCallMapType = {|'stellar.1.notify.paymentNotification'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.paymentNotification'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn, 'stellar.1.notify.paymentStatusNotification'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.paymentStatusNotification'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn, 'stellar.1.notify.requestStatusNotification'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.requestStatusNotification'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn, 'stellar.1.notify.accountDetailsUpdate'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.accountDetailsUpdate'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn, 'stellar.1.notify.pendingPaymentsUpdate'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.pendingPaymentsUpdate'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn, 'stellar.1.notify.recentPaymentsUpdate'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.recentPaymentsUpdate'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn, 'stellar.1.ui.paymentReviewed'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.ui.paymentReviewed'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn|}
 


### PR DESCRIPTION
* add the CurrencyLocal object (currency code, display string, etc.) to the return objects of GetWalletAccountLocal and GetWalletAccountsLocal rpcs. this should help reduce calls to other RPCs. 
* if it's not set, default to USD
* total aside: move the currency validation logic so it'll also run if display currency is changed from the CLI

see https://github.com/keybase/keybase/pull/3250 for related changes.