### PR TITLE
Cleanup WalletState refresh

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -701,7 +701,6 @@ type Stellar interface {
 	GetMigrationLock() *sync.Mutex
 	SpecMiniChatPayments(mctx MetaContext, payments []MiniChatPayment) (*MiniChatPaymentSummary, error)
 	SendMiniChatPayments(mctx MetaContext, payments []MiniChatPayment) ([]MiniChatPaymentResult, error)
-	RefreshWalletState(ctx context.Context)
 	HandleOobm(context.Context, gregor.OutOfBandMessage) (bool, error)
 }
 

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -50,8 +50,6 @@ func (n *nullStellar) SpecMiniChatPayments(mctx MetaContext, payments []MiniChat
 	return nil, errors.New("nullStellar SpecMiniChatPayments")
 }
 
-func (n *nullStellar) RefreshWalletState(ctx context.Context) {}
-
 func (n *nullStellar) HandleOobm(context.Context, gregor.OutOfBandMessage) (bool, error) {
 	return false, errors.New("nullStellar HandleOobm")
 }

--- a/go/protocol/stellar1/common.go
+++ b/go/protocol/stellar1/common.go
@@ -222,16 +222,18 @@ func (e RelayDirection) String() string {
 }
 
 type PaymentResult struct {
-	KeybaseID KeybaseTransactionID `codec:"keybaseID" json:"keybaseID"`
-	StellarID TransactionID        `codec:"stellarID" json:"stellarID"`
-	Pending   bool                 `codec:"pending" json:"pending"`
+	SenderAccountID AccountID            `codec:"senderAccountID" json:"senderAccountID"`
+	KeybaseID       KeybaseTransactionID `codec:"keybaseID" json:"keybaseID"`
+	StellarID       TransactionID        `codec:"stellarID" json:"stellarID"`
+	Pending         bool                 `codec:"pending" json:"pending"`
 }
 
 func (o PaymentResult) DeepCopy() PaymentResult {
 	return PaymentResult{
-		KeybaseID: o.KeybaseID.DeepCopy(),
-		StellarID: o.StellarID.DeepCopy(),
-		Pending:   o.Pending,
+		SenderAccountID: o.SenderAccountID.DeepCopy(),
+		KeybaseID:       o.KeybaseID.DeepCopy(),
+		StellarID:       o.StellarID.DeepCopy(),
+		Pending:         o.Pending,
 	}
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -329,7 +329,6 @@ func (d *Service) setupTeams() error {
 
 func (d *Service) setupStellar() error {
 	stellar.ServiceInit(d.G(), d.walletState, d.badger)
-	go d.walletState.RefreshAll(context.Background())
 	return nil
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -671,7 +671,7 @@ func (d *Service) chatOutboxPurgeCheck() {
 }
 
 func (d *Service) minuteChecks() {
-	ticker := libkb.NewBgTicker(1 * time.Minute)
+	ticker := libkb.NewBgTicker(5 * time.Minute)
 	m := libkb.NewMetaContextBackground(d.G()).WithLogTag("MINT")
 	d.G().PushShutdownHook(func() error {
 		m.CDebugf("stopping minuteChecks loop")
@@ -679,10 +679,9 @@ func (d *Service) minuteChecks() {
 		return nil
 	})
 	go func() {
-		d.walletState.RefreshAll(m.Ctx(), "service bg loop")
 		for {
 			<-ticker.C
-			m.CDebugf("+ minute check loop")
+			m.CDebugf("+ 5 minute check loop")
 
 			// In theory, this periodic refresh shouldn't be necessary,
 			// but as the WalletState code is new, this is a nice insurance
@@ -693,7 +692,7 @@ func (d *Service) minuteChecks() {
 				m.CDebugf("service walletState.RefreshAll error: %s", err)
 			}
 
-			m.CDebugf("- minute check loop")
+			m.CDebugf("- 5 minute check loop")
 		}
 	}()
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -679,7 +679,7 @@ func (d *Service) minuteChecks() {
 		return nil
 	})
 	go func() {
-		d.walletState.RefreshAll(m.Ctx())
+		d.walletState.RefreshAll(m.Ctx(), "service bg loop")
 		for {
 			<-ticker.C
 			m.CDebugf("+ minute check loop")
@@ -689,7 +689,7 @@ func (d *Service) minuteChecks() {
 			// policy.  The gregor payment notifications should
 			// keep the WalletState refreshed properly.
 			m.CDebugf("| refreshing wallet state")
-			if err := d.walletState.RefreshAll(m.Ctx()); err != nil {
+			if err := d.walletState.RefreshAll(m.Ctx(), "service bg loop"); err != nil {
 				m.CDebugf("service walletState.RefreshAll error: %s", err)
 			}
 

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -244,11 +244,11 @@ func (s *Stellar) handleReconnect(ctx context.Context) {
 	go func() {
 		ctx := context.Background()
 		if s.walletState.Primed() {
-			s.G().Log.CDebugf(ctx, "stellar received reconnect msg, doing wallet refresh on unprimed wallet")
-		} else {
 			s.G().Log.CDebugf(ctx, "stellar received reconnect msg, doing delayed wallet refresh")
 			time.Sleep(4 * time.Second)
 			s.G().Log.CDebugf(ctx, "stellar reconnect msg delay complete, refreshing wallet state")
+		} else {
+			s.G().Log.CDebugf(ctx, "stellar received reconnect msg, doing wallet refresh on unprimed wallet")
 		}
 		if err := s.walletState.RefreshAll(ctx, "reconnect"); err != nil {
 			s.G().Log.CDebugf(ctx, "Stellar.handleReconnect RefreshAll error: %s", err)

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -217,13 +217,6 @@ func (s *Stellar) SpecMiniChatPayments(mctx libkb.MetaContext, payments []libkb.
 	return SpecMiniChatPayments(mctx, s.walletState, payments)
 }
 
-// RefreshWalletState refreshes the WalletState.
-func (s *Stellar) RefreshWalletState(ctx context.Context) {
-	if err := s.walletState.RefreshAll(ctx); err != nil {
-		s.G().Log.CDebugf(ctx, "stellar global RefreshWalletState error: %s", err)
-	}
-}
-
 // HandleOobm will handle any out of band gregor messages for stellar.
 func (s *Stellar) HandleOobm(ctx context.Context, obm gregor.OutOfBandMessage) (bool, error) {
 	if obm.System() == nil {
@@ -249,7 +242,9 @@ func (s *Stellar) HandleOobm(ctx context.Context, obm gregor.OutOfBandMessage) (
 func (s *Stellar) handleReconnect(ctx context.Context) {
 	defer s.G().CTraceTimed(ctx, "Stellar.handleReconnect", func() error { return nil })()
 	s.G().Log.CDebugf(ctx, "stellar received reconnect msg, refreshing wallet state")
-	s.RefreshWalletState(ctx)
+	if err := s.walletState.RefreshAll(ctx); err != nil {
+		s.G().Log.CDebugf(ctx, "Stellar.handleReconnect RefreshAll error: %s", err)
+	}
 }
 
 func (s *Stellar) handlePaymentStatus(ctx context.Context, obm gregor.OutOfBandMessage) (err error) {

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -242,7 +242,7 @@ func (s *Stellar) HandleOobm(ctx context.Context, obm gregor.OutOfBandMessage) (
 func (s *Stellar) handleReconnect(ctx context.Context) {
 	defer s.G().CTraceTimed(ctx, "Stellar.handleReconnect", func() error { return nil })()
 	s.G().Log.CDebugf(ctx, "stellar received reconnect msg, refreshing wallet state")
-	if err := s.walletState.RefreshAll(ctx); err != nil {
+	if err := s.walletState.RefreshAll(ctx, "reconnect"); err != nil {
 		s.G().Log.CDebugf(ctx, "Stellar.handleReconnect RefreshAll error: %s", err)
 	}
 }
@@ -281,7 +281,7 @@ func (s *Stellar) handlePaymentNotification(ctx context.Context, obm gregor.OutO
 }
 
 func (s *Stellar) refreshPaymentFromNotification(ctx context.Context, accountID stellar1.AccountID, paymentID stellar1.PaymentID) error {
-	s.walletState.Refresh(ctx, accountID)
+	s.walletState.Refresh(ctx, accountID, "notification received")
 	DefaultLoader(s.G()).UpdatePayment(ctx, paymentID)
 
 	return nil

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -625,7 +625,7 @@ func sendPayment(m libkb.MetaContext, walletState *WalletState, sendArg SendPaym
 	}
 	m.CDebugf("sent payment (direct) kbTxID:%v txID:%v pending:%v", rres.KeybaseID, rres.StellarID, rres.Pending)
 
-	walletState.Refresh(m.Ctx(), senderEntry.AccountID)
+	walletState.Refresh(m.Ctx(), senderEntry.AccountID, "SubmitPayment")
 
 	if senderEntry.IsPrimary {
 		sendChat := func(mctx libkb.MetaContext) {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -295,7 +295,7 @@ func (s *Server) AcceptDisclaimerLocal(ctx context.Context, sessionID int) (err 
 		return fmt.Errorf("user wallet not created")
 	}
 
-	s.walletState.RefreshAll(ctx)
+	s.walletState.RefreshAll(ctx, "AcceptDisclaimer")
 
 	return nil
 }
@@ -321,7 +321,7 @@ func (s *Server) LinkNewWalletAccountLocal(ctx context.Context, arg stellar1.Lin
 		return "", err
 	}
 
-	s.walletState.RefreshAll(ctx)
+	s.walletState.RefreshAll(ctx, "LinkNewWalletAccount")
 
 	return accountID, nil
 }

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -1026,6 +1026,9 @@ func TestSendToSelf(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	tcs[0].Srv.walletState.Refresh(context.Background(), accountID1)
+	tcs[0].Srv.walletState.Refresh(context.Background(), accountID2)
+
 	page, err := tcs[0].Srv.GetPaymentsLocal(context.Background(), stellar1.GetPaymentsLocalArg{AccountID: accountID1})
 	require.NoError(t, err)
 	t.Logf("%v", spew.Sdump(page))

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -1026,8 +1026,8 @@ func TestSendToSelf(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tcs[0].Srv.walletState.Refresh(context.Background(), accountID1)
-	tcs[0].Srv.walletState.Refresh(context.Background(), accountID2)
+	tcs[0].Srv.walletState.Refresh(context.Background(), accountID1, "test")
+	tcs[0].Srv.walletState.Refresh(context.Background(), accountID2, "test")
 
 	page, err := tcs[0].Srv.GetPaymentsLocal(context.Background(), stellar1.GetPaymentsLocalArg{AccountID: accountID1})
 	require.NoError(t, err)
@@ -1380,8 +1380,8 @@ func TestBuildPaymentLocal(t *testing.T) {
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
 	tcs[0].Backend.Gift(senderAccountID, "20")
 	tcs[0].Backend.Gift(senderSecondaryAccountID, "30")
-	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID)
-	tcs[0].Srv.walletState.Refresh(context.Background(), senderSecondaryAccountID)
+	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID, "test")
+	tcs[0].Srv.walletState.Refresh(context.Background(), senderSecondaryAccountID, "test")
 
 	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
 		From:   senderAccountID,
@@ -1549,7 +1549,7 @@ func TestBuildPaymentLocal(t *testing.T) {
 	requireBannerSet(t, bres.DeepCopy().Banners, []stellar1.SendBannerLocal{})
 
 	tcs[0].Backend.Gift(senderAccountID, "30")
-	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID)
+	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID, "test")
 
 	t.Logf("sending in amount composed in USD")
 	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
@@ -1717,7 +1717,7 @@ func testBuildPaymentLocalBidHappy(t *testing.T, bypassReview bool) {
 	require.NoError(t, err)
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
 	tcs[0].Backend.Gift(senderAccountID, "100")
-	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID)
+	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID, "test")
 
 	bid1, err := tcs[0].Srv.StartBuildPaymentLocal(context.Background(), 0)
 	require.NoError(t, err)
@@ -1850,7 +1850,7 @@ func TestBuildPaymentLocalBidBlocked(t *testing.T) {
 	require.NoError(t, err)
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
 	tcs[0].Backend.Gift(senderAccountID, "100")
-	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID)
+	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID, "test")
 
 	send := func(bid stellar1.BuildPaymentID, amount string) (errorString string) {
 		_, err = tcs[0].Srv.SendPaymentLocal(context.Background(), stellar1.SendPaymentLocalArg{
@@ -2076,7 +2076,7 @@ func TestGetSendAssetChoices(t *testing.T) {
 	fakeAccts[0].AdjustAssetBalance(0, keys)
 	fakeAccts[0].AdjustAssetBalance(0, astro)
 
-	tcs[0].Srv.walletState.Refresh(context.Background(), fakeAccts[0].accountID)
+	tcs[0].Srv.walletState.Refresh(context.Background(), fakeAccts[0].accountID, "test")
 
 	// New asset choices should be visible
 	choices, err = tcs[0].Srv.GetSendAssetChoicesLocal(context.Background(), stellar1.GetSendAssetChoicesLocalArg{
@@ -2113,7 +2113,7 @@ func TestGetSendAssetChoices(t *testing.T) {
 	// Open AstroDollars for tcs[1]
 	fakeAccts2[0].AdjustAssetBalance(0, astro)
 
-	tcs[0].Srv.walletState.Refresh(context.Background(), fakeAccts[0].accountID)
+	tcs[0].Srv.walletState.Refresh(context.Background(), fakeAccts[0].accountID, "test")
 
 	choices2, err = tcs[0].Srv.GetSendAssetChoicesLocal(context.Background(), stellar1.GetSendAssetChoicesLocalArg{
 		From: fakeAccts[0].accountID,

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -976,7 +976,7 @@ func (r *BackendMock) ImportAccountsForUser(tc *TestContext) (res []*FakeAccount
 	}
 	r.Unlock()
 
-	tc.Srv.walletState.RefreshAll(context.Background())
+	tc.Srv.walletState.RefreshAll(context.Background(), "test")
 
 	return res
 }

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -122,13 +122,7 @@ func (s *Server) ImportSecretKeyLocal(ctx context.Context, arg stellar1.ImportSe
 		return err
 	}
 
-	err = stellar.ImportSecretKey(ctx, s.G(), arg.SecretKey, arg.MakePrimary, arg.Name)
-	/*
-		if err == nil {
-			s.wallet.RefreshAll(ctx)
-		}
-	*/
-	return err
+	return stellar.ImportSecretKey(ctx, s.G(), arg.SecretKey, arg.MakePrimary, arg.Name)
 }
 
 func (s *Server) ExportSecretKeyLocal(ctx context.Context, accountID stellar1.AccountID) (res stellar1.SecretKey, err error) {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -606,7 +606,7 @@ func testRelaySBS(t *testing.T, yank bool) {
 		require.NoError(t, err)
 	}
 
-	tcs[claimant].Srv.walletState.RefreshAll(context.Background())
+	tcs[claimant].Srv.walletState.RefreshAll(context.Background(), "test")
 
 	history, err := tcs[claimant].Srv.RecentPaymentsCLILocal(context.Background(), nil)
 	require.NoError(t, err)
@@ -694,7 +694,7 @@ func testRelaySBS(t *testing.T, yank bool) {
 		require.Equal(t, "Canceled", history[0].Payment.Status)
 	}
 
-	tcs[0].Srv.walletState.RefreshAll(context.Background())
+	tcs[0].Srv.walletState.RefreshAll(context.Background(), "test")
 
 	fhistoryPage, err = tcs[0].Srv.GetPaymentsLocal(context.Background(), stellar1.GetPaymentsLocalArg{AccountID: getPrimaryAccountID(tcs[0])})
 	require.NoError(t, err)
@@ -764,7 +764,7 @@ func testRelayReset(t *testing.T, yank bool) {
 		claimant = 0
 	}
 
-	tcs[claimant].Srv.walletState.RefreshAll(context.Background())
+	tcs[claimant].Srv.walletState.RefreshAll(context.Background(), "test")
 	tcs[claimant].Srv.walletState.DumpToLog(context.Background())
 
 	history, err := tcs[claimant].Srv.RecentPaymentsCLILocal(context.Background(), nil)

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -223,24 +223,6 @@ func (w *WalletState) RecentPayments(ctx context.Context, accountID stellar1.Acc
 	return a.RecentPayments(ctx)
 }
 
-// SubmitPayment is an override of remoter's SubmitPayment.
-func (w *WalletState) SubmitPayment(ctx context.Context, post stellar1.PaymentDirectPost) (stellar1.PaymentResult, error) {
-	result, err := w.Remoter.SubmitPayment(ctx, post)
-	if err == nil {
-		w.RefreshAll(ctx)
-	}
-	return result, err
-}
-
-// SubmitRelayPayment is an override of remoter's SubmitRelayPayment.
-func (w *WalletState) SubmitRelayPayment(ctx context.Context, post stellar1.PaymentRelayPost) (stellar1.PaymentResult, error) {
-	result, err := w.Remoter.SubmitRelayPayment(ctx, post)
-	if err == nil {
-		w.RefreshAll(ctx)
-	}
-	return result, err
-}
-
 // SubmitRelayClaim is an override of remoter's SubmitRelayClaim.
 func (w *WalletState) SubmitRelayClaim(ctx context.Context, post stellar1.RelayClaimPost) (stellar1.RelayClaimResult, error) {
 	result, err := w.Remoter.SubmitRelayClaim(ctx, post)

--- a/protocol/avdl/stellar1/common.avdl
+++ b/protocol/avdl/stellar1/common.avdl
@@ -55,6 +55,7 @@ protocol common {
   }
 
   record PaymentResult {
+    AccountID senderAccountID;
     KeybaseTransactionID keybaseID;
     // Direct: tx ID of the payment tx
     // Relay : tx ID of the funding payment tx

--- a/protocol/json/stellar1/common.json
+++ b/protocol/json/stellar1/common.json
@@ -155,6 +155,10 @@
       "name": "PaymentResult",
       "fields": [
         {
+          "type": "AccountID",
+          "name": "senderAccountID"
+        },
+        {
           "type": "KeybaseTransactionID",
           "name": "keybaseID"
         },

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -345,7 +345,7 @@ export type PaymentNotificationMsg = $ReadOnly<{accountID: AccountID, paymentID:
 export type PaymentOrErrorCLILocal = $ReadOnly<{payment?: ?PaymentCLILocal, err?: ?String}>
 export type PaymentOrErrorLocal = $ReadOnly<{payment?: ?PaymentLocal, err?: ?String}>
 export type PaymentRelayPost = $ReadOnly<{fromDeviceID: Keybase1.DeviceID, to?: ?Keybase1.UserVersion, toAssertion: String, relayAccount: AccountID, teamID: Keybase1.TeamID, displayAmount: String, displayCurrency: String, boxB64: String, signedTransaction: String, quickReturn: Boolean}>
-export type PaymentResult = $ReadOnly<{keybaseID: KeybaseTransactionID, stellarID: TransactionID, pending: Boolean}>
+export type PaymentResult = $ReadOnly<{senderAccountID: AccountID, keybaseID: KeybaseTransactionID, stellarID: TransactionID, pending: Boolean}>
 export type PaymentStatus =
   | 0 // NONE_0
   | 1 // PENDING_1


### PR DESCRIPTION
1. Only call RefreshAll once when the app starts (not 3 times)
2. on reconnect, if we have WalletState primed, wait 4s before refreshing
3. schedule a refresh when a get operation performed that returns wallet state data
4. increase the background loop timer to 5 minutes (I'm just about ready to kill it, but want to keep it for another day or two)
5. all refreshes have a "reason" to help debug why they happened
6. remove extra refresh calls from SubmitPayment