### PR TITLE
Review payment identifies the recipient

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -453,6 +453,7 @@ func (e *Identify2WithUID) runReturnError(m libkb.MetaContext) (err error) {
 
 	if e.hitFastCache(m) {
 		m.CDebugf("| hit fast cache")
+		e.maybeNotify(m, "hit fast cache")
 		return nil
 	}
 
@@ -482,11 +483,13 @@ func (e *Identify2WithUID) runReturnError(m libkb.MetaContext) (err error) {
 
 		if e.untrackedFastPath(m) {
 			m.CDebugf("| used untracked fast path")
+			e.maybeNotify(m, "untracked fast path")
 			return nil
 		}
 
 		if e.checkSlowCacheHit(m) {
 			m.CDebugf("| hit slow cache, first check")
+			e.maybeNotify(m, "slow cache, first check")
 			return nil
 		}
 	}
@@ -511,6 +514,7 @@ func (e *Identify2WithUID) runReturnError(m libkb.MetaContext) (err error) {
 
 	if e.useRemoteAssertions() && e.allowEarlyOuts() && e.checkSlowCacheHit(m) {
 		m.CDebugf("| hit slow cache, second check")
+		e.maybeNotify(m, "slow cache, second check")
 		return nil
 	}
 
@@ -818,9 +822,9 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 		return err
 	}
 
-	itm := libkb.IdentifyTableModeActive
+	identifyTableMode := libkb.IdentifyTableModeActive
 	if e.arg.IdentifyBehavior.ShouldSuppressTrackerPopups() {
-		itm = libkb.IdentifyTableModePassive
+		identifyTableMode = libkb.IdentifyTableModePassive
 	}
 
 	// When we get a callback from IDTabe().Identify, we don't get to thread our metacontext
@@ -828,7 +832,7 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	e.metaContext = m
 	if them.IDTable() == nil {
 		m.CDebugf("| No IDTable for user")
-	} else if err = them.IDTable().Identify(m, e.state, e.forceRemoteCheck(), iui, e, itm); err != nil {
+	} else if err = them.IDTable().Identify(m, e.state, e.forceRemoteCheck(), iui, e, identifyTableMode); err != nil {
 		m.CDebugf("| Failure in running IDTable")
 		return err
 	}
@@ -865,6 +869,10 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	if err == nil && !e.arg.NoErrorOnTrackFailure {
 		// We only care about tracking errors in this case; hence GetErrorLax
 		_, err = e.state.Result().GetErrorLax()
+	}
+
+	if outcome.IsOK() {
+		e.maybeNotify(m, "runIdentifyUI complete IsOk")
 	}
 
 	return err
@@ -1125,14 +1133,14 @@ func (e *Identify2WithUID) checkSlowCacheHit(m libkb.MetaContext) (ret bool) {
 		return false
 	}
 
-	tfn := func(u keybase1.Identify2ResUPK2) keybase1.Time { return u.IdentifiedAt }
-	dfn := func(u keybase1.Identify2ResUPK2) time.Duration {
+	timeFn := func(u keybase1.Identify2ResUPK2) keybase1.Time { return u.IdentifiedAt }
+	durationFn := func(u keybase1.Identify2ResUPK2) time.Duration {
 		if u.TrackBreaks != nil {
 			return libkb.Identify2CacheBrokenTimeout
 		}
 		return libkb.Identify2CacheLongTimeout
 	}
-	u, err := e.getCache().Get(e.them.GetUID(), tfn, dfn, e.arg.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks())
+	u, err := e.getCache().Get(e.them.GetUID(), timeFn, durationFn, e.arg.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks())
 
 	trackBrokenError := false
 	if err != nil {
@@ -1236,4 +1244,26 @@ func (e *Identify2WithUID) FullThemUser() *libkb.User {
 		return nil
 	}
 	return e.them.Full()
+}
+
+func (e *Identify2WithUID) maybeNotify(mctx libkb.MetaContext, explanation string) {
+	target := e.arg.Uid
+	if e.them != nil {
+		target = e.them.GetUID()
+	}
+	if e.me == nil {
+		// This check is needed because ActLoggedOut causes the untracked fast path
+		// to succeed even when the true active user is tracking the identifyee.
+		mctx.CDebugf("Identify2WithUID.maybeNotify(%v, %v) nope missing ME", target, explanation)
+	}
+	if target.IsNil() {
+		mctx.CDebugf("Identify2WithUID.maybeNotify(%v, %v) nope missing UID", target, explanation)
+		return
+	}
+	if e.arg.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks() {
+		mctx.CDebugf("Identify2WithUID.maybeNotify(%v, %v) nope WarningInsteadOfErrorOnBrokenTracks", target, explanation)
+		return
+	}
+	mctx.CDebugf("Identify2WithUID.maybeNotify(%v, %v) -> sending", target, explanation)
+	go mctx.G().IdentifyDispatch.NotifyTrackingSuccess(mctx, target)
 }

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -266,6 +266,7 @@ func (e *TrackToken) storeRemoteTrack(m libkb.MetaContext, pubKID keybase1.KID) 
 	}
 
 	me.SigChainBump(linkID, sigID, false)
+	m.G().IdentifyDispatch.NotifyTrackingSuccess(m, e.them.GetUID())
 
 	return err
 }

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -111,6 +111,7 @@ func (e *UntrackEngine) Run(m libkb.MetaContext) (err error) {
 
 	e.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetNormalizedName(), false)
 	e.G().NotifyRouter.HandleTrackingChanged(them.GetUID(), them.GetNormalizedName(), false)
+	m.G().IdentifyDispatch.NotifyTrackingSuccess(m, them.GetUID())
 
 	return
 }

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -311,7 +311,7 @@ func doRequestShared(m MetaContext, api Requester, arg APIArg, req *http.Request
 	timer.Report(req.Method + " " + arg.Endpoint)
 
 	if err != nil {
-		return nil, finisher, nil, APINetError{err: err}
+		return nil, finisher, nil, APINetError{Err: err}
 	}
 	status = internalResp.Status
 

--- a/go/libkb/api_test.go
+++ b/go/libkb/api_test.go
@@ -126,9 +126,9 @@ func checkX509Err(t *testing.T, err error) {
 		return
 	}
 
-	b, ok := a.err.(*url.Error)
+	b, ok := a.Err.(*url.Error)
 	if !ok {
-		t.Errorf("APINetError err field type: %T, expected *url.Error", a.err)
+		t.Errorf("APINetError err field type: %T, expected *url.Error", a.Err)
 		return
 	}
 

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -1365,11 +1365,11 @@ func NewUntrackError(d string, a ...interface{}) UntrackError {
 //=============================================================================
 
 type APINetError struct {
-	err error
+	Err error
 }
 
 func (e APINetError) Error() string {
-	return fmt.Sprintf("API network error: %s", e.err)
+	return fmt.Sprintf("API network error: %s", e.Err)
 }
 
 //=============================================================================

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -64,6 +64,7 @@ type GlobalContext struct {
 	AppState         *AppState            // The state of focus for the currently running instance of the app
 	ChatHelper       ChatHelper           // conveniently send chat messages
 	RPCCanceller     *RPCCanceller        // register live RPCs so they can be cancelleed en masse
+	IdentifyDispatch *IdentifyDispatch    // get notified of identify successes
 
 	cacheMu          *sync.RWMutex   // protects all caches
 	ProofCache       *ProofCache     // where to cache proof results
@@ -232,6 +233,7 @@ func (g *GlobalContext) Init() *GlobalContext {
 	g.localSigchainGuard = NewLocalSigchainGuard(g)
 	g.AppState = NewAppState(g)
 	g.RPCCanceller = NewRPCCanceller()
+	g.IdentifyDispatch = NewIdentifyDispatch()
 
 	g.Log.Debug("GlobalContext#Init(%p)\n", g)
 
@@ -337,6 +339,8 @@ func (g *GlobalContext) Logout(ctx context.Context) (err error) {
 	g.NotifyRouter.HandleLogout()
 
 	g.FeatureFlags.Clear()
+
+	g.IdentifyDispatch.OnLogout()
 
 	return nil
 }

--- a/go/libkb/identify_dispatch.go
+++ b/go/libkb/identify_dispatch.go
@@ -1,0 +1,66 @@
+package libkb
+
+import (
+	"sync"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+type IdentifyDispatchMsg struct {
+	Target keybase1.UID
+}
+
+type IdentifyDispatch struct {
+	sync.Mutex
+	listeners []chan<- IdentifyDispatchMsg
+}
+
+func NewIdentifyDispatch() *IdentifyDispatch { return &IdentifyDispatch{} }
+
+// NotifyTrackingSuccess notifies listeners that a target user has been found to satisfy tracking.
+// This could be through
+// - An identify call that heeded the active user's tracking of the target.
+// - A user tracked or untracked the target.
+// When the active user is the target all bets are off.
+func (d *IdentifyDispatch) NotifyTrackingSuccess(mctx MetaContext, target keybase1.UID) {
+	mctx.CDebugf("IdentifyDispatch.NotifyTrackingSuccess(%v)", target)
+	d.Lock()
+	defer d.Unlock()
+	for _, listener := range d.listeners {
+		select {
+		case listener <- IdentifyDispatchMsg{Target: target}:
+		default:
+		}
+	}
+}
+
+// Subscribe to notifications.
+// `unsubscribe` releases resources associated with the subscription and should be called asap.
+func (d *IdentifyDispatch) Subscribe(mctx MetaContext) (unsubscribe func(), recvCh <-chan IdentifyDispatchMsg) {
+	mctx.CDebugf("IdentifyDispatch.Subscribe")
+	ch := make(chan IdentifyDispatchMsg, 10)
+	d.Lock()
+	defer d.Unlock()
+	d.listeners = append(d.listeners, ch)
+	unsubscribe = func() {
+		mctx.CDebugf("IdentifyDispatch.Unsubcribe")
+		d.Lock()
+		defer d.Unlock()
+		var listeners []chan<- IdentifyDispatchMsg
+		for _, ch2 := range d.listeners {
+			if ch == ch2 {
+				continue
+			}
+			listeners = append(listeners, ch2)
+		}
+		d.listeners = listeners
+	}
+	return unsubscribe, ch
+}
+
+// OnLogout drops all subscriptions.
+func (d *IdentifyDispatch) OnLogout() {
+	d.Lock()
+	defer d.Unlock()
+	d.listeners = nil
+}

--- a/go/libkb/track.go
+++ b/go/libkb/track.go
@@ -453,7 +453,11 @@ func LocalTmpTrackChainLinkFor(m MetaContext, tracker, trackee keybase1.UID) (re
 
 func StoreLocalTrack(m MetaContext, tracker keybase1.UID, trackee keybase1.UID, expiringLocal bool, statement *jsonw.Wrapper) error {
 	m.CDebugf("| StoreLocalTrack, expiring = %v", expiringLocal)
-	return m.G().LocalDb.Put(LocalTrackDBKey(tracker, trackee, expiringLocal), nil, statement)
+	err := m.G().LocalDb.Put(LocalTrackDBKey(tracker, trackee, expiringLocal), nil, statement)
+	if err == nil {
+		m.G().IdentifyDispatch.NotifyTrackingSuccess(m, trackee)
+	}
+	return err
 }
 
 func removeLocalTrack(m MetaContext, tracker keybase1.UID, trackee keybase1.UID, expiringLocal bool) error {

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -170,6 +170,63 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 		}
 		wg.Wait()
 		return "", nil
+	case "reviewpayment":
+		// Send a payment including the review stage.
+		if len(args) != 1 {
+			return "", fmt.Errorf("require 1 args: <recipient>")
+		}
+		recipient := args[0]
+		sessionIDNext := 500
+		sessionID := func() int {
+			sessionIDNext++
+			return sessionIDNext - 1
+		}
+		bid, err := t.walletHandler.StartBuildPaymentLocal(ctx, sessionID())
+		if err != nil {
+			return "", err
+		}
+		log("%v", bid)
+
+		buildRes, err := t.walletHandler.BuildPaymentLocal(ctx, stellar1.BuildPaymentLocalArg{
+			SessionID:          sessionID(),
+			Bid:                bid,
+			FromPrimaryAccount: true,
+			To:                 recipient,
+			Amount:             "3.004",
+			SecretNote:         "xx",
+			PublicMemo:         "yy",
+		})
+		if err != nil {
+			return "", err
+		}
+		log("%v", spew.Sdump(buildRes))
+
+		err = t.walletHandler.ReviewPaymentLocal(ctx, stellar1.ReviewPaymentLocalArg{
+			SessionID: sessionID(),
+			Bid:       bid,
+		})
+		if err != nil {
+			return "", err
+		}
+		// Assume that the review closed because it succeeded.
+		// This is not necessarily true. Better would be to use stellar UI.
+		// Grep for "sending UIPaymentReview".
+
+		sendRes, err := t.walletHandler.SendPaymentLocal(ctx, stellar1.SendPaymentLocalArg{
+			SessionID:  sessionID(),
+			Bid:        bid,
+			From:       buildRes.From,
+			To:         recipient,
+			Amount:     "3.004",
+			Asset:      stellar1.AssetNative(),
+			SecretNote: "xx",
+			PublicMemo: "yy",
+		})
+		if err != nil {
+			return "", err
+		}
+		log("%v", spew.Sdump(sendRes))
+		return "done\n", nil
 	case "minichatpayment":
 		parsed := chatwallet.FindChatTxCandidates(strings.Join(args, " "))
 		minis := make([]libkb.MiniChatPayment, len(parsed))

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -113,6 +113,7 @@ func (s *Stellar) deleteDisclaimer() {
 }
 
 func (s *Stellar) clearBids() {
+	s.buildPaymentSlot.Stop()
 	s.bidLock.Lock()
 	defer s.bidLock.Unlock()
 	for _, bid := range s.bids {

--- a/go/stellar/send.go
+++ b/go/stellar/send.go
@@ -1,7 +1,9 @@
 package stellar
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
@@ -69,6 +71,10 @@ func SendPaymentLocal(mctx libkb.MetaContext, arg stellar1.SendPaymentLocalArg) 
 		}
 	}
 
+	var cancel func()
+	mctx, cancel = mctx.WithTimeout(30 * time.Second)
+	defer cancel()
+
 	sendRes, err := SendPaymentGUI(mctx, getGlobal(mctx.G()).walletState, SendPaymentArg{
 		From:           arg.From,
 		To:             stellarcommon.RecipientInput(to),
@@ -80,10 +86,26 @@ func SendPaymentLocal(mctx libkb.MetaContext, arg stellar1.SendPaymentLocalArg) 
 		QuickReturn:    arg.QuickReturn,
 	})
 	if err != nil {
+		if isTimeoutError(err) {
+			return res, fmt.Errorf("Timed out while sending payment. Look at your payment history and maybe try again.")
+		}
 		return res, err
 	}
 	return stellar1.SendPaymentResLocal{
 		KbTxID:  sendRes.KbTxID,
 		Pending: sendRes.Pending,
 	}, nil
+}
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if err == context.DeadlineExceeded {
+		return true
+	}
+	if err, ok := err.(libkb.APINetError); ok && err.Err == context.DeadlineExceeded {
+		return true
+	}
+	return false
 }

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -515,10 +515,6 @@ func SendPaymentGUI(m libkb.MetaContext, walletState *WalletState, sendArg SendP
 func sendPayment(m libkb.MetaContext, walletState *WalletState, sendArg SendPaymentArg, isCLI bool) (res SendPaymentResult, err error) {
 	defer m.CTraceTimed("Stellar.SendPayment", func() error { return err })()
 
-	if err = m.Ctx().Err(); err != nil {
-		return res, err
-	}
-
 	// look up sender account
 	senderEntry, senderAccountBundle, err := LookupSender(m.Ctx(), m.G(), sendArg.From)
 	if err != nil {

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -515,6 +515,10 @@ func SendPaymentGUI(m libkb.MetaContext, walletState *WalletState, sendArg SendP
 func sendPayment(m libkb.MetaContext, walletState *WalletState, sendArg SendPaymentArg, isCLI bool) (res SendPaymentResult, err error) {
 	defer m.CTraceTimed("Stellar.SendPayment", func() error { return err })()
 
+	if err = m.Ctx().Err(); err != nil {
+		return res, err
+	}
+
 	// look up sender account
 	senderEntry, senderAccountBundle, err := LookupSender(m.Ctx(), m.G(), sendArg.From)
 	if err != nil {
@@ -1224,6 +1228,7 @@ func localizePayment(ctx context.Context, g *libkb.GlobalContext, p stellar1.Pay
 func lookupRecipientAssertion(m libkb.MetaContext, assertion string, isCLI bool) (maybeUsername string, err error) {
 	defer m.CTraceTimed(fmt.Sprintf("Stellar.lookupRecipientAssertion(isCLI:%v, %v)", isCLI, assertion), func() error { return err })()
 	reason := fmt.Sprintf("Find transaction recipient for %s", assertion)
+
 	// GUI is a verified lookup modeled after func ResolveAndCheck.
 	arg := keybase1.Identify2Arg{
 		UserAssertion:         assertion,

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -1836,9 +1837,145 @@ func reviewPaymentExpectContractFailure(t testing.TB, tc *TestContext, arg stell
 	check(t)
 }
 
+// Start a review. Expect that the review will send a broken tracking banner and then hang.
+// `expectSuccess` can be called later after fixing the tracking and will assert that the review soon enables the button.
+func reviewPaymentExpectBrokenTracking(t testing.TB, tc *TestContext, arg stellar1.ReviewPaymentLocalArg) (expectSuccess func()) {
+	start := time.Now()
+	timeout := time.Second
+	if libkb.UseCITime(tc.G) {
+		timeout = 15 * time.Second
+	}
+	timeoutCh := time.After(timeout)
+	mockUI := tc.Srv.uiSource.(*testUISource).stellarUI.(*mockStellarUI)
+	original := mockUI.PaymentReviewedHandler
+	reviewDisabledCh := make(chan struct{}, 1)
+	// Install a handler that's geared for track failures.
+	mockUI.PaymentReviewedHandler = func(ctx context.Context, notification stellar1.PaymentReviewedArg) error {
+		assert.Equal(t, arg.Bid, notification.Msg.Bid)
+		switch notification.Msg.NextButton {
+		case "spinning":
+		case "disabled":
+			select {
+			case reviewDisabledCh <- struct{}{}:
+			default:
+				assert.Fail(t, "review disabled channel full")
+			}
+		default:
+			assert.Failf(t, "unexpected button status", "%v", notification.Msg.NextButton)
+		}
+		return nil
+	}
+	reviewFinishCh := make(chan error, 1)
+	go func() {
+		err := tc.Srv.ReviewPaymentLocal(context.Background(), arg)
+		reviewFinishCh <- err
+	}()
+	select {
+	case <-timeoutCh:
+		assert.Fail(t, "timed out")
+	case err := <-reviewFinishCh:
+		require.FailNowf(t, "review unexpectedly finished", "%v", err)
+	case <-reviewDisabledCh:
+		// great
+	}
+	t.Logf("review ran for %v", time.Since(start))
+	check(t)
+
+	// Install a new handler that's geared for success.
+	reviewEnabledCh := make(chan struct{}, 1)
+	mockUI.PaymentReviewedHandler = func(ctx context.Context, notification stellar1.PaymentReviewedArg) error {
+		assert.Equal(t, arg.Bid, notification.Msg.Bid)
+		switch notification.Msg.NextButton {
+		case "enabled":
+			select {
+			case reviewEnabledCh <- struct{}{}:
+			default:
+				assert.Fail(t, "review enabled channel full")
+			}
+		default:
+			assert.Failf(t, "unexpected button status", "%v", notification.Msg.NextButton)
+		}
+		return nil
+	}
+	return func() {
+		defer func() {
+			mockUI.PaymentReviewedHandler = original
+		}()
+		timeoutCh := time.After(timeout)
+		select {
+		case <-timeoutCh:
+			require.FailNow(t, "timed out")
+		case <-reviewEnabledCh:
+			// great
+		}
+		check(t)
+	}
+}
+
+// Review a payment.
+// - At first the review fails on a tracking failure.
+// - The user reaffirms their tracking of the recipient.
+// - As a result the review succeeds.
+func TestReviewPaymentLocal(t *testing.T) {
+	tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	acceptDisclaimer(tcs[0])
+	senderAccountID, err := stellar.GetOwnPrimaryAccountID(context.Background(), tcs[0].G)
+	require.NoError(t, err)
+	tcs[0].Backend.ImportAccountsForUser(tcs[0])
+	tcs[0].Backend.Gift(senderAccountID, "100")
+	tcs[0].Srv.walletState.Refresh(context.Background(), senderAccountID)
+
+	t.Logf("u1 proves rooter")
+	_, sigID := proveRooter(tcs[1])
+
+	t.Logf("u0 tracks u1")
+	_, err = kbtest.RunTrack(tcs[0].TestContext, tcs[0].Fu, tcs[1].Fu.Username)
+	require.NoError(t, err)
+
+	t.Logf("u1 removes their proof")
+	eng := engine.NewRevokeSigsEngine(tcs[1].G, []string{sigID.String()})
+	err = engine.RunEngine2(tcs[1].MetaContext().WithUIs(libkb.UIs{
+		LogUI:    tcs[1].G.UI.GetLogUI(),
+		SecretUI: &libkb.TestSecretUI{Passphrase: "dummy-passphrase"},
+	}), eng)
+	require.NoError(t, err)
+
+	t.Logf("u0 starts a payment")
+	bid1, err := tcs[0].Srv.StartBuildPaymentLocal(context.Background(), 0)
+	require.NoError(t, err)
+	amount := "11.0"
+	buildRes, err := tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		Bid:    bid1,
+		From:   senderAccountID,
+		To:     tcs[1].Fu.Username,
+		Amount: amount,
+	})
+	require.NoError(t, err)
+	require.Equal(t, true, buildRes.ReadyToReview)
+
+	t.Logf("u0 starts review of a payment, which gets stuck on u1's broken proof")
+	expectSuccess := reviewPaymentExpectBrokenTracking(t, tcs[0], stellar1.ReviewPaymentLocalArg{Bid: bid1})
+
+	t.Logf("u0 affirms tracking of u1, causing the review to complete")
+	_, err = kbtest.RunTrack(tcs[0].TestContext, tcs[0].Fu, tcs[1].Fu.Username)
+	require.NoError(t, err)
+	expectSuccess()
+
+	t.Logf("u0 completes the send")
+	_, err = tcs[0].Srv.SendPaymentLocal(context.Background(), stellar1.SendPaymentLocalArg{
+		Bid:    bid1,
+		From:   senderAccountID,
+		To:     tcs[1].Fu.Username,
+		Amount: amount,
+		Asset:  stellar1.AssetNative(),
+	})
+	require.NoError(t, err)
+}
+
 // Cases where Send is blocked because the build gamut wasn't run.
 func TestBuildPaymentLocalBidBlocked(t *testing.T) {
-	// xxx update this test to purposefully use or not use review
 	tcs, cleanup := setupNTests(t, 2)
 	defer cleanup()
 

--- a/go/stellar/stellarsvc/rooter_test.go
+++ b/go/stellar/stellarsvc/rooter_test.go
@@ -1,0 +1,111 @@
+// Stuff copied from engine tests
+package stellarsvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func proveRooter(tc *TestContext) (postID string, sigID keybase1.SigID) {
+	ui, sigID, err := proveRooterWithSecretUI(tc.G, tc.Fu, &libkb.TestSecretUI{}, libkb.GetDefaultSigVersion(tc.G))
+	require.NoError(tc.T, err)
+	return ui.postID, sigID
+}
+
+func proveRooterWithSecretUI(g *libkb.GlobalContext, fu *kbtest.FakeUser, secretUI libkb.SecretUI, sigVersion libkb.SigVersion) (*ProveUIMock, keybase1.SigID, error) {
+	sv := keybase1.SigVersion(sigVersion)
+	arg := keybase1.StartProofArg{
+		Service:      "rooter",
+		Username:     fu.Username,
+		Force:        false,
+		PromptPosted: true,
+		SigVersion:   &sv,
+	}
+
+	eng := engine.NewProve(g, &arg)
+
+	hook := func(arg keybase1.OkToCheckArg) (bool, string, error) {
+		sigID := eng.SigID()
+		if sigID.IsNil() {
+			return false, "", fmt.Errorf("empty sigID; can't make a post")
+		}
+		apiArg := libkb.APIArg{
+			Endpoint:    "rooter",
+			SessionType: libkb.APISessionTypeREQUIRED,
+			Args: libkb.HTTPArgs{
+				"post": libkb.S{Val: sigID.ToMediumID()},
+			},
+		}
+		res, err := g.API.Post(apiArg)
+		ok := err == nil
+		var postID string
+		if ok {
+			pid, err := res.Body.AtKey("post_id").GetString()
+			if err == nil {
+				postID = pid
+			}
+		}
+		return ok, postID, err
+	}
+
+	proveUI := &ProveUIMock{hook: hook}
+
+	uis := libkb.UIs{
+		LogUI:    g.UI.GetLogUI(),
+		SecretUI: secretUI,
+		ProveUI:  proveUI,
+	}
+	m := libkb.NewMetaContextTODO(g).WithUIs(uis)
+	err := engine.RunEngine2(m, eng)
+	return proveUI, eng.SigID(), err
+}
+
+type ProveUIMock struct {
+	username, recheck, overwrite, warning, checked bool
+	postID                                         string
+	hook                                           func(arg keybase1.OkToCheckArg) (bool, string, error)
+}
+
+func (p *ProveUIMock) PromptOverwrite(_ context.Context, arg keybase1.PromptOverwriteArg) (bool, error) {
+	p.overwrite = true
+	return true, nil
+}
+
+func (p *ProveUIMock) PromptUsername(_ context.Context, arg keybase1.PromptUsernameArg) (string, error) {
+	p.username = true
+	return "", nil
+}
+
+func (p *ProveUIMock) OutputPrechecks(_ context.Context, arg keybase1.OutputPrechecksArg) error {
+	return nil
+}
+
+func (p *ProveUIMock) PreProofWarning(_ context.Context, arg keybase1.PreProofWarningArg) (bool, error) {
+	p.warning = true
+	return true, nil
+}
+
+func (p *ProveUIMock) OutputInstructions(_ context.Context, arg keybase1.OutputInstructionsArg) error {
+	return nil
+}
+
+func (p *ProveUIMock) OkToCheck(_ context.Context, arg keybase1.OkToCheckArg) (bool, error) {
+	if !p.checked {
+		p.checked = true
+		ok, postID, err := p.hook(arg)
+		p.postID = postID
+		return ok, err
+	}
+	return false, fmt.Errorf("Check should have worked the first time!")
+}
+
+func (p *ProveUIMock) DisplayRecheckWarning(_ context.Context, arg keybase1.DisplayRecheckWarningArg) error {
+	p.recheck = true
+	return nil
+}

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -1372,7 +1372,7 @@ func setupTestsWithSettings(t *testing.T, settings []usetting) ([]*TestContext, 
 	require.True(t, len(settings) > 0, "must create at least 1 tc")
 	var tcs []*TestContext
 	bem := NewBackendMock(t)
-	for _, setting := range settings {
+	for i, setting := range settings {
 		tc := SetupTest(t, "wall", 1)
 		switch setting {
 		case usettingFull:
@@ -1394,6 +1394,7 @@ func setupTestsWithSettings(t *testing.T, settings []usetting) ([]*TestContext, 
 			// All TCs in a test share the same backend.
 			Backend: bem,
 		}
+		t.Logf("setup user %v %v", i, tc2.Fu.Username)
 		rcm := NewRemoteClientMock(tc2, bem)
 		ws := stellar.NewWalletState(tc.G, rcm)
 		tc2.Srv = New(tc.G, newTestUISource(), ws)


### PR DESCRIPTION
`reviewPaymentLocal` identifies the recipient. There are 3 outcomes.
1. The identify succeeds, the caller is notified, and the call exits. ReadyToSend
2. If an identify ever succeeds or the recipient is tracked or untracked by this device then the caller is notified just like 1.
3. The identify errors out, the caller gets a banner and then hangs out forever. If 2 ever happens that's great.