### PR TITLE
only count known TODO categories against badge counts

### DIFF
--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -82,10 +82,39 @@ type memberOutBody struct {
 	} `json:"reset_user"`
 }
 
+type homeTodoMap map[keybase1.HomeScreenTodoType]int
+type homeItemMap map[keybase1.HomeScreenItemType]homeTodoMap
+
 type homeStateBody struct {
 	Version        int           `json:"version"`
-	BadgeCount     int           `json:"badge_count"`
+	BadgeCountMap  homeItemMap   `json:"badge_count_map"`
 	LastViewedTime keybase1.Time `json:"last_viewed_time"`
+}
+
+// countKnownBadges looks at the map sent down by gregor and considers only those
+// types that are known to the client. The rest, it assumes it cannot display,
+// and doesn't count those badges toward the badge count. Note that the shape
+// of this map is two-deep in the case of home todo items, e.g.:
+//
+//   { 1 : { 2 : 3, 5 : 6 }, 3 : 4 }
+//
+// Implies that are 3 badges on TODO type CHAT, 5 badges on TODO type PAPERKEY,
+// and 4 badges on ANNOUNCEMENTs.
+//
+func countKnownBadges(m homeItemMap) int {
+	var ret int
+	for itemType, todoMap := range m {
+		if _, found := keybase1.HomeScreenItemTypeRevMap[itemType]; !found {
+			continue
+		}
+		for todoType, v := range todoMap {
+			if _, found := keybase1.HomeScreenTodoTypeRevMap[todoType]; !found {
+				continue
+			}
+			ret += v
+		}
+	}
+	return ret
 }
 
 // UpdateWithGregor updates the badge state from a gregor state.
@@ -130,7 +159,7 @@ func (b *BadgeState) UpdateWithGregor(ctx context.Context, gstate gregor.State) 
 			sentUp := false
 			if hsb == nil || hsb.Version < tmp.Version || (hsb.Version == tmp.Version && hsb.LastViewedTime < tmp.LastViewedTime) {
 				hsb = &tmp
-				b.state.HomeTodoItems = hsb.BadgeCount
+				b.state.HomeTodoItems = countKnownBadges(hsb.BadgeCountMap)
 				sentUp = true
 			}
 			b.log.Debug("incoming home.state (sentUp=%v): %+v", sentUp, tmp)

--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -96,10 +96,10 @@ type homeStateBody struct {
 // and doesn't count those badges toward the badge count. Note that the shape
 // of this map is two-deep in the case of home todo items, e.g.:
 //
-//   { 1 : { 2 : 3, 5 : 6 }, 3 : 4 }
+//   { 1 : { 2 : 3, 4 : 5 }, 3 : 7 }
 //
-// Implies that are 3 badges on TODO type CHAT, 5 badges on TODO type PAPERKEY,
-// and 4 badges on ANNOUNCEMENTs.
+// Implies that are 3 badges on TODO type PROOF, 5 badges on TODO type FOLLOW,
+// and 7 badges on ANNOUNCEMENTs.
 //
 func countKnownBadges(m homeItemMap) int {
 	var ret int

--- a/go/protocol/keybase1/home.go
+++ b/go/protocol/keybase1/home.go
@@ -239,53 +239,56 @@ func (o HomeScreenAnnouncement) DeepCopy() HomeScreenAnnouncement {
 type HomeScreenTodoType int
 
 const (
-	HomeScreenTodoType_NONE          HomeScreenTodoType = 0
-	HomeScreenTodoType_BIO           HomeScreenTodoType = 1
-	HomeScreenTodoType_PROOF         HomeScreenTodoType = 2
-	HomeScreenTodoType_DEVICE        HomeScreenTodoType = 3
-	HomeScreenTodoType_FOLLOW        HomeScreenTodoType = 4
-	HomeScreenTodoType_CHAT          HomeScreenTodoType = 5
-	HomeScreenTodoType_PAPERKEY      HomeScreenTodoType = 6
-	HomeScreenTodoType_TEAM          HomeScreenTodoType = 7
-	HomeScreenTodoType_FOLDER        HomeScreenTodoType = 8
-	HomeScreenTodoType_GIT_REPO      HomeScreenTodoType = 9
-	HomeScreenTodoType_TEAM_SHOWCASE HomeScreenTodoType = 10
-	HomeScreenTodoType_AVATAR_USER   HomeScreenTodoType = 11
-	HomeScreenTodoType_AVATAR_TEAM   HomeScreenTodoType = 12
+	HomeScreenTodoType_NONE                    HomeScreenTodoType = 0
+	HomeScreenTodoType_BIO                     HomeScreenTodoType = 1
+	HomeScreenTodoType_PROOF                   HomeScreenTodoType = 2
+	HomeScreenTodoType_DEVICE                  HomeScreenTodoType = 3
+	HomeScreenTodoType_FOLLOW                  HomeScreenTodoType = 4
+	HomeScreenTodoType_CHAT                    HomeScreenTodoType = 5
+	HomeScreenTodoType_PAPERKEY                HomeScreenTodoType = 6
+	HomeScreenTodoType_TEAM                    HomeScreenTodoType = 7
+	HomeScreenTodoType_FOLDER                  HomeScreenTodoType = 8
+	HomeScreenTodoType_GIT_REPO                HomeScreenTodoType = 9
+	HomeScreenTodoType_TEAM_SHOWCASE           HomeScreenTodoType = 10
+	HomeScreenTodoType_AVATAR_USER             HomeScreenTodoType = 11
+	HomeScreenTodoType_AVATAR_TEAM             HomeScreenTodoType = 12
+	HomeScreenTodoType_ANNONCEMENT_PLACEHOLDER HomeScreenTodoType = 10000
 )
 
 func (o HomeScreenTodoType) DeepCopy() HomeScreenTodoType { return o }
 
 var HomeScreenTodoTypeMap = map[string]HomeScreenTodoType{
-	"NONE":          0,
-	"BIO":           1,
-	"PROOF":         2,
-	"DEVICE":        3,
-	"FOLLOW":        4,
-	"CHAT":          5,
-	"PAPERKEY":      6,
-	"TEAM":          7,
-	"FOLDER":        8,
-	"GIT_REPO":      9,
-	"TEAM_SHOWCASE": 10,
-	"AVATAR_USER":   11,
-	"AVATAR_TEAM":   12,
+	"NONE":                    0,
+	"BIO":                     1,
+	"PROOF":                   2,
+	"DEVICE":                  3,
+	"FOLLOW":                  4,
+	"CHAT":                    5,
+	"PAPERKEY":                6,
+	"TEAM":                    7,
+	"FOLDER":                  8,
+	"GIT_REPO":                9,
+	"TEAM_SHOWCASE":           10,
+	"AVATAR_USER":             11,
+	"AVATAR_TEAM":             12,
+	"ANNONCEMENT_PLACEHOLDER": 10000,
 }
 
 var HomeScreenTodoTypeRevMap = map[HomeScreenTodoType]string{
-	0:  "NONE",
-	1:  "BIO",
-	2:  "PROOF",
-	3:  "DEVICE",
-	4:  "FOLLOW",
-	5:  "CHAT",
-	6:  "PAPERKEY",
-	7:  "TEAM",
-	8:  "FOLDER",
-	9:  "GIT_REPO",
-	10: "TEAM_SHOWCASE",
-	11: "AVATAR_USER",
-	12: "AVATAR_TEAM",
+	0:     "NONE",
+	1:     "BIO",
+	2:     "PROOF",
+	3:     "DEVICE",
+	4:     "FOLLOW",
+	5:     "CHAT",
+	6:     "PAPERKEY",
+	7:     "TEAM",
+	8:     "FOLDER",
+	9:     "GIT_REPO",
+	10:    "TEAM_SHOWCASE",
+	11:    "AVATAR_USER",
+	12:    "AVATAR_TEAM",
+	10000: "ANNONCEMENT_PLACEHOLDER",
 }
 
 func (e HomeScreenTodoType) String() string {

--- a/protocol/avdl/keybase1/home.avdl
+++ b/protocol/avdl/keybase1/home.avdl
@@ -59,7 +59,8 @@ protocol home {
     GIT_REPO_9,
     TEAM_SHOWCASE_10,
     AVATAR_USER_11,
-    AVATAR_TEAM_12
+    AVATAR_TEAM_12,
+    ANNONCEMENT_PLACEHOLDER_10000
   }
 
   variant HomeScreenTodo switch (HomeScreenTodoType t) {

--- a/protocol/json/keybase1/home.json
+++ b/protocol/json/keybase1/home.json
@@ -134,7 +134,8 @@
         "GIT_REPO_9",
         "TEAM_SHOWCASE_10",
         "AVATAR_USER_11",
-        "AVATAR_TEAM_12"
+        "AVATAR_TEAM_12",
+        "ANNONCEMENT_PLACEHOLDER_10000"
       ]
     },
     {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -378,6 +378,7 @@ export const homeHomeScreenTodoType = {
   teamShowcase: 10,
   avatarUser: 11,
   avatarTeam: 12,
+  annoncementPlaceholder: 10000,
 }
 
 export const identifyCommonIdentifyReasonType = {

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -1325,6 +1325,7 @@ export const homeHomeScreenTodoType = {
   teamShowcase: 10,
   avatarUser: 11,
   avatarTeam: 12,
+  annoncementPlaceholder: 10000,
 }
 
 export const identifyCommonIdentifyReasonType = {
@@ -2093,6 +2094,7 @@ export type HomeScreenTodoType =
   | 10 // TEAM_SHOWCASE_10
   | 11 // AVATAR_USER_11
   | 12 // AVATAR_TEAM_12
+  | 10000 // ANNONCEMENT_PLACEHOLDER_10000
 
 export type HomeUserSummary = $ReadOnly<{uid: UID, username: String, bio: String, fullName: String, pics?: ?Pics}>
 export type Identify2Res = $ReadOnly<{upk: UserPlusKeys, identifiedAt: Time, trackBreaks?: ?IdentifyTrackBreaks}>


### PR DESCRIPTION
- this way we won't get mystery badges when we push out new todo item types and old clients don't understand