### PR TITLE
Improve ephemeral key error messaging

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -320,8 +320,9 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 		var ephemeralSeed *keybase1.TeamEk
 		if boxed.IsEphemeral() {
 			ek, err := CtxKeyFinder(ctx, b.G()).EphemeralKeyForDecryption(
-				ctx, tlfName, boxed.ClientHeader.Conv.Tlfid, conv.GetMembersType(), boxed.ClientHeader.TlfPublic,
-				boxed.EphemeralMetadata().Generation)
+				ctx, tlfName, boxed.ClientHeader.Conv.Tlfid, conv.GetMembersType(),
+				boxed.ClientHeader.TlfPublic, boxed.EphemeralMetadata().Generation,
+				&boxed.ServerHeader.Ctime)
 			if err != nil {
 				b.Debug(ctx, "failed to get a key for ephemeral message: msgID: %d err: %v", boxed.ServerHeader.MessageID, err)
 				uberr = b.detectPermanentError(err, tlfName)

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1615,7 +1615,8 @@ func (k *KeyFinderMock) EphemeralKeyForEncryption(ctx context.Context, tlfName s
 }
 
 func (k *KeyFinderMock) EphemeralKeyForDecryption(ctx context.Context, tlfName string, tlfID chat1.TLFID,
-	membersType chat1.ConversationMembersType, public bool, generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
+	membersType chat1.ConversationMembersType, public bool,
+	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error) {
 	panic("unimplemented")
 }
 

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -767,7 +767,7 @@ func (f failingTlf) EphemeralEncryptionKey(ctx context.Context, tlfName string, 
 
 func (f failingTlf) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
-	generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
+	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error) {
 	panic("unimplemented")
 }
 

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/ephemeral"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -138,14 +139,14 @@ func (e EphemeralAlreadyExpiredError) InternalError() string {
 
 //=============================================================================
 
-type EphemeralUnboxingError struct{ inner error }
+type EphemeralUnboxingError struct{ inner ephemeral.EphemeralKeyError }
 
-func NewEphemeralUnboxingError(inner error) EphemeralUnboxingError {
+func NewEphemeralUnboxingError(inner ephemeral.EphemeralKeyError) EphemeralUnboxingError {
 	return EphemeralUnboxingError{inner}
 }
 
 func (e EphemeralUnboxingError) Error() string {
-	return "Device is missing required ephemeral keys"
+	return e.inner.HumanError()
 }
 
 func (e EphemeralUnboxingError) InternalError() string {

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
@@ -22,7 +23,8 @@ type KeyFinder interface {
 	EphemeralKeyForEncryption(ctx context.Context, tlfName string, teamID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool) (keybase1.TeamEk, error)
 	EphemeralKeyForDecryption(ctx context.Context, tlfName string, teamID chat1.TLFID,
-		membersType chat1.ConversationMembersType, public bool, generation keybase1.EkGeneration) (keybase1.TeamEk, error)
+		membersType chat1.ConversationMembersType, public bool,
+		generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
 	ShouldPairwiseMAC(ctx context.Context, tlfName string, teamID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error)
 	Reset()
@@ -166,8 +168,10 @@ func (k *KeyFinderImpl) EphemeralKeyForEncryption(ctx context.Context, tlfName s
 }
 
 func (k *KeyFinderImpl) EphemeralKeyForDecryption(ctx context.Context, tlfName string, tlfID chat1.TLFID,
-	membersType chat1.ConversationMembersType, public bool, generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
-	return k.createNameInfoSource(ctx, membersType).EphemeralDecryptionKey(ctx, tlfName, tlfID, membersType, public, generation)
+	membersType chat1.ConversationMembersType, public bool,
+	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error) {
+	return k.createNameInfoSource(ctx, membersType).EphemeralDecryptionKey(
+		ctx, tlfName, tlfID, membersType, public, generation, contentCtime)
 }
 
 func (k *KeyFinderImpl) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
 	context "golang.org/x/net/context"
@@ -431,7 +432,8 @@ func (t *TeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfNam
 }
 
 func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
-	membersType chat1.ConversationMembersType, public bool, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+	membersType chat1.ConversationMembersType, public bool,
+	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
 	if public {
 		return teamEK, NewPublicTeamEphemeralKeyError()
 	}
@@ -440,7 +442,7 @@ func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfNam
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation)
+	return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation, contentCtime)
 }
 
 func (t *TeamsNameInfoSource) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
@@ -761,12 +763,12 @@ func (t *ImplicitTeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context
 
 func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
-	generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
 	teamID, err := t.ephemeralLoadAndIdentify(ctx, tlfName, tlfID, membersType, public)
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation)
+	return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation, contentCtime)
 }
 
 func (t *ImplicitTeamsNameInfoSource) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
@@ -156,7 +157,7 @@ func (t *KBFSNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfName
 
 func (t *KBFSNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
-	generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
 	return teamEK, fmt.Errorf("KBFSNameInfoSource doesn't support ephemeral keys")
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -51,7 +51,7 @@ type NameInfoSource interface {
 		membersType chat1.ConversationMembersType, public bool) (keybase1.TeamEk, error)
 	EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool,
-		generation keybase1.EkGeneration) (keybase1.TeamEk, error)
+		generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
 	ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool) (bool, []keybase1.KID, error)
 }

--- a/go/ephemeral/common.go
+++ b/go/ephemeral/common.go
@@ -8,43 +8,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-type EKType string
-
-const (
-	DeviceEKStr EKType = "deviceEK"
-	UserEKStr   EKType = "userEK"
-	TeamEKStr   EKType = "teamEK"
-)
-
-type EphemeralKeyError struct {
-	Msg string
-}
-
-func newEKUnboxErr(boxType EKType, boxGeneration keybase1.EkGeneration, missingType EKType, missingGeneration keybase1.EkGeneration) EphemeralKeyError {
-	msg := fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", boxType, boxGeneration, missingType, missingGeneration)
-	return newEphemeralKeyError(msg)
-}
-
-func newEKMissingBoxErr(boxType EKType, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
-	msg := fmt.Sprintf("Missing box for %s@generation:%v", boxType, boxGeneration)
-	return newEphemeralKeyError(msg)
-}
-
-func newEKCorruptedErr(boxType EKType, expectedGeneration, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
-	msg := fmt.Sprintf("Storage error for %s@generation:%v, got generation %v instead", boxType, boxGeneration, expectedGeneration)
-	return newEphemeralKeyError(msg)
-}
-
-func newEphemeralKeyError(msg string) EphemeralKeyError {
-	return EphemeralKeyError{
-		Msg: msg,
-	}
-}
-
-func (e EphemeralKeyError) Error() string {
-	return e.Msg
-}
-
 func ctimeIsStale(ctime time.Time, currentMerkleRoot libkb.MerkleRoot) bool {
 	return keybase1.TimeFromSeconds(currentMerkleRoot.Ctime()).Time().Sub(ctime) >= libkb.MaxEphemeralKeyStaleness
 }

--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
@@ -69,4 +70,41 @@ func TestEphemeralCloneError(t *testing.T) {
 	ekErr, ok := err.(EphemeralKeyError)
 	require.True(t, ok)
 	require.Equal(t, deviceCloneErrMsg, ekErr.HumanError())
+}
+
+func TestEphemeralDeviceProvisionedAfterContent(t *testing.T) {
+	tc, _ := ephemeralKeyTestSetup(t)
+	defer tc.Cleanup()
+
+	g := tc.G
+	m := libkb.NewMetaContextForTest(tc)
+	ctx := m.Ctx()
+	teamID := createTeam(tc)
+
+	ekLib := g.GetEKLib()
+	teamEK1, err := ekLib.GetOrCreateLatestTeamEK(ctx, teamID)
+	require.NoError(t, err)
+
+	deviceEKStorage := g.GetDeviceEKStorage()
+	s := deviceEKStorage.(*DeviceEKStorage)
+	allDevicEKs, err := s.GetAll(ctx)
+	require.NoError(t, err)
+	for _, dek := range allDevicEKs {
+		err = s.Delete(ctx, dek.Metadata.Generation)
+		require.NoError(t, err)
+	}
+
+	creationCtime := gregor1.ToTime(time.Now().Add(time.Hour * -100))
+	_, err = g.GetTeamEKBoxStorage().Get(ctx, teamID, teamEK1.Metadata.Generation, &creationCtime)
+	require.Error(t, err)
+	ekErr, ok := err.(EphemeralKeyError)
+	require.True(t, ok)
+	require.Equal(t, deviceProvisionedAfterContentCreationErrMsg, ekErr.HumanError())
+
+	// If no creation ctime is specified, we just get the default error message
+	_, err = g.GetTeamEKBoxStorage().Get(ctx, teamID, teamEK1.Metadata.Generation, nil)
+	require.Error(t, err)
+	ekErr, ok = err.(EphemeralKeyError)
+	require.True(t, ok)
+	require.Equal(t, defaultHumanErr, ekErr.HumanError())
 }

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -124,7 +124,7 @@ func (s *DeviceEKStorage) Put(ctx context.Context, generation keybase1.EkGenerat
 
 	// sanity check that we got the right generation
 	if deviceEK.Metadata.Generation != generation {
-		return newEKCorruptedErr(DeviceEKStr, generation, deviceEK.Metadata.Generation)
+		return newEKCorruptedErr(ctx, s.G(), DeviceEKStr, generation, deviceEK.Metadata.Generation)
 	}
 
 	key, err := s.key(ctx, generation)
@@ -200,7 +200,7 @@ func (s *DeviceEKStorage) get(ctx context.Context, generation keybase1.EkGenerat
 	}
 	// sanity check that we got the right generation
 	if deviceEK.Metadata.Generation != generation {
-		return deviceEK, newEKCorruptedErr(DeviceEKStr, generation, deviceEK.Metadata.Generation)
+		return deviceEK, newEKCorruptedErr(ctx, s.G(), DeviceEKStr, generation, deviceEK.Metadata.Generation)
 	}
 	return deviceEK, nil
 }

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -85,11 +85,16 @@ func TestDeviceEKStorage(t *testing.T) {
 	ek.Metadata.Generation = 100
 	err = s.Put(context.Background(), corruptedGeneration, ek)
 	require.Error(t, err)
-	require.Equal(t, newEKCorruptedErr(DeviceEKStr, corruptedGeneration, 100), err)
+	ekErr, ok := err.(EphemeralKeyError)
+	require.True(t, ok)
+	require.Equal(t, newEKCorruptedErr(DeviceEKStr, corruptedGeneration, 100).Error(), ekErr.Error())
+	require.Equal(t, defaultHumanErr, ekErr.HumanError())
 
 	// Test Get nonexistent
 	nonexistent, err := s.Get(context.Background(), keybase1.EkGeneration(len(testKeys)+1))
 	require.Error(t, err)
+	_, ok = err.(erasablekv.UnboxError)
+	require.True(t, ok)
 	require.Equal(t, keybase1.DeviceEk{}, nonexistent)
 
 	s.ClearCache()
@@ -109,6 +114,8 @@ func TestDeviceEKStorage(t *testing.T) {
 
 	deviceEK, err := s.Get(context.Background(), 2)
 	require.Error(t, err)
+	_, ok = err.(erasablekv.UnboxError)
+	require.True(t, ok)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
 	// Test MaxGeneration
@@ -156,12 +163,16 @@ func TestDeviceEKStorage(t *testing.T) {
 	var badEldestSeqnoDeviceEK keybase1.DeviceEk
 	err = erasableStorage.Get(context.Background(), badEldestSeqnoKey, &badEldestSeqnoDeviceEK)
 	require.Error(t, err)
+	_, ok = err.(erasablekv.UnboxError)
+	require.True(t, ok)
 	require.Equal(t, badEldestSeqnoDeviceEK, keybase1.DeviceEk{})
 
 	// Verify we store failures in the cache
 	t.Logf("cache failures")
 	nonexistent, err = s.Get(context.Background(), maxGeneration+1)
 	require.Error(t, err)
+	_, ok = err.(erasablekv.UnboxError)
+	require.True(t, ok)
 	require.Equal(t, keybase1.DeviceEk{}, nonexistent)
 
 	cache, err := s.getCache(context.Background())
@@ -171,6 +182,8 @@ func TestDeviceEKStorage(t *testing.T) {
 	cacheItem, ok := cache[maxGeneration+1]
 	require.True(t, ok)
 	require.Error(t, cacheItem.Err)
+	_, ok = cacheItem.Err.(erasablekv.UnboxError)
+	require.True(t, ok)
 }
 
 // If we change the key format intentionally, we have to introduce some form of

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -87,7 +87,8 @@ func TestDeviceEKStorage(t *testing.T) {
 	require.Error(t, err)
 	ekErr, ok := err.(EphemeralKeyError)
 	require.True(t, ok)
-	require.Equal(t, newEKCorruptedErr(DeviceEKStr, corruptedGeneration, 100).Error(), ekErr.Error())
+	expectedErr := newEKCorruptedErr(context.TODO(), tc.G, DeviceEKStr, corruptedGeneration, 100)
+	require.Equal(t, expectedErr.Error(), ekErr.Error())
 	require.Equal(t, defaultHumanErr, ekErr.HumanError())
 
 	// Test Get nonexistent

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -1,0 +1,57 @@
+package ephemeral
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type EKType string
+
+const (
+	DeviceEKStr EKType = "deviceEK"
+	UserEKStr   EKType = "userEK"
+	TeamEKStr   EKType = "teamEK"
+)
+
+type EphemeralKeyError struct {
+	DebugMsg string
+	HumanMsg string
+}
+
+const defaultHumanErr = "This exploding message is not available to you."
+
+func newEKUnboxErr(boxType EKType, boxGeneration keybase1.EkGeneration,
+	missingType EKType, missingGeneration keybase1.EkGeneration, contentCtime *gregor1.Time) EphemeralKeyError {
+	debugMsg := fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", boxType, boxGeneration, missingType, missingGeneration)
+	return newEphemeralKeyError(debugMsg, "")
+}
+
+func newEKMissingBoxErr(boxType EKType, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
+	debugMsg := fmt.Sprintf("Missing box for %s@generation:%v", boxType, boxGeneration)
+	return newEphemeralKeyError(debugMsg, "")
+}
+
+func newEKCorruptedErr(boxType EKType, expectedGeneration, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
+	debugMsg := fmt.Sprintf("Storage error for %s@generation:%v, got generation %v instead", boxType, boxGeneration, expectedGeneration)
+	return newEphemeralKeyError(debugMsg, "")
+}
+
+func newEphemeralKeyError(debugMsg, humanMsg string) EphemeralKeyError {
+	if humanMsg == "" {
+		humanMsg = defaultHumanErr
+	}
+	return EphemeralKeyError{
+		DebugMsg: debugMsg,
+		HumanMsg: humanMsg,
+	}
+}
+
+func (e EphemeralKeyError) HumanError() string {
+	return e.HumanMsg
+}
+
+func (e EphemeralKeyError) Error() string {
+	return e.DebugMsg
+}

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -72,7 +72,7 @@ func (e EphemeralKeyError) Error() string {
 
 func deviceProvisionedAfterContentCreation(ctx context.Context, g *libkb.GlobalContext, contentCtime *gregor1.Time) bool {
 	// some callers may not specify a creation time if they aren't trying to
-	// access a message when decrypting the key
+	// decrypt a specific piece of content.
 	if contentCtime == nil {
 		return false
 	}

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -23,9 +23,9 @@ type EphemeralKeyError struct {
 }
 
 const (
-	defaultHumanErr                             = "This exploding message is not available to you."
-	deviceProvisionedAfterContentCreationErrMsg = "This exploding message is not available to you, this device was created after the message was sent."
-	deviceCloneErrMsg                           = "This exploding message is not available to you, cloned devices do not support exploding messages."
+	defaultHumanErr                             = "This exploding message is not available to you"
+	deviceProvisionedAfterContentCreationErrMsg = "This exploding message is not available to you, this device was created after the message was sent"
+	deviceCloneErrMsg                           = "This exploding message is not available to you, cloned devices do not support exploding messages"
 )
 
 func newEKUnboxErr(ctx context.Context, g *libkb.GlobalContext, boxType EKType, boxGeneration keybase1.EkGeneration,

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -1,8 +1,10 @@
 package ephemeral
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -20,20 +22,32 @@ type EphemeralKeyError struct {
 	HumanMsg string
 }
 
-const defaultHumanErr = "This exploding message is not available to you."
+const (
+	defaultHumanErr                             = "This exploding message is not available to you."
+	deviceProvisionedAfterContentCreationErrMsg = "This exploding message is not available to you, this device was created after the message was sent."
+	deviceCloneErrMsg                           = "This exploding message is not available to you, cloned devices do not support exploding messages."
+)
 
-func newEKUnboxErr(boxType EKType, boxGeneration keybase1.EkGeneration,
+func newEKUnboxErr(ctx context.Context, g *libkb.GlobalContext, boxType EKType, boxGeneration keybase1.EkGeneration,
 	missingType EKType, missingGeneration keybase1.EkGeneration, contentCtime *gregor1.Time) EphemeralKeyError {
 	debugMsg := fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", boxType, boxGeneration, missingType, missingGeneration)
-	return newEphemeralKeyError(debugMsg, "")
+	humanMsg := defaultHumanErr
+	if deviceProvisionedAfterContentCreation(ctx, g, contentCtime) {
+		humanMsg = deviceProvisionedAfterContentCreationErrMsg
+	} else if deviceIsCloned(ctx, g) {
+		humanMsg = deviceCloneErrMsg
+	}
+	return newEphemeralKeyError(debugMsg, humanMsg)
 }
 
-func newEKMissingBoxErr(boxType EKType, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
+func newEKMissingBoxErr(ctx context.Context, g *libkb.GlobalContext,
+	boxType EKType, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
 	debugMsg := fmt.Sprintf("Missing box for %s@generation:%v", boxType, boxGeneration)
 	return newEphemeralKeyError(debugMsg, "")
 }
 
-func newEKCorruptedErr(boxType EKType, expectedGeneration, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
+func newEKCorruptedErr(ctx context.Context, g *libkb.GlobalContext, boxType EKType,
+	expectedGeneration, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
 	debugMsg := fmt.Sprintf("Storage error for %s@generation:%v, got generation %v instead", boxType, boxGeneration, expectedGeneration)
 	return newEphemeralKeyError(debugMsg, "")
 }
@@ -54,4 +68,27 @@ func (e EphemeralKeyError) HumanError() string {
 
 func (e EphemeralKeyError) Error() string {
 	return e.DebugMsg
+}
+
+func deviceProvisionedAfterContentCreation(ctx context.Context, g *libkb.GlobalContext, contentCtime *gregor1.Time) bool {
+	// some callers may not specify a creation time if they aren't trying to
+	// access a message when decrypting the key
+	if contentCtime == nil {
+		return false
+	}
+	m := libkb.NewMetaContext(ctx, g)
+	deviceCtime, err := g.ActiveDevice.Ctime(m)
+	if err != nil {
+		return false
+	}
+	return contentCtime.Time().Before(deviceCtime.Time())
+}
+
+func deviceIsCloned(ctx context.Context, g *libkb.GlobalContext) bool {
+	m := libkb.NewMetaContext(ctx, g)
+	cloneState, err := libkb.GetDeviceCloneState(m)
+	if err != nil {
+		return false
+	}
+	return cloneState.IsClone()
 }

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -62,7 +62,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	var userEKX keybase1.UserEk
 	if upgradePerUserKey {
 		require.True(t, userEKGenX > 0)
-		userEKX, err = userEKBoxStorageX.Get(context.Background(), userEKGenX)
+		userEKX, err = userEKBoxStorageX.Get(context.Background(), userEKGenX, nil)
 		require.NoError(t, err)
 	} else {
 		require.EqualValues(t, userEKGenX, -1)
@@ -168,7 +168,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	require.EqualValues(t, userEKGenX, userEKGenY)
 
 	if upgradePerUserKey {
-		userEKY, err := userEKBoxStorageY.Get(context.Background(), userEKGenY)
+		userEKY, err := userEKBoxStorageY.Get(context.Background(), userEKGenY, nil)
 		require.NoError(t, err)
 		require.Equal(t, userEKX, userEKY)
 
@@ -177,7 +177,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 		rawUserEKBoxStorage.Delete(context.Background(), userEKGenY)
 		userEKBoxStorageY.ClearCache()
 
-		userEKYFetched, err := userEKBoxStorageY.Get(context.Background(), userEKGenY)
+		userEKYFetched, err := userEKBoxStorageY.Get(context.Background(), userEKGenY, nil)
 		require.NoError(t, err)
 		require.Equal(t, userEKX, userEKYFetched)
 	}

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -222,7 +222,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	// If we try to access an older teamEK that we cannot access, we don't
 	// create a new teamEK
-	teamEK, err := ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen-1)
+	teamEK, err := ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen-1, nil)
 	require.Error(t, err)
 	require.Equal(t, teamEK, keybase1.TeamEk{})
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /* teamEKCreationInProgress */)
@@ -245,7 +245,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	require.NoError(t, err)
 	tc.G.GetDeviceEKStorage().ClearCache()
 
-	teamEK, err = ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen)
+	teamEK, err = ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen, nil)
 	require.Error(t, err)
 	require.Equal(t, teamEK, keybase1.TeamEk{})
 
@@ -256,7 +256,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	// Fake the teamEK creation time so we are forced to generate a new one.
 	forceEKCtime := func(generation keybase1.EkGeneration, d time.Duration) {
-		rawTeamEKBoxStorage.Get(context.Background(), teamID, generation)
+		rawTeamEKBoxStorage.Get(context.Background(), teamID, generation, nil)
 		cache, found, err := rawTeamEKBoxStorage.getCacheForTeamID(context.Background(), teamID)
 		require.NoError(t, err)
 		require.True(t, found)

--- a/go/ephemeral/selfprovision_test.go
+++ b/go/ephemeral/selfprovision_test.go
@@ -55,7 +55,7 @@ func TestEphemeralSelfProvision(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, m.ActiveDevice().Name(), newName)
 
-	teamEK2, err := g.GetTeamEKBoxStorage().Get(ctx, teamID, teamEK1.Metadata.Generation)
+	teamEK2, err := g.GetTeamEKBoxStorage().Get(ctx, teamID, teamEK1.Metadata.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, teamEK1, teamEK2)
 

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -8,6 +8,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -16,16 +17,22 @@ const teamEKBoxStorageDBVersion = 3
 type teamEKBoxCacheItem struct {
 	TeamEKBoxed keybase1.TeamEkBoxed
 	ErrMsg      string
+	HumanMsg    string
 }
 
 func newTeamEKBoxCacheItem(teamEKBoxed keybase1.TeamEkBoxed, err error) teamEKBoxCacheItem {
 	errMsg := ""
+	humanMsg := ""
 	if err != nil {
 		errMsg = err.Error()
+		if ekErr, ok := err.(EphemeralKeyError); ok {
+			humanMsg = ekErr.HumanError()
+		}
 	}
 	return teamEKBoxCacheItem{
 		TeamEKBoxed: teamEKBoxed,
 		ErrMsg:      errMsg,
+		HumanMsg:    humanMsg,
 	}
 }
 
@@ -35,7 +42,7 @@ func (c teamEKBoxCacheItem) HasError() bool {
 
 func (c teamEKBoxCacheItem) Error() error {
 	if c.HasError() {
-		return newEphemeralKeyError(c.ErrMsg)
+		return newEphemeralKeyError(c.ErrMsg, c.HumanMsg)
 	}
 	return nil
 }
@@ -75,7 +82,8 @@ func (s *TeamEKBoxStorage) dbKey(ctx context.Context, teamID keybase1.TeamID) (d
 	}, nil
 }
 
-func (s *TeamEKBoxStorage) Get(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+func (s *TeamEKBoxStorage) Get(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration,
+	contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
 	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#Get: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	s.Lock()
@@ -86,20 +94,20 @@ func (s *TeamEKBoxStorage) Get(ctx context.Context, teamID keybase1.TeamID, gene
 		return teamEK, err
 	} else if !found {
 		s.Unlock() // release the lock while we fetch
-		return s.fetchAndStore(ctx, teamID, generation)
+		return s.fetchAndStore(ctx, teamID, generation, contentCtime)
 	}
 
 	cacheItem, ok := cache[generation]
 	if !ok {
 		s.Unlock() // release the lock while we fetch
-		return s.fetchAndStore(ctx, teamID, generation)
+		return s.fetchAndStore(ctx, teamID, generation, contentCtime)
 	}
 
 	defer s.Unlock() // release the lock after we unbox
 	if cacheItem.HasError() {
 		return teamEK, cacheItem.Error()
 	}
-	return s.unbox(ctx, generation, cacheItem.TeamEKBoxed)
+	return s.unbox(ctx, generation, cacheItem.TeamEKBoxed, contentCtime)
 }
 
 func (s *TeamEKBoxStorage) getCacheForTeamID(ctx context.Context, teamID keybase1.TeamID) (cache teamEKBoxCache, found bool, err error) {
@@ -132,7 +140,8 @@ type TeamEKBoxedResponse struct {
 	} `json:"result"`
 }
 
-func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (teamEK keybase1.TeamEk, err error) {
+func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration,
+	contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
 	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#fetchAndStore: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -188,7 +197,7 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 		Metadata:         teamEKMetadata,
 	}
 
-	teamEK, err = s.unbox(ctx, generation, teamEKBoxed)
+	teamEK, err = s.unbox(ctx, generation, teamEKBoxed, contentCtime)
 	if err != nil {
 		switch err.(type) {
 		// cache unboxing/missing box errors so we don't continually try to
@@ -213,16 +222,18 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 	return teamEK, err
 }
 
-func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) (teamEK keybase1.TeamEk, err error) {
+func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.EkGeneration,
+	teamEKBoxed keybase1.TeamEkBoxed, contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
 	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#unbox: teamEKGeneration: %v", teamEKGeneration), func() error { return err })()
 
 	userEKBoxStorage := s.G().GetUserEKBoxStorage()
-	userEK, err := userEKBoxStorage.Get(ctx, teamEKBoxed.UserEkGeneration)
+	userEK, err := userEKBoxStorage.Get(ctx, teamEKBoxed.UserEkGeneration, contentCtime)
 	if err != nil {
 		s.G().Log.CDebugf(ctx, "unable to get from userEKStorage %v", err)
 		switch err.(type) {
 		case EphemeralKeyError:
-			return teamEK, newEKUnboxErr(TeamEKStr, teamEKGeneration, UserEKStr, teamEKBoxed.UserEkGeneration)
+			return teamEK, newEKUnboxErr(TeamEKStr, teamEKGeneration, UserEKStr,
+				teamEKBoxed.UserEkGeneration, contentCtime)
 		}
 		return teamEK, err
 	}
@@ -233,7 +244,8 @@ func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.
 	msg, _, err := userKeypair.DecryptFromString(teamEKBoxed.Box)
 	if err != nil {
 		s.G().Log.CDebugf(ctx, "unable to decrypt teamEKBoxed %v", err)
-		return teamEK, newEKUnboxErr(TeamEKStr, teamEKGeneration, UserEKStr, teamEKBoxed.UserEkGeneration)
+		return teamEK, newEKUnboxErr(TeamEKStr, teamEKGeneration, UserEKStr,
+			teamEKBoxed.UserEkGeneration, contentCtime)
 	}
 
 	seed, err := newTeamEKSeedFromBytes(msg)
@@ -247,12 +259,13 @@ func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.
 	}, nil
 }
 
-func (s *TeamEKBoxStorage) Put(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) (err error) {
+func (s *TeamEKBoxStorage) Put(ctx context.Context, teamID keybase1.TeamID,
+	generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) (err error) {
 	return s.put(ctx, teamID, generation, teamEKBoxed, nil /* ekErr */)
 }
 
-func (s *TeamEKBoxStorage) put(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration,
-	teamEKBoxed keybase1.TeamEkBoxed, ekErr error) (err error) {
+func (s *TeamEKBoxStorage) put(ctx context.Context, teamID keybase1.TeamID,
+	generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed, ekErr error) (err error) {
 	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#put: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 	s.Lock()
 	defer s.Unlock()
@@ -278,13 +291,15 @@ func (s *TeamEKBoxStorage) put(ctx context.Context, teamID keybase1.TeamID, gene
 	return nil
 }
 
-func (s *TeamEKBoxStorage) Delete(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (err error) {
+func (s *TeamEKBoxStorage) Delete(ctx context.Context, teamID keybase1.TeamID,
+	generation keybase1.EkGeneration) (err error) {
 	s.Lock()
 	defer s.Unlock()
 	return s.deleteMany(ctx, teamID, []keybase1.EkGeneration{generation})
 }
 
-func (s *TeamEKBoxStorage) deleteMany(ctx context.Context, teamID keybase1.TeamID, generations []keybase1.EkGeneration) (err error) {
+func (s *TeamEKBoxStorage) deleteMany(ctx context.Context, teamID keybase1.TeamID,
+	generations []keybase1.EkGeneration) (err error) {
 	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#delete: teamID:%v, generations:%v", teamID, generations), func() error { return err })()
 
 	cache, found, err := s.getCacheForTeamID(ctx, teamID)
@@ -326,7 +341,8 @@ func (s *TeamEKBoxStorage) PurgeCacheForTeamID(ctx context.Context, teamID keyba
 	return nil
 }
 
-func (s *TeamEKBoxStorage) DeleteExpired(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (expired []keybase1.EkGeneration, err error) {
+func (s *TeamEKBoxStorage) DeleteExpired(ctx context.Context, teamID keybase1.TeamID,
+	merkleRoot libkb.MerkleRoot) (expired []keybase1.EkGeneration, err error) {
 	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#DeleteExpired: teamID:%v", teamID), func() error { return err })()
 
 	s.Lock()
@@ -379,7 +395,7 @@ func (s *TeamEKBoxStorage) GetAll(ctx context.Context, teamID keybase1.TeamID) (
 		if cacheItem.HasError() {
 			continue
 		}
-		teamEK, err := s.unbox(ctx, generation, cacheItem.TeamEKBoxed)
+		teamEK, err := s.unbox(ctx, generation, cacheItem.TeamEKBoxed, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +435,7 @@ func (s *TeamEKBoxStorage) MaxGeneration(ctx context.Context, teamID keybase1.Te
 
 // --------------------------------------------------
 
-const MemCacheLRUSize = 200
+const MemCacheLRUSize = 1000
 
 // Store some TeamEKBoxes's in memory. Threadsafe.
 type teamEKCache struct {

--- a/go/ephemeral/team_ek_box_storage_test.go
+++ b/go/ephemeral/team_ek_box_storage_test.go
@@ -40,17 +40,17 @@ func TestTeamEKBoxStorage(t *testing.T) {
 	s := tc.G.GetTeamEKBoxStorage()
 
 	// Test Get nonexistent
-	nonexistent, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation+1)
+	nonexistent, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.Equal(t, keybase1.TeamEk{}, nonexistent)
 
 	// Test invalid teamID
-	nonexistent2, err := s.Get(context.Background(), invalidID, teamEKMetadata.Generation+1)
+	nonexistent2, err := s.Get(context.Background(), invalidID, teamEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.Equal(t, keybase1.TeamEk{}, nonexistent2)
 
 	// Test get valid & unbox
-	teamEK, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation)
+	teamEK, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation, nil)
 	require.NoError(t, err)
 
 	verifyTeamEK(t, teamEKMetadata, teamEK)
@@ -90,7 +90,7 @@ func TestTeamEKBoxStorage(t *testing.T) {
 
 	userEKBoxStorage.ClearCache()
 
-	teamEK, err = s.Get(context.Background(), teamID, teamEKMetadata.Generation)
+	teamEK, err = s.Get(context.Background(), teamID, teamEKMetadata.Generation, nil)
 	require.NoError(t, err)
 	verifyTeamEK(t, teamEKMetadata, teamEK)
 
@@ -104,7 +104,7 @@ func TestTeamEKBoxStorage(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
-	bad, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation)
+	bad, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation, nil)
 	require.Error(t, err)
 	require.Equal(t, keybase1.TeamEk{}, bad)
 
@@ -132,7 +132,7 @@ func TestTeamEKBoxStorage(t *testing.T) {
 
 	// Verify we store failures in the cache
 	t.Logf("cache failures")
-	nonexistent, err = rawTeamEKBoxStorage.Get(context.Background(), teamID, teamEKMetadata.Generation+1)
+	nonexistent, err = rawTeamEKBoxStorage.Get(context.Background(), teamID, teamEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.Equal(t, keybase1.TeamEk{}, nonexistent)
 	cache, found, err := rawTeamEKBoxStorage.getCacheForTeamID(context.Background(), teamID)

--- a/go/ephemeral/team_ek_test.go
+++ b/go/ephemeral/team_ek_test.go
@@ -56,7 +56,7 @@ func TestNewTeamEK(t *testing.T) {
 	teamEKBoxStorage := tc.G.GetTeamEKBoxStorage()
 	maxGeneration, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID)
 	require.NoError(t, err)
-	ek, err := teamEKBoxStorage.Get(context.Background(), teamID, maxGeneration)
+	ek, err := teamEKBoxStorage.Get(context.Background(), teamID, maxGeneration, nil)
 	require.NoError(t, err)
 	require.Equal(t, ek.Metadata, publishedMetadata)
 

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/erasablekv"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -17,16 +18,22 @@ const userEKBoxStorageDBVersion = 3
 type userEKBoxCacheItem struct {
 	UserEKBoxed keybase1.UserEkBoxed
 	ErrMsg      string
+	HumanMsg    string
 }
 
 func newUserEKBoxCacheItem(userEKBoxed keybase1.UserEkBoxed, err error) userEKBoxCacheItem {
 	errMsg := ""
+	humanMsg := ""
 	if err != nil {
 		errMsg = err.Error()
+		if ekErr, ok := err.(EphemeralKeyError); ok {
+			humanMsg = ekErr.HumanError()
+		}
 	}
 	return userEKBoxCacheItem{
 		UserEKBoxed: userEKBoxed,
 		ErrMsg:      errMsg,
+		HumanMsg:    humanMsg,
 	}
 }
 
@@ -36,7 +43,7 @@ func (c userEKBoxCacheItem) HasError() bool {
 
 func (c userEKBoxCacheItem) Error() error {
 	if c.HasError() {
-		return newEphemeralKeyError(c.ErrMsg)
+		return newEphemeralKeyError(c.ErrMsg, c.HumanMsg)
 	}
 	return nil
 }
@@ -88,7 +95,8 @@ func (s *UserEKBoxStorage) getCache(ctx context.Context) (cache userEKBoxCache, 
 	return s.cache, nil
 }
 
-func (s *UserEKBoxStorage) Get(ctx context.Context, generation keybase1.EkGeneration) (userEK keybase1.UserEk, err error) {
+func (s *UserEKBoxStorage) Get(ctx context.Context, generation keybase1.EkGeneration,
+	contentCtime *gregor1.Time) (userEK keybase1.UserEk, err error) {
 	defer s.G().CTraceTimed(ctx, fmt.Sprintf("UserEKBoxStorage#Get: generation:%v", generation), func() error { return err })()
 
 	s.Lock()
@@ -111,7 +119,7 @@ func (s *UserEKBoxStorage) Get(ctx context.Context, generation keybase1.EkGenera
 	if cacheItem.HasError() {
 		return userEK, cacheItem.Error()
 	}
-	return s.unbox(ctx, generation, cacheItem.UserEKBoxed)
+	return s.unbox(ctx, generation, cacheItem.UserEKBoxed, contentCtime)
 }
 
 type UserEKBoxedResponse struct {
@@ -177,7 +185,7 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 		Metadata:           userEKMetadata,
 	}
 
-	userEK, err = s.unbox(ctx, generation, userEKBoxed)
+	userEK, err = s.unbox(ctx, generation, userEKBoxed, nil)
 	if err != nil {
 		// cache unboxing/missing box errors so we don't continually try to
 		// fetch something nonexistent.
@@ -230,7 +238,8 @@ func (s *UserEKBoxStorage) put(ctx context.Context, generation keybase1.EkGenera
 	return s.G().GetKVStore().PutObj(key, nil, cache)
 }
 
-func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) (userEK keybase1.UserEk, err error) {
+func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.EkGeneration,
+	userEKBoxed keybase1.UserEkBoxed, contentCtime *gregor1.Time) (userEK keybase1.UserEk, err error) {
 	defer s.G().CTraceTimed(ctx, fmt.Sprintf("UserEKBoxStorage#unbox: generation:%v", userEKGeneration), func() error { return err })()
 
 	deviceEKStorage := s.G().GetDeviceEKStorage()
@@ -239,7 +248,8 @@ func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.
 		s.G().Log.CDebugf(ctx, "unable to get from deviceEKStorage %v", err)
 		switch err.(type) {
 		case erasablekv.UnboxError:
-			return userEK, newEKUnboxErr(UserEKStr, userEKGeneration, DeviceEKStr, userEKBoxed.DeviceEkGeneration)
+			return userEK, newEKUnboxErr(UserEKStr, userEKGeneration, DeviceEKStr,
+				userEKBoxed.DeviceEkGeneration, contentCtime)
 		}
 		return userEK, err
 	}
@@ -250,7 +260,8 @@ func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.
 	msg, _, err := deviceKeypair.DecryptFromString(userEKBoxed.Box)
 	if err != nil {
 		s.G().Log.CDebugf(ctx, "unable to decrypt userEKBoxed %v", err)
-		return userEK, newEKUnboxErr(UserEKStr, userEKGeneration, DeviceEKStr, userEKBoxed.DeviceEkGeneration)
+		return userEK, newEKUnboxErr(UserEKStr, userEKGeneration, DeviceEKStr,
+			userEKBoxed.DeviceEkGeneration, contentCtime)
 	}
 
 	seed, err := newUserEKSeedFromBytes(msg)
@@ -302,7 +313,7 @@ func (s *UserEKBoxStorage) GetAll(ctx context.Context) (userEKs UserEKUnboxedMap
 		if cacheItem.HasError() {
 			continue
 		}
-		userEK, err := s.unbox(ctx, generation, cacheItem.UserEKBoxed)
+		userEK, err := s.unbox(ctx, generation, cacheItem.UserEKBoxed, nil)
 		if err != nil {
 			return userEKs, err
 		}

--- a/go/ephemeral/user_ek_box_storage_test.go
+++ b/go/ephemeral/user_ek_box_storage_test.go
@@ -35,13 +35,13 @@ func TestUserEKBoxStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test Get nonexistent
-	nonexistent, err := s.Get(context.Background(), userEKMetadata.Generation+1)
+	nonexistent, err := s.Get(context.Background(), userEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.Equal(t, keybase1.UserEk{}, nonexistent)
 
 	// Test get valid & unbox
 	s.ClearCache()
-	userEK, err := s.Get(context.Background(), userEKMetadata.Generation)
+	userEK, err := s.Get(context.Background(), userEKMetadata.Generation, nil)
 	require.NoError(t, err)
 
 	verifyUserEK(t, userEKMetadata, userEK)
@@ -74,7 +74,7 @@ func TestUserEKBoxStorage(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
-	bad, err := s.Get(context.Background(), userEKMetadata.Generation)
+	bad, err := s.Get(context.Background(), userEKMetadata.Generation, nil)
 	require.Error(t, err)
 	require.Equal(t, keybase1.UserEk{}, bad)
 
@@ -82,7 +82,7 @@ func TestUserEKBoxStorage(t *testing.T) {
 	err = rawUserEKBoxStorage.Delete(context.Background(), userEKMetadata.Generation)
 	require.NoError(t, err)
 
-	userEK, err = rawUserEKBoxStorage.Get(context.Background(), userEKMetadata.Generation)
+	userEK, err = rawUserEKBoxStorage.Get(context.Background(), userEKMetadata.Generation, nil)
 	require.Error(t, err)
 
 	s.ClearCache()
@@ -98,7 +98,7 @@ func TestUserEKBoxStorage(t *testing.T) {
 
 	// Verify we store failures in the cache
 	t.Logf("cache failures")
-	nonexistent, err = rawUserEKBoxStorage.Get(context.Background(), userEKMetadata.Generation+1)
+	nonexistent, err = rawUserEKBoxStorage.Get(context.Background(), userEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.Equal(t, keybase1.UserEk{}, nonexistent)
 

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -17,7 +17,7 @@ func publishAndVerifyUserEK(t *testing.T, tc libkb.TestContext, merkleRoot libkb
 	require.NoError(t, err)
 
 	s := tc.G.GetUserEKBoxStorage()
-	userEK, err := s.Get(context.Background(), publishedMetadata.Generation)
+	userEK, err := s.Get(context.Background(), publishedMetadata.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, userEK.Metadata, publishedMetadata)
 
@@ -34,7 +34,7 @@ func publishAndVerifyUserEK(t *testing.T, tc libkb.TestContext, merkleRoot libkb
 	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
 	maxGeneration, err := userEKBoxStorage.MaxGeneration(context.Background())
 	require.NoError(t, err)
-	ek, err := userEKBoxStorage.Get(context.Background(), maxGeneration)
+	ek, err := userEKBoxStorage.Get(context.Background(), maxGeneration, nil)
 	require.NoError(t, err)
 	require.Equal(t, ek.Metadata, publishedMetadata)
 	return maxGeneration
@@ -131,7 +131,7 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 		statement, ok = statements[uid]
 		require.True(t, ok)
 		require.EqualValues(t, statement.CurrentUserEkMetadata.Generation, 2, "after revoke, should have userEK gen 2")
-		userEK, err := tc.G.GetUserEKBoxStorage().Get(context.Background(), 2)
+		userEK, err := tc.G.GetUserEKBoxStorage().Get(context.Background(), 2, nil)
 		require.NoError(t, err)
 		require.Equal(t, statement.CurrentUserEkMetadata, userEK.Metadata)
 	}
@@ -180,7 +180,7 @@ func TestPukRollNewUserEK(t *testing.T) {
 	secondStatement, ok := statements[uid]
 	require.True(t, ok)
 	require.EqualValues(t, secondStatement.CurrentUserEkMetadata.Generation, 2, "after PUK roll, should have userEK gen 2")
-	userEK, err := tc.G.GetUserEKBoxStorage().Get(context.Background(), 2)
+	userEK, err := tc.G.GetUserEKBoxStorage().Get(context.Background(), 2, nil)
 	require.NoError(t, err)
 	require.Equal(t, secondStatement.CurrentUserEkMetadata, userEK.Metadata)
 

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -306,7 +306,7 @@ func (m *TlfMock) EphemeralEncryptionKey(ctx context.Context, tlfName string, tl
 
 func (m *TlfMock) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
-	generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
+	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error) {
 	// Returns a totally zero teamEK. That's enough to get some very simple
 	// round trip tests to pass.
 	return keybase1.TeamEk{}, nil

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -488,14 +488,15 @@ func (m MetaContext) SwitchUserLoggedOut() (err error) {
 // switch the global logged in user. It does not, however, change the
 // `current_user` in the config file, or edit the global config file in any
 // way.
-func (m MetaContext) SetActiveDevice(uv keybase1.UserVersion, deviceID keybase1.DeviceID, sigKey, encKey GenericKey, deviceName string) error {
+func (m MetaContext) SetActiveDevice(uv keybase1.UserVersion, deviceID keybase1.DeviceID,
+	sigKey, encKey GenericKey, deviceName string) error {
 	g := m.G()
 	g.switchUserMu.Lock()
 	defer g.switchUserMu.Unlock()
 	if !g.Env.GetUID().Equal(uv.Uid) {
 		return NewUIDMismatchError("UID switched out from underneath provisioning process")
 	}
-	return g.ActiveDevice.Set(m, uv, deviceID, sigKey, encKey, deviceName)
+	return g.ActiveDevice.Set(m, uv, deviceID, sigKey, encKey, deviceName, 0)
 }
 
 func (m MetaContext) SetSigningKey(uv keybase1.UserVersion, deviceID keybase1.DeviceID, sigKey GenericKey, deviceName string) error {

--- a/go/libkb/device_with_keys.go
+++ b/go/libkb/device_with_keys.go
@@ -12,13 +12,22 @@ type DeviceWithKeys struct {
 	encryptionKey GenericKey
 	deviceID      keybase1.DeviceID
 	deviceName    string
+	deviceCtime   keybase1.Time
 }
 
-func NewDeviceWithKeys(s GenericKey, e GenericKey, d keybase1.DeviceID, n string) *DeviceWithKeys {
-	return &DeviceWithKeys{s, e, d, n}
+func NewDeviceWithKeys(signingKey, encryptionKey GenericKey, deviceID keybase1.DeviceID, deviceName string) *DeviceWithKeys {
+	return &DeviceWithKeys{
+		signingKey:    signingKey,
+		encryptionKey: encryptionKey,
+		deviceID:      deviceID,
+		deviceName:    deviceName,
+	}
 }
-func NewDeviceWithKeysOnly(e GenericKey, s GenericKey) *DeviceWithKeys {
-	return &DeviceWithKeys{e, s, keybase1.DeviceID(""), ""}
+func NewDeviceWithKeysOnly(signingKey, encryptionKey GenericKey) *DeviceWithKeys {
+	return &DeviceWithKeys{
+		signingKey:    signingKey,
+		encryptionKey: encryptionKey,
+	}
 }
 func (d DeviceWithKeys) EncryptionKey() GenericKey {
 	return d.encryptionKey
@@ -31,6 +40,9 @@ func (d DeviceWithKeys) DeviceID() keybase1.DeviceID {
 }
 func (d DeviceWithKeys) DeviceName() string {
 	return d.deviceName
+}
+func (d DeviceWithKeys) DeviceCtime() keybase1.Time {
+	return d.deviceCtime
 }
 func (d *DeviceWithKeys) SetDeviceInfo(i keybase1.DeviceID, n string) {
 	d.deviceID = i
@@ -82,10 +94,11 @@ func (s *SelfDestructingDeviceWithKeys) DeviceWithKeys() *DeviceWithKeys {
 }
 
 type ownerDeviceReply struct {
-	Status     AppStatus         `json:"status"`
-	UID        keybase1.UID      `json:"uid"`
-	DeviceID   keybase1.DeviceID `json:"device_id"`
-	DeviceName string            `json:"device_name"`
+	Status      AppStatus         `json:"status"`
+	UID         keybase1.UID      `json:"uid"`
+	DeviceID    keybase1.DeviceID `json:"device_id"`
+	DeviceName  string            `json:"device_name"`
+	DeviceCtime keybase1.Time     `json:"device_ctime"`
 }
 
 func (o *ownerDeviceReply) GetAppStatus() *AppStatus {
@@ -106,6 +119,7 @@ func (d *DeviceWithKeys) Populate(m MetaContext) (uid keybase1.UID, err error) {
 	}
 	d.deviceID = res.DeviceID
 	d.deviceName = res.DeviceName
+	d.deviceCtime = res.DeviceCtime
 	return res.UID, nil
 }
 

--- a/go/libkb/device_with_keys.go
+++ b/go/libkb/device_with_keys.go
@@ -113,8 +113,7 @@ func (d *DeviceWithKeys) Populate(m MetaContext) (uid keybase1.UID, err error) {
 		NetContext:  m.Ctx(),
 	}
 	var res ownerDeviceReply
-	err = m.G().API.GetDecode(arg, &res)
-	if err != nil {
+	if err = m.G().API.GetDecode(arg, &res); err != nil {
 		return uid, err
 	}
 	d.deviceID = res.DeviceID

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -719,7 +719,7 @@ type DeviceEKStorage interface {
 
 type UserEKBoxStorage interface {
 	Put(ctx context.Context, generation keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) error
-	Get(ctx context.Context, generation keybase1.EkGeneration) (keybase1.UserEk, error)
+	Get(ctx context.Context, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.UserEk, error)
 	MaxGeneration(ctx context.Context) (keybase1.EkGeneration, error)
 	DeleteExpired(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	ClearCache()
@@ -727,7 +727,7 @@ type UserEKBoxStorage interface {
 
 type TeamEKBoxStorage interface {
 	Put(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) error
-	Get(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error)
+	Get(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
 	MaxGeneration(ctx context.Context, teamID keybase1.TeamID) (keybase1.EkGeneration, error)
 	DeleteExpired(ctx context.Context, teamID keybase1.TeamID, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	PurgeCacheForTeamID(ctx context.Context, teamID keybase1.TeamID) error
@@ -738,7 +738,7 @@ type TeamEKBoxStorage interface {
 type EKLib interface {
 	KeygenIfNeeded(ctx context.Context) error
 	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, error)
-	GetTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error)
+	GetTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
 	PurgeCachesForTeamIDAndGeneration(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration)
 	PurgeCachesForTeamID(ctx context.Context, teamID keybase1.TeamID)
 	NewEphemeralSeed() (keybase1.Bytes32, error)

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -58,7 +58,7 @@ func TestEphemeralAddMemberNoTeamEK(t *testing.T) {
 }
 
 func getTeamEK(g *libkb.GlobalContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
-	return g.GetTeamEKBoxStorage().Get(context.Background(), teamID, generation)
+	return g.GetTeamEKBoxStorage().Get(context.Background(), teamID, generation, nil)
 }
 
 func runAddMember(t *testing.T, createTeamEK bool) {
@@ -219,7 +219,7 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	ann.waitForRotateByID(teamID, keybase1.Seqno(3))
 
 	storage := annG.GetTeamEKBoxStorage()
-	teamEK, err := storage.Get(context.Background(), teamID, expectedGeneration)
+	teamEK, err := storage.Get(context.Background(), teamID, expectedGeneration, nil)
 	if createTeamEK {
 		require.NoError(t, err)
 	} else {
@@ -265,7 +265,7 @@ func TestEphemeralRotateSkipTeamEKRoll(t *testing.T) {
 	teamEKBoxStorage.ClearCache()
 	_, err = annG.LocalDb.Nuke() // Force us to refetch and verify the key from the server
 	require.NoError(t, err)
-	teamEKPostRoll, err := teamEKBoxStorage.Get(context.Background(), teamID, teamEKPreRoll.Metadata.Generation)
+	teamEKPostRoll, err := teamEKBoxStorage.Get(context.Background(), teamID, teamEKPreRoll.Metadata.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, teamEKPreRoll, teamEKPostRoll)
 
@@ -298,7 +298,7 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 	userEKBoxStorage := annG.GetUserEKBoxStorage()
 	gen, err := userEKBoxStorage.MaxGeneration(context.Background())
 	require.NoError(t, err)
-	userEKPreRevoke, err := userEKBoxStorage.Get(context.Background(), gen)
+	userEKPreRevoke, err := userEKBoxStorage.Get(context.Background(), gen, nil)
 	require.NoError(t, err)
 
 	// Provision a new device that we can revoke.
@@ -325,7 +325,7 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 	userEKBoxStorage.ClearCache()
 	_, err = annG.LocalDb.Nuke() // Force us to refetch and verify the key from the server
 	require.NoError(t, err)
-	userEKPostRevoke, err := userEKBoxStorage.Get(context.Background(), userEKPreRevoke.Metadata.Generation)
+	userEKPostRevoke, err := userEKBoxStorage.Get(context.Background(), userEKPreRevoke.Metadata.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, userEKPreRevoke, userEKPostRevoke)
 
@@ -374,7 +374,7 @@ func readdToTeamWithEKs(t *testing.T, leave bool) {
 	}
 
 	// After leaving user2 won't have access to the current teamEK
-	_, err = user2.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, currentGen)
+	_, err = user2.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, currentGen, nil)
 	require.Error(t, err)
 
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
@@ -382,10 +382,10 @@ func readdToTeamWithEKs(t *testing.T, leave bool) {
 
 	// Test that user1 and user2 both have access to the currentTeamEK
 	// (whether we recreated or reboxed)
-	teamEK2U1, err := user1.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, expectedGen)
+	teamEK2U1, err := user1.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, expectedGen, nil)
 	require.NoError(t, err)
 
-	teamEK2U2, err := user2.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, expectedGen)
+	teamEK2U2, err := user2.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, expectedGen, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, teamEK2U1, teamEK2U2)


### PR DESCRIPTION
detects two types of ephemeral errors to have more informative error messages show to users. the following errors are checked:
- the user provisioned the device since the message was sent
- the user cloned a device

relates to https://github.com/keybase/client/pull/15034 and depends on https://github.com/keybase/keybase/pull/3254
![screen shot 2018-12-13 at 9 54 53 am](https://user-images.githubusercontent.com/1144020/49946586-4d107b80-febd-11e8-95f4-503c5445706e.png)
![screen shot 2018-12-13 at 9 53 56 am](https://user-images.githubusercontent.com/1144020/49946578-46820400-febd-11e8-8867-dd5de74f3744.png)
