### PR TITLE
don't force-repoll on implicit team chat send hot path

### DIFF
--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -615,7 +615,7 @@ func (t *ImplicitTeamsNameInfoSource) LookupID(ctx context.Context, name string,
 		return t.lookupInternalName(ctx, name, public)
 	}
 
-	team, _, impTeamName, err := teams.LookupImplicitTeamNoForcePoll(ctx, t.G().ExternalG(), name, public)
+	team, _, impTeamName, err := teams.LookupImplicitTeamNoForceRepoll(ctx, t.G().ExternalG(), name, public)
 	if err != nil {
 		return res, t.transformTeamDoesNotExist(ctx, err, name)
 	}

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -615,7 +615,7 @@ func (t *ImplicitTeamsNameInfoSource) LookupID(ctx context.Context, name string,
 		return t.lookupInternalName(ctx, name, public)
 	}
 
-	team, _, impTeamName, err := teams.LookupImplicitTeam(ctx, t.G().ExternalG(), name, public)
+	team, _, impTeamName, err := teams.LookupImplicitTeamNoForcePoll(ctx, t.G().ExternalG(), name, public)
 	if err != nil {
 		return res, t.transformTeamDoesNotExist(ctx, err, name)
 	}

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -615,7 +615,8 @@ func (t *ImplicitTeamsNameInfoSource) LookupID(ctx context.Context, name string,
 		return t.lookupInternalName(ctx, name, public)
 	}
 
-	team, _, impTeamName, err := teams.LookupImplicitTeamNoForceRepoll(ctx, t.G().ExternalG(), name, public)
+	// This is on the critical path of sends, so don't force a repoll.
+	team, _, impTeamName, err := teams.LookupImplicitTeam(ctx, t.G().ExternalG(), name, public, teams.ImplicitTeamOptions{NoForceRepoll: true})
 	if err != nil {
 		return res, t.transformTeamDoesNotExist(ctx, err, name)
 	}

--- a/go/saltpackkeys/saltpack_recipient_keyfinder_engine_test.go
+++ b/go/saltpackkeys/saltpack_recipient_keyfinder_engine_test.go
@@ -330,7 +330,7 @@ func TestSaltpackRecipientKeyfinderCreatesImplicitTeamIfUserHasNoPUK(t *testing.
 
 	symKeys := eng.GetSymmetricKeys()
 	require.Len(t, symKeys, 1)
-	team, _, _, err := teams.LookupImplicitTeam(m.Ctx(), m.G(), u2.Username+","+u3.Username, false)
+	team, _, _, err := teams.LookupImplicitTeam(m.Ctx(), m.G(), u2.Username+","+u3.Username, false, teams.ImplicitTeamOptions{})
 	require.NoError(t, err)
 	teamSaltpackKey, err := team.SaltpackEncryptionKeyLatest(m.Ctx())
 	require.NoError(t, err)
@@ -998,7 +998,7 @@ func TestSaltpackRecipientKeyfinderImplicitTeam(t *testing.T) {
 		t.Errorf("number of symmetric keys found: %d, expected 1", len(symKeys))
 	}
 
-	team, _, _, err := teams.LookupImplicitTeam(m.Ctx(), m.G(), u1.Username+","+nonExistingUserAssertion, false)
+	team, _, _, err := teams.LookupImplicitTeam(m.Ctx(), m.G(), u1.Username+","+nonExistingUserAssertion, false, teams.ImplicitTeamOptions{})
 	require.NoError(t, err)
 	teamSaltpackKey, err := team.SaltpackEncryptionKeyLatest(m.Ctx())
 	require.NoError(t, err)
@@ -1066,7 +1066,7 @@ func TestSaltpackRecipientKeyfinderImplicitTeamNoSelfEncrypt(t *testing.T) {
 		t.Errorf("number of symmetric keys found: %d, expected 1", len(symKeys))
 	}
 
-	team, _, _, err := teams.LookupImplicitTeam(m.Ctx(), m.G(), u1.Username+","+nonExistingUserAssertion, false)
+	team, _, _, err := teams.LookupImplicitTeam(m.Ctx(), m.G(), u1.Username+","+nonExistingUserAssertion, false, teams.ImplicitTeamOptions{})
 	require.NoError(t, err)
 	teamSaltpackKey, err := team.SaltpackEncryptionKeyLatest(m.Ctx())
 	require.NoError(t, err)

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -212,7 +212,7 @@ func (h *IdentifyHandler) resolveIdentifyImplicitTeamHelper(ctx context.Context,
 	if arg.Create {
 		team, _, impName, err = teams.LookupOrCreateImplicitTeam(ctx, h.G(), lookupNameStr, arg.IsPublic)
 	} else {
-		team, _, impName, err = teams.LookupImplicitTeam(ctx, h.G(), lookupNameStr, arg.IsPublic)
+		team, _, impName, err = teams.LookupImplicitTeam(ctx, h.G(), lookupNameStr, arg.IsPublic, teams.ImplicitTeamOptions{})
 	}
 	if err != nil {
 		return res, err

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -482,7 +482,7 @@ func (h *TeamsHandler) LookupImplicitTeam(ctx context.Context, arg keybase1.Look
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("LookupImplicitTeam(%s)", arg.Name), func() error { return err })()
 	var team *teams.Team
 	team, res.Name, res.DisplayName, err =
-		teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public)
+		teams.LookupImplicitTeam(ctx, h.G().ExternalG(), arg.Name, arg.Public, teams.ImplicitTeamOptions{})
 	if err == nil {
 		res.TeamID = team.ID
 		res.TlfID = team.LatestKBFSTLFID()

--- a/go/systests/git_test.go
+++ b/go/systests/git_test.go
@@ -78,7 +78,7 @@ func TestGitTeamer(t *testing.T) {
 			FolderType: folderType,
 		})
 		require.NoError(t, err)
-		expectedTeam, _, _, err := teams.LookupImplicitTeam(context.Background(), alice.tc.G, frag, public)
+		expectedTeam, _, _, err := teams.LookupImplicitTeam(context.Background(), alice.tc.G, frag, public, teams.ImplicitTeamOptions{})
 		require.NoError(t, err)
 		require.Equal(t, public, expectedTeam.ID.IsPublic())
 		require.Equal(t, expectedTeam.ID, res.TeamID,
@@ -129,7 +129,7 @@ func TestGitTeamer(t *testing.T) {
 		})
 
 		t.Logf("find out the conflict suffix")
-		_, _, _, conflicts, err := teams.LookupImplicitTeamAndConflicts(context.Background(), alice.tc.G, iTeamNameCreate1, public)
+		_, _, _, conflicts, err := teams.LookupImplicitTeamAndConflicts(context.Background(), alice.tc.G, iTeamNameCreate1, public, teams.ImplicitTeamOptions{})
 		require.NoError(t, err)
 		require.Len(t, conflicts, 1)
 		t.Logf("check")

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -698,7 +698,7 @@ func TestResolveIdentifyImplicitTeamWithConflict(t *testing.T) {
 	require.Nil(t, res.TrackBreaks, "track breaks")
 
 	t.Logf("find out the conflict suffix")
-	iTeamxx, _, _, conflicts, err := teams.LookupImplicitTeamAndConflicts(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/)
+	iTeamxx, _, _, conflicts, err := teams.LookupImplicitTeamAndConflicts(context.TODO(), g, iTeamNameCreate1, false /*isPublic*/, teams.ImplicitTeamOptions{})
 	require.NoError(t, err)
 	require.Equal(t, iTeamxx.ID, iTeam1.ID)
 	require.Len(t, conflicts, 1)

--- a/go/systests/saltpack_test.go
+++ b/go/systests/saltpack_test.go
@@ -189,7 +189,7 @@ func TestSaltpackEncryptDecryptForImplicitTeams(t *testing.T) {
 	}
 
 	// Get current implicit team seqno so we can wait for it to be updated later
-	team, _, _, err := teams.LookupImplicitTeam(context.Background(), u1.tc.G, u1.username+","+u2.username+"@rooter", false)
+	team, _, _, err := teams.LookupImplicitTeam(context.Background(), u1.tc.G, u1.username+","+u2.username+"@rooter", false, teams.ImplicitTeamOptions{})
 	require.NoError(t, err)
 	nextSeqno := team.NextSeqno()
 

--- a/go/systests/stellar_test.go
+++ b/go/systests/stellar_test.go
@@ -155,7 +155,7 @@ func testStellarRelayAutoClaims(t *testing.T, startWithPUK, skipPart2 bool) {
 	require.NoError(t, err)
 
 	t.Logf("get the impteam seqno to wait on later")
-	team, _, _, err := teams.LookupImplicitTeam(context.Background(), alice.tc.G, alice.username+","+bob.username, false)
+	team, _, _, err := teams.LookupImplicitTeam(context.Background(), alice.tc.G, alice.username+","+bob.username, false, teams.ImplicitTeamOptions{})
 	require.NoError(t, err)
 	nextSeqno := team.NextSeqno()
 

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -194,15 +194,7 @@ func handleChangeSingle(ctx context.Context, g *libkb.GlobalContext, row keybase
 
 	defer m.CTrace(fmt.Sprintf("team.handleChangeSingle(%+v, %+v)", row, change), func() error { return err })()
 
-	if err = g.GetTeamLoader().HintLatestSeqno(ctx, row.Id, row.LatestSeqno); err != nil {
-		m.CWarningf("error in HintLatestSeqno: %v", err)
-		return nil
-	}
-
-	if err = g.GetFastTeamLoader().HintLatestSeqno(m, row.Id, row.LatestSeqno); err != nil {
-		m.CWarningf("error in FastTeamLoader#HintLatestSeqno: %v", err)
-		err = nil // non-fatal
-	}
+	HintLatestSeqno(m, row.Id, row.LatestSeqno)
 
 	// If we're handling a rename we should also purge the resolver cache and
 	// the KBFS favorites cache

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -35,33 +35,27 @@ func (i *implicitTeam) GetAppStatus() *libkb.AppStatus {
 	return &i.Status
 }
 
-type forceRepollToggle bool
+type ImplicitTeamOptions struct {
+	NoForceRepoll bool
+}
 
 // Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted copy 2017-03-04 #1)"
 // Resolves social assertions.
-func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (
+func LookupImplicitTeam(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool, opts ImplicitTeamOptions) (
 	team *Team, teamName keybase1.TeamName, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
-	team, teamName, impTeamName, _, err = LookupImplicitTeamAndConflicts(ctx, g, displayName, public, forceRepollToggle(true))
+	team, teamName, impTeamName, _, err = LookupImplicitTeamAndConflicts(ctx, g, displayName, public, opts)
 	return team, teamName, impTeamName, err
 }
 
 // Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted copy 2017-03-04 #1)"
 // Resolves social assertions.
-func LookupImplicitTeamNoForceRepoll(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (
-	team *Team, teamName keybase1.TeamName, impTeamName keybase1.ImplicitTeamDisplayName, err error) {
-	team, teamName, impTeamName, _, err = LookupImplicitTeamAndConflicts(ctx, g, displayName, public, forceRepollToggle(false))
-	return team, teamName, impTeamName, err
-}
-
-// Lookup an implicit team by name like "alice,bob+bob@twitter (conflicted copy 2017-03-04 #1)"
-// Resolves social assertions.
-func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool, forceRepoll forceRepollToggle) (
+func LookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool, opts ImplicitTeamOptions) (
 	team *Team, teamName keybase1.TeamName, impTeamName keybase1.ImplicitTeamDisplayName, conflicts []keybase1.ImplicitTeamConflictInfo, err error) {
 	impName, err := ResolveImplicitTeamDisplayName(ctx, g, displayName, public)
 	if err != nil {
 		return team, teamName, impTeamName, conflicts, err
 	}
-	return lookupImplicitTeamAndConflicts(ctx, g, displayName, impName, forceRepoll)
+	return lookupImplicitTeamAndConflicts(ctx, g, displayName, impName, opts)
 }
 
 func LookupImplicitTeamIDUntrusted(ctx context.Context, g *libkb.GlobalContext, displayName string,
@@ -123,10 +117,10 @@ func loadImpteamFromServer(ctx context.Context, g *libkb.GlobalContext, displayN
 // Does not resolve social assertions.
 // preResolveDisplayName is used for logging and errors
 func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
-	preResolveDisplayName string, impTeamNameInput keybase1.ImplicitTeamDisplayName, forceRepoll forceRepollToggle) (
+	preResolveDisplayName string, impTeamNameInput keybase1.ImplicitTeamDisplayName, opts ImplicitTeamOptions) (
 	team *Team, teamName keybase1.TeamName, impTeamName keybase1.ImplicitTeamDisplayName, conflicts []keybase1.ImplicitTeamConflictInfo, err error) {
 
-	defer g.CTraceTimed(ctx, fmt.Sprintf("lookupImplicitTeamAndConflicts(%v,forceRepoll=%v)", preResolveDisplayName, forceRepoll), func() error { return err })()
+	defer g.CTraceTimed(ctx, fmt.Sprintf("lookupImplicitTeamAndConflicts(%v,opts=%+v)", preResolveDisplayName, opts), func() error { return err })()
 
 	impTeamName = impTeamNameInput
 
@@ -186,7 +180,7 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	team, err = Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          teamID,
 		Public:      impTeamName.IsPublic,
-		ForceRepoll: bool(forceRepoll),
+		ForceRepoll: !opts.NoForceRepoll,
 	})
 	if err != nil {
 		return team, teamName, impTeamName, conflicts, err
@@ -235,7 +229,7 @@ func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, dis
 		return res, teamName, impTeamName, err
 	}
 
-	res, teamName, impTeamName, _, err = lookupImplicitTeamAndConflicts(ctx, g, displayName, lookupName, forceRepollToggle(true))
+	res, teamName, impTeamName, _, err = lookupImplicitTeamAndConflicts(ctx, g, displayName, lookupName, ImplicitTeamOptions{})
 	if err != nil {
 		if _, ok := err.(TeamDoesNotExistError); ok {
 			if lookupName.ConflictInfo != nil {
@@ -251,7 +245,7 @@ func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, dis
 				if isDupImplicitTeamError(ctx, err) {
 					g.Log.CDebugf(ctx, "LookupOrCreateImplicitTeam: duplicate team, trying to lookup again: err: %s", err)
 					res, teamName, impTeamName, _, err = lookupImplicitTeamAndConflicts(ctx, g, displayName,
-						lookupName, forceRepollToggle(true))
+						lookupName, ImplicitTeamOptions{})
 				}
 				return res, teamName, impTeamName, err
 			}

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -176,7 +176,7 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	team, err = Load(ctx, g, keybase1.LoadTeamArg{
 		ID:          teamID,
 		Public:      impTeamName.IsPublic,
-		ForceRepoll: true,
+		ForceRepoll: false, // it's important to hit the cache here, since we call this once per chat send!
 	})
 	if err != nil {
 		return team, teamName, impTeamName, conflicts, err

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -44,7 +44,7 @@ func TestLookupImplicitTeams(t *testing.T) {
 
 	lookupAndCreate := func(displayName string, public bool) {
 		t.Logf("displayName:%v public:%v", displayName, public)
-		_, _, _, err := LookupImplicitTeam(context.TODO(), tc.G, displayName, public)
+		_, _, _, err := LookupImplicitTeam(context.TODO(), tc.G, displayName, public, ImplicitTeamOptions{})
 		require.Error(t, err)
 		require.IsType(t, TeamDoesNotExistError{}, err)
 
@@ -68,7 +68,7 @@ func TestLookupImplicitTeams(t *testing.T) {
 		require.Equal(t, impTeamName, impTeamName2, "public: %v", public)
 		require.Equal(t, tlfid1, tlfid2, "the right TLFID came back")
 
-		lookupTeam, _, impTeamName, err := LookupImplicitTeam(context.TODO(), tc.G, displayName, public)
+		lookupTeam, _, impTeamName, err := LookupImplicitTeam(context.TODO(), tc.G, displayName, public, ImplicitTeamOptions{})
 		require.NoError(t, err)
 		require.Equal(t, createdTeam.ID, lookupTeam.ID)
 
@@ -123,7 +123,7 @@ func TestImplicitPukless(t *testing.T) {
 	team, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
 	require.NoError(t, err)
 
-	team2, _, _, err := LookupImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/)
+	team2, _, _, err := LookupImplicitTeam(context.Background(), tcs[0].G, displayName, false /*isPublic*/, ImplicitTeamOptions{})
 	require.NoError(t, err)
 	require.Equal(t, team.ID, team2.ID)
 

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -859,6 +859,7 @@ func (l *TeamLoader) userPreload(ctx context.Context, links []*ChainLinkUnpacked
 // - ForceRepoll
 // - Cache freshness / StaleOK
 // - NeedSeqnos
+// - JustUpdated
 // - If this user is in global "force repoll" mode, where it would be too spammy to
 //   push out individual team changed notifications, so all team loads need a repoll.
 func (l *TeamLoader) load2DecideRepoll(ctx context.Context, arg load2ArgT, fromCache *keybase1.TeamData) (bool, bool) {

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -245,9 +245,13 @@ func TestLoaderKBFSKeyGenOffset(t *testing.T) {
 	require.NoError(t, err)
 	keys, err := team.AllApplicationKeysWithKBFS(context.TODO(), keybase1.TeamApplication_KBFS)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(keys))
+
+	// TODO -- See CORE-9677 - fix this test to switch users to test the refresher, since if Alice does the update
+	// herself, her load is autorefreshed after bugfixes in CORE-9663.
+	require.Equal(t, 3, len(keys))
 	require.Equal(t, 1, keys[0].Generation())
-	key3 := keys[0].Key
+	key3 := keys[2].Key // See above TODO, this is also wonky
+
 	team, err = Load(context.TODO(), tcs[0].G, keybase1.LoadTeamArg{
 		ID: team.ID,
 		Refreshers: keybase1.TeamRefreshers{
@@ -256,6 +260,7 @@ func TestLoaderKBFSKeyGenOffset(t *testing.T) {
 			},
 		},
 	})
+
 	require.NoError(t, err)
 	keys, err = team.AllApplicationKeysWithKBFS(context.TODO(), keybase1.TeamApplication_KBFS)
 	require.NoError(t, err)

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -205,7 +205,10 @@ func TestLoaderKBFSKeyGen(t *testing.T) {
 		ID: team.ID,
 	})
 	require.NoError(t, err)
-	require.Zero(t, len(team.KBFSCryptKeys(context.TODO(), keybase1.TeamApplication_CHAT)))
+
+	// See TODO below, CORE-9677. This test previously relied on buggy behavior, which now is fixed.
+	//require.Zero(t, len(team.KBFSCryptKeys(context.TODO(), keybase1.TeamApplication_CHAT)))
+
 	team, err = Load(context.TODO(), tcs[0].G, keybase1.LoadTeamArg{
 		ID: team.ID,
 		Refreshers: keybase1.TeamRefreshers{

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1170,7 +1170,7 @@ func IgnoreRequest(ctx context.Context, g *libkb.GlobalContext, teamName, userna
 	if err != nil {
 		return err
 	}
-	t.notify(ctx, keybase1.TeamChangeSet{Misc: true})
+	t.notifyNoChainChange(ctx, keybase1.TeamChangeSet{Misc: true})
 	return nil
 }
 
@@ -1623,7 +1623,7 @@ func SetTarsDisabled(ctx context.Context, g *libkb.GlobalContext, teamname strin
 	if _, err := g.API.Post(arg); err != nil {
 		return err
 	}
-	t.notify(ctx, keybase1.TeamChangeSet{Misc: true})
+	t.notifyNoChainChange(ctx, keybase1.TeamChangeSet{Misc: true})
 	return nil
 }
 

--- a/go/teams/showcase_helper.go
+++ b/go/teams/showcase_helper.go
@@ -113,7 +113,7 @@ func SetTeamShowcase(ctx context.Context, g *libkb.GlobalContext, teamname strin
 	if _, err := g.API.Post(arg); err != nil {
 		return err
 	}
-	t.notify(ctx, keybase1.TeamChangeSet{Misc: true})
+	t.notifyNoChainChange(ctx, keybase1.TeamChangeSet{Misc: true})
 	return nil
 }
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -474,11 +474,12 @@ func (t *Team) Rotate(ctx context.Context) (err error) {
 		secretBoxes:   secretBoxes,
 		teamEKPayload: teamEKPayload,
 	}
-	if err := t.postChangeItem(ctx, section, libkb.LinkTypeRotateKey, nil, payloadArgs); err != nil {
+	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeRotateKey, nil, payloadArgs)
+	if err != nil {
 		return err
 	}
 
-	t.notify(ctx, keybase1.TeamChangeSet{KeyRotated: true})
+	t.notify(ctx, keybase1.TeamChangeSet{KeyRotated: true}, latestSeqno)
 	t.storeTeamEKPayload(ctx, teamEKPayload)
 
 	return nil
@@ -588,11 +589,13 @@ func (t *Team) ChangeMembershipWithOptions(ctx context.Context, req keybase1.Tea
 		sigPayloadArgs.prePayload = libkb.JSONPayload{"permanent": true}
 	}
 
-	if err := t.postChangeItem(ctx, section, libkb.LinkTypeChangeMembership, merkleRoot, sigPayloadArgs); err != nil {
+	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeChangeMembership, merkleRoot, sigPayloadArgs)
+
+	if err != nil {
 		return err
 	}
 
-	t.notify(ctx, keybase1.TeamChangeSet{MembershipChanged: true})
+	t.notify(ctx, keybase1.TeamChangeSet{MembershipChanged: true}, latestSeqno)
 
 	return nil
 }
@@ -666,10 +669,17 @@ func (t *Team) Leave(ctx context.Context, permanent bool) error {
 	sigPayloadArgs := sigPayloadArgs{
 		prePayload: libkb.JSONPayload{"permanent": permanent},
 	}
-	return t.postChangeItem(ctx, section, libkb.LinkTypeLeave, nil, sigPayloadArgs)
+	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeLeave, nil, sigPayloadArgs)
+	if err != nil {
+		return err
+	}
+
+	t.notify(ctx, keybase1.TeamChangeSet{MembershipChanged: true}, latestSeqno)
+	return nil
 }
 
 func (t *Team) deleteRoot(ctx context.Context, ui keybase1.TeamsUiInterface) error {
+	m := t.MetaContext(ctx)
 	uv, err := t.currentUserUV(ctx)
 	if err != nil {
 		return err
@@ -710,16 +720,23 @@ func (t *Team) deleteRoot(ctx context.Context, ui keybase1.TeamsUiInterface) err
 		return errors.New("No merkle root available for team delete root")
 	}
 
-	sigMultiItem, err := t.sigTeamItem(ctx, teamSection, libkb.LinkTypeDeleteRoot, mr)
+	sigMultiItem, latestSeqno, err := t.sigTeamItem(ctx, teamSection, libkb.LinkTypeDeleteRoot, mr)
 	if err != nil {
 		return err
 	}
 
 	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs{})
-	return t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
+	err = t.postMulti(m, payload)
+	if err != nil {
+		return err
+	}
+	t.HintLatestSeqno(m, latestSeqno)
+	return nil
 }
 
 func (t *Team) deleteSubteam(ctx context.Context, ui keybase1.TeamsUiInterface) error {
+
+	m := t.MetaContext(ctx)
 
 	// subteam delete consists of two links:
 	// 1. delete_subteam in parent chain
@@ -777,7 +794,7 @@ func (t *Team) deleteSubteam(ctx context.Context, ui keybase1.TeamsUiInterface) 
 		return errors.New("No merkle root available for team delete subteam")
 	}
 
-	sigParent, err := parentTeam.sigTeamItem(ctx, parentSection, libkb.LinkTypeDeleteSubteam, mr)
+	sigParent, latestSeqno, err := parentTeam.sigTeamItem(ctx, parentSection, libkb.LinkTypeDeleteSubteam, mr)
 	if err != nil {
 		return err
 	}
@@ -793,14 +810,19 @@ func (t *Team) deleteSubteam(ctx context.Context, ui keybase1.TeamsUiInterface) 
 		Public: t.IsPublic(),
 		Admin:  admin,
 	}
-	sigSub, err := t.sigTeamItem(ctx, subSection, libkb.LinkTypeDeleteUpPointer, mr)
+	sigSub, latestSeqno, err := t.sigTeamItem(ctx, subSection, libkb.LinkTypeDeleteUpPointer, mr)
 	if err != nil {
 		return err
 	}
 
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []interface{}{sigParent, sigSub}
-	return t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
+	err = t.postMulti(m, payload)
+	if err != nil {
+		return err
+	}
+	t.HintLatestSeqno(m, latestSeqno)
+	return nil
 }
 
 func (t *Team) NumActiveInvites() int {
@@ -1065,6 +1087,8 @@ func (t *Team) postInvite(ctx context.Context, invite SCTeamInvite, role keybase
 }
 
 func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error {
+	m := t.MetaContext(ctx)
+
 	admin, err := t.getAdminPermission(ctx)
 	if err != nil {
 		return err
@@ -1096,7 +1120,7 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 		return errors.New("No merkle root available for team invite")
 	}
 
-	sigMultiItem, err := t.sigTeamItem(ctx, teamSection, libkb.LinkTypeInvite, mr)
+	sigMultiItem, latestSeqno, err := t.sigTeamItem(ctx, teamSection, libkb.LinkTypeInvite, mr)
 	if err != nil {
 		return err
 	}
@@ -1108,12 +1132,12 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 	}
 
 	payload := t.sigPayload(sigMulti, sigPayloadArgs{})
-	err = t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
+	err = t.postMulti(m, payload)
 	if err != nil {
 		return err
 	}
 
-	t.notify(ctx, keybase1.TeamChangeSet{MembershipChanged: true})
+	t.notify(ctx, keybase1.TeamChangeSet{MembershipChanged: true}, latestSeqno)
 	return nil
 }
 
@@ -1222,24 +1246,28 @@ func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamCha
 	return section, secretBoxes, implicitAdminBoxes, teamEKPayload, memSet, nil
 }
 
-func (t *Team) postChangeItem(ctx context.Context, section SCTeamSection, linkType libkb.LinkType, merkleRoot *libkb.MerkleRoot, sigPayloadArgs sigPayloadArgs) error {
+func (t *Team) postChangeItem(ctx context.Context, section SCTeamSection, linkType libkb.LinkType, merkleRoot *libkb.MerkleRoot, sigPayloadArgs sigPayloadArgs) (keybase1.Seqno, error) {
 	// create the change item
-	sigMultiItem, err := t.sigTeamItem(ctx, section, linkType, merkleRoot)
+	sigMultiItem, latestSeqno, err := t.sigTeamItem(ctx, section, linkType, merkleRoot)
 	if err != nil {
-		return err
+		return keybase1.Seqno(0), err
 	}
 
 	sigMulti := []libkb.SigMultiItem{sigMultiItem}
 	err = t.precheckLinksToPost(ctx, sigMulti)
 	if err != nil {
-		return err
+		return keybase1.Seqno(0), err
 	}
 
 	// make the payload
 	payload := t.sigPayload(sigMulti, sigPayloadArgs)
 
 	// send it to the server
-	return t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
+	err = t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
+	if err != nil {
+		return keybase1.Seqno(0), err
+	}
+	return latestSeqno, nil
 }
 
 func (t *Team) currentUserUV(ctx context.Context) (keybase1.UserVersion, error) {
@@ -1269,12 +1297,12 @@ func usesPerTeamKeys(linkType libkb.LinkType) bool {
 	return true
 }
 
-func (t *Team) sigTeamItem(ctx context.Context, section SCTeamSection, linkType libkb.LinkType, merkleRoot *libkb.MerkleRoot) (libkb.SigMultiItem, error) {
+func (t *Team) sigTeamItem(ctx context.Context, section SCTeamSection, linkType libkb.LinkType, merkleRoot *libkb.MerkleRoot) (libkb.SigMultiItem, keybase1.Seqno, error) {
 	nextSeqno := t.NextSeqno()
 	lastLinkID := t.chain().GetLatestLinkID()
 
 	sig, _, err := t.sigTeamItemRaw(ctx, section, linkType, nextSeqno, lastLinkID, merkleRoot)
-	return sig, err
+	return sig, nextSeqno, err
 }
 
 func (t *Team) sigTeamItemRaw(ctx context.Context, section SCTeamSection, linkType libkb.LinkType, nextSeqno keybase1.Seqno, lastLinkID keybase1.LinkID, merkleRoot *libkb.MerkleRoot) (libkb.SigMultiItem, keybase1.LinkID, error) {
@@ -1674,12 +1702,12 @@ func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSetti
 		Public:   t.IsPublic(),
 	}
 
-	err = t.postChangeItem(ctx, section, libkb.LinkTypeSettings, nil, sigPayloadArgs{})
+	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeSettings, nil, sigPayloadArgs{})
 	if err != nil {
 		return err
 	}
 
-	t.notify(ctx, keybase1.TeamChangeSet{Misc: true})
+	t.notify(ctx, keybase1.TeamChangeSet{Misc: true}, latestSeqno)
 	return nil
 }
 
@@ -1762,11 +1790,12 @@ func (t *Team) boxKBFSCryptKeys(ctx context.Context, key keybase1.TeamApplicatio
 
 func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 	cryptKeys []keybase1.CryptKey, appType keybase1.TeamApplication) (err error) {
-	defer t.G().CTrace(ctx, "Team.AssociateWithTLFKeyset", func() error { return err })()
+	m := t.MetaContext(ctx)
+	defer m.CTrace("Team.AssociateWithTLFKeyset", func() error { return err })()
 
 	// If we get no crypt keys, just associate TLF ID and bail
 	if len(cryptKeys) == 0 {
-		t.G().Log.CDebugf(ctx, "AssociateWithTLFKeyset: no crypt keys given, aborting")
+		m.CDebugf("AssociateWithTLFKeyset: no crypt keys given, aborting")
 		return nil
 	}
 
@@ -1799,7 +1828,7 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		},
 	}
 
-	mr, err := t.G().MerkleClient.FetchRootFromServer(t.MetaContext(ctx), libkb.TeamMerkleFreshnessForAdmin)
+	mr, err := m.G().MerkleClient.FetchRootFromServer(m, libkb.TeamMerkleFreshnessForAdmin)
 	if err != nil {
 		return err
 	}
@@ -1807,7 +1836,7 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		return errors.New("No merkle root available for KBFS settings update")
 	}
 
-	sigMultiItem, err := t.sigTeamItem(ctx, teamSection, libkb.LinkTypeKBFSSettings, mr)
+	sigMultiItem, latestSeqno, err := t.sigTeamItem(ctx, teamSection, libkb.LinkTypeKBFSSettings, mr)
 	if err != nil {
 		return err
 	}
@@ -1820,11 +1849,19 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 			AppType:          appType,
 		},
 	})
-	return t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
+
+	err = t.postMulti(m, payload)
+	if err != nil {
+		return err
+	}
+
+	t.HintLatestSeqno(m, latestSeqno)
+	return nil
 }
 
 func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (err error) {
-	defer t.G().CTrace(ctx, "Team.AssociateWithTLFID", func() error { return err })()
+	m := t.MetaContext(ctx)
+	defer m.CTrace("Team.AssociateWithTLFID", func() error { return err })()
 
 	teamSection := SCTeamSection{
 		ID:       SCTeamID(t.ID),
@@ -1837,7 +1874,7 @@ func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (er
 		},
 	}
 
-	mr, err := t.G().MerkleClient.FetchRootFromServer(t.MetaContext(ctx), libkb.TeamMerkleFreshnessForAdmin)
+	mr, err := m.G().MerkleClient.FetchRootFromServer(m, libkb.TeamMerkleFreshnessForAdmin)
 	if err != nil {
 		return err
 	}
@@ -1845,26 +1882,57 @@ func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (er
 		return errors.New("No merkle root available for KBFS settings update")
 	}
 
-	sigMultiItem, err := t.sigTeamItem(ctx, teamSection, libkb.LinkTypeKBFSSettings, mr)
+	sigMultiItem, latestSeqno, err := t.sigTeamItem(ctx, teamSection, libkb.LinkTypeKBFSSettings, mr)
 	if err != nil {
 		return err
 	}
 
 	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs{})
-	return t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
+	err = t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
+	if err != nil {
+		return err
+	}
+	t.HintLatestSeqno(m, latestSeqno)
+	return nil
+}
+
+func (t *Team) notifyNoChainChange(ctx context.Context, changes keybase1.TeamChangeSet) error {
+	return t.notify(ctx, changes, keybase1.Seqno(0))
 }
 
 // Send notifyrouter messages.
 // Modifies `changes`
-// The sequence number of the is assumed to be bumped by 1, so use `NextSeqno()` and not `CurrentSeqno()`.
+// Update to the latest seqno that we're passing though, don't make any assumptions about number of sigs.
 // Note that we're probably going to be getting this same notification a second time, since it will
 // bounce off a gregor and back to us. But they are idempotent, so it should be fine to be double-notified.
-func (t *Team) notify(ctx context.Context, changes keybase1.TeamChangeSet) {
+func (t *Team) notify(ctx context.Context, changes keybase1.TeamChangeSet, latestSeqno keybase1.Seqno) error {
 	changes.KeyRotated = changes.KeyRotated || t.rotated
 	m := libkb.NewMetaContext(ctx, t.G())
-	t.G().GetTeamLoader().HintLatestSeqno(ctx, t.ID, t.NextSeqno())
-	t.G().GetFastTeamLoader().HintLatestSeqno(m, t.ID, t.NextSeqno())
+	var err error
+	if latestSeqno > 0 {
+		err = HintLatestSeqno(m, t.ID, latestSeqno)
+	}
 	t.G().NotifyRouter.HandleTeamChangedByBothKeys(ctx, t.ID, t.Name().String(), t.NextSeqno(), t.IsImplicit(), changes)
+	return err
+}
+
+func (t *Team) HintLatestSeqno(m libkb.MetaContext, n keybase1.Seqno) error {
+	return HintLatestSeqno(m, t.ID, n)
+}
+
+func HintLatestSeqno(m libkb.MetaContext, id keybase1.TeamID, n keybase1.Seqno) error {
+	err := m.G().GetTeamLoader().HintLatestSeqno(m.Ctx(), id, n)
+	if err != nil {
+		m.CWarningf("error in TeamLoader#HintLatestSeqno: %v", err)
+	}
+	e2 := m.G().GetFastTeamLoader().HintLatestSeqno(m, id, n)
+	if e2 != nil {
+		m.CWarningf("error in FastTeamLoader#HintLatestSeqno: %v", err)
+	}
+	if err != nil {
+		return err
+	}
+	return e2
 }
 
 func (t *Team) refreshUIDMapper(ctx context.Context, g *libkb.GlobalContext) {

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -836,7 +836,7 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 		return err
 	}
 
-	team.notify(mctx.Ctx(), keybase1.TeamChangeSet{MembershipChanged: true})
+	team.notify(mctx.Ctx(), keybase1.TeamChangeSet{MembershipChanged: true}, nextSeqno)
 
 	team.storeTeamEKPayload(mctx.Ctx(), teamEKPayload)
 	return nil

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -836,7 +836,7 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 		return err
 	}
 
-	team.notify(mctx.Ctx(), keybase1.TeamChangeSet{MembershipChanged: true}, nextSeqno)
+	team.notify(mctx.Ctx(), keybase1.TeamChangeSet{MembershipChanged: true}, nextSeqno-1)
 
 	team.storeTeamEKPayload(mctx.Ctx(), teamEKPayload)
 	return nil


### PR DESCRIPTION
- fix the test that this broke, and in general:
- fix the notification system internal to the app that adjusts the locally cached version of the teamchain
 - sometimes bump the chain 0, sometimes 1, sometimes 2, depending on the caller!
 - previously, always bumping +1 definitely caused some bugs, but we likely got away with it