### PR TITLE
Send device id to ephemeral key endpoints

### DIFF
--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -33,7 +33,8 @@ func (s *TeamEKSeed) DeriveDHKey() *libkb.NaclDHKeyPair {
 	return deriveDHKey(keybase1.Bytes32(*s), libkb.DeriveReasonTeamEKEncryption)
 }
 
-func postNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, sig string, boxes *[]keybase1.TeamEkBoxMetadata) (err error) {
+func postNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID,
+	sig string, boxes *[]keybase1.TeamEkBoxMetadata) (err error) {
 	defer g.CTraceTimed(ctx, "postNewTeamEK", func() error { return err })()
 
 	boxesJSON, err := json.Marshal(*boxes)
@@ -45,16 +46,20 @@ func postNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.
 		SessionType: libkb.APISessionTypeREQUIRED,
 		NetContext:  ctx,
 		Args: libkb.HTTPArgs{
-			"team_id": libkb.S{Val: string(teamID)},
-			"sig":     libkb.S{Val: sig},
-			"boxes":   libkb.S{Val: string(boxesJSON)},
+			"team_id":           libkb.S{Val: string(teamID)},
+			"sig":               libkb.S{Val: sig},
+			"boxes":             libkb.S{Val: string(boxesJSON)},
+			"creator_device_id": libkb.S{Val: string(g.Env.GetDeviceID())},
 		},
 	}
 	_, err = g.GetAPI().Post(apiArg)
 	return err
 }
 
-func prepareNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, signingKey libkb.NaclSigningKeyPair, membersMetadata map[keybase1.UID]keybase1.UserEkMetadata, merkleRoot libkb.MerkleRoot) (sig string, boxes *[]keybase1.TeamEkBoxMetadata, metadata keybase1.TeamEkMetadata, myBox *keybase1.TeamEkBoxed, err error) {
+func prepareNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID,
+	signingKey libkb.NaclSigningKeyPair, membersMetadata map[keybase1.UID]keybase1.UserEkMetadata,
+	merkleRoot libkb.MerkleRoot) (sig string, boxes *[]keybase1.TeamEkBoxMetadata,
+	metadata keybase1.TeamEkMetadata, myBox *keybase1.TeamEkBoxed, err error) {
 	defer g.CTraceTimed(ctx, "prepareNewTeamEK", func() error { return err })()
 
 	seed, err := newTeamEphemeralSeed()
@@ -114,7 +119,8 @@ func prepareNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybas
 	return sig, boxes, metadata, myTeamEKBoxed, nil
 }
 
-func publishNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
+func publishNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID,
+	merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
 	defer g.CTraceTimed(ctx, "publishNewTeamEK", func() error { return err })()
 
 	team, err := teams.Load(ctx, g, keybase1.LoadTeamArg{
@@ -191,7 +197,8 @@ func teamEKRetryWrapper(ctx context.Context, g *libkb.GlobalContext, retryFn fun
 	return nil
 }
 
-func ForcePublishNewTeamEKForTesting(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
+func ForcePublishNewTeamEKForTesting(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID,
+	merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
 	defer g.CTraceTimed(ctx, "ForcePublishNewTeamEKForTesting", func() error { return err })()
 	err = teamEKRetryWrapper(ctx, g, func() error {
 		metadata, err = publishNewTeamEK(ctx, g, teamID, merkleRoot)
@@ -200,7 +207,9 @@ func ForcePublishNewTeamEKForTesting(ctx context.Context, g *libkb.GlobalContext
 	return metadata, err
 }
 
-func boxTeamEKForUsers(ctx context.Context, g *libkb.GlobalContext, usersMetadata map[keybase1.UID]keybase1.UserEkMetadata, teamEK keybase1.TeamEk) (teamBoxes *[]keybase1.TeamEkBoxMetadata, myTeamEKBoxed *keybase1.TeamEkBoxed, err error) {
+func boxTeamEKForUsers(ctx context.Context, g *libkb.GlobalContext, usersMetadata map[keybase1.UID]keybase1.UserEkMetadata,
+	teamEK keybase1.TeamEk) (teamBoxes *[]keybase1.TeamEkBoxMetadata,
+	myTeamEKBoxed *keybase1.TeamEkBoxed, err error) {
 	defer g.CTraceTimed(ctx, "boxTeamEKForUsers", func() error { return err })()
 
 	myUID := g.Env.GetUID()
@@ -242,7 +251,8 @@ type teamEKStatementResponse struct {
 // one, this function will also return nil and log a warning. This is a
 // transitional thing, and eventually when all "reasonably up to date" clients
 // in the wild have EK support, we will make that case an error.
-func fetchTeamEKStatement(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (statement *keybase1.TeamEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
+func fetchTeamEKStatement(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (
+	statement *keybase1.TeamEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
 	defer g.CTraceTimed(ctx, "fetchTeamEKStatement", func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -304,7 +314,8 @@ func extractTeamEKStatementFromSig(sig string) (signerKey *kbcrypto.NaclSigningK
 // `wrongKID` flag. As a transitional measure while we wait for all clients in
 // the wild to have EK support, callers will treat that case as "there is no
 // key" and convert the error to a warning.
-func verifySigWithLatestPTK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, sig string) (statement *keybase1.TeamEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
+func verifySigWithLatestPTK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID,
+	sig string) (statement *keybase1.TeamEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
 	defer g.CTraceTimed(ctx, "verifySigWithLatestPTK", func() error { return err })()
 
 	// Parse the statement before we verify the signing key. Even if the
@@ -361,7 +372,8 @@ type teamMemberEKStatementResponse struct {
 // Returns nil if all team members have never published a teamEK. Verifies that
 // the map of users the server returns are indeed valid team members of the
 // team and all signatures verify correctly for the users.
-func fetchTeamMemberStatements(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (statementMap map[keybase1.UID]*keybase1.UserEkStatement, err error) {
+func fetchTeamMemberStatements(ctx context.Context, g *libkb.GlobalContext,
+	teamID keybase1.TeamID) (statementMap map[keybase1.UID]*keybase1.UserEkStatement, err error) {
 	defer g.CTraceTimed(ctx, "fetchTeamMemberStatements", func() error { return err })()
 
 	apiArg := libkb.APIArg{

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -142,6 +142,7 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 		Args: libkb.HTTPArgs{
 			"team_id":    libkb.S{Val: string(teamID)},
 			"generation": libkb.U{Val: uint64(generation)},
+			"device_id":  libkb.S{Val: string(s.G().Env.GetDeviceID())},
 		},
 	}
 

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -46,8 +46,9 @@ func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxe
 		SessionType: libkb.APISessionTypeREQUIRED,
 		NetContext:  ctx,
 		Args: libkb.HTTPArgs{
-			"sig":   libkb.S{Val: sig},
-			"boxes": libkb.S{Val: string(boxesJSON)},
+			"sig":               libkb.S{Val: sig},
+			"boxes":             libkb.S{Val: string(boxesJSON)},
+			"creator_device_id": libkb.S{Val: string(g.Env.GetDeviceID())},
 		},
 	}
 	_, err = g.GetAPI().Post(apiArg)
@@ -59,7 +60,9 @@ func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxe
 // PUK. The other is where we're rolling the PUK, and we need to sign a new
 // userEK with the new PUK to upload both together. This helper covers the
 // steps common to both cases.
-func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot, pukSigning *libkb.NaclSigningKeyPair) (sig string, boxes []keybase1.UserEkBoxMetadata, newMetadata keybase1.UserEkMetadata, myBox *keybase1.UserEkBoxed, err error) {
+func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot,
+	pukSigning *libkb.NaclSigningKeyPair) (sig string, boxes []keybase1.UserEkBoxMetadata,
+	newMetadata keybase1.UserEkMetadata, myBox *keybase1.UserEkBoxed, err error) {
 	defer g.CTraceTimed(ctx, "prepareNewUserEK", func() error { return err })()
 
 	seed, err := newUserEphemeralSeed()
@@ -116,7 +119,8 @@ func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 }
 
 // Create a new userEK and upload it. Add our box to the local box store.
-func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata keybase1.UserEkMetadata, err error) {
+func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (
+	metadata keybase1.UserEkMetadata, err error) {
 	defer g.CTraceTimed(ctx, "publishNewUserEK", func() error { return err })()
 
 	// Sign the statement blob with the latest PUK.
@@ -153,7 +157,9 @@ func ForcePublishNewUserEKForTesting(ctx context.Context, g *libkb.GlobalContext
 	return publishNewUserEK(ctx, g, merkleRoot)
 }
 
-func boxUserEKForDevices(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot, seed UserEKSeed, userMetadata keybase1.UserEkMetadata) (boxes []keybase1.UserEkBoxMetadata, myUserEKBoxed *keybase1.UserEkBoxed, err error) {
+func boxUserEKForDevices(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot,
+	seed UserEKSeed, userMetadata keybase1.UserEkMetadata) (boxes []keybase1.UserEkBoxMetadata,
+	myUserEKBoxed *keybase1.UserEkBoxed, err error) {
 	defer g.CTraceTimed(ctx, "boxUserEKForDevices", func() error { return err })()
 
 	devicesMetadata, err := allActiveDeviceEKMetadata(ctx, g, merkleRoot)
@@ -199,7 +205,8 @@ type userEKStatementResponse struct {
 // one, this function will also return nil and log a warning. This is a
 // transitional thing, and eventually when all "reasonably up to date" clients
 // in the wild have EK support, we will make that case an error.
-func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []keybase1.UID) (statements map[keybase1.UID]*keybase1.UserEkStatement, err error) {
+func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []keybase1.UID) (
+	statements map[keybase1.UID]*keybase1.UserEkStatement, err error) {
 	defer g.CTraceTimed(ctx, fmt.Sprintf("fetchUserEKStatements: numUids: %v", len(uids)), func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -245,7 +252,8 @@ func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []k
 // one, this function will return wrongKID. This allows clients to chose the
 // correct generation number but not include the statement when generating a
 // new userEK.
-func fetchUserEKStatement(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (statement *keybase1.UserEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
+func fetchUserEKStatement(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (
+	statement *keybase1.UserEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
 	defer g.CTraceTimed(ctx, "fetchUserEKStatement", func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -312,7 +320,8 @@ func extractUserEKStatementFromSig(sig string) (signerKey *kbcrypto.NaclSigningK
 // the wild to have EK support, callers will treat that case as "there is no
 // key" and convert the error to a warning. We set `latestGeneration` so that
 // callers can use this value to generate a new key even if `wrongKID` is set.
-func verifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, sig string) (statement *keybase1.UserEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
+func verifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, sig string) (
+	statement *keybase1.UserEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
 	defer g.CTraceTimed(ctx, "verifySigWithLatestPUK", func() error { return err })()
 
 	// Parse the statement before we verify the signing key. Even if the
@@ -356,7 +365,8 @@ func verifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, uid key
 	return parsedStatement, latestGeneration, false, nil
 }
 
-func filterStaleUserEKStatements(ctx context.Context, g *libkb.GlobalContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement, merkleRoot libkb.MerkleRoot) (activeMap map[keybase1.UID]keybase1.UserEkStatement, err error) {
+func filterStaleUserEKStatements(ctx context.Context, g *libkb.GlobalContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement,
+	merkleRoot libkb.MerkleRoot) (activeMap map[keybase1.UID]keybase1.UserEkStatement, err error) {
 	defer g.CTraceTimed(ctx, fmt.Sprintf("filterStaleUserEKStatements: numStatements: %v", len(statementMap)), func() error { return err })()
 
 	activeMap = make(map[keybase1.UID]keybase1.UserEkStatement)
@@ -376,7 +386,8 @@ func filterStaleUserEKStatements(ctx context.Context, g *libkb.GlobalContext, st
 	return activeMap, nil
 }
 
-func activeUserEKMetadata(ctx context.Context, g *libkb.GlobalContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement, merkleRoot libkb.MerkleRoot) (activeMetadata map[keybase1.UID]keybase1.UserEkMetadata, err error) {
+func activeUserEKMetadata(ctx context.Context, g *libkb.GlobalContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement,
+	merkleRoot libkb.MerkleRoot) (activeMetadata map[keybase1.UID]keybase1.UserEkMetadata, err error) {
 	activeMap, err := filterStaleUserEKStatements(ctx, g, statementMap, merkleRoot)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Include `device_id` when requesting userek/teamek boxes for generating device specific error messages and include creator information when posting eks for debugging, corresponds to server pr: https://github.com/keybase/keybase/pull/3257