### PR TITLE
add public box summaries to keyset uploads

### DIFF
--- a/go/teams/box_public_summary.go
+++ b/go/teams/box_public_summary.go
@@ -1,0 +1,62 @@
+package teams
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type boxPublicSummaryTable map[keybase1.UID]keybase1.Seqno
+
+type boxPublicSummary struct {
+	table boxPublicSummaryTable
+}
+
+func newBoxPublicSummary(d map[keybase1.UserVersion]keybase1.PerUserKey) (*boxPublicSummary, error) {
+	ret := boxPublicSummary{
+		table: make(boxPublicSummaryTable, len(d)),
+	}
+	for uv, puk := range d {
+		q, found := ret.table[uv.Uid]
+		if !found || q < puk.Seqno {
+			ret.table[uv.Uid] = puk.Seqno
+		}
+	}
+
+	return &ret, nil
+}
+
+func (b *boxPublicSummary) encode() ([]byte, error) {
+	return libkb.MsgpackEncode(b.table)
+}
+
+func (b *boxPublicSummary) Hash() ([]byte, error) {
+	tmp, err := b.encode()
+	if err != nil {
+		return nil, err
+	}
+	ret := sha256.Sum256(tmp)
+	return ret[:], nil
+}
+
+func (b *boxPublicSummary) HashHexEncoded() (string, error) {
+	tmp, err := b.Hash()
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(tmp), nil
+}
+
+func (b *boxPublicSummary) EncodeToString() (string, error) {
+	dst, err := b.encode()
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(dst), nil
+}
+
+func (b *boxPublicSummary) IsEmpty() bool {
+	return len(b.table) > 0
+}

--- a/go/teams/box_public_summary.go
+++ b/go/teams/box_public_summary.go
@@ -4,14 +4,15 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
 )
 
 type boxPublicSummaryTable map[keybase1.UID]keybase1.Seqno
 
 type boxPublicSummary struct {
-	table boxPublicSummaryTable
+	table    boxPublicSummaryTable
+	encoding []byte
 }
 
 func newBoxPublicSummary(d map[keybase1.UserVersion]keybase1.PerUserKey) (*boxPublicSummary, error) {
@@ -29,7 +30,21 @@ func newBoxPublicSummary(d map[keybase1.UserVersion]keybase1.PerUserKey) (*boxPu
 }
 
 func (b *boxPublicSummary) encode() ([]byte, error) {
-	return libkb.MsgpackEncode(b.table)
+	// Just encode it once, since if ever canonical encoding
+	// stops working, it won't matter, we'll still get consitent results.
+	if b.encoding != nil {
+		return b.encoding, nil
+	}
+	var mh codec.MsgpackHandle
+	mh.WriteExt = true
+	mh.Canonical = true
+	var encoded []byte
+	err := codec.NewEncoderBytes(&encoded, &mh).Encode(b.table)
+	if err != nil {
+		return nil, err
+	}
+	b.encoding = encoded
+	return encoded, nil
 }
 
 func (b *boxPublicSummary) Hash() ([]byte, error) {
@@ -58,5 +73,5 @@ func (b *boxPublicSummary) EncodeToString() (string, error) {
 }
 
 func (b *boxPublicSummary) IsEmpty() bool {
-	return len(b.table) > 0
+	return len(b.table) == 0
 }

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -12,6 +12,7 @@ import (
 type SCTeamName string
 type SCTeamID string
 type SCTeamInviteID string
+type SCTeamBoxSummaryHash string
 
 // SCTeamEntropy is used to render stubbed out links unguessable.
 // Basically, we shove a random 18-byte string into sensitive links.
@@ -27,20 +28,21 @@ type SCTeamMember keybase1.UserVersion
 type SCMapInviteIDToUV map[keybase1.TeamInviteID]keybase1.UserVersionPercentForm
 
 type SCTeamSection struct {
-	ID               SCTeamID          `json:"id"`
-	Name             *SCTeamName       `json:"name,omitempty"`
-	Members          *SCTeamMembers    `json:"members,omitempty"`
-	Parent           *SCTeamParent     `json:"parent,omitempty"`
-	Subteam          *SCSubteam        `json:"subteam,omitempty"`
-	PerTeamKey       *SCPerTeamKey     `json:"per_team_key,omitempty"`
-	Admin            *SCTeamAdmin      `json:"admin,omitempty"`
-	Invites          *SCTeamInvites    `json:"invites,omitempty"`
-	CompletedInvites SCMapInviteIDToUV `json:"completed_invites,omitempty"`
-	Implicit         bool              `json:"is_implicit,omitempty"`
-	Public           bool              `json:"is_public,omitempty"`
-	Entropy          SCTeamEntropy     `json:"entropy,omitempty"`
-	Settings         *SCTeamSettings   `json:"settings,omitempty"`
-	KBFS             *SCTeamKBFS       `json:"kbfs,omitempty"`
+	ID               SCTeamID              `json:"id"`
+	Name             *SCTeamName           `json:"name,omitempty"`
+	Members          *SCTeamMembers        `json:"members,omitempty"`
+	Parent           *SCTeamParent         `json:"parent,omitempty"`
+	Subteam          *SCSubteam            `json:"subteam,omitempty"`
+	PerTeamKey       *SCPerTeamKey         `json:"per_team_key,omitempty"`
+	Admin            *SCTeamAdmin          `json:"admin,omitempty"`
+	Invites          *SCTeamInvites        `json:"invites,omitempty"`
+	CompletedInvites SCMapInviteIDToUV     `json:"completed_invites,omitempty"`
+	Implicit         bool                  `json:"is_implicit,omitempty"`
+	Public           bool                  `json:"is_public,omitempty"`
+	Entropy          SCTeamEntropy         `json:"entropy,omitempty"`
+	Settings         *SCTeamSettings       `json:"settings,omitempty"`
+	KBFS             *SCTeamKBFS           `json:"kbfs,omitempty"`
+	BoxSummaryHash   *SCTeamBoxSummaryHash `json:"box_summary_hash,omitempty"`
 }
 
 type SCTeamMembers struct {

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -180,6 +180,11 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me libk
 		return err
 	}
 
+	err = addSummaryHash(&teamSection, secretboxes)
+	if err != nil {
+		return err
+	}
+
 	// At this point the team section has every field filled out except the
 	// reverse sig. Now we'll wrap it into a full sig, marshal it to JSON, and
 	// sign it, *twice*. The first time with the per-team signing key, to
@@ -533,6 +538,11 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 	teamSection, err := makeSubteamTeamSection(subteamName, subteamID, parentTeam, members, perTeamSigningKey.GetKID(), perTeamEncryptionKey.GetKID(), admin)
 	if err != nil {
 		return
+	}
+
+	err = addSummaryHash(&teamSection, boxes)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	subteamHeadSigBodyBeforeReverse, err := SubteamHeadSig(g, me, signingKey, teamSection)

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -290,6 +290,10 @@ func (m *memberSet) HasRemoval() bool {
 	return len(m.None) > 0
 }
 
+func (m *memberSet) HasAdditions() bool {
+	return (len(m.Owners) + len(m.Admins) + len(m.Writers) + len(m.Readers)) > 0
+}
+
 func (m *memberSet) empty() bool {
 	return len(m.Owners) == 0 && len(m.Admins) == 0 && len(m.Writers) == 0 && len(m.Readers) == 0 && len(m.None) == 0
 }

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -427,6 +427,23 @@ func (t *Team) ApplicationKeyAtGenerationWithKBFS(ctx context.Context,
 	return ApplicationKeyAtGenerationWithKBFS(t.MetaContext(ctx), t.Data, application, generation)
 }
 
+func addSummaryHash(section *SCTeamSection, boxes *PerTeamSharedSecretBoxes) error {
+	if boxes == nil {
+		return nil
+	}
+	bps := boxes.boxPublicSummary
+	if bps == nil || bps.IsEmpty() {
+		return nil
+	}
+	tmp, err := bps.HashHexEncoded()
+	if err != nil {
+		return err
+	}
+	bsh := SCTeamBoxSummaryHash(tmp)
+	section.BoxSummaryHash = &bsh
+	return nil
+}
+
 func (t *Team) Rotate(ctx context.Context) (err error) {
 
 	// initialize key manager
@@ -469,13 +486,9 @@ func (t *Team) Rotate(ctx context.Context) (err error) {
 	}
 	section.PerTeamKey = perTeamKeySection
 
-	if !secretBoxes.boxPublicSummary.IsEmpty() {
-		tmp, err := secretBoxes.boxPublicSummary.HashHexEncoded()
-		if err != nil {
-			return err
-		}
-		bsh := SCTeamBoxSummaryHash(tmp)
-		section.BoxSummaryHash = &bsh
+	err = addSummaryHash(&section, secretBoxes)
+	if err != nil {
+		return err
 	}
 
 	// post the change to the server
@@ -1240,6 +1253,11 @@ func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamCha
 		return SCTeamSection{}, nil, nil, nil, nil, err
 	}
 	section.PerTeamKey = perTeamKeySection
+
+	err = addSummaryHash(&section, secretBoxes)
+	if err != nil {
+		return SCTeamSection{}, nil, nil, nil, nil, err
+	}
 
 	section.CompletedInvites = req.CompletedInvites
 	section.Implicit = t.IsImplicit()

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -469,6 +469,15 @@ func (t *Team) Rotate(ctx context.Context) (err error) {
 	}
 	section.PerTeamKey = perTeamKeySection
 
+	if !secretBoxes.boxPublicSummary.IsEmpty() {
+		tmp, err := secretBoxes.boxPublicSummary.HashHexEncoded()
+		if err != nil {
+			return err
+		}
+		bsh := SCTeamBoxSummaryHash(tmp)
+		section.BoxSummaryHash = &bsh
+	}
+
 	// post the change to the server
 	payloadArgs := sigPayloadArgs{
 		secretBoxes:   secretBoxes,

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -681,9 +681,10 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 
 	var sections []SCTeamSection
 	memSet := newMemberSet()
+	var sectionsWithBoxSummaries []int
 
 	// Transform payloads to SCTeamSections.
-	for _, p := range tx.payloads {
+	for i, p := range tx.payloads {
 		section := SCTeamSection{
 			ID:       SCTeamID(team.ID),
 			Admin:    admin,
@@ -710,6 +711,11 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 
 			section.CompletedInvites = payload.CompletedInvites
 			sections = append(sections, section)
+
+			// If there are addditions, then there will be a new key involved.
+			// If there are deletions, then we'll be rotating. So either way,
+			// this section nneeds a box summary.
+			sectionsWithBoxSummaries = append(sectionsWithBoxSummaries, i)
 		case txPayloadTagInviteKeybase, txPayloadTagInviteSocial:
 			entropy, err := makeSCTeamEntropy()
 			if err != nil {
@@ -755,6 +761,14 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := team.recipientBoxes(mctx.Ctx(), memSet, skipKeyRotation)
 	if err != nil {
 		return err
+	}
+
+	// For all sections that we previously did add/remove members for, let's
+	for _, s := range sectionsWithBoxSummaries {
+		err = addSummaryHash(&sections[s], secretBoxes)
+		if err != nil {
+			return err
+		}
 	}
 
 	if perTeamKeySection != nil {


### PR DESCRIPTION
- we might want to disable write access while we let this bake for a bit
- but it posts successfully and populates the relevant tables..
- note there's no good way for the clients to audit this, since they don't get the boxes down from the server, but that's OK