### PR TITLE
Use new stellar notifications

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -209,6 +209,18 @@
       "payments": "Array<Types.PaymentResult>",
       "pending": "Array<Types.PaymentResult>"
     },
+    "pendingPaymentsReceived": {
+      "_description": "Received a new set of pending payments; replace existing ones with these",
+      "accountID": "Types.AccountID",
+      "pending": "Array<Types.PaymentResult>"
+    },
+    "recentPaymentsReceived": {
+      "_description": "Received a fresh first page of recent payments",
+      "accountID": "Types.AccountID",
+      "paymentCursor": "?StellarRPCTypes.PageCursor",
+      "oldestUnread": "Types.PaymentID",
+      "payments": "Array<Types.PaymentResult>"
+    },
     "requestDetailReceived": {
       "_description": "Store a request's details",
       "request": "StellarRPCTypes.RequestDetailsLocal"

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -59,6 +59,8 @@ export const markAsRead = 'wallets:markAsRead'
 export const openSendRequestForm = 'wallets:openSendRequestForm'
 export const paymentDetailReceived = 'wallets:paymentDetailReceived'
 export const paymentsReceived = 'wallets:paymentsReceived'
+export const pendingPaymentsReceived = 'wallets:pendingPaymentsReceived'
+export const recentPaymentsReceived = 'wallets:recentPaymentsReceived'
 export const refreshPayments = 'wallets:refreshPayments'
 export const rejectDisclaimer = 'wallets:rejectDisclaimer'
 export const requestDetailReceived = 'wallets:requestDetailReceived'
@@ -139,6 +141,8 @@ type _MarkAsReadPayload = $ReadOnly<{|accountID: Types.AccountID, mostRecentID: 
 type _OpenSendRequestFormPayload = $ReadOnly<{|amount?: string, currency?: string, from?: Types.AccountID, isRequest?: boolean, publicMemo?: HiddenString, recipientType?: Types.CounterpartyType, secretNote?: HiddenString, to?: string|}>
 type _PaymentDetailReceivedPayload = $ReadOnly<{|accountID: Types.AccountID, payment: Types.PaymentDetail|}>
 type _PaymentsReceivedPayload = $ReadOnly<{|accountID: Types.AccountID, paymentCursor: ?StellarRPCTypes.PageCursor, oldestUnread: Types.PaymentID, payments: Array<Types.PaymentResult>, pending: Array<Types.PaymentResult>|}>
+type _PendingPaymentsReceivedPayload = $ReadOnly<{|accountID: Types.AccountID, pending: Array<Types.PaymentResult>|}>
+type _RecentPaymentsReceivedPayload = $ReadOnly<{|accountID: Types.AccountID, paymentCursor: ?StellarRPCTypes.PageCursor, oldestUnread: Types.PaymentID, payments: Array<Types.PaymentResult>|}>
 type _RefreshPaymentsPayload = $ReadOnly<{|accountID: Types.AccountID, paymentID: Types.PaymentID|}>
 type _RejectDisclaimerPayload = void
 type _RequestDetailReceivedPayload = $ReadOnly<{|request: StellarRPCTypes.RequestDetailsLocal|}>
@@ -316,6 +320,14 @@ export const createMarkAsRead = (payload: _MarkAsReadPayload) => ({payload, type
  * Perform sending a payment
  */
 export const createSendPayment = (payload: _SendPaymentPayload) => ({payload, type: sendPayment})
+/**
+ * Received a fresh first page of recent payments
+ */
+export const createRecentPaymentsReceived = (payload: _RecentPaymentsReceivedPayload) => ({payload, type: recentPaymentsReceived})
+/**
+ * Received a new set of pending payments; replace existing ones with these
+ */
+export const createPendingPaymentsReceived = (payload: _PendingPaymentsReceivedPayload) => ({payload, type: pendingPaymentsReceived})
 /**
  * Received wallet disclaimer
  */
@@ -528,6 +540,8 @@ export type MarkAsReadPayload = {|+payload: _MarkAsReadPayload, +type: 'wallets:
 export type OpenSendRequestFormPayload = {|+payload: _OpenSendRequestFormPayload, +type: 'wallets:openSendRequestForm'|}
 export type PaymentDetailReceivedPayload = {|+payload: _PaymentDetailReceivedPayload, +type: 'wallets:paymentDetailReceived'|}
 export type PaymentsReceivedPayload = {|+payload: _PaymentsReceivedPayload, +type: 'wallets:paymentsReceived'|}
+export type PendingPaymentsReceivedPayload = {|+payload: _PendingPaymentsReceivedPayload, +type: 'wallets:pendingPaymentsReceived'|}
+export type RecentPaymentsReceivedPayload = {|+payload: _RecentPaymentsReceivedPayload, +type: 'wallets:recentPaymentsReceived'|}
 export type RefreshPaymentsPayload = {|+payload: _RefreshPaymentsPayload, +type: 'wallets:refreshPayments'|}
 export type RejectDisclaimerPayload = {|+payload: _RejectDisclaimerPayload, +type: 'wallets:rejectDisclaimer'|}
 export type RequestDetailReceivedPayload = {|+payload: _RequestDetailReceivedPayload, +type: 'wallets:requestDetailReceived'|}
@@ -612,6 +626,8 @@ export type Actions =
   | OpenSendRequestFormPayload
   | PaymentDetailReceivedPayload
   | PaymentsReceivedPayload
+  | PendingPaymentsReceivedPayload
+  | RecentPaymentsReceivedPayload
   | RefreshPaymentsPayload
   | RejectDisclaimerPayload
   | RequestDetailReceivedPayload

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -98,6 +98,7 @@ const openSendRequestForm = (state: TypedState, action: WalletsGen.OpenSendReque
           WalletsGen.createSetBuildingCurrency({
             currency:
               action.payload.currency ||
+              (state.wallets.lastSentXLM && 'XLM') ||
               (action.payload.from && Constants.getDisplayCurrency(state, action.payload.from).code) ||
               'XLM',
           }),

--- a/shared/wallets/send-form/asset-input/container.js
+++ b/shared/wallets/send-form/asset-input/container.js
@@ -12,7 +12,10 @@ const mapStateToProps = state => {
   const accountID = state.wallets.selectedAccount
   const currency = state.wallets.building.currency
   const currencyWaiting = anyWaiting(state, Constants.getDisplayCurrencyWaitingKey(accountID))
-  const displayUnit = currencyWaiting ? '' : Constants.getCurrencyAndSymbol(state, currency)
+  let displayUnit = currencyWaiting ? '' : Constants.getCurrencyAndSymbol(state, currency)
+  if (state.wallets.lastSentXLM && currency === 'XLM') {
+    displayUnit = 'XLM'
+  }
   return {
     accountID,
     bottomLabel: '', // TODO


### PR DESCRIPTION
Gets rid of our old handlers to use data from the notifications themselves. Everything on the account page should still update in real time.

Rough stellar RPC deltas doing a single send (counting responses)
before:
out: 28
in: 35

after:
out: 3
in: 10

r? @keybase/react-hackers cc @patrickxb 