### PR TITLE
add "loading" screen when we don't know PathType/MimeType

### DIFF
--- a/shared/actions/fs/platform-specific.desktop.js
+++ b/shared/actions/fs/platform-specific.desktop.js
@@ -16,7 +16,7 @@ import logger from '../../logger'
 import {spawn, execFileSync, exec} from 'child_process'
 import path from 'path'
 import {makeRetriableErrorHandler, makeUnretriableErrorHandler} from './shared'
-import {navigateTo, switchTo} from '../route-tree'
+import {switchTo} from '../route-tree'
 
 type pathType = 'file' | 'directory'
 
@@ -363,23 +363,7 @@ const loadUserFileEdits = (state: TypedState, action) =>
 const openFilesFromWidget = (state: TypedState, {payload: {path, type}}: FsGen.OpenFilesFromWidgetPayload) =>
   Saga.sequentially([
     Saga.put(ConfigGen.createShowMain()),
-    ...(path
-      ? [
-          Saga.put(
-            navigateTo([
-              Tabs.fsTab,
-              {
-                props: {path: Types.getPathParent(path)},
-                selected: 'folder',
-              },
-              {
-                props: {path},
-                selected: type === 'folder' ? 'folder' : 'preview',
-              },
-            ])
-          ),
-        ]
-      : [Saga.put(switchTo([Tabs.fsTab]))]),
+    ...(path ? [Saga.put(FsGen.createOpenPathInFilesTab({path}))] : [Saga.put(switchTo([Tabs.fsTab]))]),
   ])
 
 function* platformSpecificSaga(): Saga.SagaGenerator<any, any> {

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -860,6 +860,10 @@ export const erroredActionToMessage = (action: FsGen.Actions): string => {
       return `Failed to move file(s).`
     case FsGen.copy:
       return `Failed to copy file(s).`
+    case FsGen.openPathItem:
+      return `Failed to open path: ${Types.pathToString(action.payload.path)}.`
+    case FsGen.openPathInFilesTab:
+      return `Failed to open path: ${Types.pathToString(action.payload.path)}.`
     default:
       return 'An unexplainable error has occurred.'
   }

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -16,7 +16,7 @@ import {tlfToPreferredOrder} from '../util/kbfs'
 import {memoize, findKey} from 'lodash-es'
 import {putActionIfOnPath, navigateAppend, navigateTo} from '../actions/route-tree'
 
-export const defaultPath = '/keybase'
+export const defaultPath = Types.stringToPath('/keybase')
 
 // See Installer.m: KBExitFuseKextError
 export const ExitCodeFuseKextError = 4

--- a/shared/fs/banner/reset-banner/container.js
+++ b/shared/fs/banner/reset-banner/container.js
@@ -5,8 +5,6 @@ import * as FsGen from '../../../actions/fs-gen'
 import * as RPCTypes from '../../../constants/types/rpc-gen'
 import {namedConnect} from '../../../util/container'
 import {isMobile} from '../../../constants/platform'
-import {fsTab} from '../../../constants/tabs'
-import {navigateTo} from '../../../actions/route-tree'
 import {createShowUserProfile} from '../../../actions/profile-gen'
 import {createGetProfile} from '../../../actions/tracker-gen'
 import {folderNameWithoutUsers} from '../../../util/kbfs'
@@ -25,7 +23,7 @@ const mapDispatchToProps = dispatch => ({
     if (pathElems.length < 3) return
     const filteredPathName = folderNameWithoutUsers(pathElems[2], users)
     const filteredPath = Types.stringToPath(['', pathElems[0], pathElems[1], filteredPathName].join('/'))
-    return dispatch(navigateTo([fsTab, {props: {path: filteredPath}, selected: 'folder'}]))
+    return dispatch(FsGen.createOpenPathInFilesTab({path: filteredPath}))
   },
   _onReAddToTeam: (id: RPCTypes.TeamID, username: string) =>
     dispatch(FsGen.createLetResetUserBackIn({id, username})),

--- a/shared/fs/common/index.stories.js
+++ b/shared/fs/common/index.stories.js
@@ -7,6 +7,7 @@ import * as Styles from '../../styles'
 import * as Types from '../../constants/types/fs'
 import {Box, OverlayParentHOC} from '../../common-adapters'
 import PathItemAction from './path-item-action'
+import Loading from './loading'
 
 const pathItemActionPopupProps = (path: Types.Path) => {
   const pathElements = Types.getPathElements(path)
@@ -71,5 +72,6 @@ const load = () =>
         />
       </Box>
     ))
+    .add('Loading', () => <Loading path={Types.stringToPath('/keybase/team/kbkbfstest')} />)
 
 export default load

--- a/shared/fs/common/loading.js
+++ b/shared/fs/common/loading.js
@@ -1,0 +1,33 @@
+// @flow
+import * as React from 'react'
+import * as Kb from '../../common-adapters'
+import * as Types from '../../constants/types/fs'
+import * as Styles from '../../styles'
+
+type Props = {
+  path: Types.Path,
+}
+
+export default ({path}: Props) => (
+  <Kb.Box2
+    direction="vertical"
+    centerChildren={true}
+    style={styles.container}
+    fullHeight={true}
+    fullWidth={true}
+    gap="small"
+  >
+    <Kb.ProgressIndicator style={styles.indicator} />
+    <Kb.Text type="Body">Loading {Types.pathToString(path)} ...</Kb.Text>
+  </Kb.Box2>
+)
+
+const styles = Styles.styleSheetCreate({
+  container: {
+    backgroundColor: Styles.globalColors.blue5,
+  },
+  indicator: {
+    height: 32,
+    width: 32,
+  },
+})

--- a/shared/fs/common/loading.js
+++ b/shared/fs/common/loading.js
@@ -9,22 +9,25 @@ type Props = {
 }
 
 export default ({path}: Props) => (
-  <Kb.Box2
-    direction="vertical"
-    centerChildren={true}
-    style={styles.container}
-    fullHeight={true}
-    fullWidth={true}
-    gap="small"
-  >
-    <Kb.ProgressIndicator style={styles.indicator} />
-    <Kb.Text type="Body">Loading {Types.pathToString(path)} ...</Kb.Text>
+  <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true}>
+    <Kb.Box2 direction="horizontal" centerChildren={true} style={styles.header} fullWidth={true}>
+      <Kb.Text type="Header">Keybase Files</Kb.Text>
+    </Kb.Box2>
+    <Kb.Box2 direction="vertical" centerChildren={true} style={styles.container} fullWidth={true} gap="small">
+      <Kb.ProgressIndicator style={styles.indicator} />
+      <Kb.Text type="BodySmall">Loading ...</Kb.Text>
+    </Kb.Box2>
   </Kb.Box2>
 )
 
 const styles = Styles.styleSheetCreate({
   container: {
     backgroundColor: Styles.globalColors.blue5,
+    ...Styles.globalStyles.flexGrow,
+  },
+  header: {
+    height: 48,
+    justifyContent: 'center',
   },
   indicator: {
     height: 32,

--- a/shared/fs/common/security-prefs-prompting-hoc.js
+++ b/shared/fs/common/security-prefs-prompting-hoc.js
@@ -49,7 +49,7 @@ const displayOnce = ({shouldPromptSecurityPrefs, showSecurityPrefsOnce}) => {
   return shouldPromptSecurityPrefs
 }
 
-const ConnectedDesktopSecurityPrefs = connect<{||}, _, React.ComponentType<MergedProps>, _, _>(
+const ConnectedDesktopSecurityPrefs = connect<any, _, React.ComponentType<MergedProps>, _, _>(
   mapStateToProps,
   mapDispatchToProps,
   (s, d, o) => ({...o, ...s, ...d})
@@ -60,7 +60,7 @@ const DesktopSecurityPrefsBranch = (ComposedComponent: React.ComponentType<any>)
     render = () => (!displayOnce(this.props) ? <ComposedComponent {...this.props} /> : null)
   }
 
-const DesktopSecurityPrefsPromptingHoc = (ComposedComponent: React.ComponentType<any>) =>
+const DesktopSecurityPrefsPromptingHoc = <P>(ComposedComponent: React.ComponentType<P>) =>
   ConnectedDesktopSecurityPrefs(DesktopSecurityPrefsBranch(ComposedComponent))
 
 const SecurityPrefsPromptingHoc = isMobile ? (i: any) => i : DesktopSecurityPrefsPromptingHoc

--- a/shared/fs/common/security-prefs-prompting-hoc.js
+++ b/shared/fs/common/security-prefs-prompting-hoc.js
@@ -49,20 +49,24 @@ const displayOnce = ({shouldPromptSecurityPrefs, showSecurityPrefsOnce}) => {
   return shouldPromptSecurityPrefs
 }
 
-const ConnectedDesktopSecurityPrefs = connect<any, _, React.ComponentType<MergedProps>, _, _>(
-  mapStateToProps,
-  mapDispatchToProps,
-  (s, d, o) => ({...o, ...s, ...d})
-)
-
-const DesktopSecurityPrefsBranch = (ComposedComponent: React.ComponentType<any>) =>
-  class extends React.PureComponent<MergedProps> {
+const DesktopSecurityPrefsBranch = <P>(
+  ComposedComponent: React.ComponentType<P>
+): React.ComponentType<MergedProps & P> =>
+  class extends React.PureComponent<MergedProps & P> {
     render = () => (!displayOnce(this.props) ? <ComposedComponent {...this.props} /> : null)
   }
 
-const DesktopSecurityPrefsPromptingHoc = <P>(ComposedComponent: React.ComponentType<P>) =>
-  ConnectedDesktopSecurityPrefs(DesktopSecurityPrefsBranch(ComposedComponent))
+const DesktopSecurityPrefsPromptingHoc = <P>(
+  ComposedComponent: React.ComponentType<P>
+): React.ComponentType<P> =>
+  connect<P, _, _, _, _>(
+    mapStateToProps,
+    mapDispatchToProps,
+    (s, d, o) => ({...o, ...s, ...d})
+  )(DesktopSecurityPrefsBranch<P>(ComposedComponent))
 
-const SecurityPrefsPromptingHoc = isMobile ? (i: any) => i : DesktopSecurityPrefsPromptingHoc
+const SecurityPrefsPromptingHoc = isMobile
+  ? <P>(i: React.ComponentType<P>): React.ComponentType<P> => i
+  : DesktopSecurityPrefsPromptingHoc
 
 export default SecurityPrefsPromptingHoc

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as I from 'immutable'
 import {namedConnect, type RouteProps} from '../util/container'
-import {putActionIfOnPath, navigateAppend} from '../actions/route-tree'
+import {navigateAppend, navigateUp} from '../actions/route-tree'
 import * as Constants from '../constants/fs'
 import * as Types from '../constants/types/fs'
 import {isMobile} from '../constants/platform'
@@ -15,8 +15,10 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = (dispatch, {routePath}) => ({
-  _emitBarePreview: (path: Types.Path) =>
-    dispatch(putActionIfOnPath(routePath, navigateAppend([{props: {path}, selected: 'barePreview'}]))),
+  _emitBarePreview: (path: Types.Path) => {
+    dispatch(navigateUp()) // pop this route node before appending barePreview
+    dispatch(navigateAppend([{props: {path}, selected: 'barePreview'}]))
+  },
 })
 
 const mergeProps = (stateProps, dispatchProps, {routeProps, routePath}) => {
@@ -42,10 +44,10 @@ type ChooseComponentProps = {
 
 const useBare = isMobile
   ? (mimeType: ?Types.Mime) => {
-      return false
+      return Constants.viewTypeFromMimeType(mimeType) === 'image'
     }
   : (mimeType: ?Types.Mime) => {
-      return Constants.viewTypeFromMimeType(mimeType) === 'image'
+      return false
     }
 
 class ChooseComponent extends React.PureComponent<ChooseComponentProps> {

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -1,0 +1,87 @@
+// @flow
+import * as React from 'react'
+import * as I from 'immutable'
+import {namedConnect, type RouteProps} from '../util/container'
+import {putActionIfOnPath, navigateAppend} from '../actions/route-tree'
+import * as Constants from '../constants/fs'
+import * as Types from '../constants/types/fs'
+import {isMobile} from '../constants/platform'
+import Folder from './folder/container'
+import {NormalPreview} from './filepreview'
+import Loading from './common/loading'
+
+const mapStateToProps = state => ({
+  _pathItems: state.fs.pathItems,
+})
+
+const mapDispatchToProps = (dispatch, {routePath}) => ({
+  _emitBarePreview: (path: Types.Path) =>
+    dispatch(putActionIfOnPath(routePath, navigateAppend([{props: {path}, selected: 'barePreview'}]))),
+})
+
+const mergeProps = (stateProps, dispatchProps, {routeProps, routePath}) => {
+  const path = routeProps.get('path', Constants.defaultPath)
+  const isDefinitelyFolder = Types.getPathElements(path).length <= 3
+  const pathItem = stateProps._pathItems.get(path, Constants.unknownPathItem)
+  return {
+    emitBarePreview: () => dispatchProps._emitBarePreview(path),
+    mimeType: !isDefinitelyFolder && pathItem.type === 'file' ? pathItem.mimeType : null,
+    path,
+    pathType: isDefinitelyFolder ? 'folder' : stateProps._pathItems.get(path, Constants.unknownPathItem).type,
+    routePath,
+  }
+}
+
+type ChooseComponentProps = {
+  emitBarePreview: () => void,
+  mimeType: ?Types.Mime,
+  path: Types.Path,
+  pathType: Types.PathType,
+  routePath: I.List<string>,
+}
+
+const useBare = isMobile
+  ? (mimeType: ?Types.Mime) => {
+      return false
+    }
+  : (mimeType: ?Types.Mime) => {
+      return Constants.viewTypeFromMimeType(mimeType) === 'image'
+    }
+
+class ChooseComponent extends React.PureComponent<ChooseComponentProps> {
+  componentDidMount() {
+    if (useBare(this.props.mimeType)) {
+      this.props.emitBarePreview()
+    }
+  }
+  componentDidUpdate(prevProps) {
+    if (this.props.mimeType !== prevProps.mimeType && useBare(this.props.mimeType)) {
+      this.props.emitBarePreview()
+    }
+  }
+  render() {
+    switch (this.props.pathType) {
+      case 'folder':
+        return <Folder path={this.props.path} routePath={this.props.routePath} />
+      case 'unknown':
+        return <Loading path={this.props.path} />
+      default:
+        if (!this.props.mimeType) {
+          // We don't have it yet, so don't render.
+          return <Loading path={this.props.path} />
+        }
+        return useBare(this.props.mimeType) ? (
+          // doesn't matter here as we do a navigateAppend for bare views
+          <Loading path={this.props.path} />
+        ) : (
+          <NormalPreview path={this.props.path} routePath={this.props.routePath} />
+        )
+    }
+  }
+}
+
+type OwnProps = RouteProps<{|path: Types.Path|}, {||}>
+
+export default namedConnect<OwnProps, _, _, _, _>(mapStateToProps, mapDispatchToProps, mergeProps, 'FsMain')(
+  ChooseComponent
+)

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -51,17 +51,17 @@ const useBare = isMobile
     }
 
 class ChooseComponent extends React.PureComponent<ChooseComponentProps> {
-  componentDidMount = () => {
+  componentDidMount() {
     if (useBare(this.props.mimeType)) {
       this.props.emitBarePreview()
     }
   }
-  componentDidUpdate = prevProps => {
+  componentDidUpdate(prevProps) {
     if (this.props.mimeType !== prevProps.mimeType && useBare(this.props.mimeType)) {
       this.props.emitBarePreview()
     }
   }
-  render = () => {
+  render() {
     switch (this.props.pathType) {
       case 'folder':
         return <Folder path={this.props.path} routePath={this.props.routePath} />

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -51,17 +51,17 @@ const useBare = isMobile
     }
 
 class ChooseComponent extends React.PureComponent<ChooseComponentProps> {
-  componentDidMount() {
+  componentDidMount = () => {
     if (useBare(this.props.mimeType)) {
       this.props.emitBarePreview()
     }
   }
-  componentDidUpdate(prevProps) {
+  componentDidUpdate = prevProps => {
     if (this.props.mimeType !== prevProps.mimeType && useBare(this.props.mimeType)) {
       this.props.emitBarePreview()
     }
   }
-  render() {
+  render = () => {
     switch (this.props.pathType) {
       case 'folder':
         return <Folder path={this.props.path} routePath={this.props.routePath} />

--- a/shared/fs/filepreview/bare-preview.native.js
+++ b/shared/fs/filepreview/bare-preview.native.js
@@ -11,30 +11,20 @@ import {type BarePreviewProps} from './bare-preview'
 import View from './view-container'
 import PathItemAction from '../common/path-item-action-container'
 
-const mapStateToProps = (state, ownProps: BarePreviewProps) => {
-  // $FlowIssue Flow is confused here for no reason.
-  const path = Types.stringToPath(ownProps.routeProps.get('path'))
-  return {
-    _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
-    path,
-  }
-}
-
 const mapDispatchToProps = (dispatch, {routePath}) => ({
   onBack: () => dispatch(navigateUp()),
 })
 
-const mergeProps = ({path, _pathItem}, {onBack}, {routePath}) => ({
+const mergeProps = (stateProps, {onBack}, {routeProps, routePath}) => ({
   onBack,
-  path,
+  path: routeProps.get('path', Constants.defaultPath),
   routePath,
 })
 
 type ConnectedBarePreviewProps = {
+  onBack: () => void,
   path: Types.Path,
   routePath: I.List<string>,
-
-  onBack: () => void,
 }
 
 type State = {
@@ -118,7 +108,7 @@ const styles = Styles.styleSheetCreate({
 })
 
 export default connect<BarePreviewProps, _, _, _, _>(
-  mapStateToProps,
+  () => ({}),
   mapDispatchToProps,
   mergeProps
 )(BarePreview)

--- a/shared/fs/filepreview/normal-preview.js
+++ b/shared/fs/filepreview/normal-preview.js
@@ -1,9 +1,7 @@
 // @flow
 import * as I from 'immutable'
-import {mapProps} from '../../util/container'
 import * as React from 'react'
 import * as Types from '../../constants/types/fs'
-import * as Constants from '../../constants/fs'
 import * as Styles from '../../styles'
 import {Box, ProgressIndicator} from '../../common-adapters'
 import Footer from '../footer/footer'
@@ -19,7 +17,7 @@ type State = {
   loading: boolean,
 }
 
-class NormalPreview extends React.PureComponent<NormalPreviewProps, State> {
+export default class NormalPreview extends React.PureComponent<NormalPreviewProps, State> {
   state = {
     loading: false,
   }
@@ -89,9 +87,3 @@ const styles = Styles.styleSheetCreate({
     position: 'relative',
   },
 })
-
-// TODO: figure out typing here
-export default mapProps<any, any>(({routePath, routeProps}) => ({
-  path: Types.stringToPath(routeProps.get('path') || Constants.defaultPath),
-  routePath,
-}))(NormalPreview)

--- a/shared/fs/folder/container.js
+++ b/shared/fs/folder/container.js
@@ -1,21 +1,18 @@
 // @flow
+import * as I from 'immutable'
 import {compose, namedConnect} from '../../util/container'
 import Files from '.'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import SecurityPrefsPromptingHoc from '../common/security-prefs-prompting-hoc'
 
-const mapStateToProps = (state, {routeProps}) => {
-  const path = routeProps.get('path', Constants.defaultPath)
-  return {
-    _tlfs: state.fs.tlfs,
-    _username: state.config.username,
-    sortSetting: state.fs.pathUserSettings.get(path, Constants.makePathUserSetting()).get('sort'),
-  }
-}
+const mapStateToProps = (state, {path}) => ({
+  _tlfs: state.fs.tlfs,
+  _username: state.config.username,
+  sortSetting: state.fs.pathUserSettings.get(path, Constants.makePathUserSetting()).get('sort'),
+})
 
-const mergeProps = (stateProps, dispatchProps, {routeProps, routePath}) => {
-  const path = routeProps.get('path', Constants.defaultPath)
+const mergeProps = (stateProps, dispatchProps, {path, routePath}) => {
   const {tlfList} = Constants.getTlfListAndTypeFromPath(stateProps._tlfs, path)
   const elems = Types.getPathElements(path)
   const resetParticipants = tlfList
@@ -27,7 +24,12 @@ const mergeProps = (stateProps, dispatchProps, {routeProps, routePath}) => {
   return {isUserReset, path, resetParticipants, routePath, sortSetting}
 }
 
+type OwnProps = {
+  path: Types.Path,
+  routePath: I.List<string>,
+}
+
 export default compose(
   SecurityPrefsPromptingHoc,
-  namedConnect(mapStateToProps, () => ({}), mergeProps, 'Files')
+  namedConnect<OwnProps, _, _, _, _>(mapStateToProps, () => ({}), mergeProps, 'Files')
 )(Files)

--- a/shared/fs/folder/container.js
+++ b/shared/fs/folder/container.js
@@ -1,6 +1,6 @@
 // @flow
 import * as I from 'immutable'
-import {compose, namedConnect} from '../../util/container'
+import {namedConnect} from '../../util/container'
 import Files from '.'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
@@ -29,7 +29,7 @@ type OwnProps = {
   routePath: I.List<string>,
 }
 
-export default compose(
-  SecurityPrefsPromptingHoc,
-  namedConnect<OwnProps, _, _, _, _>(mapStateToProps, () => ({}), mergeProps, 'Files')
-)(Files)
+// flow can't figure out type when compose is used.
+export default SecurityPrefsPromptingHoc<OwnProps>(
+  namedConnect<OwnProps, _, _, _, _>(mapStateToProps, () => ({}), mergeProps, 'Files')(Files)
+)

--- a/shared/fs/folder/index.stories.js
+++ b/shared/fs/folder/index.stories.js
@@ -128,12 +128,7 @@ export default () => {
       />
     ))
     .add('Preview', () => (
-      <NormalPreview
-        routePath={I.List([])}
-        routeProps={I.Map({
-          path: '/keybase/private/foo/bar.jpg',
-        })}
-      />
+      <NormalPreview routePath={I.List([])} path={Types.stringToPath('/keybase/private/foo/bar.jpg')} />
     ))
     .add('Breadcrumbs', () => (
       <Box>

--- a/shared/fs/header/breadcrumb-container.desktop.js
+++ b/shared/fs/header/breadcrumb-container.desktop.js
@@ -3,7 +3,6 @@ import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import {namedConnect} from '../../util/container'
-import {navigateAppend} from '../../actions/route-tree'
 import * as FsGen from '../../actions/fs-gen'
 import Breadcrumb, {type Props as BreadcrumbProps} from './breadcrumb.desktop'
 
@@ -61,7 +60,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = (dispatch, {inDestinationPicker, routePath}: OwnProps) => ({
   _navigateToPath: inDestinationPicker
     ? (path: Types.Path) => dispatch(FsGen.createMoveOrCopyOpen({currentIndex: 0, path, routePath}))
-    : (path: Types.Path) => dispatch(navigateAppend([{props: {path}, selected: 'folder'}])),
+    : (path: Types.Path) => dispatch(FsGen.createOpenPathItem({path, routePath})),
 })
 
 const mergeProps = ({_username}, {_navigateToPath}, {path}: OwnProps) =>

--- a/shared/fs/routes.js
+++ b/shared/fs/routes.js
@@ -1,8 +1,8 @@
 // @flow
 import * as I from 'immutable'
-import Files from './folder/container'
+import Files from './container'
 import {isMobile} from '../constants/platform'
-import {BarePreview, NormalPreview} from './filepreview'
+import {BarePreview} from './filepreview'
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import SecurityPrefs from './common/security-prefs-container'
 import DestinationPicker from './destination-picker/container'
@@ -89,7 +89,7 @@ const _commonChildren = {
   },
 }
 
-const _folderRoute = {
+const _mainRoute = {
   children: {
     ..._commonChildren,
     barePreview: () =>
@@ -101,7 +101,8 @@ const _folderRoute = {
           title: 'Preview',
         }),
       }),
-    folder: () => makeRouteDefNode(_folderRoute),
+    main: () => makeRouteDefNode(_mainRoute),
+    /* TODO delete
     preview: () =>
       makeRouteDefNode({
         children: _commonChildren,
@@ -110,12 +111,13 @@ const _folderRoute = {
           title: 'Preview',
         }),
       }),
+      */
   },
   component: Files,
 }
 
 const routeTree = makeRouteDefNode({
-  ..._folderRoute,
+  ..._mainRoute,
   initialState: {expandedSet: I.Set()},
   tags: makeLeafTags({title: 'Files'}),
 })

--- a/shared/fs/routes.js
+++ b/shared/fs/routes.js
@@ -102,16 +102,6 @@ const _mainRoute = {
         }),
       }),
     main: () => makeRouteDefNode(_mainRoute),
-    /* TODO delete
-    preview: () =>
-      makeRouteDefNode({
-        children: _commonChildren,
-        component: NormalPreview,
-        tags: makeLeafTags({
-          title: 'Preview',
-        }),
-      }),
-      */
   },
   component: Files,
 }

--- a/shared/settings/files/container.js
+++ b/shared/settings/files/container.js
@@ -49,4 +49,4 @@ const ConnectedFiles = compose(
   })
 )(Files)
 
-export default SecurityPrefsPromptingHoc(ConnectedFiles)
+export default SecurityPrefsPromptingHoc<OwnProps>(ConnectedFiles)


### PR DESCRIPTION
Also add a connected component that looks at store and decide if we need to show a folder view or a file preview. Unfortunately BarePreview still has to live inside the route tree as it needs the fullscreen tag.

The added "loading" screen is shown when user navigates to a path but we don't know if it's a folder or or file, or if we know it's a file but don't know its mimeType and can't figure out which component to use to display it. This PR uses it for both opening links from chat, and for opening links from the widget.

Now that we don't have to wait for loading a `PathItem` (which can be slow especially when a TLF is accessed for the first time), or getting a `Mime`, clicking KBFS links should feel much more responsive.