### PR TITLE
roll back inboxversion checks

### DIFF
--- a/shared/chat/inbox/container/index.js
+++ b/shared/chat/inbox/container/index.js
@@ -23,10 +23,9 @@ const mapStateToProps = state => {
   const metaMap = state.chat2.metaMap
   const filter = state.chat2.inboxFilter
   const username = state.config.username
-  const inboxVersion = state.chat2.inboxVersion
   const {allowShowFloatingButton, rows, smallTeamsExpanded} = filter
     ? filteredRowData(metaMap, filter, username)
-    : normalRowData(metaMap, state.chat2.smallTeamsExpanded, inboxVersion)
+    : normalRowData(metaMap, state.chat2.smallTeamsExpanded)
   const neverLoaded = !state.chat2.inboxHasLoaded
   const _canRefreshOnMount = neverLoaded && !Constants.anyChatWaitingKeys(state)
 

--- a/shared/chat/inbox/container/normal.js
+++ b/shared/chat/inbox/container/normal.js
@@ -78,8 +78,8 @@ const getBigRows = memoize1(
 
 // Get smallIDs and big RowItems. Figure out the divider if it exists and truncate the small list.
 // Convert the smallIDs to the Small RowItems
-const getRowsAndMetadata = memoize3<Types.MetaMap, boolean, number, _>(
-  (metaMap: Types.MetaMap, smallTeamsExpanded: boolean, inboxVersion: number) => {
+const getRowsAndMetadata = memoize2<Types.MetaMap, boolean, _>(
+  (metaMap: Types.MetaMap, smallTeamsExpanded: boolean) => {
     const {bigMetas, smallMetas} = splitMetas(metaMap)
     const showAllSmallRows = smallTeamsExpanded || !bigMetas.length
     const smallRows = getSmallRows(smallMetas, showAllSmallRows)
@@ -95,10 +95,8 @@ const getRowsAndMetadata = memoize3<Types.MetaMap, boolean, number, _>(
       smallTeamsExpanded: showAllSmallRows, // only collapse if we're actually showing a divider,
     }
   },
-  // ignore changes to metaMap if inboxVersion is the same
-  (newMetaMap, oldMetaMap) => true,
-  (newExpanded, oldExpanded) => newExpanded === oldExpanded,
-  (newVersion, oldVersion) => newVersion === oldVersion
+  undefined,
+  undefined
 )
 
 export default getRowsAndMetadata

--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -4,7 +4,7 @@ import * as Styles from '../../../styles'
 import * as SmallTeam from '../row/small-team'
 import * as ChatTypes from '../../../constants/types/chat2'
 import type {TypedState} from '../../../constants/reducer'
-import {memoize2, memoize3} from '../../../util/memoize'
+import {memoize3} from '../../../util/memoize'
 
 export const maxShownConversations = 3
 
@@ -48,21 +48,11 @@ const valuesCached = memoize3(
       .toArray()
 )
 
-// we only care to rerender if the inboxversion increases so
-// given the same inbox version give back the same metaMap
-const inboxVersionToMetaMap = memoize2(
-  (inboxVersion, metaMap) => metaMap,
-  (oldVersion, newVersion) => oldVersion === newVersion,
-  // custom equality, if inboxVersion is the same, treat it as the same
-  (newMap, oldMap) => true
-)
-
 // A hack to store the username to avoid plumbing.
 let _username: string
 export const conversationsToSend = (state: TypedState) => {
   _username = state.config.username
-  const metaMap = inboxVersionToMetaMap(state.chat2.inboxVersion, state.chat2.metaMap)
-  return valuesCached(state.chat2.badgeMap, state.chat2.unreadMap, metaMap)
+  return valuesCached(state.chat2.badgeMap, state.chat2.unreadMap, state.chat2.metaMap)
 }
 
 export const changeAffectsWidget = (

--- a/shared/chat/inbox/row/big-teams-divider/container.js
+++ b/shared/chat/inbox/row/big-teams-divider/container.js
@@ -1,25 +1,18 @@
 // @flow
 import {BigTeamsDivider} from '.'
 import {connect} from '../../../../util/container'
-import {memoize3} from '../../../../util/memoize'
+import {memoize2} from '../../../../util/memoize'
 
 type OwnProps = {|
   toggle: () => void,
 |}
 
-const getBadgeCount = memoize3(
-  (inboxVersion, metaMap, badgeMap) =>
-    metaMap
-      .filter(meta => meta.teamType === 'big')
-      .reduce((total, map, id) => total + badgeMap.get(id, 0), 0),
-  (oldVersion, newVersion) => oldVersion === newVersion,
-  // only update if inboxVersion changes
-  (oldMMap, newMMap) => true,
-  (oldBMap, newBMap) => true
+const getBadgeCount = memoize2((metaMap, badgeMap) =>
+  metaMap.filter(meta => meta.teamType === 'big').reduce((total, map, id) => total + badgeMap.get(id, 0), 0)
 )
 
 const mapStateToProps = state => ({
-  badgeCount: getBadgeCount(state.chat2.inboxVersion, state.chat2.metaMap, state.chat2.badgeMap),
+  badgeCount: getBadgeCount(state.chat2.metaMap, state.chat2.badgeMap),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -27,7 +27,6 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   explodingModes: I.Map(),
   inboxFilter: '',
   inboxHasLoaded: false,
-  inboxVersion: 0,
   isExplodingNew: true,
   isWalletsNew: true,
   messageMap: I.Map(),

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -50,7 +50,6 @@ export type _State = {
   editingMap: I.Map<Common.ConversationIDKey, Message.Ordinal>, // current message being edited
   inboxFilter: string, // filters 'jump to chat'
   inboxHasLoaded: boolean, // if we've ever loaded
-  inboxVersion: number, // gets incremented as we get updates. used to know when the inbox has actually changed content
   smallTeamsExpanded: boolean, // if we're showing all small teams
   isExplodingNew: boolean, // controls the new-ness of exploding messages UI
   isWalletsNew: boolean, // controls new-ness of wallets in chat UI

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -883,9 +883,6 @@ const rootReducer = (
         s.set('metaMap', metaMapReducer(state.metaMap, action))
         s.set('messageMap', messageMapReducer(state.messageMap, action, state.pendingOutboxToOrdinal))
         s.set('messageOrdinals', messageOrdinalsReducer(state.messageOrdinals, action))
-        s.update('inboxVersion', old =>
-          action.payload.metas.reduce((v, meta) => Math.max(v, meta.inboxVersion), old)
-        )
       })
     }
     case Chat2Gen.paymentInfoReceived: {


### PR DESCRIPTION
@keybase/react-hackers @mmaxim 
this rolls back the inbox version checks . before i was using the inboxVersion as a proxy for structural changes in the inbox to skip unnecessary work. We've been having some inbox loading problem i think that are due to this and i think the culprit is not resetting the inbox version when refreshing.

but

instead of fixing that, i'm going to revert using it at all. instead i'm moving forward with a cleaner fix thats larger (for after the release)
