### PR TITLE
Fix jump to chat enter key 

### DIFF
--- a/shared/chat/inbox/container/index.js
+++ b/shared/chat/inbox/container/index.js
@@ -84,6 +84,16 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     allowShowFloatingButton: stateProps.allowShowFloatingButton,
     filter: stateProps.filter,
     neverLoaded: stateProps.neverLoaded,
+    onEnsureSelection: () => {
+      // $ForceType
+      if (stateProps.rows.find(r => r.conversationIDKey === stateProps._selectedConversationIDKey)) {
+        return
+      }
+      const first = stateProps.rows[0]
+      if ((first && first.type === 'small') || first.type === 'big') {
+        dispatchProps._onSelect(first.conversationIDKey)
+      }
+    },
     onNewChat: dispatchProps.onNewChat,
     onSelectDown: () =>
       dispatchProps._onSelectNext(stateProps.rows, stateProps._selectedConversationIDKey, 1),

--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -133,6 +133,7 @@ class Inbox extends React.PureComponent<Props, State> {
     this.props.onNewChat()
   }
 
+  _onEnsureSelection = () => this.props.onEnsureSelection()
   _onSelectUp = () => this.props.onSelectUp()
   _onSelectDown = () => this.props.onSelectDown()
 
@@ -148,6 +149,7 @@ class Inbox extends React.PureComponent<Props, State> {
             filterFocusCount={this.props.filterFocusCount}
             focusFilter={this.props.focusFilter}
             onNewChat={this._prepareNewChat}
+            onEnsureSelection={this._onEnsureSelection}
             onSelectUp={this._onSelectUp}
             onSelectDown={this._onSelectDown}
           />

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -174,6 +174,7 @@ class Inbox extends React.PureComponent<Props, State> {
     return {index, length, offset}
   }
 
+  _onEnsureSelection = () => this.props.onEnsureSelection()
   _onSelectUp = () => this.props.onSelectUp()
   _onSelectDown = () => this.props.onSelectDown()
 
@@ -197,6 +198,7 @@ class Inbox extends React.PureComponent<Props, State> {
         filterFocusCount={this.props.filterFocusCount}
         focusFilter={this.props.focusFilter}
         onNewChat={this.props.onNewChat}
+        onEnsureSelection={this._onEnsureSelection}
         onSelectUp={this._onSelectUp}
         onSelectDown={this._onSelectDown}
       />

--- a/shared/chat/inbox/index.stories.js
+++ b/shared/chat/inbox/index.stories.js
@@ -348,6 +348,7 @@ const propsInboxCommon = {
   onUntrustedInboxVisible: Sb.action('onUntrustedInboxVisible'),
   onSelectUp: Sb.action('onSelectUp'),
   onSelectDown: Sb.action('onSelectDown'),
+  onEnsureSelection: Sb.action('onEnsureSelection'),
   rows: [],
   smallTeamsExpanded: false,
   toggleSmallTeamsExpanded: Sb.action('toggleSmallTeamsExpanded'),

--- a/shared/chat/inbox/index.types.js.flow
+++ b/shared/chat/inbox/index.types.js.flow
@@ -46,4 +46,5 @@ export type Props = {|
   toggleSmallTeamsExpanded: () => void,
   onSelectUp: () => void,
   onSelectDown: () => void,
+  onEnsureSelection: () => void,
 |}

--- a/shared/chat/inbox/row/chat-filter-row/container.js
+++ b/shared/chat/inbox/row/chat-filter-row/container.js
@@ -8,12 +8,12 @@ import ChatFilterRow from '.'
 import flags from '../../../../util/feature-flags'
 
 type OwnProps = {
-  onNewChat: () => void,
   filterFocusCount: number,
   focusFilter: () => void,
-  onSelectUp: () => void,
-  onSelectDown: () => void,
   onEnsureSelection: () => void,
+  onNewChat: () => void,
+  onSelectDown: () => void,
+  onSelectUp: () => void,
 }
 
 const mapStateToProps = (state, ownProps: OwnProps) => {
@@ -47,10 +47,10 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   filterFocusCount: ownProps.filterFocusCount,
   hotkeys: isDarwin ? ['command+n', 'command+k'] : ['ctrl+n', 'ctrl+k'],
   isLoading: stateProps.isLoading,
+  onEnsureSelection: ownProps.onEnsureSelection,
   onNewChat: ownProps.onNewChat,
   onSelectDown: ownProps.onSelectDown,
   onSelectUp: ownProps.onSelectUp,
-  onEnsureSelection: ownProps.onEnsureSelection,
   onSetFilter: dispatchProps.onSetFilter,
 })
 

--- a/shared/chat/inbox/row/chat-filter-row/container.js
+++ b/shared/chat/inbox/row/chat-filter-row/container.js
@@ -13,6 +13,7 @@ type OwnProps = {
   focusFilter: () => void,
   onSelectUp: () => void,
   onSelectDown: () => void,
+  onEnsureSelection: () => void,
 }
 
 const mapStateToProps = (state, ownProps: OwnProps) => {
@@ -49,6 +50,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   onNewChat: ownProps.onNewChat,
   onSelectDown: ownProps.onSelectDown,
   onSelectUp: ownProps.onSelectUp,
+  onEnsureSelection: ownProps.onEnsureSelection,
   onSetFilter: dispatchProps.onSetFilter,
 })
 

--- a/shared/chat/inbox/row/chat-filter-row/index.js
+++ b/shared/chat/inbox/row/chat-filter-row/index.js
@@ -54,7 +54,6 @@ class ChatFilterRow extends React.PureComponent<Props, State> {
       e.preventDefault()
       e.stopPropagation()
       this.props.onSelectUp()
-    } else {
     }
   }
 

--- a/shared/chat/inbox/row/chat-filter-row/index.js
+++ b/shared/chat/inbox/row/chat-filter-row/index.js
@@ -1,19 +1,10 @@
 // @flow
 import * as React from 'react'
-import {Icon, Box, ClickableBox, LoadingLine, Input, Text} from '../../../../common-adapters'
-import {
-  borderRadius,
-  desktopStyles,
-  globalStyles,
-  globalColors,
-  globalMargins,
-  isMobile,
-  platformStyles,
-  styleSheetCreate,
-} from '../../../../styles'
+import * as Kb from '../../../../common-adapters'
+import * as Styles from '../../../../styles'
 
 let KeyHandler: any = c => c
-if (!isMobile) {
+if (!Styles.isMobile) {
   KeyHandler = require('../../../../util/key-handler.desktop').default
 }
 
@@ -25,6 +16,7 @@ type Props = {
   onSetFilter: (filter: string) => void,
   onSelectDown: () => void,
   onSelectUp: () => void,
+  onEnsureSelection: () => void,
 }
 
 type State = {
@@ -62,17 +54,18 @@ class ChatFilterRow extends React.PureComponent<Props, State> {
       e.preventDefault()
       e.stopPropagation()
       this.props.onSelectUp()
+    } else {
     }
   }
 
   _onEnterKeyDown = (e: SyntheticKeyboardEvent<>) => {
-    if (!isMobile) {
+    if (!Styles.isMobile) {
       e.preventDefault()
       e.stopPropagation()
       this.props.onSetFilter('')
       this._stopEditing()
       this._input && this._input.blur()
-      this.props.onSelectDown()
+      this.props.onEnsureSelection()
     }
   }
 
@@ -91,15 +84,15 @@ class ChatFilterRow extends React.PureComponent<Props, State> {
     let children
     if (this.state.isEditing || this.props.filter) {
       children = [
-        <Icon
+        <Kb.Icon
           key="0"
           type="iconfont-search"
           style={{
-            marginRight: globalMargins.tiny,
+            marginRight: Styles.globalMargins.tiny,
           }}
-          color={globalColors.black_20}
+          color={Styles.globalColors.black_20}
         />,
-        <Input
+        <Kb.Input
           hideUnderline={true}
           key="1"
           small={true}
@@ -111,30 +104,33 @@ class ChatFilterRow extends React.PureComponent<Props, State> {
           onKeyDown={this._onKeyDown}
           onEnterKeyDown={this._onEnterKeyDown}
           ref={this._setRef}
-          style={{marginRight: globalMargins.tiny}}
+          style={{marginRight: Styles.globalMargins.tiny}}
         />,
       ]
     } else {
       children = (
-        <ClickableBox style={styles.filterContainer} onClick={this._startEditing}>
-          <Icon
+        <Kb.ClickableBox style={styles.filterContainer} onClick={this._startEditing}>
+          <Kb.Icon
             type="iconfont-search"
             style={{
-              marginLeft: globalMargins.tiny,
+              marginLeft: Styles.globalMargins.tiny,
             }}
-            color={globalColors.black_20}
+            color={Styles.globalColors.black_20}
             fontSize={16}
           />
-          <Text type="Body" style={{color: globalColors.black_40, marginLeft: globalMargins.tiny}}>
+          <Kb.Text
+            type="Body"
+            style={{color: Styles.globalColors.black_40, marginLeft: Styles.globalMargins.tiny}}
+          >
             Jump to chat
-          </Text>
-        </ClickableBox>
+          </Kb.Text>
+        </Kb.ClickableBox>
       )
     }
     return (
-      <Box style={styles.container}>
+      <Kb.Box style={styles.container}>
         {children}
-        <Icon
+        <Kb.Icon
           type="iconfont-compose"
           style={propsIconPlatform.style}
           color={propsIconPlatform.color}
@@ -142,41 +138,41 @@ class ChatFilterRow extends React.PureComponent<Props, State> {
           onClick={this.props.onNewChat}
         />
         {this.props.isLoading && (
-          <Box style={styles.loadingContainer}>
-            <LoadingLine />
-          </Box>
+          <Kb.Box style={styles.loadingContainer}>
+            <Kb.LoadingLine />
+          </Kb.Box>
         )}
-      </Box>
+      </Kb.Box>
     )
   }
 }
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate({
   container: {
-    ...globalStyles.flexBoxRow,
+    ...Styles.globalStyles.flexBoxRow,
     alignItems: 'center',
-    backgroundColor: isMobile ? globalColors.fastBlank : globalColors.blueGrey,
+    backgroundColor: Styles.isMobile ? Styles.globalColors.fastBlank : Styles.globalColors.blueGrey,
     justifyContent: 'space-between',
     minHeight: 48,
-    paddingLeft: globalMargins.small,
-    paddingRight: globalMargins.small,
+    paddingLeft: Styles.globalMargins.small,
+    paddingRight: Styles.globalMargins.small,
     position: 'relative',
   },
-  filterContainer: platformStyles({
+  filterContainer: Styles.platformStyles({
     common: {
-      ...globalStyles.flexBoxRow,
+      ...Styles.globalStyles.flexBoxRow,
       alignItems: 'center',
-      backgroundColor: globalColors.black_10,
-      borderRadius,
+      backgroundColor: Styles.globalColors.black_10,
+      borderRadius: Styles.borderRadius,
       flexGrow: 1,
       height: 24,
       justifyContent: 'center',
-      marginRight: globalMargins.small,
+      marginRight: Styles.globalMargins.small,
     },
-    isElectron: desktopStyles.editable,
+    isElectron: Styles.desktopStyles.editable,
     isMobile: {
       height: 32,
-      marginRight: globalMargins.small,
+      marginRight: Styles.globalMargins.small,
     },
   }),
   loadingContainer: {
@@ -188,7 +184,7 @@ const styles = styleSheetCreate({
 })
 
 const propsIconCompose = {
-  color: globalColors.blue,
+  color: Styles.globalColors.blue,
   fontSize: 16,
   style: {},
 }
@@ -197,10 +193,10 @@ const propsIconComposeMobile = {
   ...propsIconCompose,
   fontSize: 20,
   style: {
-    padding: globalMargins.xtiny,
+    padding: Styles.globalMargins.xtiny,
   },
 }
 
-const propsIconPlatform = isMobile ? propsIconComposeMobile : propsIconCompose
+const propsIconPlatform = Styles.isMobile ? propsIconComposeMobile : propsIconCompose
 
-export default (isMobile ? ChatFilterRow : KeyHandler<any>(ChatFilterRow))
+export default (Styles.isMobile ? ChatFilterRow : KeyHandler<any>(ChatFilterRow))

--- a/shared/chat/inbox/row/chat-inbox-header/container.js
+++ b/shared/chat/inbox/row/chat-inbox-header/container.js
@@ -4,12 +4,12 @@ import {namedConnect} from '../../../../util/container'
 import ChatInboxHeader from '.'
 
 type OwnProps = {
-  onNewChat: () => void,
   filterFocusCount: number,
   focusFilter: () => void,
-  onSelectUp: () => void,
-  onSelectDown: () => void,
   onEnsureSelection: () => void,
+  onNewChat: () => void,
+  onSelectDown: () => void,
+  onSelectUp: () => void,
 }
 
 const mapStateToProps = (state, ownProps: OwnProps) => ({
@@ -22,9 +22,9 @@ const mapStateToProps = (state, ownProps: OwnProps) => ({
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   filterFocusCount: ownProps.filterFocusCount,
   focusFilter: ownProps.focusFilter,
+  onEnsureSelection: ownProps.onEnsureSelection,
   onNewChat: ownProps.onNewChat,
   onSelectDown: ownProps.onSelectDown,
-  onEnsureSelection: ownProps.onEnsureSelection,
   onSelectUp: ownProps.onSelectUp,
   showNewChat: stateProps.showNewChat,
 })

--- a/shared/chat/inbox/row/chat-inbox-header/container.js
+++ b/shared/chat/inbox/row/chat-inbox-header/container.js
@@ -9,6 +9,7 @@ type OwnProps = {
   focusFilter: () => void,
   onSelectUp: () => void,
   onSelectDown: () => void,
+  onEnsureSelection: () => void,
 }
 
 const mapStateToProps = (state, ownProps: OwnProps) => ({
@@ -23,6 +24,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   focusFilter: ownProps.focusFilter,
   onNewChat: ownProps.onNewChat,
   onSelectDown: ownProps.onSelectDown,
+  onEnsureSelection: ownProps.onEnsureSelection,
   onSelectUp: ownProps.onSelectUp,
   showNewChat: stateProps.showNewChat,
 })

--- a/shared/chat/inbox/row/chat-inbox-header/index.js
+++ b/shared/chat/inbox/row/chat-inbox-header/index.js
@@ -10,6 +10,7 @@ type Props = {
   showNewChat: boolean,
   onSelectUp: () => void,
   onSelectDown: () => void,
+  onEnsureSelection: () => void,
 }
 
 const ChatInboxHeader = (props: Props) =>
@@ -22,6 +23,7 @@ const ChatInboxHeader = (props: Props) =>
       filterFocusCount={props.filterFocusCount}
       onSelectUp={props.onSelectUp}
       onSelectDown={props.onSelectDown}
+      onEnsureSelection={props.onEnsureSelection}
     />
   )
 


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/keybase/client/pull/14952

if you hit enter we just want to ensure something is selected from the filtered list , so plumb a new prop to do this

cc: @zanderz @songgao 
@keybase/react-hackers 