### PR TITLE
feature flag kbfs/chat integration

### DIFF
--- a/shared/__mocks__/feature-flags.js
+++ b/shared/__mocks__/feature-flags.js
@@ -10,6 +10,7 @@ const ff: FeatureFlags = {
   admin: false,
   chatIndexProfilingEnabled: false,
   foldersInProfileTab: true,
+  kbfsChatIntegration: true,
   moveOrCopy: true,
   newTeamBuildingForChat: false,
   newTeamBuildingForChatAllowMakeTeam: false,

--- a/shared/common-adapters/markdown/kbfs-path.js
+++ b/shared/common-adapters/markdown/kbfs-path.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Text from '../text'
 import * as Types from '../../constants/types/fs'
+import features from '../../util/feature-flags'
 
 export type Props = {
   path: Types.Path,
@@ -9,10 +10,14 @@ export type Props = {
   allowFontScaling?: ?boolean,
 }
 
-export default (props: Props) => {
-  return (
-    <Text type="BodyPrimaryLink" onClick={props.onClick} allowFontScaling={!!props.allowFontScaling}>
-      {Types.pathToString(props.path)}
-    </Text>
-  )
-}
+export default (features.kbfsChatIntegration
+  ? (props: Props) => (
+      <Text type="BodyPrimaryLink" onClick={props.onClick} allowFontScaling={!!props.allowFontScaling}>
+        {Types.pathToString(props.path)}
+      </Text>
+    )
+  : (props: Props) => (
+      <Text type="Body" allowFontScaling={!!props.allowFontScaling}>
+        {Types.pathToString(props.path)}
+      </Text>
+    ))

--- a/shared/fs/common/send-in-app-action.js
+++ b/shared/fs/common/send-in-app-action.js
@@ -2,11 +2,11 @@
 import * as I from 'immutable'
 import * as React from 'react'
 import * as Types from '../../constants/types/fs'
-import {isMobile} from '../../constants/platform'
 import * as FsGen from '../../actions/fs-gen'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import {namedConnect} from '../../util/container'
+import features from '../../util/feature-flags'
 
 type OwnProps = {
   path: Types.Path,
@@ -32,11 +32,11 @@ const styles = Styles.styleSheetCreate({
   },
 })
 
-export default (isMobile
-  ? () => null
-  : namedConnect<OwnProps, _, _, _, _>(
+export default (features.kbfsChatIntegration
+  ? namedConnect<OwnProps, _, _, _, _>(
       () => ({}),
       mapDispatchToProps,
       (s, d, o) => ({...o, ...s, ...d}),
       'SendInAppAction'
-    )(YouSeeAButtonYouPushIt))
+    )(YouSeeAButtonYouPushIt)
+  : () => null)

--- a/shared/util/feature-flags.desktop.js
+++ b/shared/util/feature-flags.desktop.js
@@ -14,6 +14,7 @@ const ff: FeatureFlags = {
   admin: false,
   chatIndexProfilingEnabled: false,
   foldersInProfileTab: false,
+  kbfsChatIntegration: false,
   moveOrCopy: false,
   newTeamBuildingForChat: false,
   newTeamBuildingForChatAllowMakeTeam: false,
@@ -26,6 +27,7 @@ const ff: FeatureFlags = {
 const inAdmin: {[key: $Keys<FeatureFlags>]: boolean} = {
   chatIndexProfilingEnabled: true,
   foldersInProfileTab: true,
+  kbfsChatIntegration: true,
   moveOrCopy: true,
   walletsEnabled: true,
 }

--- a/shared/util/feature-flags.js.flow
+++ b/shared/util/feature-flags.js.flow
@@ -3,6 +3,7 @@ export type FeatureFlags = {|
   admin: boolean,
   chatIndexProfilingEnabled: boolean,
   foldersInProfileTab: boolean,
+  kbfsChatIntegration: boolean,
   moveOrCopy: boolean,
   newTeamBuildingForChat: boolean,
   // Enables the "Add up to 14 more people. Need more? Make it a team." feature

--- a/shared/util/feature-flags.native.js
+++ b/shared/util/feature-flags.native.js
@@ -10,6 +10,7 @@ const ff: FeatureFlags = {
   admin: __DEV__,
   chatIndexProfilingEnabled: false,
   foldersInProfileTab: false,
+  kbfsChatIntegration: false,
   moveOrCopy: true,
   newTeamBuildingForChat: false,
   newTeamBuildingForChatAllowMakeTeam: false,


### PR DESCRIPTION
Looks like the loading screen PR won't make it for this release. So we should feature-flag linkifying KBFS paths in chat for now. I'll turn the mobile back on after release.