### PR TITLE
disable moveOrCopy on mobile

### DIFF
--- a/shared/util/feature-flags.native.js
+++ b/shared/util/feature-flags.native.js
@@ -11,7 +11,7 @@ const ff: FeatureFlags = {
   chatIndexProfilingEnabled: false,
   foldersInProfileTab: false,
   kbfsChatIntegration: false,
-  moveOrCopy: true,
+  moveOrCopy: false,
   newTeamBuildingForChat: false,
   newTeamBuildingForChatAllowMakeTeam: false,
   outOfDateBanner: false,


### PR DESCRIPTION
We still have some bugs around notification. Also I feel like this feature hasn't really been tested enough, so just turn it off for now.