### PR TITLE
Files notification handling fixes

### DIFF
--- a/shared/actions/fs-gen.js
+++ b/shared/actions/fs-gen.js
@@ -12,6 +12,7 @@ export const resetStore = 'common:resetStore' // not a part of fs but is handled
 export const typePrefix = 'fs:'
 export const cancelDownload = 'fs:cancelDownload'
 export const cancelMoveOrCopy = 'fs:cancelMoveOrCopy'
+export const clearRefreshTag = 'fs:clearRefreshTag'
 export const commitEdit = 'fs:commitEdit'
 export const copy = 'fs:copy'
 export const deleteFile = 'fs:deleteFile'
@@ -79,6 +80,7 @@ export const userFileEditsLoaded = 'fs:userFileEditsLoaded'
 // Payload Types
 type _CancelDownloadPayload = $ReadOnly<{|key: string|}>
 type _CancelMoveOrCopyPayload = void
+type _ClearRefreshTagPayload = $ReadOnly<{|refreshTag: Types.RefreshTag|}>
 type _CommitEditPayload = $ReadOnly<{|editID: Types.EditID|}>
 type _CopyPayload = $ReadOnly<{|destinationParentPath: Types.Path|}>
 type _DeleteFilePayload = $ReadOnly<{|path: Types.Path|}>
@@ -146,6 +148,7 @@ type _UserFileEditsLoadedPayload = $ReadOnly<{|tlfUpdates: Types.UserTlfUpdates|
 // Action Creators
 export const createCancelDownload = (payload: _CancelDownloadPayload) => ({payload, type: cancelDownload})
 export const createCancelMoveOrCopy = (payload: _CancelMoveOrCopyPayload) => ({payload, type: cancelMoveOrCopy})
+export const createClearRefreshTag = (payload: _ClearRefreshTagPayload) => ({payload, type: clearRefreshTag})
 export const createCommitEdit = (payload: _CommitEditPayload) => ({payload, type: commitEdit})
 export const createCopy = (payload: _CopyPayload) => ({payload, type: copy})
 export const createDeleteFile = (payload: _DeleteFilePayload) => ({payload, type: deleteFile})
@@ -213,6 +216,7 @@ export const createUserFileEditsLoaded = (payload: _UserFileEditsLoadedPayload) 
 // Action Payloads
 export type CancelDownloadPayload = {|+payload: _CancelDownloadPayload, +type: 'fs:cancelDownload'|}
 export type CancelMoveOrCopyPayload = {|+payload: _CancelMoveOrCopyPayload, +type: 'fs:cancelMoveOrCopy'|}
+export type ClearRefreshTagPayload = {|+payload: _ClearRefreshTagPayload, +type: 'fs:clearRefreshTag'|}
 export type CommitEditPayload = {|+payload: _CommitEditPayload, +type: 'fs:commitEdit'|}
 export type CopyPayload = {|+payload: _CopyPayload, +type: 'fs:copy'|}
 export type DeleteFilePayload = {|+payload: _DeleteFilePayload, +type: 'fs:deleteFile'|}
@@ -282,6 +286,7 @@ export type UserFileEditsLoadedPayload = {|+payload: _UserFileEditsLoadedPayload
 export type Actions =
   | CancelDownloadPayload
   | CancelMoveOrCopyPayload
+  | ClearRefreshTagPayload
   | CommitEditPayload
   | CopyPayload
   | DeleteFilePayload

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -4,6 +4,9 @@
     "import * as ChatTypes from '../constants/types/chat2'"
   ],
   "actions": {
+    "clearRefreshTag": {
+      "refreshTag": "Types.RefreshTag"
+    },
     "folderListLoad": {
       "path": "Types.Path",
       "refreshTag?": "Types.RefreshTag"

--- a/shared/constants/types/fs.js
+++ b/shared/constants/types/fs.js
@@ -550,4 +550,4 @@ export type RowItemWithKey =
 // unsubscribe when it's not interested anymore. Instead, we use a simple
 // heuristic where Saga only keeps track of latest call from each component and
 // refresh only the most recently reuested paths for each component.
-export type RefreshTag = 'main' | 'path-item-action-popup'
+export type RefreshTag = 'main' | 'path-item-action-popup' | 'destination-picker'

--- a/shared/fs/common/path-item-action-container.js
+++ b/shared/fs/common/path-item-action-container.js
@@ -38,6 +38,7 @@ const mapDispatchToProps = (dispatch, {path}: OwnProps) => ({
       })
     )
   },
+  onHidden: () => dispatch(FsGen.createClearRefreshTag({refreshTag: 'path-item-action-popup'})),
   ...(isMobile
     ? {
         _saveMedia: () => dispatch(FsGen.createSaveMedia(Constants.makeDownloadPayload(path))),
@@ -227,6 +228,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     // request it regardless whether we have it or not. The FS saga takes care
     // of preventing the RPC if it's already subscribed.
     needLoadMimeType: type === 'file',
+    onHidden: dispatchProps.onHidden,
     path,
     pathElements,
     saveMedia,

--- a/shared/fs/common/path-item-action.js
+++ b/shared/fs/common/path-item-action.js
@@ -33,6 +33,7 @@ type Props = {
   actionIconClassName?: string,
   actionIconFontSize?: number,
   actionIconWhite?: boolean,
+  onHidden: () => void,
   path: Types.Path,
   pathElements: Array<string>,
   // Menu items
@@ -203,6 +204,7 @@ const PathItemAction = (props: Props & OverlayParentProps) => {
       }
       hideMenuCalled = true
       props.toggleShowingMenu()
+      props.onHidden()
     }
   })()
 

--- a/shared/fs/row/files-loading-hoc.js
+++ b/shared/fs/row/files-loading-hoc.js
@@ -7,15 +7,22 @@ import * as Types from '../../constants/types/fs'
 
 type OwnProps = {
   path: Types.Path,
+  destinationPickerIndex?: number,
 }
 
 const mapStateToProps = state => ({
   syncingPaths: state.fs.uploads.syncingPaths,
 })
 
-const mapDispatchToProps = (dispatch, {path}) => ({
+const mapDispatchToProps = (dispatch, {path, destinationPickerIndex}) => ({
   loadFavorites: () => dispatch(FsGen.createFavoritesLoad()),
-  loadFolderList: () => dispatch(FsGen.createFolderListLoad({path, refreshTag: 'main'})),
+  loadFolderList: () =>
+    dispatch(
+      FsGen.createFolderListLoad({
+        path,
+        refreshTag: typeof destinationPickerIndex === 'number' ? 'destination-picker' : 'main',
+      })
+    ),
 })
 
 const mergeProps = ({syncingPaths}, {loadFolderList, loadFavorites}, o) => ({

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -339,6 +339,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     case FsGen.copy:
     case FsGen.moveOrCopyOpen:
     case FsGen.cancelMoveOrCopy:
+    case FsGen.clearRefreshTag:
       return state
     default:
       Flow.ifFlowComplainsAboutThisFunctionYouHaventHandledAllCasesInASwitch(action)


### PR DESCRIPTION
There are two bugs here:

1. The `PathItemAction` popup subscribes to updates (causing automatic folderListLoad) on the path if it's a folder, but doesn't unsubscribe when it's gone. It's usually not a big problem but if the item happens to be moved or removed, next time a notification about a TLF being updated comes in we'd try to load that folder that doesn't exist anymore. So this PR makes it unsubscribe `onHidden`. This is a big issue for `moveOrCopy` but less of an issue without it.

2. The `moveOrCopy` uses the same `Rows` component which does `folderListLoad` and subscribes to the path. So when user navigates around in the `moveOrCopy` dialog, we'd update the same `refreshTag` that the main folder view uses. This cause the main folder view's subscription out of date. So this PR adds a new `refreshTag` just for the destination picker, so we can keep both subscriptions at the same time. Also clear the `refershTag` when `moveOrCopy` exits.