### PR TITLE
default to v2 bundles for new users if they have the feature flag

### DIFF
--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -108,7 +108,7 @@ func (f *featureSlot) readFrom(m MetaContext, r rawFeatureSlot) {
 }
 
 func (s *FeatureFlagSet) InvalidateCache(m MetaContext, f Feature) {
-	featureSlot := s.features[f]
+	featureSlot := s.getOrMakeSlot(f)
 	featureSlot.Lock()
 	defer featureSlot.Unlock()
 	featureSlot.cacheUntil = m.G().Clock().Now().Add(time.Duration(-1) * time.Second)

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -39,7 +39,7 @@ func ShouldCreate(ctx context.Context, g *libkb.GlobalContext) (res ShouldCreate
 	return apiRes.ShouldCreateResult, err
 }
 
-func acctBundlesEnabled(m libkb.MetaContext) bool {
+func AcctBundlesEnabled(m libkb.MetaContext) bool {
 	enabled := m.G().FeatureFlags.Enabled(m, libkb.FeatureStellarAcctBundles)
 	if enabled {
 		m.CDebugf("stellar account bundles enabled")
@@ -274,7 +274,7 @@ func (e MissingFeatureFlagMigrationError) Error() string {
 
 func preMigrationChecks(m libkb.MetaContext) error {
 	// verify that the feature flag is enabled
-	if !acctBundlesEnabled(m) {
+	if !AcctBundlesEnabled(m) {
 		return MissingFeatureFlagMigrationError{}
 	}
 
@@ -531,7 +531,7 @@ func FetchSecretlessBundle(ctx context.Context, g *libkb.GlobalContext) (acctBun
 	if err != nil && incompatibleVersionError(err) {
 		m := libkb.NewMetaContext(ctx, g)
 		m.CDebugf("requested v2 secretless bundle but not migrated yet.")
-		hasFeatureFlagForMigration := acctBundlesEnabled(m)
+		hasFeatureFlagForMigration := AcctBundlesEnabled(m)
 		if hasFeatureFlagForMigration {
 			m.CDebugf("has feature flag. kicking off migration now.")
 			err := MigrateBundleToAccountBundles(m)

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -289,8 +289,9 @@ func (s *Server) WalletInitLocal(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-
-	_, err = stellar.CreateWallet(ctx, s.G(), false)
+	m := libkb.NewMetaContext(ctx, s.G())
+	flaggedForV2 := remote.AcctBundlesEnabled(m)
+	_, err = stellar.CreateWallet(ctx, s.G(), flaggedForV2)
 	return err
 }
 

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -165,7 +165,7 @@ func setupWithNewBundle(t *testing.T, tc *TestContext) {
 	g := tc.G
 	err := remote.SetAcceptedDisclaimer(ctx, g)
 	require.NoError(t, err)
-	err = stellar.EnableMigrationFeatureFlag(ctx, g)
+	err = stellar.SetMigrationFeatureFlag(ctx, g, true)
 	require.NoError(t, err)
 	_, err = stellar.CreateWallet(ctx, g, true)
 	require.NoError(t, err)
@@ -1536,6 +1536,8 @@ func TestImplicitMigrationToAccountBundles(t *testing.T) {
 	ctx := context.TODO()
 	g := tcs[0].G
 	m := libkb.NewMetaContextTODO(g)
+	err := stellar.SetMigrationFeatureFlag(ctx, g, false)
+	require.NoError(t, err)
 	acceptDisclaimer(tcs[0])
 
 	// verify that we have a v1 bundle
@@ -1545,7 +1547,7 @@ func TestImplicitMigrationToAccountBundles(t *testing.T) {
 	require.Equal(t, len(bundle.Accounts), 1)
 
 	// enable the feature flag
-	err = stellar.EnableMigrationFeatureFlag(ctx, g)
+	err = stellar.SetMigrationFeatureFlag(ctx, g, true)
 	require.NoError(t, err)
 	m.G().FeatureFlags.InvalidateCache(m, libkb.FeatureStellarAcctBundles)
 
@@ -1576,10 +1578,10 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	g := tcs[0].G
 	m := libkb.NewMetaContextTODO(g)
 
-	acceptDisclaimer(tcs[0])
 	// create a v1 bundle with two accounts
-	_, err := stellar.CreateWallet(ctx, g, false)
+	err := stellar.SetMigrationFeatureFlag(ctx, g, false)
 	require.NoError(t, err)
+	acceptDisclaimer(tcs[0]) // this actually creates the bundle
 	v1Bundle0, _, _, err := remote.FetchV1Bundle(ctx, g)
 	require.NoError(t, err)
 	primaryAccount, err := v1Bundle0.PrimaryAccount()
@@ -1618,7 +1620,7 @@ func TestMigrateBundleToAccountBundles(t *testing.T) {
 	require.True(t, correctErrorType)
 
 	// flip feature flag and migrate
-	err = stellar.EnableMigrationFeatureFlag(ctx, g)
+	err = stellar.SetMigrationFeatureFlag(ctx, g, true)
 	require.NoError(t, err)
 	m.G().FeatureFlags.InvalidateCache(m, libkb.FeatureStellarAcctBundles)
 	enabled, err := m.G().FeatureFlags.EnabledWithError(m, libkb.FeatureStellarAcctBundles)


### PR DESCRIPTION
when a user has the `stellar_acct_bundles` feature flag before a wallet is created, go ahead and create the v2 wallet instead of the v1. 