### PR TITLE
Fix 'claim lumens' button not showing up

### DIFF
--- a/shared/chat/conversation/messages/account-payment/container.js
+++ b/shared/chat/conversation/messages/account-payment/container.js
@@ -66,7 +66,7 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
       const conv = Constants.getMeta(state, ownProps.message.conversationIDKey)
       const theirUsername = conv.participants.find(p => p !== you) || ''
 
-      const cancelable = paymentInfo.status === 'cancelable'
+      const cancelable = paymentInfo.status === 'claimable'
       const pending = cancelable || paymentInfo.status === 'pending'
       const canceled = paymentInfo.status === 'canceled'
       const verb = makeSendPaymentVerb(paymentInfo.status, youAreSender)

--- a/shared/chat/conversation/messages/message-popup/payment/container.js
+++ b/shared/chat/conversation/messages/message-popup/payment/container.js
@@ -132,7 +132,7 @@ const sendMergeProps = (stateProps, dispatchProps, ownProps: SendOwnProps) => {
     icon: paymentInfo.delta === 'increase' ? 'receiving' : 'sending',
     loading: false,
     onCancel: paymentInfo.showCancel ? () => dispatchProps.onCancel(paymentInfo.paymentID) : null,
-    onClaimLumens: paymentInfo.status === 'cancelable' && !youAreSender ? dispatchProps.onClaimLumens : null,
+    onClaimLumens: paymentInfo.status === 'claimable' && !youAreSender ? dispatchProps.onClaimLumens : null,
     onHidden: ownProps.onHidden,
     onSeeDetails:
       (paymentInfo.status === 'completed' ||


### PR DESCRIPTION
#14750 renamed status 'cancelable' to 'claimable', but we still had some checks for cancelable hanging around. In particular, these mean that no 'claim lumens' button would show in chat for recipients of relay payments. r? @keybase/react-hackers 