### PR TITLE
Don't clip the tops of emoji on mobile snippets.

### DIFF
--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -170,6 +170,7 @@ const styles = styleSheetCreate({
       flex: 1,
       fontSize: 14,
       paddingRight: 40,
+      paddingTop: 2, // so the tops of emoji aren't chopped off
     },
   }),
   contentBox: {


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review.