### PR TITLE
Avoid white screen when deleting channel

### DIFF
--- a/shared/teams/team/settings-tab/retention/index.js
+++ b/shared/teams/team/settings-tab/retention/index.js
@@ -298,7 +298,9 @@ const policyToLabel = (p: RetentionPolicy, parent: ?RetentionPolicy) => {
       return daysToLabel(p.days)
     case 'inherit':
       if (!parent) {
-        throw new Error(`Got policy of type 'inherit' without an inheritable parent policy`)
+        // Don't throw an error, as this may happen when deleting a
+        // channel.
+        return 'Team default'
       }
       return policyToInheritLabel(parent)
   }


### PR DESCRIPTION
We were throwing an Error on the render path.

The new experience still isn't great, as we get kicked to a weird info panel page,
but at least one can exit out of it.