### PR TITLE
Fix bug where 'copy to clipboard' toast wasn't showing

### DIFF
--- a/shared/common-adapters/copy-text.js
+++ b/shared/common-adapters/copy-text.js
@@ -79,8 +79,7 @@ class _CopyText extends React.Component<Props, State> {
         direction="horizontal"
         style={Styles.collapseStyles([styles.container, this.props.containerStyle])}
       >
-        {/* $FlowIssue innerRef not typed yet */}
-        <ToastContainer innerRef={r => (this._toastRef = r)} getAttachmentRef={this._getAttachmentRef} />
+        <ToastContainer ref={r => (this._toastRef = r)} getAttachmentRef={this._getAttachmentRef} />
         <Text
           lineClamp={lineClamp}
           type="Body"

--- a/shared/profile/index.desktop.js
+++ b/shared/profile/index.desktop.js
@@ -106,7 +106,7 @@ class _StellarFederatedAddress extends React.PureComponent<
     }
     return (
       <Kb.Box2 direction="horizontal" ref={r => (this._attachmentRef = r)}>
-        <Kb.ToastContainer innerRef={r => (this._toastRef = r)} getAttachmentRef={this._getAttachmentRef} />
+        <Kb.ToastContainer ref={r => (this._toastRef = r)} getAttachmentRef={this._getAttachmentRef} />
         <Kb.Box style={styles.iconContainer}>
           <Kb.Icon
             style={styles.service}


### PR DESCRIPTION
We should be using ref, now that HOCTimers supports forwarding refs.