### PR TITLE
remove dup help text

### DIFF
--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -115,7 +115,7 @@ func (c *ChatUI) ChatConfirmChannelDelete(ctx context.Context, arg chat1.ChatCon
 	if err != nil {
 		return false, err
 	}
-	return strings.TrimSpace(response) == confirm, nil
+	return response == confirm, nil
 }
 
 func (c *ChatUI) renderSearchHit(ctx context.Context, searchHit chat1.ChatSearchHit) error {

--- a/go/client/cmd_chat_leavechannel.go
+++ b/go/client/cmd_chat_leavechannel.go
@@ -64,7 +64,6 @@ func (c *CmdChatLeaveChannel) Run() error {
 
 func (c *CmdChatLeaveChannel) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelp(ctx, "leave-channel")
 		return fmt.Errorf("Incorrect usage.")
 	}
 	teamName := ctx.Args().Get(0)

--- a/go/client/cmd_chat_listchannels.go
+++ b/go/client/cmd_chat_listchannels.go
@@ -70,9 +70,12 @@ func (c *CmdChatListChannels) Run() error {
 
 	ui.Printf("Listing channels on %s:\n\n", c.tlfName)
 	for _, c := range listRes.Convs {
-		convLine := fmt.Sprintf("#%s", c.Channel)
+		// c.Channel and c.Headline are user generated content and could
+		// technically contain formatting directives so we don't use
+		// fmt.Sprintf to concatenate them.
+		convLine := "#" + c.Channel
 		if c.Headline != "" {
-			convLine += fmt.Sprintf(" [%s]", c.Headline)
+			convLine += " [" + c.Headline + "]"
 		}
 		if c.CreatorInfo != nil {
 			convLine += fmt.Sprintf(" (created by: %s on: %s)", c.CreatorInfo.Username,

--- a/go/client/cmd_chat_listchannels.go
+++ b/go/client/cmd_chat_listchannels.go
@@ -85,7 +85,6 @@ func (c *CmdChatListChannels) Run() error {
 
 func (c *CmdChatListChannels) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 1 {
-		cli.ShowCommandHelp(ctx, "list-channels")
 		return fmt.Errorf("incorrect usage")
 	}
 

--- a/go/client/cmd_chat_listchannels.go
+++ b/go/client/cmd_chat_listchannels.go
@@ -70,18 +70,15 @@ func (c *CmdChatListChannels) Run() error {
 
 	ui.Printf("Listing channels on %s:\n\n", c.tlfName)
 	for _, c := range listRes.Convs {
-		// c.Channel and c.Headline are user generated content and could
-		// technically contain formatting directives so we don't use
-		// fmt.Sprintf to concatenate them.
-		convLine := "#" + c.Channel
+		convLine := fmt.Sprintf("#%s", c.Channel)
 		if c.Headline != "" {
-			convLine += " [" + c.Headline + "]"
+			convLine += fmt.Sprintf(" [%s]", c.Headline)
 		}
 		if c.CreatorInfo != nil {
 			convLine += fmt.Sprintf(" (created by: %s on: %s)", c.CreatorInfo.Username,
 				c.CreatorInfo.Ctime.Time().Format("2006-01-02"))
 		}
-		ui.Printf(convLine + "\n")
+		ui.Printf("%s\n", convLine)
 	}
 	return nil
 }

--- a/go/client/cmd_chat_listmembers.go
+++ b/go/client/cmd_chat_listmembers.go
@@ -73,7 +73,6 @@ func (c *CmdChatListMembers) Run() error {
 
 func (c *CmdChatListMembers) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelp(ctx, "list-members")
 		return fmt.Errorf("Incorrect usage.")
 	}
 

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -203,17 +203,14 @@ func (c *CmdChatSend) ParseArgv(ctx *cli.Context) (err error) {
 			}
 			c.message = "" // get message through prompt later
 		default:
-			cli.ShowCommandHelp(ctx, "send")
 			return fmt.Errorf("chat send takes 0, 1 or 2 args")
 		}
 	}
 
 	if nActions < 1 {
-		cli.ShowCommandHelp(ctx, "send")
 		return fmt.Errorf("incorrect usage")
 	}
 	if nActions > 1 {
-		cli.ShowCommandHelp(ctx, "send")
 		return fmt.Errorf("only one of message, --set-headline, --clear-headline allowed")
 	}
 


### PR DESCRIPTION
seems like the behavior changed at some point and the help text is printed by default so we don't need to double print

before:
```
$ keybase chat list-channels
NAME:
   keybase chat list-channels - List of channels on a team

USAGE:
   keybase chat list-channels [command options] <team name>

OPTIONS:
   --topic-type "chat"	Specify topic type of the conversation. Has to be chat or dev
   -j, --json		Output channels as JSON
   

Error parsing command line arguments: incorrect usage

NAME:
   keybase chat list-channels - List of channels on a team

USAGE:
   keybase chat list-channels [command options] <team name>

OPTIONS:
   --topic-type "chat"	Specify topic type of the conversation. Has to be chat or dev
   -j, --json		Output channels as JSON
   

after:
```
$ keybase chat list-channels
Running `go install github.com/keybase/client/go/keybase`... Done.
Error parsing command line arguments: incorrect usage

NAME:
   keybase chat list-channels - List of channels on a team

USAGE:
   keybase chat list-channels [command options] <team name>

OPTIONS:
   --topic-type "chat"  Specify topic type of the conversation. Has to be chat or dev
   -j, --json           Output channels as JSON
```