### PR TITLE
add banner for when address not in sigchain

### DIFF
--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -1516,6 +1516,20 @@ func TestBuildPaymentLocal(t *testing.T) {
 		Level:   "info",
 		Message: fmt.Sprintf("Because it's %v's first transaction, you must send at least 1 XLM.", tcs[1].Fu.Username),
 	}})
+	// and from non-primary account has an additional privacy banner
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:   senderSecondaryAccountID,
+		To:     tcs[1].Fu.Username,
+		Amount: "15",
+	})
+	require.NoError(t, err)
+	requireBannerSet(t, bres.DeepCopy().Banners, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: fmt.Sprintf("Because it's %v's first transaction, you must send at least 1 XLM.", tcs[1].Fu.Username),
+	}, {
+		Level:   "info",
+		Message: fmt.Sprintf("Your Keybase username will not be linked to this transaction."),
+	}})
 
 	_, err = tcs[0].Srv.SendPaymentLocal(context.Background(), stellar1.SendPaymentLocalArg{
 		BypassBid: true,
@@ -1545,6 +1559,18 @@ func TestBuildPaymentLocal(t *testing.T) {
 	require.Equal(t, "15 XLM", bres.DisplayAmountXLM)
 	require.Equal(t, "$4.77 USD", bres.DisplayAmountFiat)
 	requireBannerSet(t, bres.DeepCopy().Banners, []stellar1.SendBannerLocal{}) // recipient is funded so banner's gone
+	// and from non-primary account has a privacy banner
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:       senderSecondaryAccountID,
+		To:         tcs[1].Fu.Username,
+		Amount:     "15",
+		PublicMemo: "🥔🥔🥔🥔🥔🥔🥔🥔",
+	})
+	require.NoError(t, err)
+	requireBannerSet(t, bres.DeepCopy().Banners, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: fmt.Sprintf("Your Keybase username will not be linked to this transaction."),
+	}})
 
 	// Send an amount so close to available to send that the fee would push it it over the edge.
 	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
@@ -1662,6 +1688,22 @@ func TestBuildPaymentLocal(t *testing.T) {
 	requireBannerSet(t, bres.DeepCopy().Banners, []stellar1.SendBannerLocal{{
 		Level:   "info",
 		Message: "Because it's their first transaction, you must send at least 1 XLM.",
+	}})
+	// and from non-primary account has an additional privacy banner
+	bres, err = tcs[0].Srv.BuildPaymentLocal(context.Background(), stellar1.BuildPaymentLocalArg{
+		From:          senderSecondaryAccountID,
+		To:            "GBJCIIIWEP2ZIKSNY3AP5GJ5OHNSN6Y4W5K4IVIY4VSQF5QLVE27GADK",
+		ToIsAccountID: true,
+		Amount:        "8.50",
+		Currency:      &usd,
+	})
+	require.NoError(t, err)
+	requireBannerSet(t, bres.DeepCopy().Banners, []stellar1.SendBannerLocal{{
+		Level:   "info",
+		Message: fmt.Sprintf("Because it's their first transaction, you must send at least 1 XLM."),
+	}, {
+		Level:   "info",
+		Message: fmt.Sprintf("Your Keybase username will not be linked to this transaction."),
 	}})
 
 	t.Logf("sending to account ID that is someone's primary")


### PR DESCRIPTION
add a new banner that says "Your Keybase identity will not be linked to the transaction." inside the payment window when: 
* the sending address is not the primary address
* you aren't just moving money between accounts