### PR TITLE
Fix autoresize and don't submit if composingIME

### DIFF
--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -128,8 +128,8 @@ class Input extends React.Component<InputProps, InputState> {
     throttled(this.props.sendTyping, text)
   }
 
-  _onKeyDown = (e: SyntheticKeyboardEvent<>) => {
-    if (e.key === 'Enter' && !(e.altKey || e.shiftKey || e.metaKey)) {
+  _onKeyDown = (e: SyntheticKeyboardEvent<>, isComposingIME: boolean) => {
+    if (e.key === 'Enter' && !(e.altKey || e.shiftKey || e.metaKey) && !isComposingIME) {
       e.preventDefault()
       if (this._lastText) {
         this._onSubmit(this._lastText)

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -45,7 +45,7 @@ type PlatformInputProps = {|
   ...CommonProps,
   inputSetRef: (r: null | PlainInput) => void,
   onChangeText: (newText: string) => void,
-  onKeyDown: (evt: SyntheticKeyboardEvent<>) => void,
+  onKeyDown: (evt: SyntheticKeyboardEvent<>, isComposingIME: boolean) => void,
   setHeight: (inputHeight: number) => void, // used on mobile to position suggestion HUD
 |}
 

--- a/shared/common-adapters/plain-input.desktop.js
+++ b/shared/common-adapters/plain-input.desktop.js
@@ -52,28 +52,8 @@ class PlainInput extends React.PureComponent<InternalProps> {
     if (!n) {
       return
     }
-
-    // Smart auto resize algorithm from `Input`, use it by default here
-    const rect = n.getBoundingClientRect()
-    const value = n.value
-    // width changed so throw out our data
-    if (rect.width !== this._smartAutoresize.width) {
-      this._smartAutoresize.width = rect.width
-      this._smartAutoresize.pivotLength = -1
-    }
-
-    // See if we've gone up in size, if so keep track of the input at that point
-    if (n.scrollHeight > rect.height) {
-      this._smartAutoresize.pivotLength = value.length
-      n.style.height = `${n.scrollHeight}px`
-    } else {
-      // see if we went back down in height
-      if (this._smartAutoresize.pivotLength !== -1 && value.length <= this._smartAutoresize.pivotLength) {
-        this._smartAutoresize.pivotLength = value.length
-        n.style.height = '1px'
-        n.style.height = `${n.scrollHeight}px`
-      }
-    }
+    n.style.height = '1px'
+    n.style.height = `${n.scrollHeight}px`
   }
 
   focus = () => {


### PR DESCRIPTION
* Removes the smart autoresize algorithm (afaict we never had it enabled, even with the old input) and opts for the more foolproof method
* Checks for `!isComposingIME` before submitting

r? @keybase/react-hackers 