### PR TITLE
Update our react-native-image-picker fork

### DIFF
--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -11467,7 +11467,7 @@ react-native-fast-image@5.1.1:
 
 "react-native-image-picker@git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes":
   version "0.27.1"
-  resolved "git://github.com/keybase/react-native-image-picker#f28619031c0be823ab668d467070d1f924b8f59e"
+  resolved "git://github.com/keybase/react-native-image-picker#5c81f1c60de50f8d5a4b883bb42208325bcc2761"
 
 react-native-mime-types@2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This picks up the Android crasher / gallery fix.