### PR TITLE
[NOMERGE] Update our react-native-image-picker fork (#15211)

### DIFF
--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "2.12.3"
+const Version = "2.12.4"

--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -103,7 +103,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         applicationId "io.keybase.ossifrage"
         versionCode timestamp()
-        versionName "2.12.3"
+        versionName "2.12.4"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.12.3</string>
+	<string>2.12.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/shared/react-native/ios/KeybaseShare/Info.plist
+++ b/shared/react-native/ios/KeybaseShare/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.12.3</string>
+	<string>2.12.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10711,7 +10711,7 @@ react-native-fast-image@5.1.1:
 
 "react-native-image-picker@git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes":
   version "0.27.1"
-  resolved "git://github.com/keybase/react-native-image-picker#389b4c1363babf0e2b059c9896836e8a934b468f"
+  resolved "git://github.com/keybase/react-native-image-picker#5c81f1c60de50f8d5a4b883bb42208325bcc2761"
 
 react-native-mime-types@2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This picks up the Android crasher / gallery fix.