### PR TITLE
Defer loading routes

### DIFF
--- a/shared/app/globals.native.js
+++ b/shared/app/globals.native.js
@@ -17,4 +17,4 @@ if (typeof __STORYBOOK__ === 'undefined') {
 // We don't storyshot RN
 __STORYSHOT__ = false
 
-require('../util/user-timings')
+// require('../util/user-timings')

--- a/shared/app/globals.native.js
+++ b/shared/app/globals.native.js
@@ -16,5 +16,3 @@ if (typeof __STORYBOOK__ === 'undefined') {
 
 // We don't storyshot RN
 __STORYSHOT__ = false
-
-// require('../util/user-timings')

--- a/shared/app/routes-login.js
+++ b/shared/app/routes-login.js
@@ -9,7 +9,6 @@ import loginRoutes from '../login/routes'
 // root.
 const loginRouteTree = makeRouteDefNode({
   children: {
-    // $FlowIssue TODO have clean flow with new route tree
     [loginTab]: loginRoutes,
   },
   containerComponent: Nav,

--- a/shared/chat/conversation/messages/react-button/emoji-picker/index.js
+++ b/shared/chat/conversation/messages/react-button/emoji-picker/index.js
@@ -1,18 +1,39 @@
 // @flow
 import * as React from 'react'
-import {categories, emojiIndex, emojiNameMap, type EmojiData} from './data'
+import type {EmojiData} from './data'
 import {ClickableBox, Box2, Emoji, SectionList, Text} from '../../../../../common-adapters'
 import {collapseStyles, globalColors, globalMargins, styleSheetCreate} from '../../../../../styles'
 import {isAndroid} from '../../../../../constants/platform'
 import {chunk} from 'lodash-es'
+import {memoize} from '../../../../../util/memoize'
 
-// SectionList data is mostly static, map categories here
-// and chunk data within component
-const emojiSections = categories.map(c => ({
-  category: c.category,
-  data: {emojis: c.emojis, key: ''},
-  key: c.category,
-}))
+// defer loading this until we need to, very expensive
+const getData = memoize(() => {
+  const {categories, emojiIndex, emojiNameMap} = require('./data')
+  // SectionList data is mostly static, map categories here
+  // and chunk data within component
+  const emojiSections = categories.map(c => ({
+    category: c.category,
+    data: {emojis: c.emojis, key: ''},
+    key: c.category,
+  }))
+
+  // Get emoji results for a query and map
+  // to full emoji data
+  const getFilterResults = filter =>
+    emojiIndex
+      .search(filter, {maxResults: maxEmojiSearchResults})
+      .map(res => emojiNameMap[res.id])
+      // MUST sort this so its stable
+      .sort((a, b) => a.sort_order - b.sort_order)
+
+  return {
+    emojiIndex,
+    emojiSections,
+    getFilterResults,
+  }
+})
+
 const singleEmojiWidth = 32
 const emojiPadding = 4
 const emojiWidthWithPadding = singleEmojiWidth + 2 * emojiPadding
@@ -27,15 +48,6 @@ const cacheSections = (width: number, sections: Array<Section>) => {
   cachedWidth = width
   cachedSections = sections
 }
-
-// Get emoji results for a query and map
-// to full emoji data
-const getFilterResults = filter =>
-  emojiIndex
-    .search(filter, {maxResults: maxEmojiSearchResults})
-    .map(res => emojiNameMap[res.id])
-    // MUST sort this so its stable
-    .sort((a, b) => a.sort_order - b.sort_order)
 
 type Section = {
   category: string,
@@ -63,6 +75,8 @@ class EmojiPicker extends React.Component<Props, State> {
       this.setState(s => (s.sections === cachedSections ? null : {sections: cachedSections}))
       return
     }
+
+    const {emojiSections} = getData()
     // width is different from cached. make new sections & cache for next time
     let sections = []
     const emojisPerLine = Math.floor(this.props.width / emojiWidthWithPadding)
@@ -91,6 +105,7 @@ class EmojiPicker extends React.Component<Props, State> {
   }
 
   render() {
+    const {getFilterResults} = getData()
     // For filtered results, we have <= `maxEmojiSearchResults` emojis
     // to render. Render them directly rather than going through _chunkData
     // pipeline for fast list of results. Go through _chunkData only

--- a/shared/chat/routes.js
+++ b/shared/chat/routes.js
@@ -1,158 +1,160 @@
 // @flow
-import * as WalletConstants from '../constants/wallets'
-import AttachmentGetTitles from './conversation/attachment-get-titles/container'
-import AttachmentFullscreen from './conversation/attachment-fullscreen/container'
-import AttachmentVideoFullscreen from './conversation/attachment-video-fullscreen/container'
-import BlockConversationWarning from './conversation/block-conversation-warning/container'
-import Conversation from './conversation/container'
-import CreateChannel from './create-channel/container'
-import EditChannel from './manage-channels/edit-channel-container'
-import EnterPaperkey from './conversation/rekey/enter-paper-key'
-import Inbox from './inbox/container'
-import InfoPanel from './conversation/info-panel/container'
-import ManageChannels from './manage-channels/container'
-import NewTeamDialogFromChat from './new-team-dialog-container'
-import ReallyLeaveTeam from '../teams/really-leave-team/container-chat'
-import InboxAndConversation from './inbox-and-conversation'
-import TeamBuilding from '../team-building/container'
-import {MaybePopupHoc} from '../common-adapters'
 import {isMobile} from '../constants/platform'
-import {makeRouteDefNode, makeLeafTags} from '../route-tree'
-import DeleteHistoryWarning from './delete-history-warning/container'
-import RetentionWarning from '../teams/team/settings-tab/retention/warning/container'
-import ChooseEmoji from './conversation/messages/react-button/emoji-picker/container'
-import ConfirmForm from '../wallets/confirm-form/container'
-import SendForm from '../wallets/send-form/container'
-import ChooseAsset from '../wallets/send-form/choose-asset/container'
-import QRScan from '../wallets/qr-scan/container'
-import PaymentsConfirm from './payments/confirm/container'
 
 // Arbitrarily stackable routes from the chat tab
-const chatChildren = {
-  attachmentFullscreen: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: AttachmentFullscreen,
-    tags: makeLeafTags(
-      isMobile ? {fullscreen: true, hideStatusBar: true, underNotch: true} : {layerOnTop: true}
-    ),
-  },
-  attachmentGetTitles: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: AttachmentGetTitles,
-    tags: makeLeafTags(isMobile ? {} : {layerOnTop: true}),
-  },
-  attachmentVideoFullscreen: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: AttachmentVideoFullscreen,
-    tags: makeLeafTags(isMobile ? {fullscreen: true} : {layerOnTop: true}),
-  },
-  chooseEmoji: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: ChooseEmoji,
-    tags: makeLeafTags({layerOnTop: false}),
-  },
-  createChannel: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: CreateChannel,
-    tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
-  },
-  deleteHistoryWarning: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: DeleteHistoryWarning,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
-  },
-  editChannel: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: MaybePopupHoc(isMobile)(EditChannel),
-    tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
-  },
-  enterPaperkey: {
-    component: EnterPaperkey,
-  },
-  infoPanel: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: InfoPanel,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
-  },
-  manageChannels: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: ManageChannels,
-    tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
-  },
-  newChat: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: TeamBuilding,
-    tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
-  },
-  paymentsConfirm: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: PaymentsConfirm,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
-  },
-  reallyLeaveTeam: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: ReallyLeaveTeam,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
-  },
-  retentionWarning: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: RetentionWarning,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
-  },
-  showBlockConversationDialog: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: BlockConversationWarning,
-    tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
-  },
-  showNewTeamDialog: {
-    children: key => makeRouteDefNode(chatChildren[key]),
-    component: NewTeamDialogFromChat,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
-  },
-  [WalletConstants.sendReceiveFormRouteKey]: {
-    children: {
-      [WalletConstants.confirmFormRouteKey]: {
-        children: {},
-        component: ConfirmForm,
-        tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true, underNotch: true}),
-      },
-      [WalletConstants.chooseAssetFormRouteKey]: {
-        children: {},
-        component: ChooseAsset,
-        tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile, renderTopmostOnly: true}),
-      },
-      qrScan: {
-        component: QRScan,
-        tags: makeLeafTags({layerOnTop: true, underNotch: true}),
-      },
+const routeTree = () => {
+  const WalletConstants = require('../constants/wallets')
+  const AttachmentGetTitles = require('./conversation/attachment-get-titles/container').default
+  const AttachmentFullscreen = require('./conversation/attachment-fullscreen/container').default
+  const AttachmentVideoFullscreen = require('./conversation/attachment-video-fullscreen/container').default
+  const BlockConversationWarning = require('./conversation/block-conversation-warning/container').default
+  const Conversation = require('./conversation/container').default
+  const CreateChannel = require('./create-channel/container').default
+  const EditChannel = require('./manage-channels/edit-channel-container').default
+  const EnterPaperkey = require('./conversation/rekey/enter-paper-key').default
+  const Inbox = require('./inbox/container').default
+  const InfoPanel = require('./conversation/info-panel/container').default
+  const ManageChannels = require('./manage-channels/container').default
+  const NewTeamDialogFromChat = require('./new-team-dialog-container').default
+  const ReallyLeaveTeam = require('../teams/really-leave-team/container-chat').default
+  const InboxAndConversation = require('./inbox-and-conversation').default
+  const TeamBuilding = require('../team-building/container').default
+  const {MaybePopupHoc} = require('../common-adapters')
+  const {makeRouteDefNode, makeLeafTags} = require('../route-tree')
+  const DeleteHistoryWarning = require('./delete-history-warning/container').default
+  const RetentionWarning = require('../teams/team/settings-tab/retention/warning/container').default
+  const ChooseEmoji = require('./conversation/messages/react-button/emoji-picker/container').default
+  const ConfirmForm = require('../wallets/confirm-form/container').default
+  const SendForm = require('../wallets/send-form/container').default
+  const ChooseAsset = require('../wallets/send-form/choose-asset/container').default
+  const QRScan = require('../wallets/qr-scan/container').default
+  const PaymentsConfirm = require('./payments/confirm/container').default
+
+  const chatChildren = {
+    attachmentFullscreen: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: AttachmentFullscreen,
+      tags: makeLeafTags(
+        isMobile ? {fullscreen: true, hideStatusBar: true, underNotch: true} : {layerOnTop: true}
+      ),
     },
-    component: SendForm,
-    tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true, underNotch: true}),
-  },
-}
-
-const conversationRoute = makeRouteDefNode({
-  children: chatChildren,
-  component: Conversation,
-})
-
-const routeTree = isMobile
-  ? makeRouteDefNode({
-      children: key => {
-        if (key !== 'conversation') {
-          return makeRouteDefNode(chatChildren[key])
-        }
-        return conversationRoute
+    attachmentGetTitles: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: AttachmentGetTitles,
+      tags: makeLeafTags(isMobile ? {} : {layerOnTop: true}),
+    },
+    attachmentVideoFullscreen: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: AttachmentVideoFullscreen,
+      tags: makeLeafTags(isMobile ? {fullscreen: true} : {layerOnTop: true}),
+    },
+    chooseEmoji: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: ChooseEmoji,
+      tags: makeLeafTags({layerOnTop: false}),
+    },
+    createChannel: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: CreateChannel,
+      tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
+    },
+    deleteHistoryWarning: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: DeleteHistoryWarning,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+    editChannel: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: MaybePopupHoc(isMobile)(EditChannel),
+      tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
+    },
+    enterPaperkey: {
+      component: EnterPaperkey,
+    },
+    infoPanel: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: InfoPanel,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+    manageChannels: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: ManageChannels,
+      tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
+    },
+    newChat: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: TeamBuilding,
+      tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
+    },
+    paymentsConfirm: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: PaymentsConfirm,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+    reallyLeaveTeam: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: ReallyLeaveTeam,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+    retentionWarning: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: RetentionWarning,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+    showBlockConversationDialog: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: BlockConversationWarning,
+      tags: makeLeafTags({hideStatusBar: isMobile, layerOnTop: !isMobile}),
+    },
+    showNewTeamDialog: {
+      children: key => makeRouteDefNode(chatChildren[key]),
+      component: NewTeamDialogFromChat,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+    [WalletConstants.sendReceiveFormRouteKey]: {
+      children: {
+        [WalletConstants.confirmFormRouteKey]: {
+          children: {},
+          component: ConfirmForm,
+          tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true, underNotch: true}),
+        },
+        [WalletConstants.chooseAssetFormRouteKey]: {
+          children: {},
+          component: ChooseAsset,
+          tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile, renderTopmostOnly: true}),
+        },
+        qrScan: {
+          component: QRScan,
+          tags: makeLeafTags({layerOnTop: true, underNotch: true}),
+        },
       },
-      component: Inbox,
-      tags: makeLeafTags({persistChildren: true}),
-    })
-  : makeRouteDefNode({
-      children: () => conversationRoute,
-      containerComponent: InboxAndConversation,
-      defaultSelected: '0',
-      initialState: {smallTeamsExpanded: false},
-      tags: makeLeafTags({persistChildren: true}),
-    })
+      component: SendForm,
+      tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true, underNotch: true}),
+    },
+  }
+
+  const conversationRoute = makeRouteDefNode({
+    children: chatChildren,
+    component: Conversation,
+  })
+  return isMobile
+    ? makeRouteDefNode({
+        children: key => {
+          if (key !== 'conversation') {
+            return makeRouteDefNode(chatChildren[key])
+          }
+          return conversationRoute
+        },
+        component: Inbox,
+        tags: makeLeafTags({persistChildren: true}),
+      })
+    : makeRouteDefNode({
+        children: () => conversationRoute,
+        containerComponent: InboxAndConversation,
+        defaultSelected: '0',
+        initialState: {smallTeamsExpanded: false},
+        tags: makeLeafTags({persistChildren: true}),
+      })
+}
 
 export default routeTree

--- a/shared/devices/routes.js
+++ b/shared/devices/routes.js
@@ -1,36 +1,38 @@
 // @flow
-import CodePage from '../provision/code-page/container'
-import DevicePage from './device-page/container'
-import Devices from './container'
-import ErrorPage from '../provision/error/container'
-import PaperKey from './paper-key/container'
-import RevokeDevice from './device-revoke/container'
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 
-const routeTree = makeRouteDefNode({
-  children: {
-    codePage: {
-      component: CodePage,
-      tags: makeLeafTags({fullscreen: true, hideStatusBar: true}),
-    },
-    devicePage: {
-      children: {
-        revokeDevice: {
-          component: RevokeDevice,
-          title: 'Device Revoke',
-        },
+const routeTree = () => {
+  const CodePage = require('../provision/code-page/container').default
+  const DevicePage = require('./device-page/container').default
+  const Devices = require('./container').default
+  const ErrorPage = require('../provision/error/container').default
+  const PaperKey = require('./paper-key/container').default
+  const RevokeDevice = require('./device-revoke/container').default
+  return makeRouteDefNode({
+    children: {
+      codePage: {
+        component: CodePage,
+        tags: makeLeafTags({fullscreen: true, hideStatusBar: true}),
       },
-      component: DevicePage,
+      devicePage: {
+        children: {
+          revokeDevice: {
+            component: RevokeDevice,
+            title: 'Device Revoke',
+          },
+        },
+        component: DevicePage,
+      },
+      error: {
+        component: ErrorPage,
+        tags: makeLeafTags({fullscreen: true, hideStatusBar: true}),
+      },
+      paperKey: {component: PaperKey},
     },
-    error: {
-      component: ErrorPage,
-      tags: makeLeafTags({fullscreen: true, hideStatusBar: true}),
-    },
-    paperKey: {component: PaperKey},
-  },
-  component: Devices,
-  initialState: {showingRevoked: false},
-  tags: makeLeafTags({title: 'Devices'}),
-})
+    component: Devices,
+    initialState: {showingRevoked: false},
+    tags: makeLeafTags({title: 'Devices'}),
+  })
+}
 
 export default routeTree

--- a/shared/fs/routes.js
+++ b/shared/fs/routes.js
@@ -1,71 +1,73 @@
 // @flow
 import * as I from 'immutable'
-import Files from './container'
 import {isMobile} from '../constants/platform'
-import {BarePreview} from './filepreview'
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
-import SecurityPrefs from './common/security-prefs-container'
-import DestinationPicker from './destination-picker/container'
-import SendLinkToChat from './send-link-to-chat/container'
-import OopsNoAccess from './oops-no-access/container'
 
-const _destinationPicker = {
-  children: {
-    destinationPicker: () => makeRouteDefNode(_destinationPicker),
-  },
-  component: DestinationPicker,
-  tags: makeLeafTags({
-    layerOnTop: !isMobile,
-    renderTopmostOnly: !isMobile,
-    title: 'Move or Copy',
-  }),
-}
+const routeTree = () => {
+  const Files = require('./container').default
+  const {BarePreview} = require('./filepreview')
+  const SecurityPrefs = require('./common/security-prefs-container').default
+  const DestinationPicker = require('./destination-picker/container').default
+  const SendLinkToChat = require('./send-link-to-chat/container').default
+  const OopsNoAccess = require('./oops-no-access/container').default
 
-const _commonChildren = {
-  destinationPicker: () => makeRouteDefNode(_destinationPicker),
-  securityPrefs: {
-    component: SecurityPrefs,
-  },
-  sendLinkToChat: {
-    component: SendLinkToChat,
+  const _destinationPicker = {
+    children: {
+      destinationPicker: () => makeRouteDefNode(_destinationPicker),
+    },
+    component: DestinationPicker,
     tags: makeLeafTags({
       layerOnTop: !isMobile,
       renderTopmostOnly: !isMobile,
-      title: 'Send link to chat',
+      title: 'Move or Copy',
     }),
-  },
-}
+  }
 
-const _mainRoute = {
-  children: {
-    ..._commonChildren,
-    barePreview: () =>
-      makeRouteDefNode({
-        children: _commonChildren,
-        component: BarePreview,
-        tags: makeLeafTags({
-          fullscreen: true,
-          title: 'Preview',
-        }),
+  const _commonChildren = {
+    destinationPicker: () => makeRouteDefNode(_destinationPicker),
+    securityPrefs: {
+      component: SecurityPrefs,
+    },
+    sendLinkToChat: {
+      component: SendLinkToChat,
+      tags: makeLeafTags({
+        layerOnTop: !isMobile,
+        renderTopmostOnly: !isMobile,
+        title: 'Send link to chat',
       }),
-    main: () => makeRouteDefNode(_mainRoute),
-    oopsNoAccess: () =>
-      makeRouteDefNode({
-        component: OopsNoAccess,
-        tags: makeLeafTags({
-          layerOnTop: !isMobile,
-          renderTopmostOnly: !isMobile,
-          title: 'Permission error',
-        }),
-      }),
-  },
-  component: Files,
-}
+    },
+  }
 
-const routeTree = makeRouteDefNode({
-  ..._mainRoute,
-  initialState: {expandedSet: I.Set()},
-  tags: makeLeafTags({title: 'Files'}),
-})
+  const _mainRoute = {
+    children: {
+      ..._commonChildren,
+      barePreview: () =>
+        makeRouteDefNode({
+          children: _commonChildren,
+          component: BarePreview,
+          tags: makeLeafTags({
+            fullscreen: true,
+            title: 'Preview',
+          }),
+        }),
+      main: () => makeRouteDefNode(_mainRoute),
+      oopsNoAccess: () =>
+        makeRouteDefNode({
+          component: OopsNoAccess,
+          tags: makeLeafTags({
+            layerOnTop: !isMobile,
+            renderTopmostOnly: !isMobile,
+            title: 'Permission error',
+          }),
+        }),
+    },
+    component: Files,
+  }
+  return makeRouteDefNode({
+    ..._mainRoute,
+    initialState: {expandedSet: I.Set()},
+    tags: makeLeafTags({title: 'Files'}),
+  })
+}
 
 export default routeTree

--- a/shared/git/routes.js
+++ b/shared/git/routes.js
@@ -1,28 +1,25 @@
 // @flow
 import * as I from 'immutable'
-import MainPage from './container'
-import NewRepo from './new-repo/container'
-import DeleteRepo from './delete-repo/container'
-import SelectChannel from './select-channel/container'
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import {isMobile} from '../constants/platform'
 
-const routeTree = makeRouteDefNode({
-  children: {
-    deleteRepo: {
-      component: DeleteRepo,
+const routeTree = () =>
+  makeRouteDefNode({
+    children: {
+      deleteRepo: {
+        component: require('./delete-repo/container').default,
+      },
+      newRepo: {
+        component: require('./new-repo/container').default,
+      },
+      selectChannel: {
+        component: require('./select-channel/container').default,
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
     },
-    newRepo: {
-      component: NewRepo,
-    },
-    selectChannel: {
-      component: SelectChannel,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
-  },
-  component: MainPage,
-  initialState: {expandedSet: I.Set()},
-  tags: makeLeafTags({title: 'Git'}),
-})
+    component: require('./container').default,
+    initialState: {expandedSet: I.Set()},
+    tags: makeLeafTags({title: 'Git'}),
+  })
 
 export default routeTree

--- a/shared/login/routes.js
+++ b/shared/login/routes.js
@@ -1,12 +1,6 @@
 // @flow
 import * as I from 'immutable'
 import * as React from 'react'
-import Feedback from '../settings/feedback-container'
-import JoinOrLogin from './join-or-login/container'
-import Loading from './loading/container'
-import Relogin from './relogin/container'
-import provisonRoutes from '../provision/routes'
-import signupRoutes from './signup/routes'
 import {connect, type RouteProps} from '../util/container'
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 
@@ -19,6 +13,9 @@ const mapStateToProps = state => {
 }
 
 const _RootLogin = ({showLoading, showRelogin, navigateAppend}) => {
+  const JoinOrLogin = require('./join-or-login/container').default
+  const Loading = require('./loading/container').default
+  const Relogin = require('./relogin/container').default
   if (showLoading) {
     return <Loading navigateAppend={navigateAppend} />
   }
@@ -36,20 +33,24 @@ const RootLogin = connect<OwnProps, _, _, _, _>(
 
 const addTags = component => ({component, tags: makeLeafTags({hideStatusBar: true})})
 
-const recursiveLazyRoutes = I.Seq({
-  feedback: addTags(Feedback),
-  login: addTags(RootLogin),
-  ...provisonRoutes,
-  ...signupRoutes,
-})
-  .map(routeData =>
-    makeRouteDefNode({
-      ...routeData,
-      children: name => recursiveLazyRoutes.get(name),
-    })
-  )
-  .toMap()
-
-const routeTree = recursiveLazyRoutes.get('login')
+const routeTree = () => {
+  const provisonRoutes = require('../provision/routes').default
+  const signupRoutes = require('./signup/routes').default
+  const Feedback = require('../settings/feedback-container').default
+  const recursiveLazyRoutes = I.Seq({
+    feedback: addTags(Feedback),
+    login: addTags(RootLogin),
+    ...provisonRoutes,
+    ...signupRoutes,
+  })
+    .map(routeData =>
+      makeRouteDefNode({
+        ...routeData,
+        children: name => recursiveLazyRoutes.get(name),
+      })
+    )
+    .toMap()
+  return recursiveLazyRoutes.get('login')
+}
 
 export default routeTree

--- a/shared/people/routes.js
+++ b/shared/people/routes.js
@@ -1,12 +1,13 @@
 // @flow
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
-import People from './container'
-import profileRoutes from '../profile/routes'
 
-const peopleRoute = makeRouteDefNode({
-  ...profileRoutes.toObject(),
-  component: People,
-  tags: makeLeafTags({title: 'People'}),
-})
+const peopleRoute = () => {
+  const profileRoutes = require('../profile/routes').default()
+  return makeRouteDefNode({
+    ...profileRoutes.toObject(),
+    component: require('./container').default,
+    tags: makeLeafTags({title: 'People'}),
+  })
+}
 
 export default peopleRoute

--- a/shared/profile/routes.js
+++ b/shared/profile/routes.js
@@ -1,119 +1,122 @@
 // @flow
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
-import pgpRoutes from './pgp/routes'
-import Profile from './container'
-import AddToTeam from './add-to-team/container'
-import EditProfile from './edit-profile/container'
-import EditAvatar from './edit-avatar/container'
-import EditAvatarPlaceholder from './edit-avatar-placeholder/container'
-import ProveEnterUsername from './prove-enter-username/container'
-import ProveWebsiteChoice from './prove-website-choice/container'
-import RevokeContainer from './revoke/container'
-import PostProof from './post-proof/container'
-import ConfirmOrPending from './confirm-or-pending/container'
-import SearchPopup from './search/container'
 import {isMobile} from '../constants/platform'
-import NonUserProfile from './non-user-profile/container'
-import ShowcaseTeamOffer from './showcase-team-offer/container'
-import ControlledRolePicker from '../teams/role-picker/controlled-container'
-import * as WalletConstants from '../constants/wallets'
-import SendForm from '../wallets/send-form/container'
-import ConfirmForm from '../wallets/confirm-form/container'
-import ChooseAsset from '../wallets/send-form/choose-asset/container'
-import QRScan from '../wallets/qr-scan/container'
 
-const proveEnterUsername = makeRouteDefNode({
-  children: {
-    confirmOrPending: {
-      component: ConfirmOrPending,
-    },
-    postProof: {
-      children: {
-        confirmOrPending: {
-          component: ConfirmOrPending,
-        },
-      },
-      component: PostProof,
-    },
-  },
-  component: ProveEnterUsername,
-})
+const profileRoute = () => {
+  const pgpRoutes = require('./pgp/routes').default
+  const Profile = require('./container').default
+  const AddToTeam = require('./add-to-team/container').default
+  const EditProfile = require('./edit-profile/container').default
+  const EditAvatar = require('./edit-avatar/container').default
+  const EditAvatarPlaceholder = require('./edit-avatar-placeholder/container').default
+  const ProveEnterUsername = require('./prove-enter-username/container').default
+  const ProveWebsiteChoice = require('./prove-website-choice/container').default
+  const RevokeContainer = require('./revoke/container').default
+  const PostProof = require('./post-proof/container').default
+  const ConfirmOrPending = require('./confirm-or-pending/container').default
+  const SearchPopup = require('./search/container').default
+  const NonUserProfile = require('./non-user-profile/container').default
+  const ShowcaseTeamOffer = require('./showcase-team-offer/container').default
+  const ControlledRolePicker = require('../teams/role-picker/controlled-container').default
+  const WalletConstants = require('../constants/wallets')
+  const SendForm = require('../wallets/send-form/container').default
+  const ConfirmForm = require('../wallets/confirm-form/container').default
+  const ChooseAsset = require('../wallets/send-form/choose-asset/container').default
+  const QRScan = require('../wallets/qr-scan/container').default
 
-const profileRoute = makeRouteDefNode({
-  children: {
-    addToTeam: {
-      children: {
-        controlledRolePicker: {
-          children: {},
-          component: ControlledRolePicker,
-          tags: makeLeafTags({layerOnTop: !isMobile}),
-        },
+  const proveEnterUsername = makeRouteDefNode({
+    children: {
+      confirmOrPending: {
+        component: ConfirmOrPending,
       },
-      component: AddToTeam,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
-    editAvatar: {
-      component: EditAvatar,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
-    editAvatarPlaceholder: {
-      component: EditAvatarPlaceholder,
-    },
-    editProfile: {
-      component: EditProfile,
-    },
-    nonUserProfile: {
-      children: {
-        profile: () => profileRoute,
-      },
-      component: NonUserProfile,
-    },
-    pgp: pgpRoutes,
-    profile: () => profileRoute,
-    proveEnterUsername,
-    proveWebsiteChoice: {
-      children: {
-        proveEnterUsername,
-      },
-      component: ProveWebsiteChoice,
-    },
-    revoke: {
-      component: RevokeContainer,
-    },
-    search: {
-      children: {},
-      component: SearchPopup,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
-    showcaseTeamOffer: {
-      children: {},
-      component: ShowcaseTeamOffer,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
-    [WalletConstants.sendReceiveFormRouteKey]: {
-      children: {
-        [WalletConstants.confirmFormRouteKey]: {
-          children: {},
-          component: ConfirmForm,
-          tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true, underNotch: true}),
+      postProof: {
+        children: {
+          confirmOrPending: {
+            component: ConfirmOrPending,
+          },
         },
-        [WalletConstants.chooseAssetFormRouteKey]: {
-          children: {},
-          component: ChooseAsset,
-          tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile, renderTopmostOnly: true}),
-        },
-        qrScan: {
-          component: QRScan,
-          tags: makeLeafTags({layerOnTop: true, underNotch: true}),
-        },
+        component: PostProof,
       },
-      component: SendForm,
-      tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true, underNotch: true}),
     },
-  },
-  component: Profile,
-  initialState: {currentFriendshipsTab: 'Followers'},
-  tags: makeLeafTags({title: 'Profile', underNotch: true}),
-})
+    component: ProveEnterUsername,
+  })
+
+  return makeRouteDefNode({
+    children: {
+      addToTeam: {
+        children: {
+          controlledRolePicker: {
+            children: {},
+            component: ControlledRolePicker,
+            tags: makeLeafTags({layerOnTop: !isMobile}),
+          },
+        },
+        component: AddToTeam,
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
+      editAvatar: {
+        component: EditAvatar,
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
+      editAvatarPlaceholder: {
+        component: EditAvatarPlaceholder,
+      },
+      editProfile: {
+        component: EditProfile,
+      },
+      nonUserProfile: {
+        children: {
+          profile: profileRoute,
+        },
+        component: NonUserProfile,
+      },
+      pgp: pgpRoutes,
+      profile: profileRoute,
+      proveEnterUsername,
+      proveWebsiteChoice: {
+        children: {
+          proveEnterUsername,
+        },
+        component: ProveWebsiteChoice,
+      },
+      revoke: {
+        component: RevokeContainer,
+      },
+      search: {
+        children: {},
+        component: SearchPopup,
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
+      showcaseTeamOffer: {
+        children: {},
+        component: ShowcaseTeamOffer,
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
+      [WalletConstants.sendReceiveFormRouteKey]: {
+        children: {
+          [WalletConstants.confirmFormRouteKey]: {
+            children: {},
+            component: ConfirmForm,
+            tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true, underNotch: true}),
+          },
+          [WalletConstants.chooseAssetFormRouteKey]: {
+            children: {},
+            component: ChooseAsset,
+            tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile, renderTopmostOnly: true}),
+          },
+          qrScan: {
+            component: QRScan,
+            tags: makeLeafTags({layerOnTop: true, underNotch: true}),
+          },
+        },
+        component: SendForm,
+        tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true, underNotch: true}),
+      },
+    },
+    component: Profile,
+    initialState: {currentFriendshipsTab: 'Followers'},
+    tags: makeLeafTags({title: 'Profile', underNotch: true}),
+  })
+}
 
 export default profileRoute

--- a/shared/settings/nav/index.native.js
+++ b/shared/settings/nav/index.native.js
@@ -58,15 +58,6 @@ function SettingsNav(props: Props) {
                   }
                 : {}),
             },
-            {
-              ...(__DEV__
-                ? {
-                    icon: 'iconfont-nav-settings',
-                    onClick: () => props.onTabChange(Constants.devMenuTab),
-                    text: 'Dev menu',
-                  }
-                : {}),
-            },
           ],
           title: '',
         },

--- a/shared/settings/routes.desktop.js
+++ b/shared/settings/routes.desktop.js
@@ -1,90 +1,91 @@
 // @flow
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import * as Constants from '../constants/settings'
-import Settings from './'
-import LandingContainer from './landing/container'
-import UpdatePayment from './payment/container'
-import AdvancedContainer from './advanced/container'
-import FilesContainer from './files/container'
-import DBNukeConfirm from './db-nuke-confirm/container'
-import InvitationsContainer from './invites/container'
-import NotificationsContainer from './notifications/container'
-import ChatContainer from './chat/container'
-import DeleteContainer from './delete/container'
-import DeleteConfirm from './delete-confirm/container'
-import RemoveDevice from '../devices/device-revoke/container'
-import InviteGenerated from './invite-generated/container'
-import Passphrase from './passphrase/container'
-import UserEmail from './email/container'
-// import PlanDetails from './plan-details/container'
-import SecurityPrefs from '../fs/common/security-prefs-container.desktop'
 
-const routeTree = makeRouteDefNode({
-  children: {
-    [Constants.landingTab]: {
-      children: {
-        changeEmail: {
-          component: UserEmail,
+const routeTree = () => {
+  const Settings = require('./').default
+  const LandingContainer = require('./landing/container').default
+  const UpdatePayment = require('./payment/container').default
+  const AdvancedContainer = require('./advanced/container').default
+  const FilesContainer = require('./files/container').default
+  const DBNukeConfirm = require('./db-nuke-confirm/container').default
+  const InvitationsContainer = require('./invites/container').default
+  const NotificationsContainer = require('./notifications/container').default
+  const ChatContainer = require('./chat/container').default
+  const DeleteContainer = require('./delete/container').default
+  const DeleteConfirm = require('./delete-confirm/container').default
+  const RemoveDevice = require('../devices/device-revoke/container').default
+  const InviteGenerated = require('./invite-generated/container').default
+  const Passphrase = require('./passphrase/container').default
+  const UserEmail = require('./email/container').default
+  const SecurityPrefs = require('../fs/common/security-prefs-container.desktop').default
+  return makeRouteDefNode({
+    children: {
+      [Constants.landingTab]: {
+        children: {
+          changeEmail: {
+            component: UserEmail,
+          },
+          changePassphrase: {
+            component: Passphrase,
+          },
+          // changePlan: {
+          // component: PlanDetails,
+          // },
         },
-        changePassphrase: {
-          component: Passphrase,
-        },
-        // changePlan: {
-        // component: PlanDetails,
-        // },
+        component: LandingContainer,
       },
-      component: LandingContainer,
-    },
-    [Constants.updatePaymentTab]: {
-      component: UpdatePayment,
-    },
-    [Constants.invitationsTab]: {
-      children: {
-        inviteSent: {
-          component: InviteGenerated,
-        },
+      [Constants.updatePaymentTab]: {
+        component: UpdatePayment,
       },
-      component: InvitationsContainer,
-    },
-    [Constants.notificationsTab]: {
-      component: NotificationsContainer,
-    },
-    [Constants.deleteMeTab]: {
-      children: {
-        deleteConfirm: {
-          component: DeleteConfirm,
-          tags: makeLeafTags({modal: true}),
+      [Constants.invitationsTab]: {
+        children: {
+          inviteSent: {
+            component: InviteGenerated,
+          },
         },
-        removeDevice: {
-          component: RemoveDevice,
-          tags: makeLeafTags({modal: true}),
-        },
+        component: InvitationsContainer,
       },
-      component: DeleteContainer,
-    },
-    [Constants.advancedTab]: {
-      children: {
-        dbNukeConfirm: {
-          component: DBNukeConfirm,
-          tags: makeLeafTags({modal: true}),
-        },
+      [Constants.notificationsTab]: {
+        component: NotificationsContainer,
       },
-      component: AdvancedContainer,
-    },
-    [Constants.fsTab]: {
-      children: {
-        securityPrefs: {
-          component: SecurityPrefs,
+      [Constants.deleteMeTab]: {
+        children: {
+          deleteConfirm: {
+            component: DeleteConfirm,
+            tags: makeLeafTags({modal: true}),
+          },
+          removeDevice: {
+            component: RemoveDevice,
+            tags: makeLeafTags({modal: true}),
+          },
         },
+        component: DeleteContainer,
       },
-      component: FilesContainer,
+      [Constants.advancedTab]: {
+        children: {
+          dbNukeConfirm: {
+            component: DBNukeConfirm,
+            tags: makeLeafTags({modal: true}),
+          },
+        },
+        component: AdvancedContainer,
+      },
+      [Constants.fsTab]: {
+        children: {
+          securityPrefs: {
+            component: SecurityPrefs,
+          },
+        },
+        component: FilesContainer,
+      },
+      [Constants.chatTab]: {
+        component: ChatContainer,
+      },
     },
-    [Constants.chatTab]: {
-      component: ChatContainer,
-    },
-  },
-  containerComponent: Settings,
-  defaultSelected: Constants.landingTab,
-})
+    containerComponent: Settings,
+    defaultSelected: Constants.landingTab,
+  })
+}
 
 export default routeTree

--- a/shared/settings/routes.native.js
+++ b/shared/settings/routes.native.js
@@ -1,73 +1,74 @@
 // @flow
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
-import Settings from './'
-import InvitationsContainer from './invites/container'
-import InviteGenerated from './invite-generated/container'
-import Feedback from './feedback-container'
-import DevicesRoute from '../devices/routes'
-import WalletsRoute from '../wallets/routes'
-import GitRoute from '../git/routes'
-import FilesRoute from '../fs/routes'
-import WebLinks from './web-links.native'
-import Passphrase from './passphrase/container'
-
-import About from './about-container'
-import NotificationsContainer from './notifications/container'
-import DBNukeConfirm from './db-nuke-confirm/container'
-import DeleteContainer from './delete/container'
-import RemoveDevice from '../devices/device-revoke/container'
-import DeleteConfirm from './delete-confirm/container'
-import AdvancedContainer from './advanced/container'
-import ChatContainer from './chat/container'
-import Screenprotector from './screenprotector-container.native'
-
 import * as Constants from '../constants/settings'
 
-const routeTree = makeRouteDefNode({
-  children: {
-    [Constants.aboutTab]: {
-      children: {
-        privacyPolicy: {component: WebLinks},
-        terms: {component: WebLinks},
-      },
-      component: About,
-    },
-    [Constants.passphraseTab]: {component: Passphrase},
-    [Constants.feedbackTab]: {component: Feedback},
-    [Constants.landingTab]: {component: About},
-    [Constants.screenprotectorTab]: {component: Screenprotector},
-    [Constants.invitationsTab]: {
-      children: {
-        inviteSent: {
-          component: InviteGenerated,
+const routeTree = () => {
+  const Settings = require('./').default
+  const InvitationsContainer = require('./invites/container').default
+  const InviteGenerated = require('./invite-generated/container').default
+  const Feedback = require('./feedback-container').default
+  const DevicesRoute = require('../devices/routes').default
+  const WalletsRoute = require('../wallets/routes').default
+  const GitRoute = require('../git/routes').default
+  const FilesRoute = require('../fs/routes').default
+  const WebLinks = require('./web-links.native').default
+  const Passphrase = require('./passphrase/container').default
+  const About = require('./about-container').default
+  const NotificationsContainer = require('./notifications/container').default
+  const DBNukeConfirm = require('./db-nuke-confirm/container').default
+  const DeleteContainer = require('./delete/container').default
+  const RemoveDevice = require('../devices/device-revoke/container').default
+  const DeleteConfirm = require('./delete-confirm/container').default
+  const AdvancedContainer = require('./advanced/container').default
+  const ChatContainer = require('./chat/container').default
+  const Screenprotector = require('./screenprotector-container.native').default
+
+  return makeRouteDefNode({
+    children: {
+      [Constants.aboutTab]: {
+        children: {
+          privacyPolicy: {component: WebLinks},
+          terms: {component: WebLinks},
         },
+        component: About,
       },
-      component: InvitationsContainer,
-    },
-    [Constants.fsTab]: FilesRoute,
-    [Constants.devicesTab]: DevicesRoute,
-    [Constants.walletsTab]: WalletsRoute,
-    [Constants.gitTab]: GitRoute,
-    [Constants.notificationsTab]: {component: NotificationsContainer},
-    [Constants.chatTab]: {component: ChatContainer},
-    [Constants.advancedTab]: {
-      children: {
-        dbNukeConfirm: {
-          component: DBNukeConfirm,
-          tags: makeLeafTags({modal: true}),
+      [Constants.passphraseTab]: {component: Passphrase},
+      [Constants.feedbackTab]: {component: Feedback},
+      [Constants.landingTab]: {component: About},
+      [Constants.screenprotectorTab]: {component: Screenprotector},
+      [Constants.invitationsTab]: {
+        children: {
+          inviteSent: {
+            component: InviteGenerated,
+          },
         },
+        component: InvitationsContainer,
       },
-      component: AdvancedContainer,
-    },
-    [Constants.deleteMeTab]: {
-      children: {
-        deleteConfirm: {component: DeleteConfirm},
-        removeDevice: {component: RemoveDevice},
+      [Constants.fsTab]: FilesRoute,
+      [Constants.devicesTab]: DevicesRoute,
+      [Constants.walletsTab]: WalletsRoute,
+      [Constants.gitTab]: GitRoute,
+      [Constants.notificationsTab]: {component: NotificationsContainer},
+      [Constants.chatTab]: {component: ChatContainer},
+      [Constants.advancedTab]: {
+        children: {
+          dbNukeConfirm: {
+            component: DBNukeConfirm,
+            tags: makeLeafTags({modal: true}),
+          },
+        },
+        component: AdvancedContainer,
       },
-      component: DeleteContainer,
+      [Constants.deleteMeTab]: {
+        children: {
+          deleteConfirm: {component: DeleteConfirm},
+          removeDevice: {component: RemoveDevice},
+        },
+        component: DeleteContainer,
+      },
     },
-  },
-  component: Settings,
-})
+    component: Settings,
+  })
+}
 
 export default routeTree

--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -1,135 +1,136 @@
 // @flow
-import TeamsContainer from './container'
-import {MaybePopupHoc} from '../common-adapters'
-import {makeRouteDefNode, makeLeafTags} from '../route-tree'
-import AddPeopleDialog from './add-people/container'
-import InviteByEmailDialog from './invite-by-email/container'
-import NewTeamDialog from './new-team/container'
-import JoinTeamDialog from './join-team/container'
-import ManageChannels from '../chat/manage-channels/container'
-import EditChannel from '../chat/manage-channels/edit-channel-container'
-import EditTeamAvatar from '../profile/edit-avatar/container'
-import EditTeamDescription from './edit-team-description/container'
-import CreateChannel from '../chat/create-channel/container'
-import ReallyLeaveTeam from './really-leave-team/container'
-import RolePicker from './role-picker/container'
-import ControlledRolePicker from './role-picker/controlled-container'
-import Member from './team/member/container'
-import ReallyRemoveMember from './team/really-remove-member/container'
-import Team from './team/container'
-import RetentionWarning from './team/settings-tab/retention/warning/container'
 import {isMobile} from '../constants/platform'
+import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 
-const makeManageChannels = {
-  createChannel: {
-    children: {},
-    component: CreateChannel,
-    tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile}),
-  },
-  manageChannels: {
-    children: {
-      editChannel: {
-        children: {},
-        component: MaybePopupHoc(false)(EditChannel),
-        tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile}),
-      },
-    },
-    component: ManageChannels,
-    tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile}),
-  },
-}
-
-const rolePicker = {
-  children: {},
-  component: RolePicker,
-  tags: makeLeafTags({layerOnTop: !isMobile}),
-}
-const reallyLeaveTeam = {
-  children: {},
-  component: ReallyLeaveTeam,
-  tags: makeLeafTags({layerOnTop: !isMobile}),
-}
-const controlledRolePicker = {
-  children: {},
-  component: ControlledRolePicker,
-  tags: makeLeafTags({layerOnTop: !isMobile}),
-}
-const reallyRemoveMember = {
-  children: {},
-  component: ReallyRemoveMember,
-  tags: makeLeafTags({layerOnTop: !isMobile}),
-}
-
-const showNewTeamDialog = {
-  children: {},
-  component: NewTeamDialog,
-  tags: makeLeafTags({layerOnTop: !isMobile}),
-}
-
-const makeAddPeopleOptions = {
-  addPeople: {
-    children: {controlledRolePicker},
-    component: AddPeopleDialog,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
-  },
-  inviteByEmail: {
-    children: {controlledRolePicker},
-    component: InviteByEmailDialog,
-    tags: makeLeafTags({layerOnTop: !isMobile}),
-  },
-}
-
-const retentionWarning = {
-  children: {},
-  component: RetentionWarning,
-  tags: makeLeafTags({layerOnTop: !isMobile}),
-}
-
-const teamRoute = makeRouteDefNode({
-  children: {
-    ...makeManageChannels,
-    ...makeAddPeopleOptions,
-    controlledRolePicker,
-    editTeamAvatar: {
-      component: EditTeamAvatar,
-      tags: makeLeafTags({layerOnTop: !isMobile}),
-    },
-    editTeamDescription: {
+const routeTree = () => {
+  const TeamsContainer = require('./container').default
+  const {MaybePopupHoc} = require('../common-adapters')
+  const AddPeopleDialog = require('./add-people/container').default
+  const InviteByEmailDialog = require('./invite-by-email/container').default
+  const NewTeamDialog = require('./new-team/container').default
+  const JoinTeamDialog = require('./join-team/container').default
+  const ManageChannels = require('../chat/manage-channels/container').default
+  const EditChannel = require('../chat/manage-channels/edit-channel-container').default
+  const EditTeamAvatar = require('../profile/edit-avatar/container').default
+  const EditTeamDescription = require('./edit-team-description/container').default
+  const CreateChannel = require('../chat/create-channel/container').default
+  const ReallyLeaveTeam = require('./really-leave-team/container').default
+  const RolePicker = require('./role-picker/container').default
+  const ControlledRolePicker = require('./role-picker/controlled-container').default
+  const Member = require('./team/member/container').default
+  const ReallyRemoveMember = require('./team/really-remove-member/container').default
+  const Team = require('./team/container').default
+  const RetentionWarning = require('./team/settings-tab/retention/warning/container').default
+  const makeManageChannels = {
+    createChannel: {
       children: {},
-      component: MaybePopupHoc(true)(EditTeamDescription),
-      tags: makeLeafTags({layerOnTop: !isMobile}),
+      component: CreateChannel,
+      tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile}),
     },
-    member: {
+    manageChannels: {
       children: {
-        reallyLeaveTeam,
-        reallyRemoveMember,
-        rolePicker,
+        editChannel: {
+          children: {},
+          component: MaybePopupHoc(false)(EditChannel),
+          tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile}),
+        },
       },
-      component: Member,
+      component: ManageChannels,
+      tags: makeLeafTags({hideStatusBar: true, layerOnTop: !isMobile}),
     },
-    reallyLeaveTeam,
-    reallyRemoveMember,
-    retentionWarning,
-    rolePicker,
-    showNewTeamDialog,
-    team: () => teamRoute,
-  },
-  component: Team,
-})
+  }
 
-const routeTree = makeRouteDefNode({
-  children: {
-    ...makeManageChannels,
-    showJoinTeamDialog: {
-      children: {},
-      component: JoinTeamDialog,
+  const rolePicker = {
+    children: {},
+    component: RolePicker,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  }
+  const reallyLeaveTeam = {
+    children: {},
+    component: ReallyLeaveTeam,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  }
+  const controlledRolePicker = {
+    children: {},
+    component: ControlledRolePicker,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  }
+  const reallyRemoveMember = {
+    children: {},
+    component: ReallyRemoveMember,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  }
+
+  const showNewTeamDialog = {
+    children: {},
+    component: NewTeamDialog,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  }
+
+  const makeAddPeopleOptions = {
+    addPeople: {
+      children: {controlledRolePicker},
+      component: AddPeopleDialog,
       tags: makeLeafTags({layerOnTop: !isMobile}),
     },
-    showNewTeamDialog,
-    team: teamRoute,
-  },
-  component: TeamsContainer,
-  tags: makeLeafTags({title: 'Teams'}),
-})
+    inviteByEmail: {
+      children: {controlledRolePicker},
+      component: InviteByEmailDialog,
+      tags: makeLeafTags({layerOnTop: !isMobile}),
+    },
+  }
+
+  const retentionWarning = {
+    children: {},
+    component: RetentionWarning,
+    tags: makeLeafTags({layerOnTop: !isMobile}),
+  }
+
+  const teamRoute = makeRouteDefNode({
+    children: {
+      ...makeManageChannels,
+      ...makeAddPeopleOptions,
+      controlledRolePicker,
+      editTeamAvatar: {
+        component: EditTeamAvatar,
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
+      editTeamDescription: {
+        children: {},
+        component: MaybePopupHoc(true)(EditTeamDescription),
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
+      member: {
+        children: {
+          reallyLeaveTeam,
+          reallyRemoveMember,
+          rolePicker,
+        },
+        component: Member,
+      },
+      reallyLeaveTeam,
+      reallyRemoveMember,
+      retentionWarning,
+      rolePicker,
+      showNewTeamDialog,
+      team: () => teamRoute,
+    },
+    component: Team,
+  })
+  return makeRouteDefNode({
+    children: {
+      ...makeManageChannels,
+      showJoinTeamDialog: {
+        children: {},
+        component: JoinTeamDialog,
+        tags: makeLeafTags({layerOnTop: !isMobile}),
+      },
+      showNewTeamDialog,
+      team: teamRoute,
+    },
+    component: TeamsContainer,
+    tags: makeLeafTags({title: 'Teams'}),
+  })
+}
 
 export default routeTree

--- a/shared/wallets/routes.js
+++ b/shared/wallets/routes.js
@@ -2,140 +2,142 @@
 import * as Constants from '../constants/wallets'
 import {makeRouteDefNode, makeLeafTags} from '../route-tree'
 import {isMobile} from '../constants/platform'
-import CreateNewAccount from './create-account/container'
-import LinkExisting from './link-existing/container'
-import WalletsAndDetails from './wallets-and-details/container'
-import ReceiveModal from './receive-modal/container'
-import ExportSecretKey from './export-secret-key/container'
-import TransactionDetails from './transaction-details/container'
-import AccountSettings from './wallet/settings/container'
-import {
-  SetDefaultAccountPopup,
-  RemoveAccountPopup,
-  ReallyRemoveAccountPopup,
-  RenameAccountPopup,
-} from './wallet/settings/popups'
-import SendForm from './send-form/container'
-import QRScan from './qr-scan/container'
-import ConfirmForm from './confirm-form/container'
-import Wallet from './wallet/container'
-import ChooseAsset from './send-form/choose-asset/container'
-import WalletsList from './wallet-list/container'
 
-const createNewAccount = {
-  children: {},
-  component: CreateNewAccount,
-  tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
-}
+const routeTree = () => {
+  const CreateNewAccount = require('./create-account/container').default
+  const LinkExisting = require('./link-existing/container').default
+  const WalletsAndDetails = require('./wallets-and-details/container').default
+  const ReceiveModal = require('./receive-modal/container').default
+  const ExportSecretKey = require('./export-secret-key/container').default
+  const TransactionDetails = require('./transaction-details/container').default
+  const AccountSettings = require('./wallet/settings/container').default
+  const {
+    SetDefaultAccountPopup,
+    RemoveAccountPopup,
+    ReallyRemoveAccountPopup,
+    RenameAccountPopup,
+  } = require('./wallet/settings/popups')
+  const SendForm = require('./send-form/container').default
+  const QRScan = require('./qr-scan/container').default
+  const ConfirmForm = require('./confirm-form/container').default
+  const Wallet = require('./wallet/container').default
+  const ChooseAsset = require('./send-form/choose-asset/container').default
+  const WalletsList = require('./wallet-list/container').default
 
-const linkExisting = {
-  children: {},
-  component: LinkExisting,
-  tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
-}
-
-const walletChildren = {
-  createNewAccount,
-  exportSecretKey: {
+  const createNewAccount = {
     children: {},
-    component: ExportSecretKey,
+    component: CreateNewAccount,
     tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
-  },
-  linkExisting,
-  receive: {
+  }
+
+  const linkExisting = {
     children: {},
-    component: ReceiveModal,
+    component: LinkExisting,
     tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
-  },
-  [Constants.sendReceiveFormRouteKey]: {
-    children: {
-      [Constants.confirmFormRouteKey]: {
-        children: {},
-        component: ConfirmForm,
-        tags: makeLeafTags({
-          layerOnTop: !isMobile,
-          renderTopmostOnly: true,
-          underNotch: true,
-        }),
-      },
-      createNewAccount,
-      linkExisting,
-      [Constants.chooseAssetFormRouteKey]: {
-        children: {},
-        component: ChooseAsset,
-        tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
-      },
-      qrScan: {
-        component: QRScan,
-        tags: makeLeafTags({layerOnTop: true, underNotch: true}),
-      },
+  }
+
+  const walletChildren = {
+    createNewAccount,
+    exportSecretKey: {
+      children: {},
+      component: ExportSecretKey,
+      tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
     },
-    component: SendForm,
-    tags: makeLeafTags({
-      layerOnTop: !isMobile,
-      renderTopmostOnly: true,
-      underNotch: true,
-    }),
-  },
-  settings: {
-    children: {
-      createNewAccount,
-      linkExisting,
-      removeAccount: {
-        children: {
-          reallyRemoveAccount: {
-            children: {},
-            component: ReallyRemoveAccountPopup,
-            tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
-          },
+    linkExisting,
+    receive: {
+      children: {},
+      component: ReceiveModal,
+      tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
+    },
+    [Constants.sendReceiveFormRouteKey]: {
+      children: {
+        [Constants.confirmFormRouteKey]: {
+          children: {},
+          component: ConfirmForm,
+          tags: makeLeafTags({
+            layerOnTop: !isMobile,
+            renderTopmostOnly: true,
+            underNotch: true,
+          }),
         },
-        component: RemoveAccountPopup,
-        tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
+        createNewAccount,
+        linkExisting,
+        [Constants.chooseAssetFormRouteKey]: {
+          children: {},
+          component: ChooseAsset,
+          tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
+        },
+        qrScan: {
+          component: QRScan,
+          tags: makeLeafTags({layerOnTop: true, underNotch: true}),
+        },
       },
-      renameAccount: {
-        children: {},
-        component: RenameAccountPopup,
-        tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
-      },
-      setDefaultAccount: {
-        children: {},
-        component: SetDefaultAccountPopup,
-        tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
-      },
+      component: SendForm,
+      tags: makeLeafTags({
+        layerOnTop: !isMobile,
+        renderTopmostOnly: true,
+        underNotch: true,
+      }),
     },
-    component: AccountSettings,
-  },
-  transactionDetails: {
-    children: {
-      createNewAccount,
-      linkExisting,
-    },
-    component: TransactionDetails,
-  },
-}
-
-const routeTree = isMobile
-  ? makeRouteDefNode({
+    settings: {
       children: {
         createNewAccount,
         linkExisting,
-        wallet: {
-          children: walletChildren,
-          component: Wallet,
+        removeAccount: {
+          children: {
+            reallyRemoveAccount: {
+              children: {},
+              component: ReallyRemoveAccountPopup,
+              tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
+            },
+          },
+          component: RemoveAccountPopup,
+          tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
+        },
+        renameAccount: {
+          children: {},
+          component: RenameAccountPopup,
+          tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
+        },
+        setDefaultAccount: {
+          children: {},
+          component: SetDefaultAccountPopup,
+          tags: makeLeafTags({layerOnTop: !isMobile, renderTopmostOnly: true}),
         },
       },
-      component: WalletsList,
-      tags: makeLeafTags({title: 'Wallets'}),
-    })
-  : makeRouteDefNode({
+      component: AccountSettings,
+    },
+    transactionDetails: {
       children: {
-        wallet: {
-          children: walletChildren,
-          component: Wallet,
-        },
+        createNewAccount,
+        linkExisting,
       },
-      containerComponent: WalletsAndDetails,
-      defaultSelected: 'wallet',
-    })
+      component: TransactionDetails,
+    },
+  }
+  return isMobile
+    ? makeRouteDefNode({
+        children: {
+          createNewAccount,
+          linkExisting,
+          wallet: {
+            children: walletChildren,
+            component: Wallet,
+          },
+        },
+        component: WalletsList,
+        tags: makeLeafTags({title: 'Wallets'}),
+      })
+    : makeRouteDefNode({
+        children: {
+          wallet: {
+            children: walletChildren,
+            component: Wallet,
+          },
+        },
+        containerComponent: WalletsAndDetails,
+        defaultSelected: 'wallet',
+      })
+}
 
 export default routeTree


### PR DESCRIPTION
This uses requires to defer loading subsections of the apps in the router configs. When we have new routing we can do this automatically and do it per screen, but until then get the top level tab routes going

much easier to read w/ whitespace: https://github.com/keybase/client/pull/15229/files?utf8=%E2%9C%93&diff=unified&w=1

