### PR TITLE
bad object types in comparison

### DIFF
--- a/shared/actions/platform-specific/index.desktop.js
+++ b/shared/actions/platform-specific/index.desktop.js
@@ -200,9 +200,9 @@ const setupEngineListeners = () => {
         console.warn('Error in sending pgpPgpStorageDismissRpc:', err)
       })
     },
-    'keybase.1.NotifyService.shutdown': code => {
-      if (isWindows && code !== RPCTypes.ctlExitCode.restart) {
-        console.log('Quitting due to service shutdown')
+    'keybase.1.NotifyService.shutdown': request => {
+      if (isWindows && request.code !== RPCTypes.ctlExitCode.restart) {
+        console.log('Quitting due to service shutdown with code: ', request.code)
         // Quit just the app, not the service
         SafeElectron.getApp().quit()
       }


### PR DESCRIPTION
Turns out the argument was a object with a property named "code". This definitely used to work - is this an Electron change? Also, how is this not caught with flow or anything?