### PR TITLE
Fix git repo data merge and remove unused field from state

### DIFF
--- a/shared/actions/__tests__/git.test.js
+++ b/shared/actions/__tests__/git.test.js
@@ -123,7 +123,6 @@ const loadedStore = {
   ...initialStore,
   git: initialStore.git.merge({
     idToInfo: gitRepos.reduce((acc, r) => acc.set(r.id, I.Record(r)()), I.Map()),
-    lastLoad: nowTimestamp,
   }),
 }
 

--- a/shared/constants/git.js
+++ b/shared/constants/git.js
@@ -27,7 +27,6 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   error: null,
   idToInfo: I.Map(),
   isNew: I.Set(),
-  lastLoad: null,
 })
 
 const parseRepoResult = (result: RPCTypes.GitRepoResult): ?Types.GitInfo => {

--- a/shared/constants/types/git.js
+++ b/shared/constants/types/git.js
@@ -17,7 +17,6 @@ export type _GitInfo = {
 export type GitInfo = I.RecordOf<_GitInfo>
 export type _State = {
   error: ?Error,
-  lastLoad: ?number,
   idToInfo: I.Map<string, GitInfo>,
   isNew: I.Set<string>,
 }

--- a/shared/reducers/git.js
+++ b/shared/reducers/git.js
@@ -14,7 +14,6 @@ export default function(state: Types.State = initialState, action: GitGen.Action
     case GitGen.loaded:
       return state.merge({
         idToInfo: state.idToInfo.merge(action.payload.repos),
-        lastLoad: Date.now(),
       })
     case GitGen.setError:
       return state.merge({error: action.payload.error})

--- a/shared/reducers/git.js
+++ b/shared/reducers/git.js
@@ -13,7 +13,7 @@ export default function(state: Types.State = initialState, action: GitGen.Action
       return initialState
     case GitGen.loaded:
       return state.merge({
-        idToInfo: I.Map(action.payload.repos),
+        idToInfo: state.idToInfo.merge(action.payload.repos),
         lastLoad: Date.now(),
       })
     case GitGen.setError:


### PR DESCRIPTION
First commit is the fix for dropped data when clicking "Announce pushes". Second is removing `state.git.lastLoad`, which I couldn't find a use of. r? @keybase/react-hackers 