### PR TITLE
stop ios from scrolling down as new content comes in if you're scrolled up

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.native.js
+++ b/shared/chat/conversation/list-area/normal/index.native.js
@@ -67,6 +67,11 @@ class ConversationList extends React.PureComponent<Props> {
     }
   }
 
+  // not highly documented. keeps new content from shifting around the list if you're scrolled up
+  _maintainVisibleContentPosition = {
+    minIndexForVisible: 0,
+  }
+
   render() {
     return (
       <ErrorBoundary>
@@ -77,6 +82,7 @@ class ConversationList extends React.PureComponent<Props> {
             getItem={this._getItem}
             getItemCount={this._getItemCount}
             renderItem={this._renderItem}
+            maintainVisibleContentPosition={this._maintainVisibleContentPosition}
             onViewableItemsChanged={this._onViewableItemsChanged}
             keyboardShouldPersistTaps="handled"
             keyExtractor={this._keyExtractor}


### PR DESCRIPTION
- [x] use maintainVisibleContentPosition prop to keep scrollview in place as new content comes in

to repro, on master load up a thread and scroll up a little bit. on another client message that thread. each message will push your mobile thread around, making reading back super annoying
this pr stops that from happening

@keybase/react-hackers 