### PR TITLE
allow for unsent text to be set in the store and fed into the input box CORE-9795

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1216,7 +1216,9 @@ func (h *Server) runStellarSendUI(ctx context.Context, sessionID int, uid gregor
 	if err := ui.ChatStellarShowConfirm(ctx); err != nil {
 		return res, err
 	}
-	defer ui.ChatStellarDone(ctx)
+	defer func() {
+		ui.ChatStellarDone(ctx, err != nil)
+	}()
 	uiSummary, toSend, err := h.G().StellarSender.DescribePayments(ctx, uid, convID, parsedPayments)
 	if err != nil {
 		ui.ChatStellarDataError(ctx, err.Error())

--- a/go/client/chat_ui.go
+++ b/go/client/chat_ui.go
@@ -292,6 +292,6 @@ func (c *ChatUI) ChatStellarDataError(ctx context.Context, arg chat1.ChatStellar
 	return false, errors.New(msg)
 }
 
-func (c *ChatUI) ChatStellarDone(ctx context.Context, sessionID int) error {
+func (c *ChatUI) ChatStellarDone(ctx context.Context, arg chat1.ChatStellarDoneArg) error {
 	return nil
 }

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -1103,7 +1103,7 @@ func (c *ChatUI) ChatStellarDataError(ctx context.Context, msg string) (bool, er
 	return false, nil
 }
 
-func (c *ChatUI) ChatStellarDone(ctx context.Context) error {
+func (c *ChatUI) ChatStellarDone(ctx context.Context, canceled bool) error {
 	c.StellarDone <- struct{}{}
 	return nil
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -396,7 +396,7 @@ type ChatUI interface {
 	ChatStellarShowConfirm(context.Context) error
 	ChatStellarDataConfirm(context.Context, chat1.UIChatPaymentSummary) (bool, error)
 	ChatStellarDataError(context.Context, string) (bool, error)
-	ChatStellarDone(context.Context) error
+	ChatStellarDone(context.Context, bool) error
 }
 
 type PromptDefault int

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -1073,7 +1073,8 @@ type ChatStellarDataErrorArg struct {
 }
 
 type ChatStellarDoneArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
+	SessionID int  `codec:"sessionID" json:"sessionID"`
+	Canceled  bool `codec:"canceled" json:"canceled"`
 }
 
 type ChatUiInterface interface {
@@ -1094,7 +1095,7 @@ type ChatUiInterface interface {
 	ChatStellarShowConfirm(context.Context, int) error
 	ChatStellarDataConfirm(context.Context, ChatStellarDataConfirmArg) (bool, error)
 	ChatStellarDataError(context.Context, ChatStellarDataErrorArg) (bool, error)
-	ChatStellarDone(context.Context, int) error
+	ChatStellarDone(context.Context, ChatStellarDoneArg) error
 }
 
 func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
@@ -1367,7 +1368,7 @@ func ChatUiProtocol(i ChatUiInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[1]ChatStellarDoneArg)(nil), args)
 						return
 					}
-					err = i.ChatStellarDone(ctx, typedArgs[0].SessionID)
+					err = i.ChatStellarDone(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -1467,8 +1468,7 @@ func (c ChatUiClient) ChatStellarDataError(ctx context.Context, __arg ChatStella
 	return
 }
 
-func (c ChatUiClient) ChatStellarDone(ctx context.Context, sessionID int) (err error) {
-	__arg := ChatStellarDoneArg{SessionID: sessionID}
+func (c ChatUiClient) ChatStellarDone(ctx context.Context, __arg ChatStellarDoneArg) (err error) {
 	err = c.Cli.Call(ctx, "chat.1.chatUi.chatStellarDone", []interface{}{__arg}, nil)
 	return
 }

--- a/go/service/remote_chat_ui.go
+++ b/go/service/remote_chat_ui.go
@@ -94,6 +94,9 @@ func (r *RemoteChatUI) ChatStellarDataError(ctx context.Context, msg string) (bo
 	})
 }
 
-func (r *RemoteChatUI) ChatStellarDone(ctx context.Context) error {
-	return r.cli.ChatStellarDone(ctx, r.sessionID)
+func (r *RemoteChatUI) ChatStellarDone(ctx context.Context, canceled bool) error {
+	return r.cli.ChatStellarDone(ctx, chat1.ChatStellarDoneArg{
+		SessionID: r.sessionID,
+		Canceled:  canceled,
+	})
 }

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -248,5 +248,5 @@ protocol chatUi {
   void chatStellarShowConfirm(int sessionID);
   boolean chatStellarDataConfirm(int sessionID, UIChatPaymentSummary summary);
   boolean chatStellarDataError(int sessionID, string message);
-  void chatStellarDone(int sessionID);
+  void chatStellarDone(int sessionID, boolean canceled);
 }

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -1112,6 +1112,10 @@
         {
           "name": "sessionID",
           "type": "int"
+        },
+        {
+          "name": "canceled",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/shared/actions/chat2-gen.js
+++ b/shared/actions/chat2-gen.js
@@ -90,6 +90,7 @@ export const setPendingConversationExistingConversationIDKey = 'chat2:setPending
 export const setPendingConversationUsers = 'chat2:setPendingConversationUsers'
 export const setPendingMode = 'chat2:setPendingMode'
 export const setPendingStatus = 'chat2:setPendingStatus'
+export const setUnsentText = 'chat2:setUnsentText'
 export const setWalletsOld = 'chat2:setWalletsOld'
 export const staticConfigLoaded = 'chat2:staticConfigLoaded'
 export const toggleLocalReaction = 'chat2:toggleLocalReaction'
@@ -189,6 +190,7 @@ type _SetPendingConversationExistingConversationIDKeyPayload = $ReadOnly<{|conve
 type _SetPendingConversationUsersPayload = $ReadOnly<{|users: Array<string>, fromSearch: boolean|}>
 type _SetPendingModePayload = $ReadOnly<{|pendingMode: Types.PendingMode, noneDestination?: 'inbox' | 'thread'|}>
 type _SetPendingStatusPayload = $ReadOnly<{|pendingStatus: Types.PendingStatus|}>
+type _SetUnsentTextPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey, text: HiddenString|}>
 type _SetWalletsOldPayload = void
 type _StaticConfigLoadedPayload = $ReadOnly<{|staticConfig: Types.StaticConfig|}>
 type _ToggleLocalReactionPayload = $ReadOnly<{|conversationIDKey: Types.ConversationIDKey, emoji: string, targetOrdinal: Types.Ordinal, username: string|}>
@@ -268,6 +270,10 @@ export const createSetPaymentConfirmInfoError = (payload: _SetPaymentConfirmInfo
  * Set the remote exploding mode for a conversation.
  */
 export const createSetConvExplodingMode = (payload: _SetConvExplodingModePayload) => ({payload, type: setConvExplodingMode})
+/**
+ * Set unsent text for a conversation
+ */
+export const createSetUnsentText = (payload: _SetUnsentTextPayload) => ({payload, type: setUnsentText})
 /**
  * Set whether exploding messages are a new feature or not.
  */
@@ -468,6 +474,7 @@ export type SetPendingConversationExistingConversationIDKeyPayload = {|+payload:
 export type SetPendingConversationUsersPayload = {|+payload: _SetPendingConversationUsersPayload, +type: 'chat2:setPendingConversationUsers'|}
 export type SetPendingModePayload = {|+payload: _SetPendingModePayload, +type: 'chat2:setPendingMode'|}
 export type SetPendingStatusPayload = {|+payload: _SetPendingStatusPayload, +type: 'chat2:setPendingStatus'|}
+export type SetUnsentTextPayload = {|+payload: _SetUnsentTextPayload, +type: 'chat2:setUnsentText'|}
 export type SetWalletsOldPayload = {|+payload: _SetWalletsOldPayload, +type: 'chat2:setWalletsOld'|}
 export type StaticConfigLoadedPayload = {|+payload: _StaticConfigLoadedPayload, +type: 'chat2:staticConfigLoaded'|}
 export type ToggleLocalReactionPayload = {|+payload: _ToggleLocalReactionPayload, +type: 'chat2:toggleLocalReaction'|}
@@ -566,6 +573,7 @@ export type Actions =
   | SetPendingConversationUsersPayload
   | SetPendingModePayload
   | SetPendingStatusPayload
+  | SetUnsentTextPayload
   | SetWalletsOldPayload
   | StaticConfigLoadedPayload
   | ToggleLocalReactionPayload

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1244,11 +1244,14 @@ function* messageSend(state, action) {
       })
     ),
   ]
-  const onHideConfirm = () =>
+  const onHideConfirm = ({canceled}) =>
     Saga.callUntyped(function*() {
       const state = yield* Saga.selectState()
       if (getPath(state.routeTree.routeState).last() === routeName) {
         yield Saga.put(RouteTreeGen.createNavigateUp())
+      }
+      if (canceled) {
+        yield Saga.put(Chat2Gen.createSetUnsentText({conversationIDKey, text}))
       }
     })
   const onDataConfirm = ({summary}, response) => {

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -524,6 +524,11 @@
     "confirmScreenResponse": {
       "_description": "User responded to the chat Stellar confirm screen",
       "accept": "boolean"
+    },
+    "setUnsentText": {
+      "_description": "Set unsent text for a conversation",
+      "conversationIDKey": "Types.ConversationIDKey",
+      "text": "HiddenString"
     }
   }
 }

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -189,6 +189,11 @@ class Input extends React.Component<InputProps, InputState> {
         this._setText('')
         return
       }
+
+      if (this.props.unsentTextRefresh) {
+        this._setText(this.props.getUnsentText(), true)
+        return
+      }
     }
 
     // Inject the appropriate text when quoting. Keep track of the

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -118,6 +118,7 @@ const InputContainer = (props: Props) => {
       {fullName: 'Alex Gessner', username: 'xgess'},
     ]),
     typing: props.typing,
+    unsentTextRefresh: false,
   }
 
   return (

--- a/shared/chat/conversation/input-area/normal/types.js
+++ b/shared/chat/conversation/input-area/normal/types.js
@@ -33,6 +33,8 @@ type CommonProps = {|
   getUnsentText: () => string,
   setUnsentText: (text: string) => void,
   sendTyping: (text: string) => void,
+
+  unsentTextRefresh: boolean,
 |}
 
 type InputProps = {|

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -48,6 +48,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   typingMap: I.Map(),
   unfurlPromptMap: I.Map(),
   unreadMap: I.Map(),
+  unsentTextMap: I.Map(),
 
   // Team Building
   ...TeamBuildingConstants.makeSubState(),

--- a/shared/constants/types/chat2/index.js
+++ b/shared/constants/types/chat2/index.js
@@ -6,6 +6,7 @@ import * as Meta from './meta'
 import * as Message from './message'
 import * as Wallet from '../wallets'
 import * as TeamBuildingTypes from '../team-building'
+import HiddenString from '../../../util/hidden-string'
 
 export type PendingMode =
   | 'none' // no pending
@@ -73,6 +74,7 @@ export type _State = {
   attachmentFullscreenMessage: ?Message.Message,
   paymentConfirmInfo: ?PaymentConfirmInfo, // chat payment confirm screen data
   paymentStatusMap: I.Map<Wallet.PaymentID, Message.ChatPaymentInfo>,
+  unsentTextMap: I.Map<Common.ConversationIDKey, HiddenString>,
 } & TeamBuildingTypes.TeamBuildingSubState
 
 export type State = I.RecordOf<_State>

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -169,7 +169,7 @@ export type MessageTypes = {|
     outParam: Boolean,
   |},
   'chat.1.chatUi.chatStellarDone': {|
-    inParam: void,
+    inParam: $ReadOnly<{|canceled: Boolean|}>,
     outParam: void,
   |},
   'chat.1.chatUi.chatStellarShowConfirm': {|

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -873,6 +873,10 @@ const rootReducer = (
         return state.update('explodingModeLocks', el => el.delete(conversationIDKey))
       }
       return alreadyLocked ? state : state.setIn(['explodingModeLocks', conversationIDKey], mode)
+    case Chat2Gen.setUnsentText:
+      return state.update('unsentTextMap', old =>
+        old.setIn([action.payload.conversationIDKey], action.payload.text)
+      )
     case Chat2Gen.setExplodingMessagesNew:
       return state.set('isExplodingNew', action.payload.new)
     case Chat2Gen.staticConfigLoaded:


### PR DESCRIPTION
@keybase/react-hackers 

Patch does the following:
1. Add a new map to the store, which maps `convID -> unsentText`. The purpose of this is to be able to override the module level unsent text with stuff from redux.
2. In the input box component, if the unsent text is set in the store, then use it in `getUnsentText()` instead of whatever we have in the module level storage. We also set a flag to let the component know it should re-run `getUnsentText()` to get the new data in there.
3. If the user types anything after that, we blow away the unsent text in the store.
4. If a user cancels a Stellar in-chat send, then we set the unsent text in the store of the message they are composing.