### PR TITLE
show typing status on small team rows

### DIFF
--- a/shared/chat/inbox/container/remote.js
+++ b/shared/chat/inbox/container/remote.js
@@ -99,6 +99,7 @@ export const serialize = ({
     isMuted: conversation.isMuted,
     // excluding onSelectConversation
     isSelected: false,
+    isTypingSnippet: false,
     participantNeedToRekey,
     participants: conversation.teamname
       ? []

--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -17,6 +17,7 @@ type Props = {
   showBold: boolean,
   snippet: ?string,
   snippetDecoration: ?string,
+  snippetStyle?: Object,
   subColor: string,
   youNeedToRekey: boolean,
   youAreReset: boolean,
@@ -61,6 +62,7 @@ class BottomLine extends PureComponent<Props> {
           color: this.props.subColor,
           ...(this.props.showBold ? globalStyles.fontBold : {}),
         },
+        this.props.snippetStyle,
       ])
 
       let snippetDecoration

--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -9,7 +9,6 @@ import {
   collapseStyles,
   platformStyles,
 } from '../../../../styles'
-import type {StylesCrossPlatform} from '../../../../styles'
 import {isMobile} from '../../../../constants/platform'
 
 type Props = {
@@ -18,13 +17,13 @@ type Props = {
   showBold: boolean,
   snippet: ?string,
   snippetDecoration: ?string,
-  snippetStyle?: StylesCrossPlatform,
   subColor: string,
   youNeedToRekey: boolean,
   youAreReset: boolean,
   hasResetUsers: boolean,
   isSelected: boolean,
   isDecryptingSnippet: boolean,
+  isTypingSnippet: boolean,
 }
 
 class BottomLine extends PureComponent<Props> {
@@ -63,7 +62,7 @@ class BottomLine extends PureComponent<Props> {
           color: this.props.subColor,
           ...(this.props.showBold ? globalStyles.fontBold : {}),
         },
-        this.props.snippetStyle,
+        this.props.isTypingSnippet ? styles.typingSnippet : null,
       ])
 
       let snippetDecoration
@@ -100,9 +99,10 @@ class BottomLine extends PureComponent<Props> {
           )
           break
         default:
-          snippetDecoration = this.props.snippetDecoration ? (
-            <Text type="BodySmall">{this.props.snippetDecoration}</Text>
-          ) : null
+          snippetDecoration =
+            this.props.snippetDecoration && !this.props.isTypingSnippet ? (
+              <Text type="BodySmall">{this.props.snippetDecoration}</Text>
+            ) : null
       }
       content = (
         <Box2 direction="horizontal" gap="xtiny" style={styles.contentBox}>
@@ -211,6 +211,9 @@ const styles = styleSheetCreate({
       lineHeight: 14,
     },
   }),
+  typingSnippet: {
+    fontStyle: 'italic',
+  },
   youAreResetText: platformStyles({
     isElectron: {
       fontSize: 12,

--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -9,6 +9,7 @@ import {
   collapseStyles,
   platformStyles,
 } from '../../../../styles'
+import type {StylesCrossPlatform} from '../../../../styles'
 import {isMobile} from '../../../../constants/platform'
 
 type Props = {
@@ -17,7 +18,7 @@ type Props = {
   showBold: boolean,
   snippet: ?string,
   snippetDecoration: ?string,
-  snippetStyle?: Object,
+  snippetStyle?: StylesCrossPlatform,
   subColor: string,
   youNeedToRekey: boolean,
   youAreReset: boolean,

--- a/shared/chat/inbox/row/small-team/bottom-line.js
+++ b/shared/chat/inbox/row/small-team/bottom-line.js
@@ -100,7 +100,7 @@ class BottomLine extends PureComponent<Props> {
           break
         default:
           snippetDecoration =
-            this.props.snippetDecoration && !this.props.isTypingSnippet ? (
+            !!this.props.snippetDecoration && !this.props.isTypingSnippet ? (
               <Text type="BodySmall">{this.props.snippetDecoration}</Text>
             ) : null
       }

--- a/shared/chat/inbox/row/small-team/container.js
+++ b/shared/chat/inbox/row/small-team/container.js
@@ -12,13 +12,23 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
   const _meta = Constants.getMeta(state, _conversationIDKey)
   const youAreReset = _meta.membershipType === 'youAreReset'
   const typers = state.chat2.typingMap.get(_conversationIDKey)
+  let snippet = _meta.snippet
+  let snippetDecoration = _meta.snippetDecoration
+  let snippetStyle
+  if (typers && typers.size > 0) {
+    snippetDecoration = ''
+    snippet = typers.size === 1 ? `${typers.first()} is typing...` : 'multiple people typing...'
+    snippetStyle = {fontStyle: 'italic'}
+  }
   return {
     _meta,
     _username: state.config.username || '',
     hasBadge: Constants.getHasBadge(state, _conversationIDKey),
     hasUnread: Constants.getHasUnread(state, _conversationIDKey),
     isSelected: !isMobile && Constants.getSelectedConversation(state) === _conversationIDKey,
-    typers,
+    snippet,
+    snippetDecoration,
+    snippetStyle,
     youAreReset,
   }
 }
@@ -34,15 +44,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const styles = Constants.getRowStyles(stateProps._meta, isSelected, hasUnread)
   const participantNeedToRekey = stateProps._meta.rekeyers.size > 0
   const youNeedToRekey = !participantNeedToRekey && stateProps._meta.rekeyers.has(stateProps._username)
-  let snippet = stateProps._meta.snippet
-  let snippetDecoration = stateProps._meta.snippetDecoration
-  let snippetStyle
-  if (stateProps.typers && stateProps.typers.size > 0) {
-    snippetDecoration = ''
-    snippet =
-      stateProps.typers.size === 1 ? `${stateProps.typers.first()} is typing...` : 'multiple people typing...'
-    snippetStyle = {fontStyle: 'italic'}
-  }
+
   return {
     backgroundColor: styles.backgroundColor,
     hasBadge: stateProps.hasBadge,
@@ -59,9 +61,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     participantNeedToRekey,
     participants: Constants.getRowParticipants(stateProps._meta, stateProps._username).toArray(),
     showBold: styles.showBold,
-    snippet,
-    snippetDecoration,
-    snippetStyle,
+    snippet: stateProps.snippet,
+    snippetDecoration: stateProps.snippetDecoration,
+    snippetStyle: stateProps.snippetStyle,
     subColor: styles.subColor,
     teamname: stateProps._meta.teamname,
     timestamp: Constants.timestampToString(stateProps._meta),

--- a/shared/chat/inbox/row/small-team/container.js
+++ b/shared/chat/inbox/row/small-team/container.js
@@ -11,12 +11,14 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
   const _conversationIDKey = ownProps.conversationIDKey
   const _meta = Constants.getMeta(state, _conversationIDKey)
   const youAreReset = _meta.membershipType === 'youAreReset'
+  const typers = state.chat2.typingMap.get(_conversationIDKey)
   return {
     _meta,
     _username: state.config.username || '',
     hasBadge: Constants.getHasBadge(state, _conversationIDKey),
     hasUnread: Constants.getHasUnread(state, _conversationIDKey),
     isSelected: !isMobile && Constants.getSelectedConversation(state) === _conversationIDKey,
+    typers,
     youAreReset,
   }
 }
@@ -32,7 +34,15 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const styles = Constants.getRowStyles(stateProps._meta, isSelected, hasUnread)
   const participantNeedToRekey = stateProps._meta.rekeyers.size > 0
   const youNeedToRekey = !participantNeedToRekey && stateProps._meta.rekeyers.has(stateProps._username)
-
+  let snippet = stateProps._meta.snippet
+  let snippetDecoration = stateProps._meta.snippetDecoration
+  let snippetStyle
+  if (stateProps.typers && stateProps.typers.size > 0) {
+    snippetDecoration = ''
+    snippet =
+      stateProps.typers.size === 1 ? `${stateProps.typers.first()} is typing...` : 'multiple people typing...'
+    snippetStyle = {fontStyle: 'italic'}
+  }
   return {
     backgroundColor: styles.backgroundColor,
     hasBadge: stateProps.hasBadge,
@@ -49,8 +59,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     participantNeedToRekey,
     participants: Constants.getRowParticipants(stateProps._meta, stateProps._username).toArray(),
     showBold: styles.showBold,
-    snippet: stateProps._meta.snippet,
-    snippetDecoration: stateProps._meta.snippetDecoration,
+    snippet,
+    snippetDecoration,
+    snippetStyle,
     subColor: styles.subColor,
     teamname: stateProps._meta.teamname,
     timestamp: Constants.timestampToString(stateProps._meta),

--- a/shared/chat/inbox/row/small-team/container.js
+++ b/shared/chat/inbox/row/small-team/container.js
@@ -13,12 +13,10 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
   const youAreReset = _meta.membershipType === 'youAreReset'
   const typers = state.chat2.typingMap.get(_conversationIDKey)
   let snippet = _meta.snippet
-  let snippetDecoration = _meta.snippetDecoration
-  let snippetStyle
+  let isTypingSnippet = false
   if (typers && typers.size > 0) {
-    snippetDecoration = ''
+    isTypingSnippet = true
     snippet = typers.size === 1 ? `${typers.first()} is typing...` : 'multiple people typing...'
-    snippetStyle = {fontStyle: 'italic'}
   }
   return {
     _meta,
@@ -26,9 +24,9 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
     hasBadge: Constants.getHasBadge(state, _conversationIDKey),
     hasUnread: Constants.getHasUnread(state, _conversationIDKey),
     isSelected: !isMobile && Constants.getSelectedConversation(state) === _conversationIDKey,
+    isTypingSnippet,
     snippet,
-    snippetDecoration,
-    snippetStyle,
+    snippetDecoration: _meta.snippetDecoration,
     youAreReset,
   }
 }
@@ -56,6 +54,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     isFinalized: !!stateProps._meta.wasFinalizedBy,
     isMuted: stateProps._meta.isMuted,
     isSelected,
+    isTypingSnippet: stateProps.isTypingSnippet,
     // Don't allow you to select yourself
     onSelectConversation: isSelected ? () => {} : dispatchProps.onSelectConversation,
     participantNeedToRekey,
@@ -63,7 +62,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     showBold: styles.showBold,
     snippet: stateProps.snippet,
     snippetDecoration: stateProps.snippetDecoration,
-    snippetStyle: stateProps.snippetStyle,
     subColor: styles.subColor,
     teamname: stateProps._meta.teamname,
     timestamp: Constants.timestampToString(stateProps._meta),

--- a/shared/chat/inbox/row/small-team/index.js
+++ b/shared/chat/inbox/row/small-team/index.js
@@ -18,13 +18,13 @@ export type Props = {
   isFinalized: boolean,
   isMuted: boolean,
   isSelected: boolean,
+  isTypingSnippet: boolean,
   onSelectConversation: () => void,
   participantNeedToRekey: boolean,
   participants: Array<string>,
   showBold: boolean,
   snippet: string,
   snippetDecoration: string,
-  snippetStyle?: Styles.StylesCrossPlatform,
   subColor: string,
   teamname: string,
   timestamp: string,
@@ -133,12 +133,12 @@ class SmallTeam extends React.PureComponent<Props, State> {
                 showBold={props.showBold}
                 snippet={props.snippet}
                 snippetDecoration={props.snippetDecoration}
-                snippetStyle={props.snippetStyle}
                 subColor={props.subColor}
                 hasResetUsers={props.hasResetUsers}
                 youNeedToRekey={props.youNeedToRekey}
                 isSelected={props.isSelected}
                 isDecryptingSnippet={props.isDecryptingSnippet}
+                isTypingSnippet={props.isTypingSnippet}
               />
             </Kb.Box>
           </Kb.Box>

--- a/shared/chat/inbox/row/small-team/index.js
+++ b/shared/chat/inbox/row/small-team/index.js
@@ -24,7 +24,7 @@ export type Props = {
   showBold: boolean,
   snippet: string,
   snippetDecoration: string,
-  snippetStyle?: Object,
+  snippetStyle?: Styles.StylesCrossPlatform,
   subColor: string,
   teamname: string,
   timestamp: string,

--- a/shared/chat/inbox/row/small-team/index.js
+++ b/shared/chat/inbox/row/small-team/index.js
@@ -24,6 +24,7 @@ export type Props = {
   showBold: boolean,
   snippet: string,
   snippetDecoration: string,
+  snippetStyle?: Object,
   subColor: string,
   teamname: string,
   timestamp: string,
@@ -132,6 +133,7 @@ class SmallTeam extends React.PureComponent<Props, State> {
                 showBold={props.showBold}
                 snippet={props.snippet}
                 snippetDecoration={props.snippetDecoration}
+                snippetStyle={props.snippetStyle}
                 subColor={props.subColor}
                 hasResetUsers={props.hasResetUsers}
                 youNeedToRekey={props.youNeedToRekey}


### PR DESCRIPTION
@keybase/react-hackers 

I think it is a nice touch to have typing status in the inbox view, and most other messengers have this. Here is what it looks like:

![image](https://user-images.githubusercontent.com/1250314/50672303-4600f880-0fa5-11e9-9623-38c01dcab971.png)

cc @cecileboucheron @adamjspooner @malgorithms for any comments/concerns.