### PR TITLE
Proof services: AllStringKeys -> StringKey

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -80,7 +80,7 @@ func newIdentify2WithUIDTester(g *libkb.GlobalContext) *Identify2WithUIDTester {
 
 func (i *Identify2WithUIDTester) ListProofCheckers() []string               { return nil }
 func (i *Identify2WithUIDTester) ListServicesThatAcceptNewProofs() []string { return nil }
-func (i *Identify2WithUIDTester) StringKey() string                         { return i.GetTypeName() }
+func (i *Identify2WithUIDTester) Key() string                               { return i.GetTypeName() }
 func (i *Identify2WithUIDTester) CheckProofText(text string, id keybase1.SigID, sig string) error {
 	return nil
 }

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -80,7 +80,7 @@ func newIdentify2WithUIDTester(g *libkb.GlobalContext) *Identify2WithUIDTester {
 
 func (i *Identify2WithUIDTester) ListProofCheckers() []string               { return nil }
 func (i *Identify2WithUIDTester) ListServicesThatAcceptNewProofs() []string { return nil }
-func (i *Identify2WithUIDTester) AllStringKeys() []string                   { return nil }
+func (i *Identify2WithUIDTester) StringKey() string                         { return i.GetTypeName() }
 func (i *Identify2WithUIDTester) CheckProofText(text string, id keybase1.SigID, sig string) error {
 	return nil
 }

--- a/go/externals/proof_service_dns.go
+++ b/go/externals/proof_service_dns.go
@@ -42,7 +42,7 @@ func (rc *DNSChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, pcm libk
 
 type DNSServiceType struct{ libkb.BaseServiceType }
 
-func (t *DNSServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *DNSServiceType) StringKey() string { return t.GetTypeName() }
 
 func (t *DNSServiceType) NormalizeUsername(s string) (string, error) {
 	if !libkb.IsValidHostname(s) {

--- a/go/externals/proof_service_dns.go
+++ b/go/externals/proof_service_dns.go
@@ -42,7 +42,7 @@ func (rc *DNSChecker) CheckStatus(m libkb.MetaContext, h libkb.SigHint, pcm libk
 
 type DNSServiceType struct{ libkb.BaseServiceType }
 
-func (t *DNSServiceType) StringKey() string { return t.GetTypeName() }
+func (t *DNSServiceType) Key() string { return t.GetTypeName() }
 
 func (t *DNSServiceType) NormalizeUsername(s string) (string, error) {
 	if !libkb.IsValidHostname(s) {

--- a/go/externals/proof_service_facebook.go
+++ b/go/externals/proof_service_facebook.go
@@ -39,7 +39,7 @@ func (rc *FacebookChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, 
 
 type FacebookServiceType struct{ libkb.BaseServiceType }
 
-func (t *FacebookServiceType) StringKey() string { return t.GetTypeName() }
+func (t *FacebookServiceType) Key() string { return t.GetTypeName() }
 
 var facebookUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9.]{1,50})$`)
 

--- a/go/externals/proof_service_facebook.go
+++ b/go/externals/proof_service_facebook.go
@@ -39,7 +39,7 @@ func (rc *FacebookChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, 
 
 type FacebookServiceType struct{ libkb.BaseServiceType }
 
-func (t *FacebookServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *FacebookServiceType) StringKey() string { return t.GetTypeName() }
 
 var facebookUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9.]{1,50})$`)
 

--- a/go/externals/proof_service_generic_social.go
+++ b/go/externals/proof_service_generic_social.go
@@ -242,7 +242,7 @@ func NewGenericSocialProofServiceType(config *GenericSocialProofConfig) *Generic
 	}
 }
 
-func (t *GenericSocialProofServiceType) StringKey() string { return t.GetTypeName() }
+func (t *GenericSocialProofServiceType) Key() string { return t.GetTypeName() }
 
 func (t *GenericSocialProofServiceType) NormalizeUsername(s string) (string, error) {
 	if err := t.config.validateRemoteUsername(s); err != nil {

--- a/go/externals/proof_service_generic_social.go
+++ b/go/externals/proof_service_generic_social.go
@@ -242,7 +242,7 @@ func NewGenericSocialProofServiceType(config *GenericSocialProofConfig) *Generic
 	}
 }
 
-func (t *GenericSocialProofServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *GenericSocialProofServiceType) StringKey() string { return t.GetTypeName() }
 
 func (t *GenericSocialProofServiceType) NormalizeUsername(s string) (string, error) {
 	if err := t.config.validateRemoteUsername(s); err != nil {

--- a/go/externals/proof_service_github.go
+++ b/go/externals/proof_service_github.go
@@ -39,7 +39,7 @@ func (rc *GithubChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _ 
 
 type GithubServiceType struct{ libkb.BaseServiceType }
 
-func (t *GithubServiceType) StringKey() string { return t.GetTypeName() }
+func (t *GithubServiceType) Key() string { return t.GetTypeName() }
 
 var githubUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9][a-z0-9-]{0,38})$`)
 

--- a/go/externals/proof_service_github.go
+++ b/go/externals/proof_service_github.go
@@ -39,7 +39,7 @@ func (rc *GithubChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _ 
 
 type GithubServiceType struct{ libkb.BaseServiceType }
 
-func (t *GithubServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *GithubServiceType) StringKey() string { return t.GetTypeName() }
 
 var githubUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9][a-z0-9-]{0,38})$`)
 

--- a/go/externals/proof_service_hackernews.go
+++ b/go/externals/proof_service_hackernews.go
@@ -57,7 +57,7 @@ func CheckKarma(mctx libkb.MetaContext, un string) (int, error) {
 
 type HackerNewsServiceType struct{ libkb.BaseServiceType }
 
-func (t *HackerNewsServiceType) StringKey() string { return t.GetTypeName() }
+func (t *HackerNewsServiceType) Key() string { return t.GetTypeName() }
 
 var hackerNewsUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_-]{2,15})$`)
 

--- a/go/externals/proof_service_hackernews.go
+++ b/go/externals/proof_service_hackernews.go
@@ -57,7 +57,7 @@ func CheckKarma(mctx libkb.MetaContext, un string) (int, error) {
 
 type HackerNewsServiceType struct{ libkb.BaseServiceType }
 
-func (t *HackerNewsServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *HackerNewsServiceType) StringKey() string { return t.GetTypeName() }
 
 var hackerNewsUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_-]{2,15})$`)
 

--- a/go/externals/proof_service_reddit.go
+++ b/go/externals/proof_service_reddit.go
@@ -84,7 +84,7 @@ func urlReencode(s string) string {
 
 type RedditServiceType struct{ libkb.BaseServiceType }
 
-func (t *RedditServiceType) StringKey() string { return t.GetTypeName() }
+func (t *RedditServiceType) Key() string { return t.GetTypeName() }
 
 var redditUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_-]{3,20})$`)
 

--- a/go/externals/proof_service_reddit.go
+++ b/go/externals/proof_service_reddit.go
@@ -84,7 +84,7 @@ func urlReencode(s string) string {
 
 type RedditServiceType struct{ libkb.BaseServiceType }
 
-func (t *RedditServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *RedditServiceType) StringKey() string { return t.GetTypeName() }
 
 var redditUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_-]{3,20})$`)
 

--- a/go/externals/proof_service_rooter.go
+++ b/go/externals/proof_service_rooter.go
@@ -41,7 +41,7 @@ func (rc *RooterChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _ 
 
 type RooterServiceType struct{ libkb.BaseServiceType }
 
-func (t *RooterServiceType) StringKey() string { return t.GetTypeName() }
+func (t *RooterServiceType) Key() string { return t.GetTypeName() }
 
 var rooterUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`)
 

--- a/go/externals/proof_service_rooter.go
+++ b/go/externals/proof_service_rooter.go
@@ -41,7 +41,7 @@ func (rc *RooterChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _ 
 
 type RooterServiceType struct{ libkb.BaseServiceType }
 
-func (t *RooterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *RooterServiceType) StringKey() string { return t.GetTypeName() }
 
 var rooterUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`)
 

--- a/go/externals/proof_service_twitter.go
+++ b/go/externals/proof_service_twitter.go
@@ -39,7 +39,7 @@ func (rc *TwitterChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _
 
 type TwitterServiceType struct{ libkb.BaseServiceType }
 
-func (t *TwitterServiceType) AllStringKeys() []string { return t.BaseAllStringKeys(t) }
+func (t *TwitterServiceType) StringKey() string { return t.GetTypeName() }
 
 var twitterUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`)
 

--- a/go/externals/proof_service_twitter.go
+++ b/go/externals/proof_service_twitter.go
@@ -39,7 +39,7 @@ func (rc *TwitterChecker) CheckStatus(mctx libkb.MetaContext, h libkb.SigHint, _
 
 type TwitterServiceType struct{ libkb.BaseServiceType }
 
-func (t *TwitterServiceType) StringKey() string { return t.GetTypeName() }
+func (t *TwitterServiceType) Key() string { return t.GetTypeName() }
 
 var twitterUsernameRegexp = regexp.MustCompile(`^(?i:[a-z0-9_]{1,20})$`)
 

--- a/go/externals/proof_service_web.go
+++ b/go/externals/proof_service_web.go
@@ -59,7 +59,7 @@ type WebServiceType struct {
 	scheme string
 }
 
-func (t *WebServiceType) StringKey() string {
+func (t *WebServiceType) Key() string {
 	if t.scheme == "" {
 		return "web"
 	}

--- a/go/externals/proof_service_web.go
+++ b/go/externals/proof_service_web.go
@@ -59,11 +59,11 @@ type WebServiceType struct {
 	scheme string
 }
 
-func (t *WebServiceType) AllStringKeys() []string {
+func (t *WebServiceType) StringKey() string {
 	if t.scheme == "" {
-		return []string{"web"}
+		return "web"
 	}
-	return []string{t.scheme}
+	return t.scheme
 }
 
 func (t *WebServiceType) NormalizeUsername(s string) (ret string, err error) {

--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -36,7 +36,7 @@ func (p *staticProofServices) register(services []libkb.ServiceType) {
 		if !useDevelProofCheckers && st.IsDevelOnly() {
 			continue
 		}
-		p.externalServices[st.StringKey()] = st
+		p.externalServices[st.Key()] = st
 	}
 }
 
@@ -93,7 +93,7 @@ func (p *proofServices) registerServiceTypes(services []libkb.ServiceType) {
 		if !useDevelProofCheckers && st.IsDevelOnly() {
 			continue
 		}
-		p.externalServices[st.StringKey()] = st
+		p.externalServices[st.Key()] = st
 	}
 }
 

--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -36,9 +36,7 @@ func (p *staticProofServices) register(services []libkb.ServiceType) {
 		if !useDevelProofCheckers && st.IsDevelOnly() {
 			continue
 		}
-		for _, k := range st.AllStringKeys() {
-			p.externalServices[k] = st
-		}
+		p.externalServices[st.StringKey()] = st
 	}
 }
 
@@ -95,9 +93,7 @@ func (p *proofServices) registerServiceTypes(services []libkb.ServiceType) {
 		if !useDevelProofCheckers && st.IsDevelOnly() {
 			continue
 		}
-		for _, k := range st.AllStringKeys() {
-			p.externalServices[k] = st
-		}
+		p.externalServices[st.StringKey()] = st
 	}
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -559,7 +559,7 @@ type ProofChecker interface {
 // ServiceType is an interface for describing an external proof service, like 'Twitter'
 // or 'GitHub', etc.
 type ServiceType interface {
-	AllStringKeys() []string
+	StringKey() string
 
 	// NormalizeUsername normalizes the given username, assuming
 	// that it's free of any leading strings like '@' or 'dns://'.

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -559,7 +559,7 @@ type ProofChecker interface {
 // ServiceType is an interface for describing an external proof service, like 'Twitter'
 // or 'GitHub', etc.
 type ServiceType interface {
-	StringKey() string
+	Key() string
 
 	// NormalizeUsername normalizes the given username, assuming
 	// that it's free of any leading strings like '@' or 'dns://'.

--- a/go/libkb/remote_proof_links.go
+++ b/go/libkb/remote_proof_links.go
@@ -43,7 +43,7 @@ func (r *RemoteProofLinks) Insert(link RemoteProofChainLink, err ProofError) {
 // ForService returns all the active proof links for a service.
 func (r *RemoteProofLinks) ForService(st ServiceType) []RemoteProofChainLink {
 	var links []RemoteProofChainLink
-	for _, l := range r.links[st.StringKey()] {
+	for _, l := range r.links[st.Key()] {
 		if l.link.IsRevoked() {
 			continue
 		}

--- a/go/libkb/remote_proof_links.go
+++ b/go/libkb/remote_proof_links.go
@@ -43,13 +43,11 @@ func (r *RemoteProofLinks) Insert(link RemoteProofChainLink, err ProofError) {
 // ForService returns all the active proof links for a service.
 func (r *RemoteProofLinks) ForService(st ServiceType) []RemoteProofChainLink {
 	var links []RemoteProofChainLink
-	for _, k := range st.AllStringKeys() {
-		for _, l := range r.links[k] {
-			if l.link.IsRevoked() {
-				continue
-			}
-			links = append(links, l.link)
+	for _, l := range r.links[st.StringKey()] {
+		if l.link.IsRevoked() {
+			continue
 		}
+		links = append(links, l.link)
 	}
 
 	// Chop the array off if it's a last-writer wins service

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -84,10 +84,6 @@ func (t *BaseServiceType) BaseGetProofType(st ServiceType) string {
 	return "web_service_binding." + st.GetTypeName()
 }
 
-func (t *BaseServiceType) BaseAllStringKeys(st ServiceType) []string {
-	return []string{st.GetTypeName()}
-}
-
 func (t *BaseServiceType) LastWriterWins() bool                               { return true }
 func (t *BaseServiceType) PreProofCheck(MetaContext, string) (*Markup, error) { return nil, nil }
 func (t *BaseServiceType) PreProofWarning(remotename string) *Markup          { return nil }


### PR DESCRIPTION
Seems like each service instance had only 1 key so this nice simplification is possible. `AllStringKeys() []string` goes away.
