### PR TITLE
fix uninstall timeouts

### DIFF
--- a/osx/KBKit/KBKit/Component/KBFuseComponent.m
+++ b/osx/KBKit/KBKit/Component/KBFuseComponent.m
@@ -202,6 +202,13 @@ typedef void (^KBOnFuseStatus)(NSError *error, KBRFuseStatus *fuseStatus);
 
 - (void)uninstall:(KBCompletion)completion {
   NSDictionary *params = @{@"destination": self.destination, @"kextID": self.kextID};
+
+  if (![self.helperTool exists]) {
+    DDLogDebug(@"FUSE wasn't installed (no helper), so no-op");
+    completion(nil);
+    return;
+  }
+
   DDLogDebug(@"Helper: kextUninstall(%@)", params);
   [self.helperTool.helper sendRequest:@"kextUninstall" params:@[params] completion:^(NSError *error, id value) {
     completion(error);

--- a/osx/KBKit/KBKit/Component/KBHelperTool.h
+++ b/osx/KBKit/KBKit/Component/KBHelperTool.h
@@ -19,5 +19,6 @@
 - (instancetype)initWithConfig:(KBEnvConfig *)config;
 
 + (MPXPCClient *)helper;
+- (BOOL)exists;
 
 @end

--- a/osx/KBKit/KBKit/Component/KBHelperTool.m
+++ b/osx/KBKit/KBKit/Component/KBHelperTool.m
@@ -102,6 +102,10 @@
   [alert runModal]; // ignore response
 }
 
+- (BOOL)exists {
+  return [NSFileManager.defaultManager fileExistsAtPath:HELPER_LOCATION isDirectory:nil];
+}
+
 - (void)refreshComponent:(KBRefreshComponentCompletion)completion {
   GHODictionary *info = [GHODictionary dictionary];
   KBSemVersion *bundleVersion = [self bundleVersion];

--- a/osx/KBKit/KBKit/Component/KBRedirector.m
+++ b/osx/KBKit/KBKit/Component/KBRedirector.m
@@ -51,6 +51,13 @@
 - (void)uninstall:(KBCompletion)completion {
   NSString *mount = [self.config redirectorMount];
   NSDictionary *params = @{@"directory": mount};
+
+  if (![self.helperTool exists]) {
+    DDLogDebug(@"Redirector wasn't installed (no helper), so no-op");
+    completion(nil);
+    return;
+  }
+
   DDLogDebug(@"Stopping redirector: %@", params);
   [self.helperTool.helper sendRequest:@"stopRedirector" params:@[params] completion:^(NSError *err, id value) {
     completion(err);


### PR DESCRIPTION
- the strategy is just to check that the root helper exists, and if not, don't try to make RPCs to it
- most of the work we can try in the installer, or don't need to do in the installer