### PR TITLE
Disable login / signup buttons when input is empty 

### DIFF
--- a/shared/common-adapters/button.js
+++ b/shared/common-adapters/button.js
@@ -16,7 +16,7 @@ import {
   styleSheetCreate,
 } from '../styles'
 
-export type Props = {
+export type Props = {|
   children?: React.Node,
   onClick?: null | ((event: SyntheticEvent<>) => void),
   onPress?: void,
@@ -42,7 +42,7 @@ export type Props = {
   fullWidth?: boolean,
   backgroundMode?: 'Normal' | 'Terminal' | 'Red' | 'Green' | 'Blue' | 'Black',
   className?: string,
-}
+|}
 
 const Progress = ({small, white}) => (
   <Box style={styles.progressContainer}>

--- a/shared/common-adapters/waiting-button.js
+++ b/shared/common-adapters/waiting-button.js
@@ -4,16 +4,18 @@ import Button, {type Props as ButtonProps} from './button'
 import {namedConnect} from '../util/container'
 import * as WaitingConstants from '../constants/waiting'
 
-export type OwnProps = ButtonProps & {
+export type OwnProps = {|
+  ...ButtonProps,
   onlyDisable?: boolean, // Must supply waiting key if this is true
   waitingKey: ?string,
-}
+|}
 
-export type Props = ButtonProps & {
+export type Props = {|
+  ...ButtonProps,
   onlyDisable?: boolean,
   storeWaiting: boolean,
   waitingKey: ?string,
-}
+|}
 
 /* Waiting button is a <Button /> with handling of waiting states.
  *
@@ -42,9 +44,10 @@ class WaitingButton extends React.Component<Props, {localWaiting: boolean}> {
       throw new Error('WaitingButton onlyDisable should only be used with a waiting key')
     }
     const waiting = this.props.storeWaiting || this.state.localWaiting
+    const {onlyDisable, storeWaiting, waitingKey, ...buttonProps} = this.props
     return (
       <Button
-        {...this.props}
+        {...buttonProps}
         onClick={this._onClick}
         disabled={this.props.onlyDisable ? waiting || this.props.disabled : this.props.disabled}
         waiting={this.props.onlyDisable ? false : waiting}

--- a/shared/login/relogin/index.desktop.js
+++ b/shared/login/relogin/index.desktop.js
@@ -141,6 +141,7 @@ class Login extends React.Component<Props, State> {
             checkboxesProps={checkboxProps}
           />
           <Kb.WaitingButton
+            disabled={!this.props.passphrase}
             waitingKey={Constants.waitingKey}
             style={{marginTop: 0}}
             type="Primary"

--- a/shared/login/relogin/index.native.js
+++ b/shared/login/relogin/index.native.js
@@ -57,6 +57,7 @@ class LoginRender extends Component<Props> {
               checkboxesProps={checkboxProps}
             />
             <Kb.WaitingButton
+              disabled={!this.props.passphrase}
               waitingKey={Constants.waitingKey}
               style={{marginTop: 0}}
               fullWidth={true}

--- a/shared/provision/paper-key/index.js
+++ b/shared/provision/paper-key/index.js
@@ -54,7 +54,7 @@ class PaperKey extends React.Component<Props, {paperKey: string}> {
               type="Primary"
               fullWidth={true}
               onClick={this._onSubmit}
-              enabled={!!this.state.paperKey}
+              disabled={!this.state.paperKey}
               waitingKey={Constants.waitingKey}
             />
           </Kb.ButtonBar>

--- a/shared/provision/passphrase/index.desktop.js
+++ b/shared/provision/passphrase/index.desktop.js
@@ -34,7 +34,7 @@ class Passphrase extends Component<Props> {
             label="Continue"
             type="Primary"
             onClick={() => this.props.onSubmit()}
-            enabled={this.props.passphrase && this.props.passphrase.length}
+            disabled={!(this.props.passphrase && this.props.passphrase.length)}
           />
           <Text style={stylesForgot} type="BodySmallSecondaryLink" onClick={this.props.onForgotPassphrase}>
             Forgot passphrase?

--- a/shared/provision/passphrase/index.native.js
+++ b/shared/provision/passphrase/index.native.js
@@ -41,7 +41,7 @@ class Passphrase extends Component<Props> {
             label="Continue"
             type="Primary"
             onClick={this.props.onSubmit}
-            enabled={this.props.passphrase && this.props.passphrase.length}
+            disabled={!(this.props.passphrase && this.props.passphrase.length)}
           />
           <Text style={stylesForgot} type="BodySmallSecondaryLink" onClick={this.props.onForgotPassphrase}>
             Forgot passphrase?

--- a/shared/provision/username-or-email/index.desktop.js
+++ b/shared/provision/username-or-email/index.desktop.js
@@ -52,7 +52,7 @@ class UsernameOrEmail extends Component<Props, State> {
             type="Primary"
             style={{alignSelf: 'center'}}
             onClick={() => this.onSubmit()}
-            enabled={this.state.usernameOrEmail}
+            disabled={!this.state.usernameOrEmail}
             waitingKey={Constants.waitingKey}
           />
         </UserCard>

--- a/shared/provision/username-or-email/index.native.js
+++ b/shared/provision/username-or-email/index.native.js
@@ -55,7 +55,7 @@ class UsernameOrEmail extends Component<Props, State> {
             label="Continue"
             type="Primary"
             onClick={() => this.onSubmit()}
-            enabled={this.state.usernameOrEmail}
+            disabled={!this.state.usernameOrEmail}
             waitingKey={Constants.waitingKey}
           />
         </UserCard>


### PR DESCRIPTION
We were using prop `enabled` which doesn't exist. r? @keybase/react-hackers 