### PR TITLE
more right padding on mobile chat

### DIFF
--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -522,7 +522,7 @@ const styles = Styles.styleSheetCreate({
         Styles.globalMargins.tiny + // right margin
         Styles.globalMargins.tiny + // left margin
         Styles.globalMargins.mediumLarge, // avatar
-      paddingRight: Styles.globalMargins.tiny,
+      paddingRight: Styles.globalMargins.small,
     },
   }),
   edited: {color: Styles.globalColors.black_20},


### PR DESCRIPTION
Before:
![simulator screen shot - iphone 6 - 2019-01-04 at 10 49 28](https://user-images.githubusercontent.com/862397/50706534-fce78d80-1012-11e9-9ecd-b8f4682dbd16.png)

After:
![simulator screen shot - iphone 6 - 2019-01-04 at 10 48 40](https://user-images.githubusercontent.com/862397/50706533-fce78d80-1012-11e9-9e49-84ab68e0a7a5.png)
