### PR TITLE
Fix asset input placeholder color

### DIFF
--- a/shared/common-adapters/plain-input.desktop.js
+++ b/shared/common-adapters/plain-input.desktop.js
@@ -262,8 +262,14 @@ class PlainInput extends React.PureComponent<InternalProps> {
 
   render = () => {
     const inputProps = this._getInputProps()
-    const css = `::-webkit-input-placeholder { color: ${this.props.placeholderColor ||
-      globalColors.black_40}; }
+    if (this.props.placeholderColor && !this.props.className) {
+      logger.warn(
+        'PlainInput warning: using prop placeholderColor without setting className. The color might be overridden by a later input in the dom. Set a className unique within the current screen to avoid this.'
+      )
+    }
+    const css = `${
+      this.props.className ? `.${this.props.className}` : ''
+    }::-webkit-input-placeholder { color: ${this.props.placeholderColor || globalColors.black_40}; }
                  ::-webkit-outer-spin-button, ::-webkit-inner-spin-button {-webkit-appearance: none; margin: 0;}`
     return (
       <React.Fragment>

--- a/shared/common-adapters/plain-input.desktop.js
+++ b/shared/common-adapters/plain-input.desktop.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {getStyle as getTextStyle} from './text.desktop'
-import {collapseStyles, globalColors, styleSheetCreate, platformStyles} from '../styles'
+import {collapseStyles, globalColors, styled, styleSheetCreate, platformStyles} from '../styles'
 import {pick} from 'lodash-es'
 import logger from '../logger'
 
@@ -161,6 +161,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
       onKeyDown: this._onKeyDown,
       onKeyUp: this._onKeyUp,
       placeholder: this.props.placeholder,
+      placeholderColor: this.props.placeholderColor,
       ref: this._setInputRef,
     }
     if (this.props.disabled) {
@@ -262,23 +263,25 @@ class PlainInput extends React.PureComponent<InternalProps> {
 
   render = () => {
     const inputProps = this._getInputProps()
-    if (this.props.placeholderColor && !this.props.className) {
-      logger.warn(
-        'PlainInput warning: using prop placeholderColor without setting className. The color might be overridden by a later input in the dom. Set a className unique within the current screen to avoid this.'
-      )
-    }
-    const css = `${
-      this.props.className ? `.${this.props.className}` : ''
-    }::-webkit-input-placeholder { color: ${this.props.placeholderColor || globalColors.black_40}; }
-                 ::-webkit-outer-spin-button, ::-webkit-inner-spin-button {-webkit-appearance: none; margin: 0;}`
     return (
       <React.Fragment>
-        <style>{css}</style>
-        {this.props.multiline ? <textarea {...inputProps} /> : <input {...inputProps} />}
+        {this.props.multiline ? <StyledTextArea {...inputProps} /> : <StyledInput {...inputProps} />}
       </React.Fragment>
     )
   }
 }
+
+const StyledTextArea = styled.textarea(props => ({
+  '&::-webkit-inner-spin-button': {'-webkit-appearance': 'none', margin: 0},
+  '&::-webkit-input-placeholder': {color: props.placeholderColor || globalColors.black_40},
+  '&::-webkit-outer-spin-button': {'-webkit-appearance': 'none', margin: 0},
+}))
+
+const StyledInput = styled.input(props => ({
+  '&::-webkit-inner-spin-button': {'-webkit-appearance': 'none', margin: 0},
+  '&::-webkit-input-placeholder': {color: props.placeholderColor || globalColors.black_40},
+  '&::-webkit-outer-spin-button': {'-webkit-appearance': 'none', margin: 0},
+}))
 
 const styles = styleSheetCreate({
   flexable: {

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -102,7 +102,6 @@ class AssetInput extends React.Component<Props> {
           onChangeText={this._onChangeAmount}
           textType="HeaderBigExtrabold"
           placeholder={this.props.inputPlaceholder}
-          className="stellar-asset-input"
           placeholderColor={Styles.globalColors.purple2_40}
           error={!!this.props.warningAsset}
           value={this.props.value}

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -102,6 +102,7 @@ class AssetInput extends React.Component<Props> {
           onChangeText={this._onChangeAmount}
           textType="HeaderBigExtrabold"
           placeholder={this.props.inputPlaceholder}
+          className="stellar-asset-input"
           placeholderColor={Styles.globalColors.purple2_40}
           error={!!this.props.warningAsset}
           value={this.props.value}

--- a/shared/wallets/send-form/note-and-memo/index.js
+++ b/shared/wallets/send-form/note-and-memo/index.js
@@ -94,6 +94,7 @@ class SecretNote extends React.Component<SecretNoteProps, SecretNoteState> {
               placeholder={`${
                 this.props.toSelf ? 'Add a note to yourself' : 'Add an encrypted note'
               } (in Keybase)`}
+              className="stellar-encrypted-note"
               placeholderColor={placeholderColor}
               rowsMin={Styles.isMobile ? 2 : 3}
               rowsMax={8}
@@ -164,6 +165,7 @@ class PublicMemo extends React.Component<PublicMemoProps, PublicMemoState> {
           <Kb.PlainInput
             multiline={true}
             placeholder="Add a public memo (on Stellar)"
+            className="stellar-public-memo"
             placeholderColor={placeholderColor}
             style={styles.input}
             rowsMin={Styles.isMobile ? 1 : 2}

--- a/shared/wallets/send-form/note-and-memo/index.js
+++ b/shared/wallets/send-form/note-and-memo/index.js
@@ -94,7 +94,6 @@ class SecretNote extends React.Component<SecretNoteProps, SecretNoteState> {
               placeholder={`${
                 this.props.toSelf ? 'Add a note to yourself' : 'Add an encrypted note'
               } (in Keybase)`}
-              className="stellar-encrypted-note"
               placeholderColor={placeholderColor}
               rowsMin={Styles.isMobile ? 2 : 3}
               rowsMax={8}
@@ -165,7 +164,6 @@ class PublicMemo extends React.Component<PublicMemoProps, PublicMemoState> {
           <Kb.PlainInput
             multiline={true}
             placeholder="Add a public memo (on Stellar)"
-            className="stellar-public-memo"
             placeholderColor={placeholderColor}
             style={styles.input}
             rowsMin={Styles.isMobile ? 1 : 2}


### PR DESCRIPTION
The style was being overridden by later `style` tags on the screen (encrypted note, asset input). I added the `className` to the `::-webkit-input-placeholder` selector so our selector is the most specific. I also added a warning message when `placeholderColor` is used without `className`. 

r? @keybase/react-hackers 