### PR TITLE
Clarify login error message on entering nonexistant username or email

### DIFF
--- a/shared/provision/error/index.js
+++ b/shared/provision/error/index.js
@@ -166,10 +166,10 @@ const Render = ({error, onBack, onAccountReset, onPasswordReset, onKBHome}: Prop
       return (
         <Wrapper onBack={onBack}>
           <Text type="Body" style={styles.centerText}>
-            The username you provided doesn't exist on Keybase.
+            The username or email you provided doesn't exist on Keybase.
           </Text>
           <Text type="Body" style={styles.centerText}>
-            Please try logging in again with a different username.
+            Please try logging in again with a different one.
           </Text>
         </Wrapper>
       )


### PR DESCRIPTION
We said 'username', but they might have entered an email. To get to this screen, log in as "someone else" with a bogus email + password.

<img width="421" alt="image" src="https://user-images.githubusercontent.com/11968340/50708371-151ad500-1032-11e9-84be-4147e3e7a1e4.png">

r? @keybase/react-hackers 