### PR TITLE
Corral user into payments list when payment fails

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -36,7 +36,7 @@
     },
     "buildingPaymentIDReceived": {
       "_description": "Update our store with an ID for a new building payment",
-      "bid": "string",
+      "bid": "string"
     },
     "builtPaymentReceived": {
       "_description": "Update our store with a prepared payment",
@@ -94,6 +94,9 @@
         "name": "string",
         "error": "string"
       }
+    },
+    "exitFailedPayment": {
+      "_description": "Close the send form and show the user their transactions so they can review."
     },
     "exportSecretKey": {
       "_description": "Export a Stellar account's secret key",
@@ -239,7 +242,7 @@
       "reviewID": "number",
       "seqno": "number",
       "nextButton": "string",
-      "banners?": "?Array<StellarRPCTypes.SendBannerLocal>",
+      "banners?": "?Array<StellarRPCTypes.SendBannerLocal>"
     },
     "secretKeyReceived": {
       "_description": "Update our store with an exported secret key",

--- a/shared/actions/wallets-gen.js
+++ b/shared/actions/wallets-gen.js
@@ -42,6 +42,7 @@ export const deletedAccount = 'wallets:deletedAccount'
 export const didSetAccountAsDefault = 'wallets:didSetAccountAsDefault'
 export const displayCurrenciesReceived = 'wallets:displayCurrenciesReceived'
 export const displayCurrencyReceived = 'wallets:displayCurrencyReceived'
+export const exitFailedPayment = 'wallets:exitFailedPayment'
 export const exportSecretKey = 'wallets:exportSecretKey'
 export const linkExistingAccount = 'wallets:linkExistingAccount'
 export const linkedExistingAccount = 'wallets:linkedExistingAccount'
@@ -127,6 +128,7 @@ type _DeletedAccountPayload = void
 type _DidSetAccountAsDefaultPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _DisplayCurrenciesReceivedPayload = $ReadOnly<{|currencies: Array<Types.Currency>|}>
 type _DisplayCurrencyReceivedPayload = $ReadOnly<{|accountID: ?Types.AccountID, currency: Types.Currency, setBuildingCurrency?: boolean|}>
+type _ExitFailedPaymentPayload = void
 type _ExportSecretKeyPayload = $ReadOnly<{|accountID: Types.AccountID|}>
 type _LinkExistingAccountPayload = $ReadOnly<{|name: string, secretKey: HiddenString, showOnCreation?: boolean, setBuildingTo?: boolean|}>
 type _LinkedExistingAccountPayload = $ReadOnly<{|accountID: Types.AccountID, showOnCreation?: boolean, setBuildingTo?: boolean|}>
@@ -264,6 +266,10 @@ export const createSecretKeySeen = (payload: _SecretKeySeenPayload) => ({payload
  * Clear our idea of which payments have not been seen by the user yet
  */
 export const createClearNewPayments = (payload: _ClearNewPaymentsPayload) => ({payload, type: clearNewPayments})
+/**
+ * Close the send form and show the user their transactions so they can review.
+ */
+export const createExitFailedPayment = (payload: _ExitFailedPaymentPayload) => ({payload, type: exitFailedPayment})
 /**
  * Delete an account
  */
@@ -546,6 +552,7 @@ export type DeletedAccountPayload = {|+payload: _DeletedAccountPayload, +type: '
 export type DidSetAccountAsDefaultPayload = {|+payload: _DidSetAccountAsDefaultPayload, +type: 'wallets:didSetAccountAsDefault'|}
 export type DisplayCurrenciesReceivedPayload = {|+payload: _DisplayCurrenciesReceivedPayload, +type: 'wallets:displayCurrenciesReceived'|}
 export type DisplayCurrencyReceivedPayload = {|+payload: _DisplayCurrencyReceivedPayload, +type: 'wallets:displayCurrencyReceived'|}
+export type ExitFailedPaymentPayload = {|+payload: _ExitFailedPaymentPayload, +type: 'wallets:exitFailedPayment'|}
 export type ExportSecretKeyPayload = {|+payload: _ExportSecretKeyPayload, +type: 'wallets:exportSecretKey'|}
 export type LinkExistingAccountPayload = {|+payload: _LinkExistingAccountPayload, +type: 'wallets:linkExistingAccount'|}
 export type LinkedExistingAccountPayload = {|+payload: _LinkedExistingAccountPayload, +type: 'wallets:linkedExistingAccount'|}
@@ -636,6 +643,7 @@ export type Actions =
   | DidSetAccountAsDefaultPayload
   | DisplayCurrenciesReceivedPayload
   | DisplayCurrencyReceivedPayload
+  | ExitFailedPaymentPayload
   | ExportSecretKeyPayload
   | LinkExistingAccountPayload
   | LinkedExistingAccountPayload

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -722,6 +722,15 @@ const readLastSentXLM = () => {
     })
 }
 
+const exitFailedPayment = (state, action) => {
+  const accountID = state.wallets.builtPayment.from
+  return [
+    WalletsGen.createAbandonPayment(),
+    WalletsGen.createSelectAccount({accountID, show: true}),
+    WalletsGen.createLoadPayments({accountID}),
+  ]
+}
+
 function* walletsSaga(): Saga.SagaGenerator<any, any> {
   if (!flags.walletsEnabled) {
     console.log('Wallets saga disabled')
@@ -901,6 +910,11 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
 
   // Effects of abandoning payments
   yield* Saga.chainAction<WalletsGen.AbandonPaymentPayload>(WalletsGen.abandonPayment, stopPayment)
+
+  yield* Saga.chainAction<WalletsGen.ExitFailedPaymentPayload>(
+    WalletsGen.exitFailedPayment,
+    exitFailedPayment
+  )
 
   yield* Saga.chainAction<WalletsGen.LoadRequestDetailPayload>(
     WalletsGen.loadRequestDetail,

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -216,6 +216,7 @@ export type Assets = I.RecordOf<_Assets>
 export type BannerBackground = 'Announcements' | 'HighRisk' | 'Information'
 
 export type Banner = {|
+  action?: () => void,
   bannerBackground: BannerBackground,
   bannerText: string,
   reviewProofs?: boolean,

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -219,6 +219,7 @@ export type Banner = {|
   bannerBackground: BannerBackground,
   bannerText: string,
   reviewProofs?: boolean,
+  sendFailed?: boolean,
 |}
 
 export type Building = I.RecordOf<_Building>

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -102,7 +102,8 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.reviewPayment:
       return state
         .setIn(['builtPayment', 'reviewBanners'], [])
-        .set('reviewCounter', state.reviewCounter + 1).set('reviewLastSeqno', null)
+        .set('reviewCounter', state.reviewCounter + 1)
+        .set('reviewLastSeqno', null)
     case WalletsGen.reviewedPaymentReceived: {
       // paymentReviewed notifications can arrive out of order, so check their freshness.
       const {bid, reviewID, seqno, banners, nextButton} = action.payload
@@ -353,6 +354,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.loadSendAssetChoices:
     case WalletsGen.loadMobileOnlyMode:
     case WalletsGen.changeMobileOnlyMode:
+    case WalletsGen.exitFailedPayment:
       return state
     default:
       Flow.ifFlowComplainsAboutThisFunctionYouHaventHandledAllCasesInASwitch(action)

--- a/shared/wallets/banner/index.js
+++ b/shared/wallets/banner/index.js
@@ -6,8 +6,9 @@ import {backgroundModeToColor, collapseStyles, globalMargins, styleSheetCreate} 
 
 type Props = {
   background: Background,
-  onReviewProofs?: () => void,
+  onAction?: ?() => void,
   reviewProofs?: boolean,
+  sendFailed?: boolean,
   text: string,
 }
 
@@ -25,9 +26,19 @@ const Banner = (props: Props) => (
           type="BodySmallSemiboldPrimaryLink"
           style={styles.secondText}
           backgroundMode={props.background}
-          onClick={props.onReviewProofs}
+          onClick={props.onAction}
         >
           Please review.
+        </Text>
+      )}
+      {props.sendFailed && (
+        <Text
+          type="BodySmallSemiboldPrimaryLink"
+          style={styles.secondText}
+          backgroundMode={props.background}
+          onClick={props.onAction}
+        >
+          Exit
         </Text>
       )}
     </Text>

--- a/shared/wallets/banner/index.js
+++ b/shared/wallets/banner/index.js
@@ -31,17 +31,17 @@ const Banner = (props: Props) => (
           Please review.
         </Text>
       )}
-      {props.sendFailed && (
-        <Text
-          type="BodySmallSemiboldPrimaryLink"
-          style={styles.secondText}
-          backgroundMode={props.background}
-          onClick={props.onAction}
-        >
-          Exit
-        </Text>
-      )}
     </Text>
+    {props.sendFailed && (
+      <Text
+        type="BodySmallSemiboldPrimaryLink"
+        style={styles.secondText}
+        backgroundMode={props.background}
+        onClick={props.onAction}
+      >
+        Exit
+      </Text>
+    )}
   </Box2>
 )
 

--- a/shared/wallets/banner/index.js
+++ b/shared/wallets/banner/index.js
@@ -39,7 +39,7 @@ const Banner = (props: Props) => (
         backgroundMode={props.background}
         onClick={props.onAction}
       >
-        Exit
+        Review payments
       </Text>
     )}
   </Box2>

--- a/shared/wallets/confirm-form/container.js
+++ b/shared/wallets/confirm-form/container.js
@@ -16,6 +16,7 @@ const mapStateToProps = state => {
         {
           bannerBackground: 'HighRisk',
           bannerText: state.wallets.sentPaymentError,
+          sendFailed: true,
         },
       ]
     : []
@@ -48,6 +49,7 @@ const mapDispatchToProps = (dispatch, {navigateUp}: OwnProps) => ({
     isMobile
       ? dispatch(ProfileGen.createShowUserProfile({username}))
       : dispatch(TrackerGen.createGetProfile({forceDisplay: true, ignoreCache: true, username})),
+  onExitFailed: () => dispatch(WalletsGen.createExitFailedPayment()),
   onSendClick: () => dispatch(WalletsGen.createSendPayment()),
 })
 
@@ -68,6 +70,7 @@ export default connect<OwnProps, _, _, _, _>(
       dispatchProps._onClearErrors()
       dispatchProps._onClose()
     },
+    onExitFailed: dispatchProps.onExitFailed,
     onReviewProofs: () => dispatchProps._onReviewProofs(stateProps.to),
     onSendClick: dispatchProps.onSendClick,
     publicMemo: stateProps.publicMemo,

--- a/shared/wallets/confirm-form/container.js
+++ b/shared/wallets/confirm-form/container.js
@@ -42,13 +42,19 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = (dispatch, {navigateUp}: OwnProps) => ({
-  _onBack: () => dispatch(navigateUp()),
-  _onClearErrors: () => dispatch(WalletsGen.createClearErrors()),
-  _onClose: () => dispatch(navigateUp()),
   _onReviewProofs: (username: string) =>
     isMobile
       ? dispatch(ProfileGen.createShowUserProfile({username}))
       : dispatch(TrackerGen.createGetProfile({forceDisplay: true, ignoreCache: true, username})),
+  onAbandonPayment: () => dispatch(WalletsGen.createAbandonPayment()),
+  onBack: () => {
+    dispatch(WalletsGen.createClearErrors())
+    dispatch(navigateUp())
+  },
+  onClose: () => {
+    dispatch(WalletsGen.createClearErrors())
+    dispatch(navigateUp())
+  },
   onExitFailed: () => dispatch(WalletsGen.createExitFailedPayment()),
   onSendClick: () => dispatch(WalletsGen.createSendPayment()),
 })
@@ -61,15 +67,9 @@ export default connect<OwnProps, _, _, _, _>(
     displayAmountFiat: stateProps.displayAmountFiat,
     displayAmountXLM: stateProps.displayAmountXLM,
     encryptedNote: stateProps.encryptedNote,
-    onBack: () => {
-      // Clear sentPaymentError when navigating away.
-      dispatchProps._onClearErrors()
-      dispatchProps._onBack()
-    },
-    onClose: () => {
-      dispatchProps._onClearErrors()
-      dispatchProps._onClose()
-    },
+    // Always close send form completely if send failed
+    onBack: stateProps.sendFailed ? dispatchProps.onAbandonPayment : dispatchProps.onBack,
+    onClose: stateProps.sendFailed ? dispatchProps.onAbandonPayment : dispatchProps.onClose,
     onExitFailed: dispatchProps.onExitFailed,
     onReviewProofs: () => dispatchProps._onReviewProofs(stateProps.to),
     onSendClick: dispatchProps.onSendClick,

--- a/shared/wallets/confirm-form/container.js
+++ b/shared/wallets/confirm-form/container.js
@@ -63,15 +63,20 @@ export default connect<OwnProps, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps,
   (stateProps, dispatchProps) => ({
-    banners: stateProps.banners,
+    banners: stateProps.banners.map(b => {
+      if (b.reviewProofs) {
+        return {...b, action: () => dispatchProps._onReviewProofs(stateProps.to)}
+      } else if (b.sendFailed) {
+        return {...b, action: dispatchProps.onExitFailed}
+      }
+      return b
+    }),
     displayAmountFiat: stateProps.displayAmountFiat,
     displayAmountXLM: stateProps.displayAmountXLM,
     encryptedNote: stateProps.encryptedNote,
     // Always close send form completely if send failed
     onBack: stateProps.sendFailed ? dispatchProps.onAbandonPayment : dispatchProps.onBack,
     onClose: stateProps.sendFailed ? dispatchProps.onAbandonPayment : dispatchProps.onClose,
-    onExitFailed: dispatchProps.onExitFailed,
-    onReviewProofs: () => dispatchProps._onReviewProofs(stateProps.to),
     onSendClick: dispatchProps.onSendClick,
     publicMemo: stateProps.publicMemo,
     readyToSend: stateProps.readyToSend,

--- a/shared/wallets/confirm-form/index.js
+++ b/shared/wallets/confirm-form/index.js
@@ -36,11 +36,11 @@ const getBannerAction = (props: ConfirmSendProps, banner: BannerType) => {
 }
 
 const ConfirmSend = (props: ConfirmSendProps) => (
-  <Kb.MaybePopup onClose={props.sendFailed ? props.onExitFailed : props.onClose}>
+  <Kb.MaybePopup onClose={props.onClose}>
     {Styles.isMobile && <Kb.SafeAreaViewTop style={styles.safeAreaViewTop} />}
     <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} style={styles.container}>
       <Header
-        onBack={props.sendFailed ? props.onExitFailed : props.onBack}
+        onBack={props.onBack}
         sendingIntentionXLM={props.sendingIntentionXLM}
         displayAmountXLM={props.displayAmountXLM}
         displayAmountFiat={props.displayAmountFiat}

--- a/shared/wallets/confirm-form/index.js
+++ b/shared/wallets/confirm-form/index.js
@@ -10,10 +10,8 @@ import {type Banner as BannerType} from '../../constants/types/wallets'
 
 type ConfirmSendProps = {|
   onClose: () => void,
-  onExitFailed: () => void,
   onSendClick: () => void,
   onBack: () => void,
-  onReviewProofs: () => void,
   encryptedNote?: string,
   publicMemo?: string,
   banners?: Array<BannerType>,
@@ -24,16 +22,6 @@ type ConfirmSendProps = {|
   displayAmountFiat: string,
   readyToSend: string,
 |}
-
-const getBannerAction = (props: ConfirmSendProps, banner: BannerType) => {
-  if (banner.reviewProofs) {
-    return props.onReviewProofs
-  }
-  if (banner.sendFailed) {
-    return props.onExitFailed
-  }
-  return null
-}
 
 const ConfirmSend = (props: ConfirmSendProps) => (
   <Kb.MaybePopup onClose={props.onClose}>
@@ -49,7 +37,7 @@ const ConfirmSend = (props: ConfirmSendProps) => (
         <Banner
           background={banner.bannerBackground}
           key={banner.bannerText}
-          onAction={getBannerAction(props, banner)}
+          onAction={banner.action}
           reviewProofs={banner.reviewProofs}
           sendFailed={banner.sendFailed}
           text={banner.bannerText}

--- a/shared/wallets/confirm-form/index.js
+++ b/shared/wallets/confirm-form/index.js
@@ -10,9 +10,10 @@ import {type Banner as BannerType} from '../../constants/types/wallets'
 
 type ConfirmSendProps = {|
   onClose: () => void,
+  onExitFailed: () => void,
   onSendClick: () => void,
   onBack: () => void,
-  onReviewProofs?: () => void,
+  onReviewProofs: () => void,
   encryptedNote?: string,
   publicMemo?: string,
   banners?: Array<BannerType>,
@@ -24,12 +25,22 @@ type ConfirmSendProps = {|
   readyToSend: string,
 |}
 
+const getBannerAction = (props: ConfirmSendProps, banner: BannerType) => {
+  if (banner.reviewProofs) {
+    return props.onReviewProofs
+  }
+  if (banner.sendFailed) {
+    return props.onExitFailed
+  }
+  return null
+}
+
 const ConfirmSend = (props: ConfirmSendProps) => (
-  <Kb.MaybePopup onClose={props.onClose}>
+  <Kb.MaybePopup onClose={props.sendFailed ? props.onExitFailed : props.onClose}>
     {Styles.isMobile && <Kb.SafeAreaViewTop style={styles.safeAreaViewTop} />}
     <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} style={styles.container}>
       <Header
-        onBack={props.onBack}
+        onBack={props.sendFailed ? props.onExitFailed : props.onBack}
         sendingIntentionXLM={props.sendingIntentionXLM}
         displayAmountXLM={props.displayAmountXLM}
         displayAmountFiat={props.displayAmountFiat}
@@ -38,8 +49,9 @@ const ConfirmSend = (props: ConfirmSendProps) => (
         <Banner
           background={banner.bannerBackground}
           key={banner.bannerText}
-          onReviewProofs={props.onReviewProofs}
+          onAction={getBannerAction(props, banner)}
           reviewProofs={banner.reviewProofs}
+          sendFailed={banner.sendFailed}
           text={banner.bannerText}
         />
       ))}

--- a/shared/wallets/confirm-form/index.stories.js
+++ b/shared/wallets/confirm-form/index.stories.js
@@ -47,6 +47,13 @@ const banner = {
   reviewProofs: false,
 }
 
+const sendFailedBanner = {
+  bannerBackground: 'HighRisk',
+  bannerText:
+    'The request to the stellar network timed out. Please make sure your payment failed before trying again.',
+  sendFailed: true,
+}
+
 const load = () => {
   participants()
   Sb.storiesOf('Wallets/ConfirmForm', module)
@@ -67,6 +74,7 @@ const load = () => {
         banners={[banner]}
       />
     ))
+    .add('With a payment failed banner', () => <ConfirmSend {...confirmProps} banners={[sendFailedBanner]} />)
 }
 
 export default load

--- a/shared/wallets/confirm-form/index.stories.js
+++ b/shared/wallets/confirm-form/index.stories.js
@@ -27,8 +27,6 @@ const confirmProps = {
   displayAmountXLM: '1.234 XLM',
   onBack: Sb.action('onBack'),
   onClose: Sb.action('onClose'),
-  onExitFailed: Sb.action('onExitFailed'),
-  onReviewProofs: Sb.action('onReviewProofs'),
   onSendClick: Sb.action('onSendClick'),
   readyToSend: 'enabled',
   sendFailed: false,
@@ -44,10 +42,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit.
 const banner = {
   bannerBackground: 'Announcements',
   bannerText: 'The conversion rate has changed since you got to this screen.',
-  reviewProofs: false,
 }
 
 const sendFailedBanner = {
+  action: Sb.action('onExitFailed'),
   bannerBackground: 'HighRisk',
   bannerText:
     'The request to the stellar network timed out. Please make sure your payment failed before trying again.',

--- a/shared/wallets/confirm-form/index.stories.js
+++ b/shared/wallets/confirm-form/index.stories.js
@@ -27,6 +27,8 @@ const confirmProps = {
   displayAmountXLM: '1.234 XLM',
   onBack: Sb.action('onBack'),
   onClose: Sb.action('onClose'),
+  onExitFailed: Sb.action('onExitFailed'),
+  onReviewProofs: Sb.action('onReviewProofs'),
   onSendClick: Sb.action('onSendClick'),
   readyToSend: 'enabled',
   sendFailed: false,

--- a/shared/wallets/wallet/index.js
+++ b/shared/wallets/wallet/index.js
@@ -54,7 +54,14 @@ class Wallet extends React.Component<Props> {
   _renderItem = ({item, index, section}) => {
     const children = []
     if (item === 'notLoadedYet') {
-      children.push(<Kb.ProgressIndicator key="spinner" style={styles.spinner} type="Small" />)
+      children.push(
+        <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.loadingBox} gap="tiny" gapStart={true}>
+          <Kb.ProgressIndicator key="spinner" style={styles.spinner} type="Small" />
+          <Kb.Text type="BodySmall">
+            {section.title === 'Your assets' ? 'Loading assets...' : 'Loading payments...'}
+          </Kb.Text>
+        </Kb.Box2>
+      )
     } else if (item === 'noPayments') {
       children.push(<HistoryPlaceholder key="placeholder" />)
     } else if (section.title === 'Your assets') {
@@ -127,6 +134,10 @@ const styles = Styles.styleSheetCreate({
   },
   historyPlaceholderText: {
     color: Styles.globalColors.black_40,
+  },
+  loadingBox: {
+    alignItems: 'center',
+    justifyContent: 'flex-start',
   },
   loadingMore: {
     bottom: 10,


### PR DESCRIPTION
This makes changes when a payment fails in the actual sendPayment call. For context: when this happens, we might not know if the payment went through or not.

* Add a link to the error banner to `Review payments`
* Make `Review payments` take you to a freshly loaded transaction list for the account (spinner while we're waiting)
* Make other ways to exit the dialog (back/`x` button, clicking outside the dialog) close all dialogs instead of going back to the send form

Easy to test with a service at `9db739b5a0`, add a secret note last and try sending the payment.

cc @mlsteele 

r? @keybase/react-hackers 