### PR TITLE
conflict_resolver: track failed resolutions

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -145,6 +145,9 @@ type ConfigLocal struct {
 	// blockCryptVersion is the version to use when encrypting blocks.
 	blockCryptVersion kbfscrypto.EncryptionVer
 
+	// conflictResolutionDB stores information about failed CRs
+	conflictResolutionDB *leveldb.DB
+
 	mode InitMode
 
 	quotaUsage      map[keybase1.UserOrTeamID]*EventuallyConsistentQuotaUsage
@@ -464,6 +467,8 @@ func NewConfigLocal(mode InitMode,
 	config.syncBlockCacheFraction = defaultSyncBlockCacheFraction
 
 	config.blockCryptVersion = defaultBlockCryptVersion
+
+	config.conflictResolutionDB = openCRDB(config)
 
 	return config
 }
@@ -1255,6 +1260,9 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 	if bms != nil {
 		bms.Shutdown()
 	}
+	if err := c.conflictResolutionDB.Close(); err != nil {
+		errorList = append(errorList, err)
+	}
 	kbfsServ := c.kbfsService
 	if kbfsServ != nil {
 		kbfsServ.Shutdown()
@@ -1702,6 +1710,11 @@ func (c *ConfigLocal) PrefetchStatus(ctx context.Context, tlfID tlf.ID,
 // GetRekeyFSMLimiter implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) GetRekeyFSMLimiter() *OngoingWorkLimiter {
 	return c.rekeyFSMLimiter
+}
+
+// GetConflictResolutionDB implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) GetConflictResolutionDB() (db *leveldb.DB) {
+	return c.conflictResolutionDB
 }
 
 // SetKBFSService sets the KBFSService for this ConfigLocal.

--- a/go/kbfs/libkbfs/config_mock_test.go
+++ b/go/kbfs/libkbfs/config_mock_test.go
@@ -134,6 +134,7 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 
 	config.SetMetadataVersion(defaultClientMetadataVer)
 	config.mode = modeTest{NewInitModeFromType(InitDefault)}
+	config.conflictResolutionDB = openCRDB(config)
 
 	return config
 }

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -7,6 +7,9 @@ package libkbfs
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	sysPath "path"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -17,7 +20,10 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
 	"github.com/pkg/errors"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 	"golang.org/x/net/context"
 )
 
@@ -40,6 +46,12 @@ const (
 	// How long we're allowed to block writes for if we exceed the max
 	// revisions threshold.
 	crMaxWriteLockTime = 10 * time.Second
+
+	// Where in config.StorageRoot() we store information about failed conflict
+	// resolutions.
+	conflictResolverRecordsDir           = "kbfs_conflicts"
+	conflictResolverRecordsVersionString = "v1"
+	conflictResolverRecordsDB            = "kbfsConflicts.leveldb"
 )
 
 // CtxCROpID is the display name for the unique operation
@@ -3183,6 +3195,125 @@ outer:
 	return nil
 }
 
+const conflictRecordVersion = 1
+
+type conflictRecord struct {
+	Version     int
+	Time        time.Time
+	Merged      string
+	Unmerged    string
+	ErrorTime   time.Time
+	ErrorString string
+	PanicString string
+	codec.UnknownFieldSetHandler
+}
+
+func (cr *ConflictResolver) getAndDeserializeConflicts(db *leveldb.DB,
+	key []byte) ([]conflictRecord, error) {
+	conflictsSoFarSerialized, err := db.Get(key, nil)
+	var conflictsSoFar []conflictRecord
+	switch err {
+	case leveldb.ErrNotFound:
+		conflictsSoFar = nil
+	case nil:
+		err = cr.config.Codec().Decode(conflictsSoFarSerialized,
+			&conflictsSoFar)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, err
+	}
+	return conflictsSoFar, nil
+}
+
+func (cr *ConflictResolver) serializeAndPutConflicts(db *leveldb.DB,
+	key []byte, conflicts []conflictRecord) error {
+	conflictsSerialized, err := cr.config.Codec().Encode(conflicts)
+	if err != nil {
+		return err
+	}
+	return db.Put(key, conflictsSerialized, nil)
+}
+
+func (cr *ConflictResolver) recordStartResolve(ci conflictInput) error {
+	db := cr.config.GetConflictResolutionDB()
+	key := cr.fbo.id().Bytes()
+	conflictsSoFar, err := cr.getAndDeserializeConflicts(db, key)
+	if err != nil {
+		return err
+	}
+
+	if len(conflictsSoFar) > 10 {
+		conflictsSoFar = conflictsSoFar[len(conflictsSoFar)-10:]
+	}
+	conflictsSoFar = append(conflictsSoFar, conflictRecord{
+		Version:  conflictRecordVersion,
+		Time:     cr.config.Clock().Now(),
+		Merged:   ci.merged.String(),
+		Unmerged: ci.unmerged.String(),
+	})
+	return cr.serializeAndPutConflicts(db, key, conflictsSoFar)
+}
+
+// recordFinishResolve does one of two things:
+//  - in the event of success, it deletes the DB entry that recorded conflict
+//    resolution attempts for this resolver
+//  - in the event of failure, it logs that CR failed and tries to record the
+//    failure to the DB.
+func (cr *ConflictResolver) recordFinishResolve(
+	ctx context.Context, ci conflictInput, receivedErr error) {
+	db := cr.config.GetConflictResolutionDB()
+	key := cr.fbo.id().Bytes()
+	panicVar := recover()
+
+	// If we neither errored nor panicked, this CR succeeded and we can wipe
+	// the DB entry.
+	if (receivedErr == nil || receivedErr == context.Canceled) &&
+		panicVar == nil {
+		err := db.Delete([]byte(cr.fbo.id().String()), nil)
+		if err != nil {
+			cr.log.CWarningf(ctx,
+				"Could not record conflict resolution success: %v", err)
+		}
+		return
+	}
+
+	var err error
+	defer func() {
+		// If we can't record the failure to the CR DB, at least log it.
+		if err != nil {
+			cr.log.CWarningf(ctx,
+				"Could not record conflict resolution failure [%v/%v]: %v",
+				receivedErr, panicVar, err)
+		}
+		// If we recovered from a panic, keep panicking.
+		if panicVar != nil {
+			panic(panicVar)
+		}
+	}()
+
+	// Otherwise we need to decode the most recent entry, modify it, and put it
+	// back in the DB.
+	var conflictsSoFar []conflictRecord
+	conflictsSoFar, err = cr.getAndDeserializeConflicts(db, key)
+	if err != nil {
+		return
+	}
+
+	thisCR := &conflictsSoFar[len(conflictsSoFar)-1]
+	thisCR.ErrorTime = cr.config.Clock().Now()
+	if receivedErr != nil {
+		thisCR.ErrorString = fmt.Sprintf("%+v", receivedErr)
+	}
+	if panicVar != nil {
+		thisCR.PanicString = fmt.Sprintf("panic(%s). stack: %b", panicVar,
+			debug.Stack())
+	}
+
+	err = cr.serializeAndPutConflicts(db, key, conflictsSoFar)
+}
+
 // CRWrapError wraps an error that happens during conflict resolution.
 type CRWrapError struct {
 	err error
@@ -3198,6 +3329,14 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	ctx = cr.config.MaybeStartTrace(ctx, "CR.doResolve",
 		fmt.Sprintf("%s %+v", cr.fbo.folderBranch, ci))
 	defer func() { cr.config.MaybeFinishTrace(ctx, err) }()
+
+	err = cr.recordStartResolve(ci)
+	if err != nil {
+		cr.log.CWarningf(ctx,
+			"Could not record conflict resolution attempt: %v", err)
+	} else {
+		defer func() { cr.recordFinishResolve(ctx, ci, err) }()
+	}
 
 	cr.log.CDebugf(ctx, "Starting conflict resolution with input %+v", ci)
 	lState := makeFBOLockState()
@@ -3439,4 +3578,28 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	// don't count against the quota forever.  (Though of course if we
 	// completely fail, we'll need to rely on a future complete scan
 	// to clean up the quota anyway . . .)
+}
+
+func openCRDBInternal(config Config) (*leveldb.DB, error) {
+	if config.IsTestMode() {
+		return leveldb.Open(storage.NewMemStorage(), leveldbOptions)
+	}
+	err := os.MkdirAll(sysPath.Join(config.StorageRoot(),
+		conflictResolverRecordsDir, conflictResolverRecordsVersionString),
+		os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	return leveldb.OpenFile(sysPath.Join(config.StorageRoot(),
+		conflictResolverRecordsDir, conflictResolverRecordsVersionString,
+		conflictResolverRecordsDB), leveldbOptions)
+}
+
+func openCRDB(config Config) (db *leveldb.DB) {
+	db, err := openCRDBInternal(config)
+	if err != nil {
+		panic(fmt.Sprintf("Could not open conflict resolver DB: %v", err))
+	}
+	return db
 }

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -58,6 +58,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	initSuccess = true
 	return ctx, cancel, mockCtrl, config, fbo.cr
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	metrics "github.com/rcrowley/go-metrics"
+	"github.com/syndtr/goleveldb/leveldb"
 	"golang.org/x/net/context"
 	billy "gopkg.in/src-d/go-billy.v4"
 )
@@ -514,7 +515,6 @@ type KBFSOps interface {
 
 	// GetNodeMetadata gets metadata associated with a Node.
 	GetNodeMetadata(ctx context.Context, node Node) (NodeMetadata, error)
-
 	// Shutdown is called to clean up any resources associated with
 	// this KBFSOps instance.
 	Shutdown(ctx context.Context) error
@@ -2393,6 +2393,9 @@ type Config interface {
 	SetBlockCryptVersion(kbfscrypto.EncryptionVer)
 	DefaultBlockType() keybase1.BlockType
 	SetDefaultBlockType(blockType keybase1.BlockType)
+	// GetConflictResolutionDB gets the levelDB in which conflict resolution
+	// status is stored.
+	GetConflictResolutionDB() (db *leveldb.DB)
 	RekeyQueue() RekeyQueue
 	SetRekeyQueue(RekeyQueue)
 	// ReqsBufSize indicates the number of read or write operations

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -17,6 +17,7 @@ import (
 	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	go_metrics "github.com/rcrowley/go-metrics"
+	leveldb "github.com/syndtr/goleveldb/leveldb"
 	context "golang.org/x/net/context"
 	go_billy_v4 "gopkg.in/src-d/go-billy.v4"
 	reflect "reflect"
@@ -2237,6 +2238,20 @@ func (m *MockKBFSOps) GetNodeMetadata(ctx context.Context, node Node) (NodeMetad
 func (mr *MockKBFSOpsMockRecorder) GetNodeMetadata(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeMetadata", reflect.TypeOf((*MockKBFSOps)(nil).GetNodeMetadata), ctx, node)
+}
+
+// GetConflictResolutionDB mocks base method
+func (m *MockKBFSOps) GetConflictResolutionDB() *leveldb.DB {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConflictResolutionDB")
+	ret0, _ := ret[0].(*leveldb.DB)
+	return ret0
+}
+
+// GetConflictResolutionDB indicates an expected call of GetConflictResolutionDB
+func (mr *MockKBFSOpsMockRecorder) GetConflictResolutionDB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConflictResolutionDB", reflect.TypeOf((*MockKBFSOps)(nil).GetConflictResolutionDB))
 }
 
 // Shutdown mocks base method
@@ -9945,6 +9960,20 @@ func (m *MockConfig) SetDefaultBlockType(blockType keybase1.BlockType) {
 func (mr *MockConfigMockRecorder) SetDefaultBlockType(blockType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultBlockType", reflect.TypeOf((*MockConfig)(nil).SetDefaultBlockType), blockType)
+}
+
+// GetConflictResolutionDB mocks base method
+func (m *MockConfig) GetConflictResolutionDB() *leveldb.DB {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConflictResolutionDB")
+	ret0, _ := ret[0].(*leveldb.DB)
+	return ret0
+}
+
+// GetConflictResolutionDB indicates an expected call of GetConflictResolutionDB
+func (mr *MockConfigMockRecorder) GetConflictResolutionDB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConflictResolutionDB", reflect.TypeOf((*MockConfig)(nil).GetConflictResolutionDB))
 }
 
 // RekeyQueue mocks base method


### PR DESCRIPTION
Porting from keybase/kbfs#1990

Create a database to keep track of failed conflict resolutions. In the future this will be used to prevent conflict resolution from being attempted when it has failed repeatedly.

Issue: KBFS-3680

@jakob223 @strib 