### PR TITLE
prefetcher: track prefetch progress

### DIFF
--- a/go/kbfs/libfs/file_info.go
+++ b/go/kbfs/libfs/file_info.go
@@ -76,8 +76,9 @@ func (fi *FileInfo) IsDir() bool {
 // KBFSMetadataForSimpleFS contains the KBFS metadata needed to answer a
 // simpleFSStat call.
 type KBFSMetadataForSimpleFS struct {
-	LastWriter     keybase1.User
-	PrefetchStatus keybase1.PrefetchStatus
+	LastWriter         keybase1.User
+	PrefetchStatus     keybase1.PrefetchStatus
+	PrefetchByteStatus libkbfs.PrefetchByteStatus
 }
 
 // KBFSMetadataForSimpleFSGetter is an interface for something that can return
@@ -124,6 +125,9 @@ func (fis fileInfoSys) KBFSMetadataForSimpleFS() (
 	}
 
 	status := KBFSMetadataForSimpleFS{PrefetchStatus: prefetchStatus}
+	if md.PrefetchByteStatus != nil {
+		status.PrefetchByteStatus = *md.PrefetchByteStatus
+	}
 
 	lastWriterName := md.LastWriterUnverified
 	if lastWriterName == "" {
@@ -141,13 +145,12 @@ func (fis fileInfoSys) KBFSMetadataForSimpleFS() (
 	if err != nil {
 		return KBFSMetadataForSimpleFS{}, err
 	}
-	return KBFSMetadataForSimpleFS{
-		LastWriter: keybase1.User{
-			Uid:      uid,
-			Username: lastWriterName.String(),
-		},
-		PrefetchStatus: prefetchStatus,
-	}, nil
+
+	status.LastWriter = keybase1.User{
+		Uid:      uid,
+		Username: lastWriterName.String(),
+	}
+	return status, nil
 }
 
 var _ PrevRevisionsGetter = fileInfoSys{}

--- a/go/kbfs/libfs/file_info.go
+++ b/go/kbfs/libfs/file_info.go
@@ -76,9 +76,9 @@ func (fi *FileInfo) IsDir() bool {
 // KBFSMetadataForSimpleFS contains the KBFS metadata needed to answer a
 // simpleFSStat call.
 type KBFSMetadataForSimpleFS struct {
-	LastWriter         keybase1.User
-	PrefetchStatus     keybase1.PrefetchStatus
-	PrefetchByteStatus libkbfs.PrefetchByteStatus
+	LastWriter       keybase1.User
+	PrefetchStatus   keybase1.PrefetchStatus
+	PrefetchProgress libkbfs.PrefetchProgress
 }
 
 // KBFSMetadataForSimpleFSGetter is an interface for something that can return
@@ -125,8 +125,8 @@ func (fis fileInfoSys) KBFSMetadataForSimpleFS() (
 	}
 
 	status := KBFSMetadataForSimpleFS{PrefetchStatus: prefetchStatus}
-	if md.PrefetchByteStatus != nil {
-		status.PrefetchByteStatus = *md.PrefetchByteStatus
+	if md.PrefetchProgress != nil {
+		status.PrefetchProgress = *md.PrefetchProgress
 	}
 
 	lastWriterName := md.LastWriterUnverified

--- a/go/kbfs/libkbfs/block_ops.go
+++ b/go/kbfs/libkbfs/block_ops.go
@@ -25,6 +25,7 @@ type blockOpsConfig interface {
 	syncedTlfGetterSetter
 	initModeGetter
 	blockCryptVersioner
+	clockGetter
 }
 
 // BlockOpsStandard implements the BlockOps interface by relaying

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -87,6 +87,7 @@ type testBlockOpsConfig struct {
 	diskBlockCacheGetter
 	*testSyncedTlfGetterSetter
 	initModeGetter
+	clock Clock
 }
 
 var _ blockOpsConfig = (*testBlockOpsConfig)(nil)
@@ -115,6 +116,10 @@ func (config testBlockOpsConfig) BlockCryptVersion() kbfscrypto.EncryptionVer {
 	return kbfscrypto.EncryptionSecretbox
 }
 
+func (config testBlockOpsConfig) Clock() Clock {
+	return config.clock
+}
+
 func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 	lm := newTestLogMaker(t)
 	codecGetter := newTestCodecGetter()
@@ -124,7 +129,7 @@ func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 	dbcg := newTestDiskBlockCacheGetter(t, nil)
 	stgs := newTestSyncedTlfGetterSetter()
 	return testBlockOpsConfig{codecGetter, lm, bserver, crypto, cache, dbcg,
-		stgs, testInitModeGetter{InitDefault}}
+		stgs, testInitModeGetter{InitDefault}, newTestClockNow()}
 }
 
 // TestBlockOpsReadySuccess checks that BlockOpsStandard.Ready()

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -39,6 +39,7 @@ type blockRetrievalPartialConfig interface {
 	diskBlockCacheGetter
 	syncedTlfGetterSetter
 	initModeGetter
+	clockGetter
 }
 
 type blockRetrievalConfig interface {

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -25,6 +25,7 @@ type testBlockRetrievalConfig struct {
 	*testDiskBlockCacheGetter
 	*testSyncedTlfGetterSetter
 	initModeGetter
+	clock Clock
 }
 
 func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter,
@@ -37,6 +38,7 @@ func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter,
 		newTestDiskBlockCacheGetter(t, dbc),
 		newTestSyncedTlfGetterSetter(),
 		testInitModeGetter{InitDefault},
+		newTestClockNow(),
 	}
 }
 
@@ -46,6 +48,10 @@ func (c *testBlockRetrievalConfig) BlockCache() BlockCache {
 
 func (c testBlockRetrievalConfig) DataVersion() DataVer {
 	return ChildHolesDataVer
+}
+
+func (c testBlockRetrievalConfig) Clock() Clock {
+	return c.clock
 }
 
 func (c testBlockRetrievalConfig) blockGetter() blockGetter {

--- a/go/kbfs/libkbfs/block_retrieval_worker_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_worker_test.go
@@ -103,17 +103,32 @@ func (bg *fakeBlockGetter) assembleBlock(ctx context.Context,
 	return nil
 }
 
+const testFakeBlockSize = uint32(150)
+
 func makeFakeFileBlock(t *testing.T, doHash bool) *FileBlock {
 	buf := make([]byte, 16)
 	_, err := rand.Read(buf)
 	require.NoError(t, err)
 	block := &FileBlock{
+		CommonBlock: CommonBlock{
+			cachedEncodedSize: testFakeBlockSize,
+		},
 		Contents: buf,
 	}
 	if doHash {
 		_ = block.GetHash()
 	}
 	return block
+}
+
+func makeFakeFileBlockWithIPtrs(iptrs []IndirectFilePtr) *FileBlock {
+	return &FileBlock{
+		CommonBlock: CommonBlock{
+			IsInd:             true,
+			cachedEncodedSize: testFakeBlockSize,
+		},
+		IPtrs: iptrs,
+	}
 }
 
 func TestBlockRetrievalWorkerBasic(t *testing.T) {

--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -755,7 +755,7 @@ type NodeMetadata struct {
 	LastWriterUnverified kbname.NormalizedUsername
 	BlockInfo            BlockInfo
 	PrefetchStatus       PrefetchStatus
-	PrefetchByteStatus   *PrefetchByteStatus `json:",omitempty"`
+	PrefetchProgress     *PrefetchProgress `json:",omitempty"`
 }
 
 // FavoritesOp defines an operation related to favorites.

--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -755,6 +755,7 @@ type NodeMetadata struct {
 	LastWriterUnverified kbname.NormalizedUsername
 	BlockInfo            BlockInfo
 	PrefetchStatus       PrefetchStatus
+	PrefetchByteStatus   *PrefetchByteStatus `json:",omitempty"`
 }
 
 // FavoritesOp defines an operation related to favorites.

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3204,7 +3204,7 @@ func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 		if err != nil {
 			return res, err
 		}
-		res.PrefetchByteStatus = &byteStatus
+		res.PrefetchProgress = &byteStatus
 	}
 	return res, nil
 }

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3198,6 +3198,14 @@ func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	}
 	res.PrefetchStatus = fbo.config.PrefetchStatus(ctx, fbo.id(),
 		res.BlockInfo.BlockPointer)
+	if res.PrefetchStatus == TriggeredPrefetch {
+		byteStatus, err := fbo.config.BlockOps().Prefetcher().Status(
+			ctx, res.BlockInfo.BlockPointer)
+		if err != nil {
+			return res, err
+		}
+		res.PrefetchByteStatus = &byteStatus
+	}
 	return res, nil
 }
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1690,6 +1690,16 @@ type KeyOps interface {
 		serverHalfID kbfscrypto.TLFCryptKeyServerHalfID) error
 }
 
+// PrefetchByteStatus tracks the number of bytes fetched for the block
+// tree rooted at a given block, along with the known total number of
+// bytes in that tree, and the start time of the prefetch.  Note that
+// the total can change over time as more blocks are downloaded.
+type PrefetchByteStatus struct {
+	SubtreeBytesFetched uint64
+	SubtreeBytesTotal   uint64
+	Start               time.Time
+}
+
 // Prefetcher is an interface to a block prefetcher.
 type Prefetcher interface {
 	// ProcessBlockForPrefetch potentially triggers and monitors a prefetch.
@@ -1704,6 +1714,9 @@ type Prefetcher interface {
 	// what they expect it to be, in case there was an error.
 	WaitChannelForBlockPrefetch(ctx context.Context, ptr BlockPointer) (
 		<-chan struct{}, error)
+	// Status returns the current status of the prefetch for the block
+	// tree rooted at the given pointer.
+	Status(ctx context.Context, ptr BlockPointer) (PrefetchByteStatus, error)
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(BlockPointer)

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1690,11 +1690,11 @@ type KeyOps interface {
 		serverHalfID kbfscrypto.TLFCryptKeyServerHalfID) error
 }
 
-// PrefetchByteStatus tracks the number of bytes fetched for the block
+// PrefetchProgress tracks the number of bytes fetched for the block
 // tree rooted at a given block, along with the known total number of
 // bytes in that tree, and the start time of the prefetch.  Note that
 // the total can change over time as more blocks are downloaded.
-type PrefetchByteStatus struct {
+type PrefetchProgress struct {
 	SubtreeBytesFetched uint64
 	SubtreeBytesTotal   uint64
 	Start               time.Time
@@ -1716,7 +1716,7 @@ type Prefetcher interface {
 		<-chan struct{}, error)
 	// Status returns the current status of the prefetch for the block
 	// tree rooted at the given pointer.
-	Status(ctx context.Context, ptr BlockPointer) (PrefetchByteStatus, error)
+	Status(ctx context.Context, ptr BlockPointer) (PrefetchProgress, error)
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(BlockPointer)

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -127,9 +127,10 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	config.mockBops.EXPECT().Archive(gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore BlockRetriever calls
-	brc := &testBlockRetrievalConfig{nil, newTestLogMaker(t),
-		config.BlockCache(), nil, newTestDiskBlockCacheGetter(t, nil),
-		newTestSyncedTlfGetterSetter(), testInitModeGetter{InitDefault}}
+	brc := &testBlockRetrievalConfig{
+		nil, newTestLogMaker(t), config.BlockCache(), nil,
+		newTestDiskBlockCacheGetter(t, nil), newTestSyncedTlfGetterSetter(),
+		testInitModeGetter{InitDefault}, newTestClockNow()}
 	brq := newBlockRetrievalQueue(0, 0, 0, brc)
 	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)
 	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(brq.prefetcher)
@@ -1356,6 +1357,7 @@ func makeDirTree(id tlf.ID, uid keybase1.UserOrTeamID, components ...string) (
 	}
 	nodes := []pathNode{{bi.BlockPointer, "{root}"}}
 	rootBlock := NewDirBlock().(*DirBlock)
+	rootBlock.SetEncodedSize(bi.EncodedSize)
 	blocks := []*DirBlock{rootBlock}
 
 	// Handle the rest.
@@ -1372,6 +1374,7 @@ func makeDirTree(id tlf.ID, uid keybase1.UserOrTeamID, components ...string) (
 		}
 		nodes = append(nodes, pathNode{bi.BlockPointer, component})
 		dirBlock := NewDirBlock().(*DirBlock)
+		dirBlock.SetEncodedSize(bi.EncodedSize)
 		blocks = append(blocks, dirBlock)
 
 		parentDirBlock = dirBlock

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -6514,9 +6514,9 @@ func (mr *MockPrefetcherMockRecorder) WaitChannelForBlockPrefetch(ctx, ptr inter
 }
 
 // Status mocks base method
-func (m *MockPrefetcher) Status(ctx context.Context, ptr BlockPointer) (PrefetchByteStatus, error) {
+func (m *MockPrefetcher) Status(ctx context.Context, ptr BlockPointer) (PrefetchProgress, error) {
 	ret := m.ctrl.Call(m, "Status", ctx, ptr)
-	ret0, _ := ret[0].(PrefetchByteStatus)
+	ret0, _ := ret[0].(PrefetchProgress)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -6513,6 +6513,19 @@ func (mr *MockPrefetcherMockRecorder) WaitChannelForBlockPrefetch(ctx, ptr inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitChannelForBlockPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).WaitChannelForBlockPrefetch), ctx, ptr)
 }
 
+// Status mocks base method
+func (m *MockPrefetcher) Status(ctx context.Context, ptr BlockPointer) (PrefetchByteStatus, error) {
+	ret := m.ctrl.Call(m, "Status", ctx, ptr)
+	ret0, _ := ret[0].(PrefetchByteStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Status indicates an expected call of Status
+func (mr *MockPrefetcherMockRecorder) Status(ctx, ptr interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockPrefetcher)(nil).Status), ctx, ptr)
+}
+
 // CancelPrefetch mocks base method
 func (m *MockPrefetcher) CancelPrefetch(arg0 BlockPointer) {
 	m.ctrl.T.Helper()

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -30,10 +31,12 @@ type prefetcherConfig interface {
 	logMaker
 	blockCacher
 	diskBlockCacheGetter
+	clockGetter
 }
 
 type prefetchRequest struct {
 	ptr            BlockPointer
+	encodedSize    uint32
 	newBlock       func() Block
 	kmd            KeyMetadata
 	priority       int
@@ -58,9 +61,12 @@ const (
 )
 
 type prefetch struct {
-	subtreeBlockCount int
-	subtreeTriggered  bool
-	req               *prefetchRequest
+	subtreeBlockCount   int
+	subtreeBytesFetched uint64
+	subtreeBytesTotal   uint64
+	start               time.Time
+	subtreeTriggered    bool
+	req                 *prefetchRequest
 	// Each refnonce for this block ID can have a different set of
 	// parents.  Track the channel for the specific instance of the
 	// prefetch that counted us in its progress (since a parent may be
@@ -170,13 +176,16 @@ func newBlockPrefetcher(retriever BlockRetriever,
 	return p
 }
 
-func (p *blockPrefetcher) newPrefetch(count int, triggered bool,
+func (p *blockPrefetcher) newPrefetch(
+	count int, bytes uint64, triggered bool,
 	req *prefetchRequest) *prefetch {
 	ctx, cancel := context.WithTimeout(p.ctx, prefetchTimeout)
 	ctx = CtxWithRandomIDReplayable(
 		ctx, ctxPrefetchIDKey, ctxPrefetchID, p.log)
 	return &prefetch{
 		subtreeBlockCount: count,
+		subtreeBytesTotal: bytes,
+		start:             p.config.Clock().Now(),
 		subtreeTriggered:  triggered,
 		req:               req,
 		parents:           make(map[kbfsblock.RefNonce]map[BlockPointer]<-chan struct{}),
@@ -284,9 +293,10 @@ func (p *blockPrefetcher) applyToParentsRecursive(
 // hit get marked complete and deleted.
 // TODO: If we ever hit a lower number than the child, panic.
 func (p *blockPrefetcher) completePrefetch(
-	numBlocks int) func(kbfsblock.ID, *prefetch) {
+	numBlocks int, numBytes uint64) func(kbfsblock.ID, *prefetch) {
 	return func(blockID kbfsblock.ID, pp *prefetch) {
 		pp.subtreeBlockCount -= numBlocks
+		pp.subtreeBytesFetched += numBytes
 		if pp.subtreeBlockCount < 0 {
 			// Both log and panic so that we get the PFID in the log.
 			p.log.CErrorf(pp.ctx, "panic: completePrefetch overstepped its "+
@@ -299,6 +309,10 @@ func (p *blockPrefetcher) completePrefetch(
 			panic("completePrefetch got a nil req")
 		}
 		if pp.subtreeBlockCount == 0 {
+			if pp.subtreeBytesFetched != pp.subtreeBytesTotal {
+				panic(fmt.Sprintf("Bytes fetch mismatch: fetched=%d, total=%d",
+					pp.subtreeBytesFetched, pp.subtreeBytesTotal))
+			}
 			delete(p.prefetches, blockID)
 			p.clearRescheduleState(blockID)
 			delete(p.rescheduled, blockID)
@@ -329,6 +343,20 @@ func (p *blockPrefetcher) decrementPrefetch(blockID kbfsblock.ID, pp *prefetch) 
 		// Both log and panic so that we get the PFID in the log.
 		p.log.CErrorf(pp.ctx, "panic: decrementPrefetch overstepped its bounds")
 		panic("decrementPrefetch overstepped its bounds")
+	}
+}
+
+func (p *blockPrefetcher) addFetchedBytes(bytes uint64) func(
+	kbfsblock.ID, *prefetch) {
+	return func(blockID kbfsblock.ID, pp *prefetch) {
+		pp.subtreeBytesFetched += bytes
+		if pp.subtreeBytesFetched > pp.subtreeBytesTotal {
+			// Both log and panic so that we get the PFID in the log.
+			p.log.CErrorf(pp.ctx, "panic: addFetchedBytes overstepped "+
+				"its bounds (fetched=%d, total=%d)", pp.subtreeBytesFetched,
+				pp.subtreeBytesTotal)
+			panic("addFetchedBytes overstepped its bounds")
+		}
 	}
 }
 
@@ -420,12 +448,14 @@ func (p *blockPrefetcher) calculatePriority(
 // request maps the parent->child block relationship in the prefetcher, and it
 // triggers child prefetches that aren't already in progress.
 func (p *blockPrefetcher) request(ctx context.Context, priority int,
-	kmd KeyMetadata, ptr BlockPointer, block Block,
+	kmd KeyMetadata, info BlockInfo, block Block,
 	lifetime BlockCacheLifetime, parentPtr BlockPointer,
 	isParentNew bool, action BlockRequestAction,
-	idsSeen map[kbfsblock.ID]bool) (numBlocks int) {
+	idsSeen map[kbfsblock.ID]bool) (
+	numBlocks int, numBytesFetched, numBytesTotal uint64) {
+	ptr := info.BlockPointer
 	if idsSeen[ptr.ID] {
-		return 0
+		return 0, 0, 0
 	}
 	idsSeen[ptr.ID] = true
 
@@ -436,9 +466,10 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 		// If the block isn't in the tree, we add it with a block count of 1 (a
 		// later TriggerPrefetch will come in and decrement it).
 		obseleted := make(chan struct{})
-		req := &prefetchRequest{ptr, block.NewEmptier(), kmd, priority,
-			lifetime, NoPrefetch, action, nil, obseleted}
-		pre = p.newPrefetch(1, false, req)
+		req := &prefetchRequest{
+			ptr, info.EncodedSize, block.NewEmptier(), kmd, priority, lifetime,
+			NoPrefetch, action, nil, obsoleted}
+		pre = p.newPrefetch(1, uint64(info.EncodedSize), false, req)
 		p.prefetches[ptr.ID] = pre
 	}
 	// If this is a new prefetch, or if we need to update the action,
@@ -479,45 +510,55 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 				"Prefetching %v, action=%s, numBlocks=%d, isParentNew=%t",
 				ptr, action, pre.subtreeBlockCount, isParentNew)
 		}
-		return pre.subtreeBlockCount
+		return pre.subtreeBlockCount, pre.subtreeBytesFetched,
+			pre.subtreeBytesTotal
 	}
-	return 0
+	return 0, 0, 0
 }
 
 func (p *blockPrefetcher) prefetchIndirectFileBlock(
 	ctx context.Context, parentPtr BlockPointer, b *FileBlock,
 	kmd KeyMetadata, lifetime BlockCacheLifetime, isPrefetchNew bool,
-	action BlockRequestAction, basePriority int) (numBlocks int, isTail bool) {
+	action BlockRequestAction, basePriority int) (
+	numBlocks int, numBytesFetched, numBytesTotal uint64, isTail bool) {
 	// Prefetch indirect block pointers.
 	newPriority := p.calculatePriority(basePriority, action)
 	idsSeen := make(map[kbfsblock.ID]bool, len(b.IPtrs))
 	for _, ptr := range b.IPtrs {
-		numBlocks += p.request(ctx, newPriority, kmd,
-			ptr.BlockPointer, b.NewEmpty(), lifetime,
+		b, f, t := p.request(
+			ctx, newPriority, kmd, ptr.BlockInfo, b.NewEmpty(), lifetime,
 			parentPtr, isPrefetchNew, action, idsSeen)
+		numBlocks += b
+		numBytesFetched += f
+		numBytesTotal += t
 	}
-	return numBlocks, len(b.IPtrs) == 0
+	return numBlocks, numBytesFetched, numBytesTotal, len(b.IPtrs) == 0
 }
 
 func (p *blockPrefetcher) prefetchIndirectDirBlock(
 	ctx context.Context, parentPtr BlockPointer, b *DirBlock,
 	kmd KeyMetadata, lifetime BlockCacheLifetime, isPrefetchNew bool,
-	action BlockRequestAction, basePriority int) (numBlocks int, isTail bool) {
+	action BlockRequestAction, basePriority int) (
+	numBlocks int, numBytesFetched, numBytesTotal uint64, isTail bool) {
 	// Prefetch indirect block pointers.
 	newPriority := p.calculatePriority(basePriority, action)
 	idsSeen := make(map[kbfsblock.ID]bool, len(b.IPtrs))
 	for _, ptr := range b.IPtrs {
-		numBlocks += p.request(ctx, newPriority, kmd,
-			ptr.BlockPointer, b.NewEmpty(), lifetime,
+		b, f, t := p.request(
+			ctx, newPriority, kmd, ptr.BlockInfo, b.NewEmpty(), lifetime,
 			parentPtr, isPrefetchNew, action, idsSeen)
+		numBlocks += b
+		numBytesFetched += f
+		numBytesTotal += t
 	}
-	return numBlocks, len(b.IPtrs) == 0
+	return numBlocks, numBytesFetched, numBytesTotal, len(b.IPtrs) == 0
 }
 
 func (p *blockPrefetcher) prefetchDirectDirBlock(
 	ctx context.Context, parentPtr BlockPointer, b *DirBlock,
 	kmd KeyMetadata, lifetime BlockCacheLifetime, isPrefetchNew bool,
-	action BlockRequestAction, basePriority int) (numBlocks int, isTail bool) {
+	action BlockRequestAction, basePriority int) (
+	numBlocks int, numBytesFetched, numBytesTotal uint64, isTail bool) {
 	// Prefetch all DirEntry root blocks.
 	dirEntries := dirEntriesBySizeAsc{dirEntryMapToDirEntries(b.Children)}
 	sort.Sort(dirEntries)
@@ -542,13 +583,17 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(
 			continue
 		}
 		totalChildEntries++
-		numBlocks += p.request(ctx, newPriority, kmd, entry.BlockPointer,
-			block, lifetime, parentPtr, isPrefetchNew, action, idsSeen)
+		b, f, t := p.request(
+			ctx, newPriority, kmd, entry.BlockInfo, block, lifetime,
+			parentPtr, isPrefetchNew, action, idsSeen)
+		numBlocks += b
+		numBytesFetched += f
+		numBytesTotal += t
 	}
 	if totalChildEntries == 0 {
 		isTail = true
 	}
-	return numBlocks, isTail
+	return numBlocks, numBytesFetched, numBytesTotal, isTail
 }
 
 // handlePrefetch allows the prefetcher to trigger prefetches. `run` calls this
@@ -559,33 +604,37 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(
 // added to the tree.
 func (p *blockPrefetcher) handlePrefetch(
 	pre *prefetch, isPrefetchNew bool, action BlockRequestAction, b Block) (
-	numBlocks int, isTail bool, err error) {
+	numBlocks int, numBytesFetched, numBytesTotal uint64, isTail bool,
+	err error) {
 	req := pre.req
 	childAction := action.ChildAction(b)
 	switch b := b.(type) {
 	case *FileBlock:
 		if b.IsInd {
-			numBlocks, isTail = p.prefetchIndirectFileBlock(
-				pre.ctx, req.ptr, b, req.kmd, req.lifetime, isPrefetchNew,
-				childAction, req.priority)
+			numBlocks, numBytesFetched, numBytesTotal, isTail =
+				p.prefetchIndirectFileBlock(
+					pre.ctx, req.ptr, b, req.kmd, req.lifetime,
+					isPrefetchNew, childAction, req.priority)
 		} else {
 			isTail = true
 		}
 	case *DirBlock:
 		if b.IsInd {
-			numBlocks, isTail = p.prefetchIndirectDirBlock(
-				pre.ctx, req.ptr, b, req.kmd, req.lifetime, isPrefetchNew,
-				childAction, req.priority)
+			numBlocks, numBytesFetched, numBytesTotal, isTail =
+				p.prefetchIndirectDirBlock(
+					pre.ctx, req.ptr, b, req.kmd, req.lifetime,
+					isPrefetchNew, childAction, req.priority)
 		} else {
-			numBlocks, isTail = p.prefetchDirectDirBlock(
-				pre.ctx, req.ptr, b, req.kmd, req.lifetime, isPrefetchNew,
-				childAction, req.priority)
+			numBlocks, numBytesFetched, numBytesTotal, isTail =
+				p.prefetchDirectDirBlock(
+					pre.ctx, req.ptr, b, req.kmd, req.lifetime,
+					isPrefetchNew, childAction, req.priority)
 		}
 	default:
 		// Skipping prefetch for block of unknown type (likely CommonBlock)
-		return 0, false, errors.New("unknown block type")
+		return 0, 0, 0, false, errors.New("unknown block type")
 	}
-	return numBlocks, isTail, nil
+	return numBlocks, numBytesFetched, numBytesTotal, isTail, nil
 }
 
 func (p *blockPrefetcher) rescheduleTopBlock(
@@ -764,7 +813,7 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				// Create new prefetch here while rescheduling, to
 				// prevent other subsequent requests from creating
 				// one.
-				pre = p.newPrefetch(1, false, req)
+				pre = p.newPrefetch(1, uint64(req.encodedSize), false, req)
 				p.prefetches[blockID] = pre
 			} else {
 				pre.req = req
@@ -844,7 +893,9 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 					// guaranteed that `pre` will be removed from the
 					// prefetcher.
 					p.applyToParentsRecursive(
-						p.completePrefetch(pre.subtreeBlockCount),
+						p.completePrefetch(
+							pre.subtreeBlockCount,
+							pre.subtreeBytesTotal-pre.subtreeBytesFetched),
 						req.ptr.ID, pre)
 				} else {
 					p.log.CDebugf(ctx, "skipping prefetch for finished block "+
@@ -937,8 +988,11 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 						panic("prefetch was in the tree, wasn't triggered, " +
 							"but had a block count of 0")
 					}
-					p.applyToParentsRecursive(p.decrementPrefetch, req.ptr.ID,
-						pre)
+					p.applyToParentsRecursive(
+						p.decrementPrefetch, req.ptr.ID, pre)
+					p.applyToParentsRecursive(
+						p.addFetchedBytes(
+							uint64(b.GetEncodedSize())), req.ptr.ID, pre)
 					pre.subtreeTriggered = true
 					pre.req.action = newAction
 				}
@@ -947,7 +1001,7 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				// If the prefetch is to be tracked, then the 0
 				// `subtreeBlockCount` will be incremented by `numBlocks`
 				// below, once we've ensured that `numBlocks` is not 0.
-				pre = p.newPrefetch(0, true, req)
+				pre = p.newPrefetch(0, 0, true, req)
 				p.prefetches[req.ptr.ID] = pre
 				ctx = pre.ctx
 				p.log.CDebugf(ctx, "created new prefetch for block %s",
@@ -964,8 +1018,8 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 			//
 			// `numBlocks` now represents only the number of blocks to add
 			// to the tree from `pre` to its roots, inclusive.
-			numBlocks, isTail, err := p.handlePrefetch(
-				pre, !isPrefetchWaiting, req.action, b)
+			numBlocks, numBytesFetched, numBytesTotal, isTail, err :=
+				p.handlePrefetch(pre, !isPrefetchWaiting, req.action, b)
 			if err != nil {
 				p.log.CWarningf(ctx, "error handling prefetch for block %s: "+
 					"%+v", req.ptr.ID, err)
@@ -990,7 +1044,7 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				// only walk up the tree once. We'd track a `numBlocks` and
 				// complete or decrement as appropriate.
 				p.applyToParentsRecursive(
-					p.completePrefetch(0), req.ptr.ID, pre)
+					p.completePrefetch(0, 0), req.ptr.ID, pre)
 				continue
 			}
 			// This is not a tail block.
@@ -1014,12 +1068,15 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				// shouldn't block anything above it in the tree from
 				// completing.
 			}
-			p.log.CDebugf(ctx, "prefetching %d block(s) with parent block %s",
-				numBlocks, req.ptr.ID)
+			p.log.CDebugf(ctx, "prefetching %d block(s) with parent block %s "+
+				"[bytesFetched=%d, bytesTotal=%d]",
+				numBlocks, numBytesFetched, numBytesTotal, req.ptr.ID)
 			// Walk up the block tree and add numBlocks to every parent,
 			// starting with this block.
 			p.applyToParentsRecursive(func(blockID kbfsblock.ID, pp *prefetch) {
 				pp.subtreeBlockCount += numBlocks
+				pp.subtreeBytesFetched += numBytesFetched
+				pp.subtreeBytesTotal += numBytesTotal
 			}, req.ptr.ID, pre)
 		case <-p.almostDoneCh:
 			p.log.CDebugf(p.ctx, "starting shutdown")
@@ -1077,9 +1134,9 @@ func (p *blockPrefetcher) ProcessBlockForPrefetch(ctx context.Context,
 	ptr BlockPointer, block Block, kmd KeyMetadata, priority int,
 	lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus,
 	action BlockRequestAction) {
-	req := &prefetchRequest{ptr, block.NewEmptier(), kmd, priority, lifetime,
-		prefetchStatus, action, nil, nil}
-
+	req := &prefetchRequest{
+		ptr, block.GetEncodedSize(), block.NewEmptier(), kmd, priority,
+		lifetime, prefetchStatus, action, nil, nil}
 	if prefetchStatus == FinishedPrefetch {
 		// Finished prefetches can always be short circuited.
 		// If we're here, then FinishedPrefetch is already cached.
@@ -1114,7 +1171,7 @@ func (p *blockPrefetcher) WaitChannelForBlockPrefetch(
 	waitCh <-chan struct{}, err error) {
 	c := make(chan (<-chan struct{}), 1)
 	req := &prefetchRequest{
-		ptr, nil, nil, 0, TransientEntry, 0, BlockRequestSolo, c, nil}
+		ptr, 0, nil, nil, 0, TransientEntry, 0, BlockRequestSolo, c, nil}
 
 	select {
 	case p.prefetchRequestCh.In() <- req:

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -682,7 +682,7 @@ func testPrefetcherForSyncedTLF(
 		context.Background(), individualTestTimeout)
 	defer cancel()
 	waitChCh := make(chan (<-chan struct{}), 1)
-	statusCh := make(chan PrefetchByteStatus)
+	statusCh := make(chan PrefetchProgress)
 	go func() {
 		waitCh, err := q.Prefetcher().WaitChannelForBlockPrefetch(ctx, rootPtr)
 		if err != nil {

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -22,7 +22,7 @@ import (
 func makeRandomBlockInfo(t *testing.T) BlockInfo {
 	return BlockInfo{
 		makeRandomBlockPointer(t),
-		150,
+		testFakeBlockSize,
 	}
 }
 
@@ -60,9 +60,34 @@ func makeFakeIndirectDirPtr(t *testing.T, off StringOffset) IndirectDirPtr {
 }
 
 func makeFakeDirBlock(t *testing.T, name string) *DirBlock {
-	return &DirBlock{Children: map[string]DirEntry{
-		name: makeRandomDirEntry(t, Dir, 100, name),
-	}}
+	return &DirBlock{
+		CommonBlock: CommonBlock{
+			cachedEncodedSize: testFakeBlockSize,
+		},
+		Children: map[string]DirEntry{
+			name: makeRandomDirEntry(t, Dir, 100, name),
+		},
+	}
+}
+
+func makeFakeDirBlockWithChildren(children map[string]DirEntry) *DirBlock {
+	return &DirBlock{
+		CommonBlock: CommonBlock{
+			cachedEncodedSize: testFakeBlockSize,
+		},
+		Children: children,
+	}
+}
+
+func makeFakeDirBlockWithIPtrs(iptrs []IndirectDirPtr) *DirBlock {
+	return &DirBlock{
+		CommonBlock: CommonBlock{
+			IsInd:             true,
+			cachedEncodedSize: testFakeBlockSize,
+		},
+		Children: map[string]DirEntry{},
+		IPtrs:    iptrs,
+	}
 }
 
 func initPrefetcherTestWithDiskCache(t *testing.T, dbc DiskBlockCache) (
@@ -212,8 +237,7 @@ func TestPrefetcherIndirectDirBlock(t *testing.T) {
 		makeFakeIndirectDirPtr(t, "b"),
 	}
 	rootPtr := makeRandomBlockPointer(t)
-	rootBlock := &DirBlock{IPtrs: ptrs, Children: make(map[string]DirEntry)}
-	rootBlock.IsInd = true
+	rootBlock := makeFakeDirBlockWithIPtrs(ptrs)
 	indBlock1 := makeFakeDirBlock(t, "a")
 	indBlock2 := makeFakeDirBlock(t, "b")
 
@@ -341,14 +365,14 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 	fileA := makeFakeFileBlock(t, true)
 	fileC := makeFakeFileBlock(t, true)
 	rootPtr := makeRandomBlockPointer(t)
-	rootDir := &DirBlock{Children: map[string]DirEntry{
+	rootDir := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 100, "a"),
 		"b": makeRandomDirEntry(t, Dir, 60, "b"),
 		"c": makeRandomDirEntry(t, Exec, 20, "c"),
-	}}
-	dirB := &DirBlock{Children: map[string]DirEntry{
+	})
+	dirB := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"d": makeRandomDirEntry(t, File, 100, "d"),
-	}}
+	})
 	dirBfileD := makeFakeFileBlock(t, true)
 
 	_, continueChRootDir := bg.setBlockToReturn(rootPtr, rootDir)
@@ -413,12 +437,12 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 		"folder, which in turn points to 1 file.")
 	fileB := makeFakeFileBlock(t, true)
 	rootPtr := makeRandomBlockPointer(t)
-	rootDir := &DirBlock{Children: map[string]DirEntry{
+	rootDir := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, Dir, 60, "a"),
-	}}
-	dirA := &DirBlock{Children: map[string]DirEntry{
+	})
+	dirA := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"b": makeRandomDirEntry(t, File, 100, "b"),
-	}}
+	})
 
 	_, continueChRootDir := bg.setBlockToReturn(rootPtr, rootDir)
 	_, continueChDirA :=
@@ -510,9 +534,9 @@ func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
 	t.Log("Initialize a direct dir block with an entry pointing to 1 file.")
 	fileA := makeFakeFileBlock(t, true)
 	rootPtr := makeRandomBlockPointer(t)
-	rootDir := &DirBlock{Children: map[string]DirEntry{
+	rootDir := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 60, "a"),
-	}}
+	})
 	ptrA := rootDir.Children["a"].BlockPointer
 
 	_, continueChRootDir := bg.setBlockToReturn(rootPtr, rootDir)
@@ -573,7 +597,7 @@ func TestPrefetcherEmptyDirectDirBlock(t *testing.T) {
 
 	t.Log("Initialize an empty direct dir block.")
 	rootPtr := makeRandomBlockPointer(t)
-	rootDir := &DirBlock{Children: map[string]DirEntry{}}
+	rootDir := makeFakeDirBlockWithChildren(map[string]DirEntry{})
 
 	_, continueChRootDir := bg.setBlockToReturn(rootPtr, rootDir)
 
@@ -609,20 +633,19 @@ func testPrefetcherForSyncedTLF(
 	fileA := makeFakeFileBlock(t, true)
 	fileC := makeFakeFileBlock(t, true)
 	rootPtr := makeRandomBlockPointer(t)
-	rootDir := &DirBlock{Children: map[string]DirEntry{
+	rootDir := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 100, "a"),
 		"b": makeRandomDirEntry(t, Dir, 60, "b"),
 		"c": makeRandomDirEntry(t, Exec, 20, "c"),
-	}}
-	dirB := &DirBlock{Children: map[string]DirEntry{
+	})
+	dirB := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"d": makeRandomDirEntry(t, File, 100, "d"),
-	}}
+	})
 	dirBfileDptrs := []IndirectFilePtr{
 		makeFakeIndirectFilePtr(t, 0),
 		makeFakeIndirectFilePtr(t, 150),
 	}
-	dirBfileD := &FileBlock{IPtrs: dirBfileDptrs}
-	dirBfileD.IsInd = true
+	dirBfileD := makeFakeFileBlockWithIPtrs(dirBfileDptrs)
 	dirBfileDblock1 := makeFakeFileBlock(t, true)
 	dirBfileDblock2 := makeFakeFileBlock(t, true)
 
@@ -939,19 +962,19 @@ func TestPrefetcherBackwardPrefetch(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {b, a -> {ab, aa -> {aab, aaa}}}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, Dir, 10, "a"),
 		"b": makeRandomDirEntry(t, File, 20, "b"),
-	}}
-	a := &DirBlock{Children: map[string]DirEntry{
+	})
+	a := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"aa": makeRandomDirEntry(t, Dir, 30, "aa"),
 		"ab": makeRandomDirEntry(t, File, 40, "ab"),
-	}}
+	})
 	b := makeFakeFileBlock(t, true)
-	aa := &DirBlock{Children: map[string]DirEntry{
+	aa := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"aaa": makeRandomDirEntry(t, File, 50, "aaa"),
 		"aab": makeRandomDirEntry(t, File, 60, "aab"),
-	}}
+	})
 	ab := makeFakeFileBlock(t, true)
 	aaa := makeFakeFileBlock(t, true)
 	aab := makeFakeFileBlock(t, true)
@@ -1089,22 +1112,22 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {b, a -> {ab, aa -> {aab, aaa}}}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, Dir, 10, "a"),
 		"b": makeRandomDirEntry(t, File, 20, "b"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
-	a := &DirBlock{Children: map[string]DirEntry{
+	a := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"aa": makeRandomDirEntry(t, Dir, 30, "aa"),
 		"ab": makeRandomDirEntry(t, File, 40, "ab"),
-	}}
+	})
 	bPtr := root.Children["b"].BlockPointer
 	b := makeFakeFileBlock(t, true)
 	aaPtr := a.Children["aa"].BlockPointer
-	aa := &DirBlock{Children: map[string]DirEntry{
+	aa := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"aaa": makeRandomDirEntry(t, File, 50, "aaa"),
 		"aab": makeRandomDirEntry(t, File, 60, "aab"),
-	}}
+	})
 	abPtr := a.Children["ab"].BlockPointer
 	ab := makeFakeFileBlock(t, true)
 	aaaPtr := aa.Children["aaa"].BlockPointer
@@ -1242,15 +1265,15 @@ func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {b, a -> {ab, aa -> {aab, aaa}}}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, Dir, 10, "a"),
 		"b": makeRandomDirEntry(t, File, 20, "b"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
-	a := &DirBlock{Children: map[string]DirEntry{
+	a := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"aa": makeRandomDirEntry(t, Dir, 30, "aa"),
 		"ab": makeRandomDirEntry(t, File, 40, "ab"),
-	}}
+	})
 	bPtr := root.Children["b"].BlockPointer
 	b := makeFakeFileBlock(t, true)
 
@@ -1330,9 +1353,9 @@ func TestPrefetcherBasicUnsyncedPrefetch(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {a}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 10, "a"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
 	a := makeFakeFileBlock(t, true)
 
@@ -1385,9 +1408,9 @@ func TestPrefetcherBasicUnsyncedBackwardPrefetch(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {a}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 10, "a"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
 	a := makeFakeFileBlock(t, true)
 
@@ -1448,9 +1471,9 @@ func TestPrefetcherUnsyncedPrefetchEvicted(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {a}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 10, "a"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
 	a := makeFakeFileBlock(t, true)
 
@@ -1541,10 +1564,10 @@ func TestPrefetcherUnsyncedPrefetchChildCanceled(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {a, b}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 10, "a"),
 		"b": makeRandomDirEntry(t, File, 10, "b"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
 	bPtr := root.Children["b"].BlockPointer
 	a := makeFakeFileBlock(t, true)
@@ -1658,10 +1681,10 @@ func TestPrefetcherUnsyncedPrefetchParentCanceled(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {a, b}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 10, "a"),
 		"b": makeRandomDirEntry(t, File, 10, "b"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
 	bPtr := root.Children["b"].BlockPointer
 	a := makeFakeFileBlock(t, true)
@@ -1774,15 +1797,15 @@ func TestPrefetcherReschedules(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {b, a -> {ab, aa}}")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, Dir, 10, "a"),
 		"b": makeRandomDirEntry(t, File, 20, "b"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
-	a := &DirBlock{Children: map[string]DirEntry{
+	a := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"aa": makeRandomDirEntry(t, File, 30, "aa"),
 		"ab": makeRandomDirEntry(t, File, 40, "ab"),
-	}}
+	})
 	aaPtr := a.Children["aa"].BlockPointer
 	aa := makeFakeFileBlock(t, true)
 	abPtr := a.Children["ab"].BlockPointer
@@ -1924,9 +1947,9 @@ func TestPrefetcherWithDedupBlocks(t *testing.T) {
 	t.Log("Initialize a folder tree with structure: " +
 		"root -> {a, b}, where a and b are refs to the same block ID.")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, File, 10, "a"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
 	childB := root.Children["a"]
 	bNonce, err := kbfsblock.MakeRefNonce()
@@ -1935,7 +1958,7 @@ func TestPrefetcherWithDedupBlocks(t *testing.T) {
 	root.Children["b"] = childB
 	bPtr := childB.BlockPointer
 
-	aBlock := &FileBlock{}
+	aBlock := makeFakeFileBlock(t, true)
 
 	encRoot, serverHalfRoot :=
 		setupRealBlockForDiskCache(t, rootPtr, root, dbcConfig)
@@ -1991,15 +2014,15 @@ func TestPrefetcherWithCanceledDedupBlocks(t *testing.T) {
 
 	t.Log("Initialize a folder tree with structure: root -> a -> b")
 	rootPtr := makeRandomBlockPointer(t)
-	root := &DirBlock{Children: map[string]DirEntry{
+	root := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a": makeRandomDirEntry(t, Dir, 10, "a"),
-	}}
+	})
 	aPtr := root.Children["a"].BlockPointer
-	aBlock := &DirBlock{Children: map[string]DirEntry{
+	aBlock := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"b": makeRandomDirEntry(t, File, 10, "b"),
-	}}
+	})
 	bPtr := aBlock.Children["b"].BlockPointer
-	bBlock := &FileBlock{}
+	bBlock := makeFakeFileBlock(t, true)
 
 	encRoot, serverHalfRoot :=
 		setupRealBlockForDiskCache(t, rootPtr, root, dbcConfig)
@@ -2037,17 +2060,17 @@ func TestPrefetcherWithCanceledDedupBlocks(t *testing.T) {
 		"new subdir pointing to the same ID but different nonce.")
 
 	root2Ptr := makeRandomBlockPointer(t)
-	root2 := &DirBlock{Children: map[string]DirEntry{
+	root2 := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"a2": makeRandomDirEntry(t, Dir, 10, "a2"),
-	}}
+	})
 	a2Ptr := root2.Children["a2"].BlockPointer
 	childB2 := aBlock.Children["b"]
 	b2Nonce, err := kbfsblock.MakeRefNonce()
 	require.NoError(t, err)
 	childB2.RefNonce = b2Nonce
-	a2Block := &DirBlock{Children: map[string]DirEntry{
+	a2Block := makeFakeDirBlockWithChildren(map[string]DirEntry{
 		"b2": childB2,
-	}}
+	})
 	b2Ptr := a2Block.Children["b2"].BlockPointer
 	_, _ = bg.setBlockToReturn(a2Ptr, a2Block)
 	_, _ = bg.setBlockToReturn(b2Ptr, bBlock)

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -682,6 +682,7 @@ func testPrefetcherForSyncedTLF(
 		context.Background(), individualTestTimeout)
 	defer cancel()
 	waitChCh := make(chan (<-chan struct{}), 1)
+	statusCh := make(chan PrefetchByteStatus)
 	go func() {
 		waitCh, err := q.Prefetcher().WaitChannelForBlockPrefetch(ctx, rootPtr)
 		if err != nil {
@@ -689,6 +690,8 @@ func testPrefetcherForSyncedTLF(
 		} else {
 			waitChCh <- waitCh
 		}
+		status, _ := q.Prefetcher().Status(ctx, rootPtr)
+		statusCh <- status
 		continueChFileC <- nil
 		continueChDirB <- nil
 		// After this, the prefetch worker can either pick up the third child of
@@ -712,6 +715,18 @@ func testPrefetcherForSyncedTLF(
 		t.Fatal(ctx.Err())
 	}
 	// Release after getting waitCh.
+	notifySyncCh(t, prefetchSyncCh)
+	select {
+	case status := <-statusCh:
+		// The root block has 3 children (the root block itself
+		// doesn't count in the bytes total).
+		require.Equal(t, uint64(3*testFakeBlockSize), status.SubtreeBytesTotal)
+		require.Equal(t, uint64(0), status.SubtreeBytesFetched)
+		require.Equal(t, config.Clock().Now(), status.Start)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	// Release after getting status.
 	notifySyncCh(t, prefetchSyncCh)
 	// Release after prefetching fileC
 	notifySyncCh(t, prefetchSyncCh)
@@ -1847,7 +1862,6 @@ func TestPrefetcherReschedules(t *testing.T) {
 	})
 	q.TogglePrefetcher(true, prefetchSyncCh)
 	q.Prefetcher().(*blockPrefetcher).makeNewBackOff = func() backoff.BackOff {
-		t.Log("ZERO\n")
 		return &backoff.ZeroBackOff{}
 	}
 	notifySyncCh(t, prefetchSyncCh)

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -362,7 +362,7 @@ func (k *SimpleFS) favoriteList(ctx context.Context, path keybase1.Path, t tlf.T
 }
 
 func (k *SimpleFS) prefetchProgressFromByteStatus(
-	status libkbfs.PrefetchByteStatus) (p keybase1.PrefetchProgress) {
+	status libkbfs.PrefetchProgress) (p keybase1.PrefetchProgress) {
 	p.BytesFetched = int64(status.SubtreeBytesFetched)
 	p.BytesTotal = int64(status.SubtreeBytesTotal)
 	p.Start = keybase1.ToTime(status.Start)
@@ -402,7 +402,7 @@ func (k *SimpleFS) setStat(de *keybase1.Dirent, fi os.FileInfo) error {
 		de.LastWriterUnverified = md.LastWriter
 		de.PrefetchStatus = md.PrefetchStatus
 		de.PrefetchProgress = k.prefetchProgressFromByteStatus(
-			md.PrefetchByteStatus)
+			md.PrefetchProgress)
 	}
 	de.Name = fi.Name()
 	return nil
@@ -2085,7 +2085,7 @@ func (k *SimpleFS) SimpleFSFolderSyncConfigAndStatus(
 			}
 			res.Status.PrefetchStatus = metadata.PrefetchStatus
 			res.Status.PrefetchProgress = k.prefetchProgressFromByteStatus(
-				metadata.PrefetchByteStatus)
+				metadata.PrefetchProgress)
 		} else {
 			k.log.CDebugf(ctx,
 				"Could not get prefetch status from filesys: %T", fi.Sys())

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -361,7 +361,25 @@ func (k *SimpleFS) favoriteList(ctx context.Context, path keybase1.Path, t tlf.T
 	return res, nil
 }
 
-func setStat(de *keybase1.Dirent, fi os.FileInfo) error {
+func (k *SimpleFS) prefetchProgressFromByteStatus(
+	status libkbfs.PrefetchByteStatus) (p keybase1.PrefetchProgress) {
+	p.BytesFetched = int64(status.SubtreeBytesFetched)
+	p.BytesTotal = int64(status.SubtreeBytesTotal)
+	p.Start = keybase1.ToTime(status.Start)
+
+	if p.BytesTotal == 0 || p.Start == 0 {
+		return p
+	}
+
+	timeRunning := k.config.Clock().Now().Sub(status.Start)
+	fracDone := float64(p.BytesFetched) / float64(p.BytesTotal)
+	totalTimeEstimate := time.Duration(float64(timeRunning) / fracDone)
+	endEstimate := status.Start.Add(totalTimeEstimate)
+	p.EndEstimate = keybase1.ToTime(endEstimate)
+	return p
+}
+
+func (k *SimpleFS) setStat(de *keybase1.Dirent, fi os.FileInfo) error {
 	de.Time = keybase1.ToTime(fi.ModTime())
 	de.Size = int(fi.Size()) // TODO: FIX protocol
 
@@ -383,6 +401,8 @@ func setStat(de *keybase1.Dirent, fi os.FileInfo) error {
 		}
 		de.LastWriterUnverified = md.LastWriter
 		de.PrefetchStatus = md.PrefetchStatus
+		de.PrefetchProgress = k.prefetchProgressFromByteStatus(
+			md.PrefetchByteStatus)
 	}
 	de.Name = fi.Name()
 	return nil
@@ -674,7 +694,7 @@ func (k *SimpleFS) SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListAr
 					}
 
 					var d keybase1.Dirent
-					err := setStat(&d, fi)
+					err := k.setStat(&d, fi)
 					if err != nil {
 						return err
 					}
@@ -734,7 +754,7 @@ func (k *SimpleFS) listRecursiveToDepth(opID keybase1.OpID,
 		var des []keybase1.Dirent
 		if !fi.IsDir() {
 			var d keybase1.Dirent
-			err := setStat(&d, fi)
+			err := k.setStat(&d, fi)
 			if err != nil {
 				return err
 			}
@@ -770,7 +790,7 @@ func (k *SimpleFS) listRecursiveToDepth(opID keybase1.OpID,
 				}
 
 				var de keybase1.Dirent
-				err := setStat(&de, fi)
+				err := k.setStat(&de, fi)
 				if err != nil {
 					return err
 				}
@@ -1461,7 +1481,7 @@ func (k *SimpleFS) SimpleFSStat(ctx context.Context, arg keybase1.SimpleFSStatAr
 		return keybase1.Dirent{}, err
 	}
 
-	err = setStat(&de, fi)
+	err = k.setStat(&de, fi)
 	return de, err
 }
 
@@ -1506,7 +1526,7 @@ func (k *SimpleFS) doGetRevisions(
 	}
 
 	var currRev keybase1.DirentWithRevision
-	err = setStat(&currRev.Entry, fi)
+	err = k.setStat(&currRev.Entry, fi)
 	if err != nil {
 		return nil, err
 	}
@@ -1644,7 +1664,7 @@ func (k *SimpleFS) doGetRevisions(
 			return err
 		}
 		var rev keybase1.DirentWithRevision
-		err = setStat(&rev.Entry, fi)
+		err = k.setStat(&rev.Entry, fi)
 		if err != nil {
 			return err
 		}
@@ -2064,6 +2084,8 @@ func (k *SimpleFS) SimpleFSFolderSyncConfigAndStatus(
 				return keybase1.FolderSyncConfigAndStatus{}, err
 			}
 			res.Status.PrefetchStatus = metadata.PrefetchStatus
+			res.Status.PrefetchProgress = k.prefetchProgressFromByteStatus(
+				metadata.PrefetchByteStatus)
 		} else {
 			k.log.CDebugf(ctx,
 				"Could not get prefetch status from filesys: %T", fi.Sys())


### PR DESCRIPTION
Ported from keybase/kbfs#1945

This tracks, for each block being tracked in the prefetcher, the number of known bytes rooted at that block, and the number of bytes fetched so far. This is a bit crude because the total doesn't represent ALL of the bytes rooted at the block; just the bytes the prefetcher has seen so far on its traversal. So for example if a lot of a TLF has already been synced and the prefetcher avoids traversing down that branch of the TLF, those bytes won't be included in the total. Also, the total can increase during the traversal.

But it's a good start I think. If the GUI needs to know the full total for a TLF, we can get that easily from the MD object. But it's hard to compute a progress percentage from that, so for now I say we go this way and see how far it gets us.

Issue: KBFS-3575

@strib @jakob223 @songgao 