### PR TITLE
fix channel mention navigate

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1417,6 +1417,8 @@ function* previewConversationFindExisting(state, action) {
       ...params,
     })
     yield* previewConversationAfterFindExisting(state, action, results, users)
+  } else {
+    yield* previewConversationAfterFindExisting(state, action, undefined, [])
   }
 }
 


### PR DESCRIPTION
@keybase/react-hackers 

This fixes clicking a channel name mention.