### PR TITLE
Fix uploading push token

### DIFF
--- a/shared/actions/platform-specific/push.native.js
+++ b/shared/actions/platform-specific/push.native.js
@@ -281,7 +281,7 @@ function* requestPermissions() {
 }
 
 function* initialPermissionsCheck(): Saga.SagaGenerator<any, any> {
-  const hasPermissions = yield checkPermissions(null, null)
+  const hasPermissions = yield _checkPermissions(null)
   if (hasPermissions) {
     // Get the token
     yield Saga.spawn(requestPermissionsFromNative)


### PR DESCRIPTION
@joshblum ran into an issue where we couldn't get pushes after logout/in. I think this function was erroneously using a helper that didn't return, but we need the return value here.

logs signing out/in twice before:
<img width="243" alt="image" src="https://user-images.githubusercontent.com/11968340/50726466-4e5b4f80-10db-11e9-8072-dded8ea5967a.png">

after:
<img width="255" alt="image" src="https://user-images.githubusercontent.com/11968340/50726458-2bc93680-10db-11e9-9327-1f0811294f97.png">

 r? @keybase/react-hackers 