### PR TITLE
Fix RemoteProofLinks.ForService

### DIFF
--- a/go/libkb/remote_proof_links.go
+++ b/go/libkb/remote_proof_links.go
@@ -43,22 +43,17 @@ func (r *RemoteProofLinks) Insert(link RemoteProofChainLink, err ProofError) {
 // ForService returns all the active proof links for a service.
 func (r *RemoteProofLinks) ForService(st ServiceType) []RemoteProofChainLink {
 	var links []RemoteProofChainLink
-	for _, l := range r.links[st.Key()] {
-		if l.link.IsRevoked() {
+	for _, linkWithState := range r.links[st.Key()] {
+		if linkWithState.link.LastWriterWins() {
+			// Clear the array if it's a last-writer wins service.
+			// (like many social networks)
+			links = nil
+		}
+		if linkWithState.link.IsRevoked() {
 			continue
 		}
-		links = append(links, l.link)
+		links = append(links, linkWithState.link)
 	}
-
-	// Chop the array off if it's a last-writer wins service
-	// (like many social networks).
-	for i := len(links) - 1; i >= 0; i-- {
-		if links[i].LastWriterWins() {
-			links = links[i:]
-			break
-		}
-	}
-
 	return links
 }
 


### PR DESCRIPTION
```
seqno | action
104   | claimed ownership of github account asdlkfjlaskdjf
105   | claimed ownership of github account asdlkfjlaskdjf1
...
178   | revoked signature 105
```

`RemoteProofLinks.ForService(github)` returned [104]. But 104 was revoked by 105. This patch should fix `ForService`. But is it a deeper problem that `linkWithState.link.IsRevoked()` returns false?
