### PR TITLE
folder_branch_ops: use background context to commit MD

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -659,7 +659,7 @@ func (fbo *folderBranchOps) commitHeadLocked(
 	id := fbo.id()
 	log := fbo.log
 	go func() {
-		err := diskMDCache.Commit(ctx, id, rev)
+		err := diskMDCache.Commit(context.Background(), id, rev)
 		if err != nil {
 			log.CDebugf(ctx, "Error commiting revision %d: %+v", rev, err)
 		}


### PR DESCRIPTION
Noticed an error in the logs while debugging something else.

Issue: keybase/client#15288