### PR TITLE
Disable save if bio is too long

### DIFF
--- a/shared/constants/profile.js
+++ b/shared/constants/profile.js
@@ -32,7 +32,7 @@ export const makeInitialState: I.RecordFactory<Types._State> = I.Record({
 })
 
 export const waitingKey = 'profile:waiting'
-export const maxProfileBioChars = 256
+export const maxProfileBioChars = 255
 export const AVATAR_SIZE = 128
 export const BACK_ZINDEX = 12
 export const SEARCH_CONTAINER_ZINDEX = BACK_ZINDEX + 1

--- a/shared/profile/edit-profile/container.js
+++ b/shared/profile/edit-profile/container.js
@@ -57,7 +57,7 @@ class Wrapper extends React.Component<Props, State> {
   onSubmit = () => this.props._onSubmit(this.state.bio, this.state.fullname, this.state.location)
 
   render() {
-    const bioLengthLeft = this.props.bio ? maxProfileBioChars - this.props.bio.length : maxProfileBioChars
+    const bioLengthLeft = this.state.bio ? maxProfileBioChars - this.state.bio.length : maxProfileBioChars
     const extra = isMobile ? {} : {onCancel: this.props.onBack}
 
     return (

--- a/shared/profile/edit-profile/index.desktop.js
+++ b/shared/profile/edit-profile/index.desktop.js
@@ -33,7 +33,7 @@ const EditProfileRender = (props: Props) => (
       />
       <ButtonBar>
         <Button type="Secondary" onClick={props.onCancel} label="Cancel" />
-        <Button type="Primary" disabled={props.bioLengthLeft <= 0} onClick={props.onSubmit} label="Save" />
+        <Button type="Primary" disabled={props.bioLengthLeft < 0} onClick={props.onSubmit} label="Save" />
       </ButtonBar>
     </Box>
   </StandardScreen>

--- a/shared/profile/edit-profile/index.native.js
+++ b/shared/profile/edit-profile/index.native.js
@@ -38,7 +38,7 @@ const EditProfileRender = (props: Props) => (
     )}
     <Kb.ButtonBar fullWidth={true}>
       <Kb.Button
-        disabled={props.bioLengthLeft <= 0}
+        disabled={props.bioLengthLeft < 0}
         style={styles.button}
         type="Primary"
         onClick={props.onSubmit}


### PR DESCRIPTION
Looks like we had some code to do this, but it was using `props.bio` when it should have used `state.bio`. r? @keybase/react-hackers 