### PR TITLE
[New new conversation] - Ability to Remove users on press

### DIFF
--- a/shared/common-adapters/box.desktop.js
+++ b/shared/common-adapters/box.desktop.js
@@ -3,9 +3,10 @@ import * as React from 'react'
 import {intersperseFn} from '../util/arrays'
 import type {Box2Props} from './box'
 
-class Box extends React.Component<any> {
+class Box extends React.PureComponent<any> {
   render() {
-    return <div {...this.props} />
+    const {forwardedRef, ...rest} = this.props
+    return <div {...rest} ref={this.props.forwardedRef} />
   }
 }
 

--- a/shared/common-adapters/icon.native.js
+++ b/shared/common-adapters/icon.native.js
@@ -106,8 +106,8 @@ class Icon extends React.PureComponent<Props> {
 
     if (iconMeta[iconType].isFont) {
       const code = String.fromCharCode(iconMeta[iconType].charCode || 0)
-      if (props.color) {
-        iconStyle = Styles.collapseStyles([iconStyle, {color: props.color}])
+      if (props.colorOverride || props.color) {
+        iconStyle = Styles.collapseStyles([iconStyle, {color: props.colorOverride || props.color}])
       }
       icon = (
         <Text style={iconStyle} type={props.type} fontSize={props.fontSize}>

--- a/shared/common-adapters/toast.js.flow
+++ b/shared/common-adapters/toast.js.flow
@@ -7,7 +7,7 @@ export type Props = {
   children: React.Node,
   containerStyle?: StylesCrossPlatform,
   visible: boolean,
-  attachTo?: () => ?React.ElementRef<any>,
+  attachTo?: ?() => ?React.ElementRef<any>,
   // applies on desktop only. Mobile is always centered in the screen
   position?: Position,
 }

--- a/shared/common-adapters/with-tooltip.desktop.js
+++ b/shared/common-adapters/with-tooltip.desktop.js
@@ -9,21 +9,23 @@ import {type Props} from './with-tooltip'
 type State = {
   mouseIn: boolean,
   visible: boolean,
+  attachmentRef: ?React.Component<any>,
 }
 
 class WithTooltip extends React.Component<Props, State> {
   state = {
+    attachmentRef: null,
     mouseIn: false,
     visible: false,
   }
-  _attachmentRef: ?React.Component<any> = null
   _onMouseEnter = () => {
     this.setState({mouseIn: true})
   }
   _onMouseLeave = () => {
     this.setState({mouseIn: false, visible: false})
   }
-  _setAttachmentRef = attachmentRef => (this._attachmentRef = attachmentRef)
+  _setAttachmentRef = attachmentRef => this.setState({attachmentRef})
+  _getAttachmentRef = () => this.state.attachmentRef
   componentDidUpdate(prevProps: Props, prevState: State) {
     if (!prevState.mouseIn && this.state.mouseIn) {
       // Set visible after Toast is mounted, to trigger transition on opacity.
@@ -39,7 +41,7 @@ class WithTooltip extends React.Component<Props, State> {
       <>
         <Box
           style={this.props.containerStyle}
-          ref={this._setAttachmentRef}
+          forwardedRef={this._setAttachmentRef}
           onMouseEnter={this._onMouseEnter}
           onMouseLeave={this._onMouseLeave}
           className={this.props.className}
@@ -53,7 +55,7 @@ class WithTooltip extends React.Component<Props, State> {
               this.props.multiline && styles.containerMultiline,
             ])}
             visible={!!this.props.text && this.state.visible}
-            attachTo={() => this._attachmentRef}
+            attachTo={this.state.attachmentRef && this._getAttachmentRef}
             position={this.props.position || 'top center'}
           >
             <Text type="BodySmall" style={Styles.collapseStyles([styles.text, this.props.textStyle])}>

--- a/shared/team-building/team-box.js
+++ b/shared/team-building/team-box.js
@@ -18,7 +18,7 @@ type Props = {
 }
 
 const TeamBox = (props: Props) => (
-  <Kb.Box2 direction="horizontal" style={styles.container}>
+  <Kb.Box2 direction="horizontal" centerChildren={true} style={styles.container}>
     {Styles.isMobile && <Kb.Icon fontSize={22} type={'iconfont-search'} style={styles.searchIcon} />}
     {props.teamSoFar.map(u => (
       <UserBubble
@@ -26,7 +26,7 @@ const TeamBox = (props: Props) => (
         onRemove={() => props.onRemove(u.userId)}
         username={u.username}
         service={u.service}
-        prettyName={u.prettyName}
+        prettyName={u.service === 'keybase' ? u.username : `${u.username} on ${u.service}`}
       />
     ))}
     <Input

--- a/shared/team-building/user-bubble.js
+++ b/shared/team-building/user-bubble.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import * as Kb from '../common-adapters/index'
 import * as Styles from '../styles'
 import {serviceIdToIconFont, serviceIdToAccentColor} from './shared'
@@ -39,14 +39,59 @@ const RemoveBubble = ({onRemove, prettyName}: {onRemove: () => void, prettyName:
   </Kb.WithTooltip>
 )
 
-const UserBubble = (props: Props) => {
-  const HoverComponent = Kb.HoverHoc(
-    () =>
-      props.service === 'keybase' ? <KeybaseUserBubble {...props} /> : <GeneralServiceBubble {...props} />,
-    () => <RemoveBubble prettyName={props.prettyName} onRemove={props.onRemove} />
-  )
+type SwapOnClickProps = Kb.PropsWithTimer<{
+  children: React.Node,
+  clickedLayerComponent: React.AbstractComponent<{||}>,
+  clickedLayerTimeout: number,
+  containerStyle?: Styles.StylesCrossPlatform,
+}>
 
-  return <HoverComponent containerStyle={styles.container} />
+class _SwapOnClick extends React.PureComponent<SwapOnClickProps, {showClickedLayer: boolean}> {
+  state = {showClickedLayer: false}
+  _onClick = () => {
+    if (!this.state.showClickedLayer) {
+      this.setState({showClickedLayer: true})
+      if (this.props.clickedLayerTimeout) {
+        this.props.setTimeout(() => this.setState({showClickedLayer: false}), this.props.clickedLayerTimeout)
+      }
+    }
+  }
+
+  render() {
+    const ClickedLayerComponent = this.props.clickedLayerComponent
+    return (
+      <Kb.ClickableBox onClick={this._onClick} style={this.props.containerStyle}>
+        {this.state.showClickedLayer ? <ClickedLayerComponent /> : this.props.children}
+      </Kb.ClickableBox>
+    )
+  }
+}
+const SwapOnClick = Kb.HOCTimers(_SwapOnClick)
+
+function SwapOnClickHoc<A>(
+  Component: React.AbstractComponent<{}, A>,
+  OtherComponent: React.AbstractComponent<{}, A>
+): React.AbstractComponent<{containerStyle?: Styles.StylesCrossPlatform}> {
+  return ({containerStyle}) => (
+    <SwapOnClick
+      containerStyle={containerStyle}
+      clickedLayerTimeout={5e3}
+      clickedLayerComponent={OtherComponent}
+    >
+      <Component />
+    </SwapOnClick>
+  )
+}
+
+const UserBubble = (props: Props) => {
+  const NormalComponent = () =>
+    props.service === 'keybase' ? <KeybaseUserBubble {...props} /> : <GeneralServiceBubble {...props} />
+  const AlternateComponent = () => <RemoveBubble prettyName={props.prettyName} onRemove={props.onRemove} />
+  const Component = Styles.isMobile
+    ? SwapOnClickHoc(NormalComponent, AlternateComponent)
+    : Kb.HoverHoc(NormalComponent, AlternateComponent)
+
+  return <Component containerStyle={styles.container} />
 }
 
 const bubbleSize = 32
@@ -84,9 +129,15 @@ const styles = Styles.styleSheetCreate({
     },
   }),
 
-  removeBubbleTextAlignCenter: {
-    textAlign: 'center',
-  },
+  removeBubbleTextAlignCenter: Styles.platformStyles({
+    isElectron: {
+      textAlign: 'center',
+    },
+    isMobile: {
+      flex: 1,
+      alignItems: 'center',
+    },
+  }),
 
   removeIcon: Styles.platformStyles({
     isElectron: {


### PR DESCRIPTION
@keybase/react-hackers implements a SwapOnClickHoc that shows a different component when the user presses it. I use this to show the remove bubble when the user presses a user bubble.

Looks like this: 
<img width="361" alt="screen shot 2019-01-07 at 3 14 16 pm" src="https://user-images.githubusercontent.com/594035/50798992-29a7d900-128f-11e9-8251-3fd61ff2b895.png">
 

cc @adamjspooner 

Also fixes a racey conditon in WithTooltip. A similar bug to what @zanderz fixed a bit ago. Fixes the big warning we got related to passing a ref of a Box instead of the underlying div.