### PR TITLE
refactor chat-api listen command

### DIFF
--- a/go/chat/msgchecker/constants.go
+++ b/go/chat/msgchecker/constants.go
@@ -3,12 +3,12 @@ package msgchecker
 import "github.com/keybase/client/go/protocol/chat1"
 
 const (
-	TextMessageMaxLength     = 10000
-	DevTextMessageMaxLength  = 1000000
-	ReactionMessageMaxLength = 50
-	HeadlineMaxLength        = 280
-	TopicMaxLength           = 20
-	PaymentTextMaxLength     = 240
+	TextMessageMaxLength        = 10000
+	DevTextMessageMaxLength     = 1000000
+	ReactionMessageMaxLength    = 50
+	HeadlineMaxLength           = 280
+	TopicMaxLength              = 20
+	RequestPaymentTextMaxLength = 240
 )
 
 const (

--- a/go/chat/msgchecker/plaintext_checker.go
+++ b/go/chat/msgchecker/plaintext_checker.go
@@ -106,7 +106,7 @@ func checkMessagePlaintextLength(msg chat1.MessagePlaintext) error {
 		return nil
 	case chat1.MessageType_REQUESTPAYMENT:
 		return plaintextFieldLengthChecker("request payment note",
-			len(msg.MessageBody.Requestpayment().Note), PaymentTextMaxLength)
+			len(msg.MessageBody.Requestpayment().Note), RequestPaymentTextMaxLength)
 	default:
 		typ, err := msg.MessageBody.MessageType()
 		if err != nil {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -1348,7 +1348,7 @@ func TestChatSrvPostLocalLengthLimit(t *testing.T) {
 		require.Error(t, err)
 
 		// request payment
-		maxPaymentNote := strings.Repeat(".", msgchecker.PaymentTextMaxLength)
+		maxPaymentNote := strings.Repeat(".", msgchecker.RequestPaymentTextMaxLength)
 		_, err = postLocalForTest(t, ctc, users[0], created, chat1.NewMessageBodyWithRequestpayment(
 			chat1.MessageRequestPayment{
 				RequestID: stellar1.KeybaseRequestID("dummy id"),

--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -425,7 +426,7 @@ func (c *sendOptions) Check() error {
 			return ErrInvalidAccountID
 		}
 	}
-	if len(c.Message) > 400 {
+	if len(c.Message) > msgchecker.PaymentTextMaxLength {
 		return ErrMessageTooLong
 	}
 

--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/keybase/client/go/chat/msgchecker"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -426,7 +425,7 @@ func (c *sendOptions) Check() error {
 			return ErrInvalidAccountID
 		}
 	}
-	if len(c.Message) > msgchecker.PaymentTextMaxLength {
+	if len(c.Message) > libkb.MaxStellarPaymentNoteLength {
 		return ErrMessageTooLong
 	}
 

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -720,28 +720,25 @@ func (m UIMessage) GetOutboxID() *OutboxID {
 }
 
 func (m UIMessage) GetMessageType() MessageType {
-	if state, err := m.State(); err == nil {
-		if state == MessageUnboxedState_VALID {
-			body := m.Valid().MessageBody
-			typ, err := body.MessageType()
-			if err != nil {
-				return MessageType_NONE
-			}
-			return typ
-		}
-		if state == MessageUnboxedState_ERROR {
-			return m.Error().MessageType
-		}
-		if state == MessageUnboxedState_OUTBOX {
-			return m.Outbox().MessageType
-		}
-		if state == MessageUnboxedState_PLACEHOLDER {
-			// All we know about a place holder is the ID, so just
-			// call it type NONE
+	state, err := m.State()
+	if err != nil {
+		return MessageType_NONE
+	}
+	switch state {
+	case MessageUnboxedState_VALID:
+		body := m.Valid().MessageBody
+		typ, err := body.MessageType()
+		if err != nil {
 			return MessageType_NONE
 		}
+		return typ
+	case MessageUnboxedState_ERROR:
+		return m.Error().MessageType
+	case MessageUnboxedState_OUTBOX:
+		return m.Outbox().MessageType
+	default:
+		return MessageType_NONE
 	}
-	return MessageType_NONE
 }
 
 func (m UIMessage) SearchableText() string {
@@ -749,6 +746,21 @@ func (m UIMessage) SearchableText() string {
 		return ""
 	}
 	return m.Valid().MessageBody.SearchableText()
+}
+
+func (m UIMessage) IsEphemeral() bool {
+	state, err := m.State()
+	if err != nil {
+		return false
+	}
+	switch state {
+	case MessageUnboxedState_VALID:
+		return m.Valid().IsEphemeral
+	case MessageUnboxedState_ERROR:
+		return m.Error().IsEphemeral
+	default:
+		return false
+	}
 }
 
 func (m MessageBoxed) GetMessageID() MessageID {


### PR DESCRIPTION
some minor tweaks, main fix is if an ephemeral error comes in we now skip the message based on the `showExploding` flag, previously ephemeral was only checked for valid messages