### PR TITLE
only mark chat as read if you're actually active

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2747,6 +2747,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
     | Chat2Gen.MarkInitiallyLoadedThreadAsReadPayload
     | Chat2Gen.UpdateReactionsPayload
     | ConfigGen.ChangedFocusPayload
+    | ConfigGen.ChangedActivePayload
     | RouteTreeGen.Actions
   >(
     [
@@ -2755,6 +2756,7 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
       Chat2Gen.markInitiallyLoadedThreadAsRead,
       Chat2Gen.updateReactions,
       ConfigGen.changedFocus,
+      ConfigGen.changedActive,
       a => typeof a.type === 'string' && a.type.startsWith(RouteTreeGen.typePrefix),
     ],
     markThreadAsRead

--- a/shared/actions/platform-specific/index.desktop.js
+++ b/shared/actions/platform-specific/index.desktop.js
@@ -88,28 +88,25 @@ function* handleWindowFocusEvents(): Generator<any, void, any> {
   }, Saga.buffers.expanding(1))
   while (true) {
     const type = yield Saga.take(channel)
-    switch (type) {
-      case 'focus':
-        if (skipAppFocusActions) {
-          console.log('Skipping app focus actions!')
-        } else {
+    if (skipAppFocusActions) {
+      console.log('Skipping app focus actions!')
+    } else {
+      switch (type) {
+        case 'focus':
           yield Saga.put(ConfigGen.createChangedFocus({appFocused: true}))
-        }
-        break
-      case 'blur':
-        if (skipAppFocusActions) {
-          console.log('Skipping app focus actions!')
-        } else {
+          break
+        case 'blur':
           yield Saga.put(ConfigGen.createChangedFocus({appFocused: false}))
-        }
+          break
+      }
     }
   }
 }
 
 function* initializeInputMonitor(): Generator<any, void, any> {
-  const inputMonitor = new InputMonitor()
   const channel = Saga.eventChannel(emitter => {
-    inputMonitor.notifyActive = isActive => emitter(isActive ? 'active' : 'inactive')
+    // eslint-disable-next-line no-new
+    new InputMonitor(isActive => emitter(isActive ? 'active' : 'inactive'))
     return () => {}
   }, Saga.buffers.expanding(1))
 

--- a/shared/actions/platform-specific/input-monitor.desktop.js
+++ b/shared/actions/platform-specific/input-monitor.desktop.js
@@ -1,8 +1,7 @@
 // @flow
 
-// TEMP
-const timeToConsiderActiveForAwhile = 10000 // 300000
-const timeToConsiderInactive = 2000 // 60000
+const timeToConsiderActiveForAwhile = 300000
+const timeToConsiderInactive = 60000
 
 type NotifyActiveFunction = (isActive: boolean) => void
 // 5 minutes after being active, consider us inactive after

--- a/shared/actions/platform-specific/input-monitor.desktop.js
+++ b/shared/actions/platform-specific/input-monitor.desktop.js
@@ -13,7 +13,8 @@ class InputMonitor {
   activeTimeoutID: ?TimeoutID
   inactiveTimeoutID: ?TimeoutID
 
-  constructor() {
+  constructor(notifyActive: NotifyActiveFunction) {
+    this.notifyActive = notifyActive
     // go into listening mode again
     window.addEventListener('focus', this.goListening)
     window.addEventListener('blur', this.goInactive)
@@ -21,14 +22,11 @@ class InputMonitor {
   }
 
   _clearTimers = () => {
-    if (this.activeTimeoutID) {
-      window.clearTimeout(this.activeTimeoutID)
-      this.activeTimeoutID = null
-    }
-    if (this.inactiveTimeoutID) {
-      window.clearTimeout(this.inactiveTimeoutID)
-      this.inactiveTimeoutID = null
-    }
+    window.clearTimeout(this.activeTimeoutID)
+    this.activeTimeoutID = null
+
+    window.clearTimeout(this.inactiveTimeoutID)
+    this.inactiveTimeoutID = null
   }
 
   resetInactiveTimer = () => {

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -121,7 +121,7 @@ export const isUserActivelyLookingAtThisThread = (
   conversationIDKey: Types.ConversationIDKey
 ) => {
   const selectedConversationIDKey = getSelectedConversation(state)
-  const appFocused = state.config.appFocused
+
   const routePath = getPath(state.routeTree.routeState)
   let chatThreadSelected = false
   if (isMobile) {
@@ -132,7 +132,8 @@ export const isUserActivelyLookingAtThisThread = (
   }
 
   return (
-    appFocused && // app focused?
+    state.config.appFocused && // app focused?
+    state.config.userActive && // actually interacting w/ the app
     chatThreadSelected && // looking at the chat tab?
     conversationIDKey === selectedConversationIDKey // looking at the selected thread?
   )

--- a/shared/desktop/app/app-state.desktop.js
+++ b/shared/desktop/app/app-state.desktop.js
@@ -19,7 +19,6 @@ export type State = {
   dockHidden: boolean,
   notifySound: boolean,
   openAtLogin: boolean,
-  isUserActive: ?boolean,
 }
 
 export type Config = {
@@ -54,7 +53,6 @@ export default class AppState {
       height: 600,
       isFullScreen: null,
       isMaximized: null,
-      isUserActive: true,
       notifySound: false,
       openAtLogin: true,
       tab: null,
@@ -251,9 +249,6 @@ export default class AppState {
         stateLoaded.openAtLogin = true
       }
 
-      // assume active on startup
-      stateLoaded.isUserActive = true
-
       this.state = stateLoaded
     } catch (e) {
       console.warn('Error loading app state:', e)
@@ -292,7 +287,6 @@ export default class AppState {
 
   _closedHandler() {
     this._clearWindow()
-    this.state.isUserActive = false
     this.saveState()
   }
 

--- a/shared/desktop/renderer/main.desktop.js
+++ b/shared/desktop/renderer/main.desktop.js
@@ -19,9 +19,7 @@ import {throttle, merge} from 'lodash-es'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import {setupContextMenu} from '../app/menu-helper.desktop'
 import flags from '../../util/feature-flags'
-import InputMonitor from './input-monitor.desktop'
 import {dumpLogs} from '../../actions/platform-specific/index.desktop'
-import {skipAppFocusActions} from '../../local-debug.desktop'
 import {initDesktopStyles} from '../../styles/index.desktop'
 
 // Top level HMR accept
@@ -90,28 +88,6 @@ function setupApp(store, runSagas) {
     store.dispatch(ConfigGen.createInstallerRan())
   })
   SafeElectron.getIpcRenderer().send('install-check')
-
-  var inputMonitor = new InputMonitor(function(isActive) {
-    store.dispatch(ConfigGen.createChangedActive({userActive: isActive}))
-    SafeElectron.getIpcRenderer().send('setAppState', {isUserActive: isActive})
-  })
-  inputMonitor.startActiveTimer()
-
-  window.addEventListener('focus', () => {
-    inputMonitor.goActive()
-    if (skipAppFocusActions) {
-      console.log('Skipping app focus actions!')
-    } else {
-      store.dispatch(ConfigGen.createChangedFocus({appFocused: true}))
-    }
-  })
-  window.addEventListener('blur', () => {
-    if (skipAppFocusActions) {
-      console.log('Skipping app focus actions!')
-    } else {
-      store.dispatch(ConfigGen.createChangedFocus({appFocused: false}))
-    }
-  })
 
   const subsetsRemotesCareAbout = store => {
     return {


### PR DESCRIPTION
On osx when you close a window sibling windows will be foregrounded. There are also times where foregrounding a window can focus/defocus the main window.
This has the bad side effect in chat where this can cause you to read the currently selected thread

Steps to repro:
1. Open chat tab w/ a convo selected
2. Bring another app into focus (not devtools, else that can get focused instead)
3. Click on widget 2x

This should bring the main back on top of the app from step 2 and mark the thread read.

This PR changes the flow so you need the userActive flag (which is driven by InputMonitor) in addition to appFocus

I moved InputMonitor into the render thread so its easier to analyze and it does all window / actions stuff anyways so it doesn't really belong on the node side

- [x] Move input monitor to render thread (platform specific saga)
- [x] Remove unused appState
- [x] Never allow both timers to overlap unless we intend to
