### PR TITLE
Fix up width of non image attachments

### DIFF
--- a/shared/chat/conversation/messages/attachment/file/index.js
+++ b/shared/chat/conversation/messages/attachment/file/index.js
@@ -17,7 +17,7 @@ class FileAttachment extends React.PureComponent<Props> {
   render() {
     const iconType = 'icon-file-24' // TODO other states
     return (
-      <Kb.ClickableBox onClick={this.props.onDownload}>
+      <Kb.ClickableBox onClick={this.props.onDownload} style={styles.fullWidth}>
         <Kb.Box style={styles.containerStyle}>
           <Kb.Box style={styles.titleStyle}>
             <Kb.Icon type={iconType} style={Kb.iconCastPlatformStyles(styles.iconStyle)} />
@@ -69,6 +69,7 @@ const styles = Styles.styleSheetCreate({
     position: 'absolute',
     right: 0,
   },
+  fullWidth: {width: '100%'},
   iconStyle: {
     height: 24,
     marginRight: Styles.globalMargins.tiny,


### PR DESCRIPTION
before:
<img width="498" alt="image" src="https://user-images.githubusercontent.com/11968340/50859591-c3d85180-1361-11e9-877c-4c87a44014ff.png">

after:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/11968340/50859612-d488c780-1361-11e9-8d4d-bf1d58c461cc.png">

cc @mmaxim 