### PR TITLE
add temp right spacing to header hoc

### DIFF
--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -35,6 +35,17 @@ export class HeaderHocHeader extends React.Component<Props, State> {
         ]
       : null
 
+    // temp this is a short term hack to even out the spacing on the right side so the title is centered
+    // if there is no right action (most places) we add padding on the right to match the left side
+    let rightStyle = null
+    if (!rightActions) {
+      if (leftAction === 'back') {
+        rightStyle = styles.rightActionOnBack
+      } else if (leftAction === 'cancel') {
+        rightStyle = styles.rightActionOnCancel
+      }
+    }
+
     return (
       <Box
         style={Styles.collapseStyles([
@@ -65,6 +76,7 @@ export class HeaderHocHeader extends React.Component<Props, State> {
           hideFloatingMenu={this._hideFloatingMenu}
           rightActions={rightActions}
           showFloatingMenu={this._showFloatingMenu}
+          style={rightStyle}
         />
       </Box>
     )
@@ -117,8 +129,9 @@ const RightActions = ({
   hideFloatingMenu,
   rightActions,
   showFloatingMenu,
+  style,
 }): React.Node => (
-  <Box style={Styles.collapseStyles([styles.rightActions, hasTitleComponent && styles.unflex])}>
+  <Box style={Styles.collapseStyles([styles.rightActions, hasTitleComponent && styles.unflex, style])}>
     <Box style={styles.rightActionsWrapper}>
       {rightActions &&
         rightActions
@@ -249,7 +262,6 @@ const styles = Styles.styleSheetCreate({
       justifyContent: 'flex-start',
     },
     isIOS: {
-      flex: 1,
       paddingLeft: Styles.globalMargins.tiny,
     },
   }),
@@ -261,10 +273,15 @@ const styles = Styles.styleSheetCreate({
       justifyContent: 'flex-end',
     },
     isIOS: {
-      flex: 1,
       paddingRight: Styles.globalMargins.tiny,
     },
   }),
+  rightActionOnBack: {
+    minWidth: 53,
+  },
+  rightActionOnCancel: {
+    minWidth: 83,
+  },
   rightActionsWrapper: {
     ...Styles.globalStyles.flexBoxRow,
   },
@@ -275,9 +292,8 @@ const styles = Styles.styleSheetCreate({
     common: {
       ...Styles.globalStyles.flexBoxColumn,
       alignItems: 'center',
-      flex: 1,
+      flexGrow: 1,
       justifyContent: 'center',
-      width: '100%',
     },
     isAndroid: {
       alignItems: 'flex-start',

--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -265,6 +265,8 @@ const styles = Styles.styleSheetCreate({
       paddingLeft: Styles.globalMargins.tiny,
     },
   }),
+  rightActionOnBack: {minWidth: 53},
+  rightActionOnCancel: {minWidth: 83},
   rightActions: Styles.platformStyles({
     common: {
       ...Styles.globalStyles.flexBoxColumn,
@@ -276,12 +278,6 @@ const styles = Styles.styleSheetCreate({
       paddingRight: Styles.globalMargins.tiny,
     },
   }),
-  rightActionOnBack: {
-    minWidth: 53,
-  },
-  rightActionOnCancel: {
-    minWidth: 83,
-  },
   rightActionsWrapper: {
     ...Styles.globalStyles.flexBoxRow,
   },


### PR DESCRIPTION
Currently the header hoc changes give a ton of empty space to the left action / right action which eats into the title space. Instead we should maximize space for the title and have actions only take up their own space.
I didn't want to touch this a ton since adam is in here so this is a minimal fix. If you go into a transaction detail you can see on master it shows up as 'Transaction...' instead of 'Transaction Details'

I think this could be done correctly by placing left/right actions on the other side but opacity 0 and have them share a container so the sizes will be the max of both (and the same). anyways we can discuss options

@keybase/react-hackers 
@adamjspooner 