### PR TITLE
Make author wrapper padding the same as under author

### DIFF
--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -143,7 +143,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
     forceAsh,
     hasUnfurlPrompts: stateProps.hasUnfurlPrompts,
     isPendingPayment: stateProps.isPendingPayment,
-    isRevoked: (message.type === 'text' || message.type === 'attachment') && !!message.deviceRevokedAt,
+    isRevoked: true, // (message.type === 'text' || message.type === 'attachment') && !!message.deviceRevokedAt,
     measure: ownProps.measure,
     message: message,
     onAuthorClick: () => dispatchProps._onAuthorClick(message.author),

--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -143,7 +143,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
     forceAsh,
     hasUnfurlPrompts: stateProps.hasUnfurlPrompts,
     isPendingPayment: stateProps.isPendingPayment,
-    isRevoked: true, // (message.type === 'text' || message.type === 'attachment') && !!message.deviceRevokedAt,
+    isRevoked: (message.type === 'text' || message.type === 'attachment') && !!message.deviceRevokedAt,
     measure: ownProps.measure,
     message: message,
     onAuthorClick: () => dispatchProps._onAuthorClick(message.author),

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -302,9 +302,9 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     let explodedBy = null
     switch (message.type) {
       case 'text':
-        exploding = message.exploding
-        exploded = message.exploded
-        explodedBy = message.explodedBy
+        exploding = true // message.exploding
+        exploded = false // message.exploded
+        explodedBy = null // message.explodedBy
         child = <TextMessage key="text" message={message} />
         break
       case 'attachment':
@@ -522,7 +522,7 @@ const styles = Styles.styleSheetCreate({
         Styles.globalMargins.tiny + // right margin
         Styles.globalMargins.tiny + // left margin
         Styles.globalMargins.mediumLarge, // avatar
-      paddingRight: Styles.globalMargins.small,
+      paddingRight: Styles.globalMargins.tiny,
     },
   }),
   edited: {color: Styles.globalColors.black_20},

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -517,12 +517,14 @@ const styles = Styles.styleSheetCreate({
     },
     isMobile: {
       marginTop: -12,
+      paddingBottom: 3,
       paddingLeft:
         // Space for below the avatar
         Styles.globalMargins.tiny + // right margin
         Styles.globalMargins.tiny + // left margin
         Styles.globalMargins.mediumLarge, // avatar
       paddingRight: Styles.globalMargins.tiny,
+      paddingTop: 3,
     },
   }),
   edited: {color: Styles.globalColors.black_20},

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -302,9 +302,9 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     let explodedBy = null
     switch (message.type) {
       case 'text':
-        exploding = true // message.exploding
-        exploded = false // message.exploded
-        explodedBy = null // message.explodedBy
+        exploding = message.exploding
+        exploded = message.exploded
+        explodedBy = message.explodedBy
         child = <TextMessage key="text" message={message} />
         break
       case 'attachment':


### PR DESCRIPTION
@keybase/react-hackers this fixes exploding / revoked icons being different between the first message and secondary ones

cc: @mmaxim  @cecileboucheron 