### PR TITLE
Don't spam buildPayment on openSendRequestForm

### DIFF
--- a/shared/actions/__tests__/wallets.test.js
+++ b/shared/actions/__tests__/wallets.test.js
@@ -11,6 +11,7 @@ import walletsSaga from '../wallets'
 import appRouteTree from '../../app/routes-app'
 import * as Testing from '../../util/testing'
 import {getPath as getRoutePath} from '../../route-tree'
+import HiddenString from '../../util/hidden-string'
 
 jest.mock('../../engine/require')
 
@@ -187,5 +188,71 @@ it('build and send request', () => {
     .then(({requestRPC}) => {
       expect(getState().wallets.builtRequest).toEqual(Constants.makeBuiltRequest())
       expect(requestRPC).toHaveBeenCalled()
+    })
+})
+
+const buildingResSecretNote = new HiddenString('please send')
+const buildingRes = {
+  amount: '5',
+  bid: 'fake build ID',
+  currency: '123',
+  from: Types.noAccountID,
+  isRequest: false,
+  publicMemo: new HiddenString(''),
+  recipientType: 'keybaseUser',
+  secretNote: buildingResSecretNote,
+  to: 'akalin',
+}
+
+it('primes send/request form', () => {
+  const {dispatch, getState} = startReduxSaga()
+  // accept disclaimer
+  const acceptRPC = jest.spyOn(RPCStellarTypes, 'localAcceptDisclaimerLocalRpcPromise')
+  acceptRPC.mockImplementation(() => Promise.resolve())
+
+  const checkRPC = jest.spyOn(RPCStellarTypes, 'localHasAcceptedDisclaimerLocalRpcPromise')
+  checkRPC.mockImplementation(() => Promise.resolve(true))
+
+  dispatch(WalletsGen.createAcceptDisclaimer())
+  dispatch(WalletsGen.createCheckDisclaimer({nextScreen: 'openWallet'}))
+  return Testing.flushPromises()
+    .then(() => {
+      const startPaymentRPC = jest.spyOn(RPCStellarTypes, 'localStartBuildPaymentLocalRpcPromise')
+      startPaymentRPC.mockImplementation(() => Promise.resolve('fake build ID'))
+
+      const buildRPC = jest.spyOn(RPCStellarTypes, 'localBuildPaymentLocalRpcPromise')
+      buildRPC.mockImplementation(() => Promise.resolve(buildPaymentRes))
+
+      dispatch(
+        WalletsGen.createOpenSendRequestForm({
+          amount: '5',
+          currency: '123',
+          secretNote: buildingResSecretNote,
+          to: 'akalin',
+        })
+      )
+      return Testing.flushPromises({buildRPC, startPaymentRPC})
+    })
+    .then(({buildRPC, startPaymentRPC}) => {
+      expect(startPaymentRPC).toHaveBeenCalled()
+
+      const state = getState()
+      const expectedBuildRes = Constants.makeBuilding(buildingRes)
+      expect(state.wallets.building).toEqual(expectedBuildRes)
+      // build RPC should have been called last with buildRes
+      expect(buildRPC.mock.calls[buildRPC.mock.calls.length - 1]).toEqual([
+        {
+          amount: expectedBuildRes.amount,
+          bid: 'fake build ID',
+          currency: '123',
+          from: '',
+          fromPrimaryAccount: true,
+          publicMemo: '',
+          secretNote: expectedBuildRes.secretNote.stringValue(),
+          to: 'akalin',
+          toIsAccountID: false,
+        },
+        Constants.buildPaymentWaitingKey,
+      ])
     })
 })

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -174,10 +174,9 @@ const requestPayment = state =>
 
 const startPayment = state =>
   state.wallets.acceptedDisclaimer && !state.wallets.building.isRequest
-    ? RPCStellarTypes.localStartBuildPaymentLocalRpcPromise().then(bid => [
-        WalletsGen.createBuildingPaymentIDReceived({bid}),
-        WalletsGen.createBuildPayment(),
-      ])
+    ? RPCStellarTypes.localStartBuildPaymentLocalRpcPromise().then(bid =>
+        WalletsGen.createBuildingPaymentIDReceived({bid})
+      )
     : null
 
 const reviewPayment = state =>
@@ -836,6 +835,7 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
     | WalletsGen.SetBuildingIsRequestPayload
     | WalletsGen.SetBuildingToPayload
     | WalletsGen.DisplayCurrencyReceivedPayload
+    | WalletsGen.BuildingPaymentIDReceivedPayload
   >(
     [
       WalletsGen.setBuildingAmount,
@@ -844,6 +844,7 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
       WalletsGen.setBuildingIsRequest,
       WalletsGen.setBuildingTo,
       WalletsGen.displayCurrencyReceived,
+      WalletsGen.buildingPaymentIDReceived,
     ],
     spawnBuildPayment
   )

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -172,11 +172,13 @@ const requestPayment = state =>
     })
   )
 
-const startPayment = () =>
-  RPCStellarTypes.localStartBuildPaymentLocalRpcPromise().then(bid => [
-    WalletsGen.createBuildingPaymentIDReceived({bid}),
-    WalletsGen.createBuildPayment(),
-  ])
+const startPayment = state =>
+  state.wallets.acceptedDisclaimer
+    ? RPCStellarTypes.localStartBuildPaymentLocalRpcPromise().then(bid => [
+        WalletsGen.createBuildingPaymentIDReceived({bid}),
+        WalletsGen.createBuildPayment(),
+      ])
+    : null
 
 const reviewPayment = state =>
   RPCStellarTypes.localReviewPaymentLocalRpcPromise({

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -79,35 +79,12 @@ const spawnBuildPayment = (state, action) => {
 const openSendRequestForm = (state, action) =>
   state.wallets.acceptedDisclaimer
     ? [
-        action.payload.isRequest
-          ? WalletsGen.createClearBuiltRequest()
-          : WalletsGen.createClearBuiltPayment(),
-        WalletsGen.createSetBuildingAmount({amount: action.payload.amount || ''}),
-        WalletsGen.createSetBuildingCurrency({
-          currency:
-            action.payload.currency ||
-            (state.wallets.lastSentXLM && 'XLM') ||
-            (action.payload.from && Constants.getDisplayCurrency(state, action.payload.from).code) ||
-            'XLM',
-        }),
         WalletsGen.createLoadDisplayCurrency({
           // in case from account differs
           accountID: action.payload.from || Types.noAccountID,
           setBuildingCurrency: !action.payload.currency,
         }),
         WalletsGen.createLoadDisplayCurrencies(),
-        WalletsGen.createSetBuildingFrom({from: action.payload.from || Types.noAccountID}),
-        WalletsGen.createSetBuildingIsRequest({isRequest: !!action.payload.isRequest}),
-        WalletsGen.createSetBuildingPublicMemo({
-          publicMemo: action.payload.publicMemo || new HiddenString(''),
-        }),
-        WalletsGen.createSetBuildingRecipientType({
-          recipientType: action.payload.recipientType || 'keybaseUser',
-        }),
-        WalletsGen.createSetBuildingSecretNote({
-          secretNote: action.payload.secretNote || new HiddenString(''),
-        }),
-        WalletsGen.createSetBuildingTo({to: action.payload.to || ''}),
         RouteTreeGen.createNavigateAppend({
           path: [Constants.sendRequestFormRouteKey],
         }),
@@ -196,9 +173,10 @@ const requestPayment = state =>
   )
 
 const startPayment = () =>
-  RPCStellarTypes.localStartBuildPaymentLocalRpcPromise().then(bid =>
-    WalletsGen.createBuildingPaymentIDReceived({bid})
-  )
+  RPCStellarTypes.localStartBuildPaymentLocalRpcPromise().then(bid => [
+    WalletsGen.createBuildingPaymentIDReceived({bid}),
+    WalletsGen.createBuildPayment(),
+  ])
 
 const reviewPayment = state =>
   RPCStellarTypes.localReviewPaymentLocalRpcPromise({

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -173,7 +173,7 @@ const requestPayment = state =>
   )
 
 const startPayment = state =>
-  state.wallets.acceptedDisclaimer
+  state.wallets.acceptedDisclaimer && !state.wallets.building.isRequest
     ? RPCStellarTypes.localStartBuildPaymentLocalRpcPromise().then(bid => [
         WalletsGen.createBuildingPaymentIDReceived({bid}),
         WalletsGen.createBuildPayment(),

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -602,6 +602,7 @@ export {
   makeAssetDescription,
   makeAssets,
   makeCurrencies,
+  makeCurrency,
   makeBuilding,
   makeBuiltPayment,
   makeBuiltRequest,

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -43,6 +43,9 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
           })
         : state
     case WalletsGen.openSendRequestForm:
+      if (!state.acceptedDisclaimer) {
+        return state
+      }
       const initialBuilding = Constants.makeBuilding()
       return state.merge({
         building: initialBuilding.merge({

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -42,9 +42,29 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
             builtRequest: state.builtRequest.merge(Constants.makeBuiltRequest(action.payload.build)),
           })
         : state
+    case WalletsGen.openSendRequestForm:
+      const initialBuilding = Constants.makeBuilding()
+      return state.merge({
+        building: initialBuilding.merge({
+          amount: action.payload.amount || '',
+          currency:
+            action.payload.currency ||
+            (state.lastSentXLM && 'XLM') ||
+            (action.payload.from &&
+              state.currencyMap.get(action.payload.from, Constants.makeCurrency()).code) ||
+            'XLM',
+          from: action.payload.from || Types.noAccountID,
+          isRequest: !!action.payload.isRequest,
+          publicMemo: action.payload.publicMemo || new HiddenString(''),
+          recipientType: action.payload.recipientType || 'keybaseUser',
+          secretNote: action.payload.secretNote || new HiddenString(''),
+          to: action.payload.to || '',
+        }),
+        builtPayment: Constants.makeBuiltPayment(),
+        builtRequest: Constants.makeBuiltRequest(),
+      })
     case WalletsGen.abandonPayment:
     case WalletsGen.clearBuilding:
-    case WalletsGen.openSendRequestForm:
       return state.merge({building: Constants.makeBuilding()})
     case WalletsGen.clearBuiltPayment:
       return state.merge({builtPayment: Constants.makeBuiltPayment()})


### PR DESCRIPTION
Currently, `openSendRequestForm` works by firing off a bunch of `setBuilding*` actions, with each of them sending off a `buildPayment`. This changes it so the flow is
```
dispatch(openSendRequestForm)
 |
 v
reducer populates state.building ----
 |                                   |
 v                                   v
startPayment fetches buildID         openSendRequestForm (saga) dispatches currency loads
 |                                   and navigates to form
 v
buildPayment
```

Fixes:
* Fulfilling requests from chat resulting in error "payment not ready for review"
* Fulfilling requests from chat error for people who haven't accepted the disclaimer
* Getting build ID for opening request dialog

I tried to preserve the logic as much as possible, this should behave similarly to master other than the fixes.

r? @keybase/react-hackers 