### PR TITLE
prefetcher: get status from the block retriever instead of request

### DIFF
--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2647,6 +2647,12 @@ type BlockRetriever interface {
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime,
 		action BlockRequestAction) <-chan error
+	// RequestWithPrefetchStatus is like `Request`, but also fills in
+	// a prefetch status.
+	RequestWithPrefetchStatus(
+		ctx context.Context, priority int, kmd KeyMetadata,
+		ptr BlockPointer, block Block, prefetchStatus *PrefetchStatus,
+		lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error
 	// PutInCaches puts the block into the in-memory cache, and ensures that
 	// the disk cache metadata is updated.
 	PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID,

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -10731,6 +10731,20 @@ func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockBlockRetriever)(nil).Request), ctx, priority, kmd, ptr, block, lifetime, action)
 }
 
+// RequestWithPrefetchStatus mocks base method
+func (m *MockBlockRetriever) RequestWithPrefetchStatus(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, prefetchStatus *PrefetchStatus, lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestWithPrefetchStatus", ctx, priority, kmd, ptr, block, prefetchStatus, lifetime, action)
+	ret0, _ := ret[0].(<-chan error)
+	return ret0
+}
+
+// RequestWithPrefetchStatus indicates an expected call of RequestWithPrefetchStatus
+func (mr *MockBlockRetrieverMockRecorder) RequestWithPrefetchStatus(ctx, priority, kmd, ptr, block, prefetchStatus, lifetime, action interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestWithPrefetchStatus", reflect.TypeOf((*MockBlockRetriever)(nil).RequestWithPrefetchStatus), ctx, priority, kmd, ptr, block, prefetchStatus, lifetime, action)
+}
+
 // PutInCaches mocks base method
 func (m *MockBlockRetriever) PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID, block Block, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Because the request status could be out of date, and that cound end up confusing the outstanding block counts.

Here's an example scenario where this can happen:

* A prefetch request for block `a` triggers a request for child `b`.
* Another request for block `a` gets re-queued while it is `TriggeredPrefetch` in the cache.
* Child `b` completes, which marks block `a` as `FinishedPrefetch`.
* The prefetch request from the second step now gets handled.  But because the request itself contains a `TriggeredPrefetch` status still, it kicks off a new request for child `b`.
* Another prefetch request for `a` comes in, but this request is properly marked `FinishedPrefetch`, and so the outstanding prefetch for `a` is closed immediately.
* The parent block of `a` is requested, which opens another prefetch request for `a`, with a block count of 1 (`a` itself).
* The `b` request from the 4th step completes, and decrements the count of parent `a` to 0 even though the previous request is still outstanding.

This doesn't cause any major problems right now, but once #15328 is in, it really messes up the byte counts.

Issue: KBFS-3575