### PR TITLE
Delete staticProofServices

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -78,9 +78,11 @@ func newIdentify2WithUIDTester(g *libkb.GlobalContext) *Identify2WithUIDTester {
 	}
 }
 
-func (i *Identify2WithUIDTester) ListProofCheckers() []string               { return nil }
-func (i *Identify2WithUIDTester) ListServicesThatAcceptNewProofs() []string { return nil }
-func (i *Identify2WithUIDTester) Key() string                               { return i.GetTypeName() }
+func (i *Identify2WithUIDTester) ListProofCheckers(libkb.MetaContext) []string { return nil }
+func (i *Identify2WithUIDTester) ListServicesThatAcceptNewProofs(libkb.MetaContext) []string {
+	return nil
+}
+func (i *Identify2WithUIDTester) Key() string { return i.GetTypeName() }
 func (i *Identify2WithUIDTester) CheckProofText(text string, id keybase1.SigID, sig string) error {
 	return nil
 }
@@ -101,7 +103,9 @@ func (i *Identify2WithUIDTester) ToServiceJSON(remotename string) *jsonw.Wrapper
 func (i *Identify2WithUIDTester) MakeProofChecker(_ libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return i
 }
-func (i *Identify2WithUIDTester) GetServiceType(n string) libkb.ServiceType { return i }
+func (i *Identify2WithUIDTester) GetServiceType(mctx libkb.MetaContext, n string) libkb.ServiceType {
+	return i
+}
 
 func (i *Identify2WithUIDTester) CheckStatus(m libkb.MetaContext, h libkb.SigHint,
 	pcm libkb.ProofCheckerMode, _ keybase1.MerkleStoreEntry) (*libkb.SigHint, libkb.ProofError) {

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -320,7 +320,7 @@ func (p *Prove) checkProofText(m libkb.MetaContext) error {
 }
 
 func (p *Prove) getServiceType(m libkb.MetaContext) (err error) {
-	p.st = m.G().GetProofServices().GetServiceType(p.arg.Service)
+	p.st = m.G().GetProofServices().GetServiceType(m, p.arg.Service)
 	if p.st == nil {
 		return libkb.BadServiceError{Service: p.arg.Service}
 	}

--- a/go/engine/prove_help_test.go
+++ b/go/engine/prove_help_test.go
@@ -227,7 +227,7 @@ func proveGubbleUniverse(tc libkb.TestContext, serviceName, endpoint string, fu 
 	tc.T.Logf("proof for %s", serviceName)
 	g := tc.G
 	sv := keybase1.SigVersion(sigVersion)
-	proofService := g.GetProofServices().GetServiceType(serviceName)
+	proofService := g.GetProofServices().GetServiceType(libkb.NewMetaContext(context.Background(), g), serviceName)
 	require.NotNil(tc.T, proofService)
 
 	// Post a proof to the testing generic social service
@@ -308,7 +308,7 @@ func proveGubbleUniverse(tc libkb.TestContext, serviceName, endpoint string, fu 
 
 func proveGubbleSocialFail(g *libkb.GlobalContext, fu *FakeUser, sigVersion libkb.SigVersion) (*ProveUIMock, error) {
 	sv := keybase1.SigVersion(sigVersion)
-	proofService := g.GetProofServices().GetServiceType("gubble.social")
+	proofService := g.GetProofServices().GetServiceType(libkb.NewMetaContext(context.Background(), g), "gubble.social")
 	if proofService == nil {
 		return nil, fmt.Errorf("Unable to find gubble.social service")
 	}

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -385,7 +385,7 @@ func (e *ScanProofsEngine) CheckOne(m libkb.MetaContext, rec map[string]string, 
 		return nil, foundhint, err
 	}
 
-	pc, err := libkb.MakeProofChecker(m.G().GetProofServices(), link)
+	pc, err := libkb.MakeProofChecker(m, m.G().GetProofServices(), link)
 	if err != nil {
 		return nil, foundhint, err
 	}

--- a/go/externals/common_test.go
+++ b/go/externals/common_test.go
@@ -8,7 +8,7 @@ import (
 func setupTest(tb libkb.TestingTB, name string, depth int) libkb.TestContext {
 	tc := libkb.SetupTest(tb, name, depth)
 	g := tc.G
-	g.SetProofServices(NewProofServices(g))
+	g.SetProofServices(NewProofServices())
 	g.ConfigureMerkleClient()
 	pvl.NewPvlSourceAndInstall(g)
 	NewParamProofStoreAndInstall(g)

--- a/go/externals/init.go
+++ b/go/externals/init.go
@@ -23,7 +23,7 @@ func NewParamProofStoreAndInstall(g *libkb.GlobalContext) libkb.MerkleStore {
 
 func NewGlobalContextInit() *libkb.GlobalContext {
 	g := libkb.NewGlobalContext().Init()
-	g.SetProofServices(NewProofServices(g))
+	g.SetProofServices(NewProofServices())
 	g.ConfigureMerkleClient()
 	pvl.NewPvlSourceAndInstall(g)
 	NewParamProofStoreAndInstall(g)

--- a/go/externals/services_test.go
+++ b/go/externals/services_test.go
@@ -15,11 +15,11 @@ func TestLoadParamServices(t *testing.T) {
 
 	m := libkb.NewMetaContextForTest(tc)
 
-	proofServices := newProofServices(tc.G)
+	proofServices := newProofServices()
 	entry, err := tc.G.GetParamProofStore().GetLatestEntry(m)
 	require.NoError(t, err)
 
-	proofConfigs, displayConfigs, err := proofServices.parseServiceConfigs(entry)
+	proofConfigs, displayConfigs, err := proofServices.parseServiceConfigs(m, entry)
 	require.NoError(t, err)
 	require.NotNil(t, proofConfigs)
 	require.NotNil(t, displayConfigs)

--- a/go/externals/social_assertion.go
+++ b/go/externals/social_assertion.go
@@ -6,7 +6,7 @@ import (
 )
 
 func MakeAssertionContext(g *libkb.GlobalContext) libkb.AssertionContext {
-	return libkb.MakeAssertionContext(NewProofServices(g))
+	return libkb.MakeAssertionContext(g, NewProofServices())
 }
 
 func NormalizeSocialAssertion(g *libkb.GlobalContext, s string) (keybase1.SocialAssertion, bool) {
@@ -31,20 +31,4 @@ func ParseAssertionsWithReaders(g *libkb.GlobalContext, s string) (writers, read
 
 func ParseAssertionList(g *libkb.GlobalContext, s string) ([]libkb.AssertionExpression, error) {
 	return libkb.ParseAssertionList(MakeAssertionContext(g), s)
-}
-
-// NOTE the static methods should only be used in tests or as a basic sanity
-// check for the syntactical correctness of an assertion. All other callers
-// should use the non-static versions.
-// This uses only the 'static' services which exclude any parameterized proofs.
-func makeStaticAssertionContext() libkb.AssertionContext {
-	return libkb.MakeStaticAssertionContext(newStaticProofServices())
-}
-
-func NormalizeSocialAssertionStatic(s string) (keybase1.SocialAssertion, bool) {
-	return libkb.NormalizeSocialAssertion(makeStaticAssertionContext(), s)
-}
-
-func AssertionParseAndOnlyStatic(s string) (libkb.AssertionExpression, error) {
-	return libkb.AssertionParseAndOnly(makeStaticAssertionContext(), s)
 }

--- a/go/externalstest/test_common.go
+++ b/go/externalstest/test_common.go
@@ -17,7 +17,7 @@ func SetupTest(tb libkb.TestingTB, name string, depthIgnored int) (tc libkb.Test
 	// libkb.SetupTest ignores the third argument (depth).
 	tc = libkb.SetupTest(tb, name, depthIgnored)
 
-	tc.G.SetProofServices(externals.NewProofServices(tc.G))
+	tc.G.SetProofServices(externals.NewProofServices())
 	tc.G.SetUIDMapper(uidmap.NewUIDMap(10000))
 	pvl.NewPvlSourceAndInstall(tc.G)
 	externals.NewParamProofStoreAndInstall(tc.G)

--- a/go/git/common_test.go
+++ b/go/git/common_test.go
@@ -13,7 +13,7 @@ import (
 func SetupTest(tb testing.TB, name string, depth int) (tc libkb.TestContext) {
 	tc = libkb.SetupTest(tb, name, depth+1)
 	InstallInsecureTriplesec(tc.G)
-	tc.G.SetProofServices(externals.NewProofServices(tc.G))
+	tc.G.SetProofServices(externals.NewProofServices())
 	tc.G.ChatHelper = kbtest.NewMockChatHelper()
 	teams.ServiceInit(tc.G)
 	return tc

--- a/go/git/crypto_test.go
+++ b/go/git/crypto_test.go
@@ -28,7 +28,7 @@ func InstallInsecureTriplesec(g *libkb.GlobalContext) {
 
 func setupTest(tb testing.TB, name string) libkb.TestContext {
 	tc := libkb.SetupTest(tb, name, 1)
-	tc.G.SetProofServices(externals.NewProofServices(tc.G))
+	tc.G.SetProofServices(externals.NewProofServices())
 	InstallInsecureTriplesec(tc.G)
 	teams.NewTeamLoaderAndInstall(tc.G)
 	teams.NewAuditorAndInstall(tc.G)

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -1074,7 +1074,7 @@ func (g *GlobalContext) MakeAssertionContext() AssertionContext {
 	if g.proofServices == nil {
 		return nil
 	}
-	return MakeAssertionContext(g.proofServices)
+	return MakeAssertionContext(g, g.proofServices)
 }
 
 func (g *GlobalContext) SetProofServices(s ExternalServicesCollector) {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1635,7 +1635,7 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 
 	// Call the Global context's version of what a proof checker is. We might want to stub it out
 	// for the purposes of testing.
-	pc, res.err = MakeProofChecker(m.G().GetProofServices(), p)
+	pc, res.err = MakeProofChecker(m, m.G().GetProofServices(), p)
 
 	if res.err != nil || pc == nil {
 		return

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/gregor"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
+	"golang.org/x/net/context"
 )
 
 type IdentifyOutcome struct {
@@ -111,7 +112,7 @@ func (i *IdentifyOutcome) proofChecksSortedByDisplayPriority() []*LinkCheckResul
 	for _, lcr := range pc {
 		key := lcr.link.DisplayPriorityKey()
 		if _, ok := serviceTypes[key]; !ok {
-			st := proofServices.GetServiceType(key)
+			st := proofServices.GetServiceType(NewMetaContext(context.TODO(), i.G()), key)
 			displayPriority := 0
 			if st != nil {
 				displayPriority = st.DisplayPriority()

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -598,9 +598,9 @@ type ServiceType interface {
 }
 
 type ExternalServicesCollector interface {
-	GetServiceType(n string) ServiceType
-	ListProofCheckers() []string
-	ListServicesThatAcceptNewProofs() []string
+	GetServiceType(MetaContext, string) ServiceType
+	ListProofCheckers(MetaContext) []string
+	ListServicesThatAcceptNewProofs(MetaContext) []string
 }
 
 // Generic store for data that is hashed into the merkle root. Used by pvl and

--- a/go/service/prove.go
+++ b/go/service/prove.go
@@ -99,5 +99,5 @@ func (ph *ProveHandler) CheckProof(ctx context.Context, arg keybase1.CheckProofA
 
 // Prove handles the `keybase.1.listProofServices` RPC.
 func (ph *ProveHandler) ListProofServices(ctx context.Context) (res []string, err error) {
-	return ph.G().GetProofServices().ListServicesThatAcceptNewProofs(), nil
+	return ph.G().GetProofServices().ListServicesThatAcceptNewProofs(ph.MetaContext(ctx)), nil
 }

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -187,7 +187,7 @@ func TestImplicitDisplayTeamNameParse(t *testing.T) {
 	// It will probably fail because <uid>@keybase is the wrong format.
 
 	makeAssertionContext := func() libkb.AssertionContext {
-		return libkb.MakeAssertionContext(externals.NewProofServices(tc.G))
+		return libkb.MakeAssertionContext(tc.G, externals.NewProofServices())
 	}
 
 	for _, public := range []bool{true, false} {

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -412,7 +412,7 @@ func TestMemberAddNotAUser(t *testing.T) {
 	tc, _, name := memberSetup(t)
 	defer tc.Cleanup()
 
-	tc.G.SetProofServices(externals.NewProofServices(tc.G))
+	tc.G.SetProofServices(externals.NewProofServices())
 
 	_, err := AddMember(context.TODO(), tc.G, name, "not_a_kb_user", keybase1.TeamRole_READER)
 	if err == nil {
@@ -427,7 +427,7 @@ func TestMemberAddSocial(t *testing.T) {
 	tc, _, name := memberSetup(t)
 	defer tc.Cleanup()
 
-	tc.G.SetProofServices(externals.NewProofServices(tc.G))
+	tc.G.SetProofServices(externals.NewProofServices())
 
 	res, err := AddMember(context.TODO(), tc.G, name, "not_on_kb_yet@twitter", keybase1.TeamRole_OWNER)
 	if err == nil {
@@ -1081,7 +1081,7 @@ func TestMemberCancelInviteSocial(t *testing.T) {
 	tc, _, name := memberSetup(t)
 	defer tc.Cleanup()
 
-	tc.G.SetProofServices(externals.NewProofServices(tc.G))
+	tc.G.SetProofServices(externals.NewProofServices())
 
 	username := "not_on_kb_yet@twitter"
 	_, err := AddMember(context.TODO(), tc.G, name, username, keybase1.TeamRole_READER)
@@ -1101,7 +1101,7 @@ func TestMemberCancelInviteEmail(t *testing.T) {
 	tc, _, name := memberSetup(t)
 	defer tc.Cleanup()
 
-	tc.G.SetProofServices(externals.NewProofServices(tc.G))
+	tc.G.SetProofServices(externals.NewProofServices())
 
 	address := "noone@keybase.io"
 


### PR DESCRIPTION
When adding stuff to `proofServices` having to do it to `staticProofServices` was a bother. This deletes `staticProofServices`. Basically just shuffling around where `G` pointers are stored.

As a side effect the "This uses only the 'static' services which exclude any parameterized proofs " assertion context seems to be deletable. I hope that's a bonus but maybe it's an issue?
