### PR TITLE
Move staticProofServices to staticAssertionContext

### DIFF
--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -16,52 +16,6 @@ import (
 // SupportedVersion is which version of ParamProofs is supported by this client.
 const SupportedVersion int = 1
 
-// staticProofServies are only used for testing or for basic assertion
-// validation
-type staticProofServices struct {
-	externalServices map[string]libkb.ServiceType
-}
-
-func newStaticProofServices() libkb.ExternalServicesCollector {
-	staticServices := getStaticProofServices()
-	p := staticProofServices{
-		externalServices: make(map[string]libkb.ServiceType),
-	}
-	p.register(staticServices)
-	return &p
-}
-
-func (p *staticProofServices) register(services []libkb.ServiceType) {
-	for _, st := range services {
-		if !useDevelProofCheckers && st.IsDevelOnly() {
-			continue
-		}
-		p.externalServices[st.Key()] = st
-	}
-}
-
-func (p *staticProofServices) GetServiceType(s string) libkb.ServiceType {
-	return p.externalServices[strings.ToLower(s)]
-}
-
-func (p *staticProofServices) ListProofCheckers() []string {
-	var ret []string
-	for k := range p.externalServices {
-		ret = append(ret, k)
-	}
-	return ret
-}
-
-func (p *staticProofServices) ListServicesThatAcceptNewProofs() []string {
-	var ret []string
-	for k, v := range p.externalServices {
-		if v.CanMakeNewProofs() {
-			ret = append(ret, k)
-		}
-	}
-	return ret
-}
-
 // Contains both the statically known services and loads the configurations for
 // known services from the server
 type proofServices struct {

--- a/go/externals/social_assertion.go
+++ b/go/externals/social_assertion.go
@@ -1,6 +1,8 @@
 package externals
 
 import (
+	"strings"
+
 	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
@@ -33,13 +35,36 @@ func ParseAssertionList(g *libkb.GlobalContext, s string) ([]libkb.AssertionExpr
 	return libkb.ParseAssertionList(MakeAssertionContext(g), s)
 }
 
+type staticAssertionContext struct {
+	services map[string]libkb.ServiceType
+}
+
+func makeStaticAssertionContext() libkb.AssertionContext {
+	services := make(map[string]libkb.ServiceType)
+	for _, st := range getStaticProofServices() {
+		if !useDevelProofCheckers && st.IsDevelOnly() {
+			continue
+		}
+		services[st.Key()] = st
+	}
+	return staticAssertionContext{services: services}
+}
+
+func (a staticAssertionContext) NormalizeSocialName(service string, username string) (string, error) {
+	st := a.services[strings.ToLower(service)]
+	if st == nil {
+		// If we don't know about this service, normalize by going to lowercase
+		return strings.ToLower(username), nil
+	}
+	return st.NormalizeUsername(username)
+}
+
 // NOTE the static methods should only be used in tests or as a basic sanity
 // check for the syntactical correctness of an assertion. All other callers
 // should use the non-static versions.
 // This uses only the 'static' services which exclude any parameterized proofs.
-func makeStaticAssertionContext() libkb.AssertionContext {
-	return libkb.MakeStaticAssertionContext(newStaticProofServices())
-}
+
+//=============================================================================
 
 func NormalizeSocialAssertionStatic(s string) (keybase1.SocialAssertion, bool) {
 	return libkb.NormalizeSocialAssertion(makeStaticAssertionContext(), s)
@@ -48,3 +73,5 @@ func NormalizeSocialAssertionStatic(s string) (keybase1.SocialAssertion, bool) {
 func AssertionParseAndOnlyStatic(s string) (libkb.AssertionExpression, error) {
 	return libkb.AssertionParseAndOnly(makeStaticAssertionContext(), s)
 }
+
+//=============================================================================

--- a/go/externals/social_assertion.go
+++ b/go/externals/social_assertion.go
@@ -35,6 +35,12 @@ func ParseAssertionList(g *libkb.GlobalContext, s string) ([]libkb.AssertionExpr
 	return libkb.ParseAssertionList(MakeAssertionContext(g), s)
 }
 
+// NOTE The 'Static' methods should only be used in tests or as a basic sanity
+// check for the syntactical correctness of an assertion. All other callers
+// should use the non-static versions.
+// This uses only the 'static' services which exclude any parameterized proofs.
+//=============================================================================
+
 type staticAssertionContext struct {
 	services map[string]libkb.ServiceType
 }
@@ -58,13 +64,6 @@ func (a staticAssertionContext) NormalizeSocialName(service string, username str
 	}
 	return st.NormalizeUsername(username)
 }
-
-// NOTE the static methods should only be used in tests or as a basic sanity
-// check for the syntactical correctness of an assertion. All other callers
-// should use the non-static versions.
-// This uses only the 'static' services which exclude any parameterized proofs.
-
-//=============================================================================
 
 func NormalizeSocialAssertionStatic(s string) (keybase1.SocialAssertion, bool) {
 	return libkb.NormalizeSocialAssertion(makeStaticAssertionContext(), s)

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -175,28 +175,3 @@ func (a assertionContext) NormalizeSocialName(service string, username string) (
 	}
 	return st.NormalizeUsername(username)
 }
-
-//=============================================================================
-
-// NOTE the static methods should only be used in tests or as a basic sanity
-// check for the syntactical correctness of an assertion. All other callers
-// should use the non-static versions.
-// This uses only the 'static' services which exclude any parameterized proofs.
-type staticAssertionContext struct {
-	esc ExternalServicesCollector
-}
-
-func MakeStaticAssertionContext(s ExternalServicesCollector) AssertionContext {
-	return staticAssertionContext{esc: s}
-}
-
-func (a staticAssertionContext) NormalizeSocialName(service string, username string) (string, error) {
-	st := a.esc.GetServiceType(service)
-	if st == nil {
-		// If we don't know about this service, normalize by going to lowercase
-		return strings.ToLower(username), nil
-	}
-	return st.NormalizeUsername(username)
-}
-
-//=============================================================================


### PR DESCRIPTION
This makes it easier to make additions to `proofServices` since now it's the only implementer of `ExternalServicesCollector`.