### PR TITLE
Wallet main page sectionList tweaks

### DIFF
--- a/shared/common-adapters/section-list.desktop.js
+++ b/shared/common-adapters/section-list.desktop.js
@@ -74,7 +74,10 @@ class SectionList extends React.Component<Props, State> {
     }
     const indexWithinSection = section.data.indexOf(item.item)
     return item.type === 'header' ? (
-      <Box key={item.key || key} style={this.props.stickySectionHeadersEnabled && styles.stickySectionHeader}>
+      <Box
+        key={item.key || key}
+        style={this.props.stickySectionHeadersEnabled ? styles.stickySectionHeader : null}
+      >
         {this.props.renderSectionHeader({section})}
       </Box>
     ) : (

--- a/shared/wallets/asset/index.js
+++ b/shared/wallets/asset/index.js
@@ -178,7 +178,7 @@ const styles = Styles.styleSheetCreate({
     paddingRight: Styles.globalMargins.small,
   },
   headerContainer: {
-    height: 48,
+    height: Styles.isMobile ? 56 : 48,
     padding: Styles.globalMargins.tiny,
     paddingRight: Styles.globalMargins.small,
   },

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -69,7 +69,14 @@ const Header = (props: Props) => {
     </Kb.Box2>
   )
   return (
-    <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny" gapStart={true} style={styles.noShrink}>
+    <Kb.Box2
+      direction="vertical"
+      fullWidth={true}
+      gap="tiny"
+      gapStart={true}
+      gapEnd={true}
+      style={styles.container}
+    >
       {nameAndInfo}
       <Kb.Box2 direction="horizontal" gap="tiny" centerChildren={true}>
         <SendButton
@@ -85,7 +92,6 @@ const Header = (props: Props) => {
           disabled={!props.walletName}
         />
       </Kb.Box2>
-      <Kb.Divider />
     </Kb.Box2>
   )
 }
@@ -195,6 +201,12 @@ const styles = Styles.styleSheetCreate({
     marginLeft: Styles.globalMargins.xtiny,
     width: 10,
   },
+  container: {
+    borderBottomColor: Styles.globalColors.black_10,
+    borderBottomWidth: 1,
+    borderStyle: 'solid',
+    flexShrink: 0,
+  },
   dropdownButton: Styles.platformStyles({
     isElectron: {
       paddingLeft: Styles.globalMargins.small,
@@ -205,7 +217,6 @@ const styles = Styles.styleSheetCreate({
       paddingRight: Styles.globalMargins.xsmall,
     },
   }),
-  noShrink: {flexShrink: 0},
   smallAccountID: {
     marginLeft: Styles.globalMargins.tiny,
     marginRight: Styles.globalMargins.tiny,

--- a/shared/wallets/wallet/index.js
+++ b/shared/wallets/wallet/index.js
@@ -119,6 +119,7 @@ class Wallet extends React.Component<Props> {
           sections={this.props.sections}
           renderItem={this._renderItem}
           renderSectionHeader={this._renderSectionHeader}
+          stickySectionHeadersEnabled={false}
           keyExtractor={this._keyExtractor}
           onEndReached={this._onEndReached}
         />

--- a/shared/wallets/wallet/index.js
+++ b/shared/wallets/wallet/index.js
@@ -150,7 +150,10 @@ const styles = Styles.styleSheetCreate({
   sectionHeader: {
     ...Styles.globalStyles.flexBoxColumn,
     backgroundColor: Styles.globalColors.blue5,
-    padding: Styles.globalMargins.xtiny,
+    paddingBottom: Styles.globalMargins.xtiny,
+    paddingLeft: Styles.globalMargins.tiny,
+    paddingRight: Styles.globalMargins.xtiny,
+    paddingTop: Styles.globalMargins.xtiny,
     width: '100%',
   },
   spinner: {


### PR DESCRIPTION
- No sticky section headers
- Asset row taller on mobile
- Section header more left padding

r? @keybase/react-hackers cc @cecileboucheron 