### PR TITLE
block_retrieval_queue: throttle low-priority requests

### DIFF
--- a/go/kbfs/libkbfs/block_ops.go
+++ b/go/kbfs/libkbfs/block_ops.go
@@ -5,6 +5,8 @@
 package libkbfs
 
 import (
+	"time"
+
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -36,14 +38,16 @@ type BlockOpsStandard struct {
 var _ BlockOps = (*BlockOpsStandard)(nil)
 
 // NewBlockOpsStandard creates a new BlockOpsStandard
-func NewBlockOpsStandard(config blockOpsConfig,
-	queueSize, prefetchQueueSize int) *BlockOpsStandard {
+func NewBlockOpsStandard(
+	config blockOpsConfig, queueSize, prefetchQueueSize int,
+	throttledPrefetchPeriod time.Duration) *BlockOpsStandard {
 	bg := &realBlockGetter{config: config}
 	qConfig := &realBlockRetrievalConfig{
 		blockRetrievalPartialConfig: config,
 		bg: bg,
 	}
-	q := newBlockRetrievalQueue(queueSize, prefetchQueueSize, qConfig)
+	q := newBlockRetrievalQueue(
+		queueSize, prefetchQueueSize, throttledPrefetchPeriod, qConfig)
 	bops := &BlockOpsStandard{
 		config: config,
 		log:    traceLogger{config.MakeLogger("")},

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -131,8 +131,9 @@ func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 // encrypts its given block properly.
 func TestBlockOpsReadySuccess(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -172,8 +173,9 @@ func TestBlockOpsReadySuccess(t *testing.T) {
 // fails properly if we fail to retrieve the key.
 func TestBlockOpsReadyFailKeyGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -199,8 +201,9 @@ func (c badServerHalfMaker) MakeRandomBlockCryptKeyServerHalf() (
 func TestBlockOpsReadyFailServerHalfGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.cp = badServerHalfMaker{config.cryptoPure()}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -227,8 +230,9 @@ func (c badBlockEncryptor) EncryptBlock(
 func TestBlockOpsReadyFailEncryption(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.cp = badBlockEncryptor{config.cryptoPure()}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -269,8 +273,9 @@ func (c badEncoder) Encode(o interface{}) ([]byte, error) {
 func TestBlockOpsReadyFailEncode(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.testCodecGetter.codec = badEncoder{config.codec}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -295,8 +300,9 @@ func (c tooSmallEncoder) Encode(o interface{}) ([]byte, error) {
 func TestBlockOpsReadyTooSmallEncode(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.codec = tooSmallEncoder{config.codec}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -312,8 +318,9 @@ func TestBlockOpsReadyTooSmallEncode(t *testing.T) {
 // previous key generation.
 func TestBlockOpsGetSuccess(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -349,8 +356,9 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 // if it can't retrieve the block from the server.
 func TestBlockOpsGetFailServerGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -393,8 +401,9 @@ func (bserver badGetBlockServer) Get(
 func TestBlockOpsGetFailVerify(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = badGetBlockServer{config.bserver}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -424,8 +433,9 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 // fails if it can't get the decryption key.
 func TestBlockOpsGetFailKeyGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -493,8 +503,9 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 		errors: make(map[string]error),
 	}
 	config.codec = &badDecoder
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -538,8 +549,9 @@ func (c badBlockDecryptor) DecryptBlock(
 func TestBlockOpsGetFailDecrypt(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.cp = badBlockDecryptor{config.cryptoPure()}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -573,8 +585,9 @@ func TestBlockOpsDeleteSuccess(t *testing.T) {
 	bserver := NewMockBlockServer(mockCtrl)
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = bserver
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	// Expect one call to delete several blocks.
@@ -610,8 +623,9 @@ func TestBlockOpsDeleteFail(t *testing.T) {
 	bserver := NewMockBlockServer(mockCtrl)
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = bserver
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	b1 := BlockPointer{ID: kbfsblock.FakeID(1)}
@@ -645,8 +659,9 @@ func TestBlockOpsArchiveSuccess(t *testing.T) {
 	bserver := NewMockBlockServer(mockCtrl)
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = bserver
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	// Expect one call to archive several blocks.
@@ -679,8 +694,9 @@ func TestBlockOpsArchiveFail(t *testing.T) {
 	bserver := NewMockBlockServer(mockCtrl)
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = bserver
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
-		testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	defer bops.Shutdown()
 
 	b1 := BlockPointer{ID: kbfsblock.FakeID(1)}

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -490,11 +490,13 @@ func (brq *blockRetrievalQueue) request(
 				priority >= defaultOnDemandRequestPriority) ||
 				(oldPriority <= throttleRequestPriority &&
 					priority > throttleRequestPriority) {
-				// We've crossed the priority threshold for prefetch workers,
-				// so we now need an on-demand worker to pick up the request.
-				// This means that we might have up to two workers "activated"
-				// per request. However, they won't leak because if a worker
-				// sees an empty queue, it continues merrily along.
+				// We've crossed the priority threshold for a given
+				// worker type, so we now need a worker for the new
+				// priority level to pick up the request.  This means
+				// that we might have up to two workers "activated"
+				// per request. However, they won't leak because if a
+				// worker sees an empty queue, it continues merrily
+				// along.
 				brq.notifyWorker(priority)
 			}
 		}

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"io"
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -309,4 +310,45 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	require.Equal(t, uint64(1), br.insertionOrder)
 	require.Len(t, br.requests, 1)
 	require.Equal(t, block, br.requests[0].block)
+}
+
+func TestBlockRetrievalQueueThrottling(t *testing.T) {
+	t.Log("Start test with no throttling channel so we can pass in our own")
+	q := initBlockRetrievalQueueTest(t)
+	require.NotNil(t, q)
+	defer q.Shutdown()
+
+	throttleCh := make(chan struct{}, workerQueueSize)
+	q.throttledWorkCh = throttleCh
+
+	t.Log("Make a few throttled requests that won't be serviced until we " +
+		"start the background loop.")
+
+	ctx := context.Background()
+	ptr1 := makeRandomBlockPointer(t)
+	block1 := &FileBlock{}
+	_ = q.Request(
+		ctx, throttleRequestPriority, makeKMD(), ptr1, block1,
+		NoCacheEntry, BlockRequestSolo)
+	ptr2 := makeRandomBlockPointer(t)
+	block2 := &FileBlock{}
+	_ = q.Request(
+		ctx, throttleRequestPriority-100, makeKMD(), ptr2, block2,
+		NoCacheEntry, BlockRequestSolo)
+
+	t.Log("Make sure they are queued to be throttled")
+	require.Len(t, throttleCh, 2)
+
+	t.Log("Start background loop with short period")
+	go q.throttleReleaseLoop(1*time.Millisecond, throttleCh)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	for len(throttleCh) > 0 {
+		time.Sleep(1 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		default:
+		}
+	}
 }

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -72,7 +72,8 @@ func makeKMD() KeyMetadata {
 }
 
 func initBlockRetrievalQueueTest(t *testing.T) *blockRetrievalQueue {
-	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, nil, nil))
+	q := newBlockRetrievalQueue(
+		0, 0, 0, newTestBlockRetrievalConfig(t, nil, nil))
 	<-q.TogglePrefetcher(false, nil)
 	return q
 }

--- a/go/kbfs/libkbfs/block_retrieval_worker_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_worker_test.go
@@ -117,7 +117,8 @@ func makeFakeFileBlock(t *testing.T, doHash bool) *FileBlock {
 func TestBlockRetrievalWorkerBasic(t *testing.T) {
 	t.Log("Test the basic ability of a worker to return a block.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(
+		0, 1, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -138,7 +139,8 @@ func TestBlockRetrievalWorkerBasic(t *testing.T) {
 func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 	t.Log("Test the ability of multiple workers to retrieve concurrently.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(2, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(
+		2, 0, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -185,7 +187,8 @@ func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 	t.Log("Test the ability of a worker and queue to work correctly together.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(
+		1, 0, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -249,7 +252,8 @@ func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 func TestBlockRetrievalWorkerCancel(t *testing.T) {
 	t.Log("Test the ability of a worker to handle a request cancelation.")
 	bg := newFakeBlockGetter(true)
-	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(
+		0, 1, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -269,7 +273,8 @@ func TestBlockRetrievalWorkerCancel(t *testing.T) {
 func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 	t.Log("Test that worker shutdown works.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(
+		1, 0, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -316,7 +321,8 @@ func TestBlockRetrievalWorkerPrefetchedPriorityElevation(t *testing.T) {
 	t.Log("Test that we can escalate the priority of a request and it " +
 		"correctly switches workers.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, 1, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(
+		1, 1, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 

--- a/go/kbfs/libkbfs/disk_block_cache_test.go
+++ b/go/kbfs/libkbfs/disk_block_cache_test.go
@@ -549,7 +549,8 @@ func TestDiskBlockCacheWithRetrievalQueue(t *testing.T) {
 
 	t.Log("Create a queue with 0 workers to rule it out from serving blocks.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, bg, cache))
+	q := newBlockRetrievalQueue(
+		0, 0, 0, newTestBlockRetrievalConfig(t, bg, cache))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -633,7 +633,9 @@ func doInit(
 
 	workers := config.Mode().BlockWorkers()
 	prefetchWorkers := config.Mode().PrefetchWorkers()
-	config.SetBlockOps(NewBlockOpsStandard(config, workers, prefetchWorkers))
+	throttledPrefetchPeriod := config.Mode().ThrottledPrefetchPeriod()
+	config.SetBlockOps(NewBlockOpsStandard(
+		config, workers, prefetchWorkers, throttledPrefetchPeriod))
 
 	bsplitter, err := NewBlockSplitterSimple(MaxBlockSizeBytesDefault, 8*1024,
 		config.Codec())

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2233,6 +2233,9 @@ type InitMode interface {
 	BlockWorkers() int
 	// PrefetchWorkers returns the number of prefetch workers to run.
 	PrefetchWorkers() int
+	// ThrottledPrefetchTime returns the period for each prefetch
+	// worker to start a throttled prefetch request.
+	ThrottledPrefetchPeriod() time.Duration
 	// DefaultBlockRequestAction returns the action to be used by
 	// default whenever fetching a block.
 	DefaultBlockRequestAction() BlockRequestAction

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -130,7 +130,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	brc := &testBlockRetrievalConfig{nil, newTestLogMaker(t),
 		config.BlockCache(), nil, newTestDiskBlockCacheGetter(t, nil),
 		newTestSyncedTlfGetterSetter(), testInitModeGetter{InitDefault}}
-	brq := newBlockRetrievalQueue(0, 0, brc)
+	brq := newBlockRetrievalQueue(0, 0, 0, brc)
 	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)
 	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(brq.prefetcher)
 

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -8467,6 +8467,20 @@ func (mr *MockInitModeMockRecorder) PrefetchWorkers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchWorkers", reflect.TypeOf((*MockInitMode)(nil).PrefetchWorkers))
 }
 
+// ThrottledPrefetchPeriod mocks base method
+func (m *MockInitMode) ThrottledPrefetchPeriod() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ThrottledPrefetchPeriod")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// ThrottledPrefetchPeriod indicates an expected call of ThrottledPrefetchPeriod
+func (mr *MockInitModeMockRecorder) ThrottledPrefetchPeriod() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ThrottledPrefetchPeriod", reflect.TypeOf((*MockInitMode)(nil).ThrottledPrefetchPeriod))
+}
+
 // DefaultBlockRequestAction mocks base method
 func (m *MockInitMode) DefaultBlockRequestAction() BlockRequestAction {
 	m.ctrl.T.Helper()

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -53,6 +53,10 @@ func (md modeDefault) PrefetchWorkers() int {
 	return defaultPrefetchWorkerQueueSize
 }
 
+func (md modeDefault) ThrottledPrefetchPeriod() time.Duration {
+	return defaultThrottledPrefetchPeriod
+}
+
 func (md modeDefault) DefaultBlockRequestAction() BlockRequestAction {
 	return BlockRequestWithPrefetch
 }
@@ -168,6 +172,10 @@ func (mm modeMinimal) BlockWorkers() int {
 }
 
 func (mm modeMinimal) PrefetchWorkers() int {
+	return 0
+}
+
+func (mm modeMinimal) ThrottledPrefetchPeriod() time.Duration {
 	return 0
 }
 

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -338,6 +338,11 @@ top:
 // high priority for a synced TLF.
 func (p *blockPrefetcher) calculatePriority(
 	basePriority int, action BlockRequestAction) int {
+	// A prefetched, non-deep-synced child always gets throttled for
+	// now, until we fix the database performance issues.
+	if basePriority > throttleRequestPriority && !action.DeepSync() {
+		basePriority = throttleRequestPriority
+	}
 	return basePriority - 1
 }
 

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -73,7 +73,7 @@ func initPrefetcherTestWithDiskCache(t *testing.T, dbc DiskBlockCache) (
 	// _actually_ completed.
 	bg := newFakeBlockGetter(false)
 	config := newTestBlockRetrievalConfig(t, bg, dbc)
-	q := newBlockRetrievalQueue(1, 1, config)
+	q := newBlockRetrievalQueue(1, 1, 0, config)
 	require.NotNil(t, q)
 
 	return q, bg, config

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -47,8 +47,9 @@ func newConfigForTest(modeType InitModeType, loggerFn func(module string) logger
 	mode := modeTest{NewInitModeFromType(modeType)}
 	config := NewConfigLocal(mode, loggerFn, "", DiskCacheModeOff, &env.KBFSContext{})
 
-	bops := NewBlockOpsStandard(config,
-		testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize)
+	bops := NewBlockOpsStandard(
+		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
+		0)
 	config.SetBlockOps(bops)
 
 	maxDirEntriesPerBlock, err := getMaxDirEntriesPerBlock()


### PR DESCRIPTION
This PR adds a new priority threshold, at or below which requests are throttled to a configured speed.  And we use that priority for both: a) recently-edit files being partially synced, and b) prefetched children during a non-deep-sync.  The reason for the latter restriction is that if the user (or, say, the partial sync loop itself) does a `Lookup` on one of the nodes (which triggers a regular prefetch), that will immediately bump up the priority of any queued requests above the throttle threshold, and then all prefetched children will inherit that.  So in addition to slowing down the recent-edit sync, this will also slow down normal prefetches.  I think that's ok for now, until we can figure out the db performance issues.

Issue: KBFS-3739