### PR TITLE
fix react-list mis-measure

### DIFF
--- a/shared/actions/platform-specific/index.desktop.js
+++ b/shared/actions/platform-specific/index.desktop.js
@@ -112,7 +112,11 @@ function* initializeInputMonitor(): Generator<any, void, any> {
 
   while (true) {
     const type = yield Saga.take(channel)
-    yield Saga.put(ConfigGen.createChangedActive({userActive: type === 'active'}))
+    if (skipAppFocusActions) {
+      console.log('Skipping app focus actions!')
+    } else {
+      yield Saga.put(ConfigGen.createChangedActive({userActive: type === 'active'}))
+    }
   }
 }
 

--- a/shared/search/results-list/index.desktop.js
+++ b/shared/search/results-list/index.desktop.js
@@ -53,7 +53,7 @@ class SearchResultsList extends Component<Props> {
           ref={this._setRef}
           length={items.length}
           itemSizeGetter={this._itemSizeGetter}
-          type="uniform"
+          type="variable"
         />
       </Box>
     )

--- a/shared/search/results-list/index.desktop.js
+++ b/shared/search/results-list/index.desktop.js
@@ -28,6 +28,7 @@ class SearchResultsList extends Component<Props> {
 
   _list = null
   _setRef = r => (this._list = r)
+  _itemSizeGetter = () => 48
 
   render() {
     const {showSearchSuggestions, style, items} = this.props
@@ -51,6 +52,7 @@ class SearchResultsList extends Component<Props> {
           itemRenderer={this._itemRenderer}
           ref={this._setRef}
           length={items.length}
+          itemSizeGetter={this._itemSizeGetter}
           type="uniform"
         />
       </Box>


### PR DESCRIPTION
@keybase/react-hackers so react-list when starting up isn't measuring the items correctly. if you pass uniform it doesn't go through the measurement flow unless something thrashes it (hence us sometimes trying to fix this with forceUpdate).
So there's 3 options
1. don't use react-list (we're already doing this) but thats a larger change
2. use type `variable`  (what this does)