### PR TITLE
block_retrieval_queue: don't get full block for prefetch status

### DIFF
--- a/go/kbfs/genprotocol/kbgitkbfs1-avdl/disk_block_cache.avdl
+++ b/go/kbfs/genprotocol/kbgitkbfs1-avdl/disk_block_cache.avdl
@@ -37,6 +37,11 @@ protocol DiskBlockCache {
   GetBlockRes GetBlock(bytes tlfID, bytes blockID);
 
   /**
+   GetPrefetchStatus gets the prefetch status from the disk cache.
+   */
+  PrefetchStatus GetPrefetchStatus(bytes tlfID, bytes blockID);
+
+  /**
     PutBlock puts a block into the disk cache.
     */
   void PutBlock(bytes tlfID, bytes blockID, bytes buf, bytes serverHalf);

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -335,22 +335,27 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	kmd KeyMetadata, ptr BlockPointer, block Block, action BlockRequestAction) (
 	PrefetchStatus, error) {
 	dbc := brq.config.DiskBlockCache()
-	if dbc == nil {
-		// Attempt to retrieve the block from the memory cache, but
-		// only if the disk cache is nil, since if it's not nil we
-		// need to get the prefetch status from the disk anyway.  Just
-		// use a simple cache for storing the prefetch status; the
-		// most likely reason we have no disk block cache is that
-		// we're testing.
-		cachedBlock, err := brq.config.BlockCache().Get(ptr)
-		if err != nil {
-			return NoPrefetch, err
-		}
+	preferredCacheType := action.CacheType()
+
+	cachedBlock, err := brq.config.BlockCache().Get(ptr)
+	if err == nil {
 		block.Set(cachedBlock)
-		return brq.getPrefetchStatus(ptr.ID), nil
+		if dbc == nil {
+			return brq.getPrefetchStatus(ptr.ID), nil
+		}
+
+		prefetchStatus, err := dbc.GetPrefetchStatus(
+			ctx, kmd.TlfID(), ptr.ID, preferredCacheType)
+		if err == nil {
+			return prefetchStatus, nil
+		}
+		// If the prefetch status wasn't in the preferred cache, do a
+		// full `Get()` below in an attempt to move the full block
+		// into the preferred cache.
+	} else if dbc == nil {
+		return NoPrefetch, err
 	}
 
-	preferredCacheType := action.CacheType()
 	blockBuf, serverHalf, prefetchStatus, err := dbc.Get(
 		ctx, kmd.TlfID(), ptr.ID, preferredCacheType)
 	if err != nil {

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -582,13 +582,7 @@ func (cache *DiskBlockCacheLocal) Get(
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, NoPrefetch, err
 	}
 	buf, serverHalf, err = cache.decodeBlockCacheEntry(entry)
-	prefetchStatus = NoPrefetch
-	if md.FinishedPrefetch {
-		prefetchStatus = FinishedPrefetch
-	} else if md.TriggeredPrefetch {
-		prefetchStatus = TriggeredPrefetch
-	}
-	return buf, serverHalf, prefetchStatus, err
+	return buf, serverHalf, md.PrefetchStatus(), err
 }
 
 func (cache *DiskBlockCacheLocal) evictUntilBytesAvailable(

--- a/go/kbfs/libkbfs/disk_block_cache_helper.go
+++ b/go/kbfs/libkbfs/disk_block_cache_helper.go
@@ -41,6 +41,15 @@ type DiskBlockCacheMetadata struct {
 	Tag string
 }
 
+func (dbcm DiskBlockCacheMetadata) PrefetchStatus() PrefetchStatus {
+	if dbcm.FinishedPrefetch {
+		return FinishedPrefetch
+	} else if dbcm.TriggeredPrefetch {
+		return TriggeredPrefetch
+	}
+	return NoPrefetch
+}
+
 // lruEntry is an entry for sorting LRU times
 type lruEntry struct {
 	BlockID kbfsblock.ID

--- a/go/kbfs/libkbfs/disk_block_cache_remote.go
+++ b/go/kbfs/libkbfs/disk_block_cache_remote.go
@@ -76,6 +76,32 @@ func (dbcr *DiskBlockCacheRemote) Get(ctx context.Context, tlfID tlf.ID,
 	return res.Buf, serverHalf, prefetchStatus, nil
 }
 
+// GetPefetchStatus implements the DiskBlockCache interface for
+// DiskBlockCacheRemote.
+func (dbcr *DiskBlockCacheRemote) GetPrefetchStatus(
+	ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID,
+	cacheType DiskBlockCacheType) (
+	prefetchStatus PrefetchStatus, err error) {
+	dbcr.log.LazyTrace(
+		ctx, "DiskBlockCacheRemote: GetPrefetchStatus %s", blockID)
+	defer func() {
+		dbcr.log.LazyTrace(
+			ctx, "DiskBlockCacheRemote: GetPrefetchStatus %s done (err=%+v)",
+			blockID, err)
+	}()
+
+	res, err := dbcr.client.GetPrefetchStatus(
+		ctx, kbgitkbfs.GetPrefetchStatusArg{
+			TlfID:   tlfID.Bytes(),
+			BlockID: blockID.Bytes(),
+		})
+	if err != nil {
+		return NoPrefetch, err
+	}
+
+	return PrefetchStatusFromProtocol(res), nil
+}
+
 // Put implements the DiskBlockCache interface for DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) Put(ctx context.Context, tlfID tlf.ID,
 	blockID kbfsblock.ID, buf []byte,

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1320,6 +1320,10 @@ type DiskBlockCache interface {
 		preferredCacheType DiskBlockCacheType) (
 		buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf,
 		prefetchStatus PrefetchStatus, err error)
+	// GetPrefetchStatus returns just the prefetchStatus for the block.
+	GetPrefetchStatus(
+		ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID,
+		cacheType DiskBlockCacheType) (PrefetchStatus, error)
 	// Put puts a block to the disk cache. Returns after it has
 	// updated the metadata but before it has finished writing the
 	// block.  If cacheType is specified, the block is put into that

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -5141,6 +5141,21 @@ func (mr *MockDiskBlockCacheMockRecorder) Get(ctx, tlfID, blockID, preferredCach
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDiskBlockCache)(nil).Get), ctx, tlfID, blockID, preferredCacheType)
 }
 
+// GetPrefetchStatus mocks base method
+func (m *MockDiskBlockCache) GetPrefetchStatus(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, cacheType DiskBlockCacheType) (PrefetchStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrefetchStatus", ctx, tlfID, blockID, cacheType)
+	ret0, _ := ret[0].(PrefetchStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPrefetchStatus indicates an expected call of GetPrefetchStatus
+func (mr *MockDiskBlockCacheMockRecorder) GetPrefetchStatus(ctx, tlfID, blockID, cacheType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrefetchStatus", reflect.TypeOf((*MockDiskBlockCache)(nil).GetPrefetchStatus), ctx, tlfID, blockID, cacheType)
+}
+
 // Put mocks base method
 func (m *MockDiskBlockCache) Put(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, cacheType DiskBlockCacheType) error {
 	m.ctrl.T.Helper()

--- a/go/kbfs/protocol/kbgitkbfs1/disk_block_cache.go
+++ b/go/kbfs/protocol/kbgitkbfs1/disk_block_cache.go
@@ -80,6 +80,11 @@ type GetBlockArg struct {
 	BlockID []byte `codec:"blockID" json:"blockID"`
 }
 
+type GetPrefetchStatusArg struct {
+	TlfID   []byte `codec:"tlfID" json:"tlfID"`
+	BlockID []byte `codec:"blockID" json:"blockID"`
+}
+
 type PutBlockArg struct {
 	TlfID      []byte `codec:"tlfID" json:"tlfID"`
 	BlockID    []byte `codec:"blockID" json:"blockID"`
@@ -100,6 +105,8 @@ type UpdateBlockMetadataArg struct {
 type DiskBlockCacheInterface interface {
 	// GetBlock gets a block from the disk cache.
 	GetBlock(context.Context, GetBlockArg) (GetBlockRes, error)
+	// GetPrefetchStatus gets the prefetch status from the disk cache.
+	GetPrefetchStatus(context.Context, GetPrefetchStatusArg) (PrefetchStatus, error)
 	// PutBlock puts a block into the disk cache.
 	PutBlock(context.Context, PutBlockArg) error
 	// DeleteBlocks deletes a set of blocks from the disk cache.
@@ -124,6 +131,21 @@ func DiskBlockCacheProtocol(i DiskBlockCacheInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.GetBlock(ctx, typedArgs[0])
+					return
+				},
+			},
+			"GetPrefetchStatus": {
+				MakeArg: func() interface{} {
+					var ret [1]GetPrefetchStatusArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]GetPrefetchStatusArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]GetPrefetchStatusArg)(nil), args)
+						return
+					}
+					ret, err = i.GetPrefetchStatus(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -183,6 +205,12 @@ type DiskBlockCacheClient struct {
 // GetBlock gets a block from the disk cache.
 func (c DiskBlockCacheClient) GetBlock(ctx context.Context, __arg GetBlockArg) (res GetBlockRes, err error) {
 	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.GetBlock", []interface{}{__arg}, &res)
+	return
+}
+
+// GetPrefetchStatus gets the prefetch status from the disk cache.
+func (c DiskBlockCacheClient) GetPrefetchStatus(ctx context.Context, __arg GetPrefetchStatusArg) (res PrefetchStatus, err error) {
+	err = c.Cli.Call(ctx, "kbgitkbfs.1.DiskBlockCache.GetPrefetchStatus", []interface{}{__arg}, &res)
 	return
 }
 


### PR DESCRIPTION
When a block is available in the in-memory cache, don't bother getting it from the disk just to get its prefetch status.  Just fetch the prefetch status from disk instead.

A further PR might optimize this more by keeping an LRU cache of prefetch status within the `DiskBlockCache` (and `DiskBlockCacheRemote`) itself, to avoid any disk or RPC calls when possible.

Issue: KBFS-3744
