### PR TITLE
Update react-native-image-picker

### DIFF
--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -11627,7 +11627,7 @@ react-native-fast-image@5.1.1:
 
 "react-native-image-picker@git://github.com/keybase/react-native-image-picker#v0.27.1-with-keybase-fixes":
   version "0.27.1"
-  resolved "git://github.com/keybase/react-native-image-picker#5c81f1c60de50f8d5a4b883bb42208325bcc2761"
+  resolved "git://github.com/keybase/react-native-image-picker#bbbf8fdf1fb351c3e739ea6dab55b15c390430d4"
 
 react-native-mime-types@2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This picks up a fix that makes taking video work on Android
without storage permissions (the default), and also prevents
videos from showing up in Google Photos on some phones.