### PR TITLE
Fix channel creation

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -237,6 +237,10 @@ func NewRemoteInboxSource(g *globals.Context, ri func() chat1.RemoteInterface) *
 	return s
 }
 
+func (s *RemoteInboxSource) Clear(ctx context.Context, uid gregor1.UID) error {
+	return nil
+}
+
 func (s *RemoteInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	localizerTyp types.ConversationLocalizerTyp, useLocalData bool, maxLocalize *int,
 	query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (types.Inbox, chan types.AsyncInboxResult, error) {
@@ -395,6 +399,10 @@ func NewHybridInboxSource(g *globals.Context,
 
 func (s *HybridInboxSource) createInbox() *storage.Inbox {
 	return storage.NewInbox(s.G(), storage.FlushMode(storage.InboxFlushModeDelegate))
+}
+
+func (s *HybridInboxSource) Clear(ctx context.Context, uid gregor1.UID) error {
+	return s.createInbox().Clear(ctx, uid)
 }
 
 func (s *HybridInboxSource) Start(ctx context.Context, uid gregor1.UID) {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -533,7 +533,7 @@ func (s *HybridInboxSource) Read(ctx context.Context, uid gregor1.UID,
 	// on this channel
 	localizeCb = make(chan types.AsyncInboxResult, len(inbox.ConvsUnverified)+1)
 	localizer := s.createConversationLocalizer(ctx, localizerTyp, localizeCb)
-	s.Debug(ctx, "Read: using localizer: %s", localizer.Name())
+	s.Debug(ctx, "Read: using localizer: %s on %d convs", localizer.Name(), len(inbox.ConvsUnverified))
 
 	// Localize
 	inbox.Convs, err = localizer.Localize(ctx, uid, inbox, maxLocalize)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4808,9 +4808,9 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		listener0 := newServerChatListener()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
 		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
-		//tc := ctc.world.Tcs[users[0].Username]
-		//uid := users[0].User.GetUID().ToBytes()
-		//ri := ctc.as(t, users[0]).ri
+		tc := ctc.world.Tcs[users[0].Username]
+		uid := users[0].User.GetUID().ToBytes()
+		ri := ctc.as(t, users[0]).ri
 
 		firstConv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
 
@@ -4840,97 +4840,97 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		consumeTeamType(t, listener0)
 		t.Logf("Deleted conv")
 
-		//topicName = "josh"
-		//ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
-		//	chat1.NewConversationLocalArg{
-		//		TlfName:       firstConv.TlfName,
-		//		TopicName:     &topicName,
-		//		TopicType:     chat1.TopicType_CHAT,
-		//		TlfVisibility: keybase1.TLFVisibility_PRIVATE,
-		//		MembersType:   chat1.ConversationMembersType_TEAM,
-		//	})
-		//require.NoError(t, err)
-		//conv = ncres.Conv.Info
+		topicName = "josh"
+		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
+			chat1.NewConversationLocalArg{
+				TlfName:       firstConv.TlfName,
+				TopicName:     &topicName,
+				TopicType:     chat1.TopicType_CHAT,
+				TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+				MembersType:   chat1.ConversationMembersType_TEAM,
+			})
+		require.NoError(t, err)
+		conv = ncres.Conv.Info
 
-		// convRemote, err := GetUnverifiedConv(ctx, tc.Context(), uid, conv.Id, true)
-		// require.NoError(t, err)
+		convRemote, err := GetUnverifiedConv(ctx, tc.Context(), uid, conv.Id, true)
+		require.NoError(t, err)
 
-		// // Creating a conversation with same topic name just returns the matching one
-		// topicName = "random"
-		// ncarg := chat1.NewConversationLocalArg{
-		// 	TlfName:       conv.TlfName,
-		// 	TopicName:     &topicName,
-		// 	TopicType:     chat1.TopicType_CHAT,
-		// 	TlfVisibility: keybase1.TLFVisibility_PRIVATE,
-		// 	MembersType:   chat1.ConversationMembersType_TEAM,
-		// }
-		// ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
-		// require.NoError(t, err)
-		// consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
-		// consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)
+		// Creating a conversation with same topic name just returns the matching one
+		topicName = "random"
+		ncarg := chat1.NewConversationLocalArg{
+			TlfName:       conv.TlfName,
+			TopicName:     &topicName,
+			TopicType:     chat1.TopicType_CHAT,
+			TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+			MembersType:   chat1.ConversationMembersType_TEAM,
+		}
+		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
+		require.NoError(t, err)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)
 
-		// randomConvID := ncres.Conv.GetConvID()
-		// ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
-		// require.NoError(t, err)
-		// require.Equal(t, randomConvID, ncres.Conv.GetConvID())
-		// consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
+		randomConvID := ncres.Conv.GetConvID()
+		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
+		require.NoError(t, err)
+		require.Equal(t, randomConvID, ncres.Conv.GetConvID())
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
 
-		// // Try to change topic name to one that exists
-		// plarg := chat1.PostLocalArg{
-		// 	ConversationID: conv.Id,
-		// 	Msg: chat1.MessagePlaintext{
-		// 		ClientHeader: chat1.MessageClientHeader{
-		// 			Conv:        conv.Triple,
-		// 			MessageType: chat1.MessageType_METADATA,
-		// 			TlfName:     conv.TlfName,
-		// 		},
-		// 		MessageBody: chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
-		// 			ConversationTitle: topicName,
-		// 		}),
-		// 	},
-		// 	IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		// }
-		// _, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
-		// require.Error(t, err)
-		// require.IsType(t, DuplicateTopicNameError{}, err)
-		// plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
-		// 	ConversationTitle: "EULALIA",
-		// })
-		// _, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
-		// require.NoError(t, err)
-		// consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
+		// Try to change topic name to one that exists
+		plarg := chat1.PostLocalArg{
+			ConversationID: conv.Id,
+			Msg: chat1.MessagePlaintext{
+				ClientHeader: chat1.MessageClientHeader{
+					Conv:        conv.Triple,
+					MessageType: chat1.MessageType_METADATA,
+					TlfName:     conv.TlfName,
+				},
+				MessageBody: chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+					ConversationTitle: topicName,
+				}),
+			},
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		}
+		_, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
+		require.Error(t, err)
+		require.IsType(t, DuplicateTopicNameError{}, err)
+		plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+			ConversationTitle: "EULALIA",
+		})
+		_, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
+		require.NoError(t, err)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
 
-		// // Create race with topic name state, and make sure we do the right thing
-		// plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
-		// 	ConversationTitle: "ANOTHERONE",
-		// })
-		// sender := NewBlockingSender(tc.Context(), NewBoxer(tc.Context()),
-		// 	func() chat1.RemoteInterface { return ri })
-		// prepareRes, err := sender.Prepare(ctx, plarg.Msg, mt, &convRemote)
-		// require.NoError(t, err)
-		// msg1 := prepareRes.Boxed
-		// ts1 := prepareRes.TopicNameState
-		// prepareRes, err = sender.Prepare(ctx, plarg.Msg, mt, &convRemote)
-		// require.NoError(t, err)
-		// msg2 := prepareRes.Boxed
-		// ts2 := prepareRes.TopicNameState
-		// require.True(t, ts1.Eq(*ts2))
+		// Create race with topic name state, and make sure we do the right thing
+		plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+			ConversationTitle: "ANOTHERONE",
+		})
+		sender := NewBlockingSender(tc.Context(), NewBoxer(tc.Context()),
+			func() chat1.RemoteInterface { return ri })
+		prepareRes, err := sender.Prepare(ctx, plarg.Msg, mt, &convRemote)
+		require.NoError(t, err)
+		msg1 := prepareRes.Boxed
+		ts1 := prepareRes.TopicNameState
+		prepareRes, err = sender.Prepare(ctx, plarg.Msg, mt, &convRemote)
+		require.NoError(t, err)
+		msg2 := prepareRes.Boxed
+		ts2 := prepareRes.TopicNameState
+		require.True(t, ts1.Eq(*ts2))
 
-		// _, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
-		// 	ConversationID: conv.Id,
-		// 	MessageBoxed:   msg1,
-		// 	TopicNameState: ts1,
-		// })
-		// require.NoError(t, err)
-		// consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
+		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
+			ConversationID: conv.Id,
+			MessageBoxed:   msg1,
+			TopicNameState: ts1,
+		})
+		require.NoError(t, err)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
 
-		// _, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
-		// 	ConversationID: conv.Id,
-		// 	MessageBoxed:   msg2,
-		// 	TopicNameState: ts2,
-		// })
-		// require.Error(t, err)
-		// require.IsType(t, libkb.ChatStalePreviousStateError{}, err)
+		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
+			ConversationID: conv.Id,
+			MessageBoxed:   msg2,
+			TopicNameState: ts2,
+		})
+		require.Error(t, err)
+		require.IsType(t, libkb.ChatStalePreviousStateError{}, err)
 	})
 }
 
@@ -5303,16 +5303,6 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		consumeMembersUpdate(t, listener1)
 		consumeTeamType(t, listener0)
 		consumeTeamType(t, listener1)
-
-		t.Logf("READ convID: %v", channelConvID)
-		_, lconvs, _, err = storage.NewInbox(g).Read(context.TODO(), uid, &chat1.GetInboxQuery{
-			ConvID:       &channelConvID,
-			MemberStatus: []chat1.ConversationMemberStatus{chat1.ConversationMemberStatus_LEFT},
-		}, nil)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(lconvs))
-		require.Equal(t, lconvs[0].GetConvID(), channelConvID)
-		require.Equal(t, chat1.ConversationExistence_ARCHIVED, lconvs[0].Conv.Metadata.Existence)
 
 		iboxRes, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(ctx,
 			chat1.GetInboxAndUnboxLocalArg{})

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4792,17 +4792,28 @@ func TestChatSrvSetConvMinWriterRole(t *testing.T) {
 
 func TestChatSrvTopicNameState(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
-		ctc := makeChatTestContext(t, "TestChatSrvTopicNameState", 1)
-		defer ctc.cleanup()
-		users := ctc.users()
-
 		// Only run this test for teams
 		switch mt {
 		case chat1.ConversationMembersType_TEAM:
 		default:
 			return
 		}
+
+		ctc := makeChatTestContext(t, "TestChatSrvTopicNameState", 1)
+		defer ctc.cleanup()
+		users := ctc.users()
+
+		ui := kbtest.NewChatUI()
+		ctc.as(t, users[0]).h.mockChatUI = ui
+		listener0 := newServerChatListener()
+		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
+		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
+		tc := ctc.world.Tcs[users[0].Username]
+		uid := users[0].User.GetUID().ToBytes()
+		ri := ctc.as(t, users[0]).ri
+
 		firstConv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
+
 		topicName := "MIKE"
 		ctx := ctc.as(t, users[0]).startCtx
 		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
@@ -4815,10 +4826,32 @@ func TestChatSrvTopicNameState(t *testing.T) {
 			})
 		require.NoError(t, err)
 		conv := ncres.Conv.Info
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
+		consumeTeamType(t, listener0)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)
 
-		tc := ctc.world.Tcs[users[0].Username]
-		uid := users[0].User.GetUID().ToBytes()
-		ri := ctc.as(t, users[0]).ri
+		// Delete the conv, make sure we can still create a new channel after
+		_, err = ctc.as(t, users[0]).chatLocalHandler().DeleteConversationLocal(ctx,
+			chat1.DeleteConversationLocalArg{
+				ConvID: conv.Id,
+			})
+		require.NoError(t, err)
+		consumeLeaveConv(t, listener0)
+		consumeTeamType(t, listener0)
+		t.Logf("Deleted conv")
+
+		topicName = "josh"
+		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
+			chat1.NewConversationLocalArg{
+				TlfName:       firstConv.TlfName,
+				TopicName:     &topicName,
+				TopicType:     chat1.TopicType_CHAT,
+				TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+				MembersType:   chat1.ConversationMembersType_TEAM,
+			})
+		require.NoError(t, err)
+		conv = ncres.Conv.Info
+
 		convRemote, err := GetUnverifiedConv(ctx, tc.Context(), uid, conv.Id, true)
 		require.NoError(t, err)
 
@@ -4833,10 +4866,14 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		}
 		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
 		require.NoError(t, err)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)
+
 		randomConvID := ncres.Conv.GetConvID()
 		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
 		require.NoError(t, err)
 		require.Equal(t, randomConvID, ncres.Conv.GetConvID())
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
 
 		// Try to change topic name to one that exists
 		plarg := chat1.PostLocalArg{
@@ -4861,6 +4898,7 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		})
 		_, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
 		require.NoError(t, err)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
 
 		// Create race with topic name state, and make sure we do the right thing
 		plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
@@ -4878,18 +4916,14 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		ts2 := prepareRes.TopicNameState
 		require.True(t, ts1.Eq(*ts2))
 
-		/*_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
-			ConversationID: conv.Id,
-			MessageBoxed:   *msg1,
-		})
-		require.Error(t, err)
-		require.IsType(t, libkb.ChatClientError{}, err)*/
 		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
 			ConversationID: conv.Id,
 			MessageBoxed:   msg1,
 			TopicNameState: ts1,
 		})
 		require.NoError(t, err)
+		consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
+
 		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
 			ConversationID: conv.Id,
 			MessageBoxed:   msg2,
@@ -4897,7 +4931,6 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.IsType(t, libkb.ChatStalePreviousStateError{}, err)
-
 	})
 }
 
@@ -5183,16 +5216,16 @@ func TestChatSrvTeamTypeChanged(t *testing.T) {
 
 func TestChatSrvDeleteConversation(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
-		ctc := makeChatTestContext(t, "TestChatSrvTeamTypeChanged", 2)
-		defer ctc.cleanup()
-		users := ctc.users()
-
 		// Only run this test for teams
 		switch mt {
 		case chat1.ConversationMembersType_TEAM:
 		default:
 			return
 		}
+
+		ctc := makeChatTestContext(t, "TestChatSrvTeamTypeChanged", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
 
 		ctx := ctc.as(t, users[0]).startCtx
 		ctx1 := ctc.as(t, users[1]).startCtx

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4808,9 +4808,9 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		listener0 := newServerChatListener()
 		ctc.as(t, users[0]).h.G().NotifyRouter.SetListener(listener0)
 		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
-		tc := ctc.world.Tcs[users[0].Username]
-		uid := users[0].User.GetUID().ToBytes()
-		ri := ctc.as(t, users[0]).ri
+		//tc := ctc.world.Tcs[users[0].Username]
+		//uid := users[0].User.GetUID().ToBytes()
+		//ri := ctc.as(t, users[0]).ri
 
 		firstConv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
 
@@ -4840,97 +4840,97 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		consumeTeamType(t, listener0)
 		t.Logf("Deleted conv")
 
-		topicName = "josh"
-		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
-			chat1.NewConversationLocalArg{
-				TlfName:       firstConv.TlfName,
-				TopicName:     &topicName,
-				TopicType:     chat1.TopicType_CHAT,
-				TlfVisibility: keybase1.TLFVisibility_PRIVATE,
-				MembersType:   chat1.ConversationMembersType_TEAM,
-			})
-		require.NoError(t, err)
-		conv = ncres.Conv.Info
+		//topicName = "josh"
+		//ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
+		//	chat1.NewConversationLocalArg{
+		//		TlfName:       firstConv.TlfName,
+		//		TopicName:     &topicName,
+		//		TopicType:     chat1.TopicType_CHAT,
+		//		TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+		//		MembersType:   chat1.ConversationMembersType_TEAM,
+		//	})
+		//require.NoError(t, err)
+		//conv = ncres.Conv.Info
 
-		convRemote, err := GetUnverifiedConv(ctx, tc.Context(), uid, conv.Id, true)
-		require.NoError(t, err)
+		// convRemote, err := GetUnverifiedConv(ctx, tc.Context(), uid, conv.Id, true)
+		// require.NoError(t, err)
 
-		// Creating a conversation with same topic name just returns the matching one
-		topicName = "random"
-		ncarg := chat1.NewConversationLocalArg{
-			TlfName:       conv.TlfName,
-			TopicName:     &topicName,
-			TopicType:     chat1.TopicType_CHAT,
-			TlfVisibility: keybase1.TLFVisibility_PRIVATE,
-			MembersType:   chat1.ConversationMembersType_TEAM,
-		}
-		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
-		require.NoError(t, err)
-		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
-		consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)
+		// // Creating a conversation with same topic name just returns the matching one
+		// topicName = "random"
+		// ncarg := chat1.NewConversationLocalArg{
+		// 	TlfName:       conv.TlfName,
+		// 	TopicName:     &topicName,
+		// 	TopicType:     chat1.TopicType_CHAT,
+		// 	TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+		// 	MembersType:   chat1.ConversationMembersType_TEAM,
+		// }
+		// ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
+		// require.NoError(t, err)
+		// consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
+		// consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)
 
-		randomConvID := ncres.Conv.GetConvID()
-		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
-		require.NoError(t, err)
-		require.Equal(t, randomConvID, ncres.Conv.GetConvID())
-		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
+		// randomConvID := ncres.Conv.GetConvID()
+		// ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
+		// require.NoError(t, err)
+		// require.Equal(t, randomConvID, ncres.Conv.GetConvID())
+		// consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
 
-		// Try to change topic name to one that exists
-		plarg := chat1.PostLocalArg{
-			ConversationID: conv.Id,
-			Msg: chat1.MessagePlaintext{
-				ClientHeader: chat1.MessageClientHeader{
-					Conv:        conv.Triple,
-					MessageType: chat1.MessageType_METADATA,
-					TlfName:     conv.TlfName,
-				},
-				MessageBody: chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
-					ConversationTitle: topicName,
-				}),
-			},
-			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		}
-		_, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
-		require.Error(t, err)
-		require.IsType(t, DuplicateTopicNameError{}, err)
-		plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
-			ConversationTitle: "EULALIA",
-		})
-		_, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
-		require.NoError(t, err)
-		consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
+		// // Try to change topic name to one that exists
+		// plarg := chat1.PostLocalArg{
+		// 	ConversationID: conv.Id,
+		// 	Msg: chat1.MessagePlaintext{
+		// 		ClientHeader: chat1.MessageClientHeader{
+		// 			Conv:        conv.Triple,
+		// 			MessageType: chat1.MessageType_METADATA,
+		// 			TlfName:     conv.TlfName,
+		// 		},
+		// 		MessageBody: chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+		// 			ConversationTitle: topicName,
+		// 		}),
+		// 	},
+		// 	IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
+		// }
+		// _, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
+		// require.Error(t, err)
+		// require.IsType(t, DuplicateTopicNameError{}, err)
+		// plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+		// 	ConversationTitle: "EULALIA",
+		// })
+		// _, err = ctc.as(t, users[0]).chatLocalHandler().PostLocal(ctx, plarg)
+		// require.NoError(t, err)
+		// consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
 
-		// Create race with topic name state, and make sure we do the right thing
-		plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
-			ConversationTitle: "ANOTHERONE",
-		})
-		sender := NewBlockingSender(tc.Context(), NewBoxer(tc.Context()),
-			func() chat1.RemoteInterface { return ri })
-		prepareRes, err := sender.Prepare(ctx, plarg.Msg, mt, &convRemote)
-		require.NoError(t, err)
-		msg1 := prepareRes.Boxed
-		ts1 := prepareRes.TopicNameState
-		prepareRes, err = sender.Prepare(ctx, plarg.Msg, mt, &convRemote)
-		require.NoError(t, err)
-		msg2 := prepareRes.Boxed
-		ts2 := prepareRes.TopicNameState
-		require.True(t, ts1.Eq(*ts2))
+		// // Create race with topic name state, and make sure we do the right thing
+		// plarg.Msg.MessageBody = chat1.NewMessageBodyWithMetadata(chat1.MessageConversationMetadata{
+		// 	ConversationTitle: "ANOTHERONE",
+		// })
+		// sender := NewBlockingSender(tc.Context(), NewBoxer(tc.Context()),
+		// 	func() chat1.RemoteInterface { return ri })
+		// prepareRes, err := sender.Prepare(ctx, plarg.Msg, mt, &convRemote)
+		// require.NoError(t, err)
+		// msg1 := prepareRes.Boxed
+		// ts1 := prepareRes.TopicNameState
+		// prepareRes, err = sender.Prepare(ctx, plarg.Msg, mt, &convRemote)
+		// require.NoError(t, err)
+		// msg2 := prepareRes.Boxed
+		// ts2 := prepareRes.TopicNameState
+		// require.True(t, ts1.Eq(*ts2))
 
-		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
-			ConversationID: conv.Id,
-			MessageBoxed:   msg1,
-			TopicNameState: ts1,
-		})
-		require.NoError(t, err)
-		consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
+		// _, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
+		// 	ConversationID: conv.Id,
+		// 	MessageBoxed:   msg1,
+		// 	TopicNameState: ts1,
+		// })
+		// require.NoError(t, err)
+		// consumeNewMsgRemote(t, listener0, chat1.MessageType_METADATA)
 
-		_, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
-			ConversationID: conv.Id,
-			MessageBoxed:   msg2,
-			TopicNameState: ts2,
-		})
-		require.Error(t, err)
-		require.IsType(t, libkb.ChatStalePreviousStateError{}, err)
+		// _, err = ri.PostRemote(ctx, chat1.PostRemoteArg{
+		// 	ConversationID: conv.Id,
+		// 	MessageBoxed:   msg2,
+		// 	TopicNameState: ts2,
+		// })
+		// require.Error(t, err)
+		// require.IsType(t, libkb.ChatStalePreviousStateError{}, err)
 	})
 }
 
@@ -5266,8 +5266,19 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)
 		consumeNewMsgRemote(t, listener1, chat1.MessageType_SYSTEM)
 
+		uid := users[0].User.GetUID().ToBytes()
+		g := ctc.world.Tcs[users[0].Username].Context()
+		channelConvID := channel.Conv.GetConvID()
+		_, lconvs, _, err := storage.NewInbox(g).Read(context.TODO(), uid, &chat1.GetInboxQuery{
+			ConvID: &channelConvID,
+		}, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(lconvs))
+		require.Equal(t, lconvs[0].GetConvID(), channelConvID)
+		require.Equal(t, chat1.ConversationExistence_ACTIVE, lconvs[0].Conv.Metadata.Existence)
+
 		_, err = ctc.as(t, users[1]).chatLocalHandler().JoinConversationByIDLocal(ctx1,
-			channel.Conv.GetConvID())
+			channelConvID)
 		require.NoError(t, err)
 		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
 		consumeNewMsgRemote(t, listener1, chat1.MessageType_JOIN)
@@ -5276,14 +5287,14 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 
 		_, err = ctc.as(t, users[1]).chatLocalHandler().DeleteConversationLocal(ctx1,
 			chat1.DeleteConversationLocalArg{
-				ConvID: channel.Conv.GetConvID(),
+				ConvID: channelConvID,
 			})
 		require.Error(t, err)
 		require.IsType(t, libkb.ChatClientError{}, err)
 
 		_, err = ctc.as(t, users[0]).chatLocalHandler().DeleteConversationLocal(ctx,
 			chat1.DeleteConversationLocalArg{
-				ConvID: channel.Conv.GetConvID(),
+				ConvID: channelConvID,
 			})
 		require.NoError(t, err)
 		consumeLeaveConv(t, listener0)
@@ -5292,6 +5303,16 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		consumeMembersUpdate(t, listener1)
 		consumeTeamType(t, listener0)
 		consumeTeamType(t, listener1)
+
+		t.Logf("READ convID: %v", channelConvID)
+		_, lconvs, _, err = storage.NewInbox(g).Read(context.TODO(), uid, &chat1.GetInboxQuery{
+			ConvID:       &channelConvID,
+			MemberStatus: []chat1.ConversationMemberStatus{chat1.ConversationMemberStatus_LEFT},
+		}, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(lconvs))
+		require.Equal(t, lconvs[0].GetConvID(), channelConvID)
+		require.Equal(t, chat1.ConversationExistence_ARCHIVED, lconvs[0].Conv.Metadata.Existence)
 
 		iboxRes, err := ctc.as(t, users[0]).chatLocalHandler().GetInboxAndUnboxLocal(ctx,
 			chat1.GetInboxAndUnboxLocalArg{})

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -669,7 +669,7 @@ func (i *Inbox) queryExists(ctx context.Context, ibox inboxDiskData, query *chat
 		i.Debug(ctx, "Read: queryExists: error hashing query: %s", err.Error())
 		return false
 	}
-	i.Debug(ctx, "Read: queryExists: query hash: %s p: %v", hquery, p)
+	i.Debug(ctx, "Read: queryExists: query: %+v,\n query hash: %s p: %v", query, hquery, p)
 
 	qp := inboxDiskQuery{QueryHash: hquery, Pagination: p}
 	for _, q := range ibox.Queries {
@@ -1521,6 +1521,7 @@ func (i *Inbox) Sync(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 			}
 
 			ibox.Conversations[index].Conv = newConv
+			i.Debug(ctx, "Sync:  %v", newConv)
 			delete(convMap, conv.GetConvID().String())
 		}
 	}
@@ -1554,7 +1555,8 @@ func (i *Inbox) MembershipUpdate(ctx context.Context, uid gregor1.UID, vers chat
 	defer i.Trace(ctx, func() error { return err }, "MembershipUpdate")()
 	defer i.maybeNukeFn(func() Error { return err }, i.dbKey(uid))
 
-	i.Debug(ctx, "MembershipUpdate: updating userJoined: %d userRemoved: %d othersJoined: %d othersRemoved: %d", len(userJoined), len(userRemoved), len(othersJoined), len(othersRemoved))
+	i.Debug(ctx, "MembershipUpdate: updating userJoined: %d userRemoved: %d othersJoined: %d othersRemoved: %d",
+		len(userJoined), len(userRemoved), len(othersJoined), len(othersRemoved))
 	ibox, err := i.readDiskInbox(ctx, uid, true)
 	if err != nil {
 		if _, ok := err.(MissError); ok {

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -260,8 +260,8 @@ func (i *Inbox) writeDiskInbox(ctx context.Context, uid gregor1.UID, ibox inboxD
 	ibox.ServerVersion = vers.InboxVers
 	ibox.Version = inboxVersion
 	ibox.Conversations = i.summarizeConvs(ibox.Conversations)
-	i.Debug(ctx, "writeDiskInbox: uid: %s version: %d disk version: %d server version: %d convs: %d: %v",
-		uid, ibox.InboxVersion, ibox.Version, ibox.ServerVersion, len(ibox.Conversations), ibox.Conversations)
+	i.Debug(ctx, "writeDiskInbox: uid: %s version: %d disk version: %d server version: %d convs: %d",
+		uid, ibox.InboxVersion, ibox.Version, ibox.ServerVersion, len(ibox.Conversations))
 	inboxMemCache.Put(uid, &ibox)
 	switch i.flushMode {
 	case InboxFlushModeActive:
@@ -512,7 +512,6 @@ func (i *Inbox) applyQuery(ctx context.Context, query *chat1.GetInboxQuery, rcs 
 	}
 
 	for _, rc := range rcs {
-		i.Debug(ctx, "applyQuery: %v", rc)
 		conv := rc.Conv
 		// Existence check
 		if conv.Metadata.Existence != chat1.ConversationExistence_ACTIVE {
@@ -674,7 +673,7 @@ func (i *Inbox) queryExists(ctx context.Context, ibox inboxDiskData, query *chat
 		i.Debug(ctx, "Read: queryExists: error hashing query: %s", err.Error())
 		return false
 	}
-	i.Debug(ctx, "Read: queryExists: query: %+v,\n query hash: %s p: %v", query, hquery, p)
+	i.Debug(ctx, "Read: queryExists: query hash: %s p: %v", hquery, p)
 
 	qp := inboxDiskQuery{QueryHash: hquery, Pagination: p}
 	for _, q := range ibox.Queries {
@@ -1526,7 +1525,6 @@ func (i *Inbox) Sync(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers,
 			}
 
 			ibox.Conversations[index].Conv = newConv
-			i.Debug(ctx, "Sync:  %v", newConv)
 			delete(convMap, conv.GetConvID().String())
 		}
 	}

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -381,7 +381,6 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		incr := syncRes.InboxRes.Incremental()
 		s.Debug(ctx, "Sync: version out of date, but can incrementally sync: old vers: %v vers: %v convs: %d",
 			vers, incr.Vers, len(incr.Convs))
-		s.Debug(ctx, "incr.Convs: %+v", incr.Convs)
 
 		var iboxSyncRes storage.InboxSyncRes
 		expunges := make(map[string]chat1.Expunge)

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -381,6 +381,7 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 		incr := syncRes.InboxRes.Incremental()
 		s.Debug(ctx, "Sync: version out of date, but can incrementally sync: old vers: %v vers: %v convs: %d",
 			vers, incr.Vers, len(incr.Convs))
+		s.Debug(ctx, "incr.Convs: %+v", incr.Convs)
 
 		var iboxSyncRes storage.InboxSyncRes
 		expunges := make(map[string]chat1.Expunge)

--- a/go/chat/teamchannelsource.go
+++ b/go/chat/teamchannelsource.go
@@ -21,6 +21,8 @@ type TeamChannelSource struct {
 var _ types.TeamChannelSource = (*TeamChannelSource)(nil)
 
 func NewTeamChannelSource(g *globals.Context) *TeamChannelSource {
+	// store this in sorted order so we keep the order consistent for
+	// GetInboxQuery which checks the hash of the query to hit the cache.
 	memberStatus := chat1.AllConversationMemberStatuses()
 	sort.Sort(utils.ByConversationMemberStatus(memberStatus))
 	return &TeamChannelSource{
@@ -60,9 +62,6 @@ func (c *TeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID
 	convs = append(convs, inbox.Convs...)
 	sort.Sort(utils.ConvLocalByTopicName(convs))
 	c.Debug(ctx, "GetChannelsFull: found %d convs", len(convs))
-	for _, conv := range convs {
-		c.Debug(ctx, "GetChannelsFull: %+v", conv.Info)
-	}
 	return convs, nil
 }
 

--- a/go/chat/teamchannelsource.go
+++ b/go/chat/teamchannelsource.go
@@ -15,14 +15,18 @@ import (
 type TeamChannelSource struct {
 	globals.Contextified
 	utils.DebugLabeler
+	memberStatus []chat1.ConversationMemberStatus
 }
 
 var _ types.TeamChannelSource = (*TeamChannelSource)(nil)
 
 func NewTeamChannelSource(g *globals.Context) *TeamChannelSource {
+	memberStatus := chat1.AllConversationMemberStatuses()
+	sort.Sort(utils.ByConversationMemberStatus(memberStatus))
 	return &TeamChannelSource{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "TeamChannelSource", false),
+		memberStatus: memberStatus,
 	}
 }
 
@@ -33,7 +37,8 @@ func (c *TeamChannelSource) getTLFConversations(ctx context.Context, uid gregor1
 			TlfID:            &teamID,
 			TopicType:        &topicType,
 			SummarizeMaxMsgs: false,
-			MemberStatus:     chat1.AllConversationMemberStatuses(),
+			MemberStatus:     c.memberStatus,
+			Existences:       []chat1.ConversationExistence{chat1.ConversationExistence_ACTIVE},
 		}, nil /* pagination */)
 	return inbox, err
 }
@@ -55,6 +60,9 @@ func (c *TeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID
 	convs = append(convs, inbox.Convs...)
 	sort.Sort(utils.ConvLocalByTopicName(convs))
 	c.Debug(ctx, "GetChannelsFull: found %d convs", len(convs))
+	for _, conv := range convs {
+		c.Debug(ctx, "GetChannelsFull: %+v", conv.Info)
+	}
 	return convs, nil
 }
 

--- a/go/chat/teamchannelsource.go
+++ b/go/chat/teamchannelsource.go
@@ -40,7 +40,7 @@ func (c *TeamChannelSource) getTLFConversations(ctx context.Context, uid gregor1
 
 func (c *TeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID,
 	teamID chat1.TLFID, topicType chat1.TopicType) (res []chat1.ConversationLocal, err error) {
-	defer c.Trace(ctx, func() error { return err }, "GetChannelsFull", res)()
+	defer c.Trace(ctx, func() error { return err }, "GetChannelsFull")()
 
 	inbox, err := c.getTLFConversations(ctx, uid, teamID, topicType)
 	if err != nil {
@@ -54,6 +54,7 @@ func (c *TeamChannelSource) GetChannelsFull(ctx context.Context, uid gregor1.UID
 	}
 	convs = append(convs, inbox.Convs...)
 	sort.Sort(utils.ConvLocalByTopicName(convs))
+	c.Debug(ctx, "GetChannelsFull: found %d convs", len(convs))
 	return convs, nil
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -138,6 +138,7 @@ type InboxSource interface {
 	Resumable
 	Suspendable
 
+	Clear(ctx context.Context, uid gregor1.UID) error
 	Read(ctx context.Context, uid gregor1.UID, localizeTyp ConversationLocalizerTyp, useLocalData bool,
 		maxLocalize *int, query *chat1.GetInboxLocalQuery, p *chat1.Pagination) (Inbox, chan AsyncInboxResult, error)
 	ReadUnverified(ctx context.Context, uid gregor1.UID, useLocalData bool,

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1503,6 +1503,12 @@ func (m ByMsgID) Len() int           { return len(m) }
 func (m ByMsgID) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 func (m ByMsgID) Less(i, j int) bool { return m[i] > m[j] }
 
+type ByConversationMemberStatus []chat1.ConversationMemberStatus
+
+func (m ByConversationMemberStatus) Len() int           { return len(m) }
+func (m ByConversationMemberStatus) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+func (m ByConversationMemberStatus) Less(i, j int) bool { return m[i] > m[j] }
+
 func GetTopicName(conv chat1.ConversationLocal) string {
 	maxTopicMsg, err := conv.GetMaxMessage(chat1.MessageType_METADATA)
 	if err != nil {


### PR DESCRIPTION
- clears inbox store on `ChatStalePreviousStateError` so we can get data from the server on retry. 
- fixes bug in `queryExists` which would ignore a single `ConvID` in `GetInboxQuery
- fixes bug with `TeamChannelSource` query where `MemberStatus` parameter was not ordered and would result in cache misses