### PR TITLE
block_retrieval_queue: don't panic then no disk block cache

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -268,6 +268,10 @@ func (brq *blockRetrievalQueue) initPrefetchStatusCacheLocked() {
 		return
 	}
 	if !brq.config.IsTestMode() && brq.config.Mode().Type() != InitSingleOp {
+		// If the disk block cache directory can't be accessed due to
+		// permission errors (happens sometimes on iOS for some
+		// reason), we might need to rely on this in-memory map.
+		// TODO(KBFS-3750): make it an LRU cache.
 		brq.log.Warning("No disk block cache is initialized when not testing")
 	}
 	brq.log.CDebugf(nil, "Using a local cache for prefetch status")

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -264,12 +264,11 @@ func (brq *blockRetrievalQueue) notifyWorker(priority int) {
 }
 
 func (brq *blockRetrievalQueue) initPrefetchStatusCacheLocked() {
-	if !brq.config.IsTestMode() && brq.config.Mode().Type() != InitSingleOp {
-		// Only panic if we're not using SingleOp mode.
-		panic("A disk block cache is required outside of tests")
-	}
 	if brq.prefetchStatusForTest != nil {
 		return
+	}
+	if !brq.config.IsTestMode() && brq.config.Mode().Type() != InitSingleOp {
+		brq.log.Warning("No disk block cache is initialized when not testing")
 	}
 	brq.log.CDebugf(nil, "Using a local cache for prefetch status")
 	brq.prefetchStatusForTest = make(map[kbfsblock.ID]PrefetchStatus)


### PR DESCRIPTION
Sometimes in prod on iOS the disk block cache can't be initialized because of a "permission denied" error.  Use the in-memory cache in that degenerative case.