### PR TITLE
Consolidate display currency logic on opening send form

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -90,6 +90,11 @@ const openSendRequestForm = (state, action) => {
   ]
 }
 
+const maybePopulateBuildingCurrency = (state, action) =>
+  state.wallets.building.bid && !state.wallets.building.currency // building a payment and haven't set currency yet
+    ? WalletsGen.createSetBuildingCurrency({currency: Constants.getDefaultDisplayCurrency(state).code})
+    : null
+
 const createNewAccount = (state, action) => {
   const {name} = action.payload
   return RPCStellarTypes.localCreateWalletAccountLocalRpcPromise({name}, Constants.createNewAccountWaitingKey)
@@ -850,6 +855,10 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
   )
   yield* Saga.chainAction<WalletsGen.ReviewPaymentPayload>(WalletsGen.reviewPayment, reviewPayment)
   yield* Saga.chainAction<WalletsGen.OpenSendRequestFormPayload>(WalletsGen.openSendRequestForm, startPayment)
+  yield* Saga.chainAction<WalletsGen.AccountsReceivedPayload>(
+    WalletsGen.accountsReceived,
+    maybePopulateBuildingCurrency
+  )
 
   yield* Saga.chainAction<WalletsGen.DeletedAccountPayload>(WalletsGen.deletedAccount, deletedAccount)
 

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -320,7 +320,7 @@ const loadMorePayments = (state, action) => {
 const loadDisplayCurrencies = (state, action) =>
   RPCStellarTypes.localGetDisplayCurrenciesLocalRpcPromise().then(res =>
     WalletsGen.createDisplayCurrenciesReceived({
-      currencies: (res || []).map(c => Constants.currenciesResultToCurrencies(c)),
+      currencies: (res || []).map(c => Constants.currencyResultToCurrency(c)),
     })
   )
 
@@ -343,7 +343,7 @@ const loadDisplayCurrency = (state, action) => {
   ).then(res =>
     WalletsGen.createDisplayCurrencyReceived({
       accountID: accountID,
-      currency: Constants.makeCurrencies(res),
+      currency: Constants.makeCurrency(res),
       setBuildingCurrency: action.payload.setBuildingCurrency,
     })
   )

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -43,7 +43,9 @@ const buildPayment = (state, action) =>
         {
           amount: state.wallets.building.amount,
           bid: state.wallets.building.bid,
-          currency: state.wallets.building.currency === 'XLM' ? null : state.wallets.building.currency,
+          currency: ['XLM', ''].includes(state.wallets.building.currency)
+            ? null
+            : state.wallets.building.currency,
           from: state.wallets.building.from === Types.noAccountID ? '' : state.wallets.building.from,
           fromPrimaryAccount: state.wallets.building.from === Types.noAccountID,
           publicMemo: state.wallets.building.publicMemo.stringValue(),

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -572,6 +572,12 @@ const setupEngineListeners = () => {
           account: Constants.accountResultToAccount(account),
         })
       ),
+    'stellar.1.notify.accountsUpdate': ({accounts}) =>
+      Saga.put(
+        WalletsGen.createAccountsReceived({
+          accounts: (accounts || []).map(account => Constants.accountResultToAccount(account)),
+        })
+      ),
     'stellar.1.notify.pendingPaymentsUpdate': ({accountID: _accountID, pending: _pending}) => {
       if (!_pending) {
         logger.warn(`pendingPaymentsUpdate: no pending payments in payload`)

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -18,7 +18,6 @@ import * as SettingsConstants from '../constants/settings'
 import * as I from 'immutable'
 import flags from '../util/feature-flags'
 import {getEngine} from '../engine'
-import {anyWaiting} from '../constants/waiting'
 import {RPCError} from '../util/errors'
 import {isMobile} from '../constants/platform'
 import {actionHasError} from '../util/container'
@@ -210,19 +209,6 @@ const loadWalletDisclaimer = () =>
   RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise().then(accepted =>
     WalletsGen.createWalletDisclaimerReceived({accepted})
   )
-
-const loadAccount = (state, action) => {
-  const {from: _accountID} = action.payload.build
-  const accountID = Types.stringToAccountID(_accountID)
-
-  // Don't load the account if we already have a call doing this
-  const waitingKey = Constants.loadAccountWaitingKey(accountID)
-  if (!Constants.isAccountLoaded(state, accountID) && !anyWaiting(state, waitingKey)) {
-    return RPCStellarTypes.localGetWalletAccountLocalRpcPromise({accountID: accountID}, waitingKey).then(
-      account => WalletsGen.createAccountsReceived({accounts: [Constants.accountResultToAccount(account)]})
-    )
-  }
-}
 
 const loadAccounts = (state, action) =>
   !actionHasError(action) &&
@@ -720,10 +706,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
   }
 
   yield* Saga.chainAction<WalletsGen.CreateNewAccountPayload>(WalletsGen.createNewAccount, createNewAccount)
-  yield* Saga.chainAction<WalletsGen.BuiltPaymentReceivedPayload>(
-    WalletsGen.builtPaymentReceived,
-    loadAccount
-  )
   yield* Saga.chainAction<
     | WalletsGen.LoadAccountsPayload
     | WalletsGen.CreatedNewAccountPayload
@@ -732,7 +714,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
     | WalletsGen.DidSetAccountAsDefaultPayload
     | WalletsGen.ChangedAccountNamePayload
     | WalletsGen.DeletedAccountPayload
-    | WalletsGen.OpenSendRequestFormPayload
   >(
     [
       WalletsGen.loadAccounts,
@@ -742,7 +723,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
       WalletsGen.didSetAccountAsDefault,
       WalletsGen.changedAccountName,
       WalletsGen.deletedAccount,
-      WalletsGen.openSendRequestForm,
     ],
     loadAccounts
   )

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -351,7 +351,7 @@ const changeDisplayCurrency = (state, action) =>
       currency: action.payload.code, // called currency, though it is a code
     },
     Constants.changeDisplayCurrencyWaitingKey
-  ).then(res => WalletsGen.createLoadDisplayCurrency({accountID: action.payload.accountID}))
+  )
 
 const changeAccountName = (state, action) =>
   RPCStellarTypes.localChangeWalletAccountNameLocalRpcPromise(
@@ -717,7 +717,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
     | WalletsGen.CreatedNewAccountPayload
     | WalletsGen.LinkedExistingAccountPayload
     | WalletsGen.RefreshPaymentsPayload
-    | WalletsGen.DidSetAccountAsDefaultPayload
     | WalletsGen.ChangedAccountNamePayload
     | WalletsGen.DeletedAccountPayload
   >(
@@ -726,7 +725,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
       WalletsGen.createdNewAccount,
       WalletsGen.linkedExistingAccount,
       WalletsGen.refreshPayments,
-      WalletsGen.didSetAccountAsDefault,
       WalletsGen.changedAccountName,
       WalletsGen.deletedAccount,
     ],

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -46,13 +46,6 @@ export const paymentIDToRPCPaymentID = (id: PaymentID): StellarRPCTypes.PaymentI
 export const paymentIDToString = (id: PaymentID): string => id
 export const paymentIDIsEqual = (p1: PaymentID, p2: PaymentID) => p1 === p2
 
-export type _Account = {
-  accountID: AccountID,
-  balanceDescription: string,
-  isDefault: boolean,
-  name: string,
-}
-
 export type _Assets = {
   assetCode: string,
   balanceAvailableToSend: string,
@@ -195,7 +188,19 @@ export type AssetDescription = I.RecordOf<_AssetDescription>
 
 export type Asset = 'native' | 'currency' | AssetDescription
 
-export type Account = I.RecordOf<_Account>
+export type _Request = {
+  amount: string, // The number alone
+  amountDescription: string, // The amount the request was made in (XLM, asset, or equivalent fiat) (i.e. '<number> <code>')
+  asset: Asset,
+  completed: boolean,
+  completedTransactionID: ?StellarRPCTypes.KeybaseTransactionID,
+  currencyCode: string, // set if asset === 'currency'
+  id: StellarRPCTypes.KeybaseRequestID,
+  requestee: string, // username or assertion
+  requesteeType: string,
+  sender: string,
+  status: 'ok' | 'canceled',
+}
 
 export type Assets = I.RecordOf<_Assets>
 
@@ -221,6 +226,15 @@ export type Payment = I.RecordOf<_Payment>
 
 export type Currency = I.RecordOf<_LocalCurrency>
 
+export type _Account = {
+  accountID: AccountID,
+  balanceDescription: string,
+  displayCurrency: Currency,
+  isDefault: boolean,
+  name: string,
+}
+export type Account = I.RecordOf<_Account>
+
 export type ValidationState = 'none' | 'waiting' | 'error' | 'valid'
 
 export type _State = {
@@ -237,7 +251,6 @@ export type _State = {
   builtRequest: BuiltRequest,
   createNewAccountError: string,
   currencies: I.List<Currency>,
-  currencyMap: I.Map<AccountID, Currency>,
   exportedSecretKey: HiddenString,
   exportedSecretKeyAccountID: AccountID,
   lastSentXLM: boolean,

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -188,20 +188,6 @@ export type AssetDescription = I.RecordOf<_AssetDescription>
 
 export type Asset = 'native' | 'currency' | AssetDescription
 
-export type _Request = {
-  amount: string, // The number alone
-  amountDescription: string, // The amount the request was made in (XLM, asset, or equivalent fiat) (i.e. '<number> <code>')
-  asset: Asset,
-  completed: boolean,
-  completedTransactionID: ?StellarRPCTypes.KeybaseTransactionID,
-  currencyCode: string, // set if asset === 'currency'
-  id: StellarRPCTypes.KeybaseRequestID,
-  requestee: string, // username or assertion
-  requesteeType: string,
-  sender: string,
-  status: 'ok' | 'canceled',
-}
-
 export type Assets = I.RecordOf<_Assets>
 
 export type BannerBackground = 'Announcements' | 'HighRisk' | 'Information'

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -476,11 +476,22 @@ const getOldestUnread = (state: TypedState, accountID: Types.AccountID) =>
 const getPayment = (state: TypedState, accountID: Types.AccountID, paymentID: Types.PaymentID) =>
   state.wallets.paymentsMap.get(accountID, I.Map()).get(paymentID, makePayment())
 
+const getAccountInner = (state: Types.State, accountID: Types.AccountID) =>
+  state.accountMap.get(accountID, unknownAccount)
+
 const getAccount = (state: TypedState, accountID: Types.AccountID) =>
-  state.wallets.accountMap.get(accountID, unknownAccount)
+  getAccountInner(state.wallets, accountID)
+
+const getDisplayCurrencyInner = (state: Types.State, accountID: Types.AccountID) =>
+  getAccountInner(state, accountID).displayCurrency
 
 const getDisplayCurrency = (state: TypedState, accountID: Types.AccountID) =>
-  getAccount(state, accountID).displayCurrency
+  getDisplayCurrencyInner(state.wallets, accountID)
+
+const getDefaultDisplayCurrencyInner = (state: Types.State) => {
+  const defaultAccount = state.accountMap.find(a => a.isDefault)
+  return defaultAccount ? defaultAccount.displayCurrency : unknownCurrency
+}
 
 const getDefaultAccountID = (state: TypedState) => {
   const defaultAccount = state.wallets.accountMap.find(a => a.isDefault)
@@ -512,6 +523,8 @@ const isPaymentUnread = (state: TypedState, accountID: Types.AccountID, paymentI
   const newPaymentsForAccount = state.wallets.newPayments.get(accountID, false)
   return newPaymentsForAccount && newPaymentsForAccount.has(paymentID)
 }
+
+const displayCurrenciesLoaded = (state: TypedState) => state.wallets.currencies.size > 0
 
 const getCurrencyAndSymbol = (state: TypedState, code: string) => {
   if (!state.wallets.currencies || !code) {
@@ -571,16 +584,20 @@ export {
   confirmFormRouteKey,
   createNewAccountWaitingKey,
   deleteAccountWaitingKey,
+  displayCurrenciesLoaded,
   getAcceptedDisclaimer,
   getAccountIDs,
   getAccounts,
   getAccount,
+  getAccountInner,
   getAssets,
   getCurrencyAndSymbol,
   getDisplayCurrencies,
   getDisplayCurrency,
+  getDisplayCurrencyInner,
   getDisplayCurrencyWaitingKey,
   getDefaultAccountID,
+  getDefaultDisplayCurrencyInner,
   getFederatedAddress,
   getPayment,
   getPayments,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -92,7 +92,6 @@ const makeState: I.RecordFactory<Types._State> = I.Record({
   builtRequest: makeBuiltRequest(),
   createNewAccountError: '',
   currencies: I.List(),
-  currencyMap: I.Map(),
   exportedSecretKey: new HiddenString(''),
   exportedSecretKeyAccountID: Types.noAccountID,
   lastSentXLM: false,
@@ -147,19 +146,11 @@ const buildRequestResultToBuiltRequest = (b: RPCTypes.BuildRequestResLocal) =>
     worthInfo: b.worthInfo,
   })
 
-const makeAccount: I.RecordFactory<Types._Account> = I.Record({
-  accountID: Types.noAccountID,
-  balanceDescription: '',
-  isDefault: false,
-  name: '',
-})
-
-const unknownAccount = makeAccount()
-
 const accountResultToAccount = (w: RPCTypes.WalletAccountLocal) =>
   makeAccount({
     accountID: Types.stringToAccountID(w.accountID),
     balanceDescription: w.balanceDescription,
+    displayCurrency: currencyResultToCurrency(w.currencyLocal),
     isDefault: w.isDefault,
     name: w.name,
   })
@@ -191,15 +182,8 @@ const assetsResultToAssets = (w: RPCTypes.AccountAssetLocal) =>
     worth: w.worth,
   })
 
-const makeCurrencies: I.RecordFactory<Types._LocalCurrency> = I.Record({
-  code: '',
-  description: '',
-  name: '',
-  symbol: '',
-})
-
-const currenciesResultToCurrencies = (w: RPCTypes.CurrencyLocal) =>
-  makeCurrencies({
+const currencyResultToCurrency = (w: RPCTypes.CurrencyLocal) =>
+  makeCurrency({
     code: w.code,
     description: w.description,
     name: w.name,
@@ -261,6 +245,16 @@ const makeCurrency: I.RecordFactory<Types._LocalCurrency> = I.Record({
   name: '',
   symbol: '',
 })
+const unknownCurrency = makeCurrency()
+
+const makeAccount: I.RecordFactory<Types._Account> = I.Record({
+  accountID: Types.noAccountID,
+  balanceDescription: '',
+  displayCurrency: unknownCurrency,
+  isDefault: false,
+  name: '',
+})
+const unknownAccount = makeAccount()
 
 const partyToDescription = (type, username, assertion, name, id): string => {
   switch (type) {
@@ -473,9 +467,6 @@ const getSelectedAccount = (state: TypedState) => state.wallets.selectedAccount
 
 const getDisplayCurrencies = (state: TypedState) => state.wallets.currencies
 
-const getDisplayCurrency = (state: TypedState, accountID: Types.AccountID) =>
-  state.wallets.currencyMap.get(accountID, makeCurrency())
-
 const getPayments = (state: TypedState, accountID: Types.AccountID) =>
   state.wallets.paymentsMap.get(accountID, null)
 
@@ -487,6 +478,9 @@ const getPayment = (state: TypedState, accountID: Types.AccountID, paymentID: Ty
 
 const getAccount = (state: TypedState, accountID: Types.AccountID) =>
   state.wallets.accountMap.get(accountID, unknownAccount)
+
+const getDisplayCurrency = (state: TypedState, accountID: Types.AccountID) =>
+  getAccount(state, accountID).displayCurrency
 
 const getDefaultAccountID = (state: TypedState) => {
   const defaultAccount = state.wallets.accountMap.find(a => a.isDefault)
@@ -568,7 +562,7 @@ export {
   buildPaymentWaitingKey,
   cancelPaymentWaitingKey,
   changeDisplayCurrencyWaitingKey,
-  currenciesResultToCurrencies,
+  currencyResultToCurrency,
   changeAccountNameWaitingKey,
   balanceDeltaToString,
   buildPaymentResultToBuiltPayment,
@@ -604,11 +598,10 @@ export {
   makeAccount,
   makeAssetDescription,
   makeAssets,
-  makeCurrencies,
-  makeCurrency,
   makeBuilding,
   makeBuiltPayment,
   makeBuiltRequest,
+  makeCurrency,
   makePaymentResult,
   makePaymentDetail,
   makePayment,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -478,13 +478,11 @@ const getPayment = (state: TypedState, accountID: Types.AccountID, paymentID: Ty
 
 const getAccountInner = (state: Types.State, accountID: Types.AccountID) =>
   state.accountMap.get(accountID, unknownAccount)
-
 const getAccount = (state: TypedState, accountID: Types.AccountID) =>
   getAccountInner(state.wallets, accountID)
 
 const getDisplayCurrencyInner = (state: Types.State, accountID: Types.AccountID) =>
   getAccountInner(state, accountID).displayCurrency
-
 const getDisplayCurrency = (state: TypedState, accountID: Types.AccountID) =>
   getDisplayCurrencyInner(state.wallets, accountID)
 
@@ -492,6 +490,7 @@ const getDefaultDisplayCurrencyInner = (state: Types.State) => {
   const defaultAccount = state.accountMap.find(a => a.isDefault)
   return defaultAccount ? defaultAccount.displayCurrency : unknownCurrency
 }
+const getDefaultDisplayCurrency = (state: TypedState) => getDefaultDisplayCurrencyInner(state.wallets)
 
 const getDefaultAccountID = (state: TypedState) => {
   const defaultAccount = state.wallets.accountMap.find(a => a.isDefault)
@@ -597,6 +596,7 @@ export {
   getDisplayCurrencyInner,
   getDisplayCurrencyWaitingKey,
   getDefaultAccountID,
+  getDefaultDisplayCurrency,
   getDefaultDisplayCurrencyInner,
   getFederatedAddress,
   getPayment,

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -54,7 +54,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
             action.payload.currency ||
             (state.lastSentXLM && 'XLM') ||
             (action.payload.from &&
-              state.currencyMap.get(action.payload.from, Constants.makeCurrency()).code) ||
+              state.accountMap.get(action.payload.from, Constants.unknownAccount).displayCurrency.code) ||
             'XLM',
           from: action.payload.from || Types.noAccountID,
           isRequest: !!action.payload.isRequest,

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -51,11 +51,11 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         building: initialBuilding.merge({
           amount: action.payload.amount || '',
           currency:
-            action.payload.currency ||
-            (state.lastSentXLM && 'XLM') ||
-            (action.payload.from &&
-              state.accountMap.get(action.payload.from, Constants.unknownAccount).displayCurrency.code) ||
-            'XLM',
+            action.payload.currency || // explicitly set
+            (state.lastSentXLM && 'XLM') || // lastSentXLM override
+            (action.payload.from && Constants.getDisplayCurrencyInner(state, action.payload.from).code) || // display currency of explicitly set 'from' account
+            Constants.getDefaultDisplayCurrencyInner(state).code || // display currency of default account
+            'XLM', // XLM fallback
           from: action.payload.from || Types.noAccountID,
           isRequest: !!action.payload.isRequest,
           publicMemo: action.payload.publicMemo || new HiddenString(''),

--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -55,7 +55,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
             (state.lastSentXLM && 'XLM') || // lastSentXLM override
             (action.payload.from && Constants.getDisplayCurrencyInner(state, action.payload.from).code) || // display currency of explicitly set 'from' account
             Constants.getDefaultDisplayCurrencyInner(state).code || // display currency of default account
-            'XLM', // XLM fallback
+            '', // Empty string -> not loaded
           from: action.payload.from || Types.noAccountID,
           isRequest: !!action.payload.isRequest,
           publicMemo: action.payload.publicMemo || new HiddenString(''),

--- a/shared/wallets/send-form/asset-input/container.js
+++ b/shared/wallets/send-form/asset-input/container.js
@@ -4,27 +4,20 @@ import * as WalletsGen from '../../../actions/wallets-gen'
 import {namedConnect} from '../../../util/container'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as Constants from '../../../constants/wallets'
-import {anyWaiting} from '../../../constants/waiting'
 
 type OwnProps = {||}
 
 const mapStateToProps = state => {
-  const accountID = state.wallets.selectedAccount
-  const currency = state.wallets.building.currency
-  const currencyWaiting = anyWaiting(state, Constants.getDisplayCurrencyWaitingKey(accountID))
-  let displayUnit = currencyWaiting ? '' : Constants.getCurrencyAndSymbol(state, currency)
-  if (state.wallets.lastSentXLM && currency === 'XLM') {
-    displayUnit = 'XLM'
-  }
+  const {amount, currency} = state.wallets.building
   return {
-    accountID,
     bottomLabel: '', // TODO
-    displayUnit,
+    currencyLoading: currency === '',
+    displayUnit: currency,
     // TODO differentiate between an asset (7 digits) and a display currency (2 digits) below
-    inputPlaceholder: currency && currency !== 'XLM' ? '0.00' : '0.0000000',
-    numDecimalsAllowed: currency && currency !== 'XLM' ? 2 : 7,
+    inputPlaceholder: currency !== 'XLM' ? '0.00' : '0.0000000',
+    numDecimalsAllowed: currency !== 'XLM' ? 2 : 7,
     topLabel: '', // TODO
-    value: state.wallets.building.amount,
+    value: amount,
   }
 }
 
@@ -32,18 +25,21 @@ const mapDispatchToProps = dispatch => ({
   onChangeAmount: (amount: string) => dispatch(WalletsGen.createSetBuildingAmount({amount})),
   onChangeDisplayUnit: () => {
     dispatch(
-      RouteTreeGen.createNavigateAppend({path: [
-        {
-          props: {},
-          selected: Constants.chooseAssetFormRouteKey,
-        },
-      ]})
+      RouteTreeGen.createNavigateAppend({
+        path: [
+          {
+            props: {},
+            selected: Constants.chooseAssetFormRouteKey,
+          },
+        ],
+      })
     )
   },
 })
 
 const mergeProps = (stateProps, dispatchProps) => ({
   bottomLabel: stateProps.bottomLabel,
+  currencyLoading: stateProps.currencyLoading,
   displayUnit: stateProps.displayUnit,
   inputPlaceholder: stateProps.inputPlaceholder,
   numDecimalsAllowed: stateProps.numDecimalsAllowed,

--- a/shared/wallets/send-form/asset-input/index.js
+++ b/shared/wallets/send-form/asset-input/index.js
@@ -31,6 +31,7 @@ type Props = {|
   bottomLabel: string,
   displayUnit: string,
   inputPlaceholder: string,
+  currencyLoading: boolean,
   numDecimalsAllowed: number,
   onChangeAmount: string => void,
   onChangeDisplayUnit: () => void,
@@ -81,21 +82,25 @@ class AssetInput extends React.Component<Props> {
           type="text"
           keyboardType="numeric"
           decoration={
-            <Kb.Box2 direction="vertical" style={styles.flexEnd}>
-              <Kb.Text
-                onClick={this.props.displayUnit ? this.props.onChangeDisplayUnit : null}
-                type="HeaderBigExtrabold"
-                style={styles.unit}
-              >
-                {this.props.displayUnit}
-              </Kb.Text>
-              <Kb.Text
-                type="BodySmallPrimaryLink"
-                onClick={this.props.displayUnit ? this.props.onChangeDisplayUnit : null}
-              >
-                Change
-              </Kb.Text>
-            </Kb.Box2>
+            this.props.currencyLoading ? (
+              <Kb.ProgressIndicator style={styles.currencyContainer} />
+            ) : (
+              <Kb.Box2 direction="vertical" style={styles.currencyContainer}>
+                <Kb.Text
+                  onClick={this.props.displayUnit ? this.props.onChangeDisplayUnit : null}
+                  type="HeaderBigExtrabold"
+                  style={styles.unit}
+                >
+                  {this.props.displayUnit}
+                </Kb.Text>
+                <Kb.Text
+                  type="BodySmallPrimaryLink"
+                  onClick={this.props.displayUnit ? this.props.onChangeDisplayUnit : null}
+                >
+                  Change
+                </Kb.Text>
+              </Kb.Box2>
+            )
           }
           containerStyle={styles.inputContainer}
           style={styles.input}
@@ -134,9 +139,17 @@ const styles = Styles.styleSheetCreate({
     paddingRight: Styles.globalMargins.small,
     paddingTop: Styles.globalMargins.tiny,
   },
-  flexEnd: {
-    alignItems: 'flex-end',
-  },
+  currencyContainer: Styles.platformStyles({
+    common: {
+      alignItems: 'flex-end',
+    },
+    isElectron: {
+      height: 44,
+    },
+    isMobile: {
+      height: 52,
+    },
+  }),
   input: {
     color: Styles.globalColors.purple2,
     position: 'relative',

--- a/shared/wallets/send-form/asset-input/index.stories.js
+++ b/shared/wallets/send-form/asset-input/index.stories.js
@@ -11,6 +11,7 @@ const provider = Sb.createPropProvider({
 })
 
 const common = {
+  currencyLoading: false,
   onChangeAmount: Sb.action('onChangeAmount'),
   onChangeDisplayUnit: Sb.action('onChangeDisplayUnit'),
   topLabel: '',

--- a/shared/wallets/wallet/settings/index.stories.js
+++ b/shared/wallets/wallet/settings/index.stories.js
@@ -38,7 +38,7 @@ const testCurrencies = I.List([
     name: 'British Pount',
     symbol: '£',
   },
-]).map(c => Constants.currenciesResultToCurrencies(c))
+]).map(c => Constants.currencyResultToCurrency(c))
 
 const sharedSettingsProps = {
   accountID: Types.noAccountID,


### PR DESCRIPTION
This is the data flow for display currencies given we'll have notifications for when they change.

- Loads accounts on opening send form if we haven't already
- Store display currency on account records
- Sets precedence for display currency 
    - Request currency > XLM if lastSentXLM > "From" acct display currency > Default account display currency.

\-

- [x] Hook up notifications.
- [x] Remove loads on setting etc.
