### PR TITLE
use 1 instead of hairline for orange line

### DIFF
--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -550,7 +550,7 @@ const styles = Styles.styleSheetCreate({
     // don't push down content due to orange line
     backgroundColor: Styles.globalColors.orange,
     flexShrink: 0,
-    height: Styles.hairlineWidth,
+    height: 1,
     left: 0,
     position: 'absolute',
     right: 0,


### PR DESCRIPTION
@keybase/react-hackers 

Use 1px instead of hairline for the orange line cc @cecileboucheron 