### PR TITLE
Don't let user navigate up while sending

### DIFF
--- a/shared/wallets/confirm-form/container.js
+++ b/shared/wallets/confirm-form/container.js
@@ -4,6 +4,7 @@ import * as Constants from '../../constants/wallets'
 import * as ProfileGen from '../../actions/profile-gen'
 import * as TrackerGen from '../../actions/tracker-gen'
 import * as WalletsGen from '../../actions/wallets-gen'
+import {anyWaiting} from '../../constants/waiting'
 import {connect, isMobile, type RouteProps} from '../../util/container'
 
 type OwnProps = RouteProps<{}, {}>
@@ -27,7 +28,10 @@ const mapStateToProps = state => {
       reviewProofs: banner.proofsChanged,
     }))
   )
+  const waitingKey = Constants.sendPaymentWaitingKey
+  const _waiting = anyWaiting(state, waitingKey)
   return {
+    _waiting,
     banners,
     displayAmountFiat: built.displayAmountFiat,
     displayAmountXLM: built.displayAmountXLM,
@@ -37,7 +41,7 @@ const mapStateToProps = state => {
     sendFailed: !!state.wallets.sentPaymentError,
     sendingIntentionXLM: built.sendingIntentionXLM,
     to: build.to,
-    waitingKey: Constants.sendPaymentWaitingKey,
+    waitingKey,
   }
 }
 
@@ -51,10 +55,6 @@ const mapDispatchToProps = (dispatch, {navigateUp}: OwnProps) => ({
     dispatch(WalletsGen.createClearErrors())
     dispatch(navigateUp())
   },
-  onClose: () => {
-    dispatch(WalletsGen.createClearErrors())
-    dispatch(navigateUp())
-  },
   onExitFailed: () => dispatch(WalletsGen.createExitFailedPayment()),
   onSendClick: () => dispatch(WalletsGen.createSendPayment()),
 })
@@ -62,26 +62,36 @@ const mapDispatchToProps = (dispatch, {navigateUp}: OwnProps) => ({
 export default connect<OwnProps, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps,
-  (stateProps, dispatchProps) => ({
-    banners: stateProps.banners.map(b => {
-      if (b.reviewProofs) {
-        return {...b, action: () => dispatchProps._onReviewProofs(stateProps.to)}
-      } else if (b.sendFailed) {
-        return {...b, action: dispatchProps.onExitFailed}
-      }
-      return b
-    }),
-    displayAmountFiat: stateProps.displayAmountFiat,
-    displayAmountXLM: stateProps.displayAmountXLM,
-    encryptedNote: stateProps.encryptedNote,
-    // Always close send form completely if send failed
-    onBack: stateProps.sendFailed ? dispatchProps.onAbandonPayment : dispatchProps.onBack,
-    onClose: stateProps.sendFailed ? dispatchProps.onAbandonPayment : dispatchProps.onClose,
-    onSendClick: dispatchProps.onSendClick,
-    publicMemo: stateProps.publicMemo,
-    readyToSend: stateProps.readyToSend,
-    sendFailed: stateProps.sendFailed,
-    sendingIntentionXLM: stateProps.sendingIntentionXLM,
-    waitingKey: stateProps.waitingKey,
-  })
+  (stateProps, dispatchProps) => {
+    let onBack = dispatchProps.onBack
+    if (stateProps._waiting) {
+      // Not allowed to go anywhere while waiting for send
+      onBack = () => {}
+    } else if (stateProps.sendFailed) {
+      // Can't go back to send form if failed
+      onBack = dispatchProps.onAbandonPayment
+    }
+    return {
+      banners: stateProps.banners.map(b => {
+        if (b.reviewProofs) {
+          return {...b, action: () => dispatchProps._onReviewProofs(stateProps.to)}
+        } else if (b.sendFailed) {
+          return {...b, action: dispatchProps.onExitFailed}
+        }
+        return b
+      }),
+      displayAmountFiat: stateProps.displayAmountFiat,
+      displayAmountXLM: stateProps.displayAmountXLM,
+      encryptedNote: stateProps.encryptedNote,
+      // Always close send form completely if send failed
+      onBack,
+      onClose: onBack,
+      onSendClick: dispatchProps.onSendClick,
+      publicMemo: stateProps.publicMemo,
+      readyToSend: stateProps.readyToSend,
+      sendFailed: stateProps.sendFailed,
+      sendingIntentionXLM: stateProps.sendingIntentionXLM,
+      waitingKey: stateProps.waitingKey,
+    }
+  }
 )(ConfirmSend)

--- a/shared/wallets/send-form/footer/container.js
+++ b/shared/wallets/send-form/footer/container.js
@@ -21,7 +21,9 @@ const mapStateToProps = state => {
     calculating: !!state.wallets.building.amount,
     disabled: !isReady || currencyWaiting,
     isRequest,
-    waitingKey: Constants.buildPaymentWaitingKey,
+    waitingKey: state.wallets.building.isRequest
+      ? Constants.requestPaymentWaitingKey
+      : Constants.buildPaymentWaitingKey,
     worthDescription: isRequest
       ? state.wallets.builtRequest.worthDescription
       : state.wallets.builtPayment.worthDescription,


### PR DESCRIPTION
I noticed you could go back to the send form while the `sendPayment` was in progress. This stops that. Also makes the button spin correctly on requesting. r? @keybase/react-hackers 