### PR TITLE
disk_block_cache: give `currBytes` its own lock to avoid data race

### DIFF
--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -97,13 +97,18 @@ type DiskBlockCacheLocal struct {
 	priorityBlockCounts map[evictionPriority]int
 	priorityTlfMap      map[evictionPriority]map[tlf.ID]int
 	// Track the aggregate size of blocks in the cache per TLF and overall.
-	tlfSizes  map[tlf.ID]uint64
-	currBytes uint64
+	tlfSizes map[tlf.ID]uint64
 	// Track the last unref'd revisions for each TLF.
 	tlfLastUnrefs map[tlf.ID]kbfsmd.Revision
 	// Don't evict files from the user's private or public home directory.
 	// Higher numbers are more important not to evict.
 	homeDirs map[tlf.ID]evictionPriority
+
+	// currBytes gets its own lock, since tests need to access it
+	// directly and taking the full lock causes deadlocks under some
+	// situations.
+	currBytesLock sync.RWMutex
+	currBytes     uint64
 
 	startedCh  chan struct{}
 	startErrCh chan struct{}
@@ -276,7 +281,7 @@ func newDiskBlockCacheLocalFromStorage(
 			// determined it.
 			ctx := context.Background()
 			cache.config.DiskLimiter().onSimpleByteTrackerEnable(ctx,
-				cache.cacheType, int64(cache.currBytes))
+				cache.cacheType, int64(cache.getCurrBytes()))
 		}
 		close(startedCh)
 	}()
@@ -356,6 +361,30 @@ func newDiskBlockCacheLocalForTest(config diskBlockCacheConfig,
 		storage.NewMemStorage())
 }
 
+func (cache *DiskBlockCacheLocal) getCurrBytes() uint64 {
+	cache.currBytesLock.RLock()
+	defer cache.currBytesLock.RUnlock()
+	return cache.currBytes
+}
+
+func (cache *DiskBlockCacheLocal) setCurrBytes(b uint64) {
+	cache.currBytesLock.Lock()
+	defer cache.currBytesLock.Unlock()
+	cache.currBytes = b
+}
+
+func (cache *DiskBlockCacheLocal) addCurrBytes(b uint64) {
+	cache.currBytesLock.Lock()
+	defer cache.currBytesLock.Unlock()
+	cache.currBytes += b
+}
+
+func (cache *DiskBlockCacheLocal) subCurrBytes(b uint64) {
+	cache.currBytesLock.Lock()
+	defer cache.currBytesLock.Unlock()
+	cache.currBytes -= b
+}
+
 // WaitUntilStarted waits until this cache has started.
 func (cache *DiskBlockCacheLocal) WaitUntilStarted() error {
 	select {
@@ -422,7 +451,7 @@ func (cache *DiskBlockCacheLocal) syncBlockCountsAndUnrefsFromDb() error {
 	cache.tlfCounts = tlfCounts
 	cache.numBlocks = numBlocks
 	cache.tlfSizes = tlfSizes
-	cache.currBytes = totalSize
+	cache.setCurrBytes(totalSize)
 	cache.priorityTlfMap = priorityTlfMap
 	cache.priorityBlockCounts = priorityBlockCounts
 
@@ -680,7 +709,7 @@ func (cache *DiskBlockCacheLocal) Put(
 		cache.numBlocks++
 		encodedLenUint := uint64(encodedLen)
 		cache.tlfSizes[tlfID] += encodedLenUint
-		cache.currBytes += encodedLenUint
+		cache.addCurrBytes(encodedLenUint)
 	}
 	tlfKey := cache.tlfKey(tlfID, blockKey)
 	hasKey, err = cache.tlfDb.Has(tlfKey, nil)
@@ -801,7 +830,7 @@ func (cache *DiskBlockCacheLocal) deleteLocked(ctx context.Context,
 		cache.priorityTlfMap[cache.homeDirs[k]][k] -= v
 		cache.numBlocks -= v
 		cache.tlfSizes[k] -= removalSizes[k]
-		cache.currBytes -= removalSizes[k]
+		cache.subCurrBytes(removalSizes[k])
 	}
 	cache.config.DiskLimiter().release(ctx, cache.cacheType,
 		sizeRemoved, 0)
@@ -1174,7 +1203,7 @@ func (cache *DiskBlockCacheLocal) Status(
 		name: {
 			StartState:              DiskBlockCacheStartStateStarted,
 			NumBlocks:               uint64(cache.numBlocks),
-			BlockBytes:              cache.currBytes,
+			BlockBytes:              cache.getCurrBytes(),
 			CurrByteLimit:           maxLimit,
 			LastUnrefCount:          uint64(len(cache.tlfLastUnrefs)),
 			Hits:                    rateMeterToStatus(cache.hitMeter),
@@ -1383,7 +1412,7 @@ func (cache *DiskBlockCacheLocal) Shutdown(ctx context.Context) {
 	cache.metaDb = nil
 	cache.tlfDb = nil
 	cache.config.DiskLimiter().onSimpleByteTrackerDisable(ctx,
-		cache.cacheType, int64(cache.currBytes))
+		cache.cacheType, int64(cache.getCurrBytes()))
 	cache.hitMeter.Shutdown()
 	cache.missMeter.Shutdown()
 	cache.putMeter.Shutdown()

--- a/go/kbfs/libkbfs/disk_block_cache_test.go
+++ b/go/kbfs/libkbfs/disk_block_cache_test.go
@@ -93,8 +93,9 @@ func newDiskBlockCacheForTest(config *testDiskBlockCacheConfig,
 		delayFn:           defaultDoDelay,
 		freeBytesAndFilesFn: func() (int64, int64, error) {
 			// hackity hackeroni: simulate the disk cache taking up space.
-			freeBytes := maxBytes - int64(syncCache.currBytes) -
-				int64(workingSetCache.currBytes)
+			syncBytes, workingBytes := testGetDiskCacheBytes(
+				syncCache, workingSetCache)
+			freeBytes := maxBytes - syncBytes - workingBytes
 			return freeBytes, maxFiles, nil
 		},
 		quotaFn: func(

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -1216,12 +1216,10 @@ func setLimiterLimits(
 	limiter.diskCacheByteTracker.limit = workingLimit
 }
 
-func testPrefetcherGetCacheBytes(
-	ctx context.Context, syncCache, workingCache *DiskBlockCacheLocal) (
+func testGetDiskCacheBytes(syncCache, workingCache *DiskBlockCacheLocal) (
 	syncBytes, workingBytes int64) {
-	syncBytes = int64(syncCache.Status(ctx)[syncCacheName].BlockBytes)
-	workingBytes = int64(
-		workingCache.Status(ctx)[workingSetCacheName].BlockBytes)
+	syncBytes = int64(syncCache.getCurrBytes())
+	workingBytes = int64(workingCache.getCurrBytes())
 	return syncBytes, workingBytes
 }
 
@@ -1303,8 +1301,7 @@ func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
 		kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Set the cache maximum bytes to the current total.")
-	syncBytes, workingBytes := testPrefetcherGetCacheBytes(
-		ctx, syncCache, workingCache)
+	syncBytes, workingBytes := testGetDiskCacheBytes(syncCache, workingCache)
 	limiter := dbcConfig.DiskLimiter().(*backpressureDiskLimiter)
 	setLimiterLimits(limiter, syncBytes, workingBytes)
 
@@ -1833,8 +1830,7 @@ func TestPrefetcherReschedules(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Set the cache maximum bytes to the current total.")
-	syncBytes, workingBytes := testPrefetcherGetCacheBytes(
-		ctx, syncCache, workingCache)
+	syncBytes, workingBytes := testGetDiskCacheBytes(syncCache, workingCache)
 	limiter := dbcConfig.DiskLimiter().(*backpressureDiskLimiter)
 	setLimiterLimits(limiter, syncBytes, workingBytes)
 
@@ -1885,8 +1881,7 @@ func TestPrefetcherReschedules(t *testing.T) {
 		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Set the cache maximum bytes to the current total again.")
-	syncBytes, workingBytes = testPrefetcherGetCacheBytes(
-		ctx, syncCache, workingCache)
+	syncBytes, workingBytes = testGetDiskCacheBytes(syncCache, workingCache)
 	setLimiterLimits(limiter, syncBytes, workingBytes)
 
 	t.Log("Release reschedule requests of two more children.")


### PR DESCRIPTION
The test `freeBytesAndFilesFn` function was accessing `currBytes` directly and causing a data race.  But we can't go through `Status` there, because it causes a deadlock.  So just give it its own lock.