### PR TITLE
Mobile only changes

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -925,8 +925,8 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
   )
   yield* Saga.chainAction<WalletsGen.RejectDisclaimerPayload>(WalletsGen.rejectDisclaimer, rejectDisclaimer)
 
-  yield* Saga.chainAction<WalletsGen.LoadMobileOnlyModePayload>(
-    WalletsGen.loadMobileOnlyMode,
+  yield* Saga.chainAction<WalletsGen.LoadMobileOnlyModePayload, WalletsGen.SelectAccountPayload>(
+    [WalletsGen.loadMobileOnlyMode, WalletsGen.selectAccount],
     loadMobileOnlyMode
   )
   yield* Saga.chainAction<WalletsGen.ChangeMobileOnlyModePayload>(

--- a/shared/chat/conversation/input-area/normal/container.js
+++ b/shared/chat/conversation/input-area/normal/container.js
@@ -49,7 +49,7 @@ const mapStateToProps = (state, {conversationIDKey}: OwnProps) => {
     isExplodingNew: Constants.getIsExplodingNew(state),
     quoteCounter: quoteInfo ? quoteInfo.counter : 0,
     quoteText: quoteInfo ? quoteInfo.text : '',
-    showWalletsIcon: Constants.shouldShowWalletsIcon(Constants.getMeta(state, conversationIDKey), _you),
+    showWalletsIcon: Constants.shouldShowWalletsIcon(state, conversationIDKey),
     suggestChannels: Constants.getChannelSuggestions(state, teamname),
     suggestUsers: Constants.getParticipantSuggestions(state, conversationIDKey),
     typing: Constants.getTyping(state, conversationIDKey),

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -3,6 +3,7 @@
 import * as I from 'immutable'
 import * as RPCChatTypes from '../types/rpc-chat-gen'
 import * as RPCTypes from '../types/rpc-gen'
+import * as WalletConstants from '../wallets'
 import * as Types from '../types/chat2'
 import * as TeamConstants from '../teams'
 import type {_ConversationMeta} from '../types/chat2/meta'
@@ -331,10 +332,18 @@ export const getChannelSuggestions = (state: TypedState, teamname: string) =>
 
 const bgPlatform = isMobile ? globalColors.fastBlank : globalColors.blueGrey
 // show wallets icon for one-on-one conversations
-export const shouldShowWalletsIcon = (meta: Types.ConversationMeta, yourUsername: string) =>
-  flags.walletsEnabled &&
-  meta.teamType === 'adhoc' &&
-  meta.participants.filter(u => u !== yourUsername).size === 1
+export const shouldShowWalletsIcon = (state: TypedState, id: Types.ConversationIDKey) => {
+  const meta = getMeta(state, id)
+  const accountID = WalletConstants.getDefaultAccountID(state)
+  const sendDisabled = !isMobile && accountID && !!state.wallets.mobileOnlyMap.get(accountID)
+
+  return (
+    flags.walletsEnabled &&
+    !sendDisabled &&
+    meta.teamType === 'adhoc' &&
+    meta.participants.filter(u => u !== state.config.username).size === 1
+  )
+}
 
 export const getRowStyles = (meta: Types.ConversationMeta, isSelected: boolean, hasUnread: boolean) => {
   const isError = meta.trustedState === 'error'

--- a/shared/wallets/send-form/footer/container.js
+++ b/shared/wallets/send-form/footer/container.js
@@ -3,7 +3,7 @@ import Footer from '.'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import * as Constants from '../../../constants/wallets'
-import {namedConnect} from '../../../util/container'
+import {namedConnect, isMobile} from '../../../util/container'
 import {anyWaiting} from '../../../constants/waiting'
 
 type OwnProps = {
@@ -17,9 +17,10 @@ const mapStateToProps = state => {
     ? state.wallets.builtRequest.readyToRequest
     : state.wallets.builtPayment.readyToReview
   const currencyWaiting = anyWaiting(state, Constants.getDisplayCurrencyWaitingKey(accountID))
+  const sendDisabledDueToMobileOnly = !isMobile && !!state.wallets.mobileOnlyMap.get(accountID)
   return {
     calculating: !!state.wallets.building.amount,
-    disabled: !isReady || currencyWaiting,
+    disabled: !isReady || currencyWaiting || sendDisabledDueToMobileOnly,
     isRequest,
     waitingKey: Constants.buildPaymentWaitingKey,
     worthDescription: isRequest

--- a/shared/wallets/wallet/header/container.js
+++ b/shared/wallets/wallet/header/container.js
@@ -14,6 +14,7 @@ const mapStateToProps = state => {
     accountID: selectedAccount.accountID,
     isDefaultWallet: selectedAccount.isDefault,
     keybaseUser: state.config.username,
+    sendDisabled: !isMobile && !!state.wallets.mobileOnlyMap.getIn([selectedAccount.accountID]),
     unreadPayments: state.wallets.unreadPaymentsMap.get(selectedAccount.accountID, 0),
     walletName: selectedAccount.name,
   }
@@ -69,7 +70,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   onSendToStellarAddress: () =>
     dispatchProps._onGoToSendReceive(stateProps.accountID, 'stellarPublicKey', false),
   onSettings: () => dispatchProps._onSettings(stateProps.accountID),
-  onShowSecretKey: () => dispatchProps._onShowSecretKey(stateProps.accountID, stateProps.walletName),
+  onShowSecretKey: stateProps.sendDisabled
+    ? null
+    : () => dispatchProps._onShowSecretKey(stateProps.accountID, stateProps.walletName),
 })
 
 export default connect<OwnProps, _, _, _, _>(

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -17,7 +17,8 @@ type Props = {
   onSendToKeybaseUser: () => void,
   onSendToStellarAddress: () => void,
   onSettings: () => void,
-  onShowSecretKey: () => void,
+  onShowSecretKey: ?() => void,
+  sendDisabled: boolean,
   keybaseUser: string,
   walletName: ?string,
 }
@@ -79,12 +80,14 @@ const Header = (props: Props) => {
     >
       {nameAndInfo}
       <Kb.Box2 direction="horizontal" gap="tiny" centerChildren={true}>
-        <SendButton
-          onSendToKeybaseUser={props.onSendToKeybaseUser}
-          onSendToStellarAddress={props.onSendToStellarAddress}
-          onSendToAnotherAccount={props.onSendToAnotherAccount}
-          disabled={!props.walletName}
-        />
+        {!props.sendDisabled && (
+          <SendButton
+            onSendToKeybaseUser={props.onSendToKeybaseUser}
+            onSendToStellarAddress={props.onSendToStellarAddress}
+            onSendToAnotherAccount={props.onSendToAnotherAccount}
+            disabled={!props.walletName}
+          />
+        )}
         <Kb.Button type="Secondary" onClick={props.onReceive} label="Receive" disabled={!props.walletName} />
         <DropdownButton
           onSettings={props.onSettings}
@@ -142,24 +145,27 @@ class _SendButton extends React.PureComponent<SendProps & Kb.OverlayParentProps>
 }
 
 type DropdownProps = {|
-  onShowSecretKey: () => void,
+  onShowSecretKey: ?() => void,
   onSettings: () => void,
   disabled: boolean,
 |}
 
 class _DropdownButton extends React.PureComponent<DropdownProps & Kb.OverlayParentProps> {
-  _menuItems = [
-    {
-      onClick: () => this.props.onShowSecretKey(),
-      title: 'Show secret key',
-    },
-    {
-      onClick: () => this.props.onSettings(),
-      title: 'Settings',
-    },
-  ]
-
   render() {
+    const onShowSecretKey = this.props.onShowSecretKey
+    const _menuItems = [
+      onShowSecretKey
+        ? {
+            onClick: () => onShowSecretKey(),
+            title: 'Show secret key',
+          }
+        : null,
+      {
+        onClick: () => this.props.onSettings(),
+        title: 'Settings',
+      },
+    ].filter(Boolean)
+
     return (
       <Kb.ClickableBox
         onClick={!this.props.disabled ? this.props.toggleShowingMenu : undefined}
@@ -182,7 +188,7 @@ class _DropdownButton extends React.PureComponent<DropdownProps & Kb.OverlayPare
         <Kb.FloatingMenu
           attachTo={this.props.getAttachmentRef}
           closeOnSelect={true}
-          items={this._menuItems}
+          items={_menuItems}
           onHidden={this.props.toggleShowingMenu}
           visible={this.props.showingMenu}
           position="bottom center"

--- a/shared/wallets/wallet/header/index.stories.js
+++ b/shared/wallets/wallet/header/index.stories.js
@@ -8,12 +8,14 @@ import Header from '.'
 const defaultWalletMock = {
   isDefaultWallet: true,
   keybaseUser: 'cecileb',
+  sendDisabled: false,
   walletName: "cecileb's account",
 }
 
 const secondWalletMock = {
   isDefaultWallet: false,
   keybaseUser: 'cecileb',
+  sendDisabled: false,
   walletName: 'Second account',
 }
 


### PR DESCRIPTION
- [x] disable send on wallets tab
- [x] disable show secret key
- [x] disable send icon on chat

caveat here: to minimize changes this only understands mobile only when an account is loaded. i made a ticket to make this easier for us on the core side. With this pr you need to load a wallet to understand this state, therefore when you click on the wallets in the wallets tab you'll see send button while its loading then it go away (once per session)
additionally in chat you'll see send no matter what until that default wallet is loaded so its possible you see send , click send, the dialog shows but the send button is disabled. you close the dialog and now the send button is gone. we should fix this but not before the release

cc: @adamjspooner @malgorithms @cecileboucheron @patrickxb @keybase/react-hackers 