### PR TITLE
Count empty transaction as loading for tx details

### DIFF
--- a/shared/wallets/transaction-details/container.js
+++ b/shared/wallets/transaction-details/container.js
@@ -19,7 +19,10 @@ const mapStateToProps = (state, ownProps) => {
   const paymentID = ownProps.routeProps.get('paymentID')
   const _transaction = Constants.getPayment(state, accountID, paymentID)
   const yourInfoAndCounterparty = Constants.paymentToYourInfoAndCounterparty(_transaction)
-  const loading = anyWaiting(state, Constants.getRequestDetailsWaitingKey(paymentID))
+  // Transaction can briefly be empty when status changes
+  const loading =
+    anyWaiting(state, Constants.getRequestDetailsWaitingKey(paymentID)) ||
+    _transaction.id === Types.noPaymentID
   return {
     _transaction,
     counterpartyMeta:


### PR DESCRIPTION
1. Payment going from `Pending` -> `Sent`
2. `pendingPaymentsUpdate` comes in without payment -> payment gets cleared out
3. Tx details finds no payment -> crash!
4. `recentPaymentsUpdate` comes in with payment -> GUI already crashed, too late

This counts an empty payment as a loading state for the tx details. r? @keybase/react-hackers 