### PR TITLE
block_retrieval_queue: fix bug failing to use mem-cached blocks

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -342,14 +342,15 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 
 	cachedBlock, err := brq.config.BlockCache().Get(ptr)
 	if err == nil {
-		block.Set(cachedBlock)
 		if dbc == nil {
+			block.Set(cachedBlock)
 			return brq.getPrefetchStatus(ptr.ID), nil
 		}
 
 		prefetchStatus, err := dbc.GetPrefetchStatus(
 			ctx, kmd.TlfID(), ptr.ID, preferredCacheType)
 		if err == nil {
+			block.Set(cachedBlock)
 			return prefetchStatus, nil
 		}
 		// If the prefetch status wasn't in the preferred cache, do a


### PR DESCRIPTION
If a block was in the memory cache, but had no prefetch status in our preferred on-disk cache, we drop down to do a full get of the block (which moves the block into our preferred cache).  But in that case we were leaving `block` filled in (from the memory cache), which caused an error when trying to decode the encoded-disk version of the block again, and this caused the block to never be read from the disk cache.
