### PR TITLE
Revert "prefetcher: get status from the block retriever instead of request"

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -57,9 +57,8 @@ func (c *realBlockRetrievalConfig) blockGetter() blockGetter {
 
 // blockRetrievalRequest represents one consumer's request for a block.
 type blockRetrievalRequest struct {
-	block          Block
-	prefetchStatus *PrefetchStatus
-	doneCh         chan error
+	block  Block
+	doneCh chan error
 }
 
 // blockRetrieval contains the metadata for a given block retrieval. May
@@ -381,10 +380,9 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 }
 
 // request retrieves blocks asynchronously.
-func (brq *blockRetrievalQueue) request(
-	ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer,
-	block Block, ps *PrefetchStatus, lifetime BlockCacheLifetime,
-	action BlockRequestAction) <-chan error {
+func (brq *blockRetrievalQueue) request(ctx context.Context,
+	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
+	lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
 	brq.log.CDebugf(ctx, "Request of %v, action=%s, priority=%d",
 		ptr, action, priority)
 
@@ -414,9 +412,6 @@ func (brq *blockRetrievalQueue) request(
 		if action.PrefetchTracked() {
 			brq.Prefetcher().ProcessBlockForPrefetch(ctx, ptr, block, kmd,
 				priority, lifetime, prefetchStatus, action)
-		}
-		if ps != nil {
-			*ps = prefetchStatus
 		}
 		ch <- nil
 		return ch
@@ -473,9 +468,8 @@ func (brq *blockRetrievalQueue) request(
 	br.reqMtx.Lock()
 	defer br.reqMtx.Unlock()
 	br.requests = append(br.requests, &blockRetrievalRequest{
-		block:          block,
-		prefetchStatus: ps,
-		doneCh:         ch,
+		block:  block,
+		doneCh: ch,
 	})
 	if lifetime > br.cacheLifetime {
 		br.cacheLifetime = lifetime
@@ -517,20 +511,7 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	if brq.config.IsSyncedTlf(kmd.TlfID()) {
 		action = action.AddSync()
 	}
-	return brq.request(ctx, priority, kmd, ptr, block, nil, lifetime, action)
-}
-
-// RequestWithPrefetchStatus implements the BlockRetriever interface
-// for blockRetrievalQueue.
-func (brq *blockRetrievalQueue) RequestWithPrefetchStatus(
-	ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer,
-	block Block, prefetchStatus *PrefetchStatus,
-	lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
-	if brq.config.IsSyncedTlf(kmd.TlfID()) {
-		action = action.AddSync()
-	}
-	return brq.request(
-		ctx, priority, kmd, ptr, block, prefetchStatus, lifetime, action)
+	return brq.request(ctx, priority, kmd, ptr, block, lifetime, action)
 }
 
 // FinalizeRequest is the last step of a retrieval request once a block has
@@ -579,9 +560,6 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 		if block != nil {
 			// Copy the decrypted block to the caller
 			req.block.Set(block)
-		}
-		if req.prefetchStatus != nil {
-			*req.prefetchStatus = NoPrefetch
 		}
 		// Since we created this channel with a buffer size of 1, this won't
 		// block.

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2654,12 +2654,6 @@ type BlockRetriever interface {
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime,
 		action BlockRequestAction) <-chan error
-	// RequestWithPrefetchStatus is like `Request`, but also fills in
-	// a prefetch status.
-	RequestWithPrefetchStatus(
-		ctx context.Context, priority int, kmd KeyMetadata,
-		ptr BlockPointer, block Block, prefetchStatus *PrefetchStatus,
-		lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error
 	// PutInCaches puts the block into the in-memory cache, and ensures that
 	// the disk cache metadata is updated.
 	PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID,

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -10760,20 +10760,6 @@ func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockBlockRetriever)(nil).Request), ctx, priority, kmd, ptr, block, lifetime, action)
 }
 
-// RequestWithPrefetchStatus mocks base method
-func (m *MockBlockRetriever) RequestWithPrefetchStatus(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, prefetchStatus *PrefetchStatus, lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RequestWithPrefetchStatus", ctx, priority, kmd, ptr, block, prefetchStatus, lifetime, action)
-	ret0, _ := ret[0].(<-chan error)
-	return ret0
-}
-
-// RequestWithPrefetchStatus indicates an expected call of RequestWithPrefetchStatus
-func (mr *MockBlockRetrieverMockRecorder) RequestWithPrefetchStatus(ctx, priority, kmd, ptr, block, prefetchStatus, lifetime, action interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestWithPrefetchStatus", reflect.TypeOf((*MockBlockRetriever)(nil).RequestWithPrefetchStatus), ctx, priority, kmd, ptr, block, prefetchStatus, lifetime, action)
-}
-
 // PutInCaches mocks base method
 func (m *MockBlockRetriever) PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID, block Block, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) error {
 	m.ctrl.T.Helper()

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -33,13 +33,14 @@ type prefetcherConfig interface {
 }
 
 type prefetchRequest struct {
-	ptr      BlockPointer
-	newBlock func() Block
-	kmd      KeyMetadata
-	priority int
-	lifetime BlockCacheLifetime
-	action   BlockRequestAction
-	sendCh   chan<- <-chan struct{}
+	ptr            BlockPointer
+	newBlock       func() Block
+	kmd            KeyMetadata
+	priority       int
+	lifetime       BlockCacheLifetime
+	prefetchStatus PrefetchStatus
+	action         BlockRequestAction
+	sendCh         chan<- <-chan struct{}
 }
 
 type ctxPrefetcherTagKey int
@@ -389,8 +390,8 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 	if !isPrefetchWaiting {
 		// If the block isn't in the tree, we add it with a block count of 1 (a
 		// later TriggerPrefetch will come in and decrement it).
-		req := &prefetchRequest{
-			ptr, block.NewEmptier(), kmd, priority, lifetime, action, nil}
+		req := &prefetchRequest{ptr, block.NewEmptier(), kmd, priority,
+			lifetime, NoPrefetch, action, nil}
 		pre = p.newPrefetch(1, false, req)
 		p.prefetches[ptr.ID] = pre
 	}
@@ -756,11 +757,9 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 
 			// Ensure the block is in the right cache.
 			b := req.newBlock()
-			var prefetchStatus PrefetchStatus
-			err := <-p.retriever.RequestWithPrefetchStatus(
+			err := <-p.retriever.Request(
 				ctx, defaultOnDemandRequestPriority, req.kmd,
-				req.ptr, b, &prefetchStatus, req.lifetime,
-				req.action.SoloAction())
+				req.ptr, b, req.lifetime, req.action.SoloAction())
 			if err != nil {
 				p.log.CWarningf(ctx, "error requesting for block %s: "+
 					"%+v", req.ptr.ID, err)
@@ -771,7 +770,7 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 			// If the request is finished (i.e., if it's marked as
 			// finished or if it has no child blocks to fetch), then
 			// complete the prefetch.
-			if prefetchStatus == FinishedPrefetch || b.IsTail() {
+			if req.prefetchStatus == FinishedPrefetch || b.IsTail() {
 				// First we handle finished prefetches.
 				if isPrefetchWaiting {
 					if pre.subtreeBlockCount < 0 {
@@ -791,7 +790,7 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				} else {
 					p.log.CDebugf(ctx, "skipping prefetch for finished block "+
 						"%s", req.ptr.ID)
-					if prefetchStatus != FinishedPrefetch {
+					if req.prefetchStatus != FinishedPrefetch {
 						// Mark this block as finished in the cache.
 						err = p.retriever.PutInCaches(
 							ctx, req.ptr, req.kmd.TlfID(), b, req.lifetime,
@@ -819,7 +818,7 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				}
 				continue
 			}
-			if prefetchStatus == TriggeredPrefetch &&
+			if req.prefetchStatus == TriggeredPrefetch &&
 				!req.action.DeepSync() &&
 				(isPrefetchWaiting &&
 					req.action.Sync() == pre.req.action.Sync() &&
@@ -1002,8 +1001,8 @@ func (p *blockPrefetcher) ProcessBlockForPrefetch(ctx context.Context,
 	ptr BlockPointer, block Block, kmd KeyMetadata, priority int,
 	lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus,
 	action BlockRequestAction) {
-	req := &prefetchRequest{
-		ptr, block.NewEmptier(), kmd, priority, lifetime, action, nil}
+	req := &prefetchRequest{ptr, block.NewEmptier(), kmd, priority, lifetime,
+		prefetchStatus, action, nil}
 	if prefetchStatus == FinishedPrefetch {
 		// Finished prefetches can always be short circuited.
 		// If we're here, then FinishedPrefetch is already cached.
@@ -1038,7 +1037,7 @@ func (p *blockPrefetcher) WaitChannelForBlockPrefetch(
 	waitCh <-chan struct{}, err error) {
 	c := make(chan (<-chan struct{}), 1)
 	req := &prefetchRequest{
-		ptr, nil, nil, 0, TransientEntry, BlockRequestSolo, c}
+		ptr, nil, nil, 0, TransientEntry, 0, BlockRequestSolo, c}
 
 	select {
 	case p.prefetchRequestCh.In() <- req:


### PR DESCRIPTION
This reverts commit a181f27dbfac333c89d84b31e044f1fba1dd689a, which caused flaky prefetcher behavior.  The underlying issue will need to be fixed in another way.