### PR TITLE
 don't downgrade trusted status for an inbox update that doesn't contain a newer version of the meta CORE-9899

### DIFF
--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -124,7 +124,6 @@ export const updateMeta = (
       return old
     }
   }
-
   const participants = old.participants.equals(meta.participants) ? old.participants : meta.participants
   const rekeyers = old.rekeyers.equals(meta.rekeyers) ? old.rekeyers : meta.rekeyers
   const resetParticipants = old.resetParticipants.equals(meta.resetParticipants)
@@ -132,6 +131,16 @@ export const updateMeta = (
     : meta.resetParticipants
 
   return meta.withMutations(m => {
+    // don't downgrade trusted status for an inbox update that doesn't contain a newer version of the
+    // meta
+    m.set(
+      'trustedState',
+      old.trustedState === 'trusted' &&
+        meta.trustedState === 'untrusted' &&
+        old.inboxVersion >= meta.inboxVersion
+        ? 'trusted'
+        : meta.trustedState
+    )
     m.set('channelname', meta.channelname || old.channelname)
     m.set('participants', participants)
     m.set('rekeyers', rekeyers)


### PR DESCRIPTION
I think the following can happen:

1. Foreground mobile app
2. Two unboxing operations get fired from the UI: one for the sync call from the service, and another from "inbox visible" event from the screen getting shown.
3. If we sync a conversation that is below the fold, then I think it is possible that that item will get an untrusted fetch for it, but not a corresponding unbox request.
4. I think it is then possible for that untrusted req to lose out on the race with the sync request, and end up writing into the store that the inbox item is untrusted, meaning the "decrypting" text gets stuck on the item.

Assuming this is right, then this PR attempts to disallow downgrading a meta to untrusted in the case where the inbox version is the same. 