### PR TITLE
remove watchdog instance check

### DIFF
--- a/go/client/cmd_ctl_watchdog2.go
+++ b/go/client/cmd_ctl_watchdog2.go
@@ -47,10 +47,6 @@ func (c *CmdWatchdog2) Run() error {
 		return err
 	}
 
-	if !libkb.CheckInstance("keybase.watchdog2") {
-		return fmt.Errorf("Watchdog instance already running")
-	}
-
 	serviceLogPath := filepath.Join(env.GetLogDir(), libkb.ServiceLogFileName)
 	serviceProgram := watchdog.Program{
 		Path: keybasePath,

--- a/go/libkb/util_nix.go
+++ b/go/libkb/util_nix.go
@@ -68,8 +68,3 @@ func isUnicodeMark(b []byte) bool {
 func ChangeMountIcon(oldMount string, newMount string) error {
 	return nil
 }
-
-// CheckInstance is a non-op on non-Windows
-func CheckInstance(name string) bool {
-	return true
-}

--- a/go/libkb/util_windows.go
+++ b/go/libkb/util_windows.go
@@ -232,22 +232,3 @@ func ChangeMountIcon(oldMount string, newMount string) error {
 	notifyShell(newMount)
 	return err
 }
-
-// CheckInstance returns true if no other instance is found
-// see https://stackoverflow.com/questions/23162986/restricting-to-single-instance-of-executable-with-golang
-func CheckInstance(name string) bool {
-	namep, err := syscall.UTF16PtrFromString(name)
-	if err != nil {
-		return true // should never happen
-	}
-	_, _, err = procCreateMutex.Call(
-		0,
-		0,
-		uintptr(unsafe.Pointer(namep)),
-	)
-
-	if int(err.(syscall.Errno)) == 0 {
-		return true
-	}
-	return false
-}


### PR DESCRIPTION
This was only put in because someone once had multiple watchdog instances a few months ago, but testing shows that with this change, in the normal case, running a second watchdog will close the first one. Otherwise, with the instance check, the second one would bail out. It seems healthier to let the second one restart the service, and may even solve this user's problem (https://keybase.atlassian.net/browse/DESKTOP-8686)