### PR TITLE
config_local: enforce minimum block cache size

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -397,10 +397,14 @@ func MakeLocalTeams(teams []kbname.NormalizedUsername) []TeamInfo {
 // <MaxBlockSizeBytesDefault * DefaultBlocksInMemCache>; otherwise,
 // fallback to latter.
 func getDefaultCleanBlockCacheCapacity(mode InitMode) uint64 {
+	const minCapacity = 10 * uint64(MaxBlockSizeBytesDefault) // 5mb
 	capacity := uint64(MaxBlockSizeBytesDefault) * DefaultBlocksInMemCache
 	vmstat, err := mem.VirtualMemory()
 	if err == nil {
 		ramBased := vmstat.Total / 8
+		if ramBased < minCapacity {
+			ramBased = minCapacity
+		}
 		if ramBased < capacity {
 			capacity = ramBased
 		}


### PR DESCRIPTION
In some CI environments, the virtual memory stats returns 0 total memory.  So enforce a minimum cache capacity of 5mb in case that happens in tests or in real user environments.

Issue: KBFS-3734