### PR TITLE
Make review payment error scarier and show on send form

### DIFF
--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -461,7 +461,7 @@ func (s *Stellar) acquireBuildPayment(mctx1 libkb.MetaContext, bid stellar1.Buil
 			continue
 		}
 		if entry.Stopped {
-			return mctx, nil, release, fmt.Errorf("this payment has been stopped")
+			return mctx, nil, release, fmt.Errorf("This payment might have already been sent. Check your recent payments before trying again.")
 		}
 		mctx = mctx.WithCtx(entry.Slot.Use(mctx.Ctx(), sessionID))
 		if err = mctx.Ctx().Err(); err != nil {
@@ -491,7 +491,7 @@ func (s *Stellar) finalizeBuildPayment(mctx libkb.MetaContext, bid stellar1.Buil
 			continue
 		}
 		if entry.Stopped {
-			return nil, fmt.Errorf("this payment has been stopped")
+			return nil, fmt.Errorf("This payment might have already been sent. Check your recent payments before trying again.")
 		}
 		entry.Slot.Shutdown()
 		entry.Stopped = true

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -2240,7 +2240,7 @@ func TestBuildPaymentLocalBidBlocked(t *testing.T) {
 			require.Equal(t, "mismatched amount: 15 != 12", errString)
 
 			errString = send(bid1, "15")
-			require.Equal(t, "this payment has been stopped", errString)
+			require.Equal(t, "This payment might have already been sent. Check your recent payments before trying again.", errString)
 
 		case "afterStoppedBySend":
 			bres, err := build(bid1, "11")
@@ -2253,7 +2253,7 @@ func TestBuildPaymentLocalBidBlocked(t *testing.T) {
 			require.Equal(t, "", errString)
 
 			errString = send(bid1, "11")
-			require.Equal(t, "this payment has been stopped", errString)
+			require.Equal(t, "This payment might have already been sent. Check your recent payments before trying again.", errString)
 
 		case "afterStoppedByStop":
 			errString := send(bid1, "11")
@@ -2263,7 +2263,7 @@ func TestBuildPaymentLocalBidBlocked(t *testing.T) {
 			require.NoError(t, err)
 
 			errString = send(bid1, "11")
-			require.Equal(t, "this payment has been stopped", errString)
+			require.Equal(t, "This payment might have already been sent. Check your recent payments before trying again.", errString)
 
 		case "afterStopppedByStopThenBuild":
 			errString := send(bid1, "11")
@@ -2275,10 +2275,10 @@ func TestBuildPaymentLocalBidBlocked(t *testing.T) {
 			_, err := build(bid1, "11")
 			_ = err // Calling build on a stopped payment is do-no-harm undefined behavior.
 
-			reviewExpectContractFailure("this payment has been stopped") // Calling review on a stopped payment is do-no-harm not gonna happen.
+			reviewExpectContractFailure("This payment might have already been sent. Check your recent payments before trying again.") // Calling review on a stopped payment is do-no-harm not gonna happen.
 
 			errString = send(bid1, "11")
-			require.Equal(t, "this payment has been stopped", errString)
+			require.Equal(t, "This payment might have already been sent. Check your recent payments before trying again.", errString)
 
 		case "build-review-build-send":
 			bres, err := build(bid1, "12")

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -191,7 +191,7 @@ const reviewPayment = state =>
       // ignore cancellation, which is expected in the case where we have a
       // failing review and then we build or stop a payment
     } else {
-      throw error
+      return WalletsGen.createSentPaymentError({error: error.desc})
     }
   })
 


### PR DESCRIPTION
* 'this payment has been stopped' -> 'This payment might have already been sent. Check your recent payments before trying again.'
* Plumb through as error banner on confirm screen

<img width="375" alt="image" src="https://user-images.githubusercontent.com/11968340/51138379-f628f980-180e-11e9-9179-7b9473fd4edb.png">

r? @keybase/react-hackers 