### PR TITLE
prefetcher: fewer logs messages for easier debugging

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -383,8 +383,10 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 func (brq *blockRetrievalQueue) request(ctx context.Context,
 	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
 	lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
-	brq.log.CDebugf(ctx, "Request of %v, action=%s, priority=%d",
-		ptr, action, priority)
+	if action != BlockRequestSolo {
+		brq.log.CDebugf(ctx, "Request of %v, action=%s, priority=%d",
+			ptr, action, priority)
+	}
 
 	// Only continue if we haven't been shut down
 	ch := make(chan error, 1)
@@ -408,7 +410,9 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	// Check caches before locking the mutex.
 	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block, action)
 	if err == nil {
-		brq.log.CDebugf(ctx, "Found %v in caches: %s", ptr, prefetchStatus)
+		if action != BlockRequestSolo {
+			brq.log.CDebugf(ctx, "Found %v in caches: %s", ptr, prefetchStatus)
+		}
 		if action.PrefetchTracked() {
 			brq.Prefetcher().ProcessBlockForPrefetch(ctx, ptr, block, kmd,
 				priority, lifetime, prefetchStatus, action)

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -430,7 +430,7 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 		pre.parents[ptr.RefNonce][parentPtr] = parentPre.waitCh
 		if pre.subtreeBlockCount > 0 {
 			p.log.CDebugf(ctx,
-				"Prefetching %v, action=%s, numBlocks=%d, isPrefetchNew=%t",
+				"Prefetching %v, action=%s, numBlocks=%d, isParentNew=%t",
 				ptr, action, pre.subtreeBlockCount, isParentNew)
 		}
 		return pre.subtreeBlockCount

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -428,7 +428,11 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 			pre.parents[ptr.RefNonce] = make(map[BlockPointer]<-chan struct{})
 		}
 		pre.parents[ptr.RefNonce][parentPtr] = parentPre.waitCh
-		p.log.CDebugf(ctx, "%d blocks to prefetch %t", pre.subtreeBlockCount, isParentNew)
+		if pre.subtreeBlockCount > 0 {
+			p.log.CDebugf(ctx,
+				"Prefetching %v, action=%s, numBlocks=%d, isPrefetchNew=%t",
+				ptr, action, pre.subtreeBlockCount, isParentNew)
+		}
 		return pre.subtreeBlockCount
 	}
 	return 0
@@ -491,8 +495,6 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(
 				"unknown type %d", entry.Type)
 			continue
 		}
-		p.log.CDebugf(ctx,
-			"Prefetching %v, action=%s", entry.BlockPointer, action)
 		totalChildEntries++
 		numBlocks += p.request(ctx, newPriority, kmd, entry.BlockPointer,
 			block, lifetime, parentPtr, isPrefetchNew, action, idsSeen)


### PR DESCRIPTION
1. `BlockRequestSolo` requests come from the prefetcher itself, and should denote blocks that we already know are in the caches.  No need to log for them.

2. Consolidate dirblock prefetching messages into one message when possible.