### PR TITLE
Changes from testing stellar on bad network

### DIFF
--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -469,7 +469,7 @@ func ReviewPaymentLocal(mctx libkb.MetaContext, stellarUI stellar1.UiInterface, 
 				stickyBanners = nil
 				notify([]stellar1.SendBannerLocal{{
 					Level:   "error",
-					Message: fmt.Sprintf("Error while identifying %v", recipientAssertion),
+					Message: fmt.Sprintf("Error while identifying %v. Please check your network and try again.", recipientAssertion),
 				}}, reviewButtonDisabled)
 			case <-identifyTrackFailCh:
 				stickyBanners = nil

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -716,7 +716,10 @@ const changeMobileOnlyMode = (state, action) => {
   let f = action.payload.enabled
     ? RPCStellarTypes.localSetAccountMobileOnlyLocalRpcPromise
     : RPCStellarTypes.localSetAccountAllDevicesLocalRpcPromise
-  return f({accountID}).then(res => WalletsGen.createLoadMobileOnlyMode({accountID}))
+  return f({accountID}, Constants.setAccountMobileOnlyWaitingKey(accountID)).then(res => [
+    WalletsGen.createLoadedMobileOnlyMode({accountID, enabled: action.payload.enabled}),
+    WalletsGen.createLoadMobileOnlyMode({accountID}),
+  ])
 }
 
 const writeLastSentXLM = (state, action) => {

--- a/shared/chat/payments/status/error.js
+++ b/shared/chat/payments/status/error.js
@@ -46,6 +46,7 @@ const styles = Styles.styleSheetCreate({
     common: {color: Styles.globalColors.red},
     isElectron: {
       textAlign: 'center',
+      wordBreak: 'break-word',
     },
   }),
   errorContainer: Styles.platformStyles({

--- a/shared/chat/payments/status/error.js
+++ b/shared/chat/payments/status/error.js
@@ -43,9 +43,8 @@ const PaymentStatusError = (props: Props) => {
 
 const styles = Styles.styleSheetCreate({
   bodyError: Styles.platformStyles({
-    common: {color: Styles.globalColors.red},
+    common: {color: Styles.globalColors.red, textAlign: 'center'},
     isElectron: {
-      textAlign: 'center',
       wordBreak: 'break-word',
     },
   }),

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -472,6 +472,8 @@ export const validateSecretKeyWaitingKey = 'wallets:validateSecretKey'
 export const getRequestDetailsWaitingKey = (id: Types.PaymentID) =>
   `wallets:requestDetailsWaitingKey:${Types.paymentIDToString(id)}`
 export const inflationDestinationWaitingKey = 'wallets:inflationDestination'
+export const setAccountMobileOnlyWaitingKey = (id: Types.AccountID) =>
+  `wallets:setAccountMobileOnly:${Types.accountIDToString(id)}`
 
 export const getAccountIDs = (state: TypedState) => state.wallets.accountMap.keySeq().toList()
 

--- a/shared/wallets/confirm-form/index.js
+++ b/shared/wallets/confirm-form/index.js
@@ -43,7 +43,7 @@ const ConfirmSend = (props: ConfirmSendProps) => (
           text={banner.bannerText}
         />
       ))}
-      <Kb.ScrollView style={styles.scrollView}>
+      <Kb.ScrollView style={styles.scrollView} alwaysBounceVertical={false}>
         <Participants />
         {(!!props.encryptedNote || !!props.publicMemo) && (
           <NoteAndMemo encryptedNote={props.encryptedNote} publicMemo={props.publicMemo} />

--- a/shared/wallets/wallet/settings/container.js
+++ b/shared/wallets/wallet/settings/container.js
@@ -23,6 +23,7 @@ const mapStateToProps = (state, {routeProps}) => {
   )
   const saveCurrencyWaiting = anyWaiting(state, Constants.changeDisplayCurrencyWaitingKey)
   const mobileOnlyMode = state.wallets.mobileOnlyMap.get(accountID, false)
+  const mobileOnlyWaiting = anyWaiting(state, Constants.setAccountMobileOnlyWaitingKey(accountID))
 
   let inflationDestination = state.wallets.inflationDestination
   const dest = state.wallets.inflationDestinations.find(d => d.address === inflationDestination)
@@ -38,6 +39,7 @@ const mapStateToProps = (state, {routeProps}) => {
     inflationDestination,
     isDefault: account.isDefault,
     mobileOnlyMode,
+    mobileOnlyWaiting,
     name,
     saveCurrencyWaiting,
     user,

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -26,6 +26,7 @@ export type SettingsProps = {|
   refresh: () => void,
   saveCurrencyWaiting: boolean,
   mobileOnlyMode: boolean,
+  mobileOnlyWaiting: boolean,
 |}
 
 const HoverText = Styles.isMobile
@@ -126,12 +127,26 @@ class AccountSettings extends React.Component<SettingsProps> {
             </Kb.Box2>
             <Divider />
             <Kb.Box2 direction="vertical" gap="tiny" style={styles.section} fullWidth={true}>
-              <Kb.Checkbox
-                checked={props.mobileOnlyMode}
-                disabled={!Styles.isMobile}
-                label="Mobile only"
-                onCheck={props.onMobileOnlyModeChange}
-              />
+              <Kb.Box style={{position: 'relative'}}>
+                <Kb.Checkbox
+                  checked={props.mobileOnlyMode}
+                  disabled={!Styles.isMobile || props.mobileOnlyWaiting}
+                  label="Mobile only"
+                  onCheck={props.onMobileOnlyModeChange}
+                />
+                {props.mobileOnlyWaiting && (
+                  <Kb.Box2
+                    direction="horizontal"
+                    centerChildren={true}
+                    style={Styles.collapseStyles([
+                      Styles.globalStyles.fillAbsolute,
+                      styles.mobileOnlySpinner,
+                    ])}
+                  >
+                    <Kb.ProgressIndicator type="Small" />
+                  </Kb.Box2>
+                )}
+              </Kb.Box>
               {!Styles.isMobile && (
                 <Kb.Text type="BodySmall">This setting can only be changed from a mobile device.</Kb.Text>
               )}
@@ -217,6 +232,9 @@ const styles = Styles.styleSheetCreate({
   identityBox: {
     flexGrow: 1,
     flexShrink: 1,
+  },
+  mobileOnlySpinner: {
+    backgroundColor: Styles.globalColors.white_90,
   },
   red: {color: Styles.globalColors.red},
   remove: {

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -127,7 +127,7 @@ class AccountSettings extends React.Component<SettingsProps> {
             </Kb.Box2>
             <Divider />
             <Kb.Box2 direction="vertical" gap="tiny" style={styles.section} fullWidth={true}>
-              <Kb.Box style={{position: 'relative'}}>
+              <Kb.Box>
                 <Kb.Checkbox
                   checked={props.mobileOnlyMode}
                   disabled={!Styles.isMobile || props.mobileOnlyWaiting}

--- a/shared/wallets/wallet/settings/index.stories.js
+++ b/shared/wallets/wallet/settings/index.stories.js
@@ -46,6 +46,7 @@ const sharedSettingsProps = {
   currencyWaiting: false,
   inflationDestination: '',
   mobileOnlyMode: false,
+  mobileOnlyWaiting: false,
   onBack: Sb.action('onBack'),
   onCurrencyChange: Sb.action('onCurrencyChange'),
   onDelete: Sb.action('onDelete'),


### PR DESCRIPTION
* Better error for identify failure during review
* Error styling for inline payments
* Spinner for set account mobile only

before: (I click at the beginning of the gif)
![mobile-only-no-spinner](https://user-images.githubusercontent.com/11968340/51146407-b8cf6680-1824-11e9-9ec2-5000c36f8576.gif)

after:
![mobile-only-spinner](https://user-images.githubusercontent.com/11968340/51146354-92a9c680-1824-11e9-83f0-2e4464129b04.gif)

r? @keybase/react-hackers 