### PR TITLE
TrackChainLink.GetTrackedUsername never errors

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -407,8 +407,8 @@ func (e *Identify2WithUID) untrackedFastPath(m libkb.MetaContext) (ret bool) {
 
 	// check if there's a tcl in the testArgs
 	if e.testArgs != nil && e.testArgs.tcl != nil {
-		trackedUsername, err := e.testArgs.tcl.GetTrackedUsername()
-		if err == nil && trackedUsername == nun {
+		trackedUsername := e.testArgs.tcl.GetTrackedUsername()
+		if trackedUsername == nun {
 			m.CDebugf("| Test track link found for %s", nun.String())
 			return false
 		}

--- a/go/engine/list_tracking.go
+++ b/go/engine/list_tracking.go
@@ -235,11 +235,7 @@ func condenseRecord(l *libkb.TrackChainLink) (*jsonw.Wrapper, error) {
 		fpsDisplay[i] = strings.ToUpper(trackedKey.Fingerprint.String())
 	}
 
-	un, err := l.GetTrackedUsername()
-	if err != nil {
-		return nil, err
-	}
-
+	un := l.GetTrackedUsername()
 	rp := l.RemoteKeyProofs()
 
 	out := jsonw.NewDictionary()

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -164,11 +164,7 @@ func (e *UntrackEngine) loadThem(m libkb.MetaContext) (them *libkb.User, remoteL
 			return
 		}
 
-		var trackedUsername libkb.NormalizedUsername
-		trackedUsername, err = lLink.GetTrackedUsername()
-		if err != nil {
-			return
-		}
+		trackedUsername := lLink.GetTrackedUsername()
 
 		if !e.arg.Username.Eq(trackedUsername) {
 			err = libkb.NewUntrackError("Username mismatch: expected @%s, got @%s", e.arg.Username, trackedUsername)

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -534,12 +534,12 @@ func (l *TrackChainLink) GetTrackedUID() (keybase1.UID, error) {
 	return GetUID(l.UnmarshalPayloadJSON().AtPath("body.track.id"))
 }
 
-func (l *TrackChainLink) GetTrackedUsername() (NormalizedUsername, error) {
+func (l *TrackChainLink) GetTrackedUsername() NormalizedUsername {
 	tmp, err := l.UnmarshalPayloadJSON().AtPath("body.track.basics.username").GetString()
 	if err != nil {
-		return NormalizedUsername(""), nil
+		return NormalizedUsername("")
 	}
-	return NewNormalizedUsername(tmp), err
+	return NewNormalizedUsername(tmp)
 }
 
 func (l *TrackChainLink) IsRevoked() bool {

--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -574,11 +574,9 @@ func isFollowingForReview(mctx libkb.MetaContext, assertion string) (isFollowing
 		}
 		targetUsername := libkb.NewNormalizedUsername(assertion)
 		for _, track := range idTable.GetTrackList() {
-			if trackedUsername, err := track.GetTrackedUsername(); err == nil {
-				if trackedUsername.Eq(targetUsername) {
-					isFollowing = true
-					return nil
-				}
+			if track.GetTrackedUsername().Eq(targetUsername) {
+				isFollowing = true
+				return nil
 			}
 		}
 		return nil


### PR DESCRIPTION
related https://github.com/keybase/client/pull/15511

This should be equivalent to the current behavior ...