### PR TITLE
TrackChainLink.GetTrackedUsername returns error

### DIFF
--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -537,7 +537,7 @@ func (l *TrackChainLink) GetTrackedUID() (keybase1.UID, error) {
 func (l *TrackChainLink) GetTrackedUsername() (NormalizedUsername, error) {
 	tmp, err := l.UnmarshalPayloadJSON().AtPath("body.track.basics.username").GetString()
 	if err != nil {
-		return NormalizedUsername(""), nil
+		return NormalizedUsername(""), fmt.Errorf("no tracked username: %v", err)
 	}
 	return NewNormalizedUsername(tmp), err
 }


### PR DESCRIPTION
related https://github.com/keybase/client/pull/15510

... but this is stricter.

I prefer this one.