### PR TITLE
fix random bad behavior 

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -116,16 +116,13 @@ func (b *Boxer) detectPermanentError(err error, tlfName string) types.UnboxingEr
 		switch keybase1.StatusCode(aerr.Code) {
 		case keybase1.StatusCode_SCTeamNotFound:
 			return NewPermanentUnboxingError(err)
-		case keybase1.StatusCode_SCTeamReadError:
-			// These errors get obfuscated by the server on purpose. Just mark this as permanent error
-			// since it likely means the team is in bad shape.
-			if aerr.Error() == "You are not a member of this team (error 2623)" {
-				return NewPermanentUnboxingError(err)
-			}
-			return NewTransientUnboxingError(err)
 		}
 	}
-
+	// All team read errors get marked as transient errors, since we are going to make them rekey errors
+	// later
+	if teams.IsTeamReadError(err) {
+		return NewTransientUnboxingError(err)
+	}
 	switch err := err.(type) {
 	case libkb.UserDeletedError:
 		if len(err.Msg) == 0 {

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -824,6 +824,7 @@ func PreviewConversation(ctx context.Context, g *globals.Context, debugger utils
 func NewConversation(ctx context.Context, g *globals.Context, uid gregor1.UID, tlfName string,
 	topicName *string, topicType chat1.TopicType, membersType chat1.ConversationMembersType,
 	vis keybase1.TLFVisibility, ri func() chat1.RemoteInterface) (chat1.ConversationLocal, error) {
+	defer utils.SuspendComponent(ctx, g, g.ConvLoader)()
 	helper := newNewConversationHelper(g, uid, tlfName, topicName, topicType, membersType, vis, ri)
 	return helper.create(ctx)
 }


### PR DESCRIPTION
* Label all team read errors as "transient"
* Suspend background loader during new conversation.