### PR TITLE
Check for load more regardless of ignoreScrollToBottom

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.desktop.js
+++ b/shared/chat/conversation/list-area/normal/index.desktop.js
@@ -144,6 +144,7 @@ class Thread extends React.PureComponent<Props, State> {
   _cleanupDebounced = () => {
     this._onAfterScroll.cancel()
     this._onScrollThrottled.cancel()
+    this._checkForLoadMoreThrottled.cancel()
   }
 
   _onScroll = e => {


### PR DESCRIPTION
Moves the check for `loadMoreMessages` outside of the check for `this._ignoreScrollToBottomRefCount > 0`

Examples; `Digging ancient messages...` is the thing to watch.

before (I have to scroll down+up a few times when it gets stuck)
![stuck-scrolling](https://user-images.githubusercontent.com/11968340/51209966-8e8eaf00-18df-11e9-8bb8-6cf80431b71b.gif)

after (I never scroll down)
![not-stuck-scrolling](https://user-images.githubusercontent.com/11968340/51209992-98b0ad80-18df-11e9-8b0f-baf49cdcec2f.gif)

(I changed my client to make the problem easier to repro for those)

r? @keybase/react-hackers