### PR TITLE
prevent error on double join

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -736,16 +736,15 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 	}
 	defer g.ConvSource.ReleaseConversationLock(ctx, uid, convID)
 
-	alreadyIn, err := g.InboxSource.IsMember(ctx, uid, convID)
-	if err != nil {
-		debugger.Debug(ctx, "JoinConversation: IsMember err: %s", err.Error())
-		// Assume we're not in.
-		alreadyIn = false
+	if alreadyIn, err := g.InboxSource.IsMember(ctx, uid, convID); err != nil {
+		// charge forward anyway
+		debugger.Debug(ctx, "JoinConversation: IsMember err: %v", err)
+	} else if alreadyIn {
+		return nil
 	}
 
-	// Send the join command even if we're in.
 	if _, err = ri().JoinConversation(ctx, convID); err != nil {
-		debugger.Debug(ctx, "JoinConversation: failed to join conversation: %s", err.Error())
+		debugger.Debug(ctx, "JoinConversation: failed to join conversation: %v", err)
 		return err
 	}
 
@@ -755,17 +754,14 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 			ConvID: convID,
 		},
 	}, nil, nil, nil); err != nil {
-		debugger.Debug(ctx, "JoinConversation: failed to apply membership update: %s", err.Error())
+		debugger.Debug(ctx, "JoinConversation: failed to apply membership update: %v", err)
 	}
-
-	if !alreadyIn {
-		// Send a message to the channel after joining.
-		joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
-		debugger.Debug(ctx, "JoinConversation: sending join message to: %s", convID)
-		if err := postJoinLeave(ctx, g, ri, uid, convID, joinMessageBody); err != nil {
-			debugger.Debug(ctx, "JoinConversation: posting join-conv message failed: %v", err)
-			// ignore the error
-		}
+	// Send a message to the channel after joining.
+	joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
+	debugger.Debug(ctx, "JoinConversation: sending join message to: %s", convID)
+	if err := postJoinLeave(ctx, g, ri, uid, convID, joinMessageBody); err != nil {
+		debugger.Debug(ctx, "JoinConversation: posting join-conv message failed: %v", err)
+		// ignore the error
 	}
 	return nil
 }

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -744,8 +744,7 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 	}
 
 	// Send the join command even if we're in.
-	_, err = ri().JoinConversation(ctx, convID)
-	if err != nil {
+	if _, err = ri().JoinConversation(ctx, convID); err != nil {
 		debugger.Debug(ctx, "JoinConversation: failed to join conversation: %s", err.Error())
 		return err
 	}
@@ -763,8 +762,7 @@ func JoinConversation(ctx context.Context, g *globals.Context, debugger utils.De
 		// Send a message to the channel after joining.
 		joinMessageBody := chat1.NewMessageBodyWithJoin(chat1.MessageJoin{})
 		debugger.Debug(ctx, "JoinConversation: sending join message to: %s", convID)
-		err := postJoinLeave(ctx, g, ri, uid, convID, joinMessageBody)
-		if err != nil {
+		if err := postJoinLeave(ctx, g, ri, uid, convID, joinMessageBody); err != nil {
 			debugger.Debug(ctx, "JoinConversation: posting join-conv message failed: %v", err)
 			// ignore the error
 		}
@@ -813,8 +811,7 @@ func PreviewConversation(ctx context.Context, g *globals.Context, debugger utils
 		return nil
 	}
 
-	_, err = ri().PreviewConversation(ctx, convID)
-	if err != nil {
+	if _, err = ri().PreviewConversation(ctx, convID); err != nil {
 		debugger.Debug(ctx, "PreviewConversation: failed to preview conversation: %s", err.Error())
 		return err
 	}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1786,7 +1786,7 @@ func (h *Server) JoinConversationByIDLocal(ctx context.Context, convID chat1.Con
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
 		&identBreaks, h.identNotifier)
-	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("JoinConversationByID(%s)", convID))()
+	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("JoinConversationByIDLocal: convID: %s", convID))()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
 	defer func() {
@@ -1885,20 +1885,19 @@ func (h *Server) PreviewConversationByIDLocal(ctx context.Context, convID chat1.
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = Context(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI,
 		&identBreaks, h.identNotifier)
-	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("PreviewConversation(%s)", convID))()
+	defer h.Trace(ctx, func() error { return err }, fmt.Sprintf("PreviewConversationByIDLocal: convID: %s", convID))()
 	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
 	defer func() { h.setResultRateLimit(ctx, &res) }()
 	defer func() {
 		if res.Offline {
-			h.Debug(ctx, "PreviewConversationLocal: result obtained offline")
+			h.Debug(ctx, "PreviewConversationByIDLocal: result obtained offline")
 		}
 	}()
 	uid, err := utils.AssertLoggedInUID(ctx, h.G())
 	if err != nil {
 		return res, err
 	}
-	err = PreviewConversation(ctx, h.G(), h.DebugLabeler, h.remoteClient, uid, convID)
-	if err != nil {
+	if err = PreviewConversation(ctx, h.G(), h.DebugLabeler, h.remoteClient, uid, convID); err != nil {
 		return res, err
 	}
 	res.Offline = h.G().InboxSource.IsOffline(ctx)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -5283,6 +5283,10 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 		consumeNewMsgRemote(t, listener1, chat1.MessageType_JOIN)
 		consumeMembersUpdate(t, listener0)
 		consumeJoinConv(t, listener1)
+		// second join attempt doesn't error
+		_, err = ctc.as(t, users[1]).chatLocalHandler().JoinConversationByIDLocal(ctx1,
+			channelConvID)
+		require.NoError(t, err)
 
 		_, err = ctc.as(t, users[1]).chatLocalHandler().DeleteConversationLocal(ctx1,
 			chat1.DeleteConversationLocalArg{


### PR DESCRIPTION
if there is some legacy reason we need to attempt the server call even if our local store says we are already a member we can plumb an error from the server that we ignore instead 