### PR TITLE
only load Files history when logged in; also clean up load logic

### DIFF
--- a/shared/__mocks__/electron.js
+++ b/shared/__mocks__/electron.js
@@ -13,6 +13,7 @@ export const remote = {
   Menu: {},
   getCurrentWindow: () => ({
     on: () => {},
+    removeListener: () => {},
   }),
 }
 

--- a/shared/desktop/renderer/main.desktop.js
+++ b/shared/desktop/renderer/main.desktop.js
@@ -85,7 +85,9 @@ function setupApp(store, runSagas) {
 
   // Run installer
   SafeElectron.getIpcRenderer().on('installed', (event, message) => {
-    store.dispatch(ConfigGen.createInstallerRan())
+    setTimeout(() => {
+      store.dispatch(ConfigGen.createInstallerRan())
+    }, 10 * 1000)
   })
   SafeElectron.getIpcRenderer().send('install-check')
 

--- a/shared/desktop/renderer/main.desktop.js
+++ b/shared/desktop/renderer/main.desktop.js
@@ -85,9 +85,7 @@ function setupApp(store, runSagas) {
 
   // Run installer
   SafeElectron.getIpcRenderer().on('installed', (event, message) => {
-    setTimeout(() => {
-      store.dispatch(ConfigGen.createInstallerRan())
-    }, 10 * 1000)
+    store.dispatch(ConfigGen.createInstallerRan())
   })
   SafeElectron.getIpcRenderer().send('install-check')
 

--- a/shared/menubar/files-container.desktop.js
+++ b/shared/menubar/files-container.desktop.js
@@ -1,14 +1,11 @@
 // @flow
-import * as React from 'react'
 import * as FsTypes from '../constants/types/fs'
 import * as FsGen from '../actions/fs-gen'
 import * as FsUtil from '../util/kbfs'
 import * as TimestampUtil from '../util/timestamp'
 import {type RemoteTlfUpdates} from '../fs/remote-container'
-import {FilesPreview, type UserTlfUpdateRowProps} from './files.desktop'
+import {FilesPreview} from './files.desktop'
 import {remoteConnect, setDisplayName} from '../util/container'
-import * as SafeElectron from '../util/safe-electron.desktop'
-import {throttle} from 'lodash'
 
 type State = {|
   username: string,
@@ -23,11 +20,9 @@ const mapStateToProps = (state: State) => ({
 const mapDispatchToProps = dispatch => ({
   _onSelectPath: (path: FsTypes.Path, type: FsTypes.PathType) =>
     dispatch(FsGen.createOpenFilesFromWidget({path, type})),
-  loadTlfUpdates: () => dispatch(FsGen.createUserFileEditsLoad()),
 })
 
 const mergeProps = (stateProps, dispatchProps) => ({
-  loadTlfUpdates: dispatchProps.loadTlfUpdates,
   userTlfUpdates: stateProps._userTlfUpdates.map(c => {
     const tlf = FsTypes.pathToString(c.tlf)
     const {participants, teamname} = FsUtil.tlfToParticipantsOrTeamname(tlf)
@@ -53,25 +48,6 @@ const mergeProps = (stateProps, dispatchProps) => ({
   }),
 })
 
-type TlfUpdateHocProps = {|
-  loadTlfUpdates: () => void,
-  userTlfUpdates: Array<UserTlfUpdateRowProps>,
-|}
-
-const TlfUpdateHoc = (ComposedComponent: React.ComponentType<any>) =>
-  class extends React.PureComponent<TlfUpdateHocProps> {
-    _refresh = throttle(() => this.props.loadTlfUpdates(), 1000 * 5)
-    componentDidMount = () => {
-      SafeElectron.getRemote()
-        .getCurrentWindow()
-        .on('show', this._refresh)
-    }
-    render() {
-      return <ComposedComponent {...this.props} />
-    }
-  }
-
-export default ((ComposedComponent: React.ComponentType<any>) =>
-  remoteConnect<{||}, State, _, _, _, _>(mapStateToProps, mapDispatchToProps, mergeProps)(
-    setDisplayName('FilesPreview')(TlfUpdateHoc(ComposedComponent))
-  ))(FilesPreview)
+export default remoteConnect<{||}, State, _, _, _, _>(mapStateToProps, mapDispatchToProps, mergeProps)(
+  setDisplayName('FilesPreview')(FilesPreview)
+)

--- a/shared/menubar/index.desktop.js
+++ b/shared/menubar/index.desktop.js
@@ -9,7 +9,6 @@ import ChatContainer from './chat-container.desktop'
 import FilesPreview from './files-container.desktop'
 import {isDarwin} from '../constants/platform'
 import * as SafeElectron from '../util/safe-electron.desktop'
-import {throttle} from 'lodash-es'
 import OutOfDate from './out-of-date'
 import Upload from '../fs/footer/upload'
 import UploadCountdownHOC, {type UploadCountdownHOCProps} from '../fs/footer/upload-countdown-hoc'
@@ -45,15 +44,19 @@ class MenubarRender extends React.Component<Props, State> {
 
   attachmentRef = React.createRef<Kb.Icon>()
 
-  _onShow = throttle(() => {
-    this.props.refresh()
-  }, 1000 * 5)
+  _refreshIfLoggedIn = () => this.props.loggedIn && this.props.refresh()
 
-  constructor(props: Props) {
-    super(props)
+  componentDidMount() {
+    this._refreshIfLoggedIn()
     SafeElectron.getRemote()
       .getCurrentWindow()
-      .on('show', this._onShow)
+      .on('show', this._refreshIfLoggedIn)
+  }
+
+  componentWillUnmount() {
+    SafeElectron.getRemote()
+      .getCurrentWindow()
+      .removeListener('show', this._refreshIfLoggedIn)
   }
 
   render() {

--- a/shared/menubar/remote-container.desktop.js
+++ b/shared/menubar/remote-container.desktop.js
@@ -7,6 +7,7 @@ import {remoteConnect} from '../util/container'
 import {createOpenPopup as createOpenRekeyPopup} from '../actions/unlock-folders-gen'
 import {executeActionsForContext} from '../util/quit-helper.desktop'
 import {loginTab, type Tab} from '../constants/tabs'
+import {throttle} from 'lodash-es'
 import * as RouteTreeGen from '../actions/route-tree-gen'
 import * as SafeElectron from '../util/safe-electron.desktop'
 import {urlHelper} from '../util/url-helper'
@@ -44,7 +45,7 @@ const mapDispatchToProps = dispatch => ({
       executeActionsForContext('quitButton')
     }, 2000)
   },
-  refresh: () => dispatch(FsGen.createUserFileEditsLoad()),
+  refresh: throttle(() => dispatch(FsGen.createUserFileEditsLoad()), 1000 * 5),
   showBug: () => {
     const version = __VERSION__ // eslint-disable-line no-undef
     SafeElectron.getShell().openExternal(
@@ -66,6 +67,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   return {
     ...stateProps,
     ...dispatchProps,
+    refresh: dispatchProps.refresh,
     showUser: () => dispatchProps._showUser(stateProps.username),
     ...ownProps,
   }


### PR DESCRIPTION
I believe this is the cause for those "KBFS client not found" blackbars. The bug is that we add a listener to the `show` event of the menubar window and load the Files edit history in its handle. If the app is just updated, there's a brief period where service/kbfs are not up yet but electron is up. If the widget window is shown during this time, we fire the RPC and get a black bar. Fix it by checking `loggedIn`.

Also some cleanup:

* properly cleanup the handler in `componentWillUnmount` so we don't end up having multiple identical handlers on the event.
* remove `TlfUpdateHoc` as we already load the thing in the handler mentioned above