### PR TITLE
fix key warning in widget

### DIFF
--- a/shared/menubar/files-container.desktop.js
+++ b/shared/menubar/files-container.desktop.js
@@ -44,6 +44,7 @@ const mergeProps = (stateProps, dispatchProps) => ({
       updates: c.updates.map(({path, uploading}) => ({
         name: FsTypes.getPathName(path),
         onClick: () => dispatchProps._onSelectPath(path, 'file'),
+        path,
         tlfType,
         uploading,
       })),

--- a/shared/menubar/files.desktop.js
+++ b/shared/menubar/files.desktop.js
@@ -98,9 +98,11 @@ const defaultNumFileOptionsShown = 3
 
 const FileUpdates = (props: FileUpdatesProps & FileUpdatesHocProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
-    {props.updates.slice(0, props.isShowingAll ? props.updates.length : defaultNumFileOptionsShown).map(u => (
-      <FileUpdate key={u.name} {...u} />
-    ))}
+    {props.updates
+      .slice(0, props.isShowingAll ? props.updates.length : defaultNumFileOptionsShown)
+      .map((u, index) => (
+        <FileUpdate key={String(index)} {...u} />
+      ))}
     {props.updates.length > defaultNumFileOptionsShown && (
       // $FlowIssue ¯\_(ツ)_/¯
       <FileUpdatesShowAll

--- a/shared/menubar/files.desktop.js
+++ b/shared/menubar/files.desktop.js
@@ -8,6 +8,7 @@ import ConnectedUsernames from '../common-adapters/usernames/remote-container'
 
 type FileUpdateProps = {|
   name: string,
+  path: FsTypes.Path,
   tlfType: FsTypes.TlfType,
   uploading: boolean,
   onClick: () => void,
@@ -98,11 +99,9 @@ const defaultNumFileOptionsShown = 3
 
 const FileUpdates = (props: FileUpdatesProps & FileUpdatesHocProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
-    {props.updates
-      .slice(0, props.isShowingAll ? props.updates.length : defaultNumFileOptionsShown)
-      .map((u, index) => (
-        <FileUpdate key={String(index)} {...u} />
-      ))}
+    {props.updates.slice(0, props.isShowingAll ? props.updates.length : defaultNumFileOptionsShown).map(u => (
+      <FileUpdate key={FsTypes.pathToString(u.path)} {...u} />
+    ))}
     {props.updates.length > defaultNumFileOptionsShown && (
       // $FlowIssue ¯\_(ツ)_/¯
       <FileUpdatesShowAll

--- a/shared/menubar/index.stories.desktop.js
+++ b/shared/menubar/index.stories.desktop.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as Storybook from '../stories/storybook'
 import * as Kb from '../common-adapters'
 import * as ConfigConstants from '../constants/config'
+import * as Types from '../constants/types/fs'
 import Menubar from './index.desktop'
 import OutOfDate from './out-of-date'
 import {FileUpdate} from './files.desktop'
@@ -108,10 +109,34 @@ const load = () => {
     .add('Uploading', () => <Menubar {...props} files={1} totalSyncingBytes={1} />)
     .add('FileUpdate', () => (
       <Kb.Box2 direction="vertical">
-        <FileUpdate name="foo" tlfType="private" onClick={Storybook.action('onClick')} uploading={false} />
-        <FileUpdate name="bar" tlfType="private" onClick={Storybook.action('onClick')} uploading={true} />
-        <FileUpdate name="cow" tlfType="private" onClick={Storybook.action('onClick')} uploading={true} />
-        <FileUpdate name="poo" tlfType="private" onClick={Storybook.action('onClick')} uploading={false} />
+        <FileUpdate
+          path={Types.stringToPath('/keybase/team/kbkbfstest/foo')}
+          name="foo"
+          tlfType="private"
+          onClick={Storybook.action('onClick')}
+          uploading={false}
+        />
+        <FileUpdate
+          path={Types.stringToPath('/keybase/team/kbkbfstest/bar')}
+          name="bar"
+          tlfType="private"
+          onClick={Storybook.action('onClick')}
+          uploading={true}
+        />
+        <FileUpdate
+          path={Types.stringToPath('/keybase/team/kbkbfstest/cow')}
+          name="cow"
+          tlfType="private"
+          onClick={Storybook.action('onClick')}
+          uploading={true}
+        />
+        <FileUpdate
+          path={Types.stringToPath('/keybase/team/kbkbfstest/poo')}
+          name="poo"
+          tlfType="private"
+          onClick={Storybook.action('onClick')}
+          uploading={false}
+        />
       </Kb.Box2>
     ))
 }


### PR DESCRIPTION
filename from the same TLF can be same as they can be in different subdirs