### PR TITLE
keybase_service_base: add KSID debug tag for `CurrentSession`

### DIFF
--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1069,6 +1069,9 @@ func (k *KeybaseServiceBase) getCurrentSession(
 // CurrentSession implements the KeybaseService interface for KeybaseServiceBase.
 func (k *KeybaseServiceBase) CurrentSession(ctx context.Context, sessionID int) (
 	SessionInfo, error) {
+	ctx = CtxWithRandomIDReplayable(
+		ctx, CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID, k.log)
+
 	s, newSession, err := k.getCurrentSession(ctx, sessionID)
 	if err != nil {
 		return SessionInfo{}, err


### PR DESCRIPTION
`CurrentSession` is called from a lot of places that might not have other debug tags, and it would be nice for any RPCs that result from `serviceLoggedIn` to have some kind of tag on them so we can narrow down where they came from.