### PR TITLE
go: Fix more tiny bugs found by staticcheck

### DIFF
--- a/go/chat/wallet/sender.go
+++ b/go/chat/wallet/sender.go
@@ -113,6 +113,7 @@ func (s *Sender) ParsePayments(ctx context.Context, uid gregor1.UID, convID chat
 	if len(parsed) == 0 {
 		return nil
 	}
+	// FIXME error is ignored.
 	parts, membersType, err := s.getConvParseInfo(ctx, uid, convID)
 	for _, p := range parsed {
 		var username string

--- a/go/client/cmd_simplefs_sync_show.go
+++ b/go/client/cmd_simplefs_sync_show.go
@@ -107,6 +107,10 @@ func (c *CmdSimpleFSSyncShow) Run() error {
 		ui.Printf("Syncing configured for %s:\n", paths)
 		for _, p := range res.Config.Paths {
 			fullPath, err := appendToTlfPath(tlfPath, p)
+			if err != nil {
+				ui.Printf("\tError: %v", err)
+				continue
+			}
 			e, err := cli.SimpleFSStat(
 				ctx, keybase1.SimpleFSStatArg{Path: fullPath})
 			if err != nil {

--- a/go/kbfs/kbfsgit/runner.go
+++ b/go/kbfs/kbfsgit/runner.go
@@ -1531,6 +1531,9 @@ func (r *runner) pushSome(
 		Name: localRepoRemoteName,
 		URLs: []string{r.gitDir},
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	results := make(map[string]error, len(args))
 	var refspecs []gogitcfg.RefSpec
@@ -1701,6 +1704,9 @@ func (r *runner) handlePushBatch(ctx context.Context, args [][]string) (
 			result = fmt.Sprintf("error %s %s", d, e.Error())
 		}
 		_, err = r.output.Write([]byte(result + "\n"))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Remove any errored commits so that we don't send an update

--- a/go/kbfs/libgit/browser_file.go
+++ b/go/kbfs/libgit/browser_file.go
@@ -37,7 +37,7 @@ func newBrowserFile(f *object.File) (*browserFile, error) {
 }
 
 func (bf *browserFile) Name() string {
-	return bf.Name()
+	return bf.f.Name
 }
 
 func (bf *browserFile) Write(_ []byte) (n int, err error) {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5970,9 +5970,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		// them anymore
 		fbo.log.CDebugf(ctx, "notifyOneOp: GCOp with latest rev %d and %d unref'd blocks", realOp.LatestRev, len(realOp.Unrefs()))
 		bcache := fbo.config.BlockCache()
-		idsToDelete := make([]kbfsblock.ID, 0, len(realOp.Unrefs()))
 		for _, ptr := range realOp.Unrefs() {
-			idsToDelete = append(idsToDelete, ptr.ID)
 			if err := bcache.DeleteTransient(ptr.ID, fbo.id()); err != nil {
 				fbo.log.CDebugf(ctx,
 					"Couldn't delete transient entry for %v: %v", ptr, err)

--- a/go/kbfs/libpages/server.go
+++ b/go/kbfs/libpages/server.go
@@ -226,7 +226,7 @@ func (s *Server) isDirWithNoIndexHTML(
 		return false, nil
 	}
 
-	fi, err = realFS.Stat(path.Join(requestPath, "index.html"))
+	_, err = realFS.Stat(path.Join(requestPath, "index.html"))
 	switch {
 	case err == nil:
 		return false, nil

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -686,6 +686,9 @@ func (k *SimpleFS) SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListAr
 				var fis []os.FileInfo
 				if finalElemFI.IsDir() {
 					fis, err = fs.ReadDir(finalElem)
+					if err != nil {
+						return err
+					}
 				} else {
 					fis = append(fis, finalElemFI)
 				}
@@ -703,6 +706,9 @@ func (k *SimpleFS) SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListAr
 					res = append(res, d)
 				}
 				k.updateReadProgress(arg.OpID, 0, int64(len(fis)))
+			}
+			if err != nil {
+				return err
 			}
 			k.setResult(arg.OpID, keybase1.SimpleFSListResult{Entries: res})
 			return nil

--- a/go/libkb/device_clone_state.go
+++ b/go/libkb/device_clone_state.go
@@ -33,6 +33,9 @@ func (d DeviceCloneState) IsClone() bool {
 
 func UpdateDeviceCloneState(m MetaContext) (before, after int, err error) {
 	d, err := GetDeviceCloneState(m)
+	if err != nil {
+		return 0, 0, err
+	}
 	before = d.Clones
 
 	prior, stage := d.Prior, d.Stage

--- a/go/lru/disk_lru.go
+++ b/go/lru/disk_lru.go
@@ -109,7 +109,7 @@ func (d *diskLRUIndex) Unmarshal(m diskLRUIndexMarshaled) {
 
 func (d *diskLRUIndex) Size() int {
 	d.Lock()
-	d.Unlock()
+	defer d.Unlock()
 	return d.EntryKeys.Len()
 }
 

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -636,7 +636,7 @@ func handleSeitanSingleV2(key keybase1.SeitanPubKey, invite keybase1.TeamInvite,
 
 	var sig SeitanSig
 	decodedSig, err := base64.StdEncoding.DecodeString(string(seitan.Akey)) // For V2 the server responds with sig in the akey field
-	if len(sig) != len(decodedSig) {
+	if err != nil || len(sig) != len(decodedSig) {
 		return errors.New("Signature length verification failed (seitan)")
 	}
 	copy(sig[:], decodedSig[:])


### PR DESCRIPTION
Fix small bugs (mainly ignored errors) found by staticcheck.

Also delete go/gregor/fastlookup_state.go which was dead code and buggy.