### PR TITLE
Reset exploding selection when time picker closes

### DIFF
--- a/shared/chat/conversation/messages/set-explode-popup/index.native.js
+++ b/shared/chat/conversation/messages/set-explode-popup/index.native.js
@@ -40,14 +40,22 @@ class SetExplodePopup extends React.Component<Props, State> {
     this.props.onHidden()
   }
 
+  onCancel = () => {
+    if (this.state.selected !== this.props.selected) {
+      // reset selection
+      this.setState({selected: this.props.selected || 0})
+    }
+    this.props.onHidden()
+  }
+
   render() {
     const items = this.props.items.map(item => ({label: item.text, value: item.seconds}))
     return (
       <FloatingPicker
         items={items}
         onSelect={this.setSelected}
-        onHidden={this.props.onHidden}
-        onCancel={this.props.onHidden}
+        onHidden={this.onCancel}
+        onCancel={this.onCancel}
         onDone={this.onDone}
         prompt={<Prompt />}
         promptString="Pick a timeout"


### PR DESCRIPTION
Noticed while working on #15563 that if you go into the select-time popup on native, change the selection, then close the popup via 'Cancel' or tapping above, that the selection is still changed when it opens again. This PR resets it if you exit the popup without hitting 'Done'. r? @keybase/react-hackers 