### PR TITLE
make unpauseBlockPutCh async

### DIFF
--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -1439,7 +1439,7 @@ func testTLFJournalPauseBlocksAndConvertBranch(t *testing.T,
 	var lock sync.Mutex
 	var puts []interface{}
 
-	unpauseBlockPutCh := make(chan struct{})
+	unpauseBlockPutCh := make(chan struct{}, 1)
 	bserver := orderedBlockServer{
 		lock:      &lock,
 		puts:      &puts,


### PR DESCRIPTION
The deadlocks were mostly on `unpauseBlockPutCh <-`. The receiver side is in the mock `orderedBlockServer` where it receives from the channel for the first put. If the Put doesn't happen (e.g. it errored before actually calling Put), then we'd get stuck here. So just make the channel async.

There might be other bugs i.e. why the Put errored, but they are not exposed in the logs. This would expose those flakes hopefully.