### PR TITLE
jenkins: Disable systests on Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -481,6 +481,9 @@ def testGo(prefix, packagesToTest) {
       ],
       test_windows_go_: [
         '*': [],
+        'github.com/keybase/client/go/systests': [
+          disable: true,
+        ],
       ],
     ]
     def defaultPackageTestSpec = { pkg ->


### PR DESCRIPTION
Talked with @maxtaco and the Windows flakes are mostly due to flaky I/O timeouts. We're just going to disable systests on Windows.