### PR TITLE
Keep track of pending submits in WalletState

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -709,6 +709,7 @@ type Stellar interface {
 	SpecMiniChatPayments(mctx MetaContext, payments []MiniChatPayment) (*MiniChatPaymentSummary, error)
 	SendMiniChatPayments(mctx MetaContext, convID chat1.ConversationID, payments []MiniChatPayment) ([]MiniChatPaymentResult, error)
 	HandleOobm(context.Context, gregor.OutOfBandMessage) (bool, error)
+	RemovePendingTx(mctx MetaContext, accountID stellar1.AccountID, txID stellar1.TransactionID) error
 }
 
 type DeviceEKStorage interface {

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -54,3 +54,7 @@ func (n *nullStellar) SpecMiniChatPayments(mctx MetaContext, payments []MiniChat
 func (n *nullStellar) HandleOobm(context.Context, gregor.OutOfBandMessage) (bool, error) {
 	return false, errors.New("nullStellar HandleOobm")
 }
+
+func (n *nullStellar) RemovePendingTx(MetaContext, stellar1.AccountID, stellar1.TransactionID) error {
+	return errors.New("nullStellar RemovePendingTx")
+}

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -508,6 +508,10 @@ func (s *Stellar) finalizeBuildPayment(mctx libkb.MetaContext, bid stellar1.Buil
 	return nil, fmt.Errorf("payment build not found")
 }
 
+func (s *Stellar) RemovePendingTx(mctx libkb.MetaContext, accountID stellar1.AccountID, txID stellar1.TransactionID) error {
+	return s.walletState.RemovePendingTx(mctx.Ctx(), accountID, txID)
+}
+
 // getFederationClient is a helper function used during
 // initialization.
 func getFederationClient(g *libkb.GlobalContext) federation.ClientInterface {

--- a/go/stellar/loader.go
+++ b/go/stellar/loader.go
@@ -314,8 +314,15 @@ func (p *Loader) sendPaymentNotification(m libkb.MetaContext, id stellar1.Paymen
 	} else {
 		m.CDebugf("sending chat notification for payment %s to %s, %s", id, msg.convID, msg.msgID)
 	}
+
 	uid := p.G().ActiveDevice.UID()
 	info := p.uiPaymentInfo(m, summary, msg)
+
+	if info.AccountID != nil && summary.StatusSimplified != stellar1.PaymentStatus_PENDING {
+		// let WalletState know
+		p.G().GetStellar().RemovePendingTx(m, *info.AccountID, stellar1.TransactionIDFromPaymentID(id))
+	}
+
 	p.G().NotifyRouter.HandleChatPaymentInfo(m.Ctx(), uid, msg.convID, msg.msgID, *info)
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -541,6 +541,7 @@ func sendPayment(mctx libkb.MetaContext, walletState *WalletState, sendArg SendP
 		return res, err
 	}
 	senderSeed := senderAccountBundle.Signers[0]
+	senderAccountID := senderEntry.AccountID
 
 	// look up recipient
 	recipient, err := LookupRecipient(mctx, sendArg.To, isCLI)
@@ -598,6 +599,7 @@ func sendPayment(mctx libkb.MetaContext, walletState *WalletState, sendArg SendP
 
 	// check if recipient account exists
 	var txID string
+	var seqno uint64
 	funded, err := isAccountFunded(mctx.Ctx(), walletState, stellar1.AccountID(recipient.AccountID.String()))
 	if err != nil {
 		return res, fmt.Errorf("error checking destination account balance: %v", err)
@@ -612,6 +614,7 @@ func sendPayment(mctx libkb.MetaContext, walletState *WalletState, sendArg SendP
 		}
 		post.SignedTransaction = sig.Signed
 		txID = sig.TxHash
+		seqno = sig.Seqno
 	} else {
 		// if balance, payment operation
 		sig, err := stellarnet.PaymentXLMTransaction(senderSeed2, *recipient.AccountID, sendArg.Amount, sendArg.PublicMemo, sp, tb)
@@ -620,6 +623,11 @@ func sendPayment(mctx libkb.MetaContext, walletState *WalletState, sendArg SendP
 		}
 		post.SignedTransaction = sig.Signed
 		txID = sig.TxHash
+		seqno = sig.Seqno
+	}
+
+	if err := walletState.AddPendingTx(mctx.Ctx(), senderAccountID, stellar1.TransactionID(txID), seqno); err != nil {
+		mctx.CDebugf("error calling AddPendingTx: %s", err)
 	}
 
 	if len(sendArg.SecretNote) > 0 {
@@ -643,6 +651,10 @@ func sendPayment(mctx libkb.MetaContext, walletState *WalletState, sendArg SendP
 		return res, err
 	}
 	mctx.CDebugf("sent payment (direct) kbTxID:%v txID:%v pending:%v", rres.KeybaseID, rres.StellarID, rres.Pending)
+	if !rres.Pending {
+		mctx.CDebugf("SubmitPayment result wasn't pending, removing from wallet state: %s/%s", senderAccountID, txID)
+		walletState.RemovePendingTx(mctx.Ctx(), senderAccountID, stellar1.TransactionID(txID))
+	}
 
 	walletState.Refresh(mctx, senderEntry.AccountID, "SubmitPayment")
 
@@ -777,7 +789,7 @@ func specMiniChatPayment(mctx libkb.MetaContext, walletState *WalletState, payme
 func SendMiniChatPayments(m libkb.MetaContext, walletState *WalletState, convID chat1.ConversationID, payments []libkb.MiniChatPayment) (res []libkb.MiniChatPaymentResult, err error) {
 	defer m.CTraceTimed("Stellar.SendMiniChatPayments", func() error { return err })()
 	// look up sender account
-	_, senderAccountBundle, err := LookupSenderPrimary(m)
+	senderEntry, senderAccountBundle, err := LookupSenderPrimary(m)
 	if err != nil {
 		return nil, err
 	}
@@ -785,6 +797,7 @@ func SendMiniChatPayments(m libkb.MetaContext, walletState *WalletState, convID 
 	if err != nil {
 		return nil, err
 	}
+	senderAccountID := senderEntry.AccountID
 
 	prepared, err := PrepareMiniChatPayments(m, walletState, senderSeed, convID, payments)
 	if err != nil {
@@ -805,6 +818,11 @@ func SendMiniChatPayments(m libkb.MetaContext, walletState *WalletState, convID 
 		} else {
 			// submit the transaction
 			m.CDebugf("submitting payment seqno %d", prepared[i].Seqno)
+
+			if err := walletState.AddPendingTx(m.Ctx(), senderAccountID, prepared[i].TxID, prepared[i].Seqno); err != nil {
+				m.CDebugf("error calling AddPendingTx: %s", err)
+			}
+
 			var submitRes stellar1.PaymentResult
 			switch {
 			case prepared[i].Direct != nil:
@@ -831,6 +849,7 @@ type MiniPrepared struct {
 	Username libkb.NormalizedUsername
 	Direct   *stellar1.PaymentDirectPost
 	Relay    *stellar1.PaymentRelayPost
+	TxID     stellar1.TransactionID
 	Seqno    uint64
 	Error    error
 }
@@ -922,6 +941,7 @@ func prepareMiniChatPaymentDirect(m libkb.MetaContext, remoter remote.Remoter, s
 	}
 	result.Direct.SignedTransaction = signResult.Signed
 	result.Seqno = signResult.Seqno
+	result.TxID = stellar1.TransactionID(signResult.TxHash)
 	return result
 
 }
@@ -982,6 +1002,7 @@ func prepareMiniChatPaymentRelay(mctx libkb.MetaContext, remoter remote.Remoter,
 
 	result.Relay = &post
 	result.Seqno = relay.FundTx.Seqno
+	result.TxID = stellar1.TransactionID(relay.FundTx.TxHash)
 
 	if convID != nil {
 		result.Relay.ChatConversationID = stellar1.NewChatConversationID(convID)
@@ -1017,6 +1038,15 @@ func sendRelayPayment(mctx libkb.MetaContext, walletState *WalletState,
 	if err != nil {
 		return res, err
 	}
+
+	_, accountID, _, err := libkb.ParseStellarSecretKey(string(from))
+	if err != nil {
+		return res, err
+	}
+	if err := walletState.AddPendingTx(mctx.Ctx(), accountID, stellar1.TransactionID(relay.FundTx.TxHash), relay.FundTx.Seqno); err != nil {
+		mctx.CDebugf("error calling AddPendingTx: %s", err)
+	}
+
 	post := stellar1.PaymentRelayPost{
 		FromDeviceID:      mctx.ActiveDevice().DeviceID(),
 		ToAssertion:       string(recipient.Input),
@@ -1036,6 +1066,12 @@ func sendRelayPayment(mctx libkb.MetaContext, walletState *WalletState,
 		return res, err
 	}
 	mctx.CDebugf("sent payment (relay) kbTxID:%v txID:%v pending:%v", rres.KeybaseID, rres.StellarID, rres.Pending)
+
+	if !rres.Pending {
+		if err := walletState.RemovePendingTx(mctx.Ctx(), accountID, stellar1.TransactionID(relay.FundTx.TxHash)); err != nil {
+			mctx.CDebugf("error calling RemovePendingTx: %s", err)
+		}
+	}
 
 	if err := chatSendPaymentMessage(mctx, recipient, rres.StellarID); err != nil {
 		// if the chat message fails to send, just log the error


### PR DESCRIPTION
WalletState now keeps track of any pending submits.
This is so ForceSeqnoRefresh can know if it should
replace the cached seqno with the network's seqno
or not.