### PR TITLE
Fix FloatingBox storyshot mock

### DIFF
--- a/shared/common-adapters/floating-box/__mocks__/index.desktop.js
+++ b/shared/common-adapters/floating-box/__mocks__/index.desktop.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
-import Box from '../box'
-import type {Props} from '../floating-box/index.types'
+import Box from '../../box'
+import type {Props} from '../index.types'
 
 export default class FloatingBox extends React.Component<Props, {}> {
   state = {}


### PR DESCRIPTION
https://github.com/keybase/client/commit/4feb6b4eaf2c03d1edbb44d8912e75732eb803ce moved floating box into it's own dir, but didn't move the mock with it, so we lost coverage for floating box stuff in stories. This moves the mock back and updates storyshots. r? @keybase/react-hackers 