### PR TITLE
always refresh path metadata at mount or whenever path changes

### DIFF
--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -61,28 +61,17 @@ const useBare = isMobile
     }
 
 class ChooseComponent extends React.PureComponent<ChooseComponentProps> {
-  _needsLoadMatadata = () => {
-    if (this.props.pathType === 'unknown') {
-      return true
-    }
-    if (this.props.pathType === 'file' && !this.props.mimeType) {
-      return true
-    }
-    return false
-  }
   componentDidMount() {
     if (useBare(this.props.mimeType)) {
       this.props.emitBarePreview()
     }
-    if (this._needsLoadMatadata()) {
-      this.props.loadPathMetadata()
-    }
+    this.props.loadPathMetadata()
   }
   componentDidUpdate(prevProps) {
     if (this.props.mimeType !== prevProps.mimeType && useBare(this.props.mimeType)) {
       this.props.emitBarePreview()
     }
-    if (this.props.path !== prevProps.path || this._needsLoadMatadata()) {
+    if (this.props.path !== prevProps.path) {
       this.props.loadPathMetadata()
     }
   }


### PR DESCRIPTION
Bug before this change: when user gets to a TLF through a link in chat,
we'd know it's a folder and wouldn't load metadata for it. But we
actually don't have a PathItem for it, thus have no info on whether it's
writalbe. So just always load it on component mount, and in update
whenever path changes.