### PR TITLE
keybase_service_base: clear the team info cache on migration

### DIFF
--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1336,6 +1336,21 @@ func (k *KeybaseServiceBase) FinalizeMigration(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	if handle.TypeForKeying() == tlf.TeamKeying {
+		// Clear the cache for this implicit team, to ensure we get
+		// all the latest key generations for the team info during the
+		// migration.
+		id := handle.FirstResolvedWriter()
+		if id.IsTeamOrSubteam() {
+			tid, err := id.AsTeam()
+			if err != nil {
+				return err
+			}
+			k.log.CDebugf(ctx, "Clearing team info for tid=%s, handle=%s",
+				tid, handle.GetCanonicalPath())
+			k.setCachedTeamInfo(tid, TeamInfo{})
+		}
+	}
 	return k.config.KBFSOps().MigrateToImplicitTeam(ctx, handle.TlfID())
 }
 


### PR DESCRIPTION
Otherwise, there might be a race where, even though the service has migrated the KBFS keys into the implicit team, KBFS hasn't received the `TeamChangedByID` notification yet and will continue to use its old cache.

Issue: KBFS-3774