### PR TITLE
change mention handling to use decoration system instead of pure md parser

### DIFF
--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1784,6 +1784,7 @@ func DecorateBody(ctx context.Context, body string, offset, length int, decorati
 	if err != nil {
 		return res, 0
 	}
+	//b64out := string(out)
 	b64out := base64.StdEncoding.EncodeToString(out)
 	strDecoration := fmt.Sprintf("%s%s%s", decorateBegin, b64out, decorateEnd)
 	added = len(strDecoration) - length

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -195,12 +195,40 @@ type decorateMentionTest struct {
 }
 
 func TestDecorateMentions(t *testing.T) {
+	convID := chat1.ConversationID([]byte{1, 2, 3, 4})
 	cases := []decorateMentionTest{
 		decorateMentionTest{
 			body:       "@mikem fix something",
 			atMentions: []string{"mikem"},
 			// {"typ":1,"atmention":"mikem"}
 			result: "$>kb$eyJ0eXAiOjEsImF0bWVudGlvbiI6Im1pa2VtIn0=$<kb$ fix something",
+		},
+		decorateMentionTest{
+			body:        "@mikem,@max please check out #general, also @here you should too",
+			atMentions:  []string{"mikem", "max"},
+			chanMention: chat1.ChannelMention_HERE,
+			channelNameMentions: []chat1.ChannelNameMention{chat1.ChannelNameMention{
+				ConvID:    convID,
+				TopicName: "general",
+			}},
+			// {"typ":1,"atmention":"mikem"}
+			// {"typ":1,"atmention":"max"}
+			// {"typ":2,"channelnamemention":{"name":"general","convID":"01020304"}}
+			// {"typ":1,"atmention":"here"}
+			result: "$>kb$eyJ0eXAiOjEsImF0bWVudGlvbiI6Im1pa2VtIn0=$<kb$,$>kb$eyJ0eXAiOjEsImF0bWVudGlvbiI6Im1heCJ9$<kb$ please check out $>kb$eyJ0eXAiOjIsImNoYW5uZWxuYW1lbWVudGlvbiI6eyJuYW1lIjoiZ2VuZXJhbCIsImNvbnZJRCI6IjAxMDIwMzA0In19$<kb$, also $>kb$eyJ0eXAiOjEsImF0bWVudGlvbiI6ImhlcmUifQ==$<kb$ you should too",
+		},
+		decorateMentionTest{
+			body:       "@mikem talk to @patrick",
+			atMentions: []string{"mikem"},
+			result:     "$>kb$eyJ0eXAiOjEsImF0bWVudGlvbiI6Im1pa2VtIn0=$<kb$ talk to @patrick",
+		},
+		decorateMentionTest{
+			body:   "see #general",
+			result: "see #general",
+		},
+		decorateMentionTest{
+			body:   "@here what are you doing!",
+			result: "@here what are you doing!",
 		},
 	}
 	for _, c := range cases {

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -185,3 +185,27 @@ func TestGetQueryRe(t *testing.T) {
 		require.True(t, ok)
 	}
 }
+
+type decorateMentionTest struct {
+	body                string
+	atMentions          []string
+	chanMention         chat1.ChannelMention
+	channelNameMentions []chat1.ChannelNameMention
+	result              string
+}
+
+func TestDecorateMentions(t *testing.T) {
+	cases := []decorateMentionTest{
+		decorateMentionTest{
+			body:       "@mikem fix something",
+			atMentions: []string{"mikem"},
+			// {"typ":1,"atmention":"mikem"}
+			result: "$>kb$eyJ0eXAiOjEsImF0bWVudGlvbiI6Im1pa2VtIn0=$<kb$ fix something",
+		},
+	}
+	for _, c := range cases {
+		res := DecorateWithMentions(context.TODO(), c.body, c.atMentions, c.chanMention,
+			c.channelNameMentions)
+		require.Equal(t, c.result, res)
+	}
+}

--- a/go/chat/wallet/decorate_test.go
+++ b/go/chat/wallet/decorate_test.go
@@ -26,7 +26,8 @@ func TestStellarDecorate(t *testing.T) {
 					Result:      chat1.NewTextPaymentResultWithSent(stellar1.PaymentID("stellarid")),
 				},
 			},
-			result: "$>kb${\"typ\":0,\"payment\":{\"username\":\"mikem\",\"paymentText\":\"+1XLM\",\"result\":{\"resultTyp\":0,\"sent\":\"stellarid\"}}}$<kb$ other test",
+			// {"typ":0,"payment":{"username":"mikem","paymentText":"+1XLM","result":{"resultTyp":0,"sent":"stellarid"}}}
+			result: "$>kb$eyJ0eXAiOjAsInBheW1lbnQiOnsidXNlcm5hbWUiOiJtaWtlbSIsInBheW1lbnRUZXh0IjoiKzFYTE0iLCJyZXN1bHQiOnsicmVzdWx0VHlwIjowLCJzZW50Ijoic3RlbGxhcmlkIn19fQ==$<kb$ other test",
 		},
 		decorateTest{
 			body: "`+1xlm` +1xlm other test",
@@ -37,7 +38,8 @@ func TestStellarDecorate(t *testing.T) {
 					Result:      chat1.NewTextPaymentResultWithSent(stellar1.PaymentID("stellarid")),
 				},
 			},
-			result: "`+1xlm` $>kb${\"typ\":0,\"payment\":{\"username\":\"mikem\",\"paymentText\":\"+1XLM\",\"result\":{\"resultTyp\":0,\"sent\":\"stellarid\"}}}$<kb$ other test",
+			// {"typ":0,"payment":{"username":"mikem","paymentText":"+1XLM","result":{"resultTyp":0,"sent":"stellarid"}}}
+			result: "`+1xlm` $>kb$eyJ0eXAiOjAsInBheW1lbnQiOnsidXNlcm5hbWUiOiJtaWtlbSIsInBheW1lbnRUZXh0IjoiKzFYTE0iLCJyZXN1bHQiOnsicmVzdWx0VHlwIjowLCJzZW50Ijoic3RlbGxhcmlkIn19fQ==$<kb$ other test",
 		},
 		decorateTest{
 			body: "HIHIH ```+5xlm@patrick``` +5xlm@patrick `+1xlm` +1xlm other test",
@@ -53,7 +55,9 @@ func TestStellarDecorate(t *testing.T) {
 					Result:      chat1.NewTextPaymentResultWithSent(stellar1.PaymentID("stellarid")),
 				},
 			},
-			result: "HIHIH ```+5xlm@patrick``` $>kb${\"typ\":0,\"payment\":{\"username\":\"patrick\",\"paymentText\":\"+5XLM@patrick\",\"result\":{\"resultTyp\":0,\"sent\":\"stellarid\"}}}$<kb$ `+1xlm` $>kb${\"typ\":0,\"payment\":{\"username\":\"mikem\",\"paymentText\":\"+1XLM\",\"result\":{\"resultTyp\":0,\"sent\":\"stellarid\"}}}$<kb$ other test",
+			// {"typ":0,"payment":{"username":"patrick","paymentText":"+5XLM@patrick","result":{"resultTyp":0,"sent":"stellarid"}}}
+			// {"typ":0,"payment":{"username":"mikem","paymentText":"+1XLM","result":{"resultTyp":0,"sent":"stellarid"}}}
+			result: "HIHIH ```+5xlm@patrick``` $>kb$eyJ0eXAiOjAsInBheW1lbnQiOnsidXNlcm5hbWUiOiJwYXRyaWNrIiwicGF5bWVudFRleHQiOiIrNVhMTUBwYXRyaWNrIiwicmVzdWx0Ijp7InJlc3VsdFR5cCI6MCwic2VudCI6InN0ZWxsYXJpZCJ9fX0=$<kb$ `+1xlm` $>kb$eyJ0eXAiOjAsInBheW1lbnQiOnsidXNlcm5hbWUiOiJtaWtlbSIsInBheW1lbnRUZXh0IjoiKzFYTE0iLCJyZXN1bHQiOnsicmVzdWx0VHlwIjowLCJzZW50Ijoic3RlbGxhcmlkIn19fQ==$<kb$ other test",
 		},
 		decorateTest{
 			body: "   ```   `+124.005XLM@max```  my life to yours, my breath become yours  ```   `+124.005XLM@mikem``    ",
@@ -64,7 +68,8 @@ func TestStellarDecorate(t *testing.T) {
 					Result:      chat1.NewTextPaymentResultWithSent(stellar1.PaymentID("stellarid")),
 				},
 			},
-			result: "   ```   `+124.005XLM@max```  my life to yours, my breath become yours  ```   `$>kb${\"typ\":0,\"payment\":{\"username\":\"mikem\",\"paymentText\":\"+124.005XLM@mikem\",\"result\":{\"resultTyp\":0,\"sent\":\"stellarid\"}}}$<kb$``    ",
+			// {"typ":0,"payment":{"username":"mikem","paymentText":"+124.005XLM@mikem","result":{"resultTyp":0,"sent":"stellarid"}}}
+			result: "   ```   `+124.005XLM@max```  my life to yours, my breath become yours  ```   `$>kb$eyJ0eXAiOjAsInBheW1lbnQiOnsidXNlcm5hbWUiOiJtaWtlbSIsInBheW1lbnRUZXh0IjoiKzEyNC4wMDVYTE1AbWlrZW0iLCJyZXN1bHQiOnsicmVzdWx0VHlwIjowLCJzZW50Ijoic3RlbGxhcmlkIn19fQ==$<kb$``    ",
 		},
 	}
 	for _, c := range cases {

--- a/go/chat/wallet/parser.go
+++ b/go/chat/wallet/parser.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/keybase/client/go/chat/utils"
 )
 
 var txPattern = regexp.MustCompile(
@@ -33,7 +35,7 @@ type ChatTxCandidate struct {
 func FindChatTxCandidates(xs string) []ChatTxCandidate {
 	// A string that does not appear in the candidate regex so we don't get
 	// false positives from concatenations.
-	replaced := replaceQuotedSubstrings(xs)
+	replaced := utils.ReplaceQuotedSubstrings(xs, false)
 
 	allRawIndices := txPattern.FindAllStringSubmatchIndex(replaced, maxTxsPerMessage)
 	matches := make([]ChatTxCandidate, 0, len(allRawIndices))
@@ -68,27 +70,4 @@ func FindChatTxCandidates(xs string) []ChatTxCandidate {
 		}
 	}
 	return matches
-}
-
-var startQuote = ">"
-var newline = []rune("\n")
-
-func replaceQuotedSubstrings(xs string) string {
-	replacer := func(s string) string {
-		return strings.Repeat("$", len(s))
-	}
-	xs = regexp.MustCompile("((?s)```.*?```)").ReplaceAllStringFunc(xs, replacer)
-	xs = regexp.MustCompile("((?s)`.*?`)").ReplaceAllStringFunc(xs, replacer)
-
-	// Remove all quoted lines. Because we removed all codeblocks
-	// before, we only need to consider single lines.
-	var ret []string
-	for _, line := range strings.Split(xs, string(newline)) {
-		if !strings.HasPrefix(strings.TrimLeft(line, " "), startQuote) {
-			ret = append(ret, line)
-		} else {
-			ret = append(ret, replacer(line))
-		}
-	}
-	return strings.Join(ret, string(newline))
 }

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -886,17 +886,26 @@ func (o UIMessages) DeepCopy() UIMessages {
 type UITextDecorationTyp int
 
 const (
-	UITextDecorationTyp_PAYMENT UITextDecorationTyp = 0
+	UITextDecorationTyp_PAYMENT            UITextDecorationTyp = 0
+	UITextDecorationTyp_ATMENTION          UITextDecorationTyp = 1
+	UITextDecorationTyp_CHANNELNAMEMENTION UITextDecorationTyp = 2
+	UITextDecorationTyp_SHRUG              UITextDecorationTyp = 3
 )
 
 func (o UITextDecorationTyp) DeepCopy() UITextDecorationTyp { return o }
 
 var UITextDecorationTypMap = map[string]UITextDecorationTyp{
-	"PAYMENT": 0,
+	"PAYMENT":            0,
+	"ATMENTION":          1,
+	"CHANNELNAMEMENTION": 2,
+	"SHRUG":              3,
 }
 
 var UITextDecorationTypRevMap = map[UITextDecorationTyp]string{
 	0: "PAYMENT",
+	1: "ATMENTION",
+	2: "CHANNELNAMEMENTION",
+	3: "SHRUG",
 }
 
 func (e UITextDecorationTyp) String() string {
@@ -907,8 +916,10 @@ func (e UITextDecorationTyp) String() string {
 }
 
 type UITextDecoration struct {
-	Typ__     UITextDecorationTyp `codec:"typ" json:"typ"`
-	Payment__ *TextPayment        `codec:"payment,omitempty" json:"payment,omitempty"`
+	Typ__                UITextDecorationTyp   `codec:"typ" json:"typ"`
+	Payment__            *TextPayment          `codec:"payment,omitempty" json:"payment,omitempty"`
+	Atmention__          *string               `codec:"atmention,omitempty" json:"atmention,omitempty"`
+	Channelnamemention__ *UIChannelNameMention `codec:"channelnamemention,omitempty" json:"channelnamemention,omitempty"`
 }
 
 func (o *UITextDecoration) Typ() (ret UITextDecorationTyp, err error) {
@@ -916,6 +927,16 @@ func (o *UITextDecoration) Typ() (ret UITextDecorationTyp, err error) {
 	case UITextDecorationTyp_PAYMENT:
 		if o.Payment__ == nil {
 			err = errors.New("unexpected nil value for Payment__")
+			return ret, err
+		}
+	case UITextDecorationTyp_ATMENTION:
+		if o.Atmention__ == nil {
+			err = errors.New("unexpected nil value for Atmention__")
+			return ret, err
+		}
+	case UITextDecorationTyp_CHANNELNAMEMENTION:
+		if o.Channelnamemention__ == nil {
+			err = errors.New("unexpected nil value for Channelnamemention__")
 			return ret, err
 		}
 	}
@@ -932,10 +953,50 @@ func (o UITextDecoration) Payment() (res TextPayment) {
 	return *o.Payment__
 }
 
+func (o UITextDecoration) Atmention() (res string) {
+	if o.Typ__ != UITextDecorationTyp_ATMENTION {
+		panic("wrong case accessed")
+	}
+	if o.Atmention__ == nil {
+		return
+	}
+	return *o.Atmention__
+}
+
+func (o UITextDecoration) Channelnamemention() (res UIChannelNameMention) {
+	if o.Typ__ != UITextDecorationTyp_CHANNELNAMEMENTION {
+		panic("wrong case accessed")
+	}
+	if o.Channelnamemention__ == nil {
+		return
+	}
+	return *o.Channelnamemention__
+}
+
 func NewUITextDecorationWithPayment(v TextPayment) UITextDecoration {
 	return UITextDecoration{
 		Typ__:     UITextDecorationTyp_PAYMENT,
 		Payment__: &v,
+	}
+}
+
+func NewUITextDecorationWithAtmention(v string) UITextDecoration {
+	return UITextDecoration{
+		Typ__:       UITextDecorationTyp_ATMENTION,
+		Atmention__: &v,
+	}
+}
+
+func NewUITextDecorationWithChannelnamemention(v UIChannelNameMention) UITextDecoration {
+	return UITextDecoration{
+		Typ__:                UITextDecorationTyp_CHANNELNAMEMENTION,
+		Channelnamemention__: &v,
+	}
+}
+
+func NewUITextDecorationWithShrug() UITextDecoration {
+	return UITextDecoration{
+		Typ__: UITextDecorationTyp_SHRUG,
 	}
 }
 
@@ -949,6 +1010,20 @@ func (o UITextDecoration) DeepCopy() UITextDecoration {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Payment__),
+		Atmention__: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.Atmention__),
+		Channelnamemention__: (func(x *UIChannelNameMention) *UIChannelNameMention {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Channelnamemention__),
 	}
 }
 

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -648,15 +648,16 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 }
 
 type UIMessageOutbox struct {
-	State       OutboxState     `codec:"state" json:"state"`
-	OutboxID    string          `codec:"outboxID" json:"outboxID"`
-	MessageType MessageType     `codec:"messageType" json:"messageType"`
-	Body        string          `codec:"body" json:"body"`
-	Ctime       gregor1.Time    `codec:"ctime" json:"ctime"`
-	Ordinal     float64         `codec:"ordinal" json:"ordinal"`
-	Filename    string          `codec:"filename" json:"filename"`
-	Title       string          `codec:"title" json:"title"`
-	Preview     *MakePreviewRes `codec:"preview,omitempty" json:"preview,omitempty"`
+	State             OutboxState     `codec:"state" json:"state"`
+	OutboxID          string          `codec:"outboxID" json:"outboxID"`
+	MessageType       MessageType     `codec:"messageType" json:"messageType"`
+	Body              string          `codec:"body" json:"body"`
+	DecoratedTextBody *string         `codec:"decoratedTextBody,omitempty" json:"decoratedTextBody,omitempty"`
+	Ctime             gregor1.Time    `codec:"ctime" json:"ctime"`
+	Ordinal           float64         `codec:"ordinal" json:"ordinal"`
+	Filename          string          `codec:"filename" json:"filename"`
+	Title             string          `codec:"title" json:"title"`
+	Preview           *MakePreviewRes `codec:"preview,omitempty" json:"preview,omitempty"`
 }
 
 func (o UIMessageOutbox) DeepCopy() UIMessageOutbox {
@@ -665,10 +666,17 @@ func (o UIMessageOutbox) DeepCopy() UIMessageOutbox {
 		OutboxID:    o.OutboxID,
 		MessageType: o.MessageType.DeepCopy(),
 		Body:        o.Body,
-		Ctime:       o.Ctime.DeepCopy(),
-		Ordinal:     o.Ordinal,
-		Filename:    o.Filename,
-		Title:       o.Title,
+		DecoratedTextBody: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.DecoratedTextBody),
+		Ctime:    o.Ctime.DeepCopy(),
+		Ordinal:  o.Ordinal,
+		Filename: o.Filename,
+		Title:    o.Title,
 		Preview: (func(x *MakePreviewRes) *MakePreviewRes {
 			if x == nil {
 				return nil
@@ -889,7 +897,6 @@ const (
 	UITextDecorationTyp_PAYMENT            UITextDecorationTyp = 0
 	UITextDecorationTyp_ATMENTION          UITextDecorationTyp = 1
 	UITextDecorationTyp_CHANNELNAMEMENTION UITextDecorationTyp = 2
-	UITextDecorationTyp_SHRUG              UITextDecorationTyp = 3
 )
 
 func (o UITextDecorationTyp) DeepCopy() UITextDecorationTyp { return o }
@@ -898,14 +905,12 @@ var UITextDecorationTypMap = map[string]UITextDecorationTyp{
 	"PAYMENT":            0,
 	"ATMENTION":          1,
 	"CHANNELNAMEMENTION": 2,
-	"SHRUG":              3,
 }
 
 var UITextDecorationTypRevMap = map[UITextDecorationTyp]string{
 	0: "PAYMENT",
 	1: "ATMENTION",
 	2: "CHANNELNAMEMENTION",
-	3: "SHRUG",
 }
 
 func (e UITextDecorationTyp) String() string {
@@ -991,12 +996,6 @@ func NewUITextDecorationWithChannelnamemention(v UIChannelNameMention) UITextDec
 	return UITextDecoration{
 		Typ__:                UITextDecorationTyp_CHANNELNAMEMENTION,
 		Channelnamemention__: &v,
-	}
-}
-
-func NewUITextDecorationWithShrug() UITextDecoration {
-	return UITextDecoration{
-		Typ__: UITextDecorationTyp_SHRUG,
 	}
 }
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -181,6 +181,7 @@ protocol chatUi {
     string outboxID;
     MessageType messageType;
     string body;
+    union { null, string } decoratedTextBody;
     gregor1.Time ctime;
     double ordinal;
 
@@ -213,15 +214,13 @@ protocol chatUi {
   enum UITextDecorationTyp {
     PAYMENT_0,
     ATMENTION_1,
-    CHANNELNAMEMENTION_2,
-    SHRUG_3
+    CHANNELNAMEMENTION_2
   }
 
   variant UITextDecoration switch (UITextDecorationTyp typ) {
     case PAYMENT: TextPayment;
     case ATMENTION: string;
     case CHANNELNAMEMENTION: UIChannelNameMention;
-    case SHRUG: void;
   }
 
   void chatAttachmentDownloadStart(int sessionID);

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -211,11 +211,17 @@ protocol chatUi {
   }
 
   enum UITextDecorationTyp {
-    PAYMENT_0
+    PAYMENT_0,
+    ATMENTION_1,
+    CHANNELNAMEMENTION_2,
+    SHRUG_3
   }
 
   variant UITextDecoration switch (UITextDecorationTyp typ) {
     case PAYMENT: TextPayment;
+    case ATMENTION: string;
+    case CHANNELNAMEMENTION: UIChannelNameMention;
+    case SHRUG: void;
   }
 
   void chatAttachmentDownloadStart(int sessionID);

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -836,7 +836,10 @@
       "type": "enum",
       "name": "UITextDecorationTyp",
       "symbols": [
-        "PAYMENT_0"
+        "PAYMENT_0",
+        "ATMENTION_1",
+        "CHANNELNAMEMENTION_2",
+        "SHRUG_3"
       ]
     },
     {
@@ -853,6 +856,27 @@
             "def": false
           },
           "body": "TextPayment"
+        },
+        {
+          "label": {
+            "name": "ATMENTION",
+            "def": false
+          },
+          "body": "string"
+        },
+        {
+          "label": {
+            "name": "CHANNELNAMEMENTION",
+            "def": false
+          },
+          "body": "UIChannelNameMention"
+        },
+        {
+          "label": {
+            "name": "SHRUG",
+            "def": false
+          },
+          "body": null
         }
       ]
     },

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -733,6 +733,13 @@
           "name": "body"
         },
         {
+          "type": [
+            null,
+            "string"
+          ],
+          "name": "decoratedTextBody"
+        },
+        {
           "type": "gregor1.Time",
           "name": "ctime"
         },
@@ -838,8 +845,7 @@
       "symbols": [
         "PAYMENT_0",
         "ATMENTION_1",
-        "CHANNELNAMEMENTION_2",
-        "SHRUG_3"
+        "CHANNELNAMEMENTION_2"
       ]
     },
     {
@@ -870,13 +876,6 @@
             "def": false
           },
           "body": "UIChannelNameMention"
-        },
-        {
-          "label": {
-            "name": "SHRUG",
-            "def": false
-          },
-          "body": null
         }
       ]
     },

--- a/shared/chat/conversation/messages/text/container.js
+++ b/shared/chat/conversation/messages/text/container.js
@@ -16,9 +16,6 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
 const mapDispatchToProps = dispatch => ({})
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   isEditing: stateProps.isEditing,
-  mentionsAt: ownProps.message.mentionsAt,
-  mentionsChannel: ownProps.message.mentionsChannel,
-  mentionsChannelName: ownProps.message.mentionsChannelName,
   message: ownProps.message,
   text: ownProps.message.decoratedText
     ? ownProps.message.decoratedText.stringValue()

--- a/shared/chat/conversation/messages/text/index.js
+++ b/shared/chat/conversation/messages/text/index.js
@@ -6,9 +6,6 @@ import * as Styles from '../../../../styles'
 
 export type Props = {
   isEditing: boolean,
-  mentionsAt: Types.MentionsAt,
-  mentionsChannel: Types.MentionsChannel,
-  mentionsChannelName: Types.MentionsChannelName,
   message: Types.MessageText,
   text: string,
   type: 'error' | 'pending' | 'sent',
@@ -26,7 +23,7 @@ const MessageText = ({
   const markdown = (
     <Kb.Markdown
       style={getStyle(type, isEditing)}
-      meta={{mentionsAt, mentionsChannel, mentionsChannelName, message}}
+      meta={{message}}
       styleOverride={Styles.isMobile ? {paragraph: getStyle(type, isEditing)} : undefined}
       allowFontScaling={true}
     >

--- a/shared/common-adapters/markdown/index.js.flow
+++ b/shared/common-adapters/markdown/index.js.flow
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import * as Styles from '../../styles'
-import type {MentionsAt, MentionsChannel, MentionsChannelName, MessageText} from '../../constants/types/chat2'
+import type {MessageText} from '../../constants/types/chat2'
 
 type MarkdownComponentType =
   | 'inline-code'
@@ -23,9 +23,6 @@ export type MarkdownCreateComponent = (
 ) => ?React.Node
 
 export type MarkdownMeta = {|
-  mentionsAt: MentionsAt,
-  mentionsChannelName: MentionsChannelName,
-  mentionsChannel: MentionsChannel,
   message: MessageText,
 |}
 

--- a/shared/common-adapters/markdown/index.stories.js
+++ b/shared/common-adapters/markdown/index.stories.js
@@ -1,5 +1,4 @@
 // @flow
-import * as I from 'immutable'
 import * as React from 'react'
 import * as ChatConstants from '../../constants/chat2'
 import * as Sb from '../../stories/storybook'
@@ -188,12 +187,6 @@ else echo "bar";
 }
 
 const mockMeta = {
-  mentionsAt: I.Set(['following', 'notFollowing', 'myUsername', 'noTheme']),
-  mentionsChannel: 'all',
-  mentionsChannelName: I.Map({
-    // $ForceType
-    general: '0000bbbbbbbbbbbbbbaaaaaaaaaaaaadddddddddccccccc0000000ffffffeeee',
-  }),
   message: ChatConstants.makeMessageText(),
 }
 
@@ -208,9 +201,6 @@ const mocksWithMeta = {
   },
   'Inline send': {
     meta: {
-      mentionsAt: I.Set(),
-      mentionsChannel: 'none',
-      mentionsChannelName: I.Map(),
       message: ChatConstants.makeMessageText({
         decoratedText: new HiddenString(
           `$>kb\${"typ":0,"payment":{"username":"chrisnojima","paymentText":"+0.001XLM@chrisnojima","result":{"resultTyp":0,"sent":"63f55e57bf53402e54b587cd035f96fb7136d0c98b46d6926e41360000000000"}}}$<kb$`
@@ -218,42 +208,6 @@ const mocksWithMeta = {
       }),
     },
     text: `$>kb\${"typ":0,"payment":{"username":"chrisnojima","paymentText":"+0.001XLM@chrisnojima","result":{"resultTyp":0,"sent":"63f55e57bf53402e54b587cd035f96fb7136d0c98b46d6926e41360000000000"}}}$<kb$`,
-  },
-  'User mention - Edge cases': {
-    meta: {
-      ...mockMeta,
-      // This is here to test that the regex is properly not picking up some of these
-      mentionsAt: I.Set([
-        'valid_',
-        '_not',
-        'either',
-        'this_is',
-        'this',
-        'aa',
-        'a_',
-        'a',
-        'long_username',
-        '01234567890abcdef',
-        'you',
-      ]),
-    },
-    text: `hi @you, I hope you're doing well.
-
-this is @valid_
-
-this is @_not
-
-this isn't@either
-
-@this_is though
-
-and @this!
-
-this is the smallest username @aa and @a_ this is too small @a
-
-this is a @long_username
-
-this is too long: @01234567890abcdef`,
   },
   'User mention - Following': {
     meta: mockMeta,

--- a/shared/common-adapters/markdown/react.js
+++ b/shared/common-adapters/markdown/react.js
@@ -3,11 +3,8 @@ import React, {PureComponent} from 'react'
 import SimpleMarkdown from 'simple-markdown'
 import {isMobile} from '../../constants/platform'
 import * as Styles from '../../styles'
-import * as Types from '../../constants/types/chat2'
 import Text from '../text'
 import KbfsPath from './kbfs-path-container'
-import Channel from '../channel-container'
-import Mention from '../mention-container'
 import {type MarkdownMeta, type StyleOverride} from '.'
 import Box from '../box'
 import Emoji from '../emoji'
@@ -193,16 +190,6 @@ const reactComponentsForMarkdownType = {
       {output(node.content, {...state, inBlockQuote: true})}
     </Box>
   ),
-  channel: (node, output, state) => {
-    return (
-      <Channel
-        name={node.content}
-        convID={Types.stringToConversationIDKey(node.convID)}
-        key={state.key}
-        style={linkStyle}
-      />
-    )
-  },
   del: (node, output, state) => {
     return (
       <Text
@@ -298,16 +285,6 @@ const reactComponentsForMarkdownType = {
       </React.Fragment>
     )
   },
-  mention: (node, output, state) => {
-    return (
-      <Mention
-        username={node.content}
-        key={state.key}
-        style={wrapStyle}
-        allowFontScaling={state.allowFontScaling}
-      />
-    )
-  },
   newline: (node, output, state) =>
     !isMobile || state.inParagraph ? (
       '\n'
@@ -346,6 +323,7 @@ const reactComponentsForMarkdownType = {
         key={state.key}
         allowFontScaling={state.allowFontScaling}
         message={message}
+        styles={markdownStyles}
       />
     )
   },

--- a/shared/common-adapters/markdown/service-decoration.js
+++ b/shared/common-adapters/markdown/service-decoration.js
@@ -3,20 +3,25 @@ import React from 'react'
 import * as Types from '../../constants/types/chat2'
 import * as WalletTypes from '../../constants/types/wallets'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
+import {toByteArray} from 'base64-js'
 import PaymentStatus from '../../chat/payments/status/container'
+import Mention from '../mention-container'
+import Channel from '../channel-container'
 
 export type Props = {
   json: string,
   onClick?: () => void,
   allowFontScaling?: ?boolean,
   message: Types.MessageText,
+  styles: Object,
 }
 
 const ServiceDecoration = (props: Props) => {
   // Parse JSON to get the type of the decoration
   let parsed: RPCChatTypes.UITextDecoration
   try {
-    parsed = JSON.parse(props.json)
+    const json = Buffer.from(toByteArray(props.json)).toString()
+    parsed = JSON.parse(json)
   } catch (e) {
     return null
   }
@@ -43,6 +48,26 @@ const ServiceDecoration = (props: Props) => {
         text={parsed.payment.paymentText}
         allowFontScaling={props.allowFontScaling}
         message={props.message}
+      />
+    )
+  } else if (parsed.typ === RPCChatTypes.chatUiUITextDecorationTyp.atmention && parsed.atmention) {
+    return (
+      <Mention
+        allowFontScaling={props.allowFontScaling || false}
+        style={props.styles.wrapStyle}
+        username={parsed.atmention}
+      />
+    )
+  } else if (
+    parsed.typ === RPCChatTypes.chatUiUITextDecorationTyp.channelnamemention &&
+    parsed.channelnamemention
+  ) {
+    return (
+      <Channel
+        allowFontScaling={props.allowFontScaling || false}
+        convID={parsed.channelnamemention.convID}
+        name={parsed.channelnamemention.name}
+        style={props.styles.wrapStyle}
       />
     )
   }

--- a/shared/common-adapters/markdown/service-decoration.js
+++ b/shared/common-adapters/markdown/service-decoration.js
@@ -67,7 +67,7 @@ const ServiceDecoration = (props: Props) => {
         allowFontScaling={props.allowFontScaling || false}
         convID={parsed.channelnamemention.convID}
         name={parsed.channelnamemention.name}
-        style={props.styles.wrapStyle}
+        style={props.styles.linkStyle}
       />
     )
   }

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -4,49 +4,10 @@ import React, {PureComponent} from 'react'
 import SimpleMarkdown from 'simple-markdown'
 import Text from '../text'
 import logger from '../../logger'
-import type {MarkdownMeta, Props as MarkdownProps} from '.'
+import type {Props as MarkdownProps} from '.'
 import {emojiIndexByChar, emojiRegex, tldExp, commonTlds} from './emoji-gen'
 import {isMobile} from '../../constants/platform'
-import {specialMentions} from '../../constants/chat2'
 import {reactOutput, previewOutput, bigEmojiOutput, markdownStyles} from './react'
-import {type ConversationIDKey} from '../../constants/types/chat2'
-
-function createMentionRegex(meta: ?MarkdownMeta): ?RegExp {
-  if (!meta || !meta.mentionsAt || !meta.mentionsChannel) {
-    return null
-  }
-
-  if (meta.mentionsChannel === 'none' && meta.mentionsAt.isEmpty()) {
-    return null
-  }
-
-  return new RegExp(`^@(${[...specialMentions, ...meta.mentionsAt.toArray()].join('|')})\\b`)
-}
-
-function createMentionMatcher(meta: ?MarkdownMeta) {
-  const mentionRegex = createMentionRegex(meta)
-  if (!mentionRegex) {
-    return null
-  }
-
-  return SimpleMarkdown.inlineRegex(mentionRegex)
-}
-
-function createChannelRegex(meta: ?MarkdownMeta): ?RegExp {
-  if (!meta || !meta.mentionsChannelName || meta.mentionsChannelName.isEmpty()) {
-    return null
-  }
-
-  return new RegExp(`^#(${meta.mentionsChannelName.keySeq().join('|')})\\b`)
-}
-
-function createChannelMatcher(meta: ?MarkdownMeta) {
-  const channelRegex = createChannelRegex(meta)
-  if (!channelRegex) {
-    return null
-  }
-  return SimpleMarkdown.inlineRegex(channelRegex)
-}
 
 function createKbfsPathRegex(): ?RegExp {
   const username = `(?:[a-zA-Z0-9]+_?)+` // from go/kbun/username.go
@@ -60,15 +21,15 @@ function createKbfsPathRegex(): ?RegExp {
 
 const kbfsPathMatcher = SimpleMarkdown.inlineRegex(createKbfsPathRegex())
 
+const serviceBeginDecorationTag = '\\$\\>kb\\$'
+const serviceEndDecorationTag = '\\$\\<kb\\$'
 function createServiceDecorationRegex(): ?RegExp {
-  return new RegExp(`^\\$\\>kb\\$(((?!\\$\\<kb\\$).)*)\\$\\<kb\\$`)
+  return new RegExp(
+    `^${serviceBeginDecorationTag}(((?!${serviceEndDecorationTag}).)*)${serviceEndDecorationTag}`
+  )
 }
 
 const serviceDecorationMatcher = SimpleMarkdown.inlineRegex(createServiceDecorationRegex())
-
-function channelNameToConvID(meta: ?MarkdownMeta, channel: string): ?ConversationIDKey {
-  return meta && meta.mentionsChannelName && meta.mentionsChannelName.get(channel)
-}
 
 const _makeLinkRegex = () => {
   const valid = `[:,!]*[\\w=#%~\\-_~&@+\\u00c0-\\uffff]`
@@ -183,29 +144,6 @@ const rules = {
         content: parse(content, nextState),
       }
     },
-  },
-  channel: {
-    // Just needs to be a higher order than mentions
-    match: (source, state, lookBehind) => {
-      const channelMatcher = state.channelMatcher
-      if (!channelMatcher) {
-        return null
-      }
-
-      const matches = channelMatcher(source, state, lookBehind)
-      // Also check that the lookBehind is not text
-      if (matches && (!lookBehind || lookBehind.match(/\B$/))) {
-        return matches
-      }
-
-      return null
-    },
-    order: SimpleMarkdown.defaultRules.autolink.order + 0.5,
-    parse: (capture, parse, state) => ({
-      content: capture[1],
-      convID: channelNameToConvID(state.markdownMeta, capture[1]),
-      type: 'channel',
-    }),
   },
   del: {
     ...SimpleMarkdown.defaultRules.del,
@@ -323,28 +261,6 @@ const rules = {
       return {content: capture[2], mailto: `mailto:${capture[2]}`, spaceInFront: capture[1]}
     },
   },
-  mention: {
-    // A decent enough starting template
-    // We'll change most of the stuff here anyways
-    ...SimpleMarkdown.defaultRules.autolink,
-    match: (source, state, lookBehind) => {
-      const mentionMatcher = state.mentionMatcher
-      if (!mentionMatcher) {
-        return null
-      }
-
-      const matches = mentionMatcher(source, state, lookBehind)
-      // Also check that the lookBehind is not text
-      if (matches && (!lookBehind || lookBehind.match(/\B$/))) {
-        return matches
-      }
-      return null
-    },
-    parse: capture => ({
-      content: capture[1],
-      type: 'mention',
-    }),
-  },
   newline: {
     // handle newlines, keep this to handle \n w/ other matchers
     ...SimpleMarkdown.defaultRules.newline,
@@ -398,8 +314,8 @@ const rules = {
   serviceDecoration: {
     match: (source, state, lookBehind) => {
       return serviceDecorationMatcher(source, state, lookBehind)
-    }, // high
-    order: SimpleMarkdown.defaultRules.autolink.order + 1,
+    },
+    order: 1,
     parse: capture => ({
       content: capture[1],
       type: 'serviceDecoration',
@@ -461,13 +377,11 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps, {hasError: bo
     let output
     try {
       parseTree = simpleMarkdownParser((this.props.children || '').trim() + '\n', {
-        channelMatcher: createChannelMatcher(this.props.meta),
         // This flag adds 2 new lines at the end of our input. One is necessary to parse the text as a paragraph, but the other isn't
         // So we add our own new line
         disableAutoBlockNewlines: true,
         inline: false,
         markdownMeta: this.props.meta,
-        mentionMatcher: createMentionMatcher(this.props.meta),
       })
 
       const state = {

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -831,6 +831,7 @@ const outboxUIMessagetoMessage = (
       return makeMessageText({
         author: state.config.username || '',
         conversationIDKey,
+        decoratedText: o.decoratedTextBody ? new HiddenString(o.decoratedTextBody) : null,
         deviceName: state.config.deviceName || '',
         deviceType: isMobile ? 'mobile' : 'desktop',
         errorReason,

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -15,6 +15,9 @@ export const chatUiMessageUnboxedState = {
 
 export const chatUiUITextDecorationTyp = {
   payment: 0,
+  atmention: 1,
+  channelnamemention: 2,
+  shrug: 3,
 }
 
 export const commonAssetMetadataType = {

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -17,7 +17,6 @@ export const chatUiUITextDecorationTyp = {
   payment: 0,
   atmention: 1,
   channelnamemention: 2,
-  shrug: 3,
 }
 
 export const commonAssetMetadataType = {

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -371,6 +371,9 @@ export const chatUiMessageUnboxedState = {
 
 export const chatUiUITextDecorationTyp = {
   payment: 0,
+  atmention: 1,
+  channelnamemention: 2,
+  shrug: 3,
 }
 
 export const commonAssetMetadataType = {
@@ -1121,8 +1124,12 @@ export type UIMessages = $ReadOnly<{messages?: ?Array<UIMessage>, unreadLineID?:
 export type UIPagination = $ReadOnly<{next: String, previous: String, num: Int, last: Boolean}>
 export type UIPaymentInfo = $ReadOnly<{accountID?: ?Stellar1.AccountID, amountDescription: String, worth: String, worthAtSendTime: String, delta: Stellar1.BalanceDelta, note: String, paymentID: Stellar1.PaymentID, status: Stellar1.PaymentStatus, statusDescription: String, statusDetail: String, showCancel: Boolean, fromUsername: String, toUsername: String}>
 export type UIRequestInfo = $ReadOnly<{amount: String, amountDescription: String, asset?: ?Stellar1.Asset, currency?: ?Stellar1.OutsideCurrencyCode, status: Stellar1.RequestStatus}>
-export type UITextDecoration = {typ: 0, payment: ?TextPayment}
-export type UITextDecorationTyp = 0 // PAYMENT_0
+export type UITextDecoration = {typ: 0, payment: ?TextPayment} | {typ: 1, atmention: ?String} | {typ: 2, channelnamemention: ?UIChannelNameMention} | {typ: 3}
+export type UITextDecorationTyp =
+  | 0 // PAYMENT_0
+  | 1 // ATMENTION_1
+  | 2 // CHANNELNAMEMENTION_2
+  | 3 // SHRUG_3
 
 export type Unfurl = {unfurlType: 0, generic: ?UnfurlGeneric} | {unfurlType: 1, youtube: ?UnfurlYoutube} | {unfurlType: 2, giphy: ?UnfurlGiphy}
 export type UnfurlDisplay = {unfurlType: 0, generic: ?UnfurlGenericDisplay} | {unfurlType: 1, youtube: ?UnfurlYoutubeDisplay} | {unfurlType: 2, giphy: ?UnfurlGiphyDisplay}

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -373,7 +373,6 @@ export const chatUiUITextDecorationTyp = {
   payment: 0,
   atmention: 1,
   channelnamemention: 2,
-  shrug: 3,
 }
 
 export const commonAssetMetadataType = {
@@ -1117,19 +1116,18 @@ export type UIChannelNameMention = $ReadOnly<{name: String, convID: String}>
 export type UIChatPayment = $ReadOnly<{username: String, fullName: String, xlmAmount: String, error?: ?String, displayAmount?: ?String}>
 export type UIChatPaymentSummary = $ReadOnly<{xlmTotal: String, displayTotal: String, payments?: ?Array<UIChatPayment>}>
 export type UIMessage = {state: 1, valid: ?UIMessageValid} | {state: 2, error: ?MessageUnboxedError} | {state: 3, outbox: ?UIMessageOutbox} | {state: 4, placeholder: ?MessageUnboxedPlaceholder}
-export type UIMessageOutbox = $ReadOnly<{state: OutboxState, outboxID: String, messageType: MessageType, body: String, ctime: Gregor1.Time, ordinal: Double, filename: String, title: String, preview?: ?MakePreviewRes}>
+export type UIMessageOutbox = $ReadOnly<{state: OutboxState, outboxID: String, messageType: MessageType, body: String, decoratedTextBody?: ?String, ctime: Gregor1.Time, ordinal: Double, filename: String, title: String, preview?: ?MakePreviewRes}>
 export type UIMessageUnfurlInfo = $ReadOnly<{unfurlMessageID: MessageID, url: String, unfurl: UnfurlDisplay}>
 export type UIMessageValid = $ReadOnly<{messageID: MessageID, ctime: Gregor1.Time, outboxID?: ?String, messageBody: MessageBody, decoratedTextBody?: ?String, senderUsername: String, senderDeviceName: String, senderDeviceType: String, senderUID: Gregor1.UID, senderDeviceID: Gregor1.DeviceID, superseded: Boolean, assetUrlInfo?: ?UIAssetUrlInfo, senderDeviceRevokedAt?: ?Gregor1.Time, atMentions?: ?Array<String>, channelMention: ChannelMention, channelNameMentions?: ?Array<UIChannelNameMention>, isEphemeral: Boolean, isEphemeralExpired: Boolean, explodedBy?: ?String, etime: Gregor1.Time, reactions: ReactionMap, hasPairwiseMacs: Boolean, paymentInfos?: ?Array<UIPaymentInfo>, requestInfo?: ?UIRequestInfo, unfurls?: ?Array<UIMessageUnfurlInfo>}>
 export type UIMessages = $ReadOnly<{messages?: ?Array<UIMessage>, unreadLineID?: ?MessageID, pagination?: ?UIPagination}>
 export type UIPagination = $ReadOnly<{next: String, previous: String, num: Int, last: Boolean}>
 export type UIPaymentInfo = $ReadOnly<{accountID?: ?Stellar1.AccountID, amountDescription: String, worth: String, worthAtSendTime: String, delta: Stellar1.BalanceDelta, note: String, paymentID: Stellar1.PaymentID, status: Stellar1.PaymentStatus, statusDescription: String, statusDetail: String, showCancel: Boolean, fromUsername: String, toUsername: String}>
 export type UIRequestInfo = $ReadOnly<{amount: String, amountDescription: String, asset?: ?Stellar1.Asset, currency?: ?Stellar1.OutsideCurrencyCode, status: Stellar1.RequestStatus}>
-export type UITextDecoration = {typ: 0, payment: ?TextPayment} | {typ: 1, atmention: ?String} | {typ: 2, channelnamemention: ?UIChannelNameMention} | {typ: 3}
+export type UITextDecoration = {typ: 0, payment: ?TextPayment} | {typ: 1, atmention: ?String} | {typ: 2, channelnamemention: ?UIChannelNameMention}
 export type UITextDecorationTyp =
   | 0 // PAYMENT_0
   | 1 // ATMENTION_1
   | 2 // CHANNELNAMEMENTION_2
-  | 3 // SHRUG_3
 
 export type Unfurl = {unfurlType: 0, generic: ?UnfurlGeneric} | {unfurlType: 1, youtube: ?UnfurlYoutube} | {unfurlType: 2, giphy: ?UnfurlGiphy}
 export type UnfurlDisplay = {unfurlType: 0, generic: ?UnfurlGenericDisplay} | {unfurlType: 1, youtube: ?UnfurlYoutubeDisplay} | {unfurlType: 2, giphy: ?UnfurlGiphyDisplay}


### PR DESCRIPTION
**Go**
1. Add `DecorateWithMentions` to use `DecorateBody` to label @mentions and channel name mentions in text. 
2. Add decorated text to outbox messages.
3. Factor out the quote replacer function into `util` so it can be used in all decoration style functions.

**JS**
@keybase/react-hackers 
1. Remove all custom code in the markdown parser pipeline for mentions of all kinds.
2. Change `ServiceDecoration` to put in `Mention` and `Channel` components when processing the relevant service decorations. 