### PR TITLE
Block send form if there was an error sending

### DIFF
--- a/shared/reducers/wallets.js
+++ b/shared/reducers/wallets.js
@@ -65,6 +65,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         }),
         builtPayment: Constants.makeBuiltPayment(),
         builtRequest: Constants.makeBuiltRequest(),
+        sentPaymentError: '',
       })
     case WalletsGen.abandonPayment:
     case WalletsGen.clearBuilding:

--- a/shared/wallets/send-form/body/container.js
+++ b/shared/wallets/send-form/body/container.js
@@ -2,23 +2,27 @@
 import {SendBody as SendBodyComponent, RequestBody as RequestBodyComponent} from '.'
 import {namedConnect} from '../../../util/container'
 import * as Constants from '../../../constants/wallets'
+import * as WalletsGen from '../../../actions/wallets-gen'
 
 type OwnProps = {||}
 
 const mapStateToProps = state => ({
+  _failed: !!state.wallets.sentPaymentError,
   banners: state.wallets.building.isRequest
     ? state.wallets.builtRequest.builtBanners
     : state.wallets.builtPayment.builtBanners,
 })
 
-const mapDispatchToProps = dispatch => ({})
+const mapDispatchToProps = dispatch => ({
+  _onReviewPayments: () => dispatch(WalletsGen.createExitFailedPayment()),
+})
 
 const mergeProps = (stateProps, dispatchProps) => ({
-  ...dispatchProps,
   banners: (stateProps.banners || []).map(banner => ({
     bannerBackground: Constants.bannerLevelToBackground(banner.level),
     bannerText: banner.message,
   })),
+  onReviewPayments: stateProps._failed ? dispatchProps._onReviewPayments : null,
 })
 
 export const SendBody = namedConnect<OwnProps, _, _, _, _>(

--- a/shared/wallets/send-form/body/index.js
+++ b/shared/wallets/send-form/body/index.js
@@ -11,6 +11,7 @@ import type {Banner as BannerType} from '../../../constants/types/wallets'
 
 type SendBodyProps = {|
   banners: Array<BannerType>,
+  onReviewPayments: ?() => void,
   isProcessing?: boolean,
 |}
 
@@ -39,6 +40,7 @@ export const SendBody = (props: SendBodyProps) => (
       <PublicMemo />
     </Kb.ScrollView>
     <Footer />
+    {!!props.onReviewPayments && <Failure onReviewPayments={props.onReviewPayments} />}
   </Kb.Box2>
 )
 
@@ -58,10 +60,39 @@ export const RequestBody = (props: RequestBodyProps) => (
   </Kb.Box2>
 )
 
+const Failure = ({onReviewPayments}: {onReviewPayments: () => void}) => (
+  <Kb.Box2
+    direction="vertical"
+    centerChildren={true}
+    fullWidth={true}
+    fullHeight={true}
+    gap="small"
+    style={styles.failureContainer}
+  >
+    <Kb.Box2 direction="vertical" centerChildren={true} fullWidth={true}>
+      <Kb.Text center={true} type="BodyBig">
+        PAYMENT FAILED
+      </Kb.Text>
+      <Kb.Text center={true} type="Body">
+        Or, your internet connection failed.
+      </Kb.Text>
+      <Kb.Text center={true} type="Body">
+        Please check your recent payments before trying again.
+      </Kb.Text>
+    </Kb.Box2>
+    <Kb.Button type="Primary" label="Review payments" onClick={onReviewPayments} />
+  </Kb.Box2>
+)
+
 const styles = Styles.styleSheetCreate({
   container: {
     flexGrow: 1,
     flexShrink: 1,
+  },
+  failureContainer: {
+    ...Styles.globalStyles.fillAbsolute,
+    backgroundColor: Styles.globalColors.white_90,
+    padding: Styles.globalMargins.tiny,
   },
   scrollView: Styles.platformStyles({
     common: {


### PR DESCRIPTION
Send form looks like this if there's a `sentPaymentError`
<img width="446" alt="image" src="https://user-images.githubusercontent.com/11968340/51500066-baf07280-1d9a-11e9-86ff-b8a3e5e7a256.png">

r? @keybase/react-hackers 