### PR TITLE
folder_block_manager: fix and simplify quota reclamation

### DIFF
--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1063,7 +1063,6 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	if !fbm.isQRNecessary(ctx, head) {
 		// Nothing has changed since last time, or the current head is
 		// too new, so no need to do any QR.
-		fbm.log.CDebugf(ctx, "QR NOT NEEDED")
 		return nil
 	}
 	var complete bool
@@ -1117,7 +1116,6 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 		return err
 	}
 	if head.Revision() <= lastGCRev {
-		fbm.log.CDebugf(ctx, "QR NOT NEEDED %d", lastGCRev)
 		// TODO: need a log level more fine-grained than Debug to
 		// print out that we're not doing reclamation.
 		complete = true


### PR DESCRIPTION
Previously we would give up doing QR if there were more than 100 recent revisions that were less than 2 weeks old.  This is clearly the wrong thing to do.  I think we did this previously due to historical limitations of old data formats (i.e., not having the `LastGCRevision` field, and not being able to tell when an MD revision was made).

These limitations are ancient now, and it's notably preventing QR on some folders.  So fix it by counting MDs forward from the `LastGCRevision`, instead of backward (which could result in an arbitrary amount of work).

Issue: KBFS-3597