### PR TITLE
root_metadata: initialize TLF with LastGCRevision=1

### DIFF
--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -542,7 +542,11 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 			return false, ImmutableRootMetadata{}, tlf.NullID, err
 		}
 		if rmd != (ImmutableRootMetadata{}) && rmd.IsReadable() {
-			if rev <= rmd.data.LastGCRevision {
+			// `rev` is still readable even if it matches
+			// `rmd.data.LastGCRevision`, since the GC process just
+			// removes the unref'd blocks in that revision; the actual
+			// data represented by the revision is still readable.
+			if rev < rmd.data.LastGCRevision {
 				return false, ImmutableRootMetadata{}, tlf.NullID,
 					RevGarbageCollectedError{rev, rmd.data.LastGCRevision}
 			}

--- a/go/kbfs/libkbfs/root_metadata.go
+++ b/go/kbfs/libkbfs/root_metadata.go
@@ -158,7 +158,12 @@ func makeInitialRootMetadata(
 	}
 	// Need to keep the TLF handle around long enough to rekey the
 	// metadata for the first time.
-	return makeRootMetadata(bareMD, nil, h), nil
+	rmd := makeRootMetadata(bareMD, nil, h)
+	// The initial revision never has any unrefs, so set the
+	// last GC revision to 1 to avoid having to walk backwards
+	// through all the MDs during the first QR for this TLF.
+	rmd.data.LastGCRevision = kbfsmd.RevisionInitial
+	return rmd, nil
 }
 
 // Data returns the private metadata of this RootMetadata.


### PR DESCRIPTION
For TLFs that are older than the `LastGCRevision` field, the QR process has to walk backwards to find the last GC op.  But for new folders, we shouldn't have to pay this price when doing the first QR. Since revision 1 will never have any unrefs, it's safe to mark it as GC'd from the very beginning, to avoid that walking backwards.

Issue: KBFS-3597