### PR TITLE
Tweak when emojirow is visible with existing reactions

### DIFF
--- a/shared/chat/conversation/conversation.css
+++ b/shared/chat/conversation/conversation.css
@@ -45,7 +45,7 @@
   box-shadow: 0 2px 2px 0 rgba(224, 224, 224, 0.5);
 }
 .WrapperMessage-hoverBox:hover .WrapperMessage-emojiButton.noShadow,
-.WrapperMessage-hoverBox:hover .WrapperMessage-emojiButton:hover {
+.WrapperMessage-hoverBox:hover .WrapperMessage-emojiButton:active {
   box-shadow: none;
 }
 .WrapperMessage-hoverBox .WrapperMessage-newEmojiButton {

--- a/shared/chat/conversation/conversation.css
+++ b/shared/chat/conversation/conversation.css
@@ -48,3 +48,9 @@
 .WrapperMessage-hoverBox:hover .WrapperMessage-emojiButton:hover {
   box-shadow: none;
 }
+.WrapperMessage-hoverBox .WrapperMessage-newEmojiButton {
+  visibility: hidden;
+}
+.WrapperMessage-hoverBox:hover .WrapperMessage-newEmojiButton {
+  visibility: visible;
+}

--- a/shared/chat/conversation/conversation.css
+++ b/shared/chat/conversation/conversation.css
@@ -9,7 +9,7 @@
   width: 100%;
 }
 .WrapperMessage-noOverflow {
-  overflow: 'hidden';
+  overflow: hidden;
 }
 .WrapperMessage-hoverBox .WrapperMessage-buttons {
   display: none;

--- a/shared/chat/conversation/messages/reactions-row/container.js
+++ b/shared/chat/conversation/messages/reactions-row/container.js
@@ -19,6 +19,7 @@ const getOrderedReactions = (reactions: ?Types.Reactions) => {
 
 export type OwnProps = {|
   btnClassName?: string,
+  newBtnClassName?: string,
   conversationIDKey: Types.ConversationIDKey,
   ordinal: Types.Ordinal,
 |}

--- a/shared/chat/conversation/messages/reactions-row/index.js
+++ b/shared/chat/conversation/messages/reactions-row/index.js
@@ -5,23 +5,22 @@ import {Box, Box2} from '../../../../common-adapters'
 import ReactButton from '../react-button/container'
 import ReactionTooltip from '../reaction-tooltip/container'
 import EmojiRow from '../react-button/emoji-row/container'
-import {collapseStyles, globalMargins, isMobile, platformStyles, styleSheetCreate} from '../../../../styles'
+import {classNames, globalMargins, isMobile, platformStyles, styleSheetCreate} from '../../../../styles'
 
 export type Props = {|
   btnClassName?: string, // class to apply to all reacji buttons
+  newBtnClassName?: string, // class to apply to emoji row
   conversationIDKey: Types.ConversationIDKey,
   emojis: Array<string>,
   ordinal: Types.Ordinal,
 |}
 type State = {
   activeEmoji: string,
-  showAddReaction: boolean,
   showMobileTooltip: boolean,
 }
 class ReactionsRow extends React.Component<Props, State> {
   state = {
     activeEmoji: '',
-    showAddReaction: false,
     showMobileTooltip: false,
   }
   _attachmentRefs: {[emojiName: string]: ?React.Component<any>} = {}
@@ -33,9 +32,6 @@ class ReactionsRow extends React.Component<Props, State> {
   _setActiveEmoji = (emojiName: string) =>
     this.setState(s => (s.activeEmoji === emojiName ? null : {activeEmoji: emojiName}))
 
-  _setHoveringRow = (hovering: boolean) =>
-    this.setState(s => (s.showAddReaction === hovering ? null : {showAddReaction: hovering}))
-
   _setShowMobileTooltip = (showMobileTooltip: boolean) =>
     this.setState(s => (s.showMobileTooltip === showMobileTooltip ? null : {showMobileTooltip}))
 
@@ -45,14 +41,7 @@ class ReactionsRow extends React.Component<Props, State> {
 
   render() {
     return this.props.emojis.length === 0 ? null : (
-      <Box2
-        onMouseOver={() => this._setHoveringRow(true)}
-        onMouseLeave={() => this._setHoveringRow(false)}
-        direction="horizontal"
-        gap="xtiny"
-        fullWidth={true}
-        style={styles.container}
-      >
+      <Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.container}>
         {this.props.emojis.map(emoji => (
           <Box
             onMouseOver={() => this._setHoveringButton(true, emoji)}
@@ -86,15 +75,11 @@ class ReactionsRow extends React.Component<Props, State> {
             onLongPress={() => this._setShowMobileTooltip(true)}
             ordinal={this.props.ordinal}
             showBorder={true}
-            style={collapseStyles([
-              styles.button,
-              // Important to the animation for this to be `visibility: hidden`
-              !this.state.showAddReaction && !isMobile && styles.visibilityHidden,
-            ])}
+            style={styles.button}
           />
         ) : (
           <EmojiRow
-            className={this.props.btnClassName}
+            className={classNames([this.props.btnClassName, this.props.newBtnClassName])}
             conversationIDKey={this.props.conversationIDKey}
             ordinal={this.props.ordinal}
             style={styles.button}

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -194,6 +194,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       <ReactionsRow
         key="ReactionsRow"
         btnClassName="WrapperMessage-emojiButton"
+        newBtnClassName="WrapperMessage-newEmojiButton"
         conversationIDKey={this.props.conversationIDKey}
         ordinal={this.props.message.ordinal}
       />


### PR DESCRIPTION
Currently it's always there if there are existing reactions, this changes it so `EmojiRow` pops in while hovering the message. Also removes some unused login in `ReactionsRow` related to how this used to work. r? @keybase/react-hackers 
![emoji-row-hovering](https://user-images.githubusercontent.com/11968340/51561385-15e6a000-1e55-11e9-8e48-9f11b360aaf0.gif)
