### PR TITLE
Close send/request form after requesting from the wallets tab

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -168,13 +168,14 @@ const requestPayment = state =>
       recipient: state.wallets.building.to,
     },
     Constants.requestPaymentWaitingKey
-  ).then(kbRqID =>
+  ).then(kbRqID => [
+    maybeNavigateAwayFromSendForm(state),
     WalletsGen.createRequestedPayment({
       kbRqID: new HiddenString(kbRqID),
       lastSentXLM: state.wallets.building.currency === 'XLM',
       requestee: state.wallets.building.to,
-    })
-  )
+    }),
+  ])
 
 const startPayment = state =>
   state.wallets.acceptedDisclaimer && !state.wallets.building.isRequest


### PR DESCRIPTION
Currently on desktop:

1. Open request form from wallet page -> Receive
2. Make a request, auto-nav to chat afterwards
3. Go back to wallets tab; send form is still open

This closes the form before navigating to the convo. r? @keybase/react-hackers 