### PR TITLE
don't folderList in a TLF list

### DIFF
--- a/shared/fs/row/files-loading-hoc.js
+++ b/shared/fs/row/files-loading-hoc.js
@@ -47,10 +47,7 @@ const FilesLoadingHoc = (ComposedComponent: React.ComponentType<any>) =>
       if (pathLevel < 2) {
         return
       }
-      pathLevel === 2 && this.props.loadFavorites()
-      // This is needed not only inside in a tlf, but also in tlf list, to get
-      // `writable` for tlf root.
-      this.props.loadFolderList()
+      pathLevel === 2 ? this.props.loadFavorites() : this.props.loadFolderList()
     }
     componentDidMount() {
       this._load()


### PR DESCRIPTION
We used to do it in order to know whether a TLF is writable. Now that we
have loadPathMetadata, we already cover that part when user navigates
into a TLF. So just don't list a TLF list. This removes the "Loading
..." in /keybase/{private,public/team}

Also remove irrelevant condition in loadPathMetadata.