### PR TITLE
Fix setting display currency on opening request form with no wallets data

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -93,7 +93,7 @@ const openSendRequestForm = (state, action) => {
 }
 
 const maybePopulateBuildingCurrency = (state, action) =>
-  state.wallets.building.bid && !state.wallets.building.currency // building a payment and haven't set currency yet
+  (state.wallets.building.bid || state.wallets.building.isRequest) && !state.wallets.building.currency // building a payment and haven't set currency yet
     ? WalletsGen.createSetBuildingCurrency({currency: Constants.getDefaultDisplayCurrency(state).code})
     : null
 


### PR DESCRIPTION
1. Have `lastSentXLM === false`
2. Refresh / quit + restart client
3. Go to own profile > federated address > 'Request lumens'
4. Display currency permaspins

It works if you close out + reopen. We checked for `state.wallets.building.bid` before setting this, but for requests we don't have a `bid`. This changes the check to `state.wallets.building.bid || state.wallets.building.isRequest`. r? @keybase/react-hackers 