### PR TITLE
Fix seqno state on error, plus check amounts

### DIFF
--- a/go/stellar/batch.go
+++ b/go/stellar/batch.go
@@ -332,11 +332,3 @@ func submitBatchTx(mctx libkb.MetaContext, walletState *WalletState, senderAccou
 		bpResult.EndTime = stellar1.ToTimeMs(time.Now())
 	}
 }
-
-func isAmountLessThanMin(amount, min string) bool {
-	cmp, err := stellarnet.CompareStellarAmounts(amount, min)
-	if err == nil && cmp == -1 {
-		return true
-	}
-	return false
-}

--- a/go/stellar/util.go
+++ b/go/stellar/util.go
@@ -110,3 +110,11 @@ func LookupSenderSeed(mctx libkb.MetaContext) (stellar1.AccountID, stellarnet.Se
 
 	return senderEntry.AccountID, senderSeed, nil
 }
+
+func isAmountLessThanMin(amount, min string) bool {
+	cmp, err := stellarnet.CompareStellarAmounts(amount, min)
+	if err == nil && cmp == -1 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
There was a bug that when SubmitPayment or SubmitRelayPayment
returned an error, the pending tx wasn't removed from WalletState.
This causes seqno issues after that...

Also, this adds some more checks for low payment amounts up front.
Since we are predicting seqnos so much now, it doesn't make sense
to burn one on a low amount payment that we can detect easily.