### PR TITLE
disable-typing setting

### DIFF
--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -30,6 +30,7 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 		newCmdChatReport(cl, g),
 		newCmdChatSetRetention(cl, g),
 		newCmdChatSetConvMinWriterRole(cl, g),
+		newCmdChatSetNotificationSettings(cl, g),
 		newCmdChatSearchInbox(cl, g),
 		newCmdChatSearchRegexp(cl, g),
 		newCmdChatSend(cl, g),

--- a/go/client/cmd_chat_notification_settings.go
+++ b/go/client/cmd_chat_notification_settings.go
@@ -1,0 +1,120 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"strconv"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"golang.org/x/net/context"
+)
+
+type CmdChatSetNotificationSettings struct {
+	libkb.Contextified
+	settings chat1.GlobalAppNotificationSettings
+}
+
+func NewCmdChatSetNotificationSettingsRunner(g *libkb.GlobalContext) *CmdChatSetNotificationSettings {
+	return &CmdChatSetNotificationSettings{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatSetNotificationSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := []cli.Flag{}
+	for _, setting := range chat1.GlobalAppNotificationSettingsSorted() {
+		usage := setting.Usage()
+		flagName := setting.FlagName()
+		flags = append(flags, cli.BoolFlag{
+			Name:  flagName,
+			Usage: usage,
+		})
+	}
+	return cli.Command{
+		Name:  "notification-settings",
+		Usage: "Manage personal notification settings",
+		Examples: `
+View the current settings:
+    keybase chat notification-settings
+
+Enable plaintext notifications:
+    keybase chat notification-settings --plaintext-mobile
+
+Disable plaintext notifications:
+    keybase chat notification-settings --plaintext-mobile=0
+`,
+		ArgumentHelp: "[options]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatSetNotificationSettingsRunner(g), "notification-settings", c)
+		},
+		Flags: flags,
+	}
+}
+
+func (c *CmdChatSetNotificationSettings) Run() error {
+	if len(c.settings.Settings) > 0 {
+		if err := c.setGlobalAppNotificationSettings(context.TODO()); err != nil {
+			return err
+		}
+	}
+	return c.getGlobalAppNotificationSettings(context.TODO())
+}
+
+func (c *CmdChatSetNotificationSettings) ParseArgv(ctx *cli.Context) (err error) {
+
+	c.settings.Settings = make(map[chat1.GlobalAppNotificationSetting]bool)
+	for _, setting := range chat1.GlobalAppNotificationSettingsSorted() {
+		flagName := setting.FlagName()
+		if ctx.IsSet(flagName) {
+			c.settings.Settings[setting] = ctx.Bool(flagName)
+		}
+	}
+	return nil
+}
+
+func (c *CmdChatSetNotificationSettings) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}
+
+func (c *CmdChatSetNotificationSettings) setGlobalAppNotificationSettings(ctx context.Context) error {
+	lcli, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	strSettings := map[string]bool{}
+	for setting, enabled := range c.settings.Settings {
+		strSettings[strconv.FormatInt(int64(setting), 10)] = enabled
+	}
+	return lcli.SetGlobalAppNotificationSettingsLocal(ctx, strSettings)
+}
+
+func (c *CmdChatSetNotificationSettings) getGlobalAppNotificationSettings(ctx context.Context) error {
+	dui := c.G().UI.GetDumbOutputUI()
+	lcli, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return err
+	}
+	settings, err := lcli.GetGlobalAppNotificationSettingsLocal(ctx)
+	if err != nil {
+		return err
+	}
+	for _, setting := range chat1.GlobalAppNotificationSettingsSorted() {
+		usage := setting.Usage()
+		flagName := setting.FlagName()
+		enabled := settings.Settings[setting]
+		enabledStr := "disabled"
+		if enabled {
+			enabledStr = "enabled"
+		}
+		dui.Printf("%v (%v)\n\t%v\n", flagName, enabledStr, usage)
+	}
+	return nil
+}

--- a/go/client/cmd_chat_notification_settings.go
+++ b/go/client/cmd_chat_notification_settings.go
@@ -1,6 +1,3 @@
-// Copyright 2018 Keybase, Inc. All rights reserved. Use of
-// this source code is governed by the included BSD license.
-
 package client
 
 import (
@@ -27,11 +24,9 @@ func NewCmdChatSetNotificationSettingsRunner(g *libkb.GlobalContext) *CmdChatSet
 func newCmdChatSetNotificationSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	flags := []cli.Flag{}
 	for _, setting := range chat1.GlobalAppNotificationSettingsSorted() {
-		usage := setting.Usage()
-		flagName := setting.FlagName()
 		flags = append(flags, cli.BoolFlag{
-			Name:  flagName,
-			Usage: usage,
+			Name:  setting.FlagName(),
+			Usage: setting.Usage(),
 		})
 	}
 	return cli.Command{
@@ -65,7 +60,6 @@ func (c *CmdChatSetNotificationSettings) Run() error {
 }
 
 func (c *CmdChatSetNotificationSettings) ParseArgv(ctx *cli.Context) (err error) {
-
 	c.settings.Settings = make(map[chat1.GlobalAppNotificationSetting]bool)
 	for _, setting := range chat1.GlobalAppNotificationSettingsSorted() {
 		flagName := setting.FlagName()
@@ -97,7 +91,6 @@ func (c *CmdChatSetNotificationSettings) setGlobalAppNotificationSettings(ctx co
 }
 
 func (c *CmdChatSetNotificationSettings) getGlobalAppNotificationSettings(ctx context.Context) error {
-	dui := c.G().UI.GetDumbOutputUI()
 	lcli, err := GetChatLocalClient(c.G())
 	if err != nil {
 		return err
@@ -106,15 +99,13 @@ func (c *CmdChatSetNotificationSettings) getGlobalAppNotificationSettings(ctx co
 	if err != nil {
 		return err
 	}
+	dui := c.G().UI.GetDumbOutputUI()
 	for _, setting := range chat1.GlobalAppNotificationSettingsSorted() {
-		usage := setting.Usage()
-		flagName := setting.FlagName()
-		enabled := settings.Settings[setting]
 		enabledStr := "disabled"
-		if enabled {
+		if settings.Settings[setting] {
 			enabledStr = "enabled"
 		}
-		dui.Printf("%v (%v)\n\t%v\n", flagName, enabledStr, usage)
+		dui.Printf("%v (%v)\n\t%v\n", setting.FlagName(), enabledStr, setting.Usage())
 	}
 	return nil
 }

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -360,6 +360,7 @@ const (
 	GlobalAppNotificationSetting_PLAINTEXTMOBILE    GlobalAppNotificationSetting = 1
 	GlobalAppNotificationSetting_PLAINTEXTDESKTOP   GlobalAppNotificationSetting = 2
 	GlobalAppNotificationSetting_DEFAULTSOUNDMOBILE GlobalAppNotificationSetting = 3
+	GlobalAppNotificationSetting_DISABLETYPING      GlobalAppNotificationSetting = 4
 )
 
 func (o GlobalAppNotificationSetting) DeepCopy() GlobalAppNotificationSetting { return o }
@@ -369,6 +370,7 @@ var GlobalAppNotificationSettingMap = map[string]GlobalAppNotificationSetting{
 	"PLAINTEXTMOBILE":    1,
 	"PLAINTEXTDESKTOP":   2,
 	"DEFAULTSOUNDMOBILE": 3,
+	"DISABLETYPING":      4,
 }
 
 var GlobalAppNotificationSettingRevMap = map[GlobalAppNotificationSetting]string{
@@ -376,6 +378,7 @@ var GlobalAppNotificationSettingRevMap = map[GlobalAppNotificationSetting]string
 	1: "PLAINTEXTMOBILE",
 	2: "PLAINTEXTDESKTOP",
 	3: "DEFAULTSOUNDMOBILE",
+	4: "DISABLETYPING",
 }
 
 func (e GlobalAppNotificationSetting) String() string {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -2041,3 +2041,47 @@ func NewUnfurlSettings() UnfurlSettings {
 		Whitelist: make(map[string]bool),
 	}
 }
+
+func GlobalAppNotificationSettingsSorted() (res []GlobalAppNotificationSetting) {
+	for setting := range GlobalAppNotificationSettingRevMap {
+		if setting.Usage() != "" && setting.FlagName() != "" {
+			res = append(res, setting)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool {
+		return res[i] < res[j]
+	})
+	return res
+}
+
+// Add to `Usage`/`FlagName` for a setting to be usable in the CLI via
+// `keybase notification-settings`
+func (g GlobalAppNotificationSetting) Usage() string {
+	switch g {
+	case GlobalAppNotificationSetting_NEWMESSAGES:
+		return "Show notifications for new messages"
+	case GlobalAppNotificationSetting_PLAINTEXTMOBILE:
+		return "Show plaintext notifications on mobile devices"
+	case GlobalAppNotificationSetting_DEFAULTSOUNDMOBILE:
+		return "Use the default system sound on mobile devices"
+	case GlobalAppNotificationSetting_DISABLETYPING:
+		return "Disable sending/receiving typing notifications"
+	default:
+		return ""
+	}
+}
+
+func (g GlobalAppNotificationSetting) FlagName() string {
+	switch g {
+	case GlobalAppNotificationSetting_NEWMESSAGES:
+		return "new-messages"
+	case GlobalAppNotificationSetting_PLAINTEXTMOBILE:
+		return "plaintext-mobile"
+	case GlobalAppNotificationSetting_DEFAULTSOUNDMOBILE:
+		return "default-sound-mobile"
+	case GlobalAppNotificationSetting_DISABLETYPING:
+		return "disable-typing"
+	default:
+		return ""
+	}
+}

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -81,12 +81,13 @@
     ATMENTION_1
   }
 
-  // Global notification settings (on by default)
+  // Global notification settings
   enum GlobalAppNotificationSetting {
     NEWMESSAGES_0,
     PLAINTEXTMOBILE_1,
     PLAINTEXTDESKTOP_2,
-    DEFAULTSOUNDMOBILE_3
+    DEFAULTSOUNDMOBILE_3,
+    DISABLETYPING_4
   }
   record GlobalAppNotificationSettings {
     map<GlobalAppNotificationSetting, bool> settings;

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -186,7 +186,8 @@
         "NEWMESSAGES_0",
         "PLAINTEXTMOBILE_1",
         "PLAINTEXTDESKTOP_2",
-        "DEFAULTSOUNDMOBILE_3"
+        "DEFAULTSOUNDMOBILE_3",
+        "DISABLETYPING_4"
       ]
     },
     {

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -284,6 +284,13 @@ function* refreshNotifications() {
           `${ChatTypes.commonGlobalAppNotificationSetting.plaintextmobile}`
         ],
       },
+      {
+        description: 'Disable sending/receiving typing notifications',
+        name: 'disabletyping',
+        subscribed: !!chatGlobalSettings.settings[
+          `${ChatTypes.commonGlobalAppNotificationSetting.disabletyping}`
+        ],
+      },
       ...(isAndroidNewerThanN
         ? []
         : [

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -79,6 +79,7 @@ export const commonGlobalAppNotificationSetting = {
   plaintextmobile: 1,
   plaintextdesktop: 2,
   defaultsoundmobile: 3,
+  disabletyping: 4,
 }
 
 export const commonInboxResType = {

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -439,6 +439,7 @@ export const commonGlobalAppNotificationSetting = {
   plaintextmobile: 1,
   plaintextdesktop: 2,
   defaultsoundmobile: 3,
+  disabletyping: 4,
 }
 
 export const commonInboxResType = {
@@ -853,6 +854,7 @@ export type GlobalAppNotificationSetting =
   | 1 // PLAINTEXTMOBILE_1
   | 2 // PLAINTEXTDESKTOP_2
   | 3 // DEFAULTSOUNDMOBILE_3
+  | 4 // DISABLETYPING_4
 
 export type GlobalAppNotificationSettings = $ReadOnly<{settings: {[key: string]: Bool}}>
 export type Hash = Bytes

--- a/shared/settings/notifications/render.js
+++ b/shared/settings/notifications/render.js
@@ -122,7 +122,7 @@ const Notifications = (props: Props) =>
               style={{marginRight: 0, marginTop: globalMargins.tiny}}
               onCheck={props.onToggleSound}
               checked={!!props.sound}
-              label="Desktop Chat Notification Sound"
+              label="Desktop chat notification sound"
             />
           </Box>
         </Box>


### PR DESCRIPTION
depends on https://github.com/keybase/keybase/pull/3377 for server side support.

- adds cli get/set support go global app settings
- adds disabletyping setting
- updates ui:
![screen shot 2019-01-23 at 5 37 36 pm](https://user-images.githubusercontent.com/1144020/51641970-c75d0280-1f35-11e9-8f61-20bafb502c1e.png)

in action:
```
$ keybase chat notification-settings --help
NAME:
   keybase chat notification-settings - Manage personal notification settings

USAGE:
   keybase chat notification-settings [command options] [options]

OPTIONS:
   --new-messages               Show notifications for new messages
   --plaintext-mobile           Show plaintext notifications on mobile devices
   --default-sound-mobile       Use the default system sound on mobile devices
   --disable-typing             Disable sending/receiving typing notifications
   
EXAMPLES:
   View the current settings:
       keybase chat notification-settings
   
   Enable plaintext notifications:
       keybase chat notification-settings --plaintext-mobile
   
   Disable plaintext notifications:
       keybase chat notification-settings --plaintext-mobile=0

$ keybase chat notification-settings --disable-typing
new-messages (enabled)
        Show notifications for new messages
plaintext-mobile (disabled)
        Show plaintext notifications on mobile devices
default-sound-mobile (disabled)
        Use the default system sound on mobile devices
disable-typing (enabled)
        Disable sending/receiving typing notifications

$ keybase chat notification-settings --disable-typing=0
new-messages (enabled)
        Show notifications for new messages
plaintext-mobile (disabled)
        Show plaintext notifications on mobile devices
default-sound-mobile (disabled)
        Use the default system sound on mobile devices
disable-typing (disabled)
        Disable sending/receiving typing notifications
```
