### PR TITLE
Add back button to Reload screens on mobile

### DIFF
--- a/shared/common-adapters/reload.js
+++ b/shared/common-adapters/reload.js
@@ -16,7 +16,7 @@ type ReloadProps = {|
   reason: string,
 |}
 
-class _Reload extends React.PureComponent<ReloadProps, {expanded: boolean}> {
+class Reload extends React.PureComponent<ReloadProps, {expanded: boolean}> {
   state = {expanded: false}
   _toggle = () => this.setState(p => ({expanded: !p.expanded}))
   render() {
@@ -41,7 +41,7 @@ class _Reload extends React.PureComponent<ReloadProps, {expanded: boolean}> {
   }
 }
 
-const Reload = HeaderHoc(_Reload)
+const ReloadWithHeader = HeaderHoc(Reload)
 
 export type Props = {|
   children: React.Node,
@@ -58,10 +58,17 @@ class Reloadable extends React.PureComponent<Props> {
   }
 
   render() {
-    return this.props.needsReload ? (
-      <Reload onBack={this.props.onBack} onReload={this.props.onReload} reason={this.props.reason} />
+    if (!this.props.needsReload) {
+      return this.props.children
+    }
+    return this.props.onBack ? (
+      <ReloadWithHeader
+        onBack={this.props.onBack}
+        onReload={this.props.onReload}
+        reason={this.props.reason}
+      />
     ) : (
-      this.props.children
+      <Reload onReload={this.props.onReload} reason={this.props.reason} />
     )
   }
 }

--- a/shared/common-adapters/reload.js
+++ b/shared/common-adapters/reload.js
@@ -14,6 +14,7 @@ type ReloadProps = {|
   onBack?: () => void,
   onReload: () => void,
   reason: string,
+  title?: string,
 |}
 
 class Reload extends React.PureComponent<ReloadProps, {expanded: boolean}> {
@@ -50,6 +51,7 @@ export type Props = {|
   onReload: () => void,
   reason: string,
   reloadOnMount?: boolean,
+  title?: string,
 |}
 
 class Reloadable extends React.PureComponent<Props> {
@@ -66,6 +68,7 @@ class Reloadable extends React.PureComponent<Props> {
         onBack={this.props.onBack}
         onReload={this.props.onReload}
         reason={this.props.reason}
+        title={this.props.title}
       />
     ) : (
       <Reload onReload={this.props.onReload} reason={this.props.reason} />
@@ -115,6 +118,7 @@ export type OwnProps = {|
   onBack?: () => void,
   onReload: () => void,
   reloadOnMount?: boolean,
+  title?: string,
   waitingKeys: string | Array<string>,
 |}
 
@@ -133,6 +137,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   onReload: ownProps.onReload,
   reason: stateProps.reason,
   reloadOnMount: ownProps.reloadOnMount,
+  title: ownProps.title,
 })
 
 export default namedConnect<OwnProps, _, _, _, _>(

--- a/shared/common-adapters/reload.stories.js
+++ b/shared/common-adapters/reload.stories.js
@@ -9,9 +9,11 @@ const provider = Sb.createPropProviderWithCommon({
   Reloadable: p => ({
     children: p.children,
     needsReload: p.needsReload,
+    onBack: p.onBack,
     onReload: p.onReload,
     reason: p.reason,
     reloadOnMount: p.reloadOnMount,
+    title: p.title,
   }),
 })
 
@@ -47,6 +49,18 @@ const load = () => {
     .add('Reload long', () => (
       // $FlowIssue need that helper thats not merged yet
       <Reloadable {...props} needsReload={true} reason={longReason}>
+        <Child />
+      </Reloadable>
+    ))
+    .add('Reload with back', () => (
+      // $FlowIssue need that helper thats not merged yet
+      <Reloadable
+        {...props}
+        onBack={Sb.action('onBack')}
+        needsReload={true}
+        reason={longReason}
+        title="Title"
+      >
         <Child />
       </Reloadable>
     ))

--- a/shared/devices/container.js
+++ b/shared/devices/container.js
@@ -7,7 +7,7 @@ import * as RouteTreeGen from '../actions/route-tree-gen'
 import * as Constants from '../constants/devices'
 import * as I from 'immutable'
 import * as Kb from '../common-adapters'
-import {compose, namedConnect, safeSubmitPerMount} from '../util/container'
+import {compose, isMobile, namedConnect, safeSubmitPerMount} from '../util/container'
 import {partition} from 'lodash-es'
 
 const mapStateToProps = state => ({
@@ -65,6 +65,7 @@ class ReloadableDevices extends React.PureComponent<React.ElementConfig<typeof D
   render() {
     return (
       <Kb.Reloadable
+        onBack={isMobile ? this.props.onBack : undefined}
         waitingKeys={Constants.waitingKey}
         onReload={this.props.loadDevices}
         reloadOnMount={true}

--- a/shared/devices/container.js
+++ b/shared/devices/container.js
@@ -69,6 +69,7 @@ class ReloadableDevices extends React.PureComponent<React.ElementConfig<typeof D
         waitingKeys={Constants.waitingKey}
         onReload={this.props.loadDevices}
         reloadOnMount={true}
+        title={this.props.title}
       >
         <Devices
           _stateOverride={this.props._stateOverride}

--- a/shared/git/container.js
+++ b/shared/git/container.js
@@ -6,7 +6,7 @@ import * as GitGen from '../actions/git-gen'
 import * as Constants from '../constants/git'
 import * as Kb from '../common-adapters'
 import {anyWaiting} from '../constants/waiting'
-import {compose, connect, type RouteProps} from '../util/container'
+import {compose, connect, isMobile, type RouteProps} from '../util/container'
 import {sortBy, partition} from 'lodash-es'
 
 type OwnProps = RouteProps<{}, {expandedSet: I.Set<string>}>
@@ -67,6 +67,7 @@ class GitReloadable extends React.PureComponent<{
     return (
       <Kb.Reloadable
         waitingKeys={Constants.loadingWaitingKey}
+        onBack={isMobile ? this.props.onBack : undefined}
         onReload={this.props._loadGit}
         reloadOnMount={true}
       >

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -9,7 +9,7 @@ import * as TeamsGen from '../actions/teams-gen'
 import Teams from './main'
 import openURL from '../util/open-url'
 import * as RouteTreeGen from '../actions/route-tree-gen'
-import {compose, lifecycle, connect, type RouteProps} from '../util/container'
+import {compose, isMobile, lifecycle, connect, type RouteProps} from '../util/container'
 import * as Constants from '../constants/teams'
 import * as WaitingConstants from '../constants/waiting'
 import {type Teamname} from '../constants/types/teams'
@@ -82,6 +82,7 @@ class Reloadable extends React.PureComponent<{
     return (
       <Kb.Reloadable
         waitingKeys={Constants.teamsLoadedWaitingKey}
+        onBack={isMobile ? this.props.onBack : undefined}
         onReload={this.props._loadTeams}
         reloadOnMount={true}
       >

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -85,6 +85,7 @@ class Reloadable extends React.PureComponent<{
         onBack={isMobile ? this.props.onBack : undefined}
         onReload={this.props._loadTeams}
         reloadOnMount={true}
+        title={this.props.title}
       >
         <Teams
           loaded={this.props.loaded}


### PR DESCRIPTION
...for screens that are children of the Settings tab.

Also add and use the title property.

Don't use HeaderHOC for Reloadable if there is no onBack, so as to avoid showing
a header divider.