### PR TITLE
user_history: add logging

### DIFF
--- a/go/kbfs/kbfsedits/user_history.go
+++ b/go/kbfs/kbfsedits/user_history.go
@@ -5,12 +5,14 @@
 package kbfsedits
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -36,12 +38,14 @@ type tlfKey struct {
 type UserHistory struct {
 	lock      sync.RWMutex
 	histories map[tlfKey]writersByRevision
+	log       logger.Logger
 }
 
 // NewUserHistory constructs a UserHistory instance.
-func NewUserHistory() *UserHistory {
+func NewUserHistory(log logger.Logger) *UserHistory {
 	return &UserHistory{
 		histories: make(map[tlfKey]writersByRevision),
+		log:       log,
 	}
 }
 
@@ -50,6 +54,8 @@ func NewUserHistory() *UserHistory {
 func (uh *UserHistory) UpdateHistory(
 	tlfName tlf.CanonicalName, tlfType tlf.Type, tlfHistory *TlfHistory,
 	loggedInUser string) {
+	uh.log.CDebugf(context.Background(), "Updating user history for TLF %s, "+
+		"user %s", tlfName, loggedInUser)
 	history := tlfHistory.getHistory(loggedInUser)
 	key := tlfKey{tlfName, tlfType}
 
@@ -134,7 +140,7 @@ func (uh *UserHistory) Get(loggedInUser string) (
 	history []keybase1.FSFolderEditHistory) {
 	uh.lock.RLock()
 	defer uh.lock.RUnlock()
-
+	uh.log.CDebugf(context.Background(), "User history requested: %s", loggedInUser)
 	var clusters historyClusters
 	for key := range uh.histories {
 		history := uh.getTlfHistoryLocked(key.tlfName, key.tlfType)
@@ -166,7 +172,8 @@ func (uh *UserHistory) Get(loggedInUser string) (
 		}
 	}
 
-	// We need to sort these by clusters, not by the full TLF time.
+	// We need to sort these by the ServerTime of these particular edits,
+	// not by the full TLF time.
 	sort.Sort(clusters)
 
 	// TODO: consolidate neighboring clusters that share the same folder?

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -446,7 +446,7 @@ func NewConfigLocal(mode InitMode,
 	config.ResetCaches()
 	config.SetKeyOps(&KeyOpsStandard{config})
 	config.SetRekeyQueue(NewRekeyQueueStandard(config))
-	config.SetUserHistory(kbfsedits.NewUserHistory())
+	config.SetUserHistory(kbfsedits.NewUserHistory(config.MakeLogger("HIS")))
 
 	config.maxNameBytes = maxNameBytesDefault
 	config.rwpWaitTime = rekeyWithPromptWaitTimeDefault

--- a/go/kbfs/libkbfs/config_mock_test.go
+++ b/go/kbfs/libkbfs/config_mock_test.go
@@ -123,7 +123,7 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	config.SetClock(config.mockClock)
 	config.mockRekeyQueue = NewMockRekeyQueue(c)
 	config.SetRekeyQueue(config.mockRekeyQueue)
-	config.SetUserHistory(kbfsedits.NewUserHistory())
+	config.SetUserHistory(kbfsedits.NewUserHistory(config.MakeLogger("HIS")))
 	config.observer = &FakeObserver{}
 	config.ctr = ctr
 	// turn off background flushing by default during tests


### PR DESCRIPTION
Add logging to UserHistory object so as to better debug a test flake.
Issue: KBFS-3759