### PR TITLE
config_local: use `DiskBlockCache.GetPrefetchStatus` instead

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1703,7 +1703,7 @@ func (c *ConfigLocal) PrefetchStatus(ctx context.Context, tlfID tlf.ID,
 		return bops.queue.getPrefetchStatus(ptr.ID)
 	}
 
-	_, _, prefetchStatus, err := dbc.Get(
+	prefetchStatus, err := dbc.GetPrefetchStatus(
 		ctx, tlfID, ptr.ID, DiskBlockAnyCache)
 	if err != nil {
 		return NoPrefetch

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -745,6 +745,10 @@ func (cache *DiskBlockCacheLocal) GetMetadata(ctx context.Context,
 	blockID kbfsblock.ID) (DiskBlockCacheMetadata, error) {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
+	err := cache.checkCacheLocked("Block(GetMetadata)")
+	if err != nil {
+		return DiskBlockCacheMetadata{}, err
+	}
 	return cache.getMetadataLocked(blockID, false)
 }
 


### PR DESCRIPTION
Instead of getting the full block and throwing it away.