### PR TITLE
don't let chat inline sends wrap lines

### DIFF
--- a/shared/chat/payments/status/index.js
+++ b/shared/chat/payments/status/index.js
@@ -121,7 +121,7 @@ const styles = Styles.styleSheetCreate({
   },
   container: Styles.platformStyles({
     isElectron: {
-      display: 'inline',
+      display: 'inline-block',
     },
   }),
   error: {


### PR DESCRIPTION
Fixes the payment status popup being way off sometimes. r? @keybase/react-hackers cc @mmaxim 