### PR TITLE
vendor: update go-git to fix corrupt ref issue

### DIFF
--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -2054,11 +2054,11 @@
 			"revisionTime": "2018-10-12T20:00:37Z"
 		},
 		{
-			"checksumSHA1": "kqdRKFSqBAPJ7/+E6IBgV0J3vJ8=",
+			"checksumSHA1": "Zwp4Lp8/UNY4VHiETCIFCYzcLA8=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit",
-			"revision": "2e89fc61e599832d99af61b8ada501fa436e3932",
-			"revisionTime": "2018-10-12T20:00:37Z"
+			"revision": "6cefa0af82e8fbea04ecc95531983ba4314ced44",
+			"revisionTime": "2019-01-24T21:46:07Z"
 		},
 		{
 			"checksumSHA1": "/ZSEKNlCQavBBy9cytcG4sxIWn0=",


### PR DESCRIPTION
A user hit the following scenario:
* Started pushing a new git branch.
* Wrote all git objects successfully to the journal.
* Open the ref filename with O_CREATE, creating the file in the local journal.
* Attempt to take the lock on the file.
* A flaky network failed the Lock command (or possibly the later Close/Unlock command), causing the `setRef` call to return an error.
* This fails that one specific ref push, but git has independent errors for each ref, so it doesn't fail the whole git operation.
* The kbfsgit runner then tries to sync the whole journal, and succeeds eventually, which pushes the still-empty ref file to the main repo.
* Later when the user tries to pull from the repo, they see an error:

```
fatal: bad object 0000000000000000000000000000000000000000
error: keybase://team/teamname/reponame did not send all necessary objects
```

This fix in the go-git repo attempts to prevent this from happening by reverting files in the local journal to their original state if the `setRef` operation fails.  In the example above, it would have meant that the ref file was deleted and never pushed to the server (though all the object files still would have been synced correctly).  (The fix was already reviewed by taruti in keybase/go-git#25.)

Issue: KBFS-3703