### PR TITLE
disk_block_cache: introduce a new disk cache type for CR

### DIFF
--- a/go/kbfs/libkbfs/disk_limiter.go
+++ b/go/kbfs/libkbfs/disk_limiter.go
@@ -22,6 +22,7 @@ const (
 	journalLimitTrackerType
 	workingSetCacheLimitTrackerType
 	syncCacheLimitTrackerType
+	crDirtyBlockCacheLimitTrackerType // allow unlimited bytes for CR
 )
 
 // simpleResourceTracker is an interface for limiting a single resource type.


### PR DESCRIPTION
During CR, we shouldn't do any limiting based on disk space.  If we don't have enough space, we'll just have to fail.

Issue: KBFS-3679