### PR TITLE
conflict_resolver: be ok with corrupted DB

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -146,7 +146,7 @@ type ConfigLocal struct {
 	blockCryptVersion kbfscrypto.EncryptionVer
 
 	// conflictResolutionDB stores information about failed CRs
-	conflictResolutionDB *leveldb.DB
+	conflictResolutionDB *levelDb
 
 	mode InitMode
 
@@ -1717,7 +1717,7 @@ func (c *ConfigLocal) GetRekeyFSMLimiter() *OngoingWorkLimiter {
 }
 
 // GetConflictResolutionDB implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) GetConflictResolutionDB() (db *leveldb.DB) {
+func (c *ConfigLocal) GetConflictResolutionDB() (db *levelDb) {
 	return c.conflictResolutionDB
 }
 

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -146,7 +146,7 @@ type ConfigLocal struct {
 	blockCryptVersion kbfscrypto.EncryptionVer
 
 	// conflictResolutionDB stores information about failed CRs
-	conflictResolutionDB *levelDb
+	conflictResolutionDB *LevelDb
 
 	mode InitMode
 
@@ -1529,7 +1529,7 @@ func (c *ConfigLocal) MakeBlockMetadataStoreIfNotExists() (err error) {
 	return nil
 }
 
-func (c *ConfigLocal) openConfigLevelDB(configName string) (*levelDb, error) {
+func (c *ConfigLocal) openConfigLevelDB(configName string) (*LevelDb, error) {
 	dbPath := filepath.Join(c.storageRoot, configName)
 	stor, err := storage.OpenFile(dbPath, false)
 	if err != nil {
@@ -1717,7 +1717,7 @@ func (c *ConfigLocal) GetRekeyFSMLimiter() *OngoingWorkLimiter {
 }
 
 // GetConflictResolutionDB implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) GetConflictResolutionDB() (db *levelDb) {
+func (c *ConfigLocal) GetConflictResolutionDB() (db *LevelDb) {
 	return c.conflictResolutionDB
 }
 

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3215,7 +3215,7 @@ type conflictRecord struct {
 	codec.UnknownFieldSetHandler `json:"-"`
 }
 
-func getAndDeserializeConflicts(config Config, db *levelDb,
+func getAndDeserializeConflicts(config Config, db *LevelDb,
 	key []byte) ([]conflictRecord, error) {
 	conflictsSoFarSerialized, err := db.Get(key, nil)
 	var conflictsSoFar []conflictRecord
@@ -3233,7 +3233,7 @@ func getAndDeserializeConflicts(config Config, db *levelDb,
 	return conflictsSoFar, nil
 }
 
-func serializeAndPutConflicts(config Config, db *levelDb,
+func serializeAndPutConflicts(config Config, db *LevelDb,
 	key []byte, conflicts []conflictRecord) error {
 	conflictsSerialized, err := config.Codec().Encode(conflicts)
 	if err != nil {
@@ -3591,7 +3591,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	// to clean up the quota anyway . . .)
 }
 
-func openCRDBInternal(config Config) (*levelDb, error) {
+func openCRDBInternal(config Config) (*LevelDb, error) {
 	if config.IsTestMode() {
 		return openLevelDBWithOptions(storage.NewMemStorage(), leveldbOptions)
 	}
@@ -3613,7 +3613,7 @@ func openCRDBInternal(config Config) (*levelDb, error) {
 	return openLevelDBWithOptions(stor, leveldbOptions)
 }
 
-func openCRDB(config Config) (db *levelDb) {
+func openCRDB(config Config) (db *LevelDb) {
 	db, err := openCRDBInternal(config)
 	if err != nil {
 		panic(fmt.Sprintf("Could not open conflict resolver DB: %v", err))

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -85,10 +85,10 @@ type DiskBlockCacheLocal struct {
 	// Protect the disk caches from being shutdown while they're being
 	// accessed, and mutable data.
 	lock        sync.RWMutex
-	blockDb     *levelDb
-	metaDb      *levelDb
-	tlfDb       *levelDb
-	lastUnrefDb *levelDb
+	blockDb     *LevelDb
+	metaDb      *LevelDb
+	tlfDb       *LevelDb
+	lastUnrefDb *LevelDb
 	cacheType   diskLimitTrackerType
 	// Track the number of blocks in the cache per TLF and overall.
 	tlfCounts map[tlf.ID]int

--- a/go/kbfs/libkbfs/disk_block_metadata_store.go
+++ b/go/kbfs/libkbfs/disk_block_metadata_store.go
@@ -55,7 +55,7 @@ type diskBlockMetadataStore struct {
 	putMeter  *CountMeter
 
 	lock       sync.RWMutex
-	db         *levelDb
+	db         *LevelDb
 	shutdownCh chan struct{}
 }
 

--- a/go/kbfs/libkbfs/disk_md_cache.go
+++ b/go/kbfs/libkbfs/disk_md_cache.go
@@ -56,7 +56,7 @@ type DiskMDCacheLocal struct {
 	// Protect the disk caches from being shutdown while they're being
 	// accessed, and mutable data.
 	lock       sync.RWMutex
-	headsDb    *levelDb // tlfID -> metadata block
+	headsDb    *LevelDb // tlfID -> metadata block
 	tlfsCached map[tlf.ID]kbfsmd.Revision
 	tlfsStaged map[tlf.ID][]diskMDBlock
 

--- a/go/kbfs/libkbfs/disk_quota_cache.go
+++ b/go/kbfs/libkbfs/disk_quota_cache.go
@@ -46,7 +46,7 @@ type DiskQuotaCacheLocal struct {
 	// Protect the disk caches from being shutdown while they're being
 	// accessed, and mutable data.
 	lock         sync.RWMutex
-	db           *levelDb // id -> quota info
+	db           *LevelDb // id -> quota info
 	quotasCached map[keybase1.UserOrTeamID]bool
 
 	startedCh  chan struct{}

--- a/go/kbfs/libkbfs/favorites.go
+++ b/go/kbfs/libkbfs/favorites.go
@@ -97,7 +97,7 @@ type Favorites struct {
 	cache           map[Favorite]bool
 	cacheExpireTime time.Time
 
-	diskCache *levelDb
+	diskCache *LevelDb
 
 	inFlightLock sync.Mutex
 	inFlightAdds map[favToAdd]*favReq
@@ -147,7 +147,7 @@ type favoritesCacheEncryptedForDisk struct {
 
 func (f *Favorites) readCacheFromDisk(ctx context.Context) error {
 	// Read the encrypted cache from disk
-	var db *levelDb
+	var db *LevelDb
 	var err error
 	if f.config.IsTestMode() {
 		db, err = openLevelDB(storage.NewMemStorage())
@@ -228,7 +228,7 @@ func (f *Favorites) writeCacheToDisk(ctx context.Context) error {
 	}
 
 	// Encode the encrypted data in a versioned struct before writing it to
-	// the levelDb.
+	// the LevelDb.
 	cacheEncryptedForDisk := favoritesCacheEncryptedForDisk{
 		encryptedCache: data,
 		version:        favoritesDiskCacheStorageVersion,

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2414,7 +2414,7 @@ type Config interface {
 	SetDefaultBlockType(blockType keybase1.BlockType)
 	// GetConflictResolutionDB gets the levelDB in which conflict resolution
 	// status is stored.
-	GetConflictResolutionDB() (db *levelDb)
+	GetConflictResolutionDB() (db *LevelDb)
 	RekeyQueue() RekeyQueue
 	SetRekeyQueue(RekeyQueue)
 	// ReqsBufSize indicates the number of read or write operations

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -18,7 +18,6 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	metrics "github.com/rcrowley/go-metrics"
-	"github.com/syndtr/goleveldb/leveldb"
 	"golang.org/x/net/context"
 	billy "gopkg.in/src-d/go-billy.v4"
 )
@@ -2415,7 +2414,7 @@ type Config interface {
 	SetDefaultBlockType(blockType keybase1.BlockType)
 	// GetConflictResolutionDB gets the levelDB in which conflict resolution
 	// status is stored.
-	GetConflictResolutionDB() (db *leveldb.DB)
+	GetConflictResolutionDB() (db *levelDb)
 	RekeyQueue() RekeyQueue
 	SetRekeyQueue(RekeyQueue)
 	// ReqsBufSize indicates the number of read or write operations

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -9992,10 +9992,10 @@ func (mr *MockConfigMockRecorder) SetDefaultBlockType(blockType interface{}) *go
 }
 
 // GetConflictResolutionDB mocks base method
-func (m *MockConfig) GetConflictResolutionDB() *levelDb {
+func (m *MockConfig) GetConflictResolutionDB() *LevelDb {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConflictResolutionDB")
-	ret0, _ := ret[0].(*levelDb)
+	ret0, _ := ret[0].(*LevelDb)
 	return ret0
 }
 

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -17,7 +17,6 @@ import (
 	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	go_metrics "github.com/rcrowley/go-metrics"
-	leveldb "github.com/syndtr/goleveldb/leveldb"
 	context "golang.org/x/net/context"
 	go_billy_v4 "gopkg.in/src-d/go-billy.v4"
 	reflect "reflect"
@@ -2238,20 +2237,6 @@ func (m *MockKBFSOps) GetNodeMetadata(ctx context.Context, node Node) (NodeMetad
 func (mr *MockKBFSOpsMockRecorder) GetNodeMetadata(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeMetadata", reflect.TypeOf((*MockKBFSOps)(nil).GetNodeMetadata), ctx, node)
-}
-
-// GetConflictResolutionDB mocks base method
-func (m *MockKBFSOps) GetConflictResolutionDB() *leveldb.DB {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConflictResolutionDB")
-	ret0, _ := ret[0].(*leveldb.DB)
-	return ret0
-}
-
-// GetConflictResolutionDB indicates an expected call of GetConflictResolutionDB
-func (mr *MockKBFSOpsMockRecorder) GetConflictResolutionDB() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConflictResolutionDB", reflect.TypeOf((*MockKBFSOps)(nil).GetConflictResolutionDB))
 }
 
 // Shutdown mocks base method
@@ -6515,6 +6500,7 @@ func (mr *MockPrefetcherMockRecorder) WaitChannelForBlockPrefetch(ctx, ptr inter
 
 // Status mocks base method
 func (m *MockPrefetcher) Status(ctx context.Context, ptr BlockPointer) (PrefetchProgress, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status", ctx, ptr)
 	ret0, _ := ret[0].(PrefetchProgress)
 	ret1, _ := ret[1].(error)
@@ -6523,6 +6509,7 @@ func (m *MockPrefetcher) Status(ctx context.Context, ptr BlockPointer) (Prefetch
 
 // Status indicates an expected call of Status
 func (mr *MockPrefetcherMockRecorder) Status(ctx, ptr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockPrefetcher)(nil).Status), ctx, ptr)
 }
 
@@ -10005,10 +9992,10 @@ func (mr *MockConfigMockRecorder) SetDefaultBlockType(blockType interface{}) *go
 }
 
 // GetConflictResolutionDB mocks base method
-func (m *MockConfig) GetConflictResolutionDB() *leveldb.DB {
+func (m *MockConfig) GetConflictResolutionDB() *levelDb {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConflictResolutionDB")
-	ret0, _ := ret[0].(*leveldb.DB)
+	ret0, _ := ret[0].(*levelDb)
 	return ret0
 }
 


### PR DESCRIPTION
Previously, if KBFS shut down uncleanly, it would panic on startup because of a
corrupted levelDb.

This PR switches to using existing KBFS helper methods to interact with levelDB, and thus trying to recover the DB if opening it doesn't work.