### PR TITLE
disk_block_put_state: a disk-based way to store ready block data

### DIFF
--- a/go/kbfs/libkbfs/block_put_state_disk.go
+++ b/go/kbfs/libkbfs/block_put_state_disk.go
@@ -1,0 +1,117 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+)
+
+type blockPutStateDiskConfig interface {
+	codecGetter
+	cryptoPureGetter
+	keyGetterGetter
+}
+
+// blockPutStateDisk tracks block info while making a revision, by
+// using a disk-based block cache.
+type blockPutStateDisk struct {
+	*blockPutStateMemory // won't store actual block data
+
+	config    blockPutStateDiskConfig
+	diskCache *DiskBlockCacheLocal
+	kmd       KeyMetadata
+	isDir     map[BlockPointer]bool
+}
+
+var _ blockPutState = (*blockPutStateDisk)(nil)
+
+func newBlockPutStateDisk(
+	length int, config blockPutStateDiskConfig,
+	diskCache *DiskBlockCacheLocal, kmd KeyMetadata) *blockPutStateDisk {
+	return &blockPutStateDisk{
+		blockPutStateMemory: newBlockPutStateMemory(length),
+		config:              config,
+		diskCache:           diskCache,
+		kmd:                 kmd,
+		isDir:               make(map[BlockPointer]bool),
+	}
+}
+
+// addNewBlock implements the blockPutState interface for blockPutStateDisk.
+func (bps *blockPutStateDisk) addNewBlock(
+	ctx context.Context, blockPtr BlockPointer, block Block,
+	readyBlockData ReadyBlockData, syncedCb func() error) error {
+	// Add the pointer and the cb to the memory-based put state, and
+	// put the ready data directly into the disk cache.
+	err := bps.diskCache.Put(
+		ctx, bps.kmd.TlfID(), blockPtr.ID, readyBlockData.buf,
+		readyBlockData.serverHalf)
+	if err != nil {
+		return err
+	}
+
+	if _, isDir := block.(*DirBlock); isDir {
+		bps.isDir[blockPtr] = true
+	}
+
+	return bps.blockPutStateMemory.addNewBlock(
+		ctx, blockPtr, nil, ReadyBlockData{}, syncedCb)
+}
+
+func (bps *blockPutStateDisk) mergeOtherBps(
+	_ context.Context, other blockPutState) error {
+	panic("unimplemented")
+}
+
+func (bps *blockPutStateDisk) removeOtherBps(
+	ctx context.Context, other blockPutState) error {
+	panic("unimplemented")
+}
+
+func (bps *blockPutStateDisk) getBlock(
+	ctx context.Context, blockPtr BlockPointer) (Block, error) {
+	data, serverHalf, _, err := bps.diskCache.Get(
+		ctx, bps.kmd.TlfID(), blockPtr.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var block Block
+	if bps.isDir[blockPtr] {
+		block = NewDirBlock()
+	} else {
+		block = NewFileBlock()
+	}
+	err = assembleBlock(
+		ctx, bps.config.keyGetter(), bps.config.Codec(),
+		bps.config.cryptoPure(), bps.kmd, blockPtr, block, data, serverHalf)
+	if err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
+func (bps *blockPutStateDisk) getReadyBlockData(
+	ctx context.Context, blockPtr BlockPointer) (ReadyBlockData, error) {
+	data, serverHalf, _, err := bps.diskCache.Get(
+		ctx, bps.kmd.TlfID(), blockPtr.ID)
+	if err != nil {
+		return ReadyBlockData{}, err
+	}
+	return ReadyBlockData{
+		buf:        data,
+		serverHalf: serverHalf,
+	}, nil
+}
+
+func (bps *blockPutStateDisk) deepCopy(
+	_ context.Context) (blockPutState, error) {
+	panic("unimplemented")
+}
+
+func (bps *blockPutStateDisk) deepCopyWithBlacklist(
+	_ context.Context, blacklist map[BlockPointer]bool) (blockPutState, error) {
+	panic("unimplemented")
+}

--- a/go/kbfs/libkbfs/block_put_state_disk.go
+++ b/go/kbfs/libkbfs/block_put_state_disk.go
@@ -60,16 +60,6 @@ func (bps *blockPutStateDisk) addNewBlock(
 		ctx, blockPtr, nil, ReadyBlockData{}, syncedCb)
 }
 
-func (bps *blockPutStateDisk) mergeOtherBps(
-	_ context.Context, other blockPutState) error {
-	panic("unimplemented")
-}
-
-func (bps *blockPutStateDisk) removeOtherBps(
-	ctx context.Context, other blockPutState) error {
-	panic("unimplemented")
-}
-
 func (bps *blockPutStateDisk) getBlock(
 	ctx context.Context, blockPtr BlockPointer) (Block, error) {
 	data, serverHalf, _, err := bps.diskCache.Get(
@@ -104,14 +94,4 @@ func (bps *blockPutStateDisk) getReadyBlockData(
 		buf:        data,
 		serverHalf: serverHalf,
 	}, nil
-}
-
-func (bps *blockPutStateDisk) deepCopy(
-	_ context.Context) (blockPutState, error) {
-	panic("unimplemented")
-}
-
-func (bps *blockPutStateDisk) deepCopyWithBlacklist(
-	_ context.Context, blacklist map[BlockPointer]bool) (blockPutState, error) {
-	panic("unimplemented")
 }

--- a/go/kbfs/libkbfs/block_put_state_memory.go
+++ b/go/kbfs/libkbfs/block_put_state_memory.go
@@ -24,7 +24,7 @@ type blockPutStateMemory struct {
 	lastBlock   BlockPointer
 }
 
-var _ blockPutState = (*blockPutStateMemory)(nil)
+var _ blockPutStateCopiable = (*blockPutStateMemory)(nil)
 
 func newBlockPutStateMemory(length int) *blockPutStateMemory {
 	bps := &blockPutStateMemory{}
@@ -72,7 +72,7 @@ func (bps *blockPutStateMemory) oldPtr(
 }
 
 func (bps *blockPutStateMemory) mergeOtherBps(
-	_ context.Context, other blockPutState) error {
+	_ context.Context, other blockPutStateCopiable) error {
 	otherMem, ok := other.(*blockPutStateMemory)
 	if !ok {
 		return errors.Errorf("Cannot remove other bps of type %T", other)
@@ -85,7 +85,7 @@ func (bps *blockPutStateMemory) mergeOtherBps(
 }
 
 func (bps *blockPutStateMemory) removeOtherBps(
-	ctx context.Context, other blockPutState) error {
+	ctx context.Context, other blockPutStateCopiable) error {
 	otherMem, ok := other.(*blockPutStateMemory)
 	if !ok {
 		return errors.Errorf("Cannot remove other bps of type %T", other)
@@ -154,7 +154,7 @@ func (bps *blockPutStateMemory) numBlocks() int {
 }
 
 func (bps *blockPutStateMemory) deepCopy(
-	_ context.Context) (blockPutState, error) {
+	_ context.Context) (blockPutStateCopiable, error) {
 	newBps := &blockPutStateMemory{}
 	newBps.blockStates = make(map[BlockPointer]blockState, len(bps.blockStates))
 	for ptr, bs := range bps.blockStates {
@@ -164,7 +164,8 @@ func (bps *blockPutStateMemory) deepCopy(
 }
 
 func (bps *blockPutStateMemory) deepCopyWithBlacklist(
-	_ context.Context, blacklist map[BlockPointer]bool) (blockPutState, error) {
+	_ context.Context, blacklist map[BlockPointer]bool) (
+	blockPutStateCopiable, error) {
 	newBps := &blockPutStateMemory{}
 	newLen := len(bps.blockStates) - len(blacklist)
 	if newLen < 0 {

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3123,10 +3123,11 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 		}
 	}
 
-	updates, bps, blocksToDelete, err := cr.prepper.prepUpdateForPaths(
+	bps := newBlockPutStateMemory(0)
+	updates, blocksToDelete, err := cr.prepper.prepUpdateForPaths(
 		ctx, lState, md, unmergedChains, mergedChains,
 		mostRecentUnmergedMD, mostRecentMergedMD, resolvedPaths, lbc,
-		newFileBlocks, dirtyBcache, prepFolderCopyIndirectFileBlocks)
+		newFileBlocks, dirtyBcache, bps, prepFolderCopyIndirectFileBlocks)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -58,14 +58,14 @@ const (
 
 type mdToCleanIfUnused struct {
 	md  ReadOnlyRootMetadata
-	bps blockPutState
+	bps blockPutStateCopiable
 }
 
 type syncInfo struct {
 	oldInfo         BlockInfo
 	op              *syncOp
 	unrefs          []BlockInfo
-	bps             blockPutState
+	bps             blockPutStateCopiable
 	refBytes        uint64
 	unrefBytes      uint64
 	toCleanIfUnused []mdToCleanIfUnused
@@ -2555,7 +2555,7 @@ type fileSyncState struct {
 // entry, dirtyDe will be nil.
 func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 	lState *lockState, md *RootMetadata, file path) (
-	fblock *FileBlock, bps blockPutState, syncState fileSyncState,
+	fblock *FileBlock, bps blockPutStateCopiable, syncState fileSyncState,
 	dirtyDe *DirEntry, err error) {
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
@@ -2769,7 +2769,7 @@ func (fbo *folderBlockOps) mergeDirtyEntryWithLBC(
 //  })
 func (fbo *folderBlockOps) StartSync(ctx context.Context,
 	lState *lockState, md *RootMetadata, file path) (
-	fblock *FileBlock, bps blockPutState, dirtyDe *DirEntry,
+	fblock *FileBlock, bps blockPutStateCopiable, dirtyDe *DirEntry,
 	syncState fileSyncState, err error) {
 	if jServer, err := GetJournalServer(fbo.config); err == nil {
 		jServer.dirtyOpStart(fbo.id())

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5162,7 +5162,7 @@ type cleanupFn func(context.Context, *lockState, []BlockPointer, error)
 func (fbo *folderBranchOps) startSyncLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata, node Node, file path) (
 	doSync, stillDirty bool, fblock *FileBlock, dirtyDe *DirEntry,
-	bps blockPutState, syncState fileSyncState,
+	bps blockPutStateCopiable, syncState fileSyncState,
 	cleanup cleanupFn, err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5560,9 +5560,9 @@ func (fbo *folderBranchOps) syncAllLocked(
 	// Squash the batch of updates together into a set of blocks and
 	// ready `md` for putting to the server.
 	md.AddOp(newResolutionOp())
-	_, newBps, blocksToDelete, err := fbo.prepper.prepUpdateForPaths(
+	_, blocksToDelete, err := fbo.prepper.prepUpdateForPaths(
 		ctx, lState, md, syncChains, dummyHeadChains, tempIRMD, head,
-		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(),
+		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(), bps,
 		prepFolderDontCopyIndirectFileBlocks)
 	if err != nil {
 		return err
@@ -5570,10 +5570,6 @@ func (fbo *folderBranchOps) syncAllLocked(
 	if len(blocksToDelete) > 0 {
 		return errors.Errorf("Unexpectedly found unflushed blocks to delete "+
 			"during syncAllLocked: %v", blocksToDelete)
-	}
-	err = bps.mergeOtherBps(ctx, newBps)
-	if err != nil {
-		return err
 	}
 
 	defer func() {

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2738,22 +2738,31 @@ type Chat interface {
 	ClearCache()
 }
 
+// blockPutState is an interface for keeping track of readied blocks
+// before putting them to the bserver.
 type blockPutState interface {
 	addNewBlock(
 		ctx context.Context, blockPtr BlockPointer, block Block,
 		readyBlockData ReadyBlockData, syncedCb func() error) error
 	saveOldPtr(ctx context.Context, oldPtr BlockPointer) error
 	oldPtr(ctx context.Context, blockPtr BlockPointer) (BlockPointer, error)
-	mergeOtherBps(ctx context.Context, other blockPutState) error
-	removeOtherBps(ctx context.Context, other blockPutState) error
 	ptrs() []BlockPointer
 	getBlock(ctx context.Context, blockPtr BlockPointer) (Block, error)
 	getReadyBlockData(
 		ctx context.Context, blockPtr BlockPointer) (ReadyBlockData, error)
 	synced(blockPtr BlockPointer) error
 	numBlocks() int
-	deepCopy(ctx context.Context) (blockPutState, error)
+}
+
+// blockPutStateCopiable is a more manipulatable interface around
+// `blockPutState`, allowing copying as well as merging/unmerging.
+type blockPutStateCopiable interface {
+	blockPutState
+
+	mergeOtherBps(ctx context.Context, other blockPutStateCopiable) error
+	removeOtherBps(ctx context.Context, other blockPutStateCopiable) error
+	deepCopy(ctx context.Context) (blockPutStateCopiable, error)
 	deepCopyWithBlacklist(
 		ctx context.Context, blacklist map[BlockPointer]bool) (
-		blockPutState, error)
+		blockPutStateCopiable, error)
 }

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -11043,34 +11043,6 @@ func (mr *MockblockPutStateMockRecorder) oldPtr(ctx, blockPtr interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "oldPtr", reflect.TypeOf((*MockblockPutState)(nil).oldPtr), ctx, blockPtr)
 }
 
-// mergeOtherBps mocks base method
-func (m *MockblockPutState) mergeOtherBps(ctx context.Context, other blockPutState) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "mergeOtherBps", ctx, other)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// mergeOtherBps indicates an expected call of mergeOtherBps
-func (mr *MockblockPutStateMockRecorder) mergeOtherBps(ctx, other interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "mergeOtherBps", reflect.TypeOf((*MockblockPutState)(nil).mergeOtherBps), ctx, other)
-}
-
-// removeOtherBps mocks base method
-func (m *MockblockPutState) removeOtherBps(ctx context.Context, other blockPutState) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "removeOtherBps", ctx, other)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// removeOtherBps indicates an expected call of removeOtherBps
-func (mr *MockblockPutStateMockRecorder) removeOtherBps(ctx, other interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeOtherBps", reflect.TypeOf((*MockblockPutState)(nil).removeOtherBps), ctx, other)
-}
-
 // ptrs mocks base method
 func (m *MockblockPutState) ptrs() []BlockPointer {
 	m.ctrl.T.Helper()
@@ -11143,32 +11115,198 @@ func (mr *MockblockPutStateMockRecorder) numBlocks() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "numBlocks", reflect.TypeOf((*MockblockPutState)(nil).numBlocks))
 }
 
+// MockblockPutStateCopiable is a mock of blockPutStateCopiable interface
+type MockblockPutStateCopiable struct {
+	ctrl     *gomock.Controller
+	recorder *MockblockPutStateCopiableMockRecorder
+}
+
+// MockblockPutStateCopiableMockRecorder is the mock recorder for MockblockPutStateCopiable
+type MockblockPutStateCopiableMockRecorder struct {
+	mock *MockblockPutStateCopiable
+}
+
+// NewMockblockPutStateCopiable creates a new mock instance
+func NewMockblockPutStateCopiable(ctrl *gomock.Controller) *MockblockPutStateCopiable {
+	mock := &MockblockPutStateCopiable{ctrl: ctrl}
+	mock.recorder = &MockblockPutStateCopiableMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockblockPutStateCopiable) EXPECT() *MockblockPutStateCopiableMockRecorder {
+	return m.recorder
+}
+
+// addNewBlock mocks base method
+func (m *MockblockPutStateCopiable) addNewBlock(ctx context.Context, blockPtr BlockPointer, block Block, readyBlockData ReadyBlockData, syncedCb func() error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "addNewBlock", ctx, blockPtr, block, readyBlockData, syncedCb)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// addNewBlock indicates an expected call of addNewBlock
+func (mr *MockblockPutStateCopiableMockRecorder) addNewBlock(ctx, blockPtr, block, readyBlockData, syncedCb interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addNewBlock", reflect.TypeOf((*MockblockPutStateCopiable)(nil).addNewBlock), ctx, blockPtr, block, readyBlockData, syncedCb)
+}
+
+// saveOldPtr mocks base method
+func (m *MockblockPutStateCopiable) saveOldPtr(ctx context.Context, oldPtr BlockPointer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "saveOldPtr", ctx, oldPtr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// saveOldPtr indicates an expected call of saveOldPtr
+func (mr *MockblockPutStateCopiableMockRecorder) saveOldPtr(ctx, oldPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "saveOldPtr", reflect.TypeOf((*MockblockPutStateCopiable)(nil).saveOldPtr), ctx, oldPtr)
+}
+
+// oldPtr mocks base method
+func (m *MockblockPutStateCopiable) oldPtr(ctx context.Context, blockPtr BlockPointer) (BlockPointer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "oldPtr", ctx, blockPtr)
+	ret0, _ := ret[0].(BlockPointer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// oldPtr indicates an expected call of oldPtr
+func (mr *MockblockPutStateCopiableMockRecorder) oldPtr(ctx, blockPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "oldPtr", reflect.TypeOf((*MockblockPutStateCopiable)(nil).oldPtr), ctx, blockPtr)
+}
+
+// ptrs mocks base method
+func (m *MockblockPutStateCopiable) ptrs() []BlockPointer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ptrs")
+	ret0, _ := ret[0].([]BlockPointer)
+	return ret0
+}
+
+// ptrs indicates an expected call of ptrs
+func (mr *MockblockPutStateCopiableMockRecorder) ptrs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ptrs", reflect.TypeOf((*MockblockPutStateCopiable)(nil).ptrs))
+}
+
+// getBlock mocks base method
+func (m *MockblockPutStateCopiable) getBlock(ctx context.Context, blockPtr BlockPointer) (Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getBlock", ctx, blockPtr)
+	ret0, _ := ret[0].(Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getBlock indicates an expected call of getBlock
+func (mr *MockblockPutStateCopiableMockRecorder) getBlock(ctx, blockPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getBlock", reflect.TypeOf((*MockblockPutStateCopiable)(nil).getBlock), ctx, blockPtr)
+}
+
+// getReadyBlockData mocks base method
+func (m *MockblockPutStateCopiable) getReadyBlockData(ctx context.Context, blockPtr BlockPointer) (ReadyBlockData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getReadyBlockData", ctx, blockPtr)
+	ret0, _ := ret[0].(ReadyBlockData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getReadyBlockData indicates an expected call of getReadyBlockData
+func (mr *MockblockPutStateCopiableMockRecorder) getReadyBlockData(ctx, blockPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getReadyBlockData", reflect.TypeOf((*MockblockPutStateCopiable)(nil).getReadyBlockData), ctx, blockPtr)
+}
+
+// synced mocks base method
+func (m *MockblockPutStateCopiable) synced(blockPtr BlockPointer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "synced", blockPtr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// synced indicates an expected call of synced
+func (mr *MockblockPutStateCopiableMockRecorder) synced(blockPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "synced", reflect.TypeOf((*MockblockPutStateCopiable)(nil).synced), blockPtr)
+}
+
+// numBlocks mocks base method
+func (m *MockblockPutStateCopiable) numBlocks() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "numBlocks")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// numBlocks indicates an expected call of numBlocks
+func (mr *MockblockPutStateCopiableMockRecorder) numBlocks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "numBlocks", reflect.TypeOf((*MockblockPutStateCopiable)(nil).numBlocks))
+}
+
+// mergeOtherBps mocks base method
+func (m *MockblockPutStateCopiable) mergeOtherBps(ctx context.Context, other blockPutStateCopiable) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "mergeOtherBps", ctx, other)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// mergeOtherBps indicates an expected call of mergeOtherBps
+func (mr *MockblockPutStateCopiableMockRecorder) mergeOtherBps(ctx, other interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "mergeOtherBps", reflect.TypeOf((*MockblockPutStateCopiable)(nil).mergeOtherBps), ctx, other)
+}
+
+// removeOtherBps mocks base method
+func (m *MockblockPutStateCopiable) removeOtherBps(ctx context.Context, other blockPutStateCopiable) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "removeOtherBps", ctx, other)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// removeOtherBps indicates an expected call of removeOtherBps
+func (mr *MockblockPutStateCopiableMockRecorder) removeOtherBps(ctx, other interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeOtherBps", reflect.TypeOf((*MockblockPutStateCopiable)(nil).removeOtherBps), ctx, other)
+}
+
 // deepCopy mocks base method
-func (m *MockblockPutState) deepCopy(ctx context.Context) (blockPutState, error) {
+func (m *MockblockPutStateCopiable) deepCopy(ctx context.Context) (blockPutStateCopiable, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "deepCopy", ctx)
-	ret0, _ := ret[0].(blockPutState)
+	ret0, _ := ret[0].(blockPutStateCopiable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // deepCopy indicates an expected call of deepCopy
-func (mr *MockblockPutStateMockRecorder) deepCopy(ctx interface{}) *gomock.Call {
+func (mr *MockblockPutStateCopiableMockRecorder) deepCopy(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deepCopy", reflect.TypeOf((*MockblockPutState)(nil).deepCopy), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deepCopy", reflect.TypeOf((*MockblockPutStateCopiable)(nil).deepCopy), ctx)
 }
 
 // deepCopyWithBlacklist mocks base method
-func (m *MockblockPutState) deepCopyWithBlacklist(ctx context.Context, blacklist map[BlockPointer]bool) (blockPutState, error) {
+func (m *MockblockPutStateCopiable) deepCopyWithBlacklist(ctx context.Context, blacklist map[BlockPointer]bool) (blockPutStateCopiable, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "deepCopyWithBlacklist", ctx, blacklist)
-	ret0, _ := ret[0].(blockPutState)
+	ret0, _ := ret[0].(blockPutStateCopiable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // deepCopyWithBlacklist indicates an expected call of deepCopyWithBlacklist
-func (mr *MockblockPutStateMockRecorder) deepCopyWithBlacklist(ctx, blacklist interface{}) *gomock.Call {
+func (mr *MockblockPutStateCopiableMockRecorder) deepCopyWithBlacklist(ctx, blacklist interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deepCopyWithBlacklist", reflect.TypeOf((*MockblockPutState)(nil).deepCopyWithBlacklist), ctx, blacklist)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deepCopyWithBlacklist", reflect.TypeOf((*MockblockPutStateCopiable)(nil).deepCopyWithBlacklist), ctx, blacklist)
 }


### PR DESCRIPTION
Instead of storing all readied blocks in memory during CR, instead store them in a disk-block-cache-backed data structure.

This also simplifies the `blockPutState` interface used by CR, and plumbs a `blockPutState` through to the prepper from CR, instead of letting the prepper make one itself.

Issue: KBFS-3679