### PR TITLE
easier access to account mode (mobile only) for front end

### DIFF
--- a/go/protocol/stellar1/bundle.go
+++ b/go/protocol/stellar1/bundle.go
@@ -15,35 +15,6 @@ func (o BundleRevision) DeepCopy() BundleRevision {
 	return o
 }
 
-type AccountMode int
-
-const (
-	AccountMode_NONE   AccountMode = 0
-	AccountMode_USER   AccountMode = 1
-	AccountMode_MOBILE AccountMode = 2
-)
-
-func (o AccountMode) DeepCopy() AccountMode { return o }
-
-var AccountModeMap = map[string]AccountMode{
-	"NONE":   0,
-	"USER":   1,
-	"MOBILE": 2,
-}
-
-var AccountModeRevMap = map[AccountMode]string{
-	0: "NONE",
-	1: "USER",
-	2: "MOBILE",
-}
-
-func (e AccountMode) String() string {
-	if v, ok := AccountModeRevMap[e]; ok {
-		return v
-	}
-	return ""
-}
-
 type EncryptedBundle struct {
 	V   int                           `codec:"v" json:"v"`
 	E   []byte                        `codec:"e" json:"e"`

--- a/go/protocol/stellar1/common.go
+++ b/go/protocol/stellar1/common.go
@@ -419,6 +419,35 @@ func (o PageCursor) DeepCopy() PageCursor {
 	}
 }
 
+type AccountMode int
+
+const (
+	AccountMode_NONE   AccountMode = 0
+	AccountMode_USER   AccountMode = 1
+	AccountMode_MOBILE AccountMode = 2
+)
+
+func (o AccountMode) DeepCopy() AccountMode { return o }
+
+var AccountModeMap = map[string]AccountMode{
+	"NONE":   0,
+	"USER":   1,
+	"MOBILE": 2,
+}
+
+var AccountModeRevMap = map[AccountMode]string{
+	0: "NONE",
+	1: "USER",
+	2: "MOBILE",
+}
+
+func (e AccountMode) String() string {
+	if v, ok := AccountModeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type CommonInterface interface {
 }
 

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -15,6 +15,7 @@ type WalletAccountLocal struct {
 	BalanceDescription string        `codec:"balanceDescription" json:"balanceDescription"`
 	Seqno              string        `codec:"seqno" json:"seqno"`
 	CurrencyLocal      CurrencyLocal `codec:"currencyLocal" json:"currencyLocal"`
+	AccountMode        AccountMode   `codec:"accountMode" json:"accountMode"`
 }
 
 func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
@@ -25,6 +26,7 @@ func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
 		BalanceDescription: o.BalanceDescription,
 		Seqno:              o.Seqno,
 		CurrencyLocal:      o.CurrencyLocal.DeepCopy(),
+		AccountMode:        o.AccountMode.DeepCopy(),
 	}
 }
 

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -741,6 +741,7 @@ type OwnAccountCLILocal struct {
 	Name         string               `codec:"name" json:"name"`
 	Balance      []Balance            `codec:"balance" json:"balance"`
 	ExchangeRate *OutsideExchangeRate `codec:"exchangeRate,omitempty" json:"exchangeRate,omitempty"`
+	AccountMode  AccountMode          `codec:"accountMode" json:"accountMode"`
 }
 
 func (o OwnAccountCLILocal) DeepCopy() OwnAccountCLILocal {
@@ -766,6 +767,7 @@ func (o OwnAccountCLILocal) DeepCopy() OwnAccountCLILocal {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.ExchangeRate),
+		AccountMode: o.AccountMode.DeepCopy(),
 	}
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -2146,7 +2146,7 @@ func accountLocal(mctx libkb.MetaContext, remoter remote.Remoter, entry stellar1
 		mctx.CDebugf("AccountDetails for entry.AccountID %q returned empty account id (full details: %+v)", entry.AccountID, details)
 	}
 
-	return AccountDetailsToWalletAccountLocal(mctx, entry.AccountID, details, entry.IsPrimary, entry.Name)
+	return AccountDetailsToWalletAccountLocal(mctx, entry.AccountID, details, entry.IsPrimary, entry.Name, entry.Mode)
 }
 
 // AccountDetails gets stellar1.AccountDetails for accountID.

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -51,6 +51,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.Equal(t, accountID, accts[0].AccountID, accountID)
 	require.True(t, accts[0].IsDefault)
 	require.Equal(t, "qq", accts[0].Name)
+	require.Equal(t, stellar1.AccountMode_USER, accts[0].AccountMode)
 	require.Equal(t, "10,000.00 XLM", accts[0].BalanceDescription)
 	currencyLocal := accts[0].CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
@@ -61,6 +62,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 
 	require.False(t, accts[1].IsDefault)
 	require.Equal(t, firstAccountName(t, tcs[0]), accts[1].Name)
+	require.Equal(t, stellar1.AccountMode_USER, accts[1].AccountMode)
 	require.Equal(t, "0 XLM", accts[1].BalanceDescription)
 	currencyLocal = accts[1].CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
@@ -70,21 +72,22 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	argDetails := stellar1.GetWalletAccountLocalArg{AccountID: accountID}
 	details, err := tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
 	require.NoError(t, err)
-	require.Equal(t, "qq", accts[0].Name)
+	require.Equal(t, "qq", details.Name)
+	require.Equal(t, stellar1.AccountMode_USER, details.AccountMode)
 	require.True(t, details.IsDefault)
 	require.Equal(t, "10,000.00 XLM", details.BalanceDescription)
 	require.NotEmpty(t, details.Seqno)
-	currencyLocal = accts[1].CurrencyLocal
+	currencyLocal = details.CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
 
 	argDetails.AccountID = accts[1].AccountID
 	details, err = tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
 	require.NoError(t, err)
-	require.Equal(t, firstAccountName(t, tcs[0]), accts[1].Name)
+	require.Equal(t, firstAccountName(t, tcs[0]), details.Name)
 	require.False(t, details.IsDefault)
 	require.Equal(t, "0 XLM", details.BalanceDescription)
 	require.NotEmpty(t, details.Seqno)
-	currencyLocal = accts[1].CurrencyLocal
+	currencyLocal = details.CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
 }
 
@@ -2577,6 +2580,7 @@ func TestSetMobileOnly(t *testing.T) {
 
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
 	accountID := getPrimaryAccountID(tcs[0])
+	walletAcctLocalArg := stellar1.GetWalletAccountLocalArg{AccountID: accountID}
 
 	// assert not mobile only yet
 	mobileOnly, err := tcs[0].Srv.IsAccountMobileOnlyLocal(context.Background(), stellar1.IsAccountMobileOnlyLocalArg{AccountID: accountID})
@@ -2586,6 +2590,9 @@ func TestSetMobileOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, accs, 1)
 	require.Equal(t, accs[0].AccountMode, stellar1.AccountMode_USER)
+	details, err := tcs[0].Srv.GetWalletAccountLocal(context.Background(), walletAcctLocalArg)
+	require.NoError(t, err)
+	require.Equal(t, stellar1.AccountMode_USER, details.AccountMode)
 
 	err = tcs[0].Srv.SetAccountMobileOnlyLocal(context.Background(), stellar1.SetAccountMobileOnlyLocalArg{AccountID: accountID})
 	require.NoError(t, err)
@@ -2598,6 +2605,9 @@ func TestSetMobileOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, accs, 1)
 	require.Equal(t, accs[0].AccountMode, stellar1.AccountMode_MOBILE)
+	details, err = tcs[0].Srv.GetWalletAccountLocal(context.Background(), walletAcctLocalArg)
+	require.NoError(t, err)
+	require.Equal(t, stellar1.AccountMode_MOBILE, details.AccountMode)
 
 	// service_test verifies that `SetAccountMobileOnlyLocal` behaves correctly under the covers
 }

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -2573,23 +2573,31 @@ func TestSetMobileOnly(t *testing.T) {
 	defer cleanup()
 
 	makeActiveDeviceOlder(t, tcs[0].G)
-
-	// this only works with a v2 bundle now
 	setupWithNewBundle(t, tcs[0])
 
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
 	accountID := getPrimaryAccountID(tcs[0])
 
+	// assert not mobile only yet
 	mobileOnly, err := tcs[0].Srv.IsAccountMobileOnlyLocal(context.Background(), stellar1.IsAccountMobileOnlyLocalArg{AccountID: accountID})
 	require.NoError(t, err)
 	require.False(t, mobileOnly)
+	accs, err := tcs[0].Srv.WalletGetAccountsCLILocal(context.Background())
+	require.NoError(t, err)
+	require.Len(t, accs, 1)
+	require.Equal(t, accs[0].AccountMode, stellar1.AccountMode_USER)
 
 	err = tcs[0].Srv.SetAccountMobileOnlyLocal(context.Background(), stellar1.SetAccountMobileOnlyLocalArg{AccountID: accountID})
 	require.NoError(t, err)
 
+	// yes mobile only
 	mobileOnly, err = tcs[0].Srv.IsAccountMobileOnlyLocal(context.Background(), stellar1.IsAccountMobileOnlyLocalArg{AccountID: accountID})
 	require.NoError(t, err)
 	require.True(t, mobileOnly)
+	accs, err = tcs[0].Srv.WalletGetAccountsCLILocal(context.Background())
+	require.NoError(t, err)
+	require.Len(t, accs, 1)
+	require.Equal(t, accs[0].AccountMode, stellar1.AccountMode_MOBILE)
 
 	// service_test verifies that `SetAccountMobileOnlyLocal` behaves correctly under the covers
 }

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -351,9 +351,10 @@ func (s *Server) WalletGetAccountsCLILocal(ctx context.Context) (ret []stellar1.
 	for _, account := range currentBundle.Accounts {
 		accID := account.AccountID
 		acc := stellar1.OwnAccountCLILocal{
-			AccountID: accID,
-			IsPrimary: account.IsPrimary,
-			Name:      account.Name,
+			AccountID:   accID,
+			IsPrimary:   account.IsPrimary,
+			Name:        account.Name,
+			AccountMode: account.Mode,
 		}
 
 		balances, err := s.remoter.Balances(ctx, accID)

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -440,7 +440,7 @@ func RemotePendingToLocal(mctx libkb.MetaContext, remoter remote.Remoter, accoun
 	return payments, nil
 }
 
-func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stellar1.AccountID, details stellar1.AccountDetails, isPrimary bool, accountName string) (stellar1.WalletAccountLocal, error) {
+func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stellar1.AccountID, details stellar1.AccountDetails, isPrimary bool, accountName string, accountMode stellar1.AccountMode) (stellar1.WalletAccountLocal, error) {
 
 	var empty stellar1.WalletAccountLocal
 	balance, err := balanceList(details.Balances).balanceDescription()
@@ -454,6 +454,7 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 		Name:               accountName,
 		BalanceDescription: balance,
 		Seqno:              details.Seqno,
+		AccountMode:        accountMode,
 	}
 
 	conf, err := mctx.G().GetStellar().GetServerDefinitions(mctx.Ctx())

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -445,6 +445,7 @@ type AccountState struct {
 	seqno        uint64
 	isPrimary    bool
 	name         string
+	accountMode  stellar1.AccountMode
 	balances     []stellar1.Balance
 	details      *stellar1.AccountDetails
 	pending      []stellar1.PaymentSummary
@@ -500,10 +501,11 @@ func (a *AccountState) refresh(mctx libkb.MetaContext, router *libkb.NotifyRoute
 		// get these while locked
 		isPrimary := a.isPrimary
 		name := a.name
+		accountMode := a.accountMode
 		a.Unlock()
 
 		if notify && router != nil {
-			accountLocal, err := AccountDetailsToWalletAccountLocal(mctx, a.accountID, details, isPrimary, name)
+			accountLocal, err := AccountDetailsToWalletAccountLocal(mctx, a.accountID, details, isPrimary, name, accountMode)
 			if err == nil {
 				router.HandleWalletAccountDetailsUpdate(mctx.Ctx(), a.accountID, accountLocal)
 			}
@@ -704,6 +706,7 @@ func (a *AccountState) updateEntry(entry stellar1.BundleEntry) {
 
 	a.isPrimary = entry.IsPrimary
 	a.name = entry.Name
+	a.accountMode = entry.Mode
 }
 
 // enqueueRefreshReq adds an account ID to the refresh request queue.

--- a/protocol/avdl/stellar1/bundle.avdl
+++ b/protocol/avdl/stellar1/bundle.avdl
@@ -5,12 +5,6 @@ protocol bundle {
 
   @typedef("uint64") @lint("ignore") record BundleRevision {}
 
-  enum AccountMode {
-    NONE_0,
-    USER_1,  // Each of the user's devices has access to the keys
-    MOBILE_2 // Only the user's mobile devices have access to the keys
-  }
-
   // The same format as in chat1.EncryptedData (and KBFS, Git)
   record EncryptedBundle {
     // v=1 Used an incorrect context string. No longer supported. (CORE-8135)

--- a/protocol/avdl/stellar1/common.avdl
+++ b/protocol/avdl/stellar1/common.avdl
@@ -138,4 +138,10 @@ protocol common {
     string directCursor;
     string relayCursor;
   }
+
+  enum AccountMode {
+    NONE_0,
+    USER_1,  // Each of the user's devices has access to the keys
+    MOBILE_2 // Only the user's mobile devices have access to the keys
+  }
 }

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -75,7 +75,7 @@ protocol local {
     string amountDescription;       // "1,323.1234567 XLM"
     BalanceDelta delta;             // NONE/INCREASE/DECREASE (e.g. INCREASE for "+ 1,323.1234567 XLM" amount above)
     string worth;                   // "$123.23 CLP", senders intended amount if this was made as a lumens-worth-currency payment
-    string worthAtSendTime;         // "$123.23 CLP", amount in current user's display currency. Set if frontend should show an 
+    string worthAtSendTime;         // "$123.23 CLP", amount in current user's display currency. Set if frontend should show an
                                     // (APPROXIMATELY $X.XX) message i.e. if this is a pure-XLM payment.
 
     string issuerDescription;       // For non-XLM assets: either "Unknown issuer" or domain name
@@ -134,7 +134,7 @@ protocol local {
     string amountDescription;       // "1,323.1234567 XLM" - always amount of XLM, even if converted from OutsideCurrency
     BalanceDelta delta;             // NONE/INCREASE/DECREASE (e.g. INCREASE for "+ 1,323.1234567 XLM" amount above)
     string worth;                   // "$123.23 CLP", senders intended amount if this was made as a lumens-worth-currency payment
-    string worthAtSendTime;         // "$123.23 CLP", amount in current user's display currency. Set if frontend should show an 
+    string worthAtSendTime;         // "$123.23 CLP", amount in current user's display currency. Set if frontend should show an
                                     // (APPROXIMATELY $X.XX) message i.e. if this is a pure-XLM payment.
 
     string issuerDescription;       // For non-XLM assets: either "Unknown issuer" or domain name
@@ -540,6 +540,7 @@ protocol local {
     string name;
     array<Balance> balance;
     union { null, OutsideExchangeRate } exchangeRate;
+    AccountMode accountMode;
   }
 
   array<OwnAccountCLILocal> walletGetAccountsCLILocal();

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -13,6 +13,7 @@ protocol local {
     string balanceDescription;  // example: "56.0227002 XLM + more"
     string seqno;               // the stellar sequence number for this account
     CurrencyLocal currencyLocal;// user configurable, defaults to USD and related details
+    AccountMode accountMode;    // mobile only vs all devices
   }
   array<WalletAccountLocal> getWalletAccountsLocal(int sessionID);
   WalletAccountLocal getWalletAccountLocal(int sessionID, AccountID accountID);

--- a/protocol/json/stellar1/bundle.json
+++ b/protocol/json/stellar1/bundle.json
@@ -20,15 +20,6 @@
       "lint": "ignore"
     },
     {
-      "type": "enum",
-      "name": "AccountMode",
-      "symbols": [
-        "NONE_0",
-        "USER_1",
-        "MOBILE_2"
-      ]
-    },
-    {
       "type": "record",
       "name": "EncryptedBundle",
       "fields": [

--- a/protocol/json/stellar1/common.json
+++ b/protocol/json/stellar1/common.json
@@ -368,6 +368,15 @@
           "name": "relayCursor"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "AccountMode",
+      "symbols": [
+        "NONE_0",
+        "USER_1",
+        "MOBILE_2"
+      ]
     }
   ],
   "messages": {},

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -878,6 +878,10 @@
             "OutsideExchangeRate"
           ],
           "name": "exchangeRate"
+        },
+        {
+          "type": "AccountMode",
+          "name": "accountMode"
         }
       ]
     },

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -34,6 +34,10 @@
         {
           "type": "CurrencyLocal",
           "name": "currencyLocal"
+        },
+        {
+          "type": "AccountMode",
+          "name": "accountMode"
         }
       ]
     },

--- a/shared/constants/types/rpc-stellar-gen.js
+++ b/shared/constants/types/rpc-stellar-gen.js
@@ -19,12 +19,6 @@ export const bundleAccountBundleVersion = {
   v10: 10,
 }
 
-export const bundleAccountMode = {
-  none: 0,
-  user: 1,
-  mobile: 2,
-}
-
 export const bundleBundleVersion = {
   v1: 1,
   v2: 2,
@@ -36,6 +30,12 @@ export const bundleBundleVersion = {
   v8: 8,
   v9: 9,
   v10: 10,
+}
+
+export const commonAccountMode = {
+  none: 0,
+  user: 1,
+  mobile: 2,
 }
 
 export const commonPaymentStrategy = {

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -446,7 +446,7 @@ export type TransactionStatus =
   | 4 // ERROR_PERMANENT_4
 
 export type UIPaymentReviewed = $ReadOnly<{bid: BuildPaymentID, reviewID: Int, seqno: Int, banners?: ?Array<SendBannerLocal>, nextButton: String}>
-export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal}>
+export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal, accountMode: AccountMode}>
 
 export type IncomingCallMapType = {|
   'stellar.1.notify.paymentNotification'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.paymentNotification'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -211,12 +211,6 @@ export const bundleAccountBundleVersion = {
   v10: 10,
 }
 
-export const bundleAccountMode = {
-  none: 0,
-  user: 1,
-  mobile: 2,
-}
-
 export const bundleBundleVersion = {
   v1: 1,
   v2: 2,
@@ -228,6 +222,12 @@ export const bundleBundleVersion = {
   v8: 8,
   v9: 9,
   v10: 10,
+}
+
+export const commonAccountMode = {
+  none: 0,
+  user: 1,
+  mobile: 2,
 }
 
 export const commonPaymentStrategy = {
@@ -365,7 +365,7 @@ export type NoteRecipient = $ReadOnly<{user: Keybase1.UserVersion, pukGen: Keyba
 export type OutsideCurrencyCode = String
 export type OutsideCurrencyDefinition = $ReadOnly<{name: String, symbol: CurrencySymbol}>
 export type OutsideExchangeRate = $ReadOnly<{currency: OutsideCurrencyCode, rate: String}>
-export type OwnAccountCLILocal = $ReadOnly<{accountID: AccountID, isPrimary: Boolean, name: String, balance?: ?Array<Balance>, exchangeRate?: ?OutsideExchangeRate}>
+export type OwnAccountCLILocal = $ReadOnly<{accountID: AccountID, isPrimary: Boolean, name: String, balance?: ?Array<Balance>, exchangeRate?: ?OutsideExchangeRate, accountMode: AccountMode}>
 export type PageCursor = $ReadOnly<{horizonCursor: String, directCursor: String, relayCursor: String}>
 export type ParticipantType =
   | 0 // NONE_0


### PR DESCRIPTION
add the account mode (currently just all-devices and mobile-only, but it's an enum so we have more flexibility than just the boolean) to a handful of stellar account RPCs (`walletGetAccountsCLILocal`, `getWalletAccountsLocal`, `getWalletAccountLocal`) and to the `accountsUpdate` notification. this should obviate the need for the front end to call `isAccountMobileOnly` perhaps entirely(?). 
