### PR TITLE
fix native globalerror scrolling

### DIFF
--- a/shared/app/global-errors/index.native.js
+++ b/shared/app/global-errors/index.native.js
@@ -80,7 +80,13 @@ class GlobalError extends React.Component<Props, State> {
     const details = this.state.cachedDetails
 
     return (
-      <Kb.Box2 direction="vertical" style={styles.container}>
+      <Kb.Box2
+        direction="vertical"
+        style={Styles.collapseStyles([
+          styles.container,
+          this.state.size === 'Big' && Styles.globalStyles.fillAbsolute,
+        ])}
+      >
         <Kb.SafeAreaViewTop style={{backgroundColor: Styles.globalColors.transparent, flexGrow: 0}} />
         <Kb.Box style={Styles.globalStyles.flexBoxColumn}>
           <Kb.Box
@@ -91,14 +97,14 @@ class GlobalError extends React.Component<Props, State> {
             }}
           >
             <Kb.Text
-              center={true} type="BodySmallSemibold"
+              center={true}
+              type="BodySmallSemibold"
               style={{color: Styles.globalColors.white, flex: 1}}
               onClick={this._onExpandClick}
             >
-              <Kb.Icon
-                type={this.state.size === 'Big' ? 'iconfont-caret-down' : 'iconfont-caret-right'}
-                color={Styles.globalColors.white_75}
-              />
+              {this.state.size !== 'Big' && (
+                <Kb.Icon type="iconfont-caret-right" color={Styles.globalColors.white_75} />
+              )}
               {'  '}
               An error occurred.
             </Kb.Text>


### PR DESCRIPTION
Before:
![globalerr-noscroll](https://user-images.githubusercontent.com/11968340/51864413-b5060e80-2311-11e9-97c3-6b03e50df0e2.gif)

After:
![globalerr-scroll](https://user-images.githubusercontent.com/11968340/51864362-930c8c00-2311-11e9-8d61-68c2ad2f789f.gif)

r? @keybase/react-hackers 