### PR TITLE
handle empty filename in mobileMessageAttachmentSave

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1672,7 +1672,9 @@ function* downloadAttachment(fileName: string, message: Types.Message) {
     )
     yield Saga.put(Chat2Gen.createAttachmentDownloaded({message, path: fileName}))
     return rpcRes.filename
-  } catch (e) {}
+  } catch (e) {
+    logger.error(`downloadAttachment error: ${e.message}`)
+  }
   return fileName
 }
 
@@ -2006,6 +2008,11 @@ function* mobileMessageAttachmentSave(state, action) {
     throw new Error('Invalid share message')
   }
   const fileName = yield* downloadAttachment('', message)
+  if (fileName === '') {
+    // failed to download
+    logger.error('Downloading attachment failed')
+    throw new Error('Downloading attachment failed')
+  }
   yield Saga.put(
     Chat2Gen.createAttachmentMobileSave({
       conversationIDKey: message.conversationIDKey,


### PR DESCRIPTION
Currently if `DownloadFileAttachmentLocal` fails we try to save an empty path to the camera roll, which causes a confusing `Error: (No such file or directory)` message. This blocks the save if we have an empty filename. r? @keybase/react-hackers 