### PR TITLE
cr: store pointers in the `fileBlockMap`, not full blocks

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -2242,8 +2242,8 @@ func (cr *ConflictResolver) computeActions(ctx context.Context,
 }
 
 // fileBlockMap maps latest merged block pointer to a map of final
-// merged name -> file block.
-type fileBlockMap map[BlockPointer]map[string]*FileBlock
+// merged name -> file block pointer.
+type fileBlockMap map[BlockPointer]map[string]BlockPointer
 
 func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	lState *lockState, chains *crChains, mergedMostRecent BlockPointer,
@@ -2262,15 +2262,6 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 		ctx, lState, kmd, file, dirtyBcache, cr.config.DataVersion())
 	if err != nil {
 		return BlockPointer{}, err
-	}
-
-	block, err := dirtyBcache.Get(ctx, cr.fbo.id(), newPtr, cr.fbo.branch())
-	if err != nil {
-		return BlockPointer{}, err
-	}
-	fblock, isFileBlock := block.(*FileBlock)
-	if !isFileBlock {
-		return BlockPointer{}, NotFileBlockError{ptr, cr.fbo.branch(), file}
 	}
 
 	// Mark this as having been created during this chain, so that
@@ -2292,14 +2283,14 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	}
 
 	if _, ok := blocks[mergedMostRecent]; !ok {
-		blocks[mergedMostRecent] = make(map[string]*FileBlock)
+		blocks[mergedMostRecent] = make(map[string]BlockPointer)
 	}
 
 	for _, childPtr := range allChildPtrs {
 		chains.createdOriginals[childPtr] = true
 	}
 
-	blocks[mergedMostRecent][name] = fblock
+	blocks[mergedMostRecent][name] = newPtr
 	return newPtr, nil
 }
 

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -1431,8 +1431,12 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 			mergedRootPath.tailPointer())
 	} else if len(blocks) != 1 {
 		t.Errorf("Unexpected number of blocks")
-	} else if fblock, ok := blocks[mergedName]; !ok {
-		t.Errorf("No block for name %s", mergedName)
+	} else if fptr, ok := blocks[mergedName]; !ok {
+		t.Errorf("No pointer for name %s", mergedName)
+	} else if block, err := dirtyBcache.Get(ctx, fb.Tlf, fptr, fb.Branch); err != nil {
+		t.Errorf("Couldn't get fblock: %v", err)
+	} else if fblock, ok := block.(*FileBlock); !ok {
+		t.Errorf("No file block for name %s, block %T", mergedName, block)
 	} else if fblock.IsInd {
 		t.Errorf("Unexpected indirect block")
 	} else if g, e := fblock.Contents, unmergedData; !reflect.DeepEqual(g, e) {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5420,7 +5420,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 		fbo.log.CDebugf(ctx, "Syncing file %v (%s)", ref, file)
 
 		// Start the sync for this dirty file.
-		doSync, stillDirty, fblock, dirtyDe, newBps, syncState, cleanup, err :=
+		doSync, stillDirty, _, dirtyDe, newBps, syncState, cleanup, err :=
 			fbo.startSyncLocked(ctx, lState, md, node, file)
 		if cleanup != nil {
 			// Note: This passes the same `blocksToRemove` into each
@@ -5454,9 +5454,9 @@ func (fbo *folderBranchOps) syncAllLocked(
 		resolvedPaths[file.tailPointer()] = file
 		parent := file.parentPath().tailPointer()
 		if _, ok := fileBlocks[parent]; !ok {
-			fileBlocks[parent] = make(map[string]*FileBlock)
+			fileBlocks[parent] = make(map[string]BlockPointer)
 		}
-		fileBlocks[parent][file.tailName()] = fblock
+		fileBlocks[parent][file.tailName()] = file.tailPointer()
 
 		// Collect its `afterUpdateFn` along with all the others, so
 		// they all get invoked under the same lock, to avoid any


### PR DESCRIPTION
Change the map that was storing the top block of each changed file in a directory, into just storing the file pointer for each changed file in a directory.  The blocks themselves are already stored in the dirty block cache, so no need to keep them in memory in this other data structure.

Issue: KBFS-3679