### PR TITLE
Badge account dropdown if another account has unread txs

### DIFF
--- a/shared/wallets/wallet/header/container.js
+++ b/shared/wallets/wallet/header/container.js
@@ -1,9 +1,12 @@
 // @flow
 import {connect, isMobile} from '../../../util/container'
+import {memoize} from '../../../util/memoize'
 import * as Constants from '../../../constants/wallets'
 import * as Types from '../../../constants/types/wallets'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import Header from '.'
+
+const otherUnreadPayments = memoize((map, accID) => !!map.delete(accID).some(v => !!v))
 
 type OwnProps = {navigateAppend: (...Array<any>) => any, onBack: () => void}
 
@@ -15,7 +18,7 @@ const mapStateToProps = state => {
     isDefaultWallet: selectedAccount.isDefault,
     keybaseUser: state.config.username,
     sendDisabled: !isMobile && !!state.wallets.mobileOnlyMap.getIn([selectedAccount.accountID]),
-    unreadPayments: state.wallets.unreadPaymentsMap.get(selectedAccount.accountID, 0),
+    unreadPayments: otherUnreadPayments(state.wallets.unreadPaymentsMap, selectedAccount.accountID),
     walletName: selectedAccount.name,
   }
 }

--- a/shared/wallets/wallet/header/container.js
+++ b/shared/wallets/wallet/header/container.js
@@ -6,7 +6,7 @@ import * as Types from '../../../constants/types/wallets'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import Header from '.'
 
-const otherUnreadPayments = memoize((map, accID) => !!map.delete(accID).some(v => !!v))
+const otherUnreadPayments = memoize((map, accID) => !!map.delete(accID).some(Boolean))
 
 type OwnProps = {navigateAppend: (...Array<any>) => any, onBack: () => void}
 

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -9,7 +9,7 @@ import MaybeSwitcher from './maybe-switcher'
 type Props = {
   accountID: Types.AccountID,
   isDefaultWallet: boolean,
-  unreadPayments: number,
+  unreadPayments: boolean,
   onReceive: () => void,
   onBack: ?() => void,
   onRequest: () => void,
@@ -28,7 +28,7 @@ const Header = (props: Props) => {
   // Only show caret/unread badge when we have a switcher,
   // i.e. when isMobile is true.
   const caret = Styles.isMobile && <Kb.Icon key="icon" type="iconfont-caret-down" style={styles.caret} />
-  const unread = Styles.isMobile && !!props.unreadPayments && (
+  const unread = Styles.isMobile && props.unreadPayments && (
     <Kb.Box2 direction="vertical" style={styles.unread} />
   )
   const nameAndInfo = props.walletName ? (

--- a/shared/wallets/wallet/header/index.stories.js
+++ b/shared/wallets/wallet/header/index.stories.js
@@ -31,7 +31,7 @@ const common = {
   onSendToStellarAddress: Sb.action('onSendToStellarAddress'),
   onSettings: Sb.action('onSettings'),
   onShowSecretKey: Sb.action('onShowSecretKey'),
-  unreadPayments: 0,
+  unreadPayments: false,
 }
 
 export const Container = (storyFn: any) => (


### PR DESCRIPTION
Currently we badge the dropdown if the selected account has badgeworthy transactions. That doesn't help direct attention to the dropdown when we want to - when an account besides this one has unread payments. This makes it so we badge if another account has unread. r? @keybase/react-hackers 