### PR TITLE
disk_block_cache: fix `TestKBFSOpsPartialSync` flakes

### DIFF
--- a/go/kbfs/genprotocol/kbgitkbfs1-avdl/disk_block_cache.avdl
+++ b/go/kbfs/genprotocol/kbgitkbfs1-avdl/disk_block_cache.avdl
@@ -54,5 +54,5 @@ protocol DiskBlockCache {
   /**
     UpdateBlockMetadata updates the metadata for a block in the disk cache.
     */
-  void UpdateBlockMetadata(bytes blockID, PrefetchStatus prefetchStatus);
+  void UpdateBlockMetadata(bytes tlfID, bytes blockID, PrefetchStatus prefetchStatus);
 }

--- a/go/kbfs/libkbfs/block_ops.go
+++ b/go/kbfs/libkbfs/block_ops.go
@@ -205,7 +205,7 @@ func (b *BlockOpsStandard) GetLiveCount(
 
 // TogglePrefetcher implements the BlockOps interface for BlockOpsStandard.
 func (b *BlockOpsStandard) TogglePrefetcher(enable bool) <-chan struct{} {
-	return b.queue.TogglePrefetcher(enable, nil)
+	return b.queue.TogglePrefetcher(enable, nil, nil)
 }
 
 // Prefetcher implements the BlockOps interface for BlockOpsStandard.

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -363,11 +363,9 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	blockBuf, serverHalf, prefetchStatus, err := dbc.Get(
 		ctx, kmd.TlfID(), ptr.ID, preferredCacheType)
 	if err != nil {
-		brq.log.CDebugf(ctx, "checkCaches failing 1: %+v", err)
 		return NoPrefetch, err
 	}
 	if len(blockBuf) == 0 {
-		brq.log.CDebugf(ctx, "checkCaches failing 2: %+v", err)
 		return NoPrefetch, NoSuchBlockError{ptr.ID}
 	}
 

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -82,7 +82,7 @@ func makeKMD() KeyMetadata {
 func initBlockRetrievalQueueTest(t *testing.T) *blockRetrievalQueue {
 	q := newBlockRetrievalQueue(
 		0, 0, 0, newTestBlockRetrievalConfig(t, nil, nil))
-	<-q.TogglePrefetcher(false, nil)
+	<-q.TogglePrefetcher(false, nil, nil)
 	return q
 }
 

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -779,6 +779,10 @@ func (cache *DiskBlockCacheLocal) UpdateMetadata(ctx context.Context,
 	if err != nil {
 		return NoSuchBlockError{blockID}
 	}
+	if md.FinishedPrefetch {
+		// Don't update md that's already completed.
+		return nil
+	}
 	md.TriggeredPrefetch = false
 	md.FinishedPrefetch = false
 	switch prefetchStatus {

--- a/go/kbfs/libkbfs/disk_block_cache_remote.go
+++ b/go/kbfs/libkbfs/disk_block_cache_remote.go
@@ -172,7 +172,8 @@ func (dbcr *DiskBlockCacheRemote) Delete(
 // UpdateMetadata implements the DiskBlockCache interface for
 // DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) UpdateMetadata(ctx context.Context,
-	blockID kbfsblock.ID, prefetchStatus PrefetchStatus) error {
+	_ tlf.ID, blockID kbfsblock.ID, prefetchStatus PrefetchStatus,
+	_ DiskBlockCacheType) error {
 	dbcr.statuses.Add(blockID, prefetchStatus)
 	return dbcr.client.UpdateBlockMetadata(ctx,
 		kbgitkbfs.UpdateBlockMetadataArg{

--- a/go/kbfs/libkbfs/disk_block_cache_service.go
+++ b/go/kbfs/libkbfs/disk_block_cache_service.go
@@ -169,12 +169,19 @@ func (cache *DiskBlockCacheService) UpdateBlockMetadata(ctx context.Context,
 	if dbc == nil {
 		return DiskBlockCacheError{"Disk cache is nil"}
 	}
-	blockID := kbfsblock.ID{}
-	err := blockID.UnmarshalBinary(arg.BlockID)
+	tlfID := tlf.ID{}
+	err := tlfID.UnmarshalBinary(arg.TlfID)
 	if err != nil {
 		return newDiskBlockCacheError(err)
 	}
-	err = dbc.UpdateMetadata(ctx, blockID, PrefetchStatus(arg.PrefetchStatus))
+	blockID := kbfsblock.ID{}
+	err = blockID.UnmarshalBinary(arg.BlockID)
+	if err != nil {
+		return newDiskBlockCacheError(err)
+	}
+	err = dbc.UpdateMetadata(
+		ctx, tlfID, blockID, PrefetchStatus(arg.PrefetchStatus),
+		DiskBlockAnyCache)
 	if err != nil {
 		return newDiskBlockCacheError(err)
 	}

--- a/go/kbfs/libkbfs/disk_block_cache_test.go
+++ b/go/kbfs/libkbfs/disk_block_cache_test.go
@@ -757,7 +757,8 @@ func TestDiskBlockCacheMoveBlock(t *testing.T) {
 		ctx, tlf1, block1Ptr.ID, block1Encoded, block1ServerHalf,
 		DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = cache.UpdateMetadata(ctx, block1Ptr.ID, FinishedPrefetch)
+	err = cache.UpdateMetadata(
+		ctx, tlf1, block1Ptr.ID, FinishedPrefetch, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, 1, cache.workingSetCache.numBlocks)
 	require.Equal(t, 0, cache.syncCache.numBlocks)

--- a/go/kbfs/libkbfs/disk_block_cache_wrapped.go
+++ b/go/kbfs/libkbfs/disk_block_cache_wrapped.go
@@ -130,7 +130,7 @@ func (cache *diskBlockCacheWrapped) IsSyncCacheEnabled() bool {
 func (cache *diskBlockCacheWrapped) rankCachesLocked(
 	preferredCacheType DiskBlockCacheType) (
 	primaryCache, secondaryCache *DiskBlockCacheLocal) {
-	if preferredCacheType == DiskBlockSyncCache {
+	if preferredCacheType != DiskBlockWorkingSetCache {
 		if cache.syncCache == nil {
 			log := cache.config.MakeLogger("DBC")
 			log.Warning("Sync cache is preferred, but there is no sync cache")

--- a/go/kbfs/libkbfs/disk_block_cache_wrapped.go
+++ b/go/kbfs/libkbfs/disk_block_cache_wrapped.go
@@ -127,6 +127,54 @@ func (cache *diskBlockCacheWrapped) IsSyncCacheEnabled() bool {
 	return cache.syncCache != nil
 }
 
+func (cache *diskBlockCacheWrapped) rankCachesLocked(
+	preferredCacheType DiskBlockCacheType) (
+	primaryCache, secondaryCache *DiskBlockCacheLocal) {
+	if preferredCacheType == DiskBlockSyncCache {
+		if cache.syncCache == nil {
+			log := cache.config.MakeLogger("DBC")
+			log.Warning("Sync cache is preferred, but there is no sync cache")
+			return cache.workingSetCache, nil
+		}
+		return cache.syncCache, cache.workingSetCache
+	}
+	return cache.workingSetCache, cache.syncCache
+}
+
+func (cache *diskBlockCacheWrapped) moveBetweenCachesWithBlockLocked(
+	ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte,
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	prefetchStatus PrefetchStatus, newCacheType DiskBlockCacheType) {
+	primaryCache, secondaryCache := cache.rankCachesLocked(newCacheType)
+	// Move the block into its preferred cache.
+	err := primaryCache.Put(ctx, tlfID, blockID, buf, serverHalf)
+	if err != nil {
+		// The cache will log the non-fatal error, so just return.
+		return
+	}
+
+	if prefetchStatus == FinishedPrefetch {
+		// Don't propagate a finished status to the primary
+		// cache, since the status needs to be with respect to
+		// that particular cache (i.e., if the primary cache
+		// is the sync cache, all the child blocks must be in
+		// the sync cache, for this block to be considered
+		// synced, and we can't verify that here).
+		prefetchStatus = TriggeredPrefetch
+	}
+	if prefetchStatus != NoPrefetch {
+		_ = primaryCache.UpdateMetadata(ctx, blockID, prefetchStatus)
+	}
+
+	// Remove the block from the non-preferred cache (which is
+	// set to be the secondary cache at this point).
+	cache.deleteGroup.Add(1)
+	go func() {
+		defer cache.deleteGroup.Done()
+		secondaryCache.Delete(ctx, []kbfsblock.ID{blockID})
+	}()
+}
+
 // Get implements the DiskBlockCache interface for diskBlockCacheWrapped.
 func (cache *diskBlockCacheWrapped) Get(
 	ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID,
@@ -135,20 +183,10 @@ func (cache *diskBlockCacheWrapped) Get(
 	prefetchStatus PrefetchStatus, err error) {
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
-	primaryCache := cache.workingSetCache
-	secondaryCache := cache.syncCache
-	if preferredCacheType == DiskBlockSyncCache {
-		if cache.syncCache != nil {
-			primaryCache, secondaryCache =
-				cache.syncCache, cache.workingSetCache
-		} else {
-			log := cache.config.MakeLogger("DBC")
-			log.Warning("Sync cache is preferred, but there is no sync cache")
-		}
-	}
+	primaryCache, secondaryCache := cache.rankCachesLocked(preferredCacheType)
 	// Check both caches if the primary cache doesn't have the block.
 	buf, serverHalf, prefetchStatus, err = primaryCache.Get(ctx, tlfID, blockID)
-	if _, isNoSuchBlockError := err.(NoSuchBlockError); isNoSuchBlockError &&
+	if _, isNoSuchBlockError := errors.Cause(err).(NoSuchBlockError); isNoSuchBlockError &&
 		secondaryCache != nil {
 		buf, serverHalf, prefetchStatus, err = secondaryCache.Get(
 			ctx, tlfID, blockID)
@@ -156,33 +194,9 @@ func (cache *diskBlockCacheWrapped) Get(
 			return nil, kbfscrypto.BlockCryptKeyServerHalf{}, NoPrefetch, err
 		}
 		if preferredCacheType != DiskBlockAnyCache {
-			// Move the block into its preferred cache.
-			err := primaryCache.Put(ctx, tlfID, blockID, buf, serverHalf)
-			if err != nil {
-				// The cache will log the non-fatal error, so just return nil.
-				return buf, serverHalf, prefetchStatus, nil
-			}
-
-			if prefetchStatus == FinishedPrefetch {
-				// Don't propagate a finished status to the primary
-				// cache, since the status needs to be with respect to
-				// that particular cache (i.e., if the primary cache
-				// is the sync cache, all the child blocks must be in
-				// the sync cache, for this block to be considered
-				// synced, and we can't verify that here).
-				prefetchStatus = TriggeredPrefetch
-			}
-			if prefetchStatus != NoPrefetch {
-				_ = primaryCache.UpdateMetadata(ctx, blockID, prefetchStatus)
-			}
-
-			// Remove the block from the non-preferred cache (which is
-			// set to be the secondary cache at this point).
-			cache.deleteGroup.Add(1)
-			go func() {
-				defer cache.deleteGroup.Done()
-				secondaryCache.Delete(ctx, []kbfsblock.ID{blockID})
-			}()
+			cache.moveBetweenCachesWithBlockLocked(
+				ctx, tlfID, blockID, buf, serverHalf, prefetchStatus,
+				preferredCacheType)
 		}
 	}
 	return buf, serverHalf, prefetchStatus, err
@@ -207,10 +221,25 @@ func (cache *diskBlockCacheWrapped) GetMetadata(ctx context.Context,
 	return cache.workingSetCache.GetMetadata(ctx, blockID)
 }
 
+func (cache *diskBlockCacheWrapped) moveBetweenCachesLocked(
+	ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID,
+	newCacheType DiskBlockCacheType) (moved bool) {
+	_, secondaryCache := cache.rankCachesLocked(newCacheType)
+	buf, serverHalf, prefetchStatus, err := secondaryCache.Get(
+		ctx, tlfID, blockID)
+	if err != nil {
+		// The block isn't in the secondary cache, so there's nothing to move.
+		return false
+	}
+	cache.moveBetweenCachesWithBlockLocked(
+		ctx, tlfID, blockID, buf, serverHalf, prefetchStatus, newCacheType)
+	return true
+}
+
 // GetPefetchStatus implements the DiskBlockCache interface for
 // diskBlockCacheWrapped.
 func (cache *diskBlockCacheWrapped) GetPrefetchStatus(
-	ctx context.Context, _ tlf.ID, blockID kbfsblock.ID,
+	ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID,
 	cacheType DiskBlockCacheType) (prefetchStatus PrefetchStatus, err error) {
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
@@ -223,6 +252,16 @@ func (cache *diskBlockCacheWrapped) GetPrefetchStatus(
 			return md.PrefetchStatus(), nil
 		case ldberrors.ErrNotFound:
 			if cacheType == DiskBlockSyncCache {
+				// Try moving the block and getting it again.
+				moved := cache.moveBetweenCachesLocked(
+					ctx, tlfID, blockID, cacheType)
+				if moved {
+					md, err := cache.syncCache.GetMetadata(ctx, blockID)
+					if err != nil {
+						return NoPrefetch, err
+					}
+					return md.PrefetchStatus(), nil
+				}
 				return NoPrefetch, err
 			}
 			// Otherwise try the working set cache below.
@@ -299,21 +338,30 @@ func (cache *diskBlockCacheWrapped) Delete(ctx context.Context,
 
 // UpdateMetadata implements the DiskBlockCache interface for
 // diskBlockCacheWrapped.
-func (cache *diskBlockCacheWrapped) UpdateMetadata(ctx context.Context,
-	blockID kbfsblock.ID, prefetchStatus PrefetchStatus) error {
+func (cache *diskBlockCacheWrapped) UpdateMetadata(
+	ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID,
+	prefetchStatus PrefetchStatus, cacheType DiskBlockCacheType) error {
 	// This is a write operation but we are only reading the pointers to the
 	// caches. So we use a read lock.
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
-	// Try to update metadata for both caches.
-	if cache.syncCache != nil {
-		err := cache.syncCache.UpdateMetadata(ctx, blockID, prefetchStatus)
-		_, isNoSuchBlockError := err.(NoSuchBlockError)
-		if !isNoSuchBlockError {
-			return err
-		}
+	primaryCache, secondaryCache := cache.rankCachesLocked(cacheType)
+
+	err := primaryCache.UpdateMetadata(ctx, blockID, prefetchStatus)
+	_, isNoSuchBlockError := errors.Cause(err).(NoSuchBlockError)
+	if !isNoSuchBlockError {
+		return err
 	}
-	return cache.workingSetCache.UpdateMetadata(ctx, blockID, prefetchStatus)
+	if cacheType == DiskBlockSyncCache {
+		// Try moving the block and getting it again.
+		moved := cache.moveBetweenCachesLocked(
+			ctx, tlfID, blockID, cacheType)
+		if moved {
+			err = primaryCache.UpdateMetadata(ctx, blockID, prefetchStatus)
+		}
+		return err
+	}
+	return secondaryCache.UpdateMetadata(ctx, blockID, prefetchStatus)
 }
 
 // ClearAllTlfBlocks implements the DiskBlockCache interface for

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -3689,7 +3689,10 @@ func (fbo *folderBlockOps) MarkNode(
 
 	for _, info := range infos {
 		err = dbc.Mark(ctx, info.BlockPointer.ID, tag, cacheType)
-		if err != nil {
+		switch errors.Cause(err).(type) {
+		case nil:
+		case NoSuchBlockError:
+		default:
 			return err
 		}
 	}

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1319,7 +1319,10 @@ type DiskBlockCache interface {
 		preferredCacheType DiskBlockCacheType) (
 		buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf,
 		prefetchStatus PrefetchStatus, err error)
-	// GetPrefetchStatus returns just the prefetchStatus for the block.
+	// GetPrefetchStatus returns just the prefetchStatus for the
+	// block. If a specific preferred cache type is given, the block
+	// and its metadata are moved to that cache if they're not yet in
+	// it.
 	GetPrefetchStatus(
 		ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID,
 		cacheType DiskBlockCacheType) (PrefetchStatus, error)
@@ -1335,9 +1338,12 @@ type DiskBlockCache interface {
 		ctx context.Context, blockIDs []kbfsblock.ID,
 		cacheType DiskBlockCacheType) (
 		numRemoved int, sizeRemoved int64, err error)
-	// UpdateMetadata updates metadata for a given block in the disk cache.
-	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID,
-		prefetchStatus PrefetchStatus) error
+	// UpdateMetadata updates metadata for a given block in the disk
+	// cache.  If a specific preferred cache type is given, the block
+	// and its metadata are moved to that cache if they're not yet in
+	// it.
+	UpdateMetadata(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID,
+		prefetchStatus PrefetchStatus, cacheType DiskBlockCacheType) error
 	// ClearAllTlfBlocks deletes all the synced blocks corresponding
 	// to the given TLF ID from the cache.  It doesn't affect
 	// transient blocks for unsynced TLFs.
@@ -2673,7 +2679,7 @@ type BlockRetriever interface {
 	// the disk cache metadata is updated.
 	PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID,
 		block Block, lifetime BlockCacheLifetime,
-		prefetchStatus PrefetchStatus) error
+		prefetchStatus PrefetchStatus, cacheType DiskBlockCacheType) error
 	// TogglePrefetcher creates a new prefetcher.
 	TogglePrefetcher(enable bool, syncCh <-chan struct{}) <-chan struct{}
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2681,7 +2681,7 @@ type BlockRetriever interface {
 		block Block, lifetime BlockCacheLifetime,
 		prefetchStatus PrefetchStatus, cacheType DiskBlockCacheType) error
 	// TogglePrefetcher creates a new prefetcher.
-	TogglePrefetcher(enable bool, syncCh <-chan struct{}) <-chan struct{}
+	TogglePrefetcher(enable bool, syncCh <-chan struct{}, doneCh chan<- struct{}) <-chan struct{}
 }
 
 // ChatChannelNewMessageCB is a callback function that can be called

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4381,10 +4381,15 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	require.NoError(t, err)
 	dNode, _, err := kbfsOps2.CreateDir(ctx, rootNode2, "d")
 	require.NoError(t, err)
+	c, err := DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
+	require.NoError(t, err)
+	err = kbfsOps2.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
 	t.Log("Blocks 'b' and 'c' should be synced, nothing else")
+	c <- struct{}{}
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -4411,10 +4416,15 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps2.Write(ctx, fNode, []byte("fdata"), 0)
 	require.NoError(t, err)
+	c, err = DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
+	require.NoError(t, err)
+	err = kbfsOps2.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
 	t.Log("Check that two new blocks are synced")
+	c <- struct{}{}
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -4426,10 +4436,15 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	t.Log("Add something that's not synced")
 	gNode, _, err := kbfsOps2.CreateDir(ctx, dNode, "g")
 	require.NoError(t, err)
+	c, err = DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
+	require.NoError(t, err)
+	err = kbfsOps2.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
 	t.Log("Check that the updated root block is synced, but nothing new")
+	c <- struct{}{}
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -4469,8 +4484,13 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 
 	t.Log("Move a synced subdirectory somewhere else")
 	err = kbfsOps2.Rename(ctx, cNode, "e", dNode, "e")
+	c, err = DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
+	err = kbfsOps2.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
+	c <- struct{}{}
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -10804,17 +10804,17 @@ func (mr *MockBlockRetrieverMockRecorder) PutInCaches(ctx, ptr, tlfID, block, li
 }
 
 // TogglePrefetcher mocks base method
-func (m *MockBlockRetriever) TogglePrefetcher(enable bool, syncCh <-chan struct{}) <-chan struct{} {
+func (m *MockBlockRetriever) TogglePrefetcher(enable bool, syncCh <-chan struct{}, doneCh chan<- struct{}) <-chan struct{} {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TogglePrefetcher", enable, syncCh)
+	ret := m.ctrl.Call(m, "TogglePrefetcher", enable, syncCh, doneCh)
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
 // TogglePrefetcher indicates an expected call of TogglePrefetcher
-func (mr *MockBlockRetrieverMockRecorder) TogglePrefetcher(enable, syncCh interface{}) *gomock.Call {
+func (mr *MockBlockRetrieverMockRecorder) TogglePrefetcher(enable, syncCh, doneCh interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockRetriever)(nil).TogglePrefetcher), enable, syncCh)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockRetriever)(nil).TogglePrefetcher), enable, syncCh, doneCh)
 }
 
 // MockChat is a mock of Chat interface

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -5187,17 +5187,17 @@ func (mr *MockDiskBlockCacheMockRecorder) Delete(ctx, blockIDs, cacheType interf
 }
 
 // UpdateMetadata mocks base method
-func (m *MockDiskBlockCache) UpdateMetadata(ctx context.Context, blockID kbfsblock.ID, prefetchStatus PrefetchStatus) error {
+func (m *MockDiskBlockCache) UpdateMetadata(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, prefetchStatus PrefetchStatus, cacheType DiskBlockCacheType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMetadata", ctx, blockID, prefetchStatus)
+	ret := m.ctrl.Call(m, "UpdateMetadata", ctx, tlfID, blockID, prefetchStatus, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateMetadata indicates an expected call of UpdateMetadata
-func (mr *MockDiskBlockCacheMockRecorder) UpdateMetadata(ctx, blockID, prefetchStatus interface{}) *gomock.Call {
+func (mr *MockDiskBlockCacheMockRecorder) UpdateMetadata(ctx, tlfID, blockID, prefetchStatus, cacheType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetadata", reflect.TypeOf((*MockDiskBlockCache)(nil).UpdateMetadata), ctx, blockID, prefetchStatus)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetadata", reflect.TypeOf((*MockDiskBlockCache)(nil).UpdateMetadata), ctx, tlfID, blockID, prefetchStatus, cacheType)
 }
 
 // ClearAllTlfBlocks mocks base method
@@ -10790,17 +10790,17 @@ func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block
 }
 
 // PutInCaches mocks base method
-func (m *MockBlockRetriever) PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID, block Block, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) error {
+func (m *MockBlockRetriever) PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID, block Block, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus, cacheType DiskBlockCacheType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutInCaches", ctx, ptr, tlfID, block, lifetime, prefetchStatus)
+	ret := m.ctrl.Call(m, "PutInCaches", ctx, ptr, tlfID, block, lifetime, prefetchStatus, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PutInCaches indicates an expected call of PutInCaches
-func (mr *MockBlockRetrieverMockRecorder) PutInCaches(ctx, ptr, tlfID, block, lifetime, prefetchStatus interface{}) *gomock.Call {
+func (mr *MockBlockRetrieverMockRecorder) PutInCaches(ctx, ptr, tlfID, block, lifetime, prefetchStatus, cacheType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutInCaches", reflect.TypeOf((*MockBlockRetriever)(nil).PutInCaches), ctx, ptr, tlfID, block, lifetime, prefetchStatus)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutInCaches", reflect.TypeOf((*MockBlockRetriever)(nil).PutInCaches), ctx, ptr, tlfID, block, lifetime, prefetchStatus, cacheType)
 }
 
 // TogglePrefetcher mocks base method

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -1880,7 +1880,6 @@ func TestPrefetcherReschedules(t *testing.T) {
 	ch := q.Request(
 		ctx, defaultOnDemandRequestPriority, kmd,
 		rootPtr, block, TransientEntry, BlockRequestWithPrefetch)
-	notifySyncCh(t, prefetchSyncCh)
 	err = <-ch
 	require.NoError(t, err)
 
@@ -1888,7 +1887,7 @@ func TestPrefetcherReschedules(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
+		NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Make room in the cache.")
 	setLimiterLimits(limiter, math.MaxInt64, math.MaxInt64)

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -1269,6 +1269,7 @@ func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
 	ctx, cancel := context.WithTimeout(
 		context.Background(), individualTestTimeout)
 	defer cancel()
+	defer cache.Shutdown(ctx)
 	kmd := makeKMD()
 	prefetchSyncCh := make(chan struct{})
 	q.TogglePrefetcher(true, prefetchSyncCh)
@@ -1519,7 +1520,8 @@ func TestPrefetcherUnsyncedPrefetchEvicted(t *testing.T) {
 
 	t.Log("Set the metadata of the block in the disk cache to NoPrefetch, " +
 		"simulating an eviction and a BlockServer.Get.")
-	err = dbc.UpdateMetadata(ctx, rootPtr.ID, NoPrefetch)
+	err = dbc.UpdateMetadata(
+		ctx, kmd.TlfID(), rootPtr.ID, NoPrefetch, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	t.Log("Evict the root block from the block cache.")
@@ -1626,7 +1628,8 @@ func TestPrefetcherUnsyncedPrefetchChildCanceled(t *testing.T) {
 
 	t.Log("Set the metadata of the root block in the disk cache to " +
 		"NoPrefetch, simulating an eviction and a BlockServer.Get.")
-	err = dbc.UpdateMetadata(ctx, rootPtr.ID, NoPrefetch)
+	err = dbc.UpdateMetadata(
+		ctx, kmd.TlfID(), rootPtr.ID, NoPrefetch, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	t.Log("Evict the root block from the block cache.")
@@ -1743,7 +1746,8 @@ func TestPrefetcherUnsyncedPrefetchParentCanceled(t *testing.T) {
 
 	t.Log("Set the metadata of the root block in the disk cache to " +
 		"NoPrefetch, simulating an eviction and a BlockServer.Get.")
-	err = dbc.UpdateMetadata(ctx, rootPtr.ID, NoPrefetch)
+	err = dbc.UpdateMetadata(
+		ctx, kmd.TlfID(), rootPtr.ID, NoPrefetch, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	t.Log("Evict the root block from the block cache.")

--- a/go/kbfs/protocol/kbgitkbfs1/disk_block_cache.go
+++ b/go/kbfs/protocol/kbgitkbfs1/disk_block_cache.go
@@ -97,6 +97,7 @@ type DeleteBlocksArg struct {
 }
 
 type UpdateBlockMetadataArg struct {
+	TlfID          []byte         `codec:"tlfID" json:"tlfID"`
 	BlockID        []byte         `codec:"blockID" json:"blockID"`
 	PrefetchStatus PrefetchStatus `codec:"prefetchStatus" json:"prefetchStatus"`
 }


### PR DESCRIPTION
There were multiple independent problems that needed fixing:

1. Move blocks to sync cache when preferred. We already move blocks to the sync cache on `DiskBlockCache.Get()`, but now that we read the blocks from the in-memory cache without consulting the disk cache, it's rarely called.  So _also_ move the blocks to the sync cache when preferred during `GetPrefetchStatus` and `UpdateMetadata` calls.
2. Ignore `NoSuchBlockError`s during `folderBlockOps.Mark()`.  (Not the cause of any real bugs, but a reasonable cleanup.)
3. During the test, make sure node 2 archives all its unrefs before node 1 cleans its sync cache, by disabling updates on node 1.
4. During the test, always get the prefetch status directly from the sync cache, in case the block was prefetched into the working set cache.
5. The above change to `UpdateMetadata` resulted in an error from that function now when the sync cache is full, unlike before, because  `UpdateMetadata` no longer tries to update the working set cache, which causes `PutInCaches` to return an error, which prevented rescheduling.  So still reschedule in that case, and fix test to reflect the new reality.  (Fixing the test reliably required extra control, so I added a second type of test channel to the prefetcher run loop.)

Might be worth reviewing the commits one by one.

Issue: KBFS-3779