### PR TITLE
Stellar settings: be aware if we can send tx, do not show "Set Inflation" button if not

### DIFF
--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -18,7 +18,7 @@ type WalletAccountLocal struct {
 	AccountMode         AccountMode   `codec:"accountMode" json:"accountMode"`
 	AccountModeEditable bool          `codec:"accountModeEditable" json:"accountModeEditable"`
 	IsFunded            bool          `codec:"isFunded" json:"isFunded"`
-	CanMakeTx           bool          `codec:"canMakeTx" json:"canMakeTx"`
+	CanSubmitTx         bool          `codec:"canSubmitTx" json:"canSubmitTx"`
 }
 
 func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
@@ -32,7 +32,7 @@ func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
 		AccountMode:         o.AccountMode.DeepCopy(),
 		AccountModeEditable: o.AccountModeEditable,
 		IsFunded:            o.IsFunded,
-		CanMakeTx:           o.CanMakeTx,
+		CanSubmitTx:         o.CanSubmitTx,
 	}
 }
 

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -17,6 +17,8 @@ type WalletAccountLocal struct {
 	CurrencyLocal       CurrencyLocal `codec:"currencyLocal" json:"currencyLocal"`
 	AccountMode         AccountMode   `codec:"accountMode" json:"accountMode"`
 	AccountModeEditable bool          `codec:"accountModeEditable" json:"accountModeEditable"`
+	IsFunded            bool          `codec:"isFunded" json:"isFunded"`
+	CanMakeTx           bool          `codec:"canMakeTx" json:"canMakeTx"`
 }
 
 func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
@@ -29,6 +31,8 @@ func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
 		CurrencyLocal:       o.CurrencyLocal.DeepCopy(),
 		AccountMode:         o.AccountMode.DeepCopy(),
 		AccountModeEditable: o.AccountModeEditable,
+		IsFunded:            o.IsFunded,
+		CanMakeTx:           o.CanMakeTx,
 	}
 }
 

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1193,6 +1193,10 @@ func isAccountFunded(ctx context.Context, remoter remote.Remoter, accountID stel
 	if err != nil {
 		return false, err
 	}
+	return hasPositiveLumenBalance(balances)
+}
+
+func hasPositiveLumenBalance(balances []stellar1.Balance) (res bool, err error) {
 	for _, b := range balances {
 		if b.Asset.IsNativeXLM() {
 			a, err := stellarnet.ParseStellarAmount(b.Amount)

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -2156,7 +2156,6 @@ func accountLocal(mctx libkb.MetaContext, remoter remote.Remoter, entry stellar1
 // stellar payment unread count for accountID.
 func AccountDetails(mctx libkb.MetaContext, remoter remote.Remoter, accountID stellar1.AccountID) (stellar1.AccountDetails, error) {
 	details, err := remoter.Details(mctx.Ctx(), accountID)
-	details.SetDefaultDisplayCurrency()
 	if err != nil {
 		return details, err
 	}

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -2156,6 +2156,7 @@ func accountLocal(mctx libkb.MetaContext, remoter remote.Remoter, entry stellar1
 // stellar payment unread count for accountID.
 func AccountDetails(mctx libkb.MetaContext, remoter remote.Remoter, accountID stellar1.AccountID) (stellar1.AccountDetails, error) {
 	details, err := remoter.Details(mctx.Ctx(), accountID)
+	details.SetDefaultDisplayCurrency()
 	if err != nil {
 		return details, err
 	}

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -82,6 +82,8 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.NotEmpty(t, details.Seqno)
 	currencyLocal = details.CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
+	require.True(t, details.IsFunded)
+	require.True(t, details.CanMakeTx)
 
 	argDetails.AccountID = accts[1].AccountID
 	details, err = tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
@@ -92,6 +94,28 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.NotEmpty(t, details.Seqno)
 	currencyLocal = details.CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
+	require.False(t, details.IsFunded)
+	require.False(t, details.CanMakeTx)
+
+	// Add another account that we will add 1 XLM, enough to be funded but not
+	// enough to make any txs out of it.
+	anotherAccountID := tcs[0].Backend.AddAccountEmpty(t)
+	err = tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
+		SecretKey:   tcs[0].Backend.SecretKey(anotherAccountID),
+		MakePrimary: false,
+		Name:        "funded but 0 avail.",
+	})
+	require.NoError(t, err)
+
+	tcs[0].Backend.Gift(anotherAccountID, "1")
+
+	argDetails.AccountID = anotherAccountID
+	details, err = tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
+	require.NoError(t, err)
+	require.Equal(t, "1 XLM", details.BalanceDescription)
+	require.True(t, details.IsFunded)
+	require.False(t, details.CanMakeTx)
+	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), details.CurrencyLocal.Code)
 }
 
 func TestGetAccountAssetsLocalWithBalance(t *testing.T) {

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -83,7 +83,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	currencyLocal = details.CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
 	require.True(t, details.IsFunded)
-	require.True(t, details.CanMakeTx)
+	require.True(t, details.CanSubmitTx)
 
 	argDetails.AccountID = accts[1].AccountID
 	details, err = tcs[0].Srv.GetWalletAccountLocal(context.Background(), argDetails)
@@ -95,7 +95,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	currencyLocal = details.CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
 	require.False(t, details.IsFunded)
-	require.False(t, details.CanMakeTx)
+	require.False(t, details.CanSubmitTx)
 
 	// Add another account that we will add 1 XLM, enough to be funded but not
 	// enough to make any txs out of it.
@@ -114,7 +114,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1 XLM", details.BalanceDescription)
 	require.True(t, details.IsFunded)
-	require.False(t, details.CanMakeTx)
+	require.False(t, details.CanSubmitTx)
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), details.CurrencyLocal.Code)
 }
 

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -917,18 +917,9 @@ func (r *BackendMock) Details(ctx context.Context, tc *TestContext, accountID st
 		return res, err
 	}
 
-	a, ok := r.accounts[accountID]
-	if !ok {
-		// If an account does not exist on the network, return empty details (WAT)
-		res.AccountID = accountID
-		return res, nil
-	}
-	var balances []stellar1.Balance
-	if a.balance.Amount != "" {
-		balances = []stellar1.Balance{a.balance}
-	}
-
-	// fetch the currency display preference for this account
+	// Fetch the currency display preference for this account first,
+	// users are allowed to have currency preferences even for accounts
+	// that do not exist on the network yet.
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/accountcurrency",
 		SessionType: libkb.APISessionTypeREQUIRED,
@@ -943,6 +934,25 @@ func (r *BackendMock) Details(ctx context.Context, tc *TestContext, accountID st
 		return res, err
 	}
 
+	displayCurrency := apiRes.CurrencyDisplayPreference
+
+	a, ok := r.accounts[accountID]
+	if !ok {
+		// If an account does not exist on the network, return something reasonable.
+		return stellar1.AccountDetails{
+			AccountID:       accountID,
+			Seqno:           "0",
+			Balances:        nil,
+			SubentryCount:   0,
+			Available:       "0",
+			DisplayCurrency: displayCurrency,
+		}, nil
+	}
+	var balances []stellar1.Balance
+	if a.balance.Amount != "" {
+		balances = []stellar1.Balance{a.balance}
+	}
+
 	var inflationDest *stellar1.AccountID
 	if a.inflationDest != "" {
 		inflationDest = &a.inflationDest
@@ -954,7 +964,7 @@ func (r *BackendMock) Details(ctx context.Context, tc *TestContext, accountID st
 		Balances:             balances,
 		SubentryCount:        a.subentries,
 		Available:            a.availableBalance(),
-		DisplayCurrency:      apiRes.CurrencyDisplayPreference,
+		DisplayCurrency:      displayCurrency,
 		InflationDestination: inflationDest,
 	}, nil
 }

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -981,13 +981,12 @@ func (r *BackendMock) addAccountRandom(funded bool) stellar1.AccountID {
 		T:         r.T,
 		accountID: stellar1.AccountID(full.Address()),
 		secretKey: stellar1.SecretKey(full.Seed()),
-	}
-	if amount != "" {
-		a.balance = stellar1.Balance{
+		balance: stellar1.Balance{
 			Asset:  stellar1.Asset{Type: "native"},
 			Amount: amount,
-		}
+		},
 	}
+
 	require.Nil(r.T, r.accounts[a.accountID], "attempt to re-add account %v", a.accountID)
 	r.accounts[a.accountID] = a
 	r.seqnos[a.accountID] = uint64(time.Now().UnixNano())

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar/relays"
 	"github.com/keybase/client/go/stellar/remote"
+	"github.com/keybase/stellarnet"
 )
 
 // TransformPaymentSummaryGeneric converts a stellar1.PaymentSummary (p) into a
@@ -461,6 +462,8 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 	deviceProvisionedAt := time.Unix(int64(ctime)/1000, 0)
 	deviceAge := mctx.G().Clock().Since(deviceProvisionedAt)
 
+	canMakeTx := SubtractFeeSoft(mctx, details.Available) != stellarnet.StringFromStellarAmount(0)
+
 	acct := stellar1.WalletAccountLocal{
 		AccountID:           accountID,
 		IsDefault:           isPrimary,
@@ -470,7 +473,7 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 		AccountMode:         accountMode,
 		AccountModeEditable: isMobile && deviceAge > 7*24*time.Hour,
 		IsFunded:            len(details.Balances) > 0,
-		CanMakeTx:           len(details.Balances) > 0,
+		CanMakeTx:           canMakeTx,
 	}
 
 	conf, err := mctx.G().GetStellar().GetServerDefinitions(mctx.Ctx())

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -469,6 +469,8 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 		Seqno:               details.Seqno,
 		AccountMode:         accountMode,
 		AccountModeEditable: isMobile && deviceAge > 7*24*time.Hour,
+		IsFunded:            len(details.Balances) > 0,
+		CanMakeTx:           len(details.Balances) > 0,
 	}
 
 	conf, err := mctx.G().GetStellar().GetServerDefinitions(mctx.Ctx())

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -468,7 +468,7 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 	if err != nil {
 		return empty, err
 	}
-	canMakeTx := availableInt > 100 // base fee is 100
+	canSubmitTx := availableInt > 100 // base fee is 100
 	// TODO: this is something that stellard can just tell us.
 	isFunded, err := hasPositiveLumenBalance(details.Balances)
 	if err != nil {
@@ -484,7 +484,7 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 		AccountMode:         accountMode,
 		AccountModeEditable: isMobile && deviceAge > 7*24*time.Hour,
 		IsFunded:            isFunded,
-		CanMakeTx:           canMakeTx,
+		CanSubmitTx:         canSubmitTx,
 	}
 
 	conf, err := mctx.G().GetStellar().GetServerDefinitions(mctx.Ctx())

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -15,6 +15,8 @@ protocol local {
     CurrencyLocal currencyLocal;// user configurable, defaults to USD and related details
     AccountMode accountMode;    // mobile only vs all devices
     boolean accountModeEditable;// is this device able to change it
+    boolean isFunded;           // does the account have min amount of XLM (exists on the network)
+    boolean canMakeTx;          // does the account have enough XLM for a transaction fee
   }
   array<WalletAccountLocal> getWalletAccountsLocal(int sessionID);
   WalletAccountLocal getWalletAccountLocal(int sessionID, AccountID accountID);

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -15,8 +15,8 @@ protocol local {
     CurrencyLocal currencyLocal;// user configurable, defaults to USD and related details
     AccountMode accountMode;    // mobile only vs all devices
     boolean accountModeEditable;// is this device able to change it
-    boolean isFunded;           // does the account have min amount of XLM (exists on the network)
-    boolean canMakeTx;          // does the account have enough XLM for a transaction fee
+    boolean isFunded;           // does the account have minimum amount of XLM to exist on the network
+    boolean canSubmitTx;        // does the account have enough XLM to submit a transaction (enough for the fee)
   }
   array<WalletAccountLocal> getWalletAccountsLocal(int sessionID);
   WalletAccountLocal getWalletAccountLocal(int sessionID, AccountID accountID);

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -42,6 +42,14 @@
         {
           "type": "boolean",
           "name": "accountModeEditable"
+        },
+        {
+          "type": "boolean",
+          "name": "isFunded"
+        },
+        {
+          "type": "boolean",
+          "name": "canMakeTx"
         }
       ]
     },

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -49,7 +49,7 @@
         },
         {
           "type": "boolean",
-          "name": "canMakeTx"
+          "name": "canSubmitTx"
         }
       ]
     },

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -449,7 +449,7 @@ export type TransactionStatus =
   | 4 // ERROR_PERMANENT_4
 
 export type UIPaymentReviewed = $ReadOnly<{bid: BuildPaymentID, reviewID: Int, seqno: Int, banners?: ?Array<SendBannerLocal>, nextButton: String}>
-export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal, accountMode: AccountMode, accountModeEditable: Boolean, isFunded: Boolean, canMakeTx: Boolean}>
+export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal, accountMode: AccountMode, accountModeEditable: Boolean, isFunded: Boolean, canSubmitTx: Boolean}>
 
 export type IncomingCallMapType = {|
   'stellar.1.notify.paymentNotification'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.paymentNotification'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -449,7 +449,7 @@ export type TransactionStatus =
   | 4 // ERROR_PERMANENT_4
 
 export type UIPaymentReviewed = $ReadOnly<{bid: BuildPaymentID, reviewID: Int, seqno: Int, banners?: ?Array<SendBannerLocal>, nextButton: String}>
-export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal, accountMode: AccountMode, accountModeEditable: Boolean}>
+export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal, accountMode: AccountMode, accountModeEditable: Boolean, isFunded: Boolean, canMakeTx: Boolean}>
 
 export type IncomingCallMapType = {|
   'stellar.1.notify.paymentNotification'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.paymentNotification'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -220,7 +220,7 @@ export type _Account = {
   name: string,
   mobileOnlyEditable: boolean,
   isFunded: boolean,
-  canMakeTx: boolean,
+  canSubmitTx: boolean,
 }
 export type Account = I.RecordOf<_Account>
 

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -219,6 +219,8 @@ export type _Account = {
   isDefault: boolean,
   name: string,
   mobileOnlyEditable: boolean,
+  isFunded: boolean,
+  canMakeTx: boolean,
 }
 export type Account = I.RecordOf<_Account>
 

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -219,7 +219,6 @@ export type _Account = {
   isDefault: boolean,
   name: string,
   mobileOnlyEditable: boolean,
-  isFunded: boolean,
   canSubmitTx: boolean,
 }
 export type Account = I.RecordOf<_Account>

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -166,7 +166,7 @@ export const accountResultToAccount = (w: RPCTypes.WalletAccountLocal) =>
   makeAccount({
     accountID: Types.stringToAccountID(w.accountID),
     balanceDescription: w.balanceDescription,
-    canMakeTx: w.canMakeTx,
+    canSubmitTx: w.canSubmitTx,
     displayCurrency: currencyResultToCurrency(w.currencyLocal),
     isDefault: w.isDefault,
     mobileOnlyEditable: w.accountModeEditable,
@@ -269,7 +269,7 @@ export const unknownCurrency = makeCurrency()
 export const makeAccount: I.RecordFactory<Types._Account> = I.Record({
   accountID: Types.noAccountID,
   balanceDescription: '',
-  canMakeTx: false,
+  canSubmitTx: false,
   displayCurrency: unknownCurrency,
   isDefault: false,
   mobileOnlyEditable: false,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -170,7 +170,6 @@ export const accountResultToAccount = (w: RPCTypes.WalletAccountLocal) =>
     displayCurrency: currencyResultToCurrency(w.currencyLocal),
     isDefault: w.isDefault,
     mobileOnlyEditable: w.accountModeEditable,
-    isFunded: w.isFunded,
     name: w.name,
   })
 
@@ -273,7 +272,6 @@ export const makeAccount: I.RecordFactory<Types._Account> = I.Record({
   displayCurrency: unknownCurrency,
   isDefault: false,
   mobileOnlyEditable: false,
-  isFunded: false,
   name: '',
 })
 export const unknownAccount = makeAccount()

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -166,9 +166,11 @@ export const accountResultToAccount = (w: RPCTypes.WalletAccountLocal) =>
   makeAccount({
     accountID: Types.stringToAccountID(w.accountID),
     balanceDescription: w.balanceDescription,
+    canMakeTx: w.canMakeTx,
     displayCurrency: currencyResultToCurrency(w.currencyLocal),
     isDefault: w.isDefault,
     mobileOnlyEditable: w.accountModeEditable,
+    isFunded: w.isFunded,
     name: w.name,
   })
 
@@ -267,9 +269,11 @@ export const unknownCurrency = makeCurrency()
 export const makeAccount: I.RecordFactory<Types._Account> = I.Record({
   accountID: Types.noAccountID,
   balanceDescription: '',
+  canMakeTx: false,
   displayCurrency: unknownCurrency,
   isDefault: false,
   mobileOnlyEditable: false,
+  isFunded: false,
   name: '',
 })
 export const unknownAccount = makeAccount()

--- a/shared/wallets/wallet/settings/container.js
+++ b/shared/wallets/wallet/settings/container.js
@@ -25,12 +25,12 @@ const mapStateToProps = (state, {routeProps}) => {
   const saveCurrencyWaiting = anyWaiting(state, Constants.changeDisplayCurrencyWaitingKey)
   const mobileOnlyMode = state.wallets.mobileOnlyMap.get(accountID, false)
   const mobileOnlyWaiting = anyWaiting(state, Constants.setAccountMobileOnlyWaitingKey(accountID))
-  const canMakeTx = account.canMakeTx
+  const canSubmitTx = account.canSubmitTx
 
   const inflationDest = Constants.getInflationDestination(state, accountID)
   return {
     accountID,
-    canMakeTx,
+    canSubmitTx,
     currencies,
     currency,
     currencyWaiting,

--- a/shared/wallets/wallet/settings/container.js
+++ b/shared/wallets/wallet/settings/container.js
@@ -25,10 +25,12 @@ const mapStateToProps = (state, {routeProps}) => {
   const saveCurrencyWaiting = anyWaiting(state, Constants.changeDisplayCurrencyWaitingKey)
   const mobileOnlyMode = state.wallets.mobileOnlyMap.get(accountID, false)
   const mobileOnlyWaiting = anyWaiting(state, Constants.setAccountMobileOnlyWaitingKey(accountID))
+  const canMakeTx = account.canMakeTx
 
   const inflationDest = Constants.getInflationDestination(state, accountID)
   return {
     accountID,
+    canMakeTx,
     currencies,
     currency,
     currencyWaiting,

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -188,7 +188,7 @@ class AccountSettings extends React.Component<SettingsProps> {
               )}
               {!props.canSubmitTx && (
                 <Kb.Text type="BodySmall">
-                  Your account needs a minimum balance to set an inflation destination.
+                  Your account needs more funds to set an inflation destination.
                 </Kb.Text>
               )}
             </Kb.Box2>

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -16,6 +16,7 @@ export type SettingsProps = {|
   currencyWaiting: boolean,
   currency: Types.Currency,
   currencies: I.List<Types.Currency>,
+  canMakeTx: boolean,
   onBack: () => void,
   onDelete: () => void,
   onSetDefault: () => void,
@@ -177,12 +178,19 @@ class AccountSettings extends React.Component<SettingsProps> {
                   {props.inflationDestination}
                 </Kb.Text>
               )}
-              <Kb.Button
-                type="Secondary"
-                label={props.inflationDestination ? 'Change' : 'Set up'}
-                onClick={props.onSetupInflation}
-                style={styles.setupInflation}
-              />
+              {!!props.canMakeTx && (
+                <Kb.Button
+                  type="Secondary"
+                  label={props.inflationDestination ? 'Change' : 'Set up'}
+                  onClick={props.onSetupInflation}
+                  style={styles.setupInflation}
+                />
+              )}
+              {!props.canMakeTx && (
+                <Kb.Text type="BodySmall">
+                  Your accounts needs minimum balance to set inflation destination.
+                </Kb.Text>
+              )}
             </Kb.Box2>
             <Kb.Box2
               direction="vertical"

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -16,7 +16,7 @@ export type SettingsProps = {|
   currencyWaiting: boolean,
   currency: Types.Currency,
   currencies: I.List<Types.Currency>,
-  canMakeTx: boolean,
+  canSubmitTx: boolean,
   onBack: () => void,
   onDelete: () => void,
   onSetDefault: () => void,
@@ -178,7 +178,7 @@ class AccountSettings extends React.Component<SettingsProps> {
                   {props.inflationDestination}
                 </Kb.Text>
               )}
-              {!!props.canMakeTx && (
+              {!!props.canSubmitTx && (
                 <Kb.Button
                   type="Secondary"
                   label={props.inflationDestination ? 'Change' : 'Set up'}
@@ -186,7 +186,7 @@ class AccountSettings extends React.Component<SettingsProps> {
                   style={styles.setupInflation}
                 />
               )}
-              {!props.canMakeTx && (
+              {!props.canSubmitTx && (
                 <Kb.Text type="BodySmall">
                   Your accounts needs a minimum balance to set an inflation destination.
                 </Kb.Text>

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -188,7 +188,7 @@ class AccountSettings extends React.Component<SettingsProps> {
               )}
               {!props.canMakeTx && (
                 <Kb.Text type="BodySmall">
-                  Your accounts needs minimum balance to set inflation destination.
+                  Your accounts needs a minimum balance to set an inflation destination.
                 </Kb.Text>
               )}
             </Kb.Box2>

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -188,7 +188,7 @@ class AccountSettings extends React.Component<SettingsProps> {
               )}
               {!props.canSubmitTx && (
                 <Kb.Text type="BodySmall">
-                  Your accounts needs a minimum balance to set an inflation destination.
+                  Your account needs a minimum balance to set an inflation destination.
                 </Kb.Text>
               )}
             </Kb.Box2>

--- a/shared/wallets/wallet/settings/index.stories.js
+++ b/shared/wallets/wallet/settings/index.stories.js
@@ -42,7 +42,7 @@ const testCurrencies = I.List([
 
 const sharedSettingsProps = {
   accountID: Types.noAccountID,
-  canMakeTx: true,
+  canSubmitTx: true,
   currencies: testCurrencies,
   currencyWaiting: false,
   inflationDestination: '',
@@ -83,7 +83,7 @@ const load = () => {
       <Settings {...defaultSettingsProps} inflationDestination="Stellar Development Foundation" />
     ))
     .add("Not founded account (can't make tx)", () => (
-      <Settings {...defaultSettingsProps} canMakeTx={false} />
+      <Settings {...defaultSettingsProps} canSubmitTx={false} />
     ))
     .add('Secondary', () => <Settings {...secondarySettingsProps} />)
     .add('MobileOnlyEditable', () => <Settings {...secondarySettingsProps} mobileOnlyEditable={true} />)

--- a/shared/wallets/wallet/settings/index.stories.js
+++ b/shared/wallets/wallet/settings/index.stories.js
@@ -82,7 +82,7 @@ const load = () => {
     .add('Default with inflation dest', () => (
       <Settings {...defaultSettingsProps} inflationDestination="Stellar Development Foundation" />
     ))
-    .add("Not founded account (can't make tx)", () => (
+    .add("Not funded account (can't make tx)", () => (
       <Settings {...defaultSettingsProps} canSubmitTx={false} />
     ))
     .add('Secondary', () => <Settings {...secondarySettingsProps} />)

--- a/shared/wallets/wallet/settings/index.stories.js
+++ b/shared/wallets/wallet/settings/index.stories.js
@@ -42,6 +42,7 @@ const testCurrencies = I.List([
 
 const sharedSettingsProps = {
   accountID: Types.noAccountID,
+  canMakeTx: true,
   currencies: testCurrencies,
   currencyWaiting: false,
   inflationDestination: '',
@@ -80,6 +81,9 @@ const load = () => {
     .add('Default', () => <Settings {...defaultSettingsProps} />)
     .add('Default with inflation dest', () => (
       <Settings {...defaultSettingsProps} inflationDestination="Stellar Development Foundation" />
+    ))
+    .add("Not founded account (can't make tx)", () => (
+      <Settings {...defaultSettingsProps} canMakeTx={false} />
     ))
     .add('Secondary', () => <Settings {...secondarySettingsProps} />)
     .add('MobileOnlyEditable', () => <Settings {...secondarySettingsProps} mobileOnlyEditable={true} />)


### PR DESCRIPTION
Present the distinction between "funded accounts" and not to the frontend, as well as another field that says whether there is enough to make a tx or not. Use this info to hide "Set inflation" button if this account can't set any inflation yet.