### PR TITLE
use consistent envfile directory

### DIFF
--- a/go/client/cmd_ctl_nix.go
+++ b/go/client/cmd_ctl_nix.go
@@ -513,7 +513,7 @@ func (c *CmdCtlInit) RunEnv() error {
 		fmt.Printf("Writing following text to %s...\n", envfileName)
 		fmt.Print(s)
 	} else {
-		err := os.MkdirAll(c.G().Env.GetConfigDir(), 0755)
+		err := os.MkdirAll(c.G().Env.GetEnvFileDir(), 0755)
 		if err != nil {
 			return err
 		}

--- a/go/client/cmd_ctl_nix.go
+++ b/go/client/cmd_ctl_nix.go
@@ -513,7 +513,11 @@ func (c *CmdCtlInit) RunEnv() error {
 		fmt.Printf("Writing following text to %s...\n", envfileName)
 		fmt.Print(s)
 	} else {
-		err := os.MkdirAll(c.G().Env.GetEnvFileDir(), 0755)
+		dir, err := c.G().Env.GetEnvFileDir()
+		if err != nil {
+			return err
+		}
+		err = os.MkdirAll(dir, 0755)
 		if err != nil {
 			return err
 		}

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -553,10 +553,16 @@ func (e *Env) GetRootConfigFilename() (string, error) {
 	return filepath.Join(dir, "config.json"), nil
 }
 
+func (e *Env) GetEnvFileDir() string {
+	// Do not respect $XDG_CONFIG_HOME due to debian systemd 229 not supporting %E
+	// see keybase.service systemd unit
+	return filepath.Join(e.GetHome(), ".config", "keybase")
+}
+
 func (e *Env) GetEnvfileName() (string, error) {
 	switch RuntimeGroup() {
 	case keybase1.RuntimeGroup_LINUXLIKE:
-		return filepath.Join(e.GetConfigDir(), "keybase.autogen.env"), nil
+		return filepath.Join(e.GetEnvFileDir(), "keybase.autogen.env"), nil
 	default:
 		return "", fmt.Errorf("No envfile for %s.", runtime.GOOS)
 	}
@@ -565,7 +571,7 @@ func (e *Env) GetEnvfileName() (string, error) {
 func (e *Env) GetOverrideEnvfileName() (string, error) {
 	switch RuntimeGroup() {
 	case keybase1.RuntimeGroup_LINUXLIKE:
-		return filepath.Join(e.GetConfigDir(), "keybase.env"), nil
+		return filepath.Join(e.GetEnvFileDir(), "keybase.env"), nil
 	default:
 		return "", fmt.Errorf("No envfile override for %s.", runtime.GOOS)
 	}

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -553,28 +553,31 @@ func (e *Env) GetRootConfigFilename() (string, error) {
 	return filepath.Join(dir, "config.json"), nil
 }
 
-func (e *Env) GetEnvFileDir() string {
-	// Do not respect $XDG_CONFIG_HOME due to debian systemd 229 not supporting %E
-	// see keybase.service systemd unit
-	return filepath.Join(e.GetHome(), ".config", "keybase")
+func (e *Env) GetEnvFileDir() (string, error) {
+	switch RuntimeGroup() {
+	case keybase1.RuntimeGroup_LINUXLIKE:
+		// Do not respect $XDG_CONFIG_HOME due to debian systemd 229 not supporting %E
+		// see keybase.service systemd unit
+		return filepath.Join(e.GetHome(), ".config", "keybase"), nil
+	default:
+		return "", fmt.Errorf("No envfiledir for %s.", runtime.GOOS)
+	}
 }
 
 func (e *Env) GetEnvfileName() (string, error) {
-	switch RuntimeGroup() {
-	case keybase1.RuntimeGroup_LINUXLIKE:
-		return filepath.Join(e.GetEnvFileDir(), "keybase.autogen.env"), nil
-	default:
-		return "", fmt.Errorf("No envfile for %s.", runtime.GOOS)
+	dir, err := e.GetEnvFileDir()
+	if err != nil {
+		return "", err
 	}
+	return filepath.Join(dir, "keybase.autogen.env"), nil
 }
 
 func (e *Env) GetOverrideEnvfileName() (string, error) {
-	switch RuntimeGroup() {
-	case keybase1.RuntimeGroup_LINUXLIKE:
-		return filepath.Join(e.GetEnvFileDir(), "keybase.env"), nil
-	default:
-		return "", fmt.Errorf("No envfile override for %s.", runtime.GOOS)
+	dir, err := e.GetEnvFileDir()
+	if err != nil {
+		return "", err
 	}
+	return filepath.Join(dir, "keybase.env"), nil
 }
 
 func (e *Env) GetConfigFilename() string {

--- a/packaging/linux/systemd/keybase.service
+++ b/packaging/linux/systemd/keybase.service
@@ -10,7 +10,7 @@ Environment=KEYBASE_SERVICE_TYPE=systemd
 EnvironmentFile=-%t/keybase/keybase.env
 
 # Use %h/.config instead of %E because %E isn't supported in systemd 229
-# though this breaks non-standard $XDG_CONFIG_HOMEs
+# though this breaks non-standard $XDG_CONFIG_HOMEs.
 # See GetEnvFileDir; change when Debian
 # updates to a systemd version accepting %E.
 EnvironmentFile=-%h/.config/keybase/keybase.autogen.env

--- a/packaging/linux/systemd/keybase.service
+++ b/packaging/linux/systemd/keybase.service
@@ -11,6 +11,8 @@ EnvironmentFile=-%t/keybase/keybase.env
 
 # Use %h/.config instead of %E because %E isn't supported in systemd 229
 # though this breaks non-standard $XDG_CONFIG_HOMEs
+# See GetEnvFileDir; change when Debian
+# updates to a systemd version accepting %E.
 EnvironmentFile=-%h/.config/keybase/keybase.autogen.env
 EnvironmentFile=-%h/.config/keybase/keybase.env
 


### PR DESCRIPTION
I had a workaround in the unitfile to use $HOME/.config and not respect $XDG_CONFIG_HOME due to systemd issues, but did not change go code to reflect that.