### PR TITLE
add KEYBASE_PROVE_BYPASS

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -78,8 +78,10 @@ func newIdentify2WithUIDTester(g *libkb.GlobalContext) *Identify2WithUIDTester {
 	}
 }
 
-func (i *Identify2WithUIDTester) ListProofCheckers() []string                         { return nil }
-func (i *Identify2WithUIDTester) ListServicesThatAcceptNewProofs() []string           { return nil }
+func (i *Identify2WithUIDTester) ListProofCheckers() []string { return nil }
+func (i *Identify2WithUIDTester) ListServicesThatAcceptNewProofs(libkb.MetaContext) []string {
+	return nil
+}
 func (i *Identify2WithUIDTester) ListDisplayConfigs() []keybase1.ServiceDisplayConfig { return nil }
 func (i *Identify2WithUIDTester) SuggestionFoldPriority() int                         { return 0 }
 func (i *Identify2WithUIDTester) Key() string                                         { return i.GetTypeName() }

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -324,7 +324,7 @@ func (p *Prove) getServiceType(m libkb.MetaContext) (err error) {
 	if p.st == nil {
 		return libkb.BadServiceError{Service: p.arg.Service}
 	}
-	if !p.st.CanMakeNewProofs() {
+	if !p.st.CanMakeNewProofs(m) {
 		return libkb.ServiceDoesNotSupportNewProofsError{Service: p.arg.Service}
 	}
 	return nil

--- a/go/externals/proof_service_facebook.go
+++ b/go/externals/proof_service_facebook.go
@@ -70,7 +70,7 @@ func (t *FacebookServiceType) GetPrompt() string {
 
 // TODO remove this in favor of server flag when server configs are enabled
 // with CORE-9923
-func (t *FacebookServiceType) CanMakeNewProofs() bool { return false }
+func (t *FacebookServiceType) CanMakeNewProofs(libkb.MetaContext) bool { return false }
 
 func (t *FacebookServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)

--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -72,13 +72,13 @@ func (p *proofServices) ListProofCheckers() []string {
 	return ret
 }
 
-func (p *proofServices) ListServicesThatAcceptNewProofs() []string {
+func (p *proofServices) ListServicesThatAcceptNewProofs(mctx libkb.MetaContext) []string {
 	p.Lock()
 	defer p.Unlock()
 	p.loadServiceConfigs()
 	var ret []string
 	for k, v := range p.externalServices {
-		if v.CanMakeNewProofs() {
+		if v.CanMakeNewProofs(mctx) {
 			ret = append(ret, k)
 		}
 	}

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -96,6 +96,9 @@ func (p CommandLine) GetPvlKitFilename() string {
 func (p CommandLine) GetParamProofKitFilename() string {
 	return p.GetGString("paramproof-kit")
 }
+func (p CommandLine) GetProveBypass() (bool, bool) {
+	return p.GetBool("prove-bypass", true)
+}
 func (p CommandLine) GetDebug() (bool, bool) {
 	// --no-debug suppresses --debug. Note that although we don't define a
 	// separate GetNoDebug() accessor, fork_server.go still looks for
@@ -582,6 +585,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.StringFlag{
 			Name:  "paramproof-kit",
 			Usage: "Specify an alternate local parameterized proof kit file location.",
+		},
+		cli.BoolFlag{
+			Name:  "prove-bypass",
+			Usage: "Prove even disabled proof services",
 		},
 		cli.BoolFlag{
 			Name:  "remember-passphrase",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -429,6 +429,9 @@ func (f *JSONConfigFile) GetPvlKitFilename() string {
 func (f *JSONConfigFile) GetParamProofKitFilename() string {
 	return f.GetTopLevelString("paramproof_kit")
 }
+func (f *JSONConfigFile) GetProveBypass() (bool, bool) {
+	return f.GetBoolAtPath("prove_bypass")
+}
 func (f *JSONConfigFile) GetPinentry() string {
 	res, _ := f.GetStringAtPath("pinentry.path")
 	return res

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -31,6 +31,7 @@ func (n NullConfiguration) GetDbFilename() string                               
 func (n NullConfiguration) GetChatDbFilename() string                                      { return "" }
 func (n NullConfiguration) GetPvlKitFilename() string                                      { return "" }
 func (n NullConfiguration) GetParamProofKitFilename() string                               { return "" }
+func (n NullConfiguration) GetProveBypass() (bool, bool)                                   { return false, false }
 func (n NullConfiguration) GetUsername() NormalizedUsername                                { return NormalizedUsername("") }
 func (n NullConfiguration) GetEmail() string                                               { return "" }
 func (n NullConfiguration) GetUpgradePerUserKey() (bool, bool)                             { return false, false }
@@ -663,6 +664,15 @@ func (e *Env) GetParamProofKitFilename() string {
 		func() string { return os.Getenv("KEYBASE_PARAM_PROOF_KIT_FILE") },
 		func() string { return e.GetConfig().GetParamProofKitFilename() },
 	)
+}
+
+// GetProveBypass ignores creation_disabled so that the client will let the user
+// try to make a proof for any known service.
+func (e *Env) GetProveBypass() bool {
+	return e.GetBool(false,
+		func() (bool, bool) { return e.cmd.GetProveBypass() },
+		func() (bool, bool) { return e.getEnvBool("KEYBASE_PROVE_BYPASS") },
+		func() (bool, bool) { return e.GetConfig().GetProveBypass() })
 }
 
 func (e *Env) GetDebug() bool {

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -953,11 +953,10 @@ type ServiceDoesNotSupportNewProofsError struct {
 }
 
 func (e ServiceDoesNotSupportNewProofsError) Error() string {
-	service := e.Service
-	if len(service) > 0 {
-		service = fmt.Sprintf("%q", service)
+	if len(e.Service) == 0 {
+		return fmt.Sprintf("New proofs of that type are not supported")
 	}
-	return fmt.Sprintf("New %s proofs are no longer supported", service)
+	return fmt.Sprintf("New %s proofs are not supported", e.Service)
 }
 
 //=============================================================================

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -41,6 +41,7 @@ type configGetter interface {
 	GetChatDbFilename() string
 	GetPvlKitFilename() string
 	GetParamProofKitFilename() string
+	GetProveBypass() (bool, bool)
 	GetCodeSigningKIDs() []string
 	GetConfigFilename() string
 	GetDbFilename() string
@@ -598,7 +599,7 @@ type ServiceType interface {
 
 	MakeProofChecker(l RemoteProofChainLink) ProofChecker
 	SetDisplayConfig(*keybase1.ServiceDisplayConfig)
-	CanMakeNewProofs() bool
+	CanMakeNewProofs(mctx MetaContext) bool
 	DisplayPriority() int
 	DisplayGroup() string
 }
@@ -606,7 +607,7 @@ type ServiceType interface {
 type ExternalServicesCollector interface {
 	GetServiceType(n string) ServiceType
 	ListProofCheckers() []string
-	ListServicesThatAcceptNewProofs() []string
+	ListServicesThatAcceptNewProofs(MetaContext) []string
 	ListDisplayConfigs() (res []keybase1.ServiceDisplayConfig)
 	SuggestionFoldPriority() int
 }

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -158,9 +158,12 @@ func (t *BaseServiceType) DisplayGroup() string {
 	return *t.displayConf.Group
 }
 
-func (t *BaseServiceType) CanMakeNewProofs() bool {
+func (t *BaseServiceType) CanMakeNewProofs(mctx MetaContext) bool {
 	t.Lock()
 	defer t.Unlock()
+	if mctx.G().GetEnv().GetProveBypass() {
+		return true
+	}
 	if t.displayConf == nil {
 		return true
 	}

--- a/go/service/prove.go
+++ b/go/service/prove.go
@@ -107,5 +107,6 @@ func (ph *ProveHandler) CheckProof(ctx context.Context, arg keybase1.CheckProofA
 func (ph *ProveHandler) ListProofServices(ctx context.Context) (res []string, err error) {
 	ctx = libkb.WithLogTag(ctx, "PV")
 	defer ph.G().CTraceTimed(ctx, fmt.Sprintf("ListProofServices"), func() error { return err })()
-	return ph.G().GetProofServices().ListServicesThatAcceptNewProofs(), nil
+	mctx := libkb.NewMetaContext(ctx, ph.G())
+	return ph.G().GetProofServices().ListServicesThatAcceptNewProofs(mctx), nil
 }

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -416,7 +416,7 @@ func (h *UserHandler) proofSuggestionsHelper(mctx libkb.MetaContext) (ret []Proo
 	}
 
 	var suggestions []ProofSuggestion
-	serviceKeys := mctx.G().GetProofServices().ListServicesThatAcceptNewProofs()
+	serviceKeys := mctx.G().GetProofServices().ListServicesThatAcceptNewProofs(mctx)
 	for _, service := range serviceKeys {
 		switch service {
 		case "web", "dns", "http", "https":


### PR DESCRIPTION
Using the env var `KEYBASE_PROVE_BYPASS` or flag `--prove-bypass` on the service (not the client) will make your client ignore `creation_disabled` for all proof types. (Except facebook which is still hardcoded in the client)

cc @xgess 