### PR TITLE
Don't try to show a loading line on the left side of the inbox sidebar on desktop

### DIFF
--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -155,11 +155,6 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
             onClick={this.props.onNewChat}
           />
         )}
-        {this.props.isLoading && (
-          <Kb.Box style={styles.loadingContainer}>
-            <Kb.LoadingLine />
-          </Kb.Box>
-        )}
       </Kb.Box2>
     )
   }


### PR DESCRIPTION
@keybase/react-hackers CC @songgao 

A little hard to follow the intent of the change here, but I think this gets us back to where we were -- the loading line lives at this point (underneath "Jump to Chat...") on mobile, but here in this desktop codepath we do the loading state on the right hand side of the sidebar instead, so I think this component shouldn't be here.  It was causing "Jump to Chat..." to change size as you move between convos on desktop.