### PR TITLE
Add startup states for menubar

### DIFF
--- a/shared/constants/types/config.js
+++ b/shared/constants/types/config.js
@@ -11,6 +11,7 @@ export type _OutOfDate = {
   updating: boolean,
 }
 export type OutOfDate = I.RecordOf<_OutOfDate>
+export type DaemonHandshakeState = 'starting' | 'waitingForWaiters' | 'done'
 
 export type _State = {
   appFocused: boolean,
@@ -18,7 +19,7 @@ export type _State = {
   avatars: I.Map<string, I.Map<number, string>>,
   configuredAccounts: I.List<string>,
   daemonError: ?Error,
-  daemonHandshakeState: 'starting' | 'waitingForWaiters' | 'done',
+  daemonHandshakeState: DaemonHandshakeState,
   daemonHandshakeFailedReason: string,
   daemonHandshakeRetriesLeft: number,
   daemonHandshakeWaiters: I.Map<string, number>,

--- a/shared/menubar/index.stories.desktop.js
+++ b/shared/menubar/index.stories.desktop.js
@@ -25,6 +25,7 @@ const props = {
   conversations: [
     // TODO: fill in a few.
   ],
+  daemonHandshakeState: 'done',
   fileName: null,
   files: 0,
   folderProps: null,
@@ -62,6 +63,8 @@ const load = () => {
   Storybook.storiesOf('Menubar', module)
     .addDecorator(providers)
     .add('Normal', () => <Menubar {...props} />)
+    .add('Starting up', () => <Menubar {...props} daemonHandshakeState={'starting'} />)
+    .add('Waiting on bootstrap', () => <Menubar {...props} daemonHandshakeState={'waitingForWaiters'} />)
     .add('Not logged in', () => <Menubar {...props} loggedIn={false} />)
     .add('With a file notification', () => (
       <Menubar

--- a/shared/menubar/remote-proxy.desktop.js
+++ b/shared/menubar/remote-proxy.desktop.js
@@ -41,6 +41,7 @@ const mapStateToProps = state => ({
   _tlfUpdates: state.fs.tlfUpdates,
   _uploads: state.fs.uploads,
   conversationsToSend: conversationsToSend(state),
+  daemonHandshakeState: state.config.daemonHandshakeState,
   loggedIn: state.config.loggedIn,
   outOfDate: state.config.outOfDate,
   userInfo: state.users.infoMap,
@@ -60,6 +61,7 @@ const mergeProps = stateProps => {
     clearCacheTrigger: _lastClearCacheTrigger,
     conversationIDs: stateProps.conversationsToSend,
     conversationMap: stateProps.conversationsToSend,
+    daemonHandshakeState: stateProps.daemonHandshakeState,
     externalRemoteWindow: stateProps._externalRemoteWindowID
       ? SafeElectron.getRemote().BrowserWindow.fromId(stateProps._externalRemoteWindowID)
       : null,

--- a/shared/menubar/remote-serializer.desktop.js
+++ b/shared/menubar/remote-serializer.desktop.js
@@ -36,6 +36,7 @@ export const serialize: any = {
             [toSend.conversation.conversationIDKey]: conversationSerialize(toSend),
           }
     }, {}),
+  daemonHandshakeState: v => v,
   endEstimate: v => v,
   externalRemoteWindow: v => v,
   fileName: v => v,


### PR DESCRIPTION
@keybase/react-hackers part of DESKTOP-8486

Adds startup states for the keybase menubar when the app is starting up:

daemonHandshakeState === 'starting'
<img width="472" alt="screen shot 2019-01-30 at 1 30 22 pm" src="https://user-images.githubusercontent.com/594035/52010753-8748d300-2493-11e9-825d-63e99de99922.png">


=== 'waitingForWaitiers'

<img width="472" alt="screen shot 2019-01-30 at 1 30 37 pm" src="https://user-images.githubusercontent.com/594035/52010765-90d23b00-2493-11e9-903a-9b70e9075c51.png">


I would have liked to cleanup the file, but I was optimizing for turnaround time. Cleanup is DESKTOP-8883