### PR TITLE
Reactji bar: increase size 16->18

### DIFF
--- a/shared/chat/conversation/messages/react-button/emoji-row/index.js
+++ b/shared/chat/conversation/messages/react-button/emoji-row/index.js
@@ -33,12 +33,12 @@ class HoverEmoji extends React.Component<
         {this.props.isReacjiIcon ? (
           <Kb.Icon
             color={Styles.globalColors.black_50}
-            fontSize={this.state.hovering ? 22 : 16}
+            fontSize={this.state.hovering ? 22 : 18}
             style={Kb.iconCastPlatformStyles(styles.reacjiIcon)}
             type="iconfont-reacji"
           />
         ) : (
-          <Kb.Emoji size={this.state.hovering ? 22 : 16} emojiName={this.props.name} />
+          <Kb.Emoji size={this.state.hovering ? 22 : 18} emojiName={this.props.name} />
         )}
       </Kb.ClickableBox>
     )

--- a/shared/chat/conversation/messages/react-button/index.js
+++ b/shared/chat/conversation/messages/react-button/index.js
@@ -71,7 +71,7 @@ const ReactButton = (props: Props) => (
   >
     <Box2 centerChildren={true} fullHeight={true} direction="horizontal" gap="xtiny" style={styles.container}>
       <Box2 direction="horizontal" style={styles.emojiWrapper}>
-        <EmojiIfExists size={16} lineClamp={1} emojiName={props.emoji} />
+        <EmojiIfExists size={Styles.isMobile ? 16 : 18} lineClamp={1} emojiName={props.emoji} />
       </Box2>
       <Text
         type="BodyTinyBold"
@@ -195,7 +195,7 @@ export class NewReactionButton extends React.Component<NewReactionButtonProps, N
                 key={iconName}
                 type={iconName}
                 color={this.state.hovering ? Styles.globalColors.black_50 : Styles.globalColors.black_50}
-                fontSize={16}
+                fontSize={18}
                 style={iconCastPlatformStyles(
                   Styles.collapseStyles([
                     styles.emojiIconWrapper,


### PR DESCRIPTION
@keybase/react-hackers 

The reactji bar does a zoom on hover from 16 to 22px -- the 16pt looks very small on non-retina desktop, so change it to go from 18 to 22px.