### PR TITLE
check that input is focused before showing suggestions

### DIFF
--- a/shared/chat/conversation/input-area/suggestors/index.js
+++ b/shared/chat/conversation/input-area/suggestors/index.js
@@ -178,7 +178,7 @@ const AddSuggestors = <WrappedOwnProps: {}, WrappedState>(
           this.props.suggestorToMarker
         )) {
           const matchInfo = matchesMarker(word, marker)
-          if (matchInfo.matches) {
+          if (matchInfo.matches && this._inputRef.current && this._inputRef.current.isFocused()) {
             this.setState({active: suggestor, filter: word.substring(matchInfo.marker.length)})
           }
         }

--- a/shared/common-adapters/plain-input.desktop.js
+++ b/shared/common-adapters/plain-input.desktop.js
@@ -64,6 +64,8 @@ class PlainInput extends React.PureComponent<InternalProps> {
     this._input && this._input.blur()
   }
 
+  isFocused = () => !!this._input && document.activeElement === this._input
+
   transformText = (fn: TextInfo => TextInfo, reflectChange?: boolean) => {
     if (this._controlled()) {
       const errMsg =

--- a/shared/common-adapters/plain-input.js.flow
+++ b/shared/common-adapters/plain-input.js.flow
@@ -101,6 +101,7 @@ declare export default class PlainInput extends React.Component<Props> {
   static defaultProps: DefaultProps;
   blur: () => void;
   focus: () => void;
+  isFocused: () => boolean;
   getSelection: () => ?Selection;
   /**
    *  This can only be used when the input is controlled. Use `transformText` if

--- a/shared/common-adapters/plain-input.native.js
+++ b/shared/common-adapters/plain-input.native.js
@@ -161,6 +161,8 @@ class PlainInput extends Component<InternalProps, State> {
     this._input && this._input.blur()
   }
 
+  isFocused = () => !!this._input && this._input.isFocused()
+
   _onFocus = () => {
     this.setState({focused: true})
     this.props.onFocus && this.props.onFocus()


### PR DESCRIPTION
Fixes a bug on mobile if you nav into a conversation where you previously entered '/' for example. The suggestions show up like this:
<img width="376" alt="image" src="https://user-images.githubusercontent.com/11968340/52012411-7fdff480-24a8-11e9-9458-a614a165860e.png">

It's fairly bad because your only choice is to choose an option since the input is beneath the suggestions. This PR fixes it by adding `isFocused()` to `PlainInput` and checking it before activating the suggestions. r? @keybase/react-hackers 