### PR TITLE
Make unclaimed relay text in Chat padded and less scary

### DIFF
--- a/shared/chat/conversation/messages/message-popup/payment/index.js
+++ b/shared/chat/conversation/messages/message-popup/payment/index.js
@@ -107,8 +107,8 @@ const Header = (props: HeaderProps) =>
         </Kb.Text>
       )}
       {!!props.errorDetails && (
-        <Kb.Box2 direction="horizontal" style={{maxWidth: 200}}>
-          <Kb.Text center={true} type="BodyExtrabold" style={styles.errorDetails}>
+        <Kb.Box2 direction="horizontal" style={styles.errorDetails}>
+          <Kb.Text center={true} type="BodySmall">
             {props.errorDetails}
           </Kb.Text>
         </Kb.Box2>
@@ -179,7 +179,11 @@ const PaymentPopup = (props: Props) => {
 
 const styles = Styles.styleSheetCreate({
   colorWhite: {color: Styles.globalColors.white},
-  errorDetails: {color: Styles.globalColors.red},
+  errorDetails: {
+    maxWidth: 200,
+    paddingLeft: Styles.globalMargins.tiny,
+    paddingRight: Styles.globalMargins.tiny,
+  },
   headerIcon: Styles.platformStyles({
     common: {height: headerIconHeight},
     isAndroid: {


### PR DESCRIPTION
@keybase/react-hackers 

This was in extrabold red because it's a more general "errorDetails" prop, used here just to say that the recipient needs to claim their account before they can receive the payment.  I'll change it to smaller black text just for this message popup.