### PR TITLE
fix desktop reactions

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -536,7 +536,7 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				notificationSnippet := ""
 				if desktopNotification {
 					notificationSnippet = utils.GetDesktopNotificationSnippet(conv,
-						g.G().Env.GetUsername().String())
+						g.G().Env.GetUsername().String(), &decmsg)
 				}
 				activity = new(chat1.ChatActivity)
 				*activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -929,11 +929,19 @@ func GetMsgSnippet(msg chat1.MessageUnboxed, conv chat1.ConversationLocal, curre
 }
 
 // We don't want to display the contents of an exploding message in notifications
-func GetDesktopNotificationSnippet(conv *chat1.ConversationLocal, currentUsername string) string {
-	if conv == nil || conv.Info.SnippetMsg == nil {
+func GetDesktopNotificationSnippet(conv *chat1.ConversationLocal, currentUsername string,
+	fromMsg *chat1.MessageUnboxed) string {
+	if conv == nil {
 		return ""
 	}
-	msg := *conv.Info.SnippetMsg
+	var msg chat1.MessageUnboxed
+	if fromMsg != nil {
+		msg = *fromMsg
+	} else if conv.Info.SnippetMsg != nil {
+		msg = *conv.Info.SnippetMsg
+	} else {
+		return ""
+	}
 	if !msg.IsValid() {
 		return ""
 	}


### PR DESCRIPTION
We no longer get `REACTION` messages when unboxing a conversation, and so let's just pass it in from the notification itself.