### PR TITLE
Don't try to load Stellar info if we're logged out

### DIFF
--- a/shared/actions/__tests__/wallets.test.js
+++ b/shared/actions/__tests__/wallets.test.js
@@ -18,6 +18,7 @@ jest.mock('../../engine/require')
 const blankStore = Testing.getInitialStore()
 const initialStore = {
   ...blankStore,
+  config: {loggedIn: true},
   wallets: blankStore.wallets.merge({
     accountMap: blankStore.wallets.accountMap.set(
       Types.stringToAccountID('fake account ID'),


### PR DESCRIPTION
@keybase/react-hackers 

There's a race where we can log out, and then receive a remote Stellar notification which causes us to queue up a call to LoadAssets, which makes RPCs that black bar because we're logged out.  Throwing a `&& state.config.loggedIn &&` on everything that can be caused by a notification seems like the right idea.