### PR TITLE
Remove CanLogout API call from Logout RPC

### DIFF
--- a/go/service/login.go
+++ b/go/service/login.go
@@ -48,18 +48,6 @@ func canLogout(mctx libkb.MetaContext) (res canLogoutRet, err error) {
 
 func (h *LoginHandler) Logout(ctx context.Context, arg keybase1.LogoutArg) (err error) {
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("Logout(force=%t) [service RPC]", arg.Force), func() error { return err })()
-	res, err := canLogout(libkb.NewMetaContext(ctx, h.G()))
-	if err != nil {
-		return err
-	}
-	if !res.CanLogout {
-		if !arg.Force {
-			return fmt.Errorf("Cannot logout: %s", res.Reason)
-		}
-		// Log the reason, logout anyway.
-		h.G().Log.CWarningf(ctx, "Server advised not to logout because: %s", res.Reason)
-		h.G().Log.CWarningf(ctx, "Logging out anyway (`force` argument is set)")
-	}
 	return h.G().Logout(ctx)
 }
 

--- a/go/service/random_pw_test.go
+++ b/go/service/random_pw_test.go
@@ -41,14 +41,16 @@ func TestSignupRandomPWUser(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ret)
 
-	handler := NewLoginHandler(nil, tc.G)
-	err = handler.Logout(context.Background(), keybase1.LogoutArg{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Cannot logout")
-	require.Contains(t, err.Error(), "Set a password first")
-	require.NoError(t, sessCheck(t, tc.G), "expecting to still have a valid session and no error in sesscheck")
+	// TODO: Bring back some kind of logout check in CORE-10084.
 
-	err = handler.Logout(context.Background(), keybase1.LogoutArg{Force: true})
-	require.NoError(t, err)
-	require.Error(t, sessCheck(t, tc.G), "expecting to be logged out and error in sesscheck")
+	// handler := NewLoginHandler(nil, tc.G)
+	// err = handler.Logout(context.Background(), keybase1.LogoutArg{})
+	// require.Error(t, err)
+	// require.Contains(t, err.Error(), "Cannot logout")
+	// require.Contains(t, err.Error(), "Set a password first")
+	// require.NoError(t, sessCheck(t, tc.G), "expecting to still have a valid session and no error in sesscheck")
+
+	// err = handler.Logout(context.Background(), keybase1.LogoutArg{Force: true})
+	// require.NoError(t, err)
+	// require.Error(t, sessCheck(t, tc.G), "expecting to be logged out and error in sesscheck")
 }

--- a/go/service/random_pw_test.go
+++ b/go/service/random_pw_test.go
@@ -41,7 +41,12 @@ func TestSignupRandomPWUser(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ret)
 
-	// TODO: Bring back some kind of logout check in CORE-10084.
+	// TODO: Bring back some kind "you shouldn't logout" test in CORE-10084.
+
+	handler := NewLoginHandler(nil, tc.G)
+	err = handler.Logout(context.Background(), keybase1.LogoutArg{})
+	require.NoError(t, err)
+	require.Error(t, sessCheck(t, tc.G), "expecting to be logged out and error in sesscheck")
 
 	// handler := NewLoginHandler(nil, tc.G)
 	// err = handler.Logout(context.Background(), keybase1.LogoutArg{})


### PR DESCRIPTION
Let's clean this up for the upcoming release while we are working on the actual solution.