### PR TITLE
Dim the label on text next to disabled checkboxes

### DIFF
--- a/shared/common-adapters/checkbox.desktop.js
+++ b/shared/common-adapters/checkbox.desktop.js
@@ -51,7 +51,7 @@ class Checkbox extends Component<Props> {
             fontSize={9}
           />
         </div>
-        <Text type="Body" style={{color: globalColors.black_75}}>
+        <Text type="Body" style={collapseStyles([styleText, this.props.disabled && {opacity: 0.3}])}>
           {this.props.labelComponent || this.props.label}
         </Text>
       </div>
@@ -71,6 +71,10 @@ const styleIcon = {
   left: 1,
   position: 'absolute',
   top: 1,
+}
+
+const styleText = {
+  color: globalColors.black_75,
 }
 
 export default Checkbox

--- a/shared/common-adapters/checkbox.native.js
+++ b/shared/common-adapters/checkbox.native.js
@@ -75,7 +75,7 @@ class Checkbox extends Component<Props, State> {
           </NativeAnimated.View>
           {!!this.props.labelComponent && <Box style={styleLabel}>{this.props.labelComponent}</Box>}
           {!this.props.labelComponent && (
-            <Text type="Body" style={styleText}>
+            <Text type="Body" style={collapseStyles([styleText, this.props.disabled && {opacity: 0.3}])}>
               {this.props.label}
             </Text>
           )}


### PR DESCRIPTION
@keybase/react-hackers 

This changes other occurrences of text next to disabled checkboxes to be `opacity: 0.3` too, seen in the storyshots:

* the common-adapters/checkbox storyshot
* the "Yes, I wrote it down" prompt on a paper key (before the paper key has loaded)