### PR TITLE
Show chat coins icon more reliably

### DIFF
--- a/shared/chat/conversation/messages/text/index.js
+++ b/shared/chat/conversation/messages/text/index.js
@@ -85,7 +85,7 @@ const styles = Styles.styleSheetCreate({
   pendingFailEditing,
   sent,
   sentEditing,
-  wrapper: {alignSelf: 'flex-start', flexGrow: 1},
+  wrapper: {alignSelf: 'flex-start', flex: 1},
 })
 
 export default MessageText

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -186,7 +186,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
 
   _shouldShowReactionsRow = () =>
     // $ForceType
-    this.props.message.reactions && !this.props.message.reactions.isEmpty()
+    (this.props.message.reactions && !this.props.message.reactions.isEmpty()) || this.props.isPendingPayment
 
   _reactionsRow = () =>
     this._shouldShowReactionsRow() && (

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -280,7 +280,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       exploded || Styles.isMobile ? 0 : 16, // ... menu
       exploding ? (Styles.isMobile ? 57 : 46) : 0, // exploding
     ].filter(Boolean)
-    const padding = 8
+    const padding = Styles.globalMargins.tiny
     const width =
       iconSizes.length <= 0 ? 0 : iconSizes.reduce((total, size) => total + size, iconSizes.length * padding)
 

--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -224,16 +224,6 @@ export const anyToConversationMembersType = (a: any): ?RPCChatTypes.Conversation
   }
 }
 
-const successfulInlinePaymentStatuses = ['completed', 'claimable']
-export const hasSuccessfulInlinePayments = (state: TypedState, message: Types.Message) => {
-  if (message.type !== 'text' || !message.inlinePaymentIDs) {
-    return false
-  }
-  return message.inlinePaymentIDs.some(id =>
-    successfulInlinePaymentStatuses.includes(state.chat2.paymentStatusMap.get(id)?.status)
-  )
-}
-
 export const threadRoute = isMobile
   ? [chatTab, 'conversation']
   : [{props: {}, selected: chatTab}, {props: {}, selected: null}]
@@ -268,6 +258,7 @@ export {
   getMessageID,
   getRequestMessageInfo,
   getPaymentMessageInfo,
+  hasSuccessfulInlinePayments,
   isPendingPaymentMessage,
   isSpecialMention,
   isVideoAttachment,

--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -72,7 +72,7 @@ export const isPendingPaymentMessage = (state: TypedState, message: Types.Messag
     return false
   }
   const paymentInfo = getPaymentMessageInfo(state, message)
-  return !!(paymentInfo && ['claimable', 'pending'].includes(paymentInfo.status))
+  return !!(paymentInfo && paymentInfo.status === 'pending')
 }
 
 // Map service message types to our message types.

--- a/shared/constants/types/chat2/message.js
+++ b/shared/constants/types/chat2/message.js
@@ -101,6 +101,7 @@ export type _MessageText = {
   hasBeenEdited: boolean,
   id: MessageID,
   inlinePaymentIDs: ?I.List<WalletTypes.PaymentID>,
+  inlinePaymentSuccessful: boolean,
   reactions: Reactions,
   submitState: null | 'deleting' | 'editing' | 'pending' | 'failed',
   mentionsAt: MentionsAt,


### PR DESCRIPTION
* Fix `MessageText` styling pushing coins icon over
* Fix getting payment IDs off message
* Fix getting payment statuses if the infos are on the message and not in `state.chat2.accountsInfoMap`
* (Bonus) no background animation on claimable payments
* (Bonus) no reacji bar on pending payments