### PR TITLE
Make chat compose icon blue again on mobile

### DIFF
--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -123,6 +123,7 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
           rightActions={[
             {
               icon: 'iconfont-compose',
+              iconColor: Styles.globalColors.blue,
               label: 'New chat',
               onPress: this.props.onNewChat,
             },

--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -182,6 +182,7 @@ const renderAction = (action: Action, index: number): React.Node =>
     </Box>
   ) : action.icon ? (
     <Icon
+      color={action.iconColor || undefined}
       key={action.label || index}
       fontSize={22}
       onClick={action.onPress}

--- a/shared/common-adapters/header-hoc/types.js.flow
+++ b/shared/common-adapters/header-hoc/types.js.flow
@@ -6,6 +6,7 @@ export type Action = {
   custom?: React.Node,
   label?: string, // TODO: make this required after updates are fully integrated
   icon?: IconType,
+  iconColor?: string,
   onPress?: ?Function,
 }
 export type Props = {


### PR DESCRIPTION
@keybase/react-hackers CC @songgao 

A recent refactor made the compose icon next to "Jump to chat" lose its blue color on mobile. It's because it now uses HeaderHoc's `rightActions` list of icons to render, and a HeaderHoc `Action` can specify an icon but not its color, so let's fix that.