### PR TITLE
dont send reachability inside lock

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -804,6 +804,7 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 
 	// Call out to reachability module if we have one
 	if g.reachability != nil {
+		g.chatLog.Debug(ctx, "setting reachability")
 		g.reachability.setReachability(keybase1.Reachability{
 			Reachable: keybase1.Reachable_YES,
 		})
@@ -811,11 +812,13 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 
 	// Broadcast reconnect oobm. Spawn this off into a goroutine so that we don't delay
 	// reconnection any longer than we have to.
+	g.chatLog.Debug(ctx, "broadcasting reconnect oobm")
 	go func(m gregor1.Message) {
 		g.BroadcastMessage(context.Background(), m)
 	}(g.makeReconnectOobm())
 
 	// No longer first connect if we are now connected
+	g.chatLog.Debug(ctx, "setting first connect to false")
 	g.setFirstConnect(false)
 	// On successful login we can reset this guy to not force a check
 	g.forceSessionCheck = false

--- a/go/service/reachability.go
+++ b/go/service/reachability.go
@@ -61,10 +61,7 @@ func newReachability(g *libkb.GlobalContext, gh *gregorHandler) *reachability {
 
 func (h *reachability) setReachability(r keybase1.Reachability) {
 	h.setMutex.Lock()
-	changed := false
-	if h.lastReachability.Reachable != r.Reachable {
-		changed = true
-	}
+	changed := h.lastReachability.Reachable != r.Reachable
 	h.lastReachability = r
 	h.setMutex.Unlock()
 

--- a/go/service/reachability.go
+++ b/go/service/reachability.go
@@ -61,13 +61,17 @@ func newReachability(g *libkb.GlobalContext, gh *gregorHandler) *reachability {
 
 func (h *reachability) setReachability(r keybase1.Reachability) {
 	h.setMutex.Lock()
-	defer h.setMutex.Unlock()
-
+	changed := false
 	if h.lastReachability.Reachable != r.Reachable {
+		changed = true
+	}
+	h.lastReachability = r
+	h.setMutex.Unlock()
+
+	if changed {
 		h.G().Log.Debug("Reachability changed: %#v", r)
 		h.G().NotifyRouter.HandleReachability(r)
 	}
-	h.lastReachability = r
 }
 
 func (h *reachability) check() (k keybase1.Reachability) {


### PR DESCRIPTION
I think it's possible for the reachability call to get jammed, in which case this function becomes a blocker chance in `OnConnect`. Make it so we don't have the lock while called out to inform of reachability change.