### PR TITLE
dsl_test: call SyncFromServer at the end of every `as` block

### DIFF
--- a/go/kbfs/test/journal_test.go
+++ b/go/kbfs/test/journal_test.go
@@ -511,8 +511,8 @@ func TestJournalCoalescingCreatesPlusCR(t *testing.T) {
 // squashes -- this happens multiple times before bob's flush is able
 // to succeed.  This is a regression for KBFS-1979.
 func TestJournalCoalescingCreatesPlusMultiCR(t *testing.T) {
-	var busyWork []fileOp
-	var busyWork2 []fileOp
+	busyWork := []fileOp{noSyncEnd()}
+	busyWork2 := []fileOp{noSyncEnd()}
 	listing := m{}
 	iters := libkbfs.ForcedBranchSquashRevThreshold + 1
 	unflushedPaths := []string{"/keybase/private/alice,bob/a"}
@@ -540,21 +540,21 @@ func TestJournalCoalescingCreatesPlusMultiCR(t *testing.T) {
 			pauseJournal(),
 		),
 		as(bob, busyWork...),
-		as(bob,
+		as(bob, noSyncEnd(),
 			// Coalescing, round 1.
 			flushJournal(),
 		),
 		// Second sync to wait for the CR caused by `flushJournal`.
-		as(bob,
+		as(bob, noSyncEnd(),
 			flushJournal(),
 		),
 		as(bob, busyWork2...),
-		as(bob,
+		as(bob, noSyncEnd(),
 			// Coalescing, round 2.
 			flushJournal(),
 		),
 		// Second sync to wait for the CR caused by `flushJournal`.
-		as(bob,
+		as(bob, noSyncEnd(),
 			flushJournal(),
 		),
 		as(alice,
@@ -562,11 +562,11 @@ func TestJournalCoalescingCreatesPlusMultiCR(t *testing.T) {
 			// squashes.
 			mkdir("b"),
 		),
-		as(bob,
+		as(bob, noSyncEnd(),
 			flushJournal(),
 		),
 		// Second sync to wait for the CR caused by `flushJournal`.
-		as(bob,
+		as(bob, noSyncEnd(),
 			flushJournal(),
 			// Disable updates to make sure we don't get notified of
 			// alice's next write until we attempt a journal flush, so


### PR DESCRIPTION
Tests that check the edit history sometimes go in this order:

1) bob writes something.
2) alice checks the edit history for that write.

Unfortunately, the chat notification from bob is sent asynchronously after the write operation, and a `bob.SyncFromServer()` call is needed to make sure that the notification was sent all the way through to all the other users.  If there isn't another `bob` block between steps 1 and 2, there's no guarantee that this will happen, since currently in the code `SyncFromServer` is only called at the _beginning_ of each block.

Instead, let's also call it at the _end_ of each block, unless the test specifically doesn't want to and disables the behavior.

Issue: KBFS-3804