### PR TITLE
fix random logout bug on desktop

### DIFF
--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -325,7 +325,7 @@ func (g *GlobalContext) Logout(ctx context.Context) (err error) {
 
 	// remove stored secret
 	g.secretStoreMu.Lock()
-	if g.secretStore != nil {
+	if g.secretStore != nil && !username.IsNil() {
 		if err := g.secretStore.ClearSecret(mctx, username); err != nil {
 			mctx.CDebugf("clear stored secret error: %s", err)
 		}

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -213,11 +213,18 @@ func (s *SecretStoreLocked) StoreSecret(m MetaContext, username NormalizedUserna
 }
 
 func (s *SecretStoreLocked) ClearSecret(m MetaContext, username NormalizedUsername) error {
+
+	if username.IsNil() {
+		m.CDebugf("NOOPing SecretStoreLocked#ClearSecret for empty username")
+		return nil
+	}
+
 	if s == nil || s.isNil() {
 		return nil
 	}
 	s.Lock()
 	defer s.Unlock()
+
 	err := s.mem.ClearSecret(m, username)
 	if err != nil {
 		m.CDebugf("SecretStoreLocked#ClearSecret: failed to clear memory: %s", err.Error())

--- a/go/libkb/secret_store_darwin.go
+++ b/go/libkb/secret_store_darwin.go
@@ -107,7 +107,11 @@ func (k KeychainSecretStore) RetrieveSecret(m MetaContext, accountName Normalize
 }
 
 func (k KeychainSecretStore) ClearSecret(m MetaContext, accountName NormalizedUsername) error {
-	m.CDebugf("KeychainSecretStore.ClearSecret(%s)", accountName)
+	m.CDebugf("KeychainSecretStore#ClearSecret(%s)", accountName)
+	if accountName.IsNil() {
+		m.CDebugf("NOOPing KeychainSecretStore#ClearSecret for empty username")
+		return nil
+	}
 	var query keychain.Item
 	if isIOS {
 		query = keychain.NewGenericPassword(k.serviceName(m), string(accountName), "", nil, k.accessGroup(m))
@@ -117,14 +121,14 @@ func (k KeychainSecretStore) ClearSecret(m MetaContext, accountName NormalizedUs
 	}
 	err := keychain.DeleteItem(query)
 	if err == keychain.ErrorItemNotFound {
-		m.CDebugf("KeychainSecretStore.ClearSecret(%s), item not found", accountName)
+		m.CDebugf("KeychainSecretStore#ClearSecret(%s), item not found", accountName)
 		return nil
 	}
 	if err != nil {
-		m.CDebugf("KeychainSecretStore.ClearSecret(%s), DeleteItem error: %s", accountName, err)
+		m.CDebugf("KeychainSecretStore#ClearSecret(%s), DeleteItem error: %s", accountName, err)
 	}
 
-	m.CDebugf("KeychainSecretStore.ClearSecret(%s) success", accountName)
+	m.CDebugf("KeychainSecretStore#ClearSecret(%s) success", accountName)
 
 	return err
 }

--- a/go/libkb/secret_store_external.go
+++ b/go/libkb/secret_store_external.go
@@ -144,7 +144,10 @@ func (s *secretStoreAndroid) RetrieveSecret(m MetaContext, username NormalizedUs
 
 func (s *secretStoreAndroid) ClearSecret(m MetaContext, username NormalizedUsername) (err error) {
 	defer m.CTraceTimed("secret_store_external ClearSecret", func() error { return err })()
-
+	if username.IsNil() {
+		m.CDebugf("NOOPing secretStoreAndroid#ClearSecret for empty username")
+		return nil
+	}
 	ks, err := getGlobalExternalKeyStore(m)
 	if err != nil {
 		return err

--- a/go/libkb/secret_store_file.go
+++ b/go/libkb/secret_store_file.go
@@ -196,6 +196,12 @@ func (s *SecretStoreFile) StoreSecret(m MetaContext, username NormalizedUsername
 
 func (s *SecretStoreFile) ClearSecret(m MetaContext, username NormalizedUsername) error {
 	// try both
+
+	if username.IsNil() {
+		m.CDebugf("NOOPing SecretStoreFile#ClearSecret for empty username")
+		return nil
+	}
+
 	errV1 := s.clearSecretV1(username)
 	errV2 := s.clearSecretV2(username)
 

--- a/go/libkb/secret_store_mem.go
+++ b/go/libkb/secret_store_mem.go
@@ -26,6 +26,10 @@ func (s *SecretStoreMem) StoreSecret(m MetaContext, username NormalizedUsername,
 }
 
 func (s *SecretStoreMem) ClearSecret(m MetaContext, username NormalizedUsername) error {
+	if username.IsNil() {
+		m.CDebugf("NOOPing SecretStoreMem#ClearSecret for empty username")
+		return nil
+	}
 	delete(s.secrets, username)
 	return nil
 }


### PR DESCRIPTION
- the bug was that ClearSecret() was being being called with an empty username, which
  seems to blast everything out of the keychain
- this codepath is triggered on Login, since Login logs out the previous user, which can
  easily be "" for a new install