### PR TITLE
message id for json api

### DIFF
--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -595,7 +595,8 @@ func (c *chatServiceHandler) AttachV1(ctx context.Context, opts attachOptionsV1,
 	}
 
 	res := SendRes{
-		Message: "attachment sent",
+		Message:   "attachment sent",
+		MessageID: &pres.MessageID,
 		RateLimits: RateLimits{
 			RateLimits: c.aggRateLimits(rl),
 		},
@@ -987,6 +988,7 @@ func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1, chatUI c
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	}
 	var idFails []keybase1.TLFIdentifyFailure
+	var msgID *chat1.MessageID
 	if arg.nonblock {
 		var nbarg chat1.PostLocalNonblockArg
 		nbarg.ConversationID = postArg.ConversationID
@@ -1003,12 +1005,14 @@ func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1, chatUI c
 		if err != nil {
 			return c.errReply(err)
 		}
+		msgID = &plres.MessageID
 		rl = append(rl, plres.RateLimits...)
 		idFails = plres.IdentifyFailures
 	}
 
 	res := SendRes{
-		Message: arg.response,
+		Message:   arg.response,
+		MessageID: msgID,
 		RateLimits: RateLimits{
 			RateLimits: c.aggRateLimits(rl),
 		},
@@ -1332,6 +1336,7 @@ type ChatList struct {
 // SendRes is the result of successfully sending a message.
 type SendRes struct {
 	Message          string                        `json:"message"`
+	MessageID        *chat1.MessageID              `json:"id,omitempty"`
 	IdentifyFailures []keybase1.TLFIdentifyFailure `json:"identify_failures,omitempty"`
 	RateLimits
 }

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -989,6 +989,7 @@ func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1, chatUI c
 	}
 	var idFails []keybase1.TLFIdentifyFailure
 	var msgID *chat1.MessageID
+	var obid *chat1.OutboxID
 	if arg.nonblock {
 		var nbarg chat1.PostLocalNonblockArg
 		nbarg.ConversationID = postArg.ConversationID
@@ -998,6 +999,7 @@ func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1, chatUI c
 		if err != nil {
 			return c.errReply(err)
 		}
+		obid = &plres.OutboxID
 		rl = append(rl, plres.RateLimits...)
 		idFails = plres.IdentifyFailures
 	} else {
@@ -1013,6 +1015,7 @@ func (c *chatServiceHandler) sendV1(ctx context.Context, arg sendArgV1, chatUI c
 	res := SendRes{
 		Message:   arg.response,
 		MessageID: msgID,
+		OutboxID:  obid,
 		RateLimits: RateLimits{
 			RateLimits: c.aggRateLimits(rl),
 		},
@@ -1337,6 +1340,7 @@ type ChatList struct {
 type SendRes struct {
 	Message          string                        `json:"message"`
 	MessageID        *chat1.MessageID              `json:"id,omitempty"`
+	OutboxID         *chat1.OutboxID               `json:"outbox_id,omitempty"`
 	IdentifyFailures []keybase1.TLFIdentifyFailure `json:"identify_failures,omitempty"`
 	RateLimits
 }


### PR DESCRIPTION
adds the message id to the json api response for blocking sends. 

blocking send:
```
$ kb chat api -p -m '{"method": "send", "params": {"options": {"channel": {"name": "test1"}, "message": {"body": "hey!"}}}}'
{   
    "result": {
        "message": "message sent",
        "id": 372,
        "ratelimits": [
            {   
                "tank": "chat",
                "capacity": 9000,
                "reset": 697,
                "gas": 8998
            }
        ]
    }
}
```
nonblock send:
```
$ kb chat api -p -m '{"method": "send", "params": {"options": {"nonblock": true, "channel": {"name": "test1"}, "message": {"body": "hey!"}}}}'
{
    "result": {
        "message": "message sent"
    }
}
```

cc @songgao 
