### PR TITLE
only ui notify on active

### DIFF
--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -653,16 +653,15 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				g.Debug(ctx, "chat activity: unable to update inbox: %v", err)
 			}
 			conv = &inbox.Convs[0]
-			// only notify the UI of the conversation if it should be visible
 			switch memberStatus := conv.ReaderInfo.Status; memberStatus {
-			case chat1.ConversationMemberStatus_ACTIVE, chat1.ConversationMemberStatus_RESET:
+			case chat1.ConversationMemberStatus_LEFT, chat1.ConversationMemberStatus_NEVER_JOINED:
+				g.Debug(ctx, "chat activity: newConversation: suppressing ChatActivity, membersStatus: %v", memberStatus)
+			default:
 				activity = new(chat1.ChatActivity)
 				*activity = chat1.NewChatActivityWithNewConversation(chat1.NewConversationInfo{
 					Conv:   g.presentUIItem(ctx, conv, uid),
 					ConvID: conv.GetConvID(),
 				})
-			default:
-				g.Debug(ctx, "chat activity: newConversation: suppressing ChatActivity, membersStatus: %v", memberStatus)
 			}
 		case types.ActionTeamType:
 			var nm chat1.TeamTypePayload

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4777,7 +4777,6 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
 		require.NoError(t, err)
 		require.Equal(t, randomConvID, ncres.Conv.GetConvID())
-		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
 		assertNoNewConversation(t, listener0)
 
 		// Try to change topic name to one that exists

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2098,6 +2098,7 @@ func TestChatSrvPostLocalNonblock(t *testing.T) {
 			case chat1.ConversationMembersType_TEAM:
 				first := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 					mt, ctc.as(t, users[1]).user())
+				consumeNewConversation(t, listener, first.Id)
 				topicName := "mike"
 				ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(tc.startCtx,
 					chat1.NewConversationLocalArg{
@@ -3935,6 +3936,9 @@ func TestChatSrvTeamChannels(t *testing.T) {
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 			mt, ctc.as(t, users[1]).user(), ctc.as(t, users[2]).user())
 		t.Logf("first conv: %s", conv.Id)
+		consumeNewConversation(t, listener0, conv.Id)
+		consumeNewConversation(t, listener1, conv.Id)
+		consumeNewConversation(t, listener2, conv.Id)
 
 		t.Logf("create a conversation, and join user 1 into by sending a message")
 		topicName := "zjoinonsend"
@@ -4521,6 +4525,8 @@ func TestChatSrvSetConvMinWriterRole(t *testing.T) {
 		created := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 			mt, tc2.user())
 		convID := created.Id
+		consumeNewConversation(t, listener1, convID)
+		consumeNewConversation(t, listener2, convID)
 
 		verifyMinWriterRoleInfoOnConv := func(user *kbtest.FakeUser, role *keybase1.TeamRole) {
 			tc := ctc.as(t, user)
@@ -4706,6 +4712,7 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		ri := ctc.as(t, users[0]).ri
 
 		firstConv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
+		consumeNewConversation(t, listener0, firstConv.Id)
 
 		topicName := "MIKE"
 		ctx := ctc.as(t, users[0]).startCtx
@@ -4766,7 +4773,6 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		randomConvID := ncres.Conv.GetConvID()
 		consumeNewConversation(t, listener0, randomConvID)
 		consumeNewMsgRemote(t, listener0, chat1.MessageType_JOIN)
-		consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)
 
 		ncres, err = ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx, ncarg)
 		require.NoError(t, err)
@@ -5139,6 +5145,8 @@ func TestChatSrvDeleteConversation(t *testing.T) {
 
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt,
 			ctc.as(t, users[1]).user())
+		consumeNewConversation(t, listener0, conv.Id)
+		consumeNewConversation(t, listener1, conv.Id)
 
 		_, err := ctc.as(t, users[0]).chatLocalHandler().DeleteConversationLocal(ctx,
 			chat1.DeleteConversationLocalArg{
@@ -5629,7 +5637,7 @@ func TestChatSrvTeamChannelNameMentions(t *testing.T) {
 			t.Logf("conv: %s chan: %s, err: %v", conv.Id, channel.Conv.GetConvID(), err)
 			require.NoError(t, err)
 			assertNoNewConversation(t, listener0)
-			consumeNewConversation(t, listener1, conv.Id)
+			consumeNewConversation(t, listener1, channel.Conv.GetConvID())
 			consumeNewMsgRemote(t, listener1, chat1.MessageType_JOIN)
 			if index == 0 {
 				consumeNewMsgRemote(t, listener0, chat1.MessageType_SYSTEM)


### PR DESCRIPTION
could also kill these convs from ever being rendered in the ui as well but they are a good indicator of other bugs

```
2019-01-31T15:10:56.032082-05:00 ▶ [DEBU keybase push.go:665] 927 ++Chat: | PushHandler: chat activity: chat activity: newConversation: suppressing ChatActivity, membersStatus NEVER_JOINED [tags:chat-trace=vqChjIsvh3aw]
```