### PR TITLE
 dont set the delay check if the request has been aborted CORE-10094

### DIFF
--- a/go/chat/sourceofflinable.go
+++ b/go/chat/sourceofflinable.go
@@ -85,7 +85,7 @@ func (s *sourceOfflinable) IsOffline(ctx context.Context) bool {
 			defer s.Unlock()
 			select {
 			case <-ctx.Done():
-				s.Debug(ctx, "IsOffline: timed out, but context canceled so not setting offline: state: %v",
+				s.Debug(ctx, "IsOffline: timed out, but context canceled so not setting delayed: state: %v",
 					s.offline)
 				return s.offline
 			default:

--- a/go/chat/sourceofflinable.go
+++ b/go/chat/sourceofflinable.go
@@ -80,6 +80,11 @@ func (s *sourceOfflinable) IsOffline(ctx context.Context) bool {
 			defer s.Unlock()
 			s.Debug(ctx, "IsOffline: waited and got %v", s.offline)
 			return s.offline
+		case <-ctx.Done():
+			s.Lock()
+			defer s.Unlock()
+			s.Debug(ctx, "IsOffline: aborted: %s state: %v", ctx.Err(), s.offline)
+			return s.offline
 		case <-time.After(4 * time.Second):
 			s.Lock()
 			defer s.Unlock()

--- a/go/chat/sourceofflinable.go
+++ b/go/chat/sourceofflinable.go
@@ -83,8 +83,15 @@ func (s *sourceOfflinable) IsOffline(ctx context.Context) bool {
 		case <-time.After(4 * time.Second):
 			s.Lock()
 			defer s.Unlock()
+			select {
+			case <-ctx.Done():
+				s.Debug(ctx, "IsOffline: timed out, but context canceled so not setting offline: state: %v",
+					s.offline)
+				return s.offline
+			default:
+			}
 			s.delayed = true
-			s.Debug(ctx, "IsOffline: timed out")
+			s.Debug(ctx, "IsOffline: timed out, setting delay wait: state: %v", s.offline)
 			return s.offline
 		}
 	}


### PR DESCRIPTION
It is possible that we can background the app in the middle of one of these `IsOffline` checks. If we do, then we are guaranteed to set `s.delayed = true` when foregrounding it again. If we do that, then we turn off the check in `GetThreadNonblock`, which can cause the gray bar to flash on the screen.

Now, we detect if the request for `IsOffline` has been aborted, and if so, we do not set the `delayed` bit indicating we did a meaningful check of our offline status. 