### PR TITLE
fix after-delete and after-move routing for filepreview view

### DIFF
--- a/shared/actions/fs-gen.js
+++ b/shared/actions/fs-gen.js
@@ -11,8 +11,8 @@ import * as ChatTypes from '../constants/types/chat2'
 export const resetStore = 'common:resetStore' // not a part of fs but is handled by every reducer. NEVER dispatch this
 export const typePrefix = 'fs:'
 export const cancelDownload = 'fs:cancelDownload'
-export const cancelMoveOrCopy = 'fs:cancelMoveOrCopy'
 export const clearRefreshTag = 'fs:clearRefreshTag'
+export const closeMoveOrCopy = 'fs:closeMoveOrCopy'
 export const commitEdit = 'fs:commitEdit'
 export const copy = 'fs:copy'
 export const deleteFile = 'fs:deleteFile'
@@ -82,8 +82,8 @@ export const userFileEditsLoaded = 'fs:userFileEditsLoaded'
 
 // Payload Types
 type _CancelDownloadPayload = $ReadOnly<{|key: string|}>
-type _CancelMoveOrCopyPayload = void
 type _ClearRefreshTagPayload = $ReadOnly<{|refreshTag: Types.RefreshTag|}>
+type _CloseMoveOrCopyPayload = void
 type _CommitEditPayload = $ReadOnly<{|editID: Types.EditID|}>
 type _CopyPayload = $ReadOnly<{|destinationParentPath: Types.Path|}>
 type _DeleteFilePayload = $ReadOnly<{|path: Types.Path|}>
@@ -153,8 +153,8 @@ type _UserFileEditsLoadedPayload = $ReadOnly<{|tlfUpdates: Types.UserTlfUpdates|
 
 // Action Creators
 export const createCancelDownload = (payload: _CancelDownloadPayload) => ({payload, type: cancelDownload})
-export const createCancelMoveOrCopy = (payload: _CancelMoveOrCopyPayload) => ({payload, type: cancelMoveOrCopy})
 export const createClearRefreshTag = (payload: _ClearRefreshTagPayload) => ({payload, type: clearRefreshTag})
+export const createCloseMoveOrCopy = (payload: _CloseMoveOrCopyPayload) => ({payload, type: closeMoveOrCopy})
 export const createCommitEdit = (payload: _CommitEditPayload) => ({payload, type: commitEdit})
 export const createCopy = (payload: _CopyPayload) => ({payload, type: copy})
 export const createDeleteFile = (payload: _DeleteFilePayload) => ({payload, type: deleteFile})
@@ -224,8 +224,8 @@ export const createUserFileEditsLoaded = (payload: _UserFileEditsLoadedPayload) 
 
 // Action Payloads
 export type CancelDownloadPayload = {|+payload: _CancelDownloadPayload, +type: 'fs:cancelDownload'|}
-export type CancelMoveOrCopyPayload = {|+payload: _CancelMoveOrCopyPayload, +type: 'fs:cancelMoveOrCopy'|}
 export type ClearRefreshTagPayload = {|+payload: _ClearRefreshTagPayload, +type: 'fs:clearRefreshTag'|}
+export type CloseMoveOrCopyPayload = {|+payload: _CloseMoveOrCopyPayload, +type: 'fs:closeMoveOrCopy'|}
 export type CommitEditPayload = {|+payload: _CommitEditPayload, +type: 'fs:commitEdit'|}
 export type CopyPayload = {|+payload: _CopyPayload, +type: 'fs:copy'|}
 export type DeleteFilePayload = {|+payload: _DeleteFilePayload, +type: 'fs:deleteFile'|}
@@ -297,8 +297,8 @@ export type UserFileEditsLoadedPayload = {|+payload: _UserFileEditsLoadedPayload
 // prettier-ignore
 export type Actions =
   | CancelDownloadPayload
-  | CancelMoveOrCopyPayload
   | ClearRefreshTagPayload
+  | CloseMoveOrCopyPayload
   | CommitEditPayload
   | CopyPayload
   | DeleteFilePayload

--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -755,7 +755,7 @@ const moveOrCopyOpen = (state, action) => [
 const showMoveOrCopy = (state, action) =>
   RouteTreeGen.createNavigateAppend({path: [{props: {index: 0}, selected: 'destinationPicker'}]})
 
-const cancelMoveOrCopy = (state, action) => {
+const closeMoveOrCopy = (state, action) => {
   const currentRoutes = getPathProps(state.routeTree.routeState)
   const firstDestinationPickerIndex = currentRoutes.findIndex(({node}) => node === 'destinationPicker')
   const newRoute = currentRoutes.reduce(
@@ -899,7 +899,7 @@ function* fsSaga(): Saga.SagaGenerator<any, any> {
   yield* Saga.chainAction<FsGen.MovePayload | FsGen.CopyPayload>([FsGen.move, FsGen.copy], moveOrCopy)
   yield* Saga.chainAction<FsGen.MoveOrCopyOpenPayload>(FsGen.moveOrCopyOpen, moveOrCopyOpen)
   yield* Saga.chainAction<FsGen.ShowMoveOrCopyPayload>(FsGen.showMoveOrCopy, showMoveOrCopy)
-  yield* Saga.chainAction<FsGen.CancelMoveOrCopyPayload>(FsGen.cancelMoveOrCopy, cancelMoveOrCopy)
+  yield* Saga.chainAction<FsGen.CloseMoveOrCopyPayload>(FsGen.closeMoveOrCopy, closeMoveOrCopy)
   yield* Saga.chainGenerator<FsGen.ShowSendLinkToChatPayload>(FsGen.showSendLinkToChat, showSendLinkToChat)
   yield* Saga.chainAction<FsGen.ClearRefreshTagPayload>(FsGen.clearRefreshTag, clearRefreshTag)
 

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -204,7 +204,7 @@
       "path": "Types.Path"
     },
     "showMoveOrCopy": {"initialDestinationParentPath": "Types.Path"},
-    "cancelMoveOrCopy": {},
+    "closeMoveOrCopy": {},
     "moveOrCopyOpen": {
       "routePath": "I.List<string>",
       "path": "Types.Path",

--- a/shared/fs/common/path-item-action/menu-container.js
+++ b/shared/fs/common/path-item-action/menu-container.js
@@ -34,7 +34,10 @@ const mapDispatchToProps = (dispatch, {path, routePath}: OwnProps) => ({
   _confirmSendToOtherApp: () =>
     dispatch(FsGen.createSetPathItemActionMenuView({view: 'confirm-send-to-other-app'})),
   _copyPath: () => dispatch(ConfigGen.createCopyToClipboard({text: Constants.escapePath(path)})),
-  _delete: () => dispatch(FsGen.createDeleteFile({path})),
+  _delete: () => {
+    dispatch(FsGen.createDeleteFile({path}))
+    dispatch(FsGen.createOpenPathInFilesTab({path: Types.getPathParent(path), routePath}))
+  },
   _download: () => dispatch(FsGen.createDownload({key: Constants.makeDownloadKey(path), path})),
   _ignoreTlf: () => dispatch(FsGen.createFavoriteIgnore({path})),
   _moveOrCopy: () => {

--- a/shared/fs/destination-picker/container.js
+++ b/shared/fs/destination-picker/container.js
@@ -37,15 +37,15 @@ const mapDispatchToProps = (dispatch, ownProps: OwnProps) => ({
     ),
   _onCopyHere: destinationParentPath => {
     dispatch(FsGen.createCopy({destinationParentPath}))
-    dispatch(FsGen.createCancelMoveOrCopy())
+    dispatch(FsGen.createCloseMoveOrCopy())
   },
   _onMoveHere: destinationParentPath => {
     dispatch(FsGen.createMove({destinationParentPath}))
-    dispatch(FsGen.createCancelMoveOrCopy())
+    dispatch(FsGen.createOpenPathInFilesTab({path: destinationParentPath, routePath: ownProps.routePath}))
   },
   _onNewFolder: destinationParentPath =>
     dispatch(FsGen.createNewFolderRow({parentPath: destinationParentPath})),
-  onCancel: () => dispatch(FsGen.createCancelMoveOrCopy()),
+  onCancel: () => dispatch(FsGen.createCloseMoveOrCopy()),
 })
 
 const canWrite = memoize(

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -346,7 +346,7 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
     case FsGen.move:
     case FsGen.copy:
     case FsGen.moveOrCopyOpen:
-    case FsGen.cancelMoveOrCopy:
+    case FsGen.closeMoveOrCopy:
     case FsGen.clearRefreshTag:
     case FsGen.loadPathMetadata:
       return state


### PR DESCRIPTION
1. When it's a delete, always navigate to the parent folder of the thing
that's deleted.

2. When it's a move, always navigate to the destination parent folder.