### PR TITLE
folder_block_manager: protect against degenerate folders

### DIFF
--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -1272,3 +1272,11 @@ func (e NextMDNotCachedError) Error() string {
 	return fmt.Sprintf("The MD following %d for folder %s is not cached",
 		e.RootSeqno, e.TlfID)
 }
+
+// StopQRError indicates that we shouldn't retry QR for this folder.
+type StopQRError struct{}
+
+// Error implements the Error interface for StopQRError.
+func (e StopQRError) Error() string {
+	return "Stopping QR permanently"
+}


### PR DESCRIPTION
Really old TLFs might not have `LastGCRevision` field set in their MDs, and so have to search backwards for the last GC revision.  But trying to read revisions that are too old is too expensive, so just give up and stop QR instead.  Hopefully at some point we can revisit folders like this with a better QR algorithm.  This is just a quick fix for now.

Issue: KBFS-3839