### PR TITLE
Move random pw signup flag to devel build restricted

### DIFF
--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -36,10 +36,6 @@ func NewCmdSignup(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 				Name:  "username",
 				Usage: "Specify a username.",
 			},
-			cli.BoolFlag{
-				Name:  "no-passphrase",
-				Usage: "Sign up without passphrase.",
-			},
 		},
 	}
 
@@ -117,10 +113,6 @@ func (s *CmdSignup) ParseArgv(ctx *cli.Context) (err error) {
 	if s.defaultDevice == "" {
 		s.defaultDevice = "home computer"
 	}
-	s.randomPassphrase = ctx.Bool("no-passphrase")
-	if s.randomPassphrase && s.defaultPassphrase != "" {
-		return fmt.Errorf("cannot pass both --no-passphrase and --passphrase")
-	}
 
 	if ctx.Bool("batch") {
 		s.fields = &PromptFields{
@@ -136,6 +128,10 @@ func (s *CmdSignup) ParseArgv(ctx *cli.Context) (err error) {
 		s.genPaper = true
 		s.doPrompt = false
 		s.storeSecret = true
+		s.randomPassphrase = ctx.Bool("no-passphrase")
+		if s.randomPassphrase && s.defaultPassphrase != "" {
+			return fmt.Errorf("cannot pass both --no-passphrase and --passphrase")
+		}
 	} else {
 		s.doPrompt = true
 	}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -85,6 +85,10 @@ var restrictedSignupFlags = []cli.Flag{
 		Name:  "pgp",
 		Usage: "Add a server-synced pgp key",
 	},
+	cli.BoolFlag{
+		Name:  "no-passphrase",
+		Usage: "Sign up without passphrase.",
+	},
 }
 
 var restrictedProveFlags = []cli.Flag{


### PR DESCRIPTION
Batch mode was already disabled on prod builds. So this removes invalid flag combination from `signup` command and fixes the help page.

```
» keybase help signup                                     18:10:31
NAME:
   keybase signup - Signup for a new account

USAGE:
   keybase signup [command options]

OPTIONS:
   -c, --invite-code 	Specify an invite code.
   --email 		Specify an account email.
   --username 		Specify a username.
   --no-passphrase	Sign up without passphrase.
```
`--no-passphrase	Sign up without passphrase.` was useless because it only worked correctly with batch mode. In non-batch, the prompter wouldn't allow empty passphrase, so this command later errors out with
`▶ ERROR Requested random passphrase but passphrase was provided`
