### PR TITLE
Fix header padding bug on Android.

### DIFF
--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -63,7 +63,7 @@ export class HeaderHocHeader extends React.Component<Props, State> {
                 paddingRight: titlePadding,
               },
               Styles.isAndroid && {
-                paddingLeft: titlePaddingLeft,
+                paddingLeft: onLeftAction ? titlePaddingLeft : Styles.globalMargins.small,
                 paddingRight: titlePadding,
               },
             ])}


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. There was too much padding on Android (which has left-aligned titles) when there was no left action.