### PR TITLE
fix setting retention policy on new convos

### DIFF
--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -127,17 +127,22 @@ const metaMapReducer = (metaMap, action) => {
       })
     case Chat2Gen.updateConvRetentionPolicy:
       const {conv} = action.payload
-      const newMeta = Constants.inboxUIItemToConversationMeta(conv)
+      const newMeta = Constants.inboxUIItemToConversationMeta(conv, true)
       if (!newMeta) {
         logger.warn('Invalid inboxUIItem received in conv retention policy update')
         return metaMap
       }
-      return metaMap.set(newMeta.conversationIDKey, newMeta)
+      // don't insert inbox item if this is the first we've heard about this convo
+      if (metaMap.has(newMeta.conversationIDKey)) {
+        return metaMap.set(newMeta.conversationIDKey, newMeta)
+      }
+      return metaMap
     case Chat2Gen.updateTeamRetentionPolicy:
       const {convs} = action.payload
       const newMetas = convs.reduce((updated, conv) => {
-        const newMeta = Constants.inboxUIItemToConversationMeta(conv)
-        if (newMeta) {
+        const newMeta = Constants.inboxUIItemToConversationMeta(conv, true)
+        // don't insert inbox item if this is the first we've heard about this convo
+        if (newMeta && metaMap.has(newMeta.conversationIDKey)) {
           updated[Types.conversationIDKeyToString(newMeta.conversationIDKey)] = newMeta
         }
         return updated

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -132,8 +132,8 @@ const metaMapReducer = (metaMap, action) => {
         logger.warn('Invalid inboxUIItem received in conv retention policy update')
         return metaMap
       }
-      // don't insert inbox item if this is the first we've heard about this convo
       if (metaMap.has(newMeta.conversationIDKey)) {
+        // only insert if the convo is already in the inbox
         return metaMap.set(newMeta.conversationIDKey, newMeta)
       }
       return metaMap
@@ -141,8 +141,8 @@ const metaMapReducer = (metaMap, action) => {
       const {convs} = action.payload
       const newMetas = convs.reduce((updated, conv) => {
         const newMeta = Constants.inboxUIItemToConversationMeta(conv, true)
-        // don't insert inbox item if this is the first we've heard about this convo
         if (newMeta && metaMap.has(newMeta.conversationIDKey)) {
+          // only insert if the convo is already in the inbox
           updated[Types.conversationIDKeyToString(newMeta.conversationIDKey)] = newMeta
         }
         return updated


### PR DESCRIPTION
Confirmed that when the policy is set it sticks for the sender and the convo doesn't appear for the reciever. r? @keybase/react-hackers 