### PR TITLE
Revert "cr: store pointers in the `fileBlockMap`, not full blocks"

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -1431,12 +1431,8 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 			mergedRootPath.tailPointer())
 	} else if len(blocks) != 1 {
 		t.Errorf("Unexpected number of blocks")
-	} else if fptr, ok := blocks[mergedName]; !ok {
-		t.Errorf("No pointer for name %s", mergedName)
-	} else if block, err := dirtyBcache.Get(ctx, fb.Tlf, fptr, fb.Branch); err != nil {
-		t.Errorf("Couldn't get fblock: %v", err)
-	} else if fblock, ok := block.(*FileBlock); !ok {
-		t.Errorf("No file block for name %s, block %T", mergedName, block)
+	} else if fblock, ok := blocks[mergedName]; !ok {
+		t.Errorf("No block for name %s", mergedName)
 	} else if fblock.IsInd {
 		t.Errorf("Unexpected indirect block")
 	} else if g, e := fblock.Contents, unmergedData; !reflect.DeepEqual(g, e) {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5459,7 +5459,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 		fbo.log.CDebugf(ctx, "Syncing file %v (%s)", ref, file)
 
 		// Start the sync for this dirty file.
-		doSync, stillDirty, _, dirtyDe, newBps, syncState, cleanup, err :=
+		doSync, stillDirty, fblock, dirtyDe, newBps, syncState, cleanup, err :=
 			fbo.startSyncLocked(ctx, lState, md, node, file)
 		if cleanup != nil {
 			// Note: This passes the same `blocksToRemove` into each
@@ -5493,9 +5493,9 @@ func (fbo *folderBranchOps) syncAllLocked(
 		resolvedPaths[file.tailPointer()] = file
 		parent := file.parentPath().tailPointer()
 		if _, ok := fileBlocks[parent]; !ok {
-			fileBlocks[parent] = make(map[string]BlockPointer)
+			fileBlocks[parent] = make(map[string]*FileBlock)
 		}
-		fileBlocks[parent][file.tailName()] = file.tailPointer()
+		fileBlocks[parent][file.tailName()] = fblock
 
 		// Collect its `afterUpdateFn` along with all the others, so
 		// they all get invoked under the same lock, to avoid any

--- a/go/kbfs/libkbfs/folder_update_prepper.go
+++ b/go/kbfs/libkbfs/folder_update_prepper.go
@@ -439,21 +439,12 @@ func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 				return nil, fmt.Errorf("No file blocks found for parent %v",
 					node.parent.ptr)
 			}
-			fptr, ok := fileBlocks[node.mergedPath.tailName()]
+			fblock, ok = fileBlocks[node.mergedPath.tailName()]
 			if !ok {
 				return nil, fmt.Errorf("No file block found name %s under "+
 					"parent %v", node.mergedPath.tailName(), node.parent.ptr)
 			}
-			var err error
-			block, err = dirtyBcache.Get(ctx, fup.id(), fptr, fup.branch())
-			if err != nil {
-				return nil, err
-			}
-			fblock, ok = block.(*FileBlock)
-			if !ok {
-				return nil, errors.Errorf(
-					"%s is unexpectedly not a file block", fptr)
-			}
+			block = fblock
 			entryType = File // TODO: FIXME for Ex and Sym
 		}
 
@@ -941,7 +932,7 @@ func (fup *folderUpdatePrepper) updateResolutionUsageAndPointersLockedCache(
 func (fup *folderUpdatePrepper) setChildrenNodes(
 	ctx context.Context, lState *lockState, kmd KeyMetadata, p path,
 	indexInPath int, lbc localBcache, nextNode *pathTreeNode, currPath path,
-	blocks map[string]BlockPointer) {
+	blocks map[string]*FileBlock) {
 	dd, cleanupFn := fup.blocks.newDirDataWithLBC(
 		lState, currPath, keybase1.UserOrTeamID(""), kmd, lbc)
 	defer cleanupFn()


### PR DESCRIPTION
This reverts commit 2101f43334d8b4b836ba16ea828b6266bcf82b49.

It seems like looking the file block up in the dirty bcache during the sync is problematic, because it could be an indirect block containing block pointers from writes happening concurrently with the sync.

Issue: KBFS-3832