### PR TITLE
Fix typing status container on mobile.

### DIFF
--- a/shared/chat/conversation/input-area/normal/typing/index.js
+++ b/shared/chat/conversation/input-area/normal/typing/index.js
@@ -79,6 +79,7 @@ export const Typing = (props: Props) => (
   </Kb.Box>
 )
 
+export const MOBILE_TYPING_CONTAINER_HEIGHT = 18
 const styles = Styles.styleSheetCreate({
   isTypingAnimation: Styles.platformStyles({
     isElectron: {
@@ -97,10 +98,12 @@ const styles = Styles.styleSheetCreate({
     isMobile: {
       ...Styles.globalStyles.flexBoxRow,
       alignItems: 'flex-end',
-      bottom: 2,
-      height: 16,
-      left: 3,
-      position: 'relative',
+      backgroundColor: Styles.globalColors.white,
+      height: MOBILE_TYPING_CONTAINER_HEIGHT,
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: -MOBILE_TYPING_CONTAINER_HEIGHT,
     },
   }),
   isTypingContainerVisible: {
@@ -130,7 +133,7 @@ const styles = Styles.styleSheetCreate({
   typingIconContainer: Styles.platformStyles({
     isMobile: {
       alignItems: 'center',
-      width: 45,
+      width: 48,
     },
   }),
 })

--- a/shared/chat/conversation/input-area/normal/typing/index.js
+++ b/shared/chat/conversation/input-area/normal/typing/index.js
@@ -79,7 +79,7 @@ export const Typing = (props: Props) => (
   </Kb.Box>
 )
 
-export const MOBILE_TYPING_CONTAINER_HEIGHT = 18
+export const mobileTypingContainerHeight = 18
 const styles = Styles.styleSheetCreate({
   isTypingAnimation: Styles.platformStyles({
     isElectron: {
@@ -99,11 +99,11 @@ const styles = Styles.styleSheetCreate({
       ...Styles.globalStyles.flexBoxRow,
       alignItems: 'flex-end',
       backgroundColor: Styles.globalColors.white,
-      height: MOBILE_TYPING_CONTAINER_HEIGHT,
+      height: mobileTypingContainerHeight,
       left: 0,
       position: 'absolute',
       right: 0,
-      top: -MOBILE_TYPING_CONTAINER_HEIGHT,
+      top: -mobileTypingContainerHeight,
     },
   }),
   isTypingContainerVisible: {

--- a/shared/chat/conversation/list-area/normal/index.native.js
+++ b/shared/chat/conversation/list-area/normal/index.native.js
@@ -3,7 +3,9 @@ import * as React from 'react'
 import Message from '../../messages'
 import SpecialTopMessage from '../../messages/special-top-message'
 import SpecialBottomMessage from '../../messages/special-bottom-message'
+import {MOBILE_TYPING_CONTAINER_HEIGHT} from '../../input-area/normal/typing'
 import {Box, NativeVirtualizedList, ErrorBoundary} from '../../../../common-adapters/mobile.native'
+import * as Styles from '../../../../styles'
 import type {Props} from './index.types'
 
 class ConversationList extends React.PureComponent<Props> {
@@ -75,8 +77,9 @@ class ConversationList extends React.PureComponent<Props> {
   render() {
     return (
       <ErrorBoundary>
-        <Box style={containerStyle}>
+        <Box style={styles.container}>
           <NativeVirtualizedList
+            contentContainerStyle={styles.contentContainer}
             data={this.props.messageOrdinals}
             inverted={true}
             getItem={this._getItem}
@@ -96,8 +99,13 @@ class ConversationList extends React.PureComponent<Props> {
   }
 }
 
-const containerStyle = {
-  flex: 1,
-}
+const styles = Styles.styleSheetCreate({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {
+    bottom: -MOBILE_TYPING_CONTAINER_HEIGHT,
+  },
+})
 
 export default ConversationList

--- a/shared/chat/conversation/list-area/normal/index.native.js
+++ b/shared/chat/conversation/list-area/normal/index.native.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import Message from '../../messages'
 import SpecialTopMessage from '../../messages/special-top-message'
 import SpecialBottomMessage from '../../messages/special-bottom-message'
-import {MOBILE_TYPING_CONTAINER_HEIGHT} from '../../input-area/normal/typing'
+import {mobileTypingContainerHeight} from '../../input-area/normal/typing'
 import {Box, NativeVirtualizedList, ErrorBoundary} from '../../../../common-adapters/mobile.native'
 import * as Styles from '../../../../styles'
 import type {Props} from './index.types'
@@ -104,7 +104,7 @@ const styles = Styles.styleSheetCreate({
     flex: 1,
   },
   contentContainer: {
-    bottom: -MOBILE_TYPING_CONTAINER_HEIGHT,
+    bottom: -mobileTypingContainerHeight,
   },
 })
 


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. The problem was that we were always clipping the bottom 16px (now 18px) of the conversation thread where we're holding space for the typing status.