### PR TITLE
Use an ellipsis instead of wrapping on typing status and formatting guide.

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -261,7 +261,13 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
           </Kb.Box>
           <Kb.Box style={styles.footerContainer}>
             <Typing conversationIDKey={this.props.conversationIDKey} />
-            <Kb.Text type="BodySmall" style={styles.footer} onClick={this._inputFocus} selectable={true}>
+            <Kb.Text
+              lineClamp={1}
+              type="BodySmall"
+              style={styles.footer}
+              onClick={this._inputFocus}
+              selectable={true}
+            >
               *bold*, _italics_, `code`, >quote
             </Kb.Text>
           </Kb.Box>

--- a/shared/chat/conversation/input-area/normal/typing/index.js
+++ b/shared/chat/conversation/input-area/normal/typing/index.js
@@ -73,7 +73,7 @@ export const Typing = (props: Props) => (
     <Kb.Box style={styles.typingIconContainer}>
       <Kb.Animation animationType="typing" containerStyle={styles.isTypingAnimation} />
     </Kb.Box>
-    <Kb.Text type={Styles.isMobile ? 'BodyTiny' : 'BodySmall'} style={styles.isTypingText}>
+    <Kb.Text lineClamp={1} type={Styles.isMobile ? 'BodyTiny' : 'BodySmall'} style={styles.isTypingText}>
       <Names names={props.names} />
     </Kb.Text>
   </Kb.Box>
@@ -92,6 +92,7 @@ const styles = Styles.styleSheetCreate({
   }),
   isTypingContainer: Styles.platformStyles({
     common: {
+      flexGrow: 1,
       opacity: 0,
     },
     isMobile: {


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review.