### PR TITLE
Add teams as a top level route on mobile

### DIFF
--- a/shared/app/routes-app.js
+++ b/shared/app/routes-app.js
@@ -33,12 +33,12 @@ const appRouteTree = makeRouteDefNode({
     [peopleTab]: peopleRoutes,
     [profileTab]: profileRoutes,
     [settingsTab]: settingsRoutes,
+    [teamsTab]: teamsRoutes, // TODO remove with DESKTOP-8924
     ...(flags.walletsEnabled && !isMobile ? {[walletsTab]: walletsRoutes} : {}),
     ...(isMobile
       ? {}
       : {
           [devicesTab]: devicesRoutes, // not a top level route in mobile
-          [teamsTab]: teamsRoutes,
         }),
   },
   containerComponent: Nav,

--- a/shared/app/tab-bar/container.js
+++ b/shared/app/tab-bar/container.js
@@ -3,7 +3,15 @@ import * as I from 'immutable'
 import * as Chat2Gen from '../../actions/chat2-gen'
 import {connect, isMobile} from '../../util/container'
 import TabBarRender from '.'
-import {chatTab, peopleTab, profileTab, walletsTab, type Tab} from '../../constants/tabs'
+import {
+  chatTab,
+  peopleTab,
+  profileTab,
+  settingsTab,
+  teamsTab,
+  walletsTab,
+  type Tab,
+} from '../../constants/tabs'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import {createShowUserProfile} from '../../actions/profile-gen'
 
@@ -94,7 +102,8 @@ const mergeProps = (stateProps, dispatchProps, {routeSelected}) => ({
     [walletsTab]: stateProps.isWalletsNew,
   },
   onTabClick: (tab: Tab) => dispatchProps._onTabClick(tab, stateProps.username, stateProps.isWalletsNew),
-  selectedTab: routeSelected,
+  // TODO DESKTOP-8924 remove this isMobile special case
+  selectedTab: isMobile && routeSelected === teamsTab ? settingsTab : routeSelected,
   username: stateProps.username || '',
 })
 

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -33,6 +33,7 @@ const mapDispatchToProps = (dispatch, {routePath, navigateUp}) => ({
   onBack: () => {
     if (isMobile) {
       // TODO remove with DESKTOP-8924
+      dispatch(RouteTreeGen.createNavigateTo({parentPath: [Tabs.settingsTab], path: []}))
       dispatch(RouteTreeGen.createSwitchTo({parentPath: [], path: [Tabs.settingsTab]}))
     } else {
       dispatch(navigateUp())

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -6,6 +6,7 @@ import * as FsGen from '../actions/fs-gen'
 import * as FsTypes from '../constants/types/fs'
 import * as GregorGen from '../actions/gregor-gen'
 import * as TeamsGen from '../actions/teams-gen'
+import * as Tabs from '../constants/tabs'
 import Teams from './main'
 import openURL from '../util/open-url'
 import * as RouteTreeGen from '../actions/route-tree-gen'
@@ -29,7 +30,14 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = (dispatch, {routePath, navigateUp}) => ({
   _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
-  onBack: () => dispatch(navigateUp()),
+  onBack: () => {
+    if (isMobile) {
+      // TODO remove with DESKTOP-8924
+      dispatch(RouteTreeGen.createSwitchTo({parentPath: [], path: [Tabs.settingsTab]}))
+    } else {
+      dispatch(navigateUp())
+    }
+  },
   onCreateTeam: () => {
     dispatch(
       RouteTreeGen.createNavigateAppend({


### PR DESCRIPTION
We have around 60 instances of routing to `tab:teamsTab` which were broken on mobile when we moved teams into settings. I made a ticket to go through and fix those but for the sake of simplicity this adds teams back to the top level routes so the navigation actions will still work. I tested some flows (nav from chat, new team, leave team) and they worked. r? @keybase/react-hackers 