### PR TITLE
Fix header on Android when using `titleComponent`.

### DIFF
--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -83,7 +83,17 @@ export class HeaderHocHeader extends React.Component<Props, State> {
           onLeftAction={onLeftAction}
           theme={this.props.theme}
         />
-        {this.props.titleComponent && <Box style={styles.titleContainer}>{this.props.titleComponent}</Box>}
+        {this.props.titleComponent && (
+          <Box
+            style={Styles.collapseStyles([
+              styles.titleContainer,
+              rightActions && styles.titleContainerLeftPadding,
+              leftAction && styles.titleContainerRightPadding,
+            ])}
+          >
+            {this.props.titleComponent}
+          </Box>
+        )}
         <RightActions
           floatingMenuVisible={this.state.floatingMenuVisible}
           hasTextTitle={hasTextTitle}
@@ -297,10 +307,21 @@ const styles = Styles.styleSheetCreate({
     },
     isAndroid: {
       alignItems: 'flex-start',
+      flexShrink: 1,
     },
     isIOS: {
       paddingLeft: Styles.globalMargins.tiny,
       paddingRight: Styles.globalMargins.tiny,
+    },
+  }),
+  titleContainerLeftPadding: Styles.platformStyles({
+    isAndroid: {
+      paddingLeft: Styles.globalMargins.small,
+    },
+  }),
+  titleContainerRightPadding: Styles.platformStyles({
+    isAndroid: {
+      paddingRight: Styles.globalMargins.small,
     },
   }),
   titleTextContainer: {

--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -87,8 +87,8 @@ export class HeaderHocHeader extends React.Component<Props, State> {
           <Box
             style={Styles.collapseStyles([
               styles.titleContainer,
-              rightActions && styles.titleContainerLeftPadding,
-              leftAction && styles.titleContainerRightPadding,
+              onLeftAction && styles.titleContainerRightPadding,
+              rightActions.length && styles.titleContainerLeftPadding,
             ])}
           >
             {this.props.titleComponent}

--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -307,7 +307,6 @@ const styles = Styles.styleSheetCreate({
     },
     isAndroid: {
       alignItems: 'flex-start',
-      flexShrink: 1,
     },
     isIOS: {
       paddingLeft: Styles.globalMargins.tiny,


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review.