### PR TITLE
level db stats in kb status

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -103,6 +103,8 @@ type fstatus struct {
 	PlatformInfo         keybase1.PlatformInfo
 	OSVersion            string
 	DeviceEKNames        []string
+	LocalDbStats         []string
+	LocalChatDbStats     []string
 }
 
 func (c *CmdStatus) Run() error {
@@ -214,6 +216,8 @@ func (c *CmdStatus) load() (*fstatus, error) {
 	status.Clients = extStatus.Clients
 	status.PlatformInfo = extStatus.PlatformInfo
 	status.DeviceEKNames = extStatus.DeviceEkNames
+	status.LocalDbStats = extStatus.LocalDbStats
+	status.LocalChatDbStats = extStatus.LocalChatDbStats
 
 	// set anything os-specific:
 	if err := c.osSpecific(&status); err != nil {
@@ -311,6 +315,8 @@ func (c *CmdStatus) outputTerminal(status *fstatus) error {
 	dui.Printf("Other users:   %s\n", strings.Join(status.ProvisionedUsernames, ", "))
 	dui.Printf("Known DeviceEKs:\n")
 	dui.Printf("    %s \n", strings.Join(status.DeviceEKNames, "\n    "))
+	dui.Printf("LocalDbStats:\n%s \n", strings.Join(status.LocalDbStats, "\n"))
+	dui.Printf("LocalChatDbStats:\n%s \n", strings.Join(status.LocalChatDbStats, "\n"))
 
 	c.outputClients(dui, status.Clients)
 	return nil

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -94,6 +94,7 @@ func (j *JSONLocalDb) Open() error           { return j.engine.Open() }
 func (j *JSONLocalDb) ForceOpen() error      { return j.engine.ForceOpen() }
 func (j *JSONLocalDb) Close() error          { return j.engine.Close() }
 func (j *JSONLocalDb) Nuke() (string, error) { return j.engine.Nuke() }
+func (j *JSONLocalDb) Stats() string         { return j.engine.Stats() }
 
 func (j *JSONLocalDb) PutRaw(id DbKey, b []byte) error       { return j.engine.Put(id, nil, b) }
 func (j *JSONLocalDb) GetRaw(id DbKey) ([]byte, bool, error) { return j.engine.Get(id) }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -136,6 +136,7 @@ type LocalDbOps interface {
 	Delete(id DbKey) error
 	Get(id DbKey) ([]byte, bool, error)
 	Lookup(alias DbKey) ([]byte, bool, error)
+	Stats() string
 }
 
 type LocalDbTransaction interface {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -136,7 +136,6 @@ type LocalDbOps interface {
 	Delete(id DbKey) error
 	Get(id DbKey) ([]byte, bool, error)
 	Lookup(alias DbKey) ([]byte, bool, error)
-	Stats() string
 }
 
 type LocalDbTransaction interface {
@@ -148,6 +147,7 @@ type LocalDbTransaction interface {
 type LocalDb interface {
 	LocalDbOps
 	Open() error
+	Stats() string
 	ForceOpen() error
 	Close() error
 	Nuke() (string, error)

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -189,6 +189,16 @@ func (l *LevelDb) ForceOpen() error {
 	return l.doWhileOpenAndNukeIfCorrupted(func() error { return nil })
 }
 
+func (l *LevelDb) Stats() (stats string) {
+	if err := l.doWhileOpenAndNukeIfCorrupted(func() (err error) {
+		stats, err = l.db.GetProperty("leveldb.stats")
+		return err
+	}); err != nil {
+		return ""
+	}
+	return stats
+}
+
 func (l *LevelDb) GetFilename() string {
 	if len(l.filename) == 0 {
 		l.G().Log.Fatalf("DB filename empty")
@@ -316,6 +326,10 @@ func (l *LevelDb) OpenTransaction() (LocalDbTransaction, error) {
 
 type LevelDbTransaction struct {
 	tr *leveldb.Transaction
+}
+
+func (l LevelDbTransaction) Stats() string {
+	return ""
 }
 
 func (l LevelDbTransaction) Put(id DbKey, aliases []DbKey, value []byte) error {

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -328,10 +328,6 @@ type LevelDbTransaction struct {
 	tr *leveldb.Transaction
 }
 
-func (l LevelDbTransaction) Stats() string {
-	return ""
-}
-
 func (l LevelDbTransaction) Put(id DbKey, aliases []DbKey, value []byte) error {
 	return levelDbPut(l.tr, id, aliases, value)
 }

--- a/go/libkb/memdb.go
+++ b/go/libkb/memdb.go
@@ -22,6 +22,7 @@ func NewMemDb(size int) *MemDb {
 }
 
 func (m *MemDb) Open() error      { return nil }
+func (m *MemDb) Stats() string    { return "" }
 func (m *MemDb) ForceOpen() error { return nil }
 func (m *MemDb) Close() error {
 	m.lru.Purge()

--- a/go/libkb/status.go
+++ b/go/libkb/status.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"runtime"
+	"strings"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
@@ -58,7 +59,7 @@ func GetExtendedStatus(m MetaContext) (res keybase1.ExtendedStatus, err error) {
 		res.Clients = g.ConnectionManager.ListAllLabeledConnections()
 	}
 
-	err = g.GetFullSelfer().WithSelf(m.Ctx(), func(me *User) error {
+	if err = g.GetFullSelfer().WithSelf(m.Ctx(), func(me *User) error {
 		device, err := me.GetComputedKeyFamily().GetCurrentDevice(g)
 		if err != nil {
 			m.CDebugf("| GetCurrentDevice failed: %s", err)
@@ -75,8 +76,7 @@ func GetExtendedStatus(m MetaContext) (res keybase1.ExtendedStatus, err error) {
 			}
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		m.CDebugf("| could not load me user: %s", err)
 		res.DeviceErr = &keybase1.LoadDeviceErr{Where: "libkb.LoadMe", Desc: err.Error()}
 	}
@@ -125,6 +125,9 @@ func GetExtendedStatus(m MetaContext) (res keybase1.ExtendedStatus, err error) {
 		}
 		res.DeviceEkNames = dekNames
 	}
+
+	res.LocalDbStats = strings.Split(g.LocalDb.Stats(), "\n")
+	res.LocalChatDbStats = strings.Split(g.LocalChatDb.Stats(), "\n")
 
 	return res, nil
 }

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -127,6 +127,8 @@ type ExtendedStatus struct {
 	DeviceEkNames          []string        `codec:"deviceEkNames" json:"deviceEkNames"`
 	PlatformInfo           PlatformInfo    `codec:"platformInfo" json:"platformInfo"`
 	DefaultDeviceID        DeviceID        `codec:"defaultDeviceID" json:"defaultDeviceID"`
+	LocalDbStats           []string        `codec:"localDbStats" json:"localDbStats"`
+	LocalChatDbStats       []string        `codec:"localChatDbStats" json:"localChatDbStats"`
 }
 
 func (o ExtendedStatus) DeepCopy() ExtendedStatus {
@@ -199,6 +201,28 @@ func (o ExtendedStatus) DeepCopy() ExtendedStatus {
 		})(o.DeviceEkNames),
 		PlatformInfo:    o.PlatformInfo.DeepCopy(),
 		DefaultDeviceID: o.DefaultDeviceID.DeepCopy(),
+		LocalDbStats: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			ret := make([]string, len(x))
+			for i, v := range x {
+				vCopy := v
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.LocalDbStats),
+		LocalChatDbStats: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			ret := make([]string, len(x))
+			for i, v := range x {
+				vCopy := v
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.LocalChatDbStats),
 	}
 }
 

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -70,6 +70,8 @@ protocol config {
     PlatformInfo platformInfo;
     DeviceID defaultDeviceID;               /* this contains the device ID for defaultUsername
                                                in the config file. */
+    array<string> localDbStats;
+    array<string> localChatDbStats;
   }
 
   ExtendedStatus getExtendedStatus(int sessionID);

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -234,6 +234,20 @@
         {
           "type": "DeviceID",
           "name": "defaultDeviceID"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "localDbStats"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "localChatDbStats"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -2026,7 +2026,7 @@ export type ExitCode =
   | 2 // NOTOK_2
   | 4 // RESTART_4
 
-export type ExtendedStatus = $ReadOnly<{standalone: Boolean, passphraseStreamCached: Boolean, tsecCached: Boolean, deviceSigKeyCached: Boolean, deviceEncKeyCached: Boolean, paperSigKeyCached: Boolean, paperEncKeyCached: Boolean, storedSecret: Boolean, secretPromptSkip: Boolean, rememberPassphrase: Boolean, device?: ?Device, deviceErr?: ?LoadDeviceErr, logDir: String, session?: ?SessionStatus, defaultUsername: String, provisionedUsernames?: ?Array<String>, Clients?: ?Array<ClientDetails>, deviceEkNames?: ?Array<String>, platformInfo: PlatformInfo, defaultDeviceID: DeviceID}>
+export type ExtendedStatus = $ReadOnly<{standalone: Boolean, passphraseStreamCached: Boolean, tsecCached: Boolean, deviceSigKeyCached: Boolean, deviceEncKeyCached: Boolean, paperSigKeyCached: Boolean, paperEncKeyCached: Boolean, storedSecret: Boolean, secretPromptSkip: Boolean, rememberPassphrase: Boolean, device?: ?Device, deviceErr?: ?LoadDeviceErr, logDir: String, session?: ?SessionStatus, defaultUsername: String, provisionedUsernames?: ?Array<String>, Clients?: ?Array<ClientDetails>, deviceEkNames?: ?Array<String>, platformInfo: PlatformInfo, defaultDeviceID: DeviceID, localDbStats?: ?Array<String>, localChatDbStats?: ?Array<String>}>
 export type ExternalServiceConfig = $ReadOnly<{schemaVersion: Int, display?: ?ServiceDisplayConfig, config?: ?ParamProofServiceConfig}>
 export type FSEditListRequest = $ReadOnly<{folder: Folder, requestID: Int}>
 export type FSErrorType =


### PR DESCRIPTION
nice for debugging, have a sense for what this size is in the wild

```
$keybase status
...
LocalDbStats:
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   1   |         28 |      54.98328 |       0.38301 |      53.36131 |      52.96155
 
LocalChatDbStats:
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   0   |          2 |       7.06853 |       0.00000 |       0.00000 |       0.00000
   1   |         13 |      25.26196 |       0.00000 |       0.00000 |       0.00000
```
 
