### PR TITLE
Alert JS when engine has reset so it can reconnect [Android]

### DIFF
--- a/shared/engine/index.platform.native.js
+++ b/shared/engine/index.platform.native.js
@@ -14,6 +14,8 @@ import type {createClientType, incomingRPCCallbackType, connectDisconnectCB} fro
 const nativeBridge: {
   runWithData: string => void,
   eventName: string,
+  metaEventName: string,
+  metaEventEngineReset: string,
   start: () => void,
   reset: () => void,
 } = NativeModules.KeybaseEngine
@@ -87,6 +89,13 @@ function createClient(
     const ret = client.transport.packetize_data(buffer)
     measureStop(measureName)
     return ret
+  })
+
+  RNEmitter.addListener(nativeBridge.metaEventName, (payload: string) => {
+    switch (payload) {
+      case nativeBridge.metaEventEngineReset:
+        connectCallback()
+    }
   })
 
   return client

--- a/shared/react-native/ios/Keybase/Engine.m
+++ b/shared/react-native/ios/Keybase/Engine.m
@@ -34,6 +34,9 @@ static Engine * sharedEngine = nil;
 @implementation Engine
 
 static NSString *const eventName = @"objc-engine-event";
+static NSString *const metaEventName = @"objc-meta-engine-event";
+static NSString *const metaEventEngineReset = @"engine-reset";
+
 
 - (instancetype)initWithSettings:(NSDictionary *)settings error:(NSError **)error {
   if ((self = [super init])) {
@@ -102,6 +105,7 @@ static NSString *const eventName = @"objc-engine-event";
 - (void)reset {
   NSError *error = nil;
   KeybaseReset(&error);
+  [self.keybaseEngine sendEventWithName:metaEventName body:metaEventEngineReset];
   if (error) {
     NSLog(@"Error in reset: %@", error);
   }
@@ -126,7 +130,7 @@ RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[eventName];
+  return @[eventName, metaEventName];
 }
 
 RCT_EXPORT_METHOD(runWithData:(NSString *)data) {
@@ -164,6 +168,8 @@ RCT_EXPORT_METHOD(start) {
   NSString * appBuildString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
 
   return @{ @"eventName": eventName,
+            @"metaEventName": metaEventName,
+            @"metaEventEngineReset": metaEventEngineReset,
             @"test": testVal,
             @"appVersionName": appVersionString,
             @"appVersionCode": appBuildString,


### PR DESCRIPTION
This fixes the bug where if you back out of the app (by pressing the back button) and re enter the app, the app is no longer registered as a delegate for anything. So things like the delegateIdentifyUI call will never happen.

This happens when we reset the engine. The go side removes us as delegates since we've effectively disconnected. The reset call was added by me [here](https://github.com/keybase/client/pull/14909) to fix another bug that caused messages to be dropped.

The problem is that Android calls onDestroy on our activity, so we shutdown the thread that is communicating with the engine. Even though it calls onDestroy on the activity, the go side and the js side may still be alive. When this happens, we relaunch our thread to communicate with the engine and we resume our JS. JS doesn't know the connection to the engine is a new one, so it doesn't try to re-register itself as a delegate (and other onConnect logic).

This fixes the problem by alerting JS when we reset the engine so it can make the onConnect calls again.