### PR TITLE
Make `chat api-listen` official

### DIFF
--- a/go/client/cmd_chat.go
+++ b/go/client/cmd_chat.go
@@ -12,6 +12,7 @@ import (
 func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	subcommands := []cli.Command{
 		newCmdChatAPI(cl, g),
+		newCmdChatAPIListen(cl, g),
 		newCmdChatDeleteChannel(cl, g),
 		newCmdChatDeleteHistory(cl, g),
 		newCmdChatDownload(cl, g),
@@ -35,7 +36,6 @@ func NewCmdChat(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command 
 		newCmdChatSearchRegexp(cl, g),
 		newCmdChatSend(cl, g),
 		newCmdChatUpload(cl, g),
-		newCmdChatAPIListen(cl, g),
 	}
 	subcommands = append(subcommands, getBuildSpecificChatCommands(cl, g)...)
 	return cli.Command{

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -34,9 +34,8 @@ type CmdChatAPIListen struct {
 
 func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
-		Name: "api-listen",
-		// No "Usage" field makes it hidden in command list.
-		Description: "Listen and print incoming chat actions in JSON format",
+		Name:  "api-listen",
+		Usage: "Listen and print incoming chat actions in JSON format",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdChatAPIListen{
 				Contextified: libkb.NewContextified(g),


### PR DESCRIPTION
```
» keybase chat help
NAME:
   keybase chat - Chat securely with keybase users

USAGE:
   keybase chat <command> [arguments...]

COMMANDS:
   api				JSON API
   api-listen			Listen and print incoming chat actions in JSON format
   delete-channel		Delete a channel
   delete-history		Delete chat history in a conversation
   download			Download an attachment from a conversation

...
```