### PR TITLE
libkbfs: hide .kbfs_deleted_repos from listing

### DIFF
--- a/go/kbfs/libgit/repo_test.go
+++ b/go/kbfs/libgit/repo_test.go
@@ -286,8 +286,7 @@ func TestDeleteRepo(t *testing.T) {
 	require.NoError(t, err)
 	children, err := config.KBFSOps().GetDirChildren(ctx, gitNode)
 	require.NoError(t, err)
-	require.Len(t, children, 1)
-	require.Contains(t, children, kbfsDeletedReposDir)
+	require.Len(t, children, 0) // .kbfs_deleted_repos is hidden
 
 	deletedReposNode, _, err := config.KBFSOps().Lookup(
 		ctx, gitNode, kbfsDeletedReposDir)

--- a/go/kbfs/libkbfs/dir_data.go
+++ b/go/kbfs/libkbfs/dir_data.go
@@ -59,8 +59,9 @@ func (dd *dirData) blockGetter(
 }
 
 var hiddenEntries = map[string]bool{
-	".kbfs_git":     true,
-	".kbfs_autogit": true,
+	".kbfs_git":           true,
+	".kbfs_autogit":       true,
+	".kbfs_deleted_repos": true,
 }
 
 func (dd *dirData) getTopBlock(ctx context.Context, rtype blockReqType) (


### PR DESCRIPTION
Autogit was listing `.kbfs_deleted_repos` as a repository name.  This causes issues, especially on the mobile GUI, where recursive lookups try to browse it on parent path lookups, although it is not a proper repo.