### PR TITLE
friendlier ui for mobile only

### DIFF
--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -270,6 +270,21 @@ func (a *ActiveDevice) DeviceID() keybase1.DeviceID {
 	return a.deviceID
 }
 
+func (a *ActiveDevice) DeviceType() (string, error) {
+	devices, err := a.secretSyncer.Devices()
+	if err != nil {
+		return "", err
+	}
+	for devID, dev := range devices {
+		if devID == a.DeviceID() {
+			return dev.Type, nil
+		}
+	}
+	return "", NotFoundError{
+		Msg: "Not found: device type",
+	}
+}
+
 // SigningKey returns the signing key for the active device.
 // Safe for use by concurrent goroutines.
 func (a *ActiveDevice) SigningKey() (GenericKey, error) {

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -9,24 +9,26 @@ import (
 )
 
 type WalletAccountLocal struct {
-	AccountID          AccountID     `codec:"accountID" json:"accountID"`
-	IsDefault          bool          `codec:"isDefault" json:"isDefault"`
-	Name               string        `codec:"name" json:"name"`
-	BalanceDescription string        `codec:"balanceDescription" json:"balanceDescription"`
-	Seqno              string        `codec:"seqno" json:"seqno"`
-	CurrencyLocal      CurrencyLocal `codec:"currencyLocal" json:"currencyLocal"`
-	AccountMode        AccountMode   `codec:"accountMode" json:"accountMode"`
+	AccountID           AccountID     `codec:"accountID" json:"accountID"`
+	IsDefault           bool          `codec:"isDefault" json:"isDefault"`
+	Name                string        `codec:"name" json:"name"`
+	BalanceDescription  string        `codec:"balanceDescription" json:"balanceDescription"`
+	Seqno               string        `codec:"seqno" json:"seqno"`
+	CurrencyLocal       CurrencyLocal `codec:"currencyLocal" json:"currencyLocal"`
+	AccountMode         AccountMode   `codec:"accountMode" json:"accountMode"`
+	AccountModeEditable bool          `codec:"accountModeEditable" json:"accountModeEditable"`
 }
 
 func (o WalletAccountLocal) DeepCopy() WalletAccountLocal {
 	return WalletAccountLocal{
-		AccountID:          o.AccountID.DeepCopy(),
-		IsDefault:          o.IsDefault,
-		Name:               o.Name,
-		BalanceDescription: o.BalanceDescription,
-		Seqno:              o.Seqno,
-		CurrencyLocal:      o.CurrencyLocal.DeepCopy(),
-		AccountMode:        o.AccountMode.DeepCopy(),
+		AccountID:           o.AccountID.DeepCopy(),
+		IsDefault:           o.IsDefault,
+		Name:                o.Name,
+		BalanceDescription:  o.BalanceDescription,
+		Seqno:               o.Seqno,
+		CurrencyLocal:       o.CurrencyLocal.DeepCopy(),
+		AccountMode:         o.AccountMode.DeepCopy(),
+		AccountModeEditable: o.AccountModeEditable,
 	}
 }
 

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -52,6 +52,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.True(t, accts[0].IsDefault)
 	require.Equal(t, "qq", accts[0].Name)
 	require.Equal(t, stellar1.AccountMode_USER, accts[0].AccountMode)
+	require.Equal(t, false, accts[0].AccountModeEditable)
 	require.Equal(t, "10,000.00 XLM", accts[0].BalanceDescription)
 	currencyLocal := accts[0].CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
@@ -63,6 +64,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.False(t, accts[1].IsDefault)
 	require.Equal(t, firstAccountName(t, tcs[0]), accts[1].Name)
 	require.Equal(t, stellar1.AccountMode_USER, accts[1].AccountMode)
+	require.Equal(t, false, accts[1].AccountModeEditable)
 	require.Equal(t, "0 XLM", accts[1].BalanceDescription)
 	currencyLocal = accts[1].CurrencyLocal
 	require.Equal(t, stellar1.OutsideCurrencyCode("USD"), currencyLocal.Code)
@@ -74,6 +76,7 @@ func TestGetWalletAccountsLocal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "qq", details.Name)
 	require.Equal(t, stellar1.AccountMode_USER, details.AccountMode)
+	require.Equal(t, false, accts[1].AccountModeEditable)
 	require.True(t, details.IsDefault)
 	require.Equal(t, "10,000.00 XLM", details.BalanceDescription)
 	require.NotEmpty(t, details.Seqno)
@@ -2593,6 +2596,7 @@ func TestSetMobileOnly(t *testing.T) {
 	details, err := tcs[0].Srv.GetWalletAccountLocal(context.Background(), walletAcctLocalArg)
 	require.NoError(t, err)
 	require.Equal(t, stellar1.AccountMode_USER, details.AccountMode)
+	require.Equal(t, true, details.AccountModeEditable)
 
 	err = tcs[0].Srv.SetAccountMobileOnlyLocal(context.Background(), stellar1.SetAccountMobileOnlyLocalArg{AccountID: accountID})
 	require.NoError(t, err)
@@ -2608,6 +2612,7 @@ func TestSetMobileOnly(t *testing.T) {
 	details, err = tcs[0].Srv.GetWalletAccountLocal(context.Background(), walletAcctLocalArg)
 	require.NoError(t, err)
 	require.Equal(t, stellar1.AccountMode_MOBILE, details.AccountMode)
+	require.Equal(t, true, details.AccountModeEditable)
 
 	// service_test verifies that `SetAccountMobileOnlyLocal` behaves correctly under the covers
 }

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -1430,6 +1431,7 @@ func setupTestsWithSettings(t *testing.T, settings []usetting) ([]*TestContext, 
 		switch setting {
 		case usettingFull:
 		case usettingMobile:
+			os.Setenv("KEYBASE_APP_TYPE", string(libkb.MobileAppType))
 		case usettingPukless:
 			tc.Tp.DisableUpgradePerUserKey = true
 		}
@@ -1457,6 +1459,7 @@ func setupTestsWithSettings(t *testing.T, settings []usetting) ([]*TestContext, 
 	cleanup := func() {
 		for _, tc := range tcs {
 			tc.Cleanup()
+			os.Unsetenv("KEYBASE_APP_TYPE")
 		}
 	}
 	for i, tc := range tcs {

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -1431,7 +1430,6 @@ func setupTestsWithSettings(t *testing.T, settings []usetting) ([]*TestContext, 
 		switch setting {
 		case usettingFull:
 		case usettingMobile:
-			os.Setenv("KEYBASE_APP_TYPE", string(libkb.MobileAppType))
 		case usettingPukless:
 			tc.Tp.DisableUpgradePerUserKey = true
 		}
@@ -1459,7 +1457,6 @@ func setupTestsWithSettings(t *testing.T, settings []usetting) ([]*TestContext, 
 	cleanup := func() {
 		for _, tc := range tcs {
 			tc.Cleanup()
-			os.Unsetenv("KEYBASE_APP_TYPE")
 		}
 	}
 	for i, tc := range tcs {

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -449,7 +449,11 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 		return empty, err
 	}
 
-	isMobile := mctx.G().GetAppType() == libkb.MobileAppType
+	activeDeviceType, err := mctx.G().ActiveDevice.DeviceType()
+	if err != nil {
+		return empty, err
+	}
+	isMobile := activeDeviceType == libkb.DeviceTypeMobile
 	ctime, err := mctx.G().ActiveDevice.Ctime(mctx)
 	if err != nil {
 		return empty, err

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -451,8 +451,11 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 
 	isMobile := mctx.G().GetAppType() == libkb.MobileAppType
 	ctime, err := mctx.G().ActiveDevice.Ctime(mctx)
-	ctimeEpochSeconds := int64(ctime) / 1000
-	deviceAge := time.Since(time.Unix(ctimeEpochSeconds, 0)).Hours() / 24.0 // in days
+	if err != nil {
+		return empty, err
+	}
+	deviceProvisionedAt := time.Unix(int64(ctime)/1000, 0)
+	deviceAge := mctx.G().Clock().Since(deviceProvisionedAt)
 
 	acct := stellar1.WalletAccountLocal{
 		AccountID:           accountID,
@@ -461,7 +464,7 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 		BalanceDescription:  balance,
 		Seqno:               details.Seqno,
 		AccountMode:         accountMode,
-		AccountModeEditable: isMobile && deviceAge > 7,
+		AccountModeEditable: isMobile && deviceAge > 7*24*time.Hour,
 	}
 
 	conf, err := mctx.G().GetStellar().GetServerDefinitions(mctx.Ctx())

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -448,13 +449,19 @@ func AccountDetailsToWalletAccountLocal(mctx libkb.MetaContext, accountID stella
 		return empty, err
 	}
 
+	isMobile := mctx.G().GetAppType() == libkb.MobileAppType
+	ctime, err := mctx.G().ActiveDevice.Ctime(mctx)
+	ctimeEpochSeconds := int64(ctime) / 1000
+	deviceAge := time.Since(time.Unix(ctimeEpochSeconds, 0)).Hours() / 24.0 // in days
+
 	acct := stellar1.WalletAccountLocal{
-		AccountID:          accountID,
-		IsDefault:          isPrimary,
-		Name:               accountName,
-		BalanceDescription: balance,
-		Seqno:              details.Seqno,
-		AccountMode:        accountMode,
+		AccountID:           accountID,
+		IsDefault:           isPrimary,
+		Name:                accountName,
+		BalanceDescription:  balance,
+		Seqno:               details.Seqno,
+		AccountMode:         accountMode,
+		AccountModeEditable: isMobile && deviceAge > 7,
 	}
 
 	conf, err := mctx.G().GetStellar().GetServerDefinitions(mctx.Ctx())

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -14,6 +14,7 @@ protocol local {
     string seqno;               // the stellar sequence number for this account
     CurrencyLocal currencyLocal;// user configurable, defaults to USD and related details
     AccountMode accountMode;    // mobile only vs all devices
+    boolean accountModeEditable;// is this device able to change it
   }
   array<WalletAccountLocal> getWalletAccountsLocal(int sessionID);
   WalletAccountLocal getWalletAccountLocal(int sessionID, AccountID accountID);
@@ -486,7 +487,7 @@ protocol local {
   InflationDestinationResultLocal getInflationDestinationLocal(int sessionID, AccountID accountID);
 
   // airdropDetailsLocal returns a json blob of details about the current
-  // airdrop.  If the current airdrop has expired, it will return an 
+  // airdrop.  If the current airdrop has expired, it will return an
   // expired error.
   string airdropDetailsLocal(int sessionID);
 

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -38,6 +38,10 @@
         {
           "type": "AccountMode",
           "name": "accountMode"
+        },
+        {
+          "type": "boolean",
+          "name": "accountModeEditable"
         }
       ]
     },

--- a/shared/constants/types/rpc-stellar-gen.js.flow
+++ b/shared/constants/types/rpc-stellar-gen.js.flow
@@ -449,7 +449,7 @@ export type TransactionStatus =
   | 4 // ERROR_PERMANENT_4
 
 export type UIPaymentReviewed = $ReadOnly<{bid: BuildPaymentID, reviewID: Int, seqno: Int, banners?: ?Array<SendBannerLocal>, nextButton: String}>
-export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal, accountMode: AccountMode}>
+export type WalletAccountLocal = $ReadOnly<{accountID: AccountID, isDefault: Boolean, name: String, balanceDescription: String, seqno: String, currencyLocal: CurrencyLocal, accountMode: AccountMode, accountModeEditable: Boolean}>
 
 export type IncomingCallMapType = {|
   'stellar.1.notify.paymentNotification'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'stellar.1.notify.paymentNotification'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -212,12 +212,17 @@ export type Payment = I.RecordOf<_Payment>
 
 export type Currency = I.RecordOf<_LocalCurrency>
 
+export type AccountMode = StellarRPCTypes.AccountMode
+export const accountModeNone = StellarRPCTypes.commonAccountMode.none
+
 export type _Account = {
   accountID: AccountID,
   balanceDescription: string,
   displayCurrency: Currency,
   isDefault: boolean,
   name: string,
+  accountMode: AccountMode,
+  mobileOnlyEditable: boolean,
 }
 export type Account = I.RecordOf<_Account>
 

--- a/shared/constants/types/wallets.js
+++ b/shared/constants/types/wallets.js
@@ -212,16 +212,12 @@ export type Payment = I.RecordOf<_Payment>
 
 export type Currency = I.RecordOf<_LocalCurrency>
 
-export type AccountMode = StellarRPCTypes.AccountMode
-export const accountModeNone = StellarRPCTypes.commonAccountMode.none
-
 export type _Account = {
   accountID: AccountID,
   balanceDescription: string,
   displayCurrency: Currency,
   isDefault: boolean,
   name: string,
-  accountMode: AccountMode,
   mobileOnlyEditable: boolean,
 }
 export type Account = I.RecordOf<_Account>

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -165,7 +165,6 @@ export const buildRequestResultToBuiltRequest = (b: RPCTypes.BuildRequestResLoca
 export const accountResultToAccount = (w: RPCTypes.WalletAccountLocal) =>
   makeAccount({
     accountID: Types.stringToAccountID(w.accountID),
-    accountMode: w.accountMode,
     balanceDescription: w.balanceDescription,
     displayCurrency: currencyResultToCurrency(w.currencyLocal),
     isDefault: w.isDefault,
@@ -267,7 +266,6 @@ export const unknownCurrency = makeCurrency()
 
 export const makeAccount: I.RecordFactory<Types._Account> = I.Record({
   accountID: Types.noAccountID,
-  accountMode: Types.accountModeNone,
   balanceDescription: '',
   displayCurrency: unknownCurrency,
   isDefault: false,

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -165,9 +165,11 @@ export const buildRequestResultToBuiltRequest = (b: RPCTypes.BuildRequestResLoca
 export const accountResultToAccount = (w: RPCTypes.WalletAccountLocal) =>
   makeAccount({
     accountID: Types.stringToAccountID(w.accountID),
+    accountMode: w.accountMode,
     balanceDescription: w.balanceDescription,
     displayCurrency: currencyResultToCurrency(w.currencyLocal),
     isDefault: w.isDefault,
+    mobileOnlyEditable: w.accountModeEditable,
     name: w.name,
   })
 
@@ -265,9 +267,11 @@ export const unknownCurrency = makeCurrency()
 
 export const makeAccount: I.RecordFactory<Types._Account> = I.Record({
   accountID: Types.noAccountID,
+  accountMode: Types.accountModeNone,
   balanceDescription: '',
   displayCurrency: unknownCurrency,
   isDefault: false,
+  mobileOnlyEditable: false,
   name: '',
 })
 export const unknownAccount = makeAccount()

--- a/shared/wallets/wallet/settings/container.js
+++ b/shared/wallets/wallet/settings/container.js
@@ -12,6 +12,7 @@ const mapStateToProps = (state, {routeProps}) => {
   const accountID = routeProps.get('accountID')
   const account = Constants.getAccount(state, accountID)
   const name = account.name
+  const mobileOnlyEditable = account.mobileOnlyEditable
   const me = state.config.username || ''
   const user = account.isDefault ? me : ''
   const currencies = Constants.getDisplayCurrencies(state)
@@ -36,6 +37,7 @@ const mapStateToProps = (state, {routeProps}) => {
         ? ''
         : inflationDest.name || inflationDest.accountID,
     isDefault: account.isDefault,
+    mobileOnlyEditable,
     mobileOnlyMode,
     mobileOnlyWaiting,
     name,

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -27,6 +27,7 @@ export type SettingsProps = {|
   saveCurrencyWaiting: boolean,
   mobileOnlyMode: boolean,
   mobileOnlyWaiting: boolean,
+  mobileOnlyEditable: boolean,
 |}
 
 const HoverText = Styles.isMobile
@@ -130,7 +131,7 @@ class AccountSettings extends React.Component<SettingsProps> {
               <Kb.Box>
                 <Kb.Checkbox
                   checked={props.mobileOnlyMode}
-                  disabled={!Styles.isMobile || props.mobileOnlyWaiting}
+                  disabled={!props.mobileOnlyEditable || props.mobileOnlyWaiting}
                   label="Mobile only"
                   onCheck={props.onMobileOnlyModeChange}
                 />
@@ -147,10 +148,12 @@ class AccountSettings extends React.Component<SettingsProps> {
                   </Kb.Box2>
                 )}
               </Kb.Box>
-              {!Styles.isMobile && (
-                <Kb.Text type="BodySmall">This setting can only be changed from a mobile device.</Kb.Text>
+              {!props.mobileOnlyEditable && (
+                <Kb.Text type="BodySmall">
+                  This setting can only be changed from a mobile device over 7 days old.
+                </Kb.Text>
               )}
-              {Styles.isMobile && (
+              {props.mobileOnlyEditable && (
                 <Kb.Text type="BodySmall">
                   Prevents sending from this account, when on a desktop or laptop.
                 </Kb.Text>

--- a/shared/wallets/wallet/settings/index.stories.js
+++ b/shared/wallets/wallet/settings/index.stories.js
@@ -45,6 +45,7 @@ const sharedSettingsProps = {
   currencies: testCurrencies,
   currencyWaiting: false,
   inflationDestination: '',
+  mobileOnlyEditable: false,
   mobileOnlyMode: false,
   mobileOnlyWaiting: false,
   onBack: Sb.action('onBack'),
@@ -74,6 +75,11 @@ const secondarySettingsProps = {
   name: 'some other account',
 }
 
+const withMobileOnlyEditable = {
+  ...secondarySettingsProps,
+  mobileOnlyEditable: true,
+}
+
 const load = () => {
   Sb.storiesOf('Wallets/Wallet/Settings', module)
     .add('Default', () => <Settings {...defaultSettingsProps} />)
@@ -81,6 +87,7 @@ const load = () => {
       <Settings {...defaultSettingsProps} inflationDestination="Stellar Development Foundation" />
     ))
     .add('Secondary', () => <Settings {...secondarySettingsProps} />)
+    .add('MobileOnlyEditable', () => <Settings {...withMobileOnlyEditable} />)
   popups()
 }
 

--- a/shared/wallets/wallet/settings/index.stories.js
+++ b/shared/wallets/wallet/settings/index.stories.js
@@ -75,11 +75,6 @@ const secondarySettingsProps = {
   name: 'some other account',
 }
 
-const withMobileOnlyEditable = {
-  ...secondarySettingsProps,
-  mobileOnlyEditable: true,
-}
-
 const load = () => {
   Sb.storiesOf('Wallets/Wallet/Settings', module)
     .add('Default', () => <Settings {...defaultSettingsProps} />)
@@ -87,7 +82,7 @@ const load = () => {
       <Settings {...defaultSettingsProps} inflationDestination="Stellar Development Foundation" />
     ))
     .add('Secondary', () => <Settings {...secondarySettingsProps} />)
-    .add('MobileOnlyEditable', () => <Settings {...withMobileOnlyEditable} />)
+    .add('MobileOnlyEditable', () => <Settings {...secondarySettingsProps} mobileOnlyEditable={true} />)
   popups()
 }
 


### PR DESCRIPTION
* add AccountModeEditable to GetWalletAccountLocal and GetWalletAccountsLocal rpcs. 
* add a couple little tests for it. this was more of a pain than i expected because during tests, the type of device can't be plucked from global state the way it can in a normal run. i don't love what i did here for this; i'm looping through device keys looking for the one that matches the active device. seems to work ok, but it's a little different from how we do this elsewhere.
* pull AccountModeEditable into wallet settings UI as mobileOnlyEditable. start using it instead of `Styles.isMobile` to determine whether or not the toggle should be disabled. 