### PR TITLE
cleanup path standardization

### DIFF
--- a/osx/Helper/Info.plist
+++ b/osx/Helper/Info.plist
@@ -9,11 +9,11 @@
 	<key>CFBundleName</key>
 	<string>Helper</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.35</string>
+	<string>1.0.39</string>
 	<key>KBBuild</key>
 	<string>3</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.35</string>
+	<string>1.0.39</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = &quot;99229SGT5K&quot;) and (identifier &quot;keybase.Installer2&quot; or identifier &quot;keybase.Keybase&quot;)</string>

--- a/osx/Helper/KBHelper.m
+++ b/osx/Helper/KBHelper.m
@@ -176,6 +176,9 @@
   if (!p.absolutePath) {
     return NO;
   }
+  if ([KBFSUtils checkIfPathIsFishy:path]) {
+    return NO;
+  }
   NSArray *a = [p componentsSeparatedByString:@"/"];
   if (a.count != 3) {
     return NO;
@@ -373,6 +376,11 @@
   NSString *linkDir = @"/usr/local/bin";
   NSString *linkPath = [NSString stringWithFormat:@"%@/%@", linkDir, name];
 
+  if ([KBFSUtils checkIfPathIsFishy:path]) {
+    completion(KBMakeError(MPXPCErrorCodeInvalidRequest, @"Fishy path rejected"), nil);
+    return;
+  }
+
   // Check if link dir exists and resolves correctly
   if ([NSFileManager.defaultManager fileExistsAtPath:linkDir]) {
     NSString *resolved = [self resolveLinkPath:linkPath];
@@ -385,7 +393,6 @@
     NSString *neededPrefix = @"/Applications/Keybase.app";
 
     if ([KBFSUtils checkAbsolutePath:path hasAbsolutePrefix:neededPrefix]) {
-
       KBLog(@"Allowing creation of symlink %@ -> %@ since it's in %@", linkPath, path, neededPrefix);
 
       // Fix the link

--- a/osx/Helper/fs.h
+++ b/osx/Helper/fs.h
@@ -8,5 +8,6 @@
 +(BOOL)checkFile:(NSString *)linkPath isType:(NSFileAttributeType)fileType;
 +(void)checkKeybaseResource:(NSURL *)bin identifier:(NSString *)identifier error:(NSError **)error;
 +(BOOL)checkAbsolutePath:(NSString *)path hasAbsolutePrefix:(NSString *)prefix;
++(BOOL)checkIfPathIsFishy:(NSString *)path;
 
 @end

--- a/osx/Helper/fs.m
+++ b/osx/Helper/fs.m
@@ -64,6 +64,31 @@
     if (keybaseRequirement) CFRelease(keybaseRequirement);
 }
 
++(BOOL)checkIfPathIsFishy:(NSString *)path {
+    NSArray *v = [path componentsSeparatedByString:@"/"];
+    for (int i = 0; i < v.count; i++) {
+        if ([v[i] isEqualToString:@".."]) {
+            return YES;
+        }
+        if ([v[i] isEqualToString:@"."]) {
+            return YES;
+        }
+    }
+
+    // Only allow vanilla characters in our paths. A whitelist approach, as opposed to a
+    // blacklist.
+    NSError *error = NULL;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^[a-zA-Z0-9./_() -]+$" options:0 error:&error];
+    if (!regex) {
+        return YES;
+    }
+    NSTextCheckingResult *match = [regex firstMatchInString:path options:0 range:NSMakeRange(0, [path length])];
+    if (!match) {
+        return YES;
+    }
+    return NO;
+}
+
 /*
  * check that the path path has the prefix prefix, being wise to
  * whatever attacks people will throw at us, like /a/b/../../.., etc
@@ -75,8 +100,14 @@
     if (!path.absolutePath) {
         return NO;
     }
-    NSArray *a = [path.stringByStandardizingPath componentsSeparatedByString:@"/"];
-    NSArray *b = [prefix.stringByStandardizingPath componentsSeparatedByString:@"/"];
+    if ([self checkIfPathIsFishy:path]) {
+        return NO;
+    }
+    if ([self checkIfPathIsFishy:prefix]) {
+        return NO;
+    }
+    NSArray *a = [path   componentsSeparatedByString:@"/"];
+    NSArray *b = [prefix componentsSeparatedByString:@"/"];
     if (a.count < b.count) {
         return NO;
     }

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,19 +15,19 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.68</string>
+	<string>1.1.72</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.68</string>
+	<string>1.1.72</string>
 	<key>KBFuseBuild</key>
 	<string>3.8.2</string>
 	<key>KBFuseVersion</key>
 	<string>3.8.2</string>
 	<key>KBHelperBuild</key>
-	<string>1.0.35</string>
+	<string>1.0.39</string>
 	<key>KBHelperVersion</key>
-	<string>1.0.35</string>
+	<string>1.0.39</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/osx/KBKit/KBKit/Component/KBCommandLine.m
+++ b/osx/KBKit/KBKit/Component/KBCommandLine.m
@@ -29,13 +29,24 @@
     return;
   }
 
+  if ([KBFSUtils checkIfPathIsFishy:self.servicePath]) {
+    completion(KBMakeWarning(@"Rejecting fishy service path: %@", self.servicePath));
+    return;
+  }
+
   if (![self.config isInApplications:self.servicePath]) {
     completion(KBMakeWarning(@"Command line install is not supported from this location: %@", self.servicePath));
     return;
   }
 
+  if (![KBFSUtils checkAbsolutePath:self.servicePath hasAbsolutePrefix:@"/Applications/Keybase.app"]) {
+    completion(KBMakeWarning(@"Can only link to commands in the installed Keybase app bundle (%@ didn't suffice)", self.servicePath));
+    return;
+  }
+
   NSDictionary *params = @{@"directory": self.servicePath, @"name": self.config.serviceBinName, @"appName": self.config.appName};
   DDLogDebug(@"Helper: addToPath(%@)", params);
+
   [self.helperTool.helper sendRequest:@"addToPath" params:@[params] completion:^(NSError *error, id value) {
     DDLogDebug(@"Result: %@", value);
     if (error) {

--- a/osx/KBKit/KBKit/Component/KBComponent.h
+++ b/osx/KBKit/KBKit/Component/KBComponent.h
@@ -31,3 +31,8 @@ typedef void (^KBRefreshComponentCompletion)(KBComponentStatus *componentStatus)
 - (instancetype)initWithName:(NSString *)name info:(NSString *)info image:(NSImage *)image;
 
 @end
+
+@interface KBFSUtils : NSObject
++(BOOL)checkAbsolutePath:(NSString *)path hasAbsolutePrefix:(NSString *)prefix;
++(BOOL)checkIfPathIsFishy:(NSString *)path;
+@end

--- a/osx/KBKit/KBKit/Component/KBComponent.m
+++ b/osx/KBKit/KBKit/Component/KBComponent.m
@@ -34,3 +34,62 @@
 @end
 
 
+@implementation KBFSUtils
+
++(BOOL)checkIfPathIsFishy:(NSString *)path {
+    NSArray *v = [path componentsSeparatedByString:@"/"];
+    for (int i = 0; i < v.count; i++) {
+        if ([v[i] isEqualToString:@".."]) {
+            return YES;
+        }
+        if ([v[i] isEqualToString:@"."]) {
+            return YES;
+        }
+    }
+
+    // Only allow vanilla characters in our paths. A whitelist approach, as opposed to a
+    // blacklist.
+    NSError *error = NULL;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^[a-zA-Z0-9./_() -]+$" options:0 error:&error];
+    if (!regex) {
+        return YES;
+    }
+    NSTextCheckingResult *match = [regex firstMatchInString:path options:0 range:NSMakeRange(0, [path length])];
+    if (!match) {
+        return YES;
+    }
+    return NO;
+}
+
+/*
+ * check that the path path has the prefix prefix, being wise to
+ * whatever attacks people will throw at us, like /a/b/../../.., etc
+ */
++(BOOL)checkAbsolutePath:(NSString *)path hasAbsolutePrefix:(NSString *)prefix {
+    if (!prefix.absolutePath) {
+        return NO;
+    }
+    if (!path.absolutePath) {
+        return NO;
+    }
+    if ([self checkIfPathIsFishy:path]) {
+        return NO;
+    }
+    if ([self checkIfPathIsFishy:prefix]) {
+        return NO;
+    }
+    NSArray *a = [path   componentsSeparatedByString:@"/"];
+    NSArray *b = [prefix componentsSeparatedByString:@"/"];
+    if (a.count < b.count) {
+        return NO;
+    }
+
+    for (int i = 0; i < b.count; i++) {
+        if (![a[i] isEqualToString:b[i]]) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
+@end

--- a/osx/KBKit/KBKit/Component/KBHelperTool.m
+++ b/osx/KBKit/KBKit/Component/KBHelperTool.m
@@ -83,16 +83,20 @@
 
   NSString *alertText = @"Keybase is about to upgrade the Keybase file system, allowing end-to-end encrypted files from right inside your Finder.";
   NSString *infoText = @"";
-  if ([bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.31"]]) {
+
+  BOOL multiUser = [bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.31"]];
+  BOOL activeDirectory = [bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.35"]];
+
+  if (multiUser) {
     alertText = @"New Keybase feature: multiple users in macOS";
     // Use a division slash instead of a regular / to avoid weird line breaks.
     infoText = @"Previously, only one user of this computer could find their Keybase files at \u2215keybase. With this update, \u2215keybase will now support multiple users on the same computer by linking to user-specific Keybase directories in \u2215Volumes.\n\nYou may need to enter your password for this update.";
-  } else if ([bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.32"]] || [bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.33"]] || [bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.34"]]) {
-    alertText = @"Keybase helper update";
-    infoText = @"This Keybase release contains security updates to the helper tool.\n\nYou may need to enter your password for this update.";
-  } else if ([bundleVersion isOrderedSame:[KBSemVersion version:@"1.0.35"]]) {
+  } else if (activeDirectory) {
     alertText = @"Keybase helper update";
     infoText = @"This Keybase release fixes a regression in macOS installs that use Active Directory for user management.\n\nYou may need to enter your password for this update.";
+  } else {
+    alertText = @"Keybase helper update";
+    infoText = @"This Keybase release contains bugfixes and security updates to the Keybase installer helper tool.\n\nYou may need to enter your password for this update.";
   }
   NSAlert *alert = [[NSAlert alloc] init];
   [alert setMessageText:alertText];

--- a/osx/KBKit/KBKit/Component/KBInstaller.m
+++ b/osx/KBKit/KBKit/Component/KBInstaller.m
@@ -99,6 +99,9 @@
     DDLogError(@"No app bundle found (for login item check)");
     return;
   }
+
+  // Note that these two checks can be fooled by paths with '..' in them, but that doesn't
+  // seem problematic since the installer is run by an unprivileged user.
   if (loginItemEnabled && ![config isInApplications:appBundle.bundlePath] && ![config isInUserApplications:appBundle.bundlePath]) {
     DDLogError(@"Bundle path is invalid for adding login item: %@", appBundle.bundlePath);
     return;


### PR DESCRIPTION
- upgrade to new helper tool on next release
- rewrite the ~/$ check, and also check on both the installer and the helper for fishy paths
- cleanup upgrade paths
- upgrade installer version
- use a whitelist instead of a blacklist for fishy path characters
  - also allow '(' and ')' in whitelist, since we have that for our mount dirs
- vbump again to 1.0.39 and 1.1.72 (helper and installer)
- change the update text switch logic to be simpler