### PR TITLE
WIP: tweak details page to overcome recentPaymentsReceived race

### DIFF
--- a/shared/wallets/transaction-details/index.js
+++ b/shared/wallets/transaction-details/index.js
@@ -431,13 +431,10 @@ class LoadTransactionDetails extends React.Component<Props> {
   }
   componentDidUpdate(prevProps: Props) {
     // An erased transaction ID likely means the payment was updated,
-    // which means details need to be retrieved again
-    if (
-      (!this.props.transactionID || !this.props.senderAccountID) &&
-      prevProps.transactionID &&
-      prevProps.senderAccountID &&
-      !this.props.loading
-    ) {
+    // which means details need to be retrieved again.
+    // Also, recentPaymentsReceived can race with paymentDetailReceived
+    // so that loading finishes before transactionID is ever seen here.
+    if ((!this.props.transactionID || !this.props.senderAccountID) && !this.props.loading) {
       this.props.onLoadPaymentDetail()
     }
   }

--- a/shared/wallets/transaction-details/index.js
+++ b/shared/wallets/transaction-details/index.js
@@ -434,7 +434,11 @@ class LoadTransactionDetails extends React.Component<Props> {
     // which means details need to be retrieved again.
     // Also, recentPaymentsReceived can race with paymentDetailReceived
     // so that loading finishes before transactionID is ever seen here.
-    if ((!this.props.transactionID || !this.props.senderAccountID) && !this.props.loading) {
+    // which means details need to be retrieved again
+    if (
+      (!this.props.transactionID && prevProps.transactionID) ||
+      (!this.props.senderAccountID && prevProps.senderAccountID && !this.props.loading)
+    ) {
       this.props.onLoadPaymentDetail()
     }
   }


### PR DESCRIPTION
This is the case again when you send a payment and then click it for details right away. This change makes a bit more sense logically but it really looks like even if the details are requested a second time, they don't come from the service (specifically, a public message). Still looking into that.