### PR TITLE
Fix crash in status.go, change GetAllProvisionedUsernames not to bail

### DIFF
--- a/go/libkb/all_provisioned_usernames.go
+++ b/go/libkb/all_provisioned_usernames.go
@@ -49,14 +49,15 @@ func GetAllProvisionedUsernames(m MetaContext) (current NormalizedUsername, all 
 	if currentUC != nil {
 		current, err = getUsernameIfProvisioned(m, *currentUC)
 		if err != nil {
-			return current, nil, err
+			m.CErrorf("Error while checking user %q uid=%q, `current` will be nil", currentUC.GetUsername(), currentUC.GetUID())
 		}
 	}
 
 	for _, u := range allUCs {
 		tmp, err := getUsernameIfProvisioned(m, u)
 		if err != nil {
-			return current, nil, err
+			m.CErrorf("Error while checking user %q uid=%q, skipping", currentUC.GetUsername(), currentUC.GetUID())
+			continue
 		}
 		if !tmp.IsNil() {
 			all = append(all, tmp)

--- a/go/libkb/status.go
+++ b/go/libkb/status.go
@@ -4,6 +4,7 @@
 package libkb
 
 import (
+	"errors"
 	"runtime"
 	"strings"
 
@@ -60,7 +61,11 @@ func GetExtendedStatus(m MetaContext) (res keybase1.ExtendedStatus, err error) {
 	}
 
 	if err = g.GetFullSelfer().WithSelf(m.Ctx(), func(me *User) error {
-		device, err := me.GetComputedKeyFamily().GetCurrentDevice(g)
+		ckf := me.GetComputedKeyFamily()
+		if ckf == nil {
+			return errors.New("Couldn't load key family")
+		}
+		device, err := ckf.GetCurrentDevice(g)
 		if err != nil {
 			m.CDebugf("| GetCurrentDevice failed: %s", err)
 			res.DeviceErr = &keybase1.LoadDeviceErr{Where: "ckf.GetCurrentDevice", Desc: err.Error()}


### PR DESCRIPTION
After initial investigation - there is a user who is in bad state because they have bad cache of sigchain, of currently logged in user.

Note that I haven't been able to repro how the got into this state, but I intentionally corrupted my local cache and examined app behaviour.

Their app crashes after GUI starts because GUI calls GetExtendedStatus which has a nil dereference if when UPAK is bad. This PR fixes said crash, and GetExtendedStatus errors out normally.

Another change is `GetAllProvisionedUsernames`, which does not bail out on bad users. Without this change, GUI will start with an error and user can't do anything, not even log in as another user. This could be especially annoying on mobile, because on desktop at least they can try to `db nuke` from terminal. 

Another thing to note is that in my local testing, after nuking (`keybase db nuke -f`) and getting rid of my intentionally poisoned cache, i was able to open app normally, didn't even have to re-provision.

I'm not convinced that this is the way to go, though. User still can't login as their user, and there is no "db nuke" button or anything telling them what to do, besides an advice to send feedback. But at least they have a functional screen when they open the app, instead of an error.

Here is what we can do - when pulling out links from storage, clear the cache on error. I don't think we are ever caching bad links, so if we pull out one that's bad, it means we have a bad cache.