### PR TITLE
root_metadata: remove the users of the current merkle root

### DIFF
--- a/go/kbfs/kbfsmd/root_metadata.go
+++ b/go/kbfs/kbfsmd/root_metadata.go
@@ -124,9 +124,6 @@ type RootMetadata interface {
 	MDDiskUsage() uint64
 	// RevisionNumber returns the revision number associated with this metadata structure.
 	RevisionNumber() Revision
-	// MerkleRoot returns the root of the global Keybase Merkle tree
-	// at the time the MD was written.
-	MerkleRoot() keybase1.MerkleRootV2
 	// BID returns the per-device branch ID associated with this metadata revision.
 	BID() BranchID
 	// GetPrevRoot returns the hash of the previous metadata revision.
@@ -216,9 +213,6 @@ type MutableRootMetadata interface {
 	SetWriterMetadataCopiedBit()
 	// SetRevision sets the revision number of the underlying metadata.
 	SetRevision(revision Revision)
-	// SetMerkleRoot sets the root of the global Keybase Merkle tree
-	// at the time the MD was written.
-	SetMerkleRoot(root keybase1.MerkleRootV2)
 	// SetUnresolvedReaders sets the list of unresolved readers associated with this folder.
 	SetUnresolvedReaders(readers []keybase1.SocialAssertion)
 	// SetUnresolvedWriters sets the list of unresolved writers associated with this folder.

--- a/go/kbfs/kbfsmd/root_metadata_v2.go
+++ b/go/kbfs/kbfsmd/root_metadata_v2.go
@@ -971,13 +971,6 @@ func (md *RootMetadataV2) RevisionNumber() Revision {
 	return md.Revision
 }
 
-// MerkleRoot implements the RootMetadata interface for
-// RootMetadataV2.
-func (md *RootMetadataV2) MerkleRoot() keybase1.MerkleRootV2 {
-	// No v2 MDs will have had this field set.
-	return keybase1.MerkleRootV2{}
-}
-
 // BID implements the RootMetadata interface for RootMetadataV2.
 func (md *RootMetadataV2) BID() BranchID {
 	return md.WriterMetadataV2.BID
@@ -1079,12 +1072,6 @@ func (md *RootMetadataV2) SetWriterMetadataCopiedBit() {
 // SetRevision implements the MutableRootMetadata interface for RootMetadataV2.
 func (md *RootMetadataV2) SetRevision(revision Revision) {
 	md.Revision = revision
-}
-
-// SetMerkleRoot implements the MutableRootMetadata interface for
-// RootMetadataV2.
-func (md *RootMetadataV2) SetMerkleRoot(root keybase1.MerkleRootV2) {
-	// V2 doesn't support merkle seqnos, just ignore.
 }
 
 // SetUnresolvedReaders implements the MutableRootMetadata interface for RootMetadataV2.

--- a/go/kbfs/kbfsmd/root_metadata_v3.go
+++ b/go/kbfs/kbfsmd/root_metadata_v3.go
@@ -87,6 +87,9 @@ type RootMetadataV3 struct {
 	// of writing to the given folder.
 	FinalizedInfo *tlf.HandleExtension `codec:"fi,omitempty"`
 
+	// KBMerkleRoot is now DEPRECATED, and shouldn't be relied on for
+	// future features.  Below is the original text for historians:
+	//
 	// The root of the global Keybase Merkle tree at the time this
 	// update was created (from the writer's perspective).  This field
 	// was added to V3 after it was live for a while, and older
@@ -1117,12 +1120,6 @@ func (md *RootMetadataV3) RevisionNumber() Revision {
 	return md.Revision
 }
 
-// MerkleRoot implements the RootMetadata interface for
-// RootMetadataV3.
-func (md *RootMetadataV3) MerkleRoot() keybase1.MerkleRootV2 {
-	return *md.KBMerkleRoot
-}
-
 // BID implements the RootMetadata interface for RootMetadataV3.
 func (md *RootMetadataV3) BID() BranchID {
 	return md.WriterMetadata.BID
@@ -1218,12 +1215,6 @@ func (md *RootMetadataV3) SetWriterMetadataCopiedBit() {
 // SetRevision implements the MutableRootMetadata interface for RootMetadataV3.
 func (md *RootMetadataV3) SetRevision(revision Revision) {
 	md.Revision = revision
-}
-
-// SetMerkleRoot implements the MutableRootMetadata interface for
-// RootMetadataV3.
-func (md *RootMetadataV3) SetMerkleRoot(root keybase1.MerkleRootV2) {
-	md.KBMerkleRoot = &root
 }
 
 func (md *RootMetadataV3) updateKeyBundles(codec kbfscodec.Codec,

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -364,7 +364,6 @@ type folderBranchOps struct {
 	branchChanges      kbfssync.RepeatedWaitGroup
 	mdFlushes          kbfssync.RepeatedWaitGroup
 	forcedFastForwards kbfssync.RepeatedWaitGroup
-	merkleFetches      kbfssync.RepeatedWaitGroup
 	editActivity       kbfssync.RepeatedWaitGroup
 	partialSyncs       kbfssync.RepeatedWaitGroup
 	launchEditMonitor  sync.Once
@@ -522,7 +521,6 @@ func (fbo *folderBranchOps) Shutdown(ctx context.Context) error {
 	}
 
 	close(fbo.shutdownChan)
-	fbo.merkleFetches.Wait(ctx)
 	fbo.cr.Shutdown()
 	fbo.fbm.shutdown()
 	fbo.rekeyFSM.Shutdown()
@@ -3883,17 +3881,6 @@ func (fbo *folderBranchOps) canonicalPath(ctx context.Context, dir Node, name st
 func (fbo *folderBranchOps) signalWrite() {
 	select {
 	case fbo.syncNeededChan <- struct{}{}:
-		// Kick off a merkle root fetch in the background, so that it's
-		// ready by the time we do the SyncAll.
-		fbo.merkleFetches.Add(1)
-		go func() {
-			defer fbo.merkleFetches.Done()
-			newCtx := fbo.ctxWithFBOID(context.Background())
-			_, _, err := fbo.config.KBPKI().GetCurrentMerkleRoot(newCtx)
-			if err != nil {
-				fbo.log.CDebugf(newCtx, "Couldn't fetch merkle root: %+v", err)
-			}
-		}()
 	default:
 	}
 	// A local write always means any ongoing CR should be canceled,

--- a/go/kbfs/libkbfs/root_metadata.go
+++ b/go/kbfs/libkbfs/root_metadata.go
@@ -286,13 +286,6 @@ func (md *RootMetadata) MakeSuccessor(
 		return nil, errors.New("MD with invalid revision")
 	}
 	newMd.SetRevision(md.Revision() + 1)
-
-	merkleRoot, _, err := merkleGetter.GetCurrentMerkleRoot(ctx)
-	if err != nil {
-		return nil, err
-	}
-	newMd.SetMerkleRoot(merkleRoot)
-
 	return newMd, nil
 }
 
@@ -677,12 +670,6 @@ func (md *RootMetadata) Revision() kbfsmd.Revision {
 	return md.bareMd.RevisionNumber()
 }
 
-// MerkleRoot wraps the respective method of the underlying
-// BareRootMetadata for convenience.
-func (md *RootMetadata) MerkleRoot() keybase1.MerkleRootV2 {
-	return md.bareMd.MerkleRoot()
-}
-
 // MergedStatus wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) MergedStatus() kbfsmd.MergeStatus {
 	return md.bareMd.MergedStatus()
@@ -765,12 +752,6 @@ func (md *RootMetadata) SetWriterMetadataCopiedBit() {
 // SetRevision wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) SetRevision(revision kbfsmd.Revision) {
 	md.bareMd.SetRevision(revision)
-}
-
-// SetMerkleRoot wraps the respective method of the underlying
-// BareRootMetadata for convenience.
-func (md *RootMetadata) SetMerkleRoot(root keybase1.MerkleRootV2) {
-	md.bareMd.SetMerkleRoot(root)
 }
 
 // SetWriters wraps the respective method of the underlying BareRootMetadata for convenience.


### PR DESCRIPTION
It can block offline writes and is not used for anything, and not likely to be useful in the future, since we decided on other, more robust methods for verifying MDs written by revoked devices.

Issue: KBFS-3785