### PR TITLE
block_retrieval_worker: don't act on stop-if-full reqs when full

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_worker_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_worker_test.go
@@ -418,7 +418,7 @@ func TestBlockRetrievalWorkerStopIfFull(t *testing.T) {
 	case err := <-req:
 		require.IsType(t, DiskCacheTooFullForBlockError{}, err)
 	case <-ctx.Done():
-		require.NoError(t, ctx.Err())
+		require.FailNow(t, ctx.Err().Error())
 	}
 
 	t.Log("Request without stop-if-full, when full")
@@ -433,6 +433,6 @@ func TestBlockRetrievalWorkerStopIfFull(t *testing.T) {
 	case err := <-req:
 		require.NoError(t, err)
 	case <-ctx.Done():
-		require.NoError(t, ctx.Err())
+		require.FailNow(t, ctx.Err().Error())
 	}
 }

--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -1033,7 +1033,13 @@ func (bra BlockRequestAction) String() string {
 // Combine returns a new action by taking `other` into account.
 func (bra BlockRequestAction) Combine(
 	other BlockRequestAction) BlockRequestAction {
-	return bra | other
+	combined := bra | other
+	// If the actions don't agree on stop-if-full, we should remove it
+	// from the combined result.
+	if bra.StopIfFull() != other.StopIfFull() {
+		combined = combined &^ blockRequestStopIfFull
+	}
+	return combined
 }
 
 func (bra BlockRequestAction) prefetch() bool {

--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -1272,3 +1272,17 @@ func (e NextMDNotCachedError) Error() string {
 	return fmt.Sprintf("The MD following %d for folder %s is not cached",
 		e.RootSeqno, e.TlfID)
 }
+
+// DiskCacheTooFullForBlockError indicates that the disk cache is too
+// full to fetch a block requested with the `StopIfFull` action type.
+type DiskCacheTooFullForBlockError struct {
+	Ptr    BlockPointer
+	Action BlockRequestAction
+}
+
+// Error implements the Error interface for DiskCacheTooFullForBlockError.
+func (e DiskCacheTooFullForBlockError) Error() string {
+	return fmt.Sprintf(
+		"Disk cache too full for block %s requested with action %s",
+		e.Ptr, e.Action)
+}


### PR DESCRIPTION
I noticed that prefetching recent files keeps fetching blocks long after the disk cache is full.  It seemed to be a vicious cycle of:

* The prefetcher queues some blocks requests before the cache is full.
* The cache gets full.
* A worker picks up the queued requests and fetches the blocks.
* The blocks get put in the working-set cache, which causes enough eviction to get the cache down below 99% full.
* The prefetcher requests more blocks, since the cache is no longer full.
* Ad infinitum.

So this PR simply rejects stop-if-full requests in the worker itself, if the cache is already full.

Issue: KBFS-3803