### PR TITLE
Fix spinner on saving team settings

### DIFF
--- a/shared/teams/team/settings-tab/container.js
+++ b/shared/teams/team/settings-tab/container.js
@@ -28,7 +28,12 @@ const mapStateToProps = (state, {teamname}: OwnProps) => {
     publicityMember,
     publicityTeam,
     teamname,
-    waitingForSavePublicity: anyWaiting(state, `setPublicity:${teamname}`, `getDetails:${teamname}`),
+    waitingForSavePublicity: anyWaiting(
+      state,
+      `team:${teamname}`,
+      `teamRetention:${teamname}`,
+      `teamSettings:${teamname}`
+    ),
     yourOperations: Constants.getCanPerform(state, teamname),
   }
 }


### PR DESCRIPTION
@keybase/react-hackers 

Looks like we refactored the waiting keys but not this use of them, so the Save button was never spinning.