### PR TITLE
libfs: pretend non-existent TLF is empty on iteam write error

### DIFF
--- a/go/kbfs/libfs/tlf.go
+++ b/go/kbfs/libfs/tlf.go
@@ -58,6 +58,13 @@ func FilterTLFEarlyExitError(ctx context.Context, err error, log logger.Logger, 
 			name)
 		return true, nil
 
+	case libkbfs.NonExistentTeamForHandleError:
+		// Same as above; cannot fallthrough in type switch
+		log.CDebugf(ctx,
+			"No permission to write to %s, so pretending it's empty",
+			name)
+		return true, nil
+
 	default:
 		if strings.Contains(err.Error(), "need writer access") {
 			// The service returns an untyped error when we try to

--- a/go/kbfs/libfs/tlf.go
+++ b/go/kbfs/libfs/tlf.go
@@ -38,7 +38,8 @@ func FilterTLFEarlyExitError(ctx context.Context, err error, log logger.Logger, 
 			name)
 		return true, nil
 
-	case libkbfs.WriteAccessError:
+	case libkbfs.WriteAccessError, kbfsmd.ServerErrorWriteAccess,
+		libkbfs.NonExistentTeamForHandleError:
 		// No permission to create TLF, so pretend it's still
 		// empty.
 		//
@@ -46,20 +47,6 @@ func FilterTLFEarlyExitError(ctx context.Context, err error, log logger.Logger, 
 		// is created, but in practice, the Linux kernel
 		// doesn't cache readdir results, and probably not
 		// OSXFUSE either.
-		log.CDebugf(ctx,
-			"No permission to write to %s, so pretending it's empty",
-			name)
-		return true, nil
-
-	case kbfsmd.ServerErrorWriteAccess:
-		// Same as above; cannot fallthrough in type switch
-		log.CDebugf(ctx,
-			"No permission to write to %s, so pretending it's empty",
-			name)
-		return true, nil
-
-	case libkbfs.NonExistentTeamForHandleError:
-		// Same as above; cannot fallthrough in type switch
 		log.CDebugf(ctx,
 			"No permission to write to %s, so pretending it's empty",
 			name)

--- a/go/kbfs/libfs/tlf.go
+++ b/go/kbfs/libfs/tlf.go
@@ -5,10 +5,13 @@
 package libfs
 
 import (
+	"strings"
+
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/logger"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -24,7 +27,7 @@ func (TlfDoesNotExist) Error() string { return "TLF does not exist" }
 // folder (exitEarly == true), or not.
 func FilterTLFEarlyExitError(ctx context.Context, err error, log logger.Logger, name tlf.CanonicalName) (
 	exitEarly bool, retErr error) {
-	switch err := err.(type) {
+	switch err := errors.Cause(err).(type) {
 	case nil:
 		// No error.
 		return false, nil
@@ -56,6 +59,16 @@ func FilterTLFEarlyExitError(ctx context.Context, err error, log logger.Logger, 
 		return true, nil
 
 	default:
+		if strings.Contains(err.Error(), "need writer access") {
+			// The service returns an untyped error when we try to
+			// write a TLF ID into an implicit team sigchain without
+			// writer permissions.
+			log.CDebugf(ctx,
+				"No permission to write to %s, so pretending it's empty",
+				name)
+			return true, nil
+		}
+
 		// Some other error.
 		return false, err
 	}

--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -1286,3 +1286,16 @@ func (e DiskCacheTooFullForBlockError) Error() string {
 		"Disk cache too full for block %s requested with action %s",
 		e.Ptr, e.Action)
 }
+
+// NonExistentTeamForHandleError indicates that we're trying to create
+// a TLF for a handle that has no corresponding implicit team yet.
+// Likely a writer needs to create the implicit team first.
+type NonExistentTeamForHandleError struct {
+	h *TlfHandle
+}
+
+// Error implements the Error interface for NonExistentTeamForHandleError.
+func (e NonExistentTeamForHandleError) Error() string {
+	return fmt.Sprintf("Can't create TLF ID for non-team-backed handle %s",
+		e.h.GetCanonicalPath())
+}

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -442,7 +442,7 @@ func (fs *KBFSOpsStandard) getOpsByHandle(ctx context.Context,
 
 func (fs *KBFSOpsStandard) resetTlfID(ctx context.Context, h *TlfHandle) error {
 	if !h.IsBackedByTeam() {
-		return errors.New("Can't create TLF ID for non-team-backed handle")
+		return errors.WithStack(NonExistentTeamForHandleError{h})
 	}
 
 	teamID, err := h.FirstResolvedWriter().AsTeam()

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -6,7 +6,6 @@ package simplefs
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,6 +25,7 @@ import (
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	billy "gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/osfs"
@@ -657,7 +657,7 @@ func (k *SimpleFS) SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListAr
 				res, err = k.favoriteList(ctx, arg.Path, tlf.SingleTeam)
 			default:
 				fs, finalElem, err := k.getFSIfExists(ctx, arg.Path)
-				switch err.(type) {
+				switch errors.Cause(err).(type) {
 				case nil:
 				case libfs.TlfDoesNotExist:
 					// TLF doesn't exist yet; just return an empty result.
@@ -735,7 +735,7 @@ func (k *SimpleFS) listRecursiveToDepth(opID keybase1.OpID,
 		var paths []pathStackElem
 
 		fs, finalElem, err := k.getFSIfExists(ctx, path)
-		switch err.(type) {
+		switch errors.Cause(err).(type) {
 		case nil:
 		case libfs.TlfDoesNotExist:
 			// TLF doesn't exist yet; just return an empty result.
@@ -1480,9 +1480,22 @@ func (k *SimpleFS) SimpleFSStat(ctx context.Context, arg keybase1.SimpleFSStatAr
 	defer func() { k.doneSyncOp(ctx, err) }()
 
 	fs, finalElem, err := k.getFSIfExists(ctx, arg.Path)
-	if err != nil {
+	switch errors.Cause(err).(type) {
+	case nil:
+	case libfs.TlfDoesNotExist:
+		if finalElem != "" && finalElem != "." {
+			return keybase1.Dirent{}, err
+		}
+
+		// TLF doesn't exist yet; just return an empty result.
+		return keybase1.Dirent{
+			DirentType: keybase1.DirentType_DIR,
+			Writable:   false,
+		}, nil
+	default:
 		return keybase1.Dirent{}, err
 	}
+
 	// Use LStat so we don't follow symlinks.
 	fi, err := fs.Lstat(finalElem)
 	if err != nil {


### PR DESCRIPTION
After the switch to implicit teams, a reader of a folder gets a new kind of error when trying to initialize a TLF that it doesn't have write access for.  Pretend it is empty in that case instead.