### PR TITLE
Round of fixes for GUI PGP generation

### DIFF
--- a/go/engine/pgp_keygen.go
+++ b/go/engine/pgp_keygen.go
@@ -105,11 +105,6 @@ func (e *PGPKeyGen) Run(m libkb.MetaContext) error {
 func (e *PGPKeyGen) push(m libkb.MetaContext, bundle *libkb.PGPKeyBundle, pushPrivate bool) (err error) {
 	defer m.CTrace("PGPKeyGen.push", func() error { return err })()
 
-	tsec, gen, err := libkb.GetTriplesecMaybePrompt(m)
-	if err != nil {
-		return err
-	}
-
 	me, err := libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(m).WithPublicKeyOptional())
 	if err != nil {
 		return err
@@ -127,6 +122,11 @@ func (e *PGPKeyGen) push(m libkb.MetaContext, bundle *libkb.PGPKeyBundle, pushPr
 	del.NewKey = bundle
 
 	if pushPrivate {
+		tsec, gen, err := libkb.GetTriplesecMaybePrompt(m)
+		if err != nil {
+			return err
+		}
+
 		skb, err := bundle.ToServerSKB(m.G(), tsec, gen)
 		if err != nil {
 			return err

--- a/shared/profile/pgp/finished.desktop.js
+++ b/shared/profile/pgp/finished.desktop.js
@@ -43,7 +43,9 @@ class Finished extends React.Component<Props, State> {
             label="Store encrypted private key on Keybase's server"
           />
           <Kb.Text style={styleUploadTextSublabel} type="BodySmall">
-            {'Allows you to download & import your key to other devices.'}
+            {
+              'Allows you to download & import your key to other devices. You might need to enter your Keybase passphrase.'
+            }
           </Kb.Text>
         </Kb.Box>
         <Kb.Button

--- a/shared/profile/revoke/index.shared.js
+++ b/shared/profile/revoke/index.shared.js
@@ -26,6 +26,9 @@ function formatMessage(platform: PlatformsExpandedType) {
     case 'hackernews':
       body = 'Hacker News identity'
       break
+    case 'pgp':
+      body = 'PGP key'
+      break
     default:
       body = `${capitalize(platform)} identity`
   }


### PR DESCRIPTION
- Only invoke tsec passphrase prompt from `PGPKeyGen` engine when user asks to push private key, not always.
- Change screens:
   - `Are you sure you want to drop your Pgp identity?` -> `Are you sure you want to drop your PGP key?`
   - Mention passphrase entry in `Store encrypted private key on Keybase's server` label.