### PR TITLE
 attach local metadata to incremental sync convs

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -269,13 +269,13 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 		return chat1.ThreadView{}, err
 	}
 
-	thread, err := s.boxer.UnboxThread(ctx, boxed.Thread, conv)
+	thread, err := s.boxer.UnboxThread(ctx, boxed.Thread, conv.Conv)
 	if err != nil {
 		return chat1.ThreadView{}, err
 	}
 
 	// Post process thread before returning
-	if err = s.postProcessThread(ctx, uid, conv, &thread, query, nil, true, false); err != nil {
+	if err = s.postProcessThread(ctx, uid, conv.Conv, &thread, query, nil, true, false); err != nil {
 		return chat1.ThreadView{}, err
 	}
 
@@ -591,7 +591,7 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 		return decmsg, continuousUpdate, err
 	}
 
-	decmsg, err = s.boxer.UnboxMessage(ctx, msg, conv, nil)
+	decmsg, err = s.boxer.UnboxMessage(ctx, msg, conv.Conv, nil)
 	if err != nil {
 		return decmsg, continuousUpdate, err
 	}
@@ -745,9 +745,10 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	defer s.lockTab.Release(ctx, uid, convID)
 
 	// Get conversation metadata
-	conv, err := GetUnverifiedConv(ctx, s.G(), uid, convID, types.InboxSourceDataSourceAll)
+	rc, err := GetUnverifiedConv(ctx, s.G(), uid, convID, types.InboxSourceDataSourceAll)
 	var unboxConv types.UnboxConversationInfo
 	if err == nil {
+		conv := rc.Conv
 		unboxConv = conv
 		// Try locally first
 		var holesFilled int
@@ -1150,7 +1151,7 @@ func (s *HybridConversationSource) notifyUnfurls(ctx context.Context, uid gregor
 		s.Debug(ctx, "notifyUnfurls: failed to get conv: %s", err)
 		return
 	}
-	unfurledMsgs, err := s.TransformSupersedes(ctx, conv, uid, msgs)
+	unfurledMsgs, err := s.TransformSupersedes(ctx, conv.Conv, uid, msgs)
 	if err != nil {
 		s.Debug(ctx, "notifyUnfurls: failed to transform supersedes: %s", err)
 		return

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -816,7 +816,7 @@ func (s *HybridInboxSource) TeamTypeChanged(ctx context.Context, uid gregor1.UID
 		return nil, err
 	}
 	ib := s.createInbox()
-	if cerr := ib.TeamTypeChanged(ctx, uid, vers, convID, teamType, remoteConv.Notifications); cerr != nil {
+	if cerr := ib.TeamTypeChanged(ctx, uid, vers, convID, teamType, remoteConv.Conv.Notifications); cerr != nil {
 		err = s.handleInboxError(ctx, cerr, uid)
 		return nil, err
 	}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2317,11 +2317,11 @@ func (h *Server) ResolveUnfurlPrompt(ctx context.Context, arg chat1.ResolveUnfur
 		if err != nil {
 			return err
 		}
-		msgs, err := h.G().ConvSource.GetMessages(ctx, conv, uid, []chat1.MessageID{arg.MsgID}, nil)
+		msgs, err := h.G().ConvSource.GetMessages(ctx, conv.Conv, uid, []chat1.MessageID{arg.MsgID}, nil)
 		if err != nil {
 			return err
 		}
-		msgs, err = h.G().ConvSource.TransformSupersedes(ctx, conv, uid, msgs)
+		msgs, err = h.G().ConvSource.TransformSupersedes(ctx, conv.Conv, uid, msgs)
 		if err != nil {
 			return err
 		}

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -296,11 +296,23 @@ func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid gregor1.UID,
 			chat1.NewChatSyncResultWithCurrent())
 		return
 	}
+	// gather local metadata
+	mds := make(map[string]*types.RemoteConversationMetadata)
+	ibox, err := s.G().InboxSource.ReadUnverified(ctx, uid, types.InboxSourceDataSourceLocalOnly,
+		&chat1.GetInboxQuery{
+			ConvIDs: utils.PluckConvIDs(allConvs),
+		}, nil)
+	if err == nil {
+		for _, c := range ibox.ConvsUnverified {
+			mds[c.GetConvID().String()] = c.LocalMetadata
+		}
+	}
 	m := make(map[chat1.TopicType][]chat1.ChatSyncIncrementalConv)
 	for _, c := range allConvs {
 		m[c.GetTopicType()] = append(m[c.GetTopicType()], chat1.ChatSyncIncrementalConv{
 			Conv: utils.PresentRemoteConversation(ctx, s.G(), types.RemoteConversation{
-				Conv: c,
+				Conv:          c,
+				LocalMetadata: mds[c.GetConvID().String()],
 			}),
 			ShouldUnbox: shouldUnboxMap[c.GetConvID().String()],
 		})

--- a/go/chat/upgrade_test.go
+++ b/go/chat/upgrade_test.go
@@ -53,7 +53,7 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 
 	boxer := NewBoxer(tc.Context())
 	sender := NewBlockingSender(tc.Context(), boxer, func() chat1.RemoteInterface { return ri })
-	prepareRes, err := sender.Prepare(ctx, kbfsPlain, chat1.ConversationMembersType_KBFS, &conv)
+	prepareRes, err := sender.Prepare(ctx, kbfsPlain, chat1.ConversationMembersType_KBFS, &conv.Conv)
 	require.NoError(t, err)
 	kbfsBoxed := prepareRes.Boxed
 	kbfsBoxed.ServerHeader = &chat1.MessageServerHeader{
@@ -64,7 +64,7 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 	require.NoError(t, teams.UpgradeTLFIDToImpteam(ctx, tc.G, u.Username, tlfID, false,
 		keybase1.TeamApplication_CHAT, cres.CryptKeys))
 
-	conv.Metadata.MembersType = chat1.ConversationMembersType_IMPTEAMUPGRADE
+	conv.Conv.Metadata.MembersType = chat1.ConversationMembersType_IMPTEAMUPGRADE
 	ctx = CtxAddTestingNameInfoSource(ctx, nil)
 	header = chat1.MessageClientHeader{
 		TlfPublic:   false,
@@ -73,7 +73,7 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 	}
 	teamPlain := textMsgWithHeader(t, "team", header)
 	prepareRes, err = sender.Prepare(ctx, teamPlain,
-		chat1.ConversationMembersType_IMPTEAMUPGRADE, &conv)
+		chat1.ConversationMembersType_IMPTEAMUPGRADE, &conv.Conv)
 	require.NoError(t, err)
 	teamBoxed := prepareRes.Boxed
 	teamBoxed.ServerHeader = &chat1.MessageServerHeader{
@@ -82,7 +82,7 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 	}
 
 	checkUnbox := func() {
-		unboxed, err := boxer.UnboxMessages(ctx, []chat1.MessageBoxed{teamBoxed, kbfsBoxed}, conv)
+		unboxed, err := boxer.UnboxMessages(ctx, []chat1.MessageBoxed{teamBoxed, kbfsBoxed}, conv.Conv)
 		require.NoError(t, err)
 		require.Len(t, unboxed, 2)
 		for _, u := range unboxed {


### PR DESCRIPTION
The "local metadata" in the inbox contains the last known value of things derived from "unboxing" the inbox items. If we don't pass up this value during sync, then the frontend will clear out the relevant data while waiting for the unboxed version to make it up.