### PR TITLE
libgit: treat `OfflineUnsyncedError` as timeout when repo-cleaning

### DIFF
--- a/go/kbfs/libgit/repo.go
+++ b/go/kbfs/libgit/repo.go
@@ -201,10 +201,15 @@ func CleanOldDeletedReposTimeLimited(
 	ctx, cancel := context.WithTimeout(ctx, cleaningTimeLimit)
 	defer cancel()
 	err := CleanOldDeletedRepos(ctx, config, tlfHandle)
-	if errors.Cause(err) == context.DeadlineExceeded {
+	switch errors.Cause(err) {
+	case context.DeadlineExceeded, context.Canceled:
 		return nil
+	default:
+		if _, ok := err.(libkbfs.OfflineUnsyncedError); ok {
+			return nil
+		}
+		return err
 	}
-	return err
 }
 
 // UpdateRepoMD lets the Keybase service know that a repo's MD has


### PR DESCRIPTION
`folderBranchOps` now turns a `DeadlineExceeded` error into this kind of error for unsynced TLFs.  When cleaning repos during a git operation, we're just trying to remove as many old files as we can within the deadline window, so we want to ignore those kinds of errors in that case.

Issue: KBFS-3864