### PR TITLE
Make some chat shortcuts work even without input focus

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -63,21 +63,31 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
     return this._lastText || ''
   }
 
-  _onKeyDown = (e: SyntheticKeyboardEvent<>, isComposingIME: boolean) => {
+  _commonOnKeyDown = (e: SyntheticKeyboardEvent<> | KeyboardEvent) => {
     const text = this._getText()
     if (e.key === 'ArrowUp' && !this.props.isEditing && !text) {
       e.preventDefault()
       this.props.onEditLastMessage()
+      return true
     } else if (e.key === 'Escape' && this.props.isEditing) {
       this.props.onCancelEditing()
+      return true
     } else if (e.key === 'u' && (e.ctrlKey || e.metaKey)) {
       this._filePickerOpen()
+      return true
     } else if (e.key === 'PageDown') {
       this.props.onRequestScrollDown()
+      return true
     } else if (e.key === 'PageUp') {
       this.props.onRequestScrollUp()
+      return true
     }
 
+    return false
+  }
+
+  _onKeyDown = (e: SyntheticKeyboardEvent<>, isComposingIME: boolean) => {
+    this._commonOnKeyDown(e)
     this.props.onKeyDown && this.props.onKeyDown(e, isComposingIME)
   }
 
@@ -93,8 +103,11 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
       return
     }
 
+    if (this._commonOnKeyDown(ev)) {
+      return
+    }
+
     const isPasteKey = ev.key === 'v' && (ev.ctrlKey || ev.metaKey)
-    const isUploadKey = ev.key === 'u' && (ev.ctrlKey || ev.metaKey)
     const isValidSpecialKey = [
       'Backspace',
       'Delete',
@@ -104,9 +117,7 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
       'ArrowDown',
       'Enter',
     ].includes(ev.key)
-    if (isUploadKey) {
-      this._filePickerOpen()
-    } else if (ev.type === 'keypress' || isPasteKey || isValidSpecialKey) {
+    if (ev.type === 'keypress' || isPasteKey || isValidSpecialKey) {
       this._inputFocus()
     } else if (ev.key === 'PageDown') {
       this.props.onRequestScrollDown()

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -122,10 +122,6 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
     ].includes(ev.key)
     if (ev.type === 'keypress' || isPasteKey || isValidSpecialKey) {
       this._inputFocus()
-    } else if (ev.key === 'PageDown') {
-      this.props.onRequestScrollDown()
-    } else if (ev.key === 'PageUp') {
-      this.props.onRequestScrollUp()
     }
   }
 

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.js
@@ -63,6 +63,9 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
     return this._lastText || ''
   }
 
+  // Key-handling code shared by both the input key handler
+  // (_onKeyDown) and the global key handler
+  // (_globalKeyDownPressHandler).
   _commonOnKeyDown = (e: SyntheticKeyboardEvent<> | KeyboardEvent) => {
     const text = this._getText()
     if (e.key === 'ArrowUp' && !this.props.isEditing && !text) {


### PR DESCRIPTION
In particular, ArrowUp and Esc would work differently depending on whether
the input was actually focused.