### PR TITLE
kbfs_ops_test: fix bugs for TestKBFSOpsPartialSync, and re-enable it

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_worker.go
+++ b/go/kbfs/libkbfs/block_retrieval_worker.go
@@ -62,8 +62,9 @@ func (brw *blockRetrievalWorker) HandleRequest() (err error) {
 	}
 
 	var block Block
+	var cacheType DiskBlockCacheType
 	defer func() {
-		brw.queue.FinalizeRequest(retrieval, block, err)
+		brw.queue.FinalizeRequest(retrieval, block, cacheType, err)
 	}()
 
 	// Handle canceled contexts.
@@ -97,9 +98,9 @@ func (brw *blockRetrievalWorker) HandleRequest() (err error) {
 		}
 	}
 
+	cacheType = action.CacheType()
 	return brw.getBlock(
-		retrieval.ctx, retrieval.kmd, retrieval.blockPtr, block,
-		action.CacheType())
+		retrieval.ctx, retrieval.kmd, retrieval.blockPtr, block, cacheType)
 }
 
 // Shutdown shuts down the blockRetrievalWorker once its current work is done.

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4309,12 +4309,12 @@ func waitForPrefetchInTest(
 	select {
 	case <-ch:
 	case <-ctx.Done():
-		t.Fatal(ctx.Err())
+		require.FailNow(t, ctx.Err().Error())
 	}
 }
 
 func TestKBFSOpsPartialSync(t *testing.T) {
-	t.Skip("Broken, KBFS-3840")
+	//t.Skip("Broken, KBFS-3840")
 
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
@@ -4362,16 +4362,17 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Root block and 'a' block should be synced")
-	checkSyncCache := func(expectedBlocks uint64) {
-		waitForPrefetchInTest(t, ctx, config, rootNode)
-		waitForPrefetchInTest(t, ctx, config, aNode)
+	checkSyncCache := func(expectedBlocks uint64, nodesToWaitOn ...Node) {
+		for _, node := range nodesToWaitOn {
+			waitForPrefetchInTest(t, ctx, config, node)
+		}
 		syncStatusMap := dbc.syncCache.Status(ctx)
 		require.Len(t, syncStatusMap, 1)
 		syncStatus, ok := syncStatusMap[syncCacheName]
 		require.True(t, ok)
 		require.Equal(t, expectedBlocks, syncStatus.NumBlocks)
 	}
-	checkSyncCache(2)
+	checkSyncCache(2, rootNode, aNode)
 
 	t.Log("First device completes synced path, along with others")
 	bNode, _, err := kbfsOps2.CreateDir(ctx, aNode, "b")
@@ -4399,7 +4400,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	// 8 blocks: root node (1 indirect, 2 direct), `a` node (1
 	// indirect, 2 direct), `b` node, `c` node (and the old archived
 	// ones have been GC'd from the sync cache).
-	checkSyncCache(8)
+	checkSyncCache(8, bNode, cNode)
 
 	checkStatus := func(node Node, expectedStatus PrefetchStatus) {
 		md, err := kbfsOps.GetNodeMetadata(ctx, node)
@@ -4441,7 +4442,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	checkSyncCache(10)
+	checkSyncCache(10, cNode)
 	checkStatus(cNode, FinishedPrefetch)
 	checkStatus(eNode, FinishedPrefetch)
 	checkStatus(fNode, FinishedPrefetch)
@@ -4461,7 +4462,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	checkSyncCache(10)
+	checkSyncCache(10, cNode)
 	checkStatus(cNode, FinishedPrefetch)
 	checkStatus(eNode, FinishedPrefetch)
 	checkStatus(fNode, FinishedPrefetch)
@@ -4473,7 +4474,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	checkSyncCache(12)
+	checkSyncCache(12, cNode, dNode)
 	checkStatus(cNode, FinishedPrefetch)
 	checkStatus(eNode, FinishedPrefetch)
 	checkStatus(fNode, FinishedPrefetch)
@@ -4487,7 +4488,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	checkSyncCache(10)
+	checkSyncCache(10, cNode)
 	checkStatus(bNode, FinishedPrefetch)
 	checkStatus(cNode, FinishedPrefetch)
 	checkStatus(eNode, FinishedPrefetch)
@@ -4513,7 +4514,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	checkSyncCache(8)
+	checkSyncCache(8, cNode)
 	checkStatus(bNode, FinishedPrefetch)
 	checkStatus(cNode, FinishedPrefetch)
 	checkStatus(eNode, NoPrefetch)


### PR DESCRIPTION
A few real bugs and a few test bugs addressed here:

* disk_block_cache_wrapped: fix a race where `UpdateMetadata` wouldn't find the metadata if another goroutine moved the block.
* block_retrieval_queue: handle the action for the block request changing _after_ a worker sends the request, but before it's finalized
* kbfs_ops_test: we can't reliably wait for the root and `a` nodes to finish their prefetching, because of the path "a/b2" that is not synced, and is not required to be prefetched by the test. Instead, wait for the indirect pointers of root and `a` to be retrieved and finalized before we check the sync cache counts.

With these changes, the test passed `-test.count 1000` multiple times in a row.

Issue: KBFS-3840