### PR TITLE
Devices improvements 2 - 'Create a paper key' box if we've never had one

### DIFF
--- a/shared/devices/add-device/container.js
+++ b/shared/devices/add-device/container.js
@@ -21,9 +21,15 @@ const mapDispatchToProps = (dispatch, {navigateUp}) => ({
   onCancel: () => dispatch(navigateUp()),
 })
 
-export default Container.namedConnect<RouteProps<{}, {}>, _, _, _, _>(
+export default Container.namedConnect<
+  RouteProps<{highlight: Array<'computer' | 'phone' | 'paper key'>}, {}>,
+  _,
+  _,
+  _,
+  _
+>(
   () => ({}),
   mapDispatchToProps,
-  (s, d, o) => ({...d, title: 'Add a device'}),
+  (s, d, o) => ({...d, highlight: o.routeProps.get('highlight'), title: 'Add a device'}),
   'AddDevice'
 )(AddDevice)

--- a/shared/devices/add-device/index.js
+++ b/shared/devices/add-device/index.js
@@ -5,6 +5,7 @@ import * as Styles from '../../styles'
 import {isLargeScreen} from '../../constants/platform'
 
 type Props = {|
+  highlight?: ?Array<'computer' | 'phone' | 'paper key'>,
   onAddComputer: () => void,
   onAddPaperKey: () => void,
   onAddPhone: () => void,
@@ -31,12 +32,24 @@ const AddDevice = (props: Props) => (
       <Kb.Box2
         direction={Styles.isMobile ? 'vertical' : 'horizontal'}
         gap="large"
-        gapStart={true}
+        style={styles.deviceOptions}
         gapEnd={true}
       >
-        <DeviceOption onClick={props.onAddComputer} type="computer" />
-        <DeviceOption onClick={props.onAddPhone} type="phone" />
-        <DeviceOption onClick={props.onAddPaperKey} type="paper key" />
+        <DeviceOption
+          onClick={props.onAddComputer}
+          type="computer"
+          highlight={props.highlight && props.highlight.includes('computer')}
+        />
+        <DeviceOption
+          onClick={props.onAddPhone}
+          type="phone"
+          highlight={props.highlight && props.highlight.includes('phone')}
+        />
+        <DeviceOption
+          onClick={props.onAddPaperKey}
+          type="paper key"
+          highlight={props.highlight && props.highlight.includes('paper key')}
+        />
       </Kb.Box2>
     </Kb.Box2>
   </Kb.ScrollView>
@@ -49,10 +62,6 @@ const DeviceBox = Styles.isMobile
       '&:hover': {
         backgroundColor: Styles.globalColors.blue4,
       },
-      border: `1px solid ${Styles.globalColors.black_05}`,
-      borderRadius: Styles.borderRadius,
-      padding: Styles.globalMargins.tiny,
-      width: 140,
     })
 const bigIcon = isLargeScreen && Styles.isMobile
 const typeToIcon = {
@@ -60,9 +69,15 @@ const typeToIcon = {
   'paper key': bigIcon ? `icon-paper-key-96` : `icon-paper-key-64`,
   phone: bigIcon ? `icon-phone-96` : `icon-phone-64`,
 }
-const DeviceOption = ({onClick, type}) => (
+const DeviceOption = ({highlight, onClick, type}) => (
   <Kb.ClickableBox onClick={onClick}>
-    <DeviceBox direction="vertical" centerChildren={true} gap="xtiny" gapEnd={true}>
+    <DeviceBox
+      style={Styles.collapseStyles([styles.deviceOption, highlight && styles.deviceOptionHighlighted])}
+      direction="vertical"
+      centerChildren={true}
+      gap="xtiny"
+      gapEnd={!Styles.isMobile}
+    >
       <Kb.Icon type={typeToIcon[type]} />
       <Kb.Text type="BodySemibold">
         {type === 'paper key' ? 'Create' : 'Add'} a {type}
@@ -75,6 +90,23 @@ const styles = Styles.styleSheetCreate({
   container: {
     padding: Styles.globalMargins.small,
   },
+  deviceOption: {
+    borderColor: Styles.globalColors.black_05,
+    borderRadius: Styles.borderRadius,
+    borderStyle: 'solid',
+    borderWidth: 1,
+    padding: Styles.globalMargins.tiny,
+    width: Styles.isMobile ? 160 : 140,
+  },
+  deviceOptionHighlighted: {backgroundColor: Styles.globalColors.blue4},
+  deviceOptions: Styles.platformStyles({
+    isElectron: {
+      paddingLeft: Styles.globalMargins.large,
+    },
+    isMobile: {
+      paddingTop: Styles.globalMargins.medium,
+    },
+  }),
 })
 
 export default Kb.HeaderOrPopup(AddDevice)

--- a/shared/devices/container.js
+++ b/shared/devices/container.js
@@ -18,7 +18,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = (dispatch, {navigateAppend}) => ({
   loadDevices: () => dispatch(DevicesGen.createLoad()),
-  onAddDevice: () => dispatch(navigateAppend(['addDevice'])),
+  onAddDevice: (highlight?: Array<'computer' | 'phone' | 'paper key'>) =>
+    dispatch(navigateAppend([{props: {highlight}, selected: 'addDevice'}])),
   onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
 })
 

--- a/shared/devices/container.js
+++ b/shared/devices/container.js
@@ -44,10 +44,15 @@ function mergeProps(stateProps, dispatchProps, ownProps: OwnProps) {
   const [revoked, normal] = splitAndSortDevices(stateProps._deviceMap)
   const revokedItems = revoked.map(deviceToItem)
   const newlyRevokedIds = I.Set(revokedItems.map(d => d.key)).intersect(stateProps._newlyChangedItemIds)
+  const showPaperKeyNudge = !stateProps._deviceMap.some(v => v.type === 'backup')
+  const items = normal.map(deviceToItem)
+  if (showPaperKeyNudge) {
+    items.push({key: 'paperKeyNudge', type: 'paperKeyNudge'})
+  }
   return {
     _stateOverride: null,
     hasNewlyRevoked: newlyRevokedIds.size > 0,
-    items: normal.map(deviceToItem),
+    items,
     loadDevices: dispatchProps.loadDevices,
     onAddDevice: dispatchProps.onAddDevice,
     onBack: dispatchProps.onBack,

--- a/shared/devices/container.js
+++ b/shared/devices/container.js
@@ -46,14 +46,10 @@ function mergeProps(stateProps, dispatchProps, ownProps: OwnProps) {
   const newlyRevokedIds = I.Set(revokedItems.map(d => d.key)).intersect(stateProps._newlyChangedItemIds)
   const showPaperKeyNudge =
     !stateProps._deviceMap.isEmpty() && !stateProps._deviceMap.some(v => v.type === 'backup')
-  const items = normal.map(deviceToItem)
-  if (showPaperKeyNudge) {
-    items.push({key: 'paperKeyNudge', type: 'paperKeyNudge'})
-  }
   return {
     _stateOverride: null,
     hasNewlyRevoked: newlyRevokedIds.size > 0,
-    items,
+    items: normal.map(deviceToItem),
     loadDevices: dispatchProps.loadDevices,
     onAddDevice: dispatchProps.onAddDevice,
     onBack: dispatchProps.onBack,

--- a/shared/devices/container.js
+++ b/shared/devices/container.js
@@ -44,7 +44,8 @@ function mergeProps(stateProps, dispatchProps, ownProps: OwnProps) {
   const [revoked, normal] = splitAndSortDevices(stateProps._deviceMap)
   const revokedItems = revoked.map(deviceToItem)
   const newlyRevokedIds = I.Set(revokedItems.map(d => d.key)).intersect(stateProps._newlyChangedItemIds)
-  const showPaperKeyNudge = !stateProps._deviceMap.some(v => v.type === 'backup')
+  const showPaperKeyNudge =
+    !stateProps._deviceMap.isEmpty() && !stateProps._deviceMap.some(v => v.type === 'backup')
   const items = normal.map(deviceToItem)
   if (showPaperKeyNudge) {
     items.push({key: 'paperKeyNudge', type: 'paperKeyNudge'})
@@ -57,6 +58,7 @@ function mergeProps(stateProps, dispatchProps, ownProps: OwnProps) {
     onAddDevice: dispatchProps.onAddDevice,
     onBack: dispatchProps.onBack,
     revokedItems: revokedItems,
+    showPaperKeyNudge,
     title: 'Devices',
     waiting: stateProps.waiting,
   }
@@ -80,6 +82,7 @@ class ReloadableDevices extends React.PureComponent<React.ElementConfig<typeof D
           loadDevices={this.props.loadDevices}
           onBack={this.props.onBack}
           revokedItems={this.props.revokedItems}
+          showPaperKeyNudge={this.props.showPaperKeyNudge}
           title={this.props.title}
           waiting={this.props.waiting}
         />

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -6,7 +6,10 @@ import DeviceRow from './row/container'
 import * as Styles from '../styles'
 import {compose} from '../util/container'
 
-type Item = {key: string, id: Types.DeviceID, type: 'device'} | {key: string, type: 'revokedHeader'}
+type Item =
+  | {key: string, id: Types.DeviceID, type: 'device'}
+  | {key: string, type: 'revokedHeader'}
+  | {key: string, type: 'paperKeyNudge'}
 
 type State = {
   revokedExpanded: boolean,
@@ -50,6 +53,8 @@ class Devices extends React.PureComponent<Props, State> {
           onToggleExpanded={this._toggleExpanded}
         />
       )
+    } else if (item.type === 'paperKeyNudge') {
+      return null // TODO
     } else {
       return <DeviceRow key={item.id} deviceID={item.id} firstItem={index === 0} />
     }

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -113,13 +113,14 @@ const RevokedHeader = ({children, onToggleExpanded, expanded}) => (
         style={revokedHeaderStyles.textContainer}
       >
         <Kb.Text type="BodySmallSemibold" style={revokedHeaderStyles.text}>
-          Revoked devices
+          Revoked devices{' '}
+          <Kb.Icon
+            boxStyle={revokedHeaderStyles.icon}
+            type={expanded ? 'iconfont-caret-down' : 'iconfont-caret-right'}
+            color={Styles.globalColors.black_50}
+            fontSize={10}
+          />
         </Kb.Text>
-        <Kb.Icon
-          type={expanded ? 'iconfont-caret-down' : 'iconfont-caret-right'}
-          color={Styles.globalColors.black_50}
-          fontSize={10}
-        />
       </Kb.Box2>
       {expanded && (
         <Kb.Text center={true} type="BodySmallSemibold" style={revokedHeaderStyles.desc}>
@@ -135,9 +136,9 @@ const revokedHeaderStyles = Styles.styleSheetCreate({
     paddingLeft: Styles.globalMargins.small,
     paddingRight: Styles.globalMargins.small,
   },
-  text: {color: Styles.globalColors.black_50},
+  icon: Styles.platformStyles({isElectron: {display: 'inline-block'}}),
+  text: {color: Styles.globalColors.black_50, paddingLeft: Styles.globalMargins.tiny},
   textContainer: {
-    alignItems: 'center',
     minHeight: Styles.isMobile ? 32 : 24,
   },
 })

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -17,7 +17,7 @@ type Props = {|
   _stateOverride: ?State,
   items: Array<Item>,
   loadDevices: () => void,
-  onAddDevice: () => void,
+  onAddDevice: (highlight?: Array<'computer' | 'phone' | 'paper key'>) => void,
   onBack: () => void,
   revokedItems: Array<Item>,
   showPaperKeyNudge: boolean,
@@ -65,8 +65,10 @@ class Devices extends React.PureComponent<Props, State> {
 
     return (
       <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} style={styles.container}>
-        <DeviceHeader onAddNew={this.props.onAddDevice} waiting={this.props.waiting} />
-        {this.props.showPaperKeyNudge && <PaperKeyNudge onAddDevice={this.props.onAddDevice} />}
+        <DeviceHeader onAddNew={() => this.props.onAddDevice()} waiting={this.props.waiting} />
+        {this.props.showPaperKeyNudge && (
+          <PaperKeyNudge onAddDevice={() => this.props.onAddDevice(['paper key'])} />
+        )}
         {this.props.waiting && <Kb.ProgressIndicator style={styles.progress} />}
         <Kb.List bounces={false} items={items} renderItem={this._renderRow} style={{width: '100%'}} />
       </Kb.Box2>

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -177,16 +177,10 @@ const paperKeyNudgeStyles = Styles.styleSheetCreate({
       flex: 1,
     },
     isElectron: {
-      paddingBottom: Styles.globalMargins.tiny,
-      paddingLeft: Styles.globalMargins.small,
-      paddingRight: Styles.globalMargins.small,
-      paddingTop: Styles.globalMargins.tiny,
+      ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),
     },
     isMobile: {
-      paddingBottom: Styles.globalMargins.tiny,
-      paddingLeft: Styles.globalMargins.xsmall,
-      paddingRight: Styles.globalMargins.xsmall,
-      paddingTop: Styles.globalMargins.tiny,
+      ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.xsmall),
     },
   }),
   container: Styles.platformStyles({

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -6,10 +6,7 @@ import DeviceRow from './row/container'
 import * as Styles from '../styles'
 import {compose} from '../util/container'
 
-type Item =
-  | {key: string, id: Types.DeviceID, type: 'device'}
-  | {key: string, type: 'revokedHeader'}
-  | {key: string, type: 'paperKeyNudge'}
+type Item = {key: string, id: Types.DeviceID, type: 'device'} | {key: string, type: 'revokedHeader'}
 
 type State = {
   revokedExpanded: boolean,
@@ -54,8 +51,6 @@ class Devices extends React.PureComponent<Props, State> {
           onToggleExpanded={this._toggleExpanded}
         />
       )
-    } else if (item.type === 'paperKeyNudge') {
-      return !Styles.isMobile && <PaperKeyNudge />
     } else {
       return <DeviceRow key={item.id} deviceID={item.id} firstItem={index === 0} />
     }
@@ -71,9 +66,9 @@ class Devices extends React.PureComponent<Props, State> {
     return (
       <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} style={styles.container}>
         <DeviceHeader onAddNew={this.props.onAddDevice} waiting={this.props.waiting} />
+        {this.props.showPaperKeyNudge && <PaperKeyNudge onAddDevice={this.props.onAddDevice} />}
         {this.props.waiting && <Kb.ProgressIndicator style={styles.progress} />}
-        <Kb.List items={items} renderItem={this._renderRow} style={{width: '100%'}} />
-        {this.props.showPaperKeyNudge && Styles.isMobile && <PaperKeyNudge />}
+        <Kb.List bounces={false} items={items} renderItem={this._renderRow} style={{width: '100%'}} />
       </Kb.Box2>
     )
   }
@@ -92,21 +87,26 @@ const styles = Styles.styleSheetCreate({
 })
 
 const DeviceHeader = ({onAddNew, waiting}) => (
-  <Kb.ClickableBox onClick={onAddNew}>
-    <Kb.Box2
-      direction="horizontal"
-      gap="xtiny"
-      style={headerStyles.container}
-      fullWidth={true}
-      centerChildren={true}
-    >
-      <Kb.Icon type="iconfont-new" color={Styles.globalColors.blue} />
-      <Kb.Text type="BodyBigLink">Add a device</Kb.Text>
-    </Kb.Box2>
+  <Kb.ClickableBox onClick={onAddNew} style={headerStyles.container}>
+    <Kb.Button type="Primary" label="Add device">
+      <Kb.Icon
+        type="iconfont-new"
+        color={Styles.globalColors.white}
+        style={Kb.iconCastPlatformStyles(headerStyles.icon)}
+      />
+    </Kb.Button>
   </Kb.ClickableBox>
 )
 const headerStyles = Styles.styleSheetCreate({
-  container: {height: Styles.isMobile ? 64 : 48},
+  container: {
+    ...Styles.globalStyles.flexBoxRow,
+    height: Styles.isMobile ? 64 : 48,
+    justifyContent: 'center',
+  },
+  icon: {
+    alignSelf: 'center',
+    marginRight: Styles.globalMargins.tiny,
+  },
 })
 
 const RevokedHeader = ({children, onToggleExpanded, expanded}) => (
@@ -150,32 +150,49 @@ const revokedHeaderStyles = Styles.styleSheetCreate({
   },
 })
 
-const PaperKeyNudge = () => (
-  <Kb.Box2 direction="horizontal" style={paperKeyNudgeStyles.container} fullWidth={true}>
-    <Kb.Box2 direction="horizontal" gap="xsmall" alignItems="center" style={paperKeyNudgeStyles.border}>
-      <Kb.Icon type="icon-paper-key-48" />
-      <Kb.Box2 direction="vertical" style={{flex: 1}}>
-        <Kb.Text type="BodySemibold">Create a paper key</Kb.Text>
-        <Kb.Text type={Styles.isMobile ? 'BodySmall' : 'Body'} style={paperKeyNudgeStyles.desc}>
-          A paper key can be used to access your account on a new device. Keep one in a safe place (like in a
-          wallet) to keep your data safe.
-        </Kb.Text>
+const PaperKeyNudge = ({onAddDevice}) => (
+  <Kb.ClickableBox onClick={onAddDevice}>
+    <Kb.Box2 direction="horizontal" style={paperKeyNudgeStyles.container} fullWidth={true}>
+      <Kb.Box2 direction="horizontal" gap="xsmall" alignItems="center" style={paperKeyNudgeStyles.border}>
+        <Kb.Icon type={Styles.isMobile ? 'icon-onboarding-paper-key-48' : 'icon-onboarding-paper-key-32'} />
+        <Kb.Box2 direction="vertical" style={paperKeyNudgeStyles.flexOne}>
+          <Kb.Text type="BodySemibold">Create a paper key</Kb.Text>
+          <Kb.Text type={Styles.isMobile ? 'BodySmall' : 'Body'} style={paperKeyNudgeStyles.desc}>
+            A paper key can be used to access your account in case you lose all your devices. Keep one in a
+            safe place (like a wallet) to keep your data safe.
+          </Kb.Text>
+        </Kb.Box2>
+        {!Styles.isMobile && <Kb.Text type="BodyBigLink">Create a paper key</Kb.Text>}
       </Kb.Box2>
     </Kb.Box2>
-  </Kb.Box2>
+  </Kb.ClickableBox>
 )
 const paperKeyNudgeStyles = Styles.styleSheetCreate({
-  border: {
-    borderColor: Styles.globalColors.black_05,
-    borderRadius: Styles.borderRadius,
-    borderStyle: 'solid',
-    borderWidth: 1,
-    flex: 1,
-    padding: Styles.globalMargins.tiny,
-  },
+  border: Styles.platformStyles({
+    common: {
+      borderColor: Styles.globalColors.black_05,
+      borderRadius: Styles.borderRadius,
+      borderStyle: 'solid',
+      borderWidth: 1,
+      flex: 1,
+    },
+    isElectron: {
+      paddingBottom: Styles.globalMargins.tiny,
+      paddingLeft: Styles.globalMargins.small,
+      paddingRight: Styles.globalMargins.small,
+      paddingTop: Styles.globalMargins.tiny,
+    },
+    isMobile: {
+      paddingBottom: Styles.globalMargins.tiny,
+      paddingLeft: Styles.globalMargins.xsmall,
+      paddingRight: Styles.globalMargins.xsmall,
+      paddingTop: Styles.globalMargins.tiny,
+    },
+  }),
   container: Styles.platformStyles({
     common: {
       padding: Styles.globalMargins.small,
+      paddingTop: 0,
     },
     isMobile: {
       padding: Styles.globalMargins.tiny,
@@ -186,6 +203,7 @@ const paperKeyNudgeStyles = Styles.styleSheetCreate({
       maxWidth: 450,
     },
   }),
+  flexOne: {flex: 1},
 })
 
 export default compose(Kb.HeaderOnMobile)(Devices)

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -23,6 +23,7 @@ type Props = {|
   onAddDevice: () => void,
   onBack: () => void,
   revokedItems: Array<Item>,
+  showPaperKeyNudge: boolean,
   hasNewlyRevoked: boolean,
   waiting: boolean,
   title: string,
@@ -54,7 +55,7 @@ class Devices extends React.PureComponent<Props, State> {
         />
       )
     } else if (item.type === 'paperKeyNudge') {
-      return null // TODO
+      return !Styles.isMobile && <PaperKeyNudge />
     } else {
       return <DeviceRow key={item.id} deviceID={item.id} firstItem={index === 0} />
     }
@@ -71,7 +72,8 @@ class Devices extends React.PureComponent<Props, State> {
       <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} style={styles.container}>
         <DeviceHeader onAddNew={this.props.onAddDevice} waiting={this.props.waiting} />
         {this.props.waiting && <Kb.ProgressIndicator style={styles.progress} />}
-        <Kb.List items={items} renderItem={this._renderRow} />
+        <Kb.List items={items} renderItem={this._renderRow} style={{width: '100%'}} />
+        {this.props.showPaperKeyNudge && Styles.isMobile && <PaperKeyNudge />}
       </Kb.Box2>
     )
   }
@@ -146,6 +148,44 @@ const revokedHeaderStyles = Styles.styleSheetCreate({
   textContainer: {
     minHeight: Styles.isMobile ? 32 : 24,
   },
+})
+
+const PaperKeyNudge = () => (
+  <Kb.Box2 direction="horizontal" style={paperKeyNudgeStyles.container} fullWidth={true}>
+    <Kb.Box2 direction="horizontal" gap="xsmall" alignItems="center" style={paperKeyNudgeStyles.border}>
+      <Kb.Icon type="icon-paper-key-48" />
+      <Kb.Box2 direction="vertical" style={{flex: 1}}>
+        <Kb.Text type="BodySemibold">Create a paper key</Kb.Text>
+        <Kb.Text type={Styles.isMobile ? 'BodySmall' : 'Body'} style={paperKeyNudgeStyles.desc}>
+          A paper key can be used to access your account on a new device. Keep one in a safe place (like in a
+          wallet) to keep your data safe.
+        </Kb.Text>
+      </Kb.Box2>
+    </Kb.Box2>
+  </Kb.Box2>
+)
+const paperKeyNudgeStyles = Styles.styleSheetCreate({
+  border: {
+    borderColor: Styles.globalColors.black_05,
+    borderRadius: Styles.borderRadius,
+    borderStyle: 'solid',
+    borderWidth: 1,
+    flex: 1,
+    padding: Styles.globalMargins.tiny,
+  },
+  container: Styles.platformStyles({
+    common: {
+      padding: Styles.globalMargins.small,
+    },
+    isMobile: {
+      padding: Styles.globalMargins.tiny,
+    },
+  }),
+  desc: Styles.platformStyles({
+    isElectron: {
+      maxWidth: 450,
+    },
+  }),
 })
 
 export default compose(Kb.HeaderOnMobile)(Devices)

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -70,7 +70,7 @@ class Devices extends React.PureComponent<Props, State> {
           <PaperKeyNudge onAddDevice={() => this.props.onAddDevice(['paper key'])} />
         )}
         {this.props.waiting && <Kb.ProgressIndicator style={styles.progress} />}
-        <Kb.List bounces={false} items={items} renderItem={this._renderRow} style={{width: '100%'}} />
+        <Kb.List bounces={false} items={items} renderItem={this._renderRow} />
       </Kb.Box2>
     )
   }

--- a/shared/styles/index.desktop.js
+++ b/shared/styles/index.desktop.js
@@ -151,7 +151,7 @@ export const collapseStyles = (styles: $ReadOnlyArray<CollapsibleStyle>): Object
   return isEmpty(style) ? undefined : style
 }
 export {isMobile, fileUIName, isIPhoneX, isIOS, isAndroid} from '../constants/platform'
-export {globalMargins, backgroundModeToColor, platformStyles} from './shared'
+export {globalMargins, backgroundModeToColor, platformStyles, padding} from './shared'
 export {css as styledCss, keyframes as styledKeyframes} from '@emotion/core'
 export {default as styled} from '@emotion/styled'
 export {default as globalColors} from './colors'

--- a/shared/styles/index.js.flow
+++ b/shared/styles/index.js.flow
@@ -65,6 +65,13 @@ declare export var windowStyle: {
 
 declare export function styled<T>(Component: T): (...styles: Array<any>) => T
 
+declare export function padding(
+  top: number,
+  right?: number,
+  bottom?: number,
+  left?: number
+): {|paddingTop: number, paddingRight: number, paddingBottom: number, paddingLeft: number|}
+
 declare export var styledCss: any // TODO better type
 declare export var styledKeyframes: any // TODO better type
 

--- a/shared/styles/index.native.js
+++ b/shared/styles/index.native.js
@@ -61,7 +61,7 @@ export const backgroundURL = (...path: Array<string>) => ({})
 export const styledKeyframes = () => null
 
 export {isMobile, fileUIName, isIPhoneX, isIOS, isAndroid} from '../constants/platform'
-export {globalMargins, backgroundModeToColor, platformStyles} from './shared'
+export {globalMargins, backgroundModeToColor, platformStyles, padding} from './shared'
 export {default as glamorous} from '@emotion/native'
 export {default as styled, css as styledCss} from '@emotion/native'
 export {default as globalColors} from './colors'

--- a/shared/styles/shared.js
+++ b/shared/styles/shared.js
@@ -60,3 +60,12 @@ export const platformStyles = (options: {|
   ...(isAndroid && options.isAndroid ? options.isAndroid : {}),
   ...(isElectron && options.isElectron ? unifyStyles(options.isElectron) : {}),
 })
+
+/* eslint-disable sort-keys */
+export const padding = (top: number, right?: number, bottom?: number, left?: number) => ({
+  paddingTop: top,
+  paddingRight: right || top,
+  paddingBottom: bottom || top,
+  paddingLeft: left || right || top,
+})
+/* eslint-enable sort-keys */


### PR DESCRIPTION
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/11968340/52481599-efc33e80-2b7c-11e9-93af-c40cbd08df4e.png">

It leads to the add device dialog from #15932 with some plumbing to highlight the paper key option in this case. Right now the "highlight" is making the background blue, next PR will be to draw better attention to it. Also:
* Adds `Styles.padding(top, right?, bottom?, left?)`
* Makes 'Add device' a button instead of a link

r? @keybase/react-hackers 