### PR TITLE
Devices improvements 3 - Animation for add device options

### DIFF
--- a/shared/devices/add-device/emphasis-box/index.desktop.js
+++ b/shared/devices/add-device/emphasis-box/index.desktop.js
@@ -1,0 +1,15 @@
+// @flow
+import * as Kb from '../../../common-adapters/'
+import * as Styles from '../../../styles'
+import type {Props} from '.'
+
+const emphasize = Styles.styledKeyframes({
+  from: {transform: 'scale(1)'},
+  to: {transform: 'scale(1.05)'},
+})
+
+const EmphasisBox = Styles.styled(Kb.Box2)((props: Props) =>
+  props.emphasize ? {animation: `${emphasize} 500ms ease-in-out infinite alternate`} : null
+)
+
+export default EmphasisBox

--- a/shared/devices/add-device/emphasis-box/index.js.flow
+++ b/shared/devices/add-device/emphasis-box/index.js.flow
@@ -1,0 +1,9 @@
+// @flow
+import * as React from 'react'
+
+export type Props = {
+  children: React.Node,
+  emphasize: boolean,
+}
+
+export default class extends React.Component<Props> {}

--- a/shared/devices/add-device/emphasis-box/index.native.js
+++ b/shared/devices/add-device/emphasis-box/index.native.js
@@ -1,0 +1,54 @@
+// @flow
+import * as React from 'react'
+import * as Kb from '../../../common-adapters/mobile.native'
+import type {Props} from '.'
+
+type State = {
+  zoom: Kb.NativeAnimated.Value,
+}
+class EmphasisBox extends React.Component<Props, State> {
+  state = {zoom: new Kb.NativeAnimated.Value(1)}
+  _animation = Kb.NativeAnimated.loop(
+    Kb.NativeAnimated.sequence([
+      Kb.NativeAnimated.timing(this.state.zoom, {
+        duration: 500,
+        toValue: 1.05,
+        useNativeDriver: true,
+      }),
+      Kb.NativeAnimated.timing(this.state.zoom, {
+        duration: 500,
+        toValue: 1,
+        useNativeDriver: true,
+      }),
+    ])
+  )
+
+  componentDidMount() {
+    if (this.props.emphasize) {
+      this._animation.start()
+    }
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (this.props.emphasize && !prevProps.emphasize) {
+      this._animation.start()
+    }
+    if (!this.props.emphasize && prevProps.emphasize) {
+      this._animation.stop()
+    }
+  }
+
+  componentWillUnmount() {
+    this._animation.stop()
+  }
+
+  render() {
+    return (
+      <Kb.NativeAnimated.View style={{transform: [{scale: this.state.zoom}]}}>
+        {this.props.children}
+      </Kb.NativeAnimated.View>
+    )
+  }
+}
+
+export default EmphasisBox

--- a/shared/devices/add-device/index.js
+++ b/shared/devices/add-device/index.js
@@ -66,9 +66,9 @@ const DeviceBox = Styles.isMobile
     })
 const bigIcon = isLargeScreen && Styles.isMobile
 const typeToIcon = {
-  computer: bigIcon ? `icon-computer-96` : `icon-computer-64`,
-  'paper key': bigIcon ? `icon-paper-key-96` : `icon-paper-key-64`,
-  phone: bigIcon ? `icon-phone-96` : `icon-phone-64`,
+  computer: bigIcon ? 'icon-computer-96' : 'icon-computer-64',
+  'paper key': bigIcon ? 'icon-paper-key-96' : 'icon-paper-key-64',
+  phone: bigIcon ? 'icon-phone-96' : 'icon-phone-64',
 }
 const DeviceOption = ({highlight, onClick, type}) => (
   <Kb.ClickableBox onClick={onClick}>

--- a/shared/devices/add-device/index.js
+++ b/shared/devices/add-device/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
+import EmphasisBox from './emphasis-box'
 import {isLargeScreen} from '../../constants/platform'
 
 type Props = {|
@@ -38,17 +39,17 @@ const AddDevice = (props: Props) => (
         <DeviceOption
           onClick={props.onAddComputer}
           type="computer"
-          highlight={props.highlight && props.highlight.includes('computer')}
+          highlight={!!props.highlight && props.highlight.includes('computer')}
         />
         <DeviceOption
           onClick={props.onAddPhone}
           type="phone"
-          highlight={props.highlight && props.highlight.includes('phone')}
+          highlight={!!props.highlight && props.highlight.includes('phone')}
         />
         <DeviceOption
           onClick={props.onAddPaperKey}
           type="paper key"
-          highlight={props.highlight && props.highlight.includes('paper key')}
+          highlight={!!props.highlight && props.highlight.includes('paper key')}
         />
       </Kb.Box2>
     </Kb.Box2>
@@ -71,18 +72,23 @@ const typeToIcon = {
 }
 const DeviceOption = ({highlight, onClick, type}) => (
   <Kb.ClickableBox onClick={onClick}>
-    <DeviceBox
-      style={Styles.collapseStyles([styles.deviceOption, highlight && styles.deviceOptionHighlighted])}
-      direction="vertical"
-      centerChildren={true}
-      gap="xtiny"
-      gapEnd={!Styles.isMobile}
-    >
-      <Kb.Icon type={typeToIcon[type]} />
-      <Kb.Text type="BodySemibold">
-        {type === 'paper key' ? 'Create' : 'Add'} a {type}
-      </Kb.Text>
-    </DeviceBox>
+    <EmphasisBox emphasize={highlight}>
+      <DeviceBox
+        style={Styles.collapseStyles([
+          styles.deviceOption,
+          Styles.isMobile && highlight && styles.deviceOptionHighlighted,
+        ])}
+        direction="vertical"
+        centerChildren={true}
+        gap="xtiny"
+        gapEnd={!Styles.isMobile}
+      >
+        <Kb.Icon type={typeToIcon[type]} />
+        <Kb.Text type="BodySemibold">
+          {type === 'paper key' ? 'Create' : 'Add'} a {type}
+        </Kb.Text>
+      </DeviceBox>
+    </EmphasisBox>
   </Kb.ClickableBox>
 )
 

--- a/shared/devices/add-device/index.js
+++ b/shared/devices/add-device/index.js
@@ -56,14 +56,6 @@ const AddDevice = (props: Props) => (
   </Kb.ScrollView>
 )
 
-const DeviceBox = Styles.isMobile
-  ? Kb.Box2
-  : Styles.styled(Kb.Box2)({
-      ...Styles.transition('background-color'),
-      '&:hover': {
-        backgroundColor: Styles.globalColors.blue4,
-      },
-    })
 const bigIcon = isLargeScreen && Styles.isMobile
 const typeToIcon = {
   computer: bigIcon ? 'icon-computer-96' : 'icon-computer-64',
@@ -73,7 +65,8 @@ const typeToIcon = {
 const DeviceOption = ({highlight, onClick, type}) => (
   <Kb.ClickableBox onClick={onClick}>
     <EmphasisBox emphasize={highlight}>
-      <DeviceBox
+      <Kb.Box2
+        className="hover_background_color_blue4"
         style={Styles.collapseStyles([
           styles.deviceOption,
           Styles.isMobile && highlight && styles.deviceOptionHighlighted,
@@ -87,7 +80,7 @@ const DeviceOption = ({highlight, onClick, type}) => (
         <Kb.Text type="BodySemibold">
           {type === 'paper key' ? 'Create' : 'Add'} a {type}
         </Kb.Text>
-      </DeviceBox>
+      </Kb.Box2>
     </EmphasisBox>
   </Kb.ClickableBox>
 )
@@ -97,6 +90,7 @@ const styles = Styles.styleSheetCreate({
     padding: Styles.globalMargins.small,
   },
   deviceOption: {
+    ...Styles.transition('background-color'),
     borderColor: Styles.globalColors.black_05,
     borderRadius: Styles.borderRadius,
     borderStyle: 'solid',

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -4,7 +4,6 @@ import * as React from 'react'
 import * as Kb from '../common-adapters'
 import DeviceRow from './row/container'
 import * as Styles from '../styles'
-import {compose} from '../util/container'
 
 type Item = {key: string, id: Types.DeviceID, type: 'device'} | {key: string, type: 'revokedHeader'}
 
@@ -202,4 +201,4 @@ const paperKeyNudgeStyles = Styles.styleSheetCreate({
   flexOne: {flex: 1},
 })
 
-export default compose(Kb.HeaderOnMobile)(Devices)
+export default Kb.HeaderOnMobile(Devices)

--- a/shared/people/todo/container.js
+++ b/shared/people/todo/container.js
@@ -121,12 +121,17 @@ const PaperKeyConnector = connect<TodoOwnProps, _, _, _, _>(
     onConfirm: () => {
       if (!isMobile) {
         dispatch(RouteTreeGen.createSwitchTo({path: [Tabs.devicesTab]}))
-        dispatch(RouteTreeGen.createNavigateAppend({parentPath: [Tabs.devicesTab], path: ['addDevice']}))
+        dispatch(
+          RouteTreeGen.createNavigateAppend({
+            parentPath: [Tabs.devicesTab],
+            path: [{props: {highlight: ['paper key']}, selected: 'addDevice'}],
+          })
+        )
       } else {
         dispatch(
           RouteTreeGen.createNavigateTo({
             parentPath: [Tabs.settingsTab],
-            path: [SettingsTabs.devicesTab, 'addDevice'],
+            path: [SettingsTabs.devicesTab, {props: {highlight: ['paper key']}, selected: 'addDevice'}],
           })
         )
         dispatch(RouteTreeGen.createSwitchTo({path: [Tabs.settingsTab]}))


### PR DESCRIPTION
Support for animating options in the add device dialog if we want to draw attention to them. Hooks the animation up to the paper key todo item and the nudge from #15964. 
![device-animate-desktop](https://user-images.githubusercontent.com/11968340/52494841-0aa5ab00-2b9d-11e9-8b83-991cb531e9e5.gif)
![device-animate-mobile](https://user-images.githubusercontent.com/11968340/52494881-23ae5c00-2b9d-11e9-9686-264af3cf9b5a.gif)

r? @keybase/react-hackers 
