### PR TITLE
ident3 perf fixes and remove blackbar

### DIFF
--- a/shared/actions/tracker2.js
+++ b/shared/actions/tracker2.js
@@ -61,7 +61,8 @@ const updateUserCard = (state, action) => {
   const {guiID, card} = action.payload.params
   const username = Constants.guiIDToUsername(state.tracker2, guiID)
   if (!username) {
-    throw new Error('update user card w/ no username? ' + guiID)
+    // an unknown or stale guiid, just ignore
+    return
   }
 
   return Tracker2Gen.createUpdatedDetails({

--- a/shared/profile/user/container.js
+++ b/shared/profile/user/container.js
@@ -6,19 +6,19 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as ProfileGen from '../../actions/profile-gen'
 import * as Tracker2Gen from '../../actions/tracker2-gen'
 import * as SearchGen from '../../actions/search-gen'
-import * as Styles from '../../styles'
 import Profile2 from '.'
+import {memoize} from '../../util/memoize'
 import type {RouteProps} from '../../route-tree/render-route'
 import type {Response} from 'react-native-image-picker'
 
 type OwnProps = RouteProps<{username: string}, {}>
 const emptySet = I.OrderedSet()
 
-const headerBackgroundColor = (state, followThem) => {
+const headerBackgroundColorType = (state, followThem) => {
   if (['broken', 'error'].includes(state)) {
-    return Styles.globalColors.red
+    return 'red'
   } else {
-    return followThem ? Styles.globalColors.green : Styles.globalColors.blue
+    return followThem ? 'green' : 'blue'
   }
 }
 
@@ -32,7 +32,7 @@ const mapStateToProps = (state, ownProps) => {
     _assertions: d.assertions,
     _suggestionKeys: _userIsYou ? state.tracker2.proofSuggestions : null,
     _userIsYou,
-    backgroundColor: headerBackgroundColor(d.state, followThem),
+    backgroundColorType: headerBackgroundColorType(d.state, followThem),
     followThem,
     followers: state.tracker2.usernameToDetails.getIn([username, 'followers']) || emptySet,
     following: state.tracker2.usernameToDetails.getIn([username, 'following']) || emptySet,
@@ -64,12 +64,16 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     dispatch(RouteTreeGen.createNavigateAppend({path: [{props: {}, selected: 'search'}]}))
   },
 })
+
+const followToArray = memoize((followers, following) => ({
+  followers: followers.toArray(),
+  following: following.toArray(),
+}))
+
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   assertionKeys: stateProps._assertions ? stateProps._assertions.keySeq().toArray() : null,
-  backgroundColor: stateProps.backgroundColor,
+  backgroundColorType: stateProps.backgroundColorType,
   followThem: stateProps.followThem,
-  followers: stateProps.followers.toArray(),
-  following: stateProps.following.toArray(),
   onBack: dispatchProps.onBack,
   onEditAvatar: stateProps._userIsYou ? dispatchProps._onEditAvatar : null,
   onReload: () => dispatchProps._onReload(stateProps.username, stateProps._userIsYou),
@@ -79,6 +83,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
     ? stateProps._suggestionKeys.map(s => s.assertionKey).toArray()
     : null,
   username: stateProps.username,
+  ...followToArray(stateProps.followers, stateProps.following),
 })
 
 export default Container.namedConnect<OwnProps, _, _, _, _>(

--- a/shared/profile/user/index.js
+++ b/shared/profile/user/index.js
@@ -98,9 +98,13 @@ const Proofs = p => {
   )
 }
 
-class FriendshipTabs extends React.Component<
-  Props & {onChangeFollowing: boolean => void, selectedFollowing: boolean}
-> {
+type FriendshipTabsProps = {|
+  onChangeFollowing: boolean => void,
+  selectedFollowing: boolean,
+  numFollowers: number,
+  numFollowing: number,
+|}
+class FriendshipTabs extends React.Component<FriendshipTabsProps> {
   _tab = following => (
     <Kb.ClickableBox
       style={Styles.collapseStyles([
@@ -115,9 +119,7 @@ class FriendshipTabs extends React.Component<
           following === this.props.selectedFollowing ? styles.followTabTextSelected : styles.followTabText
         }
       >
-        {following
-          ? `FOLLOWING (${this.props.following.length})`
-          : `FOLLOWERS (${this.props.followers.length})`}
+        {following ? `FOLLOWING (${this.props.numFollowing})` : `FOLLOWERS (${this.props.numFollowers})`}
       </Kb.Text>
     </Kb.ClickableBox>
   )
@@ -151,7 +153,12 @@ class FriendRow extends React.PureComponent<{|usernames: Array<string>, itemWidt
   }
 }
 
-class BioTeamProofs extends React.PureComponent<Props> {
+type BioTeamProofsProps = {|
+  backgroundColor: string,
+  onEditAvatar: ?() => void,
+  username: string,
+|}
+class BioTeamProofs extends React.PureComponent<BioTeamProofsProps> {
   render() {
     return Styles.isMobile ? (
       <Kb.Box2 direction="vertical" fullWidth={true} style={styles.bioAndProofs}>
@@ -225,7 +232,8 @@ class User extends React.Component<Props, State> {
     return (
       <FriendshipTabs
         key="tabs"
-        {...this.props}
+        numFollowers={this.props.followers.length}
+        numFollowing={this.props.following.length}
         onChangeFollowing={this._changeFollowing}
         selectedFollowing={this.state.selectedFollowing}
       />
@@ -236,7 +244,16 @@ class User extends React.Component<Props, State> {
     <FriendRow key={'friend' + index} usernames={item} itemWidth={section.itemWidth} />
   )
 
-  _bioTeamProofsSection = {data: ['bioTeamProofs'], renderItem: () => <BioTeamProofs {...this.props} />}
+  _bioTeamProofsSection = {
+    data: ['bioTeamProofs'],
+    renderItem: () => (
+      <BioTeamProofs
+        backgroundColor={this.props.backgroundColor}
+        username={this.props.username}
+        onEditAvatar={this.props.onEditAvatar}
+      />
+    ),
+  }
 
   _onMeasured = width => this.setState(p => (p.width !== width ? {width} : null))
   _keyExtractor = (item, index) => index
@@ -277,9 +294,7 @@ class User extends React.Component<Props, State> {
               ]}
               style={Styles.collapseStyles([
                 styles.sectionList,
-                {
-                  backgroundColor: Styles.isMobile ? this.props.backgroundColor : Styles.globalColors.white,
-                },
+                {backgroundColor: Styles.isMobile ? this.props.backgroundColor : Styles.globalColors.white},
               ])}
               contentContainerStyle={styles.sectionListContentStyle}
             />

--- a/shared/profile/user/index.js
+++ b/shared/profile/user/index.js
@@ -184,8 +184,10 @@ class FriendRow extends React.Component<FriendRowProps> {
 }
 
 type BioTeamProofsProps = {|
+  assertionKeys: ?Array<string>,
   backgroundColorType: BackgroundColorType,
   onEditAvatar: ?() => void,
+  suggestionKeys: ?Array<string>,
   username: string,
 |}
 class BioTeamProofs extends React.PureComponent<BioTeamProofsProps> {
@@ -278,8 +280,10 @@ class User extends React.Component<Props, State> {
     data: ['bioTeamProofs'],
     renderItem: () => (
       <BioTeamProofs
+        assertionKeys={this.props.assertionKeys}
         backgroundColorType={this.props.backgroundColorType}
         username={this.props.username}
+        suggestionKeys={this.props.suggestionKeys}
         onEditAvatar={this.props.onEditAvatar}
       />
     ),


### PR DESCRIPTION
@keybase/react-hackers this reduces some render thrashing and fixes a blackbar

Mostly not passing unneeded props to children
Blackbar would happen as we overwrite guiid if we happen to do multiple ids. I think its fine to toss old guiIDs and just ignore incoming calls