### PR TITLE
chat attachments: use SimpleFS for KBFS paths; also ensure Close()

### DIFF
--- a/go/bind/extension.go
+++ b/go/bind/extension.go
@@ -341,7 +341,7 @@ func extensionRegisterFailure(ctx context.Context, gc *globals.Context, err erro
 
 func ExtensionDetectMIMEType(filename string) (res string, err error) {
 	defer kbCtx.Trace("ExtensionDetectMIMEType", func() error { return err })()
-	src, err := attachments.NewFileReadResetter(filename)
+	src, err := attachments.NewFileReadCloseResetter(filename)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/attachments/sender.go
+++ b/go/chat/attachments/sender.go
@@ -27,12 +27,7 @@ func NewSender(gc *globals.Context) *Sender {
 
 func (s *Sender) MakePreview(ctx context.Context, filename string, outboxID chat1.OutboxID) (res chat1.MakePreviewRes, err error) {
 	defer s.Trace(ctx, func() error { return err }, "MakePreview")()
-	var src ReadCloseResetter
-	if IsKbfsPath(filename) {
-		src, err = NewKbfsReadResetter(ctx, s.G().GlobalContext, filename)
-	} else {
-		src, err = NewFileReadResetter(filename)
-	}
+	src, err := NewReadCloseResetter(ctx, s.G().GlobalContext, filename)
 	if err != nil {
 		return res, err
 	}
@@ -54,12 +49,7 @@ func (s *Sender) MakePreview(ctx context.Context, filename string, outboxID chat
 }
 
 func (s *Sender) preprocess(ctx context.Context, filename string, callerPreview *chat1.MakePreviewRes) (res Preprocess, err error) {
-	var src ReadCloseResetter
-	if IsKbfsPath(filename) {
-		src, err = NewKbfsReadResetter(ctx, s.G().GlobalContext, filename)
-	} else {
-		src, err = NewFileReadResetter(filename)
-	}
+	src, err := NewReadCloseResetter(ctx, s.G().GlobalContext, filename)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -393,12 +393,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 	if err != nil {
 		return res, err
 	}
-	var src ReadCloseResetter
-	if IsKbfsPath(filename) {
-		src, err = NewKbfsReadResetter(bgctx, u.G().GlobalContext, filename)
-	} else {
-		src, err = NewFileReadResetter(filename)
-	}
+	src, err := NewReadCloseResetter(bgctx, u.G().GlobalContext, filename)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -393,10 +393,22 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 	if err != nil {
 		return res, err
 	}
-	src, err := NewFileReadResetter(filename)
+	var src ReadCloseResetter
+	if IsKbfsPath(filename) {
+		src, err = NewKbfsReadResetter(bgctx, u.G().GlobalContext, filename)
+	} else {
+		src, err = NewFileReadResetter(filename)
+	}
 	if err != nil {
 		return res, err
 	}
+
+	deferToBackgroundRoutine := false
+	defer func() {
+		if !deferToBackgroundRoutine {
+			src.Close()
+		}
+	}()
 
 	progress := func(bytesComplete, bytesTotal int64) {
 		u.G().ActivityNotifier.AttachmentUploadProgress(ctx, uid, convID, outboxID, bytesComplete, bytesTotal)
@@ -538,7 +550,10 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 			return err
 		})
 	}
+
+	deferToBackgroundRoutine = true
 	go func() {
+		defer src.Close()
 		var errStr string
 		status := types.AttachmentUploaderTaskStatusSuccess
 		if err := g.Wait(); err != nil {


### PR DESCRIPTION
Will use this for sending attachments to chat from Files tab.