### PR TITLE
Admin re-add reset owner

### DIFF
--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/client/go/teams"
 	"github.com/keybase/stellarnet"
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
@@ -259,6 +260,21 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 		}
 		log("%v", spew.Sdump(ret))
 		return "", nil
+	case "execute-invite":
+		teamID, err := keybase1.TeamIDFromString("978d0d88131e85123a142f87e8769d24")
+		if err != nil {
+			return "", err
+		}
+		err = teams.HandleSBSRequest(ctx, m.G(), keybase1.TeamSBSMsg{
+			TeamID: teamID,
+			Invitees: []keybase1.TeamInvitee{{
+				InviteID:    "828cb94d4c2b07b694ce578b2944ae27",
+				Uid:         "7080d7d007b46805c33e66b267e1e819",
+				EldestSeqno: 30,
+				Role:        keybase1.TeamRole_OWNER,
+			}},
+		})
+		return "", err
 	case "":
 		return "", fmt.Errorf("empty script name")
 	default:

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -359,6 +359,7 @@ func (u *smuUser) perUserKeyUpgrade() error {
 }
 
 type smuTeam struct {
+	ID   keybase1.TeamID
 	name string
 }
 
@@ -399,7 +400,8 @@ func (u *smuUser) getTeamsClient() keybase1.TeamsClient {
 	return keybase1.TeamsClient{Cli: u.primaryDevice().rpcClient()}
 }
 
-func (u *smuUser) pollForMembershipUpdate(team smuTeam, kg keybase1.PerTeamKeyGeneration, poller func(d keybase1.TeamDetails) bool) keybase1.TeamDetails {
+func (u *smuUser) pollForMembershipUpdate(team smuTeam, keyGen keybase1.PerTeamKeyGeneration,
+	poller func(d keybase1.TeamDetails) bool) keybase1.TeamDetails {
 	wait := 100 * time.Millisecond
 	var totalWait time.Duration
 	i := 0
@@ -411,8 +413,8 @@ func (u *smuUser) pollForMembershipUpdate(team smuTeam, kg keybase1.PerTeamKeyGe
 		}
 		// If the caller specified a "poller" that means we should keep polling until
 		// the predicate turns true
-		if details.KeyGeneration == kg && (poller == nil || poller(details)) {
-			u.ctx.log.Debug("found key generation %d", kg)
+		if details.KeyGeneration == keyGen && (poller == nil || poller(details)) {
+			u.ctx.log.Debug("found key generation %d", keyGen)
 			return details
 		}
 		if i == 9 {
@@ -425,7 +427,7 @@ func (u *smuUser) pollForMembershipUpdate(team smuTeam, kg keybase1.PerTeamKeyGe
 		totalWait += wait
 		wait = wait * 2
 	}
-	u.ctx.t.Fatalf("Failed to find the needed key generation (%d) after %s of waiting (%d iterations)", kg, totalWait, i)
+	u.ctx.t.Fatalf("Failed to find the needed key generation (%d) after %s of waiting (%d iterations)", keyGen, totalWait, i)
 	return keybase1.TeamDetails{}
 }
 
@@ -451,27 +453,30 @@ func (u *smuUser) pollForTeamSeqnoLink(team smuTeam, toSeqno keybase1.Seqno) {
 }
 
 func (u *smuUser) createTeam(writers []*smuUser) smuTeam {
+	return u.createTeam2(nil, writers, nil, nil)
+}
+
+func (u *smuUser) createTeam2(readers, writers, admins, owners []*smuUser) smuTeam {
 	name := u.username + "t"
 	nameK1, err := keybase1.TeamNameFromString(name)
-	if err != nil {
-		u.ctx.t.Fatal(err)
-	}
+	require.NoError(u.ctx.t, err)
 	cli := u.getTeamsClient()
-	_, err = cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{Name: nameK1.String()})
-	if err != nil {
-		u.ctx.t.Fatal(err)
-	}
-	for _, w := range writers {
-		_, err = cli.TeamAddMember(context.TODO(), keybase1.TeamAddMemberArg{
-			Name:     name,
-			Username: w.username,
-			Role:     keybase1.TeamRole_WRITER,
-		})
-		if err != nil {
-			u.ctx.t.Fatal(err)
+	x, err := cli.TeamCreate(context.TODO(), keybase1.TeamCreateArg{Name: nameK1.String()})
+	require.NoError(u.ctx.t, err)
+	lists := [][]*smuUser{readers, writers, admins, owners}
+	roles := []keybase1.TeamRole{keybase1.TeamRole_READER,
+		keybase1.TeamRole_WRITER, keybase1.TeamRole_ADMIN, keybase1.TeamRole_OWNER}
+	for i, list := range lists {
+		for _, u2 := range list {
+			_, err = cli.TeamAddMember(context.TODO(), keybase1.TeamAddMemberArg{
+				Name:     name,
+				Username: u2.username,
+				Role:     roles[i],
+			})
+			require.NoError(u.ctx.t, err)
 		}
 	}
-	return smuTeam{name: name}
+	return smuTeam{ID: x.TeamID, name: name}
 }
 
 func (u *smuUser) lookupImplicitTeam(create bool, displayName string, public bool) smuImplicitTeam {
@@ -530,6 +535,15 @@ func (u *smuUser) addAdmin(team smuTeam, w *smuUser) {
 
 func (u *smuUser) addOwner(team smuTeam, w *smuUser) {
 	u.addTeamMember(team, w, keybase1.TeamRole_OWNER)
+}
+
+func (u *smuUser) editMember(team *smuTeam, username string, role keybase1.TeamRole) {
+	err := u.getTeamsClient().TeamEditMember(context.TODO(), keybase1.TeamEditMemberArg{
+		Name:     team.name,
+		Username: username,
+		Role:     role,
+	})
+	require.NoError(u.ctx.t, err)
 }
 
 func (u *smuUser) reAddUserAfterReset(team smuImplicitTeam, w *smuUser) {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -412,8 +412,20 @@ func reAddMemberAfterResetInner(ctx context.Context, g *libkb.GlobalContext, tea
 
 		hasPUK := len(upak.Current.PerUserKeys) > 0
 
+		loggedInRole, err := t.myRole(ctx)
+		if err != nil {
+			return err
+		}
+
+		targetRole := existingRole
+		if existingRole.IsOrAbove(loggedInRole) {
+			// If an admin is trying to re-add an owner, re-add them as an admin.
+			// An admin cannot grant owner privileges, so this is the best we can do.
+			targetRole = loggedInRole
+		}
+
 		tx := CreateAddMemberTx(t)
-		if err := tx.ReAddMemberToImplicitTeam(uv, hasPUK, existingRole); err != nil {
+		if err := tx.ReAddMemberToImplicitTeam(uv, hasPUK, targetRole); err != nil {
 			return err
 		}
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -219,6 +219,14 @@ func AddMemberByID(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.
 			return err
 		}
 
+		loggedInRole, err := t.myRole(ctx)
+		if err != nil {
+			return err
+		}
+		if role == keybase1.TeamRole_OWNER && loggedInRole == keybase1.TeamRole_ADMIN {
+			return fmt.Errorf("Cannot add owner to team as an admin")
+		}
+
 		if inviteRequired && !uv.Uid.Exists() {
 			// Handle social invites without transactions.
 			res, err = t.InviteMember(ctx, username, role, resolvedUsername, uv)

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -118,6 +118,10 @@
       "role": "Types.TeamRoleType",
       "sendChatNotification": "boolean"
     },
+    "reAddToTeam": {
+      "teamname": "string",
+      "username": "string",
+    },
     "editTeamDescription": {
       "teamname": "string",
       "description": "string"

--- a/shared/actions/teams-gen.js
+++ b/shared/actions/teams-gen.js
@@ -41,6 +41,7 @@ export const inviteToTeamByPhone = 'teams:inviteToTeamByPhone'
 export const joinTeam = 'teams:joinTeam'
 export const leaveTeam = 'teams:leaveTeam'
 export const leftTeam = 'teams:leftTeam'
+export const reAddToTeam = 'teams:reAddToTeam'
 export const removeMemberOrPendingInvite = 'teams:removeMemberOrPendingInvite'
 export const removeParticipant = 'teams:removeParticipant'
 export const saveChannelMembership = 'teams:saveChannelMembership'
@@ -105,6 +106,7 @@ type _InviteToTeamByPhonePayload = $ReadOnly<{|teamname: string, role: Types.Tea
 type _JoinTeamPayload = $ReadOnly<{|teamname: string|}>
 type _LeaveTeamPayload = $ReadOnly<{|teamname: string, context: 'teams' | 'chat'|}>
 type _LeftTeamPayload = $ReadOnly<{|teamname: string, context: 'teams' | 'chat'|}>
+type _ReAddToTeamPayload = $ReadOnly<{|teamname: string, username: string|}>
 type _RemoveMemberOrPendingInvitePayload = $ReadOnly<{|email: string, teamname: string, username: string, inviteID: string|}>
 type _RemoveParticipantPayload = $ReadOnly<{|teamname: string, conversationIDKey: ChatTypes.ConversationIDKey, participant: string|}>
 type _SaveChannelMembershipPayload = $ReadOnly<{|teamname: string, oldChannelState: Types.ChannelMembershipState, newChannelState: Types.ChannelMembershipState, you: string|}>
@@ -185,6 +187,7 @@ export const createInviteToTeamByEmail = (payload: _InviteToTeamByEmailPayload) 
 export const createInviteToTeamByPhone = (payload: _InviteToTeamByPhonePayload) => ({payload, type: inviteToTeamByPhone})
 export const createJoinTeam = (payload: _JoinTeamPayload) => ({payload, type: joinTeam})
 export const createLeaveTeam = (payload: _LeaveTeamPayload) => ({payload, type: leaveTeam})
+export const createReAddToTeam = (payload: _ReAddToTeamPayload) => ({payload, type: reAddToTeam})
 export const createRemoveMemberOrPendingInvite = (payload: _RemoveMemberOrPendingInvitePayload) => ({payload, type: removeMemberOrPendingInvite})
 export const createRemoveParticipant = (payload: _RemoveParticipantPayload) => ({payload, type: removeParticipant})
 export const createSaveChannelMembership = (payload: _SaveChannelMembershipPayload) => ({payload, type: saveChannelMembership})
@@ -248,6 +251,7 @@ export type InviteToTeamByPhonePayload = {|+payload: _InviteToTeamByPhonePayload
 export type JoinTeamPayload = {|+payload: _JoinTeamPayload, +type: 'teams:joinTeam'|}
 export type LeaveTeamPayload = {|+payload: _LeaveTeamPayload, +type: 'teams:leaveTeam'|}
 export type LeftTeamPayload = {|+payload: _LeftTeamPayload, +type: 'teams:leftTeam'|}
+export type ReAddToTeamPayload = {|+payload: _ReAddToTeamPayload, +type: 'teams:reAddToTeam'|}
 export type RemoveMemberOrPendingInvitePayload = {|+payload: _RemoveMemberOrPendingInvitePayload, +type: 'teams:removeMemberOrPendingInvite'|}
 export type RemoveParticipantPayload = {|+payload: _RemoveParticipantPayload, +type: 'teams:removeParticipant'|}
 export type SaveChannelMembershipPayload = {|+payload: _SaveChannelMembershipPayload, +type: 'teams:saveChannelMembership'|}
@@ -314,6 +318,7 @@ export type Actions =
   | JoinTeamPayload
   | LeaveTeamPayload
   | LeftTeamPayload
+  | ReAddToTeamPayload
   | RemoveMemberOrPendingInvitePayload
   | RemoveParticipantPayload
   | SaveChannelMembershipPayload

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -323,6 +323,27 @@ const addToTeam = (_, action) => {
     })
 }
 
+const reAddToTeam = (state, action) => {
+  const {teamname, username} = action.payload
+  return RPCTypes.teamsTeamReAddMemberAfterResetRpcPromise(
+    {
+      id: state.teams.teamNameToID.get(teamname, ''),
+      username,
+    },
+    [Constants.teamWaitingKey(teamname), Constants.addMemberWaitingKey(teamname, username)]
+  )
+    .then(() => {})
+    .catch(e => {
+      // identify error
+      if (e.code === RPCTypes.constantsStatusCode.scidentifysummaryerror) {
+        if (isMobile) {
+          // show profile card on mobile
+          return ProfileGen.createShowUserProfile({username})
+        }
+      }
+    })
+}
+
 const editDescription = (_, action) => {
   const {teamname, description} = action.payload
   return RPCTypes.teamsSetTeamShowcaseRpcPromise(
@@ -1459,6 +1480,7 @@ const teamsSaga = function*(): Saga.SagaGenerator<any, any> {
   )
   yield* Saga.chainGenerator<TeamsGen.CreateChannelPayload>(TeamsGen.createChannel, createChannel)
   yield* Saga.chainAction<TeamsGen.AddToTeamPayload>(TeamsGen.addToTeam, addToTeam)
+  yield* Saga.chainAction<TeamsGen.ReAddToTeamPayload>(TeamsGen.reAddToTeam, reAddToTeam)
   yield* Saga.chainAction<TeamsGen.AddPeopleToTeamPayload>(TeamsGen.addPeopleToTeam, addPeopleToTeam)
   yield* Saga.chainGenerator<TeamsGen.AddUserToTeamsPayload>(TeamsGen.addUserToTeams, addUserToTeams)
   yield* Saga.chainGenerator<TeamsGen.InviteToTeamByEmailPayload>(TeamsGen.inviteToTeamByEmail, inviteByEmail)

--- a/shared/reducers/teams.js
+++ b/shared/reducers/teams.js
@@ -126,6 +126,7 @@ const rootReducer = (state: Types.State = initialState, action: TeamsGen.Actions
     case TeamsGen.addPeopleToTeam:
     case TeamsGen.addUserToTeams:
     case TeamsGen.addToTeam:
+    case TeamsGen.reAddToTeam:
     case TeamsGen.badgeAppForTeams:
     case TeamsGen.checkRequestedAccess:
     case TeamsGen.createChannel:

--- a/shared/teams/team/members-tab/member-row/container.js
+++ b/shared/teams/team/members-tab/member-row/container.js
@@ -1,6 +1,5 @@
 // @flow
 import * as Constants from '../../../../constants/teams'
-import * as Types from '../../../../constants/types/teams'
 import * as TeamsGen from '../../../../actions/teams-gen'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as TrackerGen from '../../../../actions/tracker-gen'
@@ -36,7 +35,7 @@ const mapStateToProps = (state, {teamname, username}: OwnProps) => {
 }
 
 type DispatchProps = {
-  _onReAddToTeam: (teamname: string, username: string, role: Types.TeamRoleType) => void,
+  _onReAddToTeam: (teamname: string, username: string) => void,
   _onRemoveFromTeam: (teamname: string, username: string) => void,
   _onShowTracker: (username: string) => void,
   onChat: () => void,
@@ -44,11 +43,9 @@ type DispatchProps = {
 }
 
 const mapDispatchToProps = (dispatch, ownProps: OwnProps): DispatchProps => ({
-  _onReAddToTeam: (teamname: string, username: string, role: Types.TeamRoleType) => {
+  _onReAddToTeam: (teamname: string, username: string) => {
     dispatch(
-      TeamsGen.createAddToTeam({
-        role: role,
-        sendChatNotification: false,
+      TeamsGen.createReAddToTeam({
         teamname,
         username,
       })
@@ -77,8 +74,7 @@ const mergeProps = (stateProps, dispatchProps: DispatchProps, ownProps: OwnProps
     fullName: stateProps.fullName,
     onChat: dispatchProps.onChat,
     onClick: dispatchProps.onClick,
-    onReAddToTeam: () =>
-      dispatchProps._onReAddToTeam(ownProps.teamname, ownProps.username, stateProps.roleType),
+    onReAddToTeam: () => dispatchProps._onReAddToTeam(ownProps.teamname, ownProps.username),
     onRemoveFromTeam: () => dispatchProps._onRemoveFromTeam(ownProps.teamname, ownProps.username),
     onShowTracker: () => dispatchProps._onShowTracker(ownProps.username),
     roleType: stateProps.roleType,


### PR DESCRIPTION
The gui uses `teamReAddMemberAfterReset` for the "Re-admit" button. That RPC doesn't take the role so it has leeway to figure out that when an admin is re-adding an owner they should re-add them as an admin. Since that's the best an admin can do.

Make ReAdd on the service actually do that.

Add tests for re-adding reset owners.