### PR TITLE
Team sigchain stricter checks on owner invites

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1705,8 +1705,11 @@ func assertIsKeybaseInvite(g *libkb.GlobalContext, i SCTeamInvite) bool {
 // They slipped in before that was banned. They are excepted from the rule.
 var hardcodedInviteRuleExceptionSigIDs = map[keybase1.SigID]bool{
 	"c06e8da2959d8c8054fb10e005910716f776b3c3df9ef2eb4c4b8584f45e187f22": true,
+	"c06e8da2959d8c8054fb10e005910716f776b3c3df9ef2eb4c4b8584f45e187f0f": true,
 	"e800db474fa75f39503e9241990c3707121c7c414687a7b1f5ef579a625eaf8222": true,
+	"e800db474fa75f39503e9241990c3707121c7c414687a7b1f5ef579a625eaf820f": true,
 	"46d9f2700b8d4287a2dc46dae00974a794b5778149214cf91fa4b69229a6abbc22": true,
+	"46d9f2700b8d4287a2dc46dae00974a794b5778149214cf91fa4b69229a6abbc0f": true,
 }
 
 // sanityCheckInvites sanity checks a raw SCTeamInvites section and coerces it into a
@@ -1738,6 +1741,7 @@ func (t *teamSigchainPlayer) sanityCheckInvites(
 				return nil, nil, fmt.Errorf("encountered invite of owner in non-root team")
 			}
 			if !signerIsExplicitOwner {
+				fmt.Printf("xxx sigID: %v\n", sigID)
 				if !hardcodedInviteRuleExceptionSigIDs[sigID] {
 					return nil, nil, fmt.Errorf("encountered invite of owner by non-owner")
 				}

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1741,7 +1741,6 @@ func (t *teamSigchainPlayer) sanityCheckInvites(
 				return nil, nil, fmt.Errorf("encountered invite of owner in non-root team")
 			}
 			if !signerIsExplicitOwner {
-				fmt.Printf("xxx sigID: %v\n", sigID)
 				if !hardcodedInviteRuleExceptionSigIDs[sigID] {
 					return nil, nil, fmt.Errorf("encountered invite of owner by non-owner")
 				}

--- a/go/teams/loader_types.go
+++ b/go/teams/loader_types.go
@@ -96,33 +96,19 @@ func unpackChainLink(link *SCChainLink) (*ChainLinkUnpacked, error) {
 	return ret, nil
 }
 
-func (l *ChainLinkUnpacked) Seqno() keybase1.Seqno {
-	return l.outerLink.Seqno
-}
+func (l *ChainLinkUnpacked) Seqno() keybase1.Seqno { return l.outerLink.Seqno }
 
-func (l *ChainLinkUnpacked) SeqType() keybase1.SeqType {
-	return l.outerLink.SeqType
-}
+func (l *ChainLinkUnpacked) SeqType() keybase1.SeqType { return l.outerLink.SeqType }
 
-func (l *ChainLinkUnpacked) Prev() libkb.LinkID {
-	return l.outerLink.Prev
-}
+func (l *ChainLinkUnpacked) Prev() libkb.LinkID { return l.outerLink.Prev }
 
-func (l *ChainLinkUnpacked) LinkID() libkb.LinkID {
-	return l.outerLink.LinkID()
-}
+func (l *ChainLinkUnpacked) LinkID() libkb.LinkID { return l.outerLink.LinkID() }
 
-func (l *ChainLinkUnpacked) SigID() keybase1.SigID {
-	return l.outerLink.SigID()
-}
+func (l *ChainLinkUnpacked) SigID() keybase1.SigID { return l.outerLink.SigID() }
 
-func (l *ChainLinkUnpacked) LinkType() libkb.SigchainV2Type {
-	return l.outerLink.LinkType
-}
+func (l *ChainLinkUnpacked) LinkType() libkb.SigchainV2Type { return l.outerLink.LinkType }
 
-func (l *ChainLinkUnpacked) isStubbed() bool {
-	return l.inner == nil
-}
+func (l *ChainLinkUnpacked) isStubbed() bool { return l.inner == nil }
 
 func (l ChainLinkUnpacked) SignatureMetadata() keybase1.SignatureMetadata {
 	return l.inner.SignatureMetadata()
@@ -139,6 +125,8 @@ func (l ChainLinkUnpacked) LinkTriple() keybase1.LinkTriple {
 		LinkID:  l.LinkID().Export(),
 	}
 }
+
+func (s ChainLinkUnpacked) TeamAdmin() *SCTeamAdmin { return s.inner.TeamAdmin() }
 
 func (i *SCChainLinkPayload) SignatureMetadata() keybase1.SignatureMetadata {
 	return keybase1.SignatureMetadata{

--- a/go/teams/loader_types.go
+++ b/go/teams/loader_types.go
@@ -126,7 +126,7 @@ func (l ChainLinkUnpacked) LinkTriple() keybase1.LinkTriple {
 	}
 }
 
-func (s ChainLinkUnpacked) TeamAdmin() *SCTeamAdmin { return s.inner.TeamAdmin() }
+func (l ChainLinkUnpacked) TeamAdmin() *SCTeamAdmin { return l.inner.TeamAdmin() }
 
 func (i *SCChainLinkPayload) SignatureMetadata() keybase1.SignatureMetadata {
 	return keybase1.SignatureMetadata{

--- a/go/tools/teamchain/main.go
+++ b/go/tools/teamchain/main.go
@@ -29,7 +29,12 @@ func main2() (err error) {
 		return fmt.Errorf("Usage: tool <jsonfile>")
 	}
 	filepath := os.Args[1]
-	cf, err := readChainFile(filepath)
+	var cf ChainFile
+	if filepath == "-" {
+		cf, err = readChainStdin()
+	} else {
+		cf, err = readChainFile(filepath)
+	}
 	if err != nil {
 		return err
 	}
@@ -55,6 +60,11 @@ func main2() (err error) {
 	}
 	fmt.Printf("%v\n", spew.Sdump(state))
 	return nil
+}
+
+func readChainStdin() (res ChainFile, err error) {
+	err = json.NewDecoder(os.Stdin).Decode(&res)
+	return res, err
 }
 
 func readChainFile(path string) (res ChainFile, err error) {

--- a/go/tools/teamchain/main.go
+++ b/go/tools/teamchain/main.go
@@ -51,7 +51,9 @@ func main2() (err error) {
 			return err
 		}
 
-		signerX := teams.NewSignerX(keybase1.NewUserVersion(prelink.UID, prelink.EldestSeqno), false)
+		implicitAdmin := link.TeamAdmin() != nil // Assume all admin claims are OK.
+		signerX := teams.NewSignerX(
+			keybase1.NewUserVersion(prelink.UID, prelink.EldestSeqno), implicitAdmin)
 		newState, err := teams.AppendChainLink(mctx.Ctx(), g, reader, state, link, &signerX)
 		if err != nil {
 			return err

--- a/go/tools/teamchain/main.go
+++ b/go/tools/teamchain/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 
@@ -25,10 +26,16 @@ func main() {
 }
 
 func main2() (err error) {
-	if len(os.Args) != 2 {
-		return fmt.Errorf("Usage: tool <jsonfile>")
+	var silent bool
+	flag.BoolVar(&silent, "silent", false, "print nothing")
+	var filepath string
+	flag.StringVar(&filepath, "path", "", "path to file containing json team chain")
+	flag.Parse()
+	if filepath == "" {
+		flag.Usage()
+		return fmt.Errorf("missing required path flag")
 	}
-	filepath := os.Args[1]
+
 	var cf ChainFile
 	if filepath == "-" {
 		cf, err = readChainStdin()
@@ -60,7 +67,9 @@ func main2() (err error) {
 		}
 		state = &newState
 	}
-	fmt.Printf("%v\n", spew.Sdump(state))
+	if !silent {
+		fmt.Printf("%v\n", spew.Sdump(state))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Non-owners can't invite owners. If this is wrong or disagrees with the real wild world, then teams will be unloadable. Better block these shenanigans on the server and scan existing teams. I don't want to merge this until those are done.