### PR TITLE
conflict_resolver: use a disk-based fileBlockMap

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -2252,10 +2252,6 @@ func (cr *ConflictResolver) computeActions(ctx context.Context,
 	return actionMap, append(newUnmergedPaths, moreNewUnmergedPaths...), nil
 }
 
-// fileBlockMap maps latest merged block pointer to a map of final
-// merged name -> file block.
-type fileBlockMap map[BlockPointer]map[string]*FileBlock
-
 func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	lState *lockState, chains *crChains, mergedMostRecent BlockPointer,
 	parentPath path, name string, ptr BlockPointer, blocks fileBlockMap,
@@ -2302,15 +2298,15 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 		}
 	}
 
-	if _, ok := blocks[mergedMostRecent]; !ok {
-		blocks[mergedMostRecent] = make(map[string]*FileBlock)
+	err = blocks.putTopBlock(ctx, mergedMostRecent, name, fblock)
+	if err != nil {
+		return BlockPointer{}, err
 	}
 
 	for _, childPtr := range allChildPtrs {
 		chains.createdOriginals[childPtr] = true
 	}
 
-	blocks[mergedMostRecent][name] = fblock
 	return newPtr, nil
 }
 
@@ -3537,7 +3533,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 		// nothing to do
 		cr.log.CDebugf(ctx, "No updates to resolve, so finishing")
 		lbc := make(localBcache)
-		newFileBlocks := make(fileBlockMap)
+		newFileBlocks := newFileBlockMapMemory()
 		bps := newBlockPutStateMemory(0)
 		err = cr.completeResolution(ctx, lState, unmergedChains,
 			mergedChains, unmergedPaths, mergedPaths,
@@ -3622,7 +3618,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	// sync.  If a block is indirect, we need to put it and add new
 	// references for all indirect pointers inside it.  If it is not
 	// an indirect block, just add a new reference to the block.
-	newFileBlocks := make(fileBlockMap)
+	newFileBlocks := newFileBlockMapMemory()
 	dbc, cleanupFn, err := cr.makeDiskBlockCache(ctx)
 	if err != nil {
 		return

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3618,7 +3618,6 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	// sync.  If a block is indirect, we need to put it and add new
 	// references for all indirect pointers inside it.  If it is not
 	// an indirect block, just add a new reference to the block.
-	newFileBlocks := newFileBlockMapMemory()
 	dbc, cleanupFn, err := cr.makeDiskBlockCache(ctx)
 	if err != nil {
 		return
@@ -3628,6 +3627,8 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	}
 	dirtyBcache := newDirtyBlockCacheDisk(
 		cr.config, dbc, mergedChains.mostRecentChainMDInfo, cr.fbo.branch())
+	newFileBlocks := newFileBlockMapDisk(
+		dirtyBcache, mergedChains.mostRecentChainMDInfo)
 
 	err = cr.doActions(ctx, lState, unmergedChains, mergedChains,
 		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks, dirtyBcache)

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -1293,7 +1293,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 	}
 
 	lbc := make(localBcache)
-	newFileBlocks := make(fileBlockMap)
+	newFileBlocks := newFileBlockMapMemory()
 	dirtyBcache := simpleDirtyBlockCacheStandard()
 	err = cr2.doActions(ctx, lState, unmergedChains, mergedChains,
 		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks, dirtyBcache)
@@ -1315,7 +1315,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 			t.Errorf("Couldn't find entry in merged children: %s", file)
 		}
 	}
-	if len(newFileBlocks) != 0 {
+	if len(newFileBlocks.blocks) != 0 {
 		t.Errorf("Unexpected new file blocks!")
 	}
 }
@@ -1416,7 +1416,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 	}
 
 	lbc := make(localBcache)
-	newFileBlocks := make(fileBlockMap)
+	newFileBlocks := newFileBlockMapMemory()
 	dirtyBcache := simpleDirtyBlockCacheStandard()
 	err = cr2.doActions(ctx, lState, unmergedChains, mergedChains,
 		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks, dirtyBcache)
@@ -1428,10 +1428,10 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 	mergedRootPath := cr1.fbo.nodeCache.PathFromNode(dir1)
 	cre := WriterDeviceDateConflictRenamer{}
 	mergedName := cre.ConflictRenameHelper(now, "u2", "dev1", "file")
-	if len(newFileBlocks) != 1 {
+	if len(newFileBlocks.blocks) != 1 {
 		t.Errorf("Unexpected new file blocks!")
 	}
-	if blocks, ok := newFileBlocks[mergedRootPath.tailPointer()]; !ok {
+	if blocks, ok := newFileBlocks.blocks[mergedRootPath.tailPointer()]; !ok {
 		t.Errorf("No blocks for dir merged ptr: %v",
 			mergedRootPath.tailPointer())
 	} else if len(blocks) != 1 {

--- a/go/kbfs/libkbfs/file_block_map_disk.go
+++ b/go/kbfs/libkbfs/file_block_map_disk.go
@@ -1,0 +1,95 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/kbfs/kbfsblock"
+	"github.com/pkg/errors"
+)
+
+// fileBlockMapDisk tracks block info while making a revision, by
+// using a disk-based block cache.
+type fileBlockMapDisk struct {
+	dirtyBcache *DirtyBlockCacheDisk
+	kmd         KeyMetadata
+	ptrs        map[BlockPointer]map[string]BlockPointer
+}
+
+var _ fileBlockMap = (*fileBlockMapDisk)(nil)
+
+func newFileBlockMapDisk(
+	dirtyBcache *DirtyBlockCacheDisk, kmd KeyMetadata) *fileBlockMapDisk {
+	return &fileBlockMapDisk{
+		dirtyBcache: dirtyBcache,
+		kmd:         kmd,
+		ptrs:        make(map[BlockPointer]map[string]BlockPointer),
+	}
+}
+
+func (fbmd *fileBlockMapDisk) putTopBlock(
+	ctx context.Context, parentPtr BlockPointer, childName string,
+	topBlock *FileBlock) error {
+	// To reuse the DirtyBlockCacheDisk code, we need to assign a
+	// random BlockPointer to this block.
+	id, err := kbfsblock.MakeTemporaryID()
+	if err != nil {
+		return err
+	}
+	ptr := BlockPointer{ID: id}
+
+	err = fbmd.dirtyBcache.Put(
+		ctx, fbmd.kmd.TlfID(), ptr, MasterBranch, topBlock)
+	if err != nil {
+		return err
+	}
+
+	ptrMap, ok := fbmd.ptrs[parentPtr]
+	if !ok {
+		ptrMap = make(map[string]BlockPointer)
+		fbmd.ptrs[parentPtr] = ptrMap
+	}
+
+	ptrMap[childName] = ptr
+	return nil
+}
+
+func (fbmd *fileBlockMapDisk) getTopBlock(
+	ctx context.Context, parentPtr BlockPointer, childName string) (
+	*FileBlock, error) {
+	ptrMap, ok := fbmd.ptrs[parentPtr]
+	if !ok {
+		return nil, errors.Errorf("No such parent %s", parentPtr)
+	}
+	ptr, ok := ptrMap[childName]
+	if !ok {
+		return nil, errors.Errorf(
+			"No such name %s in parent %s", childName, parentPtr)
+	}
+	block, err := fbmd.dirtyBcache.Get(ctx, fbmd.kmd.TlfID(), ptr, MasterBranch)
+	if err != nil {
+		return nil, err
+	}
+	fblock, ok := block.(*FileBlock)
+	if !ok {
+		return nil, errors.Errorf(
+			"Unexpected block type for file block: %T", block)
+	}
+	return fblock, nil
+}
+
+func (fbmd *fileBlockMapDisk) getFilenames(
+	_ context.Context, parentPtr BlockPointer) (names []string, err error) {
+	ptrMap, ok := fbmd.ptrs[parentPtr]
+	if !ok {
+		return nil, nil
+	}
+	names = make([]string, 0, len(ptrMap))
+	for name := range ptrMap {
+		names = append(names, name)
+	}
+	return names, nil
+}

--- a/go/kbfs/libkbfs/file_block_map_memory.go
+++ b/go/kbfs/libkbfs/file_block_map_memory.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// fileBlockMapMemory is an internal structure to track file block
+// data in memory when putting blocks.
+type fileBlockMapMemory struct {
+	blocks map[BlockPointer]map[string]*FileBlock
+}
+
+var _ fileBlockMap = (*fileBlockMapMemory)(nil)
+
+func newFileBlockMapMemory() *fileBlockMapMemory {
+	return &fileBlockMapMemory{make(map[BlockPointer]map[string]*FileBlock)}
+}
+
+func (fbmm *fileBlockMapMemory) putTopBlock(
+	_ context.Context, parentPtr BlockPointer, childName string,
+	topBlock *FileBlock) error {
+	nameMap, ok := fbmm.blocks[parentPtr]
+	if !ok {
+		nameMap = make(map[string]*FileBlock)
+		fbmm.blocks[parentPtr] = nameMap
+	}
+	nameMap[childName] = topBlock
+	return nil
+}
+
+func (fbmm *fileBlockMapMemory) getTopBlock(
+	_ context.Context, parentPtr BlockPointer, childName string) (
+	*FileBlock, error) {
+	nameMap, ok := fbmm.blocks[parentPtr]
+	if !ok {
+		return nil, errors.Errorf("No such parent %s", parentPtr)
+	}
+	block, ok := nameMap[childName]
+	if !ok {
+		return nil, errors.Errorf(
+			"No such name %s in parent %s", childName, parentPtr)
+	}
+	return block, nil
+}
+
+func (fbmm *fileBlockMapMemory) getFilenames(
+	_ context.Context, parentPtr BlockPointer) (names []string, err error) {
+	nameMap, ok := fbmm.blocks[parentPtr]
+	if !ok {
+		return nil, nil
+	}
+	names = make([]string, 0, len(nameMap))
+	for name := range nameMap {
+		names = append(names, name)
+	}
+	return names, nil
+}

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5267,7 +5267,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	fbo.log.LazyTrace(ctx, "Processing %d op(s)", len(fbo.dirOps))
 
 	newBlocks := make(map[BlockPointer]bool)
-	fileBlocks := make(fileBlockMap)
+	fileBlocks := newFileBlockMapMemory()
 	parentsToAddChainsFor := make(map[BlockPointer]bool)
 	for _, dop := range fbo.dirOps {
 		// Copy the op before modifying it, in case there's an error
@@ -5429,10 +5429,10 @@ func (fbo *folderBranchOps) syncAllLocked(
 		}
 		resolvedPaths[file.tailPointer()] = file
 		parent := file.parentPath().tailPointer()
-		if _, ok := fileBlocks[parent]; !ok {
-			fileBlocks[parent] = make(map[string]*FileBlock)
+		err = fileBlocks.putTopBlock(ctx, parent, file.tailName(), fblock)
+		if err != nil {
+			return err
 		}
-		fileBlocks[parent][file.tailName()] = fblock
 
 		// Collect its `afterUpdateFn` along with all the others, so
 		// they all get invoked under the same lock, to avoid any

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2766,3 +2766,13 @@ type blockPutStateCopiable interface {
 		ctx context.Context, blacklist map[BlockPointer]bool) (
 		blockPutStateCopiable, error)
 }
+
+type fileBlockMap interface {
+	putTopBlock(
+		ctx context.Context, parentPtr BlockPointer, childName string,
+		topBlock *FileBlock) error
+	getTopBlock(
+		ctx context.Context, parentPtr BlockPointer, childName string) (
+		*FileBlock, error)
+	getFilenames(ctx context.Context, parentPtr BlockPointer) ([]string, error)
+}

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -11310,3 +11310,70 @@ func (mr *MockblockPutStateCopiableMockRecorder) deepCopyWithBlacklist(ctx, blac
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deepCopyWithBlacklist", reflect.TypeOf((*MockblockPutStateCopiable)(nil).deepCopyWithBlacklist), ctx, blacklist)
 }
+
+// MockfileBlockMap is a mock of fileBlockMap interface
+type MockfileBlockMap struct {
+	ctrl     *gomock.Controller
+	recorder *MockfileBlockMapMockRecorder
+}
+
+// MockfileBlockMapMockRecorder is the mock recorder for MockfileBlockMap
+type MockfileBlockMapMockRecorder struct {
+	mock *MockfileBlockMap
+}
+
+// NewMockfileBlockMap creates a new mock instance
+func NewMockfileBlockMap(ctrl *gomock.Controller) *MockfileBlockMap {
+	mock := &MockfileBlockMap{ctrl: ctrl}
+	mock.recorder = &MockfileBlockMapMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockfileBlockMap) EXPECT() *MockfileBlockMapMockRecorder {
+	return m.recorder
+}
+
+// putTopBlock mocks base method
+func (m *MockfileBlockMap) putTopBlock(ctx context.Context, parentPtr BlockPointer, childName string, topBlock *FileBlock) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "putTopBlock", ctx, parentPtr, childName, topBlock)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// putTopBlock indicates an expected call of putTopBlock
+func (mr *MockfileBlockMapMockRecorder) putTopBlock(ctx, parentPtr, childName, topBlock interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "putTopBlock", reflect.TypeOf((*MockfileBlockMap)(nil).putTopBlock), ctx, parentPtr, childName, topBlock)
+}
+
+// getTopBlock mocks base method
+func (m *MockfileBlockMap) getTopBlock(ctx context.Context, parentPtr BlockPointer, childName string) (*FileBlock, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getTopBlock", ctx, parentPtr, childName)
+	ret0, _ := ret[0].(*FileBlock)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getTopBlock indicates an expected call of getTopBlock
+func (mr *MockfileBlockMapMockRecorder) getTopBlock(ctx, parentPtr, childName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getTopBlock", reflect.TypeOf((*MockfileBlockMap)(nil).getTopBlock), ctx, parentPtr, childName)
+}
+
+// getFilenames mocks base method
+func (m *MockfileBlockMap) getFilenames(ctx context.Context, parentPtr BlockPointer) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getFilenames", ctx, parentPtr)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getFilenames indicates an expected call of getFilenames
+func (mr *MockfileBlockMapMockRecorder) getFilenames(ctx, parentPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getFilenames", reflect.TypeOf((*MockfileBlockMap)(nil).getFilenames), ctx, parentPtr)
+}


### PR DESCRIPTION
This stores the top block for each file in a disk cache, to help the case where there are tons of files being CR'd.

Issue: KBFS-3852