### PR TITLE
Keep track of pending message as being explosive

### DIFF
--- a/shared/constants/chat2/message.js
+++ b/shared/constants/chat2/message.js
@@ -865,6 +865,7 @@ const outboxUIMessagetoMessage = (
         deviceName: state.config.deviceName || '',
         deviceType: isMobile ? 'mobile' : 'desktop',
         errorReason,
+        exploding: o.isEphemeral,
         ordinal: Types.numberToOrdinal(o.ordinal),
         outboxID: Types.stringToOutboxID(o.outboxID),
         submitState: 'pending',


### PR DESCRIPTION
Connects the other side of this: https://github.com/keybase/client/pull/15962

Before this we lost the information that the message was exploding until after it was sent. This meant that we added the exploding meta content only on send. This led to a visible jump as the text was rearranged on mobile.

This doesn't happen anymore because we now know the pending message is an exploding one, so we can reserve space for the exploding meta contents.