### PR TITLE
Replace smart apostrophes and dashes in device names

### DIFF
--- a/go/client/prompter.go
+++ b/go/client/prompter.go
@@ -4,8 +4,9 @@
 package client
 
 import (
-	"github.com/keybase/client/go/libkb"
 	"strings"
+
+	"github.com/keybase/client/go/libkb"
 )
 
 type Field struct {
@@ -112,6 +113,10 @@ func (p *Prompter) ReadField(f *Field) (err error) {
 			}
 		}
 		if f.Checker != nil {
+			if f.Checker.Transform != nil {
+				val = f.Checker.Transform(val)
+			}
+
 			done = f.Checker.F(val)
 		} else {
 			done = true

--- a/go/client/provision_ui.go
+++ b/go/client/provision_ui.go
@@ -277,7 +277,6 @@ func (p ProvisionUI) PromptNewDeviceName(ctx context.Context, arg keybase1.Promp
 	p.parent.Output("\n\n\n")
 
 	for i := 0; i < 10; i++ {
-
 		name, err := PromptWithChecker(PromptDescriptorProvisionDeviceName, p.parent, "Enter a public name for this device", false, libkb.CheckDeviceName)
 		if err != nil {
 			return "", err

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -952,6 +952,9 @@ func PromptWithChecker(pd libkb.PromptDescriptor, ui libkb.TerminalUI, prompt st
 		}
 		p = p + ": "
 		res, err = prompter(p)
+		if err == nil && checker.Transform != nil {
+			res = checker.Transform(res)
+		}
 		if err != nil || checker.F(res) {
 			break
 		}

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -518,6 +518,7 @@ func (e *loginProvision) deviceName(m libkb.MetaContext) (string, error) {
 			arg.ErrorMessage = "Invalid device name. Device names should be " + libkb.CheckDeviceName.Hint
 			continue
 		}
+		devname = libkb.CheckDeviceName.Transform(devname)
 		duplicate := false
 		for _, name := range names {
 			if devname == name {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -3515,6 +3515,33 @@ func TestBeforeResetDeviceName(t *testing.T) {
 	}
 }
 
+func TestProvisioningWithSmartPunctuationDeviceName(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+
+	fu := NewFakeUserOrBust(tc.T, "login")
+	tc.G.Log.Debug("New test user: %s / %s", fu.Username, fu.Email)
+
+	arg := MakeTestSignupEngineRunArg(fu)
+	desiredName := arg.DeviceName + "'s test's cool-thing-device"
+	arg.DeviceName = arg.DeviceName + "’s test‘s cool—thing–device"
+	SignupFakeUserWithArg(tc, fu, arg)
+	fu.LoginOrBust(tc)
+	if err := fu.LoadUser(tc); err != nil {
+		t.Errorf("unable to load user: %q", err)
+	}
+	deviceNames, err := fu.User.DeviceNames()
+	if err != nil {
+		t.Errorf("unable to list device names: %q", err)
+	}
+	if len(deviceNames) < 1 {
+		t.Error("no devices returned")
+	}
+	if deviceNames[0] != desiredName {
+		t.Errorf("device name 0: %q, should be %q", deviceNames[0], desiredName)
+	}
+}
+
 type testProvisionUI struct {
 	secretCh               chan kex2.Secret
 	method                 keybase1.ProvisionMethod

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -232,7 +232,7 @@ func (s *SignupEngine) registerDevice(m libkb.MetaContext, deviceName string) er
 	s.lks = libkb.NewLKSec(s.ppStream, s.uid)
 	args := &DeviceWrapArgs{
 		Me:         s.me,
-		DeviceName: deviceName,
+		DeviceName: libkb.CheckDeviceName.Transform(deviceName),
 		Lks:        s.lks,
 		IsEldest:   true,
 	}

--- a/go/libkb/checkers.go
+++ b/go/libkb/checkers.go
@@ -14,7 +14,7 @@ import (
 
 var emailRE = regexp.MustCompile(`^\S+@\S+\.\S+$`)
 
-var deviceRE = regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+-]*$`)
+var deviceRE = regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+-—–‘’]*$`)
 var badDeviceRE = regexp.MustCompile(`  |[ '+_-]$|['+_-][ ]?['+_-]`)
 
 var CheckEmail = Checker{
@@ -65,6 +65,13 @@ var CheckInviteCode = Checker{
 var CheckDeviceName = Checker{
 	F: func(s string) bool {
 		return len(s) >= 3 && len(s) <= 64 && deviceRE.MatchString(s) && !badDeviceRE.MatchString(s)
+	},
+	Transform: func(s string) string {
+		s = strings.Replace(s, "—", "-", -1) // em dash
+		s = strings.Replace(s, "–", "-", -1) // en dash
+		s = strings.Replace(s, "‘", "'", -1) // curly quote #1
+		s = strings.Replace(s, "’", "'", -1) // curly quote #2
+		return s
 	},
 	Hint: "between 3 and 64 characters long; use a-Z, 0-9, space, plus, underscore, dash and apostrophe",
 }

--- a/go/libkb/checkers_test.go
+++ b/go/libkb/checkers_test.go
@@ -46,6 +46,7 @@ var deviceNameTests = []checkerTest{
 	{input: "home computer'", valid: false},
 	{input: "home computer_", valid: false},
 	{input: "not😂ascii", valid: false},
+	{input: "John’s iPhone", valid: true},
 }
 
 func TestCheckDeviceName(t *testing.T) {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -328,6 +328,7 @@ type IdentifyUI interface {
 
 type Checker struct {
 	F             func(string) bool
+	Transform     func(string) string
 	Hint          string
 	PreserveSpace bool
 }


### PR DESCRIPTION
Feels slightly hacky but this is indeed the simplest way to accomplish this.

@patrickxb
I'm not 100% about the signup stuff, wrote it just because it looked like it wasn't anyhow related to login provisioning, please correct me if I misinterpreted how it works.