### PR TITLE
move disklru to libkb

### DIFF
--- a/go/.go_package_deps_darwin
+++ b/go/.go_package_deps_darwin
@@ -1994,7 +1994,6 @@
       "github.com/keybase/client/go/uidmap" : 1
    },
    "github.com/keybase/client/go/lru" : {
-      "github.com/keybase/client/go/avatars" : 1,
       "github.com/keybase/client/go/chat" : 1,
       "github.com/keybase/client/go/client" : 1,
       "github.com/keybase/client/go/ephemeral" : 1,

--- a/go/.go_package_deps_linux
+++ b/go/.go_package_deps_linux
@@ -1959,7 +1959,6 @@
       "github.com/keybase/client/go/uidmap" : 1
    },
    "github.com/keybase/client/go/lru" : {
-      "github.com/keybase/client/go/avatars" : 1,
       "github.com/keybase/client/go/chat" : 1,
       "github.com/keybase/client/go/client" : 1,
       "github.com/keybase/client/go/ephemeral" : 1,

--- a/go/.go_package_deps_windows
+++ b/go/.go_package_deps_windows
@@ -1905,7 +1905,6 @@
       "github.com/keybase/client/go/uidmap" : 1
    },
    "github.com/keybase/client/go/lru" : {
-      "github.com/keybase/client/go/avatars" : 1,
       "github.com/keybase/client/go/chat" : 1,
       "github.com/keybase/client/go/client" : 1,
       "github.com/keybase/client/go/ephemeral" : 1,

--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/lru"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -59,7 +58,7 @@ type populateArg struct {
 }
 
 type FullCachingSource struct {
-	diskLRU        *lru.DiskLRU
+	diskLRU        *libkb.DiskLRU
 	staleThreshold time.Duration
 	simpleSource   Source
 
@@ -76,7 +75,7 @@ var _ Source = (*FullCachingSource)(nil)
 
 func NewFullCachingSource(staleThreshold time.Duration, size int) *FullCachingSource {
 	return &FullCachingSource{
-		diskLRU:        lru.NewDiskLRU("avatars", 1, size),
+		diskLRU:        libkb.NewDiskLRU("avatars", 1, size),
 		staleThreshold: staleThreshold,
 		simpleSource:   NewSimpleSource(),
 	}
@@ -103,7 +102,7 @@ func (c *FullCachingSource) avatarKey(name string, format keybase1.AvatarFormat)
 	return fmt.Sprintf("%s:%s", name, format.String())
 }
 
-func (c *FullCachingSource) isStale(m libkb.MetaContext, item lru.DiskLRUEntry) bool {
+func (c *FullCachingSource) isStale(m libkb.MetaContext, item libkb.DiskLRUEntry) bool {
 	return m.G().GetClock().Now().Sub(item.Ctime) > c.staleThreshold
 }
 
@@ -218,7 +217,7 @@ func (c *FullCachingSource) commitAvatarToDisk(m libkb.MetaContext, data io.Read
 	return path, nil
 }
 
-func (c *FullCachingSource) removeFile(m libkb.MetaContext, ent *lru.DiskLRUEntry) {
+func (c *FullCachingSource) removeFile(m libkb.MetaContext, ent *libkb.DiskLRUEntry) {
 	if ent != nil {
 		file := ent.Value.(string)
 		if err := os.Remove(file); err != nil {

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -5,12 +5,11 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/lru"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type URLCachingSource struct {
-	diskLRU        *lru.DiskLRU
+	diskLRU        *libkb.DiskLRU
 	staleThreshold time.Duration
 	simpleSource   *SimpleSource
 
@@ -22,7 +21,7 @@ var _ Source = (*URLCachingSource)(nil)
 
 func NewURLCachingSource(staleThreshold time.Duration, size int) *URLCachingSource {
 	return &URLCachingSource{
-		diskLRU:        lru.NewDiskLRU("avatarurls", 1, size),
+		diskLRU:        libkb.NewDiskLRU("avatarurls", 1, size),
 		staleThreshold: staleThreshold,
 		simpleSource:   NewSimpleSource(),
 	}
@@ -44,7 +43,7 @@ func (c *URLCachingSource) avatarKey(name string, format keybase1.AvatarFormat) 
 	return fmt.Sprintf("%s:%s", name, format.String())
 }
 
-func (c *URLCachingSource) isStale(m libkb.MetaContext, item lru.DiskLRUEntry) bool {
+func (c *URLCachingSource) isStale(m libkb.MetaContext, item libkb.DiskLRUEntry) bool {
 	return m.G().GetClock().Now().Sub(item.Ctime) > c.staleThreshold
 }
 

--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -20,7 +20,6 @@ import (
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/kbhttp"
 	"github.com/keybase/client/go/libkb"
-	disklru "github.com/keybase/client/go/lru"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -482,7 +481,7 @@ type CachingAttachmentFetcher struct {
 	utils.DebugLabeler
 
 	store   attachments.Store
-	diskLRU *disklru.DiskLRU
+	diskLRU *libkb.DiskLRU
 
 	// testing
 	tempDir string
@@ -495,7 +494,7 @@ func NewCachingAttachmentFetcher(g *globals.Context, store attachments.Store, si
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "CachingAttachmentFetcher", false),
 		store:        store,
-		diskLRU:      disklru.NewDiskLRU("attachments", 1, size),
+		diskLRU:      libkb.NewDiskLRU("attachments", 1, size),
 	}
 }
 

--- a/go/libkb/disk_lru_test.go
+++ b/go/libkb/disk_lru_test.go
@@ -1,17 +1,16 @@
-package lru
+package libkb
 
 import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
 func TestDiskLRUBasic(t *testing.T) {
-	tc := libkb.SetupTest(t, "TestDiskLRU", 1)
+	tc := SetupTest(t, "TestDiskLRU", 1)
 	defer tc.Cleanup()
 
 	ctx := context.TODO()
@@ -45,7 +44,7 @@ func TestDiskLRUBasic(t *testing.T) {
 }
 
 func TestDiskLRUVersion(t *testing.T) {
-	tc := libkb.SetupTest(t, "TestDiskLRU", 1)
+	tc := SetupTest(t, "TestDiskLRU", 1)
 	defer tc.Cleanup()
 
 	ctx := context.TODO()
@@ -66,7 +65,7 @@ func TestDiskLRUVersion(t *testing.T) {
 }
 
 func TestDiskLRUEvict(t *testing.T) {
-	tc := libkb.SetupTest(t, "TestDiskLRU", 1)
+	tc := SetupTest(t, "TestDiskLRU", 1)
 	defer tc.Cleanup()
 
 	ctx := context.TODO()
@@ -107,7 +106,7 @@ func TestDiskLRUEvict(t *testing.T) {
 }
 
 func TestDiskLRUFlush(t *testing.T) {
-	tc := libkb.SetupTest(t, "TestDiskLRU", 1)
+	tc := SetupTest(t, "TestDiskLRU", 1)
 	defer tc.Cleanup()
 
 	ctx := context.TODO()


### PR DESCRIPTION
unfortunately leveldb is not separable from libkb and will be using disk_lru for the dbcleaner state 