### PR TITLE
prefetcher: send most debug logs to the verbose debug logger

### DIFF
--- a/go/kbfs/env/context.go
+++ b/go/kbfs/env/context.go
@@ -54,6 +54,7 @@ type Context interface {
 	NewRPCLogFactory() rpc.LogFactory
 	GetKBFSSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error)
 	BindToKBFSSocket() (net.Listener, error)
+	GetVDebugSetting() string
 }
 
 // KBFSContext is an implementation for libkbfs.Context
@@ -262,4 +263,9 @@ func (c *KBFSContext) BindToKBFSSocket() (net.Listener, error) {
 		return nil, err
 	}
 	return c.kbfsSocket.BindToSocket()
+}
+
+// GetVDebugLog returns the verbose debug logger.
+func (c *KBFSContext) GetVDebugSetting() string {
+	return c.g.Env.GetVDebugSetting()
 }

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -14,6 +14,7 @@ import (
 	"github.com/eapache/channels"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -111,6 +112,7 @@ type blockPtrLookup struct {
 type blockRetrievalQueue struct {
 	config blockRetrievalConfig
 	log    logger.Logger
+	vlog   *libkb.VDebugLog
 	// protects ptrs, insertionCount, and the heap
 	mtx sync.RWMutex
 	// queued or in progress retrievals
@@ -158,6 +160,7 @@ func newBlockRetrievalQueue(
 	q := &blockRetrievalQueue{
 		config:           config,
 		log:              config.MakeLogger(""),
+		vlog:             config.MakeVLogger(""),
 		ptrs:             make(map[blockPtrLookup]*blockRetrieval),
 		heap:             &blockRetrievalHeap{},
 		workerCh:         NewInfiniteChannelWrapper(),
@@ -324,10 +327,10 @@ func (brq *blockRetrievalQueue) PutInCaches(ctx context.Context,
 	case NoSuchBlockError:
 		// TODO: Add the block to the DBC. This is complicated because we
 		// need the serverHalf.
-		brq.log.CDebugf(ctx, "Block %s missing for disk block "+
-			"cache metadata update", ptr.ID)
+		brq.vlog.CLogf(ctx, libkb.VLog1,
+			"Block %s missing for disk block cache metadata update", ptr.ID)
 	default:
-		brq.log.CDebugf(ctx, "Error updating metadata: %+v", err)
+		brq.vlog.CLogf(ctx, libkb.VLog1, "Error updating metadata: %+v", err)
 	}
 	// All disk cache errors are fatal
 	return err
@@ -384,10 +387,8 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 func (brq *blockRetrievalQueue) request(ctx context.Context,
 	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
 	lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
-	if action != BlockRequestSolo {
-		brq.log.CDebugf(ctx, "Request of %v, action=%s, priority=%d",
-			ptr, action, priority)
-	}
+	brq.vlog.CLogf(ctx, libkb.VLog1,
+		"Request of %v, action=%s, priority=%d", ptr, action, priority)
 
 	// Only continue if we haven't been shut down
 	ch := make(chan error, 1)
@@ -412,7 +413,8 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block, action)
 	if err == nil {
 		if action != BlockRequestSolo {
-			brq.log.CDebugf(ctx, "Found %v in caches: %s", ptr, prefetchStatus)
+			brq.vlog.CLogf(
+				ctx, libkb.VLog1, "Found %v in caches: %s", ptr, prefetchStatus)
 		}
 		if action.PrefetchTracked() {
 			brq.Prefetcher().ProcessBlockForPrefetch(ctx, ptr, block, kmd,
@@ -469,7 +471,14 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 		}
 		break
 	}
-	brq.log.CDebugf(ctx, "Scheduling request of %v", ptr)
+	if br.index == -1 {
+		// Log newly-scheduled requests via the normal logger, so we
+		// can understand why the bserver fetches certain blocks, and
+		// be able to time the request from start to finish.
+		brq.log.CDebugf(ctx,
+			"Scheduling request of %v, action=%s, priority=%d",
+			ptr, action, priority)
+	}
 	br.reqMtx.Lock()
 	defer br.reqMtx.Unlock()
 	br.requests = append(br.requests, &blockRetrievalRequest{
@@ -503,9 +512,10 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 		}
 	}
 	// Update the action if needed.
-	brq.log.CDebugf(ctx, "Combining actions %d and %d", action, br.action)
+	brq.vlog.CLogf(
+		ctx, libkb.VLog1, "Combining actions %d and %d", action, br.action)
 	br.action = action.Combine(br.action)
-	brq.log.CDebugf(ctx, "Got action %d", br.action)
+	brq.vlog.CLogf(ctx, libkb.VLog2, "Got action %d", br.action)
 	return ch
 }
 

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -32,7 +32,7 @@ func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter,
 	dbc DiskBlockCache) *testBlockRetrievalConfig {
 	return &testBlockRetrievalConfig{
 		newTestCodecGetter(),
-		newTestLogMaker(t),
+		newTestLogMakerWithVDebug(t, "vlog2"),
 		NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity(NewInitModeFromType(InitDefault))),
 		bg,
 		newTestDiskBlockCacheGetter(t, dbc),

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -20,6 +20,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -111,6 +112,7 @@ type ConfigLocal struct {
 	kbCtx              Context
 	rootNodeWrappers   []func(Node) Node
 	tlfClearCancels    map[tlf.ID]context.CancelFunc
+	vdebugSetting      string
 
 	maxNameBytes           uint32
 	rekeyQueue             RekeyQueue
@@ -1082,11 +1084,20 @@ func (c *ConfigLocal) ResetCaches() {
 	}
 }
 
-// MakeLogger implements the Config interface for ConfigLocal.
+// MakeLogger implements the logMaker interface for ConfigLocal.
 func (c *ConfigLocal) MakeLogger(module string) logger.Logger {
 	// No need to lock since c.loggerFn is initialized once at
 	// construction. Also resetCachesWithoutShutdown would deadlock.
 	return c.loggerFn(module)
+}
+
+// MakeVLogger implements the logMaker interface for ConfigLocal.
+func (c *ConfigLocal) MakeVLogger(module string) *libkb.VDebugLog {
+	// No need to lock since c.loggerFn is initialized once at
+	// construction. Also resetCachesWithoutShutdown would deadlock.
+	vlog := libkb.NewVDebugLog(c.loggerFn(module))
+	vlog.Configure(c.vdebugSetting)
+	return vlog
 }
 
 // MetricsRegistry implements the Config interface for ConfigLocal.

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -639,6 +639,7 @@ func doInit(
 			}
 			return lg
 		}, params.StorageRoot, params.DiskCacheMode, kbCtx)
+	config.vdebugSetting = kbCtx.GetVDebugSetting()
 
 	if params.CleanBlockCacheCapacity > 0 {
 		log.CDebugf(

--- a/go/kbfs/libkbfs/interface_test.go
+++ b/go/kbfs/libkbfs/interface_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -26,15 +27,27 @@ func (cg testCodecGetter) Codec() kbfscodec.Codec {
 }
 
 type testLogMaker struct {
-	log logger.Logger
+	log           logger.Logger
+	vdebugSetting string
+}
+
+func newTestLogMakerWithVDebug(
+	t *testing.T, vdebugSetting string) testLogMaker {
+	return testLogMaker{logger.NewTestLogger(t), vdebugSetting}
 }
 
 func newTestLogMaker(t *testing.T) testLogMaker {
-	return testLogMaker{logger.NewTestLogger(t)}
+	return newTestLogMakerWithVDebug(t, "")
 }
 
 func (lm testLogMaker) MakeLogger(_ string) logger.Logger {
 	return lm.log
+}
+
+func (lm testLogMaker) MakeVLogger(_ string) *libkb.VDebugLog {
+	vlog := libkb.NewVDebugLog(lm.log)
+	vlog.Configure(lm.vdebugSetting)
+	return vlog
 }
 
 type testClockGetter struct {

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -29,6 +30,7 @@ type dataVersioner interface {
 
 type logMaker interface {
 	MakeLogger(module string) logger.Logger
+	MakeVLogger(module string) *libkb.VDebugLog
 }
 
 type blockCacher interface {

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4341,6 +4341,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	config.vdebugSetting = "vlog2"
 
 	name := "u1"
 	h, err := ParseTlfHandle(
@@ -4560,6 +4561,7 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.
 	config.mode = modeTest{NewInitModeFromType(InitDefault)}
+	config.vdebugSetting = "vlog2"
 
 	name := "u1"
 	h, err := ParseTlfHandle(

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -13,6 +13,7 @@ import (
 	kbfsmd "github.com/keybase/client/go/kbfs/kbfsmd"
 	tlf "github.com/keybase/client/go/kbfs/tlf"
 	kbun "github.com/keybase/client/go/kbun"
+	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
 	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -95,6 +96,20 @@ func (m *MocklogMaker) MakeLogger(module string) logger.Logger {
 func (mr *MocklogMakerMockRecorder) MakeLogger(module interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLogger", reflect.TypeOf((*MocklogMaker)(nil).MakeLogger), module)
+}
+
+// MakeVLogger mocks base method
+func (m *MocklogMaker) MakeVLogger(module string) *libkb.VDebugLog {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeVLogger", module)
+	ret0, _ := ret[0].(*libkb.VDebugLog)
+	return ret0
+}
+
+// MakeVLogger indicates an expected call of MakeVLogger
+func (mr *MocklogMakerMockRecorder) MakeVLogger(module interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeVLogger", reflect.TypeOf((*MocklogMaker)(nil).MakeVLogger), module)
 }
 
 // MockblockCacher is a mock of blockCacher interface
@@ -9021,6 +9036,20 @@ func (m *MockConfig) MakeLogger(module string) logger.Logger {
 func (mr *MockConfigMockRecorder) MakeLogger(module interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLogger", reflect.TypeOf((*MockConfig)(nil).MakeLogger), module)
+}
+
+// MakeVLogger mocks base method
+func (m *MockConfig) MakeVLogger(module string) *libkb.VDebugLog {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeVLogger", module)
+	ret0, _ := ret[0].(*libkb.VDebugLog)
+	return ret0
+}
+
+// MakeVLogger indicates an expected call of MakeVLogger
+func (mr *MockConfigMockRecorder) MakeVLogger(module interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeVLogger", reflect.TypeOf((*MockConfig)(nil).MakeVLogger), module)
 }
 
 // BlockCache mocks base method


### PR DESCRIPTION
Expose a `MakeVLogger()` method in the config, and use that in the prefetcher and block retrieval queue to send spammy log messages there.  Only turn it on during certain tests that require it.

This improves testing time a little bit.  With current logging:

```sh
src/github.com/keybase/client/go/kbfs/test$ time ./test.test -test.v > /tmp/x 2>&1

real	0m30.997s
user	0m44.824s
sys	0m4.360s
src/github.com/keybase/client/go/kbfs/test$ ls -l /tmp/x
-rw-rw-r-- 1 strib strib 253229687 Feb 12 13:07 /tmp/x
```

With this PR:

```sh
src/github.com/keybase/client/go/kbfs/test$ time ./test.test -test.v > /tmp/y 2>&1

real	0m27.354s
user	0m38.836s
sys	0m4.372s
src/github.com/keybase/client/go/kbfs/test$ ls -l /tmp/y
-rw-rw-r-- 1 strib strib 121987372 Feb 12 13:08 /tmp/y
```

In production, we can turn this on via the `KEYBASE_VDEBUG` environment variable (e.g., `KEYBASE_VDEBUG=vlog1`) or by setting the `vdebug` key in the Keybase config file (e.g., `keybase config set vdebug vlog1` + a restart).

Issue: KBFS-3875