### PR TITLE
Add lock to SeqnoProvider that is held until submit finished

### DIFF
--- a/go/stellar/inflation.go
+++ b/go/stellar/inflation.go
@@ -35,7 +35,8 @@ func SetInflationDestinationLocal(mctx libkb.MetaContext, arg stellar1.SetInflat
 		return fmt.Errorf("Malformed destination account ID: %s", err)
 	}
 
-	sp := NewSeqnoProvider(mctx, walletState)
+	sp, unlock := NewSeqnoProvider(mctx, walletState)
+	defer unlock()
 
 	tb, err := getTimeboundsForSending(mctx, walletState)
 	if err != nil {

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -554,7 +554,7 @@ func sendPayment(mctx libkb.MetaContext, walletState *WalletState, sendArg SendP
 	if recipient.AccountID == nil || sendArg.ForceRelay {
 		return sendRelayPayment(mctx, walletState,
 			senderSeed, recipient, sendArg.Amount, sendArg.DisplayBalance,
-			sendArg.SecretNote, sendArg.PublicMemo, sendArg.QuickReturn)
+			sendArg.SecretNote, sendArg.PublicMemo, sendArg.QuickReturn, senderEntry.IsPrimary)
 	}
 
 	ownRecipient, _, err := OwnAccount(mctx, stellar1.AccountID(recipient.AccountID.String()))
@@ -599,7 +599,8 @@ func sendPayment(mctx libkb.MetaContext, walletState *WalletState, sendArg SendP
 		return res, fmt.Errorf("you must send at least %s XLM to fund the account for %s", minAmountCreateAccountXLM, sendArg.To)
 	}
 
-	sp := NewSeqnoProvider(mctx, walletState)
+	sp, unlock := NewSeqnoProvider(mctx, walletState)
+	defer unlock()
 
 	tb, err := getTimeboundsForSending(mctx, walletState)
 	if err != nil {
@@ -800,7 +801,8 @@ func SendMiniChatPayments(m libkb.MetaContext, walletState *WalletState, convID 
 		return nil, err
 	}
 
-	prepared, err := PrepareMiniChatPayments(m, walletState, senderSeed, convID, payments)
+	prepared, unlock, err := PrepareMiniChatPayments(m, walletState, senderSeed, convID, payments)
+	defer unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -855,13 +857,13 @@ type MiniPrepared struct {
 	Error    error
 }
 
-func PrepareMiniChatPayments(m libkb.MetaContext, walletState *WalletState, senderSeed stellarnet.SeedStr, convID chat1.ConversationID, payments []libkb.MiniChatPayment) ([]*MiniPrepared, error) {
+func PrepareMiniChatPayments(m libkb.MetaContext, walletState *WalletState, senderSeed stellarnet.SeedStr, convID chat1.ConversationID, payments []libkb.MiniChatPayment) ([]*MiniPrepared, func(), error) {
 	prepared := make(chan *MiniPrepared)
 
-	sp := NewSeqnoProvider(m, walletState)
+	sp, unlock := NewSeqnoProvider(m, walletState)
 	tb, err := getTimeboundsForSending(m, walletState)
 	if err != nil {
-		return nil, err
+		return nil, unlock, err
 	}
 
 	for _, payment := range payments {
@@ -877,7 +879,7 @@ func PrepareMiniChatPayments(m libkb.MetaContext, walletState *WalletState, send
 	}
 	sort.Slice(preparedList, func(a, b int) bool { return preparedList[a].Seqno < preparedList[b].Seqno })
 
-	return preparedList, nil
+	return preparedList, unlock, nil
 }
 
 func prepareMiniChatPayment(m libkb.MetaContext, remoter remote.Remoter, sp build.SequenceProvider, tb *build.Timebounds, senderSeed stellarnet.SeedStr, convID chat1.ConversationID, payment libkb.MiniChatPayment) *MiniPrepared {
@@ -1024,7 +1026,7 @@ func prepareMiniChatPaymentRelay(mctx libkb.MetaContext, remoter remote.Remoter,
 // The balance of the relay account can be claimed by either party.
 func sendRelayPayment(mctx libkb.MetaContext, walletState *WalletState,
 	from stellar1.SecretKey, recipient stellarcommon.Recipient, amount string, displayBalance DisplayBalance,
-	secretNote string, publicMemo string, quickReturn bool) (res SendPaymentResult, err error) {
+	secretNote string, publicMemo string, quickReturn bool, senderEntryPrimary bool) (res SendPaymentResult, err error) {
 	defer mctx.CTraceTimed("Stellar.sendRelayPayment", func() error { return err })()
 	appKey, teamID, err := relays.GetKey(mctx, recipient)
 	if err != nil {
@@ -1035,7 +1037,8 @@ func sendRelayPayment(mctx libkb.MetaContext, walletState *WalletState,
 		return res, fmt.Errorf("you must send at least %s XLM to fund the account for %s", minAmountRelayXLM, recipient.Input)
 	}
 
-	sp := NewSeqnoProvider(mctx, walletState)
+	sp, unlock := NewSeqnoProvider(mctx, walletState)
+	defer unlock()
 	tb, err := getTimeboundsForSending(mctx, walletState)
 	if err != nil {
 		return res, err
@@ -1090,9 +1093,20 @@ func sendRelayPayment(mctx libkb.MetaContext, walletState *WalletState,
 		}
 	}
 
-	if err := chatSendPaymentMessage(mctx, recipient, rres.StellarID); err != nil {
-		// if the chat message fails to send, just log the error
-		mctx.CDebugf("failed to send chat SendPayment message: %s", err)
+	if senderEntryPrimary {
+		sendChat := func(mctx libkb.MetaContext) {
+			if err := chatSendPaymentMessage(mctx, recipient, rres.StellarID); err != nil {
+				// if the chat message fails to send, just log the error
+				mctx.CDebugf("failed to send chat SendPayment message: %s", err)
+			}
+		}
+		if post.QuickReturn {
+			go sendChat(mctx.WithCtx(context.Background()))
+		} else {
+			sendChat(mctx)
+		}
+	} else {
+		mctx.CDebugf("not sending chat message (relay): sending from non-primary account")
 	}
 
 	return SendPaymentResult{
@@ -1171,7 +1185,9 @@ func claimPaymentWithDetail(mctx libkb.MetaContext, walletState *WalletState,
 		// Direction from caller
 		useDir = *dir
 	}
-	sp := NewSeqnoProvider(mctx, walletState)
+
+	sp, unlock := NewSeqnoProvider(mctx, walletState)
+	defer unlock()
 	tb, err := getTimeboundsForSending(mctx, walletState)
 	if err != nil {
 		return res, err

--- a/go/stellar/stellarsvc/batch_test.go
+++ b/go/stellar/stellarsvc/batch_test.go
@@ -36,7 +36,8 @@ func TestPrepareBatchRelays(t *testing.T) {
 	senderSeed, err := stellarnet.NewSeedStr(senderAccountBundle.Signers[0].SecureNoLogString())
 	require.NoError(t, err)
 
-	prepared, err := stellar.PrepareBatchPayments(mctx, tc.Srv.walletState, senderSeed, payments)
+	prepared, unlock, err := stellar.PrepareBatchPayments(mctx, tc.Srv.walletState, senderSeed, payments)
+	defer unlock()
 	require.NoError(t, err)
 	require.Len(t, prepared, 2)
 	for i, p := range prepared {
@@ -90,7 +91,8 @@ func TestPrepareBatchLowAmounts(t *testing.T) {
 	senderSeed, err := stellarnet.NewSeedStr(senderAccountBundle.Signers[0].SecureNoLogString())
 	require.NoError(t, err)
 
-	prepared, err := stellar.PrepareBatchPayments(mctx, tc.Srv.walletState, senderSeed, payments)
+	prepared, unlock, err := stellar.PrepareBatchPayments(mctx, tc.Srv.walletState, senderSeed, payments)
+	defer unlock()
 	require.NoError(t, err)
 	require.Len(t, prepared, 2)
 	for i, p := range prepared {

--- a/go/stellar/stellarsvc/minichat_test.go
+++ b/go/stellar/stellarsvc/minichat_test.go
@@ -177,7 +177,8 @@ func TestPrepareMiniChatRelays(t *testing.T) {
 	senderSeed, err := stellarnet.NewSeedStr(senderAccountBundle.Signers[0].SecureNoLogString())
 	require.NoError(t, err)
 
-	prepared, err := stellar.PrepareMiniChatPayments(mctx, tc.Srv.walletState, senderSeed, nil, payments)
+	prepared, unlock, err := stellar.PrepareMiniChatPayments(mctx, tc.Srv.walletState, senderSeed, nil, payments)
+	defer unlock()
 	require.NoError(t, err)
 	require.Len(t, prepared, 2)
 	for i, p := range prepared {
@@ -224,7 +225,8 @@ func TestPrepareMiniChatLowAmounts(t *testing.T) {
 	senderSeed, err := stellarnet.NewSeedStr(senderAccountBundle.Signers[0].SecureNoLogString())
 	require.NoError(t, err)
 
-	prepared, err := stellar.PrepareMiniChatPayments(mctx, tc.Srv.walletState, senderSeed, nil, payments)
+	prepared, unlock, err := stellar.PrepareMiniChatPayments(mctx, tc.Srv.walletState, senderSeed, nil, payments)
+	defer unlock()
 	require.NoError(t, err)
 	require.Len(t, prepared, 2)
 	for i, p := range prepared {

--- a/go/stellar/stellarsvc/seqno_test.go
+++ b/go/stellar/stellarsvc/seqno_test.go
@@ -2,8 +2,12 @@ package stellarsvc
 
 import (
 	"context"
+	"math/rand"
+	"sort"
 	"testing"
+	"time"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar"
 	"github.com/stretchr/testify/require"
@@ -40,16 +44,19 @@ func TestSeqno(t *testing.T) {
 	// is simulating three in-chat send messages starting before the submit
 	// payment happens.
 
-	sp0 := stellar.NewSeqnoProvider(mctx, ws)
+	sp0, unlock := stellar.NewSeqnoProvider(mctx, ws)
 	seqno0, err := sp0.SequenceForAccount(accountID1.String())
+	unlock()
 	require.NoError(t, err)
 
-	sp1 := stellar.NewSeqnoProvider(mctx, ws)
+	sp1, unlock := stellar.NewSeqnoProvider(mctx, ws)
 	seqno1, err := sp1.SequenceForAccount(accountID1.String())
+	unlock()
 	require.NoError(t, err)
 
-	sp2 := stellar.NewSeqnoProvider(mctx, ws)
+	sp2, unlock := stellar.NewSeqnoProvider(mctx, ws)
 	seqno2, err := sp2.SequenceForAccount(accountID1.String())
+	unlock()
 	require.NoError(t, err)
 
 	t.Logf("seqno0: %d", seqno0)
@@ -59,4 +66,48 @@ func TestSeqno(t *testing.T) {
 	require.Equal(t, seqno0+1, seqno1, "seqno1")
 	require.Equal(t, seqno0+2, seqno2, "seqno2")
 
+}
+
+// TestSeqnoConcurrent will check that concurrent seqno attempts
+// arrive at submitpayment in order.
+func TestSeqnoConcurrent(t *testing.T) {
+	tcs, cleanup := setupNTests(t, 1)
+	defer cleanup()
+
+	acceptDisclaimer(tcs[0])
+	rm := tcs[0].Backend
+	accountID1 := rm.AddAccount()
+	err := tcs[0].Srv.ImportSecretKeyLocal(context.Background(), stellar1.ImportSecretKeyLocalArg{
+		SecretKey:   rm.SecretKey(accountID1),
+		MakePrimary: true,
+		Name:        "qq",
+	})
+	require.NoError(t, err)
+
+	ws := tcs[0].Srv.walletState
+	submits := make(chan uint64, 100)
+
+	// fakePayment simulates getting a seqno and then "submitting" that
+	// seqno after a delay.
+	var fakePayment = func(t *testing.T) {
+		mctx := libkb.NewMetaContextBackground(tcs[0].G)
+		sp, unlock := stellar.NewSeqnoProvider(mctx, ws)
+		defer unlock()
+		seqno, err := sp.SequenceForAccount(accountID1.String())
+		require.NoError(t, err)
+		time.Sleep(time.Duration(rand.Intn(50)) * time.Millisecond)
+		submits <- uint64(seqno)
+	}
+
+	numPayments := 10
+	for i := 0; i < numPayments; i++ {
+		go fakePayment(t)
+	}
+
+	seqnos := make([]uint64, numPayments)
+	for i := 0; i < numPayments; i++ {
+		seqnos[i] = <-submits
+	}
+
+	require.True(t, sort.SliceIsSorted(seqnos, func(i, j int) bool { return seqnos[i] < seqnos[j] }), "seqnos in order")
 }

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -514,12 +514,14 @@ func TestRelayTransferInnards(t *testing.T) {
 	require.NoError(t, err)
 	appKey, teamID, err := relays.GetKey(m, recipient)
 	require.NoError(t, err)
+	sp, unlock := stellar.NewSeqnoProvider(libkb.NewMetaContextForTest(tcs[0].TestContext), tcs[0].Srv.walletState)
+	defer unlock()
 	out, err := relays.Create(relays.Input{
 		From:          senderAccountBundle.Signers[0],
 		AmountXLM:     "10.0005",
 		Note:          "hey",
 		EncryptFor:    appKey,
-		SeqnoProvider: stellar.NewSeqnoProvider(libkb.NewMetaContextForTest(tcs[0].TestContext), tcs[0].Srv.walletState),
+		SeqnoProvider: sp,
 	})
 	require.NoError(t, err)
 	_, err = libkb.ParseStellarAccountID(out.RelayAccountID.String())
@@ -1301,7 +1303,9 @@ func TestShutdown(t *testing.T) {
 
 	accountID := tcs[0].Backend.AddAccount()
 
+	tcs[0].Srv.walletState.SeqnoLock()
 	_, err := tcs[0].Srv.walletState.AccountSeqnoAndBump(context.Background(), accountID)
+	tcs[0].Srv.walletState.SeqnoUnlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -645,6 +645,9 @@ func (a *AccountState) ForceSeqnoRefresh(mctx libkb.MetaContext) error {
 
 	// delete any stale inuse seqnos (in case missed notification somehow)
 	for k, v := range a.inuseSeqnos {
+		if seqno >= k {
+			delete(a.inuseSeqnos, k)
+		}
 		age := time.Since(v.ctime)
 		if age > 30*time.Second {
 			mctx.CDebugf("ForceSeqnoRefresh removing inuse seqno %d due to old age (%s)", k, age)

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -645,7 +645,8 @@ func (a *AccountState) ForceSeqnoRefresh(mctx libkb.MetaContext) error {
 
 	// delete any stale inuse seqnos (in case missed notification somehow)
 	for k, v := range a.inuseSeqnos {
-		if seqno >= k {
+		if seqno > k {
+			mctx.CDebugf("ForceSeqnoRefresh removing inuse seqno %d due to network seqno > to it (%s)", k, seqno)
 			delete(a.inuseSeqnos, k)
 		}
 		age := time.Since(v.ctime)


### PR DESCRIPTION
There was a race exposed by the dust storm.  This ensures that every transaction from one client makes it to stellard in seqno order.

Tested it in production and couldn't break the dust storm with this in place and a change that was made in stellarnet as well.