### PR TITLE
folder_branch_ops: always wait for archives on Shutdown

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -518,6 +518,10 @@ func (fbo *folderBranchOps) Shutdown(ctx context.Context) error {
 		}
 	}
 
+	if err := fbo.fbm.waitForArchives(ctx); err != nil {
+		return err
+	}
+
 	close(fbo.shutdownChan)
 	fbo.cr.Shutdown()
 	fbo.fbm.shutdown()


### PR DESCRIPTION
Operations that create temporary configs, like git, should wait for all their unref'd blocks to be archived.  Otherwise, any unref'd blocks will count towards the user's quota until garbage collection kicks in two weeks later.  This is especially bad when deleting data from a deleted repo.  (This is just a guess at the root cause for keybase/keybase-issues#3342.)

Issue: keybase/keybase-issues#3342