### PR TITLE
init: clean old temporary storage roots on startup

### DIFF
--- a/go/kbfs/libgit/init.go
+++ b/go/kbfs/libgit/init.go
@@ -37,9 +37,7 @@ const (
 func Params(kbCtx libkbfs.Context,
 	storageRoot string, paramsBase *libkbfs.InitParams) (
 	params libkbfs.InitParams, tempDir string, err error) {
-	// TODO(KBFS-2443): Also remove all kbfsgit directories older than
-	// an hour.
-	tempDir, err = ioutil.TempDir(storageRoot, "kbfsgit")
+	tempDir, err = ioutil.TempDir(storageRoot, libkbfs.GitStorageRootPrefix)
 	if err != nil {
 		return libkbfs.InitParams{}, "", err
 	}

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3346,7 +3346,7 @@ func (cr *ConflictResolver) makeDiskBlockCache(ctx context.Context) (
 		cleanupFn = dbc.Shutdown
 	} else {
 		tempDir, err := ioutil.TempDir(
-			cr.config.StorageRoot(), "kbfs_conflict_disk_cache")
+			cr.config.StorageRoot(), ConflictStorageRootPrefix)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -879,7 +879,7 @@ func doInit(
 		params.BGFlushDirOpBatchSize)
 	config.SetBGFlushDirOpBatchSize(params.BGFlushDirOpBatchSize)
 
-	if mode != InitSingleOp {
+	if config.Mode().OldStorageRootCleaningEnabled() {
 		go cleanOldTempStorageRoots(config)
 	}
 

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -44,6 +44,19 @@ const (
 	InitMemoryLimitedString = "memoryLimited"
 )
 
+// CtxInitTagKey is the type used for unique context tags for KBFS init.
+type CtxInitTagKey int
+
+const (
+	// CtxInitKey is the type of the tag for unique operation IDs
+	// for KBFS init.
+	CtxInitKey CtxInitTagKey = iota
+)
+
+// CtxInitID is the display name for the unique operation
+// init ID tag.
+const CtxInitID = "KBFSINIT"
+
 // AdditionalProtocolCreator creates an additional protocol.
 type AdditionalProtocolCreator func(Context, Config) (rpc.Protocol, error)
 
@@ -602,6 +615,8 @@ func doInit(
 	ctx context.Context, kbCtx Context, params InitParams,
 	keybaseServiceCn KeybaseServiceCn, log logger.Logger,
 	logPrefix string) (Config, error) {
+	ctx = CtxWithRandomIDReplayable(ctx, CtxInitKey, CtxInitID, log)
+
 	mode := InitDefault
 	switch params.Mode {
 	case InitDefaultString:
@@ -863,6 +878,10 @@ func doInit(
 	log.CDebugf(ctx, "Enabling a dir op batch size of %d",
 		params.BGFlushDirOpBatchSize)
 	config.SetBGFlushDirOpBatchSize(params.BGFlushDirOpBatchSize)
+
+	if mode != InitSingleOp {
+		go cleanOldTempStorageRoots(config)
+	}
 
 	return config, nil
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2331,6 +2331,9 @@ type InitMode interface {
 	// MaxCleanBlockCacheCapacity is the maximum number of bytes to be taken up
 	// by the clean block cache.
 	MaxCleanBlockCacheCapacity() uint64
+	// OldStorageRootCleaningEnabled indicates whether we should clean
+	// old temporary storage root directories.
+	OldStorageRootCleaningEnabled() bool
 }
 
 type initModeGetter interface {

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -8885,6 +8885,20 @@ func (mr *MockInitModeMockRecorder) MaxCleanBlockCacheCapacity() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxCleanBlockCacheCapacity", reflect.TypeOf((*MockInitMode)(nil).MaxCleanBlockCacheCapacity))
 }
 
+// OldStorageRootCleaningEnabled mocks base method
+func (m *MockInitMode) OldStorageRootCleaningEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OldStorageRootCleaningEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// OldStorageRootCleaningEnabled indicates an expected call of OldStorageRootCleaningEnabled
+func (mr *MockInitModeMockRecorder) OldStorageRootCleaningEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldStorageRootCleaningEnabled", reflect.TypeOf((*MockInitMode)(nil).OldStorageRootCleaningEnabled))
+}
+
 // MockinitModeGetter is a mock of initModeGetter interface
 type MockinitModeGetter struct {
 	ctrl     *gomock.Controller

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -156,6 +156,10 @@ func (md modeDefault) MaxCleanBlockCacheCapacity() uint64 {
 	return math.MaxUint64
 }
 
+func (md modeDefault) OldStorageRootCleaningEnabled() bool {
+	return true
+}
+
 // Minimal mode:
 
 type modeMinimal struct {
@@ -291,6 +295,10 @@ func (mm modeMinimal) MaxCleanBlockCacheCapacity() uint64 {
 	return math.MaxUint64
 }
 
+func (mm modeMinimal) OldStorageRootCleaningEnabled() bool {
+	return false
+}
+
 // Single op mode:
 
 type modeSingleOp struct {
@@ -356,6 +364,10 @@ func (mso modeSingleOp) ClientType() keybase1.ClientType {
 }
 
 func (mso modeSingleOp) LocalHTTPServerEnabled() bool {
+	return false
+}
+
+func (mso modeSingleOp) OldStorageRootCleaningEnabled() bool {
 	return false
 }
 

--- a/go/kbfs/libkbfs/util.go
+++ b/go/kbfs/libkbfs/util.go
@@ -5,9 +5,13 @@
 package libkbfs
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
@@ -15,7 +19,6 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // Runs fn (which may block) in a separate goroutine and waits for it
@@ -247,4 +250,62 @@ func IsOnlyWriterInNonTeamTlf(ctx context.Context, kbpki KBPKI,
 		return false
 	}
 	return tlf.UserIsOnlyWriter(session.Name, h.GetCanonicalName())
+}
+
+const (
+	// GitStorageRootPrefix is the prefix of the temp storage root
+	// directory made for single-op git operations.
+	GitStorageRootPrefix = "kbfsgit"
+	// ConflictStorageRootPrefix is the prefix of the temp directory
+	// made for the conflict resolution disk cache.
+	ConflictStorageRootPrefix = "kbfs_conflict_disk_cache"
+
+	minAgeForStorageCleanup = 24 * time.Hour
+)
+
+func cleanOldTempStorageRoots(config Config) {
+	log := config.MakeLogger("")
+	ctx := CtxWithRandomIDReplayable(
+		context.Background(), CtxInitKey, CtxInitID, log)
+
+	storageRoot := config.StorageRoot()
+	d, err := os.Open(storageRoot)
+	if err != nil {
+		log.CDebugf(ctx, "Error opening storage root %s: %+v", storageRoot, err)
+		return
+	}
+	defer d.Close()
+
+	fis, err := d.Readdir(0)
+	if err != nil {
+		log.CDebugf(ctx, "Error reading storage root %s: %+v", storageRoot, err)
+		return
+	}
+
+	modTimeCutoff := config.Clock().Now().Add(-minAgeForStorageCleanup)
+	cleanedOne := false
+	for _, fi := range fis {
+		if fi.ModTime().After(modTimeCutoff) {
+			continue
+		}
+
+		if !strings.HasPrefix(fi.Name(), GitStorageRootPrefix) &&
+			!strings.HasPrefix(fi.Name(), ConflictStorageRootPrefix) {
+			continue
+		}
+
+		cleanedOne = true
+		dir := filepath.Join(storageRoot, fi.Name())
+		log.CDebugf(ctx, "Cleaning up old storage root %s, "+
+			"last modified at %s", dir, fi.ModTime())
+		err = os.RemoveAll(dir)
+		if err != nil {
+			log.CDebugf(ctx, "Error deleting %s: %+v", dir, err)
+			continue
+		}
+	}
+
+	if cleanedOne {
+		log.CDebugf(ctx, "Done cleaning old storage roots")
+	}
 }


### PR DESCRIPTION
kbfsgit and CR make temporary storage roots that could be leftover after a crash.  Delete them on startup if they're more than a day old.

Issue: KBFS-3877