### PR TITLE
switchUserMu becomes a VerboseLock

### DIFF
--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -67,6 +67,7 @@ func (e *EKLib) backgroundKeygen() {
 	lastRun := time.Now()
 
 	runIfNeeded := func(force bool) {
+		ctx := libkb.WithLogTag(ctx, "BKG")
 		now := libkb.ForceWallClock(time.Now())
 		shouldRun := now.Sub(lastRun) >= keygenInterval
 		e.G().Log.CDebugf(ctx, "backgroundKeygen: runIfNeeded: lastRun: %v, now: %v, shouldRun: %v, force: %v",

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -67,7 +67,7 @@ func (e *EKLib) backgroundKeygen() {
 	lastRun := time.Now()
 
 	runIfNeeded := func(force bool) {
-		ctx := libkb.WithLogTag(ctx, "BKG")
+		ctx := libkb.WithLogTag(ctx, "EKBKG")
 		now := libkb.ForceWallClock(time.Now())
 		shouldRun := now.Sub(lastRun) >= keygenInterval
 		e.G().Log.CDebugf(ctx, "backgroundKeygen: runIfNeeded: lastRun: %v, now: %v, shouldRun: %v, force: %v",

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -333,8 +333,7 @@ func (m MetaContext) SwitchUserNewConfig(u keybase1.UID, n NormalizedUsername, s
 
 func (m MetaContext) switchUserNewConfig(u keybase1.UID, n NormalizedUsername, salt []byte, d keybase1.DeviceID, ad *ActiveDevice) error {
 	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "switchUserNewConfig")()
 	cw := g.Env.GetConfigWriter()
 	if cw == nil {
 		return NoConfigWriterError{}
@@ -360,8 +359,7 @@ func (m MetaContext) SwitchUserNewConfigActiveDevice(uv keybase1.UserVersion, n 
 // etc). It does this in a critical section, holding switchUserMu.
 func (m MetaContext) SwitchUserNukeConfig(n NormalizedUsername) error {
 	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "SwitchUserNukeConfig")()
 	cw := g.Env.GetConfigWriter()
 	cr := g.Env.GetConfig()
 	if cw == nil {
@@ -396,8 +394,7 @@ func (m MetaContext) SwitchUserToActiveDevice(n NormalizedUsername, ad *ActiveDe
 	if !n.IsValid() {
 		return NewBadUsernameError(n.String())
 	}
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "SwitchUserToActiveDevice %v", n)()
 	cw := g.Env.GetConfigWriter()
 	if cw == nil {
 		return NoConfigWriterError{}
@@ -421,8 +418,7 @@ func (m MetaContext) SwitchUserToActiveDevice(n NormalizedUsername, ad *ActiveDe
 
 func (m MetaContext) SwitchUserDeprovisionNukeConfig(username NormalizedUsername) error {
 	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "SwitchUserDeprovisionNukeConfig %v", username)()
 
 	cw := g.Env.GetConfigWriter()
 	if cw == nil {
@@ -444,8 +440,7 @@ func (m MetaContext) SwitchUserToActiveOneshotDevice(uv keybase1.UserVersion, nu
 	defer m.CTrace("MetaContext#SwitchUserToActiveOneshotDevice", func() error { return err })()
 
 	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "SwitchUserToActiveOneshotDevice")()
 	cw := g.Env.GetConfigWriter()
 	if cw == nil {
 		return NoConfigWriterError{}
@@ -468,8 +463,7 @@ func (m MetaContext) SwitchUserToActiveOneshotDevice(uv keybase1.UserVersion, nu
 func (m MetaContext) SwitchUserLoggedOut() (err error) {
 	defer m.CTrace("MetaContext#SwitchUserLoggedOut", func() error { return err })()
 	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "SwitchUserLoggedOut")()
 	cw := g.Env.GetConfigWriter()
 	if cw == nil {
 		return NoConfigWriterError{}
@@ -491,8 +485,7 @@ func (m MetaContext) SwitchUserLoggedOut() (err error) {
 func (m MetaContext) SetActiveDevice(uv keybase1.UserVersion, deviceID keybase1.DeviceID,
 	sigKey, encKey GenericKey, deviceName string) error {
 	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "SetActiveDevice")()
 	if !g.Env.GetUID().Equal(uv.Uid) {
 		return NewUIDMismatchError("UID switched out from underneath provisioning process")
 	}
@@ -501,15 +494,13 @@ func (m MetaContext) SetActiveDevice(uv keybase1.UserVersion, deviceID keybase1.
 
 func (m MetaContext) SetSigningKey(uv keybase1.UserVersion, deviceID keybase1.DeviceID, sigKey GenericKey, deviceName string) error {
 	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "SetSigningKey")()
 	return g.ActiveDevice.setSigningKey(g, uv, deviceID, sigKey, deviceName)
 }
 
 func (m MetaContext) SetEncryptionKey(uv keybase1.UserVersion, deviceID keybase1.DeviceID, encKey GenericKey) error {
 	g := m.G()
-	g.switchUserMu.Lock()
-	defer g.switchUserMu.Unlock()
+	defer g.switchUserMu.Acquire(m, "SetEncryptionKey")()
 	return g.ActiveDevice.setEncryptionKey(uv, deviceID, encKey)
 }
 

--- a/go/libkb/vlock.go
+++ b/go/libkb/vlock.go
@@ -1,0 +1,35 @@
+package libkb
+
+import (
+	"fmt"
+	"sync"
+)
+
+type VerboseLockRelease = func()
+
+type VerboseLock struct {
+	mu    sync.Mutex
+	level VDebugLevel
+	name  string
+}
+
+func NewVerboseLock(level VDebugLevel, name string) *VerboseLock {
+	return &VerboseLock{
+		level: level,
+		name:  name,
+	}
+}
+
+func (l *VerboseLock) Acquire(mctx MetaContext, reasonFormat string, args ...interface{}) (release VerboseLockRelease) {
+	reason := fmt.Sprintf(reasonFormat, args...)
+	log := func(symbol string, word string) {
+		mctx.VLogf(l.level, "%v VerboseLock [%v] %v: %v", symbol, l.name, word, reason)
+	}
+	log("+", "acquiring")
+	l.mu.Lock()
+	log("|", "acquired")
+	return func() {
+		l.mu.Unlock()
+		log("-", "released")
+	}
+}


### PR DESCRIPTION
Something in the wild acquired `switchUserMu` and didn't release it. Hopefully next time we can figure out what.

```
2019-02-13T14:51:54.941850-05:00 ▶ [DEBU keybase vlock.go:26] 078 {VDL:0} + VerboseLock [switchUserMu] acquiring: SetActiveDevice [tags:ENG=zfsuH7oSYLnw]
2019-02-13T14:51:54.942161-05:00 ▶ [DEBU keybase vlock.go:26] 07b {VDL:0} | VerboseLock [switchUserMu] acquired: SetActiveDevice [tags:ENG=zfsuH7oSYLnw]
2019-02-13T14:51:54.941926-05:00 ▶ [DEBU keybase vlock.go:26] 07a {VDL:0} + VerboseLock [switchUserMu] acquiring: SetActiveDevice [tags:BKG=AITTVMug1fUE]
2019-02-13T14:51:54.942234-05:00 ▶ [DEBU keybase vlock.go:26] 07c {VDL:0} - VerboseLock [switchUserMu] released: SetActiveDevice [tags:ENG=zfsuH7oSYLnw]
2019-02-13T14:51:54.942290-05:00 ▶ [DEBU keybase vlock.go:26] 07d {VDL:0} | VerboseLock [switchUserMu] acquired: SetActiveDevice [tags:BKG=AITTVMug1fUE]
2019-02-13T14:51:54.942501-05:00 ▶ [DEBU keybase vlock.go:26] 080 {VDL:0} - VerboseLock [switchUserMu] released: SetActiveDevice [tags:BKG=AITTVMug1fUE]
2019-02-13T14:52:03.652632-05:00 ▶ [DEBU keybase vlock.go:26] 5e6 {VDL:0} + VerboseLock [switchUserMu] acquiring: Logout [tags:LOGOUT=T4KKvwRf0z1V]
2019-02-13T14:52:03.652668-05:00 ▶ [DEBU keybase vlock.go:26] 5e7 {VDL:0} | VerboseLock [switchUserMu] acquired: Logout [tags:LOGOUT=T4KKvwRf0z1V]
2019-02-13T14:52:03.829897-05:00 ▶ [DEBU keybase vlock.go:26] 63d {VDL:0} - VerboseLock [switchUserMu] released: Logout [tags:LOGOUT=T4KKvwRf0z1V]
2019-02-13T14:52:11.157763-05:00 ▶ [DEBU keybase vlock.go:26] 79b {VDL:0} + VerboseLock [switchUserMu] acquiring: SwitchUserToActiveDevice tst5 [tags:ENG=7lfrkN-ckTQ8,LOGIN=cD7kcHBu3rDq]
2019-02-13T14:52:11.157807-05:00 ▶ [DEBU keybase vlock.go:26] 79c {VDL:0} | VerboseLock [switchUserMu] acquired: SwitchUserToActiveDevice tst5 [tags:ENG=7lfrkN-ckTQ8,LOGIN=cD7kcHBu3rDq]
2019-02-13T14:52:11.158047-05:00 ▶ [DEBU keybase vlock.go:26] 7a0 {VDL:0} - VerboseLock [switchUserMu] released: SwitchUserToActiveDevice tst5 [tags:ENG=7lfrkN-ckTQ8,LOGIN=cD7kcHBu3rDq]
```