### PR TITLE
Only scroll to selected convo if the filter is focused

### DIFF
--- a/shared/chat/inbox/container/index.js
+++ b/shared/chat/inbox/container/index.js
@@ -23,6 +23,7 @@ type OwnProps = {|
 const mapStateToProps = state => {
   const metaMap = state.chat2.metaMap
   const filter = state.chat2.inboxFilter
+  const filterHasFocus = state.chat2.focus === 'filter'
   const username = state.config.username
   const {allowShowFloatingButton, rows, smallTeamsExpanded} = filter
     ? filteredRowData(metaMap, filter, username)
@@ -36,6 +37,7 @@ const mapStateToProps = state => {
     _selectedConversationIDKey: Constants.getSelectedConversation(state),
     allowShowFloatingButton,
     filter,
+    filterHasFocus,
     neverLoaded,
     rows,
     smallTeamsExpanded,
@@ -92,6 +94,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     _refreshInbox: dispatchProps._refreshInbox,
     allowShowFloatingButton: stateProps.allowShowFloatingButton,
     filter: stateProps.filter,
+    filterHasFocus: stateProps.filterHasFocus,
     neverLoaded: stateProps.neverLoaded,
     onEnsureSelection: () => {
       // $ForceType

--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -50,7 +50,12 @@ class Inbox extends React.PureComponent<Props, State> {
       this._list && this._list.resetAfterIndex(0)
     }
 
-    if (this.props.selectedIndex !== prevProps.selectedIndex && this.props.selectedIndex >= 0 && this._list) {
+    if (
+      this.props.filterHasFocus &&
+      this.props.selectedIndex !== prevProps.selectedIndex &&
+      this.props.selectedIndex >= 0 &&
+      this._list
+    ) {
       this._list.scrollToItem(this.props.selectedIndex)
     }
   }

--- a/shared/chat/inbox/index.stories.js
+++ b/shared/chat/inbox/index.stories.js
@@ -344,6 +344,7 @@ const propsInboxCommon = {
   focusFilter: () => {},
   filter: '',
   filterFocusCount: 0,
+  filterHasFocus: false,
   neverLoaded: false,
   nowOverride: 0, // just for dumb rendering
   onNewChat: Sb.action('onNewChat'),

--- a/shared/chat/inbox/index.types.js.flow
+++ b/shared/chat/inbox/index.types.js.flow
@@ -38,6 +38,7 @@ export type Props = {|
   focusFilter: () => void, // withStateHandler function
   filter: string,
   filterFocusCount: number,
+  filterHasFocus: boolean,
   neverLoaded: boolean,
   nowOverride?: number, // just for dumb rendering
   onEnsureSelection: () => void,


### PR DESCRIPTION
Fixes the inbox scrolling way down if you click `+123 more` and have a big team channel selected. r? @keybase/react-hackers 