### PR TITLE
leveldb: use bloom filters on all leveldbs

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3664,7 +3664,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 
 func openCRDBInternal(config Config) (*LevelDb, error) {
 	if config.IsTestMode() {
-		return openLevelDBWithOptions(storage.NewMemStorage(), leveldbOptions)
+		return openLevelDB(storage.NewMemStorage())
 	}
 	err := os.MkdirAll(sysPath.Join(config.StorageRoot(),
 		conflictResolverRecordsDir, conflictResolverRecordsVersionString),
@@ -3681,7 +3681,7 @@ func openCRDBInternal(config Config) (*LevelDb, error) {
 		return nil, err
 	}
 
-	return openLevelDBWithOptions(stor, leveldbOptions)
+	return openLevelDB(stor)
 }
 
 func openCRDB(config Config) (db *LevelDb) {

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -23,6 +23,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/util"
@@ -199,6 +200,7 @@ func newDiskBlockCacheLocalFromStorage(
 	blockDbOptions := *leveldbOptions
 	blockDbOptions.CompactionTableSize = defaultBlockCacheTableSize
 	blockDbOptions.BlockSize = defaultBlockCacheBlockSize
+	blockDbOptions.Filter = filter.NewBloomFilter(16)
 	blockDb, err := openLevelDBWithOptions(blockStorage, &blockDbOptions)
 	if err != nil {
 		return nil, err

--- a/go/kbfs/libkbfs/disk_md_cache.go
+++ b/go/kbfs/libkbfs/disk_md_cache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/pkg/errors"
 	ldberrors "github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 )
@@ -131,6 +132,7 @@ func newDiskMDCacheLocalFromStorage(
 	}()
 	mdDbOptions := *leveldbOptions
 	mdDbOptions.CompactionTableSize = defaultMDCacheTableSize
+	mdDbOptions.Filter = filter.NewBloomFilter(16)
 	headsDb, err := openLevelDBWithOptions(headsStorage, &mdDbOptions)
 	if err != nil {
 		return nil, err

--- a/go/kbfs/libkbfs/disk_quota_cache.go
+++ b/go/kbfs/libkbfs/disk_quota_cache.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
+	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 )
@@ -119,6 +120,7 @@ func newDiskQuotaCacheLocalFromStorage(
 	}()
 	quotaDbOptions := *leveldbOptions
 	quotaDbOptions.CompactionTableSize = defaultQuotaCacheTableSize
+	quotaDbOptions.Filter = filter.NewBloomFilter(16)
 	db, err := openLevelDBWithOptions(quotaStorage, &quotaDbOptions)
 	if err != nil {
 		return nil, err

--- a/go/kbfs/libkbfs/leveldb.go
+++ b/go/kbfs/libkbfs/leveldb.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/syndtr/goleveldb/leveldb"
 	ldberrors "github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 )
@@ -119,7 +120,9 @@ func openLevelDBWithOptions(stor storage.Storage, options *opt.Options) (
 // openLevelDB opens or recovers a leveldb.DB with a passed-in storage.Storage
 // as its underlying storage layer.
 func openLevelDB(stor storage.Storage) (*LevelDb, error) {
-	return openLevelDBWithOptions(stor, leveldbOptions)
+	options := *leveldbOptions
+	options.Filter = filter.NewBloomFilter(16)
+	return openLevelDBWithOptions(stor, &options)
 }
 
 func versionPathFromVersion(dirPath string, version uint64) string {


### PR DESCRIPTION
This gives small performance improvements on read workloads, at a very small cost of more on-disk storage and memory usage.

Issue: KBFS-3882