### PR TITLE
Use showusername logic to decide which username to go to when clicked on

### DIFF
--- a/shared/chat/conversation/messages/wrapper/container.js
+++ b/shared/chat/conversation/messages/wrapper/container.js
@@ -150,7 +150,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
     isRevoked: (message.type === 'text' || message.type === 'attachment') && !!message.deviceRevokedAt,
     measure: ownProps.measure,
     message: message,
-    onAuthorClick: () => dispatchProps._onAuthorClick(message.author),
+    onAuthorClick: () => dispatchProps._onAuthorClick(showUsername),
     onCancel,
     onEdit: resolveByEdit ? () => dispatchProps._onEdit(message.conversationIDKey, message.ordinal) : null,
     onRetry,


### PR DESCRIPTION
@keybase/react-hackers 

For some system messages, like when someone else is added to a team by you, we fake the chat message as being "authored" by the addee, when the literal message was authored by the adder.

But we weren't extending that logic to the callback for clicking on a username in that message to go to its profile.  Since `showUsername` is that calculated username, we can just reuse that here.