### PR TITLE
kbfs: use libkb.Version instead of libkbfs.Version

### DIFF
--- a/go/kbfs/libdokan/start.go
+++ b/go/kbfs/libdokan/start.go
@@ -89,7 +89,7 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 		if err != nil {
 			return libfs.InitError(err.Error())
 		}
-		info := libkb.NewServiceInfo(libkbfs.Version, libkbfs.PrereleaseBuild, options.Label, os.Getpid())
+		info := libkb.NewServiceInfo(libkb.Version, libkbfs.PrereleaseBuild, options.Label, os.Getpid())
 		err = info.WriteFile(path.Join(options.RuntimeDir, "kbfs.info"), log)
 		if err != nil {
 			return libfs.InitError(err.Error())

--- a/go/kbfs/libfuse/start.go
+++ b/go/kbfs/libfuse/start.go
@@ -122,7 +122,7 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 		if err != nil {
 			return libfs.InitError(err.Error())
 		}
-		info := libkb.NewServiceInfo(libkbfs.Version, libkbfs.PrereleaseBuild, options.Label, os.Getpid())
+		info := libkb.NewServiceInfo(libkb.Version, libkbfs.PrereleaseBuild, options.Label, os.Getpid())
 		err = info.WriteFile(path.Join(options.RuntimeDir, "kbfs.info"), log)
 		if err != nil {
 			return libfs.InitError(err.Error())

--- a/go/kbfs/libkbfs/util.go
+++ b/go/kbfs/libkbfs/util.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -69,9 +70,9 @@ var PrereleaseBuild string
 // VersionString returns semantic version string
 func VersionString() string {
 	if PrereleaseBuild != "" {
-		return fmt.Sprintf("%s-%s", Version, PrereleaseBuild)
+		return fmt.Sprintf("%s-%s", libkb.Version, PrereleaseBuild)
 	}
-	return Version
+	return libkb.Version
 }
 
 // CtxBackgroundSyncKeyType is the type for a context background sync key.

--- a/go/kbfs/libkbfs/version.go
+++ b/go/kbfs/libkbfs/version.go
@@ -1,8 +1,0 @@
-// Copyright 2016 Keybase Inc. All rights reserved.
-// Use of this source code is governed by a BSD
-// license that can be found in the LICENSE file.
-
-package libkbfs
-
-// Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "1.0.2"


### PR DESCRIPTION
I don't know what magic updated the libkbfs/version.go file in the pre-monorepo times, but it's broken now.  But since we're in the same repo now, we can just rely on libkb/version.go directly.