### PR TITLE
Fix having to double click on filtered rows in the chat inbox

### DIFF
--- a/shared/chat/inbox/container/index.js
+++ b/shared/chat/inbox/container/index.js
@@ -23,7 +23,6 @@ type OwnProps = {|
 const mapStateToProps = state => {
   const metaMap = state.chat2.metaMap
   const filter = state.chat2.inboxFilter
-  const filterHasFocus = state.chat2.focus === 'filter'
   const username = state.config.username
   const {allowShowFloatingButton, rows, smallTeamsExpanded} = filter
     ? filteredRowData(metaMap, filter, username)
@@ -37,7 +36,6 @@ const mapStateToProps = state => {
     _selectedConversationIDKey: Constants.getSelectedConversation(state),
     allowShowFloatingButton,
     filter,
-    filterHasFocus,
     neverLoaded,
     rows,
     smallTeamsExpanded,
@@ -94,7 +92,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     _refreshInbox: dispatchProps._refreshInbox,
     allowShowFloatingButton: stateProps.allowShowFloatingButton,
     filter: stateProps.filter,
-    filterHasFocus: stateProps.filterHasFocus,
     neverLoaded: stateProps.neverLoaded,
     onEnsureSelection: () => {
       // $ForceType

--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -51,7 +51,7 @@ class Inbox extends React.PureComponent<Props, State> {
     }
 
     if (
-      this.props.filterHasFocus &&
+      this.props.filter &&
       this.props.selectedIndex !== prevProps.selectedIndex &&
       this.props.selectedIndex >= 0 &&
       this._list

--- a/shared/chat/inbox/index.stories.js
+++ b/shared/chat/inbox/index.stories.js
@@ -344,7 +344,6 @@ const propsInboxCommon = {
   focusFilter: () => {},
   filter: '',
   filterFocusCount: 0,
-  filterHasFocus: false,
   neverLoaded: false,
   nowOverride: 0, // just for dumb rendering
   onNewChat: Sb.action('onNewChat'),

--- a/shared/chat/inbox/index.types.js.flow
+++ b/shared/chat/inbox/index.types.js.flow
@@ -38,7 +38,6 @@ export type Props = {|
   focusFilter: () => void, // withStateHandler function
   filter: string,
   filterFocusCount: number,
-  filterHasFocus: boolean,
   neverLoaded: boolean,
   nowOverride?: number, // just for dumb rendering
   onEnsureSelection: () => void,


### PR DESCRIPTION
Side effect is that inbox scroll won't follow keying ⬇️ off the screen unless the filter is set. r? @keybase/react-hackers cc @mmaxim 