### PR TITLE
Remove extra bottom border on relogin dropdown

### DIFF
--- a/shared/login/relogin/index.desktop.js
+++ b/shared/login/relogin/index.desktop.js
@@ -12,7 +12,6 @@ type State = {
 
 const ItemBox = Styles.styled(Kb.Box)({
   ...Styles.globalStyles.flexBoxCenter,
-  borderBottom: `1px solid ${Styles.globalColors.lightGrey2}`,
   minHeight: 40,
   width: '100%',
 })


### PR DESCRIPTION
Before:
<img width="289" alt="image" src="https://user-images.githubusercontent.com/11968340/52822330-667da180-307f-11e9-835b-727ae92853b8.png">

After:
<img width="289" alt="image" src="https://user-images.githubusercontent.com/11968340/52822313-5796ef00-307f-11e9-867d-988089de7232.png">
r? @keybase/react-hackers 