### PR TITLE
Normalize Device Names when checking duplicates

### DIFF
--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 
 	"golang.org/x/net/context"
 
@@ -535,7 +534,7 @@ func (e *loginProvision) deviceName(m libkb.MetaContext) (string, error) {
 			// if we have a collision on the normalized values add some extra
 			// info the error message so the user isn't confused why we
 			// consider the names equal.
-			if strings.ToLower(devname) != strings.ToLower(dupname) {
+			if devname != dupname {
 				dupnameErrMsg = fmt.Sprintf(" as %q", dupname)
 			}
 			arg.ErrorMessage = fmt.Sprintf("The device name %q is already taken%s. You can't reuse device names, even revoked ones, for security reasons. Otherwise, someone who stole one of your devices could cause a lot of confusion.", devname, dupnameErrMsg)

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -520,8 +520,9 @@ func (e *loginProvision) deviceName(m libkb.MetaContext) (string, error) {
 		}
 		devname = libkb.CheckDeviceName.Transform(devname)
 		duplicate := false
+		normalizedDevName := libkb.CheckDeviceName.Normalize(devname)
 		for _, name := range names {
-			if devname == name {
+			if normalizedDevName == libkb.CheckDeviceName.Normalize(name) {
 				duplicate = true
 				break
 			}
@@ -529,7 +530,7 @@ func (e *loginProvision) deviceName(m libkb.MetaContext) (string, error) {
 
 		if duplicate {
 			m.CDebugf("Device name reused: %q", devname)
-			arg.ErrorMessage = fmt.Sprintf("Device name %q already used", devname)
+			arg.ErrorMessage = fmt.Sprintf("The device name %q is already taken. You can't reuse device names, even revoked ones, for security reasons. Otherwise, someone who stole one of your devices could cause a lot of confusion.", devname)
 			continue
 		}
 

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -519,18 +519,18 @@ func (e *loginProvision) deviceName(m libkb.MetaContext) (string, error) {
 			continue
 		}
 		devname = libkb.CheckDeviceName.Transform(devname)
-		duplicate := false
+		var dupName string
 		normalizedDevName := libkb.CheckDeviceName.Normalize(devname)
 		for _, name := range names {
 			if normalizedDevName == libkb.CheckDeviceName.Normalize(name) {
-				duplicate = true
+				dupName = name
 				break
 			}
 		}
 
-		if duplicate {
+		if dupName != "" {
 			m.CDebugf("Device name reused: %q", devname)
-			arg.ErrorMessage = fmt.Sprintf("The device name %q is already taken. You can't reuse device names, even revoked ones, for security reasons. Otherwise, someone who stole one of your devices could cause a lot of confusion.", devname)
+			arg.ErrorMessage = fmt.Sprintf("The device name %q is already taken as %q. You can't reuse device names, even revoked ones, for security reasons. Otherwise, someone who stole one of your devices could cause a lot of confusion.", devname, dupName)
 			continue
 		}
 

--- a/go/libkb/checkers.go
+++ b/go/libkb/checkers.go
@@ -16,6 +16,7 @@ var emailRE = regexp.MustCompile(`^\S+@\S+\.\S+$`)
 
 var deviceRE = regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+-—–‘’]*$`)
 var badDeviceRE = regexp.MustCompile(`  |[ '+_-]$|['+_-][ ]?['+_-]`)
+var normalizeDeviceRE = regexp.MustCompile(`[^a-zA-Z0-9]`)
 
 var CheckEmail = Checker{
 	F: func(s string) bool {
@@ -72,6 +73,9 @@ var CheckDeviceName = Checker{
 		s = strings.Replace(s, "‘", "'", -1) // curly quote #1
 		s = strings.Replace(s, "’", "'", -1) // curly quote #2
 		return s
+	},
+	Normalize: func(s string) string {
+		return strings.ToLower(normalizeDeviceRE.ReplaceAllString(s, ""))
 	},
 	Hint: "between 3 and 64 characters long; use a-Z, 0-9, space, plus, underscore, dash and apostrophe",
 }

--- a/go/libkb/checkers_test.go
+++ b/go/libkb/checkers_test.go
@@ -3,7 +3,11 @@
 
 package libkb
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 type checkerTest struct {
 	input string
@@ -24,9 +28,7 @@ var usernameTests = []checkerTest{
 func TestCheckUsername(t *testing.T) {
 	for _, test := range usernameTests {
 		res := CheckUsername.F(test.input)
-		if res != test.valid {
-			t.Errorf("input: %q, got %v, expected %v", test.input, res, test.valid)
-		}
+		require.Equal(t, res, test.valid)
 	}
 }
 
@@ -52,8 +54,24 @@ var deviceNameTests = []checkerTest{
 func TestCheckDeviceName(t *testing.T) {
 	for _, test := range deviceNameTests {
 		res := CheckDeviceName.F(test.input)
-		if res != test.valid {
-			t.Errorf("input: %q, got %v, expected %v", test.input, res, test.valid)
-		}
+		require.Equal(t, res, test.valid)
+	}
+}
+
+type normalizeTest struct {
+	name1 string
+	name2 string
+}
+
+var deviceNormalizeTests = []normalizeTest{
+	{name1: "home computer", name2: "homecomputer"},
+	{name1: "home - computer", name2: "homecomputer"},
+	{name1: "Mike's computer", name2: "mikescomputer"},
+	{name1: "John’s iPhone", name2: "johnsiphone"},
+}
+
+func TestNormalizeDeviceName(t *testing.T) {
+	for _, test := range deviceNormalizeTests {
+		require.Equal(t, test.name2, CheckDeviceName.Normalize(test.name1))
 	}
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -329,6 +329,7 @@ type IdentifyUI interface {
 type Checker struct {
 	F             func(string) bool
 	Transform     func(string) string
+	Normalize     func(string) string
 	Hint          string
 	PreserveSpace bool
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1591,13 +1591,13 @@ func (u UserPlusKeysV2AllIncarnations) AllDeviceNames() []string {
 	var names []string
 
 	for _, k := range u.Current.DeviceKeys {
-		if k.DeviceDescription != "" && (k.DeviceType == "mobile" || k.DeviceType == "desktop") {
+		if k.DeviceDescription != "" {
 			names = append(names, k.DeviceDescription)
 		}
 	}
 	for _, v := range u.PastIncarnations {
 		for _, k := range v.DeviceKeys {
-			if k.DeviceDescription != "" && (k.DeviceType == "mobile" || k.DeviceType == "desktop") {
+			if k.DeviceDescription != "" {
 				names = append(names, k.DeviceDescription)
 			}
 		}

--- a/shared/actions/__tests__/provision.test.js
+++ b/shared/actions/__tests__/provision.test.js
@@ -228,19 +228,6 @@ describe('device name happy path', () => {
     expect(getRoutePath()).toEqual(I.List([Tabs.loginTab, 'setPublicName']))
   })
 
-  it("don't allow submit dupe", () => {
-    const {response, getState, dispatch} = init
-    const name: string = (existingDevices.first(): any)
-    dispatch(ProvisionGen.createSubmitDeviceName({name}))
-    expect(
-      getState()
-        .provision.error.stringValue()
-        .indexOf('is already taken')
-    ).not.toEqual(-1)
-    expect(response.result).not.toHaveBeenCalled()
-    expect(response.error).not.toHaveBeenCalled()
-  })
-
   it('submit', () => {
     const {response, getState, dispatch} = init
     const name = 'new name'

--- a/shared/reducers/provision.js
+++ b/shared/reducers/provision.js
@@ -64,17 +64,6 @@ export default function(state: Types.State = initialState, action: ProvisionGen.
         error: initialState.error,
       })
     case ProvisionGen.submitDeviceName:
-      const newNameLowerCase = action.payload.name.toLowerCase()
-      if (state.existingDevices.find(ed => ed.toLowerCase() === newNameLowerCase)) {
-        return state.merge({
-          deviceName: action.payload.name,
-          error: new HiddenString(
-            `The device name '${
-              action.payload.name
-            }' is already taken. You can't reuse device names, even revoked ones, for security reasons. Otherwise, someone who stole one of your devices could cause a lot of confusion.`
-          ),
-        })
-      }
       return state.merge({
         deviceName: action.payload.name,
         error: initialState.error,


### PR DESCRIPTION
improves the client side check so we don't get a server error
- mirrors the server normalization in the service for checking duplicate device names
- includes paper keys in `keybase1.AllDeviceNames()` to check for duplicates
- removes duplicate frontend code and improves error message to avoid confusion on normalization (open to suggestions here)

error when simple collision:
![screen shot 2019-02-15 at 9 51 15 am](https://user-images.githubusercontent.com/1144020/52864418-1b5ba100-3108-11e9-9d93-76381218c3fb.png)


error when normalization causes collision:
![screen shot 2019-02-14 at 5 47 59 pm](https://user-images.githubusercontent.com/1144020/52864400-14cd2980-3108-11e9-82ca-954be10538bd.png)


