### PR TITLE
folder_branch_ops: fix `keybase fs history` after re-login

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -7956,6 +7956,8 @@ func (fbo *folderBranchOps) ClearPrivateFolderMD(ctx context.Context) {
 			fbo.cancelEdits = nil
 		}
 		fbo.editHistory = kbfsedits.NewTlfHistory()
+		// Allow the edit monitor to be re-launched later whenever the
+		// MD is set again.
 		fbo.launchEditMonitor = sync.Once{}
 		fbo.convLock.Lock()
 		defer fbo.convLock.Unlock()


### PR DESCRIPTION
Need to reinitialize the sync.Once object when the edit history is cleared on logout, so chat monitoring can be started up again after login.