### PR TITLE
Zero _ignoreScrollRefCount before handling page up/down

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.desktop.js
+++ b/shared/chat/conversation/list-area/normal/index.desktop.js
@@ -44,8 +44,17 @@ class Thread extends React.PureComponent<Props, State> {
   _pointerWrapperRef = React.createRef()
   // Not a state so we don't rerender, just mutate the dom
   _isScrolling = false
-  // When we're triggering scrolling we don't want our event subscribers to fire so we increment this value
+
+  // When we're triggering scrolling we don't want our event
+  // subscribers to fire so we increment this value.
+  //
+  // NOTE: Since scroll events don't correspond 1:1 to events that
+  // trigger scrolling, this has a high chance of getting 'stuck'
+  // above 0, e.g. when resizing a window. Skipping a few user-driven
+  // scroll events is harmless, but we want to clear these out when
+  // simulating user-driven scroll events, e.g. page up/page down.
   _ignoreScrollRefCount = 0
+
   // last height we saw from resize
   _scrollHeight: number = 0
 

--- a/shared/chat/conversation/list-area/normal/index.desktop.js
+++ b/shared/chat/conversation/list-area/normal/index.desktop.js
@@ -108,7 +108,9 @@ class Thread extends React.PureComponent<Props, State> {
   _scrollDown = () => {
     const list = this._listRef.current
     if (list) {
-      this._logScrollTop(list, '_scrollDown', () => {
+      this._logAll(list, '_scrollDown', () => {
+        // User-driven scroll event, so clear ignore count.
+        this._ignoreScrollRefCount = 0
         list.scrollTop += list.clientHeight
       })
     }
@@ -117,7 +119,9 @@ class Thread extends React.PureComponent<Props, State> {
   _scrollUp = () => {
     const list = this._listRef.current
     if (list) {
-      this._logScrollTop(list, '_scrollUp', () => {
+      this._logAll(list, '_scrollUp', () => {
+        // User-driven scroll event, so clear ignore count.
+        this._ignoreScrollRefCount = 0
         list.scrollTop -= list.clientHeight
       })
     }


### PR DESCRIPTION
We used it whenever we programmatically scrolled, and wanted the next
scroll event to get ignored. However, it turns out that changes to scrollTop
don't correspond 1:1 to scroll events.

In particular, it's possible for the ref count to get "stuck" at > 0, in which case
hitting page up would trigger a scroll event that would get ignored, causing
isLockedToBottom to remain true, which would then cause onResize to snap
back the scroll event and re-increment the ref count.

So zero it out before we handle page up/page down, since we're handling
a user-driven scroll event.