### PR TITLE
generate dependencies before tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ shared/react-native/android/app/local.properties
 
 browser/node_modules
 browser/js/bundle.js
+go/.go_package_deps*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,11 @@ helpers.rootLinuxNode(env, {
     def hasJSChanges = helpers.hasChanges('shared', env)
     println "Has go changes: " + hasGoChanges
     println "Has JS changes: " + hasJSChanges
+    if (hasGoChanges) {
+        dir("go") {
+          sh "make gen-deps"
+        }
+    }
 
     stage("Test") {
       helpers.withKbweb() {
@@ -101,9 +106,6 @@ helpers.rootLinuxNode(env, {
                 sh "make"
               }
               checkDiffs(['./go/', './protocol/'], 'Please run \\"make\\" inside the client/protocol directory.')
-              dir("go") {
-                sh "make gen-deps"
-              }
             }
             parallel (
               test_linux: {


### PR DESCRIPTION
fixes ci failure like: https://ci.keyba.se/job/client/job/PR-16103/1/execution/node/372/log/ introduced in https://github.com/keybase/client/pull/16088