### PR TITLE
Use the full channel list for channel suggestions

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1955,10 +1955,8 @@ function* loadChannelInfos(state, action) {
     return
   }
   if (!TeamsConstants.hasChannelInfos(state, teamname)) {
-    yield Saga.sequentially([
-      Saga.callUntyped(Saga.delay, 4000),
-      Saga.put(TeamsGen.createGetChannels({teamname})),
-    ])
+    yield Saga.callUntyped(Saga.delay, 4000)
+    yield Saga.put(TeamsGen.createGetChannels({teamname}))
   }
 }
 

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -23,7 +23,7 @@ import * as Tabs from '../../constants/tabs'
 import * as UsersGen from '../users-gen'
 import * as WaitingGen from '../waiting-gen'
 import chatTeamBuildingSaga from './team-building'
-import {hasCanPerform, retentionPolicyToServiceRetentionPolicy, teamRoleByEnum} from '../../constants/teams'
+import * as TeamsConstants from '../../constants/teams'
 import logger from '../../logger'
 import engine from '../../engine'
 import {isMobile} from '../../constants/platform'
@@ -674,7 +674,7 @@ const onChatSetConvSettings = (_, action) => {
     conv.convSettings &&
     conv.convSettings.minWriterRoleInfo &&
     conv.convSettings.minWriterRoleInfo.role
-  const role = newRole && teamRoleByEnum[newRole]
+  const role = newRole && TeamsConstants.teamRoleByEnum[newRole]
   logger.info(`ChatHandler: got new minWriterRole ${role || ''} for convID ${conversationIDKey}`)
   if (role && role !== 'none') {
     return Chat2Gen.createSaveMinWriterRole({conversationIDKey, role})
@@ -1941,8 +1941,24 @@ const loadCanUserPerform = (state, action) => {
   if (!teamname) {
     return
   }
-  if (!hasCanPerform(state, teamname)) {
+  if (!TeamsConstants.hasCanPerform(state, teamname)) {
     return TeamsGen.createGetTeamOperations({teamname})
+  }
+}
+
+// Get the full channel names/descs for a team if we don't already have them.
+function* loadChannelInfos(state, action) {
+  const {conversationIDKey} = action.payload
+  const meta = Constants.getMeta(state, conversationIDKey)
+  const teamname = meta.teamname
+  if (!teamname) {
+    return
+  }
+  if (!TeamsConstants.hasChannelInfos(state, teamname)) {
+    yield Saga.sequentially([
+      Saga.callUntyped(Saga.delay, 4000),
+      Saga.put(TeamsGen.createGetChannels({teamname})),
+    ])
   }
 }
 
@@ -2125,7 +2141,7 @@ const setConvRetentionPolicy = (_, action) => {
   const convID = Types.keyToConversationID(conversationIDKey)
   let servicePolicy: ?RPCChatTypes.RetentionPolicy
   try {
-    servicePolicy = retentionPolicyToServiceRetentionPolicy(policy)
+    servicePolicy = TeamsConstants.retentionPolicyToServiceRetentionPolicy(policy)
     if (servicePolicy) {
       return RPCChatTypes.localSetConvRetentionLocalRpcPromise({
         convID,
@@ -2920,6 +2936,11 @@ function* chat2Saga(): Saga.SagaGenerator<any, any> {
   yield* Saga.chainAction<Chat2Gen.PrepareFulfillRequestFormPayload>(
     Chat2Gen.prepareFulfillRequestForm,
     prepareFulfillRequestForm
+  )
+
+  yield* Saga.chainGenerator<Chat2Gen.SelectConversationPayload>(
+    Chat2Gen.selectConversation,
+    loadChannelInfos
   )
 
   yield* Saga.chainAction<EngineGen.Chat1NotifyChatChatPromptUnfurlPayload>(

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -287,7 +287,10 @@ class Input extends React.Component<InputProps, InputState> {
 
   _getChannelSuggestions = filter => {
     const fil = filter.toLowerCase()
-    return this.props.suggestChannels.filter(ch => ch.toLowerCase().includes(fil)).toArray()
+    return this.props.suggestChannels
+      .filter(ch => ch.toLowerCase().includes(fil))
+      .sort()
+      .toArray()
   }
 
   _renderChannelSuggestion = (channelname: string, selected) => (

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -338,7 +338,7 @@ export const getChannelSuggestions = (state: TypedState, teamname: string) => {
   // partial list of channels that you have joined).
   const convs = state.teams.getIn(['teamNameToChannelInfos', teamname])
   if (convs) {
-    return convs.toIndexedSeq().map(conv => conv.channelname)
+    return convs.toIndexedSeq().toList().map(conv => conv.channelname)
   }
   return state.chat2.metaMap
     .filter(v => v.teamname === teamname)

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -330,13 +330,21 @@ export const getParticipantSuggestions = (state: TypedState, id: Types.Conversat
   return suggestions
 }
 
-export const getChannelSuggestions = (state: TypedState, teamname: string) =>
-  teamname
-    ? state.chat2.metaMap
-        .filter(v => v.teamname === teamname)
-        .map(v => v.channelname)
-        .toList()
-    : I.List()
+export const getChannelSuggestions = (state: TypedState, teamname: string) => {
+  if (!teamname) {
+    return I.List()
+  }
+  // First try channelinfos (all channels in a team), then try inbox (the
+  // partial list of channels that you have joined).
+  const convs = state.teams.getIn(['teamNameToChannelInfos', teamname])
+  if (convs) {
+    return convs.toIndexedSeq().map(conv => conv.channelname)
+  }
+  return state.chat2.metaMap
+    .filter(v => v.teamname === teamname)
+    .map(v => v.channelname)
+    .toList()
+}
 
 export const getCommands = (state: TypedState, id: Types.ConversationIDKey) => {
   const {commands} = getMeta(state, id)

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -254,6 +254,9 @@ const getCanPerform = (state: TypedState, teamname: Types.Teamname): RPCTypes.Te
 const hasCanPerform = (state: TypedState, teamname: Types.Teamname): boolean =>
   state.teams.hasIn(['teamNameToCanPerform', teamname])
 
+const hasChannelInfos = (state: TypedState, teamname: Types.Teamname): boolean =>
+  state.teams.hasIn(['teamNameToChannelInfos', teamname])
+
 const getTeamMemberCount = (state: TypedState, teamname: Types.Teamname): number =>
   state.teams.getIn(['teammembercounts', teamname], 0)
 
@@ -455,6 +458,7 @@ export {
   getRole,
   getCanPerform,
   hasCanPerform,
+  hasChannelInfos,
   getEmailInviteError,
   getTeamMemberCount,
   userIsActiveInTeamHelper,


### PR DESCRIPTION
@keybase/react-hackers 

Previously, we only showed channel suggestions for channels that you're in.  This was because we don't *know* anything about channels you're not in unless you've been to the Manage Channels screen for that team, which is where we load the details of all channels for the first time.

This PR tries to balance the cost of loading them with the payoff, and does it this way:

* four seconds after a selectConversation, if the convo is a team chat and we don't already have any channelInfos for it, try to get them.  So this `getChannels` only happens once per team per launch.

* for channel suggestions, prefer the full details from teamNameToChannelInfos if they exist, else just use the inbox-based suggestions that we use today.

So, if someone hits the "#" in the first four seconds of going to a team channel for the first time for that team that launch, they'll see a smaller list of suggestions that becomes a larger list in a few seconds' time.