### PR TITLE
block_retrieval_queue: put block in cache when prefetching is off

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -584,6 +584,16 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 		} else {
 			brq.Prefetcher().CancelPrefetch(retrieval.blockPtr)
 		}
+	} else {
+		// Even if the block is not being tracked by the prefetcher,
+		// we still want to put it in the block caches.
+		err = brq.PutInCaches(
+			retrieval.ctx, retrieval.blockPtr, retrieval.kmd.TlfID(), block,
+			retrieval.cacheLifetime, NoPrefetch, retrieval.action.CacheType())
+		if err != nil {
+			brq.log.CDebugf(
+				retrieval.ctx, "Couldn't put block in cache: %+v", err)
+		}
 	}
 
 	for _, r := range retrieval.requests {


### PR DESCRIPTION
If prefetching is off (like on mobile), we were never storing fetched blocks in the in-memory cache.  They would still be stored in the disk cache, but in some rare cases that cache can't be initialized on mobile, which could lead to the same block being downloaded over and over again.

Issue: KBFS-3891