### PR TITLE
fix keeping all things in the dom after the first render

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.desktop.js
+++ b/shared/chat/conversation/list-area/normal/index.desktop.js
@@ -479,6 +479,10 @@ class OrdinalWaypoint extends React.Component<OrdinalWaypointProps, OrdinalWaypo
       shouldUpdate = true
     }
 
+    if (this.state.height !== nextState.height) {
+      shouldUpdate = true
+    }
+
     return shouldUpdate
   }
 


### PR DESCRIPTION
@keybase/react-hackers this should make the thread view keep less stuff in the window. What would happen is the renderMessages flag would change but we'd never change since shouldComponentUpdate wasn't firing when the height changed