### PR TITLE
Id3: assertion color and icon tweaks

### DIFF
--- a/shared/tracker2/assertion/index.js
+++ b/shared/tracker2/assertion/index.js
@@ -48,26 +48,6 @@ const stateToIcon = state => {
   }
 }
 
-const stateToColor = state => {
-  switch (state) {
-    case 'checking':
-      return Styles.globalColors.black_50
-    case 'valid':
-      return Styles.globalColors.blue2
-    case 'error':
-      return Styles.globalColors.red
-    case 'warning':
-      return Styles.globalColors.blue2
-    case 'revoked':
-      return Styles.globalColors.red
-    case 'suggestion':
-      return Styles.globalColors.grey
-    default:
-      Flow.ifFlowComplainsAboutThisFunctionYouHaventHandledAllCasesInASwitch(state)
-      throw new Error('Impossible')
-  }
-}
-
 const stateToValueTextStyle = state => {
   switch (state) {
     case 'revoked':
@@ -96,10 +76,8 @@ const assertionColorToColor = (c: Types.AssertionColor) => {
       return Styles.globalColors.green
     case 'gray':
       return Styles.globalColors.black_50
-    case 'yellow':
-      return Styles.globalColors.yellow2
+    case 'yellow': // fallthrough
     case 'orange':
-      return Styles.globalColors.orange
     default:
       return Styles.globalColors.red
   }
@@ -342,7 +320,7 @@ class Assertion extends React.PureComponent<Props, State> {
             type={stateToIcon(p.state)}
             fontSize={20}
             onClick={p.onShowProof}
-            hoverColor={stateToColor(p.state)}
+            hoverColor={assertionColorToColor(p.color)}
             color={p.isSuggestion ? Styles.globalColors.black_20 : assertionColorToColor(p.color)}
           />
           {items ? (

--- a/shared/tracker2/assertion/index.js
+++ b/shared/tracker2/assertion/index.js
@@ -37,7 +37,7 @@ const stateToIcon = state => {
     case 'error':
       return 'iconfont-proof-broken'
     case 'warning':
-      return 'iconfont-proof-good'
+      return 'iconfont-proof-broken'
     case 'revoked':
       return 'iconfont-proof-broken'
     case 'suggestion':

--- a/shared/tracker2/assertion/index.js
+++ b/shared/tracker2/assertion/index.js
@@ -34,10 +34,8 @@ const stateToIcon = state => {
       return 'iconfont-proof-pending'
     case 'valid':
       return 'iconfont-proof-good'
-    case 'error':
-      return 'iconfont-proof-broken'
+    case 'error': // fallthrough
     case 'warning':
-      return 'iconfont-proof-broken'
     case 'revoked':
       return 'iconfont-proof-broken'
     case 'suggestion':

--- a/shared/tracker2/bio/index.js
+++ b/shared/tracker2/bio/index.js
@@ -16,7 +16,7 @@ type Props = {|
 
 const Bio = (p: Props) => (
   <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container} centerChildren={true} gap="xtiny">
-    <Kb.Text type="BodyBig" lineClamp={p.inTracker ? 1 : undefined} style={styles.text}>
+    <Kb.Text type="BodyBig" lineClamp={p.inTracker ? 1 : undefined} style={styles.text} selectable={true}>
       {p.fullname}
     </Kb.Text>
     {p.followThem && p.followsYou && <Kb.Text type="BodySmall">YOU FOLLOW EACH OTHER</Kb.Text>}
@@ -39,12 +39,12 @@ const Bio = (p: Props) => (
       </Kb.Text>
     )}
     {!!p.bio && (
-      <Kb.Text type="Body" lineClamp={p.inTracker ? 2 : undefined} style={styles.text}>
+      <Kb.Text type="Body" lineClamp={p.inTracker ? 2 : undefined} style={styles.text} selectable={true}>
         {p.bio}
       </Kb.Text>
     )}
     {!!p.location && (
-      <Kb.Text type="BodySmall" lineClamp={p.inTracker ? 1 : undefined} style={styles.text}>
+      <Kb.Text type="BodySmall" lineClamp={p.inTracker ? 1 : undefined} style={styles.text} selectable={true}>
         {p.location}
       </Kb.Text>
     )}
@@ -61,7 +61,7 @@ const styles = Styles.styleSheetCreate({
       textAlign: 'center',
     },
     isElectron: {
-      wordBreak: 'break-all',
+      wordBreak: 'break-word',
     },
   }),
 })


### PR DESCRIPTION
- State `warning` gets a broken proof icon
- Assertion colors `yellow` and `orange` are rendered as red
- Fullname+bio+location are selectable, bio doesn't line break in the middle of words anymore

r? @keybase/react-hackers 