### PR TITLE
folder_branch_status: print MD timestamp in KBFS status

### DIFF
--- a/go/kbfs/libdokan/mount_test.go
+++ b/go/kbfs/libdokan/mount_test.go
@@ -2454,6 +2454,15 @@ func TestStatusFile(t *testing.T) {
 	var bufStatus libkbfs.FolderBranchStatus
 	json.Unmarshal(buf, &bufStatus)
 
+	// Use a fuzzy check on the timestamps, since it could include
+	// monotonic clock stuff.
+	if !timeEqualFuzzy(
+		status.LocalTimestamp, bufStatus.LocalTimestamp, time.Millisecond) {
+		t.Fatalf("Local timestamp (%s) didn't match expected timestamp %v",
+			bufStatus.LocalTimestamp, status.LocalTimestamp)
+	}
+	status.LocalTimestamp = bufStatus.LocalTimestamp
+
 	// It's safe to compare the path slices with DeepEqual since they
 	// will all be null for this test (nothing is dirtied).
 	if !reflect.DeepEqual(status, bufStatus) {

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -3127,6 +3127,15 @@ func TestStatusFile(t *testing.T) {
 	var bufStatus libkbfs.FolderBranchStatus
 	json.Unmarshal(buf, &bufStatus)
 
+	// Use a fuzzy check on the timestamps, since it could include
+	// monotonic clock stuff.
+	if !timeEqualFuzzy(
+		status.LocalTimestamp, bufStatus.LocalTimestamp, time.Millisecond) {
+		t.Fatalf("Local timestamp (%s) didn't match expected timestamp %v",
+			bufStatus.LocalTimestamp, status.LocalTimestamp)
+	}
+	status.LocalTimestamp = bufStatus.LocalTimestamp
+
 	// It's safe to compare the path slices with DeepEqual since they
 	// will all be null for this test (nothing is dirtied).
 	if !reflect.DeepEqual(status, bufStatus) {

--- a/go/kbfs/libkbfs/folder_branch_status.go
+++ b/go/kbfs/libkbfs/folder_branch_status.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -38,6 +39,7 @@ type FolderBranchStatus struct {
 	GitUsageBytes       int64
 	GitArchiveBytes     int64
 	GitLimitBytes       int64
+	LocalTimestamp      time.Time
 
 	// DirtyPaths are files that have been written, but not flushed.
 	// They do not represent unstaged changes in your local instance.
@@ -229,6 +231,7 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 			fbsk.md.Data().Dir.BlockPointer)
 		fbs.PrefetchStatus = prefetchStatus.String()
 		fbs.RootBlockID = fbsk.md.Data().Dir.BlockPointer.ID.String()
+		fbs.LocalTimestamp = fbsk.md.localTimestamp
 
 		if fbsk.quotaUsage == nil {
 			loggerSuffix := fmt.Sprintf("status-%s", fbsk.md.TlfID())


### PR DESCRIPTION
This will print the string of the server's timestamp for the MD object, but adjusted for the time skew against the local clock.  Example:

```
$ cat /keybase/private/strib/.kbfs_status
{
  "Staged": false,
 ...
  "LocalTimestamp": "2019-02-19T10:01:21.263666333-08:00",
 ...
}
```