### PR TITLE
temporary fix for fs tab on mobile

### DIFF
--- a/shared/fs/folder/index.js
+++ b/shared/fs/folder/index.js
@@ -45,17 +45,10 @@ class Files extends React.PureComponent<FolderProps> {
           <FolderHeader path={this.props.path} routePath={this.props.routePath} />
           <Kbfs.Errs />
           <Kb.Divider />
-          {isMobile ? (
-            <Kb.ScrollView>
-              {this.props.resetParticipants.length > 0 && <ConnectedResetBanner path={this.props.path} />}
-              <Kb.Box>{content}</Kb.Box>
-            </Kb.ScrollView>
-          ) : (
-            <>
-              {this.props.resetParticipants.length > 0 && <ConnectedResetBanner path={this.props.path} />}
-              {content}
-            </>
+          {!isMobile && this.props.resetParticipants.length > 0 && (
+            <ConnectedResetBanner path={this.props.path} />
           )}
+          {content}
           <Footer />
         </Kb.Box2>
       </Kb.BoxGrow>


### PR DESCRIPTION
This is just a quick fix that brings the Files tab back by disabling the reset banner on mobile (thus removing the scrollview). The real and right fix is covered by https://github.com/keybase/client/pull/16161 which makes the banners part of the list. If that one doesn't get merged before the release, we should merge this to unbrick Files on mobile.