### PR TITLE
speculative iOS keychain deletion fix

### DIFF
--- a/go/libkb/secret_store_darwin.go
+++ b/go/libkb/secret_store_darwin.go
@@ -21,19 +21,27 @@ func (k KeychainSecretStore) serviceName(m MetaContext) string {
 	return m.G().GetStoredSecretServiceName()
 }
 
-func (k KeychainSecretStore) StoreSecret(m MetaContext, accountName NormalizedUsername, secret LKSecFullSecret) (err error) {
-	// Base64 encode to make it easy to work with Keychain Access (since we are using a password item and secret is not utf-8)
-	encodedSecret := base64.StdEncoding.EncodeToString(secret.Bytes())
-	item := keychain.NewGenericPassword(k.serviceName(m), string(accountName), "", []byte(encodedSecret), k.accessGroup(m))
+func (k KeychainSecretStore) makeKeychainItem(m MetaContext, accountName NormalizedUsername, encodedSecret []byte) keychain.Item {
+	item := keychain.NewGenericPassword(k.serviceName(m), string(accountName), "", encodedSecret, k.accessGroup(m))
 	item.SetSynchronizable(k.synchronizable())
 	item.SetAccessible(k.accessible())
+	return item
+}
+
+func (k KeychainSecretStore) StoreSecret(m MetaContext, accountName NormalizedUsername, secret LKSecFullSecret) (err error) {
+
+	item := k.makeKeychainItem(m, accountName, nil)
 	m.CDebugf("KeychainSecretStore.StoreSecret(%s): deleting item before adding new one", accountName)
 	err = keychain.DeleteItem(item)
 	if err != nil {
 		// error probably ok here?
 		m.CDebugf("KeychainSecretStore.StoreSecret(%s): DeleteItem error: %s", accountName, err)
 	}
+
 	m.CDebugf("KeychainSecretStore.StoreSecret(%s): adding item", accountName)
+	// Base64 encode to make it easy to work with Keychain Access (since we are using a password item and secret is not utf-8)
+	encodedSecret := base64.StdEncoding.EncodeToString(secret.Bytes())
+	item = k.makeKeychainItem(m, accountName, []byte(encodedSecret))
 	err = keychain.AddItem(item)
 	if err != nil {
 		m.CWarningf("KeychainSecretStore.StoreSecret(%s): AddItem error: %s", accountName, err)


### PR DESCRIPTION
- it's a conjecture that the old keychain code didn't actually delete keychain items if their encodedSecret value differed
- this prevented some people, possibly, from reinstalling the app and being able to use the secret store, since their old value was never deleted
- we'll know for sure if this helps out affected users