### PR TITLE
fast path flip messages in dev conversations to bypass any state updates CORE-10266

### DIFF
--- a/go/chat/flipmanager.go
+++ b/go/chat/flipmanager.go
@@ -639,6 +639,10 @@ func (m *FlipManager) MaybeInjectFlipMessage(ctx context.Context, boxedMsg chat1
 	if err != nil {
 		m.Debug(ctx, "MaybeInjectFlipMessage: failed to unbox: %s", err)
 	}
+	if err := storage.New(m.G(), nil).SetMaxMsgID(ctx, convID, uid, msg.GetMessageID()); err != nil {
+		m.Debug(ctx, "MaybeInjectFlipMessage: failed to write max msgid: %s", err)
+		// charge forward from this error
+	}
 	// Ignore anything from the current device
 	sender := flip.UserDevice{
 		U: msg.Valid().ClientHeader.Sender,

--- a/go/chat/flipmanager.go
+++ b/go/chat/flipmanager.go
@@ -616,11 +616,28 @@ func (m *FlipManager) StartFlip(ctx context.Context, uid gregor1.UID, hostConvID
 }
 
 // MaybeInjectFlipMessage implements the types.CoinFlipManager interface
-func (m *FlipManager) MaybeInjectFlipMessage(ctx context.Context, msg chat1.MessageUnboxed,
-	convID chat1.ConversationID, topicType chat1.TopicType) {
+func (m *FlipManager) MaybeInjectFlipMessage(ctx context.Context, boxedMsg chat1.MessageBoxed,
+	inboxVers chat1.InboxVers, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType) bool {
 	// earliest of outs if this isn't a dev convo, an error, or the outbox ID message
-	if topicType != chat1.TopicType_DEV || !msg.IsValid() || m.isHostMessageInfoMsgID(msg.GetMessageID()) {
-		return
+	if topicType != chat1.TopicType_DEV || boxedMsg.GetMessageType() != chat1.MessageType_FLIP ||
+		m.isHostMessageInfoMsgID(boxedMsg.GetMessageID()) {
+		return false
+	}
+	defer m.Trace(ctx, func() error { return nil }, "MaybeInjectFlipMessage: convID: %s", convID)()
+	// Update inbox for this guy
+	if err := m.G().InboxSource.UpdateInboxVersion(ctx, uid, inboxVers); err != nil {
+		m.Debug(ctx, "MaybeInjectFlipMessage: failed to update inbox version: %s", err)
+		// charge forward here, we will figure it out
+	}
+	// Unbox the message
+	conv, err := utils.GetUnverifiedConv(ctx, m.G(), uid, convID, types.InboxSourceDataSourceAll)
+	if err != nil {
+		m.Debug(ctx, "MaybeInjectFlipMessage: failed to get conversation for unbox: %s", err)
+		return true
+	}
+	msg, err := NewBoxer(m.G()).UnboxMessage(ctx, boxedMsg, conv.Conv, nil)
+	if err != nil {
+		m.Debug(ctx, "MaybeInjectFlipMessage: failed to unbox: %s", err)
 	}
 	// Ignore anything from the current device
 	sender := flip.UserDevice{
@@ -628,17 +645,18 @@ func (m *FlipManager) MaybeInjectFlipMessage(ctx context.Context, msg chat1.Mess
 		D: msg.Valid().ClientHeader.SenderDevice,
 	}
 	if sender.Eq(m.Me()) {
-		return
+		return true
 	}
-	defer m.Trace(ctx, func() error { return nil }, "MaybeInjectFlipMessage: convID: %s", convID)()
 	body := msg.Valid().MessageBody
 	if !body.IsType(chat1.MessageType_FLIP) {
-		return
+		m.Debug(ctx, "MaybeInjectFlipMessage: bogus flip message with a non-flip body")
+		return true
 	}
 	if err := m.dealer.InjectIncomingChat(ctx, sender, convID, body.Flip().GameID,
 		flip.MakeGameMessageEncoded(body.Flip().Text), m.isStartMsgID(msg.GetMessageID())); err != nil {
 		m.Debug(ctx, "MaybeInjectFlipMessage: failed to inject: %s", err)
 	}
+	return true
 }
 
 func (m *FlipManager) loadGame(ctx context.Context, job loadGameJob) (err error) {

--- a/go/chat/flipmanager_test.go
+++ b/go/chat/flipmanager_test.go
@@ -18,6 +18,7 @@ import (
 
 func consumeFlipToResult(t *testing.T, ui *kbtest.ChatUI, listener *serverChatListener, numUsers int) string {
 	timeout := 20 * time.Second
+	consumeNewMsgRemote(t, listener, chat1.MessageType_FLIP) // host msg
 	for {
 		select {
 		case updates := <-ui.CoinFlipUpdates:

--- a/go/chat/flipmanager_test.go
+++ b/go/chat/flipmanager_test.go
@@ -19,7 +19,6 @@ import (
 func consumeFlipToResult(t *testing.T, ui *kbtest.ChatUI, listener *serverChatListener, numUsers int) string {
 	timeout := 20 * time.Second
 	for {
-		consumeNewMsgRemote(t, listener, chat1.MessageType_FLIP)
 		select {
 		case updates := <-ui.CoinFlipUpdates:
 			require.Equal(t, 1, len(updates))

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -429,6 +429,11 @@ func (s *RemoteInboxSource) UpgradeKBFSToImpteam(ctx context.Context, uid gregor
 	return conv, err
 }
 
+func (s *RemoteInboxSource) UpdateInboxVersion(ctx context.Context, uid gregor1.UID,
+	vers chat1.InboxVers) error {
+	return nil
+}
+
 type HybridInboxSource struct {
 	sync.Mutex
 	globals.Contextified
@@ -999,6 +1004,11 @@ func (s *HybridInboxSource) SubteamRename(ctx context.Context, uid gregor1.UID, 
 		return nil, nil
 	}
 	return convs, nil
+}
+
+func (s *HybridInboxSource) UpdateInboxVersion(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers) (err error) {
+	defer s.Trace(ctx, func() error { return err }, "UpdateInboxVersion")()
+	return s.createInbox().UpdateInboxVersion(ctx, uid, vers)
 }
 
 func (s *HybridInboxSource) modConversation(ctx context.Context, debugLabel string, uid gregor1.UID, convID chat1.ConversationID,

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -376,6 +376,7 @@ type FetchResult struct {
 // Merge requires msgs to be sorted by descending message ID
 func (s *Storage) Merge(ctx context.Context,
 	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed) (res MergeResult, err Error) {
+	defer s.Trace(ctx, func() error { return err }, "Merge")()
 	return s.MergeHelper(ctx, convID, uid, msgs, nil)
 }
 

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -342,12 +342,20 @@ func (s *Storage) maybeNukeLocked(ctx context.Context, force bool, err Error, co
 	return err
 }
 
-func (s *Storage) GetMaxMsgID(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (chat1.MessageID, error) {
+func (s *Storage) SetMaxMsgID(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
+	msgID chat1.MessageID) (err Error) {
+	defer s.Trace(ctx, func() error { return err }, "SetMaxMsgID")()
+	locks.Storage.Lock()
+	defer locks.Storage.Unlock()
+	return s.idtracker.bumpMaxMessageID(ctx, convID, uid, msgID)
+}
+
+func (s *Storage) GetMaxMsgID(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (maxMsgID chat1.MessageID, err Error) {
+	defer s.Trace(ctx, func() error { return err }, "GetMaxMsgID")()
 	locks.Storage.Lock()
 	defer locks.Storage.Unlock()
 
-	maxMsgID, err := s.idtracker.getMaxMessageID(ctx, convID, uid)
-	if err != nil {
+	if maxMsgID, err = s.idtracker.getMaxMessageID(ctx, convID, uid); err != nil {
 		return maxMsgID, s.maybeNukeLocked(ctx, false, err, convID, uid)
 	}
 	return maxMsgID, nil
@@ -368,7 +376,6 @@ type FetchResult struct {
 // Merge requires msgs to be sorted by descending message ID
 func (s *Storage) Merge(ctx context.Context,
 	convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed) (res MergeResult, err Error) {
-	defer s.Trace(ctx, func() error { return err }, "Merge")()
 	return s.MergeHelper(ctx, convID, uid, msgs, nil)
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -184,6 +184,7 @@ type InboxSource interface {
 	SetConvSettings(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convID chat1.ConversationID,
 		convSettings *chat1.ConversationSettings) (*chat1.ConversationLocal, error)
 	SubteamRename(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers, convIDs []chat1.ConversationID) ([]chat1.ConversationLocal, error)
+	UpdateInboxVersion(ctx context.Context, uid gregor1.UID, vers chat1.InboxVers) error
 
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)
@@ -435,8 +436,8 @@ type ConversationCommandsSource interface {
 type CoinFlipManager interface {
 	Resumable
 	StartFlip(ctx context.Context, uid gregor1.UID, hostConvID chat1.ConversationID, tlfName, text string) error
-	MaybeInjectFlipMessage(ctx context.Context, msg chat1.MessageUnboxed, convID chat1.ConversationID,
-		topicType chat1.TopicType)
+	MaybeInjectFlipMessage(ctx context.Context, boxedMsg chat1.MessageBoxed, inboxVers chat1.InboxVers,
+		uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType) bool
 	LoadFlip(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID, gameID chat1.FlipGameID)
 	DescribeFlipText(ctx context.Context, text string) string
 }

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -412,8 +412,9 @@ func (d DummyCoinFlipManager) Stop(ctx context.Context) chan struct{} {
 func (d DummyCoinFlipManager) StartFlip(ctx context.Context, uid gregor1.UID, hostConvID chat1.ConversationID, tlfName, text string) error {
 	return nil
 }
-func (d DummyCoinFlipManager) MaybeInjectFlipMessage(ctx context.Context, msg chat1.MessageUnboxed,
-	convID chat1.ConversationID, topicType chat1.TopicType) {
+func (d DummyCoinFlipManager) MaybeInjectFlipMessage(ctx context.Context, boxedMsg chat1.MessageBoxed,
+	inboxVers chat1.InboxVers, uid gregor1.UID, convID chat1.ConversationID, topicType chat1.TopicType) bool {
+	return false
 }
 
 func (d DummyCoinFlipManager) LoadFlip(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,


### PR DESCRIPTION
The goal is to make it so we can process these messages faster, to reduce chances of failed flips.