### PR TITLE
folder_block_manager: cancel all prefetches before cleaning cache

### DIFF
--- a/go/kbfs/libkbfs/folder_block_manager_test.go
+++ b/go/kbfs/libkbfs/folder_block_manager_test.go
@@ -685,6 +685,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	config.vdebugSetting = "vlog2"
 
 	config.EnableDiskLimiter(tempdir)
 	config.loadSyncedTlfsLocked()

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -3383,6 +3383,11 @@ func (fbo *folderBlockOps) UpdatePointers(kmd KeyMetadata, lState *lockState,
 		}
 	}
 
+	// Cancel any prefetches for all unreferenced block pointers.
+	for _, unref := range op.Unrefs() {
+		fbo.config.BlockOps().Prefetcher().CancelPrefetch(unref)
+	}
+
 	if afterUpdateFn == nil {
 		return affectedNodeIDs, nil
 	}

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -407,7 +407,7 @@ func (p *blockPrefetcher) cancelQueuedPrefetch(ptr BlockPointer) {
 		delete(p.queuedPrefetchHandles, ptr)
 		p.log.Debug("cancelled queued prefetch for block %s", ptr)
 	} else {
-		p.log.Debug("nothing to cancel for block %s", ptr)
+		p.vlog.Log(libkb.VLog1, "nothing to cancel for block %s", ptr)
 	}
 }
 


### PR DESCRIPTION
When `folderBranchOps` applies the changes from a new revision, it goes through each updated pointer, and cancels prefetches for the old version of the pointer.  But the pointers aren't ordered in anyway, so this scenario is possible, when block A points to block B:

1) Cancel prefetch for B.
2) Prefetch for A starts, which schedules a prefetch for B.
3) Cancel prefetch for A.
4) Cache-cleaning completes.
5) Prefetch for B starts, and block B is put into the cache after it was cleaned.

To fix this, let's do a second round of prefetch-cancellations before cleaning cache, and wait for each one individually to complete.  These two cancellation loops together should be enough to ensure that the block won't end up back in the cache.

Also, cancel prefetches for unreferenced (not just updated) blocks, which was an oversight in the existing code.

Issue: KBFS-3784