### PR TITLE
Dispatch closeTracker action before closing BrowserWindow

### DIFF
--- a/shared/reducers/tracker2.js
+++ b/shared/reducers/tracker2.js
@@ -4,6 +4,7 @@ import * as Constants from '../constants/tracker2'
 import * as Types from '../constants/types/tracker2'
 import * as Tracker2Gen from '../actions/tracker2-gen'
 import * as Flow from '../util/flow'
+import logger from '../logger'
 
 const initialState: Types.State = Constants.makeState()
 
@@ -13,6 +14,9 @@ export default function(state: Types.State = initialState, action: Tracker2Gen.A
       return initialState
     case Tracker2Gen.load: {
       const guiID = action.payload.guiID
+      if (action.payload.forceDisplay) {
+        logger.info(`Showing tracker for assertion: ${action.payload.assertion}`)
+      }
       return state.merge({
         usernameToDetails: state.usernameToDetails.updateIn(
           [action.payload.assertion],
@@ -71,6 +75,7 @@ export default function(state: Types.State = initialState, action: Tracker2Gen.A
       if (!username) {
         return state
       }
+      logger.info(`Closing tracker for assertion: ${username}`)
       return state.merge({
         usernameToDetails: state.usernameToDetails.updateIn([username], (old = Constants.makeDetails()) =>
           old.merge({showTracker: false})

--- a/shared/tracker2/remote-container.desktop.js
+++ b/shared/tracker2/remote-container.desktop.js
@@ -35,10 +35,10 @@ const mapDispatchToProps = dispatch => ({
     dispatch(Chat2Gen.createPreviewConversation({participants: [username], reason: 'tracker'}))
   },
   _onClose: (guiID: string) => {
+    dispatch(Tracker2Gen.createCloseTracker({guiID}))
     // close immediately
     const w = SafeElectron.getCurrentWindowFromRemote()
     w && w.close()
-    dispatch(Tracker2Gen.createCloseTracker({guiID}))
   },
   _onFollow: (guiID: string) => dispatch(Tracker2Gen.createChangeFollow({follow: true, guiID})),
   _onIgnoreFor24Hours: (guiID: string) => dispatch(Tracker2Gen.createIgnore({guiID})),


### PR DESCRIPTION
Fixes the tracker popup not reopening for the same user, the `closeTracker` action wasn't making it to the main window. The problem is only reproducible on a prod build, I tested by making a test darwin build. r? @keybase/react-hackers 