### PR TITLE
don't leak exploded message in snippet

### DIFF
--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -123,17 +123,17 @@ export const updateMeta = (
     // new is older, keep old
     return oldMeta
   } else if (oldMeta.inboxVersion === newMeta.inboxVersion) {
-    // same version, only take data if untrusted -> trusted
-    if (newMeta.trustedState === 'trusted' && oldMeta.trustedState !== 'trusted') {
+    // same version, take data if new is trusted
+    if (newMeta.trustedState === 'trusted') {
       // prettier-ignore
       return newMeta.withMutations(nm => {
-        // keep immutable stuff to reduce render thrashing
-        I.is(oldMeta.participants, nm.participants) && nm.set('participants', oldMeta.participants)
-        I.is(oldMeta.rekeyers, nm.rekeyers) && nm.set('rekeyers', oldMeta.rekeyers)
-        I.is(oldMeta.resetParticipants, nm.resetParticipants) && nm.set('resetParticipants', oldMeta.resetParticipants)
-        I.is(oldMeta.retentionPolicy, nm.retentionPolicy) && nm.set('retentionPolicy', oldMeta.retentionPolicy)
-        I.is(oldMeta.teamRetentionPolicy, nm.teamRetentionPolicy) && nm.set('teamRetentionPolicy', oldMeta.teamRetentionPolicy)
-      })
+          // keep immutable stuff to reduce render thrashing
+          I.is(oldMeta.participants, nm.participants) && nm.set('participants', oldMeta.participants)
+          I.is(oldMeta.rekeyers, nm.rekeyers) && nm.set('rekeyers', oldMeta.rekeyers)
+          I.is(oldMeta.resetParticipants, nm.resetParticipants) && nm.set('resetParticipants', oldMeta.resetParticipants)
+          I.is(oldMeta.retentionPolicy, nm.retentionPolicy) && nm.set('retentionPolicy', oldMeta.retentionPolicy)
+          I.is(oldMeta.teamRetentionPolicy, nm.teamRetentionPolicy) && nm.set('teamRetentionPolicy', oldMeta.teamRetentionPolicy)
+        })
     }
     return oldMeta
   }
@@ -338,7 +338,10 @@ export const getChannelSuggestions = (state: TypedState, teamname: string) => {
   // partial list of channels that you have joined).
   const convs = state.teams.getIn(['teamNameToChannelInfos', teamname])
   if (convs) {
-    return convs.toIndexedSeq().toList().map(conv => conv.channelname)
+    return convs
+      .toIndexedSeq()
+      .toList()
+      .map(conv => conv.channelname)
   }
   return state.chat2.metaMap
     .filter(v => v.teamname === teamname)

--- a/shared/constants/chat2/meta.js
+++ b/shared/constants/chat2/meta.js
@@ -123,17 +123,22 @@ export const updateMeta = (
     // new is older, keep old
     return oldMeta
   } else if (oldMeta.inboxVersion === newMeta.inboxVersion) {
-    // same version, take data if new is trusted
-    if (newMeta.trustedState === 'trusted') {
+    // same version, only take data if untrusted -> trusted
+    if (newMeta.trustedState === 'trusted' && oldMeta.trustedState !== 'trusted') {
       // prettier-ignore
       return newMeta.withMutations(nm => {
-          // keep immutable stuff to reduce render thrashing
-          I.is(oldMeta.participants, nm.participants) && nm.set('participants', oldMeta.participants)
-          I.is(oldMeta.rekeyers, nm.rekeyers) && nm.set('rekeyers', oldMeta.rekeyers)
-          I.is(oldMeta.resetParticipants, nm.resetParticipants) && nm.set('resetParticipants', oldMeta.resetParticipants)
-          I.is(oldMeta.retentionPolicy, nm.retentionPolicy) && nm.set('retentionPolicy', oldMeta.retentionPolicy)
-          I.is(oldMeta.teamRetentionPolicy, nm.teamRetentionPolicy) && nm.set('teamRetentionPolicy', oldMeta.teamRetentionPolicy)
-        })
+        // keep immutable stuff to reduce render thrashing
+        I.is(oldMeta.participants, nm.participants) && nm.set('participants', oldMeta.participants)
+        I.is(oldMeta.rekeyers, nm.rekeyers) && nm.set('rekeyers', oldMeta.rekeyers)
+        I.is(oldMeta.resetParticipants, nm.resetParticipants) && nm.set('resetParticipants', oldMeta.resetParticipants)
+        I.is(oldMeta.retentionPolicy, nm.retentionPolicy) && nm.set('retentionPolicy', oldMeta.retentionPolicy)
+        I.is(oldMeta.teamRetentionPolicy, nm.teamRetentionPolicy) && nm.set('teamRetentionPolicy', oldMeta.teamRetentionPolicy)
+      })
+    }
+    if (newMeta.trustedState === 'trusted' && oldMeta.trustedState === 'trusted') {
+      // TODO DESKTOP-9068 check localInboxVersion and take newMeta if it's higher
+      // For now take oldMeta + new snippet in case the last message exploded
+      return oldMeta.set('snippet', newMeta.snippet).set('snippetDecoration', newMeta.snippetDecoration)
     }
     return oldMeta
   }


### PR DESCRIPTION
When a message explodes via timeout (not explode now) the snippet updates but the inbox version doesn't. The recently new `updateMeta` function doesn't use the new meta in this case, so we started to leak the exploded message in the snippet. This changes `updateMeta` so if:
```
old.inboxVersion === new.inboxVersion && new.trustedState === 'trusted'
```
we take the new meta. This will take the new meta more often than the old condition which was
```
old.inboxVersion === new.inboxVersion && old.trustedState === 'untrusted' && new.trustedState === 'trusted'
```

Other options if we don't want to make this change:
* Increment the inboxVersion when this happens 🤞
* Signal that this meta update is due to an explode and take the new meta indiscriminately
* Keep the old logic, but accept the new snippet/decoration no matter what

Thoughts? @chrisnojima @mmaxim @joshblum 