### PR TITLE
folder_branch_ops: kick off partial sync on new edit message

### DIFF
--- a/go/kbfs/kbfsedits/user_history_test.go
+++ b/go/kbfs/kbfsedits/user_history_test.go
@@ -78,15 +78,15 @@ func TestUserHistorySimple(t *testing.T) {
 	}
 	privHomeTime := keybase1.ToTime(now)
 
-	err = privSharedTH.AddNotifications(bobName, privSharedBob)
+	_, err = privSharedTH.AddNotifications(bobName, privSharedBob)
 	require.NoError(t, err)
-	err = privSharedTH.AddNotifications(aliceName, privSharedAlice)
-	require.NoError(t, err)
-
-	err = privHomeTH.AddNotifications(aliceName, privHomeAlice)
+	_, err = privSharedTH.AddNotifications(aliceName, privSharedAlice)
 	require.NoError(t, err)
 
-	err = publicTH.AddNotifications(aliceName, publicAlice)
+	_, err = privHomeTH.AddNotifications(aliceName, privHomeAlice)
+	require.NoError(t, err)
+
+	_, err = publicTH.AddNotifications(aliceName, publicAlice)
 	require.NoError(t, err)
 
 	uh := NewUserHistory(logger.New("UH"))
@@ -141,7 +141,7 @@ func TestUserHistorySimple(t *testing.T) {
 	// Alice writes one more thing to the private shared folder.
 	now = now.Add(1 * time.Minute)
 	_ = privSharedNN.make("7", NotificationCreate, aliceUID, nil, now)
-	err = privSharedTH.AddNotifications(
+	_, err = privSharedTH.AddNotifications(
 		aliceName, []string{privSharedNN.encode(t)})
 	require.NoError(t, err)
 	uh.UpdateHistory(privSharedName, tlf.Private, privSharedTH, aliceName)

--- a/go/kbfs/libkbfs/favorites_test.go
+++ b/go/kbfs/libkbfs/favorites_test.go
@@ -240,7 +240,7 @@ func TestFavoritesControlUserHistory(t *testing.T) {
 
 	// Put a thing in user history.
 	history := kbfsedits.NewTlfHistory()
-	err = history.AddNotifications(username, []string{"hello"})
+	_, err = history.AddNotifications(username, []string{"hello"})
 	require.NoError(t, err)
 	config.UserHistory().UpdateHistory(tlf.CanonicalName(tlfName), tlfType,
 		history, username)

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -8482,7 +8482,7 @@ func (fbo *folderBranchOps) getEditMessages(
 			id, err)
 		return nil
 	}
-	err = fbo.editHistory.AddNotifications(channelName, messages)
+	_, err = fbo.editHistory.AddNotifications(channelName, messages)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Couldn't add messages for conv %s: %+v",
 			id, err)
@@ -8569,7 +8569,7 @@ func (fbo *folderBranchOps) handleEditActivity(
 	}
 	if a.message != "" {
 		fbo.log.CDebugf(ctx, "New edit message for %s", name)
-		err := fbo.editHistory.AddNotifications(name, []string{a.message})
+		_, err := fbo.editHistory.AddNotifications(name, []string{a.message})
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4617,14 +4617,6 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	checkStatus(aNode, FinishedPrefetch)
 
 	t.Log("Writer adds a file, which gets prefetched")
-	// Disable updates for the reader until after the edit
-	// notification is sent and delivered.  This reflects a real issue
-	// in production where the MD update can be delivered and
-	// processed before the edit notification, and thus the new
-	// activity wouldn't be properly prefetched.  TODO(KBFS-3698): fix
-	// this in production and remove this disabling.
-	c, err := DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
-	require.NoError(t, err)
 	bNode, _, err := kbfsOps2.CreateFile(ctx, aNode, "b", false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.Write(ctx, bNode, []byte("bdata"), 0)
@@ -4633,7 +4625,6 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps2.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
-	c <- struct{}{}
 
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
If a client gets notified about a new MD revision (via the mdserver) before it gets notified about the corresponding new edits from that revision (via chat), and there is no syncing explicitly configured for the folder, then the client's edit history wouldn't be up-to-date when it tried to sync the recent files based on that revision.

This change makes the new edit messages trigger a new partial sync if the client has already learned about the MD.

Issue: KBFS-3698