### PR TITLE
allow loadTeamPlusApplicationKeys to hit the offline RPC cache

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -2864,11 +2864,12 @@ type TeamReAddMemberAfterResetArg struct {
 }
 
 type LoadTeamPlusApplicationKeysArg struct {
-	SessionID       int             `codec:"sessionID" json:"sessionID"`
-	Id              TeamID          `codec:"id" json:"id"`
-	Application     TeamApplication `codec:"application" json:"application"`
-	Refreshers      TeamRefreshers  `codec:"refreshers" json:"refreshers"`
-	IncludeKBFSKeys bool            `codec:"includeKBFSKeys" json:"includeKBFSKeys"`
+	SessionID       int                 `codec:"sessionID" json:"sessionID"`
+	Id              TeamID              `codec:"id" json:"id"`
+	Application     TeamApplication     `codec:"application" json:"application"`
+	Refreshers      TeamRefreshers      `codec:"refreshers" json:"refreshers"`
+	IncludeKBFSKeys bool                `codec:"includeKBFSKeys" json:"includeKBFSKeys"`
+	Oa              OfflineAvailability `codec:"oa" json:"oa"`
 }
 
 type GetTeamRootIDArg struct {

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -3000,7 +3000,9 @@ type TeamsInterface interface {
 	TeamReAddMemberAfterReset(context.Context, TeamReAddMemberAfterResetArg) error
 	// * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.
 	// * If refreshers are non-empty, then force a refresh of the cache if the requirements
-	// * of the refreshers aren't met.
+	// * of the refreshers aren't met. If OfflineAvailability is set to BEST_EFFORT, and the
+	// * client is currently offline (or thinks it's offline), then the refreshers are overridden
+	// * and ignored, and stale data might still be returned.
 	LoadTeamPlusApplicationKeys(context.Context, LoadTeamPlusApplicationKeysArg) (TeamPlusApplicationKeys, error)
 	GetTeamRootID(context.Context, TeamID) (TeamID, error)
 	GetTeamShowcase(context.Context, string) (TeamShowcase, error)
@@ -3972,7 +3974,9 @@ func (c TeamsClient) TeamReAddMemberAfterReset(ctx context.Context, __arg TeamRe
 
 // * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.
 // * If refreshers are non-empty, then force a refresh of the cache if the requirements
-// * of the refreshers aren't met.
+// * of the refreshers aren't met. If OfflineAvailability is set to BEST_EFFORT, and the
+// * client is currently offline (or thinks it's offline), then the refreshers are overridden
+// * and ignored, and stale data might still be returned.
 func (c TeamsClient) LoadTeamPlusApplicationKeys(ctx context.Context, __arg LoadTeamPlusApplicationKeysArg) (res TeamPlusApplicationKeys, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.loadTeamPlusApplicationKeys", []interface{}{__arg}, &res)
 	return

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -150,7 +150,7 @@ func (d *Service) RegisterProtocols(srv *rpc.Server, xp rpc.Transporter, connID 
 		keybase1.SimpleFSProtocol(NewSimpleFSHandler(xp, g)),
 		keybase1.LogsendProtocol(NewLogsendHandler(xp, g)),
 		keybase1.AppStateProtocol(newAppStateHandler(xp, g)),
-		CancelingProtocol(g, keybase1.TeamsProtocol(NewTeamsHandler(xp, connID, cg, d.gregor)),
+		CancelingProtocol(g, keybase1.TeamsProtocol(NewTeamsHandler(xp, connID, cg, d)),
 			libkb.RPCCancelerReasonLogout),
 		keybase1.BadgerProtocol(newBadgerHandler(xp, g, d.badger)),
 		keybase1.MerkleProtocol(newMerkleHandler(xp, g)),

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/offline"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -488,7 +489,7 @@ func (h *TeamsHandler) LoadTeamPlusApplicationKeys(ctx context.Context, arg keyb
 	argKey.SessionID = 0
 	argKey.IncludeKBFSKeys = false
 
-	err = h.service.offlineRPCCache.Serve(mctx, arg.Oa, "teams.loadTeamPlusApplicationKeys", true, argKey, resp, loader)
+	err = h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "teams.loadTeamPlusApplicationKeys", true, argKey, resp, loader)
 	return res, err
 
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1031,7 +1031,9 @@ protocol teams {
   /**
    * loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.
    * If refreshers are non-empty, then force a refresh of the cache if the requirements
-   * of the refreshers aren't met.
+   * of the refreshers aren't met. If OfflineAvailability is set to BEST_EFFORT, and the
+   * client is currently offline (or thinks it's offline), then the refreshers are overridden
+   * and ignored, and stale data might still be returned.
    */
   TeamPlusApplicationKeys loadTeamPlusApplicationKeys(int sessionID, TeamID id, TeamApplication application, TeamRefreshers refreshers, boolean includeKBFSKeys, OfflineAvailability oa);
   TeamID getTeamRootID(TeamID id);

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1033,7 +1033,7 @@ protocol teams {
    * If refreshers are non-empty, then force a refresh of the cache if the requirements
    * of the refreshers aren't met.
    */
-  TeamPlusApplicationKeys loadTeamPlusApplicationKeys(int sessionID, TeamID id, TeamApplication application, TeamRefreshers refreshers, boolean includeKBFSKeys);
+  TeamPlusApplicationKeys loadTeamPlusApplicationKeys(int sessionID, TeamID id, TeamApplication application, TeamRefreshers refreshers, boolean includeKBFSKeys, OfflineAvailability oa);
   TeamID getTeamRootID(TeamID id);
 
   TeamShowcase getTeamShowcase(string name);

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2996,7 +2996,7 @@
         }
       ],
       "response": "TeamPlusApplicationKeys",
-      "doc": "* loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.\n   * If refreshers are non-empty, then force a refresh of the cache if the requirements\n   * of the refreshers aren't met."
+      "doc": "* loadTeamPlusApplicationKeys loads team information for applications like KBFS and Chat.\n   * If refreshers are non-empty, then force a refresh of the cache if the requirements\n   * of the refreshers aren't met. If OfflineAvailability is set to BEST_EFFORT, and the\n   * client is currently offline (or thinks it's offline), then the refreshers are overridden\n   * and ignored, and stale data might still be returned."
     },
     "getTeamRootID": {
       "request": [

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2989,6 +2989,10 @@
         {
           "name": "includeKBFSKeys",
           "type": "boolean"
+        },
+        {
+          "name": "oa",
+          "type": "OfflineAvailability"
         }
       ],
       "response": "TeamPlusApplicationKeys",


### PR DESCRIPTION
- don't add testing, but it should be covered mainly by existing tests and independent tests to the offline RPC system