### PR TITLE
Show placeholder text for empty followers/following on mobile profile view

### DIFF
--- a/shared/profile/user/container.js
+++ b/shared/profile/user/container.js
@@ -27,6 +27,8 @@ const mapStateToProps = (state, ownProps) => {
   const d = Constants.getDetails(state, username)
   const followThem = Constants.followThem(state, username)
   const _userIsYou = username === state.config.username
+  const followersCount = state.tracker2.usernameToDetails.getIn([username, 'followersCount'])
+  const followingCount = state.tracker2.usernameToDetails.getIn([username, 'followingCount'])
 
   return {
     _assertions: d.assertions,
@@ -35,7 +37,9 @@ const mapStateToProps = (state, ownProps) => {
     backgroundColorType: headerBackgroundColorType(d.state, followThem),
     followThem,
     followers: state.tracker2.usernameToDetails.getIn([username, 'followers']) || emptySet,
+    followersCount,
     following: state.tracker2.usernameToDetails.getIn([username, 'following']) || emptySet,
+    followingCount,
     guiID: d.guiID,
     state: d.state,
     username,
@@ -74,6 +78,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   assertionKeys: stateProps._assertions ? stateProps._assertions.keySeq().toArray() : null,
   backgroundColorType: stateProps.backgroundColorType,
   followThem: stateProps.followThem,
+  followersCount: stateProps.followersCount,
+  followingCount: stateProps.followingCount,
   onBack: dispatchProps.onBack,
   onEditAvatar: stateProps._userIsYou ? dispatchProps._onEditAvatar : null,
   onReload: () => dispatchProps._onReload(stateProps.username, stateProps._userIsYou),

--- a/shared/profile/user/index.js
+++ b/shared/profile/user/index.js
@@ -22,7 +22,9 @@ export type Props = {|
   backgroundColorType: BackgroundColorType,
   followThem: boolean,
   followers: Array<string>,
+  followersCount: ?number,
   following: Array<string>,
+  followingCount: ?number,
   onBack: () => void,
   onReload: () => void,
   onSearch: () => void,
@@ -117,6 +119,7 @@ const Proofs = p => {
 }
 
 type FriendshipTabsProps = {|
+  loading: boolean,
   onChangeFollowing: boolean => void,
   selectedFollowing: boolean,
   numFollowers: number,
@@ -139,7 +142,9 @@ class FriendshipTabs extends React.Component<FriendshipTabsProps> {
           following === this.props.selectedFollowing ? styles.followTabTextSelected : styles.followTabText
         }
       >
-        {following ? `Following (${this.props.numFollowing})` : `Followers (${this.props.numFollowers})`}
+        {following
+          ? `Following${!this.props.loading ? ` (${this.props.numFollowing})` : ''}`
+          : `Followers${!this.props.loading ? ` (${this.props.numFollowers})` : ''}`}
       </Kb.Text>
     </Kb.ClickableBox>
   )
@@ -263,9 +268,11 @@ class User extends React.Component<Props, State> {
         />
       )
     }
+    const loading = this.props.followersCount == null || this.props.followingCount == null
     return (
       <FriendshipTabs
         key="tabs"
+        loading={loading}
         numFollowers={this.props.followers.length}
         numFollowing={this.props.following.length}
         onChangeFollowing={this._changeFollowing}
@@ -309,12 +316,11 @@ class User extends React.Component<Props, State> {
   }
 
   render() {
-    console.warn(this.props.following)
     const friends = this.state.selectedFollowing ? this.props.following : this.props.followers
     const {itemsInARow, itemWidth} = widthToDimentions(this.state.width)
     // TODO memoize?
     let chunks = this.state.width ? chunk(friends, itemsInARow) : []
-    if (chunks.length === 0) {
+    if (chunks.length === 0 && this.props.followingCount !== null && this.props.followingCount !== null) {
       chunks.push({
         text: this.state.selectedFollowing ? 'You are not following anyone.' : 'You have no followers.',
         type: 'dummy',

--- a/shared/profile/user/index.js
+++ b/shared/profile/user/index.js
@@ -274,9 +274,14 @@ class User extends React.Component<Props, State> {
     )
   }
 
-  _renderOtherUsers = ({item, section, index}) => (
-    <FriendRow key={'friend' + index} usernames={item} itemWidth={section.itemWidth} />
-  )
+  _renderOtherUsers = ({item, section, index}) =>
+    item.type === 'dummy' ? (
+      <Kb.Box2 direction="horizontal" style={styles.textEmpty} centerChildren={true}>
+        <Kb.Text type="BodySmall">{item.text}</Kb.Text>
+      </Kb.Box2>
+    ) : (
+      <FriendRow key={'friend' + index} usernames={item} itemWidth={section.itemWidth} />
+    )
 
   _bioTeamProofsSection = {
     data: ['bioTeamProofs'],
@@ -304,10 +309,17 @@ class User extends React.Component<Props, State> {
   }
 
   render() {
+    console.warn(this.props.following)
     const friends = this.state.selectedFollowing ? this.props.following : this.props.followers
     const {itemsInARow, itemWidth} = widthToDimentions(this.state.width)
     // TODO memoize?
-    const chunks = this.state.width ? chunk(friends, itemsInARow) : []
+    let chunks = this.state.width ? chunk(friends, itemsInARow) : []
+    if (chunks.length === 0) {
+      chunks.push({
+        text: this.state.selectedFollowing ? 'You are not following anyone.' : 'You have no followers.',
+        type: 'dummy',
+      })
+    }
 
     return (
       <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.container}>
@@ -486,6 +498,10 @@ const styles = Styles.styleSheetCreate({
   teamShowcases: {
     flexShrink: 0,
     paddingBottom: Styles.globalMargins.small,
+  },
+  textEmpty: {
+    paddingBottom: Styles.globalMargins.small,
+    paddingTop: Styles.globalMargins.small,
   },
   typedBackgroundBlue: {backgroundColor: Styles.globalColors.blue},
   typedBackgroundGreen: {backgroundColor: Styles.globalColors.green},

--- a/shared/profile/user/index.js
+++ b/shared/profile/user/index.js
@@ -282,7 +282,7 @@ class User extends React.Component<Props, State> {
   }
 
   _renderOtherUsers = ({item, section, index}) =>
-    item.type === 'dummy' ? (
+    item.type === 'noFriends' ? (
       <Kb.Box2 direction="horizontal" style={styles.textEmpty} centerChildren={true}>
         <Kb.Text type="BodySmall">{item.text}</Kb.Text>
       </Kb.Box2>
@@ -323,7 +323,7 @@ class User extends React.Component<Props, State> {
     if (chunks.length === 0 && this.props.followingCount !== null && this.props.followingCount !== null) {
       chunks.push({
         text: this.state.selectedFollowing ? 'You are not following anyone.' : 'You have no followers.',
-        type: 'dummy',
+        type: 'noFriends',
       })
     }
 


### PR DESCRIPTION
@keybase/react-hackers

This was more involved than I expected.

~It looks like mobile's using identifyv3 (`profile/user/`), but desktop's still using the old mechanisms and store (via `friendships.desktop.js`).  Sounds like we should file a ticket for migrating the Followers/Following on desktop to identifyv3?~

I had to find a way to distinguish between a tracker2 profile being loaded or not loaded yet, and went with `followersCount === null` as the difference.

And there's now a sentinel list entry for the `profile/user` list renderer to use to show the placeholder text.