### PR TITLE
enable outOfDateBanner for admin

### DIFF
--- a/shared/util/feature-flags.desktop.js
+++ b/shared/util/feature-flags.desktop.js
@@ -28,6 +28,7 @@ const inAdmin: {[key: $Keys<FeatureFlags>]: boolean} = {
   chatIndexProfilingEnabled: true,
   identify3: true,
   moveOrCopy: true,
+  outOfDateBanner: true,
 }
 
 // load overrides


### PR DESCRIPTION
This is the out-of-date banner in the widget. I was gonna enable it for the release, but realized it wasn't on for admin yet. So just turn it on for admins for now.