### PR TITLE
cleanup ephemeral purger

### DIFF
--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -31,7 +31,7 @@ func setupLoaderTest(t *testing.T) (context.Context, *kbtest.ChatTestContext, *k
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := baseSender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_KBFS, nil)
+		chat1.ConversationMembersType_IMPTEAMNATIVE, nil)
 	firstMessageBoxed := prepareRes.Boxed
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/ephemeral_purger_test.go
+++ b/go/chat/ephemeral_purger_test.go
@@ -14,28 +14,56 @@ import (
 )
 
 func TestBackgroundPurge(t *testing.T) {
-	ctx, tc, world, _, baseSender, listener, res := setupLoaderTest(t)
+	ctx, tc, world, ri, baseSender, listener, conv1 := setupLoaderTest(t)
 	defer world.Cleanup()
 
 	g := globals.NewContext(tc.G, tc.ChatG)
 	u := world.GetUsers()[0]
 	uid := gregor1.UID(u.GetUID().ToBytes())
-	trip := newConvTriple(ctx, t, tc, u.Username)
+	trip1 := newConvTriple(ctx, t, tc, u.Username)
 	clock := world.Fc
 	chatStorage := storage.New(g, tc.ChatG.ConvSource)
 	chatStorage.SetClock(clock)
 
-	assertListener := func(convID chat1.ConversationID) {
+	<-g.EphemeralPurger.Stop(ctx)
+	purger := NewBackgroundEphemeralPurger(g, chatStorage)
+	purger.SetClock(world.Fc)
+	g.EphemeralPurger = purger
+	purger.Start(ctx, uid)
+
+	trip2 := newConvTriple(ctx, t, tc, u.Username)
+	trip2.TopicType = chat1.TopicType_DEV
+	firstMessagePlaintext := chat1.MessagePlaintext{
+		ClientHeader: chat1.MessageClientHeader{
+			Conv:        trip2,
+			TlfName:     u.Username,
+			TlfPublic:   false,
+			MessageType: chat1.MessageType_TLFNAME,
+		},
+		MessageBody: chat1.MessageBody{},
+	}
+	prepareRes, err := baseSender.Prepare(ctx, firstMessagePlaintext,
+		chat1.ConversationMembersType_IMPTEAMNATIVE, nil)
+	firstMessageBoxed := prepareRes.Boxed
+	require.NoError(t, err)
+	conv2, err := ri().NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
+		IdTriple:   trip2,
+		TLFMessage: firstMessageBoxed,
+	})
+	require.NoError(t, err)
+
+	assertListener := func(convID chat1.ConversationID, queueSize int) {
 		select {
-		case convID := <-listener.bgConvLoads:
-			require.Equal(t, res.ConvID, convID)
+		case loadID := <-listener.bgConvLoads:
+			require.Equal(t, convID, loadID)
+			require.Equal(t, queueSize, purger.pq.Len())
 		case <-time.After(10 * time.Second):
-			t.Fatal("timeout waiting for conversation load")
+			require.Fail(t, "timeout waiting for conversation load")
 		}
 	}
 
-	sendEphemeral := func(lifetime gregor1.DurationSec) {
-		_, _, err := baseSender.Send(ctx, res.ConvID, chat1.MessagePlaintext{
+	sendEphemeral := func(convID chat1.ConversationID, trip chat1.ConversationIDTriple, lifetime gregor1.DurationSec) chat1.MessageUnboxed {
+		_, _, err := baseSender.Send(ctx, convID, chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
 				Conv:              trip,
 				Sender:            uid,
@@ -49,6 +77,14 @@ func TestBackgroundPurge(t *testing.T) {
 			}),
 		}, 0, nil)
 		require.NoError(t, err)
+		thread, err := tc.ChatG.ConvSource.Pull(ctx, convID, uid,
+			chat1.GetThreadReason_GENERAL,
+			&chat1.GetThreadQuery{
+				MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
+			}, nil)
+		require.NoError(t, err)
+		require.True(t, len(thread.Messages) > 0)
+		return thread.Messages[0]
 	}
 
 	assertTrackerState := func(convID chat1.ConversationID, expectedPurgeInfo chat1.EphemeralPurgeInfo) {
@@ -74,87 +110,169 @@ func TestBackgroundPurge(t *testing.T) {
 	}
 
 	// Load our conv with the initial tlf msg
-	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
-		types.NewConvLoaderJob(res.ConvID, nil, &chat1.Pagination{Num: 3}, types.ConvLoaderPriorityHigh, nil)))
 	t.Logf("assert listener 0")
-	assertListener(res.ConvID)
+	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
+		types.NewConvLoaderJob(conv1.ConvID, nil, &chat1.Pagination{Num: 3}, types.ConvLoaderPriorityHigh, nil)))
+	assertListener(conv1.ConvID, 0)
+	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
+		types.NewConvLoaderJob(conv2.ConvID, nil, &chat1.Pagination{Num: 3}, types.ConvLoaderPriorityHigh, nil)))
+	assertListener(conv2.ConvID, 0)
 
 	// Nothing is up for purging yet
-	expectedPurgeInfo := chat1.EphemeralPurgeInfo{
-		ConvID:          res.ConvID,
+	assertTrackerState(conv1.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv1.ConvID,
 		MinUnexplodedID: 1,
 		NextPurgeTime:   0,
 		IsActive:        false,
-	}
-	assertTrackerState(res.ConvID, expectedPurgeInfo)
+	})
+	assertTrackerState(conv2.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv2.ConvID,
+		MinUnexplodedID: 1,
+		NextPurgeTime:   0,
+		IsActive:        false,
+	})
 
-	// Send two ephemeral messages, and ensure both get purged
+	// Send ephemeral messages, and ensure all get purged
 	lifetime := gregor1.DurationSec(1)
 	lifetimeDuration := time.Second
-	sendEphemeral(lifetime)
-	sendEphemeral(lifetime * 2)
-	sendEphemeral(lifetime * 3)
-
-	thread, err := tc.ChatG.ConvSource.Pull(ctx, res.ConvID, uid,
-		chat1.GetThreadReason_GENERAL,
-		&chat1.GetThreadQuery{
-			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
-		}, nil)
-	require.NoError(t, err)
-	msgs := thread.Messages
-	require.Len(t, msgs, 3)
-	msgUnboxed3 := msgs[0]
-	msgUnboxed2 := msgs[1]
-	msgUnboxed1 := msgs[2]
+	msgs := []chat1.MessageUnboxed{}
+	for i := 1; i <= 5; i++ {
+		convID := conv1.ConvID
+		trip := trip1
+		if i%2 == 0 {
+			convID = conv2.ConvID
+			trip = trip2
+		}
+		msg := sendEphemeral(convID, trip, lifetime*gregor1.DurationSec(i))
+		msgs = append(msgs, msg)
+	}
 
 	t.Logf("assert listener 1")
 	world.Fc.Advance(lifetimeDuration)
-	assertListener(res.ConvID)
-	assertTrackerState(res.ConvID, chat1.EphemeralPurgeInfo{
-		ConvID:          res.ConvID,
-		MinUnexplodedID: msgUnboxed2.GetMessageID(),
-		NextPurgeTime:   msgUnboxed2.Valid().Etime(),
+	assertListener(conv1.ConvID, 2)
+	assertEphemeralPurgeNotifInfo(conv1.ConvID, []chat1.MessageID{msgs[0].GetMessageID()})
+	assertTrackerState(conv1.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv1.ConvID,
+		MinUnexplodedID: msgs[2].GetMessageID(),
+		NextPurgeTime:   msgs[2].Valid().Etime(),
 		IsActive:        true,
 	})
-	assertEphemeralPurgeNotifInfo(res.ConvID, []chat1.MessageID{msgUnboxed1.GetMessageID()})
+	assertTrackerState(conv2.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv2.ConvID,
+		MinUnexplodedID: 1,
+		NextPurgeTime:   msgs[1].Valid().Etime(),
+		IsActive:        true,
+	})
 
-	// Ensure things run smoothly even with extraneous start/stop calls to purger
+	// Ensure things run smoothly even with extraneous start/stop calls to
+	// purger
 	g.EphemeralPurger.Start(context.Background(), uid)
 	<-g.EphemeralPurger.Stop(context.Background())
 	<-g.EphemeralPurger.Stop(context.Background())
 	g.EphemeralPurger.Start(context.Background(), uid)
 	g.EphemeralPurger.Start(context.Background(), uid)
+	assertListener(conv1.ConvID, 2)
 
 	t.Logf("assert listener 2")
 	world.Fc.Advance(lifetimeDuration)
-	assertListener(res.ConvID)
-	assertTrackerState(res.ConvID, chat1.EphemeralPurgeInfo{
-		ConvID:          res.ConvID,
-		MinUnexplodedID: msgUnboxed3.GetMessageID(),
-		NextPurgeTime:   msgUnboxed3.Valid().Etime(),
+	assertListener(conv2.ConvID, 2)
+	assertEphemeralPurgeNotifInfo(conv2.ConvID, []chat1.MessageID{msgs[1].GetMessageID()})
+	assertTrackerState(conv1.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv1.ConvID,
+		MinUnexplodedID: msgs[2].GetMessageID(),
+		NextPurgeTime:   msgs[2].Valid().Etime(),
 		IsActive:        true,
 	})
-	assertEphemeralPurgeNotifInfo(res.ConvID, []chat1.MessageID{msgUnboxed2.GetMessageID()})
+	assertTrackerState(conv2.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv2.ConvID,
+		MinUnexplodedID: msgs[3].GetMessageID(),
+		NextPurgeTime:   msgs[3].Valid().Etime(),
+		IsActive:        true,
+	})
 
-	// Stop the Purger, and ensure the final message gets purged when we Pull
+	// Stop the Purger, and ensure the next message gets purged when we Pull
 	// the conversation and the GUI get's a notification
 	<-g.EphemeralPurger.Stop(context.Background())
 	t.Logf("assert listener 3")
 	world.Fc.Advance(lifetimeDuration)
-	thread, err = tc.ChatG.ConvSource.Pull(ctx, res.ConvID, uid,
+	thread, err := tc.ChatG.ConvSource.Pull(ctx, conv1.ConvID, uid,
 		chat1.GetThreadReason_GENERAL,
 		&chat1.GetThreadQuery{
 			MessageTypes: []chat1.MessageType{chat1.MessageType_TEXT},
 		}, nil)
 	require.NoError(t, err)
 	require.Len(t, thread.Messages, 3)
-	assertTrackerState(res.ConvID, chat1.EphemeralPurgeInfo{
-		ConvID:          res.ConvID,
-		MinUnexplodedID: msgUnboxed3.GetMessageID(),
-		NextPurgeTime:   msgUnboxed3.Valid().Etime(),
+	assertEphemeralPurgeNotifInfo(conv1.ConvID, []chat1.MessageID{msgs[2].GetMessageID()})
+	assertTrackerState(conv1.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv1.ConvID,
+		MinUnexplodedID: msgs[2].GetMessageID(),
+		NextPurgeTime:   msgs[2].Valid().Etime(),
 		IsActive:        true,
 	})
-	assertEphemeralPurgeNotifInfo(res.ConvID, []chat1.MessageID{msgUnboxed3.GetMessageID()})
+	assertTrackerState(conv2.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv2.ConvID,
+		MinUnexplodedID: msgs[3].GetMessageID(),
+		NextPurgeTime:   msgs[3].Valid().Etime(),
+		IsActive:        true,
+	})
+	require.Equal(t, 2, purger.pq.Len())
+
+	g.EphemeralPurger.Start(ctx, uid)
+	world.Fc.Advance(lifetimeDuration * 3)
+	// keep the fakeclock ticking
+	go func() {
+		for i := 0; i < 10; i++ {
+			world.Fc.Advance(lifetimeDuration)
+			time.Sleep(lifetimeDuration)
+		}
+	}()
+
+	t.Logf("assert listener 4 & 5")
+	assertListener(conv2.ConvID, 0)
+	assertListener(conv1.ConvID, 0)
+	for i := 0; i < 3; i++ {
+		select {
+		case <-listener.bgConvLoads:
+		case <-time.After(time.Second):
+			require.Fail(t, "did not drain")
+		}
+	}
+	assertEphemeralPurgeNotifInfo(conv2.ConvID, []chat1.MessageID{msgs[3].GetMessageID()})
+	assertEphemeralPurgeNotifInfo(conv1.ConvID, []chat1.MessageID{msgs[4].GetMessageID()})
+	assertTrackerState(conv1.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv1.ConvID,
+		MinUnexplodedID: msgs[4].GetMessageID(),
+		NextPurgeTime:   0,
+		IsActive:        false,
+	})
+	assertTrackerState(conv2.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv2.ConvID,
+		MinUnexplodedID: msgs[3].GetMessageID(),
+		NextPurgeTime:   0,
+		IsActive:        false,
+	})
+
+	world.Fc.Advance(lifetimeDuration * 5)
+	select {
+	case <-listener.bgConvLoads:
+		require.Fail(t, "unexpected load")
+	case <-listener.ephemeralPurge:
+		require.Fail(t, "unexpected purge")
+	case <-time.After(1 * time.Second):
+	}
+	assertTrackerState(conv1.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv1.ConvID,
+		MinUnexplodedID: msgs[4].GetMessageID(),
+		NextPurgeTime:   0,
+		IsActive:        false,
+	})
+	assertTrackerState(conv2.ConvID, chat1.EphemeralPurgeInfo{
+		ConvID:          conv2.ConvID,
+		MinUnexplodedID: msgs[3].GetMessageID(),
+		NextPurgeTime:   0,
+		IsActive:        false,
+	})
+	require.Equal(t, 0, purger.pq.Len())
 }
 
 func TestQueueState(t *testing.T) {

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -141,7 +141,7 @@ func (n *chatListener) consumeEphemeralPurge(t *testing.T) chat1.EphemeralPurgeN
 }
 
 func newConvTriple(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext, username string) chat1.ConversationIDTriple {
-	return newConvTripleWithMembersType(ctx, t, tc, username, chat1.ConversationMembersType_KBFS)
+	return newConvTripleWithMembersType(ctx, t, tc, username, chat1.ConversationMembersType_IMPTEAMNATIVE)
 }
 
 func newConvTripleWithMembersType(ctx context.Context, t *testing.T, tc *kbtest.ChatTestContext,

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1986,6 +1986,13 @@ func (i EphemeralPurgeInfo) String() string {
 		i.ConvID, i.IsActive, i.NextPurgeTime.Time(), i.MinUnexplodedID)
 }
 
+func (i EphemeralPurgeInfo) Eq(o EphemeralPurgeInfo) bool {
+	return (i.IsActive == o.IsActive &&
+		i.MinUnexplodedID == o.MinUnexplodedID &&
+		i.NextPurgeTime == o.NextPurgeTime &&
+		i.ConvID.Eq(o.ConvID))
+}
+
 func (r ReactionMap) HasReactionFromUser(reactionText, username string) (found bool, reactionMsgID MessageID) {
 	reactions, ok := r.Reactions[reactionText]
 	if !ok {


### PR DESCRIPTION
- fixes a race in Stop/Start (which i think was only really trigger in tests)
- adds test cases of multiple conversations
- short circuits getting into the queue if already expired or already in the queue

the real bug continues to elude me since it is transient and haven't had any accurate logs with it manifesting but was hoping to catch it in the beefed up tests. 