### PR TITLE
Moved team-related type definitions to the correct protocol definition

### DIFF
--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -63,12 +63,6 @@ protocol Common {
   record TLFID {}
 
   @typedef("string")
-  record TeamID {}
-
-  @typedef("string")
-  record UserOrTeamID {}
-
-  @typedef("string")
   record GitRepoName {}
 
   @typedef("bytes")
@@ -96,16 +90,6 @@ protocol Common {
     ANY_0,
     PUBLIC_1,
     PRIVATE_2
-  }
-
-  record TeamIDWithVisibility {
-    TeamID teamID;
-    TLFVisibility visibility;
-  }
-
-  record TeamIDAndName {
-    TeamID id;
-    TeamName name;
   }
 
   @typedef("int64") @lint("ignore")

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -30,6 +30,9 @@ protocol Common {
   record UID {}
 
   @typedef("string")
+  record UserOrTeamID {}
+
+  @typedef("string")
   record DeviceID {}
 
   @typedef("string")

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -76,19 +76,6 @@ protocol Common {
     Seqno eldestSeqno;
   }
 
-  enum TeamType {
-    NONE_0,
-    LEGACY_1,
-    MODERN_2
-  }
-
-  // CompatibilityTeamID can refer to either a legacy TLF ID or a new-style team ID.
-  // Might eventually be useful but haven't found a need yet.
-  variant CompatibilityTeamID switch (TeamType typ) {
-    case LEGACY: TLFID;
-    case MODERN: TeamID;
-  }
-
   enum TLFVisibility {
     ANY_0,
     PUBLIC_1,

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -7,9 +7,6 @@ protocol teams {
   @typedef("string")
   record TeamID {}
 
-  @typedef("string")
-  record UserOrTeamID {}
-
   enum TeamRole {
     // These must be ordered by privilege.
     NONE_0,
@@ -524,6 +521,19 @@ protocol teams {
   record TeamIDAndName {
     TeamID id;
     TeamName name;
+  }
+
+  enum TeamType {
+    NONE_0,
+    LEGACY_1,
+    MODERN_2
+  }
+
+  // CompatibilityTeamID can refer to either a legacy TLF ID or a new-style team ID.
+  // Might eventually be useful but haven't found a need yet.
+  variant CompatibilityTeamID switch (TeamType typ) {
+    case LEGACY: TLFID;
+    case MODERN: TeamID;
   }
 
   // Sometimes during CLKR server will hint us that users are reset.

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -2,6 +2,14 @@
 
 protocol teams {
 
+  import idl "common.avdl";
+
+  @typedef("string")
+  record TeamID {}
+
+  @typedef("string")
+  record UserOrTeamID {}
+
   enum TeamRole {
     // These must be ordered by privilege.
     NONE_0,
@@ -506,6 +514,16 @@ protocol teams {
   // matches the team name struct from api server
   record TeamName {
     array<TeamNamePart> parts;
+  }
+
+  record TeamIDWithVisibility {
+    TeamID teamID;
+    TLFVisibility visibility;
+  }
+
+  record TeamIDAndName {
+    TeamID id;
+    TeamName name;
   }
 
   // Sometimes during CLKR server will hint us that users are reset.


### PR DESCRIPTION
keybase1/common.avdl had teams-related type definitions, including a reference to the record `TeamName` which is defined in keybase1/teams.avdl.

To get rid of the undefined reference I simply moved the stuff over to the correct definition file.