### PR TITLE
Warn in add to team dialog when role 'owner' is selected

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -656,12 +656,17 @@ function* addUserToTeams(state, action) {
   const errorAddingTo = []
   for (const team of teams) {
     try {
+      let rpcRole = RPCTypes.teamsTeamRole[role]
+      if (rpcRole === RPCTypes.teamsTeamRole.owner && Constants.getRole(state, team) !== 'owner') {
+        // can't add as owner if we're not an owner, add as admin instead
+        rpcRole = RPCTypes.teamsTeamRole.admin
+      }
       yield* Saga.callPromise(
         RPCTypes.teamsTeamAddMemberRpcPromise,
         {
           email: '',
           name: team,
-          role: role ? RPCTypes.teamsTeamRole[role] : RPCTypes.teamsTeamRole.none,
+          role: rpcRole,
           sendChatNotification: true,
           username: user,
         },

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -656,17 +656,12 @@ function* addUserToTeams(state, action) {
   const errorAddingTo = []
   for (const team of teams) {
     try {
-      let rpcRole = RPCTypes.teamsTeamRole[role]
-      if (rpcRole === RPCTypes.teamsTeamRole.owner && Constants.getRole(state, team) !== 'owner') {
-        // can't add as owner if we're not an owner, add as admin instead
-        rpcRole = RPCTypes.teamsTeamRole.admin
-      }
       yield* Saga.callPromise(
         RPCTypes.teamsTeamAddMemberRpcPromise,
         {
           email: '',
           name: team,
-          role: rpcRole,
+          role: RPCTypes.teamsTeamRole[role],
           sendChatNotification: true,
           username: user,
         },

--- a/shared/profile/add-to-team/container.js
+++ b/shared/profile/add-to-team/container.js
@@ -19,6 +19,7 @@ type OwnProps = RouteProps<{username: string}, {}>
 
 const mapStateToProps = (state, {routeProps}) => {
   return {
+    _teamNameToRole: state.teams.teamNameToRole,
     _them: routeProps.get('username'),
     teamProfileAddList: state.teams.get('teamProfileAddList'),
     teamnames: Constants.getSortedTeamnames(state),
@@ -31,18 +32,18 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps, navigateAppend}) 
     dispatch(TeamsGen.createAddUserToTeams({role, teams, user}))
     dispatch(navigateUp())
   },
-  loadTeamList: () => dispatch(TeamsGen.createGetTeamProfileAddList({username: routeProps.get('username')})),
-  onBack: () => {
-    dispatch(navigateUp())
-    dispatch(TeamsGen.createSetTeamProfileAddList({teamlist: I.List([])}))
-  },
-  onOpenRolePicker: (role: TeamRoleType, onComplete: (string, boolean) => void, styleCover?: Object) => {
+  _onOpenRolePicker: (
+    role: TeamRoleType,
+    onComplete: (string, boolean) => void,
+    ownerDisabledExp: string,
+    styleCover?: Object
+  ) => {
     dispatch(
       navigateAppend([
         {
           props: {
-            allowOwner: true,
             onComplete,
+            ownerDisabledExp,
             selectedRole: role,
             sendNotificationChecked: true,
             showNotificationCheckbox: false,
@@ -52,6 +53,11 @@ const mapDispatchToProps = (dispatch, {navigateUp, routeProps, navigateAppend}) 
         },
       ])
     )
+  },
+  loadTeamList: () => dispatch(TeamsGen.createGetTeamProfileAddList({username: routeProps.get('username')})),
+  onBack: () => {
+    dispatch(navigateUp())
+    dispatch(TeamsGen.createSetTeamProfileAddList({teamlist: I.List([])}))
   },
 })
 
@@ -65,12 +71,36 @@ const mergeProps = (stateProps, dispatchProps) => {
     onAddToTeams: (role: TeamRoleType, teams: Array<string>) =>
       dispatchProps._onAddToTeams(role, teams, stateProps._them),
     onBack: dispatchProps.onBack,
+    onOpenRolePicker: (
+      role: TeamRoleType,
+      onComplete: (string, boolean) => void,
+      selectedTeams: {[string]: boolean},
+      styleCover?: Object
+    ) => {
+      const selectedTeamsArr = Object.keys(selectedTeams).filter(st => selectedTeams[st])
+      const ownerDisabledExp = getOwnerDisabledExp(selectedTeamsArr, stateProps._teamNameToRole)
+      dispatchProps._onOpenRolePicker(role, onComplete, ownerDisabledExp, styleCover)
+    },
     teamProfileAddList: teamProfileAddList.toArray(),
     them: _them,
     title,
   }
 }
 
+const getOwnerDisabledExp = (selected, teamNameToRole) => {
+  for (let st of selected) {
+    // important for subteam check to come first
+    if (Constants.isSubteam(st)) {
+      return `${st} is a subteam which cannot have owners.`
+    } else if (teamNameToRole.get(st) !== 'owner') {
+      return `You are not an owner of ${st}.`
+    }
+  }
+  return ''
+}
+
+// The data flow in this component is confusing
+// TODO make the component a class and remove recompose
 export default compose(
   connect<OwnProps, _, _, _, _>(
     mapStateToProps,
@@ -86,7 +116,11 @@ export default compose(
     {role: 'writer', selectedTeams: {}, sendNotification: true},
     {
       onRoleChange: () => role => ({role}),
-      setSelectedTeams: () => selectedTeams => ({selectedTeams}),
+      setSelectedTeams: ({role}, {_teamNameToRole}) => selectedTeams => {
+        const selectedTeamsArr = Object.keys(selectedTeams).filter(st => selectedTeams[st])
+        const shouldSetRole = role === 'owner' && !!getOwnerDisabledExp(selectedTeamsArr, _teamNameToRole)
+        return {role: shouldSetRole ? 'admin' : role, selectedTeams}
+      },
       setSendNotification: () => sendNotification => ({sendNotification}),
     }
   ),

--- a/shared/profile/add-to-team/index.js
+++ b/shared/profile/add-to-team/index.js
@@ -114,29 +114,35 @@ const AddToTeam = (props: Props) => {
           )}
         </Box2>
       </ScrollView>
-      <Box2 direction={isMobile ? 'vertical' : 'horizontal'} style={addToTeam}>
-        <Text style={addToTeamTitle} type="BodySmall">
-          {props.them} will be added as a
-        </Text>
-        <DropdownButton
-          toggleOpen={() =>
-            props.onOpenRolePicker(props.role, selectedRole => props.onRoleChange(selectedRole))
-          }
-          selected={DropdownItem(props.role)}
-          style={{width: isMobile ? '100%' : 100}}
-        />
+      <Box2 alignItems="center" direction="vertical" gap="tiny" style={addToTeam} noShrink={true}>
+        <Box2 alignItems="center" direction={isMobile ? 'vertical' : 'horizontal'} gap="tiny">
+          <Text type="BodySmall">{props.them} will be added as a</Text>
+          <DropdownButton
+            toggleOpen={() =>
+              props.onOpenRolePicker(props.role, selectedRole => props.onRoleChange(selectedRole))
+            }
+            selected={DropdownItem(props.role)}
+            style={{width: isMobile ? '100%' : 100}}
+          />
+        </Box2>
+        {props.role.toLowerCase() === 'owner' && (
+          <Text type="BodySmall" center={true}>
+            {props.them} will be added as an owner to teams you're an owner of, otherwise they'll be added as
+            an admin.
+          </Text>
+        )}
+        <ButtonBar fullWidth={true} style={buttonBar}>
+          {!isMobile && <Button type="Secondary" onClick={props.onBack} label="Cancel" />}
+          <Button
+            disabled={selectedTeamCount === 0}
+            fullWidth={isMobile}
+            style={addButton}
+            type="Primary"
+            onClick={() => props.onSave(props.role, props.selectedTeams)}
+            label={selectedTeamCount <= 1 ? 'Add to team' : `Add to ${selectedTeamCount} teams`}
+          />
+        </ButtonBar>
       </Box2>
-      <ButtonBar fullWidth={true} style={buttonBar}>
-        {!isMobile && <Button type="Secondary" onClick={props.onBack} label="Cancel" />}
-        <Button
-          disabled={selectedTeamCount === 0}
-          fullWidth={isMobile}
-          style={addButton}
-          type="Primary"
-          onClick={() => props.onSave(props.role, props.selectedTeams)}
-          label={selectedTeamCount <= 1 ? 'Add to team' : `Add to ${selectedTeamCount} teams`}
-        />
-      </ButtonBar>
     </Box2>
   )
 }
@@ -184,21 +190,13 @@ const styleTeamRow = platformStyles({
 
 const addToTeam = platformStyles({
   common: {
-    alignItems: 'center',
     marginLeft: globalMargins.small,
     marginRight: globalMargins.small,
   },
   isElectron: {
     marginTop: globalMargins.small,
   },
-})
-
-const addToTeamTitle = platformStyles({
-  isElectron: {
-    marginRight: globalMargins.tiny,
-  },
   isMobile: {
-    marginBottom: globalMargins.tiny,
     marginTop: globalMargins.tiny,
   },
 })

--- a/shared/profile/add-to-team/index.js
+++ b/shared/profile/add-to-team/index.js
@@ -119,18 +119,16 @@ const AddToTeam = (props: Props) => {
           <Text type="BodySmall">{props.them} will be added as a</Text>
           <DropdownButton
             toggleOpen={() =>
-              props.onOpenRolePicker(props.role, selectedRole => props.onRoleChange(selectedRole))
+              props.onOpenRolePicker(
+                props.role,
+                selectedRole => props.onRoleChange(selectedRole),
+                props.selectedTeams
+              )
             }
             selected={DropdownItem(props.role)}
             style={{width: isMobile ? '100%' : 100}}
           />
         </Box2>
-        {props.role.toLowerCase() === 'owner' && (
-          <Text type="BodySmall" center={true}>
-            {props.them} will be added as an owner to teams you're an owner of. Otherwise they'll be added as
-            an admin.
-          </Text>
-        )}
         <ButtonBar fullWidth={true} style={buttonBar}>
           {!isMobile && <Button type="Secondary" onClick={props.onBack} label="Cancel" />}
           <Button

--- a/shared/profile/add-to-team/index.js
+++ b/shared/profile/add-to-team/index.js
@@ -127,7 +127,7 @@ const AddToTeam = (props: Props) => {
         </Box2>
         {props.role.toLowerCase() === 'owner' && (
           <Text type="BodySmall" center={true}>
-            {props.them} will be added as an owner to teams you're an owner of, otherwise they'll be added as
+            {props.them} will be added as an owner to teams you're an owner of. Otherwise they'll be added as
             an admin.
           </Text>
         )}

--- a/shared/profile/add-to-team/index.js.flow
+++ b/shared/profile/add-to-team/index.js.flow
@@ -20,7 +20,12 @@ export type Props = {
   loaded: {[string]: boolean},
   onBack: () => void,
   onCancel?: () => void,
-  onOpenRolePicker: (role: string, selectedRole: (Types.TeamRoleType) => void, styleCover?: Object) => void,
+  onOpenRolePicker: (
+    role: string,
+    selectedRole: (Types.TeamRoleType) => void,
+    selectedTeams: {[string]: boolean},
+    styleCover?: Object
+  ) => void,
   onRoleChange: string => void,
   onSave: (role: string, selectedTeams: {[string]: boolean}) => void,
   onToggle: string => void,

--- a/shared/profile/routes.js
+++ b/shared/profile/routes.js
@@ -48,11 +48,11 @@ const profileRoute = () => {
           controlledRolePicker: {
             children: {},
             component: ControlledRolePicker,
-            tags: makeLeafTags({layerOnTop: !isMobile}),
+            tags: makeLeafTags({fullscreen: isMobile, layerOnTop: !isMobile}),
           },
         },
         component: AddToTeam,
-        tags: makeLeafTags({layerOnTop: !isMobile}),
+        tags: makeLeafTags({fullscreen: isMobile, layerOnTop: !isMobile}),
       },
       editAvatar: {
         component: EditAvatar,

--- a/shared/teams/role-picker/controlled-container.js
+++ b/shared/teams/role-picker/controlled-container.js
@@ -19,6 +19,7 @@ export type ControlledRolePickerProps = {
   allowOwner?: boolean,
   allowAdmin?: boolean,
   headerTitle?: string,
+  ownerDisabledExp?: string,
   pluralizeRoleName?: boolean,
   showNotificationCheckbox?: boolean,
   sendNotificationChecked?: boolean,
@@ -39,6 +40,7 @@ const mapStateToProps = (state, {routeProps}) => {
   const addButtonLabel = routeProps.get('addButtonLabel')
   const allowAdmin = routeProps.get('allowAdmin')
   const allowOwner = routeProps.get('allowOwner')
+  const ownerDisabledExp = routeProps.get('ownerDisabledExp')
   const headerTitle = routeProps.get('headerTitle')
   const pluralizeRoleName = routeProps.get('pluralizeRoleName')
   const sendNotificationChecked = routeProps.get('sendNotificationChecked')
@@ -53,6 +55,7 @@ const mapStateToProps = (state, {routeProps}) => {
     controlled: true,
     currentType,
     headerTitle,
+    ownerDisabledExp,
     pluralizeRoleName,
     sendNotificationChecked,
     showSendNotification,

--- a/shared/teams/role-picker/index.js
+++ b/shared/teams/role-picker/index.js
@@ -27,6 +27,7 @@ export type RolePickerProps = {
   allowAdmin?: boolean,
   allowOwner?: boolean,
   headerTitle?: string,
+  ownerDisabledExp?: string,
   pluralizeRoleName?: boolean,
   sendNotification: boolean,
   teamname: string,
@@ -44,46 +45,54 @@ const makeRoleOption = (
   role: TeamRoleType,
   selected: TeamRoleType,
   setSelected: TeamRoleType => void,
-  pluralizeRoleName?: boolean = false,
-  disabled?: boolean = false
-) => (
-  <ClickableBox
-    hoverColor={globalColors.black_05}
-    style={{
-      ...globalStyles.flexBoxRow,
-      alignItems: 'center',
-      backgroundColor: selected === role ? globalColors.blue : globalColors.white,
-      borderRadius: 0,
-      padding: globalMargins.tiny,
-      paddingLeft: globalMargins.small,
-      paddingRight: globalMargins.large,
-      width: '100%',
-    }}
-    onClick={() => setSelected(role)}
-  >
-    <Icon type="iconfont-check" style={{alignSelf: 'center'}} color={globalColors.white} />
-    <Box style={{...globalStyles.flexBoxColumn, paddingLeft: globalMargins.small}}>
-      <Box style={globalStyles.flexBoxRow}>
-        {!!roleIconMap[role] && (
-          <Icon
-            type={roleIconMap[role]}
-            style={{
-              marginRight: globalMargins.xtiny,
-            }}
-            color={selected === role ? globalColors.white : roleIconColorMap[role]}
-            fontSize={16}
-          />
-        )}
-        <Text style={{color: selected === role ? globalColors.white : globalColors.black}} type="BodyBig">
-          {pluralizeRoleName ? pluralize(typeToLabel[role]) : typeToLabel[role]}
-        </Text>
+  pluralizeRoleName: boolean = false,
+  disabledExp?: string
+) => {
+  const subtext = disabledExp ? (
+    <Text type="BodySmallError">{disabledExp}</Text>
+  ) : (
+    <Text negative={selected === role} type="BodySmall">
+      {role && roleDescMap[role]}
+    </Text>
+  )
+  const children = (
+    <Box style={styles.optionContainer}>
+      <Icon type="iconfont-check" style={{alignSelf: 'center'}} color={globalColors.white} />
+      <Box style={{...globalStyles.flexBoxColumn, paddingLeft: globalMargins.small}}>
+        <Box style={globalStyles.flexBoxRow}>
+          {!!roleIconMap[role] && (
+            <Icon
+              type={roleIconMap[role]}
+              style={{
+                marginRight: globalMargins.xtiny,
+              }}
+              color={selected === role ? globalColors.white : roleIconColorMap[role]}
+              fontSize={16}
+            />
+          )}
+          <Text style={{color: selected === role ? globalColors.white : globalColors.black}} type="BodyBig">
+            {pluralizeRoleName ? pluralize(typeToLabel[role]) : typeToLabel[role]}
+          </Text>
+        </Box>
+        {subtext}
       </Box>
-      <Text style={{color: selected === role ? globalColors.white : globalColors.black_50}} type="BodySmall">
-        {role && roleDescMap[role]}
-      </Text>
     </Box>
-  </ClickableBox>
-)
+  )
+  return disabledExp ? (
+    <Box style={styles.disabledOption}>{children}</Box>
+  ) : (
+    <ClickableBox
+      style={{
+        backgroundColor: selected === role ? globalColors.blue : globalColors.white,
+        width: '100%',
+      }}
+      hoverColor={globalColors.black_05}
+      onClick={disabledExp ? null : () => setSelected(role)}
+    >
+      {children}
+    </ClickableBox>
+  )
+}
 
 // 1. Display roles for user to pick from
 export const RoleOptions = ({
@@ -95,6 +104,7 @@ export const RoleOptions = ({
   allowAdmin = true,
   allowOwner = true,
   headerTitle,
+  ownerDisabledExp,
   pluralizeRoleName = false,
   setSendNotification,
   sendNotification,
@@ -108,7 +118,8 @@ export const RoleOptions = ({
         {headerTitle || (username ? `Select a role for ${username}:` : 'Select a role:')}
       </Text>
     </Box>
-    {allowOwner && makeRoleOption('owner', selectedRole, setSelectedRole, pluralizeRoleName)}
+    {allowOwner &&
+      makeRoleOption('owner', selectedRole, setSelectedRole, pluralizeRoleName, ownerDisabledExp)}
     {allowAdmin && makeRoleOption('admin', selectedRole, setSelectedRole, pluralizeRoleName)}
     {makeRoleOption('writer', selectedRole, setSelectedRole, pluralizeRoleName)}
     {makeRoleOption('reader', selectedRole, setSelectedRole, pluralizeRoleName)}
@@ -241,12 +252,25 @@ const styles = styleSheetCreate({
     paddingBottom: globalMargins.tiny,
     paddingTop: globalMargins.small,
   },
+  disabledOption: {
+    opacity: 0.7,
+    width: '100%',
+  },
   headerBox: {
     marginBottom: globalMargins.small,
     marginTop: globalMargins.small,
   },
   headerTitle: {
     color: globalColors.black_50,
+  },
+  optionContainer: {
+    ...globalStyles.flexBoxRow,
+    alignItems: 'center',
+    borderRadius: 0,
+    padding: globalMargins.tiny,
+    paddingLeft: globalMargins.small,
+    paddingRight: globalMargins.large,
+    width: '100%',
   },
   promptBox: {
     margin: globalMargins.tiny,


### PR DESCRIPTION
(removed screenshots of unused)
Also fixes some styling in this footer area and of course swaps out `owner` for `admin` in the RPC call in this case. r? @keybase/react-hackers 