### PR TITLE
fix wallet pagination on desktop

### DIFF
--- a/shared/common-adapters/section-list.desktop.js
+++ b/shared/common-adapters/section-list.desktop.js
@@ -25,8 +25,8 @@ class SectionList extends React.Component<Props, State> {
   _mounted = true
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    if (this.props.items !== prevProps.items) {
-      // Items changed so let's also reset the onEndReached call
+    if (this.props.sections !== prevProps.sections) {
+      // sections changed so let's also reset the onEndReached call
       this._onEndReached = once(() => this.props.onEndReached && this.props.onEndReached())
     }
   }

--- a/shared/common-adapters/section-list.js.flow
+++ b/shared/common-adapters/section-list.js.flow
@@ -2,6 +2,9 @@
 import * as React from 'react'
 import {SectionList} from 'react-native'
 
+// This resolves to 'any'
+// check https://facebook.github.io/react-native/docs/sectionlist#props for the time being
+// TODO import the type from react-native
 export type Props = React.ElementProps<typeof SectionList>
 
 export default class extends SectionList {}


### PR DESCRIPTION
`react-native` exports are `any` because of this: https://github.com/keybase/client/blob/master/shared/libs/flow-interface.js.flow#L21
I started on redefining type `Props` here but the full type is huge (inherits from `VirtualizedSectionList` which inherits from `ScrollView`). Left a TODO to import the type from react-native. r? @keybase/react-hackers 