### PR TITLE
test_logger: fix newline when duping logs to stdout

### DIFF
--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -61,7 +61,7 @@ func (log *TestLogger) common(ctx context.Context, lvl logging.Level, useFatal b
 
 	if os.Getenv("KEYBASE_TEST_DUP_LOG_TO_STDOUT") != "" {
 		fmt.Printf(prepareString(ctx,
-			log.prefixCaller(log.extraDepth, lvl, fmts+"\n")), arg...)
+			log.prefixCaller(log.extraDepth, lvl, fmts))+"\n", arg...)
 	}
 
 	if ctx != nil {


### PR DESCRIPTION
Without this fix, the line breaks before the debug tags, making the logs pretty confusing.