### PR TITLE
cr: disk-based local dir block map

### DIFF
--- a/go/kbfs/libkbfs/block_tree.go
+++ b/go/kbfs/libkbfs/block_tree.go
@@ -1102,6 +1102,18 @@ func (bt *blockTree) ready(
 		}
 		off = nextBlockOff // Will be `nil` if there are no more blocks.
 
+		// Make sure there's only one copy of each pblock among all
+		// the paths, so `readyHelper` can update the blocks in place
+		// along any path, and they will all be updated.
+		for _, p := range dirtyLeafPaths {
+			for i := range parentBlocks {
+				if i == 0 || p[i-1].childBlockPtr() ==
+					parentBlocks[i-1].childBlockPtr() {
+					parentBlocks[i].pblock = p[i].pblock
+				}
+			}
+		}
+
 		dirtyLeafPaths = append(dirtyLeafPaths,
 			append(parentBlocks, parentBlockAndChildIndex{block, -1}))
 	}

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -2444,7 +2444,8 @@ func (cr *ConflictResolver) doOneAction(
 					}
 					uDir = cr.fbo.blocks.newDirDataWithDBMLocked(
 						lState, newPath, chargedTo,
-						mergedChains.mostRecentChainMDInfo, nil)
+						mergedChains.mostRecentChainMDInfo,
+						newDirBlockMapMemory())
 				}
 			}
 
@@ -3622,8 +3623,6 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	// "unmerged" ops need to be pushed as part of the MD update,
 	// while the "merged" ops need to be applied locally.
 
-	// dbm contains the modified directory blocks we need to sync
-	dbm := newDirBlockMapMemory()
 	// newFileBlocks contains the copies of the file blocks we need to
 	// sync.  If a block is indirect, we need to put it and add new
 	// references for all indirect pointers inside it.  If it is not
@@ -3639,6 +3638,8 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 		cr.config, dbc, mergedChains.mostRecentChainMDInfo, cr.fbo.branch())
 	newFileBlocks := newFileBlockMapDisk(
 		dirtyBcache, mergedChains.mostRecentChainMDInfo)
+	// dbm contains the modified directory blocks we need to sync
+	dbm := newDirBlockMapDisk(dirtyBcache, mergedChains.mostRecentChainMDInfo)
 
 	err = cr.doActions(ctx, lState, unmergedChains, mergedChains,
 		unmergedPaths, mergedPaths, actionMap, dbm, newFileBlocks, dirtyBcache)

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -1292,18 +1292,18 @@ func TestCRDoActionsSimple(t *testing.T) {
 		t.Fatalf("Couldn't compute actions: %v", err)
 	}
 
-	lbc := make(localBcache)
+	dbm := newDirBlockMapMemory()
 	newFileBlocks := newFileBlockMapMemory()
 	dirtyBcache := simpleDirtyBlockCacheStandard()
 	err = cr2.doActions(ctx, lState, unmergedChains, mergedChains,
-		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks, dirtyBcache)
+		unmergedPaths, mergedPaths, actionMap, dbm, newFileBlocks, dirtyBcache)
 	if err != nil {
 		t.Fatalf("Couldn't do actions: %v", err)
 	}
 
 	// Does the merged block contain both entries?
 	mergedRootPath := cr1.fbo.nodeCache.PathFromNode(dir1)
-	block1, ok := lbc[mergedRootPath.tailPointer()]
+	block1, ok := dbm.blocks[mergedRootPath.tailPointer()]
 	if !ok {
 		t.Fatalf("Couldn't find merged block at path %s", mergedRootPath)
 	}
@@ -1415,11 +1415,11 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 		t.Fatalf("Couldn't compute actions: %v", err)
 	}
 
-	lbc := make(localBcache)
+	dbm := newDirBlockMapMemory()
 	newFileBlocks := newFileBlockMapMemory()
 	dirtyBcache := simpleDirtyBlockCacheStandard()
 	err = cr2.doActions(ctx, lState, unmergedChains, mergedChains,
-		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks, dirtyBcache)
+		unmergedPaths, mergedPaths, actionMap, dbm, newFileBlocks, dirtyBcache)
 	if err != nil {
 		t.Fatalf("Couldn't do actions: %v", err)
 	}

--- a/go/kbfs/libkbfs/cr_chains.go
+++ b/go/kbfs/libkbfs/cr_chains.go
@@ -297,8 +297,9 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 		FolderBranch: fbo.folderBranch,
 		path:         []pathNode{{parentMostRecent, ""}},
 	}
-	parentDD, cleanupFn := fbo.newDirDataWithLBC(
-		makeFBOLockState(), parentPath, keybase1.UserOrTeamID(""), kmd, nil)
+	parentDD, cleanupFn := fbo.newDirDataWithDBM(
+		makeFBOLockState(), parentPath, keybase1.UserOrTeamID(""), kmd,
+		newDirBlockMapMemory())
 	defer cleanupFn()
 	entries, err := parentDD.getEntries(ctx)
 	if err != nil {

--- a/go/kbfs/libkbfs/dir_block_map_disk.go
+++ b/go/kbfs/libkbfs/dir_block_map_disk.go
@@ -1,0 +1,76 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// dirBlockMapDisk tracks dir block info while making a revision, by
+// using a disk-based block cache.
+type dirBlockMapDisk struct {
+	dirtyBcache *DirtyBlockCacheDisk
+	kmd         KeyMetadata
+	ptrs        map[BlockPointer]bool
+}
+
+var _ dirBlockMap = (*dirBlockMapDisk)(nil)
+
+func newDirBlockMapDisk(
+	dirtyBcache *DirtyBlockCacheDisk, kmd KeyMetadata) *dirBlockMapDisk {
+	return &dirBlockMapDisk{
+		dirtyBcache: dirtyBcache,
+		kmd:         kmd,
+		ptrs:        make(map[BlockPointer]bool),
+	}
+}
+
+func (dbmd *dirBlockMapDisk) putBlock(
+	ctx context.Context, ptr BlockPointer, block *DirBlock) error {
+	err := dbmd.dirtyBcache.Put(
+		ctx, dbmd.kmd.TlfID(), ptr, MasterBranch, block)
+	if err != nil {
+		return err
+	}
+
+	dbmd.ptrs[ptr] = true
+	return nil
+}
+
+func (dbmd *dirBlockMapDisk) getBlock(
+	ctx context.Context, ptr BlockPointer) (*DirBlock, error) {
+	if !dbmd.ptrs[ptr] {
+		return nil, errors.Errorf("No such block %s", ptr)
+	}
+	block, err := dbmd.dirtyBcache.Get(ctx, dbmd.kmd.TlfID(), ptr, MasterBranch)
+	if err != nil {
+		return nil, err
+	}
+	dblock, ok := block.(*DirBlock)
+	if !ok {
+		return nil, errors.Errorf(
+			"Unexpected block type for dir block: %T", block)
+	}
+	return dblock, nil
+}
+
+func (dbmd *dirBlockMapDisk) hasBlock(
+	_ context.Context, ptr BlockPointer) (bool, error) {
+	return dbmd.ptrs[ptr], nil
+}
+
+func (dbmd *dirBlockMapDisk) deleteBlock(
+	_ context.Context, ptr BlockPointer) error {
+	delete(dbmd.ptrs, ptr)
+	return nil
+}
+
+// numBlocks only tracks the blocks that have been put into the dirty
+// block cache since `dbdm` was constructed.
+func (dbmd *dirBlockMapDisk) numBlocks() int {
+	return len(dbmd.ptrs)
+}

--- a/go/kbfs/libkbfs/dir_block_map_memory.go
+++ b/go/kbfs/libkbfs/dir_block_map_memory.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// dirBlockMapMemory is an internal structure to track file block
+// data in memory when putting blocks.
+type dirBlockMapMemory struct {
+	blocks map[BlockPointer]*DirBlock
+}
+
+var _ dirBlockMap = (*dirBlockMapMemory)(nil)
+
+func newDirBlockMapMemory() *dirBlockMapMemory {
+	return &dirBlockMapMemory{make(map[BlockPointer]*DirBlock)}
+}
+
+func (dbmm *dirBlockMapMemory) putBlock(
+	_ context.Context, ptr BlockPointer, block *DirBlock) error {
+	dbmm.blocks[ptr] = block
+	return nil
+}
+
+func (dbmm *dirBlockMapMemory) getBlock(
+	_ context.Context, ptr BlockPointer) (*DirBlock, error) {
+	block, ok := dbmm.blocks[ptr]
+	if !ok {
+		return nil, errors.Errorf("No such block for %s", ptr)
+	}
+	return block, nil
+}
+
+func (dbmm *dirBlockMapMemory) hasBlock(
+	_ context.Context, ptr BlockPointer) (bool, error) {
+	_, ok := dbmm.blocks[ptr]
+	return ok, nil
+}
+
+func (dbmm *dirBlockMapMemory) deleteBlock(
+	_ context.Context, ptr BlockPointer) error {
+	delete(dbmm.blocks, ptr)
+	return nil
+}
+
+func (dbmm *dirBlockMapMemory) numBlocks() int {
+	return len(dbmm.blocks)
+}

--- a/go/kbfs/libkbfs/dir_data.go
+++ b/go/kbfs/libkbfs/dir_data.go
@@ -243,9 +243,7 @@ func (dd *dirData) processModifiedBlock(
 		}
 
 		// Shift it over if needed.
-		topBlock := rightParents[0].pblock
-		_, newUnrefs, _, err :=
-			dd.tree.shiftBlocksToFillHole(ctx, topBlock, rightParents)
+		_, newUnrefs, _, err := dd.tree.shiftBlocksToFillHole(ctx, rightParents)
 		if err != nil {
 			return nil, err
 		}

--- a/go/kbfs/libkbfs/file_data.go
+++ b/go/kbfs/libkbfs/file_data.go
@@ -487,7 +487,7 @@ func (fd *fileData) write(ctx context.Context, data []byte, off Int64Offset,
 			// the hole and shift everything else over.
 			if needFillHole {
 				newDirtyPtrs, newUnrefs, bytes, err :=
-					fd.tree.shiftBlocksToFillHole(ctx, topBlock, rightParents)
+					fd.tree.shiftBlocksToFillHole(ctx, rightParents)
 				if err != nil {
 					return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
 				}

--- a/go/kbfs/libkbfs/folder_update_prepper.go
+++ b/go/kbfs/libkbfs/folder_update_prepper.go
@@ -376,6 +376,13 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			for _, unref := range unrefs {
 				md.AddUnrefBlock(unref)
 			}
+			// Fetch the current block again, since `setEntry` might
+			// not modify the original `currBlock`, but some
+			// re-assembled version if the disk cache is in use.
+			currBlock, err = dbm.getBlock(ctx, currDD.rootBlockPointer())
+			if err != nil {
+				return path{}, DirEntry{}, err
+			}
 		}
 		currName = nextName
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2781,3 +2781,13 @@ type fileBlockMap interface {
 		*FileBlock, error)
 	getFilenames(ctx context.Context, parentPtr BlockPointer) ([]string, error)
 }
+
+type dirBlockMap interface {
+	putBlock(
+		ctx context.Context, ptr BlockPointer, block *DirBlock) error
+	getBlock(
+		ctx context.Context, ptr BlockPointer) (*DirBlock, error)
+	hasBlock(ctx context.Context, ptr BlockPointer) (bool, error)
+	deleteBlock(ctx context.Context, ptr BlockPointer) error
+	numBlocks() int
+}

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -11420,3 +11420,84 @@ func (mr *MockfileBlockMapMockRecorder) getFilenames(ctx, parentPtr interface{})
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getFilenames", reflect.TypeOf((*MockfileBlockMap)(nil).getFilenames), ctx, parentPtr)
 }
+
+// MockdirBlockMap is a mock of dirBlockMap interface
+type MockdirBlockMap struct {
+	ctrl     *gomock.Controller
+	recorder *MockdirBlockMapMockRecorder
+}
+
+// MockdirBlockMapMockRecorder is the mock recorder for MockdirBlockMap
+type MockdirBlockMapMockRecorder struct {
+	mock *MockdirBlockMap
+}
+
+// NewMockdirBlockMap creates a new mock instance
+func NewMockdirBlockMap(ctrl *gomock.Controller) *MockdirBlockMap {
+	mock := &MockdirBlockMap{ctrl: ctrl}
+	mock.recorder = &MockdirBlockMapMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdirBlockMap) EXPECT() *MockdirBlockMapMockRecorder {
+	return m.recorder
+}
+
+// putBlock mocks base method
+func (m *MockdirBlockMap) putBlock(ctx context.Context, ptr BlockPointer, block *DirBlock) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "putBlock", ctx, ptr, block)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// putBlock indicates an expected call of putBlock
+func (mr *MockdirBlockMapMockRecorder) putBlock(ctx, ptr, block interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "putBlock", reflect.TypeOf((*MockdirBlockMap)(nil).putBlock), ctx, ptr, block)
+}
+
+// getBlock mocks base method
+func (m *MockdirBlockMap) getBlock(ctx context.Context, ptr BlockPointer) (*DirBlock, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getBlock", ctx, ptr)
+	ret0, _ := ret[0].(*DirBlock)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getBlock indicates an expected call of getBlock
+func (mr *MockdirBlockMapMockRecorder) getBlock(ctx, ptr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getBlock", reflect.TypeOf((*MockdirBlockMap)(nil).getBlock), ctx, ptr)
+}
+
+// hasBlock mocks base method
+func (m *MockdirBlockMap) hasBlock(ctx context.Context, ptr BlockPointer) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "hasBlock", ctx, ptr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// hasBlock indicates an expected call of hasBlock
+func (mr *MockdirBlockMapMockRecorder) hasBlock(ctx, ptr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hasBlock", reflect.TypeOf((*MockdirBlockMap)(nil).hasBlock), ctx, ptr)
+}
+
+// numBlocks mocks base method
+func (m *MockdirBlockMap) numBlocks() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "numBlocks")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// numBlocks indicates an expected call of numBlocks
+func (mr *MockdirBlockMapMockRecorder) numBlocks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "numBlocks", reflect.TypeOf((*MockdirBlockMap)(nil).numBlocks))
+}


### PR DESCRIPTION
This turns the existing data structure `localBcache` into an interface called `dirBlockMap`.  This structure holds all the directory blocks while prepping updates, either for normal sync operations, or for conflict resolution.  In the latter case, the number of directories being updated could in theory be very large, so we want to store those in a disk-based cache instead of in memory.

To get this to work, this PR also fixes all the place in the code that assumed a directory block could be modified without re-putting it into the cache, or subsequently re-getting it from the cache.  This is necessary since, with the disk-based cache, the `*DirBlock` is re-assembled from disk each time it's accessed.

Issue: KBFS-3818