### PR TITLE
file_data: remove "file too big for CR" error

### DIFF
--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -1041,17 +1041,6 @@ func (e cachePutCacheFullError) Error() string {
 		e.blockID)
 }
 
-// FileTooBigForCRError indicates that a file is too big to fit in
-// memory, and CR can't handle it.
-type FileTooBigForCRError struct {
-	p path
-}
-
-// Error implements the error interface for FileTooBigForCRError.
-func (e FileTooBigForCRError) Error() string {
-	return fmt.Sprintf("Cannot complete CR because the file %s is too big", e.p)
-}
-
 // NoMergedMDError indicates that no MDs for this folder have been
 // created yet.
 type NoMergedMDError struct {

--- a/go/kbfs/libkbfs/file_data.go
+++ b/go/kbfs/libkbfs/file_data.go
@@ -1255,19 +1255,6 @@ func (fd *fileData) undupChildrenInCopy(ctx context.Context,
 			"Indirect file %v had no indirect blocks", fd.rootBlockPointer())
 	}
 
-	// If the number of leaf blocks (len(pfr)) is likely to represent
-	// a file greater than 2 GB, abort conflict resolution.  Until
-	// disk caching is ready, we'll have to help people deal with this
-	// on a case-by-case basis.  // TODO: once the disk-backed cache
-	// is ready, make sure we use it here for both the dirty block
-	// cache and blockPutState (via some sort of "ready" block cache),
-	// so we avoid memory explosion in the case of journaling and
-	// multiple devices modifying the same large file or set of files.
-	// And then remove this check.
-	if len(pfr) > (2*1024*1024*1024)/MaxBlockSizeBytesDefault {
-		return nil, FileTooBigForCRError{fd.tree.file}
-	}
-
 	// Append the leaf block to each path, since readyHelper expects it.
 	// TODO: parallelize these fetches.
 	for i, path := range pfr {

--- a/go/kbfs/libkbfs/reporter_kbpki.go
+++ b/go/kbfs/libkbfs/reporter_kbpki.go
@@ -132,9 +132,6 @@ func (r *ReporterKBPKI) ReportErr(ctx context.Context,
 	case NeedOtherRekeyError:
 		code = keybase1.FSErrorType_REKEY_NEEDED
 		params[errorParamRekeySelf] = "false"
-	case FileTooBigForCRError:
-		code = keybase1.FSErrorType_NOT_IMPLEMENTED
-		params[errorParamFeature] = errorFeatureFileLimit
 	case kbfsmd.NewMetadataVersionError:
 		code = keybase1.FSErrorType_OLD_VERSION
 		err = OutdatedVersionError{}


### PR DESCRIPTION
Now that we store blocks on disk during CR, there's no need for a hard limit on file size.  If the disk fills up during CR, the code will `RemoveAll` the CR directory and treat it like a normal error, rather than just panic'ing.