### PR TITLE
folder_block_manager: wrap defer in func to set next QR period

### DIFF
--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1022,7 +1022,9 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	fbm.setReclamationCancel(cancel)
 	defer fbm.cancelReclamation()
 	nextPeriod := fbm.config.Mode().QuotaReclamationPeriod()
-	defer timer.Reset(nextPeriod)
+	defer func() {
+		timer.Reset(nextPeriod)
+	}()
 	defer fbm.reclamationGroup.Done()
 
 	// Don't set a context deadline.  For users that have written a

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1023,6 +1023,9 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	defer fbm.cancelReclamation()
 	nextPeriod := fbm.config.Mode().QuotaReclamationPeriod()
 	defer func() {
+		// `nextPeriod` may be changed by later code in this function,
+		// to speed up the next QR cycle when we couldn't reclaim a
+		// complete set of blocks during this run.
 		timer.Reset(nextPeriod)
 	}()
 	defer fbm.reclamationGroup.Done()


### PR DESCRIPTION
`nextPeriod` can be changed in the code below, so it shouldn't be interpreted until the `defer` actually executes.