### PR TITLE
Bring flip help text up faster

### DIFF
--- a/go/chat/commands/base.go
+++ b/go/chat/commands/base.go
@@ -23,9 +23,10 @@ type baseCommand struct {
 	aliases     []string
 	usage       string
 	description string
+	hasHelpText bool
 }
 
-func newBaseCommand(g *globals.Context, name, usage, desc string, aliases ...string) *baseCommand {
+func newBaseCommand(g *globals.Context, name, usage, desc string, hasHelpText bool, aliases ...string) *baseCommand {
 	return &baseCommand{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), fmt.Sprintf("Commands.%s", name), false),
@@ -33,6 +34,7 @@ func newBaseCommand(g *globals.Context, name, usage, desc string, aliases ...str
 		usage:        usage,
 		aliases:      aliases,
 		description:  desc,
+		hasHelpText:  hasHelpText,
 	}
 }
 
@@ -88,6 +90,10 @@ func (b *baseCommand) Description() string {
 	return b.description
 }
 
+func (b *baseCommand) HasHelpText() bool {
+	return b.hasHelpText
+}
+
 func (b *baseCommand) Preview(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
 	text string) {
 }
@@ -97,5 +103,6 @@ func (b *baseCommand) Export() chat1.ConversationCommand {
 		Name:        b.Name(),
 		Usage:       b.Usage(),
 		Description: b.Description(),
+		HasHelpText: b.HasHelpText(),
 	}
 }

--- a/go/chat/commands/collapse.go
+++ b/go/chat/commands/collapse.go
@@ -15,7 +15,7 @@ type Collapse struct {
 
 func NewCollapse(g *globals.Context) *Collapse {
 	return &Collapse{
-		baseCommand: newBaseCommand(g, "collapse", "", "Collapse all inline previews"),
+		baseCommand: newBaseCommand(g, "collapse", "", "Collapse all inline previews", false),
 	}
 }
 

--- a/go/chat/commands/expand.go
+++ b/go/chat/commands/expand.go
@@ -15,7 +15,7 @@ type Expand struct {
 
 func NewExpand(g *globals.Context) *Expand {
 	return &Expand{
-		baseCommand: newBaseCommand(g, "expand", "", "Expand all inline previews"),
+		baseCommand: newBaseCommand(g, "expand", "", "Expand all inline previews", false),
 	}
 }
 

--- a/go/chat/commands/flip.go
+++ b/go/chat/commands/flip.go
@@ -19,7 +19,7 @@ type Flip struct {
 
 func NewFlip(g *globals.Context) *Flip {
 	return &Flip{
-		baseCommand: newBaseCommand(g, "flip", "", "Flip a cryptographic coin"),
+		baseCommand: newBaseCommand(g, "flip", "", "Flip a cryptographic coin", true),
 	}
 }
 

--- a/go/chat/commands/giphy.go
+++ b/go/chat/commands/giphy.go
@@ -37,7 +37,7 @@ func NewGiphy(g *globals.Context) *Giphy {
 		usage = "Post a random GIF"
 	}
 	return &Giphy{
-		baseCommand:  newBaseCommand(g, "giphy", "[search terms]", usage),
+		baseCommand:  newBaseCommand(g, "giphy", "[search terms]", usage, false),
 		shownResults: make(map[string]bool),
 		searcher:     defaultGiphySearcher{},
 	}

--- a/go/chat/commands/headline.go
+++ b/go/chat/commands/headline.go
@@ -15,7 +15,7 @@ type Headline struct {
 func NewHeadline(g *globals.Context) *Headline {
 	return &Headline{
 		baseCommand: newBaseCommand(g, "headline", "<description>",
-			"Set the team channel topic", "topic"),
+			"Set the team channel topic", false, "topic"),
 	}
 }
 

--- a/go/chat/commands/hide.go
+++ b/go/chat/commands/hide.go
@@ -15,7 +15,7 @@ type Hide struct {
 func NewHide(g *globals.Context) *Hide {
 	return &Hide{
 		baseCommand: newBaseCommand(g, "hide", "[conversation]",
-			"Hides [conversation] or the current one"),
+			"Hides [conversation] or the current one", false),
 	}
 }
 

--- a/go/chat/commands/join.go
+++ b/go/chat/commands/join.go
@@ -16,7 +16,7 @@ type Join struct {
 
 func NewJoin(g *globals.Context) *Join {
 	return &Join{
-		baseCommand: newBaseCommand(g, "join", "", "Join a team channel"),
+		baseCommand: newBaseCommand(g, "join", "", "Join a team channel", false),
 	}
 }
 

--- a/go/chat/commands/leave.go
+++ b/go/chat/commands/leave.go
@@ -14,7 +14,7 @@ type Leave struct {
 
 func NewLeave(g *globals.Context) *Leave {
 	return &Leave{
-		baseCommand: newBaseCommand(g, "leave", "", "Leave the current team channel"),
+		baseCommand: newBaseCommand(g, "leave", "", "Leave the current team channel", false),
 	}
 }
 

--- a/go/chat/commands/me.go
+++ b/go/chat/commands/me.go
@@ -15,7 +15,7 @@ type Me struct {
 
 func NewMe(g *globals.Context) *Me {
 	return &Me{
-		baseCommand: newBaseCommand(g, "me", "<message>", "Displays action text"),
+		baseCommand: newBaseCommand(g, "me", "<message>", "Displays action text", false),
 	}
 }
 

--- a/go/chat/commands/msg.go
+++ b/go/chat/commands/msg.go
@@ -16,7 +16,7 @@ type Msg struct {
 func NewMsg(g *globals.Context) *Msg {
 	return &Msg{
 		baseCommand: newBaseCommand(g, "msg", "<conversation> <message>",
-			"Send a message to a conversation", "dm"),
+			"Send a message to a conversation", false, "dm"),
 	}
 }
 

--- a/go/chat/commands/mute.go
+++ b/go/chat/commands/mute.go
@@ -16,7 +16,7 @@ type Mute struct {
 
 func NewMute(g *globals.Context) *Mute {
 	return &Mute{
-		baseCommand: newBaseCommand(g, "mute", "", "Mute the current conversation", "shh"),
+		baseCommand: newBaseCommand(g, "mute", "", "Mute the current conversation", false, "shh"),
 	}
 }
 

--- a/go/chat/commands/shrug.go
+++ b/go/chat/commands/shrug.go
@@ -14,7 +14,7 @@ type Shrug struct {
 
 func NewShrug(g *globals.Context) *Shrug {
 	return &Shrug{
-		baseCommand: newBaseCommand(g, "shrug", "", `Appends ¯\_(ツ)_/¯ to your message`),
+		baseCommand: newBaseCommand(g, "shrug", "", `Appends ¯\_(ツ)_/¯ to your message`, false),
 	}
 }
 

--- a/go/chat/commands/unhide.go
+++ b/go/chat/commands/unhide.go
@@ -14,7 +14,7 @@ type Unhide struct {
 
 func NewUnhide(g *globals.Context) *Unhide {
 	return &Unhide{
-		baseCommand: newBaseCommand(g, "unhide", "<conversation>", "Unhide <conversation>"),
+		baseCommand: newBaseCommand(g, "unhide", "<conversation>", "Unhide <conversation>", false),
 	}
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -417,6 +417,7 @@ type ConversationCommand interface {
 	Name() string
 	Usage() string
 	Description() string
+	HasHelpText() bool
 	Export() chat1.ConversationCommand
 }
 

--- a/go/protocol/chat1/commands.go
+++ b/go/protocol/chat1/commands.go
@@ -12,6 +12,7 @@ type ConversationCommand struct {
 	Description string  `codec:"description" json:"description"`
 	Name        string  `codec:"name" json:"name"`
 	Usage       string  `codec:"usage" json:"usage"`
+	HasHelpText bool    `codec:"hasHelpText" json:"hasHelpText"`
 	Username    *string `codec:"username,omitempty" json:"username,omitempty"`
 }
 
@@ -20,6 +21,7 @@ func (o ConversationCommand) DeepCopy() ConversationCommand {
 		Description: o.Description,
 		Name:        o.Name,
 		Usage:       o.Usage,
+		HasHelpText: o.HasHelpText,
 		Username: (func(x *string) *string {
 			if x == nil {
 				return nil

--- a/protocol/avdl/chat1/commands.avdl
+++ b/protocol/avdl/chat1/commands.avdl
@@ -7,6 +7,7 @@ protocol commands {
     string description;
     string name;
     string usage;
+    boolean hasHelpText;
     union { null, string } username;
   }
 

--- a/protocol/json/chat1/commands.json
+++ b/protocol/json/chat1/commands.json
@@ -24,6 +24,10 @@
           "name": "usage"
         },
         {
+          "type": "boolean",
+          "name": "hasHelpText"
+        },
+        {
           "type": [
             null,
             "string"

--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -139,7 +139,19 @@ class Input extends React.Component<InputProps, InputState> {
     this.props.setUnsentText(text)
     this._lastText = text
     throttled(this.props.sendTyping, !!text)
-    debounced(this.props.unsentTextChanged, text)
+
+    // check if input matches a command with help text,
+    // skip debouncing unsentText if so
+    let skipDebounce = false
+    if (text.length <= this._maxCmdLength) {
+      skipDebounce = !!this.props.suggestCommands.find(sc => sc.hasHelpText && `/${sc.name}` === text)
+    }
+    if (skipDebounce) {
+      debounced.cancel()
+      this.props.unsentTextChanged(text)
+    } else {
+      debounced(this.props.unsentTextChanged, text)
+    }
   }
 
   _onKeyDown = (e: SyntheticKeyboardEvent<>, isComposingIME: boolean) => {

--- a/shared/chat/conversation/input-area/normal/index.stories.js
+++ b/shared/chat/conversation/input-area/normal/index.stories.js
@@ -116,9 +116,9 @@ const InputContainer = (props: Props) => {
     showWalletsIcon: !props.isEditing,
     suggestChannels: List(['general', 'random', 'spelunky', 'music', 'vidya-games']),
     suggestCommands: [
-      {description: 'Hide current or given conv', name: 'hide', usage: '[conversation]'},
-      {description: 'Message a user', name: 'msg', usage: '<conversation> <msg>'},
-      {description: 'Send a shrug', name: 'shrug', usage: ''},
+      {description: 'Hide current or given conv', hasHelpText: false, name: 'hide', usage: '[conversation]'},
+      {description: 'Message a user', hasHelpText: false, name: 'msg', usage: '<conversation> <msg>'},
+      {description: 'Send a shrug', hasHelpText: false, name: 'shrug', usage: ''},
     ],
     suggestUsers: List([
       {fullName: 'Danny Ayoub', username: 'ayoubd'},

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -783,7 +783,7 @@ export type ConversationBuiltinCommandTyp =
   | 3 // BIGTEAM_3
   | 4 // BIGTEAMGENERAL_4
 
-export type ConversationCommand = $ReadOnly<{description: String, name: String, usage: String, username?: ?String}>
+export type ConversationCommand = $ReadOnly<{description: String, name: String, usage: String, hasHelpText: Boolean, username?: ?String}>
 export type ConversationCommandGroups = {typ: 0, builtin: ?ConversationBuiltinCommandTyp} | {typ: 1, custom: ?ConversationCommandGroupsCustom}
 export type ConversationCommandGroupsCustom = $ReadOnly<{commands?: ?Array<ConversationCommand>}>
 export type ConversationCommandGroupsTyp =


### PR DESCRIPTION
Adds a bool `hasHelpText` to `ConversationCommand` and sets it to true for `flip`. On the js side, skip debouncing our call into the service if the text exactly matches a command with `hasHelpText: true`.

![flip-help-text](https://user-images.githubusercontent.com/11968340/53438976-09fb7a00-39cf-11e9-98a3-d9cb57ff9f15.gif)


cc @malgorithms this fixes hitting enter right after entering /flip. r? @keybase/react-hackers 