### PR TITLE
nav2 signup flow

### DIFF
--- a/shared/actions/__tests__/signup.test.js
+++ b/shared/actions/__tests__/signup.test.js
@@ -52,7 +52,7 @@ describe('requestAutoInvite', () => {
     const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
     expect(_testing.showInviteScreen()).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['inviteCode']})
+      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupInviteCode']})
     )
   })
 
@@ -61,7 +61,7 @@ describe('requestAutoInvite', () => {
     const nextState = makeTypedState(reducer(state, action))
     expect(nextState).toEqual(makeTypedState(state))
     expect(_testing.showInviteScreen()).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['inviteCode']})
+      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupInviteCode']})
     )
   })
 })
@@ -81,7 +81,7 @@ describe('requestInvite', () => {
     expect(nextState.signup.email).toEqual(action.payload.email)
     expect(nextState.signup.name).toEqual(action.payload.name)
     expect(_testing.showInviteSuccessOnNoErrors(nextState)).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['requestInviteSuccess']})
+      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupRequestInviteSuccess']})
     )
   })
 
@@ -131,7 +131,7 @@ describe('checkInviteCode', () => {
     // leaves state alone
     expect(nextState).toEqual(makeTypedState(state))
     expect(_testing.showUserEmailOnNoErrors(nextState)).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['usernameAndEmail']})
+      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupUsernameAndEmail']})
     )
   })
   it("shows error on fail: must match invite code. doesn't go to next screen", () => {
@@ -233,7 +233,7 @@ describe('checkedUsernameEmail', () => {
     const nextState = makeTypedState(reducer(state, action))
     // doesn't update
     expect(_testing.showPassphraseOnNoErrors(nextState)).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['passphraseSignup']})
+      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupPassphrase']})
     )
   })
 })

--- a/shared/actions/json/route-tree.json
+++ b/shared/actions/json/route-tree.json
@@ -27,7 +27,7 @@
     },
     "navigateAppend": {
       "path": "RCConstants.PropsPath<any>",
-      "parentPath?": "?RCConstants.Path"
+      "parentPath?": "?RCConstants.Path",
     },
     "navigateUp": {},
     "putActionIfOnPath": {

--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -32,31 +32,31 @@ const showUserEmailOnNoErrors = (state: TypedState) => {
     return (
       noErrors(state) && [
         RouteTreeGen.createNavigateUp(),
-        RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['usernameAndEmail']}),
+        RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupUsernameAndEmail']}),
       ]
     )
   } else {
     return (
       noErrors(state) &&
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['usernameAndEmail']})
+      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupUsernameAndEmail']})
     )
   }
 }
 
 const showInviteScreen = () =>
-  RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['inviteCode']})
+  RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupInviteCode']})
 
 const showInviteSuccessOnNoErrors = (state: TypedState) =>
   noErrors(state) &&
-  RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['requestInviteSuccess']})
+  RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupRequestInviteSuccess']})
 
 const goToLoginRoot = () => RouteTreeGen.createNavigateTo({parentPath: [loginTab], path: []})
 
 const showPassphraseOnNoErrors = (state: TypedState) =>
-  noErrors(state) && RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['passphraseSignup']})
+  noErrors(state) && RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupPassphrase']})
 
 const showDeviceScreenOnNoErrors = (state: TypedState) =>
-  noErrors(state) && RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['deviceName']})
+  noErrors(state) && RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupDeviceName']})
 
 const showErrorOrCleanupAfterSignup = (state: TypedState) =>
   noErrors(state)

--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -10,6 +10,7 @@ import {loginTab} from '../constants/tabs'
 import * as RouteTreeGen from '../actions/route-tree-gen'
 import {RPCError} from '../util/errors'
 import type {TypedState} from '../constants/reducer'
+import flags from '../util/feature-flags'
 
 // Helpers ///////////////////////////////////////////////////////////
 // returns true if there are no errors, we check all errors at every transition just to be extra careful
@@ -26,8 +27,21 @@ const noErrors = (state: TypedState) =>
 // When going back we clear all errors so we can fix things and move forward
 const goBackAndClearErrors = () => RouteTreeGen.createNavigateUp()
 
-const showUserEmailOnNoErrors = (state: TypedState) =>
-  noErrors(state) && RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['usernameAndEmail']})
+const showUserEmailOnNoErrors = (state: TypedState) => {
+  if (flags.useNewRouter) {
+    return (
+      noErrors(state) && [
+        RouteTreeGen.createNavigateUp(),
+        RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['usernameAndEmail']}),
+      ]
+    )
+  } else {
+    return (
+      noErrors(state) &&
+      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['usernameAndEmail']})
+    )
+  }
+}
 
 const showInviteScreen = () =>
   RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['inviteCode']})

--- a/shared/login/signup/invite-code/index.js
+++ b/shared/login/signup/invite-code/index.js
@@ -16,7 +16,7 @@ type State = {|
 |}
 
 class InviteCode extends React.Component<Props, State> {
-  state = {inviteCode: '', loading: true}
+  state = {inviteCode: '', loading: !__STORYSHOT__}
   _loadingID: ?TimeoutID
   _doneLoading = () => this.setState({loading: false})
 

--- a/shared/login/signup/invite-code/index.js
+++ b/shared/login/signup/invite-code/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
-import {Icon, Text} from '../../../common-adapters'
+import * as Kb from '../../../common-adapters'
+import * as Styles from '../../../styles'
 import {Wrapper, Input, ContinueButton} from '../common'
 
 type Props = {|
@@ -11,34 +12,58 @@ type Props = {|
 |}
 type State = {|
   inviteCode: string,
+  loading: boolean, // don't show this screen immediately
 |}
 
 class InviteCode extends React.Component<Props, State> {
-  state = {inviteCode: ''}
+  state = {inviteCode: '', loading: true}
+  _loadingID: ?TimeoutID
+  _doneLoading = () => this.setState({loading: false})
+
+  componentDidMount() {
+    this._loadingID = setTimeout(this._doneLoading, 1000)
+  }
+
+  componentWillUnmount() {
+    this._loadingID && clearTimeout(this._loadingID)
+  }
 
   _onSubmit = () => {
     this.props.onSubmit(this.state.inviteCode)
   }
+
   render() {
     return (
       <Wrapper onBack={this.props.onBack}>
-        <Text type="Header">Type in your invite code:</Text>
-        <Icon type="icon-invite-code-48" />
-        <Input
-          autoFocus={true}
-          value={this.state.inviteCode}
-          errorText={this.props.error}
-          onEnterKeyDown={this._onSubmit}
-          onChangeText={inviteCode => this.setState({inviteCode})}
-        />
-        <ContinueButton disabled={!this.state.inviteCode} onClick={this._onSubmit} />
-        <Text type="BodySmall">Not invited?</Text>
-        <Text type="BodySmallSecondaryLink" onClick={this.props.onRequestInvite}>
-          Request an invite
-        </Text>
+        {this.state.loading ? (
+          <Kb.ProgressIndicator style={styles.progress} />
+        ) : (
+          <>
+            <Kb.Text type="Header">Type in your invite code:</Kb.Text>
+            <Kb.Icon type="icon-invite-code-48" />
+            <Input
+              autoFocus={true}
+              value={this.state.inviteCode}
+              errorText={this.props.error}
+              onEnterKeyDown={this._onSubmit}
+              onChangeText={inviteCode => this.setState({inviteCode})}
+            />
+            <ContinueButton disabled={!this.state.inviteCode} onClick={this._onSubmit} />
+            <Kb.Text type="BodySmall">Not invited?</Kb.Text>
+            <Kb.Text type="BodySmallSecondaryLink" onClick={this.props.onRequestInvite}>
+              Request an invite
+            </Kb.Text>
+          </>
+        )}
       </Wrapper>
     )
   }
 }
+
+const styles = Styles.styleSheetCreate({
+  progress: {
+    width: 40,
+  },
+})
 
 export default InviteCode

--- a/shared/login/signup/routes.js
+++ b/shared/login/signup/routes.js
@@ -8,23 +8,23 @@ import DeviceName from './device-name/container'
 import SignupError from './error/container'
 
 const children = {
-  deviceName: {component: DeviceName},
-  inviteCode: {component: InviteCode},
-  passphraseSignup: {component: PassphraseSignup},
-  requestInvite: {component: RequestInvite},
-  requestInviteSuccess: {component: RequestInviteSuccess},
+  signupDeviceName: {component: DeviceName},
   signupError: {component: SignupError},
-  usernameAndEmail: {component: UsernameEmail},
+  signupInviteCode: {component: InviteCode},
+  signupPassphrase: {component: PassphraseSignup},
+  signupRequestInvite: {component: RequestInvite},
+  signupRequestInviteSuccess: {component: RequestInviteSuccess},
+  signupUsernameAndEmail: {component: UsernameEmail},
 }
 
 export default children
 
 export const newRoutes = {
-  deviceName: {getScreen: () => DeviceName},
-  inviteCode: {getScreen: () => InviteCode},
-  passphraseSignup: {getScreen: () => PassphraseSignup},
-  requestInvite: {getScreen: () => RequestInvite},
-  requestInviteSuccess: {getScreen: () => RequestInviteSuccess},
+  signupDeviceName: {getScreen: () => DeviceName},
   signupError: {getScreen: () => SignupError},
-  usernameAndEmail: {getScreen: () => UsernameEmail},
+  signupInviteCode: {getScreen: () => InviteCode},
+  signupPassphrase: {getScreen: () => PassphraseSignup},
+  signupRequestInvite: {getScreen: () => RequestInvite},
+  signupRequestInviteSuccess: {getScreen: () => RequestInviteSuccess},
+  signupUsernameAndEmail: {getScreen: () => UsernameEmail},
 }

--- a/shared/router-v2/router.desktop.js
+++ b/shared/router-v2/router.desktop.js
@@ -39,11 +39,16 @@ class AppView extends React.PureComponent<any> {
     const activeKey = navigation.state.routes[index].key
     const descriptor = this.props.descriptors[activeKey]
     const childNav = descriptor.navigation
+    const selectedTab = nameToTab[descriptor.state.routeName]
 
     return (
       <Kb.Box2 direction="horizontal" fullHeight={true} fullWidth={true}>
-        <TabBar selectedTab={nameToTab[descriptor.state.routeName]} />
-        <Kb.Box2 direction="vertical" fullHeight={true} style={styles.contentArea}>
+        <TabBar selectedTab={selectedTab} />
+        <Kb.Box2
+          direction="vertical"
+          fullHeight={true}
+          style={selectedTab ? styles.contentArea : styles.contentAreaLogin}
+        >
           <Header options={descriptor.options} onPop={childNav.pop} allowBack={index !== 0} />
           <SceneView
             navigation={childNav}
@@ -258,6 +263,17 @@ const styles = Styles.styleSheetCreate({
     flexGrow: 1,
     position: 'relative',
   },
+  contentAreaLogin: Styles.platformStyles({
+    isElectron: {
+      flexGrow: 1,
+      paddingTop: 20, // don't cover system buttons
+      position: 'relative',
+    },
+    isMobile: {
+      flexGrow: 1,
+      position: 'relative',
+    },
+  }),
   modalContainer: {
     ...Styles.globalStyles.fillAbsolute,
   },


### PR DESCRIPTION
this adds some niceties to the signup flow for nav v2
- [x] Progress indicator on invitation page so if it flashes you just see a spinner
- [x] nav up and append moving past the invite page so you don't click back and see it
- [x] fix layout of main app in login route, don't let the header touch the upper left (where on osx you have the system close buttons)
- [x] tested mobile
- [x] tested nav v2
- [x] tested nav v1
- [x] tested auto invite not being supplied