### PR TITLE
Fix a typo in the device name checker regex

### DIFF
--- a/go/libkb/checkers.go
+++ b/go/libkb/checkers.go
@@ -14,7 +14,7 @@ import (
 
 var emailRE = regexp.MustCompile(`^\S+@\S+\.\S+$`)
 
-var deviceRE = regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+-—–‘’]*$`)
+var deviceRE = regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+\-—–‘’]*$`)
 var badDeviceRE = regexp.MustCompile(`  |[ '+_-]$|['+_-][ ]?['+_-]`)
 var normalizeDeviceRE = regexp.MustCompile(`[^a-zA-Z0-9]`)
 

--- a/go/libkb/checkers.go
+++ b/go/libkb/checkers.go
@@ -14,7 +14,7 @@ import (
 
 var emailRE = regexp.MustCompile(`^\S+@\S+\.\S+$`)
 
-var deviceRE = regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+\-—–‘’]*$`)
+var deviceRE = regexp.MustCompile(`^[a-zA-Z0-9][ _'a-zA-Z0-9+‘’—–-]*$`)
 var badDeviceRE = regexp.MustCompile(`  |[ '+_-]$|['+_-][ ]?['+_-]`)
 var normalizeDeviceRE = regexp.MustCompile(`[^a-zA-Z0-9]`)
 

--- a/go/libkb/checkers_test.go
+++ b/go/libkb/checkers_test.go
@@ -50,6 +50,7 @@ var deviceNameTests = []checkerTest{
 	{input: "not😂ascii", valid: false},
 	{input: "John’s iPhone", valid: true},
 	{input: "absolute@unit", valid: false},
+	{input: "absolute(unit", valid: false},
 }
 
 func TestCheckDeviceName(t *testing.T) {

--- a/go/libkb/checkers_test.go
+++ b/go/libkb/checkers_test.go
@@ -49,6 +49,7 @@ var deviceNameTests = []checkerTest{
 	{input: "home computer_", valid: false},
 	{input: "not😂ascii", valid: false},
 	{input: "John’s iPhone", valid: true},
+	{input: "absolute@unit", valid: false},
 }
 
 func TestCheckDeviceName(t *testing.T) {


### PR DESCRIPTION
For some reason I totally ignored the fact that `['+_-]` only didn't resolve to a range because there was nothing after the dash and simply added new chars after it, resulting in a massive ASCII-unicode range that somehow didn't fail any tests. I fixed the typo and added tests checking `@` and `(`, which should be triggered by such mistakes.