### PR TITLE
visible error when re-adding reset team member

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -349,6 +349,10 @@ const reAddToTeam = (state, action) => {
         if (isMobile) {
           // show profile card on mobile
           return ProfileGen.createShowUserProfile({username})
+        } else {
+          throw new Error(
+            `You follow ${username}, so you must first review their profile and follow them again before letting them back in`
+          )
         }
       }
     })


### PR DESCRIPTION
The error was not being surfaced in a particular case of re-adding a reset team member.
![image](https://user-images.githubusercontent.com/862397/53445810-47a7d500-39c6-11e9-9906-8488fd183607.png)
