### PR TITLE
kbfsedits: track deleted file history and add option to show from command line

### DIFF
--- a/go/kbfs/kbfsedits/tlf_history.go
+++ b/go/kbfs/kbfsedits/tlf_history.go
@@ -18,13 +18,16 @@ import (
 
 const (
 	// The max number of edits needed for each writer.
-	maxEditsPerWriter    = 10
+	maxEditsPerWriter = 10
+	// The max number of deletes needed for each writer.
+	maxDeletesPerWriter  = 10
 	maxWritersPerHistory = 10
 )
 
 type writerNotifications struct {
 	writerName    string
 	notifications notificationsByRevision
+	deletes       notificationsByRevision
 }
 
 // writersByRevision sorts sets of per-writer notifications in reverse
@@ -40,7 +43,21 @@ func (wbr writersByRevision) Less(i, j int) bool {
 	iHasZero := len(wbr[i].notifications) == 0
 	jHasZero := len(wbr[j].notifications) == 0
 	if jHasZero {
-		return iHasZero
+		if iHasZero {
+			// If neither has any notifications, sort by the latest
+			// delete.
+			iHasZeroDeletes := len(wbr[i].deletes) == 0
+			jHasZeroDeletes := len(wbr[j].deletes) == 0
+			if jHasZeroDeletes {
+				return iHasZeroDeletes
+			} else if iHasZeroDeletes {
+				return false
+			}
+
+			// Reverse sort, so latest deletes come first.
+			return wbr[i].deletes[0].Revision > wbr[j].deletes[0].Revision
+		}
+		return false
 	} else if iHasZero {
 		return false
 	}
@@ -135,7 +152,7 @@ func (th *TlfHistory) AddNotifications(
 	defer th.lock.Unlock()
 	wn, existed := th.byWriter[writerName]
 	if !existed {
-		wn = &writerNotifications{writerName, nil}
+		wn = &writerNotifications{writerName, nil, nil}
 	}
 	oldLen := len(wn.notifications)
 	newEdits = append(newEdits, wn.notifications...)
@@ -167,7 +184,7 @@ func (th *TlfHistory) AddUnflushedNotifications(
 	th.lock.Lock()
 	defer th.lock.Unlock()
 	if th.unflushed == nil {
-		th.unflushed = &writerNotifications{loggedInUser, nil}
+		th.unflushed = &writerNotifications{loggedInUser, nil, nil}
 	}
 	if th.unflushed.writerName != loggedInUser {
 		panic(fmt.Sprintf("Logged-in user %s doesn't match unflushed user %s",
@@ -283,11 +300,6 @@ func (r *recomputer) processNotification(
 
 	// If the file is renamed in a future revision, rename it in the
 	// notification.
-	//
-	// TODO(KBFS-3073): maybe we should check all the parent
-	// directories for renames as well, so we can give a full, updated
-	// path for older edits.  That would also help avoid showing edits
-	// for files that were later deleted, but in a renamed directory.
 	eventFilename := filename
 	event, hasEvent := r.fileEvents[filename]
 	if hasEvent && event.newName != "" {
@@ -314,6 +326,18 @@ func (r *recomputer) processNotification(
 			return false
 		}
 
+		wn, ok := r.byWriter[writer]
+		if !ok {
+			wn = &writerNotifications{writer, nil, nil}
+			r.byWriter[writer] = wn
+		}
+
+		if len(wn.notifications) == maxEditsPerWriter {
+			// We don't need any more edit notifications, but we
+			// should continue looking for more deletes.
+			return false
+		}
+
 		// See if any of the parent directories were renamed, checking
 		// backwards until we get to the TLF name.
 		prefix := filename
@@ -336,11 +360,6 @@ func (r *recomputer) processNotification(
 			return false
 		}
 
-		wn, ok := r.byWriter[writer]
-		if !ok {
-			wn = &writerNotifications{writer, nil}
-			r.byWriter[writer] = wn
-		}
 		wn.notifications = append(wn.notifications, notification)
 
 		modified, ok := r.modifiedFiles[writer]
@@ -350,8 +369,9 @@ func (r *recomputer) processNotification(
 		}
 		modified[filename] = true
 
-		if len(wn.notifications) == maxEditsPerWriter {
-			// We have enough edits for this user.
+		if len(wn.notifications) == maxEditsPerWriter &&
+			len(wn.deletes) == maxDeletesPerWriter {
+			// We have enough edits and deletes for this user.
 			return true
 		}
 	case NotificationRename:
@@ -386,6 +406,56 @@ func (r *recomputer) processNotification(
 		r.fileEvents[eventFilename] = fileEvent{delete: true}
 	case NotificationDelete:
 		r.fileEvents[eventFilename] = fileEvent{delete: true}
+
+		// We only care about files, so skip dir and sym creates.
+		if notification.FileType != EntryTypeFile {
+			return false
+		}
+
+		// Ignore macOS dotfiles.
+		if ignoreFile(filename) {
+			return false
+		}
+
+		wn, ok := r.byWriter[writer]
+		if !ok {
+			wn = &writerNotifications{writer, nil, nil}
+			r.byWriter[writer] = wn
+		}
+
+		if len(wn.deletes) == maxDeletesPerWriter {
+			// We don't need any more deletes, but we
+			// should continue looking for more edit notifications.
+			return false
+		}
+
+		if hasEvent && event.delete {
+			// It's already been deleted, no need to track it further.
+			return false
+		}
+
+		// If there are no future modifications of this file, then
+		// this delete should be included in the history.
+		for _, files := range r.modifiedFiles {
+			for f := range files {
+				if f == eventFilename {
+					return false
+				}
+			}
+		}
+
+		wn.deletes = append(wn.deletes, notification)
+
+		if len(wn.notifications) == maxEditsPerWriter &&
+			len(wn.deletes) == maxDeletesPerWriter {
+			// We have enough edits and deletes for this user.
+			return true
+		}
+
+		// TODO: limit the number (or time span) of notifications we
+		// process to find the list of deleted files?  Or maybe we
+		// stop processing after we hit the last GC'd revision, since
+		// deleted files after that point can't be recovered anyway.
 	}
 	return false
 }
@@ -430,8 +500,10 @@ func (th *TlfHistory) recomputeLocked(loggedInUser string) (
 		wnCopy := writerNotifications{
 			writerName:    wn.writerName,
 			notifications: make(notificationsByRevision, len(wn.notifications)),
+			deletes:       make(notificationsByRevision, len(wn.deletes)),
 		}
 		copy(wnCopy.notifications, wn.notifications)
+		copy(wnCopy.deletes, wn.deletes)
 		writersHeap = append(writersHeap, &wnCopy)
 	}
 	heap.Init(&writersHeap)
@@ -471,17 +543,18 @@ func (th *TlfHistory) recomputeLocked(loggedInUser string) (
 	history = make(writersByRevision, 0, len(r.byWriter))
 	for writerName := range th.byWriter {
 		wn := r.byWriter[writerName]
-		if wn != nil && len(wn.notifications) > 0 {
+		if wn != nil && (len(wn.notifications) > 0 || len(wn.deletes) > 0) {
 			history = append(history, wn)
 		}
-		if wn == nil || len(wn.notifications) < maxEditsPerWriter {
+		if wn == nil || len(wn.notifications) < maxEditsPerWriter ||
+			len(wn.notifications) < maxDeletesPerWriter {
 			writersWhoNeedMore[writerName] = true
 		}
 	}
 	if _, ok := th.byWriter[loggedInUser]; !ok {
 		// The logged-in user only has unflushed edits.
 		wn := r.byWriter[loggedInUser]
-		if wn != nil && len(wn.notifications) > 0 {
+		if wn != nil && (len(wn.notifications) > 0 || len(wn.deletes) > 0) {
 			history = append(history, wn)
 		}
 	}

--- a/go/kbfs/kbfsedits/user_history_test.go
+++ b/go/kbfs/kbfsedits/user_history_test.go
@@ -47,6 +47,11 @@ func TestUserHistorySimple(t *testing.T) {
 		privSharedAlice = append(privSharedAlice, privSharedNN.encode(t))
 	}
 	privSharedTimeAlice := keybase1.ToTime(now)
+	// Alice deletes something from private shared TLF (it shouldn't
+	// affect the overall server time for the TLF).
+	now = now.Add(1 * time.Minute)
+	_ = privSharedNN.make("a", NotificationDelete, aliceUID, nil, now)
+	privSharedAlice = append(privSharedAlice, privSharedNN.encode(t))
 
 	// Alice writes to public TLF.
 	var publicAlice []string
@@ -100,27 +105,28 @@ func TestUserHistorySimple(t *testing.T) {
 		serverTime keybase1.Time
 		writer     string
 		num        int
+		numDeletes int
 	}
 	expected := []expectInfo{
 		// private home alice
 		{
 			string(privHomeName), keybase1.FolderType_PRIVATE,
-			privHomeTime, aliceName, 3,
+			privHomeTime, aliceName, 3, 0,
 		},
 		// private shared bob
 		{
 			string(privSharedName), keybase1.FolderType_PRIVATE,
-			privSharedTimeBob, bobName, 3,
+			privSharedTimeBob, bobName, 3, 0,
 		},
 		// public alice
 		{
 			string(publicName), keybase1.FolderType_PUBLIC,
-			publicTime, aliceName, 3,
+			publicTime, aliceName, 3, 0,
 		},
 		// private shared alice
 		{
 			string(privSharedName), keybase1.FolderType_PRIVATE,
-			privSharedTimeAlice, aliceName, 3,
+			privSharedTimeAlice, aliceName, 3, 1,
 		},
 	}
 

--- a/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
@@ -403,6 +403,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 					NotificationType: keybase1.FSNotificationType_FILE_MODIFIED,
 					ServerTime:       keybase1.ToTime(second),
 				}},
+				Deletes: []keybase1.FSFolderWriterEdit{},
 			},
 			{
 				WriterName: "u1",
@@ -411,6 +412,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 					NotificationType: keybase1.FSNotificationType_FILE_MODIFIED,
 					ServerTime:       keybase1.ToTime(first),
 				}},
+				Deletes: []keybase1.FSFolderWriterEdit{},
 			},
 		},
 	}

--- a/go/kbfs/test/dsl_test.go
+++ b/go/kbfs/test/dsl_test.go
@@ -1038,10 +1038,11 @@ func checkPrevRevisions(filepath string, counts []uint8) fileOp {
 }
 
 type expectedEdit struct {
-	tlfName string
-	tlfType keybase1.FolderType
-	writer  string
-	files   []string
+	tlfName      string
+	tlfType      keybase1.FolderType
+	writer       string
+	files        []string
+	deletedFiles []string
 }
 
 func checkUserEditHistory(expectedEdits []expectedEdit) fileOp {
@@ -1063,6 +1064,10 @@ func checkUserEditHistory(expectedEdits []expectedEdit) fileOp {
 			hEdits[i].writer = h.History[0].WriterName
 			for _, we := range h.History[0].Edits {
 				hEdits[i].files = append(hEdits[i].files, we.Filename)
+			}
+			for _, we := range h.History[0].Deletes {
+				hEdits[i].deletedFiles = append(
+					hEdits[i].deletedFiles, we.Filename)
 			}
 		}
 

--- a/go/protocol/keybase1/kbfs_common.go
+++ b/go/protocol/keybase1/kbfs_common.go
@@ -229,6 +229,7 @@ func (o FSFolderWriterEdit) DeepCopy() FSFolderWriterEdit {
 type FSFolderWriterEditHistory struct {
 	WriterName string               `codec:"writerName" json:"writerName"`
 	Edits      []FSFolderWriterEdit `codec:"edits" json:"edits"`
+	Deletes    []FSFolderWriterEdit `codec:"deletes" json:"deletes"`
 }
 
 func (o FSFolderWriterEditHistory) DeepCopy() FSFolderWriterEditHistory {
@@ -245,6 +246,17 @@ func (o FSFolderWriterEditHistory) DeepCopy() FSFolderWriterEditHistory {
 			}
 			return ret
 		})(o.Edits),
+		Deletes: (func(x []FSFolderWriterEdit) []FSFolderWriterEdit {
+			if x == nil {
+				return nil
+			}
+			ret := make([]FSFolderWriterEdit, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.Deletes),
 	}
 }
 

--- a/protocol/avdl/keybase1/kbfs_common.avdl
+++ b/protocol/avdl/keybase1/kbfs_common.avdl
@@ -69,6 +69,7 @@ protocol kbfsCommon {
   record FSFolderWriterEditHistory {
     string writerName;
     array<FSFolderWriterEdit> edits;
+    array<FSFolderWriterEdit> deletes;
   }
 
   record FSFolderEditHistory {

--- a/protocol/json/keybase1/kbfs_common.json
+++ b/protocol/json/keybase1/kbfs_common.json
@@ -144,6 +144,13 @@
             "items": "FSFolderWriterEdit"
           },
           "name": "edits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "FSFolderWriterEdit"
+          },
+          "name": "deletes"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -2079,7 +2079,7 @@ export type FSErrorType =
 
 export type FSFolderEditHistory = $ReadOnly<{folder: Folder, serverTime: Time, history?: ?Array<FSFolderWriterEditHistory>}>
 export type FSFolderWriterEdit = $ReadOnly<{filename: String, notificationType: FSNotificationType, serverTime: Time}>
-export type FSFolderWriterEditHistory = $ReadOnly<{writerName: String, edits?: ?Array<FSFolderWriterEdit>}>
+export type FSFolderWriterEditHistory = $ReadOnly<{writerName: String, edits?: ?Array<FSFolderWriterEdit>, deletes?: ?Array<FSFolderWriterEdit>}>
 export type FSNotification = $ReadOnly<{filename: String, status: String, statusCode: FSStatusCode, notificationType: FSNotificationType, errorType: FSErrorType, params: {[key: string]: String}, writerUid: UID, localTime: Time, folderType: FolderType}>
 export type FSNotificationType =
   | 0 // ENCRYPTING_0


### PR DESCRIPTION
This PR is a first-pass at including deleted files in the the edit history for each TLF.  The basic idea is:

* Search backward in the chat history for at most 10 deleted files per writer per TLF.
* If a file has been deleted, but subsequently overwritten, don't include in the deleted files history.
* Don't order history clusters by the delete times, unless there are no other edits in the cluster.
* Add a `-d` option to `keybase fs history`, which will show the deleted history of each cluster (but ordered by the usual overall modification time of the cluster).
* Deletes will always show up in a separate "deletes" section in `.kbfs_edit_history` for each cluster.

This isn't perfect; consider this a first dev-designed pass.  In particular, there are some weird/bad things about this:
* We'll search backward in each writer's history until we see 10 deletes.  So if the user did a ton of writes after their most recent deletes (or never did any deletes at all), we'll have to load the whole history.  In practice we can probably limit this by figuring out the last GC revision and stop checking for deleted files earlier than that, since we won't be able to restore them anyway.  But not sure if that's worth doing for now, it seems pretty fast as it is.
* There are probably some deletes we should filter out, like `*~` or `*.swp` files, but I haven't attempted to enumerate that list yet.
* It's weird that `keybase fs history -d` sorts clusters by the most recent edit notification time, rather than the most recent delete time, but I'm not sure if this matters enough to care about.  The GUI could always decide to do it differently.

Open to suggestions!

Issue: KBFS-3901