### PR TITLE
Files: fix scroll over screen

### DIFF
--- a/shared/fs/row/rows.js
+++ b/shared/fs/row/rows.js
@@ -120,13 +120,17 @@ class Rows extends React.PureComponent<Props> {
     }
   }
   // List2 caches offsets. So have the key derive from layouts so that we
-  // trigger a re-render when layout changes.
+  // trigger a re-render when layout changes. Also encode items length into
+  // this, otherwise we'd get taller-than content rows when going into a
+  // smaller folder from a larger one.
   _getListKey = memoize(items => {
     const index = items.findIndex(row => row.rowType !== 'header')
-    return items
-      .slice(0, index === -1 ? items.length : index)
-      .map(row => getRowHeight(row).toString())
-      .join('-')
+    return (
+      items
+        .slice(0, index === -1 ? items.length : index)
+        .map(row => getRowHeight(row).toString())
+        .join('-') + `:${items.length}`
+    )
   })
 
   render() {


### PR DESCRIPTION
When navigating from a folder with more items into one with fewer, we'd get larger-than-content scrollable area. This is because the list caches offsets. We have a `_getListKey` that updates the key when layout changes,  so the component instance is thrown away when total number changes. But it only cares about the header components since they are the ones with variable height. The fix is to encode the total number of items into the key as well.