### PR TITLE
journal_manager: suppress popups when enabling existing journals

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1310,7 +1310,8 @@ func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 		TLFIdentifyBehavior_KBFS_QR,
 		TLFIdentifyBehavior_SALTPACK,
 		TLFIdentifyBehavior_RESOLVE_AND_CHECK,
-		TLFIdentifyBehavior_KBFS_CHAT:
+		TLFIdentifyBehavior_KBFS_CHAT,
+		TLFIdentifyBehavior_KBFS_INIT:
 		// These are identifies that either happen without user interaction at
 		// all, or happen while you're staring at some Keybase UI that can
 		// report errors on its own. No popups needed.

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -25,6 +25,7 @@ const (
 	TLFIdentifyBehavior_KBFS_CHAT          TLFIdentifyBehavior = 11
 	TLFIdentifyBehavior_RESOLVE_AND_CHECK  TLFIdentifyBehavior = 12
 	TLFIdentifyBehavior_GUI_PROFILE        TLFIdentifyBehavior = 13
+	TLFIdentifyBehavior_KBFS_INIT          TLFIdentifyBehavior = 14
 )
 
 func (o TLFIdentifyBehavior) DeepCopy() TLFIdentifyBehavior { return o }
@@ -44,6 +45,7 @@ var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
 	"KBFS_CHAT":          11,
 	"RESOLVE_AND_CHECK":  12,
 	"GUI_PROFILE":        13,
+	"KBFS_INIT":          14,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
@@ -61,6 +63,7 @@ var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
 	11: "KBFS_CHAT",
 	12: "RESOLVE_AND_CHECK",
 	13: "GUI_PROFILE",
+	14: "KBFS_INIT",
 }
 
 func (e TLFIdentifyBehavior) String() string {

--- a/protocol/avdl/keybase1/tlf_keys.avdl
+++ b/protocol/avdl/keybase1/tlf_keys.avdl
@@ -20,7 +20,8 @@ protocol tlfKeys {
     DEFAULT_KBFS_10,
     KBFS_CHAT_11,
     RESOLVE_AND_CHECK_12,
-    GUI_PROFILE_13
+    GUI_PROFILE_13,
+    KBFS_INIT_14
   }
 
   @typedef("string")

--- a/protocol/json/keybase1/tlf_keys.json
+++ b/protocol/json/keybase1/tlf_keys.json
@@ -28,7 +28,8 @@
         "DEFAULT_KBFS_10",
         "KBFS_CHAT_11",
         "RESOLVE_AND_CHECK_12",
-        "GUI_PROFILE_13"
+        "GUI_PROFILE_13",
+        "KBFS_INIT_14"
       ]
     },
     {

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -832,6 +832,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   kbfsChat: 11,
   resolveAndCheck: 12,
   guiProfile: 13,
+  kbfsInit: 14,
 }
 
 export const uPKKeyType = {

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -1860,6 +1860,7 @@ export const tlfKeysTLFIdentifyBehavior = {
   kbfsChat: 11,
   resolveAndCheck: 12,
   guiProfile: 13,
+  kbfsInit: 14,
 }
 
 export const uPKKeyType = {
@@ -2908,6 +2909,7 @@ export type TLFIdentifyBehavior =
   | 11 // KBFS_CHAT_11
   | 12 // RESOLVE_AND_CHECK_12
   | 13 // GUI_PROFILE_13
+  | 14 // KBFS_INIT_14
 
 export type TLFIdentifyFailure = $ReadOnly<{user: User, breaks?: ?IdentifyTrackBreaks}>
 export type TLFQuery = $ReadOnly<{tlfName: String, identifyBehavior: TLFIdentifyBehavior}>


### PR DESCRIPTION
Introduce a new `KBFS_INIT` identify behavior that will suppress popups, so that journal initialization won't cause popups on a restart.  Any errors will be logged, and future accesses to the folder should cause popups as normal.

I can't figure out a way to test this, since the service seems to suppress popups on its own in some cases (I think I probably have to wait some long amount of time after the first popup in order to get the second popup to show?  Not sure), but seems like it should fix the behavior chris saw.

Issue: KBFS-3914