### PR TITLE
thread MetaContext through the IdentifyUI

### DIFF
--- a/go/chat/identify_ui.go
+++ b/go/chat/identify_ui.go
@@ -1,30 +1,35 @@
 package chat
 
-import "github.com/keybase/client/go/protocol/keybase1"
+import (
+"github.com/keybase/client/go/libkb"
+"github.com/keybase/client/go/protocol/keybase1"
+)
 
 type chatNullIdentifyUI struct{}
 
-func (c chatNullIdentifyUI) Start(string, keybase1.IdentifyReason, bool) error { return nil }
-func (c chatNullIdentifyUI) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+var _ libkb.IdentifyUI = chatNullIdentifyUI{}
+
+func (c chatNullIdentifyUI) Start(libkb.MetaContext, string, keybase1.IdentifyReason, bool) error { return nil }
+func (c chatNullIdentifyUI) FinishWebProofCheck(libkb.MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error {
 	return nil
 }
-func (c chatNullIdentifyUI) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+func (c chatNullIdentifyUI) FinishSocialProofCheck(libkb.MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error {
 	return nil
 }
-func (c chatNullIdentifyUI) Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (c chatNullIdentifyUI) Confirm(libkb.MetaContext, *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	return keybase1.ConfirmResult{}, nil
 }
-func (c chatNullIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error          { return nil }
-func (c chatNullIdentifyUI) DisplayStellarAccount(keybase1.StellarAccount) error          { return nil }
-func (c chatNullIdentifyUI) DisplayKey(keybase1.IdentifyKey) error                        { return nil }
-func (c chatNullIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) error                 { return nil }
-func (c chatNullIdentifyUI) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) error { return nil }
-func (c chatNullIdentifyUI) DisplayTrackStatement(string) error                           { return nil }
-func (c chatNullIdentifyUI) DisplayUserCard(keybase1.UserCard) error                      { return nil }
-func (c chatNullIdentifyUI) ReportTrackToken(keybase1.TrackToken) error                   { return nil }
-func (c chatNullIdentifyUI) Cancel() error                                                { return nil }
-func (c chatNullIdentifyUI) Finish() error                                                { return nil }
-func (c chatNullIdentifyUI) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
+func (c chatNullIdentifyUI) DisplayCryptocurrency(libkb.MetaContext, keybase1.Cryptocurrency) error          { return nil }
+func (c chatNullIdentifyUI) DisplayStellarAccount(libkb.MetaContext, keybase1.StellarAccount) error          { return nil }
+func (c chatNullIdentifyUI) DisplayKey(libkb.MetaContext, keybase1.IdentifyKey) error                        { return nil }
+func (c chatNullIdentifyUI) ReportLastTrack(libkb.MetaContext, *keybase1.TrackSummary) error                 { return nil }
+func (c chatNullIdentifyUI) LaunchNetworkChecks(libkb.MetaContext, *keybase1.Identity, *keybase1.User) error { return nil }
+func (c chatNullIdentifyUI) DisplayTrackStatement(libkb.MetaContext, string) error                           { return nil }
+func (c chatNullIdentifyUI) DisplayUserCard(libkb.MetaContext, keybase1.UserCard) error                      { return nil }
+func (c chatNullIdentifyUI) ReportTrackToken(libkb.MetaContext, keybase1.TrackToken) error                   { return nil }
+func (c chatNullIdentifyUI) Cancel(libkb.MetaContext) error                                                { return nil }
+func (c chatNullIdentifyUI) Finish(libkb.MetaContext) error                                                { return nil }
+func (c chatNullIdentifyUI) DisplayTLFCreateWithInvite(libkb.MetaContext, keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil
 }
-func (c chatNullIdentifyUI) Dismiss(string, keybase1.DismissReason) error { return nil }
+func (c chatNullIdentifyUI) Dismiss(libkb.MetaContext, string, keybase1.DismissReason) error { return nil }

--- a/go/client/cmd_id.go
+++ b/go/client/cmd_id.go
@@ -121,28 +121,28 @@ type idCmdIdentifyUIProofPair struct {
 	Result keybase1.LinkCheckResult `json:"result"`
 }
 
-func (ui *idCmdIdentifyUI) DisplayUserCard(keybase1.UserCard) error {
+func (ui *idCmdIdentifyUI) DisplayUserCard(libkb.MetaContext, keybase1.UserCard) error {
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) Start(username string, _ keybase1.IdentifyReason, _ bool) error {
+func (ui *idCmdIdentifyUI) Start(_ libkb.MetaContext, username string, _ keybase1.IdentifyReason, _ bool) error {
 	ui.Username = username
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) DisplayTrackStatement(stmt string) error {
+func (ui *idCmdIdentifyUI) DisplayTrackStatement(_ libkb.MetaContext, stmt string) error {
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) ReportTrackToken(_ keybase1.TrackToken) error {
+func (ui *idCmdIdentifyUI) ReportTrackToken(_ libkb.MetaContext, _ keybase1.TrackToken) error {
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) Cancel() error {
+func (ui *idCmdIdentifyUI) Cancel(_ libkb.MetaContext) error {
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) Finish() error {
+func (ui *idCmdIdentifyUI) Finish(_ libkb.MetaContext, ) error {
 	b, err := json.MarshalIndent(ui, "", "    ")
 	if err != nil {
 		return err
@@ -152,23 +152,23 @@ func (ui *idCmdIdentifyUI) Finish() error {
 	return err
 }
 
-func (ui *idCmdIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) error {
+func (ui *idCmdIdentifyUI) Dismiss(_ libkb.MetaContext, _ string, _ keybase1.DismissReason) error {
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (ui *idCmdIdentifyUI) Confirm(_ libkb.MetaContext, o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	return keybase1.ConfirmResult{IdentityConfirmed: false, RemoteConfirmed: false}, nil
 }
 
-func (ui *idCmdIdentifyUI) LaunchNetworkChecks(_ *keybase1.Identity, _ *keybase1.User) error {
+func (ui *idCmdIdentifyUI) LaunchNetworkChecks(_ libkb.MetaContext, _ *keybase1.Identity, _ *keybase1.User) error {
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) DisplayTLFCreateWithInvite(_ keybase1.DisplayTLFCreateWithInviteArg) error {
+func (ui *idCmdIdentifyUI) DisplayTLFCreateWithInvite(_ libkb.MetaContext, _ keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (ui *idCmdIdentifyUI) FinishSocialProofCheck(_ libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	ui.Proofs = append(ui.Proofs, idCmdIdentifyUIProofPair{
 		Proof:  p,
 		Result: l,
@@ -176,7 +176,7 @@ func (ui *idCmdIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keyb
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (ui *idCmdIdentifyUI) FinishWebProofCheck(_ libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	ui.Proofs = append(ui.Proofs, idCmdIdentifyUIProofPair{
 		Proof:  p,
 		Result: l,
@@ -184,22 +184,22 @@ func (ui *idCmdIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) DisplayCryptocurrency(l keybase1.Cryptocurrency) error {
+func (ui *idCmdIdentifyUI) DisplayCryptocurrency(_ libkb.MetaContext, l keybase1.Cryptocurrency) error {
 	ui.Cryptocurrencies = append(ui.Cryptocurrencies, l)
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) DisplayStellarAccount(l keybase1.StellarAccount) error {
+func (ui *idCmdIdentifyUI) DisplayStellarAccount(_ libkb.MetaContext, l keybase1.StellarAccount) error {
 	ui.Stellar = &l
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) DisplayKey(key keybase1.IdentifyKey) error {
+func (ui *idCmdIdentifyUI) DisplayKey(_ libkb.MetaContext, key keybase1.IdentifyKey) error {
 	ui.IdentifyKey = &key
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) ReportLastTrack(tl *keybase1.TrackSummary) error {
+func (ui *idCmdIdentifyUI) ReportLastTrack(_ libkb.MetaContext, tl *keybase1.TrackSummary) error {
 	if t := libkb.ImportTrackSummary(tl); t != nil {
 		ui.LastTrack = &idCmdIdentifyUILastTrack{
 			Remote: t.IsRemote(),

--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -11,97 +11,108 @@ import (
 )
 
 type IdentifyUIServer struct {
+	libkb.Contextified
 	ui libkb.IdentifyUI
 }
 
 func NewIdentifyUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
-	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{g.UI.GetIdentifyUI()})
+	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{
+		Contextified : libkb.NewContextified(g),
+		ui : g.UI.GetIdentifyUI(),
+	})
 }
 
 func NewIdentifyTrackUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
 	ui := g.UI.GetIdentifyTrackUI()
-	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{ui})
+	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{
+		Contextified : libkb.NewContextified(g),
+		ui : ui,
+	})
+}
+
+func (i *IdentifyUIServer) newMetaContext(ctx context.Context) libkb.MetaContext {
+	return libkb.NewMetaContext(ctx, i.G())
 }
 
 func (i *IdentifyUIServer) DelegateIdentifyUI(_ context.Context) (int, error) {
 	return 0, libkb.UIDelegationUnavailableError{}
 }
 
-func (i *IdentifyUIServer) Confirm(_ context.Context, arg keybase1.ConfirmArg) (keybase1.ConfirmResult, error) {
-	return i.ui.Confirm(&arg.Outcome)
+func (i *IdentifyUIServer) Confirm(ctx context.Context, arg keybase1.ConfirmArg) (keybase1.ConfirmResult, error) {
+	return i.ui.Confirm(i.newMetaContext(ctx), &arg.Outcome)
 }
 
-func (i *IdentifyUIServer) FinishWebProofCheck(_ context.Context, arg keybase1.FinishWebProofCheckArg) error {
-	i.ui.FinishWebProofCheck(arg.Rp, arg.Lcr)
+func (i *IdentifyUIServer) FinishWebProofCheck(ctx context.Context, arg keybase1.FinishWebProofCheckArg) error {
+	i.ui.FinishWebProofCheck(i.newMetaContext(ctx), arg.Rp, arg.Lcr)
 	return nil
 }
 
-func (i *IdentifyUIServer) FinishSocialProofCheck(_ context.Context, arg keybase1.FinishSocialProofCheckArg) error {
-	i.ui.FinishSocialProofCheck(arg.Rp, arg.Lcr)
+func (i *IdentifyUIServer) FinishSocialProofCheck(ctx context.Context, arg keybase1.FinishSocialProofCheckArg) error {
+	i.ui.FinishSocialProofCheck(i.newMetaContext(ctx), arg.Rp, arg.Lcr)
 	return nil
 }
 
-func (i *IdentifyUIServer) DisplayCryptocurrency(_ context.Context, arg keybase1.DisplayCryptocurrencyArg) error {
-	i.ui.DisplayCryptocurrency(arg.C)
+func (i *IdentifyUIServer) DisplayCryptocurrency(ctx context.Context, arg keybase1.DisplayCryptocurrencyArg) error {
+	i.ui.DisplayCryptocurrency(i.newMetaContext(ctx), arg.C)
 	return nil
 }
 
-func (i *IdentifyUIServer) DisplayStellarAccount(_ context.Context, arg keybase1.DisplayStellarAccountArg) error {
-	i.ui.DisplayStellarAccount(arg.A)
+func (i *IdentifyUIServer) DisplayStellarAccount(ctx context.Context, arg keybase1.DisplayStellarAccountArg) error {
+	i.ui.DisplayStellarAccount(i.newMetaContext(ctx), arg.A)
 	return nil
 }
 
-func (i *IdentifyUIServer) DisplayKey(_ context.Context, arg keybase1.DisplayKeyArg) error {
-	i.ui.DisplayKey(arg.Key)
+func (i *IdentifyUIServer) DisplayKey(ctx context.Context, arg keybase1.DisplayKeyArg) error {
+	i.ui.DisplayKey(i.newMetaContext(ctx), arg.Key)
 	return nil
 }
 
-func (i *IdentifyUIServer) ReportLastTrack(_ context.Context, arg keybase1.ReportLastTrackArg) error {
-	i.ui.ReportLastTrack(arg.Track)
+func (i *IdentifyUIServer) ReportLastTrack(ctx context.Context, arg keybase1.ReportLastTrackArg) error {
+	i.ui.ReportLastTrack(i.newMetaContext(ctx), arg.Track)
 	return nil
 }
 
-func (i *IdentifyUIServer) LaunchNetworkChecks(_ context.Context, arg keybase1.LaunchNetworkChecksArg) error {
+func (i *IdentifyUIServer) LaunchNetworkChecks(ctx context.Context, arg keybase1.LaunchNetworkChecksArg) error {
 	return nil
 }
 
-func (i *IdentifyUIServer) DisplayTrackStatement(_ context.Context, arg keybase1.DisplayTrackStatementArg) error {
-	i.ui.DisplayTrackStatement(arg.Stmt)
+func (i *IdentifyUIServer) DisplayTrackStatement(ctx context.Context, arg keybase1.DisplayTrackStatementArg) error {
+	i.ui.DisplayTrackStatement(i.newMetaContext(ctx), arg.Stmt)
 	return nil
 }
 
-func (i *IdentifyUIServer) ReportTrackToken(_ context.Context, arg keybase1.ReportTrackTokenArg) error {
-	i.ui.ReportTrackToken(arg.TrackToken)
+func (i *IdentifyUIServer) ReportTrackToken(ctx context.Context, arg keybase1.ReportTrackTokenArg) error {
+	i.ui.ReportTrackToken(i.newMetaContext(ctx), arg.TrackToken)
 	return nil
 }
 
-func (i *IdentifyUIServer) DisplayUserCard(_ context.Context, arg keybase1.DisplayUserCardArg) error {
-	i.ui.DisplayUserCard(arg.Card)
+func (i *IdentifyUIServer) DisplayUserCard(ctx context.Context, arg keybase1.DisplayUserCardArg) error {
+	i.ui.DisplayUserCard(i.newMetaContext(ctx), arg.Card)
 	return nil
 }
 
-func (i *IdentifyUIServer) Start(_ context.Context, arg keybase1.StartArg) error {
-	i.ui.Start(arg.Username, arg.Reason, arg.ForceDisplay)
+func (i *IdentifyUIServer) Start(ctx context.Context, arg keybase1.StartArg) error {
+	i.ui.Start(i.newMetaContext(ctx), arg.Username, arg.Reason, arg.ForceDisplay)
 	return nil
 }
 
-func (i *IdentifyUIServer) Cancel(_ context.Context, sessionID int) error {
-	i.ui.Cancel()
+func (i *IdentifyUIServer) Cancel(ctx context.Context, sessionID int) error {
+	i.ui.Cancel(i.newMetaContext(ctx))
 	return nil
 }
 
-func (i *IdentifyUIServer) Finish(_ context.Context, sessionID int) error {
-	i.ui.Finish()
+func (i *IdentifyUIServer) Finish(ctx context.Context, sessionID int) error {
+	i.ui.Finish(i.newMetaContext(ctx))
 	return nil
 }
 
-func (i *IdentifyUIServer) Dismiss(_ context.Context, arg keybase1.DismissArg) error {
-	i.ui.Dismiss(arg.Username, arg.Reason)
+func (i *IdentifyUIServer) Dismiss(ctx context.Context, arg keybase1.DismissArg) error {
+	i.ui.Dismiss(i.newMetaContext(ctx), arg.Username, arg.Reason)
 	return nil
 }
 
-func (i *IdentifyUIServer) DisplayTLFCreateWithInvite(_ context.Context, arg keybase1.DisplayTLFCreateWithInviteArg) error {
-	return i.ui.DisplayTLFCreateWithInvite(arg)
+func (i *IdentifyUIServer) DisplayTLFCreateWithInvite(ctx context.Context, arg keybase1.DisplayTLFCreateWithInviteArg) error {
+	return i.ui.DisplayTLFCreateWithInvite(i.newMetaContext(ctx), arg)
 }
 
 func NewNullIdentifyUIProtocol() rpc.Protocol {

--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -51,7 +51,7 @@ type BaseIdentifyUI struct {
 	username        string
 }
 
-func (ui *BaseIdentifyUI) DisplayUserCard(keybase1.UserCard) error {
+func (ui *BaseIdentifyUI) DisplayUserCard(libkb.MetaContext, keybase1.UserCard) error {
 	return nil
 }
 
@@ -59,7 +59,7 @@ type IdentifyUI struct {
 	BaseIdentifyUI
 }
 
-func (ui *BaseIdentifyUI) Start(username string, reason keybase1.IdentifyReason, forceDisplay bool) error {
+func (ui *BaseIdentifyUI) Start(_ libkb.MetaContext, username string, reason keybase1.IdentifyReason, forceDisplay bool) error {
 	msg := "Identifying "
 	switch reason.Type {
 	case keybase1.IdentifyReasonType_TRACK:
@@ -72,30 +72,30 @@ func (ui *BaseIdentifyUI) Start(username string, reason keybase1.IdentifyReason,
 	return nil
 }
 
-func (ui *BaseIdentifyUI) DisplayTrackStatement(stmt string) error {
+func (ui *BaseIdentifyUI) DisplayTrackStatement(_ libkb.MetaContext, stmt string) error {
 	return ui.parent.Output(stmt)
 }
 
-func (ui *BaseIdentifyUI) ReportTrackToken(_ keybase1.TrackToken) error {
+func (ui *BaseIdentifyUI) ReportTrackToken(_ libkb.MetaContext, _ keybase1.TrackToken) error {
 	return nil
 }
 
-func (ui *BaseIdentifyUI) Cancel() error {
+func (ui *BaseIdentifyUI) Cancel(_ libkb.MetaContext) error {
 	return nil
 }
 
-func (ui *BaseIdentifyUI) Finish() error {
+func (ui *BaseIdentifyUI) Finish(_ libkb.MetaContext) error {
 	if !ui.displayedProofs {
 		ui.ReportHook(ColorString(ui.G(), "bold", ui.username) + " hasn't proven their identity yet.")
 	}
 	return nil
 }
 
-func (ui *BaseIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) error {
+func (ui *BaseIdentifyUI) Dismiss(_ libkb.MetaContext, _ string, _ keybase1.DismissReason) error {
 	return nil
 }
 
-func (ui *BaseIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (ui *BaseIdentifyUI) Confirm(_ libkb.MetaContext, o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	warnings := libkb.ImportWarnings(o.Warnings)
 	if !warnings.IsEmpty() {
 		ui.ShowWarnings(warnings)
@@ -113,7 +113,7 @@ func (ui *BaseIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.Confirm
 	return keybase1.ConfirmResult{IdentityConfirmed: false, RemoteConfirmed: false}, nil
 }
 
-func (ui *BaseIdentifyUI) LaunchNetworkChecks(i *keybase1.Identity, u *keybase1.User) error {
+func (ui *BaseIdentifyUI) LaunchNetworkChecks(_ libkb.MetaContext, i *keybase1.Identity, u *keybase1.User) error {
 	return nil
 }
 
@@ -128,7 +128,7 @@ func (ui *BaseIdentifyUI) ReportRevoked(del []keybase1.TrackDiff) {
 	ui.displayedProofs = true
 }
 
-func (ui *BaseIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
+func (ui *BaseIdentifyUI) DisplayTLFCreateWithInvite(_ libkb.MetaContext, arg keybase1.DisplayTLFCreateWithInviteArg) error {
 	ui.displayedProofs = true // hacky, but we don't want to show the message about no proofs in this flow.
 
 	// this will only happen via `keybase favorite add` w/ no gui running:
@@ -195,7 +195,7 @@ func (ui *IdentifyTrackUI) confirmFailedTrackProofs(o *keybase1.IdentifyOutcome)
 	return
 }
 
-func (ui *IdentifyTrackUI) Confirm(o *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
+func (ui *IdentifyTrackUI) Confirm(_ libkb.MetaContext, o *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
 	var prompt string
 	username := o.Username
 
@@ -404,7 +404,7 @@ func (w LinkCheckResultWrapper) GetCachedMsg() string {
 	return msg
 }
 
-func (ui *BaseIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (ui *BaseIdentifyUI) FinishSocialProofCheck(_ libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	var msg, lcrs string
 
 	s := RemoteProofWrapper{p}
@@ -466,7 +466,7 @@ func (ui *BaseIdentifyUI) TrackDiffUpgradedToString(t libkb.TrackDiffUpgraded) s
 	return ColorString(ui.G(), "orange", "<Upgraded from "+t.GetPrev()+" to "+t.GetCurr()+">")
 }
 
-func (ui *BaseIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (ui *BaseIdentifyUI) FinishWebProofCheck(_ libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	var msg, lcrs string
 
 	s := RemoteProofWrapper{p}
@@ -520,19 +520,19 @@ func (ui *BaseIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1
 	return nil
 }
 
-func (ui *BaseIdentifyUI) DisplayCryptocurrency(l keybase1.Cryptocurrency) error {
+func (ui *BaseIdentifyUI) DisplayCryptocurrency(_ libkb.MetaContext, l keybase1.Cryptocurrency) error {
 	msg := fmt.Sprintf("%s  %s %s", BTC, l.Family, ColorString(ui.G(), "green", l.Address))
 	ui.ReportHook(msg)
 	return nil
 }
 
-func (ui *BaseIdentifyUI) DisplayStellarAccount(l keybase1.StellarAccount) error {
+func (ui *BaseIdentifyUI) DisplayStellarAccount(_ libkb.MetaContext, l keybase1.StellarAccount) error {
 	msg := fmt.Sprintf("%s  Stellar %s (%s)", XLM, ColorString(ui.G(), "green", l.AccountID), l.FederationAddress)
 	ui.ReportHook(msg)
 	return nil
 }
 
-func (ui *BaseIdentifyUI) DisplayKey(key keybase1.IdentifyKey) error {
+func (ui *BaseIdentifyUI) DisplayKey(_ libkb.MetaContext, key keybase1.IdentifyKey) error {
 	var fpq string
 	if fp := libkb.ImportPGPFingerprintSlice(key.PGPFingerprint); fp != nil {
 		fpq = fp.ToQuads()
@@ -556,7 +556,7 @@ func (ui *BaseIdentifyUI) DisplayKey(key keybase1.IdentifyKey) error {
 	return nil
 }
 
-func (ui *BaseIdentifyUI) ReportLastTrack(tl *keybase1.TrackSummary) error {
+func (ui *BaseIdentifyUI) ReportLastTrack(_ libkb.MetaContext, tl *keybase1.TrackSummary) error {
 	if t := libkb.ImportTrackSummary(tl); t != nil {
 		locally := ""
 		if !t.IsRemote() {

--- a/go/engine/buffered_identify_ui.go
+++ b/go/engine/buffered_identify_ui.go
@@ -47,6 +47,8 @@ type bufferedIdentifyUI struct {
 	userCard            *keybase1.UserCard
 }
 
+var _ libkb.IdentifyUI = (*bufferedIdentifyUI)(nil)
+
 func newBufferedIdentifyUI(g *libkb.GlobalContext, u libkb.IdentifyUI, c keybase1.ConfirmResult) *bufferedIdentifyUI {
 	return &bufferedIdentifyUI{
 		Contextified:        libkb.NewContextified(g),
@@ -56,14 +58,14 @@ func newBufferedIdentifyUI(g *libkb.GlobalContext, u libkb.IdentifyUI, c keybase
 	}
 }
 
-func (b *bufferedIdentifyUI) Start(s string, r keybase1.IdentifyReason, f bool) error {
+func (b *bufferedIdentifyUI) Start(m libkb.MetaContext, s string, r keybase1.IdentifyReason, f bool) error {
 	b.Lock()
 	defer b.Unlock()
 	b.start = &start{s, r, f}
-	return b.flush(false)
+	return b.flush(m, false)
 }
 
-func (b *bufferedIdentifyUI) flush(trackingBroke bool) (err error) {
+func (b *bufferedIdentifyUI) flush(m libkb.MetaContext, trackingBroke bool) (err error) {
 
 	// Look up the calling function for debugging purposes
 	pc := make([]uintptr, 10) // at least 1 entry needed
@@ -71,48 +73,48 @@ func (b *bufferedIdentifyUI) flush(trackingBroke bool) (err error) {
 	f := runtime.FuncForPC(pc[0])
 	caller := path.Base(f.Name())
 
-	b.G().Log.Debug("+ bufferedIdentifyUI#flush(%v) [caller=%s, buffered=%v, suppressed=%v]", trackingBroke, caller, b.bufferedMode, b.suppressed)
+	m.CDebugf("+ bufferedIdentifyUI#flush(%v) [caller=%s, buffered=%v, suppressed=%v]", trackingBroke, caller, b.bufferedMode, b.suppressed)
 
 	if !trackingBroke && b.bufferedMode {
-		b.G().Log.Debug("- bufferedIdentifyUI#flush: short-circuit")
+		m.CDebugf("- bufferedIdentifyUI#flush: short-circuit")
 		return nil
 	}
 
 	defer func() {
 		b.flushCleanup()
-		b.G().Log.Debug("- bufferedIdentifyUI#flush -> %v", err)
+		m.CDebugf("- bufferedIdentifyUI#flush -> %v", err)
 	}()
 
 	if b.start != nil {
-		err = b.raw.Start(b.start.s, b.start.r, b.start.f)
+		err = b.raw.Start(m, b.start.s, b.start.r, b.start.f)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, k := range b.keys {
-		err = b.raw.DisplayKey(k)
+		err = b.raw.DisplayKey(m, k)
 		if err != nil {
 			return err
 		}
 	}
 
 	if b.lastTrack != nil {
-		err = b.raw.ReportLastTrack(*b.lastTrack)
+		err = b.raw.ReportLastTrack(m, *b.lastTrack)
 		if err != nil {
 			return err
 		}
 	}
 
 	if b.launchNetworkChecks != nil {
-		err = b.raw.LaunchNetworkChecks(b.launchNetworkChecks.i, b.launchNetworkChecks.u)
+		err = b.raw.LaunchNetworkChecks(m, b.launchNetworkChecks.i, b.launchNetworkChecks.u)
 		if err != nil {
 			return err
 		}
 	}
 
 	if b.userCard != nil {
-		err = b.raw.DisplayUserCard(*b.userCard)
+		err = b.raw.DisplayUserCard(m, *b.userCard)
 		if err != nil {
 			return err
 		}
@@ -121,9 +123,9 @@ func (b *bufferedIdentifyUI) flush(trackingBroke bool) (err error) {
 	for _, w := range b.proofChecks {
 		var err error
 		if w.social {
-			err = b.raw.FinishSocialProofCheck(w.p, w.l)
+			err = b.raw.FinishSocialProofCheck(m, w.p, w.l)
 		} else {
-			err = b.raw.FinishWebProofCheck(w.p, w.l)
+			err = b.raw.FinishWebProofCheck(m, w.p, w.l)
 		}
 		if err != nil {
 			return err
@@ -131,14 +133,14 @@ func (b *bufferedIdentifyUI) flush(trackingBroke bool) (err error) {
 	}
 
 	for _, c := range b.cryptocurrency {
-		err = b.raw.DisplayCryptocurrency(c)
+		err = b.raw.DisplayCryptocurrency(m, c)
 		if err != nil {
 			return err
 		}
 	}
 
 	if b.stellar != nil {
-		err = b.raw.DisplayStellarAccount(*b.stellar)
+		err = b.raw.DisplayStellarAccount(m, *b.stellar)
 		if err != nil {
 			return err
 		}
@@ -159,117 +161,117 @@ func (b *bufferedIdentifyUI) flushCleanup() {
 	b.userCard = nil
 }
 
-func (b *bufferedIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (b *bufferedIdentifyUI) FinishWebProofCheck(m libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	b.Lock()
 	defer b.Unlock()
 	b.proofChecks = append(b.proofChecks, proofCheck{false, p, l})
-	return b.flush(l.BreaksTracking)
+	return b.flush(m, l.BreaksTracking)
 }
 
-func (b *bufferedIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (b *bufferedIdentifyUI) FinishSocialProofCheck(m libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	b.Lock()
 	defer b.Unlock()
 	b.proofChecks = append(b.proofChecks, proofCheck{true, p, l})
-	return b.flush(l.BreaksTracking)
+	return b.flush(m, l.BreaksTracking)
 }
 
-func (b *bufferedIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (b *bufferedIdentifyUI) Confirm(m libkb.MetaContext, o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	b.Lock()
 	defer b.Unlock()
 	if b.bufferedMode {
-		b.G().Log.Debug("| bufferedIdentifyUI#Confirm: suppressing output")
+		m.CDebugf("| bufferedIdentifyUI#Confirm: suppressing output")
 		b.suppressed = true
 		return b.confirmIfSuppressed, nil
 	}
-	b.G().Log.Debug("| bufferedIdentifyUI#Confirm: enabling output")
-	b.flush(true)
-	return b.raw.Confirm(o)
+	m.CDebugf("| bufferedIdentifyUI#Confirm: enabling output")
+	b.flush(m, true)
+	return b.raw.Confirm(m, o)
 }
 
-func (b *bufferedIdentifyUI) DisplayCryptocurrency(c keybase1.Cryptocurrency) error {
+func (b *bufferedIdentifyUI) DisplayCryptocurrency(m libkb.MetaContext, c keybase1.Cryptocurrency) error {
 	b.Lock()
 	defer b.Unlock()
 	b.cryptocurrency = append(b.cryptocurrency, c)
-	return b.flush(false)
+	return b.flush(m, false)
 }
 
-func (b *bufferedIdentifyUI) DisplayStellarAccount(c keybase1.StellarAccount) error {
+func (b *bufferedIdentifyUI) DisplayStellarAccount(m libkb.MetaContext, c keybase1.StellarAccount) error {
 	b.Lock()
 	defer b.Unlock()
 	b.stellar = &c
-	return b.flush(false)
+	return b.flush(m, false)
 }
 
-func (b *bufferedIdentifyUI) DisplayKey(k keybase1.IdentifyKey) error {
+func (b *bufferedIdentifyUI) DisplayKey(m libkb.MetaContext, k keybase1.IdentifyKey) error {
 	b.Lock()
 	defer b.Unlock()
 	b.keys = append(b.keys, k)
-	return b.flush(k.BreaksTracking)
+	return b.flush(m, k.BreaksTracking)
 }
 
-func (b *bufferedIdentifyUI) ReportLastTrack(s *keybase1.TrackSummary) error {
+func (b *bufferedIdentifyUI) ReportLastTrack(m libkb.MetaContext, s *keybase1.TrackSummary) error {
 	b.Lock()
 	defer b.Unlock()
 	b.lastTrack = &s
-	return b.flush(false)
+	return b.flush(m, false)
 }
 
-func (b *bufferedIdentifyUI) LaunchNetworkChecks(i *keybase1.Identity, u *keybase1.User) error {
+func (b *bufferedIdentifyUI) LaunchNetworkChecks(m libkb.MetaContext, i *keybase1.Identity, u *keybase1.User) error {
 	b.Lock()
 	defer b.Unlock()
 	b.launchNetworkChecks = &launchNetworkChecks{i, u}
-	return b.flush(i.BreaksTracking)
+	return b.flush(m, i.BreaksTracking)
 }
 
-func (b *bufferedIdentifyUI) DisplayTrackStatement(s string) error {
-	return b.raw.DisplayTrackStatement(s)
+func (b *bufferedIdentifyUI) DisplayTrackStatement(m libkb.MetaContext, s string) error {
+	return b.raw.DisplayTrackStatement(m, s)
 }
 
-func (b *bufferedIdentifyUI) DisplayUserCard(c keybase1.UserCard) error {
+func (b *bufferedIdentifyUI) DisplayUserCard(m libkb.MetaContext, c keybase1.UserCard) error {
 	b.Lock()
 	defer b.Unlock()
 	b.userCard = &c
-	return b.flush(false)
+	return b.flush(m, false)
 }
 
-func (b *bufferedIdentifyUI) ReportTrackToken(t keybase1.TrackToken) error {
+func (b *bufferedIdentifyUI) ReportTrackToken(m libkb.MetaContext, t keybase1.TrackToken) error {
 	b.Lock()
 	defer b.Unlock()
 	if b.suppressed {
 		return nil
 	}
-	return b.raw.ReportTrackToken(t)
+	return b.raw.ReportTrackToken(m, t)
 }
 
-func (b *bufferedIdentifyUI) Cancel() error {
+func (b *bufferedIdentifyUI) Cancel(m libkb.MetaContext) error {
 	b.Lock()
 	defer b.Unlock()
 
 	// Cancel should always go through to UI server
-	return b.raw.Cancel()
+	return b.raw.Cancel(m)
 }
 
-func (b *bufferedIdentifyUI) Finish() error {
+func (b *bufferedIdentifyUI) Finish(m libkb.MetaContext) error {
 	b.Lock()
 	defer b.Unlock()
 	if b.suppressed {
-		b.G().Log.Debug("| bufferedIdentifyUI#Finish: suppressed")
+		m.CDebugf("| bufferedIdentifyUI#Finish: suppressed")
 		return nil
 	}
-	b.G().Log.Debug("| bufferedIdentifyUI#Finish: went through to UI")
+	m.CDebugf("| bufferedIdentifyUI#Finish: went through to UI")
 
 	// This is likely a noop since we already covered this case in the `Confirm` step
 	// above. However, if due a bug we forgot to call `Confirm` from the UI, this
 	// is still useful.
-	b.flush(true)
+	b.flush(m, true)
 
-	return b.raw.Finish()
+	return b.raw.Finish(m)
 }
 
-func (b *bufferedIdentifyUI) DisplayTLFCreateWithInvite(d keybase1.DisplayTLFCreateWithInviteArg) error {
-	return b.raw.DisplayTLFCreateWithInvite(d)
+func (b *bufferedIdentifyUI) DisplayTLFCreateWithInvite(m libkb.MetaContext, d keybase1.DisplayTLFCreateWithInviteArg) error {
+	return b.raw.DisplayTLFCreateWithInvite(m, d)
 }
 
-func (b *bufferedIdentifyUI) Dismiss(s string, r keybase1.DismissReason) error {
-	return b.raw.Dismiss(s, r)
+func (b *bufferedIdentifyUI) Dismiss(m libkb.MetaContext, s string, r keybase1.DismissReason) error {
+	return b.raw.Dismiss(m, s, r)
 }

--- a/go/engine/favorite_add.go
+++ b/go/engine/favorite_add.go
@@ -125,7 +125,7 @@ func (e *FavoriteAdd) checkInviteNeeded(m libkb.MetaContext) error {
 			Throttled:       inv.Throttled,
 			InviteLink:      inv.Link(),
 		}
-		if err := m.UIs().IdentifyUI.DisplayTLFCreateWithInvite(arg); err != nil {
+		if err := m.UIs().IdentifyUI.DisplayTLFCreateWithInvite(m, arg); err != nil {
 			return err
 		}
 	}

--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -213,7 +213,7 @@ type FakeIdentifyUI struct {
 	sync.Mutex
 }
 
-func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
+func (ui *FakeIdentifyUI) FinishWebProofCheck(_ libkb.MetaContext, proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Proofs == nil {
@@ -231,7 +231,7 @@ func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result
 	return nil
 }
 
-func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
+func (ui *FakeIdentifyUI) FinishSocialProofCheck(_ libkb.MetaContext, proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Proofs == nil {
@@ -248,7 +248,7 @@ func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, res
 	return nil
 }
 
-func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
+func (ui *FakeIdentifyUI) Confirm(_ libkb.MetaContext, outcome *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
 	ui.Lock()
 	defer ui.Unlock()
 
@@ -265,15 +265,15 @@ func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result key
 	return
 }
 
-func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {
+func (ui *FakeIdentifyUI) DisplayCryptocurrency(libkb.MetaContext, keybase1.Cryptocurrency) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) DisplayStellarAccount(keybase1.StellarAccount) error {
+func (ui *FakeIdentifyUI) DisplayStellarAccount(libkb.MetaContext, keybase1.StellarAccount) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) error {
+func (ui *FakeIdentifyUI) DisplayKey(_ libkb.MetaContext, ik keybase1.IdentifyKey) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Keys == nil {
@@ -292,45 +292,45 @@ func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) error {
 	ui.DisplayKeyCalls++
 	return nil
 }
-func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) error {
+func (ui *FakeIdentifyUI) ReportLastTrack(libkb.MetaContext, *keybase1.TrackSummary) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason, _ bool) error {
+func (ui *FakeIdentifyUI) Start(_ libkb.MetaContext, username string, _ keybase1.IdentifyReason, _ bool) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.StartCount++
 	return nil
 }
 
-func (ui *FakeIdentifyUI) Cancel() error {
+func (ui *FakeIdentifyUI) Cancel(libkb.MetaContext) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) Finish() error {
+func (ui *FakeIdentifyUI) Finish(libkb.MetaContext) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) error {
+func (ui *FakeIdentifyUI) Dismiss(_ libkb.MetaContext, _ string, _ keybase1.DismissReason) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) error {
+func (ui *FakeIdentifyUI) LaunchNetworkChecks(_ libkb.MetaContext, id *keybase1.Identity, user *keybase1.User) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.User = user
 	return nil
 }
 
-func (ui *FakeIdentifyUI) DisplayTrackStatement(string) error {
+func (ui *FakeIdentifyUI) DisplayTrackStatement(libkb.MetaContext, string) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) DisplayUserCard(keybase1.UserCard) error {
+func (ui *FakeIdentifyUI) DisplayUserCard(libkb.MetaContext, keybase1.UserCard) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) ReportTrackToken(tok keybase1.TrackToken) error {
+func (ui *FakeIdentifyUI) ReportTrackToken(_ libkb.MetaContext, tok keybase1.TrackToken) error {
 	ui.Token = tok
 	return nil
 }
@@ -338,7 +338,7 @@ func (ui *FakeIdentifyUI) ReportTrackToken(tok keybase1.TrackToken) error {
 func (ui *FakeIdentifyUI) SetStrict(b bool) {
 }
 
-func (ui *FakeIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
+func (ui *FakeIdentifyUI) DisplayTLFCreateWithInvite(_ libkb.MetaContext, arg keybase1.DisplayTLFCreateWithInviteArg) error {
 	ui.DisplayTLFCount++
 	ui.DisplayTLFArg = arg
 	return nil

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -121,64 +121,64 @@ func (i *Identify2WithUIDTester) GetTorError() libkb.ProofError {
 	return nil
 }
 
-func (i *Identify2WithUIDTester) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+func (i *Identify2WithUIDTester) FinishSocialProofCheck(libkb.MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) Confirm(*keybase1.IdentifyOutcome) (res keybase1.ConfirmResult, err error) {
+func (i *Identify2WithUIDTester) Confirm(libkb.MetaContext, *keybase1.IdentifyOutcome) (res keybase1.ConfirmResult, err error) {
 	return
 }
-func (i *Identify2WithUIDTester) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+func (i *Identify2WithUIDTester) FinishWebProofCheck(libkb.MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) DisplayCryptocurrency(keybase1.Cryptocurrency) error {
+func (i *Identify2WithUIDTester) DisplayCryptocurrency(libkb.MetaContext, keybase1.Cryptocurrency) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) DisplayStellarAccount(keybase1.StellarAccount) error {
+func (i *Identify2WithUIDTester) DisplayStellarAccount(libkb.MetaContext, keybase1.StellarAccount) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) DisplayKey(keybase1.IdentifyKey) error {
+func (i *Identify2WithUIDTester) DisplayKey(libkb.MetaContext, keybase1.IdentifyKey) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) ReportLastTrack(*keybase1.TrackSummary) error {
+func (i *Identify2WithUIDTester) ReportLastTrack(libkb.MetaContext, *keybase1.TrackSummary) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) error {
+func (i *Identify2WithUIDTester) LaunchNetworkChecks(libkb.MetaContext, *keybase1.Identity, *keybase1.User) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) DisplayTrackStatement(string) error {
+func (i *Identify2WithUIDTester) DisplayTrackStatement(libkb.MetaContext, string) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) ReportTrackToken(keybase1.TrackToken) (err error) {
+func (i *Identify2WithUIDTester) ReportTrackToken(libkb.MetaContext, keybase1.TrackToken) (err error) {
 	return nil
 }
 func (i *Identify2WithUIDTester) SetStrict(b bool) error {
 	return nil
 }
-func (i *Identify2WithUIDTester) DisplayUserCard(card keybase1.UserCard) error {
+func (i *Identify2WithUIDTester) DisplayUserCard(_ libkb.MetaContext, card keybase1.UserCard) error {
 	i.Lock()
 	defer i.Unlock()
 	i.card = card
 	return nil
 }
 
-func (i *Identify2WithUIDTester) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
+func (i *Identify2WithUIDTester) DisplayTLFCreateWithInvite(libkb.MetaContext, keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil
 }
 
-func (i *Identify2WithUIDTester) Cancel() error {
+func (i *Identify2WithUIDTester) Cancel(libkb.MetaContext) error {
 	return nil
 }
 
-func (i *Identify2WithUIDTester) Finish() error {
+func (i *Identify2WithUIDTester) Finish(libkb.MetaContext) error {
 	i.finishCh <- struct{}{}
 	return nil
 }
 
-func (i *Identify2WithUIDTester) Dismiss(_ string, _ keybase1.DismissReason) error {
+func (i *Identify2WithUIDTester) Dismiss(_ libkb.MetaContext, _ string, _ keybase1.DismissReason) error {
 	return nil
 }
 
-func (i *Identify2WithUIDTester) Start(string, keybase1.IdentifyReason, bool) error {
+func (i *Identify2WithUIDTester) Start(libkb.MetaContext, string, keybase1.IdentifyReason, bool) error {
 	i.startCh <- struct{}{}
 	return nil
 }
@@ -479,7 +479,7 @@ func TestIdentify2WithUIDWithBrokenTrackFromChatGUI(t *testing.T) {
 		err := eng.Run(m)
 		// Since we threw away the test UI, we have to manually complete the UI here,
 		// otherwise the waiter() will block indefinitely.
-		origUI.Finish()
+		origUI.Finish(m)
 		waiter()
 		if err != nil {
 			t.Fatalf("expected no ID2 error; got %v", err)

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -353,7 +353,7 @@ func (e *Identify2WithUID) run(m libkb.MetaContext) {
 	// If no identifyUI was specified (because running the background)
 	// then don't do anything.
 	if m.UIs().IdentifyUI != nil {
-		m.UIs().IdentifyUI.Cancel()
+		m.UIs().IdentifyUI.Cancel(m)
 	}
 }
 
@@ -639,7 +639,7 @@ func (e *Identify2WithUID) insertTrackToken(m libkb.MetaContext, outcome *libkb.
 	if err != nil {
 		return err
 	}
-	return m.UIs().IdentifyUI.ReportTrackToken(e.trackToken)
+	return m.UIs().IdentifyUI.ReportTrackToken(m, e.trackToken)
 }
 
 // CCLCheckCompleted is triggered whenever a remote proof check completes.
@@ -800,20 +800,20 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	iui := m.UIs().IdentifyUI
 
 	m.CDebugf("| IdentifyUI.Start(%s)", e.them.GetName())
-	if err = iui.Start(e.them.GetName(), e.arg.Reason, e.arg.ForceDisplay); err != nil {
+	if err = iui.Start(m, e.them.GetName(), e.arg.Reason, e.arg.ForceDisplay); err != nil {
 		return err
 	}
 	for _, k := range e.identifyKeys {
-		if err = iui.DisplayKey(k); err != nil {
+		if err = iui.DisplayKey(m, k); err != nil {
 			return err
 		}
 	}
 	m.CDebugf("| IdentifyUI.ReportLastTrack(%s)", e.them.GetName())
-	if err = iui.ReportLastTrack(libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName())); err != nil {
+	if err = iui.ReportLastTrack(m, libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName())); err != nil {
 		return err
 	}
 	m.CDebugf("| IdentifyUI.LaunchNetworkChecks(%s)", e.them.GetName())
-	if err = iui.LaunchNetworkChecks(e.state.ExportToUncheckedIdentity(e.G()), e.them.Export()); err != nil {
+	if err = iui.LaunchNetworkChecks(m, e.state.ExportToUncheckedIdentity(e.G()), e.them.Export()); err != nil {
 		return err
 	}
 
@@ -853,7 +853,7 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	// use Confirm to display the IdentifyOutcome
 	outcome := e.state.Result()
 	outcome.TrackOptions = e.trackOptions
-	e.confirmResult, err = iui.Confirm(outcome.Export(e.G()))
+	e.confirmResult, err = iui.Confirm(m, outcome.Export(e.G()))
 	if err != nil {
 		m.CDebugf("| Failure in iui.Confirm")
 		return err
@@ -861,7 +861,7 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 
 	e.insertTrackToken(m, outcome)
 
-	if err = iui.Finish(); err != nil {
+	if err = iui.Finish(m); err != nil {
 		m.CDebugf("| Failure in iui.Finish")
 		return err
 	}

--- a/go/engine/loopback_identify_ui.go
+++ b/go/engine/loopback_identify_ui.go
@@ -16,6 +16,8 @@ type LoopbackIdentifyUI struct {
 	trackBreaksP **keybase1.IdentifyTrackBreaks
 }
 
+var _ libkb.IdentifyUI = (*LoopbackIdentifyUI)(nil)
+
 func NewLoopbackIdentifyUI(g *libkb.GlobalContext, tb **keybase1.IdentifyTrackBreaks) *LoopbackIdentifyUI {
 	return &LoopbackIdentifyUI{
 		Contextified: libkb.NewContextified(g),
@@ -23,7 +25,7 @@ func NewLoopbackIdentifyUI(g *libkb.GlobalContext, tb **keybase1.IdentifyTrackBr
 	}
 }
 
-func (b *LoopbackIdentifyUI) Start(s string, r keybase1.IdentifyReason, f bool) error {
+func (b *LoopbackIdentifyUI) Start(m libkb.MetaContext, s string, r keybase1.IdentifyReason, f bool) error {
 	return nil
 }
 
@@ -34,7 +36,7 @@ func (b *LoopbackIdentifyUI) trackBreaks() *keybase1.IdentifyTrackBreaks {
 	return *b.trackBreaksP
 }
 
-func (b *LoopbackIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+func (b *LoopbackIdentifyUI) FinishWebProofCheck(m libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
 	b.Lock()
 	defer b.Unlock()
 	if l.BreaksTracking {
@@ -47,23 +49,23 @@ func (b *LoopbackIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, l keyba
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
-	return b.FinishWebProofCheck(p, l)
+func (b *LoopbackIdentifyUI) FinishSocialProofCheck(m libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+	return b.FinishWebProofCheck(m, p, l)
 }
 
-func (b *LoopbackIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (b *LoopbackIdentifyUI) Confirm(m libkb.MetaContext, o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	return keybase1.ConfirmResult{}, nil
 }
 
-func (b *LoopbackIdentifyUI) DisplayCryptocurrency(c keybase1.Cryptocurrency) error {
+func (b *LoopbackIdentifyUI) DisplayCryptocurrency(m libkb.MetaContext, c keybase1.Cryptocurrency) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) DisplayStellarAccount(keybase1.StellarAccount) error {
+func (b *LoopbackIdentifyUI) DisplayStellarAccount(libkb.MetaContext, keybase1.StellarAccount) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) DisplayKey(k keybase1.IdentifyKey) error {
+func (b *LoopbackIdentifyUI) DisplayKey(m libkb.MetaContext, k keybase1.IdentifyKey) error {
 	b.Lock()
 	defer b.Unlock()
 	if k.BreaksTracking {
@@ -73,38 +75,38 @@ func (b *LoopbackIdentifyUI) DisplayKey(k keybase1.IdentifyKey) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) ReportLastTrack(s *keybase1.TrackSummary) error {
+func (b *LoopbackIdentifyUI) ReportLastTrack(m libkb.MetaContext, s *keybase1.TrackSummary) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) LaunchNetworkChecks(i *keybase1.Identity, u *keybase1.User) error {
+func (b *LoopbackIdentifyUI) LaunchNetworkChecks(m libkb.MetaContext, i *keybase1.Identity, u *keybase1.User) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) DisplayTrackStatement(s string) error {
+func (b *LoopbackIdentifyUI) DisplayTrackStatement(m libkb.MetaContext, s string) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) DisplayUserCard(c keybase1.UserCard) error {
+func (b *LoopbackIdentifyUI) DisplayUserCard(m libkb.MetaContext, c keybase1.UserCard) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) ReportTrackToken(t keybase1.TrackToken) error {
+func (b *LoopbackIdentifyUI) ReportTrackToken(m libkb.MetaContext, t keybase1.TrackToken) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) Cancel() error {
+func (b *LoopbackIdentifyUI) Cancel(m libkb.MetaContext) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) Finish() error {
+func (b *LoopbackIdentifyUI) Finish(m libkb.MetaContext) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) DisplayTLFCreateWithInvite(d keybase1.DisplayTLFCreateWithInviteArg) error {
+func (b *LoopbackIdentifyUI) DisplayTLFCreateWithInvite(m libkb.MetaContext, d keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil
 }
 
-func (b *LoopbackIdentifyUI) Dismiss(s string, r keybase1.DismissReason) error {
+func (b *LoopbackIdentifyUI) Dismiss(m libkb.MetaContext, s string, r keybase1.DismissReason) error {
 	return nil
 }

--- a/go/engine/user_card.go
+++ b/go/engine/user_card.go
@@ -92,7 +92,7 @@ func displayUserCard(m libkb.MetaContext, uid keybase1.UID, useSession bool) err
 		return nil
 	}
 
-	return m.UIs().IdentifyUI.DisplayUserCard(*card)
+	return m.UIs().IdentifyUI.DisplayUserCard(m, *card)
 }
 
 func displayUserCardAsync(m libkb.MetaContext, uid keybase1.UID, useSession bool) <-chan error {

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -347,7 +347,7 @@ type fakeIdentifyUI struct {
 	*engine.LoopbackIdentifyUI
 }
 
-func (l *fakeIdentifyUI) Confirm(o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (l *fakeIdentifyUI) Confirm(_ libkb.MetaContext, o *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	return keybase1.ConfirmResult{IdentityConfirmed: true, RemoteConfirmed: true}, nil
 }
 

--- a/go/kbtest/ui.go
+++ b/go/kbtest/ui.go
@@ -82,7 +82,7 @@ type FakeIdentifyUI struct {
 
 var _ libkb.IdentifyUI = (*FakeIdentifyUI)(nil)
 
-func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
+func (ui *FakeIdentifyUI) FinishWebProofCheck(_ libkb.MetaContext, proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Proofs == nil {
@@ -100,7 +100,7 @@ func (ui *FakeIdentifyUI) FinishWebProofCheck(proof keybase1.RemoteProof, result
 	return nil
 }
 
-func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
+func (ui *FakeIdentifyUI) FinishSocialProofCheck(_ libkb.MetaContext, proof keybase1.RemoteProof, result keybase1.LinkCheckResult) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Proofs == nil {
@@ -117,7 +117,7 @@ func (ui *FakeIdentifyUI) FinishSocialProofCheck(proof keybase1.RemoteProof, res
 	return nil
 }
 
-func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
+func (ui *FakeIdentifyUI) Confirm(_ libkb.MetaContext, outcome *keybase1.IdentifyOutcome) (result keybase1.ConfirmResult, err error) {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.Outcome = outcome
@@ -126,18 +126,18 @@ func (ui *FakeIdentifyUI) Confirm(outcome *keybase1.IdentifyOutcome) (result key
 	return
 }
 
-func (ui *FakeIdentifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {
+func (ui *FakeIdentifyUI) DisplayCryptocurrency(libkb.MetaContext, keybase1.Cryptocurrency) error {
 	return nil
 }
 
-func (ui *FakeIdentifyUI) DisplayStellarAccount(acc keybase1.StellarAccount) error {
+func (ui *FakeIdentifyUI) DisplayStellarAccount(_ libkb.MetaContext, acc keybase1.StellarAccount) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.StellarAccounts = append(ui.StellarAccounts, acc)
 	return nil
 }
 
-func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) error {
+func (ui *FakeIdentifyUI) DisplayKey(_ libkb.MetaContext, ik keybase1.IdentifyKey) error {
 	ui.Lock()
 	defer ui.Unlock()
 	if ui.Keys == nil {
@@ -149,43 +149,43 @@ func (ui *FakeIdentifyUI) DisplayKey(ik keybase1.IdentifyKey) error {
 	ui.DisplayKeyCalls++
 	return nil
 }
-func (ui *FakeIdentifyUI) ReportLastTrack(*keybase1.TrackSummary) error {
+func (ui *FakeIdentifyUI) ReportLastTrack(libkb.MetaContext, *keybase1.TrackSummary) error {
 	return nil
 }
-func (ui *FakeIdentifyUI) Start(username string, _ keybase1.IdentifyReason, forceDisplay bool) error {
+func (ui *FakeIdentifyUI) Start(_ libkb.MetaContext, username string, _ keybase1.IdentifyReason, forceDisplay bool) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.StartCount++
 	return nil
 }
-func (ui *FakeIdentifyUI) Cancel() error {
+func (ui *FakeIdentifyUI) Cancel(_ libkb.MetaContext) error {
 	return nil
 }
-func (ui *FakeIdentifyUI) Finish() error {
+func (ui *FakeIdentifyUI) Finish(_ libkb.MetaContext) error {
 	return nil
 }
-func (ui *FakeIdentifyUI) Dismiss(_ string, _ keybase1.DismissReason) error {
+func (ui *FakeIdentifyUI) Dismiss(_ libkb.MetaContext, _ string, _ keybase1.DismissReason) error {
 	return nil
 }
-func (ui *FakeIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) error {
+func (ui *FakeIdentifyUI) LaunchNetworkChecks(_ libkb.MetaContext, id *keybase1.Identity, user *keybase1.User) error {
 	ui.Lock()
 	defer ui.Unlock()
 	ui.User = user
 	return nil
 }
-func (ui *FakeIdentifyUI) DisplayTrackStatement(string) error {
+func (ui *FakeIdentifyUI) DisplayTrackStatement(libkb.MetaContext, string) error {
 	return nil
 }
-func (ui *FakeIdentifyUI) DisplayUserCard(keybase1.UserCard) error {
+func (ui *FakeIdentifyUI) DisplayUserCard(libkb.MetaContext, keybase1.UserCard) error {
 	return nil
 }
-func (ui *FakeIdentifyUI) ReportTrackToken(tok keybase1.TrackToken) error {
+func (ui *FakeIdentifyUI) ReportTrackToken(_ libkb.MetaContext, tok keybase1.TrackToken) error {
 	ui.Token = tok
 	return nil
 }
 func (ui *FakeIdentifyUI) SetStrict(b bool) {
 }
-func (ui *FakeIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
+func (ui *FakeIdentifyUI) DisplayTLFCreateWithInvite(_ libkb.MetaContext, arg keybase1.DisplayTLFCreateWithInviteArg) error {
 	ui.DisplayTLFCount++
 	ui.DisplayTLFArg = arg
 	return nil

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -134,7 +134,7 @@ type RemoteProofChainLink interface {
 	GetRemoteUsername() string
 	GetHostname() string
 	GetProtocol() string
-	DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error
+	DisplayCheck(m MetaContext, ui IdentifyUI, lcr LinkCheckResult) error
 	ToTrackingStatement(keybase1.ProofState) (*jsonw.Wrapper, error)
 	CheckDataJSON() *jsonw.Wrapper
 	ToIDString() string
@@ -184,8 +184,8 @@ func (w *WebProofChainLink) ToTrackingStatement(state keybase1.ProofState) (*jso
 	return ret, nil
 }
 
-func (w *WebProofChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error {
-	return ui.FinishWebProofCheck(ExportRemoteProof(w), lcr.Export())
+func (w *WebProofChainLink) DisplayCheck(m MetaContext, ui IdentifyUI, lcr LinkCheckResult) error {
+	return ui.FinishWebProofCheck(m, ExportRemoteProof(w), lcr.Export())
 }
 
 func (w *WebProofChainLink) Type() string { return "proof" }
@@ -277,8 +277,8 @@ func (s *SocialProofChainLink) ComputeTrackDiff(tl *TrackLookup) TrackDiff {
 	}
 }
 
-func (s *SocialProofChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error {
-	return ui.FinishSocialProofCheck(ExportRemoteProof(s), lcr.Export())
+func (s *SocialProofChainLink) DisplayCheck(m MetaContext, ui IdentifyUI, lcr LinkCheckResult) error {
+	return ui.FinishSocialProofCheck(m, ExportRemoteProof(s), lcr.Export())
 }
 
 func (s *SocialProofChainLink) CheckDataJSON() *jsonw.Wrapper {
@@ -977,8 +977,8 @@ func (s *WalletStellarChainLink) VerifyReverseSig(_ ComputedKeyFamily) (err erro
 	return VerifyReverseSig(s.G(), key, "body.wallet_key.reverse_sig", s.UnmarshalPayloadJSON(), s.reverseSig)
 }
 
-func (s *WalletStellarChainLink) Display(ui IdentifyUI) error {
-	return ui.DisplayStellarAccount(keybase1.StellarAccount{
+func (s *WalletStellarChainLink) Display(m MetaContext, ui IdentifyUI) error {
+	return ui.DisplayStellarAccount(m, keybase1.StellarAccount{
 		AccountID:         s.address,
 		FederationAddress: fmt.Sprintf("%s*keybase.io", s.GetUsername()),
 		SigID:             s.GetSigID(),
@@ -1095,8 +1095,8 @@ func (c *CryptocurrencyChainLink) insertIntoTable(tab *IdentityTable) {
 	tab.cryptocurrency = append(tab.cryptocurrency, c)
 }
 
-func (c CryptocurrencyChainLink) Display(ui IdentifyUI) error {
-	return ui.DisplayCryptocurrency(c.Export())
+func (c CryptocurrencyChainLink) Display(m MetaContext, ui IdentifyUI) error {
+	return ui.DisplayCryptocurrency(m, c.Export())
 }
 
 //
@@ -1168,7 +1168,7 @@ func (s *SelfSigChainLink) ProofText() string          { return "" }
 
 func (s *SelfSigChainLink) GetPGPFullHash() string { return s.extractPGPFullHash("key") }
 
-func (s *SelfSigChainLink) DisplayCheck(ui IdentifyUI, lcr LinkCheckResult) error {
+func (s *SelfSigChainLink) DisplayCheck(m MetaContext, ui IdentifyUI, lcr LinkCheckResult) error {
 	return nil
 }
 
@@ -1517,13 +1517,13 @@ func (idt *IdentityTable) Identify(m MetaContext, is IdentifyState, forceRemoteC
 
 	allAcc := idt.AllActiveCryptocurrency()
 	for _, acc := range allAcc {
-		if err := acc.Display(ui); err != nil {
+		if err := acc.Display(m, ui); err != nil {
 			return err
 		}
 	}
 
 	if stellar := idt.stellar; stellar != nil {
-		if err := stellar.Display(ui); err != nil {
+		if err := stellar.Display(m, ui); err != nil {
 			return err
 		}
 	}
@@ -1545,7 +1545,7 @@ func (idt *IdentityTable) identifyActiveProof(m MetaContext, lcr *LinkCheckResul
 	if ccl != nil {
 		ccl.CCLCheckCompleted(lcr)
 	}
-	return lcr.link.DisplayCheck(ui, *lcr)
+	return lcr.link.DisplayCheck(m, ui, *lcr)
 }
 
 type LinkCheckResult struct {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -302,22 +302,22 @@ type ExternalAPI interface {
 }
 
 type IdentifyUI interface {
-	Start(string, keybase1.IdentifyReason, bool) error
-	FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error
-	FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error
-	Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error)
-	DisplayCryptocurrency(keybase1.Cryptocurrency) error
-	DisplayStellarAccount(keybase1.StellarAccount) error
-	DisplayKey(keybase1.IdentifyKey) error
-	ReportLastTrack(*keybase1.TrackSummary) error
-	LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) error
-	DisplayTrackStatement(string) error
-	DisplayUserCard(keybase1.UserCard) error
-	ReportTrackToken(keybase1.TrackToken) error
-	Cancel() error
-	Finish() error
-	DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error
-	Dismiss(string, keybase1.DismissReason) error
+	Start(MetaContext, string, keybase1.IdentifyReason, bool) error
+	FinishWebProofCheck(MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error
+	FinishSocialProofCheck(MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error
+	Confirm(MetaContext, *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error)
+	DisplayCryptocurrency(MetaContext, keybase1.Cryptocurrency) error
+	DisplayStellarAccount(MetaContext, keybase1.StellarAccount) error
+	DisplayKey(MetaContext, keybase1.IdentifyKey) error
+	ReportLastTrack(MetaContext, *keybase1.TrackSummary) error
+	LaunchNetworkChecks(MetaContext, *keybase1.Identity, *keybase1.User) error
+	DisplayTrackStatement(MetaContext, string) error
+	DisplayUserCard(MetaContext, keybase1.UserCard) error
+	ReportTrackToken(MetaContext, keybase1.TrackToken) error
+	Cancel(MetaContext) error
+	Finish(MetaContext) error
+	DisplayTLFCreateWithInvite(MetaContext, keybase1.DisplayTLFCreateWithInviteArg) error
+	Dismiss(MetaContext, string, keybase1.DismissReason) error
 }
 
 type Checker struct {

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -1179,46 +1179,47 @@ func (h IdentifyUIHandler) handleShowTrackerPopupCreate(ctx context.Context, cli
 
 func (h IdentifyUIHandler) handleShowTrackerPopupDismiss(ctx context.Context, cli gregor1.IncomingInterface,
 	item gregor.Item) error {
+	mctx := libkb.NewMetaContext(ctx, h.G())
 
-	h.G().Log.Debug("handleShowTrackerPopupDismiss: %+v", item)
+	mctx.CDebugf("handleShowTrackerPopupDismiss: %+v", item)
 	if item.Body() == nil {
 		return errors.New("gregor dismissal for show_tracker_popup: nil message body")
 	}
 	body, err := jsonw.Unmarshal(item.Body().Bytes())
 	if err != nil {
-		h.G().Log.Debug("body failed to unmarshal", err)
+		mctx.CDebugf("body failed to unmarshal", err)
 		return err
 	}
 	uidString, err := body.AtPath("uid").GetString()
 	if err != nil {
-		h.G().Log.Debug("failed to extract uid", err)
+		mctx.CDebugf("failed to extract uid", err)
 		return err
 	}
 	uid, err := keybase1.UIDFromString(uidString)
 	if err != nil {
-		h.G().Log.Debug("failed to convert UID from string", err)
+		mctx.CDebugf("failed to convert UID from string", err)
 		return err
 	}
 	user, err := libkb.LoadUser(libkb.NewLoadUserByUIDArg(ctx, h.G(), uid))
 	if err != nil {
-		h.G().Log.Debug("failed to load user from UID", err)
+		mctx.CDebugf("failed to load user from UID", err)
 		return err
 	}
 
 	identifyUI, err := h.G().UIRouter.GetIdentifyUI()
 	if err != nil {
-		h.G().Log.Debug("failed to get IdentifyUI", err)
+		mctx.CDebugf("failed to get IdentifyUI", err)
 		return err
 	}
 	if identifyUI == nil {
-		h.G().Log.Debug("got nil IdentifyUI")
+		mctx.CDebugf("got nil IdentifyUI")
 		return errors.New("got nil IdentifyUI")
 	}
 
 	reason := keybase1.DismissReason{
 		Type: keybase1.DismissReasonType_HANDLED_ELSEWHERE,
 	}
-	identifyUI.Dismiss(user.GetName(), reason)
+	identifyUI.Dismiss(mctx, user.GetName(), reason)
 
 	return nil
 }

--- a/go/service/gregor_test.go
+++ b/go/service/gregor_test.go
@@ -142,13 +142,13 @@ func newShowTrackerPopupIdentifyUI() *showTrackerPopupIdentifyUI {
 
 var _ libkb.IdentifyUI = (*showTrackerPopupIdentifyUI)(nil)
 
-func (ui *showTrackerPopupIdentifyUI) Start(name string, reason keybase1.IdentifyReason, force bool) error {
+func (ui *showTrackerPopupIdentifyUI) Start(_ libkb.MetaContext, name string, reason keybase1.IdentifyReason, force bool) error {
 	ui.startCh <- name
 	return nil
 }
 
 // Overriding the Dismiss method lets us test that it gets called.
-func (ui *showTrackerPopupIdentifyUI) Dismiss(username string, _ keybase1.DismissReason) error {
+func (ui *showTrackerPopupIdentifyUI) Dismiss(_ libkb.MetaContext, username string, _ keybase1.DismissReason) error {
 	ui.dismissCh <- username
 	return nil
 }

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -28,6 +28,8 @@ type RemoteIdentifyUI struct {
 	skipPrompt bool
 }
 
+var _ libkb.IdentifyUI = (*RemoteIdentifyUI)(nil)
+
 type IdentifyHandler struct {
 	*BaseHandler
 	libkb.Contextified
@@ -356,115 +358,115 @@ func (h *IdentifyHandler) NormalizeSocialAssertion(ctx context.Context, assertio
 	return socialAssertion, nil
 }
 
-func (u *RemoteIdentifyUI) newContext() (context.Context, func()) {
-	return context.WithTimeout(context.Background(), libkb.RemoteIdentifyUITimeout)
+func (u *RemoteIdentifyUI) newMetaContext(mctx libkb.MetaContext) (libkb.MetaContext, func()) {
+	return mctx.WithTimeout(libkb.RemoteIdentifyUITimeout)
 }
 
-func (u *RemoteIdentifyUI) FinishWebProofCheck(p keybase1.RemoteProof, lcr keybase1.LinkCheckResult) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) FinishWebProofCheck(mctx libkb.MetaContext, p keybase1.RemoteProof, lcr keybase1.LinkCheckResult) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.FinishWebProofCheck(ctx, keybase1.FinishWebProofCheckArg{
+	return u.uicli.FinishWebProofCheck(mctx.Ctx(), keybase1.FinishWebProofCheckArg{
 		SessionID: u.sessionID,
 		Rp:        p,
 		Lcr:       lcr,
 	})
 }
 
-func (u *RemoteIdentifyUI) FinishSocialProofCheck(p keybase1.RemoteProof, lcr keybase1.LinkCheckResult) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) FinishSocialProofCheck(mctx libkb.MetaContext, p keybase1.RemoteProof, lcr keybase1.LinkCheckResult) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.FinishSocialProofCheck(ctx, keybase1.FinishSocialProofCheckArg{
+	return u.uicli.FinishSocialProofCheck(mctx.Ctx(), keybase1.FinishSocialProofCheckArg{
 		SessionID: u.sessionID,
 		Rp:        p,
 		Lcr:       lcr,
 	})
 }
 
-func (u *RemoteIdentifyUI) Confirm(io *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (u *RemoteIdentifyUI) Confirm(mctx libkb.MetaContext, io *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	if u.skipPrompt {
-		u.G().Log.Debug("skipping Confirm for %q", io.Username)
+		mctx.CDebugf("skipping Confirm for %q", io.Username)
 		return keybase1.ConfirmResult{IdentityConfirmed: true}, nil
 	}
-	return u.uicli.Confirm(context.TODO(), keybase1.ConfirmArg{SessionID: u.sessionID, Outcome: *io})
+	return u.uicli.Confirm(mctx.Ctx(), keybase1.ConfirmArg{SessionID: u.sessionID, Outcome: *io})
 }
 
-func (u *RemoteIdentifyUI) DisplayCryptocurrency(c keybase1.Cryptocurrency) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) DisplayCryptocurrency(mctx libkb.MetaContext, c keybase1.Cryptocurrency) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.DisplayCryptocurrency(ctx, keybase1.DisplayCryptocurrencyArg{SessionID: u.sessionID, C: c})
+	return u.uicli.DisplayCryptocurrency(mctx.Ctx(), keybase1.DisplayCryptocurrencyArg{SessionID: u.sessionID, C: c})
 }
 
-func (u *RemoteIdentifyUI) DisplayStellarAccount(a keybase1.StellarAccount) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) DisplayStellarAccount(mctx libkb.MetaContext, a keybase1.StellarAccount) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.DisplayStellarAccount(ctx, keybase1.DisplayStellarAccountArg{SessionID: u.sessionID, A: a})
+	return u.uicli.DisplayStellarAccount(mctx.Ctx(), keybase1.DisplayStellarAccountArg{SessionID: u.sessionID, A: a})
 }
 
-func (u *RemoteIdentifyUI) DisplayKey(key keybase1.IdentifyKey) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) DisplayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.DisplayKey(ctx, keybase1.DisplayKeyArg{SessionID: u.sessionID, Key: key})
+	return u.uicli.DisplayKey(mctx.Ctx(), keybase1.DisplayKeyArg{SessionID: u.sessionID, Key: key})
 }
 
-func (u *RemoteIdentifyUI) ReportLastTrack(t *keybase1.TrackSummary) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) ReportLastTrack(mctx libkb.MetaContext, t *keybase1.TrackSummary) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.ReportLastTrack(ctx, keybase1.ReportLastTrackArg{SessionID: u.sessionID, Track: t})
+	return u.uicli.ReportLastTrack(mctx.Ctx(), keybase1.ReportLastTrackArg{SessionID: u.sessionID, Track: t})
 }
 
-func (u *RemoteIdentifyUI) DisplayTrackStatement(s string) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) DisplayTrackStatement(mctx libkb.MetaContext, s string) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.DisplayTrackStatement(ctx, keybase1.DisplayTrackStatementArg{Stmt: s, SessionID: u.sessionID})
+	return u.uicli.DisplayTrackStatement(mctx.Ctx(), keybase1.DisplayTrackStatementArg{Stmt: s, SessionID: u.sessionID})
 }
 
-func (u *RemoteIdentifyUI) ReportTrackToken(token keybase1.TrackToken) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) ReportTrackToken(mctx libkb.MetaContext, token keybase1.TrackToken) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.ReportTrackToken(ctx, keybase1.ReportTrackTokenArg{TrackToken: token, SessionID: u.sessionID})
+	return u.uicli.ReportTrackToken(mctx.Ctx(), keybase1.ReportTrackTokenArg{TrackToken: token, SessionID: u.sessionID})
 }
 
-func (u *RemoteIdentifyUI) LaunchNetworkChecks(id *keybase1.Identity, user *keybase1.User) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) LaunchNetworkChecks(mctx libkb.MetaContext, id *keybase1.Identity, user *keybase1.User) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.LaunchNetworkChecks(ctx, keybase1.LaunchNetworkChecksArg{
+	return u.uicli.LaunchNetworkChecks(mctx.Ctx(), keybase1.LaunchNetworkChecksArg{
 		SessionID: u.sessionID,
 		Identity:  *id,
 		User:      *user,
 	})
 }
 
-func (u *RemoteIdentifyUI) DisplayUserCard(card keybase1.UserCard) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) DisplayUserCard(mctx libkb.MetaContext, card keybase1.UserCard) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.DisplayUserCard(ctx, keybase1.DisplayUserCardArg{SessionID: u.sessionID, Card: card})
+	return u.uicli.DisplayUserCard(mctx.Ctx(), keybase1.DisplayUserCardArg{SessionID: u.sessionID, Card: card})
 }
 
-func (u *RemoteIdentifyUI) Start(username string, reason keybase1.IdentifyReason, force bool) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) Start(mctx libkb.MetaContext, username string, reason keybase1.IdentifyReason, force bool) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.Start(ctx, keybase1.StartArg{SessionID: u.sessionID, Username: username, Reason: reason, ForceDisplay: force})
+	return u.uicli.Start(mctx.Ctx(), keybase1.StartArg{SessionID: u.sessionID, Username: username, Reason: reason, ForceDisplay: force})
 }
 
-func (u *RemoteIdentifyUI) Cancel() error {
+func (u *RemoteIdentifyUI) Cancel(mctx libkb.MetaContext) error {
 	if u.uicli.Cli == nil {
 		return nil
 	}
-	ctx, cancel := u.newContext()
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.Cancel(ctx, u.sessionID)
+	return u.uicli.Cancel(mctx.Ctx(), u.sessionID)
 }
 
-func (u *RemoteIdentifyUI) Finish() error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) Finish(mctx libkb.MetaContext) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.Finish(ctx, u.sessionID)
+	return u.uicli.Finish(mctx.Ctx(), u.sessionID)
 }
 
-func (u *RemoteIdentifyUI) Dismiss(username string, reason keybase1.DismissReason) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) Dismiss(mctx libkb.MetaContext, username string, reason keybase1.DismissReason) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
-	return u.uicli.Dismiss(ctx, keybase1.DismissArg{
+	return u.uicli.Dismiss(mctx.Ctx(), keybase1.DismissArg{
 		SessionID: u.sessionID,
 		Username:  username,
 		Reason:    reason,
@@ -475,9 +477,9 @@ func (u *RemoteIdentifyUI) SetStrict(b bool) {
 	u.strict = b
 }
 
-func (u *RemoteIdentifyUI) DisplayTLFCreateWithInvite(arg keybase1.DisplayTLFCreateWithInviteArg) error {
-	ctx, cancel := u.newContext()
+func (u *RemoteIdentifyUI) DisplayTLFCreateWithInvite(mctx libkb.MetaContext, arg keybase1.DisplayTLFCreateWithInviteArg) error {
+	mctx, cancel := u.newMetaContext(mctx)
 	defer cancel()
 	arg.SessionID = u.sessionID
-	return u.uicli.DisplayTLFCreateWithInvite(ctx, arg)
+	return u.uicli.DisplayTLFCreateWithInvite(mctx.Ctx(), arg)
 }

--- a/go/systests/tracking_test.go
+++ b/go/systests/tracking_test.go
@@ -26,57 +26,57 @@ func (n *trackingUI) GetIdentifyTrackUI() libkb.IdentifyUI {
 type identifyUI struct {
 }
 
-func (*identifyUI) Confirm(*keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
+func (*identifyUI) Confirm(libkb.MetaContext, *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	return keybase1.ConfirmResult{
 		IdentityConfirmed: true,
 		RemoteConfirmed:   true,
 	}, nil
 }
-func (*identifyUI) Start(string, keybase1.IdentifyReason, bool) error {
+func (*identifyUI) Start(libkb.MetaContext, string, keybase1.IdentifyReason, bool) error {
 	return nil
 }
-func (*identifyUI) FinishWebProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+func (*identifyUI) FinishWebProofCheck(libkb.MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error {
 	return nil
 }
-func (*identifyUI) FinishSocialProofCheck(keybase1.RemoteProof, keybase1.LinkCheckResult) error {
+func (*identifyUI) FinishSocialProofCheck(libkb.MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error {
 	return nil
 }
-func (*identifyUI) DisplayCryptocurrency(keybase1.Cryptocurrency) error {
+func (*identifyUI) DisplayCryptocurrency(libkb.MetaContext, keybase1.Cryptocurrency) error {
 	return nil
 }
-func (*identifyUI) DisplayStellarAccount(keybase1.StellarAccount) error {
+func (*identifyUI) DisplayStellarAccount(libkb.MetaContext, keybase1.StellarAccount) error {
 	return nil
 }
-func (*identifyUI) DisplayKey(keybase1.IdentifyKey) error {
+func (*identifyUI) DisplayKey(libkb.MetaContext, keybase1.IdentifyKey) error {
 	return nil
 }
-func (*identifyUI) ReportLastTrack(*keybase1.TrackSummary) error {
+func (*identifyUI) ReportLastTrack(libkb.MetaContext, *keybase1.TrackSummary) error {
 	return nil
 }
-func (*identifyUI) LaunchNetworkChecks(*keybase1.Identity, *keybase1.User) error {
+func (*identifyUI) LaunchNetworkChecks(libkb.MetaContext, *keybase1.Identity, *keybase1.User) error {
 	return nil
 }
-func (*identifyUI) DisplayTrackStatement(string) error {
+func (*identifyUI) DisplayTrackStatement(libkb.MetaContext, string) error {
 	return nil
 }
-func (*identifyUI) DisplayUserCard(keybase1.UserCard) error {
+func (*identifyUI) DisplayUserCard(libkb.MetaContext, keybase1.UserCard) error {
 	return nil
 }
-func (*identifyUI) ReportTrackToken(keybase1.TrackToken) error {
+func (*identifyUI) ReportTrackToken(libkb.MetaContext, keybase1.TrackToken) error {
 	return nil
 }
 func (*identifyUI) SetStrict(b bool) {}
-func (*identifyUI) Cancel() error {
+func (*identifyUI) Cancel(libkb.MetaContext) error {
 	return nil
 }
-func (*identifyUI) Finish() error {
+func (*identifyUI) Finish(libkb.MetaContext) error {
 	return nil
 }
-func (*identifyUI) Dismiss(string, keybase1.DismissReason) error {
+func (*identifyUI) Dismiss(libkb.MetaContext, string, keybase1.DismissReason) error {
 	return nil
 }
 
-func (*identifyUI) DisplayTLFCreateWithInvite(keybase1.DisplayTLFCreateWithInviteArg) error {
+func (*identifyUI) DisplayTLFCreateWithInvite(libkb.MetaContext, keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil
 }
 


### PR DESCRIPTION
- this should fix the problem of the context getting canceled in upcall-initiated identify3 from KBFS
- also, improvements with debug-tag logging throughout