### PR TITLE
Fix 'Edit Profile' from home crashing

### DIFF
--- a/shared/people/todo/container.js
+++ b/shared/people/todo/container.js
@@ -63,7 +63,7 @@ const BioConnector = connect<TodoOwnProps, _, _, _, _>(
     _onConfirm: (username: string) => {
       // make sure we have tracker state & profile is up to date
       dispatch(createGetMyProfile({}))
-      dispatch(RouteTreeGen.createNavigateAppend({parentPath: [Tabs.peopleTab], path: ['editProfile']}))
+      dispatch(RouteTreeGen.createNavigateAppend({parentPath: [Tabs.peopleTab], path: ['editProfile2']}))
     },
     onDismiss: () => {},
   }),

--- a/shared/tracker2/bio/index.js
+++ b/shared/tracker2/bio/index.js
@@ -55,7 +55,7 @@ const Bio = (p: Props) => (
         style={styles.text}
         selectable={true}
       >
-        >{p.bio}
+        {p.bio}
       </Kb.Text>
     )}
     {!!p.location && (


### PR DESCRIPTION
@keybase/react-hackers 

We had a `Didn't get trackerInfo` crash when clicking on an Edit Profile badge on the Home screen.

The main profile screen doesn't use that component anymore -- it goes to EditProfile2 instead.  Since it looks like the intent is to just remove the older EditProfile, this PR switches the Home screen over to EditProfile2 as well.

While in there, noticed that Bio strings were being displayed with an errant leading `>` char and took it out.