### PR TITLE
show more generic proof types behind a feature flag

### DIFF
--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -64,8 +64,9 @@ type FeatureFlagSet struct {
 }
 
 const (
-	FeatureFTL     = Feature("ftl")
-	FeatureIMPTOFU = Feature("imptofu")
+	FeatureFTL                = Feature("ftl")
+	FeatureIMPTOFU            = Feature("imptofu")
+	ExperimentalGenericProofs = Feature("experimental_generic_proofs")
 )
 
 // NewFeatureFlagSet makes a new set of feature flags.

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -1334,5 +1334,6 @@ func (g *GlobalContext) ShouldUseParameterizedProofs() bool {
 	return g.Env.GetRunMode() == DevelRunMode ||
 		g.Env.RunningInCI() ||
 		g.Env.GetFeatureFlags().Admin() ||
-		g.Env.GetProveBypass()
+		g.Env.GetProveBypass() ||
+		g.Env.GetFeatureFlags().HasFeature(ExperimentalGenericProofs)
 }

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -167,6 +167,9 @@ func (t *BaseServiceType) CanMakeNewProofs(mctx MetaContext) bool {
 	if t.displayConf == nil {
 		return true
 	}
+	if mctx.G().FeatureFlags.Enabled(mctx, ExperimentalGenericProofs) {
+		return true
+	}
 	return !t.displayConf.CreationDisabled
 }
 


### PR DESCRIPTION
### before
```
$ keybase prove -l
Supported services are: dns, github, hackernews, http, https, reddit, rooter, twitter, web.
```
### after
```
$ keybase prove -l
Supported services are: dns, facebook, github, hackernews, http, https, mastodon.social, mastokeyhole.herokuapp.com, reddit, rooter, twitter, web.
```

see https://github.com/keybase/keybase/pull/3522