### PR TITLE
Admins can now remove pukless post-reset ex-owners

### DIFF
--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -588,25 +588,36 @@ func TestTeamAddAfterReset(t *testing.T) {
 }
 
 func TestTeamReAddAfterReset(t *testing.T) {
-	testTeamReAddAfterReset(t, true, false)
+	testTeamReAddAfterReset(t, true, false, false)
 }
 
 func TestTeamReAddAfterResetPukless(t *testing.T) {
-	testTeamReAddAfterReset(t, false, false)
+	testTeamReAddAfterReset(t, false, false, false)
 }
 
 func TestTeamReAddAfterResetAdminOwner(t *testing.T) {
-	testTeamReAddAfterReset(t, true, true)
+	testTeamReAddAfterReset(t, true, true, false)
 }
 
 func TestTeamReAddAfterResetAdminOwnerPukless(t *testing.T) {
-	testTeamReAddAfterReset(t, false, true)
+	testTeamReAddAfterReset(t, false, true, false)
+}
+
+func TestTeamResetReAddRemoveAdminOwner(t *testing.T) {
+	testTeamReAddAfterReset(t, true, true, true)
+}
+
+func TestTeamResetReAddRemoveAdminOwnerPukless(t *testing.T) {
+	testTeamReAddAfterReset(t, false, true, true)
 }
 
 // Add a member after reset in a normal (non-implicit) team
 // pukful - re-add the user after they get a puk
 // adminOwner - an admin is re-adding an owner.
-func testTeamReAddAfterReset(t *testing.T, pukful, adminOwner bool) {
+func testTeamReAddAfterReset(t *testing.T, pukful, adminOwner, removeAfterReset bool) {
+	if removeAfterReset && !adminOwner {
+		require.FailNow(t, "nope")
+	}
 	ctx := newSMUContext(t)
 	defer ctx.cleanup()
 
@@ -646,6 +657,15 @@ func testTeamReAddAfterReset(t *testing.T, pukful, adminOwner bool) {
 		Username: bob.username,
 	})
 	require.NoError(t, err)
+
+	if removeAfterReset {
+		err := ann.getTeamsClient().TeamRemoveMember(context.TODO(), keybase1.TeamRemoveMemberArg{
+			Name:     team.name,
+			Username: bob.username,
+		})
+		require.NoError(t, err)
+		return
+	}
 
 	if !pukful {
 		// Bob gets a puk AFTER being re-added.

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -552,7 +552,7 @@ func (t *TeamSigChainState) IsInviteObsolete(id keybase1.TeamInviteID) bool {
 	return ok
 }
 
-// FindActiveKeybaseInvite finds and returns *first* Keybase-type
+// FindActiveKeybaseInvite finds and returns a Keybase-type
 // invite for given UID. Ordering here is not guaranteed, caller
 // shouldn't assume that returned invite will be the oldest/newest one
 // for the UID.

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -569,7 +569,7 @@ type ChangeMembershipOptions struct {
 }
 
 func (t *Team) ChangeMembershipWithOptions(ctx context.Context, req keybase1.TeamChangeReq, opts ChangeMembershipOptions) (err error) {
-	defer t.G().CTrace(ctx, "Team.ChangeMembershipPermanent", func() error { return err })()
+	defer t.G().CTrace(ctx, "Team.ChangeMembershipWithOptions", func() error { return err })()
 
 	if t.IsSubteam() && len(req.Owners) > 0 {
 		return NewSubteamOwnersError()


### PR DESCRIPTION
1. alice%1 is an admin of team T.
2. bob%1 is an owner of T.
3. bob resets but does not get a PUK.
4. alice re-admits bob as an admin. Now bob%1 is a cryptomember, but shouldn't get keyed for since that's pre-reset. Alice just added bob%0 as an admin sigchain-invite.
5. alice removes bob from the team using `TeamRemoveMember`.

Step 5 would fail because alice's client would try to remove the old bob%1 cryptomember. But that's not allowed since an admin can't remove an owner.

This fixes that flow by making alice's client instead remove the bob%0 invite.