### PR TITLE
memoize make items. make emojis not jump due to native sizing being weird

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.desktop.js
+++ b/shared/chat/conversation/list-area/normal/index.desktop.js
@@ -19,6 +19,7 @@ import type {Props} from './index.types'
 import shallowEqual from 'shallowequal'
 import {globalMargins} from '../../../../styles/shared'
 import logger from '../../../../logger'
+import {memoize} from '../../../../util/memoize'
 
 // hot reload isn't supported with debouncing currently so just ignore hot here
 if (module.hot) {
@@ -324,14 +325,17 @@ class Thread extends React.PureComponent<Props, State> {
   }
 
   _makeItems = () => {
+    return this._makeItemsMemoized(this.props.conversationIDKey, this.props.messageOrdinals)
+  }
+  _makeItemsMemoized = memoize((conversationIDKey, messageOrdinals) => {
     const items = []
-    items.push(<TopItem key="topItem" conversationIDKey={this.props.conversationIDKey} />)
+    items.push(<TopItem key="topItem" conversationIDKey={conversationIDKey} />)
 
-    const numOrdinals = this.props.messageOrdinals.size
+    const numOrdinals = messageOrdinals.size
     let ordinals = []
     let previous = null
     let lastBucket = null
-    this.props.messageOrdinals.forEach((ordinal, idx) => {
+    messageOrdinals.forEach((ordinal, idx) => {
       // We want to keep the mapping of ordinal to bucket fixed always
       const bucket = Math.floor(Types.ordinalToNumber(ordinal) / ordinalsInAWaypoint)
       if (lastBucket === null) {
@@ -367,10 +371,10 @@ class Thread extends React.PureComponent<Props, State> {
       ordinals.push(ordinal)
     })
 
-    items.push(<BottomItem key="bottomItem" conversationIDKey={this.props.conversationIDKey} />)
+    items.push(<BottomItem key="bottomItem" conversationIDKey={conversationIDKey} />)
 
     return items
-  }
+  })
 
   _onResize = ({scroll}) => {
     if (this._scrollHeight) {

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -286,8 +286,16 @@ body {
   transition: opacity 250ms ease-in-out;
 }
 
+.emoji-mart-emoji .emoji-mart-emoji-native {
+  line-height: 0;
+  width: 0;
+  height: 0;
+  display: inline-block;
+}
+
 .emoji-mart-emoji {
   vertical-align: middle;
+  display: inline;
 }
 
 .growFadeInSmall {

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -286,6 +286,7 @@ body {
   transition: opacity 250ms ease-in-out;
 }
 
+/* These overrides are so the 'invisible' native emoji (so we can copy and paste) doesn't affect the sizing */
 .emoji-mart-emoji .emoji-mart-emoji-native {
   line-height: 0;
   width: 0;


### PR DESCRIPTION
@keybase/react-hackers 
cc: @mmaxim 