### PR TITLE
Use the reloadable waitingKey for Stellar disclaimer checks

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -250,7 +250,8 @@ const clearErrors = () => WalletsGen.createClearErrors()
 
 const loadWalletDisclaimer = () =>
   RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise().then(accepted =>
-    WalletsGen.createWalletDisclaimerReceived({accepted})
+    WalletsGen.createWalletDisclaimerReceived({accepted}),
+    Constants.checkOnlineWaitingKey
   )
 
 const loadAccounts = (state, action) => {

--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -249,9 +249,8 @@ const clearBuilding = () => WalletsGen.createClearBuilding()
 const clearErrors = () => WalletsGen.createClearErrors()
 
 const loadWalletDisclaimer = () =>
-  RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise().then(accepted =>
+  RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise(undefined, Constants.checkOnlineWaitingKey).then(accepted =>
     WalletsGen.createWalletDisclaimerReceived({accepted}),
-    Constants.checkOnlineWaitingKey
   )
 
 const loadAccounts = (state, action) => {


### PR DESCRIPTION
@keybase/react-hackers 

We already have a waitingKey for wallets reloadable RPCs, so I think this should do it.