### PR TITLE
ICS skips known non-currency codes

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -6009,6 +6009,10 @@ func (m *mockStellar) SpecMiniChatPayments(mctx libkb.MetaContext, payments []li
 	return m.specFn(payments)
 }
 
+func (m *mockStellar) KnownCurrencyCodeInstant(context.Context, string) (bool, bool) {
+	return false, false
+}
+
 type xlmDeclineChatUI struct {
 	*kbtest.ChatUI
 }

--- a/go/chat/wallet/sender.go
+++ b/go/chat/wallet/sender.go
@@ -119,6 +119,9 @@ func (s *Sender) ParsePayments(ctx context.Context, uid gregor1.UID, convID chat
 	parts, membersType, err := s.getConvParseInfo(ctx, uid, convID)
 	for _, p := range parsed {
 		var username string
+		if known, ok := s.G().GetStellar().KnownCurrencyCodeInstant(ctx, p.CurrencyCode); ok && !known {
+			continue
+		}
 		if p.Username == nil {
 			if username, err = s.getRecipientUsername(ctx, uid, parts, membersType); err != nil {
 				s.Debug(ctx, "ParsePayments: failed to get username, skipping: %s", err)

--- a/go/chat/wallet/sender.go
+++ b/go/chat/wallet/sender.go
@@ -119,6 +119,8 @@ func (s *Sender) ParsePayments(ctx context.Context, uid gregor1.UID, convID chat
 	parts, membersType, err := s.getConvParseInfo(ctx, uid, convID)
 	for _, p := range parsed {
 		var username string
+		// The currency might be legit but `KnownCurrencyCodeInstant` may not have data yet.
+		// In that case (false, false) comes back and the entry is _not_ skipped.
 		if known, ok := s.G().GetStellar().KnownCurrencyCodeInstant(ctx, p.CurrencyCode); ok && !known {
 			continue
 		}

--- a/go/chat/wallet/sender_test.go
+++ b/go/chat/wallet/sender_test.go
@@ -53,6 +53,10 @@ func (m *mockStellar) SendMiniChatPayments(mctx libkb.MetaContext, convID chat1.
 	return m.miniFn(payments)
 }
 
+func (m *mockStellar) KnownCurrencyCodeInstant(context.Context, string) (bool, bool) {
+	return false, false
+}
+
 type mockUpakLoader struct {
 	libkb.UPAKLoader
 	usernameFn func(gregor1.UID) string

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -725,6 +725,7 @@ type Stellar interface {
 	SendMiniChatPayments(mctx MetaContext, convID chat1.ConversationID, payments []MiniChatPayment) ([]MiniChatPaymentResult, error)
 	HandleOobm(context.Context, gregor.OutOfBandMessage) (bool, error)
 	RemovePendingTx(mctx MetaContext, accountID stellar1.AccountID, txID stellar1.TransactionID) error
+	KnownCurrencyCodeInstant(ctx context.Context, code string) (known, ok bool)
 }
 
 type DeviceEKStorage interface {

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -58,3 +58,7 @@ func (n *nullStellar) HandleOobm(context.Context, gregor.OutOfBandMessage) (bool
 func (n *nullStellar) RemovePendingTx(MetaContext, stellar1.AccountID, stellar1.TransactionID) error {
 	return errors.New("nullStellar RemovePendingTx")
 }
+
+func (n *nullStellar) KnownCurrencyCodeInstant(context.Context, string) (bool, bool) {
+	return false, false
+}


### PR DESCRIPTION
If you send +10eur or +10xlm it will ICS. But if you send +10ish or +10banana it will no longer ICS, the message goes straight through. The caveat being that the currencies must be loaded for some reason. I think if you don't have a wallet that doesn't happen. So people with no wallets still can't send +10ish without a bad experience.