### PR TITLE
explicit set fuse options

### DIFF
--- a/go/kbfs/libfuse/mounter_non_osx.go
+++ b/go/kbfs/libfuse/mounter_non_osx.go
@@ -9,7 +9,10 @@ package libfuse
 import "bazil.org/fuse"
 
 func getPlatformSpecificMountOptions(dir string, platformParams PlatformParams) ([]fuse.MountOption, error) {
-	return []fuse.MountOption{}, nil
+	options := []fuse.MountOption{}
+	options = append(options, fuse.MaxReadahead(500*1024))
+	options = append(options, fuse.AsyncRead())
+	return options, nil
 }
 
 // GetPlatformSpecificMountOptionsForTest makes cross-platform tests work


### PR DESCRIPTION
Explicitly set fuse.MaxReadahead to make FUSE issue large READ (128KB)
Explicitly set fuse.AsyncRead to make FUSE issue concurrent READs

i have problem testing OSX kbfs.... so i did not do the equivalent change in mount_osx.go