### PR TITLE
add cleaner status to logsend

### DIFF
--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -130,7 +130,7 @@ func NewLevelDb(g *GlobalContext, filename func() string) *LevelDb {
 		Contextified: NewContextified(g),
 		filename:     path,
 		dbOpenerOnce: new(sync.Once),
-		cleaner:      newLevelDbCleaner(g, filepath.Base(path)),
+		cleaner:      newLevelDbCleaner(NewMetaContext(context.TODO(), g), filepath.Base(path)),
 	}
 }
 
@@ -289,7 +289,7 @@ func (l *LevelDb) Clean(force bool) (err error) {
 	l.Lock()
 	defer l.Unlock()
 	defer l.G().Trace("LevelDb::Clean", func() error { return err })()
-	return l.cleaner.clean(context.Background(), force)
+	return l.cleaner.clean(force)
 }
 
 func (l *LevelDb) Nuke() (fn string, err error) {

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -226,6 +226,7 @@ func (l *LevelDb) ForceOpen() error {
 func (l *LevelDb) Stats() (stats string) {
 	if err := l.doWhileOpenAndNukeIfCorrupted(func() (err error) {
 		stats, err = l.db.GetProperty("leveldb.stats")
+		stats = fmt.Sprintf("%s\n%s", stats, l.cleaner.Status())
 		return err
 	}); err != nil {
 		return ""

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -130,7 +130,7 @@ func NewLevelDb(g *GlobalContext, filename func() string) *LevelDb {
 		Contextified: NewContextified(g),
 		filename:     path,
 		dbOpenerOnce: new(sync.Once),
-		cleaner:      newLevelDbCleaner(NewMetaContext(context.TODO(), g), filepath.Base(path)),
+		cleaner:      newLevelDbCleaner(NewMetaContextTODO(g), filepath.Base(path)),
 	}
 }
 

--- a/go/libkb/leveldb_cleaner.go
+++ b/go/libkb/leveldb_cleaner.go
@@ -31,7 +31,7 @@ type DbCleanerConfig struct {
 }
 
 func (c DbCleanerConfig) String() string {
-	return fmt.Sprintf("MaxSize: %v, HaltSize: %v, CleanInterval: %v, CacheCapacity: %v, MinCacheSize: %v, SleepInterval: %v",
+	return fmt.Sprintf("DbCleanerConfig{MaxSize: %v, HaltSize: %v, CleanInterval: %v, CacheCapacity: %v, MinCacheSize: %v, SleepInterval: %v}",
 		humanize.Bytes(c.MaxSize), humanize.Bytes(c.HaltSize),
 		c.CleanInterval, c.CacheCapacity,
 		c.MinCacheSize, c.SleepInterval)
@@ -103,6 +103,11 @@ func newLevelDbCleanerWithConfig(g *GlobalContext, dbName string, config DbClean
 		go c.monitorAppState()
 	}
 	return c
+}
+
+func (c *levelDbCleaner) Status() string {
+	return fmt.Sprintf("levelDbCleaner{cacheSize: %d, lastRun: %v, lastKey: %v, running: %v}\n%v\n",
+		c.cache.Len(), c.lastRun, c.lastKey, c.running, c.config)
 }
 
 func (c *levelDbCleaner) Stop() {

--- a/go/libkb/leveldb_test.go
+++ b/go/libkb/leveldb_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 type teardowner struct {
@@ -133,7 +132,7 @@ func TestLevelDb(t *testing.T) {
 				require.NoError(t, err)
 
 				// cleaner will not clean the key since it was recently used
-				err = db.cleaner.clean(context.TODO(), true /* force */)
+				err = db.cleaner.clean(true /* force */)
 				require.NoError(t, err)
 				_, found, err := db.Get(key)
 				require.NoError(t, err)
@@ -143,7 +142,7 @@ func TestLevelDb(t *testing.T) {
 				require.True(t, found)
 
 				db.cleaner.clearCache()
-				err = db.cleaner.clean(context.TODO(), true /* force */)
+				err = db.cleaner.clean(true /* force */)
 				require.NoError(t, err)
 				_, found, err = db.Get(key)
 				require.NoError(t, err)


### PR DESCRIPTION
now shows:
```
LocalDbStats:
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   1   |          1 |       3.27896 |       0.08365 |       3.36182 |       3.27896
-------+------------+---------------+---------------+---------------+---------------
 Total |          1 |       3.27896 |       0.08365 |       3.36182 |       3.27896

levelDbCleaner{cacheSize: 221, lastRun: 2019-02-28 13:17:48.073898507 -0500 EST m=-3239.987974066, lastKey: [], running: false}
DbCleanerConfig{MaxSize: 2.1GB, HaltSize: 1.6GB, CleanInterval: 1h0m0s, CacheCapacity: 100000, MinCacheSize: 10000, SleepInterval: 50ms}
 
LocalChatDbStats:
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   0   |          2 |       3.27182 |       0.00000 |       0.00000 |       0.00000
   1   |          1 |       1.79310 |       0.00000 |       0.00000 |       0.00000
-------+------------+---------------+---------------+---------------+---------------
 Total |          3 |       5.06492 |       0.00000 |       0.00000 |       0.00000

levelDbCleaner{cacheSize: 1, lastRun: 2019-02-28 13:17:48.076246864 -0500 EST m=-3239.985625713, lastKey: [], running: false}
DbCleanerConfig{MaxSize: 2.1GB, HaltSize: 1.6GB, CleanInterval: 1h0m0s, CacheCapacity: 100000, MinCacheSize: 10000, SleepInterval: 50ms}
```