### PR TITLE
Open sweep client support

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1927,6 +1927,28 @@ func (o TeamSeitanMsg) DeepCopy() TeamSeitanMsg {
 	}
 }
 
+type TeamOpenSweepMsg struct {
+	TeamID              TeamID              `codec:"teamID" json:"team_id"`
+	ResetUsersUntrusted []TeamCLKRResetUser `codec:"resetUsersUntrusted" json:"reset_users"`
+}
+
+func (o TeamOpenSweepMsg) DeepCopy() TeamOpenSweepMsg {
+	return TeamOpenSweepMsg{
+		TeamID: o.TeamID.DeepCopy(),
+		ResetUsersUntrusted: (func(x []TeamCLKRResetUser) []TeamCLKRResetUser {
+			if x == nil {
+				return nil
+			}
+			ret := make([]TeamCLKRResetUser, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.ResetUsersUntrusted),
+	}
+}
+
 type TeamKBFSKeyRefresher struct {
 	Generation int             `codec:"generation" json:"generation"`
 	AppType    TeamApplication `codec:"appType" json:"appType"`

--- a/go/service/team_handler.go
+++ b/go/service/team_handler.go
@@ -51,6 +51,8 @@ func (r *teamHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
 		return true, r.sharingBeforeSignup(ctx, cli, item)
 	case "team.openreq":
 		return true, r.openTeamAccessRequest(ctx, cli, item)
+	case "team.opensweep":
+		return true, r.openTeamSweepResetUsersRequest(ctx, cli, item)
 	case "team.change":
 		return true, r.changeTeam(ctx, cli, category, item, keybase1.TeamChangeSet{})
 	case "team.force_repoll":
@@ -268,6 +270,23 @@ func (r *teamHandler) openTeamAccessRequest(ctx context.Context, cli gregor1.Inc
 	}
 
 	r.G().Log.CDebugf(ctx, "dismissing team.openreq item since it succeeded")
+	return r.G().GregorState.DismissItem(ctx, cli, item.Metadata().MsgID())
+}
+
+func (r *teamHandler) openTeamSweepResetUsersRequest(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
+	r.G().Log.CDebugf(ctx, "teamHandler: team.opensweep received")
+	var msg keybase1.TeamOpenSweepMsg
+	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
+		r.G().Log.CDebugf(ctx, "error unmarshaling team.opensweep item: %s", err)
+		return err
+	}
+	r.G().Log.CDebugf(ctx, "team.opensweep unmarshaled: %+v", msg)
+
+	if err := teams.HandleOpenTeamSweepRequest(ctx, r.G(), msg); err != nil {
+		return err
+	}
+
+	r.G().Log.CDebugf(ctx, "dismissing team.opensweep item since it succeeded")
 	return r.G().GregorState.DismissItem(ctx, cli, item.Metadata().MsgID())
 }
 

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -896,7 +896,7 @@ func enableOpenSweepForTeam(g *libkb.GlobalContext, t libkb.TestingTB, teamID ke
 
 	t.Logf("Calling team_enable_open_sweep for team ID: %s", teamID)
 
-	_, err := g.API.Post(apiArg)
+	_, err := g.API.Post(libkb.NewMetaContextTODO(g), apiArg)
 	require.NoError(t, err)
 }
 

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -894,7 +894,7 @@ func enableOpenSweepForTeam(g *libkb.GlobalContext, t libkb.TestingTB, teamID ke
 		SessionType: libkb.APISessionTypeREQUIRED,
 	}
 
-	t.Logf("Calling team_enable_open_sweep for team ID: %s")
+	t.Logf("Calling team_enable_open_sweep for team ID: %s", teamID)
 
 	_, err := g.API.Post(apiArg)
 	require.NoError(t, err)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -884,6 +884,22 @@ func kickTeamRekeyd(g *libkb.GlobalContext, t libkb.TestingTB) {
 	require.NoError(t, err)
 }
 
+func enableOpenSweepForTeam(g *libkb.GlobalContext, t libkb.TestingTB, teamID keybase1.TeamID) {
+	args := libkb.HTTPArgs{
+		"team_id": libkb.S{Val: teamID.String()},
+	}
+	apiArg := libkb.APIArg{
+		Endpoint:    "test/team_enable_open_sweep",
+		Args:        args,
+		SessionType: libkb.APISessionTypeREQUIRED,
+	}
+
+	t.Logf("Calling team_enable_open_sweep for team ID: %s")
+
+	_, err := g.API.Post(apiArg)
+	require.NoError(t, err)
+}
+
 func clearServerUIDMapCache(g *libkb.GlobalContext, t libkb.TestingTB, uids []keybase1.UID) {
 	arg := libkb.NewAPIArg("user/names")
 	arg.SessionType = libkb.APISessionTypeNONE

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -34,18 +34,31 @@ func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, msg keybas
 		return err == nil && role.IsOrAbove(keybase1.TeamRole_ADMIN)
 	}
 	if len(msg.ResetUsersUntrusted) > 0 && team.IsOpen() && isAdmin() {
-		if needRP, err := sweepOpenTeamResetAndDeletedMembers(ctx, g, team, msg.ResetUsersUntrusted); err == nil {
+		// NOTE: One day, this code path will be unused. Server should not
+		// issue CLKRs with ResetUsersUntrusted for open teams. Instead, there
+		// is a new work type to sweep reset users: OPENSWEEP. See
+		// `HandleOpenTeamSweepRequest`.
+
+		// Even though this is open team, and we are aiming to not rotate them,
+		// the server asked us specifically to do so with this CLKR. We have to
+		// obey, otherwise that CLKR will stay undone and server will keep
+		// asking users to rotate.
+		postedLink, err := sweepOpenTeamResetAndDeletedMembers(ctx, g, team, msg.ResetUsersUntrusted, true /* rotate */)
+		if err != nil {
+			g.Log.CDebugf(ctx, "Failed to sweep deleted members: %s", err)
+		} else {
 			// If sweepOpenTeamResetAndDeletedMembers does not do anything to
-			// the team, do not load team again later.
-			needTeamReload = needRP
+			// the team, do not load team again later. Otherwise, if new link
+			// was posted, we need to reload.
+			needTeamReload = postedLink
 		}
 
-		// * NOTE * Still call the regular rotate key routine even if
-		// sweep succeeds and posts link.
+		// * NOTE * Still call the regular rotate key routine even if sweep
+		// succeeds and posts link.
 
-		// In normal case, it will reload team, see that generation is
-		// higher than one requested in CLKR (because we rotated key
-		// during sweeping), and then bail out.
+		// In normal case, it will reload team, see that generation is higher
+		// than one requested in CLKR (because we rotated key during sweeping),
+		// and then bail out.
 	}
 
 	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
@@ -75,12 +88,42 @@ func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, msg keybas
 	})
 }
 
+func HandleOpenTeamSweepRequest(ctx context.Context, g *libkb.GlobalContext, msg keybase1.TeamOpenSweepMsg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "CLKR")
+	defer g.CTrace(ctx, fmt.Sprintf("HandleOpenTeamSweepRequest(teamID=%s,len(resetUsers)=%d)", msg.TeamID, len(msg.ResetUsersUntrusted)), func() error { return err })()
+
+	team, err := Load(ctx, g, keybase1.LoadTeamArg{
+		ID:          msg.TeamID,
+		Public:      msg.TeamID.IsPublic(),
+		ForceRepoll: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	role, err := team.myRole(ctx)
+	if err != nil {
+		return err
+	}
+	if !role.IsOrAbove(keybase1.TeamRole_ADMIN) {
+		return fmt.Errorf("OpenSweep request for team %s but our role is: %s", team.ID, role.String())
+	}
+
+	// CanSkipKeyRotation() should return `true` for open teams, so sweeping
+	// will not rotate. But assume the possibility of OPENSWEEP being sent for
+	// non-open teams.
+	rotate := !team.CanSkipKeyRotation()
+	_, err = sweepOpenTeamResetAndDeletedMembers(ctx, g, team, msg.ResetUsersUntrusted, rotate)
+	return err
+}
+
 func sweepOpenTeamResetAndDeletedMembers(ctx context.Context, g *libkb.GlobalContext,
-	team *Team, resetUsersUntrusted []keybase1.TeamCLKRResetUser) (needRepoll bool, err error) {
+	team *Team, resetUsersUntrusted []keybase1.TeamCLKRResetUser, rotate bool) (postedLink bool, err error) {
 	// When CLKR is invoked because of account reset and it's an open team,
 	// we go ahead and boot reset readers and writers out of the team. Key
 	// is also rotated in the process (in the same ChangeMembership link).
-	defer g.CTrace(ctx, "sweepOpenTeamResetAndDeletedMembers", func() error { return err })()
+	defer g.CTrace(ctx, fmt.Sprintf("sweepOpenTeamResetAndDeletedMembers(rotate=%t)", rotate),
+		func() error { return err })()
 
 	// Go through resetUsersUntrusted and fetch non-cached latest
 	// EldestSeqnos/Status.
@@ -165,9 +208,8 @@ func sweepOpenTeamResetAndDeletedMembers(ctx context.Context, g *libkb.GlobalCon
 
 		opts := ChangeMembershipOptions{
 			// Make it possible for user to come back in once they reprovision.
-			Permanent: false,
-			// Coming from CLKR, we want to ensure team key is rotated.
-			SkipKeyRotation: false,
+			Permanent:       false,
+			SkipKeyRotation: !rotate,
 		}
 		if err := team.ChangeMembershipWithOptions(ctx, changeReq, opts); err != nil {
 			return err
@@ -175,11 +217,11 @@ func sweepOpenTeamResetAndDeletedMembers(ctx context.Context, g *libkb.GlobalCon
 
 		// Notify the caller that we posted a sig and they have to
 		// load team again.
-		needRepoll = true
+		postedLink = true
 		return nil
 	})
 
-	return needRepoll, err
+	return postedLink, err
 }
 
 func refreshKBFSFavoritesCache(g *libkb.GlobalContext) {

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -101,6 +101,10 @@ func HandleOpenTeamSweepRequest(ctx context.Context, g *libkb.GlobalContext, msg
 		return err
 	}
 
+	if !team.IsOpen() {
+		return fmt.Errorf("OpenSweep request for team %s that is not open", team.ID)
+	}
+
 	role, err := team.myRole(ctx)
 	if err != nil {
 		return err
@@ -109,9 +113,6 @@ func HandleOpenTeamSweepRequest(ctx context.Context, g *libkb.GlobalContext, msg
 		return fmt.Errorf("OpenSweep request for team %s but our role is: %s", team.ID, role.String())
 	}
 
-	// CanSkipKeyRotation() should return `true` for open teams, so sweeping
-	// will not rotate. But assume the possibility of OPENSWEEP being sent for
-	// non-open teams.
 	rotate := !team.CanSkipKeyRotation()
 	_, err = sweepOpenTeamResetAndDeletedMembers(ctx, g, team, msg.ResetUsersUntrusted, rotate)
 	return err

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -673,6 +673,13 @@ protocol teams {
     array<TeamSeitanRequest> seitans;
   }
 
+  record TeamOpenSweepMsg {
+    @jsonkey("team_id")
+    TeamID teamID;
+    @jsonkey("reset_users")
+    array<TeamCLKRResetUser> resetUsersUntrusted;
+  }
+
   record TeamKBFSKeyRefresher {
     int generation;
     TeamApplication appType;

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1589,6 +1589,25 @@
     },
     {
       "type": "record",
+      "name": "TeamOpenSweepMsg",
+      "fields": [
+        {
+          "type": "TeamID",
+          "name": "teamID",
+          "jsonkey": "team_id"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "TeamCLKRResetUser"
+          },
+          "name": "resetUsersUntrusted",
+          "jsonkey": "reset_users"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "TeamKBFSKeyRefresher",
       "fields": [
         {

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -3001,6 +3001,7 @@ export type TeamNameLogPoint = $ReadOnly<{lastPart: TeamNamePart, seqno: Seqno}>
 export type TeamNamePart = String
 export type TeamNewlyAddedRow = $ReadOnly<{id: TeamID, name: String}>
 export type TeamOpenReqMsg = $ReadOnly<{teamID: TeamID, tars?: ?Array<TeamAccessRequest>}>
+export type TeamOpenSweepMsg = $ReadOnly<{teamID: TeamID, resetUsersUntrusted?: ?Array<TeamCLKRResetUser>}>
 export type TeamOperation = $ReadOnly<{manageMembers: Boolean, manageSubteams: Boolean, createChannel: Boolean, chat: Boolean, deleteChannel: Boolean, renameChannel: Boolean, editChannelDescription: Boolean, setTeamShowcase: Boolean, setMemberShowcase: Boolean, setRetentionPolicy: Boolean, setMinWriterRole: Boolean, changeOpenTeam: Boolean, leaveTeam: Boolean, joinTeam: Boolean, setPublicityAny: Boolean, listFirst: Boolean, changeTarsDisabled: Boolean, deleteChatHistory: Boolean, deleteOtherMessages: Boolean}>
 export type TeamPlusApplicationKeys = $ReadOnly<{id: TeamID, name: String, implicit: Boolean, public: Boolean, application: TeamApplication, writers?: ?Array<UserVersion>, onlyReaders?: ?Array<UserVersion>, applicationKeys?: ?Array<TeamApplicationKey>}>
 export type TeamProfileAddEntry = $ReadOnly<{teamName: TeamName, open: Boolean, disabledReason: String}>


### PR DESCRIPTION
See server PR: https://github.com/keybase/keybase/pull/3533

Add support for `team.opensweep` messages that removes reset members from open teams. Mostly call into the code that we already had for removing reset members during CLKR: func `sweepOpenTeamResetAndDeletedMembers`.