### PR TITLE
make it easier to send single char emoticons

### DIFF
--- a/shared/chat/conversation/input-area/normal/index.js
+++ b/shared/chat/conversation/input-area/normal/index.js
@@ -59,7 +59,8 @@ const suggestorKeyExtractors = {
   users: ({username, fullName}: {username: string, fullName: string}) => username,
 }
 
-const emojiPrepass = /[a-z0-9]/i
+// 2+ valid emoji chars and no ending colon
+const emojiPrepass = /[a-z0-9_]{2,}(?!.*:)/i
 const emojiDatasource = (filter: string) => (emojiPrepass.test(filter) ? emojiIndex.search(filter) : [])
 const emojiRenderer = (item, selected: boolean) => (
   <Kb.Box2


### PR DESCRIPTION
Two changes

- Only show results if there are >2 chars in the filter
- Hide results if there's another colon in the search string (i.e. a full emoji is already entered)

r? @keybase/react-hackers 