### PR TITLE
New new chat button and filter style

### DIFF
--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -81,6 +81,10 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
   }
 
   _setRef = r => (this._input = r)
+  _onCancel = () => {
+    this.props.onSetFilter('')
+    this._stopEditing()
+  }
 
   render() {
     let children
@@ -111,6 +115,13 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
             onEnterKeyDown={this._onEnterKeyDown}
             ref={this._setRef}
             style={styles.input}
+          />
+          <Kb.Icon
+            type="iconfont-remove"
+            fontSize={16}
+            color={Styles.globalColors.black_50}
+            onClick={this._onCancel}
+            style={styles.icon}
           />
         </Kb.Box2>
       )

--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -140,25 +140,27 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
           gapEnd={true}
           fullWidth={true}
         >
-          {flags.useNewRouter && Styles.isMobile && (
-            <Kb.BackButton onClick={this.props.onBack} style={styles.backButton} />
-          )}
-          <Kb.ClickableBox style={styles.filterContainer} onClick={this._startEditing}>
-            <Kb.Icon
-              type="iconfont-search"
-              style={styles.icon}
-              color={Styles.globalColors.black_50}
-              fontSize={Styles.isMobile ? 20 : 16}
-            />
-            <Kb.Text type="BodySemibold" style={styles.text}>
-              Jump to...
-            </Kb.Text>
-            {!Styles.isMobile && (
-              <Kb.Text type="BodySemibold" style={styles.textFaint}>
-                ({Platforms.shortcutSymbol}K)
-              </Kb.Text>
+          <Kb.Box2 alignItems="center" direction="horizontal" style={styles.flexOne}>
+            {flags.useNewRouter && Styles.isMobile && (
+              <Kb.BackButton onClick={this.props.onBack} style={styles.backButton} />
             )}
-          </Kb.ClickableBox>
+            <Kb.ClickableBox style={styles.filterContainer} onClick={this._startEditing}>
+              <Kb.Icon
+                type="iconfont-search"
+                style={styles.icon}
+                color={Styles.globalColors.black_50}
+                fontSize={Styles.isMobile ? 20 : 16}
+              />
+              <Kb.Text type="BodySemibold" style={styles.text}>
+                Jump to...
+              </Kb.Text>
+              {!Styles.isMobile && (
+                <Kb.Text type="BodySemibold" style={styles.textFaint}>
+                  ({Platforms.shortcutSymbol}K)
+                </Kb.Text>
+              )}
+            </Kb.ClickableBox>
+          </Kb.Box2>
           {!!this.props.onNewChat && (
             <Kb.WithTooltip position="bottom center" text={`${Platforms.shortcutSymbol}N`}>
               <Kb.Button small={true} type="Primary" label="New chat" onClick={this.props.onNewChat} />
@@ -190,9 +192,11 @@ const styles = Styles.styleSheetCreate({
       position: 'relative',
     },
     isElectron: {
+      ...Styles.padding(0, Styles.globalMargins.xtiny),
       backgroundColor: Styles.globalColors.blueGrey,
     },
     isMobile: {
+      ...Styles.padding(0, Styles.globalMargins.tiny),
       backgroundColor: Styles.globalColors.fastBlank,
     },
   }),

--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -131,7 +131,11 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
           direction="horizontal"
           centerChildren={true}
           gap="tiny"
-          style={Styles.collapseStyles([styles.containerNotFiltering, this.props.style])}
+          style={Styles.collapseStyles([
+            styles.containerNotFiltering,
+            flags.useNewRouter && Styles.isMobile && styles.containerWithBackButton,
+            this.props.style,
+          ])}
           gapStart={true}
           gapEnd={true}
           fullWidth={true}
@@ -210,6 +214,9 @@ const styles = Styles.styleSheetCreate({
       backgroundColor: Styles.globalColors.fastBlank,
     },
   }),
+  containerWithBackButton: {
+    ...Styles.padding(0, Styles.globalMargins.tiny, 0, 0), // back button adds the left space
+  },
   filterContainer: Styles.platformStyles({
     common: {
       ...Styles.globalStyles.flexBoxRow,

--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -87,46 +87,31 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
     if (this.state.isEditing || this.props.filter) {
       children = (
         <Kb.Box2
+          alignItems="center"
           direction="horizontal"
           fullWidth={true}
-          style={Styles.collapseStyles([styles.container, this.props.style])}
+          gap={Styles.isMobile ? 'xsmall' : 'tiny'}
+          style={Styles.collapseStyles([styles.containerFiltering, this.props.style])}
         >
-          <Kb.Box2
-            gapStart={true}
-            direction="horizontal"
-            fullWidth={true}
-            fullHeight={true}
-            alignItems="center"
-            gap="xsmall"
-          >
-            <Kb.Box2
-              direction="horizontal"
-              fullWidth={true}
-              fullHeight={true}
-              gap="xtiny"
-              alignItems="center"
-            >
-              <Kb.Icon
-                type="iconfont-search"
-                style={styles.icon}
-                color={Styles.globalColors.black_50}
-                fontSize={Styles.isMobile ? 20 : 16}
-              />
-              <Kb.Input
-                hideUnderline={true}
-                small={true}
-                value={this.props.filter}
-                hintText="Jump to..."
-                onChangeText={this.props.onSetFilter}
-                onFocus={this._startEditing}
-                onBlur={this._stopEditing}
-                onKeyDown={this._onKeyDown}
-                onEnterKeyDown={this._onEnterKeyDown}
-                ref={this._setRef}
-                style={styles.text}
-              />
-            </Kb.Box2>
-          </Kb.Box2>
+          <Kb.Icon
+            type="iconfont-search"
+            style={styles.icon}
+            color={Styles.globalColors.black_50}
+            fontSize={Styles.isMobile ? 20 : 16}
+          />
+          <Kb.Input
+            hideUnderline={true}
+            small={true}
+            value={this.props.filter}
+            hintText="Jump to..."
+            onChangeText={this.props.onSetFilter}
+            onFocus={this._startEditing}
+            onBlur={this._stopEditing}
+            onKeyDown={this._onKeyDown}
+            onEnterKeyDown={this._onEnterKeyDown}
+            ref={this._setRef}
+            style={styles.input}
+          />
         </Kb.Box2>
       )
     } else {
@@ -135,7 +120,7 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
           direction="horizontal"
           centerChildren={true}
           gap="tiny"
-          style={Styles.collapseStyles([styles.container, this.props.style])}
+          style={Styles.collapseStyles([styles.containerNotFiltering, this.props.style])}
           gapStart={true}
           gapEnd={true}
           fullWidth={true}
@@ -186,7 +171,21 @@ const styles = Styles.styleSheetCreate({
   backButton: {
     ...Styles.padding(Styles.globalMargins.tiny, 0),
   },
-  container: Styles.platformStyles({
+  containerFiltering: Styles.platformStyles({
+    common: {
+      height: 48,
+      position: 'relative',
+    },
+    isElectron: {
+      ...Styles.padding(0, Styles.globalMargins.small),
+      backgroundColor: Styles.globalColors.blueGrey,
+    },
+    isMobile: {
+      ...Styles.padding(0, Styles.globalMargins.small, 0, Styles.globalMargins.xsmall),
+      backgroundColor: Styles.globalColors.fastBlank,
+    },
+  }),
+  containerNotFiltering: Styles.platformStyles({
     common: {
       height: 48,
       position: 'relative',

--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -86,50 +86,51 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
     let children
     if (this.state.isEditing || this.props.filter) {
       children = (
-        <Kb.Box2 direction="horizontal" style={styles.flexOne}>
-          <Kb.Icon
-            type="iconfont-search"
-            style={styles.icon}
-            color={Styles.globalColors.black_50}
-            fontSize={Styles.isMobile ? 20 : 16}
-          />
-          <Kb.Input
-            hideUnderline={true}
-            small={true}
-            value={this.props.filter}
-            hintText="Jump to..."
-            onChangeText={this.props.onSetFilter}
-            onFocus={this._startEditing}
-            onBlur={this._stopEditing}
-            onKeyDown={this._onKeyDown}
-            onEnterKeyDown={this._onEnterKeyDown}
-            ref={this._setRef}
-            style={styles.text}
-          />
+        <Kb.Box2
+          direction="horizontal"
+          fullWidth={true}
+          style={Styles.collapseStyles([styles.container, this.props.style])}
+        >
+          <Kb.Box2
+            gapStart={true}
+            direction="horizontal"
+            fullWidth={true}
+            fullHeight={true}
+            alignItems="center"
+            gap="xsmall"
+          >
+            <Kb.Box2
+              direction="horizontal"
+              fullWidth={true}
+              fullHeight={true}
+              gap="xtiny"
+              alignItems="center"
+            >
+              <Kb.Icon
+                type="iconfont-search"
+                style={styles.icon}
+                color={Styles.globalColors.black_50}
+                fontSize={Styles.isMobile ? 20 : 16}
+              />
+              <Kb.Input
+                hideUnderline={true}
+                small={true}
+                value={this.props.filter}
+                hintText="Jump to..."
+                onChangeText={this.props.onSetFilter}
+                onFocus={this._startEditing}
+                onBlur={this._stopEditing}
+                onKeyDown={this._onKeyDown}
+                onEnterKeyDown={this._onEnterKeyDown}
+                ref={this._setRef}
+                style={styles.text}
+              />
+            </Kb.Box2>
+          </Kb.Box2>
         </Kb.Box2>
       )
     } else {
       children = (
-        <Kb.ClickableBox style={styles.filterContainer} onClick={this._startEditing}>
-          <Kb.Icon
-            type="iconfont-search"
-            style={styles.icon}
-            color={Styles.globalColors.black_50}
-            fontSize={Styles.isMobile ? 20 : 16}
-          />
-          <Kb.Text type="BodySemibold" style={styles.text}>
-            Jump to...
-          </Kb.Text>
-          {!Styles.isMobile && (
-            <Kb.Text type="BodySemibold" style={styles.textFaint}>
-              ({Platforms.shortcutSymbol}K)
-            </Kb.Text>
-          )}
-        </Kb.ClickableBox>
-      )
-    }
-    return (
-      <>
         <Kb.Box2
           direction="horizontal"
           centerChildren={true}
@@ -142,13 +143,33 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
           {flags.useNewRouter && Styles.isMobile && (
             <Kb.BackButton onClick={this.props.onBack} style={styles.backButton} />
           )}
-          {children}
+          <Kb.ClickableBox style={styles.filterContainer} onClick={this._startEditing}>
+            <Kb.Icon
+              type="iconfont-search"
+              style={styles.icon}
+              color={Styles.globalColors.black_50}
+              fontSize={Styles.isMobile ? 20 : 16}
+            />
+            <Kb.Text type="BodySemibold" style={styles.text}>
+              Jump to...
+            </Kb.Text>
+            {!Styles.isMobile && (
+              <Kb.Text type="BodySemibold" style={styles.textFaint}>
+                ({Platforms.shortcutSymbol}K)
+              </Kb.Text>
+            )}
+          </Kb.ClickableBox>
           {!!this.props.onNewChat && (
             <Kb.WithTooltip position="bottom center" text={`${Platforms.shortcutSymbol}N`}>
               <Kb.Button small={true} type="Primary" label="New chat" onClick={this.props.onNewChat} />
             </Kb.WithTooltip>
           )}
         </Kb.Box2>
+      )
+    }
+    return (
+      <>
+        {children}
         {this.props.isLoading && Styles.isMobile && (
           <Kb.Box style={styles.loadingContainer}>
             <Kb.LoadingLine />
@@ -165,7 +186,7 @@ const styles = Styles.styleSheetCreate({
   },
   container: Styles.platformStyles({
     common: {
-      minHeight: 48,
+      height: 48,
       position: 'relative',
     },
     isElectron: {
@@ -196,6 +217,11 @@ const styles = Styles.styleSheetCreate({
   }),
   flexOne: {flex: 1},
   icon: {
+    position: 'relative',
+    top: 1,
+  },
+  input: {
+    color: Styles.globalColors.black_50,
     position: 'relative',
     top: 1,
   },

--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -86,7 +86,7 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
     let children
     if (this.state.isEditing || this.props.filter) {
       children = (
-        <Kb.Box style={styles.inputContainer}>
+        <Kb.Box2 direction="horizontal" style={styles.flexOne}>
           <Kb.Icon
             type="iconfont-search"
             style={styles.icon}
@@ -106,7 +106,7 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
             ref={this._setRef}
             style={styles.text}
           />
-        </Kb.Box>
+        </Kb.Box2>
       )
     } else {
       children = (
@@ -118,7 +118,7 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
             fontSize={Styles.isMobile ? 20 : 16}
           />
           <Kb.Text type="BodySemibold" style={styles.text}>
-            Jump to chat
+            Jump to...
           </Kb.Text>
           {!Styles.isMobile && (
             <Kb.Text type="BodySemibold" style={styles.textFaint}>
@@ -128,56 +128,41 @@ class ConversationFilterInput extends React.PureComponent<Props, State> {
         </Kb.ClickableBox>
       )
     }
-    return Styles.isMobile ? (
+    return (
       <>
-        <Kb.HeaderHocHeader
-          borderless={true}
-          leftAction={flags.useNewRouter ? 'back' : undefined}
-          onLeftAction={flags.useNewRouter ? this.props.onBack : undefined}
-          rightActions={[
-            {
-              icon: 'iconfont-compose',
-              iconColor: Styles.globalColors.blue,
-              label: 'New chat',
-              onPress: this.props.onNewChat,
-            },
-          ]}
-          titleComponent={children}
-        />
-        {this.props.isLoading && (
+        <Kb.Box2
+          direction="horizontal"
+          centerChildren={true}
+          gap="tiny"
+          style={Styles.collapseStyles([styles.container, this.props.style])}
+          gapStart={true}
+          gapEnd={true}
+          fullWidth={true}
+        >
+          {flags.useNewRouter && Styles.isMobile && (
+            <Kb.BackButton onClick={this.props.onBack} style={styles.backButton} />
+          )}
+          {children}
+          {!!this.props.onNewChat && (
+            <Kb.WithTooltip position="bottom center" text={`${Platforms.shortcutSymbol}N`}>
+              <Kb.Button small={true} type="Primary" label="New chat" onClick={this.props.onNewChat} />
+            </Kb.WithTooltip>
+          )}
+        </Kb.Box2>
+        {this.props.isLoading && Styles.isMobile && (
           <Kb.Box style={styles.loadingContainer}>
             <Kb.LoadingLine />
           </Kb.Box>
         )}
       </>
-    ) : (
-      <Kb.Box2
-        direction="horizontal"
-        centerChildren={true}
-        gap="small"
-        style={Styles.collapseStyles([styles.container, this.props.style])}
-        gapStart={true}
-        gapEnd={true}
-        fullWidth={true}
-      >
-        {children}
-        {!!this.props.onNewChat && (
-          <Kb.WithTooltip position="bottom center" text={`${Platforms.shortcutSymbol}N`}>
-            <Kb.Icon
-              type="iconfont-compose"
-              style={propsIconPlatform.style}
-              color={propsIconPlatform.color}
-              fontSize={propsIconPlatform.fontSize}
-              onClick={this.props.onNewChat}
-            />
-          </Kb.WithTooltip>
-        )}
-      </Kb.Box2>
     )
   }
 }
 
 const styles = Styles.styleSheetCreate({
+  backButton: {
+    ...Styles.padding(Styles.globalMargins.tiny, 0),
+  },
   container: Styles.platformStyles({
     common: {
       minHeight: 48,
@@ -196,31 +181,23 @@ const styles = Styles.styleSheetCreate({
       alignItems: 'center',
       backgroundColor: Styles.globalColors.black_10,
       borderRadius: Styles.borderRadius,
-      justifyContent: 'center',
+      flexGrow: 1,
+      justifyContent: 'flex-start',
     },
     isElectron: {
       ...Styles.desktopStyles.editable,
-      flexGrow: 1,
-      height: 24,
+      height: 28,
+      paddingLeft: 8,
     },
     isMobile: {
       height: 32,
-      width: '100%',
+      paddingLeft: 16,
     },
   }),
-  icon: Styles.platformStyles({
-    common: {
-      position: 'relative',
-    },
-    isElectron: {
-      top: 2,
-    },
-    isMobile: {
-      top: 1,
-    },
-  }),
-  inputContainer: {
-    ...Styles.globalStyles.flexBoxRow,
+  flexOne: {flex: 1},
+  icon: {
+    position: 'relative',
+    top: 1,
   },
   loadingContainer: {
     bottom: 0,
@@ -230,28 +207,16 @@ const styles = Styles.styleSheetCreate({
   },
   text: {
     color: Styles.globalColors.black_50,
-    marginLeft: Styles.globalMargins.tiny,
-    marginRight: Styles.globalMargins.tiny,
+    marginLeft: Styles.globalMargins.xtiny,
+    marginRight: Styles.globalMargins.xtiny,
+    position: 'relative',
+    top: 1,
   },
   textFaint: {
     color: Styles.globalColors.black_35,
+    position: 'relative',
+    top: 1,
   },
 })
-
-const propsIconCompose = {
-  color: Styles.globalColors.blue,
-  fontSize: 16,
-  style: {},
-}
-
-const propsIconComposeMobile = {
-  ...propsIconCompose,
-  fontSize: 20,
-  style: {
-    padding: Styles.globalMargins.xtiny,
-  },
-}
-
-const propsIconPlatform = Styles.isMobile ? propsIconComposeMobile : propsIconCompose
 
 export default ConversationFilterInput


### PR DESCRIPTION
- Don't use `HeaderHocHeader` on native, unify desktop + mobile impl
- New chat button
- (x) icon on the right when filtering

Small screen fit (5S) - nav2 off:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/11968340/53663159-07995a00-3c33-11e9-9111-f9c6caba835e.png">
nav2 on:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/11968340/53663403-ad4cc900-3c33-11e9-860c-fb644a7a7cce.png">

r? @keybase/react-hackers 