### PR TITLE
fix bug in leaving as the last owner

### DIFF
--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -265,6 +265,12 @@ const hasChannelInfos = (state: TypedState, teamname: Types.Teamname): boolean =
 const getTeamMemberCount = (state: TypedState, teamname: Types.Teamname): number =>
   state.teams.getIn(['teammembercounts', teamname], 0)
 
+const isLastOwner = (state: TypedState, teamname: Types.Teamname): boolean => {
+  const allTeamMembers = state.teams.teamNameToMembers.getIn([teamname], I.Map())
+  const countOfOwners = allTeamMembers.count(m => m.type === 'owner')
+  return countOfOwners === 1 && getRole(state, teamname) === 'owner'
+}
+
 const getTeamID = (state: TypedState, teamname: Types.Teamname): string =>
   state.teams.getIn(['teamNameToID', teamname], '')
 
@@ -463,6 +469,7 @@ export {
   hasChannelInfos,
   getEmailInviteError,
   getTeamMemberCount,
+  isLastOwner,
   userIsActiveInTeamHelper,
   getTeamChannelInfos,
   getChannelInfoFromConvID,

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -265,10 +265,19 @@ const hasChannelInfos = (state: TypedState, teamname: Types.Teamname): boolean =
 const getTeamMemberCount = (state: TypedState, teamname: Types.Teamname): number =>
   state.teams.getIn(['teammembercounts', teamname], 0)
 
-const isLastOwner = (state: TypedState, teamname: Types.Teamname): boolean => {
-  const allTeamMembers = state.teams.teamNameToMembers.getIn([teamname], I.Map())
-  const countOfOwners = allTeamMembers.count(m => m.type === 'owner')
-  return countOfOwners === 1 && getRole(state, teamname) === 'owner'
+const isLastOwner = (state: TypedState, teamname: Types.Teamname): boolean =>
+  isOwner(getRole(state, teamname)) && !isMultiOwnerTeam(state, teamname)
+
+const isMultiOwnerTeam = (state: TypedState, teamname: Types.Teamname): boolean => {
+  let countOfOwners = 0
+  const allTeamMembers = state.teams.teamNameToMembers.get(teamname, I.Map())
+  const moreThanOneOwner = allTeamMembers.some(tm => {
+    if (isOwner(tm.type)) {
+      countOfOwners++
+    }
+    return countOfOwners > 1
+  })
+  return moreThanOneOwner
 }
 
 const getTeamID = (state: TypedState, teamname: Types.Teamname): string =>

--- a/shared/teams/really-leave-team/container.js
+++ b/shared/teams/really-leave-team/container.js
@@ -4,15 +4,14 @@ import * as Container from '../../util/container'
 import {branch, renderComponent} from 'recompose'
 import ReallyLeaveTeam from '.'
 import LastOwnerDialog from './last-owner'
-import {getTeamMemberCount, isSubteam, leaveTeamWaitingKey} from '../../constants/teams'
+import {isLastOwner, leaveTeamWaitingKey} from '../../constants/teams'
 import {anyWaiting} from '../../constants/waiting'
 
 type OwnProps = Container.RouteProps<{teamname: string}, {}>
 
 const mapStateToProps = (state, {routeProps}) => {
   const name = routeProps.get('teamname')
-  const memberCount = getTeamMemberCount(state, name)
-  const _lastOwner = memberCount <= 1 && !isSubteam(name)
+  const _lastOwner = isLastOwner(state, name)
   return {
     _lastOwner,
     _leaving: anyWaiting(state, leaveTeamWaitingKey(name)),


### PR DESCRIPTION
a team is not valid without an owner, so the last owner may not leave it. in JS land, we don't bother letting a user make this attempt and instead show a helpful explanation. 

previously, we were showing this message only if you were the very last remaining user in the team. this is a sufficient but not necessary condition for being the final owner, for example if there is another non-owner user in the team. in this case we should also be preventing the request instead of letting the it go through and black-bar-ing. 