### PR TITLE
config_local: store TLF path along with sync config

### DIFF
--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -911,8 +911,9 @@ type FolderSyncEncryptedPartialPaths struct {
 // FolderSyncConfig is the on-disk representation for a TLF sync
 // config.
 type FolderSyncConfig struct {
-	Mode  keybase1.FolderSyncMode         `codec:"mode" json:"mode"`
-	Paths FolderSyncEncryptedPartialPaths `codec:"paths" json:"paths"`
+	Mode    keybase1.FolderSyncMode         `codec:"mode" json:"mode"`
+	Paths   FolderSyncEncryptedPartialPaths `codec:"paths" json:"paths"`
+	TlfPath string                          `codec:"tlfpath" json:"tlfpath"`
 }
 
 type syncPathList struct {

--- a/go/kbfs/libkbfs/interface_test.go
+++ b/go/kbfs/libkbfs/interface_test.go
@@ -89,6 +89,15 @@ func (t *testSyncedTlfGetterSetter) IsSyncedTlf(tlfID tlf.ID) bool {
 	return t.syncedTlfs[tlfID].Mode == keybase1.FolderSyncMode_ENABLED
 }
 
+func (t *testSyncedTlfGetterSetter) IsSyncedTlfPath(tlfPath string) bool {
+	for _, config := range t.syncedTlfs {
+		if config.TlfPath == tlfPath {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *testSyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID,
 	config FolderSyncConfig) (<-chan error, error) {
 	t.syncedTlfs[tlfID] = config

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -121,6 +121,7 @@ type diskLimiterGetter interface {
 
 type syncedTlfGetterSetter interface {
 	IsSyncedTlf(tlfID tlf.ID) bool
+	IsSyncedTlfPath(tlfPath string) bool
 	GetTlfSyncState(tlfID tlf.ID) FolderSyncConfig
 	SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (<-chan error, error)
 	GetAllSyncedTlfs() []tlf.ID

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4297,6 +4297,10 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 		require.True(t, pathsMap[p])
 		delete(pathsMap, p)
 	}
+
+	t.Log("Make sure the TLF path is correctly marked as synced")
+	tlfPath := fmt.Sprintf("/keybase/private/%s", name)
+	require.True(t, config.IsSyncedTlfPath(tlfPath))
 }
 
 func waitForPrefetchInTest(

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -936,6 +936,20 @@ func (mr *MocksyncedTlfGetterSetterMockRecorder) IsSyncedTlf(tlfID interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSyncedTlf", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).IsSyncedTlf), tlfID)
 }
 
+// IsSyncedTlfPath mocks base method
+func (m *MocksyncedTlfGetterSetter) IsSyncedTlfPath(tlfPath string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSyncedTlfPath", tlfPath)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSyncedTlfPath indicates an expected call of IsSyncedTlfPath
+func (mr *MocksyncedTlfGetterSetterMockRecorder) IsSyncedTlfPath(tlfPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSyncedTlfPath", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).IsSyncedTlfPath), tlfPath)
+}
+
 // GetTlfSyncState mocks base method
 func (m *MocksyncedTlfGetterSetter) GetTlfSyncState(tlfID tlf.ID) FolderSyncConfig {
 	m.ctrl.T.Helper()
@@ -9382,6 +9396,20 @@ func (m *MockConfig) IsSyncedTlf(tlfID tlf.ID) bool {
 func (mr *MockConfigMockRecorder) IsSyncedTlf(tlfID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSyncedTlf", reflect.TypeOf((*MockConfig)(nil).IsSyncedTlf), tlfID)
+}
+
+// IsSyncedTlfPath mocks base method
+func (m *MockConfig) IsSyncedTlfPath(tlfPath string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSyncedTlfPath", tlfPath)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSyncedTlfPath indicates an expected call of IsSyncedTlfPath
+func (mr *MockConfigMockRecorder) IsSyncedTlfPath(tlfPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSyncedTlfPath", reflect.TypeOf((*MockConfig)(nil).IsSyncedTlfPath), tlfPath)
 }
 
 // GetTlfSyncState mocks base method


### PR DESCRIPTION
To truly work offline, we'll need to be able to tell the service that we want to resolve a given path name with offline availability, even before we know the TLF ID.  So we need to track the synced path names in the sync config DB as well.

This will be used in future work to inform set offline availability settings on service RPCs.

Issue: KBFS-3918