### PR TITLE
make flip dealer robust to reordering

### DIFF
--- a/go/chat/flip/chat_test.go
+++ b/go/chat/flip/chat_test.go
@@ -30,6 +30,7 @@ type chatClient struct {
 	dealer     *Dealer
 	history    map[string]bool
 	clock      clockwork.FakeClock
+	deliver    func(m GameMessageWrappedEncoded)
 }
 
 var _ DealersHelper = (*chatClient)(nil)
@@ -91,7 +92,7 @@ func (s *chatServer) run(ctx context.Context) {
 			s.archive(msg)
 			for _, cli := range s.chatClients {
 				if !cli.me.Eq(msg.Sender) {
-					cli.ch <- msg
+					cli.deliver(msg)
 				}
 			}
 		}
@@ -120,6 +121,9 @@ func (s *chatServer) newClient() *chatClient {
 		history:    make(map[string]bool),
 	}
 	ret.dealer = NewDealer(ret)
+	ret.deliver = func(m GameMessageWrappedEncoded) {
+		ret.ch <- m
+	}
 	s.chatClients = append(s.chatClients, ret)
 	return ret
 }
@@ -257,8 +261,8 @@ func testHappyChat(t *testing.T, n int) {
 	require.NoError(t, err)
 	forAllClients(clients, func(c *chatClient) { nTimes(n, func() { c.consumeCommitment(t) }) })
 	srv.clock.Advance(time.Duration(4001) * time.Millisecond)
-	forAllClients(clients, func(c *chatClient) { c.consumeCommitmentComplete(t, n) })
 	require.True(t, clients[0].dealer.IsGameActive(ctx, conversationID, gameID))
+	forAllClients(clients, func(c *chatClient) { c.consumeCommitmentComplete(t, n) })
 	require.False(t, clients[0].dealer.IsGameActive(ctx, genConversationID(), gameID))
 	forAllClients(clients, func(c *chatClient) { nTimes(n, func() { c.consumeReveal(t) }) })
 	var b *big.Int
@@ -267,6 +271,68 @@ func testHappyChat(t *testing.T, n int) {
 	res, err := Replay(ctx, clients[0], srv.gameHistories[GameIDToKey(gameID)])
 	require.NoError(t, err)
 	require.Equal(t, 0, b.Cmp(res.Result.Big))
+}
+
+func getType(t *testing.T, m GameMessageWrappedEncoded) MessageType {
+	w, err := m.Decode()
+	require.NoError(t, err)
+	body := w.Msg.Body
+	typ, err := body.T()
+	require.NoError(t, err)
+	return typ
+}
+
+func TestReorder(t *testing.T) {
+	srv := newChatServer()
+	ctx := context.Background()
+	go srv.run(ctx)
+	defer srv.stop()
+	conversationID := genConversationID()
+	gameID := GenerateGameID()
+	n := 25
+	clients := srv.makeAndRunClients(ctx, conversationID, n)
+	defer srv.stopClients()
+
+	last := n - 1
+	delays := 5                // 5 messages get delayed
+	normals := clients[0:last] // these guys work as normal
+	testee := clients[last]    // the guy who is being tested --- he sees reorderer messages
+
+	// for the testee, let the first (n-delay) commitments go through, them we send through
+	// the commitmentComplete message, and then the delayed commitments
+	var msgBuffer []GameMessageWrappedEncoded
+	testee.deliver = func(m GameMessageWrappedEncoded) {
+		typ := getType(t, m)
+
+		if typ == MessageType_COMMITMENT && len(msgBuffer) < delays {
+			msgBuffer = append(msgBuffer, m)
+			return
+		}
+		testee.ch <- m
+		if typ == MessageType_COMMITMENT_COMPLETE {
+			for _, b := range msgBuffer {
+				testee.ch <- b
+			}
+		}
+	}
+
+	start := NewStartWithBigInt(srv.clock.Now(), pi(), 5)
+	err := clients[0].dealer.StartFlipWithGameID(ctx, start, conversationID, gameID)
+	require.NoError(t, err)
+	forAllClients(normals, func(c *chatClient) { nTimes(n, func() { c.consumeCommitment(t) }) })
+	srv.clock.Advance(time.Duration(4001) * time.Millisecond)
+	forAllClients(normals, func(c *chatClient) { c.consumeCommitmentComplete(t, n) })
+	forAllClients(normals, func(c *chatClient) { nTimes(n, func() { c.consumeReveal(t) }) })
+
+	// Now, make sure that the messages made it to the reordered guy,
+	// but in the reordered order.
+	nTimes(n-delays, func() { testee.consumeCommitment(t) })
+	testee.consumeCommitmentComplete(t, n)
+	nTimes(delays, func() { testee.consumeCommitment(t) })
+	nTimes(n, func() { testee.consumeReveal(t) })
+
+	var b *big.Int
+	forAllClients(clients, func(c *chatClient) { c.consumeResult(t, &b) })
 }
 
 func TestSadChatOneAbsentee(t *testing.T) {

--- a/go/chat/flip/dealer.go
+++ b/go/chat/flip/dealer.go
@@ -83,14 +83,21 @@ type Game struct {
 	commitmentCompleteHash Hash
 	clock                  func() clockwork.Clock
 	clogf                  func(ctx context.Context, fmt string, args ...interface{})
+
+	// To handle reorderings between CommitmentComplete and commitements,
+	// wee need some extra bookkeeping.
+	iWasIncluded          bool
+	gotCommitmentComplete bool
+	latecomers            map[UserDeviceKey]bool
 }
 
 type GamePlayerState struct {
-	ud             UserDevice
-	commitment     Commitment
-	commitmentTime time.Time
-	included       bool
-	secret         *Secret
+	ud               UserDevice
+	commitment       *Commitment
+	commitmentTime   time.Time
+	leaderCommitment *Commitment
+	included         bool
+	secret           *Secret
 }
 
 func (g *Game) GameMetadata() GameMetadata {
@@ -235,7 +242,7 @@ func (g *Game) setSecret(ctx context.Context, ps *GamePlayerState, secret Secret
 	if ps.secret != nil {
 		return DuplicateRevealError{G: g.md, U: ps.ud}
 	}
-	if !expected.Eq(ps.commitment) {
+	if !expected.Eq(*ps.commitment) {
 		return BadRevealError{G: g.md, U: ps.ud}
 	}
 	ps.secret = &secret
@@ -295,6 +302,133 @@ func (g *Game) playerCommitedInTime(ps *GamePlayerState, now time.Time) bool {
 	return diff < g.params.CommitmentWindowWithSlack(true)
 }
 
+func (g *Game) getPlayerState(ud UserDevice) *GamePlayerState {
+	key := ud.ToKey()
+	ret := g.players[key]
+	if ret != nil {
+		return ret
+	}
+	ret = &GamePlayerState{ud: ud}
+	g.players[key] = ret
+	return ret
+}
+
+func (g *Game) handleCommitment(ctx context.Context, sender UserDevice, now time.Time, com Commitment) (err error) {
+	ps := g.getPlayerState(sender)
+	if ps.commitment != nil {
+		return DuplicateRegistrationError{g.md, sender}
+	}
+	if ps.leaderCommitment != nil && !ps.leaderCommitment.Eq(com) {
+		return CommitmentMismatchError{G: g.GameMetadata(), U: sender}
+	}
+	ps.commitment = &com
+	ps.commitmentTime = now
+
+	// If this user was a latecomer (we got the commitment after we got the CommitmentComplete),
+	// then we mark them as being accounted for.
+	delete(g.latecomers, sender.ToKey())
+
+	g.gameUpdateCh <- GameStateUpdateMessage{
+		Metadata: g.GameMetadata(),
+		Commitment: &CommitmentUpdate{
+			User:       sender,
+			Commitment: com,
+		},
+	}
+	return g.maybeReveal(ctx)
+}
+
+func (g *Game) maybeReveal(ctx context.Context) (err error) {
+
+	if !g.gotCommitmentComplete {
+		return nil
+	}
+	if len(g.latecomers) > 0 {
+		return nil
+	}
+
+	g.stage = Stage_ROUND2
+	g.stageForTimeout = Stage_ROUND2
+
+	if g.me == nil {
+		return nil
+	}
+
+	if !g.iWasIncluded {
+		g.clogf(ctx, "The leader didn't include me (%s) so not sending a reveal (%s)", g.me.me, g.md)
+		return nil
+	}
+
+	reveal := Reveal{
+		Secret: g.me.secret,
+		Cch:    g.commitmentCompleteHash,
+	}
+	g.sendOutgoingChat(ctx, NewGameMessageBodyWithReveal(reveal))
+	return nil
+}
+
+func (g *Game) handleCommitmentCompletePlayer(ctx context.Context, u UserDeviceCommitment) (err error) {
+
+	ps := g.getPlayerState(u.Ud)
+	if ps.leaderCommitment != nil {
+		return DuplicateCommitmentCompleteError{G: g.md, U: u.Ud}
+	}
+	if ps.commitment != nil && !ps.commitment.Eq(u.C) {
+		return CommitmentMismatchError{G: g.md, U: u.Ud}
+	}
+	if ps.commitment == nil {
+		g.latecomers[u.Ud.ToKey()] = true
+	}
+	ps.leaderCommitment = &u.C
+	ps.included = true
+	g.nPlayers++
+
+	if g.me != nil && g.me.me.Eq(u.Ud) {
+		g.iWasIncluded = true
+	}
+	return nil
+}
+
+func (g *Game) handleCommitmentComplete(ctx context.Context, sender UserDevice, now time.Time, cc CommitmentComplete) (err error) {
+
+	if !sender.Eq(g.md.Initiator) {
+		return WrongSenderError{G: g.md, Expected: g.md.Initiator, Actual: sender}
+	}
+
+	if !checkUserDeviceCommitments(cc.Players) {
+		return CommitmentCompleteSortError{G: g.md}
+	}
+
+	for _, u := range cc.Players {
+		err = g.handleCommitmentCompletePlayer(ctx, u)
+		if err != nil {
+			return err
+		}
+	}
+
+	cch, err := hashUserDeviceCommitments(cc.Players)
+	if err != nil {
+		return err
+	}
+
+	g.commitmentCompleteHash = cch
+	g.gotCommitmentComplete = true
+
+	// for now, just warn if users who made it in on time weren't included.
+	for _, ps := range g.players {
+		if !ps.included && g.playerCommitedInTime(ps, now) && g.clogf != nil {
+			g.clogf(ctx, "User %s wasn't included, but they should have been", ps.ud)
+		}
+	}
+
+	g.gameUpdateCh <- GameStateUpdateMessage{
+		Metadata:           g.GameMetadata(),
+		CommitmentComplete: &cc,
+	}
+
+	return g.maybeReveal(ctx)
+}
+
 func (g *Game) handleMessage(ctx context.Context, msg *GameMessageWrapped, now time.Time) error {
 	t, err := msg.Msg.Body.T()
 	if err != nil {
@@ -317,83 +451,19 @@ func (g *Game) handleMessage(ctx context.Context, msg *GameMessageWrapped, now t
 			return nil
 		}
 
-		key := msg.Sender.ToKey()
-		if g.players[key] != nil {
-			return DuplicateRegistrationError{g.md, msg.Sender}
-		}
-		g.players[key] = &GamePlayerState{
-			ud:             msg.Sender,
-			commitment:     msg.Msg.Body.Commitment(),
-			commitmentTime: now,
-		}
-		g.gameUpdateCh <- GameStateUpdateMessage{
-			Metadata: g.GameMetadata(),
-			Commitment: &CommitmentUpdate{
-				User:       msg.Sender,
-				Commitment: msg.Msg.Body.Commitment(),
-			},
+		err = g.handleCommitment(ctx, msg.Sender, now, msg.Msg.Body.Commitment())
+		if err != nil {
+			return err
 		}
 
 	case MessageType_COMMITMENT_COMPLETE:
 		if g.stage != Stage_ROUND1 {
 			return badStage()
 		}
-		if !msg.Sender.Eq(g.md.Initiator) {
-			return WrongSenderError{G: g.md, Expected: g.md.Initiator, Actual: msg.Sender}
-		}
-		cc := msg.Msg.Body.CommitmentComplete()
 
-		if !checkUserDeviceCommitments(cc.Players) {
-			return CommitmentCompleteSortError{G: g.md}
-		}
-
-		iWasIncluded := false
-
-		for _, u := range cc.Players {
-			key := u.Ud.ToKey()
-			ps := g.players[key]
-			if ps == nil {
-				return UnregisteredUserError{G: g.md, U: u.Ud}
-			}
-			if !u.C.Eq(ps.commitment) {
-				return CommitmentMismatchError{G: g.md, U: u.Ud}
-			}
-			ps.included = true
-			g.nPlayers++
-
-			if g.me != nil && g.me.me.Eq(u.Ud) {
-				iWasIncluded = true
-			}
-		}
-
-		cch, err := hashUserDeviceCommitments(cc.Players)
+		err = g.handleCommitmentComplete(ctx, msg.Sender, now, msg.Msg.Body.CommitmentComplete())
 		if err != nil {
 			return err
-		}
-
-		g.commitmentCompleteHash = cch
-
-		// for now, just warn if users who made it in on time weren't included.
-		for _, ps := range g.players {
-			if !ps.included && g.playerCommitedInTime(ps, now) && g.clogf != nil {
-				g.clogf(ctx, "User %s wasn't included, but they should have been", ps.ud)
-			}
-		}
-		g.stage = Stage_ROUND2
-		g.stageForTimeout = Stage_ROUND2
-		g.gameUpdateCh <- GameStateUpdateMessage{
-			Metadata:           g.GameMetadata(),
-			CommitmentComplete: &cc,
-		}
-
-		if iWasIncluded {
-			reveal := Reveal{
-				Secret: g.me.secret,
-				Cch:    cch,
-			}
-			g.sendOutgoingChat(ctx, NewGameMessageBodyWithReveal(reveal))
-		} else if g.me != nil {
-			g.clogf(ctx, "The leader didn't include me (%s) so not sending a reveal (%s)", g.me.me, g.md)
 		}
 
 	case MessageType_REVEAL:
@@ -446,7 +516,9 @@ func (g *Game) handleMessage(ctx context.Context, msg *GameMessageWrapped, now t
 func (g *Game) userDeviceCommitmentList() []UserDeviceCommitment {
 	var ret []UserDeviceCommitment
 	for _, p := range g.players {
-		ret = append(ret, UserDeviceCommitment{Ud: p.ud, C: p.commitment})
+		if p.commitment != nil {
+			ret = append(ret, UserDeviceCommitment{Ud: p.ud, C: *p.commitment})
+		}
 	}
 	sortUserDeviceCommitments(ret)
 	return ret
@@ -607,6 +679,7 @@ func (d *Dealer) handleMessageStart(ctx context.Context, msg *GameMessageWrapped
 		me:              me,
 		clock:           d.dh.Clock,
 		clogf:           d.dh.CLogf,
+		latecomers:      make(map[UserDeviceKey]bool),
 	}
 	d.games[key] = msgCh
 	d.gameIDs[gameIDKey] = md

--- a/go/chat/flip/errors.go
+++ b/go/chat/flip/errors.go
@@ -115,13 +115,13 @@ func (d DuplicateRegistrationError) Error() string {
 	return fmt.Sprintf("User %s registered more than once in game %s", d.G, d.U.ToKey())
 }
 
-type UnregisteredUserError struct {
+type DuplicateCommitmentCompleteError struct {
 	G GameMetadata
 	U UserDevice
 }
 
-func (u UnregisteredUserError) Error() string {
-	return fmt.Sprintf("Initiator announced an unexpected user %s in game %s", u.U.ToKey(), u.G)
+func (d DuplicateCommitmentCompleteError) Error() string {
+	return fmt.Sprintf("Initiator announced a duplicate commitment user %s in game %s", d.U.ToKey(), d.G)
 }
 
 type WrongSenderError struct {


### PR DESCRIPTION
- for non-leaders, it doesn't really matter which order commitments and commitmentCompletes come in.
- if chat is behaving, they should be strictly ordered, but if there's a bug, the dealer can be robust to it
- handle out-of-order delivery and add a test to show that it works