### PR TITLE
fix video view on mobile

### DIFF
--- a/shared/common-adapters/video.shared.js
+++ b/shared/common-adapters/video.shared.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {type State} from './video'
 import {Box2} from './box'
 import Text from './text'
-import {URL} from 'whatwg-url'
+import {URL} from 'whatwg-url' // URL is not available in rn
 
 type Size = {
   height: number,

--- a/shared/common-adapters/video.shared.js
+++ b/shared/common-adapters/video.shared.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import {type State} from './video'
 import {Box2} from './box'
 import Text from './text'
+import {URL} from 'whatwg-url'
 
 type Size = {
   height: number,

--- a/shared/package.json
+++ b/shared/package.json
@@ -181,7 +181,7 @@
     "typedarray-to-buffer": "3.1.5",
     "url-parse": "1.4.4",
     "uuid": "3.3.2",
-    "whatwg-url": "^7.0.0"
+    "whatwg-url": "7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",

--- a/shared/package.json
+++ b/shared/package.json
@@ -180,7 +180,8 @@
     "tlds": "1.203.1",
     "typedarray-to-buffer": "3.1.5",
     "url-parse": "1.4.4",
-    "uuid": "3.3.2"
+    "uuid": "3.3.2",
+    "whatwg-url": "^7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -14604,19 +14604,19 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
-whatwg-url@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
-  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
+whatwg-url@7.0.0, whatwg-url@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  integrity sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
-whatwg-url@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
-  integrity sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==
+whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"


### PR DESCRIPTION
The issues was that `URL` is not supported on react-native. So use `whatwg-url` instead. This adds the dependency, but it's already in `yarn.lock`.