### PR TITLE
fix settings precedence for linux home dir computations

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -359,7 +359,8 @@ func newEnv(cmd CommandLine, config ConfigReader, osname string, getLog LogGette
 		func() string { return e.getMobileSharedHomeFromCmdOrConfig() },
 		osname,
 		func() RunMode { return e.GetRunMode() },
-		getLog)
+		getLog,
+		os.Getenv)
 	return &e
 }
 

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -354,7 +354,8 @@ func newEnv(cmd CommandLine, config ConfigReader, osname string, getLog LogGette
 	e := Env{cmd: cmd, config: config, Test: &TestParameters{}}
 
 	e.HomeFinder = NewHomeFinder("keybase",
-		func() string { return e.getHomeFromCmdOrConfig() },
+		func() string { return e.getHomeFromTestOrCmd() },
+		func() string { return e.GetConfig().GetHome() },
 		func() string { return e.getMobileSharedHomeFromCmdOrConfig() },
 		osname,
 		func() RunMode { return e.GetRunMode() },
@@ -362,11 +363,10 @@ func newEnv(cmd CommandLine, config ConfigReader, osname string, getLog LogGette
 	return &e
 }
 
-func (e *Env) getHomeFromCmdOrConfig() string {
+func (e *Env) getHomeFromTestOrCmd() string {
 	return e.GetString(
 		func() string { return e.Test.Home },
 		func() string { return e.cmd.GetHome() },
-		func() string { return e.GetConfig().GetHome() },
 	)
 }
 

--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -80,14 +80,14 @@ func (x XdgPosix) MobileSharedHome(emptyOk bool) string {
 func (x XdgPosix) dirHelper(env string, prefixDirs ...string) string {
 	var prfx string
 
-	// If the use explicitly provided a `--home` directory, it overrides any XDG_*
+	// If the user explicitly provided a `--home` directory, it overrides any XDG_*
 	// variables. All XDR dirs are taken relative to that.
 	if x.getHomeFromCmd != nil {
 		prfx = x.getHomeFromCmd()
 	}
 
 	// If the command line didn't specify anything, then we're going to go with the XDG_
-	// environment variablre specification.
+	// environment variable specification.
 	if prfx == "" {
 		prfx = os.Getenv(env)
 	}

--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -15,6 +15,7 @@ import (
 
 type ConfigGetter func() string
 type RunModeGetter func() RunMode
+type EnvGetter func(s string) string
 
 type Base struct {
 	appName             string
@@ -23,6 +24,7 @@ type Base struct {
 	getMobileSharedHome ConfigGetter
 	getRunMode          RunModeGetter
 	getLog              LogGetter
+	getenvFunc          EnvGetter
 }
 
 type HomeFinder interface {
@@ -57,6 +59,13 @@ func (b Base) getHome() string {
 	return ""
 }
 
+func (b Base) getenv(s string) string {
+	if b.getenvFunc != nil {
+		return b.getenvFunc(s)
+	}
+	return os.Getenv(s)
+}
+
 func (b Base) Join(elem ...string) string { return filepath.Join(elem...) }
 
 type XdgPosix struct {
@@ -68,7 +77,7 @@ func (x XdgPosix) Normalize(s string) string { return s }
 func (x XdgPosix) Home(emptyOk bool) string {
 	ret := x.getHome()
 	if len(ret) == 0 && !emptyOk {
-		ret = os.Getenv("HOME")
+		ret = x.getenv("HOME")
 	}
 	return ret
 }
@@ -79,25 +88,36 @@ func (x XdgPosix) MobileSharedHome(emptyOk bool) string {
 
 func (x XdgPosix) dirHelper(env string, prefixDirs ...string) string {
 	var prfx string
+	var doAppend bool
 
 	// If the user explicitly provided a `--home` directory, it overrides any XDG_*
 	// variables. All XDR dirs are taken relative to that.
 	if x.getHomeFromCmd != nil {
 		prfx = x.getHomeFromCmd()
+		if prfx != "" {
+			doAppend = true
+		}
 	}
 
 	// If the command line didn't specify anything, then we're going to go with the XDG_
 	// environment variable specification.
 	if prfx == "" {
-		prfx = os.Getenv(env)
+		prfx = x.getenv(env)
 	}
 
 	// If there was no XDG_ environment variable, then we wind up falling back to
 	// (1) the config file first, and if not there, then: (2) the HOME environment
 	// variable.
 	if prfx == "" {
-		h := x.Home(false)
-		v := append([]string{h}, prefixDirs...)
+		prfx = x.Home(false)
+		doAppend = true
+	}
+
+	// If we're not using XDG_, and we're either using --home or HOME=, then
+	// append on the given prefixDirs, separated by the OS-appropriate path
+	// separator (which should be '/' for XdgPosix).
+	if doAppend {
+		v := append([]string{prfx}, prefixDirs...)
 		prfx = x.Join(v...)
 	}
 
@@ -225,7 +245,7 @@ func (d Darwin) Home(emptyOk bool) string {
 	var ret string
 	ret = d.getHome()
 	if len(ret) == 0 && !emptyOk {
-		ret = os.Getenv("HOME")
+		ret = d.getenv("HOME")
 	}
 	return ret
 }
@@ -236,7 +256,7 @@ func (d Darwin) MobileSharedHome(emptyOk bool) string {
 		ret = d.getMobileSharedHome()
 	}
 	if len(ret) == 0 && !emptyOk {
-		ret = os.Getenv("MOBILE_SHARED_HOME")
+		ret = d.getenv("MOBILE_SHARED_HOME")
 	}
 	return ret
 }
@@ -285,10 +305,10 @@ func (w Win32) ServiceSpawnDir() (string, error) { return w.RuntimeDir(), nil }
 func (w Win32) LogDir() string                   { return w.Home(false) }
 
 func (w Win32) deriveFromTemp() (ret string) {
-	tmp := os.Getenv("TEMP")
+	tmp := w.getenv("TEMP")
 	if len(tmp) == 0 {
 		w.getLog().Info("No 'TEMP' environment variable found")
-		tmp = os.Getenv("TMP")
+		tmp = w.getenv("TMP")
 		if len(tmp) == 0 {
 			w.getLog().Fatalf("No 'TMP' environment variable found")
 		}
@@ -344,8 +364,8 @@ func (w Win32) MobileSharedHome(emptyOk bool) string {
 }
 
 func NewHomeFinder(appName string, getHomeFromCmd ConfigGetter, getHomeFromConfig ConfigGetter, getMobileSharedHome ConfigGetter, osname string,
-	getRunMode RunModeGetter, getLog LogGetter) HomeFinder {
-	base := Base{appName, getHomeFromCmd, getHomeFromConfig, getMobileSharedHome, getRunMode, getLog}
+	getRunMode RunModeGetter, getLog LogGetter, getenv EnvGetter) HomeFinder {
+	base := Base{appName, getHomeFromCmd, getHomeFromConfig, getMobileSharedHome, getRunMode, getLog, getenv}
 	switch osname {
 	case "windows":
 		return Win32{base}

--- a/go/libkb/home_nix_test.go
+++ b/go/libkb/home_nix_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestPosix(t *testing.T) {
 	hf := NewHomeFinder("tester", nil, nil, nil, "posix", func() RunMode { return ProductionRunMode },
-		makeLogGetter(t))
+		makeLogGetter(t), nil)
 	d := hf.CacheDir()
 	if !strings.Contains(d, ".cache/tester") {
 		t.Errorf("Bad Cache dir: %s", d)
@@ -30,7 +30,7 @@ func TestPosix(t *testing.T) {
 }
 
 func TestDarwinHomeFinder(t *testing.T) {
-	hf := NewHomeFinder("keybase", nil, nil, nil, "darwin", func() RunMode { return ProductionRunMode }, makeLogGetter(t))
+	hf := NewHomeFinder("keybase", nil, nil, nil, "darwin", func() RunMode { return ProductionRunMode }, makeLogGetter(t), nil)
 	d := hf.ConfigDir()
 	if !strings.HasSuffix(d, "Library/Application Support/Keybase") {
 		t.Errorf("Bad config dir: %s", d)
@@ -40,7 +40,7 @@ func TestDarwinHomeFinder(t *testing.T) {
 		t.Errorf("Bad cache dir: %s", d)
 	}
 	hfInt := NewHomeFinder("keybase", func() string { return "home" }, nil, func() string { return "mobilehome" },
-		"darwin", func() RunMode { return ProductionRunMode }, makeLogGetter(t))
+		"darwin", func() RunMode { return ProductionRunMode }, makeLogGetter(t), nil)
 	hfDarwin := hfInt.(Darwin)
 	hfDarwin.forceIOS = true
 	hf = hfDarwin
@@ -55,7 +55,7 @@ func TestDarwinHomeFinder(t *testing.T) {
 }
 
 func TestDarwinHomeFinderInDev(t *testing.T) {
-	devHomeFinder := NewHomeFinder("keybase", nil, nil, nil, "darwin", func() RunMode { return DevelRunMode }, makeLogGetter(t))
+	devHomeFinder := NewHomeFinder("keybase", nil, nil, nil, "darwin", func() RunMode { return DevelRunMode }, makeLogGetter(t), nil)
 	configDir := devHomeFinder.ConfigDir()
 	if !strings.HasSuffix(configDir, "Library/Application Support/KeybaseDevel") {
 		t.Errorf("Bad config dir: %s", configDir)
@@ -64,4 +64,21 @@ func TestDarwinHomeFinderInDev(t *testing.T) {
 	if !strings.HasSuffix(cacheDir, "Library/Caches/KeybaseDevel") {
 		t.Errorf("Bad cache dir: %s", cacheDir)
 	}
+}
+
+func TestPosixRuntimeDir(t *testing.T) {
+	var home string
+	env := make(map[string]string)
+	ge := func(s string) string { return env[s] }
+	hf := NewHomeFinder("tester", func() string { return home }, nil, nil, "posix", func() RunMode { return ProductionRunMode }, makeLogGetter(t), ge)
+
+	// Test the case that the --home flag overrides XDG_RUNTIME_DIR
+	home = "/footown"
+	env["HOME"] = "/yoyo"
+	env["XDG_RUNTIME_DIR"] = "/barland"
+	require.Equal(t, "/footown/.config/tester", hf.RuntimeDir())
+	home = ""
+	require.Equal(t, "/barland/tester", hf.RuntimeDir())
+	delete(env, "XDG_RUNTIME_DIR")
+	require.Equal(t, "/yoyo/.config//tester", hf.RuntimeDir())
 }

--- a/go/libkb/home_nix_test.go
+++ b/go/libkb/home_nix_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPosix(t *testing.T) {
-	hf := NewHomeFinder("tester", nil, nil, "posix", func() RunMode { return ProductionRunMode },
+	hf := NewHomeFinder("tester", nil, nil, nil, "posix", func() RunMode { return ProductionRunMode },
 		makeLogGetter(t))
 	d := hf.CacheDir()
 	if !strings.Contains(d, ".cache/tester") {
@@ -30,7 +30,7 @@ func TestPosix(t *testing.T) {
 }
 
 func TestDarwinHomeFinder(t *testing.T) {
-	hf := NewHomeFinder("keybase", nil, nil, "darwin", func() RunMode { return ProductionRunMode }, makeLogGetter(t))
+	hf := NewHomeFinder("keybase", nil, nil, nil, "darwin", func() RunMode { return ProductionRunMode }, makeLogGetter(t))
 	d := hf.ConfigDir()
 	if !strings.HasSuffix(d, "Library/Application Support/Keybase") {
 		t.Errorf("Bad config dir: %s", d)
@@ -39,7 +39,7 @@ func TestDarwinHomeFinder(t *testing.T) {
 	if !strings.HasSuffix(d, "Library/Caches/Keybase") {
 		t.Errorf("Bad cache dir: %s", d)
 	}
-	hfInt := NewHomeFinder("keybase", func() string { return "home" }, func() string { return "mobilehome" },
+	hfInt := NewHomeFinder("keybase", func() string { return "home" }, nil, func() string { return "mobilehome" },
 		"darwin", func() RunMode { return ProductionRunMode }, makeLogGetter(t))
 	hfDarwin := hfInt.(Darwin)
 	hfDarwin.forceIOS = true
@@ -55,7 +55,7 @@ func TestDarwinHomeFinder(t *testing.T) {
 }
 
 func TestDarwinHomeFinderInDev(t *testing.T) {
-	devHomeFinder := NewHomeFinder("keybase", nil, nil, "darwin", func() RunMode { return DevelRunMode }, makeLogGetter(t))
+	devHomeFinder := NewHomeFinder("keybase", nil, nil, nil, "darwin", func() RunMode { return DevelRunMode }, makeLogGetter(t))
 	configDir := devHomeFinder.ConfigDir()
 	if !strings.HasSuffix(configDir, "Library/Application Support/KeybaseDevel") {
 		t.Errorf("Bad config dir: %s", configDir)

--- a/go/libkb/home_windows_test.go
+++ b/go/libkb/home_windows_test.go
@@ -31,27 +31,27 @@ func doDirectoryTest(t *testing.T, d string, description string, suffix string) 
 
 // There isn't much to test; the directory needn't exist yet
 func TestWindows(t *testing.T) {
-	hf := NewHomeFinder("tester", nil, nil, "windows", func() RunMode { return ProductionRunMode }, makeLogGetter(t))
+	hf := NewHomeFinder("tester", nil, nil, nil, "windows", func() RunMode { return ProductionRunMode }, makeLogGetter(t), nil)
 
 	doDirectoryTest(t, hf.CacheDir(), "Cache", "")
 	doDirectoryTest(t, hf.DataDir(), "Data", "")
 	doDirectoryTest(t, hf.ConfigDir(), "Config", "")
 
-	hf = NewHomeFinder("tester", nil, nil, "windows", func() RunMode { return StagingRunMode },
-		makeLogGetter(t))
+	hf = NewHomeFinder("tester", nil, nil, nil, "windows", func() RunMode { return StagingRunMode },
+		makeLogGetter(t), nil)
 
 	doDirectoryTest(t, hf.CacheDir(), "Cache", "Staging")
 	doDirectoryTest(t, hf.DataDir(), "Data", "Staging")
 	doDirectoryTest(t, hf.ConfigDir(), "Config", "Staging")
 
-	hf = NewHomeFinder("tester", nil, nil, "windows", func() RunMode { return DevelRunMode },
-		makeLogGetter(t))
+	hf = NewHomeFinder("tester", nil, nil, nil, "windows", func() RunMode { return DevelRunMode },
+		makeLogGetter(t), nil)
 
 	doDirectoryTest(t, hf.CacheDir(), "Cache", "Devel")
 	doDirectoryTest(t, hf.DataDir(), "Data", "Devel")
 	doDirectoryTest(t, hf.ConfigDir(), "Config", "Devel")
 
-	whf := Win32{Base{"tester", nil, nil, func() RunMode { return DevelRunMode }, makeLogGetter(t)}}
+	whf := Win32{Base{"tester", nil, nil, nil, func() RunMode { return DevelRunMode }, makeLogGetter(t), nil}}
 	fromTemp := whf.deriveFromTemp()
 	if len(fromTemp) == 0 {
 		t.Errorf("%s does not exist", fromTemp)

--- a/shared/reducers/chat2.js
+++ b/shared/reducers/chat2.js
@@ -943,7 +943,7 @@ const rootReducer = (
       return alreadyLocked ? state : state.setIn(['explodingModeLocks', conversationIDKey], mode)
     case Chat2Gen.giphySend: {
       let nextState = state
-      nextState = nextState.setIn(['giphyResultMap', action.payload.conversationIDKey], [])
+      nextState = nextState.setIn(['giphyWindowMap', action.payload.conversationIDKey], false)
       return nextState.update('unsentTextMap', old =>
         old.setIn([action.payload.conversationIDKey], new HiddenString(''))
       )


### PR DESCRIPTION
- Highest precendence is now `--home`, which overrides all XDG_* variables
- Then fallback to XDG_* variables
- Then fallback to home dir specification via config file (rarely if ever used)
- Then fallback to HOME directory