### PR TITLE
Filter arguments for `chat api-listen`

### DIFF
--- a/go/client/chat_api_listen_display.go
+++ b/go/client/chat_api_listen_display.go
@@ -56,7 +56,7 @@ func (d *chatNotificationDisplay) setupFilters(ctx context.Context, channelFilte
 			// to normalize display name without using resolve RPC.
 			conv, _, err := d.svc.findConversation(ctx, v)
 			if err != nil {
-				return fmt.Errorf("Unable to find chat channel for: %s: %s", v.Name, err.Error())
+				return fmt.Errorf("Unable to find chat channel for %q: %s", v.Name, err.Error())
 			}
 			v.Name = conv.Info.TlfName
 		} else {

--- a/go/client/chat_api_listen_display.go
+++ b/go/client/chat_api_listen_display.go
@@ -37,6 +37,13 @@ type msgNotification struct {
 	Pagination *chat1.UIPagination `json:"pagination,omitempty"`
 }
 
+type notificationDisplayFilter struct {
+	Team    string `json:"team,omitempty"`
+	Channel string `json:"channel,omitempty"`
+	// or: display name for user conversation, cannot be combined with team/channel.
+	Users string `json:"users,omitempty"`
+}
+
 func newMsgNotification(source string) *msgNotification {
 	return &msgNotification{
 		Type:   notifTypeChat,

--- a/go/client/chat_api_listen_display.go
+++ b/go/client/chat_api_listen_display.go
@@ -143,10 +143,8 @@ func (d *chatNotificationDisplay) matchFilters(conv *chat1.InboxUIItem) bool {
 		if matchMembersTypeToFilter(v, conv.MembersType) && v.Name == strings.ToLower(conv.Name) {
 			// If any of the following were specified by user and differ from
 			// what was received, filter the msg out.
-			if v.TopicType != "" && conv.TopicType.String() != v.TopicType {
-				continue
-			}
-			if v.TopicName != "" && conv.Channel != v.TopicName {
+			if (v.TopicType != "" && conv.TopicType.String() != v.TopicType) ||
+				(v.TopicName != "" && conv.Channel != v.TopicName) {
 				continue
 			}
 			// It's a match.

--- a/go/client/chat_api_listen_display.go
+++ b/go/client/chat_api_listen_display.go
@@ -37,13 +37,6 @@ type msgNotification struct {
 	Pagination *chat1.UIPagination `json:"pagination,omitempty"`
 }
 
-type notificationDisplayFilter struct {
-	Team    string `json:"team,omitempty"`
-	Channel string `json:"channel,omitempty"`
-	// or: display name for user conversation, cannot be combined with team/channel.
-	Users string `json:"users,omitempty"`
-}
-
 func newMsgNotification(source string) *msgNotification {
 	return &msgNotification{
 		Type:   notifTypeChat,

--- a/go/client/chat_api_listen_display.go
+++ b/go/client/chat_api_listen_display.go
@@ -121,13 +121,26 @@ func (d *chatNotificationDisplay) formatMessage(inMsg chat1.IncomingMessage) *Me
 	}
 }
 
+func matchMembersTypeToFilter(filter ChatChannel, typ chat1.ConversationMembersType) bool {
+	if filter.MembersType == "" {
+		// Default empty value matches to any non-team convo.
+		switch typ {
+		case chat1.ConversationMembersType_KBFS, chat1.ConversationMembersType_IMPTEAMNATIVE, chat1.ConversationMembersType_IMPTEAMUPGRADE:
+			return true
+		default:
+			return false
+		}
+	}
+	return filter.MembersType == typ.String()
+}
+
 func (d *chatNotificationDisplay) matchFilters(conv *chat1.InboxUIItem) bool {
 	if len(d.filtersNormalized) == 0 {
 		// No fliters - every message is relayed.
 		return true
 	}
 	for _, v := range d.filtersNormalized {
-		if conv.MembersType.String() == v.MembersType && v.Name == strings.ToLower(conv.Name) {
+		if matchMembersTypeToFilter(v, conv.MembersType) && v.Name == strings.ToLower(conv.Name) {
 			// If any of the following were specified by user and differ from
 			// what was received, filter the msg out.
 			if v.TopicType != "" && conv.TopicType.String() != v.TopicType {

--- a/go/client/chat_api_listen_display.go
+++ b/go/client/chat_api_listen_display.go
@@ -136,7 +136,7 @@ func matchMembersTypeToFilter(filter ChatChannel, typ chat1.ConversationMembersT
 
 func (d *chatNotificationDisplay) matchFilters(conv *chat1.InboxUIItem) bool {
 	if len(d.filtersNormalized) == 0 {
-		// No fliters - every message is relayed.
+		// No filters - every message is relayed.
 		return true
 	}
 	for _, v := range d.filtersNormalized {

--- a/go/client/chat_api_listen_display_test.go
+++ b/go/client/chat_api_listen_display_test.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApiListenFiltersForTeam(t *testing.T) {
+	uiItem := &chat1.InboxUIItem{
+		Name:        "keybase",
+		MembersType: chat1.ConversationMembersType_TEAM,
+		TopicType:   chat1.TopicType_CHAT,
+		Channel:     "general",
+		IsPublic:    false,
+	}
+
+	d := chatNotificationDisplay{}
+	// Chat display with no filters should match any conv.
+	require.True(t, d.matchFilters(uiItem))
+
+	// By default ChatChannel filter is for non-team convs, so the uiItem won't
+	// match here because we look for `keybase` the user chat. Note that such
+	// filter wouldn't pass validation because command looks for user
+	// conversations with that display name first.
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "keybase"}}
+	require.False(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "keybase", MembersType: "TEAM"}}
+	require.True(t, d.matchFilters(uiItem))
+
+	// We only want #desktop channel now, should not match.
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "keybase", MembersType: "TEAM", TopicName: "desktop"}}
+	require.False(t, d.matchFilters(uiItem))
+
+	// If any of the ChatChannels match, message is passed through.
+	d.filtersNormalized = []ChatChannel{
+		ChatChannel{Name: "keybase", MembersType: "TEAM", TopicName: "desktop"},
+		ChatChannel{Name: "keybase", MembersType: "TEAM", TopicName: "general"},
+	}
+	require.True(t, d.matchFilters(uiItem))
+
+	// If none match, message is dropped.
+	d.filtersNormalized = []ChatChannel{
+		ChatChannel{Name: "keybase.devops", MembersType: "TEAM", TopicName: "serverless"},
+		ChatChannel{Name: "keybase.devops", MembersType: "TEAM", TopicName: "general"},
+	}
+	require.False(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "keybase.devops", MembersType: "TEAM"}}
+	require.False(t, d.matchFilters(uiItem))
+}
+
+func TestApiListenFiltersForUsers(t *testing.T) {
+	uiItem := &chat1.InboxUIItem{
+		Name:        "alice,bob",
+		IsPublic:    false,
+		MembersType: chat1.ConversationMembersType_IMPTEAMNATIVE,
+		TopicType:   chat1.TopicType_CHAT,
+	}
+
+	d := chatNotificationDisplay{}
+	// Chat display with no filters should match any conv.
+	require.True(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "keybase", MembersType: "TEAM"}}
+	require.False(t, d.matchFilters(uiItem))
+
+	// Note: Name has to be a normalized display name for this to work, but
+	// this is done by the command when chat notification listened is
+	// initialized.
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "alice,bob"}}
+	require.True(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "bob,alice"}} // incorrect display name - not `matchFilters` fault.
+	require.False(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "alice,bob", TopicType: "DEV"}}
+	require.False(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "alice,bob", MembersType: "IMPTEAMNATIVE"}}
+	require.True(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{ChatChannel{Name: "alice,bob", MembersType: "IMPTEAMUPGRADE"}}
+	require.False(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{
+		ChatChannel{Name: "alice,bob", MembersType: "IMPTEAMNATIVE"},
+		ChatChannel{Name: "keybase", MembersType: "TEAM"},
+	}
+	require.True(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{
+		ChatChannel{Name: "keybase", MembersType: "TEAM"},
+		ChatChannel{Name: "alice,bob"},
+	}
+	require.True(t, d.matchFilters(uiItem))
+
+	d.filtersNormalized = []ChatChannel{
+		ChatChannel{Name: "alice,bob", MembersType: "IMPTEAMNATIVE"},
+		ChatChannel{Name: "alice,bob", MembersType: "IMPTEAMUPGRADE"},
+	}
+	require.True(t, d.matchFilters(uiItem))
+}

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -74,12 +74,12 @@ func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli
 
    Examples:
 
-   To only show messages from "alice,bob,charlie" conversation between users, and from
+   Only show messages from user conversation "alice,bob,charlie", and from
    "all_things_crypto" team channel #core:
 
       keybase chat api-listen --filter-channels '[{"name":"alice,bob,charlie"}, {"name":"all_things_crypto", "topic_name": "core", "members_type": "team"}]'
 
-   To only show messages from "alice,bob" conversation between users:
+   Only show messages from "alice,bob" user conversation:
 
       keybase chat api-listen --filter-channel '{"name":"alice,bob"}'
 `,

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -65,6 +65,24 @@ func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli
 				Usage: "Only show notifications for specified list of channels.",
 			},
 		},
+		Description: `"keybase chat api-listen" is a command that will print incoming chat messages or
+   wallet notifications until it's exited. Messages are printed to standard output in JSON format similar
+   to format used in "keybase chat api".
+
+   For chat messages, by default all messages will be relayed. Filtering can be used using
+   --filter-channel or --filter-channels flags, that take JSON arguments.
+
+   Examples:
+
+   To only show messages from "alice,bob,charlie" conversation between users, and from
+   "all_things_crypto" team, channel #core:
+
+      keybase chat api-listen --filter-channels '[{"name":"alice,bob,charlie"}, {"name":"all_things_crypto", "topic_name": "core", "members_type": "team"}]'
+
+   To only show messages from "alice,bob" conversation between users:
+
+      keybase chat api-listen --filter-channel '{"name":"alice,bob"}'
+`,
 	}
 }
 

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -66,16 +66,16 @@ func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli
 			},
 		},
 		Description: `"keybase chat api-listen" is a command that will print incoming chat messages or
-   wallet notifications until it's exited. Messages are printed to standard output in JSON format similar
-   to format used in "keybase chat api".
+   wallet notifications until it's exited. Messages are printed to standard output in a JSON format similar
+   to the format used in "keybase chat api" command.
 
-   For chat messages, by default all messages will be relayed. Filtering can be used using
-   --filter-channel or --filter-channels flags, that take JSON arguments.
+   For chat messages, all messages will be relayed by default. Filtering can be enabled using
+   --filter-channel or --filter-channels flags that take JSON arguments.
 
    Examples:
 
    To only show messages from "alice,bob,charlie" conversation between users, and from
-   "all_things_crypto" team, channel #core:
+   "all_things_crypto" team channel #core:
 
       keybase chat api-listen --filter-channels '[{"name":"alice,bob,charlie"}, {"name":"all_things_crypto", "topic_name": "core", "members_type": "team"}]'
 

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -66,8 +66,8 @@ func newCmdChatAPIListen(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli
 			},
 		},
 		Description: `"keybase chat api-listen" is a command that will print incoming chat messages or
-   wallet notifications until it's exited. Messages are printed to standard output in a JSON format similar
-   to the format used in "keybase chat api" command.
+   wallet notifications until it's exited. Messages are printed to standard output in
+   a JSON format similar to the format used in "keybase chat api" command.
 
    For chat messages, all messages will be relayed by default. Filtering can be enabled using
    --filter-channel or --filter-channels flags that take JSON arguments.

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -134,8 +134,8 @@ func (c *CmdChatAPIListen) Run() error {
 		return err
 	}
 
-	if len(chatDisplay.filtersNormalized) > 0 {
-		c.ErrWriteLn("Message filtering is active: %d filters")
+	if filterLen := len(chatDisplay.filtersNormalized); filterLen > 0 {
+		c.ErrWriteLn("Message filtering is active: %d filters", filterLen)
 		for i, v := range chatDisplay.filtersNormalized {
 			c.ErrWriteLn("filter %d: %+v", i, v)
 		}

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -118,6 +118,10 @@ func sendPing(cli keybase1.SessionClient) error {
 	return cli.SessionPing(ctx)
 }
 
+func (c *CmdChatAPIListen) ErrWriteLn(format string, obj ...interface{}) {
+	c.G().UI.GetTerminalUI().ErrorWriter().Write([]byte(fmt.Sprintf(format, obj...) + "\n"))
+}
+
 func (c *CmdChatAPIListen) Run() error {
 	sessionClient, err := GetSessionClient(c.G())
 	if err != nil {
@@ -125,8 +129,16 @@ func (c *CmdChatAPIListen) Run() error {
 	}
 
 	chatDisplay := newChatNotificationDisplay(c.G(), c.showLocal, c.hideExploding)
+
 	if err := chatDisplay.setupFilters(context.TODO(), c.channelFilters); err != nil {
 		return err
+	}
+
+	if len(chatDisplay.filtersNormalized) > 0 {
+		c.ErrWriteLn("Message filtering is active: %d filters")
+		for i, v := range chatDisplay.filtersNormalized {
+			c.ErrWriteLn("filter %d: %+v", i, v)
+		}
 	}
 
 	protocols := []rpc.Protocol{

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -113,6 +113,7 @@ func (c *CmdChatAPIListen) resolveFilterDisplayNames(ctx context.Context) error 
 
 		}
 	}
+	return nil
 }
 
 func NewCmdChatAPIListenRunner(g *libkb.GlobalContext) *CmdChatAPIListen {

--- a/go/client/cmd_chat_api_listen.go
+++ b/go/client/cmd_chat_api_listen.go
@@ -135,7 +135,7 @@ func (c *CmdChatAPIListen) Run() error {
 	}
 
 	if filterLen := len(chatDisplay.filtersNormalized); filterLen > 0 {
-		c.ErrWriteLn("Message filtering is active: %d filters", filterLen)
+		c.ErrWriteLn("Message filtering is active with %d filters", filterLen)
 		for i, v := range chatDisplay.filtersNormalized {
 			c.ErrWriteLn("filter %d: %+v", i, v)
 		}


### PR DESCRIPTION
Experimental filtering for `api-listen`, for chat messages. It's at the command level, not at the service level, so the messages still go through RPC layer, but they are not printed to consumer.

Example usage:
```
keybase chat api-listen --filter-channels '[{"name":"tuserac88e1@rooter,tuser5ca897,tuserac88e0" }, {"name":"ttca897", "topic_name": "core", "members_type": "team"}]'
keybase chat api-listen --filter-channel '{"name":"tuserac88e1@rooter,tuser5ca897,tuserac88e0" }'
```
