### PR TITLE
Don't restart android activity when low power mode changes

### DIFF
--- a/shared/react-native/android/app/src/main/AndroidManifest.xml
+++ b/shared/react-native/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
         android:screenOrientation="portrait"
         android:launchMode="singleTask"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:windowSoftInputMode="adjustResize"
         android:theme="@style/SplashTheme">
         <intent-filter>


### PR DESCRIPTION
This fixes our chat / gregor notify connection being nuked when low power mode turns on or off. 

This happens because low power mode also triggers `ui_night_mode`, a `uiMode` we didn't declare handling for (see [here](https://developer.android.com/guide/topics/manifest/activity-element#config)). Android's default behavior is to destory / restart our `MainActivity` which we don't support at runtime. If we want to support this in the future for some reason, [this](https://developer.android.com/guide/topics/resources/runtime-changes.html) has more info.

r? @keybase/react-hackers 