### PR TITLE
fix no convos inbox on mobile

### DIFF
--- a/shared/chat/inbox/container/index.js
+++ b/shared/chat/inbox/container/index.js
@@ -7,6 +7,7 @@ import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import Inbox from '..'
 import {isMobile} from '../../../constants/platform'
+import {anyWaiting} from '../../../constants/waiting'
 import {namedConnect} from '../../../util/container'
 import type {Props as _Props, RowItemSmall, RowItemBig} from '../index.types'
 import normalRowData from './normal'
@@ -36,7 +37,7 @@ const mapStateToProps = state => {
     _selectedConversationIDKey: Constants.getSelectedConversation(state),
     allowShowFloatingButton,
     filter,
-    neverLoaded,
+    loading: anyWaiting(state, Constants.waitingKeyInboxRefresh),
     rows,
     smallTeamsExpanded,
   }
@@ -87,7 +88,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   _refreshInbox: dispatchProps._refreshInbox,
   allowShowFloatingButton: stateProps.allowShowFloatingButton,
   filter: stateProps.filter,
-  neverLoaded: stateProps.neverLoaded,
+  loading: stateProps.loading,
   onDeselectConversation: () => dispatchProps._onSelect(Constants.noConversationIDKey),
   onEnsureSelection: () => {
     // $ForceType

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -189,7 +189,7 @@ class Inbox extends React.PureComponent<Props, State> {
       return false
     })
 
-    const noChats = !this.props.neverLoaded && !this.props.rows.length && !this.props.filter && <NoChats />
+    const noChats = !this.props.loading && !this.props.rows.length && !this.props.filter && <NoChats />
     const owl = !this.props.rows.length && !!this.props.filter && <Owl />
     const floatingDivider = this.state.showFloating && this.props.allowShowFloatingButton && (
       <BigTeamsDivider toggle={this.props.toggleSmallTeamsExpanded} />

--- a/shared/chat/inbox/index.stories.js
+++ b/shared/chat/inbox/index.stories.js
@@ -344,7 +344,7 @@ const propsInboxCommon = {
   focusFilter: () => {},
   filter: '',
   filterFocusCount: 0,
-  neverLoaded: false,
+  loading: false,
   nowOverride: 0, // just for dumb rendering
   onDeselectConversation: Sb.action('onDeselectConversation'),
   onNewChat: Sb.action('onNewChat'),

--- a/shared/chat/inbox/index.types.js.flow
+++ b/shared/chat/inbox/index.types.js.flow
@@ -38,7 +38,7 @@ export type Props = {|
   focusFilter: () => void, // withStateHandler function
   filter: string,
   filterFocusCount: number,
-  neverLoaded: boolean,
+  loading: boolean,
   nowOverride?: number, // just for dumb rendering
   onDeselectConversation: () => void,
   onEnsureSelection: () => void,


### PR DESCRIPTION
check if we're loaded instead of `neverLoaded` because that's only set on `metasReceived`, which doesn't happen here. r? @keybase/react-hackers 