### PR TITLE
Profile add-to-team no longer unselects checkboxes

### DIFF
--- a/shared/profile/add-to-team/container.js
+++ b/shared/profile/add-to-team/container.js
@@ -134,7 +134,6 @@ export default compose(
         props.role,
         Object.keys(props.selectedTeams).filter(team => props.selectedTeams[team])
       )
-      props.setSelectedTeams({})
     },
     onToggle: props => (teamname: string) => {
       props.clearAddUserToTeamsResults()


### PR DESCRIPTION
Before this patch clicking "Add to 2 teams" to add a user to teams from their profile deselected all the checkboxes for the duration of the spinner. With this patch the boxes stay selected. It doesn't seem to exhibit the opposite bug of keeping teams selected across sessions.