### PR TITLE
keybase_service_base: pass offline availability to `Resolve3`

### DIFF
--- a/go/kbfs/fsrpc/path.go
+++ b/go/kbfs/fsrpc/path.go
@@ -248,12 +248,14 @@ func (p Path) Join(childName string) (childPath Path, err error) {
 // automatically resolves non-canonical names.
 func ParseTlfHandle(
 	ctx context.Context, kbpki libkbfs.KBPKI, mdOps libkbfs.MDOps,
-	name string, t tlf.Type) (*libkbfs.TlfHandle, error) {
+	osg libkbfs.OfflineStatusGetter, name string, t tlf.Type) (
+	*libkbfs.TlfHandle, error) {
 	var tlfHandle *libkbfs.TlfHandle
 outer:
 	for {
 		var parseErr error
-		tlfHandle, parseErr = libkbfs.ParseTlfHandle(ctx, kbpki, mdOps, name, t)
+		tlfHandle, parseErr = libkbfs.ParseTlfHandle(
+			ctx, kbpki, mdOps, osg, name, t)
 		switch parseErr := errors.Cause(parseErr).(type) {
 		case nil:
 			// No error.
@@ -282,7 +284,7 @@ func (p Path) GetNode(ctx context.Context, config libkbfs.Config) (libkbfs.Node,
 	}
 
 	tlfHandle, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), p.TLFName, p.TLFType)
+		ctx, config.KBPKI(), config.MDOps(), config, p.TLFName, p.TLFType)
 	if err != nil {
 		return nil, libkbfs.EntryInfo{}, err
 	}

--- a/go/kbfs/kbfsgit/runner.go
+++ b/go/kbfs/kbfsgit/runner.go
@@ -158,7 +158,7 @@ func newRunner(ctx context.Context, config libkbfs.Config,
 	}
 
 	h, err := libkbfs.GetHandleFromFolderNameAndType(
-		ctx, config.KBPKI(), config.MDOps(), parts[1], t)
+		ctx, config.KBPKI(), config.MDOps(), config, parts[1], t)
 	if err != nil {
 		return nil, err
 	}
@@ -1123,7 +1123,8 @@ func (r *runner) checkGC(ctx context.Context) (err error) {
 	command := fmt.Sprintf("keybase git gc %s", r.repo)
 	if r.h.Type() == tlf.SingleTeam {
 		tid := r.h.FirstResolvedWriter()
-		teamName, err := r.config.KBPKI().GetNormalizedUsername(ctx, tid)
+		teamName, err := r.config.KBPKI().GetNormalizedUsername(
+			ctx, tid, r.config.OfflineAvailabilityForID(r.h.TlfID()))
 		if err != nil {
 			return err
 		}

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -94,7 +94,7 @@ func testRunnerInitRepo(t *testing.T, tlfType tlf.Type, typeString string) {
 	}()
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlfType)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlfType)
 	require.NoError(t, err)
 	if tlfType != tlf.Public {
 		_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -297,7 +297,7 @@ func testRunnerPushFetch(t *testing.T, cloning bool, secondRepoHasBranch bool) {
 	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func TestRunnerDeleteBranch(t *testing.T) {
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -408,7 +408,7 @@ func TestRunnerExitEarlyOnEOF(t *testing.T) {
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
@@ -447,7 +447,7 @@ func TestForcePush(t *testing.T) {
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -486,7 +486,7 @@ func TestPushAllWithPackedRefs(t *testing.T) {
 	gitExec(t, dotgit, git, "pack-refs", "--all")
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -509,7 +509,7 @@ func TestPushSomeWithPackedRefs(t *testing.T) {
 	defer os.RemoveAll(git)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -648,7 +648,7 @@ func TestRunnerDeletePackedRef(t *testing.T) {
 	gitExec(t, dotgit1, git1, "pack-refs", "--all")
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -751,7 +751,8 @@ func TestPackRefsAndOverwritePackedRef(t *testing.T) {
 		ctx, config2, libkbfs.StallableMDAfterGetRange, 1)
 	packErrCh := make(chan error)
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config2.KBPKI(), config.MDOps(), "user1,user2", tlf.Private)
+		ctx, config2.KBPKI(), config.MDOps(), config, "user1,user2",
+		tlf.Private)
 	require.NoError(t, err)
 	go func() {
 		packErrCh <- libgit.GCRepo(
@@ -838,7 +839,8 @@ func TestPackRefsAndDeletePackedRef(t *testing.T) {
 		ctx, config2, libkbfs.StallableMDAfterGetRange, 1)
 	packErrCh := make(chan error)
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config2.KBPKI(), config.MDOps(), "user1,user2", tlf.Private)
+		ctx, config2.KBPKI(), config.MDOps(), config, "user1,user2",
+		tlf.Private)
 	require.NoError(t, err)
 	go func() {
 		packErrCh <- libgit.GCRepo(
@@ -919,7 +921,7 @@ func TestRepackObjects(t *testing.T) {
 	defer os.RemoveAll(git)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -984,7 +986,7 @@ func TestRunnerWithKBFSReset(t *testing.T) {
 	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -1050,7 +1052,7 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 
 	t.Log("Setup the repository.")
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)

--- a/go/kbfs/kbfsmd/root_metadata.go
+++ b/go/kbfs/kbfsmd/root_metadata.go
@@ -51,11 +51,13 @@ type RootMetadata interface {
 	IsWriter(ctx context.Context, user keybase1.UID,
 		cryptKey kbfscrypto.CryptPublicKey,
 		verifyingKey kbfscrypto.VerifyingKey,
-		teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error)
+		teamMemChecker TeamMembershipChecker, extra ExtraMetadata,
+		offline keybase1.OfflineAvailability) (bool, error)
 	// IsReader returns whether or not the user+device is an authorized reader.
 	IsReader(ctx context.Context, user keybase1.UID,
 		cryptKey kbfscrypto.CryptPublicKey,
-		teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error)
+		teamMemChecker TeamMembershipChecker, extra ExtraMetadata,
+		offline keybase1.OfflineAvailability) (bool, error)
 	// DeepCopy returns a deep copy of the underlying data structure.
 	DeepCopy(codec kbfscodec.Codec) (MutableRootMetadata, error)
 	// MakeSuccessorCopy returns a newly constructed successor
@@ -103,7 +105,8 @@ type RootMetadata interface {
 	// checking with KBPKI.
 	IsValidAndSigned(ctx context.Context, codec kbfscodec.Codec,
 		teamMemChecker TeamMembershipChecker,
-		extra ExtraMetadata, writerVerifyingKey kbfscrypto.VerifyingKey) error
+		extra ExtraMetadata, writerVerifyingKey kbfscrypto.VerifyingKey,
+		offline keybase1.OfflineAvailability) error
 	// IsLastModifiedBy verifies that the RootMetadata is
 	// written by the given user and device (identified by the
 	// device verifying key), and returns an error if not.

--- a/go/kbfs/kbfsmd/root_metadata_signed.go
+++ b/go/kbfs/kbfsmd/root_metadata_signed.go
@@ -153,7 +153,8 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(
 // IsLastModifiedBy), or by checking with KBPKI.
 func (rmds *RootMetadataSigned) IsValidAndSigned(
 	ctx context.Context, codec kbfscodec.Codec,
-	teamMemChecker TeamMembershipChecker, extra ExtraMetadata) error {
+	teamMemChecker TeamMembershipChecker, extra ExtraMetadata,
+	offline keybase1.OfflineAvailability) error {
 	// Optimization -- if the RootMetadata signature is nil, it
 	// will fail verification.
 	if rmds.SigInfo.IsNil() {
@@ -166,8 +167,8 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 	}
 
 	err := rmds.MD.IsValidAndSigned(
-		ctx, codec, teamMemChecker, extra,
-		rmds.WriterSigInfo.VerifyingKey)
+		ctx, codec, teamMemChecker, extra, rmds.WriterSigInfo.VerifyingKey,
+		offline)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/kbfsmd/root_metadata_signed_test.go
+++ b/go/kbfs/kbfsmd/root_metadata_signed_test.go
@@ -45,7 +45,8 @@ func testRootMetadataSignedFinalVerify(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 
 	// verify it
-	err = rmds.IsValidAndSigned(ctx, codec, nil, extra)
+	err = rmds.IsValidAndSigned(
+		ctx, codec, nil, extra, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	ext, err := tlf.NewHandleExtension(
@@ -57,7 +58,8 @@ func testRootMetadataSignedFinalVerify(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 
 	// verify the finalized copy
-	err = rmds2.IsValidAndSigned(ctx, codec, nil, extra)
+	err = rmds2.IsValidAndSigned(
+		ctx, codec, nil, extra, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	// touch something the server shouldn't be allowed to edit for
@@ -67,7 +69,8 @@ func testRootMetadataSignedFinalVerify(t *testing.T, ver MetadataVer) {
 	md3.SetRekeyBit()
 	rmds3 := rmds2
 	rmds2.MD = md3
-	err = rmds3.IsValidAndSigned(ctx, codec, nil, extra)
+	err = rmds3.IsValidAndSigned(
+		ctx, codec, nil, extra, keybase1.OfflineAvailability_NONE)
 	require.NotNil(t, err)
 }
 

--- a/go/kbfs/kbfsmd/root_metadata_v2.go
+++ b/go/kbfs/kbfsmd/root_metadata_v2.go
@@ -319,8 +319,8 @@ func (md *RootMetadataV2) IsFinal() bool {
 // IsWriter implements the RootMetadata interface for RootMetadataV2.
 func (md *RootMetadataV2) IsWriter(
 	_ context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey,
-	_ kbfscrypto.VerifyingKey, _ TeamMembershipChecker, _ ExtraMetadata) (
-	bool, error) {
+	_ kbfscrypto.VerifyingKey, _ TeamMembershipChecker, _ ExtraMetadata,
+	_ keybase1.OfflineAvailability) (bool, error) {
 	if md.ID.Type() != tlf.Private {
 		for _, w := range md.Writers {
 			if w == user.AsUserOrTeam() {
@@ -335,7 +335,8 @@ func (md *RootMetadataV2) IsWriter(
 // IsReader implements the RootMetadata interface for RootMetadataV2.
 func (md *RootMetadataV2) IsReader(
 	_ context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey,
-	_ TeamMembershipChecker, _ ExtraMetadata) (bool, error) {
+	_ TeamMembershipChecker, _ ExtraMetadata,
+	_ keybase1.OfflineAvailability) (bool, error) {
 	switch md.ID.Type() {
 	case tlf.Public:
 		return true, nil
@@ -776,7 +777,7 @@ func (md *RootMetadataV2) GetTLFCryptKeyParams(
 func (md *RootMetadataV2) IsValidAndSigned(
 	_ context.Context, codec kbfscodec.Codec,
 	_ TeamMembershipChecker, extra ExtraMetadata,
-	_ kbfscrypto.VerifyingKey) error {
+	_ kbfscrypto.VerifyingKey, _ keybase1.OfflineAvailability) error {
 	// Optimization -- if the WriterMetadata signature is nil, it
 	// will fail verification.
 	if md.WriterMetadataSigInfo.IsNil() {

--- a/go/kbfs/kbfsmd/team_membership_checker.go
+++ b/go/kbfs/kbfsmd/team_membership_checker.go
@@ -17,11 +17,13 @@ type TeamMembershipChecker interface {
 	// IsTeamWriter checks whether the given user (with the given
 	// verifying key) is a writer of the given team right now.
 	IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID,
-		verifyingKey kbfscrypto.VerifyingKey) (bool, error)
+		verifyingKey kbfscrypto.VerifyingKey,
+		offline keybase1.OfflineAvailability) (bool, error)
 	// IsTeamReader checks whether the given user is a reader of the
 	// given team right now.
-	IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
-		bool, error)
+	IsTeamReader(
+		ctx context.Context, tid keybase1.TeamID, uid keybase1.UID,
+		offline keybase1.OfflineAvailability) (bool, error)
 	// TODO: add Was* method for figuring out whether the user was a
 	// writer/reader at a particular Merkle root.  Not sure whether
 	// these calls should also verify that sequence number corresponds

--- a/go/kbfs/kbfstool/md_common.go
+++ b/go/kbfs/kbfstool/md_common.go
@@ -245,7 +245,7 @@ func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 
 	// Make sure we're a writer before doing anything else.
 	isWriter, err := libkbfs.IsWriterFromHandle(
-		ctx, handle, config.KBPKI(), session.UID, session.VerifyingKey)
+		ctx, handle, config.KBPKI(), config, session.UID, session.VerifyingKey)
 	if err != nil {
 		return libkbfs.ImmutableRootMetadata{}, err
 	}

--- a/go/kbfs/kbfstool/md_common.go
+++ b/go/kbfs/kbfstool/md_common.go
@@ -77,7 +77,8 @@ func mdParseInput(ctx context.Context, config libkbfs.Config,
 }
 
 func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI,
-	mdOps libkbfs.MDOps, tlfStr string) (*libkbfs.TlfHandle, error) {
+	mdOps libkbfs.MDOps, osg libkbfs.OfflineStatusGetter, tlfStr string) (
+	*libkbfs.TlfHandle, error) {
 	p, err := fsrpc.NewPath(tlfStr)
 	if err != nil {
 		return nil, err
@@ -89,7 +90,7 @@ func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI,
 		return nil, fmt.Errorf(
 			"%q is not the root path of a TLF", tlfStr)
 	}
-	return fsrpc.ParseTlfHandle(ctx, kbpki, mdOps, p.TLFName, p.TLFType)
+	return fsrpc.ParseTlfHandle(ctx, kbpki, mdOps, osg, p.TLFName, p.TLFType)
 }
 
 func getTlfID(
@@ -107,7 +108,8 @@ func getTlfID(
 		return tlf.ID{}, err
 	}
 
-	handle, err := parseTLFPath(ctx, config.KBPKI(), config.MDOps(), tlfStr)
+	handle, err := parseTLFPath(
+		ctx, config.KBPKI(), config.MDOps(), config, tlfStr)
 	if err != nil {
 		return tlf.ID{}, err
 	}
@@ -230,7 +232,8 @@ func mdGet(ctx context.Context, config libkbfs.Config, tlfID tlf.ID,
 
 func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 	tlfPath string) (libkbfs.ImmutableRootMetadata, error) {
-	handle, err := parseTLFPath(ctx, config.KBPKI(), config.MDOps(), tlfPath)
+	handle, err := parseTLFPath(
+		ctx, config.KBPKI(), config.MDOps(), config, tlfPath)
 	if err != nil {
 		return libkbfs.ImmutableRootMetadata{}, err
 	}

--- a/go/kbfs/kbfstool/md_dump_common.go
+++ b/go/kbfs/kbfstool/md_dump_common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
 
@@ -68,7 +69,8 @@ func mdDumpFillReplacements(ctx context.Context, codec kbfscodec.Codec,
 			}
 
 			username, _, err := service.Resolve(
-				ctx, fmt.Sprintf("uid:%s", u))
+				ctx, fmt.Sprintf("uid:%s", u),
+				keybase1.OfflineAvailability_NONE)
 			if err == nil {
 				replacements[u.String()] = fmt.Sprintf(
 					"%s (uid:%s)", username, u)

--- a/go/kbfs/kbfstool/md_force_qr.go
+++ b/go/kbfs/kbfstool/md_force_qr.go
@@ -40,7 +40,7 @@ func mdForceQROne(
 
 	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
 		config.Codec(), config.KeyManager(),
-		config.KBPKI(), config.KBPKI(), irmd.MdID(), true)
+		config.KBPKI(), config.KBPKI(), config, irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/kbfstool/md_reset.go
+++ b/go/kbfs/kbfstool/md_reset.go
@@ -45,7 +45,7 @@ func mdResetOne(
 
 	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
 		config.Codec(), config.KeyManager(),
-		config.KBPKI(), config.KBPKI(), irmd.MdID(), true)
+		config.KBPKI(), config.KBPKI(), config, irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libdokan/dir.go
+++ b/go/kbfs/libdokan/dir.go
@@ -203,7 +203,7 @@ func (f *Folder) resolve(ctx context.Context) (*libkbfs.TlfHandle, error) {
 	if f.h.TlfID() == tlf.NullID {
 		// If the handle doesn't have a TLF ID yet, fetch it now.
 		handle, err := libkbfs.ParseTlfHandlePreferred(
-			ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(),
+			ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(), f.fs.config,
 			string(f.hPreferredName), f.h.Type())
 		if err != nil {
 			return nil, err
@@ -218,7 +218,7 @@ func (f *Folder) resolve(ctx context.Context) (*libkbfs.TlfHandle, error) {
 	// updates yet for this folder, we might have missed a name
 	// change.
 	handle, err := f.h.ResolveAgain(
-		ctx, f.fs.config.KBPKI(), f.fs.config.MDOps())
+		ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(), f.fs.config)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libdokan/folderlist.go
+++ b/go/kbfs/libdokan/folderlist.go
@@ -130,7 +130,7 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 		}
 
 		h, err := libfs.ParseTlfHandlePreferredQuick(
-			ctx, fl.fs.config.KBPKI(), name, fl.tlfType)
+			ctx, fl.fs.config.KBPKI(), fl.fs.config, name, fl.tlfType)
 		fl.fs.log.CDebugf(ctx, "FL Lookup continuing -> %v,%v", h, err)
 		switch e := errors.Cause(err).(type) {
 		case nil:

--- a/go/kbfs/libdokan/fs.go
+++ b/go/kbfs/libdokan/fs.go
@@ -574,7 +574,7 @@ func (f *FS) folderListRename(ctx context.Context, fl *FolderList, oc *openConte
 	dstName := dstPath[len(dstPath)-1]
 	// Yes, this is slow, but that is ok here.
 	if _, err := libkbfs.ParseTlfHandlePreferred(
-		ctx, f.config.KBPKI(), f.config.MDOps(), dstName,
+		ctx, f.config.KBPKI(), f.config.MDOps(), f.config, dstName,
 		fl.tlfType); err != nil {
 		return dokan.ErrObjectNameNotFound
 	}

--- a/go/kbfs/libfs/file_info.go
+++ b/go/kbfs/libfs/file_info.go
@@ -44,7 +44,8 @@ func (fi *FileInfo) Size() int64 {
 // Mode implements the os.FileInfo interface for FileInfo.
 func (fi *FileInfo) Mode() os.FileMode {
 	mode, err := WritePermMode(
-		fi.fs.ctx, fi.node, os.FileMode(0), fi.fs.config.KBPKI(), fi.fs.h)
+		fi.fs.ctx, fi.node, os.FileMode(0), fi.fs.config.KBPKI(),
+		fi.fs.config, fi.fs.h)
 	if err != nil {
 		fi.fs.log.CWarningf(
 			fi.fs.ctx, "Couldn't get mode for file %s: %+v", fi.Name(), err)

--- a/go/kbfs/libfs/file_info.go
+++ b/go/kbfs/libfs/file_info.go
@@ -137,7 +137,9 @@ func (fis fileInfoSys) KBFSMetadataForSimpleFS() (
 	}
 
 	_, id, err := fis.fi.fs.config.KBPKI().Resolve(
-		fis.fi.fs.ctx, lastWriterName.String())
+		fis.fi.fs.ctx, lastWriterName.String(),
+		fis.fi.fs.config.OfflineAvailabilityForID(
+			fis.fi.fs.root.GetFolderBranch().Tlf))
 	if err != nil {
 		return KBFSMetadataForSimpleFS{}, err
 	}

--- a/go/kbfs/libfs/fs_test.go
+++ b/go/kbfs/libfs/fs_test.go
@@ -27,7 +27,7 @@ func makeFSWithBranch(t *testing.T, branch libkbfs.BranchName, subdir string) (
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	config := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	fs, err := NewFS(
 		ctx, config, h, branch, subdir, "", keybase1.MDPriorityNormal)
@@ -65,7 +65,7 @@ func makeFSWithJournal(t *testing.T, subdir string) (
 	}
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	fs, err := NewFS(
 		ctx, config, h, libkbfs.MasterBranch, subdir, "",
@@ -275,7 +275,7 @@ func TestStat(t *testing.T) {
 	config2.SetClock(clock)
 
 	h2, err := libkbfs.ParseTlfHandle(
-		ctx, config2.KBPKI(), config2.MDOps(), "user2#user1", tlf.Private)
+		ctx, config2.KBPKI(), config2.MDOps(), nil, "user2#user1", tlf.Private)
 	require.NoError(t, err)
 	fs2U2, err := NewFS(
 		ctx, config2, h2, libkbfs.MasterBranch, "", "",
@@ -708,7 +708,7 @@ func TestEmptyFS(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	fs, err := NewFSIfExists(
 		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)

--- a/go/kbfs/libfs/mode.go
+++ b/go/kbfs/libfs/mode.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 // IsWriter returns whether or not the currently logged-in user is a
 // valid writer for the folder described by `h`.
 func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
-	h *libkbfs.TlfHandle) (bool, error) {
+	osg libkbfs.OfflineStatusGetter, h *libkbfs.TlfHandle) (bool, error) {
 	session, err := libkbfs.GetCurrentSessionIfPossible(
 		ctx, kbpki, h.Type() == tlf.Public)
 	// We are using GetCurrentUserInfoIfPossible here so err is only non-nil if
@@ -29,8 +30,12 @@ func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
 		if err != nil {
 			return false, err
 		}
+		offline := keybase1.OfflineAvailability_NONE
+		if osg != nil {
+			offline = osg.OfflineAvailabilityForID(h.TlfID())
+		}
 		isWriter, err := kbpki.IsTeamWriter(
-			ctx, tid, session.UID, session.VerifyingKey)
+			ctx, tid, session.UID, session.VerifyingKey, offline)
 		if err != nil {
 			return false, err
 		}
@@ -44,14 +49,15 @@ func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
 // by `h`.
 func WritePermMode(
 	ctx context.Context, node libkbfs.Node, original os.FileMode,
-	kbpki libkbfs.KBPKI, h *libkbfs.TlfHandle) (os.FileMode, error) {
+	kbpki libkbfs.KBPKI, osg libkbfs.OfflineStatusGetter,
+	h *libkbfs.TlfHandle) (os.FileMode, error) {
 	original &^= os.FileMode(0222) // clear write perm bits
 
 	if node != nil && node.Readonly(ctx) {
 		return original, nil
 	}
 
-	isWriter, err := IsWriter(ctx, kbpki, h)
+	isWriter, err := IsWriter(ctx, kbpki, osg, h)
 	if err != nil {
 		return 0, err
 	}

--- a/go/kbfs/libfs/tlf_handle_util.go
+++ b/go/kbfs/libfs/tlf_handle_util.go
@@ -28,10 +28,11 @@ func (nitk noImplicitTeamKBPKI) ResolveImplicitTeam(
 // doing this time consuming checks needed for implicit-team checking
 // or TLF-ID-fetching.
 func ParseTlfHandlePreferredQuick(
-	ctx context.Context, kbpki libkbfs.KBPKI, name string, ty tlf.Type) (
+	ctx context.Context, kbpki libkbfs.KBPKI, osg libkbfs.OfflineStatusGetter,
+	name string, ty tlf.Type) (
 	handle *libkbfs.TlfHandle, err error) {
 	// Override the KBPKI with one that doesn't try to resolve
 	// implicit teams.
 	kbpki = noImplicitTeamKBPKI{kbpki}
-	return libkbfs.ParseTlfHandlePreferred(ctx, kbpki, nil, name, ty)
+	return libkbfs.ParseTlfHandlePreferred(ctx, kbpki, nil, osg, name, ty)
 }

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -150,7 +150,7 @@ func (f *Folder) resolve(ctx context.Context) (*libkbfs.TlfHandle, error) {
 	if f.h.TlfID() == tlf.NullID {
 		// If the handle doesn't have a TLF ID yet, fetch it now.
 		handle, err := libkbfs.ParseTlfHandlePreferred(
-			ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(),
+			ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(), f.fs.config,
 			string(f.hPreferredName), f.h.Type())
 		if err != nil {
 			return nil, err
@@ -165,7 +165,7 @@ func (f *Folder) resolve(ctx context.Context) (*libkbfs.TlfHandle, error) {
 	// updates yet for this folder, we might have missed a name
 	// change.
 	handle, err := f.h.ResolveAgain(
-		ctx, f.fs.config.KBPKI(), f.fs.config.MDOps())
+		ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(), f.fs.config)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -359,7 +359,8 @@ func (f *Folder) writePermMode(ctx context.Context,
 	node libkbfs.Node, original os.FileMode) (os.FileMode, error) {
 	f.handleMu.RLock()
 	defer f.handleMu.RUnlock()
-	return libfs.WritePermMode(ctx, node, original, f.fs.config.KBPKI(), f.h)
+	return libfs.WritePermMode(
+		ctx, node, original, f.fs.config.KBPKI(), f.fs.config, f.h)
 }
 
 // fillAttrWithUIDAndWritePerm sets attributes based on the entry info, and
@@ -387,7 +388,7 @@ func (f *Folder) fillAttrWithUIDAndWritePerm(
 func (f *Folder) isWriter(ctx context.Context) (bool, error) {
 	f.handleMu.RLock()
 	defer f.handleMu.RUnlock()
-	return libfs.IsWriter(ctx, f.fs.config.KBPKI(), f.h)
+	return libfs.IsWriter(ctx, f.fs.config.KBPKI(), f.fs.config, f.h)
 }
 
 func (f *Folder) access(ctx context.Context, r *fuse.AccessRequest) error {

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -189,7 +189,7 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 	}
 
 	h, err := libfs.ParseTlfHandlePreferredQuick(
-		ctx, fl.fs.config.KBPKI(), req.Name, fl.tlfType)
+		ctx, fl.fs.config.KBPKI(), fl.fs.config, req.Name, fl.tlfType)
 	switch e := errors.Cause(err).(type) {
 	case nil:
 		// no error
@@ -284,7 +284,7 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 	defer func() { err = fl.fs.processError(ctx, libkbfs.WriteMode, err) }()
 
 	h, err := libfs.ParseTlfHandlePreferredQuick(
-		ctx, fl.fs.config.KBPKI(), req.Name, fl.tlfType)
+		ctx, fl.fs.config.KBPKI(), fl.fs.config, req.Name, fl.tlfType)
 
 	switch err := errors.Cause(err).(type) {
 	case nil:

--- a/go/kbfs/libgit/autogit_manager.go
+++ b/go/kbfs/libgit/autogit_manager.go
@@ -184,7 +184,7 @@ func (am *AutogitManager) removeSelfCheckouts() {
 
 	h, err := libkbfs.GetHandleFromFolderNameAndType(
 		ctx, am.config.KBPKI(), am.config.MDOps(),
-		string(session.Name), tlf.Private)
+		am.config, string(session.Name), tlf.Private)
 	if err != nil {
 		am.log.CDebugf(ctx,
 			"Unable to get private handle; ignoring self-autogit delete: +%v",

--- a/go/kbfs/libgit/autogit_node_wrappers_test.go
+++ b/go/kbfs/libgit/autogit_node_wrappers_test.go
@@ -27,7 +27,7 @@ func TestAutogitNodeWrappersNoRepos(t *testing.T) {
 	defer shutdown()
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
 		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)
@@ -80,7 +80,7 @@ func TestAutogitRepoNode(t *testing.T) {
 	config.AddRootNodeWrapper(rw.wrap)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
 		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)
@@ -182,7 +182,7 @@ func TestAutogitRepoNodeReadonly(t *testing.T) {
 	config.AddRootNodeWrapper(rw.wrap)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Public)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Public)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
 		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)

--- a/go/kbfs/libgit/browser_test.go
+++ b/go/kbfs/libgit/browser_test.go
@@ -27,7 +27,7 @@ func testBrowser(t *testing.T, sharedCache sharedInBrowserCache) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
 		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)

--- a/go/kbfs/libgit/repo_test.go
+++ b/go/kbfs/libgit/repo_test.go
@@ -54,7 +54,7 @@ func TestGetOrCreateRepoAndID(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
 	fs, id1, err := GetOrCreateRepoAndID(ctx, config, h, "Repo1", "")
@@ -109,7 +109,7 @@ func TestCreateRepoAndID(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
 	id1, err := CreateRepoAndID(ctx, config, h, "Repo1")
@@ -158,7 +158,7 @@ func TestCreateDuplicateRepo(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx2, t, config2)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1,user2", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1,user2", tlf.Private)
 	require.NoError(t, err)
 
 	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
@@ -228,7 +228,7 @@ func TestGetRepoAndID(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
 	_, _, err = GetRepoAndID(ctx, config, h, "Repo1", "")
@@ -265,7 +265,7 @@ func TestDeleteRepo(t *testing.T) {
 	config.SetClock(clock)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
 	_, err = CreateRepoAndID(ctx, config, h, "Repo1")
@@ -322,7 +322,7 @@ func TestRepoRename(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
 	id1, err := CreateRepoAndID(ctx, config, h, "Repo1")

--- a/go/kbfs/libgit/rpc.go
+++ b/go/kbfs/libgit/rpc.go
@@ -117,7 +117,7 @@ func (rh *RPCHandler) getHandleAndConfig(
 	// Use `gitConfig`, rather than `rh.config`, to make sure the
 	// journal is created under the right journal server.
 	tlfHandle, err = libkbfs.GetHandleFromFolderNameAndType(
-		ctx, gitConfig.KBPKI(), gitConfig.MDOps(), folder.Name,
+		ctx, gitConfig.KBPKI(), gitConfig.MDOps(), gitConfig, folder.Name,
 		tlf.TypeFromFolderType(folder.FolderType))
 	if err != nil {
 		return nil, nil, nil, "", err

--- a/go/kbfs/libhttpserver/server.go
+++ b/go/kbfs/libhttpserver/server.go
@@ -112,7 +112,7 @@ func (s *Server) getHTTPFileSystem(ctx context.Context, requestPath string) (
 	}
 
 	tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(ctx,
-		s.config.KBPKI(), s.config.MDOps(), fields[1], tlfType)
+		s.config.KBPKI(), s.config.MDOps(), s.config, fields[1], tlfType)
 	if err != nil {
 		return "", nil, err
 	}

--- a/go/kbfs/libhttpserver/server_test.go
+++ b/go/kbfs/libhttpserver/server_test.go
@@ -42,7 +42,7 @@ func makeTestKBFSConfig(t *testing.T) (
 	}
 
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, cfg.KBPKI(), cfg.MDOps(), "alice,bob", tlf.Private)
+		ctx, cfg.KBPKI(), cfg.MDOps(), cfg, "alice,bob", tlf.Private)
 	require.NoError(t, err)
 
 	root, _, err := cfg.KBFSOps().GetOrCreateRootNode(ctx, h, libkbfs.MasterBranch)

--- a/go/kbfs/libkbfs/chat_local.go
+++ b/go/kbfs/libkbfs/chat_local.go
@@ -137,7 +137,8 @@ func (c *chatLocal) GetConversationID(
 		if err != nil {
 			return nil, err
 		}
-		isReader, err := isReaderFromHandle(ctx, h, config.KBPKI(), session.UID)
+		isReader, err := isReaderFromHandle(
+			ctx, h, config.KBPKI(), config, session.UID)
 		if err != nil {
 			return nil, err
 		}
@@ -242,7 +243,7 @@ func (c *chatLocal) GetGroupedInbox(
 
 			// Only include if the current user can read the folder.
 			isReader, err := isReaderFromHandle(
-				ctx, h, c.config.KBPKI(), session.UID)
+				ctx, h, c.config.KBPKI(), c.config, session.UID)
 			if err != nil {
 				return nil, err
 			}

--- a/go/kbfs/libkbfs/chat_local.go
+++ b/go/kbfs/libkbfs/chat_local.go
@@ -126,7 +126,8 @@ func (c *chatLocal) GetConversationID(
 	c.data.convsByID[id.String()] = conv
 
 	h, err := GetHandleFromFolderNameAndType(
-		ctx, c.config.KBPKI(), c.config.MDOps(), string(tlfName), tlfType)
+		ctx, c.config.KBPKI(), c.config.MDOps(), c.config,
+		string(tlfName), tlfType)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,8 @@ func (c *chatLocal) GetGroupedInbox(
 			}
 
 			h, err := GetHandleFromFolderNameAndType(
-				ctx, c.config.KBPKI(), c.config.MDOps(), string(name), t)
+				ctx, c.config.KBPKI(), c.config.MDOps(), c.config,
+				string(name), t)
 			if err != nil {
 				return nil, err
 			}
@@ -271,7 +273,7 @@ func (c *chatLocal) GetGroupedInbox(
 	for i := len(c.selfConvInfos) - 1; i >= 0 && len(selfHandles) < max; i-- {
 		info := c.selfConvInfos[i]
 		h, err := GetHandleFromFolderNameAndType(
-			ctx, c.config.KBPKI(), c.config.MDOps(),
+			ctx, c.config.KBPKI(), c.config.MDOps(), c.config,
 			string(info.tlfName), info.tlfType)
 		if err != nil {
 			return nil, err

--- a/go/kbfs/libkbfs/chat_rpc.go
+++ b/go/kbfs/libkbfs/chat_rpc.go
@@ -378,7 +378,8 @@ func (c *ChatRPC) getLastSelfWrittenHandles(
 			tlfName := selfMessage.Folder.Name
 			tlfType := tlf.TypeFromFolderType(selfMessage.Folder.FolderType)
 			h, err := GetHandleFromFolderNameAndType(
-				ctx, c.config.KBPKI(), c.config.MDOps(), tlfName, tlfType)
+				ctx, c.config.KBPKI(), c.config.MDOps(), c.config,
+				tlfName, tlfType)
 			if err != nil {
 				c.log.CDebugf(ctx,
 					"Ignoring errors getting handle for %s/%s: %+v",
@@ -459,7 +460,8 @@ func (c *ChatRPC) GetGroupedInbox(
 		}
 
 		h, err := GetHandleFromFolderNameAndType(
-			ctx, c.config.KBPKI(), c.config.MDOps(), info.TlfName, tlfType)
+			ctx, c.config.KBPKI(), c.config.MDOps(), c.config,
+			info.TlfName, tlfType)
 		if err != nil {
 			c.log.CDebugf(ctx, "Ignoring errors getting handle for %s/%s: %+v",
 				info.TlfName, tlfType, err)
@@ -628,7 +630,7 @@ func (c *ChatRPC) newNotificationChannel(
 	}
 
 	tlfHandle, err := GetHandleFromFolderNameAndType(
-		ctx, c.config.KBPKI(), c.config.MDOps(), conv.Name, tlfType)
+		ctx, c.config.KBPKI(), c.config.MDOps(), c.config, conv.Name, tlfType)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -2491,7 +2491,8 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 	newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCacheSimple) error {
 	mergedMD := mergedChains.mostRecentChainMDInfo
 	chargedTo, err := chargedToForTLF(
-		ctx, cr.config.KBPKI(), cr.config.KBPKI(), mergedMD.GetTlfHandle())
+		ctx, cr.config.KBPKI(), cr.config.KBPKI(), cr.config,
+		mergedMD.GetTlfHandle())
 	if err != nil {
 		return err
 	}
@@ -2686,7 +2687,7 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 	newMD, err := mostRecentMergedMD.MakeSuccessor(
 		ctx, cr.config.MetadataVersion(), cr.config.Codec(),
 		cr.config.KeyManager(), cr.config.KBPKI(),
-		cr.config.KBPKI(), mostRecentMergedMD.MdID(), true)
+		cr.config.KBPKI(), cr.config, mostRecentMergedMD.MdID(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -33,7 +33,8 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	fbo := newFolderBranchOps(ctx, env.EmptyAppStateUpdater{}, config,
 		FolderBranch{id, MasterBranch}, standard, nil, nil)
 	// usernames don't matter for these tests
-	config.mockKbpki.EXPECT().GetNormalizedUsername(gomock.Any(), gomock.Any()).
+	config.mockKbpki.EXPECT().GetNormalizedUsername(
+		gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().Return(kbname.NormalizedUsername("mockUser"), nil)
 
 	mockDaemon := NewMockKeybaseService(mockCtrl)

--- a/go/kbfs/libkbfs/cr_chains_test.go
+++ b/go/kbfs/libkbfs/cr_chains_test.go
@@ -160,7 +160,8 @@ func newChainMDForTest(t *testing.T) rootMetadataWithKeyAndTimestamp {
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(ctx, bh, bh.Type(), nil, nug, nil)
+	h, err := MakeTlfHandle(
+		ctx, bh, bh.Type(), nil, nug, nil, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	rmd, err := makeInitialRootMetadata(defaultClientMetadataVer, tlfID, h)

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1057,7 +1057,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 		return err
 	}
 	isWriter, err := head.IsWriter(
-		ctx, fbm.config.KBPKI(), session.UID, session.VerifyingKey)
+		ctx, fbm.config.KBPKI(), fbm.config, session.UID, session.VerifyingKey)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1042,7 +1042,8 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	head, err := fbm.helper.getMostRecentFullyMergedMD(ctx)
 	if err != nil {
 		return err
-	} else if err := isReadableOrError(ctx, fbm.config.KBPKI(), head.ReadOnly()); err != nil {
+	} else if err := isReadableOrError(
+		ctx, fbm.config.KBPKI(), fbm.config, head.ReadOnly()); err != nil {
 		return err
 	} else if head.MergedStatus() != kbfsmd.Merged {
 		return errors.New("Supposedly fully-merged MD is unexpectedly unmerged")

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -789,7 +789,8 @@ func (fbo *folderBlockOps) getChargedToLocked(
 		return fbo.chargedTo, nil
 	}
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), fbo.config,
+		kmd.GetTlfHandle())
 	if err != nil {
 		return keybase1.UserOrTeamID(""), err
 	}
@@ -817,7 +818,8 @@ func (fbo *folderBlockOps) deepCopyFileLocked(
 	// so only a read lock is needed.
 	fbo.blockLock.AssertRLocked(lState)
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), fbo.config,
+		kmd.GetTlfHandle())
 	if err != nil {
 		return BlockPointer{}, nil, err
 	}
@@ -1939,7 +1941,7 @@ func (fbo *folderBlockOps) writeGetFileLocked(
 		return nil, err
 	}
 	isWriter, err := kmd.IsWriter(
-		ctx, fbo.config.KBPKI(), session.UID, session.VerifyingKey)
+		ctx, fbo.config.KBPKI(), fbo.config, session.UID, session.VerifyingKey)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/folder_branch_status.go
+++ b/go/kbfs/libkbfs/folder_branch_status.go
@@ -214,7 +214,8 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 		fbs.Staged = fbsk.md.IsUnmergedSet()
 		fbs.BranchID = fbsk.md.BID().String()
 		name, err := fbsk.config.KBPKI().GetNormalizedUsername(
-			ctx, fbsk.md.LastModifyingWriter().AsUserOrTeam())
+			ctx, fbsk.md.LastModifyingWriter().AsUserOrTeam(),
+			fbsk.config.OfflineAvailabilityForID(tlfID))
 		if err != nil {
 			return FolderBranchStatus{}, nil, tlf.NullID, err
 		}

--- a/go/kbfs/libkbfs/folder_branch_status.go
+++ b/go/kbfs/libkbfs/folder_branch_status.go
@@ -238,7 +238,7 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 			loggerSuffix := fmt.Sprintf("status-%s", fbsk.md.TlfID())
 			chargedTo, err := chargedToForTLF(
 				ctx, fbsk.config.KBPKI(), fbsk.config.KBPKI(),
-				fbsk.md.GetTlfHandle())
+				fbsk.config, fbsk.md.GetTlfHandle())
 			if err != nil {
 				return FolderBranchStatus{}, nil, tlf.NullID, err
 			}

--- a/go/kbfs/libkbfs/folder_update_prepper.go
+++ b/go/kbfs/libkbfs/folder_update_prepper.go
@@ -1162,7 +1162,8 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 	updates = make(map[BlockPointer]BlockPointer)
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fup.config.KBPKI(), fup.config.KBPKI(), md.GetTlfHandle())
+		ctx, fup.config.KBPKI(), fup.config.KBPKI(), fup.config,
+		md.GetTlfHandle())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/kbfs/libkbfs/identify_util.go
+++ b/go/kbfs/libkbfs/identify_util.go
@@ -190,8 +190,9 @@ func getExtendedIdentify(ctx context.Context) (ei *extendedIdentify) {
 // identifyUID performs identify based only on UID. It should be
 // used only if the username is not known - as e.g. when rekeying.
 func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, id keybase1.UserOrTeamID, t tlf.Type) error {
-	name, err := nug.GetNormalizedUsername(ctx, id)
+	identifier identifier, id keybase1.UserOrTeamID, t tlf.Type,
+	offline keybase1.OfflineAvailability) error {
+	name, err := nug.GetNormalizedUsername(ctx, id, offline)
 	if err != nil {
 		return err
 	}
@@ -301,7 +302,8 @@ func identifyUsers(ctx context.Context, nug normalizedUsernameGetter,
 // identifyUserList identifies the users in the given list.
 // Only use this when the usernames are not known - like when rekeying.
 func identifyUserList(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, ids []keybase1.UserOrTeamID, t tlf.Type) error {
+	identifier identifier, ids []keybase1.UserOrTeamID, t tlf.Type,
+	offline keybase1.OfflineAvailability) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	// TODO: limit the number of concurrent identifies?
@@ -310,7 +312,8 @@ func identifyUserList(ctx context.Context, nug normalizedUsernameGetter,
 		// Capture range variable.
 		id := id
 		eg.Go(func() error {
-			return identifyUID(ctx, nug, identifier, id, t)
+			return identifyUID(
+				ctx, nug, identifier, id, t, offline)
 		})
 	}
 

--- a/go/kbfs/libkbfs/identify_util_test.go
+++ b/go/kbfs/libkbfs/identify_util_test.go
@@ -21,8 +21,8 @@ import (
 type testNormalizedUsernameGetter map[keybase1.UserOrTeamID]kbname.NormalizedUsername
 
 func (g testNormalizedUsernameGetter) GetNormalizedUsername(
-	ctx context.Context, id keybase1.UserOrTeamID) (
-	kbname.NormalizedUsername, error) {
+	ctx context.Context, id keybase1.UserOrTeamID,
+	_ keybase1.OfflineAvailability) (kbname.NormalizedUsername, error) {
 	name, ok := g[id]
 	if !ok {
 		return kbname.NormalizedUsername(""),

--- a/go/kbfs/libkbfs/interface_test.go
+++ b/go/kbfs/libkbfs/interface_test.go
@@ -112,6 +112,22 @@ func (t *testSyncedTlfGetterSetter) GetAllSyncedTlfs() []tlf.ID {
 	return tlfs
 }
 
+func (t *testSyncedTlfGetterSetter) OfflineAvailabilityForPath(
+	tlfPath string) keybase1.OfflineAvailability {
+	if t.IsSyncedTlfPath(tlfPath) {
+		return keybase1.OfflineAvailability_BEST_EFFORT
+	}
+	return keybase1.OfflineAvailability_NONE
+}
+
+func (t *testSyncedTlfGetterSetter) OfflineAvailabilityForID(
+	tlfID tlf.ID) keybase1.OfflineAvailability {
+	if t.IsSyncedTlf(tlfID) {
+		return keybase1.OfflineAvailability_BEST_EFFORT
+	}
+	return keybase1.OfflineAvailability_NONE
+}
+
 type testInitModeGetter struct {
 	mode InitModeType
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -670,8 +670,15 @@ type KeybaseService interface {
 		ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error
 
 	// GetTeamSettings returns the KBFS settings for the given team.
-	GetTeamSettings(ctx context.Context, teamID keybase1.TeamID) (
-		keybase1.KBFSTeamSettings, error)
+	//
+	// If the caller knows that the settings needs to be readable
+	// while offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `GetTeamSettings` might block on a
+	// network call.
+	GetTeamSettings(
+		ctx context.Context, teamID keybase1.TeamID,
+		offline keybase1.OfflineAvailability) (keybase1.KBFSTeamSettings, error)
 
 	// LoadUserPlusKeys returns a UserInfo struct for a
 	// user with the specified UID.
@@ -797,8 +804,15 @@ type resolver interface {
 	// ResolveTeamTLFID returns the TLF ID associated with a given
 	// team ID, or tlf.NullID if no ID is yet associated with that
 	// team.
-	ResolveTeamTLFID(ctx context.Context, teamID keybase1.TeamID) (
-		tlf.ID, error)
+	//
+	// If the caller knows that the ID needs to be resolved while
+	// offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `ResolveTeamTLFID` might block on a
+	// network call.
+	ResolveTeamTLFID(
+		ctx context.Context, teamID keybase1.TeamID,
+		offline keybase1.OfflineAvailability) (tlf.ID, error)
 	// NormalizeSocialAssertion creates a SocialAssertion from its input and
 	// normalizes it.  The service name will be lowercased.  If the service is
 	// case-insensitive, then the username will also be lowercased.  Colon

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -244,7 +244,8 @@ func (j *JournalManager) getTLFJournal(
 		// the first write that happens after the user becomes a
 		// writer for the TLF.
 		isWriter, err := IsWriterFromHandle(
-			ctx, h, j.config.KBPKI(), j.currentUID, j.currentVerifyingKey)
+			ctx, h, j.config.KBPKI(), j.config, j.currentUID,
+			j.currentVerifyingKey)
 		if err != nil {
 			j.log.CWarningf(ctx, "Couldn't find writership for %s: %+v",
 				tlfID, err)
@@ -639,7 +640,8 @@ func (j *JournalManager) Enable(ctx context.Context, tlfID tlf.ID,
 		chargedTo = h.FirstResolvedWriter()
 		if tid := chargedTo.AsTeamOrBust(); tid.IsSubTeam() {
 			// We can't charge to subteams; find the root team.
-			rootID, err := j.config.KBPKI().GetTeamRootID(ctx, tid)
+			rootID, err := j.config.KBPKI().GetTeamRootID(
+				ctx, tid, j.config.OfflineAvailabilityForID(tlfID))
 			if err != nil {
 				return err
 			}

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -300,7 +300,8 @@ func (j *JournalManager) makeFBOForJournal(
 
 	handle, err := MakeTlfHandle(
 		ctx, headBareHandle, tlfID.Type(), j.config.KBPKI(),
-		j.config.KBPKI(), constIDGetter{tlfID})
+		j.config.KBPKI(), constIDGetter{tlfID},
+		j.config.OfflineAvailabilityForID(tlfID))
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/journal_manager_test.go
+++ b/go/kbfs/libkbfs/journal_manager_test.go
@@ -178,13 +178,13 @@ func TestJournalManagerOverQuotaError(t *testing.T) {
 	require.NoError(t, err)
 	tlfID2 := tlf.FakeID(2, tlf.SingleTeam)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "t1", tlf.SingleTeam)
+		ctx, config.KBPKI(), config.MDOps(), nil, "t1", tlf.SingleTeam)
 	require.NoError(t, err)
 	err = jManager.Enable(ctx, tlfID2, h, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 	tlfID3 := tlf.FakeID(2, tlf.SingleTeam)
 	h, err = ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "t1.sub", tlf.SingleTeam)
+		ctx, config.KBPKI(), config.MDOps(), nil, "t1.sub", tlf.SingleTeam)
 	require.NoError(t, err)
 	err = jManager.Enable(ctx, tlfID3, h, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestJournalManagerOverQuotaError(t *testing.T) {
 	blockServer := config.BlockServer()
 
 	h, err = ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user1,test_user2",
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1,test_user2",
 		tlf.Private)
 	require.NoError(t, err)
 	id1 := h.ResolvedWriters()[0]
@@ -311,7 +311,7 @@ func TestJournalManagerOverDiskLimitError(t *testing.T) {
 	blockServer := config.BlockServer()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user1,test_user2",
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1,test_user2",
 		tlf.Private)
 	require.NoError(t, err)
 	id1 := h.ResolvedWriters()[0]
@@ -382,7 +382,7 @@ func TestJournalManagerRestart(t *testing.T) {
 	mdOps := config.MDOps()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
 
@@ -456,7 +456,7 @@ func TestJournalManagerLogOutLogIn(t *testing.T) {
 	mdOps := config.MDOps()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
 
@@ -565,7 +565,7 @@ func TestJournalManagerMultiUser(t *testing.T) {
 	mdOps := config.MDOps()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user1,test_user2",
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1,test_user2",
 		tlf.Private)
 	require.NoError(t, err)
 	id1 := h.ResolvedWriters()[0]
@@ -735,7 +735,7 @@ func TestJournalManagerEnableAuto(t *testing.T) {
 
 	blockServer := config.BlockServer()
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
 	tlfID := h.tlfID
@@ -795,7 +795,7 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 	// initializes the journal if possible.  In this case for a
 	// public, unwritable folder, it shouldn't.
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user2", tlf.Public)
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user2", tlf.Public)
 	require.NoError(t, err)
 
 	status, tlfIDs = jManager.Status(ctx)
@@ -805,7 +805,7 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 
 	// Neither should a private, reader folder.
 	h, err = ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user2#test_user1",
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user2#test_user1",
 		tlf.Private)
 	require.NoError(t, err)
 
@@ -823,7 +823,8 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 	AddTeamReaderForTestOrBust(
 		t, config, id, h.ResolvedReaders()[0].AsUserOrBust())
 	h, err = ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(teamName), tlf.SingleTeam)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(teamName),
+		tlf.SingleTeam)
 	require.NoError(t, err)
 
 	status, tlfIDs = jManager.Status(ctx)
@@ -833,7 +834,7 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 
 	// But accessing our own should make one.
 	h, err = ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user1", tlf.Public)
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Public)
 	require.NoError(t, err)
 
 	status, tlfIDs = jManager.Status(ctx)
@@ -856,7 +857,7 @@ func TestJournalManagerNukeEmptyJournalsOnRestart(t *testing.T) {
 
 	blockServer := config.BlockServer()
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "test_user1", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
 	tlfID := h.tlfID
@@ -919,7 +920,7 @@ func TestJournalManagerTeamTLFWithRestart(t *testing.T) {
 	jManager.delegateBlockServer = shutdownOnlyBlockServer{}
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.SingleTeam)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.SingleTeam)
 	require.NoError(t, err)
 
 	tlfID := tlf.FakeID(2, tlf.SingleTeam)

--- a/go/kbfs/libkbfs/journal_md_ops.go
+++ b/go/kbfs/libkbfs/journal_md_ops.go
@@ -60,8 +60,8 @@ func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 	config := j.jManager.config
 	pmd, err := decryptMDPrivateData(ctx, config.Codec(), config.Crypto(),
 		config.BlockCache(), config.BlockOps(), config.KeyManager(),
-		config.KBPKI(), config.Mode(), uid, rmd.GetSerializedPrivateMetadata(),
-		rmd, rmd, j.jManager.log)
+		config.KBPKI(), config, config.Mode(), uid,
+		rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.jManager.log)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/go/kbfs/libkbfs/journal_md_ops.go
+++ b/go/kbfs/libkbfs/journal_md_ops.go
@@ -130,7 +130,8 @@ func (j journalMDOps) getHeadFromJournal(
 	if handle == nil {
 		handle, err = MakeTlfHandle(
 			ctx, headBareHandle, id.Type(), j.jManager.config.KBPKI(),
-			j.jManager.config.KBPKI(), constIDGetter{id})
+			j.jManager.config.KBPKI(), constIDGetter{id},
+			j.jManager.config.OfflineAvailabilityForID(id))
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
@@ -138,14 +139,16 @@ func (j journalMDOps) getHeadFromJournal(
 		// Check for mutual handle resolution.
 		headHandle, err := MakeTlfHandle(
 			ctx, headBareHandle, id.Type(), j.jManager.config.KBPKI(),
-			j.jManager.config.KBPKI(), constIDGetter{id})
+			j.jManager.config.KBPKI(), constIDGetter{id},
+			j.jManager.config.OfflineAvailabilityForID(id))
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
 
 		if err := headHandle.MutuallyResolvesTo(ctx, j.jManager.config.Codec(),
-			j.jManager.config.KBPKI(), j.jManager.config.MDOps(), *handle,
-			head.RevisionNumber(), head.TlfID(), j.jManager.log); err != nil {
+			j.jManager.config.KBPKI(), j.jManager.config.MDOps(),
+			j.jManager.config, *handle, head.RevisionNumber(), head.TlfID(),
+			j.jManager.log); err != nil {
 			return ImmutableRootMetadata{}, err
 		}
 	}
@@ -201,7 +204,8 @@ func (j journalMDOps) getRangeFromJournal(
 	}
 	handle, err := MakeTlfHandle(
 		ctx, bareHandle, id.Type(), j.jManager.config.KBPKI(),
-		j.jManager.config.KBPKI(), constIDGetter{id})
+		j.jManager.config.KBPKI(), constIDGetter{id},
+		j.jManager.config.OfflineAvailabilityForID(id))
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/journal_md_ops_test.go
+++ b/go/kbfs/libkbfs/journal_md_ops_test.go
@@ -108,7 +108,8 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	require.NoError(t, err)
 
 	h, err := MakeTlfHandle(
-		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil)
+		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	mdOps := jManager.mdOps()
@@ -285,7 +286,8 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 	require.NoError(t, err)
 
 	h, err := MakeTlfHandle(
-		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil)
+		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	mdOps := jManager.mdOps()
@@ -320,7 +322,8 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 	require.NoError(t, err)
 
 	h, err := MakeTlfHandle(
-		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil)
+		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	mdOps := jManager.mdOps()
@@ -353,7 +356,8 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	require.NoError(t, err)
 
 	h, err := MakeTlfHandle(
-		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil)
+		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	mdOps := jManager.mdOps()

--- a/go/kbfs/libkbfs/journal_md_ops_test.go
+++ b/go/kbfs/libkbfs/journal_md_ops_test.go
@@ -387,7 +387,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		rmd, err = rmd.MakeSuccessor(ctx, config.MetadataVersion(),
 			config.Codec(), config.KeyManager(),
-			config.KBPKI(), config.KBPKI(), mdID, true)
+			config.KBPKI(), config.KBPKI(), config, mdID, true)
 		require.NoError(t, err)
 		mdID, err = j.put(ctx, config.Crypto(), config.KeyManager(),
 			config.BlockSplitter(), rmd, false)

--- a/go/kbfs/libkbfs/kbfs_cr_test.go
+++ b/go/kbfs/libkbfs/kbfs_cr_test.go
@@ -258,7 +258,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	DisableCRForTesting(config1B, rootNode1.GetFolderBranch())
 
 	tlfHandle, err := ParseTlfHandle(
-		ctx, config1B.KBPKI(), config1B.MDOps(), name, tlf.Private)
+		ctx, config1B.KBPKI(), config1B.MDOps(), nil, name, tlf.Private)
 	require.NoError(t, err)
 
 	_, _, err = config1B.KBFSOps().GetTLFCryptKeys(ctx, tlfHandle)

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -789,7 +789,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 
 	// we might not be able to read the metadata if we aren't in the
 	// key group yet.
-	if err := isReadableOrError(ctx, fs.config.KBPKI(), md.ReadOnly()); err != nil {
+	if err := isReadableOrError(ctx, fs.config.KBPKI(), fs.config, md.ReadOnly()); err != nil {
 		fs.opsLock.Lock()
 		defer fs.opsLock.Unlock()
 		// If we already have an FBO for this ID, trigger a rekey

--- a/go/kbfs/libkbfs/kbfs_ops_concur_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_concur_test.go
@@ -1520,7 +1520,8 @@ func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 
 	t.Log("Ensure that the block references have been removed rather than just archived")
 	bOps := config.BlockOps()
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), config.MDOps(), "test_user", tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), nil, "test_user", tlf.Private)
 	require.NoError(t, err)
 	ptrs := make([]BlockPointer, len(pointerMap))
 	for _, ptr := range pointerMap {

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -3315,7 +3315,7 @@ func TestForceFastForwardOnEmptyTLF(t *testing.T) {
 
 	// Look up bob's public folder.
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "bob", tlf.Public)
+		ctx, config.KBPKI(), config.MDOps(), nil, "bob", tlf.Public)
 	require.NoError(t, err)
 	_, _, err = config.KBFSOps().GetOrCreateRootNode(ctx, h, MasterBranch)
 	if _, ok := err.(WriteAccessError); !ok {
@@ -3450,7 +3450,8 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 
 	t.Log("Look up bob's public folder.")
 	h, err := ParseTlfHandle(
-		ctx, config1.KBPKI(), config1.MDOps(), string(name), tlf.SingleTeam)
+		ctx, config1.KBPKI(), config1.MDOps(), nil, string(name),
+		tlf.SingleTeam)
 	require.NoError(t, err)
 	kbfsOps1 := config1.KBFSOps()
 	rootNode1, _, err := kbfsOps1.GetOrCreateRootNode(
@@ -3599,7 +3600,7 @@ func testKBFSOpsMigrateToImplicitTeam(
 
 	t.Log("Create the folder before implicit teams are enabled.")
 	h, err := ParseTlfHandle(
-		ctx, config1.KBPKI(), config1.MDOps(), string(name), ty)
+		ctx, config1.KBPKI(), config1.MDOps(), nil, string(name), ty)
 	require.NoError(t, err)
 	require.False(t, h.IsBackedByTeam())
 	kbfsOps1 := config1.KBFSOps()
@@ -3703,7 +3704,7 @@ func TestKBFSOpsArchiveBranchType(t *testing.T) {
 	t.Log("Create a private folder for the master branch.")
 	name := "u1"
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, MasterBranch)
@@ -3841,7 +3842,7 @@ func TestKBFSOpsReadonlyFSNodes(t *testing.T) {
 
 	name := "u1"
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, MasterBranch)
@@ -3907,7 +3908,7 @@ func TestKBFSOpsReset(t *testing.T) {
 	t.Log("Create a private folder.")
 	name := "u1"
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, MasterBranch)
@@ -3991,7 +3992,7 @@ func TestKBFSOpsUnsyncedMDCommit(t *testing.T) {
 	t.Log("Create a private, unsynced TLF and make sure updates are committed")
 	name := "u1"
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, MasterBranch)
@@ -4107,7 +4108,7 @@ func TestKBFSOpsSyncedMDCommit(t *testing.T) {
 	config.SetBlockServer(bserverPutToDiskCache{config.BlockServer(), dbc})
 	name := "u1"
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, MasterBranch)
@@ -4213,7 +4214,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 
 	name := "u1"
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 
@@ -4349,7 +4350,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 
 	name := "u1"
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 
@@ -4569,7 +4570,7 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 
 	name := "u1"
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(name), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 

--- a/go/kbfs/libkbfs/kbpki_client.go
+++ b/go/kbfs/libkbfs/kbpki_client.go
@@ -47,9 +47,11 @@ func (k *KBPKIClient) GetCurrentSession(ctx context.Context) (
 }
 
 // Resolve implements the KBPKI interface for KBPKIClient.
-func (k *KBPKIClient) Resolve(ctx context.Context, assertion string) (
+func (k *KBPKIClient) Resolve(
+	ctx context.Context, assertion string,
+	offline keybase1.OfflineAvailability) (
 	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
-	return k.serviceOwner.KeybaseService().Resolve(ctx, assertion)
+	return k.serviceOwner.KeybaseService().Resolve(ctx, assertion, offline)
 }
 
 // Identify implements the KBPKI interface for KBPKIClient.
@@ -121,7 +123,8 @@ func (k *KBPKIClient) IdentifyImplicitTeam(
 // GetNormalizedUsername implements the KBPKI interface for
 // KBPKIClient.
 func (k *KBPKIClient) GetNormalizedUsername(
-	ctx context.Context, id keybase1.UserOrTeamID) (
+	ctx context.Context, id keybase1.UserOrTeamID,
+	offline keybase1.OfflineAvailability) (
 	kbname.NormalizedUsername, error) {
 	var assertion string
 	if id.IsUser() {
@@ -129,7 +132,7 @@ func (k *KBPKIClient) GetNormalizedUsername(
 	} else {
 		assertion = fmt.Sprintf("tid:%s", id)
 	}
-	username, _, err := k.Resolve(ctx, assertion)
+	username, _, err := k.Resolve(ctx, assertion, offline)
 	if err != nil {
 		return kbname.NormalizedUsername(""), err
 	}

--- a/go/kbfs/libkbfs/kbpki_client.go
+++ b/go/kbfs/libkbfs/kbpki_client.go
@@ -95,9 +95,10 @@ func (k *KBPKIClient) ResolveImplicitTeamByID(
 
 // ResolveTeamTLFID implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) ResolveTeamTLFID(
-	ctx context.Context, teamID keybase1.TeamID) (tlf.ID, error) {
+	ctx context.Context, teamID keybase1.TeamID,
+	offline keybase1.OfflineAvailability) (tlf.ID, error) {
 	settings, err := k.serviceOwner.KeybaseService().GetTeamSettings(
-		ctx, teamID)
+		ctx, teamID, offline)
 	if err != nil {
 		return tlf.NullID, err
 	}

--- a/go/kbfs/libkbfs/kbpki_client_test.go
+++ b/go/kbfs/libkbfs/kbpki_client_test.go
@@ -209,7 +209,8 @@ func TestKBPKIClientGetTeamTLFCryptKeys(t *testing.T) {
 
 	for _, team := range localTeams {
 		keys, keyGen, err := c.GetTeamTLFCryptKeys(
-			context.Background(), team.TID, kbfsmd.UnspecifiedKeyGen)
+			context.Background(), team.TID, kbfsmd.UnspecifiedKeyGen,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			t.Error(err)
 		}

--- a/go/kbfs/libkbfs/kbpki_client_test.go
+++ b/go/kbfs/libkbfs/kbpki_client_test.go
@@ -79,7 +79,8 @@ func TestKBPKIClientGetNormalizedUsername(t *testing.T) {
 	c, _, _, _ := makeTestKBPKIClient(t)
 
 	name, err := c.GetNormalizedUsername(
-		context.Background(), keybase1.MakeTestUID(1).AsUserOrTeam())
+		context.Background(), keybase1.MakeTestUID(1).AsUserOrTeam(),
+		keybase1.OfflineAvailability_NONE)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/kbfs/libkbfs/kbpki_util_test.go
+++ b/go/kbfs/libkbfs/kbpki_util_test.go
@@ -66,6 +66,20 @@ func (d *daemonKBPKI) GetNormalizedUsername(
 	return userInfo.Name, nil
 }
 
+func (d *daemonKBPKI) ResolveTeamTLFID(
+	ctx context.Context, teamID keybase1.TeamID,
+	offline keybase1.OfflineAvailability) (tlf.ID, error) {
+	settings, err := d.daemon.GetTeamSettings(ctx, teamID, offline)
+	if err != nil {
+		return tlf.NullID, err
+	}
+	tlfID, err := tlf.ParseID(settings.TlfID.String())
+	if err != nil {
+		return tlf.NullID, err
+	}
+	return tlfID, nil
+}
+
 // interposeDaemonKBPKI replaces the existing (mock) KBPKI with a
 // daemonKBPKI that handles all the username-related calls.
 //

--- a/go/kbfs/libkbfs/kbpki_util_test.go
+++ b/go/kbfs/libkbfs/kbpki_util_test.go
@@ -27,9 +27,11 @@ func (d *daemonKBPKI) GetCurrentSession(ctx context.Context) (
 	return d.daemon.CurrentSession(ctx, sessionID)
 }
 
-func (d *daemonKBPKI) Resolve(ctx context.Context, assertion string) (
+func (d *daemonKBPKI) Resolve(
+	ctx context.Context, assertion string,
+	offline keybase1.OfflineAvailability) (
 	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
-	return d.daemon.Resolve(ctx, assertion)
+	return d.daemon.Resolve(ctx, assertion, offline)
 }
 
 func (d *daemonKBPKI) NormalizeSocialAssertion(ctx context.Context, assertion string) (
@@ -51,8 +53,8 @@ func (d *daemonKBPKI) ResolveImplicitTeam(
 }
 
 func (d *daemonKBPKI) GetNormalizedUsername(
-	ctx context.Context, id keybase1.UserOrTeamID) (
-	kbname.NormalizedUsername, error) {
+	ctx context.Context, id keybase1.UserOrTeamID,
+	offline keybase1.OfflineAvailability) (kbname.NormalizedUsername, error) {
 	asUser, err := id.AsUser()
 	if err != nil {
 		return kbname.NormalizedUsername(""), err

--- a/go/kbfs/libkbfs/key_manager.go
+++ b/go/kbfs/libkbfs/key_manager.go
@@ -130,7 +130,8 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 		if err != nil {
 			return kbfscrypto.TLFCryptKey{}, err
 		}
-		keys, _, err := km.config.KBPKI().GetTeamTLFCryptKeys(ctx, tid, keyGen)
+		keys, _, err := km.config.KBPKI().GetTeamTLFCryptKeys(
+			ctx, tid, keyGen, km.config.OfflineAvailabilityForID(tlfID))
 		if err != nil {
 			return kbfscrypto.TLFCryptKey{}, err
 		}
@@ -743,8 +744,8 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		pmd, err := decryptMDPrivateData(
 			ctx, km.config.Codec(), km.config.Crypto(),
 			km.config.BlockCache(), km.config.BlockOps(), km, km.config.KBPKI(),
-			km.config.Mode(), session.UID, md.GetSerializedPrivateMetadata(),
-			md, md, km.log)
+			km.config, km.config.Mode(), session.UID,
+			md.GetSerializedPrivateMetadata(), md, md, km.log)
 		if err != nil {
 			return false, nil, err
 		}

--- a/go/kbfs/libkbfs/key_manager.go
+++ b/go/kbfs/libkbfs/key_manager.go
@@ -221,7 +221,8 @@ func (km *KeyManagerStandard) getTLFCryptKeyParams(
 	kbpki := km.config.KBPKI()
 	crypto := km.config.Crypto()
 	localMakeRekeyReadError := func(err error) error {
-		return makeRekeyReadError(ctx, err, kbpki, kmd, uid, username)
+		return makeRekeyReadError(
+			ctx, err, kbpki, km.config, kmd, uid, username)
 	}
 
 	if flags&getTLFCryptKeyAnyDevice != 0 {
@@ -447,7 +448,9 @@ func (km *KeyManagerStandard) identifyUIDSets(ctx context.Context,
 		return err
 	}
 
-	return identifyUserList(ctx, kbpki, kbpki, ids, tlfID.Type())
+	return identifyUserList(
+		ctx, kbpki, kbpki, ids, tlfID.Type(),
+		km.config.OfflineAvailabilityForID(tlfID))
 }
 
 // generateKeyMapForUsers returns a kbfsmd.UserDevicePublicKeys object for
@@ -512,7 +515,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 	idGetter := constIDGetter{md.TlfID()}
 	resolvedHandle, err := handle.ResolveAgain(
-		ctx, km.config.KBPKI(), idGetter)
+		ctx, km.config.KBPKI(), idGetter, km.config)
 	if err != nil {
 		return false, nil, err
 	}
@@ -527,7 +530,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		} else {
 			// Only allow yourself to change
 			resolvedHandle, err = handle.ResolveAgainForUser(
-				ctx, km.config.KBPKI(), idGetter, session.UID)
+				ctx, km.config.KBPKI(), idGetter, km.config, session.UID)
 			if err != nil {
 				return false, nil, err
 			}

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -439,7 +439,8 @@ func testKeyManagerRekeyResolveAgainSuccessPublic(t *testing.T, ver kbfsmd.Metad
 
 	id := tlf.FakeID(1, tlf.Public)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id}, "alice,bob@twitter", tlf.Public)
+		ctx, config.KBPKI(), constIDGetter{id}, nil, "alice,bob@twitter",
+		tlf.Public)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
@@ -479,7 +480,7 @@ func testKeyManagerRekeyResolveAgainSuccessPublicSelf(t *testing.T, ver kbfsmd.M
 
 	id := tlf.FakeID(1, tlf.Public)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id},
+		ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice@twitter,bob,charlie@twitter", tlf.Public)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
@@ -515,7 +516,7 @@ func testKeyManagerRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsmd.Meta
 
 	id := tlf.FakeID(1, tlf.Private)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id},
+		ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,bob@twitter,dave@twitter#charlie@twitter", tlf.Private)
 	if err != nil {
 		t.Fatal(err)
@@ -605,7 +606,7 @@ func testKeyManagerPromoteReaderSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,bob@twitter#bob", tlf.Private)
 	require.NoError(t, err)
 
@@ -653,7 +654,7 @@ func testKeyManagerPromoteReaderSelf(t *testing.T, ver kbfsmd.MetadataVer) {
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,bob@twitter#bob", tlf.Private)
 	require.NoError(t, err)
 
@@ -703,7 +704,7 @@ func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver kbfsmd.Metadata
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,charlie@twitter#bob,charlie", tlf.Private)
 	require.NoError(t, err)
 
@@ -746,7 +747,7 @@ func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsm
 	defer keyManagerShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,dave@twitter#bob@twitter,charlie@twitter", tlf.Private)
 	if err != nil {
 		t.Fatal(err)
@@ -779,7 +780,8 @@ func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsm
 	daemon.addNewAssertionForTestOrBust("charlie", "charlie@twitter")
 	daemon.addNewAssertionForTestOrBust("dave", "dave@twitter")
 
-	_, bobID, err := daemon.Resolve(ctx, "bob")
+	_, bobID, err := daemon.Resolve(
+		ctx, "bob", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	bobUID, err := bobID.AsUser()
 	require.NoError(t, err)
@@ -827,7 +829,7 @@ func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver kbf
 
 	id := tlf.FakeID(1, tlf.Private)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id}, "alice,bob,bob@twitter",
+		ctx, config.KBPKI(), constIDGetter{id}, nil, "alice,bob,bob@twitter",
 		tlf.Private)
 	if err != nil {
 		t.Fatal(err)
@@ -1157,7 +1159,8 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.Metada
 	config1.SetMetadataVersion(ver)
 
 	// Revoke user 3's device for now, to test the "other" rekey error.
-	_, id3, err := config1.KBPKI().Resolve(ctx, u3.String())
+	_, id3, err := config1.KBPKI().Resolve(
+		ctx, u3.String(), keybase1.OfflineAvailability_NONE)
 	if err != nil {
 		t.Fatalf("Couldn't resolve u3: %+v", err)
 	}

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -168,8 +168,8 @@ func (kmd emptyKeyMetadata) GetTlfHandle() *TlfHandle {
 }
 
 func (kmd emptyKeyMetadata) IsWriter(
-	_ context.Context, _ kbfsmd.TeamMembershipChecker, _ keybase1.UID,
-	_ kbfscrypto.VerifyingKey) (bool, error) {
+	_ context.Context, _ kbfsmd.TeamMembershipChecker, _ OfflineStatusGetter,
+	_ keybase1.UID, _ kbfscrypto.VerifyingKey) (bool, error) {
 	return false, nil
 }
 
@@ -2419,7 +2419,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config1.MetadataVersion(), config1.Codec(),
 		config1.KeyManager(), config1.KBPKI(), config1.KBPKI(),
-		kbfsmd.FakeID(2), true)
+		config1, kbfsmd.FakeID(2), true)
 	require.NoError(t, err)
 
 	// Both users should see the same new key.
@@ -2459,7 +2459,8 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	}
 
 	_, latestKeyGen, err := config1.KBPKI().GetTeamTLFCryptKeys(
-		ctx, teamID, kbfsmd.UnspecifiedKeyGen)
+		ctx, teamID, kbfsmd.UnspecifiedKeyGen,
+		keybase1.OfflineAvailability_NONE)
 
 	rmd, err := makeInitialRootMetadata(config1.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
@@ -2480,7 +2481,7 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config1.MetadataVersion(), config1.Codec(),
 		config1.KeyManager(), config1.KBPKI(), config1.KBPKI(),
-		kbfsmd.FakeID(2), true)
+		config1, kbfsmd.FakeID(2), true)
 	require.NoError(t, err)
 
 	// Both users should see the same new key.

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -447,7 +447,7 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context,
 func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
 	ctx context.Context, tid keybase1.TeamID, _ tlf.Type, _ kbfsmd.KeyGen,
 	_ keybase1.UserVersion, _ kbfscrypto.VerifyingKey,
-	_ keybase1.TeamRole) (TeamInfo, error) {
+	_ keybase1.TeamRole, _ keybase1.OfflineAvailability) (TeamInfo, error) {
 	if err := checkContext(ctx); err != nil {
 		return TeamInfo{}, err
 	}

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -496,7 +496,8 @@ func (k *KeybaseDaemonLocal) CreateTeamTLF(
 // GetTeamSettings implements the KeybaseService interface for
 // KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) GetTeamSettings(
-	ctx context.Context, teamID keybase1.TeamID) (
+	ctx context.Context, teamID keybase1.TeamID,
+	_ keybase1.OfflineAvailability) (
 	settings keybase1.KBFSTeamSettings, err error) {
 	if err := checkContext(ctx); err != nil {
 		return keybase1.KBFSTeamSettings{}, err

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -217,7 +217,8 @@ func (k *KeybaseDaemonLocal) assertionToIDLocked(ctx context.Context,
 }
 
 // Resolve implements KeybaseDaemon for KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
+func (k *KeybaseDaemonLocal) Resolve(
+	ctx context.Context, assertion string, _ keybase1.OfflineAvailability) (
 	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	if err := checkContext(ctx); err != nil {
 		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
@@ -261,7 +262,7 @@ func (k *KeybaseDaemonLocal) Identify(
 	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	// The local daemon doesn't need to distinguish resolves from
 	// identifies.
-	return k.Resolve(ctx, assertion)
+	return k.Resolve(ctx, assertion, keybase1.OfflineAvailability_NONE)
 }
 
 // NormalizeSocialAssertion implements the KeybaseService interface for

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -904,10 +904,15 @@ func (k *KeybaseServiceBase) CreateTeamTLF(
 // GetTeamSettings implements the KeybaseService interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) GetTeamSettings(
-	ctx context.Context, teamID keybase1.TeamID) (
+	ctx context.Context, teamID keybase1.TeamID,
+	offline keybase1.OfflineAvailability) (
 	keybase1.KBFSTeamSettings, error) {
 	// TODO: get invalidations from the server and cache the settings?
-	return k.kbfsClient.GetKBFSTeamSettings(ctx, keybase1.GetKBFSTeamSettingsArg{TeamID: teamID})
+	return k.kbfsClient.GetKBFSTeamSettings(
+		ctx, keybase1.GetKBFSTeamSettingsArg{
+			TeamID: teamID,
+			Oa:     offline,
+		})
 }
 
 func (k *KeybaseServiceBase) getCurrentMerkleRoot(ctx context.Context) (

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -763,8 +763,8 @@ var allowedLoadTeamRoles = map[keybase1.TeamRole]bool{
 func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type,
 	desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion,
-	desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole) (
-	TeamInfo, error) {
+	desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole,
+	offline keybase1.OfflineAvailability) (TeamInfo, error) {
 	if !allowedLoadTeamRoles[desiredRole] {
 		panic(fmt.Sprintf("Disallowed team role: %v", desiredRole))
 	}
@@ -817,6 +817,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 		Id:              tid,
 		Application:     keybase1.TeamApplication_KBFS,
 		IncludeKBFSKeys: true,
+		Oa:              offline,
 	}
 
 	if desiredKeyGen >= kbfsmd.FirstValidKeyGen {

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -163,11 +163,12 @@ func (k KeybaseServiceMeasured) LoadUserPlusKeys(ctx context.Context,
 func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
 	tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen,
 	desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey,
-	desiredRole keybase1.TeamRole) (teamInfo TeamInfo, err error) {
+	desiredRole keybase1.TeamRole, offline keybase1.OfflineAvailability) (
+	teamInfo TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
 		teamInfo, err = k.delegate.LoadTeamPlusKeys(
 			ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey,
-			desiredRole)
+			desiredRole, offline)
 	})
 	return teamInfo, err
 }

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -98,10 +98,12 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 }
 
 // Resolve implements the KeybaseService interface for KeybaseServiceMeasured.
-func (k KeybaseServiceMeasured) Resolve(ctx context.Context, assertion string) (
+func (k KeybaseServiceMeasured) Resolve(
+	ctx context.Context, assertion string,
+	offline keybase1.OfflineAvailability) (
 	name kbname.NormalizedUsername, uid keybase1.UserOrTeamID, err error) {
 	k.resolveTimer.Time(func() {
-		name, uid, err = k.delegate.Resolve(ctx, assertion)
+		name, uid, err = k.delegate.Resolve(ctx, assertion, offline)
 	})
 	return name, uid, err
 }

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -185,10 +185,11 @@ func (k KeybaseServiceMeasured) CreateTeamTLF(
 // GetTeamSettings implements the KeybaseService interface for
 // KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) GetTeamSettings(
-	ctx context.Context, teamID keybase1.TeamID) (
+	ctx context.Context, teamID keybase1.TeamID,
+	offline keybase1.OfflineAvailability) (
 	settings keybase1.KBFSTeamSettings, err error) {
 	k.getTeamSettingsTimer.Time(func() {
-		settings, err = k.delegate.GetTeamSettings(ctx, teamID)
+		settings, err = k.delegate.GetTeamSettings(ctx, teamID, offline)
 	})
 	return settings, err
 }

--- a/go/kbfs/libkbfs/keybase_service_util.go
+++ b/go/kbfs/libkbfs/keybase_service_util.go
@@ -36,7 +36,7 @@ func setupDiskBlockCache(ctx context.Context, config Config, username string) {
 
 	log := config.MakeLogger("")
 	publicHandle, err := getHandleFromFolderName(ctx,
-		config.KBPKI(), config.MDOps(), username, true)
+		config.KBPKI(), config.MDOps(), config, username, true)
 	if err != nil {
 		log.CWarningf(ctx, "serviceLoggedIn: Failed to fetch TLF ID for "+
 			"user's public TLF: %+v", err)
@@ -47,8 +47,8 @@ func setupDiskBlockCache(ctx context.Context, config Config, username string) {
 				"for disk block cache: %+v", err)
 		}
 	}
-	privateHandle, err := getHandleFromFolderName(ctx, config.KBPKI(),
-		config.MDOps(), username, false)
+	privateHandle, err := getHandleFromFolderName(
+		ctx, config.KBPKI(), config.MDOps(), config, username, false)
 	if err != nil {
 		log.CWarningf(ctx, "serviceLoggedIn: Failed to fetch TLF ID for "+
 			"user's private TLF: %+v", err)

--- a/go/kbfs/libkbfs/md_journal_test.go
+++ b/go/kbfs/libkbfs/md_journal_test.go
@@ -96,7 +96,8 @@ func makeMDForTest(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	h, err := MakeTlfHandle(
-		context.Background(), bh, bh.Type(), nil, nug, nil)
+		context.Background(), bh, bh.Type(), nil, nug, nil,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	md, err := makeInitialRootMetadata(ver, tlfID, h)
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/md_ops.go
+++ b/go/kbfs/libkbfs/md_ops.go
@@ -85,8 +85,9 @@ func (md *MDOpsStandard) convertVerifyingKeyError(ctx context.Context,
 	}
 
 	tlf := handle.GetCanonicalPath()
-	writer, nameErr := md.config.KBPKI().GetNormalizedUsername(ctx,
-		rmds.MD.LastModifyingWriter().AsUserOrTeam())
+	writer, nameErr := md.config.KBPKI().GetNormalizedUsername(
+		ctx, rmds.MD.LastModifyingWriter().AsUserOrTeam(),
+		md.config.OfflineAvailabilityForPath(tlf))
 	if nameErr != nil {
 		writer = kbname.NormalizedUsername("uid: " +
 			rmds.MD.LastModifyingWriter().String())
@@ -931,14 +932,15 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 	}
 
 	mdHandle, err := MakeTlfHandle(
-		ctx, bareMdHandle, id.Type(), md.config.KBPKI(), md.config.KBPKI(), nil)
+		ctx, bareMdHandle, id.Type(), md.config.KBPKI(), md.config.KBPKI(), nil,
+		md.config.OfflineAvailabilityForID(id))
 	if err != nil {
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
 
 	// Check for mutual handle resolution.
 	if err := mdHandle.MutuallyResolvesTo(ctx, md.config.Codec(),
-		md.config.KBPKI(), nil, *handle, rmds.MD.RevisionNumber(),
+		md.config.KBPKI(), nil, md.config, *handle, rmds.MD.RevisionNumber(),
 		rmds.MD.TlfID(), md.log); err != nil {
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
@@ -1037,7 +1039,8 @@ func (md *MDOpsStandard) processSignedMD(
 	}
 	handle, err := MakeTlfHandle(
 		ctx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
-		md.config.KBPKI(), constIDGetter{id})
+		md.config.KBPKI(), constIDGetter{id},
+		md.config.OfflineAvailabilityForID(id))
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -1132,7 +1135,8 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
 			}
 			handle, err := MakeTlfHandle(
 				groupCtx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
-				md.config.KBPKI(), constIDGetter{id})
+				md.config.KBPKI(), constIDGetter{id},
+				md.config.OfflineAvailabilityForID(id))
 			if err != nil {
 				return err
 			}

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -1020,7 +1020,7 @@ func makeSuccessorRMDForTesting(
 
 	rmd, err := currRMD.MakeSuccessor(
 		ctx, config.MetadataVersion(), config.Codec(), config.KeyManager(),
-		config.KBPKI(), config.KBPKI(), mdID, true)
+		config.KBPKI(), config.KBPKI(), config, mdID, true)
 	require.NoError(t, err)
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -279,7 +279,8 @@ func testMDOpsGetIDForUnresolvedHandlePublicSuccess(
 	// Do this before setting tlfHandle to nil.
 	verifyMDForPublic(config, rmds, nil)
 
-	hUnresolved, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	hUnresolved, err := ParseTlfHandle(
+		ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,bob@twitter", tlf.Public)
 	require.NoError(t, err)
 	hUnresolved.tlfID = tlf.NullID
@@ -309,17 +310,20 @@ func testMDOpsGetIDForUnresolvedMdHandlePublicSuccess(
 	defer mdOpsShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, tlf.Public)
-	mdHandle1, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	mdHandle1, err := ParseTlfHandle(
+		ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,dave@twitter", tlf.Public)
 	require.NoError(t, err)
 	mdHandle1.tlfID = tlf.NullID
 
-	mdHandle2, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	mdHandle2, err := ParseTlfHandle(
+		ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,bob,charlie", tlf.Public)
 	require.NoError(t, err)
 	mdHandle2.tlfID = tlf.NullID
 
-	mdHandle3, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	mdHandle3, err := ParseTlfHandle(
+		ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,bob@twitter,charlie@twitter", tlf.Public)
 	require.NoError(t, err)
 	mdHandle3.tlfID = tlf.NullID
@@ -335,8 +339,8 @@ func testMDOpsGetIDForUnresolvedMdHandlePublicSuccess(
 	verifyMDForPublic(config, rmds3, nil)
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id}, "alice,bob,charlie@twitter",
-		tlf.Public)
+		ctx, config.KBPKI(), constIDGetter{id}, nil,
+		"alice,bob,charlie@twitter", tlf.Public)
 	require.NoError(t, err)
 	h.tlfID = tlf.NullID
 
@@ -378,7 +382,8 @@ func testMDOpsGetIDForUnresolvedHandlePublicFailure(
 	h := parseTlfHandleOrBust(t, config, "alice,bob", tlf.Public, id)
 	rmds, _ := newRMDS(t, config, h)
 
-	hUnresolved, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
+	hUnresolved, err := ParseTlfHandle(
+		ctx, config.KBPKI(), constIDGetter{id}, nil,
 		"alice,bob@github,bob@twitter", tlf.Public)
 	require.NoError(t, err)
 	hUnresolved.tlfID = tlf.NullID

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -193,7 +193,7 @@ func MakeCopyWithDecryptedPrivateData(
 	pmd, err := decryptMDPrivateData(
 		ctx, config.Codec(), config.Crypto(),
 		config.BlockCache(), config.BlockOps(),
-		config.KeyManager(), config.KBPKI(), config.Mode(), uid,
+		config.KeyManager(), config.KBPKI(), config, config.Mode(), uid,
 		irmdToDecrypt.GetSerializedPrivateMetadata(),
 		irmdToDecrypt, irmdWithKeys, config.MakeLogger(""))
 	if err != nil {
@@ -593,9 +593,9 @@ func reembedBlockChangesIntoCopyIfNeeded(
 func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 	crypto Crypto, bcache BlockCache, bops BlockOps,
 	keyGetter mdDecryptionKeyGetter, teamChecker kbfsmd.TeamMembershipChecker,
-	mode InitMode, uid keybase1.UID, serializedPrivateMetadata []byte,
-	rmdToDecrypt, rmdWithKeys KeyMetadata, log logger.Logger) (
-	PrivateMetadata, error) {
+	osg OfflineStatusGetter, mode InitMode, uid keybase1.UID,
+	serializedPrivateMetadata []byte, rmdToDecrypt, rmdWithKeys KeyMetadata,
+	log logger.Logger) (PrivateMetadata, error) {
 	handle := rmdToDecrypt.GetTlfHandle()
 
 	var pmd PrivateMetadata
@@ -619,7 +619,7 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 			log.CDebugf(ctx, "Couldn't get crypt key for %s (%s): %+v",
 				handle.GetCanonicalPath(), rmdToDecrypt.TlfID(), err)
 			isReader, readerErr := isReaderFromHandle(
-				ctx, handle, teamChecker, uid)
+				ctx, handle, teamChecker, osg, uid)
 			if readerErr != nil {
 				return PrivateMetadata{}, readerErr
 			}

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -46,10 +46,11 @@ func makeRekeyReadErrorHelper(
 }
 
 func makeRekeyReadError(
-	ctx context.Context, err error, kbpki KBPKI, kmd KeyMetadata,
+	ctx context.Context, err error, kbpki KBPKI,
+	syncGetter syncedTlfGetterSetter, kmd KeyMetadata,
 	uid keybase1.UID, username kbname.NormalizedUsername) error {
 	h := kmd.GetTlfHandle()
-	resolvedHandle, resolveErr := h.ResolveAgain(ctx, kbpki, nil)
+	resolvedHandle, resolveErr := h.ResolveAgain(ctx, kbpki, nil, syncGetter)
 	if resolveErr != nil {
 		// Ignore error and pretend h is already fully
 		// resolved.
@@ -61,7 +62,8 @@ func makeRekeyReadError(
 // Helper which returns nil if the md block is uninitialized or readable by
 // the current user. Otherwise an appropriate read access error is returned.
 func isReadableOrError(
-	ctx context.Context, kbpki KBPKI, md ReadOnlyRootMetadata) error {
+	ctx context.Context, kbpki KBPKI, syncGetter syncedTlfGetterSetter,
+	md ReadOnlyRootMetadata) error {
 	if !md.IsInitialized() || md.IsReadable() {
 		return nil
 	}
@@ -73,8 +75,8 @@ func isReadableOrError(
 	}
 	err = errors.Errorf("%s is not readable by %s (uid:%s)", md.TlfID(),
 		session.Name, session.UID)
-	return makeRekeyReadError(ctx, err, kbpki, md,
-		session.UID, session.Name)
+	return makeRekeyReadError(
+		ctx, err, kbpki, syncGetter, md, session.UID, session.Name)
 }
 
 func getMDRange(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.BranchID,
@@ -262,7 +264,7 @@ func getMergedMDUpdatesWithEnd(ctx context.Context, config Config, id tlf.ID,
 	// readable until the newer revision, containing the key for this
 	// device, is processed.
 	for i, rmd := range mergedRmds {
-		if err := isReadableOrError(ctx, config.KBPKI(), rmd.ReadOnly()); err != nil {
+		if err := isReadableOrError(ctx, config.KBPKI(), config, rmd.ReadOnly()); err != nil {
 			// The right secret key for the given rmd's
 			// key generation may only be present in the
 			// most recent rmd.

--- a/go/kbfs/libkbfs/md_util_test.go
+++ b/go/kbfs/libkbfs/md_util_test.go
@@ -106,7 +106,7 @@ func TestGetRevisionByTime(t *testing.T) {
 
 	t.Log("Create revision 1")
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), string(u1), tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil, string(u1), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, MasterBranch)

--- a/go/kbfs/libkbfs/mdcache_test.go
+++ b/go/kbfs/libkbfs/mdcache_test.go
@@ -29,7 +29,8 @@ func testMdcacheMakeHandle(t *testing.T, n uint32) *TlfHandle {
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(ctx, bh, bh.Type(), nil, nug, nil)
+	h, err := MakeTlfHandle(
+		ctx, bh, bh.Type(), nil, nug, nil, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	return h
 }

--- a/go/kbfs/libkbfs/mdserver_disk.go
+++ b/go/kbfs/libkbfs/mdserver_disk.go
@@ -208,7 +208,8 @@ func (md *MDServerDisk) getHandleID(ctx context.Context, handle tlf.Handle,
 	}
 	if handle.Type() == tlf.SingleTeam {
 		isReader, err := md.config.teamMembershipChecker().IsTeamReader(
-			ctx, handle.Writers[0].AsTeamOrBust(), session.UID)
+			ctx, handle.Writers[0].AsTeamOrBust(), session.UID,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 		} else if !isReader {

--- a/go/kbfs/libkbfs/mdserver_local_shared.go
+++ b/go/kbfs/libkbfs/mdserver_local_shared.go
@@ -31,7 +31,8 @@ func isReader(ctx context.Context, teamMemChecker kbfsmd.TeamMembershipChecker,
 
 	if h.Type() == tlf.SingleTeam {
 		isReader, err := teamMemChecker.IsTeamReader(
-			ctx, h.Writers[0].AsTeamOrBust(), currentUID)
+			ctx, h.Writers[0].AsTeamOrBust(), currentUID,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			return false, kbfsmd.ServerError{Err: err}
 		}
@@ -56,7 +57,8 @@ func isWriterOrValidRekey(ctx context.Context,
 
 	if h.Type() == tlf.SingleTeam {
 		isWriter, err := teamMemChecker.IsTeamWriter(
-			ctx, h.Writers[0].AsTeamOrBust(), currentUID, verifyingKey)
+			ctx, h.Writers[0].AsTeamOrBust(), currentUID, verifyingKey,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			return false, kbfsmd.ServerError{Err: err}
 		}

--- a/go/kbfs/libkbfs/mdserver_memory.go
+++ b/go/kbfs/libkbfs/mdserver_memory.go
@@ -184,7 +184,8 @@ func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
 	}
 	if handle.Type() == tlf.SingleTeam {
 		isReader, err := md.config.teamMembershipChecker().IsTeamReader(
-			ctx, handle.Writers[0].AsTeamOrBust(), session.UID)
+			ctx, handle.Writers[0].AsTeamOrBust(), session.UID,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 		}
@@ -552,8 +553,8 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 	}
 
 	err = rmds.IsValidAndSigned(
-		ctx, md.config.Codec(),
-		md.config.teamMembershipChecker(), extra)
+		ctx, md.config.Codec(), md.config.teamMembershipChecker(), extra,
+		keybase1.OfflineAvailability_NONE)
 	if err != nil {
 		return kbfsmd.ServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/go/kbfs/libkbfs/mdserver_tlf_storage.go
+++ b/go/kbfs/libkbfs/mdserver_tlf_storage.go
@@ -411,7 +411,9 @@ func (s *mdServerTlfStorage) put(ctx context.Context,
 		return false, err
 	}
 
-	err = rmds.IsValidAndSigned(ctx, s.codec, s.teamMemChecker, extra)
+	err = rmds.IsValidAndSigned(
+		ctx, s.codec, s.teamMemChecker, extra,
+		keybase1.OfflineAvailability_NONE)
 	if err != nil {
 		return false, kbfsmd.ServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -899,6 +899,57 @@ func (mr *MockdiskLimiterGetterMockRecorder) DiskLimiter() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskLimiter", reflect.TypeOf((*MockdiskLimiterGetter)(nil).DiskLimiter))
 }
 
+// MockofflineStatusGetter is a mock of offlineStatusGetter interface
+type MockofflineStatusGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockofflineStatusGetterMockRecorder
+}
+
+// MockofflineStatusGetterMockRecorder is the mock recorder for MockofflineStatusGetter
+type MockofflineStatusGetterMockRecorder struct {
+	mock *MockofflineStatusGetter
+}
+
+// NewMockofflineStatusGetter creates a new mock instance
+func NewMockofflineStatusGetter(ctrl *gomock.Controller) *MockofflineStatusGetter {
+	mock := &MockofflineStatusGetter{ctrl: ctrl}
+	mock.recorder = &MockofflineStatusGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockofflineStatusGetter) EXPECT() *MockofflineStatusGetterMockRecorder {
+	return m.recorder
+}
+
+// OfflineAvailabilityForPath mocks base method
+func (m *MockofflineStatusGetter) OfflineAvailabilityForPath(tlfPath string) keybase1.OfflineAvailability {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OfflineAvailabilityForPath", tlfPath)
+	ret0, _ := ret[0].(keybase1.OfflineAvailability)
+	return ret0
+}
+
+// OfflineAvailabilityForPath indicates an expected call of OfflineAvailabilityForPath
+func (mr *MockofflineStatusGetterMockRecorder) OfflineAvailabilityForPath(tlfPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForPath", reflect.TypeOf((*MockofflineStatusGetter)(nil).OfflineAvailabilityForPath), tlfPath)
+}
+
+// OfflineAvailabilityForID mocks base method
+func (m *MockofflineStatusGetter) OfflineAvailabilityForID(tlfID tlf.ID) keybase1.OfflineAvailability {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OfflineAvailabilityForID", tlfID)
+	ret0, _ := ret[0].(keybase1.OfflineAvailability)
+	return ret0
+}
+
+// OfflineAvailabilityForID indicates an expected call of OfflineAvailabilityForID
+func (mr *MockofflineStatusGetterMockRecorder) OfflineAvailabilityForID(tlfID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForID", reflect.TypeOf((*MockofflineStatusGetter)(nil).OfflineAvailabilityForID), tlfID)
+}
+
 // MocksyncedTlfGetterSetter is a mock of syncedTlfGetterSetter interface
 type MocksyncedTlfGetterSetter struct {
 	ctrl     *gomock.Controller
@@ -991,6 +1042,34 @@ func (m *MocksyncedTlfGetterSetter) GetAllSyncedTlfs() []tlf.ID {
 func (mr *MocksyncedTlfGetterSetterMockRecorder) GetAllSyncedTlfs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSyncedTlfs", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).GetAllSyncedTlfs))
+}
+
+// OfflineAvailabilityForPath mocks base method
+func (m *MocksyncedTlfGetterSetter) OfflineAvailabilityForPath(tlfPath string) keybase1.OfflineAvailability {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OfflineAvailabilityForPath", tlfPath)
+	ret0, _ := ret[0].(keybase1.OfflineAvailability)
+	return ret0
+}
+
+// OfflineAvailabilityForPath indicates an expected call of OfflineAvailabilityForPath
+func (mr *MocksyncedTlfGetterSetterMockRecorder) OfflineAvailabilityForPath(tlfPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForPath", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).OfflineAvailabilityForPath), tlfPath)
+}
+
+// OfflineAvailabilityForID mocks base method
+func (m *MocksyncedTlfGetterSetter) OfflineAvailabilityForID(tlfID tlf.ID) keybase1.OfflineAvailability {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OfflineAvailabilityForID", tlfID)
+	ret0, _ := ret[0].(keybase1.OfflineAvailability)
+	return ret0
+}
+
+// OfflineAvailabilityForID indicates an expected call of OfflineAvailabilityForID
+func (mr *MocksyncedTlfGetterSetterMockRecorder) OfflineAvailabilityForID(tlfID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForID", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).OfflineAvailabilityForID), tlfID)
 }
 
 // MockblockRetrieverGetter is a mock of blockRetrieverGetter interface
@@ -2647,9 +2726,9 @@ func (mr *MockKeybaseServiceMockRecorder) PutGitMetadata(ctx, folder, repoID, me
 }
 
 // Resolve mocks base method
-func (m *MockKeybaseService) Resolve(ctx context.Context, assertion string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *MockKeybaseService) Resolve(ctx context.Context, assertion string, offline keybase1.OfflineAvailability) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resolve", ctx, assertion)
+	ret := m.ctrl.Call(m, "Resolve", ctx, assertion, offline)
 	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
@@ -2657,9 +2736,9 @@ func (m *MockKeybaseService) Resolve(ctx context.Context, assertion string) (kbu
 }
 
 // Resolve indicates an expected call of Resolve
-func (mr *MockKeybaseServiceMockRecorder) Resolve(ctx, assertion interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) Resolve(ctx, assertion, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKeybaseService)(nil).Resolve), ctx, assertion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKeybaseService)(nil).Resolve), ctx, assertion, offline)
 }
 
 // Identify mocks base method
@@ -3043,9 +3122,9 @@ func (m *Mockresolver) EXPECT() *MockresolverMockRecorder {
 }
 
 // Resolve mocks base method
-func (m *Mockresolver) Resolve(ctx context.Context, assertion string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *Mockresolver) Resolve(ctx context.Context, assertion string, offline keybase1.OfflineAvailability) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resolve", ctx, assertion)
+	ret := m.ctrl.Call(m, "Resolve", ctx, assertion, offline)
 	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
@@ -3053,9 +3132,9 @@ func (m *Mockresolver) Resolve(ctx context.Context, assertion string) (kbun.Norm
 }
 
 // Resolve indicates an expected call of Resolve
-func (mr *MockresolverMockRecorder) Resolve(ctx, assertion interface{}) *gomock.Call {
+func (mr *MockresolverMockRecorder) Resolve(ctx, assertion, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*Mockresolver)(nil).Resolve), ctx, assertion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*Mockresolver)(nil).Resolve), ctx, assertion, offline)
 }
 
 // ResolveImplicitTeam mocks base method
@@ -3196,18 +3275,18 @@ func (m *MocknormalizedUsernameGetter) EXPECT() *MocknormalizedUsernameGetterMoc
 }
 
 // GetNormalizedUsername mocks base method
-func (m *MocknormalizedUsernameGetter) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (kbun.NormalizedUsername, error) {
+func (m *MocknormalizedUsernameGetter) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID, offline keybase1.OfflineAvailability) (kbun.NormalizedUsername, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNormalizedUsername", ctx, id)
+	ret := m.ctrl.Call(m, "GetNormalizedUsername", ctx, id, offline)
 	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNormalizedUsername indicates an expected call of GetNormalizedUsername
-func (mr *MocknormalizedUsernameGetterMockRecorder) GetNormalizedUsername(ctx, id interface{}) *gomock.Call {
+func (mr *MocknormalizedUsernameGetterMockRecorder) GetNormalizedUsername(ctx, id, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNormalizedUsername", reflect.TypeOf((*MocknormalizedUsernameGetter)(nil).GetNormalizedUsername), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNormalizedUsername", reflect.TypeOf((*MocknormalizedUsernameGetter)(nil).GetNormalizedUsername), ctx, id, offline)
 }
 
 // MockCurrentSessionGetter is a mock of CurrentSessionGetter interface
@@ -3432,9 +3511,9 @@ func (mr *MockKBPKIMockRecorder) GetCurrentSession(ctx interface{}) *gomock.Call
 }
 
 // Resolve mocks base method
-func (m *MockKBPKI) Resolve(ctx context.Context, assertion string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *MockKBPKI) Resolve(ctx context.Context, assertion string, offline keybase1.OfflineAvailability) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resolve", ctx, assertion)
+	ret := m.ctrl.Call(m, "Resolve", ctx, assertion, offline)
 	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
@@ -3442,9 +3521,9 @@ func (m *MockKBPKI) Resolve(ctx context.Context, assertion string) (kbun.Normali
 }
 
 // Resolve indicates an expected call of Resolve
-func (mr *MockKBPKIMockRecorder) Resolve(ctx, assertion interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) Resolve(ctx, assertion, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKBPKI)(nil).Resolve), ctx, assertion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKBPKI)(nil).Resolve), ctx, assertion, offline)
 }
 
 // ResolveImplicitTeam mocks base method
@@ -3539,18 +3618,18 @@ func (mr *MockKBPKIMockRecorder) IdentifyImplicitTeam(ctx, assertions, suffix, t
 }
 
 // GetNormalizedUsername mocks base method
-func (m *MockKBPKI) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (kbun.NormalizedUsername, error) {
+func (m *MockKBPKI) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID, offline keybase1.OfflineAvailability) (kbun.NormalizedUsername, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNormalizedUsername", ctx, id)
+	ret := m.ctrl.Call(m, "GetNormalizedUsername", ctx, id, offline)
 	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNormalizedUsername indicates an expected call of GetNormalizedUsername
-func (mr *MockKBPKIMockRecorder) GetNormalizedUsername(ctx, id interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetNormalizedUsername(ctx, id, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNormalizedUsername", reflect.TypeOf((*MockKBPKI)(nil).GetNormalizedUsername), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNormalizedUsername", reflect.TypeOf((*MockKBPKI)(nil).GetNormalizedUsername), ctx, id, offline)
 }
 
 // GetCurrentMerkleRoot mocks base method
@@ -9455,6 +9534,34 @@ func (mr *MockConfigMockRecorder) GetAllSyncedTlfs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSyncedTlfs", reflect.TypeOf((*MockConfig)(nil).GetAllSyncedTlfs))
 }
 
+// OfflineAvailabilityForPath mocks base method
+func (m *MockConfig) OfflineAvailabilityForPath(tlfPath string) keybase1.OfflineAvailability {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OfflineAvailabilityForPath", tlfPath)
+	ret0, _ := ret[0].(keybase1.OfflineAvailability)
+	return ret0
+}
+
+// OfflineAvailabilityForPath indicates an expected call of OfflineAvailabilityForPath
+func (mr *MockConfigMockRecorder) OfflineAvailabilityForPath(tlfPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForPath", reflect.TypeOf((*MockConfig)(nil).OfflineAvailabilityForPath), tlfPath)
+}
+
+// OfflineAvailabilityForID mocks base method
+func (m *MockConfig) OfflineAvailabilityForID(tlfID tlf.ID) keybase1.OfflineAvailability {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OfflineAvailabilityForID", tlfID)
+	ret0, _ := ret[0].(keybase1.OfflineAvailability)
+	return ret0
+}
+
+// OfflineAvailabilityForID indicates an expected call of OfflineAvailabilityForID
+func (mr *MockConfigMockRecorder) OfflineAvailabilityForID(tlfID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForID", reflect.TypeOf((*MockConfig)(nil).OfflineAvailabilityForID), tlfID)
+}
+
 // Mode mocks base method
 func (m *MockConfig) Mode() InitMode {
 	m.ctrl.T.Helper()
@@ -11514,6 +11621,20 @@ func (m *MockdirBlockMap) hasBlock(ctx context.Context, ptr BlockPointer) (bool,
 func (mr *MockdirBlockMapMockRecorder) hasBlock(ctx, ptr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hasBlock", reflect.TypeOf((*MockdirBlockMap)(nil).hasBlock), ctx, ptr)
+}
+
+// deleteBlock mocks base method
+func (m *MockdirBlockMap) deleteBlock(ctx context.Context, ptr BlockPointer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "deleteBlock", ctx, ptr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// deleteBlock indicates an expected call of deleteBlock
+func (mr *MockdirBlockMapMockRecorder) deleteBlock(ctx, ptr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteBlock", reflect.TypeOf((*MockdirBlockMap)(nil).deleteBlock), ctx, ptr)
 }
 
 // numBlocks mocks base method

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -2847,18 +2847,18 @@ func (mr *MockKeybaseServiceMockRecorder) LoadUserPlusKeys(ctx, uid, pollForKID 
 }
 
 // LoadTeamPlusKeys mocks base method
-func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole) (TeamInfo, error) {
+func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole, offline keybase1.OfflineAvailability) (TeamInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadTeamPlusKeys", ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole)
+	ret := m.ctrl.Call(m, "LoadTeamPlusKeys", ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole, offline)
 	ret0, _ := ret[0].(TeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadTeamPlusKeys indicates an expected call of LoadTeamPlusKeys
-func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTeamPlusKeys", reflect.TypeOf((*MockKeybaseService)(nil).LoadTeamPlusKeys), ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTeamPlusKeys", reflect.TypeOf((*MockKeybaseService)(nil).LoadTeamPlusKeys), ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole, offline)
 }
 
 // CurrentSession mocks base method
@@ -3351,48 +3351,48 @@ func (m *MockteamMembershipChecker) EXPECT() *MockteamMembershipCheckerMockRecor
 }
 
 // IsTeamWriter mocks base method
-func (m *MockteamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockteamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, offline keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTeamWriter", ctx, tid, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "IsTeamWriter", ctx, tid, uid, verifyingKey, offline)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsTeamWriter indicates an expected call of IsTeamWriter
-func (mr *MockteamMembershipCheckerMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockteamMembershipCheckerMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey, offline)
 }
 
 // NoLongerTeamWriter mocks base method
-func (m *MockteamMembershipChecker) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (keybase1.MerkleRootV2, error) {
+func (m *MockteamMembershipChecker) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, offline keybase1.OfflineAvailability) (keybase1.MerkleRootV2, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey, offline)
 	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NoLongerTeamWriter indicates an expected call of NoLongerTeamWriter
-func (mr *MockteamMembershipCheckerMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockteamMembershipCheckerMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey, offline)
 }
 
 // IsTeamReader mocks base method
-func (m *MockteamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+func (m *MockteamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, offline keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid)
+	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid, offline)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsTeamReader indicates an expected call of IsTeamReader
-func (mr *MockteamMembershipCheckerMockRecorder) IsTeamReader(ctx, tid, uid interface{}) *gomock.Call {
+func (mr *MockteamMembershipCheckerMockRecorder) IsTeamReader(ctx, tid, uid, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamReader), ctx, tid, uid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamReader), ctx, tid, uid, offline)
 }
 
 // MockteamKeysGetter is a mock of teamKeysGetter interface
@@ -3419,9 +3419,9 @@ func (m *MockteamKeysGetter) EXPECT() *MockteamKeysGetterMockRecorder {
 }
 
 // GetTeamTLFCryptKeys mocks base method
-func (m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
+func (m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen, offline keybase1.OfflineAvailability) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen)
+	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen, offline)
 	ret0, _ := ret[0].(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey)
 	ret1, _ := ret[1].(kbfsmd.KeyGen)
 	ret2, _ := ret[2].(error)
@@ -3429,9 +3429,9 @@ func (m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybas
 }
 
 // GetTeamTLFCryptKeys indicates an expected call of GetTeamTLFCryptKeys
-func (mr *MockteamKeysGetterMockRecorder) GetTeamTLFCryptKeys(ctx, tid, desiredKeyGen interface{}) *gomock.Call {
+func (mr *MockteamKeysGetterMockRecorder) GetTeamTLFCryptKeys(ctx, tid, desiredKeyGen, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockteamKeysGetter)(nil).GetTeamTLFCryptKeys), ctx, tid, desiredKeyGen)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockteamKeysGetter)(nil).GetTeamTLFCryptKeys), ctx, tid, desiredKeyGen, offline)
 }
 
 // MockteamRootIDGetter is a mock of teamRootIDGetter interface
@@ -3458,18 +3458,18 @@ func (m *MockteamRootIDGetter) EXPECT() *MockteamRootIDGetterMockRecorder {
 }
 
 // GetTeamRootID mocks base method
-func (m *MockteamRootIDGetter) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (keybase1.TeamID, error) {
+func (m *MockteamRootIDGetter) GetTeamRootID(ctx context.Context, tid keybase1.TeamID, offline keybase1.OfflineAvailability) (keybase1.TeamID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamRootID", ctx, tid)
+	ret := m.ctrl.Call(m, "GetTeamRootID", ctx, tid, offline)
 	ret0, _ := ret[0].(keybase1.TeamID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTeamRootID indicates an expected call of GetTeamRootID
-func (mr *MockteamRootIDGetterMockRecorder) GetTeamRootID(ctx, tid interface{}) *gomock.Call {
+func (mr *MockteamRootIDGetterMockRecorder) GetTeamRootID(ctx, tid, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockteamRootIDGetter)(nil).GetTeamRootID), ctx, tid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockteamRootIDGetter)(nil).GetTeamRootID), ctx, tid, offline)
 }
 
 // MockKBPKI is a mock of KBPKI interface
@@ -3663,54 +3663,54 @@ func (mr *MockKBPKIMockRecorder) VerifyMerkleRoot(ctx, root, kbfsRoot interface{
 }
 
 // IsTeamWriter mocks base method
-func (m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, offline keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTeamWriter", ctx, tid, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "IsTeamWriter", ctx, tid, uid, verifyingKey, offline)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsTeamWriter indicates an expected call of IsTeamWriter
-func (mr *MockKBPKIMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey, offline)
 }
 
 // NoLongerTeamWriter mocks base method
-func (m *MockKBPKI) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (keybase1.MerkleRootV2, error) {
+func (m *MockKBPKI) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, offline keybase1.OfflineAvailability) (keybase1.MerkleRootV2, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey, offline)
 	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NoLongerTeamWriter indicates an expected call of NoLongerTeamWriter
-func (mr *MockKBPKIMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey, offline)
 }
 
 // IsTeamReader mocks base method
-func (m *MockKBPKI) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+func (m *MockKBPKI) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, offline keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid)
+	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid, offline)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsTeamReader indicates an expected call of IsTeamReader
-func (mr *MockKBPKIMockRecorder) IsTeamReader(ctx, tid, uid interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) IsTeamReader(ctx, tid, uid, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockKBPKI)(nil).IsTeamReader), ctx, tid, uid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockKBPKI)(nil).IsTeamReader), ctx, tid, uid, offline)
 }
 
 // GetTeamTLFCryptKeys mocks base method
-func (m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
+func (m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen, offline keybase1.OfflineAvailability) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen)
+	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen, offline)
 	ret0, _ := ret[0].(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey)
 	ret1, _ := ret[1].(kbfsmd.KeyGen)
 	ret2, _ := ret[2].(error)
@@ -3718,24 +3718,24 @@ func (m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID
 }
 
 // GetTeamTLFCryptKeys indicates an expected call of GetTeamTLFCryptKeys
-func (mr *MockKBPKIMockRecorder) GetTeamTLFCryptKeys(ctx, tid, desiredKeyGen interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetTeamTLFCryptKeys(ctx, tid, desiredKeyGen, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockKBPKI)(nil).GetTeamTLFCryptKeys), ctx, tid, desiredKeyGen)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockKBPKI)(nil).GetTeamTLFCryptKeys), ctx, tid, desiredKeyGen, offline)
 }
 
 // GetTeamRootID mocks base method
-func (m *MockKBPKI) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (keybase1.TeamID, error) {
+func (m *MockKBPKI) GetTeamRootID(ctx context.Context, tid keybase1.TeamID, offline keybase1.OfflineAvailability) (keybase1.TeamID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamRootID", ctx, tid)
+	ret := m.ctrl.Call(m, "GetTeamRootID", ctx, tid, offline)
 	ret0, _ := ret[0].(keybase1.TeamID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTeamRootID indicates an expected call of GetTeamRootID
-func (mr *MockKBPKIMockRecorder) GetTeamRootID(ctx, tid interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetTeamRootID(ctx, tid, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockKBPKI)(nil).GetTeamRootID), ctx, tid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockKBPKI)(nil).GetTeamRootID), ctx, tid, offline)
 }
 
 // PutGitMetadata mocks base method
@@ -3946,18 +3946,18 @@ func (mr *MockKeyMetadataMockRecorder) GetTlfHandle() *gomock.Call {
 }
 
 // IsWriter mocks base method
-func (m *MockKeyMetadata) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockKeyMetadata) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, osg OfflineStatusGetter, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, osg, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsWriter indicates an expected call of IsWriter
-func (mr *MockKeyMetadataMockRecorder) IsWriter(ctx, checker, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockKeyMetadataMockRecorder) IsWriter(ctx, checker, osg, uid, verifyingKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadata)(nil).IsWriter), ctx, checker, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadata)(nil).IsWriter), ctx, checker, osg, uid, verifyingKey)
 }
 
 // HasKeyForUser mocks base method
@@ -4102,18 +4102,18 @@ func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetTlfHandle() *gomock.Ca
 }
 
 // IsWriter mocks base method
-func (m *MockKeyMetadataWithRootDirEntry) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockKeyMetadataWithRootDirEntry) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, osg OfflineStatusGetter, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, osg, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsWriter indicates an expected call of IsWriter
-func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) IsWriter(ctx, checker, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) IsWriter(ctx, checker, osg, uid, verifyingKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).IsWriter), ctx, checker, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).IsWriter), ctx, checker, osg, uid, verifyingKey)
 }
 
 // HasKeyForUser mocks base method

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -899,31 +899,31 @@ func (mr *MockdiskLimiterGetterMockRecorder) DiskLimiter() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskLimiter", reflect.TypeOf((*MockdiskLimiterGetter)(nil).DiskLimiter))
 }
 
-// MockofflineStatusGetter is a mock of offlineStatusGetter interface
-type MockofflineStatusGetter struct {
+// MockOfflineStatusGetter is a mock of OfflineStatusGetter interface
+type MockOfflineStatusGetter struct {
 	ctrl     *gomock.Controller
-	recorder *MockofflineStatusGetterMockRecorder
+	recorder *MockOfflineStatusGetterMockRecorder
 }
 
-// MockofflineStatusGetterMockRecorder is the mock recorder for MockofflineStatusGetter
-type MockofflineStatusGetterMockRecorder struct {
-	mock *MockofflineStatusGetter
+// MockOfflineStatusGetterMockRecorder is the mock recorder for MockOfflineStatusGetter
+type MockOfflineStatusGetterMockRecorder struct {
+	mock *MockOfflineStatusGetter
 }
 
-// NewMockofflineStatusGetter creates a new mock instance
-func NewMockofflineStatusGetter(ctrl *gomock.Controller) *MockofflineStatusGetter {
-	mock := &MockofflineStatusGetter{ctrl: ctrl}
-	mock.recorder = &MockofflineStatusGetterMockRecorder{mock}
+// NewMockOfflineStatusGetter creates a new mock instance
+func NewMockOfflineStatusGetter(ctrl *gomock.Controller) *MockOfflineStatusGetter {
+	mock := &MockOfflineStatusGetter{ctrl: ctrl}
+	mock.recorder = &MockOfflineStatusGetterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockofflineStatusGetter) EXPECT() *MockofflineStatusGetterMockRecorder {
+func (m *MockOfflineStatusGetter) EXPECT() *MockOfflineStatusGetterMockRecorder {
 	return m.recorder
 }
 
 // OfflineAvailabilityForPath mocks base method
-func (m *MockofflineStatusGetter) OfflineAvailabilityForPath(tlfPath string) keybase1.OfflineAvailability {
+func (m *MockOfflineStatusGetter) OfflineAvailabilityForPath(tlfPath string) keybase1.OfflineAvailability {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OfflineAvailabilityForPath", tlfPath)
 	ret0, _ := ret[0].(keybase1.OfflineAvailability)
@@ -931,13 +931,13 @@ func (m *MockofflineStatusGetter) OfflineAvailabilityForPath(tlfPath string) key
 }
 
 // OfflineAvailabilityForPath indicates an expected call of OfflineAvailabilityForPath
-func (mr *MockofflineStatusGetterMockRecorder) OfflineAvailabilityForPath(tlfPath interface{}) *gomock.Call {
+func (mr *MockOfflineStatusGetterMockRecorder) OfflineAvailabilityForPath(tlfPath interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForPath", reflect.TypeOf((*MockofflineStatusGetter)(nil).OfflineAvailabilityForPath), tlfPath)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForPath", reflect.TypeOf((*MockOfflineStatusGetter)(nil).OfflineAvailabilityForPath), tlfPath)
 }
 
 // OfflineAvailabilityForID mocks base method
-func (m *MockofflineStatusGetter) OfflineAvailabilityForID(tlfID tlf.ID) keybase1.OfflineAvailability {
+func (m *MockOfflineStatusGetter) OfflineAvailabilityForID(tlfID tlf.ID) keybase1.OfflineAvailability {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OfflineAvailabilityForID", tlfID)
 	ret0, _ := ret[0].(keybase1.OfflineAvailability)
@@ -945,9 +945,9 @@ func (m *MockofflineStatusGetter) OfflineAvailabilityForID(tlfID tlf.ID) keybase
 }
 
 // OfflineAvailabilityForID indicates an expected call of OfflineAvailabilityForID
-func (mr *MockofflineStatusGetterMockRecorder) OfflineAvailabilityForID(tlfID interface{}) *gomock.Call {
+func (mr *MockOfflineStatusGetterMockRecorder) OfflineAvailabilityForID(tlfID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForID", reflect.TypeOf((*MockofflineStatusGetter)(nil).OfflineAvailabilityForID), tlfID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfflineAvailabilityForID", reflect.TypeOf((*MockOfflineStatusGetter)(nil).OfflineAvailabilityForID), tlfID)
 }
 
 // MocksyncedTlfGetterSetter is a mock of syncedTlfGetterSetter interface
@@ -2817,18 +2817,18 @@ func (mr *MockKeybaseServiceMockRecorder) CreateTeamTLF(ctx, teamID, tlfID inter
 }
 
 // GetTeamSettings mocks base method
-func (m *MockKeybaseService) GetTeamSettings(ctx context.Context, teamID keybase1.TeamID) (keybase1.KBFSTeamSettings, error) {
+func (m *MockKeybaseService) GetTeamSettings(ctx context.Context, teamID keybase1.TeamID, offline keybase1.OfflineAvailability) (keybase1.KBFSTeamSettings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamSettings", ctx, teamID)
+	ret := m.ctrl.Call(m, "GetTeamSettings", ctx, teamID, offline)
 	ret0, _ := ret[0].(keybase1.KBFSTeamSettings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTeamSettings indicates an expected call of GetTeamSettings
-func (mr *MockKeybaseServiceMockRecorder) GetTeamSettings(ctx, teamID interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) GetTeamSettings(ctx, teamID, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamSettings", reflect.TypeOf((*MockKeybaseService)(nil).GetTeamSettings), ctx, teamID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamSettings", reflect.TypeOf((*MockKeybaseService)(nil).GetTeamSettings), ctx, teamID, offline)
 }
 
 // LoadUserPlusKeys mocks base method
@@ -3168,18 +3168,18 @@ func (mr *MockresolverMockRecorder) ResolveImplicitTeamByID(ctx, teamID, tlfType
 }
 
 // ResolveTeamTLFID mocks base method
-func (m *Mockresolver) ResolveTeamTLFID(ctx context.Context, teamID keybase1.TeamID) (tlf.ID, error) {
+func (m *Mockresolver) ResolveTeamTLFID(ctx context.Context, teamID keybase1.TeamID, offline keybase1.OfflineAvailability) (tlf.ID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveTeamTLFID", ctx, teamID)
+	ret := m.ctrl.Call(m, "ResolveTeamTLFID", ctx, teamID, offline)
 	ret0, _ := ret[0].(tlf.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveTeamTLFID indicates an expected call of ResolveTeamTLFID
-func (mr *MockresolverMockRecorder) ResolveTeamTLFID(ctx, teamID interface{}) *gomock.Call {
+func (mr *MockresolverMockRecorder) ResolveTeamTLFID(ctx, teamID, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTeamTLFID", reflect.TypeOf((*Mockresolver)(nil).ResolveTeamTLFID), ctx, teamID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTeamTLFID", reflect.TypeOf((*Mockresolver)(nil).ResolveTeamTLFID), ctx, teamID, offline)
 }
 
 // NormalizeSocialAssertion mocks base method
@@ -3557,18 +3557,18 @@ func (mr *MockKBPKIMockRecorder) ResolveImplicitTeamByID(ctx, teamID, tlfType in
 }
 
 // ResolveTeamTLFID mocks base method
-func (m *MockKBPKI) ResolveTeamTLFID(ctx context.Context, teamID keybase1.TeamID) (tlf.ID, error) {
+func (m *MockKBPKI) ResolveTeamTLFID(ctx context.Context, teamID keybase1.TeamID, offline keybase1.OfflineAvailability) (tlf.ID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveTeamTLFID", ctx, teamID)
+	ret := m.ctrl.Call(m, "ResolveTeamTLFID", ctx, teamID, offline)
 	ret0, _ := ret[0].(tlf.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveTeamTLFID indicates an expected call of ResolveTeamTLFID
-func (mr *MockKBPKIMockRecorder) ResolveTeamTLFID(ctx, teamID interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) ResolveTeamTLFID(ctx, teamID, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTeamTLFID", reflect.TypeOf((*MockKBPKI)(nil).ResolveTeamTLFID), ctx, teamID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTeamTLFID", reflect.TypeOf((*MockKBPKI)(nil).ResolveTeamTLFID), ctx, teamID, offline)
 }
 
 // NormalizeSocialAssertion mocks base method

--- a/go/kbfs/libkbfs/root_metadata.go
+++ b/go/kbfs/libkbfs/root_metadata.go
@@ -230,8 +230,8 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 func (md *RootMetadata) MakeSuccessor(
 	ctx context.Context, latestMDVer kbfsmd.MetadataVer, codec kbfscodec.Codec,
 	keyManager KeyManager, merkleGetter merkleRootGetter,
-	teamKeyer teamKeysGetter, mdID kbfsmd.ID, isWriter bool) (
-	*RootMetadata, error) {
+	teamKeyer teamKeysGetter, osg OfflineStatusGetter, mdID kbfsmd.ID,
+	isWriter bool) (*RootMetadata, error) {
 	if mdID == (kbfsmd.ID{}) {
 		return nil, errors.New("Empty MdID in MakeSuccessor")
 	}
@@ -266,8 +266,14 @@ func (md *RootMetadata) MakeSuccessor(
 			if err != nil {
 				return nil, err
 			}
+
+			offline := keybase1.OfflineAvailability_NONE
+			if osg != nil {
+				offline = osg.OfflineAvailabilityForID(md.TlfID())
+			}
+
 			_, keyGen, err := teamKeyer.GetTeamTLFCryptKeys(
-				ctx, tid, kbfsmd.UnspecifiedKeyGen)
+				ctx, tid, kbfsmd.UnspecifiedKeyGen, offline)
 			if err != nil {
 				return nil, err
 			}
@@ -295,8 +301,8 @@ func (md *RootMetadata) MakeSuccessor(
 func (md *RootMetadata) MakeSuccessorWithNewHandle(
 	ctx context.Context, newHandle *TlfHandle, latestMDVer kbfsmd.MetadataVer,
 	codec kbfscodec.Codec, keyManager KeyManager, merkleGetter merkleRootGetter,
-	teamKeyer teamKeysGetter, mdID kbfsmd.ID, isWriter bool) (
-	*RootMetadata, error) {
+	teamKeyer teamKeysGetter, osg OfflineStatusGetter, mdID kbfsmd.ID,
+	isWriter bool) (*RootMetadata, error) {
 	mdCopy, err := md.deepCopy(codec)
 	if err != nil {
 		return nil, err
@@ -313,8 +319,8 @@ func (md *RootMetadata) MakeSuccessorWithNewHandle(
 	mdCopy.bareMd.ClearForV4Migration()
 
 	return mdCopy.MakeSuccessor(
-		ctx, latestMDVer, codec, keyManager, merkleGetter, teamKeyer, mdID,
-		isWriter)
+		ctx, latestMDVer, codec, keyManager, merkleGetter, teamKeyer, osg,
+		mdID, isWriter)
 }
 
 // GetTlfHandle returns the TlfHandle for this RootMetadata.
@@ -900,19 +906,19 @@ func (md *RootMetadata) GetHistoricTLFCryptKey(
 // right now.  Implements the KeyMetadata interface for RootMetadata.
 func (md *RootMetadata) IsWriter(
 	ctx context.Context, checker kbfsmd.TeamMembershipChecker,
-	uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (
-	bool, error) {
+	osg OfflineStatusGetter, uid keybase1.UID,
+	verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	h := md.GetTlfHandle()
-	return IsWriterFromHandle(ctx, h, checker, uid, verifyingKey)
+	return IsWriterFromHandle(ctx, h, checker, osg, uid, verifyingKey)
 }
 
 // IsReader checks that the given user is a valid reader of the TLF
 // right now.
 func (md *RootMetadata) IsReader(
 	ctx context.Context, checker kbfsmd.TeamMembershipChecker,
-	uid keybase1.UID) (bool, error) {
+	osg OfflineStatusGetter, uid keybase1.UID) (bool, error) {
 	h := md.GetTlfHandle()
-	return isReaderFromHandle(ctx, h, checker, uid)
+	return isReaderFromHandle(ctx, h, checker, osg, uid)
 }
 
 // A ReadOnlyRootMetadata is a thin wrapper around a

--- a/go/kbfs/libkbfs/root_metadata_test.go
+++ b/go/kbfs/libkbfs/root_metadata_test.go
@@ -360,7 +360,7 @@ func testRootMetadataFinalIsFinal(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	rmd.SetFinalBit()
 	_, err = rmd.MakeSuccessor(context.Background(), -1, nil, nil, nil,
-		nil, kbfsmd.FakeID(1), true)
+		nil, nil, kbfsmd.FakeID(1), true)
 	_, isFinalError := err.(kbfsmd.MetadataIsFinalError)
 	require.Equal(t, isFinalError, true)
 }
@@ -484,8 +484,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), nil,
+		kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(2), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -576,8 +576,8 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), config,
+		kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.PublicKeyGen, rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -646,8 +646,8 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), config,
+		kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -767,7 +767,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		configReader.MetadataVersion(), configReader.Codec(),
 		configReader.KeyManager(), configReader.KBPKI(),
-		configReader.KBPKI(), kbfsmd.FakeID(1), false)
+		configReader.KBPKI(), configReader, kbfsmd.FakeID(1), false)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -791,7 +791,8 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 		rmd2.bareMd, configReader.Clock().Now())
 	require.NoError(t, err)
 	err = rmds.IsValidAndSigned(
-		ctx, configReader.Codec(), nil, rmd2.extra)
+		ctx, configReader.Codec(), nil, rmd2.extra,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 }
 
@@ -835,12 +836,12 @@ func TestRootMetadataTeamMembership(t *testing.T) {
 	// No user should be able to read this yet.
 	checkWriter := func(uid keybase1.UID, key kbfscrypto.VerifyingKey,
 		expectedIsWriter bool) {
-		isWriter, err := rmd.IsWriter(ctx, config.KBPKI(), uid, key)
+		isWriter, err := rmd.IsWriter(ctx, config.KBPKI(), config, uid, key)
 		require.NoError(t, err)
 		require.Equal(t, expectedIsWriter, isWriter)
 	}
 	checkReader := func(uid keybase1.UID, expectedIsReader bool) {
-		isReader, err := rmd.IsReader(ctx, config.KBPKI(), uid)
+		isReader, err := rmd.IsReader(ctx, config.KBPKI(), config, uid)
 		require.NoError(t, err)
 		require.Equal(t, expectedIsReader, isReader)
 	}
@@ -908,8 +909,8 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), config,
+		kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 
 	// No increase yet.
@@ -920,8 +921,8 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 
 	rmd3, err := rmd2.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(2),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), config,
+		kbfsmd.FakeID(2), true)
 	require.NoError(t, err)
 
 	// Should have been bumped by one.

--- a/go/kbfs/libkbfs/root_metadata_test.go
+++ b/go/kbfs/libkbfs/root_metadata_test.go
@@ -298,7 +298,8 @@ func testMakeRekeyReadError(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	rmd.fakeInitialRekey()
 
-	u, id, err := config.KBPKI().Resolve(ctx, "bob")
+	u, id, err := config.KBPKI().Resolve(
+		ctx, "bob", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	uid, err := id.AsUser()
 	require.NoError(t, err)
@@ -319,14 +320,16 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver kbfsmd.MetadataVer) 
 
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "alice,bob@twitter", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), nil,
+		"alice,bob@twitter", tlf.Private)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
 
 	rmd.fakeInitialRekey()
 
-	u, id, err := config.KBPKI().Resolve(ctx, "bob")
+	u, id, err := config.KBPKI().Resolve(
+		ctx, "bob", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	uid, err := id.AsUser()
 	require.NoError(t, err)
@@ -338,7 +341,7 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver kbfsmd.MetadataVer) 
 	config.KeybaseService().(*KeybaseDaemonLocal).addNewAssertionForTestOrBust(
 		"bob", "bob@twitter")
 
-	resolvedHandle, err := h.ResolveAgain(ctx, config.KBPKI(), nil)
+	resolvedHandle, err := h.ResolveAgain(ctx, config.KBPKI(), nil, nil)
 	require.NoError(t, err)
 
 	dummyErr := errors.New("dummy")
@@ -420,7 +423,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.Equal(t, 1, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 
 	// revoke bob's device
-	_, bobID, err := config.KBPKI().Resolve(context.Background(), "bob")
+	_, bobID, err := config.KBPKI().Resolve(
+		context.Background(), "bob", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	bobUID, err := bobID.AsUser()
 	require.NoError(t, err)
@@ -452,7 +456,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.Equal(t, 0, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
 	// add a device for charlie and rekey as charlie
-	_, charlieID, err := config.KBPKI().Resolve(context.Background(), "charlie")
+	_, charlieID, err := config.KBPKI().Resolve(
+		context.Background(), "charlie", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	charlieUID, err := charlieID.AsUser()
 	require.NoError(t, err)
@@ -666,7 +671,8 @@ func TestRootMetadataV3NoPanicOnWriterMismatch(t *testing.T) {
 	config := MakeTestConfigOrBust(t, "alice", "bob")
 	defer config.Shutdown(ctx)
 
-	_, id, err := config.KBPKI().Resolve(context.Background(), "alice")
+	_, id, err := config.KBPKI().Resolve(
+		context.Background(), "alice", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	uid, err := id.AsUser()
 	require.NoError(t, err)
@@ -731,7 +737,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	// Set the private MD, to make sure it gets copied properly during
 	// upconversion.
 	_, aliceID, err := configWriter.KBPKI().Resolve(
-		context.Background(), "alice")
+		context.Background(), "alice", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	aliceUID, err := aliceID.AsUser()
 	require.NoError(t, err)
@@ -742,7 +748,8 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	require.NoError(t, err)
 
 	// add a device for bob and rekey as bob
-	_, bobID, err := configWriter.KBPKI().Resolve(context.Background(), "bob")
+	_, bobID, err := configWriter.KBPKI().Resolve(
+		context.Background(), "bob", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	bobUID, err := bobID.AsUser()
 	require.NoError(t, err)
@@ -809,7 +816,8 @@ func TestRootMetadataTeamMembership(t *testing.T) {
 	require.NoError(t, err)
 
 	getUser := func(name string) (keybase1.UID, kbfscrypto.VerifyingKey) {
-		_, id, err := config.KBPKI().Resolve(context.Background(), name)
+		_, id, err := config.KBPKI().Resolve(
+			context.Background(), name, keybase1.OfflineAvailability_NONE)
 		require.NoError(t, err)
 		uid, err := id.AsUser()
 		require.NoError(t, err)

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -837,7 +837,8 @@ func CheckConfigAndShutdown(
 func GetRootNodeForTest(
 	ctx context.Context, config Config, name string,
 	t tlf.Type) (Node, error) {
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), config.MDOps(), name, t)
+	h, err := ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), config, name, t)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -551,7 +551,7 @@ func AddTeamKeyForTest(config Config, tid keybase1.TeamID) error {
 	ti, err := kbd.LoadTeamPlusKeys(
 		context.Background(), tid, tlf.Unknown, kbfsmd.UnspecifiedKeyGen,
 		keybase1.UserVersion{}, kbfscrypto.VerifyingKey{},
-		keybase1.TeamRole_NONE)
+		keybase1.TeamRole_NONE, keybase1.OfflineAvailability_NONE)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/tlf_handle_resolve.go
+++ b/go/kbfs/libkbfs/tlf_handle_resolve.go
@@ -305,7 +305,8 @@ func (ruid resolvableID) resolve(ctx context.Context) (
 	var tlfID tlf.ID
 	// Only get a team TLF ID if the caller expects to use it.
 	if ruid.idGetter != nil && ruid.id.IsTeamOrSubteam() {
-		tlfID, err = ruid.resolver.ResolveTeamTLFID(ctx, ruid.id.AsTeamOrBust())
+		tlfID, err = ruid.resolver.ResolveTeamTLFID(
+			ctx, ruid.id.AsTeamOrBust(), ruid.offline)
 		if err != nil {
 			return nameIDPair{}, keybase1.SocialAssertion{}, tlf.NullID, err
 		}
@@ -663,7 +664,8 @@ func (ra resolvableAssertion) resolve(ctx context.Context) (
 		var tlfID tlf.ID
 		// Only get a team TLF ID if the caller expects to use it.
 		if ra.idGetter != nil && id.IsTeamOrSubteam() {
-			tlfID, err = ra.resolver.ResolveTeamTLFID(ctx, id.AsTeamOrBust())
+			tlfID, err = ra.resolver.ResolveTeamTLFID(
+				ctx, id.AsTeamOrBust(), ra.offline)
 			if err != nil {
 				return nameIDPair{}, keybase1.SocialAssertion{}, tlf.NullID, err
 			}

--- a/go/kbfs/libkbfs/tlf_handle_resolve.go
+++ b/go/kbfs/libkbfs/tlf_handle_resolve.go
@@ -273,6 +273,7 @@ type resolvableID struct {
 	nug      normalizedUsernameGetter
 	id       keybase1.UserOrTeamID
 	tlfType  tlf.Type
+	offline  keybase1.OfflineAvailability
 }
 
 func (ruid resolvableID) resolve(ctx context.Context) (
@@ -297,7 +298,7 @@ func (ruid resolvableID) resolve(ctx context.Context) (
 
 	// If not, resolve it the normal way, and assume it's a classic
 	// TLF.
-	name, err := ruid.nug.GetNormalizedUsername(ctx, ruid.id)
+	name, err := ruid.nug.GetNormalizedUsername(ctx, ruid.id, ruid.offline)
 	if err != nil {
 		return nameIDPair{}, keybase1.SocialAssertion{}, tlf.NullID, err
 	}
@@ -328,11 +329,13 @@ func (rsa resolvableSocialAssertion) resolve(ctx context.Context) (
 // from `bareHandle.Type()`, if this is an implicit team TLF.)
 func MakeTlfHandle(
 	ctx context.Context, bareHandle tlf.Handle, t tlf.Type,
-	resolver resolver, nug normalizedUsernameGetter, idGetter tlfIDGetter) (
+	resolver resolver, nug normalizedUsernameGetter, idGetter tlfIDGetter,
+	offline keybase1.OfflineAvailability) (
 	*TlfHandle, error) {
 	writers := make([]resolvableUser, 0, len(bareHandle.Writers)+len(bareHandle.UnresolvedWriters))
 	for _, w := range bareHandle.Writers {
-		writers = append(writers, resolvableID{resolver, idGetter, nug, w, t})
+		writers = append(
+			writers, resolvableID{resolver, idGetter, nug, w, t, offline})
 	}
 	for _, uw := range bareHandle.UnresolvedWriters {
 		writers = append(writers, resolvableSocialAssertion(uw))
@@ -343,7 +346,7 @@ func MakeTlfHandle(
 		readers = make([]resolvableUser, 0, len(bareHandle.Readers)+len(bareHandle.UnresolvedReaders))
 		for _, r := range bareHandle.Readers {
 			readers = append(
-				readers, resolvableID{resolver, idGetter, nug, r, t})
+				readers, resolvableID{resolver, idGetter, nug, r, t, offline})
 		}
 		for _, ur := range bareHandle.UnresolvedReaders {
 			readers = append(readers, resolvableSocialAssertion(ur))
@@ -379,10 +382,16 @@ func (rp resolvableNameUIDPair) resolve(ctx context.Context) (
 // optimization, if h contains no unresolved assertions, it just
 // returns itself.  If uid != keybase1.UID(""), it only allows
 // assertions that resolve to uid.
-func (h *TlfHandle) ResolveAgainForUser(ctx context.Context, resolver resolver,
-	idGetter tlfIDGetter, uid keybase1.UID) (*TlfHandle, error) {
+func (h *TlfHandle) ResolveAgainForUser(
+	ctx context.Context, resolver resolver, idGetter tlfIDGetter,
+	osg OfflineStatusGetter, uid keybase1.UID) (*TlfHandle, error) {
 	if len(h.unresolvedWriters)+len(h.unresolvedReaders) == 0 {
 		return h, nil
+	}
+
+	offline := keybase1.OfflineAvailability_NONE
+	if osg != nil {
+		offline = osg.OfflineAvailabilityForID(h.tlfID)
 	}
 
 	writers := make([]resolvableUser, 0, len(h.resolvedWriters)+len(h.unresolvedWriters))
@@ -391,7 +400,7 @@ func (h *TlfHandle) ResolveAgainForUser(ctx context.Context, resolver resolver,
 	}
 	for _, uw := range h.unresolvedWriters {
 		writers = append(writers, resolvableAssertion{
-			resolver, nil, idGetter, uw.String(), uid})
+			resolver, nil, idGetter, uw.String(), uid, offline})
 	}
 
 	var readers []resolvableUser
@@ -402,7 +411,7 @@ func (h *TlfHandle) ResolveAgainForUser(ctx context.Context, resolver resolver,
 		}
 		for _, ur := range h.unresolvedReaders {
 			readers = append(readers, resolvableAssertion{
-				resolver, nil, idGetter, ur.String(), uid})
+				resolver, nil, idGetter, ur.String(), uid, offline})
 		}
 	}
 
@@ -420,13 +429,14 @@ func (h *TlfHandle) ResolveAgainForUser(ctx context.Context, resolver resolver,
 // optimization, if h contains no unresolved assertions, it just
 // returns itself.
 func (h *TlfHandle) ResolveAgain(
-	ctx context.Context, resolver resolver, idGetter tlfIDGetter) (
-	*TlfHandle, error) {
+	ctx context.Context, resolver resolver, idGetter tlfIDGetter,
+	osg OfflineStatusGetter) (*TlfHandle, error) {
 	if h.IsFinal() {
 		// Don't attempt to further resolve final handles.
 		return h, nil
 	}
-	return h.ResolveAgainForUser(ctx, resolver, idGetter, keybase1.UID(""))
+	return h.ResolveAgainForUser(
+		ctx, resolver, idGetter, osg, keybase1.UID(""))
 }
 
 type partialResolver struct {
@@ -434,14 +444,16 @@ type partialResolver struct {
 	unresolvedAssertions map[string]bool
 }
 
-func (pr partialResolver) Resolve(ctx context.Context, assertion string) (
+func (pr partialResolver) Resolve(
+	ctx context.Context, assertion string,
+	offline keybase1.OfflineAvailability) (
 	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	if pr.unresolvedAssertions[assertion] {
 		// Force an unresolved assertion.
 		return kbname.NormalizedUsername(""),
 			keybase1.UserOrTeamID(""), NoSuchUserError{assertion}
 	}
-	return pr.resolver.Resolve(ctx, assertion)
+	return pr.resolver.Resolve(ctx, assertion, offline)
 }
 
 // ResolvesTo returns whether this handle resolves to the given one.
@@ -450,7 +462,7 @@ func (pr partialResolver) Resolve(ctx context.Context, assertion string) (
 // equal other if and only if true is returned.
 func (h TlfHandle) ResolvesTo(
 	ctx context.Context, codec kbfscodec.Codec, resolver resolver,
-	idGetter tlfIDGetter, other TlfHandle) (
+	idGetter tlfIDGetter, osg OfflineStatusGetter, other TlfHandle) (
 	resolvesTo bool, partialResolvedH *TlfHandle, err error) {
 	// Check the conflict extension.
 	var conflictAdded, finalizedAdded bool
@@ -489,7 +501,8 @@ func (h TlfHandle) ResolvesTo(
 		// TlfHandle, restrict the resolver to use other's assertions
 		// only, so that we don't hit the network at all.
 		partialResolvedH, err = h.ResolveAgain(
-			ctx, partialResolver{resolver, unresolvedAssertions}, idGetter)
+			ctx, partialResolver{resolver, unresolvedAssertions}, idGetter,
+			osg)
 		if err != nil {
 			return false, nil, err
 		}
@@ -530,17 +543,18 @@ func (h TlfHandle) ResolvesTo(
 // `other` handle, resolve to each other.
 func (h TlfHandle) MutuallyResolvesTo(
 	ctx context.Context, codec kbfscodec.Codec,
-	resolver resolver, idGetter tlfIDGetter, other TlfHandle,
-	rev kbfsmd.Revision, tlfID tlf.ID, log logger.Logger) error {
+	resolver resolver, idGetter tlfIDGetter, osg OfflineStatusGetter,
+	other TlfHandle, rev kbfsmd.Revision, tlfID tlf.ID,
+	log logger.Logger) error {
 	handleResolvesToOther, partialResolvedHandle, err :=
-		h.ResolvesTo(ctx, codec, resolver, idGetter, other)
+		h.ResolvesTo(ctx, codec, resolver, idGetter, osg, other)
 	if err != nil {
 		return err
 	}
 
 	// TODO: If h has conflict info, other should, too.
 	otherResolvesToHandle, partialResolvedOther, err :=
-		other.ResolvesTo(ctx, codec, resolver, idGetter, h)
+		other.ResolvesTo(ctx, codec, resolver, idGetter, osg, h)
 	if err != nil {
 		return err
 	}
@@ -602,6 +616,7 @@ type resolvableAssertion struct {
 	idGetter   tlfIDGetter
 	assertion  string
 	mustBeUser keybase1.UID
+	offline    keybase1.OfflineAvailability
 }
 
 func (ra resolvableAssertion) resolve(ctx context.Context) (
@@ -610,7 +625,7 @@ func (ra resolvableAssertion) resolve(ctx context.Context) (
 		return nameIDPair{}, keybase1.SocialAssertion{}, tlf.NullID,
 			fmt.Errorf("Invalid name %s", ra.assertion)
 	}
-	name, id, err := ra.resolver.Resolve(ctx, ra.assertion)
+	name, id, err := ra.resolver.Resolve(ctx, ra.assertion, ra.offline)
 	if err == nil && ra.mustBeUser != keybase1.UID("") &&
 		ra.mustBeUser.AsUserOrTeam() != id {
 		// Force an unresolved assertion sinced the forced user doesn't match
@@ -702,8 +717,9 @@ func doResolveImplicit(_ context.Context, t tlf.Type) bool {
 // parseTlfHandleLoose parses a TLF handle but leaves some of the canonicality
 // checking to public routines like ParseTlfHandle and ParseTlfHandlePreferred.
 func parseTlfHandleLoose(
-	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter, name string,
-	t tlf.Type) (*TlfHandle, error) {
+	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter,
+	osg OfflineStatusGetter, name string, t tlf.Type) (
+	*TlfHandle, error) {
 	writerNames, readerNames, extensionSuffix, err :=
 		splitAndNormalizeTLFName(name, t)
 	if err != nil {
@@ -759,6 +775,17 @@ func parseTlfHandleLoose(
 		// (i.e., when we start creating them by default).
 	}
 
+	offline := keybase1.OfflineAvailability_NONE
+	if osg != nil {
+		normalizedName, _, err := normalizeNamesInTLF(
+			writerNames, readerNames, t, extensionSuffix)
+		if err != nil {
+			return nil, err
+		}
+		offline = osg.OfflineAvailabilityForPath(
+			buildCanonicalPathForTlfName(t, tlf.CanonicalName(normalizedName)))
+	}
+
 	// Before parsing the tlf handle (which results in identify
 	// calls that cause tracker popups), first see if there's any
 	// quick normalization of usernames we can do.  For example,
@@ -776,12 +803,12 @@ func parseTlfHandleLoose(
 			w = "team:" + w
 		}
 		writers[i] = resolvableAssertionWithChangeReport{resolvableAssertion{
-			kbpki, kbpki, idGetter, w, keybase1.UID("")}, changesCh}
+			kbpki, kbpki, idGetter, w, keybase1.UID(""), offline}, changesCh}
 	}
 	readers := make([]resolvableUser, len(readerNames))
 	for i, r := range readerNames {
 		readers[i] = resolvableAssertionWithChangeReport{resolvableAssertion{
-			kbpki, kbpki, idGetter, r, keybase1.UID("")}, changesCh}
+			kbpki, kbpki, idGetter, r, keybase1.UID(""), offline}, changesCh}
 	}
 
 	h, err := makeTlfHandleHelper(
@@ -875,9 +902,10 @@ func parseTlfHandleLoose(
 // TODO In future perhaps all code should switch over to preferred handles,
 // and rename TlfNameNotCanonical to TlfNameNotPreferred.
 func ParseTlfHandle(
-	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter, name string,
-	t tlf.Type) (*TlfHandle, error) {
-	h, err := parseTlfHandleLoose(ctx, kbpki, idGetter, name, t)
+	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter,
+	osg OfflineStatusGetter, name string, t tlf.Type) (
+	*TlfHandle, error) {
+	h, err := parseTlfHandleLoose(ctx, kbpki, idGetter, osg, name, t)
 	if err != nil {
 		return nil, err
 	}
@@ -899,9 +927,10 @@ func ParseTlfHandle(
 // TlfNameNotCanonical is returned from this function when the name is
 // not the *preferred* name.
 func ParseTlfHandlePreferred(
-	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter, name string,
-	t tlf.Type) (*TlfHandle, error) {
-	h, err := parseTlfHandleLoose(ctx, kbpki, idGetter, name, t)
+	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter,
+	osg OfflineStatusGetter, name string, t tlf.Type) (
+	*TlfHandle, error) {
+	h, err := parseTlfHandleLoose(ctx, kbpki, idGetter, osg, name, t)
 	// Return an early if there is an error, except in the case
 	// where both h is not nil and it is a TlfNameNotCanonicalError.
 	// In that case continue and return TlfNameNotCanonical later

--- a/go/kbfs/libkbfs/tlf_handle_test.go
+++ b/go/kbfs/libkbfs/tlf_handle_test.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -44,11 +45,11 @@ func TestParseTlfHandleEarlyFailure(t *testing.T) {
 	ctx := context.Background()
 
 	name := "w1,w2#r1"
-	_, err := ParseTlfHandle(ctx, nil, nil, name, tlf.Public)
+	_, err := ParseTlfHandle(ctx, nil, nil, nil, name, tlf.Public)
 	assert.Equal(t, NoSuchNameError{Name: name}, err)
 
 	nonCanonicalName := "W1,w2#r1"
-	_, err = ParseTlfHandle(ctx, nil, nil, nonCanonicalName, tlf.Private)
+	_, err = ParseTlfHandle(ctx, nil, nil, nil, nonCanonicalName, tlf.Private)
 	assert.Equal(
 		t, TlfNameNotCanonical{nonCanonicalName, name}, errors.Cause(err))
 }
@@ -68,7 +69,7 @@ func TestParseTlfHandleNoUserFailure(t *testing.T) {
 	}
 
 	name := "u2,u3#u4"
-	_, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	_, err := ParseTlfHandle(ctx, kbpki, nil, nil, name, tlf.Private)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	assert.Equal(t, NoSuchUserError{"u4"}, err)
 }
@@ -89,7 +90,7 @@ func TestParseTlfHandleNotReaderFailure(t *testing.T) {
 
 	name := "u2,u3"
 	_, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil, name,
 		tlf.Private)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	assert.Equal(t, ReadAccessError{User: "u1", Tlf: tlf.CanonicalName(name), Type: tlf.Private, Filename: "/keybase/private/u2,u3"}, err)
@@ -116,7 +117,7 @@ func TestParseTlfHandleSingleTeam(t *testing.T) {
 	}
 
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlfID}, "t1", tlf.SingleTeam)
+		ctx, kbpki, constIDGetter{tlfID}, nil, "t1", tlf.SingleTeam)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	require.NoError(t, err)
 	require.Equal(t, tlfID, h.tlfID)
@@ -137,12 +138,12 @@ func TestParseTlfHandleSingleTeamFailures(t *testing.T) {
 		},
 	}
 
-	_, err := ParseTlfHandle(ctx, kbpki, nil, "u1", tlf.SingleTeam)
+	_, err := ParseTlfHandle(ctx, kbpki, nil, nil, "u1", tlf.SingleTeam)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	assert.Equal(t, NoSuchUserError{Input: "u1@team"}, err)
 
 	checkNoSuchName := func(name string, ty tlf.Type) {
-		_, err := ParseTlfHandle(ctx, kbpki, nil, name, ty)
+		_, err := ParseTlfHandle(ctx, kbpki, nil, nil, name, ty)
 		assert.Equal(t, 0, kbpki.getIdentifyCalls())
 		if ty == tlf.SingleTeam {
 			assert.Equal(t, NoSuchNameError{Name: name}, err)
@@ -181,7 +182,7 @@ func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {
 	name := "u1,u3#u2"
 	nonCanonicalName := "u1,u3@twitter#u2"
 	_, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)},
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
 		nonCanonicalName, tlf.Private)
 	// Names with assertions should be identified before the error
 	// is returned.
@@ -206,7 +207,7 @@ func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 
 	name := "u1,u3"
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil, name,
 		tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
@@ -216,7 +217,7 @@ func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 	// name.
 	h2, err := MakeTlfHandle(
 		context.Background(), h.ToBareHandleOrBust(), tlf.Private,
-		kbpki, kbpki, nil)
+		kbpki, kbpki, nil, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }
@@ -237,7 +238,8 @@ func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 
 	name := "u1,u2,u3"
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Public)}, name, tlf.Public)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Public)}, nil,
+		name, tlf.Public)
 	require.NoError(t, err)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
@@ -246,7 +248,7 @@ func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 	// name.
 	h2, err := MakeTlfHandle(
 		context.Background(), h.ToBareHandleOrBust(), tlf.Public,
-		kbpki, kbpki, nil)
+		kbpki, kbpki, nil, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }
@@ -265,8 +267,8 @@ func TestTlfHandleAccessorsPrivate(t *testing.T) {
 
 	name := "u1,u2@twitter,u3,u4@twitter#u2,u5@twitter,u6@twitter"
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
-		tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		name, tlf.Private)
 	require.NoError(t, err)
 
 	require.False(t, h.Type() == tlf.Public)
@@ -336,7 +338,8 @@ func TestTlfHandleAccessorsPublic(t *testing.T) {
 
 	name := "u1,u2@twitter,u3,u4@twitter"
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Public)}, name, tlf.Public)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Public)}, nil,
+		name, tlf.Public)
 	require.NoError(t, err)
 
 	require.True(t, h.Type() == tlf.Public)
@@ -392,7 +395,7 @@ func TestTlfHandleConflictInfo(t *testing.T) {
 
 	name := "u1,u2,u3"
 	cname := tlf.CanonicalName(name)
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Public)
+	h, err := ParseTlfHandle(ctx, kbpki, nil, nil, name, tlf.Public)
 	require.NoError(t, err)
 
 	require.Nil(t, h.ConflictInfo())
@@ -454,7 +457,7 @@ func TestTlfHandleFinalizedInfo(t *testing.T) {
 
 	name := "u1,u2,u3"
 	cname := tlf.CanonicalName(name)
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Public)
+	h, err := ParseTlfHandle(ctx, kbpki, nil, nil, name, tlf.Public)
 	require.NoError(t, err)
 
 	require.Nil(t, h.FinalizedInfo())
@@ -489,7 +492,7 @@ func TestTlfHandleConflictAndFinalizedInfo(t *testing.T) {
 	}
 
 	name := "u1,u2,u3"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Public)
+	h, err := ParseTlfHandle(ctx, kbpki, nil, nil, name, tlf.Public)
 	require.NoError(t, err)
 
 	require.Nil(t, h.ConflictInfo())
@@ -532,7 +535,7 @@ func TestTlfHandlEqual(t *testing.T) {
 	}
 
 	name1 := "u1,u2@twitter,u3,u4@twitter"
-	h1, err := ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Public)
+	h1, err := ParseTlfHandle(ctx, kbpki, nil, nil, name1, tlf.Public)
 	require.NoError(t, err)
 
 	eq, err := h1.Equals(codec, *h1)
@@ -541,7 +544,7 @@ func TestTlfHandlEqual(t *testing.T) {
 
 	// Test public bit.
 
-	h2, err := ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Private)
+	h2, err := ParseTlfHandle(ctx, kbpki, nil, nil, name1, tlf.Private)
 	require.NoError(t, err)
 	eq, err = h1.Equals(codec, *h2)
 	require.NoError(t, err)
@@ -550,7 +553,7 @@ func TestTlfHandlEqual(t *testing.T) {
 	// Test resolved and unresolved readers and writers.
 
 	name1 = "u1,u2@twitter#u3,u4@twitter"
-	h1, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Private)
+	h1, err = ParseTlfHandle(ctx, kbpki, nil, nil, name1, tlf.Private)
 	require.NoError(t, err)
 
 	for _, name2 := range []string{
@@ -559,7 +562,7 @@ func TestTlfHandlEqual(t *testing.T) {
 		"u1,u2@twitter#u4@twitter,u5",
 		"u1,u2@twitter#u3,u5@twitter",
 	} {
-		h2, err := ParseTlfHandle(ctx, kbpki, nil, name2, tlf.Private)
+		h2, err := ParseTlfHandle(ctx, kbpki, nil, nil, name2, tlf.Private)
 		require.NoError(t, err)
 		eq, err := h1.Equals(codec, *h2)
 		require.NoError(t, err)
@@ -568,7 +571,7 @@ func TestTlfHandlEqual(t *testing.T) {
 
 	// Test conflict info and finalized info.
 
-	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Private)
+	h2, err = ParseTlfHandle(ctx, kbpki, nil, nil, name1, tlf.Private)
 	require.NoError(t, err)
 	info := tlf.HandleExtension{
 		Date:   100,
@@ -582,7 +585,7 @@ func TestTlfHandlEqual(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, eq)
 
-	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Private)
+	h2, err = ParseTlfHandle(ctx, kbpki, nil, nil, name1, tlf.Private)
 	require.NoError(t, err)
 	h2.SetFinalizedInfo(&info)
 
@@ -591,7 +594,7 @@ func TestTlfHandlEqual(t *testing.T) {
 	require.False(t, eq)
 
 	// Test failure on name difference.
-	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Private)
+	h2, err = ParseTlfHandle(ctx, kbpki, nil, nil, name1, tlf.Private)
 	require.NoError(t, err)
 	h2.name += "x"
 	eq, err = h1.Equals(codec, *h2)
@@ -615,8 +618,8 @@ func TestParseTlfHandleSocialAssertion(t *testing.T) {
 
 	name := "u1,u2#u3@twitter"
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
-		tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		name, tlf.Private)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
@@ -625,7 +628,7 @@ func TestParseTlfHandleSocialAssertion(t *testing.T) {
 	// name.
 	h2, err := MakeTlfHandle(
 		context.Background(), h.ToBareHandleOrBust(), tlf.Private,
-		kbpki, kbpki, nil)
+		kbpki, kbpki, nil, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }
@@ -646,7 +649,8 @@ func TestParseTlfHandleUIDAssertion(t *testing.T) {
 
 	a := currentUID.String() + "@uid"
 	_, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		a, tlf.Private)
 	assert.Equal(t, 1, kbpki.getIdentifyCalls())
 	assert.Equal(t, TlfNameNotCanonical{a, "u1"}, errors.Cause(err))
 }
@@ -668,7 +672,8 @@ func TestParseTlfHandleAndAssertion(t *testing.T) {
 
 	a := currentUID.String() + "@uid+u1@twitter"
 	_, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		a, tlf.Private)
 	// We expect 1 extra identify for compound assertions until
 	// KBFS-2022 is completed.
 	assert.Equal(t, 1+1, kbpki.getIdentifyCalls())
@@ -695,7 +700,8 @@ func TestParseTlfHandleConflictSuffix(t *testing.T) {
 
 	a := "u1 " + ci.String()
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		a, tlf.Private)
 	require.NoError(t, err)
 	require.NotNil(t, h.ConflictInfo())
 	require.Equal(t, ci.String(), h.ConflictInfo().String())
@@ -718,7 +724,8 @@ func TestParseTlfHandleFailConflictingAssertion(t *testing.T) {
 
 	a := currentUID.String() + "@uid+u2@twitter"
 	_, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		a, tlf.Private)
 	// We expect 1 extra identify for compound assertions until
 	// KBFS-2022 is completed.
 	assert.Equal(t, 0+1, kbpki.getIdentifyCalls())
@@ -730,7 +737,8 @@ func TestParseTlfHandleFailConflictingAssertion(t *testing.T) {
 func parseTlfHandleOrBust(t logger.TestLogBackend, config Config,
 	name string, ty tlf.Type, id tlf.ID) *TlfHandle {
 	ctx := context.Background()
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, name, ty)
+	h, err := ParseTlfHandle(
+		ctx, config.KBPKI(), constIDGetter{id}, nil, name, ty)
 	if err != nil {
 		t.Fatalf("Couldn't parse %s (type=%s) into a TLF handle: %v",
 			name, ty, err)
@@ -752,14 +760,14 @@ func TestResolveAgainBasic(t *testing.T) {
 
 	name := "u1,u2#u3@twitter"
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
-		tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		name, tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
 
 	// ResolveAgain shouldn't rely on resolving the original names again.
 	daemon.addNewAssertionForTestOrBust("u3", "u3@twitter")
-	newH, err := h.ResolveAgain(ctx, kbpki, nil)
+	newH, err := h.ResolveAgain(ctx, kbpki, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName("u1,u2#u3"), newH.GetCanonicalName())
 }
@@ -778,8 +786,8 @@ func TestResolveAgainDoubleAsserts(t *testing.T) {
 
 	name := "u1,u1@github,u1@twitter#u2,u2@github,u2@twitter"
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
-		tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		name, tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
 
@@ -787,7 +795,7 @@ func TestResolveAgainDoubleAsserts(t *testing.T) {
 	daemon.addNewAssertionForTestOrBust("u1", "u1@github")
 	daemon.addNewAssertionForTestOrBust("u2", "u2@twitter")
 	daemon.addNewAssertionForTestOrBust("u2", "u2@github")
-	newH, err := h.ResolveAgain(ctx, kbpki, nil)
+	newH, err := h.ResolveAgain(ctx, kbpki, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName("u1#u2"), newH.GetCanonicalName())
 }
@@ -806,14 +814,14 @@ func TestResolveAgainWriterReader(t *testing.T) {
 
 	name := "u1,u2@github#u2@twitter"
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
-		tlf.Private)
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, nil,
+		name, tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
 
 	daemon.addNewAssertionForTestOrBust("u2", "u2@twitter")
 	daemon.addNewAssertionForTestOrBust("u2", "u2@github")
-	newH, err := h.ResolveAgain(ctx, kbpki, nil)
+	newH, err := h.ResolveAgain(ctx, kbpki, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName("u1,u2"), newH.GetCanonicalName())
 }
@@ -833,7 +841,7 @@ func TestResolveAgainConflict(t *testing.T) {
 	name := "u1,u2#u3@twitter"
 	id := tlf.FakeID(1, tlf.Private)
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{id}, name, tlf.Private)
+		ctx, kbpki, constIDGetter{id}, nil, name, tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
 
@@ -843,7 +851,7 @@ func TestResolveAgainConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 	h.conflictInfo = ext
-	newH, err := h.ResolveAgain(ctx, kbpki, nil)
+	newH, err := h.ResolveAgain(ctx, kbpki, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName("u1,u2#u3"+
 		tlf.HandleExtensionSep+ext.String()), newH.GetCanonicalName())
@@ -866,11 +874,11 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	name1 := "u1,u2@twitter,u3,u4@twitter"
 	idPub := tlf.FakeID(1, tlf.Public)
 	h1, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+		ctx, kbpki, constIDGetter{idPub}, nil, name1, tlf.Public)
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err :=
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h1)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h1)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -879,11 +887,11 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 
 	id := tlf.FakeID(1, tlf.Private)
 	h2, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{id}, name1, tlf.Private)
+		ctx, kbpki, constIDGetter{id}, nil, name1, tlf.Private)
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -891,7 +899,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	// Test adding conflict info or finalized info.
 
 	h2, err = ParseTlfHandle(
-		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+		ctx, kbpki, constIDGetter{idPub}, nil, name1, tlf.Public)
 	require.NoError(t, err)
 	info := tlf.HandleExtension{
 		Date:   100,
@@ -902,13 +910,13 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
 
 	h2, err = ParseTlfHandle(
-		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+		ctx, kbpki, constIDGetter{idPub}, nil, name1, tlf.Public)
 	require.NoError(t, err)
 	info = tlf.HandleExtension{
 		Date:   101,
@@ -918,7 +926,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	h2.SetFinalizedInfo(&info)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -926,7 +934,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	// Test differing conflict info or finalized info.
 
 	h2, err = ParseTlfHandle(
-		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+		ctx, kbpki, constIDGetter{idPub}, nil, name1, tlf.Public)
 	require.NoError(t, err)
 	info = tlf.HandleExtension{
 		Date:   100,
@@ -944,15 +952,15 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
 	h1, err = ParseTlfHandle(
-		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+		ctx, kbpki, constIDGetter{idPub}, nil, name1, tlf.Public)
 	require.NoError(t, err)
 	h2, err = ParseTlfHandle(
-		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+		ctx, kbpki, constIDGetter{idPub}, nil, name1, tlf.Public)
 	require.NoError(t, err)
 	info = tlf.HandleExtension{
 		Date:   101,
@@ -968,14 +976,14 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	h1.SetFinalizedInfo(&info)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
 	// Try to add conflict info to a finalized handle.
 
 	h2, err = ParseTlfHandle(
-		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+		ctx, kbpki, constIDGetter{idPub}, nil, name1, tlf.Public)
 	info = tlf.HandleExtension{
 		Date:   100,
 		Number: 50,
@@ -985,14 +993,14 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.Error(t, err)
 
 	// Test positive resolution cases.
 
 	name1 = "u1,u2@twitter,u5#u3,u4@twitter"
 	h1, err = ParseTlfHandle(
-		ctx, kbpki, constIDGetter{id}, name1, tlf.Private)
+		ctx, kbpki, constIDGetter{id}, nil, name1, tlf.Private)
 	require.NoError(t, err)
 
 	type testCase struct {
@@ -1009,13 +1017,13 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 		{"u1,u3,u5#u4@twitter", "u3"},
 	} {
 		h2, err = ParseTlfHandle(
-			ctx, kbpki, constIDGetter{id}, tc.name2, tlf.Private)
+			ctx, kbpki, constIDGetter{id}, nil, tc.name2, tlf.Private)
 		require.NoError(t, err)
 
 		daemon.addNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
 		resolvesTo, partialResolvedH1, err =
-			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
+			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h2)
 		require.NoError(t, err)
 		assert.True(t, resolvesTo, tc.name2)
 		require.Equal(t, h2, partialResolvedH1, tc.name2)
@@ -1033,13 +1041,13 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 		{"u1,u2,u5#u3,u4@twitter", "u3"},
 	} {
 		h2, err = ParseTlfHandle(
-			ctx, kbpki, constIDGetter{id}, tc.name2, tlf.Private)
+			ctx, kbpki, constIDGetter{id}, nil, tc.name2, tlf.Private)
 		require.NoError(t, err)
 
 		daemon.addNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
 		resolvesTo, partialResolvedH1, err =
-			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
+			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h2)
 		require.NoError(t, err)
 		assert.False(t, resolvesTo, tc.name2)
 
@@ -1067,7 +1075,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	// Handle without iteam.
 	name1 := "u1,u2"
 	h1, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{id}, name1, tlf.Private)
+		ctx, kbpki, constIDGetter{id}, nil, name1, tlf.Private)
 	require.NoError(t, err)
 
 	makeImplicitHandle := func(
@@ -1080,7 +1088,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 		err = daemon.CreateTeamTLF(ctx, iteamInfo.TID, id)
 		require.NoError(t, err)
 		h, err := ParseTlfHandle(
-			ctx, kbpki, constIDGetter{id}, name, ty)
+			ctx, kbpki, constIDGetter{id}, nil, name, ty)
 		require.NoError(t, err)
 		require.Equal(t, tlf.TeamKeying, h.TypeForKeying())
 		return h
@@ -1088,7 +1096,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	h2 := makeImplicitHandle(name1, tlf.Private, id)
 
 	resolvesTo, partialResolvedH1, err :=
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -1097,12 +1105,12 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	idPub := tlf.FakeID(1, tlf.Public)
 	// Handle without iteam.
 	h1Pub, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+		ctx, kbpki, constIDGetter{idPub}, nil, name1, tlf.Public)
 	require.NoError(t, err)
 	h2Pub := makeImplicitHandle(name1, tlf.Public, idPub)
 
 	resolvesTo, partialResolvedH1, err =
-		h1Pub.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2Pub)
+		h1Pub.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2Pub)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1Pub, partialResolvedH1)
@@ -1111,7 +1119,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	name2 := "u1,u2,u3"
 	h3 := makeImplicitHandle(name2, tlf.Private, id)
 	resolvesTo, _, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h3)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h3)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -1119,7 +1127,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	name3 := "u1"
 	h4 := makeImplicitHandle(name3, tlf.Private, id)
 	resolvesTo, _, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h4)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h4)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -1127,7 +1135,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	name4 := "u1,u2#u3"
 	h5 := makeImplicitHandle(name4, tlf.Private, id)
 	resolvesTo, _, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h5)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h5)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -1135,11 +1143,11 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	// Handle without iteam.
 	name5 := "u1,u2,u3@twitter"
 	h6, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{id}, name5, tlf.Private)
+		ctx, kbpki, constIDGetter{id}, nil, name5, tlf.Private)
 	require.NoError(t, err)
 	h7 := makeImplicitHandle(name5, tlf.Private, id)
 	resolvesTo, partialResolvedH6, err :=
-		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h7)
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h7)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h6, partialResolvedH6)
@@ -1149,14 +1157,14 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	name6 := "u1,u2,u3@twitter,u4@twitter"
 	h8 := makeImplicitHandle(name6, tlf.Private, id)
 	resolvesTo, _, err =
-		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h8)
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h8)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
 	t.Log("Private team migration with newly-resolved user")
 	daemon.addNewAssertionForTestOrBust("u3", "u3@twitter")
 	resolvesTo, partialResolvedH6, err =
-		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h3)
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h3)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Len(t, partialResolvedH6.UnresolvedWriters(), 0)
@@ -1164,11 +1172,11 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	t.Log("Private team migration with conflict info")
 	name7 := "u1,u2 (conflicted copy 2016-03-14 #3)"
 	h9, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{id}, name7, tlf.Private)
+		ctx, kbpki, constIDGetter{id}, nil, name7, tlf.Private)
 	require.NoError(t, err)
 	h10 := makeImplicitHandle(name7, tlf.Private, id)
 	resolvesTo, partialResolvedH9, err :=
-		h9.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h10)
+		h9.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h10)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h9, partialResolvedH9)
@@ -1189,7 +1197,7 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 	name := "u1,u2#u3 (conflicted copy 2016-03-14 #3) (files before u2 account reset 2016-03-14 #2)"
 	id := tlf.FakeID(1, tlf.Private)
 	h, err := ParseTlfHandle(
-		ctx, kbpki, constIDGetter{id}, name, tlf.Private)
+		ctx, kbpki, constIDGetter{id}, nil, name, tlf.Private)
 	require.Nil(t, err)
 	assert.Equal(t, tlf.HandleExtension{
 		Type:   tlf.HandleExtensionConflict,
@@ -1205,7 +1213,7 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 
 	nonCanonicalName := "u1,u2#u3 (files before u2 account reset 2016-03-14 #2) (conflicted copy 2016-03-14 #3)"
 	_, err = ParseTlfHandle(
-		ctx, kbpki, constIDGetter{id}, nonCanonicalName, tlf.Private)
+		ctx, kbpki, constIDGetter{id}, nil, nonCanonicalName, tlf.Private)
 	assert.Equal(
 		t, TlfNameNotCanonical{nonCanonicalName, name}, errors.Cause(err))
 }
@@ -1236,7 +1244,7 @@ func TestParseTlfHandleImplicitTeams(t *testing.T) {
 	}
 
 	check := func(name string, tid keybase1.TeamID, tlfID tlf.ID, ty tlf.Type) {
-		h, err := ParseTlfHandle(ctx, kbpki, nil, name, ty)
+		h, err := ParseTlfHandle(ctx, kbpki, nil, nil, name, ty)
 		require.NoError(t, err)
 		require.Len(t, h.ResolvedWriters(), 1)
 		require.Len(t, h.ResolvedReaders(), 0)
@@ -1268,4 +1276,169 @@ func TestParseTlfHandleImplicitTeams(t *testing.T) {
 	t.Log("Implicit team with readers")
 	tid7, tlfID7 := newITeam("u1,u2#u3", "", tlf.Private)
 	check("u1,u2#u3", tid7, tlfID7, tlf.Private)
+}
+
+type offlineResolveCounterKBPKI struct {
+	KBPKI
+
+	lock                    sync.Mutex
+	bestEffortOfflineCounts map[string]int
+}
+
+func (d *offlineResolveCounterKBPKI) Resolve(
+	ctx context.Context, assertion string,
+	offline keybase1.OfflineAvailability) (
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	if offline == keybase1.OfflineAvailability_BEST_EFFORT {
+		d.lock.Lock()
+		d.bestEffortOfflineCounts[assertion]++
+		d.lock.Unlock()
+	}
+	return d.KBPKI.Resolve(ctx, assertion, offline)
+}
+
+type testOfflineStatusPathsGetter struct {
+	bestEffortPaths map[string]bool
+}
+
+func (t *testOfflineStatusPathsGetter) OfflineAvailabilityForPath(
+	tlfPath string) keybase1.OfflineAvailability {
+	if t.bestEffortPaths[tlfPath] {
+		return keybase1.OfflineAvailability_BEST_EFFORT
+	}
+	return keybase1.OfflineAvailability_NONE
+}
+
+func (t *testOfflineStatusPathsGetter) OfflineAvailabilityForID(
+	tlfID tlf.ID) keybase1.OfflineAvailability {
+	panic("Not supported")
+}
+
+func TestParseTlfHandleOfflineAvailability(t *testing.T) {
+	ctx := context.Background()
+
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers[0].Asserts = []string{"u1@twitter"}
+	currentUID := localUsers[0].UID
+	localTeams := MakeLocalTeams(
+		[]kbname.NormalizedUsername{"u1u2u3", "u3u2u1"})
+	daemon := NewKeybaseDaemonMemory(
+		currentUID, localUsers, localTeams, kbfscodec.NewMsgpack())
+
+	kbpki := &offlineResolveCounterKBPKI{
+		KBPKI: &daemonKBPKI{
+			daemon: daemon,
+		},
+		bestEffortOfflineCounts: make(map[string]int),
+	}
+
+	osg := &testOfflineStatusPathsGetter{make(map[string]bool)}
+	osg.bestEffortPaths["/keybase/private/u2"] = true
+
+	t.Log("Check unsynced private TLF")
+	_, err := ParseTlfHandle(ctx, kbpki, nil, osg, "u1", tlf.Private)
+	require.NoError(t, err)
+	require.Equal(t, kbpki.bestEffortOfflineCounts["u1"], 0)
+
+	t.Log("Check synced private TLF")
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u2", tlf.Private)
+	require.NoError(t, err)
+	require.Equal(t, kbpki.bestEffortOfflineCounts["u2"], 1)
+
+	t.Log("Check synced private shared TLF")
+	osg.bestEffortPaths["/keybase/private/u1,u2,u3"] = true
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u1,u2,u3", tlf.Private)
+	require.NoError(t, err)
+	require.Equal(t, 1, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 2, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 1, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check synced private shared TLF, different order")
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u3,u1,u2", tlf.Private)
+	assert.Equal(
+		t, TlfNameNotCanonical{"u3,u1,u2", "u1,u2,u3"}, errors.Cause(err))
+	require.Equal(t, 2, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 3, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 2, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check synced private shared TLF, " +
+		"resolved assertions don't use best effort.")
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u1@twitter,u2,u3",
+		tlf.Private)
+	assert.Equal(
+		t, TlfNameNotCanonical{"u1@twitter,u2,u3", "u1,u2,u3"},
+		errors.Cause(err))
+	require.Equal(t, 2, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 0, kbpki.bestEffortOfflineCounts["u1@twitter"])
+	require.Equal(t, 3, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 2, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check synced private shared TLF, " +
+		"unresolved assertions do use best effort.")
+	osg.bestEffortPaths["/keybase/private/u1,u2@twitter,u3"] = true
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u1,u2@twitter,u3",
+		tlf.Private)
+	assert.NoError(t, err)
+	require.Equal(t, 3, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 1, kbpki.bestEffortOfflineCounts["u2@twitter"])
+	require.Equal(t, 3, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 3, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check synced private shared TLF, with readers")
+	osg.bestEffortPaths["/keybase/private/u1#u2,u3"] = true
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u1#u2,u3",
+		tlf.Private)
+	assert.NoError(t, err)
+	require.Equal(t, 4, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 4, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 4, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check synced private shared TLF, with readers, different order")
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u1#u3,u2",
+		tlf.Private)
+	assert.Equal(
+		t, TlfNameNotCanonical{"u1#u3,u2", "u1#u2,u3"}, errors.Cause(err))
+	require.Equal(t, 5, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 5, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 5, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check synced private shared TLF, with extension")
+	ext := "(conflicted copy 2016-03-14 #3)"
+	osg.bestEffortPaths["/keybase/private/u1,u2 "+ext] = true
+	_, err = ParseTlfHandle(
+		ctx, kbpki, nil, osg, "u1,u2 "+ext, tlf.Private)
+	assert.NoError(t, err)
+	require.Equal(t, 6, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 6, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 5, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check synced private shared TLF, with extension, different order, " +
+		"with reader and unresolved assertion")
+	osg.bestEffortPaths["/keybase/private/u1,u3#u2@twitter "+ext] = true
+	_, err = ParseTlfHandle(
+		ctx, kbpki, nil, osg, "u3,u1#u2@twitter "+ext, tlf.Private)
+	assert.Equal(
+		t, TlfNameNotCanonical{
+			"u3,u1#u2@twitter " + ext, "u1,u3#u2@twitter " + ext},
+		errors.Cause(err))
+	require.Equal(t, 7, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 2, kbpki.bestEffortOfflineCounts["u2@twitter"])
+	require.Equal(t, 6, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 6, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check synced team TLF")
+	osg.bestEffortPaths["/keybase/team/u1u2u3"] = true
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u1u2u3", tlf.SingleTeam)
+	assert.NoError(t, err)
+	require.Equal(t, 1, kbpki.bestEffortOfflineCounts["team:u1u2u3"])
+	require.Equal(t, 7, kbpki.bestEffortOfflineCounts["u1"])
+	require.Equal(t, 2, kbpki.bestEffortOfflineCounts["u2@twitter"])
+	require.Equal(t, 6, kbpki.bestEffortOfflineCounts["u2"])
+	require.Equal(t, 6, kbpki.bestEffortOfflineCounts["u3"])
+
+	t.Log("Check unsynced team TLF")
+	_, err = ParseTlfHandle(ctx, kbpki, nil, osg, "u3u2u1", tlf.SingleTeam)
+	assert.NoError(t, err)
+	require.Equal(t, 1, kbpki.bestEffortOfflineCounts["team:u1u2u3"])
+	require.Equal(t, 0, kbpki.bestEffortOfflineCounts["team:u3u2u1"])
 }

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -416,8 +416,8 @@ func makeTLFJournal(
 
 	mdJournal, err := makeMDJournal(
 		ctx, uid, key, config.Codec(), config.Crypto(), config.Clock(),
-		config.teamMembershipChecker(), tlfID, config.MetadataVersion(), dir,
-		log)
+		config.teamMembershipChecker(), config, tlfID, config.MetadataVersion(),
+		dir, log)
 	if err != nil {
 		return nil, err
 	}
@@ -1752,7 +1752,8 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 			ctx, j.config.Codec(), j.config.Crypto(),
 			j.config.BlockCache(), j.config.BlockOps(),
 			j.config.mdDecryptionKeyGetter(), j.config.teamMembershipChecker(),
-			mode, j.uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.log)
+			j.config, mode, j.uid, rmd.GetSerializedPrivateMetadata(), rmd,
+			rmd, j.log)
 		if err != nil {
 			return nil, err
 		}

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -1729,7 +1729,8 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 
 	handle, err := MakeTlfHandle(
 		ctx, ibrmdBareHandle, j.tlfID.Type(), j.config.resolver(),
-		j.config.usernameGetter(), constIDGetter{j.tlfID})
+		j.config.usernameGetter(), constIDGetter{j.tlfID},
+		j.config.OfflineAvailabilityForID(j.tlfID))
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -186,7 +186,8 @@ func (c testTLFJournalConfig) checkMD(rmds *RootMetadataSigned,
 		rmds.MD, extra, expectedRevision, expectedPrevRoot,
 		expectedMergeStatus, expectedBranchID)
 	err := rmds.IsValidAndSigned(
-		context.Background(), c.Codec(), nil, extra)
+		context.Background(), c.Codec(), nil, extra,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(c.t, err)
 	err = rmds.IsLastModifiedBy(c.uid, verifyingKey)
 	require.NoError(c.t, err)

--- a/go/kbfs/libkbfs/util.go
+++ b/go/kbfs/libkbfs/util.go
@@ -160,10 +160,12 @@ func chargedToForTLF(ctx context.Context, sessionGetter CurrentSessionGetter,
 // GetHandleFromFolderNameAndType returns a TLFHandle given a folder
 // name (e.g., "u1,u2#u3") and a TLF type.
 func GetHandleFromFolderNameAndType(
-	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter, tlfName string,
+	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter,
+	syncGetter syncedTlfGetterSetter, tlfName string,
 	t tlf.Type) (*TlfHandle, error) {
 	for {
-		tlfHandle, err := ParseTlfHandle(ctx, kbpki, idGetter, tlfName, t)
+		tlfHandle, err := ParseTlfHandle(
+			ctx, kbpki, idGetter, syncGetter, tlfName, t)
 		switch e := errors.Cause(err).(type) {
 		case TlfNameNotCanonical:
 			tlfName = e.NameToTry
@@ -178,7 +180,8 @@ func GetHandleFromFolderNameAndType(
 // getHandleFromFolderName returns a TLFHandle given a folder
 // name (e.g., "u1,u2#u3") and a public/private bool.  DEPRECATED.
 func getHandleFromFolderName(
-	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter, tlfName string,
+	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter,
+	syncGetter syncedTlfGetterSetter, tlfName string,
 	public bool) (*TlfHandle, error) {
 	// TODO(KBFS-2185): update the protocol to support requests
 	// for single-team TLFs.
@@ -186,7 +189,8 @@ func getHandleFromFolderName(
 	if public {
 		t = tlf.Public
 	}
-	return GetHandleFromFolderNameAndType(ctx, kbpki, idGetter, tlfName, t)
+	return GetHandleFromFolderNameAndType(
+		ctx, kbpki, idGetter, syncGetter, tlfName, t)
 }
 
 // IsWriterFromHandle checks whether the given UID is a writer for the

--- a/go/kbfs/libpages/root.go
+++ b/go/kbfs/libpages/root.go
@@ -125,7 +125,8 @@ func (r *Root) MakeFS(
 	switch r.Type {
 	case KBFSRoot:
 		tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
-			ctx, kbfsConfig.KBPKI(), kbfsConfig.MDOps(), r.TlfNameUnparsed, r.TlfType)
+			ctx, kbfsConfig.KBPKI(), kbfsConfig.MDOps(), kbfsConfig,
+			r.TlfNameUnparsed, r.TlfType)
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err
 		}
@@ -150,7 +151,7 @@ func (r *Root) MakeFS(
 		return cacheableFS, tlfHandle.TlfID(), cancel, nil
 	case GitRoot:
 		tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
-			ctx, kbfsConfig.KBPKI(), kbfsConfig.MDOps(),
+			ctx, kbfsConfig.KBPKI(), kbfsConfig.MDOps(), kbfsConfig,
 			r.TlfNameUnparsed, r.TlfType)
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -354,7 +354,8 @@ func (k *SimpleFS) favoriteList(ctx context.Context, path keybase1.Path, t tlf.T
 			k.log.Errorf("ParseTlfHandlePreferredQuick: %s %q %v", t, pname, err)
 			continue
 		}
-		res[len(res)-1].Writable, err = libfs.IsWriter(ctx, k.config.KBPKI(), handle)
+		res[len(res)-1].Writable, err = libfs.IsWriter(
+			ctx, k.config.KBPKI(), k.config, handle)
 		if err != nil {
 			k.log.Errorf("libfs.IsWriter: %q %+v", pname, err)
 			continue

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -269,7 +269,7 @@ func (k *SimpleFS) getFSWithMaybeCreate(
 			return nil, "", err
 		}
 		tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
-			ctx, k.config.KBPKI(), k.config.MDOps(), tlfName, t)
+			ctx, k.config.KBPKI(), k.config.MDOps(), k.config, tlfName, t)
 		if err != nil {
 			return nil, "", err
 		}
@@ -348,7 +348,8 @@ func (k *SimpleFS) favoriteList(ctx context.Context, path keybase1.Path, t tlf.T
 		res[len(res)-1].Name = string(pname)
 		res[len(res)-1].DirentType = deTy2Ty(libkbfs.Dir)
 
-		handle, err := libfs.ParseTlfHandlePreferredQuick(ctx, k.config.KBPKI(), string(pname), t)
+		handle, err := libfs.ParseTlfHandlePreferredQuick(
+			ctx, k.config.KBPKI(), k.config, string(pname), t)
 		if err != nil {
 			k.log.Errorf("ParseTlfHandlePreferredQuick: %s %q %v", t, pname, err)
 			continue
@@ -557,7 +558,7 @@ func (k *SimpleFS) getFolderBranchFromPath(
 		return libkbfs.FolderBranch{}, "", err
 	}
 	tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
-		ctx, k.config.KBPKI(), k.config.MDOps(), tlfName, t)
+		ctx, k.config.KBPKI(), k.config.MDOps(), k.config, tlfName, t)
 	if err != nil {
 		return libkbfs.FolderBranch{}, "", err
 	}
@@ -1194,7 +1195,8 @@ func (k *SimpleFS) pathsForSameTlfMove(
 	}
 
 	tlfHandle, err = libkbfs.GetHandleFromFolderNameAndType(
-		ctx, k.config.KBPKI(), k.config.MDOps(), srcTlfName, srcTlfType)
+		ctx, k.config.KBPKI(), k.config.MDOps(), k.config, srcTlfName,
+		srcTlfType)
 	if err != nil {
 		return false, "", "", nil, err
 	}
@@ -1271,7 +1273,7 @@ func (k *SimpleFS) SimpleFSRename(ctx context.Context, arg keybase1.SimpleFSRena
 		return err
 	}
 	tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
-		ctx, k.config.KBPKI(), k.config.MDOps(), tlfName, t)
+		ctx, k.config.KBPKI(), k.config.MDOps(), k.config, tlfName, t)
 	if err != nil {
 		return err
 	}
@@ -2061,7 +2063,7 @@ func (k *SimpleFS) SimpleFSReset(
 		return err
 	}
 	tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
-		ctx, k.config.KBPKI(), k.config.MDOps(), tlfName, t)
+		ctx, k.config.KBPKI(), k.config.MDOps(), k.config, tlfName, t)
 	if err != nil {
 		return err
 	}
@@ -2158,7 +2160,7 @@ func (k *SimpleFS) getSyncConfig(ctx context.Context, path keybase1.Path) (
 		return tlf.NullID, keybase1.FolderSyncConfig{}, err
 	}
 	tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
-		ctx, k.config.KBPKI(), k.config.MDOps(), tlfName, t)
+		ctx, k.config.KBPKI(), k.config.MDOps(), k.config, tlfName, t)
 	if err != nil {
 		return tlf.NullID, keybase1.FolderSyncConfig{}, err
 	}

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -221,7 +221,7 @@ func TestList(t *testing.T) {
 
 	t.Log("Shouldn't have created the TLF")
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "jdoe", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), config, "jdoe", tlf.Private)
 	require.NoError(t, err)
 	rootNode, _, err := config.KBFSOps().GetRootNode(
 		ctx, h, libkbfs.MasterBranch)

--- a/go/kbfs/test/engine_libkbfs.go
+++ b/go/kbfs/test/engine_libkbfs.go
@@ -202,11 +202,12 @@ func (k *LibKBFS) GetUID(u User) (uid keybase1.UID) {
 
 func parseTlfHandle(
 	ctx context.Context, kbpki libkbfs.KBPKI, mdOps libkbfs.MDOps,
-	tlfName string, t tlf.Type) (h *libkbfs.TlfHandle, err error) {
+	osg libkbfs.OfflineStatusGetter, tlfName string, t tlf.Type) (
+	h *libkbfs.TlfHandle, err error) {
 	// Limit to one non-canonical name for now.
 outer:
 	for i := 0; i < 2; i++ {
-		h, err = libkbfs.ParseTlfHandle(ctx, kbpki, mdOps, tlfName, t)
+		h, err = libkbfs.ParseTlfHandle(ctx, kbpki, mdOps, osg, tlfName, t)
 		switch err := errors.Cause(err).(type) {
 		case nil:
 			break outer
@@ -248,7 +249,8 @@ func (k *LibKBFS) getRootDir(
 
 	ctx, cancel := k.newContext(u)
 	defer cancel()
-	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
+	h, err := parseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), config, tlfName, t)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +296,8 @@ func (k *LibKBFS) GetRootDirAtTimeString(
 	config := u.(*libkbfs.ConfigLocal)
 	ctx, cancel := k.newContext(u)
 	defer cancel()
-	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
+	h, err := parseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), config, tlfName, t)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +318,8 @@ func (k *LibKBFS) GetRootDirAtRelTimeString(
 	config := u.(*libkbfs.ConfigLocal)
 	ctx, cancel := k.newContext(u)
 	defer cancel()
-	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
+	h, err := parseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), config, tlfName, t)
 	if err != nil {
 		return nil, err
 	}
@@ -578,7 +582,8 @@ func (k *LibKBFS) GetPrevRevisions(u User, file Node) (
 // name.
 func getRootNode(ctx context.Context, config libkbfs.Config, tlfName string,
 	t tlf.Type) (libkbfs.Node, error) {
-	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
+	h, err := parseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), config, tlfName, t)
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +739,8 @@ func (k *LibKBFS) EnableJournal(u User, tlfName string, t tlf.Type) error {
 		return err
 	}
 
-	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
+	h, err := parseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), config, tlfName, t)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pass `BEST_EFFORT` offline availability mode to `Resolve3`, whenever the TLF path or ID in question is being synced.  This tells the service that it is ok to serve a stale answer from the cache, if the API server can't be reached in a timely fashion over the internet.

Issue: KBFS-3918