### PR TITLE
Warn user if logdir is unwritable

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -141,12 +141,20 @@ show_cryptosquirrel() {
 }
 
 init() {
-  # Cannot do in go due to background processes being piped to log in bash
   logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
+  runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
+
+  if ! [ -w "$logdir" ]; then
+      echo "WARNING: Cannot write to $logdir. Did you run 'run_keybase' with sudo?"
+      echo "         Keybase does not need root privileges to run."
+      echo "         Permissions can be restored by running 'sudo chown -R $(whoami):$(whoami) $logdir',"
+      echo "         after which 'run_keybase' can be run again."
+  fi
+
+  # Cannot do in go due to background processes being piped to log in bash
   mkdir -p "$logdir"
 
   # Cannot do in go due to flock using a file in this directory
-  runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
   mkdir -p "$runtime_dir"
 
   keybase ctl init

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -144,7 +144,7 @@ warn_if_unwritable() {
   if [ -w "$1" ]; then
       return
   fi
-  echo "WARNING: Cannot write to $1. Did you run 'run_keybase' with sudo?"
+  echo "WARNING: Cannot write to $1. Did you previously run 'run_keybase' with sudo?"
   echo "         Keybase does not need root privileges to run."
   echo "         Permissions can be restored by running 'sudo chown -R $(whoami):$(whoami) $1',"
   echo "         after which 'run_keybase' can be run again."

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -140,7 +140,10 @@ show_cryptosquirrel() {
   [ "${KEYBASE_NO_SQUIRREL:-}" != "1" ] && cat /opt/keybase/crypto_squirrel.txt
 }
 
-warn_unwritable() {
+warn_if_unwritable() {
+  if [ -w "$1" ]; then
+      return
+  fi
   echo "WARNING: Cannot write to $1. Did you run 'run_keybase' with sudo?"
   echo "         Keybase does not need root privileges to run."
   echo "         Permissions can be restored by running 'sudo chown -R $(whoami):$(whoami) $1',"
@@ -151,13 +154,8 @@ init() {
   logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
   runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
 
-  if ! [ -w "$logdir" ]; then
-      warn_unwritable "$logdir"
-  fi
-
-  if ! [ -w "$runtime_dir" ]; then
-      warn_unwritable "$runtime_dir"
-  fi
+  warn_if_unwritable "$logdir"
+  warn_if_unwritable "$runtime_dir"
 
   # Cannot do in go due to background processes being piped to log in bash
   mkdir -p "$logdir"

--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -140,15 +140,23 @@ show_cryptosquirrel() {
   [ "${KEYBASE_NO_SQUIRREL:-}" != "1" ] && cat /opt/keybase/crypto_squirrel.txt
 }
 
+warn_unwritable() {
+  echo "WARNING: Cannot write to $1. Did you run 'run_keybase' with sudo?"
+  echo "         Keybase does not need root privileges to run."
+  echo "         Permissions can be restored by running 'sudo chown -R $(whoami):$(whoami) $1',"
+  echo "         after which 'run_keybase' can be run again."
+}
+
 init() {
   logdir="${XDG_CACHE_HOME:-$HOME/.cache}/keybase"
   runtime_dir="${XDG_RUNTIME_DIR:-$HOME/.config}/keybase"
 
   if ! [ -w "$logdir" ]; then
-      echo "WARNING: Cannot write to $logdir. Did you run 'run_keybase' with sudo?"
-      echo "         Keybase does not need root privileges to run."
-      echo "         Permissions can be restored by running 'sudo chown -R $(whoami):$(whoami) $logdir',"
-      echo "         after which 'run_keybase' can be run again."
+      warn_unwritable "$logdir"
+  fi
+
+  if ! [ -w "$runtime_dir" ]; then
+      warn_unwritable "$runtime_dir"
   fi
 
   # Cannot do in go due to background processes being piped to log in bash


### PR DESCRIPTION
I'm not sure about how to word this error message. There's been a few reports about `sudo run_keybase` creating unwritable directories but I can't figure out how it would've happened, When I run `sudo run_keybase`, it makes `/root/.cache/keybase` (and then fails when the binary says it needs `KEYBASE_ALLOW_ROOT=1` and not `/home/me/.cache/keybase` owned by my root. Regardless, if it does happen, they should get this message.