### PR TITLE
keybase_service_base: plumb offline status for LoadTeamPlusKeys

### DIFF
--- a/go/kbfs/kbfsmd/root_metadata.go
+++ b/go/kbfs/kbfsmd/root_metadata.go
@@ -51,11 +51,13 @@ type RootMetadata interface {
 	IsWriter(ctx context.Context, user keybase1.UID,
 		cryptKey kbfscrypto.CryptPublicKey,
 		verifyingKey kbfscrypto.VerifyingKey,
-		teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error)
+		teamMemChecker TeamMembershipChecker, extra ExtraMetadata,
+		offline keybase1.OfflineAvailability) (bool, error)
 	// IsReader returns whether or not the user+device is an authorized reader.
 	IsReader(ctx context.Context, user keybase1.UID,
 		cryptKey kbfscrypto.CryptPublicKey,
-		teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error)
+		teamMemChecker TeamMembershipChecker, extra ExtraMetadata,
+		offline keybase1.OfflineAvailability) (bool, error)
 	// DeepCopy returns a deep copy of the underlying data structure.
 	DeepCopy(codec kbfscodec.Codec) (MutableRootMetadata, error)
 	// MakeSuccessorCopy returns a newly constructed successor
@@ -103,7 +105,8 @@ type RootMetadata interface {
 	// checking with KBPKI.
 	IsValidAndSigned(ctx context.Context, codec kbfscodec.Codec,
 		teamMemChecker TeamMembershipChecker,
-		extra ExtraMetadata, writerVerifyingKey kbfscrypto.VerifyingKey) error
+		extra ExtraMetadata, writerVerifyingKey kbfscrypto.VerifyingKey,
+		offline keybase1.OfflineAvailability) error
 	// IsLastModifiedBy verifies that the RootMetadata is
 	// written by the given user and device (identified by the
 	// device verifying key), and returns an error if not.

--- a/go/kbfs/kbfsmd/root_metadata_signed.go
+++ b/go/kbfs/kbfsmd/root_metadata_signed.go
@@ -153,7 +153,8 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(
 // IsLastModifiedBy), or by checking with KBPKI.
 func (rmds *RootMetadataSigned) IsValidAndSigned(
 	ctx context.Context, codec kbfscodec.Codec,
-	teamMemChecker TeamMembershipChecker, extra ExtraMetadata) error {
+	teamMemChecker TeamMembershipChecker, extra ExtraMetadata,
+	offline keybase1.OfflineAvailability) error {
 	// Optimization -- if the RootMetadata signature is nil, it
 	// will fail verification.
 	if rmds.SigInfo.IsNil() {
@@ -166,8 +167,8 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 	}
 
 	err := rmds.MD.IsValidAndSigned(
-		ctx, codec, teamMemChecker, extra,
-		rmds.WriterSigInfo.VerifyingKey)
+		ctx, codec, teamMemChecker, extra, rmds.WriterSigInfo.VerifyingKey,
+		offline)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/kbfsmd/root_metadata_signed_test.go
+++ b/go/kbfs/kbfsmd/root_metadata_signed_test.go
@@ -45,7 +45,8 @@ func testRootMetadataSignedFinalVerify(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 
 	// verify it
-	err = rmds.IsValidAndSigned(ctx, codec, nil, extra)
+	err = rmds.IsValidAndSigned(
+		ctx, codec, nil, extra, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	ext, err := tlf.NewHandleExtension(
@@ -57,7 +58,8 @@ func testRootMetadataSignedFinalVerify(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 
 	// verify the finalized copy
-	err = rmds2.IsValidAndSigned(ctx, codec, nil, extra)
+	err = rmds2.IsValidAndSigned(
+		ctx, codec, nil, extra, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 
 	// touch something the server shouldn't be allowed to edit for
@@ -67,7 +69,8 @@ func testRootMetadataSignedFinalVerify(t *testing.T, ver MetadataVer) {
 	md3.SetRekeyBit()
 	rmds3 := rmds2
 	rmds2.MD = md3
-	err = rmds3.IsValidAndSigned(ctx, codec, nil, extra)
+	err = rmds3.IsValidAndSigned(
+		ctx, codec, nil, extra, keybase1.OfflineAvailability_NONE)
 	require.NotNil(t, err)
 }
 

--- a/go/kbfs/kbfsmd/root_metadata_v2.go
+++ b/go/kbfs/kbfsmd/root_metadata_v2.go
@@ -319,8 +319,8 @@ func (md *RootMetadataV2) IsFinal() bool {
 // IsWriter implements the RootMetadata interface for RootMetadataV2.
 func (md *RootMetadataV2) IsWriter(
 	_ context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey,
-	_ kbfscrypto.VerifyingKey, _ TeamMembershipChecker, _ ExtraMetadata) (
-	bool, error) {
+	_ kbfscrypto.VerifyingKey, _ TeamMembershipChecker, _ ExtraMetadata,
+	_ keybase1.OfflineAvailability) (bool, error) {
 	if md.ID.Type() != tlf.Private {
 		for _, w := range md.Writers {
 			if w == user.AsUserOrTeam() {
@@ -335,7 +335,8 @@ func (md *RootMetadataV2) IsWriter(
 // IsReader implements the RootMetadata interface for RootMetadataV2.
 func (md *RootMetadataV2) IsReader(
 	_ context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey,
-	_ TeamMembershipChecker, _ ExtraMetadata) (bool, error) {
+	_ TeamMembershipChecker, _ ExtraMetadata,
+	_ keybase1.OfflineAvailability) (bool, error) {
 	switch md.ID.Type() {
 	case tlf.Public:
 		return true, nil
@@ -776,7 +777,7 @@ func (md *RootMetadataV2) GetTLFCryptKeyParams(
 func (md *RootMetadataV2) IsValidAndSigned(
 	_ context.Context, codec kbfscodec.Codec,
 	_ TeamMembershipChecker, extra ExtraMetadata,
-	_ kbfscrypto.VerifyingKey) error {
+	_ kbfscrypto.VerifyingKey, _ keybase1.OfflineAvailability) error {
 	// Optimization -- if the WriterMetadata signature is nil, it
 	// will fail verification.
 	if md.WriterMetadataSigInfo.IsNil() {

--- a/go/kbfs/kbfsmd/team_membership_checker.go
+++ b/go/kbfs/kbfsmd/team_membership_checker.go
@@ -17,11 +17,13 @@ type TeamMembershipChecker interface {
 	// IsTeamWriter checks whether the given user (with the given
 	// verifying key) is a writer of the given team right now.
 	IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID,
-		verifyingKey kbfscrypto.VerifyingKey) (bool, error)
+		verifyingKey kbfscrypto.VerifyingKey,
+		offline keybase1.OfflineAvailability) (bool, error)
 	// IsTeamReader checks whether the given user is a reader of the
 	// given team right now.
-	IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
-		bool, error)
+	IsTeamReader(
+		ctx context.Context, tid keybase1.TeamID, uid keybase1.UID,
+		offline keybase1.OfflineAvailability) (bool, error)
 	// TODO: add Was* method for figuring out whether the user was a
 	// writer/reader at a particular Merkle root.  Not sure whether
 	// these calls should also verify that sequence number corresponds

--- a/go/kbfs/kbfstool/md_common.go
+++ b/go/kbfs/kbfstool/md_common.go
@@ -245,7 +245,7 @@ func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 
 	// Make sure we're a writer before doing anything else.
 	isWriter, err := libkbfs.IsWriterFromHandle(
-		ctx, handle, config.KBPKI(), session.UID, session.VerifyingKey)
+		ctx, handle, config.KBPKI(), config, session.UID, session.VerifyingKey)
 	if err != nil {
 		return libkbfs.ImmutableRootMetadata{}, err
 	}

--- a/go/kbfs/kbfstool/md_force_qr.go
+++ b/go/kbfs/kbfstool/md_force_qr.go
@@ -40,7 +40,7 @@ func mdForceQROne(
 
 	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
 		config.Codec(), config.KeyManager(),
-		config.KBPKI(), config.KBPKI(), irmd.MdID(), true)
+		config.KBPKI(), config.KBPKI(), config, irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/kbfstool/md_reset.go
+++ b/go/kbfs/kbfstool/md_reset.go
@@ -45,7 +45,7 @@ func mdResetOne(
 
 	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
 		config.Codec(), config.KeyManager(),
-		config.KBPKI(), config.KBPKI(), irmd.MdID(), true)
+		config.KBPKI(), config.KBPKI(), config, irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libfs/file_info.go
+++ b/go/kbfs/libfs/file_info.go
@@ -44,7 +44,8 @@ func (fi *FileInfo) Size() int64 {
 // Mode implements the os.FileInfo interface for FileInfo.
 func (fi *FileInfo) Mode() os.FileMode {
 	mode, err := WritePermMode(
-		fi.fs.ctx, fi.node, os.FileMode(0), fi.fs.config.KBPKI(), fi.fs.h)
+		fi.fs.ctx, fi.node, os.FileMode(0), fi.fs.config.KBPKI(),
+		fi.fs.config, fi.fs.h)
 	if err != nil {
 		fi.fs.log.CWarningf(
 			fi.fs.ctx, "Couldn't get mode for file %s: %+v", fi.Name(), err)

--- a/go/kbfs/libfs/mode.go
+++ b/go/kbfs/libfs/mode.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 // IsWriter returns whether or not the currently logged-in user is a
 // valid writer for the folder described by `h`.
 func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
-	h *libkbfs.TlfHandle) (bool, error) {
+	osg libkbfs.OfflineStatusGetter, h *libkbfs.TlfHandle) (bool, error) {
 	session, err := libkbfs.GetCurrentSessionIfPossible(
 		ctx, kbpki, h.Type() == tlf.Public)
 	// We are using GetCurrentUserInfoIfPossible here so err is only non-nil if
@@ -29,8 +30,12 @@ func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
 		if err != nil {
 			return false, err
 		}
+		offline := keybase1.OfflineAvailability_NONE
+		if osg != nil {
+			offline = osg.OfflineAvailabilityForID(h.TlfID())
+		}
 		isWriter, err := kbpki.IsTeamWriter(
-			ctx, tid, session.UID, session.VerifyingKey)
+			ctx, tid, session.UID, session.VerifyingKey, offline)
 		if err != nil {
 			return false, err
 		}
@@ -44,14 +49,15 @@ func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
 // by `h`.
 func WritePermMode(
 	ctx context.Context, node libkbfs.Node, original os.FileMode,
-	kbpki libkbfs.KBPKI, h *libkbfs.TlfHandle) (os.FileMode, error) {
+	kbpki libkbfs.KBPKI, osg libkbfs.OfflineStatusGetter,
+	h *libkbfs.TlfHandle) (os.FileMode, error) {
 	original &^= os.FileMode(0222) // clear write perm bits
 
 	if node != nil && node.Readonly(ctx) {
 		return original, nil
 	}
 
-	isWriter, err := IsWriter(ctx, kbpki, h)
+	isWriter, err := IsWriter(ctx, kbpki, osg, h)
 	if err != nil {
 		return 0, err
 	}

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -359,7 +359,8 @@ func (f *Folder) writePermMode(ctx context.Context,
 	node libkbfs.Node, original os.FileMode) (os.FileMode, error) {
 	f.handleMu.RLock()
 	defer f.handleMu.RUnlock()
-	return libfs.WritePermMode(ctx, node, original, f.fs.config.KBPKI(), f.h)
+	return libfs.WritePermMode(
+		ctx, node, original, f.fs.config.KBPKI(), f.fs.config, f.h)
 }
 
 // fillAttrWithUIDAndWritePerm sets attributes based on the entry info, and
@@ -387,7 +388,7 @@ func (f *Folder) fillAttrWithUIDAndWritePerm(
 func (f *Folder) isWriter(ctx context.Context) (bool, error) {
 	f.handleMu.RLock()
 	defer f.handleMu.RUnlock()
-	return libfs.IsWriter(ctx, f.fs.config.KBPKI(), f.h)
+	return libfs.IsWriter(ctx, f.fs.config.KBPKI(), f.fs.config, f.h)
 }
 
 func (f *Folder) access(ctx context.Context, r *fuse.AccessRequest) error {

--- a/go/kbfs/libkbfs/chat_local.go
+++ b/go/kbfs/libkbfs/chat_local.go
@@ -137,7 +137,8 @@ func (c *chatLocal) GetConversationID(
 		if err != nil {
 			return nil, err
 		}
-		isReader, err := isReaderFromHandle(ctx, h, config.KBPKI(), session.UID)
+		isReader, err := isReaderFromHandle(
+			ctx, h, config.KBPKI(), config, session.UID)
 		if err != nil {
 			return nil, err
 		}
@@ -242,7 +243,7 @@ func (c *chatLocal) GetGroupedInbox(
 
 			// Only include if the current user can read the folder.
 			isReader, err := isReaderFromHandle(
-				ctx, h, c.config.KBPKI(), session.UID)
+				ctx, h, c.config.KBPKI(), c.config, session.UID)
 			if err != nil {
 				return nil, err
 			}

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -2491,7 +2491,8 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 	newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCacheSimple) error {
 	mergedMD := mergedChains.mostRecentChainMDInfo
 	chargedTo, err := chargedToForTLF(
-		ctx, cr.config.KBPKI(), cr.config.KBPKI(), mergedMD.GetTlfHandle())
+		ctx, cr.config.KBPKI(), cr.config.KBPKI(), cr.config,
+		mergedMD.GetTlfHandle())
 	if err != nil {
 		return err
 	}
@@ -2686,7 +2687,7 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 	newMD, err := mostRecentMergedMD.MakeSuccessor(
 		ctx, cr.config.MetadataVersion(), cr.config.Codec(),
 		cr.config.KeyManager(), cr.config.KBPKI(),
-		cr.config.KBPKI(), mostRecentMergedMD.MdID(), true)
+		cr.config.KBPKI(), cr.config, mostRecentMergedMD.MdID(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1057,7 +1057,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 		return err
 	}
 	isWriter, err := head.IsWriter(
-		ctx, fbm.config.KBPKI(), session.UID, session.VerifyingKey)
+		ctx, fbm.config.KBPKI(), fbm.config, session.UID, session.VerifyingKey)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -789,7 +789,8 @@ func (fbo *folderBlockOps) getChargedToLocked(
 		return fbo.chargedTo, nil
 	}
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), fbo.config,
+		kmd.GetTlfHandle())
 	if err != nil {
 		return keybase1.UserOrTeamID(""), err
 	}
@@ -817,7 +818,8 @@ func (fbo *folderBlockOps) deepCopyFileLocked(
 	// so only a read lock is needed.
 	fbo.blockLock.AssertRLocked(lState)
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), fbo.config,
+		kmd.GetTlfHandle())
 	if err != nil {
 		return BlockPointer{}, nil, err
 	}
@@ -1939,7 +1941,7 @@ func (fbo *folderBlockOps) writeGetFileLocked(
 		return nil, err
 	}
 	isWriter, err := kmd.IsWriter(
-		ctx, fbo.config.KBPKI(), session.UID, session.VerifyingKey)
+		ctx, fbo.config.KBPKI(), fbo.config, session.UID, session.VerifyingKey)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/folder_branch_status.go
+++ b/go/kbfs/libkbfs/folder_branch_status.go
@@ -238,7 +238,7 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 			loggerSuffix := fmt.Sprintf("status-%s", fbsk.md.TlfID())
 			chargedTo, err := chargedToForTLF(
 				ctx, fbsk.config.KBPKI(), fbsk.config.KBPKI(),
-				fbsk.md.GetTlfHandle())
+				fbsk.config, fbsk.md.GetTlfHandle())
 			if err != nil {
 				return FolderBranchStatus{}, nil, tlf.NullID, err
 			}

--- a/go/kbfs/libkbfs/folder_update_prepper.go
+++ b/go/kbfs/libkbfs/folder_update_prepper.go
@@ -1162,7 +1162,8 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 	updates = make(map[BlockPointer]BlockPointer)
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fup.config.KBPKI(), fup.config.KBPKI(), md.GetTlfHandle())
+		ctx, fup.config.KBPKI(), fup.config.KBPKI(), fup.config,
+		md.GetTlfHandle())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -244,7 +244,8 @@ func (j *JournalManager) getTLFJournal(
 		// the first write that happens after the user becomes a
 		// writer for the TLF.
 		isWriter, err := IsWriterFromHandle(
-			ctx, h, j.config.KBPKI(), j.currentUID, j.currentVerifyingKey)
+			ctx, h, j.config.KBPKI(), j.config, j.currentUID,
+			j.currentVerifyingKey)
 		if err != nil {
 			j.log.CWarningf(ctx, "Couldn't find writership for %s: %+v",
 				tlfID, err)
@@ -639,7 +640,8 @@ func (j *JournalManager) Enable(ctx context.Context, tlfID tlf.ID,
 		chargedTo = h.FirstResolvedWriter()
 		if tid := chargedTo.AsTeamOrBust(); tid.IsSubTeam() {
 			// We can't charge to subteams; find the root team.
-			rootID, err := j.config.KBPKI().GetTeamRootID(ctx, tid)
+			rootID, err := j.config.KBPKI().GetTeamRootID(
+				ctx, tid, j.config.OfflineAvailabilityForID(tlfID))
 			if err != nil {
 				return err
 			}

--- a/go/kbfs/libkbfs/journal_md_ops.go
+++ b/go/kbfs/libkbfs/journal_md_ops.go
@@ -60,8 +60,8 @@ func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 	config := j.jManager.config
 	pmd, err := decryptMDPrivateData(ctx, config.Codec(), config.Crypto(),
 		config.BlockCache(), config.BlockOps(), config.KeyManager(),
-		config.KBPKI(), config.Mode(), uid, rmd.GetSerializedPrivateMetadata(),
-		rmd, rmd, j.jManager.log)
+		config.KBPKI(), config, config.Mode(), uid,
+		rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.jManager.log)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/go/kbfs/libkbfs/journal_md_ops_test.go
+++ b/go/kbfs/libkbfs/journal_md_ops_test.go
@@ -387,7 +387,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		rmd, err = rmd.MakeSuccessor(ctx, config.MetadataVersion(),
 			config.Codec(), config.KeyManager(),
-			config.KBPKI(), config.KBPKI(), mdID, true)
+			config.KBPKI(), config.KBPKI(), config, mdID, true)
 		require.NoError(t, err)
 		mdID, err = j.put(ctx, config.Crypto(), config.KeyManager(),
 			config.BlockSplitter(), rmd, false)

--- a/go/kbfs/libkbfs/kbpki_client_test.go
+++ b/go/kbfs/libkbfs/kbpki_client_test.go
@@ -209,7 +209,8 @@ func TestKBPKIClientGetTeamTLFCryptKeys(t *testing.T) {
 
 	for _, team := range localTeams {
 		keys, keyGen, err := c.GetTeamTLFCryptKeys(
-			context.Background(), team.TID, kbfsmd.UnspecifiedKeyGen)
+			context.Background(), team.TID, kbfsmd.UnspecifiedKeyGen,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			t.Error(err)
 		}

--- a/go/kbfs/libkbfs/key_manager.go
+++ b/go/kbfs/libkbfs/key_manager.go
@@ -130,7 +130,8 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 		if err != nil {
 			return kbfscrypto.TLFCryptKey{}, err
 		}
-		keys, _, err := km.config.KBPKI().GetTeamTLFCryptKeys(ctx, tid, keyGen)
+		keys, _, err := km.config.KBPKI().GetTeamTLFCryptKeys(
+			ctx, tid, keyGen, km.config.OfflineAvailabilityForID(tlfID))
 		if err != nil {
 			return kbfscrypto.TLFCryptKey{}, err
 		}
@@ -743,8 +744,8 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		pmd, err := decryptMDPrivateData(
 			ctx, km.config.Codec(), km.config.Crypto(),
 			km.config.BlockCache(), km.config.BlockOps(), km, km.config.KBPKI(),
-			km.config.Mode(), session.UID, md.GetSerializedPrivateMetadata(),
-			md, md, km.log)
+			km.config, km.config.Mode(), session.UID,
+			md.GetSerializedPrivateMetadata(), md, md, km.log)
 		if err != nil {
 			return false, nil, err
 		}

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -168,8 +168,8 @@ func (kmd emptyKeyMetadata) GetTlfHandle() *TlfHandle {
 }
 
 func (kmd emptyKeyMetadata) IsWriter(
-	_ context.Context, _ kbfsmd.TeamMembershipChecker, _ keybase1.UID,
-	_ kbfscrypto.VerifyingKey) (bool, error) {
+	_ context.Context, _ kbfsmd.TeamMembershipChecker, _ OfflineStatusGetter,
+	_ keybase1.UID, _ kbfscrypto.VerifyingKey) (bool, error) {
 	return false, nil
 }
 
@@ -2419,7 +2419,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config1.MetadataVersion(), config1.Codec(),
 		config1.KeyManager(), config1.KBPKI(), config1.KBPKI(),
-		kbfsmd.FakeID(2), true)
+		config1, kbfsmd.FakeID(2), true)
 	require.NoError(t, err)
 
 	// Both users should see the same new key.
@@ -2459,7 +2459,8 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	}
 
 	_, latestKeyGen, err := config1.KBPKI().GetTeamTLFCryptKeys(
-		ctx, teamID, kbfsmd.UnspecifiedKeyGen)
+		ctx, teamID, kbfsmd.UnspecifiedKeyGen,
+		keybase1.OfflineAvailability_NONE)
 
 	rmd, err := makeInitialRootMetadata(config1.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
@@ -2480,7 +2481,7 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config1.MetadataVersion(), config1.Codec(),
 		config1.KeyManager(), config1.KBPKI(), config1.KBPKI(),
-		kbfsmd.FakeID(2), true)
+		config1, kbfsmd.FakeID(2), true)
 	require.NoError(t, err)
 
 	// Both users should see the same new key.

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -447,7 +447,7 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context,
 func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
 	ctx context.Context, tid keybase1.TeamID, _ tlf.Type, _ kbfsmd.KeyGen,
 	_ keybase1.UserVersion, _ kbfscrypto.VerifyingKey,
-	_ keybase1.TeamRole) (TeamInfo, error) {
+	_ keybase1.TeamRole, _ keybase1.OfflineAvailability) (TeamInfo, error) {
 	if err := checkContext(ctx); err != nil {
 		return TeamInfo{}, err
 	}

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -763,8 +763,8 @@ var allowedLoadTeamRoles = map[keybase1.TeamRole]bool{
 func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type,
 	desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion,
-	desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole) (
-	TeamInfo, error) {
+	desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole,
+	offline keybase1.OfflineAvailability) (TeamInfo, error) {
 	if !allowedLoadTeamRoles[desiredRole] {
 		panic(fmt.Sprintf("Disallowed team role: %v", desiredRole))
 	}
@@ -817,6 +817,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 		Id:              tid,
 		Application:     keybase1.TeamApplication_KBFS,
 		IncludeKBFSKeys: true,
+		Oa:              offline,
 	}
 
 	if desiredKeyGen >= kbfsmd.FirstValidKeyGen {

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -163,11 +163,12 @@ func (k KeybaseServiceMeasured) LoadUserPlusKeys(ctx context.Context,
 func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
 	tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen,
 	desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey,
-	desiredRole keybase1.TeamRole) (teamInfo TeamInfo, err error) {
+	desiredRole keybase1.TeamRole, offline keybase1.OfflineAvailability) (
+	teamInfo TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
 		teamInfo, err = k.delegate.LoadTeamPlusKeys(
 			ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey,
-			desiredRole)
+			desiredRole, offline)
 	})
 	return teamInfo, err
 }

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -1020,7 +1020,7 @@ func makeSuccessorRMDForTesting(
 
 	rmd, err := currRMD.MakeSuccessor(
 		ctx, config.MetadataVersion(), config.Codec(), config.KeyManager(),
-		config.KBPKI(), config.KBPKI(), mdID, true)
+		config.KBPKI(), config.KBPKI(), config, mdID, true)
 	require.NoError(t, err)
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -193,7 +193,7 @@ func MakeCopyWithDecryptedPrivateData(
 	pmd, err := decryptMDPrivateData(
 		ctx, config.Codec(), config.Crypto(),
 		config.BlockCache(), config.BlockOps(),
-		config.KeyManager(), config.KBPKI(), config.Mode(), uid,
+		config.KeyManager(), config.KBPKI(), config, config.Mode(), uid,
 		irmdToDecrypt.GetSerializedPrivateMetadata(),
 		irmdToDecrypt, irmdWithKeys, config.MakeLogger(""))
 	if err != nil {
@@ -593,9 +593,9 @@ func reembedBlockChangesIntoCopyIfNeeded(
 func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 	crypto Crypto, bcache BlockCache, bops BlockOps,
 	keyGetter mdDecryptionKeyGetter, teamChecker kbfsmd.TeamMembershipChecker,
-	mode InitMode, uid keybase1.UID, serializedPrivateMetadata []byte,
-	rmdToDecrypt, rmdWithKeys KeyMetadata, log logger.Logger) (
-	PrivateMetadata, error) {
+	osg OfflineStatusGetter, mode InitMode, uid keybase1.UID,
+	serializedPrivateMetadata []byte, rmdToDecrypt, rmdWithKeys KeyMetadata,
+	log logger.Logger) (PrivateMetadata, error) {
 	handle := rmdToDecrypt.GetTlfHandle()
 
 	var pmd PrivateMetadata
@@ -619,7 +619,7 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 			log.CDebugf(ctx, "Couldn't get crypt key for %s (%s): %+v",
 				handle.GetCanonicalPath(), rmdToDecrypt.TlfID(), err)
 			isReader, readerErr := isReaderFromHandle(
-				ctx, handle, teamChecker, uid)
+				ctx, handle, teamChecker, osg, uid)
 			if readerErr != nil {
 				return PrivateMetadata{}, readerErr
 			}

--- a/go/kbfs/libkbfs/mdserver_disk.go
+++ b/go/kbfs/libkbfs/mdserver_disk.go
@@ -208,7 +208,8 @@ func (md *MDServerDisk) getHandleID(ctx context.Context, handle tlf.Handle,
 	}
 	if handle.Type() == tlf.SingleTeam {
 		isReader, err := md.config.teamMembershipChecker().IsTeamReader(
-			ctx, handle.Writers[0].AsTeamOrBust(), session.UID)
+			ctx, handle.Writers[0].AsTeamOrBust(), session.UID,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 		} else if !isReader {

--- a/go/kbfs/libkbfs/mdserver_local_shared.go
+++ b/go/kbfs/libkbfs/mdserver_local_shared.go
@@ -31,7 +31,8 @@ func isReader(ctx context.Context, teamMemChecker kbfsmd.TeamMembershipChecker,
 
 	if h.Type() == tlf.SingleTeam {
 		isReader, err := teamMemChecker.IsTeamReader(
-			ctx, h.Writers[0].AsTeamOrBust(), currentUID)
+			ctx, h.Writers[0].AsTeamOrBust(), currentUID,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			return false, kbfsmd.ServerError{Err: err}
 		}
@@ -56,7 +57,8 @@ func isWriterOrValidRekey(ctx context.Context,
 
 	if h.Type() == tlf.SingleTeam {
 		isWriter, err := teamMemChecker.IsTeamWriter(
-			ctx, h.Writers[0].AsTeamOrBust(), currentUID, verifyingKey)
+			ctx, h.Writers[0].AsTeamOrBust(), currentUID, verifyingKey,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			return false, kbfsmd.ServerError{Err: err}
 		}

--- a/go/kbfs/libkbfs/mdserver_memory.go
+++ b/go/kbfs/libkbfs/mdserver_memory.go
@@ -184,7 +184,8 @@ func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
 	}
 	if handle.Type() == tlf.SingleTeam {
 		isReader, err := md.config.teamMembershipChecker().IsTeamReader(
-			ctx, handle.Writers[0].AsTeamOrBust(), session.UID)
+			ctx, handle.Writers[0].AsTeamOrBust(), session.UID,
+			keybase1.OfflineAvailability_NONE)
 		if err != nil {
 			return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 		}
@@ -552,8 +553,8 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 	}
 
 	err = rmds.IsValidAndSigned(
-		ctx, md.config.Codec(),
-		md.config.teamMembershipChecker(), extra)
+		ctx, md.config.Codec(), md.config.teamMembershipChecker(), extra,
+		keybase1.OfflineAvailability_NONE)
 	if err != nil {
 		return kbfsmd.ServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/go/kbfs/libkbfs/mdserver_tlf_storage.go
+++ b/go/kbfs/libkbfs/mdserver_tlf_storage.go
@@ -411,7 +411,9 @@ func (s *mdServerTlfStorage) put(ctx context.Context,
 		return false, err
 	}
 
-	err = rmds.IsValidAndSigned(ctx, s.codec, s.teamMemChecker, extra)
+	err = rmds.IsValidAndSigned(
+		ctx, s.codec, s.teamMemChecker, extra,
+		keybase1.OfflineAvailability_NONE)
 	if err != nil {
 		return false, kbfsmd.ServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -2847,18 +2847,18 @@ func (mr *MockKeybaseServiceMockRecorder) LoadUserPlusKeys(ctx, uid, pollForKID 
 }
 
 // LoadTeamPlusKeys mocks base method
-func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole) (TeamInfo, error) {
+func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole, offline keybase1.OfflineAvailability) (TeamInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadTeamPlusKeys", ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole)
+	ret := m.ctrl.Call(m, "LoadTeamPlusKeys", ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole, offline)
 	ret0, _ := ret[0].(TeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadTeamPlusKeys indicates an expected call of LoadTeamPlusKeys
-func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTeamPlusKeys", reflect.TypeOf((*MockKeybaseService)(nil).LoadTeamPlusKeys), ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTeamPlusKeys", reflect.TypeOf((*MockKeybaseService)(nil).LoadTeamPlusKeys), ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole, offline)
 }
 
 // CurrentSession mocks base method
@@ -3351,48 +3351,48 @@ func (m *MockteamMembershipChecker) EXPECT() *MockteamMembershipCheckerMockRecor
 }
 
 // IsTeamWriter mocks base method
-func (m *MockteamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockteamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, offline keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTeamWriter", ctx, tid, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "IsTeamWriter", ctx, tid, uid, verifyingKey, offline)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsTeamWriter indicates an expected call of IsTeamWriter
-func (mr *MockteamMembershipCheckerMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockteamMembershipCheckerMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey, offline)
 }
 
 // NoLongerTeamWriter mocks base method
-func (m *MockteamMembershipChecker) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (keybase1.MerkleRootV2, error) {
+func (m *MockteamMembershipChecker) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, offline keybase1.OfflineAvailability) (keybase1.MerkleRootV2, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey, offline)
 	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NoLongerTeamWriter indicates an expected call of NoLongerTeamWriter
-func (mr *MockteamMembershipCheckerMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockteamMembershipCheckerMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey, offline)
 }
 
 // IsTeamReader mocks base method
-func (m *MockteamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+func (m *MockteamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, offline keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid)
+	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid, offline)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsTeamReader indicates an expected call of IsTeamReader
-func (mr *MockteamMembershipCheckerMockRecorder) IsTeamReader(ctx, tid, uid interface{}) *gomock.Call {
+func (mr *MockteamMembershipCheckerMockRecorder) IsTeamReader(ctx, tid, uid, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamReader), ctx, tid, uid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamReader), ctx, tid, uid, offline)
 }
 
 // MockteamKeysGetter is a mock of teamKeysGetter interface
@@ -3419,9 +3419,9 @@ func (m *MockteamKeysGetter) EXPECT() *MockteamKeysGetterMockRecorder {
 }
 
 // GetTeamTLFCryptKeys mocks base method
-func (m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
+func (m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen, offline keybase1.OfflineAvailability) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen)
+	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen, offline)
 	ret0, _ := ret[0].(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey)
 	ret1, _ := ret[1].(kbfsmd.KeyGen)
 	ret2, _ := ret[2].(error)
@@ -3429,9 +3429,9 @@ func (m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybas
 }
 
 // GetTeamTLFCryptKeys indicates an expected call of GetTeamTLFCryptKeys
-func (mr *MockteamKeysGetterMockRecorder) GetTeamTLFCryptKeys(ctx, tid, desiredKeyGen interface{}) *gomock.Call {
+func (mr *MockteamKeysGetterMockRecorder) GetTeamTLFCryptKeys(ctx, tid, desiredKeyGen, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockteamKeysGetter)(nil).GetTeamTLFCryptKeys), ctx, tid, desiredKeyGen)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockteamKeysGetter)(nil).GetTeamTLFCryptKeys), ctx, tid, desiredKeyGen, offline)
 }
 
 // MockteamRootIDGetter is a mock of teamRootIDGetter interface
@@ -3458,18 +3458,18 @@ func (m *MockteamRootIDGetter) EXPECT() *MockteamRootIDGetterMockRecorder {
 }
 
 // GetTeamRootID mocks base method
-func (m *MockteamRootIDGetter) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (keybase1.TeamID, error) {
+func (m *MockteamRootIDGetter) GetTeamRootID(ctx context.Context, tid keybase1.TeamID, offline keybase1.OfflineAvailability) (keybase1.TeamID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamRootID", ctx, tid)
+	ret := m.ctrl.Call(m, "GetTeamRootID", ctx, tid, offline)
 	ret0, _ := ret[0].(keybase1.TeamID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTeamRootID indicates an expected call of GetTeamRootID
-func (mr *MockteamRootIDGetterMockRecorder) GetTeamRootID(ctx, tid interface{}) *gomock.Call {
+func (mr *MockteamRootIDGetterMockRecorder) GetTeamRootID(ctx, tid, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockteamRootIDGetter)(nil).GetTeamRootID), ctx, tid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockteamRootIDGetter)(nil).GetTeamRootID), ctx, tid, offline)
 }
 
 // MockKBPKI is a mock of KBPKI interface
@@ -3663,54 +3663,54 @@ func (mr *MockKBPKIMockRecorder) VerifyMerkleRoot(ctx, root, kbfsRoot interface{
 }
 
 // IsTeamWriter mocks base method
-func (m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, offline keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTeamWriter", ctx, tid, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "IsTeamWriter", ctx, tid, uid, verifyingKey, offline)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsTeamWriter indicates an expected call of IsTeamWriter
-func (mr *MockKBPKIMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey, offline)
 }
 
 // NoLongerTeamWriter mocks base method
-func (m *MockKBPKI) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (keybase1.MerkleRootV2, error) {
+func (m *MockKBPKI) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, offline keybase1.OfflineAvailability) (keybase1.MerkleRootV2, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey, offline)
 	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NoLongerTeamWriter indicates an expected call of NoLongerTeamWriter
-func (mr *MockKBPKIMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey, offline)
 }
 
 // IsTeamReader mocks base method
-func (m *MockKBPKI) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+func (m *MockKBPKI) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, offline keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid)
+	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid, offline)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsTeamReader indicates an expected call of IsTeamReader
-func (mr *MockKBPKIMockRecorder) IsTeamReader(ctx, tid, uid interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) IsTeamReader(ctx, tid, uid, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockKBPKI)(nil).IsTeamReader), ctx, tid, uid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockKBPKI)(nil).IsTeamReader), ctx, tid, uid, offline)
 }
 
 // GetTeamTLFCryptKeys mocks base method
-func (m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
+func (m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen, offline keybase1.OfflineAvailability) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen)
+	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen, offline)
 	ret0, _ := ret[0].(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey)
 	ret1, _ := ret[1].(kbfsmd.KeyGen)
 	ret2, _ := ret[2].(error)
@@ -3718,24 +3718,24 @@ func (m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID
 }
 
 // GetTeamTLFCryptKeys indicates an expected call of GetTeamTLFCryptKeys
-func (mr *MockKBPKIMockRecorder) GetTeamTLFCryptKeys(ctx, tid, desiredKeyGen interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetTeamTLFCryptKeys(ctx, tid, desiredKeyGen, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockKBPKI)(nil).GetTeamTLFCryptKeys), ctx, tid, desiredKeyGen)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockKBPKI)(nil).GetTeamTLFCryptKeys), ctx, tid, desiredKeyGen, offline)
 }
 
 // GetTeamRootID mocks base method
-func (m *MockKBPKI) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (keybase1.TeamID, error) {
+func (m *MockKBPKI) GetTeamRootID(ctx context.Context, tid keybase1.TeamID, offline keybase1.OfflineAvailability) (keybase1.TeamID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamRootID", ctx, tid)
+	ret := m.ctrl.Call(m, "GetTeamRootID", ctx, tid, offline)
 	ret0, _ := ret[0].(keybase1.TeamID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTeamRootID indicates an expected call of GetTeamRootID
-func (mr *MockKBPKIMockRecorder) GetTeamRootID(ctx, tid interface{}) *gomock.Call {
+func (mr *MockKBPKIMockRecorder) GetTeamRootID(ctx, tid, offline interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockKBPKI)(nil).GetTeamRootID), ctx, tid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamRootID", reflect.TypeOf((*MockKBPKI)(nil).GetTeamRootID), ctx, tid, offline)
 }
 
 // PutGitMetadata mocks base method
@@ -3946,18 +3946,18 @@ func (mr *MockKeyMetadataMockRecorder) GetTlfHandle() *gomock.Call {
 }
 
 // IsWriter mocks base method
-func (m *MockKeyMetadata) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockKeyMetadata) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, osg OfflineStatusGetter, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, osg, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsWriter indicates an expected call of IsWriter
-func (mr *MockKeyMetadataMockRecorder) IsWriter(ctx, checker, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockKeyMetadataMockRecorder) IsWriter(ctx, checker, osg, uid, verifyingKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadata)(nil).IsWriter), ctx, checker, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadata)(nil).IsWriter), ctx, checker, osg, uid, verifyingKey)
 }
 
 // HasKeyForUser mocks base method
@@ -4102,18 +4102,18 @@ func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetTlfHandle() *gomock.Ca
 }
 
 // IsWriter mocks base method
-func (m *MockKeyMetadataWithRootDirEntry) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockKeyMetadataWithRootDirEntry) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, osg OfflineStatusGetter, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, uid, verifyingKey)
+	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, osg, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsWriter indicates an expected call of IsWriter
-func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) IsWriter(ctx, checker, uid, verifyingKey interface{}) *gomock.Call {
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) IsWriter(ctx, checker, osg, uid, verifyingKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).IsWriter), ctx, checker, uid, verifyingKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).IsWriter), ctx, checker, osg, uid, verifyingKey)
 }
 
 // HasKeyForUser mocks base method

--- a/go/kbfs/libkbfs/root_metadata.go
+++ b/go/kbfs/libkbfs/root_metadata.go
@@ -230,8 +230,8 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 func (md *RootMetadata) MakeSuccessor(
 	ctx context.Context, latestMDVer kbfsmd.MetadataVer, codec kbfscodec.Codec,
 	keyManager KeyManager, merkleGetter merkleRootGetter,
-	teamKeyer teamKeysGetter, mdID kbfsmd.ID, isWriter bool) (
-	*RootMetadata, error) {
+	teamKeyer teamKeysGetter, osg OfflineStatusGetter, mdID kbfsmd.ID,
+	isWriter bool) (*RootMetadata, error) {
 	if mdID == (kbfsmd.ID{}) {
 		return nil, errors.New("Empty MdID in MakeSuccessor")
 	}
@@ -266,8 +266,14 @@ func (md *RootMetadata) MakeSuccessor(
 			if err != nil {
 				return nil, err
 			}
+
+			offline := keybase1.OfflineAvailability_NONE
+			if osg != nil {
+				offline = osg.OfflineAvailabilityForID(md.TlfID())
+			}
+
 			_, keyGen, err := teamKeyer.GetTeamTLFCryptKeys(
-				ctx, tid, kbfsmd.UnspecifiedKeyGen)
+				ctx, tid, kbfsmd.UnspecifiedKeyGen, offline)
 			if err != nil {
 				return nil, err
 			}
@@ -295,8 +301,8 @@ func (md *RootMetadata) MakeSuccessor(
 func (md *RootMetadata) MakeSuccessorWithNewHandle(
 	ctx context.Context, newHandle *TlfHandle, latestMDVer kbfsmd.MetadataVer,
 	codec kbfscodec.Codec, keyManager KeyManager, merkleGetter merkleRootGetter,
-	teamKeyer teamKeysGetter, mdID kbfsmd.ID, isWriter bool) (
-	*RootMetadata, error) {
+	teamKeyer teamKeysGetter, osg OfflineStatusGetter, mdID kbfsmd.ID,
+	isWriter bool) (*RootMetadata, error) {
 	mdCopy, err := md.deepCopy(codec)
 	if err != nil {
 		return nil, err
@@ -313,8 +319,8 @@ func (md *RootMetadata) MakeSuccessorWithNewHandle(
 	mdCopy.bareMd.ClearForV4Migration()
 
 	return mdCopy.MakeSuccessor(
-		ctx, latestMDVer, codec, keyManager, merkleGetter, teamKeyer, mdID,
-		isWriter)
+		ctx, latestMDVer, codec, keyManager, merkleGetter, teamKeyer, osg,
+		mdID, isWriter)
 }
 
 // GetTlfHandle returns the TlfHandle for this RootMetadata.
@@ -900,19 +906,19 @@ func (md *RootMetadata) GetHistoricTLFCryptKey(
 // right now.  Implements the KeyMetadata interface for RootMetadata.
 func (md *RootMetadata) IsWriter(
 	ctx context.Context, checker kbfsmd.TeamMembershipChecker,
-	uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (
-	bool, error) {
+	osg OfflineStatusGetter, uid keybase1.UID,
+	verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	h := md.GetTlfHandle()
-	return IsWriterFromHandle(ctx, h, checker, uid, verifyingKey)
+	return IsWriterFromHandle(ctx, h, checker, osg, uid, verifyingKey)
 }
 
 // IsReader checks that the given user is a valid reader of the TLF
 // right now.
 func (md *RootMetadata) IsReader(
 	ctx context.Context, checker kbfsmd.TeamMembershipChecker,
-	uid keybase1.UID) (bool, error) {
+	osg OfflineStatusGetter, uid keybase1.UID) (bool, error) {
 	h := md.GetTlfHandle()
-	return isReaderFromHandle(ctx, h, checker, uid)
+	return isReaderFromHandle(ctx, h, checker, osg, uid)
 }
 
 // A ReadOnlyRootMetadata is a thin wrapper around a

--- a/go/kbfs/libkbfs/root_metadata_test.go
+++ b/go/kbfs/libkbfs/root_metadata_test.go
@@ -360,7 +360,7 @@ func testRootMetadataFinalIsFinal(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	rmd.SetFinalBit()
 	_, err = rmd.MakeSuccessor(context.Background(), -1, nil, nil, nil,
-		nil, kbfsmd.FakeID(1), true)
+		nil, nil, kbfsmd.FakeID(1), true)
 	_, isFinalError := err.(kbfsmd.MetadataIsFinalError)
 	require.Equal(t, isFinalError, true)
 }
@@ -484,8 +484,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), nil,
+		kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(2), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -576,8 +576,8 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), config,
+		kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.PublicKeyGen, rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -646,8 +646,8 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), config,
+		kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -767,7 +767,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		configReader.MetadataVersion(), configReader.Codec(),
 		configReader.KeyManager(), configReader.KBPKI(),
-		configReader.KBPKI(), kbfsmd.FakeID(1), false)
+		configReader.KBPKI(), configReader, kbfsmd.FakeID(1), false)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -791,7 +791,8 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 		rmd2.bareMd, configReader.Clock().Now())
 	require.NoError(t, err)
 	err = rmds.IsValidAndSigned(
-		ctx, configReader.Codec(), nil, rmd2.extra)
+		ctx, configReader.Codec(), nil, rmd2.extra,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 }
 
@@ -835,12 +836,12 @@ func TestRootMetadataTeamMembership(t *testing.T) {
 	// No user should be able to read this yet.
 	checkWriter := func(uid keybase1.UID, key kbfscrypto.VerifyingKey,
 		expectedIsWriter bool) {
-		isWriter, err := rmd.IsWriter(ctx, config.KBPKI(), uid, key)
+		isWriter, err := rmd.IsWriter(ctx, config.KBPKI(), config, uid, key)
 		require.NoError(t, err)
 		require.Equal(t, expectedIsWriter, isWriter)
 	}
 	checkReader := func(uid keybase1.UID, expectedIsReader bool) {
-		isReader, err := rmd.IsReader(ctx, config.KBPKI(), uid)
+		isReader, err := rmd.IsReader(ctx, config.KBPKI(), config, uid)
 		require.NoError(t, err)
 		require.Equal(t, expectedIsReader, isReader)
 	}
@@ -908,8 +909,8 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), config,
+		kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 
 	// No increase yet.
@@ -920,8 +921,8 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 
 	rmd3, err := rmd2.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),
-		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(2),
-		true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), config,
+		kbfsmd.FakeID(2), true)
 	require.NoError(t, err)
 
 	// Should have been bumped by one.

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -551,7 +551,7 @@ func AddTeamKeyForTest(config Config, tid keybase1.TeamID) error {
 	ti, err := kbd.LoadTeamPlusKeys(
 		context.Background(), tid, tlf.Unknown, kbfsmd.UnspecifiedKeyGen,
 		keybase1.UserVersion{}, kbfscrypto.VerifyingKey{},
-		keybase1.TeamRole_NONE)
+		keybase1.TeamRole_NONE, keybase1.OfflineAvailability_NONE)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -416,8 +416,8 @@ func makeTLFJournal(
 
 	mdJournal, err := makeMDJournal(
 		ctx, uid, key, config.Codec(), config.Crypto(), config.Clock(),
-		config.teamMembershipChecker(), tlfID, config.MetadataVersion(), dir,
-		log)
+		config.teamMembershipChecker(), config, tlfID, config.MetadataVersion(),
+		dir, log)
 	if err != nil {
 		return nil, err
 	}
@@ -1752,7 +1752,8 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 			ctx, j.config.Codec(), j.config.Crypto(),
 			j.config.BlockCache(), j.config.BlockOps(),
 			j.config.mdDecryptionKeyGetter(), j.config.teamMembershipChecker(),
-			mode, j.uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.log)
+			j.config, mode, j.uid, rmd.GetSerializedPrivateMetadata(), rmd,
+			rmd, j.log)
 		if err != nil {
 			return nil, err
 		}

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -186,7 +186,8 @@ func (c testTLFJournalConfig) checkMD(rmds *RootMetadataSigned,
 		rmds.MD, extra, expectedRevision, expectedPrevRoot,
 		expectedMergeStatus, expectedBranchID)
 	err := rmds.IsValidAndSigned(
-		context.Background(), c.Codec(), nil, extra)
+		context.Background(), c.Codec(), nil, extra,
+		keybase1.OfflineAvailability_NONE)
 	require.NoError(c.t, err)
 	err = rmds.IsLastModifiedBy(c.uid, verifyingKey)
 	require.NoError(c.t, err)

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -354,7 +354,8 @@ func (k *SimpleFS) favoriteList(ctx context.Context, path keybase1.Path, t tlf.T
 			k.log.Errorf("ParseTlfHandlePreferredQuick: %s %q %v", t, pname, err)
 			continue
 		}
-		res[len(res)-1].Writable, err = libfs.IsWriter(ctx, k.config.KBPKI(), handle)
+		res[len(res)-1].Writable, err = libfs.IsWriter(
+			ctx, k.config.KBPKI(), k.config, handle)
 		if err != nil {
 			k.log.Errorf("libfs.IsWriter: %q %+v", pname, err)
 			continue


### PR DESCRIPTION
This affects all the paths for getting keys, checking team membership, and finding a team's root team ID.

Issue: KBFS-3918