### PR TITLE
kbfs: enable v2 encryption for blocks by default

### DIFF
--- a/go/kbfs/kbfshash/hash.go
+++ b/go/kbfs/kbfshash/hash.go
@@ -55,6 +55,9 @@ const (
 	SHA256Hash HashType = 1
 	// SHA256HashV2 is the type of a SHA256 hash over V2-encrypted data.
 	SHA256HashV2 HashType = 2
+
+	// MaxHashType is the numerically-largest hash type.
+	MaxHashType HashType = SHA256HashV2
 )
 
 // MaxDefaultHash is the maximum value of RawDefaultHash

--- a/go/kbfs/kbfshash/hash.go
+++ b/go/kbfs/kbfshash/hash.go
@@ -56,7 +56,7 @@ const (
 	// SHA256HashV2 is the type of a SHA256 hash over V2-encrypted data.
 	SHA256HashV2 HashType = 2
 
-	// MaxHashType is the numerically-largest hash type.
+	// MaxHashType is the highest-supported hash type.
 	MaxHashType HashType = SHA256HashV2
 )
 

--- a/go/kbfs/libkbfs/block_disk_store_test.go
+++ b/go/kbfs/libkbfs/block_disk_store_test.go
@@ -36,7 +36,8 @@ func teardownBlockDiskStoreTest(t *testing.T, tempdir string) {
 func putBlockDisk(
 	t *testing.T, s *blockDiskStore, data []byte) (
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
@@ -107,7 +108,8 @@ func TestBlockDiskStoreAddReference(t *testing.T) {
 	defer teardownBlockDiskStoreTest(t, tempdir)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	// Add a reference, which should succeed.
@@ -148,7 +150,8 @@ func TestBlockDiskStoreArchiveNonExistentReference(t *testing.T) {
 		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	// Archive references.

--- a/go/kbfs/libkbfs/block_journal_test.go
+++ b/go/kbfs/libkbfs/block_journal_test.go
@@ -142,7 +142,8 @@ func putBlockData(
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
 	oldLength := j.length()
 
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
@@ -227,7 +228,8 @@ func TestBlockJournalDuplicatePut(t *testing.T) {
 
 	oldLength := j.length()
 
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
@@ -262,7 +264,8 @@ func TestBlockJournalAddReference(t *testing.T) {
 	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	// Add a reference, which should succeed.
@@ -304,7 +307,8 @@ func TestBlockJournalArchiveNonExistentReference(t *testing.T) {
 		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	// Archive references.
@@ -1054,7 +1058,7 @@ func TestBlockJournalByteCounters(t *testing.T) {
 
 	data3 := []byte{1, 2, 3}
 	bID3, err := kbfsblock.MakePermanentID(
-		data3, kbfscrypto.EncryptionSecretbox)
+		data3, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	_ = addBlockRef(ctx, t, j, bID3)
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -113,7 +113,7 @@ func (config testBlockOpsConfig) DataVersion() DataVer {
 }
 
 func (config testBlockOpsConfig) BlockCryptVersion() kbfscrypto.EncryptionVer {
-	return kbfscrypto.EncryptionSecretbox
+	return kbfscrypto.EncryptionSecretboxWithKeyNonce
 }
 
 func (config testBlockOpsConfig) Clock() Clock {

--- a/go/kbfs/libkbfs/bserver_remote_test.go
+++ b/go/kbfs/libkbfs/bserver_remote_test.go
@@ -101,7 +101,8 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	bCtx := kbfsblock.MakeFirstContext(
 		currentUID.AsUserOrTeam(), keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -64,8 +64,8 @@ const (
 	// block cache.
 	defaultSyncBlockCacheFraction = 1.00
 
-	// By default, use v1 block encryption.
-	defaultBlockCryptVersion = kbfscrypto.EncryptionSecretbox
+	// By default, use v2 block encryption.
+	defaultBlockCryptVersion = kbfscrypto.EncryptionSecretboxWithKeyNonce
 )
 
 // ConfigLocal implements the Config interface using purely local

--- a/go/kbfs/libkbfs/crypto_common_test.go
+++ b/go/kbfs/libkbfs/crypto_common_test.go
@@ -142,7 +142,8 @@ func TestCryptoCommonEncryptDecryptBlock(t *testing.T) {
 }
 
 func checkSecretboxOpenPrivateMetadata(t *testing.T, encryptedPrivateMetadata kbfscrypto.EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (encodedData []byte) {
-	require.Equal(t, kbfscrypto.EncryptionSecretbox, encryptedPrivateMetadata.Version)
+	require.Equal(
+		t, kbfscrypto.EncryptionSecretbox, encryptedPrivateMetadata.Version)
 	require.Equal(t, 24, len(encryptedPrivateMetadata.Nonce))
 
 	var nonce [24]byte
@@ -216,7 +217,8 @@ func makeFakeBlockCryptKey(t *testing.T) (
 }
 
 func checkSecretboxOpenBlock(t *testing.T, encryptedBlock kbfscrypto.EncryptedBlock, key kbfscrypto.BlockCryptKey) (encodedData []byte) {
-	require.Equal(t, kbfscrypto.EncryptionSecretbox, encryptedBlock.Version)
+	require.Equal(
+		t, kbfscrypto.EncryptionSecretbox, encryptedBlock.Version)
 	require.Equal(t, 24, len(encryptedBlock.Nonce))
 
 	var nonce [24]byte
@@ -374,7 +376,7 @@ func TestSecretboxEncryptedLen(t *testing.T) {
 			data := randomData[j : j+i]
 			enc, err := kbfscrypto.EncryptPaddedEncodedBlock(
 				data, cryptKeys[j], serverHalfs[j],
-				kbfscrypto.EncryptionSecretbox)
+				kbfscrypto.EncryptionSecretboxWithKeyNonce)
 			require.NoError(t, err)
 			if j == 0 {
 				enclen = len(enc.EncryptedData)

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -225,8 +225,8 @@ func newDiskBlockCacheLocalFromStorage(
 	}
 	closers = append(closers, lastUnrefDb)
 
-	maxBlockID, err := kbfshash.HashFromRaw(kbfshash.DefaultHashType,
-		kbfshash.MaxDefaultHash[:])
+	maxBlockID, err := kbfshash.HashFromRaw(
+		kbfshash.MaxHashType, kbfshash.MaxDefaultHash[:])
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -212,7 +212,7 @@ func DefaultInitParams(ctx Context) InitParams {
 		MDServerAddr:      defaultMDServer(ctx),
 		TLFValidDuration:  tlfValidDurationDefault,
 		MetadataVersion:   defaultMetadataVersion(ctx),
-		BlockCryptVersion: kbfscrypto.EncryptionSecretbox,
+		BlockCryptVersion: kbfscrypto.EncryptionSecretboxWithKeyNonce,
 		LogFileConfig: logger.LogFileConfig{
 			MaxAge:       30 * 24 * time.Hour,
 			MaxSize:      128 * 1024 * 1024,

--- a/go/kbfs/libkbfs/journal_block_server_test.go
+++ b/go/kbfs/libkbfs/journal_block_server_test.go
@@ -99,7 +99,8 @@ func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	bCtx := kbfsblock.MakeFirstContext(
 		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 
 	// Put a block.

--- a/go/kbfs/libkbfs/journal_manager_test.go
+++ b/go/kbfs/libkbfs/journal_manager_test.go
@@ -201,7 +201,8 @@ func TestJournalManagerOverQuotaError(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -320,7 +321,8 @@ func TestJournalManagerOverDiskLimitError(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -390,7 +392,8 @@ func TestJournalManagerRestart(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -464,7 +467,8 @@ func TestJournalManagerLogOutLogIn(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -576,7 +580,7 @@ func TestJournalManagerMultiUser(t *testing.T) {
 	bCtx1 := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data1 := []byte{1, 2, 3, 4}
 	bID1, err := kbfsblock.MakePermanentID(
-		data1, kbfscrypto.EncryptionSecretbox)
+		data1, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf1, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -631,7 +635,7 @@ func TestJournalManagerMultiUser(t *testing.T) {
 	bCtx2 := kbfsblock.MakeFirstContext(id2, keybase1.BlockType_DATA)
 	data2 := []byte{1, 2, 3, 4, 5}
 	bID2, err := kbfsblock.MakePermanentID(
-		data2, kbfscrypto.EncryptionSecretbox)
+		data2, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf2, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -744,7 +748,8 @@ func TestJournalManagerEnableAuto(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -865,7 +870,8 @@ func TestJournalManagerNukeEmptyJournalsOnRestart(t *testing.T) {
 	// Access a TLF, which should create a journal automatically.
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -935,7 +941,8 @@ func TestJournalManagerTeamTLFWithRestart(t *testing.T) {
 	bCtx := kbfsblock.MakeFirstContext(
 		id.AsUserOrTeam(), keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	bID, err := kbfsblock.MakePermanentID(
+		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -163,7 +163,7 @@ func (c testTLFJournalConfig) BGFlushDirOpBatchSize() int {
 
 func (c testTLFJournalConfig) makeBlock(data []byte) (
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
-	id, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
+	id, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
 	require.NoError(c.t, err)
 	bCtx := kbfsblock.MakeFirstContext(
 		c.uid.AsUserOrTeam(), keybase1.BlockType_DATA)


### PR DESCRIPTION
And use in all tests.

Note that older clients won't be able to evict new v2 blocks from the disk block cache, or delete them via mark-and-sweep, because the old max block hash was still based on v1-hashes.

Issue: KBFS-3461