### PR TITLE
Do not fail entire signup if gpg fails

### DIFF
--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -116,8 +116,13 @@ func (s *SignupEngine) Run(m libkb.MetaContext) (err error) {
 		}
 	}
 
-	if err = s.doGPG(m); err != nil {
-		return err
+	if err := s.doGPG(m); err != nil {
+		// We don't care if GPG import fails, continue with the signup process
+		// because it's too late anyway. Failing here would leave a signed up
+		// and logged in user in a weird state where their GUI does not know
+		// they are logged in, and also other processes (CreateWallet) will not
+		// run.
+		m.Warning("Importing existing GPG keys failed with: %s", err)
 	}
 
 	m = m.CommitProvisionalLogin()

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -122,7 +122,7 @@ func (s *SignupEngine) Run(m libkb.MetaContext) (err error) {
 		// and logged in user in a weird state where their GUI does not know
 		// they are logged in, and also other processes (CreateWallet) will not
 		// run.
-		m.Warning("Importing existing GPG keys failed with: %s", err)
+		m.Warning("Attempt at importing PGP keys from GPG failed with: %s", err)
 	}
 
 	m = m.CommitProvisionalLogin()


### PR DESCRIPTION
We should not fail entire signup engine if GPG importing fails, because it's too late when this happens. Failing there leaves GUI in bad state where user is logged in but GUI doesn't know, and also some other stuff like `CreateWalletSoft` does not get a chance to run (but that's ok - it'd run again in future).

This bug was unfortunate because it affected both GUI and CLI, where GUI does not care about GPG importing at all - it attaches an UI which will always respond "no" to `WantToAddGPGKey` prompt. But this error happens before this prompt is even reached, failing signup process that has already succeeded.