### PR TITLE
all callers of API#Get() switched over to libkb.MetaContext

### DIFF
--- a/go/auth/user_keys_api.go
+++ b/go/auth/user_keys_api.go
@@ -68,13 +68,12 @@ func (u *userKeyAPI) GetUser(ctx context.Context, uid keybase1.UID) (
 		u.log.Debug("- GetUser -> %v", err)
 	}()
 	var ukr userKeyRes
-	err = u.api.GetDecode(libkb.APIArg{
+	err = u.api.GetDecodeCtx(ctx, libkb.APIArg{
 		Endpoint: "user/keys",
 		Args: libkb.HTTPArgs{
 			"uid":          libkb.S{Val: uid.String()},
 			"load_deleted": libkb.B{Val: true},
 		},
-		NetContext: ctx,
 	}, &ukr)
 	if err != nil {
 		return "", nil, nil, false, err
@@ -97,10 +96,9 @@ func (u *userKeyAPI) PollForChanges(ctx context.Context) (uids []keybase1.UID, e
 		"instance_id":     libkb.S{Val: u.instanceID},
 		"wait_for_msec":   libkb.I{Val: int(pollWait / time.Millisecond)},
 	}
-	err = u.api.GetDecode(libkb.APIArg{
-		Endpoint:   "pubsub/poll",
-		Args:       args,
-		NetContext: ctx,
+	err = u.api.GetDecodeCtx(ctx, libkb.APIArg{
+		Endpoint: "pubsub/poll",
+		Args:     args,
 	}, &psb)
 
 	// If there was an error (say if the API server was down), then don't busy

--- a/go/avatars/simple.go
+++ b/go/avatars/simple.go
@@ -38,7 +38,7 @@ func (s *SimpleSource) formatArg(formats []keybase1.AvatarFormat) string {
 
 func (s *SimpleSource) apiReq(m libkb.MetaContext, endpoint, param string, names []string,
 	formats []keybase1.AvatarFormat) (apiAvatarRes, error) {
-	arg := libkb.NewAPIArgWithMetaContext(m, endpoint)
+	arg := libkb.NewAPIArg(endpoint)
 	arg.Args = libkb.NewHTTPArgs()
 	arg.SessionType = libkb.APISessionTypeOPTIONAL
 	uarg := strings.Join(names, ",")
@@ -47,7 +47,7 @@ func (s *SimpleSource) apiReq(m libkb.MetaContext, endpoint, param string, names
 	arg.Args.Add("formats", libkb.S{Val: farg})
 	s.debug(m, "issuing %s avatar req: uarg: %s farg: %s", param, uarg, farg)
 	var apiRes apiAvatarRes
-	if err := m.G().API.GetDecode(arg, &apiRes); err != nil {
+	if err := m.G().API.GetDecode(m, arg, &apiRes); err != nil {
 		s.debug(m, "apiReq: API fail: %s", err)
 		return apiRes, err
 	}

--- a/go/avatars/urlcaching_test.go
+++ b/go/avatars/urlcaching_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type apiHandlerFn func(libkb.APIArg, libkb.APIResponseWrapper) error
+type apiHandlerFn func(libkb.MetaContext, libkb.APIArg, libkb.APIResponseWrapper) error
 type avatarMockAPI struct {
 	libkb.API
 	handler apiHandlerFn
 }
 
-func (a *avatarMockAPI) GetDecode(arg libkb.APIArg, res libkb.APIResponseWrapper) error {
-	return a.handler(arg, res)
+func (a *avatarMockAPI) GetDecode(mctx libkb.MetaContext, arg libkb.APIArg, res libkb.APIResponseWrapper) error {
+	return a.handler(mctx, arg, res)
 }
 
 func newAvatarMockAPI(f apiHandlerFn) *avatarMockAPI {
@@ -25,7 +25,7 @@ func newAvatarMockAPI(f apiHandlerFn) *avatarMockAPI {
 }
 
 func makeHandler(url string, cb chan struct{}) apiHandlerFn {
-	return func(arg libkb.APIArg, res libkb.APIResponseWrapper) error {
+	return func(mctx libkb.MetaContext, arg libkb.APIArg, res libkb.APIResponseWrapper) error {
 		m := make(map[keybase1.AvatarFormat]keybase1.AvatarUrl)
 		m["square"] = keybase1.MakeAvatarURL(url)
 		res.(*apiAvatarRes).Pictures = []map[keybase1.AvatarFormat]keybase1.AvatarUrl{m}

--- a/go/chat/identify_ui.go
+++ b/go/chat/identify_ui.go
@@ -1,15 +1,17 @@
 package chat
 
 import (
-"github.com/keybase/client/go/libkb"
-"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type chatNullIdentifyUI struct{}
 
 var _ libkb.IdentifyUI = chatNullIdentifyUI{}
 
-func (c chatNullIdentifyUI) Start(libkb.MetaContext, string, keybase1.IdentifyReason, bool) error { return nil }
+func (c chatNullIdentifyUI) Start(libkb.MetaContext, string, keybase1.IdentifyReason, bool) error {
+	return nil
+}
 func (c chatNullIdentifyUI) FinishWebProofCheck(libkb.MetaContext, keybase1.RemoteProof, keybase1.LinkCheckResult) error {
 	return nil
 }
@@ -19,17 +21,27 @@ func (c chatNullIdentifyUI) FinishSocialProofCheck(libkb.MetaContext, keybase1.R
 func (c chatNullIdentifyUI) Confirm(libkb.MetaContext, *keybase1.IdentifyOutcome) (keybase1.ConfirmResult, error) {
 	return keybase1.ConfirmResult{}, nil
 }
-func (c chatNullIdentifyUI) DisplayCryptocurrency(libkb.MetaContext, keybase1.Cryptocurrency) error          { return nil }
-func (c chatNullIdentifyUI) DisplayStellarAccount(libkb.MetaContext, keybase1.StellarAccount) error          { return nil }
-func (c chatNullIdentifyUI) DisplayKey(libkb.MetaContext, keybase1.IdentifyKey) error                        { return nil }
-func (c chatNullIdentifyUI) ReportLastTrack(libkb.MetaContext, *keybase1.TrackSummary) error                 { return nil }
-func (c chatNullIdentifyUI) LaunchNetworkChecks(libkb.MetaContext, *keybase1.Identity, *keybase1.User) error { return nil }
-func (c chatNullIdentifyUI) DisplayTrackStatement(libkb.MetaContext, string) error                           { return nil }
-func (c chatNullIdentifyUI) DisplayUserCard(libkb.MetaContext, keybase1.UserCard) error                      { return nil }
-func (c chatNullIdentifyUI) ReportTrackToken(libkb.MetaContext, keybase1.TrackToken) error                   { return nil }
-func (c chatNullIdentifyUI) Cancel(libkb.MetaContext) error                                                { return nil }
-func (c chatNullIdentifyUI) Finish(libkb.MetaContext) error                                                { return nil }
+func (c chatNullIdentifyUI) DisplayCryptocurrency(libkb.MetaContext, keybase1.Cryptocurrency) error {
+	return nil
+}
+func (c chatNullIdentifyUI) DisplayStellarAccount(libkb.MetaContext, keybase1.StellarAccount) error {
+	return nil
+}
+func (c chatNullIdentifyUI) DisplayKey(libkb.MetaContext, keybase1.IdentifyKey) error { return nil }
+func (c chatNullIdentifyUI) ReportLastTrack(libkb.MetaContext, *keybase1.TrackSummary) error {
+	return nil
+}
+func (c chatNullIdentifyUI) LaunchNetworkChecks(libkb.MetaContext, *keybase1.Identity, *keybase1.User) error {
+	return nil
+}
+func (c chatNullIdentifyUI) DisplayTrackStatement(libkb.MetaContext, string) error         { return nil }
+func (c chatNullIdentifyUI) DisplayUserCard(libkb.MetaContext, keybase1.UserCard) error    { return nil }
+func (c chatNullIdentifyUI) ReportTrackToken(libkb.MetaContext, keybase1.TrackToken) error { return nil }
+func (c chatNullIdentifyUI) Cancel(libkb.MetaContext) error                                { return nil }
+func (c chatNullIdentifyUI) Finish(libkb.MetaContext) error                                { return nil }
 func (c chatNullIdentifyUI) DisplayTLFCreateWithInvite(libkb.MetaContext, keybase1.DisplayTLFCreateWithInviteArg) error {
 	return nil
 }
-func (c chatNullIdentifyUI) Dismiss(libkb.MetaContext, string, keybase1.DismissReason) error { return nil }
+func (c chatNullIdentifyUI) Dismiss(libkb.MetaContext, string, keybase1.DismissReason) error {
+	return nil
+}

--- a/go/client/cmd_id.go
+++ b/go/client/cmd_id.go
@@ -142,7 +142,7 @@ func (ui *idCmdIdentifyUI) Cancel(_ libkb.MetaContext) error {
 	return nil
 }
 
-func (ui *idCmdIdentifyUI) Finish(_ libkb.MetaContext, ) error {
+func (ui *idCmdIdentifyUI) Finish(_ libkb.MetaContext) error {
 	b, err := json.MarshalIndent(ui, "", "    ")
 	if err != nil {
 		return err

--- a/go/client/cmd_ping.go
+++ b/go/client/cmd_ping.go
@@ -29,11 +29,13 @@ func (v *CmdPing) Run() error {
 		return PingGregor(v.G())
 	}
 
+	mctx := libkb.NewMetaContextBackground(v.G())
+
 	_, err := v.G().API.Post(libkb.APIArg{Endpoint: "ping"})
 	if err != nil {
 		return err
 	}
-	_, err = v.G().API.Get(libkb.APIArg{Endpoint: "ping"})
+	_, err = v.G().API.Get(mctx, libkb.APIArg{Endpoint: "ping"})
 	if err != nil {
 		return err
 	}

--- a/go/client/identify_ui.go
+++ b/go/client/identify_ui.go
@@ -17,16 +17,16 @@ type IdentifyUIServer struct {
 
 func NewIdentifyUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
 	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{
-		Contextified : libkb.NewContextified(g),
-		ui : g.UI.GetIdentifyUI(),
+		Contextified: libkb.NewContextified(g),
+		ui:           g.UI.GetIdentifyUI(),
 	})
 }
 
 func NewIdentifyTrackUIProtocol(g *libkb.GlobalContext) rpc.Protocol {
 	ui := g.UI.GetIdentifyTrackUI()
 	return keybase1.IdentifyUiProtocol(&IdentifyUIServer{
-		Contextified : libkb.NewContextified(g),
-		ui : ui,
+		Contextified: libkb.NewContextified(g),
+		ui:           ui,
 	})
 }
 

--- a/go/emails/user.go
+++ b/go/emails/user.go
@@ -96,7 +96,7 @@ func SetVisibilityAllEmail(mctx libkb.MetaContext, visibility keybase1.IdentityV
 }
 
 func GetEmails(mctx libkb.MetaContext) ([]keybase1.Email, error) {
-	return libkb.LoadUserEmails(mctx.G())
+	return libkb.LoadUserEmails(mctx)
 }
 
 type emailLookupAPIResult struct {

--- a/go/engine/common.go
+++ b/go/engine/common.go
@@ -150,7 +150,7 @@ func fetchLKS(m libkb.MetaContext, encKey libkb.GenericKey) (libkb.PassphraseGen
 		},
 		MetaContext: m,
 	}
-	res, err := m.G().API.Get(arg)
+	res, err := m.G().API.Get(m, arg)
 	var dummy libkb.LKSecClientHalf
 	if err != nil {
 		return 0, dummy, err

--- a/go/engine/common_test.go
+++ b/go/engine/common_test.go
@@ -443,7 +443,8 @@ func ForcePUK(tc libkb.TestContext) {
 }
 
 func getUserSeqno(tc *libkb.TestContext, uid keybase1.UID) keybase1.Seqno {
-	res, err := tc.G.API.Get(libkb.APIArg{
+	mctx := NewMetaContextForTest(*tc)
+	res, err := tc.G.API.Get(mctx, libkb.APIArg{
 		Endpoint: "user/lookup",
 		Args: libkb.HTTPArgs{
 			"uid": libkb.UIDArg(uid),

--- a/go/engine/email_change_test.go
+++ b/go/engine/email_change_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func assertEmail(t *testing.T, g *libkb.GlobalContext, expected string) {
-	res, err := g.API.Get(libkb.APIArg{
+func assertEmail(mctx libkb.MetaContext, t *testing.T, expected string) {
+	res, err := mctx.G().API.Get(mctx, libkb.APIArg{
 		Endpoint:    "me",
 		SessionType: libkb.APISessionTypeREQUIRED,
 	})
@@ -29,7 +29,8 @@ func TestSignedEmailChange(t *testing.T) {
 
 	u := CreateAndSignupFakeUser(tc, "email")
 
-	assertEmail(t, tc.G, u.Email)
+	m := NewMetaContextForTest(tc)
+	assertEmail(m, t, u.Email)
 
 	newEmail := "new-" + u.Email
 	arg := &keybase1.EmailChangeArg{
@@ -40,10 +41,10 @@ func TestSignedEmailChange(t *testing.T) {
 	uis := libkb.UIs{
 		SecretUI: &libkb.TestSecretUI{},
 	}
-	m := NewMetaContextForTest(tc).WithUIs(uis)
+	m = m.WithUIs(uis)
 	eng := NewEmailChange(tc.G, arg)
 	if err := RunEngine2(m, eng); err != nil {
 		t.Fatal(err)
 	}
-	assertEmail(t, tc.G, newEmail)
+	assertEmail(m, t, newEmail)
 }

--- a/go/engine/favorite_list.go
+++ b/go/engine/favorite_list.go
@@ -76,8 +76,7 @@ func (e *FavoriteList) cacheFolders(m libkb.MetaContext, folders []keybase1.Fold
 func (e *FavoriteList) Run(m libkb.MetaContext) error {
 	arg := libkb.NewRetryAPIArg("kbfs/favorite/list")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
-	arg.NetContext = m.Ctx()
-	err := m.G().API.GetDecode(arg, &e.result)
+	err := m.G().API.GetDecode(m, arg, &e.result)
 	if err != nil {
 		return err
 	}

--- a/go/engine/hasserverkeys.go
+++ b/go/engine/hasserverkeys.go
@@ -45,11 +45,10 @@ func (e *HasServerKeys) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *HasServerKeys) Run(m libkb.MetaContext) error {
-	apiRes, err := m.G().API.Get(libkb.APIArg{
+	apiRes, err := m.G().API.Get(m, libkb.APIArg{
 		Endpoint:    "key/fetch_private",
 		Args:        libkb.HTTPArgs{},
 		SessionType: libkb.APISessionTypeREQUIRED,
-		NetContext:  m.Ctx(),
 	})
 	if err != nil {
 		return err

--- a/go/engine/login_oneshot.go
+++ b/go/engine/login_oneshot.go
@@ -77,7 +77,7 @@ func (e *LoginOneshot) checkLogin(m libkb.MetaContext) (err error) {
 	defer m.Trace("LoginOneshot#checkLogin", func() error { return err })()
 	arg := libkb.NewRetryAPIArg("sesscheck")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
-	_, err = m.G().API.Get(arg)
+	_, err = m.G().API.Get(m, arg)
 	return err
 }
 

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -142,7 +142,7 @@ func TestUserEmails(t *testing.T) {
 	defer tc.Cleanup()
 
 	CreateAndSignupFakeUser(tc, "login")
-	emails, err := libkb.LoadUserEmails(tc.G)
+	emails, err := libkb.LoadUserEmails(NewMetaContextForTest(tc))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/engine/merkle_audit_test.go
+++ b/go/engine/merkle_audit_test.go
@@ -80,23 +80,23 @@ func newRetryMerkleAuditMock(tc libkb.TestContext) *retryMerkleAuditMock {
 	}
 }
 
-func (r *retryMerkleAuditMock) GetDecode(arg libkb.APIArg, w libkb.APIResponseWrapper) error {
+func (r *retryMerkleAuditMock) GetDecode(mctx libkb.MetaContext, arg libkb.APIArg, w libkb.APIResponseWrapper) error {
 	r.args = append(r.args, arg)
 	if r.getError != nil {
 		return nil
 	}
 
-	return r.api.GetDecode(arg, w)
+	return r.api.GetDecode(mctx, arg, w)
 }
 
-func (r *retryMerkleAuditMock) Get(arg libkb.APIArg) (*libkb.APIRes, error) {
+func (r *retryMerkleAuditMock) Get(mctx libkb.MetaContext, arg libkb.APIArg) (*libkb.APIRes, error) {
 	r.args = append(r.args, arg)
 	if r.getError != nil {
 		r.resps = append(r.resps, nil)
 		return nil, r.getError
 	}
 
-	res, err := r.api.Get(arg)
+	res, err := r.api.Get(mctx, arg)
 	r.resps = append(r.resps, res)
 	if err != nil {
 		return nil, err

--- a/go/engine/prove_help_test.go
+++ b/go/engine/prove_help_test.go
@@ -257,9 +257,10 @@ func proveGubbleUniverse(tc libkb.TestContext, serviceName, endpoint string, fu 
 	eng := NewProve(g, &arg)
 
 	// Post the proof to the gubble network and verify the sig hash
-	outputInstructionsHook := func(_ context.Context, _ keybase1.OutputInstructionsArg) error {
+	outputInstructionsHook := func(ctx context.Context, _ keybase1.OutputInstructionsArg) error {
 		sigID := eng.sigID
 		require.False(tc.T, sigID.IsNil())
+		mctx := libkb.NewMetaContext(ctx, g)
 
 		apiArg := libkb.APIArg{
 			Endpoint:    fmt.Sprintf("gubble_universe/%s", endpoint),
@@ -279,8 +280,7 @@ func proveGubbleUniverse(tc libkb.TestContext, serviceName, endpoint string, fu 
 			Endpoint:    fmt.Sprintf("gubble_universe/%s/%s/proofs", endpoint, fu.Username),
 			SessionType: libkb.APISessionTypeNONE,
 		}
-
-		res, err := g.GetAPI().Get(apiArg)
+		res, err := g.GetAPI().Get(mctx, apiArg)
 		require.NoError(tc.T, err)
 		objects, err := jsonhelpers.AtSelectorPath(res.Body, []keybase1.SelectorEntry{
 			keybase1.SelectorEntry{

--- a/go/engine/saltpack_sender_identify.go
+++ b/go/engine/saltpack_sender_identify.go
@@ -70,7 +70,7 @@ func (e *SaltpackSenderIdentify) Run(m libkb.MetaContext) (err error) {
 	// would audit it for consistency with the main body of the tree. File this
 	// one away in the Book of Things We Would Do With Infinite Time and Money.
 	var maybeUID keybase1.UID
-	_, maybeUID, err = libkb.KeyLookupKIDIncludingRevoked(e.G(), e.arg.publicKey)
+	_, maybeUID, err = libkb.KeyLookupKIDIncludingRevoked(m, e.arg.publicKey)
 	if _, ok := err.(libkb.NotFoundError); ok {
 		// The key in question might not be a Keybase key at all (for example,
 		// anything generated with the Python saltpack implementation, which

--- a/go/engine/scankeys.go
+++ b/go/engine/scankeys.go
@@ -256,7 +256,7 @@ func (s *ScanKeys) scan(m libkb.MetaContext, id uint64) (openpgp.EntityList, err
 // apiLookup gets the username and uid from the api server for the
 // key id.
 func (s *ScanKeys) apiLookup(m libkb.MetaContext, id uint64) (username string, uid keybase1.UID, err error) {
-	return libkb.PGPLookup(m.G(), id)
+	return libkb.PGPLookup(m, id)
 }
 
 func (s *ScanKeys) publicByID(m libkb.MetaContext, id uint64) openpgp.EntityList {

--- a/go/engine/user_card.go
+++ b/go/engine/user_card.go
@@ -51,12 +51,11 @@ func getUserCard(m libkb.MetaContext, uid keybase1.UID, useSession bool) (ret *k
 		Endpoint:    "user/card",
 		SessionType: sessionType,
 		Args:        libkb.HTTPArgs{"uid": libkb.S{Val: uid.String()}},
-		NetContext:  m.Ctx(),
 	}
 
 	var card card
 
-	if err = m.G().API.GetDecode(arg, &card); err != nil {
+	if err = m.G().API.GetDecode(m, arg, &card); err != nil {
 		m.Warning("error getting user/card for %s: %s\n", uid, err)
 		return nil, err
 	}

--- a/go/ephemeral/device_ek.go
+++ b/go/ephemeral/device_ek.go
@@ -164,15 +164,15 @@ type deviceEKStatementResponse struct {
 }
 
 func allDeviceEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata map[keybase1.DeviceID]keybase1.DeviceEkMetadata, err error) {
-	defer g.CTraceTimed(ctx, "allDeviceEKMetadataMaybeStale", func() error { return err })()
+	mctx := libkb.NewMetaContext(ctx, g)
+	defer mctx.TraceTimed("allDeviceEKMetadataMaybeStale", func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "user/device_eks",
 		SessionType: libkb.APISessionTypeREQUIRED,
-		NetContext:  ctx,
 		Args:        libkb.HTTPArgs{},
 	}
-	res, err := g.GetAPI().Get(apiArg)
+	res, err := mctx.G().GetAPI().Get(mctx, apiArg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -252,17 +252,17 @@ type teamEKStatementResponse struct {
 // in the wild have EK support, we will make that case an error.
 func fetchTeamEKStatement(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (
 	statement *keybase1.TeamEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
-	defer g.CTraceTimed(ctx, "fetchTeamEKStatement", func() error { return err })()
+	mctx := libkb.NewMetaContext(ctx, g)
+	defer mctx.TraceTimed("fetchTeamEKStatement", func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "team/team_ek",
 		SessionType: libkb.APISessionTypeREQUIRED,
-		NetContext:  ctx,
 		Args: libkb.HTTPArgs{
 			"team_id": libkb.S{Val: string(teamID)},
 		},
 	}
-	res, err := g.GetAPI().Get(apiArg)
+	res, err := mctx.G().GetAPI().Get(mctx, apiArg)
 	if err != nil {
 		return nil, latestGeneration, false, err
 	}
@@ -375,15 +375,15 @@ func fetchTeamMemberStatements(ctx context.Context, g *libkb.GlobalContext,
 	teamID keybase1.TeamID) (statementMap map[keybase1.UID]*keybase1.UserEkStatement, err error) {
 	defer g.CTraceTimed(ctx, "fetchTeamMemberStatements", func() error { return err })()
 
+	mctx := libkb.NewMetaContext(ctx, g)
 	apiArg := libkb.APIArg{
 		Endpoint:    "team/member_eks",
 		SessionType: libkb.APISessionTypeREQUIRED,
-		NetContext:  ctx,
 		Args: libkb.HTTPArgs{
 			"team_id": libkb.S{Val: string(teamID)},
 		},
 	}
-	res, err := g.GetAPI().Get(apiArg)
+	res, err := mctx.G().GetAPI().Get(mctx, apiArg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -140,12 +140,12 @@ type TeamEKBoxedResponse struct {
 
 func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration,
 	contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#fetchAndStore: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
+	mctx := libkb.NewMetaContext(ctx, s.G())
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#fetchAndStore: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "team/team_ek_box",
 		SessionType: libkb.APISessionTypeREQUIRED,
-		NetContext:  ctx,
 		Args: libkb.HTTPArgs{
 			"team_id":    libkb.S{Val: string(teamID)},
 			"generation": libkb.U{Val: uint64(generation)},
@@ -153,7 +153,7 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 	}
 
 	var result TeamEKBoxedResponse
-	res, err := s.G().GetAPI().Get(apiArg)
+	res, err := mctx.G().GetAPI().Get(mctx, apiArg)
 	if err != nil {
 		err = errFromAppStatus(err)
 		return teamEK, err

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -261,17 +261,18 @@ func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []k
 // new userEK.
 func fetchUserEKStatement(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (
 	statement *keybase1.UserEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
-	defer g.CTraceTimed(ctx, "fetchUserEKStatement", func() error { return err })()
+
+	mctx := libkb.NewMetaContext(ctx, g)
+	defer mctx.TraceTimed("fetchUserEKStatement", func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "user/user_ek",
 		SessionType: libkb.APISessionTypeREQUIRED,
-		NetContext:  ctx,
 		Args: libkb.HTTPArgs{
 			"uids": libkb.S{Val: libkb.UidsToString([]keybase1.UID{uid})},
 		},
 	}
-	res, err := g.GetAPI().Get(apiArg)
+	res, err := mctx.G().GetAPI().Get(mctx, apiArg)
 	if err != nil {
 		return nil, latestGeneration, false, err
 	}

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -130,12 +130,13 @@ type UserEKBoxedResponse struct {
 }
 
 func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase1.EkGeneration) (userEK keybase1.UserEk, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("UserEKBoxStorage#fetchAndStore: generation: %v", generation), func() error { return err })()
+
+	mctx := libkb.NewMetaContext(ctx, s.G())
+	defer mctx.TraceTimed(fmt.Sprintf("UserEKBoxStorage#fetchAndStore: generation: %v", generation), func() error { return err })()
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "user/user_ek_box",
 		SessionType: libkb.APISessionTypeREQUIRED,
-		NetContext:  ctx,
 		Args: libkb.HTTPArgs{
 			"generation":          libkb.U{Val: uint64(generation)},
 			"recipient_device_id": libkb.S{Val: string(s.G().Env.GetDeviceID())},
@@ -143,7 +144,7 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 	}
 
 	var result UserEKBoxedResponse
-	res, err := s.G().GetAPI().Get(apiArg)
+	res, err := mctx.G().GetAPI().Get(mctx, apiArg)
 	if err != nil {
 		err = errFromAppStatus(err)
 		return userEK, err

--- a/go/externals/proof_service_web.go
+++ b/go/externals/proof_service_web.go
@@ -95,13 +95,12 @@ func (t *WebServiceType) NormalizeRemoteName(mctx libkb.MetaContext, s string) (
 		return
 	}
 	var res *libkb.APIRes
-	res, err = mctx.G().GetAPI().Get(libkb.APIArg{
+	res, err = mctx.G().GetAPI().Get(mctx, libkb.APIArg{
 		Endpoint:    "remotes/check",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		Args: libkb.HTTPArgs{
 			"hostname": libkb.S{Val: host},
 		},
-		MetaContext: mctx,
 	})
 	if err != nil {
 		return

--- a/go/git/get.go
+++ b/go/git/get.go
@@ -104,12 +104,12 @@ func folderFromTeamIDImplicit(ctx context.Context, g *libkb.GlobalContext, teamI
 
 // If folder is nil, get for all folders.
 func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keybase1.Folder) ([]keybase1.GitRepoResult, error) {
+	mctx := libkb.NewMetaContext(ctx, g)
 	teamer := NewTeamer(g)
 
 	apiArg := libkb.APIArg{
 		Endpoint:    "kbfs/git/team/get",
 		SessionType: libkb.APISessionTypeREQUIRED,
-		NetContext:  ctx,
 		Args:        libkb.HTTPArgs{}, // a limit parameter exists, default 100, and we don't currently set it
 	}
 
@@ -122,7 +122,7 @@ func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keyba
 		apiArg.Args["team_id"] = libkb.S{Val: string(teamIDVis.TeamID)}
 	}
 	var serverResponse ServerResponse
-	err := g.GetAPI().GetDecode(apiArg, &serverResponse)
+	err := mctx.G().GetAPI().GetDecode(mctx, apiArg, &serverResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func getMetadataInner(ctx context.Context, g *libkb.GlobalContext, folder *keyba
 			if firstErr == nil {
 				firstErr = err
 			}
-			g.Log.CDebugf(ctx, "git.getMetadataInner error (team:%v, repo:%v): %v", responseRepo.TeamID, responseRepo.RepoID, err)
+			mctx.Debug("git.getMetadataInner error (team:%v, repo:%v): %v", responseRepo.TeamID, responseRepo.RepoID, err)
 			resultList = append(resultList, keybase1.NewGitRepoResultWithErr(err.Error()))
 		} else {
 			if !skip {

--- a/go/git/settings.go
+++ b/go/git/settings.go
@@ -21,6 +21,7 @@ func (r *settingsResponse) GetAppStatus() *libkb.AppStatus {
 }
 
 func GetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybase1.GetTeamRepoSettingsArg) (keybase1.GitTeamRepoSettings, error) {
+	mctx := libkb.NewMetaContext(ctx, g)
 	if arg.Folder.FolderType != keybase1.FolderType_TEAM {
 		return keybase1.GitTeamRepoSettings{ChatDisabled: true}, nil
 	}
@@ -31,7 +32,7 @@ func GetTeamRepoSettings(ctx context.Context, g *libkb.GlobalContext, arg keybas
 	}
 
 	var resp settingsResponse
-	if err := g.GetAPI().GetDecode(*apiArg, &resp); err != nil {
+	if err := g.GetAPI().GetDecode(mctx, *apiArg, &resp); err != nil {
 		return keybase1.GitTeamRepoSettings{}, err
 	}
 

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -409,7 +409,7 @@ func GetPhoneVerificationCode(mctx libkb.MetaContext, phoneNumber keybase1.Phone
 		},
 	}
 	var resp getCodeResponse
-	err = mctx.G().API.GetDecode(arg, &resp)
+	err = mctx.G().API.GetDecode(mctx, arg, &resp)
 	if err != nil {
 		return "", err
 	}

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -695,7 +695,8 @@ func appStatusToTypedError(ast *AppStatus) error {
 	}
 }
 
-func (a *InternalAPIEngine) Get(arg APIArg) (*APIRes, error) {
+func (a *InternalAPIEngine) Get(m MetaContext, arg APIArg) (*APIRes, error) {
+	arg.MetaContext = m
 	url1 := a.getURL(arg)
 	req, err := a.PrepareGet(url1, arg)
 	if err != nil {
@@ -706,8 +707,8 @@ func (a *InternalAPIEngine) Get(arg APIArg) (*APIRes, error) {
 
 // GetResp performs a GET request and returns the http response. The finisher
 // second arg should be called whenever we're done with the response (if it's non-nil).
-func (a *InternalAPIEngine) GetResp(arg APIArg) (*http.Response, func(), error) {
-	m := arg.GetMetaContext(a.G())
+func (a *InternalAPIEngine) GetResp(m MetaContext, arg APIArg) (*http.Response, func(), error) {
+	arg.MetaContext = m
 	m = m.EnsureCtx().WithLogTag("API")
 
 	url1 := a.getURL(arg)
@@ -726,15 +727,20 @@ func (a *InternalAPIEngine) GetResp(arg APIArg) (*http.Response, func(), error) 
 
 // GetDecode performs a GET request and decodes the response via
 // JSON into the value pointed to by v.
-func (a *InternalAPIEngine) GetDecode(arg APIArg, v APIResponseWrapper) error {
-	m := arg.GetMetaContext(a.G())
+func (a *InternalAPIEngine) GetDecode(m MetaContext, arg APIArg, v APIResponseWrapper) error {
+	arg.MetaContext = m
 	m = m.EnsureCtx().WithLogTag("API")
 	return a.getDecode(m, arg, v)
 }
 
+func (a *InternalAPIEngine) GetDecodeCtx(ctx context.Context, arg APIArg, v APIResponseWrapper) error {
+	mctx := NewMetaContext(ctx, a.G())
+	return a.GetDecode(mctx, arg, v)
+}
+
 func (a *InternalAPIEngine) getDecode(m MetaContext, arg APIArg, v APIResponseWrapper) error {
 	arg.MetaContext = m
-	resp, finisher, err := a.GetResp(arg)
+	resp, finisher, err := a.GetResp(m, arg)
 	if err != nil {
 		m.Debug("| API GetDecode, GetResp error: %s", err)
 		return err

--- a/go/libkb/api_mock.go
+++ b/go/libkb/api_mock.go
@@ -4,6 +4,7 @@
 package libkb
 
 import (
+	"golang.org/x/net/context"
 	"io"
 	"net/http"
 )
@@ -12,9 +13,12 @@ type NullMockAPI struct{}
 
 var _ API = (*NullMockAPI)(nil)
 
-func (n *NullMockAPI) Get(APIArg) (*APIRes, error)                        { return nil, nil }
-func (n *NullMockAPI) GetResp(APIArg) (*http.Response, func(), error)     { return nil, noopFinisher, nil }
-func (n *NullMockAPI) GetDecode(APIArg, APIResponseWrapper) error         { return nil }
+func (n *NullMockAPI) Get(MetaContext, APIArg) (*APIRes, error)                       { return nil, nil }
+func (n *NullMockAPI) GetDecode(MetaContext, APIArg, APIResponseWrapper) error        { return nil }
+func (n *NullMockAPI) GetDecodeCtx(context.Context, APIArg, APIResponseWrapper) error { return nil }
+func (n *NullMockAPI) GetResp(MetaContext, APIArg) (*http.Response, func(), error) {
+	return nil, noopFinisher, nil
+}
 func (n *NullMockAPI) Post(APIArg) (*APIRes, error)                       { return nil, nil }
 func (n *NullMockAPI) PostJSON(APIArg) (*APIRes, error)                   { return nil, nil }
 func (n *NullMockAPI) PostDecode(APIArg, APIResponseWrapper) error        { return nil }

--- a/go/libkb/api_test.go
+++ b/go/libkb/api_test.go
@@ -37,6 +37,7 @@ const (
 func TestProductionCA(t *testing.T) {
 	tc := SetupTest(t, "prod_ca", 1)
 	defer tc.Cleanup()
+	mctx := NewMetaContextForTest(tc)
 
 	t.Log("WARNING: setting run mode to production, be careful:")
 	tc.G.Env.Test.UseProductionRunMode = true
@@ -63,7 +64,7 @@ func TestProductionCA(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = tc.G.API.Get(arg)
+	_, err = tc.G.API.Get(mctx, arg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,6 +73,7 @@ func TestProductionCA(t *testing.T) {
 func TestProductionBadCA(t *testing.T) {
 	tc := SetupTest(t, "prod_ca", 1)
 	defer tc.Cleanup()
+	mctx := NewMetaContextForTest(tc)
 
 	t.Log("WARNING: setting run mode to production, be careful:")
 	tc.G.Env.Test.UseProductionRunMode = true
@@ -106,7 +108,7 @@ func TestProductionBadCA(t *testing.T) {
 		checkX509Err(t, err)
 	}
 
-	_, err = tc.G.API.Get(arg)
+	_, err = tc.G.API.Get(mctx, arg)
 	if err == nil {
 		t.Errorf("api ping GET worked with unknown CA")
 	} else {
@@ -193,6 +195,7 @@ func (r *DummyUpdaterConfigReader) GetInstallID() InstallID {
 func TestInstallIDHeaders(t *testing.T) {
 	tc := SetupTest(t, "test", 1)
 	defer tc.Cleanup()
+	mctx := NewMetaContextForTest(tc)
 
 	// Hack in the device ID and install ID with dummy readers.
 	tc.G.Env.config = &DummyConfigReader{}
@@ -202,7 +205,7 @@ func TestInstallIDHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := api.Get(APIArg{
+	res, err := api.Get(mctx, APIArg{
 		Endpoint:    "pkg/show",
 		SessionType: APISessionTypeNONE,
 		Args:        HTTPArgs{},

--- a/go/libkb/device_with_keys.go
+++ b/go/libkb/device_with_keys.go
@@ -110,10 +110,9 @@ func (d *DeviceWithKeys) Populate(m MetaContext) (uid keybase1.UID, err error) {
 		Endpoint:    "key/owner/device",
 		SessionType: APISessionTypeNONE,
 		Args:        HTTPArgs{"kid": S{Val: d.signingKey.GetKID().String()}},
-		NetContext:  m.Ctx(),
 	}
 	var res ownerDeviceReply
-	if err = m.G().API.GetDecode(arg, &res); err != nil {
+	if err = m.G().API.GetDecode(m, arg, &res); err != nil {
 		return uid, err
 	}
 	d.deviceID = res.DeviceID

--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -126,12 +126,12 @@ func (s *FeatureFlagSet) EnabledWithError(m MetaContext, f Feature) (on bool, er
 		return slot.on, nil
 	}
 	var raw rawFeatures
-	arg := NewAPIArgWithMetaContext(m, "user/features")
+	arg := NewAPIArg("user/features")
 	arg.SessionType = APISessionTypeREQUIRED
 	arg.Args = HTTPArgs{
 		"features": S{Val: string(f)},
 	}
-	err = m.G().API.GetDecode(arg, &raw)
+	err = m.G().API.GetDecode(m, arg, &raw)
 	if err != nil {
 		return false, err
 	}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -283,9 +283,10 @@ type ExternalAPIRes struct {
 }
 
 type API interface {
-	Get(APIArg) (*APIRes, error)
-	GetDecode(APIArg, APIResponseWrapper) error
-	GetResp(APIArg) (*http.Response, func(), error)
+	Get(MetaContext, APIArg) (*APIRes, error)
+	GetDecode(MetaContext, APIArg, APIResponseWrapper) error
+	GetDecodeCtx(context.Context, APIArg, APIResponseWrapper) error
+	GetResp(MetaContext, APIArg) (*http.Response, func(), error)
 	Post(APIArg) (*APIRes, error)
 	PostJSON(APIArg) (*APIRes, error)
 	PostDecode(APIArg, APIResponseWrapper) error

--- a/go/libkb/kex2_router.go
+++ b/go/libkb/kex2_router.go
@@ -87,12 +87,11 @@ func (k *KexRouter) Get(sessID kex2.SessionID, receiver kex2.DeviceID, low kex2.
 			"low":      I{Val: int(low)},
 			"poll":     I{Val: int(poll / time.Millisecond)},
 		},
-		MetaContext: mctx.BackgroundWithLogTags(),
 	}
 	kexAPITimeout(&arg, 2*poll)
 	var j kexResp
 
-	if err = mctx.G().API.GetDecode(arg, &j); err != nil {
+	if err = mctx.G().API.GetDecode(mctx.BackgroundWithLogTags(), arg, &j); err != nil {
 		return nil, err
 	}
 	if j.Status.Code != SCOk {

--- a/go/libkb/key_lookup.go
+++ b/go/libkb/key_lookup.go
@@ -8,24 +8,24 @@ import (
 	"github.com/keybase/saltpack"
 )
 
-func PGPLookup(g *GlobalContext, id uint64) (username string, uid keybase1.UID, err error) {
-	return keyLookup(g, keyLookupArg{uintID: id})
+func PGPLookup(mctx MetaContext, id uint64) (username string, uid keybase1.UID, err error) {
+	return keyLookup(mctx, keyLookupArg{uintID: id})
 }
 
-func PGPLookupHex(g *GlobalContext, hexID string) (username string, uid keybase1.UID, err error) {
-	return keyLookup(g, keyLookupArg{hexID: hexID})
+func PGPLookupHex(mctx MetaContext, hexID string) (username string, uid keybase1.UID, err error) {
+	return keyLookup(mctx, keyLookupArg{hexID: hexID})
 }
 
-func PGPLookupFingerprint(g *GlobalContext, fp *PGPFingerprint) (username string, uid keybase1.UID, err error) {
-	return keyLookup(g, keyLookupArg{fp: fp})
+func PGPLookupFingerprint(mctx MetaContext, fp *PGPFingerprint) (username string, uid keybase1.UID, err error) {
+	return keyLookup(mctx, keyLookupArg{fp: fp})
 }
 
-func KeyLookupKIDIncludingRevoked(g *GlobalContext, k keybase1.KID) (username string, uid keybase1.UID, err error) {
-	return keyLookup(g, keyLookupArg{kid: k, includeRevoked: true})
+func KeyLookupKIDIncludingRevoked(mctx MetaContext, k keybase1.KID) (username string, uid keybase1.UID, err error) {
+	return keyLookup(mctx, keyLookupArg{kid: k, includeRevoked: true})
 }
 
-func KeyLookupByBoxPublicKey(g *GlobalContext, k saltpack.BoxPublicKey) (username string, uid keybase1.UID, err error) {
-	return keyLookup(g, keyLookupArg{kid: BoxPublicKeyToKeybaseKID(k)})
+func KeyLookupByBoxPublicKey(mctx MetaContext, k saltpack.BoxPublicKey) (username string, uid keybase1.UID, err error) {
+	return keyLookup(mctx, keyLookupArg{kid: BoxPublicKeyToKeybaseKID(k)})
 }
 
 type keyLookupArg struct {
@@ -46,7 +46,7 @@ func (k *keyBasicsReply) GetAppStatus() *AppStatus {
 	return &k.Status
 }
 
-func keyLookup(g *GlobalContext, arg keyLookupArg) (username string, uid keybase1.UID, err error) {
+func keyLookup(mctx MetaContext, arg keyLookupArg) (username string, uid keybase1.UID, err error) {
 	httpArgs := make(HTTPArgs)
 	httpArgs["include_revoked"] = B{Val: arg.includeRevoked}
 	switch {
@@ -70,7 +70,7 @@ func keyLookup(g *GlobalContext, arg keyLookupArg) (username string, uid keybase
 		Args:     httpArgs,
 	}
 
-	if err = g.API.GetDecode(args, &data); err != nil {
+	if err = mctx.G().API.GetDecode(mctx, args, &data); err != nil {
 		if ase, ok := err.(AppStatusError); ok && ase.Code == SCKeyNotFound {
 			err = NotFoundError{}
 		}

--- a/go/libkb/key_pseudonym.go
+++ b/go/libkb/key_pseudonym.go
@@ -206,9 +206,8 @@ func GetKeyPseudonyms(m MetaContext, pnyms []KeyPseudonym) ([]KeyPseudonymOrErro
 	}
 
 	var res getKeyPseudonymsRes
-	err := m.G().API.GetDecode(
+	err := m.G().API.GetDecode(m,
 		APIArg{
-			MetaContext: m,
 			Endpoint:    "team/key_pseudonym",
 			SessionType: APISessionTypeREQUIRED,
 			Args: HTTPArgs{

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -462,9 +462,9 @@ func LoadUserFromLocalStorage(m MetaContext, uid keybase1.UID) (u *User, err err
 }
 
 // LoadUserEmails returns emails for logged in user
-func LoadUserEmails(g *GlobalContext) (emails []keybase1.Email, err error) {
-	uid := g.GetMyUID()
-	res, err := g.API.Get(APIArg{
+func LoadUserEmails(m MetaContext) (emails []keybase1.Email, err error) {
+	uid := m.G().GetMyUID()
+	res, err := m.G().API.Get(m, APIArg{
 		Endpoint:    "user/lookup",
 		SessionType: APISessionTypeREQUIRED,
 		Args: HTTPArgs{
@@ -512,14 +512,13 @@ func LoadUserFromServer(m MetaContext, uid keybase1.UID, body *jsonw.Wrapper) (u
 
 	// Res.body might already have been preloaded as a result of a Resolve call earlier.
 	if body == nil {
-		res, err := m.G().API.Get(APIArg{
+		res, err := m.G().API.Get(m, APIArg{
 			Endpoint:    "user/lookup",
 			SessionType: APISessionTypeNONE,
 			Args: HTTPArgs{
 				"uid":          UIDArg(uid),
 				"load_deleted": B{true},
 			},
-			MetaContext: m,
 		})
 
 		if err != nil {

--- a/go/libkb/login_session.go
+++ b/go/libkb/login_session.go
@@ -154,14 +154,13 @@ func (s *LoginSession) Load(m MetaContext) error {
 		return fmt.Errorf("LoginSession already loaded for %s", s.sessionFor)
 	}
 
-	res, err := m.G().API.Get(APIArg{
+	res, err := m.G().API.Get(m, APIArg{
 		Endpoint:    "getsalt",
 		SessionType: APISessionTypeNONE,
 		Args: HTTPArgs{
 			"email_or_username": S{Val: s.sessionFor},
 			"pdpka_login":       B{Val: true},
 		},
-		MetaContext: m,
 	})
 	if err != nil {
 		return err
@@ -199,13 +198,12 @@ func (s *LoginSession) Load(m MetaContext) error {
 
 func LookupSaltForUID(m MetaContext, uid keybase1.UID) (salt []byte, err error) {
 	defer m.Trace(fmt.Sprintf("GetSaltForUID(%s)", uid), func() error { return err })()
-	res, err := m.G().API.Get(APIArg{
+	res, err := m.G().API.Get(m, APIArg{
 		Endpoint:    "getsalt",
 		SessionType: APISessionTypeNONE,
 		Args: HTTPArgs{
 			"uid": S{Val: uid.String()},
 		},
-		MetaContext: m,
 	})
 	if err != nil {
 		return nil, err

--- a/go/libkb/login_session_test.go
+++ b/go/libkb/login_session_test.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -29,7 +30,7 @@ const fakeResponse = `{
 
 type FakeAPI struct{}
 
-func (a *FakeAPI) Get(arg APIArg) (*APIRes, error) {
+func (a *FakeAPI) Get(mctx MetaContext, arg APIArg) (*APIRes, error) {
 
 	decoder := json.NewDecoder(bytes.NewBufferString(fakeResponse))
 	var obj interface{}
@@ -53,11 +54,15 @@ func (a *FakeAPI) Get(arg APIArg) (*APIRes, error) {
 
 }
 
-func (a *FakeAPI) GetDecode(arg APIArg, v APIResponseWrapper) error {
+func (a *FakeAPI) GetDecode(mctx MetaContext, arg APIArg, v APIResponseWrapper) error {
 	return fmt.Errorf("GetDecode is phony")
 }
 
-func (a *FakeAPI) GetResp(APIArg) (*http.Response, func(), error) {
+func (a *FakeAPI) GetDecodeCtx(ctx context.Context, arg APIArg, v APIResponseWrapper) error {
+	return fmt.Errorf("GetDecode is phony")
+}
+
+func (a *FakeAPI) GetResp(MetaContext, APIArg) (*http.Response, func(), error) {
 	return nil, noopFinisher, fmt.Errorf("GetResp is phony")
 }
 

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -664,12 +664,11 @@ func (mc *MerkleClient) lookupRootAndSkipSequence(m MetaContext, lastRoot *Merkl
 		q.Add("last", I{int(*lastSeqno)})
 	}
 
-	apiRes, err = m.G().API.Get(APIArg{
+	apiRes, err = m.G().API.Get(m, APIArg{
 		Endpoint:       "merkle/root",
 		SessionType:    APISessionTypeNONE,
 		Args:           q,
 		AppStatusCodes: []int{SCOk},
-		MetaContext:    m,
 	})
 
 	if err != nil {
@@ -756,12 +755,11 @@ func (mc *MerkleClient) lookupPathAndSkipSequenceHelper(m MetaContext, q HTTPArg
 		q.Add("last", I{int(*lastSeqno)})
 	}
 
-	apiRes, err = m.G().API.Get(APIArg{
+	apiRes, err = m.G().API.Get(m, APIArg{
 		Endpoint:       "merkle/path",
 		SessionType:    APISessionTypeNONE,
 		Args:           q,
 		AppStatusCodes: []int{SCOk, SCNotFound, SCDeleted},
-		MetaContext:    m,
 	})
 
 	if err != nil {
@@ -993,11 +991,10 @@ func (r *firstSkipRaw) GetAppStatus() *AppStatus {
 func (mc *MerkleClient) getFirstSkipFromServer(m MetaContext) *keybase1.Seqno {
 
 	var raw firstSkipRaw
-	err := m.G().API.GetDecode(APIArg{
+	err := m.G().API.GetDecode(m, APIArg{
 		Endpoint:       "merkle/first_root_with_skips",
 		SessionType:    APISessionTypeNONE,
 		AppStatusCodes: []int{SCOk},
-		MetaContext:    m,
 	}, &raw)
 
 	if err != nil {
@@ -1154,7 +1151,7 @@ func (mc *MerkleClient) verifyAndStoreRootHelper(m MetaContext, root *MerkleRoot
 	}
 	m.VLogf(VLog1, "+ Merkle: using KID=%s for verifying server sig", kid)
 
-	key, err := mc.keyring.Load(kid)
+	key, err := mc.keyring.Load(m, kid)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -534,7 +534,7 @@ func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 	defer m.Trace("PerUserKeyring#fetchBoxesLocked", func() error { return err })()
 
 	var resp perUserKeySyncResp
-	err = m.G().API.GetDecode(APIArg{
+	err = m.G().API.GetDecode(m, APIArg{
 		Endpoint: "key/fetch_per_user_key_secrets",
 		Args: HTTPArgs{
 			"generation": I{int(s.currentGenerationLocked())},
@@ -542,7 +542,6 @@ func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 		},
 		SessionType: APISessionTypeREQUIRED,
 		RetryCount:  5, // It's pretty bad to fail this, so retry.
-		MetaContext: m,
 	}, &resp)
 	if err != nil {
 		return nil, nil, err

--- a/go/libkb/post.go
+++ b/go/libkb/post.go
@@ -231,9 +231,8 @@ func CheckInvitationCode(m MetaContext, code string) error {
 		Args: HTTPArgs{
 			"invitation_id": S{Val: code},
 		},
-		MetaContext: m,
 	}
-	_, err := m.G().API.Get(arg)
+	_, err := m.G().API.Get(m, arg)
 	return err
 }
 
@@ -241,9 +240,8 @@ func GetInvitationCode(m MetaContext) (string, error) {
 	arg := APIArg{
 		Endpoint:    "invitation_bypass_request",
 		SessionType: APISessionTypeNONE,
-		MetaContext: m,
 	}
-	res, err := m.G().API.Get(arg)
+	res, err := m.G().API.Get(m, arg)
 	var invitationID string
 	if err == nil {
 		invitationID, err = res.Body.AtKey("invitation_id").GetString()

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -329,12 +329,11 @@ func (r *ResolverImpl) resolveURLViaServerLookup(m MetaContext, au AssertionURL,
 		fields += ",public_keys,pictures"
 	}
 	ha.Add("fields", S{fields})
-	ares, res.err = m.G().API.Get(APIArg{
+	ares, res.err = m.G().API.Get(m, APIArg{
 		Endpoint:        "user/lookup",
 		SessionType:     APISessionTypeNONE,
 		Args:            ha,
 		AppStatusCodes:  []int{SCOk, SCNotFound, SCDeleted},
-		MetaContext:     m,
 		RetryCount:      3,
 		InitialTimeout:  4 * time.Second,
 		RetryMultiplier: 1.5,
@@ -409,7 +408,7 @@ func (r *ResolverImpl) resolveTeamViaServerLookup(m MetaContext, au AssertionURL
 		return res
 	}
 
-	arg := NewAPIArgWithMetaContext(m, "team/get")
+	arg := NewAPIArg("team/get")
 	arg.SessionType = APISessionTypeREQUIRED
 	arg.Args = make(HTTPArgs)
 	arg.Args[key] = S{Val: val}
@@ -419,7 +418,7 @@ func (r *ResolverImpl) resolveTeamViaServerLookup(m MetaContext, au AssertionURL
 	}
 
 	var lookup teamLookup
-	if err := m.G().API.GetDecode(arg, &lookup); err != nil {
+	if err := m.G().API.GetDecode(m, arg, &lookup); err != nil {
 		res.err = err
 		return res
 	}
@@ -456,10 +455,10 @@ func (r *ResolverImpl) resolveServerTrustAssertion(m MetaContext, au AssertionUR
 	var arg APIArg
 	switch key {
 	case "phone":
-		arg = NewAPIArgWithMetaContext(m, "user/phone_numbers_search")
+		arg = NewAPIArg("user/phone_numbers_search")
 		arg.Args = map[string]HTTPValue{"phone_number": S{Val: val}}
 	case "email":
-		arg = NewAPIArgWithMetaContext(m, "email/search")
+		arg = NewAPIArg("email/search")
 		arg.Args = map[string]HTTPValue{"email": S{Val: val}}
 	default:
 		res.err = ResolutionError{Input: input, Msg: fmt.Sprintf("Unexpected assertion: %q for server trust lookup", key), Kind: ResolutionErrorInvalidInput}
@@ -470,7 +469,7 @@ func (r *ResolverImpl) resolveServerTrustAssertion(m MetaContext, au AssertionUR
 	arg.AppStatusCodes = []int{SCOk}
 
 	var lookup serverTrustUserLookup
-	if err := m.G().API.GetDecode(arg, &lookup); err != nil {
+	if err := m.G().API.GetDecode(m, arg, &lookup); err != nil {
 		if appErr, ok := err.(AppStatusError); ok {
 			switch appErr.Code {
 			case SCInputError:

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -243,7 +243,7 @@ func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keyba
 	// admin permissions to be honored on the server.
 	readDeleted := m.G().Env.GetReadDeletedSigChain()
 
-	resp, finisher, err := sc.G().API.GetResp(APIArg{
+	resp, finisher, err := sc.G().API.GetResp(m, APIArg{
 		Endpoint:    "sig/get",
 		SessionType: APISessionTypeOPTIONAL,
 		Args: HTTPArgs{
@@ -252,7 +252,6 @@ func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keyba
 			"v2_compressed": B{!full},
 			"read_deleted":  B{readDeleted},
 		},
-		MetaContext: m,
 	})
 	if err != nil {
 		return

--- a/go/libkb/sig_hints.go
+++ b/go/libkb/sig_hints.go
@@ -160,14 +160,13 @@ func LoadSigHints(m MetaContext, uid keybase1.UID) (sh *SigHints, err error) {
 
 func (sh *SigHints) Refresh(m MetaContext) (err error) {
 	defer m.Trace(fmt.Sprintf("Refresh SigHints for uid=%s", sh.uid), func() error { return err })()
-	res, err := m.G().API.Get(APIArg{
+	res, err := m.G().API.Get(m, APIArg{
 		Endpoint:    "sig/hints",
 		SessionType: APISessionTypeNONE,
 		Args: HTTPArgs{
 			"uid": UIDArg(sh.uid),
 			"low": I{sh.version},
 		},
-		MetaContext: m,
 	})
 	if err != nil {
 		return err

--- a/go/libkb/special_keys.go
+++ b/go/libkb/special_keys.go
@@ -64,9 +64,9 @@ func LoadPGPKeyFromLocalDB(k keybase1.KID, g *GlobalContext) (*PGPKeyBundle, err
 // associated with that KID, for signature verification. If the key isn't
 // found in memory or on disk (in the case of PGP), then it will attempt
 // to fetch the key from the keybase server.
-func (sk *SpecialKeyRing) Load(kid keybase1.KID) (GenericKey, error) {
+func (sk *SpecialKeyRing) Load(m MetaContext, kid keybase1.KID) (GenericKey, error) {
 
-	sk.G().Log.Debug("+ SpecialKeyRing.Load(%s)", kid)
+	m.Debug("+ SpecialKeyRing.Load(%s)", kid)
 
 	if !sk.IsValidKID(kid) {
 		err := UnknownSpecialKIDError{kid}
@@ -74,17 +74,17 @@ func (sk *SpecialKeyRing) Load(kid keybase1.KID) (GenericKey, error) {
 	}
 
 	if key, found := sk.keys[kid]; found {
-		sk.G().Log.Debug("- SpecialKeyRing.Load(%s) -> hit inmem cache", kid)
+		m.Debug("- SpecialKeyRing.Load(%s) -> hit inmem cache", kid)
 		return key, nil
 	}
 
-	key, err := LoadPGPKeyFromLocalDB(kid, sk.G())
+	key, err := LoadPGPKeyFromLocalDB(kid, m.G())
 
 	if err != nil || key == nil {
 
-		sk.G().Log.Debug("| Load(%s) going to network", kid)
+		m.Debug("| Load(%s) going to network", kid)
 		var res *APIRes
-		res, err = sk.G().API.Get(APIArg{
+		res, err = sk.G().API.Get(m, APIArg{
 			Endpoint:    "key/special",
 			SessionType: APISessionTypeNONE,
 			Args: HTTPArgs{
@@ -98,19 +98,19 @@ func (sk *SpecialKeyRing) Load(kid keybase1.KID) (GenericKey, error) {
 		if err == nil {
 			w.Warn(sk.G())
 
-			if e2 := key.StoreToLocalDb(sk.G()); e2 != nil {
-				sk.G().Log.Warning("Failed to store key: %s", e2)
+			if e2 := key.StoreToLocalDb(m.G()); e2 != nil {
+				m.Warning("Failed to store key: %s", e2)
 			}
 		}
 	} else {
-		sk.G().Log.Debug("| Load(%s) hit DB-backed cache", kid)
+		m.Debug("| Load(%s) hit DB-backed cache", kid)
 	}
 
 	if err == nil && key != nil {
 		sk.keys[kid] = key
 	}
 
-	sk.G().Log.Debug("- SpecialKeyRing.Load(%s)", kid)
+	m.Debug("- SpecialKeyRing.Load(%s)", kid)
 
 	return key, err
 }

--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -127,12 +127,11 @@ func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, forceRel
 		hargs.Add("version", I{ss.keys.Version})
 	}
 	var res *APIRes
-	res, err = ss.G().API.Get(APIArg{
+	res, err = ss.G().API.Get(m, APIArg{
 		Endpoint:    "key/fetch_private",
 		Args:        hargs,
 		SessionType: APISessionTypeREQUIRED,
 		RetryCount:  5, // It's pretty bad to fail this, so retry.
-		MetaContext: m,
 	})
 	m.Debug("| syncFromServer -> %s", ErrToOk(err))
 	if err != nil {

--- a/go/libkb/sync_trackers.go
+++ b/go/libkb/sync_trackers.go
@@ -123,11 +123,10 @@ func (t *TrackerSyncer) syncFromServer(m MetaContext, uid keybase1.UID, forceRel
 	}
 
 	var res *APIRes
-	res, err = t.G().API.Get(APIArg{
+	res, err = m.G().API.Get(m, APIArg{
 		Endpoint:    "user/trackers",
 		Args:        hargs,
 		SessionType: APISessionTypeNONE,
-		MetaContext: m,
 	})
 	m.Debug("| syncFromServer() -> %s", ErrToOk(err))
 	if err != nil {

--- a/go/libkb/sync_trackers2.go
+++ b/go/libkb/sync_trackers2.go
@@ -75,10 +75,9 @@ func (t *Tracker2Syncer) syncFromServer(m MetaContext, uid keybase1.UID, forceRe
 		hargs.Add("version", I{lv})
 	}
 	var res *APIRes
-	res, err = t.G().API.Get(APIArg{
-		Endpoint:    "user/list_followers_for_display",
-		Args:        hargs,
-		MetaContext: m,
+	res, err = m.G().API.Get(m, APIArg{
+		Endpoint: "user/list_followers_for_display",
+		Args:     hargs,
 	})
 	m.Debug("| syncFromServer() -> %s", ErrToOk(err))
 	if err != nil {

--- a/go/libkb/upak_lite.go
+++ b/go/libkb/upak_lite.go
@@ -112,9 +112,8 @@ func (hsc *HighSigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID 
 		Endpoint:    "sig/get_high",
 		SessionType: APISessionTypeOPTIONAL,
 		Args:        HTTPArgs{"uid": S{Val: hsc.uid.String()}},
-		MetaContext: m,
 	}
-	resp, finisher, err := m.G().API.GetResp(apiArg)
+	resp, finisher, err := m.G().API.GetResp(m, apiArg)
 	if err != nil {
 		return nil, err
 	}

--- a/go/merklestore/store.go
+++ b/go/merklestore/store.go
@@ -213,10 +213,9 @@ func (r *merkleStoreServerRes) GetAppStatus() *libkb.AppStatus {
 func (s *MerkleStoreImpl) fetch(m libkb.MetaContext, hash keybase1.MerkleStoreKitHash) (keybase1.MerkleStoreKit, error) {
 	m.Debug("MerkleStore: fetching from server: %s", hash)
 	var res merkleStoreServerRes
-	err := m.G().API.GetDecode(libkb.APIArg{
+	err := m.G().API.GetDecode(m, libkb.APIArg{
 		Endpoint:    s.endpoint,
 		SessionType: libkb.APISessionTypeNONE,
-		MetaContext: m,
 		Args: libkb.HTTPArgs{
 			"hash": libkb.S{Val: string(hash)},
 		},

--- a/go/phonenumbers/user.go
+++ b/go/phonenumbers/user.go
@@ -54,7 +54,7 @@ func GetPhoneNumbers(mctx libkb.MetaContext) ([]keybase1.UserPhoneNumber, error)
 		SessionType: libkb.APISessionTypeREQUIRED,
 	}
 	var resp phoneNumbersResponse
-	err := mctx.G().API.GetDecode(arg, &resp)
+	err := mctx.G().API.GetDecode(mctx, arg, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/go/service/account.go
+++ b/go/service/account.go
@@ -114,18 +114,18 @@ type GetLockdownResponse struct {
 }
 
 func (h *AccountHandler) GetLockdownMode(ctx context.Context, sessionID int) (ret keybase1.GetLockdownResponse, err error) {
-	defer h.G().CTraceTimed(ctx, "GetLockdownMode", func() error { return err })()
+	mctx := libkb.NewMetaContext(ctx, h.G())
+	defer mctx.TraceTimed("GetLockdownMode", func() error { return err })()
 	apiArg := libkb.APIArg{
 		Endpoint:    "account/lockdown",
 		SessionType: libkb.APISessionTypeREQUIRED,
 	}
 	var response GetLockdownResponse
-	err = h.G().API.GetDecode(apiArg, &response)
+	err = mctx.G().API.GetDecode(mctx, apiArg, &response)
 	if err != nil {
 		return ret, err
 	}
 
-	mctx := libkb.NewMetaContext(ctx, h.G())
 	upak, _, err := mctx.G().GetUPAKLoader().Load(
 		libkb.NewLoadUserArgWithMetaContext(mctx).WithPublicKeyOptional().WithUID(mctx.G().ActiveDevice.UID()))
 	if err != nil {

--- a/go/service/apiserver.go
+++ b/go/service/apiserver.go
@@ -25,12 +25,14 @@ func NewAPIServerHandler(xp rpc.Transporter, g *libkb.GlobalContext) *APIServerH
 	}
 }
 
-func (a *APIServerHandler) Get(_ context.Context, arg keybase1.GetArg) (keybase1.APIRes, error) {
-	return a.doGet(arg, false)
+func (a *APIServerHandler) Get(ctx context.Context, arg keybase1.GetArg) (keybase1.APIRes, error) {
+	mctx := libkb.NewMetaContext(ctx, a.G())
+	return a.doGet(mctx, arg, false)
 }
 
-func (a *APIServerHandler) GetWithSession(_ context.Context, arg keybase1.GetWithSessionArg) (keybase1.APIRes, error) {
-	return a.doGet(arg, true)
+func (a *APIServerHandler) GetWithSession(ctx context.Context, arg keybase1.GetWithSessionArg) (keybase1.APIRes, error) {
+	mctx := libkb.NewMetaContext(ctx, a.G())
+	return a.doGet(mctx, arg, true)
 }
 
 func (a *APIServerHandler) Post(_ context.Context, arg keybase1.PostArg) (keybase1.APIRes, error) {
@@ -83,15 +85,15 @@ func (a *APIServerHandler) setupArg(arg GenericArg) libkb.APIArg {
 	return kbarg
 }
 
-func (a *APIServerHandler) doGet(arg GenericArg, sessionRequired bool) (res keybase1.APIRes, err error) {
-	defer a.G().Trace("APIServerHandler::Get", func() error { return err })()
+func (a *APIServerHandler) doGet(mctx libkb.MetaContext, arg GenericArg, sessionRequired bool) (res keybase1.APIRes, err error) {
+	defer mctx.Trace("APIServerHandler::Get", func() error { return err })()
 	// turn off session requirement if not needed
 	kbarg := a.setupArg(arg)
 	if !sessionRequired {
 		kbarg.SessionType = libkb.APISessionTypeNONE
 	}
 	var ires *libkb.APIRes
-	ires, err = a.G().API.Get(kbarg)
+	ires, err = mctx.G().API.Get(mctx, kbarg)
 	if err != nil {
 		return res, err
 	}

--- a/go/service/apiserver_test.go
+++ b/go/service/apiserver_test.go
@@ -28,9 +28,9 @@ func TestAPIServerGet(t *testing.T) {
 		Endpoint: "user/lookup",
 		Args:     harg,
 	}
-
+	mctx := libkb.NewMetaContextForTest(tc)
 	handler := NewAPIServerHandler(nil, tc.G)
-	res, err := handler.doGet(arg, false)
+	res, err := handler.doGet(mctx, arg, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -376,13 +376,13 @@ func (h ConfigHandler) GetUpdateInfo2(ctx context.Context, arg keybase1.GetUpdat
 		version = libkb.VersionString()
 	}
 
-	apiArg := libkb.NewAPIArgWithMetaContext(m, "pkg/check")
+	apiArg := libkb.NewAPIArg("pkg/check")
 	apiArg.Args = libkb.HTTPArgs{
 		"version":  libkb.S{Val: version},
 		"platform": libkb.S{Val: platform},
 	}
 	var raw rawGetPkgCheck
-	if err = m.G().API.GetDecode(apiArg, &raw); err != nil {
+	if err = m.G().API.GetDecode(m, apiArg, &raw); err != nil {
 		return res, err
 	}
 	return raw.Res, nil

--- a/go/service/device.go
+++ b/go/service/device.go
@@ -131,8 +131,9 @@ func (h *DeviceHandler) DismissDeviceChangeNotifications(c context.Context) (err
 	return err
 }
 
-func (h *DeviceHandler) CheckDeviceNameForUser(_ context.Context, arg keybase1.CheckDeviceNameForUserArg) error {
-	_, err := h.G().API.Get(libkb.APIArg{
+func (h *DeviceHandler) CheckDeviceNameForUser(ctx context.Context, arg keybase1.CheckDeviceNameForUserArg) error {
+	mctx := libkb.NewMetaContext(ctx, h.G())
+	_, err := mctx.G().API.Get(mctx, libkb.APIArg{
 		Endpoint:    "device/check_name",
 		SessionType: libkb.APISessionTypeNONE,
 		Args: libkb.HTTPArgs{

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -36,10 +36,9 @@ type canLogoutRet struct {
 
 // canLogout asks API server whether we should allow logging out or not.
 func canLogout(mctx libkb.MetaContext) (res canLogoutRet, err error) {
-	err = mctx.G().API.GetDecode(libkb.APIArg{
+	err = mctx.G().API.GetDecode(mctx, libkb.APIArg{
 		Endpoint:    "user/can_logout",
 		SessionType: libkb.APISessionTypeREQUIRED,
-		MetaContext: mctx,
 	}, &res)
 	return res, err
 }

--- a/go/service/random_pw_test.go
+++ b/go/service/random_pw_test.go
@@ -13,14 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func sessCheck(t *testing.T, g *libkb.GlobalContext) (err error) {
-	arg := libkb.NewRetryAPIArg("sesscheck")
-	arg.SessionType = libkb.APISessionTypeREQUIRED
-	_, err = g.API.Get(arg)
-	t.Logf("sesscheck returned: %q", err)
-	return err
-}
-
 func setPassphraseInTest(tc libkb.TestContext) error {
 	newPassphrase := "okokokok"
 	arg := &keybase1.PassphraseChangeArg{
@@ -79,14 +71,14 @@ type errorAPIMock struct {
 	shouldTimeout bool
 }
 
-func (r *errorAPIMock) GetDecode(arg libkb.APIArg, w libkb.APIResponseWrapper) error {
+func (r *errorAPIMock) GetDecode(mctx libkb.MetaContext, arg libkb.APIArg, w libkb.APIResponseWrapper) error {
 	if arg.Endpoint == "user/has_random_pw" {
 		r.callCount++
 		if r.shouldTimeout {
 			return errors.New("timeout or something")
 		}
 	}
-	return r.realAPI.GetDecode(arg, w)
+	return r.realAPI.GetDecode(mctx, arg, w)
 }
 
 func TestCanLogoutTimeout(t *testing.T) {

--- a/go/service/rekey_master.go
+++ b/go/service/rekey_master.go
@@ -599,14 +599,15 @@ func (u *unkeyedTLFsQueryResult) GetAppStatus() *libkb.AppStatus {
 	return &u.Status
 }
 
-func (r *RekeyHandler2) GetRevokeWarning(_ context.Context, arg keybase1.GetRevokeWarningArg) (res keybase1.RevokeWarning, err error) {
+func (r *RekeyHandler2) GetRevokeWarning(ctx context.Context, arg keybase1.GetRevokeWarningArg) (res keybase1.RevokeWarning, err error) {
 	var u unkeyedTLFsQueryResult
 	actingDevice := arg.ActingDevice
 	if actingDevice.IsNil() {
 		actingDevice = r.G().Env.GetDeviceID()
 	}
+	mctx := libkb.NewMetaContext(ctx, r.G())
 
-	err = r.G().API.GetDecode(libkb.APIArg{
+	err = r.G().API.GetDecode(mctx, libkb.APIArg{
 		Endpoint:    "kbfs/unkeyed_tlfs_from_pair",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		Args: libkb.HTTPArgs{

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -25,8 +25,9 @@ func NewSignupHandler(xp rpc.Transporter, g *libkb.GlobalContext) *SignupHandler
 	}
 }
 
-func (h *SignupHandler) CheckUsernameAvailable(_ context.Context, arg keybase1.CheckUsernameAvailableArg) error {
-	_, err := h.G().API.Get(libkb.APIArg{
+func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1.CheckUsernameAvailableArg) error {
+	mctx := libkb.NewMetaContext(ctx, h.G())
+	_, err := mctx.G().API.Get(mctx, libkb.APIArg{
 		Endpoint:    "user/lookup",
 		SessionType: libkb.APISessionTypeNONE,
 		Args: libkb.HTTPArgs{

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -176,7 +176,8 @@ func (h *UserHandler) LoadUserPlusKeys(netCtx context.Context, arg keybase1.Load
 }
 
 func (h *UserHandler) LoadMySettings(ctx context.Context, sessionID int) (us keybase1.UserSettings, err error) {
-	emails, err := libkb.LoadUserEmails(h.G())
+	mctx := libkb.NewMetaContext(ctx, h.G())
+	emails, err := libkb.LoadUserEmails(mctx)
 	if err != nil {
 		return
 	}
@@ -598,10 +599,9 @@ func (h *UserHandler) LoadHasRandomPw(ctx context.Context, arg keybase1.LoadHasR
 		libkb.AppStatusEmbed
 		RandomPW bool `json:"random_pw"`
 	}
-	err = h.G().API.GetDecode(libkb.APIArg{
+	err = m.G().API.GetDecode(m, libkb.APIArg{
 		Endpoint:       "user/has_random_pw",
 		SessionType:    libkb.APISessionTypeREQUIRED,
-		NetContext:     ctx,
 		InitialTimeout: initialTimeout,
 	}, &ret)
 	if err != nil {

--- a/go/stellar/remote/serverconfig.go
+++ b/go/stellar/remote/serverconfig.go
@@ -21,14 +21,14 @@ func (b *configResult) GetAppStatus() *libkb.AppStatus {
 }
 
 func FetchServerConfig(ctx context.Context, g *libkb.GlobalContext) (ret stellar1.StellarServerDefinitions, err error) {
+	mctx := libkb.NewMetaContext(ctx, g)
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/config",
 		SessionType: libkb.APISessionTypeNONE,
-		NetContext:  ctx,
 	}
 
 	var res configResult
-	if err := g.API.GetDecode(apiArg, &res); err != nil {
+	if err := mctx.G().API.GetDecode(mctx, apiArg, &res); err != nil {
 		return ret, err
 	}
 

--- a/go/stellar/stellarsvc/remote_mock_test.go
+++ b/go/stellar/stellarsvc/remote_mock_test.go
@@ -966,16 +966,16 @@ func (r *BackendMock) Details(ctx context.Context, tc *TestContext, accountID st
 	// users are allowed to have currency preferences even for accounts
 	// that do not exist on the network yet.
 	var displayCurrency string
+	mctx := libkb.NewMetaContext(ctx, tc.G)
 	apiArg := libkb.APIArg{
 		Endpoint:    "stellar/accountcurrency",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		Args: libkb.HTTPArgs{
 			"account_id": libkb.S{Val: string(accountID)},
 		},
-		NetContext: ctx,
 	}
 	var apiRes accountCurrencyResult
-	err = tc.G.API.GetDecode(apiArg, &apiRes)
+	err = tc.G.API.GetDecode(mctx, apiArg, &apiRes)
 	if err == nil {
 		displayCurrency = apiRes.CurrencyDisplayPreference
 	}

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -390,10 +390,11 @@ func (u *userPlusDevice) loadTeamByID(teamID keybase1.TeamID, admin bool) *teams
 }
 
 func (u *userPlusDevice) readInviteEmails(email string) []string {
+	mctx := libkb.NewMetaContextForTest(*u.tc)
 	arg := libkb.NewAPIArg("test/team/get_tokens")
 	arg.Args = libkb.NewHTTPArgs()
 	arg.Args.Add("email", libkb.S{Val: email})
-	res, err := u.tc.G.API.Get(arg)
+	res, err := u.tc.G.API.Get(mctx, arg)
 	if err != nil {
 		u.tc.T.Fatal(err)
 	}

--- a/go/teams/ftl.go
+++ b/go/teams/ftl.go
@@ -650,14 +650,14 @@ func (f *FastTeamChainLoader) loadFromServerWithRetries(m libkb.MetaContext, arg
 
 // makeHTTPRequest hits the HTTP GET endpoint for the team data.
 func (f *FastTeamChainLoader) makeHTTPRequest(m libkb.MetaContext, args libkb.HTTPArgs, isPublic bool) (t rawTeam, err error) {
-	apiArg := libkb.NewAPIArgWithMetaContext(m, "team/get")
+	apiArg := libkb.NewAPIArg("team/get")
 	apiArg.Args = args
 	if isPublic {
 		apiArg.SessionType = libkb.APISessionTypeOPTIONAL
 	} else {
 		apiArg.SessionType = libkb.APISessionTypeREQUIRED
 	}
-	err = m.G().API.GetDecode(apiArg, &t)
+	err = m.G().API.GetDecode(m, apiArg, &t)
 	if err != nil {
 		return t, err
 	}

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -91,13 +91,14 @@ func loadImpteam(ctx context.Context, g *libkb.GlobalContext, displayName string
 }
 
 func loadImpteamFromServer(ctx context.Context, g *libkb.GlobalContext, displayName string, public bool) (imp implicitTeam, err error) {
-	arg := libkb.NewAPIArgWithNetContext(ctx, "team/implicit")
+	mctx := libkb.NewMetaContext(ctx, g)
+	arg := libkb.NewAPIArg("team/implicit")
 	arg.SessionType = libkb.APISessionTypeOPTIONAL
 	arg.Args = libkb.HTTPArgs{
 		"display_name": libkb.S{Val: displayName},
 		"public":       libkb.B{Val: public},
 	}
-	if err = g.API.GetDecode(arg, &imp); err != nil {
+	if err = mctx.G().API.GetDecode(mctx, arg, &imp); err != nil {
 		if aerr, ok := err.(libkb.AppStatusError); ok {
 			code := keybase1.StatusCode(aerr.Code)
 			switch code {

--- a/go/teams/kbfs_pin_tlfs.go
+++ b/go/teams/kbfs_pin_tlfs.go
@@ -10,13 +10,13 @@ import (
 
 func getUnpinnedTLF(m libkb.MetaContext) (res *unpinnedTLF, err error) {
 
-	arg := libkb.NewAPIArgWithMetaContext(m, "kbfs/unpinned")
+	arg := libkb.NewAPIArg("kbfs/unpinned")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	arg.Args = libkb.HTTPArgs{
 		"n": libkb.I{Val: 1},
 	}
 	var r unpinnedTLFsRaw
-	err = m.G().API.GetDecode(arg, &r)
+	err = m.G().API.GetDecode(m, arg, &r)
 	if err != nil {
 		return nil, err
 	}

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -43,10 +43,10 @@ func getTeamsListFromServer(ctx context.Context, g *libkb.GlobalContext, uid key
 	if includeImplicitTeams {
 		a.Args["include_implicit_teams"] = libkb.B{Val: true}
 	}
-	a.NetContext = ctx
+	mctx := libkb.NewMetaContext(ctx, g)
 	a.SessionType = libkb.APISessionTypeREQUIRED
 	var list statusList
-	if err := g.API.GetDecode(a, &list); err != nil {
+	if err := mctx.G().API.GetDecode(mctx, a, &list); err != nil {
 		return nil, err
 	}
 	return list.Teams, nil

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -181,7 +181,8 @@ func (l *TeamLoader) ResolveNameToIDUntrusted(ctx context.Context, teamName keyb
 }
 
 func resolveNameToIDUntrustedAPICall(ctx context.Context, g *libkb.GlobalContext, teamName keybase1.TeamName, public bool) (id keybase1.TeamID, err error) {
-	arg := libkb.NewAPIArgWithNetContext(ctx, "team/get")
+	mctx := libkb.NewMetaContext(ctx, g)
+	arg := libkb.NewAPIArg("team/get")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	arg.Args = libkb.HTTPArgs{
 		"name":        libkb.S{Val: teamName.String()},
@@ -190,7 +191,7 @@ func resolveNameToIDUntrustedAPICall(ctx context.Context, g *libkb.GlobalContext
 	}
 
 	var rt rawTeam
-	if err := g.API.GetDecode(arg, &rt); err != nil {
+	if err := mctx.G().API.GetDecode(mctx, arg, &rt); err != nil {
 		return id, err
 	}
 	id = rt.ID

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -118,7 +118,8 @@ func (l *LoaderContextG) getLinksFromServer(ctx context.Context,
 func (l *LoaderContextG) getLinksFromServerCommon(ctx context.Context,
 	teamID keybase1.TeamID, lows *getLinksLows, requestSeqnos []keybase1.Seqno, readSubteamID *keybase1.TeamID) (*rawTeam, error) {
 
-	arg := libkb.NewAPIArgWithNetContext(ctx, "team/get")
+	mctx := libkb.NewMetaContext(ctx, l.G())
+	arg := libkb.NewAPIArg("team/get")
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	if teamID.IsPublic() {
 		arg.SessionType = libkb.APISessionTypeOPTIONAL
@@ -142,7 +143,7 @@ func (l *LoaderContextG) getLinksFromServerCommon(ctx context.Context,
 	}
 
 	var rt rawTeam
-	if err := l.G().API.GetDecode(arg, &rt); err != nil {
+	if err := mctx.G().API.GetDecode(mctx, arg, &rt); err != nil {
 		return nil, err
 	}
 	if !rt.ID.Eq(teamID) {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1174,6 +1174,7 @@ func (r *accessRequestList) GetAppStatus() *libkb.AppStatus {
 
 func ListRequests(ctx context.Context, g *libkb.GlobalContext, teamName *string) ([]keybase1.TeamJoinRequest, error) {
 	var arg libkb.APIArg
+	mctx := libkb.NewMetaContext(ctx, g)
 	if teamName != nil {
 		arg = apiArg(ctx, "team/access_requests")
 		arg.Args.Add("team", libkb.S{Val: *teamName})
@@ -1182,7 +1183,7 @@ func ListRequests(ctx context.Context, g *libkb.GlobalContext, teamName *string)
 	}
 
 	var arList accessRequestList
-	if err := g.API.GetDecode(arg, &arList); err != nil {
+	if err := mctx.G().API.GetDecode(mctx, arg, &arList); err != nil {
 		return nil, err
 	}
 
@@ -1210,13 +1211,14 @@ func (r *myAccessRequestsList) GetAppStatus() *libkb.AppStatus {
 }
 
 func ListMyAccessRequests(ctx context.Context, g *libkb.GlobalContext, teamName *string) (res []keybase1.TeamName, err error) {
+	mctx := libkb.NewMetaContext(ctx, g)
 	arg := apiArg(ctx, "team/my_access_requests")
 	if teamName != nil {
 		arg.Args.Add("team", libkb.S{Val: *teamName})
 	}
 
 	var arList myAccessRequestsList
-	if err := g.API.GetDecode(arg, &arList); err != nil {
+	if err := mctx.G().API.GetDecode(mctx, arg, &arList); err != nil {
 		return nil, err
 	}
 
@@ -1697,10 +1699,11 @@ func GetTarsDisabled(ctx context.Context, g *libkb.GlobalContext, teamname strin
 		return false, err
 	}
 
+	mctx := libkb.NewMetaContext(ctx, g)
 	arg := apiArg(ctx, "team/disable_tars")
 	arg.Args.Add("tid", libkb.S{Val: id.String()})
 	var ret disableTARsRes
-	if err := g.API.GetDecode(arg, &ret); err != nil {
+	if err := mctx.G().API.GetDecode(mctx, arg, &ret); err != nil {
 		return false, err
 	}
 
@@ -1746,13 +1749,14 @@ func TeamProfileAddList(ctx context.Context, g *libkb.GlobalContext, username st
 	arg := apiArg(ctx, "team/list_profile_add")
 	arg.Args.Add("uid", libkb.S{Val: uid.String()})
 	var serverRes listProfileAddServerRes
-	if err = g.API.GetDecode(arg, &serverRes); err != nil {
+	mctx := libkb.NewMetaContext(ctx, g)
+	if err = mctx.G().API.GetDecode(mctx, arg, &serverRes); err != nil {
 		return nil, err
 	}
 	for _, entry := range serverRes.Teams {
 		teamName, err := keybase1.TeamNameFromString(entry.FqName)
 		if err != nil {
-			g.Log.CDebugf(ctx, "TeamProfileAddList server returned bad team name %v: %v", entry.FqName, err)
+			mctx.Debug("TeamProfileAddList server returned bad team name %v: %v", entry.FqName, err)
 			continue
 		}
 		disabledReason := ""

--- a/go/teams/showcase_helper.go
+++ b/go/teams/showcase_helper.go
@@ -19,7 +19,8 @@ func GetTeamShowcase(ctx context.Context, g *libkb.GlobalContext, teamname strin
 	arg.Args.Add("id", libkb.S{Val: t.ID.String()})
 
 	var rt rawTeam
-	if err := g.API.GetDecode(arg, &rt); err != nil {
+	mctx := libkb.NewMetaContext(ctx, g)
+	if err := mctx.G().API.GetDecode(mctx, arg, &rt); err != nil {
 		return ret, err
 	}
 	return rt.Showcase, nil
@@ -49,7 +50,8 @@ func GetTeamAndMemberShowcase(ctx context.Context, g *libkb.GlobalContext, teamn
 	arg.Args.Add("id", libkb.S{Val: t.ID.String()})
 
 	var teamRet rawTeam
-	if err := g.API.GetDecode(arg, &teamRet); err != nil {
+	mctx := libkb.NewMetaContext(ctx, g)
+	if err := mctx.G().API.GetDecode(mctx, arg, &teamRet); err != nil {
 		return ret, err
 	}
 	ret.TeamShowcase = teamRet.Showcase
@@ -62,7 +64,7 @@ func GetTeamAndMemberShowcase(ctx context.Context, g *libkb.GlobalContext, teamn
 		arg.Args.Add("tid", libkb.S{Val: t.ID.String()})
 
 		var memberRet memberShowcaseRes
-		if err := g.API.GetDecode(arg, &memberRet); err != nil {
+		if err := mctx.G().API.GetDecode(mctx, arg, &memberRet); err != nil {
 			if appErr, ok := err.(libkb.AppStatusError); ok &&
 				appErr.Code == int(keybase1.StatusCode_SCTeamShowcasePermDenied) {
 				// It is possible that we were still a member when
@@ -72,7 +74,7 @@ func GetTeamAndMemberShowcase(ctx context.Context, g *libkb.GlobalContext, teamn
 				// checks before calling it - but if we have outdated team
 				// information, we might still end up here not being allowed
 				// to call it and getting this error.
-				g.Log.CDebugf(ctx, "GetTeamAndMemberShowcase hit a race with team %q", teamname)
+				mctx.Debug("GetTeamAndMemberShowcase hit a race with team %q", teamname)
 				return ret, nil
 			}
 

--- a/go/test/run_tests.sh
+++ b/go/test/run_tests.sh
@@ -4,6 +4,24 @@ cd "$(dirname "$BASH_SOURCE")/.."
 
 set -f -u -e
 
+options=$(getopt c $*)
+if [ $? -ne 0 ]; then
+    echo "Incorrect options provided"
+    exit 1
+fi
+
+FLAGS="-timeout 50m"
+
+for i
+do
+    case "$1" in
+    -c)
+        FLAGS=-c
+        ;;
+    esac
+    shift
+done
+
 # Log the Go version.
 echo "Running tests on commit $(git rev-parse --short HEAD) with $(go version)."
 
@@ -24,7 +42,7 @@ for i in $DIRS; do
   fi
 
   echo -n "$i......."
-  if ! (cd $i && go test -timeout 50m ) ; then
+  if ! (cd $i && go test $FLAGS ) ; then
     failures+=("$i")
   fi
 done

--- a/go/tlfupgrade/tlfupgrade.go
+++ b/go/tlfupgrade/tlfupgrade.go
@@ -148,15 +148,16 @@ func (b *BackgroundTLFUpdater) deadline(d time.Duration) time.Time {
 }
 
 func (b *BackgroundTLFUpdater) getTLFToUpgrade(ctx context.Context, appType keybase1.TeamApplication) (*GetTLFForUpgradeAvailableRes, time.Time) {
+	mctx := libkb.NewMetaContext(ctx, b.G())
 	if !b.G().ActiveDevice.HaveKeys() {
 		return nil, time.Now().Add(time.Minute)
 	}
-	arg := libkb.NewAPIArgWithNetContext(ctx, "kbfs/upgrade")
+	arg := libkb.NewAPIArg("kbfs/upgrade")
 	arg.Args = libkb.NewHTTPArgs()
 	arg.SessionType = libkb.APISessionTypeREQUIRED
 	arg.Args.Add("app_type", libkb.I{Val: int(appType)})
 	var res getUpgradeRes
-	if err := b.api().GetDecode(arg, &res); err != nil {
+	if err := b.api().GetDecode(mctx, arg, &res); err != nil {
 		b.debug(ctx, "getTLFToUpgrade: API fail: %s", err)
 		return nil, b.deadline(b.errWait)
 	}

--- a/go/tlfupgrade/tlfupgrade_test.go
+++ b/go/tlfupgrade/tlfupgrade_test.go
@@ -18,7 +18,7 @@ type testAPIServer struct {
 	responseFn func() getUpgradeRes
 }
 
-func (t *testAPIServer) GetDecode(arg libkb.APIArg, resp libkb.APIResponseWrapper) error {
+func (t *testAPIServer) GetDecode(mctx libkb.MetaContext, arg libkb.APIArg, resp libkb.APIResponseWrapper) error {
 	*(resp.(*getUpgradeRes)) = t.responseFn()
 	return nil
 }


### PR DESCRIPTION
- We didn't change the other side of the interface yet, we're just going to change the callers
- Also, the rest of the API interface still isn't ported over, we'll work on that next.