### PR TITLE
another list2 bug

### DIFF
--- a/shared/common-adapters/list.stories.js
+++ b/shared/common-adapters/list.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import Button from './button'
 import Box, {Box2} from './box'
 import Text from './text'
 import List2 from './list2'
@@ -64,6 +65,50 @@ const load = () =>
         />
       </Box>
     ))
+    .add('fixed - props change !rerenderItemOnPropUpdateDesktop', () => (
+      <PropsChangeTester rerenderItemOnPropUpdateDesktop={false} />
+    ))
+    .add('fixed - props change rerenderItemOnPropUpdateDesktop', () => (
+      <PropsChangeTester rerenderItemOnPropUpdateDesktop={true} />
+    ))
+
+class PropsChangeTester extends React.PureComponent<
+  {|rerenderItemOnPropUpdateDesktop: boolean|},
+  {|counter: number|}
+> {
+  state = {
+    counter: 0,
+  }
+  render() {
+    return (
+      <>
+        <Button
+          type="Primary"
+          label="increase"
+          onClick={() =>
+            this.setState(prevState => ({
+              counter: prevState.counter + 1,
+            }))
+          }
+        />
+        <Box style={styles.listContainer}>
+          <List2
+            items={[{val: this.state.counter}]}
+            rerenderItemOnPropUpdateDesktop={this.props.rerenderItemOnPropUpdateDesktop}
+            bounces={true}
+            indexAsKey={true}
+            itemHeight={{height: 32, type: 'fixed'}}
+            renderItem={(index, item) => (
+              <Box2 direction="horizontal" style={styles.listItem} centerChildren={true} fullWidth={true}>
+                <Text type="Body">{item.val.toString()}</Text>
+              </Box2>
+            )}
+          />
+        </Box>
+      </>
+    )
+  }
+}
 const styles = Styles.styleSheetCreate({
   listContainer: {
     backgroundColor: Styles.globalColors.red,

--- a/shared/common-adapters/list.stories.js
+++ b/shared/common-adapters/list.stories.js
@@ -65,17 +65,9 @@ const load = () =>
         />
       </Box>
     ))
-    .add('fixed - props change !rerenderItemOnPropUpdateDesktop', () => (
-      <PropsChangeTester rerenderItemOnPropUpdateDesktop={false} />
-    ))
-    .add('fixed - props change rerenderItemOnPropUpdateDesktop', () => (
-      <PropsChangeTester rerenderItemOnPropUpdateDesktop={true} />
-    ))
+    .add('fixed - props change ', () => <PropsChangeTester />)
 
-class PropsChangeTester extends React.PureComponent<
-  {|rerenderItemOnPropUpdateDesktop: boolean|},
-  {|counter: number|}
-> {
+class PropsChangeTester extends React.PureComponent<{||}, {|counter: number|}> {
   state = {
     counter: 0,
   }
@@ -94,7 +86,6 @@ class PropsChangeTester extends React.PureComponent<
         <Box style={styles.listContainer}>
           <List2
             items={[{val: this.state.counter}]}
-            rerenderItemOnPropUpdateDesktop={this.props.rerenderItemOnPropUpdateDesktop}
             bounces={true}
             indexAsKey={true}
             itemHeight={{height: 32, type: 'fixed'}}

--- a/shared/common-adapters/list2.desktop.js
+++ b/shared/common-adapters/list2.desktop.js
@@ -27,6 +27,7 @@ class List2<T> extends PureComponent<Props<T>, void> {
       height={height}
       width={width}
       itemCount={this.props.items.length}
+      itemData={this.props.items}
       itemKey={this._keyExtractor}
       itemSize={itemHeight}
     >
@@ -40,6 +41,7 @@ class List2<T> extends PureComponent<Props<T>, void> {
       height={height}
       width={width}
       itemCount={this.props.items.length}
+      itemData={this.props.items}
       itemKey={this._keyExtractor}
       itemSize={index => getItemLayout(index, this.props.items[index]).height}
       estimatedItemSize={this.props.estimatedItemHeight}

--- a/shared/common-adapters/list2.desktop.js
+++ b/shared/common-adapters/list2.desktop.js
@@ -21,13 +21,14 @@ class List2<T> extends PureComponent<Props<T>, void> {
   // all rows and mount again.
   _row = ({index, style}) => <div style={style}>{this.props.renderItem(index, this.props.items[index])}</div>
 
+  // Need to pass in itemData to make items re-render on prop changes.
   _fixed = ({height, width, itemHeight}) => (
     <FixedSizeList
       style={this.props.style}
       height={height}
       width={width}
       itemCount={this.props.items.length}
-      itemData={this.props.rerenderItemOnPropUpdateDesktop ? this.props.items : undefined}
+      itemData={this.props.items}
       itemKey={this._keyExtractor}
       itemSize={itemHeight}
     >
@@ -41,7 +42,7 @@ class List2<T> extends PureComponent<Props<T>, void> {
       height={height}
       width={width}
       itemCount={this.props.items.length}
-      itemData={this.props.rerenderItemOnPropUpdateDesktop ? this.props.items : undefined}
+      itemData={this.props.items}
       itemKey={this._keyExtractor}
       itemSize={index => getItemLayout(index, this.props.items[index]).height}
       estimatedItemSize={this.props.estimatedItemHeight}

--- a/shared/common-adapters/list2.desktop.js
+++ b/shared/common-adapters/list2.desktop.js
@@ -27,7 +27,7 @@ class List2<T> extends PureComponent<Props<T>, void> {
       height={height}
       width={width}
       itemCount={this.props.items.length}
-      itemData={this.props.items}
+      itemData={this.props.rerenderItemOnPropUpdateDesktop ? this.props.items : undefined}
       itemKey={this._keyExtractor}
       itemSize={itemHeight}
     >
@@ -41,7 +41,7 @@ class List2<T> extends PureComponent<Props<T>, void> {
       height={height}
       width={width}
       itemCount={this.props.items.length}
-      itemData={this.props.items}
+      itemData={this.props.rerenderItemOnPropUpdateDesktop ? this.props.items : undefined}
       itemKey={this._keyExtractor}
       itemSize={index => getItemLayout(index, this.props.items[index]).height}
       estimatedItemSize={this.props.estimatedItemHeight}

--- a/shared/common-adapters/list2.js.flow
+++ b/shared/common-adapters/list2.js.flow
@@ -36,6 +36,7 @@ export type Props<Item> = {|
 
   items: Array<Item>,
   renderItem: (index: number, item: Item) => React.Node,
+  rerenderItemOnPropUpdateDesktop?: ?boolean, // mobile already does that
   itemHeight: VariableItemHeight<Item> | FixedHeight,
   estimatedItemHeight?: number,
 

--- a/shared/common-adapters/list2.js.flow
+++ b/shared/common-adapters/list2.js.flow
@@ -36,7 +36,6 @@ export type Props<Item> = {|
 
   items: Array<Item>,
   renderItem: (index: number, item: Item) => React.Node,
-  rerenderItemOnPropUpdateDesktop?: ?boolean, // mobile already does that
   itemHeight: VariableItemHeight<Item> | FixedHeight,
   estimatedItemHeight?: number,
 


### PR DESCRIPTION
If `itemData` is not passed in, items don't get re-rendered when their props change.