### PR TITLE
add some logging to device notification dismissal

### DIFF
--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -398,7 +398,9 @@ func buildGregorItem(category, deviceID, msgID string) gregor.Item {
 }
 
 func TestDismissDeviceChangeNotifications(t *testing.T) {
-	c := context.TODO()
+	tc := setupTest(t, "ddcn")
+	mctx := libkb.NewMetaContextForTest(*tc)
+
 	dismisser := &libkb.FakeGregorState{}
 	exceptedDeviceID := "active-device-id"
 	state := &FakeGregorState{
@@ -414,7 +416,7 @@ func TestDismissDeviceChangeNotifications(t *testing.T) {
 		gregor1.MsgID("dismissable-2"),
 	}
 	require.Equal(t, []gregor.MsgID(nil), dismisser.PeekDismissedIDs())
-	err := service.LoopAndDismissForDeviceChangeNotifications(c, dismisser,
+	err := service.LoopAndDismissForDeviceChangeNotifications(mctx, dismisser,
 		state, exceptedDeviceID)
 	require.NoError(t, err)
 	require.Equal(t, expectedDismissedIDs, dismisser.PeekDismissedIDs())


### PR DESCRIPTION
add some logging to this flow so it's easier to distinguish between the error case of the RPC not being called, and the RPC being called but not doing anything.