### PR TITLE
rpc_cache: for best effort, only wait a short time for handler

### DIFF
--- a/go/offline/rpc_cache.go
+++ b/go/offline/rpc_cache.go
@@ -137,10 +137,7 @@ func (c *RPCCache) put(mctx libkb.MetaContext, version Version, rpcName string, 
 // success case. We also pass this function a `version`, which will
 // tell the cache-access machinery to fail if the wrong version of the
 // data is cached. Next, we pass the `rpcName`, the argument, and the
-// pointer to which the result is stored if we hit the cache. This
-// flow is unfortunately complicated, but the issue is that we're
-// trying to maintain runtime type checking, and it's hard to do
-// without generics.
+// pointer to which the result is stored if we hit the cache.
 //
 // If this function doesn't return an error, and the returned `res` is
 // nil, then `resPtr` will have been filled in already by the cache.
@@ -176,10 +173,9 @@ func (c *RPCCache) Serve(mctx libkb.MetaContext, oa keybase1.OfflineAvailability
 	resCh := make(chan handlerRes, 1)
 
 	// New goroutine needs a new metacontext, in case the original
-	// gets canceled after the timeout below.
-	newMctx := libkb.NewMetaContextBackground(mctx.G())
-	newMctx = newMctx.WithLogTag("OFLN")
-	mctx.Debug("RPCCache#Serve: Launching background best-effort handler with debug tags %s", libkb.LogTagsToString(newMctx.Ctx()))
+	// gets canceled after the timeout below.  Preserve the log tags
+	// though.
+	newMctx := mctx.BackgroundWithLogTags()
 
 	// Launch a background goroutine to try to invoke the handler.
 	// Even if we hit a timeout below and return the cached value,

--- a/go/offline/rpc_cache_test.go
+++ b/go/offline/rpc_cache_test.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package offline
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCCacheBestEffort(t *testing.T) {
+	tc := libkb.SetupTest(t, "RPCCache()", 1)
+	fakeClock := clockwork.NewFakeClock()
+	tc.G.SetClock(fakeClock)
+
+	rpcCache := NewRPCCache(tc.G)
+
+	inHandlerCh := make(chan struct{}, 1)
+	handlerCh := make(chan interface{}, 1)
+	handler := func(mctx libkb.MetaContext) (interface{}, error) {
+		inHandlerCh <- struct{}{}
+		return <-handlerCh, nil
+	}
+
+	mctx := libkb.NewMetaContextBackground(tc.G)
+
+	t.Log("Populate the cache via the handler")
+	rpc := "TestRPC"
+	key := 1
+	value := 2
+	handlerCh <- value
+	var res int
+	resp := &res
+	servedRes, err := rpcCache.Serve(
+		mctx, keybase1.OfflineAvailability_BEST_EFFORT, 1, rpc, false,
+		key, resp, handler)
+	require.NoError(t, err)
+	require.Equal(t, 0, res) // `res` isn't filled in when the handler is used.
+	require.Equal(t, value, servedRes.(int))
+	<-inHandlerCh
+
+	t.Log("Read via the handler, when the cache is populated")
+	var res2 int
+	resp2 := &res2
+	handlerCh <- value
+	servedRes2, err := rpcCache.Serve(
+		mctx, keybase1.OfflineAvailability_BEST_EFFORT, 1, rpc, false,
+		key, resp2, handler)
+	require.NoError(t, err)
+	require.Equal(t, 2, res2) // `res` is filled in by the cache, but shouldn't be used because `servedRes2` is also filled in.
+	require.Equal(t, value, servedRes2.(int))
+	<-inHandlerCh
+
+	t.Log("Read via the cache, when connected but the handler is slow")
+	var res3 int
+	resp3 := &res3
+	var servedRes3 interface{}
+	errCh := make(chan error)
+	go func() {
+		var err error
+		servedRes3, err = rpcCache.Serve(
+			mctx, keybase1.OfflineAvailability_BEST_EFFORT, 1, rpc, false,
+			key, resp3, handler)
+		errCh <- err
+	}()
+
+	// Wait for the handler to be entered, then advance the clock.
+	<-inHandlerCh
+	fakeClock.Advance(bestEffortHandlerTimeout + 1)
+	err = <-errCh
+	require.NoError(t, err)
+	require.Equal(t, 2, res3)
+	require.Nil(t, servedRes3) // The filled-in cached value should be used.
+}

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -75,21 +75,22 @@ func (h *IdentifyHandler) Identify2(netCtx context.Context, arg keybase1.Identif
 func (h *IdentifyHandler) IdentifyLite(netCtx context.Context, arg keybase1.IdentifyLiteArg) (ret keybase1.IdentifyLiteRes, err error) {
 	mctx := libkb.NewMetaContext(netCtx, h.G()).WithLogTag("IDL")
 	defer mctx.Trace("IdentifyHandler#IdentifyLite", func() error { return err })()
-	retp := &ret
 	loader := func(mctx libkb.MetaContext) (interface{}, error) {
-		tmp, err := h.identifyLite(mctx, arg)
-		if err == nil {
-			*retp = tmp
-		}
-		return tmp, err
+		return h.identifyLite(mctx, arg)
 	}
 	cacheArg := keybase1.IdentifyLiteArg{
 		Id:               arg.Id,
 		Assertion:        arg.Assertion,
 		IdentifyBehavior: arg.IdentifyBehavior,
 	}
-	err = h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.identifyLite", false, cacheArg, retp, loader)
-	return ret, err
+	servedRet, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.identifyLite", false, cacheArg, &ret, loader)
+	if err != nil {
+		return servedRet.(keybase1.IdentifyLiteRes), err
+	}
+	if s, ok := servedRet.(keybase1.IdentifyLiteRes); ok {
+		ret = s
+	}
+	return ret, nil
 }
 
 func (h *IdentifyHandler) identifyLite(mctx libkb.MetaContext, arg keybase1.IdentifyLiteArg) (res keybase1.IdentifyLiteRes, err error) {
@@ -171,15 +172,16 @@ func (h *IdentifyHandler) identifyLiteUser(netCtx context.Context, arg keybase1.
 func (h *IdentifyHandler) Resolve3(ctx context.Context, arg keybase1.Resolve3Arg) (ret keybase1.UserOrTeamLite, err error) {
 	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("RSLV")
 	defer mctx.Trace(fmt.Sprintf("IdentifyHandler#Resolve3(%+v)", arg), func() error { return err })()
-	retp := &ret
-	err = h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.resolve3", false, arg, retp, func(mctx libkb.MetaContext) (interface{}, error) {
-		tmp, err := h.resolveUserOrTeam(mctx.Ctx(), arg.Assertion)
-		if err == nil {
-			*retp = tmp
-		}
-		return tmp, err
+	servedRet, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.resolve3", false, arg, &ret, func(mctx libkb.MetaContext) (interface{}, error) {
+		return h.resolveUserOrTeam(mctx.Ctx(), arg.Assertion)
 	})
-	return ret, err
+	if err != nil {
+		return keybase1.UserOrTeamLite{}, err
+	}
+	if s, ok := servedRet.(keybase1.UserOrTeamLite); ok {
+		ret = s
+	}
+	return ret, nil
 }
 
 func (h *IdentifyHandler) resolveUserOrTeam(ctx context.Context, arg string) (u keybase1.UserOrTeamLite, err error) {
@@ -207,15 +209,18 @@ func (h *IdentifyHandler) ResolveIdentifyImplicitTeam(ctx context.Context, arg k
 		IsPublic:   arg.IsPublic,
 	}
 
-	resp := &res
-	err = h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.resolveIdentifyImplicitTeam", false, cacheArg, resp, func(mctx libkb.MetaContext) (interface{}, error) {
-		tmp, err := h.resolveIdentifyImplicitTeamHelper(mctx.Ctx(), arg, writerAssertions, readerAssertions)
-		*resp = tmp
-		return tmp, err
+	servedRes, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.resolveIdentifyImplicitTeam", false, cacheArg, &res, func(mctx libkb.MetaContext) (interface{}, error) {
+		return h.resolveIdentifyImplicitTeamHelper(mctx.Ctx(), arg, writerAssertions, readerAssertions)
 	})
 
+	if s, ok := servedRes.(keybase1.ResolveIdentifyImplicitTeamRes); ok {
+		// We explicitly want to return `servedRes` here, when err !=
+		// nil, as the caller might depend on it in certain cases.
+		res = s
+	} else if err != nil {
+		res = keybase1.ResolveIdentifyImplicitTeamRes{}
+	}
 	mctx.Debug("res: {displayName: %s, teamID: %s, folderID: %s}", res.DisplayName, res.TeamID, res.FolderID)
-
 	return res, err
 }
 


### PR DESCRIPTION
But the handler should still run to completion, in order to populate the cache for next time.

Because the handler could keep running after the function returns, there's a new requirement that the handler cannot modify variables directly in the caller's stack.  Instead, if the handler's value is returned directly from `Serve()` if it is used, and the caller must check whether it should be using the returned value, or the value in `resPtr` filled in by the cache.

Ah the joys of generics in Go.

It looks like all current users of the RPC cache are RPC handlers in service that reply directly to the user, so I don't think this introduces any new problems of out-of-date values sitting in other in-memory service caches that never get invalidated.

With this change, a kbfsdocker test that disables kbweb connectivity while reading a synced TLF passes.

Issue: KBFS-3948