### PR TITLE
folder_branch_ops: don't run mark-and-sweep for recent-edit syncs

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1638,7 +1638,7 @@ func (c *ConfigLocal) OfflineAvailabilityForPath(
 // interface for ConfigLocal.
 func (c *ConfigLocal) OfflineAvailabilityForID(
 	tlfID tlf.ID) keybase1.OfflineAvailability {
-	if c.IsSyncedTlf(tlfID) {
+	if c.GetTlfSyncState(tlfID).Mode != keybase1.FolderSyncMode_DISABLED {
 		return keybase1.OfflineAvailability_BEST_EFFORT
 	}
 	return keybase1.OfflineAvailability_NONE

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1030,7 +1030,11 @@ func (fbo *folderBranchOps) kickOffPartialSync(
 		}()
 	}
 
-	// Kick off amark-and-sweep if one doesn't exist yet.
+	if syncConfig.Mode != keybase1.FolderSyncMode_PARTIAL {
+		return
+	}
+
+	// Kick off a mark-and-sweep for synced TLFs if one doesn't exist yet.
 	fbo.syncLock.Lock(lState)
 	defer fbo.syncLock.Unlock(lState)
 	if fbo.markAndSweepTrigger == nil {


### PR DESCRIPTION
We only need to mark-and-sweep out of the sync cache.  Recent-edit syncs put blocks into the working set cache.