### PR TITLE
folder_branch_ops: improve behavior when using an out-of-date, cached MD

### DIFF
--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -3169,6 +3169,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	require.NoError(t, err)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -3179,10 +3180,10 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	// Shutdown the mdserver explicitly before the state checker tries to run
 	defer config2.MDServer().Shutdown()
 
-	_, err = GetRootNodeForTest(ctx, config2, "test_user", tlf.Private)
-	if _, ok := errors.Cause(err).(kbfshash.HashMismatchError); !ok {
-		t.Fatalf("Could unexpectedly lookup the file: %+v", err)
-	}
+	rootNode2, err := GetRootNodeForTest(ctx, config2, "test_user", tlf.Private)
+	require.NoError(t, err)
+	_, err = config2.KBFSOps().GetDirChildren(ctx, rootNode2)
+	require.IsType(t, kbfshash.HashMismatchError{}, errors.Cause(err))
 }
 
 // Test that the size of a single empty block doesn't change.  If this


### PR DESCRIPTION
If the device loads an old MD from the cache, and is online but can't contact the mdserver fast enough to fetch the latest one, `folderBranchOps` was erroring out before it registered for updates on the TLF (while trying to fetch the root block), and was passing that ugly "block does not exist" error onto the caller.

Instead:
1. Ignore root-block-fetch errors when setting the initial head of the TLF, but if it happens avoid committing that MD to disk.  This way we will still register for updates and get them whenever we can get them over the network.
2. Transform the "block does not exist" error into one about not being able to read the TLF while offline, which causes a nicer toast popup on desktop and could be specially handled by the GUI if desired.

Issue: KBFS-3946