### PR TITLE
add more logging for CreateTLF and also don't mash an already-associated TLF

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1224,6 +1224,10 @@ func (t TLFID) ToBytes() []byte {
 	return b
 }
 
+func (t TLFID) Eq(u TLFID) bool {
+	return t == u
+}
+
 func (b TLFIdentifyBehavior) UnblockThenForceIDTable() bool {
 	switch b {
 	case TLFIdentifyBehavior_GUI_PROFILE:

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -30,6 +30,47 @@ func newImplicitTLFID(public bool) keybase1.TLFID {
 	return keybase1.TLFID(hex.EncodeToString(idBytes))
 }
 
+func TestImplicitRaceCreateTLFs(t *testing.T) {
+	tc := SetupTest(t, "team", 1)
+	defer tc.Cleanup()
+	u, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
+	require.NoError(t, err)
+	displayName := u.Username
+	_, _, _, err = LookupImplicitTeam(context.TODO(), tc.G, displayName, false, ImplicitTeamOptions{})
+	require.Error(t, err)
+	require.IsType(t, TeamDoesNotExistError{}, err)
+	createdTeam, _, impTeamName, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, displayName, false)
+	require.NoError(t, err)
+	tlfid0 := createdTeam.LatestKBFSTLFID()
+	require.False(t, impTeamName.IsPublic)
+	require.True(t, tlfid0.IsNil())
+	tlfid1 := newImplicitTLFID(true)
+	n := 4
+	doneCh := make(chan struct{}, n+1)
+	for i := 0; i < n; i++ {
+		go func() {
+			err = CreateTLF(context.TODO(), tc.G, keybase1.CreateTLFArg{TeamID: createdTeam.ID, TlfID: tlfid1})
+			require.NoError(t, err)
+			doneCh <- struct{}{}
+		}()
+	}
+	for i := 0; i < n; i++ {
+		select {
+		case <-doneCh:
+		case <-time.After(time.Minute):
+			t.Fatal("failed to get racing racers back")
+		}
+		tc.G.Log.Debug("Got finisher %d", i)
+	}
+	// second time, LookupOrCreate should Lookup the team just created.
+	createdTeam2, _, impTeamName2, err := LookupOrCreateImplicitTeam(context.TODO(), tc.G, displayName, false)
+	require.NoError(t, err)
+	tlfid2 := createdTeam2.LatestKBFSTLFID()
+	require.Equal(t, createdTeam.ID, createdTeam2.ID)
+	require.Equal(t, impTeamName, impTeamName2, "public: %v", false)
+	require.Equal(t, tlfid1, tlfid2, "the right TLFID came back")
+}
+
 func TestLookupImplicitTeams(t *testing.T) {
 	tc := SetupTest(t, "team", 1)
 	defer tc.Cleanup()
@@ -56,6 +97,10 @@ func TestLookupImplicitTeams(t *testing.T) {
 		require.True(t, tlfid0.IsNil())
 
 		tlfid1 := newImplicitTLFID(public)
+		err = CreateTLF(context.TODO(), tc.G, keybase1.CreateTLFArg{TeamID: createdTeam.ID, TlfID: tlfid1})
+		require.NoError(t, err)
+
+		// We can double this, and it still should work (and noop the second Time)
 		err = CreateTLF(context.TODO(), tc.G, keybase1.CreateTLFArg{TeamID: createdTeam.ID, TlfID: tlfid1})
 		require.NoError(t, err)
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1463,6 +1463,7 @@ func CreateSeitanTokenV2(ctx context.Context, g *libkb.GlobalContext, teamname s
 // Should work on either named or implicit teams.
 func CreateTLF(ctx context.Context, g *libkb.GlobalContext, arg keybase1.CreateTLFArg) (err error) {
 	defer g.CTrace(ctx, fmt.Sprintf("CreateTLF(%v)", arg), func() error { return err })()
+	ctx = libkb.WithLogTag(ctx, "CREATETLF")
 	return RetryOnSigOldSeqnoError(ctx, g, func(ctx context.Context, _ int) error {
 		t, err := GetForTeamManagementByTeamID(ctx, g, arg.TeamID, false)
 		if err != nil {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1923,6 +1923,11 @@ func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (er
 	m := t.MetaContext(ctx)
 	defer m.Trace("Team.AssociateWithTLFID", func() error { return err })()
 
+	if tlfID.Eq(t.LatestKBFSTLFID()) {
+		m.Debug("No updated needed, TLFID already set to %s", tlfID)
+		return nil
+	}
+
 	teamSection := SCTeamSection{
 		ID:       SCTeamID(t.ID),
 		Implicit: t.IsImplicit(),


### PR DESCRIPTION
- it turns out the server is OK with a duplicated A<->B association, but let's just not send it, it's not needed
- I don't even think this solves CORE-10316, but we'll need server logs to figure that one out
- add a test that mashes