### PR TITLE
On PGP rows, also plumb through KIDs

### DIFF
--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -316,8 +316,6 @@ func (i *UIAdapter) displayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey)
 		return
 	}
 
-	kid := key.KID
-
 	arg := keybase1.Identify3Row{
 		Key:      "pgp",
 		Value:    hex.EncodeToString(key.PGPFingerprint),
@@ -329,7 +327,7 @@ func (i *UIAdapter) displayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey)
 		ProofURL:     i.makeSigchainViewURL(mctx, key.SigID),
 		SiteIcon:     externals.MakeIcons(mctx, "pgp", "logo_black", 16),
 		SiteIconFull: externals.MakeIcons(mctx, "pgp", "logo_full", 64),
-		Kid:          &kid,
+		Kid:          &key.KID,
 	}
 
 	switch {

--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -316,6 +316,8 @@ func (i *UIAdapter) displayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey)
 		return
 	}
 
+	kid := key.KID
+
 	arg := keybase1.Identify3Row{
 		Key:      "pgp",
 		Value:    hex.EncodeToString(key.PGPFingerprint),
@@ -327,6 +329,7 @@ func (i *UIAdapter) displayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey)
 		ProofURL:     i.makeSigchainViewURL(mctx, key.SigID),
 		SiteIcon:     externals.MakeIcons(mctx, "pgp", "logo_black", 16),
 		SiteIconFull: externals.MakeIcons(mctx, "pgp", "logo_full", 64),
+		Kid:          &kid,
 	}
 
 	switch {

--- a/go/protocol/keybase1/identify3_ui.go
+++ b/go/protocol/keybase1/identify3_ui.go
@@ -142,6 +142,7 @@ type Identify3Row struct {
 	State        Identify3RowState  `codec:"state" json:"state"`
 	Metas        []Identify3RowMeta `codec:"metas" json:"metas"`
 	Color        Identify3RowColor  `codec:"color" json:"color"`
+	Kid          *KID               `codec:"kid,omitempty" json:"kid,omitempty"`
 }
 
 func (o Identify3Row) DeepCopy() Identify3Row {
@@ -189,6 +190,13 @@ func (o Identify3Row) DeepCopy() Identify3Row {
 			return ret
 		})(o.Metas),
 		Color: o.Color.DeepCopy(),
+		Kid: (func(x *KID) *KID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Kid),
 	}
 }
 

--- a/protocol/avdl/keybase1/identify3_ui.avdl
+++ b/protocol/avdl/keybase1/identify3_ui.avdl
@@ -59,7 +59,8 @@ protocol identify3Ui {
     Time ctime;                    // sometimes it's zero.
     Identify3RowState state;       // 'checking' | 'valid' | 'error' | 'warning' | 'revoked',
     array<Identify3RowMeta> metas; // things like 'upgraded' | 'new' | 'unreachable' | 'pending' | 'deleted' | 'none' | 'ignored', but can be anything
-    Identify3RowColor color;        // 'blue' | 'red' | 'black' | 'green' | 'gray'
+    Identify3RowColor color;       // 'blue' | 'red' | 'black' | 'green' | 'gray'
+    union { null, KID } kid;       // in the case of PGP key, also send the KID so that we can revoke by kid
   }
 
   @lint("ignore")

--- a/protocol/json/keybase1/identify3_ui.json
+++ b/protocol/json/keybase1/identify3_ui.json
@@ -121,6 +121,13 @@
         {
           "type": "Identify3RowColor",
           "name": "color"
+        },
+        {
+          "type": [
+            null,
+            "KID"
+          ],
+          "name": "kid"
         }
       ]
     }

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -2253,7 +2253,7 @@ export type Identify3ResultType =
   | 2 // NEEDS_UPGRADE_2
   | 3 // CANCELED_3
 
-export type Identify3Row = $ReadOnly<{guiID: Identify3GUIID, key: String, value: String, priority: Int, siteURL: String, siteIcon?: ?Array<SizedImage>, siteIconFull?: ?Array<SizedImage>, proofURL: String, sigID: SigID, ctime: Time, state: Identify3RowState, metas?: ?Array<Identify3RowMeta>, color: Identify3RowColor}>
+export type Identify3Row = $ReadOnly<{guiID: Identify3GUIID, key: String, value: String, priority: Int, siteURL: String, siteIcon?: ?Array<SizedImage>, siteIconFull?: ?Array<SizedImage>, proofURL: String, sigID: SigID, ctime: Time, state: Identify3RowState, metas?: ?Array<Identify3RowMeta>, color: Identify3RowColor, kid?: ?KID}>
 export type Identify3RowColor =
   | 1 // BLUE_1
   | 2 // RED_2


### PR DESCRIPTION
- revokes should happen by KID and not by PGP fingerprints