### PR TITLE
Remove extraneous path component in navigateToAccount

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -249,8 +249,8 @@ const clearBuilding = () => WalletsGen.createClearBuilding()
 const clearErrors = () => WalletsGen.createClearErrors()
 
 const loadWalletDisclaimer = () =>
-  RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise(undefined, Constants.checkOnlineWaitingKey).then(accepted =>
-    WalletsGen.createWalletDisclaimerReceived({accepted}),
+  RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise(undefined, Constants.checkOnlineWaitingKey).then(
+    accepted => WalletsGen.createWalletDisclaimerReceived({accepted})
   )
 
 const loadAccounts = (state, action) => {
@@ -645,7 +645,7 @@ const navigateToAccount = (state, action) => {
   }
   const wallet = isMobile
     ? [Tabs.settingsTab, SettingsConstants.walletsTab]
-    : [{props: {}, selected: Tabs.walletsTab}, {props: {}, selected: null}]
+    : [{props: {}, selected: Tabs.walletsTab}]
 
   return RouteTreeGen.createNavigateTo({path: wallet})
 }


### PR DESCRIPTION
This makes it so that switching wallets changes to the top wallet page,
even if you're on a deeper page in the current wallet. In particular,
if you're on a transaction detail page and you switch wallets, you won't
get a broken transaction page.