### PR TITLE
Fix TestSetPhoneNumber by generating random numbers

### DIFF
--- a/go/phonenumbers/user_test.go
+++ b/go/phonenumbers/user_test.go
@@ -3,6 +3,8 @@
 package phonenumbers
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/keybase/client/go/kbtest"
@@ -18,7 +20,16 @@ func TestSetPhoneNumber(t *testing.T) {
 	me, err := kbtest.CreateAndSignupFakeUser("phon", tc.G)
 	require.NoError(t, err)
 
-	phoneNumber := keybase1.PhoneNumber("+14155552671")
+	// Generate a random phone number e.g. "14155552671".
+	randomNumber := kbtest.GenerateTestPhoneNumber()
+	// In strict format: "+14155552671".
+	phoneNumber := keybase1.PhoneNumber("+" + randomNumber)
+	// Create a representation likely to come from phone contact book: "+1-415-555-2671".
+	phoneFormatted := keybase1.RawPhoneNumber(fmt.Sprintf("+%s-%s-%s-%s", randomNumber[0:1], randomNumber[1:4], randomNumber[4:7], randomNumber[7:11]))
+	// Sanity check.
+	require.EqualValues(t, phoneNumber, strings.Replace(string(phoneFormatted), "-", "", -1))
+
+	t.Logf("Generated phone number: %q formatted as %q", phoneNumber, phoneFormatted)
 
 	mctx := libkb.NewMetaContextForTest(tc)
 
@@ -41,7 +52,7 @@ func TestSetPhoneNumber(t *testing.T) {
 	require.True(t, resp[0].Verified)
 
 	contactList := []keybase1.RawPhoneNumber{
-		"+1-415-555-2671",
+		phoneFormatted,
 	}
 	regionCodes := []keybase1.RegionCode{
 		"us",
@@ -53,8 +64,8 @@ func TestSetPhoneNumber(t *testing.T) {
 	myUID := me.GetUID()
 	expectedResolutions := []keybase1.PhoneNumberLookupResult{
 		keybase1.PhoneNumberLookupResult{
-			PhoneNumber:        "+1-415-555-2671",
-			CoercedPhoneNumber: "+14155552671",
+			PhoneNumber:        phoneFormatted,
+			CoercedPhoneNumber: phoneNumber,
 			Err:                nil,
 			Uid:                &myUID,
 		},


### PR DESCRIPTION
This test just happened to be ran by both windows and linux container on CI at the same time, and it completely broke because of hardcoded phone number. Use random number instead.