### PR TITLE
Transport more like http.DefaultTransport, extra_net_logging option

### DIFF
--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -406,6 +406,10 @@ func (p CommandLine) GetEnableBotLiteMode() (bool, bool) {
 	return p.GetBool("enable-bot-lite-mode", true)
 }
 
+func (p CommandLine) GetExtraNetLogging() (bool, bool) {
+	return p.GetBool("extra-net-logging", true)
+}
+
 func (p CommandLine) GetAttachmentHTTPStartPort() (int, bool) {
 	ret := p.GetGInt("attachment-httpsrv-port")
 	if ret != 0 {

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -365,7 +365,9 @@ func doRequestShared(m MetaContext, api Requester, arg APIArg, req *http.Request
 // well; a canceler function func() that the caller should call after all work is completed
 // on this request; and an error. The canceler function is to clean up the timeout.
 func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (res *http.Response, cancel func(), err error) {
-	defer m.TraceTimed("api.doRetry", func() error { return err })()
+	if m.G().Env.GetExtraNetLogging() {
+		defer m.TraceTimed("api.doRetry", func() error { return err })()
+	}
 
 	// This serves as a proxy for checking the status of the Gregor connection. If we are not
 	// connected to Gregor, then it is likely the case we are totally offline, or on a very bad
@@ -431,7 +433,9 @@ func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (res *ht
 // a canceler, and an error. The canceler ought to be called before the caller (or its caller) is done
 // with this request.
 func doTimeout(m MetaContext, cli *Client, req *http.Request, timeout time.Duration) (res *http.Response, cancel func(), err error) {
-	defer m.TraceTimed("api.doTimeout", func() error { return err })()
+	if m.G().Env.GetExtraNetLogging() {
+		defer m.TraceTimed("api.doTimeout", func() error { return err })()
+	}
 	// check to see if the current context is canceled
 	select {
 	case <-m.Ctx().Done():

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -139,7 +139,7 @@ func (api *BaseAPIEngine) getCli(cookied bool) (ret *Client) {
 	client, found := api.clients[key]
 	if !found {
 		api.G().Log.Debug("| Cli wasn't found; remaking for cookied=%v", cookied)
-		client = NewClient(api.G().Env, api.config, cookied)
+		client = NewClient(api.G(), api.config, cookied)
 		api.clients[key] = client
 	}
 	api.clientsMu.Unlock()
@@ -364,7 +364,8 @@ func doRequestShared(m MetaContext, api Requester, arg APIArg, req *http.Request
 // retry them arg.RetryCount times. It returns 3 values: the HTTP response, if all goes
 // well; a canceler function func() that the caller should call after all work is completed
 // on this request; and an error. The canceler function is to clean up the timeout.
-func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (*http.Response, func(), error) {
+func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (res *http.Response, cancel func(), err error) {
+	defer m.TraceTimed("api.doRetry", func() error { return err })()
 
 	// This serves as a proxy for checking the status of the Gregor connection. If we are not
 	// connected to Gregor, then it is likely the case we are totally offline, or on a very bad
@@ -376,8 +377,8 @@ func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (*http.R
 	}
 
 	if arg.InitialTimeout == 0 && arg.RetryCount == 0 {
-		resp, err := ctxhttp.Do(m.Ctx(), cli.cli, req)
-		return resp, nil, err
+		res, err = ctxhttp.Do(m.Ctx(), cli.cli, req)
+		return res, nil, err
 	}
 
 	timeout := cli.cli.Timeout
@@ -400,9 +401,9 @@ func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (*http.R
 		if i > 0 {
 			m.Debug("retry attempt %d of %d for %s", i, retries, arg.Endpoint)
 		}
-		resp, canc, err := doTimeout(m, cli, req, timeout)
+		res, cancel, err = doTimeout(m, cli, req, timeout)
 		if err == nil {
-			return resp, canc, nil
+			return res, cancel, nil
 		}
 		lastErr = err
 		timeout = time.Duration(float64(timeout) * multiplier)
@@ -429,7 +430,8 @@ func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (*http.R
 // doTimeout does the http request with a timeout. It returns the response from making the HTTP request,
 // a canceler, and an error. The canceler ought to be called before the caller (or its caller) is done
 // with this request.
-func doTimeout(m MetaContext, cli *Client, req *http.Request, timeout time.Duration) (*http.Response, func(), error) {
+func doTimeout(m MetaContext, cli *Client, req *http.Request, timeout time.Duration) (res *http.Response, cancel func(), err error) {
+	defer m.TraceTimed("api.doTimeout", func() error { return err })()
 	// check to see if the current context is canceled
 	select {
 	case <-m.Ctx().Done():
@@ -437,8 +439,8 @@ func doTimeout(m MetaContext, cli *Client, req *http.Request, timeout time.Durat
 	default:
 	}
 	ctx, cancel := context.WithTimeout(m.Ctx(), timeout*CITimeMultiplier(m.G()))
-	resp, err := ctxhttp.Do(ctx, cli.cli, req)
-	return resp, cancel, err
+	res, err = ctxhttp.Do(ctx, cli.cli, req)
+	return res, cancel, err
 }
 
 func checkHTTPStatus(arg APIArg, resp *http.Response) error {

--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc/resinit"
+	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 
 	"h12.me/socks"
@@ -137,18 +138,32 @@ func genClientConfigForScrapers(e *Env) (*ClientConfig, error) {
 	}, nil
 }
 
-func NewClient(e *Env, config *ClientConfig, needCookie bool) *Client {
+func NewClient(g *GlobalContext, config *ClientConfig, needCookie bool) *Client {
+	g.Log.Debug("api.Client:%v New", needCookie)
+	env := g.Env
 	var jar *cookiejar.Jar
-	if needCookie && (config == nil || config.UseCookies) && e.GetTorMode().UseCookies() {
+	if needCookie && (config == nil || config.UseCookies) && env.GetTorMode().UseCookies() {
 		jar, _ = cookiejar.New(nil)
 	}
 
-	var xprt http.Transport
-	var timeout time.Duration
+	dialer := net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}
+	xprt := http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&dialer).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 
-	xprt.Dial = func(network, addr string) (c net.Conn, err error) {
-		c, err = net.Dial(network, addr)
+	xprt.DialContext = func(ctx context.Context, network, addr string) (c net.Conn, err error) {
+		c, err = dialer.DialContext(ctx, network, addr)
 		if err != nil {
+			g.Log.CDebugf(ctx, "api.Client:%v transport.Dial err=%v", needCookie, err)
 			// If we get a DNS error, it could be because glibc has cached an
 			// old version of /etc/resolv.conf. The res_init() libc function
 			// busts that cache and keeps us from getting stuck in a state
@@ -159,25 +174,29 @@ func NewClient(e *Env, config *ClientConfig, needCookie bool) *Client {
 			return c, err
 		}
 		if err = rpc.DisableSigPipe(c); err != nil {
+			g.Log.CDebugf(ctx, "api.Client:%v transport.Dial DisableSigPipe err=%v", needCookie, err)
 			return c, err
 		}
 		return c, nil
 	}
 
-	if (config != nil && config.RootCAs != nil) || e.GetTorMode().Enabled() {
+	if (config != nil && config.RootCAs != nil) || env.GetTorMode().Enabled() {
 		if config != nil && config.RootCAs != nil {
 			xprt.TLSClientConfig = &tls.Config{RootCAs: config.RootCAs}
 		}
-		if e.GetTorMode().Enabled() {
+		if env.GetTorMode().Enabled() {
+			g.Log.Debug("api.Client:%v tor mode enabled", needCookie)
 			// TODO: should we call res_init on DNS errors here as well?
-			dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, e.GetTorProxy())
-			xprt.Dial = dialSocksProxy
+			dialSocksProxy := socks.DialSocksProxy(socks.SOCKS5, env.GetTorProxy())
+			xprt.DialContext = func(ctx context.Context, network, addr string) (c net.Conn, err error) {
+				return dialSocksProxy(network, addr)
+			}
 		} else {
 			xprt.Proxy = http.ProxyFromEnvironment
 		}
 	}
 
-	if !e.GetTorMode().Enabled() && e.GetRunMode() == DevelRunMode {
+	if !env.GetTorMode().Enabled() && env.GetRunMode() == DevelRunMode {
 		xprt.Proxy = func(req *http.Request) (*url.URL, error) {
 			host, port, err := net.SplitHostPort(req.URL.Host)
 			if err == nil && host == "localhost" {
@@ -195,6 +214,7 @@ func NewClient(e *Env, config *ClientConfig, needCookie bool) *Client {
 		}
 	}
 
+	var timeout time.Duration
 	if config == nil || config.Timeout == 0 {
 		timeout = HTTPDefaultTimeout
 	} else {
@@ -209,7 +229,9 @@ func NewClient(e *Env, config *ClientConfig, needCookie bool) *Client {
 		ret.cli.Jar = jar
 	}
 
-	http2.ConfigureTransport(&xprt)
+	if err := http2.ConfigureTransport(&xprt); err != nil {
+		g.Log.Debug("api.Client:%v New configuring http2 err=%v", err)
+	}
 	ret.cli.Transport = &xprt
 	return ret
 }

--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -156,6 +156,7 @@ func NewClient(g *GlobalContext, config *ClientConfig, needCookie bool) *Client 
 		jar, _ = cookiejar.New(nil)
 	}
 
+	// Originally copied from http.DefaultTransport
 	dialer := net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -879,6 +879,10 @@ func (f *JSONConfigFile) GetEnableBotLiteMode() (bool, bool) {
 	return f.GetBoolAtPath("enable_bot_lite_mode")
 }
 
+func (f *JSONConfigFile) GetExtraNetLogging() (bool, bool) {
+	return f.GetBoolAtPath("extra_net_logging")
+}
+
 func (f *JSONConfigFile) GetChatOutboxStorageEngine() string {
 	s, _ := f.GetStringAtPath("chat_outboxstorageengine")
 	return s

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -117,6 +117,7 @@ func (n NullConfiguration) GetDisableMerkleAuditor() (bool, bool)           { re
 func (n NullConfiguration) GetDisableSearchIndexer() (bool, bool)           { return false, false }
 func (n NullConfiguration) GetDisableBgConvLoader() (bool, bool)            { return false, false }
 func (n NullConfiguration) GetEnableBotLiteMode() (bool, bool)              { return false, false }
+func (n NullConfiguration) GetExtraNetLogging() (bool, bool)                { return false, false }
 func (n NullConfiguration) GetChatOutboxStorageEngine() string              { return "" }
 func (n NullConfiguration) GetBug3964RepairTime(NormalizedUsername) (time.Time, error) {
 	return time.Time{}, nil
@@ -951,6 +952,14 @@ func (e *Env) GetEnableBotLiteMode() bool {
 		e.cmd.GetEnableBotLiteMode,
 		func() (bool, bool) { return e.getEnvBool("KEYBASE_ENABLE_BOT_LITE_MODE") },
 		e.GetConfig().GetEnableBotLiteMode,
+	)
+}
+
+func (e *Env) GetExtraNetLogging() bool {
+	return e.GetBool(false,
+		e.cmd.GetExtraNetLogging,
+		func() (bool, bool) { return e.getEnvBool("KEYBASE_EXTRA_NET_LOGGING") },
+		e.GetConfig().GetExtraNetLogging,
 	)
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -106,6 +106,7 @@ type configGetter interface {
 	GetDisableSearchIndexer() (bool, bool)
 	GetDisableBgConvLoader() (bool, bool)
 	GetEnableBotLiteMode() (bool, bool)
+	GetExtraNetLogging() (bool, bool)
 }
 
 type CommandLine interface {


### PR DESCRIPTION
A couple people have seen issues where an api client gets disabled after waking from sleep on linux.

The `http.RoundTripper` being used started out as default-valued `var xprt http.Transport` and then had some settings changed. I don't know that that default-valued struct has a particularly good meaning. This patch switches the transport to be based on [`http.DefaultTransport`](https://golang.org/pkg/net/http/#RoundTripper)

Hopefully that shot in the dark will fix it. I'm eyeing `IdleConnTimeout`. Otherwise though this adds some extra logging that I'll ask those users to enable.