### PR TITLE
Fix initial team banner state

### DIFF
--- a/shared/teams/main/index.js
+++ b/shared/teams/main/index.js
@@ -87,7 +87,8 @@ type State = {
   sawChatBanner: boolean,
 }
 class Teams extends React.PureComponent<Props, State> {
-  state = {sawChatBanner: false}
+  state = {sawChatBanner: this.props.sawChatBanner}
+
   _teamsAndExtras = memoize((sawChatBanner, teamnames) => [
     {key: '_banner', type: '_banner'},
     ...teamnames.map(t => ({key: t, team: t, type: 'team'})),


### PR DESCRIPTION
@keybase/react-hackers 

I had a `componentDidUpdate` keeping state in sync with props, but that doesn't help for the first render, so need to initialize it correctly too.  (The banner was showing up every time.)