### PR TITLE
Show following/broken username status colors on flip participants.

### DIFF
--- a/shared/chat/conversation/messages/coinflip/participants.js
+++ b/shared/chat/conversation/messages/coinflip/participants.js
@@ -25,6 +25,8 @@ const CoinFlipParticipants = (props: Props) => {
         <Kb.ScrollView style={styles.partContainer}>
           {props.participants.map(p => (
             <Kb.NameWithIcon
+              colorBroken={true}
+              colorFollowing={true}
               key={`${p.username}${p.deviceName}`}
               horizontal={true}
               username={p.username}


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review.