### PR TITLE
libkbfs: two fixes to prevent double archiving of block pointers

### DIFF
--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -856,7 +856,6 @@ func getUnrefPointersFromMD(
 			// See syncInfo.replaceRemovedBlock for an example
 			// of how this can happen.
 			if ptr != zeroPtr && !ptrMap[ptr] {
-				ptrs = append(ptrs, ptr)
 				ptrMap[ptr] = true
 			}
 		}
@@ -866,10 +865,13 @@ func getUnrefPointersFromMD(
 			// conflict resolution), so ignore that for quota
 			// reclamation purposes.
 			if update.Ref != update.Unref && !ptrMap[update.Unref] {
-				ptrs = append(ptrs, update.Unref)
 				ptrMap[update.Unref] = true
 			}
 		}
+	}
+	ptrs = make([]BlockPointer, 0, len(ptrMap))
+	for ptr := range ptrMap {
+		ptrs = append(ptrs, ptr)
 	}
 	return ptrs
 }

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -846,6 +846,7 @@ func (fbm *folderBlockManager) getMostRecentGCRevision(
 
 func getUnrefPointersFromMD(
 	rmd ImmutableRootMetadata, includeGC bool) (ptrs []BlockPointer) {
+	ptrMap := make(map[BlockPointer]bool)
 	for _, op := range rmd.data.Changes.Ops {
 		if _, ok := op.(*GCOp); !includeGC && ok {
 			continue
@@ -854,8 +855,9 @@ func getUnrefPointersFromMD(
 			// Can be zeroPtr in weird failed sync scenarios.
 			// See syncInfo.replaceRemovedBlock for an example
 			// of how this can happen.
-			if ptr != zeroPtr {
+			if ptr != zeroPtr && !ptrMap[ptr] {
 				ptrs = append(ptrs, ptr)
+				ptrMap[ptr] = true
 			}
 		}
 		for _, update := range op.allUpdates() {
@@ -863,8 +865,9 @@ func getUnrefPointersFromMD(
 			// two identical pointers (usually because of
 			// conflict resolution), so ignore that for quota
 			// reclamation purposes.
-			if update.Ref != update.Unref {
+			if update.Ref != update.Unref && !ptrMap[update.Unref] {
 				ptrs = append(ptrs, update.Unref)
+				ptrMap[update.Unref] = true
 			}
 		}
 	}


### PR DESCRIPTION
The server should be able to handle a request to archive the same block twice, but there's no point in saving/sending redundant data.  So two fixes: 

1. When creating a `resolutionOp`, don't add an unref'd pointer that also exists in an already-included `rmOp` in the resolved MD.
2. Uniquify the pointers we send in our batch archive/delete calls to the bserver.

Issue: KBFS-3966