### PR TITLE
Catch errors in the reloadable wallet disclaimer check

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -850,7 +850,7 @@ const acceptDisclaimer = (state, action) =>
 const checkDisclaimer = state =>
   RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise().then(accepted =>
     WalletsGen.createWalletDisclaimerReceived({accepted})
-  )
+  ).catch(err => logger.error(`Error checking wallet disclaimer: ${err.message}`))
 
 const maybeNavToLinkExisting = (state, action) =>
   action.payload.nextScreen === 'linkExisting' &&


### PR DESCRIPTION
@keybase/react-hackers 

We're inside reloadable, but we just want the error to be totally silent here.