### PR TITLE
libkbfs: move favorite data types into new `favorites` package

### DIFF
--- a/go/kbfs/favorites/data_types.go
+++ b/go/kbfs/favorites/data_types.go
@@ -1,0 +1,110 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package favorites
+
+import (
+	"strings"
+
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// Folder is a top-level favorited folder name.
+type Folder struct {
+	Name string
+	Type tlf.Type
+}
+
+// NewFolderFromProtocol creates a Folder from a
+// keybase1.Folder.
+func NewFolderFromProtocol(folder keybase1.Folder) *Folder {
+	name := folder.Name
+	if !folder.Private {
+		// Old versions of the client still use an outdated "#public"
+		// suffix for favorited public folders. TODO: remove this once
+		// those old versions of the client are retired.
+		const oldPublicSuffix = tlf.ReaderSep + "public"
+		name = strings.TrimSuffix(folder.Name, oldPublicSuffix)
+	}
+
+	var t tlf.Type
+	if folder.FolderType == keybase1.FolderType_UNKNOWN {
+		// Use deprecated boolean
+		if folder.Private {
+			t = tlf.Private
+		} else {
+			t = tlf.Public
+		}
+	} else {
+		switch folder.FolderType {
+		case keybase1.FolderType_PRIVATE:
+			t = tlf.Private
+		case keybase1.FolderType_PUBLIC:
+			t = tlf.Public
+		case keybase1.FolderType_TEAM:
+			// TODO: if we ever support something other than single
+			// teams in the favorites list, we'll have to figure out
+			// which type the favorite is from its name.
+			t = tlf.SingleTeam
+		default:
+			// This shouldn't happen, but just in case the service
+			// sends us bad info....
+			t = tlf.Private
+		}
+	}
+
+	return &Folder{
+		Name: name,
+		Type: t,
+	}
+}
+
+// ToKBFolder creates a keybase1.Folder from a Folder.
+func (f Folder) ToKBFolder(created bool) keybase1.Folder {
+	return keybase1.Folder{
+		Name:       f.Name,
+		FolderType: f.Type.FolderType(),
+		Private:    f.Type != tlf.Public, // deprecated
+		Created:    created,
+	}
+}
+
+// Data represents the auxiliary data belonging to a KBFS favorite.
+type Data struct {
+	Name         string
+	FolderType   keybase1.FolderType
+	Private      bool
+	TeamID       *keybase1.TeamID
+	ResetMembers []keybase1.User
+}
+
+// DataFrom returns auxiliary data from a folder sent via the
+// keybase1 protocol.
+func DataFrom(folder keybase1.Folder) Data {
+	return Data{
+		Name:       folder.Name,
+		FolderType: folder.FolderType,
+		Private:    folder.Private,
+		TeamID:     folder.TeamID,
+	}
+}
+
+// ToAdd contains the data needed to add a new favorite to the
+// favorites list.
+type ToAdd struct {
+	Folder Folder
+	Data   Data
+
+	// Created, if set to true, indicates that this is the first time
+	// the TLF has ever existed. It is only used when adding the TLF
+	// to favorites
+	Created bool
+}
+
+// ToKBFolder converts this data into an object suitable for the
+// keybase1 protocol.
+func (ta ToAdd) ToKBFolder() keybase1.Folder {
+	return ta.Folder.ToKBFolder(ta.Created)
+}

--- a/go/kbfs/libdokan/folderlist.go
+++ b/go/kbfs/libdokan/folderlist.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/dokan"
+	"github.com/keybase/client/go/kbfs/favorites"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -190,7 +191,7 @@ func (fl *FolderList) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored
 	session, err := fl.fs.config.KBPKI().GetCurrentSession(ctx)
 	isLoggedIn := err == nil
 
-	var favs []libkbfs.Favorite
+	var favs []favorites.Folder
 	if isLoggedIn {
 		favs, err = fl.fs.config.KBFSOps().GetFavorites(ctx)
 		if err != nil {

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -16,6 +16,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
+	"github.com/keybase/client/go/kbfs/favorites"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -249,7 +250,7 @@ func (fl *FolderList) ReadDirAll(ctx context.Context) (res []fuse.Dirent, err er
 	session, err := fl.fs.config.KBPKI().GetCurrentSession(ctx)
 	isLoggedIn := err == nil
 
-	var favs []libkbfs.Favorite
+	var favs []favorites.Folder
 	if isLoggedIn {
 		favs, err = fl.fs.config.KBFSOps().GetFavorites(ctx)
 		if err != nil {

--- a/go/kbfs/libkbfs/chat_rpc.go
+++ b/go/kbfs/libkbfs/chat_rpc.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/favorites"
 	"github.com/keybase/client/go/kbfs/kbfsedits"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/libkb"
@@ -425,14 +426,14 @@ func (c *ChatRPC) GetGroupedInbox(
 		return nil, err
 	}
 
-	favorites, err := c.config.KBFSOps().GetFavorites(ctx)
+	favs, err := c.config.KBFSOps().GetFavorites(ctx)
 	if err != nil {
 		c.log.CWarningf(ctx,
 			"Unable to fetch favorites while making GroupedInbox: %v",
 			err)
 	}
-	favMap := make(map[Favorite]bool)
-	for _, fav := range favorites {
+	favMap := make(map[favorites.Folder]bool)
+	for _, fav := range favs {
 		favMap[fav] = true
 	}
 
@@ -454,7 +455,7 @@ func (c *ChatRPC) GetGroupedInbox(
 			tlfType = tlf.SingleTeam
 		}
 
-		tlfIsFavorite := favMap[Favorite{Name: info.TlfName, Type: tlfType}]
+		tlfIsFavorite := favMap[favorites.Folder{Name: info.TlfName, Type: tlfType}]
 		if !tlfIsFavorite {
 			continue
 		}

--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -331,66 +331,6 @@ func (r ReadyBlockData) GetEncodedSize() int {
 	return len(r.buf)
 }
 
-// Favorite is a top-level favorited folder name.
-type Favorite struct {
-	Name string
-	Type tlf.Type
-}
-
-// NewFavoriteFromFolder creates a Favorite from a
-// keybase1.Folder.
-func NewFavoriteFromFolder(folder keybase1.Folder) *Favorite {
-	name := folder.Name
-	if !folder.Private {
-		// Old versions of the client still use an outdated "#public"
-		// suffix for favorited public folders. TODO: remove this once
-		// those old versions of the client are retired.
-		const oldPublicSuffix = tlf.ReaderSep + "public"
-		name = strings.TrimSuffix(folder.Name, oldPublicSuffix)
-	}
-
-	var t tlf.Type
-	if folder.FolderType == keybase1.FolderType_UNKNOWN {
-		// Use deprecated boolean
-		if folder.Private {
-			t = tlf.Private
-		} else {
-			t = tlf.Public
-		}
-	} else {
-		switch folder.FolderType {
-		case keybase1.FolderType_PRIVATE:
-			t = tlf.Private
-		case keybase1.FolderType_PUBLIC:
-			t = tlf.Public
-		case keybase1.FolderType_TEAM:
-			// TODO: if we ever support something other than single
-			// teams in the favorites list, we'll have to figure out
-			// which type the favorite is from its name.
-			t = tlf.SingleTeam
-		default:
-			// This shouldn't happen, but just in case the service
-			// sends us bad info....
-			t = tlf.Private
-		}
-	}
-
-	return &Favorite{
-		Name: name,
-		Type: t,
-	}
-}
-
-// ToKBFolder creates a keybase1.Folder from a Favorite.
-func (f Favorite) ToKBFolder(created bool) keybase1.Folder {
-	return keybase1.Folder{
-		Name:       f.Name,
-		FolderType: f.Type.FolderType(),
-		Private:    f.Type != tlf.Public, // deprecated
-		Created:    created,
-	}
-}
-
 // BranchName is the name given to a KBFS branch, for a particular
 // top-level folder.  Currently, the notion of a "branch" is
 // client-side only, and can be used to specify which root to use for

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"time"
 
+	"github.com/keybase/client/go/kbfs/favorites"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
@@ -338,7 +339,7 @@ type KBFSOps interface {
 	// GetFavorites returns the logged-in user's list of favorite
 	// top-level folders.  This is a remote-access operation when the cache
 	// is empty or expired.
-	GetFavorites(ctx context.Context) ([]Favorite, error)
+	GetFavorites(ctx context.Context) ([]favorites.Folder, error)
 	// GetFavoritesAll returns the logged-in user's lists of favorite, ignored,
 	// and new top-level folders.  This is a remote-access operation when the
 	// cache is empty or expired.
@@ -353,17 +354,17 @@ type KBFSOps interface {
 	ClearCachedFavorites(ctx context.Context)
 	// AddFavorite adds the favorite to both the server and
 	// the local cache.
-	AddFavorite(ctx context.Context, fav Favorite, data FavoriteData) error
+	AddFavorite(ctx context.Context, fav favorites.Folder, data favorites.Data) error
 	// DeleteFavorite deletes the favorite from both the server and
 	// the local cache.  Idempotent, so it succeeds even if the folder
 	// isn't favorited.
-	DeleteFavorite(ctx context.Context, fav Favorite) error
+	DeleteFavorite(ctx context.Context, fav favorites.Folder) error
 	// SetFavoritesHomeTLFInfo sets the home TLF TeamIDs to initialize the
 	// favorites cache on login.
 	SetFavoritesHomeTLFInfo(ctx context.Context, info homeTLFInfo)
 	// RefreshEditHistory asks the FBO for the given favorite to reload its
 	// edit history.
-	RefreshEditHistory(fav Favorite)
+	RefreshEditHistory(fav favorites.Folder)
 
 	// GetTLFCryptKeys gets crypt key of all generations as well as
 	// TLF ID for tlfHandle. The returned keys (the keys slice) are ordered by

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/favorites"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -1344,7 +1345,7 @@ func (k *KeybaseServiceBase) StartMigration(ctx context.Context,
 	}
 	// Making a favorite here to reuse the code that converts from
 	// `keybase1.FolderType` into `tlf.Type`.
-	fav := NewFavoriteFromFolder(folder)
+	fav := favorites.NewFolderFromProtocol(folder)
 	handle, err := GetHandleFromFolderNameAndType(
 		ctx, k.config.KBPKI(), k.config.MDOps(), k.config, fav.Name, fav.Type)
 	if err != nil {
@@ -1357,7 +1358,7 @@ func (k *KeybaseServiceBase) StartMigration(ctx context.Context,
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) FinalizeMigration(ctx context.Context,
 	folder keybase1.Folder) (err error) {
-	fav := NewFavoriteFromFolder(folder)
+	fav := favorites.NewFolderFromProtocol(folder)
 	handle, err := GetHandleFromFolderNameAndType(
 		ctx, k.config.KBPKI(), k.config.MDOps(), k.config, fav.Name, fav.Type)
 	if err != nil {

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	favorites "github.com/keybase/client/go/kbfs/favorites"
 	kbfsblock "github.com/keybase/client/go/kbfs/kbfsblock"
 	kbfscodec "github.com/keybase/client/go/kbfs/kbfscodec"
 	kbfscrypto "github.com/keybase/client/go/kbfs/kbfscrypto"
@@ -1891,10 +1892,10 @@ func (m *MockKBFSOps) EXPECT() *MockKBFSOpsMockRecorder {
 }
 
 // GetFavorites mocks base method
-func (m *MockKBFSOps) GetFavorites(ctx context.Context) ([]Favorite, error) {
+func (m *MockKBFSOps) GetFavorites(ctx context.Context) ([]favorites.Folder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFavorites", ctx)
-	ret0, _ := ret[0].([]Favorite)
+	ret0, _ := ret[0].([]favorites.Folder)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1945,7 +1946,7 @@ func (mr *MockKBFSOpsMockRecorder) ClearCachedFavorites(ctx interface{}) *gomock
 }
 
 // AddFavorite mocks base method
-func (m *MockKBFSOps) AddFavorite(ctx context.Context, fav Favorite, data FavoriteData) error {
+func (m *MockKBFSOps) AddFavorite(ctx context.Context, fav favorites.Folder, data favorites.Data) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddFavorite", ctx, fav, data)
 	ret0, _ := ret[0].(error)
@@ -1959,7 +1960,7 @@ func (mr *MockKBFSOpsMockRecorder) AddFavorite(ctx, fav, data interface{}) *gomo
 }
 
 // DeleteFavorite mocks base method
-func (m *MockKBFSOps) DeleteFavorite(ctx context.Context, fav Favorite) error {
+func (m *MockKBFSOps) DeleteFavorite(ctx context.Context, fav favorites.Folder) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFavorite", ctx, fav)
 	ret0, _ := ret[0].(error)
@@ -1985,7 +1986,7 @@ func (mr *MockKBFSOpsMockRecorder) SetFavoritesHomeTLFInfo(ctx, info interface{}
 }
 
 // RefreshEditHistory mocks base method
-func (m *MockKBFSOps) RefreshEditHistory(fav Favorite) {
+func (m *MockKBFSOps) RefreshEditHistory(fav favorites.Folder) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RefreshEditHistory", fav)
 }

--- a/go/kbfs/libkbfs/tlf_handle.go
+++ b/go/kbfs/libkbfs/tlf_handle.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbfs/favorites"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
@@ -405,8 +406,8 @@ func (h *TlfHandle) GetCanonicalPath() string {
 
 // ToFavorite converts a TlfHandle into a Favorite, suitable for
 // Favorites calls.
-func (h *TlfHandle) ToFavorite() Favorite {
-	return Favorite{
+func (h *TlfHandle) ToFavorite() favorites.Folder {
+	return favorites.Folder{
 		Name: string(h.GetCanonicalName()),
 		Type: h.Type(),
 	}
@@ -414,8 +415,8 @@ func (h *TlfHandle) ToFavorite() Favorite {
 
 // FavoriteData converts a TlfHandle into FavoriteData, suitable for
 // Favorites calls.
-func (h *TlfHandle) FavoriteData() FavoriteData {
-	fd := FavoriteData{
+func (h *TlfHandle) FavoriteData() favorites.Data {
+	fd := favorites.Data{
 		Name:         string(h.GetCanonicalName()),
 		FolderType:   h.Type().FolderType(),
 		Private:      h.Type() != tlf.Public,
@@ -431,11 +432,11 @@ func (h *TlfHandle) FavoriteData() FavoriteData {
 // ToFavorite converts a TlfHandle into a Favorite, and sets internal
 // state about whether the corresponding folder was just created or
 // not.
-func (h *TlfHandle) toFavToAdd(created bool) favToAdd {
-	return favToAdd{
-		Favorite: h.ToFavorite(),
-		Data:     h.FavoriteData(),
-		created:  created,
+func (h *TlfHandle) toFavToAdd(created bool) favorites.ToAdd {
+	return favorites.ToAdd{
+		Folder:  h.ToFavorite(),
+		Data:    h.FavoriteData(),
+		Created: created,
 	}
 }
 


### PR DESCRIPTION
Eventually I'd like to also move all the favorites.go logic, but that's tied up in a lot of libkbfs stuff. But the data types are pretty self-contained and used by another type I'd like to move next, so I thought I'd get this done first.