### PR TITLE
fix xlm balance summary on mobile

### DIFF
--- a/shared/wallets/asset/index.js
+++ b/shared/wallets/asset/index.js
@@ -39,7 +39,7 @@ export default class Asset extends React.Component<Props, State> {
             <Kb.Box2 direction="horizontal" gap="tiny" style={styles.labelContainer}>
               <Kb.Icon
                 type={this.state.expanded ? 'iconfont-caret-down' : 'iconfont-caret-right'}
-                sizeType='Tiny'
+                sizeType="Tiny"
                 style={Kb.iconCastPlatformStyles(styles.caret)}
               />
               <Kb.Box2 direction="vertical">
@@ -160,10 +160,14 @@ const styles = Styles.styleSheetCreate({
     alignItems: 'flex-end',
     justifyContent: 'flex-start',
   },
-  balanceSummaryContainer: {
-    flexBasis: 355,
-    flexShrink: 1,
-  },
+  balanceSummaryContainer: Styles.platformStyles({
+    common: {
+      flexShrink: 1,
+    },
+    isElectron: {
+      flexBasis: '355px',
+    },
+  }),
   caret: Styles.platformStyles({
     isElectron: {lineHeight: '2'},
     isMobile: {marginTop: 6},


### PR DESCRIPTION
before:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/11968340/54309213-17575d80-45a6-11e9-927e-61a32c7b89c4.png">

after:
<img width="545" alt="image" src="https://user-images.githubusercontent.com/11968340/54309195-0c043200-45a6-11e9-8584-6ff28fca7533.png">
(it takes the full width on larger screens too)

r? @keybase/react-hackers 