### PR TITLE
Mobile builds get 'prelease production' tags

### DIFF
--- a/packaging/binary_name.sh
+++ b/packaging/binary_name.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # Prints out the binary name ("keybase", "kbstage", or "kbdev") that
-# corresponds to the current bulid mode. This script helps us avoid duplicating
+# corresponds to the current build mode. This script helps us avoid duplicating
 # the same switch statement in all of our packaging scripts.
 
 set -e -u -o pipefail

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -108,12 +108,12 @@ if [ "$arg" = "ios" ]; then
   ios_dest="$ios_dir/keybase.framework"
   echo "Building for iOS ($ios_dest)..."
   set +e
-  OUTPUT="$(gomobile bind -target=ios -tags="ios" -ldflags "$ldflags" -o "$ios_dest" "$package" 2>&1)"
+  OUTPUT="$(gomobile bind -target=ios -tags="ios $tags" -ldflags "$ldflags" -o "$ios_dest" "$package" 2>&1)"
   set -e
   if [[ $OUTPUT == *gomobile* ]]; then
     echo "Running gomobile init cause: $OUTPUT"
     gomobileinit
-    gomobile bind -target=ios -tags="ios" -ldflags "$ldflags" -o "$ios_dest" "$package"
+    gomobile bind -target=ios -tags="ios $tags" -ldflags "$ldflags" -o "$ios_dest" "$package"
   else
     echo $OUTPUT
   fi
@@ -122,12 +122,12 @@ elif [ "$arg" = "android" ]; then
   android_dest="$android_dir/keybaselib.aar"
   echo "Building for Android ($android_dest)..."
   set +e
-  OUTPUT="$(gomobile bind -target=android -tags="android" -ldflags "$ldflags" -o "$android_dest" "$package" 2>&1)"
+  OUTPUT="$(gomobile bind -target=android -tags="android $tags" -ldflags "$ldflags" -o "$android_dest" "$package" 2>&1)"
   set -e
   if [[ $OUTPUT == *gomobile* ]]; then
     echo "Running gomobile init cause: $OUTPUT"
     gomobileinit
-    gomobile bind -target=android -tags="android" -ldflags "$ldflags" -o "$android_dest" "$package"
+    gomobile bind -target=android -tags="android $tags" -ldflags "$ldflags" -o "$android_dest" "$package"
   else
     echo $OUTPUT
   fi


### PR DESCRIPTION
ios and android builds were'nt using the build tag `production` when compiling go. @strib this affects `defaultMountType`

ios looks good in the simulator. I didn't try android locally.