### PR TITLE
Fix background ek generation

### DIFF
--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -414,7 +414,8 @@ func (t *TeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfNam
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetEKLib().GetOrCreateLatestTeamEK(ctx, teamID)
+	teamEK, _, err = t.G().GetEKLib().GetOrCreateLatestTeamEK(ctx, teamID)
+	return teamEK, err
 }
 
 func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
@@ -713,7 +714,8 @@ func (t *ImplicitTeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetEKLib().GetOrCreateLatestTeamEK(ctx, teamID)
+	teamEK, _, err = t.G().GetEKLib().GetOrCreateLatestTeamEK(ctx, teamID)
+	return teamEK, err
 }
 
 func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,

--- a/go/ephemeral/device_ek.go
+++ b/go/ephemeral/device_ek.go
@@ -67,7 +67,7 @@ func publishNewDeviceEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot 
 	}
 
 	storage := g.GetDeviceEKStorage()
-	generation, err := storage.MaxGeneration(ctx)
+	generation, err := storage.MaxGeneration(ctx, false)
 	if err != nil {
 		// Let's try to get the max from the server
 		g.Log.CDebugf(ctx, "Error getting maxGeneration from storage")

--- a/go/ephemeral/device_ek.go
+++ b/go/ephemeral/device_ek.go
@@ -67,7 +67,7 @@ func publishNewDeviceEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot 
 	}
 
 	storage := g.GetDeviceEKStorage()
-	generation, err := storage.MaxGeneration(ctx, false)
+	generation, err := storage.MaxGeneration(ctx, true)
 	if err != nil {
 		// Let's try to get the max from the server
 		g.Log.CDebugf(ctx, "Error getting maxGeneration from storage")

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -398,7 +398,7 @@ func (s *DeviceEKStorage) listAllForUser(ctx context.Context, username libkb.Nor
 	return all, nil
 }
 
-func (s *DeviceEKStorage) MaxGeneration(ctx context.Context) (maxGeneration keybase1.EkGeneration, err error) {
+func (s *DeviceEKStorage) MaxGeneration(ctx context.Context, includeErrs bool) (maxGeneration keybase1.EkGeneration, err error) {
 	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#MaxGeneration", func() error { return err })()
 
 	s.Lock()
@@ -410,7 +410,7 @@ func (s *DeviceEKStorage) MaxGeneration(ctx context.Context) (maxGeneration keyb
 		return maxGeneration, err
 	}
 	for generation, cacheItem := range cache {
-		if cacheItem.Err != nil {
+		if cacheItem.Err != nil && !includeErrs {
 			continue
 		}
 		if generation > maxGeneration {

--- a/go/ephemeral/device_ek_test.go
+++ b/go/ephemeral/device_ek_test.go
@@ -37,7 +37,7 @@ func TestNewDeviceEK(t *testing.T) {
 	for _, fetchedDeviceMetadata := range fetchedDevices {
 		require.Equal(t, publishedMetadata, fetchedDeviceMetadata)
 	}
-	maxGeneration, err := s.MaxGeneration(context.Background())
+	maxGeneration, err := s.MaxGeneration(context.Background(), false)
 	require.NoError(t, err)
 
 	require.EqualValues(t, maxGeneration, publishedMetadata.Generation)

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -58,7 +58,7 @@ func humanMsgWithPrefix(humanMsg string) string {
 	if humanMsg == "" {
 		humanMsg = DefaultHumanErrMsg
 	} else if !strings.Contains(humanMsg, DefaultHumanErrMsg) {
-		humanMsg = fmt.Sprintf("%s. %s", DefaultHumanErrMsg, humanMsg)
+		humanMsg = fmt.Sprintf("%s, %s", DefaultHumanErrMsg, humanMsg)
 	}
 	return humanMsg
 }

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -56,7 +56,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 
 	// After the provision, Y should have access to this userEK generation
 	userEKBoxStorageX := tcX.G.GetUserEKBoxStorage()
-	userEKGenX, err := userEKBoxStorageX.MaxGeneration(context.Background())
+	userEKGenX, err := userEKBoxStorageX.MaxGeneration(context.Background(), false)
 	require.NoError(t, err)
 
 	var userEKX keybase1.UserEk
@@ -134,7 +134,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	wg.Wait()
 
 	deviceEKStorageY := tcY.G.GetDeviceEKStorage()
-	maxDeviceEKGenerationY, err := deviceEKStorageY.MaxGeneration(context.Background())
+	maxDeviceEKGenerationY, err := deviceEKStorageY.MaxGeneration(context.Background(), false)
 	require.NoError(t, err)
 	if upgradePerUserKey {
 		// Confirm that Y has a deviceEK.
@@ -163,7 +163,7 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	// Confirm Y has a userEK at the same generation as X. If we didn't have a
 	// PUK this generation will be -1.
 	userEKBoxStorageY := tcY.G.GetUserEKBoxStorage()
-	userEKGenY, err := userEKBoxStorageY.MaxGeneration(context.Background())
+	userEKGenY, err := userEKBoxStorageY.MaxGeneration(context.Background(), false)
 	require.NoError(t, err)
 	require.EqualValues(t, userEKGenX, userEKGenY)
 

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -260,7 +260,8 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	require.Equal(t, teamEK, keybase1.TeamEk{})
 	t.Logf("before expectedTeamEkGen: %v", expectedTeamEKGen)
 	select {
-	case <-ch:
+	case created := <-ch:
+		require.True(t, created)
 	case <-time.After(time.Second * 20):
 		t.Fatalf("teamEK background creation failed")
 	}
@@ -302,7 +303,8 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	// Wait until background generation completes
 	select {
-	case <-ch:
+	case created := <-ch:
+		require.True(t, created)
 	case <-time.After(time.Second * 20):
 		t.Fatalf("teamEK background creation failed")
 	}

--- a/go/ephemeral/selfprovision_test.go
+++ b/go/ephemeral/selfprovision_test.go
@@ -19,8 +19,9 @@ func TestEphemeralSelfProvision(t *testing.T) {
 	teamID := createTeam(tc)
 
 	ekLib := g.GetEKLib()
-	teamEK1, err := ekLib.GetOrCreateLatestTeamEK(ctx, teamID)
+	teamEK1, created, err := ekLib.GetOrCreateLatestTeamEK(ctx, teamID)
 	require.NoError(t, err)
+	require.True(t, created)
 
 	// Publish a few deviceEKs on the cloned account and make sure the self
 	// provision goes through successfully and we can continue to generate
@@ -33,7 +34,7 @@ func TestEphemeralSelfProvision(t *testing.T) {
 	_, err = publishNewDeviceEK(ctx, g, merkleRoot)
 	require.NoError(t, err)
 	deviceEKStorage := g.GetDeviceEKStorage()
-	maxGen, err := deviceEKStorage.MaxGeneration(ctx)
+	maxGen, err := deviceEKStorage.MaxGeneration(ctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 3, maxGen)
 
@@ -61,13 +62,13 @@ func TestEphemeralSelfProvision(t *testing.T) {
 
 	// After self provisioning we should only have a single deviceEK, and have
 	// no issues producing new ones.
-	maxGen, err = deviceEKStorage.MaxGeneration(ctx)
+	maxGen, err = deviceEKStorage.MaxGeneration(ctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, maxGen)
 
 	_, err = publishNewDeviceEK(ctx, g, merkleRoot)
 	require.NoError(t, err)
-	maxGen, err = deviceEKStorage.MaxGeneration(ctx)
+	maxGen, err = deviceEKStorage.MaxGeneration(ctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, maxGen)
 }

--- a/go/ephemeral/team_ek_test.go
+++ b/go/ephemeral/team_ek_test.go
@@ -54,7 +54,7 @@ func TestNewTeamEK(t *testing.T) {
 
 	// We've stored the result in local storage
 	teamEKBoxStorage := tc.G.GetTeamEKBoxStorage()
-	maxGeneration, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID)
+	maxGeneration, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID, false)
 	require.NoError(t, err)
 	ek, err := teamEKBoxStorage.Get(context.Background(), teamID, maxGeneration, nil)
 	require.NoError(t, err)

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -32,7 +32,7 @@ func publishAndVerifyUserEK(t *testing.T, tc libkb.TestContext, merkleRoot libkb
 
 	// We've stored the result in local storage
 	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
-	maxGeneration, err := userEKBoxStorage.MaxGeneration(context.Background())
+	maxGeneration, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
 	require.NoError(t, err)
 	ek, err := userEKBoxStorage.Get(context.Background(), maxGeneration, nil)
 	require.NoError(t, err)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -736,7 +736,7 @@ type DeviceEKStorage interface {
 	Put(ctx context.Context, generation keybase1.EkGeneration, deviceEK keybase1.DeviceEk) error
 	Get(ctx context.Context, generation keybase1.EkGeneration) (keybase1.DeviceEk, error)
 	GetAllActive(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.DeviceEkMetadata, error)
-	MaxGeneration(ctx context.Context) (keybase1.EkGeneration, error)
+	MaxGeneration(ctx context.Context, includeErrs bool) (keybase1.EkGeneration, error)
 	DeleteExpired(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	ClearCache()
 	// Dangerous! Only for deprovisioning.
@@ -750,7 +750,7 @@ type DeviceEKStorage interface {
 type UserEKBoxStorage interface {
 	Put(ctx context.Context, generation keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) error
 	Get(ctx context.Context, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.UserEk, error)
-	MaxGeneration(ctx context.Context) (keybase1.EkGeneration, error)
+	MaxGeneration(ctx context.Context, includeErrs bool) (keybase1.EkGeneration, error)
 	DeleteExpired(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	ClearCache()
 }
@@ -758,7 +758,7 @@ type UserEKBoxStorage interface {
 type TeamEKBoxStorage interface {
 	Put(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) error
 	Get(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
-	MaxGeneration(ctx context.Context, teamID keybase1.TeamID) (keybase1.EkGeneration, error)
+	MaxGeneration(ctx context.Context, teamID keybase1.TeamID, includeErrs bool) (keybase1.EkGeneration, error)
 	DeleteExpired(ctx context.Context, teamID keybase1.TeamID, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	PurgeCacheForTeamID(ctx context.Context, teamID keybase1.TeamID) error
 	Delete(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) error
@@ -767,7 +767,7 @@ type TeamEKBoxStorage interface {
 
 type EKLib interface {
 	KeygenIfNeeded(ctx context.Context) error
-	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, error)
+	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, bool, error)
 	GetTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
 	PurgeCachesForTeamIDAndGeneration(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration)
 	PurgeCachesForTeamID(ctx context.Context, teamID keybase1.TeamID)

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -25,8 +25,9 @@ func TestEphemeralNewTeamEKNotif(t *testing.T) {
 	ephemeral.ServiceInit(user1.tc.G)
 	ekLib := user1.tc.G.GetEKLib()
 
-	teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 	require.NoError(t, err)
+	require.True(t, created)
 
 	expectedArg := keybase1.NewTeamEkArg{
 		Id:         teamID,
@@ -84,8 +85,9 @@ func runAddMember(t *testing.T, createTeamEK bool) {
 	var expectedGeneration keybase1.EkGeneration
 	if createTeamEK {
 		ekLib := annG.GetEKLib()
-		teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+		teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 		require.NoError(t, err)
+		require.True(t, created)
 
 		expectedMetadata = teamEK.Metadata
 		expectedGeneration = expectedMetadata.Generation
@@ -143,8 +145,9 @@ func TestEphemeralResetMember(t *testing.T) {
 	bob.reset()
 
 	annEkLib := annG.GetEKLib()
-	teamEK, err := annEkLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	teamEK, created, err := annEkLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 	require.NoError(t, err)
+	require.True(t, created)
 
 	expectedMetadata := teamEK.Metadata
 	expectedGeneration := expectedMetadata.Generation
@@ -167,9 +170,10 @@ func TestEphemeralResetMember(t *testing.T) {
 	ann.addWriter(team, bob)
 	ann.addWriter(team, joe)
 
-	// ann now makes a new teamEk which joe can access but bob cannot
-	teamEK2, err := annEkLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	// ann gets the new teamEk which joe can access but bob cannot after he reset.
+	teamEK2, created, err := annEkLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 	require.NoError(t, err)
+	require.False(t, created)
 
 	expectedMetadata2 := teamEK2.Metadata
 	expectedGeneration2 := expectedMetadata2.Generation
@@ -216,8 +220,9 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	var expectedGeneration keybase1.EkGeneration
 	if createTeamEK {
 		ekLib := annG.GetEKLib()
-		teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+		teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 		require.NoError(t, err)
+		require.True(t, created)
 		expectedGeneration = teamEK.Metadata.Generation + 1
 	} else {
 		expectedGeneration = 1
@@ -258,8 +263,9 @@ func TestEphemeralRotateSkipTeamEKRoll(t *testing.T) {
 	// Get our ephemeral keys before the revoke and ensure we can still access
 	// them after.
 	ekLib := annG.GetEKLib()
-	teamEKPreRoll, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	teamEKPreRoll, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 	require.NoError(t, err)
+	require.True(t, created)
 
 	// This is a hack to skip the teamEK generation during the PTK roll.
 	// We want to validate that we can create a new teamEK after this roll even
@@ -306,10 +312,11 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 	ephemeral.ServiceInit(annG)
 	ekLib := annG.GetEKLib()
 
-	_, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	_, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 	require.NoError(t, err)
+	require.True(t, created)
 	userEKBoxStorage := annG.GetUserEKBoxStorage()
-	gen, err := userEKBoxStorage.MaxGeneration(context.Background())
+	gen, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
 	require.NoError(t, err)
 	userEKPreRevoke, err := userEKBoxStorage.Get(context.Background(), gen, nil)
 	require.NoError(t, err)
@@ -373,8 +380,9 @@ func readdToTeamWithEKs(t *testing.T, leave bool) {
 
 	ephemeral.ServiceInit(user1.tc.G)
 	ekLib := user1.tc.G.GetEKLib()
-	teamEK, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
 	require.NoError(t, err)
+	require.True(t, created)
 
 	currentGen := teamEK.Metadata.Generation
 	var expectedGen keybase1.EkGeneration


### PR DESCRIPTION
Fixes a bug where the background creation of a team ek would not happen even if we were unable to access the latest team ek. the issue was that we incorrectly calculated the max generation, which previously skipped errored items. also exposed a bug where we did not correctly cache errors which were allowing tests to pass incorrectly 