### PR TITLE
Chat attachments use filemode 0600

### DIFF
--- a/go/chat/attachments/downloader.go
+++ b/go/chat/attachments/downloader.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"golang.org/x/net/context"
@@ -28,7 +29,6 @@ func SinkFromFilename(ctx context.Context, g *globals.Context, uid gregor1.UID,
 	var sink io.WriteCloser
 	var err error
 	const openFlag int = os.O_RDWR | os.O_CREATE | os.O_TRUNC
-	const openFileMode os.FileMode = 0600
 	if filename == "" {
 		// No filename means we will create one in the OS temp dir
 		// Get the sent file name first
@@ -52,14 +52,14 @@ func SinkFromFilename(ctx context.Context, g *globals.Context, uid gregor1.UID,
 		if err != nil {
 			return "", nil, err
 		}
-		f, err := os.OpenFile(fullpath, openFlag, openFileMode)
+		f, err := os.OpenFile(fullpath, openFlag, libkb.PermFile)
 		if err != nil {
 			return "", nil, err
 		}
 		filename = fullpath
 		sink = f
 	} else {
-		if sink, err = os.OpenFile(filename, openFlag, openFileMode); err != nil {
+		if sink, err = os.OpenFile(filename, openFlag, libkb.PermFile); err != nil {
 			return "", nil, err
 		}
 	}

--- a/go/chat/attachments/downloader.go
+++ b/go/chat/attachments/downloader.go
@@ -27,6 +27,8 @@ func SinkFromFilename(ctx context.Context, g *globals.Context, uid gregor1.UID,
 	filename string) (string, io.WriteCloser, error) {
 	var sink io.WriteCloser
 	var err error
+	const openFlag int = os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	const openFileMode os.FileMode = 0600
 	if filename == "" {
 		// No filename means we will create one in the OS temp dir
 		// Get the sent file name first
@@ -50,14 +52,14 @@ func SinkFromFilename(ctx context.Context, g *globals.Context, uid gregor1.UID,
 		if err != nil {
 			return "", nil, err
 		}
-		f, err := os.OpenFile(fullpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		f, err := os.OpenFile(fullpath, openFlag, openFileMode)
 		if err != nil {
 			return "", nil, err
 		}
 		filename = fullpath
 		sink = f
 	} else {
-		if sink, err = os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600); err != nil {
+		if sink, err = os.OpenFile(filename, openFlag, openFileMode); err != nil {
 			return "", nil, err
 		}
 	}


### PR DESCRIPTION
The `filename == ""` case used 0644. Might as well be consistent if there's no other reasoning