### PR TITLE
fix gregor concurrency bug

### DIFF
--- a/go/gregor/client/client.go
+++ b/go/gregor/client/client.go
@@ -148,7 +148,7 @@ func (c *Client) Restore(ctx context.Context) error {
 		return fmt.Errorf("Restore(): failed to init local dismissals: %s", err)
 	}
 
-	if err := c.Sm.InitOutbox(ctx, c.User, outbox); err != nil {
+	if err := c.Sm.PrependToOutbox(ctx, c.User, outbox); err != nil {
 		c.Log.CDebugf(ctx, "Restore(): failed to init outbox: %s", err)
 	}
 
@@ -493,8 +493,8 @@ func (c *Client) outboxSend() {
 		newOutbox = append(newOutbox, msgs[i])
 	}
 	c.Log.Debug("outboxSend: adding back: %d outbox items", len(newOutbox))
-	if err := c.Sm.InitOutbox(ctx, c.User, newOutbox); err != nil {
-		c.Log.Debug("outboxSend: failed to init outbox with new items: %s", err)
+	if err := c.Sm.PrependToOutbox(ctx, c.User, newOutbox); err != nil {
+		c.Log.Debug("outboxSend: failed to put items back into outbox: %s", err)
 	}
 	if err := c.Save(ctx); err != nil {
 		c.Log.Debug("outboxSend: failed to save state: %s", err)

--- a/go/gregor/interface.go
+++ b/go/gregor/interface.go
@@ -218,8 +218,8 @@ type StateMachine interface {
 	// Outbox gives all of the pending messages in the outbox
 	Outbox(context.Context, UID) ([]Message, error)
 
-	// InitOutbox sets the outbox for the give user
-	InitOutbox(context.Context, UID, []Message) error
+	// PrependToOutbox adds a slice of messages to the beginning of the outbox
+	PrependToOutbox(context.Context, UID, []Message) error
 
 	// ConsumeOutboxMessage add a message to the outbox
 	ConsumeOutboxMessage(context.Context, UID, Message) error

--- a/go/gregor/storage/mem_sm.go
+++ b/go/gregor/storage/mem_sm.go
@@ -474,10 +474,10 @@ func (m *MemEngine) Outbox(ctx context.Context, u gregor.UID) ([]gregor.Message,
 	return m.getUser(u).outbox, nil
 }
 
-func (m *MemEngine) InitOutbox(ctx context.Context, u gregor.UID, msgs []gregor.Message) error {
+func (m *MemEngine) PrependToOutbox(ctx context.Context, u gregor.UID, msgs []gregor.Message) error {
 	m.Lock()
 	defer m.Unlock()
-	m.getUser(u).outbox = msgs
+	m.getUser(u).outbox = append(msgs, m.getUser(u).outbox...)
 	return nil
 }
 


### PR DESCRIPTION
stop inadvertently dropping messages from the gregor in-memory outbox. this will be especially noticeable for dismissing device badges, but could help in other places too. 