### PR TITLE
libkbfs: extract all identify and tlfhandle code into new packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -407,6 +407,10 @@ def testGo(prefix, packagesToTest) {
         'github.com/keybase/client/go/kbfs/libfuse': [
           disable: true,
         ],
+        'github.com/keybase/client/go/kbfs/idutil': [
+          flags: '-race',
+          timeout: '30s',
+        ],
         'github.com/keybase/client/go/kbfs/kbfsblock': [
           flags: '-race',
           timeout: '30s',
@@ -443,6 +447,10 @@ def testGo(prefix, packagesToTest) {
           flags: '-race',
           timeout: '30s',
         ],
+        'github.com/keybase/client/go/kbfs/libcontext': [
+          flags: '-race',
+          timeout: '10m',
+        ],
         'github.com/keybase/client/go/kbfs/libfs': [
           flags: '-race',
           timeout: '10m',
@@ -477,6 +485,10 @@ def testGo(prefix, packagesToTest) {
           timeout: '12m',
         ],
         'github.com/keybase/client/go/kbfs/tlf': [
+          flags: '-race',
+          timeout: '30s',
+        ],
+        'github.com/keybase/client/go/kbfs/tlfhandle': [
           flags: '-race',
           timeout: '30s',
         ],

--- a/go/kbfs/README.md
+++ b/go/kbfs/README.md
@@ -21,10 +21,16 @@ servers).
 
 The code is organized as follows:
 
+* [cache](cache/): Generic cache data structures.
 * [dokan](dokan/): Helper code for running Dokan filesystems on Windows.
 * [env](env/): Code to implement libkbfs.Context in terms of libkb.
+* [favorites](favorites/): Data structures for the favorited lists of
+  top-level folders (TLFs) that appear under private/, public/, and
+  team/.
 * [fsrpc](fsrpc/): RPC interfaces that connected clients can call in KBFS,
   to do certain operations, such as listing files.
+* [idutil](idutil/): Basic data structures, interfaces, and helper
+  code for dealing with identity data for users and teams.
 * [ioutil](ioutil/): Helper functions for I/O.
 * [kbfsblock](kbfsblock/): Types and functions to work with KBFS blocks.
 * [kbfscodec](kbfscodec/): Interfaces and types used for serialization in KBFS.
@@ -33,24 +39,43 @@ The code is organized as follows:
   Windows.
 * [kbfsfuse](kbfsfuse/): The main executable for running KBFS on Linux
   and OS X.
+* [kbfsgit](kbfsgit/): The main executable for the Keybase git remote helper.
 * [kbfshash](kbfshash/): An implementation of the KBFS hash spec.
 * [kbfsmd](kbfsmd/): Types and functions to work with KBFS TLF metadata.
 * [kbfssync](kbfssync/): KBFS-specific synchronization primitives.
 * [kbfstool](kbfstool/): A thin command line utility for interacting with KBFS
   without using a filesystem mountpoint.
+* [kbpagesconfig](kbpagesconfig/): Configuration code for Keybase Pages.
+* [kbpagesd](kbpagesd/): The main executable for Keybase Pages.
+* [libcontext](libcontext/): KBFS-specific context helper code.
 * [libdokan](libdokan/): Library code gluing together KBFS and the
   Dokan protocol.
 * [libfs](libfs/): Common library code useful to any filesystem
   presentation layer for KBFS.
 * [libfuse](libfuse/): Library code gluing together KBFS and the FUSE
   protocol.
+* [libgit](libgit/): Library for git-related logic.
+* [libhttpserver](libhttpserver/): Library for serving KBFS files with
+  a local HTTP server.
 * [libkbfs](libkbfs/): The core logic for KBFS.
+* [libmime](libmime/): Library for determining the MIME types of KBFS
+  files.
+* [libpages](libpages/): Library for the logic behind Keybase Pages.
 * [metricsutil](metricsutil/): Helper code for collecting metrics.
+* [redirector](redirector/): The executable that redirects user FUSe
+  requests to the correct user KBFS mount.  The redirector is usually
+  mounted at `/keybase` on Linux and macOS.
+* [simplefs](simplefs/): A simple RPC-based interface to KBFS.
+* [stderrutils](stderrutils/): A simple library for dealing with
+  stderr on different platforms.
+* [sysutils](sysutils/): Library for dealing with platform-specific
+  systems stuff.
 * [test](test/): A test harness with a domain-specific test language
   and tests in that language.
 * [tlf](tlf/): Code and structures for top-level folders (TLFs).
-* [vendor](vendor/): Vendored versions of the open-source libraries
-  used by KBFS.
+* [tlfhandle](tlfhandle/): The data structure for "Handles" to
+  top-level folders (TLFs), which represent an identifier for each
+  TLF, containing all the user or team IDs associated with the it.
 
 ### Status
 

--- a/go/kbfs/fsrpc/path.go
+++ b/go/kbfs/fsrpc/path.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -248,20 +250,20 @@ func (p Path) Join(childName string) (childPath Path, err error) {
 // automatically resolves non-canonical names.
 func ParseTlfHandle(
 	ctx context.Context, kbpki libkbfs.KBPKI, mdOps libkbfs.MDOps,
-	osg libkbfs.OfflineStatusGetter, name string, t tlf.Type) (
-	*libkbfs.TlfHandle, error) {
-	var tlfHandle *libkbfs.TlfHandle
+	osg idutil.OfflineStatusGetter, name string, t tlf.Type) (
+	*tlfhandle.Handle, error) {
+	var tlfHandle *tlfhandle.Handle
 outer:
 	for {
 		var parseErr error
-		tlfHandle, parseErr = libkbfs.ParseTlfHandle(
+		tlfHandle, parseErr = tlfhandle.ParseHandle(
 			ctx, kbpki, mdOps, osg, name, t)
 		switch parseErr := errors.Cause(parseErr).(type) {
 		case nil:
 			// No error.
 			break outer
 
-		case libkbfs.TlfNameNotCanonical:
+		case idutil.TlfNameNotCanonical:
 			// Non-canonical name, so try again.
 			name = parseErr.NameToTry
 

--- a/go/kbfs/idutil/daemon_local.go
+++ b/go/kbfs/idutil/daemon_local.go
@@ -1,0 +1,740 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package idutil
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbfs/kbfscodec"
+	"github.com/keybase/client/go/kbfs/kbfscrypto"
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/tlf"
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/pkg/errors"
+)
+
+func checkContext(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return errors.WithStack(ctx.Err())
+	default:
+		return nil
+	}
+}
+
+type localUserMap map[keybase1.UID]LocalUser
+
+func (m localUserMap) getLocalUser(uid keybase1.UID) (LocalUser, error) {
+	user, ok := m[uid]
+	if !ok {
+		return LocalUser{}, NoSuchUserError{uid.String()}
+	}
+	return user, nil
+}
+
+type localTeamMap map[keybase1.TeamID]TeamInfo
+
+func (m localTeamMap) getLocalTeam(tid keybase1.TeamID) (TeamInfo, error) {
+	team, ok := m[tid]
+	if !ok {
+		return TeamInfo{}, NoSuchTeamError{tid.String()}
+	}
+	return team, nil
+}
+
+type localTeamSettingsMap map[keybase1.TeamID]keybase1.KBFSTeamSettings
+
+type localImplicitTeamMap map[keybase1.TeamID]ImplicitTeamInfo
+
+func (m localImplicitTeamMap) getLocalImplicitTeam(
+	tid keybase1.TeamID) (ImplicitTeamInfo, error) {
+	team, ok := m[tid]
+	if !ok {
+		return ImplicitTeamInfo{}, NoSuchTeamError{tid.String()}
+	}
+	return team, nil
+}
+
+// DaemonLocal implements KeybaseDaemon using an in-memory user
+// and session store, and a given favorite store.
+type DaemonLocal struct {
+	codec kbfscodec.Codec
+
+	// lock protects everything below.
+	lock               sync.Mutex
+	localUsers         localUserMap
+	localTeams         localTeamMap
+	localTeamSettings  localTeamSettingsMap
+	localImplicitTeams localImplicitTeamMap
+	currentUID         keybase1.UID
+	asserts            map[string]keybase1.UserOrTeamID
+	implicitAsserts    map[string]keybase1.TeamID
+	merkleRoot         keybase1.MerkleRootV2
+	merkleTime         time.Time
+}
+
+// SetCurrentUID sets the current UID.
+func (dl *DaemonLocal) SetCurrentUID(uid keybase1.UID) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	// TODO: Send out notifications.
+	dl.currentUID = uid
+}
+
+func (dl *DaemonLocal) assertionToIDLocked(ctx context.Context,
+	assertion string) (id keybase1.UserOrTeamID, err error) {
+	expr, err := externals.AssertionParseAndOnlyStatic(assertion)
+	if err != nil {
+		return keybase1.UserOrTeamID(""), err
+	}
+	urls := expr.CollectUrls(nil)
+	if len(urls) == 0 {
+		return keybase1.UserOrTeamID(""), errors.New("No assertion URLs")
+	}
+
+	for _, url := range urls {
+		var currID keybase1.UserOrTeamID
+		if url.IsUID() {
+			currID = url.ToUID().AsUserOrTeam()
+		} else if url.IsTeamID() {
+			currID = url.ToTeamID().AsUserOrTeam()
+		} else {
+			key, val := url.ToKeyValuePair()
+			a := fmt.Sprintf("%s@%s", val, key)
+			if url.IsKeybase() && key != "team" {
+				a = val
+			}
+			var ok bool
+			currID, ok = dl.asserts[a]
+			if !ok {
+				return keybase1.UserOrTeamID(""), NoSuchUserError{a}
+			}
+		}
+		if id != keybase1.UserOrTeamID("") && currID != id {
+			return keybase1.UserOrTeamID(""),
+				errors.New("AND assertions resolve to different UIDs")
+		}
+		id = currID
+	}
+	return id, nil
+}
+
+// Resolve implements the KeybaseService interface for DaemonLocal.
+func (dl *DaemonLocal) Resolve(
+	ctx context.Context, assertion string, _ keybase1.OfflineAvailability) (
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	if err := checkContext(ctx); err != nil {
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+	}
+
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	id, err := dl.assertionToIDLocked(ctx, assertion)
+	if err != nil {
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+	}
+
+	if id.IsUser() {
+		u, err := dl.localUsers.getLocalUser(id.AsUserOrBust())
+		if err != nil {
+			return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+		}
+		return u.Name, id, nil
+	}
+
+	// Otherwise it's a team
+	ti, err := dl.localTeams.getLocalTeam(id.AsTeamOrBust())
+	if err != nil {
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+	}
+
+	_, ok := dl.localImplicitTeams[id.AsTeamOrBust()]
+	if ok {
+		// An implicit team exists, so Resolve shouldn't work.  The
+		// caller should use `ResolveImplicitTeamByID` instead.
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+			fmt.Errorf("Team ID %s is an implicit team", id)
+	}
+
+	return ti.Name, id, nil
+}
+
+// Identify implements the KeybaseService interface for DaemonLocal.
+func (dl *DaemonLocal) Identify(
+	ctx context.Context, assertion, _ string,
+	offline keybase1.OfflineAvailability) (
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	// The local daemon doesn't need to distinguish resolves from
+	// identifies.
+	return dl.Resolve(ctx, assertion, offline)
+}
+
+// NormalizeSocialAssertion implements the KeybaseService interface
+// for DaemonLocal.
+func (dl *DaemonLocal) NormalizeSocialAssertion(
+	ctx context.Context, assertion string) (keybase1.SocialAssertion, error) {
+	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(assertion)
+	if !isSocialAssertion {
+		return keybase1.SocialAssertion{}, fmt.Errorf("Invalid social assertion")
+	}
+	return socialAssertion, nil
+}
+
+func (dl *DaemonLocal) resolveForImplicitTeam(
+	ctx context.Context, name string, r []kbname.NormalizedUsername,
+	ur []keybase1.SocialAssertion,
+	resolvedIDs map[kbname.NormalizedUsername]keybase1.UserOrTeamID) (
+	[]kbname.NormalizedUsername, []keybase1.SocialAssertion, error) {
+	id, err := dl.assertionToIDLocked(ctx, name)
+	if err == nil {
+		u, err := dl.localUsers.getLocalUser(id.AsUserOrBust())
+		if err != nil {
+			return nil, nil, err
+		}
+		r = append(r, u.Name)
+		resolvedIDs[u.Name] = id
+	} else {
+		a, ok := externals.NormalizeSocialAssertionStatic(name)
+		if !ok {
+			return nil, nil, fmt.Errorf("Bad assertion: %s", name)
+		}
+		ur = append(ur, a)
+	}
+	return r, ur, nil
+}
+
+// ResolveIdentifyImplicitTeam implements the KeybaseService interface
+// for DaemonLocal.
+func (dl *DaemonLocal) ResolveIdentifyImplicitTeam(
+	ctx context.Context, assertions, suffix string, tlfType tlf.Type,
+	doIdentifies bool, reason string, _ keybase1.OfflineAvailability) (
+	ImplicitTeamInfo, error) {
+	if err := checkContext(ctx); err != nil {
+		return ImplicitTeamInfo{}, err
+	}
+
+	if tlfType != tlf.Private && tlfType != tlf.Public {
+		return ImplicitTeamInfo{}, fmt.Errorf(
+			"Invalid implicit team TLF type: %s", tlfType)
+	}
+
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+
+	// Canonicalize the name.
+	writerNames, readerNames, _, err :=
+		SplitAndNormalizeTLFName(assertions, tlfType)
+	if err != nil {
+		return ImplicitTeamInfo{}, err
+	}
+	var writers, readers []kbname.NormalizedUsername
+	var unresolvedWriters, unresolvedReaders []keybase1.SocialAssertion
+	resolvedIDs := make(map[kbname.NormalizedUsername]keybase1.UserOrTeamID)
+	for _, w := range writerNames {
+		writers, unresolvedWriters, err = dl.resolveForImplicitTeam(
+			ctx, w, writers, unresolvedWriters, resolvedIDs)
+		if err != nil {
+			return ImplicitTeamInfo{}, err
+		}
+	}
+	for _, r := range readerNames {
+		readers, unresolvedReaders, err = dl.resolveForImplicitTeam(
+			ctx, r, readers, unresolvedReaders, resolvedIDs)
+		if err != nil {
+			return ImplicitTeamInfo{}, err
+		}
+	}
+
+	var extensions []tlf.HandleExtension
+	if len(suffix) != 0 {
+		extensions, err = tlf.ParseHandleExtensionSuffix(suffix)
+		if err != nil {
+			return ImplicitTeamInfo{}, err
+		}
+	}
+	name := tlf.MakeCanonicalName(
+		writers, unresolvedWriters, readers, unresolvedReaders, extensions)
+
+	key := fmt.Sprintf("%s:%s", tlfType.String(), name)
+	tid, ok := dl.implicitAsserts[key]
+	if ok {
+		return dl.localImplicitTeams[tid], nil
+	}
+
+	// If the implicit team doesn't exist, always create it.
+
+	// Need to make the team info as well, so get the list of user
+	// names and resolve them.  Auto-generate an implicit team name.
+	implicitName := kbname.NormalizedUsername(
+		fmt.Sprintf("_implicit_%d", len(dl.localTeams)))
+	teams := makeLocalTeams(
+		[]kbname.NormalizedUsername{implicitName}, len(dl.localTeams), tlfType)
+	info := teams[0]
+	info.Writers = make(map[keybase1.UID]bool, len(writerNames))
+	for _, w := range writers {
+		id, ok := resolvedIDs[w]
+		if !ok {
+			return ImplicitTeamInfo{}, fmt.Errorf("No resolved writer %s", w)
+		}
+		info.Writers[id.AsUserOrBust()] = true
+	}
+	if len(readerNames) > 0 {
+		info.Readers = make(map[keybase1.UID]bool, len(readerNames))
+		for _, r := range readers {
+			id, ok := resolvedIDs[r]
+			if !ok {
+				return ImplicitTeamInfo{}, fmt.Errorf(
+					"No resolved reader %s", r)
+
+			}
+			info.Readers[id.AsUserOrBust()] = true
+		}
+	}
+	// Unresolved users don't need to go in the team info, they're
+	// irrelvant until they're resolved.  TODO: add resolved users
+	// into existing teams they should be on.
+
+	tid = teams[0].TID
+	dl.implicitAsserts[key] = tid
+	dl.localTeams[tid] = info
+
+	asUserName := kbname.NormalizedUsername(name)
+	iteamInfo := ImplicitTeamInfo{
+		// TODO: use the "preferred" canonical format here by listing
+		// the logged-in user first?
+		Name: asUserName,
+		TID:  tid,
+	}
+	dl.localImplicitTeams[tid] = iteamInfo
+	return iteamInfo, nil
+}
+
+// ResolveImplicitTeamByID implements the KeybaseService interface
+// for DaemonLocal.
+func (dl *DaemonLocal) ResolveImplicitTeamByID(
+	ctx context.Context, teamID keybase1.TeamID) (name string, err error) {
+	if err := checkContext(ctx); err != nil {
+		return "", err
+	}
+
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+
+	info, ok := dl.localImplicitTeams[teamID]
+	if !ok {
+		return "", NoSuchTeamError{teamID.String()}
+	}
+	return info.Name.String(), nil
+}
+
+// LoadUserPlusKeys implements the KeybaseService interface for
+// DaemonLocal.
+func (dl *DaemonLocal) LoadUserPlusKeys(
+	ctx context.Context, uid keybase1.UID, _ keybase1.KID,
+	_ keybase1.OfflineAvailability) (UserInfo, error) {
+	if err := checkContext(ctx); err != nil {
+		return UserInfo{}, err
+	}
+
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	u, err := dl.localUsers.getLocalUser(uid)
+	if err != nil {
+		return UserInfo{}, err
+	}
+
+	var infoCopy UserInfo
+	if err := kbfscodec.Update(dl.codec, &infoCopy, u.UserInfo); err != nil {
+		return UserInfo{}, err
+	}
+	return infoCopy, nil
+}
+
+// LoadTeamPlusKeys implements the KeybaseService interface for
+// DaemonLocal.
+func (dl *DaemonLocal) LoadTeamPlusKeys(
+	ctx context.Context, tid keybase1.TeamID, _ tlf.Type, _ kbfsmd.KeyGen,
+	_ keybase1.UserVersion, _ kbfscrypto.VerifyingKey,
+	_ keybase1.TeamRole, _ keybase1.OfflineAvailability) (TeamInfo, error) {
+	if err := checkContext(ctx); err != nil {
+		return TeamInfo{}, err
+	}
+
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	t, err := dl.localTeams.getLocalTeam(tid)
+	if err != nil {
+		return TeamInfo{}, err
+	}
+
+	// Copy the info since it contains a map that might be mutated.
+	var infoCopy TeamInfo
+	if err := kbfscodec.Update(dl.codec, &infoCopy, t); err != nil {
+		return TeamInfo{}, err
+	}
+	return infoCopy, nil
+}
+
+// CreateTeamTLF implements the KeybaseService interface for
+// DaemonLocal.
+func (dl *DaemonLocal) CreateTeamTLF(
+	ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) (err error) {
+	if err := checkContext(ctx); err != nil {
+		return err
+	}
+
+	// TODO: add check to make sure the private/public suffix of the
+	// team ID matches that of the tlf ID.
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	iteamInfo, isImplicit := dl.localImplicitTeams[teamID]
+	if isImplicit {
+		iteamInfo.TlfID = tlfID
+		dl.localImplicitTeams[teamID] = iteamInfo
+	}
+	_, isRegularTeam := dl.localTeams[teamID]
+	if !isImplicit && !isRegularTeam {
+		return NoSuchTeamError{teamID.String()}
+	}
+	dl.localTeamSettings[teamID] = keybase1.KBFSTeamSettings{
+		TlfID: keybase1.TLFID(tlfID.String())}
+	return nil
+}
+
+// GetTeamSettings implements the KeybaseService interface for
+// DaemonLocal.
+func (dl *DaemonLocal) GetTeamSettings(
+	ctx context.Context, teamID keybase1.TeamID,
+	_ keybase1.OfflineAvailability) (
+	settings keybase1.KBFSTeamSettings, err error) {
+	if err := checkContext(ctx); err != nil {
+		return keybase1.KBFSTeamSettings{}, err
+	}
+
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	return dl.localTeamSettings[teamID], nil
+}
+
+// GetCurrentMerkleRoot implements the MerkleRootGetter interface for
+// DaemonLocal.
+func (dl *DaemonLocal) GetCurrentMerkleRoot(ctx context.Context) (
+	keybase1.MerkleRootV2, time.Time, error) {
+	if err := checkContext(ctx); err != nil {
+		return keybase1.MerkleRootV2{}, time.Time{}, err
+	}
+
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	return dl.merkleRoot, dl.merkleTime, nil
+}
+
+// VerifyMerkleRoot implements the MerkleRootGetter interface for
+// DaemonLocal.
+func (dl *DaemonLocal) VerifyMerkleRoot(
+	_ context.Context, _ keybase1.MerkleRootV2, _ keybase1.KBFSRoot) error {
+	return nil
+}
+
+// SetCurrentMerkleRoot is a helper function, useful for tests, to set
+// the current Merkle root.
+func (dl *DaemonLocal) SetCurrentMerkleRoot(
+	root keybase1.MerkleRootV2, rootTime time.Time) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	dl.merkleRoot = root
+	dl.merkleTime = rootTime
+}
+
+// CurrentSession implements the KeybaseService interface for
+// DaemonLocal.
+func (dl *DaemonLocal) CurrentSession(ctx context.Context, sessionID int) (
+	SessionInfo, error) {
+	if err := checkContext(ctx); err != nil {
+		return SessionInfo{}, err
+	}
+
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	u, err := dl.localUsers.getLocalUser(dl.currentUID)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	return SessionInfo{
+		Name:           u.Name,
+		UID:            u.UID,
+		CryptPublicKey: u.GetCurrentCryptPublicKey(),
+		VerifyingKey:   u.GetCurrentVerifyingKey(),
+	}, nil
+}
+
+// AddNewAssertionForTest makes newAssertion, which should be a single
+// assertion that doesn't already resolve to anything, resolve to the
+// same UID as oldAssertion, which should be an arbitrary assertion
+// that does already resolve to something.  It returns the UID of the
+// user associated with the given assertions.
+func (dl *DaemonLocal) AddNewAssertionForTest(
+	oldAssertion, newAssertion string) (keybase1.UID, error) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	id, err := dl.assertionToIDLocked(context.Background(), oldAssertion)
+	if err != nil {
+		return keybase1.UID(""), err
+	}
+	uid := id.AsUserOrBust()
+
+	lu, err := dl.localUsers.getLocalUser(uid)
+	if err != nil {
+		return keybase1.UID(""), err
+	}
+	lu.Asserts = append(lu.Asserts, newAssertion)
+	dl.asserts[newAssertion] = id
+	dl.localUsers[uid] = lu
+	return uid, nil
+}
+
+// AddNewAssertionForTestOrBust is like AddNewAssertionForTest, but
+// panics if there's an error.
+func (dl *DaemonLocal) AddNewAssertionForTestOrBust(
+	oldAssertion, newAssertion string) keybase1.UID {
+	uid, err := dl.AddNewAssertionForTest(oldAssertion, newAssertion)
+	if err != nil {
+		panic(err)
+	}
+	return uid
+}
+
+// ChangeTeamNameForTest updates the name of an existing team.
+func (dl *DaemonLocal) ChangeTeamNameForTest(
+	oldName, newName string) (keybase1.TeamID, error) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	oldAssert := oldName + "@team"
+	newAssert := newName + "@team"
+
+	id, ok := dl.asserts[oldAssert]
+	if !ok {
+		return keybase1.TeamID(""),
+			fmt.Errorf("No such old team name: %s", oldName)
+	}
+	tid, err := id.AsTeam()
+	if err != nil {
+		return keybase1.TeamID(""), err
+	}
+
+	team, ok := dl.localTeams[tid]
+	if !ok {
+		return keybase1.TeamID(""),
+			fmt.Errorf("No such old team name: %s/%s", oldName, tid)
+	}
+	team.Name = kbname.NormalizedUsername(newName)
+	dl.localTeams[tid] = team
+
+	dl.asserts[newAssert] = id
+	delete(dl.asserts, oldAssert)
+	return tid, nil
+}
+
+// changeTeamNameForTestOrBust is like changeTeamNameForTest, but
+// panics if there's an error.
+func (dl *DaemonLocal) changeTeamNameForTestOrBust(
+	oldName, newName string) keybase1.TeamID {
+	tid, err := dl.ChangeTeamNameForTest(oldName, newName)
+	if err != nil {
+		panic(err)
+	}
+	return tid
+}
+
+// RemoveAssertionForTest removes the given assertion.  Should only be
+// used by tests.
+func (dl *DaemonLocal) RemoveAssertionForTest(assertion string) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	delete(dl.asserts, assertion)
+}
+
+// AddTeamWriterForTest adds a writer to a team.  Should only be used
+// by tests.
+func (dl *DaemonLocal) AddTeamWriterForTest(
+	tid keybase1.TeamID, uid keybase1.UID) (kbname.NormalizedUsername, error) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	t, err := dl.localTeams.getLocalTeam(tid)
+	if err != nil {
+		return "", err
+	}
+
+	if t.Writers == nil {
+		t.Writers = make(map[keybase1.UID]bool)
+	}
+	t.Writers[uid] = true
+	delete(t.Readers, uid)
+	dl.localTeams[tid] = t
+	return t.Name, nil
+}
+
+// RemoveTeamWriterForTest removes a writer from a team.  Should only
+// be used by tests.
+func (dl *DaemonLocal) RemoveTeamWriterForTest(
+	tid keybase1.TeamID, uid keybase1.UID) (kbname.NormalizedUsername, error) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	t, err := dl.localTeams.getLocalTeam(tid)
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := t.Writers[uid]; ok {
+		u, err := dl.localUsers.getLocalUser(uid)
+		if err != nil {
+			return "", err
+		}
+		if t.LastWriters == nil {
+			t.LastWriters = make(
+				map[kbfscrypto.VerifyingKey]keybase1.MerkleRootV2)
+		}
+		for _, key := range u.VerifyingKeys {
+			t.LastWriters[key] = dl.merkleRoot
+		}
+	}
+	dl.merkleRoot.Seqno++
+
+	delete(t.Writers, uid)
+	delete(t.Readers, uid)
+
+	dl.localTeams[tid] = t
+	return t.Name, nil
+}
+
+// AddTeamReaderForTest adds a reader to a team.  Should only be used
+// by tests.
+func (dl *DaemonLocal) AddTeamReaderForTest(
+	tid keybase1.TeamID, uid keybase1.UID) (kbname.NormalizedUsername, error) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	t, err := dl.localTeams.getLocalTeam(tid)
+	if err != nil {
+		return "", err
+	}
+
+	if t.Writers[uid] {
+		// Being a writer already implies being a reader.
+		return "", nil
+	}
+
+	if t.Readers == nil {
+		t.Readers = make(map[keybase1.UID]bool)
+	}
+	t.Readers[uid] = true
+	dl.localTeams[tid] = t
+	return t.Name, nil
+}
+
+// AddTeamKeyForTest adds a key to a team.  Should only be used by
+// tests.
+func (dl *DaemonLocal) AddTeamKeyForTest(
+	tid keybase1.TeamID, newKeyGen kbfsmd.KeyGen,
+	newKey kbfscrypto.TLFCryptKey) error {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	t, err := dl.localTeams.getLocalTeam(tid)
+	if err != nil {
+		return err
+	}
+
+	t.CryptKeys[newKeyGen] = newKey
+	if newKeyGen > t.LatestKeyGen {
+		t.LatestKeyGen = newKeyGen
+		// Only need to save back to the map if we've modified a
+		// non-reference type like the latest key gen.
+		dl.localTeams[tid] = t
+	}
+	return nil
+}
+
+func (dl *DaemonLocal) addTeamsForTestLocked(teams []TeamInfo) {
+	for _, t := range teams {
+		dl.localTeams[t.TID] = t
+		dl.asserts[string(t.Name)+"@team"] = t.TID.AsUserOrTeam()
+	}
+}
+
+// AddTeamsForTest adds teams to this daemon.  Should only be used by
+// tests.
+func (dl *DaemonLocal) AddTeamsForTest(teams []TeamInfo) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	dl.addTeamsForTestLocked(teams)
+}
+
+// GetLocalUser returns the `LocalUser` object for the given UID.
+func (dl *DaemonLocal) GetLocalUser(uid keybase1.UID) (LocalUser, error) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	return dl.localUsers.getLocalUser(uid)
+}
+
+// SetLocalUser sets the `LocalUser` object for the given UID.
+func (dl *DaemonLocal) SetLocalUser(uid keybase1.UID, user LocalUser) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	dl.localUsers[uid] = user
+}
+
+// GetIDForAssertion returns the UID associated with the given
+// assertion.
+func (dl *DaemonLocal) GetIDForAssertion(assertion string) (
+	keybase1.UserOrTeamID, bool) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	id, ok := dl.asserts[assertion]
+	return id, ok
+}
+
+// GetLocalUsers returns all of the users tracked by this daemon.
+func (dl *DaemonLocal) GetLocalUsers() (res []LocalUser) {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	for _, u := range dl.localUsers {
+		res = append(res, u)
+	}
+	return res
+}
+
+// NewDaemonLocal constructs a new DaemonLocal, initialized to contain
+// the given users and teams.
+func NewDaemonLocal(
+	currentUID keybase1.UID, users []LocalUser,
+	teams []TeamInfo, codec kbfscodec.Codec) *DaemonLocal {
+	localUserMap := make(localUserMap)
+	asserts := make(map[string]keybase1.UserOrTeamID)
+	for _, u := range users {
+		localUserMap[u.UID] = u
+		for _, a := range u.Asserts {
+			asserts[a] = u.UID.AsUserOrTeam()
+		}
+		asserts[string(u.Name)] = u.UID.AsUserOrTeam()
+	}
+	dl := &DaemonLocal{
+		codec:              codec,
+		localUsers:         localUserMap,
+		localTeams:         make(localTeamMap),
+		localTeamSettings:  make(localTeamSettingsMap),
+		localImplicitTeams: make(localImplicitTeamMap),
+		asserts:            asserts,
+		implicitAsserts:    make(map[string]keybase1.TeamID),
+		currentUID:         currentUID,
+		// TODO: let test fill in valid merkle root.
+	}
+	dl.AddTeamsForTest(teams)
+	return dl
+}

--- a/go/kbfs/idutil/data_types.go
+++ b/go/kbfs/idutil/data_types.go
@@ -1,0 +1,153 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package idutil
+
+import (
+	"github.com/keybase/client/go/kbfs/kbfscrypto"
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/tlf"
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+const (
+	// PublicUIDName is the name given to keybase1.PublicUID.  This string
+	// should correspond to an illegal or reserved Keybase user name.
+	PublicUIDName = "_public"
+)
+
+// RevokedKeyInfo contains any KBFS-relevant data to user keys that
+// have been revoked or belong to a account before it was reset.
+type RevokedKeyInfo struct {
+	// Fields are exported so they can be copied by the codec.
+	Time       keybase1.Time
+	MerkleRoot keybase1.MerkleRootV2
+
+	// These fields never need copying.
+	sigChainLocation keybase1.SigChainLocation
+	resetSeqno       keybase1.Seqno
+	isReset          bool
+	filledInMerkle   bool
+}
+
+// SigChainLocation returns the sigchain location for this revocation.
+func (rki RevokedKeyInfo) SigChainLocation() keybase1.SigChainLocation {
+	return rki.sigChainLocation
+}
+
+// SetSigChainLocation sets the sigchain location for this revocation.
+func (rki *RevokedKeyInfo) SetSigChainLocation(loc keybase1.SigChainLocation) {
+	rki.sigChainLocation = loc
+}
+
+// FilledInMerkle returns whether or not this key info has had its
+// merkle data (like the sigchain location or the reset info) filled
+// in yet.
+func (rki RevokedKeyInfo) FilledInMerkle() bool {
+	return rki.filledInMerkle
+}
+
+// SetFilledInMerkle sets whether or not this key info has had its
+// merkle data (like the sigchain location or the reset info) filled
+// in yet.
+func (rki *RevokedKeyInfo) SetFilledInMerkle(filledIn bool) {
+	rki.filledInMerkle = filledIn
+}
+
+// ResetInfo returns, if this key belongs to an account before it was
+// reset, data about that reset.
+func (rki RevokedKeyInfo) ResetInfo() (keybase1.Seqno, bool) {
+	return rki.resetSeqno, rki.isReset
+}
+
+// SetResetInfo sets, if this key belongs to an account before it was
+// reset, data about that reset.
+func (rki *RevokedKeyInfo) SetResetInfo(seqno keybase1.Seqno, isReset bool) {
+	rki.resetSeqno = seqno
+	rki.isReset = isReset
+}
+
+// UserInfo contains all the info about a keybase user that kbfs cares
+// about.
+type UserInfo struct {
+	Name            kbname.NormalizedUsername
+	UID             keybase1.UID
+	VerifyingKeys   []kbfscrypto.VerifyingKey
+	CryptPublicKeys []kbfscrypto.CryptPublicKey
+	KIDNames        map[keybase1.KID]string
+	EldestSeqno     keybase1.Seqno
+
+	// Revoked keys, and the time at which they were revoked.
+	RevokedVerifyingKeys   map[kbfscrypto.VerifyingKey]RevokedKeyInfo
+	RevokedCryptPublicKeys map[kbfscrypto.CryptPublicKey]RevokedKeyInfo
+}
+
+// DeepCopy returns a copy of `ui`, including deep copies of all slice
+// and map members.
+func (ui UserInfo) DeepCopy() UserInfo {
+	copyUI := ui
+	copyUI.VerifyingKeys = make(
+		[]kbfscrypto.VerifyingKey, len(ui.VerifyingKeys))
+	copy(copyUI.VerifyingKeys, ui.VerifyingKeys)
+	copyUI.CryptPublicKeys = make(
+		[]kbfscrypto.CryptPublicKey, len(ui.CryptPublicKeys))
+	copy(copyUI.CryptPublicKeys, ui.CryptPublicKeys)
+	copyUI.KIDNames = make(map[keybase1.KID]string, len(ui.KIDNames))
+	for k, v := range ui.KIDNames {
+		copyUI.KIDNames[k] = v
+	}
+	copyUI.RevokedVerifyingKeys = make(
+		map[kbfscrypto.VerifyingKey]RevokedKeyInfo,
+		len(ui.RevokedVerifyingKeys))
+	for k, v := range ui.RevokedVerifyingKeys {
+		copyUI.RevokedVerifyingKeys[k] = v
+	}
+	copyUI.RevokedCryptPublicKeys = make(
+		map[kbfscrypto.CryptPublicKey]RevokedKeyInfo,
+		len(ui.RevokedCryptPublicKeys))
+	for k, v := range ui.RevokedCryptPublicKeys {
+		copyUI.RevokedCryptPublicKeys[k] = v
+	}
+	return copyUI
+}
+
+// TeamInfo contains all the info about a keybase team that kbfs cares
+// about.
+type TeamInfo struct {
+	// Maybe this should be bare string?  The service doesn't give us
+	// a nice type, unfortunately.  Also note that for implicit teams,
+	// this is an auto-generated name that shouldn't be shown to
+	// users.
+	Name         kbname.NormalizedUsername
+	TID          keybase1.TeamID
+	CryptKeys    map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey
+	LatestKeyGen kbfsmd.KeyGen
+	RootID       keybase1.TeamID // for subteams only
+
+	Writers map[keybase1.UID]bool
+	Readers map[keybase1.UID]bool
+
+	// Last writers map a KID to the last time the writer associated
+	// with that KID trasitioned from writer to non-writer.
+	LastWriters map[kbfscrypto.VerifyingKey]keybase1.MerkleRootV2
+}
+
+// ImplicitTeamInfo contains information needed after
+// resolving/identifying an implicit team.  TeamInfo is used for
+// anything else.
+type ImplicitTeamInfo struct {
+	Name  kbname.NormalizedUsername // The "display" name for the i-team.
+	TID   keybase1.TeamID
+	TlfID tlf.ID
+}
+
+// SessionInfo contains all the info about the keybase session that
+// kbfs cares about.
+type SessionInfo struct {
+	Name           kbname.NormalizedUsername
+	UID            keybase1.UID
+	CryptPublicKey kbfscrypto.CryptPublicKey
+	VerifyingKey   kbfscrypto.VerifyingKey
+}

--- a/go/kbfs/idutil/errors.go
+++ b/go/kbfs/idutil/errors.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package idutil
+
+import (
+	"fmt"
+
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// NoSigChainError means that a user we were trying to identify does
+// not have a sigchain.
+type NoSigChainError struct {
+	User kbname.NormalizedUsername
+}
+
+// Error implements the error interface for NoSigChainError.
+func (e NoSigChainError) Error() string {
+	return fmt.Sprintf("%s has not yet installed Keybase and set up the "+
+		"Keybase filesystem. Please ask them to.", e.User)
+}
+
+// NoCurrentSessionError indicates that the daemon has no current
+// session.  This is basically a wrapper for session.ErrNoSession,
+// needed to give the correct return error code to the OS.
+type NoCurrentSessionError struct {
+}
+
+// Error implements the error interface for NoCurrentSessionError.
+func (e NoCurrentSessionError) Error() string {
+	return "You are not logged into Keybase.  Try `keybase login`."
+}
+
+// NoSuchUserError indicates that the given user couldn't be resolved.
+type NoSuchUserError struct {
+	Input string
+}
+
+// Error implements the error interface for NoSuchUserError
+func (e NoSuchUserError) Error() string {
+	return fmt.Sprintf("%s is not a Keybase user", e.Input)
+}
+
+// ToStatus implements the keybase1.ToStatusAble interface for NoSuchUserError
+func (e NoSuchUserError) ToStatus() keybase1.Status {
+	return keybase1.Status{
+		Name: "NotFound",
+		Code: int(keybase1.StatusCode_SCNotFound),
+		Desc: e.Error(),
+	}
+}
+
+// NoSuchTeamError indicates that the given team couldn't be resolved.
+type NoSuchTeamError struct {
+	Input string
+}
+
+// Error implements the error interface for NoSuchTeamError
+func (e NoSuchTeamError) Error() string {
+	return fmt.Sprintf("%s is not a Keybase team", e.Input)
+}
+
+// TlfNameNotCanonical indicates that a name isn't a canonical, and
+// that another (not necessarily canonical) name should be tried.
+type TlfNameNotCanonical struct {
+	Name, NameToTry string
+}
+
+// Error implements the error interface for TlfNameNotCanonical.
+func (e TlfNameNotCanonical) Error() string {
+	return fmt.Sprintf("TLF name %s isn't canonical: try %s instead",
+		e.Name, e.NameToTry)
+}
+
+// NoSuchNameError indicates that the user tried to access a
+// subdirectory entry that doesn't exist.
+type NoSuchNameError struct {
+	Name string
+}
+
+// Error implements the error interface for NoSuchNameError
+func (e NoSuchNameError) Error() string {
+	return fmt.Sprintf("%s doesn't exist", e.Name)
+}
+
+// BadTLFNameError indicates a top-level folder name that has an
+// incorrect format.
+type BadTLFNameError struct {
+	Name string
+}
+
+// Error implements the error interface for BadTLFNameError.
+func (e BadTLFNameError) Error() string {
+	return fmt.Sprintf("TLF name %s is in an incorrect format", e.Name)
+}

--- a/go/kbfs/idutil/interfaces.go
+++ b/go/kbfs/idutil/interfaces.go
@@ -1,0 +1,302 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package idutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/keybase/client/go/kbfs/kbfscrypto"
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/tlf"
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// Resolver is an interface to be used to resolve assertions, implicit
+// teams and team TLF IDs.
+type Resolver interface {
+	// Resolve, given an assertion, resolves it to a username/UID
+	// pair. The username <-> UID mapping is trusted and
+	// immutable, so it can be cached. If the assertion is just
+	// the username or a UID assertion, then the resolution can
+	// also be trusted. If the returned pair is equal to that of
+	// the current session, then it can also be
+	// trusted. Otherwise, Identify() needs to be called on the
+	// assertion before the assertion -> (username, UserOrTeamID) mapping
+	// can be trusted.
+	//
+	//
+	// If the caller knows that the assertion needs to be resolvable
+	// while offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `Resolve` might block on a network call.
+	//
+	// TODO: some of the above assumptions on cacheability aren't
+	// right for subteams, which can change their name, so this may
+	// need updating.
+	Resolve(ctx context.Context, assertion string,
+		offline keybase1.OfflineAvailability) (
+		kbname.NormalizedUsername, keybase1.UserOrTeamID, error)
+
+	// ResolveImplicitTeam resolves the given implicit team.
+	//
+	// If the caller knows that the team needs to be resolvable while
+	// offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `ResolveImplicitTeam` might block on a
+	// network call.
+	ResolveImplicitTeam(
+		ctx context.Context, assertions, suffix string, tlfType tlf.Type,
+		offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error)
+
+	// ResolveImplicitTeamByID resolves the given implicit team, given
+	// a team ID.
+	//
+	// If the caller knows that the team needs to be resolvable while
+	// offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `ResolveImplicitTeamByID` might block on
+	// a network call.
+	ResolveImplicitTeamByID(
+		ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type,
+		offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error)
+	// ResolveTeamTLFID returns the TLF ID associated with a given
+	// team ID, or tlf.NullID if no ID is yet associated with that
+	// team.
+	//
+	// If the caller knows that the ID needs to be resolved while
+	// offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `ResolveTeamTLFID` might block on a
+	// network call.
+	ResolveTeamTLFID(
+		ctx context.Context, teamID keybase1.TeamID,
+		offline keybase1.OfflineAvailability) (tlf.ID, error)
+
+	// NormalizeSocialAssertion creates a SocialAssertion from its input and
+	// normalizes it.  The service name will be lowercased.  If the service is
+	// case-insensitive, then the username will also be lowercased.  Colon
+	// assertions (twitter:user) will be transformed to the user@twitter
+	// format.  Only registered services are allowed.
+	NormalizeSocialAssertion(
+		ctx context.Context, assertion string) (keybase1.SocialAssertion, error)
+}
+
+// NormalizedUsernameGetter is an interface that can get a normalized
+// username given an ID.
+type NormalizedUsernameGetter interface {
+	// GetNormalizedUsername returns the normalized username
+	// corresponding to the given UID.
+	//
+	// If the caller knows that the assertion needs to be resolvable
+	// while offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `GetNormalizedUsername` might block on a
+	// network call.
+	GetNormalizedUsername(
+		ctx context.Context, id keybase1.UserOrTeamID,
+		offline keybase1.OfflineAvailability) (
+		kbname.NormalizedUsername, error)
+}
+
+// OfflineStatusGetter indicates whether a given TLF needs to be
+// available offline.
+type OfflineStatusGetter interface {
+	OfflineAvailabilityForPath(tlfPath string) keybase1.OfflineAvailability
+	OfflineAvailabilityForID(tlfID tlf.ID) keybase1.OfflineAvailability
+}
+
+// Identifier is an interface that can identify users and teams given
+// assertions.
+type Identifier interface {
+	// Identify resolves an assertion (which could also be a
+	// username) to a UserInfo struct, spawning tracker popups if
+	// necessary.  The reason string is displayed on any tracker
+	// popups spawned.
+	//
+	// If the caller knows that the assertion needs to be identifiable
+	// while offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `Identify` might block on a network call.
+	Identify(ctx context.Context, assertion, reason string,
+		offline keybase1.OfflineAvailability) (
+		kbname.NormalizedUsername, keybase1.UserOrTeamID, error)
+	// IdentifyImplicitTeam identifies (and creates if necessary) the
+	// given implicit team.
+	//
+	// If the caller knows that the team needs to be identifiable
+	// while offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `IdentifyImplicitTeam` might block on a
+	// network call.
+	IdentifyImplicitTeam(
+		ctx context.Context, assertions, suffix string, tlfType tlf.Type,
+		reason string, offline keybase1.OfflineAvailability) (
+		ImplicitTeamInfo, error)
+}
+
+// CurrentSessionGetter is an interface for objects that can return
+// session info.
+type CurrentSessionGetter interface {
+	// GetCurrentSession gets the current session info.
+	GetCurrentSession(ctx context.Context) (SessionInfo, error)
+}
+
+// KBPKI is an interface for something that can resolve, identify, get
+// user names, and get the current session.
+type KBPKI interface {
+	NormalizedUsernameGetter
+	Resolver
+	Identifier
+	CurrentSessionGetter
+}
+
+// Clock is an interface for getting the current time
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+}
+
+// MerkleRootGetter is an interface for getting and verifying global
+// Merkle roots.
+type MerkleRootGetter interface {
+	// GetCurrentMerkleRoot returns the current root of the global
+	// Keybase Merkle tree.
+	GetCurrentMerkleRoot(ctx context.Context) (
+		keybase1.MerkleRootV2, time.Time, error)
+	// VerifyMerkleRoot checks that the specified merkle root
+	// contains the given KBFS root; if not, it returns an error.
+	VerifyMerkleRoot(
+		ctx context.Context, root keybase1.MerkleRootV2,
+		kbfsRoot keybase1.KBFSRoot) error
+}
+
+// KeybaseService is a low-level interface for interacting with the
+// Keybase service process, for the purposes of resolving and
+// identifying users and teams.
+type KeybaseService interface {
+	MerkleRootGetter
+
+	// Resolve, given an assertion, resolves it to a username/UID
+	// pair. The username <-> UID mapping is trusted and
+	// immutable, so it can be cached. If the assertion is just
+	// the username or a UID assertion, then the resolution can
+	// also be trusted. If the returned pair is equal to that of
+	// the current session, then it can also be
+	// trusted. Otherwise, Identify() needs to be called on the
+	// assertion before the assertion -> (username, UID) mapping
+	// can be trusted.
+	//
+	// If the caller knows that the assertion needs to be resolvable
+	// while offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `Resolve` might block on a network call.
+	Resolve(ctx context.Context, assertion string,
+		offline keybase1.OfflineAvailability) (
+		kbname.NormalizedUsername, keybase1.UserOrTeamID, error)
+
+	// Identify, given an assertion, returns a name and ID that
+	// matches that assertion, or an error otherwise. The reason
+	// string is displayed on any tracker popups spawned.
+	//
+	// If the caller knows that the assertion needs to be identifiable
+	// while offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `Identify` might block on a network call.
+	Identify(ctx context.Context, assertion, reason string,
+		offline keybase1.OfflineAvailability) (
+		kbname.NormalizedUsername, keybase1.UserOrTeamID, error)
+
+	// NormalizeSocialAssertion creates a SocialAssertion from its input and
+	// normalizes it.  The service name will be lowercased.  If the service is
+	// case-insensitive, then the username will also be lowercased.  Colon
+	// assertions (twitter:user) will be transformed to the user@twitter
+	// format.  Only registered services are allowed.
+	NormalizeSocialAssertion(
+		ctx context.Context, assertion string) (keybase1.SocialAssertion, error)
+
+	// ResolveIdentifyImplicitTeam resolves, and optionally
+	// identifies, an implicit team.  If the implicit team doesn't yet
+	// exist, and doIdentifies is true, one is created.
+	//
+	// If the caller knows that the team needs to be resolvable while
+	// offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `ResolveIdentifyImplicitTeam` might block
+	// on a network call.
+	ResolveIdentifyImplicitTeam(
+		ctx context.Context, assertions, suffix string, tlfType tlf.Type,
+		doIdentifies bool, reason string,
+		offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error)
+
+	// ResolveImplicitTeamByID resolves an implicit team to a team
+	// name, given a team ID.
+	ResolveImplicitTeamByID(
+		ctx context.Context, teamID keybase1.TeamID) (string, error)
+
+	// CreateTeamTLF associates the given TLF ID with the team ID in
+	// the team's sigchain.  If the team already has a TLF ID
+	// associated with it, this overwrites it.
+	CreateTeamTLF(
+		ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error
+
+	// GetTeamSettings returns the KBFS settings for the given team.
+	//
+	// If the caller knows that the settings needs to be readable
+	// while offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `GetTeamSettings` might block on a
+	// network call.
+	GetTeamSettings(
+		ctx context.Context, teamID keybase1.TeamID,
+		offline keybase1.OfflineAvailability) (keybase1.KBFSTeamSettings, error)
+
+	// LoadUserPlusKeys returns a UserInfo struct for a
+	// user with the specified UID.
+	// If you have the UID for a user and don't require Identify to
+	// validate an assertion or the identity of a user, use this to
+	// get UserInfo structs as it is much cheaper than Identify.
+	//
+	// pollForKID, if non empty, causes `PollForKID` field to be
+	// populated, which causes the service to poll for the given
+	// KID. This is useful during provisioning where the provisioner
+	// needs to get the MD revision that the provisionee has set the
+	// rekey bit on.
+	//
+	// If the caller knows that the user needs to be loadable while
+	// offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `LoadUserPlusKeys` might block on a
+	// network call.
+	LoadUserPlusKeys(
+		ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID,
+		offline keybase1.OfflineAvailability) (UserInfo, error)
+
+	// LoadTeamPlusKeys returns a TeamInfo struct for a team with the
+	// specified TeamID.  The caller can specify `desiredKeyGen` to
+	// force a server check if that particular key gen isn't yet
+	// known; it may be set to UnspecifiedKeyGen if no server check is
+	// required.  The caller can specify `desiredUID` and
+	// `desiredRole` to force a server check if that particular UID
+	// isn't a member of the team yet according to local caches; it
+	// may be set to "" if no server check is required.
+	//
+	// If the caller knows that the team needs to be loadable while
+	// offline, they should pass in
+	// `keybase1.OfflineAvailability_BEST_EFFORT` as the `offline`
+	// parameter.  Otherwise `LoadTeamPlusKeys` might block on a
+	// network call.
+	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID,
+		tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen,
+		desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey,
+		desiredRole keybase1.TeamRole, offline keybase1.OfflineAvailability) (
+		TeamInfo, error)
+
+	// CurrentSession returns a SessionInfo struct with all the
+	// information for the current session, or an error otherwise.
+	CurrentSession(ctx context.Context, sessionID int) (
+		SessionInfo, error)
+}

--- a/go/kbfs/idutil/local.go
+++ b/go/kbfs/idutil/local.go
@@ -1,0 +1,212 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package idutil
+
+import (
+	"strings"
+
+	"github.com/keybase/client/go/kbfs/kbfscrypto"
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/tlf"
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// LocalUser represents a fake KBFS user, useful for testing.
+type LocalUser struct {
+	UserInfo
+	Asserts []string
+	// Index into UserInfo.CryptPublicKeys.
+	CurrentCryptPublicKeyIndex int
+	// Index into UserInfo.VerifyingKeys.
+	CurrentVerifyingKeyIndex int
+	// Unverified keys.
+	UnverifiedKeys []keybase1.PublicKey
+}
+
+// GetCurrentCryptPublicKey returns this LocalUser's public encryption key.
+func (lu *LocalUser) GetCurrentCryptPublicKey() kbfscrypto.CryptPublicKey {
+	return lu.CryptPublicKeys[lu.CurrentCryptPublicKeyIndex]
+}
+
+// GetCurrentVerifyingKey returns this LocalUser's public signing key.
+func (lu *LocalUser) GetCurrentVerifyingKey() kbfscrypto.VerifyingKey {
+	return lu.VerifyingKeys[lu.CurrentVerifyingKeyIndex]
+}
+
+// MakeLocalUsers is a helper function to generate a list of
+// LocalUsers suitable to use with KeybaseDaemonLocal.
+func MakeLocalUsers(users []kbname.NormalizedUsername) []LocalUser {
+	localUsers := make([]LocalUser, len(users))
+	for i := 0; i < len(users); i++ {
+		verifyingKey := MakeLocalUserVerifyingKeyOrBust(users[i])
+		cryptPublicKey := MakeLocalUserCryptPublicKeyOrBust(users[i])
+		localUsers[i] = LocalUser{
+			UserInfo: UserInfo{
+				Name:            users[i],
+				UID:             keybase1.MakeTestUID(uint32(i + 1)),
+				VerifyingKeys:   []kbfscrypto.VerifyingKey{verifyingKey},
+				CryptPublicKeys: []kbfscrypto.CryptPublicKey{cryptPublicKey},
+				KIDNames: map[keybase1.KID]string{
+					verifyingKey.KID(): "dev1",
+				},
+			},
+			CurrentCryptPublicKeyIndex: 0,
+			CurrentVerifyingKeyIndex:   0,
+		}
+	}
+	return localUsers
+}
+
+func verifyingKeysToPublicKeys(
+	keys []kbfscrypto.VerifyingKey) []keybase1.PublicKey {
+	publicKeys := make([]keybase1.PublicKey, len(keys))
+	for i, key := range keys {
+		publicKeys[i] = keybase1.PublicKey{
+			KID:      key.KID(),
+			IsSibkey: true,
+		}
+	}
+	return publicKeys
+}
+
+func cryptPublicKeysToPublicKeys(
+	keys []kbfscrypto.CryptPublicKey) []keybase1.PublicKey {
+	publicKeys := make([]keybase1.PublicKey, len(keys))
+	for i, key := range keys {
+		publicKeys[i] = keybase1.PublicKey{
+			KID:      key.KID(),
+			IsSibkey: false,
+		}
+	}
+	return publicKeys
+}
+
+// GetPublicKeys returns all of this LocalUser's public encryption keys.
+func (lu *LocalUser) GetPublicKeys() []keybase1.PublicKey {
+	sibkeys := verifyingKeysToPublicKeys(lu.VerifyingKeys)
+	subkeys := cryptPublicKeysToPublicKeys(lu.CryptPublicKeys)
+	return append(sibkeys, subkeys...)
+}
+
+// DeepCopy returns a deep copy of this `LocalUser`.
+func (lu LocalUser) DeepCopy() LocalUser {
+	luCopy := lu
+
+	luCopy.VerifyingKeys = make(
+		[]kbfscrypto.VerifyingKey, len(lu.VerifyingKeys))
+	copy(luCopy.VerifyingKeys, lu.VerifyingKeys)
+
+	luCopy.CryptPublicKeys = make(
+		[]kbfscrypto.CryptPublicKey, len(lu.CryptPublicKeys))
+	copy(luCopy.CryptPublicKeys, lu.CryptPublicKeys)
+
+	luCopy.KIDNames = make(map[keybase1.KID]string, len(lu.KIDNames))
+	for k, v := range lu.KIDNames {
+		luCopy.KIDNames[k] = v
+	}
+
+	luCopy.RevokedVerifyingKeys = make(
+		map[kbfscrypto.VerifyingKey]RevokedKeyInfo,
+		len(lu.RevokedVerifyingKeys))
+	for k, v := range lu.RevokedVerifyingKeys {
+		luCopy.RevokedVerifyingKeys[k] = v
+	}
+
+	luCopy.RevokedCryptPublicKeys = make(
+		map[kbfscrypto.CryptPublicKey]RevokedKeyInfo,
+		len(lu.RevokedCryptPublicKeys))
+	for k, v := range lu.RevokedCryptPublicKeys {
+		luCopy.RevokedCryptPublicKeys[k] = v
+	}
+
+	luCopy.Asserts = make([]string, len(lu.Asserts))
+	copy(luCopy.Asserts, lu.Asserts)
+	luCopy.UnverifiedKeys = make([]keybase1.PublicKey, len(lu.UnverifiedKeys))
+	copy(luCopy.UnverifiedKeys, lu.UnverifiedKeys)
+
+	return luCopy
+}
+
+func makeLocalTeams(
+	teams []kbname.NormalizedUsername, startingIndex int, ty tlf.Type) (
+	localTeams []TeamInfo) {
+	localTeams = make([]TeamInfo, len(teams))
+	for index := 0; index < len(teams); index++ {
+		i := index + startingIndex
+		cryptKey := MakeLocalTLFCryptKeyOrBust(
+			tlf.SingleTeam.String()+"/"+string(teams[index]),
+			kbfsmd.FirstValidKeyGen)
+		localTeams[index] = TeamInfo{
+			Name: teams[index],
+			TID:  keybase1.MakeTestTeamID(uint32(i+1), ty == tlf.Public),
+			CryptKeys: map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey{
+				kbfsmd.FirstValidKeyGen: cryptKey,
+			},
+			LatestKeyGen: kbfsmd.FirstValidKeyGen,
+		}
+		// If this is a subteam, set the root ID.
+		if strings.Contains(string(teams[index]), ".") {
+			parts := strings.SplitN(string(teams[index]), ".", 2)
+			for j := 0; j < index; j++ {
+				if parts[0] == string(localTeams[j].Name) {
+					localTeams[index].RootID = localTeams[j].TID
+					break
+				}
+			}
+		}
+	}
+	return localTeams
+}
+
+// MakeLocalTeams is a helper function to generate a list of local
+// teams suitable to use with KeybaseDaemonLocal.  Any subteams must come
+// after their root team names in the `teams` slice.
+func MakeLocalTeams(teams []kbname.NormalizedUsername) []TeamInfo {
+	return makeLocalTeams(teams, 0, tlf.Private)
+}
+
+// Helper functions to get a various keys for a local user. Each
+// function will return the same key will always be returned for a
+// given user.
+
+// MakeLocalUserSigningKeyOrBust returns a unique signing key for this user.
+func MakeLocalUserSigningKeyOrBust(
+	name kbname.NormalizedUsername) kbfscrypto.SigningKey {
+	return kbfscrypto.MakeFakeSigningKeyOrBust(
+		string(name) + " signing key")
+}
+
+// MakeLocalUserCryptPublicKeyOrBust returns the public key
+// corresponding to the crypt private key for this user.
+func MakeLocalUserCryptPublicKeyOrBust(
+	name kbname.NormalizedUsername) kbfscrypto.CryptPublicKey {
+	return MakeLocalUserCryptPrivateKeyOrBust(name).GetPublicKey()
+}
+
+// MakeLocalUserVerifyingKeyOrBust makes a new verifying key
+// corresponding to the signing key for this user.
+func MakeLocalUserVerifyingKeyOrBust(
+	name kbname.NormalizedUsername) kbfscrypto.VerifyingKey {
+	return MakeLocalUserSigningKeyOrBust(name).GetVerifyingKey()
+}
+
+// MakeLocalUserCryptPrivateKeyOrBust returns a unique private
+// encryption key for this user.
+func MakeLocalUserCryptPrivateKeyOrBust(
+	name kbname.NormalizedUsername) kbfscrypto.CryptPrivateKey {
+	return kbfscrypto.MakeFakeCryptPrivateKeyOrBust(
+		string(name) + " crypt key")
+}
+
+// MakeLocalTLFCryptKeyOrBust returns a unique private symmetric key
+// for a TLF.
+func MakeLocalTLFCryptKeyOrBust(
+	name string, keyGen kbfsmd.KeyGen) kbfscrypto.TLFCryptKey {
+	// Put the key gen first to make it more likely to fit into the
+	// 32-character "random" seed.
+	return kbfscrypto.MakeFakeTLFCryptKeyOrBust(
+		string(name) + " " + string(keyGen) + " crypt key ")
+}

--- a/go/kbfs/idutil/session.go
+++ b/go/kbfs/idutil/session.go
@@ -1,0 +1,60 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package idutil
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/kbfs/kbfscrypto"
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// GetCurrentSessionIfPossible returns the current username and UID
+// from kbpki.GetCurrentSession.  If sessionNotRequired is true
+// NoCurrentSessionError is ignored and empty username and uid will be
+// returned. If it is false all errors are returned.
+func GetCurrentSessionIfPossible(
+	ctx context.Context, kbpki CurrentSessionGetter, sessionNotRequired bool) (
+	SessionInfo, error) {
+	session, err := kbpki.GetCurrentSession(ctx)
+	if err == nil {
+		return session, nil
+	}
+	// Return all errors if a session is required.
+	if !sessionNotRequired {
+		return SessionInfo{}, err
+	}
+
+	// If not logged in, return empty session.
+	if _, notLoggedIn := err.(NoCurrentSessionError); notLoggedIn {
+		return SessionInfo{}, nil
+	}
+
+	// Otherwise, just return the error.
+	return SessionInfo{}, err
+}
+
+// SessionInfoFromProtocol returns SessionInfo from Session
+func SessionInfoFromProtocol(session keybase1.Session) (SessionInfo, error) {
+	// Import the KIDs to validate them.
+	deviceSubkey, err := libkb.ImportKeypairFromKID(session.DeviceSubkeyKid)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	deviceSibkey, err := libkb.ImportKeypairFromKID(session.DeviceSibkeyKid)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	cryptPublicKey := kbfscrypto.MakeCryptPublicKey(deviceSubkey.GetKID())
+	verifyingKey := kbfscrypto.MakeVerifyingKey(deviceSibkey.GetKID())
+	return SessionInfo{
+		Name:           kbname.NewNormalizedUsername(session.Username),
+		UID:            keybase1.UID(session.Uid),
+		CryptPublicKey: cryptPublicKey,
+		VerifyingKey:   verifyingKey,
+	}, nil
+}

--- a/go/kbfs/idutil/test/getter.go
+++ b/go/kbfs/idutil/test/getter.go
@@ -1,0 +1,39 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/client/go/kbfs/idutil"
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// NormalizedUsernameGetter is a simple map of IDs -> usernames that
+// can be useful for testing.
+type NormalizedUsernameGetter map[keybase1.UserOrTeamID]kbname.NormalizedUsername
+
+var _ idutil.NormalizedUsernameGetter = NormalizedUsernameGetter{}
+
+// GetNormalizedUsername implements the idutil.NormalizedUsernameGetter
+// interface for NormalizedUsernameGetter.
+func (g NormalizedUsernameGetter) GetNormalizedUsername(
+	ctx context.Context, id keybase1.UserOrTeamID,
+	_ keybase1.OfflineAvailability) (kbname.NormalizedUsername, error) {
+	name, ok := g[id]
+	if !ok {
+		return kbname.NormalizedUsername(""),
+			idutil.NoSuchUserError{Input: fmt.Sprintf("uid:%s", id)}
+	}
+	return name, nil
+}
+
+// UIDMap converts this getter into a typed map of user IDs ->
+// normalized names.
+func (g NormalizedUsernameGetter) UIDMap() map[keybase1.UserOrTeamID]kbname.NormalizedUsername {
+	return (map[keybase1.UserOrTeamID]kbname.NormalizedUsername)(g)
+}

--- a/go/kbfs/idutil/test/kbpki_util.go
+++ b/go/kbfs/idutil/test/kbpki_util.go
@@ -1,0 +1,131 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"sync"
+
+	"github.com/keybase/client/go/kbfs/idutil"
+	"github.com/keybase/client/go/kbfs/tlf"
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+// DaemonKBPKI is a hacky way to make a KBPKI instance that uses some
+// methods from KeybaseService.
+type DaemonKBPKI struct {
+	idutil.KBPKI
+	Daemon *idutil.DaemonLocal
+}
+
+// GetCurrentSession implements the idutil.DaemonLocal interface for
+// DaemonKBPKI.
+func (d *DaemonKBPKI) GetCurrentSession(ctx context.Context) (
+	idutil.SessionInfo, error) {
+	const sessionID = 0
+	return d.Daemon.CurrentSession(ctx, sessionID)
+}
+
+// Resolve implements the idutil.DaemonLocal interface for
+// DaemonKBPKI.
+func (d *DaemonKBPKI) Resolve(
+	ctx context.Context, assertion string,
+	offline keybase1.OfflineAvailability) (
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	return d.Daemon.Resolve(ctx, assertion, offline)
+}
+
+// NormalizeSocialAssertion implements the idutil.DaemonLocal
+// interface for DaemonKBPKI.
+func (d *DaemonKBPKI) NormalizeSocialAssertion(
+	ctx context.Context, assertion string) (
+	keybase1.SocialAssertion, error) {
+	return d.Daemon.NormalizeSocialAssertion(ctx, assertion)
+}
+
+// Identify implements the idutil.DaemonLocal interface for
+// DaemonKBPKI.
+func (d *DaemonKBPKI) Identify(
+	ctx context.Context, assertion, reason string,
+	offline keybase1.OfflineAvailability) (
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	return d.Daemon.Identify(ctx, assertion, reason, offline)
+}
+
+// ResolveImplicitTeam implements the idutil.DaemonLocal interface
+// for DaemonKBPKI.
+func (d *DaemonKBPKI) ResolveImplicitTeam(
+	ctx context.Context, assertions, suffix string, tlfType tlf.Type,
+	offline keybase1.OfflineAvailability) (
+	idutil.ImplicitTeamInfo, error) {
+	return d.Daemon.ResolveIdentifyImplicitTeam(
+		ctx, assertions, suffix, tlfType, false, "", offline)
+}
+
+// GetNormalizedUsername implements the idutil.DaemonLocal interface
+// for DaemonKBPKI.
+func (d *DaemonKBPKI) GetNormalizedUsername(
+	ctx context.Context, id keybase1.UserOrTeamID,
+	offline keybase1.OfflineAvailability) (kbname.NormalizedUsername, error) {
+	asUser, err := id.AsUser()
+	if err != nil {
+		return kbname.NormalizedUsername(""), err
+	}
+	userInfo, err := d.Daemon.LoadUserPlusKeys(
+		ctx, asUser, "", keybase1.OfflineAvailability_NONE)
+	if err != nil {
+		return kbname.NormalizedUsername(""), err
+	}
+	return userInfo.Name, nil
+}
+
+// ResolveTeamTLFID implements the idutil.DaemonLocal interface for
+// DaemonKBPKI.
+func (d *DaemonKBPKI) ResolveTeamTLFID(
+	ctx context.Context, teamID keybase1.TeamID,
+	offline keybase1.OfflineAvailability) (tlf.ID, error) {
+	settings, err := d.Daemon.GetTeamSettings(ctx, teamID, offline)
+	if err != nil {
+		return tlf.NullID, err
+	}
+	tlfID, err := tlf.ParseID(settings.TlfID.String())
+	if err != nil {
+		return tlf.NullID, err
+	}
+	return tlfID, nil
+}
+
+// IdentifyCountingKBPKI is a KBPKI instance that counts calls to
+// Identify.
+type IdentifyCountingKBPKI struct {
+	idutil.KBPKI
+	identifyLock  sync.RWMutex
+	identifyCalls int
+}
+
+func (ik *IdentifyCountingKBPKI) addIdentifyCall() {
+	ik.identifyLock.Lock()
+	defer ik.identifyLock.Unlock()
+	ik.identifyCalls++
+}
+
+// GetIdentifyCalls returns the number of times Identify has been
+// called.
+func (ik *IdentifyCountingKBPKI) GetIdentifyCalls() int {
+	ik.identifyLock.RLock()
+	defer ik.identifyLock.RUnlock()
+	return ik.identifyCalls
+}
+
+// Identify implements the idutil.Identifier interface for
+// IdentifyCountingKBPKI.
+func (ik *IdentifyCountingKBPKI) Identify(
+	ctx context.Context, assertion, reason string,
+	offline keybase1.OfflineAvailability) (
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	ik.addIdentifyCall()
+	return ik.KBPKI.Identify(ctx, assertion, reason, offline)
+}

--- a/go/kbfs/idutil/tlf_names.go
+++ b/go/kbfs/idutil/tlf_names.go
@@ -1,0 +1,145 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package idutil
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbfs/tlf"
+	kbname "github.com/keybase/client/go/kbun"
+	"github.com/pkg/errors"
+)
+
+// TODO: this function can likely be replaced with a call to
+// AssertionParseAndOnly when CORE-2967 and CORE-2968 are fixed.
+func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
+	if kbname.CheckUsername(s) {
+		return kbname.NewNormalizedUsername(s).String(), nil
+	}
+
+	// TODO: this fails for http and https right now (see CORE-2968).
+	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(s)
+	if isSocialAssertion {
+		if t == tlf.SingleTeam {
+			return "", fmt.Errorf(
+				"No social assertions allowed for team TLF: %s", s)
+		}
+		return socialAssertion.String(), nil
+	}
+
+	sAssertion := s
+	if t == tlf.SingleTeam {
+		sAssertion = "team:" + s
+	}
+	if expr, err := externals.AssertionParseAndOnlyStatic(sAssertion); err == nil {
+		// If the expression only contains a single url, make sure
+		// it's not a just considered a single keybase username.  If
+		// it is, then some non-username slipped into the default
+		// "keybase" case and should be considered an error.
+		urls := expr.CollectUrls(nil)
+		if len(urls) == 1 && urls[0].IsKeybase() {
+			return "", NoSuchUserError{s}
+		}
+
+		// Normalize and return.  Ideally `AssertionParseAndOnly`
+		// would normalize for us, but that doesn't work yet, so for
+		// now we'll just lower-case.  This will incorrectly lower
+		// case http/https/web assertions, as well as case-sensitive
+		// social assertions in AND expressions.  TODO: see CORE-2967.
+		return strings.ToLower(s), nil
+	}
+
+	return "", BadTLFNameError{s}
+}
+
+// normalizeNames normalizes a slice of names and returns
+// whether any of them changed.
+func normalizeNames(names []string, t tlf.Type) (changesMade bool, err error) {
+	for i, name := range names {
+		x, err := normalizeAssertionOrName(name, t)
+		if err != nil {
+			return false, err
+		}
+		if x != name {
+			names[i] = x
+			changesMade = true
+		}
+	}
+	return changesMade, nil
+}
+
+// NormalizeNamesInTLF takes a split TLF name and, without doing any
+// resolutions or identify calls, normalizes all elements of the
+// name. It then returns the normalized name and a boolean flag
+// whether any names were modified.
+// This modifies the slices passed as arguments.
+func NormalizeNamesInTLF(writerNames, readerNames []string,
+	t tlf.Type, extensionSuffix string) (normalizedName string,
+	changesMade bool, err error) {
+	changesMade, err = normalizeNames(writerNames, t)
+	if err != nil {
+		return "", false, err
+	}
+	sort.Strings(writerNames)
+	normalizedName = strings.Join(writerNames, ",")
+	if len(readerNames) > 0 {
+		rchanges, err := normalizeNames(readerNames, t)
+		if err != nil {
+			return "", false, err
+		}
+		changesMade = changesMade || rchanges
+		sort.Strings(readerNames)
+		normalizedName += tlf.ReaderSep + strings.Join(readerNames, ",")
+	}
+	if len(extensionSuffix) != 0 {
+		// This *should* be normalized already but make sure.  I can see not
+		// doing so might surprise a caller.
+		nExt := strings.ToLower(extensionSuffix)
+		normalizedName += tlf.HandleExtensionSep + nExt
+		changesMade = changesMade || nExt != extensionSuffix
+	}
+
+	return normalizedName, changesMade, nil
+}
+
+// SplitAndNormalizeTLFName takes a tlf name as a string
+// and tries to normalize it offline. In addition to other
+// checks it returns TlfNameNotCanonical if it does not
+// look canonical.
+// Note that ordering differences do not result in TlfNameNotCanonical
+// being returned.
+func SplitAndNormalizeTLFName(name string, t tlf.Type) (
+	writerNames, readerNames []string,
+	extensionSuffix string, err error) {
+	writerNames, readerNames, extensionSuffix, err = tlf.SplitName(name)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if t == tlf.SingleTeam && len(writerNames) != 1 {
+		// No team folder can have more than one writer.
+		return nil, nil, "", NoSuchNameError{Name: name}
+	}
+
+	hasReaders := len(readerNames) != 0
+	if t != tlf.Private && hasReaders {
+		// No public/team folder can have readers.
+		return nil, nil, "", NoSuchNameError{Name: name}
+	}
+
+	normalizedName, changes, err := NormalizeNamesInTLF(
+		writerNames, readerNames, t, extensionSuffix)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	// Check for changes - not just ordering differences here.
+	if changes {
+		return nil, nil, "", errors.WithStack(TlfNameNotCanonical{name, normalizedName})
+	}
+
+	return writerNames, readerNames, strings.ToLower(extensionSuffix), nil
+}

--- a/go/kbfs/idutil/tlf_names_test.go
+++ b/go/kbfs/idutil/tlf_names_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package idutil
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeNamesInTLF(t *testing.T) {
+	writerNames := []string{"BB", "C@Twitter", "d@twitter", "aa"}
+	readerNames := []string{"EE", "ff", "AA@HackerNews", "aa", "BB", "bb", "ZZ@hackernews"}
+	s, changes, err := NormalizeNamesInTLF(
+		writerNames, readerNames, tlf.Private, "")
+	require.NoError(t, err)
+	require.True(t, changes)
+	assert.Equal(t, "aa,bb,c@twitter,d@twitter#AA@hackernews,ZZ@hackernews,aa,bb,bb,ee,ff", s)
+}
+
+func TestNormalizeNamesInTLFWithConflict(t *testing.T) {
+	writerNames := []string{"BB", "C@Twitter", "d@twitter", "aa"}
+	readerNames := []string{"EE", "ff", "AA@HackerNews", "aa", "BB", "bb", "ZZ@hackernews"}
+	conflictSuffix := "(cOnflictED coPy 2015-05-11 #4)"
+	s, changes, err := NormalizeNamesInTLF(
+		writerNames, readerNames, tlf.Private, conflictSuffix)
+	require.NoError(t, err)
+	require.True(t, changes)
+	assert.Equal(t, "aa,bb,c@twitter,d@twitter#AA@hackernews,ZZ@hackernews,aa,bb,bb,ee,ff (conflicted copy 2015-05-11 #4)", s)
+}

--- a/go/kbfs/kbfsgit/runner.go
+++ b/go/kbfs/kbfsgit/runner.go
@@ -18,11 +18,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libgit"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -105,7 +107,7 @@ const (
 type runner struct {
 	config libkbfs.Config
 	log    logger.Logger
-	h      *libkbfs.TlfHandle
+	h      *tlfhandle.Handle
 	remote string
 	repo   string
 	gitDir string
@@ -165,7 +167,7 @@ func newRunner(ctx context.Context, config libkbfs.Config,
 
 	// Use the device ID and PID to make a unique ID (for generating
 	// temp files in KBFS).
-	session, err := libkbfs.GetCurrentSessionIfPossible(
+	session, err := idutil.GetCurrentSessionIfPossible(
 		ctx, config.KBPKI(), h.Type() == tlf.Public)
 	if err != nil {
 		return nil, err

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libgit"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 	gogitcfg "gopkg.in/src-d/go-git.v4/config"
@@ -94,7 +95,7 @@ func testRunnerInitRepo(t *testing.T, tlfType tlf.Type, typeString string) {
 		inputWriter.Write([]byte("list\n\n"))
 	}()
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlfType)
 	require.NoError(t, err)
 	if tlfType != tlf.Public {
@@ -297,7 +298,7 @@ func testRunnerPushFetch(t *testing.T, cloning bool, secondRepoHasBranch bool) {
 
 	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -378,7 +379,7 @@ func TestRunnerDeleteBranch(t *testing.T) {
 
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -408,7 +409,7 @@ func TestRunnerExitEarlyOnEOF(t *testing.T) {
 
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
@@ -447,7 +448,7 @@ func TestForcePush(t *testing.T) {
 
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -486,7 +487,7 @@ func TestPushAllWithPackedRefs(t *testing.T) {
 	dotgit := filepath.Join(git, ".git")
 	gitExec(t, dotgit, git, "pack-refs", "--all")
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -509,7 +510,7 @@ func TestPushSomeWithPackedRefs(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(git)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -648,7 +649,7 @@ func TestRunnerDeletePackedRef(t *testing.T) {
 
 	gitExec(t, dotgit1, git1, "pack-refs", "--all")
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -751,7 +752,7 @@ func TestPackRefsAndOverwritePackedRef(t *testing.T) {
 	packOnStalled, packUnstall, packCtx := libkbfs.StallMDOp(
 		ctx, config2, libkbfs.StallableMDAfterGetRange, 1)
 	packErrCh := make(chan error)
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config2.KBPKI(), config.MDOps(), config, "user1,user2",
 		tlf.Private)
 	require.NoError(t, err)
@@ -839,7 +840,7 @@ func TestPackRefsAndDeletePackedRef(t *testing.T) {
 	packOnStalled, packUnstall, packCtx := libkbfs.StallMDOp(
 		ctx, config2, libkbfs.StallableMDAfterGetRange, 1)
 	packErrCh := make(chan error)
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config2.KBPKI(), config.MDOps(), config, "user1,user2",
 		tlf.Private)
 	require.NoError(t, err)
@@ -921,7 +922,7 @@ func TestRepackObjects(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(git)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -986,7 +987,7 @@ func TestRunnerWithKBFSReset(t *testing.T) {
 
 	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -1052,7 +1053,7 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 	defer os.RemoveAll(git)
 
 	t.Log("Setup the repository.")
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")

--- a/go/kbfs/kbfstool/common.go
+++ b/go/kbfs/kbfstool/common.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/tlf"
 )
 
@@ -18,7 +18,7 @@ const (
 	privateName = "private"
 )
 
-const publicSuffix = tlf.ReaderSep + libkbfs.PublicUIDName
+const publicSuffix = tlf.ReaderSep + idutil.PublicUIDName
 
 func byteCountStr(n int) string {
 	if n == 1 {

--- a/go/kbfs/kbfstool/md_common.go
+++ b/go/kbfs/kbfstool/md_common.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/kbfs/fsrpc"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -77,8 +79,8 @@ func mdParseInput(ctx context.Context, config libkbfs.Config,
 }
 
 func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI,
-	mdOps libkbfs.MDOps, osg libkbfs.OfflineStatusGetter, tlfStr string) (
-	*libkbfs.TlfHandle, error) {
+	mdOps libkbfs.MDOps, osg idutil.OfflineStatusGetter, tlfStr string) (
+	*tlfhandle.Handle, error) {
 	p, err := fsrpc.NewPath(tlfStr)
 	if err != nil {
 		return nil, err
@@ -251,7 +253,7 @@ func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 	}
 	if !isWriter {
 		return libkbfs.ImmutableRootMetadata{},
-			libkbfs.NewWriteAccessError(
+			tlfhandle.NewWriteAccessError(
 				handle, session.Name, handle.GetCanonicalPath())
 	}
 

--- a/go/kbfs/kbfstool/md_dump_common.go
+++ b/go/kbfs/kbfstool/md_dump_common.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
@@ -20,7 +21,7 @@ import (
 // service.
 type replacementMap map[string]string
 
-func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
+func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui idutil.UserInfo) (
 	string, bool) {
 	deviceName, ok := ui.KIDNames[k.KID()]
 	if !ok {
@@ -35,7 +36,7 @@ func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui libk
 	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
 }
 
-func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui libkbfs.UserInfo) (
+func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui idutil.UserInfo) (
 	string, bool) {
 	deviceName, ok := ui.KIDNames[k.KID()]
 	if !ok {
@@ -51,7 +52,7 @@ func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui libkbfs.
 }
 
 func mdDumpFillReplacements(ctx context.Context, codec kbfscodec.Codec,
-	service libkbfs.KeybaseService, osg libkbfs.OfflineStatusGetter,
+	service libkbfs.KeybaseService, osg idutil.OfflineStatusGetter,
 	prefix string, rmd kbfsmd.RootMetadata, extra kbfsmd.ExtraMetadata,
 	replacements replacementMap) error {
 	writers, readers, err := rmd.GetUserDevicePublicKeys(extra)

--- a/go/kbfs/kbfstool/write.go
+++ b/go/kbfs/kbfstool/write.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/keybase/client/go/kbfs/fsrpc"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"golang.org/x/net/context"
 )
@@ -87,7 +88,7 @@ func writeHelper(ctx context.Context, config libkbfs.Config, args []string) (err
 
 	kbfsOps := config.KBFSOps()
 
-	noSuchFileErr := libkbfs.NoSuchNameError{Name: filename}
+	noSuchFileErr := idutil.NoSuchNameError{Name: filename}
 
 	// The operations below are racy, but that is inherent to a
 	// distributed FS.

--- a/go/kbfs/libdokan/archive_reltime_file.go
+++ b/go/kbfs/libdokan/archive_reltime_file.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/libfs"
-	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"golang.org/x/net/context"
 )
 
@@ -16,7 +16,7 @@ import (
 // by-revision directory name that corresponds to the given relative
 // time string for the given folder.
 func NewArchiveRelTimeFile(
-	fs *FS, handle *libkbfs.TlfHandle, filename string) *SpecialReadFile {
+	fs *FS, handle *tlfhandle.Handle, filename string) *SpecialReadFile {
 	return &SpecialReadFile{
 		read: func(ctx context.Context) ([]byte, time.Time, error) {
 			data, isRel, err := libfs.FileDataFromRelativeTimeString(

--- a/go/kbfs/libdokan/common.go
+++ b/go/kbfs/libdokan/common.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/dokan"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"golang.org/x/net/context"
@@ -82,9 +83,9 @@ func addFileAttribute(a *dokan.Stat, fa dokan.FileAttribute) {
 // errToDokan makes some libkbfs errors easier to digest in dokan. Not needed in most places.
 func errToDokan(err error) error {
 	switch err.(type) {
-	case libkbfs.NoSuchNameError:
+	case idutil.NoSuchNameError:
 		return dokan.ErrObjectNameNotFound
-	case libkbfs.NoSuchUserError:
+	case idutil.NoSuchUserError:
 		return dokan.ErrObjectNameNotFound
 	case kbfsmd.ServerErrorUnauthorized:
 		return dokan.ErrAccessDenied

--- a/go/kbfs/libdokan/folderlist.go
+++ b/go/kbfs/libdokan/folderlist.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/keybase/client/go/kbfs/dokan"
 	"github.com/keybase/client/go/kbfs/favorites"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -60,7 +62,7 @@ func (fl *FolderList) reportErr(ctx context.Context,
 
 }
 
-func (fl *FolderList) addToFavorite(ctx context.Context, h *libkbfs.TlfHandle) (err error) {
+func (fl *FolderList) addToFavorite(ctx context.Context, h *tlfhandle.Handle) (err error) {
 	cName := h.GetCanonicalName()
 	fl.fs.log.CDebugf(ctx, "adding %s to favorites", cName)
 	return fl.fs.config.KBFSOps().AddFavorite(ctx, h.ToFavorite(),
@@ -129,14 +131,14 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 			continue
 		}
 
-		h, err := libkbfs.ParseTlfHandlePreferredQuick(
+		h, err := tlfhandle.ParseHandlePreferredQuick(
 			ctx, fl.fs.config.KBPKI(), fl.fs.config, name, fl.tlfType)
 		fl.fs.log.CDebugf(ctx, "FL Lookup continuing -> %v,%v", h, err)
 		switch e := errors.Cause(err).(type) {
 		case nil:
 			// no error
 
-		case libkbfs.TlfNameNotCanonical:
+		case idutil.TlfNameNotCanonical:
 			// Only permit Aliases to targets that contain no errors.
 			aliasTarget = e.NameToTry
 			fl.fs.log.CDebugf(ctx, "FL Lookup set alias: %q -> %q", name, aliasTarget)
@@ -156,7 +158,7 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 			path[0] = aliasTarget
 			continue
 
-		case libkbfs.NoSuchNameError, libkbfs.BadTLFNameError:
+		case idutil.NoSuchNameError, idutil.BadTLFNameError:
 			return nil, 0, dokan.ErrObjectNameNotFound
 
 		default:
@@ -165,7 +167,7 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 		}
 
 		fl.fs.log.CDebugf(ctx, "FL Lookup adding new child")
-		session, err := libkbfs.GetCurrentSessionIfPossible(ctx, fl.fs.config.KBPKI(), h.Type() == tlf.Public)
+		session, err := idutil.GetCurrentSessionIfPossible(ctx, fl.fs.config.KBPKI(), h.Type() == tlf.Public)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -224,7 +226,7 @@ func (fl *FolderList) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored
 }
 
 func (fl *FolderList) isValidAliasTarget(ctx context.Context, nameToTry string) bool {
-	return libkbfs.CheckTlfHandleOffline(ctx, nameToTry, fl.tlfType) == nil
+	return tlfhandle.CheckHandleOffline(ctx, nameToTry, fl.tlfType) == nil
 }
 
 func (fl *FolderList) lockedAddChild(name string, val fileOpener) {

--- a/go/kbfs/libdokan/fs.go
+++ b/go/kbfs/libdokan/fs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"golang.org/x/net/context"
@@ -574,7 +575,7 @@ func (f *FS) folderListRename(ctx context.Context, fl *FolderList, oc *openConte
 	}
 	dstName := dstPath[len(dstPath)-1]
 	// Yes, this is slow, but that is ok here.
-	if _, err := libkbfs.ParseTlfHandlePreferred(
+	if _, err := tlfhandle.ParseHandlePreferred(
 		ctx, f.config.KBPKI(), f.config.MDOps(), f.config, dstName,
 		fl.tlfType); err != nil {
 		return dokan.ErrObjectNameNotFound

--- a/go/kbfs/libdokan/mount_test.go
+++ b/go/kbfs/libdokan/mount_test.go
@@ -20,11 +20,13 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/dokan"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/pkg/errors"
@@ -2155,7 +2157,7 @@ func TestErrorFile(t *testing.T) {
 	}
 
 	// Make sure the root error file reads as expected
-	expectedErr := libkbfs.NoSuchUserError{Input: "janedoe"}
+	expectedErr := idutil.NoSuchUserError{Input: "janedoe"}
 
 	// test both the root error file and one in a directory
 	testForErrorText(t, filepath.Join(mnt.Dir, libkbfs.ErrorFile),
@@ -2186,7 +2188,7 @@ func (t *testMountObserver) BatchChanges(ctx context.Context,
 }
 
 func (t *testMountObserver) TlfHandleChange(ctx context.Context,
-	newHandle *libkbfs.TlfHandle) {
+	newHandle *tlfhandle.Handle) {
 	return
 }
 

--- a/go/kbfs/libdokan/tlf.go
+++ b/go/kbfs/libdokan/tlf.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"golang.org/x/net/context"
 )
 
@@ -28,7 +29,7 @@ type TLF struct {
 	emptyFile
 }
 
-func newTLF(fl *FolderList, h *libkbfs.TlfHandle,
+func newTLF(fl *FolderList, h *tlfhandle.Handle,
 	name tlf.PreferredName) *TLF {
 	folder := newFolder(fl, h, name)
 	tlf := &TLF{

--- a/go/kbfs/libfs/archive_util.go
+++ b/go/kbfs/libfs/archive_util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/araddon/dateparse"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 )
 
 // BranchNameFromArchiveRefDir returns a branch name and true if the
@@ -36,7 +37,7 @@ func BranchNameFromArchiveRefDir(dir string) (libkbfs.BranchName, bool) {
 // timestamp greater or equal to that time.  Ambiguous dates are
 // parsed in MM/DD format.
 func RevFromTimeString(
-	ctx context.Context, config libkbfs.Config, h *libkbfs.TlfHandle,
+	ctx context.Context, config libkbfs.Config, h *tlfhandle.Handle,
 	timeString string) (kbfsmd.Revision, error) {
 	t, err := dateparse.ParseAny(timeString)
 	if err != nil {
@@ -50,7 +51,7 @@ func RevFromTimeString(
 // directory, and true, if the given link specifies a valid by-time
 // link name.  Ambiguous dates are parsed in MM/DD format.
 func LinkTargetFromTimeString(
-	ctx context.Context, config libkbfs.Config, h *libkbfs.TlfHandle,
+	ctx context.Context, config libkbfs.Config, h *tlfhandle.Handle,
 	link string) (string, bool, error) {
 	if !strings.HasPrefix(link, ArchivedTimeLinkPrefix) {
 		return "", false, nil
@@ -69,7 +70,7 @@ func LinkTargetFromTimeString(
 // past relative to now (e.g., "5m", "2h55s"), and turns it into a
 // revision number for the given TLF.
 func RevFromRelativeTimeString(
-	ctx context.Context, config libkbfs.Config, h *libkbfs.TlfHandle,
+	ctx context.Context, config libkbfs.Config, h *tlfhandle.Handle,
 	relTime string) (kbfsmd.Revision, error) {
 	d, err := time.ParseDuration(relTime)
 	if err != nil {
@@ -85,7 +86,7 @@ func RevFromRelativeTimeString(
 // file name specifies a valid by-relative-time file name.  The time
 // is relative to the local clock.
 func FileDataFromRelativeTimeString(
-	ctx context.Context, config libkbfs.Config, h *libkbfs.TlfHandle,
+	ctx context.Context, config libkbfs.Config, h *tlfhandle.Handle,
 	filename string) ([]byte, bool, error) {
 	if !strings.HasPrefix(filename, ArchivedRelTimeFilePrefix) {
 		return nil, false, nil

--- a/go/kbfs/libfs/fs_test.go
+++ b/go/kbfs/libfs/fs_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,10 +25,10 @@ import (
 )
 
 func makeFSWithBranch(t *testing.T, branch libkbfs.BranchName, subdir string) (
-	context.Context, *libkbfs.TlfHandle, *FS) {
+	context.Context, *tlfhandle.Handle, *FS) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
 	config := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	fs, err := NewFS(
@@ -37,12 +38,12 @@ func makeFSWithBranch(t *testing.T, branch libkbfs.BranchName, subdir string) (
 }
 
 func makeFS(t *testing.T, subdir string) (
-	context.Context, *libkbfs.TlfHandle, *FS) {
+	context.Context, *tlfhandle.Handle, *FS) {
 	return makeFSWithBranch(t, libkbfs.MasterBranch, subdir)
 }
 
 func makeFSWithJournal(t *testing.T, subdir string) (
-	context.Context, *libkbfs.TlfHandle, *FS, func()) {
+	context.Context, *tlfhandle.Handle, *FS, func()) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
 	config := libkbfs.MakeTestConfigOrBustLoggedInWithMode(
 		t, 0, libkbfs.InitSingleOp, "user1")
@@ -65,7 +66,7 @@ func makeFSWithJournal(t *testing.T, subdir string) (
 		assert.NoError(t, err)
 	}
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	fs, err := NewFS(
@@ -275,7 +276,7 @@ func TestStat(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
 	config2.SetClock(clock)
 
-	h2, err := libkbfs.ParseTlfHandle(
+	h2, err := tlfhandle.ParseHandle(
 		ctx, config2.KBPKI(), config2.MDOps(), nil, "user2#user1", tlf.Private)
 	require.NoError(t, err)
 	fs2U2, err := NewFS(
@@ -708,7 +709,7 @@ func TestEmptyFS(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	fs, err := NewFSIfExists(

--- a/go/kbfs/libfs/journal_control_file.go
+++ b/go/kbfs/libfs/journal_control_file.go
@@ -7,10 +7,10 @@ package libfs
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"golang.org/x/net/context"
 )
 
 // JournalAction enumerates all the possible actions to take on a
@@ -60,7 +60,7 @@ func (a JournalAction) String() string {
 // given TLF.
 func (a JournalAction) Execute(
 	ctx context.Context, jManager *libkbfs.JournalManager,
-	tlfID tlf.ID, h *libkbfs.TlfHandle) error {
+	tlfID tlf.ID, h *tlfhandle.Handle) error {
 	// These actions don't require TLF IDs.
 	switch a {
 	case JournalEnableAuto:

--- a/go/kbfs/libfs/mode.go
+++ b/go/kbfs/libfs/mode.go
@@ -8,16 +8,18 @@ import (
 	"context"
 	"os"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 // IsWriter returns whether or not the currently logged-in user is a
 // valid writer for the folder described by `h`.
 func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
-	osg libkbfs.OfflineStatusGetter, h *libkbfs.TlfHandle) (bool, error) {
-	session, err := libkbfs.GetCurrentSessionIfPossible(
+	osg idutil.OfflineStatusGetter, h *tlfhandle.Handle) (bool, error) {
+	session, err := idutil.GetCurrentSessionIfPossible(
 		ctx, kbpki, h.Type() == tlf.Public)
 	// We are using GetCurrentUserInfoIfPossible here so err is only non-nil if
 	// a real problem happened. If the user is logged out, we will get an empty
@@ -49,8 +51,8 @@ func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
 // by `h`.
 func WritePermMode(
 	ctx context.Context, node libkbfs.Node, original os.FileMode,
-	kbpki libkbfs.KBPKI, osg libkbfs.OfflineStatusGetter,
-	h *libkbfs.TlfHandle) (os.FileMode, error) {
+	kbpki libkbfs.KBPKI, osg idutil.OfflineStatusGetter,
+	h *tlfhandle.Handle) (os.FileMode, error) {
 	original &^= os.FileMode(0222) // clear write perm bits
 
 	if node != nil && node.Readonly(ctx) {

--- a/go/kbfs/libfs/sync_control_file.go
+++ b/go/kbfs/libfs/sync_control_file.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
@@ -37,7 +38,7 @@ func (a SyncAction) String() string {
 // given TLF.
 func (a SyncAction) Execute(
 	ctx context.Context, c libkbfs.Config, fb libkbfs.FolderBranch,
-	h *libkbfs.TlfHandle) (err error) {
+	h *tlfhandle.Handle) (err error) {
 	if fb == (libkbfs.FolderBranch{}) {
 		panic("zero fb in SyncAction.Execute")
 	}

--- a/go/kbfs/libfs/tlf.go
+++ b/go/kbfs/libfs/tlf.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -38,7 +39,7 @@ func FilterTLFEarlyExitError(ctx context.Context, err error, log logger.Logger, 
 			name)
 		return true, nil
 
-	case libkbfs.WriteAccessError, kbfsmd.ServerErrorWriteAccess,
+	case tlfhandle.WriteAccessError, kbfsmd.ServerErrorWriteAccess,
 		libkbfs.NonExistentTeamForHandleError:
 		// No permission to create TLF, so pretend it's still
 		// empty.

--- a/go/kbfs/libfs/user_edit_history.go
+++ b/go/kbfs/libfs/user_edit_history.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 )
 
@@ -15,7 +16,7 @@ import (
 // file edit history for the user.
 func GetEncodedUserEditHistory(ctx context.Context, config libkbfs.Config) (
 	data []byte, t time.Time, err error) {
-	session, err := libkbfs.GetCurrentSessionIfPossible(
+	session, err := idutil.GetCurrentSessionIfPossible(
 		ctx, config.KBPKI(), true)
 	if err != nil {
 		return nil, time.Time{}, err

--- a/go/kbfs/libfuse/archive_reltime_file.go
+++ b/go/kbfs/libfuse/archive_reltime_file.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/libfs"
-	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"golang.org/x/net/context"
 )
 
@@ -18,7 +18,7 @@ import (
 // by-revision directory name that corresponds to the given relative
 // time string for the given folder.
 func NewArchiveRelTimeFile(
-	fs *FS, handle *libkbfs.TlfHandle, filename string,
+	fs *FS, handle *tlfhandle.Handle, filename string,
 	entryValid *time.Duration) *SpecialReadFile {
 	*entryValid = 0
 	return &SpecialReadFile{

--- a/go/kbfs/libfuse/errors.go
+++ b/go/kbfs/libfuse/errors.go
@@ -12,9 +12,11 @@ import (
 	"github.com/pkg/errors"
 
 	"bazil.org/fuse"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 )
 
 type errorWithErrno struct {
@@ -40,15 +42,15 @@ func filterError(err error) error {
 	case kbfsmd.MetadataIsFinalError:
 		return errorWithErrno{err, syscall.EACCES}
 
-	case libkbfs.NoSuchUserError:
+	case idutil.NoSuchUserError:
 		return errorWithErrno{err, syscall.ENOENT}
-	case libkbfs.NoSuchTeamError:
+	case idutil.NoSuchTeamError:
 		return errorWithErrno{err, syscall.ENOENT}
 	case libkbfs.DirNotEmptyError:
 		return errorWithErrno{err, syscall.ENOTEMPTY}
-	case libkbfs.ReadAccessError:
+	case tlfhandle.ReadAccessError:
 		return errorWithErrno{err, syscall.EACCES}
-	case libkbfs.WriteAccessError:
+	case tlfhandle.WriteAccessError:
 		return errorWithErrno{err, syscall.EACCES}
 	case libkbfs.WriteUnsupportedError:
 		return errorWithErrno{err, syscall.ENOENT}
@@ -64,7 +66,7 @@ func filterError(err error) error {
 		return errorWithErrno{err, syscall.EINVAL}
 	case libkbfs.NameTooLongError:
 		return errorWithErrno{err, syscall.ENAMETOOLONG}
-	case libkbfs.NoCurrentSessionError:
+	case idutil.NoCurrentSessionError:
 		return errorWithErrno{err, syscall.EACCES}
 	case libkbfs.NoSuchFolderListError:
 		return errorWithErrno{err, syscall.ENOENT}

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -17,8 +17,10 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/keybase/client/go/kbfs/favorites"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -111,7 +113,7 @@ func (fl *FolderList) isRecentlyRemoved(name tlf.CanonicalName) bool {
 	return fl.recentlyRemoved != nil && fl.recentlyRemoved[name]
 }
 
-func (fl *FolderList) addToFavorite(ctx context.Context, h *libkbfs.TlfHandle) (err error) {
+func (fl *FolderList) addToFavorite(ctx context.Context, h *tlfhandle.Handle) (err error) {
 	cName := h.GetCanonicalName()
 
 	// `rmdir` command on macOS does a lookup after removing the dir. if the
@@ -129,14 +131,14 @@ func (fl *FolderList) addToFavorite(ctx context.Context, h *libkbfs.TlfHandle) (
 }
 
 // PathType returns PathType for this folder
-func (fl *FolderList) PathType() libkbfs.PathType {
+func (fl *FolderList) PathType() tlfhandle.PathType {
 	switch fl.tlfType {
 	case tlf.Private:
-		return libkbfs.PrivatePathType
+		return tlfhandle.PrivatePathType
 	case tlf.Public:
-		return libkbfs.PublicPathType
+		return tlfhandle.PublicPathType
 	case tlf.SingleTeam:
-		return libkbfs.SingleTeamPathType
+		return tlfhandle.SingleTeamPathType
 	default:
 		panic(fmt.Sprintf("Unsupported tlf type: %s", fl.tlfType))
 	}
@@ -152,7 +154,7 @@ func (fl *FolderList) Create(ctx context.Context, req *fuse.CreateRequest, resp 
 		// triggering a notification.
 		return nil, nil, syscall.ENOENT
 	}
-	return nil, nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(fl.PathType(), string(tlfName)))
+	return nil, nil, libkbfs.NewWriteUnsupportedError(tlfhandle.BuildCanonicalPath(fl.PathType(), string(tlfName)))
 }
 
 // Mkdir implements the fs.NodeMkdirer interface for FolderList.
@@ -160,7 +162,7 @@ func (fl *FolderList) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (_ fs.N
 	fl.fs.log.CDebugf(ctx, "FL Mkdir")
 	tlfName := tlf.CanonicalName(req.Name)
 	defer func() { err = fl.processError(ctx, libkbfs.WriteMode, tlfName, err) }()
-	return nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(fl.PathType(), string(tlfName)))
+	return nil, libkbfs.NewWriteUnsupportedError(tlfhandle.BuildCanonicalPath(fl.PathType(), string(tlfName)))
 }
 
 // Lookup implements the fs.NodeRequestLookuper interface.
@@ -188,13 +190,13 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 		return nil, fuse.ENOENT
 	}
 
-	h, err := libkbfs.ParseTlfHandlePreferredQuick(
+	h, err := tlfhandle.ParseHandlePreferredQuick(
 		ctx, fl.fs.config.KBPKI(), fl.fs.config, req.Name, fl.tlfType)
 	switch e := errors.Cause(err).(type) {
 	case nil:
 		// no error
 
-	case libkbfs.TlfNameNotCanonical:
+	case idutil.TlfNameNotCanonical:
 		// Only permit Aliases to targets that contain no errors.
 		if !fl.isValidAliasTarget(ctx, e.NameToTry) {
 			fl.fs.log.CDebugf(ctx, "FL Refusing alias to non-valid target %q", e.NameToTry)
@@ -207,7 +209,7 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 		}
 		return n, nil
 
-	case libkbfs.NoSuchNameError, libkbfs.BadTLFNameError:
+	case idutil.NoSuchNameError, idutil.BadTLFNameError:
 		// Invalid public TLF.
 		return nil, fuse.ENOENT
 
@@ -216,7 +218,7 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 		return nil, err
 	}
 
-	session, err := libkbfs.GetCurrentSessionIfPossible(
+	session, err := idutil.GetCurrentSessionIfPossible(
 		ctx, fl.fs.config.KBPKI(), h.Type() == tlf.Public)
 	if err != nil {
 		return nil, err
@@ -227,7 +229,7 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 }
 
 func (fl *FolderList) isValidAliasTarget(ctx context.Context, nameToTry string) bool {
-	return libkbfs.CheckTlfHandleOffline(ctx, nameToTry, fl.tlfType) == nil
+	return tlfhandle.CheckHandleOffline(ctx, nameToTry, fl.tlfType) == nil
 }
 
 func (fl *FolderList) forgetFolder(folderName string) {
@@ -283,7 +285,7 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 	fl.fs.log.CDebugf(ctx, "FolderList Remove %s", req.Name)
 	defer func() { err = fl.fs.processError(ctx, libkbfs.WriteMode, err) }()
 
-	h, err := libkbfs.ParseTlfHandlePreferredQuick(
+	h, err := tlfhandle.ParseHandlePreferredQuick(
 		ctx, fl.fs.config.KBPKI(), fl.fs.config, req.Name, fl.tlfType)
 
 	switch err := errors.Cause(err).(type) {
@@ -306,7 +308,7 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 		// the favorite.
 		return fl.fs.config.KBFSOps().DeleteFavorite(ctx, h.ToFavorite())
 
-	case libkbfs.TlfNameNotCanonical:
+	case idutil.TlfNameNotCanonical:
 		return nil
 
 	default:
@@ -315,7 +317,7 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 }
 
 func isTlfNameNotCanonical(err error) bool {
-	_, ok := errors.Cause(err).(libkbfs.TlfNameNotCanonical)
+	_, ok := errors.Cause(err).(idutil.TlfNameNotCanonical)
 	return ok
 }
 

--- a/go/kbfs/libfuse/fs.go
+++ b/go/kbfs/libfuse/fs.go
@@ -20,10 +20,12 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/pkg/errors"
@@ -389,10 +391,10 @@ func (f *FS) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.Sta
 		return nil
 	}
 
-	if session, err := libkbfs.GetCurrentSessionIfPossible(
+	if session, err := idutil.GetCurrentSessionIfPossible(
 		ctx, f.config.KBPKI(), true); err != nil {
 		return err
-	} else if session == (libkbfs.SessionInfo{}) {
+	} else if session == (idutil.SessionInfo{}) {
 		// If user is not logged in, don't bother getting quota info. Otherwise
 		// reading a public TLF while logged out can fail on macOS.
 		return nil
@@ -492,8 +494,8 @@ func (r *Root) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.L
 }
 
 // PathType returns PathType for this folder
-func (r *Root) PathType() libkbfs.PathType {
-	return libkbfs.KeybasePathType
+func (r *Root) PathType() tlfhandle.PathType {
+	return tlfhandle.KeybasePathType
 }
 
 var _ fs.NodeCreater = (*Root)(nil)
@@ -507,14 +509,14 @@ func (r *Root) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.C
 		// triggering a notification.
 		return nil, nil, syscall.ENOENT
 	}
-	return nil, nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(r.PathType(), req.Name))
+	return nil, nil, libkbfs.NewWriteUnsupportedError(tlfhandle.BuildCanonicalPath(r.PathType(), req.Name))
 }
 
 // Mkdir implements the fs.NodeMkdirer interface for Root.
 func (r *Root) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (_ fs.Node, err error) {
 	r.log().CDebugf(ctx, "FS Mkdir")
 	defer func() { err = r.private.fs.processError(ctx, libkbfs.WriteMode, err) }()
-	return nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(r.PathType(), req.Name))
+	return nil, libkbfs.NewWriteUnsupportedError(tlfhandle.BuildCanonicalPath(r.PathType(), req.Name))
 }
 
 var _ fs.Handle = (*Root)(nil)

--- a/go/kbfs/libfuse/fs_darwin.go
+++ b/go/kbfs/libfuse/fs_darwin.go
@@ -15,6 +15,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/utils"
@@ -68,7 +69,7 @@ func (r *Root) platformLookup(ctx context.Context, req *fuse.LookupRequest, resp
 
 	if r.private.fs.platformParams.UseLocal {
 		if mountRootSpecialPaths[req.Name] {
-			session, err := libkbfs.GetCurrentSessionIfPossible(ctx, r.private.fs.config.KBPKI(), false)
+			session, err := idutil.GetCurrentSessionIfPossible(ctx, r.private.fs.config.KBPKI(), false)
 			if err != nil {
 				return nil, err
 			}
@@ -76,7 +77,7 @@ func (r *Root) platformLookup(ctx context.Context, req *fuse.LookupRequest, resp
 		}
 
 		if req.Name == TrashDirName {
-			session, err := libkbfs.GetCurrentSessionIfPossible(ctx, r.private.fs.config.KBPKI(), false)
+			session, err := idutil.GetCurrentSessionIfPossible(ctx, r.private.fs.config.KBPKI(), false)
 			if err != nil {
 				return nil, err
 			}

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -24,11 +24,13 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -2817,7 +2819,7 @@ func TestErrorFile(t *testing.T) {
 	}
 
 	// Make sure the root error file reads as expected
-	expectedErr := libkbfs.NoSuchUserError{Input: "janedoe"}
+	expectedErr := idutil.NoSuchUserError{Input: "janedoe"}
 
 	// test both the root error file and one in a directory
 	testForErrorText(t, path.Join(mnt.Dir, libkbfs.ErrorFile),
@@ -2847,7 +2849,7 @@ func (t *testMountObserver) BatchChanges(ctx context.Context,
 }
 
 func (t *testMountObserver) TlfHandleChange(ctx context.Context,
-	newHandle *libkbfs.TlfHandle) {
+	newHandle *tlfhandle.Handle) {
 	return
 }
 

--- a/go/kbfs/libfuse/quarantine_darwin.go
+++ b/go/kbfs/libfuse/quarantine_darwin.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"bazil.org/fuse"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/pkg/errors"
@@ -98,7 +99,7 @@ func (h *QuarantineXattrHandler) Getxattr(ctx context.Context,
 		}
 		de, err := h.folder.fs.config.KBFSOps().Stat(ctx, h.node)
 		if err != nil {
-			if _, ok := err.(libkbfs.NoSuchNameError); ok {
+			if _, ok := err.(idutil.NoSuchNameError); ok {
 				// The node is not found, so just return ENOTSUP
 				return fuse.ENOTSUP
 			}

--- a/go/kbfs/libfuse/symlink.go
+++ b/go/kbfs/libfuse/symlink.go
@@ -12,6 +12,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"golang.org/x/net/context"
 )
@@ -38,7 +39,7 @@ func (s *Symlink) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 
 	_, de, err := s.parent.folder.fs.config.KBFSOps().Lookup(ctx, s.parent.node, s.name)
 	if err != nil {
-		if _, ok := err.(libkbfs.NoSuchNameError); ok {
+		if _, ok := err.(idutil.NoSuchNameError); ok {
 			return fuse.ESTALE
 		}
 		return err

--- a/go/kbfs/libfuse/tlf.go
+++ b/go/kbfs/libfuse/tlf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"golang.org/x/net/context"
 )
@@ -35,7 +36,7 @@ type TLF struct {
 	NoXattrHandler
 }
 
-func newTLF(ctx context.Context, fl *FolderList, h *libkbfs.TlfHandle,
+func newTLF(ctx context.Context, fl *FolderList, h *tlfhandle.Handle,
 	name tlf.PreferredName) *TLF {
 	folder := newFolder(ctx, fl, h, name)
 	tlf := &TLF{

--- a/go/kbfs/libgit/autogit_manager.go
+++ b/go/kbfs/libgit/autogit_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -106,7 +107,7 @@ func (am *AutogitManager) Shutdown() {
 }
 
 func (am *AutogitManager) removeOldCheckoutsForHandle(
-	ctx context.Context, h *libkbfs.TlfHandle, branch libkbfs.BranchName) {
+	ctx context.Context, h *tlfhandle.Handle, branch libkbfs.BranchName) {
 	// Make an "unwrapped" FS, so we don't end up recursively entering
 	// the virtual autogit nodes again.
 	fs, err := libfs.NewUnwrappedFS(
@@ -289,7 +290,7 @@ func (am *AutogitManager) BatchChanges(
 // TlfHandleChange implements the libkbfs.Observer interface for
 // AutogitManager.
 func (am *AutogitManager) TlfHandleChange(
-	ctx context.Context, newHandle *libkbfs.TlfHandle) {
+	ctx context.Context, newHandle *tlfhandle.Handle) {
 	// Do nothing.
 }
 

--- a/go/kbfs/libgit/autogit_manager_test.go
+++ b/go/kbfs/libgit/autogit_manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 	billy "gopkg.in/src-d/go-billy.v4"
@@ -86,7 +87,7 @@ func addFileToWorktree(
 
 func addFileToWorktreeAndCommit(
 	t *testing.T, ctx context.Context, config libkbfs.Config,
-	h *libkbfs.TlfHandle, repo *gogit.Repository, worktreeFS billy.Filesystem,
+	h *tlfhandle.Handle, repo *gogit.Repository, worktreeFS billy.Filesystem,
 	name, data string) {
 	addFileToWorktree(t, repo, worktreeFS, name, data)
 	commitWorktree(t, ctx, config, h, worktreeFS)
@@ -94,7 +95,7 @@ func addFileToWorktreeAndCommit(
 
 func commitWorktree(
 	t *testing.T, ctx context.Context, config libkbfs.Config,
-	h *libkbfs.TlfHandle, worktreeFS billy.Filesystem) {
+	h *tlfhandle.Handle, worktreeFS billy.Filesystem) {
 	err := worktreeFS.(*libfs.FS).SyncAll()
 	require.NoError(t, err)
 	jManager, err := libkbfs.GetJournalManager(config)

--- a/go/kbfs/libgit/autogit_node_wrappers_test.go
+++ b/go/kbfs/libgit/autogit_node_wrappers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 	gogit "gopkg.in/src-d/go-git.v4"
@@ -29,7 +30,7 @@ func TestAutogitNodeWrappersNoRepos(t *testing.T) {
 	shutdown := StartAutogit(config, 25)
 	defer shutdown()
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
@@ -82,7 +83,7 @@ func TestAutogitRepoNode(t *testing.T) {
 	rw := rootWrapper{am}
 	config.AddRootNodeWrapper(rw.wrap)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
@@ -184,7 +185,7 @@ func TestAutogitRepoNodeReadonly(t *testing.T) {
 	rw := rootWrapper{am}
 	config.AddRootNodeWrapper(rw.wrap)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Public)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
@@ -266,7 +267,7 @@ func TestAutogitCommitFile(t *testing.T) {
 	rw := rootWrapper{am}
 	config.AddRootNodeWrapper(rw.wrap)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(

--- a/go/kbfs/libgit/browser_test.go
+++ b/go/kbfs/libgit/browser_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 	gogit "gopkg.in/src-d/go-git.v4"
@@ -26,7 +27,7 @@ func testBrowser(t *testing.T, sharedCache sharedInBrowserCache) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(

--- a/go/kbfs/libgit/repo_test.go
+++ b/go/kbfs/libgit/repo_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -54,7 +55,7 @@ func TestGetOrCreateRepoAndID(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
@@ -109,7 +110,7 @@ func TestCreateRepoAndID(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
@@ -158,7 +159,7 @@ func TestCreateDuplicateRepo(t *testing.T) {
 	require.NoError(t, err)
 	defer libkbfs.CheckConfigAndShutdown(ctx2, t, config2)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1,user2", tlf.Private)
 	require.NoError(t, err)
 
@@ -228,7 +229,7 @@ func TestGetRepoAndID(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
@@ -265,7 +266,7 @@ func TestDeleteRepo(t *testing.T) {
 	clock.Set(time.Now())
 	config.SetClock(clock)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 
@@ -322,7 +323,7 @@ func TestRepoRename(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
 	require.NoError(t, err)
 

--- a/go/kbfs/libgit/rpc.go
+++ b/go/kbfs/libgit/rpc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ var _ keybase1.KBFSGitInterface = (*RPCHandler)(nil)
 
 func (rh *RPCHandler) waitForJournal(
 	ctx context.Context, gitConfig libkbfs.Config,
-	h *libkbfs.TlfHandle) error {
+	h *tlfhandle.Handle) error {
 	err := CleanOldDeletedReposTimeLimited(ctx, gitConfig, h)
 	if err != nil {
 		return err
@@ -96,7 +97,7 @@ func (rh *RPCHandler) waitForJournal(
 func (rh *RPCHandler) getHandleAndConfig(
 	ctx context.Context, folder keybase1.Folder) (
 	newCtx context.Context, gitConfigRet libkbfs.Config,
-	tlfHandle *libkbfs.TlfHandle, tempDirRet string, err error) {
+	tlfHandle *tlfhandle.Handle, tempDirRet string, err error) {
 	newCtx, gitConfig, tempDir, err := getNewConfig(
 		ctx, rh.config, rh.kbCtx, rh.kbfsInitParams, rh.log)
 	if err != nil {

--- a/go/kbfs/libhttpserver/server_test.go
+++ b/go/kbfs/libhttpserver/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,7 +43,7 @@ func makeTestKBFSConfig(t *testing.T) (
 		require.NoError(t, err)
 	}
 
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, cfg.KBPKI(), cfg.MDOps(), cfg, "alice,bob", tlf.Private)
 	require.NoError(t, err)
 

--- a/go/kbfs/libkbfs/bserver_remote.go
+++ b/go/kbfs/libkbfs/bserver_remote.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/keybase/backoff"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -34,7 +35,7 @@ type blockServerRemoteClientHandler struct {
 	name          string
 	log           logger.Logger
 	deferLog      logger.Logger
-	csg           CurrentSessionGetter
+	csg           idutil.CurrentSessionGetter
 	authToken     *kbfscrypto.AuthToken
 	srvRemote     rpc.Remote
 	connOpts      rpc.ConnectionOpts
@@ -47,7 +48,8 @@ type blockServerRemoteClientHandler struct {
 }
 
 func newBlockServerRemoteClientHandler(name string, log logger.Logger,
-	signer kbfscrypto.Signer, csg CurrentSessionGetter, srvRemote rpc.Remote,
+	signer kbfscrypto.Signer, csg idutil.CurrentSessionGetter,
+	srvRemote rpc.Remote,
 	rpcLogFactory rpc.LogFactory) *blockServerRemoteClientHandler {
 	deferLog := log.CloneWithAddedDepth(1)
 	b := &blockServerRemoteClientHandler{

--- a/go/kbfs/libkbfs/bserver_remote_test.go
+++ b/go/kbfs/libkbfs/bserver_remote_test.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"testing"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -69,7 +70,7 @@ type testBlockServerRemoteConfig struct {
 	codecGetter
 	logMaker
 	signer         kbfscrypto.Signer
-	sessionGetter  CurrentSessionGetter
+	sessionGetter  idutil.CurrentSessionGetter
 	diskBlockCache DiskBlockCache
 }
 
@@ -79,7 +80,7 @@ func (c testBlockServerRemoteConfig) Signer() kbfscrypto.Signer {
 	return c.signer
 }
 
-func (c testBlockServerRemoteConfig) CurrentSessionGetter() CurrentSessionGetter {
+func (c testBlockServerRemoteConfig) CurrentSessionGetter() idutil.CurrentSessionGetter {
 	return c.sessionGetter
 }
 

--- a/go/kbfs/libkbfs/chat_local.go
+++ b/go/kbfs/libkbfs/chat_local.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/pkg/errors"
@@ -32,7 +33,8 @@ type convLocalByNameMap map[tlf.CanonicalName]convLocalByIDMap
 
 type convLocalByTypeMap map[tlf.Type]convLocalByNameMap
 
-type newConvCB func(context.Context, *TlfHandle, chat1.ConversationID, string)
+type newConvCB func(
+	context.Context, *tlfhandle.Handle, chat1.ConversationID, string)
 
 type chatLocalSharedData struct {
 	lock          sync.RWMutex
@@ -190,7 +192,7 @@ func (c *chatLocal) SendTextMessage(
 }
 
 type chatHandleAndTime struct {
-	h     *TlfHandle
+	h     *tlfhandle.Handle
 	mtime time.Time
 }
 
@@ -212,7 +214,7 @@ func (chatbm chatHandleAndTimeByMtime) Swap(i, j int) {
 // GetGroupedInbox implements the Chat interface.
 func (c *chatLocal) GetGroupedInbox(
 	ctx context.Context, chatType chat1.TopicType, maxChats int) (
-	results []*TlfHandle, err error) {
+	results []*tlfhandle.Handle, err error) {
 	if chatType != chat1.TopicType_KBFSFILEEDIT {
 		panic(fmt.Sprintf("Bad topic type: %d", chatType))
 	}
@@ -269,7 +271,7 @@ func (c *chatLocal) GetGroupedInbox(
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	var selfHandles []*TlfHandle
+	var selfHandles []*tlfhandle.Handle
 	max := numSelfTlfs
 	for i := len(c.selfConvInfos) - 1; i >= 0 && len(selfHandles) < max; i-- {
 		info := c.selfConvInfos[i]

--- a/go/kbfs/libkbfs/chat_rpc.go
+++ b/go/kbfs/libkbfs/chat_rpc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/client/go/kbfs/favorites"
 	"github.com/keybase/client/go/kbfs/kbfsedits"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -358,7 +359,7 @@ func (c *ChatRPC) SendTextMessage(
 
 func (c *ChatRPC) getLastSelfWrittenHandles(
 	ctx context.Context, chatType chat1.TopicType, seen map[string]bool) (
-	results []*TlfHandle, err error) {
+	results []*tlfhandle.Handle, err error) {
 	selfConvID, _, err := c.getSelfConvInfo(ctx)
 	if err != nil {
 		return nil, err
@@ -407,7 +408,7 @@ func (c *ChatRPC) getLastSelfWrittenHandles(
 // GetGroupedInbox implements the Chat interface.
 func (c *ChatRPC) GetGroupedInbox(
 	ctx context.Context, chatType chat1.TopicType, maxChats int) (
-	results []*TlfHandle, err error) {
+	results []*tlfhandle.Handle, err error) {
 	// First get the latest TLFs written by this user.
 	seen := make(map[string]bool)
 	results, err = c.getLastSelfWrittenHandles(ctx, chatType, seen)

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -13,13 +13,13 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/cache"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsedits"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
-	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -200,203 +200,6 @@ func (m *DiskCacheMode) Set(s string) error {
 
 var _ Config = (*ConfigLocal)(nil)
 
-// LocalUser represents a fake KBFS user, useful for testing.
-type LocalUser struct {
-	UserInfo
-	Asserts []string
-	// Index into UserInfo.CryptPublicKeys.
-	CurrentCryptPublicKeyIndex int
-	// Index into UserInfo.VerifyingKeys.
-	CurrentVerifyingKeyIndex int
-	// Unverified keys.
-	UnverifiedKeys []keybase1.PublicKey
-}
-
-// GetCurrentCryptPublicKey returns this LocalUser's public encryption key.
-func (lu *LocalUser) GetCurrentCryptPublicKey() kbfscrypto.CryptPublicKey {
-	return lu.CryptPublicKeys[lu.CurrentCryptPublicKeyIndex]
-}
-
-// GetCurrentVerifyingKey returns this LocalUser's public signing key.
-func (lu *LocalUser) GetCurrentVerifyingKey() kbfscrypto.VerifyingKey {
-	return lu.VerifyingKeys[lu.CurrentVerifyingKeyIndex]
-}
-
-func verifyingKeysToPublicKeys(
-	keys []kbfscrypto.VerifyingKey) []keybase1.PublicKey {
-	publicKeys := make([]keybase1.PublicKey, len(keys))
-	for i, key := range keys {
-		publicKeys[i] = keybase1.PublicKey{
-			KID:      key.KID(),
-			IsSibkey: true,
-		}
-	}
-	return publicKeys
-}
-
-func cryptPublicKeysToPublicKeys(
-	keys []kbfscrypto.CryptPublicKey) []keybase1.PublicKey {
-	publicKeys := make([]keybase1.PublicKey, len(keys))
-	for i, key := range keys {
-		publicKeys[i] = keybase1.PublicKey{
-			KID:      key.KID(),
-			IsSibkey: false,
-		}
-	}
-	return publicKeys
-}
-
-// GetPublicKeys returns all of this LocalUser's public encryption keys.
-func (lu *LocalUser) GetPublicKeys() []keybase1.PublicKey {
-	sibkeys := verifyingKeysToPublicKeys(lu.VerifyingKeys)
-	subkeys := cryptPublicKeysToPublicKeys(lu.CryptPublicKeys)
-	return append(sibkeys, subkeys...)
-}
-
-func (lu LocalUser) deepCopy() LocalUser {
-	luCopy := lu
-
-	luCopy.VerifyingKeys = make(
-		[]kbfscrypto.VerifyingKey, len(lu.VerifyingKeys))
-	copy(luCopy.VerifyingKeys, lu.VerifyingKeys)
-
-	luCopy.CryptPublicKeys = make(
-		[]kbfscrypto.CryptPublicKey, len(lu.CryptPublicKeys))
-	copy(luCopy.CryptPublicKeys, lu.CryptPublicKeys)
-
-	luCopy.KIDNames = make(map[keybase1.KID]string, len(lu.KIDNames))
-	for k, v := range lu.KIDNames {
-		luCopy.KIDNames[k] = v
-	}
-
-	luCopy.RevokedVerifyingKeys = make(
-		map[kbfscrypto.VerifyingKey]revokedKeyInfo,
-		len(lu.RevokedVerifyingKeys))
-	for k, v := range lu.RevokedVerifyingKeys {
-		luCopy.RevokedVerifyingKeys[k] = v
-	}
-
-	luCopy.RevokedCryptPublicKeys = make(
-		map[kbfscrypto.CryptPublicKey]revokedKeyInfo,
-		len(lu.RevokedCryptPublicKeys))
-	for k, v := range lu.RevokedCryptPublicKeys {
-		luCopy.RevokedCryptPublicKeys[k] = v
-	}
-
-	luCopy.Asserts = make([]string, len(lu.Asserts))
-	copy(luCopy.Asserts, lu.Asserts)
-	luCopy.UnverifiedKeys = make([]keybase1.PublicKey, len(lu.UnverifiedKeys))
-	copy(luCopy.UnverifiedKeys, lu.UnverifiedKeys)
-
-	return luCopy
-}
-
-// Helper functions to get a various keys for a local user suitable
-// for use with CryptoLocal. Each function will return the same key
-// will always be returned for a given user.
-
-// MakeLocalUserSigningKeyOrBust returns a unique signing key for this user.
-func MakeLocalUserSigningKeyOrBust(
-	name kbname.NormalizedUsername) kbfscrypto.SigningKey {
-	return kbfscrypto.MakeFakeSigningKeyOrBust(
-		string(name) + " signing key")
-}
-
-// MakeLocalUserVerifyingKeyOrBust makes a new verifying key
-// corresponding to the signing key for this user.
-func MakeLocalUserVerifyingKeyOrBust(
-	name kbname.NormalizedUsername) kbfscrypto.VerifyingKey {
-	return MakeLocalUserSigningKeyOrBust(name).GetVerifyingKey()
-}
-
-// MakeLocalUserCryptPrivateKeyOrBust returns a unique private
-// encryption key for this user.
-func MakeLocalUserCryptPrivateKeyOrBust(
-	name kbname.NormalizedUsername) kbfscrypto.CryptPrivateKey {
-	return kbfscrypto.MakeFakeCryptPrivateKeyOrBust(
-		string(name) + " crypt key")
-}
-
-// MakeLocalUserCryptPublicKeyOrBust returns the public key
-// corresponding to the crypt private key for this user.
-func MakeLocalUserCryptPublicKeyOrBust(
-	name kbname.NormalizedUsername) kbfscrypto.CryptPublicKey {
-	return MakeLocalUserCryptPrivateKeyOrBust(name).GetPublicKey()
-}
-
-// MakeLocalTLFCryptKeyOrBust returns a unique private symmetric key
-// for a TLF.
-func MakeLocalTLFCryptKeyOrBust(
-	name string, keyGen kbfsmd.KeyGen) kbfscrypto.TLFCryptKey {
-	// Put the key gen first to make it more likely to fit into the
-	// 32-character "random" seed.
-	return kbfscrypto.MakeFakeTLFCryptKeyOrBust(
-		string(name) + " " + string(keyGen) + " crypt key ")
-}
-
-// MakeLocalUsers is a helper function to generate a list of
-// LocalUsers suitable to use with KeybaseDaemonLocal.
-func MakeLocalUsers(users []kbname.NormalizedUsername) []LocalUser {
-	localUsers := make([]LocalUser, len(users))
-	for i := 0; i < len(users); i++ {
-		verifyingKey := MakeLocalUserVerifyingKeyOrBust(users[i])
-		cryptPublicKey := MakeLocalUserCryptPublicKeyOrBust(users[i])
-		localUsers[i] = LocalUser{
-			UserInfo: UserInfo{
-				Name:            users[i],
-				UID:             keybase1.MakeTestUID(uint32(i + 1)),
-				VerifyingKeys:   []kbfscrypto.VerifyingKey{verifyingKey},
-				CryptPublicKeys: []kbfscrypto.CryptPublicKey{cryptPublicKey},
-				KIDNames: map[keybase1.KID]string{
-					verifyingKey.KID(): "dev1",
-				},
-			},
-			CurrentCryptPublicKeyIndex: 0,
-			CurrentVerifyingKeyIndex:   0,
-		}
-	}
-	return localUsers
-}
-
-func makeLocalTeams(
-	teams []kbname.NormalizedUsername, startingIndex int, ty tlf.Type) (
-	localTeams []TeamInfo) {
-	localTeams = make([]TeamInfo, len(teams))
-	for index := 0; index < len(teams); index++ {
-		i := index + startingIndex
-		cryptKey := MakeLocalTLFCryptKeyOrBust(
-			buildCanonicalPathForTlfType(
-				tlf.SingleTeam, string(teams[index])),
-			kbfsmd.FirstValidKeyGen)
-		localTeams[index] = TeamInfo{
-			Name: teams[index],
-			TID:  keybase1.MakeTestTeamID(uint32(i+1), ty == tlf.Public),
-			CryptKeys: map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey{
-				kbfsmd.FirstValidKeyGen: cryptKey,
-			},
-			LatestKeyGen: kbfsmd.FirstValidKeyGen,
-		}
-		// If this is a subteam, set the root ID.
-		if strings.Contains(string(teams[index]), ".") {
-			parts := strings.SplitN(string(teams[index]), ".", 2)
-			for j := 0; j < index; j++ {
-				if parts[0] == string(localTeams[j].Name) {
-					localTeams[index].RootID = localTeams[j].TID
-					break
-				}
-			}
-		}
-	}
-	return localTeams
-}
-
-// MakeLocalTeams is a helper function to generate a list of local
-// teams suitable to use with KeybaseDaemonLocal.  Any subteams must come
-// after their root team names in the `teams` slice.
-func MakeLocalTeams(teams []kbname.NormalizedUsername) []TeamInfo {
-	return makeLocalTeams(teams, 0, tlf.Private)
-}
-
 // getDefaultCleanBlockCacheCapacity returns the default clean block
 // cache capacity. If we can get total RAM of the system, we cap at
 // the smaller of <1/4 of available memory> and
@@ -502,7 +305,7 @@ func (c *ConfigLocal) KBPKI() KBPKI {
 }
 
 // CurrentSessionGetter implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) CurrentSessionGetter() CurrentSessionGetter {
+func (c *ConfigLocal) CurrentSessionGetter() idutil.CurrentSessionGetter {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.kbpki

--- a/go/kbfs/libkbfs/config_mock_test.go
+++ b/go/kbfs/libkbfs/config_mock_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfsedits"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"golang.org/x/net/context"
 )
@@ -31,7 +32,7 @@ func (fn *FakeObserver) BatchChanges(
 }
 
 func (fn *FakeObserver) TlfHandleChange(ctx context.Context,
-	newHandle *TlfHandle) {
+	newHandle *tlfhandle.Handle) {
 	return
 }
 

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
@@ -572,7 +573,7 @@ func (cr *ConflictResolver) createdFileWithNonzeroSizes(
 	}
 	kmd := mergedChains.mostRecentChainMDInfo
 	mergedEntry, err := cr.fbo.blocks.GetEntry(ctx, lState, kmd, mergedPath)
-	if _, noExists := errors.Cause(err).(NoSuchNameError); noExists {
+	if _, noExists := errors.Cause(err).(idutil.NoSuchNameError); noExists {
 		return false, nil
 	} else if err != nil {
 		return false, err
@@ -587,7 +588,7 @@ func (cr *ConflictResolver) createdFileWithNonzeroSizes(
 		},
 	}
 	unmergedEntry, err := cr.fbo.blocks.GetEntry(ctx, lState, kmd, unmergedPath)
-	if _, noExists := errors.Cause(err).(NoSuchNameError); noExists {
+	if _, noExists := errors.Cause(err).(idutil.NoSuchNameError); noExists {
 		return false, nil
 	} else if err != nil {
 		return false, err

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/kbfs/env"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
@@ -41,7 +43,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	mockDaemon := NewMockKeybaseService(mockCtrl)
 	mockDaemon.EXPECT().LoadUserPlusKeys(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		AnyTimes().Return(UserInfo{Name: "mockUser"}, nil)
+		AnyTimes().Return(idutil.UserInfo{Name: "mockUser"}, nil)
 	config.SetKeybaseService(mockDaemon)
 
 	timeoutCtx, cancel := context.WithTimeout(
@@ -88,6 +90,8 @@ func crMakeFakeRMD(rev kbfsmd.Revision, bid kbfsmd.BranchID) ImmutableRootMetada
 		writerFlags = kbfsmd.MetadataFlagUnmerged
 	}
 	key := kbfscrypto.MakeFakeVerifyingKeyOrBust("fake key")
+	h := &tlfhandle.Handle{}
+	h.SetName("fake")
 	return MakeImmutableRootMetadata(&RootMetadata{
 		bareMd: &kbfsmd.RootMetadataV2{
 			WriterMetadataV2: kbfsmd.WriterMetadataV2{
@@ -101,7 +105,7 @@ func crMakeFakeRMD(rev kbfsmd.Revision, bid kbfsmd.BranchID) ImmutableRootMetada
 			Revision: rev,
 			PrevRoot: kbfsmd.FakeID(byte(rev - 1)),
 		},
-		tlfHandle: &TlfHandle{name: "fake"},
+		tlfHandle: h,
 		data: PrivateMetadata{
 			Changes: BlockChanges{
 				Ops: []op{newGCOp(0)}, // arbitrary op to fool unembed checks

--- a/go/kbfs/libkbfs/cr_actions.go
+++ b/go/kbfs/libkbfs/cr_actions.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"fmt"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -141,7 +142,7 @@ func uniquifyName(
 	_, err := dir.lookup(ctx, name)
 	switch errors.Cause(err).(type) {
 	case nil:
-	case NoSuchNameError:
+	case idutil.NoSuchNameError:
 		return name, nil
 	default:
 		return "", err
@@ -153,7 +154,7 @@ func uniquifyName(
 		_, err := dir.lookup(ctx, newName)
 		switch errors.Cause(err).(type) {
 		case nil:
-		case NoSuchNameError:
+		case idutil.NoSuchNameError:
 			return newName, nil
 		default:
 			return "", err
@@ -190,7 +191,7 @@ func (cuea *copyUnmergedEntryAction) do(
 	mergedEntryOk := true
 	switch errors.Cause(err).(type) {
 	case nil:
-	case NoSuchNameError:
+	case idutil.NoSuchNameError:
 		mergedEntryOk = false
 	default:
 		return nil, err
@@ -488,7 +489,7 @@ func (rmea *rmMergedEntryAction) do(
 	ctx context.Context, _, _ fileBlockDeepCopier,
 	_, mergedDir *dirData) ([]BlockInfo, error) {
 	unrefs, err := mergedDir.removeEntry(ctx, rmea.name)
-	if _, notExists := errors.Cause(err).(NoSuchNameError); notExists {
+	if _, notExists := errors.Cause(err).(idutil.NoSuchNameError); notExists {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/go/kbfs/libkbfs/cr_chains.go
+++ b/go/kbfs/libkbfs/cr_chains.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
@@ -866,7 +867,7 @@ type chainMetadata interface {
 // newCRChains builds a new crChains object from the given list of
 // chainMetadatas, which must be non-empty.
 func newCRChains(
-	ctx context.Context, codec kbfscodec.Codec, osg OfflineStatusGetter,
+	ctx context.Context, codec kbfscodec.Codec, osg idutil.OfflineStatusGetter,
 	chainMDs []chainMetadata, fbo *folderBlockOps, identifyTypes bool) (
 	ccs *crChains, err error) {
 	ccs = newCRChainsEmpty()
@@ -956,7 +957,7 @@ func newCRChains(
 // newCRChainsForIRMDs simply builds a list of chainMetadatas from the
 // given list of ImmutableRootMetadatas and calls newCRChains with it.
 func newCRChainsForIRMDs(
-	ctx context.Context, codec kbfscodec.Codec, osg OfflineStatusGetter,
+	ctx context.Context, codec kbfscodec.Codec, osg idutil.OfflineStatusGetter,
 	irmds []ImmutableRootMetadata, fbo *folderBlockOps,
 	identifyTypes bool) (ccs *crChains, err error) {
 	chainMDs := make([]chainMetadata, len(irmds))

--- a/go/kbfs/libkbfs/cr_chains_test.go
+++ b/go/kbfs/libkbfs/cr_chains_test.go
@@ -9,11 +9,13 @@ import (
 	"testing"
 	"time"
 
+	idutiltest "github.com/keybase/client/go/kbfs/idutil/test"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
@@ -155,12 +157,12 @@ func newChainMDForTest(t *testing.T) rootMetadataWithKeyAndTimestamp {
 		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	nug := testNormalizedUsernameGetter{
+	nug := idutiltest.NormalizedUsernameGetter{
 		uid.AsUserOrTeam(): "fake_user",
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(
+	h, err := tlfhandle.MakeHandle(
 		ctx, bh, bh.Type(), nil, nug, nil, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 

--- a/go/kbfs/libkbfs/dir_data.go
+++ b/go/kbfs/libkbfs/dir_data.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/logger"
@@ -146,7 +147,7 @@ func (dd *dirData) lookup(ctx context.Context, name string) (DirEntry, error) {
 
 	de, ok := block.(*DirBlock).Children[name]
 	if !ok {
-		return DirEntry{}, NoSuchNameError{name}
+		return DirEntry{}, idutil.NoSuchNameError{Name: name}
 	}
 	return de, nil
 }
@@ -275,7 +276,7 @@ func (dd *dirData) addEntryHelper(
 		return nil, NameExistsError{name}
 	} else if errorIfNoMatch &&
 		(!exists || de.BlockPointer != newDe.BlockPointer) {
-		return nil, NoSuchNameError{name}
+		return nil, idutil.NoSuchNameError{Name: name}
 	}
 	dblock.Children[name] = newDe
 

--- a/go/kbfs/libkbfs/dir_data_test.go
+++ b/go/kbfs/libkbfs/dir_data_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -152,13 +153,13 @@ func TestDirDataLookup(t *testing.T) {
 
 	t.Log("No entries, direct block")
 	_, err := dd.lookup(ctx, "a")
-	require.Equal(t, NoSuchNameError{"a"}, err)
+	require.Equal(t, idutil.NoSuchNameError{Name: "a"}, err)
 
 	t.Log("Single entry, direct block")
 	addFakeDirDataEntryToBlock(topBlock, "a", 1)
 	testDirDataCheckLookup(t, ctx, dd, "a", 1)
 	_, err = dd.lookup(ctx, "b")
-	require.Equal(t, NoSuchNameError{"b"}, err)
+	require.Equal(t, idutil.NoSuchNameError{Name: "b"}, err)
 
 	t.Log("Indirect blocks")
 	addFakeDirDataEntryToBlock(topBlock, "b", 2)
@@ -406,7 +407,7 @@ func TestDirDataRemoveEntry(t *testing.T) {
 	require.Len(t, topBlock.Children, 1)
 	testDirDataCheckLookup(t, ctx, dd, "a", 1)
 	_, err = dd.lookup(ctx, "z")
-	require.Equal(t, NoSuchNameError{"z"}, err)
+	require.Equal(t, idutil.NoSuchNameError{Name: "z"}, err)
 
 	t.Log("Make a big complicated tree and remove an entry")
 	addFakeDirDataEntry(t, ctx, dd, "b", 2)
@@ -498,7 +499,7 @@ func TestDirDataUpdateEntry(t *testing.T) {
 			Size: 100,
 		},
 	})
-	require.Equal(t, NoSuchNameError{"foo"}, err)
+	require.Equal(t, idutil.NoSuchNameError{Name: "foo"}, err)
 
 }
 

--- a/go/kbfs/libkbfs/favorites_test.go
+++ b/go/kbfs/libkbfs/favorites_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/kbfs/favorites"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsedits"
 	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
@@ -27,7 +28,7 @@ func favTestInit(t *testing.T, testingDiskCache bool) (
 	if !testingDiskCache {
 		config.mockKbpki.EXPECT().GetCurrentSession(gomock.
 			Any()).AnyTimes().
-			Return(SessionInfo{
+			Return(idutil.SessionInfo{
 				Name: kbname.NormalizedUsername("tester"),
 				UID:  keybase1.MakeTestUID(16),
 			}, nil)
@@ -377,7 +378,7 @@ func TestFavoritesDiskCache(t *testing.T) {
 	// EXPECT this manually so that we can manually edit the leveldb later
 	config.mockKbpki.EXPECT().GetCurrentSession(gomock.
 		Any()).Times(3).
-		Return(SessionInfo{
+		Return(idutil.SessionInfo{
 			Name: kbname.NormalizedUsername("tester"),
 			UID:  keybase1.MakeTestUID(16),
 		}, nil)
@@ -431,7 +432,7 @@ func TestFavoritesDiskCache(t *testing.T) {
 	// EXPECT this manually so that we can manually edit the leveldb
 	config.mockKbpki.EXPECT().GetCurrentSession(gomock.
 		Any()).Times(1).
-		Return(SessionInfo{
+		Return(idutil.SessionInfo{
 			Name: kbname.NormalizedUsername("tester"),
 			UID:  keybase1.MakeTestUID(16),
 		}, nil).Do(func(_ context.Context) {

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -957,7 +958,7 @@ func (fbm *folderBlockManager) finalizeReclamation(ctx context.Context,
 		gco.AddUnrefBlock(BlockPointer{ID: id})
 	}
 
-	ctx, err := MakeExtendedIdentify(
+	ctx, err := tlfhandle.MakeExtendedIdentify(
 		// TLFIdentifyBehavior_KBFS_QR makes service suppress the tracker popup.
 		ctx, keybase1.TLFIdentifyBehavior_KBFS_QR)
 	if err != nil {
@@ -1067,7 +1068,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 		return err
 	}
 	if !isWriter {
-		return NewWriteAccessError(head.GetTlfHandle(), session.Name,
+		return tlfhandle.NewWriteAccessError(head.GetTlfHandle(), session.Name,
 			head.GetTlfHandle().GetCanonicalPath())
 	}
 
@@ -1179,7 +1180,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 
 func isPermanentQRError(err error) bool {
 	switch errors.Cause(err).(type) {
-	case WriteAccessError, kbfsmd.MetadataIsFinalError,
+	case tlfhandle.WriteAccessError, kbfsmd.MetadataIsFinalError,
 		RevokedDeviceVerificationError:
 		return true
 	default:

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/keybase/backoff"
 	"github.com/keybase/client/go/kbfs/env"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsedits"
@@ -25,6 +26,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -571,13 +573,13 @@ func (fbo *folderBranchOps) addToFavorites(ctx context.Context,
 }
 
 func (fbo *folderBranchOps) addToFavoritesByHandle(ctx context.Context,
-	favorites *Favorites, handle *TlfHandle, created bool) (err error) {
+	favorites *Favorites, handle *tlfhandle.Handle, created bool) (err error) {
 	if _, err := fbo.config.KBPKI().GetCurrentSession(ctx); err != nil {
 		// Can't favorite while not logged in
 		return nil
 	}
 
-	favorites.AddAsync(ctx, handle.toFavToAdd(created))
+	favorites.AddAsync(ctx, handle.ToFavToAdd(created))
 	return nil
 }
 
@@ -600,7 +602,7 @@ func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context,
 }
 
 func (fbo *folderBranchOps) doFavoritesOp(ctx context.Context,
-	favs *Favorites, fop FavoritesOp, handle *TlfHandle) error {
+	favs *Favorites, fop FavoritesOp, handle *tlfhandle.Handle) error {
 	switch fop {
 	case FavoritesOpNoChange:
 		return nil
@@ -942,7 +944,7 @@ pathLoop:
 			currNode, _, err = fbo.blocks.Lookup(
 				ctx, lState, latestMerged.ReadOnly(), currNode, parent)
 			switch errors.Cause(err).(type) {
-			case NoSuchNameError:
+			case idutil.NoSuchNameError:
 				fbo.log.CDebugf(ctx, "Synced path %s doesn't exist yet", p)
 				continue pathLoop
 			case nil:
@@ -964,7 +966,7 @@ pathLoop:
 		elemNode, _, err := fbo.blocks.Lookup(
 			ctx, lState, latestMerged.ReadOnly(), currNode, syncedElem)
 		switch errors.Cause(err).(type) {
-		case NoSuchNameError:
+		case idutil.NoSuchNameError:
 			fbo.log.CDebugf(ctx, "Synced element %s doesn't exist yet", p)
 			continue pathLoop
 		case nil:
@@ -1207,7 +1209,7 @@ pathLoop:
 			// TODO: parallelize the parent fetches and lookups.
 			currNode, _, err = fbo.Lookup(ctx, currNode, parent)
 			switch errors.Cause(err).(type) {
-			case NoSuchNameError:
+			case idutil.NoSuchNameError:
 				fbo.log.CDebugf(ctx, "Synced path %s doesn't exist yet", p)
 				continue pathLoop
 			case nil:
@@ -1225,7 +1227,7 @@ pathLoop:
 		// Now mark everything rooted at this path.
 		currNode, _, err = fbo.Lookup(ctx, currNode, syncedElem)
 		switch errors.Cause(err).(type) {
-		case NoSuchNameError:
+		case idutil.NoSuchNameError:
 			fbo.log.CDebugf(ctx, "Synced element %s doesn't exist yet", p)
 			continue pathLoop
 		case nil:
@@ -1771,7 +1773,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	resolvesTo, partialResolvedOldHandle, err :=
 		oldHandle.ResolvesTo(
 			ctx, fbo.config.Codec(), fbo.config.KBPKI(),
-			constIDGetter{fbo.id()}, fbo.config, *newHandle)
+			tlfhandle.ConstIDGetter{ID: fbo.id()}, fbo.config, *newHandle)
 	if err != nil {
 		fbo.log.CDebugf(ctx, "oldHandle=%+v, newHandle=%+v: err=%+v", oldHandle, newHandle, err)
 		return err
@@ -1876,8 +1878,8 @@ func (fbo *folderBranchOps) identifyOnce(
 	fbo.identifyLock.Lock()
 	defer fbo.identifyLock.Unlock()
 
-	ei := getExtendedIdentify(ctx)
-	if fbo.identifyDone && !ei.behavior.AlwaysRunIdentify() {
+	ei := tlfhandle.GetExtendedIdentify(ctx)
+	if fbo.identifyDone && !ei.Behavior.AlwaysRunIdentify() {
 		// TODO: provide a way for the service to break this cache when identify
 		// state changes on a TLF. For now, we do it this way to make chat work.
 		return nil
@@ -1886,7 +1888,7 @@ func (fbo *folderBranchOps) identifyOnce(
 	h := md.GetTlfHandle()
 	fbo.log.CDebugf(ctx, "Running identifies on %s", h.GetCanonicalPath())
 	kbpki := fbo.config.KBPKI()
-	err := identifyHandle(ctx, kbpki, kbpki, fbo.config, h)
+	err := tlfhandle.IdentifyHandle(ctx, kbpki, kbpki, fbo.config, h)
 	if err != nil {
 		fbo.log.CDebugf(ctx, "Identify finished with error: %v", err)
 		// For now, if the identify fails, let the
@@ -1894,11 +1896,11 @@ func (fbo *folderBranchOps) identifyOnce(
 		return err
 	}
 
-	if ei.behavior.WarningInsteadOfErrorOnBrokenTracks() &&
-		len(ei.getTlfBreakAndClose().Breaks) > 0 {
+	if ei.Behavior.WarningInsteadOfErrorOnBrokenTracks() &&
+		len(ei.GetTlfBreakAndClose().Breaks) > 0 {
 		fbo.log.CDebugf(ctx,
 			"Identify finished with no error but broken proof warnings")
-	} else if ei.behavior == keybase1.TLFIdentifyBehavior_CHAT_SKIP {
+	} else if ei.Behavior == keybase1.TLFIdentifyBehavior_CHAT_SKIP {
 		fbo.log.CDebugf(ctx, "Identify skipped")
 	} else {
 		fbo.log.CDebugf(ctx, "Identify finished successfully")
@@ -1930,7 +1932,7 @@ func (fbo *folderBranchOps) getMDForRead(
 
 // GetTLFHandle implements the KBFSOps interface for folderBranchOps.
 func (fbo *folderBranchOps) GetTLFHandle(ctx context.Context, _ Node) (
-	*TlfHandle, error) {
+	*tlfhandle.Handle, error) {
 	lState := makeFBOLockState()
 	md, _ := fbo.getHead(ctx, lState, mdNoCommit)
 	return md.GetTlfHandle(), nil
@@ -2036,7 +2038,7 @@ func (fbo *folderBranchOps) getMDForReadHelper(
 			return ImmutableRootMetadata{}, err
 		}
 		if !isReader {
-			return ImmutableRootMetadata{}, NewReadAccessError(
+			return ImmutableRootMetadata{}, tlfhandle.NewReadAccessError(
 				md.GetTlfHandle(), session.Name, md.GetTlfHandle().GetCanonicalPath())
 		}
 	}
@@ -2121,7 +2123,7 @@ func (fbo *folderBranchOps) getMDForReadNeedIdentifyOnMaybeFirstAccess(
 			return ImmutableRootMetadata{}, err
 		}
 		if !isReader {
-			return ImmutableRootMetadata{}, NewReadAccessError(
+			return ImmutableRootMetadata{}, tlfhandle.NewReadAccessError(
 				md.GetTlfHandle(), session.Name, md.GetTlfHandle().GetCanonicalPath())
 		}
 	}
@@ -2149,7 +2151,7 @@ func (fbo *folderBranchOps) getMDForWriteLockedForFilename(
 		return ImmutableRootMetadata{}, err
 	}
 	if !isWriter {
-		return ImmutableRootMetadata{}, NewWriteAccessError(
+		return ImmutableRootMetadata{}, tlfhandle.NewWriteAccessError(
 			md.GetTlfHandle(), session.Name, filename)
 	}
 
@@ -2339,7 +2341,7 @@ func (fbo *folderBranchOps) initMDLocked(
 		return err
 	}
 	if !isWriter {
-		return NewWriteAccessError(
+		return tlfhandle.NewWriteAccessError(
 			handle, session.Name, handle.GetCanonicalPath())
 	}
 
@@ -2653,7 +2655,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 // SetInitialHeadToNew creates a brand-new ImmutableRootMetadata
 // object and sets the head to that. This is trusted.
 func (fbo *folderBranchOps) SetInitialHeadToNew(
-	ctx context.Context, id tlf.ID, handle *TlfHandle) (err error) {
+	ctx context.Context, id tlf.ID, handle *tlfhandle.Handle) (err error) {
 	fbo.log.CDebugf(ctx, "SetInitialHeadToNew %s", id)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx, "SetInitialHeadToNew %s done: %+v",
@@ -2701,7 +2703,7 @@ func getNodeIDStr(n Node) string {
 }
 
 func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
-	node Node, ei EntryInfo, handle *TlfHandle, err error) {
+	node Node, ei EntryInfo, handle *tlfhandle.Handle, err error) {
 	fbo.log.CDebugf(ctx, "getRootNode")
 	defer func() {
 		fbo.deferLog.CDebugf(ctx, "getRootNode done: %s %+v",
@@ -3070,7 +3072,7 @@ func (fbo *folderBranchOps) lookup(ctx context.Context, dir Node, name string) (
 	if fbo.nodeCache.IsUnlinked(dir) {
 		fbo.log.CDebugf(ctx, "Refusing a lookup for unlinked directory %v",
 			fbo.nodeCache.PathFromNode(dir).tailPointer())
-		return nil, DirEntry{}, NoSuchNameError{name}
+		return nil, DirEntry{}, idutil.NoSuchNameError{Name: name}
 	}
 
 	md, err := fbo.getMDForReadNeedIdentify(ctx, lState)
@@ -3079,7 +3081,7 @@ func (fbo *folderBranchOps) lookup(ctx context.Context, dir Node, name string) (
 	}
 
 	node, de, err = fbo.blocks.Lookup(ctx, lState, md.ReadOnly(), dir, name)
-	if _, isMiss := errors.Cause(err).(NoSuchNameError); isMiss {
+	if _, isMiss := errors.Cause(err).(idutil.NoSuchNameError); isMiss {
 		node, de.EntryInfo, err = fbo.processMissedLookup(
 			ctx, lState, dir, name, err)
 		if _, exists := errors.Cause(err).(NameExistsError); exists {
@@ -3117,7 +3119,7 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	})
 	// Only retry the lookup potentially if the lookup missed.
 	if err != nil {
-		if _, isMiss := errors.Cause(err).(NoSuchNameError); !isMiss {
+		if _, isMiss := errors.Cause(err).(idutil.NoSuchNameError); !isMiss {
 			return nil, EntryInfo{}, err
 		}
 	}
@@ -3324,7 +3326,7 @@ func isRevisionConflict(err error) bool {
 }
 
 func (fbo *folderBranchOps) getConvID(
-	ctx context.Context, handle *TlfHandle) (
+	ctx context.Context, handle *tlfhandle.Handle) (
 	chat1.ConversationID, error) {
 	fbo.convLock.Lock()
 	defer fbo.convLock.Unlock()
@@ -3453,7 +3455,8 @@ func (fbo *folderBranchOps) handleUnflushedEditNotifications(
 	if err != nil {
 		return err
 	}
-	session, err := GetCurrentSessionIfPossible(ctx, fbo.config.KBPKI(), true)
+	session, err := idutil.GetCurrentSessionIfPossible(
+		ctx, fbo.config.KBPKI(), true)
 	if err != nil {
 		return err
 	}
@@ -3905,14 +3908,14 @@ func checkDisallowedPrefixes(ctx context.Context, name string) error {
 }
 
 // PathType returns path type
-func (fbo *folderBranchOps) PathType() PathType {
+func (fbo *folderBranchOps) PathType() tlfhandle.PathType {
 	switch fbo.folderBranch.Tlf.Type() {
 	case tlf.Public:
-		return PublicPathType
+		return tlfhandle.PublicPathType
 	case tlf.Private:
-		return PrivatePathType
+		return tlfhandle.PrivatePathType
 	case tlf.SingleTeam:
-		return SingleTeamPathType
+		return tlfhandle.SingleTeamPathType
 	default:
 		panic(fmt.Sprintf("Unknown TLF type: %s", fbo.folderBranch.Tlf.Type()))
 	}
@@ -3924,7 +3927,8 @@ func (fbo *folderBranchOps) canonicalPath(ctx context.Context, dir Node, name st
 	if err != nil {
 		return "", err
 	}
-	return BuildCanonicalPath(fbo.PathType(), dirPath.String(), name), nil
+	return tlfhandle.BuildCanonicalPath(
+		fbo.PathType(), dirPath.String(), name), nil
 }
 
 func (fbo *folderBranchOps) signalWrite() {
@@ -4000,7 +4004,7 @@ func (fbo *folderBranchOps) createEntryLocked(
 		ctx, lState, md.ReadOnly(), dirPath.ChildPathNoPtr(name))
 	if err == nil {
 		return nil, DirEntry{}, NameExistsError{name}
-	} else if _, notExists := errors.Cause(err).(NoSuchNameError); !notExists {
+	} else if _, notExists := errors.Cause(err).(idutil.NoSuchNameError); !notExists {
 		return nil, DirEntry{}, err
 	}
 
@@ -4441,7 +4445,7 @@ func (fbo *folderBranchOps) createLinkLocked(
 		ctx, lState, md.ReadOnly(), dirPath.ChildPathNoPtr(fromName))
 	if err == nil {
 		return DirEntry{}, NameExistsError{fromName}
-	} else if _, notExists := errors.Cause(err).(NoSuchNameError); !notExists {
+	} else if _, notExists := errors.Cause(err).(idutil.NoSuchNameError); !notExists {
 		return DirEntry{}, err
 	}
 
@@ -4580,8 +4584,8 @@ func (fbo *folderBranchOps) removeEntryLocked(ctx context.Context,
 	// make sure the entry exists
 	de, err := fbo.blocks.GetEntry(
 		ctx, lState, md, dirPath.ChildPathNoPtr(name))
-	if _, notExists := errors.Cause(err).(NoSuchNameError); notExists {
-		return NoSuchNameError{name}
+	if _, notExists := errors.Cause(err).(idutil.NoSuchNameError); notExists {
+		return idutil.NoSuchNameError{Name: name}
 	} else if err != nil {
 		return err
 	}
@@ -4642,8 +4646,8 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 
 	de, err := fbo.blocks.GetEntry(
 		ctx, lState, md.ReadOnly(), dirPath.ChildPathNoPtr(dirName))
-	if _, notExists := errors.Cause(err).(NoSuchNameError); notExists {
-		return NoSuchNameError{dirName}
+	if _, notExists := errors.Cause(err).(idutil.NoSuchNameError); notExists {
+		return idutil.NoSuchNameError{Name: dirName}
 	} else if err != nil {
 		return err
 	}
@@ -7157,7 +7161,7 @@ func (fbo *folderBranchOps) locallyFinalizeTLF(ctx context.Context) {
 		fbo.log.CErrorf(ctx, "Couldn't get finalized bare handle: %+v", err)
 		return
 	}
-	handle, err := MakeTlfHandle(
+	handle, err := tlfhandle.MakeHandle(
 		ctx, bareHandle, fbo.id().Type(), fbo.config.KBPKI(),
 		fbo.config.KBPKI(), fbo.config.MDOps(), fbo.oa())
 	if err != nil {
@@ -7758,7 +7762,8 @@ func (fbo *folderBranchOps) handleMDFlush(
 	}
 
 	fbo.editHistory.FlushRevision(rev)
-	session, err := GetCurrentSessionIfPossible(ctx, fbo.config.KBPKI(), true)
+	session, err := idutil.GetCurrentSessionIfPossible(
+		ctx, fbo.config.KBPKI(), true)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Error getting session: %+v", err)
 	}
@@ -7848,9 +7853,9 @@ func (fbo *folderBranchOps) TeamNameChanged(
 	}
 
 	// Make a copy of `head` with the new handle.
-	newHandle := oldHandle.deepCopy()
-	newHandle.name = tlf.CanonicalName(newName)
-	newHandle.resolvedWriters[tid.AsUserOrTeam()] = newName
+	newHandle := oldHandle.DeepCopy()
+	newHandle.SetName(tlf.CanonicalName(newName))
+	newHandle.SetResolvedWriter(tid.AsUserOrTeam(), newName)
 	newHead, err := fbo.head.deepCopy(fbo.config.Codec())
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Error copying head: %+v", err)
@@ -7902,7 +7907,7 @@ func (fbo *folderBranchOps) getMDForMigrationLocked(
 		return ImmutableRootMetadata{}, err
 	}
 	if !isWriter {
-		return ImmutableRootMetadata{}, NewWriteAccessError(
+		return ImmutableRootMetadata{}, tlfhandle.NewWriteAccessError(
 			md.GetTlfHandle(), session.Name, "")
 	}
 
@@ -7954,7 +7959,7 @@ func (fbo *folderBranchOps) MigrateToImplicitTeam(
 
 	name := string(md.GetTlfHandle().GetCanonicalName())
 	fbo.log.CDebugf(ctx, "Looking up implicit team for %s", name)
-	newHandle, err := ParseTlfHandle(
+	newHandle, err := tlfhandle.ParseHandle(
 		ctx, fbo.config.KBPKI(), fbo.config.MDOps(), fbo.config,
 		name, id.Type())
 	if err != nil {
@@ -8227,7 +8232,7 @@ func (fbo *folderBranchOps) ForceFastForward(ctx context.Context) {
 
 // Reset implements the KBFSOps interface for folderBranchOps.
 func (fbo *folderBranchOps) Reset(
-	ctx context.Context, handle *TlfHandle) error {
+	ctx context.Context, handle *tlfhandle.Handle) error {
 	currHandle, err := fbo.GetTLFHandle(ctx, nil)
 	if err != nil {
 		return err
@@ -8241,7 +8246,7 @@ func (fbo *folderBranchOps) Reset(
 			currHandle, handle)
 	}
 
-	oldHandle := handle.deepCopy()
+	oldHandle := handle.DeepCopy()
 
 	lState := makeFBOLockState()
 	fbo.mdWriterLock.Lock(lState)
@@ -8398,7 +8403,7 @@ func (fbo *folderBranchOps) triggerMarkAndSweepLocked() {
 }
 
 func (fbo *folderBranchOps) reResolveAndIdentify(
-	ctx context.Context, oldHandle *TlfHandle, rev kbfsmd.Revision) {
+	ctx context.Context, oldHandle *tlfhandle.Handle, rev kbfsmd.Revision) {
 	fbo.log.CDebugf(ctx, "Re-resolving handle")
 	defer func() { fbo.log.CDebugf(ctx, "Done") }()
 
@@ -8408,7 +8413,7 @@ func (fbo *folderBranchOps) reResolveAndIdentify(
 	// cached in the service), and once without it (to cause all the
 	// individual users of the folder to be cached in the service).
 	tlfName := string(oldHandle.GetCanonicalName())
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, fbo.config.KBPKI(), fbo.config.MDOps(), fbo.config,
 		tlfName, fbo.id().Type())
 	if err != nil {
@@ -8418,10 +8423,10 @@ func (fbo *folderBranchOps) reResolveAndIdentify(
 
 outer:
 	for {
-		_, err := ParseTlfHandlePreferredQuick(
+		_, err := tlfhandle.ParseHandlePreferredQuick(
 			ctx, fbo.config.KBPKI(), fbo.config, tlfName, fbo.id().Type())
 		switch e := errors.Cause(err).(type) {
-		case TlfNameNotCanonical:
+		case idutil.TlfNameNotCanonical:
 			tlfName = e.NameToTry
 		case nil:
 			break outer
@@ -8440,7 +8445,7 @@ outer:
 	}
 
 	// Suppress tracker popups.
-	ctx, err = MakeExtendedIdentify(
+	ctx, err = tlfhandle.MakeExtendedIdentify(
 		ctx, keybase1.TLFIdentifyBehavior_KBFS_INIT)
 	if err != nil {
 		fbo.log.CDebugf(
@@ -8448,7 +8453,7 @@ outer:
 		return
 	}
 
-	err = identifyHandle(
+	err = tlfhandle.IdentifyHandle(
 		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), fbo.config, h)
 	if err != nil {
 		fbo.log.CDebugf(ctx, "Couldn't identify handle: %+v", err)
@@ -8458,7 +8463,7 @@ outer:
 	// have been logged.  So just close out the extended identify.  If
 	// the user accesses the TLF directly, another proper identify
 	// should happen that shows errors.
-	_ = getExtendedIdentify(ctx).getTlfBreakAndClose()
+	_ = tlfhandle.GetExtendedIdentify(ctx).GetTlfBreakAndClose()
 }
 
 // SetSyncConfig implements the KBFSOps interface for KBFSOpsStandard.
@@ -8614,7 +8619,7 @@ func (fbo *folderBranchOps) getEditMonitoringChannel() <-chan struct{} {
 // NewNotificationChannel implements the KBFSOps interface for
 // folderBranchOps.
 func (fbo *folderBranchOps) NewNotificationChannel(
-	ctx context.Context, handle *TlfHandle, convID chat1.ConversationID,
+	ctx context.Context, handle *tlfhandle.Handle, convID chat1.ConversationID,
 	channelName string) {
 	monitoringCh := fbo.getEditMonitoringChannel()
 	if monitoringCh == nil {
@@ -8732,7 +8737,8 @@ func (fbo *folderBranchOps) recomputeEditHistory(
 	nameToNextPage map[string][]byte) {
 	gotMore := true
 
-	session, err := GetCurrentSessionIfPossible(ctx, fbo.config.KBPKI(), true)
+	session, err := idutil.GetCurrentSessionIfPossible(
+		ctx, fbo.config.KBPKI(), true)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Error getting session: %+v", err)
 		return

--- a/go/kbfs/libkbfs/folder_branch_status_test.go
+++ b/go/kbfs/libkbfs/folder_branch_status_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
@@ -29,7 +30,7 @@ func fbStatusTestInit(t *testing.T) (*gomock.Controller, *ConfigMock,
 	config := NewConfigMock(mockCtrl, ctr)
 	config.mockKbpki.EXPECT().ResolveImplicitTeam(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		AnyTimes().Return(ImplicitTeamInfo{}, errors.New("No such team"))
+		AnyTimes().Return(idutil.ImplicitTeamInfo{}, errors.New("No such team"))
 	nodeCache := NewMockNodeCache(mockCtrl)
 	fbsk := newFolderBranchStatusKeeper(config, nodeCache, nil, nil)
 	interposeDaemonKBPKI(config, "alice", "bob")

--- a/go/kbfs/libkbfs/folder_update_prepper.go
+++ b/go/kbfs/libkbfs/folder_update_prepper.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -284,11 +285,12 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			dd, cleanupFn = fup.blocks.newDirDataWithDBM(
 				lState, prevDir, chargedTo, md, dbm)
 			de, err = dd.lookup(ctx, currName)
-			if _, noExists := errors.Cause(err).(NoSuchNameError); noExists {
+			if _, noExists := errors.Cause(err).(idutil.NoSuchNameError); noExists {
 				// If this isn't the first time
 				// around, we have an error.
 				if len(newPath.path) > 1 {
-					return path{}, DirEntry{}, NoSuchNameError{currName}
+					return path{}, DirEntry{},
+						idutil.NoSuchNameError{Name: currName}
 				}
 
 				// If this is a file, the size should be 0. (TODO:
@@ -951,7 +953,7 @@ func (fup *folderUpdatePrepper) setChildrenNodes(
 		switch errors.Cause(err).(type) {
 		case nil:
 			filePtr = de.BlockPointer
-		case NoSuchNameError:
+		case idutil.NoSuchNameError:
 		default:
 			fup.log.CWarningf(ctx, "Couldn't look up child: %+v", err)
 			continue

--- a/go/kbfs/libkbfs/journal_manager_test.go
+++ b/go/kbfs/libkbfs/journal_manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -177,13 +178,13 @@ func TestJournalManagerOverQuotaError(t *testing.T) {
 	err = jManager.Enable(ctx, tlfID1, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 	tlfID2 := tlf.FakeID(2, tlf.SingleTeam)
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "t1", tlf.SingleTeam)
 	require.NoError(t, err)
 	err = jManager.Enable(ctx, tlfID2, h, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 	tlfID3 := tlf.FakeID(2, tlf.SingleTeam)
-	h, err = ParseTlfHandle(
+	h, err = tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "t1.sub", tlf.SingleTeam)
 	require.NoError(t, err)
 	err = jManager.Enable(ctx, tlfID3, h, TLFJournalBackgroundWorkPaused)
@@ -191,7 +192,7 @@ func TestJournalManagerOverQuotaError(t *testing.T) {
 
 	blockServer := config.BlockServer()
 
-	h, err = ParseTlfHandle(
+	h, err = tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1,test_user2",
 		tlf.Private)
 	require.NoError(t, err)
@@ -311,7 +312,7 @@ func TestJournalManagerOverDiskLimitError(t *testing.T) {
 
 	blockServer := config.BlockServer()
 
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1,test_user2",
 		tlf.Private)
 	require.NoError(t, err)
@@ -383,7 +384,7 @@ func TestJournalManagerRestart(t *testing.T) {
 	blockServer := config.BlockServer()
 	mdOps := config.MDOps()
 
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
@@ -458,7 +459,7 @@ func TestJournalManagerLogOutLogIn(t *testing.T) {
 	blockServer := config.BlockServer()
 	mdOps := config.MDOps()
 
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
@@ -568,7 +569,7 @@ func TestJournalManagerMultiUser(t *testing.T) {
 	blockServer := config.BlockServer()
 	mdOps := config.MDOps()
 
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1,test_user2",
 		tlf.Private)
 	require.NoError(t, err)
@@ -609,7 +610,7 @@ func TestJournalManagerMultiUser(t *testing.T) {
 	serviceLoggedOut(ctx, config)
 
 	service := config.KeybaseService().(*KeybaseDaemonLocal)
-	service.setCurrentUID(id2.AsUserOrBust())
+	service.SetCurrentUID(id2.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	session, err = config.KBPKI().GetCurrentSession(ctx)
@@ -674,7 +675,7 @@ func TestJournalManagerMultiUser(t *testing.T) {
 
 	// Log in user 1.
 
-	service.setCurrentUID(id1.AsUserOrBust())
+	service.SetCurrentUID(id1.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	session, err = config.KBPKI().GetCurrentSession(ctx)
@@ -701,7 +702,7 @@ func TestJournalManagerMultiUser(t *testing.T) {
 
 	serviceLoggedOut(ctx, config)
 
-	service.setCurrentUID(id2.AsUserOrBust())
+	service.SetCurrentUID(id2.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	session, err = config.KBPKI().GetCurrentSession(ctx)
@@ -738,11 +739,11 @@ func TestJournalManagerEnableAuto(t *testing.T) {
 	require.Len(t, tlfIDs, 0)
 
 	blockServer := config.BlockServer()
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
-	tlfID := h.tlfID
+	tlfID := h.TlfID()
 
 	jManager.PauseBackgroundWork(ctx, tlfID)
 
@@ -799,7 +800,7 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 	// This will end up calling journalMDOps.GetIDForHandle, which
 	// initializes the journal if possible.  In this case for a
 	// public, unwritable folder, it shouldn't.
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user2", tlf.Public)
 	require.NoError(t, err)
 
@@ -809,7 +810,7 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 	require.Len(t, tlfIDs, 0)
 
 	// Neither should a private, reader folder.
-	h, err = ParseTlfHandle(
+	h, err = tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user2#test_user1",
 		tlf.Private)
 	require.NoError(t, err)
@@ -827,7 +828,7 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 		t, config, id, h.FirstResolvedWriter().AsUserOrBust())
 	AddTeamReaderForTestOrBust(
 		t, config, id, h.ResolvedReaders()[0].AsUserOrBust())
-	h, err = ParseTlfHandle(
+	h, err = tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(teamName),
 		tlf.SingleTeam)
 	require.NoError(t, err)
@@ -838,7 +839,7 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 	require.Len(t, tlfIDs, 0)
 
 	// But accessing our own should make one.
-	h, err = ParseTlfHandle(
+	h, err = tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Public)
 	require.NoError(t, err)
 
@@ -861,11 +862,11 @@ func TestJournalManagerNukeEmptyJournalsOnRestart(t *testing.T) {
 	require.Len(t, tlfIDs, 0)
 
 	blockServer := config.BlockServer()
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
-	tlfID := h.tlfID
+	tlfID := h.TlfID()
 
 	// Access a TLF, which should create a journal automatically.
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
@@ -925,7 +926,7 @@ func TestJournalManagerTeamTLFWithRestart(t *testing.T) {
 	// journal tries to access it.
 	jManager.delegateBlockServer = shutdownOnlyBlockServer{}
 
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.SingleTeam)
 	require.NoError(t, err)
 

--- a/go/kbfs/libkbfs/journal_md_ops_test.go
+++ b/go/kbfs/libkbfs/journal_md_ops_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,7 +82,7 @@ func teardownJournalMDOpsTest(t *testing.T, tempdir string, ctx context.Context,
 }
 
 func makeMDForJournalMDOpsTest(
-	t *testing.T, config Config, tlfID tlf.ID, h *TlfHandle,
+	t *testing.T, config Config, tlfID tlf.ID, h *tlfhandle.Handle,
 	revision kbfsmd.Revision) *RootMetadata {
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
@@ -107,7 +108,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(
+	h, err := tlfhandle.MakeHandle(
 		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil,
 		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
@@ -120,7 +121,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	irmd, err := mdOps.GetForTLF(ctx, id, nil)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
-	h.tlfID = id
+	h.SetTlfID(id)
 
 	err = jManager.Enable(ctx, id, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -285,7 +286,7 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(
+	h, err := tlfhandle.MakeHandle(
 		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil,
 		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
@@ -321,7 +322,7 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(
+	h, err := tlfhandle.MakeHandle(
 		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil,
 		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
@@ -355,7 +356,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(
+	h, err := tlfhandle.MakeHandle(
 		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil,
 		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/kbfs_cr_test.go
+++ b/go/kbfs/libkbfs/kbfs_cr_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,7 +53,7 @@ func (t *testCRObserver) BatchChanges(ctx context.Context,
 }
 
 func (t *testCRObserver) TlfHandleChange(ctx context.Context,
-	newHandle *TlfHandle) {
+	newHandle *tlfhandle.Handle) {
 	return
 }
 
@@ -258,7 +259,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 
 	DisableCRForTesting(config1B, rootNode1.GetFolderBranch())
 
-	tlfHandle, err := ParseTlfHandle(
+	tlfHandle, err := tlfhandle.ParseHandle(
 		ctx, config1B.KBPKI(), config1B.MDOps(), nil, name, tlf.Private)
 	require.NoError(t, err)
 

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -434,7 +435,7 @@ func (fs *KBFSOpsStandard) getOpsByNode(ctx context.Context,
 }
 
 func (fs *KBFSOpsStandard) getOpsByHandle(ctx context.Context,
-	handle *TlfHandle, fb FolderBranch, fop FavoritesOp) *folderBranchOps {
+	handle *tlfhandle.Handle, fb FolderBranch, fop FavoritesOp) *folderBranchOps {
 	ops := fs.getOpsNoAdd(ctx, fb)
 	if err := ops.doFavoritesOp(ctx, fs.favs, fop, handle); err != nil {
 		// Failure to favorite shouldn't cause a failure.  Just log
@@ -461,7 +462,7 @@ func (fs *KBFSOpsStandard) getOpsByHandle(ctx context.Context,
 	return ops
 }
 
-func (fs *KBFSOpsStandard) resetTlfID(ctx context.Context, h *TlfHandle) error {
+func (fs *KBFSOpsStandard) resetTlfID(ctx context.Context, h *tlfhandle.Handle) error {
 	if !h.IsBackedByTeam() {
 		return errors.WithStack(NonExistentTeamForHandleError{h})
 	}
@@ -471,7 +472,7 @@ func (fs *KBFSOpsStandard) resetTlfID(ctx context.Context, h *TlfHandle) error {
 		return err
 	}
 
-	matches, epoch, err := h.tlfID.GetEpochFromTeamTLF(teamID)
+	matches, epoch, err := h.TlfID().GetEpochFromTeamTLF(teamID)
 	if err != nil {
 		return err
 	}
@@ -497,7 +498,7 @@ func (fs *KBFSOpsStandard) resetTlfID(ctx context.Context, h *TlfHandle) error {
 		return err
 	}
 
-	h.tlfID = tlfID
+	h.SetTlfID(tlfID)
 	return fs.config.MDCache().PutIDForHandle(h, tlfID)
 }
 
@@ -506,8 +507,8 @@ func (fs *KBFSOpsStandard) resetTlfID(ctx context.Context, h *TlfHandle) error {
 // with the team.  If it returns a `nil` error, it may have modified
 // `h` to include the new TLF ID.
 func (fs *KBFSOpsStandard) createAndStoreTlfIDIfNeeded(
-	ctx context.Context, h *TlfHandle) error {
-	if h.tlfID != tlf.NullID {
+	ctx context.Context, h *tlfhandle.Handle) error {
+	if h.TlfID() != tlf.NullID {
 		return nil
 	}
 
@@ -515,7 +516,7 @@ func (fs *KBFSOpsStandard) createAndStoreTlfIDIfNeeded(
 }
 
 func (fs *KBFSOpsStandard) transformReadError(
-	ctx context.Context, h *TlfHandle, err error) error {
+	ctx context.Context, h *tlfhandle.Handle, err error) error {
 	if errors.Cause(err) != context.DeadlineExceeded {
 		return err
 	}
@@ -523,7 +524,7 @@ func (fs *KBFSOpsStandard) transformReadError(
 		return err
 	}
 
-	if fs.config.IsSyncedTlf(h.tlfID) {
+	if fs.config.IsSyncedTlf(h.TlfID()) {
 		fs.log.CWarningf(ctx, "Got a read timeout on a synced TLF: %+v", err)
 		return err
 	}
@@ -534,17 +535,17 @@ func (fs *KBFSOpsStandard) transformReadError(
 }
 
 func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
-	mdops MDOps, h *TlfHandle, fb FolderBranch, create bool, fop FavoritesOp) (
+	mdops MDOps, h *tlfhandle.Handle, fb FolderBranch, create bool, fop FavoritesOp) (
 	initialized bool, md ImmutableRootMetadata, id tlf.ID, err error) {
 	defer func() {
 		err = fs.transformReadError(ctx, h, err)
-		if getExtendedIdentify(ctx).behavior.AlwaysRunIdentify() &&
+		if tlfhandle.GetExtendedIdentify(ctx).Behavior.AlwaysRunIdentify() &&
 			!initialized && err == nil {
 			kbpki := fs.config.KBPKI()
 			// We are not running identify for existing TLFs in
 			// KBFS. This makes sure if requested, identify runs even
 			// for existing TLFs.
-			err = identifyHandle(ctx, kbpki, kbpki, fs.config, h)
+			err = tlfhandle.IdentifyHandle(ctx, kbpki, kbpki, fs.config, h)
 		}
 	}()
 
@@ -574,7 +575,7 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		}
 
 		md, err = getSingleMD(
-			ctx, fs.config, h.tlfID, kbfsmd.NullBranchID, rev,
+			ctx, fs.config, h.TlfID(), kbfsmd.NullBranchID, rev,
 			kbfsmd.Merged, nil)
 		// This will error if there's no corresponding MD, which is
 		// what we want since that means the user input an incorrect
@@ -582,24 +583,24 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		if err != nil {
 			return false, ImmutableRootMetadata{}, tlf.NullID, err
 		}
-		return false, md, h.tlfID, nil
+		return false, md, h.TlfID(), nil
 	}
 
-	md, err = mdops.GetForTLF(ctx, h.tlfID, nil)
+	md, err = mdops.GetForTLF(ctx, h.TlfID(), nil)
 	if err != nil {
 		return false, ImmutableRootMetadata{}, tlf.NullID, err
 	}
 	if md != (ImmutableRootMetadata{}) {
-		return false, md, h.tlfID, nil
+		return false, md, h.TlfID(), nil
 	}
 
 	if !create {
-		return false, ImmutableRootMetadata{}, h.tlfID, nil
+		return false, ImmutableRootMetadata{}, h.TlfID(), nil
 	}
 
 	// Init new MD.
 	fops := fs.getOpsByHandle(ctx, h, fb, fop)
-	err = fops.SetInitialHeadToNew(ctx, h.tlfID, h)
+	err = fops.SetInitialHeadToNew(ctx, h.TlfID(), h)
 	// Someone else initialized the TLF out from under us, so we
 	// didn't initialize it.
 	_, alreadyExisted := errors.Cause(err).(RekeyConflictError)
@@ -607,17 +608,17 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		return false, ImmutableRootMetadata{}, tlf.NullID, err
 	}
 
-	md, err = mdops.GetForTLF(ctx, h.tlfID, nil)
+	md, err = mdops.GetForTLF(ctx, h.TlfID(), nil)
 	if err != nil {
 		return false, ImmutableRootMetadata{}, tlf.NullID, err
 	}
 
-	return !alreadyExisted, md, h.tlfID, err
+	return !alreadyExisted, md, h.TlfID(), err
 
 }
 
 func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
-	tlfHandle *TlfHandle, fop FavoritesOp) (rmd ImmutableRootMetadata, err error) {
+	tlfHandle *tlfhandle.Handle, fop FavoritesOp) (rmd ImmutableRootMetadata, err error) {
 	fbo := fs.getOpsByFav(tlfHandle.ToFavorite())
 	if fbo != nil {
 		lState := makeFBOLockState()
@@ -638,13 +639,13 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 	// Check for an unmerged MD first if necessary.
 	if fs.config.Mode().UnmergedTLFsEnabled() {
 		rmd, err = fs.config.MDOps().GetUnmergedForTLF(
-			ctx, tlfHandle.tlfID, kbfsmd.NullBranchID)
+			ctx, tlfHandle.TlfID(), kbfsmd.NullBranchID)
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
 	}
 
-	fb := FolderBranch{Tlf: tlfHandle.tlfID, Branch: MasterBranch}
+	fb := FolderBranch{Tlf: tlfHandle.TlfID(), Branch: MasterBranch}
 	if rmd == (ImmutableRootMetadata{}) {
 		if fop == FavoritesOpAdd {
 			_, rmd, _, err = fs.getOrInitializeNewMDMaster(
@@ -674,7 +675,7 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 // GetTLFCryptKeys implements the KBFSOps interface for
 // KBFSOpsStandard
 func (fs *KBFSOpsStandard) GetTLFCryptKeys(
-	ctx context.Context, tlfHandle *TlfHandle) (
+	ctx context.Context, tlfHandle *tlfhandle.Handle) (
 	keys []kbfscrypto.TLFCryptKey, id tlf.ID, err error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
@@ -692,7 +693,7 @@ func (fs *KBFSOpsStandard) GetTLFCryptKeys(
 
 // GetTLFID implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetTLFID(ctx context.Context,
-	tlfHandle *TlfHandle) (id tlf.ID, err error) {
+	tlfHandle *tlfhandle.Handle) (id tlf.ID, err error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -708,7 +709,7 @@ func (fs *KBFSOpsStandard) GetTLFID(ctx context.Context,
 
 // GetTLFHandle implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetTLFHandle(ctx context.Context, node Node) (
-	*TlfHandle, error) {
+	*tlfhandle.Handle, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -718,7 +719,7 @@ func (fs *KBFSOpsStandard) GetTLFHandle(ctx context.Context, node Node) (
 
 // getMaybeCreateRootNode is called for GetOrCreateRootNode and GetRootNode.
 func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
-	ctx context.Context, h *TlfHandle, branch BranchName, create bool) (
+	ctx context.Context, h *tlfhandle.Handle, branch BranchName, create bool) (
 	node Node, ei EntryInfo, err error) {
 	fs.log.CDebugf(ctx, "getMaybeCreateRootNode(%s, %v, %v)",
 		h.GetCanonicalPath(), branch, create)
@@ -739,12 +740,12 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 
 	// Check if we already have the MD cached, before contacting any
 	// servers.
-	if h.tlfID == tlf.NullID {
+	if h.TlfID() == tlf.NullID {
 		return nil, EntryInfo{},
 			errors.Errorf("Handle for %s doesn't have a TLF ID set",
 				h.GetCanonicalPath())
 	}
-	fb := FolderBranch{Tlf: h.tlfID, Branch: branch}
+	fb := FolderBranch{Tlf: h.TlfID(), Branch: branch}
 	fops := fs.getOpsIfExists(ctx, fb)
 	if fops != nil {
 		// If a folderBranchOps has already been initialized for this TLF,
@@ -771,7 +772,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 	var md ImmutableRootMetadata
 	// Check for an unmerged MD first if necessary.
 	if fs.config.Mode().UnmergedTLFsEnabled() {
-		md, err = mdops.GetUnmergedForTLF(ctx, h.tlfID, kbfsmd.NullBranchID)
+		md, err = mdops.GetUnmergedForTLF(ctx, h.TlfID(), kbfsmd.NullBranchID)
 		if err != nil {
 			return nil, EntryInfo{}, err
 		}
@@ -798,7 +799,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 		}
 		if !create && md == (ImmutableRootMetadata{}) {
 			kbpki := fs.config.KBPKI()
-			err := identifyHandle(ctx, kbpki, kbpki, fs.config, h)
+			err := tlfhandle.IdentifyHandle(ctx, kbpki, kbpki, fs.config, h)
 			if err != nil {
 				return nil, EntryInfo{}, err
 			}
@@ -846,7 +847,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 // GetOrCreateRootNode implements the KBFSOps interface for
 // KBFSOpsStandard
 func (fs *KBFSOpsStandard) GetOrCreateRootNode(
-	ctx context.Context, h *TlfHandle, branch BranchName) (
+	ctx context.Context, h *tlfhandle.Handle, branch BranchName) (
 	node Node, ei EntryInfo, err error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
@@ -858,7 +859,7 @@ func (fs *KBFSOpsStandard) GetOrCreateRootNode(
 // KBFSOpsStandard. Returns a nil Node and nil error
 // if the tlf does not exist but there is no error present.
 func (fs *KBFSOpsStandard) GetRootNode(
-	ctx context.Context, h *TlfHandle, branch BranchName) (
+	ctx context.Context, h *tlfhandle.Handle, branch BranchName) (
 	node Node, ei EntryInfo, err error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
@@ -1260,8 +1261,8 @@ func (fs *KBFSOpsStandard) KickoffAllOutstandingRekeys() error {
 }
 
 func (fs *KBFSOpsStandard) initTLFWithoutIdentifyPopups(
-	ctx context.Context, handle *TlfHandle) error {
-	ctx, err := MakeExtendedIdentify(
+	ctx context.Context, handle *tlfhandle.Handle) error {
+	ctx, err := tlfhandle.MakeExtendedIdentify(
 		ctx, keybase1.TLFIdentifyBehavior_KBFS_CHAT)
 	if err != nil {
 		return err
@@ -1276,14 +1277,14 @@ func (fs *KBFSOpsStandard) initTLFWithoutIdentifyPopups(
 	// have been logged.  So just close out the extended identify.  If
 	// the user accesses the TLF directly, another proper identify
 	// should happen that shows errors.
-	_ = getExtendedIdentify(ctx).getTlfBreakAndClose()
+	_ = tlfhandle.GetExtendedIdentify(ctx).GetTlfBreakAndClose()
 	return nil
 }
 
 // NewNotificationChannel implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) NewNotificationChannel(
-	ctx context.Context, handle *TlfHandle, convID chat1.ConversationID,
+	ctx context.Context, handle *tlfhandle.Handle, convID chat1.ConversationID,
 	channelName string) {
 	if !fs.config.Mode().TLFEditHistoryEnabled() {
 		return
@@ -1300,7 +1301,7 @@ func (fs *KBFSOpsStandard) NewNotificationChannel(
 	fav := handle.ToFavorite()
 	if ops, ok := fs.opsByFav[fav]; ok {
 		ops.NewNotificationChannel(ctx, handle, convID, channelName)
-	} else if handle.tlfID != tlf.NullID {
+	} else if handle.TlfID() != tlf.NullID {
 		fs.editActivity.Add(1)
 		go func() {
 			defer fs.editActivity.Done()
@@ -1324,7 +1325,7 @@ func (fs *KBFSOpsStandard) NewNotificationChannel(
 
 // Reset implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) Reset(
-	ctx context.Context, handle *TlfHandle) error {
+	ctx context.Context, handle *tlfhandle.Handle) error {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -1348,7 +1349,7 @@ func (fs *KBFSOpsStandard) Reset(
 	fs.opsLock.Lock()
 	defer fs.opsLock.Unlock()
 	fs.log.CDebugf(ctx, "Reset %s", handle.GetCanonicalPath())
-	fb := FolderBranch{handle.tlfID, MasterBranch}
+	fb := FolderBranch{handle.TlfID(), MasterBranch}
 	ops, ok := fs.ops[fb]
 	if ok {
 		err := ops.Reset(ctx, handle)
@@ -1394,7 +1395,7 @@ func (fs *KBFSOpsStandard) SetSyncConfig(
 }
 
 func (fs *KBFSOpsStandard) changeHandle(ctx context.Context,
-	oldFav favorites.Folder, newHandle *TlfHandle) {
+	oldFav favorites.Folder, newHandle *tlfhandle.Handle) {
 	fs.opsLock.Lock()
 	defer fs.opsLock.Unlock()
 	ops, ok := fs.opsByFav[oldFav]
@@ -1473,9 +1474,9 @@ func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
 	// Construct folderBranchOps instances for each TLF in the inbox
 	// that doesn't have one yet.
 	for _, h := range handles {
-		if h.tlfID != tlf.NullID {
+		if h.TlfID() != tlf.NullID {
 			fs.log.CDebugf(ctx, "Initializing TLF %s (%s) for the edit history",
-				h.GetCanonicalPath(), h.tlfID)
+				h.GetCanonicalPath(), h.TlfID())
 			// Fully initialize the TLF in order to kick off any
 			// necessary prefetches.
 			err := fs.initTLFWithoutIdentifyPopups(ctx, h)
@@ -1546,7 +1547,7 @@ func (kofo *kbfsOpsFavoriteObserver) BatchChanges(
 }
 
 func (kofo *kbfsOpsFavoriteObserver) TlfHandleChange(
-	ctx context.Context, newHandle *TlfHandle) {
+	ctx context.Context, newHandle *tlfhandle.Handle) {
 	kofo.lock.Lock()
 	defer kofo.lock.Unlock()
 	kofo.kbfsOps.changeHandle(ctx, kofo.currFav, newHandle)

--- a/go/kbfs/libkbfs/kbfs_ops_concur_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_concur_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -1523,7 +1524,7 @@ func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 
 	t.Log("Ensure that the block references have been removed rather than just archived")
 	bOps := config.BlockOps()
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "test_user", tlf.Private)
 	require.NoError(t, err)
 	ptrs := make([]BlockPointer, len(pointerMap))

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -296,7 +296,7 @@ func checkBlockCache(
 }
 
 // parseTlfHandleOrBust parses the given TLF name, which must be
-// canonical, into a TLF handle, and failing if there's an error.
+// canonical, into a TLF handle, failing if there's an error.
 func parseTlfHandleOrBust(t logger.TestLogBackend, config Config,
 	name string, ty tlf.Type, id tlf.ID) *tlfhandle.Handle {
 	ctx := context.Background()

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/kbfs/env"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
@@ -25,7 +26,9 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"github.com/pkg/errors"
@@ -101,7 +104,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	// Don't test implicit teams.
 	config.mockKbpki.EXPECT().ResolveImplicitTeam(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		AnyTimes().Return(ImplicitTeamInfo{}, errors.New("No such team"))
+		AnyTimes().Return(idutil.ImplicitTeamInfo{}, errors.New("No such team"))
 
 	// None of these tests depend on time
 	config.mockClock.EXPECT().Now().AnyTimes().Return(time.Now())
@@ -141,7 +144,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	// Ignore favorites
 	err := errors.New("Fake error to prevent trying to read favs from disk")
 	config.mockKbpki.EXPECT().GetCurrentSession(gomock.Any()).Return(
-		SessionInfo{}, err)
+		idutil.SessionInfo{}, err)
 	kbfsops.favs.Initialize(ctx)
 	config.mockKbpki.EXPECT().FavoriteList(gomock.Any()).AnyTimes().
 		Return(keybase1.FavoritesResult{}, nil)
@@ -292,6 +295,20 @@ func checkBlockCache(
 	}
 }
 
+// parseTlfHandleOrBust parses the given TLF name, which must be
+// canonical, into a TLF handle, and failing if there's an error.
+func parseTlfHandleOrBust(t logger.TestLogBackend, config Config,
+	name string, ty tlf.Type, id tlf.ID) *tlfhandle.Handle {
+	ctx := context.Background()
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil, name, ty)
+	if err != nil {
+		t.Fatalf("Couldn't parse %s (type=%s) into a TLF handle: %v",
+			name, ty, err)
+	}
+	return h
+}
+
 func TestKBFSOpsGetFavoritesSuccess(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
@@ -301,7 +318,7 @@ func TestKBFSOpsGetFavoritesSuccess(t *testing.T) {
 		t, config, "alice,bob", tlf.Private, tlf.NullID)
 
 	// dup for testing
-	handles := []*TlfHandle{handle1, handle2, handle2}
+	handles := []*tlfhandle.Handle{handle1, handle2, handle2}
 	for _, h := range handles {
 		config.KeybaseService().FavoriteAdd(
 			context.Background(), h.ToFavorite().ToKBFolder(false))
@@ -349,10 +366,10 @@ func getOps(config Config, id tlf.ID) *folderBranchOps {
 // createNewRMD creates a new RMD for the given name. Returns its ID
 // and handle also.
 func createNewRMD(t *testing.T, config Config, name string, ty tlf.Type) (
-	tlf.ID, *TlfHandle, *RootMetadata) {
+	tlf.ID, *tlfhandle.Handle, *RootMetadata) {
 	id := tlf.FakeID(1, ty)
 	h := parseTlfHandleOrBust(t, config, name, ty, id)
-	h.tlfID = id
+	h.SetTlfID(id)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
 	return id, h, rmd
@@ -837,9 +854,9 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 	id := tlf.FakeID(1, tlf.Private)
 
 	h := parseTlfHandleOrBust(t, config, "bob#alice", tlf.Private, id)
-	h.tlfID = id
+	h.SetTlfID(id)
 	// Hack around access check in ParseTlfHandle.
-	h.resolvedReaders = nil
+	h.ClearResolvedReaders()
 
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
@@ -860,7 +877,8 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, kbfsmd.FakeID(1))
 	ops.headStatus = headTrusted
-	expectedErr := NewReadAccessError(h, "alice", "/keybase/private/bob#alice")
+	expectedErr := tlfhandle.NewReadAccessError(
+		h, "alice", "/keybase/private/bob#alice")
 
 	if _, err := config.KBFSOps().GetDirChildren(ctx, n); err == nil {
 		t.Errorf("Got no expected error on getdir")
@@ -1053,7 +1071,7 @@ func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, dirBlock)
 
-	expectedErr := NoSuchNameError{"c"}
+	expectedErr := idutil.NoSuchNameError{Name: "c"}
 	_, _, err := config.KBFSOps().Lookup(ctx, n, "c")
 	if err == nil {
 		t.Error("No error as expected on Lookup")
@@ -1538,7 +1556,7 @@ func TestRemoveDirFailNoSuchName(t *testing.T) {
 	ops := getOps(config, id)
 	n := nodeFromPath(t, ops, p)
 
-	expectedErr := NoSuchNameError{"nonexistent"}
+	expectedErr := idutil.NoSuchNameError{Name: "nonexistent"}
 	err := config.KBFSOps().RemoveDir(ctx, n, "nonexistent")
 	require.Equal(t, expectedErr, err)
 }
@@ -2707,7 +2725,7 @@ func TestSetExFailNoSuchName(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
-	expectedErr := NoSuchNameError{p.tailName()}
+	expectedErr := idutil.NoSuchNameError{Name: p.tailName()}
 
 	// chmod a+x a
 	if err := config.KBFSOps().SetEx(ctx, n, true); err == nil {
@@ -2771,7 +2789,7 @@ func TestMtimeFailNoSuchName(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
-	expectedErr := NoSuchNameError{p.tailName()}
+	expectedErr := idutil.NoSuchNameError{Name: p.tailName()}
 
 	newMtime := time.Now()
 	if err := config.KBFSOps().SetMtime(ctx, n, &newMtime); err == nil {
@@ -2904,7 +2922,7 @@ func (t *testBGObserver) BatchChanges(ctx context.Context,
 }
 
 func (t *testBGObserver) TlfHandleChange(ctx context.Context,
-	newHandle *TlfHandle) {
+	newHandle *tlfhandle.Handle) {
 	return
 }
 
@@ -3321,11 +3339,11 @@ func TestForceFastForwardOnEmptyTLF(t *testing.T) {
 	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
 
 	// Look up bob's public folder.
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, "bob", tlf.Public)
 	require.NoError(t, err)
 	_, _, err = config.KBFSOps().GetOrCreateRootNode(ctx, h, MasterBranch)
-	if _, ok := err.(WriteAccessError); !ok {
+	if _, ok := err.(tlfhandle.WriteAccessError); !ok {
 		t.Fatalf("Unexpected err reading a public TLF: %+v", err)
 	}
 
@@ -3456,7 +3474,7 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	AddTeamReaderForTestOrBust(t, config3, tid, uid3)
 
 	t.Log("Look up bob's public folder.")
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config1.KBPKI(), config1.MDOps(), nil, string(name),
 		tlf.SingleTeam)
 	require.NoError(t, err)
@@ -3503,7 +3521,7 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, bytes.Equal(data, gotData3))
 	_, _, err = kbfsOps3.CreateFile(ctx, rootNode3, "c", false, NoExcl)
-	require.IsType(t, WriteAccessError{}, errors.Cause(err))
+	require.IsType(t, tlfhandle.WriteAccessError{}, errors.Cause(err))
 
 	// Verify that "a" has the correct writer.
 	ei, err := kbfsOps3.GetNodeMetadata(ctx, nodeA3)
@@ -3606,7 +3624,7 @@ func testKBFSOpsMigrateToImplicitTeam(
 	config2.SetMetadataVersion(initialMDVer)
 
 	t.Log("Create the folder before implicit teams are enabled.")
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config1.KBPKI(), config1.MDOps(), nil, string(name), ty)
 	require.NoError(t, err)
 	require.False(t, h.IsBackedByTeam())
@@ -3638,15 +3656,15 @@ func testKBFSOpsMigrateToImplicitTeam(
 	_ = AddImplicitTeamForTestOrBust(t, config2, name, "", 1, ty)
 	// The service should be adding the team TLF ID to the iteam's
 	// sigchain before they call `StartMigration`.
-	err = config1.KBPKI().CreateTeamTLF(ctx, teamID, h.tlfID)
+	err = config1.KBPKI().CreateTeamTLF(ctx, teamID, h.TlfID())
 	require.NoError(t, err)
-	err = config2.KBPKI().CreateTeamTLF(ctx, teamID, h.tlfID)
+	err = config2.KBPKI().CreateTeamTLF(ctx, teamID, h.TlfID())
 	require.NoError(t, err)
 	config1.SetMetadataVersion(kbfsmd.ImplicitTeamsVer)
 	config2.SetMetadataVersion(kbfsmd.ImplicitTeamsVer)
 
 	t.Log("Starting migration to implicit team")
-	err = kbfsOps1.MigrateToImplicitTeam(ctx, h.tlfID)
+	err = kbfsOps1.MigrateToImplicitTeam(ctx, h.TlfID())
 	require.NoError(t, err)
 	_, _, err = kbfsOps1.CreateDir(ctx, rootNode1, "b")
 	require.NoError(t, err)
@@ -3710,7 +3728,7 @@ func TestKBFSOpsArchiveBranchType(t *testing.T) {
 
 	t.Log("Create a private folder for the master branch.")
 	name := "u1"
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
@@ -3848,7 +3866,7 @@ func TestKBFSOpsReadonlyFSNodes(t *testing.T) {
 	err = d.Close()
 
 	name := "u1"
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
@@ -3914,14 +3932,14 @@ func TestKBFSOpsReset(t *testing.T) {
 
 	t.Log("Create a private folder.")
 	name := "u1"
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, MasterBranch)
 	require.NoError(t, err)
 
-	oldID := h.tlfID
+	oldID := h.TlfID()
 	t.Logf("Make a new revision for TLF ID %s", oldID)
 	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
 	require.NoError(t, err)
@@ -3934,10 +3952,10 @@ func TestKBFSOpsReset(t *testing.T) {
 	md.override = true
 	err = kbfsOps.Reset(ctx, h)
 	require.NoError(t, err)
-	require.NotEqual(t, oldID, h.tlfID)
+	require.NotEqual(t, oldID, h.TlfID())
 	md.override = false
 
-	t.Logf("Make a new revision for new TLF ID %s", h.tlfID)
+	t.Logf("Make a new revision for new TLF ID %s", h.TlfID())
 	rootNode, _, err = kbfsOps.GetOrCreateRootNode(ctx, h, MasterBranch)
 	require.NoError(t, err)
 	children, err := kbfsOps.GetDirChildren(ctx, rootNode)
@@ -3998,7 +4016,7 @@ func TestKBFSOpsUnsyncedMDCommit(t *testing.T) {
 
 	t.Log("Create a private, unsynced TLF and make sure updates are committed")
 	name := "u1"
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
@@ -4114,7 +4132,7 @@ func TestKBFSOpsSyncedMDCommit(t *testing.T) {
 	t.Log("Create a private, synced TLF")
 	config.SetBlockServer(bserverPutToDiskCache{config.BlockServer(), dbc})
 	name := "u1"
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
@@ -4220,7 +4238,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	name := "u1"
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
@@ -4231,7 +4249,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	_ = enableDiskCacheForTest(t, config, tempdir)
 
 	t.Log("Sync should start off as disabled.")
-	syncConfig, err := kbfsOps.GetSyncConfig(ctx, h.tlfID)
+	syncConfig, err := kbfsOps.GetSyncConfig(ctx, h.TlfID())
 	require.NoError(t, err)
 	require.Equal(t, keybase1.FolderSyncMode_DISABLED, syncConfig.Mode)
 
@@ -4245,7 +4263,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	for p := range pathsMap {
 		syncConfig.Paths = append(syncConfig.Paths, p)
 	}
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.Error(t, err)
 
 	t.Log("Initialize the TLF")
@@ -4255,11 +4273,11 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Set a partial sync config")
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.NoError(t, err)
 
 	t.Log("Make sure the lower-level config is encrypted")
-	lowLevelConfig := config.GetTlfSyncState(h.tlfID)
+	lowLevelConfig := config.GetTlfSyncState(h.TlfID())
 	require.Equal(t, keybase1.FolderSyncMode_PARTIAL, lowLevelConfig.Mode)
 	require.NotEqual(t, zeroPtr, lowLevelConfig.Paths.Ptr)
 	var zeroBytes [32]byte
@@ -4268,7 +4286,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 
 	t.Log("Read it back out unencrypted")
 	config.ResetCaches()
-	syncConfig, err = kbfsOps.GetSyncConfig(ctx, h.tlfID)
+	syncConfig, err = kbfsOps.GetSyncConfig(ctx, h.TlfID())
 	require.Equal(t, keybase1.FolderSyncMode_PARTIAL, syncConfig.Mode)
 	require.Len(t, syncConfig.Paths, len(pathsMap))
 	for _, p := range syncConfig.Paths {
@@ -4278,16 +4296,16 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 
 	t.Log("Test some failure scenarios")
 	syncConfig.Paths = []string{"a/b/c", "a/b/c"}
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.Error(t, err)
 	syncConfig.Paths = []string{"/a/b/c", "d/e/f"}
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.Error(t, err)
 	syncConfig.Paths = []string{"a/../a/b/c", "a/b/c"}
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.Error(t, err)
 	syncConfig.Paths = []string{"a/../../a/b/c"}
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.Error(t, err)
 
 	t.Log("Make sure the paths are cleaned and ToSlash'd")
@@ -4296,9 +4314,9 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 		"d/e/f": true,
 	}
 	syncConfig.Paths = []string{"a/../a/b/c", filepath.Join("d", "e", "f")}
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.NoError(t, err)
-	syncConfig, err = kbfsOps.GetSyncConfig(ctx, h.tlfID)
+	syncConfig, err = kbfsOps.GetSyncConfig(ctx, h.TlfID())
 	require.Equal(t, keybase1.FolderSyncMode_PARTIAL, syncConfig.Mode)
 	require.Len(t, syncConfig.Paths, len(pathsMap))
 	for _, p := range syncConfig.Paths {
@@ -4356,7 +4374,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	config.vdebugSetting = "vlog2"
 
 	name := "u1"
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
@@ -4391,7 +4409,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 		Mode:  keybase1.FolderSyncMode_PARTIAL,
 		Paths: []string{"a/b/c"},
 	}
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.NoError(t, err)
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
@@ -4516,7 +4534,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 
 	t.Log("Sync the new path")
 	syncConfig.Paths = append(syncConfig.Paths, "d")
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.NoError(t, err)
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
@@ -4530,7 +4548,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 
 	t.Log("Remove a synced path")
 	syncConfig.Paths = syncConfig.Paths[:len(syncConfig.Paths)-1]
-	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
+	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.NoError(t, err)
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
@@ -4576,7 +4594,7 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	config.vdebugSetting = "vlog2"
 
 	name := "u1"
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(name), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()

--- a/go/kbfs/libkbfs/kbpki_client_test.go
+++ b/go/kbfs/libkbfs/kbpki_client_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
@@ -29,13 +30,13 @@ func (o keybaseServiceSelfOwner) KeybaseService() KeybaseService {
 }
 
 func makeTestKBPKIClient(t *testing.T) (
-	client *KBPKIClient, currentUID keybase1.UID, users []LocalUser,
-	teams []TeamInfo) {
+	client *KBPKIClient, currentUID keybase1.UID, users []idutil.LocalUser,
+	teams []idutil.TeamInfo) {
 	currentUID = keybase1.MakeTestUID(1)
 	names := []kbname.NormalizedUsername{"test_name1", "test_name2"}
-	users = MakeLocalUsers(names)
+	users = idutil.MakeLocalUsers(names)
 	teamNames := []kbname.NormalizedUsername{"test_team1", "test_team2"}
-	teams = MakeLocalTeams(teamNames)
+	teams = idutil.MakeLocalTeams(teamNames)
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, users, teams, codec)
 	return NewKBPKIClient(keybaseServiceSelfOwner{daemon},
@@ -43,18 +44,19 @@ func makeTestKBPKIClient(t *testing.T) (
 }
 
 func makeTestKBPKIClientWithRevokedKey(t *testing.T, revokeTime time.Time) (
-	client *KBPKIClient, currentUID keybase1.UID, users []LocalUser) {
+	client *KBPKIClient, currentUID keybase1.UID, users []idutil.LocalUser) {
 	currentUID = keybase1.MakeTestUID(1)
 	names := []kbname.NormalizedUsername{"test_name1", "test_name2"}
-	users = MakeLocalUsers(names)
+	users = idutil.MakeLocalUsers(names)
 	// Give each user a revoked key
 	for i, user := range users {
 		index := 99
 		keySalt := keySaltForUserDevice(user.Name, index)
-		newVerifyingKey := MakeLocalUserVerifyingKeyOrBust(keySalt)
-		user.RevokedVerifyingKeys = map[kbfscrypto.VerifyingKey]revokedKeyInfo{
-			newVerifyingKey: {Time: keybase1.ToTime(revokeTime)},
-		}
+		newVerifyingKey := idutil.MakeLocalUserVerifyingKeyOrBust(keySalt)
+		user.RevokedVerifyingKeys =
+			map[kbfscrypto.VerifyingKey]idutil.RevokedKeyInfo{
+				newVerifyingKey: {Time: keybase1.ToTime(revokeTime)},
+			}
 		users[i] = user
 	}
 	codec := kbfscodec.NewMsgpack()
@@ -153,16 +155,16 @@ func TestKBPKIClientHasVerifyingKeyStaleCache(t *testing.T) {
 	}()
 
 	u := keybase1.MakeTestUID(1)
-	key1 := MakeLocalUserVerifyingKeyOrBust("u_1")
-	key2 := MakeLocalUserVerifyingKeyOrBust("u_2")
-	info1 := UserInfo{
+	key1 := idutil.MakeLocalUserVerifyingKeyOrBust("u_1")
+	key2 := idutil.MakeLocalUserVerifyingKeyOrBust("u_2")
+	info1 := idutil.UserInfo{
 		VerifyingKeys: []kbfscrypto.VerifyingKey{key1},
 	}
 	config.mockKbs.EXPECT().LoadUserPlusKeys(
 		gomock.Any(), u, gomock.Any(), gomock.Any()).Return(info1, nil)
 
 	config.mockKbs.EXPECT().FlushUserFromLocalCache(gomock.Any(), u)
-	info2 := UserInfo{
+	info2 := idutil.UserInfo{
 		VerifyingKeys: []kbfscrypto.VerifyingKey{key1, key2},
 	}
 	config.mockKbs.EXPECT().LoadUserPlusKeys(

--- a/go/kbfs/libkbfs/kbpki_util_test.go
+++ b/go/kbfs/libkbfs/kbpki_util_test.go
@@ -7,6 +7,8 @@ package libkbfs
 import (
 	"sync"
 
+	"github.com/keybase/client/go/kbfs/idutil"
+	idutiltest "github.com/keybase/client/go/kbfs/idutil/test"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
@@ -14,74 +16,54 @@ import (
 	"golang.org/x/net/context"
 )
 
-// daemonKBPKI is a hacky way to make a KBPKI instance that uses some
-// methods from KeybaseService.
 type daemonKBPKI struct {
 	KBPKI
-	daemon KeybaseService
+	daemon *idutiltest.DaemonKBPKI
 }
 
-func (d *daemonKBPKI) GetCurrentSession(ctx context.Context) (
-	SessionInfo, error) {
-	const sessionID = 0
-	return d.daemon.CurrentSession(ctx, sessionID)
+func (d daemonKBPKI) GetCurrentSession(ctx context.Context) (
+	idutil.SessionInfo, error) {
+	return d.daemon.GetCurrentSession(ctx)
 }
 
-func (d *daemonKBPKI) Resolve(
+func (d daemonKBPKI) Resolve(
 	ctx context.Context, assertion string,
 	offline keybase1.OfflineAvailability) (
 	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return d.daemon.Resolve(ctx, assertion, offline)
 }
 
-func (d *daemonKBPKI) NormalizeSocialAssertion(ctx context.Context, assertion string) (
+func (d daemonKBPKI) NormalizeSocialAssertion(
+	ctx context.Context, assertion string) (
 	keybase1.SocialAssertion, error) {
 	return d.daemon.NormalizeSocialAssertion(ctx, assertion)
 }
 
-func (d *daemonKBPKI) Identify(
+func (d daemonKBPKI) Identify(
 	ctx context.Context, assertion, reason string,
 	offline keybase1.OfflineAvailability) (
 	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return d.daemon.Identify(ctx, assertion, reason, offline)
 }
 
-// ResolveImplicitTeam implements the KBPKI interface for KBPKIClient.
-func (d *daemonKBPKI) ResolveImplicitTeam(
+func (d daemonKBPKI) ResolveImplicitTeam(
 	ctx context.Context, assertions, suffix string, tlfType tlf.Type,
 	offline keybase1.OfflineAvailability) (
-	ImplicitTeamInfo, error) {
-	return d.daemon.ResolveIdentifyImplicitTeam(
-		ctx, assertions, suffix, tlfType, false, "", offline)
+	idutil.ImplicitTeamInfo, error) {
+	return d.daemon.ResolveImplicitTeam(
+		ctx, assertions, suffix, tlfType, offline)
 }
 
-func (d *daemonKBPKI) GetNormalizedUsername(
+func (d daemonKBPKI) GetNormalizedUsername(
 	ctx context.Context, id keybase1.UserOrTeamID,
 	offline keybase1.OfflineAvailability) (kbname.NormalizedUsername, error) {
-	asUser, err := id.AsUser()
-	if err != nil {
-		return kbname.NormalizedUsername(""), err
-	}
-	userInfo, err := d.daemon.LoadUserPlusKeys(
-		ctx, asUser, "", keybase1.OfflineAvailability_NONE)
-	if err != nil {
-		return kbname.NormalizedUsername(""), err
-	}
-	return userInfo.Name, nil
+	return d.daemon.GetNormalizedUsername(ctx, id, offline)
 }
 
-func (d *daemonKBPKI) ResolveTeamTLFID(
+func (d daemonKBPKI) ResolveTeamTLFID(
 	ctx context.Context, teamID keybase1.TeamID,
 	offline keybase1.OfflineAvailability) (tlf.ID, error) {
-	settings, err := d.daemon.GetTeamSettings(ctx, teamID, offline)
-	if err != nil {
-		return tlf.NullID, err
-	}
-	tlfID, err := tlf.ParseID(settings.TlfID.String())
-	if err != nil {
-		return tlf.NullID, err
-	}
-	return tlfID, nil
+	return d.daemon.ResolveTeamTLFID(ctx, teamID, offline)
 }
 
 // interposeDaemonKBPKI replaces the existing (mock) KBPKI with a
@@ -91,18 +73,18 @@ func (d *daemonKBPKI) ResolveTeamTLFID(
 // out what to do with other mocked methods of KBPKI.
 func interposeDaemonKBPKI(
 	config *ConfigMock, users ...kbname.NormalizedUsername) {
-	localUsers := MakeLocalUsers(users)
+	localUsers := idutil.MakeLocalUsers(users)
 	loggedInUser := localUsers[0]
 
-	daemon := NewKeybaseDaemonMemory(loggedInUser.UID, localUsers, nil,
-		kbfscodec.NewMsgpack())
+	daemon := NewKeybaseDaemonMemory(
+		loggedInUser.UID, localUsers, nil, kbfscodec.NewMsgpack())
 	config.SetKeybaseService(daemon)
 
-	daemonKBPKI := &daemonKBPKI{
+	idutilDaemonKBPKI := &idutiltest.DaemonKBPKI{
 		KBPKI:  config.mockKbpki,
-		daemon: daemon,
+		Daemon: daemon.DaemonLocal,
 	}
-	config.SetKBPKI(daemonKBPKI)
+	config.SetKBPKI(daemonKBPKI{config.KBPKI(), idutilDaemonKBPKI})
 }
 
 // identifyCountingKBPKI is a KBPKI instance that counts calls to

--- a/go/kbfs/libkbfs/key_manager.go
+++ b/go/kbfs/libkbfs/key_manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
@@ -444,13 +445,13 @@ func (km *KeyManagerStandard) identifyUIDSets(ctx context.Context,
 
 	// Let the service know that we're doing the identifies because of
 	// a rekey, so they can suppress popups in some cases.
-	ctx, err := MakeExtendedIdentify(
+	ctx, err := tlfhandle.MakeExtendedIdentify(
 		ctx, keybase1.TLFIdentifyBehavior_KBFS_REKEY)
 	if err != nil {
 		return err
 	}
 
-	return identifyUserList(
+	return tlfhandle.IdentifyUserList(
 		ctx, kbpki, kbpki, ids, tlfID.Type(),
 		km.config.OfflineAvailabilityForID(tlfID))
 }
@@ -517,7 +518,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		return false, nil, err
 	}
 
-	idGetter := constIDGetter{md.TlfID()}
+	idGetter := tlfhandle.ConstIDGetter{ID: md.TlfID()}
 	resolvedHandle, err := handle.ResolveAgain(
 		ctx, km.config.KBPKI(), idGetter, km.config)
 	if err != nil {
@@ -586,7 +587,8 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 	if !isWriter && incKeyGen {
 		// Readers cannot create the first key generation
-		return false, nil, NewReadAccessError(resolvedHandle, session.Name, resolvedHandle.GetCanonicalPath())
+		return false, nil, tlfhandle.NewReadAccessError(
+			resolvedHandle, session.Name, resolvedHandle.GetCanonicalPath())
 	}
 
 	offline := km.config.OfflineAvailabilityForID(md.TlfID())

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -12,11 +12,13 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -60,7 +62,7 @@ func keyManagerInit(t *testing.T, ver kbfsmd.MetadataVer) (mockCtrl *gomock.Cont
 	// Don't test implicit teams.
 	config.mockKbpki.EXPECT().ResolveImplicitTeam(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		AnyTimes().Return(ImplicitTeamInfo{}, errors.New("No such team"))
+		AnyTimes().Return(idutil.ImplicitTeamInfo{}, errors.New("No such team"))
 
 	mockNormalizeSocialAssertion(config)
 	return mockCtrl, config, ctx
@@ -165,12 +167,12 @@ func (kmd emptyKeyMetadata) TypeForKeying() tlf.KeyingType {
 // GetTlfHandle just returns nil. This contradicts the requirements
 // for KeyMetadata, but emptyKeyMetadata shouldn't be used in contexts
 // that actually use GetTlfHandle().
-func (kmd emptyKeyMetadata) GetTlfHandle() *TlfHandle {
+func (kmd emptyKeyMetadata) GetTlfHandle() *tlfhandle.Handle {
 	return nil
 }
 
 func (kmd emptyKeyMetadata) IsWriter(
-	_ context.Context, _ kbfsmd.TeamMembershipChecker, _ OfflineStatusGetter,
+	_ context.Context, _ kbfsmd.TeamMembershipChecker, _ idutil.OfflineStatusGetter,
 	_ keybase1.UID, _ kbfscrypto.VerifyingKey) (bool, error) {
 	return false, nil
 }
@@ -440,15 +442,15 @@ func testKeyManagerRekeyResolveAgainSuccessPublic(t *testing.T, ver kbfsmd.Metad
 	defer keyManagerShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, tlf.Public)
-	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id}, nil, "alice,bob@twitter",
-		tlf.Public)
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil,
+		"alice,bob@twitter", tlf.Public)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
 
 	daemon := config.KeybaseService().(*KeybaseDaemonLocal)
-	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
+	daemon.AddNewAssertionForTestOrBust("bob", "bob@twitter")
 
 	config.mockMdops.EXPECT().GetLatestHandleForTLF(gomock.Any(), gomock.Any()).
 		Return(rmd.tlfHandle.ToBareHandleOrBust(), nil)
@@ -481,16 +483,16 @@ func testKeyManagerRekeyResolveAgainSuccessPublicSelf(t *testing.T, ver kbfsmd.M
 	defer keyManagerShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, tlf.Public)
-	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id}, nil,
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil,
 		"alice@twitter,bob,charlie@twitter", tlf.Public)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
 
 	daemon := config.KeybaseService().(*KeybaseDaemonLocal)
-	daemon.addNewAssertionForTestOrBust("alice", "alice@twitter")
-	daemon.addNewAssertionForTestOrBust("charlie", "charlie@twitter")
+	daemon.AddNewAssertionForTestOrBust("alice", "alice@twitter")
+	daemon.AddNewAssertionForTestOrBust("charlie", "charlie@twitter")
 
 	config.mockMdops.EXPECT().GetLatestHandleForTLF(gomock.Any(), gomock.Any()).
 		Return(rmd.tlfHandle.ToBareHandleOrBust(), nil)
@@ -517,8 +519,8 @@ func testKeyManagerRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsmd.Meta
 	defer keyManagerShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id}, nil,
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil,
 		"alice,bob@twitter,dave@twitter#charlie@twitter", tlf.Private)
 	if err != nil {
 		t.Fatal(err)
@@ -533,8 +535,8 @@ func testKeyManagerRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsmd.Meta
 
 	// Pretend that {bob,charlie}@twitter now resolve to {bob,charlie}.
 	daemon := config.KeybaseService().(*KeybaseDaemonLocal)
-	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
-	daemon.addNewAssertionForTestOrBust("charlie", "charlie@twitter")
+	daemon.AddNewAssertionForTestOrBust("bob", "bob@twitter")
+	daemon.AddNewAssertionForTestOrBust("charlie", "charlie@twitter")
 
 	if done, _, err := config.KeyManager().Rekey(ctx, rmd, false); !done || err != nil {
 		t.Fatalf("Got error on rekey: %t, %+v", done, err)
@@ -558,7 +560,7 @@ func testKeyManagerRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsmd.Meta
 
 	// Now resolve using only a device addition, which won't bump the
 	// generation number.
-	daemon.addNewAssertionForTestOrBust("dave", "dave@twitter")
+	daemon.AddNewAssertionForTestOrBust("dave", "dave@twitter")
 	oldKeyGen = rmd.LatestKeyGeneration()
 
 	tlfCryptKey2 := kbfscrypto.MakeTLFCryptKey([32]byte{0x2})
@@ -609,7 +611,8 @@ func testKeyManagerPromoteReaderSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, nil,
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil,
 		"alice,bob@twitter#bob", tlf.Private)
 	require.NoError(t, err)
 
@@ -631,7 +634,7 @@ func testKeyManagerPromoteReaderSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	// Pretend that bob@twitter now resolves to bob.
 	daemon := config.KeybaseService().(*KeybaseDaemonLocal)
-	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
+	daemon.AddNewAssertionForTestOrBust("bob", "bob@twitter")
 
 	// Rekey as alice.
 	done, _, err = config.KeyManager().Rekey(ctx, rmd, false)
@@ -657,7 +660,8 @@ func testKeyManagerPromoteReaderSelf(t *testing.T, ver kbfsmd.MetadataVer) {
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, nil,
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil,
 		"alice,bob@twitter#bob", tlf.Private)
 	require.NoError(t, err)
 
@@ -681,7 +685,7 @@ func testKeyManagerPromoteReaderSelf(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	// Pretend that bob@twitter now resolves to bob.
 	daemon := config2.KeybaseService().(*KeybaseDaemonLocal)
-	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
+	daemon.AddNewAssertionForTestOrBust("bob", "bob@twitter")
 
 	// Rekey as bob, which should still succeed.
 	done, _, err = config2.KeyManager().Rekey(ctx, rmd, false)
@@ -707,7 +711,8 @@ func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver kbfsmd.Metadata
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, nil,
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil,
 		"alice,charlie@twitter#bob,charlie", tlf.Private)
 	require.NoError(t, err)
 
@@ -731,7 +736,7 @@ func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver kbfsmd.Metadata
 
 	// Pretend that charlie@twitter now resolves to charlie.
 	daemon := config2.KeybaseService().(*KeybaseDaemonLocal)
-	daemon.addNewAssertionForTestOrBust("charlie", "charlie@twitter")
+	daemon.AddNewAssertionForTestOrBust("charlie", "charlie@twitter")
 
 	AddDeviceForLocalUserOrBust(t, config2, bobUID)
 
@@ -750,7 +755,8 @@ func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsm
 	defer keyManagerShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id}, nil,
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil,
 		"alice,dave@twitter#bob@twitter,charlie@twitter", tlf.Private)
 	if err != nil {
 		t.Fatal(err)
@@ -779,16 +785,16 @@ func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsm
 
 	// Now resolve everyone, but have reader bob to do the rekey
 	daemon := config.KeybaseService().(*KeybaseDaemonLocal)
-	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
-	daemon.addNewAssertionForTestOrBust("charlie", "charlie@twitter")
-	daemon.addNewAssertionForTestOrBust("dave", "dave@twitter")
+	daemon.AddNewAssertionForTestOrBust("bob", "bob@twitter")
+	daemon.AddNewAssertionForTestOrBust("charlie", "charlie@twitter")
+	daemon.AddNewAssertionForTestOrBust("dave", "dave@twitter")
 
 	_, bobID, err := daemon.Resolve(
 		ctx, "bob", keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	bobUID, err := bobID.AsUser()
 	require.NoError(t, err)
-	daemon.setCurrentUID(bobUID)
+	daemon.SetCurrentUID(bobUID)
 
 	// Now resolve using only a device addition, which won't bump the
 	// generation number.
@@ -832,9 +838,9 @@ func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver kbf
 	defer keyManagerShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), constIDGetter{id}, nil, "alice,bob,bob@twitter",
-		tlf.Private)
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), tlfhandle.ConstIDGetter{ID: id}, nil,
+		"alice,bob,bob@twitter", tlf.Private)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -862,7 +868,7 @@ func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver kbf
 
 	// Now resolve everyone, but have reader bob to do the rekey
 	daemon := config.KeybaseService().(*KeybaseDaemonLocal)
-	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
+	daemon.AddNewAssertionForTestOrBust("bob", "bob@twitter")
 
 	// Now resolve which gets rid of the unresolved writers, but
 	// doesn't otherwise change the handle since bob is already in it.
@@ -2397,13 +2403,11 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 	AddTeamWriterForTestOrBust(t, config2, tid, uid2)
 
 	tlfID := tlf.FakeID(1, tlf.SingleTeam)
-	h := &TlfHandle{
-		tlfType: tlf.SingleTeam,
-		resolvedWriters: map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
+	h := tlfhandle.NewHandle(
+		tlf.SingleTeam,
+		map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			tid.AsUserOrTeam(): name,
-		},
-		name: tlf.CanonicalName(name),
-	}
+		}, nil, nil, tlf.CanonicalName(name), tlf.NullID)
 
 	rmd, err := makeInitialRootMetadata(kbfsmd.SegregatedKeyBundlesVer, tlfID, h)
 	require.NoError(t, err)
@@ -2454,14 +2458,10 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	tlfID := tlf.FakeID(1, ty)
 
 	asUserName := kbname.NormalizedUsername(iname)
-	h := &TlfHandle{
-		tlfType: ty,
-		resolvedWriters: map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
+	h := tlfhandle.NewHandle(
+		ty, map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			teamID.AsUserOrTeam(): asUserName,
-		},
-		name:  tlf.CanonicalName(asUserName),
-		tlfID: tlfID,
-	}
+		}, nil, nil, tlf.CanonicalName(asUserName), tlfID)
 
 	_, latestKeyGen, err := config1.KBPKI().GetTeamTLFCryptKeys(
 		ctx, teamID, kbfsmd.UnspecifiedKeyGen,

--- a/go/kbfs/libkbfs/keybase_daemon.go
+++ b/go/kbfs/libkbfs/keybase_daemon.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -55,7 +56,7 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 		return nil, fmt.Errorf("user %s not in list %v", localUser, users)
 	}
 
-	localUsers := MakeLocalUsers(users)
+	localUsers := idutil.MakeLocalUsers(users)
 
 	// TODO: Auto-generate these, too?
 	localUsers[0].Asserts = []string{"github:strib"}
@@ -72,7 +73,8 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 	localUID := localUsers[userIndex].UID
 	codec := config.Codec()
 
-	teams := MakeLocalTeams([]kbname.NormalizedUsername{"kbfs", "core", "dokan"})
+	teams := idutil.MakeLocalTeams(
+		[]kbname.NormalizedUsername{"kbfs", "core", "dokan"})
 	for i := range teams {
 		teams[i].Writers = make(map[keybase1.UID]bool)
 		teams[i].Readers = make(map[keybase1.UID]bool)
@@ -121,8 +123,8 @@ func (k keybaseDaemon) NewCrypto(config Config, params InitParams, ctx Context, 
 	if localUser == "" {
 		crypto = NewCryptoClientRPC(config, ctx)
 	} else {
-		signingKey := MakeLocalUserSigningKeyOrBust(localUser)
-		cryptPrivateKey := MakeLocalUserCryptPrivateKeyOrBust(localUser)
+		signingKey := idutil.MakeLocalUserSigningKeyOrBust(localUser)
+		cryptPrivateKey := idutil.MakeLocalUserCryptPrivateKeyOrBust(localUser)
 		crypto = NewCryptoLocal(
 			config.Codec(), signingKey, cryptPrivateKey, config)
 	}

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -5,56 +5,19 @@
 package libkbfs
 
 import (
-	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"golang.org/x/net/context"
 
-	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
-	"github.com/keybase/client/go/kbfs/kbfsmd"
-	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
-
-type localUserMap map[keybase1.UID]LocalUser
-
-func (m localUserMap) getLocalUser(uid keybase1.UID) (LocalUser, error) {
-	user, ok := m[uid]
-	if !ok {
-		return LocalUser{}, NoSuchUserError{uid.String()}
-	}
-	return user, nil
-}
-
-type localTeamMap map[keybase1.TeamID]TeamInfo
-
-func (m localTeamMap) getLocalTeam(tid keybase1.TeamID) (TeamInfo, error) {
-	team, ok := m[tid]
-	if !ok {
-		return TeamInfo{}, NoSuchTeamError{tid.String()}
-	}
-	return team, nil
-}
-
-type localTeamSettingsMap map[keybase1.TeamID]keybase1.KBFSTeamSettings
-
-type localImplicitTeamMap map[keybase1.TeamID]ImplicitTeamInfo
-
-func (m localImplicitTeamMap) getLocalImplicitTeam(
-	tid keybase1.TeamID) (ImplicitTeamInfo, error) {
-	team, ok := m[tid]
-	if !ok {
-		return ImplicitTeamInfo{}, NoSuchTeamError{tid.String()}
-	}
-	return team, nil
-}
 
 type favoriteStore interface {
 	FavoriteAdd(uid keybase1.UID, folder keybase1.Folder) error
@@ -153,495 +116,15 @@ func (c memoryFavoriteClient) Shutdown() {}
 // KeybaseDaemonLocal implements KeybaseDaemon using an in-memory user
 // and session store, and a given favorite store.
 type KeybaseDaemonLocal struct {
+	*idutil.DaemonLocal
 	codec kbfscodec.Codec
 
 	// lock protects everything below.
-	lock               sync.Mutex
-	localUsers         localUserMap
-	localTeams         localTeamMap
-	localTeamSettings  localTeamSettingsMap
-	localImplicitTeams localImplicitTeamMap
-	currentUID         keybase1.UID
-	asserts            map[string]keybase1.UserOrTeamID
-	implicitAsserts    map[string]keybase1.TeamID
-	favoriteStore      favoriteStore
-	merkleRoot         keybase1.MerkleRootV2
-	merkleTime         time.Time
+	lock          sync.Mutex
+	favoriteStore favoriteStore
 }
 
 var _ KeybaseService = &KeybaseDaemonLocal{}
-
-func (k *KeybaseDaemonLocal) setCurrentUID(uid keybase1.UID) {
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	// TODO: Send out notifications.
-	k.currentUID = uid
-}
-
-func (k *KeybaseDaemonLocal) assertionToIDLocked(ctx context.Context,
-	assertion string) (id keybase1.UserOrTeamID, err error) {
-	expr, err := externals.AssertionParseAndOnlyStatic(assertion)
-	if err != nil {
-		return keybase1.UserOrTeamID(""), err
-	}
-	urls := expr.CollectUrls(nil)
-	if len(urls) == 0 {
-		return keybase1.UserOrTeamID(""), errors.New("No assertion URLs")
-	}
-
-	for _, url := range urls {
-		var currID keybase1.UserOrTeamID
-		if url.IsUID() {
-			currID = url.ToUID().AsUserOrTeam()
-		} else if url.IsTeamID() {
-			currID = url.ToTeamID().AsUserOrTeam()
-		} else {
-			key, val := url.ToKeyValuePair()
-			a := fmt.Sprintf("%s@%s", val, key)
-			if url.IsKeybase() && key != "team" {
-				a = val
-			}
-			var ok bool
-			currID, ok = k.asserts[a]
-			if !ok {
-				return keybase1.UserOrTeamID(""), NoSuchUserError{a}
-			}
-		}
-		if id != keybase1.UserOrTeamID("") && currID != id {
-			return keybase1.UserOrTeamID(""),
-				errors.New("AND assertions resolve to different UIDs")
-		}
-		id = currID
-	}
-	return id, nil
-}
-
-// Resolve implements KeybaseDaemon for KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) Resolve(
-	ctx context.Context, assertion string, _ keybase1.OfflineAvailability) (
-	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
-	if err := checkContext(ctx); err != nil {
-		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
-	}
-
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	id, err := k.assertionToIDLocked(ctx, assertion)
-	if err != nil {
-		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
-	}
-
-	if id.IsUser() {
-		u, err := k.localUsers.getLocalUser(id.AsUserOrBust())
-		if err != nil {
-			return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
-		}
-		return u.Name, id, nil
-	}
-
-	// Otherwise it's a team
-	ti, err := k.localTeams.getLocalTeam(id.AsTeamOrBust())
-	if err != nil {
-		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
-	}
-
-	_, ok := k.localImplicitTeams[id.AsTeamOrBust()]
-	if ok {
-		// An implicit team exists, so Resolve shouldn't work.  The
-		// caller should use `ResolveImplicitTeamByID` instead.
-		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
-			fmt.Errorf("Team ID %s is an implicit team", id)
-	}
-
-	return ti.Name, id, nil
-}
-
-// Identify implements KeybaseDaemon for KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) Identify(
-	ctx context.Context, assertion, _ string,
-	offline keybase1.OfflineAvailability) (
-	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
-	// The local daemon doesn't need to distinguish resolves from
-	// identifies.
-	return k.Resolve(ctx, assertion, offline)
-}
-
-// NormalizeSocialAssertion implements the KeybaseService interface for
-// KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) NormalizeSocialAssertion(
-	ctx context.Context, assertion string) (keybase1.SocialAssertion, error) {
-	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(assertion)
-	if !isSocialAssertion {
-		return keybase1.SocialAssertion{}, fmt.Errorf("Invalid social assertion")
-	}
-	return socialAssertion, nil
-}
-
-func (k *KeybaseDaemonLocal) resolveForImplicitTeam(
-	ctx context.Context, name string, r []kbname.NormalizedUsername,
-	ur []keybase1.SocialAssertion,
-	resolvedIDs map[kbname.NormalizedUsername]keybase1.UserOrTeamID) (
-	[]kbname.NormalizedUsername, []keybase1.SocialAssertion, error) {
-	id, err := k.assertionToIDLocked(ctx, name)
-	if err == nil {
-		u, err := k.localUsers.getLocalUser(id.AsUserOrBust())
-		if err != nil {
-			return nil, nil, err
-		}
-		r = append(r, u.Name)
-		resolvedIDs[u.Name] = id
-	} else {
-		a, ok := externals.NormalizeSocialAssertionStatic(name)
-		if !ok {
-			return nil, nil, fmt.Errorf("Bad assertion: %s", name)
-		}
-		ur = append(ur, a)
-	}
-	return r, ur, nil
-}
-
-// ResolveIdentifyImplicitTeam implements the KeybaseService interface
-// for KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
-	ctx context.Context, assertions, suffix string, tlfType tlf.Type,
-	doIdentifies bool, reason string, _ keybase1.OfflineAvailability) (
-	ImplicitTeamInfo, error) {
-	if err := checkContext(ctx); err != nil {
-		return ImplicitTeamInfo{}, err
-	}
-
-	if tlfType != tlf.Private && tlfType != tlf.Public {
-		return ImplicitTeamInfo{}, fmt.Errorf(
-			"Invalid implicit team TLF type: %s", tlfType)
-	}
-
-	k.lock.Lock()
-	defer k.lock.Unlock()
-
-	// Canonicalize the name.
-	writerNames, readerNames, _, err :=
-		splitAndNormalizeTLFName(assertions, tlfType)
-	if err != nil {
-		return ImplicitTeamInfo{}, err
-	}
-	var writers, readers []kbname.NormalizedUsername
-	var unresolvedWriters, unresolvedReaders []keybase1.SocialAssertion
-	resolvedIDs := make(map[kbname.NormalizedUsername]keybase1.UserOrTeamID)
-	for _, w := range writerNames {
-		writers, unresolvedWriters, err = k.resolveForImplicitTeam(
-			ctx, w, writers, unresolvedWriters, resolvedIDs)
-		if err != nil {
-			return ImplicitTeamInfo{}, err
-		}
-	}
-	for _, r := range readerNames {
-		readers, unresolvedReaders, err = k.resolveForImplicitTeam(
-			ctx, r, readers, unresolvedReaders, resolvedIDs)
-		if err != nil {
-			return ImplicitTeamInfo{}, err
-		}
-	}
-
-	var extensions []tlf.HandleExtension
-	if len(suffix) != 0 {
-		extensions, err = tlf.ParseHandleExtensionSuffix(suffix)
-		if err != nil {
-			return ImplicitTeamInfo{}, err
-		}
-	}
-	name := tlf.MakeCanonicalName(
-		writers, unresolvedWriters, readers, unresolvedReaders, extensions)
-
-	key := fmt.Sprintf("%s:%s", tlfType.String(), name)
-	tid, ok := k.implicitAsserts[key]
-	if ok {
-		return k.localImplicitTeams[tid], nil
-	}
-
-	// If the implicit team doesn't exist, always create it.
-
-	// Need to make the team info as well, so get the list of user
-	// names and resolve them.  Auto-generate an implicit team name.
-	implicitName := kbname.NormalizedUsername(
-		fmt.Sprintf("_implicit_%d", len(k.localTeams)))
-	teams := makeLocalTeams(
-		[]kbname.NormalizedUsername{implicitName}, len(k.localTeams), tlfType)
-	info := teams[0]
-	info.Writers = make(map[keybase1.UID]bool, len(writerNames))
-	for _, w := range writers {
-		id, ok := resolvedIDs[w]
-		if !ok {
-			return ImplicitTeamInfo{}, fmt.Errorf("No resolved writer %s", w)
-		}
-		info.Writers[id.AsUserOrBust()] = true
-	}
-	if len(readerNames) > 0 {
-		info.Readers = make(map[keybase1.UID]bool, len(readerNames))
-		for _, r := range readers {
-			id, ok := resolvedIDs[r]
-			if !ok {
-				return ImplicitTeamInfo{}, fmt.Errorf(
-					"No resolved reader %s", r)
-
-			}
-			info.Readers[id.AsUserOrBust()] = true
-		}
-	}
-	// Unresolved users don't need to go in the team info, they're
-	// irrelvant until they're resolved.  TODO: add resolved users
-	// into existing teams they should be on.
-
-	tid = teams[0].TID
-	k.implicitAsserts[key] = tid
-	k.localTeams[tid] = info
-
-	asUserName := kbname.NormalizedUsername(name)
-	iteamInfo := ImplicitTeamInfo{
-		// TODO: use the "preferred" canonical format here by listing
-		// the logged-in user first?
-		Name: asUserName,
-		TID:  tid,
-	}
-	k.localImplicitTeams[tid] = iteamInfo
-	return iteamInfo, nil
-}
-
-// ResolveImplicitTeamByID implements the KeybaseService interface for
-// KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) ResolveImplicitTeamByID(
-	ctx context.Context, teamID keybase1.TeamID) (name string, err error) {
-	if err := checkContext(ctx); err != nil {
-		return "", err
-	}
-
-	k.lock.Lock()
-	defer k.lock.Unlock()
-
-	info, ok := k.localImplicitTeams[teamID]
-	if !ok {
-		return "", NoSuchTeamError{teamID.String()}
-	}
-	return info.Name.String(), nil
-}
-
-// LoadUserPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) LoadUserPlusKeys(
-	ctx context.Context, uid keybase1.UID, _ keybase1.KID,
-	_ keybase1.OfflineAvailability) (UserInfo, error) {
-	if err := checkContext(ctx); err != nil {
-		return UserInfo{}, err
-	}
-
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	u, err := k.localUsers.getLocalUser(uid)
-	if err != nil {
-		return UserInfo{}, err
-	}
-
-	var infoCopy UserInfo
-	if err := kbfscodec.Update(k.codec, &infoCopy, u.UserInfo); err != nil {
-		return UserInfo{}, err
-	}
-	return infoCopy, nil
-}
-
-// LoadTeamPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID, _ tlf.Type, _ kbfsmd.KeyGen,
-	_ keybase1.UserVersion, _ kbfscrypto.VerifyingKey,
-	_ keybase1.TeamRole, _ keybase1.OfflineAvailability) (TeamInfo, error) {
-	if err := checkContext(ctx); err != nil {
-		return TeamInfo{}, err
-	}
-
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	t, err := k.localTeams.getLocalTeam(tid)
-	if err != nil {
-		return TeamInfo{}, err
-	}
-
-	// Copy the info since it contains a map that might be mutated.
-	var infoCopy TeamInfo
-	if err := kbfscodec.Update(k.codec, &infoCopy, t); err != nil {
-		return TeamInfo{}, err
-	}
-	return infoCopy, nil
-}
-
-// CreateTeamTLF implements the KBPKI interface for
-// KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) CreateTeamTLF(
-	ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) (err error) {
-	if err := checkContext(ctx); err != nil {
-		return err
-	}
-
-	// TODO: add check to make sure the private/public suffix of the
-	// team ID matches that of the tlf ID.
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	iteamInfo, isImplicit := k.localImplicitTeams[teamID]
-	if isImplicit {
-		iteamInfo.TlfID = tlfID
-		k.localImplicitTeams[teamID] = iteamInfo
-	}
-	_, isRegularTeam := k.localTeams[teamID]
-	if !isImplicit && !isRegularTeam {
-		return NoSuchTeamError{teamID.String()}
-	}
-	k.localTeamSettings[teamID] = keybase1.KBFSTeamSettings{
-		TlfID: keybase1.TLFID(tlfID.String())}
-	return nil
-}
-
-// GetTeamSettings implements the KeybaseService interface for
-// KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) GetTeamSettings(
-	ctx context.Context, teamID keybase1.TeamID,
-	_ keybase1.OfflineAvailability) (
-	settings keybase1.KBFSTeamSettings, err error) {
-	if err := checkContext(ctx); err != nil {
-		return keybase1.KBFSTeamSettings{}, err
-	}
-
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	return k.localTeamSettings[teamID], nil
-}
-
-// GetCurrentMerkleRoot implements the KeybaseService interface for
-// KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) GetCurrentMerkleRoot(ctx context.Context) (
-	keybase1.MerkleRootV2, time.Time, error) {
-	if err := checkContext(ctx); err != nil {
-		return keybase1.MerkleRootV2{}, time.Time{}, err
-	}
-
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	return k.merkleRoot, k.merkleTime, nil
-}
-
-// VerifyMerkleRoot implements the KBPKI interface for KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) VerifyMerkleRoot(
-	_ context.Context, _ keybase1.MerkleRootV2, _ keybase1.KBFSRoot) error {
-	return nil
-}
-
-func (k *KeybaseDaemonLocal) setCurrentMerkleRoot(
-	root keybase1.MerkleRootV2, rootTime time.Time) {
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	k.merkleRoot = root
-	k.merkleTime = rootTime
-}
-
-// CurrentSession implements KeybaseDaemon for KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) CurrentSession(ctx context.Context, sessionID int) (
-	SessionInfo, error) {
-	if err := checkContext(ctx); err != nil {
-		return SessionInfo{}, err
-	}
-
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	u, err := k.localUsers.getLocalUser(k.currentUID)
-	if err != nil {
-		return SessionInfo{}, err
-	}
-	return SessionInfo{
-		Name:           u.Name,
-		UID:            u.UID,
-		CryptPublicKey: u.GetCurrentCryptPublicKey(),
-		VerifyingKey:   u.GetCurrentVerifyingKey(),
-	}, nil
-}
-
-// addNewAssertionForTest makes newAssertion, which should be a single
-// assertion that doesn't already resolve to anything, resolve to the
-// same UID as oldAssertion, which should be an arbitrary assertion
-// that does already resolve to something.  It returns the UID of the
-// user associated with the given assertions.
-func (k *KeybaseDaemonLocal) addNewAssertionForTest(
-	oldAssertion, newAssertion string) (keybase1.UID, error) {
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	id, err := k.assertionToIDLocked(context.Background(), oldAssertion)
-	if err != nil {
-		return keybase1.UID(""), err
-	}
-	uid := id.AsUserOrBust()
-
-	lu, err := k.localUsers.getLocalUser(uid)
-	if err != nil {
-		return keybase1.UID(""), err
-	}
-	lu.Asserts = append(lu.Asserts, newAssertion)
-	k.asserts[newAssertion] = id
-	k.localUsers[uid] = lu
-	return uid, nil
-}
-
-// addNewAssertionForTestOrBust is like addNewAssertionForTest, but
-// panics if there's an error.
-func (k *KeybaseDaemonLocal) addNewAssertionForTestOrBust(
-	oldAssertion, newAssertion string) keybase1.UID {
-	uid, err := k.addNewAssertionForTest(oldAssertion, newAssertion)
-	if err != nil {
-		panic(err)
-	}
-	return uid
-}
-
-// changeTeamNameForTest updates the name of an existing team.
-func (k *KeybaseDaemonLocal) changeTeamNameForTest(
-	oldName, newName string) (keybase1.TeamID, error) {
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	oldAssert := oldName + "@team"
-	newAssert := newName + "@team"
-
-	id, ok := k.asserts[oldAssert]
-	if !ok {
-		return keybase1.TeamID(""),
-			fmt.Errorf("No such old team name: %s", oldName)
-	}
-	tid, err := id.AsTeam()
-	if err != nil {
-		return keybase1.TeamID(""), err
-	}
-
-	team, ok := k.localTeams[tid]
-	if !ok {
-		return keybase1.TeamID(""),
-			fmt.Errorf("No such old team name: %s/%s", oldName, tid)
-	}
-	team.Name = kbname.NormalizedUsername(newName)
-	k.localTeams[tid] = team
-
-	k.asserts[newAssert] = id
-	delete(k.asserts, oldAssert)
-	return tid, nil
-}
-
-// changeTeamNameForTestOrBust is like changeTeamNameForTest, but
-// panics if there's an error.
-func (k *KeybaseDaemonLocal) changeTeamNameForTestOrBust(
-	oldName, newName string) keybase1.TeamID {
-	tid, err := k.changeTeamNameForTest(oldName, newName)
-	if err != nil {
-		panic(err)
-	}
-	return tid
-}
-
-func (k *KeybaseDaemonLocal) removeAssertionForTest(assertion string) {
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	delete(k.asserts, assertion)
-}
 
 type makeKeysFunc func(kbname.NormalizedUsername, int) (
 	kbfscrypto.CryptPublicKey, kbfscrypto.VerifyingKey)
@@ -651,18 +134,18 @@ func (k *KeybaseDaemonLocal) addDeviceForTesting(uid keybase1.UID,
 	k.lock.Lock()
 	defer k.lock.Unlock()
 
-	user, err := k.localUsers.getLocalUser(uid)
+	user, err := k.GetLocalUser(uid)
 	if err != nil {
 		return 0, fmt.Errorf("No such user %s: %v", uid, err)
 	}
-	user = user.deepCopy()
+	user = user.DeepCopy()
 
 	index := len(user.VerifyingKeys)
 	newCryptPublicKey, newVerifyingKey := makeKeys(user.Name, index)
 	user.VerifyingKeys = append(user.VerifyingKeys, newVerifyingKey)
 	user.CryptPublicKeys = append(user.CryptPublicKeys, newCryptPublicKey)
 
-	k.localUsers[uid] = user
+	k.SetLocalUser(uid, user)
 	return index, nil
 }
 
@@ -671,28 +154,33 @@ func (k *KeybaseDaemonLocal) revokeDeviceForTesting(clock Clock,
 	k.lock.Lock()
 	defer k.lock.Unlock()
 
-	user, err := k.localUsers.getLocalUser(uid)
+	user, err := k.GetLocalUser(uid)
 	if err != nil {
 		return fmt.Errorf("No such user %s: %v", uid, err)
 	}
-	user = user.deepCopy()
+	user = user.DeepCopy()
+
+	session, err := k.CurrentSession(context.TODO(), 0)
+	if err != nil {
+		return err
+	}
 
 	if index >= len(user.VerifyingKeys) ||
-		(k.currentUID == uid && index == user.CurrentCryptPublicKeyIndex) {
+		(session.UID == uid && index == user.CurrentCryptPublicKeyIndex) {
 		return fmt.Errorf("Can't revoke index %d", index)
 	}
 
 	if user.RevokedVerifyingKeys == nil {
 		user.RevokedVerifyingKeys =
-			make(map[kbfscrypto.VerifyingKey]revokedKeyInfo)
+			make(map[kbfscrypto.VerifyingKey]idutil.RevokedKeyInfo)
 	}
 	if user.RevokedCryptPublicKeys == nil {
 		user.RevokedCryptPublicKeys =
-			make(map[kbfscrypto.CryptPublicKey]revokedKeyInfo)
+			make(map[kbfscrypto.CryptPublicKey]idutil.RevokedKeyInfo)
 	}
 
 	kbtime := keybase1.ToTime(clock.Now())
-	info := revokedKeyInfo{
+	info := idutil.RevokedKeyInfo{
 		Time: kbtime,
 		MerkleRoot: keybase1.MerkleRootV2{
 			Seqno: 1,
@@ -706,14 +194,14 @@ func (k *KeybaseDaemonLocal) revokeDeviceForTesting(clock Clock,
 	user.CryptPublicKeys = append(user.CryptPublicKeys[:index],
 		user.CryptPublicKeys[index+1:]...)
 
-	if k.currentUID == uid && index < user.CurrentCryptPublicKeyIndex {
+	if session.UID == uid && index < user.CurrentCryptPublicKeyIndex {
 		user.CurrentCryptPublicKeyIndex--
 	}
-	if k.currentUID == uid && index < user.CurrentVerifyingKeyIndex {
+	if session.UID == uid && index < user.CurrentVerifyingKeyIndex {
 		user.CurrentVerifyingKeyIndex--
 	}
 
-	k.localUsers[uid] = user
+	k.SetLocalUser(uid, user)
 	return nil
 }
 
@@ -722,7 +210,7 @@ func (k *KeybaseDaemonLocal) switchDeviceForTesting(uid keybase1.UID,
 	k.lock.Lock()
 	defer k.lock.Unlock()
 
-	user, err := k.localUsers.getLocalUser(uid)
+	user, err := k.GetLocalUser(uid)
 	if err != nil {
 		return fmt.Errorf("No such user %s: %v", uid, err)
 	}
@@ -736,7 +224,8 @@ func (k *KeybaseDaemonLocal) switchDeviceForTesting(uid keybase1.UID,
 		return fmt.Errorf("Wrong verifying key index: %d", index)
 	}
 	user.CurrentVerifyingKeyIndex = index
-	k.localUsers[uid] = user
+
+	k.SetLocalUser(uid, user)
 	return nil
 }
 
@@ -744,19 +233,12 @@ func (k *KeybaseDaemonLocal) addTeamWriterForTest(
 	tid keybase1.TeamID, uid keybase1.UID) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	t, err := k.localTeams.getLocalTeam(tid)
+	teamName, err := k.DaemonLocal.AddTeamWriterForTest(tid, uid)
 	if err != nil {
 		return err
 	}
-
-	if t.Writers == nil {
-		t.Writers = make(map[keybase1.UID]bool)
-	}
-	t.Writers[uid] = true
-	delete(t.Readers, uid)
-	k.localTeams[tid] = t
 	f := keybase1.Folder{
-		Name:       string(t.Name),
+		Name:       string(teamName),
 		FolderType: keybase1.FolderType_TEAM,
 	}
 	k.favoriteStore.FavoriteAdd(uid, f)
@@ -767,35 +249,15 @@ func (k *KeybaseDaemonLocal) removeTeamWriterForTest(
 	tid keybase1.TeamID, uid keybase1.UID) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	t, err := k.localTeams.getLocalTeam(tid)
+	teamName, err := k.DaemonLocal.RemoveTeamWriterForTest(tid, uid)
 	if err != nil {
 		return err
 	}
-
-	if _, ok := t.Writers[uid]; ok {
-		u, err := k.localUsers.getLocalUser(uid)
-		if err != nil {
-			return err
-		}
-		if t.LastWriters == nil {
-			t.LastWriters = make(
-				map[kbfscrypto.VerifyingKey]keybase1.MerkleRootV2)
-		}
-		for _, key := range u.VerifyingKeys {
-			t.LastWriters[key] = k.merkleRoot
-		}
-	}
-	k.merkleRoot.Seqno++
-
-	delete(t.Writers, uid)
-	delete(t.Readers, uid)
-
-	k.localTeams[tid] = t
 	f := keybase1.Folder{
-		Name:       string(t.Name),
+		Name:       string(teamName),
 		FolderType: keybase1.FolderType_TEAM,
 	}
-	k.favoriteStore.FavoriteAdd(uid, f)
+	k.favoriteStore.FavoriteDelete(uid, f)
 	return nil
 }
 
@@ -803,53 +265,21 @@ func (k *KeybaseDaemonLocal) addTeamReaderForTest(
 	tid keybase1.TeamID, uid keybase1.UID) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	t, err := k.localTeams.getLocalTeam(tid)
+	teamName, err := k.DaemonLocal.AddTeamReaderForTest(tid, uid)
 	if err != nil {
 		return err
 	}
-
-	if t.Writers[uid] {
-		// Being a writer already implies being a reader.
-		return nil
-	}
-
-	if t.Readers == nil {
-		t.Readers = make(map[keybase1.UID]bool)
-	}
-	t.Readers[uid] = true
-	k.localTeams[tid] = t
 	f := keybase1.Folder{
-		Name:       string(t.Name),
+		Name:       string(teamName),
 		FolderType: keybase1.FolderType_TEAM,
 	}
 	k.favoriteStore.FavoriteAdd(uid, f)
 	return nil
 }
 
-func (k *KeybaseDaemonLocal) addTeamKeyForTest(
-	tid keybase1.TeamID, newKeyGen kbfsmd.KeyGen,
-	newKey kbfscrypto.TLFCryptKey) error {
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	t, err := k.localTeams.getLocalTeam(tid)
-	if err != nil {
-		return err
-	}
-
-	t.CryptKeys[newKeyGen] = newKey
-	if newKeyGen > t.LatestKeyGen {
-		t.LatestKeyGen = newKeyGen
-		// Only need to save back to the map if we've modified a
-		// non-reference type like the latest key gen.
-		k.localTeams[tid] = t
-	}
-	return nil
-}
-
-func (k *KeybaseDaemonLocal) addTeamsForTestLocked(teams []TeamInfo) {
+func (k *KeybaseDaemonLocal) addTeamsForTestLocked(teams []idutil.TeamInfo) {
+	k.DaemonLocal.AddTeamsForTest(teams)
 	for _, t := range teams {
-		k.localTeams[t.TID] = t
-		k.asserts[string(t.Name)+"@team"] = t.TID.AsUserOrTeam()
 		f := keybase1.Folder{
 			Name:       string(t.Name),
 			FolderType: keybase1.FolderType_TEAM,
@@ -863,7 +293,7 @@ func (k *KeybaseDaemonLocal) addTeamsForTestLocked(teams []TeamInfo) {
 	}
 }
 
-func (k *KeybaseDaemonLocal) addTeamsForTest(teams []TeamInfo) {
+func (k *KeybaseDaemonLocal) addTeamsForTest(teams []idutil.TeamInfo) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	k.addTeamsForTestLocked(teams)
@@ -878,7 +308,11 @@ func (k *KeybaseDaemonLocal) FavoriteAdd(
 
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	return k.favoriteStore.FavoriteAdd(k.currentUID, folder)
+	session, err := k.CurrentSession(ctx, 0)
+	if err != nil {
+		return err
+	}
+	return k.favoriteStore.FavoriteAdd(session.UID, folder)
 }
 
 // FavoriteDelete implements KeybaseDaemon for KeybaseDaemonLocal.
@@ -890,7 +324,11 @@ func (k *KeybaseDaemonLocal) FavoriteDelete(
 
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	return k.favoriteStore.FavoriteDelete(k.currentUID, folder)
+	session, err := k.CurrentSession(ctx, 0)
+	if err != nil {
+		return err
+	}
+	return k.favoriteStore.FavoriteDelete(session.UID, folder)
 }
 
 // FavoriteList implements KeybaseDaemon for KeybaseDaemonLocal.
@@ -903,8 +341,13 @@ func (k *KeybaseDaemonLocal) FavoriteList(
 	k.lock.Lock()
 	defer k.lock.Unlock()
 
+	session, err := k.CurrentSession(ctx, 0)
+	if err != nil {
+		return keybase1.FavoritesResult{}, err
+	}
+
 	// This is only used for testing, so it's okay to only have favorites here.
-	favs, err := k.favoriteStore.FavoriteList(k.currentUID)
+	favs, err := k.favoriteStore.FavoriteList(session.UID)
 	if err != nil {
 		return keybase1.FavoritesResult{}, err
 	}
@@ -975,11 +418,21 @@ func (k *KeybaseDaemonLocal) Shutdown() {
 	k.favoriteStore.Shutdown()
 }
 
+func newKeybaseDaemonLocal(
+	codec kbfscodec.Codec, currentUID keybase1.UID, users []idutil.LocalUser,
+	teams []idutil.TeamInfo, favoriteStore favoriteStore) *KeybaseDaemonLocal {
+	k := &KeybaseDaemonLocal{
+		DaemonLocal:   idutil.NewDaemonLocal(currentUID, users, teams, codec),
+		favoriteStore: favoriteStore,
+	}
+	return k
+}
+
 // NewKeybaseDaemonDisk constructs a KeybaseDaemonLocal object given a
 // set of possible users, and one user that should be "logged in".
 // Any storage (e.g. the favorites) persists to disk.
-func NewKeybaseDaemonDisk(currentUID keybase1.UID, users []LocalUser,
-	teams []TeamInfo, favDBFile string, codec kbfscodec.Codec) (
+func NewKeybaseDaemonDisk(currentUID keybase1.UID, users []idutil.LocalUser,
+	teams []idutil.TeamInfo, favDBFile string, codec kbfscodec.Codec) (
 	*KeybaseDaemonLocal, error) {
 	favoriteDb, err := leveldb.OpenFile(favDBFile, leveldbOptions)
 	if err != nil {
@@ -994,38 +447,10 @@ func NewKeybaseDaemonDisk(currentUID keybase1.UID, users []LocalUser,
 // a set of possible users, and one user that should be "logged in".
 // Any storage (e.g. the favorites) is kept in memory only.
 func NewKeybaseDaemonMemory(currentUID keybase1.UID,
-	users []LocalUser, teams []TeamInfo,
+	users []idutil.LocalUser, teams []idutil.TeamInfo,
 	codec kbfscodec.Codec) *KeybaseDaemonLocal {
 	favoriteStore := memoryFavoriteClient{
 		favorites: make(map[keybase1.UID]map[string]keybase1.Folder),
 	}
 	return newKeybaseDaemonLocal(codec, currentUID, users, teams, favoriteStore)
-}
-
-func newKeybaseDaemonLocal(codec kbfscodec.Codec,
-	currentUID keybase1.UID, users []LocalUser, teams []TeamInfo,
-	favoriteStore favoriteStore) *KeybaseDaemonLocal {
-	localUserMap := make(localUserMap)
-	asserts := make(map[string]keybase1.UserOrTeamID)
-	for _, u := range users {
-		localUserMap[u.UID] = u
-		for _, a := range u.Asserts {
-			asserts[a] = u.UID.AsUserOrTeam()
-		}
-		asserts[string(u.Name)] = u.UID.AsUserOrTeam()
-	}
-	k := &KeybaseDaemonLocal{
-		codec:              codec,
-		localUsers:         localUserMap,
-		localTeams:         make(localTeamMap),
-		localTeamSettings:  make(localTeamSettingsMap),
-		localImplicitTeams: make(localImplicitTeamMap),
-		asserts:            asserts,
-		implicitAsserts:    make(map[string]keybase1.TeamID),
-		currentUID:         currentUID,
-		favoriteStore:      favoriteStore,
-		// TODO: let test fill in valid merkle root.
-	}
-	k.addTeamsForTest(teams)
-	return k
 }

--- a/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
@@ -56,8 +57,8 @@ func TestKeybaseDaemonRPCGetCurrentSessionCanceled(t *testing.T) {
 // TODO: Add tests for Favorite* methods, too.
 
 type fakeKeybaseClient struct {
-	session                     SessionInfo
-	users                       map[keybase1.UID]UserInfo
+	session                     idutil.SessionInfo
+	users                       map[keybase1.UID]idutil.UserInfo
 	currentSessionCalled        bool
 	identifyCalled              bool
 	loadUserPlusKeysCalled      bool
@@ -157,7 +158,7 @@ const expectCached = false
 
 func testCurrentSession(
 	t *testing.T, client *fakeKeybaseClient, c *KeybaseDaemonRPC,
-	expectedSession SessionInfo, expectedCalled bool) {
+	expectedSession idutil.SessionInfo, expectedCalled bool) {
 	client.currentSessionCalled = false
 
 	ctx := context.Background()
@@ -172,9 +173,9 @@ func testCurrentSession(
 // Test that the session cache works and is invalidated as expected.
 func TestKeybaseDaemonSessionCache(t *testing.T) {
 	name := kbname.NormalizedUsername("fake username")
-	k := MakeLocalUserCryptPublicKeyOrBust(name)
-	v := MakeLocalUserVerifyingKeyOrBust(name)
-	session := SessionInfo{
+	k := idutil.MakeLocalUserCryptPublicKeyOrBust(name)
+	v := idutil.MakeLocalUserVerifyingKeyOrBust(name)
+	session := idutil.SessionInfo{
 		Name:           name,
 		UID:            keybase1.MakeTestUID(1),
 		CryptPublicKey: k,
@@ -244,7 +245,7 @@ func TestKeybaseDaemonUserCache(t *testing.T) {
 	uid2 := keybase1.MakeTestUID(2)
 	name1 := kbname.NewNormalizedUsername("name1")
 	name2 := kbname.NewNormalizedUsername("name2")
-	users := map[keybase1.UID]UserInfo{
+	users := map[keybase1.UID]idutil.UserInfo{
 		uid1: {Name: name1},
 		uid2: {Name: name2},
 	}
@@ -299,7 +300,7 @@ func TestKeybaseDaemonUserCache(t *testing.T) {
 
 	// Test that CheckForRekey gets called only if the logged-in user
 	// changes.
-	session := SessionInfo{
+	session := idutil.SessionInfo{
 		UID: uid1,
 	}
 	c.setCachedCurrentSession(session)
@@ -420,7 +421,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 		},
 	}
 
-	users := map[keybase1.UID]UserInfo{
+	users := map[keybase1.UID]idutil.UserInfo{
 		uid1: {Name: userName1},
 		uid2: {Name: userName2},
 	}

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -10,9 +10,11 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/favorites"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
@@ -41,17 +43,17 @@ type KeybaseServiceBase struct {
 
 	sessionCacheLock sync.RWMutex
 	// Set to the zero value when invalidated.
-	cachedCurrentSession SessionInfo
+	cachedCurrentSession idutil.SessionInfo
 	sessionInProgressCh  chan struct{}
 
 	userCacheLock sync.RWMutex
 	// Map entries are removed when invalidated.
-	userCache               map[keybase1.UID]UserInfo
+	userCache               map[keybase1.UID]idutil.UserInfo
 	userCacheUnverifiedKeys map[keybase1.UID][]keybase1.PublicKey
 
 	teamCacheLock sync.RWMutex
 	// Map entries are removed when invalidated.
-	teamCache map[keybase1.TeamID]TeamInfo
+	teamCache map[keybase1.TeamID]idutil.TeamInfo
 
 	lastNotificationFilenameLock sync.Mutex
 	lastNotificationFilename     string
@@ -66,7 +68,7 @@ type keybaseServiceMerkleGetter struct {
 	k *KeybaseServiceBase
 }
 
-var _ merkleRootGetter = (*keybaseServiceMerkleGetter)(nil)
+var _ idutil.MerkleRootGetter = (*keybaseServiceMerkleGetter)(nil)
 
 func (k *keybaseServiceMerkleGetter) GetCurrentMerkleRoot(
 	ctx context.Context) (keybase1.MerkleRootV2, time.Time, error) {
@@ -84,9 +86,9 @@ func NewKeybaseServiceBase(config Config, kbCtx Context, log logger.Logger) *Key
 		config:                  config,
 		context:                 kbCtx,
 		log:                     log,
-		userCache:               make(map[keybase1.UID]UserInfo),
+		userCache:               make(map[keybase1.UID]idutil.UserInfo),
 		userCacheUnverifiedKeys: make(map[keybase1.UID][]keybase1.PublicKey),
-		teamCache:               make(map[keybase1.TeamID]TeamInfo),
+		teamCache:               make(map[keybase1.TeamID]idutil.TeamInfo),
 	}
 	if config != nil {
 		k.merkleRoot = NewEventuallyConsistentMerkleRoot(
@@ -195,32 +197,32 @@ func (k *KeybaseServiceBase) filterRevokedKeys(
 	uid keybase1.UID,
 	keys map[keybase1.KID]keybase1.PublicKeyV2NaCl,
 	reset *keybase1.ResetSummary) (
-	map[kbfscrypto.VerifyingKey]revokedKeyInfo,
-	map[kbfscrypto.CryptPublicKey]revokedKeyInfo,
+	map[kbfscrypto.VerifyingKey]idutil.RevokedKeyInfo,
+	map[kbfscrypto.CryptPublicKey]idutil.RevokedKeyInfo,
 	map[keybase1.KID]string, error) {
-	verifyingKeys := make(map[kbfscrypto.VerifyingKey]revokedKeyInfo)
-	cryptPublicKeys := make(map[kbfscrypto.CryptPublicKey]revokedKeyInfo)
+	verifyingKeys := make(map[kbfscrypto.VerifyingKey]idutil.RevokedKeyInfo)
+	cryptPublicKeys := make(
+		map[kbfscrypto.CryptPublicKey]idutil.RevokedKeyInfo)
 	var kidNames = map[keybase1.KID]string{}
 	var parents = map[keybase1.KID]keybase1.KID{}
 
 	for _, key := range keys {
-		var info revokedKeyInfo
+		var info idutil.RevokedKeyInfo
 		if key.Base.Revocation != nil {
 			info.Time = key.Base.Revocation.Time
 			info.MerkleRoot = key.Base.Revocation.PrevMerkleRootSigned
 			// If we don't have a prev seqno, then we already have the
 			// best merkle data we're going to get.
-			info.filledInMerkle = info.MerkleRoot.Seqno <= 0
-			info.sigChainLocation = key.Base.Revocation.SigChainLocation
+			info.SetFilledInMerkle(info.MerkleRoot.Seqno <= 0)
+			info.SetSigChainLocation(key.Base.Revocation.SigChainLocation)
 		} else if reset != nil {
 			info.Time = keybase1.ToTime(keybase1.FromUnixTime(reset.Ctime))
 			info.MerkleRoot.Seqno = reset.MerkleRoot.Seqno
 			info.MerkleRoot.HashMeta = reset.MerkleRoot.HashMeta
 			// If we don't have a prev seqno, then we already have the
 			// best merkle data we're going to get.
-			info.filledInMerkle = info.MerkleRoot.Seqno <= 0
-			info.resetSeqno = reset.ResetSeqno
-			info.isReset = true
+			info.SetFilledInMerkle(info.MerkleRoot.Seqno <= 0)
+			info.SetResetInfo(reset.ResetSeqno, true)
 		} else {
 			// Not revoked.
 			continue
@@ -243,25 +245,27 @@ func (k *KeybaseServiceBase) filterRevokedKeys(
 
 }
 
-func (k *KeybaseServiceBase) getCachedCurrentSession() SessionInfo {
+func (k *KeybaseServiceBase) getCachedCurrentSession() idutil.SessionInfo {
 	k.sessionCacheLock.RLock()
 	defer k.sessionCacheLock.RUnlock()
 	return k.cachedCurrentSession
 }
 
-func (k *KeybaseServiceBase) setCachedCurrentSession(s SessionInfo) {
+func (k *KeybaseServiceBase) setCachedCurrentSession(s idutil.SessionInfo) {
 	k.sessionCacheLock.Lock()
 	defer k.sessionCacheLock.Unlock()
 	k.cachedCurrentSession = s
 }
 
-func (k *KeybaseServiceBase) getCachedUserInfo(uid keybase1.UID) UserInfo {
+func (k *KeybaseServiceBase) getCachedUserInfo(
+	uid keybase1.UID) idutil.UserInfo {
 	k.userCacheLock.RLock()
 	defer k.userCacheLock.RUnlock()
 	return k.userCache[uid]
 }
 
-func (k *KeybaseServiceBase) setCachedUserInfo(uid keybase1.UID, info UserInfo) {
+func (k *KeybaseServiceBase) setCachedUserInfo(
+	uid keybase1.UID, info idutil.UserInfo) {
 	k.userCacheLock.Lock()
 	defer k.userCacheLock.Unlock()
 	if info.Name == kbname.NormalizedUsername("") {
@@ -293,14 +297,15 @@ func (k *KeybaseServiceBase) clearCachedUnverifiedKeys(uid keybase1.UID) {
 	delete(k.userCacheUnverifiedKeys, uid)
 }
 
-func (k *KeybaseServiceBase) getCachedTeamInfo(tid keybase1.TeamID) TeamInfo {
+func (k *KeybaseServiceBase) getCachedTeamInfo(
+	tid keybase1.TeamID) idutil.TeamInfo {
 	k.teamCacheLock.RLock()
 	defer k.teamCacheLock.RUnlock()
 	return k.teamCache[tid]
 }
 
 func (k *KeybaseServiceBase) setCachedTeamInfo(
-	tid keybase1.TeamID, info TeamInfo) {
+	tid keybase1.TeamID, info idutil.TeamInfo) {
 	k.teamCacheLock.Lock()
 	defer k.teamCacheLock.Unlock()
 	if info.Name == kbname.NormalizedUsername("") {
@@ -315,16 +320,16 @@ func (k *KeybaseServiceBase) setCachedTeamInfo(
 func (k *KeybaseServiceBase) ClearCaches(ctx context.Context) {
 	k.log.CDebugf(ctx, "Clearing KBFS-side user and team caches")
 
-	k.setCachedCurrentSession(SessionInfo{})
+	k.setCachedCurrentSession(idutil.SessionInfo{})
 	func() {
 		k.userCacheLock.Lock()
 		defer k.userCacheLock.Unlock()
-		k.userCache = make(map[keybase1.UID]UserInfo)
+		k.userCache = make(map[keybase1.UID]idutil.UserInfo)
 		k.userCacheUnverifiedKeys = make(map[keybase1.UID][]keybase1.PublicKey)
 	}()
 	k.teamCacheLock.Lock()
 	defer k.teamCacheLock.Unlock()
-	k.teamCache = make(map[keybase1.TeamID]TeamInfo)
+	k.teamCache = make(map[keybase1.TeamID]idutil.TeamInfo)
 }
 
 // LoggedIn implements keybase1.NotifySessionInterface.
@@ -333,7 +338,7 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 	// Since we don't have the whole session, just clear the cache and
 	// repopulate it.  The `CurrentSession` call executes the "logged
 	// in" flow.
-	k.setCachedCurrentSession(SessionInfo{})
+	k.setCachedCurrentSession(idutil.SessionInfo{})
 	const sessionID = 0
 	_, err := k.CurrentSession(ctx, sessionID)
 	if err != nil {
@@ -352,7 +357,7 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 // LoggedOut implements keybase1.NotifySessionInterface.
 func (k *KeybaseServiceBase) LoggedOut(ctx context.Context) error {
 	k.log.CDebugf(ctx, "Current session logged out")
-	k.setCachedCurrentSession(SessionInfo{})
+	k.setCachedCurrentSession(idutil.SessionInfo{})
 	if k.config != nil {
 		serviceLoggedOut(ctx, k.config)
 	}
@@ -363,7 +368,7 @@ func (k *KeybaseServiceBase) LoggedOut(ctx context.Context) error {
 func (k *KeybaseServiceBase) KeyfamilyChanged(ctx context.Context,
 	uid keybase1.UID) error {
 	k.log.CDebugf(ctx, "Key family for user %s changed", uid)
-	k.setCachedUserInfo(uid, UserInfo{})
+	k.setCachedUserInfo(uid, idutil.UserInfo{})
 	k.clearCachedUnverifiedKeys(uid)
 
 	if k.getCachedCurrentSession().UID == uid {
@@ -453,9 +458,9 @@ func (k *KeybaseServiceBase) RootAuditError(ctx context.Context,
 func ConvertIdentifyError(assertion string, err error) error {
 	switch err.(type) {
 	case libkb.NotFoundError:
-		return NoSuchUserError{assertion}
+		return idutil.NoSuchUserError{Input: assertion}
 	case libkb.ResolutionError:
-		return NoSuchUserError{assertion}
+		return idutil.NoSuchUserError{Input: assertion}
 	}
 	return err
 }
@@ -495,8 +500,8 @@ func (k *KeybaseServiceBase) Identify(
 		Oa:            offline,
 	}
 
-	ei := getExtendedIdentify(ctx)
-	arg.IdentifyBehavior = ei.behavior
+	ei := tlfhandle.GetExtendedIdentify(ctx)
+	arg.IdentifyBehavior = ei.Behavior
 
 	res, err := k.identifyClient.IdentifyLite(ctx, arg)
 	// IdentifyLite still returns keybase1.UserPlusKeys data (sans
@@ -511,10 +516,10 @@ func (k *KeybaseServiceBase) Identify(
 		k.log.CDebugf(ctx,
 			"Ignoring error (%s) for user %s with no sigchain; "+
 				"error type=%T", err, res.Ul.Name, err)
-		ei.onError(ctx)
+		ei.OnError(ctx)
 	default:
 		// If the caller is waiting for breaks, let them know we got an error.
-		ei.onError(ctx)
+		ei.OnError(ctx)
 		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			ConvertIdentifyError(assertion, err)
 	}
@@ -528,9 +533,9 @@ func (k *KeybaseServiceBase) Identify(
 		if err != nil {
 			return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 		}
-		ei.userBreak(ctx, name, asUser, res.TrackBreaks)
+		ei.UserBreak(ctx, name, asUser, res.TrackBreaks)
 	} else if !res.Ul.Id.IsNil() {
-		ei.teamBreak(ctx, res.Ul.Id.AsTeamOrBust(), res.TrackBreaks)
+		ei.TeamBreak(ctx, res.Ul.Id.AsTeamOrBust(), res.TrackBreaks)
 	}
 
 	return name, res.Ul.Id, nil
@@ -548,9 +553,9 @@ func (k *KeybaseServiceBase) NormalizeSocialAssertion(
 func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 	ctx context.Context, assertions, suffix string, tlfType tlf.Type,
 	doIdentifies bool, reason string,
-	offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error) {
+	offline keybase1.OfflineAvailability) (idutil.ImplicitTeamInfo, error) {
 	if tlfType != tlf.Private && tlfType != tlf.Public {
-		return ImplicitTeamInfo{}, fmt.Errorf(
+		return idutil.ImplicitTeamInfo{}, fmt.Errorf(
 			"Invalid implicit team TLF type: %s", tlfType)
 	}
 
@@ -564,12 +569,12 @@ func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 		Oa:           offline,
 	}
 
-	ei := getExtendedIdentify(ctx)
-	arg.IdentifyBehavior = ei.behavior
+	ei := tlfhandle.GetExtendedIdentify(ctx)
+	arg.IdentifyBehavior = ei.Behavior
 
 	res, err := k.identifyClient.ResolveIdentifyImplicitTeam(ctx, arg)
 	if err != nil {
-		return ImplicitTeamInfo{}, ConvertIdentifyError(assertions, err)
+		return idutil.ImplicitTeamInfo{}, ConvertIdentifyError(assertions, err)
 	}
 	name := kbname.NormalizedUsername(res.DisplayName)
 
@@ -580,22 +585,22 @@ func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 			for userVer, breaks := range res.TrackBreaks {
 				// TODO: resolve the UID into a username so we don't have to
 				// pass in the full display name here?
-				ei.userBreak(ctx, name, userVer.Uid, &breaks)
+				ei.UserBreak(ctx, name, userVer.Uid, &breaks)
 				break
 			}
 		} else {
-			ei.teamBreak(ctx, keybase1.TeamID(""), nil)
+			ei.TeamBreak(ctx, keybase1.TeamID(""), nil)
 		}
 	}
 
-	iteamInfo := ImplicitTeamInfo{
+	iteamInfo := idutil.ImplicitTeamInfo{
 		Name: name,
 		TID:  res.TeamID,
 	}
 	if res.FolderID != "" {
 		iteamInfo.TlfID, err = tlf.ParseID(res.FolderID.String())
 		if err != nil {
-			return ImplicitTeamInfo{}, err
+			return idutil.ImplicitTeamInfo{}, err
 		}
 	}
 
@@ -618,15 +623,15 @@ func (k *KeybaseServiceBase) ResolveImplicitTeamByID(
 }
 
 func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
-	ctx context.Context, currUserInfo UserInfo, kid keybase1.KID) (
-	newUserInfo UserInfo, exists bool, err error) {
+	ctx context.Context, currUserInfo idutil.UserInfo, kid keybase1.KID) (
+	newUserInfo idutil.UserInfo, exists bool, err error) {
 	newUserInfo = currUserInfo
 	for key, info := range currUserInfo.RevokedVerifyingKeys {
 		if !key.KID().Equal(kid) {
 			continue
 		}
 		exists = true
-		if info.filledInMerkle {
+		if info.FilledInMerkle() {
 			break
 		}
 
@@ -640,11 +645,12 @@ func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 		// server trust.
 		if info.MerkleRoot.Seqno > 0 {
 			var res keybase1.NextMerkleRootRes
-			if info.isReset {
+			resetSeqno, isReset := info.ResetInfo()
+			if isReset {
 				res, err = k.userClient.FindNextMerkleRootAfterReset(ctx,
 					keybase1.FindNextMerkleRootAfterResetArg{
 						Uid:        currUserInfo.UID,
-						ResetSeqno: info.resetSeqno,
+						ResetSeqno: resetSeqno,
 						Prev: keybase1.ResetMerkleRoot{
 							Seqno:    info.MerkleRoot.Seqno,
 							HashMeta: info.MerkleRoot.HashMeta,
@@ -655,7 +661,7 @@ func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 					keybase1.FindNextMerkleRootAfterRevokeArg{
 						Uid:  currUserInfo.UID,
 						Kid:  kid,
-						Loc:  info.sigChainLocation,
+						Loc:  info.SigChainLocation(),
 						Prev: info.MerkleRoot,
 					})
 			}
@@ -664,12 +670,12 @@ func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 					"the revoked key: %+v", err)
 				info.MerkleRoot.Seqno = 0
 			} else if err != nil {
-				return UserInfo{}, false, err
+				return idutil.UserInfo{}, false, err
 			} else if res.Res != nil {
 				info.MerkleRoot = *res.Res
 			}
 		}
-		info.filledInMerkle = true
+		info.SetFilledInMerkle(true)
 		newUserInfo = currUserInfo.DeepCopy()
 		newUserInfo.RevokedVerifyingKeys[key] = info
 		k.setCachedUserInfo(newUserInfo.UID, newUserInfo)
@@ -683,7 +689,7 @@ func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) LoadUserPlusKeys(
 	ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID,
-	offline keybase1.OfflineAvailability) (UserInfo, error) {
+	offline keybase1.OfflineAvailability) (idutil.UserInfo, error) {
 	cachedUserInfo := k.getCachedUserInfo(uid)
 	if cachedUserInfo.Name != kbname.NormalizedUsername("") {
 		if pollForKID == keybase1.KID("") {
@@ -702,7 +708,7 @@ func (k *KeybaseServiceBase) LoadUserPlusKeys(
 		cachedUserInfo, exists, err := k.checkForRevokedVerifyingKey(
 			ctx, cachedUserInfo, pollForKID)
 		if err != nil {
-			return UserInfo{}, err
+			return idutil.UserInfo{}, err
 		}
 		if exists {
 			return cachedUserInfo, nil
@@ -716,12 +722,12 @@ func (k *KeybaseServiceBase) LoadUserPlusKeys(
 	}
 	res, err := k.userClient.LoadUserPlusKeysV2(ctx, arg)
 	if err != nil {
-		return UserInfo{}, err
+		return idutil.UserInfo{}, err
 	}
 
 	userInfo, err := k.processUserPlusKeys(ctx, res)
 	if err != nil {
-		return UserInfo{}, err
+		return idutil.UserInfo{}, err
 	}
 
 	if pollForKID != keybase1.KID("") {
@@ -730,15 +736,16 @@ func (k *KeybaseServiceBase) LoadUserPlusKeys(
 		userInfo, _, err = k.checkForRevokedVerifyingKey(
 			ctx, userInfo, pollForKID)
 		if err != nil {
-			return UserInfo{}, err
+			return idutil.UserInfo{}, err
 		}
 	}
 	return userInfo, nil
 }
 
 func (k *KeybaseServiceBase) getLastWriterInfo(
-	ctx context.Context, teamInfo TeamInfo, tlfType tlf.Type, user keybase1.UID,
-	verifyingKey kbfscrypto.VerifyingKey) (TeamInfo, error) {
+	ctx context.Context, teamInfo idutil.TeamInfo, tlfType tlf.Type,
+	user keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (
+	idutil.TeamInfo, error) {
 	if _, ok := teamInfo.LastWriters[verifyingKey]; ok {
 		// Already cached, nothing to do.
 		return teamInfo, nil
@@ -752,7 +759,7 @@ func (k *KeybaseServiceBase) getLastWriterInfo(
 			IsPublic:   tlfType == tlf.Public,
 		})
 	if err != nil {
-		return TeamInfo{}, err
+		return idutil.TeamInfo{}, err
 	}
 
 	// Copy any old data to avoid races.
@@ -779,7 +786,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type,
 	desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion,
 	desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole,
-	offline keybase1.OfflineAvailability) (TeamInfo, error) {
+	offline keybase1.OfflineAvailability) (idutil.TeamInfo, error) {
 	if !allowedLoadTeamRoles[desiredRole] {
 		panic(fmt.Sprintf("Disallowed team role: %v", desiredRole))
 	}
@@ -816,7 +823,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 						ctx, cachedTeamInfo, tlfType, desiredUser.Uid,
 						desiredKey)
 					if err != nil {
-						return TeamInfo{}, err
+						return idutil.TeamInfo{}, err
 					}
 					k.setCachedTeamInfo(tid, cachedTeamInfo)
 				}
@@ -852,15 +859,15 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 
 	res, err := k.teamsClient.LoadTeamPlusApplicationKeys(ctx, arg)
 	if err != nil {
-		return TeamInfo{}, err
+		return idutil.TeamInfo{}, err
 	}
 
 	if tid != res.Id {
-		return TeamInfo{}, fmt.Errorf(
+		return idutil.TeamInfo{}, fmt.Errorf(
 			"TID doesn't match: %s vs %s", tid, res.Id)
 	}
 
-	info := TeamInfo{
+	info := idutil.TeamInfo{
 		Name:      kbname.NormalizedUsername(res.Name),
 		TID:       res.Id,
 		CryptKeys: make(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey),
@@ -887,7 +894,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	if tid.IsSubTeam() {
 		rootID, err := k.teamsClient.GetTeamRootID(ctx, tid)
 		if err != nil {
-			return TeamInfo{}, err
+			return idutil.TeamInfo{}, err
 		}
 		info.RootID = rootID
 	}
@@ -898,7 +905,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 		info, err = k.getLastWriterInfo(
 			ctx, info, tlfType, desiredUser.Uid, desiredKey)
 		if err != nil {
-			return TeamInfo{}, err
+			return idutil.TeamInfo{}, err
 		}
 	}
 
@@ -967,18 +974,18 @@ func (k *KeybaseServiceBase) VerifyMerkleRoot(
 
 func (k *KeybaseServiceBase) processUserPlusKeys(
 	ctx context.Context, upk keybase1.UserPlusKeysV2AllIncarnations) (
-	UserInfo, error) {
+	idutil.UserInfo, error) {
 	verifyingKeys, cryptPublicKeys, kidNames, err := filterKeys(
 		upk.Current.DeviceKeys)
 	if err != nil {
-		return UserInfo{}, err
+		return idutil.UserInfo{}, err
 	}
 
 	revokedVerifyingKeys, revokedCryptPublicKeys, revokedKidNames, err :=
 		k.filterRevokedKeys(
 			ctx, upk.Current.Uid, upk.Current.DeviceKeys, upk.Current.Reset)
 	if err != nil {
-		return UserInfo{}, err
+		return idutil.UserInfo{}, err
 	}
 
 	if len(revokedKidNames) > 0 {
@@ -993,7 +1000,7 @@ func (k *KeybaseServiceBase) processUserPlusKeys(
 			k.filterRevokedKeys(
 				ctx, incarnation.Uid, incarnation.DeviceKeys, incarnation.Reset)
 		if err != nil {
-			return UserInfo{}, err
+			return idutil.UserInfo{}, err
 		}
 
 		if len(revokedKidNames) > 0 {
@@ -1010,7 +1017,7 @@ func (k *KeybaseServiceBase) processUserPlusKeys(
 		}
 	}
 
-	u := UserInfo{
+	u := idutil.UserInfo{
 		Name: kbname.NewNormalizedUsername(
 			upk.Current.Username),
 		UID:                    upk.Current.Uid,
@@ -1027,27 +1034,27 @@ func (k *KeybaseServiceBase) processUserPlusKeys(
 }
 
 func (k *KeybaseServiceBase) getCachedCurrentSessionOrInProgressCh() (
-	cachedSession SessionInfo, inProgressCh chan struct{}, doRPC bool) {
+	cachedSession idutil.SessionInfo, inProgressCh chan struct{}, doRPC bool) {
 	k.sessionCacheLock.Lock()
 	defer k.sessionCacheLock.Unlock()
 
-	if k.cachedCurrentSession != (SessionInfo{}) {
+	if k.cachedCurrentSession != (idutil.SessionInfo{}) {
 		return k.cachedCurrentSession, nil, false
 	}
 
 	// If someone already started the RPC, wait for them (and release
 	// the lock).
 	if k.sessionInProgressCh != nil {
-		return SessionInfo{}, k.sessionInProgressCh, false
+		return idutil.SessionInfo{}, k.sessionInProgressCh, false
 	}
 
 	k.sessionInProgressCh = make(chan struct{})
-	return SessionInfo{}, k.sessionInProgressCh, true
+	return idutil.SessionInfo{}, k.sessionInProgressCh, true
 }
 
 func (k *KeybaseServiceBase) getCurrentSession(
-	ctx context.Context, sessionID int) (SessionInfo, bool, error) {
-	var cachedCurrentSession SessionInfo
+	ctx context.Context, sessionID int) (idutil.SessionInfo, bool, error) {
+	var cachedCurrentSession idutil.SessionInfo
 	var inProgressCh chan struct{}
 	doRPC := false
 	// Loop until either we have the session info, or until we are the
@@ -1057,7 +1064,7 @@ func (k *KeybaseServiceBase) getCurrentSession(
 	for !doRPC {
 		cachedCurrentSession, inProgressCh, doRPC =
 			k.getCachedCurrentSessionOrInProgressCh()
-		if cachedCurrentSession != (SessionInfo{}) {
+		if cachedCurrentSession != (idutil.SessionInfo{}) {
 			return cachedCurrentSession, false, nil
 		}
 
@@ -1066,12 +1073,12 @@ func (k *KeybaseServiceBase) getCurrentSession(
 			select {
 			case <-inProgressCh:
 			case <-ctx.Done():
-				return SessionInfo{}, false, ctx.Err()
+				return idutil.SessionInfo{}, false, ctx.Err()
 			}
 		}
 	}
 
-	var s SessionInfo
+	var s idutil.SessionInfo
 	// Close and clear the in-progress channel, even on an error.
 	defer func() {
 		k.sessionCacheLock.Lock()
@@ -1085,13 +1092,13 @@ func (k *KeybaseServiceBase) getCurrentSession(
 	if err != nil {
 		if _, ok := err.(libkb.NoSessionError); ok {
 			// Use an error with a proper OS error code attached to it.
-			err = NoCurrentSessionError{}
+			err = idutil.NoCurrentSessionError{}
 		}
-		return SessionInfo{}, false, err
+		return idutil.SessionInfo{}, false, err
 	}
-	s, err = SessionInfoFromProtocol(res)
+	s, err = idutil.SessionInfoFromProtocol(res)
 	if err != nil {
-		return SessionInfo{}, false, err
+		return idutil.SessionInfo{}, false, err
 	}
 
 	k.log.CDebugf(
@@ -1101,14 +1108,15 @@ func (k *KeybaseServiceBase) getCurrentSession(
 }
 
 // CurrentSession implements the KeybaseService interface for KeybaseServiceBase.
-func (k *KeybaseServiceBase) CurrentSession(ctx context.Context, sessionID int) (
-	SessionInfo, error) {
+func (k *KeybaseServiceBase) CurrentSession(
+	ctx context.Context, sessionID int) (
+	idutil.SessionInfo, error) {
 	ctx = CtxWithRandomIDReplayable(
 		ctx, CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID, k.log)
 
 	s, newSession, err := k.getCurrentSession(ctx, sessionID)
 	if err != nil {
-		return SessionInfo{}, err
+		return idutil.SessionInfo{}, err
 	}
 
 	if newSession && k.config != nil {
@@ -1206,7 +1214,7 @@ func (k *KeybaseServiceBase) NotifySyncStatus(ctx context.Context,
 func (k *KeybaseServiceBase) FlushUserFromLocalCache(ctx context.Context,
 	uid keybase1.UID) {
 	k.log.CDebugf(ctx, "Flushing cache for user %s", uid)
-	k.setCachedUserInfo(uid, UserInfo{})
+	k.setCachedUserInfo(uid, idutil.UserInfo{})
 }
 
 // CtxKeybaseServiceTagKey is the type used for unique context tags
@@ -1290,7 +1298,7 @@ func (k *KeybaseServiceBase) TeamChangedByID(ctx context.Context,
 		"(membershipChange=%t, keyRotated=%t, renamed=%t)",
 		arg.TeamID, arg.Changes.MembershipChanged,
 		arg.Changes.KeyRotated, arg.Changes.Renamed)
-	k.setCachedTeamInfo(arg.TeamID, TeamInfo{})
+	k.setCachedTeamInfo(arg.TeamID, idutil.TeamInfo{})
 
 	if arg.Changes.Renamed {
 		k.config.KBFSOps().TeamNameChanged(ctx, arg.TeamID)
@@ -1328,7 +1336,7 @@ func (k *KeybaseDaemonRPC) NewlyAddedToTeam(context.Context, keybase1.TeamID) er
 func (k *KeybaseDaemonRPC) TeamAbandoned(
 	ctx context.Context, tid keybase1.TeamID) error {
 	k.log.CDebugf(ctx, "Implicit team %s abandoned", tid)
-	k.setCachedTeamInfo(tid, TeamInfo{})
+	k.setCachedTeamInfo(tid, idutil.TeamInfo{})
 	k.config.KBFSOps().TeamAbandoned(ctx, tid)
 	return nil
 }
@@ -1380,7 +1388,7 @@ func (k *KeybaseServiceBase) FinalizeMigration(ctx context.Context,
 			}
 			k.log.CDebugf(ctx, "Clearing team info for tid=%s, handle=%s",
 				tid, handle.GetCanonicalPath())
-			k.setCachedTeamInfo(tid, TeamInfo{})
+			k.setCachedTeamInfo(tid, idutil.TeamInfo{})
 		}
 	}
 	return k.config.KBFSOps().MigrateToImplicitTeam(ctx, handle.TlfID())
@@ -1390,7 +1398,7 @@ func (k *KeybaseServiceBase) FinalizeMigration(ctx context.Context,
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,
 	query keybase1.TLFQuery) (res keybase1.GetTLFCryptKeysRes, err error) {
-	if ctx, err = MakeExtendedIdentify(
+	if ctx, err = tlfhandle.MakeExtendedIdentify(
 		CtxWithRandomIDReplayable(ctx,
 			CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID, k.log),
 		query.IdentifyBehavior,
@@ -1421,7 +1429,8 @@ func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,
 	}
 
 	if query.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks() {
-		res.NameIDBreaks.Breaks = getExtendedIdentify(ctx).getTlfBreakAndClose()
+		res.NameIDBreaks.Breaks = tlfhandle.GetExtendedIdentify(ctx).
+			GetTlfBreakAndClose()
 	}
 
 	return res, nil
@@ -1432,7 +1441,7 @@ func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,
 func (k *KeybaseServiceBase) GetPublicCanonicalTLFNameAndID(
 	ctx context.Context, query keybase1.TLFQuery) (
 	res keybase1.CanonicalTLFNameAndIDWithBreaks, err error) {
-	if ctx, err = MakeExtendedIdentify(
+	if ctx, err = tlfhandle.MakeExtendedIdentify(
 		CtxWithRandomIDReplayable(ctx,
 			CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID, k.log),
 		query.IdentifyBehavior,
@@ -1457,7 +1466,7 @@ func (k *KeybaseServiceBase) GetPublicCanonicalTLFNameAndID(
 	res.TlfID = keybase1.TLFID(id.String())
 
 	if query.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks() {
-		res.Breaks = getExtendedIdentify(ctx).getTlfBreakAndClose()
+		res.Breaks = tlfhandle.GetExtendedIdentify(ctx).GetTlfBreakAndClose()
 	}
 
 	return res, nil

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -135,7 +136,7 @@ func (k KeybaseServiceMeasured) NormalizeSocialAssertion(
 func (k KeybaseServiceMeasured) ResolveIdentifyImplicitTeam(
 	ctx context.Context, assertions, suffix string, tlfType tlf.Type,
 	doIdentifies bool, reason string, offline keybase1.OfflineAvailability) (
-	info ImplicitTeamInfo, err error) {
+	info idutil.ImplicitTeamInfo, err error) {
 	k.resolveIdentifyImplicitTeamTimer.Time(func() {
 		info, err = k.delegate.ResolveIdentifyImplicitTeam(
 			ctx, assertions, suffix, tlfType, doIdentifies, reason, offline)
@@ -156,7 +157,7 @@ func (k KeybaseServiceMeasured) ResolveImplicitTeamByID(
 // LoadUserPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) LoadUserPlusKeys(
 	ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID,
-	offline keybase1.OfflineAvailability) (userInfo UserInfo, err error) {
+	offline keybase1.OfflineAvailability) (userInfo idutil.UserInfo, err error) {
 	k.loadUserPlusKeysTimer.Time(func() {
 		userInfo, err = k.delegate.LoadUserPlusKeys(
 			ctx, uid, pollForKID, offline)
@@ -169,7 +170,7 @@ func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
 	tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen,
 	desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey,
 	desiredRole keybase1.TeamRole, offline keybase1.OfflineAvailability) (
-	teamInfo TeamInfo, err error) {
+	teamInfo idutil.TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
 		teamInfo, err = k.delegate.LoadTeamPlusKeys(
 			ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey,
@@ -224,7 +225,7 @@ func (k KeybaseServiceMeasured) VerifyMerkleRoot(
 // CurrentSession implements the KeybaseService interface for
 // KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) CurrentSession(ctx context.Context, sessionID int) (
-	sessionInfo SessionInfo, err error) {
+	sessionInfo idutil.SessionInfo, err error) {
 	k.currentSessionTimer.Time(func() {
 		sessionInfo, err = k.delegate.CurrentSession(ctx, sessionID)
 	})

--- a/go/kbfs/libkbfs/keybase_service_util.go
+++ b/go/kbfs/libkbfs/keybase_service_util.go
@@ -5,10 +5,11 @@
 package libkbfs
 
 import (
-	"github.com/keybase/client/go/kbfs/tlf"
 	"sync"
 
 	"github.com/keybase/client/go/kbconst"
+	"github.com/keybase/client/go/kbfs/idutil"
+	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
 )
@@ -41,8 +42,8 @@ func setHomeTlfIdsForDbcAndFavorites(ctx context.Context, config Config, usernam
 	if err != nil {
 		log.CWarningf(ctx, "serviceLoggedIn: Failed to fetch TLF ID for "+
 			"user's public TLF: %+v", err)
-	} else if publicHandle.tlfID != tlf.NullID {
-		err = config.DiskBlockCache().AddHomeTLF(ctx, publicHandle.tlfID)
+	} else if publicHandle.TlfID() != tlf.NullID {
+		err = config.DiskBlockCache().AddHomeTLF(ctx, publicHandle.TlfID())
 		if err != nil {
 			log.CWarningf(ctx, "serviceLoggedIn: Failed to set home TLF "+
 				"for disk block cache: %+v", err)
@@ -53,8 +54,8 @@ func setHomeTlfIdsForDbcAndFavorites(ctx context.Context, config Config, usernam
 	if err != nil {
 		log.CWarningf(ctx, "serviceLoggedIn: Failed to fetch TLF ID for "+
 			"user's private TLF: %+v", err)
-	} else if privateHandle.tlfID != tlf.NullID {
-		err = config.DiskBlockCache().AddHomeTLF(ctx, privateHandle.tlfID)
+	} else if privateHandle.TlfID() != tlf.NullID {
+		err = config.DiskBlockCache().AddHomeTLF(ctx, privateHandle.TlfID())
 		if err != nil {
 			log.CWarningf(ctx, "serviceLoggedIn: Failed to set home TLF "+
 				"for disk block cache: %+v", err)
@@ -64,13 +65,13 @@ func setHomeTlfIdsForDbcAndFavorites(ctx context.Context, config Config, usernam
 	// Send to Favorites cache
 	info := homeTLFInfo{}
 	if publicHandle != nil {
-		teamID := publicHandle.toFavToAdd(false).Data.TeamID
+		teamID := publicHandle.ToFavToAdd(false).Data.TeamID
 		if teamID != nil {
 			info.PublicTeamID = *teamID
 		}
 	}
 	if privateHandle != nil {
-		teamID := privateHandle.toFavToAdd(false).Data.TeamID
+		teamID := privateHandle.ToFavToAdd(false).Data.TeamID
 		if teamID != nil {
 			info.PrivateTeamID = *teamID
 		}
@@ -80,7 +81,7 @@ func setHomeTlfIdsForDbcAndFavorites(ctx context.Context, config Config, usernam
 
 // serviceLoggedIn should be called when a new user logs in. It
 // shouldn't be called again until after serviceLoggedOut is called.
-func serviceLoggedIn(ctx context.Context, config Config, session SessionInfo,
+func serviceLoggedIn(ctx context.Context, config Config, session idutil.SessionInfo,
 	bws TLFJournalBackgroundWorkStatus) (wg *sync.WaitGroup) {
 	wg = &sync.WaitGroup{} // To avoid returning a nil pointer.
 	log := config.MakeLogger("")

--- a/go/kbfs/libkbfs/md_journal.go
+++ b/go/kbfs/libkbfs/md_journal.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
@@ -131,7 +132,7 @@ type mdJournal struct {
 	crypto         cryptoPure
 	clock          Clock
 	teamMemChecker kbfsmd.TeamMembershipChecker
-	osg            OfflineStatusGetter
+	osg            idutil.OfflineStatusGetter
 	tlfID          tlf.ID
 	mdVer          kbfsmd.MetadataVer
 	dir            string
@@ -161,7 +162,7 @@ type mdJournal struct {
 func makeMDJournalWithIDJournal(
 	ctx context.Context, uid keybase1.UID, key kbfscrypto.VerifyingKey,
 	codec kbfscodec.Codec, crypto cryptoPure, clock Clock,
-	teamMemChecker kbfsmd.TeamMembershipChecker, osg OfflineStatusGetter,
+	teamMemChecker kbfsmd.TeamMembershipChecker, osg idutil.OfflineStatusGetter,
 	tlfID tlf.ID, mdVer kbfsmd.MetadataVer, dir string, idJournal mdIDJournal,
 	log logger.Logger) (*mdJournal, error) {
 	if uid == keybase1.UID("") {
@@ -226,7 +227,7 @@ func mdJournalPath(dir string) string {
 func makeMDJournal(
 	ctx context.Context, uid keybase1.UID, key kbfscrypto.VerifyingKey,
 	codec kbfscodec.Codec, crypto cryptoPure, clock Clock,
-	teamMemChecker kbfsmd.TeamMembershipChecker, osg OfflineStatusGetter,
+	teamMemChecker kbfsmd.TeamMembershipChecker, osg idutil.OfflineStatusGetter,
 	tlfID tlf.ID, mdVer kbfsmd.MetadataVer, dir string,
 	log logger.Logger) (*mdJournal, error) {
 	journalDir := mdJournalPath(dir)

--- a/go/kbfs/libkbfs/md_journal_test.go
+++ b/go/kbfs/libkbfs/md_journal_test.go
@@ -12,11 +12,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
+	idutiltest "github.com/keybase/client/go/kbfs/idutil/test"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/assert"
@@ -89,13 +92,13 @@ func teardownMDJournalTest(t testing.TB, tempdir string) {
 func makeMDForTest(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 	revision kbfsmd.Revision, uid keybase1.UID,
 	signer kbfscrypto.Signer, prevRoot kbfsmd.ID) *RootMetadata {
-	nug := testNormalizedUsernameGetter{
+	nug := idutiltest.NormalizedUsernameGetter{
 		uid.AsUserOrTeam(): "fake_username",
 	}
 	bh, err := tlf.MakeHandle(
 		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	h, err := MakeTlfHandle(
+	h, err := tlfhandle.MakeHandle(
 		context.Background(), bh, bh.Type(), nil, nug, nil,
 		keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
@@ -110,7 +113,7 @@ func makeMDForTest(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 
 type constMerkleRootGetter struct{}
 
-var _ merkleRootGetter = constMerkleRootGetter{}
+var _ idutil.MerkleRootGetter = constMerkleRootGetter{}
 
 func (cmrg constMerkleRootGetter) GetCurrentMerkleRoot(
 	ctx context.Context) (keybase1.MerkleRootV2, time.Time, error) {

--- a/go/kbfs/libkbfs/md_ops.go
+++ b/go/kbfs/libkbfs/md_ops.go
@@ -9,10 +9,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
@@ -79,7 +81,7 @@ func NewMDOpsStandard(config Config) *MDOpsStandard {
 // convertVerifyingKeyError gives a better error when the TLF was
 // signed by a key that is no longer associated with the last writer.
 func (md *MDOpsStandard) convertVerifyingKeyError(ctx context.Context,
-	rmds *RootMetadataSigned, handle *TlfHandle, err error) error {
+	rmds *RootMetadataSigned, handle *tlfhandle.Handle, err error) error {
 	if _, ok := err.(VerifyingKeyNotFoundError); !ok {
 		return err
 	}
@@ -548,7 +550,7 @@ func (md *MDOpsStandard) verifyKey(
 	err = md.config.KBPKI().HasVerifyingKey(
 		ctx, uid, verifyingKey, rmds.untrustedServerTimestamp,
 		md.config.OfflineAvailabilityForID(irmd.TlfID()))
-	var info revokedKeyInfo
+	var info idutil.RevokedKeyInfo
 	switch e := errors.Cause(err).(type) {
 	case nil:
 		return true, nil
@@ -584,7 +586,7 @@ func (md *MDOpsStandard) verifyKey(
 }
 
 func (md *MDOpsStandard) verifyWriterKey(ctx context.Context,
-	rmds *RootMetadataSigned, irmd ImmutableRootMetadata, handle *TlfHandle,
+	rmds *RootMetadataSigned, irmd ImmutableRootMetadata, handle *tlfhandle.Handle,
 	getRangeLock *sync.Mutex) error {
 	if !rmds.MD.IsWriterMetadataCopiedSet() {
 		// Skip verifying the writer key if it's the same as the
@@ -768,7 +770,7 @@ func (mbtc merkleBasedTeamChecker) IsTeamReader(
 // ImmutableRootMetadata. After this function is called, rmds
 // shouldn't be used.
 func (md *MDOpsStandard) processMetadata(ctx context.Context,
-	handle *TlfHandle, rmds *RootMetadataSigned, extra kbfsmd.ExtraMetadata,
+	handle *tlfhandle.Handle, rmds *RootMetadataSigned, extra kbfsmd.ExtraMetadata,
 	getRangeLock *sync.Mutex) (ImmutableRootMetadata, error) {
 	// First, construct the ImmutableRootMetadata object, even before
 	// we validate the writer or the keys, because the irmd will be
@@ -826,7 +828,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	checker := merkleBasedTeamChecker{md.config.KBPKI(), md, rmds, irmd, false}
 	err = rmds.IsValidAndSigned(
 		ctx, md.config.Codec(), checker, extra,
-		md.config.OfflineAvailabilityForID(handle.tlfID))
+		md.config.OfflineAvailabilityForID(handle.TlfID()))
 	if err != nil {
 		return ImmutableRootMetadata{}, MDMismatchError{
 			rmds.MD.RevisionNumber(), handle.GetCanonicalPath(),
@@ -863,15 +865,15 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	return irmd, nil
 }
 
-func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
+func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *tlfhandle.Handle,
 	mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 	id tlf.ID, rmd ImmutableRootMetadata, err error) {
 	// If we already know the tlf ID, we shouldn't be calling this
 	// function.
-	if handle.tlfID != tlf.NullID {
+	if handle.TlfID() != tlf.NullID {
 		return tlf.ID{}, ImmutableRootMetadata{}, errors.Errorf(
 			"GetForHandle called for %s with non-nil TLF ID %s",
-			handle.GetCanonicalPath(), handle.tlfID)
+			handle.GetCanonicalPath(), handle.TlfID())
 	}
 
 	// Check for handle readership, to give a nice error early.
@@ -882,8 +884,9 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 		}
 
 		if !handle.IsReader(session.UID) {
-			return tlf.ID{}, ImmutableRootMetadata{}, NewReadAccessError(
-				handle, session.Name, handle.GetCanonicalPath())
+			return tlf.ID{}, ImmutableRootMetadata{},
+				tlfhandle.NewReadAccessError(
+					handle, session.Name, handle.GetCanonicalPath())
 		}
 	}
 
@@ -936,7 +939,7 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
 
-	mdHandle, err := MakeTlfHandle(
+	mdHandle, err := tlfhandle.MakeHandle(
 		ctx, bareMdHandle, id.Type(), md.config.KBPKI(), md.config.KBPKI(), nil,
 		md.config.OfflineAvailabilityForID(id))
 	if err != nil {
@@ -951,7 +954,7 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 	}
 	// Set the ID after checking the resolve, because `handle` doesn't
 	// have the TLF ID set yet.
-	mdHandle.tlfID = id
+	mdHandle.SetTlfID(id)
 
 	// TODO: For now, use the mdHandle that came with rmds for
 	// consistency. In the future, we'd want to eventually notify
@@ -967,7 +970,7 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 
 // GetIDForHandle implements the MDOps interface for MDOpsStandard.
 func (md *MDOpsStandard) GetIDForHandle(
-	ctx context.Context, handle *TlfHandle) (id tlf.ID, err error) {
+	ctx context.Context, handle *tlfhandle.Handle) (id tlf.ID, err error) {
 	mdcache := md.config.MDCache()
 	id, err = mdcache.GetIDForHandle(handle)
 	switch errors.Cause(err).(type) {
@@ -995,7 +998,7 @@ func (md *MDOpsStandard) GetIDForHandle(
 }
 
 func (md *MDOpsStandard) processMetadataWithID(ctx context.Context,
-	id tlf.ID, bid kbfsmd.BranchID, handle *TlfHandle, rmds *RootMetadataSigned,
+	id tlf.ID, bid kbfsmd.BranchID, handle *tlfhandle.Handle, rmds *RootMetadataSigned,
 	extra kbfsmd.ExtraMetadata, getRangeLock *sync.Mutex) (ImmutableRootMetadata, error) {
 	// Make sure the signed-over ID matches
 	if id != rmds.MD.TlfID() {
@@ -1017,20 +1020,6 @@ func (md *MDOpsStandard) processMetadataWithID(ctx context.Context,
 	return md.processMetadata(ctx, handle, rmds, extra, getRangeLock)
 }
 
-type constIDGetter struct {
-	id tlf.ID
-}
-
-func (c constIDGetter) GetIDForHandle(_ context.Context, _ *TlfHandle) (
-	tlf.ID, error) {
-	return c.id, nil
-}
-
-func (c constIDGetter) ValidateLatestHandleNotFinal(
-	_ context.Context, _ *TlfHandle) (bool, error) {
-	return true, nil
-}
-
 func (md *MDOpsStandard) processSignedMD(
 	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID,
 	rmds *RootMetadataSigned) (ImmutableRootMetadata, error) {
@@ -1042,9 +1031,9 @@ func (md *MDOpsStandard) processSignedMD(
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
-	handle, err := MakeTlfHandle(
+	handle, err := tlfhandle.MakeHandle(
 		ctx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
-		md.config.KBPKI(), constIDGetter{id},
+		md.config.KBPKI(), tlfhandle.ConstIDGetter{ID: id},
 		md.config.OfflineAvailabilityForID(id))
 	if err != nil {
 		return ImmutableRootMetadata{}, err
@@ -1138,9 +1127,9 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
 			if err != nil {
 				return err
 			}
-			handle, err := MakeTlfHandle(
+			handle, err := tlfhandle.MakeHandle(
 				groupCtx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
-				md.config.KBPKI(), constIDGetter{id},
+				md.config.KBPKI(), tlfhandle.ConstIDGetter{ID: id},
 				md.config.OfflineAvailabilityForID(id))
 			if err != nil {
 				return err
@@ -1383,8 +1372,8 @@ func (md *MDOpsStandard) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (
 // ValidateLatestHandleNotFinal implements the MDOps interface for
 // MDOpsStandard.
 func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
-	ctx context.Context, h *TlfHandle) (bool, error) {
-	if h.IsFinal() || h.tlfID == tlf.NullID {
+	ctx context.Context, h *tlfhandle.Handle) (bool, error) {
+	if h.IsFinal() || h.TlfID() == tlf.NullID {
 		return false, nil
 	}
 
@@ -1397,14 +1386,14 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 	case NoSuchTlfIDError:
 		// Do the server-based lookup below.
 	case nil:
-		return id == h.tlfID, nil
+		return id == h.TlfID(), nil
 	default:
 		return false, err
 	}
 
 	md.log.CDebugf(ctx, "Checking the latest handle for %s; "+
-		"curr handle is %s", h.tlfID, h.GetCanonicalName())
-	latestHandle, err := md.GetLatestHandleForTLF(ctx, h.tlfID)
+		"curr handle is %s", h.TlfID(), h.GetCanonicalName())
+	latestHandle, err := md.GetLatestHandleForTLF(ctx, h.TlfID())
 	switch errors.Cause(err).(type) {
 	case kbfsmd.ServerErrorUnauthorized:
 		// The server sends this in the case that it doesn't know
@@ -1423,7 +1412,7 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 				"Latest handle is finalized, so ID is incorrect")
 			return false, nil
 		}
-		err = mdcache.PutIDForHandle(h, h.tlfID)
+		err = mdcache.PutIDForHandle(h, h.TlfID())
 		if err != nil {
 			return false, err
 		}

--- a/go/kbfs/libkbfs/md_util_test.go
+++ b/go/kbfs/libkbfs/md_util_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/pkg/errors"
@@ -105,7 +106,7 @@ func TestGetRevisionByTime(t *testing.T) {
 	config.SetClock(clock)
 
 	t.Log("Create revision 1")
-	h, err := ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), nil, string(u1), tlf.Private)
 	require.NoError(t, err)
 	kbfsOps := config.KBFSOps()
@@ -132,12 +133,12 @@ func TestGetRevisionByTime(t *testing.T) {
 	rev, err := GetMDRevisionByTime(ctx, config, h, t2)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.Revision(2), rev)
-	_, err = config.MDCache().Get(h.tlfID, rev, kbfsmd.NullBranchID)
+	_, err = config.MDCache().Get(h.TlfID(), rev, kbfsmd.NullBranchID)
 	require.NoError(t, err)
 	rev, err = GetMDRevisionByTime(ctx, config, h, t1)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.Revision(1), rev)
-	_, err = config.MDCache().Get(h.tlfID, rev, kbfsmd.NullBranchID)
+	_, err = config.MDCache().Get(h.TlfID(), rev, kbfsmd.NullBranchID)
 	require.NoError(t, err)
 
 	t.Log(ctx, "Check in-between times")

--- a/go/kbfs/libkbfs/mdcache.go
+++ b/go/kbfs/libkbfs/mdcache.go
@@ -10,6 +10,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
 )
@@ -132,7 +133,7 @@ func (md *MDCacheStandard) MarkPutToServer(
 
 // GetIDForHandle implements the MDCache interface for
 // MDCacheStandard.
-func (md *MDCacheStandard) GetIDForHandle(handle *TlfHandle) (tlf.ID, error) {
+func (md *MDCacheStandard) GetIDForHandle(handle *tlfhandle.Handle) (tlf.ID, error) {
 	md.lock.RLock()
 	defer md.lock.RUnlock()
 	key := handle.GetCanonicalPath()
@@ -149,7 +150,7 @@ func (md *MDCacheStandard) GetIDForHandle(handle *TlfHandle) (tlf.ID, error) {
 
 // PutIDForHandle implements the MDCache interface for
 // MDCacheStandard.
-func (md *MDCacheStandard) PutIDForHandle(handle *TlfHandle, id tlf.ID) error {
+func (md *MDCacheStandard) PutIDForHandle(handle *tlfhandle.Handle, id tlf.ID) error {
 	md.lock.RLock()
 	defer md.lock.RUnlock()
 	key := handle.GetCanonicalPath()
@@ -160,7 +161,7 @@ func (md *MDCacheStandard) PutIDForHandle(handle *TlfHandle, id tlf.ID) error {
 // ChangeHandleForID implements the MDCache interface for
 // MDCacheStandard.
 func (md *MDCacheStandard) ChangeHandleForID(
-	oldHandle *TlfHandle, newHandle *TlfHandle) {
+	oldHandle *tlfhandle.Handle, newHandle *tlfhandle.Handle) {
 	md.lock.RLock()
 	defer md.lock.RUnlock()
 	oldKey := oldHandle.GetCanonicalPath()

--- a/go/kbfs/libkbfs/mdcache_test.go
+++ b/go/kbfs/libkbfs/mdcache_test.go
@@ -10,33 +10,35 @@ import (
 	"testing"
 	"time"
 
+	idutiltest "github.com/keybase/client/go/kbfs/idutil/test"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
-func testMdcacheMakeHandle(t *testing.T, n uint32) *TlfHandle {
+func testMdcacheMakeHandle(t *testing.T, n uint32) *tlfhandle.Handle {
 	id := keybase1.MakeTestUID(n).AsUserOrTeam()
 	bh, err := tlf.MakeHandle([]keybase1.UserOrTeamID{id}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	nug := testNormalizedUsernameGetter{
+	nug := idutiltest.NormalizedUsernameGetter{
 		id: kbname.NormalizedUsername(fmt.Sprintf("fake_user_%d", n)),
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(
+	h, err := tlfhandle.MakeHandle(
 		ctx, bh, bh.Type(), nil, nug, nil, keybase1.OfflineAvailability_NONE)
 	require.NoError(t, err)
 	return h
 }
 
 func testMdcachePut(t *testing.T, tlfID tlf.ID, rev kbfsmd.Revision,
-	bid kbfsmd.BranchID, h *TlfHandle, mdcache *MDCacheStandard) {
+	bid kbfsmd.BranchID, h *tlfhandle.Handle, mdcache *MDCacheStandard) {
 	rmd, err := makeInitialRootMetadata(defaultClientMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	rmd.SetRevision(rev)

--- a/go/kbfs/libkbfs/mdserver_local_config.go
+++ b/go/kbfs/libkbfs/mdserver_local_config.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 )
@@ -14,7 +15,7 @@ import (
 type mdServerLocalConfig interface {
 	Clock() Clock
 	Codec() kbfscodec.Codec
-	currentSessionGetter() CurrentSessionGetter
+	currentSessionGetter() idutil.CurrentSessionGetter
 	MetadataVersion() kbfsmd.MetadataVer
 	logMaker
 	cryptoPureGetter
@@ -27,7 +28,7 @@ type mdServerLocalConfigAdapter struct {
 	Config
 }
 
-func (ca mdServerLocalConfigAdapter) currentSessionGetter() CurrentSessionGetter {
+func (ca mdServerLocalConfigAdapter) currentSessionGetter() idutil.CurrentSessionGetter {
 	return ca.Config.KBPKI()
 }
 

--- a/go/kbfs/libkbfs/mdserver_local_config_test.go
+++ b/go/kbfs/libkbfs/mdserver_local_config_test.go
@@ -7,16 +7,17 @@ package libkbfs
 import (
 	"testing"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"golang.org/x/net/context"
 )
 
 type singleCurrentSessionGetter struct {
-	session SessionInfo
+	session idutil.SessionInfo
 }
 
 func (csg singleCurrentSessionGetter) GetCurrentSession(ctx context.Context) (
-	SessionInfo, error) {
+	idutil.SessionInfo, error) {
 	return csg.session, nil
 }
 
@@ -25,11 +26,11 @@ type testMDServerLocalConfig struct {
 	logMaker
 	clock  Clock
 	crypto cryptoPure
-	csg    CurrentSessionGetter
+	csg    idutil.CurrentSessionGetter
 }
 
 func newTestMDServerLocalConfig(
-	t *testing.T, csg CurrentSessionGetter) testMDServerLocalConfig {
+	t *testing.T, csg idutil.CurrentSessionGetter) testMDServerLocalConfig {
 	cg := newTestCodecGetter()
 	return testMDServerLocalConfig{
 		codecGetter: cg,
@@ -48,7 +49,7 @@ func (c testMDServerLocalConfig) cryptoPure() cryptoPure {
 	return c.crypto
 }
 
-func (c testMDServerLocalConfig) currentSessionGetter() CurrentSessionGetter {
+func (c testMDServerLocalConfig) currentSessionGetter() idutil.CurrentSessionGetter {
 	return c.csg
 }
 

--- a/go/kbfs/libkbfs/mdserver_remote.go
+++ b/go/kbfs/libkbfs/mdserver_remote.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/keybase/backoff"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -220,7 +221,7 @@ func (md *MDServerRemote) OnConnect(ctx context.Context,
 	pingIntervalSeconds, err := md.resetAuth(ctx, c)
 	switch err.(type) {
 	case nil:
-	case NoCurrentSessionError:
+	case idutil.NoCurrentSessionError:
 		md.log.CInfof(ctx, "Logged-out user")
 	default:
 		return err
@@ -242,8 +243,9 @@ const (
 )
 
 // resetAuth is called to reset the authorization on an MDServer
-// connection.  If this function returns NoCurrentSessionError, the
-// caller should treat this as a logged-out user.
+// connection.  If this function returns
+// idutil.NoCurrentSessionError, the caller should treat this as a
+// logged-out user.
 func (md *MDServerRemote) resetAuth(
 	ctx context.Context, c keybase1.MetadataClient) (int, error) {
 	ctx = context.WithValue(ctx, ctxMDServerResetKey, "1")
@@ -324,7 +326,7 @@ func (md *MDServerRemote) RefreshAuthToken(ctx context.Context) {
 	switch err.(type) {
 	case nil:
 		md.log.CInfof(ctx, "MDServerRemote: auth token refreshed")
-	case NoCurrentSessionError:
+	case idutil.NoCurrentSessionError:
 		md.log.CInfof(ctx,
 			"MDServerRemote: no session available, connection remains anonymous")
 	default:
@@ -693,8 +695,9 @@ func (md *MDServerRemote) GetForTLFByTime(
 
 // GetRange implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) GetRange(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision,
-	lockBeforeGet *keybase1.LockID) (rmdses []*RootMetadataSigned, err error) {
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus,
+	start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID) (
+	rmdses []*RootMetadataSigned, err error) {
 	ctx = rpc.WithFireNow(ctx)
 	md.log.LazyTrace(ctx, "MDServer: GetRange %s %s %s %d-%d", id, bid, mStatus, start, stop)
 	defer func() {

--- a/go/kbfs/libkbfs/merkle_root.go
+++ b/go/kbfs/libkbfs/merkle_root.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
@@ -35,7 +36,7 @@ type cachedMerkleRoot struct {
 type EventuallyConsistentMerkleRoot struct {
 	config  Config
 	log     logger.Logger
-	getter  merkleRootGetter
+	getter  idutil.MerkleRootGetter
 	fetcher *fetchDecider
 
 	mu     sync.RWMutex
@@ -45,7 +46,7 @@ type EventuallyConsistentMerkleRoot struct {
 // NewEventuallyConsistentMerkleRoot creates a new
 // EventuallyConsistentMerkleRoot object.
 func NewEventuallyConsistentMerkleRoot(
-	config Config, getter merkleRootGetter) *EventuallyConsistentMerkleRoot {
+	config Config, getter idutil.MerkleRootGetter) *EventuallyConsistentMerkleRoot {
 	ecmr := &EventuallyConsistentMerkleRoot{
 		config: config,
 		log:    config.MakeLogger(ECMRID),

--- a/go/kbfs/libkbfs/mocks_test.go
+++ b/go/kbfs/libkbfs/mocks_test.go
@@ -7,12 +7,14 @@ package libkbfs
 import (
 	gomock "github.com/golang/mock/gomock"
 	favorites "github.com/keybase/client/go/kbfs/favorites"
+	idutil "github.com/keybase/client/go/kbfs/idutil"
 	kbfsblock "github.com/keybase/client/go/kbfs/kbfsblock"
 	kbfscodec "github.com/keybase/client/go/kbfs/kbfscodec"
 	kbfscrypto "github.com/keybase/client/go/kbfs/kbfscrypto"
 	kbfsedits "github.com/keybase/client/go/kbfs/kbfsedits"
 	kbfsmd "github.com/keybase/client/go/kbfs/kbfsmd"
 	tlf "github.com/keybase/client/go/kbfs/tlf"
+	tlfhandle "github.com/keybase/client/go/kbfs/tlfhandle"
 	kbun "github.com/keybase/client/go/kbun"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
@@ -433,10 +435,10 @@ func (m *MockcurrentSessionGetterGetter) EXPECT() *MockcurrentSessionGetterGette
 }
 
 // CurrentSessionGetter mocks base method
-func (m *MockcurrentSessionGetterGetter) CurrentSessionGetter() CurrentSessionGetter {
+func (m *MockcurrentSessionGetterGetter) CurrentSessionGetter() idutil.CurrentSessionGetter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentSessionGetter")
-	ret0, _ := ret[0].(CurrentSessionGetter)
+	ret0, _ := ret[0].(idutil.CurrentSessionGetter)
 	return ret0
 }
 
@@ -1998,7 +2000,7 @@ func (mr *MockKBFSOpsMockRecorder) RefreshEditHistory(fav interface{}) *gomock.C
 }
 
 // GetTLFCryptKeys mocks base method
-func (m *MockKBFSOps) GetTLFCryptKeys(ctx context.Context, tlfHandle *TlfHandle) ([]kbfscrypto.TLFCryptKey, tlf.ID, error) {
+func (m *MockKBFSOps) GetTLFCryptKeys(ctx context.Context, tlfHandle *tlfhandle.Handle) ([]kbfscrypto.TLFCryptKey, tlf.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTLFCryptKeys", ctx, tlfHandle)
 	ret0, _ := ret[0].([]kbfscrypto.TLFCryptKey)
@@ -2014,7 +2016,7 @@ func (mr *MockKBFSOpsMockRecorder) GetTLFCryptKeys(ctx, tlfHandle interface{}) *
 }
 
 // GetTLFID mocks base method
-func (m *MockKBFSOps) GetTLFID(ctx context.Context, tlfHandle *TlfHandle) (tlf.ID, error) {
+func (m *MockKBFSOps) GetTLFID(ctx context.Context, tlfHandle *tlfhandle.Handle) (tlf.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTLFID", ctx, tlfHandle)
 	ret0, _ := ret[0].(tlf.ID)
@@ -2029,10 +2031,10 @@ func (mr *MockKBFSOpsMockRecorder) GetTLFID(ctx, tlfHandle interface{}) *gomock.
 }
 
 // GetTLFHandle mocks base method
-func (m *MockKBFSOps) GetTLFHandle(ctx context.Context, node Node) (*TlfHandle, error) {
+func (m *MockKBFSOps) GetTLFHandle(ctx context.Context, node Node) (*tlfhandle.Handle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTLFHandle", ctx, node)
-	ret0, _ := ret[0].(*TlfHandle)
+	ret0, _ := ret[0].(*tlfhandle.Handle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2044,7 +2046,7 @@ func (mr *MockKBFSOpsMockRecorder) GetTLFHandle(ctx, node interface{}) *gomock.C
 }
 
 // GetOrCreateRootNode mocks base method
-func (m *MockKBFSOps) GetOrCreateRootNode(ctx context.Context, h *TlfHandle, branch BranchName) (Node, EntryInfo, error) {
+func (m *MockKBFSOps) GetOrCreateRootNode(ctx context.Context, h *tlfhandle.Handle, branch BranchName) (Node, EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrCreateRootNode", ctx, h, branch)
 	ret0, _ := ret[0].(Node)
@@ -2060,7 +2062,7 @@ func (mr *MockKBFSOpsMockRecorder) GetOrCreateRootNode(ctx, h, branch interface{
 }
 
 // GetRootNode mocks base method
-func (m *MockKBFSOps) GetRootNode(ctx context.Context, h *TlfHandle, branch BranchName) (Node, EntryInfo, error) {
+func (m *MockKBFSOps) GetRootNode(ctx context.Context, h *tlfhandle.Handle, branch BranchName) (Node, EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRootNode", ctx, h, branch)
 	ret0, _ := ret[0].(Node)
@@ -2541,7 +2543,7 @@ func (mr *MockKBFSOpsMockRecorder) KickoffAllOutstandingRekeys() *gomock.Call {
 }
 
 // NewNotificationChannel mocks base method
-func (m *MockKBFSOps) NewNotificationChannel(ctx context.Context, handle *TlfHandle, convID chat1.ConversationID, channelName string) {
+func (m *MockKBFSOps) NewNotificationChannel(ctx context.Context, handle *tlfhandle.Handle, convID chat1.ConversationID, channelName string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "NewNotificationChannel", ctx, handle, convID, channelName)
 }
@@ -2553,7 +2555,7 @@ func (mr *MockKBFSOpsMockRecorder) NewNotificationChannel(ctx, handle, convID, c
 }
 
 // Reset mocks base method
-func (m *MockKBFSOps) Reset(ctx context.Context, handle *TlfHandle) error {
+func (m *MockKBFSOps) Reset(ctx context.Context, handle *tlfhandle.Handle) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reset", ctx, handle)
 	ret0, _ := ret[0].(error)
@@ -2801,10 +2803,10 @@ func (mr *MockKeybaseServiceMockRecorder) NormalizeSocialAssertion(ctx, assertio
 }
 
 // ResolveIdentifyImplicitTeam mocks base method
-func (m *MockKeybaseService) ResolveIdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, doIdentifies bool, reason string, offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error) {
+func (m *MockKeybaseService) ResolveIdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, doIdentifies bool, reason string, offline keybase1.OfflineAvailability) (idutil.ImplicitTeamInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveIdentifyImplicitTeam", ctx, assertions, suffix, tlfType, doIdentifies, reason, offline)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret0, _ := ret[0].(idutil.ImplicitTeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2860,10 +2862,10 @@ func (mr *MockKeybaseServiceMockRecorder) GetTeamSettings(ctx, teamID, offline i
 }
 
 // LoadUserPlusKeys mocks base method
-func (m *MockKeybaseService) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID, offline keybase1.OfflineAvailability) (UserInfo, error) {
+func (m *MockKeybaseService) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID, offline keybase1.OfflineAvailability) (idutil.UserInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadUserPlusKeys", ctx, uid, pollForKID, offline)
-	ret0, _ := ret[0].(UserInfo)
+	ret0, _ := ret[0].(idutil.UserInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2875,10 +2877,10 @@ func (mr *MockKeybaseServiceMockRecorder) LoadUserPlusKeys(ctx, uid, pollForKID,
 }
 
 // LoadTeamPlusKeys mocks base method
-func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole, offline keybase1.OfflineAvailability) (TeamInfo, error) {
+func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole, offline keybase1.OfflineAvailability) (idutil.TeamInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadTeamPlusKeys", ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole, offline)
-	ret0, _ := ret[0].(TeamInfo)
+	ret0, _ := ret[0].(idutil.TeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2890,10 +2892,10 @@ func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(ctx, tid, tlfType, de
 }
 
 // CurrentSession mocks base method
-func (m *MockKeybaseService) CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error) {
+func (m *MockKeybaseService) CurrentSession(ctx context.Context, sessionID int) (idutil.SessionInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentSession", ctx, sessionID)
-	ret0, _ := ret[0].(SessionInfo)
+	ret0, _ := ret[0].(idutil.SessionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3178,10 +3180,10 @@ func (mr *MockresolverMockRecorder) Resolve(ctx, assertion, offline interface{})
 }
 
 // ResolveImplicitTeam mocks base method
-func (m *Mockresolver) ResolveImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error) {
+func (m *Mockresolver) ResolveImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, offline keybase1.OfflineAvailability) (idutil.ImplicitTeamInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveImplicitTeam", ctx, assertions, suffix, tlfType, offline)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret0, _ := ret[0].(idutil.ImplicitTeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3193,10 +3195,10 @@ func (mr *MockresolverMockRecorder) ResolveImplicitTeam(ctx, assertions, suffix,
 }
 
 // ResolveImplicitTeamByID mocks base method
-func (m *Mockresolver) ResolveImplicitTeamByID(ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type, offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error) {
+func (m *Mockresolver) ResolveImplicitTeamByID(ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type, offline keybase1.OfflineAvailability) (idutil.ImplicitTeamInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveImplicitTeamByID", ctx, teamID, tlfType, offline)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret0, _ := ret[0].(idutil.ImplicitTeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3277,10 +3279,10 @@ func (mr *MockidentifierMockRecorder) Identify(ctx, assertion, reason, offline i
 }
 
 // IdentifyImplicitTeam mocks base method
-func (m *Mockidentifier) IdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, reason string, offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error) {
+func (m *Mockidentifier) IdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, reason string, offline keybase1.OfflineAvailability) (idutil.ImplicitTeamInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IdentifyImplicitTeam", ctx, assertions, suffix, tlfType, reason, offline)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret0, _ := ret[0].(idutil.ImplicitTeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3353,10 +3355,10 @@ func (m *MockCurrentSessionGetter) EXPECT() *MockCurrentSessionGetterMockRecorde
 }
 
 // GetCurrentSession mocks base method
-func (m *MockCurrentSessionGetter) GetCurrentSession(ctx context.Context) (SessionInfo, error) {
+func (m *MockCurrentSessionGetter) GetCurrentSession(ctx context.Context) (idutil.SessionInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCurrentSession", ctx)
-	ret0, _ := ret[0].(SessionInfo)
+	ret0, _ := ret[0].(idutil.SessionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3536,10 +3538,10 @@ func (m *MockKBPKI) EXPECT() *MockKBPKIMockRecorder {
 }
 
 // GetCurrentSession mocks base method
-func (m *MockKBPKI) GetCurrentSession(ctx context.Context) (SessionInfo, error) {
+func (m *MockKBPKI) GetCurrentSession(ctx context.Context) (idutil.SessionInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCurrentSession", ctx)
-	ret0, _ := ret[0].(SessionInfo)
+	ret0, _ := ret[0].(idutil.SessionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3567,10 +3569,10 @@ func (mr *MockKBPKIMockRecorder) Resolve(ctx, assertion, offline interface{}) *g
 }
 
 // ResolveImplicitTeam mocks base method
-func (m *MockKBPKI) ResolveImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error) {
+func (m *MockKBPKI) ResolveImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, offline keybase1.OfflineAvailability) (idutil.ImplicitTeamInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveImplicitTeam", ctx, assertions, suffix, tlfType, offline)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret0, _ := ret[0].(idutil.ImplicitTeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3582,10 +3584,10 @@ func (mr *MockKBPKIMockRecorder) ResolveImplicitTeam(ctx, assertions, suffix, tl
 }
 
 // ResolveImplicitTeamByID mocks base method
-func (m *MockKBPKI) ResolveImplicitTeamByID(ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type, offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error) {
+func (m *MockKBPKI) ResolveImplicitTeamByID(ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type, offline keybase1.OfflineAvailability) (idutil.ImplicitTeamInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveImplicitTeamByID", ctx, teamID, tlfType, offline)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret0, _ := ret[0].(idutil.ImplicitTeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3643,10 +3645,10 @@ func (mr *MockKBPKIMockRecorder) Identify(ctx, assertion, reason, offline interf
 }
 
 // IdentifyImplicitTeam mocks base method
-func (m *MockKBPKI) IdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, reason string, offline keybase1.OfflineAvailability) (ImplicitTeamInfo, error) {
+func (m *MockKBPKI) IdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, reason string, offline keybase1.OfflineAvailability) (idutil.ImplicitTeamInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IdentifyImplicitTeam", ctx, assertions, suffix, tlfType, reason, offline)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret0, _ := ret[0].(idutil.ImplicitTeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3972,10 +3974,10 @@ func (mr *MockKeyMetadataMockRecorder) LatestKeyGeneration() *gomock.Call {
 }
 
 // GetTlfHandle mocks base method
-func (m *MockKeyMetadata) GetTlfHandle() *TlfHandle {
+func (m *MockKeyMetadata) GetTlfHandle() *tlfhandle.Handle {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTlfHandle")
-	ret0, _ := ret[0].(*TlfHandle)
+	ret0, _ := ret[0].(*tlfhandle.Handle)
 	return ret0
 }
 
@@ -3986,7 +3988,7 @@ func (mr *MockKeyMetadataMockRecorder) GetTlfHandle() *gomock.Call {
 }
 
 // IsWriter mocks base method
-func (m *MockKeyMetadata) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, osg OfflineStatusGetter, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockKeyMetadata) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, osg idutil.OfflineStatusGetter, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, osg, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
@@ -4128,10 +4130,10 @@ func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) LatestKeyGeneration() *go
 }
 
 // GetTlfHandle mocks base method
-func (m *MockKeyMetadataWithRootDirEntry) GetTlfHandle() *TlfHandle {
+func (m *MockKeyMetadataWithRootDirEntry) GetTlfHandle() *tlfhandle.Handle {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTlfHandle")
-	ret0, _ := ret[0].(*TlfHandle)
+	ret0, _ := ret[0].(*tlfhandle.Handle)
 	return ret0
 }
 
@@ -4142,7 +4144,7 @@ func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetTlfHandle() *gomock.Ca
 }
 
 // IsWriter mocks base method
-func (m *MockKeyMetadataWithRootDirEntry) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, osg OfflineStatusGetter, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+func (m *MockKeyMetadataWithRootDirEntry) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, osg idutil.OfflineStatusGetter, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, osg, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
@@ -4686,7 +4688,7 @@ func (mr *MockMDCacheMockRecorder) MarkPutToServer(tlf, rev, bid interface{}) *g
 }
 
 // GetIDForHandle mocks base method
-func (m *MockMDCache) GetIDForHandle(handle *TlfHandle) (tlf.ID, error) {
+func (m *MockMDCache) GetIDForHandle(handle *tlfhandle.Handle) (tlf.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIDForHandle", handle)
 	ret0, _ := ret[0].(tlf.ID)
@@ -4701,7 +4703,7 @@ func (mr *MockMDCacheMockRecorder) GetIDForHandle(handle interface{}) *gomock.Ca
 }
 
 // PutIDForHandle mocks base method
-func (m *MockMDCache) PutIDForHandle(handle *TlfHandle, id tlf.ID) error {
+func (m *MockMDCache) PutIDForHandle(handle *tlfhandle.Handle, id tlf.ID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutIDForHandle", handle, id)
 	ret0, _ := ret[0].(error)
@@ -4715,7 +4717,7 @@ func (mr *MockMDCacheMockRecorder) PutIDForHandle(handle, id interface{}) *gomoc
 }
 
 // ChangeHandleForID mocks base method
-func (m *MockMDCache) ChangeHandleForID(oldHandle, newHandle *TlfHandle) {
+func (m *MockMDCache) ChangeHandleForID(oldHandle, newHandle *tlfhandle.Handle) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ChangeHandleForID", oldHandle, newHandle)
 }
@@ -6336,7 +6338,7 @@ func (m *MocktlfIDGetter) EXPECT() *MocktlfIDGetterMockRecorder {
 }
 
 // GetIDForHandle mocks base method
-func (m *MocktlfIDGetter) GetIDForHandle(ctx context.Context, handle *TlfHandle) (tlf.ID, error) {
+func (m *MocktlfIDGetter) GetIDForHandle(ctx context.Context, handle *tlfhandle.Handle) (tlf.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIDForHandle", ctx, handle)
 	ret0, _ := ret[0].(tlf.ID)
@@ -6351,7 +6353,7 @@ func (mr *MocktlfIDGetterMockRecorder) GetIDForHandle(ctx, handle interface{}) *
 }
 
 // ValidateLatestHandleNotFinal mocks base method
-func (m *MocktlfIDGetter) ValidateLatestHandleNotFinal(ctx context.Context, h *TlfHandle) (bool, error) {
+func (m *MocktlfIDGetter) ValidateLatestHandleNotFinal(ctx context.Context, h *tlfhandle.Handle) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateLatestHandleNotFinal", ctx, h)
 	ret0, _ := ret[0].(bool)
@@ -6389,7 +6391,7 @@ func (m *MockMDOps) EXPECT() *MockMDOpsMockRecorder {
 }
 
 // GetIDForHandle mocks base method
-func (m *MockMDOps) GetIDForHandle(ctx context.Context, handle *TlfHandle) (tlf.ID, error) {
+func (m *MockMDOps) GetIDForHandle(ctx context.Context, handle *tlfhandle.Handle) (tlf.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIDForHandle", ctx, handle)
 	ret0, _ := ret[0].(tlf.ID)
@@ -6404,7 +6406,7 @@ func (mr *MockMDOpsMockRecorder) GetIDForHandle(ctx, handle interface{}) *gomock
 }
 
 // ValidateLatestHandleNotFinal mocks base method
-func (m *MockMDOps) ValidateLatestHandleNotFinal(ctx context.Context, h *TlfHandle) (bool, error) {
+func (m *MockMDOps) ValidateLatestHandleNotFinal(ctx context.Context, h *tlfhandle.Handle) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateLatestHandleNotFinal", ctx, h)
 	ret0, _ := ret[0].(bool)
@@ -8417,7 +8419,7 @@ func (mr *MockObserverMockRecorder) BatchChanges(ctx, changes, allAffectedNodeID
 }
 
 // TlfHandleChange mocks base method
-func (m *MockObserver) TlfHandleChange(ctx context.Context, newHandle *TlfHandle) {
+func (m *MockObserver) TlfHandleChange(ctx context.Context, newHandle *tlfhandle.Handle) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "TlfHandleChange", ctx, newHandle)
 }
@@ -9326,10 +9328,10 @@ func (mr *MockConfigMockRecorder) Signer() *gomock.Call {
 }
 
 // CurrentSessionGetter mocks base method
-func (m *MockConfig) CurrentSessionGetter() CurrentSessionGetter {
+func (m *MockConfig) CurrentSessionGetter() idutil.CurrentSessionGetter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentSessionGetter")
-	ret0, _ := ret[0].(CurrentSessionGetter)
+	ret0, _ := ret[0].(idutil.CurrentSessionGetter)
 	return ret0
 }
 
@@ -11125,10 +11127,10 @@ func (mr *MockChatMockRecorder) SendTextMessage(ctx, tlfName, tlfType, convID, b
 }
 
 // GetGroupedInbox mocks base method
-func (m *MockChat) GetGroupedInbox(ctx context.Context, chatType chat1.TopicType, maxChats int) ([]*TlfHandle, error) {
+func (m *MockChat) GetGroupedInbox(ctx context.Context, chatType chat1.TopicType, maxChats int) ([]*tlfhandle.Handle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGroupedInbox", ctx, chatType, maxChats)
-	ret0, _ := ret[0].([]*TlfHandle)
+	ret0, _ := ret[0].([]*tlfhandle.Handle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go/kbfs/libkbfs/observer_list.go
+++ b/go/kbfs/libkbfs/observer_list.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"sync"
 
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"golang.org/x/net/context"
 )
 
@@ -58,7 +59,7 @@ func (ol *observerList) batchChanges(
 }
 
 func (ol *observerList) tlfHandleChange(
-	ctx context.Context, newHandle *TlfHandle) {
+	ctx context.Context, newHandle *tlfhandle.Handle) {
 	ol.lock.RLock()
 	defer ol.lock.RUnlock()
 	for _, o := range ol.observers {

--- a/go/kbfs/libkbfs/path.go
+++ b/go/kbfs/libkbfs/path.go
@@ -9,68 +9,8 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 )
-
-// PathType describes the types for different paths
-type PathType string
-
-const (
-	// KeybasePathType is the keybase root (like /keybase)
-	KeybasePathType PathType = "keybase"
-	// PublicPathType is the keybase public folder list (like /keybase/public)
-	PublicPathType PathType = "public"
-	// PrivatePathType is the keybase private folder list (like
-	// /keybase/private)
-	PrivatePathType PathType = "private"
-	// SingleTeamPathType is the keybase team folder list (like /keybase/teams)
-	SingleTeamPathType PathType = "team"
-)
-
-// BuildCanonicalPath returns a canonical path for a path components.
-// This a canonical path and may need to be converted to a platform
-// specific path, for example, on Windows, this might correspond to
-// k:\private\username.
-func BuildCanonicalPath(pathType PathType, paths ...string) string {
-	var prefix string
-	switch pathType {
-	case KeybasePathType:
-		prefix = "/" + string(KeybasePathType)
-	default:
-		prefix = "/" + string(KeybasePathType) + "/" + string(pathType)
-	}
-	pathElements := []string{prefix}
-	for _, p := range paths {
-		if p != "" {
-			pathElements = append(pathElements, p)
-		}
-	}
-	return strings.Join(pathElements, "/")
-}
-
-func buildCanonicalPathForTlfType(t tlf.Type, paths ...string) string {
-	var pathType PathType
-	switch t {
-	case tlf.Private:
-		pathType = PrivatePathType
-	case tlf.Public:
-		pathType = PublicPathType
-	case tlf.SingleTeam:
-		pathType = SingleTeamPathType
-	default:
-		panic(fmt.Sprintf("Unknown tlf path type: %d", t))
-	}
-
-	return BuildCanonicalPath(pathType, paths...)
-}
-
-// buildCanonicalPathForTlfName returns a canonical path for a tlf.
-func buildCanonicalPathForTlfName(t tlf.Type, tlfName tlf.CanonicalName) string {
-	return buildCanonicalPathForTlfType(t, string(tlfName))
-}
-
-func buildCanonicalPathForTlf(tlf tlf.ID, paths ...string) string {
-	return buildCanonicalPathForTlfType(tlf.Type(), paths...)
-}
 
 // path represents the full KBFS path to a particular location, so
 // that a flush can traverse backwards and fix up ids along the way.
@@ -159,7 +99,7 @@ func (p path) String() string {
 // letter on Windows. It also, might need conversion if on a different run mode,
 // for example, /keybase.staging on Unix type platforms.
 func (p path) CanonicalPathString() string {
-	return buildCanonicalPathForTlf(p.Tlf, p.String())
+	return tlfhandle.BuildCanonicalPathForTlf(p.Tlf, p.String())
 }
 
 // parentPath returns a new Path representing the parent subdirectory

--- a/go/kbfs/libkbfs/root_metadata.go
+++ b/go/kbfs/libkbfs/root_metadata.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
@@ -118,7 +120,7 @@ type RootMetadata struct {
 
 	// The TLF handle for this MD. May be nil if this object was
 	// deserialized (more common on the server side).
-	tlfHandle *TlfHandle
+	tlfHandle *tlfhandle.Handle
 }
 
 var _ KeyMetadata = (*RootMetadata)(nil)
@@ -126,7 +128,7 @@ var _ KeyMetadata = (*RootMetadata)(nil)
 // makeRootMetadata makes a RootMetadata object from the given
 // parameters.
 func makeRootMetadata(bareMd kbfsmd.MutableRootMetadata,
-	extra kbfsmd.ExtraMetadata, handle *TlfHandle) *RootMetadata {
+	extra kbfsmd.ExtraMetadata, handle *tlfhandle.Handle) *RootMetadata {
 	if bareMd == nil {
 		panic("nil kbfsmd.MutableRootMetadata")
 	}
@@ -146,7 +148,7 @@ func makeRootMetadata(bareMd kbfsmd.MutableRootMetadata,
 // and handle. Note that if the given ID/handle are private, rekeying
 // must be done separately.
 func makeInitialRootMetadata(
-	ver kbfsmd.MetadataVer, tlfID tlf.ID, h *TlfHandle) (*RootMetadata, error) {
+	ver kbfsmd.MetadataVer, tlfID tlf.ID, h *tlfhandle.Handle) (*RootMetadata, error) {
 	bh, err := h.ToBareHandle()
 	if err != nil {
 		return nil, err
@@ -207,7 +209,7 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 		}
 	}
 
-	handleCopy := md.tlfHandle.deepCopy()
+	handleCopy := md.tlfHandle.DeepCopy()
 
 	rmd := makeRootMetadata(brmdCopy, extraCopy, handleCopy)
 
@@ -229,8 +231,8 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 // with the revision incremented and a correct backpointer.
 func (md *RootMetadata) MakeSuccessor(
 	ctx context.Context, latestMDVer kbfsmd.MetadataVer, codec kbfscodec.Codec,
-	keyManager KeyManager, merkleGetter merkleRootGetter,
-	teamKeyer teamKeysGetter, osg OfflineStatusGetter, mdID kbfsmd.ID,
+	keyManager KeyManager, merkleGetter idutil.MerkleRootGetter,
+	teamKeyer teamKeysGetter, osg idutil.OfflineStatusGetter, mdID kbfsmd.ID,
 	isWriter bool) (*RootMetadata, error) {
 	if mdID == (kbfsmd.ID{}) {
 		return nil, errors.New("Empty MdID in MakeSuccessor")
@@ -250,7 +252,7 @@ func (md *RootMetadata) MakeSuccessor(
 		return nil, err
 	}
 
-	handleCopy := md.tlfHandle.deepCopy()
+	handleCopy := md.tlfHandle.DeepCopy()
 
 	newMd := makeRootMetadata(brmdCopy, extraCopy, handleCopy)
 	if err := kbfscodec.Update(codec, &newMd.data, md.data); err != nil {
@@ -299,17 +301,18 @@ func (md *RootMetadata) MakeSuccessor(
 // plus it changes the handle.  (The caller is responsible for
 // ensuring that the handle change is valid.)
 func (md *RootMetadata) MakeSuccessorWithNewHandle(
-	ctx context.Context, newHandle *TlfHandle, latestMDVer kbfsmd.MetadataVer,
-	codec kbfscodec.Codec, keyManager KeyManager, merkleGetter merkleRootGetter,
-	teamKeyer teamKeysGetter, osg OfflineStatusGetter, mdID kbfsmd.ID,
-	isWriter bool) (*RootMetadata, error) {
+	ctx context.Context, newHandle *tlfhandle.Handle, latestMDVer kbfsmd.MetadataVer,
+	codec kbfscodec.Codec, keyManager KeyManager,
+	merkleGetter idutil.MerkleRootGetter, teamKeyer teamKeysGetter,
+	osg idutil.OfflineStatusGetter, mdID kbfsmd.ID, isWriter bool) (
+	*RootMetadata, error) {
 	mdCopy, err := md.deepCopy(codec)
 	if err != nil {
 		return nil, err
 	}
 
 	mdCopy.extra = nil
-	mdCopy.tlfHandle = newHandle.deepCopy()
+	mdCopy.tlfHandle = newHandle.DeepCopy()
 	mdCopy.SetWriters(newHandle.ResolvedWriters())
 	// Readers are not tracked explicitly in the MD, but their key
 	// bundles are cleared out with the `ClearForV4Migration()` call
@@ -324,7 +327,7 @@ func (md *RootMetadata) MakeSuccessorWithNewHandle(
 }
 
 // GetTlfHandle returns the TlfHandle for this RootMetadata.
-func (md *RootMetadata) GetTlfHandle() *TlfHandle {
+func (md *RootMetadata) GetTlfHandle() *tlfhandle.Handle {
 	if md.tlfHandle == nil {
 		panic(fmt.Sprintf("RootMetadata %v with no handle", md))
 	}
@@ -409,7 +412,7 @@ func (md *RootMetadata) SetLastGCRevision(rev kbfsmd.Revision) {
 // updateFromTlfHandle updates the current RootMetadata's fields to
 // reflect the given handle, which must be the result of running the
 // current handle with ResolveAgain().
-func (md *RootMetadata) updateFromTlfHandle(newHandle *TlfHandle) error {
+func (md *RootMetadata) updateFromTlfHandle(newHandle *tlfhandle.Handle) error {
 	// TODO: Strengthen check, e.g. make sure every writer/reader
 	// in the old handle is also a writer/reader of the new
 	// handle.
@@ -906,7 +909,7 @@ func (md *RootMetadata) GetHistoricTLFCryptKey(
 // right now.  Implements the KeyMetadata interface for RootMetadata.
 func (md *RootMetadata) IsWriter(
 	ctx context.Context, checker kbfsmd.TeamMembershipChecker,
-	osg OfflineStatusGetter, uid keybase1.UID,
+	osg idutil.OfflineStatusGetter, uid keybase1.UID,
 	verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	h := md.GetTlfHandle()
 	return IsWriterFromHandle(ctx, h, checker, osg, uid, verifyingKey)
@@ -916,7 +919,7 @@ func (md *RootMetadata) IsWriter(
 // right now.
 func (md *RootMetadata) IsReader(
 	ctx context.Context, checker kbfsmd.TeamMembershipChecker,
-	osg OfflineStatusGetter, uid keybase1.UID) (bool, error) {
+	osg idutil.OfflineStatusGetter, uid keybase1.UID) (bool, error) {
 	h := md.GetTlfHandle()
 	return isReaderFromHandle(ctx, h, checker, osg, uid)
 }

--- a/go/kbfs/libkbfs/test_stallers.go
+++ b/go/kbfs/libkbfs/test_stallers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
@@ -416,7 +417,7 @@ func (m *stallingMDOps) maybeStall(ctx context.Context, opName StallableMDOp) {
 }
 
 func (m *stallingMDOps) GetIDForHandle(
-	ctx context.Context, handle *TlfHandle) (tlfID tlf.ID, err error) {
+	ctx context.Context, handle *tlfhandle.Handle) (tlfID tlf.ID, err error) {
 	return m.delegate.GetIDForHandle(ctx, handle)
 }
 
@@ -456,7 +457,7 @@ func (m *stallingMDOps) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (
 }
 
 func (m *stallingMDOps) ValidateLatestHandleNotFinal(
-	ctx context.Context, h *TlfHandle) (b bool, err error) {
+	ctx context.Context, h *tlfhandle.Handle) (b bool, err error) {
 	m.maybeStall(ctx, StallableMDValidateLatestHandleNotFinal)
 	err = runWithContextCheck(ctx, func(ctx context.Context) error {
 		var errValidateLatestHandleNotFinal error

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/keybase/backoff"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
@@ -18,6 +19,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -41,8 +43,8 @@ type tlfJournalConfig interface {
 	encryptionKeyGetter() encryptionKeyGetter
 	mdDecryptionKeyGetter() mdDecryptionKeyGetter
 	MDServer() MDServer
-	usernameGetter() normalizedUsernameGetter
-	resolver() resolver
+	usernameGetter() idutil.NormalizedUsernameGetter
+	resolver() idutil.Resolver
 	MakeLogger(module string) logger.Logger
 	diskLimitTimeout() time.Duration
 	teamMembershipChecker() kbfsmd.TeamMembershipChecker
@@ -64,11 +66,11 @@ func (ca tlfJournalConfigAdapter) mdDecryptionKeyGetter() mdDecryptionKeyGetter 
 	return ca.Config.KeyManager()
 }
 
-func (ca tlfJournalConfigAdapter) usernameGetter() normalizedUsernameGetter {
+func (ca tlfJournalConfigAdapter) usernameGetter() idutil.NormalizedUsernameGetter {
 	return ca.Config.KBPKI()
 }
 
-func (ca tlfJournalConfigAdapter) resolver() resolver {
+func (ca tlfJournalConfigAdapter) resolver() idutil.Resolver {
 	return ca.Config.KBPKI()
 }
 
@@ -1727,9 +1729,9 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 		return nil, err
 	}
 
-	handle, err := MakeTlfHandle(
+	handle, err := tlfhandle.MakeHandle(
 		ctx, ibrmdBareHandle, j.tlfID.Type(), j.config.resolver(),
-		j.config.usernameGetter(), constIDGetter{j.tlfID},
+		j.config.usernameGetter(), tlfhandle.ConstIDGetter{ID: j.tlfID},
 		j.config.OfflineAvailabilityForID(j.tlfID))
 	if err != nil {
 		return nil, err

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
@@ -87,7 +88,7 @@ type testTLFJournalConfig struct {
 	uid          keybase1.UID
 	verifyingKey kbfscrypto.VerifyingKey
 	ekg          singleEncryptionKeyGetter
-	nug          normalizedUsernameGetter
+	nug          idutil.NormalizedUsernameGetter
 	mdserver     MDServer
 	dlTimeout    time.Duration
 }
@@ -136,11 +137,11 @@ func (c testTLFJournalConfig) mdDecryptionKeyGetter() mdDecryptionKeyGetter {
 	return c.ekg
 }
 
-func (c testTLFJournalConfig) usernameGetter() normalizedUsernameGetter {
+func (c testTLFJournalConfig) usernameGetter() idutil.NormalizedUsernameGetter {
 	return c.nug
 }
 
-func (c testTLFJournalConfig) resolver() resolver {
+func (c testTLFJournalConfig) resolver() idutil.Resolver {
 	return nil
 }
 
@@ -228,7 +229,7 @@ func setupTLFJournalTest(
 	ekg := singleEncryptionKeyGetter{kbfscrypto.MakeTLFCryptKey([32]byte{0x1})}
 
 	cig := singleCurrentSessionGetter{
-		SessionInfo{
+		idutil.SessionInfo{
 			Name:         "fake_user",
 			UID:          uid,
 			VerifyingKey: verifyingKey,

--- a/go/kbfs/libkbfs/unflushed_path_cache.go
+++ b/go/kbfs/libkbfs/unflushed_path_cache.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
@@ -156,7 +157,7 @@ type unflushedPathMDInfo struct {
 // blocks will need to be fetched.
 func addUnflushedPaths(ctx context.Context,
 	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
-	log logger.Logger, osg OfflineStatusGetter, mdInfos []unflushedPathMDInfo,
+	log logger.Logger, osg idutil.OfflineStatusGetter, mdInfos []unflushedPathMDInfo,
 	cpp chainsPathPopulator, unflushedPaths unflushedPathsMap) error {
 	// Make chains over the entire range to get the unflushed files.
 	chains := newCRChainsEmpty()
@@ -235,7 +236,7 @@ func addUnflushedPaths(ctx context.Context,
 // given revision.
 func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
 	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
-	log logger.Logger, osg OfflineStatusGetter, mdInfo unflushedPathMDInfo) (
+	log logger.Logger, osg idutil.OfflineStatusGetter, mdInfo unflushedPathMDInfo) (
 	unflushedPathsPerRevMap, error) {
 	cpp := func() chainsPathPopulator {
 		upc.lock.Lock()
@@ -365,7 +366,7 @@ func reinitUpcCache(revision kbfsmd.Revision,
 // unflushed path map.
 func (upc *unflushedPathCache) initialize(ctx context.Context,
 	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
-	log logger.Logger, osg OfflineStatusGetter, cpp chainsPathPopulator,
+	log logger.Logger, osg idutil.OfflineStatusGetter, cpp chainsPathPopulator,
 	mdInfos []unflushedPathMDInfo) (unflushedPathsMap, bool, error) {
 	// First get all the paths for the given range.  On the first try
 	unflushedPaths := make(unflushedPathsMap)

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/env"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libcontext"
@@ -22,6 +23,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libhttpserver"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -67,11 +69,11 @@ var errNoSuchHandle = simpleFSError{"No such handle"}
 var errNoResult = simpleFSError{"Async result not found"}
 
 type newFSFunc func(
-	context.Context, libkbfs.Config, *libkbfs.TlfHandle, libkbfs.BranchName,
+	context.Context, libkbfs.Config, *tlfhandle.Handle, libkbfs.BranchName,
 	string, bool) (billy.Filesystem, error)
 
 func defaultNewFS(ctx context.Context, config libkbfs.Config,
-	tlfHandle *libkbfs.TlfHandle, branch libkbfs.BranchName, subdir string,
+	tlfHandle *tlfhandle.Handle, branch libkbfs.BranchName, subdir string,
 	create bool) (
 	billy.Filesystem, error) {
 	maker := libfs.NewFS
@@ -206,7 +208,7 @@ func remoteTlfAndPath(path keybase1.Path) (
 }
 
 func (k *SimpleFS) branchNameFromPath(
-	ctx context.Context, tlfHandle *libkbfs.TlfHandle, path keybase1.Path) (
+	ctx context.Context, tlfHandle *tlfhandle.Handle, path keybase1.Path) (
 	libkbfs.BranchName, error) {
 	pt, err := path.PathType()
 	if err != nil {
@@ -348,7 +350,7 @@ func (k *SimpleFS) favoriteList(ctx context.Context, path keybase1.Path, t tlf.T
 		res[len(res)-1].Name = string(pname)
 		res[len(res)-1].DirentType = deTy2Ty(libkbfs.Dir)
 
-		handle, err := libkbfs.ParseTlfHandlePreferredQuick(
+		handle, err := tlfhandle.ParseHandlePreferredQuick(
 			ctx, k.config.KBPKI(), k.config, string(pname), t)
 		if err != nil {
 			k.log.Errorf("ParseTlfHandlePreferredQuick: %s %q %v", t, pname, err)
@@ -1174,7 +1176,7 @@ func (k *SimpleFS) doRemove(
 
 func (k *SimpleFS) pathsForSameTlfMove(
 	ctx context.Context, src, dst keybase1.Path) (
-	sameTlf bool, srcPath, dstPath string, tlfHandle *libkbfs.TlfHandle,
+	sameTlf bool, srcPath, dstPath string, tlfHandle *tlfhandle.Handle,
 	err error) {
 	srcType, err := src.PathType()
 	if err != nil {
@@ -1549,7 +1551,7 @@ func (k *SimpleFS) SimpleFSRemove(ctx context.Context,
 // SimpleFSStat - Get info about file
 func (k *SimpleFS) SimpleFSStat(ctx context.Context, arg keybase1.SimpleFSStatArg) (de keybase1.Dirent, err error) {
 	if arg.IdentifyBehavior != nil {
-		ctx, err = libkbfs.MakeExtendedIdentify(ctx, *arg.IdentifyBehavior)
+		ctx, err = tlfhandle.MakeExtendedIdentify(ctx, *arg.IdentifyBehavior)
 		if err != nil {
 			return keybase1.Dirent{}, err
 		}
@@ -2039,7 +2041,7 @@ func (k *SimpleFS) SimpleFSGetHTTPAddressAndToken(ctx context.Context) (
 // SimpleFSUserEditHistory returns the edit history for the logged-in user.
 func (k *SimpleFS) SimpleFSUserEditHistory(ctx context.Context) (
 	res []keybase1.FSFolderEditHistory, err error) {
-	session, err := libkbfs.GetCurrentSessionIfPossible(
+	session, err := idutil.GetCurrentSessionIfPossible(
 		ctx, k.config.KBPKI(), true)
 	// Return empty history if we are not logged in.
 	if err != nil {
@@ -2111,7 +2113,7 @@ func (k *SimpleFS) BatchChanges(
 }
 
 // TlfHandleChange implements the libkbfs.Observer interface for SimpleFS.
-func (k *SimpleFS) TlfHandleChange(_ context.Context, _ *libkbfs.TlfHandle) {
+func (k *SimpleFS) TlfHandleChange(_ context.Context, _ *tlfhandle.Handle) {
 	// TODO: the GUI might eventually care about a handle change.
 }
 

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
@@ -220,7 +221,7 @@ func TestList(t *testing.T) {
 	testList(t, ctx, sfs, path1)
 
 	t.Log("Shouldn't have created the TLF")
-	h, err := libkbfs.ParseTlfHandle(
+	h, err := tlfhandle.ParseHandle(
 		ctx, config.KBPKI(), config.MDOps(), config, "jdoe", tlf.Private)
 	require.NoError(t, err)
 	rootNode, _, err := config.KBFSOps().GetRootNode(
@@ -721,7 +722,7 @@ type fsBlockerMaker struct {
 
 func (maker fsBlockerMaker) makeNewBlocker(
 	ctx context.Context, config libkbfs.Config,
-	tlfHandle *libkbfs.TlfHandle, branch libkbfs.BranchName, subdir string,
+	tlfHandle *tlfhandle.Handle, branch libkbfs.BranchName, subdir string,
 	create bool) (billy.Filesystem, error) {
 	fsMaker := libfs.NewFS
 	if !create {

--- a/go/kbfs/test/engine_libkbfs.go
+++ b/go/kbfs/test/engine_libkbfs.go
@@ -11,12 +11,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -203,16 +205,16 @@ func (k *LibKBFS) GetUID(u User) (uid keybase1.UID) {
 
 func parseTlfHandle(
 	ctx context.Context, kbpki libkbfs.KBPKI, mdOps libkbfs.MDOps,
-	osg libkbfs.OfflineStatusGetter, tlfName string, t tlf.Type) (
-	h *libkbfs.TlfHandle, err error) {
+	osg idutil.OfflineStatusGetter, tlfName string, t tlf.Type) (
+	h *tlfhandle.Handle, err error) {
 	// Limit to one non-canonical name for now.
 outer:
 	for i := 0; i < 2; i++ {
-		h, err = libkbfs.ParseTlfHandle(ctx, kbpki, mdOps, osg, tlfName, t)
+		h, err = tlfhandle.ParseHandle(ctx, kbpki, mdOps, osg, tlfName, t)
 		switch err := errors.Cause(err).(type) {
 		case nil:
 			break outer
-		case libkbfs.TlfNameNotCanonical:
+		case idutil.TlfNameNotCanonical:
 			tlfName = err.NameToTry
 		default:
 			return nil, err
@@ -836,7 +838,7 @@ func (k *LibKBFS) UserEditHistory(u User) (
 
 	ctx, cancel := k.newContext(u)
 	defer cancel()
-	session, err := libkbfs.GetCurrentSessionIfPossible(
+	session, err := idutil.GetCurrentSessionIfPossible(
 		ctx, config.KBPKI(), true)
 	if err != nil {
 		return nil, err

--- a/go/kbfs/tlfhandle/const_id_getter.go
+++ b/go/kbfs/tlfhandle/const_id_getter.go
@@ -1,0 +1,31 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package tlfhandle
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/kbfs/tlf"
+)
+
+// ConstIDGetter is an IDGetter that always returns the same TLF ID.
+type ConstIDGetter struct {
+	ID tlf.ID
+}
+
+var _ IDGetter = ConstIDGetter{}
+
+// GetIDForHandle implements the IDGetter interface for ConstIDGetter.
+func (c ConstIDGetter) GetIDForHandle(_ context.Context, _ *Handle) (
+	tlf.ID, error) {
+	return c.ID, nil
+}
+
+// ValidateLatestHandleNotFinal implements the IDGetter interface for
+// ConstIDGetter.
+func (c ConstIDGetter) ValidateLatestHandleNotFinal(
+	_ context.Context, _ *Handle) (bool, error) {
+	return true, nil
+}

--- a/go/kbfs/tlfhandle/errors.go
+++ b/go/kbfs/tlfhandle/errors.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package tlfhandle
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/tlf"
+	kbname "github.com/keybase/client/go/kbun"
+)
+
+// NoSuchNameError indicates that the user tried to access a TLF that
+// doesn't exist.
+type NoSuchNameError struct {
+	Name string
+}
+
+// Error implements the error interface for NoSuchNameError
+func (e NoSuchNameError) Error() string {
+	return fmt.Sprintf("%s doesn't exist", e.Name)
+}
+
+// HandleFinalizedError is returned when something attempts to modify
+// a finalized TLF handle.
+type HandleFinalizedError struct {
+}
+
+// Error implements the error interface for HandleFinalizedError.
+func (e HandleFinalizedError) Error() string {
+	return "Attempt to modify finalized TLF handle"
+}
+
+// HandleMismatchError indicates an inconsistent or unverifiable MD object
+// for the given top-level folder.
+type HandleMismatchError struct {
+	Revision kbfsmd.Revision
+	Dir      string
+	TlfID    tlf.ID
+	Err      error
+}
+
+// Error implements the error interface for HandleMismatchError
+func (e HandleMismatchError) Error() string {
+	return fmt.Sprintf("Could not verify metadata (revision=%d) for directory %s (id=%s): %s",
+		e.Revision, e.Dir, e.TlfID, e.Err)
+}
+
+// ReadAccessError indicates that the user tried to read from a
+// top-level folder without read permission.
+type ReadAccessError struct {
+	User     kbname.NormalizedUsername
+	Filename string
+	Tlf      tlf.CanonicalName
+	Type     tlf.Type
+}
+
+// Error implements the error interface for ReadAccessError
+func (e ReadAccessError) Error() string {
+	return fmt.Sprintf("%s does not have read access to directory %s",
+		e.User, BuildCanonicalPathForTlfName(e.Type, e.Tlf))
+}
+
+// NewReadAccessError constructs a ReadAccessError for the given
+// directory and user.
+func NewReadAccessError(h *Handle, username kbname.NormalizedUsername, filename string) error {
+	tlfname := h.GetCanonicalName()
+	return ReadAccessError{
+		User:     username,
+		Filename: filename,
+		Tlf:      tlfname,
+		Type:     h.Type(),
+	}
+}
+
+// WriteAccessError indicates an error when trying to write a file
+type WriteAccessError struct {
+	User     kbname.NormalizedUsername
+	Filename string
+	Tlf      tlf.CanonicalName
+	Type     tlf.Type
+}
+
+// Error implements the error interface for WriteAccessError
+func (e WriteAccessError) Error() string {
+	if e.Tlf != "" {
+		return fmt.Sprintf("%s does not have write access to directory %s",
+			e.User, BuildCanonicalPathForTlfName(e.Type, e.Tlf))
+	}
+	return fmt.Sprintf("%s does not have write access to %s", e.User, e.Filename)
+}
+
+// NewWriteAccessError is an access error trying to write a file
+func NewWriteAccessError(h *Handle, username kbname.NormalizedUsername, filename string) error {
+	tlfName := tlf.CanonicalName("")
+	t := tlf.Private
+	if h != nil {
+		tlfName = h.GetCanonicalName()
+		t = h.Type()
+	}
+	return WriteAccessError{
+		User:     username,
+		Filename: filename,
+		Tlf:      tlfName,
+		Type:     t,
+	}
+}

--- a/go/kbfs/tlfhandle/handle.go
+++ b/go/kbfs/tlfhandle/handle.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD
 // license that can be found in the LICENSE file.
 
-package libkbfs
+package tlfhandle
 
 // This file has the type for TlfHandles and offline functionality.
 
@@ -12,8 +12,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbfs/favorites"
+	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
@@ -22,10 +22,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-// TlfHandle contains all the info in a tlf.Handle as well as
+// Handle contains all the info in a tlf.Handle as well as
 // additional info. This doesn't embed tlf.Handle to avoid having to
 // keep track of data in multiple places.
-type TlfHandle struct {
+type Handle struct {
 	// If this is not Private, resolvedReaders and unresolvedReaders
 	// should both be nil.
 	tlfType         tlf.Type
@@ -48,15 +48,32 @@ type TlfHandle struct {
 	tlfID tlf.ID
 }
 
+// NewHandle returns a simple new Handle based on the given fields.
+// This is probably most useful for testing.
+func NewHandle(
+	ty tlf.Type,
+	resolvedWriters map[keybase1.UserOrTeamID]kbname.NormalizedUsername,
+	unresolvedWriters, unresolvedReaders []keybase1.SocialAssertion,
+	name tlf.CanonicalName, tlfID tlf.ID) *Handle {
+	return &Handle{
+		tlfType:           ty,
+		resolvedWriters:   resolvedWriters,
+		unresolvedWriters: unresolvedWriters,
+		unresolvedReaders: unresolvedReaders,
+		name:              name,
+		tlfID:             tlfID,
+	}
+}
+
 // Type returns the type of the TLF this TlfHandle represents.
-func (h TlfHandle) Type() tlf.Type {
+func (h Handle) Type() tlf.Type {
 	return h.tlfType
 }
 
 // IsBackedByTeam returns true if h represents a TLF backed by a team. It could
 // be either a SingleTeam TLF or a private/public TLF backed by an implicit
 // team.
-func (h TlfHandle) IsBackedByTeam() bool {
+func (h Handle) IsBackedByTeam() bool {
 	if len(h.resolvedWriters) != 1 ||
 		len(h.resolvedReaders) != 0 ||
 		len(h.unresolvedReaders) != 0 ||
@@ -67,7 +84,7 @@ func (h TlfHandle) IsBackedByTeam() bool {
 }
 
 // TypeForKeying returns the keying type for the handle h.
-func (h TlfHandle) TypeForKeying() tlf.KeyingType {
+func (h Handle) TypeForKeying() tlf.KeyingType {
 	if h.IsBackedByTeam() {
 		return tlf.TeamKeying
 	}
@@ -77,13 +94,13 @@ func (h TlfHandle) TypeForKeying() tlf.KeyingType {
 // TlfID returns the TLF ID corresponding to this handle, if it's
 // known.  If it's wasn't known at the time the handle was
 // constructed, tlf.NullID is returned.
-func (h TlfHandle) TlfID() tlf.ID {
+func (h Handle) TlfID() tlf.ID {
 	return h.tlfID
 }
 
 // IsWriter returns whether or not the given user is a writer for the
 // top-level folder represented by this TlfHandle.
-func (h TlfHandle) IsWriter(user keybase1.UID) bool {
+func (h Handle) IsWriter(user keybase1.UID) bool {
 	// TODO(KBFS-2185) relax this?
 	if h.TypeForKeying() == tlf.TeamKeying {
 		panic("Can't check whether a user is a writer on a team TLF")
@@ -94,7 +111,7 @@ func (h TlfHandle) IsWriter(user keybase1.UID) bool {
 
 // IsReader returns whether or not the given user is a reader for the
 // top-level folder represented by this TlfHandle.
-func (h TlfHandle) IsReader(user keybase1.UID) bool {
+func (h Handle) IsReader(user keybase1.UID) bool {
 	// TODO(KBFS-2185) relax this?
 	if h.TypeForKeying() == tlf.TeamKeying {
 		panic("Can't check whether a user is a reader on a team TLF")
@@ -107,7 +124,7 @@ func (h TlfHandle) IsReader(user keybase1.UID) bool {
 }
 
 // ResolvedUsersMap returns a map of resolved users from uid to usernames.
-func (h TlfHandle) ResolvedUsersMap() map[keybase1.UserOrTeamID]kbname.NormalizedUsername {
+func (h Handle) ResolvedUsersMap() map[keybase1.UserOrTeamID]kbname.NormalizedUsername {
 	m := make(map[keybase1.UserOrTeamID]kbname.NormalizedUsername,
 		len(h.resolvedReaders)+len(h.resolvedWriters))
 	for k, v := range h.resolvedReaders {
@@ -119,7 +136,7 @@ func (h TlfHandle) ResolvedUsersMap() map[keybase1.UserOrTeamID]kbname.Normalize
 	return m
 }
 
-func (h TlfHandle) unsortedResolvedWriters() []keybase1.UserOrTeamID {
+func (h Handle) unsortedResolvedWriters() []keybase1.UserOrTeamID {
 	if len(h.resolvedWriters) == 0 {
 		return nil
 	}
@@ -132,7 +149,7 @@ func (h TlfHandle) unsortedResolvedWriters() []keybase1.UserOrTeamID {
 
 // ResolvedWriters returns the handle's resolved writer IDs in sorted
 // order.
-func (h TlfHandle) ResolvedWriters() []keybase1.UserOrTeamID {
+func (h Handle) ResolvedWriters() []keybase1.UserOrTeamID {
 	writers := h.unsortedResolvedWriters()
 	sort.Sort(tlf.UIDList(writers))
 	return writers
@@ -141,11 +158,11 @@ func (h TlfHandle) ResolvedWriters() []keybase1.UserOrTeamID {
 // FirstResolvedWriter returns the handle's first resolved writer ID
 // (when sorted).  For SingleTeam handles, this returns the team to
 // which the TLF belongs.
-func (h TlfHandle) FirstResolvedWriter() keybase1.UserOrTeamID {
+func (h Handle) FirstResolvedWriter() keybase1.UserOrTeamID {
 	return h.ResolvedWriters()[0]
 }
 
-func (h TlfHandle) unsortedResolvedReaders() []keybase1.UserOrTeamID {
+func (h Handle) unsortedResolvedReaders() []keybase1.UserOrTeamID {
 	if len(h.resolvedReaders) == 0 {
 		return nil
 	}
@@ -158,7 +175,7 @@ func (h TlfHandle) unsortedResolvedReaders() []keybase1.UserOrTeamID {
 
 // ResolvedReaders returns the handle's resolved reader IDs in sorted
 // order. If the handle is public, nil will be returned.
-func (h TlfHandle) ResolvedReaders() []keybase1.UserOrTeamID {
+func (h Handle) ResolvedReaders() []keybase1.UserOrTeamID {
 	readers := h.unsortedResolvedReaders()
 	sort.Sort(tlf.UIDList(readers))
 	return readers
@@ -166,7 +183,7 @@ func (h TlfHandle) ResolvedReaders() []keybase1.UserOrTeamID {
 
 // UnresolvedWriters returns the handle's unresolved writers in sorted
 // order.
-func (h TlfHandle) UnresolvedWriters() []keybase1.SocialAssertion {
+func (h Handle) UnresolvedWriters() []keybase1.SocialAssertion {
 	if len(h.unresolvedWriters) == 0 {
 		return nil
 	}
@@ -177,7 +194,7 @@ func (h TlfHandle) UnresolvedWriters() []keybase1.SocialAssertion {
 
 // UnresolvedReaders returns the handle's unresolved readers in sorted
 // order. If the handle is public, nil will be returned.
-func (h TlfHandle) UnresolvedReaders() []keybase1.SocialAssertion {
+func (h Handle) UnresolvedReaders() []keybase1.SocialAssertion {
 	if len(h.unresolvedReaders) == 0 {
 		return nil
 	}
@@ -187,7 +204,7 @@ func (h TlfHandle) UnresolvedReaders() []keybase1.SocialAssertion {
 }
 
 // ConflictInfo returns the handle's conflict info, if any.
-func (h TlfHandle) ConflictInfo() *tlf.HandleExtension {
+func (h Handle) ConflictInfo() *tlf.HandleExtension {
 	if h.conflictInfo == nil {
 		return nil
 	}
@@ -195,7 +212,7 @@ func (h TlfHandle) ConflictInfo() *tlf.HandleExtension {
 	return &conflictInfoCopy
 }
 
-func (h TlfHandle) recomputeNameWithExtensions() tlf.CanonicalName {
+func (h Handle) recomputeNameWithExtensions() tlf.CanonicalName {
 	components := strings.Split(string(h.name), tlf.HandleExtensionSep)
 	newName := components[0]
 	extensionList := tlf.HandleExtensionList(h.Extensions())
@@ -212,9 +229,9 @@ func (h TlfHandle) recomputeNameWithExtensions() tlf.CanonicalName {
 // the given one, if the existing one is nil. (In this case, the given one may
 // also be nil.) Otherwise, the given conflict info must match the existing
 // one.
-func (h TlfHandle) WithUpdatedConflictInfo(
-	codec kbfscodec.Codec, info *tlf.HandleExtension) (*TlfHandle, error) {
-	newHandle := h.deepCopy()
+func (h Handle) WithUpdatedConflictInfo(
+	codec kbfscodec.Codec, info *tlf.HandleExtension) (*Handle, error) {
+	newHandle := h.DeepCopy()
 	if newHandle.conflictInfo == nil {
 		if info == nil {
 			// Nothing to do.
@@ -241,7 +258,7 @@ func (h TlfHandle) WithUpdatedConflictInfo(
 }
 
 // FinalizedInfo returns the handle's finalized info, if any.
-func (h TlfHandle) FinalizedInfo() *tlf.HandleExtension {
+func (h Handle) FinalizedInfo() *tlf.HandleExtension {
 	if h.finalizedInfo == nil {
 		return nil
 	}
@@ -252,7 +269,7 @@ func (h TlfHandle) FinalizedInfo() *tlf.HandleExtension {
 // SetFinalizedInfo sets the handle's finalized info to the given one,
 // which may be nil.
 // TODO: remove this to make TlfHandle fully immutable
-func (h *TlfHandle) SetFinalizedInfo(info *tlf.HandleExtension) {
+func (h *Handle) SetFinalizedInfo(info *tlf.HandleExtension) {
 	if info == nil {
 		h.finalizedInfo = nil
 	} else {
@@ -262,8 +279,32 @@ func (h *TlfHandle) SetFinalizedInfo(info *tlf.HandleExtension) {
 	h.name = h.recomputeNameWithExtensions()
 }
 
+// SetName sets the TLF name associated with this Handle.  Useful for
+// testing.
+func (h *Handle) SetName(name tlf.CanonicalName) {
+	h.name = name
+}
+
+// SetResolvedWriter resolves the given `id` to the given `name`.
+// Useful for testing.
+func (h *Handle) SetResolvedWriter(
+	id keybase1.UserOrTeamID, name kbname.NormalizedUsername) {
+	h.resolvedWriters[id] = name
+}
+
+// ClearResolvedReaders forgets all the resolved reader.  Useful for
+// testing.
+func (h *Handle) ClearResolvedReaders() {
+	h.resolvedReaders = nil
+}
+
+// SetTlfID sets the TLF ID associated with this handle.
+func (h *Handle) SetTlfID(id tlf.ID) {
+	h.tlfID = id
+}
+
 // Extensions returns a list of extensions for the given handle.
-func (h TlfHandle) Extensions() (extensions []tlf.HandleExtension) {
+func (h Handle) Extensions() (extensions []tlf.HandleExtension) {
 	if h.ConflictInfo() != nil {
 		extensions = append(extensions, *h.ConflictInfo())
 	}
@@ -274,7 +315,7 @@ func (h TlfHandle) Extensions() (extensions []tlf.HandleExtension) {
 }
 
 func init() {
-	if reflect.ValueOf(TlfHandle{}).NumField() != 9 {
+	if reflect.ValueOf(Handle{}).NumField() != 9 {
 		panic(errors.New(
 			"Unexpected number of fields in TlfHandle; " +
 				"please update TlfHandle.Equals() for your " +
@@ -283,8 +324,8 @@ func init() {
 }
 
 // EqualsIgnoreName returns whether h and other contain the same info ignoring the name.
-func (h TlfHandle) EqualsIgnoreName(
-	codec kbfscodec.Codec, other TlfHandle) (bool, error) {
+func (h Handle) EqualsIgnoreName(
+	codec kbfscodec.Codec, other Handle) (bool, error) {
 	if h.tlfType != other.tlfType {
 		return false, nil
 	}
@@ -324,8 +365,8 @@ func (h TlfHandle) EqualsIgnoreName(
 }
 
 // Equals returns whether h and other contain the same info.
-func (h TlfHandle) Equals(
-	codec kbfscodec.Codec, other TlfHandle) (bool, error) {
+func (h Handle) Equals(
+	codec kbfscodec.Codec, other Handle) (bool, error) {
 	eq, err := h.EqualsIgnoreName(codec, other)
 	if err != nil {
 		return false, err
@@ -339,7 +380,7 @@ func (h TlfHandle) Equals(
 }
 
 // ToBareHandle returns a tlf.Handle corresponding to this handle.
-func (h TlfHandle) ToBareHandle() (tlf.Handle, error) {
+func (h Handle) ToBareHandle() (tlf.Handle, error) {
 	var readers []keybase1.UserOrTeamID
 	switch h.TypeForKeying() {
 	case tlf.PublicKeying:
@@ -358,7 +399,7 @@ func (h TlfHandle) ToBareHandle() (tlf.Handle, error) {
 
 // ToBareHandleOrBust returns a tlf.Handle corresponding to this
 // handle, and panics if there's an error. Used by tests.
-func (h TlfHandle) ToBareHandleOrBust() tlf.Handle {
+func (h Handle) ToBareHandleOrBust() tlf.Handle {
 	bh, err := h.ToBareHandle()
 	if err != nil {
 		panic(err)
@@ -366,8 +407,9 @@ func (h TlfHandle) ToBareHandleOrBust() tlf.Handle {
 	return bh
 }
 
-func (h TlfHandle) deepCopy() *TlfHandle {
-	hCopy := TlfHandle{
+// DeepCopy makes a deep copy of this `Handle`.
+func (h Handle) DeepCopy() *Handle {
+	hCopy := Handle{
 		tlfType:           h.tlfType,
 		name:              h.name,
 		unresolvedWriters: h.UnresolvedWriters(),
@@ -391,7 +433,7 @@ func (h TlfHandle) deepCopy() *TlfHandle {
 }
 
 // GetCanonicalName returns the canonical name of this TLF.
-func (h *TlfHandle) GetCanonicalName() tlf.CanonicalName {
+func (h *Handle) GetCanonicalName() tlf.CanonicalName {
 	if h.name == "" {
 		panic(fmt.Sprintf("TlfHandle %v with no name", h))
 	}
@@ -400,13 +442,13 @@ func (h *TlfHandle) GetCanonicalName() tlf.CanonicalName {
 }
 
 // GetCanonicalPath returns the full canonical path of this TLF.
-func (h *TlfHandle) GetCanonicalPath() string {
-	return buildCanonicalPathForTlfName(h.Type(), h.GetCanonicalName())
+func (h *Handle) GetCanonicalPath() string {
+	return BuildCanonicalPathForTlfName(h.Type(), h.GetCanonicalName())
 }
 
 // ToFavorite converts a TlfHandle into a Favorite, suitable for
 // Favorites calls.
-func (h *TlfHandle) ToFavorite() favorites.Folder {
+func (h *Handle) ToFavorite() favorites.Folder {
 	return favorites.Folder{
 		Name: string(h.GetCanonicalName()),
 		Type: h.Type(),
@@ -415,7 +457,7 @@ func (h *TlfHandle) ToFavorite() favorites.Folder {
 
 // FavoriteData converts a TlfHandle into FavoriteData, suitable for
 // Favorites calls.
-func (h *TlfHandle) FavoriteData() favorites.Data {
+func (h *Handle) FavoriteData() favorites.Data {
 	fd := favorites.Data{
 		Name:         string(h.GetCanonicalName()),
 		FolderType:   h.Type().FolderType(),
@@ -429,10 +471,10 @@ func (h *TlfHandle) FavoriteData() favorites.Data {
 	return fd
 }
 
-// ToFavorite converts a TlfHandle into a Favorite, and sets internal
-// state about whether the corresponding folder was just created or
-// not.
-func (h *TlfHandle) toFavToAdd(created bool) favorites.ToAdd {
+// ToFavToAdd converts a TlfHandle into a Favorite to be added, and
+// sets internal state about whether the corresponding folder was just
+// created or not.
+func (h *Handle) ToFavToAdd(created bool) favorites.ToAdd {
 	return favorites.ToAdd{
 		Folder:  h.ToFavorite(),
 		Data:    h.FavoriteData(),
@@ -449,152 +491,23 @@ func getSortedUnresolved(unresolved map[keybase1.SocialAssertion]bool) []keybase
 	return assertions
 }
 
-// splitAndNormalizeTLFName takes a tlf name as a string
-// and tries to normalize it offline. In addition to other
-// checks it returns TlfNameNotCanonical if it does not
-// look canonical.
-// Note that ordering differences do not result in TlfNameNotCanonical
-// being returned.
-func splitAndNormalizeTLFName(name string, t tlf.Type) (
-	writerNames, readerNames []string,
-	extensionSuffix string, err error) {
-	writerNames, readerNames, extensionSuffix, err = tlf.SplitName(name)
-	if err != nil {
-		return nil, nil, "", err
-	}
-	if t == tlf.SingleTeam && len(writerNames) != 1 {
-		// No team folder can have more than one writer.
-		return nil, nil, "", NoSuchNameError{Name: name}
-	}
-
-	hasReaders := len(readerNames) != 0
-	if t != tlf.Private && hasReaders {
-		// No public/team folder can have readers.
-		return nil, nil, "", NoSuchNameError{Name: name}
-	}
-
-	normalizedName, changes, err := normalizeNamesInTLF(
-		writerNames, readerNames, t, extensionSuffix)
-	if err != nil {
-		return nil, nil, "", err
-	}
-	// Check for changes - not just ordering differences here.
-	if changes {
-		return nil, nil, "", errors.WithStack(TlfNameNotCanonical{name, normalizedName})
-	}
-
-	return writerNames, readerNames, strings.ToLower(extensionSuffix), nil
-}
-
-// TODO: this function can likely be replaced with a call to
-// AssertionParseAndOnly when CORE-2967 and CORE-2968 are fixed.
-func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
-	if kbname.CheckUsername(s) {
-		return kbname.NewNormalizedUsername(s).String(), nil
-	}
-
-	// TODO: this fails for http and https right now (see CORE-2968).
-	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(s)
-	if isSocialAssertion {
-		if t == tlf.SingleTeam {
-			return "", fmt.Errorf(
-				"No social assertions allowed for team TLF: %s", s)
-		}
-		return socialAssertion.String(), nil
-	}
-
-	sAssertion := s
-	if t == tlf.SingleTeam {
-		sAssertion = "team:" + s
-	}
-	if expr, err := externals.AssertionParseAndOnlyStatic(sAssertion); err == nil {
-		// If the expression only contains a single url, make sure
-		// it's not a just considered a single keybase username.  If
-		// it is, then some non-username slipped into the default
-		// "keybase" case and should be considered an error.
-		urls := expr.CollectUrls(nil)
-		if len(urls) == 1 && urls[0].IsKeybase() {
-			return "", NoSuchUserError{s}
-		}
-
-		// Normalize and return.  Ideally `AssertionParseAndOnly`
-		// would normalize for us, but that doesn't work yet, so for
-		// now we'll just lower-case.  This will incorrectly lower
-		// case http/https/web assertions, as well as case-sensitive
-		// social assertions in AND expressions.  TODO: see CORE-2967.
-		return strings.ToLower(s), nil
-	}
-
-	return "", BadTLFNameError{s}
-}
-
-// normalizeNames normalizes a slice of names and returns
-// whether any of them changed.
-func normalizeNames(names []string, t tlf.Type) (changesMade bool, err error) {
-	for i, name := range names {
-		x, err := normalizeAssertionOrName(name, t)
-		if err != nil {
-			return false, err
-		}
-		if x != name {
-			names[i] = x
-			changesMade = true
-		}
-	}
-	return changesMade, nil
-}
-
-// normalizeNamesInTLF takes a split TLF name and, without doing any
-// resolutions or identify calls, normalizes all elements of the
-// name. It then returns the normalized name and a boolean flag
-// whether any names were modified.
-// This modifies the slices passed as arguments.
-func normalizeNamesInTLF(writerNames, readerNames []string,
-	t tlf.Type, extensionSuffix string) (normalizedName string,
-	changesMade bool, err error) {
-	changesMade, err = normalizeNames(writerNames, t)
-	if err != nil {
-		return "", false, err
-	}
-	sort.Strings(writerNames)
-	normalizedName = strings.Join(writerNames, ",")
-	if len(readerNames) > 0 {
-		rchanges, err := normalizeNames(readerNames, t)
-		if err != nil {
-			return "", false, err
-		}
-		changesMade = changesMade || rchanges
-		sort.Strings(readerNames)
-		normalizedName += tlf.ReaderSep + strings.Join(readerNames, ",")
-	}
-	if len(extensionSuffix) != 0 {
-		// This *should* be normalized already but make sure.  I can see not
-		// doing so might surprise a caller.
-		nExt := strings.ToLower(extensionSuffix)
-		normalizedName += tlf.HandleExtensionSep + nExt
-		changesMade = changesMade || nExt != extensionSuffix
-	}
-
-	return normalizedName, changesMade, nil
-}
-
-// CheckTlfHandleOffline does light checks whether a TLF handle looks ok,
+// CheckHandleOffline does light checks whether a TLF handle looks ok,
 // it avoids all network calls.
-func CheckTlfHandleOffline(
+func CheckHandleOffline(
 	ctx context.Context, name string, t tlf.Type) error {
-	_, _, _, err := splitAndNormalizeTLFName(name, t)
+	_, _, _, err := idutil.SplitAndNormalizeTLFName(name, t)
 	return err
 }
 
 // IsFinal returns whether or not this TlfHandle represents a finalized
 // top-level folder.
-func (h TlfHandle) IsFinal() bool {
+func (h Handle) IsFinal() bool {
 	return h.finalizedInfo != nil
 }
 
 // IsConflict returns whether or not this TlfHandle represents a conflicted
 // top-level folder.
-func (h TlfHandle) IsConflict() bool {
+func (h Handle) IsConflict() bool {
 	return h.conflictInfo != nil
 }
 
@@ -603,7 +516,7 @@ func (h TlfHandle) IsConflict() bool {
 // This calls tlf.CanonicalToPreferredName with the canonical
 // tlf name which will be reordered into the preferred format.
 // An empty username is allowed here and results in the canonical ordering.
-func (h TlfHandle) GetPreferredFormat(
+func (h Handle) GetPreferredFormat(
 	username kbname.NormalizedUsername) tlf.PreferredName {
 	s, err := tlf.CanonicalToPreferredName(username, h.GetCanonicalName())
 	if err != nil {

--- a/go/kbfs/tlfhandle/interfaces.go
+++ b/go/kbfs/tlfhandle/interfaces.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package tlfhandle
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/kbfs/tlf"
+)
+
+// IDGetter is an interface for resolving TLF handles to their TLF IDs.
+type IDGetter interface {
+	// GetIDForHandle returns the tlf.ID associated with the given
+	// handle, if the logged-in user has read permission on the
+	// folder.  It may or may not create the folder if it doesn't
+	// exist yet, and it may return `tlf.NullID` with a `nil` error if
+	// it doesn't create a missing folder.
+	GetIDForHandle(ctx context.Context, handle *Handle) (tlf.ID, error)
+	// ValidateLatestHandleForTLF returns true if the TLF ID contained
+	// in `h` does not currently map to a finalized TLF.
+	ValidateLatestHandleNotFinal(ctx context.Context, h *Handle) (
+		bool, error)
+}

--- a/go/kbfs/tlfhandle/path.go
+++ b/go/kbfs/tlfhandle/path.go
@@ -1,0 +1,74 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package tlfhandle
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/keybase/client/go/kbfs/tlf"
+)
+
+// PathType describes the types for different paths
+type PathType string
+
+const (
+	// KeybasePathType is the keybase root (like /keybase)
+	KeybasePathType PathType = "keybase"
+	// PublicPathType is the keybase public folder list (like /keybase/public)
+	PublicPathType PathType = "public"
+	// PrivatePathType is the keybase private folder list (like
+	// /keybase/private)
+	PrivatePathType PathType = "private"
+	// SingleTeamPathType is the keybase team folder list (like /keybase/teams)
+	SingleTeamPathType PathType = "team"
+)
+
+// BuildCanonicalPath returns a canonical path for a path components.
+// This a canonical path and may need to be converted to a platform
+// specific path, for example, on Windows, this might correspond to
+// k:\private\username.
+func BuildCanonicalPath(pathType PathType, paths ...string) string {
+	var prefix string
+	switch pathType {
+	case KeybasePathType:
+		prefix = "/" + string(KeybasePathType)
+	default:
+		prefix = "/" + string(KeybasePathType) + "/" + string(pathType)
+	}
+	pathElements := []string{prefix}
+	for _, p := range paths {
+		if p != "" {
+			pathElements = append(pathElements, p)
+		}
+	}
+	return strings.Join(pathElements, "/")
+}
+
+func buildCanonicalPathForTlfType(t tlf.Type, paths ...string) string {
+	var pathType PathType
+	switch t {
+	case tlf.Private:
+		pathType = PrivatePathType
+	case tlf.Public:
+		pathType = PublicPathType
+	case tlf.SingleTeam:
+		pathType = SingleTeamPathType
+	default:
+		panic(fmt.Sprintf("Unknown tlf path type: %d", t))
+	}
+
+	return BuildCanonicalPath(pathType, paths...)
+}
+
+// BuildCanonicalPathForTlfName returns a canonical path for a tlf.
+func BuildCanonicalPathForTlfName(t tlf.Type, tlfName tlf.CanonicalName) string {
+	return buildCanonicalPathForTlfType(t, string(tlfName))
+}
+
+// BuildCanonicalPathForTlf returns a canonical path for a tlf.
+func BuildCanonicalPathForTlf(tlf tlf.ID, paths ...string) string {
+	return buildCanonicalPathForTlfType(tlf.Type(), paths...)
+}

--- a/go/kbfs/tlfhandle/path_test.go
+++ b/go/kbfs/tlfhandle/path_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD
 // license that can be found in the LICENSE file.
 
-package libkbfs
+package tlfhandle
 
 import (
 	"testing"


### PR DESCRIPTION
This creates two new kbfs subpackages, consisting of existing code moved around:

* idutil: Basic data structures, interfaces, and helper code for dealing with identity data for users and teams.
* tlfhandle: The data structure for "Handles" to top-level folders (TLFs), which represent an identifier for each TLF, containing all the user or team IDs associated with the it.

Not only are these decent cleanups on their own, they will enable further refactoring of code that uses TlfHandles into other new packages (which is a lot of them).

Also I fixed up the README to point to all the new packages we've added since it was written.