### PR TITLE
ellipsize full user names in follow tabs

### DIFF
--- a/shared/profile/user/friend/index.js
+++ b/shared/profile/user/friend/index.js
@@ -45,7 +45,12 @@ const styles = Styles.styleSheetCreate({
     minWidth: 0,
   },
   fullname: Styles.platformStyles({
-    isElectron: {wordBreak: 'break-all'},
+    isElectron: {
+      textAlign: 'center',
+      whiteSpace: 'nowrap',
+      width: 80,
+      wordBreak: 'break-all',
+    },
   }),
 })
 


### PR DESCRIPTION
picked 80 pixels for cutting off full name - note keybase name can still be longer
![image](https://user-images.githubusercontent.com/862397/54400658-2232f080-4681-11e9-8b43-4f960cbc4ff9.png)
