### PR TITLE
Trigger reloadable screen on profile when loading suggestions fails

### DIFF
--- a/shared/actions/tracker2.js
+++ b/shared/actions/tracker2.js
@@ -140,6 +140,8 @@ function* load(state, action) {
       })
     )
   } catch (err) {
+    // trigger custom error display instead of reloadable
+    logger.error(`Error loading profile: ${err.message}`)
     yield Saga.put(
       Tracker2Gen.createUpdateResult({
         guiID: action.payload.guiID,
@@ -179,11 +181,13 @@ const loadFollow = (_, action) => {
 }
 
 const getProofSuggestions = () =>
-  RPCTypes.userProofSuggestionsRpcPromise().then(({suggestions, showMore}) =>
-    Tracker2Gen.createProofSuggestionsUpdated({
-      suggestions: (suggestions || []).map(Constants.rpcSuggestionToAssertion),
-    })
-  )
+  RPCTypes.userProofSuggestionsRpcPromise(undefined, Constants.profileLoadWaitingKey)
+    .then(({suggestions, showMore}) =>
+      Tracker2Gen.createProofSuggestionsUpdated({
+        suggestions: (suggestions || []).map(Constants.rpcSuggestionToAssertion),
+      })
+    )
+    .catch(e => logger.error(`Error loading proof suggestions: ${e.message}`))
 
 const showUser = (_, action) =>
   Tracker2Gen.createLoad({

--- a/shared/constants/tracker2.js
+++ b/shared/constants/tracker2.js
@@ -192,6 +192,7 @@ export const sortAssertionKeys = (a: string, b: string) => {
 export const noDetails = makeDetails({})
 export const noAssertion = makeAssertion({})
 export const waitingKey = 'tracker2:waitingKey'
+export const profileLoadWaitingKey = 'tracker2:profileLoad'
 
 export const followThem = (state: TypedState, username: string) => state.config.following.has(username)
 export const followsYou = (state: TypedState, username: string) => state.config.followers.has(username)

--- a/shared/profile/user/index.js
+++ b/shared/profile/user/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
+import * as Constants from '../../constants/tracker2'
 import * as Types from '../../constants/types/tracker2'
 import * as Styles from '../../styles'
 import {chunk} from 'lodash-es'
@@ -353,9 +354,6 @@ class User extends React.Component<Props, State> {
   _onMeasured = width => this.setState(p => (p.width !== width ? {width} : null))
   _keyExtractor = (item, index) => index
 
-  componentDidMount() {
-    this.props.onReload()
-  }
   componentDidUpdate(prevProps: Props) {
     if (this.props.username !== prevProps.username) {
       this.props.onReload()
@@ -377,37 +375,44 @@ class User extends React.Component<Props, State> {
     }
 
     return (
-      <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.container}>
-        <Kb.Box2 direction="vertical" style={styles.innerContainer}>
-          {!Styles.isMobile && <Measure onMeasured={this._onMeasured} />}
-          <Kb.SafeAreaViewTop
-            style={Styles.collapseStyles([colorTypeToStyle(this.props.backgroundColorType), styles.noGrow])}
-          />
-          {!!this.state.width && (
-            <Kb.SectionList
-              key={this.props.username + this.state.width /* forc render on user change or width change */}
-              stickySectionHeadersEnabled={true}
-              renderSectionHeader={this._renderSectionHeader}
-              keyExtractor={this._keyExtractor}
-              sections={[
-                this._bioTeamProofsSection,
-                {
-                  data: chunks,
-                  itemWidth,
-                  renderItem: this._renderOtherUsers,
-                },
-              ]}
-              style={Styles.collapseStyles([
-                styles.sectionList,
-                Styles.isMobile
-                  ? colorTypeToStyle(this.props.backgroundColorType)
-                  : {backgroundColor: Styles.globalColors.white},
-              ])}
-              contentContainerStyle={styles.sectionListContentStyle}
+      <Kb.Reloadable
+        reloadOnMount={true}
+        onReload={this.props.onReload}
+        onBack={this.props.onBack}
+        waitingKeys={[Constants.profileLoadWaitingKey]}
+      >
+        <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.container}>
+          <Kb.Box2 direction="vertical" style={styles.innerContainer}>
+            {!Styles.isMobile && <Measure onMeasured={this._onMeasured} />}
+            <Kb.SafeAreaViewTop
+              style={Styles.collapseStyles([colorTypeToStyle(this.props.backgroundColorType), styles.noGrow])}
             />
-          )}
+            {!!this.state.width && (
+              <Kb.SectionList
+                key={this.props.username + this.state.width /* forc render on user change or width change */}
+                stickySectionHeadersEnabled={true}
+                renderSectionHeader={this._renderSectionHeader}
+                keyExtractor={this._keyExtractor}
+                sections={[
+                  this._bioTeamProofsSection,
+                  {
+                    data: chunks,
+                    itemWidth,
+                    renderItem: this._renderOtherUsers,
+                  },
+                ]}
+                style={Styles.collapseStyles([
+                  styles.sectionList,
+                  Styles.isMobile
+                    ? colorTypeToStyle(this.props.backgroundColorType)
+                    : {backgroundColor: Styles.globalColors.white},
+                ])}
+                contentContainerStyle={styles.sectionListContentStyle}
+              />
+            )}
+          </Kb.Box2>
         </Kb.Box2>
-      </Kb.Box2>
+      </Kb.Reloadable>
     )
   }
 }


### PR DESCRIPTION
We have a error display for the profile when `Identify3` fails, this adds a different waitingKey for loading the proof suggestions that triggers a reloadable. r? @keybase/react-hackers 