### PR TITLE
Quarantine attachment earlier

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1625,13 +1625,13 @@ func (h *Server) DownloadFileAttachmentLocal(ctx context.Context, arg chat1.Down
 			h.Debug(ctx, "DownloadFileAttachmentLocal: deleteFileIfEmpty: %v", deleteFileIfEmpty(filename))
 		}
 	}()
+	if err := attachments.Quarantine(ctx, filename); err != nil {
+		h.Debug(ctx, "DownloadFileAttachmentLocal: failed to quarantine download: %s", err)
+	}
 	darg.Sink = sink
 	ires, err := h.downloadAttachmentLocal(ctx, uid, darg)
 	if err != nil {
 		return res, err
-	}
-	if err := attachments.Quarantine(ctx, filename); err != nil {
-		h.Debug(ctx, "DownloadFileAttachmentLocal: failed to quarantine download: %s", err)
 	}
 	return chat1.DownloadFileAttachmentLocalRes{
 		Filename:         filename,


### PR DESCRIPTION
Quarantine the attachment before filling it. This way even if the download fails at the very end, the file will be quarantined. Tested on macos. I don't have windows running hoping to ask someone who does to try it prior to release.