### PR TITLE
Align things on profiles.

### DIFF
--- a/shared/profile/generic/shared.js
+++ b/shared/profile/generic/shared.js
@@ -39,7 +39,19 @@ export const SiteIcon = (props: SiteIconProps) => {
 }
 
 const siteIconStyles = Styles.styleSheetCreate({
-  siteIcon: {flexShrink: 0, height: 16, width: 16},
+  siteIcon: Styles.platformStyles({
+    common: {
+      flexShrink: 0,
+    },
+    isElectron: {
+      height: 16,
+      width: 16,
+    },
+    isMobile: {
+      height: 18,
+      width: 18,
+    },
+  }),
   siteIconFull: Styles.platformStyles({
     common: {
       flexShrink: 0,

--- a/shared/profile/user/proofs/index.js
+++ b/shared/profile/user/proofs/index.js
@@ -148,7 +148,7 @@ const styles = Styles.styleSheetCreate({
     marginTop: Styles.globalMargins.tiny,
   },
   icon: {
-    alignSelf: 'center',
+    alignSelf: 'flex-start',
     height: 32,
     marginLeft: Styles.globalMargins.small,
     marginRight: Styles.globalMargins.small,

--- a/shared/profile/user/teams/index.js
+++ b/shared/profile/user/teams/index.js
@@ -152,7 +152,7 @@ const styles = Styles.styleSheetCreate({
       paddingBottom: Styles.globalMargins.small,
     },
     isMobile: {
-      paddingLeft: Styles.globalMargins.small,
+      paddingLeft: Styles.globalMargins.tiny,
     },
   }),
   youPublishTeam: {

--- a/shared/tracker2/assertion/index.js
+++ b/shared/tracker2/assertion/index.js
@@ -331,7 +331,7 @@ class Assertion extends React.PureComponent<Props, State> {
         fullWidth={true}
       >
         <Kb.Box2
-          alignItems="center"
+          alignItems="flex-start"
           direction="horizontal"
           gap="tiny"
           fullWidth={true}
@@ -347,7 +347,7 @@ class Assertion extends React.PureComponent<Props, State> {
               </Kb.Text>
             )}
           </Kb.Text>
-          <Kb.ClickableBox onClick={items ? this._toggleMenu : p.onShowProof}>
+          <Kb.ClickableBox onClick={items ? this._toggleMenu : p.onShowProof} style={styles.statusContainer}>
             <Kb.Box2 direction="horizontal" alignItems="center" gap="tiny">
               <Kb.Icon
                 type={stateToIcon(p.state)}
@@ -409,11 +409,14 @@ const styles = Styles.styleSheetCreate({
   positionRelative: {position: 'relative'},
   site: {color: Styles.globalColors.black_20},
   siteIconFullDecoration: {bottom: -8, position: 'absolute', right: -10},
+  statusContainer: Styles.platformStyles({
+    isMobile: {position: 'relative', top: -2},
+  }),
   strikeThrough: {textDecorationLine: 'line-through'},
   textContainer: {flexGrow: 1, flexShrink: 1, marginTop: -1},
   tooltip: Styles.platformStyles({isElectron: {display: 'inline-flex'}}),
   username: Styles.platformStyles({
-    isElectron: {display: 'inline-block', wordBreak: 'break-all'},
+    isElectron: {wordBreak: 'break-all'},
   }),
 })
 


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. It aligns the Teams section with the left edge of the provider proofs, and it aligns the provider proof and status icons with the first row of the provider text.