### PR TITLE
libgit: register repo nodes for updates on branches

### DIFF
--- a/go/kbfs/libgit/autogit_node_wrappers.go
+++ b/go/kbfs/libgit/autogit_node_wrappers.go
@@ -172,7 +172,7 @@ func (rdn *repoDirNode) GetFS(ctx context.Context) billy.Filesystem {
 		return nil
 	}
 
-	if rdn.subdir == "" && rdn.branch == "" {
+	if rdn.subdir == "" {
 		// If this is the root node for the repo, register it exactly once.
 		rdn.once.Do(func() {
 			billyFS, err := rdn.gitRootFS.Chroot(rdn.repo)


### PR DESCRIPTION
If the user _only_ looked at a non-master branch, we were not registering with the `AutogitManager` to get updates for the repository's root node.  The `AutogitManager` already makes sure to only register with KBFS once for each TLF, so it's safe to register with the manager for each different branch.