### PR TITLE
Stop using the prerelease CNAME for S3

### DIFF
--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -35,12 +35,7 @@ if [ ! "$bucket_name" = "" ]; then
   echo "Bucket name: $bucket_name"
 fi
 
-if [ "$bucket_name" = "prerelease.keybase.io" ]; then
-  # We have a CNAME for the prerelease bucket
-  s3host="https://prerelease.keybase.io"
-else
-  s3host="https://s3.amazonaws.com/$bucket_name/"
-fi
+s3host="https://s3.amazonaws.com/$bucket_name/"
 
 build_dir_keybase="/tmp/build_keybase"
 build_dir_kbfs="/tmp/build_kbfs"


### PR DESCRIPTION
@maxtaco I think this should accomplish the same as the server-side PR.  (Updater gets it from asset.uri in the JSON, `release update-json` generates the JSON, update-json receives a --uri argument with the link, the uri argument is derived from s3host.)