### PR TITLE
folder_branch_ops: return real error when stating a fake file

### DIFF
--- a/go/kbfs/libfuse/errors.go
+++ b/go/kbfs/libfuse/errors.go
@@ -75,6 +75,10 @@ func filterError(err error) error {
 		return errorWithErrno{err, syscall.ENOSPC}
 	case libkbfs.RevGarbageCollectedError:
 		return errorWithErrno{err, syscall.ENOENT}
+	case libkbfs.NoSuchNameError:
+		return errorWithErrno{err, syscall.ENOENT}
+	case libkbfs.NameExistsError:
+		return errorWithErrno{err, syscall.EEXIST}
 	}
 
 	if os.IsNotExist(errors.Cause(err)) {

--- a/go/kbfs/libfuse/errors.go
+++ b/go/kbfs/libfuse/errors.go
@@ -7,6 +7,7 @@
 package libfuse
 
 import (
+	"os"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -75,5 +76,10 @@ func filterError(err error) error {
 	case libkbfs.RevGarbageCollectedError:
 		return errorWithErrno{err, syscall.ENOENT}
 	}
+
+	if os.IsNotExist(errors.Cause(err)) {
+		return errorWithErrno{err, syscall.ENOENT}
+	}
+
 	return err
 }

--- a/go/kbfs/libgit/autogit_node_wrappers_test.go
+++ b/go/kbfs/libgit/autogit_node_wrappers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
@@ -69,6 +70,9 @@ func checkAutogitTwoFiles(t *testing.T, rootFS *libfs.FS) {
 	data2, err := ioutil.ReadAll(f2)
 	require.NoError(t, err)
 	require.Equal(t, "hello2", string(data2))
+	// Make sure a non-existent file gives the right error.
+	_, err = rootFS.Open(".kbfs_autogit/test/missing")
+	require.True(t, os.IsNotExist(errors.Cause(err)))
 }
 
 func TestAutogitRepoNode(t *testing.T) {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3046,7 +3046,7 @@ func (fbo *folderBranchOps) statUsingFS(
 
 	de, err = fbo.makeFakeFileEntry(ctx, node, name)
 	if err != nil {
-		return DirEntry{}, false, nil
+		return DirEntry{}, false, err
 	}
 	return de, true, nil
 }


### PR DESCRIPTION
Also make sure FUSE gives the right error code when a file doesn't exist.