### PR TITLE
Bind compile on non-ios

### DIFF
--- a/go/bind/dns_other.go
+++ b/go/bind/dns_other.go
@@ -1,7 +1,7 @@
 // Copyright 2017 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 //
-// +build android
+// +build !ios
 
 package keybase
 

--- a/go/test/run_tests.sh
+++ b/go/test/run_tests.sh
@@ -36,11 +36,6 @@ go get "github.com/stretchr/testify/assert"
 failures=()
 
 for i in $DIRS; do
-  if [ "$i" = "bind" ]; then
-    echo "Skipping bind"
-    continue
-  fi
-
   echo -n "$i......."
   if ! (cd $i && go test $FLAGS ) ; then
     failures+=("$i")


### PR DESCRIPTION
Bind not compiling has been a minor annoyance for running go tools and other scripts. Seems like this is all that's needed for it to compile.