### PR TITLE
cr: use the right disk block cache type for tests

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3358,7 +3358,7 @@ func (cr *ConflictResolver) makeDiskBlockCache(ctx context.Context) (
 		_ = cr.config.(*ConfigLocal).EnableDiskLimiter(os.TempDir())
 
 		dbc, err = newDiskBlockCacheLocalForTest(
-			cr.config, syncCacheLimitTrackerType)
+			cr.config, crDirtyBlockCacheLimitTrackerType)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Without this change, tests can fail if the /tmp/ directory is too full.

Issue: KBFS-3952