### PR TITLE
fix attaching from Files to chat

### DIFF
--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -389,7 +389,7 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 	}()
 
 	// Stat the file to get size
-	finfo, err := os.Stat(filename)
+	finfo, err := StatOSOrKbfsFile(ctx, u.G().GlobalContext, filename)
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
This stat call is causing attaching from Files to chat to fail if KBFS mount is not present -- which is always the case with mobile. Not sure how I missed that in the first place. I tested attaching on mobile and it worked. Perhaps it has to do with the file size and didn't go through this routine if file is smaller or larger. Anyway, this PR fixes that by using SimpleFSStat for KBFS paths.

I grep'ed and didn't find any other `os.` calls in chat/attachments that could encounter KBFS paths, so I think this is the only one. But let me know if you think of anything else!