### PR TITLE
fix nav2 chat mark as read

### DIFF
--- a/shared/constants/chat2/index.js
+++ b/shared/constants/chat2/index.js
@@ -134,7 +134,7 @@ export const isUserActivelyLookingAtThisThread = (
   if (flags.useNewRouter) {
     const routePath = Router2.getVisiblePath()
     chatThreadSelected =
-      routePath[routePath.length - 1]?.routeName === isMobile ? 'chatConversation' : 'tabs.chatTab'
+      routePath[routePath.length - 1]?.routeName === (isMobile ? 'chatConversation' : 'tabs.chatTab')
   } else {
     const routePath = getPath(state.routeTree.routeState)
     if (isMobile) {


### PR DESCRIPTION
`isUserActivelyLookingAtThisThread` was returning true even when on the wrong tab. r? @keybase/react-hackers 