### PR TITLE
Prime secret store before provisioning

### DIFF
--- a/go/engine/errors.go
+++ b/go/engine/errors.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"fmt"
+
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -53,4 +54,12 @@ type PGPNotActiveForLocalImport struct {
 func (e PGPNotActiveForLocalImport) Error() string {
 	return fmt.Sprintf("Key %s is not active in user's sigchain. Publish key first to be able to import to local Keybase keychain.",
 		e.kid)
+}
+
+type SecretStoreNotFunctionalError struct {
+	err error
+}
+
+func (e SecretStoreNotFunctionalError) Error() string {
+	return fmt.Sprintf("Secret store not functional: %s", e.err)
 }

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -90,6 +90,10 @@ func (e *loginProvision) Run(m libkb.MetaContext) error {
 		return err
 	}
 
+	if err := m.G().SecretStore().PrimeSecretStores(m); err != nil {
+		return fmt.Errorf("secret store is not functional: %s", err)
+	}
+
 	var err error
 	e.perUserKeyring, err = libkb.NewPerUserKeyring(m.G(), e.arg.User.GetUID())
 	if err != nil {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -91,7 +91,7 @@ func (e *loginProvision) Run(m libkb.MetaContext) error {
 	}
 
 	if err := m.G().SecretStore().PrimeSecretStores(m); err != nil {
-		return fmt.Errorf("secret store is not functional: %s", err)
+		return SecretStoreNotFunctionalError{err}
 	}
 
 	var err error

--- a/go/engine/selfprovision.go
+++ b/go/engine/selfprovision.go
@@ -66,6 +66,10 @@ func (e *SelfProvisionEngine) Run(m libkb.MetaContext) (err error) {
 		return fmt.Errorf("to self provision, you must be a cloned device")
 	}
 
+	if err = m.G().SecretStore().PrimeSecretStores(m); err != nil {
+		return fmt.Errorf("secret store is not functional: %s", err)
+	}
+
 	uv, _ := e.G().ActiveDevice.GetUsernameAndUserVersionIfValid(m)
 	// Pass the UV here so the passphrase stream is cached on the provisional
 	// login context

--- a/go/engine/selfprovision.go
+++ b/go/engine/selfprovision.go
@@ -67,7 +67,7 @@ func (e *SelfProvisionEngine) Run(m libkb.MetaContext) (err error) {
 	}
 
 	if err = m.G().SecretStore().PrimeSecretStores(m); err != nil {
-		return fmt.Errorf("secret store is not functional: %s", err)
+		return SecretStoreNotFunctionalError{err}
 	}
 
 	uv, _ := e.G().ActiveDevice.GetUsernameAndUserVersionIfValid(m)

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -90,6 +90,12 @@ func (s *SignupEngine) Run(m libkb.MetaContext) (err error) {
 	// check if secret store works
 	if s.arg.StoreSecret {
 		if ss := m.G().SecretStore(); ss != nil {
+			if s.arg.GenerateRandomPassphrase && !ss.IsPersistent() {
+				// IsPersistent returns true if SecretStoreLocked is
+				// disk-backed, and false if it's only memory backed.
+				return SecretStoreNotFunctionalError{err: fmt.Errorf("persistent secret store is required for no-passphrase signup")}
+			}
+
 			err = ss.PrimeSecretStores(m)
 			if err != nil {
 				return SecretStoreNotFunctionalError{err}

--- a/go/engine/signup.go
+++ b/go/engine/signup.go
@@ -92,10 +92,10 @@ func (s *SignupEngine) Run(m libkb.MetaContext) (err error) {
 		if ss := m.G().SecretStore(); ss != nil {
 			err = ss.PrimeSecretStores(m)
 			if err != nil {
-				return fmt.Errorf("secret store is not functional: %s", err)
+				return SecretStoreNotFunctionalError{err}
 			}
 		} else if s.arg.GenerateRandomPassphrase {
-			return fmt.Errorf("secret store is required for no-passphrase but wasn't found")
+			return SecretStoreNotFunctionalError{err: fmt.Errorf("secret store is required for no-passphrase signup but wasn't found")}
 		} else {
 			m.Debug("There is no secret store, but we are continuing because this is not a NOPW")
 		}

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
@@ -318,6 +319,62 @@ func TestSignupNonAsciiDeviceName(t *testing.T) {
 		arg := MakeTestSignupEngineRunArg(fu)
 		arg.DeviceName = testVal.deviceName
 		_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, fu, arg)
+		require.Error(t, err)
 		require.IsType(t, err, testVal.err)
 	}
+}
+
+func TestSignupNOPWBadParams(t *testing.T) {
+	tc := SetupEngineTest(t, "signup_nopw")
+	defer tc.Cleanup()
+
+	fu, _ := NewFakeUser("sup")
+	arg := MakeTestSignupEngineRunArg(fu)
+	arg.StoreSecret = false
+	arg.GenerateRandomPassphrase = true
+	arg.Passphrase = ""
+	_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, fu, arg)
+	require.Error(t, err)
+}
+
+func TestSignupWithoutSecretStore(t *testing.T) {
+	tc := SetupEngineTest(t, "signup_nopw")
+	defer tc.Cleanup()
+
+	// Setup memory-only secret store.
+	libkb.ReplaceSecretStoreForTests(tc, "" /* dataDir */)
+
+	fu, _ := NewFakeUser("sup")
+	arg := MakeTestSignupEngineRunArg(fu)
+	arg.StoreSecret = true
+	arg.GenerateRandomPassphrase = true
+	arg.Passphrase = ""
+	_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, fu, arg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "persistent secret store is required")
+}
+
+func TestSignupWithBadSecretStore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("this test uses chmod, skipping on Windows")
+	}
+
+	tc := SetupEngineTest(t, "signup_nopw")
+	defer tc.Cleanup()
+
+	// Create a secret store that's read only - even though
+	// secret store exists, secrets cannot be stored.
+	td, cleanup := libkb.CreateReadOnlySecretStoreDir(tc)
+	defer cleanup()
+	libkb.ReplaceSecretStoreForTests(tc, td)
+
+	fu, _ := NewFakeUser("sup")
+	arg := MakeTestSignupEngineRunArg(fu)
+	arg.StoreSecret = true
+	arg.GenerateRandomPassphrase = true
+	arg.Passphrase = ""
+	_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, fu, arg)
+	require.Error(t, err)
+	require.IsType(t, SecretStoreNotFunctionalError{}, err)
+	require.Contains(t, err.Error(), "permission denied")
 }

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -334,6 +334,13 @@ func TestSignupNOPWBadParams(t *testing.T) {
 	arg.Passphrase = ""
 	_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, fu, arg)
 	require.Error(t, err)
+
+	// Make sure user has not signed up - the engine should fail before running
+	// signup_join.
+	loadArg := libkb.NewLoadUserByNameArg(tc.G, fu.Username).WithPublicKeyOptional()
+	_, err = libkb.LoadUser(loadArg)
+	require.Error(t, err)
+	require.IsType(t, libkb.NotFoundError{}, err)
 }
 
 func TestSignupWithoutSecretStore(t *testing.T) {
@@ -351,6 +358,13 @@ func TestSignupWithoutSecretStore(t *testing.T) {
 	_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, fu, arg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "persistent secret store is required")
+
+	// Make sure user has not signed up - the engine should fail before running
+	// signup_join.
+	loadArg := libkb.NewLoadUserByNameArg(tc.G, fu.Username).WithPublicKeyOptional()
+	_, err = libkb.LoadUser(loadArg)
+	require.Error(t, err)
+	require.IsType(t, libkb.NotFoundError{}, err)
 }
 
 func TestSignupWithBadSecretStore(t *testing.T) {
@@ -376,4 +390,11 @@ func TestSignupWithBadSecretStore(t *testing.T) {
 	require.Error(t, err)
 	require.IsType(t, SecretStoreNotFunctionalError{}, err)
 	require.Contains(t, err.Error(), "permission denied")
+
+	// Make sure user has not signed up - the engine should fail before running
+	// signup_join.
+	loadArg := libkb.NewLoadUserByNameArg(tc.G, fu.Username).WithPublicKeyOptional()
+	_, err = libkb.LoadUser(loadArg)
+	require.Error(t, err)
+	require.IsType(t, libkb.NotFoundError{}, err)
 }

--- a/go/engine/signup_test.go
+++ b/go/engine/signup_test.go
@@ -319,7 +319,6 @@ func TestSignupNonAsciiDeviceName(t *testing.T) {
 		arg := MakeTestSignupEngineRunArg(fu)
 		arg.DeviceName = testVal.deviceName
 		_, err := CreateAndSignupFakeUserSafeWithArg(tc.G, fu, arg)
-		require.Error(t, err)
 		require.IsType(t, err, testVal.err)
 	}
 }

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -116,6 +116,7 @@ func createAndSignupFakeUser(prefix string, g *libkb.GlobalContext, skipPaper bo
 		SkipMail:                 true,
 		SkipPaper:                skipPaper,
 		GenerateRandomPassphrase: randomPW,
+		StoreSecret:              true,
 	}
 	uis := libkb.UIs{
 		LogUI:    g.UI.GetLogUI(),

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -264,6 +264,13 @@ func (s *SecretStoreLocked) PrimeSecretStores(mctx MetaContext) (err error) {
 	return err
 }
 
+func (s *SecretStoreLocked) IsPersistent() bool {
+	if s == nil || s.isNil() {
+		return false
+	}
+	return s.disk != nil
+}
+
 // PrimeSecretStore runs a test with current platform's secret store, trying to
 // store, retrieve, and then delete a secret with an arbitrary name. This should
 // be done before provisioning or logging in

--- a/go/libkb/secret_store_darwin_test.go
+++ b/go/libkb/secret_store_darwin_test.go
@@ -111,3 +111,12 @@ func TestSecretStoreDarwin(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, users, 0)
 }
+
+func TestPrimeSecretStoreDarwin(t *testing.T) {
+	tc := SetupTest(t, "secret store darwin", 1)
+	defer tc.Cleanup()
+
+	mctx := NewMetaContextForTest(tc)
+	err := PrimeSecretStore(mctx)
+	require.NoError(t, err)
+}

--- a/go/libkb/secret_store_darwin_test.go
+++ b/go/libkb/secret_store_darwin_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestSecretStoreDarwin(t *testing.T) {
 	tc := SetupTest(t, "secret store darwin", 1)
+	defer tc.Cleanup()
 
 	mctx := NewMetaContextForTest(tc)
 	secretStore := KeychainSecretStore{}
@@ -20,7 +21,6 @@ func TestSecretStoreDarwin(t *testing.T) {
 	defer func() {
 		err := secretStore.ClearSecret(mctx, nu)
 		require.NoError(tc.T, err)
-		tc.Cleanup()
 	}()
 
 	serviceName := secretStore.serviceName(mctx)
@@ -113,10 +113,11 @@ func TestSecretStoreDarwin(t *testing.T) {
 }
 
 func TestPrimeSecretStoreDarwin(t *testing.T) {
-	tc := SetupTest(t, "secret store darwin", 1)
+	tc := SetupTest(t, "secret_store_darwin", 1)
 	defer tc.Cleanup()
 
 	mctx := NewMetaContextForTest(tc)
-	err := PrimeSecretStore(mctx)
+	secretStore := KeychainSecretStore{}
+	err := PrimeSecretStore(mctx, secretStore)
 	require.NoError(t, err)
 }

--- a/go/libkb/secret_store_file_test.go
+++ b/go/libkb/secret_store_file_test.go
@@ -218,3 +218,16 @@ func TestSecretStoreFileNoise(t *testing.T) {
 
 	require.False(t, bytes.Equal(lksec.Bytes(), corrupt.Bytes()))
 }
+
+func TestPrimeSecretStoreFile(t *testing.T) {
+	td, tdClean := testSSDir(t)
+	defer tdClean()
+
+	tc := SetupTest(t, "secret_store_file", 1)
+	defer tc.Cleanup()
+
+	mctx := NewMetaContextForTest(tc)
+	secretStore := NewSecretStoreFile(td)
+	err := PrimeSecretStore(mctx, secretStore)
+	require.NoError(t, err)
+}

--- a/go/libkb/secret_store_file_test.go
+++ b/go/libkb/secret_store_file_test.go
@@ -238,23 +238,15 @@ func TestPrimeSecretStoreFileFail(t *testing.T) {
 		t.Skip("this test uses chmod, skipping on Windows")
 	}
 
-	td, tdClean := testSSDir(t)
-	defer tdClean()
-
 	tc := SetupTest(t, "secret_store_file", 1)
 	defer tc.Cleanup()
 
-	// Change mode of test dir to read-only so secret store on this dir can
-	// fail.
-	fi, err := os.Stat(td)
-	require.NoError(t, err)
-	oldMode := fi.Mode()
-	os.Chmod(td, 0400)
-	defer os.Chmod(td, oldMode)
+	td, cleanup := CreateReadOnlySecretStoreDir(tc)
+	defer cleanup()
 
 	mctx := NewMetaContextForTest(tc)
 	secretStore := NewSecretStoreFile(td)
-	err = PrimeSecretStore(mctx, secretStore)
+	err := PrimeSecretStore(mctx, secretStore)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "permission denied")
 }

--- a/go/libkb/secret_store_test.go
+++ b/go/libkb/secret_store_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSecretStoreOps(t *testing.T) {
@@ -135,4 +137,13 @@ func TestGetUsersWithStoredSecrets(t *testing.T) {
 	if len(usernames) != 0 {
 		t.Errorf("Expected no usernames, got %d", len(usernames))
 	}
+}
+
+func TestPrimeSecretStore(t *testing.T) {
+	tc := SetupTest(t, "secret_store", 1)
+	defer tc.Cleanup()
+
+	mctx := NewMetaContextForTest(tc)
+	err := mctx.G().SecretStore().PrimeSecretStores(mctx)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR adds a `PrimeSecretStores` function that check if the secret store is functioning - that is, it tries to store, retrieve, and then cleanup a random secret for randomly generated username.

Calls to this new functions were inserted in `loginProvision`, `SelfProvisionEngine`, and `SignupEngine`. The engines are stopped early if they discover that the secret store does not work. Normal login (`LoginProvisionedDevice`) is not protected, so it will still work, just not remember user's passphrase in case we can't use secret store.

This is important for NOPW sign up, in which we would sign someone up, (silently) fail to store their passphrase stream, and then they would be out of luck after returning to the app, unable to login again.

I tested this manually using GUI, and what happens is that signup fail without creating the user. So they try to fix their device or try another one, without "burning" that username.