### PR TITLE
Fix nav2 on Linux

### DIFF
--- a/shared/profile/search/bar.js
+++ b/shared/profile/search/bar.js
@@ -60,6 +60,7 @@ const styles = Styles.styleSheetCreate({
     isElectron: {
       ...Styles.desktopStyles.boxShadow,
       ...Styles.globalStyles.flexBoxColumn,
+      ...Styles.desktopStyles.windowDraggingClickable,
       ...(flags.useNewRouter ? {marginRight: 12} : {}),
       alignSelf: 'center',
       borderRadius: 5,
@@ -78,6 +79,7 @@ const styles = Styles.styleSheetCreate({
     },
     isElectron: {
       ...Styles.desktopStyles.clickable,
+      ...Styles.desktopStyles.windowDraggingClickable,
       height: 24,
       marginLeft: flags.useNewRouter ? 'auto' : Styles.globalMargins.small,
       marginRight: flags.useNewRouter ? Styles.globalMargins.xsmall : Styles.globalMargins.small,

--- a/shared/profile/search/bar.js
+++ b/shared/profile/search/bar.js
@@ -60,7 +60,6 @@ const styles = Styles.styleSheetCreate({
     isElectron: {
       ...Styles.desktopStyles.boxShadow,
       ...Styles.globalStyles.flexBoxColumn,
-      ...Styles.desktopStyles.windowDraggingClickable,
       ...(flags.useNewRouter ? {marginRight: 12} : {}),
       alignSelf: 'center',
       borderRadius: 5,
@@ -79,7 +78,6 @@ const styles = Styles.styleSheetCreate({
     },
     isElectron: {
       ...Styles.desktopStyles.clickable,
-      ...Styles.desktopStyles.windowDraggingClickable,
       height: 24,
       marginLeft: flags.useNewRouter ? 'auto' : Styles.globalMargins.small,
       marginRight: flags.useNewRouter ? Styles.globalMargins.xsmall : Styles.globalMargins.small,

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -83,9 +83,12 @@ const styles = Styles.styleSheetCreate({
       alignItems: 'center',
     },
   }),
-  icon: {
-    marginRight: 6,
-  },
+  icon: Styles.platformStyles({
+    isElectron: {
+      ...Styles.desktopStyles.windowDraggingClickable,
+      marginRight: 6,
+    },
+  }),
 })
 
 export default Header

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -67,7 +67,6 @@ const styles = Styles.styleSheetCreate({
   }),
   headerBack: Styles.platformStyles({
     isElectron: {
-      ...Styles.desktopStyles.windowDragging,
       alignItems: 'center',
       height: 40,
       padding: 12,
@@ -80,6 +79,7 @@ const styles = Styles.styleSheetCreate({
   },
   headerContainer: Styles.platformStyles({
     isElectron: {
+      ...Styles.desktopStyles.windowDragging,
       alignItems: 'center',
     },
   }),

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -67,6 +67,7 @@ const styles = Styles.styleSheetCreate({
   }),
   headerBack: Styles.platformStyles({
     isElectron: {
+      ...Styles.desktopStyles.windowDragging,
       alignItems: 'center',
       height: 40,
       padding: 12,
@@ -79,7 +80,6 @@ const styles = Styles.styleSheetCreate({
   },
   headerContainer: Styles.platformStyles({
     isElectron: {
-      ...Styles.desktopStyles.windowDragging,
       alignItems: 'center',
     },
   }),

--- a/shared/router-v2/router.desktop.js
+++ b/shared/router-v2/router.desktop.js
@@ -262,11 +262,6 @@ const createElectronApp = Component => {
 const ElectronApp = createElectronApp(RootStackNavigator)
 
 const styles = Styles.styleSheetCreate({
-  back: Styles.platformStyles({
-    isElectron: {
-      ...Styles.desktopStyles.windowDraggingClickable,
-    },
-  }),
   contentArea: {
     flexGrow: 1,
     position: 'relative',


### PR DESCRIPTION
@keybase/react-hackers 

Huh, the question here is actually why nav2 *was* working on macOS.  We set the nav area to draggable, which means we need to counter-set `WebkitAppRegion: 'no-drag' (via `desktopStyles.windowDraggingClickable`) in clickable areas, but that wasn't happening at all.  So the code intent was for nothing to be clickable in the nav area.

