### PR TITLE
Always show nav buttons, not only on hover

### DIFF
--- a/shared/desktop/app/main-window.desktop.js
+++ b/shared/desktop/app/main-window.desktop.js
@@ -52,8 +52,7 @@ export default function() {
     y: appState.state.y,
     ...(flags.useNewRouter
       ? {
-          frame: false,
-          titleBarStyle: 'customButtonsOnHover',
+          titleBarStyle: 'hiddenInset',
         }
       : {}),
   })

--- a/shared/desktop/remote/sync-browser-window.desktop.js
+++ b/shared/desktop/remote/sync-browser-window.desktop.js
@@ -15,12 +15,11 @@ type Props = {
 }
 
 const defaultWindowOpts = {
-  frame: false,
   fullscreen: false,
   height: 300,
   resizable: false,
   show: false, // Start hidden and show when we actually get props
-  titleBarStyle: 'customButtonsOnHover',
+  titleBarStyle: 'hiddenInset',
   webPreferences: {
     nodeIntegration: true,
     nodeIntegrationInWorker: false,


### PR DESCRIPTION
@keybase/react-hackers CC @keybase/design 

As a side-effect, Linux and Windows will get their full window frames back.  This sounds like what we want for right now, since there are currently no minimize/close buttons on those platforms under nav2.

Or if it isn't what we want, we could do:

Mac:
```js
{frame: false, titleBarStyle: 'hiddenInset'}
```
Linux and Windows:
```js
{frame: true}
```
and then we try to get buttons on Win/Linux some other way?  Design folks, which do you prefer?
  