### PR TITLE
Shutdown logger when Keybase exits

### DIFF
--- a/go/keybase/main.go
+++ b/go/keybase/main.go
@@ -42,6 +42,7 @@ func handleQuickVersion() bool {
 }
 
 func keybaseExit(exitCode int) {
+	logger.Shutdown()
 	logger.RestoreConsoleMode()
 	os.Exit(exitCode)
 }

--- a/go/logger/file.go
+++ b/go/logger/file.go
@@ -60,7 +60,7 @@ func SetLogFileConfig(lfc *LogFileConfig) error {
 	}
 
 	if first {
-		buf, shutdown := NewAutoFlushingBufferedWriter(w, loggingFrequency)
+		buf, shutdown, _ := NewAutoFlushingBufferedWriter(w, loggingFrequency)
 		w.stopFlushing = shutdown
 		fileBackend := logging.NewLogBackend(buf, "", 0)
 		logging.SetBackend(fileBackend)

--- a/go/logger/global.go
+++ b/go/logger/global.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/go-logging"
-	"github.com/mattn/go-isatty"
+	logging "github.com/keybase/go-logging"
+	isatty "github.com/mattn/go-isatty"
 )
 
 const logMS = 10
@@ -16,10 +16,25 @@ var globalLock sync.Mutex
 var stderrIsTerminal = isatty.IsTerminal(os.Stderr.Fd())
 var currentLogFileWriter *LogFileWriter
 var stdErrLoggingShutdown chan<- struct{}
+var stdErrLoggingShutdownDone <-chan struct{}
 
 func init() {
-	writer, shutdown := NewAutoFlushingBufferedWriter(ErrorWriter(), loggingFrequency)
+	writer, shutdown, done := NewAutoFlushingBufferedWriter(ErrorWriter(), loggingFrequency)
 	stdErrLoggingShutdown = shutdown
+	stdErrLoggingShutdownDone = done
 	logBackend := logging.NewLogBackend(writer, "", 0)
 	logging.SetBackend(logBackend)
+}
+
+// Shutdown shuts down logger, flushing remaining logs if a backend with
+// buffering is used.
+func Shutdown() {
+	select {
+	case stdErrLoggingShutdown <- struct{}{}:
+		// Wait till logger is done
+		select {
+		case <-stdErrLoggingShutdownDone:
+		}
+	default:
+	}
 }


### PR DESCRIPTION
The repro is to try standalone mode with some command that one expects to return an error:
```
» keybase --standalone apicall "te/st"

(nothing)
```

after the fix:
```
» keybase --standalone apicall "te/st"
▶ ERROR 404 Not Found
```

but this issue is not limited to standalone mode, I've been observing it with commands in service mode as well.