### PR TITLE
MerkleRoot don't store sigs after verify

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -122,9 +122,6 @@ type CommandLine interface {
 	GetBool(string, bool) (bool, bool)
 }
 
-type Server interface {
-}
-
 type LocalDbOps interface {
 	Put(id DbKey, aliases []DbKey, value []byte) error
 	Delete(id DbKey) error

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -19,10 +19,9 @@ import (
 
 // table names
 const (
-	levelDbTableLo = "lo"
-	levelDbTableKv = "kv"
-	// keys with this prefix are ignored by the dbcleaner
-	levelDbTablePerm = "pm"
+	levelDbTableLo   = "lo" // lookup table used by aliases
+	levelDbTableKv   = "kv" // general storage
+	levelDbTablePerm = "pm" // keys with this prefix are ignored by the dbcleaner
 )
 
 type levelDBOps interface {

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -33,7 +33,7 @@ type levelDBOps interface {
 }
 
 func levelDbPut(ops levelDBOps, cleaner *levelDbCleaner, id DbKey, aliases []DbKey, value []byte) (err error) {
-	defer convertNoSpaceError(err)
+	defer convertNoSpaceError(&err)
 
 	idb := id.ToBytes(levelDbTableKv)
 	if aliases == nil {
@@ -99,7 +99,7 @@ func levelDbLookup(ops levelDBOps, cleaner *levelDbCleaner, id DbKey) (val []byt
 }
 
 func levelDbDelete(ops levelDBOps, cleaner *levelDbCleaner, id DbKey) (err error) {
-	defer convertNoSpaceError(err)
+	defer convertNoSpaceError(&err)
 	key := id.ToBytes(levelDbTableKv)
 	if err := ops.Delete(key, nil); err != nil {
 		return err
@@ -389,7 +389,7 @@ func (l LevelDbTransaction) Delete(id DbKey) error {
 }
 
 func (l LevelDbTransaction) Commit() (err error) {
-	defer convertNoSpaceError(err)
+	defer convertNoSpaceError(&err)
 	return l.tr.Commit()
 }
 
@@ -397,11 +397,9 @@ func (l LevelDbTransaction) Discard() {
 	l.tr.Discard()
 }
 
-func convertNoSpaceError(err error) error {
-	if IsNoSpaceOnDeviceError(err) {
-		// embed in exportable error type
-		err = NoSpaceOnDeviceError{Desc: err.Error()}
+func convertNoSpaceError(err *error) {
+	if err != nil && *err != nil && IsNoSpaceOnDeviceError(*err) {
+		// replace with an exportable error type
+		*err = NoSpaceOnDeviceError{Desc: (*err).Error()}
 	}
-
-	return err
 }

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -500,7 +500,7 @@ func (mc *MerkleClient) loadRoot(m MetaContext) (err error) {
 	return nil
 }
 
-func (mr *MerkleRoot) Store() error {
+func (mr *MerkleRoot) store() error {
 	dbKeys := []DbKey{merkleHeadKey()}
 	err := mr.G().LocalDb.Put(DbKey{
 		Typ: DBMerkleRoot,
@@ -950,7 +950,7 @@ func (mr MerkleRoot) ExportToAVDL(g *GlobalContext) keybase1.MerkleRootAndTime {
 // Must be called from under a lock.
 func (mc *MerkleClient) storeRoot(m MetaContext, root *MerkleRoot) {
 	m.VLogf(VLog0, "storing merkle root: %d", *root.Seqno())
-	err := root.Store()
+	err := root.store()
 	if err != nil {
 		m.Error("Cannot commit Merkle root to local DB: %s", err)
 	} else {
@@ -1941,27 +1941,6 @@ func (mr *MerkleRoot) Fetched() time.Time {
 		return time.Time{}
 	}
 	return mr.fetched
-}
-
-func (mr *MerkleRoot) KBFSPrivate() (keybase1.KBFSRootHash, *keybase1.Seqno) {
-	if mr == nil {
-		return nil, nil
-	}
-	return mr.payload.kbfsPrivate()
-}
-
-func (mr *MerkleRoot) KBFSPublic() (keybase1.KBFSRootHash, *keybase1.Seqno) {
-	if mr == nil {
-		return nil, nil
-	}
-	return mr.payload.kbfsPublic()
-}
-
-func (mr *MerkleRoot) KBFSPrivateTeam() (keybase1.KBFSRootHash, *keybase1.Seqno) {
-	if mr == nil {
-		return nil, nil
-	}
-	return mr.payload.kbfsPrivateTeam()
 }
 
 func (mrp MerkleRootPayload) skipToSeqno(s keybase1.Seqno) NodeHash {


### PR DESCRIPTION
Sigs make up 2/3 of the leveldb storage of merkle roots. This patch omits sigs from storage if they have been verified. It's probably an invariant that sigs are checked before storage, but rather than proving that there's a book-keeping bool.

You mentioned a just-store-the-hash way of doing this. There's also `ProofServicesHash` and `PvlHash` accessed on `MerkleRoot` loaded from disk. I think the way to omit the final 1/3 would be to split the MerkleRoot type into two. One with all the info from the server. And one with a minimal set that can come from disk or from the first type.