### PR TITLE
fix for TestMerkleAuditRetry flake

### DIFF
--- a/go/engine/merkle_audit.go
+++ b/go/engine/merkle_audit.go
@@ -103,6 +103,10 @@ func (e *MerkleAudit) Shutdown() {
 
 // randSeqno picks a random number between [low, high) that's different from prev.
 func randSeqno(lo keybase1.Seqno, hi keybase1.Seqno, prev *keybase1.Seqno) (keybase1.Seqno, error) {
+	// Prevent an infinite loop if [0,1) and prev = 0
+	if hi-lo == 1 && prev != nil && *prev == lo {
+		return keybase1.Seqno(0), fmt.Errorf("unable to generate a non-duplicate seqno other than %d", *prev)
+	}
 	for {
 		rangeBig := big.NewInt(int64(hi - lo))
 		n, err := rand.Int(rand.Reader, rangeBig)


### PR DESCRIPTION
I would've never thought we'd run into it but it happened! The auditor randomly selected the same block twice in a row in CI. 