### PR TITLE
fix overlay inside popup

### DIFF
--- a/shared/common-adapters/popup-dialog.desktop.js
+++ b/shared/common-adapters/popup-dialog.desktop.js
@@ -95,7 +95,6 @@ const styles = Styles.styleSheetCreate({
     paddingLeft: Styles.globalMargins.large,
     paddingRight: Styles.globalMargins.large,
     paddingTop: Styles.globalMargins.small,
-    zIndex: 30, // Put the popup on top of any sticky section headers.
   },
 })
 


### PR DESCRIPTION
Since overlay `zIndex` is removed in https://github.com/keybase/client/pull/16656 , this one in the popup needs to be removed as well. Otherwise overlay are pushed behind popup (see wallet send to other address screen, or send attachment screen in Files). I checked the views with `stickySectionHeadersEnabled={true}` and didn't see any weirdness. But it'd be nice if someone else who knows it better can check too.