### PR TITLE
test: benchmark for writing and flushing lots of small files

### DIFF
--- a/go/kbfs/test/benchmark_test.go
+++ b/go/kbfs/test/benchmark_test.go
@@ -282,6 +282,8 @@ func benchmarkMultiFileSync(
 				cb(getBenchN(&n))
 				buf := make([]byte, numFiles*fileSize+fileSize)
 				for i := 0; i < numFiles*fileSize; i++ {
+					// Make sure we mix up the byte values a bit, so
+					// we don't accidentally trigger any deduplication.
 					buf[i] = byte(i)
 				}
 				cb(resetTimer())

--- a/go/kbfs/test/benchmark_test.go
+++ b/go/kbfs/test/benchmark_test.go
@@ -48,7 +48,7 @@ func BenchmarkWrite1mb512k(b *testing.B) {
 func benchmarkWriteSeqN(b *testing.B, n int64, mask int64) {
 	buf := make([]byte, n)
 	b.SetBytes(n)
-	benchmark(b, silentBenchmark{b},
+	benchmark(b,
 		users("alice"),
 		as(alice,
 			custom(func(cb func(fileOp) error) error {
@@ -56,14 +56,16 @@ func benchmarkWriteSeqN(b *testing.B, n int64, mask int64) {
 				if err != nil {
 					return err
 				}
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
-					err = cb(pwriteBS("bench", buf, (int64(i)*n)&mask))
+				var n int
+				cb(getBenchN(&n))
+				cb(resetTimer())
+				for i := 0; i < n; i++ {
+					err = cb(pwriteBS("bench", buf, (int64(i*n))&mask))
 					if err != nil {
 						return err
 					}
 				}
-				b.StopTimer()
+				cb(stopTimer())
 				return nil
 			}),
 		),
@@ -101,7 +103,7 @@ func BenchmarkReadHole1mb512k(b *testing.B) {
 func benchmarkReadSeqHoleN(b *testing.B, n int64, mask int64) {
 	buf := make([]byte, n)
 	b.SetBytes(n)
-	benchmark(b, silentBenchmark{b},
+	benchmark(b,
 		users("alice"),
 		as(alice,
 			custom(func(cb func(fileOp) error) error {
@@ -113,14 +115,16 @@ func benchmarkReadSeqHoleN(b *testing.B, n int64, mask int64) {
 				if err != nil {
 					return err
 				}
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
-					err = cb(preadBS("bench", buf, (int64(i)*n)&mask))
+				var n int
+				cb(getBenchN(&n))
+				cb(resetTimer())
+				for i := 0; i < n; i++ {
+					err = cb(preadBS("bench", buf, (int64(i*n))&mask))
 					if err != nil {
 						return err
 					}
 				}
-				b.StopTimer()
+				cb(stopTimer())
 				return nil
 			}),
 		),
@@ -129,7 +133,9 @@ func benchmarkReadSeqHoleN(b *testing.B, n int64, mask int64) {
 
 func benchmarkDoBenchWrites(b *testing.B, cb func(fileOp) error,
 	numWritesPerFile int, buf []byte, startIter int) error {
-	for i := startIter; i < b.N+startIter; i++ {
+	var n int
+	cb(getBenchN(&n))
+	for i := startIter; i < n+startIter; i++ {
 		name := fmt.Sprintf("bench%d", i)
 		err := cb(mkfile(name, ""))
 		if err != nil {
@@ -159,7 +165,7 @@ func benchmarkWriteWithBandwidthHelper(b *testing.B, fileBytes int64,
 	buf := make([]byte, perWriteBytes)
 	b.SetBytes(fileBytes)
 	numWritesPerFile := int(fileBytes / perWriteBytes)
-	benchmark(b, silentBenchmark{b},
+	benchmark(b,
 		users("alice"),
 		blockSize(512<<10),
 		bandwidth(writebwKBps),
@@ -167,15 +173,17 @@ func benchmarkWriteWithBandwidthHelper(b *testing.B, fileBytes int64,
 		as(alice,
 			custom(func(cb func(fileOp) error) error {
 				startIter := 0
+				var n int
+				cb(getBenchN(&n))
 				if doWarmUp {
 					if err := benchmarkDoBenchWrites(b, cb,
 						numWritesPerFile, buf, 0); err != nil {
 						return err
 					}
-					startIter = b.N
+					startIter = n
 				}
-				b.ResetTimer()
-				defer b.StopTimer()
+				cb(resetTimer())
+				defer cb(stopTimer())
 				return benchmarkDoBenchWrites(b, cb, numWritesPerFile, buf,
 					startIter)
 			}),
@@ -231,15 +239,17 @@ func BenchmarkWriteMixedFilesNormalBandwidth(b *testing.B) {
 	}
 	b.SetBytes(totalSize)
 
-	benchmark(b, silentBenchmark{b},
+	benchmark(b,
 		users("alice"),
 		blockSize(512<<10),
 		bandwidth(11*1024/8 /* 11 Mbps */),
 		opTimeout(19*time.Second),
 		as(alice,
 			custom(func(cb func(fileOp) error) error {
-				b.ResetTimer()
-				defer b.StopTimer()
+				var n int
+				cb(getBenchN(&n))
+				cb(resetTimer())
+				defer cb(stopTimer())
 				currIter := 0
 				for _, fileSize := range fileSizes {
 					numWrites := int(fileSize / perWriteBytes)
@@ -247,7 +257,69 @@ func BenchmarkWriteMixedFilesNormalBandwidth(b *testing.B) {
 						numWrites, buf, currIter); err != nil {
 						return err
 					}
-					currIter += b.N
+					currIter += n
+				}
+				return nil
+			}),
+		),
+	)
+}
+
+func benchmarkMultiFileSync(
+	b *testing.B, numFiles, fileSize int, timeWrites, timeFlush bool) {
+	benchmark(b,
+		journal(),
+		users("alice"),
+		batchSize(20),
+		as(alice,
+			mkdir("a"),
+		),
+		as(alice,
+			enableJournal(),
+			pauseJournal(),
+			custom(func(cb func(fileOp) error) error {
+				var n int
+				cb(getBenchN(&n))
+				buf := make([]byte, numFiles*fileSize+fileSize)
+				for i := 0; i < numFiles*fileSize; i++ {
+					buf[i] = byte(i)
+				}
+				cb(resetTimer())
+				defer cb(stopTimer())
+				for iter := 0; iter < n; iter++ {
+					if !timeWrites {
+						cb(stopTimer())
+					}
+					// Write to each file without syncing.
+					for i := iter * numFiles; i < (iter+1)*numFiles; i++ {
+						f := fmt.Sprintf("a/b/c/file%d", i)
+						start := (i%numFiles)*fileSize + (iter % fileSize)
+						err := cb(pwriteBSSync(
+							f, buf[start:start+fileSize], 0, false))
+						if err != nil {
+							return err
+						}
+					}
+					// Sync each file by doing a no-op truncate.
+					for i := iter * numFiles; i < (iter+1)*numFiles; i++ {
+						f := fmt.Sprintf("a/b/c/file%d", i)
+						err := cb(truncate(f, uint64(fileSize)))
+						if err != nil {
+							return err
+						}
+					}
+					if !timeWrites {
+						cb(startTimer())
+					}
+					if !timeFlush {
+						cb(stopTimer())
+					}
+					cb(resumeJournal())
+					cb(flushJournal())
+					cb(pauseJournal())
+					if !timeFlush {
+						cb(startTimer())
+					}
 				}
 				return nil
 			}),
@@ -256,47 +328,17 @@ func BenchmarkWriteMixedFilesNormalBandwidth(b *testing.B) {
 }
 
 func BenchmarkMultiFileSync(b *testing.B) {
-	numFiles := 20
-	fileSize := 5
-	benchmark(b, silentBenchmark{b},
-		journal(),
-		users("alice"),
-		as(alice,
-			enableJournal(),
-			custom(func(cb func(fileOp) error) error {
-				files := make([]string, numFiles*b.N)
-				bufs := make([][]byte, numFiles*b.N)
-				for i := 0; i < numFiles*b.N; i++ {
-					files[i] = fmt.Sprintf("a/b/c/file%d", i)
-					bufs[i] = make([]byte, fileSize)
-					for j := 0; j < fileSize; j++ {
-						bufs[i][j] = byte(i*fileSize + j)
-					}
-					err := cb(truncate(files[i], 0))
-					if err != nil {
-						return err
-					}
-				}
-				b.ResetTimer()
-				defer b.StopTimer()
-				for iter := 0; iter < b.N; iter++ {
-					// Write to each file without syncing.
-					for i := iter * numFiles; i < numFiles; i++ {
-						err := cb(pwriteBSSync(files[i], bufs[i], 0, false))
-						if err != nil {
-							return err
-						}
-					}
-					// Sync each file by doing a no-op truncate.
-					for i := iter * numFiles; i < numFiles; i++ {
-						err := cb(truncate(files[i], uint64(fileSize)))
-						if err != nil {
-							return err
-						}
-					}
-				}
-				return nil
-			}),
-		),
-	)
+	benchmarkMultiFileSync(b, 20, 5, true, false)
+}
+
+func BenchmarkMultiFileSyncLargeWrites(b *testing.B) {
+	benchmarkMultiFileSync(b, 1000, 5, true, false)
+}
+
+func BenchmarkMultiFileSyncLargeFlush(b *testing.B) {
+	benchmarkMultiFileSync(b, 1000, 5, false, true)
+}
+
+func BenchmarkMultiFileSyncLarge(b *testing.B) {
+	benchmarkMultiFileSync(b, 1000, 5, true, true)
 }


### PR DESCRIPTION
Writes 1000 5-byte files to the journal in one phase, and flushes them in a second phase, and each phase can be timed independently.

Note that we can't use `b` directly in the benchmarks, because they are actually sub-benchmarks that each get their own `*testing.B` object (due to our framework code that runs a copy of each test for different MD versions).  So this required some new DSL test helper functions that access the correct `*testing.B` for the sub-benchmark. All our benchmarks have been broken since that change.

Issue: KBFS-3979