### PR TITLE
Store only latest merkle root

### DIFF
--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -68,7 +68,8 @@ const (
 )
 
 const (
-	DBLookupUsername   = 0x00
+	DBLookupUsername = 0x00
+	// was once used to store latest merkle root with Key:"HEAD"
 	DBLookupMerkleRoot = 0x01
 )
 


### PR DESCRIPTION
Previously many merkle roots were stored using `DbKey{Typ:DBMerkleRoot,Key:%d}`. And `DbKey{Typ:DBLookupMerkleRoot,Key:"HEAD"}` was an alias to the latest. But we only need the latest.

So this just stores the latest merkle root at `DbKey{Type:DBMerkleRoot,Key:"HEAD"}` with no lookup. Db cleaner will eventually clear out the old `DBMerkleRoot` entries.