### PR TITLE
Reset DesktopAppState on gui disconnect

### DIFF
--- a/go/service/appstate.go
+++ b/go/service/appstate.go
@@ -24,6 +24,10 @@ func newAppStateHandler(xp rpc.Transporter, g *libkb.GlobalContext) *appStateHan
 	}
 }
 
+func (a *appStateHandler) Shutdown() {
+	a.G().DesktopAppState.Disconnected(a.xp)
+}
+
 func (a *appStateHandler) UpdateAppState(ctx context.Context, state keybase1.MobileAppState) (err error) {
 	a.G().Trace(fmt.Sprintf("UpdateAppState(%v)", state), func() error { return err })()
 
@@ -34,6 +38,6 @@ func (a *appStateHandler) UpdateAppState(ctx context.Context, state keybase1.Mob
 
 func (a *appStateHandler) PowerMonitorEvent(ctx context.Context, event string) (err error) {
 	a.G().Log.CDebugf(ctx, "PowerMonitorEvent(%v)", event)
-	a.G().DesktopAppState.Update(a.MetaContext(ctx), event)
+	a.G().DesktopAppState.Update(a.MetaContext(ctx), event, a.xp)
 	return nil
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -149,7 +149,6 @@ func (d *Service) RegisterProtocols(srv *rpc.Server, xp rpc.Transporter, connID 
 			libkb.RPCCancelerReasonAll),
 		keybase1.SimpleFSProtocol(NewSimpleFSHandler(xp, g)),
 		keybase1.LogsendProtocol(NewLogsendHandler(xp, g)),
-		keybase1.AppStateProtocol(newAppStateHandler(xp, g)),
 		CancelingProtocol(g, keybase1.TeamsProtocol(NewTeamsHandler(xp, connID, cg, d)),
 			libkb.RPCCancelerReasonLogout),
 		keybase1.BadgerProtocol(newBadgerHandler(xp, g, d.badger)),
@@ -161,6 +160,9 @@ func (d *Service) RegisterProtocols(srv *rpc.Server, xp rpc.Transporter, connID 
 		keybase1.EmailsProtocol(NewEmailsHandler(xp, g)),
 		keybase1.Identify3Protocol(newIdentify3Handler(xp, g)),
 	}
+	appStateHandler := newAppStateHandler(xp, g)
+	protocols = append(protocols, keybase1.AppStateProtocol(appStateHandler))
+	shutdowners = append(shutdowners, appStateHandler)
 	walletHandler := newWalletHandler(xp, g, d.walletState)
 	protocols = append(protocols, CancelingProtocol(g, stellar1.LocalProtocol(walletHandler),
 		libkb.RPCCancelerReasonLogout))


### PR DESCRIPTION
If the gui shuts down while the service thinks the machine is asleep. Then the service would continue to think so forever. This patch makes it so that when the gui (ish) disconnects the service goes back to assuming it's awake. That's a better failure mode even if wrong.