### PR TITLE
folder_block_manager: add a limit on how many ptrs get processed

### DIFF
--- a/go/kbfs/libkbfs/folder_block_manager_test.go
+++ b/go/kbfs/libkbfs/folder_block_manager_test.go
@@ -33,7 +33,8 @@ func totalBlockRefs(m map[kbfsblock.ID]blockRefMap) int {
 // does a few updates, then lets quota reclamation run, and we make
 // sure that all historical blocks have been deleted.
 func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
-	userName kbname.NormalizedUsername) {
+	userName kbname.NormalizedUsername) (
+	ops *folderBranchOps, preBlocks map[kbfsblock.ID]blockRefMap) {
 	clock, now := newTestClockAndTimeNow()
 	config.SetClock(clock)
 
@@ -63,7 +64,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 		ctx, rootNode.GetFolderBranch().Tlf)
 	require.NoError(t, err, "Couldn't get blocks: %+v", err)
 
-	ops := kbfsOps.(*KBFSOpsStandard).getOpsByNode(ctx, rootNode)
+	ops = kbfsOps.(*KBFSOpsStandard).getOpsByNode(ctx, rootNode)
 	ops.fbm.forceQuotaReclamation()
 	err = ops.fbm.waitForQuotaReclamations(ctx)
 	require.NoError(t, err, "Couldn't wait for QR: %+v", err)
@@ -89,19 +90,26 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 		ctx, rootNode.GetFolderBranch().Tlf)
 	require.NoError(t, err, "Couldn't get blocks: %+v", err)
 
+	return ops, preQR2Blocks
+}
+
+func ensureFewerBlocksPostQR(
+	t *testing.T, ctx context.Context, config *ConfigLocal,
+	ops *folderBranchOps, preBlocks map[kbfsblock.ID]blockRefMap) {
 	ops.fbm.forceQuotaReclamation()
-	err = ops.fbm.waitForQuotaReclamations(ctx)
+	err := ops.fbm.waitForQuotaReclamations(ctx)
 	require.NoError(t, err, "Couldn't wait for QR: %+v", err)
 
-	postQR2Blocks, err := bserverLocal.getAllRefsForTest(
-		ctx, rootNode.GetFolderBranch().Tlf)
+	bserverLocal, ok := config.BlockServer().(blockServerLocal)
+	require.True(t, ok)
+
+	postBlocks, err := bserverLocal.getAllRefsForTest(ctx, ops.id())
 	require.NoError(t, err, "Couldn't get blocks: %+v", err)
 
-	if pre, post := totalBlockRefs(preQR2Blocks),
-		totalBlockRefs(postQR2Blocks); post >= pre {
-		t.Errorf("Blocks didn't shrink after reclamation: pre: %d, post %d",
-			pre, post)
-	}
+	pre, post := totalBlockRefs(preBlocks), totalBlockRefs(postBlocks)
+	require.True(t, post < pre,
+		"Blocks didn't shrink after reclamation: pre: %d, post %d",
+		pre, post)
 }
 
 func TestQuotaReclamationSimple(t *testing.T) {
@@ -109,7 +117,39 @@ func TestQuotaReclamationSimple(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
-	testQuotaReclamation(t, ctx, config, userName)
+	ops, preBlocks := testQuotaReclamation(t, ctx, config, userName)
+	ensureFewerBlocksPostQR(t, ctx, config, ops, preBlocks)
+}
+
+type modeTestWithNoTimedQR struct {
+	InitMode
+}
+
+func (mtwmpl modeTestWithNoTimedQR) QuotaReclamationPeriod() time.Duration {
+	return 0
+}
+
+type modeTestWithMaxPtrsLimit struct {
+	InitMode
+}
+
+func (mtwmpl modeTestWithMaxPtrsLimit) MaxBlockPtrsToManageAtOnce() int {
+	return 1
+}
+
+func TestQuotaReclamationConstrained(t *testing.T) {
+	var userName kbname.NormalizedUsername = "test_user"
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	config.SetMode(modeTestWithNoTimedQR{config.Mode()})
+	originalMode := config.Mode()
+	config.SetMode(modeTestWithMaxPtrsLimit{originalMode})
+
+	ops, preBlocks := testQuotaReclamation(t, ctx, config, userName)
+
+	// Unconstrain it for the final QR.
+	config.SetMode(originalMode)
+	ensureFewerBlocksPostQR(t, ctx, config, ops, preBlocks)
 }
 
 // Just like the simple case, except tests that it unembeds large sets
@@ -121,12 +161,11 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 
 	config.bsplit.(*BlockSplitterSimple).blockChangeEmbedMaxSize = 32
 
-	testQuotaReclamation(t, ctx, config, userName)
+	ops, preBlocks := testQuotaReclamation(t, ctx, config, userName)
+	ensureFewerBlocksPostQR(t, ctx, config, ops, preBlocks)
 
 	// Make sure the MD has an unembedded change block.
-	rootNode := GetRootNodeOrBust(
-		ctx, t, config, userName.String(), tlf.Private)
-	md, err := config.MDOps().GetForTLF(ctx, rootNode.GetFolderBranch().Tlf, nil)
+	md, err := config.MDOps().GetForTLF(ctx, ops.id(), nil)
 	require.NoError(t, err, "Couldn't get MD: %+v", err)
 	if md.data.cachedChanges.Info.BlockPointer == zeroPtr {
 		t.Fatalf("No unembedded changes for ops %v", md.data.Changes.Ops)
@@ -495,7 +534,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 	// Re-enable QR in test mode.
-	config1.mode = modeTestWithQR{NewInitModeFromType(InitDefault)}
+	config1.SetMode(modeTestWithQR{NewInitModeFromType(InitDefault)})
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -686,6 +725,9 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 	config.vdebugSetting = "vlog2"
+
+	// Test the pointer-constraint logic.
+	config.SetMode(modeTestWithMaxPtrsLimit{config.Mode()})
 
 	config.EnableDiskLimiter(tempdir)
 	config.loadSyncedTlfsLocked()

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2079,6 +2079,10 @@ type InitMode interface {
 	// the block archive/delete background process, and whether we
 	// should be re-embedding block change blocks in MDs.
 	BlockManagementEnabled() bool
+	// MaxBlockPtrsToManageAtOnce indicates how many block pointers
+	// the block manager should try to hold in memory at once. -1
+	// indicates that there is no limit.
+	MaxBlockPtrsToManageAtOnce() int
 	// QuotaReclamationEnabled indicates whether we should be running
 	// the quota reclamation background process.
 	QuotaReclamationEnabled() bool
@@ -2173,6 +2177,7 @@ type Config interface {
 	diskLimiterGetter
 	syncedTlfGetterSetter
 	initModeGetter
+	SetMode(mode InitMode)
 	Tracer
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -216,7 +216,7 @@ func kbfsOpsInitNoMocks(t *testing.T, users ...kbname.NormalizedUsername) (
 	config := MakeTestConfigOrBust(t, users...)
 	// Turn off tlf edit history because it messes with the FBO state
 	// asynchronously.
-	config.mode = modeNoHistory{config.Mode()}
+	config.SetMode(modeNoHistory{config.Mode()})
 	config.SetRekeyWithPromptWaitTime(individualTestTimeout)
 
 	timeoutCtx, cancel := context.WithTimeout(
@@ -3245,7 +3245,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	defer kbfsTestShutdownNoMocksNoCheck(t, config1, ctx, cancel)
 	// Turn off tlf edit history because it messes with the FBO state
 	// asynchronously.
-	config1.mode = modeNoHistory{config1.Mode()}
+	config1.SetMode(modeNoHistory{config1.Mode()})
 
 	// Create alice's TLF.
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, "alice", tlf.Private)
@@ -3260,7 +3260,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 
 	// Create mallory's fake TLF using the same TLF ID as alice's.
 	config2 := ConfigAsUser(config1, "mallory")
-	config2.mode = modeNoHistory{config2.Mode()}
+	config2.SetMode(modeNoHistory{config2.Mode()})
 	crypto2 := cryptoFixedTlf{config2.Crypto(), fb1.Tlf}
 	config2.SetCrypto(crypto2)
 	mdserver2, err := NewMDServerMemory(mdServerLocalConfigAdapter{config2})
@@ -4101,7 +4101,7 @@ func (b bserverPutToDiskCache) Put(
 
 func enableDiskCacheForTest(
 	t *testing.T, config *ConfigLocal, tempdir string) *diskBlockCacheWrapped {
-	dbc, err := newDiskBlockCacheWrapped(config, "")
+	dbc, err := newDiskBlockCacheWrapped(config, "", config.Mode())
 	require.NoError(t, err)
 	config.diskBlockCache = dbc
 	err = dbc.workingSetCache.WaitUntilStarted()
@@ -4591,7 +4591,7 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.
-	config.mode = modeTest{NewInitModeFromType(InitDefault)}
+	config.SetMode(modeTest{NewInitModeFromType(InitDefault)})
 	config.vdebugSetting = "vlog2"
 
 	name := "u1"
@@ -4608,7 +4608,7 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	// config2 is the writer.
 	config2 := ConfigAsUser(config, u1)
 	defer CheckConfigAndShutdown(ctx, t, config2)
-	config2.mode = modeTest{NewInitModeFromType(InitDefault)}
+	config2.SetMode(modeTest{NewInitModeFromType(InitDefault)})
 	kbfsOps2 := config2.KBFSOps()
 
 	config.SetBlockServer(bserverPutToDiskCache{config.BlockServer(), dbc})

--- a/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
@@ -347,7 +347,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.
-	config1.mode = modeTest{NewInitModeFromType(InitDefault)}
+	config1.SetMode(modeTest{NewInitModeFromType(InitDefault)})
 
 	clock, first := newTestClockAndTimeNow()
 	config1.SetClock(clock)

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -93,6 +93,10 @@ func (md modeDefault) BlockManagementEnabled() bool {
 	return true
 }
 
+func (md modeDefault) MaxBlockPtrsToManageAtOnce() int {
+	return -1 /* unconstrained by default */
+}
+
 func (md modeDefault) QuotaReclamationEnabled() bool {
 	return true
 }
@@ -228,6 +232,10 @@ func (mm modeMinimal) BlockManagementEnabled() bool {
 	// TODO: in the future it might still be useful to have
 	// e.g. mobile devices doing QR.
 	return false
+}
+
+func (mm modeMinimal) MaxBlockPtrsToManageAtOnce() int {
+	panic("Shouldn't be called when block management is disabled")
 }
 
 func (mm modeMinimal) QuotaReclamationEnabled() bool {
@@ -407,6 +415,10 @@ func (mc modeConstrained) BackgroundFlushesEnabled() bool {
 
 func (mc modeConstrained) ConflictResolutionEnabled() bool {
 	return true
+}
+
+func (mc modeConstrained) MaxBlockPtrsToManageAtOnce() int {
+	return 10000
 }
 
 func (mc modeConstrained) QuotaReclamationEnabled() bool {

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -340,7 +340,7 @@ func ConfigAsUserWithMode(config *ConfigLocal,
 func ConfigAsUser(config *ConfigLocal,
 	loggedInUser kbname.NormalizedUsername) *ConfigLocal {
 	c := ConfigAsUserWithMode(config, loggedInUser, config.Mode().Type())
-	c.mode = config.mode // preserve any unusual test mode wrappers
+	c.SetMode(config.mode) // preserve any unusual test mode wrappers
 	return c
 }
 


### PR DESCRIPTION
Controlled by the mode, we can limit how many pointers get archived or cache-cleaned at once.  If the MD contains too many unref'd pointers, we don't want to duplicate them all in memory, when memory is constrained.  This was inspired by an MD in the wild that had 500K+ unref'd pointers.

If doing QR, we can't just reclaim a partial set of pointers from a single MD, so in that case return an error and let another device finish the QR for that revision.

Issue: KBFS-3984