### PR TITLE
folder_branch_ops: add debugging for stat'd file size

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3205,8 +3205,8 @@ func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Stat %s", getNodeIDStr(node))
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Stat %s done: %+v",
-			getNodeIDStr(node), err)
+		fbo.deferLog.CDebugf(ctx, "Stat %s (%d bytes) done: %+v",
+			getNodeIDStr(node), ei.Size, err)
 	}()
 
 	var de DirEntry


### PR DESCRIPTION
We saw a problem in the wild where `rm -rf` didn't work.  It's not clear why, but it seemed like it didn't recurse into a directory after statting it.  One possible explanation is that KBFS incorrectly returned a 0 size for the stat'd directory, and that caused `rm` to skip it even though it had files in it.  This will help us debug it in the future, if it happens again.

Issue: KBFS-3985