### PR TITLE
cr: no longer unstage automatically on a "block not found" error

### DIFF
--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -721,18 +721,6 @@ func (e InvalidOpError) Error() string {
 	return fmt.Sprintf("Invalid operation: %s", e.op)
 }
 
-// CRAbandonStagedBranchError indicates that conflict resolution had to
-// abandon a staged branch due to an unresolvable error.
-type CRAbandonStagedBranchError struct {
-	Err error
-	Bid kbfsmd.BranchID
-}
-
-func (e CRAbandonStagedBranchError) Error() string {
-	return fmt.Sprintf("Abandoning staged branch %s due to an error: %v",
-		e.Bid, e.Err)
-}
-
 // NoSuchFolderListError indicates that the user tried to access a
 // subdirectory of /keybase that doesn't exist.
 type NoSuchFolderListError struct {

--- a/go/kbfs/test/qr_test.go
+++ b/go/kbfs/test/qr_test.go
@@ -119,42 +119,6 @@ func TestQRWithMultiBlockFiles(t *testing.T) {
 	)
 }
 
-// Test that conflict resolution fails gracefully after quota
-// reclamation deletes some necessary blocks.
-func TestCRAfterQR(t *testing.T) {
-	test(t,
-		users("alice", "bob"),
-		as(bob,
-			disablePrefetch(),
-		),
-		as(alice,
-			mkfile("a/b", "hello"),
-		),
-		as(bob,
-			disableUpdates(),
-		),
-		as(alice,
-			rm("a/b"),
-		),
-		as(bob, noSync(),
-			setex("a/b", true),
-		),
-		as(alice,
-			addTime(2*time.Minute),
-			// Force rmd.data.Dir.MTime to something recent. TODO: remove me.
-			mkfile("c", "test"),
-			forceQuotaReclamation(),
-		),
-		as(bob, noSync(),
-			reenableUpdates(),
-			notExists("a/b"),
-		),
-		as(alice,
-			notExists("a/b"),
-		),
-	)
-}
-
 // Test that conflict resolution works gracefully after quota
 // reclamation deletes a modified+deleted directory from the merged
 // branch.  Regression for KBFS-1202.


### PR DESCRIPTION
This happened to someone and they lost real data from their conflict branch.  Now that we abandon CR attempts after a number of failed attempts, we're no longer at risk of infinite CR loops.  And soon we'll have tools for letting the user move conflict branches out of the way if needed (and hopefully, we'll eventually surface issues to the GUI with a badge somehow).  So it doesn't seem like we need to take the risk of automatically nuking data anymore.
