### PR TITLE
fix accidental triggerring click from floating menu

### DIFF
--- a/shared/common-adapters/floating-menu/menu-layout/index.desktop.js
+++ b/shared/common-adapters/floating-menu/menu-layout/index.desktop.js
@@ -30,8 +30,8 @@ class MenuLayout extends Component<MenuLayoutProps> {
           item.onClick && item.onClick()
           if (this.props.closeOnClick && this.props.onHidden) {
             this.props.onHidden()
-            event.stopPropagation()
           }
+          event.stopPropagation()
         }}
       >
         {item.view}


### PR DESCRIPTION
In Files, we don't use auto hide. So click event was never stopped from propagating. Not sure how this worked before but only broke after moving to ListItem2. Anyway, this fixes that.