### PR TITLE
Don't show minimize/close buttons on non-main windows e.g. tracker

### DIFF
--- a/shared/desktop/remote/sync-browser-window.desktop.js
+++ b/shared/desktop/remote/sync-browser-window.desktop.js
@@ -15,11 +15,12 @@ type Props = {
 }
 
 const defaultWindowOpts = {
+  frame: false,
   fullscreen: false,
   height: 300,
   resizable: false,
   show: false, // Start hidden and show when we actually get props
-  titleBarStyle: 'hiddenInset',
+  titleBarStyle: 'customButtonsOnHover',
   webPreferences: {
     nodeIntegration: true,
     nodeIntegrationInWorker: false,


### PR DESCRIPTION
@keybase/react-hackers 