### PR TITLE
tlf_journal: put block data to journal outside of lock

### DIFF
--- a/go/kbfs/libkbfs/block_disk_store.go
+++ b/go/kbfs/libkbfs/block_disk_store.go
@@ -567,6 +567,9 @@ func (s *blockDiskStore) getAllRefsForTest() (map[kbfsblock.ID]blockRefMap, erro
 //
 // For performance reasons, this method can be called concurrently by
 // many goroutines for different blocks.
+//
+// Note that the block won't be get-able until `addReference`
+// explicitly adds a tag for it.
 func (s *blockDiskStore) put(
 	ctx context.Context, isRegularPut bool, id kbfsblock.ID,
 	context kbfsblock.Context, buf []byte,

--- a/go/kbfs/libkbfs/block_disk_store_test.go
+++ b/go/kbfs/libkbfs/block_disk_store_test.go
@@ -47,7 +47,9 @@ func putBlockDisk(
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 
-	didPut, err := s.put(ctx, true, bID, bCtx, data, serverHalf, "tag")
+	didPut, err := s.put(ctx, true, bID, bCtx, data, serverHalf)
+	require.NoError(t, err)
+	err = s.addReference(ctx, bID, bCtx, "tag")
 	require.NoError(t, err)
 	require.True(t, didPut)
 

--- a/go/kbfs/libkbfs/block_journal.go
+++ b/go/kbfs/libkbfs/block_journal.go
@@ -346,22 +346,24 @@ func (j *blockJournal) end() (journalOrdinal, error) {
 	return last + 1, nil
 }
 
-func (j *blockJournal) hasData(id kbfsblock.ID) (bool, error) {
-	return j.s.hasData(id)
+func (j *blockJournal) hasData(
+	ctx context.Context, id kbfsblock.ID) (bool, error) {
+	return j.s.hasData(ctx, id)
 }
 
-func (j *blockJournal) isUnflushed(id kbfsblock.ID) (bool, error) {
-	return j.s.isUnflushed(id)
+func (j *blockJournal) isUnflushed(
+	ctx context.Context, id kbfsblock.ID) (bool, error) {
+	return j.s.isUnflushed(ctx, id)
 }
 
 func (j *blockJournal) remove(ctx context.Context, id kbfsblock.ID) (
 	removedBytes, removedFiles int64, err error) {
-	bytesToRemove, err := j.s.getDataSize(id)
+	bytesToRemove, err := j.s.getDataSize(ctx, id)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	err = j.s.remove(id)
+	err = j.s.remove(ctx, id)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -380,18 +382,20 @@ func (j *blockJournal) empty() bool {
 	return j.j.empty() && j.deferredGC.empty()
 }
 
-func (j *blockJournal) getDataWithContext(id kbfsblock.ID, context kbfsblock.Context) (
+func (j *blockJournal) getDataWithContext(
+	ctx context.Context, id kbfsblock.ID, context kbfsblock.Context) (
 	[]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
-	return j.s.getDataWithContext(id, context)
+	return j.s.getDataWithContext(ctx, id, context)
 }
 
-func (j *blockJournal) getData(id kbfsblock.ID) (
+func (j *blockJournal) getData(ctx context.Context, id kbfsblock.ID) (
 	[]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
-	return j.s.getData(id)
+	return j.s.getData(ctx, id)
 }
 
-func (j *blockJournal) getDataSize(id kbfsblock.ID) (int64, error) {
-	return j.s.getDataSize(id)
+func (j *blockJournal) getDataSize(
+	ctx context.Context, id kbfsblock.ID) (int64, error) {
+	return j.s.getDataSize(ctx, id)
 }
 
 func (j *blockJournal) getStoredBytes() int64 {
@@ -406,9 +410,9 @@ func (j *blockJournal) getStoredFiles() int64 {
 	return j.aggregateInfo.StoredFiles
 }
 
-// putData puts the given block data. If err is non-nil, putData will
+// putBlockData puts the given block data. If err is non-nil, putData will
 // always be false.
-func (j *blockJournal) putData(
+func (j *blockJournal) putBlockData(
 	ctx context.Context, id kbfsblock.ID, context kbfsblock.Context,
 	buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) (
 	putData bool, err error) {
@@ -422,33 +426,44 @@ func (j *blockJournal) putData(
 		}
 	}()
 
+	putData, err = j.s.put(ctx, true, id, context, buf, serverHalf, "")
+	if err != nil {
+		return false, err
+	}
+
+	return putData, nil
+}
+
+// appendBlock appends an entry for the previously-put block to the
+// journal, and records the size for the put block.
+func (j *blockJournal) appendBlock(
+	ctx context.Context, id kbfsblock.ID, context kbfsblock.Context,
+	bufLenToAdd int64) error {
+	j.log.CDebugf(ctx, "Appending %block %s to journal", id)
+
+	if bufLenToAdd > 0 {
+		var putFiles int64 = filesPerBlockMax
+		err := j.accumulateBlock(bufLenToAdd, putFiles)
+		if err != nil {
+			return err
+		}
+	}
+
 	next, err := j.next()
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	putData, err = j.s.put(true, id, context, buf, serverHalf, next.String())
+	err = j.s.addReference(ctx, id, context, next.String())
 	if err != nil {
-		return false, err
-	}
-
-	if putData {
-		var putFiles int64 = filesPerBlockMax
-		err = j.accumulateBlock(int64(len(buf)), putFiles)
-		if err != nil {
-			return false, err
-		}
+		return err
 	}
 
 	_, err = j.appendJournalEntry(ctx, blockJournalEntry{
 		Op:       blockPutOp,
 		Contexts: kbfsblock.ContextMap{id: {context}},
 	})
-	if err != nil {
-		return false, err
-	}
-
-	return putData, nil
+	return err
 }
 
 func (j *blockJournal) addReference(
@@ -469,7 +484,7 @@ func (j *blockJournal) addReference(
 		return err
 	}
 
-	err = j.s.addReference(id, context, next.String())
+	err = j.s.addReference(ctx, id, context, next.String())
 	if err != nil {
 		return err
 	}
@@ -500,7 +515,7 @@ func (j *blockJournal) archiveReferences(
 		return err
 	}
 
-	err = j.s.archiveReferences(contexts, next.String())
+	err = j.s.archiveReferences(ctx, contexts, next.String())
 	if err != nil {
 		return err
 	}
@@ -545,7 +560,7 @@ func (j *blockJournal) removeReferences(
 		// Remove the references unconditionally here (i.e.,
 		// with an empty tag), since j.s should reflect the
 		// most recent state.
-		liveCount, err := j.s.removeReferences(id, idContexts, "")
+		liveCount, err := j.s.removeReferences(ctx, id, idContexts, "")
 		if err != nil {
 			return nil, err
 		}
@@ -693,7 +708,7 @@ func (j *blockJournal) getNextEntriesToFlush(
 					kbfsmd.RevisionUninitialized, err
 			}
 
-			data, serverHalf, err = j.s.getData(id)
+			data, serverHalf, err = j.s.getData(ctx, id)
 			if err != nil {
 				return blockEntriesToFlush{}, 0,
 					kbfsmd.RevisionUninitialized, err
@@ -851,12 +866,12 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 			return 0, err
 		}
 
-		err = j.s.markFlushed(id)
+		err = j.s.markFlushed(ctx, id)
 		if err != nil {
 			return 0, err
 		}
 
-		flushedBytes, err = j.s.getDataSize(id)
+		flushedBytes, err = j.s.getDataSize(ctx, id)
 		if err != nil {
 			return 0, err
 		}
@@ -874,7 +889,7 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 	// references).
 	for id, idContexts := range entry.Contexts {
 		liveCount, err := j.s.removeReferences(
-			id, idContexts, earliestOrdinal.String())
+			ctx, id, idContexts, earliestOrdinal.String())
 		if err != nil {
 			return 0, err
 		}
@@ -974,7 +989,7 @@ func (j *blockJournal) ignoreBlocksAndMDRevMarkersInJournal(ctx context.Context,
 			if e.Op == blockPutOp && isMainJournal {
 				// Treat ignored put ops as flushed
 				// for the purposes of accounting.
-				ignoredBytes, err := j.s.getDataSize(id)
+				ignoredBytes, err := j.s.getDataSize(ctx, id)
 				if err != nil {
 					return 0, err
 				}
@@ -1090,7 +1105,7 @@ func (j *blockJournal) doGC(ctx context.Context,
 		for id := range entry.Contexts {
 			// TODO: once we support references, this needs to be made
 			// goroutine-safe.
-			hasRef, err := j.s.hasAnyRef(id)
+			hasRef, err := j.s.hasAnyRef(ctx, id)
 			if err != nil {
 				return 0, 0, err
 			}

--- a/go/kbfs/libkbfs/block_journal.go
+++ b/go/kbfs/libkbfs/block_journal.go
@@ -426,7 +426,7 @@ func (j *blockJournal) putBlockData(
 		}
 	}()
 
-	putData, err = j.s.put(ctx, true, id, context, buf, serverHalf, "")
+	putData, err = j.s.put(ctx, true, id, context, buf, serverHalf)
 	if err != nil {
 		return false, err
 	}

--- a/go/kbfs/libkbfs/block_journal.go
+++ b/go/kbfs/libkbfs/block_journal.go
@@ -439,7 +439,7 @@ func (j *blockJournal) putBlockData(
 func (j *blockJournal) appendBlock(
 	ctx context.Context, id kbfsblock.ID, context kbfsblock.Context,
 	bufLenToAdd int64) error {
-	j.log.CDebugf(ctx, "Appending %block %s to journal", id)
+	j.log.CDebugf(ctx, "Appending block %s to journal", id)
 
 	if bufLenToAdd > 0 {
 		var putFiles int64 = filesPerBlockMax

--- a/go/kbfs/libkbfs/block_ops.go
+++ b/go/kbfs/libkbfs/block_ops.go
@@ -65,7 +65,7 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd libkey.KeyMetadata,
 	// the block-fetching queue.
 	if journalBServer, ok := b.config.BlockServer().(journalBlockServer); ok {
 		data, serverHalf, found, err := journalBServer.getBlockFromJournal(
-			kmd.TlfID(), blockPtr.ID)
+			ctx, kmd.TlfID(), blockPtr.ID)
 		if err != nil {
 			return err
 		}
@@ -96,7 +96,7 @@ func (b *BlockOpsStandard) GetEncodedSize(ctx context.Context, kmd libkey.KeyMet
 	// the block-fetching queue.
 	if journalBServer, ok := b.config.BlockServer().(journalBlockServer); ok {
 		size, found, err := journalBServer.getBlockSizeFromJournal(
-			kmd.TlfID(), blockPtr.ID)
+			ctx, kmd.TlfID(), blockPtr.ID)
 		if err != nil {
 			return 0, 0, err
 		}

--- a/go/kbfs/libkbfs/bserver_disk.go
+++ b/go/kbfs/libkbfs/bserver_disk.go
@@ -228,12 +228,14 @@ func (b *BlockServerDisk) Put(
 		return errBlockServerDiskShutdown
 	}
 
-	_, err = tlfStorage.store.put(
-		ctx, true, id, context, buf, serverHalf, "tag")
+	_, err = tlfStorage.store.put(ctx, true, id, context, buf, serverHalf)
 	if err != nil {
 		return err
 	}
-
+	err = tlfStorage.store.addReference(ctx, id, context, "tag")
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -263,8 +265,11 @@ func (b *BlockServerDisk) PutAgain(
 		return errBlockServerDiskShutdown
 	}
 
-	_, err = tlfStorage.store.put(
-		ctx, false, id, context, buf, serverHalf, "tag")
+	_, err = tlfStorage.store.put(ctx, false, id, context, buf, serverHalf)
+	if err != nil {
+		return err
+	}
+	err = tlfStorage.store.addReference(ctx, id, context, "tag")
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/journal_block_server.go
+++ b/go/kbfs/libkbfs/journal_block_server.go
@@ -21,7 +21,7 @@ type journalBlockServer struct {
 var _ BlockServer = journalBlockServer{}
 
 func (j journalBlockServer) getBlockFromJournal(
-	tlfID tlf.ID, id kbfsblock.ID) (
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf,
 	found bool, err error) {
 	tlfJournal, ok := j.jManager.getTLFJournal(tlfID, nil)
@@ -32,7 +32,7 @@ func (j journalBlockServer) getBlockFromJournal(
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
-	data, serverHalf, err = tlfJournal.getBlockData(id)
+	data, serverHalf, err = tlfJournal.getBlockData(ctx, id)
 	switch errors.Cause(err).(type) {
 	case nil:
 		return data, serverHalf, true, nil
@@ -46,7 +46,7 @@ func (j journalBlockServer) getBlockFromJournal(
 }
 
 func (j journalBlockServer) getBlockSizeFromJournal(
-	tlfID tlf.ID, id kbfsblock.ID) (
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID) (
 	size uint32, found bool, err error) {
 	tlfJournal, ok := j.jManager.getTLFJournal(tlfID, nil)
 	if !ok {
@@ -56,7 +56,7 @@ func (j journalBlockServer) getBlockSizeFromJournal(
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
-	size, err = tlfJournal.getBlockSize(id)
+	size, err = tlfJournal.getBlockSize(ctx, id)
 	switch errors.Cause(err).(type) {
 	case nil:
 		return size, true, nil
@@ -78,7 +78,7 @@ func (j journalBlockServer) Get(
 		j.jManager.deferLog.LazyTrace(ctx, "jBServer: Get %s done (err=%v)", id, err)
 	}()
 
-	data, serverHalf, found, err := j.getBlockFromJournal(tlfID, id)
+	data, serverHalf, found, err := j.getBlockFromJournal(ctx, tlfID, id)
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
 	}
@@ -200,7 +200,7 @@ func (j journalBlockServer) IsUnflushed(ctx context.Context, tlfID tlf.ID,
 		defer func() {
 			err = translateToBlockServerError(err)
 		}()
-		return tlfJournal.isBlockUnflushed(id)
+		return tlfJournal.isBlockUnflushed(ctx, id)
 	}
 
 	return j.BlockServer.IsUnflushed(ctx, tlfID, id)

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -288,7 +288,7 @@ type tlfJournal struct {
 	// block (in parallel with other blocks), then clear out the whole
 	// block journal before appending the block's entry to the block
 	// journal.  Should be taken before `journalLock`.
-	blockPutLock sync.RWMutex
+	blockPutFlushLock sync.RWMutex
 
 	// Protects all operations on blockJournal and mdJournal, and all
 	// the fields until the next blank line.
@@ -1400,8 +1400,8 @@ func (j *tlfJournal) doOnMDFlushAndRemoveFlushedMDEntry(ctx context.Context,
 			removedFiles)
 	}
 
-	j.blockPutLock.Lock()
-	defer j.blockPutLock.Unlock()
+	j.blockPutFlushLock.Lock()
+	defer j.blockPutFlushLock.Unlock()
 
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
@@ -2082,8 +2082,8 @@ func (j *tlfJournal) putBlockData(
 			filesPerBlockMax, putData, j.chargedTo)
 	}()
 
-	j.blockPutLock.RLock()
-	defer j.blockPutLock.RUnlock()
+	j.blockPutFlushLock.RLock()
+	defer j.blockPutFlushLock.RUnlock()
 
 	// Put the block data before taking the lock, so block puts can
 	// run in parallel.

--- a/go/kbfs/test/benchmark_test.go
+++ b/go/kbfs/test/benchmark_test.go
@@ -267,6 +267,7 @@ func BenchmarkWriteMixedFilesNormalBandwidth(b *testing.B) {
 
 func benchmarkMultiFileSync(
 	b *testing.B, numFiles, fileSize int, timeWrites, timeFlush bool) {
+	isolateStages := !timeWrites || !timeFlush
 	benchmark(b,
 		journal(),
 		users("alice"),
@@ -276,8 +277,13 @@ func benchmarkMultiFileSync(
 		),
 		as(alice,
 			enableJournal(),
-			pauseJournal(),
 			custom(func(cb func(fileOp) error) error {
+				if isolateStages {
+					// If we want to time one of the stages
+					// separately, pause the journal.
+					cb(pauseJournal())
+				}
+
 				var n int
 				cb(getBenchN(&n))
 				buf := make([]byte, numFiles*fileSize+fileSize)
@@ -316,9 +322,13 @@ func benchmarkMultiFileSync(
 					if !timeFlush {
 						cb(stopTimer())
 					}
-					cb(resumeJournal())
+					if isolateStages {
+						cb(resumeJournal())
+					}
 					cb(flushJournal())
-					cb(pauseJournal())
+					if isolateStages {
+						cb(pauseJournal())
+					}
 					if !timeFlush {
 						cb(startTimer())
 					}
@@ -343,4 +353,16 @@ func BenchmarkMultiFileSyncLargeFlush(b *testing.B) {
 
 func BenchmarkMultiFileSyncLarge(b *testing.B) {
 	benchmarkMultiFileSync(b, 1000, 5, true, true)
+}
+
+func BenchmarkMultiFileSyncBigFilesWrites(b *testing.B) {
+	benchmarkMultiFileSync(b, 5, 1*1024*1024, true, false)
+}
+
+func BenchmarkMultiFileSyncBigFilesFlush(b *testing.B) {
+	benchmarkMultiFileSync(b, 5, 1*1024*1024, false, true)
+}
+
+func BenchmarkMultiFileSyncBigFiles(b *testing.B) {
+	benchmarkMultiFileSync(b, 5, 1*1024*1024, true, true)
 }


### PR DESCRIPTION
This allows the `SyncAll` code to write the data for multiple blocks in parallel to the disk (but still appends  knowledge of their existence to the journal serially).

Since `blockDiskStore` relied on the upper layer taking a lock during block puts, this required adding rudimentary, per-id exclusivity guarantees from the blockDiskStore, which required plumbing contexts everywhere.

Also, I added a new benchmark that uses big files (instead of lots of small ones) to show the promise of this change.  In the new benchmark, this change resulted in a 20% performance boost for the file-writing phase, and a 15% boost overall when flushing is done concurrently.  Here are results from my new desktop, which has fast M2 SSD memory:

Before this change:

```sh
$ go test -c -tags fuse && ./test.test -test.v -test.bench "BenchmarkMultiFileSyncBigFiles/MDVer\(ImplicitTeams\)" -test.run ^$ -test.benchtime 5s
goos: linux
goarch: amd64
pkg: github.com/keybase/client/go/kbfs/test
BenchmarkMultiFileSyncBigFilesWrites/MDVer(ImplicitTeams)-8         	      50	 126566790 ns/op
BenchmarkMultiFileSyncBigFilesFlush/MDVer(ImplicitTeams)-8          	     100	  62642402 ns/op
BenchmarkMultiFileSyncBigFiles/MDVer(ImplicitTeams)-8               	      50	 169649031 ns/op
PASS
```

After this change:

```sh
$ go test -c -tags fuse && ./test.test -test.v -test.bench "BenchmarkMultiFileSyncBigFiles/MDVer\(ImplicitTeams\)" -test.run ^$ -test.benchtime 5s
goos: linux
goarch: amd64
pkg: github.com/keybase/client/go/kbfs/test
BenchmarkMultiFileSyncBigFilesWrites/MDVer(ImplicitTeams)-8         	     100	 100686847 ns/op
BenchmarkMultiFileSyncBigFilesFlush/MDVer(ImplicitTeams)-8          	     100	  63893657 ns/op
BenchmarkMultiFileSyncBigFiles/MDVer(ImplicitTeams)-8               	      50	 145764578 ns/op
PASS
```

Further, I tested a real-world benchmark of copying the 501 MB from `/keybase/team/keybase/pictures` into KBFS, in the default configuration where flushing happens concurrently.  I saw a nearly 30% boost in that case:

Before this change:
```sh
$ time rsync -atrvp pictures /keybase/private/strib/tmp/pictures-test-1
...
sent 525,053,620 bytes  received 2,498 bytes  36,210,766.76 bytes/sec
total size is 524,916,752  speedup is 1.00

real	0m14.130s
user	0m1.877s
sys	0m0.541s
```

After this change:
```sh
$ time rsync -atrvp pictures /keybase/private/strib/tmp/pictures-test-2
...
sent 525,053,620 bytes  received 2,498 bytes  50,005,344.57 bytes/sec
total size is 524,916,752  speedup is 1.00

real	0m10.063s
user	0m1.728s
sys	0m0.566s
```


Issue: KBFS-3980