### PR TITLE
preliminaries for user switching and also cleanups

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -90,7 +90,7 @@ func (b *baseInboxSource) notifyTlfFinalize(ctx context.Context, username string
 	if err != nil {
 		b.Debug(ctx, "notifyTlfFinalize: failed to load finalize user, skipping user changed notification: err: %s", err.Error())
 	} else {
-		b.G().UserChanged(finalizeUser.GetUID())
+		b.G().UserChanged(ctx, finalizeUser.GetUID())
 	}
 }
 

--- a/go/client/cmd_git_mdget.go
+++ b/go/client/cmd_git_mdget.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -33,6 +34,7 @@ func NewCmdGitMdget(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 // RunClient runs the command in client/server mode.
 func (c *CmdGitMdget) Run() error {
 	cli, err := GetGitClient(c.G())
+	ctx := context.Background()
 	if err != nil {
 		return err
 	}
@@ -43,12 +45,12 @@ func (c *CmdGitMdget) Run() error {
 		if err != nil {
 			return err
 		}
-		res, err = cli.GetGitMetadata(c.G().GetNetContext(), folder)
+		res, err = cli.GetGitMetadata(ctx, folder)
 		if err != nil {
 			return err
 		}
 	} else {
-		res, err = cli.GetAllGitMetadata(c.G().GetNetContext())
+		res, err = cli.GetAllGitMetadata(ctx)
 		if err != nil {
 			return err
 		}

--- a/go/client/cmd_git_mdput.go
+++ b/go/client/cmd_git_mdput.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/keybase/cli"
@@ -42,8 +43,8 @@ func (c *CmdGitMdput) Run() error {
 	if err != nil {
 		return err
 	}
-
-	return cli.PutGitMetadata(c.G().GetNetContext(), keybase1.PutGitMetadataArg{
+	ctx := context.Background()
+	return cli.PutGitMetadata(ctx, keybase1.PutGitMetadataArg{
 		Folder: folder,
 		RepoID: keybase1.RepoID(c.repoID),
 		Metadata: keybase1.GitLocalMetadata{

--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -157,7 +157,7 @@ func (e *DeviceAdd) Run(m libkb.MetaContext) (err error) {
 		return err
 	}
 
-	m.G().KeyfamilyChanged(m.G().Env.GetUID())
+	m.G().KeyfamilyChanged(m.Ctx(), m.G().Env.GetUID())
 
 	return nil
 }

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -122,7 +122,7 @@ func (e *loginProvision) Run(m libkb.MetaContext) error {
 
 	e.displaySuccess(m)
 
-	m.G().KeyfamilyChanged(e.arg.User.GetUID())
+	m.G().KeyfamilyChanged(m.Ctx(), e.arg.User.GetUID())
 
 	// check to make sure local files stored correctly
 	verifyLocalStorage(m, e.username, e.arg.User.GetUID())

--- a/go/engine/paperkey_gen.go
+++ b/go/engine/paperkey_gen.go
@@ -122,7 +122,7 @@ func (e *PaperKeyGen) Run(m libkb.MetaContext) error {
 		return nil
 	}
 
-	e.G().KeyfamilyChanged(e.getUID())
+	e.G().KeyfamilyChanged(m.Ctx(), e.getUID())
 
 	return nil
 }

--- a/go/engine/paperkey_submit.go
+++ b/go/engine/paperkey_submit.go
@@ -63,7 +63,7 @@ func (e *PaperKeySubmit) Run(m libkb.MetaContext) error {
 	m.G().NotifyRouter.HandlePaperKeyCached(me.GetUID(), e.deviceWithKeys.EncryptionKey().GetKID(), e.deviceWithKeys.SigningKey().GetKID())
 
 	// XXX - this is temporary until KBFS handles the above notification
-	m.G().UserChanged(me.GetUID())
+	m.G().UserChanged(m.Ctx(), me.GetUID())
 
 	return nil
 }

--- a/go/engine/puk_roll.go
+++ b/go/engine/puk_roll.go
@@ -202,7 +202,7 @@ func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
 		}
 	}
 
-	m.G().UserChanged(uid)
+	m.G().UserChanged(m.Ctx(), uid)
 	return nil
 }
 

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -315,7 +315,7 @@ func (e *RevokeEngine) Run(m libkb.MetaContext) error {
 		}
 	}
 
-	e.G().UserChanged(me.GetUID())
+	e.G().UserChanged(m.Ctx(), me.GetUID())
 
 	return nil
 }

--- a/go/engine/selfprovision.go
+++ b/go/engine/selfprovision.go
@@ -266,6 +266,6 @@ func (e *SelfProvisionEngine) clearCaches(m libkb.MetaContext) {
 }
 
 func (e *SelfProvisionEngine) sendNotification(m libkb.MetaContext) {
-	e.G().KeyfamilyChanged(e.User.GetUID())
+	e.G().KeyfamilyChanged(m.Ctx(), e.User.GetUID())
 	e.G().NotifyRouter.HandleLogin(m.Ctx(), string(e.G().Env.GetUsername()))
 }

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -135,11 +135,11 @@ func (e *TrackToken) Run(m libkb.MetaContext) (err error) {
 
 	if err == nil {
 		// Remove this after desktop notification change complete:
-		m.G().UserChanged(e.them.GetUID())
+		m.G().UserChanged(m.Ctx(), e.them.GetUID())
 
 		// Remove these after desktop notification change complete, but
 		// add in: m.G().BustLocalUserCache(e.arg.Me.GetUID())
-		m.G().UserChanged(e.arg.Me.GetUID())
+		m.G().UserChanged(m.Ctx(), e.arg.Me.GetUID())
 
 		// Keep these:
 		m.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetNormalizedName(), false)

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -104,8 +104,8 @@ func (e *UntrackEngine) Run(m libkb.MetaContext) (err error) {
 		return
 	}
 
-	e.G().UserChanged(e.arg.Me.GetUID())
-	e.G().UserChanged(them.GetUID())
+	e.G().UserChanged(m.Ctx(), e.arg.Me.GetUID())
+	e.G().UserChanged(m.Ctx(), them.GetUID())
 
 	e.G().NotifyRouter.HandleTrackingChanged(e.arg.Me.GetUID(), e.arg.Me.GetNormalizedName(), false)
 	e.G().NotifyRouter.HandleTrackingChanged(them.GetUID(), them.GetNormalizedName(), false)

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -285,7 +285,7 @@ func TestUPAKDeadlock(t *testing.T) {
 	fu := CreateAndSignupFakeUserPaper(tc, "upak")
 
 	// First clear the cache
-	tc.G.KeyfamilyChanged(fu.UID())
+	tc.G.KeyfamilyChanged(context.TODO(), fu.UID())
 
 	var wg sync.WaitGroup
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -144,7 +144,7 @@ type GlobalContext struct {
 	// user (and resetting the ActiveDevice), then you should hold the switchUserMu
 	switchUserMu  *VerboseLock
 	ActiveDevice  *ActiveDevice
-	switchedUsers map[NormalizedUsername]bool
+	switchedUsers map[NormalizedUsername]bool // bookkeep users who have been switched over (and are still in secret store)
 }
 
 type GlobalTestOptions struct {
@@ -286,7 +286,12 @@ func (g *GlobalContext) logoutSecretStore(mctx MetaContext, username NormalizedU
 
 	if err := g.secretStore.ClearSecret(mctx, username); err != nil {
 		mctx.Debug("clear stored secret error: %s", err)
+		return
 	}
+
+	// If this user had previously switched into his account and wound up in the
+	// g.switchedUsers map (see just above), then now it's fine to delete them,
+	// since they are deleted from the secret store successfully.
 	delete(g.switchedUsers, username)
 }
 

--- a/go/saltpackkeys/saltpack_recipient_keyfinder_engine_test.go
+++ b/go/saltpackkeys/saltpack_recipient_keyfinder_engine_test.go
@@ -350,9 +350,10 @@ func TestSaltpackRecipientKeyfinderDeviceKeys(t *testing.T) {
 	tcY := SetupKeyfinderEngineTest(t, "SaltpackRecipientKeyfinderEngine2") // context for second device
 	defer tcY.Cleanup()
 	kbtest.ProvisionNewDeviceKex(&tc, &tcY, u2, libkb.DeviceTypeDesktop)
-	tc.G.BustLocalUserCache(u2.GetUID())
+	m := libkb.NewMetaContextForTest(tc)
+	tc.G.BustLocalUserCache(m.Ctx(), u2.GetUID())
 	tc.G.GetUPAKLoader().ClearMemory()
-	u2new, err := libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(libkb.NewMetaContextForTest(tc)))
+	u2new, err := libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(m))
 	require.NoError(t, err)
 
 	u3, err := kbtest.CreateAndSignupFakeUser("spkfe", tc.G)
@@ -368,7 +369,7 @@ func TestSaltpackRecipientKeyfinderDeviceKeys(t *testing.T) {
 		UseDeviceKeys: true,
 	}
 	eng := NewSaltpackRecipientKeyfinderEngineAsInterfaceForTesting(arg)
-	m := libkb.NewMetaContextForTest(tc).WithUIs(uis)
+	m = m.WithUIs(uis)
 	if err := engine.RunEngine2(m, eng); err != nil {
 		t.Fatal(err)
 	}
@@ -581,9 +582,10 @@ func TestSaltpackRecipientKeyfinderDevicePaperAndPerUserKeys(t *testing.T) {
 	tcY := SetupKeyfinderEngineTest(t, "SaltpackRecipientKeyfinderEngine2") // context for second device
 	defer tcY.Cleanup()
 	kbtest.ProvisionNewDeviceKex(&tc, &tcY, u2, libkb.DeviceTypeDesktop)
-	tc.G.BustLocalUserCache(u2.GetUID())
+	m := libkb.NewMetaContextForTest(tc)
+	tc.G.BustLocalUserCache(m.Ctx(), u2.GetUID())
 	tc.G.GetUPAKLoader().ClearMemory()
-	u2new, err := libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(libkb.NewMetaContextForTest(tc)))
+	u2new, err := libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(m))
 	require.NoError(t, err)
 
 	u3, err := kbtest.CreateAndSignupFakeUserPaper("spkfe", tc.G)
@@ -601,7 +603,7 @@ func TestSaltpackRecipientKeyfinderDevicePaperAndPerUserKeys(t *testing.T) {
 		UseEntityKeys: true,
 	}
 	eng := NewSaltpackRecipientKeyfinderEngineAsInterfaceForTesting(arg)
-	m := libkb.NewMetaContextForTest(tc).WithUIs(uis)
+	m = m.WithUIs(uis)
 	if err := engine.RunEngine2(m, eng); err != nil {
 		t.Fatal(err)
 	}

--- a/go/service/user_handler.go
+++ b/go/service/user_handler.go
@@ -44,14 +44,14 @@ func (r *userHandler) Create(ctx context.Context, cli gregor1.IncomingInterface,
 }
 
 func (r *userHandler) keyChange(m libkb.MetaContext) error {
-	m.G().KeyfamilyChanged(m.G().Env.GetUID())
+	m.G().KeyfamilyChanged(m.Ctx(), m.G().Env.GetUID())
 
 	// check if this device was just revoked and if so, log out
 	return m.LogoutAndDeprovisionIfRevoked()
 }
 
 func (r *userHandler) identityChange(m libkb.MetaContext) error {
-	m.G().UserChanged(m.G().Env.GetUID())
+	m.G().UserChanged(m.Ctx(), m.G().Env.GetUID())
 	return nil
 }
 

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -139,7 +139,7 @@ func PostWithChainlink(mctx libkb.MetaContext, clearBundle stellar1.Bundle) (err
 		return err
 	}
 
-	mctx.G().UserChanged(uid)
+	mctx.G().UserChanged(mctx.Ctx(), uid)
 	return nil
 }
 

--- a/go/teams/showcase_helper.go
+++ b/go/teams/showcase_helper.go
@@ -142,6 +142,6 @@ func SetTeamMemberShowcase(ctx context.Context, g *libkb.GlobalContext, teamname
 	if err := g.CardCache().Delete(u); err != nil {
 		mctx.Debug("Error in CardCache.Delete: %s", err)
 	}
-	g.UserChanged(u)
+	g.UserChanged(ctx, u)
 	return nil
 }


### PR DESCRIPTION
- get rid of `context.Context` inside of `GlobalContext`
- pass `context.Context` through to some methods on `GlobalContext`