### PR TITLE
MetaContext for ephemeral, erasablekvstore packages

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -311,7 +311,7 @@ func (b *Boxer) UnboxMessage(ctx context.Context, boxed chat1.MessageBoxed, conv
 		var ephemeralSeed *keybase1.TeamEk
 		if boxed.IsEphemeral() {
 			ek, err := CtxKeyFinder(ctx, b.G()).EphemeralKeyForDecryption(
-				ctx, tlfName, boxed.ClientHeader.Conv.Tlfid, conv.GetMembersType(),
+				b.G().MetaContext(ctx), tlfName, boxed.ClientHeader.Conv.Tlfid, conv.GetMembersType(),
 				boxed.ClientHeader.TlfPublic, boxed.EphemeralMetadata().Generation,
 				&boxed.ServerHeader.Ctime)
 			if err != nil {
@@ -1309,7 +1309,7 @@ func (b *Boxer) GetEncryptionInfo(ctx context.Context, msg *chat1.MessagePlainte
 	var pairwiseMACRecipients []keybase1.KID
 	if msg.IsEphemeral() {
 		ek, err := CtxKeyFinder(ctx, b.G()).EphemeralKeyForEncryption(
-			ctx, tlfName, msg.ClientHeader.Conv.Tlfid, membersType, msg.ClientHeader.TlfPublic)
+			b.G().MetaContext(ctx), tlfName, msg.ClientHeader.Conv.Tlfid, membersType, msg.ClientHeader.TlfPublic)
 		if err != nil {
 			return res, NewBoxingCryptKeysError(err)
 		}

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -1609,12 +1609,12 @@ func (k *KeyFinderMock) FindForDecryption(ctx context.Context,
 	return res, NewDecryptionKeyNotFoundError(keyGeneration, public, kbfsEncrypted)
 }
 
-func (k *KeyFinderMock) EphemeralKeyForEncryption(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (k *KeyFinderMock) EphemeralKeyForEncryption(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (keybase1.TeamEk, error) {
 	panic("unimplemented")
 }
 
-func (k *KeyFinderMock) EphemeralKeyForDecryption(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (k *KeyFinderMock) EphemeralKeyForDecryption(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error) {
 	panic("unimplemented")

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -771,12 +771,12 @@ func (f failingTlf) DecryptionKey(ctx context.Context, tlfName string, tlfID cha
 	return nil, nil
 }
 
-func (f failingTlf) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (f failingTlf) EphemeralEncryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (keybase1.TeamEk, error) {
 	panic("unimplemented")
 }
 
-func (f failingTlf) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (f failingTlf) EphemeralDecryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error) {
 	panic("unimplemented")

--- a/go/chat/keyfinder.go
+++ b/go/chat/keyfinder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -20,9 +21,9 @@ type KeyFinder interface {
 	FindForDecryption(ctx context.Context, tlfName string, teamID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool, keyGeneration int,
 		kbfsEncrypted bool) (types.CryptKey, error)
-	EphemeralKeyForEncryption(ctx context.Context, tlfName string, teamID chat1.TLFID,
+	EphemeralKeyForEncryption(mctx libkb.MetaContext, tlfName string, teamID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool) (keybase1.TeamEk, error)
-	EphemeralKeyForDecryption(ctx context.Context, tlfName string, teamID chat1.TLFID,
+	EphemeralKeyForDecryption(mctx libkb.MetaContext, tlfName string, teamID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool,
 		generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
 	ShouldPairwiseMAC(ctx context.Context, tlfName string, teamID chat1.TLFID,
@@ -162,16 +163,17 @@ func (k *KeyFinderImpl) FindForDecryption(ctx context.Context,
 		membersType, public, keyGeneration, kbfsEncrypted)
 }
 
-func (k *KeyFinderImpl) EphemeralKeyForEncryption(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (k *KeyFinderImpl) EphemeralKeyForEncryption(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (ek keybase1.TeamEk, err error) {
-	return k.createNameInfoSource(ctx, membersType).EphemeralEncryptionKey(ctx, tlfName, tlfID, membersType, public)
+	return k.createNameInfoSource(mctx.Ctx(), membersType).EphemeralEncryptionKey(
+		mctx, tlfName, tlfID, membersType, public)
 }
 
-func (k *KeyFinderImpl) EphemeralKeyForDecryption(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (k *KeyFinderImpl) EphemeralKeyForDecryption(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error) {
-	return k.createNameInfoSource(ctx, membersType).EphemeralDecryptionKey(
-		ctx, tlfName, tlfID, membersType, public, generation, contentCtime)
+	return k.createNameInfoSource(mctx.Ctx(), membersType).EphemeralDecryptionKey(
+		mctx, tlfName, tlfID, membersType, public, generation, contentCtime)
 }
 
 func (k *KeyFinderImpl) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,

--- a/go/chat/sbs_test.go
+++ b/go/chat/sbs_test.go
@@ -124,8 +124,10 @@ func runChatSBSScenario(t *testing.T, testCase sbsTestCase) {
 			// If we are sending ephemeral messages make sure both users have
 			// user/device EKs
 			if ephemeralLifetime != nil {
-				ctc.as(t, users[0]).h.G().GetEKLib().KeygenIfNeeded(context.Background())
-				ctc.as(t, users[1]).h.G().GetEKLib().KeygenIfNeeded(context.Background())
+				u1 := ctc.as(t, users[0])
+				u1.h.G().GetEKLib().KeygenIfNeeded(u1.h.G().MetaContext(context.Background()))
+				u2 := ctc.as(t, users[1])
+				u2.h.G().GetEKLib().KeygenIfNeeded(u2.h.G().MetaContext(context.Background()))
 			}
 
 			tc1 := ctc.world.Tcs[users[1].Username]

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -182,7 +182,8 @@ func NewChatMockWorld(t *testing.T, name string, numUsers int) (world *kbtest.Ch
 	res := kbtest.NewChatMockWorld(t, name, numUsers)
 	for _, w := range res.Tcs {
 		teams.ServiceInit(w.G)
-		ephemeral.ServiceInit(w.G)
+		mctx := libkb.NewMetaContextTODO(w.G)
+		ephemeral.ServiceInit(mctx)
 	}
 	return res
 }
@@ -1355,8 +1356,10 @@ func TestPairwiseMACChecker(t *testing.T) {
 
 		tc1 := ctc.world.Tcs[users[0].Username]
 		tc2 := ctc.world.Tcs[users[1].Username]
-		require.NoError(t, tc1.G.GetEKLib().KeygenIfNeeded(ctx1))
-		require.NoError(t, tc2.G.GetEKLib().KeygenIfNeeded(ctx2))
+		require.NoError(t, tc1.G.GetEKLib().KeygenIfNeeded(
+			ctc.as(t, users[0]).h.G().MetaContext(ctx1)))
+		require.NoError(t, tc2.G.GetEKLib().KeygenIfNeeded(
+			ctc.as(t, users[1]).h.G().MetaContext(ctx2)))
 		uid1 := users[0].User.GetUID()
 		uid2 := users[1].User.GetUID()
 		ri1 := ctc.as(t, users[0]).ri

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -404,7 +404,7 @@ func (t *TeamsNameInfoSource) DecryptionKey(ctx context.Context, name string, te
 		kbfsEncrypted)
 }
 
-func (t *TeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (t *TeamsNameInfoSource) EphemeralEncryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (teamEK keybase1.TeamEk, err error) {
 	if public {
 		return teamEK, NewPublicTeamEphemeralKeyError()
@@ -414,11 +414,11 @@ func (t *TeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfNam
 	if err != nil {
 		return teamEK, err
 	}
-	teamEK, _, err = t.G().GetEKLib().GetOrCreateLatestTeamEK(ctx, teamID)
+	teamEK, _, err = t.G().GetEKLib().GetOrCreateLatestTeamEK(mctx, teamID)
 	return teamEK, err
 }
 
-func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (t *TeamsNameInfoSource) EphemeralDecryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
 	if public {
@@ -429,7 +429,7 @@ func (t *TeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfNam
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation, contentCtime)
+	return t.G().GetEKLib().GetTeamEK(mctx, teamID, generation, contentCtime)
 }
 
 func (t *TeamsNameInfoSource) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,
@@ -708,24 +708,24 @@ func (t *ImplicitTeamsNameInfoSource) ephemeralLoadAndIdentify(ctx context.Conte
 	return team.ID, nil
 }
 
-func (t *ImplicitTeamsNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (t *ImplicitTeamsNameInfoSource) EphemeralEncryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (teamEK keybase1.TeamEk, err error) {
-	teamID, err := t.ephemeralLoadAndIdentify(ctx, tlfName, tlfID, membersType, public)
+	teamID, err := t.ephemeralLoadAndIdentify(mctx.Ctx(), tlfName, tlfID, membersType, public)
 	if err != nil {
 		return teamEK, err
 	}
-	teamEK, _, err = t.G().GetEKLib().GetOrCreateLatestTeamEK(ctx, teamID)
+	teamEK, _, err = t.G().GetEKLib().GetOrCreateLatestTeamEK(mctx, teamID)
 	return teamEK, err
 }
 
-func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (t *ImplicitTeamsNameInfoSource) EphemeralDecryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
-	teamID, err := t.ephemeralLoadAndIdentify(ctx, tlfName, tlfID, membersType, public)
+	teamID, err := t.ephemeralLoadAndIdentify(mctx.Ctx(), tlfName, tlfID, membersType, public)
 	if err != nil {
 		return teamEK, err
 	}
-	return t.G().GetEKLib().GetTeamEK(ctx, teamID, generation, contentCtime)
+	return t.G().GetEKLib().GetTeamEK(mctx, teamID, generation, contentCtime)
 }
 
 func (t *ImplicitTeamsNameInfoSource) ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,

--- a/go/chat/tlf.go
+++ b/go/chat/tlf.go
@@ -147,12 +147,12 @@ func (t *KBFSNameInfoSource) DecryptionKey(ctx context.Context, tlfName string, 
 	return nil, NewDecryptionKeyNotFoundError(keyGeneration, public, kbfsEncrypted)
 }
 
-func (t *KBFSNameInfoSource) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (t *KBFSNameInfoSource) EphemeralEncryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (teamEK keybase1.TeamEk, err error) {
 	return teamEK, fmt.Errorf("KBFSNameInfoSource doesn't support ephemeral keys")
 }
 
-func (t *KBFSNameInfoSource) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (t *KBFSNameInfoSource) EphemeralDecryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
 	return teamEK, fmt.Errorf("KBFSNameInfoSource doesn't support ephemeral keys")

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -46,9 +46,9 @@ type NameInfoSource interface {
 	DecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool,
 		keyGeneration int, kbfsEncrypted bool) (CryptKey, error)
-	EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	EphemeralEncryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool) (keybase1.TeamEk, error)
-	EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+	EphemeralDecryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 		membersType chat1.ConversationMembersType, public bool,
 		generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
 	ShouldPairwiseMAC(ctx context.Context, tlfName string, tlfID chat1.TLFID,

--- a/go/chat/unfurl_test.go
+++ b/go/chat/unfurl_test.go
@@ -353,7 +353,8 @@ func TestChatSrvUnfurl(t *testing.T) {
 
 		t.Logf("exploding unfurl: %v", ctc.world.Fc.Now())
 		dur := gregor1.ToDurationSec(120 * time.Minute)
-		ctc.as(t, users[0]).h.G().GetEKLib().KeygenIfNeeded(context.Background())
+		g := ctc.as(t, users[0]).h.G()
+		g.GetEKLib().KeygenIfNeeded(g.MetaContext(context.Background()))
 		origExplodeID := mustPostLocalEphemeralForTest(t, ctc, users[0], conv, msg, &dur)
 		consumeNewMsgRemote(t, listener0, chat1.MessageType_TEXT)
 		recvAndCheckUnfurlMsg(origExplodeID)

--- a/go/engine/device_keygen.go
+++ b/go/engine/device_keygen.go
@@ -264,7 +264,7 @@ func (e *DeviceKeygen) localSave(m libkb.MetaContext) {
 
 func (e *DeviceKeygen) reboxUserEK(m libkb.MetaContext, signingKey libkb.GenericKey) (reboxArg *keybase1.UserEkReboxArg, err error) {
 	defer m.Trace("DeviceKeygen#reboxUserEK", func() error { return err })()
-	ekKID, err := e.args.EkReboxer.getDeviceEKKID()
+	ekKID, err := e.args.EkReboxer.getDeviceEKKID(m)
 	if err != nil {
 		return nil, err
 	}

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -205,7 +205,7 @@ func (e *Kex2Provisionee) handleHello(m libkb.MetaContext, uid keybase1.UID, tok
 		return res, err
 	}
 
-	e.ekReboxer = newEphemeralKeyReboxer(m)
+	e.ekReboxer = newEphemeralKeyReboxer()
 
 	if err = e.addDeviceSibkey(m, jw); err != nil {
 		return res, err
@@ -234,7 +234,7 @@ func (e *Kex2Provisionee) HandleHello2(_ context.Context, harg keybase1.Hello2Ar
 	}
 	res.SigPayload = res1
 	res.EncryptionKey = e.dh.GetKID()
-	res.DeviceEkKID, err = e.ekReboxer.getDeviceEKKID()
+	res.DeviceEkKID, err = e.ekReboxer.getDeviceEKKID(m)
 	if err != nil {
 		return res, err
 	}

--- a/go/engine/puk_roll.go
+++ b/go/engine/puk_roll.go
@@ -54,24 +54,24 @@ func (e *PerUserKeyRoll) SubConsumers() []libkb.UIConsumer {
 }
 
 // Run starts the engine.
-func (e *PerUserKeyRoll) Run(m libkb.MetaContext) (err error) {
-	defer m.Trace("PerUserKeyRoll", func() error { return err })()
-	return e.inner(m)
+func (e *PerUserKeyRoll) Run(mctx libkb.MetaContext) (err error) {
+	defer mctx.Trace("PerUserKeyRoll", func() error { return err })()
+	return e.inner(mctx)
 }
 
-func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
+func (e *PerUserKeyRoll) inner(mctx libkb.MetaContext) error {
 	var err error
 
-	uid := m.G().GetMyUID()
+	uid := mctx.G().GetMyUID()
 	if uid.IsNil() {
 		return libkb.NoUIDError{}
 	}
 
 	me := e.args.Me
 	if me == nil {
-		m.Debug("PerUserKeyRoll load self")
+		mctx.Debug("PerUserKeyRoll load self")
 
-		loadArg := libkb.NewLoadUserArgWithMetaContext(m).
+		loadArg := libkb.NewLoadUserArgWithMetaContext(mctx).
 			WithUID(uid).
 			WithSelf(true).
 			WithPublicKeyOptional()
@@ -82,27 +82,27 @@ func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
 	}
 	meUPAK := me.ExportToUserPlusAllKeys()
 
-	sigKey, err := m.ActiveDevice().SigningKey()
+	sigKey, err := mctx.ActiveDevice().SigningKey()
 	if err != nil {
 		return fmt.Errorf("signing key not found: (%v)", err)
 	}
-	encKey, err := m.ActiveDevice().EncryptionKey()
+	encKey, err := mctx.ActiveDevice().EncryptionKey()
 	if err != nil {
 		return fmt.Errorf("encryption key not found: (%v)", err)
 	}
 
-	pukring, err := m.G().GetPerUserKeyring(m.Ctx())
+	pukring, err := mctx.G().GetPerUserKeyring(mctx.Ctx())
 	if err != nil {
 		return err
 	}
-	err = pukring.Sync(m)
+	err = pukring.Sync(mctx)
 	if err != nil {
 		return err
 	}
 
 	// Generation of the new key
 	gen := pukring.CurrentGeneration() + keybase1.PerUserKeyGeneration(1)
-	m.Debug("PerUserKeyRoll creating gen: %v", gen)
+	mctx.Debug("PerUserKeyRoll creating gen: %v", gen)
 
 	pukSeed, err := libkb.GeneratePerUserKeySeed()
 	if err != nil {
@@ -111,14 +111,14 @@ func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
 
 	var pukPrev *libkb.PerUserKeyPrev
 	if gen > 1 {
-		pukPrevInner, err := pukring.PreparePrev(m, pukSeed, gen)
+		pukPrevInner, err := pukring.PreparePrev(mctx, pukSeed, gen)
 		if err != nil {
 			return err
 		}
 		pukPrev = &pukPrevInner
 	}
 
-	pukReceivers, err := e.getPukReceivers(m, &meUPAK)
+	pukReceivers, err := e.getPukReceivers(mctx, &meUPAK)
 	if err != nil {
 		return err
 	}
@@ -127,14 +127,14 @@ func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
 	}
 
 	// Create boxes of the new per-user-key
-	pukBoxes, err := pukring.PrepareBoxesForDevices(m,
+	pukBoxes, err := pukring.PrepareBoxesForDevices(mctx,
 		pukSeed, gen, pukReceivers, encKey)
 	if err != nil {
 		return err
 	}
 
-	m.Debug("PerUserKeyRoll make sigs")
-	sig, err := libkb.PerUserKeyProofReverseSigned(m, me, pukSeed, gen, sigKey)
+	mctx.Debug("PerUserKeyRoll make sigs")
+	sig, err := libkb.PerUserKeyProofReverseSigned(mctx, me, pukSeed, gen, sigKey)
 	if err != nil {
 		return err
 	}
@@ -147,19 +147,19 @@ func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = sigsList
 
-	m.Debug("PerUserKeyRoll pukBoxes:%v pukPrev:%v for generation %v",
+	mctx.Debug("PerUserKeyRoll pukBoxes:%v pukPrev:%v for generation %v",
 		len(pukBoxes), pukPrev != nil, gen)
 	libkb.AddPerUserKeyServerArg(payload, gen, pukBoxes, pukPrev)
 
-	ekLib := m.G().GetEKLib()
+	ekLib := mctx.G().GetEKLib()
 	var myUserEKBox *keybase1.UserEkBoxed
 	var newUserEKMetadata *keybase1.UserEkMetadata
 	if ekLib != nil {
-		merkleRoot, err := m.G().GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+		merkleRoot, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 		if err != nil {
 			return err
 		}
-		sig, boxes, newMetadata, myBox, err := ekLib.PrepareNewUserEK(m.Ctx(), *merkleRoot, pukSeed)
+		sig, boxes, newMetadata, myBox, err := ekLib.PrepareNewUserEK(mctx, *merkleRoot, pukSeed)
 		if err != nil {
 			return err
 		}
@@ -173,12 +173,12 @@ func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
 			userEKSection["boxes"] = boxes
 			payload["user_ek"] = userEKSection
 		} else {
-			m.Debug("skipping userEK publishing, there are no valid deviceEKs")
+			mctx.Debug("skipping userEK publishing, there are no valid deviceEKs")
 		}
 	}
 
-	m.Debug("PerUserKeyRoll post")
-	_, err = m.G().API.PostJSON(m, libkb.APIArg{
+	mctx.Debug("PerUserKeyRoll post")
+	_, err = mctx.G().API.PostJSON(mctx, libkb.APIArg{
 		Endpoint:    "key/multi",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		JSONPayload: payload,
@@ -189,26 +189,26 @@ func (e *PerUserKeyRoll) inner(m libkb.MetaContext) error {
 	e.DidNewKey = true
 
 	// Add the per-user-key locally
-	err = pukring.AddKey(m, gen, pukSeqno, pukSeed)
+	err = pukring.AddKey(mctx, gen, pukSeqno, pukSeed)
 	if err != nil {
 		return err
 	}
 
 	// Add the new userEK box to local storage, if it was created above.
 	if myUserEKBox != nil {
-		err = m.G().GetUserEKBoxStorage().Put(m.Ctx(), newUserEKMetadata.Generation, *myUserEKBox)
+		err = mctx.G().GetUserEKBoxStorage().Put(mctx, newUserEKMetadata.Generation, *myUserEKBox)
 		if err != nil {
-			m.Error("error while saving userEK box: %s", err)
+			mctx.Error("error while saving userEK box: %s", err)
 		}
 	}
 
-	m.G().UserChanged(m.Ctx(), uid)
+	mctx.G().UserChanged(mctx.Ctx(), uid)
 	return nil
 }
 
 // Get the receivers of the new per-user-key boxes.
 // Includes all the user's device subkeys.
-func (e *PerUserKeyRoll) getPukReceivers(m libkb.MetaContext, meUPAK *keybase1.UserPlusAllKeys) (res []libkb.NaclDHKeyPair, err error) {
+func (e *PerUserKeyRoll) getPukReceivers(mctx libkb.MetaContext, meUPAK *keybase1.UserPlusAllKeys) (res []libkb.NaclDHKeyPair, err error) {
 	for _, dk := range meUPAK.Base.DeviceKeys {
 		if dk.IsSibkey == false && !dk.IsRevoked {
 			receiver, err := libkb.ImportNaclDHKeyPairFromHex(dk.KID.String())

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -262,7 +262,7 @@ func (e *RevokeEngine) Run(m libkb.MetaContext) error {
 	var newUserEKMetadata *keybase1.UserEkMetadata
 	ekLib := e.G().GetEKLib()
 	if !e.skipUserEKForTesting && addingNewPUK && ekLib != nil {
-		sig, boxes, newMetadata, myBox, err := ekLib.PrepareNewUserEK(m.Ctx(), *merkleRoot, *newPukSeed)
+		sig, boxes, newMetadata, myBox, err := ekLib.PrepareNewUserEK(m, *merkleRoot, *newPukSeed)
 		if err != nil {
 			return err
 		}
@@ -309,7 +309,7 @@ func (e *RevokeEngine) Run(m libkb.MetaContext) error {
 
 	// Add the new userEK box to local storage, if it was created above.
 	if myUserEKBox != nil {
-		err = e.G().GetUserEKBoxStorage().Put(m.Ctx(), newUserEKMetadata.Generation, *myUserEKBox)
+		err = e.G().GetUserEKBoxStorage().Put(m, newUserEKMetadata.Generation, *myUserEKBox)
 		if err != nil {
 			m.Warning("error while saving userEK box: %s", err)
 		}

--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -11,15 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ephemeralKeyTestSetup(t *testing.T) (libkb.TestContext, *kbtest.FakeUser) {
+func ephemeralKeyTestSetup(t *testing.T) (libkb.TestContext, libkb.MetaContext, *kbtest.FakeUser) {
 	tc := libkb.SetupTest(t, "ephemeral", 2)
 
-	NewEphemeralStorageAndInstall(tc.G)
+	mctx := libkb.NewMetaContextForTest(tc)
+	NewEphemeralStorageAndInstall(mctx)
 
 	user, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
 	require.NoError(t, err)
 
-	return tc, user
+	return tc, mctx, user
 }
 
 func TestTimeConversions(t *testing.T) {
@@ -42,31 +43,29 @@ func verifyTeamEK(t *testing.T, metadata keybase1.TeamEkMetadata, ek keybase1.Te
 }
 
 func TestEphemeralCloneError(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	g := tc.G
-	m := libkb.NewMetaContextForTest(tc)
-	ctx := m.Ctx()
 	teamID := createTeam(tc)
 
 	ekLib := g.GetEKLib()
-	teamEK1, created, err := ekLib.GetOrCreateLatestTeamEK(ctx, teamID)
+	teamEK1, created, err := ekLib.GetOrCreateLatestTeamEK(mctx, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
 
 	// delete all our deviceEKs and make sure the error comes back as a cloning
 	// error since we simulate the cloned state.
-	libkb.CreateClonedDevice(tc, m)
+	libkb.CreateClonedDevice(tc, mctx)
 	deviceEKStorage := g.GetDeviceEKStorage()
 	s := deviceEKStorage.(*DeviceEKStorage)
-	allDevicEKs, err := s.GetAll(ctx)
+	allDevicEKs, err := s.GetAll(mctx)
 	require.NoError(t, err)
 	for _, dek := range allDevicEKs {
-		err = s.Delete(ctx, dek.Metadata.Generation)
+		err = s.Delete(mctx, dek.Metadata.Generation)
 		require.NoError(t, err)
 	}
-	_, err = g.GetTeamEKBoxStorage().Get(ctx, teamID, teamEK1.Metadata.Generation, nil)
+	_, err = g.GetTeamEKBoxStorage().Get(mctx, teamID, teamEK1.Metadata.Generation, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr := err.(EphemeralKeyError)
@@ -74,42 +73,40 @@ func TestEphemeralCloneError(t *testing.T) {
 }
 
 func TestEphemeralDeviceProvisionedAfterContent(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	g := tc.G
-	m := libkb.NewMetaContextForTest(tc)
-	ctx := m.Ctx()
 	teamID := createTeam(tc)
 
 	ekLib := g.GetEKLib()
-	teamEK1, created, err := ekLib.GetOrCreateLatestTeamEK(ctx, teamID)
+	teamEK1, created, err := ekLib.GetOrCreateLatestTeamEK(mctx, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
 
 	deviceEKStorage := g.GetDeviceEKStorage()
 	s := deviceEKStorage.(*DeviceEKStorage)
-	allDevicEKs, err := s.GetAll(ctx)
+	allDevicEKs, err := s.GetAll(mctx)
 	require.NoError(t, err)
 	for _, dek := range allDevicEKs {
-		err = s.Delete(ctx, dek.Metadata.Generation)
+		err = s.Delete(mctx, dek.Metadata.Generation)
 		require.NoError(t, err)
 	}
 
 	creationCtime := gregor1.ToTime(time.Now().Add(time.Hour * -100))
-	_, err = g.GetTeamEKBoxStorage().Get(ctx, teamID, teamEK1.Metadata.Generation, &creationCtime)
+	_, err = g.GetTeamEKBoxStorage().Get(mctx, teamID, teamEK1.Metadata.Generation, &creationCtime)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr := err.(EphemeralKeyError)
 	require.Contains(t, ekErr.HumanError(), DeviceProvisionedAfterContentCreationErrMsg)
 
 	// clear out cached error messages
-	g.GetEKLib().ClearCaches()
+	g.GetEKLib().ClearCaches(mctx)
 	_, err = g.LocalDb.Nuke()
 	require.NoError(t, err)
 
 	// If no creation ctime is specified, we just get the default error message
-	_, err = g.GetTeamEKBoxStorage().Get(ctx, teamID, teamEK1.Metadata.Generation, nil)
+	_, err = g.GetTeamEKBoxStorage().Get(mctx, teamID, teamEK1.Metadata.Generation, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr = err.(EphemeralKeyError)

--- a/go/ephemeral/device_ek.go
+++ b/go/ephemeral/device_ek.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -24,8 +23,7 @@ func (s *DeviceEKSeed) DeriveDHKey() *libkb.NaclDHKeyPair {
 	return deriveDHKey(keybase1.Bytes32(*s), libkb.DeriveReasonDeviceEKEncryption)
 }
 
-func postNewDeviceEK(ctx context.Context, g *libkb.GlobalContext, sig string) (err error) {
-	mctx := libkb.NewMetaContext(ctx, g)
+func postNewDeviceEK(mctx libkb.MetaContext, sig string) (err error) {
 	defer mctx.TraceTimed("postNewDeviceEK", func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -33,45 +31,45 @@ func postNewDeviceEK(ctx context.Context, g *libkb.GlobalContext, sig string) (e
 		SessionType: libkb.APISessionTypeREQUIRED,
 		Args: libkb.HTTPArgs{
 			"sig":       libkb.S{Val: sig},
-			"device_id": libkb.S{Val: string(g.Env.GetDeviceID())},
+			"device_id": libkb.S{Val: string(mctx.ActiveDevice().DeviceID())},
 		},
 	}
-	_, err = g.GetAPI().Post(mctx, apiArg)
+	_, err = mctx.G().GetAPI().Post(mctx, apiArg)
 	return err
 }
 
-func serverMaxDeviceEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (maxGeneration keybase1.EkGeneration, err error) {
-	defer g.CTraceTimed(ctx, "serverMaxDeviceEK", func() error { return err })()
+func serverMaxDeviceEK(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (maxGeneration keybase1.EkGeneration, err error) {
+	defer mctx.TraceTimed("serverMaxDeviceEK", func() error { return err })()
 
-	deviceEKs, err := allDeviceEKMetadataMaybeStale(ctx, g, merkleRoot)
+	deviceEKs, err := allDeviceEKMetadataMaybeStale(mctx, merkleRoot)
 	if err != nil {
 		return maxGeneration, err
 	}
-	deviceID := g.Env.GetDeviceID()
+	deviceID := mctx.ActiveDevice().DeviceID()
 	metadata, ok := deviceEKs[deviceID]
 	if ok {
 		return metadata.Generation, nil
 	}
 	// We may not have an EK yet, let's try with this and fail if the server
 	// rejects.
-	g.Log.CDebugf(ctx, "No deviceEK found on the server")
+	mctx.Debug("No deviceEK found on the server")
 	return 0, nil
 }
 
-func publishNewDeviceEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata keybase1.DeviceEkMetadata, err error) {
-	defer g.CTraceTimed(ctx, "publishNewDeviceEK", func() error { return err })()
+func publishNewDeviceEK(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (metadata keybase1.DeviceEkMetadata, err error) {
+	defer mctx.TraceTimed("publishNewDeviceEK", func() error { return err })()
 
 	seed, err := newDeviceEphemeralSeed()
 	if err != nil {
 		return metadata, err
 	}
 
-	storage := g.GetDeviceEKStorage()
-	generation, err := storage.MaxGeneration(ctx, true)
+	storage := mctx.G().GetDeviceEKStorage()
+	generation, err := storage.MaxGeneration(mctx, true)
 	if err != nil {
 		// Let's try to get the max from the server
-		g.Log.CDebugf(ctx, "Error getting maxGeneration from storage")
-		generation, err = serverMaxDeviceEK(ctx, g, merkleRoot)
+		mctx.Debug("Error getting maxGeneration from storage")
+		generation, err = serverMaxDeviceEK(mctx, merkleRoot)
 		if err != nil {
 			return metadata, err
 		}
@@ -82,16 +80,16 @@ func publishNewDeviceEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot 
 	}
 	generation++
 
-	metadata, err = signAndPostDeviceEK(ctx, g, generation, seed, merkleRoot)
+	metadata, err = signAndPostDeviceEK(mctx, generation, seed, merkleRoot)
 	if err != nil {
-		g.Log.CDebugf(ctx, "Error posting deviceEK, retrying with server maxGeneration")
+		mctx.Debug("Error posting deviceEK, retrying with server maxGeneration")
 		// Let's retry posting with the server given max
-		generation, err = serverMaxDeviceEK(ctx, g, merkleRoot)
+		generation, err = serverMaxDeviceEK(mctx, merkleRoot)
 		if err != nil {
 			return metadata, err
 		}
 		generation++
-		metadata, err = signAndPostDeviceEK(ctx, g, generation, seed, merkleRoot)
+		metadata, err = signAndPostDeviceEK(mctx, generation, seed, merkleRoot)
 		if err != nil {
 			return metadata, err
 		}
@@ -100,13 +98,14 @@ func publishNewDeviceEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot 
 	return metadata, err
 }
 
-func signAndPostDeviceEK(ctx context.Context, g *libkb.GlobalContext, generation keybase1.EkGeneration, seed DeviceEKSeed, merkleRoot libkb.MerkleRoot) (metadata keybase1.DeviceEkMetadata, err error) {
-	defer g.CTraceTimed(ctx, "signAndPostDeviceEK", func() error { return err })()
+func signAndPostDeviceEK(mctx libkb.MetaContext, generation keybase1.EkGeneration,
+	seed DeviceEKSeed, merkleRoot libkb.MerkleRoot) (metadata keybase1.DeviceEkMetadata, err error) {
+	defer mctx.TraceTimed("signAndPostDeviceEK", func() error { return err })()
 
-	storage := g.GetDeviceEKStorage()
+	storage := mctx.G().GetDeviceEKStorage()
 
 	// Sign the statement blob with the device's long term signing key.
-	signingKey, err := g.ActiveDevice.SigningKey()
+	signingKey, err := mctx.ActiveDevice().SigningKey()
 	if err != nil {
 		return metadata, err
 	}
@@ -117,19 +116,19 @@ func signAndPostDeviceEK(ctx context.Context, g *libkb.GlobalContext, generation
 	metadata = statement.CurrentDeviceEkMetadata
 	// Ensure we successfully write the secret to disk before posting to the
 	// server since the secret never leaves the device.
-	if err = storage.Put(ctx, generation, keybase1.DeviceEk{
+	if err = storage.Put(mctx, generation, keybase1.DeviceEk{
 		Seed:     keybase1.Bytes32(seed),
 		Metadata: metadata,
 	}); err != nil {
 		return metadata, err
 	}
 
-	err = postNewDeviceEK(ctx, g, signedStatement)
+	err = postNewDeviceEK(mctx, signedStatement)
 	if err != nil {
 		storage.ClearCache()
-		serr := NewDeviceEKStorage(g).Delete(ctx, generation)
+		serr := NewDeviceEKStorage(mctx).Delete(mctx, generation)
 		if serr != nil {
-			g.Log.CDebugf(ctx, "DeviceEK deletion failed %v", err)
+			mctx.Debug("DeviceEK deletion failed %v", err)
 		}
 	}
 
@@ -163,8 +162,7 @@ type deviceEKStatementResponse struct {
 	Sigs []string `json:"sigs"`
 }
 
-func allDeviceEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata map[keybase1.DeviceID]keybase1.DeviceEkMetadata, err error) {
-	mctx := libkb.NewMetaContext(ctx, g)
+func allDeviceEKMetadataMaybeStale(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (metadata map[keybase1.DeviceID]keybase1.DeviceEkMetadata, err error) {
 	defer mctx.TraceTimed("allDeviceEKMetadataMaybeStale", func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -188,7 +186,8 @@ func allDeviceEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalContext, 
 	// the signing key is intentionally the only way to do this, so that we're
 	// forced to check authenticity.)
 	kidToDevice := map[keybase1.KID]keybase1.PublicKey{}
-	self, _, err := g.GetUPAKLoader().Load(libkb.NewLoadUserByUIDArg(ctx, g, g.Env.GetUID()))
+	self, _, err := mctx.G().GetUPAKLoader().Load(libkb.NewLoadUserArgWithMetaContext(
+		mctx).WithUID(mctx.ActiveDevice().UID()))
 	if err != nil {
 		return nil, err
 	}
@@ -232,10 +231,10 @@ func allDeviceEKMetadataMaybeStale(ctx context.Context, g *libkb.GlobalContext, 
 
 // allActiveDeviceEKMetadata fetches the latest deviceEK for each of your
 // devices, filtering out the ones that are stale.
-func allActiveDeviceEKMetadata(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata map[keybase1.DeviceID]keybase1.DeviceEkMetadata, err error) {
-	defer g.CTraceTimed(ctx, "allActiveDeviceEKMetadata", func() error { return err })()
+func allActiveDeviceEKMetadata(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (metadata map[keybase1.DeviceID]keybase1.DeviceEkMetadata, err error) {
+	defer mctx.TraceTimed("allActiveDeviceEKMetadata", func() error { return err })()
 
-	maybeStale, err := allDeviceEKMetadataMaybeStale(ctx, g, merkleRoot)
+	maybeStale, err := allDeviceEKMetadataMaybeStale(mctx, merkleRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +245,7 @@ func allActiveDeviceEKMetadata(ctx context.Context, g *libkb.GlobalContext, merk
 		// since the server doesn't do this check for us. We log these cases
 		// and skip them.
 		if ctimeIsStale(metadata.Ctime.Time(), merkleRoot) {
-			g.Log.CDebugf(ctx, "skipping stale deviceEK %s for device KID %s", metadata.Kid, deviceID)
+			mctx.Debug("skipping stale deviceEK %s for device KID %s", metadata.Kid, deviceID)
 			continue
 		}
 		active[deviceID] = metadata

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -31,7 +30,6 @@ type deviceEKCache map[keybase1.EkGeneration]deviceEKCacheItem
 type DeviceEKMap map[keybase1.EkGeneration]keybase1.DeviceEk
 
 type DeviceEKStorage struct {
-	libkb.Contextified
 	sync.Mutex
 	storage erasablekv.ErasableKVStore
 	cache   deviceEKCache
@@ -39,8 +37,8 @@ type DeviceEKStorage struct {
 	logger  *log.Logger
 }
 
-func getLogger(g *libkb.GlobalContext) *log.Logger {
-	filename := g.Env.GetEKLogFile()
+func getLogger(mctx libkb.MetaContext) *log.Logger {
+	filename := mctx.G().Env.GetEKLogFile()
 
 	lfc := &logger.LogFileConfig{
 		Path:               filename,
@@ -48,7 +46,7 @@ func getLogger(g *libkb.GlobalContext) *log.Logger {
 		MaxKeepFiles:       3,
 		SkipRedirectStdErr: true,
 	}
-	switch g.GetAppType() {
+	switch mctx.G().GetAppType() {
 	case libkb.MobileAppType:
 		lfc.MaxSize = 1 * 1024 * 1024 // 1mb
 	default:
@@ -56,60 +54,60 @@ func getLogger(g *libkb.GlobalContext) *log.Logger {
 	}
 	lfw := logger.NewLogFileWriter(*lfc)
 	if err := lfw.Open(time.Now()); err != nil {
-		g.Log.CDebugf(context.TODO(), "Unable to getLogger %v", err)
+		mctx.Debug("Unable to getLogger %v", err)
 		return nil
 	}
-	l := log.New(lfw, getLogPrefix(g), log.LstdFlags|log.Lshortfile)
+	l := log.New(lfw, getLogPrefix(mctx), log.LstdFlags|log.Lshortfile)
 	return l
 }
 
-func getLogPrefix(g *libkb.GlobalContext) string {
-	return fmt.Sprintf("[username=%v] ", g.Env.GetUsername())
+func getLogPrefix(mctx libkb.MetaContext) string {
+	return fmt.Sprintf("[username=%v] ", mctx.G().Env.GetUsername())
 }
 
-func NewDeviceEKStorage(g *libkb.GlobalContext) *DeviceEKStorage {
+func NewDeviceEKStorage(mctx libkb.MetaContext) *DeviceEKStorage {
 	return &DeviceEKStorage{
-		Contextified: libkb.NewContextified(g),
-		storage:      erasablekv.NewFileErasableKVStore(g, deviceEKSubDir),
-		cache:        make(deviceEKCache),
-		logger:       getLogger(g),
+		storage: erasablekv.NewFileErasableKVStore(mctx, deviceEKSubDir),
+		cache:   make(deviceEKCache),
+		logger:  getLogger(mctx),
 	}
 }
 
-func (s *DeviceEKStorage) SetLogPrefix() {
-	s.logger.SetPrefix(getLogPrefix(s.G()))
+func (s *DeviceEKStorage) SetLogPrefix(mctx libkb.MetaContext) {
+	s.logger.SetPrefix(getLogPrefix(mctx))
 }
 
 // Log sensitive deletion actions to a separate log file so we don't lose the
 // logs during normal rotation.
-func (s *DeviceEKStorage) ekLogf(ctx context.Context, format string, args ...interface{}) {
-	s.G().Log.CDebugf(ctx, format, args...)
+func (s *DeviceEKStorage) ekLogf(mctx libkb.MetaContext, format string, args ...interface{}) {
+	mctx.Debug(format, args...)
 	if s.logger != nil {
 		s.logger.Printf(format, args...)
 	}
 }
 
-func (s *DeviceEKStorage) ekLogCTraceTimed(ctx context.Context, msg string, f func() error) func() {
+func (s *DeviceEKStorage) ekLogCTraceTimed(mctx libkb.MetaContext, msg string, f func() error) func() {
 	if s.logger != nil {
 		s.logger.Print(msg)
 	}
-	return s.G().CTraceTimed(ctx, msg, f)
+	return mctx.TraceTimed(msg, f)
 }
 
 func (s *DeviceEKStorage) keyPrefixFromUsername(username libkb.NormalizedUsername) string {
 	return fmt.Sprintf("%s-%s-", deviceEKPrefix, username)
 }
 
-func (s *DeviceEKStorage) keyPrefix(ctx context.Context) (prefix string, err error) {
-	uv, err := s.G().GetMeUV(ctx)
+func (s *DeviceEKStorage) keyPrefix(mctx libkb.MetaContext) (prefix string, err error) {
+	uv, err := mctx.G().GetMeUV(mctx.Ctx())
 	if err != nil {
 		return prefix, err
 	}
-	return fmt.Sprintf("%s%s-", s.keyPrefixFromUsername(s.G().Env.GetUsername()), uv.EldestSeqno), nil
+	username := mctx.ActiveDevice().Username(mctx)
+	return fmt.Sprintf("%s%s-", s.keyPrefixFromUsername(username), uv.EldestSeqno), nil
 }
 
-func (s *DeviceEKStorage) key(ctx context.Context, generation keybase1.EkGeneration) (key string, err error) {
-	prefix, err := s.keyPrefix(ctx)
+func (s *DeviceEKStorage) key(mctx libkb.MetaContext, generation keybase1.EkGeneration) (key string, err error) {
+	prefix, err := s.keyPrefix(mctx)
 	if err != nil {
 		return key, err
 	}
@@ -121,7 +119,7 @@ func (s *DeviceEKStorage) key(ctx context.Context, generation keybase1.EkGenerat
 // eldestSeqno that is not our current, we purge it since we don't want the
 // ephemeral key to stick around if we've reset. If we are unable to parse out
 // the value, the key is not valid, or not for the logged in user we return -1
-func (s *DeviceEKStorage) keyToEldestSeqno(key string) keybase1.Seqno {
+func (s *DeviceEKStorage) keyToEldestSeqno(mctx libkb.MetaContext, key string) keybase1.Seqno {
 	if !strings.HasPrefix(key, deviceEKPrefix) {
 		return -1
 	}
@@ -130,7 +128,8 @@ func (s *DeviceEKStorage) keyToEldestSeqno(key string) keybase1.Seqno {
 		return -1
 	}
 	// Make sure this key is for our current user and not a different one.
-	if parts[1] != s.G().Env.GetUsername().String() {
+	username := mctx.ActiveDevice().Username(mctx)
+	if parts[1] != username.String() {
 		return -1
 	}
 	e, err := strconv.ParseUint(parts[2], 10, 64)
@@ -143,43 +142,43 @@ func (s *DeviceEKStorage) keyToEldestSeqno(key string) keybase1.Seqno {
 // keyToEldestSeqno parses out the `generation` from a key of the form
 // deviceEKPrefix-username-eldestSeqno-generation.ek. Unparseable keys return a
 // generation of -1 and should be ignored.
-func (s *DeviceEKStorage) keyToGeneration(ctx context.Context, key string) keybase1.EkGeneration {
-	prefix, err := s.keyPrefix(ctx)
+func (s *DeviceEKStorage) keyToGeneration(mctx libkb.MetaContext, key string) keybase1.EkGeneration {
+	prefix, err := s.keyPrefix(mctx)
 	if err != nil {
-		s.G().Log.CDebugf(ctx, "keyToGeneration: unable to get keyPrefix: %v", err)
+		mctx.Debug("keyToGeneration: unable to get keyPrefix: %v", err)
 		return -1
 	}
 	if !strings.HasPrefix(key, prefix) || !strings.HasSuffix(key, deviceEKSuffix) {
-		s.G().Log.CDebugf(ctx, "keyToGeneration: key missing prefix: %v or suffix: %s", prefix, deviceEKSuffix)
+		mctx.Debug("keyToGeneration: key missing prefix: %v or suffix: %s", prefix, deviceEKSuffix)
 		return -1
 	}
 
 	key = strings.TrimSuffix(key, deviceEKSuffix)
 	parts := strings.Split(key, prefix)
 	if len(parts) != 2 {
-		s.G().Log.CDebugf(ctx, "keyToGeneration: unexpected parts: %v, prefix: %v", parts)
+		mctx.Debug("keyToGeneration: unexpected parts: %v, prefix: %v", parts)
 		return -1
 	}
 	g, err := strconv.ParseUint(parts[1], 10, 64)
 	if err != nil {
-		s.G().Log.CDebugf(ctx, "keyToGeneration: unable to parseUint: %v", err)
+		mctx.Debug("keyToGeneration: unable to parseUint: %v", err)
 		return -1
 	}
 	return keybase1.EkGeneration(g)
 }
 
-func (s *DeviceEKStorage) Put(ctx context.Context, generation keybase1.EkGeneration, deviceEK keybase1.DeviceEk) (err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("DeviceEKStorage#Put: generation:%v", generation), func() error { return err })()
+func (s *DeviceEKStorage) Put(mctx libkb.MetaContext, generation keybase1.EkGeneration, deviceEK keybase1.DeviceEk) (err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("DeviceEKStorage#Put: generation:%v", generation), func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
 	// sanity check that we got the right generation
 	if deviceEK.Metadata.Generation != generation {
-		return newEKCorruptedErr(ctx, s.G(), DeviceEKStr, generation, deviceEK.Metadata.Generation)
+		return newEKCorruptedErr(mctx, DeviceEKStr, generation, deviceEK.Metadata.Generation)
 	}
 
-	key, err := s.key(ctx, generation)
+	key, err := s.key(mctx, generation)
 	if err != nil {
 		return err
 	}
@@ -187,12 +186,12 @@ func (s *DeviceEKStorage) Put(ctx context.Context, generation keybase1.EkGenerat
 	if deviceEK.Metadata.DeviceCtime == 0 {
 		deviceEK.Metadata.DeviceCtime = keybase1.ToTime(time.Now())
 	}
-	if err = s.storage.Put(ctx, key, deviceEK); err != nil {
+	if err = s.storage.Put(mctx, key, deviceEK); err != nil {
 		return err
 	}
 
 	// cache the result
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return err
 	}
@@ -203,13 +202,13 @@ func (s *DeviceEKStorage) Put(ctx context.Context, generation keybase1.EkGenerat
 	return nil
 }
 
-func (s *DeviceEKStorage) Get(ctx context.Context, generation keybase1.EkGeneration) (deviceEK keybase1.DeviceEk, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("DeviceEKStorage#Get: generation:%v", generation), func() error { return err })()
+func (s *DeviceEKStorage) Get(mctx libkb.MetaContext, generation keybase1.EkGeneration) (deviceEK keybase1.DeviceEk, err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("DeviceEKStorage#Get: generation:%v", generation), func() error { return err })()
 	s.Lock()
 	defer s.Unlock()
 
 	// Try the cache first
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return deviceEK, err
 	}
@@ -218,7 +217,7 @@ func (s *DeviceEKStorage) Get(ctx context.Context, generation keybase1.EkGenerat
 		return cacheItem.DeviceEK, cacheItem.Err
 	}
 	// Try persistent storage.
-	deviceEK, err = s.get(ctx, generation)
+	deviceEK, err = s.get(mctx, generation)
 	switch err.(type) {
 	case nil, erasablekv.UnboxError:
 		// cache the result
@@ -232,69 +231,69 @@ func (s *DeviceEKStorage) Get(ctx context.Context, generation keybase1.EkGenerat
 	}
 }
 
-func (s *DeviceEKStorage) get(ctx context.Context, generation keybase1.EkGeneration) (deviceEK keybase1.DeviceEk, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("DeviceEKStorage#get: generation:%v", generation), func() error { return err })()
+func (s *DeviceEKStorage) get(mctx libkb.MetaContext, generation keybase1.EkGeneration) (deviceEK keybase1.DeviceEk, err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("DeviceEKStorage#get: generation:%v", generation), func() error { return err })()
 
-	key, err := s.key(ctx, generation)
+	key, err := s.key(mctx, generation)
 	if err != nil {
 		return deviceEK, err
 	}
 
-	if err = s.storage.Get(ctx, key, &deviceEK); err != nil {
+	if err = s.storage.Get(mctx, key, &deviceEK); err != nil {
 		switch err.(type) {
 		case erasablekv.UnboxError:
-			s.ekLogf(ctx, "DeviceEKStorage#get: corrupted generation: %v -> %v: %v", key, generation, err)
-			if ierr := s.storage.Erase(ctx, key); ierr != nil {
-				s.ekLogf(ctx, "DeviceEKStorage#get: unable to delete corrupted generation: %v", ierr)
+			s.ekLogf(mctx, "DeviceEKStorage#get: corrupted generation: %v -> %v: %v", key, generation, err)
+			if ierr := s.storage.Erase(mctx, key); ierr != nil {
+				s.ekLogf(mctx, "DeviceEKStorage#get: unable to delete corrupted generation: %v", ierr)
 			}
 		}
 		return deviceEK, err
 	}
 	// sanity check that we got the right generation
 	if deviceEK.Metadata.Generation != generation {
-		return deviceEK, newEKCorruptedErr(ctx, s.G(), DeviceEKStr, generation, deviceEK.Metadata.Generation)
+		return deviceEK, newEKCorruptedErr(mctx, DeviceEKStr, generation, deviceEK.Metadata.Generation)
 	}
 	return deviceEK, nil
 }
 
-func (s *DeviceEKStorage) Delete(ctx context.Context, generation keybase1.EkGeneration) (err error) {
+func (s *DeviceEKStorage) Delete(mctx libkb.MetaContext, generation keybase1.EkGeneration) (err error) {
 	s.Lock()
 	defer s.Unlock()
-	return s.delete(ctx, generation)
+	return s.delete(mctx, generation)
 }
 
-func (s *DeviceEKStorage) delete(ctx context.Context, generation keybase1.EkGeneration) (err error) {
-	defer s.ekLogCTraceTimed(ctx, fmt.Sprintf("DeviceEKStorage#delete: generation:%v", generation), func() error { return err })()
+func (s *DeviceEKStorage) delete(mctx libkb.MetaContext, generation keybase1.EkGeneration) (err error) {
+	defer s.ekLogCTraceTimed(mctx, fmt.Sprintf("DeviceEKStorage#delete: generation:%v", generation), func() error { return err })()
 
 	// clear the cache
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return err
 	}
-	key, err := s.key(ctx, generation)
+	key, err := s.key(mctx, generation)
 	if err != nil {
 		return err
 	}
-	if err = s.storage.Erase(ctx, key); err != nil {
+	if err = s.storage.Erase(mctx, key); err != nil {
 		return err
 	}
 	delete(cache, generation)
 	return nil
 }
 
-func (s *DeviceEKStorage) getCache(ctx context.Context) (cache deviceEKCache, err error) {
+func (s *DeviceEKStorage) getCache(mctx libkb.MetaContext) (cache deviceEKCache, err error) {
 	if !s.indexed {
-		keys, err := s.storage.AllKeys(ctx, deviceEKSuffix)
+		keys, err := s.storage.AllKeys(mctx, deviceEKSuffix)
 		if err != nil {
 			return nil, err
 		}
 		for _, key := range keys {
-			generation := s.keyToGeneration(ctx, key)
+			generation := s.keyToGeneration(mctx, key)
 			if generation < 0 {
-				s.G().Log.CDebugf(ctx, "DeviceEKStorage#getCache: unable to get generation from key: %s", key)
+				mctx.Debug("DeviceEKStorage#getCache: unable to get generation from key: %s", key)
 				continue
 			}
-			deviceEK, err := s.get(ctx, generation)
+			deviceEK, err := s.get(mctx, generation)
 			switch err.(type) {
 			case nil, erasablekv.UnboxError:
 				s.cache[generation] = deviceEKCacheItem{
@@ -321,13 +320,13 @@ func (s *DeviceEKStorage) clearCache() {
 	s.indexed = false
 }
 
-func (s *DeviceEKStorage) GetAll(ctx context.Context) (deviceEKs DeviceEKMap, err error) {
-	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#GetAll", func() error { return err })()
+func (s *DeviceEKStorage) GetAll(mctx libkb.MetaContext) (deviceEKs DeviceEKMap, err error) {
+	defer mctx.TraceTimed("DeviceEKStorage#GetAll", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return nil, err
 	}
@@ -341,13 +340,13 @@ func (s *DeviceEKStorage) GetAll(ctx context.Context) (deviceEKs DeviceEKMap, er
 	return deviceEKs, nil
 }
 
-func (s *DeviceEKStorage) GetAllActive(ctx context.Context, merkleRoot libkb.MerkleRoot) (metadatas []keybase1.DeviceEkMetadata, err error) {
-	defer s.G().CTraceTimed(ctx, "GetAllActive", func() error { return err })()
+func (s *DeviceEKStorage) GetAllActive(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (metadatas []keybase1.DeviceEkMetadata, err error) {
+	defer mctx.TraceTimed("GetAllActive", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return nil, err
 	}
@@ -374,18 +373,18 @@ func (s *DeviceEKStorage) GetAllActive(ctx context.Context, merkleRoot libkb.Mer
 
 // ListAllForUser lists the internal storage name of deviceEKs of the logged in
 // user. This is used for logsend purposes to debug ek state.
-func (s *DeviceEKStorage) ListAllForUser(ctx context.Context) (all []string, err error) {
-	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#ListAllForUser", func() error { return err })()
+func (s *DeviceEKStorage) ListAllForUser(mctx libkb.MetaContext) (all []string, err error) {
+	defer mctx.TraceTimed("DeviceEKStorage#ListAllForUser", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
-	return s.listAllForUser(ctx, s.G().Env.GetUsername())
+	return s.listAllForUser(mctx, mctx.ActiveDevice().Username(mctx))
 }
 
-func (s *DeviceEKStorage) listAllForUser(ctx context.Context, username libkb.NormalizedUsername) (all []string, err error) {
+func (s *DeviceEKStorage) listAllForUser(mctx libkb.MetaContext, username libkb.NormalizedUsername) (all []string, err error) {
 	// key in the sense of a key-value pair, not a crypto key!
-	keys, err := s.storage.AllKeys(ctx, deviceEKSuffix)
+	keys, err := s.storage.AllKeys(mctx, deviceEKSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -398,14 +397,14 @@ func (s *DeviceEKStorage) listAllForUser(ctx context.Context, username libkb.Nor
 	return all, nil
 }
 
-func (s *DeviceEKStorage) MaxGeneration(ctx context.Context, includeErrs bool) (maxGeneration keybase1.EkGeneration, err error) {
-	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#MaxGeneration", func() error { return err })()
+func (s *DeviceEKStorage) MaxGeneration(mctx libkb.MetaContext, includeErrs bool) (maxGeneration keybase1.EkGeneration, err error) {
+	defer mctx.TraceTimed("DeviceEKStorage#MaxGeneration", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
 	maxGeneration = -1
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return maxGeneration, err
 	}
@@ -420,13 +419,13 @@ func (s *DeviceEKStorage) MaxGeneration(ctx context.Context, includeErrs bool) (
 	return maxGeneration, nil
 }
 
-func (s *DeviceEKStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.MerkleRoot) (expired []keybase1.EkGeneration, err error) {
-	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#DeleteExpired", func() error { return err })()
+func (s *DeviceEKStorage) DeleteExpired(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (expired []keybase1.EkGeneration, err error) {
+	defer mctx.TraceTimed("DeviceEKStorage#DeleteExpired", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return nil, err
 	}
@@ -460,13 +459,13 @@ func (s *DeviceEKStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.Me
 		}
 	}
 
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	epick := libkb.FirstErrorPicker{}
 	for _, generation := range expired {
-		epick.Push(s.delete(ctx, generation))
+		epick.Push(s.delete(mctx, generation))
 	}
 
-	epick.Push(s.deletedWrongEldestSeqno(ctx))
+	epick.Push(s.deletedWrongEldestSeqno(mctx))
 	return expired, epick.Error()
 }
 
@@ -492,7 +491,7 @@ func (s *DeviceEKStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.Me
 // `libkb.MaxEphemeralContentLifetime` after the creation of deviceEK_B_3, with
 // a maximum window of `libkb.MaxEphemeralKeyStaleness`. This is correct
 // because userEK_3 *must* be created at or before deviceEK_B_3's creation.
-func (s *DeviceEKStorage) getExpiredGenerations(ctx context.Context, keyMap keyExpiryMap, now time.Time) (expired []keybase1.EkGeneration) {
+func (s *DeviceEKStorage) getExpiredGenerations(mctx libkb.MetaContext, keyMap keyExpiryMap, now time.Time) (expired []keybase1.EkGeneration) {
 	// Sort the generations we have so we can walk through them in order.
 	var keys []keybase1.EkGeneration
 	for k := range keyMap {
@@ -527,7 +526,7 @@ func (s *DeviceEKStorage) getExpiredGenerations(ctx context.Context, keyMap keyE
 
 		expiryOffset := expiryOffset1 + expiryOffset2
 		if now.Sub(keyCtime) >= (libkb.MinEphemeralKeyLifetime + expiryOffset) {
-			s.ekLogf(ctx, "getExpiredGenerations: expired generation:%v, now: %v, keyCtime:%v, expiryOffset:%v, keyMap: %v, i:%v",
+			s.ekLogf(mctx, "getExpiredGenerations: expired generation:%v, now: %v, keyCtime:%v, expiryOffset:%v, keyMap: %v, i:%v",
 				generation, now, keyCtime, expiryOffset, keyMap, i)
 			expired = append(expired, generation)
 		}
@@ -535,44 +534,44 @@ func (s *DeviceEKStorage) getExpiredGenerations(ctx context.Context, keyMap keyE
 	return expired
 }
 
-func (s *DeviceEKStorage) deletedWrongEldestSeqno(ctx context.Context) (err error) {
-	keys, err := s.storage.AllKeys(ctx, deviceEKSuffix)
+func (s *DeviceEKStorage) deletedWrongEldestSeqno(mctx libkb.MetaContext) (err error) {
+	keys, err := s.storage.AllKeys(mctx, deviceEKSuffix)
 	if err != nil {
 		return err
 	}
-	uv, err := s.G().GetMeUV(ctx)
+	uv, err := mctx.G().GetMeUV(mctx.Ctx())
 	if err != nil {
 		return err
 	}
 	epick := libkb.FirstErrorPicker{}
 	for _, key := range keys {
-		eldestSeqno := s.keyToEldestSeqno(key)
+		eldestSeqno := s.keyToEldestSeqno(mctx, key)
 		if eldestSeqno < 0 {
 			continue
 		}
 		if eldestSeqno != uv.EldestSeqno {
-			s.ekLogf(ctx, "DeviceEKStorage#deletedWrongEldestSeqno: key: %v, uv: %v", key, uv)
-			epick.Push(s.storage.Erase(ctx, key))
+			s.ekLogf(mctx, "DeviceEKStorage#deletedWrongEldestSeqno: key: %v, uv: %v", key, uv)
+			epick.Push(s.storage.Erase(mctx, key))
 		}
 	}
 	return epick.Error()
 }
 
-func (s *DeviceEKStorage) ForceDeleteAll(ctx context.Context, username libkb.NormalizedUsername) (err error) {
-	defer s.ekLogCTraceTimed(ctx, "DeviceEKStorage#ForceDeleteAll", func() error { return err })()
+func (s *DeviceEKStorage) ForceDeleteAll(mctx libkb.MetaContext, username libkb.NormalizedUsername) (err error) {
+	defer s.ekLogCTraceTimed(mctx, "DeviceEKStorage#ForceDeleteAll", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
 	// only delete if the key is owned by the current user
-	keys, err := s.listAllForUser(ctx, username)
+	keys, err := s.listAllForUser(mctx, username)
 	if err != nil {
 		return err
 	}
 	epick := libkb.FirstErrorPicker{}
 	for _, key := range keys {
-		s.ekLogf(ctx, "DeviceEKStorage#ForceDeleteAll: key: %v", key)
-		epick.Push(s.storage.Erase(ctx, key))
+		s.ekLogf(mctx, "DeviceEKStorage#ForceDeleteAll: key: %v", key)
+		epick.Push(s.storage.Erase(mctx, key))
 	}
 
 	s.clearCache()

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDeviceEKStorage(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	now := time.Now()
@@ -60,39 +60,37 @@ func TestDeviceEKStorage(t *testing.T) {
 		},
 	}
 
-	m := libkb.NewMetaContextForTest(tc)
-
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
-	s := NewDeviceEKStorage(tc.G)
+	s := NewDeviceEKStorage(mctx)
 
 	for _, test := range testKeys {
-		err := s.Put(context.Background(), test.Metadata.Generation, test)
+		err := s.Put(mctx, test.Metadata.Generation, test)
 		require.NoError(t, err)
 
-		deviceEK, err := s.Get(context.Background(), test.Metadata.Generation)
+		deviceEK, err := s.Get(mctx, test.Metadata.Generation)
 		require.NoError(t, err)
 		require.Equal(t, test, deviceEK)
 	}
 
 	// corrupt a key in storage and ensure we get the right error back
 	corruptedGeneration := keybase1.EkGeneration(3)
-	ek, err := s.Get(context.Background(), corruptedGeneration)
+	ek, err := s.Get(mctx, corruptedGeneration)
 	require.NoError(t, err)
 
 	ek.Metadata.Generation = 100
-	err = s.Put(context.Background(), corruptedGeneration, ek)
+	err = s.Put(mctx, corruptedGeneration, ek)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr := err.(EphemeralKeyError)
-	expectedErr := newEKCorruptedErr(context.TODO(), tc.G, DeviceEKStr, corruptedGeneration, 100)
+	expectedErr := newEKCorruptedErr(mctx, DeviceEKStr, corruptedGeneration, 100)
 	require.Equal(t, expectedErr.Error(), ekErr.Error())
 	require.Equal(t, DefaultHumanErrMsg, ekErr.HumanError())
 
 	// Test GetAll
-	deviceEKs, err := s.GetAll(context.Background())
+	deviceEKs, err := s.GetAll(mctx)
 	require.NoError(t, err)
 
 	require.Equal(t, len(deviceEKs), len(testKeys))
@@ -103,81 +101,81 @@ func TestDeviceEKStorage(t *testing.T) {
 	}
 
 	// Test Delete
-	require.NoError(t, s.Delete(context.Background(), 2))
+	require.NoError(t, s.Delete(mctx, 2))
 
-	deviceEK, err := s.Get(context.Background(), 2)
+	deviceEK, err := s.Get(mctx, 2)
 	require.Error(t, err)
 	require.IsType(t, erasablekv.UnboxError{}, err)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
 	// Test Get nonexistent
-	nonexistent, err := s.Get(context.Background(), keybase1.EkGeneration(len(testKeys)+1))
+	nonexistent, err := s.Get(mctx, keybase1.EkGeneration(len(testKeys)+1))
 	require.Error(t, err)
 	require.IsType(t, erasablekv.UnboxError{}, err)
 	require.Equal(t, keybase1.DeviceEk{}, nonexistent)
 
 	// include the cached error in the max
-	maxGeneration, err := s.MaxGeneration(context.Background(), true)
+	maxGeneration, err := s.MaxGeneration(mctx, true)
 	require.NoError(t, err)
 	require.EqualValues(t, keybase1.EkGeneration(len(testKeys)+1), maxGeneration)
 
 	// Test MaxGeneration
-	maxGeneration, err = s.MaxGeneration(context.Background(), false)
+	maxGeneration, err = s.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 3, maxGeneration)
 	s.ClearCache()
 
-	require.NoError(t, s.Delete(context.Background(), 3))
+	require.NoError(t, s.Delete(mctx, 3))
 
-	maxGeneration, err = s.MaxGeneration(context.Background(), false)
+	maxGeneration, err = s.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, maxGeneration)
 
 	// Test delete expired and check that we handle incorrect eldest seqno
 	// deletion correctly.
-	uv, err := tc.G.GetMeUV(context.Background())
+	uv, err := tc.G.GetMeUV(context.TODO())
 	require.NoError(t, err)
-	erasableStorage := erasablekv.NewFileErasableKVStore(tc.G, deviceEKSubDir)
+	erasableStorage := erasablekv.NewFileErasableKVStore(mctx, deviceEKSubDir)
 
 	// First, let's drop a deviceEK for a different user, this shouldn't be deleted
-	badUserKey := fmt.Sprintf("%s-%s-%s-0.ek", deviceEKPrefix, s.G().Env.GetUsername()+"x", uv.EldestSeqno)
-	err = erasableStorage.Put(context.Background(), badUserKey, keybase1.DeviceEk{})
+	badUserKey := fmt.Sprintf("%s-%s-%s-0.ek", deviceEKPrefix, mctx.G().Env.GetUsername()+"x", uv.EldestSeqno)
+	err = erasableStorage.Put(mctx, badUserKey, keybase1.DeviceEk{})
 	require.NoError(t, err)
 
 	// Now let's add a file with a wrong eldest seqno
-	badEldestSeqnoKey := fmt.Sprintf("%s-%s-%s-0.ek", deviceEKPrefix, s.G().Env.GetUsername(), uv.EldestSeqno+1)
-	err = erasableStorage.Put(context.Background(), badEldestSeqnoKey, keybase1.DeviceEk{})
+	badEldestSeqnoKey := fmt.Sprintf("%s-%s-%s-0.ek", deviceEKPrefix, mctx.G().Env.GetUsername(), uv.EldestSeqno+1)
+	err = erasableStorage.Put(mctx, badEldestSeqnoKey, keybase1.DeviceEk{})
 	require.NoError(t, err)
 
 	expected := []keybase1.EkGeneration{0, 1}
-	expired, err := s.DeleteExpired(context.Background(), merkleRoot)
+	expired, err := s.DeleteExpired(mctx, merkleRoot)
 	require.NoError(t, err)
 	require.Equal(t, expected, expired)
 
-	deviceEKsAfterDeleteExpired, err := s.GetAll(context.Background())
+	deviceEKsAfterDeleteExpired, err := s.GetAll(mctx)
 	require.NoError(t, err)
 
 	require.Len(t, deviceEKsAfterDeleteExpired, 0)
 
 	var badUserDeviceEK keybase1.DeviceEk
-	err = erasableStorage.Get(context.Background(), badUserKey, &badUserDeviceEK)
+	err = erasableStorage.Get(mctx, badUserKey, &badUserDeviceEK)
 	require.NoError(t, err)
 	require.Equal(t, badUserDeviceEK, keybase1.DeviceEk{})
 
 	var badEldestSeqnoDeviceEK keybase1.DeviceEk
-	err = erasableStorage.Get(context.Background(), badEldestSeqnoKey, &badEldestSeqnoDeviceEK)
+	err = erasableStorage.Get(mctx, badEldestSeqnoKey, &badEldestSeqnoDeviceEK)
 	require.Error(t, err)
 	require.IsType(t, erasablekv.UnboxError{}, err)
 	require.Equal(t, badEldestSeqnoDeviceEK, keybase1.DeviceEk{})
 
 	// Verify we store failures in the cache
 	t.Logf("cache failures")
-	nonexistent, err = s.Get(context.Background(), maxGeneration+1)
+	nonexistent, err = s.Get(mctx, maxGeneration+1)
 	require.Error(t, err)
 	require.IsType(t, erasablekv.UnboxError{}, err)
 	require.Equal(t, keybase1.DeviceEk{}, nonexistent)
 
-	cache, err := s.getCache(context.Background())
+	cache, err := s.getCache(mctx)
 	require.NoError(t, err)
 	require.Len(t, cache, 1)
 
@@ -191,22 +189,22 @@ func TestDeviceEKStorage(t *testing.T) {
 // migration or versioning between the keys. This test should blow up if we
 // break it unintentionally.
 func TestDeviceEKStorageKeyFormat(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	s := NewDeviceEKStorage(tc.G)
+	s := NewDeviceEKStorage(mctx)
 	generation := keybase1.EkGeneration(1)
-	uv, err := tc.G.GetMeUV(context.Background())
+	uv, err := tc.G.GetMeUV(context.TODO())
 	require.NoError(t, err)
 
-	key, err := s.key(context.Background(), generation)
+	key, err := s.key(mctx, generation)
 	require.NoError(t, err)
-	expected := fmt.Sprintf("deviceEphemeralKey-%s-%s-%d.ek", s.G().Env.GetUsername(), uv.EldestSeqno, generation)
+	expected := fmt.Sprintf("deviceEphemeralKey-%s-%s-%d.ek", mctx.G().Env.GetUsername(), uv.EldestSeqno, generation)
 	require.Equal(t, expected, key)
 }
 
 func TestDeleteExpiredOffline(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	now := time.Now()
@@ -245,19 +243,19 @@ func TestDeleteExpiredOffline(t *testing.T) {
 		},
 	}
 
-	s := NewDeviceEKStorage(tc.G)
+	s := NewDeviceEKStorage(mctx)
 
 	for _, test := range expiredTestKeys {
-		err := s.Put(context.Background(), test.Metadata.Generation, test)
+		err := s.Put(mctx, test.Metadata.Generation, test)
 		require.NoError(t, err)
 	}
 
 	expected := []keybase1.EkGeneration{0, 1}
-	expired, err := s.DeleteExpired(context.Background(), libkb.MerkleRoot{})
+	expired, err := s.DeleteExpired(mctx, libkb.MerkleRoot{})
 	require.NoError(t, err)
 	require.Equal(t, expected, expired)
 
-	deviceEKsAfterDeleteExpired, err := s.GetAll(context.Background())
+	deviceEKsAfterDeleteExpired, err := s.GetAll(mctx)
 	require.NoError(t, err)
 
 	require.Len(t, deviceEKsAfterDeleteExpired, 1)
@@ -266,12 +264,12 @@ func TestDeleteExpiredOffline(t *testing.T) {
 func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 	tc := libkb.SetupTest(t, "ephemeral", 2)
 	defer tc.Cleanup()
-
-	s := NewDeviceEKStorage(tc.G)
+	mctx := libkb.NewMetaContextForTest(tc)
+	s := NewDeviceEKStorage(mctx)
 	now := time.Now()
 
 	// Test empty
-	expired := s.getExpiredGenerations(context.Background(), make(keyExpiryMap), now)
+	expired := s.getExpiredGenerations(mctx, make(keyExpiryMap), now)
 	var expected []keybase1.EkGeneration
 	expected = nil
 	require.Equal(t, expected, expected)
@@ -280,7 +278,7 @@ func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 	keyMap := keyExpiryMap{
 		0: keybase1.ToTime(now),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = nil
 	require.Equal(t, expected, expired)
 
@@ -288,7 +286,7 @@ func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 	keyMap = keyExpiryMap{
 		0: keybase1.ToTime(now.Add(-libkb.MaxEphemeralKeyStaleness)),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = nil
 	require.Equal(t, expected, expired)
 
@@ -296,7 +294,7 @@ func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 	keyMap = keyExpiryMap{
 		0: keybase1.ToTime(now.Add(-(2*libkb.MaxEphemeralKeyStaleness + libkb.MinEphemeralKeyLifetime))),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = []keybase1.EkGeneration{0}
 	require.Equal(t, expected, expired)
 
@@ -305,7 +303,7 @@ func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 		0: keybase1.ToTime(now.Add(-(2*libkb.MaxEphemeralKeyStaleness + libkb.MinEphemeralKeyLifetime))),
 		1: keybase1.ToTime(now.Add(-(libkb.MaxEphemeralKeyStaleness + libkb.MinEphemeralKeyLifetime))),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = []keybase1.EkGeneration{0}
 	require.Equal(t, expected, expired)
 
@@ -315,12 +313,12 @@ func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 		1: keybase1.ToTime(now.Add(-(libkb.MaxEphemeralKeyStaleness + libkb.MinEphemeralKeyLifetime))),
 		2: keybase1.ToTime(now.Add(-libkb.MinEphemeralKeyLifetime)),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = []keybase1.EkGeneration{0}
 	require.Equal(t, expected, expired)
 
 	// edge of deletion
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now.Add(-time.Second))
+	expired = s.getExpiredGenerations(mctx, keyMap, now.Add(-time.Second))
 	expected = nil
 	require.Equal(t, expected, expired)
 
@@ -330,7 +328,7 @@ func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 	for i := 0; i < numKeys; i++ {
 		keyMap[keybase1.EkGeneration((numKeys - i - 1))] = keybase1.ToTime(now.Add(-(libkb.MaxEphemeralKeyStaleness*time.Duration(i) + libkb.MinEphemeralKeyLifetime)))
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = []keybase1.EkGeneration{0, 1, 2}
 	require.Equal(t, expected, expired)
 
@@ -344,7 +342,7 @@ func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 		50: 1528724605000,
 		51: 1528811030000,
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = nil
 	require.Equal(t, expected, expired)
 }

--- a/go/ephemeral/device_ek_test.go
+++ b/go/ephemeral/device_ek_test.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
@@ -10,19 +9,18 @@ import (
 )
 
 func TestNewDeviceEK(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	m := libkb.NewMetaContextForTest(tc)
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
-	publishedMetadata, err := publishNewDeviceEK(context.Background(), tc.G, merkleRoot)
+	publishedMetadata, err := publishNewDeviceEK(mctx, merkleRoot)
 	require.NoError(t, err)
 
 	s := tc.G.GetDeviceEKStorage()
-	deviceEK, err := s.Get(context.Background(), publishedMetadata.Generation)
+	deviceEK, err := s.Get(mctx, publishedMetadata.Generation)
 	require.NoError(t, err)
 	// Clear out DeviceCtime since it won't be present in fetched data, it's
 	// only known locally.
@@ -30,31 +28,31 @@ func TestNewDeviceEK(t *testing.T) {
 	deviceEK.Metadata.DeviceCtime = 0
 	require.Equal(t, deviceEK.Metadata, publishedMetadata)
 
-	fetchedDevices, err := allActiveDeviceEKMetadata(context.Background(), tc.G, merkleRoot)
+	fetchedDevices, err := allActiveDeviceEKMetadata(mctx, merkleRoot)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(fetchedDevices))
 	for _, fetchedDeviceMetadata := range fetchedDevices {
 		require.Equal(t, publishedMetadata, fetchedDeviceMetadata)
 	}
-	maxGeneration, err := s.MaxGeneration(context.Background(), false)
+	maxGeneration, err := s.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 
 	require.EqualValues(t, maxGeneration, publishedMetadata.Generation)
 
 	// If we publish again, we increase the generation
-	publishedMetadata2, err := publishNewDeviceEK(context.Background(), tc.G, merkleRoot)
+	publishedMetadata2, err := publishNewDeviceEK(mctx, merkleRoot)
 	require.NoError(t, err)
 	require.EqualValues(t, maxGeneration+1, publishedMetadata2.Generation)
 
-	rawStorage := NewDeviceEKStorage(tc.G)
+	rawStorage := NewDeviceEKStorage(mctx)
 	// Put our storage in a bad state by deleting the maxGeneration
-	err = rawStorage.Delete(context.Background(), keybase1.EkGeneration(maxGeneration+1))
+	err = rawStorage.Delete(mctx, keybase1.EkGeneration(maxGeneration+1))
 	require.NoError(t, err)
 
 	// If we publish in a bad local state, we can successfully get the
 	// maxGeneration from the server and continue
-	publishedMetadata3, err := publishNewDeviceEK(context.Background(), tc.G, merkleRoot)
+	publishedMetadata3, err := publishNewDeviceEK(mctx, merkleRoot)
 	require.NoError(t, err)
 	require.EqualValues(t, maxGeneration+2, publishedMetadata3.Generation)
 }

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -30,25 +29,24 @@ const (
 	DeviceCloneErrMsg                           = "cloned devices do not support exploding messages"
 )
 
-func newEKUnboxErr(ctx context.Context, g *libkb.GlobalContext, boxType EKType, boxGeneration keybase1.EkGeneration,
+func newEKUnboxErr(mctx libkb.MetaContext, boxType EKType, boxGeneration keybase1.EkGeneration,
 	missingType EKType, missingGeneration keybase1.EkGeneration, contentCtime *gregor1.Time) EphemeralKeyError {
 	debugMsg := fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", boxType, boxGeneration, missingType, missingGeneration)
 	var humanMsg string
-	if deviceProvisionedAfterContentCreation(ctx, g, contentCtime) {
+	if deviceProvisionedAfterContentCreation(mctx, contentCtime) {
 		humanMsg = DeviceProvisionedAfterContentCreationErrMsg
-	} else if deviceIsCloned(ctx, g) {
+	} else if deviceIsCloned(mctx) {
 		humanMsg = DeviceCloneErrMsg
 	}
 	return newEphemeralKeyError(debugMsg, humanMsg)
 }
 
-func newEKMissingBoxErr(ctx context.Context, g *libkb.GlobalContext,
-	boxType EKType, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
+func newEKMissingBoxErr(mctx libkb.MetaContext, boxType EKType, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
 	debugMsg := fmt.Sprintf("Missing box for %s@generation:%v", boxType, boxGeneration)
 	return newEphemeralKeyError(debugMsg, "")
 }
 
-func newEKCorruptedErr(ctx context.Context, g *libkb.GlobalContext, boxType EKType,
+func newEKCorruptedErr(mctx libkb.MetaContext, boxType EKType,
 	expectedGeneration, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
 	debugMsg := fmt.Sprintf("Storage error for %s@generation:%v, got generation %v instead", boxType, boxGeneration, expectedGeneration)
 	return newEphemeralKeyError(debugMsg, "")
@@ -104,23 +102,21 @@ func errFromAppStatus(e error) error {
 	return e
 }
 
-func deviceProvisionedAfterContentCreation(ctx context.Context, g *libkb.GlobalContext, contentCtime *gregor1.Time) bool {
+func deviceProvisionedAfterContentCreation(mctx libkb.MetaContext, contentCtime *gregor1.Time) bool {
 	// some callers may not specify a creation time if they aren't trying to
 	// decrypt a specific piece of content.
 	if contentCtime == nil {
 		return false
 	}
-	m := libkb.NewMetaContext(ctx, g)
-	deviceCtime, err := g.ActiveDevice.Ctime(m)
+	deviceCtime, err := mctx.ActiveDevice().Ctime(mctx)
 	if err != nil {
 		return false
 	}
 	return contentCtime.Time().Before(deviceCtime.Time())
 }
 
-func deviceIsCloned(ctx context.Context, g *libkb.GlobalContext) bool {
-	m := libkb.NewMetaContext(ctx, g)
-	cloneState, err := libkb.GetDeviceCloneState(m)
+func deviceIsCloned(mctx libkb.MetaContext) bool {
+	cloneState, err := libkb.GetDeviceCloneState(mctx)
 	if err != nil {
 		return false
 	}

--- a/go/ephemeral/handler.go
+++ b/go/ephemeral/handler.go
@@ -1,18 +1,16 @@
 package ephemeral
 
 import (
-	"context"
-
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func HandleNewTeamEK(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (err error) {
-	defer g.CTrace(ctx, "HandleNewTeamEK", func() error { return err })()
+func HandleNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (err error) {
+	defer mctx.TraceTimed("HandleNewTeamEK", func() error { return err })()
 
-	if ekLib := g.GetEKLib(); ekLib != nil {
-		ekLib.PurgeCachesForTeamIDAndGeneration(ctx, teamID, generation)
+	if ekLib := mctx.G().GetEKLib(); ekLib != nil {
+		ekLib.PurgeCachesForTeamIDAndGeneration(mctx, teamID, generation)
 	}
-	g.NotifyRouter.HandleNewTeamEK(ctx, teamID, generation)
+	mctx.G().NotifyRouter.HandleNewTeamEK(mctx.Ctx(), teamID, generation)
 	return nil
 }

--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -5,21 +5,21 @@ import (
 )
 
 // Creates a ephemeral key storage and installs it into G.
-func NewEphemeralStorageAndInstall(g *libkb.GlobalContext) {
-	g.SetDeviceEKStorage(NewDeviceEKStorage(g))
-	g.SetUserEKBoxStorage(NewUserEKBoxStorage(g))
-	g.SetTeamEKBoxStorage(NewTeamEKBoxStorage(g))
-	ekLib := NewEKLib(g)
-	g.SetEKLib(ekLib)
-	g.AddLoginHook(ekLib)
-	g.AddLogoutHook(ekLib)
-	g.PushShutdownHook(func() error {
-		g.Log.Debug("stopping background eklib loop")
+func NewEphemeralStorageAndInstall(mctx libkb.MetaContext) {
+	mctx.G().SetDeviceEKStorage(NewDeviceEKStorage(mctx))
+	mctx.G().SetUserEKBoxStorage(NewUserEKBoxStorage())
+	mctx.G().SetTeamEKBoxStorage(NewTeamEKBoxStorage())
+	ekLib := NewEKLib(mctx)
+	mctx.G().SetEKLib(ekLib)
+	mctx.G().AddLoginHook(ekLib)
+	mctx.G().AddLogoutHook(ekLib)
+	mctx.G().PushShutdownHook(func() error {
+		mctx.Debug("stopping background eklib loop")
 		ekLib.Shutdown()
 		return nil
 	})
 }
 
-func ServiceInit(g *libkb.GlobalContext) {
-	NewEphemeralStorageAndInstall(g)
+func ServiceInit(mctx libkb.MetaContext) {
+	NewEphemeralStorageAndInstall(mctx)
 }

--- a/go/ephemeral/kex2_test.go
+++ b/go/ephemeral/kex2_test.go
@@ -32,7 +32,8 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	tcX := libkb.SetupTest(t, "kex2provision", 2)
 	defer tcX.Cleanup()
 	tcX.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
-	NewEphemeralStorageAndInstall(tcX.G)
+	mctxX := libkb.NewMetaContextForTest(tcX)
+	NewEphemeralStorageAndInstall(mctxX)
 
 	// provisioner needs to be logged in
 	userX, err := kbtest.CreateAndSignupFakeUser("X", tcX.G)
@@ -46,23 +47,23 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 		// explicitly sync it.
 		keyring, err := tcX.G.GetPerUserKeyring(context.Background())
 		require.NoError(t, err)
-		err = keyring.Sync(libkb.NewMetaContext(context.Background(), tcX.G))
+		err = keyring.Sync(mctxX)
 		require.NoError(t, err)
 
 		ekLib := tcX.G.GetEKLib()
-		err = ekLib.KeygenIfNeeded(context.Background())
+		err = ekLib.KeygenIfNeeded(mctxX)
 		require.NoError(t, err)
 	}
 
 	// After the provision, Y should have access to this userEK generation
 	userEKBoxStorageX := tcX.G.GetUserEKBoxStorage()
-	userEKGenX, err := userEKBoxStorageX.MaxGeneration(context.Background(), false)
+	userEKGenX, err := userEKBoxStorageX.MaxGeneration(mctxX, false)
 	require.NoError(t, err)
 
 	var userEKX keybase1.UserEk
 	if upgradePerUserKey {
 		require.True(t, userEKGenX > 0)
-		userEKX, err = userEKBoxStorageX.Get(context.Background(), userEKGenX, nil)
+		userEKX, err = userEKBoxStorageX.Get(mctxX, userEKGenX, nil)
 		require.NoError(t, err)
 	} else {
 		require.EqualValues(t, userEKGenX, -1)
@@ -72,7 +73,8 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	tcY := libkb.SetupTest(t, "kex2provision", 2)
 	defer tcY.Cleanup()
 	tcY.Tp.DisableUpgradePerUserKey = !upgradePerUserKey
-	NewEphemeralStorageAndInstall(tcY.G)
+	mctxY := libkb.NewMetaContextForTest(tcY)
+	NewEphemeralStorageAndInstall(mctxY)
 
 	var secretX kex2.Secret
 	_, err = rand.Read(secretX[:])
@@ -108,8 +110,8 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 				Type:        libkb.DeviceTypeDesktop,
 			}
 			provisionee := engine.NewKex2Provisionee(tcY.G, device, secretY, userX.GetUID(), fakeSalt())
-			m := libkb.NewMetaContextForTest(tcY).WithUIs(uis).WithNewProvisionalLoginContext()
-			return engine.RunEngine2(m, provisionee)
+			mctxY = mctxY.WithUIs(uis).WithNewProvisionalLoginContext()
+			return engine.RunEngine2(mctxY, provisionee)
 		})()
 		require.NoError(t, err, "provisionee")
 	}()
@@ -124,8 +126,8 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 		}
 		provisioner := engine.NewKex2Provisioner(tcX.G, secretX, nil)
 		go provisioner.AddSecret(secretY)
-		m := libkb.NewMetaContextForTest(tcX).WithUIs(uis)
-		if err := engine.RunEngine2(m, provisioner); err != nil {
+		mctxX = mctxX.WithUIs(uis)
+		if err := engine.RunEngine2(mctxX, provisioner); err != nil {
 			t.Errorf("provisioner error: %s", err)
 			return
 		}
@@ -134,12 +136,12 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	wg.Wait()
 
 	deviceEKStorageY := tcY.G.GetDeviceEKStorage()
-	maxDeviceEKGenerationY, err := deviceEKStorageY.MaxGeneration(context.Background(), false)
+	maxDeviceEKGenerationY, err := deviceEKStorageY.MaxGeneration(mctxY, false)
 	require.NoError(t, err)
 	if upgradePerUserKey {
 		// Confirm that Y has a deviceEK.
 		require.True(t, maxDeviceEKGenerationY > 0)
-		deviceEKY, err := deviceEKStorageY.Get(context.Background(), maxDeviceEKGenerationY)
+		deviceEKY, err := deviceEKStorageY.Get(mctxY, maxDeviceEKGenerationY)
 		require.NoError(t, err)
 		// Clear out DeviceCtime since it won't be present in fetched data,
 		// it's only known locally.
@@ -147,13 +149,13 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 		deviceEKY.Metadata.DeviceCtime = 0
 
 		// Make sure the server knows about our device_ek
-		merkleRootPtr, err := tcY.G.GetMerkleClient().FetchRootFromServer(libkb.NewMetaContextForTest(tcY), libkb.EphemeralKeyMerkleFreshness)
+		merkleRootPtr, err := tcY.G.GetMerkleClient().FetchRootFromServer(mctxY, libkb.EphemeralKeyMerkleFreshness)
 		require.NoError(t, err)
 
-		fetchedDevices, err := allActiveDeviceEKMetadata(context.Background(), tcY.G, *merkleRootPtr)
+		fetchedDevices, err := allActiveDeviceEKMetadata(mctxY, *merkleRootPtr)
 		require.NoError(t, err)
 
-		deviceEKMetatdata, ok := fetchedDevices[tcY.G.ActiveDevice.DeviceID()]
+		deviceEKMetatdata, ok := fetchedDevices[mctxY.ActiveDevice().DeviceID()]
 		require.True(t, ok)
 		require.Equal(t, deviceEKY.Metadata, deviceEKMetatdata)
 
@@ -163,21 +165,21 @@ func subTestKex2Provision(t *testing.T, upgradePerUserKey bool) {
 	// Confirm Y has a userEK at the same generation as X. If we didn't have a
 	// PUK this generation will be -1.
 	userEKBoxStorageY := tcY.G.GetUserEKBoxStorage()
-	userEKGenY, err := userEKBoxStorageY.MaxGeneration(context.Background(), false)
+	userEKGenY, err := userEKBoxStorageY.MaxGeneration(mctxY, false)
 	require.NoError(t, err)
 	require.EqualValues(t, userEKGenX, userEKGenY)
 
 	if upgradePerUserKey {
-		userEKY, err := userEKBoxStorageY.Get(context.Background(), userEKGenY, nil)
+		userEKY, err := userEKBoxStorageY.Get(mctxY, userEKGenY, nil)
 		require.NoError(t, err)
 		require.Equal(t, userEKX, userEKY)
 
 		// Now clear local store and make sure the server has reboxed userEK.
-		rawUserEKBoxStorage := NewUserEKBoxStorage(tcY.G)
-		rawUserEKBoxStorage.Delete(context.Background(), userEKGenY)
+		rawUserEKBoxStorage := NewUserEKBoxStorage()
+		rawUserEKBoxStorage.Delete(mctxY, userEKGenY)
 		userEKBoxStorageY.ClearCache()
 
-		userEKYFetched, err := userEKBoxStorageY.Get(context.Background(), userEKGenY, nil)
+		userEKYFetched, err := userEKBoxStorageY.Get(mctxY, userEKGenY, nil)
 		require.NoError(t, err)
 		require.Equal(t, userEKX, userEKYFetched)
 	}

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -23,7 +22,6 @@ const cacheEntryLifetime = time.Minute * 5
 const lruSize = 200
 
 type EKLib struct {
-	libkb.Contextified
 	teamEKGenCache *lru.Cache
 	sync.Mutex
 
@@ -35,19 +33,18 @@ type EKLib struct {
 	stopCh                   chan struct{}
 }
 
-func NewEKLib(g *libkb.GlobalContext) *EKLib {
+func NewEKLib(mctx libkb.MetaContext) *EKLib {
 	nlru, err := lru.New(lruSize)
 	if err != nil {
 		// lru.New only panics if size <= 0
 		log.Panicf("Could not create lru cache: %v", err)
 	}
 	ekLib := &EKLib{
-		Contextified:   libkb.NewContextified(g),
 		teamEKGenCache: nlru,
 		clock:          clockwork.NewRealClock(),
 		stopCh:         make(chan struct{}),
 	}
-	go ekLib.backgroundKeygen()
+	go ekLib.backgroundKeygen(mctx)
 	return ekLib
 }
 
@@ -60,21 +57,20 @@ func (e *EKLib) Shutdown() {
 	}
 }
 
-func (e *EKLib) backgroundKeygen() {
-	ctx := context.Background()
-	e.G().Log.CDebugf(ctx, "backgroundKeygen: starting up")
+func (e *EKLib) backgroundKeygen(mctx libkb.MetaContext) {
+	mctx = mctx.WithLogTag("EKBKG")
+	mctx.Debug("backgroundKeygen: starting up")
 	keygenInterval := time.Hour
 	lastRun := time.Now()
 
 	runIfNeeded := func(force bool) {
-		ctx := libkb.WithLogTag(ctx, "EKBKG")
 		now := libkb.ForceWallClock(time.Now())
 		shouldRun := now.Sub(lastRun) >= keygenInterval
-		e.G().Log.CDebugf(ctx, "backgroundKeygen: runIfNeeded: lastRun: %v, now: %v, shouldRun: %v, force: %v",
+		mctx.Debug("backgroundKeygen: runIfNeeded: lastRun: %v, now: %v, shouldRun: %v, force: %v",
 			lastRun, now, shouldRun, force)
 		if force || shouldRun {
-			if err := e.KeygenIfNeeded(ctx); err != nil {
-				e.G().Log.CDebugf(ctx, "backgroundKeygen keygenIfNeeded error: %v", err)
+			if err := e.KeygenIfNeeded(mctx); err != nil {
+				mctx.Debug("backgroundKeygen keygenIfNeeded error: %v", err)
 			}
 			lastRun = time.Now()
 		}
@@ -91,7 +87,7 @@ func (e *EKLib) backgroundKeygen() {
 		select {
 		case <-ticker.C:
 			runIfNeeded(false /* force */)
-		case state = <-e.G().MobileAppState.NextUpdate(&state):
+		case state = <-mctx.G().MobileAppState.NextUpdate(&state):
 			if state == keybase1.MobileAppState_BACKGROUNDACTIVE {
 				// Before running  we pause briefly so we don't stampede for
 				// resources with other background tasks. libkb.BgTicker
@@ -119,15 +115,14 @@ func (e *EKLib) setBackgroundDeleteTestCh(ch chan bool) {
 	e.backgroundDeletionTestCh = ch
 }
 
-func (e *EKLib) checkLogin(ctx context.Context) error {
-	if isOneshot, err := e.G().IsOneshot(ctx); err != nil {
-		e.G().Log.CDebugf(ctx, "EKLib#checkLogin unable to check IsOneshot %v", err)
+func (e *EKLib) checkLogin(mctx libkb.MetaContext) error {
+	if isOneshot, err := mctx.G().IsOneshot(mctx.Ctx()); err != nil {
+		mctx.Debug("EKLib#checkLogin unable to check IsOneshot %v", err)
 		return err
 	} else if isOneshot {
 		return fmt.Errorf("Aborting ephemeral key generation, using oneshot session!")
 	}
 
-	mctx := e.MetaContext(ctx)
 	if loggedIn, _, err := libkb.BootstrapActiveDeviceWithMetaContext(mctx); err != nil {
 		return err
 	} else if !loggedIn {
@@ -136,7 +131,7 @@ func (e *EKLib) checkLogin(ctx context.Context) error {
 	return nil
 }
 
-func (e *EKLib) KeygenIfNeeded(ctx context.Context) (err error) {
+func (e *EKLib) KeygenIfNeeded(mctx libkb.MetaContext) (err error) {
 	e.Lock()
 	defer e.Unlock()
 	var merkleRoot libkb.MerkleRoot
@@ -146,34 +141,34 @@ func (e *EKLib) KeygenIfNeeded(ctx context.Context) (err error) {
 	// error before reaching that call.
 	defer func() {
 		if err != nil {
-			e.cleanupStaleUserAndDeviceEKsInBackground(ctx, merkleRoot)
+			e.cleanupStaleUserAndDeviceEKsInBackground(mctx, merkleRoot)
 		}
 	}()
 
-	if err = e.checkLogin(ctx); err != nil {
+	if err = e.checkLogin(mctx); err != nil {
 		return err
 	}
 
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
-		e.G().Log.CDebugf(ctx, "Unable to fetch merkle root: %v, attempting keygenIfNeeded with nil root", err)
+		mctx.Debug("Unable to fetch merkle root: %v, attempting keygenIfNeeded with nil root", err)
 		merkleRootPtr = &libkb.MerkleRoot{}
 	}
 	for tries := 0; tries < maxRetries; tries++ {
-		if err = e.keygenIfNeeded(ctx, *merkleRootPtr, true /* shouldCleanup */); err == nil {
+		if err = e.keygenIfNeeded(mctx, *merkleRootPtr, true /* shouldCleanup */); err == nil {
 			return nil
 		}
 		time.Sleep(200 * time.Millisecond)
-		e.G().Log.CDebugf(ctx, "KeygenIfNeeded retrying attempt #%d: %v", tries, err)
+		mctx.Debug("KeygenIfNeeded retrying attempt #%d: %v", tries, err)
 	}
 	return err
 }
 
-func (e *EKLib) keygenIfNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot, shouldCleanup bool) (err error) {
-	defer e.G().CTraceTimed(ctx, "keygenIfNeeded", func() error { return err })()
+func (e *EKLib) keygenIfNeeded(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot, shouldCleanup bool) (err error) {
+	defer mctx.TraceTimed("keygenIfNeeded", func() error { return err })()
 	defer func() {
 		if shouldCleanup {
-			e.cleanupStaleUserAndDeviceEKsInBackground(ctx, merkleRoot)
+			e.cleanupStaleUserAndDeviceEKsInBackground(mctx, merkleRoot)
 		}
 	}()
 
@@ -182,10 +177,10 @@ func (e *EKLib) keygenIfNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot,
 		return fmt.Errorf(SkipKeygenNilMerkleRoot)
 	}
 
-	if deviceEKNeeded, err := e.newDeviceEKNeeded(ctx, merkleRoot); err != nil {
+	if deviceEKNeeded, err := e.newDeviceEKNeeded(mctx, merkleRoot); err != nil {
 		return err
 	} else if deviceEKNeeded {
-		_, err = publishNewDeviceEK(ctx, e.G(), merkleRoot)
+		_, err = publishNewDeviceEK(mctx, merkleRoot)
 		if err != nil {
 			return err
 		}
@@ -196,10 +191,10 @@ func (e *EKLib) keygenIfNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot,
 	// key is not expired. It's crucial that this verifies that the latest PUK
 	// was used since we don't want to use a key signed by an old PUK for
 	// encryption.
-	if userEKNeeded, err := e.newUserEKNeeded(ctx, merkleRoot); err != nil {
+	if userEKNeeded, err := e.newUserEKNeeded(mctx, merkleRoot); err != nil {
 		return err
 	} else if userEKNeeded {
-		_, err = publishNewUserEK(ctx, e.G(), merkleRoot)
+		_, err = publishNewUserEK(mctx, merkleRoot)
 		if err != nil {
 			return err
 		}
@@ -207,25 +202,25 @@ func (e *EKLib) keygenIfNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot,
 	return nil
 }
 
-func (e *EKLib) CleanupStaleUserAndDeviceEKs(ctx context.Context) (err error) {
+func (e *EKLib) CleanupStaleUserAndDeviceEKs(mctx libkb.MetaContext) (err error) {
 	e.Lock()
 	defer e.Unlock()
 
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
-		e.G().Log.CDebugf(ctx, "Unable to fetch merkle root: %v, attempting deviceEK deletion with nil root", err)
+		mctx.Debug("Unable to fetch merkle root: %v, attempting deviceEK deletion with nil root", err)
 		merkleRootPtr = &libkb.MerkleRoot{}
 	}
-	return e.cleanupStaleUserAndDeviceEKs(ctx, *merkleRootPtr)
+	return e.cleanupStaleUserAndDeviceEKs(mctx, *merkleRootPtr)
 }
 
-func (e *EKLib) cleanupStaleUserAndDeviceEKs(ctx context.Context, merkleRoot libkb.MerkleRoot) (err error) {
-	defer e.G().CTraceTimed(ctx, "cleanupStaleUserAndDeviceEKs", func() error { return err })()
+func (e *EKLib) cleanupStaleUserAndDeviceEKs(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (err error) {
+	defer mctx.TraceTimed("cleanupStaleUserAndDeviceEKs", func() error { return err })()
 
 	epick := libkb.FirstErrorPicker{}
 
-	deviceEKStorage := e.G().GetDeviceEKStorage()
-	_, err = deviceEKStorage.DeleteExpired(ctx, merkleRoot)
+	deviceEKStorage := mctx.G().GetDeviceEKStorage()
+	_, err = deviceEKStorage.DeleteExpired(mctx, merkleRoot)
 	epick.Push(err)
 
 	// Abort. We only cared about deleting expired deviceEKs.
@@ -233,16 +228,16 @@ func (e *EKLib) cleanupStaleUserAndDeviceEKs(ctx context.Context, merkleRoot lib
 		return fmt.Errorf("skipping userEK deletion, unable to fetch merkle root")
 	}
 
-	userEKBoxStorage := e.G().GetUserEKBoxStorage()
-	_, err = userEKBoxStorage.DeleteExpired(ctx, merkleRoot)
+	userEKBoxStorage := mctx.G().GetUserEKBoxStorage()
+	_, err = userEKBoxStorage.DeleteExpired(mctx, merkleRoot)
 	epick.Push(err)
 	return epick.Error()
 }
 
-func (e *EKLib) cleanupStaleUserAndDeviceEKsInBackground(ctx context.Context, merkleRoot libkb.MerkleRoot) {
+func (e *EKLib) cleanupStaleUserAndDeviceEKsInBackground(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) {
 	go func() {
-		if err := e.cleanupStaleUserAndDeviceEKs(ctx, merkleRoot); err != nil {
-			e.G().Log.CDebugf(ctx, "Unable to cleanupStaleUserAndDeviceEKsInBackground: %v", err)
+		if err := e.cleanupStaleUserAndDeviceEKs(mctx, merkleRoot); err != nil {
+			mctx.Debug("Unable to cleanupStaleUserAndDeviceEKsInBackground: %v", err)
 		}
 
 		if e.backgroundDeletionTestCh != nil {
@@ -251,64 +246,64 @@ func (e *EKLib) cleanupStaleUserAndDeviceEKsInBackground(ctx context.Context, me
 	}()
 }
 
-func (e *EKLib) NewDeviceEKNeeded(ctx context.Context) (needed bool, err error) {
+func (e *EKLib) NewDeviceEKNeeded(mctx libkb.MetaContext) (needed bool, err error) {
 	e.Lock()
 	defer e.Unlock()
 
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
 		return false, err
 	}
-	return e.newDeviceEKNeeded(ctx, *merkleRootPtr)
+	return e.newDeviceEKNeeded(mctx, *merkleRootPtr)
 }
 
-func (e *EKLib) newDeviceEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
-	defer e.G().CTraceTimed(ctx, "newDeviceEKNeeded", func() error { return err })()
+func (e *EKLib) newDeviceEKNeeded(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
+	defer mctx.TraceTimed("newDeviceEKNeeded", func() error { return err })()
 	defer func() {
 		switch err.(type) {
 		case erasablekv.UnboxError:
-			e.G().Log.Debug("newDeviceEKNeeded: unable to fetch latest: %v, creating new deviceEK", err)
+			mctx.Debug("newDeviceEKNeeded: unable to fetch latest: %v, creating new deviceEK", err)
 			needed = true
 			err = nil
 		}
 	}()
 
-	s := e.G().GetDeviceEKStorage()
-	maxGeneration, err := s.MaxGeneration(ctx, true)
+	s := mctx.G().GetDeviceEKStorage()
+	maxGeneration, err := s.MaxGeneration(mctx, true)
 	if err != nil {
 		return false, err
 	} else if maxGeneration < 0 {
 		return true, nil
 	}
 
-	ek, err := s.Get(ctx, maxGeneration)
+	ek, err := s.Get(mctx, maxGeneration)
 	if err != nil {
 		return false, err
 	}
 
 	// Ok we can access the ek, check lifetime.
-	e.G().Log.CDebugf(ctx, "nextDeviceEKNeeded at: %v", nextKeygenTime(ek.Metadata.Ctime.Time()))
+	mctx.Debug("nextDeviceEKNeeded at: %v", nextKeygenTime(ek.Metadata.Ctime.Time()))
 	return keygenNeeded(ek.Metadata.Ctime.Time(), merkleRoot), nil
 }
 
-func (e *EKLib) NewUserEKNeeded(ctx context.Context) (needed bool, err error) {
+func (e *EKLib) NewUserEKNeeded(mctx libkb.MetaContext) (needed bool, err error) {
 	e.Lock()
 	defer e.Unlock()
 
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
 		return false, err
 	}
-	return e.newUserEKNeeded(ctx, *merkleRootPtr)
+	return e.newUserEKNeeded(mctx, *merkleRootPtr)
 }
 
-func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
-	defer e.G().CTraceTimed(ctx, "newUserEKNeeded", func() error { return err })()
+func (e *EKLib) newUserEKNeeded(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (needed bool, err error) {
+	defer mctx.TraceTimed("newUserEKNeeded", func() error { return err })()
 
 	// Let's see what the latest server statement is. This verifies that the
 	// latest statement was signed by the latest PUK and otherwise fails with
 	// wrongKID set.
-	statement, _, wrongKID, err := fetchUserEKStatement(ctx, e.G(), e.G().Env.GetUID())
+	statement, _, wrongKID, err := fetchUserEKStatement(mctx, mctx.G().Env.GetUID())
 	if wrongKID {
 		return true, nil
 	} else if err != nil {
@@ -318,41 +313,42 @@ func (e *EKLib) newUserEKNeeded(ctx context.Context, merkleRoot libkb.MerkleRoot
 		return true, nil
 	}
 	// Can we access this generation? If not, let's regenerate.
-	s := e.G().GetUserEKBoxStorage()
-	ek, err := s.Get(ctx, statement.CurrentUserEkMetadata.Generation, nil)
+	s := mctx.G().GetUserEKBoxStorage()
+	ek, err := s.Get(mctx, statement.CurrentUserEkMetadata.Generation, nil)
 	if err != nil {
 		switch err.(type) {
 		case EphemeralKeyError:
-			e.G().Log.Debug(err.Error())
+			mctx.Debug(err.Error())
 			return true, nil
 		default:
 			return false, err
 		}
 	}
 	// Ok we can access the ek, check lifetime.
-	e.G().Log.CDebugf(ctx, "nextUserEKNeeded at: %v", nextKeygenTime(ek.Metadata.Ctime.Time()))
+	mctx.Debug("nextUserEKNeeded at: %v", nextKeygenTime(ek.Metadata.Ctime.Time()))
 	return keygenNeeded(ek.Metadata.Ctime.Time(), merkleRoot), nil
 }
 
-func (e *EKLib) NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (needed bool, err error) {
+func (e *EKLib) NewTeamEKNeeded(mctx libkb.MetaContext, teamID keybase1.TeamID) (needed bool, err error) {
 	e.Lock()
 	defer e.Unlock()
 
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
 		return false, err
 	}
-	needed, _, _, err = e.newTeamEKNeeded(ctx, teamID, *merkleRootPtr)
+	needed, _, _, err = e.newTeamEKNeeded(mctx, teamID, *merkleRootPtr)
 	return needed, err
 }
 
-func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (needed, backgroundGenPossible bool, latestGeneration keybase1.EkGeneration, err error) {
-	defer e.G().CTraceTimed(ctx, "newTeamEKNeeded", func() error { return err })()
+func (e *EKLib) newTeamEKNeeded(mctx libkb.MetaContext, teamID keybase1.TeamID,
+	merkleRoot libkb.MerkleRoot) (needed, backgroundGenPossible bool, latestGeneration keybase1.EkGeneration, err error) {
+	defer mctx.TraceTimed("newTeamEKNeeded", func() error { return err })()
 
 	// Let's see what the latest server statement is. This verifies that the
 	// latest statement was signed by the latest PTK and otherwise fails with
 	// wrongKID set.
-	statement, latestGeneration, wrongKID, err := fetchTeamEKStatement(ctx, e.G(), teamID)
+	statement, latestGeneration, wrongKID, err := fetchTeamEKStatement(mctx, teamID)
 	if wrongKID {
 		return true, false, latestGeneration, nil
 	} else if err != nil {
@@ -365,19 +361,19 @@ func (e *EKLib) newTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID, mer
 		return true, false, latestGeneration, nil
 	}
 	// Can we access this generation? If not, let's regenerate.
-	s := e.G().GetTeamEKBoxStorage()
-	ek, err := s.Get(ctx, teamID, statement.CurrentTeamEkMetadata.Generation, nil)
+	s := mctx.G().GetTeamEKBoxStorage()
+	ek, err := s.Get(mctx, teamID, statement.CurrentTeamEkMetadata.Generation, nil)
 	if err != nil {
 		switch err.(type) {
 		case EphemeralKeyError:
-			e.G().Log.Debug(err.Error())
+			mctx.Debug(err.Error())
 			return true, false, latestGeneration, nil
 		default:
 			return false, false, latestGeneration, err
 		}
 	}
 	// Ok we can access the ek, check lifetime.
-	e.G().Log.CDebugf(ctx, "nextTeamEKNeeded at: %v", nextKeygenTime(ek.Metadata.Ctime.Time()))
+	mctx.Debug("nextTeamEKNeeded at: %v", nextKeygenTime(ek.Metadata.Ctime.Time()))
 	if backgroundKeygenPossible(ek.Metadata.Ctime.Time(), merkleRoot) {
 		return false, true, latestGeneration, nil
 	}
@@ -410,16 +406,16 @@ func (e *EKLib) isEntryExpired(val interface{}) (*teamEKGenCacheEntry, bool) {
 	return cacheEntry, e.clock.Now().Sub(cacheEntry.Ctime.Time()) >= cacheEntryLifetime
 }
 
-func (e *EKLib) PurgeCachesForTeamID(ctx context.Context, teamID keybase1.TeamID) {
-	e.G().Log.CDebugf(ctx, "PurgeCachesForTeamID: teamID: %v", teamID)
+func (e *EKLib) PurgeCachesForTeamID(mctx libkb.MetaContext, teamID keybase1.TeamID) {
+	mctx.Debug("PurgeCachesForTeamID: teamID: %v", teamID)
 	e.teamEKGenCache.Remove(e.cacheKey(teamID))
-	if err := e.G().GetTeamEKBoxStorage().PurgeCacheForTeamID(ctx, teamID); err != nil {
-		e.G().Log.CDebugf(ctx, "unable to PurgeCacheForTeamID: %v", err)
+	if err := mctx.G().GetTeamEKBoxStorage().PurgeCacheForTeamID(mctx, teamID); err != nil {
+		mctx.Debug("unable to PurgeCacheForTeamID: %v", err)
 	}
 }
 
-func (e *EKLib) PurgeCachesForTeamIDAndGeneration(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) {
-	e.G().Log.CDebugf(ctx, "PurgeCachesForTeamIDAndGeneration: teamID: %v, generation: %v", teamID, generation)
+func (e *EKLib) PurgeCachesForTeamIDAndGeneration(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) {
+	mctx.Debug("PurgeCachesForTeamIDAndGeneration: teamID: %v, generation: %v", teamID, generation)
 	cacheKey := e.cacheKey(teamID)
 	val, ok := e.teamEKGenCache.Get(cacheKey)
 	if ok {
@@ -427,35 +423,35 @@ func (e *EKLib) PurgeCachesForTeamIDAndGeneration(ctx context.Context, teamID ke
 			e.teamEKGenCache.Remove(cacheKey)
 		}
 	}
-	if err := e.G().GetTeamEKBoxStorage().Delete(ctx, teamID, generation); err != nil {
-		e.G().Log.CDebugf(ctx, "unable to PurgeCacheForTeamIDAndGeneration: %v", err)
+	if err := mctx.G().GetTeamEKBoxStorage().Delete(mctx, teamID, generation); err != nil {
+		mctx.Debug("unable to PurgeCacheForTeamIDAndGeneration: %v", err)
 	}
 }
 
-func (e *EKLib) GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, created bool, err error) {
-	if err = e.checkLogin(ctx); err != nil {
+func (e *EKLib) GetOrCreateLatestTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, created bool, err error) {
+	if err = e.checkLogin(mctx); err != nil {
 		return teamEK, false, err
 	}
 
-	err = teamEKRetryWrapper(ctx, e.G(), func() error {
-		teamEK, created, err = e.getOrCreateLatestTeamEKInner(ctx, teamID)
+	err = teamEKRetryWrapper(mctx, func() error {
+		teamEK, created, err = e.getOrCreateLatestTeamEKInner(mctx, teamID)
 		return err
 	})
 	return teamEK, created, err
 }
 
-func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, created bool, err error) {
-	defer e.G().CTraceTimed(ctx, "getOrCreateLatestTeamEKInner", func() error { return err })()
+func (e *EKLib) getOrCreateLatestTeamEKInner(mctx libkb.MetaContext, teamID keybase1.TeamID) (teamEK keybase1.TeamEk, created bool, err error) {
+	defer mctx.TraceTimed("getOrCreateLatestTeamEKInner", func() error { return err })()
 	e.Lock()
 	defer e.Unlock()
 
-	teamEKBoxStorage := e.G().GetTeamEKBoxStorage()
+	teamEKBoxStorage := mctx.G().GetTeamEKBoxStorage()
 	// Check if we have a cached latest generation
 	cacheKey := e.cacheKey(teamID)
 	val, ok := e.teamEKGenCache.Get(cacheKey)
 	if ok {
 		if cacheEntry, expired := e.isEntryExpired(val); !expired || cacheEntry.CreationInProgress {
-			teamEK, err = teamEKBoxStorage.Get(ctx, teamID, cacheEntry.Generation, nil)
+			teamEK, err = teamEKBoxStorage.Get(mctx, teamID, cacheEntry.Generation, nil)
 			if err == nil {
 				return teamEK, false, nil
 			}
@@ -464,18 +460,18 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 		}
 	}
 
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
 		return teamEK, false, err
 	}
 	merkleRoot := *merkleRootPtr
-	defer func() { e.cleanupStaleUserAndDeviceEKsInBackground(ctx, merkleRoot) }()
-	defer teamEKBoxStorage.DeleteExpired(ctx, teamID, merkleRoot)
+	defer func() { e.cleanupStaleUserAndDeviceEKsInBackground(mctx, merkleRoot) }()
+	defer teamEKBoxStorage.DeleteExpired(mctx, teamID, merkleRoot)
 
 	// First publish new device or userEKs if we need to. We pass shouldCleanup
 	// = false so we can run deletion in the background ourselves and not block
 	// this call.
-	if err = e.keygenIfNeeded(ctx, merkleRoot, false /* shouldCleanup */); err != nil {
+	if err = e.keygenIfNeeded(mctx, merkleRoot, false /* shouldCleanup */); err != nil {
 		return teamEK, false, err
 	}
 
@@ -484,7 +480,7 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 	// is not expired. It's crucial that this verifies that the latest PTK was
 	// used since we don't want to use a key signed by an old PTK for
 	// encryption.
-	teamEKNeeded, backgroundGenPossible, latestGeneration, err := e.newTeamEKNeeded(ctx, teamID, merkleRoot)
+	teamEKNeeded, backgroundGenPossible, latestGeneration, err := e.newTeamEKNeeded(mctx, teamID, merkleRoot)
 	if err != nil {
 		return teamEK, false, err
 	} else if backgroundGenPossible {
@@ -500,14 +496,14 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 				}
 			}
 
-			publishedMetadata, err := publishNewTeamEK(ctx, e.G(), teamID, merkleRoot)
+			publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot)
 			// Grab the lock once we finish publishing so we do don't block
 			e.Lock()
 			defer e.Unlock()
 			created := false
 			if err != nil {
 				// Let's just clear the cache and try again later
-				e.G().Log.CDebugf(ctx, "Unable to GetOrCreateLatestTeamEK in the background: %v", err)
+				mctx.Debug("Unable to GetOrCreateLatestTeamEK in the background: %v", err)
 				e.teamEKGenCache.Remove(cacheKey)
 			} else {
 				e.teamEKGenCache.Add(cacheKey, e.newCacheEntry(publishedMetadata.Generation, false))
@@ -519,14 +515,14 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 			}
 		}()
 	} else if teamEKNeeded {
-		publishedMetadata, err := publishNewTeamEK(ctx, e.G(), teamID, merkleRoot)
+		publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot)
 		if err != nil {
 			return teamEK, false, err
 		}
 		latestGeneration = publishedMetadata.Generation
 	}
 
-	teamEK, err = teamEKBoxStorage.Get(ctx, teamID, latestGeneration, nil)
+	teamEK, err = teamEKBoxStorage.Get(mctx, teamID, latestGeneration, nil)
 	if err != nil {
 		return teamEK, false, err
 	}
@@ -538,35 +534,34 @@ func (e *EKLib) getOrCreateLatestTeamEKInner(ctx context.Context, teamID keybase
 
 // Try to get the TeamEK for the given `generation`. If this fails and the
 // `generation` is also the current maxGeneration, create a new teamEK.
-func (e *EKLib) GetTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration,
+func (e *EKLib) GetTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration,
 	contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
-	defer e.G().CTraceTimed(ctx, "GetTeamEK", func() error { return err })()
+	defer mctx.TraceTimed("GetTeamEK", func() error { return err })()
 
-	teamEKBoxStorage := e.G().GetTeamEKBoxStorage()
-	teamEK, err = teamEKBoxStorage.Get(ctx, teamID, generation, contentCtime)
+	teamEKBoxStorage := mctx.G().GetTeamEKBoxStorage()
+	teamEK, err = teamEKBoxStorage.Get(mctx, teamID, generation, contentCtime)
 	if err != nil {
 		switch err.(type) {
 		case EphemeralKeyError:
-			e.G().Log.Debug(err.Error())
+			mctx.Debug(err.Error())
 			// If we are unable to get the current max generation, try to kick
 			// off creation of a new key.
-			bgctx := libkb.CopyTagsToBackground(ctx)
-			go func(ctx context.Context) {
-				maxGeneration, err := teamEKBoxStorage.MaxGeneration(ctx, teamID, true)
+			go func(mctx libkb.MetaContext) {
+				maxGeneration, err := teamEKBoxStorage.MaxGeneration(mctx, teamID, true)
 				if err != nil {
-					e.G().Log.CDebugf(ctx, "Unable to get MaxGeneration: %v", err)
+					mctx.Debug("Unable to get MaxGeneration: %v", err)
 					return
 				}
 				if generation == maxGeneration {
-					_, created, cerr := e.GetOrCreateLatestTeamEK(ctx, teamID)
+					_, created, cerr := e.GetOrCreateLatestTeamEK(mctx, teamID)
 					if cerr != nil {
-						e.G().Log.CDebugf(ctx, "Unable to GetOrCreateLatestTeamEK: %v", cerr)
+						mctx.Debug("Unable to GetOrCreateLatestTeamEK: %v", cerr)
 					}
 					if e.backgroundCreationTestCh != nil {
 						e.backgroundCreationTestCh <- created
 					}
 				}
-			}(bgctx)
+			}(libkb.NewMetaContextBackground(mctx.G()))
 		}
 	}
 	return teamEK, err
@@ -581,10 +576,11 @@ func (e *EKLib) DeriveDeviceDHKey(seed keybase1.Bytes32) *libkb.NaclDHKeyPair {
 	return deviceEKSeed.DeriveDHKey()
 }
 
-func (e *EKLib) SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey libkb.GenericKey) (statement keybase1.DeviceEkStatement, signedStatement string, err error) {
-	defer e.G().CTraceTimed(ctx, "SignedDeviceEKStatementFromSeed", func() error { return err })()
+func (e *EKLib) SignedDeviceEKStatementFromSeed(mctx libkb.MetaContext, generation keybase1.EkGeneration,
+	seed keybase1.Bytes32, signingKey libkb.GenericKey) (statement keybase1.DeviceEkStatement, signedStatement string, err error) {
+	defer mctx.TraceTimed("SignedDeviceEKStatementFromSeed", func() error { return err })()
 
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
 		return statement, signedStatement, err
 	}
@@ -593,24 +589,25 @@ func (e *EKLib) SignedDeviceEKStatementFromSeed(ctx context.Context, generation 
 }
 
 // For device provisioning
-func (e *EKLib) BoxLatestUserEK(ctx context.Context, receiverKey libkb.NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (userEKBox *keybase1.UserEkBoxed, err error) {
-	defer e.G().CTraceTimed(ctx, "BoxLatestUserEK", func() error { return err })()
+func (e *EKLib) BoxLatestUserEK(mctx libkb.MetaContext, receiverKey libkb.NaclDHKeyPair,
+	deviceEKGeneration keybase1.EkGeneration) (userEKBox *keybase1.UserEkBoxed, err error) {
+	defer mctx.TraceTimed("BoxLatestUserEK", func() error { return err })()
 
 	// Let's make sure we are up to date with keys first and we have the latest userEK cached.
-	if err = e.KeygenIfNeeded(ctx); err != nil {
+	if err = e.KeygenIfNeeded(mctx); err != nil {
 		return nil, err
 	}
 
-	userEKBoxStorage := e.G().GetUserEKBoxStorage()
-	maxGeneration, err := userEKBoxStorage.MaxGeneration(ctx, false)
+	userEKBoxStorage := mctx.G().GetUserEKBoxStorage()
+	maxGeneration, err := userEKBoxStorage.MaxGeneration(mctx, false)
 	if err != nil {
 		return nil, err
 	}
 	if maxGeneration < 0 {
-		e.G().Log.CDebugf(ctx, "No userEK found")
+		mctx.Debug("No userEK found")
 		return nil, nil
 	}
-	userEK, err := userEKBoxStorage.Get(ctx, maxGeneration, nil)
+	userEK, err := userEKBoxStorage.Get(mctx, maxGeneration, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -625,109 +622,112 @@ func (e *EKLib) BoxLatestUserEK(ctx context.Context, receiverKey libkb.NaclDHKey
 	}, nil
 }
 
-func (e *EKLib) PrepareNewUserEK(ctx context.Context, merkleRoot libkb.MerkleRoot, pukSeed libkb.PerUserKeySeed) (sig string, boxes []keybase1.UserEkBoxMetadata, newMetadata keybase1.UserEkMetadata, myBox *keybase1.UserEkBoxed, err error) {
+func (e *EKLib) PrepareNewUserEK(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot,
+	pukSeed libkb.PerUserKeySeed) (sig string, boxes []keybase1.UserEkBoxMetadata,
+	newMetadata keybase1.UserEkMetadata, myBox *keybase1.UserEkBoxed, err error) {
 	signingKey, err := pukSeed.DeriveSigningKey()
 	if err != nil {
 		return "", nil, newMetadata, nil, err
 	}
-	return prepareNewUserEK(ctx, e.G(), merkleRoot, signingKey)
+	return prepareNewUserEK(mctx, merkleRoot, signingKey)
 }
 
-func (e *EKLib) BoxLatestTeamEK(ctx context.Context, teamID keybase1.TeamID, recipients []keybase1.UID) (teamEKBoxes *[]keybase1.TeamEkBoxMetadata, err error) {
-	defer e.G().CTraceTimed(ctx, "BoxLatestTeamEK", func() error { return err })()
+func (e *EKLib) BoxLatestTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, recipients []keybase1.UID) (teamEKBoxes *[]keybase1.TeamEkBoxMetadata, err error) {
+	defer mctx.TraceTimed("BoxLatestTeamEK", func() error { return err })()
 
 	// If we need a new teamEK let's just create it when needed, the new
 	// members will be part of the team and will have access to it via the
 	// normal mechanisms.
-	if teamEKNeeded, err := e.NewTeamEKNeeded(ctx, teamID); err != nil {
+	if teamEKNeeded, err := e.NewTeamEKNeeded(mctx, teamID); err != nil {
 		return nil, err
 	} else if teamEKNeeded {
 		return nil, nil
 	}
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
 		return nil, err
 	}
-	statementMap, err := fetchUserEKStatements(ctx, e.G(), recipients)
+	statementMap, err := fetchUserEKStatements(mctx, recipients)
 	if err != nil {
 		return nil, err
 	}
-	usersMetadata, err := activeUserEKMetadata(ctx, e.G(), statementMap, *merkleRootPtr)
+	usersMetadata, err := activeUserEKMetadata(mctx, statementMap, *merkleRootPtr)
 	if err != nil {
 		return nil, err
 	}
 
-	teamEKBoxStorage := e.G().GetTeamEKBoxStorage()
-	maxGeneration, err := teamEKBoxStorage.MaxGeneration(ctx, teamID, false)
+	teamEKBoxStorage := mctx.G().GetTeamEKBoxStorage()
+	maxGeneration, err := teamEKBoxStorage.MaxGeneration(mctx, teamID, false)
 	if err != nil {
 		return nil, err
 	}
-	teamEK, err := teamEKBoxStorage.Get(ctx, teamID, maxGeneration, nil)
+	teamEK, err := teamEKBoxStorage.Get(mctx, teamID, maxGeneration, nil)
 	if err != nil {
 		return nil, err
 	}
-	boxes, _, err := boxTeamEKForUsers(ctx, e.G(), usersMetadata, teamEK)
+	boxes, _, err := boxTeamEKForUsers(mctx, usersMetadata, teamEK)
 	return boxes, err
 }
 
-func (e *EKLib) PrepareNewTeamEK(ctx context.Context, teamID keybase1.TeamID, signingKey libkb.NaclSigningKeyPair, recipients []keybase1.UID) (sig string, boxes *[]keybase1.TeamEkBoxMetadata, newMetadata keybase1.TeamEkMetadata, myBox *keybase1.TeamEkBoxed, err error) {
+func (e *EKLib) PrepareNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, signingKey libkb.NaclSigningKeyPair, recipients []keybase1.UID) (sig string, boxes *[]keybase1.TeamEkBoxMetadata, newMetadata keybase1.TeamEkMetadata, myBox *keybase1.TeamEkBoxed, err error) {
 
 	// If we need a new teamEK let's just create it when needed, the new
 	// members will be part of the team and will have access to it via the
 	// normal mechanisms.
-	if teamEKNeeded, err := e.NewTeamEKNeeded(ctx, teamID); err != nil {
+	if teamEKNeeded, err := e.NewTeamEKNeeded(mctx, teamID); err != nil {
 		return "", nil, newMetadata, nil, err
 	} else if teamEKNeeded {
 		return "", nil, newMetadata, nil, nil
 	}
 
-	merkleRootPtr, err := e.G().GetMerkleClient().FetchRootFromServer(e.MetaContext(ctx), libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	if err != nil {
 		return "", nil, newMetadata, nil, err
 	}
 	merkleRoot := *merkleRootPtr
 
-	statementMap, err := fetchUserEKStatements(ctx, e.G(), recipients)
+	statementMap, err := fetchUserEKStatements(mctx, recipients)
 	if err != nil {
 		return "", nil, newMetadata, nil, err
 	}
-	usersMetadata, err := activeUserEKMetadata(ctx, e.G(), statementMap, merkleRoot)
+	usersMetadata, err := activeUserEKMetadata(mctx, statementMap, merkleRoot)
 	if err != nil {
 		return "", nil, newMetadata, nil, err
 	}
-	return prepareNewTeamEK(ctx, e.G(), teamID, signingKey, usersMetadata, merkleRoot)
+	return prepareNewTeamEK(mctx, teamID, signingKey, usersMetadata, merkleRoot)
 }
 
-func (e *EKLib) OnLogin() error {
-	if err := e.KeygenIfNeeded(context.Background()); err != nil {
-		e.G().Log.CDebugf(context.Background(), "OnLogin error: %v", err)
+func (e *EKLib) OnLogin(mctx libkb.MetaContext) error {
+	// META??
+	if err := e.KeygenIfNeeded(mctx); err != nil {
+		mctx.Debug("OnLogin error: %v", err)
 	}
-	if deviceEKStorage := e.G().GetDeviceEKStorage(); deviceEKStorage != nil {
-		deviceEKStorage.SetLogPrefix()
+	if deviceEKStorage := mctx.G().GetDeviceEKStorage(); deviceEKStorage != nil {
+		deviceEKStorage.SetLogPrefix(mctx)
 	}
 	return nil
 }
 
-func (e *EKLib) ClearCaches() {
+func (e *EKLib) ClearCaches(mctx libkb.MetaContext) {
 	e.Lock()
 	defer e.Unlock()
 
 	e.teamEKGenCache.Purge()
-	if deviceEKStorage := e.G().GetDeviceEKStorage(); deviceEKStorage != nil {
+	if deviceEKStorage := mctx.G().GetDeviceEKStorage(); deviceEKStorage != nil {
 		deviceEKStorage.ClearCache()
 	}
-	if userEKBoxStorage := e.G().GetUserEKBoxStorage(); userEKBoxStorage != nil {
+	if userEKBoxStorage := mctx.G().GetUserEKBoxStorage(); userEKBoxStorage != nil {
 		userEKBoxStorage.ClearCache()
 	}
-	if teamEKBoxStorage := e.G().GetTeamEKBoxStorage(); teamEKBoxStorage != nil {
+	if teamEKBoxStorage := mctx.G().GetTeamEKBoxStorage(); teamEKBoxStorage != nil {
 		teamEKBoxStorage.ClearCache()
 	}
 }
 
 func (e *EKLib) OnLogout(mctx libkb.MetaContext) error {
-	e.ClearCaches()
-	if deviceEKStorage := e.G().GetDeviceEKStorage(); deviceEKStorage != nil {
-		deviceEKStorage.SetLogPrefix()
+	e.ClearCaches(mctx)
+	if deviceEKStorage := mctx.G().GetDeviceEKStorage(); deviceEKStorage != nil {
+		deviceEKStorage.SetLogPrefix(mctx)
 	}
 	return nil
 }

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -24,51 +24,51 @@ func getNoiseFilePath(tc libkb.TestContext, key string) string {
 }
 
 func TestKeygenIfNeeded(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	ekLib := NewEKLib(tc.G)
+	ekLib := NewEKLib(mctx)
 	defer ekLib.Shutdown()
 	deviceEKStorage := tc.G.GetDeviceEKStorage()
 	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
 
-	expectedDeviceEKGen, err := deviceEKStorage.MaxGeneration(context.Background(), false)
+	expectedDeviceEKGen, err := deviceEKStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	if expectedDeviceEKGen < 0 {
 		expectedDeviceEKGen = 1
-		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(context.Background())
+		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(mctx)
 		require.NoError(t, err)
 		require.True(t, deviceEKNeeded)
 	}
 
-	expectedUserEKGen, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
+	expectedUserEKGen, err := userEKBoxStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	if expectedUserEKGen < 0 {
 		expectedUserEKGen = 1
-		userEKNeeded, err := ekLib.NewUserEKNeeded(context.Background())
+		userEKNeeded, err := ekLib.NewUserEKNeeded(mctx)
 		require.NoError(t, err)
 		require.True(t, userEKNeeded)
 	}
 
 	keygen := func(expectedDeviceEKGen, expectedUserEKGen keybase1.EkGeneration) {
-		err := ekLib.KeygenIfNeeded(context.Background())
+		err := ekLib.KeygenIfNeeded(mctx)
 		require.NoError(t, err)
 
 		// verify deviceEK
-		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(context.Background())
+		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(mctx)
 		require.NoError(t, err)
 		require.False(t, deviceEKNeeded)
 
-		deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(context.Background(), false)
+		deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(mctx, false)
 		require.NoError(t, err)
 		require.Equal(t, expectedDeviceEKGen, deviceEKMaxGen)
 
 		// verify userEK
-		userEKNeeded, err := ekLib.NewUserEKNeeded(context.Background())
+		userEKNeeded, err := ekLib.NewUserEKNeeded(mctx)
 		require.NoError(t, err)
 		require.False(t, userEKNeeded)
 
-		userEKMaxGen, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
+		userEKMaxGen, err := userEKBoxStorage.MaxGeneration(mctx, false)
 		require.NoError(t, err)
 		require.Equal(t, expectedUserEKGen, userEKMaxGen)
 	}
@@ -79,19 +79,19 @@ func TestKeygenIfNeeded(t *testing.T) {
 	t.Logf("Keygen again does not create new keys")
 	keygen(expectedDeviceEKGen, expectedUserEKGen)
 
-	rawDeviceEKStorage := NewDeviceEKStorage(tc.G)
-	rawUserEKBoxStorage := NewUserEKBoxStorage(tc.G)
+	rawDeviceEKStorage := NewDeviceEKStorage(mctx)
+	rawUserEKBoxStorage := NewUserEKBoxStorage()
 
 	// Let's purge our local userEK store and make sure we don't regenerate
 	// (respecting the server max)
-	err = rawUserEKBoxStorage.Delete(context.Background(), expectedUserEKGen)
+	err = rawUserEKBoxStorage.Delete(mctx, expectedUserEKGen)
 	require.NoError(t, err)
 	userEKBoxStorage.ClearCache()
 	keygen(expectedDeviceEKGen, expectedUserEKGen)
 
 	// Now let's kill our deviceEK as well by deleting the noise file, we
 	// should regenerate a new userEK since we can't access the old one
-	key, err := rawDeviceEKStorage.key(context.Background(), expectedDeviceEKGen)
+	key, err := rawDeviceEKStorage.key(mctx, expectedDeviceEKGen)
 	require.NoError(t, err)
 	noiseFilePath := getNoiseFilePath(tc, key)
 	err = os.Remove(noiseFilePath)
@@ -104,19 +104,19 @@ func TestKeygenIfNeeded(t *testing.T) {
 	keygen(expectedDeviceEKGen, expectedUserEKGen)
 
 	// Test ForceDeleteAll
-	err = deviceEKStorage.ForceDeleteAll(context.Background(), tc.G.Env.GetUsername())
+	err = deviceEKStorage.ForceDeleteAll(mctx, tc.G.Env.GetUsername())
 	require.NoError(t, err)
-	deviceEKs, err := rawDeviceEKStorage.GetAll(context.Background())
+	deviceEKs, err := rawDeviceEKStorage.GetAll(mctx)
 	require.NoError(t, err)
 	require.Len(t, deviceEKs, 0)
 }
 
 func TestNewTeamEKNeeded(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	teamID := createTeam(tc)
-	ekLib := NewEKLib(tc.G)
+	ekLib := NewEKLib(mctx)
 	defer ekLib.Shutdown()
 	fc := clockwork.NewFakeClockAt(time.Now())
 	ekLib.setClock(fc)
@@ -125,30 +125,30 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	teamEKBoxStorage := tc.G.GetTeamEKBoxStorage()
 
 	// We don't have any keys, so we should need a new teamEK
-	needed, err := ekLib.NewTeamEKNeeded(context.Background(), teamID)
+	needed, err := ekLib.NewTeamEKNeeded(mctx, teamID)
 	require.NoError(t, err)
 	require.True(t, needed)
 
-	expectedTeamEKGen, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID, false)
+	expectedTeamEKGen, err := teamEKBoxStorage.MaxGeneration(mctx, teamID, false)
 	require.NoError(t, err)
 	if expectedTeamEKGen < 0 {
 		expectedTeamEKGen = 1
 	}
 
-	expectedDeviceEKGen, err := deviceEKStorage.MaxGeneration(context.Background(), false)
+	expectedDeviceEKGen, err := deviceEKStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	if expectedDeviceEKGen < 0 {
 		expectedDeviceEKGen = 1
 	}
 
-	expectedUserEKGen, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
+	expectedUserEKGen, err := userEKBoxStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	if expectedUserEKGen < 0 {
 		expectedUserEKGen = 1
 	}
 
 	assertKeyGenerations := func(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen keybase1.EkGeneration, shouldCreate, teamEKCreationInProgress bool) {
-		teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+		teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(mctx, teamID)
 		require.NoError(t, err)
 		require.Equal(t, shouldCreate, created)
 
@@ -163,30 +163,30 @@ func TestNewTeamEKNeeded(t *testing.T) {
 		require.Equal(t, teamEK.Metadata.Generation, cacheEntry.Generation)
 
 		// verify deviceEK
-		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(context.Background())
+		deviceEKNeeded, err := ekLib.NewDeviceEKNeeded(mctx)
 		require.NoError(t, err)
 		require.False(t, deviceEKNeeded)
 
-		deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(context.Background(), false)
+		deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(mctx, false)
 		require.NoError(t, err)
 		require.Equal(t, expectedDeviceEKGen, deviceEKMaxGen)
 
 		// verify userEK
-		userEKNeeded, err := ekLib.NewUserEKNeeded(context.Background())
+		userEKNeeded, err := ekLib.NewUserEKNeeded(mctx)
 		require.NoError(t, err)
 		require.False(t, userEKNeeded)
 
-		userEKMaxGen, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
+		userEKMaxGen, err := userEKBoxStorage.MaxGeneration(mctx, false)
 		require.NoError(t, err)
 		require.Equal(t, expectedUserEKGen, userEKMaxGen)
 
 		// verify teamEK
-		teamEKGen, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID, false)
+		teamEKGen, err := teamEKBoxStorage.MaxGeneration(mctx, teamID, false)
 		require.NoError(t, err)
 		require.Equal(t, expectedTeamEKGen, teamEKGen)
 		require.Equal(t, expectedTeamEKGen, teamEK.Metadata.Generation)
 
-		teamEKNeeded, err := ekLib.NewTeamEKNeeded(context.Background(), teamID)
+		teamEKNeeded, err := ekLib.NewTeamEKNeeded(mctx, teamID)
 		require.NoError(t, err)
 		require.False(t, teamEKNeeded)
 	}
@@ -195,26 +195,26 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	// If we retry keygen, we don't regenerate keys
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /*created*/, false /* teamEKCreationInProgress */)
 
-	rawDeviceEKStorage := NewDeviceEKStorage(tc.G)
-	rawUserEKBoxStorage := NewUserEKBoxStorage(tc.G)
-	rawTeamEKBoxStorage := NewTeamEKBoxStorage(tc.G)
+	rawDeviceEKStorage := NewDeviceEKStorage(mctx)
+	rawUserEKBoxStorage := NewUserEKBoxStorage()
+	rawTeamEKBoxStorage := NewTeamEKBoxStorage()
 
 	// Let's purge our local teamEK store and make sure we don't regenerate
 	// (respecting the server max)
-	err = rawTeamEKBoxStorage.Delete(context.Background(), teamID, expectedTeamEKGen)
+	err = rawTeamEKBoxStorage.Delete(mctx, teamID, expectedTeamEKGen)
 	require.NoError(t, err)
 	teamEKBoxStorage.ClearCache()
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /*created */, false /* teamEKCreationInProgress */)
 
 	// Now let's kill our userEK, we should gracefully not regenerate
 	// since we can still fetch the userEK from the server.
-	err = rawUserEKBoxStorage.Delete(context.Background(), expectedUserEKGen)
+	err = rawUserEKBoxStorage.Delete(mctx, expectedUserEKGen)
 	require.NoError(t, err)
 	tc.G.GetDeviceEKStorage().ClearCache()
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /*created*/, false /* teamEKCreationInProgress */)
 
 	// Now let's kill our deviceEK as well, and we should generate all new keys
-	err = rawDeviceEKStorage.Delete(context.Background(), expectedDeviceEKGen)
+	err = rawDeviceEKStorage.Delete(mctx, expectedDeviceEKGen)
 	require.NoError(t, err)
 	tc.G.GetDeviceEKStorage().ClearCache()
 	expectedDeviceEKGen++
@@ -224,7 +224,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	// If we try to access an older teamEK that we cannot access, we don't
 	// create a new teamEK
-	teamEK, err := ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen-1, nil)
+	teamEK, err := ekLib.GetTeamEK(mctx, teamID, expectedTeamEKGen-1, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr := err.(EphemeralKeyError)
@@ -235,7 +235,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	// Now let's kill our deviceEK by corrupting a single bit in the noiseFile,
 	// so we can no longer access the latest teamEK and will generate a new one
 	// and verify it is the new valid max.
-	key, err := rawDeviceEKStorage.key(context.Background(), expectedDeviceEKGen)
+	key, err := rawDeviceEKStorage.key(mctx, expectedDeviceEKGen)
 	require.NoError(t, err)
 	noiseFilePath := getNoiseFilePath(tc, key)
 	noise, err := ioutil.ReadFile(noiseFilePath)
@@ -252,7 +252,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	ch := make(chan bool, 1)
 	ekLib.setBackgroundCreationTestCh(ch)
-	teamEK, err = ekLib.GetTeamEK(context.Background(), teamID, expectedTeamEKGen, nil)
+	teamEK, err = ekLib.GetTeamEK(mctx, teamID, expectedTeamEKGen, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr = err.(EphemeralKeyError)
@@ -274,8 +274,8 @@ func TestNewTeamEKNeeded(t *testing.T) {
 
 	// Fake the teamEK creation time so we are forced to generate a new one.
 	forceEKCtime := func(generation keybase1.EkGeneration, d time.Duration) {
-		rawTeamEKBoxStorage.Get(context.Background(), teamID, generation, nil)
-		cache, found, err := rawTeamEKBoxStorage.getCacheForTeamID(context.Background(), teamID)
+		rawTeamEKBoxStorage.Get(mctx, teamID, generation, nil)
+		cache, found, err := rawTeamEKBoxStorage.getCacheForTeamID(mctx, teamID)
 		require.NoError(t, err)
 		require.True(t, found)
 		cacheItem, ok := cache[generation]
@@ -283,7 +283,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 		require.False(t, cacheItem.HasError())
 		teamEKBoxed := cacheItem.TeamEKBoxed
 		teamEKBoxed.Metadata.Ctime = keybase1.ToTime(teamEKBoxed.Metadata.Ctime.Time().Add(d))
-		err = teamEKBoxStorage.Put(context.Background(), teamID, generation, teamEKBoxed)
+		err = teamEKBoxStorage.Put(mctx, teamID, generation, teamEKBoxed)
 		require.NoError(t, err)
 	}
 
@@ -314,14 +314,14 @@ func TestNewTeamEKNeeded(t *testing.T) {
 }
 
 func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	seed, err := newDeviceEphemeralSeed()
 	require.NoError(t, err)
 	s := tc.G.GetDeviceEKStorage()
 	ctimeExpired := time.Now().Add(-libkb.MaxEphemeralKeyStaleness * 3)
-	err = s.Put(context.Background(), 0, keybase1.DeviceEk{
+	err = s.Put(mctx, 0, keybase1.DeviceEk{
 		Seed: keybase1.Bytes32(seed),
 		Metadata: keybase1.DeviceEkMetadata{
 			Ctime: keybase1.ToTime(ctimeExpired),
@@ -329,30 +329,30 @@ func TestCleanupStaleUserAndDeviceEKs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ekLib := NewEKLib(tc.G)
+	ekLib := NewEKLib(mctx)
 	defer ekLib.Shutdown()
-	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background())
+	err = ekLib.CleanupStaleUserAndDeviceEKs(mctx)
 	require.NoError(t, err)
 
-	deviceEK, err := s.Get(context.Background(), 0)
+	deviceEK, err := s.Get(mctx, 0)
 	require.Error(t, err)
 	_, ok := err.(erasablekv.UnboxError)
 	require.True(t, ok)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
-	err = ekLib.CleanupStaleUserAndDeviceEKs(context.Background())
+	err = ekLib.CleanupStaleUserAndDeviceEKs(mctx)
 	require.NoError(t, err)
 }
 
 func TestCleanupStaleUserAndDeviceEKsOffline(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	seed, err := newDeviceEphemeralSeed()
 	require.NoError(t, err)
 	s := tc.G.GetDeviceEKStorage()
 	ctimeExpired := time.Now().Add(-libkb.MaxEphemeralKeyStaleness * 3)
-	err = s.Put(context.Background(), 0, keybase1.DeviceEk{
+	err = s.Put(mctx, 0, keybase1.DeviceEk{
 		Seed: keybase1.Bytes32(seed),
 		Metadata: keybase1.DeviceEkMetadata{
 			Ctime:       keybase1.ToTime(ctimeExpired),
@@ -361,11 +361,11 @@ func TestCleanupStaleUserAndDeviceEKsOffline(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ekLib := NewEKLib(tc.G)
+	ekLib := NewEKLib(mctx)
 	defer ekLib.Shutdown()
 	ch := make(chan bool, 1)
 	ekLib.setBackgroundDeleteTestCh(ch)
-	err = ekLib.keygenIfNeeded(context.Background(), libkb.MerkleRoot{}, true /* shouldCleanup */)
+	err = ekLib.keygenIfNeeded(mctx, libkb.MerkleRoot{}, true /* shouldCleanup */)
 	require.Error(t, err)
 	_, ok := err.(EphemeralKeyError)
 	require.False(t, ok)
@@ -375,13 +375,13 @@ func TestCleanupStaleUserAndDeviceEKsOffline(t *testing.T) {
 	// successfully.
 	select {
 	case <-ch:
-		deviceEK, err := s.Get(context.Background(), 0)
+		deviceEK, err := s.Get(mctx, 0)
 		require.Error(t, err)
 		_, ok = err.(erasablekv.UnboxError)
 		require.True(t, ok)
 		require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 	}
-	err = ekLib.keygenIfNeeded(context.Background(), libkb.MerkleRoot{}, true /* shouldCleanup */)
+	err = ekLib.keygenIfNeeded(mctx, libkb.MerkleRoot{}, true /* shouldCleanup */)
 	require.Error(t, err)
 	_, ok = err.(erasablekv.UnboxError)
 	require.False(t, ok)
@@ -389,45 +389,45 @@ func TestCleanupStaleUserAndDeviceEKsOffline(t *testing.T) {
 }
 
 func TestLoginOneshotNoEphemeral(t *testing.T) {
-	tc, user := ephemeralKeyTestSetup(t)
+	tc, mctx, user := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 	uis := libkb.UIs{
 		LogUI:    tc.G.UI.GetLogUI(),
 		LoginUI:  &libkb.TestLoginUI{RevokeBackup: false},
 		SecretUI: &libkb.TestSecretUI{},
 	}
-	m := libkb.NewMetaContextForTest(tc).WithUIs(uis)
+	mctx = mctx.WithUIs(uis)
 	teamID := createTeam(tc)
 
-	ekLib := NewEKLib(tc.G)
+	ekLib := NewEKLib(mctx)
 	defer ekLib.Shutdown()
-	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(mctx, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
 
 	eng := engine.NewPaperKey(tc.G)
-	err = engine.RunEngine2(m, eng)
+	err = engine.RunEngine2(mctx, eng)
 	require.NoError(t, err)
 	require.NotZero(t, len(eng.Passphrase()))
 	require.NoError(t, tc.G.Logout(context.TODO()))
 
 	tc2 := libkb.SetupTest(t, "ephemeral", 2)
 	defer tc2.Cleanup()
-	m2 := libkb.NewMetaContextForTest(tc2)
-	NewEphemeralStorageAndInstall(tc2.G)
+	mctx2 := libkb.NewMetaContextForTest(tc2)
+	NewEphemeralStorageAndInstall(mctx2)
 
 	eng2 := engine.NewLoginOneshot(tc2.G, keybase1.LoginOneshotArg{
 		Username: user.NormalizedUsername().String(),
 		PaperKey: eng.Passphrase(),
 	})
-	err = engine.RunEngine2(m2, eng2)
+	err = engine.RunEngine2(mctx2, eng2)
 	require.NoError(t, err)
 
-	ekLib2 := NewEKLib(tc2.G)
+	ekLib2 := NewEKLib(mctx2)
 	defer ekLib2.Shutdown()
 
 	// Make sure we can't access or create any ephemeral keys
-	teamEK, created, err = ekLib2.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	teamEK, created, err = ekLib2.GetOrCreateLatestTeamEK(mctx2, teamID)
 	require.Error(t, err)
 	require.False(t, created)
 	_, ok := err.(EphemeralKeyError)
@@ -435,17 +435,17 @@ func TestLoginOneshotNoEphemeral(t *testing.T) {
 	require.Equal(t, keybase1.TeamEk{}, teamEK)
 
 	deks := tc2.G.GetDeviceEKStorage()
-	gen, err := deks.MaxGeneration(context.Background(), false)
+	gen, err := deks.MaxGeneration(mctx2, false)
 	require.NoError(t, err)
 	require.EqualValues(t, -1, gen)
 
 	ueks := tc2.G.GetUserEKBoxStorage()
-	gen, err = ueks.MaxGeneration(context.Background(), false)
+	gen, err = ueks.MaxGeneration(mctx2, false)
 	require.NoError(t, err)
 	require.EqualValues(t, -1, gen)
 
 	teks := tc2.G.GetUserEKBoxStorage()
-	gen, err = teks.MaxGeneration(context.Background(), false)
+	gen, err = teks.MaxGeneration(mctx2, false)
 	require.NoError(t, err)
 	require.EqualValues(t, -1, gen)
 }

--- a/go/ephemeral/selfprovision_test.go
+++ b/go/ephemeral/selfprovision_test.go
@@ -10,31 +10,29 @@ import (
 )
 
 func TestEphemeralSelfProvision(t *testing.T) {
-	tc, user := ephemeralKeyTestSetup(t)
+	tc, mctx, user := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	g := tc.G
-	m := libkb.NewMetaContextForTest(tc)
-	ctx := m.Ctx()
 	teamID := createTeam(tc)
 
 	ekLib := g.GetEKLib()
-	teamEK1, created, err := ekLib.GetOrCreateLatestTeamEK(ctx, teamID)
+	teamEK1, created, err := ekLib.GetOrCreateLatestTeamEK(mctx, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
 
 	// Publish a few deviceEKs on the cloned account and make sure the self
 	// provision goes through successfully and we can continue to generate
 	// deviceEKs after.
-	merkleRootPtr, err := g.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := g.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
-	_, err = publishNewDeviceEK(ctx, g, merkleRoot)
+	_, err = publishNewDeviceEK(mctx, merkleRoot)
 	require.NoError(t, err)
-	_, err = publishNewDeviceEK(ctx, g, merkleRoot)
+	_, err = publishNewDeviceEK(mctx, merkleRoot)
 	require.NoError(t, err)
 	deviceEKStorage := g.GetDeviceEKStorage()
-	maxGen, err := deviceEKStorage.MaxGeneration(ctx, false)
+	maxGen, err := deviceEKStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 3, maxGen)
 
@@ -48,27 +46,27 @@ func TestEphemeralSelfProvision(t *testing.T) {
 		LoginUI:     provLoginUI,
 	}
 
-	m = m.WithUIs(uis)
-	libkb.CreateClonedDevice(tc, m)
+	mctx = mctx.WithUIs(uis)
+	libkb.CreateClonedDevice(tc, mctx)
 	newName := "uncloneme"
 	eng := engine.NewSelfProvisionEngine(g, newName)
-	err = engine.RunEngine2(m, eng)
+	err = engine.RunEngine2(mctx, eng)
 	require.NoError(t, err)
-	require.Equal(t, m.ActiveDevice().Name(), newName)
+	require.Equal(t, mctx.ActiveDevice().Name(), newName)
 
-	teamEK2, err := g.GetTeamEKBoxStorage().Get(ctx, teamID, teamEK1.Metadata.Generation, nil)
+	teamEK2, err := g.GetTeamEKBoxStorage().Get(mctx, teamID, teamEK1.Metadata.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, teamEK1, teamEK2)
 
 	// After self provisioning we should only have a single deviceEK, and have
 	// no issues producing new ones.
-	maxGen, err = deviceEKStorage.MaxGeneration(ctx, false)
+	maxGen, err = deviceEKStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, maxGen)
 
-	_, err = publishNewDeviceEK(ctx, g, merkleRoot)
+	_, err = publishNewDeviceEK(mctx, merkleRoot)
 	require.NoError(t, err)
-	maxGen, err = deviceEKStorage.MaxGeneration(ctx, false)
+	maxGen, err = deviceEKStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, maxGen)
 }

--- a/go/ephemeral/team_ek_box_storage.go
+++ b/go/ephemeral/team_ek_box_storage.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -51,56 +50,54 @@ type teamEKBoxCache map[keybase1.EkGeneration]teamEKBoxCacheItem
 type TeamEKBoxMap map[keybase1.EkGeneration]keybase1.TeamEkBoxed
 type TeamEKMap map[keybase1.EkGeneration]keybase1.TeamEk
 
-func teamKey(teamID keybase1.TeamID, g *libkb.GlobalContext) string {
-	return fmt.Sprintf("teamEphemeralKeyBox-%s-%s", teamID, g.Env.GetUsername())
+func teamKey(teamID keybase1.TeamID, mctx libkb.MetaContext) string {
+	return fmt.Sprintf("teamEphemeralKeyBox-%s-%s", teamID, mctx.G().Env.GetUsername())
 }
 
 // We cache TeamEKBoxes from the server in a LRU and a persist to a local
 // KVStore.
 type TeamEKBoxStorage struct {
-	libkb.Contextified
 	sync.Mutex
 	cache *teamEKCache
 }
 
-func NewTeamEKBoxStorage(g *libkb.GlobalContext) *TeamEKBoxStorage {
+func NewTeamEKBoxStorage() *TeamEKBoxStorage {
 	return &TeamEKBoxStorage{
-		Contextified: libkb.NewContextified(g),
-		cache:        newTeamEKCache(g),
+		cache: newTeamEKCache(),
 	}
 }
 
-func (s *TeamEKBoxStorage) dbKey(ctx context.Context, teamID keybase1.TeamID) (dbKey libkb.DbKey, err error) {
-	uv, err := s.G().GetMeUV(ctx)
+func (s *TeamEKBoxStorage) dbKey(mctx libkb.MetaContext, teamID keybase1.TeamID) (dbKey libkb.DbKey, err error) {
+	uv, err := mctx.G().GetMeUV(mctx.Ctx())
 	if err != nil {
 		return dbKey, err
 	}
-	key := fmt.Sprintf("%s-%s-%d", teamKey(teamID, s.G()), uv.EldestSeqno, teamEKBoxStorageDBVersion)
+	key := fmt.Sprintf("%s-%s-%d", teamKey(teamID, mctx), uv.EldestSeqno, teamEKBoxStorageDBVersion)
 	return libkb.DbKey{
 		Typ: libkb.DBTeamEKBox,
 		Key: key,
 	}, nil
 }
 
-func (s *TeamEKBoxStorage) Get(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration,
+func (s *TeamEKBoxStorage) Get(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration,
 	contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#Get: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#Get: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	s.Lock()
 
-	cache, found, err := s.getCacheForTeamID(ctx, teamID)
+	cache, found, err := s.getCacheForTeamID(mctx, teamID)
 	if err != nil {
 		s.Unlock()
 		return teamEK, err
 	} else if !found {
 		s.Unlock() // release the lock while we fetch
-		return s.fetchAndStore(ctx, teamID, generation, contentCtime)
+		return s.fetchAndStore(mctx, teamID, generation, contentCtime)
 	}
 
 	cacheItem, ok := cache[generation]
 	if !ok {
 		s.Unlock() // release the lock while we fetch
-		return s.fetchAndStore(ctx, teamID, generation, contentCtime)
+		return s.fetchAndStore(mctx, teamID, generation, contentCtime)
 	}
 
 	defer s.Unlock() // release the lock after we unbox
@@ -108,31 +105,31 @@ func (s *TeamEKBoxStorage) Get(ctx context.Context, teamID keybase1.TeamID, gene
 		return teamEK, cacheItem.Error()
 	}
 
-	teamEK, err = s.unbox(ctx, generation, cacheItem.TeamEKBoxed, contentCtime)
+	teamEK, err = s.unbox(mctx, generation, cacheItem.TeamEKBoxed, contentCtime)
 	if err != nil { // if we can no longer unbox this, store the error
-		if perr := s.putLocked(ctx, teamID, generation, keybase1.TeamEkBoxed{}, err); perr != nil {
-			s.G().Log.CDebugf(ctx, "unable to store unboxing error %v", perr)
+		if perr := s.putLocked(mctx, teamID, generation, keybase1.TeamEkBoxed{}, err); perr != nil {
+			mctx.Debug("unable to store unboxing error %v", perr)
 		}
 	}
 	return teamEK, err
 }
 
-func (s *TeamEKBoxStorage) getCacheForTeamID(ctx context.Context, teamID keybase1.TeamID) (cache teamEKBoxCache, found bool, err error) {
-	cache, found = s.cache.GetMap(teamID)
+func (s *TeamEKBoxStorage) getCacheForTeamID(mctx libkb.MetaContext, teamID keybase1.TeamID) (cache teamEKBoxCache, found bool, err error) {
+	cache, found = s.cache.GetMap(mctx, teamID)
 	if found {
 		return cache, found, nil
 	}
 
-	key, err := s.dbKey(ctx, teamID)
+	key, err := s.dbKey(mctx, teamID)
 	if err != nil {
 		return nil, false, err
 	}
 	cache = make(teamEKBoxCache)
-	found, err = s.G().GetKVStore().GetInto(&cache, key)
+	found, err = mctx.G().GetKVStore().GetInto(&cache, key)
 	if err != nil {
 		return nil, found, err
 	} else if found {
-		s.cache.PutMap(teamID, cache)
+		s.cache.PutMap(mctx, teamID, cache)
 	}
 	return cache, found, err
 }
@@ -145,9 +142,8 @@ type TeamEKBoxedResponse struct {
 	} `json:"result"`
 }
 
-func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration,
+func (s *TeamEKBoxStorage) fetchAndStore(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration,
 	contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
-	mctx := libkb.NewMetaContext(ctx, s.G())
 	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#fetchAndStore: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	// cache unboxing/missing box errors so we don't continually try to fetch
@@ -157,8 +153,8 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 		case EphemeralKeyError:
 			s.Lock()
 			defer s.Unlock()
-			if perr := s.putLocked(ctx, teamID, generation, keybase1.TeamEkBoxed{}, err); perr != nil {
-				s.G().Log.CDebugf(ctx, "unable to store error %v", perr)
+			if perr := s.putLocked(mctx, teamID, generation, keybase1.TeamEkBoxed{}, err); perr != nil {
+				mctx.Debug("unable to store error %v", perr)
 			}
 		}
 	}()
@@ -185,7 +181,7 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 	}
 
 	if result.Result == nil {
-		err = newEKMissingBoxErr(ctx, s.G(), TeamEKStr, generation)
+		err = newEKMissingBoxErr(mctx, TeamEKStr, generation)
 		return teamEK, err
 	}
 
@@ -205,7 +201,7 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 	teamEKMetadata := teamEKStatement.CurrentTeamEkMetadata
 	if generation != teamEKMetadata.Generation {
 		// sanity check that we go the right generation
-		return teamEK, newEKCorruptedErr(ctx, s.G(), TeamEKStr, generation, teamEKMetadata.Generation)
+		return teamEK, newEKCorruptedErr(mctx, TeamEKStr, generation, teamEKMetadata.Generation)
 	}
 	teamEKBoxed := keybase1.TeamEkBoxed{
 		Box:              result.Result.Box,
@@ -213,7 +209,7 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 		Metadata:         teamEKMetadata,
 	}
 
-	teamEK, err = s.unbox(ctx, generation, teamEKBoxed, contentCtime)
+	teamEK, err = s.unbox(mctx, generation, teamEKBoxed, contentCtime)
 	if err != nil {
 		return teamEK, err
 	}
@@ -226,21 +222,21 @@ func (s *TeamEKBoxStorage) fetchAndStore(ctx context.Context, teamID keybase1.Te
 	}
 
 	// Store the boxed version, return the unboxed
-	err = s.Put(ctx, teamID, generation, teamEKBoxed)
+	err = s.Put(mctx, teamID, generation, teamEKBoxed)
 	return teamEK, err
 }
 
-func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.EkGeneration,
+func (s *TeamEKBoxStorage) unbox(mctx libkb.MetaContext, teamEKGeneration keybase1.EkGeneration,
 	teamEKBoxed keybase1.TeamEkBoxed, contentCtime *gregor1.Time) (teamEK keybase1.TeamEk, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#unbox: teamEKGeneration: %v", teamEKGeneration), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#unbox: teamEKGeneration: %v", teamEKGeneration), func() error { return err })()
 
-	userEKBoxStorage := s.G().GetUserEKBoxStorage()
-	userEK, err := userEKBoxStorage.Get(ctx, teamEKBoxed.UserEkGeneration, contentCtime)
+	userEKBoxStorage := mctx.G().GetUserEKBoxStorage()
+	userEK, err := userEKBoxStorage.Get(mctx, teamEKBoxed.UserEkGeneration, contentCtime)
 	if err != nil {
-		s.G().Log.CDebugf(ctx, "unable to get from userEKStorage %v", err)
+		mctx.Debug("unable to get from userEKStorage %v", err)
 		switch err.(type) {
 		case EphemeralKeyError:
-			return teamEK, newEKUnboxErr(ctx, s.G(), TeamEKStr, teamEKGeneration, UserEKStr,
+			return teamEK, newEKUnboxErr(mctx, TeamEKStr, teamEKGeneration, UserEKStr,
 				teamEKBoxed.UserEkGeneration, contentCtime)
 		}
 		return teamEK, err
@@ -251,8 +247,8 @@ func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.
 
 	msg, _, err := userKeypair.DecryptFromString(teamEKBoxed.Box)
 	if err != nil {
-		s.G().Log.CDebugf(ctx, "unable to decrypt teamEKBoxed %v", err)
-		return teamEK, newEKUnboxErr(ctx, s.G(), TeamEKStr, teamEKGeneration, UserEKStr,
+		mctx.Debug("unable to decrypt teamEKBoxed %v", err)
+		return teamEK, newEKUnboxErr(mctx, TeamEKStr, teamEKGeneration, UserEKStr,
 			teamEKBoxed.UserEkGeneration, contentCtime)
 	}
 
@@ -267,50 +263,50 @@ func (s *TeamEKBoxStorage) unbox(ctx context.Context, teamEKGeneration keybase1.
 	}, nil
 }
 
-func (s *TeamEKBoxStorage) Put(ctx context.Context, teamID keybase1.TeamID,
+func (s *TeamEKBoxStorage) Put(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) (err error) {
 	s.Lock()
 	defer s.Unlock()
-	return s.putLocked(ctx, teamID, generation, teamEKBoxed, nil /* ekErr */)
+	return s.putLocked(mctx, teamID, generation, teamEKBoxed, nil /* ekErr */)
 }
 
-func (s *TeamEKBoxStorage) putLocked(ctx context.Context, teamID keybase1.TeamID,
+func (s *TeamEKBoxStorage) putLocked(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed, ekErr error) (err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#putLocked: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#putLocked: teamID:%v, generation:%v", teamID, generation), func() error { return err })()
 
 	// sanity check that we got the right generation
 	if teamEKBoxed.Metadata.Generation != generation && ekErr == nil {
-		return newEKCorruptedErr(ctx, s.G(), TeamEKStr, generation, teamEKBoxed.Metadata.Generation)
+		return newEKCorruptedErr(mctx, TeamEKStr, generation, teamEKBoxed.Metadata.Generation)
 	}
 
-	key, err := s.dbKey(ctx, teamID)
+	key, err := s.dbKey(mctx, teamID)
 	if err != nil {
 		return err
 	}
-	cache, _, err := s.getCacheForTeamID(ctx, teamID)
+	cache, _, err := s.getCacheForTeamID(mctx, teamID)
 	if err != nil {
 		return err
 	}
 	cache[generation] = newTeamEKBoxCacheItem(teamEKBoxed, ekErr)
-	if err = s.G().GetKVStore().PutObj(key, nil, cache); err != nil {
+	if err = mctx.G().GetKVStore().PutObj(key, nil, cache); err != nil {
 		return err
 	}
-	s.cache.PutMap(teamID, cache)
+	s.cache.PutMap(mctx, teamID, cache)
 	return nil
 }
 
-func (s *TeamEKBoxStorage) Delete(ctx context.Context, teamID keybase1.TeamID,
+func (s *TeamEKBoxStorage) Delete(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	generation keybase1.EkGeneration) (err error) {
 	s.Lock()
 	defer s.Unlock()
-	return s.deleteMany(ctx, teamID, []keybase1.EkGeneration{generation})
+	return s.deleteMany(mctx, teamID, []keybase1.EkGeneration{generation})
 }
 
-func (s *TeamEKBoxStorage) deleteMany(ctx context.Context, teamID keybase1.TeamID,
+func (s *TeamEKBoxStorage) deleteMany(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	generations []keybase1.EkGeneration) (err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#delete: teamID:%v, generations:%v", teamID, generations), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#delete: teamID:%v, generations:%v", teamID, generations), func() error { return err })()
 
-	cache, found, err := s.getCacheForTeamID(ctx, teamID)
+	cache, found, err := s.getCacheForTeamID(mctx, teamID)
 	if err != nil {
 		return err
 	} else if !found {
@@ -321,42 +317,42 @@ func (s *TeamEKBoxStorage) deleteMany(ctx context.Context, teamID keybase1.TeamI
 		delete(cache, generation)
 	}
 
-	key, err := s.dbKey(ctx, teamID)
+	key, err := s.dbKey(mctx, teamID)
 	if err != nil {
 		return err
 	}
-	if err = s.G().GetKVStore().PutObj(key, nil, cache); err != nil {
+	if err = mctx.G().GetKVStore().PutObj(key, nil, cache); err != nil {
 		return err
 	}
-	s.cache.PutMap(teamID, cache)
+	s.cache.PutMap(mctx, teamID, cache)
 	return nil
 }
 
-func (s *TeamEKBoxStorage) PurgeCacheForTeamID(ctx context.Context, teamID keybase1.TeamID) (err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#PurgeCacheForTeamID: teamID:%v", teamID), func() error { return err })()
+func (s *TeamEKBoxStorage) PurgeCacheForTeamID(mctx libkb.MetaContext, teamID keybase1.TeamID) (err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#PurgeCacheForTeamID: teamID:%v", teamID), func() error { return err })()
 	s.Lock()
 	defer s.Unlock()
 
-	key, err := s.dbKey(ctx, teamID)
+	key, err := s.dbKey(mctx, teamID)
 	if err != nil {
 		return err
 	}
 	cache := make(teamEKBoxCache)
-	if err = s.G().GetKVStore().PutObj(key, nil, cache); err != nil {
+	if err = mctx.G().GetKVStore().PutObj(key, nil, cache); err != nil {
 		return err
 	}
-	s.cache.PutMap(teamID, cache)
+	s.cache.PutMap(mctx, teamID, cache)
 	return nil
 }
 
-func (s *TeamEKBoxStorage) DeleteExpired(ctx context.Context, teamID keybase1.TeamID,
+func (s *TeamEKBoxStorage) DeleteExpired(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	merkleRoot libkb.MerkleRoot) (expired []keybase1.EkGeneration, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#DeleteExpired: teamID:%v", teamID), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#DeleteExpired: teamID:%v", teamID), func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
-	cache, found, err := s.getCacheForTeamID(ctx, teamID)
+	cache, found, err := s.getCacheForTeamID(mctx, teamID)
 	if err != nil {
 		return nil, err
 	} else if !found {
@@ -382,17 +378,17 @@ func (s *TeamEKBoxStorage) DeleteExpired(ctx context.Context, teamID keybase1.Te
 		}
 	}
 	toDelete = append(toDelete, expired...)
-	return expired, s.deleteMany(ctx, teamID, toDelete)
+	return expired, s.deleteMany(mctx, teamID, toDelete)
 }
 
-func (s *TeamEKBoxStorage) GetAll(ctx context.Context, teamID keybase1.TeamID) (teamEKs TeamEKMap, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#GetAll: teamID:%v", teamID), func() error { return err })()
+func (s *TeamEKBoxStorage) GetAll(mctx libkb.MetaContext, teamID keybase1.TeamID) (teamEKs TeamEKMap, err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#GetAll: teamID:%v", teamID), func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
 	teamEKs = make(TeamEKMap)
-	cache, found, err := s.getCacheForTeamID(ctx, teamID)
+	cache, found, err := s.getCacheForTeamID(mctx, teamID)
 	if err != nil {
 		return nil, err
 	} else if !found {
@@ -403,7 +399,7 @@ func (s *TeamEKBoxStorage) GetAll(ctx context.Context, teamID keybase1.TeamID) (
 		if cacheItem.HasError() {
 			continue
 		}
-		teamEK, err := s.unbox(ctx, generation, cacheItem.TeamEKBoxed, nil)
+		teamEK, err := s.unbox(mctx, generation, cacheItem.TeamEKBoxed, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -418,14 +414,14 @@ func (s *TeamEKBoxStorage) ClearCache() {
 	s.cache.Clear()
 }
 
-func (s *TeamEKBoxStorage) MaxGeneration(ctx context.Context, teamID keybase1.TeamID, includeErrs bool) (maxGeneration keybase1.EkGeneration, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("TeamEKBoxStorage#MaxGeneration: teamID:%v", teamID), func() error { return nil })()
+func (s *TeamEKBoxStorage) MaxGeneration(mctx libkb.MetaContext, teamID keybase1.TeamID, includeErrs bool) (maxGeneration keybase1.EkGeneration, err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#MaxGeneration: teamID:%v", teamID), func() error { return nil })()
 
 	s.Lock()
 	defer s.Unlock()
 
 	maxGeneration = -1
-	cache, _, err := s.getCacheForTeamID(ctx, teamID)
+	cache, _, err := s.getCacheForTeamID(mctx, teamID)
 	if err != nil {
 		return maxGeneration, err
 	}
@@ -447,47 +443,45 @@ const MemCacheLRUSize = 1000
 
 // Store some TeamEKBoxes's in memory. Threadsafe.
 type teamEKCache struct {
-	libkb.Contextified
 	lru *lru.Cache
 	sync.Mutex
 }
 
-func newTeamEKCache(g *libkb.GlobalContext) *teamEKCache {
+func newTeamEKCache() *teamEKCache {
 	nlru, err := lru.New(MemCacheLRUSize)
 	if err != nil {
 		// lru.New only panics if size <= 0
 		log.Panicf("Could not create lru cache: %v", err)
 	}
 	return &teamEKCache{
-		Contextified: libkb.NewContextified(g),
-		lru:          nlru,
+		lru: nlru,
 	}
 }
 
-func (s *teamEKCache) GetMap(teamID keybase1.TeamID) (cache teamEKBoxCache, found bool) {
+func (s *teamEKCache) GetMap(mctx libkb.MetaContext, teamID keybase1.TeamID) (cache teamEKBoxCache, found bool) {
 	s.Lock()
 	defer s.Unlock()
 
-	untyped, found := s.lru.Get(s.key(teamID))
+	untyped, found := s.lru.Get(s.key(mctx, teamID))
 	if !found {
 		return nil, found
 	}
 	cache, ok := untyped.(teamEKBoxCache)
 	if !ok {
-		s.G().Log.CDebugf(context.TODO(), "TeamEK teamEKCache got bad type from lru: %T", untyped)
+		mctx.Debug("TeamEK teamEKCache got bad type from lru: %T", untyped)
 		return nil, found
 	}
 	return cache, found
 }
 
-func (s *teamEKCache) PutMap(teamID keybase1.TeamID, cache teamEKBoxCache) {
-	s.lru.Add(s.key(teamID), cache)
+func (s *teamEKCache) PutMap(mctx libkb.MetaContext, teamID keybase1.TeamID, cache teamEKBoxCache) {
+	s.lru.Add(s.key(mctx, teamID), cache)
 }
 
 func (s *teamEKCache) Clear() {
 	s.lru.Purge()
 }
 
-func (s *teamEKCache) key(teamID keybase1.TeamID) (key string) {
-	return teamKey(teamID, s.G())
+func (s *teamEKCache) key(mctx libkb.MetaContext, teamID keybase1.TeamID) (key string) {
+	return teamKey(teamID, mctx)
 }

--- a/go/ephemeral/team_ek_box_storage_test.go
+++ b/go/ephemeral/team_ek_box_storage_test.go
@@ -1,6 +1,7 @@
 package ephemeral
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -8,53 +9,50 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestTeamEKBoxStorage(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	m := libkb.NewMetaContextForTest(tc)
-
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
 	// Login hooks should have run
 	deviceEKStorage := tc.G.GetDeviceEKStorage()
-	deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(context.Background(), false)
+	deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(mctx, false)
 	require.True(t, deviceEKMaxGen > 0)
 	require.NoError(t, err)
 
 	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
-	userEKMaxGen, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
+	userEKMaxGen, err := userEKBoxStorage.MaxGeneration(mctx, false)
 	require.True(t, userEKMaxGen > 0)
 	require.NoError(t, err)
 
 	teamID := createTeam(tc)
 	invalidID := teamID + keybase1.TeamID("foo")
 
-	teamEKMetadata, err := publishNewTeamEK(context.Background(), tc.G, teamID, merkleRoot)
+	teamEKMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot)
 	require.NoError(t, err)
 
 	s := tc.G.GetTeamEKBoxStorage()
 
 	// Test invalid teamID
-	nonexistent2, err := s.Get(context.Background(), invalidID, teamEKMetadata.Generation+1, nil)
+	nonexistent2, err := s.Get(mctx, invalidID, teamEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	_, ok := err.(EphemeralKeyError)
 	require.False(t, ok)
 	require.Equal(t, keybase1.TeamEk{}, nonexistent2)
 
 	// Test get valid & unbox
-	teamEK, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation, nil)
+	teamEK, err := s.Get(mctx, teamID, teamEKMetadata.Generation, nil)
 	require.NoError(t, err)
 
 	verifyTeamEK(t, teamEKMetadata, teamEK)
 
 	// Test Get nonexistent
-	nonexistent, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation+1, nil)
+	nonexistent, err := s.Get(mctx, teamID, teamEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr := err.(EphemeralKeyError)
@@ -62,25 +60,25 @@ func TestTeamEKBoxStorage(t *testing.T) {
 	require.Equal(t, keybase1.TeamEk{}, nonexistent)
 
 	// include the cached error in the max
-	maxGeneration, err := s.MaxGeneration(context.Background(), teamID, true)
+	maxGeneration, err := s.MaxGeneration(mctx, teamID, true)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, maxGeneration)
 
 	// Test MaxGeneration
-	maxGeneration, err = s.MaxGeneration(context.Background(), teamID, false)
+	maxGeneration, err = s.MaxGeneration(mctx, teamID, false)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, maxGeneration)
 
 	// Invalid id
-	maxGeneration2, err := s.MaxGeneration(context.Background(), invalidID, false)
+	maxGeneration2, err := s.MaxGeneration(mctx, invalidID, false)
 	require.NoError(t, err)
 	require.EqualValues(t, -1, maxGeneration2)
 
 	//	NOTE: We don't expose Delete on the interface put on the GlobalContext
 	//	since they should never be called, only DeleteExpired should be used.
 	//	GetAll is also not exposed since it' only needed for tests.
-	rawTeamEKBoxStorage := NewTeamEKBoxStorage(tc.G)
-	teamEKs, err := rawTeamEKBoxStorage.GetAll(context.Background(), teamID)
+	rawTeamEKBoxStorage := NewTeamEKBoxStorage()
+	teamEKs, err := rawTeamEKBoxStorage.GetAll(mctx, teamID)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(teamEKs))
 
@@ -90,34 +88,34 @@ func TestTeamEKBoxStorage(t *testing.T) {
 	verifyTeamEK(t, teamEKMetadata, teamEK)
 
 	// Test invalid
-	teamEKs2, err := rawTeamEKBoxStorage.GetAll(context.Background(), invalidID)
+	teamEKs2, err := rawTeamEKBoxStorage.GetAll(mctx, invalidID)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(teamEKs2))
 
 	// Let's delete our userEK and verify we will refetch and unbox properly
-	rawUserEKBoxStorage := NewUserEKBoxStorage(tc.G)
-	err = rawUserEKBoxStorage.Delete(context.Background(), userEKMaxGen)
+	rawUserEKBoxStorage := NewUserEKBoxStorage()
+	err = rawUserEKBoxStorage.Delete(mctx, userEKMaxGen)
 	require.NoError(t, err)
 
 	userEKBoxStorage.ClearCache()
 
-	teamEK, err = s.Get(context.Background(), teamID, teamEKMetadata.Generation, nil)
+	teamEK, err = s.Get(mctx, teamID, teamEKMetadata.Generation, nil)
 	require.NoError(t, err)
 	verifyTeamEK(t, teamEKMetadata, teamEK)
 
 	// No let's the deviceEK which we can't recover from
-	rawDeviceEKStorage := NewDeviceEKStorage(tc.G)
-	err = rawDeviceEKStorage.Delete(context.Background(), deviceEKMaxGen)
+	rawDeviceEKStorage := NewDeviceEKStorage(mctx)
+	err = rawDeviceEKStorage.Delete(mctx, deviceEKMaxGen)
 	require.NoError(t, err)
 
 	deviceEKStorage.ClearCache()
-	deviceEK, err := deviceEKStorage.Get(context.Background(), deviceEKMaxGen)
+	deviceEK, err := deviceEKStorage.Get(mctx, deviceEKMaxGen)
 	require.Error(t, err)
 	_, ok = err.(erasablekv.UnboxError)
 	require.True(t, ok)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
-	bad, err := s.Get(context.Background(), teamID, teamEKMetadata.Generation, nil)
+	bad, err := s.Get(mctx, teamID, teamEKMetadata.Generation, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr = err.(EphemeralKeyError)
@@ -125,33 +123,33 @@ func TestTeamEKBoxStorage(t *testing.T) {
 	require.Equal(t, keybase1.TeamEk{}, bad)
 
 	// test delete
-	err = rawTeamEKBoxStorage.Delete(context.Background(), teamID, teamEKMetadata.Generation)
+	err = rawTeamEKBoxStorage.Delete(mctx, teamID, teamEKMetadata.Generation)
 	require.NoError(t, err)
 	// delete invalid
-	err = rawTeamEKBoxStorage.Delete(context.Background(), invalidID, teamEKMetadata.Generation)
+	err = rawTeamEKBoxStorage.Delete(mctx, invalidID, teamEKMetadata.Generation)
 	require.NoError(t, err)
 
-	teamEKs, err = rawTeamEKBoxStorage.GetAll(context.Background(), teamID)
+	teamEKs, err = rawTeamEKBoxStorage.GetAll(mctx, teamID)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(teamEKs))
 
 	s.ClearCache()
 
-	maxGeneration3, err := s.MaxGeneration(context.Background(), teamID, false)
+	maxGeneration3, err := s.MaxGeneration(mctx, teamID, false)
 	require.NoError(t, err)
 	require.EqualValues(t, -1, maxGeneration3)
 
-	expired, err := s.DeleteExpired(context.Background(), teamID, merkleRoot)
+	expired, err := s.DeleteExpired(mctx, teamID, merkleRoot)
 	expected := []keybase1.EkGeneration(nil)
 	require.NoError(t, err)
 	require.Equal(t, expected, expired)
 
 	// Verify we store failures in the cache
 	t.Logf("cache failures")
-	nonexistent, err = rawTeamEKBoxStorage.Get(context.Background(), teamID, teamEKMetadata.Generation+1, nil)
+	nonexistent, err = rawTeamEKBoxStorage.Get(mctx, teamID, teamEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.Equal(t, keybase1.TeamEk{}, nonexistent)
-	cache, found, err := rawTeamEKBoxStorage.getCacheForTeamID(context.Background(), teamID)
+	cache, found, err := rawTeamEKBoxStorage.getCacheForTeamID(mctx, teamID)
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Len(t, cache, 1)
@@ -165,17 +163,17 @@ func TestTeamEKBoxStorage(t *testing.T) {
 // migration or versioning between the keys. This test should blow up if we
 // break it unintentionally.
 func TestTeamEKStorageKeyFormat(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	s := NewTeamEKBoxStorage(tc.G)
-	uv, err := tc.G.GetMeUV(context.Background())
+	s := NewTeamEKBoxStorage()
+	uv, err := tc.G.GetMeUV(context.TODO())
 	require.NoError(t, err)
 
 	teamID := createTeam(tc)
 
-	key, err := s.dbKey(context.Background(), teamID)
+	key, err := s.dbKey(mctx, teamID)
 	require.NoError(t, err)
-	expected := fmt.Sprintf("teamEphemeralKeyBox-%s-%s-%s-%d", teamID, s.G().Env.GetUsername(), uv.EldestSeqno, teamEKBoxStorageDBVersion)
+	expected := fmt.Sprintf("teamEphemeralKeyBox-%s-%s-%s-%d", teamID, mctx.G().Env.GetUsername(), uv.EldestSeqno, teamEKBoxStorageDBVersion)
 	require.Equal(t, expected, key.Key)
 }

--- a/go/ephemeral/team_ek_test.go
+++ b/go/ephemeral/team_ek_test.go
@@ -25,11 +25,10 @@ func createTeam(tc libkb.TestContext) keybase1.TeamID {
 }
 
 func TestNewTeamEK(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	m := libkb.NewMetaContextForTest(tc)
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
@@ -37,14 +36,14 @@ func TestNewTeamEK(t *testing.T) {
 
 	// Before we've published any teamEK's, fetchTeamEKStatement should return
 	// nil.
-	nilStatement, _, _, err := fetchTeamEKStatement(context.Background(), tc.G, teamID)
+	nilStatement, _, _, err := fetchTeamEKStatement(mctx, teamID)
 	require.NoError(t, err)
 	require.Nil(t, nilStatement)
 
-	publishedMetadata, err := publishNewTeamEK(context.Background(), tc.G, teamID, merkleRoot)
+	publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot)
 	require.NoError(t, err)
 
-	statementPtr, _, _, err := fetchTeamEKStatement(context.Background(), tc.G, teamID)
+	statementPtr, _, _, err := fetchTeamEKStatement(mctx, teamID)
 	require.NoError(t, err)
 	require.NotNil(t, statementPtr)
 	statement := *statementPtr
@@ -54,20 +53,20 @@ func TestNewTeamEK(t *testing.T) {
 
 	// We've stored the result in local storage
 	teamEKBoxStorage := tc.G.GetTeamEKBoxStorage()
-	maxGeneration, err := teamEKBoxStorage.MaxGeneration(context.Background(), teamID, false)
+	maxGeneration, err := teamEKBoxStorage.MaxGeneration(mctx, teamID, false)
 	require.NoError(t, err)
-	ek, err := teamEKBoxStorage.Get(context.Background(), teamID, maxGeneration, nil)
+	ek, err := teamEKBoxStorage.Get(mctx, teamID, maxGeneration, nil)
 	require.NoError(t, err)
 	require.Equal(t, ek.Metadata, publishedMetadata)
 
-	s := NewTeamEKBoxStorage(tc.G)
+	s := NewTeamEKBoxStorage()
 	// Put our storage in a bad state by deleting the maxGeneration
-	err = s.Delete(context.Background(), teamID, keybase1.EkGeneration(1))
+	err = s.Delete(mctx, teamID, keybase1.EkGeneration(1))
 	require.NoError(t, err)
 
 	// If we publish in a bad local state, we can successfully get the
 	// maxGeneration from the server and continue
-	publishedMetadata2, err := publishNewTeamEK(context.Background(), tc.G, teamID, merkleRoot)
+	publishedMetadata2, err := publishNewTeamEK(mctx, teamID, merkleRoot)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, publishedMetadata2.Generation)
 }

--- a/go/ephemeral/user_ek.go
+++ b/go/ephemeral/user_ek.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -34,8 +33,7 @@ func (s *UserEKSeed) DeriveDHKey() *libkb.NaclDHKeyPair {
 
 // Upload a new userEK directly, when we're not adding it to a PUK or device
 // transaction.
-func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxes []keybase1.UserEkBoxMetadata) (err error) {
-	mctx := libkb.NewMetaContext(ctx, g)
+func postNewUserEK(mctx libkb.MetaContext, sig string, boxes []keybase1.UserEkBoxMetadata) (err error) {
 	defer mctx.TraceTimed("postNewUserEK", func() error { return err })()
 
 	boxesJSON, err := json.Marshal(boxes)
@@ -48,10 +46,10 @@ func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxe
 		Args: libkb.HTTPArgs{
 			"sig":               libkb.S{Val: sig},
 			"boxes":             libkb.S{Val: string(boxesJSON)},
-			"creator_device_id": libkb.S{Val: string(g.Env.GetDeviceID())},
+			"creator_device_id": libkb.S{Val: string(mctx.ActiveDevice().DeviceID())},
 		},
 	}
-	_, err = g.GetAPI().Post(mctx, apiArg)
+	_, err = mctx.G().GetAPI().Post(mctx, apiArg)
 	return err
 }
 
@@ -60,17 +58,17 @@ func postNewUserEK(ctx context.Context, g *libkb.GlobalContext, sig string, boxe
 // PUK. The other is where we're rolling the PUK, and we need to sign a new
 // userEK with the new PUK to upload both together. This helper covers the
 // steps common to both cases.
-func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot,
+func prepareNewUserEK(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot,
 	pukSigning *libkb.NaclSigningKeyPair) (sig string, boxes []keybase1.UserEkBoxMetadata,
 	newMetadata keybase1.UserEkMetadata, myBox *keybase1.UserEkBoxed, err error) {
-	defer g.CTraceTimed(ctx, "prepareNewUserEK", func() error { return err })()
+	defer mctx.TraceTimed("prepareNewUserEK", func() error { return err })()
 
 	seed, err := newUserEphemeralSeed()
 	if err != nil {
 		return "", nil, newMetadata, nil, err
 	}
 
-	prevStatement, latestGeneration, wrongKID, err := fetchUserEKStatement(ctx, g, g.Env.GetUID())
+	prevStatement, latestGeneration, wrongKID, err := fetchUserEKStatement(mctx, mctx.G().Env.GetUID())
 	if !wrongKID && err != nil {
 		return "", nil, newMetadata, nil, err
 	}
@@ -110,7 +108,7 @@ func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 		return "", nil, newMetadata, nil, err
 	}
 
-	boxes, myUserEKBoxed, err := boxUserEKForDevices(ctx, g, merkleRoot, seed, metadata)
+	boxes, myUserEKBoxed, err := boxUserEKForDevices(mctx, merkleRoot, seed, metadata)
 	if err != nil {
 		return "", nil, newMetadata, nil, err
 	}
@@ -119,16 +117,15 @@ func prepareNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 }
 
 // Create a new userEK and upload it. Add our box to the local box store.
-func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (
+func publishNewUserEK(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (
 	metadata keybase1.UserEkMetadata, err error) {
-	defer g.CTraceTimed(ctx, "publishNewUserEK", func() error { return err })()
+	defer mctx.TraceTimed("publishNewUserEK", func() error { return err })()
 
 	// Sign the statement blob with the latest PUK.
-	pukKeyring, err := g.GetPerUserKeyring(ctx)
+	pukKeyring, err := mctx.G().GetPerUserKeyring(mctx.Ctx())
 	if err != nil {
 		return metadata, err
 	}
-	mctx := libkb.NewMetaContext(ctx, g)
 	if err := pukKeyring.Sync(mctx); err != nil {
 		return metadata, err
 	}
@@ -140,41 +137,41 @@ func publishNewUserEK(ctx context.Context, g *libkb.GlobalContext, merkleRoot li
 		return metadata, err
 	}
 
-	sig, boxes, newMetadata, myBox, err := prepareNewUserEK(ctx, g, merkleRoot, pukSigning)
+	sig, boxes, newMetadata, myBox, err := prepareNewUserEK(mctx, merkleRoot, pukSigning)
 	if err != nil {
 		return metadata, err
 	}
 
-	if err = postNewUserEK(ctx, g, sig, boxes); err != nil {
+	if err = postNewUserEK(mctx, sig, boxes); err != nil {
 		return metadata, err
 	}
 
 	// Cache the new box after we see the post succeeded.
 	if myBox == nil {
-		g.Log.CDebugf(ctx, "No box made for own deviceEK")
+		mctx.Debug("No box made for own deviceEK")
 	} else {
-		storage := g.GetUserEKBoxStorage()
-		err = storage.Put(ctx, newMetadata.Generation, *myBox)
+		storage := mctx.G().GetUserEKBoxStorage()
+		err = storage.Put(mctx, newMetadata.Generation, *myBox)
 	}
 	return newMetadata, err
 }
 
-func ForcePublishNewUserEKForTesting(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot) (metadata keybase1.UserEkMetadata, err error) {
-	defer g.CTraceTimed(ctx, "ForcePublishNewUserEKForTesting", func() error { return err })()
-	return publishNewUserEK(ctx, g, merkleRoot)
+func ForcePublishNewUserEKForTesting(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (metadata keybase1.UserEkMetadata, err error) {
+	defer mctx.TraceTimed("ForcePublishNewUserEKForTesting", func() error { return err })()
+	return publishNewUserEK(mctx, merkleRoot)
 }
 
-func boxUserEKForDevices(ctx context.Context, g *libkb.GlobalContext, merkleRoot libkb.MerkleRoot,
+func boxUserEKForDevices(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot,
 	seed UserEKSeed, userMetadata keybase1.UserEkMetadata) (boxes []keybase1.UserEkBoxMetadata,
 	myUserEKBoxed *keybase1.UserEkBoxed, err error) {
-	defer g.CTraceTimed(ctx, "boxUserEKForDevices", func() error { return err })()
+	defer mctx.TraceTimed("boxUserEKForDevices", func() error { return err })()
 
-	devicesMetadata, err := allActiveDeviceEKMetadata(ctx, g, merkleRoot)
+	devicesMetadata, err := allActiveDeviceEKMetadata(mctx, merkleRoot)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	myDeviceID := g.Env.GetDeviceID()
+	myDeviceID := mctx.ActiveDevice().DeviceID()
 	for deviceID, deviceMetadata := range devicesMetadata {
 		recipientKey, err := libkb.ImportKeypairFromKID(deviceMetadata.Kid)
 		if err != nil {
@@ -212,9 +209,8 @@ type userEKStatementResponse struct {
 // one, this function will also return nil and log a warning. This is a
 // transitional thing, and eventually when all "reasonably up to date" clients
 // in the wild have EK support, we will make that case an error.
-func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []keybase1.UID) (
+func fetchUserEKStatements(mctx libkb.MetaContext, uids []keybase1.UID) (
 	statements map[keybase1.UID]*keybase1.UserEkStatement, err error) {
-	mctx := libkb.NewMetaContext(ctx, g)
 	defer mctx.TraceTimed(fmt.Sprintf("fetchUserEKStatements: numUids: %v", len(uids)), func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -224,7 +220,7 @@ func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []k
 			"uids": libkb.S{Val: libkb.UidsToString(uids)},
 		},
 	}
-	res, err := g.GetAPI().Post(mctx, apiArg)
+	res, err := mctx.G().GetAPI().Post(mctx, apiArg)
 	if err != nil {
 		return nil, err
 	}
@@ -237,12 +233,12 @@ func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []k
 
 	statements = make(map[keybase1.UID]*keybase1.UserEkStatement)
 	for uid, sig := range parsedResponse.Sigs {
-		statement, _, wrongKID, err := verifySigWithLatestPUK(ctx, g, uid, *sig)
+		statement, _, wrongKID, err := verifySigWithLatestPUK(mctx, uid, *sig)
 		// Check the wrongKID condition before checking the error, since an error
 		// is still returned in this case. TODO: Turn this warning into an error
 		// after EK support is sufficiently widespread.
 		if wrongKID {
-			g.Log.CDebugf(ctx, "It looks like you revoked a device without generating new ephemeral keys. Are you running an old version?")
+			mctx.Debug("It looks like you revoked a device without generating new ephemeral keys. Are you running an old version?")
 			// Don't include this statement since it is invalid.
 			continue
 		} else if err != nil {
@@ -259,10 +255,8 @@ func fetchUserEKStatements(ctx context.Context, g *libkb.GlobalContext, uids []k
 // one, this function will return wrongKID. This allows clients to chose the
 // correct generation number but not include the statement when generating a
 // new userEK.
-func fetchUserEKStatement(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID) (
+func fetchUserEKStatement(mctx libkb.MetaContext, uid keybase1.UID) (
 	statement *keybase1.UserEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
-
-	mctx := libkb.NewMetaContext(ctx, g)
 	defer mctx.TraceTimed("fetchUserEKStatement", func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -294,12 +288,12 @@ func fetchUserEKStatement(ctx context.Context, g *libkb.GlobalContext, uid keyba
 		return nil, latestGeneration, false, fmt.Errorf("Invalid server response, wrong uid returned")
 	}
 
-	statement, latestGeneration, wrongKID, err = verifySigWithLatestPUK(ctx, g, uid, *sig)
+	statement, latestGeneration, wrongKID, err = verifySigWithLatestPUK(mctx, uid, *sig)
 	// Check the wrongKID condition before checking the error, since an error
 	// is still returned in this case. TODO: Turn this warning into an error
 	// after EK support is sufficiently widespread.
 	if wrongKID {
-		g.Log.CDebugf(ctx, "It looks like you revoked a device without generating new ephemeral keys. Are you running an old version?")
+		mctx.Debug("It looks like you revoked a device without generating new ephemeral keys. Are you running an old version?")
 		return nil, latestGeneration, true, nil
 	} else if err != nil {
 		return nil, latestGeneration, false, err
@@ -328,9 +322,9 @@ func extractUserEKStatementFromSig(sig string) (signerKey *kbcrypto.NaclSigningK
 // the wild to have EK support, callers will treat that case as "there is no
 // key" and convert the error to a warning. We set `latestGeneration` so that
 // callers can use this value to generate a new key even if `wrongKID` is set.
-func verifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, sig string) (
+func verifySigWithLatestPUK(mctx libkb.MetaContext, uid keybase1.UID, sig string) (
 	statement *keybase1.UserEkStatement, latestGeneration keybase1.EkGeneration, wrongKID bool, err error) {
-	defer g.CTraceTimed(ctx, "verifySigWithLatestPUK", func() error { return err })()
+	defer mctx.TraceTimed("verifySigWithLatestPUK", func() error { return err })()
 
 	// Parse the statement before we verify the signing key. Even if the
 	// signing key is bad (likely because of a legacy PUK roll that didn't
@@ -345,14 +339,16 @@ func verifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, uid key
 	// UPAK from cache, but if the KID doesn't match, we try a forced reload to
 	// see if the cache might've been stale. Only if the KID still doesn't
 	// match after the reload do we complain.
-	upak, _, err := g.GetUPAKLoader().LoadV2(libkb.NewLoadUserByUIDArg(ctx, g, uid))
+	upak, _, err := mctx.G().GetUPAKLoader().LoadV2(
+		libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(uid))
 	if err != nil {
 		return nil, latestGeneration, false, err
 	}
 	latestPUK := upak.Current.GetLatestPerUserKey()
 	if latestPUK == nil || !latestPUK.SigKID.Equal(signerKey.GetKID()) {
 		// The latest PUK might be stale. Force a reload, then check this over again.
-		upak, _, err = g.GetUPAKLoader().LoadV2(libkb.NewLoadUserByUIDForceArg(g, uid))
+		upak, _, err = mctx.G().GetUPAKLoader().LoadV2(
+			libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(uid).WithForceReload())
 		if err != nil {
 			return nil, latestGeneration, false, err
 		}
@@ -373,19 +369,19 @@ func verifySigWithLatestPUK(ctx context.Context, g *libkb.GlobalContext, uid key
 	return parsedStatement, latestGeneration, false, nil
 }
 
-func filterStaleUserEKStatements(ctx context.Context, g *libkb.GlobalContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement,
+func filterStaleUserEKStatements(mctx libkb.MetaContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement,
 	merkleRoot libkb.MerkleRoot) (activeMap map[keybase1.UID]keybase1.UserEkStatement, err error) {
-	defer g.CTraceTimed(ctx, fmt.Sprintf("filterStaleUserEKStatements: numStatements: %v", len(statementMap)), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("filterStaleUserEKStatements: numStatements: %v", len(statementMap)), func() error { return err })()
 
 	activeMap = make(map[keybase1.UID]keybase1.UserEkStatement)
 	for uid, statement := range statementMap {
 		if statement == nil {
-			g.Log.CDebugf(ctx, "found stale userStatement for uid: %s", uid)
+			mctx.Debug("found stale userStatement for uid: %s", uid)
 			continue
 		}
 		metadata := statement.CurrentUserEkMetadata
 		if ctimeIsStale(metadata.Ctime.Time(), merkleRoot) {
-			g.Log.CDebugf(ctx, "found stale userStatement for KID: %s", metadata.Kid)
+			mctx.Debug("found stale userStatement for KID: %s", metadata.Kid)
 			continue
 		}
 		activeMap[uid] = *statement
@@ -394,9 +390,9 @@ func filterStaleUserEKStatements(ctx context.Context, g *libkb.GlobalContext, st
 	return activeMap, nil
 }
 
-func activeUserEKMetadata(ctx context.Context, g *libkb.GlobalContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement,
+func activeUserEKMetadata(mctx libkb.MetaContext, statementMap map[keybase1.UID]*keybase1.UserEkStatement,
 	merkleRoot libkb.MerkleRoot) (activeMetadata map[keybase1.UID]keybase1.UserEkMetadata, err error) {
-	activeMap, err := filterStaleUserEKStatements(ctx, g, statementMap, merkleRoot)
+	activeMap, err := filterStaleUserEKStatements(mctx, statementMap, merkleRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -55,38 +54,36 @@ type UserEKUnboxedMap map[keybase1.EkGeneration]keybase1.UserEk
 // We cache UserEKBoxes from the server in memory and a persist to a local
 // KVStore.
 type UserEKBoxStorage struct {
-	libkb.Contextified
 	sync.Mutex
 	indexed bool
 	cache   userEKBoxCache
 }
 
-func NewUserEKBoxStorage(g *libkb.GlobalContext) *UserEKBoxStorage {
+func NewUserEKBoxStorage() *UserEKBoxStorage {
 	return &UserEKBoxStorage{
-		Contextified: libkb.NewContextified(g),
-		cache:        make(userEKBoxCache),
+		cache: make(userEKBoxCache),
 	}
 }
 
-func (s *UserEKBoxStorage) dbKey(ctx context.Context) (dbKey libkb.DbKey, err error) {
-	uv, err := s.G().GetMeUV(ctx)
+func (s *UserEKBoxStorage) dbKey(mctx libkb.MetaContext) (dbKey libkb.DbKey, err error) {
+	uv, err := mctx.G().GetMeUV(mctx.Ctx())
 	if err != nil {
 		return dbKey, err
 	}
-	key := fmt.Sprintf("userEphemeralKeyBox-%s-%s-%d", s.G().Env.GetUsername(), uv.EldestSeqno, userEKBoxStorageDBVersion)
+	key := fmt.Sprintf("userEphemeralKeyBox-%s-%s-%d", mctx.G().Env.GetUsername(), uv.EldestSeqno, userEKBoxStorageDBVersion)
 	return libkb.DbKey{
 		Typ: libkb.DBUserEKBox,
 		Key: key,
 	}, nil
 }
 
-func (s *UserEKBoxStorage) getCache(ctx context.Context) (cache userEKBoxCache, err error) {
+func (s *UserEKBoxStorage) getCache(mctx libkb.MetaContext) (cache userEKBoxCache, err error) {
 	if !s.indexed {
-		key, err := s.dbKey(ctx)
+		key, err := s.dbKey(mctx)
 		if err != nil {
 			return s.cache, err
 		}
-		if _, err = s.G().GetKVStore().GetInto(&s.cache, key); err != nil {
+		if _, err = mctx.G().GetKVStore().GetInto(&s.cache, key); err != nil {
 			return s.cache, err
 		}
 		s.indexed = true
@@ -94,13 +91,13 @@ func (s *UserEKBoxStorage) getCache(ctx context.Context) (cache userEKBoxCache, 
 	return s.cache, nil
 }
 
-func (s *UserEKBoxStorage) Get(ctx context.Context, generation keybase1.EkGeneration,
+func (s *UserEKBoxStorage) Get(mctx libkb.MetaContext, generation keybase1.EkGeneration,
 	contentCtime *gregor1.Time) (userEK keybase1.UserEk, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("UserEKBoxStorage#Get: generation:%v", generation), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("UserEKBoxStorage#Get: generation:%v", generation), func() error { return err })()
 
 	s.Lock()
 
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		s.Unlock()
 		return userEK, err
@@ -111,17 +108,17 @@ func (s *UserEKBoxStorage) Get(ctx context.Context, generation keybase1.EkGenera
 	if !ok {
 		// We don't have anything in our cache, fetch from the server
 		s.Unlock() // release the lock while we fetch
-		return s.fetchAndStore(ctx, generation)
+		return s.fetchAndStore(mctx, generation)
 	}
 
 	defer s.Unlock() // release the lock after we unbox
 	if cacheItem.HasError() {
 		return userEK, cacheItem.Error()
 	}
-	userEK, err = s.unbox(ctx, generation, cacheItem.UserEKBoxed, contentCtime)
+	userEK, err = s.unbox(mctx, generation, cacheItem.UserEKBoxed, contentCtime)
 	if err != nil { // if we can no longer unbox this, store the error
-		if perr := s.putLocked(ctx, generation, keybase1.UserEkBoxed{}, err); perr != nil {
-			s.G().Log.CDebugf(ctx, "unable to store unboxing error %v", perr)
+		if perr := s.putLocked(mctx, generation, keybase1.UserEkBoxed{}, err); perr != nil {
+			mctx.Debug("unable to store unboxing error %v", perr)
 		}
 	}
 	return userEK, err
@@ -135,9 +132,7 @@ type UserEKBoxedResponse struct {
 	} `json:"result"`
 }
 
-func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase1.EkGeneration) (userEK keybase1.UserEk, err error) {
-
-	mctx := libkb.NewMetaContext(ctx, s.G())
+func (s *UserEKBoxStorage) fetchAndStore(mctx libkb.MetaContext, generation keybase1.EkGeneration) (userEK keybase1.UserEk, err error) {
 	defer mctx.TraceTimed(fmt.Sprintf("UserEKBoxStorage#fetchAndStore: generation: %v", generation), func() error { return err })()
 
 	// cache unboxing/missing box errors so we don't continually try to fetch
@@ -147,8 +142,8 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 		case EphemeralKeyError:
 			s.Lock()
 			defer s.Unlock()
-			if perr := s.putLocked(ctx, generation, keybase1.UserEkBoxed{}, err); perr != nil {
-				s.G().Log.CDebugf(ctx, "unable to store error %v", perr)
+			if perr := s.putLocked(mctx, generation, keybase1.UserEkBoxed{}, err); perr != nil {
+				mctx.Debug("unable to store error %v", perr)
 			}
 		}
 	}()
@@ -158,7 +153,7 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 		SessionType: libkb.APISessionTypeREQUIRED,
 		Args: libkb.HTTPArgs{
 			"generation":          libkb.U{Val: uint64(generation)},
-			"recipient_device_id": libkb.S{Val: string(s.G().Env.GetDeviceID())},
+			"recipient_device_id": libkb.S{Val: string(mctx.ActiveDevice().DeviceID())},
 		},
 	}
 
@@ -174,7 +169,7 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 	}
 
 	if result.Result == nil {
-		err = newEKMissingBoxErr(ctx, s.G(), UserEKStr, generation)
+		err = newEKMissingBoxErr(mctx, UserEKStr, generation)
 		return userEK, err
 	}
 
@@ -194,7 +189,7 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 	userEKMetadata := userEKStatement.CurrentUserEkMetadata
 	if generation != userEKMetadata.Generation {
 		// sanity check that we go the right generation
-		return userEK, newEKCorruptedErr(ctx, s.G(), UserEKStr, generation, userEKMetadata.Generation)
+		return userEK, newEKCorruptedErr(mctx, UserEKStr, generation, userEKMetadata.Generation)
 	}
 	userEKBoxed := keybase1.UserEkBoxed{
 		Box:                result.Result.Box,
@@ -202,7 +197,7 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 		Metadata:           userEKMetadata,
 	}
 
-	userEK, err = s.unbox(ctx, generation, userEKBoxed, nil)
+	userEK, err = s.unbox(mctx, generation, userEKBoxed, nil)
 	if err != nil {
 		return userEK, err
 	}
@@ -215,48 +210,48 @@ func (s *UserEKBoxStorage) fetchAndStore(ctx context.Context, generation keybase
 	}
 
 	// Store the boxed version, return the unboxed
-	err = s.Put(ctx, generation, userEKBoxed)
+	err = s.Put(mctx, generation, userEKBoxed)
 	return userEK, err
 }
 
-func (s *UserEKBoxStorage) Put(ctx context.Context, generation keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) (err error) {
+func (s *UserEKBoxStorage) Put(mctx libkb.MetaContext, generation keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) (err error) {
 	s.Lock()
 	defer s.Unlock()
-	return s.putLocked(ctx, generation, userEKBoxed, nil /* ekErr */)
+	return s.putLocked(mctx, generation, userEKBoxed, nil /* ekErr */)
 }
 
-func (s *UserEKBoxStorage) putLocked(ctx context.Context, generation keybase1.EkGeneration,
+func (s *UserEKBoxStorage) putLocked(mctx libkb.MetaContext, generation keybase1.EkGeneration,
 	userEKBoxed keybase1.UserEkBoxed, ekErr error) (err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("UserEKBoxStorage#putLocked: generation:%v", generation), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("UserEKBoxStorage#putLocked: generation:%v", generation), func() error { return err })()
 
 	// sanity check that we got the right generation
 	if userEKBoxed.Metadata.Generation != generation && ekErr == nil {
-		return newEKCorruptedErr(ctx, s.G(), UserEKStr, generation, userEKBoxed.Metadata.Generation)
+		return newEKCorruptedErr(mctx, UserEKStr, generation, userEKBoxed.Metadata.Generation)
 	}
 
-	key, err := s.dbKey(ctx)
+	key, err := s.dbKey(mctx)
 	if err != nil {
 		return err
 	}
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return err
 	}
 	cache[generation] = newUserEKBoxCacheItem(userEKBoxed, ekErr)
-	return s.G().GetKVStore().PutObj(key, nil, cache)
+	return mctx.G().GetKVStore().PutObj(key, nil, cache)
 }
 
-func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.EkGeneration,
+func (s *UserEKBoxStorage) unbox(mctx libkb.MetaContext, userEKGeneration keybase1.EkGeneration,
 	userEKBoxed keybase1.UserEkBoxed, contentCtime *gregor1.Time) (userEK keybase1.UserEk, err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("UserEKBoxStorage#unbox: generation:%v", userEKGeneration), func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("UserEKBoxStorage#unbox: generation:%v", userEKGeneration), func() error { return err })()
 
-	deviceEKStorage := s.G().GetDeviceEKStorage()
-	deviceEK, err := deviceEKStorage.Get(ctx, userEKBoxed.DeviceEkGeneration)
+	deviceEKStorage := mctx.G().GetDeviceEKStorage()
+	deviceEK, err := deviceEKStorage.Get(mctx, userEKBoxed.DeviceEkGeneration)
 	if err != nil {
-		s.G().Log.CDebugf(ctx, "unable to get from deviceEKStorage %v", err)
+		mctx.Debug("unable to get from deviceEKStorage %v", err)
 		switch err.(type) {
 		case erasablekv.UnboxError:
-			return userEK, newEKUnboxErr(ctx, s.G(), UserEKStr, userEKGeneration, DeviceEKStr,
+			return userEK, newEKUnboxErr(mctx, UserEKStr, userEKGeneration, DeviceEKStr,
 				userEKBoxed.DeviceEkGeneration, contentCtime)
 		}
 		return userEK, err
@@ -267,8 +262,8 @@ func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.
 
 	msg, _, err := deviceKeypair.DecryptFromString(userEKBoxed.Box)
 	if err != nil {
-		s.G().Log.CDebugf(ctx, "unable to decrypt userEKBoxed %v", err)
-		return userEK, newEKUnboxErr(ctx, s.G(), UserEKStr, userEKGeneration, DeviceEKStr,
+		mctx.Debug("unable to decrypt userEKBoxed %v", err)
+		return userEK, newEKUnboxErr(mctx, UserEKStr, userEKGeneration, DeviceEKStr,
 			userEKBoxed.DeviceEkGeneration, contentCtime)
 	}
 
@@ -283,35 +278,35 @@ func (s *UserEKBoxStorage) unbox(ctx context.Context, userEKGeneration keybase1.
 	}, nil
 }
 
-func (s *UserEKBoxStorage) Delete(ctx context.Context, generation keybase1.EkGeneration) (err error) {
+func (s *UserEKBoxStorage) Delete(mctx libkb.MetaContext, generation keybase1.EkGeneration) (err error) {
 	s.Lock()
 	defer s.Unlock()
-	return s.deleteMany(ctx, []keybase1.EkGeneration{generation})
+	return s.deleteMany(mctx, []keybase1.EkGeneration{generation})
 }
 
-func (s *UserEKBoxStorage) deleteMany(ctx context.Context, generations []keybase1.EkGeneration) (err error) {
-	defer s.G().CTraceTimed(ctx, fmt.Sprintf("UserEKBoxStorage#deleteMany: generations:%v", generations), func() error { return err })()
+func (s *UserEKBoxStorage) deleteMany(mctx libkb.MetaContext, generations []keybase1.EkGeneration) (err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("UserEKBoxStorage#deleteMany: generations:%v", generations), func() error { return err })()
 
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return err
 	}
 	for _, generation := range generations {
 		delete(cache, generation)
 	}
-	key, err := s.dbKey(ctx)
+	key, err := s.dbKey(mctx)
 	if err != nil {
 		return err
 	}
-	return s.G().GetKVStore().PutObj(key, nil, cache)
+	return mctx.G().GetKVStore().PutObj(key, nil, cache)
 }
 
-func (s *UserEKBoxStorage) GetAll(ctx context.Context) (userEKs UserEKUnboxedMap, err error) {
-	defer s.G().CTraceTimed(ctx, "UserEKBoxStorage#GetAll", func() error { return err })()
+func (s *UserEKBoxStorage) GetAll(mctx libkb.MetaContext) (userEKs UserEKUnboxedMap, err error) {
+	defer mctx.TraceTimed("UserEKBoxStorage#GetAll", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return userEKs, err
 	}
@@ -321,7 +316,7 @@ func (s *UserEKBoxStorage) GetAll(ctx context.Context) (userEKs UserEKUnboxedMap
 		if cacheItem.HasError() {
 			continue
 		}
-		userEK, err := s.unbox(ctx, generation, cacheItem.UserEKBoxed, nil)
+		userEK, err := s.unbox(mctx, generation, cacheItem.UserEKBoxed, nil)
 		if err != nil {
 			return userEKs, err
 		}
@@ -337,14 +332,14 @@ func (s *UserEKBoxStorage) ClearCache() {
 	s.indexed = false
 }
 
-func (s *UserEKBoxStorage) MaxGeneration(ctx context.Context, includeErrs bool) (maxGeneration keybase1.EkGeneration, err error) {
-	defer s.G().CTraceTimed(ctx, "UserEKBoxStorage#MaxGeneration", func() error { return err })()
+func (s *UserEKBoxStorage) MaxGeneration(mctx libkb.MetaContext, includeErrs bool) (maxGeneration keybase1.EkGeneration, err error) {
+	defer mctx.TraceTimed("UserEKBoxStorage#MaxGeneration", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
 	maxGeneration = -1
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return maxGeneration, err
 	}
@@ -360,13 +355,13 @@ func (s *UserEKBoxStorage) MaxGeneration(ctx context.Context, includeErrs bool) 
 	return maxGeneration, nil
 }
 
-func (s *UserEKBoxStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.MerkleRoot) (expired []keybase1.EkGeneration, err error) {
-	defer s.G().CTraceTimed(ctx, "DeviceEKStorage#DeleteExpired", func() error { return err })()
+func (s *UserEKBoxStorage) DeleteExpired(mctx libkb.MetaContext, merkleRoot libkb.MerkleRoot) (expired []keybase1.EkGeneration, err error) {
+	defer mctx.TraceTimed("DeviceEKStorage#DeleteExpired", func() error { return err })()
 
 	s.Lock()
 	defer s.Unlock()
 
-	cache, err := s.getCache(ctx)
+	cache, err := s.getCache(mctx)
 	if err != nil {
 		return nil, err
 	}
@@ -383,9 +378,9 @@ func (s *UserEKBoxStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.M
 		}
 	}
 	now := keybase1.TimeFromSeconds(merkleRoot.Ctime()).Time()
-	expired = s.getExpiredGenerations(ctx, keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	toDelete = append(toDelete, expired...)
-	return expired, s.deleteMany(ctx, toDelete)
+	return expired, s.deleteMany(mctx, toDelete)
 }
 
 // getExpiredGenerations calculates which keys have expired and are safe to
@@ -396,7 +391,7 @@ func (s *UserEKBoxStorage) DeleteExpired(ctx context.Context, merkleRoot libkb.M
 // determine expiration, we look at all of the current keys and account for any
 // gaps since we don't want to expire a key if it is still used to encrypt a
 // different key or ephemeral content.
-func (s *UserEKBoxStorage) getExpiredGenerations(ctx context.Context, keyMap keyExpiryMap, now time.Time) (expired []keybase1.EkGeneration) {
+func (s *UserEKBoxStorage) getExpiredGenerations(mctx libkb.MetaContext, keyMap keyExpiryMap, now time.Time) (expired []keybase1.EkGeneration) {
 	// Sort the generations we have so we can walk through them in order.
 	var keys []keybase1.EkGeneration
 	for k := range keyMap {
@@ -415,7 +410,7 @@ func (s *UserEKBoxStorage) getExpiredGenerations(ctx context.Context, keyMap key
 			}
 		}
 		if now.Sub(keyCtime) >= (libkb.MinEphemeralKeyLifetime + expiryOffset) {
-			s.G().Log.CDebugf(ctx, "getExpiredGenerations: expired generation:%v, now: %v, keyCtime:%v, expiryOffset:%v, keyMap: %v, i:%v, %v, %v",
+			mctx.Debug("getExpiredGenerations: expired generation:%v, now: %v, keyCtime:%v, expiryOffset:%v, keyMap: %v, i:%v, %v, %v",
 				generation, now, keyCtime, expiryOffset, keyMap, i, now.Sub(keyCtime), (libkb.MinEphemeralKeyLifetime + expiryOffset))
 			expired = append(expired, generation)
 		}

--- a/go/ephemeral/user_ek_box_storage_test.go
+++ b/go/ephemeral/user_ek_box_storage_test.go
@@ -1,6 +1,7 @@
 package ephemeral
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -9,40 +10,38 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestUserEKBoxStorage(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
-	m := libkb.NewMetaContextForTest(tc)
 
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
 	// Login hooks should have run
 	deviceEKStorage := tc.G.GetDeviceEKStorage()
-	deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(context.Background(), false)
+	deviceEKMaxGen, err := deviceEKStorage.MaxGeneration(mctx, false)
 	require.True(t, deviceEKMaxGen > 0)
 	require.NoError(t, err)
 
 	s := tc.G.GetUserEKBoxStorage()
-	userEKMaxGen, err := s.MaxGeneration(context.Background(), false)
+	userEKMaxGen, err := s.MaxGeneration(mctx, false)
 	require.True(t, userEKMaxGen > 0)
 	require.NoError(t, err)
 
-	userEKMetadata, err := publishNewUserEK(context.Background(), tc.G, merkleRoot)
+	userEKMetadata, err := publishNewUserEK(mctx, merkleRoot)
 	require.NoError(t, err)
 
 	// Test get valid & unbox
-	userEK, err := s.Get(context.Background(), userEKMetadata.Generation, nil)
+	userEK, err := s.Get(mctx, userEKMetadata.Generation, nil)
 	require.NoError(t, err)
 
 	verifyUserEK(t, userEKMetadata, userEK)
 
 	// Test Get nonexistent
-	nonexistent, err := s.Get(context.Background(), userEKMetadata.Generation+1, nil)
+	nonexistent, err := s.Get(mctx, userEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr := err.(EphemeralKeyError)
@@ -50,20 +49,20 @@ func TestUserEKBoxStorage(t *testing.T) {
 	require.Equal(t, keybase1.UserEk{}, nonexistent)
 
 	// include the cached error in the max
-	maxGeneration, err := s.MaxGeneration(context.Background(), true)
+	maxGeneration, err := s.MaxGeneration(mctx, true)
 	require.NoError(t, err)
 	require.Equal(t, userEKMetadata.Generation+1, maxGeneration)
 
 	// Test MaxGeneration
-	maxGeneration, err = s.MaxGeneration(context.Background(), false)
+	maxGeneration, err = s.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	require.True(t, maxGeneration > 0)
 
 	//	NOTE: We don't expose Delete on the interface put on the GlobalContext
 	//	since they should never be called, only DeleteExpired should be used.
 	//	GetAll is also not exposed since it' only needed for tests.
-	rawUserEKBoxStorage := NewUserEKBoxStorage(tc.G)
-	userEKs, err := rawUserEKBoxStorage.GetAll(context.Background())
+	rawUserEKBoxStorage := NewUserEKBoxStorage()
+	userEKs, err := rawUserEKBoxStorage.GetAll(mctx)
 	require.NoError(t, err)
 	require.EqualValues(t, maxGeneration, len(userEKs))
 
@@ -73,17 +72,17 @@ func TestUserEKBoxStorage(t *testing.T) {
 	verifyUserEK(t, userEKMetadata, userEK)
 
 	// Let's delete our deviceEK and verify we can't unbox the userEK
-	rawDeviceEKStorage := NewDeviceEKStorage(tc.G)
-	err = rawDeviceEKStorage.Delete(context.Background(), deviceEKMaxGen)
+	rawDeviceEKStorage := NewDeviceEKStorage(mctx)
+	err = rawDeviceEKStorage.Delete(mctx, deviceEKMaxGen)
 	require.NoError(t, err)
 
 	deviceEKStorage.ClearCache()
-	deviceEK, err := deviceEKStorage.Get(context.Background(), deviceEKMaxGen)
+	deviceEK, err := deviceEKStorage.Get(mctx, deviceEKMaxGen)
 	require.Error(t, err)
 	require.IsType(t, erasablekv.UnboxError{}, err)
 	require.Equal(t, keybase1.DeviceEk{}, deviceEK)
 
-	bad, err := s.Get(context.Background(), userEKMetadata.Generation, nil)
+	bad, err := s.Get(mctx, userEKMetadata.Generation, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr = err.(EphemeralKeyError)
@@ -91,10 +90,10 @@ func TestUserEKBoxStorage(t *testing.T) {
 	require.Equal(t, keybase1.UserEk{}, bad)
 
 	// test delete
-	err = rawUserEKBoxStorage.Delete(context.Background(), userEKMetadata.Generation)
+	err = rawUserEKBoxStorage.Delete(mctx, userEKMetadata.Generation)
 	require.NoError(t, err)
 
-	userEK, err = rawUserEKBoxStorage.Get(context.Background(), userEKMetadata.Generation, nil)
+	userEK, err = rawUserEKBoxStorage.Get(mctx, userEKMetadata.Generation, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr = err.(EphemeralKeyError)
@@ -102,25 +101,25 @@ func TestUserEKBoxStorage(t *testing.T) {
 
 	s.ClearCache()
 
-	maxGeneration, err = s.MaxGeneration(context.Background(), false)
+	maxGeneration, err = s.MaxGeneration(mctx, false)
 	require.NoError(t, err)
 	require.EqualValues(t, userEKMaxGen, maxGeneration)
 
-	expired, err := s.DeleteExpired(context.Background(), merkleRoot)
+	expired, err := s.DeleteExpired(mctx, merkleRoot)
 	expected := []keybase1.EkGeneration(nil)
 	require.NoError(t, err)
 	require.Equal(t, expected, expired)
 
 	// Verify we store failures in the cache
 	t.Logf("cache failures")
-	nonexistent, err = rawUserEKBoxStorage.Get(context.Background(), userEKMetadata.Generation+1, nil)
+	nonexistent, err = rawUserEKBoxStorage.Get(mctx, userEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr = err.(EphemeralKeyError)
 	require.Equal(t, DefaultHumanErrMsg, ekErr.HumanError())
 	require.Equal(t, keybase1.UserEk{}, nonexistent)
 
-	cache, err := rawUserEKBoxStorage.getCache(context.Background())
+	cache, err := rawUserEKBoxStorage.getCache(mctx)
 	require.NoError(t, err)
 	require.Len(t, cache, 3)
 
@@ -133,28 +132,29 @@ func TestUserEKBoxStorage(t *testing.T) {
 // migration or versioning between the keys. This test should blow up if we
 // break it unintentionally.
 func TestUserEKStorageKeyFormat(t *testing.T) {
-	tc, _ := ephemeralKeyTestSetup(t)
+	tc, mctx, _ := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	s := NewUserEKBoxStorage(tc.G)
-	uv, err := tc.G.GetMeUV(context.Background())
+	s := NewUserEKBoxStorage()
+	uv, err := tc.G.GetMeUV(context.TODO())
 	require.NoError(t, err)
 
-	key, err := s.dbKey(context.Background())
+	key, err := s.dbKey(mctx)
 	require.NoError(t, err)
-	expected := fmt.Sprintf("userEphemeralKeyBox-%s-%s-%d", s.G().Env.GetUsername(), uv.EldestSeqno, userEKBoxStorageDBVersion)
+	expected := fmt.Sprintf("userEphemeralKeyBox-%s-%s-%d", mctx.G().Env.GetUsername(), uv.EldestSeqno, userEKBoxStorageDBVersion)
 	require.Equal(t, expected, key.Key)
 }
 
 func TestUserEKBoxStorageDeleteExpiredKeys(t *testing.T) {
 	tc := libkb.SetupTest(t, "ephemeral", 2)
 	defer tc.Cleanup()
+	mctx := libkb.NewMetaContextForTest(tc)
 
-	s := NewUserEKBoxStorage(tc.G)
+	s := NewUserEKBoxStorage()
 	now := time.Now()
 
 	// Test empty
-	expired := s.getExpiredGenerations(context.Background(), make(keyExpiryMap), now)
+	expired := s.getExpiredGenerations(mctx, make(keyExpiryMap), now)
 	var expected []keybase1.EkGeneration
 	expected = nil
 	require.Equal(t, expected, expired)
@@ -163,7 +163,7 @@ func TestUserEKBoxStorageDeleteExpiredKeys(t *testing.T) {
 	keyMap := keyExpiryMap{
 		0: keybase1.ToTime(now),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = nil
 	require.Equal(t, expected, expired)
 
@@ -171,7 +171,7 @@ func TestUserEKBoxStorageDeleteExpiredKeys(t *testing.T) {
 	keyMap = keyExpiryMap{
 		0: keybase1.ToTime(now.Add(-libkb.MaxEphemeralKeyStaleness)),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = nil
 	require.Equal(t, expected, expired)
 
@@ -179,7 +179,7 @@ func TestUserEKBoxStorageDeleteExpiredKeys(t *testing.T) {
 	keyMap = keyExpiryMap{
 		0: keybase1.ToTime(now.Add(-(libkb.MaxEphemeralKeyStaleness + libkb.MinEphemeralKeyLifetime))),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = []keybase1.EkGeneration{0}
 	require.Equal(t, expected, expired)
 
@@ -188,12 +188,12 @@ func TestUserEKBoxStorageDeleteExpiredKeys(t *testing.T) {
 		0: keybase1.ToTime(now.Add(-(libkb.MaxEphemeralKeyStaleness + libkb.MinEphemeralKeyLifetime))),
 		1: keybase1.ToTime(now.Add(-(libkb.MinEphemeralKeyLifetime))),
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = []keybase1.EkGeneration{0}
 	require.Equal(t, expected, expired)
 
 	// edge of deletion
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now.Add(-time.Second))
+	expired = s.getExpiredGenerations(mctx, keyMap, now.Add(-time.Second))
 	expected = nil
 	require.Equal(t, expected, expired)
 
@@ -203,7 +203,7 @@ func TestUserEKBoxStorageDeleteExpiredKeys(t *testing.T) {
 	for i := 0; i < numKeys; i++ {
 		keyMap[keybase1.EkGeneration((numKeys - i - 1))] = keybase1.ToTime(now.Add(-libkb.MaxEphemeralKeyStaleness * time.Duration(i)))
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = []keybase1.EkGeneration{0, 1, 2}
 	require.Equal(t, expected, expired)
 
@@ -217,7 +217,7 @@ func TestUserEKBoxStorageDeleteExpiredKeys(t *testing.T) {
 		50: 1528724605000,
 		51: 1528811030000,
 	}
-	expired = s.getExpiredGenerations(context.Background(), keyMap, now)
+	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	expected = nil
 	require.Equal(t, expected, expired)
 }

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -1,7 +1,6 @@
 package ephemeral
 
 import (
-	"context"
 	"testing"
 
 	"github.com/keybase/client/go/engine"
@@ -11,18 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func publishAndVerifyUserEK(t *testing.T, tc libkb.TestContext, merkleRoot libkb.MerkleRoot, uid keybase1.UID) keybase1.EkGeneration {
+func publishAndVerifyUserEK(mctx libkb.MetaContext, t *testing.T,
+	merkleRoot libkb.MerkleRoot, uid keybase1.UID) keybase1.EkGeneration {
 
-	publishedMetadata, err := publishNewUserEK(context.Background(), tc.G, merkleRoot)
+	publishedMetadata, err := publishNewUserEK(mctx, merkleRoot)
 	require.NoError(t, err)
 
-	s := tc.G.GetUserEKBoxStorage()
-	userEK, err := s.Get(context.Background(), publishedMetadata.Generation, nil)
+	s := mctx.G().GetUserEKBoxStorage()
+	userEK, err := s.Get(mctx, publishedMetadata.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, userEK.Metadata, publishedMetadata)
 
 	uids := []keybase1.UID{uid}
-	statements, err := fetchUserEKStatements(context.Background(), tc.G, uids)
+	statements, err := fetchUserEKStatements(mctx, uids)
 	require.NoError(t, err)
 	statement, ok := statements[uid]
 	require.True(t, ok)
@@ -31,35 +31,34 @@ func publishAndVerifyUserEK(t *testing.T, tc libkb.TestContext, merkleRoot libkb
 	require.Equal(t, currentMetadata, publishedMetadata)
 
 	// We've stored the result in local storage
-	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
-	maxGeneration, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
+	userEKBoxStorage := mctx.G().GetUserEKBoxStorage()
+	maxGeneration, err := userEKBoxStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)
-	ek, err := userEKBoxStorage.Get(context.Background(), maxGeneration, nil)
+	ek, err := userEKBoxStorage.Get(mctx, maxGeneration, nil)
 	require.NoError(t, err)
 	require.Equal(t, ek.Metadata, publishedMetadata)
 	return maxGeneration
 }
 
 func TestNewUserEK(t *testing.T) {
-	tc, user := ephemeralKeyTestSetup(t)
+	tc, mctx, user := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
-	m := libkb.NewMetaContextForTest(tc)
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
 	uid := tc.G.Env.GetUID()
-	maxGeneration := publishAndVerifyUserEK(t, tc, merkleRoot, uid)
+	maxGeneration := publishAndVerifyUserEK(mctx, t, merkleRoot, uid)
 
-	rawStorage := NewUserEKBoxStorage(tc.G)
+	rawStorage := NewUserEKBoxStorage()
 	// Put our storage in a bad state by deleting the maxGeneration
-	err = rawStorage.Delete(context.Background(), maxGeneration)
+	err = rawStorage.Delete(mctx, maxGeneration)
 	require.NoError(t, err)
 
 	// If we publish in a bad local state, we can successfully get the
 	// maxGeneration from the server and continue
-	publishedMetadata2, err := publishNewUserEK(context.Background(), tc.G, merkleRoot)
+	publishedMetadata2, err := publishNewUserEK(mctx, merkleRoot)
 	require.NoError(t, err)
 	require.EqualValues(t, maxGeneration+1, publishedMetadata2.Generation)
 
@@ -68,7 +67,7 @@ func TestNewUserEK(t *testing.T) {
 	err = user.Login(tc.G)
 	require.NoError(t, err)
 
-	publishAndVerifyUserEK(t, tc, merkleRoot, uid)
+	publishAndVerifyUserEK(mctx, t, merkleRoot, uid)
 }
 
 // TODO: test cases chat verify we can detect invalid signatures and bad metadata
@@ -87,7 +86,8 @@ func TestDeviceRevokeNoNewUserEK(t *testing.T) {
 func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 	tc := libkb.SetupTest(t, "testDeviceRevoke", 2)
 	defer tc.Cleanup()
-	NewEphemeralStorageAndInstall(tc.G)
+	mctx := libkb.NewMetaContextForTest(tc)
+	NewEphemeralStorageAndInstall(mctx)
 
 	// Include a paper key with this test user, so that we have something to
 	// revoke.
@@ -97,7 +97,7 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 	// Confirm that the user has a userEK.
 	uid := tc.G.Env.GetUID()
 	uids := []keybase1.UID{uid}
-	statements, err := fetchUserEKStatements(context.Background(), tc.G, uids)
+	statements, err := fetchUserEKStatements(mctx, uids)
 	require.NoError(t, err)
 	statement, ok := statements[uid]
 	require.True(t, ok)
@@ -120,24 +120,24 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: user.NewSecretUI(),
 	}
-	m := libkb.NewMetaContextForTest(tc).WithUIs(uis)
-	err = engine.RunEngine2(m, revokeEngine)
+	mctx = mctx.WithUIs(uis)
+	err = engine.RunEngine2(mctx, revokeEngine)
 	require.NoError(t, err)
 
 	// Finally, confirm that the revocation above rolled a new userEK.
 	if !skipUserEKForTesting {
-		statements, err = fetchUserEKStatements(context.Background(), tc.G, uids)
+		statements, err = fetchUserEKStatements(mctx, uids)
 		require.NoError(t, err)
 		statement, ok = statements[uid]
 		require.True(t, ok)
 		require.EqualValues(t, statement.CurrentUserEkMetadata.Generation, 2, "after revoke, should have userEK gen 2")
-		userEK, err := tc.G.GetUserEKBoxStorage().Get(context.Background(), 2, nil)
+		userEK, err := tc.G.GetUserEKBoxStorage().Get(mctx, 2, nil)
 		require.NoError(t, err)
 		require.Equal(t, statement.CurrentUserEkMetadata, userEK.Metadata)
 	}
 
 	// Confirm that we can make a new userEK after rolling the PUK
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 	lib := tc.G.GetEKLib()
@@ -145,20 +145,20 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 	require.True(t, ok)
 	// disable background keygen
 	ekLib.Shutdown()
-	needed, err := ekLib.NewUserEKNeeded(context.Background())
+	needed, err := ekLib.NewUserEKNeeded(mctx)
 	require.NoError(t, err)
 	require.Equal(t, skipUserEKForTesting, needed)
-	publishAndVerifyUserEK(t, tc, merkleRoot, uid)
+	publishAndVerifyUserEK(mctx, t, merkleRoot, uid)
 }
 
 func TestPukRollNewUserEK(t *testing.T) {
-	tc, user := ephemeralKeyTestSetup(t)
+	tc, mctx, user := ephemeralKeyTestSetup(t)
 	defer tc.Cleanup()
 
 	// Confirm that the user has a userEK.
 	uid := tc.G.Env.GetUID()
 	uids := []keybase1.UID{uid}
-	statements, err := fetchUserEKStatements(context.Background(), tc.G, uids)
+	statements, err := fetchUserEKStatements(mctx, uids)
 	require.NoError(t, err)
 	firstStatement, ok := statements[uid]
 	require.True(t, ok)
@@ -170,23 +170,23 @@ func TestPukRollNewUserEK(t *testing.T) {
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: user.NewSecretUI(),
 	}
-	m := libkb.NewMetaContextForTest(tc).WithUIs(uis)
-	err = engine.RunEngine2(m, rollEngine)
+	mctx = mctx.WithUIs(uis)
+	err = engine.RunEngine2(mctx, rollEngine)
 	require.NoError(t, err)
 
 	// Finally, confirm that the roll above also rolled a new userEK.
-	statements, err = fetchUserEKStatements(context.Background(), tc.G, uids)
+	statements, err = fetchUserEKStatements(mctx, uids)
 	require.NoError(t, err)
 	secondStatement, ok := statements[uid]
 	require.True(t, ok)
 	require.EqualValues(t, secondStatement.CurrentUserEkMetadata.Generation, 2, "after PUK roll, should have userEK gen 2")
-	userEK, err := tc.G.GetUserEKBoxStorage().Get(context.Background(), 2, nil)
+	userEK, err := tc.G.GetUserEKBoxStorage().Get(mctx, 2, nil)
 	require.NoError(t, err)
 	require.Equal(t, secondStatement.CurrentUserEkMetadata, userEK.Metadata)
 
 	// Confirm that we can make a new userEK after rolling the PUK
-	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(m, libkb.EphemeralKeyMerkleFreshness)
+	merkleRootPtr, err := tc.G.GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
-	publishAndVerifyUserEK(t, tc, merkleRoot, uid)
+	publishAndVerifyUserEK(mctx, t, merkleRoot, uid)
 }

--- a/go/erasablekv/disable_backup_darwin.go
+++ b/go/erasablekv/disable_backup_darwin.go
@@ -7,19 +7,18 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/pkg/xattr"
-	"golang.org/x/net/context"
 )
 
 const noBackup = "com.apple.metadata:com_apple_backup_excludeItem com.apple.backupd"
 
-func SetDisableBackup(ctx context.Context, g *libkb.GlobalContext, name string) error {
+func SetDisableBackup(mctx libkb.MetaContext, name string) error {
 	path := filepath.Dir(name)
 	filename := filepath.Base(name)
 	// CrashPlan respects this metadata flag as does TimeMachine.
 	// https://support.crashplan.com/Troubleshooting/CrashPlan_And_OS_X_Metadata
 	err := xattr.Set(path, filename, []byte(noBackup))
 	if err != nil {
-		g.Log.CDebugf(ctx, "Unable to write xattr %s", filepath.Join(path, filename))
+		mctx.Debug("Unable to write xattr %s", filepath.Join(path, filename))
 	}
 	return err
 }

--- a/go/erasablekv/disable_backup_darwin_test.go
+++ b/go/erasablekv/disable_backup_darwin_test.go
@@ -3,7 +3,6 @@
 package erasablekv
 
 import (
-	"context"
 	"testing"
 
 	"github.com/keybase/client/go/kbtest"
@@ -15,19 +14,20 @@ import (
 func TestSetDisableBackup(t *testing.T) {
 	tc := libkb.SetupTest(t, "erasable kv store disable backup", 1)
 	defer tc.Cleanup()
+	mctx := libkb.NewMetaContextForTest(tc)
 
 	_, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
 	require.NoError(t, err)
 
 	subDir := ""
-	s := NewFileErasableKVStore(tc.G, subDir)
+	s := NewFileErasableKVStore(mctx, subDir)
 	key := "test-key"
 	value := "value"
 
-	err = s.Put(context.Background(), key, value)
+	err = s.Put(mctx, key, value)
 	require.NoError(t, err)
 
-	storageDir := getStorageDir(tc.G, subDir)
+	storageDir := getStorageDir(mctx, subDir)
 	// Check that we set noBackup on the key
 	metadata, err := xattr.Get(storageDir, key)
 	require.NoError(t, err)

--- a/go/erasablekv/disable_backup_default.go
+++ b/go/erasablekv/disable_backup_default.go
@@ -4,9 +4,8 @@ package erasablekv
 
 import (
 	"github.com/keybase/client/go/libkb"
-	"golang.org/x/net/context"
 )
 
-func SetDisableBackup(ctx context.Context, g *libkb.GlobalContext, name string) error {
+func SetDisableBackup(mctx libkb.MetaContext, name string) error {
 	return nil
 }

--- a/go/erasablekv/erasable_kv_store_test.go
+++ b/go/erasablekv/erasable_kv_store_test.go
@@ -9,25 +9,25 @@ import (
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestErasableKVStore(t *testing.T) {
 	tc := libkb.SetupTest(t, "erasablekv store encryption", 1)
 	defer tc.Cleanup()
+	mctx := libkb.NewMetaContextForTest(tc)
 
 	_, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
 	require.NoError(t, err)
 
 	subDir := ""
-	s := NewFileErasableKVStore(tc.G, subDir)
+	s := NewFileErasableKVStore(mctx, subDir)
 	key := "test-key.key"
 	expected := "value"
-	err = s.Put(context.Background(), key, expected)
+	err = s.Put(mctx, key, expected)
 	require.NoError(t, err)
 
 	var val string
-	err = s.Get(context.Background(), key, &val)
+	err = s.Get(mctx, key, &val)
 	require.NoError(t, err)
 	require.Equal(t, expected, val)
 
@@ -36,7 +36,7 @@ func TestErasableKVStore(t *testing.T) {
 	tmp, err := ioutil.TempFile(s.storageDir, key)
 	require.NoError(t, err)
 	for i := 0; i < 5; i++ {
-		keys, err := s.AllKeys(context.Background(), ".key")
+		keys, err := s.AllKeys(mctx, ".key")
 		require.NoError(t, err)
 		require.Equal(t, []string{key}, keys)
 		exists, err := libkb.FileExists(tmp.Name())
@@ -48,7 +48,7 @@ func TestErasableKVStore(t *testing.T) {
 
 	// Test noise file corruption
 	noiseName := fmt.Sprintf("%s%s", key, noiseSuffix)
-	storageDir := getStorageDir(tc.G, subDir)
+	storageDir := getStorageDir(mctx, subDir)
 	noiseFilePath := filepath.Join(storageDir, noiseName)
 	noise, err := ioutil.ReadFile(noiseFilePath)
 	require.NoError(t, err)
@@ -62,17 +62,17 @@ func TestErasableKVStore(t *testing.T) {
 	require.NoError(t, err)
 
 	var corrupt string
-	err = s.Get(context.Background(), key, &corrupt)
+	err = s.Get(mctx, key, &corrupt)
 	require.Error(t, err)
 	uerr, ok := err.(UnboxError)
 	require.True(t, ok)
 	require.Equal(t, fmt.Sprintf("ErasableKVStore UnboxError: secretbox.Open failure. Stored noise hash: %x, current noise hash: %x, equal: %v", s.noiseHash(noise), s.noiseHash(corruptedNoise), false), uerr.Error())
 	require.NotEqual(t, expected, corrupt)
 
-	err = s.Erase(context.Background(), key)
+	err = s.Erase(mctx, key)
 	require.NoError(t, err)
 
-	keys, err := s.AllKeys(context.Background(), ".key")
+	keys, err := s.AllKeys(mctx, ".key")
 	require.NoError(t, err)
 	require.Equal(t, []string(nil), keys)
 }

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -289,14 +289,14 @@ func (m *TlfMock) DecryptionKey(ctx context.Context, tlfName string, tlfID chat1
 	return nil, errors.New("no mock key found")
 }
 
-func (m *TlfMock) EphemeralEncryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (m *TlfMock) EphemeralEncryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool) (keybase1.TeamEk, error) {
 	// Returns a totally zero teamEK. That's enough to get some very simple
 	// round trip tests to pass.
 	return keybase1.TeamEk{}, nil
 }
 
-func (m *TlfMock) EphemeralDecryptionKey(ctx context.Context, tlfName string, tlfID chat1.TLFID,
+func (m *TlfMock) EphemeralDecryptionKey(mctx libkb.MetaContext, tlfName string, tlfID chat1.TLFID,
 	membersType chat1.ConversationMembersType, public bool,
 	generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error) {
 	// Returns a totally zero teamEK. That's enough to get some very simple

--- a/go/libkb/deprovision.go
+++ b/go/libkb/deprovision.go
@@ -3,7 +3,7 @@ package libkb
 // XXX: THIS DELETES SECRET KEYS. Deleting the wrong secret keys can make you
 // lose all your data forever. We only run this in the DeprovisionEngine and if
 // we detect that our device was revoked in LogoutAndDeprovisionIfRevoked.
-func ClearSecretsOnDeprovision(m MetaContext, username NormalizedUsername) error {
+func ClearSecretsOnDeprovision(mctx MetaContext, username NormalizedUsername) error {
 	// 1. Delete all the user's secret keys!!!
 	// 2. Delete the user's ephemeralKeys
 	// 3. Delete the user from the config file.
@@ -12,39 +12,39 @@ func ClearSecretsOnDeprovision(m MetaContext, username NormalizedUsername) error
 	epick := FirstErrorPicker{}
 
 	var logger func(string, ...interface{})
-	if m.UIs().LogUI == nil {
-		logger = m.Info
+	if mctx.UIs().LogUI == nil {
+		logger = mctx.Info
 	} else {
-		logger = m.UIs().LogUI.Info
+		logger = mctx.UIs().LogUI.Info
 	}
 
-	if clearSecretErr := ClearStoredSecret(m, username); clearSecretErr != nil {
-		m.Warning("ClearStoredSecret error: %s", clearSecretErr)
+	if clearSecretErr := ClearStoredSecret(mctx, username); clearSecretErr != nil {
+		mctx.Warning("ClearStoredSecret error: %s", clearSecretErr)
 	}
 
 	// XXX: Delete the user's secret keyring. It's very important that we never
 	// do this to the wrong user. Please do not copy this code :)
 	logger("Deleting %s's secret keys file...", username.String())
-	filename := m.G().SKBFilenameForUser(username)
+	filename := mctx.G().SKBFilenameForUser(username)
 	epick.Push(ShredFile(filename))
 
 	logger("Deleting %s's ephemeralKeys...", username.String())
 	// NOTE: We only store userEK/teamEK boxes locally and these are removed in
 	// the LocalDb.Nuke() below so we just delete any deviceEKs here.
-	deviceEKStorage := m.G().GetDeviceEKStorage()
+	deviceEKStorage := mctx.G().GetDeviceEKStorage()
 	if deviceEKStorage != nil {
-		epick.Push(deviceEKStorage.ForceDeleteAll(m.Ctx(), username))
+		epick.Push(deviceEKStorage.ForceDeleteAll(mctx, username))
 	}
 
 	logger("Deleting %s from config.json...", username.String())
-	epick.Push(m.SwitchUserDeprovisionNukeConfig(username))
+	epick.Push(mctx.SwitchUserDeprovisionNukeConfig(username))
 
 	logger("Clearing the local cache db...")
-	_, err := m.G().LocalDb.Nuke()
+	_, err := mctx.G().LocalDb.Nuke()
 	epick.Push(err)
 
 	logger("Clearing the local cache chat db...")
-	_, err = m.G().LocalChatDb.Nuke()
+	_, err = mctx.G().LocalChatDb.Nuke()
 	epick.Push(err)
 
 	logger("Deprovision finished.")

--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -16,7 +16,7 @@ type FullSelfer interface {
 	HandleUserChanged(u keybase1.UID) error
 	Update(ctx context.Context, u *User) error
 	New() FullSelfer
-	OnLogin() error
+	OnLogin(mctx MetaContext) error
 }
 
 type UncachedFullSelf struct {
@@ -44,7 +44,7 @@ func (n *UncachedFullSelf) WithUser(arg LoadUserArg, f func(u *User) error) erro
 }
 
 func (n *UncachedFullSelf) HandleUserChanged(u keybase1.UID) error    { return nil }
-func (n *UncachedFullSelf) OnLogin() error                            { return nil }
+func (n *UncachedFullSelf) OnLogin(mctx MetaContext) error            { return nil }
 func (n *UncachedFullSelf) Update(ctx context.Context, u *User) error { return nil }
 
 func (n *UncachedFullSelf) New() FullSelfer { return NewUncachedFullSelf(n.G()) }
@@ -261,7 +261,7 @@ func (m *CachedFullSelf) HandleUserChanged(u keybase1.UID) error {
 }
 
 // OnLogin clears the cached self user if it differs from what's already cached.
-func (m *CachedFullSelf) OnLogin() error {
+func (m *CachedFullSelf) OnLogin(mctx MetaContext) error {
 	m.Lock()
 	defer m.Unlock()
 	if m.me != nil && !m.me.GetUID().Equal(m.G().GetMyUID()) {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -34,11 +34,11 @@ import (
 type ShutdownHook func() error
 
 type LoginHook interface {
-	OnLogin() error
+	OnLogin(mctx MetaContext) error
 }
 
 type LogoutHook interface {
-	OnLogout(m MetaContext) error
+	OnLogout(mctx MetaContext) error
 }
 
 type StandaloneChatConnector interface {
@@ -963,18 +963,19 @@ func (g *GlobalContext) AddLoginHook(hook LoginHook) {
 }
 
 func (g *GlobalContext) CallLoginHooks() {
+	mctx := NewMetaContextTODO(g)
 	g.Log.Debug("G#CallLoginHooks")
 
 	// Trigger the creation of a per-user-keyring
 	_, _ = g.GetPerUserKeyring(context.TODO())
 
 	// Do so outside the lock below
-	g.GetFullSelfer().OnLogin()
+	g.GetFullSelfer().OnLogin(mctx)
 
 	g.hookMu.RLock()
 	defer g.hookMu.RUnlock()
 	for _, h := range g.loginHooks {
-		if err := h.OnLogin(); err != nil {
+		if err := h.OnLogin(mctx); err != nil {
 			g.Log.Warning("OnLogin hook error: %s", err)
 		}
 	}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -733,54 +733,54 @@ type Stellar interface {
 }
 
 type DeviceEKStorage interface {
-	Put(ctx context.Context, generation keybase1.EkGeneration, deviceEK keybase1.DeviceEk) error
-	Get(ctx context.Context, generation keybase1.EkGeneration) (keybase1.DeviceEk, error)
-	GetAllActive(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.DeviceEkMetadata, error)
-	MaxGeneration(ctx context.Context, includeErrs bool) (keybase1.EkGeneration, error)
-	DeleteExpired(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
+	Put(mctx MetaContext, generation keybase1.EkGeneration, deviceEK keybase1.DeviceEk) error
+	Get(mctx MetaContext, generation keybase1.EkGeneration) (keybase1.DeviceEk, error)
+	GetAllActive(mctx MetaContext, merkleRoot MerkleRoot) ([]keybase1.DeviceEkMetadata, error)
+	MaxGeneration(mctx MetaContext, includeErrs bool) (keybase1.EkGeneration, error)
+	DeleteExpired(mctx MetaContext, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	ClearCache()
 	// Dangerous! Only for deprovisioning.
-	ForceDeleteAll(ctx context.Context, username NormalizedUsername) error
+	ForceDeleteAll(mctx MetaContext, username NormalizedUsername) error
 	// For keybase log send
-	ListAllForUser(ctx context.Context) ([]string, error)
+	ListAllForUser(mctx MetaContext) ([]string, error)
 	// Called on login/logout hooks to set the logged in username in the EK log
-	SetLogPrefix()
+	SetLogPrefix(mctx MetaContext)
 }
 
 type UserEKBoxStorage interface {
-	Put(ctx context.Context, generation keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) error
-	Get(ctx context.Context, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.UserEk, error)
-	MaxGeneration(ctx context.Context, includeErrs bool) (keybase1.EkGeneration, error)
-	DeleteExpired(ctx context.Context, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
+	Put(mctx MetaContext, generation keybase1.EkGeneration, userEKBoxed keybase1.UserEkBoxed) error
+	Get(mctx MetaContext, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.UserEk, error)
+	MaxGeneration(mctx MetaContext, includeErrs bool) (keybase1.EkGeneration, error)
+	DeleteExpired(mctx MetaContext, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	ClearCache()
 }
 
 type TeamEKBoxStorage interface {
-	Put(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) error
-	Get(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
-	MaxGeneration(ctx context.Context, teamID keybase1.TeamID, includeErrs bool) (keybase1.EkGeneration, error)
-	DeleteExpired(ctx context.Context, teamID keybase1.TeamID, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
-	PurgeCacheForTeamID(ctx context.Context, teamID keybase1.TeamID) error
-	Delete(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration) error
+	Put(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) error
+	Get(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
+	MaxGeneration(mctx MetaContext, teamID keybase1.TeamID, includeErrs bool) (keybase1.EkGeneration, error)
+	DeleteExpired(mctx MetaContext, teamID keybase1.TeamID, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
+	PurgeCacheForTeamID(mctx MetaContext, teamID keybase1.TeamID) error
+	Delete(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) error
 	ClearCache()
 }
 
 type EKLib interface {
-	KeygenIfNeeded(ctx context.Context) error
-	GetOrCreateLatestTeamEK(ctx context.Context, teamID keybase1.TeamID) (keybase1.TeamEk, bool, error)
-	GetTeamEK(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
-	PurgeCachesForTeamIDAndGeneration(ctx context.Context, teamID keybase1.TeamID, generation keybase1.EkGeneration)
-	PurgeCachesForTeamID(ctx context.Context, teamID keybase1.TeamID)
+	KeygenIfNeeded(mctx MetaContext) error
+	GetOrCreateLatestTeamEK(mctx MetaContext, teamID keybase1.TeamID) (keybase1.TeamEk, bool, error)
+	GetTeamEK(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
+	PurgeCachesForTeamIDAndGeneration(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration)
+	PurgeCachesForTeamID(mctx MetaContext, teamID keybase1.TeamID)
 	NewEphemeralSeed() (keybase1.Bytes32, error)
 	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair
-	SignedDeviceEKStatementFromSeed(ctx context.Context, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey) (keybase1.DeviceEkStatement, string, error)
-	BoxLatestUserEK(ctx context.Context, receiverKey NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (*keybase1.UserEkBoxed, error)
-	PrepareNewUserEK(ctx context.Context, merkleRoot MerkleRoot, pukSeed PerUserKeySeed) (string, []keybase1.UserEkBoxMetadata, keybase1.UserEkMetadata, *keybase1.UserEkBoxed, error)
-	BoxLatestTeamEK(ctx context.Context, teamID keybase1.TeamID, uids []keybase1.UID) (*[]keybase1.TeamEkBoxMetadata, error)
-	PrepareNewTeamEK(ctx context.Context, teamID keybase1.TeamID, signingKey NaclSigningKeyPair, uids []keybase1.UID) (string, *[]keybase1.TeamEkBoxMetadata, keybase1.TeamEkMetadata, *keybase1.TeamEkBoxed, error)
-	ClearCaches()
+	SignedDeviceEKStatementFromSeed(mctx MetaContext, generation keybase1.EkGeneration, seed keybase1.Bytes32, signingKey GenericKey) (keybase1.DeviceEkStatement, string, error)
+	BoxLatestUserEK(mctx MetaContext, receiverKey NaclDHKeyPair, deviceEKGeneration keybase1.EkGeneration) (*keybase1.UserEkBoxed, error)
+	PrepareNewUserEK(mctx MetaContext, merkleRoot MerkleRoot, pukSeed PerUserKeySeed) (string, []keybase1.UserEkBoxMetadata, keybase1.UserEkMetadata, *keybase1.UserEkBoxed, error)
+	BoxLatestTeamEK(mctx MetaContext, teamID keybase1.TeamID, uids []keybase1.UID) (*[]keybase1.TeamEkBoxMetadata, error)
+	PrepareNewTeamEK(mctx MetaContext, teamID keybase1.TeamID, signingKey NaclSigningKeyPair, uids []keybase1.UID) (string, *[]keybase1.TeamEkBoxMetadata, keybase1.TeamEkMetadata, *keybase1.TeamEkBoxed, error)
+	ClearCaches(mctx MetaContext)
 	// For testing
-	NewTeamEKNeeded(ctx context.Context, teamID keybase1.TeamID) (bool, error)
+	NewTeamEKNeeded(mctx MetaContext, teamID keybase1.TeamID) (bool, error)
 }
 
 type ImplicitTeamConflictInfoCacher interface {

--- a/go/service/ctl.go
+++ b/go/service/ctl.go
@@ -75,7 +75,7 @@ func (c *CtlHandler) DbNuke(ctx context.Context, sessionID int) error {
 		teamLoader.ClearMem()
 	}
 	if ekLib := c.G().GetEKLib(); ekLib != nil {
-		ekLib.ClearCaches()
+		ekLib.ClearCaches(c.MetaContext(ctx))
 	}
 	// Now drop caches, since we had the DB's state in-memory too.
 	c.G().FlushCaches()

--- a/go/service/ephemeral_handler.go
+++ b/go/service/ephemeral_handler.go
@@ -63,7 +63,7 @@ func (r *ekHandler) newTeamEK(ctx context.Context, cli gregor1.IncomingInterface
 	}
 	r.G().Log.CDebugf(ctx, "ephemeral.new_team_ek unmarshaled: %+v", msg)
 
-	if err := ephemeral.HandleNewTeamEK(ctx, r.G(), msg.Id, msg.Generation); err != nil {
+	if err := ephemeral.HandleNewTeamEK(r.MetaContext(ctx), msg.Id, msg.Generation); err != nil {
 		return err
 	}
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -324,7 +324,7 @@ func (d *Service) SetupCriticalSubServices() error {
 	stellar.ServiceInit(d.G(), d.walletState, d.badger)
 	pvl.NewPvlSourceAndInstall(d.G())
 	externals.NewParamProofStoreAndInstall(d.G())
-	ephemeral.ServiceInit(d.G())
+	ephemeral.ServiceInit(d.MetaContext(context.TODO()))
 	avatars.ServiceInit(d.G(), d.avatarLoader)
 	return nil
 }
@@ -850,7 +850,7 @@ func (d *Service) runBackgroundWalletUpkeep() {
 	})
 }
 
-func (d *Service) OnLogin() error {
+func (d *Service) OnLogin(mctx libkb.MetaContext) error {
 	d.rekeyMaster.Login()
 	if err := d.gregordConnect(); err != nil {
 		return err

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-	context "golang.org/x/net/context"
 )
 
 func TestEphemeralNewTeamEKNotif(t *testing.T) {
@@ -18,14 +17,15 @@ func TestEphemeralNewTeamEKNotif(t *testing.T) {
 
 	user1 := tt.addUser("one")
 	user2 := tt.addUser("wtr")
+	mctx := libkb.NewMetaContextForTest(*user1.tc)
 
 	teamID, teamName := user1.createTeam2()
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 
-	ephemeral.ServiceInit(user1.tc.G)
+	ephemeral.ServiceInit(mctx)
 	ekLib := user1.tc.G.GetEKLib()
 
-	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(mctx, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
 
@@ -58,8 +58,8 @@ func TestEphemeralAddMemberNoTeamEK(t *testing.T) {
 	runAddMember(t, false /* createTeamEK*/)
 }
 
-func getTeamEK(g *libkb.GlobalContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
-	return g.GetTeamEKBoxStorage().Get(context.Background(), teamID, generation, nil)
+func getTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (keybase1.TeamEk, error) {
+	return mctx.G().GetTeamEKBoxStorage().Get(mctx, teamID, generation, nil)
 }
 
 func runAddMember(t *testing.T, createTeamEK bool) {
@@ -71,10 +71,10 @@ func runAddMember(t *testing.T, createTeamEK bool) {
 	bob := ctx.installKeybaseForUser("bob", 10)
 	bob.signup()
 
-	annG := ann.getPrimaryGlobalContext()
-	ephemeral.ServiceInit(annG)
-	bobG := bob.getPrimaryGlobalContext()
-	ephemeral.ServiceInit(bobG)
+	annMctx := ann.MetaContext()
+	ephemeral.ServiceInit(annMctx)
+	bobMctx := bob.MetaContext()
+	ephemeral.ServiceInit(bobMctx)
 
 	team := ann.createTeam([]*smuUser{})
 	teamName, err := keybase1.TeamNameFromString(team.name)
@@ -84,8 +84,8 @@ func runAddMember(t *testing.T, createTeamEK bool) {
 	var expectedMetadata keybase1.TeamEkMetadata
 	var expectedGeneration keybase1.EkGeneration
 	if createTeamEK {
-		ekLib := annG.GetEKLib()
-		teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+		ekLib := annMctx.G().GetEKLib()
+		teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(annMctx, teamID)
 		require.NoError(t, err)
 		require.True(t, created)
 
@@ -98,8 +98,8 @@ func runAddMember(t *testing.T, createTeamEK bool) {
 
 	ann.addWriter(team, bob)
 
-	annTeamEK, annErr := getTeamEK(annG, teamID, expectedGeneration)
-	bobTeamEK, bobErr := getTeamEK(bobG, teamID, expectedGeneration)
+	annTeamEK, annErr := getTeamEK(annMctx, teamID, expectedGeneration)
+	bobTeamEK, bobErr := getTeamEK(bobMctx, teamID, expectedGeneration)
 	if createTeamEK {
 		require.NoError(t, annErr)
 		require.NoError(t, bobErr)
@@ -129,12 +129,12 @@ func TestEphemeralResetMember(t *testing.T) {
 	joe := ctx.installKeybaseForUser("joe", 10)
 	joe.signup()
 
-	annG := ann.getPrimaryGlobalContext()
-	ephemeral.ServiceInit(annG)
-	bobG := bob.getPrimaryGlobalContext()
-	ephemeral.ServiceInit(bobG)
-	joeG := joe.getPrimaryGlobalContext()
-	ephemeral.ServiceInit(joeG)
+	annMctx := ann.MetaContext()
+	ephemeral.ServiceInit(annMctx)
+	bobMctx := bob.MetaContext()
+	ephemeral.ServiceInit(bobMctx)
+	joeMctx := joe.MetaContext()
+	ephemeral.ServiceInit(joeMctx)
 
 	team := ann.createTeam([]*smuUser{bob})
 	teamName, err := keybase1.TeamNameFromString(team.name)
@@ -144,23 +144,23 @@ func TestEphemeralResetMember(t *testing.T) {
 	// Reset bob, invaliding any userEK he has.
 	bob.reset()
 
-	annEkLib := annG.GetEKLib()
-	teamEK, created, err := annEkLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	annEkLib := annMctx.G().GetEKLib()
+	teamEK, created, err := annEkLib.GetOrCreateLatestTeamEK(annMctx, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
 
 	expectedMetadata := teamEK.Metadata
 	expectedGeneration := expectedMetadata.Generation
 
-	annTeamEK, annErr := getTeamEK(annG, teamID, expectedGeneration)
+	annTeamEK, annErr := getTeamEK(annMctx, teamID, expectedGeneration)
 	require.Equal(t, annTeamEK.Metadata, expectedMetadata)
 	require.NoError(t, annErr)
 
 	// Bob should not have access to this teamEK since he's no longer in the
 	// team after resetting.
 	bob.loginAfterReset(10)
-	bobG = bob.getPrimaryGlobalContext()
-	bobTeamEK, bobErr := getTeamEK(bobG, teamID, expectedGeneration)
+	bobMctx = bob.MetaContext()
+	bobTeamEK, bobErr := getTeamEK(bobMctx, teamID, expectedGeneration)
 	require.Error(t, bobErr)
 	require.IsType(t, libkb.AppStatusError{}, bobErr)
 	appStatusErr := bobErr.(libkb.AppStatusError)
@@ -171,7 +171,7 @@ func TestEphemeralResetMember(t *testing.T) {
 	ann.addWriter(team, joe)
 
 	// ann gets the new teamEk which joe can access but bob cannot after he reset.
-	teamEK2, created, err := annEkLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	teamEK2, created, err := annEkLib.GetOrCreateLatestTeamEK(annMctx, teamID)
 	require.NoError(t, err)
 	require.False(t, created)
 
@@ -181,15 +181,15 @@ func TestEphemeralResetMember(t *testing.T) {
 	// previous, because there's a race where a CLKR sneaks in here.
 	require.True(t, expectedGeneration < expectedGeneration2)
 
-	annTeamEK, annErr = getTeamEK(annG, teamID, expectedGeneration2)
+	annTeamEK, annErr = getTeamEK(annMctx, teamID, expectedGeneration2)
 	require.Equal(t, annTeamEK.Metadata, expectedMetadata2)
 	require.NoError(t, annErr)
 
-	bobTeamEK, bobErr = getTeamEK(bobG, teamID, expectedGeneration2)
+	bobTeamEK, bobErr = getTeamEK(bobMctx, teamID, expectedGeneration2)
 	require.NoError(t, bobErr)
 	require.Equal(t, bobTeamEK.Metadata, expectedMetadata2)
 
-	joeTeamEk, joeErr := getTeamEK(joeG, teamID, expectedGeneration2)
+	joeTeamEk, joeErr := getTeamEK(joeMctx, teamID, expectedGeneration2)
 	require.NoError(t, joeErr)
 	require.Equal(t, joeTeamEk.Metadata, expectedMetadata2)
 }
@@ -209,18 +209,18 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	ann := tt.addUser("ann")
 	bob := tt.addUserWithPaper("bob")
 
-	annG := ann.tc.G
-	ephemeral.ServiceInit(annG)
-	bobG := bob.tc.G
-	ephemeral.ServiceInit(bobG)
+	annMctx := ann.MetaContext()
+	ephemeral.ServiceInit(annMctx)
+	bobMctx := bob.MetaContext()
+	ephemeral.ServiceInit(bobMctx)
 
 	teamID, teamName := ann.createTeam2()
 
 	// After rotate, we should have rolled the teamEK if one existed.
 	var expectedGeneration keybase1.EkGeneration
 	if createTeamEK {
-		ekLib := annG.GetEKLib()
-		teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+		ekLib := annMctx.G().GetEKLib()
+		teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(annMctx, teamID)
 		require.NoError(t, err)
 		require.True(t, created)
 		expectedGeneration = teamEK.Metadata.Generation + 1
@@ -233,8 +233,8 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	bob.revokePaperKey()
 	ann.waitForRotateByID(teamID, keybase1.Seqno(3))
 
-	storage := annG.GetTeamEKBoxStorage()
-	teamEK, err := storage.Get(context.Background(), teamID, expectedGeneration, nil)
+	storage := annMctx.G().GetTeamEKBoxStorage()
+	teamEK, err := storage.Get(annMctx, teamID, expectedGeneration, nil)
 	if createTeamEK {
 		require.NoError(t, err)
 	} else {
@@ -253,49 +253,49 @@ func TestEphemeralRotateSkipTeamEKRoll(t *testing.T) {
 	ann := tt.addUser("ann")
 	bob := tt.addUserWithPaper("bob")
 
-	annG := ann.tc.G
-	ephemeral.ServiceInit(annG)
-	bobG := bob.tc.G
-	ephemeral.ServiceInit(bobG)
+	annMctx := ann.MetaContext()
+	ephemeral.ServiceInit(annMctx)
+	bobMctx := bob.MetaContext()
+	ephemeral.ServiceInit(bobMctx)
 
 	teamID, teamName := ann.createTeam2()
 
 	// Get our ephemeral keys before the revoke and ensure we can still access
 	// them after.
-	ekLib := annG.GetEKLib()
-	teamEKPreRoll, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	ekLib := annMctx.G().GetEKLib()
+	teamEKPreRoll, created, err := ekLib.GetOrCreateLatestTeamEK(annMctx, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
 
 	// This is a hack to skip the teamEK generation during the PTK roll.
 	// We want to validate that we can create a new teamEK after this roll even
 	// though our existing teamEK is signed by a (now) invalid PTK
-	annG.SetEKLib(nil)
+	annMctx.G().SetEKLib(nil)
 
 	ann.addTeamMember(teamName.String(), bob.username, keybase1.TeamRole_WRITER)
 
 	bob.revokePaperKey()
 	ann.waitForRotateByID(teamID, keybase1.Seqno(3))
-	annG.SetEKLib(ekLib)
+	annMctx.G().SetEKLib(ekLib)
 
 	// Ensure that we access the old teamEK even though it was signed by a
 	// non-latest PTK
-	teamEKBoxStorage := annG.GetTeamEKBoxStorage()
+	teamEKBoxStorage := annMctx.G().GetTeamEKBoxStorage()
 	teamEKBoxStorage.ClearCache()
-	_, err = annG.LocalDb.Nuke() // Force us to refetch and verify the key from the server
+	_, err = annMctx.G().LocalDb.Nuke() // Force us to refetch and verify the key from the server
 	require.NoError(t, err)
-	teamEKPostRoll, err := teamEKBoxStorage.Get(context.Background(), teamID, teamEKPreRoll.Metadata.Generation, nil)
+	teamEKPostRoll, err := teamEKBoxStorage.Get(annMctx, teamID, teamEKPreRoll.Metadata.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, teamEKPreRoll, teamEKPostRoll)
 
 	// After rotating, ensure we can create a new TeamEK without issue.
-	needed, err := ekLib.NewTeamEKNeeded(context.Background(), teamID)
+	needed, err := ekLib.NewTeamEKNeeded(annMctx, teamID)
 	require.NoError(t, err)
 	require.True(t, needed)
 
-	merkleRoot, err := annG.GetMerkleClient().FetchRootFromServer(libkb.NewMetaContextForTest(*ann.tc), libkb.EphemeralKeyMerkleFreshness)
+	merkleRoot, err := annMctx.G().GetMerkleClient().FetchRootFromServer(libkb.NewMetaContextForTest(*ann.tc), libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
-	metadata, err := ephemeral.ForcePublishNewTeamEKForTesting(context.Background(), annG, teamID, *merkleRoot)
+	metadata, err := ephemeral.ForcePublishNewTeamEKForTesting(annMctx, teamID, *merkleRoot)
 	require.NoError(t, err)
 	require.Equal(t, teamEKPreRoll.Metadata.Generation+1, metadata.Generation)
 }
@@ -308,24 +308,24 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 
 	teamID, _ := ann.createTeam2()
 
-	annG := ann.tc.G
-	ephemeral.ServiceInit(annG)
-	ekLib := annG.GetEKLib()
+	annMctx := ann.MetaContext()
+	ephemeral.ServiceInit(annMctx)
+	ekLib := annMctx.G().GetEKLib()
 
-	_, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	_, created, err := ekLib.GetOrCreateLatestTeamEK(annMctx, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
-	userEKBoxStorage := annG.GetUserEKBoxStorage()
-	gen, err := userEKBoxStorage.MaxGeneration(context.Background(), false)
+	userEKBoxStorage := annMctx.G().GetUserEKBoxStorage()
+	gen, err := userEKBoxStorage.MaxGeneration(annMctx, false)
 	require.NoError(t, err)
-	userEKPreRevoke, err := userEKBoxStorage.Get(context.Background(), gen, nil)
+	userEKPreRevoke, err := userEKBoxStorage.Get(annMctx, gen, nil)
 	require.NoError(t, err)
 
 	// Provision a new device that we can revoke.
 	newDevice := ann.provisionNewDevice()
 
 	// Revoke it.
-	revokeEngine := engine.NewRevokeDeviceEngine(annG, engine.RevokeDeviceEngineArgs{
+	revokeEngine := engine.NewRevokeDeviceEngine(annMctx.G(), engine.RevokeDeviceEngineArgs{
 		ID:        newDevice.deviceKey.DeviceID,
 		ForceSelf: true,
 		ForceLast: false,
@@ -333,7 +333,7 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 		SkipUserEKForTesting: true,
 	})
 	uis := libkb.UIs{
-		LogUI:    annG.Log,
+		LogUI:    annMctx.G().Log,
 		SecretUI: ann.newSecretUI(),
 	}
 	m := libkb.NewMetaContextForTest(*ann.tc).WithUIs(uis)
@@ -343,21 +343,21 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 	// Ensure that we access the old userEKs even though it was signed by a
 	// non-latest PUK
 	userEKBoxStorage.ClearCache()
-	_, err = annG.LocalDb.Nuke() // Force us to refetch and verify the key from the server
+	_, err = annMctx.G().LocalDb.Nuke() // Force us to refetch and verify the key from the server
 	require.NoError(t, err)
-	userEKPostRevoke, err := userEKBoxStorage.Get(context.Background(), userEKPreRevoke.Metadata.Generation, nil)
+	userEKPostRevoke, err := userEKBoxStorage.Get(annMctx, userEKPreRevoke.Metadata.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, userEKPreRevoke, userEKPostRevoke)
 
 	// Now provision a new userEK. This makes sure that we don't get confused
 	// by the revoked device's deviceEKs.
-	merkleRoot, err := annG.GetMerkleClient().FetchRootFromServer(libkb.NewMetaContextForTest(*ann.tc), libkb.EphemeralKeyMerkleFreshness)
+	merkleRoot, err := annMctx.G().GetMerkleClient().FetchRootFromServer(annMctx, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
-	_, err = ephemeral.ForcePublishNewUserEKForTesting(context.Background(), annG, *merkleRoot)
+	_, err = ephemeral.ForcePublishNewUserEKForTesting(annMctx, *merkleRoot)
 	require.NoError(t, err)
 
 	// And do the same for the teamEK, just to be sure.
-	_, err = ephemeral.ForcePublishNewTeamEKForTesting(context.Background(), annG, teamID, *merkleRoot)
+	_, err = ephemeral.ForcePublishNewTeamEKForTesting(annMctx, teamID, *merkleRoot)
 	require.NoError(t, err)
 }
 
@@ -378,9 +378,10 @@ func readdToTeamWithEKs(t *testing.T, leave bool) {
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 	user2.waitForNewlyAddedToTeamByID(teamID)
 
-	ephemeral.ServiceInit(user1.tc.G)
-	ekLib := user1.tc.G.GetEKLib()
-	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(context.Background(), teamID)
+	mctx1 := user1.MetaContext()
+	ephemeral.ServiceInit(mctx1)
+	ekLib := mctx1.G().GetEKLib()
+	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(mctx1, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
 
@@ -395,7 +396,7 @@ func readdToTeamWithEKs(t *testing.T, leave bool) {
 	}
 
 	// After leaving user2 won't have access to the current teamEK
-	_, err = user2.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, currentGen, nil)
+	_, err = user2.tc.G.GetTeamEKBoxStorage().Get(user2.MetaContext(), teamID, currentGen, nil)
 	require.Error(t, err)
 	require.IsType(t, libkb.AppStatusError{}, err)
 	appStatusErr := err.(libkb.AppStatusError)
@@ -406,10 +407,10 @@ func readdToTeamWithEKs(t *testing.T, leave bool) {
 
 	// Test that user1 and user2 both have access to the currentTeamEK
 	// (whether we recreated or reboxed)
-	teamEK2U1, err := user1.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, expectedGen, nil)
+	teamEK2U1, err := user1.tc.G.GetTeamEKBoxStorage().Get(mctx1, teamID, expectedGen, nil)
 	require.NoError(t, err)
 
-	teamEK2U2, err := user2.tc.G.GetTeamEKBoxStorage().Get(context.Background(), teamID, expectedGen, nil)
+	teamEK2U2, err := user2.tc.G.GetTeamEKBoxStorage().Get(user2.MetaContext(), teamID, expectedGen, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, teamEK2U1, teamEK2U2)
@@ -433,42 +434,41 @@ func TestEphemeralAfterEKError(t *testing.T) {
 	})
 	teamID, teamName := user1.createTeam2()
 	g1 := user1.tc.G
-	ephemeral.ServiceInit(g1)
-	ctx := context.Background()
-	merkleRoot, err := g1.GetMerkleClient().FetchRootFromServer(libkb.NewMetaContextForTest(*user1.tc), libkb.EphemeralKeyMerkleFreshness)
+	mctx1 := user1.MetaContext()
+	ephemeral.ServiceInit(mctx1)
+	merkleRoot, err := g1.GetMerkleClient().FetchRootFromServer(mctx1, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	// Force two team EKs to be created and then create/add u2 to the team.
 	// They should not be able to access the first key since they were added
 	// after (they are reboxed for the second as part of the add
-	teamEKMetadata1, err := ephemeral.ForcePublishNewTeamEKForTesting(ctx, g1, teamID, *merkleRoot)
+	teamEKMetadata1, err := ephemeral.ForcePublishNewTeamEKForTesting(mctx1, teamID, *merkleRoot)
 	require.NoError(t, err)
-	teamEKMetadata2, err := ephemeral.ForcePublishNewTeamEKForTesting(ctx, g1, teamID, *merkleRoot)
+	teamEKMetadata2, err := ephemeral.ForcePublishNewTeamEKForTesting(mctx1, teamID, *merkleRoot)
 	require.NoError(t, err)
 
 	user2 := tt.addUserWithPaper("u2")
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 	user2.waitForNewlyAddedToTeamByID(teamID)
 
-	g2 := user2.tc.G
-	_, err = g2.GetTeamEKBoxStorage().Get(ctx, teamID, teamEKMetadata1.Generation, nil)
+	mctx2 := libkb.NewMetaContextForTest(*user2.tc)
+	_, err = mctx2.G().GetTeamEKBoxStorage().Get(mctx2, teamID, teamEKMetadata1.Generation, nil)
 	require.Error(t, err)
 	require.IsType(t, ephemeral.EphemeralKeyError{}, err)
 	ekErr := err.(ephemeral.EphemeralKeyError)
 	require.Equal(t, libkb.SCEphemeralMemberAfterEK, ekErr.StatusCode)
 
-	teamEK2, err := g2.GetTeamEKBoxStorage().Get(ctx, teamID, teamEKMetadata2.Generation, nil)
+	teamEK2, err := mctx2.G().GetTeamEKBoxStorage().Get(mctx2, teamID, teamEKMetadata2.Generation, nil)
 	require.NoError(t, err)
 	require.Equal(t, teamEKMetadata2, teamEK2.Metadata)
 
 	// Force a second userEK so when the new device is provisioned it is only
 	// reboxed for the second userEK. Try to access the first userEK and fail.
-	userEKMetdata, err := ephemeral.ForcePublishNewUserEKForTesting(ctx, g2, *merkleRoot)
+	userEKMetdata, err := ephemeral.ForcePublishNewUserEKForTesting(mctx2, *merkleRoot)
 	require.NoError(t, err)
 	newDevice := user2.provisionNewDevice()
-	require.NoError(t, err)
-	g2 = newDevice.tctx.G
+	mctx2 = libkb.NewMetaContextForTest(*newDevice.tctx)
 
-	_, err = g2.GetUserEKBoxStorage().Get(ctx, userEKMetdata.Generation-1, nil)
+	_, err = mctx2.G().GetUserEKBoxStorage().Get(mctx2, userEKMetdata.Generation-1, nil)
 	require.Error(t, err)
 	require.IsType(t, ephemeral.EphemeralKeyError{}, err)
 	ekErr = err.(ephemeral.EphemeralKeyError)

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -595,6 +595,10 @@ func (u *smuUser) userVersion() keybase1.UserVersion {
 	return uv
 }
 
+func (u *smuUser) MetaContext() libkb.MetaContext {
+	return libkb.NewMetaContextForTest(*u.primaryDevice().tctx)
+}
+
 func (u *smuUser) getPrimaryGlobalContext() *libkb.GlobalContext {
 	return u.primaryDevice().tctx.G
 }

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -390,7 +390,7 @@ func (u *userPlusDevice) loadTeamByID(teamID keybase1.TeamID, admin bool) *teams
 }
 
 func (u *userPlusDevice) readInviteEmails(email string) []string {
-	mctx := libkb.NewMetaContextForTest(*u.tc)
+	mctx := u.MetaContext()
 	arg := libkb.NewAPIArg("test/team/get_tokens")
 	arg.Args = libkb.NewHTTPArgs()
 	arg.Args.Add("email", libkb.S{Val: email})
@@ -717,7 +717,7 @@ func (u *userPlusDevice) lookupImplicitTeam2(create bool, displayName string, pu
 }
 
 func (u *userPlusDevice) delayMerkleTeam(teamID keybase1.TeamID) {
-	mctx := libkb.NewMetaContextForTest(*u.tc)
+	mctx := u.MetaContext()
 	_, err := u.tc.G.API.Post(mctx, libkb.APIArg{
 		Endpoint: "test/merkled/delay_team",
 		Args: libkb.HTTPArgs{

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1545,7 +1545,8 @@ func (t *Team) teamEKPayload(ctx context.Context, recipients []keybase1.UID) (*t
 	if err != nil {
 		return nil, err
 	}
-	sig, boxes, metadata, box, err := ekLib.PrepareNewTeamEK(ctx, t.ID, sigKey, recipients)
+	mctx := libkb.NewMetaContext(ctx, t.G())
+	sig, boxes, metadata, box, err := ekLib.PrepareNewTeamEK(mctx, t.ID, sigKey, recipients)
 	if err != nil {
 		return nil, err
 	}
@@ -1561,7 +1562,8 @@ func (t *Team) teamEKPayload(ctx context.Context, recipients []keybase1.UID) (*t
 func (t *Team) storeTeamEKPayload(ctx context.Context, teamEKPayload *teamEKPayload) {
 	// Add the new teamEK box to local storage, if it was created above.
 	if teamEKPayload != nil && teamEKPayload.box != nil {
-		if err := t.G().GetTeamEKBoxStorage().Put(ctx, t.ID, teamEKPayload.metadata.Generation, *teamEKPayload.box); err != nil {
+		mctx := libkb.NewMetaContext(ctx, t.G())
+		if err := t.G().GetTeamEKBoxStorage().Put(mctx, t.ID, teamEKPayload.metadata.Generation, *teamEKPayload.box); err != nil {
 			t.G().Log.CErrorf(ctx, "error while saving teamEK box: %s", err)
 		}
 	}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -818,7 +818,7 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 		ekLib := g.GetEKLib()
 		if ekLib != nil && len(memSet.recipients) > 0 {
 			uids := memSet.recipientUids()
-			teamEKBoxes, err = ekLib.BoxLatestTeamEK(mctx.Ctx(), team.ID, uids)
+			teamEKBoxes, err = ekLib.BoxLatestTeamEK(mctx, team.ID, uids)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
refactor `ephemeral` and `erasablekvstore` to use `libkb.MetaContext` throughout to pave the way for user switching