### PR TITLE
set MaxIdleConnsPerHost

### DIFF
--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -166,6 +166,7 @@ func NewClient(g *GlobalContext, config *ClientConfig, needCookie bool) *Client 
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           (&dialer).DialContext,
 		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
Have noticed the error `write: can't assign requested address` in several logs after trying to foreground the app on mobile. The setting was suggested here: https://github.com/golang/go/issues/16012#issuecomment-224948823. According to [the docs](https://golang.org/pkg/net/http/#Transport.MaxIdleConnsPerHost) this setting is independent of `MaxIdleConns` (set in https://github.com/keybase/client/pull/16551)

I was also thinking of setting `GetExtraNetLogging` to `true` by default until release so we can get more debug info for admin builds. what do you think?