### PR TITLE
Fix desktop SectionList blank rendering with tall items sometimes

### DIFF
--- a/shared/common-adapters/box.desktop.js
+++ b/shared/common-adapters/box.desktop.js
@@ -25,7 +25,7 @@ const injectGaps = (component, _children, gap, gapStart, gapEnd) => {
   return children
 }
 
-const Box2 = (props: Box2Props) => {
+const box2 = (props: Box2Props) => {
   let horizontal = props.direction === 'horizontal' || props.direction === 'horizontalReverse'
 
   const className = [
@@ -64,6 +64,12 @@ const Box2 = (props: Box2Props) => {
       {injectGaps(horizontal ? hBoxGap : vBoxGap, props.children, props.gap, props.gapStart, props.gapEnd)}
     </div>
   )
+}
+
+class Box2 extends React.Component<Box2Props> {
+  render() {
+    return box2(this.props)
+  }
 }
 
 const vBoxGap = (key, gap) => <div key={key} className={`box2_gap_vertical_${gap}`} />

--- a/shared/common-adapters/box.desktop.js
+++ b/shared/common-adapters/box.desktop.js
@@ -25,7 +25,7 @@ const injectGaps = (component, _children, gap, gapStart, gapEnd) => {
   return children
 }
 
-const box2 = (props: Box2Props) => {
+const Box2 = React.forwardRef<Box2Props, HTMLDivElement>((props: Box2Props, ref) => {
   let horizontal = props.direction === 'horizontal' || props.direction === 'horizontalReverse'
 
   const className = [
@@ -59,17 +59,12 @@ const box2 = (props: Box2Props) => {
       onCopyCapture={props.onCopyCapture}
       className={className}
       style={style}
+      ref={ref}
     >
       {injectGaps(horizontal ? hBoxGap : vBoxGap, props.children, props.gap, props.gapStart, props.gapEnd)}
     </div>
   )
-}
-
-class Box2 extends React.Component<Box2Props> {
-  render() {
-    return box2(this.props)
-  }
-}
+})
 
 const vBoxGap = (key, gap) => <div key={key} className={`box2_gap_vertical_${gap}`} />
 const hBoxGap = (key, gap) => <div key={key} className={`box2_gap_horizontal_${gap}`} />

--- a/shared/common-adapters/box.desktop.js
+++ b/shared/common-adapters/box.desktop.js
@@ -25,7 +25,7 @@ const injectGaps = (component, _children, gap, gapStart, gapEnd) => {
   return children
 }
 
-const Box2 = React.forwardRef<Box2Props, HTMLDivElement>((props: Box2Props, ref) => {
+const Box2 = (props: Box2Props) => {
   let horizontal = props.direction === 'horizontal' || props.direction === 'horizontalReverse'
 
   const className = [
@@ -59,12 +59,12 @@ const Box2 = React.forwardRef<Box2Props, HTMLDivElement>((props: Box2Props, ref)
       onCopyCapture={props.onCopyCapture}
       className={className}
       style={style}
-      ref={ref}
+      ref={props.divRef}
     >
       {injectGaps(horizontal ? hBoxGap : vBoxGap, props.children, props.gap, props.gapStart, props.gapEnd)}
     </div>
   )
-})
+}
 
 const vBoxGap = (key, gap) => <div key={key} className={`box2_gap_vertical_${gap}`} />
 const hBoxGap = (key, gap) => <div key={key} className={`box2_gap_horizontal_${gap}`} />

--- a/shared/common-adapters/box.js.flow
+++ b/shared/common-adapters/box.js.flow
@@ -10,6 +10,7 @@ export type Box2Props = {|
   centerChildren?: boolean,
   className?: ?string,
   direction: 'horizontal' | 'vertical' | 'horizontalReverse' | 'verticalReverse',
+  divRef?: {current: null | HTMLDivElement}, // desktop only, passthrough to div
   fullHeight?: boolean,
   fullWidth?: boolean,
   noShrink?: boolean,

--- a/shared/common-adapters/section-list.desktop.js
+++ b/shared/common-adapters/section-list.desktop.js
@@ -115,8 +115,12 @@ class SectionList extends React.Component<Props, State> {
       const item = this._flat[firstIndex]
       if (item) {
         if (this._parentRef.current && this._nextSectionHeaderRef.current) {
-          const {y} = this._parentRef.current.getBoundingClientRect()
-          const {y: nextY} = this._nextSectionHeaderRef.current.getBoundingClientRect()
+          const parentRef = this._parentRef.current
+          const nextRef = this._nextSectionHeaderRef.current
+          // $ForceType see https://github.com/facebook/flow/issues/5475
+          const {y}: DOMRect = parentRef.getBoundingClientRect()
+          // $ForceType
+          const {y: nextY}: DOMRect = nextRef.getBoundingClientRect()
           if (nextY <= y) {
             this.setState(p =>
               p.currentSectionFlatIndex !== this._nextSectionHeaderFlatIndex


### PR DESCRIPTION
Two problems: 

1. `ReactList` doesn't support returning `null` from itemRenderer, at least in the case on the profile screen.
2. The code assumed `itemRenderer` only has one param in `ReactList`, but it actually has two.

I also tweaked the calculation of when to render the sticky header. This is a tradeoff, on the plus side it gets rid of the jitter in the old implementation. The con is that when scrolling real fast the header can sometimes end up in the wrong state, bit it's fixed by any subsequent scrolling so this is pretty minor IMO. r? @keybase/react-hackers 