### PR TITLE
when logging out, switch to other active user

### DIFF
--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -196,6 +196,103 @@ func TestUserEmails(t *testing.T) {
 	}
 }
 
+func TestProvisionDesktopAfterSwitch(t *testing.T) {
+
+	// device X (provisioner) context:
+	t.Logf("setup X")
+	tcX := SetupEngineTest(t, "kex2provision")
+	defer tcX.Cleanup()
+
+	// device Y (provisionee) context:
+	t.Logf("setup Y")
+	tcY := SetupEngineTest(t, "template")
+	defer tcY.Cleanup()
+
+	// provisioner needs to be logged in
+	t.Logf("provisioner login")
+	userX := CreateAndSignupFakeUserPaper(tcX, "login")
+	Logout(tcX)
+	CreateAndSignupFakeUser(tcX, "secon")
+
+	// Ok, now switch back to original user userX
+	userX.SwitchTo(tcX.G, true)
+
+	var secretX kex2.Secret
+	_, err := rand.Read(secretX[:])
+	require.NoError(t, err)
+
+	secretCh := make(chan kex2.Secret)
+
+	// provisionee calls login:
+	t.Logf("provisionee login")
+	uis := libkb.UIs{
+		ProvisionUI: newTestProvisionUISecretCh(secretCh),
+		LoginUI:     &libkb.TestLoginUI{Username: userX.Username},
+		LogUI:       tcY.G.UI.GetLogUI(),
+		SecretUI:    &libkb.TestSecretUI{},
+		GPGUI:       &gpgtestui{},
+	}
+
+	eng := NewLogin(tcY.G, libkb.DeviceTypeDesktop, "", keybase1.ClientType_CLI)
+
+	var wg sync.WaitGroup
+
+	// start provisionee
+	t.Logf("start provisionee")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m := NewMetaContextForTest(tcY).WithUIs(uis)
+		if err := RunEngine2(m, eng); err != nil {
+			t.Errorf("login error: %s", err)
+			return
+		}
+	}()
+
+	// start provisioner
+	t.Logf("start provisioner")
+	provisioner := NewKex2Provisioner(tcX.G, secretX, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		uis := libkb.UIs{
+			SecretUI:    userX.NewSecretUI(),
+			ProvisionUI: newTestProvisionUI(),
+		}
+		m := NewMetaContextForTest(tcX).WithUIs(uis)
+		if err := RunEngine2(m, provisioner); err != nil {
+			t.Errorf("provisioner error: %s", err)
+			return
+		}
+	}()
+
+	secretFromY := <-secretCh
+
+	provisioner.AddSecret(secretFromY)
+
+	t.Logf("wait")
+	wg.Wait()
+
+	require.False(t, t.Failed(), "prior failure in a goroutine")
+
+	t.Logf("asserts")
+	if err := AssertProvisioned(tcY); err != nil {
+		t.Fatal(err)
+	}
+
+	// after provisioning, the passphrase stream should be cached
+	// (note that this just checks the passphrase stream, not 3sec)
+	assertPassphraseStreamCache(tcY)
+
+	// after provisioning, the device keys should be cached
+	assertDeviceKeysCached(tcY)
+
+	// after provisioning, the secret should be stored
+	assertSecretStored(tcY, userX.Username)
+
+}
+
 func TestProvisionAfterSwitchWithWrongUser(t *testing.T) {
 	// device X (provisioner) context:
 	t.Logf("setup X")

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -52,6 +52,25 @@ func TestLoginAndSwitchWithLogout(t *testing.T) {
 	return
 }
 
+func TestLoginTwiceLogoutOnce(t *testing.T) {
+	tc := SetupEngineTest(t, "login")
+	defer tc.Cleanup()
+	u1 := CreateAndSignupFakeUser(tc, "first")
+	Logout(tc)
+	t.Logf("Logout first, and signup  u2")
+	u2 := CreateAndSignupFakeUser(tc, "secon")
+	t.Logf("Login u1")
+	u1.SwitchTo(tc.G, true)
+	t.Logf("Logged in u1")
+	u2.SwitchTo(tc.G, true)
+	eng := NewLogout()
+	mctx := NewMetaContextForTest(tc)
+	err := RunEngine2(mctx, eng)
+	require.NoError(t, err)
+	require.True(t, tc.G.ActiveDevice.Valid())
+	require.Equal(t, tc.G.ActiveDevice.UID(), u1.UID())
+}
+
 // Test login switching between two different users.
 func TestLoginAndSwitchWithoutLogout(t *testing.T) {
 	tc := SetupEngineTest(t, "login")

--- a/go/engine/logout.go
+++ b/go/engine/logout.go
@@ -1,0 +1,53 @@
+package engine
+
+import (
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+type LogoutEngine struct{}
+
+func NewLogout() *LogoutEngine                           { return &LogoutEngine{} }
+func (e *LogoutEngine) Name() string                     { return "Logout" }
+func (e *LogoutEngine) Prereqs() Prereqs                 { return Prereqs{} }
+func (e *LogoutEngine) RequiredUIs() []libkb.UIKind      { return []libkb.UIKind{} }
+func (e *LogoutEngine) SubConsumers() []libkb.UIConsumer { return []libkb.UIConsumer{} }
+
+func (e *LogoutEngine) findLoggedInAccount(mctx libkb.MetaContext, accounts []keybase1.ConfiguredAccount) (ret libkb.NormalizedUsername) {
+	for _, acct := range accounts {
+		if acct.HasStoredSecret {
+			return libkb.NewNormalizedUsername(acct.Username)
+		}
+	}
+	return ret
+}
+
+func (e *LogoutEngine) doSwitch(mctx libkb.MetaContext) (err error) {
+	defer mctx.Trace("Logout#doSwitch", func() error { return err })()
+	accounts, err := mctx.G().GetConfiguredAccounts(mctx.Ctx())
+	if err != nil {
+		return err
+	}
+	acct := e.findLoggedInAccount(mctx, accounts)
+	if acct.IsNil() {
+		mctx.Debug("Failed to find a logged in account")
+		return nil
+	}
+	mctx.Debug("Switching to another logged in account: %s", acct)
+
+	eng := NewLoginProvisionedDevice(mctx.G(), acct.String())
+	eng.SecretStoreOnly = true
+	return RunEngine2(mctx, eng)
+}
+
+func (e *LogoutEngine) Run(mctx libkb.MetaContext) (err error) {
+	defer mctx.Trace("Logout#Run", func() error { return err })()
+	err = mctx.G().Logout(mctx.Ctx())
+	if err != nil {
+		return err
+	}
+	e.doSwitch(mctx)
+	return nil
+}
+
+var _ Engine2 = (*LogoutEngine)(nil)

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -227,7 +227,7 @@ func getNIST(m MetaContext, sessType APISessionType) *NIST {
 		return nil
 	}
 
-	nist, err := m.ActiveDevice().NIST(m.Ctx())
+	nist, err := m.NIST()
 	if nist == nil {
 		m.Debug("active device couldn't generate a NIST")
 		return nil

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -118,6 +118,18 @@ func (m MetaContext) ActiveDevice() *ActiveDevice {
 	return m.G().ActiveDevice
 }
 
+func (m MetaContext) NIST() (*NIST, error) {
+	nist, uid, err := m.ActiveDevice().NISTAndUID(m.Ctx())
+	if err != nil {
+		return nil, err
+	}
+	if !uid.Equal(m.CurrentUID()) {
+		m.Debug("MetaContext#NIST: Not returning nist, since for wrong UID: %s != %s", uid, m.CurrentUID())
+		return nil, nil
+	}
+	return nist, nil
+}
+
 func NewMetaContextTODO(g *GlobalContext) MetaContext {
 	return MetaContext{ctx: context.TODO(), g: g}
 }

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -28,24 +28,11 @@ func (h *LoginHandler) GetConfiguredAccounts(context context.Context, sessionID 
 	return h.G().GetConfiguredAccounts(context)
 }
 
-type canLogoutRet struct {
-	libkb.AppStatusEmbed
-	CanLogout bool   `json:"can_logout"`
-	Reason    string `json:"reason,omitempty"`
-}
-
-// canLogout asks API server whether we should allow logging out or not.
-func canLogout(mctx libkb.MetaContext) (res canLogoutRet, err error) {
-	err = mctx.G().API.GetDecode(mctx, libkb.APIArg{
-		Endpoint:    "user/can_logout",
-		SessionType: libkb.APISessionTypeREQUIRED,
-	}, &res)
-	return res, err
-}
-
 func (h *LoginHandler) Logout(ctx context.Context, sessionID int) (err error) {
 	defer h.G().CTraceTimed(ctx, "Logout [service RPC]", func() error { return err })()
-	return h.G().Logout(ctx)
+	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("LOGOUT")
+	eng := engine.NewLogout()
+	return engine.RunEngine2(mctx, eng)
 }
 
 func (h *LoginHandler) Deprovision(ctx context.Context, arg keybase1.DeprovisionArg) error {


### PR DESCRIPTION
- a new Logout engine
- in Login, don't return the global NIST if we're logging in as a different user
- we might want to revisit the whole strategy to logging in as a separate user, since we wind up mutating global state for a failed login, if we're already
logged in as A and we're switching over to B. this is a bigger change, so maybe let's wait on it.