### PR TITLE
ShouldUseParameterizedProofs -> true

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -461,7 +461,7 @@ var RemoteServiceTypes = map[string]keybase1.ProofType{
 	"generic_social": keybase1.ProofType_GENERIC_SOCIAL,
 }
 
-// TODO Remove with CORE-9923
+// remove when ShouldUseParameterizedProofs is removed
 var RemoteServiceOrder = []keybase1.ProofType{
 	keybase1.ProofType_KEYBASE,
 	keybase1.ProofType_TWITTER,

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -1330,13 +1330,8 @@ func (g *GlobalContext) GetMeUV(ctx context.Context) (res keybase1.UserVersion, 
 	return res, nil
 }
 
-// TODO CORE-9923: set this to true and remove it
-// Whether to use parameterized proofs apparatus on normal clients.
+// Whether to use parameterized proofs apparatus.
 // Affects non-parameterized proof listing too.
 func (g *GlobalContext) ShouldUseParameterizedProofs() bool {
-	return g.Env.GetRunMode() == DevelRunMode ||
-		g.Env.RunningInCI() ||
-		g.Env.GetFeatureFlags().Admin(g.Env.GetUID()) ||
-		g.Env.GetProveBypass() ||
-		g.Env.GetFeatureFlags().HasFeature(ExperimentalGenericProofs)
+	return true
 }

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -73,7 +73,7 @@ func (i *IdentifyOutcome) ProofChecksSorted() []*LinkCheckResult {
 
 }
 
-// TODO Remove with CORE-9923
+// remove when ShouldUseParameterizedProofs is removed
 func (i *IdentifyOutcome) proofChecksSortedByProofType() []*LinkCheckResult {
 	// Treat DNS and Web as the same type, and sort them together
 	// in the same bucket.


### PR DESCRIPTION
Always use parameterized proofs apparatus. This means fetching the list of available proofs from the merkle tree. Affects the order and allowedness of non-parameterized proof types too.

Users will see any existing parameterized proofs. Whether they can create new ones of each type is gated by the server.

This should be safe now that the gui is in. The app should now be forwards compatible. Any reason it wouldn't be?