### PR TITLE
Hide rooter in prod mode

### DIFF
--- a/go/externals/proof_service_rooter.go
+++ b/go/externals/proof_service_rooter.go
@@ -62,6 +62,10 @@ func (t *RooterServiceType) GetPrompt() string {
 	return "Your username on Rooter"
 }
 
+func (t *RooterServiceType) CanMakeNewProofs(mctx libkb.MetaContext) bool {
+	return mctx.G().GetRunMode() != libkb.ProductionRunMode
+}
+
 func (t *RooterServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)
 }


### PR DESCRIPTION
Rooter isn't compiled into production builds anyway. This way it won't show up for dev builds running in prod mode either.