### PR TITLE
make 'Unread messages' and floating teams divider respond faster to inbox changes

### DIFF
--- a/shared/chat/inbox/container/index.js
+++ b/shared/chat/inbox/container/index.js
@@ -80,14 +80,21 @@ const mapDispatchToProps = (dispatch, {navigateAppend}) => ({
 // This merge props is not spreading on purpose so we never have any random props that might mutate and force a re-render
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const unreadIndices = []
-  for (let i = stateProps.rows.length - 1; i >= 0; i--) {
-    const row = stateProps.rows[i]
-    if (!['big', 'bigHeader'].includes(row.type)) {
-      // only check big teams for large inbox perf
-      break
-    }
-    if (row.conversationIDKey && stateProps._badgeMap.get(row.conversationIDKey)) {
-      unreadIndices.unshift(i)
+  if (!stateProps.filter) {
+    for (let i = stateProps.rows.length - 1; i >= 0; i--) {
+      const row = stateProps.rows[i]
+      if (!['big', 'bigHeader'].includes(row.type)) {
+        // only check big teams for large inbox perf
+        break
+      }
+      if (
+        row.conversationIDKey &&
+        stateProps._badgeMap.get(row.conversationIDKey) &&
+        (isMobile || row.conversationIDKey !== stateProps._selectedConversationIDKey)
+      ) {
+        // on mobile include all convos, on desktop only not currently selected convo
+        unreadIndices.unshift(i)
+      }
     }
   }
   return {

--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -56,6 +56,7 @@ class Inbox extends React.PureComponent<Props, State> {
 
     // list changed
     if (this.props.rows.length !== prevProps.rows.length) {
+      this._calculateShowFloating()
       listRowsResized = true
     }
 
@@ -146,6 +147,19 @@ class Inbox extends React.PureComponent<Props, State> {
     }
   }
 
+  _calculateShowFloating = () => {
+    if (this._lastVisibleIdx < 0) {
+      return
+    }
+    let showFloating = true
+    const row = this.props.rows[this._lastVisibleIdx]
+    if (!row || row.type !== 'small') {
+      showFloating = false
+    }
+
+    this.setState(old => (old.showFloating !== showFloating ? {showFloating} : null))
+  }
+
   _onItemsRendered = debounce(({visibleStartIndex, visibleStopIndex}) => {
     this._lastVisibleIdx = visibleStopIndex
     if (this.props.filter.length) {
@@ -165,14 +179,7 @@ class Inbox extends React.PureComponent<Props, State> {
       return arr
     }, [])
 
-    let showFloating = true
-    const row = this.props.rows[visibleStopIndex]
-    if (!row || row.type !== 'small') {
-      showFloating = false
-    }
-
-    this.setState(old => (old.showFloating !== showFloating ? {showFloating} : null))
-
+    this._calculateShowFloating()
     this._calculateShowUnreadShortcut()
 
     this.props.onUntrustedInboxVisible(toUnbox)

--- a/shared/chat/inbox/index.native.js
+++ b/shared/chat/inbox/index.native.js
@@ -54,6 +54,10 @@ class Inbox extends React.PureComponent<Props, State> {
     if (!I.is(prevProps.unreadIndices, this.props.unreadIndices)) {
       this._updateShowUnread()
     }
+    if (this.props.rows.length !== prevProps.rows.length) {
+      // list has changed, floating divider is likely to change
+      this._updateShowFloating()
+    }
   }
 
   _renderItem = ({item, index}) => {
@@ -115,11 +119,11 @@ class Inbox extends React.PureComponent<Props, State> {
       return
     }
     this._onScrollUnbox(data)
-    this._updateShowFloating(data)
 
     const lastVisibleIdx = data.viewableItems[data.viewableItems.length - 1]?.index
     this._lastVisibleIdx = lastVisibleIdx || -1
     this._updateShowUnread()
+    this._updateShowFloating()
   }
 
   _updateShowUnread = () => {
@@ -150,13 +154,14 @@ class Inbox extends React.PureComponent<Props, State> {
   }
 
   _updateShowFloating = data => {
-    let showFloating = true
-    const {viewableItems} = data
-    const item = viewableItems && viewableItems[viewableItems.length - 1]
-    if (!item) {
+    if (this._lastVisibleIdx < 0) {
       return
     }
-    const row = item.item
+    let showFloating = true
+    const row = this.props.rows[this._lastVisibleIdx]
+    if (!row) {
+      return
+    }
 
     if (!row || row.type !== 'small') {
       showFloating = false


### PR DESCRIPTION
cc @mmaxim this fixes one and hopefully the other issue you saw

- "Unread messages" banner can flash in when expanding small teams
- (maybe) banner can sit around at the bottom of the inbox occasionally

@keybase/react-hackers 