### PR TITLE
favorites: improve behavior when offline / on startup

### DIFF
--- a/go/kbfs/libkbfs/favorites.go
+++ b/go/kbfs/libkbfs/favorites.go
@@ -714,6 +714,13 @@ func (f *Favorites) RefreshCache(ctx context.Context, mode FavoritesRefreshMode)
 	}
 	select {
 	case f.reqChan <- req:
+		go func() {
+			<-req.done
+			if req.err != nil {
+				f.log.CDebugf(ctx, "Failed to refresh cached Favorites ("+
+					"error in main loop): %+v", req.err)
+			}
+		}()
 	case <-ctx.Done():
 		// Because the request will not make it to the main processing
 		// loop, mark it as done and clear the refresh channel here.

--- a/go/kbfs/libkbfs/favorites_test.go
+++ b/go/kbfs/libkbfs/favorites_test.go
@@ -33,6 +33,7 @@ func favTestInit(t *testing.T, testingDiskCache bool) (
 				UID:  keybase1.MakeTestUID(16),
 			}, nil)
 	}
+	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).AnyTimes()
 
 	return mockCtrl, config, context.Background()
 }
@@ -64,7 +65,6 @@ func TestFavoritesAddTwice(t *testing.T) {
 	config.mockKbpki.EXPECT().FavoriteList(gomock.Any()).Return(keybase1.FavoritesResult{}, nil)
 	config.mockKbpki.EXPECT().FavoriteAdd(gomock.Any(), fav1.ToKBFolder()).
 		Return(nil)
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).Times(2)
 	if err := f.Add(ctx, fav1); err != nil {
 		t.Fatalf("Couldn't add favorite: %v", err)
 	}
@@ -96,7 +96,6 @@ func TestFavoriteAddCreatedAlwaysGoThrough(t *testing.T) {
 	}
 	config.mockKbpki.EXPECT().FavoriteList(gomock.Any()).Return(keybase1.FavoritesResult{}, nil)
 	config.mockKbpki.EXPECT().FavoriteAdd(gomock.Any(), expected1).Return(nil)
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).Times(2)
 	if err := f.Add(ctx, fav1); err != nil {
 		t.Fatalf("Couldn't add favorite: %v", err)
 	}
@@ -136,7 +135,6 @@ func TestFavoritesAddCreated(t *testing.T) {
 		Created: true,
 	}
 	config.mockKbpki.EXPECT().FavoriteList(gomock.Any()).Return(keybase1.FavoritesResult{}, nil)
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0))
 	expected := keybase1.Folder{
 		Name:       "test",
 		FolderType: keybase1.FolderType_PUBLIC,
@@ -170,7 +168,6 @@ func TestFavoritesAddRemoveAdd(t *testing.T) {
 		Times(2).Return(nil)
 	config.mockKbpki.EXPECT().FavoriteDelete(gomock.Any(), folder1).
 		Return(nil)
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).Times(3)
 
 	if err := f.Add(ctx, fav1); err != nil {
 		t.Fatalf("Couldn't add favorite: %v", err)
@@ -203,7 +200,6 @@ func TestFavoritesAddAsync(t *testing.T) {
 		Created: false,
 	}
 	config.mockKbpki.EXPECT().FavoriteList(gomock.Any()).Return(keybase1.FavoritesResult{}, nil)
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0))
 
 	c := make(chan struct{})
 	// Block until there are multiple outstanding calls
@@ -238,8 +234,6 @@ func TestFavoritesListFailsDuringAddAsync(t *testing.T) {
 		Data:    favorites.Data{},
 		Created: false,
 	}
-
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).Times(2)
 
 	// Cancel the first list request
 	config.mockKbpki.EXPECT().FavoriteList(gomock.Any()).Return(keybase1.
@@ -276,7 +270,6 @@ func TestFavoritesControlUserHistory(t *testing.T) {
 	config.mockKbs.EXPECT().EncryptFavorites(gomock.Any(),
 		gomock.Any()).Return(nil, nil)
 	config.mockCodec.EXPECT().Encode(gomock.Any()).Return(nil, nil).Times(2)
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).Times(2)
 	config.mockKbpki.EXPECT().FavoriteDelete(gomock.Any(), gomock.Any()).
 		Return(nil)
 
@@ -347,7 +340,6 @@ func TestFavoritesGetAll(t *testing.T) {
 	}
 	// Mock out the API server.
 	config.mockKbpki.EXPECT().FavoriteList(gomock.Any()).Return(res, nil)
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).Times(1)
 	config.mockCodec.EXPECT().Encode(gomock.Any()).Return(nil, nil).Times(2)
 	config.mockKbs.EXPECT().EncryptFavorites(gomock.Any(),
 		gomock.Any()).Return(nil, nil)
@@ -385,7 +377,6 @@ func TestFavoritesDiskCache(t *testing.T) {
 
 	f := NewFavorites(config)
 
-	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).Times(2)
 	f.Initialize(ctx)
 
 	// Add a favorite. Expect that it will be encoded to disk.

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -276,7 +276,7 @@ type KBFSOps interface {
 	// favorites list and fetch a new list from the server.  The
 	// effects are asychronous; if there's an error refreshing the
 	// favorites, the cached favorites will become empty.
-	RefreshCachedFavorites(ctx context.Context, async bool)
+	RefreshCachedFavorites(ctx context.Context, mode FavoritesRefreshMode)
 	// ClearCachedFavorites tells the instances to forget any cached
 	// favorites list, e.g. when a user logs out.
 	ClearCachedFavorites(ctx context.Context)

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -276,7 +276,7 @@ type KBFSOps interface {
 	// favorites list and fetch a new list from the server.  The
 	// effects are asychronous; if there's an error refreshing the
 	// favorites, the cached favorites will become empty.
-	RefreshCachedFavorites(ctx context.Context)
+	RefreshCachedFavorites(ctx context.Context, async bool)
 	// ClearCachedFavorites tells the instances to forget any cached
 	// favorites list, e.g. when a user logs out.
 	ClearCachedFavorites(ctx context.Context)

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -276,11 +276,12 @@ func (fs *KBFSOpsStandard) GetFavoritesAll(ctx context.Context) (keybase1.
 
 // RefreshCachedFavorites implements the KBFSOps interface for
 // KBFSOpsStandard.
-func (fs *KBFSOpsStandard) RefreshCachedFavorites(ctx context.Context) {
+func (fs *KBFSOpsStandard) RefreshCachedFavorites(ctx context.Context,
+	async bool) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
-	fs.favs.RefreshCache(ctx)
+	fs.favs.RefreshCache(ctx, async)
 }
 
 // ClearCachedFavorites implements the KBFSOps interface for

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -277,11 +277,11 @@ func (fs *KBFSOpsStandard) GetFavoritesAll(ctx context.Context) (keybase1.
 // RefreshCachedFavorites implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) RefreshCachedFavorites(ctx context.Context,
-	async bool) {
+	mode FavoritesRefreshMode) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
-	fs.favs.RefreshCache(ctx, async)
+	fs.favs.RefreshCache(ctx, mode)
 }
 
 // ClearCachedFavorites implements the KBFSOps interface for

--- a/go/kbfs/libkbfs/keybase_daemon_rpc.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc.go
@@ -465,6 +465,6 @@ func newNotifyServiceHandler(config Config, log logger.Logger) keybase1.NotifySe
 func (k *KeybaseDaemonRPC) FavoritesChanged(ctx context.Context,
 	uid keybase1.UID) error {
 	k.log.Debug("Received FavoritesChanged RPC.")
-	k.config.KBFSOps().RefreshCachedFavorites(ctx)
+	go k.config.KBFSOps().RefreshCachedFavorites(ctx, true)
 	return nil
 }

--- a/go/kbfs/libkbfs/keybase_daemon_rpc.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc.go
@@ -465,6 +465,7 @@ func newNotifyServiceHandler(config Config, log logger.Logger) keybase1.NotifySe
 func (k *KeybaseDaemonRPC) FavoritesChanged(ctx context.Context,
 	uid keybase1.UID) error {
 	k.log.Debug("Received FavoritesChanged RPC.")
-	go k.config.KBFSOps().RefreshCachedFavorites(ctx, true)
+	go k.config.KBFSOps().RefreshCachedFavorites(context.Background(),
+		FavoritesRefreshModeBlocking)
 	return nil
 }

--- a/go/kbfs/libkbfs/keybase_daemon_rpc.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc.go
@@ -466,6 +466,6 @@ func (k *KeybaseDaemonRPC) FavoritesChanged(ctx context.Context,
 	uid keybase1.UID) error {
 	k.log.Debug("Received FavoritesChanged RPC.")
 	go k.config.KBFSOps().RefreshCachedFavorites(context.Background(),
-		FavoritesRefreshModeBlocking)
+		FavoritesRefreshModeInMainFavoritesLoop)
 	return nil
 }

--- a/go/kbfs/libkbfs/keybase_daemon_rpc.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc.go
@@ -466,6 +466,6 @@ func (k *KeybaseDaemonRPC) FavoritesChanged(ctx context.Context,
 	uid keybase1.UID) error {
 	k.log.Debug("Received FavoritesChanged RPC.")
 	go k.config.KBFSOps().RefreshCachedFavorites(context.Background(),
-		FavoritesRefreshModeBackground)
+		FavoritesRefreshModeBlocking)
 	return nil
 }

--- a/go/kbfs/libkbfs/keybase_daemon_rpc.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc.go
@@ -465,7 +465,7 @@ func newNotifyServiceHandler(config Config, log logger.Logger) keybase1.NotifySe
 func (k *KeybaseDaemonRPC) FavoritesChanged(ctx context.Context,
 	uid keybase1.UID) error {
 	k.log.Debug("Received FavoritesChanged RPC.")
-	go k.config.KBFSOps().RefreshCachedFavorites(context.Background(),
+	k.config.KBFSOps().RefreshCachedFavorites(ctx,
 		FavoritesRefreshModeInMainFavoritesLoop)
 	return nil
 }

--- a/go/kbfs/libkbfs/keybase_daemon_rpc.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc.go
@@ -466,6 +466,6 @@ func (k *KeybaseDaemonRPC) FavoritesChanged(ctx context.Context,
 	uid keybase1.UID) error {
 	k.log.Debug("Received FavoritesChanged RPC.")
 	go k.config.KBFSOps().RefreshCachedFavorites(context.Background(),
-		FavoritesRefreshModeBlocking)
+		FavoritesRefreshModeBackground)
 	return nil
 }

--- a/go/kbfs/libkbfs/keybase_service_util.go
+++ b/go/kbfs/libkbfs/keybase_service_util.go
@@ -123,7 +123,7 @@ func serviceLoggedIn(ctx context.Context, config Config, session idutil.SessionI
 		go bServer.RefreshAuthToken(context.Background())
 	}
 
-	config.KBFSOps().RefreshCachedFavorites(ctx)
+	config.KBFSOps().RefreshCachedFavorites(ctx, false)
 	config.KBFSOps().PushStatusChange()
 	return wg
 }

--- a/go/kbfs/libkbfs/keybase_service_util.go
+++ b/go/kbfs/libkbfs/keybase_service_util.go
@@ -123,7 +123,7 @@ func serviceLoggedIn(ctx context.Context, config Config, session idutil.SessionI
 		go bServer.RefreshAuthToken(context.Background())
 	}
 
-	config.KBFSOps().RefreshCachedFavorites(ctx, false)
+	config.KBFSOps().RefreshCachedFavorites(ctx, FavoritesRefreshModeInMainFavoritesLoop)
 	config.KBFSOps().PushStatusChange()
 	return wg
 }

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -1332,7 +1332,7 @@ func (mr *MockKBFSOpsMockRecorder) Read(arg0, arg1, arg2, arg3 interface{}) *gom
 }
 
 // RefreshCachedFavorites mocks base method
-func (m *MockKBFSOps) RefreshCachedFavorites(arg0 context.Context, arg1 bool) {
+func (m *MockKBFSOps) RefreshCachedFavorites(arg0 context.Context, arg1 FavoritesRefreshMode) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RefreshCachedFavorites", arg0, arg1)
 }

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -1332,15 +1332,15 @@ func (mr *MockKBFSOpsMockRecorder) Read(arg0, arg1, arg2, arg3 interface{}) *gom
 }
 
 // RefreshCachedFavorites mocks base method
-func (m *MockKBFSOps) RefreshCachedFavorites(arg0 context.Context) {
+func (m *MockKBFSOps) RefreshCachedFavorites(arg0 context.Context, arg1 bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RefreshCachedFavorites", arg0)
+	m.ctrl.Call(m, "RefreshCachedFavorites", arg0, arg1)
 }
 
 // RefreshCachedFavorites indicates an expected call of RefreshCachedFavorites
-func (mr *MockKBFSOpsMockRecorder) RefreshCachedFavorites(arg0 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) RefreshCachedFavorites(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshCachedFavorites", reflect.TypeOf((*MockKBFSOps)(nil).RefreshCachedFavorites), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshCachedFavorites", reflect.TypeOf((*MockKBFSOps)(nil).RefreshCachedFavorites), arg0, arg1)
 }
 
 // RefreshEditHistory mocks base method


### PR DESCRIPTION
Don't wait the whole normal timeout when trying to refresh favorites on startup. Instead, wait 500ms and then serve the request from the disk cache while refreshing in the background.

Issue: KBFS-3938