### PR TITLE
stop chat modules in tests

### DIFF
--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -321,7 +321,9 @@ var _ EphemeralPurger = (*DummyEphemeralPurger)(nil)
 
 func (d DummyEphemeralPurger) Start(ctx context.Context, uid gregor1.UID) {}
 func (d DummyEphemeralPurger) Stop(ctx context.Context) chan struct{} {
-	return nil
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }
 func (d DummyEphemeralPurger) Queue(ctx context.Context, purgeInfo chat1.EphemeralPurgeInfo) error {
 	return nil
@@ -333,7 +335,9 @@ var _ Indexer = (*DummyIndexer)(nil)
 
 func (d DummyIndexer) Start(ctx context.Context, uid gregor1.UID) {}
 func (d DummyIndexer) Stop(ctx context.Context) chan struct{} {
-	return nil
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }
 func (d DummyIndexer) Search(ctx context.Context, uid gregor1.UID, query string, opts chat1.SearchOpts,
 	hitUICh chan chat1.ChatSearchInboxHit, indexUICh chan chat1.ChatSearchIndexStatus) (*chat1.ChatSearchInboxResults, error) {
@@ -435,7 +439,9 @@ var _ CoinFlipManager = (*DummyCoinFlipManager)(nil)
 
 func (d DummyCoinFlipManager) Start(ctx context.Context, uid gregor1.UID) {}
 func (d DummyCoinFlipManager) Stop(ctx context.Context) chan struct{} {
-	return nil
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }
 func (d DummyCoinFlipManager) StartFlip(ctx context.Context, uid gregor1.UID, hostConvID chat1.ConversationID, tlfName, text string, outboxID *chat1.OutboxID) error {
 	return nil

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -44,11 +44,20 @@ func (c ChatTestContext) Cleanup() {
 	if c.ChatG.MessageDeliverer != nil {
 		<-c.ChatG.MessageDeliverer.Stop(context.TODO())
 	}
+	if c.ChatG.ConvLoader != nil {
+		<-c.ChatG.ConvLoader.Stop(context.TODO())
+	}
 	if c.ChatG.FetchRetrier != nil {
 		<-c.ChatG.FetchRetrier.Stop(context.TODO())
 	}
+	if c.ChatG.EphemeralPurger != nil {
+		<-c.ChatG.EphemeralPurger.Stop(context.TODO())
+	}
 	if c.ChatG.InboxSource != nil {
 		<-c.ChatG.InboxSource.Stop(context.TODO())
+	}
+	if c.ChatG.Indexer != nil {
+		<-c.ChatG.Indexer.Stop(context.TODO())
 	}
 	if c.ChatG.CoinFlipManager != nil {
 		<-c.ChatG.CoinFlipManager.Stop(context.TODO())


### PR DESCRIPTION
Some chat modules were not stopped in tests. `EphemeralPurger` was hanging when trying to stop because of the `DummyEphemeralPurger` not closing the stop ch but also looked into simplifing some of the outdated/complicated purger start/stop logic. 