### PR TITLE
leveldb: tune options

### DIFF
--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -35,6 +35,7 @@ const (
 	defaultDiskBlockCacheMaxBytes   uint64 = 10 * (1 << 30)
 	defaultBlockCacheTableSize      int    = 50 * opt.MiB
 	defaultBlockCacheBlockSize      int    = 4 * opt.MiB
+	defaultBlockCacheCapacity       int    = 8 * opt.MiB
 	evictionConsiderationFactor     int    = 3
 	defaultNumBlocksToEvict         int    = 10
 	defaultNumBlocksToEvictOnClear  int    = 100
@@ -200,6 +201,7 @@ func newDiskBlockCacheLocalFromStorage(
 	blockDbOptions := *leveldbOptions
 	blockDbOptions.CompactionTableSize = defaultBlockCacheTableSize
 	blockDbOptions.BlockSize = defaultBlockCacheBlockSize
+	blockDbOptions.BlockCacheCapacity = defaultBlockCacheCapacity
 	blockDbOptions.Filter = filter.NewBloomFilter(16)
 	blockDb, err := openLevelDBWithOptions(blockStorage, &blockDbOptions)
 	if err != nil {

--- a/go/kbfs/libkbfs/leveldb.go
+++ b/go/kbfs/libkbfs/leveldb.go
@@ -29,6 +29,7 @@ const (
 
 var leveldbOptions = &opt.Options{
 	Compression: opt.NoCompression,
+	WriteBuffer: 10 * opt.MiB,
 	BlockSize:   1 << 16,
 	// Default max open file descriptors (ulimit -n) is 256 on OS
 	// X, and >=1024 on (most?) Linux machines. So set to a low


### PR DESCRIPTION
Change a few leveldb parameters to increase performance of operations with lots of small files in big directory structures

TODO:
 - figure out how to deal with compaction