### PR TITLE
Don't get stuck showing the unread messages banner if we shouldn't

### DIFF
--- a/shared/chat/inbox/index.desktop.js
+++ b/shared/chat/inbox/index.desktop.js
@@ -166,6 +166,7 @@ class Inbox extends React.PureComponent<Props, State> {
     if (this.props.filter.length) {
       return
     }
+    this._calculateShowUnreadShortcut()
     if (this.props.clearedFilterCount > this._clearedFilterCount) {
       // just cleared out filter
       // re-rendering normal inbox for the first time
@@ -181,7 +182,6 @@ class Inbox extends React.PureComponent<Props, State> {
     }, [])
 
     this._calculateShowFloating()
-    this._calculateShowUnreadShortcut()
 
     this.props.onUntrustedInboxVisible(toUnbox)
   }, 200)


### PR DESCRIPTION
Fixes one place where we get stuck showing the banner. It's not perfect, but it should settle to the right state all the time now. r? @keybase/react-hackers cc @mmaxim 