### PR TITLE
Core changes for passphrase => password in UI strings

### DIFF
--- a/go/client/cmd_passphrase_check.go
+++ b/go/client/cmd_passphrase_check.go
@@ -82,7 +82,7 @@ func (c *CmdPassphraseCheck) Run() error {
 	}
 
 	if !ret {
-		return errors.New("Invalid passphrase")
+		return errors.New("Invalid password")
 	}
 	c.G().Log.Info("Passphrase confirmed.")
 	return nil

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -419,7 +419,7 @@ type PassphraseError struct {
 }
 
 func (p PassphraseError) Error() string {
-	msg := "Bad passphrase"
+	msg := "Bad password"
 	if len(p.Msg) != 0 {
 		msg = msg + ": " + p.Msg + "."
 	}

--- a/go/libkb/passphrase_helper.go
+++ b/go/libkb/passphrase_helper.go
@@ -165,10 +165,10 @@ func DefaultPassphraseArg(m MetaContext) keybase1.GUIEntryArg {
 
 func DefaultPassphrasePromptArg(mctx MetaContext, username string) keybase1.GUIEntryArg {
 	arg := DefaultPassphraseArg(mctx)
-	arg.WindowTitle = "Keybase passphrase"
+	arg.WindowTitle = "Keybase password"
 	arg.Type = keybase1.PassphraseType_PASS_PHRASE
 	arg.Username = username
-	arg.Prompt = fmt.Sprintf("Please enter the Keybase passphrase for %s (%d+ characters)", username, MinPassphraseLength)
+	arg.Prompt = fmt.Sprintf("Please enter the Keybase password for %s (%d+ characters)", username, MinPassphraseLength)
 	return arg
 }
 

--- a/go/libkb/passphrase_login.go
+++ b/go/libkb/passphrase_login.go
@@ -150,7 +150,7 @@ func pplPost(m MetaContext, eOu string, lp PDPKALoginPackage) (*loginAPIResult, 
 	if res.Status.Code == SCBadLoginPassword {
 		// NOTE: This error message is also hardcoded in the frontend to detect
 		// this class of errors.
-		return nil, PassphraseError{"Invalid passphrase. Server rejected login attempt."}
+		return nil, PassphraseError{"Invalid password. Server rejected login attempt."}
 	}
 	if res.Status.Code == SCBadLoginUserNotFound {
 		return nil, NotFoundError{}

--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -30,8 +30,8 @@ const getPasswordHandler = passphrase => (params, response) => {
     if (params.pinentry.retryLabel) {
       cancelOnCallback(params, response)
       let retryLabel = params.pinentry.retryLabel
-      if (retryLabel === 'Bad passphrase: Invalid passphrase. Server rejected login attempt..') {
-        retryLabel = 'Incorrect password'
+      if (retryLabel === Constants.invalidPasswordErrorString) {
+        retryLabel = 'Incorrect password.'
       }
       return Saga.put(LoginGen.createLoginError({error: new HiddenString(retryLabel)}))
     } else {

--- a/shared/actions/pinentry.js
+++ b/shared/actions/pinentry.js
@@ -2,6 +2,7 @@
 import logger from '../logger'
 import * as EngineGen from '../actions/engine-gen-gen'
 import * as PinentryGen from '../actions/pinentry-gen'
+import * as Constants from '../constants/login'
 import * as Saga from '../util/saga'
 import * as I from 'immutable'
 import * as RPCTypes from '../constants/types/rpc-gen'
@@ -25,7 +26,8 @@ const onConnect = () => {
 const onGetPassword = (state, action) => {
   logger.info('Asked for password')
   const {pinentry} = action.payload.params
-  const {prompt, submitLabel, cancelLabel, windowTitle, retryLabel, features, type} = pinentry
+  const {prompt, submitLabel, cancelLabel, windowTitle, features, type} = pinentry
+  const retryLabel = pinentry.retryLabel === Constants.invalidPasswordErrorString ? 'Incorrect password.' : pinentry.retryLabel
 
   // Stash response
   _response = action.payload.response

--- a/shared/constants/login.js
+++ b/shared/constants/login.js
@@ -3,6 +3,9 @@ import * as I from 'immutable'
 import * as Types from './types/login'
 import HiddenString from '../util/hidden-string'
 
+// An ugly error message from the service that we'd like to rewrite ourselves.
+export const invalidPasswordErrorString = 'Bad password: Invalid password. Server rejected login attempt..'
+
 export const waitingKey = 'login:waiting'
 
 export const makeState: I.RecordFactory<Types._State> = I.Record({


### PR DESCRIPTION
There's a request from @keybase/design to change "passphrase" to "password" everywhere in the UI.  This PR does that for some visible strings from Core.  There are probably others -- I think it's okay if we don't change every last one as long as we get the common cases.  Let me know if you can think of others to change here.

There's a separate PR that does this all across the frontend (the target branch of this PR).

r? @patrickxb @zapu 