### PR TITLE
Hide/unhide in info panel

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -151,16 +151,6 @@ The app uses [storybook](https://storybook.js.org/) snapshots. If you make a cha
 
 To update the stories, first determine which stories changed. Run the tests `yarn test Storyshots` and look for lines containing:
 
-```
-Received value does not match stored snapshot
-# for example
-Received value does not match stored snapshot "Storyshots Wallets/Transaction Account (receiverOnly) 1".
-```
-
-```
-yarn test Storyshots 2>&1 | grep "Received value does not match stored snapshot"
-```
-
 Run the local storybook server. Verify that the affected stories look correct.
 
 ```

--- a/shared/chat/conversation/info-panel/channel-utils.js
+++ b/shared/chat/conversation/info-panel/channel-utils.js
@@ -41,27 +41,32 @@ const DangerButton = (props: {label: string, onClick: () => void}) => (
 const CaptionedDangerIcon = ({
   icon,
   caption,
+  noDanger,
   onClick,
 }: {
-  icon: Kb.IconType,
+  icon?: Kb.IconType,
   caption: string,
+  noDanger?: boolean,
   onClick: () => void,
-}) => (
-  <Kb.ClickableBox
-    style={{
-      ...Styles.globalStyles.flexBoxRow,
-      alignItems: 'center',
-      justifyContent: 'center',
-      paddingBottom: Styles.globalMargins.tiny,
-      paddingTop: Styles.globalMargins.tiny,
-    }}
-    onClick={onClick}
-  >
-    <Kb.Icon type={icon} style={{marginRight: Styles.globalMargins.tiny}} color={Styles.globalColors.red} />
-    <Kb.Text type="BodySemibold" style={{color: Styles.globalColors.red}} className="hover-underline">
-      {caption}
-    </Kb.Text>
-  </Kb.ClickableBox>
-)
+}) => {
+  const color = noDanger ? null : Styles.globalColors.red
+  return (
+    <Kb.ClickableBox
+      style={{
+        ...Styles.globalStyles.flexBoxRow,
+        alignItems: 'center',
+        justifyContent: 'center',
+        paddingBottom: Styles.globalMargins.tiny,
+        paddingTop: Styles.globalMargins.tiny,
+      }}
+      onClick={onClick}
+    >
+      {!!icon && <Kb.Icon type={icon} style={{marginRight: Styles.globalMargins.tiny}} color={color} />}
+      <Kb.Text type="BodySemibold" style={{color: color}} className="hover-underline">
+        {caption}
+      </Kb.Text>
+    </Kb.ClickableBox>
+  )
+}
 
 export {CaptionedButton, DangerButton, CaptionedDangerIcon}

--- a/shared/chat/conversation/info-panel/container.js
+++ b/shared/chat/conversation/info-panel/container.js
@@ -10,6 +10,7 @@ import {connect, getRouteProps, isMobile, type RouteProps} from '../../../util/c
 import {createShowUserProfile} from '../../../actions/profile-gen'
 import {getCanPerform} from '../../../constants/teams'
 import {Box} from '../../../common-adapters'
+import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
 
 type OwnProps = {|
   conversationIDKey: Types.ConversationIDKey,
@@ -45,6 +46,7 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
     canSetRetention,
     channelname: meta.channelname,
     description: meta.description,
+    ignored: meta.status === RPCChatTypes.commonConversationStatus.ignored,
     isPreview: meta.membershipType === 'youArePreviewing',
     selectedConversationIDKey: conversationIDKey,
     smallTeam: meta.teamType !== 'big',
@@ -68,6 +70,7 @@ const mapDispatchToProps = (dispatch, {conversationIDKey, onBack}: OwnProps) => 
       })
     )
   },
+  onHideConv: () => dispatch(Chat2Gen.createHideConversation({conversationIDKey})),
   onJoinChannel: () => dispatch(Chat2Gen.createJoinConversation({conversationIDKey})),
   onLeaveConversation: () => dispatch(Chat2Gen.createLeaveConversation({conversationIDKey})),
   onShowBlockConversationDialog: () => {
@@ -95,6 +98,7 @@ const mapDispatchToProps = (dispatch, {conversationIDKey, onBack}: OwnProps) => 
     )
   },
   onShowProfile: (username: string) => dispatch(createShowUserProfile({username})),
+  onUnhideConv: () => dispatch(Chat2Gen.createUnhideConversation({conversationIDKey})),
 })
 
 // state props
@@ -107,16 +111,19 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   channelname: stateProps.channelname,
   customCancelText: 'Done',
   description: stateProps.description,
+  ignored: stateProps.ignored,
   isPreview: stateProps.isPreview,
   onBack: ownProps.onBack,
   onCancel: ownProps.onCancel,
   onEditChannel: () => dispatchProps._onEditChannel(stateProps.teamname),
+  onHideConv: dispatchProps.onHideConv,
   onJoinChannel: dispatchProps.onJoinChannel,
   onLeaveConversation: dispatchProps.onLeaveConversation,
   onShowBlockConversationDialog: dispatchProps.onShowBlockConversationDialog,
   onShowClearConversationDialog: () => dispatchProps._onShowClearConversationDialog(),
   onShowNewTeamDialog: dispatchProps.onShowNewTeamDialog,
   onShowProfile: dispatchProps.onShowProfile,
+  onUnhideConv: dispatchProps.onUnhideConv,
   participants: stateProps._participants
     .map(p => ({
       fullname: stateProps._infoMap.getIn([p, 'fullname'], ''),

--- a/shared/chat/conversation/info-panel/index.js
+++ b/shared/chat/conversation/info-panel/index.js
@@ -44,6 +44,7 @@ type InfoPanelProps = {|
   channelname: ?string,
   smallTeam: boolean,
   admin: boolean,
+  ignored: boolean,
 
   // Used by HeaderHoc.
   onBack: () => void,
@@ -55,6 +56,8 @@ type InfoPanelProps = {|
   onShowBlockConversationDialog: () => void,
   onShowClearConversationDialog: () => void,
   onShowNewTeamDialog: () => void,
+  onHideConv: () => void,
+  onUnhideConv: () => void,
 
   // Used for small and big teams.
   canSetMinWriterRole: boolean,
@@ -161,6 +164,18 @@ type ClearThisConversationRow = {
   onShowClearConversationDialog: () => void,
 }
 
+type HideThisConversationRow = {
+  type: 'hide this conversation',
+  key: 'hide this conversation',
+  onHideConv: () => void,
+}
+
+type UnhideThisConversationRow = {
+  type: 'unhide this conversation',
+  key: 'unhide this conversation',
+  onUnhideConv: () => void,
+}
+
 type ParticipantCountRow = {
   type: 'participant count',
   key: 'participant count',
@@ -214,6 +229,8 @@ type TeamHeaderRow =
   | ParticipantCountRow
   | RetentionRow
   | ClearThisConversationRow
+  | HideThisConversationRow
+  | UnhideThisConversationRow
   | SmallTeamHeaderRow
   | BigTeamHeaderRow
   | JoinChannelRow
@@ -229,6 +246,8 @@ type Row =
   | TurnIntoTeamRow
   | ClearThisConversationRow
   | BlockThisConversationRow
+  | HideThisConversationRow
+  | UnhideThisConversationRow
   | TeamHeaderRow
 
 const typeSizeEstimator = (row: Row): number => {
@@ -301,6 +320,27 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
             caption="Clear entire conversation"
             onClick={row.onShowClearConversationDialog}
             icon="iconfont-fire"
+          />
+        )
+
+      case 'hide this conversation':
+        return (
+          <CaptionedDangerIcon
+            key="hide this conversation"
+            caption="Hide this conversation"
+            onClick={row.onHideConv}
+            noDanger={true}
+            icon="iconfont-remove"
+          />
+        )
+
+      case 'unhide this conversation':
+        return (
+          <CaptionedDangerIcon
+            key="unhide this conversation"
+            caption="Unhide this conversation"
+            onClick={row.onUnhideConv}
+            noDanger={true}
           />
         )
 
@@ -503,6 +543,22 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
             marginTop: 8,
             type: 'divider',
           },
+          props.ignored
+            ? {
+                key: 'unhide this conversation',
+                onUnhideConv: props.onUnhideConv,
+                type: 'unhide this conversation',
+              }
+            : {
+                key: 'hide this conversation',
+                onHideConv: props.onHideConv,
+                type: 'hide this conversation',
+              },
+          {
+            key: nextKey(),
+            marginTop: 8,
+            type: 'divider',
+          },
           {
             key: 'participant count',
             label: 'In this team',
@@ -696,6 +752,22 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
           onShowBlockConversationDialog: props.onShowBlockConversationDialog,
           type: 'block this conversation',
         },
+        {
+          key: nextKey(),
+          marginTop: 8,
+          type: 'divider',
+        },
+        props.ignored
+          ? {
+              key: 'unhide this conversation',
+              onUnhideConv: props.onUnhideConv,
+              type: 'unhide this conversation',
+            }
+          : {
+              key: 'hide this conversation',
+              onHideConv: props.onHideConv,
+              type: 'hide this conversation',
+            },
         {
           height: globalMargins.small,
           key: nextKey(),

--- a/shared/chat/conversation/info-panel/index.stories.js
+++ b/shared/chat/conversation/info-panel/index.stories.js
@@ -65,8 +65,11 @@ const provider = Sb.createPropProviderWithCommon({
 const commonProps = {
   canDeleteHistory: true,
   canSetMinWriterRole: false,
+  ignored: false,
   onBack: Sb.unexpected('onBack'),
+  onHideConv: Sb.action(`onHideConv`),
   onShowProfile: (username: string) => Sb.action(`onShowProfile(${username})`),
+  onUnhideConv: Sb.action(`onUnhideConv`),
   participants: [
     {
       fullname: 'Fred Akalin',
@@ -175,8 +178,10 @@ const load = () => {
     .addDecorator(story => (
       <Box style={{...globalStyles.flexBoxColumn, height: 500, width: 320}}>{story()}</Box>
     ))
-    .add('Conversation', () => <InfoPanel {...conversationProps} />)
+    .add('Adhoc conv', () => <InfoPanel {...conversationProps} />)
+    .add('Adhoc conv (hidden)', () => <InfoPanel {...conversationProps} ignored={true} />)
     .add('Small team', () => <InfoPanel {...smallTeamProps} />)
+    .add('Small team (hidden)', () => <InfoPanel {...smallTeamProps} ignored={true} />)
     .add('Big team lotsa users', () => <InfoPanel {...bigTeamLotsaUsersCommonProps} />)
     .add('Big team preview', () => <InfoPanel {...bigTeamPreviewProps} />)
     .add('Big team no preview', () => <InfoPanel {...bigTeamNoPreviewProps} />)

--- a/shared/chat/conversation/info-panel/menu/container.js
+++ b/shared/chat/conversation/info-panel/menu/container.js
@@ -98,9 +98,7 @@ const mapDispatchToProps = (dispatch, {teamname, conversationIDKey}: OwnProps) =
       dispatch(RouteTreeGen.createSwitchTo({path: [teamsTab]}))
     }
   },
-  onHideConv: () => {
-    dispatch(ChatGen.createHideConversation({conversationIDKey}))
-  },
+  onHideConv: () => dispatch(ChatGen.createHideConversation({conversationIDKey})),
   onInvite: () => {
     if (flags.useNewRouter) {
       dispatch(
@@ -125,9 +123,7 @@ const mapDispatchToProps = (dispatch, {teamname, conversationIDKey}: OwnProps) =
     dispatch(RouteTreeGen.createNavigateAppend({path: [{props: {teamname}, selected: 'chatManageChannels'}]}))
     dispatch(TeamsGen.createAddTeamWithChosenChannels({teamname}))
   },
-  onUnhideConv: () => {
-    dispatch(ChatGen.createUnhideConversation({conversationIDKey}))
-  },
+  onUnhideConv: () => dispatch(ChatGen.createUnhideConversation({conversationIDKey})),
   onViewTeam: () => {
     if (flags.useNewRouter) {
       dispatch(RouteTreeGen.createClearModals())


### PR DESCRIPTION
Hide and unhide ad-hoc and small team convs from the info panel.

![image](https://user-images.githubusercontent.com/705646/55188075-e1eb6c00-5170-11e9-8cf2-cdf3438066f5.png)
