### PR TITLE
add support for claiming bech32 bitcoin addresses

### DIFF
--- a/go/client/cmd_currency.go
+++ b/go/client/cmd_currency.go
@@ -6,6 +6,7 @@ package client
 import (
 	"errors"
 	"fmt"
+
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"

--- a/go/engine/cryptocurrency.go
+++ b/go/engine/cryptocurrency.go
@@ -74,9 +74,12 @@ func (e *CryptocurrencyEngine) Run(m libkb.MetaContext) (err error) {
 	var typ libkb.CryptocurrencyType
 	e.arg.Address = normalizeAddress(e.arg.Address)
 	typ, _, err = libkb.CryptocurrencyParseAndCheck(e.arg.Address)
-
 	if err != nil {
 		return libkb.InvalidAddressError{Msg: err.Error()}
+	}
+	if e.arg.Address[0:3] == "bc1" && !m.G().FeatureFlags.Enabled(m, libkb.CreateBTCBech32) {
+		// delete this around June 2019
+		return libkb.InvalidAddressError{Msg: "cannot sign bech32 bitcoin addresses yet"}
 	}
 
 	family := typ.ToCryptocurrencyFamily()

--- a/go/libkb/cryptocurrency.go
+++ b/go/libkb/cryptocurrency.go
@@ -6,8 +6,9 @@ package libkb
 import (
 	"crypto/sha256"
 	"errors"
-	"github.com/btcsuite/btcutil/bech32"
 	"strings"
+
+	"github.com/btcsuite/btcutil/bech32"
 )
 
 type CryptocurrencyType int
@@ -18,6 +19,7 @@ const (
 	CryptocurrencyTypeNone                  CryptocurrencyType = -1
 	CryptocurrencyTypeBTC                   CryptocurrencyType = 0      // 0x0
 	CryptocurrencyTypeBTCMultiSig           CryptocurrencyType = 5      // 0x5
+	CryptocurrencyTypeBTCSegwit             CryptocurrencyType = 0x6263 // "bc"
 	CryptocurrencyTypeZCashShielded         CryptocurrencyType = 5786   // 0x169a
 	CryptocurrencyTypeZCashTransparentP2PKH CryptocurrencyType = 7352   // 0x1cb8
 	CryptocurrencyTypeZCashTransparentP2SH  CryptocurrencyType = 7357   // 0x1cbd
@@ -49,7 +51,7 @@ type CryptocurrencyPrefix struct {
 
 func (p CryptocurrencyType) String() string {
 	switch p {
-	case CryptocurrencyTypeBTC, CryptocurrencyTypeBTCMultiSig:
+	case CryptocurrencyTypeBTC, CryptocurrencyTypeBTCMultiSig, CryptocurrencyTypeBTCSegwit:
 		return "bitcoin"
 	case CryptocurrencyTypeZCashShielded:
 		return "zcash.z"
@@ -64,7 +66,7 @@ func (p CryptocurrencyType) String() string {
 
 func (p CryptocurrencyType) ToCryptocurrencyFamily() CryptocurrencyFamily {
 	switch p {
-	case CryptocurrencyTypeBTC, CryptocurrencyTypeBTCMultiSig:
+	case CryptocurrencyTypeBTC, CryptocurrencyTypeBTCMultiSig, CryptocurrencyTypeBTCSegwit:
 		return CryptocurrencyFamilyBitcoin
 	case CryptocurrencyTypeZCashShielded, CryptocurrencyTypeZCashTransparentP2PKH, CryptocurrencyTypeZCashTransparentP2SH, CryptocurrencyTypeZCashSapling:
 		return CryptocurrencyFamilyZCash
@@ -117,9 +119,27 @@ func cryptocurrencyIsZCashSaplingViaPrefix(s string) bool {
 	return len(s) > 3 && strings.ToLower(s[0:3]) == "zs1"
 }
 
+func cryptocurrencyParseBTCSegwit(s string) (CryptocurrencyType, []byte, error) {
+	hrp, decoded, err := bech32.Decode(s)
+	if err != nil {
+		return CryptocurrencyTypeNone, nil, err
+	}
+	if strings.ToLower(hrp) != "bc" {
+		return CryptocurrencyTypeNone, nil, errors.New("bad prefix after bech32 parse")
+	}
+	return CryptocurrencyTypeBTCSegwit, decoded, nil
+}
+
+func cryptocurrencyIsBTCSegwitViaPrefix(s string) bool {
+	return len(s) > 3 && strings.ToLower(s[0:3]) == "bc1"
+}
+
 func CryptocurrencyParseAndCheck(s string) (CryptocurrencyType, []byte, error) {
 
-	if cryptocurrencyIsZCashSaplingViaPrefix(s) {
+	switch {
+	case cryptocurrencyIsBTCSegwitViaPrefix(s):
+		return cryptocurrencyParseBTCSegwit(s)
+	case cryptocurrencyIsZCashSaplingViaPrefix(s):
 		return cryptocurrencyParseZCashSapling(s)
 	}
 
@@ -156,7 +176,7 @@ func BtcAddrCheck(s string, _ *BtcOpts) (version int, pkhash []byte, err error) 
 	if err != nil {
 		return version, pkhash, err
 	}
-	if typ != CryptocurrencyTypeBTC && typ != CryptocurrencyTypeBTCMultiSig {
+	if typ != CryptocurrencyTypeBTC && typ != CryptocurrencyTypeBTCMultiSig && typ != CryptocurrencyTypeBTCSegwit {
 		return int(CryptocurrencyTypeNone), nil, errors.New("only support BTC vanila and multisig")
 	}
 	return int(typ), pkhash, nil

--- a/go/libkb/cryptocurrency.go
+++ b/go/libkb/cryptocurrency.go
@@ -34,7 +34,7 @@ const (
 
 // Wallet and cryptocurrency are separate systems.
 // Wallet links have reverse signatures, and the control secrets are in keybase.
-// Whereas Cryptocurrency links are generally are public only and have no reverse sigs.
+// Whereas Cryptocurrency links are generally public only and have no reverse sigs.
 // CryptocurrencyFamily and WalletNetwork are defined next to each other so that
 // someone will notice if they start to overlap.
 type WalletNetwork string
@@ -177,7 +177,7 @@ func BtcAddrCheck(s string, _ *BtcOpts) (version int, pkhash []byte, err error) 
 		return version, pkhash, err
 	}
 	if typ != CryptocurrencyTypeBTC && typ != CryptocurrencyTypeBTCMultiSig && typ != CryptocurrencyTypeBTCSegwit {
-		return int(CryptocurrencyTypeNone), nil, errors.New("only support BTC vanila and multisig")
+		return int(CryptocurrencyTypeNone), nil, errors.New("unrecognizable btc address")
 	}
 	return int(typ), pkhash, nil
 }

--- a/go/libkb/cryptocurrency_test.go
+++ b/go/libkb/cryptocurrency_test.go
@@ -53,6 +53,7 @@ var testVectors = []struct {
 	{"zs1fw4tgx9gccv2f8af6ugu727slx7pq0nc46yflcuqyluruxtcmg20hxh3r4d9ec9yejj6gfrf2hc", CryptocurrencyTypeZCashSapling},
 	{"ZS1FW4TGX9GCCV2F8AF6UGU727SLX7PQ0NC46YFLCUQYLURUXTCMG20HXH3R4D9EC9YEJJ6GFRF2HC", CryptocurrencyTypeZCashSapling},
 	{"zs1fw4tgx9gccv2f8af6ugu727slx7pq0nc46yflcuqyluruxtcmg20hxh3r4d9ec9yejj6gfrf2hd", CryptocurrencyTypeNone},
+	{"bc1qcerjvfmt8qr8xlp6pv4htjhwlj2wgdjnayc3cc", CryptocurrencyTypeBTCSegwit},
 }
 
 func TestCryptocurrencyParseAndCheck(t *testing.T) {
@@ -65,16 +66,26 @@ func TestCryptocurrencyParseAndCheck(t *testing.T) {
 }
 
 func TestAddressValidation(t *testing.T) {
-	validAddr := "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
-	invalidAddr := "4J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy" // changed first digit
-
-	_, _, err := BtcAddrCheck(validAddr, nil)
-	if err != nil {
-		t.Fatal("Failed to validate a good address.")
+	btcTestAddrs := []struct {
+		address string
+		valid   bool
+	}{
+		{"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy", true},
+		{"4J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy", false}, // changed first digit
+		{"bc1qcerjvfmt8qr8xlp6pv4htjhwlj2wgdjnayc3cc", true},
+		{"bc1qcerjvfmt8qr8xlp6pv4htjhwlj2wgdjnaycccc", false}, // bad checksum
+		{"bc11cerjvfmt8qr8xlp6pv4htjhwlj2wgdjnayc3cc", false},
+		{"bc20cerjvfmt8qr8xlp6pv4htjhwlj2wgdjnayc3cc", false},
+		{"bc1q7k78aepp3epmlzvxwvvhc4up849efeg7r5j0xk", true},
+		{"bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9", true},
 	}
-
-	_, _, err = BtcAddrCheck(invalidAddr, nil)
-	if err == nil {
-		t.Fatal("Failed to catch a bad address.")
+	for _, testAddr := range btcTestAddrs {
+		_, _, err := BtcAddrCheck(testAddr.address, nil)
+		if testAddr.valid && err != nil {
+			t.Fatalf("Failed to validate a good address %s.", testAddr.address)
+		}
+		if !testAddr.valid && err == nil {
+			t.Fatalf("Failed to catch a bad address %s.", testAddr.address)
+		}
 	}
 }

--- a/go/libkb/cryptocurrency_test.go
+++ b/go/libkb/cryptocurrency_test.go
@@ -77,6 +77,7 @@ func TestAddressValidation(t *testing.T) {
 		{"bc11cerjvfmt8qr8xlp6pv4htjhwlj2wgdjnayc3cc", false},
 		{"bc20cerjvfmt8qr8xlp6pv4htjhwlj2wgdjnayc3cc", false},
 		{"bc1q7k78aepp3epmlzvxwvvhc4up849efeg7r5j0xk", true},
+		{"BC1QCERJVFMT8QR8XLP6PV4HTJHWLJ2WGDJNAYC3CC", true}, // uppercase is accepted
 		{"bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9", true},
 	}
 	for _, testAddr := range btcTestAddrs {

--- a/go/systests/cryptocurrency_test.go
+++ b/go/systests/cryptocurrency_test.go
@@ -1,0 +1,43 @@
+package systests
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProveCapitalizedBech32Address(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+	alice := tt.addUser("abc")
+
+	bech32Test := []struct {
+		address string
+		valid   bool
+	}{
+		{"bc1qcerjvfmt8qr8xlp6pv4htjhwlj2wgdjnayc3cc", true},
+		{"BC1QCERJVFMT8QR8XLP6PV4HTJHWLJ2WGDJNAYC3CC", true},  // uppercase is accepted
+		{"BC1qcerJVFMt8qr8XLP6PV4HTJHWLJ2WGDJNAYC3CC", false}, // mixed case is not
+		{"zs1x2q4pej08shm9pd5fx8jvl97f8f7t8sej8lsgp08jsczxsucr5gkff0yasc0gc43dtv3wczerv5", true},
+		{"ZS1X2Q4PEJ08SHM9PD5FX8JVL97F8F7T8SEJ8LSGP08JSCZXSUCR5GKFF0YASC0GC43DTV3WCZERV5", true},
+		{"zs1X2Q4PEJ08SHM9Pd5fx8JVL97F8F7T8SEJ8LSGP08JSCZXSUCR5GKFF0YASC0GC43DTV3wczerv5", false},
+	}
+	for _, testAddr := range bech32Test {
+		eng := engine.NewCryptocurrencyEngine(alice.MetaContext().G(), keybase1.RegisterAddressArg{
+			Address: testAddr.address,
+			Force:   true,
+		})
+		err := engine.RunEngine2(alice.MetaContext().WithUIs(libkb.UIs{
+			LogUI:    alice.MetaContext().G().Log,
+			SecretUI: alice.newSecretUI(),
+		}), eng)
+		if testAddr.valid {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+		}
+	}
+}

--- a/go/systests/cryptocurrency_test.go
+++ b/go/systests/cryptocurrency_test.go
@@ -9,10 +9,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBech32FeatureFlag(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+	jan := tt.addUser("abc")
+	m := libkb.NewMetaContextForTest(*jan.tc)
+
+	runEngine := func() error {
+		eng := engine.NewCryptocurrencyEngine(jan.MetaContext().G(), keybase1.RegisterAddressArg{
+			Address: "bc1qcerjvfmt8qr8xlp6pv4htjhwlj2wgdjnayc3cc",
+			Force:   true,
+		})
+		err := engine.RunEngine2(jan.MetaContext().WithUIs(libkb.UIs{
+			LogUI:    jan.MetaContext().G().Log,
+			SecretUI: jan.newSecretUI(),
+		}), eng)
+		return err
+	}
+	err := runEngine()
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "cannot sign bech32 bitcoin addresses yet")
+
+	err = m.G().FeatureFlags.EnableImmediately(m, libkb.CreateBTCBech32)
+	require.NoError(t, err)
+	err = runEngine()
+	require.NoError(t, err)
+}
+
 func TestProveCapitalizedBech32Address(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 	alice := tt.addUser("abc")
+	m := libkb.NewMetaContextForTest(*alice.tc)
+	err := m.G().FeatureFlags.EnableImmediately(m, libkb.CreateBTCBech32)
+	require.NoError(t, err)
 
 	bech32Test := []struct {
 		address string

--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -27,7 +27,12 @@ const updateUsername = state => {
       break
     case 'btc':
       // A simple check, the server does a fuller check
-      usernameValid = !!username.match(/^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/)
+      const legacyFormat = !!username.match(/^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/)
+      const segwitFormat = !!username.toLowerCase().match(/^(bc1)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{11,71}$/)
+      if (segwitFormat) {
+        username = username.toLowerCase()
+      }
+      usernameValid = legacyFormat || segwitFormat
       break
   }
 

--- a/shared/reducers/profile.js
+++ b/shared/reducers/profile.js
@@ -29,9 +29,6 @@ const updateUsername = state => {
       // A simple check, the server does a fuller check
       const legacyFormat = !!username.match(/^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/)
       const segwitFormat = !!username.toLowerCase().match(/^(bc1)[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{11,71}$/)
-      if (segwitFormat) {
-        username = username.toLowerCase()
-      }
       usernameValid = legacyFormat || segwitFormat
       break
   }


### PR DESCRIPTION
* add bech32 (segwit native) support for bitcoin addresses
* fix a bug with casing bech32 addresses
* put the ability to sign new links behind a feature flag

this depends on https://github.com/keybase/node-bitcoyne/pull/3 and https://github.com/keybase/keybase/pull/3657