### PR TITLE
Make sure all bundle changes update wallet state

### DIFF
--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1649,7 +1649,7 @@ func ChangeAccountName(m libkb.MetaContext, walletState *WalletState, accountID 
 	return walletState.UpdateAccountEntriesWithBundle(m, "change account name", &nextBundle)
 }
 
-func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err error) {
+func SetAccountAsPrimary(m libkb.MetaContext, walletState *WalletState, accountID stellar1.AccountID) (err error) {
 	if accountID.IsNil() {
 		return errors.New("passed empty AccountID")
 	}
@@ -1679,7 +1679,11 @@ func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err
 		return fmt.Errorf("account not found: %v", accountID)
 	}
 	nextBundle := bundle.AdvanceAccounts(*b, []stellar1.AccountID{accountID})
-	return remote.PostWithChainlink(m, nextBundle)
+	if err = remote.PostWithChainlink(m, nextBundle); err != nil {
+		return err
+	}
+
+	return walletState.UpdateAccountEntriesWithBundle(m, "set account as primary", &nextBundle)
 }
 
 func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1616,7 +1616,7 @@ func FormatAmount(mctx libkb.MetaContext, amount string, precisionTwo bool, roun
 // An empty name is not allowed.
 // Renaming an account to an already used name is blocked.
 // Maximum length of AccountNameMaxRunes runes.
-func ChangeAccountName(m libkb.MetaContext, accountID stellar1.AccountID, newName string) (err error) {
+func ChangeAccountName(m libkb.MetaContext, walletState *WalletState, accountID stellar1.AccountID, newName string) (err error) {
 	if newName == "" {
 		return fmt.Errorf("name required")
 	}
@@ -1642,7 +1642,11 @@ func ChangeAccountName(m libkb.MetaContext, accountID stellar1.AccountID, newNam
 		return fmt.Errorf("account not found: %v", accountID)
 	}
 	nextBundle := bundle.AdvanceBundle(*b)
-	return remote.Post(m, nextBundle)
+	if err := remote.Post(m, nextBundle); err != nil {
+		return err
+	}
+
+	return walletState.UpdateAccountEntriesWithBundle(m, "change account name", &nextBundle)
 }
 
 func SetAccountAsPrimary(m libkb.MetaContext, accountID stellar1.AccountID) (err error) {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -560,7 +560,7 @@ func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.
 		return ErrAccountIDMissing
 	}
 
-	return stellar.ChangeAccountName(mctx, arg.AccountID, arg.NewName)
+	return stellar.ChangeAccountName(mctx, s.walletState, arg.AccountID, arg.NewName)
 }
 
 func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (err error) {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -579,7 +579,7 @@ func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar
 		return ErrAccountIDMissing
 	}
 
-	return stellar.SetAccountAsPrimary(mctx, arg.AccountID)
+	return stellar.SetAccountAsPrimary(mctx, s.walletState, arg.AccountID)
 }
 
 func (s *Server) DeleteWalletAccountLocal(ctx context.Context, arg stellar1.DeleteWalletAccountLocalArg) (err error) {
@@ -962,7 +962,15 @@ func (s *Server) SetAccountMobileOnlyLocal(ctx context.Context, arg stellar1.Set
 		return ErrAccountIDMissing
 	}
 
-	return s.remoter.SetAccountMobileOnly(mctx.Ctx(), arg.AccountID)
+	if err = s.remoter.SetAccountMobileOnly(mctx.Ctx(), arg.AccountID); err != nil {
+		return err
+	}
+
+	if err = s.walletState.UpdateAccountEntries(mctx, "set account mobile only"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *Server) SetAccountAllDevicesLocal(ctx context.Context, arg stellar1.SetAccountAllDevicesLocalArg) (err error) {
@@ -980,7 +988,15 @@ func (s *Server) SetAccountAllDevicesLocal(ctx context.Context, arg stellar1.Set
 		return ErrAccountIDMissing
 	}
 
-	return s.remoter.MakeAccountAllDevices(mctx.Ctx(), arg.AccountID)
+	if err = s.remoter.MakeAccountAllDevices(mctx.Ctx(), arg.AccountID); err != nil {
+		return err
+	}
+
+	if err = s.walletState.UpdateAccountEntries(mctx, "set account all devices"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *Server) GetPredefinedInflationDestinationsLocal(ctx context.Context, sessionID int) (ret []stellar1.PredefinedInflationDestination, err error) {

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -332,7 +332,9 @@ func TestChangeWalletName(t *testing.T) {
 	chk("career debter", "")
 
 	// check to make sure that the stored entry in wallet state also changed.
-	tcs[0].Srv.walletState
+	name, err := tcs[0].Srv.walletState.AccountName(accs[0].AccountID)
+	require.NoError(t, err)
+	require.Equal(t, "office lunch money", name)
 
 	accs, err = tcs[0].Srv.WalletGetAccountsCLILocal(context.Background())
 	require.NoError(t, err)

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -429,6 +429,10 @@ func TestSetAccountAsDefault(t *testing.T) {
 	u0addr := u0.StellarAccountID()
 	require.NotNil(t, u0addr)
 	require.Equal(t, additionalAccs[0], *u0addr)
+
+	isPrimary, err := tcs[0].Srv.walletState.IsPrimary(additionalAccs[0])
+	require.NoError(t, err)
+	require.True(t, isPrimary)
 }
 
 func testCreateOrLinkNewAccount(t *testing.T, create bool) {
@@ -2653,6 +2657,10 @@ func TestSetMobileOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, stellar1.AccountMode_MOBILE, details.AccountMode)
 	require.Equal(t, true, details.AccountModeEditable)
+
+	mode, err := tcs[0].Srv.walletState.AccountMode(accountID)
+	require.NoError(t, err)
+	require.Equal(t, stellar1.AccountMode_MOBILE, mode)
 
 	// service_test verifies that `SetAccountMobileOnlyLocal` behaves correctly under the covers
 }

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -331,6 +331,9 @@ func TestChangeWalletName(t *testing.T) {
 	chk("office lunch money", "you already have an account with that name")
 	chk("career debter", "")
 
+	// check to make sure that the stored entry in wallet state also changed.
+	tcs[0].Srv.walletState
+
 	accs, err = tcs[0].Srv.WalletGetAccountsCLILocal(context.Background())
 	require.NoError(t, err)
 	require.Len(t, accs, 1)

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -120,6 +120,33 @@ func (w *WalletState) AccountName(accountID stellar1.AccountID) (string, error) 
 	return a.name, nil
 }
 
+// IsPrimary returns true if an account is the primary account for the user.
+func (w *WalletState) IsPrimary(accountID stellar1.AccountID) (bool, error) {
+	a, ok := w.accountState(accountID)
+	if !ok {
+		return false, ErrAccountNotFound
+	}
+
+	a.RLock()
+	defer a.RUnlock()
+
+	return a.isPrimary, nil
+}
+
+// AccountMode returns the mode of the account (USER or MOBILE).
+// MOBILE accounts can only get access to the secret key from a mobile device.
+func (w *WalletState) AccountMode(accountID stellar1.AccountID) (stellar1.AccountMode, error) {
+	a, ok := w.accountState(accountID)
+	if !ok {
+		return stellar1.AccountMode_NONE, ErrAccountNotFound
+	}
+
+	a.RLock()
+	defer a.RUnlock()
+
+	return a.accountMode, nil
+}
+
 // accountState returns the AccountState object for an accountID.
 // If it doesn't exist in `accounts`, it will return nil, false.
 func (w *WalletState) accountState(accountID stellar1.AccountID) (*AccountState, bool) {

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -228,10 +228,22 @@ func (w *WalletState) UpdateAccountEntriesWithBundle(mctx libkb.MetaContext, rea
 		return errors.New("nil bundle")
 	}
 
+	active := make(map[stellar1.AccountID]bool)
 	for _, account := range bundle.Accounts {
 		a, _ := w.accountStateBuild(account.AccountID)
 		a.updateEntry(account)
+		active[account.AccountID] = true
 	}
+
+	// clean out any unusued accounts
+	w.Lock()
+	for accountID, _ := range w.accounts {
+		if active[accountID] {
+			continue
+		}
+		delete(w.accounts, accountID)
+	}
+	w.Unlock()
 
 	return nil
 }

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -237,7 +237,7 @@ func (w *WalletState) UpdateAccountEntriesWithBundle(mctx libkb.MetaContext, rea
 
 	// clean out any unusued accounts
 	w.Lock()
-	for accountID, _ := range w.accounts {
+	for accountID := range w.accounts {
 		if active[accountID] {
 			continue
 		}

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -107,6 +107,19 @@ func (w *WalletState) BaseFee(mctx libkb.MetaContext) uint64 {
 	return w.options.BaseFee(mctx, w)
 }
 
+// AccountName returns the name for an account.
+func (w *WalletState) AccountName(accountID stellar1.AccountID) (string, error) {
+	a, ok := w.accountState(accountID)
+	if !ok {
+		return "", ErrAccountNotFound
+	}
+
+	a.RLock()
+	defer a.RUnlock()
+
+	return a.name, nil
+}
+
 // accountState returns the AccountState object for an accountID.
 // If it doesn't exist in `accounts`, it will return nil, false.
 func (w *WalletState) accountState(accountID stellar1.AccountID) (*AccountState, bool) {
@@ -176,7 +189,7 @@ func (w *WalletState) UpdateAccountEntries(mctx libkb.MetaContext, reason string
 		return err
 	}
 
-	return UpdateAccountEntriesWithBundle(mctx, reason, bundle)
+	return w.UpdateAccountEntriesWithBundle(mctx, reason, bundle)
 }
 
 // UpdateAccountEntriesWithBundle updates the individual account entries with the


### PR DESCRIPTION
There's a bug where if you change your bundle (say change an account name) the wallet state can be stale for some time and send old data with its notifications to the frontend.

This PR fixes that so that any bundle changes update wallet state.

cc @buoyad 