### PR TITLE
skip checking for existing topic name for flip convs

### DIFF
--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -31,7 +31,7 @@ func setupLoaderTest(t *testing.T) (context.Context, *kbtest.ChatTestContext, *k
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := baseSender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_IMPTEAMNATIVE, nil)
+		chat1.ConversationMembersType_IMPTEAMNATIVE, nil, nil)
 	firstMessageBoxed := prepareRes.Boxed
 	require.NoError(t, err)
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -41,7 +41,7 @@ func testGetThreadSupersedes(t *testing.T, deleteHistory bool) {
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := sender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_KBFS, nil)
+		chat1.ConversationMembersType_KBFS, nil, nil)
 	require.NoError(t, err)
 	firstMessageBoxed := prepareRes.Boxed
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -175,7 +175,7 @@ func TestExplodeNow(t *testing.T) {
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := sender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_TEAM, nil)
+		chat1.ConversationMembersType_TEAM, nil, nil)
 	require.NoError(t, err)
 	firstMessageBoxed := prepareRes.Boxed
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -309,7 +309,7 @@ func TestReactions(t *testing.T) {
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := sender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_TEAM, nil)
+		chat1.ConversationMembersType_TEAM, nil, nil)
 	require.NoError(t, err)
 	firstMessageBoxed := prepareRes.Boxed
 
@@ -893,7 +893,7 @@ func TestGetThreadCaching(t *testing.T) {
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := sender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_KBFS, nil)
+		chat1.ConversationMembersType_KBFS, nil, nil)
 	require.NoError(t, err)
 	firstMessageBoxed := prepareRes.Boxed
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -1010,7 +1010,7 @@ func TestGetThreadHoleResolution(t *testing.T) {
 		pt.MessageBody = chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: fmt.Sprintf("MIKE: %d", i),
 		})
-		prepareRes, err := sender.Prepare(ctx, pt, chat1.ConversationMembersType_KBFS, &conv)
+		prepareRes, err := sender.Prepare(ctx, pt, chat1.ConversationMembersType_KBFS, &conv, nil)
 		require.NoError(t, err)
 		msg = &prepareRes.Boxed
 

--- a/go/chat/devstorage.go
+++ b/go/chat/devstorage.go
@@ -39,7 +39,8 @@ func (s *DevConversationBackedStorage) Put(ctx context.Context, uid gregor1.UID,
 		return err
 	}
 	conv, err := NewConversation(ctx, s.G(), uid, username, &name, chat1.TopicType_DEV,
-		chat1.ConversationMembersType_IMPTEAMNATIVE, keybase1.TLFVisibility_PRIVATE, s.ri)
+		chat1.ConversationMembersType_IMPTEAMNATIVE, keybase1.TLFVisibility_PRIVATE, s.ri,
+		NewConvFindExistingNormal)
 	if err != nil {
 		return err
 	}

--- a/go/chat/ephemeral_purger_test.go
+++ b/go/chat/ephemeral_purger_test.go
@@ -44,7 +44,7 @@ func TestBackgroundPurge(t *testing.T) {
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := baseSender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_IMPTEAMNATIVE, nil)
+		chat1.ConversationMembersType_IMPTEAMNATIVE, nil, nil)
 	firstMessageBoxed := prepareRes.Boxed
 	require.NoError(t, err)
 	conv2, err := ri().NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/flipmanager.go
+++ b/go/chat/flipmanager.go
@@ -982,9 +982,9 @@ func (m *FlipManager) StartFlip(ctx context.Context, uid gregor1.UID, hostConvID
 	go func() {
 		var err error
 		topicName := m.gameTopicNameFromGameID(gameID)
-		conv, err = m.G().ChatHelper.NewConversationWithMemberSourceConv(ctx, uid, tlfName, &topicName,
+		conv, err = NewConversationWithMemberSourceConv(ctx, m.G(), uid, tlfName, &topicName,
 			chat1.TopicType_DEV, hostConv.GetMembersType(),
-			keybase1.TLFVisibility_PRIVATE, &hostConvID)
+			keybase1.TLFVisibility_PRIVATE, m.ri, NewConvFindExistingSkip, &hostConvID)
 		convCreatedCh <- err
 	}()
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -1215,9 +1215,11 @@ func (n *newConversationHelper) makeFirstMessage(ctx context.Context, triple cha
 			},
 		}
 	}
-
+	opts := types.SenderPrepareOptions{
+		SkipTopicNameState: n.findExistingMode == NewConvFindExistingSkip,
+	}
 	sender := NewBlockingSender(n.G(), NewBoxer(n.G()), n.ri)
-	prepareRes, err := sender.Prepare(ctx, msg, membersType, nil)
+	prepareRes, err := sender.Prepare(ctx, msg, membersType, nil, opts)
 	return &prepareRes.Boxed, prepareRes.TopicNameState, err
 }
 

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -40,14 +40,14 @@ func (h *Helper) NewConversation(ctx context.Context, uid gregor1.UID, tlfName s
 	topicName *string, topicType chat1.TopicType, membersType chat1.ConversationMembersType,
 	vis keybase1.TLFVisibility) (chat1.ConversationLocal, error) {
 	return NewConversation(ctx, h.G(), uid, tlfName, topicName,
-		topicType, membersType, vis, h.ri)
+		topicType, membersType, vis, h.ri, NewConvFindExistingNormal)
 }
 
 func (h *Helper) NewConversationWithMemberSourceConv(ctx context.Context, uid gregor1.UID, tlfName string,
 	topicName *string, topicType chat1.TopicType, membersType chat1.ConversationMembersType,
 	vis keybase1.TLFVisibility, memberSourceConv *chat1.ConversationID) (chat1.ConversationLocal, error) {
 	return NewConversationWithMemberSourceConv(ctx, h.G(), uid, tlfName, topicName,
-		topicType, membersType, vis, h.ri, memberSourceConv)
+		topicType, membersType, vis, h.ri, NewConvFindExistingNormal, memberSourceConv)
 }
 
 func (h *Helper) SendTextByID(ctx context.Context, convID chat1.ConversationID,
@@ -336,7 +336,8 @@ func (s *sendHelper) conversation(ctx context.Context) error {
 	}
 	uid := gregor1.UID(kuid.ToBytes())
 	conv, err := NewConversation(ctx, s.G(), uid, s.name, s.topicName,
-		chat1.TopicType_CHAT, s.membersType, keybase1.TLFVisibility_PRIVATE, s.remoteInterface)
+		chat1.TopicType_CHAT, s.membersType, keybase1.TLFVisibility_PRIVATE, s.remoteInterface,
+		NewConvFindExistingNormal)
 	if err != nil {
 		return err
 	}
@@ -863,17 +864,26 @@ func PreviewConversation(ctx context.Context, g *globals.Context, debugger utils
 	return nil
 }
 
+type NewConvFindExistingMode int
+
+const (
+	NewConvFindExistingNormal NewConvFindExistingMode = iota
+	NewConvFindExistingSkip
+)
+
 func NewConversation(ctx context.Context, g *globals.Context, uid gregor1.UID, tlfName string,
 	topicName *string, topicType chat1.TopicType, membersType chat1.ConversationMembersType,
-	vis keybase1.TLFVisibility, ri func() chat1.RemoteInterface) (chat1.ConversationLocal, error) {
-	return NewConversationWithMemberSourceConv(ctx, g, uid, tlfName, topicName, topicType, membersType, vis, ri, nil)
+	vis keybase1.TLFVisibility, ri func() chat1.RemoteInterface, findExistingMode NewConvFindExistingMode) (chat1.ConversationLocal, error) {
+	return NewConversationWithMemberSourceConv(ctx, g, uid, tlfName, topicName, topicType, membersType, vis, ri, findExistingMode, nil)
 }
 
-func NewConversationWithMemberSourceConv(ctx context.Context, g *globals.Context, uid gregor1.UID, tlfName string,
-	topicName *string, topicType chat1.TopicType, membersType chat1.ConversationMembersType,
-	vis keybase1.TLFVisibility, ri func() chat1.RemoteInterface, memberSourceConv *chat1.ConversationID) (chat1.ConversationLocal, error) {
+func NewConversationWithMemberSourceConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
+	tlfName string, topicName *string, topicType chat1.TopicType, membersType chat1.ConversationMembersType,
+	vis keybase1.TLFVisibility, ri func() chat1.RemoteInterface,
+	findExistingMode NewConvFindExistingMode, memberSourceConv *chat1.ConversationID) (chat1.ConversationLocal, error) {
 	defer utils.SuspendComponent(ctx, g, g.ConvLoader)()
-	helper := newNewConversationHelper(g, uid, tlfName, topicName, topicType, membersType, vis, ri, memberSourceConv)
+	helper := newNewConversationHelper(g, uid, tlfName, topicName, topicType, membersType, vis, ri,
+		findExistingMode, memberSourceConv)
 	return helper.create(ctx)
 }
 
@@ -889,11 +899,13 @@ type newConversationHelper struct {
 	memberSourceConv *chat1.ConversationID
 	vis              keybase1.TLFVisibility
 	ri               func() chat1.RemoteInterface
+	findExistingMode NewConvFindExistingMode
 }
 
 func newNewConversationHelper(g *globals.Context, uid gregor1.UID, tlfName string, topicName *string,
 	topicType chat1.TopicType, membersType chat1.ConversationMembersType, vis keybase1.TLFVisibility,
-	ri func() chat1.RemoteInterface, memberSourceConv *chat1.ConversationID) *newConversationHelper {
+	ri func() chat1.RemoteInterface, findExistingMode NewConvFindExistingMode,
+	memberSourceConv *chat1.ConversationID) *newConversationHelper {
 	return &newConversationHelper{
 		Contextified:     globals.NewContextified(g),
 		DebugLabeler:     utils.NewDebugLabeler(g.GetLog(), "newConversationHelper", false),
@@ -905,26 +917,33 @@ func newNewConversationHelper(g *globals.Context, uid gregor1.UID, tlfName strin
 		memberSourceConv: memberSourceConv,
 		vis:              vis,
 		ri:               ri,
+		findExistingMode: findExistingMode,
 	}
 }
 
 func (n *newConversationHelper) findExisting(ctx context.Context, tlfID chat1.TLFID, topicName string,
 	dataSource types.InboxSourceDataSourceTyp) (res []chat1.ConversationLocal, err error) {
-	ib, _, err := n.G().InboxSource.Read(ctx, n.uid, types.ConversationLocalizerBlocking,
-		dataSource, nil, &chat1.GetInboxLocalQuery{
-			Name: &chat1.NameQuery{
-				Name:        n.tlfName,
-				TlfID:       &tlfID,
-				MembersType: n.membersType,
-			},
-			TlfVisibility: &n.vis,
-			TopicName:     &topicName,
-			TopicType:     &n.topicType,
-		}, nil)
-	if err != nil {
-		return res, err
+	switch n.findExistingMode {
+	case NewConvFindExistingNormal:
+		ib, _, err := n.G().InboxSource.Read(ctx, n.uid, types.ConversationLocalizerBlocking,
+			dataSource, nil, &chat1.GetInboxLocalQuery{
+				Name: &chat1.NameQuery{
+					Name:        n.tlfName,
+					TlfID:       &tlfID,
+					MembersType: n.membersType,
+				},
+				TlfVisibility: &n.vis,
+				TopicName:     &topicName,
+				TopicType:     &n.topicType,
+			}, nil)
+		if err != nil {
+			return res, err
+		}
+		return ib.Convs, nil
+	case NewConvFindExistingSkip:
+		return nil, nil
 	}
-	return ib.Convs, nil
+	return nil, nil
 }
 
 func (n *newConversationHelper) getNameInfo(ctx context.Context) (res types.NameInfo, err error) {

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -1219,7 +1219,7 @@ func (n *newConversationHelper) makeFirstMessage(ctx context.Context, triple cha
 		SkipTopicNameState: n.findExistingMode == NewConvFindExistingSkip,
 	}
 	sender := NewBlockingSender(n.G(), NewBoxer(n.G()), n.ri)
-	prepareRes, err := sender.Prepare(ctx, msg, membersType, nil, opts)
+	prepareRes, err := sender.Prepare(ctx, msg, membersType, nil, &opts)
 	return &prepareRes.Boxed, prepareRes.TopicNameState, err
 }
 

--- a/go/chat/helper_test.go
+++ b/go/chat/helper_test.go
@@ -152,7 +152,7 @@ func TestTopicNameRace(t *testing.T) {
 				ctx = globals.CtxAddLogTags(ctx, tc.Context())
 				conv, err := NewConversation(ctx, tc.Context(), uid, first.TlfName, &topicName,
 					chat1.TopicType_DEV, mt, keybase1.TLFVisibility_PRIVATE,
-					func() chat1.RemoteInterface { return ri })
+					func() chat1.RemoteInterface { return ri }, NewConvFindExistingNormal)
 				retCh <- ncRes{convID: conv.GetConvID(), err: err}
 			}()
 		}

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -123,7 +123,7 @@ func TestInboxSourceSkipAhead(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: "HIHI",
 		}),
-	}, chat1.ConversationMembersType_KBFS, &conv)
+	}, chat1.ConversationMembersType_KBFS, &conv, nil)
 	require.NoError(t, err)
 	boxed := prepareRes.Boxed
 

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -378,7 +378,7 @@ func TestNonblockTimer(t *testing.T) {
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := baseSender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_KBFS, nil)
+		chat1.ConversationMembersType_KBFS, nil, nil)
 	require.NoError(t, err)
 	firstMessageBoxed := prepareRes.Boxed
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{
@@ -513,7 +513,8 @@ func (f FailingSender) Send(ctx context.Context, convID chat1.ConversationID,
 }
 
 func (f FailingSender) Prepare(ctx context.Context, msg chat1.MessagePlaintext,
-	membersType chat1.ConversationMembersType, convID *chat1.Conversation) (types.SenderPrepareResult, error) {
+	membersType chat1.ConversationMembersType, convID *chat1.Conversation,
+	opts *types.SenderPrepareOptions) (types.SenderPrepareResult, error) {
 	return types.SenderPrepareResult{}, nil
 }
 
@@ -831,7 +832,7 @@ func TestDeletionHeaders(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: []chat1.MessageID{firstMessageID}}),
 	}
 	prepareRes, err := blockingSender.Prepare(ctx, deletion,
-		chat1.ConversationMembersType_KBFS, &conv)
+		chat1.ConversationMembersType_KBFS, &conv, nil)
 	require.NoError(t, err)
 	preparedDeletion := prepareRes.Boxed
 
@@ -879,7 +880,7 @@ func TestAtMentionsText(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: text,
 		}),
-	}, chat1.ConversationMembersType_KBFS, &conv)
+	}, chat1.ConversationMembersType_KBFS, &conv, nil)
 	require.NoError(t, err)
 	atMentions := prepareRes.AtMentions
 	chanMention := prepareRes.ChannelMention
@@ -897,7 +898,7 @@ func TestAtMentionsText(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: text,
 		}),
-	}, chat1.ConversationMembersType_KBFS, &conv)
+	}, chat1.ConversationMembersType_KBFS, &conv, nil)
 	require.NoError(t, err)
 	atMentions = prepareRes.AtMentions
 	chanMention = prepareRes.ChannelMention
@@ -948,7 +949,7 @@ func TestAtMentionsEdit(t *testing.T) {
 			MessageID: firstMessageID,
 			Body:      text,
 		}),
-	}, chat1.ConversationMembersType_KBFS, &conv)
+	}, chat1.ConversationMembersType_KBFS, &conv, nil)
 	require.NoError(t, err)
 	atMentions := prepareRes.AtMentions
 	chanMention := prepareRes.ChannelMention
@@ -969,7 +970,7 @@ func TestAtMentionsEdit(t *testing.T) {
 			MessageID: firstMessageID,
 			Body:      text,
 		}),
-	}, chat1.ConversationMembersType_KBFS, &conv)
+	}, chat1.ConversationMembersType_KBFS, &conv, nil)
 	require.NoError(t, err)
 	atMentions = prepareRes.AtMentions
 	chanMention = prepareRes.ChannelMention
@@ -993,7 +994,7 @@ func TestKBFSFileEditSize(t *testing.T) {
 		tc := userTc(t, world, u)
 		conv, err := NewConversation(ctx, tc.Context(), uid, tlfName, nil, chat1.TopicType_KBFSFILEEDIT,
 			chat1.ConversationMembersType_IMPTEAMNATIVE, keybase1.TLFVisibility_PRIVATE,
-			func() chat1.RemoteInterface { return ri })
+			func() chat1.RemoteInterface { return ri }, NewConvFindExistingNormal)
 		require.NoError(t, err)
 
 		body := strings.Repeat("M", 100000)
@@ -1111,7 +1112,7 @@ func TestPrevPointerAddition(t *testing.T) {
 					EphemeralMetadata: ephemeralMetadata,
 				},
 				MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
-			}, mt, &conv)
+			}, mt, &conv, nil)
 			require.NoError(t, err)
 			boxed := prepareRes.Boxed
 			pendingAssetDeletes := prepareRes.PendingAssetDeletes
@@ -1142,7 +1143,7 @@ func TestPrevPointerAddition(t *testing.T) {
 				MessageType: chat1.MessageType_TEXT,
 			},
 			MessageBody: chat1.NewMessageBodyWithText(chat1.MessageText{Body: "foo"}),
-		}, mt, &conv)
+		}, mt, &conv, nil)
 		require.NoError(t, err)
 		boxed := prepareRes.Boxed
 		pendingAssetDeletes := prepareRes.PendingAssetDeletes
@@ -1250,7 +1251,7 @@ func TestDeletionAssets(t *testing.T) {
 		MessageBody: chat1.NewMessageBodyWithDelete(chat1.MessageDelete{MessageIDs: []chat1.MessageID{firstMessageID}}),
 	}
 	prepareRes, err := blockingSender.Prepare(ctx, deletion,
-		chat1.ConversationMembersType_KBFS, &conv)
+		chat1.ConversationMembersType_KBFS, &conv, nil)
 	require.NoError(t, err)
 	preparedDeletion := prepareRes.Boxed
 	pendingAssetDeletes := prepareRes.PendingAssetDeletes
@@ -1503,7 +1504,7 @@ func TestProcessDuplicateReactionMsgs(t *testing.T) {
 		MessageBody: chat1.MessageBody{},
 	}
 	prepareRes, err := baseSender.Prepare(ctx, firstMessagePlaintext,
-		chat1.ConversationMembersType_KBFS, nil)
+		chat1.ConversationMembersType_KBFS, nil, nil)
 	require.NoError(t, err)
 	firstMessageBoxed := prepareRes.Boxed
 	res, err := ri.NewConversationRemote2(ctx, chat1.NewConversationRemote2Arg{

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -896,7 +896,7 @@ func (h *Server) NewConversationLocal(ctx context.Context, arg chat1.NewConversa
 	}
 
 	conv, err := NewConversation(ctx, h.G(), uid, arg.TlfName, arg.TopicName,
-		arg.TopicType, arg.MembersType, arg.TlfVisibility, h.remoteClient)
+		arg.TopicType, arg.MembersType, arg.TlfVisibility, h.remoteClient, NewConvFindExistingNormal)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -5105,11 +5105,11 @@ func TestChatSrvTopicNameState(t *testing.T) {
 		})
 		sender := NewBlockingSender(tc.Context(), NewBoxer(tc.Context()),
 			func() chat1.RemoteInterface { return ri })
-		prepareRes, err := sender.Prepare(ctx, plarg.Msg, mt, &convRemote.Conv)
+		prepareRes, err := sender.Prepare(ctx, plarg.Msg, mt, &convRemote.Conv, nil)
 		require.NoError(t, err)
 		msg1 := prepareRes.Boxed
 		ts1 := prepareRes.TopicNameState
-		prepareRes, err = sender.Prepare(ctx, plarg.Msg, mt, &convRemote.Conv)
+		prepareRes, err = sender.Prepare(ctx, plarg.Msg, mt, &convRemote.Conv, nil)
 		require.NoError(t, err)
 		msg2 := prepareRes.Boxed
 		ts2 := prepareRes.TopicNameState
@@ -5171,7 +5171,7 @@ func TestChatSrvUnboxMobilePushNotification(t *testing.T) {
 		ri := ctc.as(t, users[0]).ri
 		sender := NewBlockingSender(tc.Context(), NewBoxer(tc.Context()),
 			func() chat1.RemoteInterface { return ri })
-		prepareRes, err := sender.Prepare(ctx, plarg.Msg, mt, &convRemote.Conv)
+		prepareRes, err := sender.Prepare(ctx, plarg.Msg, mt, &convRemote.Conv, nil)
 		require.NoError(t, err)
 		msg := prepareRes.Boxed
 		msg.ServerHeader = &chat1.MessageServerHeader{

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -26,7 +26,7 @@ func newBlankConvWithMembersType(ctx context.Context, t *testing.T, tc *kbtest.C
 	uid gregor1.UID, ri chat1.RemoteInterface, sender types.Sender, tlfName string,
 	membersType chat1.ConversationMembersType) chat1.Conversation {
 	res, err := NewConversation(ctx, tc.Context(), uid, tlfName, nil, chat1.TopicType_CHAT, membersType,
-		keybase1.TLFVisibility_PRIVATE, func() chat1.RemoteInterface { return ri })
+		keybase1.TLFVisibility_PRIVATE, func() chat1.RemoteInterface { return ri }, NewConvFindExistingNormal)
 	require.NoError(t, err)
 	convID := res.GetConvID()
 	ires, err := ri.GetInboxRemote(ctx, chat1.GetInboxRemoteArg{

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -135,7 +135,7 @@ type Sender interface {
 		clientPrev chat1.MessageID, outboxID *chat1.OutboxID,
 		joinMentionsAs *chat1.ConversationMemberStatus) (chat1.OutboxID, *chat1.MessageBoxed, error)
 	Prepare(ctx context.Context, msg chat1.MessagePlaintext, membersType chat1.ConversationMembersType,
-		conv *chat1.Conversation, opts SenderPrepareOptions) (SenderPrepareResult, error)
+		conv *chat1.Conversation, opts *SenderPrepareOptions) (SenderPrepareResult, error)
 }
 
 type InboxSource interface {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -135,7 +135,7 @@ type Sender interface {
 		clientPrev chat1.MessageID, outboxID *chat1.OutboxID,
 		joinMentionsAs *chat1.ConversationMemberStatus) (chat1.OutboxID, *chat1.MessageBoxed, error)
 	Prepare(ctx context.Context, msg chat1.MessagePlaintext, membersType chat1.ConversationMembersType,
-		conv *chat1.Conversation) (SenderPrepareResult, error)
+		conv *chat1.Conversation, opts SenderPrepareOptions) (SenderPrepareResult, error)
 }
 
 type InboxSource interface {

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -223,6 +223,10 @@ type BoxerEncryptionInfo struct {
 	Version               chat1.MessageBoxedVersion
 }
 
+type SenderPrepareOptions struct {
+	SkipTopicNameState bool
+}
+
 type SenderPrepareResult struct {
 	Boxed               chat1.MessageBoxed
 	EncryptionInfo      BoxerEncryptionInfo

--- a/go/chat/upgrade_test.go
+++ b/go/chat/upgrade_test.go
@@ -56,7 +56,7 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 
 	boxer := NewBoxer(tc.Context())
 	sender := NewBlockingSender(tc.Context(), boxer, func() chat1.RemoteInterface { return ri })
-	prepareRes, err := sender.Prepare(ctx, kbfsPlain, chat1.ConversationMembersType_KBFS, &conv.Conv)
+	prepareRes, err := sender.Prepare(ctx, kbfsPlain, chat1.ConversationMembersType_KBFS, &conv.Conv, nil)
 	require.NoError(t, err)
 	kbfsBoxed := prepareRes.Boxed
 	kbfsBoxed.ServerHeader = &chat1.MessageServerHeader{
@@ -76,7 +76,7 @@ func TestChatKBFSUpgradeMixed(t *testing.T) {
 	}
 	teamPlain := textMsgWithHeader(t, "team", header)
 	prepareRes, err = sender.Prepare(ctx, teamPlain,
-		chat1.ConversationMembersType_IMPTEAMUPGRADE, &conv.Conv)
+		chat1.ConversationMembersType_IMPTEAMUPGRADE, &conv.Conv, nil)
 	require.NoError(t, err)
 	teamBoxed := prepareRes.Boxed
 	teamBoxed.ServerHeader = &chat1.MessageServerHeader{


### PR DESCRIPTION
Skip the checking for existing conv, and don't do anything with topic name state for new flip convs.