### PR TITLE
[KBFS-4010] Stopgap for full disk caches

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -6,11 +6,12 @@ package libkbfs
 
 import (
 	"container/heap"
-	lru "github.com/hashicorp/golang-lru"
 	"io"
 	"reflect"
 	"sync"
 	"time"
+
+	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/eapache/channels"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
@@ -610,6 +611,8 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 		if err != nil {
 			brq.log.CDebugf(
 				retrieval.ctx, "Couldn't put block in cache: %+v", err)
+			// swallow the error if we were unable to put the block into caches.
+			err = nil
 		}
 	}
 

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -1044,6 +1044,7 @@ func (cache *DiskBlockCacheLocal) evictLocked(ctx context.Context,
 		for _, tlfIDStruct := range shuffledSlice {
 			tlfID := tlfIDStruct.value
 			if cache.tlfCounts[tlfID] == 0 {
+				cache.log.CDebugf(ctx, "No blocks to delete in TLF %s", tlfID)
 				continue
 			}
 			tlfBytes := tlfID.Bytes()

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -878,6 +878,9 @@ func (cache *DiskBlockCacheLocal) Delete(ctx context.Context,
 	}
 
 	cache.log.CDebugf(ctx, "Cache Delete numBlocks=%d", len(blockIDs))
+	defer func() {
+		cache.log.CDebugf(ctx, "Deleted numRequested=%d numRemoved=%d sizeRemoved=%d err=%+v", len(blockIDs), numRemoved, sizeRemoved, err)
+	}()
 	if cache.config.IsTestMode() {
 		for _, bID := range blockIDs {
 			cache.log.CDebugf(ctx, "Cache type=%d delete block ID %s",

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -679,7 +679,7 @@ func (cache *DiskBlockCacheLocal) Put(
 	encodedLen := int64(len(entry))
 	defer func() {
 		cache.log.CDebugf(ctx, "Cache Put id=%s tlf=%s bSize=%d entrySize=%d "+
-			"cacheType=%d err=%+v", blockID, tlfID, blockLen, encodedLen,
+			"cacheType=%s err=%+v", blockID, tlfID, blockLen, encodedLen,
 			cache.cacheType, err)
 	}()
 	blockKey := blockID.Bytes()

--- a/go/kbfs/libkbfs/disk_limiter.go
+++ b/go/kbfs/libkbfs/disk_limiter.go
@@ -9,6 +9,23 @@ import (
 
 type diskLimitTrackerType int
 
+func (d diskLimitTrackerType) String() string {
+	switch d {
+	case unknownLimitTrackerType:
+		return "unknown"
+	case journalLimitTrackerType:
+		return "journal"
+	case workingSetCacheLimitTrackerType:
+		return "workingSet"
+	case syncCacheLimitTrackerType:
+		return "sync"
+	case crDirtyBlockCacheLimitTrackerType:
+		return "cr"
+	default:
+		return "undefined"
+	}
+}
+
 type unknownTrackerTypeError struct {
 	typ diskLimitTrackerType
 }


### PR DESCRIPTION
This doesn't completely solve the problem, since under the hood the disk cache still won't evict. But at least we will not surface errors in caching to the user.

I also added logging to help debug what's happening. And I created a ticket to be able to obtain KBFS status on mobile.