### PR TITLE
leveldb: adjust compaction parameters based on usage

### DIFF
--- a/go/kbfs/libkbfs/leveldb.go
+++ b/go/kbfs/libkbfs/leveldb.go
@@ -27,7 +27,7 @@ const (
 	diskCacheVersionFilename string = "version"
 	metered                         = true
 	unmetered                       = false
-	compactionTimeout               = 2 * time.Second
+	compactionTimeout               = 5 * time.Second
 )
 
 var (
@@ -76,8 +76,9 @@ func (ldb *LevelDb) tryTriggerCompaction() {
 	ldb.compactionLock.Lock()
 	defer ldb.compactionLock.Unlock()
 	// If we're not supposed to be compacting yet, return early
-	if time.Now().After(ldb.compactionTime) {
-		ldb.compactionTimer.Reset(ldb.compactionTime.Sub(time.Now()))
+	timeUntilCompact := ldb.compactionTime.Sub(time.Now())
+	if timeUntilCompact > 0 {
+		ldb.compactionTimer.Reset(timeUntilCompact)
 		return
 	}
 

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/db.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/db.go
@@ -1014,6 +1014,12 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 	return
 }
 
+// TODO: commit this to a fork of leveldb
+// SetOptions allows changing the DB options without restarting the DB session.
+func (db *DB) SetOptions(newOptions *opt.Options) {
+	db.s.setOptions(newOptions)
+}
+
 // DBStats is database statistics.
 type DBStats struct {
 	WriteDelayCount    int32


### PR DESCRIPTION
This spends less time compacting... but it spends a lot more time on the mutexes and timers involved in timing out when to trigger. Working on reducing that.