### PR TITLE
disk_block_cache: try harder to evict during a put

### DIFF
--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -41,7 +41,7 @@ const (
 	defaultNumBlocksToEvictOnClear  int    = 100
 	defaultNumUnmarkedBlocksToCheck int    = 100
 	defaultClearTickerDuration             = 1 * time.Second
-	maxEvictionsPerPut              int    = 4
+	maxEvictionsPerPut              int    = 100
 	blockDbFilename                 string = "diskCacheBlocks.leveldb"
 	metaDbFilename                  string = "diskCacheMetadata.leveldb"
 	tlfDbFilename                   string = "diskCacheTLF.leveldb"


### PR DESCRIPTION
If the cache is overfull, and we happen to only evict a bunch of small blocks, we won't be able to put the new block.  Seems reasonable to retry the eviction many more times until we get the job done, in the rare case we hit a situation like this.

(Note this doesn't affect the other cache issue where we can't evict blocks, and it doesn't slow things down in the case either since there's a check for `numRemoved == 0`.)

Issue: KBFS-4003