### PR TITLE
externals.proofServices drops rows

### DIFF
--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -126,7 +126,6 @@ func (p *proofServices) loadServiceConfigs() {
 	p.clearServiceTypes()
 	p.registerServiceTypes(getStaticProofServices())
 	p.registerServiceTypes(services)
-	p.displayConfigs = make(map[string]keybase1.ServiceDisplayConfig)
 	for _, config := range config.DisplayConfigs {
 		p.displayConfigs[config.Key] = *config
 		if service, ok := p.externalServices[config.Key]; ok {


### PR DESCRIPTION
Tested locally flipping alternating gubble.social and gubble.cloud enabledness without restarting service.