### PR TITLE
fix panic in GetAllProvisionedUsernames

### DIFF
--- a/go/libkb/all_provisioned_usernames.go
+++ b/go/libkb/all_provisioned_usernames.go
@@ -53,10 +53,10 @@ func GetAllProvisionedUsernames(m MetaContext) (current NormalizedUsername, all 
 		}
 	}
 
-	for _, u := range allUCs {
-		tmp, err := getUsernameIfProvisioned(m, u)
+	for _, uc := range allUCs {
+		tmp, err := getUsernameIfProvisioned(m, uc)
 		if err != nil {
-			m.Error("Error while checking user %q uid=%q, skipping", currentUC.GetUsername(), currentUC.GetUID())
+			m.Error("Error while checking user %q uid=%q, skipping", uc.GetUsername(), uc.GetUID())
 			continue
 		}
 		if !tmp.IsNil() {


### PR DESCRIPTION
function was incorrectly logging `currentUC` and this could be `nil`