### PR TITLE
Turn nav2 on for admins on desktop

### DIFF
--- a/shared/util/feature-flags.desktop.js
+++ b/shared/util/feature-flags.desktop.js
@@ -33,6 +33,7 @@ const inAdmin: {[key: $Keys<FeatureFlags>]: boolean} = {
   outOfDateBanner: true,
   proofProviders: true,
   sendAttachmentToChat: true,
+  useNewRouter: true,
 }
 
 // load overrides


### PR DESCRIPTION
@keybase/react-hackers 

I think we should mobile on nav1 because that's what we're releasing on Monday, makes sense?  We can go to nav2 on mobile too later next week.