### PR TITLE
Allow images from localhost

### DIFF
--- a/shared/desktop/renderer/index.html.template
+++ b/shared/desktop/renderer/index.html.template
@@ -7,7 +7,7 @@
     object-src 'self';
     font-src 'self' <%= htmlWebpackPlugin.options.isDev ? 'http://localhost:4000' : '' %>;
     media-src http://127.0.0.1:*;
-    img-src 'self' data: http://127.0.0.1:* https://keybase.io/ https://pbs.twimg.com/ https://avatars.githubusercontent.com/ https://s3.amazonaws.com/keybase_processed_uploads/ <%= htmlWebpackPlugin.options.isDev ? 'http://localhost:4000' : '' %>;
+    img-src 'self' data: http://127.0.0.1:* http://localhost:* https://keybase.io/ https://pbs.twimg.com/ https://avatars.githubusercontent.com/ https://s3.amazonaws.com/keybase_processed_uploads/ <%= htmlWebpackPlugin.options.isDev ? 'http://localhost:4000' : '' %>;
     style-src 'unsafe-inline';
     script-src <%= htmlWebpackPlugin.options.isDev ?  "file: http://localhost:4000 chrome-extension://react-developer-tools 'unsafe-eval'" : "'self' 'sha256-kp1KQ5r953LCGHnfoVBB27bpdE7Gxt2t7H6ML2tcYoo='" %>;
     connect-src http://127.0.0.1:* <%= htmlWebpackPlugin.options.isDev ? 'ws://localhost:4000 http://localhost:4000' : '' %>;


### PR DESCRIPTION
Allow images from `http://localhost`. `http://127.0.0.1` is already there. This lets icons on profiles work in dev. The service serves up localhost links using `SiteURILookup`.