### PR TITLE
Android: Fix non-plaintext notifications

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -69,7 +69,6 @@ public class KeybasePushNotificationListenerService extends RNPushNotificationLi
         }
         try {
             String type = bundle.getString("type");
-            String convID = bundle.getString("c");
             String payload = bundle.getString("m");
             Integer membersType = Integer.parseInt(bundle.getString("t"));
             KBPushNotifier notifier = new KBPushNotifier(getApplicationContext());
@@ -77,6 +76,7 @@ public class KeybasePushNotificationListenerService extends RNPushNotificationLi
             switch (type) {
                 case "chat.newmessageSilent_2": {
                     Boolean displayPlaintext = "true".equals(bundle.getString("n"));
+                    String convID = bundle.getString("c");
                     Integer messageId = Integer.parseInt(bundle.getString("d"));
                     JSONArray pushes = parseJSONArray(bundle.getString("p"));
                     String pushId = pushes.getString(0);
@@ -88,10 +88,14 @@ public class KeybasePushNotificationListenerService extends RNPushNotificationLi
                 }
                 break;
                 case "chat.newmessage": {
+                    String convID = bundle.getString("convID");
                     Integer messageId = Integer.parseInt(bundle.getString("msgID"));
                     Keybase.handleBackgroundNotification(convID, payload, membersType, false, messageId, "", 0, 0, "", notifier);
+                    super.onMessageReceived(message);
                 }
                 break;
+                default:
+                    super.onMessageReceived(message);
             }
         } catch (JSONException jex) {
             NativeLogger.error("Couldn't parse json: " + jex.getMessage());

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -94,18 +94,6 @@ public class MainActivity extends ReactFragmentActivity {
                 mainWindow.setBackgroundDrawableResource(R.color.white);
             }
         }, 300);
-
-        // Wait for the reactContext, then send the intent.
-        ReactInstanceManager mReactInstanceManager = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
-        mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
-            public void onReactContextInitialized(ReactContext reactContext) {
-                reactContext.getNativeModule(IntentHandler.class).handleIntent(getIntent());
-            }
-        });
-        if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {
-            // Construct it in the background
-            mReactInstanceManager.createReactContextInBackground();
-        }
     }
 
     @Override

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -94,6 +94,18 @@ public class MainActivity extends ReactFragmentActivity {
                 mainWindow.setBackgroundDrawableResource(R.color.white);
             }
         }, 300);
+
+        // Wait for the reactContext, then send the intent.
+        ReactInstanceManager mReactInstanceManager = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
+        mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
+            public void onReactContextInitialized(ReactContext reactContext) {
+                reactContext.getNativeModule(IntentHandler.class).handleIntent(getIntent());
+            }
+        });
+        if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {
+            // Construct it in the background
+            mReactInstanceManager.createReactContextInBackground();
+        }
     }
 
     @Override

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/IntentHandler.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/modules/IntentHandler.java
@@ -153,7 +153,7 @@ public class IntentHandler extends ReactContextBaseJavaModule {
         if (activity == null) {
             NativeLogger.warn("activity not yet initialized");
         }
-        handleIntent(getCurrentActivity().getIntent());
+        handleIntent(activity.getIntent());
     }
 
     @Override


### PR DESCRIPTION
@MarcoPolo looks like I inadvertently ruined non-plaintext notifications. After these commits, I've tested all 4 scenarios:
- [x] Plaintext from cold start [BUG: sometimes also shows the non-plaintext]
- [x] Plaintext from hot start
- [x] Non-plaintext from cold start
- [x] Non-plaintext from hot start