### PR TITLE
go-crypto vendor with stubs fix

### DIFF
--- a/go/engine/pgp_sign.go
+++ b/go/engine/pgp_sign.go
@@ -87,7 +87,7 @@ func (p *PGPSignEngine) Run(m libkb.MetaContext) (err error) {
 	if err != nil {
 		return
 	} else if pgp, ok = key.(*libkb.PGPKeyBundle); !ok {
-		err = fmt.Errorf("Can only sign with PGP keys (for now)")
+		err = fmt.Errorf("Can only sign with PGP keys")
 		return
 	}
 

--- a/go/libkb/sign.go
+++ b/go/libkb/sign.go
@@ -74,7 +74,7 @@ func ArmoredAttachedSign(out io.WriteCloser, signed openpgp.Entity, hints *openp
 	in, err = openpgp.AttachedSign(hwc, signed, hints, config)
 	h = func() []byte { return hwc.hasher.Sum(nil) }
 
-	return
+	return in, h, err
 }
 
 func AttachedSignWrapper(out io.WriteCloser, key PGPKeyBundle, armored bool) (

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/packet/encrypted_key.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/packet/encrypted_key.go
@@ -83,6 +83,10 @@ func checksumKeyMaterial(key []byte) uint16 {
 // private key must have been decrypted first.
 // If config is nil, sensible defaults will be used.
 func (e *EncryptedKey) Decrypt(priv *PrivateKey, config *Config) error {
+	if priv == nil || priv.PrivateKey == nil {
+		return errors.InvalidArgumentError("attempting to decrypt with nil PrivateKey")
+	}
+
 	var err error
 	var b []byte
 

--- a/go/vendor/github.com/keybase/go-crypto/openpgp/read.go
+++ b/go/vendor/github.com/keybase/go-crypto/openpgp/read.go
@@ -161,8 +161,15 @@ FindKey:
 				continue
 			}
 			if !pk.key.PrivateKey.Encrypted {
+				if pk.key.PrivateKey.PrivateKey == nil {
+					// Key is stubbed
+					continue
+				}
 				if len(pk.encryptedKey.Key) == 0 {
-					pk.encryptedKey.Decrypt(pk.key.PrivateKey, config)
+					err := pk.encryptedKey.Decrypt(pk.key.PrivateKey, config)
+					if err != nil {
+						continue
+					}
 				}
 				if len(pk.encryptedKey.Key) == 0 {
 					continue

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -541,52 +541,52 @@
 			"revisionTime": "2017-01-27T01:24:59Z"
 		},
 		{
-			"checksumSHA1": "IcsUw1En0CCbFeI2NtpRqL1acAg=",
+			"checksumSHA1": "Yg+fF0sf26WCOZO3xwkWAqMbrz8=",
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "b475f2ecc1fe24e8fbf4994e69cbb066c6846554",
-			"revisionTime": "2019-03-12T10:10:36Z"
+			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
+			"revisionTime": "2019-04-03T09:28:28Z"
 		},
 		{
 			"checksumSHA1": "OaxYRgIReJPa1+DSBEFemGzt/Iw=",
 			"path": "github.com/keybase/go-crypto/openpgp/armor",
-			"revision": "b475f2ecc1fe24e8fbf4994e69cbb066c6846554",
-			"revisionTime": "2019-03-12T10:10:36Z"
+			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
+			"revisionTime": "2019-04-03T09:28:28Z"
 		},
 		{
 			"checksumSHA1": "cTboJNAg/so2wzlf6HscarfPlDE=",
 			"path": "github.com/keybase/go-crypto/openpgp/clearsign",
-			"revision": "b475f2ecc1fe24e8fbf4994e69cbb066c6846554",
-			"revisionTime": "2019-03-12T10:10:36Z"
+			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
+			"revisionTime": "2019-04-03T09:28:28Z"
 		},
 		{
 			"checksumSHA1": "LhCQJCoB7yqxN6hSaPP7qXW2y5s=",
 			"path": "github.com/keybase/go-crypto/openpgp/ecdh",
-			"revision": "b475f2ecc1fe24e8fbf4994e69cbb066c6846554",
-			"revisionTime": "2019-03-12T10:10:36Z"
+			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
+			"revisionTime": "2019-04-03T09:28:28Z"
 		},
 		{
 			"checksumSHA1": "uxXG9IC/XF8jwwvZUbW65+x8/+M=",
 			"path": "github.com/keybase/go-crypto/openpgp/elgamal",
-			"revision": "b475f2ecc1fe24e8fbf4994e69cbb066c6846554",
-			"revisionTime": "2019-03-12T10:10:36Z"
+			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
+			"revisionTime": "2019-04-03T09:28:28Z"
 		},
 		{
 			"checksumSHA1": "ofZhU2758YZAAGSEJ8UjFMQLc+k=",
 			"path": "github.com/keybase/go-crypto/openpgp/errors",
-			"revision": "b475f2ecc1fe24e8fbf4994e69cbb066c6846554",
-			"revisionTime": "2019-03-12T10:10:36Z"
+			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
+			"revisionTime": "2019-04-03T09:28:28Z"
 		},
 		{
-			"checksumSHA1": "8Fp0B6L11cjcbTlmtFQLXn5zzsc=",
+			"checksumSHA1": "Ak84t7WVMcDlWl+q3KPn46SALrE=",
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "b475f2ecc1fe24e8fbf4994e69cbb066c6846554",
-			"revisionTime": "2019-03-12T10:10:36Z"
+			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
+			"revisionTime": "2019-04-03T09:28:28Z"
 		},
 		{
 			"checksumSHA1": "BGDxg1Xtsz0DSPzdQGJLLQqfYc8=",
 			"path": "github.com/keybase/go-crypto/openpgp/s2k",
-			"revision": "b475f2ecc1fe24e8fbf4994e69cbb066c6846554",
-			"revisionTime": "2019-03-12T10:10:36Z"
+			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
+			"revisionTime": "2019-04-03T09:28:28Z"
 		},
 		{
 			"checksumSHA1": "rE3pp7b3gfcmBregzpIvN5IdFhY=",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -543,50 +543,50 @@
 		{
 			"checksumSHA1": "Yg+fF0sf26WCOZO3xwkWAqMbrz8=",
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
-			"revisionTime": "2019-04-03T09:28:28Z"
+			"revision": "d65b6b94177fc86b352de754be0aa306de59a759",
+			"revisionTime": "2019-04-03T13:23:59Z"
 		},
 		{
 			"checksumSHA1": "OaxYRgIReJPa1+DSBEFemGzt/Iw=",
 			"path": "github.com/keybase/go-crypto/openpgp/armor",
-			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
-			"revisionTime": "2019-04-03T09:28:28Z"
+			"revision": "d65b6b94177fc86b352de754be0aa306de59a759",
+			"revisionTime": "2019-04-03T13:23:59Z"
 		},
 		{
 			"checksumSHA1": "cTboJNAg/so2wzlf6HscarfPlDE=",
 			"path": "github.com/keybase/go-crypto/openpgp/clearsign",
-			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
-			"revisionTime": "2019-04-03T09:28:28Z"
+			"revision": "d65b6b94177fc86b352de754be0aa306de59a759",
+			"revisionTime": "2019-04-03T13:23:59Z"
 		},
 		{
 			"checksumSHA1": "LhCQJCoB7yqxN6hSaPP7qXW2y5s=",
 			"path": "github.com/keybase/go-crypto/openpgp/ecdh",
-			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
-			"revisionTime": "2019-04-03T09:28:28Z"
+			"revision": "d65b6b94177fc86b352de754be0aa306de59a759",
+			"revisionTime": "2019-04-03T13:23:59Z"
 		},
 		{
 			"checksumSHA1": "uxXG9IC/XF8jwwvZUbW65+x8/+M=",
 			"path": "github.com/keybase/go-crypto/openpgp/elgamal",
-			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
-			"revisionTime": "2019-04-03T09:28:28Z"
+			"revision": "d65b6b94177fc86b352de754be0aa306de59a759",
+			"revisionTime": "2019-04-03T13:23:59Z"
 		},
 		{
 			"checksumSHA1": "ofZhU2758YZAAGSEJ8UjFMQLc+k=",
 			"path": "github.com/keybase/go-crypto/openpgp/errors",
-			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
-			"revisionTime": "2019-04-03T09:28:28Z"
+			"revision": "d65b6b94177fc86b352de754be0aa306de59a759",
+			"revisionTime": "2019-04-03T13:23:59Z"
 		},
 		{
 			"checksumSHA1": "Ak84t7WVMcDlWl+q3KPn46SALrE=",
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
-			"revisionTime": "2019-04-03T09:28:28Z"
+			"revision": "d65b6b94177fc86b352de754be0aa306de59a759",
+			"revisionTime": "2019-04-03T13:23:59Z"
 		},
 		{
 			"checksumSHA1": "BGDxg1Xtsz0DSPzdQGJLLQqfYc8=",
 			"path": "github.com/keybase/go-crypto/openpgp/s2k",
-			"revision": "c1ce7b786b8c0003f453fe6787beba6604d9a33c",
-			"revisionTime": "2019-04-03T09:28:28Z"
+			"revision": "d65b6b94177fc86b352de754be0aa306de59a759",
+			"revisionTime": "2019-04-03T13:23:59Z"
 		},
 		{
 			"checksumSHA1": "rE3pp7b3gfcmBregzpIvN5IdFhY=",


### PR DESCRIPTION
TODO: revendor again when go-crypto is merged to get right commit ids.