### PR TITLE
go/*dokan: Log process exit much cleaner

### DIFF
--- a/go/kbfs/kbfsdokan/main.go
+++ b/go/kbfs/kbfsdokan/main.go
@@ -123,5 +123,6 @@ func main() {
 
 		os.Exit(err.Code)
 	}
+	fmt.Fprintf(os.Stderr, "kbfsdokan normal shutdown")
 	os.Exit(0)
 }

--- a/go/kbfs/libdokan/start.go
+++ b/go/kbfs/libdokan/start.go
@@ -145,6 +145,8 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 		}
 	}
 
+	log.CDebugf(ctx, "Entering mount wait")
 	mi.Wait()
+	log.CDebugf(ctx, "Filesystem unmounted - mount wait returned - exiting")
 	return nil
 }


### PR DESCRIPTION
To get more idea about some user bug reports.