### PR TITLE
folder: add offline prop to folder and make component

### DIFF
--- a/shared/common-adapters/icon.js.flow
+++ b/shared/common-adapters/icon.js.flow
@@ -8,7 +8,7 @@ import {
   globalMargins,
 } from '../styles'
 
-export type SizeType = 'Bigger' | 'Big' | 'Default' | 'Small' | 'Tiny'
+export type SizeType = 'Huge' | 'Bigger' | 'Big' | 'Default' | 'Small' | 'Tiny'
 
 // These must be passed as props
 export type DisallowedStyles = {

--- a/shared/common-adapters/icon.shared.js
+++ b/shared/common-adapters/icon.shared.js
@@ -75,6 +75,8 @@ export function fontSize(type: IconType): ?Object {
 
 export function typeToFontSize(sizeType: SizeType) {
   switch (sizeType) {
+    case 'Huge':
+      return Styles.isMobile ? 64 : 48
     case 'Bigger':
       return Styles.isMobile ? 48 : 36
     case 'Big':

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -740,6 +740,16 @@ export const usernameInPath = (username: string, path: Types.Path) => {
   return elems.length >= 3 && elems[2].split(',').includes(username)
 }
 
+export const isOfflineUnsynced = (
+  daemonStatus: Types.KbfsDaemonStatus,
+  pathItems: Types.PathItems,
+  path: Types.Path
+) =>
+  flags.kbfsOfflineMode &&
+  !daemonStatus.online &&
+  Types.getPathLevel(path) > 2 &&
+  pathItems.get(path, unknownPathItem).prefetchStatus !== prefetchComplete
+
 // To make sure we have consistent badging, all badging related stuff should go
 // through this function. That is:
 // * When calculating number of TLFs being badged, a TLF should be counted if

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -742,13 +742,13 @@ export const usernameInPath = (username: string, path: Types.Path) => {
 
 export const isOfflineUnsynced = (
   daemonStatus: Types.KbfsDaemonStatus,
-  pathItems: Types.PathItems,
+  pathItem: Types.PathItem,
   path: Types.Path
 ) =>
   flags.kbfsOfflineMode &&
   !daemonStatus.online &&
   Types.getPathLevel(path) > 2 &&
-  pathItems.get(path, unknownPathItem).prefetchStatus !== prefetchComplete
+  pathItem.prefetchStatus !== prefetchComplete
 
 // To make sure we have consistent badging, all badging related stuff should go
 // through this function. That is:

--- a/shared/fs/folder/container.js
+++ b/shared/fs/folder/container.js
@@ -9,6 +9,8 @@ import * as FsGen from '../../actions/fs-gen'
 const mapStateToProps = (state, {path}) => ({
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
   _username: state.config.username,
+  // TODO: figure out how to get this info
+  offline: false,
   resetBannerType: Constants.resetBannerType(state, path),
   shouldShowSFMIBanner: state.fs.sfmi.showingBanner,
 })
@@ -20,6 +22,7 @@ const mapDispatchToProps = (dispatch, {path}: OwnProps) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, {path, routePath}) => ({
+  offline: stateProps.offline,
   onAttach: stateProps._pathItem.writable ? dispatchProps.onAttach : null,
   path,
   resetBannerType: stateProps.resetBannerType,

--- a/shared/fs/folder/container.js
+++ b/shared/fs/folder/container.js
@@ -5,12 +5,12 @@ import Folder from '.'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import * as FsGen from '../../actions/fs-gen'
+import flags from '../../util/feature-flags'
 
 const mapStateToProps = (state, {path}) => ({
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
   _username: state.config.username,
-  // TODO: figure out how to get this info
-  offline: false,
+  offline: !state.fs.kbfsDaemonStatus.online,
   resetBannerType: Constants.resetBannerType(state, path),
   shouldShowSFMIBanner: state.fs.sfmi.showingBanner,
 })
@@ -22,7 +22,11 @@ const mapDispatchToProps = (dispatch, {path}: OwnProps) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, {path, routePath}) => ({
-  offline: stateProps.offline,
+  offline:
+    flags.kbfsOfflineMode &&
+    stateProps.offline &&
+    Types.getPathLevel(path) > 2 &&
+    stateProps._pathItem.prefetchStatus !== Constants.prefetchComplete,
   onAttach: stateProps._pathItem.writable ? dispatchProps.onAttach : null,
   path,
   resetBannerType: stateProps.resetBannerType,

--- a/shared/fs/folder/container.js
+++ b/shared/fs/folder/container.js
@@ -5,12 +5,11 @@ import Folder from '.'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import * as FsGen from '../../actions/fs-gen'
-import flags from '../../util/feature-flags'
 
 const mapStateToProps = (state, {path}) => ({
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
   _username: state.config.username,
-  offline: !state.fs.kbfsDaemonStatus.online,
+  offline: Constants.isOfflineUnsynced(state.fs.kbfsDaemonStatus, state.fs.pathItems, path),
   resetBannerType: Constants.resetBannerType(state, path),
   shouldShowSFMIBanner: state.fs.sfmi.showingBanner,
 })
@@ -22,11 +21,7 @@ const mapDispatchToProps = (dispatch, {path}: OwnProps) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, {path, routePath}) => ({
-  offline:
-    flags.kbfsOfflineMode &&
-    stateProps.offline &&
-    Types.getPathLevel(path) > 2 &&
-    stateProps._pathItem.prefetchStatus !== Constants.prefetchComplete,
+  offline: stateProps.offline,
   onAttach: stateProps._pathItem.writable ? dispatchProps.onAttach : null,
   path,
   resetBannerType: stateProps.resetBannerType,

--- a/shared/fs/folder/container.js
+++ b/shared/fs/folder/container.js
@@ -7,9 +7,9 @@ import * as Constants from '../../constants/fs'
 import * as FsGen from '../../actions/fs-gen'
 
 const mapStateToProps = (state, {path}) => ({
+  _kbfsDaemonStatus: state.fs.kbfsDaemonStatus,
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
   _username: state.config.username,
-  offline: Constants.isOfflineUnsynced(state.fs.kbfsDaemonStatus, state.fs.pathItems, path),
   resetBannerType: Constants.resetBannerType(state, path),
   shouldShowSFMIBanner: state.fs.sfmi.showingBanner,
 })
@@ -21,7 +21,7 @@ const mapDispatchToProps = (dispatch, {path}: OwnProps) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, {path, routePath}) => ({
-  offline: stateProps.offline,
+  offline: Constants.isOfflineUnsynced(stateProps._kbfsDaemonStatus, stateProps._pathItem, path),
   onAttach: stateProps._pathItem.writable ? dispatchProps.onAttach : null,
   path,
   resetBannerType: stateProps.resetBannerType,

--- a/shared/fs/folder/index.js
+++ b/shared/fs/folder/index.js
@@ -63,7 +63,7 @@ const Folder = (props: Props) => (
       {props.resetBannerType === 'self' ? (
         <SelfReset {...props} />
       ) : props.offline ? (
-        <OfflineFolder />
+        <OfflineFolder path={props.path} />
       ) : (
         <WithContent {...props} />
       )}

--- a/shared/fs/folder/index.js
+++ b/shared/fs/folder/index.js
@@ -12,6 +12,7 @@ import Rows from '../row/rows-container'
 import {asRows as sfmiBannerAsRows} from '../banner/system-file-manager-integration-banner/container'
 import {asRows as resetBannerAsRows} from '../banner/reset-banner/container'
 import flags from '../../util/feature-flags'
+import OfflineFolder from './offline'
 
 type Props = {|
   onAttach?: ?(paths: Array<string>) => void,
@@ -19,6 +20,7 @@ type Props = {|
   routePath: I.List<string>,
   shouldShowSFMIBanner: boolean,
   resetBannerType: Types.ResetBannerType,
+  offline: boolean,
 |}
 
 const WithContent = (props: Props) => (
@@ -58,7 +60,13 @@ const Folder = (props: Props) => (
     <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
       {!flags.useNewRouter && <FolderHeader path={props.path} routePath={props.routePath} />}
       <Kbfs.Errs />
-      {props.resetBannerType === 'self' ? <SelfReset {...props} /> : <WithContent {...props} />}
+      {props.resetBannerType === 'self' ? (
+        <SelfReset {...props} />
+      ) : props.offline ? (
+        <OfflineFolder />
+      ) : (
+        <WithContent {...props} />
+      )}
       <Footer />
     </Kb.Box2>
   </Kb.BoxGrow>

--- a/shared/fs/folder/index.stories.js
+++ b/shared/fs/folder/index.stories.js
@@ -31,6 +31,7 @@ export default () => {
           routePath={I.List([])}
           shouldShowSFMIBanner={false}
           resetBannerType="none"
+          offline={false}
         />
       </Kb.Box2>
     ))
@@ -41,6 +42,7 @@ export default () => {
           routePath={I.List([])}
           shouldShowSFMIBanner={true}
           resetBannerType="none"
+          offline={false}
         />
       </Kb.Box2>
     ))
@@ -51,6 +53,7 @@ export default () => {
           routePath={I.List([])}
           shouldShowSFMIBanner={false}
           resetBannerType="self"
+          offline={false}
         />
       </Kb.Box2>
     ))
@@ -61,6 +64,18 @@ export default () => {
           routePath={I.List([])}
           shouldShowSFMIBanner={false}
           resetBannerType={1}
+          offline={false}
+        />
+      </Kb.Box2>
+    ))
+    .add('offline and not synced', () => (
+      <Kb.Box2 direction="horizontal" fullWidth={true} fullHeight={true}>
+        <Folder
+          path={Types.stringToPath('/keybase/private/others,reset')}
+          routePath={I.List([])}
+          shouldShowSFMIBanner={false}
+          resetBannerType="none"
+          offline={true}
         />
       </Kb.Box2>
     ))

--- a/shared/fs/folder/offline.js
+++ b/shared/fs/folder/offline.js
@@ -1,0 +1,32 @@
+// @flow
+import * as Kb from '../../common-adapters'
+import React from 'react'
+import * as Styles from '../../styles/index'
+
+type Props = {||}
+const OfflineFolder = (props: Props) => (
+  <Kb.Box2 direction="vertical" style={styles.contentContainer} fullWidth={true}>
+    <Kb.Box2
+      direction="vertical"
+      style={styles.emptyContainer}
+      fullHeight={true}
+      fullWidth={true}
+      centerChildren={true}
+    >
+      <Kb.Icon type="iconfont-cloud" sizeType={'Huge'} color={Styles.globalColors.black_10} />
+      <Kb.Text type="BodySmall">You haven't synced this folder.</Kb.Text>
+    </Kb.Box2>
+  </Kb.Box2>
+)
+
+const styles = Styles.styleSheetCreate({
+  contentContainer: {
+    flex: 1,
+  },
+  emptyContainer: {
+    ...Styles.globalStyles.flexGrow,
+    backgroundColor: Styles.globalColors.blueGrey,
+  },
+})
+
+export default OfflineFolder

--- a/shared/fs/folder/offline.js
+++ b/shared/fs/folder/offline.js
@@ -2,17 +2,17 @@
 import * as Kb from '../../common-adapters'
 import React from 'react'
 import * as Styles from '../../styles/index'
+import * as Types from '../../constants/types/fs'
+import TopBar from '../top-bar'
 
-type Props = {||}
+type Props = {|
+  path: Types.Path,
+|}
+
 const OfflineFolder = (props: Props) => (
-  <Kb.Box2 direction="vertical" style={styles.contentContainer} fullWidth={true}>
-    <Kb.Box2
-      direction="vertical"
-      style={styles.emptyContainer}
-      fullHeight={true}
-      fullWidth={true}
-      centerChildren={true}
-    >
+  <Kb.Box2 direction="vertical" style={styles.contentContainer} fullWidth={true} alignItems={'stretch'}>
+    <TopBar path={props.path} mode={'offline'} />
+    <Kb.Box2 direction="vertical" style={styles.emptyContainer} fullWidth={true} centerChildren={true}>
       <Kb.Icon type="iconfont-cloud" sizeType={'Huge'} color={Styles.globalColors.black_10} />
       <Kb.Text type="BodySmall">You haven't synced this folder.</Kb.Text>
     </Kb.Box2>
@@ -26,6 +26,7 @@ const styles = Styles.styleSheetCreate({
   emptyContainer: {
     ...Styles.globalStyles.flexGrow,
     backgroundColor: Styles.globalColors.blueGrey,
+    flex: 1,
   },
 })
 

--- a/shared/fs/folder/offline.js
+++ b/shared/fs/folder/offline.js
@@ -11,7 +11,7 @@ type Props = {|
 
 const OfflineFolder = (props: Props) => (
   <Kb.Box2 direction="vertical" style={styles.contentContainer} fullWidth={true} alignItems={'stretch'}>
-    <TopBar path={props.path} mode={'offline'} />
+    <TopBar path={props.path} />
     <Kb.Box2 direction="vertical" style={styles.emptyContainer} fullWidth={true} centerChildren={true}>
       <Kb.Icon type="iconfont-cloud" sizeType={'Huge'} color={Styles.globalColors.black_10} />
       <Kb.Text type="BodySmall">You haven't synced this folder.</Kb.Text>

--- a/shared/fs/top-bar/index.js
+++ b/shared/fs/top-bar/index.js
@@ -39,7 +39,7 @@ const TopBar = (props: Props) =>
       {Types.getPathLevel(props.path) === 3 && <SyncToggle tlfPath={props.path} />}
       <Kb.Box style={styles.flex} />
       <Loading path={props.path} />
-      {props.mode !== 'offline' && <Sort path={props.path} />}
+      <Sort path={props.path} />
     </TopBarContainer>
   )
 

--- a/shared/fs/top-bar/index.js
+++ b/shared/fs/top-bar/index.js
@@ -10,6 +10,7 @@ import SyncToggle from './sync-toggle-container'
 
 type Props = {|
   path: Types.Path,
+  mode?: 'offline' | 'default',
 |}
 
 const TopBarContainer = (props: {|children: React.Node|}) => (
@@ -38,7 +39,7 @@ const TopBar = (props: Props) =>
       {Types.getPathLevel(props.path) === 3 && <SyncToggle tlfPath={props.path} />}
       <Kb.Box style={styles.flex} />
       <Loading path={props.path} />
-      <Sort path={props.path} />
+      {props.mode !== 'offline' && <Sort path={props.path} />}
     </TopBarContainer>
   )
 

--- a/shared/fs/top-bar/sort-container.js
+++ b/shared/fs/top-bar/sort-container.js
@@ -11,7 +11,8 @@ type OwnProps = {|
 
 const mapStateToProps = (state, {path}: OwnProps) => ({
   _isEmpty: Constants.isEmptyFolder(state.fs.pathItems, path),
-  _isOffline: Constants.isOfflineUnsynced(state.fs.kbfsDaemonStatus, state.fs.pathItems, path),
+  _kbfsDaemonStatus: state.fs.kbfsDaemonStatus,
+  _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
   _sortSetting: state.fs.pathUserSettings.get(path, Constants.defaultPathUserSetting).sort,
 })
 
@@ -36,7 +37,9 @@ const mapDispatchToProps = (dispatch, {path}) => ({
 
 const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => ({
   sortSetting:
-    path === Constants.defaultPath || stateProps._isEmpty || stateProps._isOffline
+    path === Constants.defaultPath ||
+    stateProps._isEmpty ||
+    Constants.isOfflineUnsynced(stateProps._kbfsDaemonStatus, stateProps._pathItem, path)
       ? undefined
       : stateProps._sortSetting,
   ...dispatchProps,

--- a/shared/fs/top-bar/sort-container.js
+++ b/shared/fs/top-bar/sort-container.js
@@ -11,6 +11,7 @@ type OwnProps = {|
 
 const mapStateToProps = (state, {path}: OwnProps) => ({
   _isEmpty: Constants.isEmptyFolder(state.fs.pathItems, path),
+  _isOffline: Constants.isOfflineUnsynced(state.fs.kbfsDaemonStatus, state.fs.pathItems, path),
   _sortSetting: state.fs.pathUserSettings.get(path, Constants.defaultPathUserSetting).sort,
 })
 
@@ -34,7 +35,10 @@ const mapDispatchToProps = (dispatch, {path}) => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => ({
-  sortSetting: path === Constants.defaultPath || stateProps._isEmpty ? undefined : stateProps._sortSetting,
+  sortSetting:
+    path === Constants.defaultPath || stateProps._isEmpty || stateProps._isOffline
+      ? undefined
+      : stateProps._sortSetting,
   ...dispatchProps,
 })
 


### PR DESCRIPTION
I made a component and a story shot for the component and a prop to the `Folder` component, but I'm not sure if the scope of this ticket includes calling that prop from somewhere. It seems to me like it probably should, but I'm not really sure how to get started on that or if the framework is in place yet.

Issue: KBFS-4018