### PR TITLE
Singleflight LoadUser, logging

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -15,8 +15,6 @@ import (
 	jsonw "github.com/keybase/go-jsonw"
 )
 
-var locktab libkb.LockTable
-
 type Identify2TestStats struct {
 	untrackedFastPaths int
 }
@@ -438,7 +436,7 @@ func (e *Identify2WithUID) untrackedFastPath(m libkb.MetaContext) (ret bool) {
 func (e *Identify2WithUID) runReturnError(m libkb.MetaContext) (err error) {
 
 	m.Debug("+ acquire singleflight lock for %s", e.arg.Uid)
-	lock, err := locktab.AcquireOnNameWithContext(m.Ctx(), m.G(), e.arg.Uid.String())
+	lock, err := m.G().IDLocktab.AcquireOnNameWithContext(m.Ctx(), m.G(), e.arg.Uid.String())
 	if err != nil {
 		m.Debug("| error acquiring singleflight lock for %s: %v", e.arg.Uid, err)
 		return err

--- a/go/engine/prove_test.go
+++ b/go/engine/prove_test.go
@@ -4,10 +4,13 @@
 package engine
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestProveRooter(t *testing.T) {
@@ -67,4 +70,79 @@ func TestProveGenericSocial(t *testing.T) {
 	fu := CreateAndSignupFakeUser(tc, "prove")
 	proveGubbleSocial(tc, fu, sigVersion)
 	proveGubbleCloud(tc, fu, sigVersion)
+}
+
+func TestProveGenericSocialTiming(t *testing.T) {
+	tc := SetupEngineTest(t, "prove")
+	defer tc.Cleanup()
+	sigVersion := libkb.KeybaseSignatureV2
+
+	fu := CreateAndSignupFakeUser(tc, "prove")
+	proveGubbleUniverseSimple(tc, "gubble.social", "gubble_social", fu, sigVersion)
+
+	res := runID3(t, mctx, alice.Username, true)
+	require.False(t, res.userWasReset)
+
+	// We get one row of results, just the cryptocurrency row.
+	require.Equal(t, 1, len(res.rows))
+	require.Equal(t, "btc", res.rows[0].Key)
+	require.Equal(t, addr, res.rows[0].Value)
+	require.Equal(t, keybase1.Identify3RowColor_GREEN, res.rows[0].Color)
+	require.Equal(t, keybase1.Identify3RowState_VALID, res.rows[0].State)
+}
+
+func proveGubbleUniverseSimple(tc libkb.TestContext, serviceName, endpoint string, fu *FakeUser, sigVersion libkb.SigVersion) keybase1.SigID {
+	tc.T.Logf("proof for %s", serviceName)
+	g := tc.G
+	sv := keybase1.SigVersion(sigVersion)
+	proofService := g.GetProofServices().GetServiceType(serviceName)
+	require.NotNil(tc.T, proofService)
+
+	// Post a proof to the testing generic social service
+	arg := keybase1.StartProofArg{
+		Service:      proofService.GetTypeName(),
+		Username:     fu.Username,
+		Force:        false,
+		PromptPosted: true,
+		SigVersion:   &sv,
+	}
+	eng := NewProve(g, &arg)
+
+	// Post the proof to the gubble network and verify the sig hash
+	outputInstructionsHook := func(ctx context.Context, _ keybase1.OutputInstructionsArg) error {
+		sigID := eng.sigID
+		require.False(tc.T, sigID.IsNil())
+		mctx := libkb.NewMetaContext(ctx, g)
+
+		apiArg := libkb.APIArg{
+			Endpoint:    fmt.Sprintf("gubble_universe/%s", endpoint),
+			SessionType: libkb.APISessionTypeREQUIRED,
+			Args: libkb.HTTPArgs{
+				"sig_hash":      libkb.S{Val: sigID.String()},
+				"username":      libkb.S{Val: fu.Username},
+				"kb_username":   libkb.S{Val: fu.Username},
+				"kb_ua":         libkb.S{Val: libkb.UserAgent},
+				"json_redirect": libkb.B{Val: true},
+			},
+		}
+		_, err := g.API.Post(libkb.NewMetaContext(ctx, g), apiArg)
+		require.NoError(tc.T, err)
+		return nil
+	}
+
+	proveUI := &ProveUIMock{outputInstructionsHook: outputInstructionsHook}
+	uis := libkb.UIs{
+		LogUI:    g.UI.GetLogUI(),
+		SecretUI: fu.NewSecretUI(),
+		ProveUI:  proveUI,
+	}
+	m := libkb.NewMetaContextTODO(g).WithUIs(uis)
+	err := RunEngine2(m, eng)
+	checkFailed(tc.T.(testing.TB))
+	require.NoError(tc.T, err)
+	require.False(tc.T, proveUI.overwrite)
+	require.False(tc.T, proveUI.warning)
+	require.False(tc.T, proveUI.recheck)
+	require.True(tc.T, proveUI.checked)
+	return eng.sigID
 }

--- a/go/engine/prove_test.go
+++ b/go/engine/prove_test.go
@@ -4,13 +4,10 @@
 package engine
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestProveRooter(t *testing.T) {
@@ -70,79 +67,4 @@ func TestProveGenericSocial(t *testing.T) {
 	fu := CreateAndSignupFakeUser(tc, "prove")
 	proveGubbleSocial(tc, fu, sigVersion)
 	proveGubbleCloud(tc, fu, sigVersion)
-}
-
-func TestProveGenericSocialTiming(t *testing.T) {
-	tc := SetupEngineTest(t, "prove")
-	defer tc.Cleanup()
-	sigVersion := libkb.KeybaseSignatureV2
-
-	fu := CreateAndSignupFakeUser(tc, "prove")
-	proveGubbleUniverseSimple(tc, "gubble.social", "gubble_social", fu, sigVersion)
-
-	res := runID3(t, mctx, alice.Username, true)
-	require.False(t, res.userWasReset)
-
-	// We get one row of results, just the cryptocurrency row.
-	require.Equal(t, 1, len(res.rows))
-	require.Equal(t, "btc", res.rows[0].Key)
-	require.Equal(t, addr, res.rows[0].Value)
-	require.Equal(t, keybase1.Identify3RowColor_GREEN, res.rows[0].Color)
-	require.Equal(t, keybase1.Identify3RowState_VALID, res.rows[0].State)
-}
-
-func proveGubbleUniverseSimple(tc libkb.TestContext, serviceName, endpoint string, fu *FakeUser, sigVersion libkb.SigVersion) keybase1.SigID {
-	tc.T.Logf("proof for %s", serviceName)
-	g := tc.G
-	sv := keybase1.SigVersion(sigVersion)
-	proofService := g.GetProofServices().GetServiceType(serviceName)
-	require.NotNil(tc.T, proofService)
-
-	// Post a proof to the testing generic social service
-	arg := keybase1.StartProofArg{
-		Service:      proofService.GetTypeName(),
-		Username:     fu.Username,
-		Force:        false,
-		PromptPosted: true,
-		SigVersion:   &sv,
-	}
-	eng := NewProve(g, &arg)
-
-	// Post the proof to the gubble network and verify the sig hash
-	outputInstructionsHook := func(ctx context.Context, _ keybase1.OutputInstructionsArg) error {
-		sigID := eng.sigID
-		require.False(tc.T, sigID.IsNil())
-		mctx := libkb.NewMetaContext(ctx, g)
-
-		apiArg := libkb.APIArg{
-			Endpoint:    fmt.Sprintf("gubble_universe/%s", endpoint),
-			SessionType: libkb.APISessionTypeREQUIRED,
-			Args: libkb.HTTPArgs{
-				"sig_hash":      libkb.S{Val: sigID.String()},
-				"username":      libkb.S{Val: fu.Username},
-				"kb_username":   libkb.S{Val: fu.Username},
-				"kb_ua":         libkb.S{Val: libkb.UserAgent},
-				"json_redirect": libkb.B{Val: true},
-			},
-		}
-		_, err := g.API.Post(libkb.NewMetaContext(ctx, g), apiArg)
-		require.NoError(tc.T, err)
-		return nil
-	}
-
-	proveUI := &ProveUIMock{outputInstructionsHook: outputInstructionsHook}
-	uis := libkb.UIs{
-		LogUI:    g.UI.GetLogUI(),
-		SecretUI: fu.NewSecretUI(),
-		ProveUI:  proveUI,
-	}
-	m := libkb.NewMetaContextTODO(g).WithUIs(uis)
-	err := RunEngine2(m, eng)
-	checkFailed(tc.T.(testing.TB))
-	require.NoError(tc.T, err)
-	require.False(tc.T, proveUI.overwrite)
-	require.False(tc.T, proveUI.warning)
-	require.False(tc.T, proveUI.recheck)
-	require.True(tc.T, proveUI.checked)
-	return eng.sigID
 }

--- a/go/externals/proof_service_generic_social.go
+++ b/go/externals/proof_service_generic_social.go
@@ -160,7 +160,9 @@ func NewGenericSocialProofChecker(proof libkb.RemoteProofChainLink, config *Gene
 func (rc *GenericSocialProofChecker) GetTorError() libkb.ProofError { return nil }
 
 func (rc *GenericSocialProofChecker) CheckStatus(mctx libkb.MetaContext, _ libkb.SigHint, _ libkb.ProofCheckerMode,
-	pvlU keybase1.MerkleStoreEntry) (*libkb.SigHint, libkb.ProofError) {
+	pvlU keybase1.MerkleStoreEntry) (_ *libkb.SigHint, retErr libkb.ProofError) {
+	mctx = mctx.WithLogTag("PCS")
+	defer mctx.TraceTimed("GenericSocialProofChecker.CheckStatus", func() error { return retErr })()
 
 	_, sigID, err := libkb.OpenSig(rc.proof.GetArmoredSig())
 	if err != nil {

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -76,6 +76,7 @@ type GlobalContext struct {
 	upakLoader       UPAKLoader      // Load flat users with the ability to hit the cache
 	teamLoader       TeamLoader      // Play back teams for id/name properties
 	fastTeamLoader   FastTeamLoader  // Play back team in "fast" mode for keys and names only
+	loadUserLockTab  LockTable
 	teamAuditor      TeamAuditor
 	stellar          Stellar          // Stellar related ops
 	deviceEKStorage  DeviceEKStorage  // Store device ephemeral keys
@@ -1187,7 +1188,7 @@ func (g *GlobalContext) KeyfamilyChanged(ctx context.Context, u keybase1.UID) {
 	if g.NotifyRouter != nil {
 		g.NotifyRouter.HandleKeyfamilyChanged(u)
 		// TODO: remove this when KBFS handles KeyfamilyChanged
-		g.NotifyRouter.HandleUserChanged(u)
+		g.NotifyRouter.HandleUserChanged(NewMetaContext(ctx, g), u, "KeyfamilyChanged")
 	}
 }
 
@@ -1199,7 +1200,7 @@ func (g *GlobalContext) UserChanged(ctx context.Context, u keybase1.UID) {
 
 	g.BustLocalUserCache(ctx, u)
 	if g.NotifyRouter != nil {
-		g.NotifyRouter.HandleUserChanged(u)
+		g.NotifyRouter.HandleUserChanged(NewMetaContext(ctx, g), u, "G.UserChanged")
 	}
 
 	g.uchMu.Lock()

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -76,6 +76,7 @@ type GlobalContext struct {
 	upakLoader       UPAKLoader      // Load flat users with the ability to hit the cache
 	teamLoader       TeamLoader      // Play back teams for id/name properties
 	fastTeamLoader   FastTeamLoader  // Play back team in "fast" mode for keys and names only
+	IDLocktab        LockTable
 	loadUserLockTab  LockTable
 	teamAuditor      TeamAuditor
 	stellar          Stellar          // Stellar related ops

--- a/go/libkb/locktab.go
+++ b/go/libkb/locktab.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"sync"
+	"time"
 
 	"golang.org/x/net/context"
 )
@@ -90,4 +91,13 @@ func (t *LockTable) AcquireOnNameWithContext(ctx context.Context, g VLogContext,
 	}
 	g.GetVDebugLog().CLogf(ctx, VLog1, "- LockTable.Lock(%s)", s)
 	return ret, nil
+}
+
+// AcquireOnNameWithContextAndTimeout acquires s's lock.
+// Returns (ret, nil) if the lock was acquired.
+// Returns (nil, err) if it was not. The error is from ctx.Err() or context.DeadlineExceeded.
+func (t *LockTable) AcquireOnNameWithContextAndTimeout(ctx context.Context, g VLogContext, s string, timeout time.Duration) (ret *NamedLock, err error) {
+	ctx2, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return t.AcquireOnNameWithContext(ctx2, g, s)
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -382,7 +382,8 @@ func (n *NotifyRouter) HandleClientOutOfDate(upgradeTo, upgradeURI, upgradeMsg s
 // HandleUserChanged is called whenever we know that a given user has
 // changed (and must be cache-busted). It will broadcast the messages
 // to all curious listeners.
-func (n *NotifyRouter) HandleUserChanged(uid keybase1.UID) {
+func (n *NotifyRouter) HandleUserChanged(mctx MetaContext, uid keybase1.UID, reason string) {
+	mctx.Debug("Sending UserChanged notification %v '%v')", uid, reason)
 	if n == nil {
 		return
 	}
@@ -394,7 +395,7 @@ func (n *NotifyRouter) HandleUserChanged(uid keybase1.UID) {
 			go func() {
 				// A send of a `UserChanged` RPC with the user's UID
 				(keybase1.NotifyUsersClient{
-					Cli: rpc.NewClient(xp, NewContextifiedErrorUnwrapper(n.G()), nil),
+					Cli: rpc.NewClient(xp, NewContextifiedErrorUnwrapper(mctx.G()), nil),
 				}).UserChanged(context.Background(), uid)
 			}()
 		}

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -288,17 +288,18 @@ func (u *User) HasEncryptionSubkey() bool {
 	return false
 }
 
-func (u *User) CheckBasicsFreshness(server int64) (current bool, err error) {
+func (u *User) CheckBasicsFreshness(server int64) (current bool, reason string, err error) {
 	var stored int64
-	if stored, err = u.GetIDVersion(); err == nil {
-		current = (stored >= server)
-		if current {
-			u.G().Log.Debug("| Local basics version is up-to-date @ version %d", stored)
-		} else {
-			u.G().Log.Debug("| Local basics version is out-of-date: %d < %d", stored, server)
-		}
+	if stored, err = u.GetIDVersion(); err != nil {
+		return false, "", err
 	}
-	return
+	if stored >= server {
+		u.G().Log.Debug("| Local basics version is up-to-date @ version %d", stored)
+		return true, "", nil
+	} else {
+		u.G().Log.Debug("| Local basics version is out-of-date: %d < %d", stored, server)
+		return false, fmt.Sprintf("idv %v < %v", stored, server), nil
+	}
 }
 
 func (u *User) StoreSigChain(m MetaContext) error {

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -296,10 +296,9 @@ func (u *User) CheckBasicsFreshness(server int64) (current bool, reason string, 
 	if stored >= server {
 		u.G().Log.Debug("| Local basics version is up-to-date @ version %d", stored)
 		return true, "", nil
-	} else {
-		u.G().Log.Debug("| Local basics version is out-of-date: %d < %d", stored, server)
-		return false, fmt.Sprintf("idv %v < %v", stored, server), nil
 	}
+	u.G().Log.Debug("| Local basics version is out-of-date: %d < %d", stored, server)
+	return false, fmt.Sprintf("idv %v < %v", stored, server), nil
 }
 
 func (u *User) StoreSigChain(m MetaContext) error {


### PR DESCRIPTION
Singleflighting LoadUser reduces the number of UserChanged notifications that get sent to the frontend. Previously, two concurrent LoadUser's each thought they had discovered a new id version. LoadUser is allowed 30 seconds waiting on the lock before it bails.