### PR TITLE
Skip passphrase prompt in `keybase signup`

### DIFF
--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -121,7 +121,9 @@ func (s *CmdSignup) SetNoInvitationCodeBypass() {
 	// affected by whether API server allows us to skip invite code (see
 	// requestInvitationCode).
 
-	// Used in tests.
+	// Used in tests. If the test is checking prompts that occurred, it should
+	// use this to avoid invitation code bypass behaviour that may differ
+	// between testing environments.
 	s.noInvitationCodeBypass = true
 }
 

--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -95,6 +95,7 @@ func NewCmdSignupRunner(g *libkb.GlobalContext) *CmdSignup {
 func (s *CmdSignup) SetTest() {
 	s.skipMail = true
 	s.genPaper = true
+	s.doPromptPassphrase = true // signup test users with passwords
 }
 
 func (s *CmdSignup) SetTestWithPaper(b bool) {

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -190,7 +190,6 @@ func (smc *smuContext) setupDeviceHelper(u *smuUser, puk bool) *smuDeviceWrapper
 	tctx := setupTest(smc.t, u.usernamePrefix)
 	tctx.Tp.DisableUpgradePerUserKey = !puk
 	tctx.G.SetClock(smc.fakeClock)
-	installInsecureTriplesec(tctx.G)
 	ret := &smuDeviceWrapper{ctx: smc, tctx: tctx}
 	u.devices = append(u.devices, ret)
 	if u.primary == nil {

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -274,6 +274,7 @@ func TestSignupLogout(t *testing.T) {
 	tc2.G.SetUI(&sui)
 	signup := client.NewCmdSignupRunner(tc2.G)
 	signup.SetTest()
+	signup.SetNoInvitationCodeBypass()
 
 	logout := client.NewCmdLogoutRunner(tc2.G)
 
@@ -339,6 +340,7 @@ func TestSignupLogout(t *testing.T) {
 
 	expectedPrompts := []libkb.PromptDescriptor{
 		client.PromptDescriptorSignupEmail,
+		client.PromptDescriptorSignupCode,
 		client.PromptDescriptorSignupUsername,
 		client.PromptDescriptorSignupDevice,
 	}

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -89,6 +89,9 @@ func (n *signupSecretUI) GetPassphrase(p keybase1.GUIEntryArg, terminal *keybase
 	}
 	n.G().Log.Debug("| GetPassphrase: %v -> %v", p, res)
 	n.parent.passphrasePrompts = append(n.parent.passphrasePrompts, p)
+	if len(n.parent.passphrasePrompts) > 100 {
+		err = fmt.Errorf("too many passphrase prompts, something is likely wrong")
+	}
 	return res, err
 }
 
@@ -107,6 +110,9 @@ func (n *signupTerminalUI) Prompt(pd libkb.PromptDescriptor, s string) (ret stri
 	}
 	n.G().Log.Debug("Terminal Prompt %d: %s -> %s (%v)\n", pd, s, ret, libkb.ErrToOk(err))
 	n.parent.terminalPrompts = append(n.parent.terminalPrompts, pd)
+	if len(n.parent.terminalPrompts) > 100 {
+		err = fmt.Errorf("too many prompts, something is likely wrong")
+	}
 	return ret, err
 }
 


### PR DESCRIPTION
Do not ask for passphrase in prompter mode in `keybase signup` unless `--set-password` is passed.

`keybase signup` help page now looks like this:

```
» keybase help signup
NAME:
   keybase signup - Signup for a new account

USAGE:
   keybase signup [command options] 

OPTIONS:
   -c, --invite-code 	Specify an invite code.
   --email 		Specify an account email.
   --username 		Specify a username.
   --set-password	Ask for password (optional by default).
```