### PR TITLE
Tweaks on No-password flows

### DIFF
--- a/shared/common-adapters/button.js
+++ b/shared/common-adapters/button.js
@@ -159,6 +159,7 @@ const styles = styleSheetCreate({
     alignSelf: undefined,
     flexGrow: 1,
     height: fullWidthHeight,
+    maxWidth: isMobile ? undefined : 400,
     width: undefined,
   },
   labelContainer: {height: '100%', position: 'relative'},

--- a/shared/settings/landing/index.desktop.js
+++ b/shared/settings/landing/index.desktop.js
@@ -284,10 +284,8 @@ function AccountFirstEmail({onChangeEmail}: {onChangeEmail: () => void}) {
       }}
     >
       <Text type="Body">
-        No e-mail set. You should{' '}
-        <Text type="BodyPrimaryLink" onClick={onChangeEmail}>
-          add an e-mail address.
-        </Text>
+        Email address:
+        <Button label="Add an email address" type="Secondary" small={true} onClick={onChangeEmail} />
       </Text>
     </Box>
   )
@@ -315,13 +313,7 @@ function AccountFirstPassword({onChangePassword}: {onChangePassword: () => void}
       <Text type="Body" style={{marginRight: globalMargins.xtiny}}>
         Password:
       </Text>
-      <Text type="Body">
-        Not set! You should{' '}
-        <Text type="Body" style={{color: globalColors.blue}} onClick={onChangePassword}>
-          set a password
-        </Text>
-        .
-      </Text>
+      <Button label="Set a password" type="Secondary" small={true} onClick={onChangePassword} />
     </Box>
   )
 }

--- a/shared/settings/logout/index.js
+++ b/shared/settings/logout/index.js
@@ -82,8 +82,6 @@ class OfferToCheckPassword extends React.Component<TestProps, State> {
               type="PrimaryGreen"
             />
           </Kb.ButtonBar>
-        )}
-        {!this.props.checkPasswordIsCorrect && (
           <Kb.Box2 direction="horizontal" gap="xtiny" style={{marginBottom: Styles.globalMargins.medium}}>
             <Kb.Icon type="iconfont-leave" sizeType="Small" color={Styles.globalColors.black_50} />
             <Kb.Text type="BodySmallSecondaryLink" onClick={this.props.onLogout}>

--- a/shared/settings/logout/index.js
+++ b/shared/settings/logout/index.js
@@ -37,98 +37,106 @@ class OfferToCheckPassword extends React.Component<TestProps, State> {
     return (
       <>
         <Kb.Box2 direction="vertical" centerChildren={true} style={styles.offer}>
-          <Kb.Input
-            errorText={
-              this.props.checkPasswordIsCorrect === false
-                ? 'Your password was incorrect, please try again.'
-                : ''
-            }
-            hintText="Enter your password"
-            type={inputType}
-            value={this.state.password}
-            onChangeText={password => this.setState({password})}
-            uncontrolled={false}
-            style={styles.input}
-          />
-          <Kb.Checkbox
-            label="Show typing"
-            onCheck={showTyping => this.setState(prevState => ({showTyping: !prevState.showTyping}))}
-            checked={this.state.showTyping}
-          />
-          {this.props.checkPasswordIsCorrect && (
-            <Kb.Box2 direction="horizontal" gap="xtiny">
-              <Kb.Icon type="iconfont-check" color={Styles.globalColors.green} />
-              <Kb.Text style={{color: Styles.globalColors.green}} type="BodySmall">
-                Your password is correct.
-              </Kb.Text>
+          {!this.props.checkPasswordIsCorrect && (
+            <Kb.Box2 direction="vertical" centerChildren={true}>
+              <Kb.Input
+                errorText={
+                  this.props.checkPasswordIsCorrect === false ? 'Wrong password. Please try again.' : ''
+                }
+                hintText="Your password"
+                type={inputType}
+                value={this.state.password}
+                onChangeText={password => this.setState({password})}
+                uncontrolled={false}
+                style={styles.input}
+              />
+              <Kb.Checkbox
+                label="Show typing"
+                onCheck={showTyping => this.setState(prevState => ({showTyping: !prevState.showTyping}))}
+                checked={this.state.showTyping}
+              />
             </Kb.Box2>
           )}
         </Kb.Box2>
-        <Kb.ButtonBar align="center" direction="row" fullWidth={true} style={styles.buttonbar}>
-          <Kb.Button
-            fullWidth={true}
-            label={this.props.checkPasswordIsCorrect ? 'Safely sign out' : 'Just sign out'}
-            onClick={this.props.onLogout}
-            type={this.props.checkPasswordIsCorrect ? 'PrimaryGreen' : 'Danger'}
-          />
-
-          {!this.props.checkPasswordIsCorrect && (
+        {!this.props.checkPasswordIsCorrect ? (
+          <Kb.ButtonBar align="center" direction="row" fullWidth={true} style={styles.buttonbar}>
+            <Kb.Button onClick={this.props.onCancel} label="Cancel" fullWidth={true} type="Secondary" />
             <Kb.WaitingButton
               fullWidth={true}
               waitingKey={Constants.checkPasswordWaitingKey}
-              type={this.props.checkPasswordIsCorrect ? 'PrimaryGreen' : 'Primary'}
+              type="Primary"
               disabled={!!this.props.checkPasswordIsCorrect}
               label="Test password"
               onClick={() => {
                 this.props.onCheckPassword(this.state.password)
               }}
             />
-          )}
-        </Kb.ButtonBar>
+          </Kb.ButtonBar>
+        ) : (
+          <Kb.ButtonBar align="center" direction="row" fullWidth={true}>
+            <Kb.Button
+              label="Safely sign out"
+              fullWidth={true}
+              onClick={this.props.onLogout}
+              type="PrimaryGreen"
+            />
+          </Kb.ButtonBar>
+        )}
+        {!this.props.checkPasswordIsCorrect && (
+          <Kb.Box2 direction="horizontal" gap="xtiny" style={{marginBottom: Styles.globalMargins.medium}}>
+            <Kb.Icon type="iconfont-leave" sizeType="Small" color={Styles.globalColors.black_50} />
+            <Kb.Text type="BodySmallSecondaryLink" onClick={this.props.onLogout}>
+              Just sign out
+            </Kb.Text>
+          </Kb.Box2>
+        )}
       </>
     )
   }
 }
 
 export default (props: Props) => (
-  <Kb.ScrollView contentContainerStyle={styles.container}>
+  <Kb.Box2>
     {props.hasRandomPW ? (
-      <Kb.Box2 centerChildren={true} direction="vertical">
-        <Kb.Text type="Body">
-          You don't have a password set -- you should set one before signing out, so that you can sign in
-          again later.
-        </Kb.Text>
-        <UpdatePassword
-          onSave={props.onSavePassword}
-          saveLabel="Create password and sign out"
-          waitingForResponse={props.waitingForResponse}
-        />
-      </Kb.Box2>
+      <UpdatePassword
+        onSave={props.onSavePassword}
+        saveLabel="Sign out"
+        waitingForResponse={props.waitingForResponse}
+      />
     ) : (
-      <Kb.Box2 centerChildren={true} direction="vertical">
-        <Kb.Text style={styles.bodyText} type="Body">
-          Would you like to make sure that you know your password before signing out?
-        </Kb.Text>
-        <Kb.Text style={styles.bodyText} type="Body">
-          You'll need it to sign back in.
-        </Kb.Text>
-        <OfferToCheckPassword
-          checkPasswordIsCorrect={props.checkPasswordIsCorrect}
-          onCheckPassword={props.onCheckPassword}
-          onLogout={props.onLogout}
-        />
-      </Kb.Box2>
+      <Kb.ScrollView contentContainerStyle={styles.container}>
+        <Kb.Box2 centerChildren={true} direction="vertical">
+          {props.checkPasswordIsCorrect ? (
+            <Kb.Box2 direction="vertical" gap="xtiny" centerChildren={true} style={styles.headerText}>
+              <Kb.Icon type="iconfont-check" sizeType="Small" color={Styles.globalColors.green} />
+              <Kb.Text style={{color: Styles.globalColors.green}} type="Header">
+                Your password is correct.
+              </Kb.Text>
+            </Kb.Box2>
+          ) : (
+            <Kb.Text style={styles.headerText} type="Header">
+              Do you know your password?
+            </Kb.Text>
+          )}
+          <Kb.Text style={styles.bodyText} type="Body">
+            You will need it to sign back in.
+          </Kb.Text>
+          <OfferToCheckPassword
+            checkPasswordIsCorrect={props.checkPasswordIsCorrect}
+            onCancel={props.onCancel}
+            onCheckPassword={props.onCheckPassword}
+            onLogout={props.onLogout}
+          />
+        </Kb.Box2>
+      </Kb.ScrollView>
     )}
-  </Kb.ScrollView>
+  </Kb.Box2>
 )
 
 const styles = Styles.styleSheetCreate({
   bodyText: {
     paddingBottom: Styles.globalMargins.tiny,
     textAlign: 'center',
-  },
-  buttonbar: {
-    padding: Styles.globalMargins.small,
   },
   container: Styles.platformStyles({
     common: {
@@ -139,10 +147,17 @@ const styles = Styles.styleSheetCreate({
     isElectron: {
       width: 560,
     },
+    isMobile: {
+      width: '100%',
+    },
   }),
+  headerText: {
+    paddingBottom: Styles.globalMargins.small,
+    paddingTop: Styles.globalMargins.small,
+  },
   input: {
     marginBottom: Styles.globalMargins.small,
   },
   // Avoid moving the buttons down when an errorText is added
-  offer: Styles.platformStyles({isElectron: {minHeight: 200}}),
+  offer: {minHeight: 200},
 })

--- a/shared/settings/logout/index.js
+++ b/shared/settings/logout/index.js
@@ -60,19 +60,27 @@ class OfferToCheckPassword extends React.Component<TestProps, State> {
           )}
         </Kb.Box2>
         {!this.props.checkPasswordIsCorrect ? (
-          <Kb.ButtonBar align="center" direction="row" fullWidth={true}>
-            <Kb.Button onClick={this.props.onCancel} label="Cancel" fullWidth={true} type="Secondary" />
-            <Kb.WaitingButton
-              fullWidth={true}
-              waitingKey={Constants.checkPasswordWaitingKey}
-              type="Primary"
-              disabled={!!this.props.checkPasswordIsCorrect}
-              label="Test password"
-              onClick={() => {
-                this.props.onCheckPassword(this.state.password)
-              }}
-            />
-          </Kb.ButtonBar>
+          <Kb.Box2 direction="vertical">
+            <Kb.ButtonBar align="center" direction="row" fullWidth={true}>
+              <Kb.Button onClick={this.props.onCancel} label="Cancel" fullWidth={true} type="Secondary" />
+              <Kb.WaitingButton
+                fullWidth={true}
+                waitingKey={Constants.checkPasswordWaitingKey}
+                type="Primary"
+                disabled={!!this.props.checkPasswordIsCorrect}
+                label="Test password"
+                onClick={() => {
+                  this.props.onCheckPassword(this.state.password)
+                }}
+              />
+            </Kb.ButtonBar>
+            <Kb.Box2 direction="horizontal" gap="xtiny" style={{marginBottom: Styles.globalMargins.medium}}>
+              <Kb.Icon type="iconfont-leave" sizeType="Small" color={Styles.globalColors.black_50} />
+              <Kb.Text type="BodySmallSecondaryLink" onClick={this.props.onLogout}>
+                Just sign out
+              </Kb.Text>
+            </Kb.Box2>
+          </Kb.Box2>
         ) : (
           <Kb.ButtonBar align="center" direction="row" fullWidth={true}>
             <Kb.Button
@@ -82,12 +90,6 @@ class OfferToCheckPassword extends React.Component<TestProps, State> {
               type="PrimaryGreen"
             />
           </Kb.ButtonBar>
-          <Kb.Box2 direction="horizontal" gap="xtiny" style={{marginBottom: Styles.globalMargins.medium}}>
-            <Kb.Icon type="iconfont-leave" sizeType="Small" color={Styles.globalColors.black_50} />
-            <Kb.Text type="BodySmallSecondaryLink" onClick={this.props.onLogout}>
-              Just sign out
-            </Kb.Text>
-          </Kb.Box2>
         )}
       </>
     )

--- a/shared/settings/logout/index.js
+++ b/shared/settings/logout/index.js
@@ -17,6 +17,7 @@ export type Props = {|
 
 type TestProps = {|
   checkPasswordIsCorrect: ?boolean,
+  onCancel: () => void,
   onCheckPassword: (password: string) => void,
   onLogout: () => void,
 |}
@@ -59,7 +60,7 @@ class OfferToCheckPassword extends React.Component<TestProps, State> {
           )}
         </Kb.Box2>
         {!this.props.checkPasswordIsCorrect ? (
-          <Kb.ButtonBar align="center" direction="row" fullWidth={true} style={styles.buttonbar}>
+          <Kb.ButtonBar align="center" direction="row" fullWidth={true}>
             <Kb.Button onClick={this.props.onCancel} label="Cancel" fullWidth={true} type="Secondary" />
             <Kb.WaitingButton
               fullWidth={true}
@@ -96,7 +97,7 @@ class OfferToCheckPassword extends React.Component<TestProps, State> {
 }
 
 export default (props: Props) => (
-  <Kb.Box2>
+  <Kb.Box2 direction="vertical">
     {props.hasRandomPW ? (
       <UpdatePassword
         onSave={props.onSavePassword}

--- a/shared/settings/nav/index.native.js
+++ b/shared/settings/nav/index.native.js
@@ -71,7 +71,6 @@ function SettingsNav(props: Props) {
             {
               onClick: () => props.onTabChange(Constants.passwordTab),
               text: props.hasRandomPW ? 'Set a password' : 'Change password',
-              textColor: props.hasRandomPW ? globalColors.red : undefined,
             },
             {
               ...(isAndroid

--- a/shared/settings/password/index.js
+++ b/shared/settings/password/index.js
@@ -68,8 +68,7 @@ export class UpdatePassword extends Component<Props, State> {
           <Kb.Text style={styles.headerText} type="Header">
             Set a password
           </Kb.Text>
-
-          <Kb.Text type="Body" style={styles.bodyText}>
+          <Kb.Text type="Body" style={styles.bodyText} center={true}>
             A password allows you to sign out and sign back in, and use the keybase.io website.
           </Kb.Text>
           <Kb.Input
@@ -95,7 +94,7 @@ export class UpdatePassword extends Component<Props, State> {
             onCheck={showTyping => this.setState(prevState => ({showTyping: !prevState.showTyping}))}
             checked={this.state.showTyping || !!this.props.showTyping}
           />
-          <Kb.Text style={{margin: Styles.globalMargins.small, textAlign: 'center'}} type="BodySmall">
+          <Kb.Text style={styles.passwordFormat} type="BodySmall">
             (Password must be at least 8 characters.)
           </Kb.Text>
           <Kb.ButtonBar align="center" direction="row" fullWidth={true}>
@@ -137,7 +136,6 @@ const UpdatePasswordWrapper = (props: Props) => {
 const styles = Styles.styleSheetCreate({
   bodyText: {
     paddingBottom: Styles.globalMargins.tiny,
-    textAlign: 'center',
   },
   container: Styles.platformStyles({
     common: {
@@ -155,6 +153,10 @@ const styles = Styles.styleSheetCreate({
   headerText: {
     paddingBottom: Styles.globalMargins.small,
     paddingTop: Styles.globalMargins.small,
+  },
+  passwordFormat: {
+    margin: Styles.globalMargins.small,
+    textAlign: 'center',
   },
 })
 

--- a/shared/settings/password/index.js
+++ b/shared/settings/password/index.js
@@ -124,11 +124,15 @@ const UpdatePasswordWrapper = (props: Props) => {
     : props.hasPGPKeyOnServer
     ? {
         message:
-          "Note: changing your password will delete your PGP key from Keybase, and you'll need to generate or upload one again.",
+          "Changing your password will delete your PGP key from Keybase, and you'll need to generate or upload one again.",
         type: 'error',
       }
     : null
-  return <UpdatePassword {...props} />
+  return (
+    <Kb.StandardScreen notification={notification} style={{alignItems: 'center', margin: 0}}>
+      <UpdatePassword {...props} />
+    </Kb.StandardScreen>
+  )
 }
 const styles = Styles.styleSheetCreate({
   bodyText: {

--- a/shared/settings/password/index.js
+++ b/shared/settings/password/index.js
@@ -64,7 +64,14 @@ export class UpdatePassword extends Component<Props, State> {
     const inputType = this.state.showTyping ? 'passwordVisible' : 'password'
     return (
       <Kb.ScrollView contentContainerStyle={styles.container}>
-        <Kb.Box2 direction="vertical" centerChildren={true}>
+        <Kb.Box2 centerChildren={true} direction="vertical">
+          <Kb.Text style={styles.headerText} type="Header">
+            Set a password
+          </Kb.Text>
+
+          <Kb.Text type="Body" style={styles.bodyText}>
+            A password allows you to sign out and sign back in, and use the keybase.io website.
+          </Kb.Text>
           <Kb.Input
             hintText="New password"
             type={inputType}
@@ -88,10 +95,10 @@ export class UpdatePassword extends Component<Props, State> {
             onCheck={showTyping => this.setState(prevState => ({showTyping: !prevState.showTyping}))}
             checked={this.state.showTyping || !!this.props.showTyping}
           />
-          <Kb.Text style={{marginBottom: Styles.globalMargins.medium}} type="BodySmall">
+          <Kb.Text style={{margin: Styles.globalMargins.small, textAlign: 'center'}} type="BodySmall">
             (Password must be at least 8 characters.)
           </Kb.Text>
-          <Kb.ButtonBar align="center" direction="row" fullWidth={true} style={styles.buttonbar}>
+          <Kb.ButtonBar align="center" direction="row" fullWidth={true}>
             <Kb.Button
               fullWidth={true}
               type="Primary"
@@ -121,21 +128,30 @@ const UpdatePasswordWrapper = (props: Props) => {
         type: 'error',
       }
     : null
-  return (
-    <Kb.StandardScreen notification={notification} style={{alignItems: 'center', margin: 0}}>
-      <UpdatePassword {...props} />
-    </Kb.StandardScreen>
-  )
+  return <UpdatePassword {...props} />
 }
 const styles = Styles.styleSheetCreate({
-  buttonbar: {
-    padding: Styles.globalMargins.small,
+  bodyText: {
+    paddingBottom: Styles.globalMargins.tiny,
+    textAlign: 'center',
   },
   container: Styles.platformStyles({
+    common: {
+      paddingLeft: Styles.globalMargins.medium,
+      paddingRight: Styles.globalMargins.medium,
+      paddingTop: Styles.globalMargins.medium,
+    },
     isElectron: {
       width: 560,
     },
+    isMobile: {
+      width: '100%',
+    },
   }),
+  headerText: {
+    paddingBottom: Styles.globalMargins.small,
+    paddingTop: Styles.globalMargins.small,
+  },
 })
 
 export default UpdatePasswordWrapper


### PR DESCRIPTION
@keybase/react-hackers 

* Tweaked Sign out modal
* Tweaked Set password view
* Tweaked empty states in Your account page
* Added max-width to full-width buttons (cc @adamjspooner)

I couldn't figure out how to get rid of that top bar (screenshot) on both desktop and mobile and I need help for that. Removing `Kb.StandardScreen` solves it (I put it back in my last commit), but then the `notification` thing for PGP key owners no longer works.

![image](https://user-images.githubusercontent.com/2807426/55663216-6de44000-57d0-11e9-8b94-9a8c03cf2937.png)

cc @cjb 