### PR TITLE
Check for nopw during password change

### DIFF
--- a/go/client/cmd_passphrase_change.go
+++ b/go/client/cmd_passphrase_change.go
@@ -7,7 +7,9 @@ import (
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	context "golang.org/x/net/context"
 )
 
 type CmdPassphraseChange struct {
@@ -38,19 +40,29 @@ func (c *CmdPassphraseChange) Run() error {
 		return err
 	}
 
+	cliUser, err := GetUserClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	// If the user has a randompw, we force the password change since we cannot
+	// prompt them for the old one.
+	forcePassphraseChange, err := cliUser.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	if err != nil {
+		return err
+	}
+
 	pp, err := PromptNewPassphrase(c.G())
 	if err != nil {
 		return err
 	}
 
-	if err := passphraseChange(c.G(), newChangeArg(pp, false)); err != nil {
+	if err := passphraseChange(c.G(), newChangeArg(pp, forcePassphraseChange)); err != nil {
 		dui := c.G().UI.GetDumbOutputUI()
 		dui.Printf("\nThere was a problem during the standard update of your passphrase.")
 		dui.Printf("\n%s\n\n", err)
-		dui.Printf("If you have forgotten your existing passphrase, you can recover\n")
-		// TODO: Fix `passphrase change` to not ask for current passphrase when
-		// in NOPW, and advise users to use `keybase passphrase change`.
-		dui.Printf("your account with the command 'keybase passphrase recover'.\n\n")
+		dui.Printf("You can attempt to recover your account with the command\n")
+		dui.Printf("'keybase passphrase recover'.\n\n")
 		return err
 	}
 

--- a/go/client/cmd_passphrase_recover.go
+++ b/go/client/cmd_passphrase_recover.go
@@ -70,14 +70,11 @@ func (c *CmdPassphraseRecover) Run() error {
 	}
 
 	// Confirm with the user.
-	ui.Printf("Password recovery will put your account on probation for 5 days.\n")
-	ui.Printf("You won't be able to perform certain actions, like revoking devices.\n")
 	if hsk.HasServerKeys {
 		ui.Printf("You have uploaded an encrypted PGP private key, it will be lost.\n")
-	}
-	err = ui.PromptForConfirmation("Continue with password recovery?")
-	if err != nil {
-		return err
+		if err = ui.PromptForConfirmation("Continue with password recovery?"); err != nil {
+			return err
+		}
 	}
 
 	// Ask for the new passphase.


### PR DESCRIPTION
- pass `force=true` if the user is nopw during `keybase passphrase change` gui always passes `force=true`, see https://github.com/keybase/client/pull/5506
- remove out-dated probation warning. 

