### PR TITLE
Fs: some optimizations to speedup or reduce component updates

### DIFF
--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -149,7 +149,7 @@ const getPrefetchStatusFromRPC = (
 
 const direntToMetadata = (d: RPCTypes.Dirent) => ({
   lastModifiedTimestamp: d.time,
-  lastWriter: d.lastWriterUnverified,
+  lastWriter: d.lastWriterUnverified.username,
   name: d.name.split('/').pop(),
   prefetchStatus: getPrefetchStatusFromRPC(d.prefetchStatus, d.prefetchProgress),
   size: d.size,

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -109,7 +109,6 @@ export const makeTlf: I.RecordFactory<Types._Tlf> = I.Record({
   resetParticipants: I.List(),
   syncConfig: null,
   teamId: '',
-  tlfType: 'private',
   waitingForParticipantUnlock: I.List(),
   youCanUnlock: I.List(),
 })

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -41,7 +41,7 @@ export const emptyFolder = makeNewFolder()
 
 export const prefetchNotStarted: Types.PrefetchNotStarted = I.Record({state: 'not-started'})()
 
-export const prefetchComplete: Types.PrefetchComplete = I.Record({state: 'completet'})()
+export const prefetchComplete: Types.PrefetchComplete = I.Record({state: 'complete'})()
 
 export const makePrefetchInProgress: I.RecordFactory<Types._PrefetchInProgress> = I.Record({
   bytesFetched: 0,

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -52,13 +52,11 @@ export const makePrefetchInProgress: I.RecordFactory<Types._PrefetchInProgress> 
 })
 
 const pathItemMetadataDefault = {
-  badgeCount: 0,
   lastModifiedTimestamp: 0,
-  lastWriter: {uid: '', username: ''},
+  lastWriter: '',
   name: 'unknown',
   prefetchStatus: prefetchNotStarted,
   size: 0,
-  tlfMeta: undefined,
   writable: false,
 }
 

--- a/shared/constants/types/fs.js
+++ b/shared/constants/types/fs.js
@@ -16,7 +16,7 @@ import {memoize} from '../../util/memoize'
 export opaque type Path = ?string
 
 export type PathType = 'folder' | 'file' | 'symlink' | 'unknown'
-export type ProgressType = 'favorite' | 'pending' | 'loaded'
+export type ProgressType = 'pending' | 'loaded'
 
 // not naming Error because it has meaning in js.
 export type _FsError = {
@@ -179,7 +179,7 @@ type _PathItemMetadata = {
   name: string,
   lastModifiedTimestamp: number,
   size: number,
-  lastWriter: RPCTypes.User,
+  lastWriter: string,
   writable: boolean,
   prefetchStatus: PrefetchStatus,
 }

--- a/shared/fs/banner/reset-banner/container.js
+++ b/shared/fs/banner/reset-banner/container.js
@@ -69,7 +69,7 @@ export default ConnectedBanner
 export const asRows = (
   path: Types.Path,
   resetBannerType: Types.ResetBannerType
-): Array<RowTypes.RowItemWithKey> =>
+): Array<RowTypes.HeaderRowItem> =>
   typeof resetBannerType === 'number'
     ? [
         {

--- a/shared/fs/banner/system-file-manager-integration-banner/container.js
+++ b/shared/fs/banner/system-file-manager-integration-banner/container.js
@@ -32,7 +32,7 @@ export default ConnectedBanner
 
 export const asRows = isMobile
   ? (path: Types.Path, showBanner: boolean) => []
-  : (path: Types.Path, showBanner: boolean): Array<RowTypes.RowItemWithKey> =>
+  : (path: Types.Path, showBanner: boolean): Array<RowTypes.HeaderRowItem> =>
       showBanner
         ? [
             {

--- a/shared/fs/common/folder-view-filter.js
+++ b/shared/fs/common/folder-view-filter.js
@@ -136,7 +136,7 @@ const mapDispatchToProps = (dispatch, {path}: OwnProps) => ({
 })
 
 const mergeProps = (s, d, o) => ({
-  onUpdate: debounce(d._onUpdate, 250),
+  onUpdate: debounce(d._onUpdate, 100),
   path: o.path,
   style: o.style,
 })

--- a/shared/fs/common/path-item-info-container.js
+++ b/shared/fs/common/path-item-info-container.js
@@ -19,7 +19,7 @@ const mergeProps = (stateProps, dispatchProps, {mode}) => ({
       ? undefined
       : stateProps._pathItem.lastModifiedTimestamp,
   lastWriter:
-    stateProps._pathItem === Constants.unknownPathItem ? undefined : stateProps._pathItem.lastWriter.username,
+    stateProps._pathItem === Constants.unknownPathItem ? undefined : stateProps._pathItem.lastWriter,
   mode,
 })
 

--- a/shared/fs/filepreview/index.stories.js
+++ b/shared/fs/filepreview/index.stories.js
@@ -18,7 +18,7 @@ export const filepreviewProvider = {
     onShare: () => {},
     onShowInSystemFileManager: () => {},
     pathItem: Constants.makeFile({
-      lastWriter: {uid: '', username: 'foo'},
+      lastWriter: 'foo',
       name: 'bar.jpg',
       size: 10240,
     }),
@@ -32,7 +32,7 @@ export const filepreviewProvider = {
     onShowInSystemFileManager: () => {},
     path,
     pathItem: Constants.makeFile({
-      lastWriter: {uid: '', username: 'foo'},
+      lastWriter: 'foo',
       name: 'bar.jpg',
       size: 10240,
     }),

--- a/shared/fs/row/editing-container.js
+++ b/shared/fs/row/editing-container.js
@@ -6,10 +6,10 @@ import * as Constants from '../../constants/fs'
 import {namedConnect} from '../../util/container'
 import Editing from './editing'
 
-type OwnProps = {
+type OwnProps = {|
   editID: Types.EditID,
   routePath: I.List<string>,
-}
+|}
 
 const mapStateToProps = (state, {editID}: OwnProps) => ({
   _edit: state.fs.edits.get(editID, Constants.emptyFolder),

--- a/shared/fs/row/index.stories.js
+++ b/shared/fs/row/index.stories.js
@@ -24,7 +24,7 @@ export const rowsProvider = {
   }),
   ConnectedRows: (o: any) => ({
     destinationPickerIndex: o.destinationPickerIndex,
-    items: [
+    items: I.List([
       ...(o.headerRows || []),
       ...topBarAsRow(o.path),
       {key: 'me', name: 'me', path: Types.stringToPath('/keybase/private/me'), rowType: 'still'},
@@ -72,15 +72,16 @@ export const rowsProvider = {
       ...(!isMobile && typeof o.destinationPickerIndex === 'number'
         ? [{key: 'empty:0', rowType: 'empty'}, {key: 'empty:1', rowType: 'empty'}]
         : []),
-    ],
+    ]),
     routePath: I.List(),
   }),
   ConnectedStillRow: ({
     path,
     destinationPickerIndex,
   }: {
-    path: Types.Path,
     destinationPickerIndex?: number,
+    path: Types.Path,
+    routePath: I.List<string>,
   }) => {
     const pathStr = Types.pathToString(path)
     return {
@@ -88,6 +89,7 @@ export const rowsProvider = {
       isEmpty: pathStr.includes('empty'),
       name: Types.getPathName(path),
       path,
+      routePath: I.List(),
       type: 'folder',
     }
   },
@@ -128,7 +130,6 @@ const load = () =>
           <ConnectedStillRow
             name="a"
             path={Types.stringToPath('/keybase/private/meatball/a')}
-            routeProps={I.Map({path: '/keybase/private/meatball/a'})}
             routePath={I.List([])}
           />
         </WrapRow>
@@ -265,7 +266,6 @@ const load = () =>
           <ConnectedStillRow
             name="empty"
             path={Types.stringToPath('/keybase/private/meatball/empty')}
-            routeProps={I.Map({path: '/keybase/private/meatball/empty'})}
             routePath={I.List([])}
           />
         </WrapRow>

--- a/shared/fs/row/rows-container.js
+++ b/shared/fs/row/rows-container.js
@@ -5,163 +5,164 @@ import * as Types from '../../constants/types/fs'
 import * as RowTypes from './types'
 import * as Constants from '../../constants/fs'
 import {isMobile} from '../../constants/platform'
-import {
-  sortRowItems,
-  type SortableStillRowItem,
-  type SortableEditingRowItem,
-  type SortableUploadingRowItem,
-  type SortableRowItem,
-} from './sort'
+import {sortRowItems, type SortableRowItem} from './sort'
 import Rows from './rows'
 import {asRows as topBarAsRow} from '../top-bar'
+import {memoize} from '../../util/memoize'
 
 type OwnProps = {|
   path: Types.Path, // path to the parent folder containering the rows
   routePath: I.List<string>,
   destinationPickerIndex?: number,
-  headerRows?: ?Array<RowTypes.RowItemWithKey>,
+  headerRows?: ?Array<RowTypes.HeaderRowItem>,
 |}
 
-const getEditingRows = (
-  edits: I.Map<Types.EditID, Types.Edit>,
-  parentPath: Types.Path
-): Array<SortableEditingRowItem> =>
-  edits
-    .filter(edit => edit.parentPath === parentPath)
-    .toArray()
-    .map(([editID, edit]) => ({
-      editID,
-      editType: edit.type,
-      key: `edit:${Types.editIDToString(editID)}`,
-      name: edit.name,
-      // fields for sortable
-      rowType: 'editing',
-      type: 'folder',
-    }))
+const getEditingRows = memoize(
+  (edits: I.Map<Types.EditID, Types.Edit>, parentPath: Types.Path): I.List<RowTypes.EditingRowItem> =>
+    I.List(
+      edits
+        .filter(edit => edit.parentPath === parentPath)
+        .toArray()
+        .map(([editID, edit]) => ({
+          editID,
+          editType: edit.type,
+          key: `edit:${Types.editIDToString(editID)}`,
+          name: edit.name,
+          // fields for sortable
+          rowType: 'editing',
+          type: 'folder',
+        }))
+    )
+)
 
-const getStillRows = (
-  pathItems: I.Map<Types.Path, Types.PathItem>,
-  parentPath: Types.Path,
-  names: Array<string>
-): Array<SortableStillRowItem> =>
-  names.reduce((items, name) => {
-    const item = pathItems.get(Types.pathConcat(parentPath, name), Constants.unknownPathItem)
-    const path = Types.pathConcat(parentPath, item.name)
-    return [
-      ...items,
-      {
-        key: `still:${name}`,
-        lastModifiedTimestamp: item.lastModifiedTimestamp,
-        name: item.name,
-        path,
-        // fields for sortable
-        rowType: 'still',
-        type: item.type,
-      },
-    ]
-  }, [])
+const getStillRows = memoize(
+  (
+    pathItems: I.Map<Types.Path, Types.PathItem>,
+    parentPath: Types.Path,
+    names: I.Set<string>
+  ): I.List<RowTypes.StillRowItem> =>
+    I.List(
+      names.toArray().reduce((items, name) => {
+        const item = pathItems.get(Types.pathConcat(parentPath, name), Constants.unknownPathItem)
+        const path = Types.pathConcat(parentPath, item.name)
+        return [
+          ...items,
+          {
+            key: `still:${name}`,
+            lastModifiedTimestamp: item.lastModifiedTimestamp,
+            name: item.name,
+            path,
+            // fields for sortable
+            rowType: 'still',
+            type: item.type,
+          },
+        ]
+      }, [])
+    )
+)
 
 // TODO: when we have renames, reconcile editing rows in here too.
-const amendStillRows = (
-  stills: Array<SortableStillRowItem>,
-  uploads: Types.Uploads
-): Array<SortableRowItem> =>
-  stills.map(still => {
-    const {name, type, path} = still
-    if (type === 'folder') {
-      // Don't show an upload row for folders.
-      return still
-    }
-    if (!uploads.writingToJournal.has(path) && !uploads.syncingPaths.has(path)) {
-      // The entry is absent from uploads. So just show a still row.
-      return still
-    }
-    return ({
-      key: `uploading:${name}`,
-      name,
-      path,
-      rowType: 'uploading',
-      // field for sortable
-      type,
-    }: SortableUploadingRowItem)
-  })
+const amendStillRowsWithUploads = memoize(
+  (stills: I.List<RowTypes.StillRowItem>, uploads: Types.Uploads): I.List<SortableRowItem> =>
+    stills.map(still => {
+      const {name, type, path} = still
+      if (type === 'folder') {
+        // Don't show an upload row for folders.
+        return still
+      }
+      if (!uploads.writingToJournal.has(path) && !uploads.syncingPaths.has(path)) {
+        // The entry is absent from uploads. So just show a still row.
+        return still
+      }
+      return ({
+        key: `uploading:${name}`,
+        name,
+        path,
+        rowType: 'uploading',
+        // field for sortable
+        type,
+      }: RowTypes.UploadingRowItem)
+    })
+)
 
-const getPlaceholderRows = type => [
-  {key: 'placeholder:1', name: '1', rowType: 'placeholder', type},
-  {key: 'placeholder:2', name: '2', rowType: 'placeholder', type},
-  {key: 'placeholder:3', name: '3', rowType: 'placeholder', type},
-]
+const _getPlaceholderRows = (type): I.List<RowTypes.PlaceholderRowItem> =>
+  I.List([
+    {key: 'placeholder:1', name: '1', rowType: 'placeholder', type},
+    {key: 'placeholder:2', name: '2', rowType: 'placeholder', type},
+    {key: 'placeholder:3', name: '3', rowType: 'placeholder', type},
+  ])
+const filePlaceholderRows = _getPlaceholderRows('file')
+const folderPlaceholderRows = _getPlaceholderRows('folder')
 
-const getInTlfItemsFromStateProps = (stateProps, path: Types.Path) => {
+const _makeInTlfRows = memoize((editingRows, amendedStillRows) => editingRows.concat(amendedStillRows))
+
+const getInTlfItemsFromStateProps = (stateProps, path: Types.Path): I.List<RowTypes.NamedRowItem> => {
   const _pathItem = stateProps._pathItems.get(path, Constants.unknownPathItem)
   if (_pathItem.type !== 'folder') {
-    return getPlaceholderRows('file')
+    return filePlaceholderRows
   }
 
   if (_pathItem.progress === 'pending') {
-    return getPlaceholderRows('file')
+    return filePlaceholderRows
   }
 
   const editingRows = getEditingRows(stateProps._edits, path)
-  const stillRows = getStillRows(stateProps._pathItems, path, _pathItem.children.toArray())
+  const stillRows = getStillRows(stateProps._pathItems, path, _pathItem.children)
 
   return sortRowItems(
-    editingRows.concat(amendStillRows(stillRows, stateProps._uploads)),
+    _makeInTlfRows(editingRows, amendStillRowsWithUploads(stillRows, stateProps._uploads)),
     stateProps._sortSetting,
-    undefined
+    ''
   )
 }
 
-const getRootRows = stateProps =>
-  sortRowItems(
-    [
-      {key: 'tlfType:private', name: 'private', rowType: 'tlf-type', type: 'folder'},
-      {key: 'tlfType:public', name: 'public', rowType: 'tlf-type', type: 'folder'},
-      {key: 'tlfType:team', name: 'team', rowType: 'tlf-type', type: 'folder'},
-    ],
-    stateProps._sortSetting,
-    undefined
-  )
+const getRootRows = (stateProps): I.List<RowTypes.TlfTypeRowItem> =>
+  I.List([
+    {key: 'tlfType:private', name: 'private', rowType: 'tlf-type', type: 'folder'},
+    {key: 'tlfType:public', name: 'public', rowType: 'tlf-type', type: 'folder'},
+    {key: 'tlfType:team', name: 'team', rowType: 'tlf-type', type: 'folder'},
+  ])
 
-const getTlfRowsFromTlfs = (tlfs: I.Map<string, Types.Tlf>, tlfType: Types.TlfType): Array<SortableRowItem> =>
-  tlfs.reduce(
-    (rows, {isIgnored, isNew}, name) =>
-      isIgnored
-        ? rows
-        : [
-            ...rows,
-            {
-              isNew,
-              key: `tlf:${name}`,
-              name,
-              rowType: 'tlf',
-              tlfType,
-              type: 'folder',
-            },
-          ],
-    ([]: Array<SortableRowItem>)
-  )
+const getTlfRowsFromTlfs = memoize(
+  (tlfs: I.Map<string, Types.Tlf>, tlfType: Types.TlfType): I.List<SortableRowItem> =>
+    I.List().withMutations(list =>
+      tlfs.reduce(
+        (rows, {isIgnored, isNew}, name) =>
+          isIgnored
+            ? rows
+            : rows.push({
+                isNew,
+                key: `tlf:${name}`,
+                name,
+                rowType: 'tlf',
+                tlfType,
+                type: 'folder',
+              }),
+        list
+      )
+    )
+)
 
-const getTlfItemsFromStateProps = (stateProps, path) => {
+const getTlfItemsFromStateProps = (stateProps, path): I.List<RowTypes.NamedRowItem> => {
   if (stateProps._tlfs.private.count() === 0) {
     // /keybase/private/<me> is always favorited. If it's not there it must be
     // unintialized.
-    return getPlaceholderRows('folder')
+    return folderPlaceholderRows
   }
 
   const {tlfList, tlfType} = Constants.getTlfListAndTypeFromPath(stateProps._tlfs, path)
   return sortRowItems(
     getTlfRowsFromTlfs(tlfList, tlfType),
     stateProps._sortSetting,
-    (Types.pathIsNonTeamTLFList(path) && stateProps._username) || undefined
+    (Types.pathIsNonTeamTLFList(path) && stateProps._username) || ''
   )
 }
 
-const getNormalRowItemsFromStateProps = (stateProps, path) => {
+const getNormalRowItemsFromStateProps = (stateProps, path): I.List<RowTypes.NamedRowItem> => {
   const level = Types.getPathLevel(path)
   switch (level) {
     case 0:
-      return [] // should never happen
+      return I.List() // should never happen
     case 1:
       return getRootRows(stateProps)
     case 2:
@@ -191,23 +192,25 @@ const mergeProps = (s, d, o: OwnProps) => {
   const normalRowItems = filterRowItems(getNormalRowItemsFromStateProps(s, o.path), s._filter)
   return {
     destinationPickerIndex: o.destinationPickerIndex,
-    isEmpty: !normalRowItems.length,
-    // $FlowIssue
-    items: [
+    isEmpty: !normalRowItems.size,
+    items: I.List([
       ...(o.headerRows || []),
-      ...topBarAsRow(o.path),
-      ...filterRowItems(normalRowItems),
-      // If we are in the destination picker, inject two empty rows so when
-      // user scrolls to the bottom nothing is blocked by the
-      // semi-transparent footer.
-      //
-      // TODO: add `footerRows` and inject these from destination-picker, so that
-      // Rows componenet don't need to worry about whether it's in
-      // destinationPicker mode or not.
-      ...(!isMobile && typeof o.destinationPickerIndex === 'number'
-        ? [{key: 'empty:0', rowType: 'empty'}, {key: 'empty:1', rowType: 'empty'}]
-        : []),
-    ],
+      // don't show top bar in destinationPicker.
+      ...(typeof o.destinationPickerIndex === 'number' ? [] : topBarAsRow(o.path)),
+    ])
+      .concat(normalRowItems)
+      .concat(
+        // If we are in the destination picker, inject two empty rows so when
+        // user scrolls to the bottom nothing is blocked by the
+        // semi-transparent footer.
+        //
+        // TODO: add `footerRows` and inject these from destination-picker, so that
+        // Rows componenet don't need to worry about whether it's in
+        // destinationPicker mode or not.
+        isMobile && typeof o.destinationPickerIndex === 'number'
+          ? [{key: 'empty:0', rowType: 'empty'}, {key: 'empty:1', rowType: 'empty'}]
+          : []
+      ),
     path: o.path,
     routePath: o.routePath,
   }

--- a/shared/fs/row/rows-container.js
+++ b/shared/fs/row/rows-container.js
@@ -207,7 +207,7 @@ const mergeProps = (s, d, o: OwnProps) => {
         // TODO: add `footerRows` and inject these from destination-picker, so that
         // Rows componenet don't need to worry about whether it's in
         // destinationPicker mode or not.
-        isMobile && typeof o.destinationPickerIndex === 'number'
+        !isMobile && typeof o.destinationPickerIndex === 'number'
           ? [{key: 'empty:0', rowType: 'empty'}, {key: 'empty:1', rowType: 'empty'}]
           : []
       ),

--- a/shared/fs/row/rows.js
+++ b/shared/fs/row/rows.js
@@ -18,7 +18,7 @@ import {memoize} from '../../util/memoize'
 
 type Props = {
   destinationPickerIndex?: number,
-  items: Array<RowTypes.RowItemWithKey>,
+  items: I.List<RowTypes.RowItem>,
   isEmpty: boolean,
   path: Types.Path,
   routePath: I.List<string>,
@@ -101,13 +101,13 @@ class Rows extends React.PureComponent<Props> {
   }
   _getVariableRowLayout = (items, index) => ({
     index,
-    length: getRowHeight(items[index]),
+    length: getRowHeight(items.get(index, _unknownEmptyRowItem)),
     offset: items.slice(0, index).reduce((offset, row) => offset + getRowHeight(row), 0),
   })
   _getTopVariableRowCountAndTotalHeight = memoize(items => {
     const index = items.findIndex(row => row !== 'header')
     return index === -1
-      ? {count: items.length, totalHeight: -1}
+      ? {count: items.size, totalHeight: -1}
       : {count: index, totalHeight: this._getVariableRowLayout(items, index).offset}
   })
   _getItemLayout = index => {
@@ -117,7 +117,7 @@ class Rows extends React.PureComponent<Props> {
     }
     return {
       index,
-      length: getRowHeight(this.props.items[index]),
+      length: getRowHeight(this.props.items.get(index, _unknownEmptyRowItem)),
       offset: (index - top.count) * normalRowHeight + top.totalHeight,
     }
   }
@@ -129,9 +129,9 @@ class Rows extends React.PureComponent<Props> {
     const index = items.findIndex(row => row.rowType !== 'header')
     return (
       items
-        .slice(0, index === -1 ? items.length : index)
+        .slice(0, index === -1 ? items.size : index)
         .map(row => getRowHeight(row).toString())
-        .join('-') + `:${items.length}`
+        .join('-') + `:${items.size}`
     )
   })
 
@@ -148,7 +148,7 @@ class Rows extends React.PureComponent<Props> {
       <Kb.BoxGrow>
         <Kb.List2
           key={this._getListKey(this.props.items)}
-          items={this.props.items}
+          items={this.props.items.toArray()}
           bounces={true}
           itemHeight={{
             getItemLayout: this._getItemLayout,
@@ -185,7 +185,11 @@ const styles = Styles.styleSheetCreate({
   },
 })
 
-const getRowHeight = (row: RowTypes.RowItemWithKey) =>
-  row.rowType === 'header' ? row.height : normalRowHeight
+const getRowHeight = (row: RowTypes.RowItem) => (row.rowType === 'header' ? row.height : normalRowHeight)
+
+const _unknownEmptyRowItem = {
+  key: 'unknown-empty-row-item',
+  rowType: 'empty',
+}
 
 export default Rows

--- a/shared/fs/row/still-container.js
+++ b/shared/fs/row/still-container.js
@@ -1,16 +1,18 @@
 // @flow
 import * as React from 'react'
 import * as I from 'immutable'
-import * as RowTypes from './types'
+import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import {namedConnect} from '../../util/container'
 import OpenHOC from '../common/open-hoc'
 import Still from './still'
 
-type OwnProps = $Diff<RowTypes.StillRowItem, {rowType: 'still'}> & {
-  routePath: I.List<string>,
+type OwnProps = {|
   destinationPickerIndex?: number,
-}
+  name: string,
+  path: Types.Path,
+  routePath: I.List<string>,
+|}
 
 const mapStateToProps = (state, {path}: OwnProps) => ({
   _downloads: state.fs.downloads,

--- a/shared/fs/row/tlf-container.js
+++ b/shared/fs/row/tlf-container.js
@@ -1,16 +1,18 @@
 // @flow
 import * as React from 'react'
 import * as I from 'immutable'
-import * as RowTypes from './types'
+import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import {namedConnect} from '../../util/container'
 import OpenHOC from '../common/open-hoc'
 import Tlf from './tlf'
 
-type OwnProps = $Diff<RowTypes.TlfRowItem, {rowType: 'tlf'}> & {
-  routePath: I.List<string>,
+type OwnProps = {|
   destinationPickerIndex?: number,
-}
+  name: string,
+  routePath: I.List<string>,
+  tlfType: Types.TlfType,
+|}
 
 const mapStateToProps = (state, {tlfType, name}: OwnProps) => ({
   _tlf: Constants.getTlfFromTlfs(state.fs.tlfs, tlfType, name),

--- a/shared/fs/row/tlf-type-container.js
+++ b/shared/fs/row/tlf-type-container.js
@@ -2,16 +2,16 @@
 import * as React from 'react'
 import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
-import * as RowTypes from './types'
 import * as Constants from '../../constants/fs'
 import {namedConnect} from '../../util/container'
 import OpenHOC from '../common/open-hoc'
 import TlfType from './tlf-type'
 
-type OwnProps = $Diff<RowTypes.TlfTypeRowItem, {rowType: 'tlf-type'}> & {
-  routePath: I.List<string>,
+type OwnProps = {|
   destinationPickerIndex?: number,
-}
+  name: 'private' | 'public' | 'team',
+  routePath: I.List<string>,
+|}
 
 const mapStateToProps = (state, {name}: OwnProps) => ({
   _tlfList: Constants.getTlfListFromType(state.fs.tlfs, name),

--- a/shared/fs/row/types.js
+++ b/shared/fs/row/types.js
@@ -3,66 +3,72 @@ import * as Types from '../../constants/types/fs'
 import * as React from 'react'
 
 export type TlfTypeRowItem = {
-  rowType: 'tlf-type',
+  key: string,
   name: Types.TlfType,
+  rowType: 'tlf-type',
+  type: 'folder',
 }
 
 export type TlfRowItem = {
+  isNew: boolean,
+  key: string,
+  name: string,
   rowType: 'tlf',
   tlfType: Types.TlfType,
-  name: string,
+  type: 'folder',
 }
 
 export type StillRowItem = {
-  rowType: 'still',
-  path: Types.Path,
+  key: string,
+  lastModifiedTimestamp: number,
   name: string,
+  path: Types.Path,
+  rowType: 'still',
+  type: Types.PathType,
 }
 
 export type EditingRowItem = {
-  rowType: 'editing',
+  editType: Types.EditType,
   editID: Types.EditID,
+  key: string,
   name: string,
+  rowType: 'editing',
+  type: Types.PathType,
 }
 
 export type UploadingRowItem = {
-  rowType: 'uploading',
+  key: string,
   name: string,
   path: Types.Path,
+  rowType: 'uploading',
+  type: Types.PathType,
 }
 
 export type PlaceholderRowItem = {
-  rowType: 'placeholder',
+  key: string,
   name: string,
+  rowType: 'placeholder',
   type: 'folder' | 'file',
 }
 
 export type EmptyRowItem = {
+  key: string,
   rowType: 'empty',
 }
 
 export type HeaderRowItem = {
+  key: string,
   rowType: 'header',
   height: number,
   node: React.Node,
 }
 
-export type RowItem =
+export type NamedRowItem =
   | TlfTypeRowItem
   | TlfRowItem
   | StillRowItem
   | EditingRowItem
   | UploadingRowItem
   | PlaceholderRowItem
-  | EmptyRowItem
-  | HeaderRowItem
 
-export type RowItemWithKey =
-  | ({key: string} & TlfTypeRowItem)
-  | ({key: string} & TlfRowItem)
-  | ({key: string} & StillRowItem)
-  | ({key: string} & EditingRowItem)
-  | ({key: string} & UploadingRowItem)
-  | ({key: string} & PlaceholderRowItem)
-  | ({key: string} & EmptyRowItem)
-  | ({key: string} & HeaderRowItem)
+export type RowItem = NamedRowItem | EmptyRowItem | HeaderRowItem

--- a/shared/fs/top-bar/index.js
+++ b/shared/fs/top-bar/index.js
@@ -53,7 +53,7 @@ const styles = Styles.styleSheetCreate({
 })
 
 export default TopBar
-export const asRows = (path: Types.Path): Array<RowTypes.RowItemWithKey> => [
+export const asRows = (path: Types.Path): Array<RowTypes.HeaderRowItem> => [
   {
     height,
     key: 'top-bar',

--- a/shared/reducers/__tests__/fs.js
+++ b/shared/reducers/__tests__/fs.js
@@ -1,0 +1,160 @@
+// @flow
+/* eslint-env jest */
+import * as Types from '../../constants/types/fs'
+import * as Constants from '../../constants/fs'
+import * as FsGen from '../../actions/fs-gen'
+import * as I from 'immutable'
+import reducer from '../fs'
+
+jest.unmock('immutable')
+
+const kbkbfstestPath = Types.stringToPath('/keybase/team/kbkbfstest')
+const file0Path = Types.pathConcat(kbkbfstestPath, 'file0')
+const folder0Path = Types.pathConcat(kbkbfstestPath, 'folder0')
+
+const getFolderOrFail = (pathItems, path): Types.FolderPathItem => {
+  const pathItem = pathItems.get(path)
+  expect(pathItem).toBeTruthy()
+  expect(pathItem ? pathItem.type : 'nope').toBe('folder')
+  return pathItem && pathItem.type === 'folder' ? pathItem : Constants.makeFolder()
+}
+
+const state0 = Constants.makeState({
+  pathItems: I.Map([
+    [
+      kbkbfstestPath,
+      Constants.makeFolder({
+        children: I.Set(['file0', 'folder0']),
+        name: 'kbkbfstest',
+        progress: 'loaded',
+      }),
+    ],
+    [
+      file0Path,
+      Constants.makeFile({
+        lastModifiedTimestamp: 1,
+        lastWriter: 'foo',
+        mimeType: Constants.makeMime({
+          displayPreview: true,
+          mimeType: 'text/plain',
+        }),
+        name: 'file0',
+      }),
+    ],
+    [
+      folder0Path,
+      Constants.makeFolder({
+        children: I.Set(),
+        name: 'folder0',
+        progress: 'pending',
+      }),
+    ],
+  ]),
+})
+
+describe('fs reducer', () => {
+  test('pathItemLoaded: reuse old pathItem even if new one lacks mimeType', () => {
+    const state1 = reducer(
+      state0,
+      FsGen.createPathItemLoaded({
+        path: file0Path,
+        pathItem: Constants.makeFile({
+          lastModifiedTimestamp: 1,
+          lastWriter: 'foo',
+          name: 'file0',
+        }),
+      })
+    )
+    expect(state1.pathItems).toBe(state0.pathItems)
+  })
+
+  test('pathItemLoaded: reuse old pathItem even if new one remains the same', () => {
+    const state1 = reducer(
+      state0,
+      FsGen.createPathItemLoaded({
+        path: file0Path,
+        pathItem: Constants.makeFile({
+          lastModifiedTimestamp: 1,
+          lastWriter: 'foo',
+          mimeType: Constants.makeMime({
+            displayPreview: true,
+            mimeType: 'text/plain',
+          }),
+          name: 'file0',
+        }),
+      })
+    )
+    expect(state1.pathItems).toBe(state0.pathItems)
+  })
+
+  test('pathItemLoaded: unset mimeType when other metadata changes', () => {
+    const newPathItem = Constants.makeFile({
+      lastModifiedTimestamp: 2,
+      lastWriter: 'foo',
+      name: 'file0',
+      size: 1,
+    })
+    const state1 = reducer(
+      state0,
+      FsGen.createPathItemLoaded({
+        path: file0Path,
+        pathItem: newPathItem,
+      })
+    )
+    expect(state1.pathItems).not.toBe(state0.pathItems)
+    expect(state1.pathItems.get(file0Path)).toBe(newPathItem)
+  })
+
+  test('pathItemLoaded: pending folder should not over ride loaded children', () => {
+    const state1 = reducer(
+      state0,
+      FsGen.createPathItemLoaded({
+        path: kbkbfstestPath,
+        pathItem: Constants.makeFolder({
+          lastModifiedTimestamp: 1,
+          name: 'kbkbfstest',
+        }),
+      })
+    )
+    expect(state1.pathItems).not.toBe(state0.pathItems)
+    expect(getFolderOrFail(state1.pathItems, kbkbfstestPath).children).toBe(
+      getFolderOrFail(state0.pathItems, kbkbfstestPath).children
+    )
+  })
+
+  test('pathItemLoaded: reuse old pathItem if new folder remains the same', () => {
+    const state1 = reducer(
+      state0,
+      FsGen.createPathItemLoaded({
+        path: kbkbfstestPath,
+        pathItem: Constants.makeFolder({
+          children: I.Set(['file0', 'folder0']),
+          name: 'kbkbfstest',
+          progress: 'loaded',
+        }),
+      })
+    )
+    expect(state1.pathItems).toBe(state0.pathItems)
+  })
+
+  test('folderListLoaded: load folder0', () => {
+    const stage1 = reducer(
+      state0,
+      FsGen.createFolderListLoaded({
+        path: folder0Path,
+        pathItems: I.Map([
+          [
+            folder0Path,
+            Constants.makeFolder({
+              children: I.Set(['file1']),
+              name: 'folder0',
+              progress: 'loaded',
+            }),
+          ],
+        ]),
+      })
+    )
+    expect(stage1.pathItems).not.toBe(state0.pathItems)
+    expect(getFolderOrFail(stage1.pathItems, folder0Path).children).toEqual(I.Set(['file1']))
+  })
+})

--- a/shared/reducers/__tests__/fs.js
+++ b/shared/reducers/__tests__/fs.js
@@ -190,14 +190,21 @@ describe('fs reducer', () => {
       name: 'foo',
       needsRekey: true,
       resetParticipants: I.List(),
-      syncConfig: Constants.makeTlfSyncPartial({enabledPaths: I.List([Constants.defaultPath])}),
       teamId: '123',
       waitingForParticipantUnlock: I.List(),
       youCanUnlock: I.List(),
     }
     const state0 = Constants.makeState({
       tlfs: Constants.makeTlfs({
-        private: I.Map([['foo', Constants.makeTlf(tlfFields)]]),
+        private: I.Map([
+          [
+            'foo',
+            Constants.makeTlf({
+              ...tlfFields,
+              syncConfig: Constants.makeTlfSyncPartial({enabledPaths: I.List([Constants.defaultPath])}),
+            }),
+          ],
+        ]),
       }),
     })
     const state1 = reducer(

--- a/shared/reducers/__tests__/fs.js
+++ b/shared/reducers/__tests__/fs.js
@@ -26,6 +26,7 @@ const state0 = Constants.makeState({
       Constants.makeFolder({
         children: I.Set(['file0', 'folder0']),
         name: 'kbkbfstest',
+        prefetchStatus: Constants.makePrefetchInProgress(),
         progress: 'loaded',
       }),
     ],
@@ -68,7 +69,7 @@ describe('fs reducer', () => {
     expect(state1.pathItems).toBe(state0.pathItems)
   })
 
-  test('pathItemLoaded: reuse old pathItem even if new one remains the same', () => {
+  test('pathItemLoaded: reuse old pathItem if new one remains the same', () => {
     const state1 = reducer(
       state0,
       FsGen.createPathItemLoaded({
@@ -130,6 +131,7 @@ describe('fs reducer', () => {
         pathItem: Constants.makeFolder({
           children: I.Set(['file0', 'folder0']),
           name: 'kbkbfstest',
+          prefetchStatus: Constants.makePrefetchInProgress(),
           progress: 'loaded',
         }),
       })
@@ -148,6 +150,7 @@ describe('fs reducer', () => {
             Constants.makeFolder({
               children: I.Set(['file1']),
               name: 'folder0',
+              prefetchStatus: Constants.prefetchNotStarted,
               progress: 'loaded',
             }),
           ],
@@ -156,5 +159,26 @@ describe('fs reducer', () => {
     )
     expect(stage1.pathItems).not.toBe(state0.pathItems)
     expect(getFolderOrFail(stage1.pathItems, folder0Path).children).toEqual(I.Set(['file1']))
+    expect(getFolderOrFail(stage1.pathItems, folder0Path).prefetchStatus).toBe(Constants.prefetchNotStarted)
+  })
+
+  test('folderListLoaded: folder0 prefetch complete', () => {
+    const stage1 = reducer(
+      state0,
+      FsGen.createFolderListLoaded({
+        path: folder0Path,
+        pathItems: I.Map([
+          [
+            folder0Path,
+            Constants.makeFolder({
+              name: 'folder0',
+              prefetchStatus: Constants.prefetchComplete,
+            }),
+          ],
+        ]),
+      })
+    )
+    expect(stage1.pathItems).not.toBe(state0.pathItems)
+    expect(getFolderOrFail(stage1.pathItems, folder0Path).prefetchStatus).toBe(Constants.prefetchComplete)
   })
 })

--- a/shared/reducers/__tests__/fs.js
+++ b/shared/reducers/__tests__/fs.js
@@ -140,7 +140,7 @@ describe('fs reducer', () => {
   })
 
   test('folderListLoaded: load folder0', () => {
-    const stage1 = reducer(
+    const state1 = reducer(
       state0,
       FsGen.createFolderListLoaded({
         path: folder0Path,
@@ -157,13 +157,13 @@ describe('fs reducer', () => {
         ]),
       })
     )
-    expect(stage1.pathItems).not.toBe(state0.pathItems)
-    expect(getFolderOrFail(stage1.pathItems, folder0Path).children).toEqual(I.Set(['file1']))
-    expect(getFolderOrFail(stage1.pathItems, folder0Path).prefetchStatus).toBe(Constants.prefetchNotStarted)
+    expect(state1.pathItems).not.toBe(state0.pathItems)
+    expect(getFolderOrFail(state1.pathItems, folder0Path).children).toEqual(I.Set(['file1']))
+    expect(getFolderOrFail(state1.pathItems, folder0Path).prefetchStatus).toBe(Constants.prefetchNotStarted)
   })
 
   test('folderListLoaded: folder0 prefetch complete', () => {
-    const stage1 = reducer(
+    const state1 = reducer(
       state0,
       FsGen.createFolderListLoaded({
         path: folder0Path,
@@ -178,7 +178,36 @@ describe('fs reducer', () => {
         ]),
       })
     )
-    expect(stage1.pathItems).not.toBe(state0.pathItems)
-    expect(getFolderOrFail(stage1.pathItems, folder0Path).prefetchStatus).toBe(Constants.prefetchComplete)
+    expect(state1.pathItems).not.toBe(state0.pathItems)
+    expect(getFolderOrFail(state1.pathItems, folder0Path).prefetchStatus).toBe(Constants.prefetchComplete)
+  })
+
+  test('favorritesLoaded: reuse tlf', () => {
+    const tlfFields = {
+      isFavorite: true,
+      isIgnored: true,
+      isNew: true,
+      name: 'foo',
+      needsRekey: true,
+      resetParticipants: I.List(),
+      syncConfig: Constants.makeTlfSyncPartial({enabledPaths: I.List([Constants.defaultPath])}),
+      teamId: '123',
+      waitingForParticipantUnlock: I.List(),
+      youCanUnlock: I.List(),
+    }
+    const state0 = Constants.makeState({
+      tlfs: Constants.makeTlfs({
+        private: I.Map([['foo', Constants.makeTlf(tlfFields)]]),
+      }),
+    })
+    const state1 = reducer(
+      state0,
+      FsGen.createFavoritesLoaded({
+        private: I.Map([['foo', Constants.makeTlf(tlfFields)]]),
+        public: I.Map(),
+        team: I.Map(),
+      })
+    )
+    expect(state1.tlfs.private.get('foo')).toBe(state0.tlfs.private.get('foo'))
   })
 })

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -232,8 +232,8 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
       )
     case FsGen.favoritesLoaded:
       return state.update('tlfs', tlfs =>
-        tlfs.withMutations(tlfsMutatable =>
-          tlfsMutatable
+        tlfs.withMutations(tlfsMutable =>
+          tlfsMutable
             .update('private', privateTlfs => updateTlfList(privateTlfs, action.payload.private))
             .update('public', publicTlfs => updateTlfList(publicTlfs, action.payload.public))
             .update('team', team => updateTlfList(team, action.payload.team))

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -16,7 +16,13 @@ const updatePathItem = (
   if (!oldPathItem || oldPathItem.type !== newPathItemFromAction.type) {
     return newPathItemFromAction
   }
-  // Reuse prefetchStatus if they equal in value.
+  // Reuse prefetchStatus if they equal in value. Note that `update` and
+  // `merge` don't actually make a new record unless we do give it a new value.
+  // So re-using the old prefetchStatus reference here makes it possible to
+  // reuse the oldPathItem as long as other fields are identical. For
+  // prefetchComplete and prefetchNotStarted this may not matter, since we are
+  // using the same references anyway. But for PrefetchInProgress it's a
+  // different record everytime, and this becomes useful.
   // $FlowIssue
   const newPathItem = newPathItemFromAction.update('prefetchStatus', newPrefetchStatus =>
     newPrefetchStatus.equals(oldPathItem.prefetchStatus) ? oldPathItem.prefetchStatus : newPrefetchStatus

--- a/shared/reducers/fs.js
+++ b/shared/reducers/fs.js
@@ -9,10 +9,18 @@ import * as Types from '../constants/types/fs'
 
 const initialState = Constants.makeState()
 
-const updatePathItem = (oldPathItem?: ?Types.PathItem, newPathItem: Types.PathItem): Types.PathItem => {
-  if (!oldPathItem || oldPathItem.type !== newPathItem.type) {
-    return newPathItem
+const updatePathItem = (
+  oldPathItem?: ?Types.PathItem,
+  newPathItemFromAction: Types.PathItem
+): Types.PathItem => {
+  if (!oldPathItem || oldPathItem.type !== newPathItemFromAction.type) {
+    return newPathItemFromAction
   }
+  // Reuse prefetchStatus if they equal in value.
+  // $FlowIssue
+  const newPathItem = newPathItemFromAction.update('prefetchStatus', newPrefetchStatus =>
+    newPrefetchStatus.equals(oldPathItem.prefetchStatus) ? oldPathItem.prefetchStatus : newPrefetchStatus
+  )
   switch (newPathItem.type) {
     case 'unknown':
       return newPathItem


### PR DESCRIPTION
1. In `Rows`'s container, memoize `sortRowItems` result, so if we get state updates that don't involve pathItem changes, we can skip sorting. 
1.1 Reduce the debounce delay for folder filter to 100ms since computing the results have lower overhead now.
2. Make the Fs reducer smarter by doing some value comparison when we get updates about pathItem changes, and try to reuse the old pathItem reference when the content doesn't change. This way, components relying on `state.fs.get(blahblah)` in `mapStateToProps` only triggers updates when its content actually changes.
2.2 Add some tests for it.