### PR TITLE
Tweaks on crowns

### DIFF
--- a/shared/chat/conversation/info-panel/participant.js
+++ b/shared/chat/conversation/info-panel/participant.js
@@ -26,7 +26,7 @@ const Participant = ({fullname, isAdmin, isOwner, username, onShowProfile}: Prop
                   <Kb.Text type="BodySmall">•</Kb.Text>
                   <Kb.Icon
                     color={isOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_35}
-                    sizeType="Tiny"
+                    fontSize={10}
                     type="iconfont-crown-owner"
                   />
                   <Kb.Text type="BodySmall">{isAdmin ? 'Admin' : 'Owner'}</Kb.Text>

--- a/shared/chat/conversation/info-panel/participant.js
+++ b/shared/chat/conversation/info-panel/participant.js
@@ -18,19 +18,20 @@ const Participant = ({fullname, isAdmin, isOwner, username, onShowProfile}: Prop
         <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.row}>
           <Kb.Avatar size={Styles.isMobile ? 48 : 32} username={username} />
           <Kb.Box2 direction="vertical" style={styles.wrapper}>
+            <Kb.ConnectedUsernames colorFollowing={true} type="BodySemibold" usernames={[username]} />
             <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center" gap="xtiny">
-              <Kb.ConnectedUsernames colorFollowing={true} type="BodySemibold" usernames={[username]} />
+              {fullname !== '' && <Kb.Text type="BodySmall">{fullname} • </Kb.Text>}
               {(isAdmin || isOwner) && (
-                <Kb.WithTooltip text={isOwner ? 'Owner' : 'Admin'}>
+                <Kb.Box2 direction="horizontal" alignItems="center" gap="xtiny">
                   <Kb.Icon
-                    color={isOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_50}
-                    sizeType="Small"
+                    color={isOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_35}
+                    sizeType="Tiny"
                     type="iconfont-crown-owner"
                   />
-                </Kb.WithTooltip>
+                  <Kb.Text type="BodySmall">{isAdmin ? 'Admin' : 'Owner'}</Kb.Text>
+                </Kb.Box2>
               )}
             </Kb.Box2>
-            {fullname !== '' && <Kb.Text type="BodySmall">{fullname}</Kb.Text>}
           </Kb.Box2>
         </Kb.Box2>
       </Kb.Box2>

--- a/shared/chat/conversation/info-panel/participant.js
+++ b/shared/chat/conversation/info-panel/participant.js
@@ -20,9 +20,10 @@ const Participant = ({fullname, isAdmin, isOwner, username, onShowProfile}: Prop
           <Kb.Box2 direction="vertical" style={styles.wrapper}>
             <Kb.ConnectedUsernames colorFollowing={true} type="BodySemibold" usernames={[username]} />
             <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center" gap="xtiny">
-              {fullname !== '' && <Kb.Text type="BodySmall">{fullname} • </Kb.Text>}
+              {fullname !== '' && <Kb.Text type="BodySmall">{fullname}</Kb.Text>}
               {(isAdmin || isOwner) && (
                 <Kb.Box2 direction="horizontal" alignItems="center" gap="xtiny">
+                  <Kb.Text type="BodySmall">•</Kb.Text>
                   <Kb.Icon
                     color={isOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_35}
                     sizeType="Tiny"

--- a/shared/chat/conversation/info-panel/participant.js
+++ b/shared/chat/conversation/info-panel/participant.js
@@ -22,14 +22,15 @@ const Participant = ({fullname, isAdmin, isOwner, username, onShowProfile}: Prop
             <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center" gap="xtiny">
               {fullname !== '' && <Kb.Text type="BodySmall">{fullname}</Kb.Text>}
               {(isAdmin || isOwner) && (
-                <Kb.Box2 direction="horizontal" alignItems="center" gap="xtiny">
-                  <Kb.Text type="BodySmall">•</Kb.Text>
+                <Kb.Box2 direction="horizontal" alignItems="center" gap="xxtiny">
+                  <Kb.Text type="BodySmall">(</Kb.Text>
                   <Kb.Icon
                     color={isOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_35}
                     fontSize={10}
                     type="iconfont-crown-owner"
                   />
                   <Kb.Text type="BodySmall">{isAdmin ? 'Admin' : 'Owner'}</Kb.Text>
+                  <Kb.Text type="BodySmall">)</Kb.Text>
                 </Kb.Box2>
               )}
             </Kb.Box2>

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -100,7 +100,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     if (this.props.showUsername) {
       result = (
         <React.Fragment key="authorAndContent">
-          <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny">
+          <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="xtiny">
             <Kb.Avatar
               size={32}
               username={this.props.showUsername}
@@ -120,9 +120,9 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               <Kb.WithTooltip text={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
                 <Kb.Icon
                   color={
-                    this.props.authorIsOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_50
+                    this.props.authorIsOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_35
                   }
-                  sizeType="Small"
+                  sizeType="Tiny"
                   type="iconfont-crown-owner"
                 />
               </Kb.WithTooltip>

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -108,25 +108,27 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               onClick={this._onAuthorClick}
               style={styles.avatar}
             />
-            <Kb.ConnectedUsernames
-              colorBroken={true}
-              colorFollowing={true}
-              colorYou={true}
-              type="BodySmallBold"
-              usernames={[this.props.showUsername]}
-              onUsernameClicked={this._onAuthorClick}
-            />
-            {this.props.showCrowns && (this.props.authorIsOwner || this.props.authorIsAdmin) && (
-              <Kb.WithTooltip text={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
-                <Kb.Icon
-                  color={
-                    this.props.authorIsOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_35
-                  }
-                  fontSize={10}
-                  type="iconfont-crown-owner"
-                />
-              </Kb.WithTooltip>
-            )}
+            <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.usernameCrown}>
+              <Kb.ConnectedUsernames
+                colorBroken={true}
+                colorFollowing={true}
+                colorYou={true}
+                type="BodySmallBold"
+                usernames={[this.props.showUsername]}
+                onUsernameClicked={this._onAuthorClick}
+              />
+              {this.props.showCrowns && (this.props.authorIsOwner || this.props.authorIsAdmin) && (
+                <Kb.WithTooltip text={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
+                  <Kb.Icon
+                    color={
+                      this.props.authorIsOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_35
+                    }
+                    fontSize={10}
+                    type="iconfont-crown-owner"
+                  />
+                </Kb.WithTooltip>
+              )}
+            </Kb.Box2>
             <Kb.Text type="BodyTiny" style={styles.timestamp}>
               {formatTimeForChat(this.props.message.timestamp)}
             </Kb.Text>
@@ -655,6 +657,9 @@ const styles = Styles.styleSheetCreate({
     isElectron: {lineHeight: 18},
     isMobile: {lineHeight: 20},
   }),
+  usernameCrown: {
+    alignSelf: 'flex-start',
+  },
 })
 
 export default WrapperMessage

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -108,7 +108,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               onClick={this._onAuthorClick}
               style={styles.avatar}
             />
-            <Kb.Box2 direction="horizontal" gap="xtiny" centerChildren={true} style={styles.usernameCrown}>
+            <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.usernameCrown}>
               <Kb.ConnectedUsernames
                 colorBroken={true}
                 colorFollowing={true}
@@ -657,9 +657,11 @@ const styles = Styles.styleSheetCreate({
     common: {paddingLeft: Styles.globalMargins.xtiny},
     isElectron: {lineHeight: 19},
   }),
-  usernameCrown: {
-    alignSelf: 'flex-start',
-  },
+  usernameCrown: Styles.platformStyles({
+    common: {alignSelf: 'flex-start'},
+    isElectron: {alignItems: 'baseline'},
+    isMobile: {alignItems: 'center'},
+  }),
 })
 
 export default WrapperMessage

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -108,7 +108,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               onClick={this._onAuthorClick}
               style={styles.avatar}
             />
-            <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.usernameCrown}>
+            <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.usernameCrown}>
               <Kb.ConnectedUsernames
                 colorBroken={true}
                 colorFollowing={true}
@@ -658,7 +658,6 @@ const styles = Styles.styleSheetCreate({
     isElectron: {lineHeight: 19},
   }),
   usernameCrown: Styles.platformStyles({
-    common: {alignSelf: 'flex-start'},
     isElectron: {alignItems: 'baseline'},
     isMobile: {alignItems: 'center'},
   }),

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -128,10 +128,10 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                   />
                 </Kb.WithTooltip>
               )}
+              <Kb.Text type="BodyTiny" style={styles.timestamp}>
+                {formatTimeForChat(this.props.message.timestamp)}
+              </Kb.Text>
             </Kb.Box2>
-            <Kb.Text type="BodyTiny" style={styles.timestamp}>
-              {formatTimeForChat(this.props.message.timestamp)}
-            </Kb.Text>
           </Kb.Box2>
           <Kb.Box2
             key="content"
@@ -655,7 +655,6 @@ const styles = Styles.styleSheetCreate({
   }),
   timestamp: Styles.platformStyles({
     isElectron: {lineHeight: 18},
-    isMobile: {lineHeight: 20},
   }),
   usernameCrown: {
     alignSelf: 'flex-start',

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -100,7 +100,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     if (this.props.showUsername) {
       result = (
         <React.Fragment key="authorAndContent">
-          <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="xtiny">
+          <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny">
             <Kb.Avatar
               size={32}
               username={this.props.showUsername}

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -122,7 +122,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                   color={
                     this.props.authorIsOwner ? Styles.globalColors.yellow2 : Styles.globalColors.black_35
                   }
-                  sizeType="Tiny"
+                  fontSize={10}
                   type="iconfont-crown-owner"
                 />
               </Kb.WithTooltip>

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -108,7 +108,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               onClick={this._onAuthorClick}
               style={styles.avatar}
             />
-            <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.usernameCrown}>
+            <Kb.Box2 direction="horizontal" gap="xtiny" centerChildren={true} style={styles.usernameCrown}>
               <Kb.ConnectedUsernames
                 colorBroken={true}
                 colorFollowing={true}

--- a/shared/chat/conversation/messages/wrapper/index.js
+++ b/shared/chat/conversation/messages/wrapper/index.js
@@ -654,7 +654,8 @@ const styles = Styles.styleSheetCreate({
     isMobile: {right: 0},
   }),
   timestamp: Styles.platformStyles({
-    isElectron: {lineHeight: 18},
+    common: {paddingLeft: Styles.globalMargins.xtiny},
+    isElectron: {lineHeight: 19},
   }),
   usernameCrown: {
     alignSelf: 'flex-start',

--- a/shared/teams/role-picker/index.meta.js
+++ b/shared/teams/role-picker/index.meta.js
@@ -19,7 +19,7 @@ export const roleIconMap = {
 }
 
 export const roleIconColorMap = {
-  admin: globalColors.black_50,
+  admin: globalColors.black_35,
   owner: globalColors.yellow2,
   reader: '',
   writer: '',

--- a/shared/teams/team/members-tab/member-row/index.js
+++ b/shared/teams/team/members-tab/member-row/index.js
@@ -55,7 +55,7 @@ export const TeamMemberRow = (props: Props) => {
         style={{
           marginRight: globalMargins.xtiny,
         }}
-        sizeType="Tiny"
+        fontSize={10}
         color={roleIconColorMap[props.roleType]}
       />
     )

--- a/shared/teams/team/members-tab/member-row/index.js
+++ b/shared/teams/team/members-tab/member-row/index.js
@@ -55,8 +55,8 @@ export const TeamMemberRow = (props: Props) => {
         style={{
           marginRight: globalMargins.xtiny,
         }}
+        sizeType="Tiny"
         color={roleIconColorMap[props.roleType]}
-        fontSize={isMobile ? 16 : 12}
       />
     )
   }


### PR DESCRIPTION
@keybase/react-hackers @adamjspooner 
* makes crown icons smaller
* color of admin crown: black_50 => black_35
* moved crown to subrow in infopane to match member row design elsewhere

@mmaxim we shouldn't show the crown icons in the thread view if there are only admins in the team