### PR TITLE
Checking if current device is revoked in CanLogout

### DIFF
--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -33,7 +33,7 @@ func (a *ActiveDevice) Dump(m MetaContext, prefix string) {
 	m.Debug("%sUsername (via env): %s", prefix, a.Username(m))
 	m.Debug("%sDeviceID: %s", prefix, a.deviceID)
 	m.Debug("%sDeviceName: %s", prefix, a.deviceName)
-	m.Debug("%sDeviceCtime: %s", prefix, a.deviceCtime)
+	m.Debug("%sDeviceCtime: %s", prefix, keybase1.FormatTime(a.deviceCtime))
 	if a.signingKey != nil {
 		m.Debug("%sSigKey: %s", prefix, a.signingKey.GetKID())
 	}

--- a/go/libkb/all_provisioned_usernames.go
+++ b/go/libkb/all_provisioned_usernames.go
@@ -16,7 +16,7 @@ func getUsernameIfProvisioned(m MetaContext, uc UserConfig) (ret NormalizedUsern
 		m.Debug("- user was likely reset (%s)", err)
 		return ret, nil
 	case KeyRevokedError:
-		m.Debug("- device was revoked (s)", err)
+		m.Debug("- device was revoked (%s)", err)
 		return ret, nil
 	case UserDeletedError:
 		m.Debug(" - user was deleted (%s)", err)

--- a/go/service/random_pw_test.go
+++ b/go/service/random_pw_test.go
@@ -217,4 +217,9 @@ func TestCanLogoutWhenRevoked(t *testing.T) {
 	ret, err = userHandler2.CanLogout(context.Background(), 0)
 	require.NoError(t, err)
 	require.True(t, ret.CanLogout)
+
+	// Device 1 still can't logout.
+	ret, err = userHandler.CanLogout(context.Background(), 0)
+	require.NoError(t, err)
+	require.False(t, ret.CanLogout)
 }

--- a/go/service/random_pw_test.go
+++ b/go/service/random_pw_test.go
@@ -81,6 +81,16 @@ func (r *errorAPIMock) GetDecode(mctx libkb.MetaContext, arg libkb.APIArg, w lib
 	return r.realAPI.GetDecode(mctx, arg, w)
 }
 
+func (r errorAPIMock) Get(mctx libkb.MetaContext, arg libkb.APIArg) (*libkb.APIRes, error) {
+	if arg.Endpoint == "user/has_random_pw" {
+		r.callCount++
+		if r.shouldTimeout {
+			return nil, errors.New("timeout or something")
+		}
+	}
+	return r.realAPI.Get(mctx, arg)
+}
+
 func TestCanLogoutTimeout(t *testing.T) {
 	tc := libkb.SetupTest(t, "randompw", 3)
 	defer tc.Cleanup()

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -639,29 +638,6 @@ func (h *UserHandler) LoadHasRandomPw(ctx context.Context, arg keybase1.LoadHasR
 	return ret.RandomPW, err
 }
 
-func isActiveDeviceRevoked(mctx libkb.MetaContext) (res bool, err error) {
-	if !mctx.ActiveDevice().Valid() {
-		return false, errors.New("ActiveDevice is not valid")
-	}
-	deviceID := mctx.ActiveDevice().DeviceID()
-	me, err := libkb.LoadMe(libkb.NewLoadUserArgWithMetaContext(mctx))
-	if err != nil {
-		return false, err
-	}
-	devices := me.GetComputedKeyFamily().GetAllActiveDevices()
-	if len(devices) == 0 {
-		return false, errors.New("GetAllActiveDevices returned empty list")
-	}
-	for _, device := range devices {
-		if device.ID.Eq(deviceID) {
-			// Device found in ActiveDevices list, we are not revoked.
-			return false, nil
-		}
-	}
-	// Current device not found, we are likely revoked.
-	return true, nil
-}
-
 func (h *UserHandler) CanLogout(ctx context.Context, sessionID int) (res keybase1.CanLogoutRes, err error) {
 	if !h.G().ActiveDevice.Valid() {
 		h.G().Log.CDebugf(ctx, "CanLogout: looks like user is not logged in")
@@ -675,13 +651,16 @@ func (h *UserHandler) CanLogout(ctx context.Context, sessionID int) (res keybase
 	})
 
 	if err != nil {
-		isRevoked, err2 := isActiveDeviceRevoked(libkb.NewMetaContext(ctx, h.G()))
-		if err2 == nil && isRevoked {
-			// We are revoked, green-light logging out.
-			h.G().Log.CDebugf(ctx, "CanLogout: Current device is revoked, allowing logout")
-			return keybase1.CanLogoutRes{CanLogout: true}, nil
-		} else if err2 != nil {
-			h.G().Log.CDebugf(ctx, "CanLogout: cannot check if current device is revoked: %s", err2.Error())
+		// Couldn't check Random PW. Maybe we are logged in as invalid user or
+		// revoked device. If so, green-light logout.
+		if checkUIDErr := libkb.CheckCurrentUIDDeviceID(libkb.NewMetaContext(ctx, h.G())); checkUIDErr != nil {
+			switch checkUIDErr.(type) {
+			case libkb.DeviceNotFoundError, libkb.UserNotFoundError, libkb.KeyRevokedError, libkb.NoDeviceError, libkb.NoUIDError:
+				h.G().Log.CDebugf(ctx, "CanLogout: allowing logout because of CheckCurrentUIDDeviceID returning: %s", checkUIDErr.Error())
+				return keybase1.CanLogoutRes{CanLogout: true}, nil
+			default:
+				h.G().Log.CDebugf(ctx, "CanLogout: CheckCurrentUIDDeviceID returned: %s", checkUIDErr.Error())
+			}
 		}
 
 		return keybase1.CanLogoutRes{

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -655,7 +655,8 @@ func (h *UserHandler) CanLogout(ctx context.Context, sessionID int) (res keybase
 		// revoked device. If so, green-light logout.
 		if checkUIDErr := libkb.CheckCurrentUIDDeviceID(libkb.NewMetaContext(ctx, h.G())); checkUIDErr != nil {
 			switch checkUIDErr.(type) {
-			case libkb.DeviceNotFoundError, libkb.UserNotFoundError, libkb.KeyRevokedError, libkb.NoDeviceError, libkb.NoUIDError:
+			case libkb.DeviceNotFoundError, libkb.UserNotFoundError,
+				libkb.KeyRevokedError, libkb.NoDeviceError, libkb.NoUIDError:
 				h.G().Log.CDebugf(ctx, "CanLogout: allowing logout because of CheckCurrentUIDDeviceID returning: %s", checkUIDErr.Error())
 				return keybase1.CanLogoutRes{CanLogout: true}, nil
 			default:


### PR DESCRIPTION
If we are unable to check HasRandomPW while logging out, check if we are revoked.

Checking HasRandomPW status code would be sufficient (API session error) but this would be server trust, and also prone to other misc errors. And we are trying really hard not to log user out if they don't have passphrase.