### PR TITLE
Fix progressindicator style in message placeholder

### DIFF
--- a/shared/chat/conversation/messages/placeholder/index.js
+++ b/shared/chat/conversation/messages/placeholder/index.js
@@ -34,6 +34,7 @@ const styles = styleSheetCreate({
   spinner: {
     height: 13,
     marginLeft: 0,
+    width: 13,
   },
 })
 


### PR DESCRIPTION
https://github.com/keybase/client/pull/16730 made `ProgressIndicator` easier to use but also added a [width](https://github.com/keybase/client/pull/16730/files#diff-e06deca0e9d6616145c72ea753291aa7R21) that wasn't overridden by `MessagePlaceholder`.

Before: 
<img width="351" alt="image" src="https://user-images.githubusercontent.com/11968340/55735549-87af9e00-59ef-11e9-925e-3b50b1908722.png">

After:
<img width="351" alt="image" src="https://user-images.githubusercontent.com/11968340/55735513-76669180-59ef-11e9-9b5d-a740d4333c59.png">


r? @keybase/react-hackers 