### PR TITLE
Fix 'startProof finished' showing on profile after startProof finishes

### DIFF
--- a/shared/actions/profile/proofs.js
+++ b/shared/actions/profile/proofs.js
@@ -253,7 +253,7 @@ function* addProof(state, action) {
     assertion: state.config.username,
     guiID: Tracker2Constants.generateGUIID(),
     inTracker: false,
-    reason: 'startProof finished',
+    reason: '',
   })
   try {
     const {sigID} = yield RPCTypes.proveStartProofRpcSaga({
@@ -281,6 +281,9 @@ function* addProof(state, action) {
     })
     yield Saga.put(ProfileGen.createUpdateSigID({sigID}))
     logger.info('Start Proof done: ', sigID)
+    if (!genericService) {
+      yield Saga.put(ProfileGen.createCheckProof())
+    }
     yield Saga.put(loadAfter)
     if (genericService) {
       yield Saga.put(ProfileGen.createUpdatePlatformGenericChecking({checking: false}))


### PR DESCRIPTION
and having to click 'Ok tweeted! Check for it!' and analogs twice when making non-generic proofs. r? @keybase/react-hackers cc @mlsteele 