### PR TITLE
Squash tls conn closed/protocol shutdown errors

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -537,6 +537,9 @@ func IsOfflineError(err error) OfflineErrorKind {
 		return OfflineErrorKindOfflineBasic
 	}
 
+	// Unfortunately, Go throws these without a type and they can occasionally
+	// propagate up. The strings were copied from
+	// https://golang.org/src/crypto/tls/conn.go
 	switch err.Error() {
 	case "tls: use of closed connection",
 		"tls: protocol is shutdown":

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -536,6 +536,12 @@ func IsOfflineError(err error) OfflineErrorKind {
 	case ErrDuplicateConnection:
 		return OfflineErrorKindOfflineBasic
 	}
+
+	switch err.Error() {
+	case "tls: use of closed connection",
+		"tls: protocol is shutdown":
+		return OfflineErrorKindOfflineReconnect
+	}
 	return OfflineErrorKindOnline
 }
 


### PR DESCRIPTION
Got a blackbar from this earlier during `MarkLocalAsRead`, is this the correct place to squash?