### PR TITLE
Add NEW to add identities button and turn on for everyone

### DIFF
--- a/shared/profile/user/index.js
+++ b/shared/profile/user/index.js
@@ -194,6 +194,19 @@ export type BioTeamProofsProps = {|
 |}
 export class BioTeamProofs extends React.PureComponent<BioTeamProofsProps> {
   render() {
+    const addIdentity = this.props.onAddIdentity ? (
+      <Kb.Box2 direction="horizontal" style={styles.addIdentityContainer}>
+        <Kb.Button
+          label="Mastodon + other identities"
+          labelStyle={styles.label}
+          onClick={this.props.onAddIdentity}
+          style={styles.addIdentityButton}
+          type="Secondary"
+        >
+          <Kb.Meta backgroundColor={Styles.globalColors.blue} title="NEW" style={styles.newMeta} />
+        </Kb.Button>
+      </Kb.Box2>
+    ) : null
     return Styles.isMobile ? (
       <Kb.Box2 direction="vertical" fullWidth={true} style={styles.bioAndProofs}>
         <Kb.Text
@@ -218,17 +231,7 @@ export class BioTeamProofs extends React.PureComponent<BioTeamProofsProps> {
         <Kb.Box2 direction="vertical" fullWidth={true} style={styles.proofsArea}>
           <Teams username={this.props.username} />
           <Proofs {...this.props} />
-          {this.props.onAddIdentity && (
-            <Kb.Box2 direction="horizontal" style={styles.addIdentityContainer}>
-              <Kb.Button
-                label="Mastodon + other identities"
-                labelStyle={styles.label}
-                onClick={this.props.onAddIdentity}
-                style={styles.addIdentityButton}
-                type="Secondary"
-              />
-            </Kb.Box2>
-          )}
+          {addIdentity}
           <Folders profileUsername={this.props.username} />
         </Kb.Box2>
       </Kb.Box2>
@@ -250,17 +253,7 @@ export class BioTeamProofs extends React.PureComponent<BioTeamProofsProps> {
             </Kb.Text>
             <Teams username={this.props.username} />
             <Proofs {...this.props} />
-            {this.props.onAddIdentity && (
-              <Kb.Box2 direction="horizontal" style={styles.addIdentityContainer}>
-                <Kb.Button
-                  label="Mastodon + other identities"
-                  labelStyle={styles.label}
-                  onClick={this.props.onAddIdentity}
-                  style={styles.addIdentityButton}
-                  type="Secondary"
-                />
-              </Kb.Box2>
-            )}
+            {addIdentity}
             <Folders profileUsername={this.props.username} />
           </Kb.Box2>
         </Kb.Box2>
@@ -511,6 +504,16 @@ const styles = Styles.styleSheetCreate({
   label: {
     color: Styles.globalColors.black,
   },
+  newMeta: Styles.platformStyles({
+    common: {
+      alignSelf: 'center',
+      marginRight: Styles.globalMargins.tiny,
+    },
+    isMobile: {
+      position: 'relative',
+      top: -1,
+    },
+  }),
   noGrow: {flexGrow: 0},
   proofs: Styles.platformStyles({
     isElectron: {

--- a/shared/util/feature-flags.desktop.js
+++ b/shared/util/feature-flags.desktop.js
@@ -22,7 +22,7 @@ const ff: FeatureFlags = {
   newTeamBuildingForChatAllowMakeTeam: false,
   outOfDateBanner: false,
   plansEnabled: false,
-  proofProviders: __DEV__,
+  proofProviders: true,
   sendAttachmentToChat: false,
   useNewRouter: false,
 }


### PR DESCRIPTION
- Add "NEW" to the button
<img width="473" alt="image" src="https://user-images.githubusercontent.com/11968340/55751474-bf304180-5a13-11e9-9130-74c04064386a.png">

- Turns on the `proofProviders` flag for everyone
  - Only controls whether this button appears

r? @keybase/react-hackers 