### PR TITLE
Fix invalid username permaspinner in generic proofs

### DIFF
--- a/shared/profile/generic/enter-username/index.js
+++ b/shared/profile/generic/enter-username/index.js
@@ -139,9 +139,16 @@ type Props = {|
 |}
 
 class _EnterUsername extends React.Component<Props> {
+  _waitingButtonKey = 0
   componentDidUpdate(prevProps: Props) {
     if (!this.props.waiting && prevProps.waiting) {
       this.props.onContinue()
+    }
+    if (this.props.error && !prevProps.error) {
+      // We just tried an invalid username
+      // increment waiting button key so it
+      // remounts and we avoid a perma-spinner
+      this._waitingButtonKey++
     }
   }
   render() {
@@ -223,6 +230,7 @@ class _EnterUsername extends React.Component<Props> {
                 label={props.submitButtonLabel}
                 style={styles.buttonBig}
                 waitingKey={null}
+                key={this._waitingButtonKey}
               />
             )}
           </Kb.ButtonBar>


### PR DESCRIPTION
Fixes a bug where this button would permaspin if you entered an invalid username
<img width="558" alt="Keybase_DEV" src="https://user-images.githubusercontent.com/11968340/55757131-420bc900-5a21-11e9-97fe-4b93ab7c16bc.png">

r? @keybase/react-hackers 
