### PR TITLE
mock timestamp in device page stories

### DIFF
--- a/shared/devices/device-page/index.js
+++ b/shared/devices/device-page/index.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as Types from '../../constants/types/devices'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
-import moment from 'moment'
+import {formatTimeForDeviceTimeline, formatTimeRelativeToNow} from '../../util/timestamp'
 
 type Props = {
   device: Types.Device,
@@ -35,13 +35,12 @@ const TimelineLabel = ({desc, subDesc, subDescIsName, spacerOnBottom}) => (
   </Kb.Box2>
 )
 
-const formatTime = t => moment(t).format('MMM D, YYYY')
 const Timeline = ({device}) => {
   const timeline = [
     ...(device.revokedAt
       ? [
           {
-            desc: `Revoked ${formatTime(device.revokedAt)}`,
+            desc: `Revoked ${formatTimeForDeviceTimeline(device.revokedAt)}`,
             subDesc: device.revokedByName || '',
             type: 'Revoked',
           },
@@ -50,14 +49,14 @@ const Timeline = ({device}) => {
     ...(device.lastUsed
       ? [
           {
-            desc: `Last used ${formatTime(device.lastUsed)}`,
-            subDesc: moment(device.lastUsed).fromNow(),
+            desc: `Last used ${formatTimeForDeviceTimeline(device.lastUsed)}`,
+            subDesc: formatTimeRelativeToNow(device.lastUsed),
             type: 'LastUsed',
           },
         ]
       : []),
     {
-      desc: `Added ${formatTime(device.created)}`,
+      desc: `Added ${formatTimeForDeviceTimeline(device.created)}`,
       subDesc: device.provisionerName || '',
       type: 'Added',
     },

--- a/shared/util/__mocks__/timestamp.js
+++ b/shared/util/__mocks__/timestamp.js
@@ -30,6 +30,14 @@ export function formatTimeForAssertionPopup(time: number): string {
   return '[mocked]'
 }
 
+export function formatTimeForDeviceTimeline(time: number): string {
+  return '[mocked]'
+}
+
+export function formatTimeRelativeToNow(time: number): string {
+  return '[mocked]'
+}
+
 export function daysToLabel(days: number): string {
   return '[mocked]'
 }

--- a/shared/util/timestamp.js
+++ b/shared/util/timestamp.js
@@ -128,6 +128,14 @@ export function formatTimeForAssertionPopup(time: number): string {
   return m.format('ddd MMM D, YYYY') // Wed Jan 5, 2018
 }
 
+export function formatTimeForDeviceTimeline(time: number): string {
+  return moment(time).format('MMM D, YYYY')
+}
+
+export function formatTimeRelativeToNow(time: number): string {
+  return moment(time).fromNow()
+}
+
 export function daysToLabel(days: number): string {
   let label = `${days} day`
   if (days !== 1) {


### PR DESCRIPTION
It just changed years and broke storyshots on master
```
    -                 16 years ago
    +                 17 years ago
```
r? @keybase/react-hackers 