### PR TITLE
bcache: specify hash behavior on Put

### DIFF
--- a/go/kbfs/data/bcache_test.go
+++ b/go/kbfs/data/bcache_test.go
@@ -24,7 +24,7 @@ func testBcachePutWithBlock(t *testing.T, id kbfsblock.ID, bcache BlockCache, li
 	tlf := tlf.FakeID(1, tlf.Private)
 
 	// put the block
-	err := bcache.Put(ptr, tlf, block, lifetime)
+	err := bcache.Put(ptr, tlf, block, lifetime, SkipCacheHash)
 	require.NoError(t, err)
 
 	// make sure we can get it successfully
@@ -79,7 +79,7 @@ func TestBlockCacheCheckPtrSuccess(t *testing.T) {
 	ptr := BlockPointer{ID: id}
 	tlf := tlf.FakeID(1, tlf.Private)
 
-	err := bcache.Put(ptr, tlf, block, TransientEntry)
+	err := bcache.Put(ptr, tlf, block, TransientEntry, DoCacheHash)
 	require.NoError(t, err)
 
 	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block)
@@ -96,7 +96,7 @@ func TestBlockCacheCheckPtrPermanent(t *testing.T) {
 	ptr := BlockPointer{ID: id}
 	tlf := tlf.FakeID(1, tlf.Private)
 
-	err := bcache.Put(ptr, tlf, block, PermanentEntry)
+	err := bcache.Put(ptr, tlf, block, PermanentEntry, SkipCacheHash)
 	require.NoError(t, err)
 
 	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block)
@@ -113,7 +113,7 @@ func TestBlockCacheCheckPtrNotFound(t *testing.T) {
 	ptr := BlockPointer{ID: id}
 	tlf := tlf.FakeID(1, tlf.Private)
 
-	err := bcache.Put(ptr, tlf, block, TransientEntry)
+	err := bcache.Put(ptr, tlf, block, TransientEntry, DoCacheHash)
 	require.NoError(t, err)
 
 	block2 := NewFileBlock().(*FileBlock)
@@ -132,7 +132,7 @@ func TestBlockCacheDeleteTransient(t *testing.T) {
 	ptr := BlockPointer{ID: id}
 	tlf := tlf.FakeID(1, tlf.Private)
 
-	err := bcache.Put(ptr, tlf, block, TransientEntry)
+	err := bcache.Put(ptr, tlf, block, TransientEntry, DoCacheHash)
 	require.NoError(t, err)
 
 	err = bcache.DeleteTransient(ptr.ID, tlf)
@@ -175,7 +175,7 @@ func TestBlockCacheEmptyTransient(t *testing.T) {
 	// Make sure all the operations work even if the cache has no
 	// transient capacity.
 
-	err := bcache.Put(ptr, tlf, block, TransientEntry)
+	err := bcache.Put(ptr, tlf, block, TransientEntry, DoCacheHash)
 	require.NoError(t, err)
 
 	_, err = bcache.Get(ptr)
@@ -200,7 +200,7 @@ func TestBlockCacheEvictOnBytes(t *testing.T) {
 		id := kbfsblock.FakeID(i)
 		ptr := BlockPointer{ID: id}
 
-		err := bcache.Put(ptr, tlf, block, TransientEntry)
+		err := bcache.Put(ptr, tlf, block, TransientEntry, SkipCacheHash)
 		require.NoError(t, err)
 	}
 
@@ -227,7 +227,7 @@ func TestBlockCacheEvictIncludesPermanentSize(t *testing.T) {
 	block := &FileBlock{
 		Contents: make([]byte, 2),
 	}
-	err := bcache.Put(ptr, tlf, block, PermanentEntry)
+	err := bcache.Put(ptr, tlf, block, PermanentEntry, SkipCacheHash)
 	require.NoError(t, err)
 
 	for i := byte(1); i < 8; i++ {
@@ -237,7 +237,7 @@ func TestBlockCacheEvictIncludesPermanentSize(t *testing.T) {
 		id := kbfsblock.FakeID(i)
 		ptr := BlockPointer{ID: id}
 
-		err := bcache.Put(ptr, tlf, block, TransientEntry)
+		err := bcache.Put(ptr, tlf, block, TransientEntry, SkipCacheHash)
 		require.NoError(t, err)
 	}
 
@@ -264,7 +264,7 @@ func TestBlockCacheEvictIncludesPermanentSize(t *testing.T) {
 	block.SetEncodedSize(7)
 	id := kbfsblock.FakeID(8)
 	ptr = BlockPointer{ID: id}
-	err = bcache.Put(ptr, tlf, block, TransientEntry)
+	err = bcache.Put(ptr, tlf, block, TransientEntry, SkipCacheHash)
 	require.EqualError(t, err, CachePutCacheFullError{ptr.ID}.Error())
 
 	// All transient blocks should be gone (including the new one)
@@ -284,7 +284,7 @@ func TestBlockCacheEvictIncludesPermanentSize(t *testing.T) {
 	block2 := &FileBlock{
 		Contents: make([]byte, 10),
 	}
-	err = bcache.Put(ptr2, tlf, block2, PermanentEntry)
+	err = bcache.Put(ptr2, tlf, block2, PermanentEntry, SkipCacheHash)
 	require.NoError(t, err)
 
 	_, err = bcache.Get(BlockPointer{ID: idPerm})
@@ -304,7 +304,7 @@ func TestBlockCachePutNoHashCalculation(t *testing.T) {
 	// into the cache
 	hash := &kbfshash.RawDefaultHash{}
 	block.hash = hash
-	err := bcache.Put(ptr, tlf, block, TransientEntry)
+	err := bcache.Put(ptr, tlf, block, TransientEntry, DoCacheHash)
 	require.NoError(t, err)
 
 	// CheckForKnownPtr() calculates hash only if it's nil. If the block with

--- a/go/kbfs/data/block_tree.go
+++ b/go/kbfs/data/block_tree.go
@@ -1037,7 +1037,7 @@ func (bt *blockTree) readyWorker(
 	defer lock.Unlock()
 
 	err = bcache.Put(
-		newInfo.BlockPointer, id, pb.pblock, PermanentEntry)
+		newInfo.BlockPointer, id, pb.pblock, PermanentEntry, SkipCacheHash)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/data/block_types.go
+++ b/go/kbfs/data/block_types.go
@@ -554,7 +554,12 @@ func (fb *FileBlock) Set(other Block) {
 	// Ensure that the Set is complete from Go's perspective by calculating the
 	// hash on the new FileBlock if the old one has been set. This is mainly so
 	// tests can blindly compare that blocks are equivalent.
-	if otherFb.hash != nil {
+	h := func() *kbfshash.RawDefaultHash {
+		otherFb.cacheMtx.RLock()
+		defer otherFb.cacheMtx.RUnlock()
+		return otherFb.hash
+	}()
+	if h != nil {
 		_ = fb.GetHash()
 	}
 }

--- a/go/kbfs/data/data_types.go
+++ b/go/kbfs/data/data_types.go
@@ -447,3 +447,14 @@ const (
 	// explicitly removed from the cache.
 	PermanentEntry
 )
+
+// BlockCacheHashBehavior denotes whether the cache should hash the
+// plaintext of a new block or not.
+type BlockCacheHashBehavior int
+
+const (
+	// SkipCacheHash means that the plaintext of a block should not be hashed.
+	SkipCacheHash BlockCacheHashBehavior = iota
+	// DoCacheHash means that the plaintext of a block should be hashed.
+	DoCacheHash
+)

--- a/go/kbfs/data/dir_data_test.go
+++ b/go/kbfs/data/dir_data_test.go
@@ -77,7 +77,8 @@ func TestDirDataGetChildren(t *testing.T) {
 	ctx := context.Background()
 	topBlock := NewDirBlock().(*DirBlock)
 	cleanBcache.Put(
-		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry)
+		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry,
+		SkipCacheHash)
 
 	t.Log("No entries, direct block")
 	children, err := dd.GetChildren(ctx)
@@ -123,9 +124,12 @@ func TestDirDataGetChildren(t *testing.T) {
 	addFakeDirDataEntryToBlock(block2, "z1", 3)
 	addFakeDirDataEntryToBlock(block2, "z2", 4)
 	cleanBcache.Put(
-		dd.rootBlockPointer(), dd.tree.file.Tlf, newTopBlock, TransientEntry)
-	cleanBcache.Put(ptr1, dd.tree.file.Tlf, topBlock, TransientEntry)
-	cleanBcache.Put(ptr2, dd.tree.file.Tlf, block2, TransientEntry)
+		dd.rootBlockPointer(), dd.tree.file.Tlf, newTopBlock, TransientEntry,
+		SkipCacheHash)
+	cleanBcache.Put(
+		ptr1, dd.tree.file.Tlf, topBlock, TransientEntry, SkipCacheHash)
+	cleanBcache.Put(
+		ptr2, dd.tree.file.Tlf, block2, TransientEntry, SkipCacheHash)
 	children, err = dd.GetChildren(ctx)
 	require.NoError(t, err)
 	require.Len(t, children, 4)
@@ -148,7 +152,8 @@ func TestDirDataLookup(t *testing.T) {
 	ctx := context.Background()
 	topBlock := NewDirBlock().(*DirBlock)
 	cleanBcache.Put(
-		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry)
+		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry,
+		SkipCacheHash)
 
 	t.Log("No entries, direct block")
 	_, err := dd.Lookup(ctx, "a")
@@ -185,9 +190,12 @@ func TestDirDataLookup(t *testing.T) {
 	addFakeDirDataEntryToBlock(block2, "z1", 3)
 	addFakeDirDataEntryToBlock(block2, "z2", 4)
 	cleanBcache.Put(
-		dd.rootBlockPointer(), dd.tree.file.Tlf, newTopBlock, TransientEntry)
-	cleanBcache.Put(ptr1, dd.tree.file.Tlf, topBlock, TransientEntry)
-	cleanBcache.Put(ptr2, dd.tree.file.Tlf, block2, TransientEntry)
+		dd.rootBlockPointer(), dd.tree.file.Tlf, newTopBlock, TransientEntry,
+		SkipCacheHash)
+	cleanBcache.Put(
+		ptr1, dd.tree.file.Tlf, topBlock, TransientEntry, SkipCacheHash)
+	cleanBcache.Put(
+		ptr2, dd.tree.file.Tlf, block2, TransientEntry, SkipCacheHash)
 
 	testDirDataCheckLookup(t, ctx, dd, "a", 1)
 	testDirDataCheckLookup(t, ctx, dd, "b", 2)
@@ -290,7 +298,8 @@ func testDirDataCleanCache(
 	dbc := dirtyBCache.(*DirtyBlockCacheStandard)
 	for id, block := range dbc.cache {
 		ptr := BlockPointer{ID: id.id}
-		cleanBCache.Put(ptr, dd.tree.file.Tlf, block, TransientEntry)
+		cleanBCache.Put(
+			ptr, dd.tree.file.Tlf, block, TransientEntry, SkipCacheHash)
 	}
 	dbc.cache = make(map[dirtyBlockID]Block)
 }
@@ -300,7 +309,8 @@ func TestDirDataAddEntry(t *testing.T) {
 	ctx := context.Background()
 	topBlock := NewDirBlock().(*DirBlock)
 	cleanBcache.Put(
-		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry)
+		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry,
+		SkipCacheHash)
 
 	t.Log("Add first entry")
 	addFakeDirDataEntry(t, ctx, dd, "a", 1)
@@ -396,7 +406,8 @@ func TestDirDataRemoveEntry(t *testing.T) {
 	ctx := context.Background()
 	topBlock := NewDirBlock().(*DirBlock)
 	cleanBcache.Put(
-		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry)
+		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry,
+		SkipCacheHash)
 
 	t.Log("Make a simple dir and remove one entry")
 	addFakeDirDataEntry(t, ctx, dd, "a", 1)
@@ -445,7 +456,8 @@ func TestDirDataUpdateEntry(t *testing.T) {
 	ctx := context.Background()
 	topBlock := NewDirBlock().(*DirBlock)
 	cleanBcache.Put(
-		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry)
+		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry,
+		SkipCacheHash)
 
 	t.Log("Make a simple dir and update one entry")
 	addFakeDirDataEntry(t, ctx, dd, "a", 1)
@@ -507,7 +519,8 @@ func TestDirDataShifting(t *testing.T) {
 	ctx := context.Background()
 	topBlock := NewDirBlock().(*DirBlock)
 	cleanBcache.Put(
-		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry)
+		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry,
+		SkipCacheHash)
 
 	for i := 0; i <= 10; i++ {
 		addFakeDirDataEntry(t, ctx, dd, strconv.Itoa(i), uint64(i+1))

--- a/go/kbfs/data/file_data_test.go
+++ b/go/kbfs/data/file_data_test.go
@@ -277,7 +277,8 @@ func testFileDataWriteExtendEmptyFile(t *testing.T, maxBlockSize Int64Offset,
 		t, int64(maxBlockSize), maxPtrsPerBlock)
 	topBlock := NewFileBlock().(*FileBlock)
 	cleanBcache.Put(
-		fd.rootBlockPointer(), fd.tree.file.Tlf, topBlock, TransientEntry)
+		fd.rootBlockPointer(), fd.tree.file.Tlf, topBlock, TransientEntry,
+		SkipCacheHash)
 	de := DirEntry{}
 	data := make([]byte, fullDataLen)
 	for i := 0; i < int(fullDataLen); i++ {
@@ -405,7 +406,8 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *FileData,
 					BlockInfo: BlockInfo{ptr, 0},
 					Off:       off,
 				})
-				cleanBcache.Put(ptr, fd.tree.file.Tlf, child, TransientEntry)
+				cleanBcache.Put(
+					ptr, fd.tree.file.Tlf, child, TransientEntry, SkipCacheHash)
 			}
 			prevChildIndex = newIndex
 			level = append(level, fblock)
@@ -420,7 +422,7 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *FileData,
 
 	cleanBcache.Put(
 		fd.rootBlockPointer(), fd.tree.file.Tlf, prevChildren[0],
-		TransientEntry)
+		TransientEntry, SkipCacheHash)
 	return prevChildren[0], numLevels
 }
 

--- a/go/kbfs/data/interfaces.go
+++ b/go/kbfs/data/interfaces.go
@@ -135,18 +135,20 @@ type BlockCacheSimple interface {
 	// Get gets the block associated with the given block ID.
 	Get(ptr BlockPointer) (Block, error)
 	// Put stores the final (content-addressable) block associated
-	// with the given block ID. If lifetime is TransientEntry,
-	// then it is assumed that the block exists on the server and
-	// the entry may be evicted from the cache at any time. If
-	// lifetime is PermanentEntry, then it is assumed that the
-	// block doesn't exist on the server and must remain in the
-	// cache until explicitly removed. As an intermediary state,
-	// as when a block is being sent to the server, the block may
-	// be put into the cache both with TransientEntry and
-	// PermanentEntry -- these are two separate entries. This is
-	// fine, since the block should be the same.
+	// with the given block ID. If lifetime is TransientEntry, then it
+	// is assumed that the block exists on the server and the entry
+	// may be evicted from the cache at any time. If lifetime is
+	// PermanentEntry, then it is assumed that the block doesn't exist
+	// on the server and must remain in the cache until explicitly
+	// removed. As an intermediary state, as when a block is being
+	// sent to the server, the block may be put into the cache both
+	// with TransientEntry and PermanentEntry -- these are two
+	// separate entries. This is fine, since the block should be the
+	// same.  `hashBehavior` indicates whether the plaintext contents
+	// of transient, direct blocks should be hashed, in order to
+	// identify blocks that can be de-duped.
 	Put(ptr BlockPointer, tlf tlf.ID, block Block,
-		lifetime BlockCacheLifetime) error
+		lifetime BlockCacheLifetime, hashBehavior BlockCacheHashBehavior) error
 }
 
 // BlockCache specifies the interface of BlockCacheSimple, and also more

--- a/go/kbfs/libkbfs/data_mocks_test.go
+++ b/go/kbfs/libkbfs/data_mocks_test.go
@@ -139,17 +139,17 @@ func (mr *MockBlockCacheMockRecorder) GetWithLifetime(arg0 interface{}) *gomock.
 }
 
 // Put mocks base method
-func (m *MockBlockCache) Put(arg0 data.BlockPointer, arg1 tlf.ID, arg2 data.Block, arg3 data.BlockCacheLifetime) error {
+func (m *MockBlockCache) Put(arg0 data.BlockPointer, arg1 tlf.ID, arg2 data.Block, arg3 data.BlockCacheLifetime, arg4 data.BlockCacheHashBehavior) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put
-func (mr *MockBlockCacheMockRecorder) Put(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockBlockCache)(nil).Put), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockBlockCache)(nil).Put), arg0, arg1, arg2, arg3, arg4)
 }
 
 // SetCleanBytesCapacity mocks base method

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -556,7 +556,8 @@ func expectBlock(config *ConfigMock, kmd libkey.KeyMetadata, blockPtr data.Block
 		Do(func(ctx context.Context, kmd libkey.KeyMetadata,
 			blockPtr data.BlockPointer, getBlock data.Block, lifetime data.BlockCacheLifetime) {
 			getBlock.Set(block)
-			config.BlockCache().Put(blockPtr, kmd.TlfID(), getBlock, lifetime)
+			config.BlockCache().Put(blockPtr, kmd.TlfID(), getBlock, lifetime,
+				data.DoCacheHash)
 		}).Return(err)
 }
 
@@ -757,7 +758,8 @@ func nodeFromPath(t *testing.T, ops *folderBranchOps, p data.Path) Node {
 func testPutBlockInCache(
 	t *testing.T, config *ConfigMock, ptr data.BlockPointer, id tlf.ID,
 	block data.Block) {
-	err := config.BlockCache().Put(ptr, id, block, data.TransientEntry)
+	err := config.BlockCache().Put(
+		ptr, id, block, data.TransientEntry, data.DoCacheHash)
 	require.NoError(t, err)
 	if config.mockBcache != nil {
 		config.mockBcache.EXPECT().Get(ptr).AnyTimes().Return(block, nil)

--- a/go/kbfs/libkbfs/md_util_test.go
+++ b/go/kbfs/libkbfs/md_util_test.go
@@ -31,7 +31,7 @@ func (c testBlockCache) Get(ptr data.BlockPointer) (data.Block, error) {
 }
 
 func (testBlockCache) Put(ptr data.BlockPointer, tlf tlf.ID, block data.Block,
-	lifetime data.BlockCacheLifetime) error {
+	lifetime data.BlockCacheLifetime, _ data.BlockCacheHashBehavior) error {
 	return errors.New("Shouldn't be called")
 }
 
@@ -74,7 +74,9 @@ func TestReembedBlockChanges(t *testing.T) {
 
 	// We make the cache always return a block, so we can pass in
 	// nil for bops and rmdWithKeys.
-	err = reembedBlockChanges(ctx, codec, bcache, nil, mode, tlfID, &pmd, nil, logger.NewTestLogger(t))
+	err = reembedBlockChanges(
+		ctx, codec, bcache, nil, mode, tlfID, &pmd, nil,
+		logger.NewTestLogger(t))
 	require.NoError(t, err)
 
 	// We expect to get changes back, except with the implicit ref


### PR DESCRIPTION
When journaling is disabled, it makes no sense to waste time hashing the plaintext of a file block, because we aren't doing any de-duping.

This saves about 10% of write time in the big file benchmark, and about 6% while rsyncing the Go source code.