### PR TITLE
identify3: fix deadlock

### DIFF
--- a/go/identify3/service.go
+++ b/go/identify3/service.go
@@ -44,11 +44,10 @@ func FollowUser(mctx libkb.MetaContext, arg keybase1.Identify3FollowUserArg) (er
 	} else {
 		action = identify3ActionUnfollow
 	}
-	return doAction(mctx, arg.GuiID, action)
+	return doActionAndRemove(mctx, arg.GuiID, action)
 }
 
 func doAction(mctx libkb.MetaContext, guiID keybase1.Identify3GUIID, action identify3Action) error {
-
 	sess, err := mctx.G().Identify3State.Get(guiID)
 	if err != nil {
 		return err
@@ -57,9 +56,13 @@ func doAction(mctx libkb.MetaContext, guiID keybase1.Identify3GUIID, action iden
 		return libkb.NewNotFoundError(fmt.Sprintf("session %s wasn't found", guiID))
 	}
 
+	// Lock the session mainly because we want to protect the outcome, which unfortunately
+	// is difficult to copy. But be certain never to grab the Identify3State lock while
+	// holding the session lock (see comment below in doActionAndRemove).
 	sess.Lock()
 	defer sess.Unlock()
-	outcome := sess.OutcomeUnlocked()
+	outcome := sess.OutcomeLocked()
+
 	if outcome == nil {
 		return libkb.NewNotFoundError(fmt.Sprintf("outcome for session %s wasn't ready; is there a race?", guiID))
 	}
@@ -70,9 +73,20 @@ func doAction(mctx libkb.MetaContext, guiID keybase1.Identify3GUIID, action iden
 	case identify3ActionUnfollow:
 		err = doUnfollow(mctx, outcome)
 	}
-	if err == nil {
-		mctx.G().Identify3State.Remove(guiID)
+
+	return err
+}
+
+func doActionAndRemove(mctx libkb.MetaContext, guiID keybase1.Identify3GUIID, action identify3Action) error {
+	err := doAction(mctx, guiID, action)
+	if err != nil {
+		return err
 	}
+
+	// It's important not to hold the session lock when calling this function, since the background expire
+	// thread in identify3 grabs the state lock and then the session locks.
+	mctx.G().Identify3State.Remove(guiID)
+
 	return err
 }
 
@@ -102,5 +116,5 @@ func doFollow(mctx libkb.MetaContext, action identify3Action, outcome *libkb.Ide
 }
 
 func IgnoreUser(mctx libkb.MetaContext, guiID keybase1.Identify3GUIID) (err error) {
-	return doAction(mctx, guiID, identify3ActionIgnore)
+	return doActionAndRemove(mctx, guiID, identify3ActionIgnore)
 }

--- a/go/libkb/identify3.go
+++ b/go/libkb/identify3.go
@@ -72,7 +72,7 @@ func (s *Identify3Session) ResultType() keybase1.Identify3ResultType {
 	}
 }
 
-func (s *Identify3Session) OutcomeUnlocked() *IdentifyOutcome {
+func (s *Identify3Session) OutcomeLocked() *IdentifyOutcome {
 	return s.outcome
 }
 


### PR DESCRIPTION
- in the background, the expire thread was grabbing the Identify3State lock, and then blocking on individual session locks
- when tracking, the session lock is grabbed, and we were trying to grab the Identify3State lock at the Remove() call
- this was validated pretty well with logs
- solution is not to have the session lock while we're calling Remove()