### PR TITLE
Non-interactive, automated keybase login provisioning with paper keys

### DIFF
--- a/go/client/cmd_login.go
+++ b/go/client/cmd_login.go
@@ -30,8 +30,8 @@ func NewCmdLogin(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command
 			Usage: "Automatically provision using a paper key provided in stdin",
 		},
 		cli.StringFlag{
-			Name:  "machine-name",
-			Usage: "Machine name used in automated provisioning",
+			Name:  "device-name",
+			Usage: "Device name used in automated provisioning",
 		},
 	}
 	cmd := cli.Command{
@@ -61,7 +61,7 @@ type CmdLogin struct {
 	doUserSwitch bool
 
 	paperkeyFromStdin bool
-	machineName       string
+	deviceName        string
 
 	clientType keybase1.ClientType
 	cancel     func()
@@ -118,8 +118,8 @@ func (c *CmdLogin) Run() error {
 			SessionID:    c.SessionID,
 			DoUserSwitch: c.doUserSwitch,
 
-			PaperKey:    paperKey,
-			MachineName: c.machineName,
+			PaperKey:   paperKey,
+			DeviceName: c.deviceName,
 		})
 	c.done <- struct{}{}
 
@@ -159,7 +159,7 @@ func (c *CmdLogin) ParseArgv(ctx *cli.Context) error {
 	}
 	c.doUserSwitch = ctx.Bool("switch")
 	c.paperkeyFromStdin = ctx.Bool("paperkey-from-stdin")
-	c.machineName = ctx.String("machine-name")
+	c.deviceName = ctx.String("device-name")
 	return nil
 }
 

--- a/go/client/cmd_login.go
+++ b/go/client/cmd_login.go
@@ -38,6 +38,14 @@ func NewCmdLogin(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command
 		Name:         "login",
 		ArgumentHelp: "[username]",
 		Usage:        "Establish a session with the keybase server",
+		Description: `"keybase login" allows you to authenticate your local service against
+the keybase server. By default this runs an interactive flow, but
+you can automate this if your service has never been logged into
+a particular account before and the account has a paper key - in order
+to do so, pass the username as an argument, your desired unique device
+name as the "-devicename" flag and pass the paper key as the standard
+input. Alternatively, these parameters can be passed as "KEYBASE_PAPERKEY"
+and "KEYBASE_DEVICENAME" environment variables.`,
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(NewCmdLoginRunner(g), "login", c)
 		},

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -20,10 +20,13 @@ var errNoDevice = errors.New("No device provisioned locally for this user")
 // Login is an engine.
 type Login struct {
 	libkb.Contextified
-	deviceType   string
-	username     string
-	clientType   keybase1.ClientType
+	deviceType string
+	username   string
+	clientType keybase1.ClientType
+
 	doUserSwitch bool
+	PaperKey     string
+	MachineName  string
 }
 
 // NewLogin creates a Login engine.  username is optional.
@@ -144,6 +147,9 @@ func (e *Login) Run(m libkb.MetaContext) (err error) {
 		DeviceType: e.deviceType,
 		ClientType: e.clientType,
 		User:       ueng.User(),
+
+		PaperKey:    e.PaperKey,
+		MachineName: e.MachineName,
 	}
 	deng := newLoginProvision(m.G(), darg)
 	if err := RunEngine2(m, deng); err != nil {

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -26,7 +26,7 @@ type Login struct {
 
 	doUserSwitch bool
 	PaperKey     string
-	MachineName  string
+	DeviceName   string
 }
 
 // NewLogin creates a Login engine.  username is optional.
@@ -148,8 +148,8 @@ func (e *Login) Run(m libkb.MetaContext) (err error) {
 		ClientType: e.clientType,
 		User:       ueng.User(),
 
-		PaperKey:    e.PaperKey,
-		MachineName: e.MachineName,
+		PaperKey:   e.PaperKey,
+		DeviceName: e.DeviceName,
 	}
 	deng := newLoginProvision(m.G(), darg)
 	if err := RunEngine2(m, deng); err != nil {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -45,8 +45,8 @@ type loginProvisionArg struct {
 	User       *libkb.User
 
 	// Used for non-interactive provisioning
-	PaperKey    string
-	MachineName string
+	PaperKey   string
+	DeviceName string
 }
 
 // newLoginProvision creates a loginProvision engine.
@@ -511,12 +511,12 @@ func (e *loginProvision) deviceName(m libkb.MetaContext) (string, error) {
 	}
 
 	// Fully non-interactive flow
-	if e.arg.MachineName != "" {
-		if !libkb.CheckDeviceName.F(e.arg.MachineName) {
+	if e.arg.DeviceName != "" {
+		if !libkb.CheckDeviceName.F(e.arg.DeviceName) {
 			return "", libkb.DeviceBadNameError{}
 		}
 
-		devname := libkb.CheckDeviceName.Transform(e.arg.MachineName)
+		devname := libkb.CheckDeviceName.Transform(e.arg.DeviceName)
 		normalizedDevName := libkb.CheckDeviceName.Normalize(devname)
 		for _, name := range names {
 			if normalizedDevName == libkb.CheckDeviceName.Normalize(name) {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -3746,7 +3746,7 @@ func TestProvisionAutomatedPaperKey(t *testing.T) {
 	}
 	eng := NewLogin(tc2.G, libkb.DeviceTypeDesktop, fu.Username, keybase1.ClientType_CLI)
 	eng.PaperKey = loginUI.PaperPhrase
-	eng.MachineName = "a different machine name"
+	eng.DeviceName = "a different device name"
 	m2 := NewMetaContextForTest(tc2).WithUIs(uis2)
 	if err := RunEngine2(m2, eng); err != nil {
 		t.Fatal(err)

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -3748,20 +3748,13 @@ func TestProvisionAutomatedPaperKey(t *testing.T) {
 	eng.PaperKey = loginUI.PaperPhrase
 	eng.DeviceName = "a different device name"
 	m2 := NewMetaContextForTest(tc2).WithUIs(uis2)
-	if err := RunEngine2(m2, eng); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, RunEngine2(m2, eng), "run login engine")
 
 	assertNumDevicesAndKeys(tc, fu, 3, 6)
-	if err := AssertProvisioned(tc2); err != nil {
-		t.Fatal(err)
-	}
-	if provLoginUI.CalledGetEmailOrUsername != 0 {
-		t.Errorf("expected 0 calls to GetEmailOrUsername, got %d", provLoginUI.CalledGetEmailOrUsername)
-	}
-	if provUI.calledChooseDevice != 0 {
-		t.Errorf("expected 0 calls to ChooseDevice, got %d", provUI.calledChooseDevice)
-	}
+	require.NoError(t, AssertProvisioned(tc2), "provisioned")
+
+	require.Equal(t, provLoginUI.CalledGetEmailOrUsername, 0, "expected no calls to GetEmailOrUsername")
+	require.Equal(t, provUI.calledChooseDevice, 0, "expected no calls to ChooseDevice")
 }
 
 type testProvisionUI struct {

--- a/go/protocol/keybase1/login.go
+++ b/go/protocol/keybase1/login.go
@@ -30,6 +30,8 @@ type LoginArg struct {
 	Username     string     `codec:"username" json:"username"`
 	ClientType   ClientType `codec:"clientType" json:"clientType"`
 	DoUserSwitch bool       `codec:"doUserSwitch" json:"doUserSwitch"`
+	PaperKey     string     `codec:"paperKey" json:"paperKey"`
+	MachineName  string     `codec:"machineName" json:"machineName"`
 }
 
 type LoginProvisionedDeviceArg struct {

--- a/go/protocol/keybase1/login.go
+++ b/go/protocol/keybase1/login.go
@@ -31,7 +31,7 @@ type LoginArg struct {
 	ClientType   ClientType `codec:"clientType" json:"clientType"`
 	DoUserSwitch bool       `codec:"doUserSwitch" json:"doUserSwitch"`
 	PaperKey     string     `codec:"paperKey" json:"paperKey"`
-	MachineName  string     `codec:"machineName" json:"machineName"`
+	DeviceName   string     `codec:"deviceName" json:"deviceName"`
 }
 
 type LoginProvisionedDeviceArg struct {

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -125,6 +125,8 @@ func (h *LoginHandler) Login(ctx context.Context, arg keybase1.LoginArg) error {
 	}
 	m := libkb.NewMetaContext(ctx, h.G()).WithUIs(uis)
 	eng := engine.NewLoginWithUserSwitch(h.G(), arg.DeviceType, arg.Username, arg.ClientType, arg.DoUserSwitch)
+	eng.PaperKey = arg.PaperKey
+	eng.MachineName = arg.MachineName
 	return engine.RunEngine2(m, eng)
 }
 

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -126,7 +126,7 @@ func (h *LoginHandler) Login(ctx context.Context, arg keybase1.LoginArg) error {
 	m := libkb.NewMetaContext(ctx, h.G()).WithUIs(uis)
 	eng := engine.NewLoginWithUserSwitch(h.G(), arg.DeviceType, arg.Username, arg.ClientType, arg.DoUserSwitch)
 	eng.PaperKey = arg.PaperKey
-	eng.MachineName = arg.MachineName
+	eng.DeviceName = arg.DeviceName
 	return engine.RunEngine2(m, eng)
 }
 

--- a/protocol/avdl/keybase1/login.avdl
+++ b/protocol/avdl/keybase1/login.avdl
@@ -21,7 +21,15 @@ protocol login {
     or libkb.DeviceTypeMobile. username is optional. If the current
     device isn't provisioned, this function will provision it.
     */
-  void login(int sessionID, string deviceType, string username, ClientType clientType, boolean doUserSwitch=false);
+  void login(
+    int sessionID,
+    string deviceType,
+    string username,
+    ClientType clientType,
+    boolean doUserSwitch=false,
+    string paperKey,
+    string machineName
+  );
 
   /**
     Login a user only if the user is on a provisioned device. Username is optional.

--- a/protocol/avdl/keybase1/login.avdl
+++ b/protocol/avdl/keybase1/login.avdl
@@ -28,7 +28,7 @@ protocol login {
     ClientType clientType,
     boolean doUserSwitch=false,
     string paperKey,
-    string machineName
+    string deviceName
   );
 
   /**

--- a/protocol/json/keybase1/login.json
+++ b/protocol/json/keybase1/login.json
@@ -58,6 +58,14 @@
           "name": "doUserSwitch",
           "type": "boolean",
           "default": false
+        },
+        {
+          "name": "paperKey",
+          "type": "string"
+        },
+        {
+          "name": "machineName",
+          "type": "string"
         }
       ],
       "response": null,

--- a/protocol/json/keybase1/login.json
+++ b/protocol/json/keybase1/login.json
@@ -64,7 +64,7 @@
           "type": "string"
         },
         {
-          "name": "machineName",
+          "name": "deviceName",
           "type": "string"
         }
       ],

--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -79,6 +79,8 @@ function* login(state, action) {
           clientType: RPCTypes.commonClientType.guiMain,
           deviceType: isMobile ? 'mobile' : 'desktop',
           username: action.payload.username,
+          deviceName: '',
+          paperKey: '',
         },
         waitingKey: Constants.waitingKey,
       })

--- a/shared/actions/login.js
+++ b/shared/actions/login.js
@@ -77,10 +77,10 @@ function* login(state, action) {
         },
         params: {
           clientType: RPCTypes.commonClientType.guiMain,
-          deviceType: isMobile ? 'mobile' : 'desktop',
-          username: action.payload.username,
           deviceName: '',
+          deviceType: isMobile ? 'mobile' : 'desktop',
           paperKey: '',
+          username: action.payload.username,
         },
         waitingKey: Constants.waitingKey,
       })

--- a/shared/actions/provision.js
+++ b/shared/actions/provision.js
@@ -399,6 +399,8 @@ function* startProvisioning(state) {
         clientType: RPCTypes.commonClientType.guiMain,
         deviceType: isMobile ? 'mobile' : 'desktop',
         username: username,
+        deviceName: '',
+        paperKey: '',
       },
       waitingKey: Constants.waitingKey,
     })

--- a/shared/actions/provision.js
+++ b/shared/actions/provision.js
@@ -397,10 +397,10 @@ function* startProvisioning(state) {
       incomingCallMap: ProvisioningManager.getSingleton().getIncomingCallMap(),
       params: {
         clientType: RPCTypes.commonClientType.guiMain,
-        deviceType: isMobile ? 'mobile' : 'desktop',
-        username: username,
         deviceName: '',
+        deviceType: isMobile ? 'mobile' : 'desktop',
         paperKey: '',
+        username: username,
       },
       waitingKey: Constants.waitingKey,
     })

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -657,7 +657,7 @@ export type MessageTypes = {|
     outParam: ?Array<ConfiguredAccount>,
   |},
   'keybase.1.login.login': {|
-    inParam: $ReadOnly<{|deviceType: String, username: String, clientType: ClientType, doUserSwitch?: Boolean|}>,
+    inParam: $ReadOnly<{|deviceType: String, username: String, clientType: ClientType, doUserSwitch?: Boolean, paperKey: String, machineName: String|}>,
     outParam: void,
   |},
   'keybase.1.login.logout': {|

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -657,7 +657,7 @@ export type MessageTypes = {|
     outParam: ?Array<ConfiguredAccount>,
   |},
   'keybase.1.login.login': {|
-    inParam: $ReadOnly<{|deviceType: String, username: String, clientType: ClientType, doUserSwitch?: Boolean, paperKey: String, machineName: String|}>,
+    inParam: $ReadOnly<{|deviceType: String, username: String, clientType: ClientType, doUserSwitch?: Boolean, paperKey: String, deviceName: String|}>,
     outParam: void,
   |},
   'keybase.1.login.logout': {|


### PR DESCRIPTION
I don't like how I had to do some of the plumbing but I didn't want to pollute the engine root level namespace that much. Maybe we should just do a NewLoginWithArg instead?