### PR TITLE
Avoid white screens on transition on nav2

### DIFF
--- a/shared/router-v2/shim.native.js
+++ b/shared/router-v2/shim.native.js
@@ -1,7 +1,6 @@
 // @flow
 import * as Kb from '../common-adapters/mobile.native'
 import * as React from 'react'
-import {InteractionManager} from 'react-native'
 import * as Styles from '../styles'
 import * as Shared from './shim.shared'
 
@@ -9,25 +8,9 @@ export const shim = (routes: any) => Shared.shim(routes, shimNewRoute)
 
 const shimNewRoute = (Original: any) => {
   // Wrap everything in a keyboard avoiding view (maybe this is opt in/out?)
-  // Defer drawing until didfocus got called so transitions are faster
-  class ShimmedNew extends React.PureComponent<any, {canDraw: boolean}> {
+  class ShimmedNew extends React.PureComponent<any, void> {
     static navigationOptions = Original.navigationOptions
-    state = {canDraw: false}
-    _drawTask = null
-    componentDidMount() {
-      this._drawTask = InteractionManager.runAfterInteractions(this._didFocus)
-    }
-    componentWillUnmount() {
-      this._drawTask && this._drawTask.cancel()
-    }
-    _didFocus = () => {
-      this.setState({canDraw: true})
-      this._drawTask = null
-    }
     render() {
-      if (!this.state.canDraw) {
-        return null
-      }
       const body = <Original {...this.props} />
       const keyboardBody = (
         <Kb.NativeKeyboardAvoidingView


### PR DESCRIPTION
@keybase/react-hackers 

This isn't a real fix, because the delay on drawing nav2 routes until after focus was there intentionally to give faster touch feedback.  But it'll avoid screens flashing white before render, which was perhaps more annoying.  The real fix involves finding out why rendering seems slower than nav1 now.