### PR TITLE
Fix asset input cut off on mobile

### DIFF
--- a/shared/common-adapters/plain-input.native.js
+++ b/shared/common-adapters/plain-input.native.js
@@ -2,7 +2,7 @@
 import React, {Component} from 'react'
 import {getStyle as getTextStyle} from './text'
 import {NativeTextInput} from './native-wrappers.native'
-import {collapseStyles, globalColors, styleSheetCreate} from '../styles'
+import {collapseStyles, globalColors, platformStyles, styleSheetCreate} from '../styles'
 import {isIOS} from '../constants/platform'
 import {checkTextInfo} from './input.shared'
 import {pick} from 'lodash-es'
@@ -254,12 +254,15 @@ class PlainInput extends Component<InternalProps, State> {
 
 const styles = styleSheetCreate({
   common: {backgroundColor: globalColors.fastBlank, borderWidth: 0, flexGrow: 1},
-  multiline: {
-    height: undefined,
-    // TODO: Maybe remove these paddings?
-    paddingBottom: 0,
-    paddingTop: 0,
-  },
+  multiline: platformStyles({
+    isMobile: {
+      height: undefined,
+      // TODO: Maybe remove these paddings?
+      paddingBottom: 0,
+      paddingTop: 0,
+      textAlignVertical: 'top', // android centers by default
+    },
+  }),
   singleline: {padding: 0},
 })
 

--- a/shared/common-adapters/plain-input.native.js
+++ b/shared/common-adapters/plain-input.native.js
@@ -175,6 +175,8 @@ class PlainInput extends Component<InternalProps, State> {
 
   _getCommonStyle = () => {
     const textStyle = getTextStyle(this.props.textType)
+    // RN TextInput plays better without this
+    delete textStyle.lineHeight
     return collapseStyles([styles.common, textStyle])
   }
 

--- a/shared/profile/generic/enter-username/index.js
+++ b/shared/profile/generic/enter-username/index.js
@@ -261,11 +261,11 @@ const styles = Styles.styleSheetCreate({
   },
   input: Styles.platformStyles({
     common: {marginRight: Styles.globalMargins.medium},
+    isAndroid: {
+      top: 1,
+    },
     isElectron: {
       marginTop: -1,
-    },
-    isMobile: {
-      top: 3,
     },
   }),
   inputBox: {
@@ -291,7 +291,9 @@ const styles = Styles.styleSheetCreate({
     top: 1,
   },
   invisible: {
-    opacity: 0,
+    // opacity doesn't work in nested Text on android
+    // see here: https://github.com/facebook/react-native/issues/18057
+    color: Styles.globalColors.transparent,
   },
   marginLeftAuto: {marginLeft: 'auto'},
   opacity40: {

--- a/shared/provision/code-page/index.js
+++ b/shared/provision/code-page/index.js
@@ -361,13 +361,13 @@ const styles = Styles.styleSheetCreate({
       backgroundColor: Styles.globalColors.white,
       borderRadius: 4,
       color: Styles.globalColors.green,
-      fontSize: 16,
       paddingBottom: 15,
       paddingLeft: 20,
       paddingRight: 20,
       paddingTop: 15,
     },
     isElectron: {
+      fontSize: 16,
       maxWidth: 460,
     },
     isMobile: {

--- a/shared/wallets/send-form/root.js
+++ b/shared/wallets/send-form/root.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import Header from './header'
+import flags from '../../util/feature-flags'
 
 type Props = {|
   onClose: () => void,
@@ -25,12 +26,9 @@ const PoweredByStellar = () => (
   </Kb.Box2>
 )
 
-const Root = (props: Props) => (
-  <Kb.MaybePopup onClose={props.onClose}>
-    <Kb.KeyboardAvoidingView
-      behavior={Styles.isAndroid ? undefined : 'padding'}
-      style={Styles.globalStyles.fillAbsolute}
-    >
+const Root = (props: Props) => {
+  let child = (
+    <>
       <Kb.SafeAreaViewTop style={styles.backgroundColorPurple} />
       <Kb.Box2 direction="vertical" style={styles.container}>
         <Header isRequest={props.isRequest} onBack={Styles.isMobile ? props.onClose : null} />
@@ -38,9 +36,21 @@ const Root = (props: Props) => (
       </Kb.Box2>
       {!Styles.isMobile && <PoweredByStellar />}
       <Kb.SafeAreaView style={styles.backgroundColorBlue5} />
-    </Kb.KeyboardAvoidingView>
-  </Kb.MaybePopup>
-)
+    </>
+  )
+  if (!flags.useNewRouter) {
+    // new router adds this by default
+    child = (
+      <Kb.KeyboardAvoidingView
+        behavior={Styles.isAndroid ? undefined : 'padding'}
+        style={Styles.globalStyles.fillAbsolute}
+      >
+        {child}
+      </Kb.KeyboardAvoidingView>
+    )
+  }
+  return <Kb.MaybePopup onClose={props.onClose}>{child}</Kb.MaybePopup>
+}
 
 const styles = Styles.styleSheetCreate({
   backgroundColorBlue5: {backgroundColor: Styles.globalColors.blue5},


### PR DESCRIPTION
- Remove double `KeyboardAvoidingView` in send form
  - We need a nav2 solution to change the color of the `SafeAreaView`
- Remove `lineHeight` from default native styles on `PlainInput`, mobile plays better without it
- Add `textAlignVertical: 'top'` to multiline styles
- Fix up a couple places - generic enter username and provisioning code page

r? @keybase/react-hackers 