### PR TITLE
libkb: merkle lookups pass c=1 to save bandwidth

### DIFF
--- a/go/kbcrypto/nacl_sig_info.go
+++ b/go/kbcrypto/nacl_sig_info.go
@@ -42,6 +42,10 @@ type VerificationError struct {
 	Cause error
 }
 
+func newVerificationError(s string) VerificationError {
+	return VerificationError{errors.New(s)}
+}
+
 const (
 	SCSigCannotVerify = int(keybase1.StatusCode_SCSigCannotVerify)
 )
@@ -81,24 +85,24 @@ func (s NaclSigInfo) verifyWithPayload(payload []byte, checkPayloadEquality bool
 		return nil, BadKeyError{}
 	}
 	if payload == nil {
-		return nil, VerificationError{errors.New("nil payload")}
+		return nil, newVerificationError("nil payload")
 	}
 
 	if checkPayloadEquality && s.Payload != nil && !SecureByteArrayEq(payload, s.Payload) {
-		return nil, VerificationError{errors.New("payload mismatch")}
+		return nil, newVerificationError("payload mismatch")
 	}
 
 	switch s.Version {
 	case 0, 1:
 		if !key.Verify(payload, s.Sig) {
-			return nil, VerificationError{}
+			return nil, newVerificationError("verify failed")
 		}
 	case 2:
 		if !s.Prefix.IsWhitelisted() {
-			return nil, VerificationError{errors.New("unknown prefix")}
+			return nil, newVerificationError("unknown prefix")
 		}
 		if !key.Verify(s.Prefix.Prefix(payload), s.Sig) {
-			return nil, VerificationError{}
+			return nil, newVerificationError("verify failed")
 		}
 	default:
 		return nil, UnhandledSignatureError{s.Version}

--- a/go/kbcrypto/sig_test.go
+++ b/go/kbcrypto/sig_test.go
@@ -1,0 +1,86 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package kbcrypto
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"github.com/keybase/go-crypto/ed25519"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type keypair struct {
+	pub  NaclSigningKeyPublic
+	priv NaclSigningKeyPrivate
+}
+
+func makeKeypair() (keypair, error) {
+	reader := rand.Reader
+	publicKey, privateKey, err := ed25519.GenerateKey(reader)
+	var ret keypair
+	if err != nil {
+		return ret, err
+	}
+	copy(ret.pub[:], publicKey)
+	copy(ret.priv[:], privateKey)
+
+	return ret, nil
+}
+
+func TestVerifyWithPayload(t *testing.T) {
+	kp, err := makeKeypair()
+	require.NoError(t, err)
+
+	msg := []byte("let there be songs / to fill the air")
+
+	sig, _, err := kp.priv.SignToStringV0(msg, kp.pub)
+	require.NoError(t, err)
+
+	requireError := func(err error, s string) {
+		require.Error(t, err)
+		require.Equal(t, errors.New(s), err.(VerificationError).Cause, errors.New("nil payload"))
+	}
+
+	_, _, _, err = NaclVerifyWithPayload(sig, msg)
+	require.NoError(t, err)
+	_, _, _, err = NaclVerifyWithPayload(sig, nil)
+	requireError(err, "nil payload")
+	_, _, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
+	requireError(err, "payload mismatch")
+
+	info := kp.priv.SignInfoV0(msg, kp.pub)
+	info.Payload = nil
+	body, err := EncodePacketToBytes(&info)
+	require.NoError(t, err)
+	sig = base64.StdEncoding.EncodeToString(body)
+
+	_, _, _, err = NaclVerifyWithPayload(sig, msg)
+	require.NoError(t, err)
+
+	// Now corrupt and make sure we get the right answer
+	info.Sig[10] ^= 0x1
+	body, err = EncodePacketToBytes(&info)
+	require.NoError(t, err)
+	sig = base64.StdEncoding.EncodeToString(body)
+	_, _, _, err = NaclVerifyWithPayload(sig, msg)
+	require.Error(t, err)
+	require.IsType(t, VerificationError{}, err)
+	require.Nil(t, err.(VerificationError).Cause)
+
+	// Get the same failure if we have the wrong sig and the wrong payload
+	_, _, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
+	require.Error(t, err)
+	require.IsType(t, VerificationError{}, err)
+	require.Nil(t, err.(VerificationError).Cause)
+
+	// Fail with bad payload before the sig fails, if we have the right payload and it's doubled up
+	info.Payload = msg
+	body, err = EncodePacketToBytes(&info)
+	require.NoError(t, err)
+	sig = base64.StdEncoding.EncodeToString(body)
+	_, _, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
+	requireError(err, "payload mismatch")
+}

--- a/go/kbcrypto/sig_test.go
+++ b/go/kbcrypto/sig_test.go
@@ -41,13 +41,15 @@ func TestVerifyWithPayload(t *testing.T) {
 
 	requireError := func(err error, s string) {
 		require.Error(t, err)
-		require.Equal(t, errors.New(s), err.(VerificationError).Cause, errors.New("nil payload"))
+		require.Equal(t, errors.New(s), err.(VerificationError).Cause)
 	}
 
 	_, _, _, err = NaclVerifyWithPayload(sig, msg)
 	require.NoError(t, err)
 	_, _, _, err = NaclVerifyWithPayload(sig, nil)
 	requireError(err, "nil payload")
+	_, _, _, err = NaclVerifyWithPayload(sig, []byte(""))
+	requireError(err, "empty payload")
 	_, _, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
 	requireError(err, "payload mismatch")
 

--- a/go/kbcrypto/sig_test.go
+++ b/go/kbcrypto/sig_test.go
@@ -66,15 +66,11 @@ func TestVerifyWithPayload(t *testing.T) {
 	require.NoError(t, err)
 	sig = base64.StdEncoding.EncodeToString(body)
 	_, _, _, err = NaclVerifyWithPayload(sig, msg)
-	require.Error(t, err)
-	require.IsType(t, VerificationError{}, err)
-	require.Nil(t, err.(VerificationError).Cause)
+	requireError(err, "verify failed")
 
 	// Get the same failure if we have the wrong sig and the wrong payload
 	_, _, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
-	require.Error(t, err)
-	require.IsType(t, VerificationError{}, err)
-	require.Nil(t, err.(VerificationError).Cause)
+	requireError(err, "verify failed")
 
 	// Fail with bad payload before the sig fails, if we have the right payload and it's doubled up
 	info.Payload = msg

--- a/go/kbcrypto/sig_test.go
+++ b/go/kbcrypto/sig_test.go
@@ -44,13 +44,13 @@ func TestVerifyWithPayload(t *testing.T) {
 		require.Equal(t, errors.New(s), err.(VerificationError).Cause)
 	}
 
-	_, _, _, err = NaclVerifyWithPayload(sig, msg)
+	_, _, err = NaclVerifyWithPayload(sig, msg)
 	require.NoError(t, err)
-	_, _, _, err = NaclVerifyWithPayload(sig, nil)
+	_, _, err = NaclVerifyWithPayload(sig, nil)
 	requireError(err, "nil payload")
-	_, _, _, err = NaclVerifyWithPayload(sig, []byte(""))
+	_, _, err = NaclVerifyWithPayload(sig, []byte(""))
 	requireError(err, "empty payload")
-	_, _, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
+	_, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
 	requireError(err, "payload mismatch")
 
 	info := kp.priv.SignInfoV0(msg, kp.pub)
@@ -59,7 +59,7 @@ func TestVerifyWithPayload(t *testing.T) {
 	require.NoError(t, err)
 	sig = base64.StdEncoding.EncodeToString(body)
 
-	_, _, _, err = NaclVerifyWithPayload(sig, msg)
+	_, _, err = NaclVerifyWithPayload(sig, msg)
 	require.NoError(t, err)
 
 	// Now corrupt and make sure we get the right answer
@@ -67,11 +67,11 @@ func TestVerifyWithPayload(t *testing.T) {
 	body, err = EncodePacketToBytes(&info)
 	require.NoError(t, err)
 	sig = base64.StdEncoding.EncodeToString(body)
-	_, _, _, err = NaclVerifyWithPayload(sig, msg)
+	_, _, err = NaclVerifyWithPayload(sig, msg)
 	requireError(err, "verify failed")
 
 	// Get the same failure if we have the wrong sig and the wrong payload
-	_, _, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
+	_, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
 	requireError(err, "verify failed")
 
 	// Fail with bad payload before the sig fails, if we have the right payload and it's doubled up
@@ -79,6 +79,6 @@ func TestVerifyWithPayload(t *testing.T) {
 	body, err = EncodePacketToBytes(&info)
 	require.NoError(t, err)
 	sig = base64.StdEncoding.EncodeToString(body)
-	_, _, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
+	_, _, err = NaclVerifyWithPayload(sig, []byte("yo"))
 	requireError(err, "payload mismatch")
 }

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -644,7 +644,11 @@ func (mc *MerkleClient) fetchRootFromServer(m MetaContext, lastRoot *MerkleRoot)
 }
 
 func (mc *MerkleClient) lookupRootAndSkipSequence(m MetaContext, lastRoot *MerkleRoot, opts MerkleOpts) (mr *MerkleRoot, ss SkipSequence, apiRes *APIRes, err error) {
-	q := NewHTTPArgs()
+
+	// c=1 invokes server-side compression
+	q := HTTPArgs{
+		"c": B{true},
+	}
 
 	// Get back a series of skips from the last merkle root we had to the new
 	// one we're getting back, and hold the server to it.
@@ -727,6 +731,7 @@ func (mc *MerkleClient) lookupPathAndSkipSequenceHelper(m MetaContext, q HTTPArg
 	w := 10 * int(CITimeMultiplier(mc.G()))
 
 	q.Add("poll", I{w})
+	q.Add("c", B{true})
 	if isUser {
 		q.Add("load_deleted", B{true})
 		q.Add("load_reset_chain", B{true})

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -320,31 +320,36 @@ func (k NaclSigningKeyPair) VerifyStringAndExtract(ctx VerifyContext, sig string
 	var fullSigBody []byte
 	keyInSignature, msg, fullSigBody, err = kbcrypto.NaclVerifyAndExtract(sig)
 	if err != nil {
-		return
+		return nil, id, err
 	}
 
 	kidInSig := keyInSignature.GetKID()
 	kidWanted := k.GetKID()
 	if kidWanted.NotEqual(kidInSig) {
 		err = WrongKidError{kidInSig, kidWanted}
-		return
+		return nil, id, err
 	}
 
 	id = kbcrypto.ComputeSigIDFromSigBody(fullSigBody)
-	return
+	return msg, id, nil
 }
 
 func (k NaclSigningKeyPair) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigID, err error) {
-	extractedMsg, resID, err := k.VerifyStringAndExtract(ctx, sig)
+	var keyInSignature *kbcrypto.NaclSigningKeyPublic
+	var fullSigBody []byte
+	keyInSignature, msg, fullSigBody, err = kbcrypto.NaclVerifyWithPayload(sig, msg)
 	if err != nil {
-		return
+		return id, err
 	}
-	if !FastByteArrayEq(extractedMsg, msg) {
-		err = BadSigError{"wrong payload"}
-		return
+	kidInSig := keyInSignature.GetKID()
+	kidWanted := k.GetKID()
+	if kidWanted.NotEqual(kidInSig) {
+		err = WrongKidError{kidInSig, kidWanted}
+		return id, err
 	}
-	id = resID
-	return
+
+	id = kbcrypto.ComputeSigIDFromSigBody(fullSigBody)
+	return id, nil
 }
 
 func (k NaclDHKeyPair) SignToString(msg []byte) (sig string, id keybase1.SigID, err error) {

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -337,7 +337,7 @@ func (k NaclSigningKeyPair) VerifyStringAndExtract(ctx VerifyContext, sig string
 func (k NaclSigningKeyPair) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigID, err error) {
 	var keyInSignature *kbcrypto.NaclSigningKeyPublic
 	var fullSigBody []byte
-	keyInSignature, msg, fullSigBody, err = kbcrypto.NaclVerifyWithPayload(sig, msg)
+	keyInSignature, fullSigBody, err = kbcrypto.NaclVerifyWithPayload(sig, msg)
 	if err != nil {
 		return id, err
 	}


### PR DESCRIPTION
- implement detached signatures to check this properly
- add a little sig/verify test