### PR TITLE
Fix flake in TestChatSearchInbox, fix don't query for aliases

### DIFF
--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -184,20 +184,17 @@ func (idx *Indexer) searchConv(ctx context.Context, convID chat1.ConversationID,
 	}
 
 	var allMsgIDs mapset.Set
-	for token, aliases := range tokens {
+	for token := range tokens {
 		matchedIDs := mapset.NewThreadUnsafeSet()
 
 		// first gather the messages that directly match the token
 		for msgID := range convIdx.Index[token] {
 			matchedIDs.Add(msgID)
 		}
-		// now check any aliases for matches, including our token itself
-		aliases[token] = struct{}{}
-		for alias := range aliases {
-			for atoken := range convIdx.Alias[alias] {
-				for msgID := range convIdx.Index[atoken] {
-					matchedIDs.Add(msgID)
-				}
+		// now check any aliases for matches
+		for atoken := range convIdx.Alias[token] {
+			for msgID := range convIdx.Index[atoken] {
+				matchedIDs.Add(msgID)
 			}
 		}
 

--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -831,8 +831,10 @@ func TestChatSearchInbox(t *testing.T) {
 		verifyHit(convID, []chat1.MessageID{msgID3, msgID7}, msgID8, nil, []chat1.ChatSearchMatch{searchMatch}, convHit.Hits[0])
 		verifySearchDone(1)
 		verifyIndex(expectedIndex)
+
 		// since our index is full, we shouldn't fire off any calls to get messages
 		runSearch(query, opts, false /* expectedReindex*/)
+		verifySearchDone(1)
 
 		// Verify background syncing
 		g1.LocalChatDb.Nuke()
@@ -847,8 +849,10 @@ func TestChatSearchInbox(t *testing.T) {
 		verifyHit(convID, []chat1.MessageID{msgID3, msgID7}, msgID8, nil, []chat1.ChatSearchMatch{searchMatch}, convHit.Hits[0])
 		verifySearchDone(1)
 		verifyIndex(expectedIndex)
+
 		// since our index is full, we shouldn't fire off any calls to get messages
 		runSearch(query, opts, false /* expectedReindex*/)
+		verifySearchDone(1)
 
 		// Test prefix searching
 		query = "pay"
@@ -864,6 +868,11 @@ func TestChatSearchInbox(t *testing.T) {
 		require.Equal(t, 1, len(convHit.Hits))
 		verifyHit(convID, []chat1.MessageID{msgID2, msgID3}, msgID7, []chat1.MessageID{msgID8}, []chat1.ChatSearchMatch{searchMatch}, convHit.Hits[0])
 		verifySearchDone(1)
+
+		query = "payments"
+		res = runSearch(query, opts, false /* expectedReindex*/)
+		require.Equal(t, 0, len(res.Hits))
+		verifySearchDone(0)
 
 		// Test deletehistory
 		msgID9 := mustDeleteHistory(tc2.startCtx, t, ctc, u2, conv, msgID8+1)


### PR DESCRIPTION
i think this will address the flake people were seeing, if not the extra logging should help track it down