### PR TITLE
Override Body's font size instead.

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.native.js
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.js
@@ -189,7 +189,7 @@ class _PlatformInput extends PureComponent<PlatformInputPropsInternal, State> {
             onSelectionChange={this.props.onSelectionChange}
             ref={this._inputSetRef}
             style={styles.input}
-            textType="BodyBig"
+            textType="Body"
             rowsMax={3}
             rowsMin={1}
           />
@@ -326,8 +326,7 @@ const styles = Styles.styleSheetCreate({
   },
   input: {
     flex: 1,
-    // Override BodyBig's default weight.
-    fontWeight: Styles.globalStyles.fontRegular.fontWeight,
+    fontSize: 17, // Override Body's font size with BodyBig.
     marginLeft: Styles.globalMargins.tiny,
     marginRight: Styles.globalMargins.tiny,
     ...(isIOS


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. There was an issue with Android showing the wrong font weight with the reverse approach.