### PR TITLE
kbfs: vloggify loquacious loggers

### DIFF
--- a/go/kbfs/data/dir_data_test.go
+++ b/go/kbfs/data/dir_data_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libkey"
 	libkeytest "github.com/keybase/client/go/kbfs/libkey/test"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
@@ -59,8 +60,10 @@ func setupDirDataTest(t *testing.T, maxPtrsPerBlock, numDirEntries int) (
 		return dirtyBcache.Put(ctx, id, ptr, MasterBranch, block)
 	}
 
+	log := logger.NewTestLogger(t)
 	dd := NewDirData(
-		dir, chargedTo, bsplit, kmd, getter, cacher, logger.NewTestLogger(t))
+		dir, chargedTo, bsplit, kmd, getter, cacher, log,
+		libkb.NewVDebugLog(log))
 	return dd, cleanCache, dirtyBcache
 }
 

--- a/go/kbfs/data/dirty_bcache_test.go
+++ b/go/kbfs/data/dirty_bcache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/test/clocktest"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"golang.org/x/net/context"
 )
@@ -55,17 +56,18 @@ func testExpectedMissingDirty(
 }
 
 func TestDirtyBcachePut(t *testing.T) {
+	log := logger.NewTestLogger(t)
 	dirtyBcache := NewDirtyBlockCacheStandard(
-		&WallClock{}, logger.NewTestLogger(t),
-		5<<20, 10<<20, 5<<20)
+		&WallClock{}, log, libkb.NewVDebugLog(log), 5<<20, 10<<20, 5<<20)
 	defer dirtyBcache.Shutdown()
 	testDirtyBcachePut(
 		t, context.Background(), kbfsblock.FakeID(1), dirtyBcache)
 }
 
 func TestDirtyBcachePutDuplicate(t *testing.T) {
-	dirtyBcache := NewDirtyBlockCacheStandard(&WallClock{}, logger.NewTestLogger(t),
-		5<<20, 10<<20, 5<<20)
+	log := logger.NewTestLogger(t)
+	dirtyBcache := NewDirtyBlockCacheStandard(
+		&WallClock{}, log, libkb.NewVDebugLog(log), 5<<20, 10<<20, 5<<20)
 	defer dirtyBcache.Shutdown()
 	id1 := kbfsblock.FakeID(1)
 
@@ -111,8 +113,9 @@ func TestDirtyBcachePutDuplicate(t *testing.T) {
 }
 
 func TestDirtyBcacheDelete(t *testing.T) {
-	dirtyBcache := NewDirtyBlockCacheStandard(&WallClock{}, logger.NewTestLogger(t),
-		5<<20, 10<<20, 5<<20)
+	log := logger.NewTestLogger(t)
+	dirtyBcache := NewDirtyBlockCacheStandard(
+		&WallClock{}, log, libkb.NewVDebugLog(log), 5<<20, 10<<20, 5<<20)
 	defer dirtyBcache.Shutdown()
 
 	id1 := kbfsblock.FakeID(1)
@@ -136,8 +139,9 @@ func TestDirtyBcacheDelete(t *testing.T) {
 
 func TestDirtyBcacheRequestPermission(t *testing.T) {
 	bufSize := int64(5)
-	dirtyBcache := NewDirtyBlockCacheStandard(&WallClock{}, logger.NewTestLogger(t),
-		bufSize, bufSize*2, bufSize)
+	log := logger.NewTestLogger(t)
+	dirtyBcache := NewDirtyBlockCacheStandard(
+		&WallClock{}, log, libkb.NewVDebugLog(log), bufSize, bufSize*2, bufSize)
 	defer dirtyBcache.Shutdown()
 	blockedChan := make(chan int64, 1)
 	dirtyBcache.blockedChanForTesting = blockedChan
@@ -222,8 +226,9 @@ func TestDirtyBcacheRequestPermission(t *testing.T) {
 func TestDirtyBcacheCalcBackpressure(t *testing.T) {
 	bufSize := int64(10)
 	clock, now := clocktest.NewTestClockAndTimeNow()
-	dirtyBcache := NewDirtyBlockCacheStandard(clock, logger.NewTestLogger(t),
-		bufSize, bufSize*2, bufSize)
+	log := logger.NewTestLogger(t)
+	dirtyBcache := NewDirtyBlockCacheStandard(
+		clock, log, libkb.NewVDebugLog(log), bufSize, bufSize*2, bufSize)
 	defer dirtyBcache.Shutdown()
 	// no backpressure yet
 	bp := dirtyBcache.calcBackpressure(now, now.Add(11*time.Second))
@@ -263,8 +268,9 @@ func TestDirtyBcacheCalcBackpressure(t *testing.T) {
 
 func TestDirtyBcacheResetBufferCap(t *testing.T) {
 	bufSize := int64(5)
-	dirtyBcache := NewDirtyBlockCacheStandard(&WallClock{}, logger.NewTestLogger(t),
-		bufSize, bufSize*2, bufSize)
+	log := logger.NewTestLogger(t)
+	dirtyBcache := NewDirtyBlockCacheStandard(
+		&WallClock{}, log, libkb.NewVDebugLog(log), bufSize, bufSize*2, bufSize)
 	defer dirtyBcache.Shutdown()
 	dirtyBcache.resetBufferCapTime = 1 * time.Millisecond
 	blockedChan := make(chan int64, 1)

--- a/go/kbfs/data/file_data_test.go
+++ b/go/kbfs/data/file_data_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libkey"
 	libkeytest "github.com/keybase/client/go/kbfs/libkey/test"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
@@ -59,8 +60,10 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 		return dirtyBcache.Put(ctx, id, ptr, MasterBranch, block)
 	}
 
+	log := logger.NewTestLogger(t)
 	fd := NewFileData(
-		file, chargedTo, bsplit, kmd, getter, cacher, logger.NewTestLogger(t))
+		file, chargedTo, bsplit, kmd, getter, cacher, log,
+		libkb.NewVDebugLog(log))
 	df := NewDirtyFile(file, dirtyBcache)
 	return fd, cleanCache, dirtyBcache, df
 }

--- a/go/kbfs/kbfsedits/user_history.go
+++ b/go/kbfs/kbfsedits/user_history.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -38,13 +39,15 @@ type UserHistory struct {
 	lock      sync.RWMutex
 	histories map[tlfKey]writersByRevision
 	log       logger.Logger
+	vlog      *libkb.VDebugLog
 }
 
 // NewUserHistory constructs a UserHistory instance.
-func NewUserHistory(log logger.Logger) *UserHistory {
+func NewUserHistory(log logger.Logger, vlog *libkb.VDebugLog) *UserHistory {
 	return &UserHistory{
 		histories: make(map[tlfKey]writersByRevision),
 		log:       log,
+		vlog:      vlog,
 	}
 }
 
@@ -53,7 +56,7 @@ func NewUserHistory(log logger.Logger) *UserHistory {
 func (uh *UserHistory) UpdateHistory(
 	tlfName tlf.CanonicalName, tlfType tlf.Type, tlfHistory *TlfHistory,
 	loggedInUser string) {
-	uh.log.CDebugf(nil, "Updating user history for TLF %s, "+
+	uh.vlog.CLogf(nil, libkb.VLog1, "Updating user history for TLF %s, "+
 		"user %s", tlfName, loggedInUser)
 	history := tlfHistory.getHistory(loggedInUser)
 	key := tlfKey{tlfName, tlfType}
@@ -163,7 +166,7 @@ func (uh *UserHistory) Get(loggedInUser string) (
 	history []keybase1.FSFolderEditHistory) {
 	uh.lock.RLock()
 	defer uh.lock.RUnlock()
-	uh.log.CDebugf(nil, "User history requested: %s", loggedInUser)
+	uh.vlog.CLogf(nil, libkb.VLog1, "User history requested: %s", loggedInUser)
 	var clusters historyClusters
 	for key := range uh.histories {
 		history := uh.getTlfHistoryLocked(key.tlfName, key.tlfType)

--- a/go/kbfs/kbfsedits/user_history_test.go
+++ b/go/kbfs/kbfsedits/user_history_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
@@ -94,7 +95,8 @@ func TestUserHistorySimple(t *testing.T) {
 	_, err = publicTH.AddNotifications(aliceName, publicAlice)
 	require.NoError(t, err)
 
-	uh := NewUserHistory(logger.New("UH"))
+	log := logger.New("UH")
+	uh := NewUserHistory(log, libkb.NewVDebugLog(log))
 	uh.UpdateHistory(privSharedName, tlf.Private, privSharedTH, aliceName)
 	uh.UpdateHistory(privHomeName, tlf.Private, privHomeTH, aliceName)
 	uh.UpdateHistory(publicName, tlf.Public, publicTH, aliceName)

--- a/go/kbfs/kbfsfuse/main.go
+++ b/go/kbfs/kbfsfuse/main.go
@@ -91,6 +91,7 @@ func start() *libfs.Error {
 	}
 
 	if kbfsParams.Debug {
+		// Temporary, until we make a config and can make a vlogger.
 		fuseLog := logger.NewWithCallDepth("FUSE", 1)
 		fuseLog.Configure("", true, "")
 		fuse.Debug = libfuse.MakeFuseDebugFn(

--- a/go/kbfs/kbfsgit/start.go
+++ b/go/kbfs/kbfsgit/start.go
@@ -37,7 +37,8 @@ func Start(ctx context.Context, options StartOptions,
 	// of this once we integrate with the kbfs daemon.
 	errput.Write([]byte("Initializing Keybase... "))
 	ctx, config, err := libgit.Init(
-		ctx, options.KbfsParams, kbCtx, nil, defaultLogPath)
+		ctx, options.KbfsParams, kbCtx, nil, defaultLogPath,
+		kbCtx.GetVDebugSetting())
 	if err != nil {
 		return libfs.InitError(err.Error())
 	}

--- a/go/kbfs/libdokan/fakeroot.go
+++ b/go/kbfs/libdokan/fakeroot.go
@@ -6,6 +6,7 @@ package libdokan
 
 import (
 	"github.com/keybase/client/go/kbfs/dokan"
+	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
 )
 
@@ -15,7 +16,7 @@ type fakeRoot struct {
 
 func openFakeRoot(ctx context.Context, fs *FS, fi *dokan.FileInfo) (dokan.File, dokan.CreateStatus, error) {
 	path := fi.Path()
-	fs.log.CDebugf(ctx, "openFakeRoot %q", path)
+	fs.vlog.CLogf(ctx, libkb.VLog1, "openFakeRoot %q", path)
 	switch path {
 	case `\` + WrongUserErrorFileName:
 		return stringReadFile(WrongUserErrorContents), dokan.ExistingFile, nil

--- a/go/kbfs/libdokan/tlf.go
+++ b/go/kbfs/libdokan/tlf.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
 )
 
@@ -263,7 +264,8 @@ func (tlf *TLF) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 		tlf.folder.handleMu.Lock()
 		fav := tlf.folder.h.ToFavorite()
 		tlf.folder.handleMu.Unlock()
-		tlf.folder.fs.log.CDebugf(ctx, "TLF Removing favorite %q", fav.Name)
+		tlf.folder.fs.vlog.CLogf(
+			ctx, libkb.VLog1, "TLF Removing favorite %q", fav.Name)
 		defer func() {
 			tlf.folder.reportErr(ctx, libkbfs.WriteMode, err)
 		}()

--- a/go/kbfs/libfuse/debug.go
+++ b/go/kbfs/libfuse/debug.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 )
 
@@ -30,5 +31,23 @@ func MakeFuseDebugFn(
 			return
 		}
 		log.Debug("%s", str)
+	}
+}
+
+// MakeFuseVDebugFn returns a function that logs its argument to the
+// given vlog at level 1, suitable to assign to fuse.Debug.
+func MakeFuseVDebugFn(
+	vlog *libkb.VDebugLog, superVerbose bool) func(msg interface{}) {
+	return func(msg interface{}) {
+		str := fmt.Sprintf("%s", msg)
+		// If superVerbose is not set, filter out Statfs and
+		// Access messages, since they're spammy on OS X.
+		//
+		// Ideally, bazil would let us filter this better, and
+		// also pass in the ctx.
+		if !superVerbose && statfsOrAccessRegexp.MatchString(str) {
+			return
+		}
+		vlog.Log(libkb.VLog1, "%s", str)
 	}
 }

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -25,6 +25,7 @@ import (
 	"github.com/keybase/client/go/kbfs/sysutils"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
 )
 
@@ -84,7 +85,7 @@ func (f *Folder) name() tlf.CanonicalName {
 func (f *Folder) processError(ctx context.Context,
 	mode libkbfs.ErrorModeType, err error) error {
 	if err == nil {
-		f.fs.errLog.CDebugf(ctx, "Request complete")
+		f.fs.errVlog.CLogf(ctx, libkb.VLog1, "Request complete")
 		return nil
 	}
 
@@ -490,7 +491,7 @@ func (d *Dir) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 		ctx, "Dir.Attr", d.node.GetBasename())
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir Attr")
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Attr")
 	defer func() { err = d.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -541,7 +542,7 @@ func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir Lookup %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Lookup %s", req.Name)
 	defer func() { err = d.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -624,7 +625,7 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir Create %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", req.Name)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	isExec := (req.Mode.Perm() & 0100) != 0
@@ -660,7 +661,7 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir Mkdir %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", req.Name)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -691,8 +692,8 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 			req.NewName, req.Target))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir Symlink %s -> %s",
-		req.NewName, req.Target)
+	d.folder.fs.vlog.CLogf(
+		ctx, libkb.VLog1, "Dir Symlink %s -> %s", req.NewName, req.Target)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -723,8 +724,8 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 			req.OldName, req.NewName))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir Rename %s -> %s",
-		req.OldName, req.NewName)
+	d.folder.fs.vlog.CLogf(
+		ctx, libkb.VLog1, "Dir Rename %s -> %s", req.OldName, req.NewName)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	var realNewDir *Dir
@@ -775,7 +776,7 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
 		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir Remove %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Remove %s", req.Name)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -806,7 +807,7 @@ func (d *Dir) ReadDirAll(ctx context.Context) (res []fuse.Dirent, err error) {
 		ctx, "Dir.ReadDirAll", d.node.GetBasename())
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir ReadDirAll")
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir ReadDirAll")
 	defer func() { err = d.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	children, err := d.folder.fs.config.KBFSOps().GetDirChildren(ctx, d.node)
@@ -834,7 +835,7 @@ func (d *Dir) ReadDirAll(ctx context.Context) (res []fuse.Dirent, err error) {
 		}
 		res = append(res, fde)
 	}
-	d.folder.fs.log.CDebugf(ctx, "Returning %d entries", len(res))
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Returning %d entries", len(res))
 	return res, nil
 }
 
@@ -850,7 +851,7 @@ func (d *Dir) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.
 		fmt.Sprintf("%s %s", d.node.GetBasename(), valid))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir SetAttr %s", valid)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir SetAttr %s", valid)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	if valid.Mode() {
@@ -859,8 +860,9 @@ func (d *Dir) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.
 		// applications like unzip.  Instead ignore it, print a debug
 		// message, and advertise this behavior on the
 		// "understand_kbfs" doc online.
-		d.folder.fs.log.CDebugf(ctx, "Ignoring unsupported attempt to set "+
-			"the mode on a directory")
+		d.folder.fs.vlog.CLogf(
+			ctx, libkb.VLog1, "Ignoring unsupported attempt to set "+
+				"the mode on a directory")
 		valid &^= fuse.SetattrMode
 	}
 
@@ -885,8 +887,9 @@ func (d *Dir) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.
 		// some programs like mv.  Instead ignore it, print a debug
 		// message, and advertise this behavior on the
 		// "understand_kbfs" doc online.
-		d.folder.fs.log.CDebugf(ctx, "Ignoring unsupported attempt to set "+
-			"the UID/GID on a directory")
+		d.folder.fs.vlog.CLogf(
+			ctx, libkb.VLog1, "Ignoring unsupported attempt to set "+
+				"the UID/GID on a directory")
 		valid &^= fuse.SetattrUid | fuse.SetattrGid
 	}
 
@@ -907,7 +910,7 @@ func (d *Dir) Fsync(ctx context.Context, req *fuse.FsyncRequest) (err error) {
 		ctx, "Dir.Fsync", d.node.GetBasename())
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.log.CDebugf(ctx, "Dir Fsync")
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Fsync")
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go

--- a/go/kbfs/libfuse/file.go
+++ b/go/kbfs/libfuse/file.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
 )
 
@@ -90,7 +91,7 @@ func (f *File) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 		ctx, "File.Attr", f.node.GetBasename())
 	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	f.folder.fs.log.CDebugf(ctx, "File Attr")
+	f.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "File Attr")
 	defer func() { err = f.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	if reqID, ok := ctx.Value(CtxIDKey).(string); ok {
@@ -193,7 +194,7 @@ func (f *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) (err error) {
 		ctx, "File.Fsync", f.node.GetBasename())
 	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	f.folder.fs.log.CDebugf(ctx, "File Fsync")
+	f.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "File Fsync")
 	defer func() { err = f.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -219,7 +220,7 @@ func (f *File) Read(ctx context.Context, req *fuse.ReadRequest,
 		fmt.Sprintf("%s off=%d sz=%d", f.node.GetBasename(), off, sz))
 	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	f.folder.fs.log.CDebugf(ctx, "File Read off=%d sz=%d", off, sz)
+	f.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "File Read off=%d sz=%d", off, sz)
 	defer func() { err = f.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	n, err := f.folder.fs.config.KBFSOps().Read(
@@ -241,7 +242,7 @@ func (f *File) Write(ctx context.Context, req *fuse.WriteRequest,
 		fmt.Sprintf("%s sz=%d", f.node.GetBasename(), sz))
 	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	f.folder.fs.log.CDebugf(ctx, "File Write sz=%d ", sz)
+	f.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "File Write sz=%d ", sz)
 	defer func() { err = f.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	f.eiCache.destroy()
@@ -263,7 +264,7 @@ func (f *File) Setattr(ctx context.Context, req *fuse.SetattrRequest,
 		fmt.Sprintf("%s %s", f.node.GetBasename(), valid))
 	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	f.folder.fs.log.CDebugf(ctx, "File SetAttr %s", valid)
+	f.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "File SetAttr %s", valid)
 	defer func() { err = f.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	f.eiCache.destroy()
@@ -302,8 +303,9 @@ func (f *File) Setattr(ctx context.Context, req *fuse.SetattrRequest,
 		// programs like mv.  Instead ignore it, print a debug
 		// message, and advertise this behavior on the
 		// "understand_kbfs" doc online.
-		f.folder.fs.log.CDebugf(ctx, "Ignoring unsupported attempt to set "+
-			"the UID/GID on a file")
+		f.folder.fs.vlog.CLogf(
+			ctx, libkb.VLog1, "Ignoring unsupported attempt to set "+
+				"the UID/GID on a file")
 		valid &^= fuse.SetattrUid | fuse.SetattrGid
 	}
 

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -47,12 +47,16 @@ func makeFS(t testing.TB, ctx context.Context, config *libkbfs.ConfigLocal) (
 	fuse.Debug = MakeFuseDebugFn(debugLog, false /* superVerbose */)
 
 	// TODO duplicates main() in kbfsfuse/main.go too much
+	quLog := config.MakeLogger(libkbfs.QuotaUsageLogModule("FSTest"))
 	filesys := &FS{
 		config:        config,
 		log:           log,
+		vlog:          config.MakeVLogger(log),
 		errLog:        log,
+		errVlog:       config.MakeVLogger(log),
 		notifications: libfs.NewFSNotifications(log),
-		quotaUsage:    libkbfs.NewEventuallyConsistentQuotaUsage(config, "FSTest"),
+		quotaUsage: libkbfs.NewEventuallyConsistentQuotaUsage(
+			config, quLog, config.MakeVLogger(quLog)),
 	}
 	filesys.root.private = &FolderList{
 		fs:      filesys,

--- a/go/kbfs/libfuse/start.go
+++ b/go/kbfs/libfuse/start.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 
+	"bazil.org/fuse"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libgit"
 	"github.com/keybase/client/go/kbfs/libkbfs"
@@ -138,6 +139,12 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 		return libfs.InitError(err.Error())
 	}
 	defer libkbfs.Shutdown()
+
+	if options.KbfsParams.Debug {
+		fuseLog := config.MakeLogger("FUSE").CloneWithAddedDepth(1)
+		fuse.Debug = MakeFuseVDebugFn(
+			config.MakeVLogger(fuseLog), false /* superVerbose */)
+	}
 
 	// Report "startup successful" to the supervisor (currently just systemd on
 	// Linux). This isn't necessary for correctness, but it allows commands

--- a/go/kbfs/libfuse/symlink.go
+++ b/go/kbfs/libfuse/symlink.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
 )
 
@@ -35,7 +36,7 @@ var _ fs.Node = (*Symlink)(nil)
 
 // Attr implements the fs.Node interface for Symlink
 func (s *Symlink) Attr(ctx context.Context, a *fuse.Attr) (err error) {
-	s.parent.folder.fs.log.CDebugf(ctx, "Symlink Attr")
+	s.parent.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Symlink Attr")
 	defer func() { err = s.parent.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	_, de, err := s.parent.folder.fs.config.KBFSOps().Lookup(ctx, s.parent.node, s.name)
@@ -56,7 +57,7 @@ var _ fs.NodeReadlinker = (*Symlink)(nil)
 
 // Readlink implements the fs.NodeReadlinker interface for Symlink
 func (s *Symlink) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (link string, err error) {
-	s.parent.folder.fs.log.CDebugf(ctx, "Symlink Readlink")
+	s.parent.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Symlink Readlink")
 	defer func() { err = s.parent.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	_, de, err := s.parent.folder.fs.config.KBFSOps().Lookup(ctx, s.parent.node, s.name)

--- a/go/kbfs/libfuse/tlf.go
+++ b/go/kbfs/libfuse/tlf.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"golang.org/x/net/context"
 )
@@ -63,6 +64,10 @@ func (tlf *TLF) clearStoredDir() {
 
 func (tlf *TLF) log() logger.Logger {
 	return tlf.folder.fs.log
+}
+
+func (tlf *TLF) vlog() *libkb.VDebugLog {
+	return tlf.folder.fs.vlog
 }
 
 func (tlf *TLF) loadDirHelper(
@@ -158,8 +163,8 @@ func (tlf *TLF) Attr(ctx context.Context, a *fuse.Attr) error {
 	dir := tlf.getStoredDir()
 	a.Inode = tlf.inode
 	if dir == nil {
-		tlf.log().CDebugf(
-			ctx, "Faking Attr for TLF %s", tlf.folder.name())
+		tlf.vlog().CLogf(
+			ctx, libkb.VLog1, "Faking Attr for TLF %s", tlf.folder.name())
 		// Have a low non-zero value for Valid to avoid being
 		// swamped with requests, while still not showing
 		// stale data for too long if we end up loading the
@@ -191,8 +196,8 @@ func (tlf *TLF) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.
 	if tlfLoadAvoidingLookupNames[req.Name] {
 		dir := tlf.getStoredDir()
 		if dir == nil {
-			tlf.log().CDebugf(
-				ctx, "Avoiding TLF loading for name %s", req.Name)
+			tlf.vlog().CLogf(
+				ctx, libkb.VLog1, "Avoiding TLF loading for name %s", req.Name)
 			return nil, fuse.ENOENT
 		}
 		return dir.Lookup(ctx, req, resp)

--- a/go/kbfs/libgit/init.go
+++ b/go/kbfs/libgit/init.go
@@ -78,7 +78,8 @@ func Params(kbCtx libkbfs.Context,
 // The config should be shutdown when it is done being used.
 func Init(ctx context.Context, gitKBFSParams libkbfs.InitParams,
 	kbCtx libkbfs.Context, keybaseServiceCn libkbfs.KeybaseServiceCn,
-	defaultLogPath string) (context.Context, libkbfs.Config, error) {
+	defaultLogPath string, vlogLevel string) (
+	context.Context, libkbfs.Config, error) {
 	log, err := libkbfs.InitLogWithPrefix(
 		gitKBFSParams, kbCtx, "git", defaultLogPath)
 	if err != nil {
@@ -100,6 +101,7 @@ func Init(ctx context.Context, gitKBFSParams libkbfs.InitParams,
 	if err != nil {
 		return ctx, nil, err
 	}
+	config.SetVLogLevel(vlogLevel)
 
 	// Make any blocks written by via this config charged to the git
 	// quota.
@@ -162,7 +164,8 @@ func getNewConfig(
 	params.LogFileConfig.Path = ""
 
 	newCtx, gitConfig, err = Init(
-		ctx, params, kbCtx, keybaseServicePassthrough{config}, "")
+		ctx, params, kbCtx, keybaseServicePassthrough{config}, "",
+		config.VLogLevel())
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/go/kbfs/libkbfs/block_journal_test.go
+++ b/go/kbfs/libkbfs/block_journal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
@@ -119,7 +120,7 @@ func setupBlockJournalTest(t *testing.T) (
 		}
 	}()
 
-	j, err = makeBlockJournal(ctx, codec, tempdir, log)
+	j, err = makeBlockJournal(ctx, codec, tempdir, log, libkb.NewVDebugLog(log))
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), j.length())
 
@@ -212,7 +213,7 @@ func TestBlockJournalBasic(t *testing.T) {
 	// Shutdown and restart.
 	err := j.checkInSyncForTest()
 	require.NoError(t, err)
-	j, err = makeBlockJournal(ctx, j.codec, tempdir, j.log)
+	j, err = makeBlockJournal(ctx, j.codec, tempdir, j.log, j.vlog)
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(2), j.length())

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -161,10 +161,11 @@ func newBlockRetrievalQueue(
 		throttledWorkCh = NewInfiniteChannelWrapper()
 	}
 
+	log := config.MakeLogger("")
 	q := &blockRetrievalQueue{
 		config:           config,
-		log:              config.MakeLogger(""),
-		vlog:             config.MakeVLogger(""),
+		log:              log,
+		vlog:             config.MakeVLogger(log),
 		ptrs:             make(map[blockPtrLookup]*blockRetrieval),
 		heap:             &blockRetrievalHeap{},
 		workerCh:         NewInfiniteChannelWrapper(),
@@ -349,10 +350,10 @@ func (brq *blockRetrievalQueue) PutInCaches(ctx context.Context,
 	case data.NoSuchBlockError:
 		// TODO: Add the block to the DBC. This is complicated because we
 		// need the serverHalf.
-		brq.vlog.CLogf(ctx, libkb.VLog1,
+		brq.vlog.CLogf(ctx, libkb.VLog2,
 			"Block %s missing for disk block cache metadata update", ptr.ID)
 	default:
-		brq.vlog.CLogf(ctx, libkb.VLog1, "Error updating metadata: %+v", err)
+		brq.vlog.CLogf(ctx, libkb.VLog2, "Error updating metadata: %+v", err)
 	}
 	// All disk cache errors are fatal
 	return err
@@ -411,7 +412,7 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 func (brq *blockRetrievalQueue) request(ctx context.Context,
 	priority int, kmd libkey.KeyMetadata, ptr data.BlockPointer, block data.Block,
 	lifetime data.BlockCacheLifetime, action BlockRequestAction) <-chan error {
-	brq.vlog.CLogf(ctx, libkb.VLog1,
+	brq.vlog.CLogf(ctx, libkb.VLog2,
 		"Request of %v, action=%s, priority=%d", ptr, action, priority)
 
 	// Only continue if we haven't been shut down
@@ -438,7 +439,7 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	if err == nil {
 		if action != BlockRequestSolo {
 			brq.vlog.CLogf(
-				ctx, libkb.VLog1, "Found %v in caches: %s", ptr, prefetchStatus)
+				ctx, libkb.VLog2, "Found %v in caches: %s", ptr, prefetchStatus)
 		}
 		if action.PrefetchTracked() {
 			brq.Prefetcher().ProcessBlockForPrefetch(ctx, ptr, block, kmd,
@@ -537,7 +538,7 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	}
 	// Update the action if needed.
 	brq.vlog.CLogf(
-		ctx, libkb.VLog1, "Combining actions %d and %d", action, br.action)
+		ctx, libkb.VLog2, "Combining actions %d and %d", action, br.action)
 	br.action = action.Combine(br.action)
 	brq.vlog.CLogf(ctx, libkb.VLog2, "Got action %d", br.action)
 	return ch

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -16,6 +16,7 @@ import (
 	libkeytest "github.com/keybase/client/go/kbfs/libkey/test"
 	"github.com/keybase/client/go/kbfs/test/clocktest"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -36,7 +37,7 @@ func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter,
 	dbc DiskBlockCache) *testBlockRetrievalConfig {
 	return &testBlockRetrievalConfig{
 		newTestCodecGetter(),
-		newTestLogMakerWithVDebug(t, "vlog2"),
+		newTestLogMakerWithVDebug(t, libkb.VLog2String),
 		data.NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity(NewInitModeFromType(InitDefault))),
 		bg,
 		newTestDiskBlockCacheGetter(t, dbc),

--- a/go/kbfs/libkbfs/chat_rpc.go
+++ b/go/kbfs/libkbfs/chat_rpc.go
@@ -39,6 +39,7 @@ const (
 type ChatRPC struct {
 	config   Config
 	log      logger.Logger
+	vlog     *libkb.VDebugLog
 	deferLog logger.Logger
 	client   chat1.LocalInterface
 
@@ -56,6 +57,7 @@ func NewChatRPC(config Config, kbCtx Context) *ChatRPC {
 	deferLog := log.CloneWithAddedDepth(1)
 	c := &ChatRPC{
 		log:      log,
+		vlog:     config.MakeVLogger(log),
 		deferLog: deferLog,
 		config:   config,
 		convCBs:  make(map[string][]ChatChannelNewMessageCB),
@@ -305,7 +307,8 @@ func (c *ChatRPC) SendTextMessage(
 		return nil
 	}
 
-	c.log.CDebugf(ctx, "Writing self-write message to %s", selfConvID)
+	c.vlog.CLogf(
+		ctx, libkb.VLog1, "Writing self-write message to %s", selfConvID)
 
 	session, err := c.config.KBPKI().GetCurrentSession(ctx)
 	if err != nil {
@@ -558,7 +561,9 @@ func (c *ChatRPC) ReadChannel(
 				return nil, nil, err
 			}
 			if msgType != chat1.MessageType_TEXT {
-				c.log.CDebugf(ctx, "Ignoring unexpected msg type: %d", msgType)
+				c.vlog.CLogf(
+					ctx, libkb.VLog1, "Ignoring unexpected msg type: %d",
+					msgType)
 				continue
 			}
 			messages = append(messages, msgBody.Text().Body)
@@ -651,7 +656,8 @@ func (c *ChatRPC) setLastWrittenConvID(ctx context.Context, body string) error {
 	if err != nil {
 		return err
 	}
-	c.log.CDebugf(ctx, "Last self-written conversation is %s", msg.ConvID)
+	c.vlog.CLogf(
+		ctx, libkb.VLog1, "Last self-written conversation is %s", msg.ConvID)
 	c.lastWrittenConvID = msg.ConvID
 	return nil
 }

--- a/go/kbfs/libkbfs/config_mock_test.go
+++ b/go/kbfs/libkbfs/config_mock_test.go
@@ -125,7 +125,9 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	config.SetClock(config.mockClock)
 	config.mockRekeyQueue = NewMockRekeyQueue(c)
 	config.SetRekeyQueue(config.mockRekeyQueue)
-	config.SetUserHistory(kbfsedits.NewUserHistory(config.MakeLogger("HIS")))
+	uhLog := config.MakeLogger("HIS")
+	config.SetUserHistory(kbfsedits.NewUserHistory(
+		uhLog, config.MakeVLogger(uhLog)))
 	config.observer = &FakeObserver{}
 	config.ctr = ctr
 	// turn off background flushing by default during tests

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -120,8 +120,8 @@ func NewConflictResolver(
 		branchSuffix = " " + string(fbo.branch())
 	}
 	tlfStringFull := fbo.id().String()
-	log := config.MakeLogger(fmt.Sprintf("CR %s%s", tlfStringFull[:8],
-		branchSuffix))
+	log := config.MakeLogger(
+		fmt.Sprintf("CR %s%s", tlfStringFull[:8], branchSuffix))
 
 	cr := &ConflictResolver{
 		config: config,
@@ -131,6 +131,7 @@ func NewConflictResolver(
 			folderBranch: fbo.folderBranch,
 			blocks:       &fbo.blocks,
 			log:          log,
+			vlog:         config.MakeVLogger(log),
 		},
 		log:              traceLogger{log},
 		deferLog:         traceLogger{log.CloneWithAddedDepth(1)},

--- a/go/kbfs/libkbfs/fetch_decider_test.go
+++ b/go/kbfs/libkbfs/fetch_decider_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/test/clocktest"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -22,7 +23,8 @@ func TestFetchDecider(t *testing.T) {
 
 	log := logger.NewTestLogger(t)
 	clock := clocktest.NewTestClockNow()
-	fd := newFetchDecider(log, fetcher, "", "", &testClockGetter{clock})
+	fd := newFetchDecider(
+		log, libkb.NewVDebugLog(log), fetcher, "", "", &testClockGetter{clock})
 	ctx, cancel := context.WithTimeout(
 		context.Background(), individualTestTimeout)
 	defer cancel()

--- a/go/kbfs/libkbfs/folder_block_manager_test.go
+++ b/go/kbfs/libkbfs/folder_block_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/client/go/kbfs/test/clocktest"
 	"github.com/keybase/client/go/kbfs/tlf"
 	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -728,7 +729,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
-	config.vdebugSetting = "vlog2"
+	config.SetVLogLevel(libkb.VLog2String)
 
 	// Test the pointer-constraint logic.
 	config.SetMode(modeTestWithMaxPtrsLimit{config.Mode()})

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -319,8 +319,12 @@ type folderBranchOps struct {
 	status *folderBranchStatusKeeper
 
 	// How to log
-	log      traceLogger
-	deferLog traceLogger
+	log        traceLogger
+	deferLog   traceLogger
+	defer2Log  traceLogger
+	vlog       *libkb.VDebugLog
+	deferVlog  *libkb.VDebugLog
+	defer2Vlog *libkb.VDebugLog
 
 	// Closed on shutdown
 	shutdownChan chan struct{}
@@ -420,6 +424,9 @@ func newFolderBranchOps(
 	// unique enough for a local node.
 	log := config.MakeLogger(fmt.Sprintf("FBO %s%s", tlfStringFull[:8],
 		branchSuffix))
+	deferLog := log.CloneWithAddedDepth(1)
+	defer2Log := log.CloneWithAddedDepth(2)
+
 	// But print it out once in full, just in case.
 	log.CInfof(ctx, "Created new folder-branch for %s", tlfStringFull)
 
@@ -451,6 +458,7 @@ func newFolderBranchOps(
 		blocks: folderBlockOps{
 			config:        config,
 			log:           log,
+			vlog:          config.MakeVLogger(log),
 			folderBranch:  fb,
 			observers:     observers,
 			forceSyncChan: forceSyncChan,
@@ -465,7 +473,11 @@ func newFolderBranchOps(
 		},
 		nodeCache:                 nodeCache,
 		log:                       traceLogger{log},
-		deferLog:                  traceLogger{log.CloneWithAddedDepth(1)},
+		deferLog:                  traceLogger{deferLog},
+		defer2Log:                 traceLogger{defer2Log},
+		vlog:                      config.MakeVLogger(log),
+		deferVlog:                 config.MakeVLogger(deferLog),
+		defer2Vlog:                config.MakeVLogger(defer2Log),
 		shutdownChan:              make(chan struct{}),
 		updatePauseChan:           make(chan (<-chan struct{})),
 		forceSyncChan:             forceSyncChan,
@@ -479,6 +491,7 @@ func newFolderBranchOps(
 		folderBranch: fb,
 		blocks:       &fbo.blocks,
 		log:          log,
+		vlog:         config.MakeVLogger(log),
 	}
 	fbo.cr = NewConflictResolver(config, fbo)
 	fbo.fbm = newFolderBlockManager(appStateUpdater, config, fb, bType, fbo)
@@ -901,15 +914,50 @@ func (fbo *folderBranchOps) syncOneNode(
 	}
 }
 
+func (fbo *folderBranchOps) startOp(
+	ctx context.Context, fs string, args ...interface{}) (
+	time.Time, *time.Timer) {
+	now := fbo.config.Clock().Now()
+	// Immediately log with vlog, and if the operation takes more than
+	// one second, log via the normal logger too.
+	fbo.deferVlog.CLogf(ctx, libkb.VLog1, fs, args...)
+	timer := time.AfterFunc(1*time.Second, func() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			newArgs := make([]interface{}, len(args)+1)
+			newArgs[0] = now
+			copy(newArgs[1:], args)
+			fbo.deferLog.CDebugf(
+				ctx, "(Long operation, started=%s) "+fs, newArgs...)
+		}
+	})
+	return now, timer
+}
+
+func (fbo *folderBranchOps) endOp(
+	ctx context.Context, startTime time.Time, timer *time.Timer, fs string,
+	args ...interface{}) {
+	timer.Stop()
+	d := fbo.config.Clock().Now().Sub(startTime)
+	newArgs := make([]interface{}, len(args)+1)
+	newArgs[0] = d
+	copy(newArgs[1:], args)
+	fbo.defer2Log.CDebugf(ctx, "[duration=%s] "+fs, newArgs...)
+}
+
 // doPartialSync iterates through the paths, deep-syncing them and
 // also syncing their parent directories up to the root node.
 func (fbo *folderBranchOps) doPartialSync(
 	ctx context.Context, syncConfig keybase1.FolderSyncConfig,
 	latestMerged ImmutableRootMetadata) (err error) {
-	fbo.log.CDebugf(
+	startTime, timer := fbo.startOp(
 		ctx, "Starting partial sync at revision %d", latestMerged.Revision())
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Partial sync done: %+v", err)
+		fbo.endOp(
+			ctx, startTime, timer, "Partial sync at revision %d done: %+v",
+			latestMerged.Revision(), err)
 	}()
 
 	var parentSyncAction, pathSyncAction BlockRequestAction
@@ -955,7 +1003,7 @@ pathLoop:
 			return ctx.Err()
 		default:
 		}
-		fbo.log.CDebugf(ctx, "Partially-syncing %s", p)
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Partially-syncing %s", p)
 
 		parentPath, syncedElem := stdpath.Split(p)
 		parents := strings.Split(strings.TrimSuffix(parentPath, "/"), "/")
@@ -969,7 +1017,8 @@ pathLoop:
 				ctx, lState, latestMerged.ReadOnly(), currNode, parent)
 			switch errors.Cause(err).(type) {
 			case idutil.NoSuchNameError:
-				fbo.log.CDebugf(ctx, "Synced path %s doesn't exist yet", p)
+				fbo.vlog.CLogf(
+					ctx, libkb.VLog1, "Synced path %s doesn't exist yet", p)
 				continue pathLoop
 			case nil:
 			default:
@@ -991,7 +1040,8 @@ pathLoop:
 			ctx, lState, latestMerged.ReadOnly(), currNode, syncedElem)
 		switch errors.Cause(err).(type) {
 		case idutil.NoSuchNameError:
-			fbo.log.CDebugf(ctx, "Synced element %s doesn't exist yet", p)
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "Synced element %s doesn't exist yet", p)
 			continue pathLoop
 		case nil:
 		default:
@@ -1014,7 +1064,7 @@ pathLoop:
 	for p, ch := range chs {
 		select {
 		case <-ch:
-			fbo.log.CDebugf(ctx, "Prefetch for %s complete", p)
+			fbo.vlog.CLogf(ctx, libkb.VLog1, "Prefetch for %s complete", p)
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -1047,8 +1097,9 @@ func (fbo *folderBranchOps) kickOffPartialSync(
 		fbo.headLock.Lock(lState)
 		defer fbo.headLock.Unlock(lState)
 		if rmd.Revision() != fbo.latestMergedRevision {
-			fbo.log.CDebugf(
-				partialSyncCtx, "Latest merged revision is now %d, not %d; "+
+			fbo.vlog.CLogf(
+				partialSyncCtx, libkb.VLog1,
+				"Latest merged revision is now %d, not %d; "+
 					"aborting partial sync", fbo.latestMergedRevision,
 				rmd.Revision())
 			return nil
@@ -1186,11 +1237,14 @@ func (fbo *folderBranchOps) markRecursive(
 func (fbo *folderBranchOps) doPartialMarkAndSweep(
 	ctx context.Context, syncConfig keybase1.FolderSyncConfig,
 	latestMerged ImmutableRootMetadata) (err error) {
-	fbo.log.CDebugf(
+	startTime, timer := fbo.startOp(
 		ctx, "Starting partial mark-and-sweep at revision %d",
 		latestMerged.Revision())
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Partial mark-and-sweep done: %+v", err)
+		fbo.endOp(
+			ctx, startTime, timer,
+			"Partial mark-and-sweep at revision %d done: %+v",
+			latestMerged.Revision(), err)
 	}()
 
 	if syncConfig.Mode != keybase1.FolderSyncMode_PARTIAL {
@@ -1220,7 +1274,7 @@ pathLoop:
 			return ctx.Err()
 		default:
 		}
-		fbo.log.CDebugf(ctx, "Marking %s", p)
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Marking %s", p)
 
 		// Mark the parent directories.
 		parentPath, syncedElem := stdpath.Split(p)
@@ -1234,7 +1288,8 @@ pathLoop:
 			currNode, _, err = fbo.Lookup(ctx, currNode, parent)
 			switch errors.Cause(err).(type) {
 			case idutil.NoSuchNameError:
-				fbo.log.CDebugf(ctx, "Synced path %s doesn't exist yet", p)
+				fbo.vlog.CLogf(
+					ctx, libkb.VLog1, "Synced path %s doesn't exist yet", p)
 				continue pathLoop
 			case nil:
 			default:
@@ -1252,7 +1307,8 @@ pathLoop:
 		currNode, _, err = fbo.Lookup(ctx, currNode, syncedElem)
 		switch errors.Cause(err).(type) {
 		case idutil.NoSuchNameError:
-			fbo.log.CDebugf(ctx, "Synced element %s doesn't exist yet", p)
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "Synced element %s doesn't exist yet", p)
 			continue pathLoop
 		case nil:
 		default:
@@ -1292,8 +1348,9 @@ func (fbo *folderBranchOps) kickOffPartialMarkAndSweep(
 		fbo.headLock.Lock(lState)
 		defer fbo.headLock.Unlock(lState)
 		if rmd.Revision() != fbo.latestMergedRevision {
-			fbo.log.CDebugf(
-				partialMSCtx, "Latest merged changed is now %d, not %d; "+
+			fbo.vlog.CLogf(
+				partialMSCtx, libkb.VLog1,
+				"Latest merged changed is now %d, not %d; "+
 					"aborting partial mark-and-sweep", fbo.latestMergedRevision,
 				rmd.Revision())
 			return nil
@@ -1335,8 +1392,9 @@ func (fbo *folderBranchOps) kickOffPartialMarkAndSweepIfNeeded(
 	// Skip mark-and-sweep if we were woken up by the timer and
 	// the revision hasn't changed since last time.
 	if !triggered && md.Revision() == lastMDRev {
-		fbo.log.CDebugf(
-			ctx, "Revision hasn't changed since last mark-and-sweep")
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1,
+			"Revision hasn't changed since last mark-and-sweep")
 		return nil, nil, 0, nil
 	}
 
@@ -1393,7 +1451,8 @@ func (fbo *folderBranchOps) partialMarkAndSweepLoop(trigger <-chan struct{}) {
 		triggered := false
 		select {
 		case <-currMarkAndSweepCtxDone:
-			fbo.log.CDebugf(ctx, "Mark-and-sweep finished; resetting timer")
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "Mark-and-sweep finished; resetting timer")
 			timer = time.NewTimer(markAndSweepPeriod)
 			currMarkAndSweepCtxDone = nil
 			continue
@@ -1402,12 +1461,12 @@ func (fbo *folderBranchOps) partialMarkAndSweepLoop(trigger <-chan struct{}) {
 				fbo.log.CDebugf(ctx, "Mark-and-sweep is shutting down.")
 				return
 			}
-			fbo.log.CDebugf(ctx, "New mark-and-sweep triggered")
+			fbo.vlog.CLogf(ctx, libkb.VLog1, "New mark-and-sweep triggered")
 			triggered = true
 		case <-timer.C:
-			fbo.log.CDebugf(ctx, "Mark-and-sweep timer fired")
+			fbo.vlog.CLogf(ctx, libkb.VLog1, "Mark-and-sweep timer fired")
 		case <-fbo.shutdownChan:
-			fbo.log.CDebugf(ctx, "Shutdown")
+			fbo.vlog.CLogf(ctx, libkb.VLog1, "Shutdown")
 			return
 		}
 
@@ -1424,8 +1483,9 @@ func (fbo *folderBranchOps) partialMarkAndSweepLoop(trigger <-chan struct{}) {
 			return
 		}
 		if rev == 0 {
-			fbo.log.CDebugf(
-				ctx, "No mark-and-sweep was launched; resetting timer")
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1,
+				"No mark-and-sweep was launched; resetting timer")
 			timer = time.NewTimer(markAndSweepPeriod)
 			continue
 		}
@@ -1442,14 +1502,23 @@ func (fbo *folderBranchOps) kickOffRootBlockFetch(
 		data.TransientEntry, fbo.config.Mode().DefaultBlockRequestAction())
 }
 
+func (fbo *folderBranchOps) logIfErr(
+	ctx context.Context, err error, fs string, args ...interface{}) {
+	if err != nil {
+		fbo.deferLog.CDebugf(ctx, fs, args...)
+	} else {
+		fbo.deferVlog.CLogf(ctx, libkb.VLog1, fs, args...)
+	}
+}
+
 func (fbo *folderBranchOps) waitForRootBlockFetch(
 	ctx context.Context, rmd ImmutableRootMetadata,
 	fetchChan <-chan error) error {
-	fbo.log.CDebugf(ctx, "Ensuring that the latest root directory "+
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Ensuring that the latest root directory "+
 		"block for revision %d is available", rmd.Revision())
 	select {
 	case err := <-fetchChan:
-		fbo.log.CDebugf(ctx, "Root block fetch complete: +%v", err)
+		fbo.logIfErr(ctx, err, "Root block fetch complete: +%v", err)
 		return err
 	case <-ctx.Done():
 		return errors.WithStack(ctx.Err())
@@ -1479,8 +1548,9 @@ func (fbo *folderBranchOps) commitFlushedMD(
 		// `rootPtr`. When it's successfully done, commit the
 		// corresponding MD.
 		rootPtr := rmd.Data().Dir.BlockPointer
-		fbo.log.CDebugf(ctx, "Fetching root block of revision %d, ptr %v",
-			rev, rootPtr)
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1,
+			"Fetching root block of revision %d, ptr %v", rev, rootPtr)
 		rootCh := fbo.kickOffRootBlockFetch(ctx, rmd)
 		select {
 		case err := <-rootCh:
@@ -1489,14 +1559,16 @@ func (fbo *folderBranchOps) commitFlushedMD(
 				return
 			}
 		case <-updatedCh:
-			fbo.log.CDebugf(ctx, "The latest merged rev has been updated")
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "The latest merged rev has been updated")
 			return
 		case <-fbo.shutdownChan:
 			fbo.log.CDebugf(ctx, "Shutdown, canceling root block wait")
 			return
 		}
 
-		fbo.log.CDebugf(ctx, "Waiting for prefetch of revision %d, ptr %v",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Waiting for prefetch of revision %d, ptr %v",
 			rev, rootPtr)
 		waitCh, err := fbo.config.BlockOps().Prefetcher().
 			WaitChannelForBlockPrefetch(ctx, rootPtr)
@@ -1509,7 +1581,8 @@ func (fbo *folderBranchOps) commitFlushedMD(
 		select {
 		case <-waitCh:
 		case <-updatedCh:
-			fbo.log.CDebugf(ctx, "The latest merged rev has been updated")
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "The latest merged rev has been updated")
 			fbo.config.BlockOps().Prefetcher().CancelPrefetch(rootPtr)
 			return
 		case <-fbo.shutdownChan:
@@ -1523,12 +1596,14 @@ func (fbo *folderBranchOps) commitFlushedMD(
 			return
 		}
 		if prefetchStatus != FinishedPrefetch {
-			fbo.log.CDebugf(ctx, "Revision was not fully prefetched: status=%s",
-				prefetchStatus)
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1,
+				"Revision was not fully prefetched: status=%s", prefetchStatus)
 			return
 		}
 
-		fbo.log.CDebugf(ctx, "Prefetch for revision %d complete; commiting",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Prefetch for revision %d complete; commiting",
 			rev)
 	case keybase1.FolderSyncMode_PARTIAL:
 		// For partially-synced TLFs, wait for the partial sync to
@@ -2093,7 +2168,8 @@ func (fbo *folderBranchOps) getMostRecentFullyMergedMD(ctx context.Context) (
 		return ImmutableRootMetadata{}, err
 	}
 
-	fbo.log.CDebugf(ctx, "Most recent fully merged revision is %d", mergedRev)
+	fbo.vlog.CLogf(
+		ctx, libkb.VLog1, "Most recent fully merged revision is %d", mergedRev)
 	return rmd, nil
 }
 
@@ -2433,7 +2509,7 @@ func (fbo *folderBranchOps) initMDLocked(
 	// before we push anything to the servers.
 	if h, _ := fbo.getHead(
 		ctx, lState, mdNoCommit); h != (ImmutableRootMetadata{}) {
-		fbo.log.CDebugf(ctx, "Head was already set, aborting")
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Head was already set, aborting")
 		return nil
 	}
 
@@ -2535,8 +2611,9 @@ func (fbo *folderBranchOps) checkNodeForRead(
 
 	services, _ := fbo.serviceStatus.CurrentStatus()
 	if len(services) > 0 {
-		fbo.log.CDebugf(ctx, "Failing read of archived data while offline; "+
-			"failing services=%v", services)
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Failing read of archived data while offline; "+
+				"failing services=%v", services)
 		h, err := fbo.GetTLFHandle(ctx, nil)
 		if err != nil {
 			return err
@@ -2568,10 +2645,12 @@ func (fbo *folderBranchOps) checkNodeForWrite(
 // ImmutableRootMetadata, which must be retrieved from the MD server.
 func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	ctx context.Context, md ImmutableRootMetadata) (err error) {
-	fbo.log.CDebugf(ctx, "SetInitialHeadFromServer, revision=%d (%s)",
+	startTime, timer := fbo.startOp(
+		ctx, "SetInitialHeadFromServer, revision=%d (%s)",
 		md.Revision(), md.MergedStatus())
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
+		fbo.endOp(
+			ctx, startTime, timer,
 			"SetInitialHeadFromServer, revision=%d (%s) done: %+v",
 			md.Revision(), md.MergedStatus(), err)
 	}()
@@ -2585,7 +2664,8 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 		// occur.  Use a fresh context, in case `ctx` is canceled by
 		// the caller before we complete.
 		prefetchCtx := fbo.ctxWithFBOID(context.Background())
-		fbo.log.CDebugf(ctx,
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1,
 			"Prefetching root block with a new context: FBOID=%s",
 			prefetchCtx.Value(CtxFBOIDKey))
 		latestRootBlockFetch = fbo.kickOffRootBlockFetch(ctx, md)
@@ -2608,8 +2688,10 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	// head) if head is already set.
 	head, headStatus := fbo.getHead(ctx, lState, mdNoCommit)
 	if headStatus == headTrusted && head != (ImmutableRootMetadata{}) && head.mdID == md.mdID {
-		fbo.log.CDebugf(ctx, "Head MD already set to revision %d (%s), no "+
-			"need to set initial head again", md.Revision(), md.MergedStatus())
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Head MD already set to revision %d (%s), no "+
+				"need to set initial head again",
+			md.Revision(), md.MergedStatus())
 		return nil
 	}
 
@@ -2691,10 +2773,10 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 // object and sets the head to that. This is trusted.
 func (fbo *folderBranchOps) SetInitialHeadToNew(
 	ctx context.Context, id tlf.ID, handle *tlfhandle.Handle) (err error) {
-	fbo.log.CDebugf(ctx, "SetInitialHeadToNew %s", id)
+	startTime, timer := fbo.startOp(ctx, "SetInitialHeadToNew %s", id)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "SetInitialHeadToNew %s done: %+v",
-			id, err)
+		fbo.endOp(
+			ctx, startTime, timer, "SetInitialHeadToNew %s done: %+v", id, err)
 	}()
 
 	rmd, err := makeInitialRootMetadata(
@@ -2739,9 +2821,10 @@ func getNodeIDStr(n Node) string {
 
 func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	node Node, ei data.EntryInfo, handle *tlfhandle.Handle, err error) {
-	fbo.log.CDebugf(ctx, "getRootNode")
+	startTime, timer := fbo.startOp(ctx, "getRootNode")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "getRootNode done: %s %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "getRootNode done: %s %+v",
 			getNodeIDStr(node), err)
 	}()
 
@@ -2805,7 +2888,7 @@ func (fbo *folderBranchOps) getDirChildren(ctx context.Context, dir Node) (
 	children map[string]data.EntryInfo, err error) {
 	fs := dir.GetFS(ctx)
 	if fs != nil {
-		fbo.log.CDebugf(ctx, "Getting children using an FS")
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Getting children using an FS")
 		fis, err := fs.ReadDir("")
 		if err != nil {
 			return nil, err
@@ -2834,7 +2917,7 @@ func (fbo *folderBranchOps) getDirChildren(ctx context.Context, dir Node) (
 	}
 
 	if fbo.nodeCache.IsUnlinked(dir) {
-		fbo.log.CDebugf(ctx, "Returning an empty children set for "+
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Returning an empty children set for "+
 			"unlinked directory %v", dirPath.TailPointer())
 		return nil, nil
 	}
@@ -2888,10 +2971,11 @@ func (fbo *folderBranchOps) transformReadError(
 
 func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 	children map[string]data.EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "GetDirChildren %s", getNodeIDStr(dir))
+	startTime, timer := fbo.startOp(ctx, "GetDirChildren %s", getNodeIDStr(dir))
 	defer func() {
 		err = fbo.transformReadError(ctx, dir, err)
-		fbo.deferLog.CDebugf(ctx, "GetDirChildren %s done, %d entries: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "GetDirChildren %s done, %d entries: %+v",
 			getNodeIDStr(dir), len(children), err)
 	}()
 
@@ -2916,7 +3000,8 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 			return nil, nil
 		}
 
-		fbo.log.CDebugf(ctx, "Retrying GetDirChildren of an empty directory")
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Retrying GetDirChildren of an empty directory")
 		err = runUnlessCanceled(ctx, func() error {
 			retChildren, err = fbo.getDirChildren(ctx, dir)
 			return err
@@ -2943,7 +3028,7 @@ func (fbo *folderBranchOps) makeFakeEntryID(
 func (fbo *folderBranchOps) makeFakeDirEntry(
 	ctx context.Context, dir Node, name string) (
 	de data.DirEntry, err error) {
-	fbo.log.CDebugf(ctx, "Faking directory entry for %s", name)
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Faking directory entry for %s", name)
 	id, err := fbo.makeFakeEntryID(ctx, dir, name)
 	if err != nil {
 		return data.DirEntry{}, err
@@ -2969,7 +3054,7 @@ func (fbo *folderBranchOps) makeFakeDirEntry(
 
 func (fbo *folderBranchOps) makeFakeFileEntry(
 	ctx context.Context, dir Node, name string) (de data.DirEntry, err error) {
-	fbo.log.CDebugf(ctx, "Faking file entry for %s", name)
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Faking file entry for %s", name)
 	id, err := fbo.makeFakeEntryID(ctx, dir, name)
 	if err != nil {
 		return data.DirEntry{}, err
@@ -3040,8 +3125,9 @@ func (fbo *folderBranchOps) processMissedLookup(
 			"Invalid sympath %s for entry type %s", sympath, et)
 	}
 
-	fbo.log.CDebugf(
-		ctx, "Auto-creating %s of type %s after a missed lookup", name, et)
+	fbo.vlog.CLogf(
+		ctx, libkb.VLog1,
+		"Auto-creating %s of type %s after a missed lookup", name, et)
 	switch et {
 	case data.File:
 		return fbo.CreateFile(ctx, dir, name, false, NoExcl)
@@ -3079,7 +3165,7 @@ func (fbo *folderBranchOps) statUsingFS(
 		return data.DirEntry{}, false, nil
 	}
 
-	fbo.log.CDebugf(ctx, "Using an FS to satisfy stat of %s", name)
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Using an FS to satisfy stat of %s", name)
 
 	de, err = fbo.makeFakeFileEntry(ctx, node, name)
 	if err != nil {
@@ -3105,7 +3191,8 @@ func (fbo *folderBranchOps) lookup(ctx context.Context, dir Node, name string) (
 	}
 
 	if fbo.nodeCache.IsUnlinked(dir) {
-		fbo.log.CDebugf(ctx, "Refusing a lookup for unlinked directory %v",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Refusing a lookup for unlinked directory %v",
 			fbo.nodeCache.PathFromNode(dir).TailPointer())
 		return nil, data.DirEntry{}, idutil.NoSuchNameError{Name: name}
 	}
@@ -3131,10 +3218,12 @@ func (fbo *folderBranchOps) lookup(ctx context.Context, dir Node, name string) (
 
 func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	node Node, ei data.EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "Lookup %s %s", getNodeIDStr(dir), name)
+	startTime, timer := fbo.startOp(
+		ctx, "Lookup %s %s", getNodeIDStr(dir), name)
 	defer func() {
 		err = fbo.transformReadError(ctx, dir, err)
-		fbo.deferLog.CDebugf(ctx, "Lookup %s %s done: %v %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "Lookup %s %s done: %v %+v",
 			getNodeIDStr(dir), name, getNodeIDStr(node), err)
 	}()
 
@@ -3166,7 +3255,8 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 			return n, de.EntryInfo, err
 		}
 
-		fbo.log.CDebugf(ctx, "Retrying lookup of an empty directory")
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Retrying lookup of an empty directory")
 		err = runUnlessCanceled(ctx, func() error {
 			var err error
 			n, de, err = fbo.lookup(ctx, dir, name)
@@ -3233,11 +3323,21 @@ func (fbo *folderBranchOps) statEntry(ctx context.Context, node Node) (
 		ctx, lState, md.ReadOnly(), nodePath)
 }
 
+func (fbo *folderBranchOps) deferLogIfErr(
+	ctx context.Context, err error, fs string, args ...interface{}) {
+	if err != nil {
+		fbo.defer2Log.CDebugf(ctx, fs, args...)
+	} else {
+		fbo.defer2Vlog.CLogf(ctx, libkb.VLog1, fs, args...)
+	}
+}
+
 func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 	ei data.EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "Stat %s", getNodeIDStr(node))
+	// Stats are common and clog up the logs, so only print to vlog.
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Stat %s", getNodeIDStr(node))
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Stat %s (%d bytes) done: %+v",
+		fbo.deferLogIfErr(ctx, err, "Stat %s (%d bytes) done: %+v",
 			getNodeIDStr(node), ei.Size, err)
 	}()
 
@@ -3254,9 +3354,11 @@ func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 
 func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	res NodeMetadata, err error) {
-	fbo.log.CDebugf(ctx, "GetNodeMetadata %s", getNodeIDStr(node))
+	startTime, timer := fbo.startOp(
+		ctx, "GetNodeMetadata %s", getNodeIDStr(node))
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "GetNodeMetadata %s done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "GetNodeMetadata %s done: %+v",
 			getNodeIDStr(node), err)
 	}()
 
@@ -3505,8 +3607,8 @@ func (fbo *folderBranchOps) handleUnflushedEditNotifications(
 func (fbo *folderBranchOps) loadCachedMDChanges(ctx context.Context,
 	bps blockPutState, key kbfscrypto.VerifyingKey, md *RootMetadata,
 	irmd ImmutableRootMetadata) (*RootMetadata, ImmutableRootMetadata, error) {
-	md, copied := md.loadCachedBlockChanges(ctx, bps, fbo.log,
-		fbo.config.Codec())
+	md, copied := md.loadCachedBlockChanges(
+		ctx, bps, fbo.log, fbo.vlog, fbo.config.Codec())
 
 	if copied {
 		irmd = MakeImmutableRootMetadata(
@@ -3701,7 +3803,9 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 		// Send edit notifications and archive the old, unref'd blocks
 		// if journaling is off.
 		fbo.editActivity.Add(1)
-		fbo.log.CDebugf(ctx, "Sending notifications for %v", irmd.data.Changes.Ops)
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Sending notifications for %v",
+			irmd.data.Changes.Ops)
 		go func() {
 			defer fbo.editActivity.Done()
 			ctx, cancelFunc := fbo.newCtxWithFBOID()
@@ -4215,7 +4319,7 @@ func (fbo *folderBranchOps) maybeWaitForSquash(
 		return
 	}
 
-	fbo.log.CDebugf(ctx, "Blocking until squash finishes")
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Blocking until squash finishes")
 	// Limit the time we wait to just under the ctx deadline if there
 	// is one, or 10s if there isn't.
 	deadline, ok := ctx.Deadline()
@@ -4288,8 +4392,9 @@ func (fbo *folderBranchOps) doMDWriteWithRetry(ctx context.Context,
 					case <-newCtx.Done():
 					}
 				}()
-				fbo.log.CDebugf(ctx, "Got a revision conflict while unmerged "+
-					"(%v); forcing a sync", err)
+				fbo.vlog.CLogf(
+					ctx, libkb.VLog1, "Got a revision conflict while unmerged "+
+						"(%v); forcing a sync", err)
 				err = fbo.getAndApplyNewestUnmergedHead(newCtx, lState)
 				if err != nil {
 					// TODO: we might be stuck at this point if we're
@@ -4319,9 +4424,11 @@ func (fbo *folderBranchOps) doMDWriteWithRetryUnlessCanceled(
 func (fbo *folderBranchOps) CreateDir(
 	ctx context.Context, dir Node, path string) (
 	n Node, ei data.EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "CreateDir %s %s", getNodeIDStr(dir), path)
+	startTime, timer := fbo.startOp(
+		ctx, "CreateDir %s %s", getNodeIDStr(dir), path)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "CreateDir %s %s done: %v %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "CreateDir %s %s done: %v %+v",
 			getNodeIDStr(dir), path, getNodeIDStr(n), err)
 	}()
 
@@ -4351,10 +4458,12 @@ func (fbo *folderBranchOps) CreateDir(
 func (fbo *folderBranchOps) CreateFile(
 	ctx context.Context, dir Node, path string, isExec bool, excl Excl) (
 	n Node, ei data.EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "CreateFile %s %s isExec=%v Excl=%s",
-		getNodeIDStr(dir), path, isExec, excl)
+	startTime, timer := fbo.startOp(
+		ctx, "CreateFile %s %s isExec=%v Excl=%s", getNodeIDStr(dir),
+		path, isExec, excl)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
+		fbo.endOp(
+			ctx, startTime, timer,
 			"CreateFile %s %s isExec=%v Excl=%s done: %v %+v",
 			getNodeIDStr(dir), path, isExec, excl,
 			getNodeIDStr(n), err)
@@ -4375,7 +4484,8 @@ func (fbo *folderBranchOps) CreateFile(
 	// If journaling is turned on, an exclusive create may end up on a
 	// conflict branch.
 	if excl == WithExcl && TLFJournalEnabled(fbo.config, fbo.id()) {
-		fbo.log.CDebugf(ctx, "Exclusive create status is being discarded.")
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Exclusive create status is being discarded.")
 		excl = NoExcl
 	}
 
@@ -4524,10 +4634,11 @@ func (fbo *folderBranchOps) createLinkLocked(
 func (fbo *folderBranchOps) CreateLink(
 	ctx context.Context, dir Node, fromName string, toPath string) (
 	ei data.EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "CreateLink %s %s -> %s",
+	startTime, timer := fbo.startOp(ctx, "CreateLink %s %s -> %s",
 		getNodeIDStr(dir), fromName, toPath)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "CreateLink %s %s -> %s done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "CreateLink %s %s -> %s done: %+v",
 			getNodeIDStr(dir), fromName, toPath, err)
 	}()
 
@@ -4711,9 +4822,11 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) RemoveDir(
 	ctx context.Context, dir Node, dirName string) (err error) {
-	fbo.log.CDebugf(ctx, "RemoveDir %s %s", getNodeIDStr(dir), dirName)
+	startTime, timer := fbo.startOp(
+		ctx, "RemoveDir %s %s", getNodeIDStr(dir), dirName)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "RemoveDir %s %s done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "RemoveDir %s %s done: %+v",
 			getNodeIDStr(dir), dirName, err)
 	}()
 
@@ -4738,9 +4851,11 @@ func (fbo *folderBranchOps) RemoveDir(
 
 func (fbo *folderBranchOps) RemoveEntry(ctx context.Context, dir Node,
 	name string) (err error) {
-	fbo.log.CDebugf(ctx, "RemoveEntry %s %s", getNodeIDStr(dir), name)
+	startTime, timer := fbo.startOp(
+		ctx, "RemoveEntry %s %s", getNodeIDStr(dir), name)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "RemoveEntry %s %s done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "RemoveEntry %s %s done: %+v",
 			getNodeIDStr(dir), name, err)
 	}()
 
@@ -4861,10 +4976,12 @@ func (fbo *folderBranchOps) renameLocked(
 func (fbo *folderBranchOps) Rename(
 	ctx context.Context, oldParent Node, oldName string, newParent Node,
 	newName string) (err error) {
-	fbo.log.CDebugf(ctx, "Rename %s/%s -> %s/%s", getNodeIDStr(oldParent),
+	startTime, timer := fbo.startOp(
+		ctx, "Rename %s/%s -> %s/%s", getNodeIDStr(oldParent),
 		oldName, getNodeIDStr(newParent), newName)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Rename %s/%s -> %s/%s done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "Rename %s/%s -> %s/%s done: %+v",
 			getNodeIDStr(oldParent), oldName,
 			getNodeIDStr(newParent), newName, err)
 	}()
@@ -4893,11 +5010,12 @@ func (fbo *folderBranchOps) Rename(
 func (fbo *folderBranchOps) Read(
 	ctx context.Context, file Node, dest []byte, off int64) (
 	n int64, err error) {
-	fbo.log.CDebugf(ctx, "Read %s %d %d", getNodeIDStr(file),
-		len(dest), off)
+	startTime, timer := fbo.startOp(
+		ctx, "Read %s %d %d", getNodeIDStr(file), len(dest), off)
 	defer func() {
 		err = fbo.transformReadError(ctx, file, err)
-		fbo.deferLog.CDebugf(ctx, "Read %s %d %d (n=%d) done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "Read %s %d %d (n=%d) done: %+v",
 			getNodeIDStr(file), len(dest), off, n, err)
 	}()
 
@@ -4909,7 +5027,7 @@ func (fbo *folderBranchOps) Read(
 	fsFile := file.GetFile(ctx)
 	if fsFile != nil {
 		defer fsFile.Close()
-		fbo.log.CDebugf(ctx, "Reading from an FS file")
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Reading from an FS file")
 		nInt, err := fsFile.ReadAt(dest, off)
 		return int64(nInt), err
 	}
@@ -4969,10 +5087,11 @@ func (fbo *folderBranchOps) Read(
 
 func (fbo *folderBranchOps) Write(
 	ctx context.Context, file Node, data []byte, off int64) (err error) {
-	fbo.log.CDebugf(ctx, "Write %s %d %d", getNodeIDStr(file),
-		len(data), off)
+	startTime, timer := fbo.startOp(
+		ctx, "Write %s %d %d", getNodeIDStr(file), len(data), off)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Write %s %d %d done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "Write %s %d %d done: %+v",
 			getNodeIDStr(file), len(data), off, err)
 	}()
 
@@ -5006,9 +5125,11 @@ func (fbo *folderBranchOps) Write(
 
 func (fbo *folderBranchOps) Truncate(
 	ctx context.Context, file Node, size uint64) (err error) {
-	fbo.log.CDebugf(ctx, "Truncate %s %d", getNodeIDStr(file), size)
+	startTime, timer := fbo.startOp(
+		ctx, "Truncate %s %d", getNodeIDStr(file), size)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Truncate %s %d done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "Truncate %s %d done: %+v",
 			getNodeIDStr(file), size, err)
 	}()
 
@@ -5069,7 +5190,7 @@ func (fbo *folderBranchOps) setExLocked(
 	// If the file is a symlink, do nothing (to match ext4
 	// behavior).
 	if de.Type == data.Sym || de.Type == data.Dir {
-		fbo.log.CDebugf(ctx, "Ignoring setex on type %s", de.Type)
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Ignoring setex on type %s", de.Type)
 		return nil
 	}
 
@@ -5081,7 +5202,7 @@ func (fbo *folderBranchOps) setExLocked(
 		// Treating this as a no-op, without updating the ctime, is a
 		// POSIX violation, but it's an important optimization to keep
 		// permissions-preserving rsyncs fast.
-		fbo.log.CDebugf(ctx, "Ignoring no-op setex")
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Ignoring no-op setex")
 		return nil
 	}
 
@@ -5097,7 +5218,8 @@ func (fbo *folderBranchOps) setExLocked(
 
 	// If the node has been unlinked, we can safely ignore this setex.
 	if fbo.nodeCache.IsUnlinked(file) {
-		fbo.log.CDebugf(ctx, "Skipping setex for a removed file %v",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Skipping setex for a removed file %v",
 			filePath.TailPointer())
 		fbo.blocks.UpdateCachedEntryAttributesOnRemovedFile(
 			ctx, lState, md.ReadOnly(), sao, filePath, de)
@@ -5117,9 +5239,11 @@ func (fbo *folderBranchOps) setExLocked(
 
 func (fbo *folderBranchOps) SetEx(
 	ctx context.Context, file Node, ex bool) (err error) {
-	fbo.log.CDebugf(ctx, "SetEx %s %t", getNodeIDStr(file), ex)
+	startTime, timer := fbo.startOp(
+		ctx, "SetEx %s %t", getNodeIDStr(file), ex)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "SetEx %s %t done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "SetEx %s %t done: %+v",
 			getNodeIDStr(file), ex, err)
 	}()
 
@@ -5174,7 +5298,8 @@ func (fbo *folderBranchOps) setMtimeLocked(
 	// If the node has been unlinked, we can safely ignore this
 	// setmtime.
 	if fbo.nodeCache.IsUnlinked(file) {
-		fbo.log.CDebugf(ctx, "Skipping setmtime for a removed file %v",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Skipping setmtime for a removed file %v",
 			filePath.TailPointer())
 		fbo.blocks.UpdateCachedEntryAttributesOnRemovedFile(
 			ctx, lState, md.ReadOnly(), sao, filePath, de)
@@ -5194,9 +5319,11 @@ func (fbo *folderBranchOps) setMtimeLocked(
 
 func (fbo *folderBranchOps) SetMtime(
 	ctx context.Context, file Node, mtime *time.Time) (err error) {
-	fbo.log.CDebugf(ctx, "SetMtime %s %v", getNodeIDStr(file), mtime)
+	startTime, timer := fbo.startOp(
+		ctx, "SetMtime %s %v", getNodeIDStr(file), mtime)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "SetMtime %s %v done: %+v",
+		fbo.endOp(
+			ctx, startTime, timer, "SetMtime %s %v done: %+v",
 			getNodeIDStr(file), mtime, err)
 	}()
 
@@ -5253,7 +5380,8 @@ func (fbo *folderBranchOps) startSyncLocked(ctx context.Context,
 	// implies we are using a cached path, which implies the node has
 	// been unlinked.  In that case, we can safely ignore this sync.
 	if fbo.nodeCache.IsUnlinked(node) {
-		fbo.log.CDebugf(ctx, "Skipping sync for a removed file %v",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Skipping sync for a removed file %v",
 			file.TailPointer())
 		// Removing the cached info here is a little sketchy,
 		// since there's no guarantee that this sync comes
@@ -5320,6 +5448,13 @@ func (fbo *folderBranchOps) syncAllLocked(
 		return nil
 	}
 
+	startTime, timer := fbo.startOp(ctx, "syncAllLocked")
+	defer func() {
+		fbo.endOp(ctx, startTime, timer,
+			"syncAllLocked (%d files, %d dirs) done: %+v",
+			len(dirtyFiles), len(dirtyDirs), err)
+	}()
+
 	ctx = fbo.config.MaybeStartTrace(ctx, "FBO.SyncAll",
 		fmt.Sprintf("%d files, %d dirs", len(dirtyFiles), len(dirtyDirs)))
 	defer func() { fbo.config.MaybeFinishTrace(ctx, err) }()
@@ -5352,7 +5487,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	}
 
 	// First prep all the directories.
-	fbo.log.CDebugf(ctx, "Syncing %d dir(s)", len(dirtyDirs))
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Syncing %d dir(s)", len(dirtyDirs))
 	for _, ref := range dirtyDirs {
 		node := fbo.nodeCache.Get(ref)
 		if node == nil {
@@ -5549,7 +5684,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 
 	fbo.log.LazyTrace(ctx, "Syncing %d file(s)", len(dirtyFiles))
 
-	fbo.log.CDebugf(ctx, "Syncing %d file(s)", len(dirtyFiles))
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Syncing %d file(s)", len(dirtyFiles))
 	fileSyncBlocks := newBlockPutStateMemory(1)
 	for _, ref := range dirtyFiles {
 		node := fbo.nodeCache.Get(ref)
@@ -5557,7 +5692,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 			continue
 		}
 		file := fbo.nodeCache.PathFromNode(node)
-		fbo.log.CDebugf(ctx, "Syncing file %v (%s)", ref, file)
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Syncing file %v (%s)", ref, file)
 
 		// Start the sync for this dirty file.
 		doSync, stillDirty, fblock, dirtyDe, newBps, syncState, cleanup, err :=
@@ -5768,8 +5903,10 @@ func (fbo *folderBranchOps) syncAllUnlocked(
 // SyncAll implements the KBFSOps interface for folderBranchOps.
 func (fbo *folderBranchOps) SyncAll(
 	ctx context.Context, folderBranch data.FolderBranch) (err error) {
-	fbo.log.CDebugf(ctx, "SyncAll")
-	defer func() { fbo.deferLog.CDebugf(ctx, "SyncAll done: %+v", err) }()
+	startTime, timer := fbo.startOp(ctx, "SyncAll")
+	defer func() {
+		fbo.endOp(ctx, startTime, timer, "SyncAll done: %+v", err)
+	}()
 
 	if folderBranch != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, folderBranch}
@@ -5784,8 +5921,10 @@ func (fbo *folderBranchOps) SyncAll(
 func (fbo *folderBranchOps) FolderStatus(
 	ctx context.Context, folderBranch data.FolderBranch) (
 	fbs FolderBranchStatus, updateChan <-chan StatusUpdate, err error) {
-	fbo.log.CDebugf(ctx, "Status")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Status done: %+v", err) }()
+	startTime, timer := fbo.startOp(ctx, "Status")
+	defer func() {
+		fbo.endOp(ctx, startTime, timer, "Status done: %+v", err)
+	}()
 
 	if folderBranch != fbo.folderBranch {
 		return FolderBranchStatus{}, nil,
@@ -5917,7 +6056,8 @@ func (fbo *folderBranchOps) getUnlinkPathBeforeUpdatingPointers(
 		(len(fbo.dirOps) == 0 || op != fbo.dirOps[len(fbo.dirOps)-1].dirOp) {
 		for _, update := range resOp.allUpdates() {
 			if update.Ref == p.TailPointer() {
-				fbo.log.CDebugf(ctx,
+				fbo.vlog.CLogf(
+					ctx, libkb.VLog1,
 					"Backing up ptr %v in op %s to original pointer %v",
 					p.TailPointer(), op, update.Unref)
 				p.Path[len(p.Path)-1].BlockPointer = update.Unref
@@ -5931,7 +6071,8 @@ func (fbo *folderBranchOps) getUnlinkPathBeforeUpdatingPointers(
 		// If we didn't fix up the pointer using a resolutionOp, the
 		// directory was likely created during this md update, and so
 		// no unlinking is needed.
-		fbo.log.CDebugf(ctx,
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1,
 			"Ignoring unlink when resolutionOp never fixed up %v",
 			p.TailPointer())
 		return data.Path{}, data.DirEntry{}, false, nil
@@ -5991,7 +6132,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if node == nil {
 			break
 		}
-		fbo.log.CDebugf(ctx, "notifyOneOp: create %s in node %s",
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "notifyOneOp: create %s in node %s",
 			realOp.NewName, getNodeIDStr(node))
 		changes = append(changes, NodeChange{
 			Node:       node,
@@ -6002,7 +6143,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if node == nil {
 			break
 		}
-		fbo.log.CDebugf(ctx, "notifyOneOp: remove %s in node %s",
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "notifyOneOp: remove %s in node %s",
 			realOp.OldName, getNodeIDStr(node))
 		changes = append(changes, NodeChange{
 			Node:       node,
@@ -6041,7 +6182,8 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		}
 
 		if oldNode != nil {
-			fbo.log.CDebugf(ctx, "notifyOneOp: rename %v from %s/%s to %s/%s",
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "notifyOneOp: rename %v from %s/%s to %s/%s",
 				realOp.Renamed, realOp.OldName, getNodeIDStr(oldNode),
 				realOp.NewName, getNodeIDStr(newNode))
 
@@ -6081,7 +6223,8 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if node == nil {
 			break
 		}
-		fbo.log.CDebugf(ctx, "notifyOneOp: sync %d writes in node %s",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "notifyOneOp: sync %d writes in node %s",
 			len(realOp.Writes), getNodeIDStr(node))
 
 		changes = append(changes, NodeChange{
@@ -6093,7 +6236,8 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if node == nil {
 			break
 		}
-		fbo.log.CDebugf(ctx, "notifyOneOp: setAttr %s for file %s in node %s",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "notifyOneOp: setAttr %s for file %s in node %s",
 			realOp.Attr, realOp.Name, getNodeIDStr(node))
 
 		childNode := fbo.nodeCache.Get(realOp.File.Ref())
@@ -6107,7 +6251,10 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 	case *GCOp:
 		// Unreferenced blocks in a GCOp mean that we shouldn't cache
 		// them anymore
-		fbo.log.CDebugf(ctx, "notifyOneOp: GCOp with latest rev %d and %d unref'd blocks", realOp.LatestRev, len(realOp.Unrefs()))
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1,
+			"notifyOneOp: GCOp with latest rev %d and %d unref'd blocks",
+			realOp.LatestRev, len(realOp.Unrefs()))
 		bcache := fbo.config.BlockCache()
 		for _, ptr := range realOp.Unrefs() {
 			if err := bcache.DeleteTransient(ptr.ID, fbo.id()); err != nil {
@@ -6147,7 +6294,8 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 				})
 			}
 
-			fbo.log.CDebugf(ctx, "resolutionOp: remove %s, node %s",
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "resolutionOp: remove %s, node %s",
 				p.TailPointer(), getNodeIDStr(node))
 			// Revert the path back to the original BlockPointers,
 			// before the updates were applied.
@@ -6441,7 +6589,8 @@ func (fbo *folderBranchOps) setLatestMergedRevisionLocked(
 
 	if fbo.latestMergedRevision < rev || allowBackward {
 		fbo.latestMergedRevision = rev
-		fbo.log.CDebugf(ctx, "Updated latestMergedRevision to %d.", rev)
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Updated latestMergedRevision to %d.", rev)
 	} else {
 		fbo.log.CDebugf(ctx, "Local latestMergedRevision (%d) is higher than "+
 			"the new revision (%d); won't update.", fbo.latestMergedRevision, rev)
@@ -6476,7 +6625,7 @@ func (fbo *folderBranchOps) getAndApplyMDUpdates(ctx context.Context,
 
 func (fbo *folderBranchOps) getAndApplyNewestUnmergedHead(ctx context.Context,
 	lState *kbfssync.LockState) error {
-	fbo.log.CDebugf(ctx, "Fetching the newest unmerged head")
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Fetching the newest unmerged head")
 	unmergedBID := func() kbfsmd.BranchID {
 		fbo.mdWriterLock.Lock(lState)
 		defer fbo.mdWriterLock.Unlock(lState)
@@ -6500,7 +6649,8 @@ func (fbo *folderBranchOps) getAndApplyNewestUnmergedHead(ctx context.Context,
 	if fbo.unmergedBID != unmergedBID {
 		// The branches switched (apparently CR completed), so just
 		// try again.
-		fbo.log.CDebugf(ctx, "Branches switched while fetching unmerged head")
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Branches switched while fetching unmerged head")
 		return nil
 	}
 
@@ -6693,9 +6843,9 @@ func (fbo *folderBranchOps) unstageLocked(ctx context.Context,
 // TODO: remove once we have automatic conflict resolution
 func (fbo *folderBranchOps) UnstageForTesting(
 	ctx context.Context, folderBranch data.FolderBranch) (err error) {
-	fbo.log.CDebugf(ctx, "UnstageForTesting")
+	startTime, timer := fbo.startOp(ctx, "UnstageForTesting")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "UnstageForTesting done: %+v", err)
+		fbo.endOp(ctx, startTime, timer, "UnstageForTesting done: %+v", err)
 	}()
 
 	if folderBranch != fbo.folderBranch {
@@ -6742,9 +6892,9 @@ func (fbo *folderBranchOps) UnstageForTesting(
 // mdWriterLock must be taken by the caller.
 func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 	lState *kbfssync.LockState, promptPaper bool) (res RekeyResult, err error) {
-	fbo.log.CDebugf(ctx, "rekeyLocked")
+	startTime, timer := fbo.startOp(ctx, "rekeyLocked")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "rekeyLocked done: %+v %+v", res, err)
+		fbo.endOp(ctx, startTime, timer, "rekeyLocked done: %+v %+v", res, err)
 	}()
 
 	fbo.mdWriterLock.AssertLocked(lState)
@@ -6771,7 +6921,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 
 		head, _ = fbo.getHead(ctx, lState, mdNoCommit)
 		if head.TypeForKeying() == tlf.TeamKeying {
-			fbo.log.CDebugf(ctx, "A team TLF doesn't need a rekey")
+			fbo.vlog.CLogf(ctx, libkb.VLog1, "A team TLF doesn't need a rekey")
 			return RekeyResult{}, nil
 		}
 	}
@@ -6922,9 +7072,9 @@ func (fbo *folderBranchOps) RequestRekey(_ context.Context, tlf tlf.ID) {
 
 func (fbo *folderBranchOps) SyncFromServer(ctx context.Context,
 	folderBranch data.FolderBranch, lockBeforeGet *keybase1.LockID) (err error) {
-	fbo.log.CDebugf(ctx, "SyncFromServer")
+	startTime, timer := fbo.startOp(ctx, "SyncFromServer")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "SyncFromServer done: %+v", err)
+		fbo.endOp(ctx, startTime, timer, "SyncFromServer done: %+v", err)
 	}()
 
 	if folderBranch != fbo.folderBranch {
@@ -6953,7 +7103,8 @@ func (fbo *folderBranchOps) SyncFromServer(ctx context.Context,
 	}
 
 	if !fbo.config.MDServer().IsConnected() {
-		fbo.log.CDebugf(ctx, "Not fetching new updates while offline")
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Not fetching new updates while offline")
 		return nil
 	}
 
@@ -6972,7 +7123,7 @@ func (fbo *folderBranchOps) SyncFromServer(ctx context.Context,
 		dirtyFiles := fbo.blocks.GetDirtyFileBlockRefs(lState)
 		if len(dirtyFiles) > 0 {
 			for _, ref := range dirtyFiles {
-				fbo.log.CDebugf(ctx, "DeCache entry left: %v", ref)
+				fbo.vlog.CLogf(ctx, libkb.VLog1, "DeCache entry left: %v", ref)
 			}
 			return errors.New("can't sync from server while dirty")
 		}
@@ -6995,7 +7146,8 @@ func (fbo *folderBranchOps) SyncFromServer(ctx context.Context,
 			ctx, lState, lockBeforeGet, fbo.applyMDUpdates); err != nil {
 			if applyErr, ok := err.(kbfsmd.MDRevisionMismatch); ok {
 				if applyErr.Rev == applyErr.Curr {
-					fbo.log.CDebugf(ctx, "Already up-to-date with server")
+					fbo.vlog.CLogf(
+						ctx, libkb.VLog1, "Already up-to-date with server")
 					return nil
 				}
 			}
@@ -7132,13 +7284,15 @@ func (fbo *folderBranchOps) maybeFastForward(ctx context.Context,
 		return false, nil
 	}
 
-	fbo.log.CDebugf(ctx, "Checking head for possible "+
-		"fast-forwarding (last update time=%s)", lastUpdate)
+	fbo.vlog.CLogf(
+		ctx, libkb.VLog1, "Checking head for possible "+
+			"fast-forwarding (last update time=%s)", lastUpdate)
 	currHead, err := fbo.config.MDOps().GetForTLF(ctx, fbo.id(), nil)
 	if err != nil {
 		return false, err
 	}
-	fbo.log.CDebugf(ctx, "Current head is revision %d", currHead.Revision())
+	fbo.vlog.CLogf(
+		ctx, libkb.VLog1, "Current head is revision %d", currHead.Revision())
 
 	fbo.mdWriterLock.Lock(lState)
 	defer fbo.mdWriterLock.Unlock(lState)
@@ -7375,11 +7529,12 @@ func (fbo *folderBranchOps) registerForUpdates(ctx context.Context) (
 		fireNow = true
 	}
 
-	fbo.log.CDebugf(ctx,
-		"Registering for updates (curr rev = %d, fire now = %v)",
+	startTime, timer := fbo.startOp(
+		ctx, "Registering for updates (curr rev = %d, fire now = %v)",
 		currRev, fireNow)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
+		fbo.endOp(
+			ctx, startTime, timer,
 			"Registering for updates (curr rev = %d, fire now = %v) done: %+v",
 			currRev, fireNow, err)
 	}()
@@ -7391,9 +7546,9 @@ func (fbo *folderBranchOps) waitForAndProcessUpdates(
 	ctx context.Context, lastUpdate time.Time,
 	updateChan <-chan error) (currUpdate time.Time, err error) {
 	// successful registration; now, wait for an update or a shutdown
-	fbo.log.CDebugf(ctx, "Waiting for updates")
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Waiting for updates")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Waiting for updates done: %+v", err)
+		fbo.deferLogIfErr(ctx, err, "Waiting for updates done: %+v", err)
 	}()
 
 	lState := makeFBOLockState()
@@ -7401,7 +7556,7 @@ func (fbo *folderBranchOps) waitForAndProcessUpdates(
 	for {
 		select {
 		case err := <-updateChan:
-			fbo.log.CDebugf(ctx, "Got an update: %v", err)
+			fbo.vlog.CLogf(ctx, libkb.VLog1, "Got an update: %v", err)
 			if err != nil {
 				return time.Time{}, err
 			}
@@ -7533,8 +7688,9 @@ func (fbo *folderBranchOps) backgroundFlusher() {
 					return context.WithValue(ctx, CtxBackgroundSyncKey, "1")
 				})
 
-			fbo.log.CDebugf(ctx, "Background sync triggered: %d dirty files, "+
-				"%d dir ops in batch", len(dirtyFiles), dirOpsCount)
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "Background sync triggered: %d dirty files, "+
+					"%d dir ops in batch", len(dirtyFiles), dirOpsCount)
 
 			if sameDirtyFileCount >= 100 {
 				// If the local journal is full, we might not be able to
@@ -7691,7 +7847,7 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 
 	if fbo.isUnmergedLocked(lState) {
 		if fbo.unmergedBID == newBID {
-			fbo.log.CDebugf(ctx, "Already on branch %s", newBID)
+			fbo.vlog.CLogf(ctx, libkb.VLog1, "Already on branch %s", newBID)
 			return
 		}
 		panic(fmt.Sprintf("Cannot switch to branch %s while on branch %s",
@@ -7710,7 +7866,8 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 		// This can happen if CR got kicked off in some other way and
 		// completed before we took the lock to process this
 		// notification.
-		fbo.log.CDebugf(ctx, "Ignoring stale branch change: md=%v, newBID=%d",
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Ignoring stale branch change: md=%v, newBID=%d",
 			md, newBID)
 		return
 	}
@@ -7752,7 +7909,8 @@ func (fbo *folderBranchOps) onTLFBranchChange(newBID kbfsmd.BranchID) {
 		// This only happens on a `PruneBranch` call, in which case we
 		// would have already updated fbo's local view of the branch/head.
 		if newBID == kbfsmd.NullBranchID {
-			fbo.log.CDebugf(ctx, "Ignoring branch change back to master")
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "Ignoring branch change back to master")
 			return
 		}
 
@@ -7762,7 +7920,8 @@ func (fbo *folderBranchOps) onTLFBranchChange(newBID kbfsmd.BranchID) {
 
 func (fbo *folderBranchOps) handleMDFlush(
 	ctx context.Context, rev kbfsmd.Revision) {
-	fbo.log.CDebugf(ctx,
+	fbo.vlog.CLogf(
+		ctx, libkb.VLog1,
 		"Considering archiving references for flushed MD revision %d", rev)
 
 	lState := makeFBOLockState()
@@ -7828,8 +7987,9 @@ func (fbo *folderBranchOps) onMDFlush(
 		defer cancelFunc()
 
 		if unmergedBID != kbfsmd.NullBranchID {
-			fbo.log.CDebugf(ctx, "Ignoring MD flush on branch %v for "+
-				"revision %d", unmergedBID, rev)
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "Ignoring MD flush on branch %v for "+
+					"revision %d", unmergedBID, rev)
 			return
 		}
 
@@ -7842,7 +8002,7 @@ func (fbo *folderBranchOps) TeamNameChanged(
 	ctx context.Context, tid keybase1.TeamID) {
 	ctx, cancelFunc := fbo.newCtxWithFBOID()
 	defer cancelFunc()
-	fbo.log.CDebugf(ctx, "Starting name change for team %s", tid)
+	fbo.vlog.CLogf(ctx, libkb.VLog1, "Starting name change for team %s", tid)
 
 	// First check if this is an implicit team.
 	var newName kbname.NormalizedUsername
@@ -7878,7 +8038,8 @@ func (fbo *folderBranchOps) TeamNameChanged(
 	oldHandle := fbo.head.GetTlfHandle()
 
 	if string(oldHandle.GetCanonicalName()) == string(newName) {
-		fbo.log.CDebugf(ctx, "Name didn't change: %s", newName)
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1, "Name didn't change: %s", newName)
 		return
 	}
 
@@ -8036,9 +8197,9 @@ func (fbo *folderBranchOps) MigrateToImplicitTeam(
 // GetUpdateHistory implements the KBFSOps interface for folderBranchOps
 func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 	folderBranch data.FolderBranch) (history TLFUpdateHistory, err error) {
-	fbo.log.CDebugf(ctx, "GetUpdateHistory")
+	startTime, timer := fbo.startOp(ctx, "GetUpdateHistory")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "GetUpdateHistory done: %+v", err)
+		fbo.endOp(ctx, startTime, timer, "GetUpdateHistory done: %+v", err)
 	}()
 
 	if folderBranch != fbo.folderBranch {
@@ -8634,10 +8795,11 @@ func (fbo *folderBranchOps) SetSyncConfig(
 // folderBranchOps.
 func (fbo *folderBranchOps) InvalidateNodeAndChildren(
 	ctx context.Context, node Node) (err error) {
-	fbo.log.CDebugf(ctx, "InvalidateNodeAndChildren %p", node)
+	startTime, timer := fbo.startOp(ctx, "InvalidateNodeAndChildren %p", node)
 	defer func() {
-		fbo.log.CDebugf(ctx,
-			"InvalidateNodeAndChildren %p done: %+v", node, err)
+		fbo.endOp(
+			ctx, startTime, timer, "InvalidateNodeAndChildren %p done: %+v",
+			node, err)
 	}()
 
 	lState := makeFBOLockState()
@@ -8666,12 +8828,15 @@ func (fbo *folderBranchOps) NewNotificationChannel(
 	channelName string) {
 	monitoringCh := fbo.getEditMonitoringChannel()
 	if monitoringCh == nil {
-		fbo.log.CDebugf(ctx,
+		fbo.vlog.CLogf(
+			ctx, libkb.VLog1,
 			"Ignoring new notification channel while edits are unmonitored")
 		return
 	}
 
-	fbo.log.CDebugf(ctx, "New notification channel: %s %s", convID, channelName)
+	fbo.vlog.CLogf(
+		ctx, libkb.VLog1, "New notification channel: %s %s",
+		convID, channelName)
 	fbo.editActivity.Add(1)
 	select {
 	case fbo.editChannels <- editChannelActivity{convID, channelName, ""}:
@@ -8699,7 +8864,8 @@ func (fbo *folderBranchOps) PushConnectionStatusChange(service string, newStatus
 		return
 	}
 
-	fbo.log.CDebugf(nil, "Asking for an edit re-init after reconnection")
+	fbo.vlog.CLogf(
+		nil, libkb.VLog1, "Asking for an edit re-init after reconnection")
 	fbo.editActivity.Add(1)
 	select {
 	case fbo.editChannels <- editChannelActivity{nil, "", ""}:
@@ -8799,11 +8965,13 @@ func (fbo *folderBranchOps) recomputeEditHistory(
 			if startPage, ok := nameToNextPage[w]; ok && startPage != nil {
 				id, ok := nameToID[w]
 				if !ok {
-					fbo.log.CDebugf(ctx, "No channel found for %s", w)
+					fbo.vlog.CLogf(
+						ctx, libkb.VLog1, "No channel found for %s", w)
 					continue
 				}
-				fbo.log.CDebugf(
-					ctx, "Going to fetch more messages for writer %s", w)
+				fbo.vlog.CLogf(
+					ctx, libkb.VLog1,
+					"Going to fetch more messages for writer %s", w)
 				gotMore = true
 				nextPage := fbo.getEditMessages(ctx, id, w, startPage)
 				if nextPage == nil {
@@ -8825,8 +8993,9 @@ func (fbo *folderBranchOps) kickOffEditActivityPartialSync(
 	rmd ImmutableRootMetadata) (err error) {
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Couldn't kick off partial sync "+
-				"for edit activity: %+v", err)
+			fbo.log.CDebugf(
+				ctx, "Couldn't kick off partial sync for edit activity: %+v",
+				err)
 		}
 	}()
 
@@ -8838,8 +9007,9 @@ func (fbo *folderBranchOps) kickOffEditActivityPartialSync(
 		return nil
 	}
 
-	fbo.log.CDebugf(ctx, "Kicking off partial sync for revision %d "+
-		"due to new edit message", rmd.Revision())
+	fbo.vlog.CLogf(
+		ctx, libkb.VLog1, "Kicking off partial sync for revision %d "+
+			"due to new edit message", rmd.Revision())
 
 	syncConfig, err = fbo.makeRecentFilesSyncConfig(ctx, rmd)
 	if err != nil {
@@ -8870,7 +9040,7 @@ func (fbo *folderBranchOps) handleEditActivity(
 	}()
 
 	if a.convID == nil {
-		fbo.log.CDebugf(ctx, "Re-initializing chat channels")
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Re-initializing chat channels")
 		return fbo.initEditChatChannels(ctx, tlfName)
 	}
 
@@ -8885,7 +9055,7 @@ func (fbo *folderBranchOps) handleEditActivity(
 		name = a.name
 	}
 	if a.message != "" {
-		fbo.log.CDebugf(ctx, "New edit message for %s", name)
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "New edit message for %s", name)
 		maxRev, err := fbo.editHistory.AddNotifications(
 			name, []string{a.message})
 		if err != nil {
@@ -8906,7 +9076,7 @@ func (fbo *folderBranchOps) handleEditActivity(
 			}
 		}
 	} else {
-		fbo.log.CDebugf(ctx, "New edit channel for %s", name)
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "New edit channel for %s", name)
 		nextPage := fbo.getEditMessages(ctx, a.convID, name, nil)
 		if nextPage != nil {
 			nameToNextPage[name] = nextPage

--- a/go/kbfs/libkbfs/folder_branch_status.go
+++ b/go/kbfs/libkbfs/folder_branch_status.go
@@ -235,7 +235,9 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 		fbs.LocalTimestamp = fbsk.md.localTimestamp
 
 		if fbsk.quotaUsage == nil {
-			loggerSuffix := fmt.Sprintf("status-%s", fbsk.md.TlfID())
+			log := fbsk.config.MakeLogger(QuotaUsageLogModule(fmt.Sprintf(
+				"status-%s", fbsk.md.TlfID())))
+			vlog := fbsk.config.MakeVLogger(log)
 			chargedTo, err := chargedToForTLF(
 				ctx, fbsk.config.KBPKI(), fbsk.config.KBPKI(),
 				fbsk.config, fbsk.md.GetTlfHandle())
@@ -246,13 +248,13 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 				// TODO: somehow share this team quota usage instance
 				// with the journal for the team (and subteam) TLFs?
 				fbsk.quotaUsage = NewEventuallyConsistentTeamQuotaUsage(
-					fbsk.config, chargedTo.AsTeamOrBust(), loggerSuffix)
+					fbsk.config, chargedTo.AsTeamOrBust(), log, vlog)
 			} else {
 				// Almost certainly this should be being passed in by
 				// the caller of fbsk's constructor, and in that case
 				// we wouldn't be making a new one here
 				fbsk.quotaUsage = NewEventuallyConsistentQuotaUsage(
-					fbsk.config, loggerSuffix)
+					fbsk.config, log, vlog)
 			}
 		}
 		_, usageBytes, archiveBytes, limitBytes,

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -659,6 +659,11 @@ func doInit(
 			return lg
 		}, params.StorageRoot, params.DiskCacheMode, kbCtx)
 	config.SetVLogLevel(kbCtx.GetVDebugSetting())
+	if mode == InitConstrained {
+		// Until we have a way to turn on debug logging for mobile,
+		// log everything.
+		config.SetVLogLevel(libkb.VLog1String)
+	}
 
 	if params.CleanBlockCacheCapacity > 0 {
 		log.CDebugf(

--- a/go/kbfs/libkbfs/interface_test.go
+++ b/go/kbfs/libkbfs/interface_test.go
@@ -45,8 +45,8 @@ func (lm testLogMaker) MakeLogger(_ string) logger.Logger {
 	return lm.log
 }
 
-func (lm testLogMaker) MakeVLogger(_ string) *libkb.VDebugLog {
-	vlog := libkb.NewVDebugLog(lm.log)
+func (lm testLogMaker) MakeVLogger(log logger.Logger) *libkb.VDebugLog {
+	vlog := libkb.NewVDebugLog(log)
 	vlog.Configure(lm.vdebugSetting)
 	return vlog
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -29,7 +29,7 @@ import (
 
 type logMaker interface {
 	MakeLogger(module string) logger.Logger
-	MakeVLogger(module string) *libkb.VDebugLog
+	MakeVLogger(logger.Logger) *libkb.VDebugLog
 }
 
 type blockCacher interface {
@@ -2029,6 +2029,11 @@ type Config interface {
 	// strings are hard-coded in go/libkb/vdebug.go, but include
 	// "mobile", "vlog1", "vlog2", etc.
 	SetVLogLevel(levelString string)
+
+	// VLogLevel gets the vdebug level for this config.  The possible
+	// strings are hard-coded in go/libkb/vdebug.go, but include
+	// "mobile", "vlog1", "vlog2", etc.
+	VLogLevel() string
 }
 
 // NodeCache holds Nodes, and allows libkbfs to update them when

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -65,6 +65,7 @@ const longOperationDebugDumpDuration = time.Minute
 // NewKBFSOpsStandard constructs a new KBFSOpsStandard object.
 func NewKBFSOpsStandard(appStateUpdater env.AppStateUpdater, config Config) *KBFSOpsStandard {
 	log := config.MakeLogger("")
+	quLog := config.MakeLogger(QuotaUsageLogModule("KBFSOps"))
 	kops := &KBFSOpsStandard{
 		appStateUpdater:       appStateUpdater,
 		config:                config,
@@ -73,8 +74,9 @@ func NewKBFSOpsStandard(appStateUpdater env.AppStateUpdater, config Config) *KBF
 		ops:                   make(map[data.FolderBranch]*folderBranchOps),
 		opsByFav:              make(map[favorites.Folder]*folderBranchOps),
 		reIdentifyControlChan: make(chan chan<- struct{}),
-		favs:       NewFavorites(config),
-		quotaUsage: NewEventuallyConsistentQuotaUsage(config, "KBFSOps"),
+		favs: NewFavorites(config),
+		quotaUsage: NewEventuallyConsistentQuotaUsage(
+			config, quLog, config.MakeVLogger(quLog)),
 		longOperationDebugDumper: NewImpatientDebugDumper(
 			config, longOperationDebugDumpDuration),
 		currentStatus: &kbfsCurrentStatus{},

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -86,8 +87,9 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	// Each test is expected to check the cache for correctness at the
 	// end of the test.
 	config.SetBlockCache(data.NewBlockCacheStandard(100, 1<<30))
-	config.SetDirtyBlockCache(data.NewDirtyBlockCacheStandard(data.WallClock{},
-		config.MakeLogger(""), 5<<20, 10<<20, 5<<20))
+	log := config.MakeLogger("")
+	config.SetDirtyBlockCache(data.NewDirtyBlockCacheStandard(
+		data.WallClock{}, log, libkb.NewVDebugLog(log), 5<<20, 10<<20, 5<<20))
 	config.mockBcache = nil
 	config.mockDirtyBcache = nil
 
@@ -4692,7 +4694,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
-	config.vdebugSetting = "vlog2"
+	config.SetVLogLevel(libkb.VLog2String)
 
 	name := "u1"
 	h, err := tlfhandle.ParseHandle(
@@ -4913,7 +4915,7 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.
 	config.SetMode(modeTest{NewInitModeFromType(InitDefault)})
-	config.vdebugSetting = "vlog2"
+	config.SetVLogLevel(libkb.VLog2String)
 
 	name := "u1"
 	h, err := tlfhandle.ParseHandle(

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -493,7 +494,8 @@ func getFileBlockForMD(ctx context.Context, bcache data.BlockCacheSimple, bops B
 
 func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 	bcache data.BlockCacheSimple, bops BlockOps, mode InitMode, tlfID tlf.ID,
-	pmd *PrivateMetadata, rmdWithKeys libkey.KeyMetadata, log logger.Logger) error {
+	pmd *PrivateMetadata, rmdWithKeys libkey.KeyMetadata,
+	log logger.Logger) error {
 	info := pmd.Changes.Info
 	if info.BlockPointer == data.ZeroPtr {
 		return nil
@@ -537,7 +539,9 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 	// just pass in nil.  Also, reading doesn't depend on the UID, so
 	// it's ok to be empty.
 	var id keybase1.UserOrTeamID
-	fd := data.NewFileData(file, id, nil, rmdWithKeys, getter, cacher, log)
+	fd := data.NewFileData(
+		file, id, nil, rmdWithKeys, getter, cacher, log,
+		libkb.NewVDebugLog(log) /* one-off, short-lived, unconfigured vlog */)
 
 	buf, err := fd.GetBytes(ctx, 0, -1)
 	if err != nil {

--- a/go/kbfs/libkbfs/merkle_root.go
+++ b/go/kbfs/libkbfs/merkle_root.go
@@ -53,7 +53,8 @@ func NewEventuallyConsistentMerkleRoot(
 		getter: getter,
 	}
 	ecmr.fetcher = newFetchDecider(
-		ecmr.log, ecmr.getAndCache, ECMRCtxTagKey{}, ECMRID, ecmr.config)
+		ecmr.log, config.MakeVLogger(ecmr.log), ecmr.getAndCache,
+		ECMRCtxTagKey{}, ECMRID, ecmr.config)
 	return ecmr
 }
 

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -166,7 +166,7 @@ func newBlockPrefetcher(retriever BlockRetriever,
 	}
 	if config != nil {
 		p.log = config.MakeLogger("PRE")
-		p.vlog = config.MakeVLogger("PRE")
+		p.vlog = config.MakeVLogger(p.log)
 	} else {
 		p.log = logger.NewNull()
 		p.vlog = libkb.NewVDebugLog(p.log)
@@ -409,7 +409,7 @@ func (p *blockPrefetcher) cancelQueuedPrefetch(ptr data.BlockPointer) {
 		delete(p.queuedPrefetchHandles, ptr)
 		p.log.Debug("cancelled queued prefetch for block %s", ptr)
 	} else {
-		p.vlog.Log(libkb.VLog1, "nothing to cancel for block %s", ptr)
+		p.vlog.Log(libkb.VLog2, "nothing to cancel for block %s", ptr)
 	}
 }
 
@@ -419,7 +419,7 @@ func (p *blockPrefetcher) markQueuedPrefetchDone(ptr data.BlockPointer) {
 	qp, present := p.queuedPrefetchHandles[ptr]
 	if !present {
 		p.vlog.CLogf(
-			context.Background(), libkb.VLog1, "queuedPrefetch not present in"+
+			context.Background(), libkb.VLog2, "queuedPrefetch not present in"+
 				" queuedPrefetchHandles: %s", ptr)
 		return
 	}
@@ -517,7 +517,7 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 	}
 	parentPre, isParentWaiting := p.prefetches[parentPtr.ID]
 	if !isParentWaiting {
-		p.vlog.CLogf(pre.ctx, libkb.VLog1,
+		p.vlog.CLogf(pre.ctx, libkb.VLog2,
 			"prefetcher doesn't know about parent block "+
 				"%s for child block %s", parentPtr, ptr.ID)
 		panic("prefetcher doesn't know about parent block when trying to " +
@@ -537,7 +537,7 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 		}
 		pre.parents[ptr.RefNonce][parentPtr] = parentPre.waitCh
 		if pre.subtreeBlockCount > 0 {
-			p.vlog.CLogf(ctx, libkb.VLog1,
+			p.vlog.CLogf(ctx, libkb.VLog2,
 				"Prefetching %v, action=%s, numBlocks=%d, isParentNew=%t",
 				ptr, action, pre.subtreeBlockCount, isParentNew)
 		}
@@ -742,7 +742,7 @@ func (p *blockPrefetcher) stopIfNeeded(
 
 	defer func() {
 		if doStop {
-			p.vlog.CLogf(ctx, libkb.VLog1,
+			p.vlog.CLogf(ctx, libkb.VLog2,
 				"stopping prefetch for block %s due to full cache (sync=%t)",
 				req.ptr.ID, req.action.Sync())
 		}
@@ -863,10 +863,10 @@ func (p *blockPrefetcher) run(
 			ptr := ptrInt.(data.BlockPointer)
 			pre, ok := p.prefetches[ptr.ID]
 			if !ok {
-				p.log.Debug("nothing to cancel for block %s", ptr)
+				p.vlog.Log(libkb.VLog2, "nothing to cancel for block %s", ptr)
 				continue
 			}
-			p.log.Debug("canceling prefetch for block %s", ptr)
+			p.vlog.Log(libkb.VLog2, "canceling prefetch for block %s", ptr)
 			// Walk up the block tree and delete every parent, but
 			// only ancestors of this given pointer with this
 			// refnonce.  Other references to the same ID might still
@@ -885,7 +885,7 @@ func (p *blockPrefetcher) run(
 			} else {
 				pre.req = req
 			}
-			p.vlog.CLogf(pre.ctx, libkb.VLog1,
+			p.vlog.CLogf(pre.ctx, libkb.VLog2,
 				"rescheduling top-block prefetch for block %s", blockID)
 			p.applyToParentsRecursive(p.rescheduleTopBlock, blockID, pre)
 		case reqInt := <-p.prefetchRequestCh.Out():
@@ -916,7 +916,7 @@ func (p *blockPrefetcher) run(
 			select {
 			case <-req.obseleted:
 				// This request was cancelled while it was waiting.
-				p.vlog.CLogf(context.Background(), libkb.VLog1,
+				p.vlog.CLogf(context.Background(), libkb.VLog2,
 					"Request not processing because it was canceled already"+
 						": id=%v action=%v", req.ptr.ID, req.action)
 				continue
@@ -928,7 +928,7 @@ func (p *blockPrefetcher) run(
 			if isPrefetchWaiting {
 				ctx = pre.ctx
 			}
-			p.vlog.CLogf(ctx, libkb.VLog1, "Handling request for %v, action=%s",
+			p.vlog.CLogf(ctx, libkb.VLog2, "Handling request for %v, action=%s",
 				req.ptr, req.action)
 
 			// Ensure the block is in the right cache.
@@ -963,7 +963,7 @@ func (p *blockPrefetcher) run(
 							pre.SubtreeBytesTotal-pre.SubtreeBytesFetched),
 						req.ptr.ID, pre)
 				} else {
-					p.vlog.CLogf(ctx, libkb.VLog1,
+					p.vlog.CLogf(ctx, libkb.VLog2,
 						"skipping prefetch for finished block %s", req.ptr.ID)
 					if req.prefetchStatus != FinishedPrefetch {
 						// Mark this block as finished in the cache.
@@ -971,7 +971,7 @@ func (p *blockPrefetcher) run(
 							ctx, req.ptr, req.kmd.TlfID(), b, req.lifetime,
 							FinishedPrefetch, req.action.CacheType())
 						if err != nil {
-							p.vlog.CLogf(ctx, libkb.VLog1,
+							p.vlog.CLogf(ctx, libkb.VLog2,
 								"Couldn't put finished block %s in cache: %+v",
 								req.ptr, err)
 						}
@@ -981,7 +981,7 @@ func (p *blockPrefetcher) run(
 				continue
 			}
 			if !req.action.Prefetch(b) {
-				p.vlog.CLogf(ctx, libkb.VLog1,
+				p.vlog.CLogf(ctx, libkb.VLog2,
 					"skipping prefetch for block %s, action %s",
 					req.ptr.ID, req.action)
 				if isPrefetchWaiting && !pre.req.action.Prefetch(b) {
@@ -999,7 +999,7 @@ func (p *blockPrefetcher) run(
 				(isPrefetchWaiting &&
 					req.action.Sync() == pre.req.action.Sync() &&
 					req.action.StopIfFull() == pre.req.action.StopIfFull()) {
-				p.vlog.CLogf(ctx, libkb.VLog1,
+				p.vlog.CLogf(ctx, libkb.VLog2,
 					"prefetch already triggered for block ID %s", req.ptr.ID)
 				continue
 			}
@@ -1018,7 +1018,7 @@ func (p *blockPrefetcher) run(
 				newAction := pre.req.action.Combine(req.action)
 				if pre.subtreeTriggered {
 					p.vlog.CLogf(
-						ctx, libkb.VLog1, "prefetch subtree already triggered "+
+						ctx, libkb.VLog2, "prefetch subtree already triggered "+
 							"for block ID %s", req.ptr.ID)
 					// Redundant prefetch request.
 					// We've already seen _this_ block, and already triggered
@@ -1071,7 +1071,7 @@ func (p *blockPrefetcher) run(
 				pre = p.newPrefetch(0, 0, true, req)
 				p.prefetches[req.ptr.ID] = pre
 				ctx = pre.ctx
-				p.vlog.CLogf(ctx, libkb.VLog1,
+				p.vlog.CLogf(ctx, libkb.VLog2,
 					"created new prefetch for block %s", req.ptr.ID)
 			}
 
@@ -1094,7 +1094,7 @@ func (p *blockPrefetcher) run(
 				continue
 			}
 			if isTail {
-				p.vlog.CLogf(ctx, libkb.VLog1,
+				p.vlog.CLogf(ctx, libkb.VLog2,
 					"completed prefetch for tail block %s ", req.ptr.ID)
 				// This is a tail block with no children.  Parent blocks are
 				// potentially waiting for this prefetch, so we percolate the
@@ -1116,7 +1116,7 @@ func (p *blockPrefetcher) run(
 			}
 			// This is not a tail block.
 			if numBlocks == 0 {
-				p.vlog.CLogf(ctx, libkb.VLog1,
+				p.vlog.CLogf(ctx, libkb.VLog2,
 					"no blocks to prefetch for block %s", req.ptr.ID)
 				// All the blocks to be triggered have already done so. Do
 				// nothing.  This is simply an optimization to avoid crawling
@@ -1124,7 +1124,7 @@ func (p *blockPrefetcher) run(
 				continue
 			}
 			if !isPrefetchWaiting {
-				p.vlog.CLogf(ctx, libkb.VLog1,
+				p.vlog.CLogf(ctx, libkb.VLog2,
 					"adding block %s to the prefetch tree", req.ptr.ID)
 				// This block doesn't appear in the prefetch tree, so it's the
 				// root of a new prefetch tree. Add it to the tree.
@@ -1135,7 +1135,7 @@ func (p *blockPrefetcher) run(
 				// shouldn't block anything above it in the tree from
 				// completing.
 			}
-			p.vlog.CLogf(ctx, libkb.VLog1,
+			p.vlog.CLogf(ctx, libkb.VLog2,
 				"prefetching %d block(s) with parent block %s "+
 					"[bytesFetched=%d, bytesTotal=%d]",
 				numBlocks, req.ptr.ID, numBytesFetched, numBytesTotal)
@@ -1215,7 +1215,7 @@ func (p *blockPrefetcher) cacheOrCancelPrefetch(ctx context.Context,
 		}
 
 		p.vlog.CLogf(
-			ctx, libkb.VLog1, "error prefetching block %s: %+v, canceling",
+			ctx, libkb.VLog2, "error prefetching block %s: %+v, canceling",
 			ptr.ID, err)
 		p.CancelPrefetch(ptr)
 	}

--- a/go/kbfs/libkbfs/quota_usage.go
+++ b/go/kbfs/libkbfs/quota_usage.go
@@ -5,10 +5,12 @@
 package libkbfs
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/keybase/client/go/kbfs/kbfsblock"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -55,16 +57,22 @@ type EventuallyConsistentQuotaUsage struct {
 	bgFetch bool
 }
 
+// QuotaUsageLogModule makes a log module for a quota usage log.
+func QuotaUsageLogModule(suffix string) string {
+	return fmt.Sprintf("%s - %s", ECQUID, suffix)
+}
+
 // NewEventuallyConsistentQuotaUsage creates a new
 // EventuallyConsistentQuotaUsage object.
 func NewEventuallyConsistentQuotaUsage(
-	config Config, loggerSuffix string) *EventuallyConsistentQuotaUsage {
+	config Config, log logger.Logger,
+	vlog *libkb.VDebugLog) *EventuallyConsistentQuotaUsage {
 	q := &EventuallyConsistentQuotaUsage{
 		config: config,
-		log:    config.MakeLogger(ECQUID + "-" + loggerSuffix),
+		log:    log,
 	}
 	q.fetcher = newFetchDecider(
-		q.log, q.getAndCache, ECQUCtxTagKey{}, ECQUID, q.config)
+		q.log, vlog, q.getAndCache, ECQUCtxTagKey{}, ECQUID, q.config)
 	return q
 }
 
@@ -72,8 +80,8 @@ func NewEventuallyConsistentQuotaUsage(
 // EventuallyConsistentQuotaUsage object.
 func NewEventuallyConsistentTeamQuotaUsage(
 	config Config, tid keybase1.TeamID,
-	loggerSuffix string) *EventuallyConsistentQuotaUsage {
-	q := NewEventuallyConsistentQuotaUsage(config, loggerSuffix)
+	log logger.Logger, vlog *libkb.VDebugLog) *EventuallyConsistentQuotaUsage {
+	q := NewEventuallyConsistentQuotaUsage(config, log, vlog)
 	q.tid = tid
 	return q
 }

--- a/go/kbfs/libkbfs/root_metadata.go
+++ b/go/kbfs/libkbfs/root_metadata.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libkey"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
@@ -477,7 +478,7 @@ func (md *RootMetadata) updateFromTlfHandle(newHandle *tlfhandle.Handle) error {
 // Possibly copies the MD, returns the copy if so, and whether copied.
 func (md *RootMetadata) loadCachedBlockChanges(
 	ctx context.Context, bps blockPutState, log logger.Logger,
-	codec kbfscodec.Codec) (*RootMetadata, bool) {
+	vlog *libkb.VDebugLog, codec kbfscodec.Codec) (*RootMetadata, bool) {
 	if md.data.Changes.Ops != nil {
 		return md, false
 	}
@@ -539,7 +540,7 @@ func (md *RootMetadata) loadCachedBlockChanges(
 		},
 		func(_ context.Context, ptr data.BlockPointer, block data.Block) error {
 			return nil
-		}, log)
+		}, log, vlog)
 
 	infos, err := fd.GetIndirectFileBlockInfos(ctx)
 	if err != nil {

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -49,6 +50,7 @@ const (
 func newConfigForTest(modeType InitModeType, loggerFn func(module string) logger.Logger) *ConfigLocal {
 	mode := modeTest{NewInitModeFromType(modeType)}
 	config := NewConfigLocal(mode, loggerFn, "", DiskCacheModeOff, &env.KBFSContext{})
+	config.SetVLogLevel(libkb.VLog1String)
 
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,


### PR DESCRIPTION
This commit turns many of the most prolific log lines into vlog lines, at debug level 1.  (Prefetcher logs get a demotion to debug level 2.)

As a compromise, at normal debug levels it logs a single line at the end of each major `folderBranchOps` operation, that includes the duration of the operation, for performance debugging if needed.  And if the operation takes more than a second, it logs an opening line too, to make sure _something_ is logged.

An example end log line is:

```
2019-04-12T17:23:52.666804-07:00 ▶ [DEBU kbfs(FBO 3209b467) folder_branch_ops.go:3014] 16b [duration=220.358µs] GetDirChildren NodeID(0xc421902a20) done, 138 entries: <nil> [tags:FID=7DF4w09kDJkYkrOeYDxMTw]
```

This improves the go source rsync benchmark by about 23%.  If we removed that single line still being logged, it would improve it by about 34% instead, but I'm not sure it's worth the loss of debugability.

This also leaves in place `bserver_remote` and `disk_block_cache` logs for now, just in case.  But maybe we can remove them in the future.

This also sets the mobile debug level to vlog1, since there is currently no way to turn on debugging in mobile, and there may be bugs we can't find without being able to turn this back on.  Since bulk transfers of data in mobile are unlikely right now, this seems acceptable.

Issue: KBFS-4054