### PR TITLE
libgit: add autogit tolerance for submodules

### DIFF
--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1129,6 +1130,10 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 }
 
 func TestRunnerSubmodule(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("submodule add doesn't work well on Windows")
+	}
+
 	ctx, config, tempdir := initConfigForRunner(t)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	defer os.RemoveAll(tempdir)

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -139,8 +139,8 @@ func gitExec(t *testing.T, gitDir, workTree string, command ...string) {
 	cmd := exec.Command("git",
 		append([]string{"--git-dir", gitDir, "--work-tree", workTree},
 			command...)...)
-	err := cmd.Run()
-	require.NoError(t, err)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
 }
 
 func makeLocalRepoWithOneFileCustomCommitMsg(t *testing.T,

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -1127,3 +1127,56 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 	require.True(t, master.IsDelete)
 	require.Len(t, master.Commits, 0)
 }
+
+func TestRunnerSubmodule(t *testing.T) {
+	ctx, config, tempdir := initConfigForRunner(t)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+	defer os.RemoveAll(tempdir)
+
+	shutdown := libgit.StartAutogit(config, 25)
+	defer shutdown()
+
+	t.Log("Make a local repo that will become a KBFS repo")
+	git1, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git1)
+	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
+	dotgit1 := filepath.Join(git1, ".git")
+
+	t.Log("Make a second local repo that will be a submodule")
+	git2, err := ioutil.TempDir(os.TempDir(), "kbfsgittest2")
+	require.NoError(t, err)
+	defer os.RemoveAll(git2)
+	makeLocalRepoWithOneFile(t, git2, "foo2", "hello2", "")
+	dotgit2 := filepath.Join(git2, ".git")
+
+	t.Log("Add the submodule to the first local repo")
+	// git-submodules requires a real working directory for some reason.
+	err = os.Chdir(git1)
+	require.NoError(t, err)
+	gitExec(t, dotgit1, git1, "submodule", "add", "-f", dotgit2)
+	gitExec(t, dotgit1, git1, "-c", "user.name=Foo",
+		"-c", "user.email=foo@foo.com", "commit", "-a", "-m", "submodule")
+
+	t.Log("Push the first local repo into KBFS")
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), config.MDOps(), config, "user1", tlf.Private)
+	require.NoError(t, err)
+	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
+	require.NoError(t, err)
+	testPush(t, ctx, config, git1, "refs/heads/master:refs/heads/master")
+
+	t.Log("Use autogit to browse it")
+	rootFS, err := libfs.NewFS(
+		ctx, config, h, data.MasterBranch, "", "", keybase1.MDPriorityNormal)
+	require.NoError(t, err)
+	fis, err := rootFS.ReadDir(".kbfs_autogit/test")
+	require.NoError(t, err)
+	require.Len(t, fis, 3 /* foo, kbfsgittest2, and .gitmodules */)
+	f, err := rootFS.Open(".kbfs_autogit/test/" + filepath.Base(git2))
+	require.NoError(t, err)
+	defer f.Close()
+	data, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(string(data), "git submodule"))
+}

--- a/go/kbfs/libgit/submodule_file.go
+++ b/go/kbfs/libgit/submodule_file.go
@@ -1,0 +1,112 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"io"
+	"time"
+
+	"github.com/pkg/errors"
+	billy "gopkg.in/src-d/go-billy.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+type submoduleFile struct {
+	name  string
+	mtime time.Time
+	data  []byte
+
+	// TODO: proper locking for `nextRead` if we ever use it outside
+	// of autogit (which always uses `ReadAt`).
+	nextRead int
+}
+
+const (
+	submodulePrefix = "git submodule at commit "
+)
+
+var _ billy.File = (*submoduleFile)(nil)
+
+func newSubmoduleFile(
+	h plumbing.Hash, name string, mtime time.Time) *submoduleFile {
+	data := []byte(submodulePrefix + h.String() + "\n")
+	return &submoduleFile{
+		name:  name,
+		mtime: mtime,
+		data:  data,
+	}
+}
+
+func (sf *submoduleFile) Len() int {
+	return len(sf.data)
+}
+
+func (sf *submoduleFile) Name() string {
+	return sf.name
+}
+
+func (sf *submoduleFile) Write(_ []byte) (n int, err error) {
+	return 0, errors.New("diff files can't be written")
+}
+
+func (sf *submoduleFile) Read(p []byte) (n int, err error) {
+	if sf.nextRead >= sf.Len() {
+		return 0, io.EOF
+	}
+	n = copy(p, sf.data[sf.nextRead:])
+	sf.nextRead += n
+	return n, nil
+}
+
+func (sf *submoduleFile) ReadAt(p []byte, off int64) (n int, err error) {
+	if off >= int64(sf.Len()) {
+		return 0, io.EOF
+	}
+
+	n = copy(p, sf.data[off:])
+	return n, nil
+}
+
+func (sf *submoduleFile) Seek(offset int64, whence int) (int64, error) {
+	newOffset := offset
+	switch whence {
+	case io.SeekStart:
+	case io.SeekCurrent:
+		newOffset = int64(sf.nextRead) + offset
+	case io.SeekEnd:
+		newOffset = int64(sf.Len()) + offset
+	}
+	if newOffset < 0 {
+		return 0, errors.Errorf("Cannot seek to offset %d", newOffset)
+	}
+
+	sf.nextRead = int(newOffset)
+	return newOffset, nil
+}
+
+func (sf *submoduleFile) Close() error {
+	return nil
+}
+
+func (sf *submoduleFile) Lock() error {
+	return errors.New("diff files can't be locked")
+}
+
+func (sf *submoduleFile) Unlock() error {
+	return errors.New("diff files can't be unlocked")
+}
+
+func (sf *submoduleFile) Truncate(size int64) error {
+	return errors.New("diff files can't be truncated")
+}
+
+func (sf *submoduleFile) GetInfo() *submoduleFileInfo {
+	return &submoduleFileInfo{
+		name:  sf.Name(),
+		size:  int64(sf.Len()),
+		mtime: sf.mtime,
+		sf:    sf,
+	}
+}

--- a/go/kbfs/libgit/submodule_file_info.go
+++ b/go/kbfs/libgit/submodule_file_info.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"os"
+	"time"
+)
+
+type submoduleFileInfo struct {
+	name  string
+	size  int64
+	mtime time.Time
+	sf    *submoduleFile
+}
+
+var _ os.FileInfo = (*submoduleFileInfo)(nil)
+
+func (sfi *submoduleFileInfo) Name() string {
+	return sfi.name
+}
+
+func (sfi *submoduleFileInfo) Size() int64 {
+	return sfi.size
+}
+
+func (sfi *submoduleFileInfo) Mode() os.FileMode {
+	// Make it read-only.
+	return 0600
+}
+
+func (sfi *submoduleFileInfo) ModTime() time.Time {
+	return sfi.mtime
+}
+
+func (sfi *submoduleFileInfo) IsDir() bool {
+	return false
+}
+
+func (sfi *submoduleFileInfo) Sys() interface{} {
+	return nil
+}


### PR DESCRIPTION
Previously, autogit would EIO if there was a submodule, because it's represented internally by the commit hash from the other repo.

Instead, detect when we can't find the git object for an entry, and turn that into a special file that just contains the string "git submodule at commit ", followed by the commit in the other repo.

It proved nearly impossible to test submodules without running a full kbfsgit runner process, so I wrote the test under `kbfsgit/` instead of `libgit/`.  Please have mercy on my soul.

Issue: KBFS-4046
