### PR TITLE
folder_branch_ops: fix crash during partial sync mark-and-sweep

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1172,6 +1172,10 @@ func (fbo *folderBranchOps) markRecursive(
 		if err != nil {
 			return err
 		}
+		if childNode == nil {
+			// A symlink.
+			continue
+		}
 		err = fbo.markRecursive(ctx, lState, childNode, rmd, tag, cacheType)
 		if err != nil {
 			return err


### PR DESCRIPTION
If the synced paths contain a symlink, it would crash because `childNode` would be `nil`.