### PR TITLE
simplefs: speed up recursive copies by caching FSes

### DIFF
--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -717,6 +717,14 @@ func (fs *fsBlocker) ReadDir(p string) (fis []os.FileInfo, err error) {
 	return fs.FS.ReadDir(p)
 }
 
+func (fs *fsBlocker) Chroot(p string) (newFS billy.Filesystem, err error) {
+	chrootFS, err := fs.FS.ChrootAsLibFS(p)
+	if err != nil {
+		return nil, err
+	}
+	return &fsBlocker{chrootFS, fs.signalCh, fs.unblockCh}, nil
+}
+
 type fsBlockerMaker struct {
 	signalCh  chan<- struct{}
 	unblockCh <-chan struct{}


### PR DESCRIPTION
It was super expensive to create new FS objects for every copied element.  Instead, use `Chroot()` intelligently and reuse FSes across copied elements when possible.  This speeds up `keybase fs cp -r` immensely -- copying the go source code now only takes 20s (compared to ~60s with FUSE; before this commit SimpleFS took well over 6 minutes, though I grew impatient and didn't even let it finish).

Also I was annoyed by the inconsistency of "dst" vs. "dest" everywhere, so I made everything "dest" to match the simplefs protocol args.

Issue: KBFS-4051
