### PR TITLE
pipeline search, reindex modes

### DIFF
--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -87,10 +87,15 @@ func (idx *Indexer) Start(ctx context.Context, uid gregor1.UID) {
 	}
 	idx.started = true
 	ticker := libkb.NewBgTicker(time.Hour)
-	// run one quickly
-	idx.SelectiveSync(ctx, uid, false /*forceReindex */)
 	go func() {
 		idx.Debug(ctx, "starting SelectiveSync bg loop")
+
+		// run one quickly
+		select {
+		case <-time.After(libkb.DefaultBgTickerWait):
+			idx.SelectiveSync(ctx, uid, false /*forceReindex */)
+		}
+
 		for {
 			select {
 			case <-ticker.C:

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -531,9 +531,11 @@ func (idx *Indexer) allConvs(ctx context.Context, uid gregor1.UID) (map[string]t
 		if err != nil {
 			return nil, err
 		}
-		pagination = inbox.Pagination
-		pagination.Num = idx.pageSize
-		pagination.Previous = nil
+		if inbox.Pagination != nil {
+			pagination = inbox.Pagination
+			pagination.Num = idx.pageSize
+			pagination.Previous = nil
+		}
 		for _, conv := range inbox.ConvsUnverified {
 			if !conv.Conv.IsSelfFinalized(username) {
 				convID := conv.GetConvID()

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -658,6 +658,11 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 		switch opts.ReindexMode {
 		case chat1.ReIndexingMode_PRESEARCH_SYNC:
 			for _, conv := range convList {
+				select {
+				case <-ectx.Done():
+					return ectx.Err()
+				default:
+				}
 				convIDStr := conv.GetConvID().String()
 				convLock.Lock()
 				convIdx := convIdxMap[convIDStr]

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -359,6 +359,11 @@ func (idx *Indexer) convHits(ctx context.Context, conv types.RemoteConversation,
 	hits.Query = query
 	if hitUICh != nil {
 		// Stream search hits back to the UI channel
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		hitUICh <- *hits
 	}
 	return hits, nil
@@ -496,6 +501,11 @@ func (idx *Indexer) reindexConvWithUIUpdate(ctx context.Context, conv chat1.Conv
 		totalPercentIndexed -= percentIndexed
 		totalPercentIndexed += newPercentIndexed
 		if indexUICh != nil { // stream back index percentage as we update it
+			select {
+			case <-ctx.Done():
+				return nil, totalPercentIndexed, ctx.Err()
+			default:
+			}
 			indexUICh <- chat1.ChatSearchIndexStatus{
 				PercentIndexed: totalPercentIndexed / totalConvs,
 			}
@@ -651,6 +661,11 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 			}
 		}
 		if indexUICh != nil {
+			select {
+			case <-ectx.Done():
+				return ectx.Err()
+			default:
+			}
 			indexUICh <- chat1.ChatSearchIndexStatus{
 				PercentIndexed: totalPercentIndexed / len(convList),
 			}

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -618,7 +618,7 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 	var convLock sync.Mutex
 	// convID -> convIdx
 	convIdxMap := map[string]*chat1.ConversationIndex{}
-	convIdxCh := make(chan string)
+	convIdxCh := make(chan string, 200)
 	eg, ectx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		defer close(convIdxCh)

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"golang.org/x/sync/errgroup"
 )
 
 type Indexer struct {
@@ -25,7 +26,7 @@ type Indexer struct {
 
 	store    *store
 	pageSize int
-	stopCh   chan chan struct{}
+	stopCh   chan struct{}
 	started  bool
 
 	maxSyncConvs int
@@ -43,7 +44,7 @@ func NewIndexer(g *globals.Context) *Indexer {
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "Search.Indexer", false),
 		store:        newStore(g),
 		pageSize:     defaultPageSize,
-		stopCh:       make(chan chan struct{}),
+		stopCh:       make(chan struct{}),
 	}
 	switch idx.G().GetAppType() {
 	case libkb.MobileAppType:
@@ -86,14 +87,18 @@ func (idx *Indexer) Start(ctx context.Context, uid gregor1.UID) {
 	}
 	idx.started = true
 	ticker := libkb.NewBgTicker(time.Hour)
+	// run one quickly
+	idx.SelectiveSync(ctx, uid, false /*forceReindex */)
 	go func() {
+		idx.Debug(ctx, "starting SelectiveSync bg loop")
 		for {
 			select {
 			case <-ticker.C:
 				// queue up some jobs on the background loader
+				idx.Debug(ctx, "running SelectiveSync")
 				idx.SelectiveSync(ctx, uid, false /*forceReindex */)
-			case ch := <-idx.stopCh:
-				close(ch)
+			case <-idx.stopCh:
+				idx.Debug(ctx, "stopping SelectiveSync loop")
 				ticker.Stop()
 				return
 			}
@@ -108,11 +113,11 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 
 	ch := make(chan struct{})
 	if idx.started {
+		close(idx.stopCh)
+		idx.stopCh = make(chan struct{})
 		idx.started = false
-		idx.stopCh <- ch
-	} else {
-		close(ch)
 	}
+	close(ch)
 	return ch
 }
 
@@ -284,22 +289,24 @@ func (idx *Indexer) searchHitsFromMsgIDs(ctx context.Context, conv types.RemoteC
 	hits := []chat1.ChatSearchHit{}
 	for i, msg := range msgs {
 		if idSet.Contains(msg.GetMessageID()) && msg.IsValidFull() && opts.Matches(msg) {
-			matches := searchMatches(msg, queryRe)
-			afterLimit := i - opts.AfterContext
-			if afterLimit < 0 {
-				afterLimit = 0
+			var afterMessages, beforeMessages []chat1.UIMessage
+			if opts.AfterContext > 0 {
+				afterLimit := i - opts.AfterContext
+				if afterLimit < 0 {
+					afterLimit = 0
+				}
+				afterMessages = getUIMsgs(ctx, idx.G(), convID, uid, msgs[afterLimit:i])
 			}
-			afterMessages := getUIMsgs(ctx, idx.G(), convID, uid, msgs[afterLimit:i])
 
-			var beforeMessages []chat1.UIMessage
-			if i < len(msgs)-1 {
-				beforeLimit := i + 1 + opts.AfterContext
+			if opts.BeforeContext > 0 && i < len(msgs)-1 {
+				beforeLimit := i + 1 + opts.BeforeContext
 				if beforeLimit >= len(msgs) {
 					beforeLimit = len(msgs)
 				}
 				beforeMessages = getUIMsgs(ctx, idx.G(), convID, uid, msgs[i+1:beforeLimit])
 			}
 
+			matches := searchMatches(msg, queryRe)
 			searchHit := chat1.ChatSearchHit{
 				BeforeMessages: beforeMessages,
 				HitMessage:     utils.PresentMessageUnboxed(ctx, idx.G(), msg, uid, convID),
@@ -322,6 +329,34 @@ func (idx *Indexer) searchHitsFromMsgIDs(ctx context.Context, conv types.RemoteC
 		Hits:     hits,
 		Time:     hits[0].HitMessage.Valid().Ctime,
 	}, nil
+}
+
+func (idx *Indexer) convHits(ctx context.Context, conv types.RemoteConversation,
+	convIdx *chat1.ConversationIndex, uid gregor1.UID, tokens tokenMap, queryRe *regexp.Regexp,
+	query string, hitUICh chan chat1.ChatSearchInboxHit,
+	opts chat1.SearchOpts) (*chat1.ChatSearchInboxHit, error) {
+
+	msgIDs, err := idx.searchConv(ctx, conv.GetConvID(), convIdx, uid, tokens, opts)
+	if err != nil {
+		return nil, err
+	}
+	hits, err := idx.searchHitsFromMsgIDs(ctx, conv, uid, msgIDs, queryRe, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(msgIDs) != hits.Size() {
+		idx.Debug(ctx, "Search: hit mismatch, found %d msgIDs in index, %d hits in conv: %v",
+			len(msgIDs), hits.Size(), conv.GetName())
+	}
+	if hits == nil {
+		return nil, nil
+	}
+	hits.Query = query
+	if hitUICh != nil {
+		// Stream search hits back to the UI channel
+		hitUICh <- *hits
+	}
+	return hits, nil
 }
 
 type reindexOpts struct {
@@ -358,7 +393,8 @@ func (idx *Indexer) reindexConv(ctx context.Context, conv chat1.Conversation, ui
 
 	convID := conv.GetConvID()
 	defer idx.Trace(ctx, func() error { return err },
-		fmt.Sprintf("Indexer.reindex: convID: %v, minID: %v, maxID: %v, numMissing: %v", convID, minIdxID, maxIdxID, len(missingIDs)))()
+		fmt.Sprintf("Indexer.reindex: convID: %v, minID: %v, maxID: %v, numMissing: %v",
+			convID, minIdxID, maxIdxID, len(missingIDs)))()
 
 	reason := chat1.GetThreadReason_INDEXED_SEARCH
 	if len(missingIDs) < idx.pageSize {
@@ -438,6 +474,29 @@ func (idx *Indexer) reindexConv(ctx context.Context, conv chat1.Conversation, ui
 		}
 	}
 	return completedJobs, convIdx, nil
+}
+
+func (idx *Indexer) reindexConvWithUIUpdate(ctx context.Context, conv chat1.Conversation,
+	uid gregor1.UID, convIdx *chat1.ConversationIndex, indexUICh chan chat1.ChatSearchIndexStatus,
+	totalPercentIndexed, totalConvs int) (*chat1.ConversationIndex, int, error) {
+
+	percentIndexed := convIdx.PercentIndexed(conv)
+	_, convIdx, err := idx.reindexConv(ctx, conv, uid, convIdx,
+		reindexOpts{forceReindex: true})
+	if err != nil {
+		return convIdx, totalPercentIndexed, err
+	}
+	newPercentIndexed := convIdx.PercentIndexed(conv)
+	if percentIndexed != newPercentIndexed { // only write out updates..
+		totalPercentIndexed -= percentIndexed
+		totalPercentIndexed += newPercentIndexed
+		if indexUICh != nil { // stream back index percentage as we update it
+			indexUICh <- chat1.ChatSearchIndexStatus{
+				PercentIndexed: totalPercentIndexed / totalConvs,
+			}
+		}
+	}
+	return convIdx, totalPercentIndexed, nil
 }
 
 func (idx *Indexer) allConvs(ctx context.Context, uid gregor1.UID) (map[string]types.RemoteConversation, error) {
@@ -548,115 +607,183 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 	if err != nil || len(convMap) == 0 {
 		return nil, err
 	}
-	idx.Debug(ctx, "Search: allConvs: %d", len(convMap))
+	convList := idx.flattenConvMap(ctx, uid, convMap)
 
+	var totalPercentIndexed int
+	var convLock sync.Mutex
 	// convID -> convIdx
 	convIdxMap := map[string]*chat1.ConversationIndex{}
-	totalPercentIndexed := 0
-	for _, conv := range convMap {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-		convID := conv.GetConvID()
-		convIdx, err := idx.store.getConvIndex(ctx, convID, uid)
-		if err != nil {
-			return nil, err
-		}
-		totalPercentIndexed += convIdx.PercentIndexed(conv.Conv)
-		convIdxMap[convID.String()] = convIdx
-	}
-	if indexUICh != nil {
-		indexUICh <- chat1.ChatSearchIndexStatus{
-			PercentIndexed: totalPercentIndexed / len(convMap),
-		}
-	}
-	idx.Debug(ctx, "Search: convIdxMap: %d percent: %d", len(convIdxMap), totalPercentIndexed/len(convMap))
-	switch opts.ReindexMode {
-	case chat1.ReIndexingMode_FORCE:
-		for convIDStr, conv := range convMap {
-			convIdx := convIdxMap[convIDStr]
-			percentIndexed := convIdx.PercentIndexed(conv.Conv)
-			_, convIdx, err = idx.reindexConv(ctx, conv.Conv, uid, convIdx,
-				reindexOpts{forceReindex: true})
+	convIdxCh := make(chan string)
+	eg, ectx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		defer close(convIdxCh)
+		for _, conv := range convList {
+			select {
+			case <-ectx.Done():
+				return ectx.Err()
+			default:
+			}
+
+			convID := conv.GetConvID()
+			convIdx, err := idx.store.getConvIndex(ectx, convID, uid)
 			if err != nil {
-				idx.Debug(ctx, "Search: Unable to reindexConv: %v, %v", conv.Conv.GetConvID(), err)
+				return err
+			}
+			totalPercentIndexed += convIdx.PercentIndexed(conv.Conv)
+			convIDStr := convID.String()
+
+			convLock.Lock()
+			convIdxMap[convIDStr] = convIdx
+			convLock.Unlock()
+
+			switch opts.ReindexMode {
+			case chat1.ReIndexingMode_PRESEARCH_SYNC:
+				// don't send the conv to be searched until we reindex
+			default:
+				convIdxCh <- convIDStr
+			}
+		}
+		if indexUICh != nil {
+			indexUICh <- chat1.ChatSearchIndexStatus{
+				PercentIndexed: totalPercentIndexed / len(convList),
+			}
+		}
+		idx.Debug(ectx, "Search: convIdxMap: %d percent: %d", len(convIdxMap), totalPercentIndexed/len(convList))
+
+		switch opts.ReindexMode {
+		case chat1.ReIndexingMode_PRESEARCH_SYNC:
+			for _, conv := range convList {
+				convIDStr := conv.GetConvID().String()
+				convLock.Lock()
+				convIdx := convIdxMap[convIDStr]
+				convLock.Unlock()
+
+				convIdx, totalPercentIndexed, err = idx.reindexConvWithUIUpdate(ectx, conv.Conv, uid, convIdx,
+					indexUICh, totalPercentIndexed, len(convList))
+				if err != nil {
+					idx.Debug(ectx, "Search: Unable to reindexConv: %v, %v", convIDStr, err)
+					continue
+				}
+				convLock.Lock()
+				convIdxMap[convIDStr] = convIdx
+				convLock.Unlock()
+
+				convIdxCh <- convIDStr
+			}
+		}
+		return nil
+	})
+
+	var numConvsSearched int
+	// convID -> hit
+	hitMap := make(map[string]chat1.ChatSearchInboxHit)
+	eg.Go(func() error {
+		defer func() {
+			for range convIdxCh {
+				// drain the channel in case we short circuit the search.
+			}
+		}()
+		for convIDStr := range convIdxCh {
+			select {
+			case <-ectx.Done():
+				return ectx.Err()
+			default:
+			}
+
+			convLock.Lock()
+			convIdx := convIdxMap[convIDStr]
+			convLock.Unlock()
+
+			conv := convMap[convIDStr]
+			numConvsSearched++
+			convHits, err := idx.convHits(ectx, conv, convIdx, uid,
+				tokens, queryRe, query, hitUICh, opts)
+			if err != nil {
+				return err
+			}
+			if convHits == nil {
 				continue
 			}
-			convIdxMap[convIDStr] = convIdx
-			newPercentIndexed := convIdx.PercentIndexed(conv.Conv)
-			if percentIndexed != newPercentIndexed { // only write out updates..
-				totalPercentIndexed -= percentIndexed
-				totalPercentIndexed += newPercentIndexed
-				if indexUICh != nil { // stream back index percentage as we update it
-					indexUICh <- chat1.ChatSearchIndexStatus{
-						PercentIndexed: totalPercentIndexed / len(convMap),
-					}
+			hitMap[convIDStr] = *convHits
+			if opts.MaxConvsSearched > 0 && numConvsSearched >= opts.MaxConvsSearched {
+				idx.Debug(ectx, "Search: max search convs reached, ending search")
+				break
+			}
+			if opts.MaxConvsHit > 0 && len(hitMap) >= opts.MaxConvsHit {
+				idx.Debug(ectx, "Search: max hit convs reached, ending search")
+				break
+			}
+		}
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	switch opts.ReindexMode {
+	case chat1.ReIndexingMode_POSTSEARCH_ASYNC,
+		chat1.ReIndexingMode_POSTSEARCH_SYNC:
+		for _, conv := range convList {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+			convIDStr := conv.GetConvID().String()
+			convIdx := convIdxMap[convIDStr]
+
+			switch opts.ReindexMode {
+			// kick this off in the background after we have our results so there is no
+			// lock contention during the search
+			case chat1.ReIndexingMode_POSTSEARCH_ASYNC:
+				_, _, err = idx.reindexConv(ctx, conv.Conv, uid, convIdx, reindexOpts{forceReindex: false})
+				if err != nil {
+					return nil, err
 				}
+			// reindex all of the conversations and research to populate any new results
+			case chat1.ReIndexingMode_POSTSEARCH_SYNC:
+				// ignore any fully indexed convs since we respect
+				// opts.MaxConvsSearched
+				if convIdx.PercentIndexed(conv.Conv) == 100 {
+					continue
+				}
+				convIdx, totalPercentIndexed, err = idx.reindexConvWithUIUpdate(ctx, conv.Conv, uid,
+					convIdx, indexUICh, totalPercentIndexed, len(convList))
+				if err != nil {
+					return nil, err
+				}
+
+				if opts.MaxConvsSearched > 0 && numConvsSearched >= opts.MaxConvsSearched {
+					idx.Debug(ctx, "Search: postSync: max search convs reached, reindexing without sending more search results")
+					continue
+				}
+				if opts.MaxConvsHit > 0 && len(hitMap) >= opts.MaxConvsHit {
+					idx.Debug(ctx, "Search: postSync: max hit convs reached, reindexing without sending more search results")
+					continue
+				}
+
+				numConvsSearched++
+				convHits, err := idx.convHits(ctx, conv, convIdx, uid,
+					tokens, queryRe, query, hitUICh, opts)
+				if err != nil {
+					return nil, err
+				}
+				if convHits == nil {
+					continue
+				}
+				hitMap[convIDStr] = *convHits
 			}
 		}
 	}
 
-	var numConvsSearched, numConvsHit int
-	hits := []chat1.ChatSearchInboxHit{}
-	convList := idx.flattenConvMap(ctx, uid, convMap)
-	idx.Debug(ctx, "Search: beginning conv searches")
-	for _, conv := range convList {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-		convID := conv.GetConvID()
-		convIDStr := convID.String()
-		numConvsSearched++
-		convIdx := convIdxMap[convIDStr]
-		msgIDs, err := idx.searchConv(ctx, convID, convIdx, uid, tokens, opts)
-		if err != nil {
-			return nil, err
-		}
-		convHits, err := idx.searchHitsFromMsgIDs(ctx, conv, uid, msgIDs, queryRe, opts)
-		if err != nil {
-			return nil, err
-		}
-		if len(msgIDs) != convHits.Size() {
-			idx.Debug(ctx, "Search: hit mismatch, found %d msgIDs in index, %d hits in conv: %v",
-				len(msgIDs), convHits.Size(), conv.GetName())
-		}
-		if convHits == nil {
-			continue
-		}
-		convHits.Query = query
-		numConvsHit++
-		if hitUICh != nil {
-			// Stream search hits back to the UI channel
-			hitUICh <- *convHits
-		}
-		hits = append(hits, *convHits)
-		if opts.MaxConvsSearched > 0 && numConvsSearched >= opts.MaxConvsSearched {
-			idx.Debug(ctx, "Search: max search convs reached, ending search")
-			break
-		}
-		if opts.MaxConvsHit > 0 && numConvsHit >= opts.MaxConvsHit {
-			idx.Debug(ctx, "Search: max hit convs reached, ending search")
-			break
-		}
+	hits := make([]chat1.ChatSearchInboxHit, len(hitMap))
+	index := 0
+	for _, hit := range hitMap {
+		hits[index] = hit
+		index++
 	}
-	// kick this off in the background after we have our results so there is no
-	// lock contention during the search
-	switch opts.ReindexMode {
-	case chat1.ReIndexingMode_AFTERSEARCH:
-		for _, conv := range convList {
-			convIDStr := conv.GetConvID().String()
-			convIdx := convIdxMap[convIDStr]
-			_, _, err = idx.reindexConv(ctx, conv.Conv, uid, convIdx, reindexOpts{forceReindex: false})
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	percentIndexed := totalPercentIndexed / len(convMap)
+	percentIndexed := totalPercentIndexed / len(convList)
 	res = &chat1.ChatSearchInboxResults{
 		Hits:           hits,
 		PercentIndexed: percentIndexed,

--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -822,7 +822,7 @@ func TestChatSearchInbox(t *testing.T) {
 
 		// DB nuke, ensure that we reindex after the search
 		g1.LocalChatDb.Nuke()
-		opts.ReindexMode = chat1.ReIndexingMode_FORCE // force reindex so we're fully up to date.
+		opts.ReindexMode = chat1.ReIndexingMode_PRESEARCH_SYNC // force reindex so we're fully up to date.
 		res = runSearch(query, opts, true /* expectedReindex*/)
 		require.Equal(t, 1, len(res.Hits))
 		convHit = res.Hits[0]
@@ -840,7 +840,20 @@ func TestChatSearchInbox(t *testing.T) {
 		g1.LocalChatDb.Nuke()
 		ictx := globals.CtxAddIdentifyMode(ctx, keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil)
 		indexer1.SelectiveSync(ictx, uid1, true /* forceReindex */)
-		opts.ReindexMode = chat1.ReIndexingMode_AFTERSEARCH
+		opts.ReindexMode = chat1.ReIndexingMode_POSTSEARCH_ASYNC
+		res = runSearch(query, opts, true /* expectedReindex*/)
+		require.Equal(t, 1, len(res.Hits))
+		convHit = res.Hits[0]
+		require.Equal(t, convID, convHit.ConvID)
+		require.Equal(t, 1, len(convHit.Hits))
+		verifyHit(convID, []chat1.MessageID{msgID3, msgID7}, msgID8, nil, []chat1.ChatSearchMatch{searchMatch}, convHit.Hits[0])
+		verifySearchDone(1)
+		verifyIndex(expectedIndex)
+
+		// Verify POSTSEARCH_SYNC
+		g1.LocalChatDb.Nuke()
+		indexer1.SelectiveSync(ictx, uid1, true /* forceReindex */)
+		opts.ReindexMode = chat1.ReIndexingMode_POSTSEARCH_SYNC
 		res = runSearch(query, opts, true /* expectedReindex*/)
 		require.Equal(t, 1, len(res.Hits))
 		convHit = res.Hits[0]

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -790,9 +790,9 @@ func (c *chatServiceHandler) SearchInboxV1(ctx context.Context, opts searchInbox
 		opts.MaxHits = 10
 	}
 
-	reindexMode := chat1.ReIndexingMode_AFTERSEARCH
+	reindexMode := chat1.ReIndexingMode_POSTSEARCH_ASYNC
 	if opts.ForceReindex {
-		reindexMode = chat1.ReIndexingMode_FORCE
+		reindexMode = chat1.ReIndexingMode_PRESEARCH_SYNC
 	}
 	searchOpts := chat1.SearchOpts{
 		ReindexMode:   reindexMode,

--- a/go/client/cmd_chat_search_inbox.go
+++ b/go/client/cmd_chat_search_inbox.go
@@ -95,9 +95,9 @@ func (c *CmdChatSearchInbox) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 1 {
 		return errors.New("usage: keybase chat search <query>")
 	}
-	reindexMode := chat1.ReIndexingMode_AFTERSEARCH
+	reindexMode := chat1.ReIndexingMode_POSTSEARCH_ASYNC
 	if ctx.Bool("force-reindex") {
-		reindexMode = chat1.ReIndexingMode_FORCE
+		reindexMode = chat1.ReIndexingMode_PRESEARCH_SYNC
 	}
 	c.query = ctx.Args().Get(0)
 	c.opts.ReindexMode = reindexMode

--- a/go/libkb/bgticker.go
+++ b/go/libkb/bgticker.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-const defaultWait = 5 * time.Second
+const DefaultBgTickerWait = 5 * time.Second
 
 type BgTicker struct {
 	C          <-chan time.Time
@@ -20,7 +20,7 @@ type BgTicker struct {
 // NewBgTicker will panic if wait > duration as time.Ticker does with a
 // negative duration.
 func NewBgTicker(duration time.Duration) *BgTicker {
-	return NewBgTickerWithWait(duration, defaultWait)
+	return NewBgTickerWithWait(duration, DefaultBgTickerWait)
 }
 
 func NewBgTickerWithWait(duration time.Duration, wait time.Duration) *BgTicker {

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1910,23 +1910,26 @@ func (e GetThreadReason) String() string {
 type ReIndexingMode int
 
 const (
-	ReIndexingMode_NONE        ReIndexingMode = 0
-	ReIndexingMode_FORCE       ReIndexingMode = 1
-	ReIndexingMode_AFTERSEARCH ReIndexingMode = 2
+	ReIndexingMode_NONE             ReIndexingMode = 0
+	ReIndexingMode_PRESEARCH_SYNC   ReIndexingMode = 1
+	ReIndexingMode_POSTSEARCH_ASYNC ReIndexingMode = 2
+	ReIndexingMode_POSTSEARCH_SYNC  ReIndexingMode = 3
 )
 
 func (o ReIndexingMode) DeepCopy() ReIndexingMode { return o }
 
 var ReIndexingModeMap = map[string]ReIndexingMode{
-	"NONE":        0,
-	"FORCE":       1,
-	"AFTERSEARCH": 2,
+	"NONE":             0,
+	"PRESEARCH_SYNC":   1,
+	"POSTSEARCH_ASYNC": 2,
+	"POSTSEARCH_SYNC":  3,
 }
 
 var ReIndexingModeRevMap = map[ReIndexingMode]string{
 	0: "NONE",
-	1: "FORCE",
-	2: "AFTERSEARCH",
+	1: "PRESEARCH_SYNC",
+	2: "POSTSEARCH_ASYNC",
+	3: "POSTSEARCH_SYNC",
 }
 
 func (e ReIndexingMode) String() string {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -542,8 +542,9 @@
 
   enum ReIndexingMode {
     NONE_0,
-    FORCE_1,
-    AFTERSEARCH_2
+    PRESEARCH_SYNC_1,
+    POSTSEARCH_ASYNC_2,
+    POSTSEARCH_SYNC_3
   }
 
   record SearchOpts {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -1411,8 +1411,9 @@
       "name": "ReIndexingMode",
       "symbols": [
         "NONE_0",
-        "FORCE_1",
-        "AFTERSEARCH_2"
+        "PRESEARCH_SYNC_1",
+        "POSTSEARCH_ASYNC_2",
+        "POSTSEARCH_SYNC_3"
       ]
     },
     {

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1463,7 +1463,7 @@ function* inboxSearch(state, action) {
             query.stringValue().length > 0
               ? Constants.inboxSearchMaxNameResults
               : Constants.inboxSearchMaxUnreadNameResults,
-          reindexMode: RPCChatTypes.commonReIndexingMode.none,
+          reindexMode: RPCChatTypes.commonReIndexingMode.postsearchSync,
           sentAfter: 0,
           sentBefore: 0,
           sentBy: '',

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -155,8 +155,9 @@ export const commonNotificationKind = {
 
 export const commonReIndexingMode = {
   none: 0,
-  force: 1,
-  aftersearch: 2,
+  presearchSync: 1,
+  postsearchAsync: 2,
+  postsearchSync: 3,
 }
 
 export const commonRetentionPolicyType = {

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -571,8 +571,9 @@ export const commonNotificationKind = {
 
 export const commonReIndexingMode = {
   none: 0,
-  force: 1,
-  aftersearch: 2,
+  presearchSync: 1,
+  postsearchAsync: 2,
+  postsearchSync: 3,
 }
 
 export const commonRetentionPolicyType = {
@@ -1169,8 +1170,9 @@ export type ProfileSearchConvStats = $ReadOnly<{numMessages: Int, indexSize: Int
 export type RateLimit = $ReadOnly<{name: String, callsRemaining: Int, windowReset: Int, maxCalls: Int}>
 export type ReIndexingMode =
   | 0 // NONE_0
-  | 1 // FORCE_1
-  | 2 // AFTERSEARCH_2
+  | 1 // PRESEARCH_SYNC_1
+  | 2 // POSTSEARCH_ASYNC_2
+  | 3 // POSTSEARCH_SYNC_3
 
 export type Reaction = $ReadOnly<{ctime: Gregor1.Time, reactionMsgID: MessageID}>
 export type ReactionMap = $ReadOnly<{reactions: {[key: string]: {[key: string]: Reaction}}}>


### PR DESCRIPTION
patch does the following:

- splits the search process into a pipeline of first reading the index off disk to calculate the current indexed percentage and then searching the conv. this gets the first hits back to the UI much faster than blocking on reading every index before searching
- splits the reindexing modes into pre/post search sync/async and uses `POSTSEARCH_SYNC` as the default for the UI. as long as the search is not cancelled the UI will continue to have conversations reindexed and will return any new results 
- runs selective sync during startup after a short delay since it was unlikely to trigger on mobile