### PR TITLE
Dismiss team badges on nav into teams tab on nav2

### DIFF
--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -10,6 +10,7 @@
       "teams": "Array<string>",
       "user": "string"
     },
+    "clearNavBadges": {},
     "createNewTeam": {
       "joinSubteam": "boolean",
       "teamname": "string",
@@ -47,7 +48,9 @@
       "_description": "Fetches the channel information for all channels in a team from the server. Should only be called for components that need the full list.",
       "teamname": "string"
     },
-    "getTeams": {},
+    "getTeams": {
+      "clearNavBadges?": "boolean"
+    },
     "getDetails": {
       "teamname": "string"
     },

--- a/shared/actions/teams-gen.js
+++ b/shared/actions/teams-gen.js
@@ -19,6 +19,7 @@ export const addUserToTeams = 'teams:addUserToTeams'
 export const badgeAppForTeams = 'teams:badgeAppForTeams'
 export const checkRequestedAccess = 'teams:checkRequestedAccess'
 export const clearAddUserToTeamsResults = 'teams:clearAddUserToTeamsResults'
+export const clearNavBadges = 'teams:clearNavBadges'
 export const clearTeamRequests = 'teams:clearTeamRequests'
 export const createChannel = 'teams:createChannel'
 export const createNewTeam = 'teams:createNewTeam'
@@ -87,6 +88,7 @@ type _AddUserToTeamsPayload = $ReadOnly<{|role: Types.TeamRoleType, teams: Array
 type _BadgeAppForTeamsPayload = $ReadOnly<{|newTeamNames: Array<string>, newTeamAccessRequests: Array<string>, teamsWithResetUsers: Array<$ReadOnly<{id: Buffer, teamname: string, username: string, uid: string}>>|}>
 type _CheckRequestedAccessPayload = $ReadOnly<{|teamname: string|}>
 type _ClearAddUserToTeamsResultsPayload = void
+type _ClearNavBadgesPayload = void
 type _ClearTeamRequestsPayload = $ReadOnly<{|teamname: string|}>
 type _CreateChannelPayload = $ReadOnly<{|teamname: string, channelname: string, description: ?string, rootPath: I.List<string>, sourceSubPath: I.List<string>, destSubPath: I.List<string>|}>
 type _CreateNewTeamFromConversationPayload = $ReadOnly<{|conversationIDKey: ChatTypes.ConversationIDKey, teamname: string|}>
@@ -104,7 +106,7 @@ type _GetTeamOperationsPayload = $ReadOnly<{|teamname: string|}>
 type _GetTeamProfileAddListPayload = $ReadOnly<{|username: string|}>
 type _GetTeamPublicityPayload = $ReadOnly<{|teamname: string|}>
 type _GetTeamRetentionPolicyPayload = $ReadOnly<{|teamname: string|}>
-type _GetTeamsPayload = void
+type _GetTeamsPayload = $ReadOnly<{|clearNavBadges?: boolean|}>
 type _IgnoreRequestPayload = $ReadOnly<{|teamname: string, username: string|}>
 type _InviteToTeamByEmailPayload = $ReadOnly<{|destSubPath?: I.List<string>, invitees: string, role: Types.TeamRoleType, rootPath?: I.List<string>, sourceSubPath?: I.List<string>, teamname: string|}>
 type _InviteToTeamByPhonePayload = $ReadOnly<{|teamname: string, role: Types.TeamRoleType, phoneNumber: string, fullName: string|}>
@@ -175,6 +177,7 @@ export const createAddUserToTeams = (payload: _AddUserToTeamsPayload) => ({paylo
 export const createBadgeAppForTeams = (payload: _BadgeAppForTeamsPayload) => ({payload, type: badgeAppForTeams})
 export const createCheckRequestedAccess = (payload: _CheckRequestedAccessPayload) => ({payload, type: checkRequestedAccess})
 export const createClearAddUserToTeamsResults = (payload: _ClearAddUserToTeamsResultsPayload) => ({payload, type: clearAddUserToTeamsResults})
+export const createClearNavBadges = (payload: _ClearNavBadgesPayload) => ({payload, type: clearNavBadges})
 export const createClearTeamRequests = (payload: _ClearTeamRequestsPayload) => ({payload, type: clearTeamRequests})
 export const createCreateChannel = (payload: _CreateChannelPayload) => ({payload, type: createChannel})
 export const createCreateNewTeam = (payload: _CreateNewTeamPayload) => ({payload, type: createNewTeam})
@@ -238,6 +241,7 @@ export type AddUserToTeamsPayload = {|+payload: _AddUserToTeamsPayload, +type: '
 export type BadgeAppForTeamsPayload = {|+payload: _BadgeAppForTeamsPayload, +type: 'teams:badgeAppForTeams'|}
 export type CheckRequestedAccessPayload = {|+payload: _CheckRequestedAccessPayload, +type: 'teams:checkRequestedAccess'|}
 export type ClearAddUserToTeamsResultsPayload = {|+payload: _ClearAddUserToTeamsResultsPayload, +type: 'teams:clearAddUserToTeamsResults'|}
+export type ClearNavBadgesPayload = {|+payload: _ClearNavBadgesPayload, +type: 'teams:clearNavBadges'|}
 export type ClearTeamRequestsPayload = {|+payload: _ClearTeamRequestsPayload, +type: 'teams:clearTeamRequests'|}
 export type CreateChannelPayload = {|+payload: _CreateChannelPayload, +type: 'teams:createChannel'|}
 export type CreateNewTeamFromConversationPayload = {|+payload: _CreateNewTeamFromConversationPayload, +type: 'teams:createNewTeamFromConversation'|}
@@ -308,6 +312,7 @@ export type Actions =
   | BadgeAppForTeamsPayload
   | CheckRequestedAccessPayload
   | ClearAddUserToTeamsResultsPayload
+  | ClearNavBadgesPayload
   | ClearTeamRequestsPayload
   | CreateChannelPayload
   | CreateNewTeamFromConversationPayload

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -1561,9 +1561,8 @@ const teamsSaga = function*(): Saga.SagaGenerator<any, any> {
 
   if (!flags.useNewRouter) {
     yield* Saga.chainAction<RouteTreeGen.SwitchToPayload>(RouteTreeGen.switchTo, onTabChange)
-  } else {
-    yield* Saga.chainAction<TeamsGen.ClearNavBadgesPayload>(TeamsGen.clearNavBadges, clearNavBadges)
   }
+  yield* Saga.chainAction<TeamsGen.ClearNavBadgesPayload>(TeamsGen.clearNavBadges, clearNavBadges)
 }
 
 export default teamsSaga

--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -1427,6 +1427,15 @@ const onTabChange = (_, action) => {
   }
 }
 
+const clearNavBadges = () =>
+  RPCTypes.gregorDismissCategoryRpcPromise({
+    category: 'team.newly_added_to_team',
+  }).then(() =>
+    RPCTypes.gregorDismissCategoryRpcPromise({
+      category: 'team.request_access',
+    })
+  )
+
 const receivedBadgeState = (state, action) =>
   TeamsGen.createBadgeAppForTeams({
     newTeamAccessRequests: action.payload.badgeState.newTeamAccessRequests || [],
@@ -1511,7 +1520,6 @@ const teamsSaga = function*(): Saga.SagaGenerator<any, any> {
     deleteChannelConfirmed
   )
   yield* Saga.chainAction<TeamsGen.BadgeAppForTeamsPayload>(TeamsGen.badgeAppForTeams, badgeAppForTeams)
-  yield* Saga.chainAction<RouteTreeGen.SwitchToPayload>(RouteTreeGen.switchTo, onTabChange)
   yield* Saga.chainAction<TeamsGen.InviteToTeamByPhonePayload>(
     TeamsGen.inviteToTeamByPhone,
     inviteToTeamByPhone
@@ -1553,6 +1561,12 @@ const teamsSaga = function*(): Saga.SagaGenerator<any, any> {
   yield* Saga.chainAction<
     EngineGen.Keybase1NotifyTeamTeamDeletedPayload | EngineGen.Keybase1NotifyTeamTeamExitPayload
   >([EngineGen.keybase1NotifyTeamTeamDeleted, EngineGen.keybase1NotifyTeamTeamExit], teamDeletedOrExit)
+
+  if (flags.useNewRouter) {
+    yield* Saga.chainAction<TeamsGen.GetTeamsPayload>(TeamsGen.getTeams, clearNavBadges)
+  } else {
+    yield* Saga.chainAction<RouteTreeGen.SwitchToPayload>(RouteTreeGen.switchTo, onTabChange)
+  }
 }
 
 export default teamsSaga

--- a/shared/git/new-repo/container.js
+++ b/shared/git/new-repo/container.js
@@ -19,7 +19,7 @@ const mapStateToProps = (state, {routeProps, navigation}) => ({
 })
 
 const mapDispatchToProps = (dispatch: any, {navigateAppend, navigateUp, routeProps, navigation}) => ({
-  loadTeams: () => dispatch(TeamsGen.createGetTeams()),
+  loadTeams: () => dispatch(TeamsGen.createGetTeams({clearNavBadges: false})),
   onCancel: () => dispatch(navigateUp()),
   onClose: () => dispatch(navigateUp()),
   onCreate: (name: string, teamname: ?string, notifyTeam: boolean) => {

--- a/shared/profile/showcase-team-offer/container.js
+++ b/shared/profile/showcase-team-offer/container.js
@@ -27,7 +27,7 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = dispatch => ({
-  loadTeams: teamname => dispatch(TeamsGen.createGetTeams()),
+  loadTeams: teamname => dispatch(TeamsGen.createGetTeams({clearNavBadges: false})),
   onCancel: (you: string) => {
     // sadly a little racy, doing this for now
     setTimeout(() => {

--- a/shared/profile/showcased-team-info/container.js
+++ b/shared/profile/showcased-team-info/container.js
@@ -53,7 +53,7 @@ const mapDispatchToProps = (dispatch, {team}: OwnProps) => {
   const teamname = team.fqName
   return {
     _checkRequestedAccess: () => dispatch(TeamsGen.createCheckRequestedAccess({teamname})),
-    _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
+    _loadTeams: () => dispatch(TeamsGen.createGetTeams({clearNavBadges: false})),
     _onSetTeamJoinError: (error: string) => dispatch(TeamsGen.createSetTeamJoinError({error})),
     _onSetTeamJoinSuccess: (success: boolean) =>
       dispatch(TeamsGen.createSetTeamJoinSuccess({success, teamname: ''})),

--- a/shared/reducers/teams.js
+++ b/shared/reducers/teams.js
@@ -136,6 +136,7 @@ const rootReducer = (state: Types.State = initialState, action: TeamsGen.Actions
     case TeamsGen.reAddToTeam:
     case TeamsGen.badgeAppForTeams:
     case TeamsGen.checkRequestedAccess:
+    case TeamsGen.clearNavBadges:
     case TeamsGen.createChannel:
     case TeamsGen.createNewTeam:
     case TeamsGen.createNewTeamFromConversation:

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -47,7 +47,7 @@ const headerActions = dispatch => ({
 })
 const mapDispatchToProps = (dispatch, {routePath}) => ({
   ...headerActions(dispatch),
-  _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
+  _loadTeams: () => dispatch(TeamsGen.createGetTeams({clearNavBadges: true})),
   onHideChatBanner: () => dispatch(GregorGen.createUpdateCategory({body: 'true', category: 'sawChatBanner'})),
   onManageChat: (teamname: Teamname) =>
     dispatch(

--- a/shared/teams/invite-by-email/container.desktop.js
+++ b/shared/teams/invite-by-email/container.desktop.js
@@ -42,7 +42,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         })
       )
     }
-    dispatch(TeamsGen.createGetTeams())
+    dispatch(TeamsGen.createGetTeams({clearNavBadges: false}))
   },
   onOpenRolePicker: (role: Types.TeamRoleType, onComplete: Types.TeamRoleType => void) => {
     dispatch(

--- a/shared/teams/invite-by-email/container.native.js
+++ b/shared/teams/invite-by-email/container.native.js
@@ -77,7 +77,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         })
       )
     }
-    dispatch(TeamsGen.createGetTeams())
+    dispatch(TeamsGen.createGetTeams({clearNavBadges: false}))
   },
   onInvitePhone: ({invitee, role, fullName = ''}) => {
     dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))
@@ -89,7 +89,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         teamname: getRouteProps(ownProps, 'teamname'),
       })
     )
-    dispatch(TeamsGen.createGetTeams())
+    dispatch(TeamsGen.createGetTeams({clearNavBadges: false}))
   },
   onOpenRolePicker: (role: string, onComplete: string => void) => {
     dispatch(


### PR DESCRIPTION
@keybase/react-hackers 

Before this PR, team nav badges are not dismissable on nav2 because the dismiss logic hooks into `RouteTreeGen.switchTo`, and that's not how we get to the teams tab in nav2 -- we just navigateAppend into it.

The new badging logic for nav2 is that we dismiss when you first get to the badged screen.  For devices and git, we handle that by hooking into their sagas for loading data.  But many different components load teams data, so we need to do something else here.

Instead of hooking into navigateAppend and looking for the visible screen to be the root teams tab, I decided to wait until the load's been successful and just trigger a new dismiss action, if the load came from the root container.  Not sure whether this is the best idea, open to other suggestions.

nav1 doesn't bind a saga to the new `clearNavBadges` action so it behaves the same way as always.

I'm aware that I could avoid creating the new `clearNavBadges` action and just call a function in `actions/teams.js` directly -- I like going through dispatched actions here because it's going to make logs easier to debug if we're trying to work out whether/why we tried to unbadge.

I would've preferred to have the `clearNavBadges` bool be an optional payload, but flow doesn't like that:

```
Cannot call TeamsGen.createGetTeams because inexact undefined [1] is
incompatible with exact _GetTeamsPayload [2].
 [1]  80│     dispatch(TeamsGen.createGetTeams())
 [2] 195│ export const createGetTeams = (payload: _GetTeamsPayload) => ({payload, type: getTeams})
```