### PR TITLE
android: Missing break statement causing fallthrough

### DIFF
--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -102,6 +102,7 @@ public class KeybasePushNotificationListenerService extends RNPushNotificationLi
                     NotificationManagerCompat notificationManager = NotificationManagerCompat.from(getApplicationContext());
                     notificationManager.cancelAll();
                 }
+                break;
                 default:
                     super.onMessageReceived(message);
             }


### PR DESCRIPTION
r? @cjb @MarcoPolo 