### PR TITLE
libfs: handle the .kbfs_status file as a wrapped file

### DIFF
--- a/go/kbfs/libdokan/mount_test.go
+++ b/go/kbfs/libdokan/mount_test.go
@@ -2438,6 +2438,8 @@ func TestStatusFile(t *testing.T) {
 	defer mnt.Close()
 	defer cancelFn()
 
+	libfs.AddRootWrapper(config)
+
 	jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", tlf.Public)
 
 	ops := config.KBFSOps()

--- a/go/kbfs/libdokan/special_files.go
+++ b/go/kbfs/libdokan/special_files.go
@@ -14,9 +14,6 @@ func handleTLFSpecialFile(name string, folder *Folder) dokan.File {
 	// Common files (the equivalent of handleCommonSpecialFile
 	// from libfuse) are handled in fs.go.
 	switch name {
-	case libfs.StatusFileName:
-		return NewTLFStatusFile(folder)
-
 	case libfs.UpdateHistoryFileName:
 		return NewUpdateHistoryFile(folder)
 

--- a/go/kbfs/libdokan/start.go
+++ b/go/kbfs/libdokan/start.go
@@ -85,6 +85,8 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 
 	defer libkbfs.Shutdown()
 
+	libfs.AddRootWrapper(config)
+
 	if options.RuntimeDir != "" {
 		err := os.MkdirAll(options.RuntimeDir, libkb.PermDir)
 		if err != nil {

--- a/go/kbfs/libdokan/status_file.go
+++ b/go/kbfs/libdokan/status_file.go
@@ -21,15 +21,3 @@ func NewNonTLFStatusFile(fs *FS) *SpecialReadFile {
 		fs: fs,
 	}
 }
-
-// NewTLFStatusFile returns a special read file that contains a text
-// representation of the status of the current TLF.
-func NewTLFStatusFile(folder *Folder) *SpecialReadFile {
-	return &SpecialReadFile{
-		read: func(ctx context.Context) ([]byte, time.Time, error) {
-			return libfs.GetEncodedFolderStatus(
-				ctx, folder.fs.config, folder.getFolderBranch())
-		},
-		fs: folder.fs,
-	}
-}

--- a/go/kbfs/libfs/node_wrappers.go
+++ b/go/kbfs/libfs/node_wrappers.go
@@ -1,0 +1,135 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/logger"
+	billy "gopkg.in/src-d/go-billy.v4"
+)
+
+type statusFileNode struct {
+	libkbfs.Node
+
+	fb     data.FolderBranch
+	config libkbfs.Config
+	log    logger.Logger
+}
+
+var _ libkbfs.Node = (*statusFileNode)(nil)
+
+func (sfn *statusFileNode) GetFile(ctx context.Context) billy.File {
+	return &wrappedReadFile{
+		name: StatusFileName,
+		reader: func(ctx context.Context) ([]byte, time.Time, error) {
+			return GetEncodedFolderStatus(ctx, sfn.config, sfn.fb)
+		},
+		log: sfn.log,
+	}
+}
+
+func (sfn *statusFileNode) FillCacheDuration(d *time.Duration) {
+	// Suggest kindly that no one should cache this node, since it
+	// could change each time it's read.
+	*d = 0
+}
+
+// specialFileNode is a Node wrapper around a TLF node, that causes
+// special files to be fake-created when they are accessed.
+type specialFileNode struct {
+	libkbfs.Node
+
+	config libkbfs.Config
+	log    logger.Logger
+}
+
+var _ libkbfs.Node = (*specialFileNode)(nil)
+
+var perTlfWrappedNodeNames = map[string]bool{
+	StatusFileName: true,
+}
+
+// ShouldCreateMissedLookup implements the Node interface for
+// specialFileNode.
+func (sfn *specialFileNode) ShouldCreateMissedLookup(
+	ctx context.Context, name string) (
+	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	if !perTlfWrappedNodeNames[name] {
+		return sfn.Node.ShouldCreateMissedLookup(ctx, name)
+	}
+
+	switch name {
+	case StatusFileName:
+		sfn := &statusFileNode{
+			Node:   nil,
+			fb:     sfn.GetFolderBranch(),
+			config: sfn.config,
+			log:    sfn.log,
+		}
+		f := sfn.GetFile(ctx)
+		return true, ctx, data.FakeFile, f.(*wrappedReadFile).GetInfo(), ""
+	default:
+		panic(fmt.Sprintf("Name %s was in map, but not in switch", name))
+	}
+
+}
+
+// WrapChild implements the Node interface for specialFileNode.
+func (sfn *specialFileNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+	child = sfn.Node.WrapChild(child)
+	name := child.GetBasename()
+	if !perTlfWrappedNodeNames[name] {
+		if child.EntryType() == data.Dir {
+			// Wrap this child too, so we can look up special files in
+			// subdirectories of this node as well.
+			return &specialFileNode{
+				Node:   child,
+				config: sfn.config,
+				log:    sfn.log,
+			}
+		}
+		return child
+	}
+
+	switch name {
+	case StatusFileName:
+		return &statusFileNode{
+			Node:   &libkbfs.ReadonlyNode{Node: child},
+			fb:     sfn.GetFolderBranch(),
+			config: sfn.config,
+			log:    sfn.log,
+		}
+	default:
+		panic(fmt.Sprintf("Name %s was in map, but not in switch", name))
+	}
+}
+
+// rootWrapper is a struct that manages wrapping root nodes with
+// special per-TLF content.
+type rootWrapper struct {
+	config libkbfs.Config
+	log    logger.Logger
+}
+
+func (rw rootWrapper) wrap(node libkbfs.Node) libkbfs.Node {
+	return &specialFileNode{
+		Node:   node,
+		config: rw.config,
+		log:    rw.log,
+	}
+}
+
+// AddRootWrapper should be called on startup by any KBFS interface
+// that wants to handle special files.
+func AddRootWrapper(config libkbfs.Config) {
+	rw := rootWrapper{config, config.MakeLogger("")}
+	config.AddRootNodeWrapper(rw.wrap)
+}

--- a/go/kbfs/libfs/wrapped_read_file.go
+++ b/go/kbfs/libfs/wrapped_read_file.go
@@ -1,0 +1,130 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/logger"
+	"github.com/pkg/errors"
+	billy "gopkg.in/src-d/go-billy.v4"
+)
+
+const (
+	// Debug tag ID for an individual FS operation.
+	ctxFSOpID = "FSID"
+)
+
+type ctxFSTagKey int
+
+const (
+	ctxFSIDKey ctxFSTagKey = iota
+)
+
+// wrappedReadFile is a read-only file that serves data from a given
+// `reader` function.
+type wrappedReadFile struct {
+	name   string
+	reader func(context.Context) ([]byte, time.Time, error)
+	log    logger.Logger
+
+	// TODO: proper locking for `nextRead` if we ever use it outside
+	// of libkbfs node-wrapping (which always uses `ReadAt`).
+	nextRead int
+}
+
+var _ billy.File = (*wrappedReadFile)(nil)
+
+func (wrf *wrappedReadFile) getDataAndTime() ([]byte, time.Time) {
+	ctx := libkbfs.CtxWithRandomIDReplayable(
+		context.Background(), ctxFSIDKey, ctxFSOpID, nil)
+	data, t, err := wrf.reader(ctx)
+	if err != nil {
+		wrf.log.CDebugf(ctx, "Couldn't read wrapped file: %+v", err)
+		return nil, time.Time{}
+	}
+	return data, t
+}
+
+func (wrf *wrappedReadFile) Len() int {
+	data, _ := wrf.getDataAndTime()
+	return len(data)
+}
+
+func (wrf *wrappedReadFile) Name() string {
+	return wrf.name
+}
+
+func (wrf *wrappedReadFile) Write(_ []byte) (n int, err error) {
+	return 0, errors.New("wrapped read files can't be written")
+}
+
+func (wrf *wrappedReadFile) Read(p []byte) (n int, err error) {
+	data, _ := wrf.getDataAndTime()
+
+	if wrf.nextRead >= len(data) {
+		return 0, io.EOF
+	}
+	n = copy(p, data[wrf.nextRead:])
+	wrf.nextRead += n
+	return n, nil
+}
+
+func (wrf *wrappedReadFile) ReadAt(p []byte, off int64) (n int, err error) {
+	data, _ := wrf.getDataAndTime()
+
+	if off >= int64(len(data)) {
+		return 0, io.EOF
+	}
+
+	n = copy(p, data[off:])
+	return n, nil
+}
+
+func (wrf *wrappedReadFile) Seek(offset int64, whence int) (int64, error) {
+	newOffset := offset
+	switch whence {
+	case io.SeekStart:
+	case io.SeekCurrent:
+		newOffset = int64(wrf.nextRead) + offset
+	case io.SeekEnd:
+		data, _ := wrf.getDataAndTime()
+		newOffset = int64(len(data)) + offset
+	}
+	if newOffset < 0 {
+		return 0, errors.Errorf("Cannot seek to offset %d", newOffset)
+	}
+
+	wrf.nextRead = int(newOffset)
+	return newOffset, nil
+}
+
+func (wrf *wrappedReadFile) Close() error {
+	return nil
+}
+
+func (wrf *wrappedReadFile) Lock() error {
+	return errors.New("wrapped read files can't be locked")
+}
+
+func (wrf *wrappedReadFile) Unlock() error {
+	return errors.New("wrapped read files can't be unlocked")
+}
+
+func (wrf *wrappedReadFile) Truncate(size int64) error {
+	return errors.New("wrapped read files can't be truncated")
+}
+
+func (wrf *wrappedReadFile) GetInfo() *wrappedReadFileInfo {
+	data, t := wrf.getDataAndTime()
+	return &wrappedReadFileInfo{
+		name:  wrf.Name(),
+		size:  int64(len(data)),
+		mtime: t,
+	}
+}

--- a/go/kbfs/libfs/wrapped_read_file_info.go
+++ b/go/kbfs/libfs/wrapped_read_file_info.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"os"
+	"time"
+)
+
+type wrappedReadFileInfo struct {
+	name  string
+	size  int64
+	mtime time.Time
+	dir   bool
+}
+
+var _ os.FileInfo = (*wrappedReadFileInfo)(nil)
+
+func (cfi *wrappedReadFileInfo) Name() string {
+	return cfi.name
+}
+
+func (cfi *wrappedReadFileInfo) Size() int64 {
+	return cfi.size
+}
+
+func (cfi *wrappedReadFileInfo) Mode() os.FileMode {
+	// Make it read-only.
+	return 0600
+}
+
+func (cfi *wrappedReadFileInfo) ModTime() time.Time {
+	return cfi.mtime
+}
+
+func (cfi *wrappedReadFileInfo) IsDir() bool {
+	return cfi.dir
+}
+
+func (cfi *wrappedReadFileInfo) Sys() interface{} {
+	return nil
+}

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -375,6 +375,7 @@ func (f *Folder) fillAttrWithUIDAndWritePerm(
 	ctx context.Context, node libkbfs.Node, ei *data.EntryInfo,
 	a *fuse.Attr) (err error) {
 	a.Valid = 1 * time.Minute
+	node.FillCacheDuration(&a.Valid)
 
 	a.Size = ei.Size
 	a.Blocks = getNumBlocksFromSize(ei.Size)
@@ -584,6 +585,8 @@ func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 		if n, ok := d.folder.nodes[newNode.GetID()]; ok {
 			return n, nil
 		}
+
+		newNode.FillCacheDuration(&resp.EntryValid)
 	}
 
 	switch de.Type {

--- a/go/kbfs/libfuse/file.go
+++ b/go/kbfs/libfuse/file.go
@@ -119,6 +119,8 @@ func (f *File) attr(ctx context.Context, a *fuse.Attr) (err error) {
 		return err
 	}
 
+	f.node.FillCacheDuration(&a.Valid)
+
 	return f.fillAttrWithMode(ctx, &de, a)
 }
 

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -3117,6 +3117,8 @@ func TestStatusFile(t *testing.T) {
 	defer mnt.Close()
 	defer cancelFn()
 
+	libfs.AddRootWrapper(config)
+
 	jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", tlf.Public)
 
 	ops := config.KBFSOps()

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -83,9 +83,6 @@ func handleTLFSpecialFile(
 	}
 
 	switch name {
-	case libfs.StatusFileName:
-		return NewTLFStatusFile(folder, entryValid)
-
 	case libfs.UpdateHistoryFileName:
 		return NewUpdateHistoryFile(folder, entryValid)
 

--- a/go/kbfs/libfuse/start.go
+++ b/go/kbfs/libfuse/start.go
@@ -140,6 +140,8 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	}
 	defer libkbfs.Shutdown()
 
+	libfs.AddRootWrapper(config)
+
 	if options.KbfsParams.Debug {
 		fuseLog := config.MakeLogger("FUSE").CloneWithAddedDepth(1)
 		fuse.Debug = MakeFuseVDebugFn(

--- a/go/kbfs/libfuse/status_file.go
+++ b/go/kbfs/libfuse/status_file.go
@@ -24,16 +24,3 @@ func NewNonTLFStatusFile(fs *FS, entryValid *time.Duration) *SpecialReadFile {
 		},
 	}
 }
-
-// NewTLFStatusFile returns a special read file that contains a text
-// representation of the status of the current TLF.
-func NewTLFStatusFile(
-	folder *Folder, entryValid *time.Duration) *SpecialReadFile {
-	*entryValid = 0
-	return &SpecialReadFile{
-		read: func(ctx context.Context) ([]byte, time.Time, error) {
-			return libfs.GetEncodedFolderStatus(
-				ctx, folder.fs.config, folder.getFolderBranch())
-		},
-	}
-}

--- a/go/kbfs/libgit/autogit_node_wrappers.go
+++ b/go/kbfs/libgit/autogit_node_wrappers.go
@@ -137,7 +137,7 @@ var _ libkbfs.Node = (*repoDirNode)(nil)
 // repoDirNode.
 func (rdn *repoDirNode) ShouldCreateMissedLookup(
 	ctx context.Context, name string) (
-	bool, context.Context, data.EntryType, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, string) {
 	switch {
 	case strings.HasPrefix(name, AutogitBranchPrefix):
 		branchName := strings.TrimPrefix(name, AutogitBranchPrefix)
@@ -147,16 +147,26 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 		// It's difficult to tell if a given name is a legitimate
 		// prefix for a branch name or not, so just accept everything.
 		// If it's not legit, trying to read the data will error out.
-		return true, ctx, data.FakeDir, ""
+		return true, ctx, data.FakeDir, nil, ""
 	case strings.HasPrefix(name, AutogitCommitPrefix):
 		commit := strings.TrimPrefix(name, AutogitCommitPrefix)
 		if len(commit) == 0 {
 			return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 		}
-		// It's a bit involved to tell if a given name is a legitimate
-		// commit or not, so just accept everything.  If it's not
-		// legit, trying to read the data will error out.
-		return true, ctx, data.FakeFile, ""
+
+		rcn := &repoCommitNode{
+			Node:      nil,
+			am:        rdn.am,
+			gitRootFS: rdn.gitRootFS,
+			repo:      rdn.repo,
+			hash:      plumbing.NewHash(commit),
+		}
+		f := rcn.GetFile(ctx)
+		if f == nil {
+			rdn.am.log.CDebugf(ctx, "Error getting commit file")
+			return rdn.Node.ShouldCreateMissedLookup(ctx, name)
+		}
+		return true, ctx, data.FakeFile, f.(*diffFile).GetInfo(), ""
 	default:
 		return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -297,7 +307,7 @@ var _ libkbfs.Node = (*rootNode)(nil)
 // ShouldCreateMissedLookup implements the Node interface for
 // rootNode.
 func (rn *rootNode) ShouldCreateMissedLookup(ctx context.Context, name string) (
-	bool, context.Context, data.EntryType, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, string) {
 	if name != AutogitRoot {
 		return rn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -326,7 +336,7 @@ func (rn *rootNode) ShouldCreateMissedLookup(ctx context.Context, name string) (
 		}
 		rn.fs = fs
 	}
-	return true, ctx, data.FakeDir, ""
+	return true, ctx, data.FakeDir, nil, ""
 }
 
 // WrapChild implements the Node interface for rootNode.

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3057,19 +3057,10 @@ func (fbo *folderBranchOps) makeFakeDirEntry(
 }
 
 func (fbo *folderBranchOps) makeFakeFileEntry(
-	ctx context.Context, dir Node, name string) (de data.DirEntry, err error) {
+	ctx context.Context, dir Node, name string, fi os.FileInfo,
+	sympath string) (de data.DirEntry, err error) {
 	fbo.vlog.CLogf(ctx, libkb.VLog1, "Faking file entry for %s", name)
 	id, err := fbo.makeFakeEntryID(ctx, dir, name)
-	if err != nil {
-		return data.DirEntry{}, err
-	}
-
-	fs := dir.GetFS(ctx)
-	if fs == nil {
-		return data.DirEntry{}, errors.New("No FS")
-	}
-
-	fi, err := fs.Lstat(name)
 	if err != nil {
 		return data.DirEntry{}, err
 	}
@@ -3084,11 +3075,7 @@ func (fbo *folderBranchOps) makeFakeFileEntry(
 		EntryInfo: data.EntryInfoFromFileInfo(fi),
 	}
 	if de.Type == data.Sym {
-		target, err := fs.Readlink(name)
-		if err != nil {
-			return data.DirEntry{}, err
-		}
-		de.SymPath = target
+		de.SymPath = sympath
 	}
 	return de, nil
 }
@@ -3097,7 +3084,7 @@ func (fbo *folderBranchOps) processMissedLookup(
 	ctx context.Context, lState *kbfssync.LockState, dir Node, name string,
 	missErr error) (node Node, ei data.EntryInfo, err error) {
 	// Check if the directory node wants to autocreate this.
-	autocreate, ctx, et, sympath := dir.ShouldCreateMissedLookup(ctx, name)
+	autocreate, ctx, et, fi, sympath := dir.ShouldCreateMissedLookup(ctx, name)
 	if !autocreate {
 		return nil, data.EntryInfo{}, missErr
 	}
@@ -3113,7 +3100,7 @@ func (fbo *folderBranchOps) processMissedLookup(
 		}
 		return node, de.EntryInfo, nil
 	} else if et == data.FakeFile {
-		de, err := fbo.makeFakeFileEntry(ctx, dir, name)
+		de, err := fbo.makeFakeFileEntry(ctx, dir, name, fi, sympath)
 		if err != nil {
 			return nil, data.EntryInfo{}, missErr
 		}
@@ -3155,13 +3142,21 @@ func (fbo *folderBranchOps) statUsingFS(
 	}
 
 	// First check if this is needs to be a faked-out node.
-	autocreate, _, et, _ := node.ShouldCreateMissedLookup(ctx, name)
-	if autocreate && et == data.FakeDir {
-		de, err := fbo.makeFakeDirEntry(ctx, node, name)
-		if err != nil {
-			return data.DirEntry{}, false, err
+	autocreate, _, et, fi, sympath := node.ShouldCreateMissedLookup(ctx, name)
+	if autocreate {
+		if et == data.FakeDir {
+			de, err := fbo.makeFakeDirEntry(ctx, node, name)
+			if err != nil {
+				return data.DirEntry{}, false, err
+			}
+			return de, true, nil
+		} else if et == data.FakeFile {
+			de, err = fbo.makeFakeFileEntry(ctx, node, name, fi, sympath)
+			if err != nil {
+				return data.DirEntry{}, false, err
+			}
+			return de, true, nil
 		}
-		return de, true, nil
 	}
 
 	fs := node.GetFS(ctx)
@@ -3171,7 +3166,19 @@ func (fbo *folderBranchOps) statUsingFS(
 
 	fbo.vlog.CLogf(ctx, libkb.VLog1, "Using an FS to satisfy stat of %s", name)
 
-	de, err = fbo.makeFakeFileEntry(ctx, node, name)
+	fi, err = fs.Lstat(name)
+	if err != nil {
+		return data.DirEntry{}, false, err
+	}
+
+	if fi.Mode()&os.ModeSymlink != 0 {
+		sympath, err = fs.Readlink(name)
+		if err != nil {
+			return data.DirEntry{}, false, err
+		}
+	}
+
+	de, err = fbo.makeFakeFileEntry(ctx, node, name, fi, sympath)
 	if err != nil {
 		return data.DirEntry{}, false, err
 	}

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/keybase/client/go/kbfs/data"
@@ -169,13 +170,17 @@ type Node interface {
 	// as a context to use for the creation, the type of the new entry
 	// and the symbolic link contents if the entry is a Sym; the
 	// caller should then create this entry.  Otherwise it should
-	// return false.  It may return the type `FakeDir` to indicate
-	// that the caller should pretend the entry exists, even if it
-	// really does not.  An implementation that wraps another `Node`
-	// (`inner`) must return `inner.ShouldCreateMissedLookup()` if it
-	// decides not to return `true` on its own.
+	// return false.  It may return the types `FakeDir` or `FakeFile`
+	// to indicate that the caller should pretend the entry exists,
+	// even if it really does not.  In the case of fake files, a
+	// non-nil `fi` can be returned and used by the caller to
+	// construct the dir entry for the file.  An implementation that
+	// wraps another `Node` (`inner`) must return
+	// `inner.ShouldCreateMissedLookup()` if it decides not to return
+	// `true` on its own.
 	ShouldCreateMissedLookup(ctx context.Context, name string) (
-		shouldCreate bool, newCtx context.Context, et data.EntryType, sympath string)
+		shouldCreate bool, newCtx context.Context, et data.EntryType,
+		fi os.FileInfo, sympath string)
 	// ShouldRetryOnDirRead is called for Nodes representing
 	// directories, whenever a `Lookup` or `GetDirChildren` is done on
 	// them.  It should return true to instruct the caller that it

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -219,6 +219,9 @@ type Node interface {
 	EntryType() data.EntryType
 	// GetBlockID returns the block ID of the node.
 	GetBlockID() kbfsblock.ID
+	// FillCacheDuration sets `d` to the suggested cache time for this
+	// node, if desired.
+	FillCacheDuration(d *time.Duration)
 }
 
 // KBFSOps handles all file system operations.  Expands all indirect

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -3320,6 +3320,18 @@ func (mr *MockNodeMockRecorder) EntryType() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntryType", reflect.TypeOf((*MockNode)(nil).EntryType))
 }
 
+// FillCacheDuration mocks base method
+func (m *MockNode) FillCacheDuration(arg0 *time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "FillCacheDuration", arg0)
+}
+
+// FillCacheDuration indicates an expected call of FillCacheDuration
+func (mr *MockNodeMockRecorder) FillCacheDuration(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FillCacheDuration", reflect.TypeOf((*MockNode)(nil).FillCacheDuration), arg0)
+}
+
 // GetBasename mocks base method
 func (m *MockNode) GetBasename() string {
 	m.ctrl.T.Helper()

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -20,6 +20,7 @@ import (
 	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	go_billy_v4 "gopkg.in/src-d/go-billy.v4"
+	os "os"
 	reflect "reflect"
 	time "time"
 )
@@ -3433,14 +3434,15 @@ func (mr *MockNodeMockRecorder) RemoveDir(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // ShouldCreateMissedLookup mocks base method
-func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 string) (bool, context.Context, data.EntryType, string) {
+func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 string) (bool, context.Context, data.EntryType, os.FileInfo, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldCreateMissedLookup", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(context.Context)
 	ret2, _ := ret[2].(data.EntryType)
-	ret3, _ := ret[3].(string)
-	return ret0, ret1, ret2, ret3
+	ret3, _ := ret[3].(os.FileInfo)
+	ret4, _ := ret[4].(string)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // ShouldCreateMissedLookup indicates an expected call of ShouldCreateMissedLookup

--- a/go/kbfs/libkbfs/node.go
+++ b/go/kbfs/libkbfs/node.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
@@ -131,3 +132,5 @@ func (n *nodeStandard) GetFile(_ context.Context) billy.File {
 func (n *nodeStandard) EntryType() data.EntryType {
 	return n.core.entryType
 }
+
+func (n *nodeStandard) FillCacheDuration(d *time.Duration) {}

--- a/go/kbfs/libkbfs/node.go
+++ b/go/kbfs/libkbfs/node.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/keybase/client/go/kbfs/data"
@@ -98,8 +99,8 @@ func (n *nodeStandard) Readonly(_ context.Context) bool {
 }
 
 func (n *nodeStandard) ShouldCreateMissedLookup(ctx context.Context, _ string) (
-	bool, context.Context, data.EntryType, string) {
-	return false, ctx, data.File, ""
+	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	return false, ctx, data.File, nil, ""
 }
 
 func (n *nodeStandard) ShouldRetryOnDirRead(ctx context.Context) bool {

--- a/go/kbfs/test/run_fuse_test.go
+++ b/go/kbfs/test/run_fuse_test.go
@@ -14,6 +14,7 @@ import (
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
+	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libfuse"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/logger"
@@ -39,6 +40,7 @@ func createEngine(tb testing.TB) Engine {
 
 func createUserFuse(tb testing.TB, ith int, config *libkbfs.ConfigLocal,
 	opTimeout time.Duration) *fsUser {
+	libfs.AddRootWrapper(config)
 	filesys := libfuse.NewFS(config, nil, false, libfuse.PlatformParams{})
 	fn := func(mnt *fstestutil.Mount) fs.FS {
 		filesys.SetFuseConn(mnt.Server, mnt.Conn)


### PR DESCRIPTION
This creates a generic libfs framework for handling TLF special files (at any level of the hierarchy inside the TLF), and uses it to serve per-TLF `.kbfs_status` files.  So now we can do this:

```
$ keybase fs read /keybase/public/chris/.kbfs_status
{
  "Staged": false,
  "BranchID": "00000000000000000000000000000000",
  "HeadWriter": "chris",
  "DiskUsage": 9054562209,
  "RekeyPending": false,
  "LatestKeyGeneration": -1,
  "FolderID": "7f4f5b66a042b95736b6ab7c98afd317",
  "Revision": 30887,
  "LastGCRevision": 30886,
  "MDVersion": 3,
  "RootBlockID": "01b4f034998d056df9066f0d9e4efa9b5897e2b5475dcb22c31b7c81f518a19f8d",
  "SyncEnabled": false,
  "PrefetchStatus": "TriggeredPrefetch",
  "UsageBytes": 209330339990,
  "ArchiveBytes": 27287819224,
  "LimitBytes": 268435456000,
  "GitUsageBytes": 2480949046,
  "GitArchiveBytes": 170731329,
  "GitLimitBytes": 107374182400,
  "LocalTimestamp": "2019-03-25T10:11:13.01239706-07:00",
  "DirtyPaths": null,
  "Unmerged": null,
  "Merged": null
}
```