### PR TITLE
index memcache, debounce

### DIFF
--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -536,6 +536,11 @@ func (idx *Indexer) allConvs(ctx context.Context, uid gregor1.UID) (map[string]t
 	// convID -> remoteConv
 	convMap := map[string]types.RemoteConversation{}
 	for !pagination.Last {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		inbox, err := idx.G().InboxSource.ReadUnverified(ctx, uid, types.InboxSourceDataSourceAll,
 			inboxQuery, pagination)
 		if err != nil {

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -19,12 +19,18 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// cap the in-memory cache size
+const cacheSize = 250
+
 type Indexer struct {
 	globals.Contextified
 	utils.DebugLabeler
 	sync.Mutex
 
-	store    *store
+	// encrypted on-disk storage
+	store *store
+	// in-memory cache, "uid:convID" -> idx
+	cache    map[string]*chat1.ConversationIndex
 	pageSize int
 	stopCh   chan struct{}
 	started  bool
@@ -42,6 +48,7 @@ func NewIndexer(g *globals.Context) *Indexer {
 	idx := &Indexer{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "Search.Indexer", false),
+		cache:        make(map[string]*chat1.ConversationIndex),
 		store:        newStore(g),
 		pageSize:     defaultPageSize,
 		stopCh:       make(chan struct{}),
@@ -127,11 +134,39 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 }
 
 func (idx *Indexer) ClearCache() {
-	idx.store.ClearCache()
+	idx.Lock()
+	defer idx.Unlock()
+	idx.cache = make(map[string]*chat1.ConversationIndex)
+}
+
+func (idx *Indexer) cacheKey(convID chat1.ConversationID, uid gregor1.UID) string {
+	return fmt.Sprintf("%s:%s", uid, convID)
+}
+
+func (idx *Indexer) deleteFromCache(convID chat1.ConversationID, uid gregor1.UID) {
+	idx.Lock()
+	defer idx.Unlock()
+
+	key := idx.cacheKey(convID, uid)
+	delete(idx.cache, key)
 }
 
 func (idx *Indexer) GetConvIndex(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (*chat1.ConversationIndex, error) {
-	return idx.store.getConvIndex(ctx, convID, uid)
+	idx.Lock()
+	defer idx.Unlock()
+
+	key := idx.cacheKey(convID, uid)
+	if convIdx, ok := idx.cache[key]; ok {
+		return convIdx, nil
+	}
+	convIdx, err := idx.store.getConvIndex(ctx, convID, uid)
+	if err != nil {
+		return nil, err
+	}
+	if len(idx.cache) < cacheSize {
+		idx.cache[key] = convIdx
+	}
+	return convIdx, nil
 }
 
 // validBatch verifies the topic type is CHAT
@@ -172,6 +207,7 @@ func (idx *Indexer) Add(ctx context.Context, convID chat1.ConversationID, uid gr
 	defer idx.Trace(ctx, func() error { return err },
 		fmt.Sprintf("Indexer.Add convID: %v, msgs: %d", convID.String(), len(msgs)))()
 	defer idx.consumeResultsForTest(convID, err)
+	idx.deleteFromCache(convID, uid)
 	return idx.store.add(ctx, convID, uid, msgs)
 }
 
@@ -186,6 +222,7 @@ func (idx *Indexer) Remove(ctx context.Context, convID chat1.ConversationID, uid
 	defer idx.Trace(ctx, func() error { return err },
 		fmt.Sprintf("Indexer.Remove convID: %v, msgs: %d", convID.String(), len(msgs)))()
 	defer idx.consumeResultsForTest(convID, err)
+	idx.deleteFromCache(convID, uid)
 	return idx.store.remove(ctx, convID, uid, msgs)
 }
 
@@ -482,7 +519,7 @@ func (idx *Indexer) reindexConv(ctx context.Context, conv chat1.Conversation, ui
 	}
 	if opts.forceReindex { // refresh the index
 		var err error
-		convIdx, err = idx.store.getConvIndex(ctx, convID, uid)
+		convIdx, err = idx.GetConvIndex(ctx, convID, uid)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -651,7 +688,7 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 			}
 
 			convID := conv.GetConvID()
-			convIdx, err := idx.store.getConvIndex(ectx, convID, uid)
+			convIdx, err := idx.GetConvIndex(ectx, convID, uid)
 			if err != nil {
 				return err
 			}
@@ -847,7 +884,7 @@ func (idx *Indexer) SelectiveSync(ctx context.Context, uid gregor1.UID, forceRei
 	convIdxs := []convIdxWithPercent{}
 	for _, conv := range convMap {
 		convID := conv.GetConvID()
-		convIdx, err := idx.store.getConvIndex(ctx, convID, uid)
+		convIdx, err := idx.GetConvIndex(ctx, convID, uid)
 		if err != nil {
 			idx.Debug(ctx, "SelectiveSync: Unable to get idx for conv: %v, %v", convID, err)
 			continue
@@ -929,7 +966,7 @@ func (idx *Indexer) indexConvWithProfile(ctx context.Context, conv types.RemoteC
 	}()
 
 	convID := conv.GetConvID()
-	convIdx, err = idx.store.getConvIndex(ctx, convID, uid)
+	convIdx, err = idx.GetConvIndex(ctx, convID, uid)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -126,6 +126,10 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 	return ch
 }
 
+func (idx *Indexer) ClearCache() {
+	idx.store.ClearCache()
+}
+
 func (idx *Indexer) GetConvIndex(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (*chat1.ConversationIndex, error) {
 	return idx.store.getConvIndex(ctx, convID, uid)
 }

--- a/go/chat/search/storage.go
+++ b/go/chat/search/storage.go
@@ -60,6 +60,12 @@ func newStore(g *globals.Context) *store {
 	}
 }
 
+func (s *store) ClearCache() {
+	s.Lock()
+	defer s.Unlock()
+	s.lru.Purge()
+}
+
 func (s *store) memKey(convID chat1.ConversationID, uid gregor1.UID) string {
 	return fmt.Sprintf("idx:%s:%s", uid, convID)
 }

--- a/go/chat/search/storage.go
+++ b/go/chat/search/storage.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/utils"
@@ -20,7 +19,6 @@ type store struct {
 	globals.Contextified
 	utils.DebugLabeler
 	encryptedDB *encrypteddb.EncryptedDB
-	lru         *lru.Cache
 }
 
 // store keeps an encrypted index of chat messages for all conversations
@@ -48,32 +46,17 @@ func newStore(g *globals.Context) *store {
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalChatDb
 	}
-	nlru, err := lru.New(1000)
-	if err != nil {
-		panic(fmt.Sprintf("Could not create lru cache: %v", err))
-	}
 	return &store{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "Search.store", false),
 		encryptedDB:  encrypteddb.New(g.ExternalG(), dbFn, keyFn),
-		lru:          nlru,
 	}
-}
-
-func (s *store) ClearCache() {
-	s.Lock()
-	defer s.Unlock()
-	s.lru.Purge()
-}
-
-func (s *store) memKey(convID chat1.ConversationID, uid gregor1.UID) string {
-	return fmt.Sprintf("idx:%s:%s", uid, convID)
 }
 
 func (s *store) dbKey(convID chat1.ConversationID, uid gregor1.UID) libkb.DbKey {
 	return libkb.DbKey{
 		Typ: libkb.DBChatIndex,
-		Key: s.memKey(convID, uid),
+		Key: fmt.Sprintf("idx:%s:%s", uid, convID),
 	}
 }
 
@@ -92,18 +75,10 @@ func (s *store) getLocked(ctx context.Context, convID chat1.ConversationID, uid 
 			}
 		}
 	}()
-	val, found := s.lru.Get(s.memKey(convID, uid))
-	if found {
-		entry, ok := val.(chat1.ConversationIndex)
-		if ok && entry.Metadata.Version == IndexVersion {
-			return &entry, nil
-		}
-		s.lru.Remove(s.memKey(convID, uid))
-	}
 
 	dbKey := s.dbKey(convID, uid)
 	var entry chat1.ConversationIndex
-	found, err = s.encryptedDB.Get(ctx, dbKey, &entry)
+	found, err := s.encryptedDB.Get(ctx, dbKey, &entry)
 	if err != nil || !found {
 		return nil, err
 	}
@@ -112,7 +87,6 @@ func (s *store) getLocked(ctx context.Context, convID chat1.ConversationID, uid 
 		err = s.deleteLocked(ctx, convID, uid)
 		return nil, err
 	}
-	s.lru.Add(s.memKey(convID, uid), entry)
 	return &entry, nil
 }
 
@@ -122,13 +96,11 @@ func (s *store) putLocked(ctx context.Context, convID chat1.ConversationID, uid 
 	}
 	dbKey := s.dbKey(convID, uid)
 	entry.Metadata.Version = IndexVersion
-	s.lru.Add(s.memKey(convID, uid), entry)
 	return s.encryptedDB.Put(ctx, dbKey, *entry)
 }
 
 func (s *store) deleteLocked(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) error {
 	dbKey := s.dbKey(convID, uid)
-	s.lru.Remove(s.memKey(convID, uid))
 	return s.encryptedDB.Delete(ctx, dbKey)
 }
 

--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -822,6 +822,7 @@ func TestChatSearchInbox(t *testing.T) {
 
 		// DB nuke, ensure that we reindex after the search
 		g1.LocalChatDb.Nuke()
+		indexer1.ClearCache()
 		opts.ReindexMode = chat1.ReIndexingMode_PRESEARCH_SYNC // force reindex so we're fully up to date.
 		res = runSearch(query, opts, true /* expectedReindex*/)
 		require.Equal(t, 1, len(res.Hits))
@@ -838,6 +839,7 @@ func TestChatSearchInbox(t *testing.T) {
 
 		// Verify background syncing
 		g1.LocalChatDb.Nuke()
+		indexer1.ClearCache()
 		ictx := globals.CtxAddIdentifyMode(ctx, keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil)
 		indexer1.SelectiveSync(ictx, uid1, true /* forceReindex */)
 		opts.ReindexMode = chat1.ReIndexingMode_POSTSEARCH_ASYNC
@@ -852,6 +854,7 @@ func TestChatSearchInbox(t *testing.T) {
 
 		// Verify POSTSEARCH_SYNC
 		g1.LocalChatDb.Nuke()
+		indexer1.ClearCache()
 		indexer1.SelectiveSync(ictx, uid1, true /* forceReindex */)
 		opts.ReindexMode = chat1.ReIndexingMode_POSTSEARCH_SYNC
 		res = runSearch(query, opts, true /* expectedReindex*/)

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2468,6 +2468,11 @@ func (h *Server) SearchInbox(ctx context.Context, arg chat1.SearchInboxArg) (res
 
 	var searchRes *chat1.ChatSearchInboxResults
 	if doIndexSearch {
+		select {
+		case <-time.After(50 * time.Millisecond):
+		case <-ctx.Done():
+			return
+		}
 		if searchRes, err = h.G().Indexer.Search(ctx, uid, query, arg.Opts, hitUICh, indexUICh); err != nil {
 			return res, err
 		}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -124,6 +124,7 @@ type Indexer interface {
 	Add(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msg []chat1.MessageUnboxed) error
 	// Remove the given messages from the index
 	Remove(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msg []chat1.MessageUnboxed) error
+	ClearCache()
 	// For devel/testing
 	IndexInbox(ctx context.Context, uid gregor1.UID) (map[string]chat1.ProfileSearchConvStats, error)
 }

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -360,6 +360,9 @@ func (d DummyIndexer) Remove(ctx context.Context, convID chat1.ConversationID, u
 func (d DummyIndexer) IndexInbox(ctx context.Context, uid gregor1.UID) (map[string]chat1.ProfileSearchConvStats, error) {
 	return nil, nil
 }
+func (d DummyIndexer) ClearCache() {
+	return
+}
 
 type DummyNativeVideoHelper struct{}
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -1333,4 +1333,7 @@ func (d *Service) onDbNuke(ctx context.Context) {
 	if srv := d.ChatG().AttachmentURLSrv; srv != nil {
 		srv.OnCacheCleared(mctx)
 	}
+	if idx := d.ChatG().Indexer; idx != nil {
+		idx.ClearCache()
+	}
 }


### PR DESCRIPTION
- adds a in memory lru cache to the index store
- adds a short delay before running the search in case we can canceled by a subsequent search.

i'm not sure the delay buys us anything, wouldn't it be better for the GUI to debounce it's calls or for the server to keep some state instead of delay every search 50ms? unless i misunderstood the ticket..