### PR TITLE
OnDbNuke hook

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -378,10 +378,11 @@ func (c *FullCachingSource) ClearCacheForName(m libkb.MetaContext, name string, 
 	return c.clearName(m, name, formats)
 }
 
-func (c *FullCachingSource) OnCacheCleared(m libkb.MetaContext) {
+func (c *FullCachingSource) OnDbNuke(m libkb.MetaContext) error {
 	if c.diskLRU != nil {
 		if err := c.diskLRU.Clean(m.Ctx(), m.G(), c.getCacheDir(m)); err != nil {
 			c.debug(m, "unable to run clean: %v", err)
 		}
 	}
+	return nil
 }

--- a/go/avatars/simple.go
+++ b/go/avatars/simple.go
@@ -101,4 +101,4 @@ func (s *SimpleSource) ClearCacheForName(m libkb.MetaContext, name string, forma
 	return nil
 }
 
-func (s *SimpleSource) OnCacheCleared(m libkb.MetaContext) {}
+func (s *SimpleSource) OnDbNuke(m libkb.MetaContext) error { return nil }

--- a/go/avatars/urlcaching.go
+++ b/go/avatars/urlcaching.go
@@ -182,4 +182,4 @@ func (c *URLCachingSource) ClearCacheForName(m libkb.MetaContext, name string, f
 	return c.clearName(m, name, formats)
 }
 
-func (c *URLCachingSource) OnCacheCleared(m libkb.MetaContext) {}
+func (c *URLCachingSource) OnDbNuke(m libkb.MetaContext) error { return nil }

--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -96,8 +96,9 @@ func NewAttachmentHTTPSrv(g *globals.Context, fetcher types.AttachmentFetcher, r
 	return r
 }
 
-func (r *AttachmentHTTPSrv) OnCacheCleared(mctx libkb.MetaContext) {
-	r.fetcher.OnCacheCleared(mctx)
+func (r *AttachmentHTTPSrv) OnDbNuke(mctx libkb.MetaContext) error {
+	r.fetcher.OnDbNuke(mctx)
+	return nil
 }
 
 func (r *AttachmentHTTPSrv) monitorAppState() {
@@ -639,7 +640,7 @@ func (r *RemoteAttachmentFetcher) IsAssetLocal(ctx context.Context, asset chat1.
 	return false, nil
 }
 
-func (r *RemoteAttachmentFetcher) OnCacheCleared(mctx libkb.MetaContext) {}
+func (r *RemoteAttachmentFetcher) OnDbNuke(mctx libkb.MetaContext) error { return nil }
 
 type CachingAttachmentFetcher struct {
 	globals.Contextified
@@ -850,10 +851,11 @@ func (c *CachingAttachmentFetcher) DeleteAssets(ctx context.Context,
 	return nil
 }
 
-func (c *CachingAttachmentFetcher) OnCacheCleared(mctx libkb.MetaContext) {
+func (c *CachingAttachmentFetcher) OnDbNuke(mctx libkb.MetaContext) error {
 	if c.diskLRU != nil {
 		if err := c.diskLRU.Clean(mctx.Ctx(), mctx.G(), c.getCacheDir()); err != nil {
 			c.Debug(mctx.Ctx(), "unable to run clean: %v", err)
 		}
 	}
+	return nil
 }

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -142,6 +142,16 @@ func (idx *Indexer) ClearCache() {
 	idx.cache = make(map[string]*chat1.ConversationIndex)
 }
 
+func (idx *Indexer) OnLogout(mctx libkb.MetaContext) error {
+	idx.ClearCache()
+	return nil
+}
+
+func (idx *Indexer) OnDbNuke(mctx libkb.MetaContext) error {
+	idx.ClearCache()
+	return nil
+}
+
 func (idx *Indexer) cacheKey(convID chat1.ConversationID, uid gregor1.UID) string {
 	return fmt.Sprintf("%s:%s", uid, convID)
 }

--- a/go/chat/storage/blockengine_memcache.go
+++ b/go/chat/storage/blockengine_memcache.go
@@ -45,4 +45,9 @@ func (b *blockEngineMemCacheImpl) OnLogout(m libkb.MetaContext) error {
 	return nil
 }
 
+func (b *blockEngineMemCacheImpl) OnDbNuke(m libkb.MetaContext) error {
+	b.blockCache.Purge()
+	return nil
+}
+
 var blockEngineMemCache = newBlockEngineMemCache()

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -111,6 +111,7 @@ func NewInbox(g *globals.Context, config ...func(*Inbox)) *Inbox {
 	// add a logout hook to clear the in-memory inbox cache, but only add it once:
 	addInboxMemCacheHookOnce.Do(func() {
 		g.ExternalG().AddLogoutHook(inboxMemCache, "chat/storage/inbox")
+		g.ExternalG().AddDbNukeHook(inboxMemCache, "chat/storage/inbox")
 	})
 
 	i := &Inbox{

--- a/go/chat/storage/inbox_memcache.go
+++ b/go/chat/storage/inbox_memcache.go
@@ -40,10 +40,19 @@ func (i *inboxMemCacheImpl) Clear(uid gregor1.UID) {
 	delete(i.datMap, uid.String())
 }
 
-func (i *inboxMemCacheImpl) OnLogout(m libkb.MetaContext) error {
+func (i *inboxMemCacheImpl) clearCache() {
 	i.Lock()
 	defer i.Unlock()
 	i.datMap = make(map[string]*inboxDiskData)
+}
+
+func (i *inboxMemCacheImpl) OnLogout(m libkb.MetaContext) error {
+	i.clearCache()
+	return nil
+}
+
+func (i *inboxMemCacheImpl) OnDbNuke(m libkb.MetaContext) error {
+	i.clearCache()
 	return nil
 }
 

--- a/go/chat/storage/reacjis.go
+++ b/go/chat/storage/reacjis.go
@@ -61,11 +61,20 @@ func (i *reacjiMemCacheImpl) Put(uid gregor1.UID, data *ReacjiInternalStorage) {
 	i.data = data
 }
 
-func (i *reacjiMemCacheImpl) OnLogout(m libkb.MetaContext) error {
+func (i *reacjiMemCacheImpl) clearMemCaches() {
 	i.Lock()
 	defer i.Unlock()
 	i.data = NewReacjiInternalStorage()
 	i.uid = nil
+}
+
+func (i *reacjiMemCacheImpl) OnLogout(mctx libkb.MetaContext) error {
+	i.clearMemCaches()
+	return nil
+}
+
+func (i *reacjiMemCacheImpl) OnDbNuke(mctx libkb.MetaContext) error {
+	i.clearMemCaches()
 	return nil
 }
 
@@ -106,6 +115,7 @@ func NewReacjiStore(g *globals.Context) *ReacjiStore {
 	// add a logout hook to clear the in-memory cache, but only add it once:
 	addReacjiMemCacheHookOnce.Do(func() {
 		g.ExternalG().AddLogoutHook(reacjiMemCache, "reacjiMemCache")
+		g.ExternalG().AddDbNukeHook(reacjiMemCache, "reacjiMemCache")
 	})
 	return &ReacjiStore{
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "ReacjiStore", false),

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -28,6 +28,7 @@ func newBlockEngine(g *globals.Context) *blockEngine {
 	// add a logout hook to clear the in-memory block cache, but only add it once:
 	addBlockHookOnce.Do(func() {
 		g.ExternalG().AddLogoutHook(blockEngineMemCache, "blockEngineMemCache")
+		g.ExternalG().AddDbNukeHook(blockEngineMemCache, "blockEngineMemCache")
 	})
 
 	return &blockEngine{

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -349,7 +349,7 @@ type AttachmentFetcher interface {
 		ri func() chat1.RemoteInterface, signer s3.Signer) (io.ReadSeeker, error)
 	PutUploadedAsset(ctx context.Context, filename string, asset chat1.Asset) error
 	IsAssetLocal(ctx context.Context, asset chat1.Asset) (bool, error)
-	OnCacheCleared(mctx libkb.MetaContext)
+	OnDbNuke(mctx libkb.MetaContext) error
 }
 
 type AttachmentURLSrv interface {
@@ -361,7 +361,7 @@ type AttachmentURLSrv interface {
 	GetGiphyGalleryURL(ctx context.Context, convID chat1.ConversationID,
 		tlfName string, results []chat1.GiphySearchResult) string
 	GetAttachmentFetcher() AttachmentFetcher
-	OnCacheCleared(mctx libkb.MetaContext)
+	OnDbNuke(mctx libkb.MetaContext) error
 }
 
 type RateLimitedResult interface {

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -127,6 +127,8 @@ type Indexer interface {
 	ClearCache()
 	// For devel/testing
 	IndexInbox(ctx context.Context, uid gregor1.UID) (map[string]chat1.ProfileSearchConvStats, error)
+	OnLogout(mctx libkb.MetaContext) error
+	OnDbNuke(mctx libkb.MetaContext) error
 }
 
 type Sender interface {

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -363,6 +363,12 @@ func (d DummyIndexer) IndexInbox(ctx context.Context, uid gregor1.UID) (map[stri
 func (d DummyIndexer) ClearCache() {
 	return
 }
+func (d DummyIndexer) OnLogout(mctx libkb.MetaContext) error {
+	return nil
+}
+func (d DummyIndexer) OnDbNuke(mctx libkb.MetaContext) error {
+	return nil
+}
 
 type DummyNativeVideoHelper struct{}
 

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -278,7 +278,7 @@ func (d DummyAttachmentFetcher) PutUploadedAsset(ctx context.Context, filename s
 func (d DummyAttachmentFetcher) IsAssetLocal(ctx context.Context, asset chat1.Asset) (bool, error) {
 	return false, nil
 }
-func (d DummyAttachmentFetcher) OnCacheCleared(mctx libkb.MetaContext) {}
+func (d DummyAttachmentFetcher) OnDbNuke(mctx libkb.MetaContext) error { return nil }
 
 type DummyAttachmentHTTPSrv struct{}
 
@@ -309,7 +309,7 @@ func (d DummyAttachmentHTTPSrv) GetGiphyGalleryURL(ctx context.Context, convID c
 	tlfName string, results []chat1.GiphySearchResult) string {
 	return ""
 }
-func (d DummyAttachmentHTTPSrv) OnCacheCleared(mctx libkb.MetaContext) {}
+func (d DummyAttachmentHTTPSrv) OnDbNuke(mctx libkb.MetaContext) error { return nil }
 
 type DummyStellarLoader struct{}
 

--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -13,6 +13,7 @@ func NewEphemeralStorageAndInstall(mctx libkb.MetaContext) {
 	mctx.G().SetEKLib(ekLib)
 	mctx.G().AddLoginHook(ekLib)
 	mctx.G().AddLogoutHook(ekLib, "ekLib")
+	mctx.G().AddDbNukeHook(ekLib, "ekLib")
 	mctx.G().PushShutdownHook(func() error {
 		mctx.Debug("stopping background eklib loop")
 		ekLib.Shutdown()

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -697,17 +697,6 @@ func (e *EKLib) PrepareNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	return prepareNewTeamEK(mctx, teamID, signingKey, usersMetadata, merkleRoot)
 }
 
-func (e *EKLib) OnLogin(mctx libkb.MetaContext) error {
-	// META??
-	if err := e.KeygenIfNeeded(mctx); err != nil {
-		mctx.Debug("OnLogin error: %v", err)
-	}
-	if deviceEKStorage := mctx.G().GetDeviceEKStorage(); deviceEKStorage != nil {
-		deviceEKStorage.SetLogPrefix(mctx)
-	}
-	return nil
-}
-
 func (e *EKLib) ClearCaches(mctx libkb.MetaContext) {
 	defer mctx.TraceTimed("EKLib.ClearCaches", func() error { return nil })()
 	e.Lock()
@@ -728,10 +717,25 @@ func (e *EKLib) ClearCaches(mctx libkb.MetaContext) {
 	}
 }
 
+func (e *EKLib) OnLogin(mctx libkb.MetaContext) error {
+	if err := e.KeygenIfNeeded(mctx); err != nil {
+		mctx.Debug("OnLogin error: %v", err)
+	}
+	if deviceEKStorage := mctx.G().GetDeviceEKStorage(); deviceEKStorage != nil {
+		deviceEKStorage.SetLogPrefix(mctx)
+	}
+	return nil
+}
+
 func (e *EKLib) OnLogout(mctx libkb.MetaContext) error {
 	e.ClearCaches(mctx)
 	if deviceEKStorage := mctx.G().GetDeviceEKStorage(); deviceEKStorage != nil {
 		deviceEKStorage.SetLogPrefix(mctx)
 	}
+	return nil
+}
+
+func (e *EKLib) OnDbNuke(mctx libkb.MetaContext) error {
+	e.ClearCaches(mctx)
 	return nil
 }

--- a/go/home/home.go
+++ b/go/home/home.go
@@ -46,6 +46,7 @@ func (r *rawGetHome) GetAppStatus() *libkb.AppStatus {
 func NewHome(g *libkb.GlobalContext) *Home {
 	home := &Home{Contextified: libkb.NewContextified(g)}
 	g.AddLogoutHook(home, "home")
+	g.AddDbNukeHook(home, "home")
 	return home
 }
 
@@ -317,6 +318,11 @@ func (h *Home) ActionTaken(ctx context.Context) (err error) {
 }
 
 func (h *Home) OnLogout(m libkb.MetaContext) error {
+	h.bustCache(m.Ctx(), true)
+	return nil
+}
+
+func (h *Home) OnDbNuke(m libkb.MetaContext) error {
 	h.bustCache(m.Ctx(), true)
 	return nil
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -679,7 +679,6 @@ type TeamLoader interface {
 	HintLatestSeqno(ctx context.Context, id keybase1.TeamID, seqno keybase1.Seqno) error
 	ResolveNameToIDUntrusted(ctx context.Context, teamName keybase1.TeamName, public bool, allowCache bool) (id keybase1.TeamID, err error)
 	ForceRepollUntil(ctx context.Context, t gregor.TimeOrOffset) error
-	OnLogout()
 	// Clear the in-memory cache. Does not affect the disk cache.
 	ClearMem()
 }
@@ -690,12 +689,10 @@ type FastTeamLoader interface {
 	HintLatestSeqno(m MetaContext, id keybase1.TeamID, seqno keybase1.Seqno) error
 	VerifyTeamName(m MetaContext, id keybase1.TeamID, name keybase1.TeamName, forceRefresh bool) error
 	ForceRepollUntil(m MetaContext, t gregor.TimeOrOffset) error
-	OnLogout()
 }
 
 type TeamAuditor interface {
 	AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkleSeqno keybase1.Seqno, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno) (err error)
-	OnLogout(m MetaContext)
 }
 
 type TeamBoxAuditor interface {
@@ -705,7 +702,6 @@ type TeamBoxAuditor interface {
 	BoxAuditRandomTeam(m MetaContext) (attempt *keybase1.BoxAuditAttempt, err error)
 	BoxAuditTeam(m MetaContext, id keybase1.TeamID) (attempt *keybase1.BoxAuditAttempt, err error)
 	Attempt(m MetaContext, id keybase1.TeamID, rotateBeforeAudit bool) keybase1.BoxAuditAttempt
-	OnLogout(m MetaContext)
 }
 
 // MiniChatPayment is the argument for sending an in-chat payment.
@@ -740,7 +736,6 @@ type MiniChatPaymentSummary struct {
 }
 
 type Stellar interface {
-	OnLogout()
 	CreateWalletSoft(context.Context)
 	Upkeep(context.Context) error
 	GetServerDefinitions(context.Context) (stellar1.StellarServerDefinitions, error)
@@ -828,11 +823,15 @@ type LRUKeyer interface {
 type LRUer interface {
 	Get(context.Context, LRUContext, LRUKeyer) (interface{}, error)
 	Put(context.Context, LRUContext, LRUKeyer, interface{}) error
+	OnLogout(mctx MetaContext) error
+	OnDbNuke(mctx MetaContext) error
 }
 
 type MemLRUer interface {
 	Get(key interface{}) (interface{}, bool)
 	Put(key, value interface{}) bool
+	OnLogout(mctx MetaContext) error
+	OnDbNuke(mctx MetaContext) error
 }
 
 type ClockContext interface {

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -21,8 +21,6 @@ func newNullStellar(g *GlobalContext) *nullStellar {
 	return &nullStellar{NewContextified(g)}
 }
 
-func (n *nullStellar) OnLogout() {}
-
 func (n *nullStellar) CreateWalletSoft(ctx context.Context) {
 	n.G().Log.CErrorf(ctx, "null stellar impl")
 }

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -67,8 +67,6 @@ func (n *nullTeamLoader) ForceRepollUntil(ctx context.Context, t gregor.TimeOrOf
 	return nil
 }
 
-func (n nullTeamLoader) OnLogout() {}
-
 func (n nullTeamLoader) ClearMem() {}
 
 type nullFastTeamLoader struct{}
@@ -91,8 +89,6 @@ func (n nullFastTeamLoader) ForceRepollUntil(_ MetaContext, _ gregor.TimeOrOffse
 	return nil
 }
 
-func (n nullFastTeamLoader) OnLogout() {}
-
 func newNullFastTeamLoader() nullFastTeamLoader { return nullFastTeamLoader{} }
 
 type nullTeamAuditor struct{}
@@ -102,8 +98,6 @@ var _ TeamAuditor = nullTeamAuditor{}
 func (n nullTeamAuditor) AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkleSeqno keybase1.Seqno, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno) (err error) {
 	return fmt.Errorf("null team auditor")
 }
-
-func (n nullTeamAuditor) OnLogout(m MetaContext) {}
 
 func newNullTeamAuditor() nullTeamAuditor { return nullTeamAuditor{} }
 
@@ -147,5 +141,4 @@ func (n nullTeamBoxAuditor) BoxAuditTeam(m MetaContext, id keybase1.TeamID) (*ke
 func (n nullTeamBoxAuditor) Attempt(m MetaContext, id keybase1.TeamID, rotateBeforeAudit bool) keybase1.BoxAuditAttempt {
 	return *attemptNullBoxAuditor()
 }
-func (n nullTeamBoxAuditor) OnLogout(m MetaContext) {}
-func newNullTeamBoxAuditor() nullTeamBoxAuditor     { return nullTeamBoxAuditor{} }
+func newNullTeamBoxAuditor() nullTeamBoxAuditor { return nullTeamBoxAuditor{} }

--- a/go/lru/lru.go
+++ b/go/lru/lru.go
@@ -113,4 +113,14 @@ func (c *Cache) Put(ctx context.Context, lctx libkb.LRUContext, k libkb.LRUKeyer
 	return nil
 }
 
+func (c *Cache) OnLogout(mctx libkb.MetaContext) error {
+	c.ClearMemory()
+	return nil
+}
+
+func (c *Cache) OnDbNuke(mctx libkb.MetaContext) error {
+	c.ClearMemory()
+	return nil
+}
+
 var _ libkb.LRUer = (*Cache)(nil)

--- a/go/service/ctl.go
+++ b/go/service/ctl.go
@@ -71,15 +71,10 @@ func (c *CtlHandler) DbNuke(ctx context.Context, sessionID int) error {
 	}
 	logui.Warning("Nuking chat database %s", fn)
 
-	if teamLoader := c.G().GetTeamLoader(); teamLoader != nil {
-		teamLoader.ClearMem()
-	}
-	if ekLib := c.G().GetEKLib(); ekLib != nil {
-		ekLib.ClearCaches(c.MetaContext(ctx))
-	}
 	// Now drop caches, since we had the DB's state in-memory too.
 	c.G().FlushCaches()
-	c.service.onDbNuke(ctx)
+	mctx := libkb.NewMetaContext(ctx, c.G())
+	c.G().CallDbNukeHooks(mctx)
 	return nil
 }
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -94,7 +94,7 @@ func NewService(g *libkb.GlobalContext, isDaemon bool) *Service {
 		home:             home.NewHome(g),
 		tlfUpgrader:      tlfupgrade.NewBackgroundTLFUpdater(g),
 		teamUpgrader:     teams.NewUpgrader(),
-		avatarLoader:     avatars.CreateSourceFromEnv(g),
+		avatarLoader:     avatars.CreateSourceFromEnvAndInstall(g),
 		walletState:      stellar.NewWalletState(g, remote.NewRemoteNet(g)),
 		offlineRPCCache:  offline.NewRPCCache(g),
 	}
@@ -424,6 +424,7 @@ func (d *Service) SetupChatModules(ri func() chat1.RemoteInterface) {
 	chatStorage.SetAssetDeleter(g.ConvSource)
 	g.RegexpSearcher = search.NewRegexpSearcher(g)
 	g.Indexer = search.NewIndexer(g)
+	g.AddDbNukeHook(g.Indexer, "SearchIndexer")
 	g.ServerCacheVersions = storage.NewServerVersions(g)
 
 	// Syncer and retriers
@@ -451,6 +452,7 @@ func (d *Service) SetupChatModules(ri func() chat1.RemoteInterface) {
 	g.TeamChannelSource = chat.NewTeamChannelSource(g)
 
 	g.AttachmentURLSrv = chat.NewAttachmentHTTPSrv(g, chat.NewCachingAttachmentFetcher(g, store, 1000), ri)
+	g.AddDbNukeHook(g.AttachmentURLSrv, "AttachmentURLSrv")
 
 	g.StellarLoader = stellar.DefaultLoader(g.ExternalG())
 	g.StellarSender = wallet.NewSender(g)
@@ -1324,16 +1326,4 @@ func (d *Service) StartStandaloneChat(g *libkb.GlobalContext) error {
 	d.startChatModules()
 
 	return nil
-}
-
-// Called by CtlHandler after DbNuke finishes and succeeds.
-func (d *Service) onDbNuke(ctx context.Context) {
-	mctx := libkb.NewMetaContext(ctx, d.G())
-	d.avatarLoader.OnCacheCleared(mctx)
-	if srv := d.ChatG().AttachmentURLSrv; srv != nil {
-		srv.OnCacheCleared(mctx)
-	}
-	if idx := d.ChatG().Indexer; idx != nil {
-		idx.ClearCache()
-	}
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -424,6 +424,7 @@ func (d *Service) SetupChatModules(ri func() chat1.RemoteInterface) {
 	chatStorage.SetAssetDeleter(g.ConvSource)
 	g.RegexpSearcher = search.NewRegexpSearcher(g)
 	g.Indexer = search.NewIndexer(g)
+	g.AddLogoutHook(g.Indexer, "SearchIndexer")
 	g.AddDbNukeHook(g.Indexer, "SearchIndexer")
 	g.ServerCacheVersions = storage.NewServerVersions(g)
 

--- a/go/teams/conflicts.go
+++ b/go/teams/conflicts.go
@@ -108,4 +108,6 @@ func NewImplicitTeamConflictInfoCache(g *libkb.GlobalContext) *lru.Cache {
 func NewImplicitTeamConflictInfoCacheAndInstall(g *libkb.GlobalContext) {
 	cache := NewImplicitTeamConflictInfoCache(g)
 	g.SetImplicitTeamConflictInfoCacher(cache)
+	g.AddLogoutHook(cache, "implicitTeamConflictInfoCache")
+	g.AddDbNukeHook(cache, "implicitTeamConflictInfoCache")
 }

--- a/go/teams/ftl.go
+++ b/go/teams/ftl.go
@@ -64,6 +64,8 @@ func NewFastTeamLoader(g *libkb.GlobalContext) *FastTeamChainLoader {
 func NewFastTeamLoaderAndInstall(g *libkb.GlobalContext) *FastTeamChainLoader {
 	l := NewFastTeamLoader(g)
 	g.SetFastTeamLoader(l)
+	g.AddLogoutHook(l, "fastTeamLoader")
+	g.AddDbNukeHook(l, "fastTeamLoader")
 	return l
 }
 
@@ -1254,10 +1256,18 @@ func (f *FastTeamChainLoader) loadLocked(m libkb.MetaContext, arg fastLoadArg) (
 	return f.toResult(m, arg, state)
 }
 
-// OnLogout is called when the user logs out, which pruges the LRU.
-func (f *FastTeamChainLoader) OnLogout() {
+// OnLogout is called when the user logs out, which purges the LRU.
+func (f *FastTeamChainLoader) OnLogout(mctx libkb.MetaContext) error {
 	f.storage.clearMem()
 	f.featureFlagGate.Clear()
+	return nil
+}
+
+// OnDbNuke is called when the disk cache is cleared, which purges the LRU.
+func (f *FastTeamChainLoader) OnDbNuke(mctx libkb.MetaContext) error {
+	f.storage.clearMem()
+	f.featureFlagGate.Clear()
+	return nil
 }
 
 func (f *FastTeamChainLoader) HintLatestSeqno(m libkb.MetaContext, id keybase1.TeamID, seqno keybase1.Seqno) (err error) {

--- a/go/teams/ftl_test.go
+++ b/go/teams/ftl_test.go
@@ -1,11 +1,12 @@
 package teams
 
 import (
+	"testing"
+
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestFastLoaderBasic(t *testing.T) {
@@ -99,7 +100,9 @@ func TestFastLoaderKeyGen(t *testing.T) {
 	require.True(t, teamName.Eq(team.Name))
 
 	t.Logf("clear A's FTL state")
-	tcs[0].G.GetFastTeamLoader().OnLogout()
+	ftl, ok := tcs[0].G.GetFastTeamLoader().(*FastTeamChainLoader)
+	require.True(t, ok)
+	require.NoError(t, ftl.OnLogout(m[0]))
 
 	t.Logf("more tests as A; let's first load at generation=1")
 	arg = keybase1.FastTeamLoadArg{
@@ -225,7 +228,9 @@ func TestFastLoaderUpPointerUnstub(t *testing.T) {
 
 	// Also check that it works on a fresh load on a clean cache (thought this
 	// duplicates what we did in TestFastLoaderMultilevel)
-	tcs[0].G.GetFastTeamLoader().OnLogout()
+	ftl, ok := tcs[0].G.GetFastTeamLoader().(*FastTeamChainLoader)
+	require.True(t, ok)
+	require.NoError(t, ftl.OnLogout(m[0]))
 	loadSubteam()
 }
 

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -388,10 +388,16 @@ func (i *implicitTeamCache) OnLogout(m libkb.MetaContext) error {
 	return nil
 }
 
+func (i *implicitTeamCache) OnDbNuke(m libkb.MetaContext) error {
+	i.cache.Purge()
+	return nil
+}
+
 var _ libkb.MemLRUer = &implicitTeamCache{}
 
 func NewImplicitTeamCacheAndInstall(g *libkb.GlobalContext) {
 	cache := newImplicitTeamCache(g)
 	g.SetImplicitTeamCacher(cache)
 	g.AddLogoutHook(cache, "implicitTeamCache")
+	g.AddDbNukeHook(cache, "implicitTeamCache")
 }

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -95,6 +95,8 @@ func NewTeamLoaderAndInstall(g *libkb.GlobalContext) *TeamLoader {
 	st := NewStorage(g)
 	l := NewTeamLoader(g, world, st)
 	g.SetTeamLoader(l)
+	g.AddLogoutHook(l, "teamLoader")
+	g.AddDbNukeHook(l, "teamLoader")
 	return l
 }
 
@@ -1322,8 +1324,14 @@ func (l *TeamLoader) lows(ctx context.Context, state *keybase1.TeamData) getLink
 	return lows
 }
 
-func (l *TeamLoader) OnLogout() {
+func (l *TeamLoader) OnLogout(mctx libkb.MetaContext) error {
 	l.storage.clearMem()
+	return nil
+}
+
+func (l *TeamLoader) OnDbNuke(mctx libkb.MetaContext) error {
+	l.storage.clearMem()
+	return nil
 }
 
 // Clear the in-memory cache.


### PR DESCRIPTION
Adds `DbNukeHooks` to `GlobalContext` to unify clearing of caches.