### PR TITLE
prefetcher: record total prefetch bytes first, to fix test flake

### DIFF
--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -989,8 +989,8 @@ func (p *blockPrefetcher) run(
 				req.action.Sync() {
 				// This request turned into a syncing request, so
 				// update the overall sync status.
-				p.updateOverallSyncFetchedBytes(pre.SubtreeBytesFetched, req)
 				p.updateOverallSyncTotalBytes(pre.SubtreeBytesTotal, req)
+				p.updateOverallSyncFetchedBytes(pre.SubtreeBytesFetched, req)
 			}
 
 			// If the request is finished (i.e., if it's marked as


### PR DESCRIPTION
We enforce with a panic that fetched bytes can never exceed total bytes, so when updating both, total bytes should always be done first.