### PR TITLE
add required styles for lineclamp and use in chat + teams header

### DIFF
--- a/shared/chat/header.desktop.js
+++ b/shared/chat/header.desktop.js
@@ -39,7 +39,7 @@ const Header = (p: Props) => (
       <Kb.Box2 direction="vertical" style={styles.grow}>
         <Kb.Box2 direction="horizontal" fullWidth={true}>
           {p.channel ? (
-            <Kb.Text selectable={true} type="Header">
+            <Kb.Text selectable={true} type="Header" lineClamp={1}>
               {p.channel}
             </Kb.Text>
           ) : p.participants ? (
@@ -65,7 +65,7 @@ const Header = (p: Props) => (
           )}
         </Kb.Box2>
         {!!p.desc && (
-          <Kb.Text selectable={true} type="BodyTiny" style={styles.desc}>
+          <Kb.Text selectable={true} type="BodyTiny" style={styles.desc} lineClamp={1}>
             {p.desc}
           </Kb.Text>
         )}

--- a/shared/common-adapters/text.meta.desktop.js
+++ b/shared/common-adapters/text.meta.desktop.js
@@ -17,8 +17,10 @@ function defaultColor(backgroundMode: ?Background) {
 const lineClamp = (lines: number) => ({
   WebkitBoxOrient: 'vertical',
   WebkitLineClamp: lines,
+  display: '-webkit-box',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
+  wordBreak: 'break-word',
 })
 
 function fontSizeToSizeStyle(fontSize: number): ?Object {

--- a/shared/common-adapters/text.stories.js
+++ b/shared/common-adapters/text.stories.js
@@ -2,8 +2,9 @@
 import * as React from 'react'
 import * as Sb from '../stories/storybook'
 import Box from './box'
+import Icon from './icon'
 import Text, {allTextTypes} from './text'
-import {globalColors, globalStyles, isMobile, platformStyles} from '../styles'
+import {globalColors, globalMargins, globalStyles, isMobile, platformStyles} from '../styles'
 
 const SmallGap = () => <Box style={{minHeight: 24}} />
 const LargeGap = () => <Box style={{minHeight: 36}} />
@@ -117,6 +118,9 @@ const mapText = (secondary: boolean) => {
   return items
 }
 
+// prettier-ignore
+const longText = ['At', 'Et', 'Itaque', 'Nam', 'Nemo', 'Quis', 'Sed', 'Temporibus', 'Ut', 'a', 'ab', 'accusamus', 'accusantium', 'ad', 'alias', 'aliquam', 'aliquid', 'amet', 'animi', 'aperiam', 'architecto', 'asperiores', 'aspernatur', 'assumenda', 'atque', 'aut', 'autem', 'beatae', 'blanditiis', 'commodi', 'consectetur', 'consequatur', 'consequatur', 'consequatur', 'consequuntur', 'corporis', 'corrupti', 'culpa', 'cum', 'cumque', 'cupiditate', 'debitis', 'delectus', 'deleniti', 'deserunt', 'dicta', 'dignissimos', 'distinctio', 'dolor', 'dolore', 'dolorem', 'doloremque', 'dolores', 'doloribus', 'dolorum', 'ducimus', 'ea', 'eaque', 'earum', 'eius', 'eligendi', 'enim', 'eos', 'eos', 'error', 'esse', 'est', 'est', 'et', 'eum', 'eveniet', 'ex', 'excepturi', 'exercitationem', 'expedita', 'explicabo', 'facere', 'facilis', 'fuga', 'fugiat', 'fugit', 'harum', 'hic', 'id', 'id', 'illo', 'illum', 'impedit', 'in', 'inventore', 'ipsa', 'ipsam', 'ipsum', 'iste', 'iure', 'iusto', 'labore', 'laboriosam', 'laborum', 'laudantium', 'libero', 'magnam', 'magni', 'maiores', 'maxime', 'minima', 'minus', 'modi', 'molestiae', 'molestias', 'mollitia', 'natus', 'necessitatibus', 'neque', 'nesciunt', 'nihil', 'nisi', 'nobis', 'non-numquam', 'non-provident', 'non-recusandae', 'nostrum', 'nulla', 'obcaecati', 'odio', 'odit', 'officia', 'officiis', 'omnis', 'optio', 'pariatur', 'perferendis', 'perspiciatis', 'placeat', 'porro', 'possimus', 'praesentium', 'quae', 'quaerat', 'quam', 'quas', 'quasi', 'qui', 'quia', 'quibusdam', 'quidem', 'quis', 'quisquam', 'quo', 'quod', 'quos', 'ratione', 'reiciendis', 'rem', 'repellat', 'repellendus', 'reprehenderit', 'repudiandae', 'rerum', 'saepe', 'sapiente', 'sed', 'sequi', 'similique', 'sint', 'sint', 'sit', 'sit', 'soluta', 'sunt', 'sunt', 'suscipit', 'tempora', 'tempore', 'tenetur', 'totam', 'ullam', 'unde', 'ut', 'vel', 'velit', 'velit', 'veniam', 'veritatis', 'vero', 'vitae', 'voluptas', 'voluptate', 'voluptatem', 'voluptatem', 'voluptatem', 'voluptates', 'voluptatibus', 'voluptatum'].join(' ')
+
 const load = () => {
   Sb.storiesOf('Common', module)
     .addDecorator(Sb.scrollViewDecorator)
@@ -129,7 +133,7 @@ const load = () => {
         </Container>
       </Box>
     ))
-    .add('TextAll', () => (
+    .add('Text all', () => (
       <>
         {Object.keys(allTextTypes).map(t => (
           <Box key={t}>
@@ -138,11 +142,40 @@ const load = () => {
         ))}
       </>
     ))
-    .add('TextCentered', () => (
+    .add('Text centered', () => (
       <Box style={{backgroundColor: 'red', width: 100}}>
         <Text type="Header" center={true}>
           This is centered
         </Text>
+      </Box>
+    ))
+    .add('Text lineclamp', () => (
+      <Box style={{...globalStyles.flexBoxColumn, maxWidth: 600}}>
+        <Text type="Body">Lineclamp = 1</Text>
+        <Box style={{...globalStyles.flexBoxRow, flex: 1}}>
+          <Text type="BodySemibold" lineClamp={1}>
+            {longText}
+          </Text>
+        </Box>
+
+        <Text type="Body" style={{marginTop: globalMargins.small}}>
+          Lineclamp = 1 with content to the right
+        </Text>
+        <Box style={{...globalStyles.flexBoxRow, flex: 1}}>
+          <Text type="BodySemibold" lineClamp={1} style={{flex: 1}}>
+            {longText}
+          </Text>
+          <Icon type="iconfont-edit" />
+        </Box>
+
+        <Text type="Body" style={{marginTop: globalMargins.small}}>
+          Lineclamp = 4
+        </Text>
+        <Box style={{...globalStyles.flexBoxRow, flex: 1}}>
+          <Text type="BodySemibold" lineClamp={4}>
+            {longText}
+          </Text>
+        </Box>
       </Box>
     ))
 }

--- a/shared/teams/team/nav-header/index.js
+++ b/shared/teams/team/nav-header/index.js
@@ -77,14 +77,16 @@ export const HeaderTitle = (props: HeaderTitleProps) => (
       ])}
     />
     <Kb.Box2 direction="vertical">
-      <Kb.Text type="Header">{props.teamname}</Kb.Text>
+      <Kb.Text type="Header" lineClamp={1}>
+        {props.teamname}
+      </Kb.Text>
       <Kb.Text type="BodySmall">
         TEAM · {props.members} {pluralize('member', props.members)}
         {!!props.role && ` · ${props.role === 'none' ? 'Not a member' : capitalize(props.role)}`}
       </Kb.Text>
       <Kb.Text
         type={props.onEditDescription && !props.description ? 'BodySmallItalic' : 'BodySmall'}
-        lineClamp={1}
+        lineClamp={3}
         onClick={props.onEditDescription}
         className={Styles.classNames({'hover-underline': !!props.onEditDescription})}
         style={styles.clickable}


### PR DESCRIPTION
This works nicely in the headers. I also tried it in some random places around the app with different parent styles - it worked everywhere I checked. No external styles required :tada: 

r? @keybase/react-hackers 