### PR TITLE
link to slack importer

### DIFF
--- a/shared/teams/team/header/add-people-how/container.js
+++ b/shared/teams/team/header/add-people-how/container.js
@@ -4,6 +4,7 @@ import {connect} from '../../../../util/container'
 import {AddPeopleHow} from '.'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
 import {teamsTab} from '../../../../constants/tabs'
+import openURL from '../../../../util/open-url'
 
 type OwnProps = {
   attachTo: () => ?React.Component<any>,
@@ -32,6 +33,7 @@ const mapDispatchToProps = (dispatch, {teamname}: OwnProps) => {
       )
       dispatch(RouteTreeGen.createSwitchTo({path: [teamsTab]}))
     },
+    onSlackImport: () => openURL(`https://keybase.io/slack-importer/${teamname}`),
   }
 }
 

--- a/shared/teams/team/header/add-people-how/index.js
+++ b/shared/teams/team/header/add-people-how/index.js
@@ -15,11 +15,16 @@ type Props = {
 const AddPeopleHow = (props: Props) => {
   const items = [
     {onClick: props.onAddPeople, subTitle: 'Keybase, Twitter, etc.', title: 'By username'},
-    {onClick: props.onInvite, style: {borderTopWidth: 0}, title: isMobile ? 'From address book' : 'By email'},
+    {
+      onClick: props.onInvite,
+      style: {borderTopWidth: 0},
+      subTitle: 'friends@friendships.com',
+      title: isMobile ? 'From address book' : 'By email',
+    },
     {
       onClick: props.onSlackImport,
       style: {borderTopWidth: 0},
-      subTitle: 'New! Secure your team',
+      subTitle: 'New! Migrate your team',
       title: 'From Slack',
     },
   ]

--- a/shared/teams/team/header/add-people-how/index.js
+++ b/shared/teams/team/header/add-people-how/index.js
@@ -9,12 +9,19 @@ type Props = {
   onAddPeople: () => void,
   onHidden: () => void,
   onInvite: () => void,
+  onSlackImport: () => void,
 }
 
 const AddPeopleHow = (props: Props) => {
   const items = [
     {onClick: props.onAddPeople, subTitle: 'Keybase, Twitter, etc.', title: 'By username'},
     {onClick: props.onInvite, style: {borderTopWidth: 0}, title: isMobile ? 'From address book' : 'By email'},
+    {
+      onClick: props.onSlackImport,
+      style: {borderTopWidth: 0},
+      subTitle: 'New! Secure your team',
+      title: 'From Slack',
+    },
   ]
 
   return (


### PR DESCRIPTION
this seems to work.  I just wanted to add this menu item, linking to the site.

![image](https://user-images.githubusercontent.com/614943/56391898-07aee280-61fe-11e9-8f9d-68c2fb6bee8d.png)


clicking that sends you to the slack importer experimental page, with your team name prefilled.