### PR TITLE
simplefs: print total stored bytes for synced TLFs and overall

### DIFF
--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -1436,6 +1436,15 @@ func (cache *DiskBlockCacheLocal) ClearHomeTLFs(ctx context.Context) error {
 	return nil
 }
 
+// GetTlfSize returns the number of bytes stored for the given TLF in
+// the cache.
+func (cache *DiskBlockCacheLocal) GetTlfSize(
+	_ context.Context, tlfID tlf.ID) (uint64, error) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	return cache.tlfSizes[tlfID], nil
+}
+
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheLocal.
 func (cache *DiskBlockCacheLocal) Shutdown(ctx context.Context) {
 	// Wait for the cache to either finish starting or error.

--- a/go/kbfs/libkbfs/disk_block_cache_remote.go
+++ b/go/kbfs/libkbfs/disk_block_cache_remote.go
@@ -249,6 +249,13 @@ func (dbcr *DiskBlockCacheRemote) ClearHomeTLFs(ctx context.Context) error {
 	return nil
 }
 
+// GetTlfSize implements the DiskBlockCache interface for
+// DiskBlockCacheRemote.
+func (dbcr *DiskBlockCacheRemote) GetTlfSize(
+	_ context.Context, _ tlf.ID, _ DiskBlockCacheType) (uint64, error) {
+	panic("GetTlfSize() not implemented in DiskBlockCacheRemote")
+}
+
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) Shutdown(ctx context.Context) {
 	dbcr.conn.Close()

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -999,6 +999,12 @@ type DiskBlockCache interface {
 	// ClearHomeTLFs should be called on logout so that the old user's TLFs
 	// are not still marked as home.
 	ClearHomeTLFs(ctx context.Context) error
+	// GetTlfSize returns the number of bytes stored for the given TLF
+	// in the cache of the given type.  If `DiskBlockAnyCache` is
+	// specified, it returns the total sum of bytes across all caches.
+	GetTlfSize(
+		ctx context.Context, tlfID tlf.ID, cacheType DiskBlockCacheType) (
+		uint64, error)
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }

--- a/go/protocol/keybase1/kbfs_common.go
+++ b/go/protocol/keybase1/kbfs_common.go
@@ -347,6 +347,7 @@ type FolderSyncStatus struct {
 	LocalDiskBytesTotal     int64            `codec:"localDiskBytesTotal" json:"localDiskBytesTotal"`
 	PrefetchStatus          PrefetchStatus   `codec:"prefetchStatus" json:"prefetchStatus"`
 	PrefetchProgress        PrefetchProgress `codec:"prefetchProgress" json:"prefetchProgress"`
+	StoredBytesTotal        int64            `codec:"storedBytesTotal" json:"storedBytesTotal"`
 }
 
 func (o FolderSyncStatus) DeepCopy() FolderSyncStatus {
@@ -355,6 +356,7 @@ func (o FolderSyncStatus) DeepCopy() FolderSyncStatus {
 		LocalDiskBytesTotal:     o.LocalDiskBytesTotal,
 		PrefetchStatus:          o.PrefetchStatus.DeepCopy(),
 		PrefetchProgress:        o.PrefetchProgress.DeepCopy(),
+		StoredBytesTotal:        o.StoredBytesTotal,
 	}
 }
 

--- a/protocol/avdl/keybase1/kbfs_common.avdl
+++ b/protocol/avdl/keybase1/kbfs_common.avdl
@@ -108,5 +108,6 @@ protocol kbfsCommon {
     int64 localDiskBytesTotal;
     PrefetchStatus prefetchStatus;
     PrefetchProgress prefetchProgress;
+    int64 storedBytesTotal;
   }
 }

--- a/protocol/json/keybase1/kbfs_common.json
+++ b/protocol/json/keybase1/kbfs_common.json
@@ -254,6 +254,10 @@
         {
           "type": "PrefetchProgress",
           "name": "prefetchProgress"
+        },
+        {
+          "type": "int64",
+          "name": "storedBytesTotal"
         }
       ]
     }

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -2211,7 +2211,7 @@ export type FolderSyncMode =
   | 1 // ENABLED_1
   | 2 // PARTIAL_2
 
-export type FolderSyncStatus = $ReadOnly<{localDiskBytesAvailable: Int64, localDiskBytesTotal: Int64, prefetchStatus: PrefetchStatus, prefetchProgress: PrefetchProgress}>
+export type FolderSyncStatus = $ReadOnly<{localDiskBytesAvailable: Int64, localDiskBytesTotal: Int64, prefetchStatus: PrefetchStatus, prefetchProgress: PrefetchProgress, storedBytesTotal: Int64}>
 export type FolderType =
   | 0 // UNKNOWN_0
   | 1 // PRIVATE_1


### PR DESCRIPTION
* Have a way for the disk block cache to supply per-TLF sizes.
* Populate those in simplefs and route them through the protocol.
* Display from the CLI, like this:

```sh
$ ./keybase --run-mode=prod fs sync show /keybase/private/strib,jzila
Syncing enabled
Status: fully synced
41.37 MB bytes stored
799.80 GB (87.43%) of the local disk is available for caching.

$ ./keybase --run-mode=prod fs sync show 
private/strib,eleanor
  Syncing enabled
  Status: fully synced
  398.63 MB bytes stored

private/strib,jzila
  Syncing enabled
  Status: fully synced
  41.37 MB bytes stored

private/strib,songgao
  Syncing enabled
  Status: fully synced
  1.07 GB bytes stored

team/keybase.staff_v8
  Syncing configured for this subpath:
  	candidates
  		Status: fully synced
  168.89 MB bytes stored

1.67 GB bytes stored
799.80 GB (87.43%) of the local disk is available for caching.
```

Issue: KBFS-4069