### PR TITLE
engine: better UID switch machinery

### DIFF
--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -50,9 +50,18 @@ func isLoggedInWithUIDAndError(m libkb.MetaContext) (ret bool, uid keybase1.UID,
 	ret, uid, err = libkb.BootstrapActiveDeviceWithMetaContext(m)
 	return ret, uid, err
 }
+
 func isLoggedIn(m libkb.MetaContext) (ret bool, uid keybase1.UID) {
 	ret, uid, _ = libkb.BootstrapActiveDeviceWithMetaContext(m)
 	return ret, uid
+}
+
+func isLoggedInAs(m libkb.MetaContext, uid keybase1.UID) (ret bool) {
+	ret, err := libkb.BootstrapActiveDeviceWithMetaContextAndAssertUID(m, uid)
+	if err != nil {
+		m.Debug("isLoggedAs error: %s", err)
+	}
+	return ret
 }
 
 func assertLoggedIn(m libkb.MetaContext, which string) (err error) {


### PR DESCRIPTION
The issue now is that if you are both logged in as A and B, and you call LoginProvisionedDevice(B), it might actually log you in as A, just to see if you're not B. I think we used to do this because of the complexities of email-based logins, which we're doing away with.

Instead, the following:

* get the target UID from the username (via the config file username -> uid lookup)
* if username is provided
  * call something like isLoggedInAs(uid), which will make side-effects to global state only if we match the targeted UID
  * if not then try an unlock with the current UID
* the back to the existing behavior