### PR TITLE
Fix conv indices not getting fully indexed

### DIFF
--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -831,7 +831,7 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query string, o
 			case chat1.ReIndexingMode_POSTSEARCH_SYNC:
 				// ignore any fully indexed convs since we respect
 				// opts.MaxConvsSearched
-				if convIdx.PercentIndexed(conv.Conv) == 100 {
+				if convIdx.FullyIndexed(conv.Conv) {
 					continue
 				}
 				convIdx, totalPercentIndexed, err = idx.reindexConvWithUIUpdate(ctx, conv.Conv, uid,

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -437,23 +437,12 @@ type reindexOpts struct {
 func (idx *Indexer) reindexConv(ctx context.Context, conv chat1.Conversation, uid gregor1.UID,
 	convIdx *chat1.ConversationIndex, opts reindexOpts) (completedJobs int, newIdx *chat1.ConversationIndex, err error) {
 
-	// find the min and max missing ids so we can page between them to fill the gaps.
-	minConvMsgID := conv.GetMaxDeletedUpTo()
-	maxConvMsgID := conv.GetMaxMessageID()
-	missingIDs := convIdx.MissingIDs(minConvMsgID, maxConvMsgID)
+	missingIDs := convIdx.MissingIDForConv(conv)
 	if len(missingIDs) == 0 {
 		return 0, convIdx, nil
 	}
-	minIdxID := maxConvMsgID
-	maxIdxID := minConvMsgID
-	for _, msgID := range missingIDs {
-		if msgID < minIdxID {
-			minIdxID = msgID
-		}
-		if msgID > maxIdxID {
-			maxIdxID = msgID
-		}
-	}
+	minIdxID := missingIDs[0]
+	maxIdxID := missingIDs[len(missingIDs)-1]
 
 	convID := conv.GetConvID()
 	defer idx.Trace(ctx, func() error { return err },

--- a/go/chat/search/storage.go
+++ b/go/chat/search/storage.go
@@ -64,10 +64,13 @@ func (s *store) getLocked(ctx context.Context, convID chat1.ConversationID, uid 
 	defer func() {
 		// return a blank index
 		if err == nil && ret == nil {
-			ret = &chat1.ConversationIndex{}
-			ret.Index = map[string]map[chat1.MessageID]chat1.EmptyStruct{}
-			ret.Alias = map[string]map[string]chat1.EmptyStruct{}
-			ret.Metadata.SeenIDs = map[chat1.MessageID]chat1.EmptyStruct{}
+			ret = &chat1.ConversationIndex{
+				Index: make(map[string]map[chat1.MessageID]chat1.EmptyStruct),
+				Alias: make(map[string]map[string]chat1.EmptyStruct),
+				Metadata: chat1.ConversationIndexMetadata{
+					SeenIDs: make(map[chat1.MessageID]chat1.EmptyStruct),
+				},
+			}
 		}
 		if err != nil {
 			if derr := s.deleteLocked(ctx, convID, uid); derr != nil {

--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/search"
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -373,10 +375,6 @@ func TestChatSearchInbox(t *testing.T) {
 		u1 := users[0]
 		u2 := users[1]
 
-		conv := mustCreateConversationForTest(t, ctc, u1, chat1.TopicType_CHAT,
-			mt, ctc.as(t, u2).user())
-		convID := conv.Id
-
 		tc1 := ctc.as(t, u1)
 		tc2 := ctc.as(t, u2)
 		uid1 := u1.User.GetUID().ToBytes()
@@ -418,6 +416,24 @@ func TestChatSearchInbox(t *testing.T) {
 			require.Fail(t, "g2 Indexer did not stop")
 		}
 		g2.Indexer = indexer2
+
+		conv := mustCreateConversationForTest(t, ctc, u1, chat1.TopicType_CHAT,
+			mt, ctc.as(t, u2).user())
+		convID := conv.Id
+
+		rconv, err := utils.GetUnverifiedConv(ctx, g1, uid1, conv.Id,
+			types.InboxSourceDataSourceRemoteOnly)
+		require.NoError(t, err)
+		// verify zero messages case
+		convIdx, err := indexer1.GetConvIndex(ctx, convID, uid1)
+		require.NoError(t, err)
+		require.True(t, convIdx.FullyIndexed(rconv.Conv))
+		require.Equal(t, 100, convIdx.PercentIndexed(rconv.Conv))
+
+		convIdx, err = indexer2.GetConvIndex(ctx, convID, uid2)
+		require.NoError(t, err)
+		require.True(t, convIdx.FullyIndexed(rconv.Conv))
+		require.Equal(t, 100, convIdx.PercentIndexed(rconv.Conv))
 
 		sendMessage := func(msgBody chat1.MessageBody, user *kbtest.FakeUser) chat1.MessageID {
 			msgID := mustPostLocalForTest(t, ctc, user, conv, msgBody)

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -2119,6 +2119,17 @@ func (idx *ConversationIndex) PercentIndexed(conv Conversation) int {
 	return 100 * (1 - (len(missingIDs) / numMessages))
 }
 
+func (idx *ConversationIndex) FullyIndexed(conv Conversation) bool {
+	if idx == nil {
+		return false
+	}
+	// lowest msgID we care about
+	min := conv.GetMaxDeletedUpTo()
+	// highest msgID we care about
+	max := conv.GetMaxMessageID()
+	return len(idx.MissingIDs(min, max)) == 0
+}
+
 func (u UnfurlRaw) GetUrl() string {
 	typ, err := u.UnfurlType()
 	if err != nil {


### PR DESCRIPTION
- adds `FullyIndexed` to correctly check the index state during `POSTSEARCH_SYNC` reindexing
- fixes index percentage calculation for empty convs
- sorts convs by mtime during selectivesync so recent convs are always reindexed. 