### PR TITLE
prefetcher: cancel all prefetches for a given TLF

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -607,6 +607,8 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 				retrieval.blockPtr, block, retrieval.kmd, retrieval.priority,
 				retrieval.cacheLifetime, NoPrefetch, retrieval.action)
 		} else {
+			brq.log.CDebugf(
+				retrieval.ctx, "Couldn't get block %s: %+v", retrieval.blockPtr, retrievalErr)
 			brq.Prefetcher().CancelPrefetch(retrieval.blockPtr)
 		}
 	} else if retrievalErr == nil {

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1390,7 +1390,7 @@ func (c *ConfigLocal) openConfigLevelDB(configName string) (*LevelDb, error) {
 
 func (c *ConfigLocal) loadSyncedTlfsLocked() (err error) {
 	defer func() {
-		c.MakeLogger("").CDebugf(nil, "Loading synced TLFs: %+v", err)
+		c.MakeLogger("").CDebugf(nil, "Loaded synced TLFs: %+v", err)
 	}()
 	syncedTlfs := make(map[tlf.ID]FolderSyncConfig)
 	syncedTlfPaths := make(map[string]bool)

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1389,6 +1389,9 @@ func (c *ConfigLocal) openConfigLevelDB(configName string) (*LevelDb, error) {
 }
 
 func (c *ConfigLocal) loadSyncedTlfsLocked() (err error) {
+	defer func() {
+		c.MakeLogger("").CDebugf(nil, "Loading synced TLFs: %+v", err)
+	}()
 	syncedTlfs := make(map[tlf.ID]FolderSyncConfig)
 	syncedTlfPaths := make(map[string]bool)
 	if c.mode.IsTestMode() {
@@ -1483,32 +1486,32 @@ func (c *ConfigLocal) OfflineAvailabilityForID(
 }
 
 func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
-	<-chan error, BlockOps, error) {
+	<-chan error, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	diskCacheWrapped, ok := c.diskBlockCache.(*diskBlockCacheWrapped)
 	if !ok {
-		return nil, nil, errors.Errorf(
+		return nil, errors.Errorf(
 			"invalid disk cache type to set TLF sync state: %T",
 			c.diskBlockCache)
 	}
 	if !diskCacheWrapped.IsSyncCacheEnabled() {
-		return nil, nil, errors.New("sync block cache is not enabled")
+		return nil, errors.New("sync block cache is not enabled")
 	}
 
 	if !c.mode.IsTestMode() {
 		if c.storageRoot == "" {
-			return nil, nil, errors.New(
+			return nil, errors.New(
 				"empty storageRoot specified for non-test run")
 		}
 		ldb, err := c.openConfigLevelDB(syncedTlfConfigFolderName)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		defer ldb.Close()
 		tlfBytes, err := tlfID.MarshalText()
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if config.Mode == keybase1.FolderSyncMode_DISABLED {
 			err = ldb.Delete(tlfBytes, nil)
@@ -1519,12 +1522,12 @@ func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
 			var buf []byte
 			buf, err = c.codec.Encode(&config)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			err = ldb.Put(tlfBytes, buf, nil)
 		}
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
@@ -1556,18 +1559,25 @@ func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
 	if config.TlfPath != "" {
 		c.syncedTlfPaths[config.TlfPath] = true
 	}
-	return ch, c.bops, nil
+	return ch, nil
 }
 
 // SetTlfSyncState implements the syncedTlfGetterSetter interface for
 // ConfigLocal.
-func (c *ConfigLocal) SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
+func (c *ConfigLocal) SetTlfSyncState(
+	ctx context.Context, tlfID tlf.ID, config FolderSyncConfig) (
 	<-chan error, error) {
-	ch, bops, err := c.setTlfSyncState(tlfID, config)
-	// Toggle the prefetcher outside of holding the lock, since the
-	// previous prefetcher might depend on accessing the config.
-	<-bops.TogglePrefetcher(true)
-	return ch, err
+	if config.Mode != keybase1.FolderSyncMode_DISABLED {
+		// If we're disabling, or just changing the partial sync
+		// config (which may be removing paths), we should cancel all
+		// the previous prefetches for this TLF.  For partial syncs, a
+		// new sync will be started.
+		err := c.BlockOps().Prefetcher().CancelTlfPrefetches(ctx, tlfID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.setTlfSyncState(tlfID, config)
 }
 
 // GetAllSyncedTlfs implements the syncedTlfGetterSetter interface for

--- a/go/kbfs/libkbfs/disk_block_cache_test.go
+++ b/go/kbfs/libkbfs/disk_block_cache_test.go
@@ -733,7 +733,7 @@ func TestDiskBlockCacheUnsyncTlf(t *testing.T) {
 	standardCache.numBlocksToEvictOnClear = 1
 
 	tlfToUnsync := tlf.FakeID(1, tlf.Private)
-	ch, err := config.SetTlfSyncState(tlfToUnsync, FolderSyncConfig{
+	ch, err := config.SetTlfSyncState(ctx, tlfToUnsync, FolderSyncConfig{
 		Mode: keybase1.FolderSyncMode_DISABLED,
 	})
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/folder_block_manager_test.go
+++ b/go/kbfs/libkbfs/folder_block_manager_test.go
@@ -749,7 +749,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 		ctx, t, config, userName.String(), tlf.Private)
 	kbfsOps := config.KBFSOps()
 	_, err = config.SetTlfSyncState(
-		rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
+		ctx, rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
 			Mode: keybase1.FolderSyncMode_ENABLED,
 		})
 	require.NoError(t, err)
@@ -815,7 +815,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 
 	t.Log("Set new TLF to syncing, and add a new revision")
 	_, err = config.SetTlfSyncState(
-		rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
+		ctx, rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
 			Mode: keybase1.FolderSyncMode_ENABLED,
 		})
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -8536,7 +8536,8 @@ func (fbo *folderBranchOps) GetSyncConfig(
 		return keybase1.FolderSyncConfig{}, err
 	}
 
-	if md == (ImmutableRootMetadata{}) ||
+	if config.Mode == keybase1.FolderSyncMode_DISABLED ||
+		md == (ImmutableRootMetadata{}) ||
 		md.GetTlfHandle().GetCanonicalPath() == tlfPath {
 		return config, nil
 	}
@@ -8807,7 +8808,7 @@ func (fbo *folderBranchOps) SetSyncConfig(
 		}
 	}
 
-	ch, err = fbo.config.SetTlfSyncState(tlfID, newConfig)
+	ch, err = fbo.config.SetTlfSyncState(ctx, tlfID, newConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/interface_test.go
+++ b/go/kbfs/libkbfs/interface_test.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/keybase/client/go/kbfs/kbfscodec"
@@ -99,7 +100,8 @@ func (t *testSyncedTlfGetterSetter) IsSyncedTlfPath(tlfPath string) bool {
 	return false
 }
 
-func (t *testSyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID,
+func (t *testSyncedTlfGetterSetter) SetTlfSyncState(
+	_ context.Context, tlfID tlf.ID,
 	config FolderSyncConfig) (<-chan error, error) {
 	t.syncedTlfs[tlfID] = config
 	return nil, nil

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -123,7 +123,9 @@ type syncedTlfGetterSetter interface {
 	IsSyncedTlf(tlfID tlf.ID) bool
 	IsSyncedTlfPath(tlfPath string) bool
 	GetTlfSyncState(tlfID tlf.ID) FolderSyncConfig
-	SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (<-chan error, error)
+	SetTlfSyncState(
+		ctx context.Context, tlfID tlf.ID, config FolderSyncConfig) (
+		<-chan error, error)
 	GetAllSyncedTlfs() []tlf.ID
 
 	idutil.OfflineStatusGetter
@@ -1309,6 +1311,9 @@ type Prefetcher interface {
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(data.BlockPointer)
+	// CancelTlfPrefetches notifies the prefetcher that all prefetches
+	// for a given TLF should be canceled.
+	CancelTlfPrefetches(context.Context, tlf.ID) error
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4502,7 +4502,7 @@ func TestKBFSOpsSyncedMDCommit(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 	config.SetTlfSyncState(
-		rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
+		ctx, rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
 			Mode: keybase1.FolderSyncMode_ENABLED,
 		})
 	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -2265,9 +2265,7 @@ func TestPrefetcherCancelTlfPrefetches(t *testing.T) {
 	}
 
 	t.Log("Cancel the first TLF's prefetches")
-	go func() {
-		notifySyncCh(t, prefetchSyncCh)
-	}()
+	go notifySyncCh(t, prefetchSyncCh)
 	err = q.Prefetcher().CancelTlfPrefetches(ctx, kmd1.TlfID())
 	require.NoError(t, err)
 


### PR DESCRIPTION
Previously, when changing a sync config, we would toggle the whole prefetcher to make sure the old requests were canceled.  But this can block for a really long time if there are a lot of requests outstanding.  We were doing this to make sure that when a block no longer needs to be prefetched (due to the config change), it wouldn't continue to be prefetched.  But we can handle this a different way, without all the blocking.

Instead, When a sync config is disabled, or a partial sync config is changed, just cancel all the prefetches associated with that TLF ID. It should be relatively rare, so that it doesn't matter much that we have to loop through all the prefetches when it happens.

Do it synchronously so we can make sure all the requests are canceled before the disk cache is scrubbed.

Issue: KBFS-4070