### PR TITLE
Drop postsearch_async option

### DIFF
--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -853,22 +853,8 @@ func TestChatSearchInbox(t *testing.T) {
 		runSearch(query, opts, false /* expectedReindex*/)
 		verifySearchDone(1)
 
-		// Verify background syncing
-		g1.LocalChatDb.Nuke()
-		indexer1.ClearCache()
-		ictx := globals.CtxAddIdentifyMode(ctx, keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil)
-		indexer1.SelectiveSync(ictx, uid1, true /* forceReindex */)
-		opts.ReindexMode = chat1.ReIndexingMode_POSTSEARCH_ASYNC
-		res = runSearch(query, opts, true /* expectedReindex*/)
-		require.Equal(t, 1, len(res.Hits))
-		convHit = res.Hits[0]
-		require.Equal(t, convID, convHit.ConvID)
-		require.Equal(t, 1, len(convHit.Hits))
-		verifyHit(convID, []chat1.MessageID{msgID3, msgID7}, msgID8, nil, []chat1.ChatSearchMatch{searchMatch}, convHit.Hits[0])
-		verifySearchDone(1)
-		verifyIndex(expectedIndex)
-
 		// Verify POSTSEARCH_SYNC
+		ictx := globals.CtxAddIdentifyMode(ctx, keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil)
 		g1.LocalChatDb.Nuke()
 		indexer1.ClearCache()
 		indexer1.SelectiveSync(ictx, uid1, true /* forceReindex */)

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -790,7 +790,7 @@ func (c *chatServiceHandler) SearchInboxV1(ctx context.Context, opts searchInbox
 		opts.MaxHits = 10
 	}
 
-	reindexMode := chat1.ReIndexingMode_POSTSEARCH_ASYNC
+	reindexMode := chat1.ReIndexingMode_NONE
 	if opts.ForceReindex {
 		reindexMode = chat1.ReIndexingMode_PRESEARCH_SYNC
 	}

--- a/go/client/cmd_chat_search_inbox.go
+++ b/go/client/cmd_chat_search_inbox.go
@@ -95,7 +95,7 @@ func (c *CmdChatSearchInbox) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 1 {
 		return errors.New("usage: keybase chat search <query>")
 	}
-	reindexMode := chat1.ReIndexingMode_POSTSEARCH_ASYNC
+	reindexMode := chat1.ReIndexingMode_NONE
 	if ctx.Bool("force-reindex") {
 		reindexMode = chat1.ReIndexingMode_PRESEARCH_SYNC
 	}

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1922,26 +1922,23 @@ func (e GetThreadReason) String() string {
 type ReIndexingMode int
 
 const (
-	ReIndexingMode_NONE             ReIndexingMode = 0
-	ReIndexingMode_PRESEARCH_SYNC   ReIndexingMode = 1
-	ReIndexingMode_POSTSEARCH_ASYNC ReIndexingMode = 2
-	ReIndexingMode_POSTSEARCH_SYNC  ReIndexingMode = 3
+	ReIndexingMode_NONE            ReIndexingMode = 0
+	ReIndexingMode_PRESEARCH_SYNC  ReIndexingMode = 1
+	ReIndexingMode_POSTSEARCH_SYNC ReIndexingMode = 2
 )
 
 func (o ReIndexingMode) DeepCopy() ReIndexingMode { return o }
 
 var ReIndexingModeMap = map[string]ReIndexingMode{
-	"NONE":             0,
-	"PRESEARCH_SYNC":   1,
-	"POSTSEARCH_ASYNC": 2,
-	"POSTSEARCH_SYNC":  3,
+	"NONE":            0,
+	"PRESEARCH_SYNC":  1,
+	"POSTSEARCH_SYNC": 2,
 }
 
 var ReIndexingModeRevMap = map[ReIndexingMode]string{
 	0: "NONE",
 	1: "PRESEARCH_SYNC",
-	2: "POSTSEARCH_ASYNC",
-	3: "POSTSEARCH_SYNC",
+	2: "POSTSEARCH_SYNC",
 }
 
 func (e ReIndexingMode) String() string {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -544,8 +544,7 @@
   enum ReIndexingMode {
     NONE_0,
     PRESEARCH_SYNC_1,
-    POSTSEARCH_ASYNC_2,
-    POSTSEARCH_SYNC_3
+    POSTSEARCH_SYNC_2
   }
 
   record SearchOpts {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -1419,8 +1419,7 @@
       "symbols": [
         "NONE_0",
         "PRESEARCH_SYNC_1",
-        "POSTSEARCH_ASYNC_2",
-        "POSTSEARCH_SYNC_3"
+        "POSTSEARCH_SYNC_2"
       ]
     },
     {

--- a/shared/constants/types/rpc-chat-gen.js
+++ b/shared/constants/types/rpc-chat-gen.js
@@ -156,8 +156,7 @@ export const commonNotificationKind = {
 export const commonReIndexingMode = {
   none: 0,
   presearchSync: 1,
-  postsearchAsync: 2,
-  postsearchSync: 3,
+  postsearchSync: 2,
 }
 
 export const commonRetentionPolicyType = {

--- a/shared/constants/types/rpc-chat-gen.js.flow
+++ b/shared/constants/types/rpc-chat-gen.js.flow
@@ -572,8 +572,7 @@ export const commonNotificationKind = {
 export const commonReIndexingMode = {
   none: 0,
   presearchSync: 1,
-  postsearchAsync: 2,
-  postsearchSync: 3,
+  postsearchSync: 2,
 }
 
 export const commonRetentionPolicyType = {
@@ -1171,8 +1170,7 @@ export type RateLimit = $ReadOnly<{name: String, callsRemaining: Int, windowRese
 export type ReIndexingMode =
   | 0 // NONE_0
   | 1 // PRESEARCH_SYNC_1
-  | 2 // POSTSEARCH_ASYNC_2
-  | 3 // POSTSEARCH_SYNC_3
+  | 2 // POSTSEARCH_SYNC_2
 
 export type Reaction = $ReadOnly<{ctime: Gregor1.Time, reactionMsgID: MessageID}>
 export type ReactionMap = $ReadOnly<{reactions: {[key: string]: {[key: string]: Reaction}}}>


### PR DESCRIPTION
reduces the complexity of search, not necessarily needed since the cli can  pass `--force-reindex`