### PR TITLE
prefetcher: propagate higher priority requests

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -538,9 +538,9 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	}
 	// Update the action if needed.
 	brq.vlog.CLogf(
-		ctx, libkb.VLog2, "Combining actions %d and %d", action, br.action)
+		ctx, libkb.VLog2, "Combining actions %s and %s", action, br.action)
 	br.action = action.Combine(br.action)
-	brq.vlog.CLogf(ctx, libkb.VLog2, "Got action %d", br.action)
+	brq.vlog.CLogf(ctx, libkb.VLog2, "Got action %s", br.action)
 	return ch
 }
 

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -1093,6 +1093,9 @@ func (p *blockPrefetcher) run(
 			}
 
 			if isPrefetchWaiting {
+				if req.priority > pre.req.priority {
+					pre.req.priority = req.priority
+				}
 				newAction := pre.req.action.Combine(req.action)
 				if pre.subtreeTriggered {
 					p.vlog.CLogf(


### PR DESCRIPTION
Partial prefetches work by first doing a normal (non-deep-sync) lookup, and then a full deep-sync request for the same block ID, at a high priority.  Any child blocks that get prefetched due to the first request get dropped to a throttled priority, and when the same blocks are then prefetched as part of the deep sync, the requests at the throttle priority are already in the queue and hence still get throttled.  Which means partial prefetches end up taking forever.

So override the priority in the prefetch queue.

Partial prefetches still seem to take a while, but not an unbounded amount of time, like before.

And fix a debug message to stringify actions.

Issue: KBFS-4070