### PR TITLE
Serve dev logos from 127

### DIFF
--- a/go/externals/icon.go
+++ b/go/externals/icon.go
@@ -28,9 +28,13 @@ func MakeIcons(mctx libkb.MetaContext, serviceKey, imgName string, size int) (re
 			factorix = fmt.Sprintf("@%vx", factor)
 		}
 
+		site := libkb.SiteURILookup[mctx.G().Env.GetRunMode()]
+		if mctx.G().Env.GetRunMode() == libkb.DevelRunMode {
+			site = strings.Replace(site, "localhost", "127.0.0.1", 1)
+		}
+
 		res = append(res, keybase1.SizedImage{
-			Path: strings.Join([]string{
-				libkb.SiteURILookup[mctx.G().Env.GetRunMode()],
+			Path: strings.Join([]string{site,
 				"images/paramproofs/services",
 				normalizeIconKey(serviceKey),
 				fmt.Sprintf("%v_%v%v.png", imgName, size, factorix),


### PR DESCRIPTION
Serve devel proof service logos from http://127.0.0.1 instead of localhost. Since gui's CSP allows 127 but not localhost. This lets icons on profiles work in dev.

Less risky version of https://github.com/keybase/client/pull/16818