### PR TITLE
config: clean sync block cache on a restart

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1281,7 +1281,7 @@ func (c *ConfigLocal) EnableJournaling(
 	return nil
 }
 
-func (c *ConfigLocal) cleanSyncBlockCacheForTlfInBackground(
+func (c *ConfigLocal) cleanSyncBlockCacheForTlfInBackgroundLocked(
 	tlfID tlf.ID, ch chan<- error) {
 	// Start a background goroutine deleting all the blocks from this
 	// TLF.
@@ -1321,7 +1321,7 @@ func (c *ConfigLocal) cleanSyncBlockCache() {
 			continue
 		}
 
-		c.cleanSyncBlockCacheForTlfInBackground(id, make(chan error, 1))
+		c.cleanSyncBlockCacheForTlfInBackgroundLocked(id, make(chan error, 1))
 	}
 }
 
@@ -1580,7 +1580,7 @@ func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
 
 	ch := make(chan error, 1)
 	if config.Mode == keybase1.FolderSyncMode_DISABLED {
-		c.cleanSyncBlockCacheForTlfInBackground(tlfID, ch)
+		c.cleanSyncBlockCacheForTlfInBackgroundLocked(tlfID, ch)
 	} else {
 		ch <- nil
 	}

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -1449,8 +1449,8 @@ func (cache *DiskBlockCacheLocal) GetTlfSize(
 // the cache.
 func (cache *DiskBlockCacheLocal) GetTlfIDs(
 	_ context.Context) (tlfIDs []tlf.ID, err error) {
-	cache.lock.Lock()
-	defer cache.lock.Unlock()
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
 	tlfIDs = make([]tlf.ID, 0, len(cache.tlfSizes))
 	for id := range cache.tlfSizes {
 		tlfIDs = append(tlfIDs, id)

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -1440,8 +1440,8 @@ func (cache *DiskBlockCacheLocal) ClearHomeTLFs(ctx context.Context) error {
 // the cache.
 func (cache *DiskBlockCacheLocal) GetTlfSize(
 	_ context.Context, tlfID tlf.ID) (uint64, error) {
-	cache.lock.Lock()
-	defer cache.lock.Unlock()
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
 	return cache.tlfSizes[tlfID], nil
 }
 

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -1445,6 +1445,19 @@ func (cache *DiskBlockCacheLocal) GetTlfSize(
 	return cache.tlfSizes[tlfID], nil
 }
 
+// GetTlfIDs returns the IDs of all the TLFs with blocks stored in
+// the cache.
+func (cache *DiskBlockCacheLocal) GetTlfIDs(
+	_ context.Context) (tlfIDs []tlf.ID, err error) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	tlfIDs = make([]tlf.ID, 0, len(cache.tlfSizes))
+	for id := range cache.tlfSizes {
+		tlfIDs = append(tlfIDs, id)
+	}
+	return tlfIDs, nil
+}
+
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheLocal.
 func (cache *DiskBlockCacheLocal) Shutdown(ctx context.Context) {
 	// Wait for the cache to either finish starting or error.

--- a/go/kbfs/libkbfs/disk_block_cache_remote.go
+++ b/go/kbfs/libkbfs/disk_block_cache_remote.go
@@ -256,6 +256,13 @@ func (dbcr *DiskBlockCacheRemote) GetTlfSize(
 	panic("GetTlfSize() not implemented in DiskBlockCacheRemote")
 }
 
+// GetTlfIDs implements the DiskBlockCache interface for
+// DiskBlockCacheRemote.
+func (dbcr *DiskBlockCacheRemote) GetTlfIDs(
+	_ context.Context, _ DiskBlockCacheType) ([]tlf.ID, error) {
+	panic("GetTlfIDs() not implemented in DiskBlockCacheRemote")
+}
+
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) Shutdown(ctx context.Context) {
 	dbcr.conn.Close()

--- a/go/kbfs/libkbfs/disk_block_cache_remote.go
+++ b/go/kbfs/libkbfs/disk_block_cache_remote.go
@@ -263,6 +263,13 @@ func (dbcr *DiskBlockCacheRemote) GetTlfIDs(
 	panic("GetTlfIDs() not implemented in DiskBlockCacheRemote")
 }
 
+// WaitUntilStarted implements the DiskBlockCache interface for
+// DiskBlockCacheRemote.
+func (dbcr *DiskBlockCacheRemote) WaitUntilStarted(
+	_ DiskBlockCacheType) error {
+	panic("WaitUntilStarted() not implemented in DiskBlockCacheRemote")
+}
+
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) Shutdown(ctx context.Context) {
 	dbcr.conn.Close()

--- a/go/kbfs/libkbfs/disk_block_cache_wrapped.go
+++ b/go/kbfs/libkbfs/disk_block_cache_wrapped.go
@@ -503,6 +503,7 @@ func (cache *diskBlockCacheWrapped) GetTlfSize(
 	defer cache.mtx.RUnlock()
 
 	if cacheType != DiskBlockWorkingSetCache {
+		// Either sync cache only, or both.
 		syncSize, err := cache.syncCache.GetTlfSize(ctx, tlfID)
 		if err != nil {
 			return 0, err
@@ -511,6 +512,7 @@ func (cache *diskBlockCacheWrapped) GetTlfSize(
 	}
 
 	if cacheType != DiskBlockSyncCache {
+		// Either working set cache only, or both.
 		workingSetSize, err := cache.workingSetCache.GetTlfSize(ctx, tlfID)
 		if err != nil {
 			return 0, err
@@ -530,6 +532,7 @@ func (cache *diskBlockCacheWrapped) GetTlfIDs(
 	defer cache.mtx.RUnlock()
 
 	if cacheType != DiskBlockWorkingSetCache {
+		// Either sync cache only, or both.
 		tlfIDs, err = cache.syncCache.GetTlfIDs(ctx)
 		if err != nil {
 			return nil, err
@@ -537,6 +540,7 @@ func (cache *diskBlockCacheWrapped) GetTlfIDs(
 	}
 
 	if cacheType != DiskBlockSyncCache {
+		// Either working set cache only, or both.
 		wsTlfIDs, err := cache.workingSetCache.GetTlfIDs(ctx)
 		if err != nil {
 			return nil, err

--- a/go/kbfs/libkbfs/disk_block_cache_wrapped.go
+++ b/go/kbfs/libkbfs/disk_block_cache_wrapped.go
@@ -563,6 +563,30 @@ func (cache *diskBlockCacheWrapped) GetTlfIDs(
 	return tlfIDs, nil
 }
 
+// WaitUntilStarted implements the DiskBlockCache interface for
+// diskBlockCacheWrapped.
+func (cache *diskBlockCacheWrapped) WaitUntilStarted(
+	cacheType DiskBlockCacheType) (err error) {
+	cache.mtx.RLock()
+	defer cache.mtx.RUnlock()
+
+	if cacheType != DiskBlockWorkingSetCache {
+		err = cache.syncCache.WaitUntilStarted()
+		if err != nil {
+			return err
+		}
+	}
+
+	if cacheType != DiskBlockSyncCache {
+		err = cache.workingSetCache.WaitUntilStarted()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Shutdown implements the DiskBlockCache interface for diskBlockCacheWrapped.
 func (cache *diskBlockCacheWrapped) Shutdown(ctx context.Context) {
 	cache.mtx.Lock()

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1010,6 +1010,10 @@ type DiskBlockCache interface {
 	// TLF IDs across all caches.
 	GetTlfIDs(
 		ctx context.Context, cacheType DiskBlockCacheType) ([]tlf.ID, error)
+	// WaitUntilStarted waits until the block cache of the given type
+	// has finished starting. If `DiskBlockAnyCache` is specified, it
+	// waits for all caches to start.
+	WaitUntilStarted(cacheType DiskBlockCacheType) error
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1005,6 +1005,11 @@ type DiskBlockCache interface {
 	GetTlfSize(
 		ctx context.Context, tlfID tlf.ID, cacheType DiskBlockCacheType) (
 		uint64, error)
+	// GetTlfIDs returns the TLF IDs with blocks in the cache.  If
+	// `DiskBlockAnyCache` is specified, it returns the set of
+	// TLF IDs across all caches.
+	GetTlfIDs(
+		ctx context.Context, cacheType DiskBlockCacheType) ([]tlf.ID, error)
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }


### PR DESCRIPTION
A previous sync disable may not have finished cleaning out all the blocks for that TLF before the process was killed, so make sure there aren't any leftover blocks from unsynced TLFs in the cache.
