### PR TITLE
prefetcher: fix dumb prefetch cancel bug, add some more canceling

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1567,7 +1567,7 @@ func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
 func (c *ConfigLocal) SetTlfSyncState(
 	ctx context.Context, tlfID tlf.ID, config FolderSyncConfig) (
 	<-chan error, error) {
-	if config.Mode != keybase1.FolderSyncMode_DISABLED {
+	if !c.IsTestMode() && config.Mode != keybase1.FolderSyncMode_ENABLED {
 		// If we're disabling, or just changing the partial sync
 		// config (which may be removing paths), we should cancel all
 		// the previous prefetches for this TLF.  For partial syncs, a

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -1038,6 +1038,17 @@ func (p *blockPrefetcher) run(
 				p.markQueuedPrefetchDone(req.ptr)
 			}
 
+			if isPrefetchWaiting {
+				select {
+				case <-pre.ctx.Done():
+					p.vlog.CLogf(context.Background(), libkb.VLog2,
+						"Request not processing because it was canceled "+
+							"already: id=%v action=%v", req.ptr.ID, req.action)
+					continue
+				default:
+				}
+			}
+
 			ctx := context.TODO()
 			if isPrefetchWaiting {
 				ctx = pre.ctx


### PR DESCRIPTION
A dumb typo was preventing prefetches from being properly disabled.

Also cancel any ongoing edit-history based prefetches when syncing is enabled, and check for context cancellation right away when processing prefetch requests.