### PR TITLE
Fix borders on add to channel dialog

### DIFF
--- a/shared/chat/conversation/info-panel/add-to-channel/index.js
+++ b/shared/chat/conversation/info-panel/add-to-channel/index.js
@@ -21,7 +21,7 @@ type State = {|
 class AddToChannel extends React.Component<Props, State> {
   state = {selected: I.Set()}
   _itemHeight = {
-    height: Styles.isMobile ? 48 : 40,
+    height: 48,
     type: 'fixed',
   }
 


### PR DESCRIPTION
Broke in https://github.com/keybase/client/pull/16507/. r? @keybase/react-hackers 

before:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/11968340/56609706-c6427c80-65db-11e9-85fa-4560f20ed121.png">

after:
<img width="407" alt="image" src="https://user-images.githubusercontent.com/11968340/56609811-07d32780-65dc-11e9-859b-065d5d26f8c8.png">
