### PR TITLE
chat: system-git-push: link commits to autogit

### DIFF
--- a/shared/chat/conversation/messages/system-git-push/container.js
+++ b/shared/chat/conversation/messages/system-git-push/container.js
@@ -5,12 +5,25 @@ import * as Types from '../../../../constants/types/chat2'
 import * as Tracker2Gen from '../../../../actions/tracker2-gen'
 import Git from '.'
 import {connect, isMobile} from '../../../../util/container'
-
+import * as FsTypes from '../../../../constants/types/fs'
+import * as FsConstants from '../../../../constants/fs'
 type OwnProps = {|
   message: Types.MessageSystemGitPush,
 |}
 
-const mapDispatchToProps = dispatch => ({
+const getAutogitPath = (commitHash: string, ownProps: OwnProps): FsTypes.Path =>
+  FsTypes.stringToPath(
+    '/keybase/team/' +
+      ownProps.message.team +
+      '/.kbfs_autogit/' +
+      ownProps.message.repo +
+      '/.kbfs_autogit_commit_' +
+      commitHash
+  )
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  onClickCommit: (commitHash: string) =>
+    dispatch(FsConstants.makeActionForOpenPathInFilesTab(getAutogitPath(commitHash, ownProps))),
   onClickUserAvatar: (username: string) =>
     isMobile
       ? dispatch(ProfileGen.createShowUserProfile({username}))

--- a/shared/chat/conversation/messages/system-git-push/index.js
+++ b/shared/chat/conversation/messages/system-git-push/index.js
@@ -12,6 +12,7 @@ const branchRefPrefix = 'refs/heads/'
 
 type Props = {
   message: Types.MessageSystemGitPush,
+  onClickCommit: (commitHash: string) => void,
   onClickUserAvatar: (username: string) => void,
   onViewGitRepo: (repoID: string, teamname: string) => void,
 }
@@ -46,7 +47,16 @@ const GitPushCreate = ({pusher, repo, repoID, team, onViewGitRepo}) => {
   )
 }
 
-const GitPushDefault = ({pusher, commitRef, repo, repoID, team, branchName, onViewGitRepo}) => {
+const GitPushDefault = ({
+  pusher,
+  commitRef,
+  repo,
+  repoID,
+  team,
+  branchName,
+  onViewGitRepo,
+  onClickCommit,
+}) => {
   return (
     <Box style={globalStyles.flexBoxColumn}>
       <Text center={true} type="BodySmallSemibold" style={{marginBottom: globalMargins.xtiny}}>
@@ -82,7 +92,6 @@ const GitPushDefault = ({pusher, commitRef, repo, repoID, team, branchName, onVi
               >
                 <Text
                   type="Terminal"
-                  selectable={true}
                   style={platformStyles({
                     common: {
                       color: globalColors.blue,
@@ -90,6 +99,7 @@ const GitPushDefault = ({pusher, commitRef, repo, repoID, team, branchName, onVi
                       lineHeight: 16,
                     },
                   })}
+                  onClick={() => onClickCommit(commit.commitHash)}
                 >
                   {commit.commitHash.substr(0, 8)}
                 </Text>
@@ -159,6 +169,7 @@ class GitPush extends React.PureComponent<Props> {
                     repoID={repoID}
                     team={team}
                     onViewGitRepo={this.props.onViewGitRepo}
+                    onClickCommit={this.props.onClickCommit}
                   />
                 </GitPushCommon>
               )


### PR DESCRIPTION
Link commit hashes in system git push messages in chat to the commit summaries in autogit.

The thing here that I was not sure about is that this text was previously selectable, and text can't be all three of clickable, selectable, acts as you expect. So I made it not selectable, but I'm not fully convinced that's the best choice.

r? @keybase/react-hackers

Issue: KBFS-4076