### PR TITLE
prefetcher: check for and handle status requests constantly

### DIFF
--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -644,6 +644,33 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 	return 0, 0, 0
 }
 
+func (p *blockPrefetcher) handleStatusRequest(req *prefetchStatusRequest) {
+	pre, isPrefetchWaiting := p.prefetches[req.ptr.ID]
+	if !isPrefetchWaiting {
+		req.ch <- PrefetchProgress{}
+	} else {
+		req.ch <- pre.PrefetchProgress
+	}
+}
+
+// handleCriticalRequests should be called periodically during any
+// long prefetch requests, to make sure we handle critical requests
+// quickly.  These are requests that are required to be run in the
+// main processing goroutine, but shouldn'won't interfere with
+// whatever request we're in the middle of.
+func (p *blockPrefetcher) handleCriticalRequests() {
+	for {
+		// Fulfill any status requests since the user could be waiting
+		// for them.
+		select {
+		case req := <-p.prefetchStatusCh.Out():
+			p.handleStatusRequest(req.(*prefetchStatusRequest))
+		default:
+			return
+		}
+	}
+}
+
 func (p *blockPrefetcher) prefetchIndirectFileBlock(
 	ctx context.Context, parentPtr data.BlockPointer, b *data.FileBlock,
 	kmd libkey.KeyMetadata, lifetime data.BlockCacheLifetime, isPrefetchNew bool,
@@ -659,6 +686,8 @@ func (p *blockPrefetcher) prefetchIndirectFileBlock(
 		numBlocks += b
 		numBytesFetched += f
 		numBytesTotal += t
+
+		p.handleCriticalRequests()
 	}
 	return numBlocks, numBytesFetched, numBytesTotal, len(b.IPtrs) == 0
 }
@@ -678,6 +707,8 @@ func (p *blockPrefetcher) prefetchIndirectDirBlock(
 		numBlocks += b
 		numBytesFetched += f
 		numBytesTotal += t
+
+		p.handleCriticalRequests()
 	}
 	return numBlocks, numBytesFetched, numBytesTotal, len(b.IPtrs) == 0
 }
@@ -719,6 +750,8 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(
 		numBlocks += b
 		numBytesFetched += f
 		numBytesTotal += t
+
+		p.handleCriticalRequests()
 	}
 	if totalChildEntries == 0 {
 		isTail = true
@@ -864,15 +897,6 @@ type prefetchStatusRequest struct {
 	ch  chan<- PrefetchProgress
 }
 
-func (p *blockPrefetcher) handleStatusRequest(req *prefetchStatusRequest) {
-	pre, isPrefetchWaiting := p.prefetches[req.ptr.ID]
-	if !isPrefetchWaiting {
-		req.ch <- PrefetchProgress{}
-	} else {
-		req.ch <- pre.PrefetchProgress
-	}
-}
-
 // run prefetches blocks.
 // E.g. a synced prefetch:
 // a -> {b -> {c, d}, e -> {f, g}}:
@@ -942,14 +966,7 @@ func (p *blockPrefetcher) run(
 			<-testSyncCh
 		}
 
-		// First fulfill any status requests since the user could be
-		// waiting for them.
-		select {
-		case req := <-p.prefetchStatusCh.Out():
-			p.handleStatusRequest(req.(*prefetchStatusRequest))
-			continue
-		default:
-		}
+		p.handleCriticalRequests()
 
 		select {
 		case req := <-p.prefetchStatusCh.Out():


### PR DESCRIPTION
`keybase fs show` depends on being able to request the prefetch status from the prefetcher, which in turn requires sending a message on a channel and waiting for it to be processed by the main processing goroutine.  But in some cases that goroutine can be busy for tens of seconds, e.g. when it is processing a block with 1000s of child pointers, each one involving a disk cache operation.

So this just processes any pending status requests (which are quick) inline during every iteration of that child processing, to guarantee a quick return.  This is safe, since the status request is read-only and isn't interfering with the prefetching logic at all.