### PR TITLE
Add retries to LookupUser calls

### DIFF
--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -738,10 +738,13 @@ func (mc *MerkleClient) lookupPathAndSkipSequenceHelper(m MetaContext, q HTTPArg
 	}
 
 	apiRes, err = m.G().API.Get(m, APIArg{
-		Endpoint:       "merkle/path",
-		SessionType:    APISessionTypeNONE,
-		Args:           q,
-		AppStatusCodes: []int{SCOk, SCNotFound, SCDeleted},
+		Endpoint:        "merkle/path",
+		SessionType:     APISessionTypeNONE,
+		Args:            q,
+		AppStatusCodes:  []int{SCOk, SCNotFound, SCDeleted},
+		RetryCount:      3,
+		InitialTimeout:  4 * time.Second,
+		RetryMultiplier: 1.1,
 	})
 
 	if err != nil {


### PR DESCRIPTION
I think we should just add a bunch of "quick" retry params on all GET requests but eh, this one should be good for now. I followed the local user lookup flow and it seems that this is the only significant request that can fail.