### PR TITLE
Very small perf tweak to help box2

### DIFF
--- a/shared/util/arrays.js
+++ b/shared/util/arrays.js
@@ -6,13 +6,13 @@ export function intersperseFn<A, B>(
   arr: Array<A>
 ): Array<A | B> {
   if (arr.length === 0) {
-    return []
+    // $FlowIssue an array with no length is a valid type for any Array
+    return arr
   }
 
-  return arr.slice(1).reduce(
-    (acc, x, i, a) => {
-      return acc.concat([separatorFn(i, x, a), x])
-    },
-    [arr[0]]
-  )
+  let toReturn = [arr[0]]
+  for (let i = 1; i < arr.length; i++) {
+    toReturn.push(separatorFn(i, arr[i], arr), arr[i])
+  }
+  return toReturn
 }

--- a/shared/util/arrays.js
+++ b/shared/util/arrays.js
@@ -10,9 +10,11 @@ export function intersperseFn<A, B>(
     return arr
   }
 
-  let toReturn = [arr[0]]
+  let toReturn = new Array(arr.length * 2 - 1)
+  toReturn[0] = arr[0]
   for (let i = 1; i < arr.length; i++) {
-    toReturn.push(separatorFn(i, arr[i], arr), arr[i])
+    toReturn[i * 2 - 1] = separatorFn(i, arr[i], arr)
+    toReturn[i * 2] = arr[i]
   }
   return toReturn
 }


### PR DESCRIPTION
@keybase/react-hackers 

Small tweak to `intersperseFn` which is used by Box2 when you ask for gaps.

On my machine it makes box2 with 100 children 10% faster. In practice it probably won't be so dramatic since I don't think we use box2 with a lot of children and gap. When the children count is small it's basically the same thing as the reduce version.

It does have fewer allocations which could help with GC /shrug