### PR TITLE
cleanup uploadedfulls/uploadpreviews

### DIFF
--- a/go/chat/attachment_httpsrv_test.go
+++ b/go/chat/attachment_httpsrv_test.go
@@ -218,7 +218,7 @@ func TestChatSrvAttachmentUploadPreviewCached(t *testing.T) {
 	tc.ChatG.AttachmentURLSrv = NewAttachmentHTTPSrv(tc.Context(),
 		fetcher, func() chat1.RemoteInterface { return mockSigningRemote{} })
 	uploader := attachments.NewUploader(tc.Context(), store, mockSigningRemote{},
-		func() chat1.RemoteInterface { return ri })
+		func() chat1.RemoteInterface { return ri }, 1)
 	uploader.SetPreviewTempDir(fetcher.tempDir)
 	tc.ChatG.AttachmentUploader = uploader
 

--- a/go/chat/attachments/uploader_test.go
+++ b/go/chat/attachments/uploader_test.go
@@ -3,6 +3,7 @@ package attachments
 import (
 	"errors"
 	"io"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -244,4 +245,15 @@ func TestAttachmentUploader(t *testing.T) {
 	case res := <-resChan.Wait():
 		require.NotNil(t, res.Error)
 	}
+
+	// verify uploadedPreviewsDir is clean
+	baseDir := uploader.getBaseDir()
+	uploadedPreviews, err := filepath.Glob(filepath.Join(baseDir, uploadedPreviewsDir, "*"))
+	require.NoError(t, err)
+	require.Zero(t, len(uploadedPreviews))
+
+	// verify uploadedFullsDir is clean
+	uploadedFulls, err := filepath.Glob(filepath.Join(baseDir, uploadedFullsDir, "*"))
+	require.NoError(t, err)
+	require.Zero(t, len(uploadedFulls))
 }

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -389,6 +389,7 @@ type AttachmentUploader interface {
 	Cancel(ctx context.Context, outboxID chat1.OutboxID) error
 	Complete(ctx context.Context, outboxID chat1.OutboxID)
 	GetUploadTempFile(ctx context.Context, outboxID chat1.OutboxID, filename string) (string, error)
+	OnDbNuke(mctx libkb.MetaContext) error
 }
 
 type NativeVideoHelper interface {

--- a/go/lru/disk_lru.go
+++ b/go/lru/disk_lru.go
@@ -417,6 +417,9 @@ func (d *DiskLRU) Clean(ctx context.Context, lctx libkb.LRUContext, cacheDir str
 	d.Lock()
 	defer d.Unlock()
 
+	// clear our inmemory cache without flushing to disk to force a new read
+	d.index = nil
+
 	// reverse map of filepaths to lru keys
 	cacheRevMap := map[string]string{}
 	allVals, err := d.allValuesLocked(ctx, lctx)

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -444,6 +444,7 @@ func (d *Service) SetupChatModules(ri func() chat1.RemoteInterface) {
 	s3signer := attachments.NewS3Signer(ri)
 	store := attachments.NewS3Store(g.GetLog(), g.GetEnv(), g.GetRuntimeDir())
 	g.AttachmentUploader = attachments.NewUploader(g, store, s3signer, ri)
+	g.AddDbNukeHook(g.AttachmentUploader, "AttachmentUploader")
 	sender := chat.NewBlockingSender(g, chat.NewBoxer(g), ri)
 	g.MessageDeliverer = chat.NewDeliverer(g, sender)
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -443,15 +443,15 @@ func (d *Service) SetupChatModules(ri func() chat1.RemoteInterface) {
 	// Message sending apparatus
 	s3signer := attachments.NewS3Signer(ri)
 	store := attachments.NewS3Store(g.GetLog(), g.GetEnv(), g.GetRuntimeDir())
-	g.AttachmentUploader = attachments.NewUploader(g, store, s3signer, ri)
-	g.AddDbNukeHook(g.AttachmentUploader, "AttachmentUploader")
+	attachmentLRUSize := 1000
+	g.AttachmentUploader = attachments.NewUploader(g, store, s3signer, ri, attachmentLRUSize)
 	sender := chat.NewBlockingSender(g, chat.NewBoxer(g), ri)
 	g.MessageDeliverer = chat.NewDeliverer(g, sender)
 
 	// team channel source
 	g.TeamChannelSource = chat.NewTeamChannelSource(g)
 
-	g.AttachmentURLSrv = chat.NewAttachmentHTTPSrv(g, chat.NewCachingAttachmentFetcher(g, store, 1000), ri)
+	g.AttachmentURLSrv = chat.NewAttachmentHTTPSrv(g, chat.NewCachingAttachmentFetcher(g, store, attachmentLRUSize), ri)
 	g.AddDbNukeHook(g.AttachmentURLSrv, "AttachmentURLSrv")
 
 	g.StellarLoader = stellar.DefaultLoader(g.ExternalG())


### PR DESCRIPTION
addresses https://github.com/keybase/client/issues/16826

- ~cleans tmp uploadedfull/uploaded preview files~ limits total number of uploadedfull/uploaded preview files
- adds `OnDbNuke` hook to purge any existing files