### PR TITLE
styling tweaks for generic proofs

### DIFF
--- a/shared/profile/generic/enter-username/index.js
+++ b/shared/profile/generic/enter-username/index.js
@@ -171,9 +171,11 @@ class _EnterUsername extends React.Component<Props> {
               style={styles.serviceProofIcon}
             />
           </Kb.Box2>
-          <Kb.Box2 direction="vertical" alignItems="center">
+          <Kb.Box2 direction="vertical" alignItems="center" style={styles.serviceMeta}>
             <Kb.Text type="BodySemibold">{props.serviceName}</Kb.Text>
-            <Kb.Text type="BodySmall">{props.serviceSub}</Kb.Text>
+            <Kb.Text type="BodySmall" center={true}>
+              {props.serviceSub}
+            </Kb.Text>
           </Kb.Box2>
         </Kb.Box2>
         <Kb.Box2
@@ -319,6 +321,16 @@ const styles = Styles.styleSheetCreate({
   serviceIconHeaderContainer: {
     paddingTop: Styles.globalMargins.medium,
   },
+  serviceMeta: Styles.platformStyles({
+    isElectron: {
+      paddingLeft: Styles.globalMargins.medium,
+      paddingRight: Styles.globalMargins.medium,
+    },
+    isMobile: {
+      paddingLeft: Styles.globalMargins.small,
+      paddingRight: Styles.globalMargins.small,
+    },
+  }),
   serviceProofIcon: {bottom: 0, position: 'absolute', right: 0},
   unreachableBox: Styles.platformStyles({
     common: {...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.xsmall)},

--- a/shared/profile/generic/proofs-list/index.js
+++ b/shared/profile/generic/proofs-list/index.js
@@ -96,6 +96,7 @@ class _ProofsList extends React.Component<Props, State> {
               fontSize={Styles.isMobile ? 20 : 16}
             />
             <Kb.PlainInput
+              autoFocus={true}
               placeholder={`Search ${this.props.providers.length} platforms`}
               placeholderColor={Styles.globalColors.black_50}
               flexable={true}

--- a/shared/profile/user/index.js
+++ b/shared/profile/user/index.js
@@ -413,9 +413,15 @@ const styles = Styles.styleSheetCreate({
     marginBottom: Styles.globalMargins.xsmall,
     marginTop: Styles.globalMargins.xsmall,
   },
-  addIdentityContainer: {
-    justifyContent: 'center',
-  },
+  addIdentityContainer: Styles.platformStyles({
+    common: {
+      justifyContent: 'center',
+    },
+    isElectron: {
+      paddingLeft: Styles.globalMargins.tiny,
+      paddingRight: Styles.globalMargins.tiny,
+    },
+  }),
   backButton: {color: Styles.globalColors.white},
   backgroundColor: {
     ...Styles.globalStyles.fillAbsolute,


### PR DESCRIPTION
- Autofocus filter on opening proofs list
- Give add identities button some horizontal padding on desktop
- Center service descriptions and add horizontal padding (support long descriptions)

before:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/11968340/56672794-09a4f580-6685-11e9-928a-fc1b38aa7c1e.png">

after:
<img width="585" alt="image" src="https://user-images.githubusercontent.com/11968340/56672767-fdb93380-6684-11e9-9132-baf6114a0d9a.png">

r? @keybase/react-hackers 