### PR TITLE
Change /headline tooltip position

### DIFF
--- a/shared/chat/header.desktop.js
+++ b/shared/chat/header.desktop.js
@@ -42,7 +42,7 @@ const Header = (p: Props) => {
   }
   if (p.isTeam && p.desc && p.canEditDesc) {
     description = (
-      <Kb.WithTooltip position="bottom center" text="Set the description using the /headline command.">
+      <Kb.WithTooltip position="bottom left" text="Set the description using the /headline command.">
         {description}
       </Kb.WithTooltip>
     )


### PR DESCRIPTION
Makes cases where the window is much wider than the description better. Currently it's like:
<img width="685" alt="image" src="https://user-images.githubusercontent.com/11968340/56682593-dde03a80-6699-11e9-97da-a988f8eff4ac.png">

r? @keybase/react-hackers 