### PR TITLE
workaround RN bug that broke pasting into confirm new password input

### DIFF
--- a/shared/settings/password/index.js
+++ b/shared/settings/password/index.js
@@ -81,7 +81,7 @@ export class UpdatePassword extends Component<Props, State> {
             style={styleInput}
           />
           <Kb.Input
-            hintText="Confirm new password"
+            hintText="Confirm"
             type={inputType}
             value={this.state.passwordConfirm}
             errorText={this.state.errorSaving || this.props.newPasswordConfirmError}


### PR DESCRIPTION
It seems if the placeholder takes up the entire width of the textinput, the context menu doesn't appear. Workaround by shortening "Confirm new password" to "Confirm"

- [x] Check other password inputs