### PR TITLE
revert accidental tabbar color change

### DIFF
--- a/shared/router-v2/tab-bar/tab-bar.css
+++ b/shared/router-v2/tab-bar/tab-bar.css
@@ -1,5 +1,5 @@
 .tab-container {
-  background-color: #1036ac;
+  background-color: #3663ea;
   flex-shrink: 0;
   width: 160px;
 }
@@ -14,7 +14,7 @@
   transition-property: background-color;
 }
 .tab .tab-icon {
-  color: #3663ea;
+  color: #1036ac;
   margin-left: 24px;
   margin-right: 12px;
 }


### PR DESCRIPTION
oops. I use these colors locally to differentiate between prod and dev app, but accidentally pushed and then merged them.
thanks for catching this, @cecileboucheron 

r? @keybase/react-hackers 