### PR TITLE
Speed up ProofSuggestions

### DIFF
--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -118,7 +118,7 @@ func (p *proofServices) SuggestionFoldPriority() int {
 }
 
 func (p *proofServices) loadServiceConfigs() {
-	tracer := p.G().CTimeTracer(context.TODO(), "proofServices.loadServiceConfigs", libkb.ProfileProofSuggestions)
+	tracer := p.G().CTimeTracer(context.TODO(), "proofServices.loadServiceConfigs", false)
 	defer tracer.Finish()
 	if !p.G().ShouldUseParameterizedProofs() {
 		return
@@ -134,6 +134,7 @@ func (p *proofServices) loadServiceConfigs() {
 		// Latest config already loaded.
 		return
 	}
+	defer mctx.TraceTimed("proofServices.loadServiceConfigsBulk", func() error { return err })()
 	tracer.Stage("parse")
 	config, err := p.parseServerConfig(*entry)
 	if err != nil {

--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -117,7 +117,7 @@ func (p *proofServices) SuggestionFoldPriority() int {
 }
 
 func (p *proofServices) loadServiceConfigs() {
-	tracer := p.G().CTimeTracer(context.TODO(), "proofServices.loadServiceConfigs", true)
+	tracer := p.G().CTimeTracer(context.TODO(), "proofServices.loadServiceConfigs", libkb.ProfileProofSuggestions)
 	defer tracer.Finish()
 	if !p.G().ShouldUseParameterizedProofs() {
 		return

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -719,4 +719,4 @@ const (
 	AutoresetEventReset  = 5
 )
 
-const ProfileProofSuggestions = false
+const ProfileProofSuggestions = true

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -718,3 +718,5 @@ const (
 	AutoresetEventReady  = 4
 	AutoresetEventReset  = 5
 )
+
+const ProfileProofSuggestions = false

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -644,6 +644,7 @@ type ExternalServicesCollector interface {
 // parameterized proofs.
 type MerkleStore interface {
 	GetLatestEntry(m MetaContext) (keybase1.MerkleStoreEntry, error)
+	GetLatestEntryWithKnown(MetaContext, *keybase1.MerkleStoreKitHash) (*keybase1.MerkleStoreEntry, error)
 }
 
 // UserChangedHandler is a generic interface for handling user changed events.

--- a/go/merklestore/store.go
+++ b/go/merklestore/store.go
@@ -90,7 +90,7 @@ type merkleStoreKitT struct {
 
 // GetLatestEntry returns the latest (active) entry for the given MerkleStore
 func (s *MerkleStoreImpl) GetLatestEntry(m libkb.MetaContext) (ret keybase1.MerkleStoreEntry, err error) {
-	tracer := m.G().CTimeTracer(m.Ctx(), "MerkleStore.GetLatestEntry", true)
+	tracer := m.G().CTimeTracer(m.Ctx(), "MerkleStore.GetLatestEntry", libkb.ProfileProofSuggestions)
 	defer tracer.Finish()
 	kitJSON, hash, err := s.getKitString(m, tracer)
 	if err != nil {

--- a/go/merklestore/store.go
+++ b/go/merklestore/store.go
@@ -90,8 +90,8 @@ type merkleStoreKitT struct {
 
 // GetLatestEntry returns the latest entry for the given MerkleStore.
 // Returns (nil, nil) if knownHash is the active entry.
-func (s *MerkleStoreImpl) GetLatestEntryWithKnown(m libkb.MetaContext, knownHash *keybase1.MerkleStoreKitHash) (*keybase1.MerkleStoreEntry, error) {
-	tracer := m.G().CTimeTracer(m.Ctx(), "MerkleStore.GetLatestEntry", libkb.ProfileProofSuggestions)
+func (s *MerkleStoreImpl) GetLatestEntryWithKnown(m libkb.MetaContext, knownHash *keybase1.MerkleStoreKitHash) (ret *keybase1.MerkleStoreEntry, err error) {
+	tracer := m.G().CTimeTracer(m.Ctx(), "MerkleStore.GetLatestEntryWithKnown", false)
 	defer tracer.Finish()
 	kitJSON, hash, err := s.getKitString(m, knownHash, tracer)
 	if err != nil {

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -373,7 +373,7 @@ func (h *UserHandler) UploadUserAvatar(ctx context.Context, arg keybase1.UploadU
 func (h *UserHandler) ProofSuggestions(ctx context.Context, sessionID int) (ret keybase1.ProofSuggestionsRes, err error) {
 	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("US")
 	defer mctx.TraceTimed("ProofSuggestions", func() error { return err })()
-	tracer := mctx.G().CTimeTracer(mctx.Ctx(), "ProofSuggestions", true)
+	tracer := mctx.G().CTimeTracer(mctx.Ctx(), "ProofSuggestions", libkb.ProfileProofSuggestions)
 	defer tracer.Finish()
 	suggestions, err := h.proofSuggestionsHelper(mctx, tracer)
 	if err != nil {


### PR DESCRIPTION
Bring `ProofSuggestions` from ~600ms to ~200ms on my laptop. On all calls but the first in each run of the service, the bulk of the time is now in `libkb.LoadMe`, as it should be. Time was being spent parsing and loading services many times. Now that only happens after initial load if the merkley hash changes.