### PR TITLE
Fix the nav bar on loggedOut routes

### DIFF
--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
+import * as Platform from '../../constants/platform'
 import * as Styles from '../../styles'
 import SyncingFolders from './syncing-folders'
 import flags from '../../util/feature-flags'
@@ -53,6 +54,10 @@ class Header extends React.PureComponent<Props> {
       showDivider = false
     }
 
+    const backArrowStyle = {
+      ...(this.props.allowBack ? styles.icon : styles.disabledIcon),
+      ...(!this.props.loggedIn && Platform.isDarwin ? {position: 'relative', top: 30} : {}),
+    }
     return (
       <Kb.Box2 noShrink={true} direction="vertical" fullWidth={true}>
         {!!opt.headerBanner && opt.headerBanner}
@@ -65,7 +70,7 @@ class Header extends React.PureComponent<Props> {
           <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.headerBack} alignItems="center">
             <Kb.Icon
               type="iconfont-arrow-left"
-              style={this.props.allowBack ? styles.icon : styles.disabledIcon}
+              style={backArrowStyle}
               color={this.props.allowBack ? Styles.globalColors.black_50 : Styles.globalColors.black_10}
               onClick={this.props.onPop}
             />

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -54,6 +54,10 @@ class Header extends React.PureComponent<Props> {
       showDivider = false
     }
 
+    // We normally have the back arrow at the top of the screen. It doesn't overlap with the system
+    // icons (minimize etc) because the left nav bar pushes it to the right -- unless you're logged
+    // out, in which case there's no nav bar and they overlap. So, if we're on Mac, and logged out,
+    // push the back arrow down below the system icons.
     const backArrowStyle = {
       ...(this.props.allowBack ? styles.icon : styles.disabledIcon),
       ...(!this.props.loggedIn && Platform.isDarwin ? {position: 'relative', top: 30} : {}),

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -58,6 +58,11 @@ class Header extends React.PureComponent<Props> {
       ...(this.props.allowBack ? styles.icon : styles.disabledIcon),
       ...(!this.props.loggedIn && Platform.isDarwin ? {position: 'relative', top: 30} : {}),
     }
+    const iconColor = this.props.allowBack
+      ? Styles.globalColors.black_50
+      : this.props.loggedIn
+      ? Styles.globalColors.black_10
+      : Styles.globalColors.transparent
     return (
       <Kb.Box2 noShrink={true} direction="vertical" fullWidth={true}>
         {!!opt.headerBanner && opt.headerBanner}
@@ -71,8 +76,8 @@ class Header extends React.PureComponent<Props> {
             <Kb.Icon
               type="iconfont-arrow-left"
               style={backArrowStyle}
-              color={this.props.allowBack ? Styles.globalColors.black_50 : Styles.globalColors.black_10}
-              onClick={this.props.onPop}
+              color={iconColor}
+              onClick={this.props.allowBack || this.props.loggedIn ? this.props.onPop : null}
             />
             {flags.kbfsOfflineMode && <SyncingFolders />}
             {!title && rightActions}

--- a/shared/router-v2/router.desktop.js
+++ b/shared/router-v2/router.desktop.js
@@ -71,7 +71,7 @@ class AppView extends React.PureComponent<any> {
           style={selectedTab ? styles.contentArea : styles.contentAreaLogin}
         >
           {scene}
-          <Header options={descriptor.options} onPop={() => childNav.pop()} allowBack={index !== 0} />
+          <Header loggedIn={selectedTab} options={descriptor.options} onPop={() => childNav.pop()} allowBack={index !== 0} />
         </Kb.Box2>
       </Kb.Box2>
     )
@@ -286,7 +286,6 @@ const styles = Styles.styleSheetCreate({
   contentAreaLogin: Styles.platformStyles({
     isElectron: {
       flexGrow: 1,
-      paddingTop: 20, // don't cover system buttons
       position: 'relative',
     },
     isMobile: {

--- a/shared/router-v2/router.desktop.js
+++ b/shared/router-v2/router.desktop.js
@@ -71,7 +71,12 @@ class AppView extends React.PureComponent<any> {
           style={selectedTab ? styles.contentArea : styles.contentAreaLogin}
         >
           {scene}
-          <Header loggedIn={selectedTab} options={descriptor.options} onPop={() => childNav.pop()} allowBack={index !== 0} />
+          <Header
+            loggedIn={!!selectedTab}
+            options={descriptor.options}
+            onPop={() => childNav.pop()}
+            allowBack={index !== 0}
+          />
         </Kb.Box2>
       </Kb.Box2>
     )

--- a/shared/router-v2/routes.js
+++ b/shared/router-v2/routes.js
@@ -13,8 +13,9 @@ import {newRoutes as walletsNewRoutes, newModalRoutes as walletsNewModalRoutes} 
 import {isMobile} from '../constants/platform'
 import * as Tabs from '../constants/tabs'
 
-// We have normal routes, modal routes, and logged out routes
-
+// We have normal routes, modal routes, and logged out routes.
+// We also end up using existence of a nameToTab value for a route as a test
+// of whether we're on a loggedIn route: loggedOut routes have no selected tab.
 export const nameToTab = {}
 // TODO could make a stronger type
 export type Route = {


### PR DESCRIPTION
@keybase/react-hackers 

On macOS, when logged out, the sidebar isn't rendered and so the nav2 back arrow is at the left edge of the screen and overlaps the system buttons (minimize, maximize, close).  When you're logged in it doesn't overlap because it's offset by the sidebar.

To fix this, we put a 20px paddingTop on the nav2 header when you're logged out.  But the nav2 header is also the draggable area, so this broke dragging on the top of the window when logged out -- the draggable area doesn't start until 20px down.

The best thing I could think to do is tell the header whether we're in the state of logged out and on macOS, and let it relatively offset the back arrow down below the system buttons in that case.