### PR TITLE
Fix TestOverallStatusFile logger race

### DIFF
--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -3282,6 +3282,7 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 
 	// start the background flusher
 	config.SetBGFlushPeriod(1 * time.Millisecond)
+	ops.doneWg.Add(1)
 	go ops.backgroundFlusher()
 
 	// Wait for the stall to know the background work is done.

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -808,7 +808,11 @@ func ForceQuotaReclamationForTesting(config Config,
 // test if there's an error.
 func CheckConfigAndShutdown(
 	ctx context.Context, t logger.TestLogBackend, config Config) {
-	if err := config.Shutdown(ctx); err != nil {
+	err := config.Shutdown(ctx)
+	switch err.(type) {
+	case data.ShutdownHappenedError:
+	case nil:
+	default:
 		t.Errorf("err=%+v", err)
 	}
 }


### PR DESCRIPTION
Add a sync.WaitGroup to track when all the goroutines launched by an fbo are done, so we avoid test races

Issue: KBFS-4104