### PR TITLE
Hide the back arrow on logged out screens if it doesn't go anywhere

### DIFF
--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -58,6 +58,11 @@ class Header extends React.PureComponent<Props> {
       ...(this.props.allowBack ? styles.icon : styles.disabledIcon),
       ...(!this.props.loggedIn && Platform.isDarwin ? {position: 'relative', top: 30} : {}),
     }
+    const iconColor = this.props.allowBack
+      ? Styles.globalColors.black_50
+      : this.props.loggedIn
+      ? Styles.globalColors.black_10
+      : Styles.globalColors.transparent
     return (
       <Kb.Box2 noShrink={true} direction="vertical" fullWidth={true}>
         {!!opt.headerBanner && opt.headerBanner}
@@ -71,8 +76,8 @@ class Header extends React.PureComponent<Props> {
             <Kb.Icon
               type="iconfont-arrow-left"
               style={backArrowStyle}
-              color={this.props.allowBack ? Styles.globalColors.black_50 : Styles.globalColors.black_10}
-              onClick={this.props.onPop}
+              color={iconColor}
+              onClick={this.props.allowBack || this.props.loggedIn ? this.props.onPop : null}
             />
             {flags.kbfsOfflineMode && <SyncingFolders />}
             {!title && rightActions}


### PR DESCRIPTION
@keybase/react-hackers 

e.g. the loading screen, the login-or-signup splash screen.