### PR TITLE
Have banner always underline actions

### DIFF
--- a/shared/common-adapters/banner.js
+++ b/shared/common-adapters/banner.js
@@ -47,8 +47,7 @@ const Banner = (props: Props) => (
                 key={`action-${index}`}
                 type="BodySmallSemibold"
                 onClick={onClick}
-                style={colorToTextColorStyles[props.color]}
-                underline={true}
+                style={Styles.collapseStyles([colorToTextColorStyles[props.color], styles.underline])}
               >
                 {title}
               </Text>,
@@ -117,6 +116,9 @@ const styles = Styles.styleSheetCreate({
       paddingRight: Styles.globalMargins.medium,
     },
   }),
+  underline: {
+    textDecorationLine: 'underline',
+  },
 })
 
 const colorToBackgroundColorStyles = Styles.styleSheetCreate({


### PR DESCRIPTION
Went into the last hotfix. I was going to fix it in `Text` but the logic for when to underline is convoluted, it depends on several other props. Banner can just add the style since it's doing it's own thing with setting the text color / background color. r? @keybase/react-hackers 