### PR TITLE
fix lineClamp for long big team headers

### DIFF
--- a/shared/__mocks__/react-virtualized-auto-sizer.js
+++ b/shared/__mocks__/react-virtualized-auto-sizer.js
@@ -1,0 +1,23 @@
+// @noflow
+import * as React from 'react'
+if (!__STORYBOOK__) {
+  throw new Error('Invalid load of mock')
+}
+
+type Props = {|
+  children: ({height: number, width: number}) => React.Node,
+|}
+
+const mockSize = {height: 300, width: 300}
+
+class AutoSizerMock extends React.Component<Props, {}> {
+  render() {
+    return (
+      <div className="AutoSizerMock" style={{...mockSize, overflow: 'visible'}}>
+        {this.props.children(mockSize)}
+      </div>
+    )
+  }
+}
+
+export default AutoSizerMock

--- a/shared/chat/inbox/index.stories.js
+++ b/shared/chat/inbox/index.stories.js
@@ -248,30 +248,30 @@ const mapPropProviderProps = {
 
   // Big Team B
   bigTeamBHeader: {
-    teamname: 'techtonica',
+    teamname: 'techtonica.long.team.name.with.ellipsis',
     memberCount: 0, // Handled by PropProviders.TeamDropdownMenu
     badgeSubscribe: false,
   },
   bigTeamBChannel1: {
     ...commonBigChannel,
-    teamname: 'techtonica',
+    teamname: 'techtonica.long.team.name.with.ellipsis',
     channelname: 'general',
     isSelected: !isMobile,
   },
   bigTeamBChannel2: {
     ...commonBigChannel,
-    teamname: 'techtonica',
+    teamname: 'techtonica.long.team.name.with.ellipsis',
     channelname: 'ignore-selected-below',
   },
   bigTeamBChannel3: {
     ...commonBigChannel,
-    teamname: 'techtonica',
+    teamname: 'techtonica.long.team.name.with.ellipsis',
     channelname: 'random',
     isMuted: true,
   },
   bigTeamBChannel4: {
     ...commonBigChannel,
-    teamname: 'techtonica',
+    teamname: 'techtonica.long.team.name.with.ellipsis',
     channelname: 'happy-hour',
     isMuted: true,
   },
@@ -324,7 +324,7 @@ const mapPropProviderProps = {
  * Uses either conversationIDKey or teamname as a key in mapPropProviderProps
  */
 const getPropProviderProps = own => {
-  if (own.conversationIDKey) {
+  if (own.conversationIDKey && own.conversationIDKey !== 'EMPTY') {
     const props = mapPropProviderProps[own.conversationIDKey]
     return {
       ...props,
@@ -388,10 +388,14 @@ const propsInboxTeam = {
     makeRowItemBigChannel('bigTeamAChannel4', 'Keybase', 'video-games'),
 
     makeRowItemBigHeader('bigTeamBHeader'),
-    makeRowItemBigChannel('bigTeamBChannel1', 'techtonica', 'general'),
-    makeRowItemBigChannel('bigTeamBChannel2', 'techtonica', 'ignore-selected-below'),
-    makeRowItemBigChannel('bigTeamBChannel3', 'techtonica', 'random'),
-    makeRowItemBigChannel('bigTeamBChannel4', 'techtonica', 'happy-hour'),
+    makeRowItemBigChannel('bigTeamBChannel1', 'techtonica.long.team.name.with.ellipsis', 'general'),
+    makeRowItemBigChannel(
+      'bigTeamBChannel2',
+      'techtonica.long.team.name.with.ellipsis',
+      'ignore-selected-below'
+    ),
+    makeRowItemBigChannel('bigTeamBChannel3', 'techtonica.long.team.name.with.ellipsis', 'random'),
+    makeRowItemBigChannel('bigTeamBChannel4', 'techtonica.long.team.name.with.ellipsis', 'happy-hour'),
   ],
 }
 
@@ -419,10 +423,14 @@ const propsInboxDivider = {
 
     // Big Team B
     makeRowItemBigHeader('bigTeamBHeader'),
-    makeRowItemBigChannel('bigTeamBChannel1', 'techtonica', 'general'),
-    makeRowItemBigChannel('bigTeamBChannel2', 'techtonica', 'ignore-selected-below'),
-    makeRowItemBigChannel('bigTeamBChannel3', 'techtonica', 'random'),
-    makeRowItemBigChannel('bigTeamBChannel4', 'techtonica', 'happy-hour'),
+    makeRowItemBigChannel('bigTeamBChannel1', 'techtonica.long.team.name.with.ellipsis', 'general'),
+    makeRowItemBigChannel(
+      'bigTeamBChannel2',
+      'techtonica.long.team.name.with.ellipsis',
+      'ignore-selected-below'
+    ),
+    makeRowItemBigChannel('bigTeamBChannel3', 'techtonica.long.team.name.with.ellipsis', 'random'),
+    makeRowItemBigChannel('bigTeamBChannel4', 'techtonica.long.team.name.with.ellipsis', 'happy-hour'),
   ],
 }
 
@@ -450,7 +458,7 @@ const propsInboxExpanded = {
  */
 const teamMemberCounts = {
   Keybase: 30,
-  techtonica: 30,
+  'techtonica.long.team.name.with.ellipsis': 30,
   stripe: 1337,
 }
 
@@ -495,10 +503,8 @@ const provider = Sb.createPropProviderWithCommon({
     style: {marginBottom: globalMargins.tiny},
     toggle: Sb.action('onToggle'),
   }),
-  // BigTeamHeader is wrapped by OverlayParent
-  OverlayParent: getPropProviderProps,
+  InboxBigTeamHeader: getPropProviderProps,
   SmallTeam: getPropProviderProps,
-  BigTeamHeader: getPropProviderProps,
   BigTeamsDivider: ownProps => ({badgeCount: 5}),
   BigTeamChannel: getPropProviderProps,
   FilterSmallTeam: getPropProviderProps,

--- a/shared/chat/inbox/row/big-team-header/container.js
+++ b/shared/chat/inbox/row/big-team-header/container.js
@@ -1,5 +1,5 @@
 // @flow
-import {connect} from '../../../../util/container'
+import {namedConnect} from '../../../../util/container'
 import {isTeamWithChosenChannels} from '../../../../constants/teams'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
 import {teamsTab} from '../../../../constants/tabs'
@@ -29,8 +29,9 @@ const mergeProps = (stateProps, dispatchProps) => ({
   teamname: stateProps.teamname,
 })
 
-export default connect<OwnProps, _, _, _, _>(
+export default namedConnect<OwnProps, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps,
-  mergeProps
+  mergeProps,
+  'InboxBigTeamHeader'
 )(BigTeamHeader)

--- a/shared/chat/inbox/row/big-team-header/index.js
+++ b/shared/chat/inbox/row/big-team-header/index.js
@@ -91,7 +91,6 @@ const styles = Styles.styleSheetCreate({
       marginLeft: Styles.globalMargins.tiny,
       marginRight: Styles.globalMargins.tiny,
     },
-    isElectron: {display: 'inline'},
     isMobile: {backgroundColor: Styles.globalColors.fastBlank},
   }),
   teamRowContainer: Styles.platformStyles({


### PR DESCRIPTION
Fix is removing `display: 'inline'` which conflicts with recently fixed lineClamp styles. The rest of this diff is fixing inbox stories + adding a long big teamname. The stories don't show in storyshots because of `react-virtualized-auto-sizer`. Fix coming in separate PR. r? @keybase/react-hackers 