### PR TITLE
Mock react-virtualized-auto-sizer for storyshots

### DIFF
--- a/shared/__mocks__/react-virtualized-auto-sizer.js
+++ b/shared/__mocks__/react-virtualized-auto-sizer.js
@@ -1,0 +1,23 @@
+// @noflow
+import * as React from 'react'
+if (!__STORYBOOK__) {
+  throw new Error('Invalid load of mock')
+}
+
+type Props = {|
+  children: ({height: number, width: number}) => React.Node,
+|}
+
+const mockSize = {height: 300, width: 300}
+
+class AutoSizerMock extends React.Component<Props, {}> {
+  render() {
+    return (
+      <div className="AutoSizerMock" style={{...mockSize, overflow: 'visible'}}>
+        {this.props.children(mockSize)}
+      </div>
+    )
+  }
+}
+
+export default AutoSizerMock


### PR DESCRIPTION
Makes snapshots of anything that uses `react-virtualized-auto-sizer` work, most notably the inbox and `List2`. r? @keybase/react-hackers 