### PR TITLE
Header changes

### DIFF
--- a/shared/teams/team/custom-title/container.js
+++ b/shared/teams/team/custom-title/container.js
@@ -1,7 +1,5 @@
 // @flow
 import * as Constants from '../../../constants/teams'
-import * as FsConstants from '../../../constants/fs'
-import * as FsTypes from '../../../constants/types/fs'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import Title from '.'
 import {connect} from '../../../util/container'
@@ -13,23 +11,18 @@ const mapStateToProps = (state, {teamname}) => {
   const yourOperations = Constants.getCanPerform(state, teamname)
   return {
     canChat: !yourOperations.joinTeam,
-    canViewFolder: !yourOperations.joinTeam,
     loading: anyWaiting(state, Constants.teamWaitingKey(teamname)),
   }
 }
 
 const mapDispatchToProps = (dispatch, {teamname}) => ({
   onChat: () => dispatch(Chat2Gen.createPreviewConversation({reason: 'teamHeader', teamname})),
-  onOpenFolder: () =>
-    dispatch(FsConstants.makeActionForOpenPathInFilesTab(FsTypes.stringToPath(`/keybase/team/${teamname}`))),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   canChat: stateProps.canChat,
-  canViewFolder: stateProps.canViewFolder,
   loading: stateProps.loading,
   onChat: dispatchProps.onChat,
-  onOpenFolder: dispatchProps.onOpenFolder,
   teamname: ownProps.teamname,
 })
 

--- a/shared/teams/team/custom-title/index.js
+++ b/shared/teams/team/custom-title/index.js
@@ -11,14 +11,12 @@ import {
 import {globalStyles, globalMargins, isMobile, styleSheetCreate} from '../../../styles'
 import TeamMenu from '../menu-container'
 
-type Props = {
-  onOpenFolder: () => void,
+type Props = {|
   onChat: () => void,
   canChat: boolean,
-  canViewFolder: boolean,
   loading: boolean,
   teamname: string,
-}
+|}
 
 const fontSize = isMobile ? 20 : 16
 
@@ -31,14 +29,6 @@ const _CustomComponent = (props: Props & OverlayParentProps) => (
         fontSize={fontSize}
         style={iconCastPlatformStyles(styles.icon)}
         type="iconfont-chat"
-      />
-    )}
-    {!isMobile && props.canViewFolder && (
-      <Icon
-        onClick={props.onOpenFolder}
-        fontSize={fontSize}
-        style={iconCastPlatformStyles(styles.icon)}
-        type="iconfont-folder-private"
       />
     )}
     <Icon

--- a/shared/teams/team/menu-container.js
+++ b/shared/teams/team/menu-container.js
@@ -1,6 +1,8 @@
 // @flow
 import * as React from 'react'
 import * as Constants from '../../constants/teams'
+import * as FsConstants from '../../constants/fs'
+import * as FsTypes from '../../constants/types/fs'
 import {connect} from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import {type MenuItem} from '../../common-adapters/floating-menu/menu-layout'
@@ -21,6 +23,7 @@ const mapStateToProps = (state, {teamname}: OwnProps) => {
     canCreateSubteam: yourOperations.manageSubteams,
     canLeaveTeam: yourOperations.leaveTeam,
     canManageChat: yourOperations.renameChannel,
+    canViewFolder: !yourOperations.joinTeam,
     isBigTeam,
   }
 }
@@ -47,6 +50,8 @@ const mapDispatchToProps = (dispatch, {teamname}: OwnProps) => ({
         path: [{props: {teamname}, selected: 'chatManageChannels'}],
       })
     ),
+  onOpenFolder: () =>
+    dispatch(FsConstants.makeActionForOpenPathInFilesTab(FsTypes.stringToPath(`/keybase/team/${teamname}`))),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
@@ -63,6 +68,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
   }
   if (stateProps.canCreateSubteam) {
     items.push({onClick: dispatchProps.onCreateSubteam, title: 'Create subteam'})
+  }
+  if (stateProps.canViewFolder) {
+    items.push({onClick: dispatchProps.onOpenFolder, title: 'Open folder'})
   }
   return {
     attachTo: ownProps.attachTo,

--- a/shared/teams/team/nav-header/container.js
+++ b/shared/teams/team/nav-header/container.js
@@ -1,7 +1,5 @@
 // @flow
 import * as Constants from '../../../constants/teams'
-import * as FsConstants from '../../../constants/fs'
-import * as FsTypes from '../../../constants/types/fs'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as SearchGen from '../../../actions/search-gen'
@@ -20,24 +18,19 @@ const mapStateToProps = (state, {teamname}) => {
   return {
     canAddPeople: yourOperations.manageMembers,
     canChat: !yourOperations.joinTeam,
-    canViewFolder: !yourOperations.joinTeam,
     loading: anyWaiting(state, Constants.teamWaitingKey(teamname)),
   }
 }
 
 const mapDispatchToProps = (dispatch, {teamname}) => ({
   onChat: () => dispatch(Chat2Gen.createPreviewConversation({reason: 'teamHeader', teamname})),
-  onOpenFolder: () =>
-    dispatch(FsConstants.makeActionForOpenPathInFilesTab(FsTypes.stringToPath(`/keybase/team/${teamname}`))),
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   canAddPeople: stateProps.canAddPeople,
   canChat: stateProps.canChat,
-  canViewFolder: stateProps.canViewFolder,
   loading: stateProps.loading,
   onChat: dispatchProps.onChat,
-  onOpenFolder: dispatchProps.onOpenFolder,
   teamname: ownProps.teamname,
 })
 

--- a/shared/teams/team/nav-header/index.js
+++ b/shared/teams/team/nav-header/index.js
@@ -29,11 +29,9 @@ const AddPeopleButton = Kb.OverlayParentHOC(_AddPeopleButton)
 
 type Props = {|
   ...$Exact<Kb.OverlayParentProps>,
-  onOpenFolder: () => void,
   onChat: () => void,
   canAddPeople: boolean,
   canChat: boolean,
-  canViewFolder: boolean,
   loading: boolean,
   teamname: string,
 |}
@@ -42,9 +40,6 @@ const _HeaderRightActions = (props: Props) => (
   <Kb.Box2 direction="horizontal" gap="tiny" alignItems="center" style={styles.rightActionsContainer}>
     {props.canChat && <Kb.Button label="Chat" onClick={props.onChat} small={true} />}
     {props.canAddPeople && <AddPeopleButton teamname={props.teamname} />}
-    {!Styles.isMobile && props.canViewFolder && (
-      <Kb.Button small={true} mode="Secondary" label="Open folder" onClick={props.onOpenFolder} />
-    )}
     <Kb.Button mode="Secondary" small={true} ref={props.setAttachmentRef} onClick={props.toggleShowingMenu}>
       <Kb.Icon type="iconfont-ellipsis" color={Styles.globalColors.blue} />
     </Kb.Button>

--- a/shared/wallets/nav-header/container.js
+++ b/shared/wallets/nav-header/container.js
@@ -14,6 +14,7 @@ const mergePropsHeaderTitle = s => ({
   accountID: s._account.accountID,
   accountName: s._account.name,
   isDefault: s._account.isDefault,
+  loading: s._account.accountID === Types.noAccountID,
   username: s.username,
 })
 

--- a/shared/wallets/nav-header/index.js
+++ b/shared/wallets/nav-header/index.js
@@ -10,6 +10,7 @@ type HeaderTitleProps = {|
   accountID: Types.AccountID,
   accountName: string,
   isDefault: boolean,
+  loading: boolean,
   username: string,
 |}
 
@@ -19,13 +20,19 @@ export const HeaderTitle = (props: HeaderTitleProps) => (
       <AddAccount />
     </Kb.Box2>
     <Kb.Box2 direction="vertical" alignItems="flex-start" style={styles.accountInfo}>
-      <Kb.Box2 direction="horizontal" alignItems="center" gap="tiny" style={styles.accountNameContainer}>
-        {props.isDefault && <Kb.Avatar size={16} username={props.username} />}
-        <Kb.Text type="Header" lineClamp={1}>
-          {props.accountName}
-        </Kb.Text>
-      </Kb.Box2>
-      <SmallAccountID accountID={props.accountID} />
+      {props.loading ? (
+        <Kb.ProgressIndicator small={true} style={styles.loading} />
+      ) : (
+        <>
+          <Kb.Box2 direction="horizontal" alignItems="center" gap="tiny" style={styles.accountNameContainer}>
+            {props.isDefault && <Kb.Avatar size={16} username={props.username} />}
+            <Kb.Text type="Header" lineClamp={1}>
+              {props.accountName}
+            </Kb.Text>
+          </Kb.Box2>
+          <SmallAccountID accountID={props.accountID} />
+        </>
+      )}
     </Kb.Box2>
   </Kb.Box2>
 )
@@ -54,6 +61,10 @@ const styles = Styles.styleSheetCreate({
     minWidth: 240,
     paddingLeft: Styles.globalMargins.xsmall,
     paddingRight: Styles.globalMargins.xsmall,
+  },
+  loading: {
+    height: 16,
+    width: 16,
   },
   rightActions: {
     alignSelf: 'stretch',

--- a/shared/wallets/routes.js
+++ b/shared/wallets/routes.js
@@ -183,6 +183,7 @@ export const newRoutes = {
 
         WalletsSubNavigator.navigationOptions = {
           header: undefined,
+          headerExpandable: true,
           headerRightActions: HeaderRightActions,
           headerTitle: HeaderTitle,
           title: 'Wallet',


### PR DESCRIPTION
- Make wallet header expandable
- Move 'Open folder' into overflow menu on teams header
- Show spinner in wallet header if we're still loading accounts

r? @keybase/react-hackers cc @cecileboucheron 