### PR TITLE
SelectiveSync fixes

### DIFF
--- a/go/chat/identify_test.go
+++ b/go/chat/identify_test.go
@@ -42,6 +42,7 @@ func TestChatBackgroundIdentify(t *testing.T) {
 		},
 		MaxMsgs:         []chat1.MessageBoxed{msg},
 		MaxMsgSummaries: []chat1.MessageSummary{msg.Summary()},
+		ReaderInfo:      &chat1.ConversationReaderInfo{},
 	}
 	require.NoError(t, inbox.Merge(context.TODO(), u.User.GetUID().ToBytes(), 1, []chat1.Conversation{conv},
 		nil, nil))

--- a/go/chat/search/constants.go
+++ b/go/chat/search/constants.go
@@ -1,5 +1,7 @@
 package search
 
+import "time"
+
 const defaultPageSize = 300
 const MaxAllowedSearchHits = 10000
 
@@ -10,21 +12,15 @@ const MaxAllowedSearchMessages = 100000
 const MaxContext = 15
 
 const (
-	// max number of conversations to use regexp searcher to boost the search
-	// results on misses
-	maxBoostConvsDesktop = 500
-	maxBoostConvsMobile  = 250
-	// max number of messages the boost can use
-	maxBoostMsgsDesktop = 1000
-	maxBoostMsgsMobile  = 500
 	// max convs to sync in the background
-	maxSyncConvsDesktop = 10
+	maxSyncConvsDesktop = 50
 	maxSyncConvsMobile  = 5
+
 	// tokenizer
 	maxPrefixLength = 10
 	minTokenLength  = 3
-)
 
-// Bumped whenever there are tokenization or structural changes to building the
-// index
-const IndexVersion = 5
+	// delay before starting SelectiveSync
+	startSyncDelayDesktop = 10 * time.Second
+	startSyncDelayMobile  = 30 * time.Second
+)

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -45,7 +45,7 @@ func NewIndexer(g *globals.Context) *Indexer {
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "Search.Indexer", false),
 		store:        newStore(g),
 		pageSize:     defaultPageSize,
-		stopCh:       make(chan chan struct{}),
+		stopCh:       make(chan chan struct{}, 10),
 		cancelSyncCh: make(chan struct{}, 100),
 		pokeSyncCh:   make(chan struct{}, 100),
 	}

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type Indexer struct {
@@ -27,11 +28,13 @@ type Indexer struct {
 	stopCh   chan struct{}
 	started  bool
 
-	maxSyncConvs int
+	maxSyncConvs   int
+	startSyncDelay time.Duration
 
 	// for testing
-	consumeCh chan chat1.ConversationID
-	reindexCh chan chat1.ConversationID
+	consumeCh  chan chat1.ConversationID
+	reindexCh  chan chat1.ConversationID
+	syncLoopCh chan struct{}
 }
 
 var _ types.Indexer = (*Indexer)(nil)
@@ -47,11 +50,16 @@ func NewIndexer(g *globals.Context) *Indexer {
 	switch idx.G().GetAppType() {
 	case libkb.MobileAppType:
 		idx.SetMaxSyncConvs(maxSyncConvsMobile)
+		idx.startSyncDelay = startSyncDelayMobile
 	default:
-
+		idx.startSyncDelay = startSyncDelayDesktop
 		idx.SetMaxSyncConvs(maxSyncConvsDesktop)
 	}
 	return idx
+}
+
+func (idx *Indexer) SetStartSyncDelay(d time.Duration) {
+	idx.startSyncDelay = d
 }
 
 func (idx *Indexer) SetMaxSyncConvs(x int) {
@@ -70,6 +78,10 @@ func (idx *Indexer) SetReindexCh(ch chan chat1.ConversationID) {
 	idx.reindexCh = ch
 }
 
+func (idx *Indexer) SetSyncLoopCh(ch chan struct{}) {
+	idx.syncLoopCh = ch
+}
+
 func (idx *Indexer) Start(ctx context.Context, uid gregor1.UID) {
 	defer idx.Trace(ctx, func() error { return nil }, "Start")()
 	idx.Lock()
@@ -84,32 +96,71 @@ func (idx *Indexer) Start(ctx context.Context, uid gregor1.UID) {
 		return
 	}
 	idx.started = true
-	ticker := libkb.NewBgTicker(time.Hour)
-	go func(stopCh chan struct{}) {
-		idx.Debug(ctx, "starting SelectiveSync bg loop")
+	go idx.SyncLoop(ctx, uid)
+}
 
-		// run one quickly
+func (idx *Indexer) SyncLoop(ctx context.Context, uid gregor1.UID) {
+	idx.Lock()
+	stopCh := idx.stopCh
+	syncLoopCh := idx.syncLoopCh
+	idx.Unlock()
+	idx.Debug(ctx, "starting SelectiveSync bg loop")
+
+	var cancelFn context.CancelFunc
+	var l sync.Mutex
+	attemptSync := func(ctx context.Context) {
+		l.Lock()
+		defer l.Unlock()
+		if cancelFn == nil {
+			ctx, cancelFn = context.WithCancel(ctx)
+			go func() {
+				idx.Debug(ctx, "running SelectiveSync")
+				if err := idx.SelectiveSync(ctx, uid); err != nil {
+					idx.Debug(ctx, "unable to complete SelectiveSync: %v", err)
+					if syncLoopCh != nil {
+						syncLoopCh <- struct{}{}
+					}
+				}
+				l.Lock()
+				if cancelFn != nil {
+					cancelFn()
+					cancelFn = nil
+				}
+				l.Unlock()
+			}()
+		}
+	}
+	cancelSync := func() {
+		l.Lock()
+		defer l.Unlock()
+		if cancelFn != nil {
+			cancelFn()
+			cancelFn = nil
+		}
+	}
+	ticker := libkb.NewBgTicker(time.Hour)
+	after := time.After(idx.startSyncDelay)
+	state := keybase1.MobileAppState_FOREGROUND
+	for {
 		select {
-		case <-time.After(libkb.DefaultBgTickerWait):
-			idx.SelectiveSync(ctx, uid, false /*forceReindex */)
+		case <-after:
+			attemptSync(ctx)
+		case <-ticker.C:
+			attemptSync(ctx)
+		case state = <-idx.G().MobileAppState.NextUpdate(&state):
+			switch state {
+			case keybase1.MobileAppState_FOREGROUND:
+			// if we enter any state besides foreground cancel any running syncs
+			default:
+				cancelSync()
+			}
 		case <-stopCh:
 			idx.Debug(ctx, "stopping SelectiveSync bg loop")
+			cancelSync()
+			ticker.Stop()
 			return
 		}
-
-		for {
-			select {
-			case <-ticker.C:
-				// queue up some jobs on the background loader
-				idx.Debug(ctx, "running SelectiveSync")
-				idx.SelectiveSync(ctx, uid, false /*forceReindex */)
-			case <-stopCh:
-				idx.Debug(ctx, "stopping SelectiveSync bg loop")
-				ticker.Stop()
-				return
-			}
-		}
-	}(idx.stopCh)
+	}
 }
 
 func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
@@ -182,19 +233,12 @@ func (idx *Indexer) Remove(ctx context.Context, convID chat1.ConversationID, uid
 	return idx.store.Remove(ctx, uid, convID, msgs)
 }
 
-type reindexOpts struct {
-	forceReindex bool
-	limitMaxJobs bool
-	maxJobs      int
-}
-
-// reindexConv attempts to fill in any missing messages from the index.
-// forceReindex toggles if the behavior is blocking or queued into the
-// background conversation loader. For a small number of messages we use the
-// GetMessages api to fill in the holes. If our index is missing many messages,
-// we page through and add batches of missing messages.
+// reindexConv attempts to fill in any missing messages from the index.  For a
+// small number of messages we use the GetMessages api to fill in the holes. If
+// our index is missing many messages, we page through and add batches of
+// missing messages.
 func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversation, uid gregor1.UID,
-	opts reindexOpts) (completedJobs int, err error) {
+	numJobs int) (completedJobs int, err error) {
 
 	conv := rconv.Conv
 	convID := conv.GetConvID()
@@ -215,30 +259,15 @@ func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversat
 
 	reason := chat1.GetThreadReason_INDEXED_SEARCH
 	if len(missingIDs) < idx.pageSize {
-		postHook := func(ctx context.Context) error {
-			msgs, err := idx.G().ConvSource.GetMessages(ctx, conv, uid, missingIDs, &reason)
-			if err != nil {
-				if utils.IsPermanentErr(err) {
-					return err
-				}
-				return nil
-			}
-			return idx.Add(ctx, convID, uid, msgs)
-		}
-		if opts.forceReindex { // block on gathering results
-			if err := postHook(ctx); err != nil {
+		msgs, err := idx.G().ConvSource.GetMessages(ctx, conv, uid, missingIDs, &reason)
+		if err != nil {
+			if utils.IsPermanentErr(err) {
 				return 0, err
 			}
-		} else { // queue up GetMessages in the background
-			job := types.NewConvLoaderJob(convID, nil /*query*/, nil /*pagination*/, types.ConvLoaderPriorityMedium,
-				func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
-					if err := postHook(ctx); err != nil {
-						idx.Debug(ctx, "unable to GetMessages: %v", err)
-					}
-				})
-			if err := idx.G().ConvLoader.Queue(ctx, job); err != nil {
-				idx.Debug(ctx, "unable queue job: %v", err)
-			}
+			return 0, nil
+		}
+		if err := idx.Add(ctx, convID, uid, msgs); err != nil {
+			return 0, err
 		}
 		completedJobs++
 	} else {
@@ -247,35 +276,28 @@ func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversat
 			MarkAsRead:               false,
 		}
 		for i := minIdxID; i < maxIdxID; i += chat1.MessageID(idx.pageSize) {
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			default:
+			}
 			pagination := utils.MessageIDControlToPagination(ctx, idx.DebugLabeler, &chat1.MessageIDControl{
 				Num:   idx.pageSize,
 				Pivot: &i,
 				Mode:  chat1.MessageIDControlMode_NEWERMESSAGES,
 			}, nil)
-			if opts.forceReindex { // block on gathering results
-				tv, err := idx.G().ConvSource.Pull(ctx, convID, uid, reason, query, pagination)
-				if err != nil {
-					if utils.IsPermanentErr(err) {
-						return 0, err
-					}
-					continue
-				}
-				if err := idx.Add(ctx, convID, uid, tv.Messages); err != nil {
+			tv, err := idx.G().ConvSource.Pull(ctx, convID, uid, reason, query, pagination)
+			if err != nil {
+				if utils.IsPermanentErr(err) {
 					return 0, err
 				}
-			} else { // queue up results
-				job := types.NewConvLoaderJob(convID, query, pagination, types.ConvLoaderPriorityMedium,
-					func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
-						if err := idx.Add(ctx, convID, uid, tv.Messages); err != nil {
-							idx.Debug(ctx, "unable add ids: %v", err)
-						}
-					})
-				if err := idx.G().ConvLoader.Queue(ctx, job); err != nil {
-					idx.Debug(ctx, "unable queue job: %v", err)
-				}
+				continue
+			}
+			if err := idx.Add(ctx, convID, uid, tv.Messages); err != nil {
+				return 0, err
 			}
 			completedJobs++
-			if opts.limitMaxJobs && completedJobs >= opts.maxJobs {
+			if numJobs > 0 && completedJobs >= numJobs {
 				break
 			}
 		}
@@ -390,20 +412,24 @@ func (idx *Indexer) Search(ctx context.Context, uid gregor1.UID, query, origQuer
 // SelectiveSync queues up a small number of jobs on the background loader
 // periodically so our index can cover all conversations. The number of jobs
 // varies between desktop and mobile so mobile can be more conservative.
-func (idx *Indexer) SelectiveSync(ctx context.Context, uid gregor1.UID, forceReindex bool) {
-	defer idx.Trace(ctx, func() error { return nil }, "SelectiveSync")()
+func (idx *Indexer) SelectiveSync(ctx context.Context, uid gregor1.UID) (err error) {
+	defer idx.Trace(ctx, func() error { return err }, "SelectiveSync")()
 
 	convMap, err := idx.allConvs(ctx, uid, nil)
 	if err != nil {
-		idx.Debug(ctx, "SelectiveSync: Unable to get convs: %v", err)
-		return
+		return err
 	}
 
 	// make sure the most recently modified convs are fully indexed
 	convs := idx.convsByMTime(ctx, uid, convMap)
-	maxJobs := idx.maxSyncConvs
-	var totalCompletedJobs, fullyIndexedConvs int
+	// number of batches of messages to fetch in total
+	numJobs := idx.maxSyncConvs
 	for _, conv := range convs {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		convID := conv.GetConvID()
 		md, err := idx.store.GetMetadata(ctx, uid, convID)
 		if err != nil {
@@ -411,30 +437,23 @@ func (idx *Indexer) SelectiveSync(ctx context.Context, uid gregor1.UID, forceRei
 			continue
 		}
 		if md.FullyIndexed(conv.Conv) {
-			fullyIndexedConvs++
 			continue
 		}
 
-		completedJobs, err := idx.reindexConv(ctx, conv, uid, reindexOpts{
-			forceReindex: forceReindex, // only true in tests
-			limitMaxJobs: true,
-			maxJobs:      maxJobs - totalCompletedJobs,
-		})
+		completedJobs, err := idx.reindexConv(ctx, conv, uid, numJobs)
 		if err != nil {
 			idx.Debug(ctx, "Unable to reindex conv: %v, %v", convID, err)
 			continue
 		} else if completedJobs == 0 {
-			fullyIndexedConvs++
 			continue
 		}
-		totalCompletedJobs += completedJobs
-		idx.Debug(ctx, "SelectiveSync: Indexed %d/%d jobs", totalCompletedJobs, maxJobs)
-		if totalCompletedJobs >= maxJobs {
+		idx.Debug(ctx, "SelectiveSync: Indexed completed jobs %d", completedJobs)
+		numJobs -= completedJobs
+		if numJobs <= 0 {
 			break
 		}
 	}
-	idx.Debug(ctx, "SelectiveSync: Complete, %d/%d convs already fully indexed",
-		fullyIndexedConvs, len(convs))
+	return nil
 }
 
 // IndexInbox is only exposed in devel for debugging/profiling the indexing
@@ -485,7 +504,7 @@ func (idx *Indexer) indexConvWithProfile(ctx context.Context, conv types.RemoteC
 	}()
 
 	startT := time.Now()
-	_, err = idx.reindexConv(ctx, conv, uid, reindexOpts{forceReindex: true})
+	_, err = idx.reindexConv(ctx, conv, uid, 0)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -874,9 +874,15 @@ func TestChatSearchInbox(t *testing.T) {
 		// Test canceling sync loop
 		syncLoopCh := make(chan struct{})
 		indexer1.SetSyncLoopCh(syncLoopCh)
-		ctx, cancelFn := context.WithCancel(ctx)
 		go indexer1.SyncLoop(ctx, uid1)
-		cancelFn()
+		indexer1.CancelSync()
+		select {
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "indexer SyncLoop never finished")
+		case <-syncLoopCh:
+		}
+		indexer1.PokeSync()
+		indexer1.CancelSync()
 		select {
 		case <-time.After(5 * time.Second):
 			require.Fail(t, "indexer SyncLoop never finished")

--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -412,6 +412,7 @@ func TestChatSearchInbox(t *testing.T) {
 		reindexCh1 := make(chan chat1.ConversationID, 100)
 		indexer1.SetConsumeCh(consumeCh1)
 		indexer1.SetReindexCh(reindexCh1)
+		indexer1.SetStartSyncDelay(0)
 		// Stop the original
 		select {
 		case <-g1.Indexer.Stop(ctx):
@@ -425,6 +426,7 @@ func TestChatSearchInbox(t *testing.T) {
 		reindexCh2 := make(chan chat1.ConversationID, 100)
 		indexer2.SetConsumeCh(consumeCh2)
 		indexer2.SetReindexCh(reindexCh2)
+		indexer2.SetStartSyncDelay(0)
 		// Stop the original
 		select {
 		case <-g2.Indexer.Stop(ctx):
@@ -559,6 +561,7 @@ func TestChatSearchInbox(t *testing.T) {
 		msgID1 := sendMessage(chat1.NewMessageBodyWithText(chat1.MessageText{
 			Body: msgBody,
 		}), u1)
+
 		queries := []string{"hello", "hello, ByE"}
 		matches := []chat1.ChatSearchMatch{
 			chat1.ChatSearchMatch{
@@ -798,7 +801,8 @@ func TestChatSearchInbox(t *testing.T) {
 		// Verify POSTSEARCH_SYNC
 		ictx := globals.CtxAddIdentifyMode(ctx, keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil)
 		g1.LocalChatDb.Nuke()
-		indexer1.SelectiveSync(ictx, uid1, true /* forceReindex */)
+		err = indexer1.SelectiveSync(ictx, uid1)
+		require.NoError(t, err)
 		opts.ReindexMode = chat1.ReIndexingMode_POSTSEARCH_SYNC
 		res = runSearch(query, opts, true /* expectedReindex*/)
 		require.Equal(t, 1, len(res.Hits))
@@ -866,5 +870,17 @@ func TestChatSearchInbox(t *testing.T) {
 		verifyHit(convID, []chat1.MessageID{}, msgID10, nil, []chat1.ChatSearchMatch{searchMatch}, convHit.Hits[0])
 		verifySearchDone(1)
 		opts.SentTo = ""
+
+		// Test canceling sync loop
+		syncLoopCh := make(chan struct{})
+		indexer1.SetSyncLoopCh(syncLoopCh)
+		ctx, cancelFn := context.WithCancel(ctx)
+		go indexer1.SyncLoop(ctx, uid1)
+		cancelFn()
+		select {
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "indexer SyncLoop never finished")
+		case <-syncLoopCh:
+		}
 	})
 }

--- a/go/chat/search_test.go
+++ b/go/chat/search_test.go
@@ -875,14 +875,14 @@ func TestChatSearchInbox(t *testing.T) {
 		syncLoopCh := make(chan struct{})
 		indexer1.SetSyncLoopCh(syncLoopCh)
 		go indexer1.SyncLoop(ctx, uid1)
-		indexer1.CancelSync()
+		indexer1.CancelSync(ctx)
 		select {
 		case <-time.After(5 * time.Second):
 			require.Fail(t, "indexer SyncLoop never finished")
 		case <-syncLoopCh:
 		}
-		indexer1.PokeSync()
-		indexer1.CancelSync()
+		indexer1.PokeSync(ctx)
+		indexer1.CancelSync(ctx)
 		select {
 		case <-time.After(5 * time.Second):
 			require.Fail(t, "indexer SyncLoop never finished")

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -289,6 +289,7 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	ictx := globals.CtxAddIdentifyMode(context.Background(), keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil)
 	indexer.Start(ictx, uid)
 	indexer.SetPageSize(2)
+	indexer.SetStartSyncDelay(0)
 	g.Indexer = indexer
 	g.AttachmentURLSrv = types.DummyAttachmentHTTPSrv{}
 	g.Unfurler = types.DummyUnfurler{}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -375,6 +375,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	ictx := globals.CtxAddIdentifyMode(context.Background(), keybase1.TLFIdentifyBehavior_CHAT_SKIP, nil)
 	indexer.Start(ictx, uid)
 	indexer.SetPageSize(2)
+	indexer.SetStartSyncDelay(0)
 	g.Indexer = indexer
 
 	h.setTestRemoteClient(ri)

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -128,9 +128,9 @@ type Indexer interface {
 	FullyIndexed(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (bool, error)
 	PercentIndexed(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID) (int, error)
 	SearchableConvs(ctx context.Context, uid gregor1.UID, convID *chat1.ConversationID) ([]RemoteConversation, error)
+	OnDbNuke(mctx libkb.MetaContext) error
 	// For devel/testing
 	IndexInbox(ctx context.Context, uid gregor1.UID) (map[string]chat1.ProfileSearchConvStats, error)
-	OnDbNuke(mctx libkb.MetaContext) error
 }
 
 type Sender interface {


### PR DESCRIPTION
- increase delay to selective sync, especially important on mobile
- drop use of `ConvLoader` in `reindexConv` to reduce complexity, instead check mobile background state in `Indexer` directly
- separate index tokenization version from on disk format version, cleanup old disk formats
- add `PokeSync`, which triggers selective sync to run after a search completes
- add `CancelSync`, canceling any running sync at the start of search