### PR TITLE
SendLinkToChat: sort channel list

### DIFF
--- a/shared/actions/fs/index.js
+++ b/shared/actions/fs/index.js
@@ -810,7 +810,9 @@ const initSendLinkToChat = (state, action) => {
       : [
           FsGen.createSetSendLinkToChatChannels({
             channels: I.Map(
-              result.convs.map(conv => [ChatTypes.stringToConversationIDKey(conv.convID), conv.channel])
+              result.convs
+                .filter(conv => conv.memberStatus === RPCChatTypes.commonConversationMemberStatus.active)
+                .map(conv => [ChatTypes.stringToConversationIDKey(conv.convID), conv.channel])
             ),
           }),
 

--- a/shared/fs/send-link-to-chat/container.js
+++ b/shared/fs/send-link-to-chat/container.js
@@ -115,16 +115,18 @@ const mergeProps = (stateProps, {onCancel, _onSent, _send, _selectChannel}, ownP
 
   // big team
 
-  const channels = stateProps._sendLinkToChat.channels.reduce(
-    (channels, channelname, convID) => [
-      ...channels,
-      {
-        channelname,
-        convID,
-      },
-    ],
-    []
-  )
+  const channels = stateProps._sendLinkToChat.channels
+    .reduce(
+      (channels, channelname, convID) => [
+        ...channels,
+        {
+          channelname,
+          convID,
+        },
+      ],
+      []
+    )
+    .sort((a, b) => a.channelname.localeCompare(b.channelname, 'undefined', {sensitivity: 'base'}))
 
   return {
     conversation: {


### PR DESCRIPTION
@joshblum said he would look at adding a parameter for whether to only get channels the user is a member of to the `GetTLFConversationsLocal` RPC. I'm going to wait for that before doing the other half of the work here.

Issue: KBFS-3762