### PR TITLE
fix selectable in SearchFilter on desktop

### DIFF
--- a/shared/common-adapters/search-filter.js
+++ b/shared/common-adapters/search-filter.js
@@ -217,7 +217,7 @@ class SearchFilter extends React.PureComponent<Props, State> {
         onMouseLeave={this._mouseLeave}
         onClick={
           this.props.onClick ||
-          // On moile we can't just make a null for Kb.ClickableBox here when
+          // On mobile we can't just make a null for Kb.ClickableBox here when
           // focused, as that'd cause PlainInput to be re-constructed.
           (Styles.isMobile || !this.state.focused ? this._focus : null)
         }

--- a/shared/common-adapters/search-filter.js
+++ b/shared/common-adapters/search-filter.js
@@ -217,9 +217,9 @@ class SearchFilter extends React.PureComponent<Props, State> {
         onMouseLeave={this._mouseLeave}
         onClick={
           this.props.onClick ||
-          // Can't just make a null for Kb.ClickableBox here when focused, as
-          // that'd cause PlainInput to be re-constructed.
-          this._focus
+          // On moile we can't just make a null for Kb.ClickableBox here when
+          // focused, as that'd cause PlainInput to be re-constructed.
+          (Styles.isMobile || !this.state.focused ? this._focus : null)
         }
         underlayColor={Styles.globalColors.transparent}
         hoverColor={Styles.globalColors.transparent}


### PR DESCRIPTION
I fixed the draggable thing in a previous PR, but just realized that didn't actually make the test in the box selectable. This PR fixes that.