### PR TITLE
Keep the chat headline emoji small when on its own

### DIFF
--- a/shared/chat/header.desktop.js
+++ b/shared/chat/header.desktop.js
@@ -43,7 +43,7 @@ const descStyleOverride = {
 const Header = (p: Props) => {
   let description = !!p.desc && (
     // $FlowIssue not used on mobile
-    <Kb.Markdown style={styles.desc} styleOverride={descStyleOverride} lineClamp={1} selectable={true}>
+    <Kb.Markdown preview={true} style={styles.desc} styleOverride={descStyleOverride} lineClamp={1} selectable={true}>
       {p.desc}
     </Kb.Markdown>
   )

--- a/shared/chat/header.desktop.js
+++ b/shared/chat/header.desktop.js
@@ -43,7 +43,13 @@ const descStyleOverride = {
 const Header = (p: Props) => {
   let description = !!p.desc && (
     // $FlowIssue not used on mobile
-    <Kb.Markdown preview={true} style={styles.desc} styleOverride={descStyleOverride} lineClamp={1} selectable={true}>
+    <Kb.Markdown
+      smallStandaloneEmoji={true}
+      style={styles.desc}
+      styleOverride={descStyleOverride}
+      lineClamp={1}
+      selectable={true}
+    >
       {p.desc}
     </Kb.Markdown>
   )

--- a/shared/common-adapters/markdown/index.js.flow
+++ b/shared/common-adapters/markdown/index.js.flow
@@ -43,7 +43,7 @@ export type Props = {|
   children?: string,
   lineClamp?: number,
   selectable?: boolean, // desktop - applies to outer container only
-  smallStandaloneEmoji?: boolean, // desktop - don't increase font size for a standalone emoji
+  smallStandaloneEmoji?: boolean, // don't increase font size for a standalone emoji
   preview?: boolean, // if true render a simplified version
   // Style only styles the top level container.
   // This is only useful in desktop because of cascading styles and there is a top level wrapper.

--- a/shared/common-adapters/markdown/index.js.flow
+++ b/shared/common-adapters/markdown/index.js.flow
@@ -43,6 +43,7 @@ export type Props = {|
   children?: string,
   lineClamp?: number,
   selectable?: boolean, // desktop - applies to outer container only
+  smallStandaloneEmoji?: boolean, // desktop - don't increase font size for a standalone emoji
   preview?: boolean, // if true render a simplified version
   // Style only styles the top level container.
   // This is only useful in desktop because of cascading styles and there is a top level wrapper.

--- a/shared/common-adapters/markdown/shared.js
+++ b/shared/common-adapters/markdown/shared.js
@@ -393,7 +393,7 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps, {hasError: bo
 
       output = this.props.preview
         ? previewOutput(parseTree)
-        : isAllEmoji(parseTree)
+        : isAllEmoji(parseTree) && !this.props.smallStandaloneEmoji
         ? bigEmojiOutput(parseTree, state)
         : reactOutput(parseTree, state)
     } catch (e) {


### PR DESCRIPTION
@keybase/react-hackers 

Before above, after below:

<img width="1183" alt="Screen Shot 2019-04-29 at 8 20 26 AM" src="https://user-images.githubusercontent.com/21217/56906788-d03f0200-6a57-11e9-8b42-4c3ec296d0df.png">
