### PR TITLE
fix erroring chat send command and shim errors for better readability

### DIFF
--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -148,24 +148,17 @@ func (r *chatConversationResolver) resolveWithCliUIInteractively(ctx context.Con
 func (r *chatConversationResolver) create(ctx context.Context, req chatConversationResolvingRequest) (
 	conversationInfo *chat1.ConversationLocal, err error) {
 
+	if len(req.TlfName) == 0 {
+		return nil, errors.New("Cannot create a new conversation without more information")
+	}
+
 	var newConversation string
 	if req.TopicType == chat1.TopicType_CHAT {
 		newConversation = fmt.Sprintf("Creating a new %s %s conversation", req.Visibility, req.TopicType)
 	} else {
 		newConversation = fmt.Sprintf("Creating a new %s %s conversation [%s]", req.Visibility, req.TopicType, req.TopicName)
 	}
-
-	if len(req.TlfName) == 0 {
-		tlfName, err := r.G.UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatTLFName, fmt.Sprintf(
-			"No conversation found. %s. Hit Ctrl-C to cancel, or specify a TLF name to continue: ",
-			newConversation))
-		if err != nil {
-			return nil, err
-		}
-		req.TlfName = tlfName
-	} else {
-		r.G.UI.GetTerminalUI().Printf("%s\n", newConversation)
-	}
+	r.G.UI.GetTerminalUI().Printf("%s\n", newConversation)
 
 	var tnp *string
 	if len(req.TopicName) > 0 {

--- a/go/client/chat_send_common.go
+++ b/go/client/chat_send_common.go
@@ -48,7 +48,12 @@ func chatSend(ctx context.Context, g *libkb.GlobalContext, c ChatSendArg) error 
 		Interactive:       c.hasTTY,
 		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
 	})
-	if err != nil {
+	switch err.(type) {
+	case nil:
+		break
+	case libkb.ResolutionError:
+		return fmt.Errorf("could not resolve `%s` into Keybase user(s) or a team", c.resolvingRequest.TlfName)
+	default:
 		return err
 	}
 	conversationInfo := conversation.Info

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -83,10 +83,20 @@ func (c *CmdChatSend) Run() (err error) {
 		return err
 	}
 
-	if c.resolvingRequest.TlfName != "" {
-		if err = annotateResolvingRequest(c.G(), &c.resolvingRequest); err != nil {
+	// if no tlfname specified, request one
+	if c.resolvingRequest.TlfName == "" {
+		c.resolvingRequest.TlfName, err = c.G().UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatTLFName,
+			"Specify a team name, a single receiving user, or a comma-separated list of users (e.g. alice,bob,charlie) to continue: ")
+		if err != nil {
 			return err
 		}
+		if c.resolvingRequest.TlfName == "" {
+			return fmt.Errorf("no user or team name specified")
+		}
+	}
+
+	if err = annotateResolvingRequest(c.G(), &c.resolvingRequest); err != nil {
+		return err
 	}
 	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
 	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {


### PR DESCRIPTION
there were weird, unintuitive errors in `keybase chat send _____` and `keybase chat send` without a specified tlf. i'm not really sure i did this right.

1. instead of interactively requesting a tlf deep in the resolution process, i pulled this up closer to the beginning of the command. this makes the errors a lot more consistent, and it did not appear that this was being used for any other flows than this one. 
2. catch resolution errors (now more consistent) and replace them with something a little more user friendly. 