### PR TITLE
SFMIBanner: disable showing on linux

### DIFF
--- a/shared/fs/folder/container.js
+++ b/shared/fs/folder/container.js
@@ -4,6 +4,7 @@ import {namedConnect} from '../../util/container'
 import Folder from '.'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
+import * as PlatformConstants from '../../constants/platform'
 import * as FsGen from '../../actions/fs-gen'
 
 const mapStateToProps = (state, {path}) => ({
@@ -11,7 +12,7 @@ const mapStateToProps = (state, {path}) => ({
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
   _username: state.config.username,
   resetBannerType: Constants.resetBannerType(state, path),
-  shouldShowSFMIBanner: state.fs.sfmi.showingBanner,
+  shouldShowSFMIBanner: state.fs.sfmi.showingBanner && !PlatformConstants.isLinux,
 })
 
 const mapDispatchToProps = (dispatch, {path}: OwnProps) => ({


### PR DESCRIPTION
Disable showing the system file manager integration banner on linux, even
when it thinks it should be showing. I'm not confident that this is the right
approach, but the user log did not enlighten me as to why the banner was
appearing at all, so this seemed like the simplest approach.

Issue: KBFS-4084