### PR TITLE
Ease up on ExperimentalGenericProofs feature flag

### DIFF
--- a/go/externals/proof_service_facebook.go
+++ b/go/externals/proof_service_facebook.go
@@ -62,10 +62,6 @@ func (t *FacebookServiceType) GetPrompt() string {
 	return "Your username on Facebook"
 }
 
-func (t *FacebookServiceType) CanMakeNewProofs(mctx libkb.MetaContext) bool {
-	return t.BaseServiceType.CanMakeNewProofs(mctx)
-}
-
 func (t *FacebookServiceType) ToServiceJSON(un string) *jsonw.Wrapper {
 	return t.BaseToServiceJSON(t, un)
 }

--- a/go/externals/services.go
+++ b/go/externals/services.go
@@ -84,8 +84,9 @@ func (p *proofServices) ListServicesThatAcceptNewProofs(mctx libkb.MetaContext) 
 	defer p.Unlock()
 	p.loadServiceConfigs()
 	var services []serviceAndPriority
+	experimentalGenericProofs := mctx.G().FeatureFlags.Enabled(mctx, libkb.ExperimentalGenericProofs)
 	for k, v := range p.externalServices {
-		if v.CanMakeNewProofs(mctx) {
+		if experimentalGenericProofs || v.CanMakeNewProofsSkipFeatureFlag(mctx) {
 			s := serviceAndPriority{name: k, priority: v.DisplayPriority()}
 			services = append(services, s)
 		}

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -627,6 +627,7 @@ type ServiceType interface {
 	MakeProofChecker(l RemoteProofChainLink) ProofChecker
 	SetDisplayConfig(*keybase1.ServiceDisplayConfig)
 	CanMakeNewProofs(mctx MetaContext) bool
+	CanMakeNewProofsSkipFeatureFlag(mctx MetaContext) bool
 	DisplayPriority() int
 	DisplayGroup() string
 	IsNew(MetaContext) bool

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -185,6 +185,18 @@ func (t *BaseServiceType) CanMakeNewProofs(mctx MetaContext) bool {
 	return !t.displayConf.CreationDisabled
 }
 
+func (t *BaseServiceType) CanMakeNewProofsSkipFeatureFlag(mctx MetaContext) bool {
+	t.Lock()
+	defer t.Unlock()
+	if mctx.G().GetEnv().GetProveBypass() {
+		return true
+	}
+	if t.displayConf == nil {
+		return true
+	}
+	return !t.displayConf.CreationDisabled
+}
+
 func (t *BaseServiceType) IsNew(mctx MetaContext) bool {
 	if t.displayConf == nil {
 		return false

--- a/go/libkb/services.go
+++ b/go/libkb/services.go
@@ -171,21 +171,14 @@ func (t *BaseServiceType) DisplayGroup() string {
 }
 
 func (t *BaseServiceType) CanMakeNewProofs(mctx MetaContext) bool {
-	t.Lock()
-	defer t.Unlock()
-	if mctx.G().GetEnv().GetProveBypass() {
-		return true
-	}
-	if t.displayConf == nil {
-		return true
-	}
-	if mctx.G().FeatureFlags.Enabled(mctx, ExperimentalGenericProofs) {
-		return true
-	}
-	return !t.displayConf.CreationDisabled
+	return t.canMakeNewProofsHelper(mctx, false)
 }
 
 func (t *BaseServiceType) CanMakeNewProofsSkipFeatureFlag(mctx MetaContext) bool {
+	return t.canMakeNewProofsHelper(mctx, true)
+}
+
+func (t *BaseServiceType) canMakeNewProofsHelper(mctx MetaContext, skipFeatureFlag bool) bool {
 	t.Lock()
 	defer t.Unlock()
 	if mctx.G().GetEnv().GetProveBypass() {
@@ -193,6 +186,11 @@ func (t *BaseServiceType) CanMakeNewProofsSkipFeatureFlag(mctx MetaContext) bool
 	}
 	if t.displayConf == nil {
 		return true
+	}
+	if !skipFeatureFlag {
+		if mctx.G().FeatureFlags.Enabled(mctx, ExperimentalGenericProofs) {
+			return true
+		}
 	}
 	return !t.displayConf.CreationDisabled
 }


### PR DESCRIPTION
Hit `FeatureFlagSet` once per ProofSuggestions call instead of once per proof type. Don't know if the cpu effect matters but it will stop logging this line so many times
```
2019-04-29T11:59:12.385349-04:00 ▶ [DEBU keybase features.go:150] 10c3 Feature (cached) "experimental_generic_proofs" -> false [tags:FEAT=xPPKIV9ht5tl,PV=vnYBZ07NgUCC]
```