### PR TITLE
Stop propagation of inline dropdown

### DIFF
--- a/shared/common-adapters/dropdown.js
+++ b/shared/common-adapters/dropdown.js
@@ -16,7 +16,7 @@ type DropdownButtonProps = {
   selectedBoxStyle?: Styles.StylesCrossPlatform,
   style?: Styles.StylesCrossPlatform,
   setAttachmentRef?: $PropertyType<OverlayParentProps, 'setAttachmentRef'>,
-  toggleOpen: () => void,
+  toggleOpen: (e: SyntheticEvent<>) => void,
   inline?: boolean,
 }
 export const DropdownButton = (props: DropdownButtonProps) => (
@@ -118,7 +118,10 @@ export const InlineDropdown = (props: InlineDropdownProps) => {
     <DropdownButton
       inline={true}
       style={styles.inlineDropdown}
-      toggleOpen={props.onPress}
+      toggleOpen={e => {
+        e.stopPropagation && e.stopPropagation()
+        props.onPress && props.onPress()
+      }}
       selectedBoxStyle={styles.inlineDropdownSelected}
       selected={selected}
     />


### PR DESCRIPTION
@keybase/react-hackers 

In this case inline dropdown was inside a checkbox component. The event from clicking the dropdown propagated up to the checkbox component. I made the fix inside inline dropdown because I don't think you ever want the click to propagate and having callers do this seems tedious & error prone.