### PR TITLE
plumb text break to text. apply to paper key to remove hypens

### DIFF
--- a/shared/common-adapters/text.js.flow
+++ b/shared/common-adapters/text.js.flow
@@ -31,6 +31,7 @@ type Props = {|
   plainText?: boolean,
   selectable?: boolean,
   style?: StylesCrossPlatform,
+  textBreakStrategy?: 'simple' | 'highQuality' | 'balanced', // android only
   title?: ?string,
   type: TextType,
   underline?: boolean,

--- a/shared/common-adapters/text.native.js
+++ b/shared/common-adapters/text.native.js
@@ -117,6 +117,7 @@ class Text extends Component<Props> {
           this._nativeText = ref
         }}
         selectable={this.props.selectable}
+        textBreakStrategy={this.props.textBreakStrategy}
         style={style}
         {...lineClamp(this.props.lineClamp, this.props.ellipsizeMode)}
         onPress={onPress}

--- a/shared/devices/paper-key/index.js
+++ b/shared/devices/paper-key/index.js
@@ -37,7 +37,13 @@ class PaperKey extends React.Component<Props, State> {
           </Kb.Text>
           <Kb.Box2 direction="vertical" style={styles.keyBox} centerChildren={true} fullWidth={true}>
             {this.props.paperkey ? (
-              <Kb.Text center={true} type="Header" selectable={true} style={styles.text}>
+              <Kb.Text
+                center={true}
+                type="Header"
+                selectable={true}
+                style={styles.text}
+                textBreakStrategy="simple"
+              >
                 {this.props.paperkey}
               </Kb.Text>
             ) : (


### PR DESCRIPTION
@keybase/react-hackers removes extra hypens in paper keys when width is small