### PR TITLE
Remove extra header space android

### DIFF
--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -106,7 +106,7 @@ export class HeaderHocHeader extends React.Component<Props, State> {
       </Box>
     )
 
-    return flags.useNewRouter && !this.props.underNotch ? <SafeAreaViewTop>{header}</SafeAreaViewTop> : header
+    return header
   }
 }
 

--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -106,7 +106,10 @@ export class HeaderHocHeader extends React.Component<Props, State> {
       </Box>
     )
 
-    return header
+    if (Styles.isAndroid) {
+      return header
+    }
+    return flags.useNewRouter && !this.props.underNotch ? <SafeAreaViewTop>{header}</SafeAreaViewTop> : header
   }
 }
 

--- a/shared/fs/nav-header/mobile-header.js
+++ b/shared/fs/nav-header/mobile-header.js
@@ -64,7 +64,7 @@ const styles = Styles.styleSheetCreate({
   },
   container: {
     backgroundColor: Styles.globalColors.white,
-    paddingTop: isIPhoneX ? 45 : 20,
+    paddingTop: isIPhoneX ? 45 : Styles.isAndroid ? undefined : 20,
   },
   expandedTitleContainer: {
     backgroundColor: Styles.globalColors.white,

--- a/shared/profile/search/index.native.js
+++ b/shared/profile/search/index.native.js
@@ -7,8 +7,8 @@ import * as Styles from '../../styles'
 import type {Props} from '.'
 import {searchKey, placeholder} from './index.shared'
 
-const Search = (props: Props) => (
-  <Kb.SafeAreaViewTop>
+const Search = (props: Props) => {
+  const search = (
     <Kb.StandardScreen
       headerStyle={headerStyle}
       style={styleContainer}
@@ -24,8 +24,14 @@ const Search = (props: Props) => (
       />
       <ResultsList searchKey={searchKey} onClick={props.onClick} disableListBuilding={true} />
     </Kb.StandardScreen>
-  </Kb.SafeAreaViewTop>
-)
+  )
+
+  if (Styles.isAndroid) {
+    return search
+  }
+
+  return <Kb.SafeAreaViewTop>{search}</Kb.SafeAreaViewTop>
+}
 
 const headerStyle = {
   backgroundColor: Styles.globalColors.white,


### PR DESCRIPTION
@keybase/react-hackers Not a real solution, but if we want to ship android this should do the trick for now. I still need to figure out exactly why this is a problem on android, but not ios.


!only merge if there isn't a better solution!