### PR TITLE
Add APISessionTypeOPTIONAL to user/lookup calls

### DIFF
--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -549,7 +549,7 @@ func LoadUserFromServer(m MetaContext, uid keybase1.UID, body *jsonw.Wrapper) (u
 	if body == nil {
 		res, err := m.G().API.Get(m, APIArg{
 			Endpoint:    "user/lookup",
-			SessionType: APISessionTypeNONE,
+			SessionType: APISessionTypeOPTIONAL,
 			Args: HTTPArgs{
 				"uid":          UIDArg(uid),
 				"load_deleted": B{true},

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -331,7 +331,7 @@ func (r *ResolverImpl) resolveURLViaServerLookup(m MetaContext, au AssertionURL,
 	ha.Add("fields", S{fields})
 	ares, res.err = m.G().API.Get(m, APIArg{
 		Endpoint:        "user/lookup",
-		SessionType:     APISessionTypeNONE,
+		SessionType:     APISessionTypeOPTIONAL,
 		Args:            ha,
 		AppStatusCodes:  []int{SCOk, SCNotFound, SCDeleted},
 		RetryCount:      3,

--- a/go/systests/team_reset_test.go
+++ b/go/systests/team_reset_test.go
@@ -839,6 +839,14 @@ func TestTeamAfterDeleteUser(t *testing.T) {
 	kickTeamRekeyd(ann.getPrimaryGlobalContext(), t)
 	ann.delete()
 
+	{
+		// See if bob can still load ann after delete. They used to be in the
+		// same team, so he should be able to.
+		arg := libkb.NewLoadUserArg(bob.getPrimaryGlobalContext()).WithUID(ann.uid()).WithPublicKeyOptional().WithForcePoll(true)
+		_, _, err := bob.getPrimaryGlobalContext().GetUPAKLoader().LoadV2(arg)
+		require.NoError(t, err)
+	}
+
 	bob.pollForMembershipUpdate(team, keybase1.PerTeamKeyGeneration(2), nil)
 
 	divDebug(ctx, "Deleted ann (%s)", ann.username)


### PR DESCRIPTION
If the server checks for readability of users in user/lookup calls, we need to present a valid session so API can serve us deleted users we are eligible to see.