### PR TITLE
prefetcher: delay the disk cache checks for inline block requests

### DIFF
--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -380,8 +380,8 @@ func (brq *blockRetrievalQueue) PutInCaches(ctx context.Context,
 
 // checkCaches copies a block into `block` if it's in one of our caches.
 func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
-	kmd libkey.KeyMetadata, ptr data.BlockPointer, block data.Block, action BlockRequestAction) (
-	PrefetchStatus, error) {
+	kmd libkey.KeyMetadata, ptr data.BlockPointer, block data.Block,
+	action BlockRequestAction) (PrefetchStatus, error) {
 	dbc := brq.config.DiskBlockCache()
 	preferredCacheType := action.CacheType()
 
@@ -401,7 +401,7 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 		// If the prefetch status wasn't in the preferred cache, do a
 		// full `Get()` below in an attempt to move the full block
 		// into the preferred cache.
-	} else if dbc == nil {
+	} else if dbc == nil || action.DelayCacheCheck() {
 		return NoPrefetch, err
 	}
 

--- a/go/kbfs/libkbfs/block_retrieval_worker.go
+++ b/go/kbfs/libkbfs/block_retrieval_worker.go
@@ -103,6 +103,15 @@ func (brw *blockRetrievalWorker) HandleRequest() (err error) {
 	}
 
 	cacheType = action.CacheType()
+	if action.DelayCacheCheck() {
+		_, err := brw.queue.checkCaches(
+			retrieval.ctx, retrieval.kmd, retrieval.blockPtr, block,
+			action.WithoutDelayedCacheCheckAction())
+		if err == nil {
+			return nil
+		}
+	}
+
 	return brw.getBlock(
 		retrieval.ctx, retrieval.kmd, retrieval.blockPtr, block, cacheType)
 }

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -647,7 +647,8 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 		}
 
 		ch := p.retriever.Request(
-			pre.ctx, priority, kmd, ptr, block.NewEmpty(), lifetime, action)
+			pre.ctx, priority, kmd, ptr, block.NewEmpty(), lifetime,
+			action.DelayedCacheCheckAction())
 		p.inFlightFetches.In() <- ch
 	}
 	parentPre, isParentWaiting := p.prefetches[parentPtr.ID]


### PR DESCRIPTION
When processing the child blocks to prefetch, don't wait for the disk cache check.  Instead, relegate it to the block worker, so the prefetch can complete more quickly.

Issue: KBFS-4904