### PR TITLE
misc nav2+ fixes

### DIFF
--- a/shared/chat/conversation-filter-input.js
+++ b/shared/chat/conversation-filter-input.js
@@ -99,7 +99,6 @@ class ConversationFilterInput extends React.PureComponent<Props> {
           gap="tiny"
           style={Styles.collapseStyles([
             styles.containerNotFiltering,
-            flags.useNewRouter && Styles.isMobile && styles.containerWithBackButton,
             flags.useNewRouter && !Styles.isMobile && styles.whiteBg,
             this.props.style,
           ])}
@@ -108,9 +107,6 @@ class ConversationFilterInput extends React.PureComponent<Props> {
           fullWidth={true}
         >
           <Kb.Box2 alignItems="center" direction="horizontal" style={styles.searchBox}>
-            {flags.useNewRouter && Styles.isMobile && (
-              <Kb.BackButton onClick={this.props.onBack} style={styles.backButton} />
-            )}
             <Kb.ClickableBox style={styles.filterContainer} onClick={this.props.onStartSearch}>
               <Kb.Icon
                 type="iconfont-search"
@@ -152,9 +148,6 @@ class ConversationFilterInput extends React.PureComponent<Props> {
 }
 
 const styles = Styles.styleSheetCreate({
-  backButton: {
-    ...Styles.padding(Styles.globalMargins.tiny, 0),
-  },
   containerFiltering: Styles.platformStyles({
     common: {
       position: 'relative',
@@ -187,9 +180,6 @@ const styles = Styles.styleSheetCreate({
       backgroundColor: Styles.globalColors.fastBlank,
     },
   }),
-  containerWithBackButton: {
-    ...Styles.padding(0, Styles.globalMargins.tiny, 0, 0), // back button adds the left space
-  },
   filterContainer: Styles.platformStyles({
     common: {
       ...Styles.globalStyles.flexBoxRow,
@@ -234,6 +224,7 @@ const styles = Styles.styleSheetCreate({
   searchBox: Styles.platformStyles({
     common: {flex: 1},
     isElectron: Styles.desktopStyles.windowDraggingClickable,
+    isMobile: {...Styles.padding(6, 0)},
   }),
   text: Styles.platformStyles({
     common: {

--- a/shared/common-adapters/usernames/index.js
+++ b/shared/common-adapters/usernames/index.js
@@ -100,7 +100,14 @@ function UsernameText(props: Props) {
               negative={backgroundModeIsNegative(props.backgroundMode)}
               className={Styles.classNames({'hover-underline': props.underline})}
               selectable={props.selectable}
-              onClick={_onUsernameClicked ? () => _onUsernameClicked(u.username) : undefined}
+              onClick={
+                _onUsernameClicked
+                  ? evt => {
+                      evt && evt.stopPropagation()
+                      _onUsernameClicked(u.username)
+                    }
+                  : undefined
+              }
               style={userStyle}
             >
               {u.username}

--- a/shared/devices/index.js
+++ b/shared/devices/index.js
@@ -169,7 +169,6 @@ const paperKeyNudgeStyles = Styles.styleSheetCreate({
   container: Styles.platformStyles({
     common: {
       padding: Styles.globalMargins.small,
-      paddingTop: 0,
     },
     isMobile: {
       padding: Styles.globalMargins.tiny,

--- a/shared/fs/container.js
+++ b/shared/fs/container.js
@@ -143,7 +143,9 @@ Connected.navigationOptions = ({navigation}: {navigation: any}) => {
   const path = navigation.getParam('path') || Constants.defaultPath
   return isMobile
     ? {
-        header: <MobileHeader path={path} onBack={navigation.pop} />,
+        header: (
+          <MobileHeader path={path} onBack={navigation.isFirstRouteInParent() ? null : navigation.pop} />
+        ),
         headerHeight: mobileHeaderHeight,
       }
     : {

--- a/shared/fs/nav-header/mobile-header.js
+++ b/shared/fs/nav-header/mobile-header.js
@@ -12,7 +12,7 @@ import flags from '../../util/feature-flags'
 type BannerType = 'none' | 'offline'
 type Props = {|
   bannerType: BannerType,
-  onBack: () => void,
+  onBack: ?() => void,
   path: Types.Path,
 |}
 type State = {|
@@ -42,7 +42,9 @@ class MobileHeader extends React.PureComponent<Props, State> {
           <Kbfs.FolderViewFilter path={this.props.path} onCancel={this._filterDone} />
         ) : (
           <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.expandedTopContainer}>
-            <Kb.BackButton badgeNumber={0 /* TODO KBFS-4109 */} onClick={this.props.onBack} />
+            {this.props.onBack && (
+              <Kb.BackButton badgeNumber={0 /* TODO KBFS-4109 */} onClick={this.props.onBack} />
+            )}
             <Kb.Box style={styles.gap} />
             <Actions path={this.props.path} onTriggerFilterMobile={this._triggerFilterMobile} />
           </Kb.Box2>
@@ -89,7 +91,7 @@ const styles = Styles.styleSheetCreate({
 
 type OwnProps = {|
   path: Types.Path,
-  onBack: () => void,
+  onBack: ?() => void,
 |}
 
 const mapStateToProps = (state, {path}: OwnProps) => ({

--- a/shared/router-v2/router.desktop.js
+++ b/shared/router-v2/router.desktop.js
@@ -27,11 +27,22 @@ import OutOfDate from '../app/out-of-date'
  * Modal screens
  * Floating screens
  *
- * You have 2 nested routers, a normal stack and modal stack
+ * You have 2 nested routers, a tab router and modal stack
  * When the modal has a valid route ModalView is rendered, which renders AppView underneath
  * When there are no modals AppView is rendered
  * Floating is rendered to a portal on top
  */
+
+// We could have subnavigators, so traverse the routes so we can get the active
+// screen's index so we know when to enable the back button. Note this doesn't
+// support a subnavigator with a root you can hit back from.
+const getActiveIndex = navState => {
+  const route = navState.routes[navState.index]
+  if (route.routes) {
+    return getActiveIndex(route)
+  }
+  return navState.index
+}
 
 // The app with a tab bar on the left and content area on the right
 // A single content view and n-modals on top
@@ -45,6 +56,7 @@ class AppView extends React.PureComponent<any> {
     const selectedTab = nameToTab[descriptor.state.routeName]
     // transparent headers use position absolute and need to be rendered last so they go on top w/o zindex
     const direction = descriptor.options.headerTransparent ? 'vertical' : 'verticalReverse'
+    const activeIndex = getActiveIndex(navigation.state)
 
     const sceneView = (
       <SceneView
@@ -74,8 +86,8 @@ class AppView extends React.PureComponent<any> {
           <Header
             loggedIn={!!selectedTab}
             options={descriptor.options}
-            onPop={() => childNav.goBack()}
-            allowBack={index !== 0}
+            onPop={() => childNav.pop()}
+            allowBack={activeIndex !== 0}
           />
         </Kb.Box2>
       </Kb.Box2>

--- a/shared/router-v2/router.native.js
+++ b/shared/router-v2/router.native.js
@@ -28,13 +28,8 @@ const defaultNavigationOptions = {
   backBehavior: 'none',
   header: null,
   headerLeft: hp => {
-    return (
-      <LeftAction
-        badgeNumber={0}
-        leftAction="back"
-        onLeftAction={hp.onPress}
-        disabled={hp.scene.index === 0}
-      />
+    return hp.scene.index === 0 ? null : (
+      <LeftAction badgeNumber={0} leftAction="back" onLeftAction={hp.onPress} />
     )
   },
   headerTitle: hp => (

--- a/shared/teams/container.js
+++ b/shared/teams/container.js
@@ -6,7 +6,6 @@ import * as FsConstants from '../constants/fs'
 import * as FsTypes from '../constants/types/fs'
 import * as GregorGen from '../actions/gregor-gen'
 import * as TeamsGen from '../actions/teams-gen'
-import * as Styles from '../styles'
 import Teams from './main'
 import {HeaderRightActions} from './main/header'
 import openURL from '../util/open-url'
@@ -132,11 +131,7 @@ const ConnectedHeaderRightActions = connect<{}, _, _, _, _>(
 Connected.navigationOptions = {
   header: undefined,
   headerRightActions: () => <ConnectedHeaderRightActions />,
-  headerTitle: () => (
-    <Kb.Text type="Header" style={{marginLeft: Styles.globalMargins.xsmall}}>
-      Teams
-    </Kb.Text>
-  ),
+  headerTitle: 'Teams',
   title: 'Teams',
 }
 


### PR DESCRIPTION
* Remove back button from mobile tab roots
* `stopPropagation` in username `onUsernameClicked` (fixes clicking username in tx row) (this most likely broke with nav2)
* fix hitting back from inside the wallets subnavigator

r? @keybase/react-hackers 