### PR TITLE
Marco: Remove extra Android vertical spacing, rebased

### DIFF
--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -106,7 +106,7 @@ export class HeaderHocHeader extends React.Component<Props, State> {
       </Box>
     )
 
-    return flags.useNewRouter && !this.props.underNotch ? <SafeAreaViewTop>{header}</SafeAreaViewTop> : header
+    return header
   }
 }
 

--- a/shared/common-adapters/header-hoc/index.native.js
+++ b/shared/common-adapters/header-hoc/index.native.js
@@ -106,7 +106,10 @@ export class HeaderHocHeader extends React.Component<Props, State> {
       </Box>
     )
 
-    return header
+    if (Styles.isAndroid) {
+      return header
+    }
+    return flags.useNewRouter && !this.props.underNotch ? <SafeAreaViewTop>{header}</SafeAreaViewTop> : header
   }
 }
 

--- a/shared/fs/nav-header/mobile-header.js
+++ b/shared/fs/nav-header/mobile-header.js
@@ -70,7 +70,7 @@ const styles = Styles.styleSheetCreate({
     height,
     maxHeight: height,
     minHeight: height,
-    paddingTop: Styles.statusBarHeight,
+    paddingTop: Styles.isAndroid ? undefined : Styles.statusBarHeight,
   },
   expandedTitleContainer: {
     backgroundColor: Styles.globalColors.white,

--- a/shared/profile/search/index.native.js
+++ b/shared/profile/search/index.native.js
@@ -7,8 +7,8 @@ import * as Styles from '../../styles'
 import type {Props} from '.'
 import {searchKey, placeholder} from './index.shared'
 
-const Search = (props: Props) => (
-  <Kb.SafeAreaViewTop>
+const Search = (props: Props) => {
+  const search = (
     <Kb.StandardScreen
       headerStyle={headerStyle}
       style={styleContainer}
@@ -24,8 +24,14 @@ const Search = (props: Props) => (
       />
       <ResultsList searchKey={searchKey} onClick={props.onClick} disableListBuilding={true} />
     </Kb.StandardScreen>
-  </Kb.SafeAreaViewTop>
-)
+  )
+
+  if (Styles.isAndroid) {
+    return search
+  }
+
+  return <Kb.SafeAreaViewTop>{search}</Kb.SafeAreaViewTop>
+}
 
 const headerStyle = {
   backgroundColor: Styles.globalColors.white,


### PR DESCRIPTION
@keybase/react-hackers 

@MarcoPolo's #17257 wasn't opened against master, so this is that PR rebased against master.  There were conflicts -- I'm changing this line of Marco's:
```js
    paddingTop: isIPhoneX ? 45 : Styles.isAndroid ? undefined : 20,
```
to:
```js
    paddingTop: Styles.isAndroid ? undefined : Styles.statusBarHeight,
```
... since as I understand it statusBarHeight already encapsulates the 45/20 difference via `react-native-iphonex-helper`.