### PR TITLE
Fix leaving a team on mobile not naving away afterwards

### DIFF
--- a/shared/actions/teams.js
+++ b/shared/actions/teams.js
@@ -157,7 +157,7 @@ const leaveTeam = (state, action) => {
 
 const leftTeam = (state, action) => {
   if (flags.useNewRouter) {
-    return RouteTreeGen.createNavUpToScreen({routeName: teamsTab})
+    return RouteTreeGen.createNavUpToScreen({routeName: 'teamsRoot'})
   }
   const selectedTeamnames = Constants.getSelectedTeamNames(state)
   if (selectedTeamnames.includes(action.payload.teamname)) {

--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -126,7 +126,7 @@ const routeTree = () => {
 export default routeTree
 
 export const newRoutes = {
-  'settingsTabs.teamsTab': {getScreen: () => require('./container').default, upgraded: true},
+  'tabs.teamsTab': {getScreen: () => require('./container').default, upgraded: true},
   team: {getScreen: () => require('./team/container').default, upgraded: true},
   teamMember: {getScreen: () => require('./team/member/container').default, upgraded: true},
   teamsRoot: {getScreen: () => require('./container').default, upgraded: true},


### PR DESCRIPTION
@keybase/react-hackers 

Some kind of mismerge here, I think -- SettingsTabs.teamsTab went away altogether when Teams was promoted back to the main mobile nav, but was reintroduced today in place of the main teamsTab route.  I think we can just nav directly to teamsRoot.