### PR TITLE
remove 'tabs.teamsTab' route key from stack router

### DIFF
--- a/shared/teams/routes.js
+++ b/shared/teams/routes.js
@@ -126,7 +126,6 @@ const routeTree = () => {
 export default routeTree
 
 export const newRoutes = {
-  'tabs.teamsTab': {getScreen: () => require('./container').default, upgraded: true},
   team: {getScreen: () => require('./team/container').default, upgraded: true},
   teamMember: {getScreen: () => require('./team/member/container').default, upgraded: true},
   teamsRoot: {getScreen: () => require('./container').default, upgraded: true},


### PR DESCRIPTION
So when the tab bar `navigate`s
https://github.com/keybase/client/blob/f9200a94519355fec17d23bf8b124f2431d670e5/shared/router-v2/tab-bar/container.desktop.js#L42
it'll correctly "bubble" (is there a better word for this?) up to the `SwitchRouter` instead of pushing the teams list on the current tab. r? @keybase/react-hackers 