### PR TITLE
cr_chains: when identifying types, handle self-contained subdirs

### DIFF
--- a/go/kbfs/kbfsblock/id.go
+++ b/go/kbfs/kbfsblock/id.go
@@ -100,19 +100,30 @@ func (id *ID) HashType() kbfshash.HashType {
 	return id.h.GetHashType()
 }
 
-// MakeTemporaryID generates a temporary block ID using a CSPRNG. This
-// is used for indirect blocks before they're committed to the server.
-func MakeTemporaryID() (ID, error) {
+func makeRandomID(ht kbfshash.HashType) (ID, error) {
 	var dh kbfshash.RawDefaultHash
 	err := kbfscrypto.RandRead(dh[:])
 	if err != nil {
 		return ID{}, err
 	}
-	h, err := kbfshash.HashFromRaw(kbfshash.DefaultHashType, dh[:])
+	h, err := kbfshash.HashFromRaw(ht, dh[:])
 	if err != nil {
 		return ID{}, err
 	}
 	return ID{h}, nil
+}
+
+// MakeTemporaryID generates a temporary block ID with an invalid hash
+// type using a CSPRNG. This is used for indirect blocks before
+// they're committed to the server.
+func MakeTemporaryID() (ID, error) {
+	return makeRandomID(kbfshash.TemporaryHashType)
+}
+
+// MakeFakeID generates a fake block ID with a valid hash type using a
+// CSPRNG. This is used for fake block IDs in tests.
+func MakeFakeID() (ID, error) {
+	return makeRandomID(kbfshash.DefaultHashType)
 }
 
 const (

--- a/go/kbfs/kbfshash/hash.go
+++ b/go/kbfs/kbfshash/hash.go
@@ -58,6 +58,10 @@ const (
 
 	// MaxHashType is the highest-supported hash type.
 	MaxHashType HashType = SHA256HashV2
+
+	// TemporaryHashType is a hash type to be used for random
+	// byte-strings that can be used in place of real hashes.
+	TemporaryHashType HashType = 0xff
 )
 
 // MaxDefaultHash is the maximum value of RawDefaultHash

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -71,7 +71,7 @@ func (c testBlockRetrievalConfig) blockGetter() blockGetter {
 }
 
 func makeRandomBlockPointer(t *testing.T) data.BlockPointer {
-	id, err := kbfsblock.MakeTemporaryID()
+	id, err := kbfsblock.MakeFakeID()
 	require.NoError(t, err)
 	return data.BlockPointer{
 		ID:         id,

--- a/go/kbfs/libkbfs/cr_chains.go
+++ b/go/kbfs/libkbfs/cr_chains.go
@@ -285,8 +285,12 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 			"Can't find parent dir chain, unref=%s/ref=%s, for op %s (file=%s)",
 			lastSetAttr.Dir.Unref, lastSetAttr.Dir.Ref,
 			lastSetAttr, lastSetAttr.File)
-		// Fall through and hope we can still look up the parent's
-		// block and find the entry.
+
+		// If the parent still can't be found, then likely the whole
+		// directory was created and deleted within this update, so it
+		// should be treated as deleted.
+		chains.deletedOriginals[cc.original] = true
+		return nil
 	}
 
 	// We have to find the current parent directory block.  If the

--- a/go/kbfs/libkbfs/cr_chains.go
+++ b/go/kbfs/libkbfs/cr_chains.go
@@ -286,9 +286,9 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 			lastSetAttr.Dir.Unref, lastSetAttr.Dir.Ref,
 			lastSetAttr, lastSetAttr.File)
 
-		// If the parent still can't be found, then likely the whole
-		// directory was created and deleted within this update, so it
-		// should be treated as deleted.
+		// If the parent still can't be found, then barring bugs the
+		// whole directory was created and deleted within this update,
+		// so it should be treated as deleted.
 		chains.deletedOriginals[cc.original] = true
 		return nil
 	}

--- a/go/kbfs/test/cr_simple_test.go
+++ b/go/kbfs/test/cr_simple_test.go
@@ -1471,3 +1471,33 @@ func TestCrBothTruncateFileUnmergedWrite(t *testing.T) {
 		),
 	)
 }
+
+// bob creates a dir, creates a file in dir, setattrs the file,
+// removes the file, and removes the dir, all while unmerged.
+// Regression test for KBFS-4114.
+func TestCrSetattrRemovedFileInRemovedDir(t *testing.T) {
+	targetMtime1 := time.Now().Add(1 * time.Minute)
+	test(t,
+		users("alice", "bob"),
+		as(alice,
+			mkdir("a"),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			mkdir("a/b"),
+		),
+		as(bob, noSync(),
+			mkdir("a/c/d"),
+			setmtime("a/c/d", targetMtime1),
+			rm("a/c/d"),
+			rmdir("a/c"),
+			reenableUpdates(),
+			lsdir("a/", m{"b$": "DIR"}),
+		),
+		as(alice,
+			lsdir("a/", m{"b$": "DIR"}),
+		),
+	)
+}


### PR DESCRIPTION
If a directory was both created and deleted within a branch, and a file within that directory was created, set-attr'd, and deleted within the branch as well, we had a bug where CR couldn't complete because it choked on trying to find the deleted file's entry in the deleted parent block, and the parent block couldn't be fetched from anywhere.

In this case, just assume the file has been deleted, and return early.

Also adds a test that repros the failure.

Finally, tracking down this issue was made harder by the fact that the logs contained error messages for seemingly-normal block IDs, so I burned a lot of time trying to figure out if the blocks were somehow deleted from the servers.  So this PR also makes temporary block IDs (the ones that persist in the `setAttrOp` of the removed file) obvious by giving them an invalid ID prefix.

Issue: KBFS-4114