### PR TITLE
In scankeys, add all synced secret key, not just one at random

### DIFF
--- a/go/engine/scankeys.go
+++ b/go/engine/scankeys.go
@@ -59,7 +59,7 @@ func NewScanKeys(m libkb.MetaContext) (sk *ScanKeys, err error) {
 		return nil, fmt.Errorf("loadme error: %s", err)
 	}
 
-	// if user provided, then load their local keys, and their synced secret key:
+	// if user provided, then load their local keys, and their synced secret keys:
 	synced, err := sk.me.GetSyncedSecretKeys(m)
 	if err != nil {
 		return nil, fmt.Errorf("getsyncedsecret err: %s", err)

--- a/go/engine/scankeys.go
+++ b/go/engine/scankeys.go
@@ -60,7 +60,7 @@ func NewScanKeys(m libkb.MetaContext) (sk *ScanKeys, err error) {
 	}
 
 	// if user provided, then load their local keys, and their synced secret key:
-	synced, err := sk.me.GetSyncedSecretKey(m)
+	synced, err := sk.me.GetSyncedSecretKeys(m)
 	if err != nil {
 		return nil, fmt.Errorf("getsyncedsecret err: %s", err)
 	}
@@ -195,7 +195,7 @@ func (s *ScanKeys) KeyOwnerByEntity(entity *openpgp.Entity) *libkb.User {
 
 // coalesceBlocks puts the synced pgp key block and all the pgp key
 // blocks in ring into s.skbs.
-func (s *ScanKeys) coalesceBlocks(m libkb.MetaContext, ring *libkb.SKBKeyringFile, synced *libkb.SKB) (err error) {
+func (s *ScanKeys) coalesceBlocks(m libkb.MetaContext, ring *libkb.SKBKeyringFile, synced []*libkb.SKB) (err error) {
 	defer m.Trace("ScanKeys#coalesceBlocks", func() error { return err })()
 
 	// We want keys in this order: first local keyring keys that are LKSec, and
@@ -219,9 +219,7 @@ func (s *ScanKeys) coalesceBlocks(m libkb.MetaContext, ring *libkb.SKBKeyringFil
 		s.skbs = append(s.skbs, b)
 	}
 
-	if synced != nil {
-		s.skbs = append(s.skbs, synced)
-	}
+	s.skbs = append(s.skbs, synced...)
 
 	return nil
 }

--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -170,7 +170,9 @@ func (ss *SecretSyncer) store(m MetaContext, uid keybase1.UID) (err error) {
 	return
 }
 
-// FindActiveKey examines the synced keys, looking for one that's currently active.
+// FindActiveKey examines the synced keys, looking for one that's currently
+// active. The key will be chosen at random due to non-deterministic order of
+// FindActiveKeys output.
 // Returns ret=nil if none was found.
 func (ss *SecretSyncer) FindActiveKey(ckf *ComputedKeyFamily) (ret *SKB, err error) {
 	keys, err := ss.FindActiveKeys(ckf)
@@ -184,6 +186,8 @@ func (ss *SecretSyncer) FindActiveKey(ckf *ComputedKeyFamily) (ret *SKB, err err
 	return keys[0], nil
 }
 
+// FindActiveKey examines the synced keys, and returns keys that are currently
+// active.
 func (ss *SecretSyncer) FindActiveKeys(ckf *ComputedKeyFamily) (ret []*SKB, err error) {
 	ss.Lock()
 	defer ss.Unlock()

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -402,6 +402,19 @@ func (u *User) getSyncedSecretKeyLogin(m MetaContext, lctx LoginContext) (ret *S
 
 func (u *User) GetSyncedSecretKey(m MetaContext) (ret *SKB, err error) {
 	defer m.Trace("User#GetSyncedSecretKey", func() error { return err })()
+	skbs, err := u.GetSyncedSecretKeys(m)
+	if err != nil {
+		return nil, err
+	}
+	if len(skbs) == 0 {
+		return nil, nil
+	}
+	m.Debug("NOTE: using GetSyncedSecretKey, returning first secret key from randomly ordered map")
+	return skbs[0], nil
+}
+
+func (u *User) GetSyncedSecretKeys(m MetaContext) (ret []*SKB, err error) {
+	defer m.Trace("User#GetSyncedSecretKeys", func() error { return err })()
 
 	if err = u.SyncSecrets(m); err != nil {
 		return
@@ -418,7 +431,7 @@ func (u *User) GetSyncedSecretKey(m MetaContext) (ret *SKB, err error) {
 		return nil, err
 	}
 
-	ret, err = syncer.FindActiveKey(ckf)
+	ret, err = syncer.FindActiveKeys(ckf)
 	return ret, err
 }
 


### PR DESCRIPTION
Non-determinism came from here: https://github.com/keybase/client/blob/master/go/libkb/sync_secret.go#L182 

`ss.keys.PrivateKeys` is a map of strings and iterating over it is randomized.

I added new methods like `GetSyncedSecretKeys` that have "signular" `~Key` methods equivalent because there are multiple flows that assumed only one key - including PGP provisioning :( - and I don't want to change all of this right now.