### PR TITLE
Plumb context through assertion parsing

### DIFF
--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -129,7 +129,7 @@ func AggRateLimits(rlimits []chat1.RateLimit) (res []chat1.RateLimit) {
 // This never fails, worse comes to worst it just returns the split of tlfname.
 func ReorderParticipants(mctx libkb.MetaContext, g libkb.UIDMapperContext, umapper libkb.UIDMapper,
 	tlfname string, activeList []gregor1.UID) (writerNames []chat1.ConversationLocalParticipant, err error) {
-	srcWriterNames, _, _, err := splitAndNormalizeTLFNameCanonicalize(mctx.G(), tlfname, false)
+	srcWriterNames, _, _, err := splitAndNormalizeTLFNameCanonicalize(mctx, tlfname, false)
 	if err != nil {
 		return writerNames, err
 	}
@@ -181,10 +181,10 @@ func ReorderParticipants(mctx libkb.MetaContext, g libkb.UIDMapperContext, umapp
 }
 
 // Drive splitAndNormalizeTLFName with one attempt to follow TlfNameNotCanonical.
-func splitAndNormalizeTLFNameCanonicalize(g *libkb.GlobalContext, name string, public bool) (writerNames, readerNames []string, extensionSuffix string, err error) {
-	writerNames, readerNames, extensionSuffix, err = SplitAndNormalizeTLFName(g, name, public)
+func splitAndNormalizeTLFNameCanonicalize(mctx libkb.MetaContext, name string, public bool) (writerNames, readerNames []string, extensionSuffix string, err error) {
+	writerNames, readerNames, extensionSuffix, err = SplitAndNormalizeTLFName(mctx, name, public)
 	if retryErr, retry := err.(TlfNameNotCanonical); retry {
-		return SplitAndNormalizeTLFName(g, retryErr.NameToTry, public)
+		return SplitAndNormalizeTLFName(mctx, retryErr.NameToTry, public)
 	}
 	return writerNames, readerNames, extensionSuffix, err
 }

--- a/go/engine/favorite_add.go
+++ b/go/engine/favorite_add.go
@@ -101,7 +101,7 @@ func (e *FavoriteAdd) checkInviteNeeded(m libkb.MetaContext) error {
 	}
 
 	for _, user := range strings.Split(e.arg.Folder.Name, ",") {
-		assertion, ok := externals.NormalizeSocialAssertion(m.G(), user)
+		assertion, ok := externals.NormalizeSocialAssertion(m, user)
 		if !ok {
 			m.Debug("not a social assertion: %s", user)
 			continue

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -13,6 +13,7 @@ import (
 	clockwork "github.com/keybase/clockwork"
 	jsonw "github.com/keybase/go-jsonw"
 	require "github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func importTrackingLink(t *testing.T, g *libkb.GlobalContext) *libkb.TrackChainLink {
@@ -78,13 +79,15 @@ func newIdentify2WithUIDTester(g *libkb.GlobalContext) *Identify2WithUIDTester {
 	}
 }
 
-func (i *Identify2WithUIDTester) ListProofCheckers() []string { return nil }
+func (i *Identify2WithUIDTester) ListProofCheckers(libkb.MetaContext) []string { return nil }
 func (i *Identify2WithUIDTester) ListServicesThatAcceptNewProofs(libkb.MetaContext) []string {
 	return nil
 }
-func (i *Identify2WithUIDTester) ListDisplayConfigs() []keybase1.ServiceDisplayConfig { return nil }
-func (i *Identify2WithUIDTester) SuggestionFoldPriority() int                         { return 0 }
-func (i *Identify2WithUIDTester) Key() string                                         { return i.GetTypeName() }
+func (i *Identify2WithUIDTester) ListDisplayConfigs(libkb.MetaContext) []keybase1.ServiceDisplayConfig {
+	return nil
+}
+func (i *Identify2WithUIDTester) SuggestionFoldPriority(libkb.MetaContext) int { return 0 }
+func (i *Identify2WithUIDTester) Key() string                                  { return i.GetTypeName() }
 func (i *Identify2WithUIDTester) CheckProofText(text string, id keybase1.SigID, sig string) error {
 	return nil
 }
@@ -105,8 +108,8 @@ func (i *Identify2WithUIDTester) ToServiceJSON(remotename string) *jsonw.Wrapper
 func (i *Identify2WithUIDTester) MakeProofChecker(_ libkb.RemoteProofChainLink) libkb.ProofChecker {
 	return i
 }
-func (i *Identify2WithUIDTester) GetServiceType(n string) libkb.ServiceType { return i }
-func (i *Identify2WithUIDTester) PickerSubtext() string                     { return "" }
+func (i *Identify2WithUIDTester) GetServiceType(context.Context, string) libkb.ServiceType { return i }
+func (i *Identify2WithUIDTester) PickerSubtext() string                                    { return "" }
 
 func (i *Identify2WithUIDTester) CheckStatus(m libkb.MetaContext, h libkb.SigHint,
 	pcm libkb.ProofCheckerMode, _ keybase1.MerkleStoreEntry) (*libkb.SigHint, libkb.ProofError) {

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -449,7 +449,7 @@ func (e *Identify2WithUID) runReturnError(m libkb.MetaContext) (err error) {
 		m.Debug("- Released singleflight lock")
 	}()
 
-	if err = e.loadAssertion(); err != nil {
+	if err = e.loadAssertion(m); err != nil {
 		return err
 	}
 
@@ -709,11 +709,11 @@ func (e *Identify2WithUID) checkRemoteAssertions(okStates []keybase1.ProofState)
 	return nil
 }
 
-func (e *Identify2WithUID) loadAssertion() (err error) {
+func (e *Identify2WithUID) loadAssertion(mctx libkb.MetaContext) (err error) {
 	if len(e.arg.UserAssertion) == 0 {
 		return nil
 	}
-	e.themAssertion, err = libkb.AssertionParseAndOnly(e.G().MakeAssertionContext(), e.arg.UserAssertion)
+	e.themAssertion, err = libkb.AssertionParseAndOnly(e.G().MakeAssertionContext(mctx), e.arg.UserAssertion)
 	if err == nil {
 		e.remoteAssertion, e.localAssertion = libkb.CollectAssertions(e.themAssertion)
 	}
@@ -811,7 +811,7 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 		return err
 	}
 	m.Debug("| IdentifyUI.LaunchNetworkChecks(%s)", e.them.GetName())
-	if err = iui.LaunchNetworkChecks(m, e.state.ExportToUncheckedIdentity(e.G()), e.them.Export()); err != nil {
+	if err = iui.LaunchNetworkChecks(m, e.state.ExportToUncheckedIdentity(m), e.them.Export()); err != nil {
 		return err
 	}
 

--- a/go/engine/pgp_pull.go
+++ b/go/engine/pgp_pull.go
@@ -90,7 +90,7 @@ func (e *PGPPullEngine) getTrackedUserSummaries(m libkb.MetaContext) ([]keybase1
 	// First parse all the assertion expressions.
 	parsedAsserts := make(map[string]libkb.AssertionExpression)
 	for _, assertString := range e.userAsserts {
-		assertExpr, err := libkb.AssertionParseAndOnly(e.G().MakeAssertionContext(), assertString)
+		assertExpr, err := libkb.AssertionParseAndOnly(e.G().MakeAssertionContext(m), assertString)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/engine/prove.go
+++ b/go/engine/prove.go
@@ -370,7 +370,7 @@ func (p *Prove) checkProofText(m libkb.MetaContext) error {
 }
 
 func (p *Prove) getServiceType(m libkb.MetaContext) (err error) {
-	p.serviceType = m.G().GetProofServices().GetServiceType(p.arg.Service)
+	p.serviceType = m.G().GetProofServices().GetServiceType(m.Ctx(), p.arg.Service)
 	if p.serviceType == nil {
 		return libkb.BadServiceError{Service: p.arg.Service}
 	}

--- a/go/engine/prove_help_test.go
+++ b/go/engine/prove_help_test.go
@@ -246,7 +246,7 @@ func proveGubbleUniverse(tc libkb.TestContext, serviceName, endpoint string, fu 
 	tc.T.Logf("proof for %s", serviceName)
 	g := tc.G
 	sv := keybase1.SigVersion(sigVersion)
-	proofService := g.GetProofServices().GetServiceType(serviceName)
+	proofService := g.GetProofServices().GetServiceType(context.Background(), serviceName)
 	require.NotNil(tc.T, proofService)
 
 	// Post a proof to the testing generic social service
@@ -331,7 +331,7 @@ func proveGubbleUniverse(tc libkb.TestContext, serviceName, endpoint string, fu 
 func proveGubbleSocialFail(tc libkb.TestContext, fu *FakeUser, sigVersion libkb.SigVersion) {
 	g := tc.G
 	sv := keybase1.SigVersion(sigVersion)
-	proofService := g.GetProofServices().GetServiceType("gubble.social")
+	proofService := g.GetProofServices().GetServiceType(context.Background(), "gubble.social")
 	require.NotNil(tc.T, proofService, "expected to find gubble.social service type")
 	arg := keybase1.StartProofArg{
 		Service:      proofService.GetTypeName(),

--- a/go/engine/scanproofs.go
+++ b/go/engine/scanproofs.go
@@ -385,7 +385,7 @@ func (e *ScanProofsEngine) CheckOne(m libkb.MetaContext, rec map[string]string, 
 		return nil, foundhint, err
 	}
 
-	pc, err := libkb.MakeProofChecker(m.G().GetProofServices(), link)
+	pc, err := libkb.MakeProofChecker(m, m.G().GetProofServices(), link)
 	if err != nil {
 		return nil, foundhint, err
 	}

--- a/go/externals/assertion_parser_test.go
+++ b/go/externals/assertion_parser_test.go
@@ -4,8 +4,10 @@
 package externals
 
 import (
+	"context"
 	"testing"
 
+	libkb "github.com/keybase/client/go/libkb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +16,7 @@ func TestNormalization(t *testing.T) {
 	defer tc.Cleanup()
 	inp := "Web://A.AA || HttP://B.bb && dnS://C.cc || MaxFactor@reddit || zQueal@keyBASE || XanxA@hackernews || foO@TWITTER || 0123456789ABCDEF0123456789abcd19@uid || josh@gubble.SoCiAl"
 	outp := "a.aa@web,b.bb@http+c.cc@dns,maxfactor@reddit,zqueal,XanxA@hackernews,foo@twitter,0123456789abcdef0123456789abcd19@uid,josh@gubble.social"
-	expr, err := AssertionParse(tc.G, inp)
+	expr, err := AssertionParse(libkb.NewMetaContext(context.Background(), tc.G), inp)
 	require.NoError(t, err)
 	require.Equal(t, expr.String(), outp)
 }
@@ -108,7 +110,7 @@ func TestParserFail1(t *testing.T) {
 	}
 
 	for _, bad := range bads {
-		ret, err := AssertionParse(tc.G, bad.k)
+		ret, err := AssertionParse(libkb.NewMetaContext(context.Background(), tc.G), bad.k)
 		require.Error(t, err, "for %q: ret is: %+v", bad.k, ret)
 		require.Equal(t, bad.v, err.Error(), "when testing %q", bad.k)
 	}

--- a/go/externals/implicit_team_test.go
+++ b/go/externals/implicit_team_test.go
@@ -5,6 +5,7 @@ package externals
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"testing"
@@ -37,11 +38,11 @@ func TestParseImplicitTeamTLFName(t *testing.T) {
 		"/keybase/public/foobar__underscore",
 	}
 	for _, badName := range badNames {
-		_, err := libkb.ParseImplicitTeamTLFName(MakeAssertionContext(tc.G), badName)
+		_, err := libkb.ParseImplicitTeamTLFName(MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), badName)
 		require.Error(t, err)
 	}
 	goodName := "/keybase/public/dave,twitter:alice,bob@facebook,carol@keybase,echo"
-	name, err := libkb.ParseImplicitTeamTLFName(MakeAssertionContext(tc.G), goodName)
+	name, err := libkb.ParseImplicitTeamTLFName(MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), goodName)
 	require.NoError(t, err)
 	require.Equal(t, name.IsPublic, true)
 	require.Equal(t, len(name.Writers.KeybaseUsers), 3)
@@ -59,7 +60,7 @@ func TestParseImplicitTeamTLFName(t *testing.T) {
 	require.True(t, secondSocial == aliceExpected || secondSocial == bobExpected)
 
 	goodName = "/keybase/public/dave,bob@facebook#alice (conflicted copy 2017-03-04)"
-	name, err = libkb.ParseImplicitTeamTLFName(MakeAssertionContext(tc.G), goodName)
+	name, err = libkb.ParseImplicitTeamTLFName(MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), goodName)
 	require.NoError(t, err)
 	require.Equal(t, name.IsPublic, true)
 	require.Equal(t, len(name.Writers.KeybaseUsers), 1)
@@ -68,7 +69,7 @@ func TestParseImplicitTeamTLFName(t *testing.T) {
 	require.Equal(t, name.ConflictInfo.Generation, keybase1.ConflictGeneration(1), "right conflict info")
 
 	goodName = "/keybase/public/dave,bob@facebook#alice (conflicted copy 2017-03-04 #2)"
-	name, err = libkb.ParseImplicitTeamTLFName(MakeAssertionContext(tc.G), goodName)
+	name, err = libkb.ParseImplicitTeamTLFName(MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), goodName)
 	require.NoError(t, err)
 	require.Equal(t, name.IsPublic, true)
 	require.Equal(t, len(name.Writers.KeybaseUsers), 1)
@@ -159,7 +160,7 @@ func TestParseImplicitTeamTLFNameEvenMore(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		itn, err := libkb.ParseImplicitTeamTLFName(MakeAssertionContext(tc.G), test.input)
+		itn, err := libkb.ParseImplicitTeamTLFName(MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), test.input)
 		if test.output == nil {
 			require.Error(t, err)
 		} else {
@@ -174,11 +175,11 @@ func TestParseImplicitTeamDisplayName(t *testing.T) {
 	tc := setupTest(t, "ParseImplicitTeamDisplayName", 1)
 	defer tc.Cleanup()
 	goodName := "twitter:alice,bob@facebook,carol@keybase,dave"
-	_, err := libkb.ParseImplicitTeamDisplayName(MakeAssertionContext(tc.G), "", false)
+	_, err := libkb.ParseImplicitTeamDisplayName(MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), "", false)
 	require.Error(t, err)
-	namePrivate, err := libkb.ParseImplicitTeamDisplayName(MakeAssertionContext(tc.G), goodName, false)
+	namePrivate, err := libkb.ParseImplicitTeamDisplayName(MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), goodName, false)
 	require.NoError(t, err)
-	namePublic, err := libkb.ParseImplicitTeamDisplayName(MakeAssertionContext(tc.G), goodName, true)
+	namePublic, err := libkb.ParseImplicitTeamDisplayName(MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), goodName, true)
 	require.NoError(t, err)
 	require.False(t, namePrivate.IsPublic)
 	require.True(t, namePublic.IsPublic)

--- a/go/externals/services_test.go
+++ b/go/externals/services_test.go
@@ -19,7 +19,7 @@ func TestLoadParamServices(t *testing.T) {
 	entry, err := tc.G.GetParamProofStore().GetLatestEntry(m)
 	require.NoError(t, err)
 
-	config, err := proofServices.parseServerConfig(entry)
+	config, err := proofServices.parseServerConfig(m, entry)
 	require.NoError(t, err)
 	require.NotNil(t, config.ProofConfigs)
 	require.NotNil(t, config.DisplayConfigs)

--- a/go/externals/social_assertion_test.go
+++ b/go/externals/social_assertion_test.go
@@ -6,6 +6,7 @@ package externals
 import (
 	"testing"
 
+	libkb "github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +46,7 @@ func TestNormalizeSocialAssertion(t *testing.T) {
 	tc := setupTest(t, "NormalizeSocialAssertion", 1)
 	defer tc.Cleanup()
 	for _, test := range nsatests {
-		out, ok := NormalizeSocialAssertion(tc.G, test.in)
+		out, ok := NormalizeSocialAssertion(libkb.NewMetaContextForTest(tc), test.in)
 
 		require.Equal(t, test.out, out)
 		require.Equal(t, test.ok, ok)

--- a/go/git/put_get_test.go
+++ b/go/git/put_get_test.go
@@ -231,7 +231,7 @@ func testPutAndGetImplicitTeam(t *testing.T, public bool) {
 
 	t.Logf("second repo")
 	repoName2 := keybase1.GitRepoName(fmt.Sprintf("two person %s repo", publicnessStr))
-	normalizedTLFName, err := tlf.NormalizeNamesInTLF(tc.G, []string{u1.Username, u2.Username}, nil, "")
+	normalizedTLFName, err := tlf.NormalizeNamesInTLF(libkb.NewMetaContextForTest(tc), []string{u1.Username, u2.Username}, nil, "")
 	require.NoError(t, err)
 	testFolder2 := keybase1.Folder{
 		Name:       normalizedTLFName,

--- a/go/git/teamer.go
+++ b/go/git/teamer.go
@@ -78,7 +78,7 @@ func (t *TeamerImpl) lookupOrCreateImplicitTeam(ctx context.Context, folder keyb
 		visibility = keybase1.TLFVisibility_PUBLIC
 	}
 
-	impName, err := libkb.ParseImplicitTeamTLFName(t.G().MakeAssertionContext(), "/keybase/"+folder.ToString())
+	impName, err := libkb.ParseImplicitTeamTLFName(t.G().MakeAssertionContext(t.MetaContext(ctx)), "/keybase/"+folder.ToString())
 	if err != nil {
 		return res, err
 	}

--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -100,7 +100,7 @@ func (i *UIAdapter) Start(mctx libkb.MetaContext, user string, reason keybase1.I
 func (i *UIAdapter) initPriorityMap(mctx libkb.MetaContext) {
 	i.priorityMap = make(map[string]int)
 	var haveDisplayConfigs bool
-	for _, displayConfig := range mctx.G().GetProofServices().ListDisplayConfigs() {
+	for _, displayConfig := range mctx.G().GetProofServices().ListDisplayConfigs(mctx) {
 		haveDisplayConfigs = true
 		i.priorityMap[displayConfig.Key] = displayConfig.Priority
 		var altKey string
@@ -254,7 +254,7 @@ func (i *UIAdapter) rowPartial(mctx libkb.MetaContext, proof keybase1.RemoteProo
 		iconKey = "facebook"
 	case keybase1.ProofType_GENERIC_SOCIAL:
 		row.SiteURL = humanURLOrSigchainURL
-		serviceType := mctx.G().GetProofServices().GetServiceType(proof.Key)
+		serviceType := mctx.G().GetProofServices().GetServiceType(mctx.Ctx(), proof.Key)
 		if serviceType != nil {
 			if serviceType, ok := serviceType.(*externals.GenericSocialProofServiceType); ok {
 				profileURL, err := serviceType.ProfileURL(proof.Value)

--- a/go/kbfs/idutil/daemon_local.go
+++ b/go/kbfs/idutil/daemon_local.go
@@ -91,7 +91,7 @@ func (dl *DaemonLocal) SetCurrentUID(uid keybase1.UID) {
 
 func (dl *DaemonLocal) assertionToIDLocked(ctx context.Context,
 	assertion string) (id keybase1.UserOrTeamID, err error) {
-	expr, err := externals.AssertionParseAndOnlyStatic(assertion)
+	expr, err := externals.AssertionParseAndOnlyStatic(ctx, assertion)
 	if err != nil {
 		return keybase1.UserOrTeamID(""), err
 	}
@@ -181,7 +181,7 @@ func (dl *DaemonLocal) Identify(
 // for DaemonLocal.
 func (dl *DaemonLocal) NormalizeSocialAssertion(
 	ctx context.Context, assertion string) (keybase1.SocialAssertion, error) {
-	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(assertion)
+	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(ctx, assertion)
 	if !isSocialAssertion {
 		return keybase1.SocialAssertion{}, fmt.Errorf("Invalid social assertion")
 	}
@@ -202,7 +202,7 @@ func (dl *DaemonLocal) resolveForImplicitTeam(
 		r = append(r, u.Name)
 		resolvedIDs[u.Name] = id
 	} else {
-		a, ok := externals.NormalizeSocialAssertionStatic(name)
+		a, ok := externals.NormalizeSocialAssertionStatic(ctx, name)
 		if !ok {
 			return nil, nil, fmt.Errorf("Bad assertion: %s", name)
 		}

--- a/go/kbfs/idutil/tlf_names.go
+++ b/go/kbfs/idutil/tlf_names.go
@@ -5,6 +5,7 @@
 package idutil
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -23,7 +24,7 @@ func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
 	}
 
 	// TODO: this fails for http and https right now (see CORE-2968).
-	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(s)
+	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(context.TODO(), s)
 	if isSocialAssertion {
 		if t == tlf.SingleTeam {
 			return "", fmt.Errorf(
@@ -36,7 +37,7 @@ func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
 	if t == tlf.SingleTeam {
 		sAssertion = "team:" + s
 	}
-	if expr, err := externals.AssertionParseAndOnlyStatic(sAssertion); err == nil {
+	if expr, err := externals.AssertionParseAndOnlyStatic(context.TODO(), sAssertion); err == nil {
 		// If the expression only contains a single url, make sure
 		// it's not a just considered a single keybase username.  If
 		// it is, then some non-username slipped into the default

--- a/go/kbfs/kbfsmd/root_metadata_v2_test.go
+++ b/go/kbfs/kbfsmd/root_metadata_v2_test.go
@@ -171,8 +171,8 @@ func TestWriterMetadataV2UnchangedEncoding(t *testing.T) {
 
 // Test that WriterMetadataV2 has only a fixed (frozen) set of fields.
 func TestWriterMetadataV2EncodedFields(t *testing.T) {
-	sa1, _ := externals.NormalizeSocialAssertionStatic("uid1@twitter")
-	sa2, _ := externals.NormalizeSocialAssertionStatic("uid2@twitter")
+	sa1, _ := externals.NormalizeSocialAssertionStatic(context.Background(), "uid1@twitter")
+	sa2, _ := externals.NormalizeSocialAssertionStatic(context.Background(), "uid2@twitter")
 	// Usually exactly one of Writers/WKeys is filled in, but we
 	// fill in both here for testing.
 	wm := WriterMetadataV2{
@@ -277,7 +277,7 @@ func makeFakeWriterMetadataV2Future(t *testing.T) writerMetadataV2Future {
 		WriterMetadataExtraV2{},
 	}
 	wkb := makeFakeTLFWriterKeyBundleV2Future(t)
-	sa, _ := externals.NormalizeSocialAssertionStatic("foo@twitter")
+	sa, _ := externals.NormalizeSocialAssertionStatic(context.Background(), "foo@twitter")
 	return writerMetadataV2Future{
 		wmd,
 		tlfWriterKeyGenerationsV2Future{&wkb},
@@ -343,7 +343,7 @@ func (brmf *rootMetadataV2Future) ToCurrentStruct() kbfscodec.CurrentStruct {
 func makeFakeRootMetadataV2Future(t *testing.T) *rootMetadataV2Future {
 	wmf := makeFakeWriterMetadataV2Future(t)
 	rkb := makeFakeTLFReaderKeyBundleV2Future(t)
-	sa, _ := externals.NormalizeSocialAssertionStatic("bar@github")
+	sa, _ := externals.NormalizeSocialAssertionStatic(context.Background(), "bar@github")
 	rmf := rootMetadataV2Future{
 		wmf,
 		rootMetadataWrapper{

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -37,7 +37,7 @@ type shimKMCrypto struct {
 func mockNormalizeSocialAssertion(config *ConfigMock) {
 	config.mockKbpki.EXPECT().NormalizeSocialAssertion(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, assertion string) (keybase1.SocialAssertion, error) {
-			socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(assertion)
+			socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(context.Background(), assertion)
 			if !isSocialAssertion {
 				return keybase1.SocialAssertion{}, fmt.Errorf("Invalid social assertion")
 			}

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -460,7 +460,7 @@ func AddNewAssertionForTest(
 	// configs, it may end up invoking the following call more than
 	// once on the shared md databases.  That's ok though, it's an
 	// idempotent call.
-	newSocialAssertion, ok := externals.NormalizeSocialAssertionStatic(newAssertion)
+	newSocialAssertion, ok := externals.NormalizeSocialAssertionStatic(context.Background(), newAssertion)
 	if !ok {
 		return errors.Errorf("%s couldn't be parsed as a social assertion", newAssertion)
 	}

--- a/go/kbfs/tlf/utils.go
+++ b/go/kbfs/tlf/utils.go
@@ -28,7 +28,7 @@ const (
 // SplitAndNormalizeTLFName returns separate lists of normalized
 // writer and reader names, as well as the extension suffix, of the
 // given `name`.
-func SplitAndNormalizeTLFName(g *libkb.GlobalContext, name string, public bool) (
+func SplitAndNormalizeTLFName(mctx libkb.MetaContext, name string, public bool) (
 	writerNames, readerNames []string,
 	extensionSuffix string, err error) {
 
@@ -56,7 +56,7 @@ func SplitAndNormalizeTLFName(g *libkb.GlobalContext, name string, public bool) 
 		return nil, nil, "", NoSuchNameError{Name: name}
 	}
 
-	normalizedName, err := NormalizeNamesInTLF(g,
+	normalizedName, err := NormalizeNamesInTLF(mctx,
 		writerNames, readerNames, extensionSuffix)
 	if err != nil {
 		return nil, nil, "", err
@@ -71,12 +71,12 @@ func SplitAndNormalizeTLFName(g *libkb.GlobalContext, name string, public bool) 
 // NormalizeNamesInTLF takes a split TLF name and, without doing any
 // resolutions or identify calls, normalizes all elements of the
 // name. It then returns the normalized name.
-func NormalizeNamesInTLF(g *libkb.GlobalContext, writerNames, readerNames []string,
+func NormalizeNamesInTLF(mctx libkb.MetaContext, writerNames, readerNames []string,
 	extensionSuffix string) (string, error) {
 	sortedWriterNames := make([]string, len(writerNames))
 	var err error
 	for i, w := range writerNames {
-		sortedWriterNames[i], err = NormalizeAssertionOrName(g, w)
+		sortedWriterNames[i], err = NormalizeAssertionOrName(mctx, w)
 		if err != nil {
 			return "", err
 		}
@@ -86,7 +86,7 @@ func NormalizeNamesInTLF(g *libkb.GlobalContext, writerNames, readerNames []stri
 	if len(readerNames) > 0 {
 		sortedReaderNames := make([]string, len(readerNames))
 		for i, r := range readerNames {
-			sortedReaderNames[i], err = NormalizeAssertionOrName(g, r)
+			sortedReaderNames[i], err = NormalizeAssertionOrName(mctx, r)
 			if err != nil {
 				return "", err
 			}
@@ -107,18 +107,18 @@ func NormalizeNamesInTLF(g *libkb.GlobalContext, writerNames, readerNames []stri
 //
 // TODO: this function can likely be replaced with a call to
 // AssertionParseAndOnly when CORE-2967 and CORE-2968 are fixed.
-func NormalizeAssertionOrName(g *libkb.GlobalContext, s string) (string, error) {
+func NormalizeAssertionOrName(mctx libkb.MetaContext, s string) (string, error) {
 	if libkb.CheckUsername.F(s) {
 		return libkb.NewNormalizedUsername(s).String(), nil
 	}
 
 	// TODO: this fails for http and https right now (see CORE-2968).
-	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertion(g, s)
+	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertion(mctx, s)
 	if isSocialAssertion {
 		return socialAssertion.String(), nil
 	}
 
-	if expr, err := externals.AssertionParseAndOnly(g, s); err == nil {
+	if expr, err := externals.AssertionParseAndOnly(mctx, s); err == nil {
 		// If the expression only contains a single url, make sure
 		// it's not a just considered a single keybase username.  If
 		// it is, then some non-username slipped into the default

--- a/go/kbfs/tlfhandle/identify_util_test.go
+++ b/go/kbfs/tlfhandle/identify_util_test.go
@@ -68,7 +68,7 @@ func (ti *testIdentifier) Identify(
 
 func (ti *testIdentifier) NormalizeSocialAssertion(
 	ctx context.Context, assertion string) (keybase1.SocialAssertion, error) {
-	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(assertion)
+	socialAssertion, isSocialAssertion := externals.NormalizeSocialAssertionStatic(ctx, assertion)
 	if !isSocialAssertion {
 		return keybase1.SocialAssertion{}, fmt.Errorf("Invalid social assertion")
 	}

--- a/go/libkb/assertion_test.go
+++ b/go/libkb/assertion_test.go
@@ -9,9 +9,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 type testAssertionContext struct{}
+
+func (t testAssertionContext) Ctx() context.Context { return context.Background() }
 
 func (t testAssertionContext) NormalizeSocialName(service string, username string) (string, error) {
 	return strings.ToLower(username), nil
@@ -20,6 +23,8 @@ func (t testAssertionContext) NormalizeSocialName(service string, username strin
 type testAlwaysFailAssertionContext struct{}
 
 const failAssertionContextErr = "Unknown social network BECAUSE IT'S A TEST"
+
+func (t testAlwaysFailAssertionContext) Ctx() context.Context { return context.Background() }
 
 func (t testAlwaysFailAssertionContext) NormalizeSocialName(service string, username string) (string, error) {
 	return "", fmt.Errorf("%s: %s", failAssertionContextErr, service)

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -1106,13 +1106,13 @@ func (g *GlobalContext) LogoutSelfCheck(ctx context.Context) error {
 	return nil
 }
 
-func (g *GlobalContext) MakeAssertionContext() AssertionContext {
+func (g *GlobalContext) MakeAssertionContext(mctx MetaContext) AssertionContext {
 	g.cacheMu.Lock()
 	defer g.cacheMu.Unlock()
 	if g.proofServices == nil {
 		return nil
 	}
-	return MakeAssertionContext(g.proofServices)
+	return MakeAssertionContext(mctx, g.proofServices)
 }
 
 func (g *GlobalContext) SetProofServices(s ExternalServicesCollector) {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1660,7 +1660,7 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 
 	// Call the Global context's version of what a proof checker is. We might want to stub it out
 	// for the purposes of testing.
-	pc, res.err = MakeProofChecker(m.G().GetProofServices(), p)
+	pc, res.err = MakeProofChecker(m, m.G().GetProofServices(), p)
 
 	if res.err != nil || pc == nil {
 		return

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -64,7 +64,7 @@ func (i *IdentifyOutcome) TrackSet() *TrackSet {
 	return i.remoteProofLinks().TrackSet()
 }
 
-func (i *IdentifyOutcome) ProofChecksSorted() []*LinkCheckResult {
+func (i *IdentifyOutcome) ProofChecksSorted(mctx MetaContext) []*LinkCheckResult {
 	// Sort by display priority
 	pc := make([]*LinkCheckResult, len(i.ProofChecks))
 	copy(pc, i.ProofChecks)
@@ -73,7 +73,7 @@ func (i *IdentifyOutcome) ProofChecksSorted() []*LinkCheckResult {
 	for _, lcr := range pc {
 		key := lcr.link.DisplayPriorityKey()
 		if _, ok := serviceTypes[key]; !ok {
-			st := proofServices.GetServiceType(key)
+			st := proofServices.GetServiceType(mctx.Ctx(), key)
 			displayPriority := 0
 			if st != nil {
 				displayPriority = st.DisplayPriority()

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -571,6 +571,7 @@ type DNSContext interface {
 }
 
 type AssertionContext interface {
+	Ctx() context.Context
 	NormalizeSocialName(service string, username string) (string, error)
 }
 
@@ -638,11 +639,11 @@ type ServiceType interface {
 }
 
 type ExternalServicesCollector interface {
-	GetServiceType(n string) ServiceType
-	ListProofCheckers() []string
+	GetServiceType(context.Context, string) ServiceType
+	ListProofCheckers(MetaContext) []string
 	ListServicesThatAcceptNewProofs(MetaContext) []string
-	ListDisplayConfigs() (res []keybase1.ServiceDisplayConfig)
-	SuggestionFoldPriority() int
+	ListDisplayConfigs(MetaContext) (res []keybase1.ServiceDisplayConfig)
+	SuggestionFoldPriority(MetaContext) int
 }
 
 // Generic store for data that is hashed into the merkle root. Used by pvl and

--- a/go/libkb/resolve.go
+++ b/go/libkb/resolve.go
@@ -136,7 +136,7 @@ func (r *ResolverImpl) resolve(m MetaContext, input string, withBody bool) (res 
 	defer m.TraceTimed(fmt.Sprintf("Resolving username %q", input), func() error { return res.err })()
 
 	var au AssertionURL
-	if au, res.err = ParseAssertionURL(m.G().MakeAssertionContext(), input, false); res.err != nil {
+	if au, res.err = ParseAssertionURL(m.G().MakeAssertionContext(m), input, false); res.err != nil {
 		return res
 	}
 	res = r.resolveURL(m, au, input, withBody, false)
@@ -172,7 +172,7 @@ func (r *ResolverImpl) resolveFullExpression(m MetaContext, input string, withBo
 	defer m.VTrace(VLog1, fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
 
 	var expr AssertionExpression
-	expr, res.err = AssertionParseAndOnly(m.G().MakeAssertionContext(), input)
+	expr, res.err = AssertionParseAndOnly(m.G().MakeAssertionContext(m), input)
 	if res.err != nil {
 		return res
 	}
@@ -719,7 +719,7 @@ func (r *ResolverImpl) CacheTeamResolution(m MetaContext, id keybase1.TeamID, na
 
 func (r *ResolverImpl) PurgeResolveCache(m MetaContext, input string) (err error) {
 	defer m.Trace(fmt.Sprintf("Resolver#PurgeResolveCache(input = %q)", input), func() error { return err })()
-	expr, err := AssertionParseAndOnly(m.G().MakeAssertionContext(), input)
+	expr, err := AssertionParseAndOnly(m.G().MakeAssertionContext(m), input)
 	if err != nil {
 		return err
 	}

--- a/go/libkb/rpc_exim.go
+++ b/go/libkb/rpc_exim.go
@@ -94,19 +94,19 @@ func ExportRemoteProof(p RemoteProofChainLink) keybase1.RemoteProof {
 	}
 }
 
-func (is IdentifyState) ExportToUncheckedIdentity(g *GlobalContext) *keybase1.Identity {
-	return is.res.ExportToUncheckedIdentity(g)
+func (is IdentifyState) ExportToUncheckedIdentity(mctx MetaContext) *keybase1.Identity {
+	return is.res.ExportToUncheckedIdentity(mctx)
 }
 
-func (ir IdentifyOutcome) ExportToUncheckedIdentity(g *GlobalContext) *keybase1.Identity {
+func (ir IdentifyOutcome) ExportToUncheckedIdentity(mctx MetaContext) *keybase1.Identity {
 	tmp := keybase1.Identity{
-		Status: ExportErrorAsStatus(g, ir.Error),
+		Status: ExportErrorAsStatus(mctx.G(), ir.Error),
 	}
 	if ir.TrackUsed != nil {
 		tmp.WhenLastTracked = keybase1.ToTime(ir.TrackUsed.GetCTime())
 	}
 
-	pc := ir.ProofChecksSorted()
+	pc := ir.ProofChecksSorted(mctx)
 	tmp.Proofs = make([]keybase1.IdentifyRow, len(pc))
 	for j, p := range pc {
 		tmp.Proofs[j] = p.ExportToIdentifyRow(j)

--- a/go/saltpackkeys/saltpack_recipient_keyfinder_engine.go
+++ b/go/saltpackkeys/saltpack_recipient_keyfinder_engine.go
@@ -158,7 +158,7 @@ func (e *SaltpackRecipientKeyfinderEngine) identifyAndAddUserRecipient(m libkb.M
 	case libkb.IsNotFoundError(err) || libkb.IsResolutionNotFoundError(err):
 		// recipient is not a keybase user
 
-		expr, err := externals.AssertionParse(m.G(), u)
+		expr, err := externals.AssertionParse(m, u)
 		if err != nil {
 			m.Debug("error parsing assertion: %s", err)
 			return libkb.NewRecipientNotFoundError(fmt.Sprintf("Cannot encrypt for %v: it is not a keybase user or social assertion (err = %v)", u, err))

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -100,7 +100,7 @@ func (h *IdentifyHandler) identifyLite(mctx libkb.MetaContext, arg keybase1.Iden
 	if len(arg.Assertion) > 0 {
 		// It's OK to fail this assertion; it will be off in the case of regular lookups
 		// for users like `t_ellen` without a `type` specification
-		au, parseError = libkb.ParseAssertionURL(mctx.G().MakeAssertionContext(), arg.Assertion, true)
+		au, parseError = libkb.ParseAssertionURL(mctx.G().MakeAssertionContext(mctx), arg.Assertion, true)
 	} else {
 		// empty assertion url required for teams.IdentifyLite
 		au = libkb.AssertionKeybase{}
@@ -198,7 +198,7 @@ func (h *IdentifyHandler) ResolveIdentifyImplicitTeam(ctx context.Context, arg k
 	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("RIIT")
 	defer mctx.Trace(fmt.Sprintf("IdentifyHandler#ResolveIdentifyImplicitTeam(%+v)", arg), func() error { return err })()
 
-	writerAssertions, readerAssertions, err := externals.ParseAssertionsWithReaders(h.G(), arg.Assertions)
+	writerAssertions, readerAssertions, err := externals.ParseAssertionsWithReaders(h.MetaContext(ctx), arg.Assertions)
 	if err != nil {
 		return res, err
 	}
@@ -388,7 +388,7 @@ func (h *IdentifyHandler) ResolveImplicitTeam(ctx context.Context, arg keybase1.
 func (h *IdentifyHandler) NormalizeSocialAssertion(ctx context.Context, assertion string) (socialAssertion keybase1.SocialAssertion, err error) {
 	ctx = libkb.WithLogTag(ctx, "NSA")
 	defer h.G().CTrace(ctx, fmt.Sprintf("IdentifyHandler#NormalizeSocialAssertion(%s)", assertion), func() error { return err })()
-	socialAssertion, isSocialAssertion := libkb.NormalizeSocialAssertion(h.G().MakeAssertionContext(), assertion)
+	socialAssertion, isSocialAssertion := libkb.NormalizeSocialAssertion(h.G().MakeAssertionContext(h.MetaContext(ctx)), assertion)
 	if !isSocialAssertion {
 		return keybase1.SocialAssertion{}, fmt.Errorf("Invalid social assertion")
 	}

--- a/go/service/prove.go
+++ b/go/service/prove.go
@@ -94,7 +94,7 @@ func (ph *ProveHandler) StartProof(ctx context.Context, arg keybase1.StartProofA
 
 func (ph *ProveHandler) ValidateUsername(ctx context.Context, arg keybase1.ValidateUsernameArg) error {
 	mctx := libkb.NewMetaContext(ctx, ph.G())
-	serviceType := mctx.G().GetProofServices().GetServiceType(arg.Service)
+	serviceType := mctx.G().GetProofServices().GetServiceType(ctx, arg.Service)
 	if serviceType == nil {
 		return libkb.BadServiceError{Service: arg.Service}
 	}

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -381,7 +381,7 @@ func (h *UserHandler) ProofSuggestions(ctx context.Context, sessionID int) (ret 
 		return ret, err
 	}
 	tracer.Stage("fold-pri")
-	foldPriority := mctx.G().GetProofServices().SuggestionFoldPriority()
+	foldPriority := mctx.G().GetProofServices().SuggestionFoldPriority(h.MetaContext(ctx))
 	tracer.Stage("fold-loop")
 	for _, suggestion := range suggestions {
 		if foldPriority > 0 && suggestion.Priority >= foldPriority {
@@ -459,7 +459,7 @@ func (h *UserHandler) proofSuggestionsHelper(mctx libkb.MetaContext, tracer prof
 			// "web" is added below.
 			continue
 		}
-		serviceType := mctx.G().GetProofServices().GetServiceType(service)
+		serviceType := mctx.G().GetProofServices().GetServiceType(mctx.Ctx(), service)
 		if serviceType == nil {
 			mctx.Debug("missing proof service type: %v", service)
 			continue
@@ -518,7 +518,7 @@ func (h *UserHandler) proofSuggestionsHelper(mctx libkb.MetaContext, tracer prof
 	tracer.Stage("prioritize-server")
 	serverPriority := make(map[string]int) // key -> server priority
 	maxServerPriority := 0
-	for _, displayConfig := range mctx.G().GetProofServices().ListDisplayConfigs() {
+	for _, displayConfig := range mctx.G().GetProofServices().ListDisplayConfigs(mctx) {
 		if displayConfig.Priority <= 0 {
 			continue
 		}

--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -590,7 +590,7 @@ func isFollowingForReview(mctx libkb.MetaContext, assertion string) (isFollowing
 }
 
 func isKeybaseAssertion(mctx libkb.MetaContext, assertion string) bool {
-	expr, err := externals.AssertionParse(mctx.G(), string(assertion))
+	expr, err := externals.AssertionParse(mctx, string(assertion))
 	if err != nil {
 		mctx.Debug("error parsing assertion: %s", err)
 		return false

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -411,7 +411,7 @@ func LookupRecipient(m libkb.MetaContext, to stellarcommon.RecipientInput, isCLI
 		return res, err
 	}
 	if maybeUsername == "" {
-		expr, err := externals.AssertionParse(m.G(), string(to))
+		expr, err := externals.AssertionParse(m, string(to))
 		if err != nil {
 			m.Debug("error parsing assertion: %s", err)
 			return res, fmt.Errorf("invalid recipient %q: %s", to, err)

--- a/go/teams/identify_test.go
+++ b/go/teams/identify_test.go
@@ -20,7 +20,7 @@ func TestIdentifyLite(t *testing.T) {
 	// test identify by assertion only
 	var assertions = []string{"team:" + name, "tid:" + team.ID.String()}
 	for _, assertion := range assertions {
-		au, err := libkb.ParseAssertionURL(tc.G.MakeAssertionContext(), assertion, true)
+		au, err := libkb.ParseAssertionURL(tc.G.MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), assertion, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -39,7 +39,7 @@ func TestIdentifyLite(t *testing.T) {
 
 	// test identify by id and assertions
 	for _, assertion := range assertions {
-		au, err := libkb.ParseAssertionURL(tc.G.MakeAssertionContext(), assertion, true)
+		au, err := libkb.ParseAssertionURL(tc.G.MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G)), assertion, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -339,7 +339,7 @@ func formatImplicitTeamDisplayNameCommon(ctx context.Context, g *libkb.GlobalCon
 		return "", fmt.Errorf("invalid implicit team name: no writers")
 	}
 
-	return tlf.NormalizeNamesInTLF(g, writerNames, readerNames, suffix)
+	return tlf.NormalizeNamesInTLF(libkb.NewMetaContext(ctx, g), writerNames, readerNames, suffix)
 }
 
 // Sort a list of strings but order `front` in front IF it appears.

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -232,7 +232,7 @@ func TestImplicitDisplayTeamNameParse(t *testing.T) {
 	// It will probably fail because <uid>@keybase is the wrong format.
 
 	makeAssertionContext := func() libkb.AssertionContext {
-		return libkb.MakeAssertionContext(externals.NewProofServices(tc.G))
+		return libkb.MakeAssertionContext(libkb.NewMetaContext(context.Background(), tc.G), externals.NewProofServices(tc.G))
 	}
 
 	for _, public := range []bool{true, false} {

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -153,7 +153,7 @@ func loadUPAK2(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, fo
 }
 
 func parseSocialAssertion(m libkb.MetaContext, username string) (typ string, name string, err error) {
-	assertion, err := libkb.ParseAssertionURL(m.G().MakeAssertionContext(), username, false)
+	assertion, err := libkb.ParseAssertionURL(m.G().MakeAssertionContext(m), username, false)
 	if err != nil {
 		return "", "", err
 	}

--- a/go/teams/resolve.go
+++ b/go/teams/resolve.go
@@ -84,7 +84,7 @@ func ResolveImplicitTeamDisplayName(ctx context.Context, g *libkb.GlobalContext,
 		suffix = split1[1]
 	}
 
-	writerAssertions, readerAssertions, err := externals.ParseAssertionsWithReaders(g, assertions)
+	writerAssertions, readerAssertions, err := externals.ParseAssertionsWithReaders(libkb.NewMetaContext(ctx, g), assertions)
 	if err != nil {
 		return res, err
 	}

--- a/go/teams/resolve_test.go
+++ b/go/teams/resolve_test.go
@@ -40,7 +40,7 @@ func TestVerifyResolveEvilServer(t *testing.T) {
 	defer cleanup()
 
 	t.Logf("check good assertion")
-	assertion, err := externals.AssertionParseAndOnly(tcs[0].G, "t_tracy@rooter")
+	assertion, err := externals.AssertionParseAndOnly(libkb.NewMetaContext(context.Background(), tcs[0].G), "t_tracy@rooter")
 	require.NoError(t, err)
 	err = verifyResolveResult(context.TODO(), tcs[0].G, libkb.ResolvedAssertion{
 		Assertion: assertion,
@@ -49,7 +49,7 @@ func TestVerifyResolveEvilServer(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("check bad assertion")
-	assertion, err = externals.AssertionParseAndOnly(tcs[0].G, "beluga@rooter")
+	assertion, err = externals.AssertionParseAndOnly(libkb.NewMetaContext(context.Background(), tcs[0].G), "beluga@rooter")
 	require.NoError(t, err)
 	err = verifyResolveResult(context.TODO(), tcs[0].G, libkb.ResolvedAssertion{
 		Assertion: assertion,

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -421,7 +421,7 @@ func (tx *AddMemberTx) AddMemberByUsername(ctx context.Context, username string,
 // If it's an email (or phone) assertion, we assert that it only has one part (and isn't a+b compound).
 // If there is only one factor in the assertion, then that's returned. Otherwise, nil.
 func preprocessAssertion(m libkb.MetaContext, s string) (isServerTrustInvite bool, single libkb.AssertionURL, err error) {
-	a, err := externals.AssertionParseAndOnly(m.G(), s)
+	a, err := externals.AssertionParseAndOnly(m, s)
 	if err != nil {
 		return false, nil, err
 	}


### PR DESCRIPTION
CI basically passed. `TestPrefetcherForSyncedTLF` is today's 👻 