### PR TITLE
Fix adding yourself to a subteam with new role picker

### DIFF
--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -327,6 +327,11 @@ const getDisabledReasonsForRolePicker = (
   teamname: Types.Teamname,
   memberToModify: ?string
 ): Types.DisabledReasonsForRolePicker => {
+  const canManageMembers = getCanPerform(state, teamname).manageMembers
+  if (canManageMembers) {
+    // If you're an implicit admin, the tests below will fail for you, but you can still change roles.
+    return {}
+  }
   const members = getTeamMembers(state, teamname)
   const member = memberToModify ? members.get(memberToModify) : null
   const theyAreOwner = member ? member.type === 'owner' : false

--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -330,7 +330,7 @@ const getDisabledReasonsForRolePicker = (
   const canManageMembers = getCanPerform(state, teamname).manageMembers
   if (canManageMembers) {
     // If you're an implicit admin, the tests below will fail for you, but you can still change roles.
-    return {}
+    return isSubteam(teamname) ? {owner: 'Subteams cannot have owners.'} : {}
   }
   const members = getTeamMembers(state, teamname)
   const member = memberToModify ? members.get(memberToModify) : null
@@ -343,7 +343,9 @@ const getDisabledReasonsForRolePicker = (
   if (yourRole !== 'owner' && yourRole !== 'admin') {
     return {
       admin: 'You must be at least an admin to make role changes.',
-      owner: 'You must be at least an admin to make role changes.',
+      owner: isSubteam(teamname)
+        ? 'Subteams cannot have owners'
+        : 'You must be at least an admin to make role changes.',
       reader: 'You must be at least an admin to make role changes.',
       writer: 'You must be at least an admin to make role changes.',
     }
@@ -353,7 +355,9 @@ const getDisabledReasonsForRolePicker = (
   if (theyAreOwner && yourRole !== 'owner') {
     return {
       admin: `Only owners can change another owner's role`,
-      owner: `Only owners can change another owner's role`,
+      owner: isSubteam(teamname)
+        ? 'Subteams cannot have owners.'
+        : `Only owners can change another owner's role`,
       reader: `Only owners can change another owner's role`,
       writer: `Only owners can change another owner's role`,
     }
@@ -362,7 +366,9 @@ const getDisabledReasonsForRolePicker = (
   // We shouldn't get here, but in case we do this is correct.
   if (yourRole !== 'owner') {
     return {
-      owner: `Only owners can turn members into owners`,
+      owner: isSubteam(teamname)
+        ? 'Subteams cannot have owners.'
+        : `Only owners can turn members into owners`,
     }
   }
 


### PR DESCRIPTION
@keybase/react-hackers CC @MarcoPolo 

Adding yourself to a subteam wasn't possible, because getDisabledReasonsForRolepicker noticed that you aren't an admin and refused to show you the options.  In the implicit admin case of a subteam, you don't have any role on the team at all, but you're still allowed to manage members.

This PR makes it so that the ultimate test of whether you can perform the add comes from the service (via canUserPerform.manageMembers).  If manageMembers says you can't, then the existing code seems correct to explain why to the user.