### PR TITLE
libkbfs init: behave nicer when levelDBs won't open

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1110,8 +1110,10 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 	if bms != nil {
 		bms.Shutdown()
 	}
-	if err := c.conflictResolutionDB.Close(); err != nil {
-		errorList = append(errorList, err)
+	if c.conflictResolutionDB != nil {
+		if err := c.conflictResolutionDB.Close(); err != nil {
+			errorList = append(errorList, err)
+		}
 	}
 	kbfsServ := c.kbfsService
 	if kbfsServ != nil {
@@ -1423,7 +1425,9 @@ func (c *ConfigLocal) MakeBlockMetadataStoreIfNotExists() (err error) {
 	}
 	c.blockMetadataStore, err = newDiskBlockMetadataStore(c)
 	if err != nil {
-		// TODO: open read-only instead KBFS-3659
+		// TODO (KBFS-3659): when we can open levelDB read-only,
+		//  do that instead of returning a Noop version.
+		c.blockMetadataStore = &NoopBlockMetadataStore{}
 		return err
 	}
 	return nil

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -835,9 +835,6 @@ func doInit(
 	if err != nil {
 		log.CWarningf(ctx,
 			"Could not initialize block metadata store: %+v", err)
-		return nil, err
-		// TODO (KBFS-3659): when we can open levelDB read-only, re-enable
-		//                   this, instead of failing the init.
 		/*
 			notification := &keybase1.FSNotification{
 				StatusCode:       keybase1.FSStatusCode_ERROR,


### PR DESCRIPTION
 - CR DB can be null now
 - disk metadata store replaced with noop DB when busy

Issue: KBFS-4107