### PR TITLE
Put search bar inside 'Browse people' TODO

### DIFF
--- a/shared/people/container.js
+++ b/shared/people/container.js
@@ -19,9 +19,6 @@ const mapStateToPropsHeader = state => ({
 
 const mapDispatchToPropsHeader = dispatch => ({
   onClickUser: (username: string) => dispatch(createShowUserProfile({username})),
-  onSearch: () => {
-    dispatch(createSearchSuggestions({searchKey: 'profileSearch'}))
-  },
 })
 
 const mergePropsHeader = (stateProps, dispatchProps) => ({
@@ -39,7 +36,6 @@ type Props = {
   newItems: I.List<Types.PeopleScreenItem>,
   followSuggestions: I.List<Types.FollowSuggestion>,
   getData: (markViewed?: boolean) => void,
-  onSearch: () => void,
   onClickUser: (username: string) => void,
   showAirdrop: boolean,
   myUsername: string,
@@ -47,7 +43,6 @@ type Props = {
 }
 
 class LoadOnMount extends React.PureComponent<Props> {
-  _onSearch = () => this.props.onSearch()
   _onReload = () => this.props.getData(false)
   _getData = (markViewed?: boolean) => this.props.getData(markViewed)
   _onClickUser = (username: string) => this.props.onClickUser(username)
@@ -65,7 +60,6 @@ class LoadOnMount extends React.PureComponent<Props> {
           myUsername={this.props.myUsername}
           waiting={this.props.waiting}
           getData={this._getData}
-          onSearch={this._onSearch}
           onClickUser={this._onClickUser}
           showAirdrop={this.props.showAirdrop}
         />

--- a/shared/people/index.desktop.js
+++ b/shared/people/index.desktop.js
@@ -5,7 +5,7 @@ import * as Styles from '../styles'
 import {PeoplePageList} from './index.shared'
 import {type Props} from '.'
 import flags from '../util/feature-flags'
-import ProfileSearch from '../profile/search/bar'
+import ProfileSearch from '../profile/search/bar-container'
 
 export const Header = flags.useNewRouter
   ? (props: Props) => (
@@ -13,7 +13,7 @@ export const Header = flags.useNewRouter
         <Kb.Text type="Header" style={styles.sectionTitle}>
           People
         </Kb.Text>
-        <ProfileSearch onSearch={props.onSearch} />
+        <ProfileSearch />
       </Kb.Box2>
     )
   : (props: Props) => (
@@ -32,7 +32,7 @@ export const Header = flags.useNewRouter
             label: 'Avatar',
           },
         ]}
-        titleComponent={<ProfileSearch onSearch={props.onSearch} />}
+        titleComponent={<ProfileSearch />}
       />
     )
 const People = (props: Props) => (
@@ -40,7 +40,7 @@ const People = (props: Props) => (
     {props.waiting && <Kb.ProgressIndicator style={styles.progress} />}
     {!flags.useNewRouter && (
       <Kb.Box2 direction="horizontal" centerChildren={true} style={styles.searchContainer}>
-        <ProfileSearch onSearch={props.onSearch} />
+        <ProfileSearch />
       </Kb.Box2>
     )}
     <PeoplePageList {...props} />

--- a/shared/people/index.js.flow
+++ b/shared/people/index.js.flow
@@ -7,7 +7,6 @@ export type Props = {
   newItems: Array<Types.PeopleScreenItem>,
   followSuggestions: Array<Types.FollowSuggestion>,
   getData: (markViewed?: boolean) => void,
-  onSearch: () => void,
   onClickUser: (username: string) => void,
   showAirdrop: boolean,
   myUsername: string,
@@ -17,6 +16,5 @@ export type Props = {
 export default class People extends React.Component<Props> {}
 export class Header extends React.Component<{
   onClickUser: string => void,
-  onSearch: () => void,
   myUsername: string,
 }> {}

--- a/shared/people/index.native.js
+++ b/shared/people/index.native.js
@@ -6,7 +6,7 @@ import {type Props} from '.'
 import {globalStyles, styleSheetCreate} from '../styles'
 import {isIOS} from '../constants/platform'
 import flags from '../util/feature-flags'
-import ProfileSearch from '../profile/search/bar'
+import ProfileSearch from '../profile/search/bar-container'
 
 export const Header = (props: Props) => (
   <Kb.HeaderHocHeader
@@ -24,7 +24,7 @@ export const Header = (props: Props) => (
         label: 'Avatar',
       },
     ]}
-    titleComponent={<ProfileSearch onSearch={props.onSearch} />}
+    titleComponent={<ProfileSearch />}
   />
 )
 

--- a/shared/people/todo/container.js
+++ b/shared/people/todo/container.js
@@ -106,7 +106,7 @@ const FollowConnector = connect<TodoOwnProps, _, _, _, _>(
       dispatch(RouteTreeGen.createNavigateAppend({parentPath: [Tabs.peopleTab], path: ['profileSearch']})),
     onDismiss: onSkipTodo('follow', dispatch),
   }),
-  (s, d, o) => ({...o, ...s, ...d})
+  (s, d, o) => ({...o, ...s, ...d, showSearchBar: true})
 )(Task)
 
 const ChatConnector = connect<TodoOwnProps, _, _, _, _>(

--- a/shared/people/todo/container.js
+++ b/shared/people/todo/container.js
@@ -30,7 +30,12 @@ const mapStateToProps = state => ({myUsername: state.config.username || ''})
 const AvatarTeamConnector = connect<TodoOwnProps, _, _, _, _>(
   mapStateToProps,
   dispatch => ({
-    onConfirm: () => dispatch(RouteTreeGen.createSwitchTo({path: [Tabs.teamsTab]})),
+    onConfirm: () =>
+      dispatch(
+        flags.useNewRouter
+          ? RouteTreeGen.createSwitchTab({tab: Tabs.teamsTab})
+          : RouteTreeGen.createSwitchTo({path: [Tabs.teamsTab]})
+      ),
     onDismiss: () => {},
   }),
   (stateProps, dispatchProps, ownProps) => ({
@@ -112,7 +117,12 @@ const FollowConnector = connect<TodoOwnProps, _, _, _, _>(
 const ChatConnector = connect<TodoOwnProps, _, _, _, _>(
   () => ({}),
   dispatch => ({
-    onConfirm: () => dispatch(RouteTreeGen.createSwitchTo({path: [Tabs.chatTab]})),
+    onConfirm: () =>
+      dispatch(
+        flags.useNewRouter
+          ? RouteTreeGen.createSwitchTab({tab: Tabs.chatTab})
+          : RouteTreeGen.createSwitchTo({path: [Tabs.chatTab]})
+      ),
     onDismiss: onSkipTodo('chat', dispatch),
   }),
   (s, d, o) => ({...o, ...s, ...d})
@@ -165,6 +175,10 @@ const FolderConnector = connect<TodoOwnProps, _, _, _, _>(
   () => ({}),
   dispatch => ({
     onConfirm: () => {
+      if (flags.useNewRouter) {
+        dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.fsTab}))
+        return
+      }
       if (!isMobile) {
         dispatch(RouteTreeGen.createNavigateTo({parentPath: [Tabs.folderTab], path: ['private']}))
         dispatch(RouteTreeGen.createSwitchTo({path: [Tabs.folderTab]}))
@@ -187,6 +201,17 @@ const GitRepoConnector = connect<TodoOwnProps, _, _, _, _>(
   () => ({}),
   dispatch => ({
     onConfirm: () => {
+      if (flags.useNewRouter) {
+        if (isMobile) {
+          dispatch(RouteTreeGen.createNavigateAppend({path: [SettingsTabs.gitTab]}))
+        } else {
+          dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.gitTab}))
+        }
+        dispatch(
+          RouteTreeGen.createNavigateAppend({path: [{props: {isTeam: false}, selected: 'gitNewRepo'}]})
+        )
+        return
+      }
       dispatch(
         RouteTreeGen.createNavigateTo({
           parentPath: [Tabs.gitTab],
@@ -204,6 +229,10 @@ const TeamShowcaseConnector = connect<TodoOwnProps, _, _, _, _>(
   () => ({}),
   dispatch => ({
     onConfirm: () => {
+      if (flags.useNewRouter) {
+        dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.teamsTab}))
+        return
+      }
       // TODO find a team that the current user is an admin of and nav there?
       dispatch(RouteTreeGen.createNavigateTo({parentPath: [Tabs.teamsTab], path: []}))
       dispatch(RouteTreeGen.createSwitchTo({path: [Tabs.teamsTab]}))

--- a/shared/people/todo/index.js
+++ b/shared/people/todo/index.js
@@ -18,7 +18,7 @@ export type Props = {
 
 export const Task = (props: Props) => (
   <PeopleItem format="multi" badged={props.badged} icon={<Icon type={props.icon} />}>
-    <Text type="Body" style={{marginRight: Styles.isMobile ? 112 : 80, marginTop: 2}}>
+    <Text type="Body" style={styles.instructions}>
       {props.instructions}
     </Text>
     <Box style={styles.actionContainer}>
@@ -47,7 +47,10 @@ const styles = Styles.styleSheetCreate({
     alignItems: 'center',
     flexWrap: 'wrap',
     justifyContent: 'flex-start',
+    marginRight: Styles.isMobile ? 112 : 80,
+    width: 'auto',
   },
+  instructions: {marginRight: Styles.isMobile ? 112 : 80, marginTop: 2},
   search: {
     alignSelf: undefined,
     flexGrow: 0,

--- a/shared/people/todo/index.js
+++ b/shared/people/todo/index.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import PeopleItem from '../item'
 import {Box, Button, Icon, Text, type IconType} from '../../common-adapters'
+import PeopleSearch from '../../profile/search/bar-container'
 import * as Styles from '../../styles'
 
 export type Props = {
@@ -12,6 +13,7 @@ export type Props = {
   dismissable: boolean,
   onConfirm: () => void,
   onDismiss: () => void,
+  showSearchBar?: boolean,
 }
 
 export const Task = (props: Props) => (
@@ -19,13 +21,17 @@ export const Task = (props: Props) => (
     <Text type="Body" style={{marginRight: Styles.isMobile ? 112 : 80, marginTop: 2}}>
       {props.instructions}
     </Text>
-    <Box style={actionContainerStyle}>
-      <Button
-        small={true}
-        label={props.confirmLabel}
-        onClick={props.onConfirm}
-        style={{marginRight: Styles.globalMargins.small}}
-      />
+    <Box style={styles.actionContainer}>
+      {props.showSearchBar ? (
+        <PeopleSearch style={styles.search} />
+      ) : (
+        <Button
+          small={true}
+          label={props.confirmLabel}
+          onClick={props.onConfirm}
+          style={{marginRight: Styles.globalMargins.small}}
+        />
+      )}
       {props.dismissable && (
         <Text type="BodyPrimaryLink" onClick={props.onDismiss}>
           Later
@@ -35,9 +41,15 @@ export const Task = (props: Props) => (
   </PeopleItem>
 )
 
-const actionContainerStyle = {
-  ...Styles.globalStyles.flexBoxRow,
-  alignItems: 'center',
-  flexWrap: 'wrap',
-  justifyContent: 'flex-start',
-}
+const styles = Styles.styleSheetCreate({
+  actionContainer: {
+    ...Styles.globalStyles.flexBoxRow,
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-start',
+  },
+  search: {
+    alignSelf: undefined,
+    flexGrow: 0,
+  },
+})

--- a/shared/profile/search/bar-container.js
+++ b/shared/profile/search/bar-container.js
@@ -1,0 +1,22 @@
+// @flow
+import * as Container from '../../util/container'
+import type {StylesCrossPlatform} from '../../styles'
+import {createSearchSuggestions} from '../../actions/search-gen'
+import Bar from './bar'
+
+type OwnProps = {|style?: StylesCrossPlatform, whiteText?: boolean|}
+
+const mapDispatchToProps = dispatch => ({
+  onSearch: () => {
+    dispatch(createSearchSuggestions({searchKey: 'profileSearch'}))
+  },
+})
+
+const mergeProps = (_, dispatchProps, ownProps) => ({...ownProps, ...dispatchProps})
+
+export default Container.namedConnect<OwnProps, _, _, _, _>(
+  () => ({}),
+  mapDispatchToProps,
+  mergeProps,
+  'PeopleTabSearch'
+)(Bar)

--- a/shared/profile/search/bar.js
+++ b/shared/profile/search/bar.js
@@ -49,7 +49,8 @@ class ProfileSearch extends React.PureComponent<Props, State> {
           visible={this.state.show}
           onHidden={this._onHide}
           attachTo={this._getAttachmentRef}
-          position={flags.useNewRouter ? 'top left' : 'top center'}
+          position={flags.useNewRouter ? 'bottom left' : 'bottom center'}
+          positionFallbacks={[]}
           style={styles.overlay}
         >
           <Search onClose={this._onHide} />

--- a/shared/profile/search/bar.js
+++ b/shared/profile/search/bar.js
@@ -5,7 +5,7 @@ import * as Styles from '../../styles'
 import flags from '../../util/feature-flags'
 import Search from './container'
 
-type Props = {|onSearch: () => void, whiteText?: boolean|}
+type Props = {|onSearch: () => void, style?: Styles.StylesCrossPlatform, whiteText?: boolean|}
 type State = {|show: boolean|}
 
 class ProfileSearch extends React.PureComponent<Props, State> {
@@ -20,7 +20,11 @@ class ProfileSearch extends React.PureComponent<Props, State> {
   _getAttachmentRef = () => this._ref.current
   render() {
     return (
-      <Kb.Box2 style={styles.container} direction="horizontal" ref={this._ref}>
+      <Kb.Box2
+        style={Styles.collapseStyles([styles.container, this.props.style])}
+        direction="horizontal"
+        ref={this._ref}
+      >
         <Kb.ClickableBox
           onClick={this._onShow}
           style={Styles.collapseStyles([styles.searchContainer, this.state.show && {opacity: 0}])}


### PR DESCRIPTION
Edit: went with putting the search bar inside the TODO at nojima's suggestion. @keybase/react-hackers 

<img width="442" alt="image" src="https://user-images.githubusercontent.com/11968340/57140037-d0573e80-6d84-11e9-938d-e2b80b88d28d.png">

I [originally tried](https://github.com/keybase/client/compare/danny/DESKTOP-9570-nav2-todos?expand=1) passing the counter from the page body -> through navigation params -> to the page header, but ran into issues with the header remounting when the param changes. 

This is a lot of work to control something in the header from the page body, open to other suggestions. On the plus side this is resilient to changes in the nav structure. r? @keybase/react-hackers 