### PR TITLE
sync status: minor fix

### DIFF
--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -1010,7 +1010,7 @@ export const getSyncStatusInMergeProps = (
   uploadingPaths: I.Set<Types.Path>,
   path: Types.Path
 ): Types.SyncStatus => {
-  if (!tlf.syncConfig || pathItem === unknownPathItem) {
+  if (!tlf.syncConfig || (pathItem === unknownPathItem && tlf.syncConfig.mode !== 'disabled')) {
     return 'unknown'
   }
   const tlfSyncConfig: Types.TlfSyncConfig = tlf.syncConfig


### PR DESCRIPTION
show "online only" sync state whenever sync is disabled, even if the pathItem is
not loaded.

This, once Song's #17268 is merged, will finish filling in all the gaps in sync status propogation and display.

Issue: KBFS-4113