### PR TITLE
allow disabling of plaintext notifications on desktop

### DIFF
--- a/go/chat/notification_settings.go
+++ b/go/chat/notification_settings.go
@@ -9,10 +9,10 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 )
 
-const disablePlaintextDestkopKey = "disableplaintextdestkop"
+const disablePlaintextDesktopKey = "disableplaintextdesktop"
 
 func setPlaintextDesktopDisabled(ctx context.Context, g *globals.Context, disabled bool) error {
-	_, err := g.GregorState.UpdateCategory(ctx, disablePlaintextDestkopKey,
+	_, err := g.GregorState.UpdateCategory(ctx, disablePlaintextDesktopKey,
 		[]byte(strconv.FormatBool(disabled)), gregor1.TimeOrOffset{})
 	return err
 }
@@ -22,7 +22,7 @@ func getPlaintextDesktopDisabled(ctx context.Context, g *globals.Context) (bool,
 	if err != nil {
 		return false, err
 	}
-	cat, err := gregor1.ObjFactory{}.MakeCategory(disablePlaintextDestkopKey)
+	cat, err := gregor1.ObjFactory{}.MakeCategory(disablePlaintextDesktopKey)
 	if err != nil {
 		return false, err
 	}
@@ -40,15 +40,15 @@ func getPlaintextDesktopDisabled(ctx context.Context, g *globals.Context) (bool,
 
 func getGlobalAppNotificationSettings(ctx context.Context, g *globals.Context, ri func() chat1.RemoteInterface) (
 	res chat1.GlobalAppNotificationSettings, err error) {
+	settings, err := ri().GetGlobalAppNotificationSettings(ctx)
+	if err != nil {
+		return res, err
+	}
 	plaintextDesktopDisabled, err := getPlaintextDesktopDisabled(ctx, g)
 	if err != nil {
 		return res, err
 	}
 
-	settings, err := ri().GetGlobalAppNotificationSettings(ctx)
-	if err != nil {
-		return res, err
-	}
 	settings.Settings[chat1.GlobalAppNotificationSetting_PLAINTEXTDESKTOP] = !plaintextDesktopDisabled
 	return settings, nil
 }
@@ -75,6 +75,9 @@ func setGlobalAppNotificationSettings(ctx context.Context, g *globals.Context, r
 		default:
 			settings.Settings[gkey] = v
 		}
+	}
+	if len(settings.Settings) == 0 {
+		return nil
 	}
 	return ri().SetGlobalAppNotificationSettings(ctx, settings)
 }

--- a/go/chat/notification_settings.go
+++ b/go/chat/notification_settings.go
@@ -1,0 +1,80 @@
+package chat
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+)
+
+const disablePlaintextDestkopKey = "disableplaintextdestkop"
+
+func setPlaintextDesktopDisabled(ctx context.Context, g *globals.Context, disabled bool) error {
+	_, err := g.GregorState.UpdateCategory(ctx, disablePlaintextDestkopKey,
+		[]byte(strconv.FormatBool(disabled)), gregor1.TimeOrOffset{})
+	return err
+}
+
+func getPlaintextDesktopDisabled(ctx context.Context, g *globals.Context) (bool, error) {
+	st, err := g.GregorState.State(ctx)
+	if err != nil {
+		return false, err
+	}
+	cat, err := gregor1.ObjFactory{}.MakeCategory(disablePlaintextDestkopKey)
+	if err != nil {
+		return false, err
+	}
+	items, err := st.ItemsWithCategoryPrefix(cat)
+	if err != nil {
+		return false, err
+	}
+	if len(items) > 0 {
+		it := items[0]
+		body := string(it.Body().Bytes())
+		return strconv.ParseBool(body)
+	}
+	return false, nil
+}
+
+func getGlobalAppNotificationSettings(ctx context.Context, g *globals.Context, ri func() chat1.RemoteInterface) (
+	res chat1.GlobalAppNotificationSettings, err error) {
+	plaintextDesktopDisabled, err := getPlaintextDesktopDisabled(ctx, g)
+	if err != nil {
+		return res, err
+	}
+
+	settings, err := ri().GetGlobalAppNotificationSettings(ctx)
+	if err != nil {
+		return res, err
+	}
+	settings.Settings[chat1.GlobalAppNotificationSetting_PLAINTEXTDESKTOP] = !plaintextDesktopDisabled
+	return settings, nil
+}
+
+func setGlobalAppNotificationSettings(ctx context.Context, g *globals.Context, ri func() chat1.RemoteInterface,
+	strSettings map[string]bool) error {
+
+	var settings chat1.GlobalAppNotificationSettings
+	settings.Settings = make(map[chat1.GlobalAppNotificationSetting]bool)
+	for k, v := range strSettings {
+		key, err := strconv.Atoi(k)
+		if err != nil {
+			g.Log.CDebugf(ctx, "setGlobalAppNotificationSettings: failed to convert key: %s", err.Error())
+			continue
+		}
+		gkey := chat1.GlobalAppNotificationSetting(key)
+		g.Log.CDebugf(ctx, "setGlobalAppNotificationSettings: setting typ: %s enabled: %v",
+			chat1.GlobalAppNotificationSettingRevMap[gkey], v)
+		switch gkey {
+		case chat1.GlobalAppNotificationSetting_PLAINTEXTDESKTOP:
+			if err := setPlaintextDesktopDisabled(ctx, g, !v); err != nil {
+				return err
+			}
+		default:
+			settings.Settings[gkey] = v
+		}
+	}
+	return ri().SetGlobalAppNotificationSettings(ctx, settings)
+}

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -574,8 +574,12 @@ func (g *PushHandler) Activity(ctx context.Context, m gregor.OutOfBandMessage) (
 				desktopNotification := g.shouldDisplayDesktopNotification(ctx, uid, conv, decmsg)
 				notificationSnippet := ""
 				if desktopNotification {
+					plaintextDesktopDisabled, err := getPlaintextDesktopDisabled(ctx, g.G())
+					if err != nil {
+						g.Debug(ctx, "chat activity: unable to get app notification settings: %v defaulting to disable plaintext", err)
+					}
 					notificationSnippet = utils.GetDesktopNotificationSnippet(conv,
-						g.G().Env.GetUsername().String(), &decmsg)
+						g.G().Env.GetUsername().String(), &decmsg, plaintextDesktopDisabled)
 				}
 				activity = new(chat1.ChatActivity)
 				*activity = chat1.NewChatActivityWithIncomingMessage(chat1.IncomingMessage{

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"regexp"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -2076,21 +2075,7 @@ func (h *Server) SetGlobalAppNotificationSettingsLocal(ctx context.Context,
 	if _, err = utils.AssertLoggedInUID(ctx, h.G()); err != nil {
 		return err
 	}
-	var settings chat1.GlobalAppNotificationSettings
-	settings.Settings = make(map[chat1.GlobalAppNotificationSetting]bool)
-	for k, v := range strSettings {
-		key, err := strconv.Atoi(k)
-		if err != nil {
-			h.Debug(ctx, "SetGlobalAppNotificationSettings: failed to convert key: %s", err.Error())
-			continue
-		}
-		gkey := chat1.GlobalAppNotificationSetting(key)
-		h.Debug(ctx, "SetGlobalAppNotificationSettings: setting typ: %s enabled: %v",
-			chat1.GlobalAppNotificationSettingRevMap[gkey], v)
-		settings.Settings[gkey] = v
-	}
-
-	return h.remoteClient().SetGlobalAppNotificationSettings(ctx, settings)
+	return setGlobalAppNotificationSettings(ctx, h.G(), h.remoteClient, strSettings)
 }
 
 func (h *Server) GetGlobalAppNotificationSettingsLocal(ctx context.Context) (res chat1.GlobalAppNotificationSettings, err error) {
@@ -2099,7 +2084,7 @@ func (h *Server) GetGlobalAppNotificationSettingsLocal(ctx context.Context) (res
 	if _, err = utils.AssertLoggedInUID(ctx, h.G()); err != nil {
 		return res, err
 	}
-	return h.remoteClient().GetGlobalAppNotificationSettings(ctx)
+	return getGlobalAppNotificationSettings(ctx, h.G(), h.remoteClient)
 }
 
 func (h *Server) AddTeamMemberAfterReset(ctx context.Context,

--- a/go/engine/track_token_test.go
+++ b/go/engine/track_token_test.go
@@ -449,6 +449,11 @@ func (d *FakeGregorState) State(ctx context.Context) (gregor.State, error) {
 	return nil, nil
 }
 
+func (d *FakeGregorState) UpdateCategory(ctx context.Context, cat string, body []byte,
+	dtime gregor1.TimeOrOffset) (res gregor1.MsgID, err error) {
+	return gregor1.MsgID{}, nil
+}
+
 func (d *FakeGregorState) InjectItem(ctx context.Context, cat string, body []byte, dtime gregor1.TimeOrOffset) (gregor1.MsgID, error) {
 	return nil, nil
 }

--- a/go/libkb/gregor_stub.go
+++ b/go/libkb/gregor_stub.go
@@ -17,6 +17,11 @@ func (n nullGregorState) State(ctx context.Context) (gregor.State, error) {
 	return gregor1.State{}, nil
 }
 
+func (n nullGregorState) UpdateCategory(ctx context.Context, cat string, body []byte,
+	dtime gregor1.TimeOrOffset) (gregor1.MsgID, error) {
+	return gregor1.MsgID{}, nil
+}
+
 func (n nullGregorState) InjectItem(ctx context.Context, cat string, body []byte, dtime gregor1.TimeOrOffset) (gregor1.MsgID, error) {
 	return gregor1.MsgID{}, nil
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -516,6 +516,8 @@ type Clock interface {
 
 type GregorState interface {
 	State(ctx context.Context) (gregor.State, error)
+	UpdateCategory(ctx context.Context, cat string, body []byte,
+		dtime gregor1.TimeOrOffset) (res gregor1.MsgID, err error)
 	InjectItem(ctx context.Context, cat string, body []byte, dtime gregor1.TimeOrOffset) (gregor1.MsgID, error)
 	DismissItem(ctx context.Context, cli gregor1.IncomingInterface, id gregor.MsgID) error
 	LocalDismissItem(ctx context.Context, id gregor.MsgID) error

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -476,6 +476,11 @@ func (f *FakeGregorState) State(_ context.Context) (gregor.State, error) {
 	return gregor1.State{}, nil
 }
 
+func (f *FakeGregorState) UpdateCategory(ctx context.Context, cat string, body []byte,
+	dtime gregor1.TimeOrOffset) (gregor1.MsgID, error) {
+	return gregor1.MsgID{}, nil
+}
+
 func (f *FakeGregorState) InjectItem(ctx context.Context, cat string, body []byte, dtime gregor1.TimeOrOffset) (gregor1.MsgID, error) {
 	return gregor1.MsgID{}, nil
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -2226,6 +2226,8 @@ func (g GlobalAppNotificationSetting) Usage() string {
 	switch g {
 	case GlobalAppNotificationSetting_NEWMESSAGES:
 		return "Show notifications for new messages"
+	case GlobalAppNotificationSetting_PLAINTEXTDESKTOP:
+		return "Show plaintext notifications on desktop devices"
 	case GlobalAppNotificationSetting_PLAINTEXTMOBILE:
 		return "Show plaintext notifications on mobile devices"
 	case GlobalAppNotificationSetting_DEFAULTSOUNDMOBILE:
@@ -2241,6 +2243,8 @@ func (g GlobalAppNotificationSetting) FlagName() string {
 	switch g {
 	case GlobalAppNotificationSetting_NEWMESSAGES:
 		return "new-messages"
+	case GlobalAppNotificationSetting_PLAINTEXTDESKTOP:
+		return "plaintext-desktop"
 	case GlobalAppNotificationSetting_PLAINTEXTMOBILE:
 		return "plaintext-mobile"
 	case GlobalAppNotificationSetting_DEFAULTSOUNDMOBILE:

--- a/shared/actions/settings.js
+++ b/shared/actions/settings.js
@@ -311,6 +311,13 @@ function* refreshNotifications() {
         ],
       },
       {
+        description: 'Display desktop plaintext notifications',
+        name: 'plaintextdesktop',
+        subscribed: !!chatGlobalSettings.settings[
+          `${ChatTypes.commonGlobalAppNotificationSetting.plaintextdesktop}`
+        ],
+      },
+      {
         description: 'Disable sending/receiving typing notifications',
         name: 'disabletyping',
         subscribed: !!chatGlobalSettings.settings[


### PR DESCRIPTION
Allow users to toggle if desktop notifications show a preview of an incoming message. When disabled notifications look like this (on macos):
![Screen Shot 2019-05-02 at 5 27 41 PM](https://user-images.githubusercontent.com/1144020/57108635-65b0ef00-6d01-11e9-9bd1-8e7c97f77d8f.png)

setting option:
![image](https://user-images.githubusercontent.com/1144020/57109179-c856ba80-6d02-11e9-9226-77ac0497017f.png)



relates to:
https://github.com/keybase/client/issues/15620
https://github.com/keybase/client/issues/8731
https://github.com/keybase/client/issues/7991
https://github.com/keybase/client/issues/7269
https://github.com/keybase/keybase-issues/issues/3348


cc @heronhaye 