### PR TITLE
More linux autorestart fixes CORE-10818

### DIFF
--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -106,9 +106,6 @@ safe_restart_systemd_services() {
         fi
 
         if systemd_unit_active_for "$user" "kbfs.service"; then
-            # TODO: CORE-9789
-            # We don't pass --direct to keybase config get because it doesn't work on non-root users
-            # It should still work because the service should be running
             if ! mount="$(systemd_exec_as "$user" "/usr/bin/keybase config get --direct --bare mountdir")" || [ -z "$mount" ]; then
                 echo "Could not find mountdir for $user via systemd."
                 echo "$abort_instructions"

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -9,7 +9,7 @@
 # To disable this behavior, create /etc/keybase/config.json if it doesn't exist
 # and add the key value pair { "disable-autorestart": true }.
 
-set -u
+set -u -x
 
 rootmount="/keybase"
 krbin="/usr/bin/keybase-redirector"

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -81,7 +81,9 @@ safe_restart_systemd_services() {
         return 0
     fi
 
+    echo 4 | systemd-cat
     while read -r pid; do
+        echo "5$pid" | systemd-cat
         if [ -z "$pid" ]; then
             continue
         fi
@@ -96,6 +98,7 @@ safe_restart_systemd_services() {
             continue
         fi
 
+        echo "6" | systemd-cat
         restart_instructions="Restart Keybase manually by running 'run_keybase' as $user."
         abort_instructions="Aborting Keybase autorestart for $user. $restart_instructions"
 
@@ -105,6 +108,7 @@ safe_restart_systemd_services() {
             continue
         fi
 
+        echo "7" | systemd-cat
         if systemd_unit_active_for "$user" "kbfs.service"; then
             # TODO: CORE-9789
             # We don't pass --direct to keybase config get because it doesn't work on non-root users
@@ -126,14 +130,21 @@ safe_restart_systemd_services() {
                 continue
             fi
         fi
+        echo "8" | systemd-cat
 
         echo "Autorestarting Keybase via systemd for $user."
         # Reload possibly-new systemd unit files first
+        echo "9" | systemd-cat
         systemd_exec_as "$user" "systemctl --user daemon-reload"
+        echo "10" | systemd-cat
         systemd_restart_if_active "$user" "keybase-redirector.service"
+        echo "11" | systemd-cat
         systemd_restart_if_active "$user" "keybase.gui.service"
+        echo "12" | systemd-cat
         systemd_restart_if_active "$user" "kbfs.service"
+        echo "13" | systemd-cat
         systemd_restart_if_active "$user" "keybase.service"
+        echo "14" | systemd-cat
     done <<< "$(pidof /usr/bin/keybase | tr ' ' '\n')"
 }
 
@@ -217,12 +228,16 @@ elif [ -d "$rootmount" ] ; then
     fi
 fi
 
+echo 1 | systemd-cat
+
 # Make the mountpoint if it doesn't already exist by this point.
 make_mountpoint
+echo 2 | systemd-cat
 
 # Update the GTK icon cache, if possible.
 if command -v gtk-update-icon-cache &> /dev/null ; then
   gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
 fi
+echo 3 | systemd-cat
 
 safe_restart_systemd_services

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -109,29 +109,29 @@ safe_restart_systemd_services() {
         fi
 
         echo "7" | systemd-cat
-        # if systemd_unit_active_for "$user" "kbfs.service"; then
-        #     # # TODO: CORE-9789
-        #     # # We don't pass --direct to keybase config get because it doesn't work on non-root users
-        #     # # It should still work because the service should be running
-        #     # if ! mount="$(systemd_exec_as "$user" "/usr/bin/keybase config get --bare mountdir")" || [ -z "$mount" ]; then
-        #     #     echo "Could not find mountdir for $user via systemd."
-        #     #     echo "$abort_instructions"
-        #     #     continue
-        #     # fi
+        if systemd_unit_active_for "$user" "kbfs.service"; then
+            # TODO: CORE-9789
+            # We don't pass --direct to keybase config get because it doesn't work on non-root users
+            # It should still work because the service should be running
+            if ! mount="$(systemd_exec_as "$user" "/usr/bin/keybase config get --direct --bare mountdir")" || [ -z "$mount" ]; then
+                echo "Could not find mountdir for $user via systemd."
+                echo "$abort_instructions"
+                continue
+            fi
 
-        #     echo "7.5" | systemd-cat
+            echo "7.5" | systemd-cat
 
-        #     # # Mount found, abort autorestart for user if currently being used.
-        #     # # lsof exits with zero iff there are no errors and mount is being used
-        #     # # Be slightly aggressive and restart if lsof did hit errors (e.g., if mount didn't exist)
-        #     # if lsof_output="$(systemd_exec_as "$user" "lsof $mount" 2> /dev/null)"; then
-        #     #     programs_accessing_mount="$(echo "$lsof_output" | tail -n +2 | awk '{print $1}' | tr '\n' ', ')"
-        #     #     echo "KBFS mount $mount for user $user currently in use by ($programs_accessing_mount)."
-        #     #     echo "Please stop these processes before restarting manually."
-        #     #     echo "$abort_instructions"
-        #     #     continue
-        #     # fi
-        # fi
+            # Mount found, abort autorestart for user if currently being used.
+            # lsof exits with zero iff there are no errors and mount is being used
+            # Be slightly aggressive and restart if lsof did hit errors (e.g., if mount didn't exist)
+            if lsof_output="$(systemd_exec_as "$user" "lsof $mount" 2> /dev/null)"; then
+                programs_accessing_mount="$(echo "$lsof_output" | tail -n +2 | awk '{print $1}' | tr '\n' ', ')"
+                echo "KBFS mount $mount for user $user currently in use by ($programs_accessing_mount)."
+                echo "Please stop these processes before restarting manually."
+                echo "$abort_instructions"
+                continue
+            fi
+        fi
         echo "8" | systemd-cat
 
         echo "Autorestarting Keybase via systemd for $user."

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -109,27 +109,29 @@ safe_restart_systemd_services() {
         fi
 
         echo "7" | systemd-cat
-        if systemd_unit_active_for "$user" "kbfs.service"; then
-            # TODO: CORE-9789
-            # We don't pass --direct to keybase config get because it doesn't work on non-root users
-            # It should still work because the service should be running
-            if ! mount="$(systemd_exec_as "$user" "/usr/bin/keybase config get --bare mountdir")" || [ -z "$mount" ]; then
-                echo "Could not find mountdir for $user via systemd."
-                echo "$abort_instructions"
-                continue
-            fi
+        # if systemd_unit_active_for "$user" "kbfs.service"; then
+        #     # # TODO: CORE-9789
+        #     # # We don't pass --direct to keybase config get because it doesn't work on non-root users
+        #     # # It should still work because the service should be running
+        #     # if ! mount="$(systemd_exec_as "$user" "/usr/bin/keybase config get --bare mountdir")" || [ -z "$mount" ]; then
+        #     #     echo "Could not find mountdir for $user via systemd."
+        #     #     echo "$abort_instructions"
+        #     #     continue
+        #     # fi
 
-            # Mount found, abort autorestart for user if currently being used.
-            # lsof exits with zero iff there are no errors and mount is being used
-            # Be slightly aggressive and restart if lsof did hit errors (e.g., if mount didn't exist)
-            if lsof_output="$(systemd_exec_as "$user" "lsof $mount" 2> /dev/null)"; then
-                programs_accessing_mount="$(echo "$lsof_output" | tail -n +2 | awk '{print $1}' | tr '\n' ', ')"
-                echo "KBFS mount $mount for user $user currently in use by ($programs_accessing_mount)."
-                echo "Please stop these processes before restarting manually."
-                echo "$abort_instructions"
-                continue
-            fi
-        fi
+        #     echo "7.5" | systemd-cat
+
+        #     # # Mount found, abort autorestart for user if currently being used.
+        #     # # lsof exits with zero iff there are no errors and mount is being used
+        #     # # Be slightly aggressive and restart if lsof did hit errors (e.g., if mount didn't exist)
+        #     # if lsof_output="$(systemd_exec_as "$user" "lsof $mount" 2> /dev/null)"; then
+        #     #     programs_accessing_mount="$(echo "$lsof_output" | tail -n +2 | awk '{print $1}' | tr '\n' ', ')"
+        #     #     echo "KBFS mount $mount for user $user currently in use by ($programs_accessing_mount)."
+        #     #     echo "Please stop these processes before restarting manually."
+        #     #     echo "$abort_instructions"
+        #     #     continue
+        #     # fi
+        # fi
         echo "8" | systemd-cat
 
         echo "Autorestarting Keybase via systemd for $user."

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -130,10 +130,10 @@ safe_restart_systemd_services() {
         echo "Autorestarting Keybase via systemd for $user."
         # Reload possibly-new systemd unit files first
         systemd_exec_as "$user" "systemctl --user daemon-reload"
-        systemd_restart_if_active "$user" "keybase.service"
-        systemd_restart_if_active "$user" "kbfs.service"
-        systemd_restart_if_active "$user" "keybase.gui.service"
         systemd_restart_if_active "$user" "keybase-redirector.service"
+        systemd_restart_if_active "$user" "keybase.gui.service"
+        systemd_restart_if_active "$user" "kbfs.service"
+        systemd_restart_if_active "$user" "keybase.service"
     done <<< "$(pidof /usr/bin/keybase | tr ' ' '\n')"
 }
 

--- a/packaging/linux/post_install.sh
+++ b/packaging/linux/post_install.sh
@@ -9,7 +9,7 @@
 # To disable this behavior, create /etc/keybase/config.json if it doesn't exist
 # and add the key value pair { "disable-autorestart": true }.
 
-set -u -x
+set -u
 
 rootmount="/keybase"
 krbin="/usr/bin/keybase-redirector"
@@ -81,9 +81,7 @@ safe_restart_systemd_services() {
         return 0
     fi
 
-    echo 4 | systemd-cat
     while read -r pid; do
-        echo "5$pid" | systemd-cat
         if [ -z "$pid" ]; then
             continue
         fi
@@ -98,7 +96,6 @@ safe_restart_systemd_services() {
             continue
         fi
 
-        echo "6" | systemd-cat
         restart_instructions="Restart Keybase manually by running 'run_keybase' as $user."
         abort_instructions="Aborting Keybase autorestart for $user. $restart_instructions"
 
@@ -108,7 +105,6 @@ safe_restart_systemd_services() {
             continue
         fi
 
-        echo "7" | systemd-cat
         if systemd_unit_active_for "$user" "kbfs.service"; then
             # TODO: CORE-9789
             # We don't pass --direct to keybase config get because it doesn't work on non-root users
@@ -118,8 +114,6 @@ safe_restart_systemd_services() {
                 echo "$abort_instructions"
                 continue
             fi
-
-            echo "7.5" | systemd-cat
 
             # Mount found, abort autorestart for user if currently being used.
             # lsof exits with zero iff there are no errors and mount is being used
@@ -132,21 +126,14 @@ safe_restart_systemd_services() {
                 continue
             fi
         fi
-        echo "8" | systemd-cat
 
         echo "Autorestarting Keybase via systemd for $user."
         # Reload possibly-new systemd unit files first
-        echo "9" | systemd-cat
         systemd_exec_as "$user" "systemctl --user daemon-reload"
-        echo "10" | systemd-cat
-        systemd_restart_if_active "$user" "keybase-redirector.service"
-        echo "11" | systemd-cat
-        systemd_restart_if_active "$user" "keybase.gui.service"
-        echo "12" | systemd-cat
-        systemd_restart_if_active "$user" "kbfs.service"
-        echo "13" | systemd-cat
         systemd_restart_if_active "$user" "keybase.service"
-        echo "14" | systemd-cat
+        systemd_restart_if_active "$user" "kbfs.service"
+        systemd_restart_if_active "$user" "keybase.gui.service"
+        systemd_restart_if_active "$user" "keybase-redirector.service"
     done <<< "$(pidof /usr/bin/keybase | tr ' ' '\n')"
 }
 
@@ -230,16 +217,12 @@ elif [ -d "$rootmount" ] ; then
     fi
 fi
 
-echo 1 | systemd-cat
-
 # Make the mountpoint if it doesn't already exist by this point.
 make_mountpoint
-echo 2 | systemd-cat
 
 # Update the GTK icon cache, if possible.
 if command -v gtk-update-icon-cache &> /dev/null ; then
   gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
 fi
-echo 3 | systemd-cat
 
 safe_restart_systemd_services


### PR DESCRIPTION
You suggested this when I wrote this code, but couldn't do it due to another bug in the service. I fixed the service issue a while ago, and adding it seems to makes the restart better:

I did a lot more debugging and it seems that before postinstall even restarts the services with systemd, something else (very mysterious) is shutting keybase.gui and kbfs down outside of systemd. That exits cleanly but later when systemctl goes to restart, they are already stopped so won't be restarted.

It doesn't happen with --direct.

But it's a very odd failure mode, if I build the package and then just install it repeatedly, or run post_install.sh manually, everything works perfectly. It's only when I build and install with the same command that it fails. I think maybe it's affected by the increased CPU usage relating to compiling the app.