### PR TITLE
prefetcher: send status notification right away when out of space

### DIFF
--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -1275,7 +1275,11 @@ func (cache *DiskBlockCacheLocal) DoesCacheHaveSpace(
 		ctx, keybase1.UserOrTeamID("")).(backpressureDiskLimiterStatus)
 	switch cache.cacheType {
 	case syncCacheLimitTrackerType:
-		return limiterStatus.SyncCacheByteStatus.UsedFrac <= .99
+		// The tracker doesn't track sync cache usage because we never
+		// want to throttle it, so rely on our local byte usage count
+		// instead of the fraction returned by the tracker.
+		limit := float64(limiterStatus.SyncCacheByteStatus.Max)
+		return float64(cache.getCurrBytes())/limit <= .99
 	case workingSetCacheLimitTrackerType:
 		return limiterStatus.DiskCacheByteStatus.UsedFrac <= .99
 	case crDirtyBlockCacheLimitTrackerType:

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -216,10 +216,10 @@ func (p *blockPrefetcher) sendOverallSyncStatusHelperLocked() {
 	var status keybase1.FolderSyncStatus
 	status.PrefetchProgress = p.overallSyncStatus.ToProtocolProgress(
 		p.config.Clock())
-	status.PrefetchStatus = p.overallSyncStatus.ToProtocolStatus()
 
 	FillInDiskSpaceStatus(
-		context.Background(), &status, p.config.DiskBlockCache())
+		context.Background(), &status, p.overallSyncStatus.ToProtocolStatus(),
+		p.config.DiskBlockCache())
 
 	p.config.Reporter().NotifyOverallSyncStatus(context.Background(), status)
 	p.lastOverallSyncStatusSent = p.config.Clock().Now()

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -1278,7 +1278,9 @@ func setLimiterLimits(
 	limiter.lock.Lock()
 	defer limiter.lock.Unlock()
 	limiter.syncCacheByteTracker.limit = syncLimit
+	limiter.syncCacheByteTracker.updateSemaphoreMax()
 	limiter.diskCacheByteTracker.limit = workingLimit
+	limiter.diskCacheByteTracker.updateSemaphoreMax()
 }
 
 func testGetDiskCacheBytes(syncCache, workingCache *DiskBlockCacheLocal) (

--- a/go/kbfs/libkbfs/util.go
+++ b/go/kbfs/libkbfs/util.go
@@ -353,12 +353,12 @@ func GetLocalDiskStats(ctx context.Context, dbc DiskBlockCache) (
 	return 0, 0
 }
 
-// FillInDiskSpaceStatus fills in the `OutOfSyncSpace` and local disk
-// space fields of the given status.  `status.PrefetchStatus` should
-// be populated before this function is called.
+// FillInDiskSpaceStatus fills in the `OutOfSyncSpace`,
+// prefetchStatus, and local disk space fields of the given status.
 func FillInDiskSpaceStatus(
 	ctx context.Context, status *keybase1.FolderSyncStatus,
-	dbc DiskBlockCache) {
+	prefetchStatus keybase1.PrefetchStatus, dbc DiskBlockCache) {
+	status.PrefetchStatus = prefetchStatus
 	if dbc == nil {
 		return
 	}
@@ -366,7 +366,7 @@ func FillInDiskSpaceStatus(
 	status.LocalDiskBytesAvailable, status.LocalDiskBytesTotal =
 		GetLocalDiskStats(ctx, dbc)
 
-	if status.PrefetchStatus == keybase1.PrefetchStatus_COMPLETE {
+	if prefetchStatus == keybase1.PrefetchStatus_COMPLETE {
 		return
 	}
 

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -2284,7 +2284,8 @@ func (k *SimpleFS) SimpleFSFolderSyncConfigAndStatus(
 		}
 	}
 
-	libkbfs.FillInDiskSpaceStatus(ctx, &res.Status, dbc)
+	libkbfs.FillInDiskSpaceStatus(
+		ctx, &res.Status, res.Status.PrefetchStatus, dbc)
 	return res, err
 }
 

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -2236,21 +2236,6 @@ func (k *SimpleFS) getSyncConfig(ctx context.Context, path keybase1.Path) (
 	return tlfHandle.TlfID(), config, nil
 }
 
-func (k *SimpleFS) getLocalDiskStats(ctx context.Context) (
-	bytesAvail, bytesTotal int64) {
-	dbc := k.config.DiskBlockCache()
-	if dbc == nil {
-		return 0, 0
-	}
-
-	dbcStatus := dbc.Status(ctx)
-	if status, ok := dbcStatus["SyncBlockCache"]; ok {
-		return int64(status.LocalDiskBytesAvailable),
-			int64(status.LocalDiskBytesTotal)
-	}
-	return 0, 0
-}
-
 // SimpleFSFolderSyncConfigAndStatus gets the given folder's sync config.
 func (k *SimpleFS) SimpleFSFolderSyncConfigAndStatus(
 	ctx context.Context, path keybase1.Path) (
@@ -2262,6 +2247,7 @@ func (k *SimpleFS) SimpleFSFolderSyncConfigAndStatus(
 	}
 	res := keybase1.FolderSyncConfigAndStatus{Config: config}
 
+	dbc := k.config.DiskBlockCache()
 	if config.Mode != keybase1.FolderSyncMode_DISABLED {
 		fs, finalElem, err := k.getFSIfExists(ctx, path)
 		if err != nil {
@@ -2282,7 +2268,6 @@ func (k *SimpleFS) SimpleFSFolderSyncConfigAndStatus(
 			res.Status.PrefetchProgress =
 				metadata.PrefetchProgress.ToProtocolProgress(k.config.Clock())
 
-			dbc := k.config.DiskBlockCache()
 			libfs, ok := fs.(*libfs.FS)
 			if dbc != nil && ok {
 				size, err := dbc.GetTlfSize(
@@ -2299,8 +2284,7 @@ func (k *SimpleFS) SimpleFSFolderSyncConfigAndStatus(
 		}
 	}
 
-	res.Status.LocalDiskBytesAvailable, res.Status.LocalDiskBytesTotal =
-		k.getLocalDiskStats(ctx)
+	libkbfs.FillInDiskSpaceStatus(ctx, &res.Status, dbc)
 	return res, err
 }
 
@@ -2321,7 +2305,17 @@ func (k *SimpleFS) SimpleFSSetFolderSyncConfig(
 func (k *SimpleFS) SimpleFSSyncConfigAndStatus(
 	ctx context.Context) (res keybase1.SyncConfigAndStatusRes, err error) {
 	ctx = k.makeContext(ctx)
-	bytesAvail, bytesTotal := k.getLocalDiskStats(ctx)
+	dbc := k.config.DiskBlockCache()
+	bytesAvail, bytesTotal := libkbfs.GetLocalDiskStats(ctx, dbc)
+
+	hasRoom := true
+	if dbc != nil {
+		hasRoom, err = dbc.DoesCacheHaveSpace(ctx, libkbfs.DiskBlockSyncCache)
+		if err != nil {
+			return keybase1.SyncConfigAndStatusRes{}, err
+		}
+	}
+
 	tlfIDs := k.config.GetAllSyncedTlfs()
 
 	session, err := idutil.GetCurrentSessionIfPossible(
@@ -2332,8 +2326,6 @@ func (k *SimpleFS) SimpleFSSyncConfigAndStatus(
 
 	res.Folders = make(
 		[]keybase1.FolderSyncConfigAndStatusWithFolder, len(tlfIDs))
-
-	dbc := k.config.DiskBlockCache()
 	allNotStarted := true
 	for i, tlfID := range tlfIDs {
 		config, err := k.config.KBFSOps().GetSyncConfig(ctx, tlfID)
@@ -2371,6 +2363,10 @@ func (k *SimpleFS) SimpleFSSyncConfigAndStatus(
 		}
 		res.Folders[i].Status.LocalDiskBytesAvailable = bytesAvail
 		res.Folders[i].Status.LocalDiskBytesTotal = bytesTotal
+		if res.Folders[i].Status.PrefetchStatus !=
+			keybase1.PrefetchStatus_COMPLETE {
+			res.Folders[i].Status.OutOfSyncSpace = !hasRoom
+		}
 
 		if dbc != nil {
 			size, err := dbc.GetTlfSize(ctx, tlfID, libkbfs.DiskBlockSyncCache)
@@ -2401,6 +2397,10 @@ func (k *SimpleFS) SimpleFSSyncConfigAndStatus(
 
 	res.OverallStatus.LocalDiskBytesAvailable = bytesAvail
 	res.OverallStatus.LocalDiskBytesTotal = bytesTotal
+	if res.OverallStatus.PrefetchStatus !=
+		keybase1.PrefetchStatus_COMPLETE {
+		res.OverallStatus.OutOfSyncSpace = !hasRoom
+	}
 
 	if dbc != nil {
 		statusMap := dbc.Status(ctx)

--- a/go/protocol/keybase1/kbfs_common.go
+++ b/go/protocol/keybase1/kbfs_common.go
@@ -348,6 +348,7 @@ type FolderSyncStatus struct {
 	PrefetchStatus          PrefetchStatus   `codec:"prefetchStatus" json:"prefetchStatus"`
 	PrefetchProgress        PrefetchProgress `codec:"prefetchProgress" json:"prefetchProgress"`
 	StoredBytesTotal        int64            `codec:"storedBytesTotal" json:"storedBytesTotal"`
+	OutOfSyncSpace          bool             `codec:"outOfSyncSpace" json:"outOfSyncSpace"`
 }
 
 func (o FolderSyncStatus) DeepCopy() FolderSyncStatus {
@@ -357,6 +358,7 @@ func (o FolderSyncStatus) DeepCopy() FolderSyncStatus {
 		PrefetchStatus:          o.PrefetchStatus.DeepCopy(),
 		PrefetchProgress:        o.PrefetchProgress.DeepCopy(),
 		StoredBytesTotal:        o.StoredBytesTotal,
+		OutOfSyncSpace:          o.OutOfSyncSpace,
 	}
 }
 

--- a/protocol/avdl/keybase1/kbfs_common.avdl
+++ b/protocol/avdl/keybase1/kbfs_common.avdl
@@ -109,5 +109,6 @@ protocol kbfsCommon {
     PrefetchStatus prefetchStatus;
     PrefetchProgress prefetchProgress;
     int64 storedBytesTotal;
+    boolean outOfSyncSpace;
   }
 }

--- a/protocol/json/keybase1/kbfs_common.json
+++ b/protocol/json/keybase1/kbfs_common.json
@@ -258,6 +258,10 @@
         {
           "type": "int64",
           "name": "storedBytesTotal"
+        },
+        {
+          "type": "boolean",
+          "name": "outOfSyncSpace"
         }
       ]
     }

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -2231,7 +2231,7 @@ export type FolderSyncMode =
   | 1 // ENABLED_1
   | 2 // PARTIAL_2
 
-export type FolderSyncStatus = $ReadOnly<{localDiskBytesAvailable: Int64, localDiskBytesTotal: Int64, prefetchStatus: PrefetchStatus, prefetchProgress: PrefetchProgress, storedBytesTotal: Int64}>
+export type FolderSyncStatus = $ReadOnly<{localDiskBytesAvailable: Int64, localDiskBytesTotal: Int64, prefetchStatus: PrefetchStatus, prefetchProgress: PrefetchProgress, storedBytesTotal: Int64, outOfSyncSpace: Boolean}>
 export type FolderType =
   | 0 // UNKNOWN_0
   | 1 // PRIVATE_1


### PR DESCRIPTION
When the sync cache is out of space and prefetching has stopped, send an immediate sync status notification with the `OutOfSyncSpace` field set to true.

Also populate it on polling requests in simplefs, and show it in `fs sync show`.

There was also a bug in the `DiskBlockCache` that wasn't checking the space usage correctly for the sync cache.  The `backpressureDiskLimiter` doesn't actually track the bytes used by the sync cache, because it never wants to reject bytes from being saved.  So `DoesCacheHaveSpace` wasn't working correctly for the sync cache, since the limit reported by the tracker was always 0.  Instead use the reported max limit from the tracker to calculate the current usage.

Issue: KBFS-4121
