### PR TITLE
fix showing inbox when coming from push / previous load

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -380,7 +380,7 @@ const onIncomingMessage = (state, incoming) => {
 }
 
 // Helper to handle incoming inbox updates that piggy back on various calls
-const chatActivityToMetasAction = (payload: ?{+conv?: ?RPCChatTypes.InboxUIItem}) => {
+const chatActivityToMetasAction = (payload: ?{+conv?: ?RPCChatTypes.InboxUIItem}, ignoreDelete) => {
   const conv = payload ? payload.conv : null
   const meta = conv && Constants.inboxUIItemToConversationMeta(conv)
   const conversationIDKey = meta
@@ -389,6 +389,7 @@ const chatActivityToMetasAction = (payload: ?{+conv?: ?RPCChatTypes.InboxUIItem}
   const usernameToFullname = (conv && conv.fullNames) || {}
   // We ignore inbox rows that are blocked/reported or have no content
   const isADelete =
+    !ignoreDelete &&
     conv &&
     ([RPCChatTypes.commonConversationStatus.blocked, RPCChatTypes.commonConversationStatus.reported].includes(
       conv.status
@@ -779,7 +780,7 @@ const onNewChatActivity = (state, action) => {
       actions = chatActivityToMetasAction(activity.readMessage)
       break
     case RPCChatTypes.notifyChatChatActivityType.newConversation:
-      actions = chatActivityToMetasAction(activity.newConversation)
+      actions = chatActivityToMetasAction(activity.newConversation, true)
       break
     case RPCChatTypes.notifyChatChatActivityType.failedMessage: {
       const failedMessage: ?RPCChatTypes.FailedMessageInfo = activity.failedMessage

--- a/shared/actions/config/index.js
+++ b/shared/actions/config/index.js
@@ -306,8 +306,16 @@ const routeToInitialScreen = state => {
       state.config.startupConversation &&
       state.config.startupConversation !== ChatConstants.noConversationIDKey
     ) {
+      const actions = [
+        RouteTreeGen.createNavigateAppend({
+          path: [
+            {props: {conversationIDKey: state.config.startupConversation}, selected: 'chatConversation'},
+          ],
+        }),
+      ]
       return [
         RouteTreeGen.createSwitchRouteDef({path: [Tabs.chatTab], routeDef: appRouteTree}),
+        RouteTreeGen.createResetStack({actions, index: 1, tab: Tabs.chatTab}),
         ChatGen.createSelectConversation({
           conversationIDKey: state.config.startupConversation,
           reason: state.config.startupWasFromPush ? 'push' : 'savedLastState',
@@ -512,6 +520,7 @@ function* configSaga(): Saga.SagaGenerator<any, any> {
       | RouteTreeGen.ClearModalsPayload
       | RouteTreeGen.NavUpToScreenPayload
       | RouteTreeGen.SwitchTabPayload
+      | RouteTreeGen.ResetStackPayload
     >(
       [
         RouteTreeGen.navigateAppend,
@@ -522,6 +531,7 @@ function* configSaga(): Saga.SagaGenerator<any, any> {
         RouteTreeGen.clearModals,
         RouteTreeGen.navUpToScreen,
         RouteTreeGen.switchTab,
+        RouteTreeGen.resetStack,
       ],
       newNavigation
     )

--- a/shared/actions/json/route-tree.json
+++ b/shared/actions/json/route-tree.json
@@ -55,6 +55,12 @@
     "switchTab": {
       "_description": "ONLY used by the new nav. Switch to a different tab.",
       "tab": "Tabs.AppTab"
+    },
+    "resetStack": {
+      "_description": "Reset a specific stack. actions is route tree actions TODO better typing",
+      "tab": "Tabs.AppTab",
+      "actions": "Array<any>",
+      "index": "number"
     }
   }
 }

--- a/shared/actions/platform-specific/push.native.js
+++ b/shared/actions/platform-specific/push.native.js
@@ -131,6 +131,7 @@ function* handleLoudMessage(notification) {
   const actions = [
     RouteTreeGen.createNavigateAppend({path: [{props: {conversationIDKey}, selected: 'chatConversation'}]}),
   ]
+  yield Saga.put(RouteTreeGen.createClearModals())
   yield Saga.put(RouteTreeGen.createResetStack({actions, index: 1, tab: 'tabs.chatTab'}))
   yield Saga.put(RouteTreeGen.createSwitchTab({tab: 'tabs.chatTab'}))
   yield Saga.put(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'push'}))

--- a/shared/actions/platform-specific/push.native.js
+++ b/shared/actions/platform-specific/push.native.js
@@ -127,8 +127,12 @@ function* handleLoudMessage(notification) {
 
   const {conversationIDKey, unboxPayload, membersType} = notification
 
+  // immediately show the thread on top of the inbox w/o a nav
+  const actions = [
+    RouteTreeGen.createNavigateAppend({path: [{props: {conversationIDKey}, selected: 'chatConversation'}]}),
+  ]
+  yield Saga.put(RouteTreeGen.createResetStack({actions, index: 1, tab: 'tabs.chatTab'}))
   yield Saga.put(RouteTreeGen.createSwitchTab({tab: 'tabs.chatTab'}))
-  yield Saga.put(RouteTreeGen.createNavUpToScreen({routeName: 'chatRoot'}))
   yield Saga.put(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'push'}))
   if (unboxPayload && membersType && !isIOS) {
     logger.info('[Push] unboxing message')

--- a/shared/actions/route-tree-gen.js
+++ b/shared/actions/route-tree-gen.js
@@ -20,6 +20,7 @@ export const navigateUp = 'route-tree:navigateUp'
 export const putActionIfOnPath = 'route-tree:putActionIfOnPath'
 export const refreshRouteDef = 'route-tree:refreshRouteDef'
 export const resetRoute = 'route-tree:resetRoute'
+export const resetStack = 'route-tree:resetStack'
 export const setInitialRouteDef = 'route-tree:setInitialRouteDef'
 export const setRouteState = 'route-tree:setRouteState'
 export const switchRouteDef = 'route-tree:switchRouteDef'
@@ -35,6 +36,7 @@ type _NavigateUpPayload = void
 type _PutActionIfOnPathPayload = $ReadOnly<{|expectedPath: RCConstants.Path, otherAction: any, parentPath?: ?RCConstants.Path|}>
 type _RefreshRouteDefPayload = $ReadOnly<{|loginRouteTree: RCConstants.RouteDefParams, appRouteTree: RCConstants.RouteDefParams|}>
 type _ResetRoutePayload = $ReadOnly<{|path: RCConstants.Path|}>
+type _ResetStackPayload = $ReadOnly<{|tab: Tabs.AppTab, actions: Array<any>, index: number|}>
 type _SetInitialRouteDefPayload = $ReadOnly<{|routeDef: RCConstants.RouteDefParams|}>
 type _SetRouteStatePayload = $ReadOnly<{|path: RCConstants.Path, partialState: {} | ((oldState: I.Map<string, any>) => I.Map<string, any>)|}>
 type _SwitchRouteDefPayload = $ReadOnly<{|routeDef: RCConstants.RouteDefParams, path?: ?RCConstants.Path|}>
@@ -54,6 +56,10 @@ export const createSwitchTab = (payload: _SwitchTabPayload) => ({payload, type: 
  * ONLY used by the new nav. use this to clear any modal routes
  */
 export const createClearModals = (payload: _ClearModalsPayload) => ({payload, type: clearModals})
+/**
+ * Reset a specific stack. actions is route tree actions TODO better typing
+ */
+export const createResetStack = (payload: _ResetStackPayload) => ({payload, type: resetStack})
 /**
  * Set the tree of route definitions. Dispatched at initialization time.
  */
@@ -77,6 +83,7 @@ export type NavigateUpPayload = {|+payload: _NavigateUpPayload, +type: 'route-tr
 export type PutActionIfOnPathPayload = {|+payload: _PutActionIfOnPathPayload, +type: 'route-tree:putActionIfOnPath'|}
 export type RefreshRouteDefPayload = {|+payload: _RefreshRouteDefPayload, +type: 'route-tree:refreshRouteDef'|}
 export type ResetRoutePayload = {|+payload: _ResetRoutePayload, +type: 'route-tree:resetRoute'|}
+export type ResetStackPayload = {|+payload: _ResetStackPayload, +type: 'route-tree:resetStack'|}
 export type SetInitialRouteDefPayload = {|+payload: _SetInitialRouteDefPayload, +type: 'route-tree:setInitialRouteDef'|}
 export type SetRouteStatePayload = {|+payload: _SetRouteStatePayload, +type: 'route-tree:setRouteState'|}
 export type SwitchRouteDefPayload = {|+payload: _SwitchRouteDefPayload, +type: 'route-tree:switchRouteDef'|}
@@ -94,6 +101,7 @@ export type Actions =
   | PutActionIfOnPathPayload
   | RefreshRouteDefPayload
   | ResetRoutePayload
+  | ResetStackPayload
   | SetInitialRouteDefPayload
   | SetRouteStatePayload
   | SwitchRouteDefPayload

--- a/shared/router-v2/router.desktop.js
+++ b/shared/router-v2/router.desktop.js
@@ -13,7 +13,7 @@ import {
   SceneView,
   createSwitchNavigator,
 } from '@react-navigation/core'
-import {modalRoutes, routes, nameToTab, loggedOutRoutes} from './routes'
+import {modalRoutes, routes, nameToTab, loggedOutRoutes, tabRoots} from './routes'
 import * as Shared from './router.shared'
 import Header from './header/index.desktop'
 import * as Shim from './shim.desktop'
@@ -160,7 +160,6 @@ class TabView extends React.PureComponent<any> {
 }
 
 const tabs = Shared.desktopTabs
-const tabRoots = Shared.tabRoots
 
 const TabNavigator = createNavigator(
   TabView,

--- a/shared/router-v2/router.native.js
+++ b/shared/router-v2/router.native.js
@@ -9,7 +9,7 @@ import {createSwitchNavigator, StackActions} from '@react-navigation/core'
 import {createBottomTabNavigator} from 'react-navigation-tabs'
 import {createStackNavigator} from 'react-navigation-stack'
 import * as Tabs from '../constants/tabs'
-import {modalRoutes, routes, loggedOutRoutes} from './routes'
+import {modalRoutes, routes, loggedOutRoutes, tabRoots} from './routes'
 import {LeftAction} from '../common-adapters/header-hoc'
 import * as Constants from '../constants/router2'
 import * as Shared from './router.shared'
@@ -49,7 +49,6 @@ const defaultNavigationOptions = {
 const headerMode = Styles.isAndroid ? 'screen' : 'float'
 
 const tabs = Shared.mobileTabs
-const tabRoots = Shared.tabRoots
 const icons = {
   [Tabs.chatTab]: 'iconfont-nav-2-chat',
   [Tabs.fsTab]: 'iconfont-nav-2-files',

--- a/shared/router-v2/routes.js
+++ b/shared/router-v2/routes.js
@@ -49,6 +49,17 @@ _newRoutes.forEach(({route, tab}) => {
   })
 })
 
+export const tabRoots = {
+  [Tabs.peopleTab]: 'peopleRoot',
+  [Tabs.chatTab]: 'chatRoot',
+  [Tabs.fsTab]: 'fsRoot',
+  [Tabs.teamsTab]: 'teamsRoot',
+  [Tabs.walletsTab]: 'walletsRoot',
+  [Tabs.gitTab]: 'gitRoot',
+  [Tabs.devicesTab]: 'devicesRoot',
+  [Tabs.settingsTab]: 'settingsRoot',
+}
+
 export const modalRoutes = {
   ...chatNewModalRoutes,
   ...deviceNewModalRoutes,

--- a/shared/router-v2/tab-bar/container.desktop.js
+++ b/shared/router-v2/tab-bar/container.desktop.js
@@ -13,7 +13,7 @@ import {memoize} from '../../util/memoize'
 import {isLinux} from '../../constants/platform'
 import openURL from '../../util/open-url'
 import {quit, hideWindow} from '../../util/quit-helper'
-import {tabRoots} from '../router.shared'
+import {tabRoots} from '../routes'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as SettingsGen from '../../actions/settings-gen'
 


### PR DESCRIPTION
@keybase/react-hackers this fixes you seeing the inbox when you start up and land on a prev convo or come from a push
I added a new action for this. I do want to clean this action and the switch route def (already ticketed) when we deprecate nav1