### PR TITLE
Fix wallets navigateToAccount

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -651,6 +651,14 @@ const navigateToAccount = (state, action) => {
     ? [Tabs.settingsTab, SettingsConstants.walletsTab]
     : [{props: {}, selected: Tabs.walletsTab}]
 
+  if (flags.useNewRouter) {
+    return [
+      RouteTreeGen.createClearModals(),
+      RouteTreeGen.createSwitchTab({tab: isMobile ? Tabs.settingsTab : Tabs.walletsTab}),
+      ...(isMobile ? [RouteTreeGen.createNavigateAppend({path: [SettingsConstants.walletsTab]})] : []),
+    ]
+  }
+
   return RouteTreeGen.createNavigateTo({path: wallet})
 }
 

--- a/shared/chat/inbox/row/start-new-chat.js
+++ b/shared/chat/inbox/row/start-new-chat.js
@@ -23,9 +23,6 @@ const StartNewChat = (props: Props) => {
             Start a new chat
           </Kb.Text>
         </Kb.ClickableBox>
-        {flags.useNewRouter && Styles.isMobile && (
-          <Kb.BackButton onClick={props.onBack} style={styles.backButton} />
-        )}
       </Kb.Box>
     )
   }


### PR DESCRIPTION
Used by the 'Review payments' link on the wallets error banner. This probably fixes more than just that though. r? @keybase/react-hackers 