### PR TITLE
Fix up flow after signup error

### DIFF
--- a/shared/actions/signup.js
+++ b/shared/actions/signup.js
@@ -51,7 +51,7 @@ const showInviteSuccessOnNoErrors = (state: TypedState) =>
 
 const goToLoginRoot = () =>
   flags.useNewRouter
-    ? RouteTreeGen.createNavigateUp()
+    ? [RouteTreeGen.createClearModals(), RouteTreeGen.createNavUpToScreen({routeName: loginTab})]
     : RouteTreeGen.createNavigateTo({parentPath: [loginTab], path: []})
 
 const showDeviceScreenOnNoErrors = (state: TypedState) =>
@@ -138,13 +138,7 @@ function* reallySignupOnNoErrors(state: TypedState): Saga.SagaGenerator<any, any
   const {email, username, inviteCode, devicename} = state.signup
 
   if (!email || !username || !inviteCode || !devicename) {
-    logger.warn(
-      'Missing data during signup phase',
-      email,
-      username,
-      inviteCode,
-      devicename,
-    )
+    logger.warn('Missing data during signup phase', email, username, inviteCode, devicename)
     throw new Error('Missing data for signup')
   }
 

--- a/shared/login/signup/common.js
+++ b/shared/login/signup/common.js
@@ -38,11 +38,19 @@ export const BlankAvatar = () => (
   <Avatar username="" size={isMobile ? 96 : 128} style={avatarCastPlatformStyles(styles.avatar)} />
 )
 
-export const ContinueButton = ({disabled, onClick}: {disabled?: boolean, onClick: () => void}) => (
+export const ContinueButton = ({
+  disabled,
+  label,
+  onClick,
+}: {
+  disabled?: boolean,
+  label?: string,
+  onClick: () => void,
+}) => (
   <ButtonBar fullWidth={true} style={styles.buttonBar}>
     <WaitingButton
       waitingKey={Constants.waitingKey}
-      label="Continue"
+      label={label || 'Continue'}
       disabled={disabled}
       fullWidth={true}
       onClick={onClick}

--- a/shared/login/signup/error/container.js
+++ b/shared/login/signup/error/container.js
@@ -23,7 +23,6 @@ const ConnectedSignupError = connect<OwnProps, _, _, _, _>(
 ConnectedSignupError.navigationOptions = {
   gesturesEnabled: false,
   headerLeft: null,
-  noBackButton: true,
 }
 
 export default ConnectedSignupError

--- a/shared/login/signup/error/container.js
+++ b/shared/login/signup/error/container.js
@@ -11,11 +11,19 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   onBack: () => dispatch(SignupGen.createGoBackAndClearErrors()),
-  onRestart: () => dispatch(SignupGen.createRestartSignup()),
 })
 
-export default connect<OwnProps, _, _, _, _>(
+const ConnectedSignupError = connect<OwnProps, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps,
   (s, d, o) => ({...o, ...s, ...d})
 )(Error)
+
+// $FlowIssue lets fix this
+ConnectedSignupError.navigationOptions = {
+  gesturesEnabled: false,
+  headerLeft: null,
+  noBackButton: true,
+}
+
+export default ConnectedSignupError

--- a/shared/login/signup/error/index.js
+++ b/shared/login/signup/error/index.js
@@ -6,16 +6,15 @@ import {Wrapper, ContinueButton} from '../common'
 type Props = {|
   error: string,
   onBack: () => void,
-  onRestart: () => void,
 |}
 
 const Error = (props: Props) => (
-  <Wrapper onBack={props.onBack}>
+  <Wrapper onBack={() => {}}>
     <Text center={true} type="Header" style={{maxWidth: 460, width: '80%'}}>
       Ah Shoot! Something went wrong, wanna try again?
     </Text>
     <Text type="BodySmallError">{props.error}</Text>
-    <ContinueButton label="Try again" onClick={props.onRestart} />
+    <ContinueButton label="Back" onClick={props.onBack} />
   </Wrapper>
 )
 

--- a/shared/login/signup/error/index.stories.js
+++ b/shared/login/signup/error/index.stories.js
@@ -5,7 +5,7 @@ import Error from '.'
 
 const load = () => {
   Sb.storiesOf('Signup', module).add('Error', () => (
-    <Error error="This is an error" onBack={Sb.action('onBack')} onRestart={Sb.action('onRestart')} />
+    <Error error="This is an error" onBack={Sb.action('onBack')} />
   ))
 }
 

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -103,7 +103,8 @@ class Header extends React.PureComponent<Props, State> {
           ])}
         >
           <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.headerBack} alignItems="center">
-            {!opt.noBackButton && (
+            {/* TODO have headerLeft be the back button */}
+            {opt.headerLeft !== null && (
               <Kb.Icon
                 type="iconfont-arrow-left"
                 style={backArrowStyle}

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -103,12 +103,14 @@ class Header extends React.PureComponent<Props, State> {
           ])}
         >
           <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.headerBack} alignItems="center">
-            <Kb.Icon
-              type="iconfont-arrow-left"
-              style={backArrowStyle}
-              color={iconColor}
-              onClick={this.props.allowBack ? this.props.onPop : null}
-            />
+            {!opt.noBackButton && (
+              <Kb.Icon
+                type="iconfont-arrow-left"
+                style={backArrowStyle}
+                color={iconColor}
+                onClick={this.props.allowBack ? this.props.onPop : null}
+              />
+            )}
             {flags.kbfsOfflineMode && <SyncingFolders />}
             {!title && rightActions}
 


### PR DESCRIPTION
- Remove back button on error screen
  - This is in the router and does a `childNav.pop()`, not easy to listen for in signup sagas
- Make error screen button take you back a page

r? @keybase/react-hackers 