### PR TITLE
Fix showing new display currency after a change

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -506,7 +506,7 @@ const changeDisplayCurrency = (state, action) =>
       currency: action.payload.code, // called currency, though it is a code
     },
     Constants.changeDisplayCurrencyWaitingKey
-  )
+  ).then(_ => WalletsGen.createLoadDisplayCurrency({accountID: action.payload.accountID}))
 
 const changeAccountName = (state, action) =>
   RPCStellarTypes.localChangeWalletAccountNameLocalRpcPromise(


### PR DESCRIPTION
@keybase/react-hackers 

Not sure why this broke, though this change works for me.  The dropdown is controlled through Redux, and Redux only updates when we get new data from the service, and nothing was causing that to happen.  I suppose it might be the case that there used to be a service notification that triggered our refresh that isn't there anymore?