### PR TITLE
Badge the main mobile settings nav with its subnav's badge items

### DIFF
--- a/shared/router-v2/router.native.js
+++ b/shared/router-v2/router.native.js
@@ -71,8 +71,17 @@ const TabBarIcon = ({badgeNumber, focused, routeName}) => (
   </Kb.NativeView>
 )
 
+const settingsTabChildren = [Tabs.gitTab, Tabs.devicesTab, Tabs.walletsTab]
+const getBadgeNumber = (navBadges, routeName: Tabs.Tab) => {
+  if (routeName === 'tabs.settingsTab') {
+    return settingsTabChildren.reduce((res, tab) => res + (navBadges.get(tab) || 0), 0)
+  } else {
+    return navBadges.get(routeName)
+  }
+}
+
 const ConnectedTabBarIcon = connect<{|focused: boolean, routeName: Tabs.Tab|}, _, _, _, _>(
-  (state, {routeName}) => ({badgeNumber: state.notifications.navBadges.get(routeName)}),
+  (state, {routeName}) => ({badgeNumber: getBadgeNumber(state.notifications.navBadges, routeName)}),
   () => ({}),
   (s, _, o) => ({
     badgeNumber: s.badgeNumber,

--- a/shared/router-v2/router.native.js
+++ b/shared/router-v2/router.native.js
@@ -72,7 +72,7 @@ const TabBarIcon = ({badgeNumber, focused, routeName}) => (
 )
 
 const settingsTabChildren = [Tabs.gitTab, Tabs.devicesTab, Tabs.walletsTab]
-const getBadgeNumber = (navBadges, routeName: Tabs.Tab) =>
+const getBadgeNumber = (navBadges, routeName) =>
   routeName === Tabs.settingsTab
     ? settingsTabChildren.reduce((res, tab) => res + (navBadges.get(tab) || 0), 0)
     : navBadges.get(routeName)

--- a/shared/router-v2/router.native.js
+++ b/shared/router-v2/router.native.js
@@ -72,13 +72,10 @@ const TabBarIcon = ({badgeNumber, focused, routeName}) => (
 )
 
 const settingsTabChildren = [Tabs.gitTab, Tabs.devicesTab, Tabs.walletsTab]
-const getBadgeNumber = (navBadges, routeName: Tabs.Tab) => {
-  if (routeName === 'tabs.settingsTab') {
-    return settingsTabChildren.reduce((res, tab) => res + (navBadges.get(tab) || 0), 0)
-  } else {
-    return navBadges.get(routeName)
-  }
-}
+const getBadgeNumber = (navBadges, routeName: Tabs.Tab) =>
+  routeName === Tabs.settingsTab
+    ? settingsTabChildren.reduce((res, tab) => res + (navBadges.get(tab) || 0), 0)
+    : navBadges.get(routeName)
 
 const ConnectedTabBarIcon = connect<{|focused: boolean, routeName: Tabs.Tab|}, _, _, _, _>(
   (state, {routeName}) => ({badgeNumber: getBadgeNumber(state.notifications.navBadges, routeName)}),


### PR DESCRIPTION
@keybase/react-hackers 

We had code to do this in nav1 and I think it just wasn't brought over to nav2.