### PR TITLE
fix keyboard hiding

### DIFF
--- a/shared/common-adapters/floating-box/index.native.js
+++ b/shared/common-adapters/floating-box/index.native.js
@@ -1,16 +1,25 @@
 // @flow
 import * as React from 'react'
 import Box from '../box'
+import {NativeKeyboard} from '../native-wrappers.native'
 import {Gateway} from 'react-gateway'
 import type {Props} from './index.types'
 import {globalStyles} from '../../styles'
 
-export default (props: Props) => {
-  return (
-    <Gateway into={props.dest || 'popup-root'}>
-      <Box pointerEvents="box-none" style={[globalStyles.fillAbsolute, props.containerStyle]}>
-        {props.children}
-      </Box>
-    </Gateway>
-  )
+export default class FloatingBox extends React.Component<Props> {
+  componentWillMount() {
+    if (this.props.hideKeyboard) {
+      NativeKeyboard.dismiss()
+    }
+  }
+  render() {
+    const props = this.props
+    return (
+      <Gateway into={props.dest || 'popup-root'}>
+        <Box pointerEvents="box-none" style={[globalStyles.fillAbsolute, props.containerStyle]}>
+          {props.children}
+        </Box>
+      </Gateway>
+    )
+  }
 }

--- a/shared/common-adapters/floating-box/index.types.js.flow
+++ b/shared/common-adapters/floating-box/index.types.js.flow
@@ -23,4 +23,5 @@ export type Props = {
   matchDimension?: boolean,
   position?: Position,
   positionFallbacks?: Position[],
+  hideKeyboard?: boolean, // if true, hide the keyboard on mount
 }

--- a/shared/common-adapters/overlay/index.native.js
+++ b/shared/common-adapters/overlay/index.native.js
@@ -5,18 +5,13 @@ import {Box, Box2} from '../box'
 import FloatingBox from '../floating-box'
 import type {Props} from '.'
 import {collapseStyles, globalColors, globalStyles, styleSheetCreate} from '../../styles'
-import {dismiss as dismissKeyboard, isOpen as isKeyboardOpen} from '../../util/keyboard'
 
 const Overlay = (props: Props) => {
   if (props.hasOwnProperty('visible') && !props.visible) {
     return null
   }
-  if (isKeyboardOpen()) {
-    // Keyboard will cover up the overlay; need to hide
-    dismissKeyboard()
-  }
   return (
-    <FloatingBox onHidden={() => {}} dest={props.dest}>
+    <FloatingBox onHidden={() => {}} dest={props.dest} hideKeyboard={true}>
       <Box2
         direction="vertical"
         style={collapseStyles([styles.container, !!props.color && {color: props.color}])}

--- a/shared/teams/role-picker/index.js
+++ b/shared/teams/role-picker/index.js
@@ -377,6 +377,7 @@ export class FloatingRolePicker extends React.Component<FloatingProps, S> {
             attachTo={this.state.ref && this._returnRef}
             position={position || 'top center'}
             onHidden={onCancel}
+            hideKeyboard={true}
           >
             <Kb.Box2 direction={'vertical'} fullHeight={Styles.isMobile} style={floatingContainerStyle}>
               {Styles.isMobile && (


### PR DESCRIPTION
@keybase/react-hackers 
cc: @buoyad 
turns out the floating teams picker uses floating box and not overlay so i moved the keyboard hiding down a level and added a flag