### PR TITLE
Ignore a duplicate nav push if we're doing a reset

### DIFF
--- a/shared/router-v2/router.shared.js
+++ b/shared/router-v2/router.shared.js
@@ -34,7 +34,7 @@ export const desktopTabs = [
 
 // Helper to convert old route tree actions to new actions. Likely goes away as we make
 // actual routing actions (or make RouteTreeGen append/up the only action)
-export const oldActionToNewActions = (action: any, navigation: any) => {
+export const oldActionToNewActions = (action: any, navigation: any, allowAppendDupe?: boolean) => {
   switch (action.type) {
     case RouteTreeGen.navigateTo: // fallthrough
     case RouteTreeGen.switchTo: // fallthrough
@@ -65,7 +65,7 @@ export const oldActionToNewActions = (action: any, navigation: any) => {
       const path = Constants._getVisiblePathForNavigator(navigation.state)
       const visible = path[path.length - 1]
       if (visible) {
-        if (routeName === visible.routeName && shallowEqual(visible.params, params)) {
+        if (!allowAppendDupe && routeName === visible.routeName && shallowEqual(visible.params, params)) {
           console.log('Skipping append dupe')
           return
         }
@@ -130,7 +130,7 @@ export const oldActionToNewActions = (action: any, navigation: any) => {
     }
     case RouteTreeGen.resetStack: {
       const actions = action.payload.actions.reduce(
-        (arr, a) => [...arr, ...(oldActionToNewActions(a, navigation) || [])],
+        (arr, a) => [...arr, ...(oldActionToNewActions(a, navigation, true) || [])],
         [StackActions.push({routeName: tabRoots[action.payload.tab]})]
       )
       return [

--- a/shared/router-v2/router.shared.js
+++ b/shared/router-v2/router.shared.js
@@ -129,6 +129,7 @@ export const oldActionToNewActions = (action: any, navigation: any, allowAppendD
       return isInStack ? popActions : []
     }
     case RouteTreeGen.resetStack: {
+      // TODO check for append dupes within these
       const actions = action.payload.actions.reduce(
         (arr, a) => [...arr, ...(oldActionToNewActions(a, navigation, true) || [])],
         [StackActions.push({routeName: tabRoots[action.payload.tab]})]


### PR DESCRIPTION
Currently if you background the app with a convo open + tap a push for that convo, the app will white screen crash. This is because the reducer for `resetStack` calls `oldActionsToNewActions`, which bails w/ `undefined` if it notices we're about to append a dupe route. In this case it bails on append for `chatConversation` because the same one is already on the stack. This makes so that after the reset the second screen (index 1) is selected, but only one was pushed onto the stack. Fixed by adding a bypass to that check. r? @keybase/react-hackers 