### PR TITLE
kbfs_ops: avoid panic if `Status` is called to early

### DIFF
--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -1056,7 +1056,8 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	// authenticated with our password.  TODO: fix this in the
 	// service/GUI by handling multiple simultaneous passphrase
 	// requests at once.
-	if err == nil && fs.config.MDServer().IsConnected() {
+	mdserver := fs.config.MDServer()
+	if err == nil && mdserver != nil && mdserver.IsConnected() {
 		var quErr error
 		_, usageBytes, archiveBytes, limitBytes,
 			gitUsageBytes, gitArchiveBytes, gitLimitBytes, quErr =


### PR DESCRIPTION
The `SimpleFSAreWeConnectedToMDServer` RPC can come in before the mdserver is set, leading to a panic.

Issue: KBFS-4131