### PR TITLE
only reload profiles we've loaded before

### DIFF
--- a/shared/actions/tracker2.js
+++ b/shared/actions/tracker2.js
@@ -41,15 +41,20 @@ const connected = () =>
       logger.warn('error in registering identify ui: ', error)
     })
 
-const refreshChanged = (_, action) =>
-  Tracker2Gen.createLoad({
-    assertion: action.payload.params.username,
-    fromDaemon: false,
-    guiID: Constants.generateGUIID(),
-    ignoreCache: true,
-    inTracker: false,
-    reason: '',
-  })
+const refreshChanged = (state, action) => {
+  // only refresh if we have tracked them before
+  return (
+    state.tracker2.usernameToDetails.get(action.payload.params.username) &&
+    Tracker2Gen.createLoad({
+      assertion: action.payload.params.username,
+      fromDaemon: false,
+      guiID: Constants.generateGUIID(),
+      ignoreCache: true,
+      inTracker: false,
+      reason: '',
+    })
+  )
+}
 
 const updateUserCard = (state, action) => {
   const {guiID, card} = action.payload.params

--- a/shared/actions/tracker2.js
+++ b/shared/actions/tracker2.js
@@ -41,20 +41,17 @@ const connected = () =>
       logger.warn('error in registering identify ui: ', error)
     })
 
-const refreshChanged = (state, action) => {
-  // only refresh if we have tracked them before
-  return (
-    state.tracker2.usernameToDetails.get(action.payload.params.username) &&
-    Tracker2Gen.createLoad({
-      assertion: action.payload.params.username,
-      fromDaemon: false,
-      guiID: Constants.generateGUIID(),
-      ignoreCache: true,
-      inTracker: false,
-      reason: '',
-    })
-  )
-}
+// only refresh if we have tracked them before
+const refreshChanged = (state, action) =>
+  !!state.tracker2.usernameToDetails.get(action.payload.params.username) &&
+  Tracker2Gen.createLoad({
+    assertion: action.payload.params.username,
+    fromDaemon: false,
+    guiID: Constants.generateGUIID(),
+    ignoreCache: true,
+    inTracker: false,
+    reason: '',
+  })
 
 const updateUserCard = (state, action) => {
   const {guiID, card} = action.payload.params


### PR DESCRIPTION
i noticed on provision of a new profile we get flooded with a bunch of calls.
in response to all these tracking changes calls we'll kick off IDv3s. this ignore most of those
@keybase/react-hackers 