### PR TITLE
Add largeHeap option for Android, fixes movie crashes

### DIFF
--- a/shared/react-native/android/app/src/main/AndroidManifest.xml
+++ b/shared/react-native/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
       android:networkSecurityConfig="@xml/network_security_config"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:largeHeap="true">
       <activity
         android:name=".MainActivity"
         android:screenOrientation="portrait"


### PR DESCRIPTION
@keybase/react-hackers 

Looks like this fixes my crashes in simulator playing movies under nav2. It's discussed as a common pitfall for Android react-native. It's still the case that we could crash -- it's but it sounds like basically everyone does this once they're including photos/videos in their apps.

https://shift.infinite.red/react-native-android-app-memory-investigation-55695625da9c

https://blog.swmansion.com/hunting-js-memory-leaks-in-react-native-apps-bd73807d0fde