### PR TITLE
Fix creating an account from the send form

### DIFF
--- a/shared/actions/wallets.js
+++ b/shared/actions/wallets.js
@@ -654,8 +654,11 @@ const navigateToAccount = (state, action) => {
   if (flags.useNewRouter) {
     return [
       RouteTreeGen.createClearModals(),
-      RouteTreeGen.createSwitchTab({tab: isMobile ? Tabs.settingsTab : Tabs.walletsTab}),
-      ...(isMobile ? [RouteTreeGen.createNavigateAppend({path: [SettingsConstants.walletsTab]})] : []),
+      RouteTreeGen.createResetStack({
+        actions: isMobile ? [RouteTreeGen.createNavigateAppend({path: [SettingsConstants.walletsTab]})] : [],
+        index: isMobile ? 1 : 0,
+        tab: isMobile ? Tabs.settingsTab : Tabs.walletsTab,
+      }),
     ]
   }
 

--- a/shared/wallets/common/buttons/index.js
+++ b/shared/wallets/common/buttons/index.js
@@ -12,49 +12,46 @@ type SendProps = {|
   small?: boolean,
 |}
 
-class _SendButton extends React.PureComponent<SendProps & Kb.OverlayParentProps> {
-  _menuItems = [
+const _SendButton = (props: Kb.PropsWithOverlay<SendProps>) => {
+  const menuItems = [
     {
-      onClick: this.props.onSendToKeybaseUser,
+      onClick: props.onSendToKeybaseUser,
       title: 'To a Keybase user',
     },
     {
-      onClick: this.props.onSendToStellarAddress,
+      onClick: props.onSendToStellarAddress,
       title: 'To a Stellar address',
     },
     {
-      onClick: this.props.onSendToAnotherAccount,
+      onClick: props.onSendToAnotherAccount,
       title: 'To one of your other Stellar accounts',
     },
   ]
-
-  render() {
-    const button = (
-      <>
-        <Kb.Button
-          small={this.props.small}
-          onClick={this.props.disabled ? null : this.props.toggleShowingMenu}
-          ref={this.props.setAttachmentRef}
-          type="Wallet"
-          label="Send"
-          disabled={this.props.disabled}
-        />
-        <Kb.FloatingMenu
-          attachTo={this.props.getAttachmentRef}
-          closeOnSelect={true}
-          items={this._menuItems}
-          onHidden={this.props.toggleShowingMenu}
-          visible={this.props.showingMenu}
-          position="bottom center"
-        />
-      </>
-    )
-    return this.props.disabledDueToMobileOnly ? (
-      <Kb.WithTooltip text="This is a mobile-only account.">{button}</Kb.WithTooltip>
-    ) : (
-      button
-    )
-  }
+  const button = (
+    <>
+      <Kb.Button
+        small={props.small}
+        onClick={props.disabled ? null : props.toggleShowingMenu}
+        ref={props.setAttachmentRef}
+        type="Wallet"
+        label="Send"
+        disabled={props.disabled}
+      />
+      <Kb.FloatingMenu
+        attachTo={props.getAttachmentRef}
+        closeOnSelect={true}
+        items={menuItems}
+        onHidden={props.toggleShowingMenu}
+        visible={props.showingMenu}
+        position="bottom center"
+      />
+    </>
+  )
+  return props.disabledDueToMobileOnly ? (
+    <Kb.WithTooltip text="This is a mobile-only account.">{button}</Kb.WithTooltip>
+  ) : (
+    button
+  )
 }
 export const SendButton = Kb.OverlayParentHOC(_SendButton)
 

--- a/shared/wallets/create-account/index.js
+++ b/shared/wallets/create-account/index.js
@@ -60,8 +60,6 @@ class CreateAccount extends React.Component<Props, State> {
     if (this.props.nameValidationState === 'valid' && prevProps.nameValidationState !== 'valid') {
       this.props.onClearErrors()
       this.props.onCreateAccount(this.state.name)
-      // This is for when we are showing this from a SendForm.
-      this.props.onBack && this.props.onBack()
     }
   }
 

--- a/shared/wallets/link-existing/index.js
+++ b/shared/wallets/link-existing/index.js
@@ -100,8 +100,6 @@ class LinkWallet extends React.Component<LinkWalletProps, LinkWalletState> {
     if (this.props.nameValidationState === 'valid' && this.state.view === 'name') {
       this.props.onClearErrors()
       this.props.onDone()
-      // This is for when we are showing this from a SendForm.
-      this.props.onBack && this.props.onBack()
     }
   }
 


### PR DESCRIPTION
Also: use `resetStack` in `navigateToAccount` - it was originally ported over before we had `resetStack`. Currently it always pushes a wallet screen even if you were already on one. r? @keybase/react-hackers 