### PR TITLE
turn on inline requires

### DIFF
--- a/shared/metro.config.js
+++ b/shared/metro.config.js
@@ -11,7 +11,7 @@ module.exports = {
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,
-        inlineRequires: false,
+        inlineRequires: true,
       },
     }),
   },


### PR DESCRIPTION
@keybase/react-hackers this turns on inline requires, this will be the default in the near future and they suggest trying it. it seems fine to me on ios and android