### PR TITLE
narrower check for throwing out events that trigger visibility check

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.desktop.js
+++ b/shared/chat/conversation/list-area/normal/index.desktop.js
@@ -609,7 +609,7 @@ class OrdinalWaypoint extends React.Component<OrdinalWaypointProps, OrdinalWaypo
   // we defer settings things invisible for a little bit, which seems enough to fix it
   _handlePositionChange = ({currentPosition, event}) => {
     // lets ignore when this happens, this seems like a large source of jiggliness
-    if (!event) {
+    if (this.state.isVisible && !event) {
       return
     }
     if (currentPosition) {


### PR DESCRIPTION
Fixes a specific repro for messages disappearing in a thread. Let's see if this makes it better in general. r? @keybase/react-hackers 