### PR TITLE
client: `fs clear-conflicts` requires an argument

### DIFF
--- a/go/client/cmd_simplefs_clear_conflicts.go
+++ b/go/client/cmd_simplefs_clear_conflicts.go
@@ -24,7 +24,7 @@ func NewCmdSimpleFSClearConflicts(
 	cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "clear-conflicts",
-		ArgumentHelp: "[path-to-folder]",
+		ArgumentHelp: "<path-to-folder>",
 		Usage:        "moves the conflict state of the given folder out of the way",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdSimpleFSClearConflicts{


### PR DESCRIPTION
Suggested by atoponce.

Issue: #17349