### PR TITLE
Ipad support

### DIFF
--- a/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/react-native/ios/Keybase.xcodeproj/project.pbxproj
@@ -1962,7 +1962,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv7s arm7";
 			};
 			name = Debug;
@@ -2024,7 +2024,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv7s arm7";
 			};
 			name = Release;

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -73,6 +73,12 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/shared/router-v2/router.native.js
+++ b/shared/router-v2/router.native.js
@@ -145,6 +145,7 @@ const tabStyles = Styles.styleSheetCreate({
     paddingLeft: 16,
     paddingRight: 16,
     paddingTop: 6,
+    width: '100%',
   },
 })
 


### PR DESCRIPTION
This PR add some support for ipad.  It scales the app to fit the screen of the tablet and allows for landscape orientation.

It also fixes an icon UI update.

<img width="988" alt="Screen Shot 2019-05-06 at 8 52 05 PM" src="https://user-images.githubusercontent.com/1940365/57265044-a67f6f80-7043-11e9-999d-10604aa9cf66.png">
<img width="932" alt="Screen Shot 2019-05-06 at 8 51 22 PM" src="https://user-images.githubusercontent.com/1940365/57265046-aaab8d00-7043-11e9-974e-c6eb5348ac6b.png">

I am also willing to build a split view for tablet, but I wanted to submit this first PR just to see if the maintainers would be receptive to an external contributor building better ipad support.  If so any advice would be appreciated!