### PR TITLE
Fix deselecting convo on iOS via swipe back gesture

### DIFF
--- a/shared/chat/conversation/container.js
+++ b/shared/chat/conversation/container.js
@@ -4,7 +4,7 @@ import * as Constants from '../../constants/chat2'
 import * as Chat2Gen from '../../actions/chat2-gen'
 import * as Types from '../../constants/types/chat2'
 import * as Flow from '../../util/flow'
-import {isMobile} from '../../styles'
+import {isMobile, isIOS} from '../../constants/platform'
 import {connect, getRouteProps} from '../../util/container'
 import Normal from './normal/container'
 import NoConversation from './no-conversation'
@@ -38,6 +38,14 @@ class Conversation extends React.PureComponent<SwitchProps> {
   }
   _onWillBlur = () => {
     this.props.deselectConversation()
+  }
+  componentWillUnmount() {
+    // Workaround
+    // https://github.com/react-navigation/react-navigation/issues/5669
+    // Covers the case of swiping back on iOS
+    if (isIOS) {
+      this.props.deselectConversation()
+    }
   }
 
   render() {


### PR DESCRIPTION
Use componentWillUnmount to paper over navigationEvents flakiness on iOS. See RNav [issue](https://github.com/react-navigation/react-navigation/issues/5669). r? @keybase/react-hackers 