### PR TITLE
Fix teammentionload npe

### DIFF
--- a/go/chat/teammentionloader.go
+++ b/go/chat/teammentionloader.go
@@ -132,8 +132,6 @@ func (l *TeamMentionLoader) loadMention(ctx context.Context, uid gregor1.UID,
 	defer l.Trace(ctx, func() error { return err }, "loadTeamMention: name: %s", maybeMention.Name)()
 	ui, err := l.getChatUI(ctx)
 	if err != nil {
-		ui.ChatMaybeMentionUpdate(ctx, maybeMention.Name, maybeMention.Channel,
-			chat1.NewUIMaybeMentionInfoWithUnknown())
 		return err
 	}
 	if _, err := keybase1.TeamNameFromString(maybeMention.Name); err != nil {


### PR DESCRIPTION
This panic just happened while running an atypical combination of services. Couldn't repro. Seems bound to happen if the the ui is unavailable.

```
panic: runtime error: invalid memory address or nil pointer dereference                             
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x525afc8]                            
                                                                                                    
goroutine 199 [running]:                                                                            
github.com/keybase/client/go/chat.(*TeamMentionLoader).loadMention(0xc0001d4690, 0x62e2e20, 0xc0000d
        /Users/miles/go/src/github.com/keybase/client/go/chat/teammentionloader.go:135 +0xf48       
github.com/keybase/client/go/chat.(*TeamMentionLoader).loadLoop(0xc0001d4690)                       
        /Users/miles/go/src/github.com/keybase/client/go/chat/teammentionloader.go:199 +0x132       
created by github.com/keybase/client/go/chat.(*TeamMentionLoader).Start                             
        /Users/miles/go/src/github.com/keybase/client/go/chat/teammentionloader.go:51 +0x163        
```