### PR TITLE
Don't append if we're selecting a conversation in the inbox on desktop

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2107,7 +2107,10 @@ const navigateToThreadRoute = conversationIDKey => {
   if (!flags.useNewRouter) {
     return RouteTreeGen.createNavigateTo({path: Constants.threadRoute})
   }
-
+  if (!isMobile && Router2Constants.getVisibleScreen()?.routeName === 'chatRoot') {
+    // Don't append; we don't want to increase the size of the stack on desktop
+    return
+  }
   return RouteTreeGen.createNavigateAppend({
     path: [{props: {conversationIDKey}, selected: isMobile ? 'chatConversation' : 'chatRoot'}],
   })

--- a/shared/chat/routes.js
+++ b/shared/chat/routes.js
@@ -150,7 +150,6 @@ export const newRoutes = {
   },
   chatRoot: {
     getScreen: () =>
-      // TODO mark as upgraded when inbox doesn't use routeState anymore
       isMobile ? require('./inbox/container').default : require('./inbox-and-conversation-2.desktop').default,
     upgraded: true,
   },


### PR DESCRIPTION
Fixes the inbox back button enabling after you switch conversations + having to click it several times before it works. r? @keybase/react-hackers 