### PR TITLE
libkbfs: set conflict state for each TLF in the favorites

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3249,6 +3249,10 @@ func serializeAndPutConflicts(config Config, db *LevelDb,
 	return db.Put(key, conflictsSerialized, nil)
 }
 
+func isCRStuckFromRecords(conflictsSoFar []conflictRecord) bool {
+	return len(conflictsSoFar) > maxConflictResolutionAttempts
+}
+
 func (cr *ConflictResolver) isStuckWithDbAndConflicts() (
 	db *LevelDb, key []byte, conflictsSoFar []conflictRecord, isStuck bool,
 	err error) {
@@ -3262,8 +3266,7 @@ func (cr *ConflictResolver) isStuckWithDbAndConflicts() (
 		return nil, nil, nil, false, err
 	}
 
-	return db, key, conflictsSoFar,
-		len(conflictsSoFar) > maxConflictResolutionAttempts, nil
+	return db, key, conflictsSoFar, isCRStuckFromRecords(conflictsSoFar), nil
 }
 
 func (cr *ConflictResolver) isStuck() (bool, error) {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -6081,6 +6081,24 @@ func (fbo *folderBranchOps) FolderStatus(
 	return fbo.status.getStatus(ctx, &fbo.blocks)
 }
 
+func (fbo *folderBranchOps) FolderConflictStatus(ctx context.Context) (
+	keybase1.FolderConflictType, error) {
+	isStuck, err := fbo.cr.isStuck()
+	if err != nil {
+		return keybase1.FolderConflictType_NONE, err
+	}
+
+	if isStuck {
+		return keybase1.FolderConflictType_IN_CONFLICT_AND_STUCK, nil
+	}
+
+	lState := makeFBOLockState()
+	if fbo.isUnmerged(lState) {
+		return keybase1.FolderConflictType_IN_CONFLICT, nil
+	}
+	return keybase1.FolderConflictType_NONE, nil
+}
+
 func (fbo *folderBranchOps) Status(
 	ctx context.Context) (
 	fbs KBFSStatus, updateChan <-chan StatusUpdate, err error) {

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -428,6 +428,11 @@ type KBFSOps interface {
 	// updated (to eliminate the need for polling this method).
 	FolderStatus(ctx context.Context, folderBranch data.FolderBranch) (
 		FolderBranchStatus, <-chan StatusUpdate, error)
+	// FolderConflictStatus is alightweight method to return the
+	// conflict status of a particular folder/branch.  (The conflict
+	// status is also available in `FolderBranchStatus`.
+	FolderConflictStatus(ctx context.Context, folderBranch data.FolderBranch) (
+		keybase1.FolderConflictType, error)
 	// Status returns the status of KBFS, along with a channel that will be
 	// closed when the status has been updated (to eliminate the need for
 	// polling this method). Note that this channel only applies to

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -428,9 +428,9 @@ type KBFSOps interface {
 	// updated (to eliminate the need for polling this method).
 	FolderStatus(ctx context.Context, folderBranch data.FolderBranch) (
 		FolderBranchStatus, <-chan StatusUpdate, error)
-	// FolderConflictStatus is alightweight method to return the
+	// FolderConflictStatus is a lightweight method to return the
 	// conflict status of a particular folder/branch.  (The conflict
-	// status is also available in `FolderBranchStatus`.
+	// status is also available in `FolderBranchStatus`.)
 	FolderConflictStatus(ctx context.Context, folderBranch data.FolderBranch) (
 		keybase1.FolderConflictType, error)
 	// Status returns the status of KBFS, along with a channel that will be

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -1045,6 +1045,18 @@ func (fs *KBFSOpsStandard) FolderStatus(
 	return ops.FolderStatus(ctx, folderBranch)
 }
 
+// FolderConflictStatus implements the KBFSOps interface for
+// KBFSOpsStandard
+func (fs *KBFSOpsStandard) FolderConflictStatus(
+	ctx context.Context, folderBranch data.FolderBranch) (
+	keybase1.FolderConflictType, error) {
+	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
+	defer timeTrackerDone()
+
+	ops := fs.getOps(ctx, folderBranch, FavoritesOpNoChange)
+	return ops.FolderConflictStatus(ctx)
+}
+
 // Status implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	KBFSStatus, <-chan StatusUpdate, error) {

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -1007,6 +1007,21 @@ func (mr *MockKBFSOpsMockRecorder) DeleteFavorite(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFavorite", reflect.TypeOf((*MockKBFSOps)(nil).DeleteFavorite), arg0, arg1)
 }
 
+// FolderConflictStatus mocks base method
+func (m *MockKBFSOps) FolderConflictStatus(arg0 context.Context, arg1 data.FolderBranch) (keybase1.FolderConflictType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FolderConflictStatus", arg0, arg1)
+	ret0, _ := ret[0].(keybase1.FolderConflictType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FolderConflictStatus indicates an expected call of FolderConflictStatus
+func (mr *MockKBFSOpsMockRecorder) FolderConflictStatus(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FolderConflictStatus", reflect.TypeOf((*MockKBFSOps)(nil).FolderConflictStatus), arg0, arg1)
+}
+
 // FolderStatus mocks base method
 func (m *MockKBFSOps) FolderStatus(arg0 context.Context, arg1 data.FolderBranch) (FolderBranchStatus, <-chan StatusUpdate, error) {
 	m.ctrl.T.Helper()

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -1371,3 +1371,75 @@ func TestOverallStatusFile(t *testing.T) {
 	json.Unmarshal(buf, &status)
 	require.Equal(t, "jdoe", status.CurrentUser)
 }
+
+func TestFavoriteConflicts(t *testing.T) {
+	ctx := context.Background()
+	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_for_simplefs_cr")
+	defer os.RemoveAll(tempdir)
+	require.NoError(t, err)
+	sfs := newSimpleFS(
+		env.EmptyAppStateUpdater{}, libkbfs.MakeTestConfigOrBust(t, "jdoe"))
+	defer closeSimpleFS(ctx, t, sfs)
+	config := sfs.config.(*libkbfs.ConfigLocal)
+
+	t.Log("Enable journaling")
+	err = config.EnableDiskLimiter(tempdir)
+	require.NoError(t, err)
+	err = config.EnableJournaling(
+		ctx, tempdir, libkbfs.TLFJournalBackgroundWorkEnabled)
+	require.NoError(t, err)
+	jManager, err := libkbfs.GetJournalManager(config)
+	require.NoError(t, err)
+	err = jManager.EnableAuto(ctx)
+	require.NoError(t, err)
+
+	pathPriv := keybase1.NewPathWithKbfs(`/private/jdoe`)
+	pathPub := keybase1.NewPathWithKbfs(`/public/jdoe`)
+
+	t.Log("Add one file in each directory")
+	writeRemoteFile(
+		ctx, t, sfs, pathAppend(pathPriv, `test.txt`), []byte(`foo`))
+	syncFS(ctx, t, sfs, "/private/jdoe")
+	writeRemoteFile(
+		ctx, t, sfs, pathAppend(pathPub, `test.txt`), []byte(`foo`))
+	syncFS(ctx, t, sfs, "/public/jdoe")
+
+	t.Log("Make sue we see two favorites with no conflicts")
+	favs, err := sfs.SimpleFSListFavorites(ctx)
+	require.NoError(t, err)
+	require.Len(t, favs.FavoriteFolders, 2)
+	for _, f := range favs.FavoriteFolders {
+		require.Equal(t, keybase1.FolderConflictType_NONE, f.ConflictType)
+	}
+
+	t.Log("Force a stuck conflict and make sure it's captured correctly")
+	err = sfs.SimpleFSForceStuckConflict(ctx, pathPub)
+	require.NoError(t, err)
+	favs, err = sfs.SimpleFSListFavorites(ctx)
+	require.NoError(t, err)
+	require.Len(t, favs.FavoriteFolders, 2)
+	stuck, notStuck := 0, 0
+	for _, f := range favs.FavoriteFolders {
+		if f.FolderType == keybase1.FolderType_PUBLIC {
+			require.Equal(
+				t, keybase1.FolderConflictType_IN_CONFLICT_AND_STUCK,
+				f.ConflictType)
+			stuck++
+		} else {
+			require.Equal(t, keybase1.FolderConflictType_NONE, f.ConflictType)
+			notStuck++
+		}
+	}
+	require.Equal(t, 1, stuck)
+	require.Equal(t, 1, notStuck)
+
+	t.Log("Resolve the conflict")
+	err = sfs.SimpleFSClearConflictState(ctx, pathPub)
+	require.NoError(t, err)
+	favs, err = sfs.SimpleFSListFavorites(ctx)
+	require.NoError(t, err)
+	require.Len(t, favs.FavoriteFolders, 2)
+	for _, f := range favs.FavoriteFolders {
+		require.Equal(t, keybase1.FolderConflictType_NONE, f.ConflictType)
+	}
+}

--- a/go/kbfs/tlf/id.go
+++ b/go/kbfs/tlf/id.go
@@ -67,6 +67,11 @@ func (t Type) String() string {
 	}
 }
 
+// MarshalText implements the encoding.TextMarshaler interface for Type.
+func (t Type) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
 // PathString returns the string representation of t, when they are used in a
 // KBFS path. This is different from String() where this one returns 'team'
 // instead of 'singleTeam' for SingleTeam.

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2742,3 +2742,30 @@ func (c ContactComponent) FormatDisplayLabel(addLabel bool) string {
 	}
 	return c.ValueString()
 }
+
+func (fct FolderConflictType) MarshalText() ([]byte, error) {
+	switch fct {
+	case FolderConflictType_NONE:
+		return []byte("none"), nil
+	case FolderConflictType_IN_CONFLICT:
+		return []byte("in conflict"), nil
+	case FolderConflictType_IN_CONFLICT_AND_STUCK:
+		return []byte("in conflict and stuck"), nil
+	default:
+		return []byte(fmt.Sprintf("unknown conflict type: %d", fct)), nil
+	}
+}
+
+func (fct *FolderConflictType) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "none":
+		*fct = FolderConflictType_NONE
+	case "in conflict":
+		*fct = FolderConflictType_IN_CONFLICT
+	case "in conflict and stuck":
+		*fct = FolderConflictType_IN_CONFLICT_AND_STUCK
+	default:
+		return errors.New(fmt.Sprintf("Unknown conflict type: %s", text))
+	}
+	return nil
+}

--- a/go/protocol/keybase1/favorite.go
+++ b/go/protocol/keybase1/favorite.go
@@ -40,17 +40,47 @@ func (e FolderType) String() string {
 	return ""
 }
 
+type FolderConflictType int
+
+const (
+	FolderConflictType_NONE                  FolderConflictType = 0
+	FolderConflictType_IN_CONFLICT           FolderConflictType = 1
+	FolderConflictType_IN_CONFLICT_AND_STUCK FolderConflictType = 2
+)
+
+func (o FolderConflictType) DeepCopy() FolderConflictType { return o }
+
+var FolderConflictTypeMap = map[string]FolderConflictType{
+	"NONE":                  0,
+	"IN_CONFLICT":           1,
+	"IN_CONFLICT_AND_STUCK": 2,
+}
+
+var FolderConflictTypeRevMap = map[FolderConflictType]string{
+	0: "NONE",
+	1: "IN_CONFLICT",
+	2: "IN_CONFLICT_AND_STUCK",
+}
+
+func (e FolderConflictType) String() string {
+	if v, ok := FolderConflictTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 // Folder represents a favorite top-level folder in kbfs.
 // This type is likely to change significantly as all the various parts are
 // connected and tested.
 type Folder struct {
-	Name         string     `codec:"name" json:"name"`
-	Private      bool       `codec:"private" json:"private"`
-	Created      bool       `codec:"created" json:"created"`
-	FolderType   FolderType `codec:"folderType" json:"folderType"`
-	TeamID       *TeamID    `codec:"team_id,omitempty" json:"team_id,omitempty"`
-	ResetMembers []User     `codec:"reset_members" json:"reset_members"`
-	Mtime        *Time      `codec:"mtime,omitempty" json:"mtime,omitempty"`
+	Name         string             `codec:"name" json:"name"`
+	Private      bool               `codec:"private" json:"private"`
+	Created      bool               `codec:"created" json:"created"`
+	FolderType   FolderType         `codec:"folderType" json:"folderType"`
+	TeamID       *TeamID            `codec:"team_id,omitempty" json:"team_id,omitempty"`
+	ResetMembers []User             `codec:"reset_members" json:"reset_members"`
+	Mtime        *Time              `codec:"mtime,omitempty" json:"mtime,omitempty"`
+	ConflictType FolderConflictType `codec:"conflictType" json:"conflictType"`
 }
 
 func (o Folder) DeepCopy() Folder {
@@ -84,6 +114,7 @@ func (o Folder) DeepCopy() Folder {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Mtime),
+		ConflictType: o.ConflictType.DeepCopy(),
 	}
 }
 

--- a/protocol/avdl/keybase1/favorite.avdl
+++ b/protocol/avdl/keybase1/favorite.avdl
@@ -10,6 +10,11 @@ protocol favorite {
     TEAM_3
   }
 
+  enum FolderConflictType {
+    NONE_0,
+    IN_CONFLICT_1,
+    IN_CONFLICT_AND_STUCK_2
+  }
 
   /**
     Folder represents a favorite top-level folder in kbfs.
@@ -33,6 +38,9 @@ protocol favorite {
     array<User> resetMembers;
 
     union { null, Time } mtime;
+
+    // Is the local view of this folder hosed due to stuck CR?
+    FolderConflictType conflictType;
   }
 
   // Each of your TLFs is in one of 3 states with respect to favoriting. Either

--- a/protocol/json/keybase1/favorite.json
+++ b/protocol/json/keybase1/favorite.json
@@ -18,6 +18,15 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "FolderConflictType",
+      "symbols": [
+        "NONE_0",
+        "IN_CONFLICT_1",
+        "IN_CONFLICT_AND_STUCK_2"
+      ]
+    },
+    {
       "type": "record",
       "name": "Folder",
       "fields": [
@@ -61,6 +70,10 @@
             "Time"
           ],
           "name": "mtime"
+        },
+        {
+          "type": "FolderConflictType",
+          "name": "conflictType"
         }
       ],
       "doc": "Folder represents a favorite top-level folder in kbfs.\n    This type is likely to change significantly as all the various parts are\n    connected and tested."

--- a/shared/actions/git.js
+++ b/shared/actions/git.js
@@ -14,7 +14,6 @@ import {isMobile} from '../constants/platform'
 import type {TypedState} from '../util/container'
 import {logError} from '../util/errors'
 import flags from '../util/feature-flags'
-import {FolderConflictType} from '../constants/types/rpc-gen'
 
 const load = (state: TypedState) =>
   state.config.loggedIn &&
@@ -80,7 +79,7 @@ const setTeamRepoSettings = (_, action) =>
     channelName: action.payload.channelName,
     chatDisabled: action.payload.chatDisabled,
     folder: {
-      conflictType: FolderConflictType.none,
+      conflictType: RPCTypes.favoriteFolderConflictType.none,
       created: false,
       folderType: RPCTypes.favoriteFolderType.team,
       name: action.payload.teamname,

--- a/shared/actions/git.js
+++ b/shared/actions/git.js
@@ -14,6 +14,7 @@ import {isMobile} from '../constants/platform'
 import type {TypedState} from '../util/container'
 import {logError} from '../util/errors'
 import flags from '../util/feature-flags'
+import {FolderConflictType} from '../constants/types/rpc-gen'
 
 const load = (state: TypedState) =>
   state.config.loggedIn &&
@@ -79,6 +80,7 @@ const setTeamRepoSettings = (_, action) =>
     channelName: action.payload.channelName,
     chatDisabled: action.payload.chatDisabled,
     folder: {
+      conflictType: FolderConflictType.none,
       created: false,
       folderType: RPCTypes.favoriteFolderType.team,
       name: action.payload.teamname,

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -626,7 +626,7 @@ export const folderRPCFromPath = (path: Types.Path): ?RPCTypes.Folder => {
   if (name === '') return null
 
   return {
-    conflictType: RPCTypes.FolderConflictType.none,
+    conflictType: RPCTypes.favoriteFolderConflictType.none,
     created: false,
     folderType: Types.getRPCFolderTypeFromVisibility(visibility),
     name,

--- a/shared/constants/fs.js
+++ b/shared/constants/fs.js
@@ -626,6 +626,7 @@ export const folderRPCFromPath = (path: Types.Path): ?RPCTypes.Folder => {
   if (name === '') return null
 
   return {
+    conflictType: RPCTypes.FolderConflictType.none,
     created: false,
     folderType: Types.getRPCFolderTypeFromVisibility(visibility),
     name,

--- a/shared/constants/rpc.js
+++ b/shared/constants/rpc.js
@@ -1,5 +1,6 @@
 // @flow
 import {favoriteFolderType, type FolderType} from './types/rpc-gen'
+
 import {invert} from 'lodash-es'
 
 const folderTypeToString = invert(favoriteFolderType)

--- a/shared/constants/rpc.js
+++ b/shared/constants/rpc.js
@@ -1,6 +1,5 @@
 // @flow
 import {favoriteFolderType, type FolderType} from './types/rpc-gen'
-
 import {invert} from 'lodash-es'
 
 const folderTypeToString = invert(favoriteFolderType)

--- a/shared/constants/types/rpc-gen.js
+++ b/shared/constants/types/rpc-gen.js
@@ -342,6 +342,12 @@ export const ctlExitCode = {
   restart: 4,
 }
 
+export const favoriteFolderConflictType = {
+  none: 0,
+  inConflict: 1,
+  inConflictAndStuck: 2,
+}
+
 export const favoriteFolderType = {
   unknown: 0,
   private: 1,

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -1454,6 +1454,12 @@ export const ctlExitCode = {
   restart: 4,
 }
 
+export const favoriteFolderConflictType = {
+  none: 0,
+  inConflict: 1,
+  inConflictAndStuck: 2,
+}
+
 export const favoriteFolderType = {
   unknown: 0,
   private: 1,
@@ -2238,7 +2244,12 @@ export type FileType =
 
 export type FindNextMDResponse = $ReadOnly<{kbfsRoot: MerkleRoot, merkleNodes?: ?Array<Bytes>, rootSeqno: Seqno, rootHash: HashMeta}>
 export type FirstStepResult = $ReadOnly<{valPlusTwo: Int}>
-export type Folder = $ReadOnly<{name: String, private: Boolean, created: Boolean, folderType: FolderType, team_id /* teamID */?: ?TeamID, reset_members /* resetMembers */?: ?Array<User>, mtime?: ?Time}>
+export type Folder = $ReadOnly<{name: String, private: Boolean, created: Boolean, folderType: FolderType, team_id /* teamID */?: ?TeamID, reset_members /* resetMembers */?: ?Array<User>, mtime?: ?Time, conflictType: FolderConflictType}>
+export type FolderConflictType =
+  | 0 // NONE_0
+  | 1 // IN_CONFLICT_1
+  | 2 // IN_CONFLICT_AND_STUCK_2
+
 export type FolderSyncConfig = $ReadOnly<{mode: FolderSyncMode, paths?: ?Array<String>}>
 export type FolderSyncConfigAndStatus = $ReadOnly<{config: FolderSyncConfig, status: FolderSyncStatus}>
 export type FolderSyncConfigAndStatusWithFolder = $ReadOnly<{folder: Folder, config: FolderSyncConfig, status: FolderSyncStatus}>


### PR DESCRIPTION
This PR adds a conflict state to each `keybase1.Folder` object returned with the favorites list from SimpleFS.

Rather than loop through all possible favorites, it uses the journal manager to figure out which TLFs are currently in conflict, compares that list manually against the favorites list, and marks the ones that match.

It also adds a conflict status to the TLF `.kbfs_status` file, as well as the set of conflicting TLFs to the overall `.kbfs_status` file.

Notifications to the GUI that favorites have changed will come in a future PR.

Issue: KBFS-4137