### PR TITLE
config_local: add root node wrappers to early FBO instances

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1695,6 +1695,9 @@ func (c *ConfigLocal) AddRootNodeWrapper(f func(Node) Node) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.rootNodeWrappers = append(c.rootNodeWrappers, f)
+	if c.kbfs != nil {
+		c.kbfs.AddRootNodeWrapper(f)
+	}
 }
 
 // SetVLogLevel implements the Config interface for ConfigLocal.

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -9344,3 +9344,7 @@ func (fbo *folderBranchOps) monitorEditsChat(tlfName tlf.CanonicalName) {
 		}
 	}
 }
+
+func (fbo *folderBranchOps) addRootNodeWrapper(f func(Node) Node) {
+	fbo.nodeCache.AddRootWrapper(f)
+}

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -541,6 +541,11 @@ type KBFSOps interface {
 	SetSyncConfig(
 		ctx context.Context, tlfID tlf.ID, config keybase1.FolderSyncConfig) (
 		<-chan error, error)
+
+	// AddRootNodeWrapper adds a new root node wrapper for every
+	// existing TLF.  Any Nodes that have already been returned by
+	// `KBFSOps` won't use these wrappers.
+	AddRootNodeWrapper(func(Node) Node)
 }
 
 type gitMetadataPutter interface {

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -1473,6 +1473,16 @@ func (fs *KBFSOpsStandard) changeHandle(ctx context.Context,
 	delete(fs.opsByFav, oldFav)
 }
 
+// AddRootNodeWrapper implements the KBFSOps interface for
+// KBFSOpsStandard.
+func (fs *KBFSOpsStandard) AddRootNodeWrapper(f func(Node) Node) {
+	fs.opsLock.Lock()
+	defer fs.opsLock.Unlock()
+	for _, op := range fs.ops {
+		op.addRootNodeWrapper(f)
+	}
+}
+
 // Notifier:
 var _ Notifier = (*KBFSOpsStandard)(nil)
 

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -896,6 +896,18 @@ func (mr *MockKBFSOpsMockRecorder) AddFavorite(arg0, arg1, arg2 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddFavorite", reflect.TypeOf((*MockKBFSOps)(nil).AddFavorite), arg0, arg1, arg2)
 }
 
+// AddRootNodeWrapper mocks base method
+func (m *MockKBFSOps) AddRootNodeWrapper(arg0 func(Node) Node) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddRootNodeWrapper", arg0)
+}
+
+// AddRootNodeWrapper indicates an expected call of AddRootNodeWrapper
+func (mr *MockKBFSOpsMockRecorder) AddRootNodeWrapper(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRootNodeWrapper", reflect.TypeOf((*MockKBFSOps)(nil).AddRootNodeWrapper), arg0)
+}
+
 // ClearCachedFavorites mocks base method
 func (m *MockKBFSOps) ClearCachedFavorites(arg0 context.Context) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
FBOs that were created by the journal manger initialization code (i.e., ones that aren't fully flushed yet, or ones stuck in conflict mode) can be created before the libfuse/libdokan code properly sets up the root wrappers. Since `.kbfs_status` is now handled by a root node wrapper, this means `.kbfs_status` is unavailable in those TLFs and gets an ENOENT error.

To fix, add the root wrapper to each existing FBO when it's added to the config.  Any Nodes that happened to have been created before the wrappers were added won't have their effect, but that shouldn't matter since the libfuse/libdokan code adds them before they make the mount available anyway.