### PR TITLE
Fix kbsig panic

### DIFF
--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -326,6 +326,9 @@ func (arg ProofMetadata) ToJSON2(m MetaContext) (ret *ProofMetadataRes, err erro
 			prev = jsonw.NewString(arg.PrevLinkID.String())
 		}
 	} else {
+		if arg.Me == nil {
+			return nil, fmt.Errorf("missing self user object while signing")
+		}
 		lastSeqno := arg.Me.sigChain().GetLastKnownSeqno()
 		lastLink := arg.Me.sigChain().GetLastKnownID()
 		if lastLink == nil {
@@ -386,6 +389,9 @@ func (arg ProofMetadata) ToJSON2(m MetaContext) (ret *ProofMetadataRes, err erro
 	}
 	eldest := arg.Eldest
 	if eldest == "" {
+		if arg.Me == nil {
+			return nil, fmt.Errorf("missing self user object while signing")
+		}
 		eldest = arg.Me.GetEldestKID()
 	}
 


### PR DESCRIPTION
While testing locally there was a panic in kbsig. Due to a missing `Me` object. Was trying `kbu chat send st104 hi` on a device for an account that had just been reset. Didn't repro.

```
2019-05-09T14:48:44.346592-04:00 ▶ [DEBU keybase merkle_client.go:1600] cbb7 {VDL:0} - MerkleClient.LookupUser(map[c:1 last:226686 load_deleted:1 load_reset_chain:1 poll:10 sig_hints_low:0 uid:855092fe52160334a77c0f4938ede719]) -> OK [tags:platform=darwin,apptype=desktop,chat-trace=KRCijHozChox,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,LU=BiKWJi29KUaa]
2019-05-09T14:48:44.346646-04:00 ▶ [DEBU keybase upak_loader.go:420] cbb8 - lookupSigHintsAndMerkleLeaf -> ok [tags:platform=darwin,apptype=desktop,chat-trace=KRCijHozChox,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,LU=BiKWJi29KUaa]
2019-05-09T14:48:44.346753-04:00 ▶ [DEBU keybase upak_loader.go:444] cbb9 {VDL:0} CachedUPAKLoader#Load(855092fe52160334a77c0f4938ede719): cache-hit; fresh after poll [tags:platform=darwin,apptype=desktop,chat-trace=KRCijHozChox,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,LU=BiKWJi29KUaa]
2019-05-09T14:48:44.346803-04:00 ▶ [DEBU keybase upak_loader.go:282] cbba {VDL:0} | Caching UPAK for 855092fe52160334a77c0f4938ede719 stubbed [tags:platform=darwin,apptype=desktop,chat-trace=KRCijHozChox,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,LU=BiKWJi29KUaa]
2019-05-09T14:48:44.347085-04:00 ▶ [DEBU keybase util.go:566] cbbb {VDL:0} - CachedUPAKLoader#Load() -> ok [tags:platform=darwin,apptype=desktop,chat-trace=KRCijHozChox,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,LU=BiKWJi29KUaa]
2019-05-09T14:48:44.347153-04:00 ▶ [DEBU keybase util.go:565] cbbc {VDL:0} + CachedUPAKLoader#Load() [tags:LU=_lQHZa9DX6y6,chat-trace=KRCijHozChox,apptype=desktop,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin]
2019-05-09T14:48:44.347177-04:00 ▶ [DEBU keybase resolve.go:136] cbbd + Resolving username "ireset1" [tags:chat-trace=KRCijHozChox,apptype=desktop,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin,LU=_lQHZa9DX6y6]
2019-05-09T14:48:44.347297-04:00 ▶ [DEBU keybase resolve.go:241] cbbe | Resolver#resolveURL(keybase:ireset1) -> {uid:7080d7d007b46805c33e66b267e1e819 teamID: err:ok mutable:false} [trace:m] [tags:chat-trace=KRCijHozChox,apptype=desktop,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin,LU=_lQHZa9DX6y6]
2019-05-09T14:48:44.347329-04:00 ▶ [DEBU keybase resolve.go:132] cbbf - Resolving username "ireset1" -> ok [time=101.954µs] [tags:platform=darwin,LU=_lQHZa9DX6y6,chat-trace=KRCijHozChox,apptype=desktop,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0]
2019-05-09T14:48:44.347371-04:00 ▶ [DEBU keybase uidmap.go:364] cbc0 + MapUIDsToUserPackages(7080d7d007b46805c33e66b267e1e819) [tags:chat-trace=KRCijHozChox,apptype=desktop,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin,LU=_lQHZa9DX6y6]
2019-05-09T14:48:44.348733-04:00 ▶ [DEBU keybase uidmap.go:451] cbc1 - MapUIDsToUserPackages(7080d7d007b46805c33e66b267e1e819) -> ok [tags:chat-trace=KRCijHozChox,apptype=desktop,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin,LU=_lQHZa9DX6y6]
2019-05-09T14:48:44.348780-04:00 ▶ [DEBU keybase upak_loader.go:187] cbc2 {VDL:0} | hit memory cache [tags:chat-trace=KRCijHozChox,apptype=desktop,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin,LU=_lQHZa9DX6y6]
2019-05-09T14:48:44.348807-04:00 ▶ [DEBU keybase upak_loader.go:224] cbc3 {VDL:0} | cache hit was fresh (cached 92.799ms ago) [tags:chat-trace=KRCijHozChox,apptype=desktop,user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin,LU=_lQHZa9DX6y6]
2019-05-09T14:48:44.348884-04:00 ▶ [DEBU keybase upak_loader.go:409] cbc4 {VDL:0} CachedUPAKLoader#Load(7080d7d007b46805c33e66b267e1e819): cache-hit; fresh=true [tags:user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin,LU=_lQHZa9DX6y6,chat-trace=KRCijHozChox,apptype=desktop]
2019-05-09T14:48:44.349572-04:00 ▶ [DEBU keybase util.go:566] cbc5 {VDL:0} - CachedUPAKLoader#Load() -> ok [tags:user-agent=darwin:Keybase CLI (go1.12.4):4.1.0,platform=darwin,LU=_lQHZa9DX6y6,chat-trace=KRCijHozChox,apptype=desktop]
2019-05-09T14:48:44.350903-04:00 ▶ [DEBU keybase create.go:152] cbc6 + makeSigAndPostRootTeam
2019-05-09T14:48:44.350946-04:00 ▶ [DEBU keybase create.go:153] cbc7 makeSigAndPostRootTeam get device keys [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.351004-04:00 ▶ [DEBU keybase keys.go:136] cbc8 + SharedSecretBoxes [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.351313-04:00 ▶ [DEBU keybase create.go:168] cbc9 - SharedSecretBoxes -> ok [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.351505-04:00 ▶ [DEBU keybase create.go:182] cbca makeSigAndPostRootTeam make sigs [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.353253-04:00 ▶ [DEBU keybase panic.go:82] cbcb - makeSigAndPostRootTeam -> ok
2019-05-09T14:48:44.353976-04:00 ▶ [DEBU keybase panic.go:82] cbcc - CreateImplicitTeam -> ok [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.354009-04:00 ▶ [DEBU keybase panic.go:82] cbcd - LookupOrCreateImplicitTeam(st104,ireset1) -> Team "ireset1,st104" does not exist teams.TeamDoesNotExistError [time=381.432185ms] [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.354064-04:00 ▶ [DEBU keybase panic.go:522] cbce ++Chat: - newConversationHelper: newConversationHelper -> ok [time=382.235397ms] [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.354168-04:00 ▶ [DEBU keybase convloader.go:287] cbcf ++Chat: + BackgroundConvLoader: Resume [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.354216-04:00 ▶ [DEBU keybase convloader.go:293] cbd0 ++Chat: | BackgroundConvLoader: Resume: closing resumeCh [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.354249-04:00 ▶ [DEBU keybase convloader.go:295] cbd1 ++Chat: - BackgroundConvLoader: Resume -> ok [time=82.191µs] [tags:chat-trace=KRCijHozChox]
2019-05-09T14:48:44.354274-04:00 ▶ [DEBU keybase panic.go:522] cbd2 ++Chat: - Server: NewConversationLocal(st104|IMPTEAMNATIVE) -> ok [time=383.556667ms] [tags:chat-trace=KRCijHozChox]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x90 pc=0x4a1f0ad]

goroutine 15828 [running]:
github.com/keybase/client/go/libkb.(*User).GetEldestKID(...)
	/Users/miles/go/src/github.com/keybase/client/go/libkb/user.go:467
github.com/keybase/client/go/libkb.ProofMetadata.ToJSON2(0x0, 0x62e66c0, 0xc00134fd40, 0x1, 0x0, 0x0, 0x0, 0x5c3c452, 0x9, 0x6336340, ...)
	/Users/miles/go/src/github.com/keybase/client/go/libkb/kbsig.go:389 +0x6dd
github.com/keybase/client/go/libkb.ProofMetadata.ToJSON(...)
	/Users/miles/go/src/github.com/keybase/client/go/libkb/kbsig.go:300
github.com/keybase/client/go/teams.TeamRootSig(0xc0004fe900, 0xc0027d6440, 0x20, 0xc002abc408, 0x7, 0x0, 0x0, 0x0, 0x0, 0x6336340, ...)
	/Users/miles/go/src/github.com/keybase/client/go/teams/sig.go:39 +0x30d
github.com/keybase/client/go/teams.makeSigAndPostRootTeam(0x62ff8c0, 0xc006561170, 0xc0004fe900, 0xc0027d6440, 0x20, 0xc002abc408, 0x7, 0x0, 0x0, 0x0, ...)
	/Users/miles/go/src/github.com/keybase/client/go/teams/create.go:199 +0x96f
github.com/keybase/client/go/teams.CreateImplicitTeam(0x62ff8c0, 0xc006561170, 0xc0004fe900, 0x0, 0xc001d5a4e0, 0x2, 0x2, 0x0, 0x0, 0x0, ...)
	/Users/miles/go/src/github.com/keybase/client/go/teams/create.go:144 +0x16e2
github.com/keybase/client/go/teams.LookupOrCreateImplicitTeam(0x62ff8c0, 0xc006561170, 0xc0004fe900, 0xc0062061b0, 0xd, 0x5463c00, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/miles/go/src/github.com/keybase/client/go/teams/implicit.go:276 +0x4a8
github.com/keybase/client/go/chat.(*newConversationHelper).getNameInfo(0xc003cc03f0, 0x62ff8c0, 0xc006561170, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5c5a9e9, 0x15)
	/Users/miles/go/src/github.com/keybase/client/go/chat/helper.go:966 +0x26f
github.com/keybase/client/go/chat.(*newConversationHelper).create(0xc003cc03f0, 0x62ff8c0, 0xc006561170, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/miles/go/src/github.com/keybase/client/go/chat/helper.go:994 +0x1e2
github.com/keybase/client/go/chat.NewConversationWithMemberSourceConv(0x62ff8c0, 0xc006561170, 0xc001d334b0, 0xc0033a6300, 0x10, 0x20, 0xc002e4f5f8, 0x5, 0x0, 0x1, ...)
	/Users/miles/go/src/github.com/keybase/client/go/chat/helper.go:891 +0x1b0
github.com/keybase/client/go/chat.NewConversation(...)
	/Users/miles/go/src/github.com/keybase/client/go/chat/helper.go:881
github.com/keybase/client/go/chat.(*Server).NewConversationLocal(0xc0038b3520, 0x62ff800, 0xc00633a6c0, 0xc002e4f5f8, 0x5, 0x1, 0x2, 0x0, 0x2, 0x0, ...)
	/Users/miles/go/src/github.com/keybase/client/go/chat/server.go:865 +0x5af
github.com/keybase/client/go/protocol/chat1.LocalProtocol.func46(0x62ff800, 0xc00633a6c0, 0x57aab80, 0xc006452180, 0xc, 0xc00633a6c0, 0xc002dde900, 0xc)
	/Users/miles/go/src/github.com/keybase/client/go/protocol/chat1/local.go:5870 +0xea
github.com/keybase/client/go/service.CancelingProtocol.func1(0x62ff800, 0xc00633a6c0, 0x57aab80, 0xc006452180, 0x0, 0x0, 0x0, 0x0)
	/Users/miles/go/src/github.com/keybase/client/go/service/canceling.go:21 +0xf9
github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc.(*callRequest).Serve(0xc002e36420, 0xc0065d8be0, 0xc003023780, 0xc001d33330)
	/Users/miles/go/src/github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/request.go:76 +0x1e9
github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc.(*receiveHandler).handleReceiveDispatch.func1(0x632e7a0, 0xc002e36420, 0xc0065d8c30, 0xc003023780, 0xc001d33330)
	/Users/miles/go/src/github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/receiver.go:128 +0x56
created by github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc.(*receiveHandler).handleReceiveDispatch
	/Users/miles/go/src/github.com/keybase/client/go/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/receiver.go:127 +0x192
2019-05-09T14:49:25.863797-04:00 ▶ [DEBU keybase json.go:54] 001 + loading "config" file: /Users/miles/kbus/ireset1/Library/Application Support/KeybaseDevel/config.json
2019-05-09T14:49:25.863964-04:00 ▶ [DEBU keybase json.go:95] 002 - successfully loaded config file
2019-05-09T14:49:25.864046-04:00 ▶ [DEBU keybase json.go:54] 003 + loading "updater config" file: /Users/miles/kbus/ireset1/Library/Application Support/KeybaseDevel/updater.json
2019-05-09T14:49:25.864108-04:00 ▶ [DEBU keybase json.go:62] 004 No "updater config" file found; tried /Users/miles/kbus/ireset1/Library/Application Support/KeybaseDevel/updater.json
2019-05-09T14:49:25.864271-04:00 ▶ [DEBU keybase globals.go:486] 005 Created Identify2Cache, max age: 5m0s
2019-05-09T14:49:25.864321-04:00 ▶ [DEBU keybase globals.go:489] 006 Created LinkCache, max size: 4000, clean dur: 1m0s
2019-05-09T14:49:25.864362-04:00 ▶ [DEBU keybase globals.go:491] 007 Created CardCache, max age: 5m0s
2019-05-09T14:49:25.864415-04:00 ▶ [DEBU keybase globals.go:509] 008 made a new full self cache
2019-05-09T14:49:25.864537-04:00 ▶ [DEBU keybase globals.go:511] 009 made a new cached UPAK loader (timeout=10m0s)
2019-05-09T14:49:25.866743-04:00 ▶ [DEBU keybase secret_store.go:181] 00a NewSecretStoreLocked: using os-specific SecretStore
2019-05-09T14:49:25.866812-04:00 ▶ [DEBU keybase globals.go:422] 00b Keybase CLI 4.1.0
2019-05-09T14:49:25.866836-04:00 ▶ [DEBU keybase globals.go:422] 00c - Built with go1.12.4
2019-05-09T14:49:25.866846-04:00 ▶ [DEBU keybase globals.go:422] 00d - Visit https://keybase.io for more details
```