### PR TITLE
hide username ellipsis in collapsed tab bar

### DIFF
--- a/shared/router-v2/tab-bar/tab-bar.css
+++ b/shared/router-v2/tab-bar/tab-bar.css
@@ -64,7 +64,7 @@
   }
   .tab-label,
   .username {
-    display: none;
+    display: none !important;
   }
   .tab-tooltip {
     display: flex !important;


### PR DESCRIPTION
This was overridden by `display: -webkit-box` in `lineClamp` styles. r? @keybase/react-hackers 