### PR TITLE
libkbfs: send notifications when favorites, and CR stuck state, change

### DIFF
--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -136,6 +136,10 @@ func (d *notificationDisplay) FSOverallSyncStatusChanged(_ context.Context,
 	return d.printf("KBFS overall sync status: %+v\n", status)
 }
 
+func (d *notificationDisplay) FSFavoritesChanged(_ context.Context) error {
+	return d.printf("KBFS favorites changed\n")
+}
+
 func (d *notificationDisplay) FSActivity(_ context.Context, notification keybase1.FSNotification) error {
 	return d.printf("KBFS notification: %+v\n", notification)
 }

--- a/go/kbfs/libkbfs/favorites_test.go
+++ b/go/kbfs/libkbfs/favorites_test.go
@@ -34,6 +34,8 @@ func favTestInit(t *testing.T, testingDiskCache bool) (
 			}, nil)
 	}
 	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).AnyTimes()
+	config.mockKbs.EXPECT().NotifyFavoritesChanged(gomock.Any()).Return(nil).
+		AnyTimes()
 
 	return mockCtrl, config, context.Background()
 }

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -756,7 +756,7 @@ func (fbo *folderBranchOps) clearConflictView(ctx context.Context) (
 	if err != nil {
 		return err
 	}
-	return fbo.cr.clearConflictRecords()
+	return fbo.cr.clearConflictRecords(ctx)
 }
 
 // forceStuckConflictForTesting forces the TLF into a stuck conflict

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -599,6 +599,10 @@ type KeybaseService interface {
 	NotifyOverallSyncStatus(
 		ctx context.Context, status keybase1.FolderSyncStatus) error
 
+	// NotifyFavoritesChanged sends a notification that favorites have
+	// changed.
+	NotifyFavoritesChanged(ctx context.Context) error
+
 	// FlushUserFromLocalCache instructs this layer to clear any
 	// KBFS-side, locally-cached information about the given user.
 	// This does NOT involve communication with the daemon, this is

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -375,6 +375,11 @@ func (k *KeybaseDaemonLocal) NotifyOnlineStatusChanged(ctx context.Context, onli
 	return checkContext(ctx)
 }
 
+// NotifyFavoritesChanged implements KeybaseDaemon for KeybaseDeamonLocal.
+func (k *KeybaseDaemonLocal) NotifyFavoritesChanged(ctx context.Context) error {
+	return checkContext(ctx)
+}
+
 // Notify implements KeybaseDaemon for KeybaseDeamonLocal.
 func (k *KeybaseDaemonLocal) Notify(ctx context.Context, notification *keybase1.FSNotification) error {
 	return checkContext(ctx)

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1225,6 +1225,12 @@ func (k *KeybaseServiceBase) NotifyOverallSyncStatus(
 	return k.kbfsClient.FSOverallSyncEvent(ctx, status)
 }
 
+// NotifyFavoritesChanged implements the KeybaseService interface for
+// KeybaseServiceBase.
+func (k *KeybaseServiceBase) NotifyFavoritesChanged(ctx context.Context) error {
+	return k.kbfsClient.FSFavoritesChangedEvent(ctx)
+}
+
 // FlushUserFromLocalCache implements the KeybaseService interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) FlushUserFromLocalCache(ctx context.Context,

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -328,6 +328,16 @@ func (k KeybaseServiceMeasured) NotifyOverallSyncStatus(
 	return err
 }
 
+// NotifyFavoritesChanged implements the KeybaseService interface for
+// KeybaseServiceMeasured.
+func (k KeybaseServiceMeasured) NotifyFavoritesChanged(
+	ctx context.Context) (err error) {
+	k.notifyTimer.Time(func() {
+		err = k.delegate.NotifyFavoritesChanged(ctx)
+	})
+	return err
+}
+
 // FlushUserFromLocalCache implements the KeybaseService interface for
 // KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) FlushUserFromLocalCache(

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -2322,6 +2322,20 @@ func (mr *MockKeybaseServiceMockRecorder) Notify(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockKeybaseService)(nil).Notify), arg0, arg1)
 }
 
+// NotifyFavoritesChanged mocks base method
+func (m *MockKeybaseService) NotifyFavoritesChanged(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NotifyFavoritesChanged", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// NotifyFavoritesChanged indicates an expected call of NotifyFavoritesChanged
+func (mr *MockKeybaseServiceMockRecorder) NotifyFavoritesChanged(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyFavoritesChanged", reflect.TypeOf((*MockKeybaseService)(nil).NotifyFavoritesChanged), arg0)
+}
+
 // NotifyOnlineStatusChanged mocks base method
 func (m *MockKeybaseService) NotifyOnlineStatusChanged(arg0 context.Context, arg1 bool) error {
 	m.ctrl.T.Helper()

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -42,6 +42,7 @@ type NotifyListener interface {
 	FSSyncEvent(arg keybase1.FSPathSyncStatus)
 	FSEditListRequest(arg keybase1.FSEditListRequest)
 	FSOverallSyncStatusChanged(arg keybase1.FolderSyncStatus)
+	FSFavoritesChanged()
 	FavoritesChanged(uid keybase1.UID)
 	PaperKeyCached(uid keybase1.UID, encKID keybase1.KID, sigKID keybase1.KID)
 	KeyfamilyChanged(uid keybase1.UID)
@@ -111,6 +112,7 @@ func (n *NoopNotifyListener) UserChanged(uid keybase1.UID)                      
 func (n *NoopNotifyListener) TrackingChanged(uid keybase1.UID, username NormalizedUsername) {}
 func (n *NoopNotifyListener) FSOnlineStatusChanged(online bool)                             {}
 func (n *NoopNotifyListener) FSOverallSyncStatusChanged(status keybase1.FolderSyncStatus)   {}
+func (n *NoopNotifyListener) FSFavoritesChanged()                                           {}
 func (n *NoopNotifyListener) FSActivity(activity keybase1.FSNotification)                   {}
 func (n *NoopNotifyListener) FSPathUpdated(path string)                                     {}
 func (n *NoopNotifyListener) FSEditListResponse(arg keybase1.FSEditListArg)                 {}
@@ -519,6 +521,32 @@ func (n *NotifyRouter) HandleFSOverallSyncStatusChanged(status keybase1.FolderSy
 	})
 	n.runListeners(func(listener NotifyListener) {
 		listener.FSOverallSyncStatusChanged(status)
+	})
+}
+
+// HandleFSFavoritesChanged is called when the overall sync status
+// changes. It will broadcast the messages to all curious listeners.
+func (n *NotifyRouter) HandleFSFavoritesChanged() {
+	if n == nil {
+		return
+	}
+	// For all connections we currently have open...
+	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
+		// If the connection wants the `kbfs` notification type
+		if n.getNotificationChannels(id).Kbfs {
+			// In the background do...
+			go func() {
+				// A send of a `FSFavoritesChanged` RPC with the
+				// notification
+				(keybase1.NotifyFSClient{
+					Cli: rpc.NewClient(xp, NewContextifiedErrorUnwrapper(n.G()), nil),
+				}).FSFavoritesChanged(context.Background())
+			}()
+		}
+		return true
+	})
+	n.runListeners(func(listener NotifyListener) {
+		listener.FSFavoritesChanged()
 	})
 }
 

--- a/go/protocol/keybase1/kbfs.go
+++ b/go/protocol/keybase1/kbfs.go
@@ -48,6 +48,9 @@ type FSOnlineStatusChangedEventArg struct {
 	Online bool `codec:"online" json:"online"`
 }
 
+type FSFavoritesChangedEventArg struct {
+}
+
 type CreateTLFArg struct {
 	TeamID TeamID `codec:"teamID" json:"teamID"`
 	TlfID  TLFID  `codec:"tlfID" json:"tlfID"`
@@ -98,6 +101,8 @@ type KbfsInterface interface {
 	FSOverallSyncEvent(context.Context, FolderSyncStatus) error
 	// FSOnlineStatusChangedEvent is called by KBFS when the online status changes.
 	FSOnlineStatusChangedEvent(context.Context, bool) error
+	// FSFavoritesChangedEvent is called by KBFS when the favorites list changes.
+	FSFavoritesChangedEvent(context.Context) error
 	// createTLF is called by KBFS to associate the tlfID with the given teamID,
 	// using the v2 Team-based system.
 	CreateTLF(context.Context, CreateTLFArg) error
@@ -217,6 +222,16 @@ func KbfsProtocol(i KbfsInterface) rpc.Protocol {
 						return
 					}
 					err = i.FSOnlineStatusChangedEvent(ctx, typedArgs[0].Online)
+					return
+				},
+			},
+			"FSFavoritesChangedEvent": {
+				MakeArg: func() interface{} {
+					var ret [1]FSFavoritesChangedEventArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					err = i.FSFavoritesChangedEvent(ctx)
 					return
 				},
 			},
@@ -359,6 +374,12 @@ func (c KbfsClient) FSOverallSyncEvent(ctx context.Context, status FolderSyncSta
 func (c KbfsClient) FSOnlineStatusChangedEvent(ctx context.Context, online bool) (err error) {
 	__arg := FSOnlineStatusChangedEventArg{Online: online}
 	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSOnlineStatusChangedEvent", []interface{}{__arg}, nil)
+	return
+}
+
+// FSFavoritesChangedEvent is called by KBFS when the favorites list changes.
+func (c KbfsClient) FSFavoritesChangedEvent(ctx context.Context) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.kbfs.FSFavoritesChangedEvent", []interface{}{FSFavoritesChangedEventArg{}}, nil)
 	return
 }
 

--- a/go/protocol/keybase1/notify_fs.go
+++ b/go/protocol/keybase1/notify_fs.go
@@ -34,6 +34,9 @@ type FSOverallSyncStatusChangedArg struct {
 	Status FolderSyncStatus `codec:"status" json:"status"`
 }
 
+type FSFavoritesChangedArg struct {
+}
+
 type FSOnlineStatusChangedArg struct {
 	Online bool `codec:"online" json:"online"`
 }
@@ -45,6 +48,7 @@ type NotifyFSInterface interface {
 	FSEditListResponse(context.Context, FSEditListResponseArg) error
 	FSSyncStatusResponse(context.Context, FSSyncStatusResponseArg) error
 	FSOverallSyncStatusChanged(context.Context, FolderSyncStatus) error
+	FSFavoritesChanged(context.Context) error
 	FSOnlineStatusChanged(context.Context, bool) error
 }
 
@@ -142,6 +146,16 @@ func NotifyFSProtocol(i NotifyFSInterface) rpc.Protocol {
 					return
 				},
 			},
+			"FSFavoritesChanged": {
+				MakeArg: func() interface{} {
+					var ret [1]FSFavoritesChangedArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					err = i.FSFavoritesChanged(ctx)
+					return
+				},
+			},
 			"FSOnlineStatusChanged": {
 				MakeArg: func() interface{} {
 					var ret [1]FSOnlineStatusChangedArg
@@ -196,6 +210,11 @@ func (c NotifyFSClient) FSSyncStatusResponse(ctx context.Context, __arg FSSyncSt
 func (c NotifyFSClient) FSOverallSyncStatusChanged(ctx context.Context, status FolderSyncStatus) (err error) {
 	__arg := FSOverallSyncStatusChangedArg{Status: status}
 	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSOverallSyncStatusChanged", []interface{}{__arg})
+	return
+}
+
+func (c NotifyFSClient) FSFavoritesChanged(ctx context.Context) (err error) {
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyFS.FSFavoritesChanged", []interface{}{FSFavoritesChangedArg{}})
 	return
 }
 

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -84,6 +84,11 @@ func (h *KBFSHandler) FSOverallSyncEvent(
 	return nil
 }
 
+func (h *KBFSHandler) FSFavoritesChangedEvent(_ context.Context) (err error) {
+	h.G().NotifyRouter.HandleFSFavoritesChanged()
+	return nil
+}
+
 // checkConversationRekey looks for rekey finished notifications and tries to
 // find any conversations associated with the rekeyed TLF.  If it finds any,
 // it will send ChatThreadsStale notifications for them.

--- a/protocol/avdl/keybase1/kbfs.avdl
+++ b/protocol/avdl/keybase1/kbfs.avdl
@@ -63,6 +63,12 @@ protocol kbfs {
   void FSOnlineStatusChangedEvent(boolean online);
 
   /**
+    FSFavoritesChangedEvent is called by KBFS when the favorites list changes.
+        */
+  @lint("ignore")
+  void FSFavoritesChangedEvent();
+
+  /**
     createTLF is called by KBFS to associate the tlfID with the given teamID,
     using the v2 Team-based system.
    */

--- a/protocol/avdl/keybase1/notify_fs.avdl
+++ b/protocol/avdl/keybase1/notify_fs.avdl
@@ -24,5 +24,8 @@ protocol NotifyFS {
   void FSOverallSyncStatusChanged(FolderSyncStatus status) oneway;
 
   @lint("ignore")
+  void FSFavoritesChanged() oneway;
+
+  @lint("ignore")
   void FSOnlineStatusChanged(boolean online) oneway;
 }

--- a/protocol/json/keybase1/kbfs.json
+++ b/protocol/json/keybase1/kbfs.json
@@ -105,6 +105,12 @@
       "doc": "FSOnlineStatusChangedEvent is called by KBFS when the online status changes.",
       "lint": "ignore"
     },
+    "FSFavoritesChangedEvent": {
+      "request": [],
+      "response": null,
+      "doc": "FSFavoritesChangedEvent is called by KBFS when the favorites list changes.",
+      "lint": "ignore"
+    },
     "createTLF": {
       "request": [
         {

--- a/protocol/json/keybase1/notify_fs.json
+++ b/protocol/json/keybase1/notify_fs.json
@@ -83,6 +83,12 @@
       "oneway": true,
       "lint": "ignore"
     },
+    "FSFavoritesChanged": {
+      "request": [],
+      "response": null,
+      "oneway": true,
+      "lint": "ignore"
+    },
     "FSOnlineStatusChanged": {
       "request": [
         {

--- a/shared/actions/json/engine-gen.json
+++ b/shared/actions/json/engine-gen.json
@@ -326,6 +326,9 @@
         "keybase1NotifyFSFSOverallSyncStatusChanged": {
             "params": "$Exact<$PropertyType<$PropertyType<keybase1Types.MessageTypes, 'keybase.1.NotifyFS.FSOverallSyncStatusChanged'>, 'inParam'>> & {|sessionID: number|}, response: {error: keybase1Types.IncomingErrorCallback, result: ($PropertyType<$PropertyType<keybase1Types.MessageTypes, 'keybase.1.NotifyFS.FSOverallSyncStatusChanged'>, 'outParam'>) => void}"
         },
+        "keybase1NotifyFSFSFavoritesChanged": {
+            "params": "$Exact<$PropertyType<$PropertyType<keybase1Types.MessageTypes, 'keybase.1.NotifyFS.FSFavoritesChanged'>, 'inParam'>> & {|sessionID: number|}, response: {error: keybase1Types.IncomingErrorCallback, result: ($PropertyType<$PropertyType<keybase1Types.MessageTypes, 'keybase.1.NotifyFS.FSFavoritesChanged'>, 'outParam'>) => void}"
+        },
         "keybase1NotifyFSFSOnlineStatusChanged": {
             "params": "$Exact<$PropertyType<$PropertyType<keybase1Types.MessageTypes, 'keybase.1.NotifyFS.FSOnlineStatusChanged'>, 'inParam'>> & {|sessionID: number|}, response: {error: keybase1Types.IncomingErrorCallback, result: ($PropertyType<$PropertyType<keybase1Types.MessageTypes, 'keybase.1.NotifyFS.FSOnlineStatusChanged'>, 'outParam'>) => void}"
         },

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -60,6 +60,10 @@ export type MessageTypes = {|
     inParam: $ReadOnly<{|edits: FSFolderEditHistory, requestID: Int|}>,
     outParam: void,
   |},
+  'keybase.1.NotifyFS.FSFavoritesChanged': {|
+    inParam: void,
+    outParam: void,
+  |},
   'keybase.1.NotifyFS.FSOnlineStatusChanged': {|
     inParam: $ReadOnly<{|online: Boolean|}>,
     outParam: void,
@@ -3330,6 +3334,7 @@ export type IncomingCallMapType = {|
   'keybase.1.NotifyFS.FSEditListResponse'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSEditListResponse'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,
   'keybase.1.NotifyFS.FSSyncStatusResponse'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSSyncStatusResponse'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,
   'keybase.1.NotifyFS.FSOverallSyncStatusChanged'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSOverallSyncStatusChanged'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,
+  'keybase.1.NotifyFS.FSFavoritesChanged'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSFavoritesChanged'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,
   'keybase.1.NotifyFS.FSOnlineStatusChanged'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSOnlineStatusChanged'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,
   'keybase.1.NotifyKeyfamily.keyfamilyChanged'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyKeyfamily.keyfamilyChanged'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,
   'keybase.1.NotifyPaperKey.paperKeyCached'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyPaperKey.paperKeyCached'>, 'inParam'>> & {|sessionID: number|}) => IncomingReturn,
@@ -3443,6 +3448,7 @@ export type CustomResponseIncomingCallMap = {|
   'keybase.1.NotifyFS.FSEditListResponse'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSEditListResponse'>, 'inParam'>> & {|sessionID: number|}, response: {error: IncomingErrorCallback, result: ($PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSEditListResponse'>, 'outParam'>) => void}) => IncomingReturn,
   'keybase.1.NotifyFS.FSSyncStatusResponse'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSSyncStatusResponse'>, 'inParam'>> & {|sessionID: number|}, response: {error: IncomingErrorCallback, result: ($PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSSyncStatusResponse'>, 'outParam'>) => void}) => IncomingReturn,
   'keybase.1.NotifyFS.FSOverallSyncStatusChanged'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSOverallSyncStatusChanged'>, 'inParam'>> & {|sessionID: number|}, response: {error: IncomingErrorCallback, result: ($PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSOverallSyncStatusChanged'>, 'outParam'>) => void}) => IncomingReturn,
+  'keybase.1.NotifyFS.FSFavoritesChanged'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSFavoritesChanged'>, 'inParam'>> & {|sessionID: number|}, response: {error: IncomingErrorCallback, result: ($PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSFavoritesChanged'>, 'outParam'>) => void}) => IncomingReturn,
   'keybase.1.NotifyFS.FSOnlineStatusChanged'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSOnlineStatusChanged'>, 'inParam'>> & {|sessionID: number|}, response: {error: IncomingErrorCallback, result: ($PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyFS.FSOnlineStatusChanged'>, 'outParam'>) => void}) => IncomingReturn,
   'keybase.1.NotifyKeyfamily.keyfamilyChanged'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyKeyfamily.keyfamilyChanged'>, 'inParam'>> & {|sessionID: number|}, response: {error: IncomingErrorCallback, result: ($PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyKeyfamily.keyfamilyChanged'>, 'outParam'>) => void}) => IncomingReturn,
   'keybase.1.NotifyPaperKey.paperKeyCached'?: (params: $Exact<$PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyPaperKey.paperKeyCached'>, 'inParam'>> & {|sessionID: number|}, response: {error: IncomingErrorCallback, result: ($PropertyType<$PropertyType<MessageTypes, 'keybase.1.NotifyPaperKey.paperKeyCached'>, 'outParam'>) => void}) => IncomingReturn,
@@ -3775,6 +3781,7 @@ declare export function userUploadUserAvatarRpcPromise(params: $PropertyType<$Pr
 // 'keybase.1.kbfs.FSSyncEvent'
 // 'keybase.1.kbfs.FSOverallSyncEvent'
 // 'keybase.1.kbfs.FSOnlineStatusChangedEvent'
+// 'keybase.1.kbfs.FSFavoritesChangedEvent'
 // 'keybase.1.kbfs.createTLF'
 // 'keybase.1.kbfs.getKBFSTeamSettings'
 // 'keybase.1.kbfs.upgradeTLF'
@@ -3857,6 +3864,7 @@ declare export function userUploadUserAvatarRpcPromise(params: $PropertyType<$Pr
 // 'keybase.1.NotifyFS.FSEditListResponse'
 // 'keybase.1.NotifyFS.FSSyncStatusResponse'
 // 'keybase.1.NotifyFS.FSOverallSyncStatusChanged'
+// 'keybase.1.NotifyFS.FSFavoritesChanged'
 // 'keybase.1.NotifyFS.FSOnlineStatusChanged'
 // 'keybase.1.NotifyFSRequest.FSEditListRequest'
 // 'keybase.1.NotifyFSRequest.FSSyncStatusRequest'


### PR DESCRIPTION
This PR adds a notification that the GUI can listen for, which will be fired when the favorite state changes and should be refreshed.

This needs to happen both when favorites are added/deleted, and when the CR stuck status changes for a local TLF view.

Tested using the command line dev command `keybase show-notifications`.

@jakob223 and @songgao should probably both review.

Issue: KBFS-4137