### PR TITLE
Use system frame by default on Linux

### DIFF
--- a/shared/__mocks__/electron.js
+++ b/shared/__mocks__/electron.js
@@ -26,8 +26,8 @@ export const globalShortcut = {}
 export const session = {}
 export const dialog = {}
 export const systemPreferences = {}
-export const ipcMain = {}
-export const app = {}
+export const ipcMain = {on: () => {}}
+export const app = {getPath: () => '', on: () => {}}
 export const screen = {}
 
 export const BrowserWindow = {}

--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -44,6 +44,9 @@
     "onChangeLockdownMode": {
       "enabled": "boolean"
     },
+    "onChangeUseNativeFrame": {
+      "enabled": "boolean"
+    },
     "notificationsRefresh": {},
     "notificationsRefreshed": {
       "notifications": "I.Map<string, Types.NotificationsGroupState>"

--- a/shared/actions/platform-specific/index.desktop.js
+++ b/shared/actions/platform-specific/index.desktop.js
@@ -341,11 +341,15 @@ function* startPowerMonitor() {
   }
 }
 
-const setUseNativeFrame = (state, action) =>
+const setUseNativeFrame = (state, _) =>
   SafeElectron.getIpcRenderer().send('setAppState', {useNativeFrame: state.settings.useNativeFrame})
 
 function* initializeUseNativeFrame() {
-  yield Saga.put(SettingsGen.createOnChangeUseNativeFrame({enabled: new AppState().state.useNativeFrame ?? defaultUseNativeFrame}))
+  yield Saga.put(
+    SettingsGen.createOnChangeUseNativeFrame({
+      enabled: new AppState().state.useNativeFrame ?? defaultUseNativeFrame,
+    })
+  )
 }
 
 export function* platformConfigSaga(): Saga.SagaGenerator<any, any> {

--- a/shared/actions/platform-specific/index.desktop.js
+++ b/shared/actions/platform-specific/index.desktop.js
@@ -341,7 +341,7 @@ function* startPowerMonitor() {
   }
 }
 
-const setUseNativeFrame = (state, _) =>
+const setUseNativeFrame = state =>
   SafeElectron.getIpcRenderer().send('setAppState', {useNativeFrame: state.settings.useNativeFrame})
 
 function* initializeUseNativeFrame() {

--- a/shared/actions/settings-gen.js
+++ b/shared/actions/settings-gen.js
@@ -40,6 +40,7 @@ export const onChangeNewPassword = 'settings:onChangeNewPassword'
 export const onChangeNewPasswordConfirm = 'settings:onChangeNewPasswordConfirm'
 export const onChangeRememberPassword = 'settings:onChangeRememberPassword'
 export const onChangeShowPassword = 'settings:onChangeShowPassword'
+export const onChangeUseNativeFrame = 'settings:onChangeUseNativeFrame'
 export const onSubmitNewEmail = 'settings:onSubmitNewEmail'
 export const onSubmitNewPassword = 'settings:onSubmitNewPassword'
 export const onUpdateEmailError = 'settings:onUpdateEmailError'
@@ -88,6 +89,7 @@ type _OnChangeNewPasswordConfirmPayload = $ReadOnly<{|password: HiddenString|}>
 type _OnChangeNewPasswordPayload = $ReadOnly<{|password: HiddenString|}>
 type _OnChangeRememberPasswordPayload = $ReadOnly<{|remember: boolean|}>
 type _OnChangeShowPasswordPayload = void
+type _OnChangeUseNativeFramePayload = $ReadOnly<{|enabled: boolean|}>
 type _OnSubmitNewEmailPayload = void
 type _OnSubmitNewPasswordPayload = $ReadOnly<{|thenSignOut: boolean|}>
 type _OnUpdateEmailErrorPayload = $ReadOnly<{|error: Error|}>
@@ -152,6 +154,7 @@ export const createOnChangeNewPassword = (payload: _OnChangeNewPasswordPayload) 
 export const createOnChangeNewPasswordConfirm = (payload: _OnChangeNewPasswordConfirmPayload) => ({payload, type: onChangeNewPasswordConfirm})
 export const createOnChangeRememberPassword = (payload: _OnChangeRememberPasswordPayload) => ({payload, type: onChangeRememberPassword})
 export const createOnChangeShowPassword = (payload: _OnChangeShowPasswordPayload) => ({payload, type: onChangeShowPassword})
+export const createOnChangeUseNativeFrame = (payload: _OnChangeUseNativeFramePayload) => ({payload, type: onChangeUseNativeFrame})
 export const createOnSubmitNewEmail = (payload: _OnSubmitNewEmailPayload) => ({payload, type: onSubmitNewEmail})
 export const createOnSubmitNewPassword = (payload: _OnSubmitNewPasswordPayload) => ({payload, type: onSubmitNewPassword})
 export const createOnUpdateEmailError = (payload: _OnUpdateEmailErrorPayload) => ({payload, type: onUpdateEmailError})
@@ -196,6 +199,7 @@ export type OnChangeNewPasswordConfirmPayload = {|+payload: _OnChangeNewPassword
 export type OnChangeNewPasswordPayload = {|+payload: _OnChangeNewPasswordPayload, +type: 'settings:onChangeNewPassword'|}
 export type OnChangeRememberPasswordPayload = {|+payload: _OnChangeRememberPasswordPayload, +type: 'settings:onChangeRememberPassword'|}
 export type OnChangeShowPasswordPayload = {|+payload: _OnChangeShowPasswordPayload, +type: 'settings:onChangeShowPassword'|}
+export type OnChangeUseNativeFramePayload = {|+payload: _OnChangeUseNativeFramePayload, +type: 'settings:onChangeUseNativeFrame'|}
 export type OnSubmitNewEmailPayload = {|+payload: _OnSubmitNewEmailPayload, +type: 'settings:onSubmitNewEmail'|}
 export type OnSubmitNewPasswordPayload = {|+payload: _OnSubmitNewPasswordPayload, +type: 'settings:onSubmitNewPassword'|}
 export type OnUpdateEmailErrorPayload = {|+payload: _OnUpdateEmailErrorPayload, +type: 'settings:onUpdateEmailError'|}
@@ -246,6 +250,7 @@ export type Actions =
   | OnChangeNewPasswordPayload
   | OnChangeRememberPasswordPayload
   | OnChangeShowPasswordPayload
+  | OnChangeUseNativeFramePayload
   | OnSubmitNewEmailPayload
   | OnSubmitNewPasswordPayload
   | OnUpdateEmailErrorPayload

--- a/shared/app/app-state.desktop.js
+++ b/shared/app/app-state.desktop.js
@@ -1,25 +1,11 @@
 // @flow
 // This is modified from https://github.com/mawie81/electron-window-state
-import * as SafeElectron from '../../util/safe-electron.desktop'
+import * as SafeElectron from '../util/safe-electron.desktop'
 import fs from 'fs'
 import path from 'path'
 import {isEqual} from 'lodash-es'
-import logger from '../../logger'
-
-export type State = {
-  x: ?number,
-  y: ?number,
-  width: number,
-  height: number,
-  windowHidden: boolean,
-  isMaximized: ?boolean,
-  isFullScreen: ?boolean,
-  displayBounds: ?any,
-  tab: ?string,
-  dockHidden: boolean,
-  notifySound: boolean,
-  openAtLogin: boolean,
-}
+import logger from '../logger'
+import type {State} from './app-state'
 
 export type Config = {
   path: string,
@@ -56,6 +42,7 @@ export default class AppState {
       notifySound: false,
       openAtLogin: true,
       tab: null,
+      useNativeFrame: null,
       width: 800,
       windowHidden: false,
       x: null,

--- a/shared/app/app-state.js.flow
+++ b/shared/app/app-state.js.flow
@@ -1,0 +1,23 @@
+// @flow
+
+export type State = {
+  x: ?number,
+  y: ?number,
+  width: number,
+  height: number,
+  windowHidden: boolean,
+  isMaximized: ?boolean,
+  isFullScreen: ?boolean,
+  displayBounds: ?any,
+  tab: ?string,
+  dockHidden: boolean,
+  notifySound: boolean,
+  openAtLogin: boolean,
+  useNativeFrame: ?boolean,
+}
+
+declare class AppState {
+  state: State;
+}
+
+export default AppState

--- a/shared/app/app-state.native.js
+++ b/shared/app/app-state.native.js
@@ -1,0 +1,24 @@
+// @flow
+import type {State} from './app-state'
+
+export default class AppState {
+  state: State
+
+  constructor() {
+    this.state = {
+      displayBounds: null,
+      dockHidden: false,
+      height: 0,
+      isFullScreen: null,
+      isMaximized: null,
+      notifySound: false,
+      openAtLogin: false,
+      tab: null,
+      useNativeFrame: null,
+      width: 0,
+      windowHidden: false,
+      x: null,
+      y: null,
+    }
+  }
+}

--- a/shared/constants/platform.desktop.js
+++ b/shared/constants/platform.desktop.js
@@ -14,6 +14,8 @@ export const isLinux = platform === 'linux'
 export const isAndroidNewerThanN = false
 export const shortcutSymbol = isDarwin ? '⌘' : 'Ctrl-'
 
+export const defaultUseNativeFrame = isDarwin || isLinux
+
 // For storyshots, we only want to test macOS
 export const fileUIName = isDarwin || __STORYBOOK__ ? 'Finder' : isWindows ? 'Explorer' : 'File Explorer'
 
@@ -30,7 +32,7 @@ const getLinuxPaths = () => {
   const useXDG = runMode !== 'devel' && !process.env['KEYBASE_XDG_OVERRIDE']
 
   // If XDG_RUNTIME_DIR is defined use that, else use $HOME/.config.
-  const homeConfigDir = path.join(homeEnv, '.config')
+  const homeConfigDir = (useXDG && process.env['XDG_CONFIG_HOME']) || path.join(homeEnv, '.config')
   const runtimeDir = (useXDG && process.env['XDG_RUNTIME_DIR']) || ''
   const socketDir = (useXDG && runtimeDir) || homeConfigDir
 

--- a/shared/constants/platform.js.flow
+++ b/shared/constants/platform.js.flow
@@ -12,6 +12,8 @@ export const isWindows: boolean = false
 export const isLinux: boolean = false
 export const isIPhoneX: boolean = false
 export const isAndroidNewerThanN: boolean = false
+export const defaultUseNativeFrame: boolean = false
+
 declare export var fileUIName: string
 declare export var version: string
 declare export var logFileName: string

--- a/shared/constants/platform.native.js
+++ b/shared/constants/platform.native.js
@@ -25,6 +25,7 @@ export const isDarwin = false
 export const isElectron = false
 export const isLinux = false
 export const isWindows = false
+export const defaultUseNativeFrame = true
 export const fileUIName = 'File Explorer'
 export const mobileOsVersion = Platform.Version
 export const isAndroidNewerThanM = isAndroid && parseInt(mobileOsVersion) > 22

--- a/shared/constants/settings.js
+++ b/shared/constants/settings.js
@@ -64,6 +64,7 @@ export const makeState: I.RecordFactory<Types._State> = I.Record({
   lockdownModeEnabled: null,
   notifications: makeNotifications(),
   password: makePassword(),
+  useNativeFrame: true,
   waitingForResponse: false,
 })
 

--- a/shared/constants/types/settings.js
+++ b/shared/constants/types/settings.js
@@ -105,6 +105,7 @@ export type _State = {
   email: EmailState,
   password: PasswordState,
   lockdownModeEnabled: ?boolean,
+  useNativeFrame: boolean,
   chat: ChatState,
   checkPasswordIsCorrect: ?boolean,
 }

--- a/shared/desktop/app/main-window.desktop.js
+++ b/shared/desktop/app/main-window.desktop.js
@@ -1,11 +1,11 @@
 // @flow
 import URL from 'url-parse'
-import AppState from './app-state.desktop'
+import AppState from '../../app/app-state.desktop'
 import Window from './window.desktop'
 import * as SafeElectron from '../../util/safe-electron.desktop'
 import {showDevTools} from '../../local-debug.desktop'
 import {hideDockIcon} from './dock-icon.desktop'
-import {isDarwin, isWindows} from '../../constants/platform'
+import {isDarwin, isWindows, defaultUseNativeFrame} from '../../constants/platform'
 import logger from '../../logger'
 import {resolveRootAsURL} from './resolve-root.desktop'
 
@@ -37,7 +37,7 @@ export default function() {
 
   const mainWindow = new Window(htmlFile, {
     backgroundThrottling: false,
-    frame: isDarwin,
+    frame: appState.state.useNativeFrame ?? defaultUseNativeFrame,
     height: appState.state.height,
     minHeight: 600,
     minWidth: 400,

--- a/shared/desktop/app/menu-helper.desktop.js
+++ b/shared/desktop/app/menu-helper.desktop.js
@@ -98,10 +98,6 @@ export default function makeMenu(window: any) {
     // $FlowIssue not sure yet
     const menu = SafeElectron.Menu.buildFromTemplate(template)
     SafeElectron.Menu.setApplicationMenu(menu)
-    if (!isDarwin) {
-      window.setAutoHideMenuBar(true)
-      window.setMenuBarVisibility(false)
-    }
   } else {
     const template = [
       {
@@ -132,6 +128,8 @@ export default function makeMenu(window: any) {
     ]
     // $FlowIssue not sure yet
     const menu = SafeElectron.Menu.buildFromTemplate(template)
+    window.setAutoHideMenuBar(true)
+    window.setMenuBarVisibility(false)
     window.setMenu(menu)
   }
 }

--- a/shared/reducers/settings.js
+++ b/shared/reducers/settings.js
@@ -124,6 +124,8 @@ function reducer(state: Types.State = initialState, action: SettingsGen.Actions)
       return state.update('password', password => password.merge({randomPW: action.payload.randomPW}))
     case SettingsGen.loadedCheckPassword:
       return state.merge({checkPasswordIsCorrect: action.payload.checkPasswordIsCorrect})
+    case SettingsGen.onChangeUseNativeFrame:
+      return state.merge({useNativeFrame: action.payload.enabled})
     // Saga only actions
     case SettingsGen.dbNuke:
     case SettingsGen.deleteAccountForever:

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -6,6 +6,7 @@ import * as Styles from '../../styles'
 import * as Window from '../../util/window-management'
 import SyncingFolders from './syncing-folders'
 import flags from '../../util/feature-flags'
+import AppState from '../../app/app-state.desktop'
 // A mobile-like header for desktop
 
 // Fix this as we figure out what this needs to be
@@ -25,6 +26,8 @@ const AppIconBoxOnRed = Styles.styled(Kb.ClickableBox)({
 type State = {|
   hoveringOnClose: boolean,
 |}
+
+const initialUseNativeFrame = new AppState().state.useNativeFrame ?? Platform.defaultUseNativeFrame
 
 class Header extends React.PureComponent<Props, State> {
   state = {hoveringOnClose: false}
@@ -88,6 +91,7 @@ class Header extends React.PureComponent<Props, State> {
         : this.props.loggedIn
         ? Styles.globalColors.black_10
         : Styles.globalColors.transparent)
+
     return (
       <Kb.Box2 noShrink={true} direction="vertical" fullWidth={true}>
         <Kb.Box2
@@ -114,7 +118,7 @@ class Header extends React.PureComponent<Props, State> {
             {flags.kbfsOfflineMode && <SyncingFolders />}
             {!title && rightActions}
 
-            {!Platform.isDarwin && (
+            {!Platform.isDarwin && !initialUseNativeFrame && (
               <Kb.Box2 direction="horizontal">
                 <AppIconBox direction="vertical" onClick={Window.minimizeWindow} style={styles.appIconBox}>
                   <Kb.Icon

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -6,7 +6,6 @@ import * as Styles from '../../styles'
 import * as Window from '../../util/window-management'
 import SyncingFolders from './syncing-folders'
 import flags from '../../util/feature-flags'
-import AppState from '../../app/app-state.desktop'
 // A mobile-like header for desktop
 
 // Fix this as we figure out what this needs to be
@@ -26,8 +25,6 @@ const AppIconBoxOnRed = Styles.styled(Kb.ClickableBox)({
 type State = {|
   hoveringOnClose: boolean,
 |}
-
-const initialUseNativeFrame = new AppState().state.useNativeFrame ?? Platform.defaultUseNativeFrame
 
 class Header extends React.PureComponent<Props, State> {
   state = {hoveringOnClose: false}
@@ -118,7 +115,7 @@ class Header extends React.PureComponent<Props, State> {
             {flags.kbfsOfflineMode && <SyncingFolders />}
             {!title && rightActions}
 
-            {!Platform.isDarwin && !initialUseNativeFrame && (
+            {!Platform.isDarwin && !this.props.initialUseNativeFrame && (
               <Kb.Box2 direction="horizontal">
                 <AppIconBox direction="vertical" onClick={Window.minimizeWindow} style={styles.appIconBox}>
                   <Kb.Icon

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -6,6 +6,7 @@ import * as Styles from '../../styles'
 import * as Window from '../../util/window-management'
 import SyncingFolders from './syncing-folders'
 import flags from '../../util/feature-flags'
+import AppState from '../../app/app-state.desktop'
 // A mobile-like header for desktop
 
 // Fix this as we figure out what this needs to be
@@ -25,6 +26,8 @@ const AppIconBoxOnRed = Styles.styled(Kb.ClickableBox)({
 type State = {|
   hoveringOnClose: boolean,
 |}
+
+const initialUseNativeFrame = new AppState().state.useNativeFrame ?? Platform.defaultUseNativeFrame
 
 class Header extends React.PureComponent<Props, State> {
   state = {hoveringOnClose: false}
@@ -115,7 +118,7 @@ class Header extends React.PureComponent<Props, State> {
             {flags.kbfsOfflineMode && <SyncingFolders />}
             {!title && rightActions}
 
-            {!Platform.isDarwin && !this.props.initialUseNativeFrame && (
+            {!Platform.isDarwin && !initialUseNativeFrame && (
               <Kb.Box2 direction="horizontal">
                 <AppIconBox direction="vertical" onClick={Window.minimizeWindow} style={styles.appIconBox}>
                   <Kb.Icon

--- a/shared/router-v2/router.desktop.js
+++ b/shared/router-v2/router.desktop.js
@@ -20,6 +20,8 @@ import Header from './header/index.desktop'
 import * as Shim from './shim.desktop'
 import GlobalError from '../app/global-errors/container'
 import OutOfDate from '../app/out-of-date'
+import AppState from '../app/app-state.desktop'
+import * as Platform from '../constants/platform'
 
 /**
  * How this works:
@@ -33,6 +35,8 @@ import OutOfDate from '../app/out-of-date'
  * When there are no modals AppView is rendered
  * Floating is rendered to a portal on top
  */
+
+const initialUseNativeFrame = new AppState().state.useNativeFrame ?? Platform.defaultUseNativeFrame
 
 // The app with a tab bar on the left and content area on the right
 // A single content view and n-modals on top
@@ -79,6 +83,7 @@ class AppView extends React.PureComponent<any> {
             options={descriptor.options}
             onPop={() => childNav.goBack(activeKey)}
             allowBack={activeIndex !== 0}
+            initialUseNativeFrame={initialUseNativeFrame}
           />
         </Kb.Box2>
       </Kb.Box2>

--- a/shared/router-v2/router.desktop.js
+++ b/shared/router-v2/router.desktop.js
@@ -20,8 +20,6 @@ import Header from './header/index.desktop'
 import * as Shim from './shim.desktop'
 import GlobalError from '../app/global-errors/container'
 import OutOfDate from '../app/out-of-date'
-import AppState from '../app/app-state.desktop'
-import * as Platform from '../constants/platform'
 
 /**
  * How this works:
@@ -35,8 +33,6 @@ import * as Platform from '../constants/platform'
  * When there are no modals AppView is rendered
  * Floating is rendered to a portal on top
  */
-
-const initialUseNativeFrame = new AppState().state.useNativeFrame ?? Platform.defaultUseNativeFrame
 
 // The app with a tab bar on the left and content area on the right
 // A single content view and n-modals on top
@@ -83,7 +79,6 @@ class AppView extends React.PureComponent<any> {
             options={descriptor.options}
             onPop={() => childNav.goBack(activeKey)}
             allowBack={activeIndex !== 0}
-            initialUseNativeFrame={initialUseNativeFrame}
           />
         </Kb.Box2>
       </Kb.Box2>

--- a/shared/settings/advanced/container.js
+++ b/shared/settings/advanced/container.js
@@ -6,6 +6,7 @@ import {
   createLoadLockdownMode,
   createLoadHasRandomPw,
   createOnChangeLockdownMode,
+  createOnChangeUseNativeFrame,
 } from '../../actions/settings-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import {HeaderHoc} from '../../common-adapters'
@@ -27,6 +28,7 @@ const mapStateToProps = state => {
     setLockdownModeError: setLockdownModeError?.message ?? '',
     settingLockdownMode,
     traceInProgress: Constants.traceInProgress(state),
+    useNativeFrame: state.settings.useNativeFrame,
   }
 }
 
@@ -35,6 +37,7 @@ const mapDispatchToProps = dispatch => ({
   _loadLockdownMode: () => dispatch(createLoadLockdownMode()),
   onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
   onChangeLockdownMode: (checked: boolean) => dispatch(createOnChangeLockdownMode({enabled: checked})),
+  onChangeUseNativeFrame: (checked: boolean) => dispatch(createOnChangeUseNativeFrame({enabled: checked})),
   onDBNuke: () => dispatch(RouteTreeGen.createNavigateAppend({path: ['dbNukeConfirm']})),
   onProcessorProfile: (durationSeconds: number) => dispatch(createProcessorProfile({durationSeconds})),
   onSetOpenAtLogin: (open: boolean) => dispatch(ConfigGen.createSetOpenAtLogin({open, writeFile: true})),

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -2,11 +2,12 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
-import {isLinux} from '../../constants/platform'
+import {isMobile, isLinux, defaultUseNativeFrame} from '../../constants/platform'
 import flags from '../../util/feature-flags'
 // normally never do this but this call serves no purpose for users at all
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 import * as RPCTypes from '../../constants/types/rpc-gen'
+import AppState from '../../app/app-state'
 
 type Props = {
   openAtLogin: boolean,
@@ -22,6 +23,32 @@ type Props = {
   traceInProgress: boolean,
   processorProfileInProgress: boolean,
   hasRandomPW: boolean,
+  useNativeFrame: boolean,
+  onChangeUseNativeFrame: boolean => void,
+}
+
+const initialUseNativeFrame = new AppState().state.useNativeFrame ?? defaultUseNativeFrame
+
+const UseNativeFrame = (props: Props) => {
+  return !isMobile && (
+    <>
+      <Kb.Box style={styles.checkboxContainer}>
+        <Kb.Checkbox
+          checked={!props.useNativeFrame}
+          label={
+            'Hide system window frame'
+          }
+          onCheck={(x) => props.onChangeUseNativeFrame(!x)}
+          style={styles.checkbox}
+        />
+      </Kb.Box>
+     {initialUseNativeFrame !== props.useNativeFrame && (
+       <Kb.Text type="BodySmall" style={styles.error}>
+         Keybase needs to restart for this change to take effect.
+       </Kb.Text>
+     )}
+    </>
+  )
 }
 
 const Advanced = (props: Props) => {
@@ -48,6 +75,7 @@ const Advanced = (props: Props) => {
           {props.setLockdownModeError}
         </Kb.Text>
       )}
+      {isLinux && UseNativeFrame(props)}
       {!Styles.isMobile && !isLinux && (
         <Kb.Box style={styles.openAtLoginCheckboxContainer}>
           <Kb.Checkbox

--- a/shared/settings/advanced/index.js
+++ b/shared/settings/advanced/index.js
@@ -30,24 +30,24 @@ type Props = {
 const initialUseNativeFrame = new AppState().state.useNativeFrame ?? defaultUseNativeFrame
 
 const UseNativeFrame = (props: Props) => {
-  return !isMobile && (
-    <>
-      <Kb.Box style={styles.checkboxContainer}>
-        <Kb.Checkbox
-          checked={!props.useNativeFrame}
-          label={
-            'Hide system window frame'
-          }
-          onCheck={(x) => props.onChangeUseNativeFrame(!x)}
-          style={styles.checkbox}
-        />
-      </Kb.Box>
-     {initialUseNativeFrame !== props.useNativeFrame && (
-       <Kb.Text type="BodySmall" style={styles.error}>
-         Keybase needs to restart for this change to take effect.
-       </Kb.Text>
-     )}
-    </>
+  return (
+    !isMobile && (
+      <>
+        <Kb.Box style={styles.checkboxContainer}>
+          <Kb.Checkbox
+            checked={!props.useNativeFrame}
+            label={'Hide system window frame'}
+            onCheck={x => props.onChangeUseNativeFrame(!x)}
+            style={styles.checkbox}
+          />
+        </Kb.Box>
+        {initialUseNativeFrame !== props.useNativeFrame && (
+          <Kb.Text type="BodySmall" style={styles.error}>
+            Keybase needs to restart for this change to take effect.
+          </Kb.Text>
+        )}
+      </>
+    )
   )
 }
 
@@ -75,7 +75,7 @@ const Advanced = (props: Props) => {
           {props.setLockdownModeError}
         </Kb.Text>
       )}
-      {isLinux && UseNativeFrame(props)}
+      {isLinux && <UseNativeFrame {...props} />}
       {!Styles.isMobile && !isLinux && (
         <Kb.Box style={styles.openAtLoginCheckboxContainer}>
           <Kb.Checkbox


### PR DESCRIPTION
Allow users on Linux to toggle showing of the native frame via the service's json config file.
Makes default behavior to use native decorations.