### PR TITLE
Fix mobile-only lockdown account UX

### DIFF
--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -612,6 +612,9 @@ export const getCurrencyAndSymbol = (state: TypedState, code: string) => {
 
 export const getAcceptedDisclaimer = (state: TypedState) => state.wallets.acceptedDisclaimer
 
+export const getThisDeviceIsLockedOut = (state: TypedState, accountID: Types.AccountID) =>
+  getAccount(state, accountID).mobileOnlyEditable
+
 export const balanceChangeColor = (delta: Types.PaymentDelta, status: Types.StatusSimplified) => {
   let balanceChangeColor = Styles.globalColors.black
   if (delta !== 'none') {

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -612,8 +612,12 @@ export const getCurrencyAndSymbol = (state: TypedState, code: string) => {
 
 export const getAcceptedDisclaimer = (state: TypedState) => state.wallets.acceptedDisclaimer
 
+// The device is read-only if it's a desktop device and mobile-only is on, or it's a mobile device
+// that's less than seven days old.  TODO: Use a `deviceReadOnly` field insstead once it exists.
 export const getThisDeviceIsLockedOut = (state: TypedState, accountID: Types.AccountID) =>
-  getAccount(state, accountID).mobileOnlyEditable
+  Styles.isMobile
+    ? getAccount(state, accountID).mobileOnlyEditable
+    : state.wallets.mobileOnlyMap.get(accountID, false)
 
 export const balanceChangeColor = (delta: Types.PaymentDelta, status: Types.StatusSimplified) => {
   let balanceChangeColor = Styles.globalColors.black

--- a/shared/constants/wallets.js
+++ b/shared/constants/wallets.js
@@ -616,7 +616,7 @@ export const getAcceptedDisclaimer = (state: TypedState) => state.wallets.accept
 // that's less than seven days old.  TODO: Use a `deviceReadOnly` field insstead once it exists.
 export const getThisDeviceIsLockedOut = (state: TypedState, accountID: Types.AccountID) =>
   Styles.isMobile
-    ? getAccount(state, accountID).mobileOnlyEditable
+    ? !getAccount(state, accountID).mobileOnlyEditable
     : state.wallets.mobileOnlyMap.get(accountID, false)
 
 export const balanceChangeColor = (delta: Types.PaymentDelta, status: Types.StatusSimplified) => {

--- a/shared/react-native/android/build.gradle
+++ b/shared/react-native/android/build.gradle
@@ -17,9 +17,10 @@ buildscript {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5' // To publish from gradle
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/shared/react-native/android/build.gradle
+++ b/shared/react-native/android/build.gradle
@@ -17,7 +17,6 @@ buildscript {
             url 'https://maven.google.com/'
             name 'Google'
         }
-        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'

--- a/shared/react-native/android/build.gradle
+++ b/shared/react-native/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5' // To publish from gradle
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/shared/react-native/android/gradle/wrapper/gradle-wrapper.properties
+++ b/shared/react-native/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 02 17:19:25 PDT 2019
+#Fri Aug 19 16:09:49 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/shared/react-native/android/gradle/wrapper/gradle-wrapper.properties
+++ b/shared/react-native/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 19 16:09:49 EDT 2016
+#Thu May 02 17:19:25 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/shared/wallets/common/buttons/container.js
+++ b/shared/wallets/common/buttons/container.js
@@ -14,8 +14,7 @@ const mapStateToPropsSendButton = state => {
   const _account = Constants.getSelectedAccountData(state)
   return {
     _account,
-    disabledDueToMobileOnly:
-      !Container.isMobile && state.wallets.mobileOnlyMap.get(_account.accountID, false),
+    disabledDueToMobileOnly: !Constants.getAccount(state, _account.accountID).mobileOnlyEditable,
   }
 }
 

--- a/shared/wallets/common/buttons/container.js
+++ b/shared/wallets/common/buttons/container.js
@@ -14,7 +14,7 @@ const mapStateToPropsSendButton = state => {
   const _account = Constants.getSelectedAccountData(state)
   return {
     _account,
-    disabledDueToMobileOnly: !Constants.getAccount(state, _account.accountID).mobileOnlyEditable,
+    thisDeviceIsLockedOut: Constants.getThisDeviceIsLockedOut(state, _account.accountID),
   }
 }
 
@@ -30,14 +30,14 @@ const mapDispatchToPropsSendButton = dispatch => ({
 })
 
 const mergePropsSendButton = (stateProps, dispatchProps, ownProps) => ({
-  disabled: !stateProps._account.name || stateProps.disabledDueToMobileOnly,
-  disabledDueToMobileOnly: stateProps.disabledDueToMobileOnly,
+  disabled: !stateProps._account.name || stateProps.thisDeviceIsLockedOut,
   onSendToAnotherAccount: () =>
     dispatchProps._onGoToSendReceive(stateProps._account.accountID, 'otherAccount'),
   onSendToKeybaseUser: () => dispatchProps._onGoToSendReceive(stateProps._account.accountID, 'keybaseUser'),
   onSendToStellarAddress: () =>
     dispatchProps._onGoToSendReceive(stateProps._account.accountID, 'stellarPublicKey'),
   small: ownProps.small,
+  thisDeviceIsLockedOut: stateProps.thisDeviceIsLockedOut,
 })
 
 export const SendButton = Container.namedConnect<SendButtonOwnProps, _, _, _, _>(
@@ -81,7 +81,7 @@ const mapDispatchToPropsDropdownButton = dispatch => ({
 const mergePropsDropdownButton = (stateProps, dispatchProps, ownProps) => ({
   disabled: !stateProps._account.name,
   onSettings: () => dispatchProps._onSettings(stateProps._account.accountID),
-  onShowSecretKey: stateProps.disabledDueToMobileOnly
+  onShowSecretKey: stateProps.thisDeviceIsLockedOut
     ? null
     : () => dispatchProps._onShowSecretKey(stateProps._account.accountID, stateProps._account.name),
   small: ownProps.small,

--- a/shared/wallets/common/buttons/index.js
+++ b/shared/wallets/common/buttons/index.js
@@ -48,7 +48,9 @@ const _SendButton = (props: Kb.PropsWithOverlay<SendProps>) => {
     </>
   )
   return props.disabledDueToMobileOnly ? (
-    <Kb.WithTooltip text="This is a mobile-only account.">{button}</Kb.WithTooltip>
+    <Kb.WithTooltip text="You can only send from a mobile device less than 7 days old.">
+      {button}
+    </Kb.WithTooltip>
   ) : (
     button
   )

--- a/shared/wallets/common/buttons/index.js
+++ b/shared/wallets/common/buttons/index.js
@@ -48,7 +48,7 @@ const _SendButton = (props: Kb.PropsWithOverlay<SendProps>) => {
     </>
   )
   return props.thisDeviceIsLockedOut ? (
-    <Kb.WithTooltip text="You can only send from a mobile device less than 7 days old.">
+    <Kb.WithTooltip text="You can only send from a mobile device more than 7 days old.">
       {button}
     </Kb.WithTooltip>
   ) : (

--- a/shared/wallets/common/buttons/index.js
+++ b/shared/wallets/common/buttons/index.js
@@ -5,11 +5,11 @@ import * as Styles from '../../../styles'
 
 type SendProps = {|
   disabled: boolean,
-  disabledDueToMobileOnly: boolean,
   onSendToKeybaseUser: () => void,
   onSendToStellarAddress: () => void,
   onSendToAnotherAccount: () => void,
   small?: boolean,
+  thisDeviceIsLockedOut: boolean,
 |}
 
 const _SendButton = (props: Kb.PropsWithOverlay<SendProps>) => {
@@ -47,7 +47,7 @@ const _SendButton = (props: Kb.PropsWithOverlay<SendProps>) => {
       />
     </>
   )
-  return props.disabledDueToMobileOnly ? (
+  return props.thisDeviceIsLockedOut ? (
     <Kb.WithTooltip text="You can only send from a mobile device less than 7 days old.">
       {button}
     </Kb.WithTooltip>

--- a/shared/wallets/send-form/footer/container.js
+++ b/shared/wallets/send-form/footer/container.js
@@ -3,7 +3,7 @@ import Footer from '.'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import * as Constants from '../../../constants/wallets'
-import {namedConnect, isMobile} from '../../../util/container'
+import {namedConnect} from '../../../util/container'
 import {anyWaiting} from '../../../constants/waiting'
 
 type OwnProps = {
@@ -17,12 +17,12 @@ const mapStateToProps = state => {
     ? state.wallets.builtRequest.readyToRequest
     : state.wallets.builtPayment.readyToReview
   const currencyWaiting = anyWaiting(state, Constants.getDisplayCurrencyWaitingKey(accountID))
-  const sendDisabledDueToMobileOnly = !isMobile && !!state.wallets.mobileOnlyMap.get(accountID)
+  const thisDeviceIsLockedOut = Constants.getThisDeviceIsLockedOut(state, accountID)
   return {
     calculating: !!state.wallets.building.amount,
-    disabled: !isReady || currencyWaiting || sendDisabledDueToMobileOnly,
+    disabled: !isReady || currencyWaiting || thisDeviceIsLockedOut,
     isRequest,
-    sendDisabledDueToMobileOnly,
+    thisDeviceIsLockedOut,
     waitingKey: state.wallets.building.isRequest
       ? Constants.requestPaymentWaitingKey
       : Constants.buildPaymentWaitingKey,
@@ -56,7 +56,7 @@ const mergeProps = (s, d, o) => ({
   disabled: s.disabled,
   onClickRequest: s.isRequest ? d.onClickRequest : undefined,
   onClickSend: s.isRequest ? undefined : d.onClickSend,
-  sendDisabledDueToMobileOnly: s.sendDisabledDueToMobileOnly,
+  thisDeviceIsLockedOut: s.thisDeviceIsLockedOut,
   waitingKey: s.waitingKey,
   worthDescription: s.worthDescription,
 })

--- a/shared/wallets/send-form/footer/index.js
+++ b/shared/wallets/send-form/footer/index.js
@@ -9,7 +9,7 @@ type Props = {
   disabled?: boolean,
   onClickRequest?: Function,
   onClickSend?: Function,
-  sendDisabledDueToMobileOnly: boolean,
+  thisDeviceIsLockedOut: boolean,
   waitingKey: string,
   worthDescription?: string,
 }
@@ -85,7 +85,7 @@ const Footer = (props: Props) => {
             />
           )}
           {!!props.onClickSend &&
-            (props.sendDisabledDueToMobileOnly ? (
+            (props.thisDeviceIsLockedOut ? (
               <Kb.WithTooltip text="This is a mobile-only wallet." containerStyle={styles.fullWidth}>
                 {sendButton}
               </Kb.WithTooltip>

--- a/shared/wallets/send-form/footer/index.stories.js
+++ b/shared/wallets/send-form/footer/index.stories.js
@@ -14,7 +14,7 @@ const common = {
   calculating: false,
   disabled: false,
   onClickSend: Sb.action('onClickSend'),
-  sendDisabledDueToMobileOnly: false,
+  thisDeviceIsLockedOut: false,
   waitingKey: 'wallets:buildPayment',
 }
 

--- a/shared/wallets/wallet/header/container.js
+++ b/shared/wallets/wallet/header/container.js
@@ -15,9 +15,9 @@ const mapStateToProps = state => {
   const selectedAccount = Constants.getAccount(state, accountID)
   return {
     accountID: selectedAccount.accountID,
-    disabledDueToMobileOnly: !selectedAccount.mobileOnlyEditable,
     isDefaultWallet: selectedAccount.isDefault,
     keybaseUser: state.config.username,
+    thisDeviceIsLockedOut: !selectedAccount.mobileOnlyEditable,
     unreadPayments: otherUnreadPayments(state.wallets.unreadPaymentsMap, selectedAccount.accountID),
     walletName: selectedAccount.name,
   }

--- a/shared/wallets/wallet/header/container.js
+++ b/shared/wallets/wallet/header/container.js
@@ -15,6 +15,7 @@ const mapStateToProps = state => {
   const selectedAccount = Constants.getAccount(state, accountID)
   return {
     accountID: selectedAccount.accountID,
+    disabledDueToMobileOnly: !selectedAccount.mobileOnlyEditable,
     isDefaultWallet: selectedAccount.isDefault,
     keybaseUser: state.config.username,
     unreadPayments: otherUnreadPayments(state.wallets.unreadPaymentsMap, selectedAccount.accountID),

--- a/shared/wallets/wallet/header/container.js
+++ b/shared/wallets/wallet/header/container.js
@@ -17,7 +17,7 @@ const mapStateToProps = state => {
     accountID: selectedAccount.accountID,
     isDefaultWallet: selectedAccount.isDefault,
     keybaseUser: state.config.username,
-    thisDeviceIsLockedOut: !selectedAccount.mobileOnlyEditable,
+    thisDeviceIsLockedOut: Constants.getThisDeviceIsLockedOut(state, selectedAccount.accountID),
     unreadPayments: otherUnreadPayments(state.wallets.unreadPaymentsMap, selectedAccount.accountID),
     walletName: selectedAccount.name,
   }

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -14,6 +14,7 @@ type Props = {|
   onBack: ?() => void,
   keybaseUser: string,
   walletName: ?string,
+  disabledDueToMobileOnly: boolean,
 |}
 
 const Header = (props: Props) => {
@@ -60,6 +61,7 @@ const Header = (props: Props) => {
       centerChildren={true}
       style={styles.topContainer}
     >
+      mobileOnlyEditable
       {backButton}
       <Kb.ProgressIndicator style={styles.spinner} type="Small" />
     </Kb.Box2>
@@ -85,6 +87,9 @@ const Header = (props: Props) => {
         />
         <DropdownButton />
       </Kb.Box2>
+      {!props.disabledDueToMobileOnly && !!Styles.isMobile && (
+        <Kb.Text type="BodySmall">You can only send from a mobile device less than 7 days old.</Kb.Text>
+      )}
     </Kb.Box2>
   )
 }

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -9,12 +9,12 @@ import MaybeSwitcher from './maybe-switcher'
 type Props = {|
   accountID: Types.AccountID,
   isDefaultWallet: boolean,
-  unreadPayments: boolean,
-  onReceive: () => void,
-  onBack: ?() => void,
   keybaseUser: string,
-  walletName: ?string,
+  onBack: ?() => void,
+  onReceive: () => void,
   thisDeviceIsLockedOut: boolean,
+  unreadPayments: boolean,
+  walletName: ?string,
 |}
 
 const Header = (props: Props) => {
@@ -86,7 +86,7 @@ const Header = (props: Props) => {
         />
         <DropdownButton />
       </Kb.Box2>
-      {props.thisDeviceIsLockedOut && Styles.isMobile && (
+      {props.thisDeviceIsLockedOut && (
         <Kb.Text type="BodySmall">You can only send from a mobile device more than 7 days old.</Kb.Text>
       )}
     </Kb.Box2>

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -14,7 +14,7 @@ type Props = {|
   onBack: ?() => void,
   keybaseUser: string,
   walletName: ?string,
-  disabledDueToMobileOnly: boolean,
+  thisDeviceIsLockedOut: boolean,
 |}
 
 const Header = (props: Props) => {
@@ -61,7 +61,6 @@ const Header = (props: Props) => {
       centerChildren={true}
       style={styles.topContainer}
     >
-      mobileOnlyEditable
       {backButton}
       <Kb.ProgressIndicator style={styles.spinner} type="Small" />
     </Kb.Box2>
@@ -87,7 +86,7 @@ const Header = (props: Props) => {
         />
         <DropdownButton />
       </Kb.Box2>
-      {!props.disabledDueToMobileOnly && !!Styles.isMobile && (
+      {props.thisDeviceIsLockedOut && Styles.isMobile && (
         <Kb.Text type="BodySmall">You can only send from a mobile device less than 7 days old.</Kb.Text>
       )}
     </Kb.Box2>

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -87,7 +87,7 @@ const Header = (props: Props) => {
         <DropdownButton />
       </Kb.Box2>
       {props.thisDeviceIsLockedOut && Styles.isMobile && (
-        <Kb.Text type="BodySmall">You can only send from a mobile device less than 7 days old.</Kb.Text>
+        <Kb.Text type="BodySmall">You can only send from a mobile device more than 7 days old.</Kb.Text>
       )}
     </Kb.Box2>
   )

--- a/shared/wallets/wallet/header/index.js
+++ b/shared/wallets/wallet/header/index.js
@@ -87,7 +87,9 @@ const Header = (props: Props) => {
         <DropdownButton />
       </Kb.Box2>
       {props.thisDeviceIsLockedOut && (
-        <Kb.Text type="BodySmall">You can only send from a mobile device more than 7 days old.</Kb.Text>
+        <Kb.Text center={true} type="BodySmall">
+          You can only send from a mobile device more than 7 days old.
+        </Kb.Text>
       )}
     </Kb.Box2>
   )

--- a/shared/wallets/wallet/header/index.stories.js
+++ b/shared/wallets/wallet/header/index.stories.js
@@ -14,11 +14,11 @@ const provider = Sb.createPropProviderWithCommon({
   }),
   WalletSendButton: props => ({
     disabled: false,
-    disabledDueToMobileOnly: false,
     onSendToAnotherAccount: Sb.action('onSendToAnotherAccount'),
     onSendToKeybaseUser: Sb.action('onSendToKeybaseUser'),
     onSendToStellarAddress: Sb.action('onSendToStellarAddress'),
     small: props.small,
+    thisDeviceIsLockedOut: false,
   }),
 })
 
@@ -38,6 +38,7 @@ const common = {
   accountID: Types.stringToAccountID('GDP25ACNJ6CDEJLILV5UZZIQS66SHHWQ3554EMBF4VPXXKKYXXXMTAGZ'),
   onBack: Sb.action('onBack'),
   onReceive: Sb.action('onReceive'),
+  thisDeviceIsLockedOut: false,
   unreadPayments: false,
 }
 

--- a/shared/wallets/wallet/index.stories.js
+++ b/shared/wallets/wallet/index.stories.js
@@ -23,11 +23,11 @@ const provider = Sb.createPropProviderWithCommon({
   }),
   WalletSendButton: props => ({
     disabled: false,
-    disabledDueToMobileOnly: false,
     onSendToAnotherAccount: Sb.action('onSendToAnotherAccount'),
     onSendToKeybaseUser: Sb.action('onSendToKeybaseUser'),
     onSendToStellarAddress: Sb.action('onSendToStellarAddress'),
     small: props.small,
+    thisDeviceIsLockedOut: false,
   }),
 })
 

--- a/shared/wallets/wallet/settings/container.js
+++ b/shared/wallets/wallet/settings/container.js
@@ -27,7 +27,7 @@ const mapStateToProps = state => {
   const mobileOnlyMode = state.wallets.mobileOnlyMap.get(accountID, false)
   const mobileOnlyWaiting = anyWaiting(state, Constants.setAccountMobileOnlyWaitingKey(accountID))
   const canSubmitTx = account.canSubmitTx
-
+  const thisDeviceIsLockedOut = Constants.getThisDeviceIsLockedOut(state, accountID)
   const inflationDest = Constants.getInflationDestination(state, accountID)
   return {
     accountID,
@@ -45,6 +45,7 @@ const mapStateToProps = state => {
     mobileOnlyWaiting,
     name,
     saveCurrencyWaiting,
+    thisDeviceIsLockedOut,
     user,
   }
 }

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -106,11 +106,16 @@ class AccountSettings extends React.Component<SettingsProps> {
                       ? 'All transactions and overall activity are tied to your Keybase identity.'
                       : 'Transactions will be tied to your Stellar public address only.'}
                   </Kb.Text>
-                  {!props.isDefault && (
-                    <Kb.Text type="BodySmallPrimaryLink" onClick={props.onSetDefault}>
-                      Set as default Keybase account
-                    </Kb.Text>
-                  )}
+                  {!props.isDefault &&
+                    (!props.mobileOnlyEditable ? (
+                      <Kb.Text style={styles.setAsDefaultError} type="BodySmall">
+                        This account can only be made default from a mobile device over 7 days old.
+                      </Kb.Text>
+                    ) : (
+                      <Kb.Text type="BodySmallPrimaryLink" onClick={props.onSetDefault}>
+                        Set as default Keybase account
+                      </Kb.Text>
+                    ))}
                 </Kb.Box2>
               </Kb.Box2>
             </Kb.Box2>
@@ -211,8 +216,13 @@ class AccountSettings extends React.Component<SettingsProps> {
                 gap="tiny"
                 style={styles.removeContentContainer}
               >
+                {!props.mobileOnlyEditable && (
+                  <Kb.Text type="BodySmall">
+                    This account can only be removed from a mobile device over 7 days old.
+                  </Kb.Text>
+                )}
                 <Kb.Button
-                  disabled={props.isDefault}
+                  disabled={props.isDefault || !props.mobileOnlyEditable}
                   label="Remove account"
                   fullWidth={true}
                   type="Danger"
@@ -290,6 +300,9 @@ const styles = Styles.styleSheetCreate({
   sectionLabel: {
     alignSelf: 'flex-start',
     marginBottom: Styles.globalMargins.tiny,
+  },
+  setAsDefaultError: {
+    paddingTop: Styles.globalMargins.tiny,
   },
   settingsPage: {
     alignSelf: 'flex-start',

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -216,7 +216,7 @@ class AccountSettings extends React.Component<SettingsProps> {
                 gap="tiny"
                 style={styles.removeContentContainer}
               >
-                {!props.mobileOnlyEditable && (
+                {!props.isDefault && !props.mobileOnlyEditable && (
                   <Kb.Text type="BodySmall">
                     This account can only be removed from a mobile device over 7 days old.
                   </Kb.Text>

--- a/shared/wallets/wallet/settings/index.js
+++ b/shared/wallets/wallet/settings/index.js
@@ -30,6 +30,7 @@ export type SettingsProps = {|
   mobileOnlyMode: boolean,
   mobileOnlyWaiting: boolean,
   mobileOnlyEditable: boolean,
+  thisDeviceIsLockedOut: boolean,
 |}
 
 const HoverText = Styles.isMobile
@@ -107,7 +108,7 @@ class AccountSettings extends React.Component<SettingsProps> {
                       : 'Transactions will be tied to your Stellar public address only.'}
                   </Kb.Text>
                   {!props.isDefault &&
-                    (!props.mobileOnlyEditable ? (
+                    (props.thisDeviceIsLockedOut ? (
                       <Kb.Text style={styles.setAsDefaultError} type="BodySmall">
                         This account can only be made default from a mobile device over 7 days old.
                       </Kb.Text>
@@ -216,13 +217,13 @@ class AccountSettings extends React.Component<SettingsProps> {
                 gap="tiny"
                 style={styles.removeContentContainer}
               >
-                {!props.isDefault && !props.mobileOnlyEditable && (
+                {!props.isDefault && props.thisDeviceIsLockedOut && (
                   <Kb.Text type="BodySmall">
                     This account can only be removed from a mobile device over 7 days old.
                   </Kb.Text>
                 )}
                 <Kb.Button
-                  disabled={props.isDefault || !props.mobileOnlyEditable}
+                  disabled={props.isDefault || props.thisDeviceIsLockedOut}
                   label="Remove account"
                   fullWidth={true}
                   type="Danger"

--- a/shared/wallets/wallet/settings/index.stories.js
+++ b/shared/wallets/wallet/settings/index.stories.js
@@ -58,6 +58,7 @@ const sharedSettingsProps = {
   onSetupInflation: Sb.action('onSetupInflation'),
   refresh: () => {},
   saveCurrencyWaiting: false,
+  thisDeviceIsLockedOut: false,
   user: 'testuser',
 }
 
@@ -87,6 +88,7 @@ const load = () => {
     ))
     .add('Secondary', () => <Settings {...secondarySettingsProps} />)
     .add('MobileOnlyEditable', () => <Settings {...secondarySettingsProps} mobileOnlyEditable={true} />)
+    .add('Device is locked out', () => <Settings {...secondarySettingsProps} thisDeviceIsLockedOut={true} />)
   popups()
 }
 


### PR DESCRIPTION
@keybase/react-hackers CC @buoyad @patrickxb 

We've been storing whether a Stellar account is in `mobileOnlyMode` and using that to decide whether to allow sends -- if you're on a desktop device and the account's in mobileOnlyMode, you can't send.

Two problems with this:

* There are other disallowed operations: set as default and deleting the account.

* The criteria aren't correct: it's actually "if you're on a desktop, or a mobile device that's less than 7 days old" then these operations are disallowed.

So, this PR moves `disabledDueToMobileOnly` to instead test (and be called) `thisDeviceIsLockedOut`, and then expands the use from the send form to set as default and delete as well.  The test is done using `!account.accountModeEditable` to mean that this device is locked down.

@buoyad, you mentioned a confusing error on the send form itself -- I didn't change that, but since the Send button now isn't available if it's not going to work, I think we can leave that as-is and trust that we're unlikely to see it, does that make sense?