### PR TITLE
override cmd usage if running in standalone mode

### DIFF
--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -721,6 +721,14 @@ func (u Usage) UseKeyring() bool {
 	return u.KbKeyring || u.GpgKeyring
 }
 
+var ServiceUsage = Usage{
+	Config:     true,
+	KbKeyring:  true,
+	GpgKeyring: true,
+	API:        true,
+	Socket:     true,
+}
+
 func (g *GlobalContext) ConfigureCommand(line CommandLine, cmd Command) error {
 	usage := cmd.GetUsage()
 	return g.Configure(line, usage)
@@ -730,6 +738,10 @@ func (g *GlobalContext) Configure(line CommandLine, usage Usage) error {
 	g.SetCommandLine(line)
 	if err := g.ConfigureLogging(); err != nil {
 		return err
+	}
+	if g.Env.GetStandalone() {
+		// If standalone, override the usage to be the same as in a service
+		usage = ServiceUsage
 	}
 
 	if err := g.ConfigureUsage(usage); err != nil {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -1153,13 +1153,7 @@ func NewCmdService(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comma
 }
 
 func (d *Service) GetUsage() libkb.Usage {
-	return libkb.Usage{
-		Config:     true,
-		KbKeyring:  true,
-		GpgKeyring: true,
-		API:        true,
-		Socket:     true,
-	}
+	return libkb.ServiceUsage
 }
 
 func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {


### PR DESCRIPTION
fixes a bug where sometimes standalone commands panic becuase certain components aren't initialized