### PR TITLE
LogSend RPC for gui

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -92,7 +92,7 @@ func (c *CmdStatus) outputJSON(status *keybase1.FullStatus) error {
 func (c *CmdStatus) outputTerminal(status *keybase1.FullStatus) error {
 	extStatus := status.ExtStatus
 	dui := c.G().UI.GetDumbOutputUI()
-	dui.Printf("Username:      %s\n", status.CurStatus.User.Username)
+	dui.Printf("Username:      %s\n", status.Username)
 	dui.Printf("Logged in:     %s\n", BoolString(status.CurStatus.LoggedIn, "yes", "no"))
 	if extStatus.Device != nil {
 		dui.Printf("\nDevice:\n")

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -373,6 +373,7 @@ func (o GitStatus) DeepCopy() GitStatus {
 }
 
 type FullStatus struct {
+	Username   string          `codec:"username" json:"username"`
 	ConfigPath string          `codec:"configPath" json:"configPath"`
 	CurStatus  CurrentStatus   `codec:"curStatus" json:"curStatus"`
 	ExtStatus  ExtendedStatus  `codec:"extStatus" json:"extStatus"`
@@ -387,6 +388,7 @@ type FullStatus struct {
 
 func (o FullStatus) DeepCopy() FullStatus {
 	return FullStatus{
+		Username:   o.Username,
 		ConfigPath: o.ConfigPath,
 		CurStatus:  o.CurStatus.DeepCopy(),
 		ExtStatus:  o.ExtStatus.DeepCopy(),

--- a/go/status/log_send.go
+++ b/go/status/log_send.go
@@ -4,27 +4,21 @@
 package status
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
+)
 
-	jsonw "github.com/keybase/go-jsonw"
+const (
+	LogSendDefaultBytesDesktop = 1024 * 1024 * 16
+	// NOTE: If you increase LogSendDefaultBytesMobile, check
+	// go/libkb/env.go:Env.GetLogFileConfig to make sure we store at least that
+	// much.
+	LogSendDefaultBytesMobile = 1024 * 1024 * 10
+	LogSendMaxBytes           = 1024 * 1024 * 128
 )
 
 // Logs is the struct to specify the path of log files
@@ -47,106 +41,117 @@ type Logs struct {
 // LogSendContext for LogSend
 type LogSendContext struct {
 	libkb.Contextified
+
+	InstallID  libkb.InstallID
+	UID        keybase1.UID
+	StatusJSON string
+	Feedback   string
+
 	Logs Logs
+
+	kbfsLog          string
+	svcLog           string
+	ekLog            string
+	desktopLog       string
+	updaterLog       string
+	startLog         string
+	installLog       string
+	systemLog        string
+	gitLog           string
+	traceBundle      []byte
+	cpuProfileBundle []byte
+	watchdogLog      string
+	processesLog     string
 }
 
-func addFile(mpart *multipart.Writer, param, filename string, data []byte) error {
-	if len(data) == 0 {
-		return nil
+func NewLogSendContext(g *libkb.GlobalContext, fstatus *keybase1.FullStatus, statusJSON, feedback string) *LogSendContext {
+	logs := logFilesFromStatus(g, fstatus)
+
+	var uid keybase1.UID
+	if fstatus != nil {
+		uid = fstatus.CurStatus.User.Uid
+	} else {
+		uid = g.Env.GetUID()
+	}
+	if uid.IsNil() {
+		g.Log.Info("Not sending up a UID for logged in user; none found")
 	}
 
-	part, err := mpart.CreateFormFile(param, filename)
-	if err != nil {
-		return err
+	return &LogSendContext{
+		Contextified: libkb.NewContextified(g),
+		UID:          uid,
+		InstallID:    g.Env.GetInstallID(),
+		StatusJSON:   statusJSON,
+		Feedback:     feedback,
+		Logs:         logs,
 	}
-	_, err = io.Copy(part, bytes.NewBuffer(data))
-	return err
 }
 
-func addGzippedFile(mpart *multipart.Writer, param, filename, data string) error {
-	if len(data) == 0 {
-		return nil
-	}
-
-	part, err := mpart.CreateFormFile(param, filename)
-	if err != nil {
-		return err
-	}
-	gz := gzip.NewWriter(part)
-	if _, err := gz.Write([]byte(data)); err != nil {
-		return err
-	}
-	return gz.Close()
-}
-
-func (l *LogSendContext) post(mctx libkb.MetaContext, status, feedback, kbfsLog, svcLog, ekLog,
-	desktopLog, updaterLog, startLog, installLog, systemLog, gitLog, watchdogLog string,
-	traceBundle, cpuProfileBundle []byte, uid keybase1.UID,
-	installID libkb.InstallID, processesLog string) (string, error) {
+func (l *LogSendContext) post(mctx libkb.MetaContext) (keybase1.LogSendID, error) {
 	mctx.Debug("sending status + logs to keybase")
 
 	var body bytes.Buffer
 	mpart := multipart.NewWriter(&body)
 
-	if feedback != "" {
-		mpart.WriteField("feedback", feedback)
+	if l.Feedback != "" {
+		mpart.WriteField("feedback", l.Feedback)
 	}
 
-	if len(installID) > 0 {
-		mpart.WriteField("install_id", string(installID))
+	if len(l.InstallID) > 0 {
+		mpart.WriteField("install_id", string(l.InstallID))
 	}
 
-	if !uid.IsNil() {
-		mpart.WriteField("uid", uid.String())
+	if !l.UID.IsNil() {
+		mpart.WriteField("uid", l.UID.String())
 	}
 
-	if err := addGzippedFile(mpart, "status_gz", "status.gz", status); err != nil {
+	if err := addGzippedFile(mpart, "status_gz", "status.gz", l.StatusJSON); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "kbfs_log_gz", "kbfs_log.gz", kbfsLog); err != nil {
+	if err := addGzippedFile(mpart, "kbfs_log_gz", "kbfs_log.gz", l.kbfsLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "keybase_log_gz", "keybase_log.gz", svcLog); err != nil {
+	if err := addGzippedFile(mpart, "keybase_log_gz", "keybase_log.gz", l.svcLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "ek_log_gz", "ek_log.gz", ekLog); err != nil {
+	if err := addGzippedFile(mpart, "ek_log_gz", "ek_log.gz", l.ekLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "updater_log_gz", "updater_log.gz", updaterLog); err != nil {
+	if err := addGzippedFile(mpart, "updater_log_gz", "updater_log.gz", l.updaterLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "gui_log_gz", "gui_log.gz", desktopLog); err != nil {
+	if err := addGzippedFile(mpart, "gui_log_gz", "gui_log.gz", l.desktopLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "start_log_gz", "start_log.gz", startLog); err != nil {
+	if err := addGzippedFile(mpart, "start_log_gz", "start_log.gz", l.startLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "install_log_gz", "install_log.gz", installLog); err != nil {
+	if err := addGzippedFile(mpart, "install_log_gz", "install_log.gz", l.installLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "system_log_gz", "system_log.gz", systemLog); err != nil {
+	if err := addGzippedFile(mpart, "system_log_gz", "system_log.gz", l.systemLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "git_log_gz", "git_log.gz", gitLog); err != nil {
+	if err := addGzippedFile(mpart, "git_log_gz", "git_log.gz", l.gitLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "watchdog_log_gz", "watchdog_log.gz", watchdogLog); err != nil {
+	if err := addGzippedFile(mpart, "watchdog_log_gz", "watchdog_log.gz", l.watchdogLog); err != nil {
 		return "", err
 	}
-	if err := addGzippedFile(mpart, "processes_log_gz", "processes_log.gz", processesLog); err != nil {
+	if err := addGzippedFile(mpart, "processes_log_gz", "processes_log.gz", l.processesLog); err != nil {
 		return "", err
 	}
 
-	if len(traceBundle) > 0 {
-		mctx.Debug("trace bundle size: %d", len(traceBundle))
-		if err := addFile(mpart, "trace_tar_gz", "trace.tar.gz", traceBundle); err != nil {
+	if len(l.traceBundle) > 0 {
+		mctx.Debug("trace bundle size: %d", len(l.traceBundle))
+		if err := addFile(mpart, "trace_tar_gz", "trace.tar.gz", l.traceBundle); err != nil {
 			return "", err
 		}
 	}
 
-	if len(cpuProfileBundle) > 0 {
-		mctx.Debug("CPU profile bundle size: %d", len(cpuProfileBundle))
-		if err := addFile(mpart, "cpu_profile_tar_gz", "cpu_profile.tar.gz", cpuProfileBundle); err != nil {
+	if len(l.cpuProfileBundle) > 0 {
+		mctx.Debug("CPU profile bundle size: %d", len(l.cpuProfileBundle))
+		if err := addFile(mpart, "cpu_profile_tar_gz", "cpu_profile.tar.gz", l.cpuProfileBundle); err != nil {
 			return "", err
 		}
 	}
@@ -173,411 +178,76 @@ func (l *LogSendContext) post(mctx libkb.MetaContext, status, feedback, kbfsLog,
 		return "", err
 	}
 
-	return id, nil
+	return keybase1.LogSendID(id), nil
 }
 
-// tail the logs that start with the stem `stem`, which are of type `which`.
-// Get the most recent `numBytes` from the concatenation of the files.
-func tail(log logger.Logger, which string, stem string, numBytes int) (ret string) {
-
-	numFiles := 0
-
-	log.Debug("+ tailing %s file with stem %q", which, stem)
-	defer func() {
-		log.Debug("- collected %d bytes from %d files", len(ret), numFiles)
-	}()
-
-	if len(stem) == 0 {
-		log.Debug("| skipping %s logs (since no stem given)", which)
-		return
-	}
-
-	lognames := listLogFiles(log, stem)
-	var parts []string
-	remaining := numBytes
-
-	// Keep reading logs in reverse chronological order until we've read nothing
-	// more, or we've filled up numBytes worth of buffer, or we didn't have to read
-	// the whole file.
-	for _, logname := range lognames {
-		data, seeked := tailFile(log, which, logname, remaining)
-		if len(data) == 0 {
-			break
-		}
-		parts = append(parts, data)
-		numFiles++
-		remaining -= len(data)
-		if remaining <= 0 || seeked {
-			break
-		}
-	}
-
-	// Reverse the array; took this one-line from StackOverflow answer
-	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
-		parts[i], parts[j] = parts[j], parts[i]
-	}
-
-	return strings.Join(parts, "")
-}
-
-type nameAndMTime struct {
-	name  string
-	mtime time.Time
-}
-
-type nameAndMTimes []nameAndMTime
-
-func (a nameAndMTimes) Len() int           { return len(a) }
-func (a nameAndMTimes) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a nameAndMTimes) Less(i, j int) bool { return a[i].mtime.After(a[j].mtime) }
-
-// List logfiles that match the glob filename*, and return then in reverse chronological order.
-// We'll need to read the first, and maybe the second
-func listLogFiles(log logger.Logger, stem string) (ret []string) {
-	stem = filepath.Clean(stem)
-	dir := filepath.Dir(stem)
-	base := filepath.Base(stem)
-	files, err := ioutil.ReadDir(dir)
-
-	defer func() {
-		log.Debug("listLogFiles(%q) -> %v", stem, ret)
-	}()
-
-	// In the worst case, just return the stem in an array
-	defret := []string{stem}
-
-	if err != nil {
-		log.Debug("failed to list directory %q: %s", dir, err)
-		return defret
-	}
-
-	var tmp []nameAndMTime
-	for _, d := range files {
-		fullname := filepath.Clean(filepath.Join(dir, d.Name()))
-		// Use the stat on the file (and not from the directory read)
-		// since the latter doesn't work reliably on Windows
-		finfo, err := os.Stat(fullname)
-		if err != nil {
-			log.Debug("Cannot stat %q: %s", fullname, err)
-			continue
-		}
-		if strings.HasPrefix(d.Name(), base) {
-			tmp = append(tmp, nameAndMTime{fullname, finfo.ModTime()})
-		}
-	}
-	if len(tmp) == 0 {
-		log.Debug("no files found matching \"%s*\"; falling back to default glob", stem)
-		return defret
-	}
-
-	// Sort the files in reverse chronological mtime order. We should get the raw stem first.
-	sort.Sort(nameAndMTimes(tmp))
-	log.Debug("Sorted file list: %+v", tmp)
-
-	for _, f := range tmp {
-		ret = append(ret, f.name)
-	}
-
-	// If we didn't get the raw stem first, then we have a problem, so just use only the
-	// raw stem and ignore the rest of our work.
-	if stem != ret[0] {
-		log.Debug("Expected to get %q first, but got %q instead! Falling back to one log only", stem, ret[0])
-		return defret
-	}
-	return ret
-}
-
-// findFirstNewline first the first newline in the given byte array, and then returns the
-// rest of the byte array. Should be safe to use on utf-8 strings.
-func findFirstNewline(b []byte) []byte {
-	index := bytes.IndexByte(b, '\n')
-	if index < 0 || index == len(b)-1 {
-		return nil
-	}
-	return b[(index + 1):]
-}
-
-func appendError(log logger.Logger, collected []byte, format string, args ...interface{}) []byte {
-	msg := "Error reading logs: " + fmt.Sprintf(format, args...)
-	log.Errorf(msg)
-	return append(collected, []byte("\n"+msg+"\n")...)
-}
-
-// Get logs from the systemd journal. Currently we don't use this for most of
-// our logging, since it's not persisted across boot on some systems. But we do
-// use it for startup logs.
-func tailSystemdJournal(log logger.Logger, userUnits []string, numBytes int) (ret string) {
-	log.Debug("+ tailing journalctl for %#v (%d bytes)", userUnits, numBytes)
-	defer func() {
-		log.Debug("- scanned %d bytes", len(ret))
-	}()
-
-	// Journalctl doesn't provide a "last N bytes" flag directly, so instead we
-	// use "last N lines". Large log files in practice seem to be about 150
-	// bits per line. We'll request lines on that assumption, but if we get
-	// more than 2x as many bytes as we expected, we'll stop reading and
-	// include a big error.
-	guessedLines := numBytes / 150
-	maxBytes := numBytes * 2
-
-	// We intentionally avoid the --user flag to journalctl. That would make us
-	// skip over the system journal, but in e.g. Ubuntu 16.04, that's where
-	// user units write their logs.
-	// Unfortunately, this causes permission errors in some operating systems
-	// like Debian Stretch, but it is not fatal. as we ignore errors in this
-	// function.
-	args := []string{
-		"--lines=" + strconv.Itoa(guessedLines),
-	}
-	if len(userUnits) == 0 {
-		panic("without --user-unit we would scrape all system logs!!!")
-	}
-	for _, userUnit := range userUnits {
-		args = append(args, "--user-unit="+userUnit)
-	}
-	journalCmd := exec.Command("journalctl", args...)
-	journalCmd.Stderr = os.Stderr
-	stdout, err := journalCmd.StdoutPipe()
-	if err != nil {
-		msg := fmt.Sprintf("Failed to open a pipe for journalctl: %s", err)
-		log.Errorf(msg)
-		return msg
-	}
-	err = journalCmd.Start()
-	if err != nil {
-		msg := fmt.Sprintf("Failed to run journalctl: %s", err)
-		log.Errorf(msg)
-		return msg
-	}
-
-	// Once we start reading output, don't short-circuit on errors. Just log
-	// them, and return whatever we got.
-	stdoutLimited := io.LimitReader(stdout, int64(maxBytes))
-	output, err := ioutil.ReadAll(stdoutLimited)
-	if err != nil {
-		output = appendError(log, output, "Error reading from journalctl pipe: %s", err)
-	}
-	// We must close stdout before Wait, or else Wait might deadlock.
-	stdout.Close()
-	err = journalCmd.Wait()
-	if err != nil {
-		output = appendError(log, output, "Journalctl exited with an error: %s", err)
-	}
-	if len(output) >= maxBytes {
-		output = appendError(log, output, "Journal lines longer than expected. Logs truncated.")
-	}
-	return string(output)
-}
-
-// tailFile takes the last n bytes, but advances to the first newline. Returns the log (as a string)
-// and a bool, indicating if we read the full log, or we had to advance into the log to find the newline.
-func tailFile(log logger.Logger, which string, filename string, numBytes int) (ret string, seeked bool) {
-
-	log.Debug("+ tailing %s log %q (%d bytes)", which, filename, numBytes)
-	defer func() {
-		log.Debug("- scanned %d bytes", len(ret))
-	}()
-
-	seeked = false
-	if filename == "" {
-		return ret, seeked
-	}
-	finfo, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		log.Debug("log %q doesn't exist", filename)
-		return ret, seeked
-	}
-	f, err := os.Open(filename)
-	if err != nil {
-		log.Errorf("error opening log %q: %s", filename, err)
-		return ret, seeked
-	}
-	defer f.Close()
-	if finfo.Size() > int64(numBytes) {
-		seeked = true
-		_, err = f.Seek(int64(-numBytes), io.SeekEnd)
-		if err != nil {
-			log.Errorf("Can't seek log %q: %s", filename, err)
-			return ret, seeked
-		}
-	}
-	buf, err := ioutil.ReadAll(f)
-	if err != nil {
-		log.Errorf("Failure in reading file %q: %s", filename, err)
-		return ret, seeked
-	}
-	if seeked {
-		buf = findFirstNewline(buf)
-	}
-	return string(buf), seeked
-}
-
-func addFileToTar(tw *tar.Writer, path string) error {
-	file, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	if stat, err := file.Stat(); err == nil {
-		header := tar.Header{
-			Typeflag: tar.TypeReg,
-			Name:     filepath.Base(path),
-			Size:     stat.Size(),
-			Mode:     int64(0600),
-			ModTime:  stat.ModTime(),
-		}
-		if err := tw.WriteHeader(&header); err != nil {
-			return err
-		}
-		if _, err := io.Copy(tw, file); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func addFilesToTarGz(log logger.Logger, w io.Writer, paths []string) bool {
-	gw := gzip.NewWriter(w)
-	defer gw.Close()
-	tw := tar.NewWriter(gw)
-	defer tw.Close()
-
-	added := false
-	for _, path := range paths {
-		err := addFileToTar(tw, path)
-		if err != nil {
-			log.Warning("Error adding %q to tar file: %s", path, err)
-			continue
-		}
-		log.Debug("Added trace file %q", path)
-		added = true
-	}
-	return added
-}
-
-func getBundledFiles(log logger.Logger, files []string, maxFileCount int) []byte {
-	// Send the newest files.
-	if len(files) > maxFileCount {
-		files = files[len(files)-maxFileCount:]
-	}
-
-	buf := bytes.NewBuffer(nil)
-	added := addFilesToTarGz(log, buf, files)
-	if !added {
-		return nil
-	}
-	return buf.Bytes()
-}
-
-func getTraceBundle(log logger.Logger, traceDir string) []byte {
-	traceFiles, err := libkb.GetSortedTraceFiles(traceDir)
-	if err != nil {
-		log.Warning("Error getting trace files in %q: %s", traceDir, err)
-		return nil
-	}
-
-	return getBundledFiles(log, traceFiles, libkb.MaxTraceFileCount)
-}
-
-func getCPUProfileBundle(log logger.Logger, cpuProfileDir string) []byte {
-	cpuProfileFiles, err := libkb.GetSortedCPUProfileFiles(cpuProfileDir)
-	if err != nil {
-		log.Warning("Error getting CPU profile files in %q: %s", cpuProfileDir, err)
-		return nil
-	}
-
-	return getBundledFiles(log, cpuProfileFiles, libkb.MaxCPUProfileFileCount)
-}
-
-// LogSend sends the tails of log files to kb, and also the last
-// few trace output files.
-func (l *LogSendContext) LogSend(statusJSON, feedback string, sendLogs bool, numBytes int,
-	uid keybase1.UID, installID libkb.InstallID, mergeExtendedStatus bool) (string, error) {
+// LogSend sends the tails of log files to kb, and also the last few trace
+// output files.
+func (l *LogSendContext) LogSend(sendLogs bool, numBytes int, mergeExtendedStatus bool) (keybase1.LogSendID, error) {
 	mctx := libkb.NewMetaContextBackground(l.G()).WithLogTag("LOGSEND")
+
+	if numBytes < 1 {
+		numBytes = LogSendDefaultBytesDesktop
+	} else if numBytes > LogSendMaxBytes {
+		numBytes = LogSendMaxBytes
+	}
+
 	logs := l.Logs
-	var kbfsLog string
-	var svcLog string
-	var ekLog string
-	var desktopLog string
-	var updaterLog string
-	var startLog string
-	var installLog string
-	var systemLog string
-	var gitLog string
-	var traceBundle []byte
-	var cpuProfileBundle []byte
-	var watchdogLog string
-	var processesLog string
+	// So far, install logs are Windows only
+	if logs.Install != "" {
+		defer os.Remove(logs.Install)
+	}
+	// So far, watchdog logs are Windows only
+	if logs.Watchdog != "" {
+		defer os.Remove(logs.Watchdog)
+	}
 
 	if sendLogs {
-		svcLog = tail(l.G().Log, "service", logs.Service, numBytes)
-		ekLog = tail(l.G().Log, "ek", logs.EK, numBytes)
-		kbfsLog = tail(l.G().Log, "kbfs", logs.Kbfs, numBytes)
-		desktopLog = tail(l.G().Log, "desktop", logs.Desktop, numBytes)
-		updaterLog = tail(l.G().Log, "updater", logs.Updater, numBytes)
+		l.svcLog = tail(l.G().Log, "service", logs.Service, numBytes)
+		l.ekLog = tail(l.G().Log, "ek", logs.EK, numBytes)
+		l.kbfsLog = tail(l.G().Log, "kbfs", logs.Kbfs, numBytes)
+		l.desktopLog = tail(l.G().Log, "desktop", logs.Desktop, numBytes)
+		l.updaterLog = tail(l.G().Log, "updater", logs.Updater, numBytes)
 		// We don't use the systemd journal to store regular logs, since on
 		// some systems (e.g. Ubuntu 16.04) it's not persisted across boots.
 		// However we do use it for startup logs, since that's the only place
 		// to get them in systemd mode.
 		if l.G().Env.WantsSystemd() {
-			startLog = tailSystemdJournal(l.G().Log, []string{
+			l.startLog = tailSystemdJournal(l.G().Log, []string{
 				"keybase.service",
 				"kbfs.service",
 				"keybase.gui.service",
 				"keybase-redirector.service",
 			}, numBytes)
 		} else {
-			startLog = tail(l.G().Log, "start", logs.Start, numBytes)
+			l.startLog = tail(l.G().Log, "start", logs.Start, numBytes)
 		}
-		installLog = tail(l.G().Log, "install", logs.Install, numBytes)
-		systemLog = tail(l.G().Log, "system", logs.System, numBytes)
-		gitLog = tail(l.G().Log, "git", logs.Git, numBytes)
-		watchdogLog = tail(l.G().Log, "watchdog", logs.Watchdog, numBytes)
+		l.installLog = tail(l.G().Log, "install", logs.Install, numBytes)
+		l.systemLog = tail(l.G().Log, "system", logs.System, numBytes)
+		l.gitLog = tail(l.G().Log, "git", logs.Git, numBytes)
+		l.watchdogLog = tail(l.G().Log, "watchdog", logs.Watchdog, numBytes)
 		if logs.Trace != "" {
-			traceBundle = getTraceBundle(l.G().Log, logs.Trace)
+			l.traceBundle = getTraceBundle(l.G().Log, logs.Trace)
 		}
 		if logs.CPUProfile != "" {
-			cpuProfileBundle = getCPUProfileBundle(l.G().Log, logs.CPUProfile)
+			l.cpuProfileBundle = getCPUProfileBundle(l.G().Log, logs.CPUProfile)
 		}
 		// Only add extended status if we're sending logs
 		if mergeExtendedStatus {
-			statusJSON = l.mergeExtendedStatus(statusJSON)
+			l.StatusJSON = l.mergeExtendedStatus(l.StatusJSON)
 		}
-		processesLog = keybaseProcessList()
+		l.processesLog = keybaseProcessList()
 	}
 
-	return l.post(mctx, statusJSON, feedback, kbfsLog, svcLog, ekLog,
-		desktopLog, updaterLog, startLog,
-		installLog, systemLog, gitLog, watchdogLog, traceBundle,
-		cpuProfileBundle, uid, installID, processesLog)
+	return l.post(mctx)
 }
 
 // mergeExtendedStatus adds the extended status to the given status json blob.
 // If any errors occur the original status is returned unmodified.
 func (l *LogSendContext) mergeExtendedStatus(status string) string {
-	err := jsonw.EnsureMaxDepthBytesDefault([]byte(status))
-	if err != nil {
-		return status
-	}
-
-	var statusObj map[string]interface{}
-	if err = json.Unmarshal([]byte(status), &statusObj); err != nil {
-		return status
-	}
-
 	extStatus, err := GetExtendedStatus(libkb.NewMetaContextTODO(l.G()))
 	if err != nil {
 		return status
 	}
-
-	statusMap := make(map[string]interface{})
-	statusMap["status"] = statusObj
-	statusMap["extstatus"] = extStatus
-
-	fullStatus, err := json.Marshal(statusMap)
-	if err != nil {
-		return status
-	}
-	return string(fullStatus)
+	return MergeStatusJSON(extStatus, "extstatus", status)
 }

--- a/go/status/log_send.go
+++ b/go/status/log_send.go
@@ -68,7 +68,7 @@ func NewLogSendContext(g *libkb.GlobalContext, fstatus *keybase1.FullStatus, sta
 	logs := logFilesFromStatus(g, fstatus)
 
 	var uid keybase1.UID
-	if fstatus != nil {
+	if fstatus != nil && fstatus.CurStatus.User != nil {
 		uid = fstatus.CurStatus.User.Uid
 	} else {
 		uid = g.Env.GetUID()

--- a/go/status/status.go
+++ b/go/status/status.go
@@ -184,6 +184,12 @@ func GetFullStatus(mctx libkb.MetaContext) (status *keybase1.FullStatus, err err
 		return nil, err
 	}
 
+	// Duplicate the username at top-level for backwards compatibility of
+	// output.
+	if status.CurStatus.User != nil {
+		status.Username = status.CurStatus.User.Username
+	}
+
 	status.ExtStatus, err = GetExtendedStatus(mctx)
 	if err != nil {
 		return nil, err

--- a/go/status/status.go
+++ b/go/status/status.go
@@ -225,20 +225,7 @@ func GetFullStatus(mctx libkb.MetaContext) (status *keybase1.FullStatus, err err
 	}
 
 	// set log paths
-	serviceLogPath, ok := mctx.G().Env.GetEffectiveLogFile()
-	if ok && serviceLogPath != "" {
-		serviceLogPath, err = filepath.Abs(serviceLogPath)
-		if err != nil {
-			mctx.Debug("Unable to get abspath for effective log file %v", err)
-			serviceLogPath = ""
-		} else {
-			status.Service.Log = serviceLogPath
-		}
-	}
-
-	if serviceLogPath == "" {
-		status.Service.Log = filepath.Join(status.ExtStatus.LogDir, libkb.ServiceLogFileName)
-	}
+	status.Service.Log = getServiceLog(mctx, status.ExtStatus.LogDir)
 	status.Service.EkLog = filepath.Join(status.ExtStatus.LogDir, libkb.EKLogFileName)
 	status.Kbfs.Log = filepath.Join(status.ExtStatus.LogDir, libkb.KBFSLogFileName)
 	status.Desktop.Log = filepath.Join(status.ExtStatus.LogDir, libkb.DesktopLogFileName)

--- a/go/status/status_test.go
+++ b/go/status/status_test.go
@@ -40,7 +40,7 @@ func TestMergeExtendedStatus(t *testing.T) {
 }
 
 func TestFullStatus(t *testing.T) {
-	tc := libkb.SetupTest(t, "MergedExtendedStatus", 1)
+	tc := libkb.SetupTest(t, "FullStatus", 1)
 	defer tc.Cleanup()
 	mctx := libkb.NewMetaContextForTest(tc)
 	fstatus, err := GetFullStatus(mctx)

--- a/go/status/utils.go
+++ b/go/status/utils.go
@@ -4,18 +4,442 @@
 package status
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/keybase/client/go/install"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
+	jsonw "github.com/keybase/go-jsonw"
 )
+
+// MergeStatusJSON merges the given `obj` into the given `status` JSON blob.
+// If any errors occur the original `status` is returned. Otherwise a new JSON
+// blob is created of the form {"status": status, key: obj}
+func MergeStatusJSON(obj interface{}, key, status string) string {
+	if err := jsonw.EnsureMaxDepthBytesDefault([]byte(status)); err != nil {
+		return status
+	}
+
+	var statusObj map[string]interface{}
+	if err := json.Unmarshal([]byte(status), &statusObj); err != nil {
+		return status
+	}
+
+	statusMap := make(map[string]interface{})
+	statusMap["status"] = statusObj
+	statusMap[key] = obj
+
+	fullStatus, err := json.Marshal(statusMap)
+	if err != nil {
+		return status
+	}
+	return string(fullStatus)
+}
+
+func logFilesFromStatus(g *libkb.GlobalContext, fstatus *keybase1.FullStatus) Logs {
+	logDir := g.Env.GetLogDir()
+	installLogPath, err := install.InstallLogPath()
+	if err != nil {
+		g.Log.Errorf("Error (InstallLogPath): %s", err)
+	}
+
+	watchdogLogPath, err := install.WatchdogLogPath(filepath.Join(logDir, "watchdog*.log"))
+	if err != nil {
+		g.Log.Errorf("Error (WatchdogLogPath): %s", err)
+	}
+
+	traceDir := logDir
+	cpuProfileDir := logDir
+	if fstatus != nil {
+		return Logs{
+			Desktop:    fstatus.Desktop.Log,
+			Kbfs:       fstatus.Kbfs.Log,
+			Service:    fstatus.Service.Log,
+			EK:         fstatus.Service.EkLog,
+			Updater:    fstatus.Updater.Log,
+			Start:      fstatus.Start.Log,
+			System:     install.SystemLogPath(),
+			Git:        fstatus.Git.Log,
+			Install:    installLogPath,
+			Trace:      traceDir,
+			CPUProfile: cpuProfileDir,
+			Watchdog:   watchdogLogPath,
+		}
+	}
+
+	return Logs{
+		Desktop:  filepath.Join(logDir, libkb.DesktopLogFileName),
+		Kbfs:     filepath.Join(logDir, libkb.KBFSLogFileName),
+		Service:  filepath.Join(logDir, libkb.ServiceLogFileName),
+		EK:       filepath.Join(logDir, libkb.EKLogFileName),
+		Updater:  filepath.Join(logDir, libkb.UpdaterLogFileName),
+		Start:    filepath.Join(logDir, libkb.StartLogFileName),
+		Git:      filepath.Join(logDir, libkb.GitLogFileName),
+		Install:  installLogPath,
+		Trace:    traceDir,
+		Watchdog: watchdogLogPath,
+	}
+}
+
+func addFile(mpart *multipart.Writer, param, filename string, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	part, err := mpart.CreateFormFile(param, filename)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, bytes.NewBuffer(data))
+	return err
+}
+
+func addGzippedFile(mpart *multipart.Writer, param, filename, data string) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	part, err := mpart.CreateFormFile(param, filename)
+	if err != nil {
+		return err
+	}
+	gz := gzip.NewWriter(part)
+	if _, err := gz.Write([]byte(data)); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+// tail the logs that start with the stem `stem`, which are of type `which`.
+// Get the most recent `numBytes` from the concatenation of the files.
+func tail(log logger.Logger, which string, stem string, numBytes int) (ret string) {
+
+	numFiles := 0
+
+	log.Debug("+ tailing %s file with stem %q", which, stem)
+	defer func() {
+		log.Debug("- collected %d bytes from %d files", len(ret), numFiles)
+	}()
+
+	if len(stem) == 0 {
+		log.Debug("| skipping %s logs (since no stem given)", which)
+		return
+	}
+
+	lognames := listLogFiles(log, stem)
+	var parts []string
+	remaining := numBytes
+
+	// Keep reading logs in reverse chronological order until we've read nothing
+	// more, or we've filled up numBytes worth of buffer, or we didn't have to read
+	// the whole file.
+	for _, logname := range lognames {
+		data, seeked := tailFile(log, which, logname, remaining)
+		if len(data) == 0 {
+			break
+		}
+		parts = append(parts, data)
+		numFiles++
+		remaining -= len(data)
+		if remaining <= 0 || seeked {
+			break
+		}
+	}
+
+	// Reverse the array; took this one-line from StackOverflow answer
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+
+	return strings.Join(parts, "")
+}
+
+type nameAndMTime struct {
+	name  string
+	mtime time.Time
+}
+
+type nameAndMTimes []nameAndMTime
+
+func (a nameAndMTimes) Len() int           { return len(a) }
+func (a nameAndMTimes) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a nameAndMTimes) Less(i, j int) bool { return a[i].mtime.After(a[j].mtime) }
+
+// List logfiles that match the glob filename*, and return then in reverse chronological order.
+// We'll need to read the first, and maybe the second
+func listLogFiles(log logger.Logger, stem string) (ret []string) {
+	stem = filepath.Clean(stem)
+	dir := filepath.Dir(stem)
+	base := filepath.Base(stem)
+	files, err := ioutil.ReadDir(dir)
+
+	defer func() {
+		log.Debug("listLogFiles(%q) -> %v", stem, ret)
+	}()
+
+	// In the worst case, just return the stem in an array
+	defret := []string{stem}
+
+	if err != nil {
+		log.Debug("failed to list directory %q: %s", dir, err)
+		return defret
+	}
+
+	var tmp []nameAndMTime
+	for _, d := range files {
+		fullname := filepath.Clean(filepath.Join(dir, d.Name()))
+		// Use the stat on the file (and not from the directory read)
+		// since the latter doesn't work reliably on Windows
+		finfo, err := os.Stat(fullname)
+		if err != nil {
+			log.Debug("Cannot stat %q: %s", fullname, err)
+			continue
+		}
+		if strings.HasPrefix(d.Name(), base) {
+			tmp = append(tmp, nameAndMTime{fullname, finfo.ModTime()})
+		}
+	}
+	if len(tmp) == 0 {
+		log.Debug("no files found matching \"%s*\"; falling back to default glob", stem)
+		return defret
+	}
+
+	// Sort the files in reverse chronological mtime order. We should get the raw stem first.
+	sort.Sort(nameAndMTimes(tmp))
+	log.Debug("Sorted file list: %+v", tmp)
+
+	for _, f := range tmp {
+		ret = append(ret, f.name)
+	}
+
+	// If we didn't get the raw stem first, then we have a problem, so just use only the
+	// raw stem and ignore the rest of our work.
+	if stem != ret[0] {
+		log.Debug("Expected to get %q first, but got %q instead! Falling back to one log only", stem, ret[0])
+		return defret
+	}
+	return ret
+}
+
+// findFirstNewline first the first newline in the given byte array, and then returns the
+// rest of the byte array. Should be safe to use on utf-8 strings.
+func findFirstNewline(b []byte) []byte {
+	index := bytes.IndexByte(b, '\n')
+	if index < 0 || index == len(b)-1 {
+		return nil
+	}
+	return b[(index + 1):]
+}
+
+func appendError(log logger.Logger, collected []byte, format string, args ...interface{}) []byte {
+	msg := "Error reading logs: " + fmt.Sprintf(format, args...)
+	log.Errorf(msg)
+	return append(collected, []byte("\n"+msg+"\n")...)
+}
+
+// Get logs from the systemd journal. Currently we don't use this for most of
+// our logging, since it's not persisted across boot on some systems. But we do
+// use it for startup logs.
+func tailSystemdJournal(log logger.Logger, userUnits []string, numBytes int) (ret string) {
+	log.Debug("+ tailing journalctl for %#v (%d bytes)", userUnits, numBytes)
+	defer func() {
+		log.Debug("- scanned %d bytes", len(ret))
+	}()
+
+	// Journalctl doesn't provide a "last N bytes" flag directly, so instead we
+	// use "last N lines". Large log files in practice seem to be about 150
+	// bits per line. We'll request lines on that assumption, but if we get
+	// more than 2x as many bytes as we expected, we'll stop reading and
+	// include a big error.
+	guessedLines := numBytes / 150
+	maxBytes := numBytes * 2
+
+	// We intentionally avoid the --user flag to journalctl. That would make us
+	// skip over the system journal, but in e.g. Ubuntu 16.04, that's where
+	// user units write their logs.
+	// Unfortunately, this causes permission errors in some operating systems
+	// like Debian Stretch, but it is not fatal. as we ignore errors in this
+	// function.
+	args := []string{
+		"--lines=" + strconv.Itoa(guessedLines),
+	}
+	if len(userUnits) == 0 {
+		panic("without --user-unit we would scrape all system logs!!!")
+	}
+	for _, userUnit := range userUnits {
+		args = append(args, "--user-unit="+userUnit)
+	}
+	journalCmd := exec.Command("journalctl", args...)
+	journalCmd.Stderr = os.Stderr
+	stdout, err := journalCmd.StdoutPipe()
+	if err != nil {
+		msg := fmt.Sprintf("Failed to open a pipe for journalctl: %s", err)
+		log.Errorf(msg)
+		return msg
+	}
+	err = journalCmd.Start()
+	if err != nil {
+		msg := fmt.Sprintf("Failed to run journalctl: %s", err)
+		log.Errorf(msg)
+		return msg
+	}
+
+	// Once we start reading output, don't short-circuit on errors. Just log
+	// them, and return whatever we got.
+	stdoutLimited := io.LimitReader(stdout, int64(maxBytes))
+	output, err := ioutil.ReadAll(stdoutLimited)
+	if err != nil {
+		output = appendError(log, output, "Error reading from journalctl pipe: %s", err)
+	}
+	// We must close stdout before Wait, or else Wait might deadlock.
+	stdout.Close()
+	err = journalCmd.Wait()
+	if err != nil {
+		output = appendError(log, output, "Journalctl exited with an error: %s", err)
+	}
+	if len(output) >= maxBytes {
+		output = appendError(log, output, "Journal lines longer than expected. Logs truncated.")
+	}
+	return string(output)
+}
+
+// tailFile takes the last n bytes, but advances to the first newline. Returns the log (as a string)
+// and a bool, indicating if we read the full log, or we had to advance into the log to find the newline.
+func tailFile(log logger.Logger, which string, filename string, numBytes int) (ret string, seeked bool) {
+
+	log.Debug("+ tailing %s log %q (%d bytes)", which, filename, numBytes)
+	defer func() {
+		log.Debug("- scanned %d bytes", len(ret))
+	}()
+
+	seeked = false
+	if filename == "" {
+		return ret, seeked
+	}
+	finfo, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		log.Debug("log %q doesn't exist", filename)
+		return ret, seeked
+	}
+	f, err := os.Open(filename)
+	if err != nil {
+		log.Errorf("error opening log %q: %s", filename, err)
+		return ret, seeked
+	}
+	defer f.Close()
+	if finfo.Size() > int64(numBytes) {
+		seeked = true
+		_, err = f.Seek(int64(-numBytes), io.SeekEnd)
+		if err != nil {
+			log.Errorf("Can't seek log %q: %s", filename, err)
+			return ret, seeked
+		}
+	}
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		log.Errorf("Failure in reading file %q: %s", filename, err)
+		return ret, seeked
+	}
+	if seeked {
+		buf = findFirstNewline(buf)
+	}
+	return string(buf), seeked
+}
+
+func addFileToTar(tw *tar.Writer, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if stat, err := file.Stat(); err == nil {
+		header := tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     filepath.Base(path),
+			Size:     stat.Size(),
+			Mode:     int64(0600),
+			ModTime:  stat.ModTime(),
+		}
+		if err := tw.WriteHeader(&header); err != nil {
+			return err
+		}
+		if _, err := io.Copy(tw, file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addFilesToTarGz(log logger.Logger, w io.Writer, paths []string) bool {
+	gw := gzip.NewWriter(w)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	added := false
+	for _, path := range paths {
+		err := addFileToTar(tw, path)
+		if err != nil {
+			log.Warning("Error adding %q to tar file: %s", path, err)
+			continue
+		}
+		log.Debug("Added trace file %q", path)
+		added = true
+	}
+	return added
+}
+
+func getBundledFiles(log logger.Logger, files []string, maxFileCount int) []byte {
+	// Send the newest files.
+	if len(files) > maxFileCount {
+		files = files[len(files)-maxFileCount:]
+	}
+
+	buf := bytes.NewBuffer(nil)
+	added := addFilesToTarGz(log, buf, files)
+	if !added {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+func getTraceBundle(log logger.Logger, traceDir string) []byte {
+	traceFiles, err := libkb.GetSortedTraceFiles(traceDir)
+	if err != nil {
+		log.Warning("Error getting trace files in %q: %s", traceDir, err)
+		return nil
+	}
+
+	return getBundledFiles(log, traceFiles, libkb.MaxTraceFileCount)
+}
+
+func getCPUProfileBundle(log logger.Logger, cpuProfileDir string) []byte {
+	cpuProfileFiles, err := libkb.GetSortedCPUProfileFiles(cpuProfileDir)
+	if err != nil {
+		log.Warning("Error getting CPU profile files in %q: %s", cpuProfileDir, err)
+		return nil
+	}
+
+	return getBundledFiles(log, cpuProfileFiles, libkb.MaxCPUProfileFileCount)
+}
 
 func getPlatformInfo() keybase1.PlatformInfo {
 	return keybase1.PlatformInfo{

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -149,6 +149,9 @@ protocol config {
   // commands
   union { null, FullStatus } getFullStatus(int sessionID);
 
+  @typedef("string")  record LogSendID {}
+  LogSendID logSend(int sessionID, string statusJSON, string feedback,
+    boolean sendLogs);
 
   record AllProvisionedUsernames {
     string defaultUsername;

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -129,6 +129,7 @@ protocol config {
   }
 
   record FullStatus {
+    string username;
     string configPath;
 
     CurrentStatus curStatus;

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -425,6 +425,10 @@
       "fields": [
         {
           "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "string",
           "name": "configPath"
         },
         {

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -467,6 +467,12 @@
     },
     {
       "type": "record",
+      "name": "LogSendID",
+      "fields": [],
+      "typedef": "string"
+    },
+    {
+      "type": "record",
       "name": "AllProvisionedUsernames",
       "fields": [
         {
@@ -778,6 +784,27 @@
         null,
         "FullStatus"
       ]
+    },
+    "logSend": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "statusJSON",
+          "type": "string"
+        },
+        {
+          "name": "feedback",
+          "type": "string"
+        },
+        {
+          "name": "sendLogs",
+          "type": "boolean"
+        }
+      ],
+      "response": "LogSendID"
     },
     "getAllProvisionedUsernames": {
       "request": [

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -2281,7 +2281,7 @@ export type FullNamePackageVersion =
   | 1 // V1_1
   | 2 // V2_2
 
-export type FullStatus = $ReadOnly<{configPath: String, curStatus: CurrentStatus, extStatus: ExtendedStatus, client: KbClientStatus, service: KbServiceStatus, kbfs: KBFSStatus, desktop: DesktopStatus, updater: UpdaterStatus, start: StartStatus, git: GitStatus}>
+export type FullStatus = $ReadOnly<{username: String, configPath: String, curStatus: CurrentStatus, extStatus: ExtendedStatus, client: KbClientStatus, service: KbServiceStatus, kbfs: KBFSStatus, desktop: DesktopStatus, updater: UpdaterStatus, start: StartStatus, git: GitStatus}>
 export type FuseMountInfo = $ReadOnly<{path: String, fstype: String, output: String}>
 export type FuseStatus = $ReadOnly<{version: String, bundleVersion: String, kextID: String, path: String, kextStarted: Boolean, installStatus: InstallStatus, installAction: InstallAction, mountInfos?: ?Array<FuseMountInfo>, status: Status}>
 export type GPGKey = $ReadOnly<{algorithm: String, keyID: String, creation: String, expiration: String, identities?: ?Array<PGPIdentity>}>

--- a/shared/constants/types/rpc-gen.js.flow
+++ b/shared/constants/types/rpc-gen.js.flow
@@ -2486,6 +2486,7 @@ export type LogLevel =
   | 6 // CRITICAL_6
   | 7 // FATAL_7
 
+export type LogSendID = String
 export type LookupImplicitTeamRes = $ReadOnly<{teamID: TeamID, name: TeamName, displayName: ImplicitTeamDisplayName, tlfID: TLFID}>
 export type MDBlock = $ReadOnly<{version: Int, timestamp: Time, block: Bytes}>
 export type MDPriority = Int
@@ -3693,6 +3694,7 @@ declare export function userUploadUserAvatarRpcPromise(params: $PropertyType<$Pr
 // 'keybase.1.config.getCurrentStatus'
 // 'keybase.1.config.getClientStatus'
 // 'keybase.1.config.getFullStatus'
+// 'keybase.1.config.logSend'
 // 'keybase.1.config.setUserConfig'
 // 'keybase.1.config.setPath'
 // 'keybase.1.config.clearValue'


### PR DESCRIPTION
refactors logic out of the `keybase log send` command into the `status` package to expose a simple RPC for the gui to call. 

- [x] verify mobile 