### PR TITLE
drop gregor connection on desktop power events like we do on mobile

### DIFF
--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -279,14 +279,14 @@ func (g *gregorHandler) monitorAppState() {
 	for {
 		monitorAction := monitorNoop
 		select {
-		case mobileState := <-g.G().MobileAppState.NextUpdate(&state):
-			switch mobileState {
+		case state = <-g.G().MobileAppState.NextUpdate(&state):
+			switch state {
 			case keybase1.MobileAppState_FOREGROUND, keybase1.MobileAppState_BACKGROUNDACTIVE:
 				monitorAction = monitorConnect
 			case keybase1.MobileAppState_BACKGROUND, keybase1.MobileAppState_INACTIVE:
 				monitorAction = monitorDisconnect
 			}
-		case suspended := <-g.G().DesktopAppState.NextSuspendUpdate(&suspended):
+		case suspended = <-g.G().DesktopAppState.NextSuspendUpdate(&suspended):
 			if !suspended {
 				monitorAction = monitorConnect
 			} else {


### PR DESCRIPTION
We get bizarre problems where the internal retry loop in the RPC library seems to get stuck on resume on Windows. As a result, after coming out of sleep on Windows, there is a good chance the connection to Gregor just won't get re-made. Rather than trying to figure that out, instead hook into the power events system, and drop and reconnect the entire connection object like we do in the mobile app.