### PR TITLE
link to properly cased HN profiles

### DIFF
--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -247,7 +247,12 @@ func (i *UIAdapter) rowPartial(mctx libkb.MetaContext, proof keybase1.RemoteProo
 		row.SiteURL = fmt.Sprintf("https://reddit.com/user/%v", proof.Value)
 		iconKey = "reddit"
 	case keybase1.ProofType_HACKERNEWS:
-		row.SiteURL = fmt.Sprintf("https://news.ycombinator.com/user?id=%v", proof.Value)
+		// hackernews profile urls must have the username in its original casing.
+		username := proof.Value
+		if libkb.Cicmp(proof.Value, proof.DisplayMarkup) {
+			username = proof.DisplayMarkup
+		}
+		row.SiteURL = fmt.Sprintf("https://news.ycombinator.com/user?id=%v", username)
 		iconKey = "hackernews"
 	case keybase1.ProofType_FACEBOOK:
 		row.SiteURL = fmt.Sprintf("https://facebook.com/%v", proof.Value)


### PR DESCRIPTION
HN profile links for cased usernames work now.
![image](https://user-images.githubusercontent.com/705646/57551809-f9a13d00-7337-11e9-97b2-5de9d9bf9563.png)
