### PR TITLE
Don't let confirm form header get too squished on mobile

### DIFF
--- a/shared/wallets/confirm-form/header.js
+++ b/shared/wallets/confirm-form/header.js
@@ -12,14 +12,8 @@ type HeaderProps = {|
 |}
 
 const Header = (props: HeaderProps) => (
-  <Kb.Box2 noShrink={true} direction="horizontal" fullWidth={true} style={styles.header}>
-    <Kb.Box2
-      noShrink={true}
-      direction="vertical"
-      fullWidth={true}
-      centerChildren={true}
-      style={styles.headerContent}
-    >
+  <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.header}>
+    <Kb.Box2 direction="vertical" fullWidth={true} centerChildren={true} style={styles.headerContent}>
       <Kb.Icon
         type={
           Styles.isMobile
@@ -56,6 +50,7 @@ const styles = Styles.styleSheetCreate({
     isMobile: {
       flexBasis: 'auto',
       flexGrow: 1,
+      flexShrink: 1,
       minHeight: 250,
     },
   }),

--- a/shared/wallets/confirm-form/header.js
+++ b/shared/wallets/confirm-form/header.js
@@ -45,7 +45,7 @@ const styles = Styles.styleSheetCreate({
     },
     isElectron: {
       flex: 1,
-      minHeight: 144,
+      minHeight: 160,
     },
     isMobile: {
       flexBasis: 'auto',

--- a/shared/wallets/confirm-form/header.js
+++ b/shared/wallets/confirm-form/header.js
@@ -12,8 +12,14 @@ type HeaderProps = {|
 |}
 
 const Header = (props: HeaderProps) => (
-  <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.header}>
-    <Kb.Box2 direction="vertical" fullWidth={true} centerChildren={true} style={styles.headerContent}>
+  <Kb.Box2 noShrink={true} direction="horizontal" fullWidth={true} style={styles.header}>
+    <Kb.Box2
+      noShrink={true}
+      direction="vertical"
+      fullWidth={true}
+      centerChildren={true}
+      style={styles.headerContent}
+    >
       <Kb.Icon
         type={
           Styles.isMobile
@@ -50,8 +56,7 @@ const styles = Styles.styleSheetCreate({
     isMobile: {
       flexBasis: 'auto',
       flexGrow: 1,
-      flexShrink: 1,
-      minHeight: 200,
+      minHeight: 250,
     },
   }),
   headerContent: Styles.platformStyles({

--- a/shared/wallets/confirm-form/note-and-memo.js
+++ b/shared/wallets/confirm-form/note-and-memo.js
@@ -40,9 +40,10 @@ const NoteAndMemo = (props: Props) => (
 )
 
 const styles = Styles.styleSheetCreate({
-  bodyText: {
-    color: Styles.globalColors.black,
-  },
+  bodyText: Styles.platformStyles({
+    common: {color: Styles.globalColors.black},
+    isElectron: {wordBreak: 'break-word'},
+  }),
   headingText: {
     color: Styles.globalColors.blue,
     marginBottom: Styles.globalMargins.xtiny,


### PR DESCRIPTION
<img width="415" alt="image" src="https://user-images.githubusercontent.com/11968340/57558591-eac08780-7343-11e9-9d47-117402eebfe1.png">

r? @keybase/react-hackers 