### PR TITLE
folder_branch_ops: turn a billy.Filesystem EOF into a nil error

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	stdpath "path"
@@ -5176,6 +5177,12 @@ func (fbo *folderBranchOps) Read(
 		defer fsFile.Close()
 		fbo.vlog.CLogf(ctx, libkb.VLog1, "Reading from an FS file")
 		nInt, err := fsFile.ReadAt(dest, off)
+		if nInt == 0 && errors.Cause(err) == io.EOF {
+			// The billy interfaces requires an EOF when you start
+			// reading past the end of a file, but the libkbfs
+			// interface wants a nil error in that case.
+			err = nil
+		}
 		return int64(nInt), err
 	}
 


### PR DESCRIPTION
When reading from a wrapped node using a `billy.Filesystem`, we get an EOF error.  But the libkbfs interface promises to return a nil error in that case (along with 0 bytes read), and if it doesn't, fuse ends up getting an EIO.  So just catch that case and return a nil error.

Issue: KBFS-4159