### PR TITLE
keybase_service_base: add debugging for display name issue

### DIFF
--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -576,6 +577,11 @@ func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 	res, err := k.identifyClient.ResolveIdentifyImplicitTeam(ctx, arg)
 	if err != nil {
 		return idutil.ImplicitTeamInfo{}, ConvertIdentifyError(assertions, err)
+	}
+	if strings.Contains(res.DisplayName, "_implicit_team_") {
+		k.log.CWarningf(
+			ctx, "Got display name %s for assertions %s",
+			res.DisplayName, assertions)
 	}
 	name := kbname.NormalizedUsername(res.DisplayName)
 


### PR DESCRIPTION
Sometimes we try to identify teams using their internal "_implicit_team_XXX" name, rather than their display name.  As far as I can tell, that's because the service is returning it as a display name, but it's hard to know for sure without more debugging.  So add that debugging.