### PR TITLE
bserver: add a timeout during authentication

### DIFF
--- a/go/kbfs/libkbfs/bserver_remote.go
+++ b/go/kbfs/libkbfs/bserver_remote.go
@@ -172,6 +172,13 @@ func (b *blockServerRemoteClientHandler) resetAuth(
 		return nil
 	}
 
+	_, hasDeadline := ctx.Deadline()
+	if !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, reconnectTimeout)
+		defer cancel()
+	}
+
 	// request a challenge
 	challenge, err := c.GetSessionChallenge(ctx)
 	if err != nil {

--- a/go/kbfs/libkbfs/mdserver_remote.go
+++ b/go/kbfs/libkbfs/mdserver_remote.go
@@ -166,7 +166,7 @@ func (md *MDServerRemote) initNewConnection() {
 	md.client = keybase1.MetadataClient{Cli: md.conn.GetClient()}
 }
 
-const reconnectTimeout = 30 * time.Second
+const reconnectTimeout = 10 * time.Second
 
 func (md *MDServerRemote) reconnectContext(ctx context.Context) error {
 	md.connMu.Lock()


### PR DESCRIPTION
It seems like sometimes in CI, the bserver fails to either receive or respond to an `Authenticate` request over one TCP connection, or the message/response is dropped by docker networking.

So give that a timeout that's smaller than the overall test SyncFromServer timeout, so it doesn't cause tests to fail.

Issue: KBFS-3723
Issue: KBFS-4144