### PR TITLE
conflict_resolver: don't panic on an empty CR DB

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3224,6 +3224,9 @@ type conflictRecord struct {
 
 func getAndDeserializeConflicts(config Config, db *LevelDb,
 	key []byte) ([]conflictRecord, error) {
+	if db == nil {
+		return nil, errors.New("No conflict DB given")
+	}
 	conflictsSoFarSerialized, err := db.Get(key, nil)
 	var conflictsSoFar []conflictRecord
 	switch errors.Cause(err) {
@@ -3242,6 +3245,10 @@ func getAndDeserializeConflicts(config Config, db *LevelDb,
 
 func serializeAndPutConflicts(config Config, db *LevelDb,
 	key []byte, conflicts []conflictRecord) error {
+	if db == nil {
+		return errors.New("No conflict DB given")
+	}
+
 	conflictsSerialized, err := config.Codec().Encode(conflicts)
 	if err != nil {
 		return err


### PR DESCRIPTION
Perhaps the user is running two kbfsfuse instances, and couldn't open the DB on one of them so it's nil.

Issue: KBFS-4160