### PR TITLE
tab-bar: collapse at 800 px

### DIFF
--- a/shared/router-v2/tab-bar/tab-bar.css
+++ b/shared/router-v2/tab-bar/tab-bar.css
@@ -52,7 +52,7 @@
 .tab-badge {
 }
 
-@media all and (max-width: 700px) and (min-width: 0px) {
+@media all and (max-width: 800px) and (min-width: 0px) {
   .tab-container {
     width: 80px;
   }


### PR DESCRIPTION
This reduces the feeling of being squished by all the left bars on small windows.