### PR TITLE
Pending state while waiting for a convo to resolve

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1570,8 +1570,13 @@ const confirmScreenResponse = (_, action) => {
 // We always make adhoc convos and never preview it
 const previewConversationPersonMakesAConversation = (state, action) =>
   !action.payload.teamname &&
-  action.payload.participants &&
-  Chat2Gen.createCreateConversation({participants: action.payload.participants})
+  action.payload.participants && [
+    Chat2Gen.createSelectConversation({
+      conversationIDKey: Constants.pendingWaitingConversationIDKey,
+      reason: 'justCreated',
+    }),
+    Chat2Gen.createCreateConversation({participants: action.payload.participants}),
+  ]
 
 // We preview channels
 const previewConversationTeam = (state, action) => {
@@ -1641,6 +1646,10 @@ const _maybeAutoselectNewestConversation = (state, action, logger) => {
     avoidTeam = action.payload.teamname
   }
   let selected = Constants.getSelectedConversation(state)
+  if (selected === Constants.pendingWaitingConversationIDKey) {
+    // never auto select when we're building one
+    return
+  }
   const selectedMeta = state.chat2.metaMap.get(selected)
   if (!selectedMeta) {
     selected = Constants.noConversationIDKey

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2283,6 +2283,11 @@ function* createConversation(state, action, logger) {
   }
 
   try {
+    // TEMP
+    //
+    yield Saga.put(WaitingGen.createIncrementWaiting({key: Constants.waitingKeyCreating}))
+    // TEMP
+
     const result: RPCChatTypes.NewConversationLocalRes = yield* Saga.callPromise(
       RPCChatTypes.localNewConversationLocalRpcPromise,
       {
@@ -2293,9 +2298,15 @@ function* createConversation(state, action, logger) {
           .join(','),
         tlfVisibility: RPCTypes.commonTLFVisibility.private,
         topicType: RPCChatTypes.commonTopicType.chat,
-      },
-      Constants.waitingKeyCreating
+      }
+      // Constants.waitingKeyCreating
     )
+
+    // TEMP
+    yield Saga.callUntyped(Saga.delay, 5002)
+    yield Saga.put(WaitingGen.createDecrementWaiting({key: Constants.waitingKeyCreating}))
+    // TEMP
+    //
     const conversationIDKey = Types.conversationIDToKey(result.conv.info.id)
     if (!conversationIDKey) {
       logger.warn("Couldn't make a new conversation?")

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -2310,11 +2310,6 @@ function* createConversation(state, action, logger) {
   }
 
   try {
-    // TEMP
-    //
-    yield Saga.put(WaitingGen.createIncrementWaiting({key: Constants.waitingKeyCreating}))
-    // TEMP
-
     const result: RPCChatTypes.NewConversationLocalRes = yield* Saga.callPromise(
       RPCChatTypes.localNewConversationLocalRpcPromise,
       {
@@ -2325,15 +2320,10 @@ function* createConversation(state, action, logger) {
           .join(','),
         tlfVisibility: RPCTypes.commonTLFVisibility.private,
         topicType: RPCChatTypes.commonTopicType.chat,
-      }
-      // Constants.waitingKeyCreating
+      },
+      Constants.waitingKeyCreating
     )
 
-    // TEMP
-    yield Saga.callUntyped(Saga.delay, 5002)
-    yield Saga.put(WaitingGen.createDecrementWaiting({key: Constants.waitingKeyCreating}))
-    // TEMP
-    //
     const conversationIDKey = Types.conversationIDToKey(result.conv.info.id)
     if (!conversationIDKey) {
       logger.warn("Couldn't make a new conversation?")

--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -1569,7 +1569,7 @@ const confirmScreenResponse = (_, action) => {
 
 // We always make adhoc convos and never preview it
 const previewConversationPersonMakesAConversation = (state, action) => {
-  const participants = action.payload.participants
+  const {participants} = action.payload
   return (
     !action.payload.teamname &&
     participants && [
@@ -2080,6 +2080,12 @@ const navigateToThreadRoute = conversationIDKey => {
   let replace = false
 
   const visible = Router2Constants.getVisibleScreen()
+
+  if (!isMobile && visible?.routeName === 'chatRoot') {
+    // Don't append; we don't want to increase the size of the stack on desktop
+    return
+  }
+
   // looking at the pending screen?
   if (
     visible?.routeName === 'chatConversation' &&

--- a/shared/actions/chat2/team-building.js
+++ b/shared/actions/chat2/team-building.js
@@ -143,7 +143,6 @@ const createConversation = state => [
   Chat2Gen.createCreateConversation({
     participants: state.chat2.teamBuildingFinishedTeam.toArray().map(u => u.id),
   }),
-  RouteTreeGen.createNavigateUp(),
 ]
 
 function* chatTeamBuildingSaga(): Saga.SagaGenerator<any, any> {

--- a/shared/actions/chat2/team-building.js
+++ b/shared/actions/chat2/team-building.js
@@ -5,13 +5,12 @@ import * as ChatConstants from '../../constants/chat2'
 import * as TeamBuildingTypes from '../../constants/types/team-building'
 import * as TeamBuildingGen from '../team-building-gen'
 import * as Chat2Gen from '../chat2-gen'
-import * as WaitingGen from '../waiting-gen'
 import * as RouteTreeGen from '../route-tree-gen'
 import * as Saga from '../../util/saga'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import {type TypedState} from '../../constants/reducer'
 
-const closeTeamBuilding = () => RouteTreeGen.createNavigateUp()
+const closeTeamBuilding = () => RouteTreeGen.createClearModals()
 
 const apiSearch = (
   query: string,
@@ -149,15 +148,15 @@ function* chatTeamBuildingSaga(): Saga.SagaGenerator<any, any> {
   yield* Saga.chainAction<TeamBuildingGen.SearchPayload>(TeamBuildingGen.search, search)
   yield* Saga.chainAction<TeamBuildingGen.FetchUserRecsPayload>(TeamBuildingGen.fetchUserRecs, fetchUserRecs)
   yield* Saga.chainGenerator<TeamBuildingGen.SearchPayload>(TeamBuildingGen.search, searchResultCounts)
+  // Navigation, before creating
+  yield* Saga.chainAction<
+    TeamBuildingGen.CancelTeamBuildingPayload | TeamBuildingGen.FinishedTeamBuildingPayload
+  >([TeamBuildingGen.cancelTeamBuilding, TeamBuildingGen.finishedTeamBuilding], closeTeamBuilding)
+
   yield* Saga.chainAction<TeamBuildingGen.FinishedTeamBuildingPayload>(
     TeamBuildingGen.finishedTeamBuilding,
     createConversation
   )
-
-  // Navigation
-  yield* Saga.chainAction<
-    TeamBuildingGen.CancelTeamBuildingPayload | TeamBuildingGen.FinishedTeamBuildingPayload
-  >([TeamBuildingGen.cancelTeamBuilding, TeamBuildingGen.finishedTeamBuilding], closeTeamBuilding)
 }
 
 export default chatTeamBuildingSaga

--- a/shared/chat/conversation/header-area/normal/container.js
+++ b/shared/chat/conversation/header-area/normal/container.js
@@ -25,6 +25,7 @@ const mapStateToProps = (state, {infoPanelOpen, conversationIDKey}) => {
     channelName: meta.channelname,
     infoPanelOpen,
     muted: meta.isMuted,
+    pendingWaiting: conversationIDKey === Constants.pendingWaitingConversationIDKey,
     smallTeam: meta.teamType !== 'big',
     teamName: meta.teamname,
   }
@@ -55,6 +56,7 @@ const mergeProps = (stateProps, dispatchProps) => ({
   onToggleInfoPanel: dispatchProps.onToggleInfoPanel,
   onToggleThreadSearch: dispatchProps.onToggleThreadSearch,
   participants: stateProps._participants.toArray(),
+  pendingWaiting: stateProps.pendingWaiting,
   smallTeam: stateProps.smallTeam,
   teamName: stateProps.teamName,
   unMuteConversation: dispatchProps._onUnMuteConversation,

--- a/shared/chat/conversation/header-area/normal/index.native.js
+++ b/shared/chat/conversation/header-area/normal/index.native.js
@@ -15,28 +15,26 @@ import type {Props} from './index.types'
 const shhIconColor = globalColors.black_20
 const shhIconFontSize = 24
 
-const Wrapper = (props: {
-  badgeNumber: number,
-  children: React.Node,
-  onBack: () => void,
-  onToggleInfoPanel: () => void,
-  onToggleThreadSearch: () => void,
-}) => (
+const Wrapper = (props: {...Props, children: React.Node}) => (
   <HeaderHocHeader
     badgeNumber={props.badgeNumber}
     onLeftAction={props.onBack}
-    rightActions={[
-      {
-        icon: 'iconfont-search',
-        label: 'search',
-        onPress: props.onToggleThreadSearch,
-      },
-      {
-        icon: 'iconfont-info',
-        label: 'Info',
-        onPress: props.onToggleInfoPanel,
-      },
-    ]}
+    rightActions={
+      props.pendingWaiting
+        ? undefined
+        : [
+            {
+              icon: 'iconfont-search',
+              label: 'search',
+              onPress: props.onToggleThreadSearch,
+            },
+            {
+              icon: 'iconfont-info',
+              label: 'Info',
+              onPress: props.onToggleInfoPanel,
+            },
+          ]
+    }
     titleComponent={props.children}
   />
 )

--- a/shared/chat/conversation/header-area/normal/index.stories.js
+++ b/shared/chat/conversation/header-area/normal/index.stories.js
@@ -14,6 +14,7 @@ const defaultProps = {
   onToggleInfoPanel: Sb.action('onToggleInfoPanel'),
   onToggleThreadSearch: Sb.action('onToggleThreadSearch'),
   participants: ['joshblum', 'ayoubd'],
+  pendingWaiting: false,
   smallTeam: true,
   teamName: 'keybase',
   unMuteConversation: Sb.action('unMuteConversation'),

--- a/shared/chat/conversation/header-area/normal/index.types.js.flow
+++ b/shared/chat/conversation/header-area/normal/index.types.js.flow
@@ -11,6 +11,7 @@ export type Props = {|
   infoPanelOpen: boolean,
   teamName: ?string,
   participants: Array<string>,
+  pendingWaiting: boolean,
   smallTeam: boolean,
   unMuteConversation: () => void,
 |}

--- a/shared/chat/conversation/messages/special-top-message.js
+++ b/shared/chat/conversation/messages/special-top-message.js
@@ -17,6 +17,7 @@ type Props = {
   loadMoreType: 'moreToLoad' | 'noMoreToLoad',
   showTeamOffer: boolean,
   measure: ?() => void,
+  waitingPending: boolean,
 }
 
 class TopMessage extends React.PureComponent<Props> {
@@ -36,11 +37,18 @@ class TopMessage extends React.PureComponent<Props> {
         {this.props.hasOlderResetConversation && (
           <ProfileResetNotice conversationIDKey={this.props.conversationIDKey} />
         )}
-        {this.props.loadMoreType === 'noMoreToLoad' && !this.props.showRetentionNotice && (
-          <Kb.Box style={secureStyle}>
-            <Kb.Icon type={isMobile ? 'icon-secure-static-266' : 'icon-secure-266'} />
-          </Kb.Box>
+        {this.props.waitingPending && (
+          <Kb.Text type="BodySmallSemibold" style={loadingStyle}>
+            Loading...
+          </Kb.Text>
         )}
+        {this.props.loadMoreType === 'noMoreToLoad' &&
+          !this.props.showRetentionNotice &&
+          !this.props.waitingPending && (
+            <Kb.Box style={secureStyle}>
+              <Kb.Icon type={isMobile ? 'icon-secure-static-266' : 'icon-secure-266'} />
+            </Kb.Box>
+          )}
         {this.props.showTeamOffer && (
           <Kb.Box style={moreStyle}>
             <CreateTeamNotice />
@@ -55,6 +63,10 @@ class TopMessage extends React.PureComponent<Props> {
       </Kb.Box>
     )
   }
+}
+
+const loadingStyle = {
+  marginLeft: globalMargins.small,
 }
 
 const spacerStyle = {
@@ -79,6 +91,7 @@ type OwnProps = {
 const mapStateToProps = (state, ownProps: OwnProps) => {
   const hasLoadedEver = state.chat2.messageOrdinals.get(ownProps.conversationIDKey) !== undefined
   const meta = Constants.getMeta(state, ownProps.conversationIDKey)
+  const waitingPending = ownProps.conversationIDKey === Constants.pendingWaitingConversationIDKey
   const loadMoreType = state.chat2.moreToLoadMap.get(ownProps.conversationIDKey)
     ? 'moreToLoad'
     : 'noMoreToLoad'
@@ -99,6 +112,7 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
     loadMoreType,
     showRetentionNotice,
     showTeamOffer,
+    waitingPending,
   }
 }
 const mapDispatchToProps = dispatch => ({})

--- a/shared/chat/conversation/messages/special-top-message.js
+++ b/shared/chat/conversation/messages/special-top-message.js
@@ -17,7 +17,7 @@ type Props = {
   loadMoreType: 'moreToLoad' | 'noMoreToLoad',
   showTeamOffer: boolean,
   measure: ?() => void,
-  waitingPending: boolean,
+  pendingWaiting: boolean,
 }
 
 class TopMessage extends React.PureComponent<Props> {
@@ -37,14 +37,14 @@ class TopMessage extends React.PureComponent<Props> {
         {this.props.hasOlderResetConversation && (
           <ProfileResetNotice conversationIDKey={this.props.conversationIDKey} />
         )}
-        {this.props.waitingPending && (
+        {this.props.pendingWaiting && (
           <Kb.Text type="BodySmallSemibold" style={loadingStyle}>
             Loading...
           </Kb.Text>
         )}
         {this.props.loadMoreType === 'noMoreToLoad' &&
           !this.props.showRetentionNotice &&
-          !this.props.waitingPending && (
+          !this.props.pendingWaiting && (
             <Kb.Box style={secureStyle}>
               <Kb.Icon type={isMobile ? 'icon-secure-static-266' : 'icon-secure-266'} />
             </Kb.Box>
@@ -91,7 +91,7 @@ type OwnProps = {
 const mapStateToProps = (state, ownProps: OwnProps) => {
   const hasLoadedEver = state.chat2.messageOrdinals.get(ownProps.conversationIDKey) !== undefined
   const meta = Constants.getMeta(state, ownProps.conversationIDKey)
-  const waitingPending = ownProps.conversationIDKey === Constants.pendingWaitingConversationIDKey
+  const pendingWaiting = ownProps.conversationIDKey === Constants.pendingWaitingConversationIDKey
   const loadMoreType = state.chat2.moreToLoadMap.get(ownProps.conversationIDKey)
     ? 'moreToLoad'
     : 'noMoreToLoad'
@@ -112,7 +112,7 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
     loadMoreType,
     showRetentionNotice,
     showTeamOffer,
-    waitingPending,
+    pendingWaiting,
   }
 }
 const mapDispatchToProps = dispatch => ({})

--- a/shared/chat/conversation/messages/special-top-message.js
+++ b/shared/chat/conversation/messages/special-top-message.js
@@ -110,9 +110,9 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
     conversationIDKey: ownProps.conversationIDKey,
     hasOlderResetConversation,
     loadMoreType,
+    pendingWaiting,
     showRetentionNotice,
     showTeamOffer,
-    pendingWaiting,
   }
 }
 const mapDispatchToProps = dispatch => ({})

--- a/shared/team-building/container.js
+++ b/shared/team-building/container.js
@@ -4,6 +4,8 @@ import React from 'react'
 import * as I from 'immutable'
 import {debounce, trim} from 'lodash-es'
 import TeamBuilding from '.'
+import * as WaitingConstants from '../constants/waiting'
+import * as ChatConstants from '../constants/chat2'
 import * as TeamBuildingGen from '../actions/team-building-gen'
 import {compose, namedConnect} from '../util/container'
 import {requestIdleCallback} from '../util/idle-callback'
@@ -110,6 +112,7 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
     showServiceResultCount: deriveShowServiceResultCount(ownProps.searchString),
     teamSoFar: deriveTeamSoFar(state.chat2.teamBuildingTeamSoFar),
     userFromUserId: deriveUserFromUserIdFn(userResults, state.chat2.teamBuildingUserRecs),
+    waitingForCreate: WaitingConstants.anyWaiting(state, ChatConstants.waitingKeyCreating),
   }
 }
 
@@ -203,6 +206,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
     serviceResultCount,
     showServiceResultCount,
     recommendations,
+    waitingForCreate,
   } = stateProps
 
   const showRecs = !ownProps.searchString && !!recommendations && ownProps.selectedService === 'keybase'
@@ -278,6 +282,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
     showRecs,
     showServiceResultCount,
     teamSoFar,
+    waitingForCreate,
   }
 }
 

--- a/shared/team-building/index.js
+++ b/shared/team-building/index.js
@@ -41,6 +41,7 @@ export type Props = {
   showRecs: boolean,
   showServiceResultCount: boolean,
   teamSoFar: Array<{userId: string, prettyName: string, service: ServiceIdWithContact, username: string}>,
+  waitingForCreate: boolean,
 }
 
 class TeamBuilding extends React.PureComponent<Props, void> {
@@ -158,6 +159,11 @@ class TeamBuilding extends React.PureComponent<Props, void> {
             )}
           />
         )}
+        {props.waitingForCreate && (
+          <Kb.Box2 direction="vertical" style={styles.waiting} alignItems="center">
+            <Kb.ProgressIndicator />
+          </Kb.Box2>
+        )}
       </Kb.Box2>
     )
   }
@@ -168,6 +174,7 @@ const styles = Styles.styleSheetCreate({
     common: {
       flex: 1,
       minHeight: 200,
+      position: 'relative',
     },
     isElectron: {
       borderRadius: 4,
@@ -220,6 +227,10 @@ const styles = Styles.styleSheetCreate({
   mobileFlex: Styles.platformStyles({
     isMobile: {flex: 1},
   }),
+  waiting: {
+    ...Styles.globalStyles.fillAbsolute,
+    backgroundColor: Styles.globalColors.black_20,
+  },
 })
 
 export default TeamBuilding

--- a/shared/team-building/index.js
+++ b/shared/team-building/index.js
@@ -161,7 +161,7 @@ class TeamBuilding extends React.PureComponent<Props, void> {
         )}
         {props.waitingForCreate && (
           <Kb.Box2 direction="vertical" style={styles.waiting} alignItems="center">
-            <Kb.ProgressIndicator />
+            <Kb.ProgressIndicator type="Small" white={true} style={styles.waitingProgress} />
           </Kb.Box2>
         )}
       </Kb.Box2>
@@ -230,6 +230,10 @@ const styles = Styles.styleSheetCreate({
   waiting: {
     ...Styles.globalStyles.fillAbsolute,
     backgroundColor: Styles.globalColors.black_20,
+  },
+  waitingProgress: {
+    height: 48,
+    width: 48,
   },
 })
 

--- a/shared/team-building/index.stories.js
+++ b/shared/team-building/index.stories.js
@@ -38,6 +38,7 @@ const load = () => {
       <TeamBuilding
         searchString="chris"
         selectedService="keybase"
+        waitingForCreate={false}
         onChangeService={Sb.action('onChangeService')}
         onFinishTeamBuilding={Sb.action('onFinishTeamBuilding')}
         onChangeText={Sb.action('onChangeText')}
@@ -128,6 +129,7 @@ const load = () => {
       <TeamBuilding
         searchString=""
         selectedService="keybase"
+        waitingForCreate={false}
         onChangeService={Sb.action('onChangeService')}
         onFinishTeamBuilding={Sb.action('onFinishTeamBuilding')}
         onChangeText={Sb.action('onChangeText')}
@@ -218,6 +220,7 @@ const load = () => {
       <TeamBuilding
         searchString=""
         selectedService="keybase"
+        waitingForCreate={false}
         onChangeService={Sb.action('onChangeService')}
         onFinishTeamBuilding={Sb.action('onFinishTeamBuilding')}
         onChangeText={Sb.action('onChangeText')}
@@ -245,6 +248,7 @@ const load = () => {
       <TeamBuilding
         searchString="chris"
         selectedService="keybase"
+        waitingForCreate={false}
         onChangeService={Sb.action('onChangeService')}
         onFinishTeamBuilding={Sb.action('onFinishTeamBuilding')}
         onChangeText={Sb.action('onChangeText')}
@@ -316,6 +320,7 @@ const load = () => {
       <TeamBuilding
         searchString="chris"
         selectedService="keybase"
+        waitingForCreate={false}
         onChangeService={Sb.action('onChangeService')}
         onFinishTeamBuilding={Sb.action('onFinishTeamBuilding')}
         onChangeText={Sb.action('onChangeText')}
@@ -387,6 +392,7 @@ const load = () => {
       <TeamBuilding
         searchString="chris"
         selectedService="keybase"
+        waitingForCreate={false}
         onChangeService={Sb.action('onChangeService')}
         onFinishTeamBuilding={Sb.action('onFinishTeamBuilding')}
         onChangeText={Sb.action('onChangeText')}


### PR DESCRIPTION
@keybase/react-hackers this partially resurrects the idea of a pending waiting conversation but makes it much looser / simpler.
We already had a sentry value for this in constants so we just set it when we're going to resolve a conversation and select it. In that mode we show a simple 'loading...' text so it doesn't get annoying when if it flashes
Unlike before we don't do any kind of mapping between pending convos and resolving them, we just select the convo when its done and if we're looking at the pending we replace it