### PR TITLE
get rid of double SafeAreaViewTop on stellar send/confirm form

### DIFF
--- a/shared/wallets/confirm-form/index.js
+++ b/shared/wallets/confirm-form/index.js
@@ -25,7 +25,6 @@ type ConfirmSendProps = {|
 
 const ConfirmSend = (props: ConfirmSendProps) => (
   <Kb.MaybePopup onClose={props.onClose}>
-    <Kb.SafeAreaViewTop style={styles.backgroundColorPurple} />
     <Kb.Box2 direction="vertical" fullHeight={!Styles.isMobile} fullWidth={true} style={styles.container}>
       <Header
         onBack={props.onBack}

--- a/shared/wallets/send-form/root.js
+++ b/shared/wallets/send-form/root.js
@@ -28,13 +28,11 @@ const PoweredByStellar = () => (
 const Root = (props: Props) => {
   let child = (
     <>
-      <Kb.SafeAreaViewTop style={styles.backgroundColorPurple} />
       <Kb.Box2 direction="vertical" style={styles.container}>
         <Header isRequest={props.isRequest} onBack={Styles.isMobile ? props.onClose : null} />
         {props.children}
       </Kb.Box2>
       {!Styles.isMobile && <PoweredByStellar />}
-      <Kb.SafeAreaView style={styles.backgroundColorBlue5} />
     </>
   )
   return <Kb.MaybePopup onClose={props.onClose}>{child}</Kb.MaybePopup>


### PR DESCRIPTION
Only affects android. r? @keybase/react-hackers 