### PR TITLE
dont load messages if we're just showing up due to a nav switch

### DIFF
--- a/shared/actions/chat2/index.js
+++ b/shared/actions/chat2/index.js
@@ -922,6 +922,10 @@ function* loadMoreMessages(state, action, logger) {
     case Chat2Gen.selectConversation:
       key = action.payload.conversationIDKey
       reason = action.payload.reason || 'selected'
+      if (reason === 'focused') {
+        // don't immediately load do to a nav change. this thrashes the list too much
+        return
+      }
       break
     case Chat2Gen.metasReceived:
       if (!action.payload.clearExistingMessages) {


### PR DESCRIPTION
@keybase/react-hackers 
before if you select a convo it'd try and reload it. but if we go to reactjis or info panel and click back it'd do this which is pretty annoying