### PR TITLE
folder_block_ops: defer/re-apply dir updates for non-syncing files

### DIFF
--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -2458,15 +2458,16 @@ func (fbo *folderBlockOps) clearAllDirtyDirsLocked(
 	fbo.dirtyDirs = make(map[data.BlockPointer][]data.BlockInfo)
 	fbo.dirtyRootDirEntry = nil
 	fbo.dirtyDirsSyncing = false
+	deferredDirUpdates := fbo.deferredDirUpdates
+	fbo.deferredDirUpdates = nil
 	// Re-apply any deferred directory updates related to files that
 	// weren't synced as part of this batch.
-	for _, f := range fbo.deferredDirUpdates {
+	for _, f := range deferredDirUpdates {
 		err := f(lState)
 		if err != nil {
 			fbo.log.CWarningf(ctx, "Deferred entry update failed: %+v", err)
 		}
 	}
-	fbo.deferredDirUpdates = nil
 }
 
 // ClearCacheInfo removes any cached info for the the given file.

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5598,6 +5598,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 
 	dirtyFiles := fbo.blocks.GetDirtyFileBlockRefs(lState)
 	dirtyDirs := fbo.blocks.GetDirtyDirBlockRefs(lState)
+	defer fbo.blocks.GetDirtyDirBlockRefsDone(lState)
 	if len(dirtyFiles) == 0 && len(dirtyDirs) == 0 {
 		return nil
 	}


### PR DESCRIPTION
A user hit this scenario:

* Create file X.
* Sync the creation of that file.
* Write a whole bunch of other files in the same directory.
* Start a new `SyncAll`.
* Then another write comes in for file X, during the `SyncAll`. The write doesn't get deferred because file X isn't being synced. But the directory metadata update related to the file gets lost after the `SyncAll` completes and the metadata operations are cleared, leading to the file seeming to be truncated to 0 bytes again.

So instead, during a `SyncAll` make sure we track all the directory updates for files that aren't currently being synced, and re-apply them after the sync completes successfully.

Also add a test that repros the issue without the fix in place.

Issue: KBFS-4165