### PR TITLE
ServiceUsage in standalone followup according to Surya's feedback

### DIFF
--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -721,6 +721,7 @@ func (u Usage) UseKeyring() bool {
 	return u.KbKeyring || u.GpgKeyring
 }
 
+// If changed, make sure to correct standalone usage in g.Configure below
 var ServiceUsage = Usage{
 	Config:     true,
 	KbKeyring:  true,
@@ -741,7 +742,12 @@ func (g *GlobalContext) Configure(line CommandLine, usage Usage) error {
 	}
 	if g.Env.GetStandalone() {
 		// If standalone, override the usage to be the same as in a service
-		usage = ServiceUsage
+		// If changed, make sure to correct ServiceUsage above.
+		usage.Config = ServiceUsage.Config
+		usage.KbKeyring = ServiceUsage.KbKeyring
+		usage.GpgKeyring = ServiceUsage.GpgKeyring
+		usage.API = ServiceUsage.API
+		usage.Socket = ServiceUsage.Socket
 	}
 
 	if err := g.ConfigureUsage(usage); err != nil {


### PR DESCRIPTION
@joshblum can you think of a way to do it cleaner? My original change was as following:

```
    if g.Env.GetStandalone() {
        // If standalone, override the usage to be the same as in a service
        // ServiceUsage sets everything but AllowRoot, so copy that from the original usage
        originalAllowRoot := usage.AllowRoot
        usage = ServiceUsage
        if originalAllowRoot {
            usage.AllowRoot = true
        }
    }
```

... but really there's no good way to do it. I could use reflection but that seems to be an overkill (although it wouldn't hurt perf, it's only ran once).