### PR TITLE
RFC: Namespaced Actions

### DIFF
--- a/shared/team-building/team-box.js
+++ b/shared/team-building/team-box.js
@@ -49,11 +49,7 @@ const TeamInput = (props: Props) => (
     onDownArrowKeyDown={props.onDownArrowKeyDown}
     onUpArrowKeyDown={props.onUpArrowKeyDown}
     onBackspace={props.onBackspace}
-    placeholder={
-      props.teamSoFar.length
-        ? 'Add another username or enter to chat'
-        : 'Enter a username'
-    }
+    placeholder={props.teamSoFar.length ? 'Add another username or enter to chat' : 'Enter a username'}
     searchString={props.searchString}
   />
 )
@@ -126,7 +122,6 @@ const styles = Styles.styleSheetCreate({
       borderWidth: 1,
       maxHeight: 170,
       minHeight: 40,
-      overflowY: 'scroll',
     },
     isMobile: {
       borderBottomColor: Styles.globalColors.black_10,


### PR DESCRIPTION
@keybase/react-hackers 

I'm working on letting the team building component work in more places. Right now it uses state that's inside chat2. If we want this to be used in teams without stepping on the state stored in chat2, we need some way of knowing which state we want to look at. This is just a couple of thoughts on two different approaches. The first is the one that's a little more common for us (think `searchKey` for all the search actions)

## Two different approaches

### 1. Conventional action with key prop

- TeamBuilding actions will now all have a key prop
  - (e.g key: 'chat2', 'teams')
- Reducers filter on that key when they receive a message
- Actions have to change to handle key logic

### 2. Name-spaced actions

Would look something like this:

```
Action:
{payload: {query: string, service: string}, type: 'search'}

Namspaced Action:
{type: 'namespace', ns: 'chat2', subaction: Action}
```

Components would use it like this:

```
<TeamBuilding ns={'chat2'} ... />
```

`util/saga` will provide a chainNSAction whose function takes: `(state, ns, action, logger)` (as opposed to `(state, action, logger)`)
and a `chainNSGenerator` whose function\* similarly takes an extra `ns` prop.

### Namespaced Pros/cons

#### Pros (over 1.)

- We can type it better. i.e:

```
type Namespace = 'chat2' | 'teams' // Or even generate this from the keys of TypedState
type NSAction<Action> = {type: 'namespace', ns: Namespace, subaction: Action};
```

- Easy to use with existing actions:
  `dispatch(namespace('chat2', existingAction));`

- Existing sagas don't change very much
  e.g.

from

```
saga:
const createConversation = state =>
  Chat2Gen.createCreateConversation({
    participants: state.chat2.teamBuildingFinishedTeam.toArray().map(u => u.id),
  })

// ...
  yield* Saga.chainAction<TeamBuildingGen.FinishedTeamBuildingPayload>(
    TeamBuildingGen.finishedTeamBuilding,
    createConversation
  )

```

to

```
saga:
const createConversation = (state, ns) =>
  Chat2Gen.createCreateConversation({
    participants: state[ns].teamBuildingFinishedTeam.toArray().map(u => u.id),
  })

// ...
  yield* Saga.chainNSAction<TeamBuildingGen.FinishedTeamBuildingPayload>(
    TeamBuildingGen.finishedTeamBuilding,
    createConversation
  )
```

clean up reducers for these types of things:
before:

```
// inside reducers/chat
//...
    case TeamBuildingGen.resetStore:
    case TeamBuildingGen.cancelTeamBuilding:
    case TeamBuildingGen.addUsersToTeamSoFar:
    case TeamBuildingGen.removeUsersFromTeamSoFar:
    case TeamBuildingGen.searchResultsLoaded:
    case TeamBuildingGen.finishedTeamBuilding:
    case TeamBuildingGen.search:
    case TeamBuildingGen.fetchedUserRecs:
    case TeamBuildingGen.fetchUserRecs:
      return teamBuildingReducer(state, action)
// ...
```

after:

```
// inside reducers/chat
//...
    case NSAction:
      return teamBuildingReducer(state, action.subaction)
// ...
```

after (in the case of multiple namespaced reducers):

```
// inside reducers/chat
//...
    case NSAction:
       // (this can be defined outside the reducer fn so it's not creating an array everytime)
       const nsReducers = [teamBuildingReducer, otherNSReducer, finalNSReducer]

       // reduce over all subreducers
       // Open question: Is flow okay with this?
       nsReducers.reduce((state, reducer) => reducer(state, action.subAction), state)
// ...
```

- Flow should complain if `state[ns].teamBuilding...` isn't defined.

#### Cons

- Adds a new pattern that has not been used yet.
- Adds another way to handle actions (we already have too many)
- Consumers of a component have to know that you have to dispatch namespaced actions. It may fail silently if you don't do this. (we could add a warning to catch these kind of things)
  - This is really just an issue when you are writing the `connect`. If you are just using the connected component, flow should tell you that you are missing the `ns` prop.
