### PR TITLE
Account settings with phone/email storybook

### DIFF
--- a/shared/common-adapters/floating-menu/menu-layout/index.desktop.js
+++ b/shared/common-adapters/floating-menu/menu-layout/index.desktop.js
@@ -52,6 +52,7 @@ class MenuLayout extends Component<MenuLayoutProps> {
                 style={styles.badge}
               />
             )}
+            {item.decoration}
           </Box>
         )}
         {!item.view && item.subTitle && (

--- a/shared/common-adapters/floating-menu/menu-layout/index.js.flow
+++ b/shared/common-adapters/floating-menu/menu-layout/index.js.flow
@@ -3,6 +3,7 @@ import * as React from 'react'
 
 export type MenuItem = {|
   danger?: boolean,
+  decoration?: React.Node, // on the right side. unused if `view` is given
   disabled?: boolean,
   newTag?: ?boolean,
   onClick?: ?(evt?: SyntheticEvent<>) => void,
@@ -22,7 +23,7 @@ export type MenuLayoutProps = {
   closeOnClick?: boolean,
   style?: Object,
   hoverColor?: string,
-  closeText?:?string, // mobile only; default to "Close"
+  closeText?: ?string, // mobile only; default to "Close"
 }
 
 export default class MenuLayout extends React.Component<MenuLayoutProps> {}

--- a/shared/common-adapters/floating-menu/menu-layout/index.native.js
+++ b/shared/common-adapters/floating-menu/menu-layout/index.native.js
@@ -31,12 +31,14 @@ const MenuRow = (props: MenuRowProps) => (
     {props.view || (
       <>
         <Box2 direction="horizontal" fullWidth={true} centerChildren={true}>
+          {props.decoration && <Box style={styles.flexOne} />}
           <Text center={true} type="BodyBig" style={styleRowText(props)}>
             {props.title}
           </Text>
           {props.newTag && (
             <Meta title="New" size="Small" backgroundColor={Styles.globalColors.blue} style={styles.badge} />
           )}
+          {props.decoration && <Box style={styles.flexOne}>{props.decoration}</Box>}
         </Box2>
         {!!props.subTitle && (
           <Text center={true} type="BodyTiny">
@@ -118,6 +120,9 @@ const styles = Styles.styleSheetCreate({
   },
   flexGrow: {
     flexGrow: 1,
+  },
+  flexOne: {
+    flex: 1,
   },
   itemContainer: {
     ...Styles.globalStyles.flexBoxColumn,

--- a/shared/settings/account/email-phone-row.js
+++ b/shared/settings/account/email-phone-row.js
@@ -21,6 +21,16 @@ const addSpacer = (into: string, add: string) => {
   return into + (into.length ? ' • ' : '') + add
 }
 
+const badge = (backgroundColor: string, menuItem: boolean = false) => (
+  <Kb.Box
+    style={Styles.collapseStyles([
+      styles.badge,
+      menuItem ? styles.badgeMenuItem : styles.badgeGearIcon,
+      {backgroundColor},
+    ])}
+  />
+)
+
 const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
   let subtitle = ''
   if (props.type === 'email' && props.primary) {
@@ -33,8 +43,11 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
 
   const menuItems = []
   if (!props.verified) {
-    // TODO badge
-    menuItems.push({onClick: props.onVerify, title: 'Verify'})
+    menuItems.push({
+      decoration: props.verified ? undefined : badge(Styles.globalColors.orange, true),
+      onClick: props.onVerify,
+      title: 'Verify',
+    })
   }
   if (props.type === 'email' && !props.primary && props.verified) {
     menuItems.push({
@@ -45,6 +58,7 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
   }
   if (props.verified) {
     menuItems.push({
+      decoration: props.searchable ? undefined : badge(Styles.globalColors.blue, true),
       onClick: props.onToggleSearchable,
       subTitle: props.searchable
         ? 'Disallow friends to find you by this email.'
@@ -53,6 +67,13 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
     })
   }
   menuItems.push('Divider', {danger: true, onClick: props.onDelete, title: 'Delete'})
+
+  let gearIconBadge = null
+  if (!props.verified) {
+    gearIconBadge = badge(Styles.globalColors.orange)
+  } else if (!props.searchable) {
+    gearIconBadge = badge(Styles.globalColors.blue)
+  }
 
   return (
     <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true} style={styles.container}>
@@ -65,7 +86,10 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
           </Kb.Box2>
         )}
       </Kb.Box2>
-      <Kb.Icon type="iconfont-gear" ref={props.setAttachmentRef} onClick={props.toggleShowingMenu} />
+      <Kb.Box style={styles.positionRelative}>
+        <Kb.Icon type="iconfont-gear" ref={props.setAttachmentRef} onClick={props.toggleShowingMenu} />
+        {gearIconBadge}
+      </Kb.Box>
       <Kb.FloatingMenu
         attachTo={props.getAttachmentRef}
         closeText="Cancel"
@@ -82,6 +106,20 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
 const EmailPhoneRow = Kb.OverlayParentHOC(_EmailPhoneRow)
 
 const styles = Styles.styleSheetCreate({
+  badge: {
+    borderRadius: Styles.isMobile ? 5 : 4,
+    height: Styles.isMobile ? 10 : 8,
+    width: Styles.isMobile ? 10 : 8,
+  },
+  badgeGearIcon: {
+    position: 'absolute',
+    right: -3,
+    top: -2,
+  },
+  badgeMenuItem: {
+    alignSelf: 'center',
+    marginLeft: 'auto',
+  },
   container: {
     height: Styles.isMobile ? 48 : 40,
   },
@@ -89,6 +127,7 @@ const styles = Styles.styleSheetCreate({
     flex: 1,
   },
   menuNoGrow: Styles.platformStyles({isElectron: {width: 220}}),
+  positionRelative: {position: 'relative'},
 })
 
 // props exported for stories

--- a/shared/settings/account/email-phone-row.js
+++ b/shared/settings/account/email-phone-row.js
@@ -7,30 +7,88 @@ import * as Container from '../../util/container'
 // props exported for stories
 export type Props = {|
   address: string,
-  unverified: boolean,
-  subtitle: string,
+  onDelete: () => void,
+  onMakePrimary: () => void,
+  onToggleSearchable: () => void,
+  onVerify: () => void,
+  primary: boolean, // only applies to 'email'
+  searchable: boolean,
+  type: 'phone' | 'email',
+  verified: boolean,
 |}
 
-const EmailPhoneRow = (props: Props) => {
+const addSpacer = (into: string, add: string) => {
+  return into + (into.length ? ' • ' : '') + add
+}
+
+const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
+  let subtitle = ''
+  if (props.type === 'email' && props.primary) {
+    subtitle = addSpacer(subtitle, 'Primary email')
+    // TODO 'Check your inbox' if verification email was just sent
+  }
+  if (!props.searchable) {
+    subtitle = addSpacer(subtitle, 'Not searchable')
+  }
+
+  const menuItems = []
+  if (!props.verified) {
+    // TODO badge
+    menuItems.push({onClick: props.onVerify, title: 'Verify'})
+  }
+  if (props.type === 'email' && !props.primary && props.verified) {
+    menuItems.push({
+      onClick: props.onMakePrimary,
+      subTitle: 'Use this email for important notifications.',
+      title: 'Make primary',
+    })
+  }
+  if (props.verified) {
+    menuItems.push({
+      onClick: props.onToggleSearchable,
+      subTitle: props.searchable
+        ? 'Disallow friends to find you by this email.'
+        : `${Styles.isMobile ? '' : '(Recommended) '}Allow friends to find you by this email.`,
+      title: props.searchable ? "Don't make searchable" : 'Make searchable',
+    })
+  }
+  menuItems.push('Divider', {danger: true, onClick: props.onDelete, title: 'Delete'})
+
   return (
     <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true} style={styles.container}>
-      <Kb.Box2 alignItems="flex-start" direction="vertical">
+      <Kb.Box2 alignItems="flex-start" direction="vertical" style={styles.flexOne}>
         <Kb.Text type="BodySemibold">{props.address}</Kb.Text>
-        {(!!props.subtitle || props.unverified) && (
-          <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true}>
-            {props.unverified && <Kb.Meta backgroundColor={Styles.globalColors.red} title="UNVERIFIED" />}
-            {!!props.subtitle && <Kb.Text type="BodySmall">{props.subtitle}</Kb.Text>}
+        {(!!subtitle || !props.verified) && (
+          <Kb.Box2 direction="horizontal" alignItems="flex-start" gap="xtiny" fullWidth={true}>
+            {!props.verified && <Kb.Meta backgroundColor={Styles.globalColors.red} title="UNVERIFIED" />}
+            {!!subtitle && <Kb.Text type="BodySmall">{subtitle}</Kb.Text>}
           </Kb.Box2>
         )}
       </Kb.Box2>
+      <Kb.Icon type="iconfont-gear" ref={props.setAttachmentRef} onClick={props.toggleShowingMenu} />
+      <Kb.FloatingMenu
+        attachTo={props.getAttachmentRef}
+        closeText="Cancel"
+        containerStyle={styles.menuNoGrow}
+        visible={props.showingMenu}
+        position="bottom right"
+        items={menuItems}
+        closeOnSelect={true}
+        onHidden={props.toggleShowingMenu}
+      />
     </Kb.Box2>
   )
 }
+const EmailPhoneRow = Kb.OverlayParentHOC(_EmailPhoneRow)
 
 const styles = Styles.styleSheetCreate({
   container: {
     height: Styles.isMobile ? 48 : 40,
   },
+  flexOne: {
+    flex: 1,
+  },
+  menuNoGrow: Styles.platformStyles({isElectron: {width: 220}}),
 })
 
 // props exported for stories
@@ -43,8 +101,14 @@ const mapStateToProps = (state, ownProps) => ({})
 const mapDispatchToProps = dispatch => ({})
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   address: '',
-  subtitle: '',
-  unverified: false,
+  onDelete: () => {},
+  onMakePrimary: () => {},
+  onToggleSearchable: () => {},
+  onVerify: () => {},
+  primary: false,
+  searchable: false,
+  type: 'phone',
+  verified: false,
 })
 
 const ConnectedEmailPhoneRow = Container.namedConnect<OwnProps, _, _, _, _>(

--- a/shared/settings/account/email-phone-row.js
+++ b/shared/settings/account/email-phone-row.js
@@ -75,6 +75,16 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
     gearIconBadge = badge(Styles.globalColors.blue)
   }
 
+  const header = {
+    title: 'emailPhoneHeader',
+    view: (
+      <Kb.Box2 direction="vertical" centerChildren={true} style={styles.menuHeader}>
+        <Kb.Text type="BodySmallSemibold">{props.address}</Kb.Text>
+        {props.primary && <Kb.Text type="BodySmall">Primary email</Kb.Text>}
+      </Kb.Box2>
+    ),
+  }
+
   return (
     <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true} style={styles.container}>
       <Kb.Box2 alignItems="flex-start" direction="vertical" style={styles.flexOne}>
@@ -96,6 +106,7 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
         containerStyle={styles.menuNoGrow}
         visible={props.showingMenu}
         position="bottom right"
+        header={Styles.isMobile ? header : null}
         items={menuItems}
         closeOnSelect={true}
         onHidden={props.toggleShowingMenu}
@@ -125,6 +136,9 @@ const styles = Styles.styleSheetCreate({
   },
   flexOne: {
     flex: 1,
+  },
+  menuHeader: {
+    height: 64,
   },
   menuNoGrow: Styles.platformStyles({isElectron: {width: 220}}),
   positionRelative: {position: 'relative'},

--- a/shared/settings/account/email-phone-row.js
+++ b/shared/settings/account/email-phone-row.js
@@ -87,7 +87,7 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
 
   return (
     <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true} style={styles.container}>
-      <Kb.Box2 alignItems="flex-start" direction="vertical" style={styles.flexOne}>
+      <Kb.Box2 alignItems="flex-start" direction="vertical" style={{...Styles.globalStyles.flexOne}}>
         <Kb.Text type="BodySemibold">{props.address}</Kb.Text>
         {(!!subtitle || !props.verified) && (
           <Kb.Box2 direction="horizontal" alignItems="flex-start" gap="xtiny" fullWidth={true}>
@@ -133,9 +133,6 @@ const styles = Styles.styleSheetCreate({
   },
   container: {
     height: Styles.isMobile ? 48 : 40,
-  },
-  flexOne: {
-    flex: 1,
   },
   menuHeader: {
     height: 64,

--- a/shared/settings/account/email-phone-row.js
+++ b/shared/settings/account/email-phone-row.js
@@ -1,0 +1,57 @@
+// @flow
+import * as React from 'react'
+import * as Kb from '../../common-adapters'
+import * as Styles from '../../styles'
+import * as Container from '../../util/container'
+
+// props exported for stories
+export type Props = {|
+  address: string,
+  unverified: boolean,
+  subtitle: string,
+|}
+
+const EmailPhoneRow = (props: Props) => {
+  return (
+    <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true} style={styles.container}>
+      <Kb.Box2 alignItems="flex-start" direction="vertical">
+        <Kb.Text type="BodySemibold">{props.address}</Kb.Text>
+        {(!!props.subtitle || props.unverified) && (
+          <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true}>
+            {props.unverified && <Kb.Meta backgroundColor={Styles.globalColors.red} title="UNVERIFIED" />}
+            {!!props.subtitle && <Kb.Text type="BodySmall">{props.subtitle}</Kb.Text>}
+          </Kb.Box2>
+        )}
+      </Kb.Box2>
+    </Kb.Box2>
+  )
+}
+
+const styles = Styles.styleSheetCreate({
+  container: {
+    height: Styles.isMobile ? 48 : 40,
+  },
+})
+
+// props exported for stories
+export type OwnProps = {|
+  contactKey: string,
+|}
+
+// TODO mocked for now
+const mapStateToProps = (state, ownProps) => ({})
+const mapDispatchToProps = dispatch => ({})
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  address: '',
+  subtitle: '',
+  unverified: false,
+})
+
+const ConnectedEmailPhoneRow = Container.namedConnect<OwnProps, _, _, _, _>(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+  'ConnectedEmailPhoneRow'
+)(EmailPhoneRow)
+
+export default ConnectedEmailPhoneRow

--- a/shared/settings/account/index.js
+++ b/shared/settings/account/index.js
@@ -1,0 +1,89 @@
+// @flow
+import * as React from 'react'
+import * as Kb from '../../common-adapters'
+import * as Styles from '../../styles'
+
+type Props = {|
+  onAddEmail: () => void,
+  onAddPhone: () => void,
+  onDeleteAccount: () => void,
+  onSetPassword: () => void,
+|}
+
+const AccountSettings = (props: Props) => {
+  return (
+    <Kb.ScrollView>
+      <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
+        {/* Email + Phone */}
+        <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
+          <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
+            <Kb.Text type="Header">Email & phone</Kb.Text>
+            <Kb.Text type="BodySmall">
+              Secures your account by letting us send important notifications, and allows friends and
+              teammates to find you by phone number or email.
+            </Kb.Text>
+          </Kb.Box2>
+          <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
+            <Kb.Button mode="Secondary" onClick={props.onAddEmail} label="Add email" small={true} />
+            <Kb.Button mode="Secondary" onClick={props.onAddPhone} label="Add phone" small={true} />
+          </Kb.ButtonBar>
+        </Kb.Box2>
+
+        {/* Password */}
+        <Kb.Divider />
+        <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
+          <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
+            <Kb.Text type="Header">Password</Kb.Text>
+            <Kb.Text type="BodySmall">
+              Allows you to log out and log back in, and use the keybase.io website.
+            </Kb.Text>
+          </Kb.Box2>
+          <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
+            <Kb.Button mode="Secondary" onClick={props.onSetPassword} label="Set a password" small={true} />
+          </Kb.ButtonBar>
+        </Kb.Box2>
+
+        {/* Delete account */}
+        <Kb.Divider />
+        <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
+          <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
+            <Kb.Text type="Header">Delete account</Kb.Text>
+            <Kb.Text type="BodySmall">
+              This can not be undone. You won’t be able to create a new account with the same username.
+            </Kb.Text>
+          </Kb.Box2>
+          <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
+            <Kb.Button
+              type="Danger"
+              mode="Secondary"
+              onClick={props.onDeleteAccount}
+              label="Delete account"
+              small={true}
+            />
+          </Kb.ButtonBar>
+        </Kb.Box2>
+      </Kb.Box2>
+    </Kb.ScrollView>
+  )
+}
+
+const styles = Styles.styleSheetCreate({
+  buttonBar: {
+    minHeight: undefined,
+  },
+  section: Styles.platformStyles({
+    isElectron: {
+      ...Styles.padding(
+        Styles.globalMargins.small,
+        Styles.globalMargins.mediumLarge,
+        Styles.globalMargins.medium,
+        Styles.globalMargins.small
+      ),
+    },
+    isMobile: {
+      ...Styles.padding(Styles.globalMargins.small, Styles.globalMargins.small, Styles.globalMargins.medium),
+    },
+  }),
+})
+
+export default AccountSettings

--- a/shared/settings/account/index.js
+++ b/shared/settings/account/index.js
@@ -4,6 +4,7 @@ import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 
 type Props = {|
+  hasPassword: boolean,
   onAddEmail: () => void,
   onAddPhone: () => void,
   onDeleteAccount: () => void,
@@ -11,6 +12,10 @@ type Props = {|
 |}
 
 const AccountSettings = (props: Props) => {
+  let passwordLabel = props.hasPassword ? 'Change password' : 'Set a password'
+  if (props.hasPassword && Styles.isMobile) {
+    passwordLabel = 'Change'
+  }
   return (
     <Kb.ScrollView>
       <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
@@ -38,9 +43,16 @@ const AccountSettings = (props: Props) => {
               Allows you to log out and log back in, and use the keybase.io website.
             </Kb.Text>
           </Kb.Box2>
-          <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
-            <Kb.Button mode="Secondary" onClick={props.onSetPassword} label="Set a password" small={true} />
-          </Kb.ButtonBar>
+          <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true}>
+            {props.hasPassword && (
+              <Kb.Text type="BodySemibold" style={styles.password}>
+                ********************
+              </Kb.Text>
+            )}
+            <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
+              <Kb.Button mode="Secondary" onClick={props.onSetPassword} label={passwordLabel} small={true} />
+            </Kb.ButtonBar>
+          </Kb.Box2>
         </Kb.Box2>
 
         {/* Delete account */}
@@ -70,6 +82,10 @@ const AccountSettings = (props: Props) => {
 const styles = Styles.styleSheetCreate({
   buttonBar: {
     minHeight: undefined,
+    width: undefined,
+  },
+  password: {
+    flexGrow: 1,
   },
   section: Styles.platformStyles({
     isElectron: {

--- a/shared/settings/account/index.js
+++ b/shared/settings/account/index.js
@@ -2,8 +2,10 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
+import EmailPhoneRow from './email-phone-row'
 
 type Props = {|
+  contactKeys: Array<string>,
   hasPassword: boolean,
   onAddEmail: () => void,
   onAddPhone: () => void,
@@ -28,6 +30,13 @@ const AccountSettings = (props: Props) => {
               teammates to find you by phone number or email.
             </Kb.Text>
           </Kb.Box2>
+          {!!props.contactKeys.length && (
+            <Kb.Box2 direction="vertical" style={styles.contactRows} fullWidth={true}>
+              {props.contactKeys.map(ck => (
+                <EmailPhoneRow contactKey={ck} key={ck} />
+              ))}
+            </Kb.Box2>
+          )}
           <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
             <Kb.Button mode="Secondary" onClick={props.onAddEmail} label="Add email" small={true} />
             <Kb.Button mode="Secondary" onClick={props.onAddPhone} label="Add phone" small={true} />
@@ -84,7 +93,13 @@ const styles = Styles.styleSheetCreate({
     minHeight: undefined,
     width: undefined,
   },
+  contactRows: Styles.platformStyles({
+    isElectron: {
+      paddingTop: Styles.globalMargins.xtiny,
+    },
+  }),
   password: {
+    ...Styles.padding(Styles.globalMargins.xsmall, 0),
     flexGrow: 1,
   },
   section: Styles.platformStyles({

--- a/shared/settings/account/index.js
+++ b/shared/settings/account/index.js
@@ -13,80 +13,89 @@ type Props = {|
   onSetPassword: () => void,
 |}
 
-const AccountSettings = (props: Props) => {
-  let passwordLabel = props.hasPassword ? 'Change password' : 'Set a password'
-  if (props.hasPassword && Styles.isMobile) {
-    passwordLabel = 'Change'
+const EmailPhone = props => (
+  <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
+    <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
+      <Kb.Text type="Header">Email & phone</Kb.Text>
+      <Kb.Text type="BodySmall">
+        Secures your account by letting us send important notifications, and allows friends and teammates to
+        find you by phone number or email.
+      </Kb.Text>
+    </Kb.Box2>
+    {!!props.contactKeys.length && (
+      <Kb.Box2 direction="vertical" style={styles.contactRows} fullWidth={true}>
+        {props.contactKeys.map(ck => (
+          <EmailPhoneRow contactKey={ck} key={ck} />
+        ))}
+      </Kb.Box2>
+    )}
+    <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
+      <Kb.Button mode="Secondary" onClick={props.onAddEmail} label="Add email" small={true} />
+      <Kb.Button mode="Secondary" onClick={props.onAddPhone} label="Add phone" small={true} />
+    </Kb.ButtonBar>
+  </Kb.Box2>
+)
+
+const Password = props => {
+  let passwordLabel
+  if (props.hasPassword) {
+    passwordLabel = Styles.isMobile ? 'Change' : 'Change password'
+  } else {
+    passwordLabel = 'Set a password'
   }
   return (
-    <Kb.ScrollView>
-      <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
-        {/* Email + Phone */}
-        <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
-          <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
-            <Kb.Text type="Header">Email & phone</Kb.Text>
-            <Kb.Text type="BodySmall">
-              Secures your account by letting us send important notifications, and allows friends and
-              teammates to find you by phone number or email.
-            </Kb.Text>
-          </Kb.Box2>
-          {!!props.contactKeys.length && (
-            <Kb.Box2 direction="vertical" style={styles.contactRows} fullWidth={true}>
-              {props.contactKeys.map(ck => (
-                <EmailPhoneRow contactKey={ck} key={ck} />
-              ))}
-            </Kb.Box2>
-          )}
-          <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
-            <Kb.Button mode="Secondary" onClick={props.onAddEmail} label="Add email" small={true} />
-            <Kb.Button mode="Secondary" onClick={props.onAddPhone} label="Add phone" small={true} />
-          </Kb.ButtonBar>
-        </Kb.Box2>
-
-        {/* Password */}
-        <Kb.Divider />
-        <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
-          <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
-            <Kb.Text type="Header">Password</Kb.Text>
-            <Kb.Text type="BodySmall">
-              Allows you to log out and log back in, and use the keybase.io website.
-            </Kb.Text>
-          </Kb.Box2>
-          <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true}>
-            {props.hasPassword && (
-              <Kb.Text type="BodySemibold" style={styles.password}>
-                ********************
-              </Kb.Text>
-            )}
-            <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
-              <Kb.Button mode="Secondary" onClick={props.onSetPassword} label={passwordLabel} small={true} />
-            </Kb.ButtonBar>
-          </Kb.Box2>
-        </Kb.Box2>
-
-        {/* Delete account */}
-        <Kb.Divider />
-        <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
-          <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
-            <Kb.Text type="Header">Delete account</Kb.Text>
-            <Kb.Text type="BodySmall">
-              This can not be undone. You won’t be able to create a new account with the same username.
-            </Kb.Text>
-          </Kb.Box2>
-          <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
-            <Kb.Button
-              type="Danger"
-              mode="Secondary"
-              onClick={props.onDeleteAccount}
-              label="Delete account"
-              small={true}
-            />
-          </Kb.ButtonBar>
-        </Kb.Box2>
+    <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
+      <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
+        <Kb.Text type="Header">Password</Kb.Text>
+        <Kb.Text type="BodySmall">
+          Allows you to log out and log back in, and use the keybase.io website.
+        </Kb.Text>
       </Kb.Box2>
-    </Kb.ScrollView>
+      <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true}>
+        {props.hasPassword && (
+          <Kb.Text type="BodySemibold" style={styles.password}>
+            ********************
+          </Kb.Text>
+        )}
+        <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
+          <Kb.Button mode="Secondary" onClick={props.onSetPassword} label={passwordLabel} small={true} />
+        </Kb.ButtonBar>
+      </Kb.Box2>
+    </Kb.Box2>
   )
 }
+
+const DeleteAccount = props => (
+  <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
+    <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
+      <Kb.Text type="Header">Delete account</Kb.Text>
+      <Kb.Text type="BodySmall">
+        This can not be undone. You won’t be able to create a new account with the same username.
+      </Kb.Text>
+    </Kb.Box2>
+    <Kb.ButtonBar align="flex-start" style={styles.buttonBar}>
+      <Kb.Button
+        type="Danger"
+        mode="Secondary"
+        onClick={props.onDeleteAccount}
+        label="Delete account"
+        small={true}
+      />
+    </Kb.ButtonBar>
+  </Kb.Box2>
+)
+
+const AccountSettings = (props: Props) => (
+  <Kb.ScrollView>
+    <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
+      <EmailPhone {...props} />
+      <Kb.Divider />
+      <Password {...props} />
+      <Kb.Divider />
+      <DeleteAccount {...props} />
+    </Kb.Box2>
+  </Kb.ScrollView>
+)
 
 const styles = Styles.styleSheetCreate({
   buttonBar: {

--- a/shared/settings/account/index.stories.js
+++ b/shared/settings/account/index.stories.js
@@ -13,19 +13,26 @@ const props = {
   onSetPassword: Sb.action('onSetPassword'),
 }
 
-const contacts = {
-  a: {address: 'cecile@keyba.se', subtitle: '', unverified: false},
-  b: {address: 'cecile@keyba.se', subtitle: 'Not searchable', unverified: false},
-  c: {address: 'cecile@keyba.se', subtitle: 'Primary email • Not searchable', unverified: false},
-  d: {address: 'cecile@keyba.se', subtitle: 'Primary email', unverified: true},
-  e: {address: 'cecile@keyba.se', subtitle: 'Check your inbox', unverified: true},
-  f: {address: '+33 6 76 38 86 97', subtitle: '', unverified: false},
-  g: {address: '+33 6 76 38 86 97', subtitle: 'Not searchable', unverified: false},
-  h: {address: '+33 6 76 38 86 97', subtitle: '', unverified: true},
+const cc = {
+  onDelete: Sb.action('onDelete'),
+  onMakePrimary: Sb.action('onMakePrimary'),
+  onToggleSearchable: Sb.action('onToggleSearchable'),
+  onVerify: Sb.action('onVerify'),
+}
+// prettier-ignore
+const contacts: {[key: string]: ContactRowProps} = {
+  a: {...cc, address: 'cecile@keyba.se', primary: false, searchable: true, type: 'email', verified: true},
+  b: {...cc, address: 'cecile@keyba.se', primary: false, searchable: false, type: 'email', verified: true},
+  c: {...cc, address: 'cecile@keyba.se', primary: true, searchable: false, type: 'email', verified: true},
+  d: {...cc, address: 'cecile@keyba.se', primary: true, searchable: true, type: 'email', verified: false},
+  e: {...cc, address: 'cecile@keyba.se', primary: false, searchable: true, type: 'email', verified: false},
+  f: {...cc, address: '+33 6 76 38 86 97', primary: false, searchable: true, type: 'phone', verified: true},
+  g: {...cc, address: '+33 6 76 38 86 97', primary: false, searchable: false, type: 'phone', verified: true},
+  h: {...cc, address: '+33 6 76 38 86 97', primary: false, searchable: true, type: 'phone', verified: false},
 }
 
 const provider = Sb.createPropProvider({
-  ConnectedEmailPhoneRow: ({contactKey}: ContactRowOwnProps): ContactRowProps => contacts[contactKey],
+  ConnectedEmailPhoneRow: ({contactKey}: ContactRowOwnProps) => contacts[contactKey],
 })
 
 const load = () => {

--- a/shared/settings/account/index.stories.js
+++ b/shared/settings/account/index.stories.js
@@ -1,0 +1,17 @@
+// @flow
+import * as React from 'react'
+import * as Sb from '../../stories/storybook'
+import AccountSettings from '.'
+
+const props = {
+  onAddEmail: Sb.action('onAddEmail'),
+  onAddPhone: Sb.action('onAddPhone'),
+  onDeleteAccount: Sb.action('onDeleteAccount'),
+  onSetPassword: Sb.action('onSetPassword'),
+}
+
+const load = () => {
+  Sb.storiesOf('Settings/Account', module).add('Empty', () => <AccountSettings {...props} />)
+}
+
+export default load

--- a/shared/settings/account/index.stories.js
+++ b/shared/settings/account/index.stories.js
@@ -1,9 +1,11 @@
 // @flow
 import * as React from 'react'
 import * as Sb from '../../stories/storybook'
+import type {Props as ContactRowProps, OwnProps as ContactRowOwnProps} from './email-phone-row'
 import AccountSettings from '.'
 
 const props = {
+  contactKeys: [],
   hasPassword: false,
   onAddEmail: Sb.action('onAddEmail'),
   onAddPhone: Sb.action('onAddPhone'),
@@ -11,10 +13,27 @@ const props = {
   onSetPassword: Sb.action('onSetPassword'),
 }
 
+const contacts = {
+  a: {address: 'cecile@keyba.se', subtitle: '', unverified: false},
+  b: {address: 'cecile@keyba.se', subtitle: 'Not searchable', unverified: false},
+  c: {address: 'cecile@keyba.se', subtitle: 'Primary email • Not searchable', unverified: false},
+  d: {address: 'cecile@keyba.se', subtitle: 'Primary email', unverified: true},
+  e: {address: 'cecile@keyba.se', subtitle: 'Check your inbox', unverified: true},
+  f: {address: '+33 6 76 38 86 97', subtitle: '', unverified: false},
+  g: {address: '+33 6 76 38 86 97', subtitle: 'Not searchable', unverified: false},
+  h: {address: '+33 6 76 38 86 97', subtitle: '', unverified: true},
+}
+
+const provider = Sb.createPropProvider({
+  ConnectedEmailPhoneRow: ({contactKey}: ContactRowOwnProps): ContactRowProps => contacts[contactKey],
+})
+
 const load = () => {
   Sb.storiesOf('Settings/Account', module)
+    .addDecorator(provider)
     .add('Empty', () => <AccountSettings {...props} />)
     .add('With password', () => <AccountSettings {...props} hasPassword={true} />)
+    .add('With email/phone', () => <AccountSettings {...props} contactKeys={Object.keys(contacts)} />)
 }
 
 export default load

--- a/shared/settings/account/index.stories.js
+++ b/shared/settings/account/index.stories.js
@@ -4,6 +4,7 @@ import * as Sb from '../../stories/storybook'
 import AccountSettings from '.'
 
 const props = {
+  hasPassword: false,
   onAddEmail: Sb.action('onAddEmail'),
   onAddPhone: Sb.action('onAddPhone'),
   onDeleteAccount: Sb.action('onDeleteAccount'),
@@ -11,7 +12,9 @@ const props = {
 }
 
 const load = () => {
-  Sb.storiesOf('Settings/Account', module).add('Empty', () => <AccountSettings {...props} />)
+  Sb.storiesOf('Settings/Account', module)
+    .add('Empty', () => <AccountSettings {...props} />)
+    .add('With password', () => <AccountSettings {...props} hasPassword={true} />)
 }
 
 export default load

--- a/shared/settings/index.stories.js
+++ b/shared/settings/index.stories.js
@@ -1,4 +1,5 @@
 // @flow
+import account from './account/index.stories'
 import deleteConfirm from './delete-confirm/index.stories'
 import deleteMe from './delete/index.stories'
 import email from './email/index.stories'
@@ -13,6 +14,7 @@ import files from './files/index.stories'
 
 const load = () => {
   ;[
+    account,
     email,
     password,
     deleteMe,

--- a/shared/storybook/addons.js
+++ b/shared/storybook/addons.js
@@ -1,3 +1,3 @@
 // @flow
 // DONT import this from anywhere, only the server side does this
-import '@storybook/addon-actions'
+import '@storybook/addon-actions/register'

--- a/shared/styles/index.js.flow
+++ b/shared/styles/index.js.flow
@@ -17,6 +17,7 @@ declare export var globalStyles: {
   flexBoxRow: {|flexDirection: 'row'|},
   flexBoxRowReverse: {|flexDirection: 'row-reverse'|},
   flexGrow: {|flexGrow: 1|},
+  flexOne: {|flex: 1|},
   fontBold: {|fontFamily: 'Keybase', fontWeight: '700', fontStyle: 'normal'|},
   fontExtrabold: _fakeFontDefSeeCommentsOnThisStyle,
   fontRegular: _fakeFontDefSeeCommentsOnThisStyle,

--- a/shared/styles/shared.js
+++ b/shared/styles/shared.js
@@ -49,6 +49,7 @@ export const util = ({flexCommon}: {flexCommon?: ?Object}) => ({
   flexBoxRow: {...flexCommon, flexDirection: 'row'},
   flexBoxRowReverse: {...flexCommon, flexDirection: 'row-reverse'},
   flexGrow: {flexGrow: 1},
+  flexOne: {flex: 1},
   fullHeight: {height: '100%'},
   rounded: {borderRadius: 3},
 })


### PR DESCRIPTION
<img width="854" alt="image" src="https://user-images.githubusercontent.com/11968340/57728538-27e98a00-7662-11e9-928f-481e6a4ead56.png">

Also:
* Fix actions addon in native storybook
* Add `decoration` prop to menu items for stuff that goes to the right of the title

Part 2 will be "confirm remove email/phone" dialog

- [ ] Storyshots before merge

r? @keybase/react-hackers 