### PR TITLE
[Android HOTFIX] Fix paste on TextInput

### DIFF
--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "4.0.0"
+const Version = "4.0.1"

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -4,16 +4,12 @@
 import React, {Component} from 'react'
 import Box from './box'
 import Text, {getStyle as getTextStyle} from './text'
-// import {NativeTextInput} from './native-wrappers.native'
+import NativeTextInput from './kb-text-input.native'
 import {collapseStyles, globalStyles, globalColors, styleSheetCreate} from '../styles'
 import {isIOS, isAndroid} from '../constants/platform'
-// ImageView.js
-import {requireNativeComponent} from 'react-native'
 
 import type {KeyboardType, Props, Selection, TextInfo} from './input'
 import {checkTextInfo} from './input.shared'
-
-const NativeTextInput = requireNativeComponent('KBTextInput')
 
 type State = {
   focused: boolean,

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -51,13 +51,6 @@ class Input extends Component<Props, State> {
     this._timeoutIds.forEach(clearTimeout)
   }
 
-  // componentDidMount = () => {
-  //   this._setTimeout(() => {
-  //     this.setNativeProps({editable: false})
-  //     this.setNativeProps({editable: true})
-  //   }, 3e3)
-  // }
-
   componentDidUpdate = (prevProps: Props) => {
     if (prevProps.clearTextCounter !== this.props.clearTextCounter) {
       this._clearText()

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -4,12 +4,16 @@
 import React, {Component} from 'react'
 import Box from './box'
 import Text, {getStyle as getTextStyle} from './text'
-import {NativeTextInput} from './native-wrappers.native'
+// import {NativeTextInput} from './native-wrappers.native'
 import {collapseStyles, globalStyles, globalColors, styleSheetCreate} from '../styles'
 import {isIOS, isAndroid} from '../constants/platform'
+// ImageView.js
+import {requireNativeComponent} from 'react-native'
 
 import type {KeyboardType, Props, Selection, TextInfo} from './input'
 import {checkTextInfo} from './input.shared'
+
+const NativeTextInput = requireNativeComponent('KBTextInput')
 
 type State = {
   focused: boolean,
@@ -50,6 +54,13 @@ class Input extends Component<Props, State> {
   componentWillUnmount = () => {
     this._timeoutIds.forEach(clearTimeout)
   }
+
+  // componentDidMount = () => {
+  //   this._setTimeout(() => {
+  //     this.setNativeProps({editable: false})
+  //     this.setNativeProps({editable: true})
+  //   }, 3e3)
+  // }
 
   componentDidUpdate = (prevProps: Props) => {
     if (prevProps.clearTextCounter !== this.props.clearTextCounter) {

--- a/shared/common-adapters/input.native.js
+++ b/shared/common-adapters/input.native.js
@@ -4,7 +4,7 @@
 import React, {Component} from 'react'
 import Box from './box'
 import Text, {getStyle as getTextStyle} from './text'
-import NativeTextInput from './kb-text-input.native'
+import {NativeTextInput} from './native-wrappers.native'
 import {collapseStyles, globalStyles, globalColors, styleSheetCreate} from '../styles'
 import {isIOS, isAndroid} from '../constants/platform'
 

--- a/shared/common-adapters/kb-text-input.native.js
+++ b/shared/common-adapters/kb-text-input.native.js
@@ -1,3 +1,5 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+
 // Basically the same as React Native's text input, but the long press bug is
 // fixed. Look at KBTextInput(Manager) in the android folder.
 

--- a/shared/common-adapters/kb-text-input.native.js
+++ b/shared/common-adapters/kb-text-input.native.js
@@ -4,8 +4,13 @@
 // fixed. Look at KBTextInput(Manager) in the android folder.
 
 import React from 'react'
-import {requireNativeComponent, Text, UIManager, TouchableWithoutFeedback} from 'react-native'
-import {NativeTextInput as RNTextInput} from './native-wrappers.native'
+import {
+  requireNativeComponent,
+  Text,
+  TextInput as RNTextInput,
+  UIManager,
+  TouchableWithoutFeedback,
+} from 'react-native'
 import {isAndroid} from '../constants/platform'
 
 let _KBTextInput = RNTextInput

--- a/shared/common-adapters/kb-text-input.native.js
+++ b/shared/common-adapters/kb-text-input.native.js
@@ -1,0 +1,80 @@
+// @flow
+
+// Basically the same as React Native's text input, but the long press bug is
+// fixed. Look at KBTextInput(Manager) in the android folder.
+
+import React from 'react'
+import {requireNativeComponent, Text, UIManager, TouchableWithoutFeedback} from 'react-native'
+import {NativeTextInput as RNTextInput} from './native-wrappers.native'
+import {isAndroid} from '../constants/platform'
+
+let _KBTextInput = RNTextInput
+
+if (isAndroid) {
+  const NativeTextInput = requireNativeComponent('KBTextInput')
+  class _NativeTextInputWrapper extends RNTextInput {
+    render() {
+      const props = Object.assign({}, this.props)
+
+      props.style = [this.props.style]
+      props.autoCapitalize =
+        UIManager.AndroidTextInput.Constants.AutoCapitalizationType[props.autoCapitalize || 'sentences']
+      /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This comment
+       * suppresses an error when upgrading Flow's support for React. To see the
+       * error delete this comment and run Flow. */
+
+      let children = this.props.children
+      let childCount = 0
+      React.Children.forEach(children, () => ++childCount)
+      if (childCount > 1) {
+        children = <Text>{children}</Text>
+      }
+
+      if (props.selection && props.selection.end == null) {
+        props.selection = {
+          end: props.selection.start,
+          start: props.selection.start,
+        }
+      }
+
+      const textContainer = (
+        <NativeTextInput
+          ref={this._setNativeRef}
+          {...props}
+          mostRecentEventCount={0}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
+          onChange={this._onChange}
+          onSelectionChange={this._onSelectionChange}
+          onTextInput={this._onTextInput}
+          text={this.props.text || this.props.defaultValue || ''}
+          children={children}
+          disableFullscreenUI={this.props.disableFullscreenUI}
+          textBreakStrategy={this.props.textBreakStrategy}
+          onScroll={this._onScroll}
+        />
+      )
+
+      return (
+        <TouchableWithoutFeedback
+          onLayout={props.onLayout}
+          onPress={this._onPress}
+          accessible={this.props.accessible}
+          accessibilityLabel={this.props.accessibilityLabel}
+          accessibilityRole={this.props.accessibilityRole}
+          accessibilityStates={this.props.accessibilityStates}
+          nativeID={this.props.nativeID}
+          testID={this.props.testID}
+        >
+          {textContainer}
+        </TouchableWithoutFeedback>
+      )
+    }
+  }
+
+  _KBTextInput = _NativeTextInputWrapper
+}
+
+const KBTextInput = _KBTextInput
+
+export default KBTextInput

--- a/shared/common-adapters/kb-text-input.native.js
+++ b/shared/common-adapters/kb-text-input.native.js
@@ -1,5 +1,3 @@
-// @flow
-
 // Basically the same as React Native's text input, but the long press bug is
 // fixed. Look at KBTextInput(Manager) in the android folder.
 

--- a/shared/common-adapters/native-wrappers.native.js
+++ b/shared/common-adapters/native-wrappers.native.js
@@ -24,7 +24,6 @@ import {
   StatusBar as NativeStatusBar,
   Switch as NativeSwitch,
   Text as NativeText,
-  TextInput as NativeTextInput,
   TouchableNativeFeedback as NativeTouchableNativeFeedback,
   TouchableWithoutFeedback as NativeTouchableWithoutFeedback,
   TouchableHighlight as NativeTouchableHighlight,
@@ -35,6 +34,7 @@ import {
 import NativeScrollView from './scroll-view.native'
 import {NativeImage, FastImage as NativeFastImage} from './native-image.native'
 import NativeVirtualizedList from './virtualized-list.native'
+import NativeTextInput from './kb-text-input.native'
 
 // We set some useful default here
 export {

--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -103,7 +103,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         applicationId "io.keybase.ossifrage"
         versionCode timestamp()
-        versionName "4.0.0"
+        versionName "4.0.1"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
@@ -56,9 +56,8 @@ public class KBReactPackage implements com.facebook.react.ReactPackage {
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
-//        return Arrays.asList(
-//            new KBTextInputManager()
-//        );
-        return Collections.emptyList();
+        return Arrays.<ViewManager>asList(
+            new KBTextInputManager()
+        );
     }
 }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
@@ -5,10 +5,12 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import io.keybase.ossifrage.components.KBTextInputManager;
 import io.keybase.ossifrage.modules.IntentHandler;
 import io.keybase.ossifrage.modules.KeybaseEngine;
 import io.keybase.ossifrage.modules.KillableModule;
@@ -54,6 +56,9 @@ public class KBReactPackage implements com.facebook.react.ReactPackage {
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
+//        return Arrays.asList(
+//            new KBTextInputManager()
+//        );
         return Collections.emptyList();
     }
 }

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/components/KBTextInput.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/components/KBTextInput.java
@@ -1,0 +1,32 @@
+package io.keybase.ossifrage.components;
+
+import android.content.Context;
+
+import com.facebook.react.views.textinput.ReactEditText;
+
+public class KBTextInput extends ReactEditText {
+  private boolean mEnabled = false;
+
+  public KBTextInput(Context context) {
+    super(context);
+  }
+
+  @Override
+  public void setEnabled(boolean enabled) {
+    this.mEnabled = enabled;
+    super.setEnabled(enabled);
+  }
+
+  @Override
+  public void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    try {
+      if (!mEnabled)
+        return;
+      super.setEnabled(false);
+      super.setEnabled(mEnabled);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/components/KBTextInputManager.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/components/KBTextInputManager.java
@@ -1,13 +1,23 @@
 package io.keybase.ossifrage.components;
 
+import android.text.InputType;
+
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.views.textinput.ReactEditText;
 
 @ReactModule(
-    name = "KBAndroidTextInput"
+    name = "KBTextInput"
 )
 public class KBTextInputManager extends com.facebook.react.views.textinput.ReactTextInputManager {
+  public static final String REACT_CLASS = "KBTextInput";
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
   @Override
   public KBTextInput createViewInstance(ThemedReactContext context) {
     KBTextInput editText = new KBTextInput(context);

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/components/KBTextInputManager.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/components/KBTextInputManager.java
@@ -1,0 +1,20 @@
+package io.keybase.ossifrage.components;
+
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+@ReactModule(
+    name = "KBAndroidTextInput"
+)
+public class KBTextInputManager extends com.facebook.react.views.textinput.ReactTextInputManager {
+  @Override
+  public KBTextInput createViewInstance(ThemedReactContext context) {
+    KBTextInput editText = new KBTextInput(context);
+    int inputType = editText.getInputType();
+    editText.setInputType(inputType & -131073);
+    editText.setReturnKeyType("done");
+    editText.setTextSize(0, (float)((int)Math.ceil((double) PixelUtil.toPixelFromSP(14.0F))));
+    return editText;
+  }
+}

--- a/shared/react-native/ios/Keybase/Info.plist
+++ b/shared/react-native/ios/Keybase/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>4.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/shared/react-native/ios/KeybaseShare/Info.plist
+++ b/shared/react-native/ios/KeybaseShare/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>4.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
@keybase/react-hackers @chrisnojima 

This fixes paste by extending RN's TextInput this lets us avoid adding this logic to a fork. But it should be noted that this is implicitly tied to the implementation of the specific version of RN Text Input. If RN changes how TextInput works this will likely also need to be updated...

