### PR TITLE
Fix new role picker: only owners can make other owners

### DIFF
--- a/shared/constants/teams.js
+++ b/shared/constants/teams.js
@@ -325,16 +325,21 @@ const getDisabledReasonsForRolePicker = (
   memberToModify: ?string
 ): Types.DisabledReasonsForRolePicker => {
   const canManageMembers = getCanPerform(state, teamname).manageMembers
-  if (canManageMembers) {
-    // If you're an implicit admin, the tests below will fail for you, but you can still change roles.
-    return isSubteam(teamname) ? {owner: 'Subteams cannot have owners.'} : {}
-  }
   const members = getTeamMembers(state, teamname)
   const member = memberToModify ? members.get(memberToModify) : null
   const theyAreOwner = member ? member.type === 'owner' : false
   const you = members.get(state.config.username)
   // Fallback to the lowest role, although this shouldn't happen
   const yourRole = you ? you.type : 'reader'
+
+  if (canManageMembers) {
+    // If you're an implicit admin, the tests below will fail for you, but you can still change roles.
+    return isSubteam(teamname)
+      ? {owner: 'Subteams cannot have owners.'}
+      : yourRole !== 'owner'
+      ? {owner: 'Only owners can turn team members into owners.'}
+      : {}
+  }
 
   // We shouldn't get here, but in case we do this is correct.
   if (yourRole !== 'owner' && yourRole !== 'admin') {


### PR DESCRIPTION
@keybase/react-hackers 

We were using `yourOperations.canManageMembers` to mean that you can change anyone's role in the new role picker, but that's not true: as an admin, you can change roles, but can't change anyone's role (including your own) to become an owner.  This PR fixes that.