### PR TITLE
Remove double header on confirm-leave-team page

### DIFF
--- a/shared/teams/really-leave-team/index.js
+++ b/shared/teams/really-leave-team/index.js
@@ -52,5 +52,5 @@ const _ReallyLeaveTeam = (props: Props) => (
   />
 )
 
-export default HeaderOnMobile(_ReallyLeaveTeam)
+export default _ReallyLeaveTeam
 export {Spinner}


### PR DESCRIPTION
@keybase/react-hackers 

`<ConfirmModal />` already provides a header on mobile, so don't need to add another here.