### PR TITLE
Move wallet spinner if we already have accounts

### DIFF
--- a/shared/people/index.native.js
+++ b/shared/people/index.native.js
@@ -4,7 +4,6 @@ import * as Kb from '../common-adapters/mobile.native'
 import {PeoplePageList} from './index.shared'
 import {type Props} from '.'
 import {globalStyles, styleSheetCreate} from '../styles'
-import {isIOS} from '../constants/platform'
 import ProfileSearch from '../profile/search/bar-container'
 
 export const Header = (props: Props) => (
@@ -32,12 +31,7 @@ const People = (props: Props) => (
     <Kb.ScrollView
       style={styles.scrollView}
       refreshControl={
-        // TODO set refreshing to the actual prop once the bug in RN gets fixed
-        // see https://github.com/facebook/react-native/issues/5839
-        <Kb.NativeRefreshControl
-          refreshing={isIOS ? false : props.waiting}
-          onRefresh={() => props.getData()}
-        />
+        <Kb.NativeRefreshControl refreshing={props.waiting} onRefresh={() => props.getData()} />
       }
     >
       <PeoplePageList {...props} />

--- a/shared/wallets/wallet-list/index.js
+++ b/shared/wallets/wallet-list/index.js
@@ -125,7 +125,7 @@ class WalletList extends React.Component<Props> {
   }
 
   render() {
-    if (this.props.loading) {
+    if (this.props.loading && !this.props.accountIDs.length) {
       return (
         <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} centerChildren={true}>
           <Kb.ProgressIndicator style={styles.progressIndicator} />
@@ -142,6 +142,7 @@ class WalletList extends React.Component<Props> {
 
     return (
       <>
+        {this.props.loading && <Kb.ProgressIndicator style={styles.progressHeader} />}
         <Kb.BoxGrow>
           <Kb.List items={rows} renderItem={this._renderRow} keyProperty="key" style={this.props.style} />
         </Kb.BoxGrow>
@@ -170,6 +171,14 @@ const styles = Styles.styleSheetCreate({
     borderStyle: `solid`,
     borderTopWidth: 1,
     height: rowHeight,
+  },
+  progressHeader: {
+    height: 18,
+    left: 40,
+    position: 'absolute',
+    top: 9,
+    width: 18,
+    zIndex: 2,
   },
   progressIndicator: {height: 30, width: 30},
   whatIsStellar: {


### PR DESCRIPTION
To the header like the people page spinner. r? @keybase/react-hackers 