### PR TITLE
WIP: adjust memory pressure

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.native.js
+++ b/shared/chat/conversation/list-area/normal/index.native.js
@@ -205,6 +205,7 @@ class ConversationList extends React.PureComponent<Props> {
             windowSize={5}
             forwardedRef={this._listRef}
             onScrollToIndexFailed={this._onScrollToIndexFailed}
+            removeClippedSubviews={Styles.isAndroid}
           />
           {!this.props.containsLatestMessage && this.props.messageOrdinals.size > 0 && (
             <JumpToRecent onClick={this._jumpToRecent} style={styles.jumpToRecent} />

--- a/shared/common-adapters/native-image.native.js
+++ b/shared/common-adapters/native-image.native.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react'
 import {Image, type ImageProps} from 'react-native'
-import FastImageImpl from 'react-native-fast-image'
-import {isArray} from 'lodash-es'
+// import FastImageImpl from 'react-native-fast-image'
+// import {isArray} from 'lodash-es'
 
 export class NativeImage extends React.Component<ImageProps> {
   static getSize = Image.getSize
@@ -11,13 +11,16 @@ export class NativeImage extends React.Component<ImageProps> {
   }
 }
 
-export class FastImage extends React.Component<ImageProps> {
-  static getSize = Image.getSize
-  render() {
-    let source = this.props.source
-    if (isArray(this.props.source)) {
-      source = this.props.source[0] // TODO smarter choice?
-    }
-    return !!source && !!source.uri && <FastImageImpl {...this.props} source={source} />
-  }
-}
+// This might be causing a lot of memory pressure on android. testing to see if turning it off helps
+// export class FastImage extends React.Component<ImageProps> {
+// static getSize = Image.getSize
+// render() {
+// let source = this.props.source
+// if (isArray(this.props.source)) {
+// source = this.props.source[0] // TODO smarter choice?
+// }
+// return !!source && !!source.uri && <FastImageImpl {...this.props} source={source} />
+// }
+// }
+//
+export const FastImage = NativeImage

--- a/shared/react-native/android/app/build.gradle
+++ b/shared/react-native/android/app/build.gradle
@@ -199,7 +199,7 @@ dependencies {
     implementation project(':react-native-image-picker')
     implementation project(':react-native-fetch-blob')
     implementation project(':react-native-contacts')
-    implementation project(':react-native-fast-image')
+    // implementation project(':react-native-fast-image')
     implementation project(':lottie-react-native')
     implementation project(':react-native-gesture-handler')
     implementation project(':react-native-screens')

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/CustomBitmapMemoryCacheParamsSupplier.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/CustomBitmapMemoryCacheParamsSupplier.java
@@ -1,0 +1,56 @@
+package io.keybase.ossifrage;
+
+import android.app.ActivityManager;
+import android.content.Context;
+import android.os.Build;
+
+import com.facebook.common.internal.Supplier;
+import com.facebook.common.util.ByteConstants;
+import com.facebook.imagepipeline.cache.DefaultBitmapMemoryCacheParamsSupplier;
+import com.facebook.imagepipeline.cache.MemoryCacheParams;
+
+/**
+ * Custom Bitmap cache config for Fresco based off of {@link DefaultBitmapMemoryCacheParamsSupplier}
+ */
+public class CustomBitmapMemoryCacheParamsSupplier implements Supplier<MemoryCacheParams> {
+
+    private static final int CACHE_DIVISION = 8; // cache size will be 1/8 of the max allocated app memory
+    private static final int MAX_CACHE_ENTRIES = 256;
+    private static final int MAX_EVICTION_QUEUE_SIZE = Integer.MAX_VALUE;
+    private static final int MAX_EVICTION_QUEUE_ENTRIES = Integer.MAX_VALUE;
+    private static final int MAX_CACHE_ENTRY_SIZE = Integer.MAX_VALUE;
+
+    private final ActivityManager mActivityManager;
+
+    public CustomBitmapMemoryCacheParamsSupplier(Context context) {
+        mActivityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    }
+
+    @Override
+    public MemoryCacheParams get() {
+        return new MemoryCacheParams(
+                getMaxCacheSize(),
+                MAX_CACHE_ENTRIES,
+                MAX_EVICTION_QUEUE_SIZE,
+                MAX_EVICTION_QUEUE_ENTRIES,
+                MAX_CACHE_ENTRY_SIZE);
+    }
+
+    private int getMaxCacheSize() {
+        final int maxMemory =
+                Math.min(mActivityManager.getMemoryClass() * ByteConstants.MB, Integer.MAX_VALUE);
+        if (maxMemory < 32 * ByteConstants.MB) {
+            return 4 * ByteConstants.MB;
+        } else if (maxMemory < 64 * ByteConstants.MB) {
+            return 6 * ByteConstants.MB;
+        } else {
+            // We don't want to use more ashmem on Gingerbread for now, since it doesn't respond well to
+            // native memory pressure (doesn't throw exceptions, crashes app, crashes phone)
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+                return 8 * ByteConstants.MB;
+            } else {
+                return maxMemory / CACHE_DIVISION;
+            }
+        }
+    }
+}

--- a/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/react-native/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -1,20 +1,23 @@
 package io.keybase.ossifrage;
 
 import android.app.Application;
+import android.content.Context;
 
 import com.evernote.android.job.JobManager;
+import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.shell.MainPackageConfig;
 import com.facebook.react.shell.MainReactPackage;
 import com.dieam.reactnativepushnotification.ReactNativePushNotificationPackage;
 import com.facebook.soloader.SoLoader;
 import com.imagepicker.ImagePickerPackage;
 import com.RNFetchBlob.RNFetchBlobPackage;
 import com.rt2zz.reactnativecontacts.ReactNativeContacts;
-import com.dylanvann.fastimage.FastImageViewPackage;
+//import com.dylanvann.fastimage.FastImageViewPackage;
 
 import org.reactnative.camera.RNCameraPackage;
 
@@ -64,49 +67,42 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override
         protected List<ReactPackage> getPackages() {
-            if (BuildConfig.BUILD_TYPE == "storyBook") {
-                return Arrays.<ReactPackage>asList(
-                        new MainReactPackage(),
-                        new KBReactPackage() {
-                            @Override
-                            public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
-                                List<NativeModule> modules = new ArrayList<>();
-                                modules.add(new StorybookConstants(reactApplicationContext));
-                                return modules;
-                            }
-                        },
-                        new ReactNativePushNotificationPackage(),
-                        new RNCameraPackage(),
-                        new ImagePickerPackage(),
-                        new RNFetchBlobPackage(),
-                        new ReactNativeContacts(),
-                        new FastImageViewPackage(),
-                        new LottiePackage(),
-                        new RNGestureHandlerPackage(),
-                        new RNScreensPackage(),
-                        new ReactVideoPackage(),
-                        new ReanimatedPackage()
-                );
-            }
+            Context context = getApplicationContext();
+            // limit fresco memory
+            ImagePipelineConfig frescoConfig = ImagePipelineConfig
+                    .newBuilder(context)
+                    .setBitmapMemoryCacheParamsSupplier(new CustomBitmapMemoryCacheParamsSupplier(context))
+                    .build();
 
+            MainPackageConfig appConfig = new MainPackageConfig.Builder().setFrescoConfig(frescoConfig).build();
 
             return Arrays.<ReactPackage>asList(
-                    new MainReactPackage(),
-                    new KBReactPackage(),
-                    new ReactNativePushNotificationPackage(),
-                    new RNCameraPackage(),
-                    new ImagePickerPackage(),
-                    new RNFetchBlobPackage(),
-                    new ReactNativeContacts(),
-                    new FastImageViewPackage(),
-                    new LottiePackage(),
-                    new RNGestureHandlerPackage(),
-                    new RNScreensPackage(),
-                    new ReactVideoPackage(),
-                    new ReanimatedPackage()
+                new MainReactPackage(appConfig),
+                new KBReactPackage() {
+                    @Override
+                    public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
+                        if (BuildConfig.BUILD_TYPE == "storyBook") {
+                            List<NativeModule> modules = new ArrayList<>();
+                            modules.add(new StorybookConstants(reactApplicationContext));
+                            return modules;
+                        } else {
+                            return super.createNativeModules(reactApplicationContext);
+                        }
+                    }
+                },
+                new ReactNativePushNotificationPackage(),
+                new RNCameraPackage(),
+                new ImagePickerPackage(),
+                new RNFetchBlobPackage(),
+                new ReactNativeContacts(),
+                //new FastImageViewPackage(),
+                new LottiePackage(),
+                new RNGestureHandlerPackage(),
+                new RNScreensPackage(),
+                new ReactVideoPackage(),
+                new ReanimatedPackage()
             );
         }
-
     };
 
     @Override

--- a/shared/react-native/android/settings.gradle
+++ b/shared/react-native/android/settings.gradle
@@ -14,8 +14,8 @@ include ':react-native-fetch-blob'
 project(':react-native-fetch-blob').projectDir = new File(rootProject.projectDir, '../../node_modules/rn-fetch-blob/android')
 include ':react-native-contacts'
 project(':react-native-contacts').projectDir = new File(rootProject.projectDir, '../../node_modules/react-native-contacts/android')
-include ':react-native-fast-image'
-project(':react-native-fast-image').projectDir = new File(rootProject.projectDir, '../../node_modules/react-native-fast-image/android')
+// include ':react-native-fast-image'
+// project(':react-native-fast-image').projectDir = new File(rootProject.projectDir, '../../node_modules/react-native-fast-image/android')
 include ':lottie-react-native'
 project(':lottie-react-native').projectDir = new File(rootProject.projectDir, '../../node_modules/lottie-react-native/src/android')
 include ':react-native-gesture-handler'


### PR DESCRIPTION
- [x] add clip subviews to chat threads for android only
- [x] remove fast image view. it has its own caching layer which is maybe problematic and conflicts w/ frescos
- [x] add custom fresco allocation strategy
- [x] remove dupe packages declaration in java
@keybase/react-hackers 