### PR TITLE
reorder and retry loading for new transactions in payment notifications

### DIFF
--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -325,10 +325,11 @@ func (s *Stellar) handlePaymentNotification(mctx libkb.MetaContext, obm gregor.O
 }
 
 func (s *Stellar) refreshPaymentFromNotification(mctx libkb.MetaContext, accountID stellar1.AccountID, paymentID stellar1.PaymentID) error {
+	// load the payment and then refresh the wallet state for the account.
+	DefaultLoader(s.G()).LoadPaymentSync(mctx.Ctx(), paymentID)
 	if err := s.walletState.Refresh(mctx, accountID, "notification received"); err != nil {
 		return err
 	}
-	DefaultLoader(s.G()).UpdatePayment(mctx.Ctx(), paymentID)
 
 	return nil
 }

--- a/go/stellar/loader.go
+++ b/go/stellar/loader.go
@@ -248,13 +248,16 @@ func (p *Loader) LoadPaymentSync(ctx context.Context, paymentID stellar1.Payment
 	mctx := libkb.NewMetaContext(ctx, p.G())
 	defer mctx.TraceTimed(fmt.Sprintf("LoadPaymentSync(%s)", paymentID), func() error { return nil })()
 
-	for i := 1; i <= 100; i++ {
+	backoffPolicy := libkb.BackoffPolicy{
+		Millis: []int{500, 500, 500, 500, 500, 500, 500, 1000},
+	}
+	for i := 0; i <= 30; i++ {
 		err := p.loadPayment(paymentID)
 		if err == nil {
 			break
 		}
 		mctx.Debug("error on attempt %d to load payment %s: %s. sleep and retry.", i, paymentID, err)
-		time.Sleep(1 * time.Second)
+		time.Sleep(backoffPolicy.Duration(i))
 	}
 }
 


### PR DESCRIPTION
Payments that come from outside of keybase (and to a lesser extent, from non-primary keybase accounts) are harder to lookup, and horizon is often several seconds behind the keybase notification system. This can cause the client to report a new balance but not show the transaction for multiple minutes. 

This change makes loading a payment from a notification synchronous. And move this step to before refreshing our local state on the account. 
