### PR TITLE
init storage hooks when starting chat modules

### DIFF
--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -311,9 +311,9 @@ func (s *localizerPipeline) clearQueue() {
 }
 
 func (s *localizerPipeline) start(ctx context.Context) {
+	defer s.Trace(ctx, func() error { return nil }, "start")()
 	s.Lock()
 	defer s.Unlock()
-	s.Debug(ctx, "start")
 	if s.started {
 		close(s.stopCh)
 		s.stopCh = make(chan struct{})
@@ -324,9 +324,9 @@ func (s *localizerPipeline) start(ctx context.Context) {
 }
 
 func (s *localizerPipeline) stop(ctx context.Context) chan struct{} {
+	defer s.Trace(ctx, func() error { return nil }, "stop")()
 	s.Lock()
 	defer s.Unlock()
-	s.Debug(ctx, "stop")
 	ch := make(chan struct{})
 	if s.started {
 		close(s.stopCh)

--- a/go/chat/storage/hooks.go
+++ b/go/chat/storage/hooks.go
@@ -1,0 +1,14 @@
+package storage
+
+import "github.com/keybase/client/go/chat/globals"
+
+func SetupGlobalHooks(g *globals.Context) {
+	g.ExternalG().AddLogoutHook(inboxMemCache, "chat/storage/inbox")
+	g.ExternalG().AddDbNukeHook(inboxMemCache, "chat/storage/inbox")
+
+	g.ExternalG().AddLogoutHook(reacjiMemCache, "chat/storage/reacjiMemCache")
+	g.ExternalG().AddDbNukeHook(reacjiMemCache, "chat/storage/reacjiMemCache")
+
+	g.ExternalG().AddLogoutHook(blockEngineMemCache, "chat/storage/blockEngineMemCache")
+	g.ExternalG().AddDbNukeHook(blockEngineMemCache, "chat/storage/blockEngineMemCache")
+}

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/keybase/client/go/encrypteddb"
@@ -99,8 +98,6 @@ type Inbox struct {
 	flushMode InboxFlushMode
 }
 
-var addInboxMemCacheHookOnce sync.Once
-
 func FlushMode(mode InboxFlushMode) func(*Inbox) {
 	return func(i *Inbox) {
 		i.SetFlushMode(mode)
@@ -108,12 +105,6 @@ func FlushMode(mode InboxFlushMode) func(*Inbox) {
 }
 
 func NewInbox(g *globals.Context, config ...func(*Inbox)) *Inbox {
-	// add a logout hook to clear the in-memory inbox cache, but only add it once:
-	addInboxMemCacheHookOnce.Do(func() {
-		g.ExternalG().AddLogoutHook(inboxMemCache, "chat/storage/inbox")
-		g.ExternalG().AddDbNukeHook(inboxMemCache, "chat/storage/inbox")
-	})
-
 	i := &Inbox{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "Inbox", false),

--- a/go/chat/storage/reacjis.go
+++ b/go/chat/storage/reacjis.go
@@ -19,8 +19,6 @@ const reacjiDiskVersion = 2
 // If the user has less than 5 favorite reacjis we stuff these defaults in.
 var DefaultTopReacjis = []string{":+1:", ":-1:", ":tada:", ":joy:", ":sunglasses:"}
 
-var addReacjiMemCacheHookOnce sync.Once
-
 type ReacjiInternalStorage struct {
 	FrequencyMap map[string]int
 	SkinTone     keybase1.ReacjiSkinTone
@@ -112,11 +110,6 @@ func NewReacjiStore(g *globals.Context) *ReacjiStore {
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalChatDb
 	}
-	// add a logout hook to clear the in-memory cache, but only add it once:
-	addReacjiMemCacheHookOnce.Do(func() {
-		g.ExternalG().AddLogoutHook(reacjiMemCache, "reacjiMemCache")
-		g.ExternalG().AddDbNukeHook(reacjiMemCache, "reacjiMemCache")
-	})
 	return &ReacjiStore{
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "ReacjiStore", false),
 		encryptedDB:  encrypteddb.New(g.ExternalG(), dbFn, keyFn),

--- a/go/chat/storage/storage_blockengine.go
+++ b/go/chat/storage/storage_blockengine.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/utils"
@@ -16,21 +15,12 @@ import (
 const blockIndexVersion = 8
 const blockSize = 100
 
-var addBlockHookOnce sync.Once
-
 type blockEngine struct {
 	globals.Contextified
 	utils.DebugLabeler
 }
 
 func newBlockEngine(g *globals.Context) *blockEngine {
-
-	// add a logout hook to clear the in-memory block cache, but only add it once:
-	addBlockHookOnce.Do(func() {
-		g.ExternalG().AddLogoutHook(blockEngineMemCache, "blockEngineMemCache")
-		g.ExternalG().AddDbNukeHook(blockEngineMemCache, "blockEngineMemCache")
-	})
-
 	return &blockEngine{
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.GetLog(), "BlockEngine", true),

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -423,6 +423,8 @@ func (d *Service) SetupChatModules(ri func() chat1.RemoteInterface) {
 		ri = d.gregor.GetClient
 	}
 
+	// Add OnLogout/OnDbNuke hooks for any in-memory sources
+	storage.SetupGlobalHooks(g)
 	// Set up main chat data sources
 	boxer := chat.NewBoxer(g)
 	chatStorage := storage.New(g, nil)


### PR DESCRIPTION
prevents a deadlock if a hook is trying to be added during login/logout