### PR TITLE
libkbfs: expose moved-away local conflict views as real TLFs

### DIFF
--- a/go/kbfs/data/data_types.go
+++ b/go/kbfs/data/data_types.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
 )
@@ -378,7 +379,8 @@ const (
 	// the master branch.
 	MasterBranch BranchName = ""
 
-	branchRevPrefix = "rev="
+	branchRevPrefix           = "rev="
+	branchLocalConflictPrefix = "localConflict="
 )
 
 // MakeRevBranchName returns a branch name specifying an archive
@@ -387,9 +389,25 @@ func MakeRevBranchName(rev kbfsmd.Revision) BranchName {
 	return BranchName(branchRevPrefix + strconv.FormatInt(int64(rev), 10))
 }
 
+// MakeConflictBranchName returns a branch name specifying a conflict
+// date, if possible.
+func MakeConflictBranchName(h *tlfhandle.Handle) (BranchName, bool) {
+	if !h.IsLocalConflict() {
+		return "", false
+	}
+
+	return BranchName(
+		branchLocalConflictPrefix + h.ConflictInfo().String()), true
+}
+
 // IsArchived returns true if the branch specifies an archived revision.
 func (bn BranchName) IsArchived() bool {
 	return strings.HasPrefix(string(bn), branchRevPrefix)
+}
+
+// IsLocalConflict returns true if the branch specifies a local conflict branch.
+func (bn BranchName) IsLocalConflict() bool {
+	return strings.HasPrefix(string(bn), branchLocalConflictPrefix)
 }
 
 // RevisionIfSpecified returns a valid revision number and true if

--- a/go/kbfs/idutil/daemon_local.go
+++ b/go/kbfs/idutil/daemon_local.go
@@ -565,12 +565,13 @@ func (dl *DaemonLocal) RemoveAssertionForTest(assertion string) {
 // AddTeamWriterForTest adds a writer to a team.  Should only be used
 // by tests.
 func (dl *DaemonLocal) AddTeamWriterForTest(
-	tid keybase1.TeamID, uid keybase1.UID) (kbname.NormalizedUsername, error) {
+	tid keybase1.TeamID, uid keybase1.UID) (
+	kbname.NormalizedUsername, bool, error) {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 	t, err := dl.localTeams.getLocalTeam(tid)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	if t.Writers == nil {
@@ -579,7 +580,8 @@ func (dl *DaemonLocal) AddTeamWriterForTest(
 	t.Writers[uid] = true
 	delete(t.Readers, uid)
 	dl.localTeams[tid] = t
-	return t.Name, nil
+	_, isImplicit := dl.localImplicitTeams[tid]
+	return t.Name, isImplicit, nil
 }
 
 // RemoveTeamWriterForTest removes a writer from a team.  Should only

--- a/go/kbfs/idutil/daemon_local.go
+++ b/go/kbfs/idutil/daemon_local.go
@@ -566,7 +566,7 @@ func (dl *DaemonLocal) RemoveAssertionForTest(assertion string) {
 // by tests.
 func (dl *DaemonLocal) AddTeamWriterForTest(
 	tid keybase1.TeamID, uid keybase1.UID) (
-	kbname.NormalizedUsername, bool, error) {
+	username kbname.NormalizedUsername, isImplicit bool, err error) {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 	t, err := dl.localTeams.getLocalTeam(tid)
@@ -580,7 +580,7 @@ func (dl *DaemonLocal) AddTeamWriterForTest(
 	t.Writers[uid] = true
 	delete(t.Readers, uid)
 	dl.localTeams[tid] = t
-	_, isImplicit := dl.localImplicitTeams[tid]
+	_, isImplicit = dl.localImplicitTeams[tid]
 	return t.Name, isImplicit, nil
 }
 

--- a/go/kbfs/libdokan/tlf.go
+++ b/go/kbfs/libdokan/tlf.go
@@ -81,6 +81,14 @@ func (tlf *TLF) loadDirHelper(ctx context.Context, info string,
 		return nil, false, err
 	}
 
+	if branch == data.MasterBranch {
+		conflictBranch, isLocalConflictBranch :=
+			data.MakeConflictBranchName(handle)
+		if isLocalConflictBranch {
+			branch = conflictBranch
+		}
+	}
+
 	var rootNode libkbfs.Node
 	if filterErr {
 		rootNode, _, err = tlf.folder.fs.config.KBFSOps().GetRootNode(

--- a/go/kbfs/libfuse/tlf.go
+++ b/go/kbfs/libfuse/tlf.go
@@ -101,6 +101,14 @@ func (tlf *TLF) loadDirHelper(
 		return nil, false, err
 	}
 
+	if branch == data.MasterBranch {
+		conflictBranch, isLocalConflictBranch :=
+			data.MakeConflictBranchName(handle)
+		if isLocalConflictBranch {
+			branch = conflictBranch
+		}
+	}
+
 	var rootNode libkbfs.Node
 	if filterErr {
 		rootNode, _, err = tlf.folder.fs.config.KBFSOps().GetRootNode(

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -6919,7 +6919,7 @@ func (fbo *folderBranchOps) undoUnmergedMDUpdatesLocked(
 			for _, ptr := range op.Refs() {
 				if ptr != data.ZeroPtr {
 					unflushed, err := fbo.config.BlockServer().IsUnflushed(
-						ctx, rmd.tlfHandle.TlfID(), ptr.ID)
+						ctx, fbo.id(), ptr.ID)
 					if err != nil {
 						return nil, err
 					}
@@ -6931,7 +6931,7 @@ func (fbo *folderBranchOps) undoUnmergedMDUpdatesLocked(
 			for _, update := range op.allUpdates() {
 				if update.Ref != data.ZeroPtr {
 					unflushed, err := fbo.config.BlockServer().IsUnflushed(
-						ctx, rmd.tlfHandle.TlfID(), update.Ref.ID)
+						ctx, fbo.id(), update.Ref.ID)
 					if err != nil {
 						return nil, err
 					}

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -357,10 +357,9 @@ func (j *JournalManager) getHandleForJournal(
 		return nil, err
 	}
 
-	return tlfhandle.MakeHandle(
+	return tlfhandle.MakeHandleWithTlfID(
 		ctx, headBareHandle, tlfID.Type(), j.config.KBPKI(),
-		j.config.KBPKI(), tlfhandle.ConstIDGetter{ID: tlfID},
-		j.config.OfflineAvailabilityForID(tlfID))
+		j.config.KBPKI(), tlfID, j.config.OfflineAvailabilityForID(tlfID))
 }
 
 func (j *JournalManager) makeFBOForJournal(

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -59,10 +59,11 @@ func (jsc journalManagerConfig) getEnableAuto(currentUID keybase1.UID) (
 // ConflictJournalRecord contains info for TLF journals that are
 // currently in conflict on the local device.
 type ConflictJournalRecord struct {
-	Name tlf.CanonicalName
-	Type tlf.Type
-	Path string
-	ID   tlf.ID
+	Name           tlf.CanonicalName
+	Type           tlf.Type
+	Path           string
+	ID             tlf.ID
+	ServerViewPath keybase1.Path
 }
 
 // JournalManagerStatus represents the overall status of the
@@ -1102,6 +1103,7 @@ func (j *JournalManager) getJournalsInConflictLocked(ctx context.Context) (
 		if handle == nil {
 			continue
 		}
+		serverViewPath := handle.GetProtocolPath()
 
 		ext, err := tlf.NewHandleExtension(
 			tlf.HandleExtensionLocalConflict, key.num, "", key.date)
@@ -1114,10 +1116,11 @@ func (j *JournalManager) getJournalsInConflictLocked(ctx context.Context) (
 		}
 
 		cleared = append(cleared, ConflictJournalRecord{
-			Name: handle.GetCanonicalName(),
-			Type: handle.Type(),
-			Path: handle.GetCanonicalPath(),
-			ID:   tlfJournal.tlfID,
+			Name:           handle.GetCanonicalName(),
+			Type:           handle.Type(),
+			Path:           handle.GetCanonicalPath(),
+			ID:             tlfJournal.tlfID,
+			ServerViewPath: serverViewPath,
 		})
 	}
 

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -63,7 +63,8 @@ type ConflictJournalRecord struct {
 	Type           tlf.Type
 	Path           string
 	ID             tlf.ID
-	ServerViewPath keybase1.Path
+	ServerViewPath keybase1.Path // for cleared conflicts only
+	LocalViewPath  keybase1.Path // for cleared conflicts only
 }
 
 // JournalManagerStatus represents the overall status of the
@@ -1068,6 +1069,9 @@ func (j *JournalManager) maybeMakeDiskLimitErrorReportable(
 func (j *JournalManager) getJournalsInConflictLocked(ctx context.Context) (
 	current, cleared []ConflictJournalRecord, err error) {
 	for _, tlfJournal := range j.tlfJournals {
+		if tlfJournal.overrideTlfID != tlf.NullID {
+			continue
+		}
 		isConflict, err := tlfJournal.isOnConflictBranch()
 		if err != nil {
 			return nil, nil, err
@@ -1121,6 +1125,7 @@ func (j *JournalManager) getJournalsInConflictLocked(ctx context.Context) (
 			Path:           handle.GetCanonicalPath(),
 			ID:             tlfJournal.tlfID,
 			ServerViewPath: serverViewPath,
+			LocalViewPath:  handle.GetProtocolPath(),
 		})
 	}
 

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -646,6 +646,12 @@ func (j *JournalManager) EnableExistingJournals(
 						groupCtx, "Skipping misnamed dir %s: %+v", dir, err)
 					continue
 				}
+
+				// Take a lock while inserting the conflict journal
+				// (even though we already have `journalLock`), since
+				// multiple workers could be running at once and we
+				// need to protect the cleared conflct TLF map from
+				// concurrent access.
 				conflictLock.Lock()
 				j.insertConflictJournalLocked(groupCtx, tj, fakeTlfID, t)
 				conflictLock.Unlock()

--- a/go/kbfs/libkbfs/journal_md_ops.go
+++ b/go/kbfs/libkbfs/journal_md_ops.go
@@ -134,6 +134,7 @@ func (j journalMDOps) getHeadFromJournal(
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
+		handle.SetTlfID(id)
 	} else {
 		// Check for mutual handle resolution.
 		headHandle, err := tlfhandle.MakeHandle(
@@ -208,6 +209,7 @@ func (j journalMDOps) getRangeFromJournal(
 	if err != nil {
 		return nil, err
 	}
+	handle.SetTlfID(id)
 
 	irmds := make([]ImmutableRootMetadata, 0, len(ibrmds))
 

--- a/go/kbfs/libkbfs/journal_md_ops.go
+++ b/go/kbfs/libkbfs/journal_md_ops.go
@@ -127,9 +127,9 @@ func (j journalMDOps) getHeadFromJournal(
 	}
 
 	if handle == nil {
-		handle, err = tlfhandle.MakeHandle(
+		handle, err = tlfhandle.MakeHandleWithTlfID(
 			ctx, headBareHandle, id.Type(), j.jManager.config.KBPKI(),
-			j.jManager.config.KBPKI(), tlfhandle.ConstIDGetter{ID: id},
+			j.jManager.config.KBPKI(), id,
 			j.jManager.config.OfflineAvailabilityForID(id))
 		if err != nil {
 			return ImmutableRootMetadata{}, err
@@ -137,9 +137,9 @@ func (j journalMDOps) getHeadFromJournal(
 		handle.SetTlfID(id)
 	} else {
 		// Check for mutual handle resolution.
-		headHandle, err := tlfhandle.MakeHandle(
+		headHandle, err := tlfhandle.MakeHandleWithTlfID(
 			ctx, headBareHandle, id.Type(), j.jManager.config.KBPKI(),
-			j.jManager.config.KBPKI(), tlfhandle.ConstIDGetter{ID: id},
+			j.jManager.config.KBPKI(), id,
 			j.jManager.config.OfflineAvailabilityForID(id))
 		if err != nil {
 			return ImmutableRootMetadata{}, err
@@ -202,9 +202,9 @@ func (j journalMDOps) getRangeFromJournal(
 	if err != nil {
 		return nil, err
 	}
-	handle, err := tlfhandle.MakeHandle(
+	handle, err := tlfhandle.MakeHandleWithTlfID(
 		ctx, bareHandle, id.Type(), j.jManager.config.KBPKI(),
-		j.jManager.config.KBPKI(), tlfhandle.ConstIDGetter{ID: id},
+		j.jManager.config.KBPKI(), id,
 		j.jManager.config.OfflineAvailabilityForID(id))
 	if err != nil {
 		return nil, err

--- a/go/kbfs/libkbfs/journal_md_ops.go
+++ b/go/kbfs/libkbfs/journal_md_ops.go
@@ -238,11 +238,8 @@ func (j journalMDOps) GetIDForHandle(
 	id = handle.TlfID()
 	if id == tlf.NullID {
 		id, err = j.MDOps.GetIDForHandle(ctx, handle)
-		if err != nil {
+		if err != nil || id == tlf.NullID {
 			return tlf.NullID, err
-		}
-		if id == tlf.NullID {
-			return id, nil
 		}
 	}
 

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -321,9 +321,10 @@ func (fs *KBFSOpsStandard) GetFavoritesAll(ctx context.Context) (
 	}
 
 	for _, c := range cleared {
-		serverView := keybase1.NewPathWithKbfs("")
 		cs := keybase1.NewConflictStateWithManualresolvinglocalview(
-			keybase1.ConflictManualResolvingLocalView{ServerView: serverView})
+			keybase1.ConflictManualResolvingLocalView{
+				ServerView: c.ServerViewPath,
+			})
 		favs.FavoriteFolders = append(favs.FavoriteFolders,
 			keybase1.Folder{
 				Name:          string(c.Name),

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -321,13 +321,16 @@ func (fs *KBFSOpsStandard) GetFavoritesAll(ctx context.Context) (
 	}
 
 	for _, c := range cleared {
+		serverView := keybase1.NewPathWithKbfs("")
+		cs := keybase1.NewConflictStateWithManualresolvinglocalview(
+			keybase1.ConflictManualResolvingLocalView{ServerView: serverView})
 		favs.FavoriteFolders = append(favs.FavoriteFolders,
 			keybase1.Folder{
-				Name:         string(c.Name),
-				FolderType:   c.Type.FolderType(),
-				Private:      c.Type != tlf.Public,
-				ResetMembers: []keybase1.User{},
-				ConflictType: keybase1.FolderConflictType_CLEARED_CONFLICT,
+				Name:          string(c.Name),
+				FolderType:    c.Type.FolderType(),
+				Private:       c.Type != tlf.Public,
+				ResetMembers:  []keybase1.User{},
+				ConflictState: &cs,
 			})
 	}
 

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -279,10 +279,6 @@ func (fs *KBFSOpsStandard) GetFavorites(ctx context.Context) (
 		return nil, err
 	}
 
-	if len(cleared) == 0 {
-		return favs, nil
-	}
-
 	for _, c := range cleared {
 		favs = append(favs, favorites.Folder{
 			Name: string(c.Name),

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -233,15 +233,17 @@ func (k *KeybaseDaemonLocal) addTeamWriterForTest(
 	tid keybase1.TeamID, uid keybase1.UID) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	teamName, err := k.DaemonLocal.AddTeamWriterForTest(tid, uid)
+	teamName, isImplicit, err := k.DaemonLocal.AddTeamWriterForTest(tid, uid)
 	if err != nil {
 		return err
 	}
-	f := keybase1.Folder{
-		Name:       string(teamName),
-		FolderType: keybase1.FolderType_TEAM,
+	if !isImplicit {
+		f := keybase1.Folder{
+			Name:       string(teamName),
+			FolderType: keybase1.FolderType_TEAM,
+		}
+		k.favoriteStore.FavoriteAdd(uid, f)
 	}
-	k.favoriteStore.FavoriteAdd(uid, f)
 	return nil
 }
 

--- a/go/kbfs/libkbfs/md_journal_test.go
+++ b/go/kbfs/libkbfs/md_journal_test.go
@@ -77,7 +77,7 @@ func setupMDJournalTest(t testing.TB, ver kbfsmd.MetadataVer) (
 	ctx := context.Background()
 	j, err = makeMDJournal(
 		ctx, uid, verifyingKey, codec, crypto, data.WallClock{}, nil,
-		&testSyncedTlfGetterSetter{}, tlfID, ver, tempdir, log)
+		&testSyncedTlfGetterSetter{}, tlfID, ver, tempdir, log, tlf.NullID)
 	require.NoError(t, err)
 
 	bsplit, err = data.NewBlockSplitterSimpleExact(
@@ -1009,7 +1009,8 @@ func testMDJournalRestart(t *testing.T, ver kbfsmd.MetadataVer) {
 	// Restart journal.
 	ctx := context.Background()
 	j, err := makeMDJournal(ctx, j.uid, j.key, codec, crypto, j.clock,
-		j.teamMemChecker, j.osg, j.tlfID, j.mdVer, j.dir, j.log)
+		j.teamMemChecker, j.osg, j.tlfID, j.mdVer, j.dir, j.log,
+		j.overrideTlfID)
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(mdCount), j.length())
@@ -1051,7 +1052,8 @@ func testMDJournalRestartAfterBranchConversion(t *testing.T, ver kbfsmd.Metadata
 	// Restart journal.
 
 	j, err = makeMDJournal(ctx, j.uid, j.key, codec, crypto, j.clock,
-		j.teamMemChecker, j.osg, j.tlfID, j.mdVer, j.dir, j.log)
+		j.teamMemChecker, j.osg, j.tlfID, j.mdVer, j.dir, j.log,
+		j.overrideTlfID)
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(mdCount), j.length())

--- a/go/kbfs/libkbfs/md_ops.go
+++ b/go/kbfs/libkbfs/md_ops.go
@@ -1054,10 +1054,9 @@ func (md *MDOpsStandard) processSignedMD(
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
-	handle, err := tlfhandle.MakeHandle(
+	handle, err := tlfhandle.MakeHandleWithTlfID(
 		ctx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
-		md.config.KBPKI(), tlfhandle.ConstIDGetter{ID: id},
-		md.config.OfflineAvailabilityForID(id))
+		md.config.KBPKI(), id, md.config.OfflineAvailabilityForID(id))
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -1150,10 +1149,9 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
 			if err != nil {
 				return err
 			}
-			handle, err := tlfhandle.MakeHandle(
+			handle, err := tlfhandle.MakeHandleWithTlfID(
 				groupCtx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
-				md.config.KBPKI(), tlfhandle.ConstIDGetter{ID: id},
-				md.config.OfflineAvailabilityForID(id))
+				md.config.KBPKI(), id, md.config.OfflineAvailabilityForID(id))
 			if err != nil {
 				return err
 			}

--- a/go/kbfs/libkbfs/md_ops.go
+++ b/go/kbfs/libkbfs/md_ops.go
@@ -893,7 +893,7 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *tlfhandle.Han
 	}
 
 	// Check for handle readership, to give a nice error early.
-	if handle.Type() == tlf.Private {
+	if handle.Type() == tlf.Private && !handle.IsBackedByTeam() {
 		session, err := md.config.KBPKI().GetCurrentSession(ctx)
 		if err != nil {
 			return tlf.ID{}, ImmutableRootMetadata{}, err
@@ -929,6 +929,11 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *tlfhandle.Han
 	bh, err := handle.ToBareHandle()
 	if err != nil {
 		return tlf.ID{}, ImmutableRootMetadata{}, err
+	}
+	if handle.IsLocalConflict() {
+		md.log.CDebugf(ctx, "Stripping out local conflict info from %s "+
+			"before fetching the ID", handle.GetCanonicalPath())
+		bh.ConflictInfo = nil
 	}
 
 	id, rmds, err := mdserv.GetForHandle(ctx, bh, mStatus, lockBeforeGet)
@@ -1006,9 +1011,11 @@ func (md *MDOpsStandard) GetIDForHandle(
 	default:
 		return tlf.NullID, err
 	}
-	err = mdcache.PutIDForHandle(handle, id)
-	if err != nil {
-		return tlf.NullID, err
+	if !handle.IsLocalConflict() {
+		err = mdcache.PutIDForHandle(handle, id)
+		if err != nil {
+			return tlf.NullID, err
+		}
 	}
 	return id, nil
 }

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -1785,9 +1785,9 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 		return nil, err
 	}
 
-	handle, err := tlfhandle.MakeHandle(
+	handle, err := tlfhandle.MakeHandleWithTlfID(
 		ctx, ibrmdBareHandle, j.tlfID.Type(), j.config.resolver(),
-		j.config.usernameGetter(), tlfhandle.ConstIDGetter{ID: j.tlfID},
+		j.config.usernameGetter(), j.tlfID,
 		j.config.OfflineAvailabilityForID(j.tlfID))
 	if err != nil {
 		return nil, err

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -114,7 +114,7 @@ const (
 )
 
 var tlfJournalBakRegexp = regexp.MustCompile(
-	`[/\\]([[:alnum:]]+)-([[:digit:]]+).bak$`)
+	`[/\\]([[:alnum:]]+)-([[:digit:]]+)\.bak$`)
 
 // TLFJournalStatus represents the status of a TLF's journal for
 // display in diagnostics. It is suitable for encoding directly as

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -286,7 +286,7 @@ func setupTLFJournalTest(
 		math.MaxInt64, math.MaxInt64, math.MaxInt64)
 	tlfJournal, err = makeTLFJournal(ctx, uid, verifyingKey,
 		tempdir, config.tlfID, uid.AsUserOrTeam(), config, delegateBlockServer,
-		bwStatus, delegate, nil, nil, diskLimitSemaphore)
+		bwStatus, delegate, nil, nil, diskLimitSemaphore, tlf.NullID)
 	require.NoError(t, err)
 
 	switch bwStatus {

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -225,6 +225,12 @@ func (k *SimpleFS) branchNameFromPath(
 	}
 	switch pt {
 	case keybase1.PathType_KBFS:
+		if tlfHandle.IsLocalConflict() {
+			b, ok := data.MakeConflictBranchName(tlfHandle)
+			if ok {
+				return b, nil
+			}
+		}
 		return data.MasterBranch, nil
 	case keybase1.PathType_KBFS_ARCHIVED:
 		archivedParam := path.KbfsArchived().ArchivedParam

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -1426,6 +1426,7 @@ func TestFavoriteConflicts(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, keybase1.ConflictStateType_AutomaticResolving,
 				conflictStateType)
+			require.True(t, f.ConflictState.Automaticresolving().IsStuck)
 			stuck++
 		} else {
 			require.Nil(t, f.ConflictState)
@@ -1449,6 +1450,8 @@ func TestFavoriteConflicts(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(
 				t, keybase1.ConflictStateType_ManualResolvingLocalView, ct)
+			mrlv := f.ConflictState.Manualresolvinglocalview()
+			require.Equal(t, pathPub.String(), mrlv.ServerView.String())
 			pathConflict = keybase1.NewPathWithKbfs("/public/" + f.Name)
 		} else {
 			require.Nil(t, f.ConflictState)

--- a/go/kbfs/test/dsl_test.go
+++ b/go/kbfs/test/dsl_test.go
@@ -1158,18 +1158,26 @@ func lsfavoritesOp(c *ctx, expected []string, t tlf.Type) error {
 		return err
 	}
 	c.tb.Log("lsfavorites", t, "=>", favorites)
-	expectedMap := make(map[string]bool)
 	for _, f := range expected {
-		if !favorites[f] {
+		if favorites[f] {
+			delete(favorites, f)
+			continue
+		}
+
+		p, err := tlf.CanonicalToPreferredName(
+			kbname.NormalizedUsername(c.username), tlf.CanonicalName(f))
+		if err != nil {
+			return err
+		}
+		if favorites[string(p)] {
+			delete(favorites, string(p))
+		} else {
 			return fmt.Errorf("Missing favorite %s", f)
 		}
-		expectedMap[f] = true
 	}
 
 	for f := range favorites {
-		if !expectedMap[f] {
-			return fmt.Errorf("Unexpected favorite %s", f)
-		}
+		return fmt.Errorf("Unexpected favorite %s", f)
 	}
 	return nil
 }

--- a/go/kbfs/test/dsl_test.go
+++ b/go/kbfs/test/dsl_test.go
@@ -1152,6 +1152,18 @@ func disablePrefetch() fileOp {
 	}, IsInit, "disablePrefetch()"}
 }
 
+func forceConflict() fileOp {
+	return fileOp{func(c *ctx) error {
+		return c.engine.ForceConflict(c.user, c.tlfName, c.tlfType)
+	}, IsInit, "forceConflict()"}
+}
+
+func clearConflicts() fileOp {
+	return fileOp{func(c *ctx) error {
+		return c.engine.ClearConflicts(c.user, c.tlfName, c.tlfType)
+	}, IsInit, "clearConflicts()"}
+}
+
 func lsfavoritesOp(c *ctx, expected []string, t tlf.Type) error {
 	favorites, err := c.engine.GetFavorites(c.user, t)
 	if err != nil {
@@ -1192,6 +1204,12 @@ func lsprivatefavorites(contents []string) fileOp {
 	return fileOp{func(c *ctx) error {
 		return lsfavoritesOp(c, contents, tlf.Private)
 	}, Defaults, fmt.Sprintf("lsprivatefavorites(%s)", contents)}
+}
+
+func lsteamfavorites(contents []string) fileOp {
+	return fileOp{func(c *ctx) error {
+		return lsfavoritesOp(c, contents, tlf.SingleTeam)
+	}, Defaults, fmt.Sprintf("lsteamfavorites(%s)", contents)}
 }
 
 func lsdir(name string, contents m) fileOp {

--- a/go/kbfs/test/engine.go
+++ b/go/kbfs/test/engine.go
@@ -177,6 +177,11 @@ type Engine interface {
 	// TogglePrefetch is called by the test harness as the given user to toggle
 	// whether prefetching should be enabled
 	TogglePrefetch(u User, enable bool) error
+	// ForceConflict can force a stuck conflict in the given TLF.
+	ForceConflict(u User, tlfName string, t tlf.Type) (err error)
+	// ClearConflicts can clear the conflicts in a TLF by moving the
+	// conflict view out of the way.
+	ClearConflicts(u User, tlfName string, t tlf.Type) (err error)
 	// Shutdown is called by the test harness when it is done with the
 	// given user.
 	Shutdown(u User) error

--- a/go/kbfs/test/engine_fs_test.go
+++ b/go/kbfs/test/engine_fs_test.go
@@ -501,6 +501,49 @@ func (*fsEngine) TogglePrefetch(user User, enable bool) error {
 		[]byte("1"), 0644)
 }
 
+// ForceConflict implements the Engine interface.
+func (*fsEngine) ForceConflict(user User, tlfName string, t tlf.Type) error {
+	u := user.(*fsUser)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx, err := libcontext.NewContextWithCancellationDelayer(
+		libcontext.NewContextReplayable(
+			ctx, func(ctx context.Context) context.Context { return ctx }))
+	if err != nil {
+		return err
+	}
+
+	root, err := getRootNode(ctx, u.config, tlfName, t)
+	if err != nil {
+		return err
+	}
+
+	return u.config.KBFSOps().ForceStuckConflictForTesting(
+		ctx, root.GetFolderBranch().Tlf)
+}
+
+// ClearConflicts implements the Engine interface.
+func (*fsEngine) ClearConflicts(user User, tlfName string, t tlf.Type) error {
+	u := user.(*fsUser)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx, err := libcontext.NewContextWithCancellationDelayer(
+		libcontext.NewContextReplayable(
+			ctx, func(ctx context.Context) context.Context { return ctx }))
+	if err != nil {
+		return err
+	}
+
+	root, err := getRootNode(ctx, u.config, tlfName, t)
+	if err != nil {
+		return err
+	}
+
+	return u.config.KBFSOps().ClearConflictView(ctx, root.GetFolderBranch().Tlf)
+}
+
 // Shutdown is called by the test harness when it is done with the
 // given user.
 func (e *fsEngine) Shutdown(user User) error {

--- a/go/kbfs/tlfhandle/handle.go
+++ b/go/kbfs/tlfhandle/handle.go
@@ -508,7 +508,15 @@ func (h Handle) IsFinal() bool {
 // IsConflict returns whether or not this TlfHandle represents a conflicted
 // top-level folder.
 func (h Handle) IsConflict() bool {
-	return h.conflictInfo != nil
+	return h.conflictInfo != nil &&
+		h.conflictInfo.Type == tlf.HandleExtensionConflict
+}
+
+// IsLocalConflict returns whether or not this TlfHandle represents a
+// locally conflict branch for a top-level folder.
+func (h Handle) IsLocalConflict() bool {
+	return h.conflictInfo != nil &&
+		h.conflictInfo.Type == tlf.HandleExtensionLocalConflict
 }
 
 // GetPreferredFormat returns a TLF name formatted with the username given

--- a/go/kbfs/tlfhandle/handle.go
+++ b/go/kbfs/tlfhandle/handle.go
@@ -446,6 +446,12 @@ func (h *Handle) GetCanonicalPath() string {
 	return BuildCanonicalPathForTlfName(h.Type(), h.GetCanonicalName())
 }
 
+// GetProtocolPath returns the `keybase1.Path` representing this
+// handle.
+func (h *Handle) GetProtocolPath() keybase1.Path {
+	return BuildProtocolPathForTlfName(h.Type(), h.GetCanonicalName())
+}
+
 // ToFavorite converts a TlfHandle into a Favorite, suitable for
 // Favorites calls.
 func (h *Handle) ToFavorite() favorites.Folder {

--- a/go/kbfs/tlfhandle/path.go
+++ b/go/kbfs/tlfhandle/path.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 // PathType describes the types for different paths
@@ -49,7 +50,7 @@ func BuildCanonicalPath(pathType PathType, paths ...string) string {
 }
 
 // BuildCanonicalPathForTlfType is like BuildCanonicalPath, but accepts a
-// tlf.Type instead of PathhType.
+// tlf.Type instead of PathType.
 func BuildCanonicalPathForTlfType(t tlf.Type, paths ...string) string {
 	var pathType PathType
 	switch t {
@@ -76,4 +77,24 @@ func BuildCanonicalPathForTlfName(t tlf.Type, tlfName tlf.CanonicalName) string 
 // does not try to canonicalize TLF names.
 func BuildCanonicalPathForTlf(tlf tlf.ID, paths ...string) string {
 	return BuildCanonicalPathForTlfType(tlf.Type(), paths...)
+}
+
+// BuildProtocolPathForTlfName builds a `keybase1.Path` for the given
+// TLF type and name.
+func BuildProtocolPathForTlfName(
+	t tlf.Type, tlfName tlf.CanonicalName) keybase1.Path {
+	var pathType PathType
+	switch t {
+	case tlf.Private:
+		pathType = PrivatePathType
+	case tlf.Public:
+		pathType = PublicPathType
+	case tlf.SingleTeam:
+		pathType = SingleTeamPathType
+	default:
+		panic(fmt.Sprintf("Unknown tlf path type: %d", t))
+	}
+
+	return keybase1.NewPathWithKbfs(
+		"/" + string(pathType) + "/" + string(tlfName))
 }

--- a/go/kbfs/tlfhandle/resolve.go
+++ b/go/kbfs/tlfhandle/resolve.go
@@ -250,9 +250,13 @@ func makeHandleHelper(
 		tlfID:             tlfID,
 	}
 
-	if !isImplicit && h.tlfID == tlf.NullID && idGetter != nil {
+	needIDLookup := (!isImplicit && h.tlfID == tlf.NullID) ||
+		(conflictInfo != nil &&
+			conflictInfo.Type == tlf.HandleExtensionLocalConflict)
+	if needIDLookup && idGetter != nil {
 		// If this isn't an implicit team yet, look up possible
-		// pre-existing TLF ID from the mdserver.
+		// pre-existing TLF ID from the mdserver.  If this is a local
+		// conflict branch, look up the fake TLF ID from the journal.
 		tlfID, err := idGetter.GetIDForHandle(ctx, h)
 		if err != nil {
 			return nil, err
@@ -468,7 +472,12 @@ func (h Handle) ResolvesTo(
 	resolvesTo bool, partialResolvedH *Handle, err error) {
 	// Check the conflict extension.
 	var conflictAdded, finalizedAdded bool
-	if !h.IsConflict() && other.IsConflict() {
+	if (h.IsConflict() && other.IsLocalConflict()) ||
+		(h.IsLocalConflict() && other.IsConflict()) {
+		return false, nil, errors.New(
+			"Can't transition between conflict and local conflict")
+	} else if (!h.IsConflict() && other.IsConflict()) ||
+		(!h.IsLocalConflict() && other.IsLocalConflict()) {
 		conflictAdded = true
 		// Ignore the added extension for resolution comparison purposes.
 		other.conflictInfo = nil
@@ -758,9 +767,23 @@ func parseHandleLoose(
 	// that doesn't work, fall through to individual name resolution.
 	var iteamHandle *Handle
 	if doResolveImplicit(ctx, t) {
-		rit := resolvableImplicitTeam{kbpki, name, t, offline}
+		// The service doesn't know about local conflict branches, so
+		// strip those out before resolving if needed.
+		assertions, extensionSuffix, err := tlf.SplitExtension(name)
+		if err != nil {
+			return nil, err
+		}
+
+		iteamName := name
+		var iteamExtensions tlf.HandleExtensionList
+		if tlf.ContainsLocalConflictExtensionPrefix(extensionSuffix) {
+			iteamName = assertions
+			iteamExtensions = tlf.HandleExtensionList(extensions)
+		}
+
+		rit := resolvableImplicitTeam{kbpki, iteamName, t, offline}
 		iteamHandle, err = makeHandleHelper(
-			ctx, t, []resolvableUser{rit}, nil, nil, idGetter)
+			ctx, t, []resolvableUser{rit}, nil, iteamExtensions, idGetter)
 		if err == nil && iteamHandle.tlfID != tlf.NullID {
 			// The iteam already has a TLF ID, let's use it.
 

--- a/go/protocol/keybase1/favorite.go
+++ b/go/protocol/keybase1/favorite.go
@@ -47,6 +47,7 @@ const (
 	FolderConflictType_NONE                  FolderConflictType = 0
 	FolderConflictType_IN_CONFLICT           FolderConflictType = 1
 	FolderConflictType_IN_CONFLICT_AND_STUCK FolderConflictType = 2
+	FolderConflictType_CLEARED_CONFLICT      FolderConflictType = 3
 )
 
 func (o FolderConflictType) DeepCopy() FolderConflictType { return o }
@@ -55,12 +56,14 @@ var FolderConflictTypeMap = map[string]FolderConflictType{
 	"NONE":                  0,
 	"IN_CONFLICT":           1,
 	"IN_CONFLICT_AND_STUCK": 2,
+	"CLEARED_CONFLICT":      3,
 }
 
 var FolderConflictTypeRevMap = map[FolderConflictType]string{
 	0: "NONE",
 	1: "IN_CONFLICT",
 	2: "IN_CONFLICT_AND_STUCK",
+	3: "CLEARED_CONFLICT",
 }
 
 func (e FolderConflictType) String() string {

--- a/protocol/avdl/keybase1/favorite.avdl
+++ b/protocol/avdl/keybase1/favorite.avdl
@@ -13,8 +13,9 @@ protocol favorite {
   enum FolderConflictType {
     NONE_0,
     IN_CONFLICT_1,
-    IN_CONFLICT_AND_STUCK_2
-  }
+    IN_CONFLICT_AND_STUCK_2,
+    CLEARED_CONFLICT_3
+}
 
   enum ConflictStateType {
     AutomaticResolving_0,

--- a/protocol/json/keybase1/favorite.json
+++ b/protocol/json/keybase1/favorite.json
@@ -23,7 +23,8 @@
       "symbols": [
         "NONE_0",
         "IN_CONFLICT_1",
-        "IN_CONFLICT_AND_STUCK_2"
+        "IN_CONFLICT_AND_STUCK_2",
+        "CLEARED_CONFLICT_3"
       ]
     },
     {

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1319,6 +1319,7 @@ export enum FolderConflictType {
   none = 0,
   inConflict = 1,
   inConflictAndStuck = 2,
+  clearedConflict = 3,
 }
 
 export enum FolderSyncMode {


### PR DESCRIPTION
When a user calls `keybase fs clear-conflicts`, it renames the stuck conflict journal to a backup directory, but doesn't delete it.  The user would then have access to the "master" view of the TLF via the usual path (e.g., `/keybase/private/alice,bob`), but might want to retrieve and manually copy changes from the old conflict branch into the master view again, in hopes that the conflict doesn't recur this time.

So this PR exposes that stuck, local conflict view as a read-only TLF under a new path.  In the above example, the new path would be `/keybase/private/alice,bob (local conflicted copy 2019-05-16 #1)`, if they cleared the conflict on 5/16/19 UTC time.  Since they could theoretically clear multiple conflicts on the same day, we also support `#2`, `#3`, etc in this name.  (Old-style, pre-iteam TLFs omit the `#1` when there's only one, but the service expects it to always be there for new, iteam-backed TLFs.)

But because we put this in the favorites list as a new TLF (as opposed to something like `.kbfs_archived_rev=` directories that live under the main TLF itself), we needed to give it a unique TLF ID. This turns out to be pretty challenging, as it needs to be plumbed through to where handles are created.  Much of the development time came to shaking out corner cases related to that, and fixing latent bugs that it exposed.

This works by the `JournalManager` scanning all backup directories on startup, creating fake TLF IDs for each of them, and maintaining a map from the real TLF ID plus the date+number conflict suffix to the fake ID.  The journal serves that as the TLF ID whenever a handle lookup needs to find the TLF ID for the handle.  From there, the journal just serves any data requested for the fake TLF ID from that backup directory.

This also adds a new TLF handle extension type for local conflicts, and treats handles with those conflicts specially in some places (like when looking up the TLF ID).  This extension type isn't known by either the service or the mdserver, so it needs to be stripped out before communicating with them, to ensure we get the data corresponding to the "master" TLF.

I didn't bother making this conflict-clearing stuff work with the _other_ type of TLF-level conflict, when an SBS resolution conflicts.  I figured the possibility of a stuck conflict on one of those folders is so remote that it isn't worth our time to support it.  (The client will panic in that case, I think.)  If anyone feels strongly we should support it, let me know.

The local conflict view TLFs are returned in the favorites list, so that the user can easily find them from the CLI.  In addition to the conflict suffix described above, they are also given a new conflict type to show that they have been moved away from the master view.

The commits are separately reviewable, if that's preferred.

Issue: KBFS-4138