### PR TITLE
Delete with NIST only if random_pw

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -5885,7 +5885,7 @@ func TestChatSrvUserResetAndDeleted(t *testing.T) {
 
 		t.Logf("delete user 3")
 		ctcForUser3 := ctc.as(t, users[3])
-		require.NoError(t, libkb.DeleteAccount(ctcForUser3.m, users[3].NormalizedUsername(), users[3].Passphrase))
+		require.NoError(t, libkb.DeleteAccount(ctcForUser3.m, users[3].NormalizedUsername(), &users[3].Passphrase))
 		select {
 		case <-listener0.membersUpdate:
 			require.Fail(t, "got members update after delete")

--- a/go/client/cmd_account_delete.go
+++ b/go/client/cmd_account_delete.go
@@ -5,6 +5,9 @@ package client
 
 import (
 	"errors"
+	"fmt"
+
+	"github.com/keybase/client/go/protocol/keybase1"
 
 	"golang.org/x/net/context"
 
@@ -42,9 +45,36 @@ func NewCmdAccountDeleteRunner(g *libkb.GlobalContext) *CmdAccountDelete {
 	}
 }
 
-func (c *CmdAccountDelete) Run() error {
+func (c *CmdAccountDelete) promptToConfirm() error {
 	ui := c.G().UI.GetTerminalUI()
 	err := ui.PromptForConfirmation("Are you sure you want to " + ColorString(c.G(), "red", "permanently delete") + " your account?")
+	if err != nil {
+		return err
+	}
+	cli, err := GetUserClient(c.G())
+	if err != nil {
+		return err
+	}
+	randomPW, err := cli.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	if err != nil {
+		return err
+	}
+	if randomPW {
+		expected := fmt.Sprintf("I want to delete my account %s", c.G().Env.GetUsername().String())
+		promptStr := fmt.Sprintf("Please type '%s' to confirm: ", expected)
+		ret, err := ui.Prompt(PromptDescriptorAccountDeleteConfirmation, promptStr)
+		if err != nil {
+			return err
+		}
+		if ret != expected {
+			return errors.New("Input did not match expected text")
+		}
+	}
+	return nil
+}
+
+func (c *CmdAccountDelete) Run() error {
+	err := c.promptToConfirm()
 	if err != nil {
 		return err
 	}
@@ -58,7 +88,12 @@ func (c *CmdAccountDelete) Run() error {
 	if err != nil {
 		return err
 	}
-	return cli.AccountDelete(context.Background(), 0)
+	err = cli.AccountDelete(context.Background(), 0)
+	if err != nil {
+		return err
+	}
+	c.G().UI.GetDumbOutputUI().PrintfStderr("Account deleted.\n")
+	return nil
 }
 
 func (c *CmdAccountDelete) GetUsage() libkb.Usage {

--- a/go/client/cmd_account_reset.go
+++ b/go/client/cmd_account_reset.go
@@ -71,7 +71,12 @@ func (c *CmdAccountReset) Run() error {
 	if err != nil {
 		return err
 	}
-	return cli.ResetAccount(context.Background(), keybase1.ResetAccountArg{})
+	err = cli.ResetAccount(context.Background(), keybase1.ResetAccountArg{})
+	if err != nil {
+		return err
+	}
+	c.G().UI.GetDumbOutputUI().PrintfStderr("Account has been reset.\n")
+	return nil
 }
 
 func (c *CmdAccountReset) GetUsage() libkb.Usage {

--- a/go/client/cmd_account_reset.go
+++ b/go/client/cmd_account_reset.go
@@ -41,7 +41,26 @@ func (c *CmdAccountReset) ParseArgv(ctx *cli.Context) error {
 	return nil
 }
 
+func (c *CmdAccountReset) checkRandomPW() error {
+	cli, err := GetUserClient(c.G())
+	if err != nil {
+		return err
+	}
+	randomPW, err := cli.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	if err != nil {
+		return err
+	}
+	if randomPW {
+		return errors.New("Can't reset without a password. Set a password first")
+	}
+	return nil
+}
+
 func (c *CmdAccountReset) Run() error {
+	err := c.checkRandomPW()
+	if err != nil {
+		return err
+	}
 	protocols := []rpc.Protocol{
 		NewSecretUIProtocol(c.G()),
 	}

--- a/go/client/cmd_account_reset.go
+++ b/go/client/cmd_account_reset.go
@@ -57,8 +57,7 @@ func (c *CmdAccountReset) checkRandomPW() error {
 }
 
 func (c *CmdAccountReset) Run() error {
-	err := c.checkRandomPW()
-	if err != nil {
+	if err := c.checkRandomPW(); err != nil {
 		return err
 	}
 	protocols := []rpc.Protocol{

--- a/go/client/prompts.go
+++ b/go/client/prompts.go
@@ -72,6 +72,7 @@ const (
 	PromptDescriptorResetAccount
 	PromptDescriptorPassphraseRecovery
 	PromptDescriptorStellarURIAmount
+	PromptDescriptorAccountDeleteConfirmation
 )
 
 const (

--- a/go/engine/merkle_client_historical_test.go
+++ b/go/engine/merkle_client_historical_test.go
@@ -2,10 +2,11 @@ package engine
 
 import (
 	"context"
+	"testing"
+
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestMerkleClientHistorical(t *testing.T) {
@@ -112,7 +113,7 @@ func TestFindNextMerkleRootAfterRevoke(t *testing.T) {
 	t.Logf("Found merkle root %d > %d", after, before)
 
 	// Make sure we can find this after fu is deleted
-	err = libkb.DeleteAccount(m, fu.NormalizedUsername(), fu.Passphrase)
+	err = libkb.DeleteAccount(m, fu.NormalizedUsername(), &fu.Passphrase)
 	require.NoError(t, err)
 	err = tc.G.Logout(context.TODO())
 	require.NoError(t, err)

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -147,7 +147,7 @@ func ResetAccount(tc libkb.TestContext, u *FakeUser) {
 
 func DeleteAccount(tc libkb.TestContext, u *FakeUser) {
 	m := libkb.NewMetaContextForTest(tc)
-	err := libkb.DeleteAccount(m, u.NormalizedUsername(), u.Passphrase)
+	err := libkb.DeleteAccount(m, u.NormalizedUsername(), &u.Passphrase)
 	require.NoError(tc.T, err)
 	tc.T.Logf("Account deleted for user %s", u.Username)
 	Logout(tc)


### PR DESCRIPTION
I realized we shouldn't allow this for nuking because then you are not able to sign in to reprovision anyway.

BUT - the `account reset` command is devel only and the whole thing is being replaced with reset pipeline, so we are fine. 

Just fix delete for random pws here.