### PR TITLE
test rpm md sig

### DIFF
--- a/packaging/linux/rpm/layout_repo.sh
+++ b/packaging/linux/rpm/layout_repo.sh
@@ -92,6 +92,9 @@ for arch in i386 x86_64 ; do
   # Run createrepo to update the database files.
   "$CREATEREPO" "$repo_root/repo/$arch"
 
+  gpg --detach-sign --armor --use-agent --local-user "$code_signing_fingerprint" \
+      -o "$repo_root/repo/$arch/repodata/repomd.xml.asc" "$repo_root/repo/$arch/repodata/repomd.xml"
+
   # Add updateinfo.xml changelog to the repo
   "$MODIFYREPO" "$here/updateinfo.xml" "$repo_root/repo/$arch/repodata"
 done


### PR DESCRIPTION
Addresses https://github.com/keybase/keybase-issues/issues/3412

We were signing the binary but not the metadata file. Seems it is common practice to sign the metadata file as well.