### PR TITLE
favorites: add a buffered refresh mode for when mtime changes

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3328,7 +3328,7 @@ func (cr *ConflictResolver) recordFinishResolve(
 		}
 
 		if wasStuck {
-			cr.config.KeybaseService().NotifyFavoritesChanged(ctx)
+			cr.config.Reporter().NotifyFavoritesChanged(ctx)
 		}
 		return
 	}
@@ -3372,7 +3372,7 @@ func (cr *ConflictResolver) recordFinishResolve(
 	}
 
 	if !wasStuck && isCRStuckFromRecords(conflictsSoFar) {
-		cr.config.KeybaseService().NotifyFavoritesChanged(ctx)
+		cr.config.Reporter().NotifyFavoritesChanged(ctx)
 	}
 }
 
@@ -3732,7 +3732,7 @@ func (cr *ConflictResolver) clearConflictRecords(ctx context.Context) error {
 	}
 
 	if wasStuck {
-		cr.config.KeybaseService().NotifyFavoritesChanged(ctx)
+		cr.config.Reporter().NotifyFavoritesChanged(ctx)
 	}
 	return nil
 }

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -37,7 +37,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	id := tlf.FakeID(1, tlf.Private)
 	fbo := newFolderBranchOps(ctx, env.EmptyAppStateUpdater{}, config,
 		data.FolderBranch{Tlf: id, Branch: data.MasterBranch}, standard,
-		nil, nil)
+		nil, nil, nil)
 	// usernames don't matter for these tests
 	config.mockKbpki.EXPECT().GetNormalizedUsername(
 		gomock.Any(), gomock.Any(), gomock.Any()).

--- a/go/kbfs/libkbfs/favorites.go
+++ b/go/kbfs/libkbfs/favorites.go
@@ -332,7 +332,7 @@ func (f *Favorites) handleReq(req *favReq) (err error) {
 	defer func() {
 		f.closeReq(req, err)
 		if changed {
-			f.config.KeybaseService().NotifyFavoritesChanged(req.ctx)
+			f.config.Reporter().NotifyFavoritesChanged(req.ctx)
 		}
 	}()
 

--- a/go/kbfs/libkbfs/favorites_test.go
+++ b/go/kbfs/libkbfs/favorites_test.go
@@ -34,8 +34,8 @@ func favTestInit(t *testing.T, testingDiskCache bool) (
 			}, nil)
 	}
 	config.mockClock.EXPECT().Now().Return(time.Unix(0, 0)).AnyTimes()
-	config.mockKbs.EXPECT().NotifyFavoritesChanged(gomock.Any()).Return(nil).
-		AnyTimes()
+	config.mockRep.EXPECT().
+		NotifyFavoritesChanged(gomock.Any()).Return().AnyTimes()
 
 	return mockCtrl, config, context.Background()
 }

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -261,6 +261,7 @@ type folderBranchOps struct {
 	bType         branchType
 	observers     *observerList
 	serviceStatus *kbfsCurrentStatus
+	favs          *Favorites
 
 	// The leveled locks below, when locked concurrently by the same
 	// goroutine, should only be taken in the following order to avoid
@@ -399,7 +400,7 @@ func newFolderBranchOps(
 	config Config, fb data.FolderBranch,
 	bType branchType,
 	quotaUsage *EventuallyConsistentQuotaUsage,
-	serviceStatus *kbfsCurrentStatus) *folderBranchOps {
+	serviceStatus *kbfsCurrentStatus, favs *Favorites) *folderBranchOps {
 	var nodeCache NodeCache
 	if config.Mode().NodeCacheEnabled() {
 		nodeCache = newNodeCacheStandard(fb)
@@ -453,6 +454,7 @@ func newFolderBranchOps(
 		bType:         bType,
 		observers:     observers,
 		serviceStatus: serviceStatus,
+		favs:          favs,
 		status: newFolderBranchStatusKeeper(
 			config, nodeCache, quotaUsage, fb.Tlf.Bytes()),
 		mdWriterLock: mdWriterLock,
@@ -576,30 +578,29 @@ func (fbo *folderBranchOps) branch() data.BranchName {
 	return fbo.folderBranch.Branch
 }
 
-func (fbo *folderBranchOps) addToFavorites(ctx context.Context,
-	favorites *Favorites, created bool) (err error) {
+func (fbo *folderBranchOps) addToFavorites(
+	ctx context.Context, created bool) (err error) {
 	lState := makeFBOLockState()
 	head := fbo.getTrustedHead(ctx, lState, mdNoCommit)
 	if head == (ImmutableRootMetadata{}) {
 		return OpsCantHandleFavorite{"Can't add a favorite without a handle"}
 	}
 
-	return fbo.addToFavoritesByHandle(ctx, favorites, head.GetTlfHandle(), created)
+	return fbo.addToFavoritesByHandle(ctx, head.GetTlfHandle(), created)
 }
 
-func (fbo *folderBranchOps) addToFavoritesByHandle(ctx context.Context,
-	favorites *Favorites, handle *tlfhandle.Handle, created bool) (err error) {
+func (fbo *folderBranchOps) addToFavoritesByHandle(
+	ctx context.Context, handle *tlfhandle.Handle, created bool) (err error) {
 	if _, err := fbo.config.KBPKI().GetCurrentSession(ctx); err != nil {
 		// Can't favorite while not logged in
 		return nil
 	}
 
-	favorites.AddAsync(ctx, handle.ToFavToAdd(created))
+	fbo.favs.AddAsync(ctx, handle.ToFavToAdd(created))
 	return nil
 }
 
-func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context,
-	favorites *Favorites) error {
+func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context) error {
 	if _, err := fbo.config.KBPKI().GetCurrentSession(ctx); err != nil {
 		// Can't unfavorite while not logged in
 		return nil
@@ -613,26 +614,26 @@ func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context,
 	}
 
 	h := head.GetTlfHandle()
-	return favorites.Delete(ctx, h.ToFavorite())
+	return fbo.favs.Delete(ctx, h.ToFavorite())
 }
 
-func (fbo *folderBranchOps) doFavoritesOp(ctx context.Context,
-	favs *Favorites, fop FavoritesOp, handle *tlfhandle.Handle) error {
+func (fbo *folderBranchOps) doFavoritesOp(
+	ctx context.Context, fop FavoritesOp, handle *tlfhandle.Handle) error {
 	switch fop {
 	case FavoritesOpNoChange:
 		return nil
 	case FavoritesOpAdd:
 		if handle != nil {
-			return fbo.addToFavoritesByHandle(ctx, favs, handle, false)
+			return fbo.addToFavoritesByHandle(ctx, handle, false)
 		}
-		return fbo.addToFavorites(ctx, favs, false)
+		return fbo.addToFavorites(ctx, false)
 	case FavoritesOpAddNewlyCreated:
 		if handle != nil {
-			return fbo.addToFavoritesByHandle(ctx, favs, handle, true)
+			return fbo.addToFavoritesByHandle(ctx, handle, true)
 		}
-		return fbo.addToFavorites(ctx, favs, true)
+		return fbo.addToFavorites(ctx, true)
 	case FavoritesOpRemove:
-		return fbo.deleteFromFavorites(ctx, favs)
+		return fbo.deleteFromFavorites(ctx)
 	default:
 		return InvalidFavoritesOpError{}
 	}
@@ -9304,6 +9305,7 @@ func (fbo *folderBranchOps) handleEditActivity(
 		if rmd != (ImmutableRootMetadata{}) {
 			_ = fbo.kickOffEditActivityPartialSync(ctx, lState, rmd)
 		}
+		fbo.favs.RefreshCacheWhenMTimeChanged(ctx)
 		fbo.editActivity.Done()
 	}()
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -880,6 +880,8 @@ type Reporter interface {
 	// status to any sink.
 	NotifyOverallSyncStatus(
 		ctx context.Context, status keybase1.FolderSyncStatus)
+	// NotifyFavoritesChanged sends the a favorites invalidation to any sink.
+	NotifyFavoritesChanged(ctx context.Context)
 	// Shutdown frees any resources allocated by a Reporter.
 	Shutdown()
 }

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -407,7 +407,7 @@ func (fs *KBFSOpsStandard) DeleteFavorite(ctx context.Context,
 	// Let this ops remove itself, if we have one available.
 	ops := fs.getOpsByFav(fav)
 	if ops != nil {
-		err := ops.doFavoritesOp(ctx, fs.favs, FavoritesOpRemove, nil)
+		err := ops.doFavoritesOp(ctx, FavoritesOpRemove, nil)
 		if _, ok := err.(OpsCantHandleFavorite); !ok {
 			return err
 		}
@@ -461,7 +461,7 @@ func (fs *KBFSOpsStandard) getOpsNoAdd(
 		}
 		ops = newFolderBranchOps(
 			ctx, fs.appStateUpdater, fs.config, fb, bType, quotaUsage,
-			fs.currentStatus)
+			fs.currentStatus, fs.favs)
 		fs.ops[fb] = ops
 	}
 	return ops
@@ -481,7 +481,7 @@ func (fs *KBFSOpsStandard) getOpsIfExists(
 func (fs *KBFSOpsStandard) getOps(ctx context.Context,
 	fb data.FolderBranch, fop FavoritesOp) *folderBranchOps {
 	ops := fs.getOpsNoAdd(ctx, fb)
-	if err := ops.doFavoritesOp(ctx, fs.favs, fop, nil); err != nil {
+	if err := ops.doFavoritesOp(ctx, fop, nil); err != nil {
 		// Failure to favorite shouldn't cause a failure.  Just log
 		// and move on.
 		fs.log.CDebugf(ctx, "Couldn't add favorite: %v", err)
@@ -497,7 +497,7 @@ func (fs *KBFSOpsStandard) getOpsByNode(ctx context.Context,
 func (fs *KBFSOpsStandard) getOpsByHandle(ctx context.Context,
 	handle *tlfhandle.Handle, fb data.FolderBranch, fop FavoritesOp) *folderBranchOps {
 	ops := fs.getOpsNoAdd(ctx, fb)
-	if err := ops.doFavoritesOp(ctx, fs.favs, fop, handle); err != nil {
+	if err := ops.doFavoritesOp(ctx, fop, handle); err != nil {
 		// Failure to favorite shouldn't cause a failure.  Just log
 		// and move on.
 		fs.log.CDebugf(ctx, "Couldn't add favorite: %v", err)
@@ -896,7 +896,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 		return nil, data.EntryInfo{}, err
 	}
 
-	if err := ops.doFavoritesOp(ctx, fs.favs, FavoritesOpAdd, h); err != nil {
+	if err := ops.doFavoritesOp(ctx, FavoritesOpAdd, h); err != nil {
 		// Failure to favorite shouldn't cause a failure.  Just log
 		// and move on.
 		fs.log.CDebugf(ctx, "Couldn't add favorite: %v", err)
@@ -1431,6 +1431,7 @@ func (fs *KBFSOpsStandard) NewNotificationChannel(
 			"Handle %s for existing folder unexpectedly has no TLF ID",
 			handle.GetCanonicalName())
 	}
+	fs.favs.RefreshCacheWhenMTimeChanged(ctx)
 }
 
 // Reset implements the KBFSOps interface for KBFSOpsStandard.

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -150,6 +150,8 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	err := errors.New("Fake error to prevent trying to read favs from disk")
 	config.mockKbpki.EXPECT().GetCurrentSession(gomock.Any()).Return(
 		idutil.SessionInfo{}, err)
+	config.mockRep.EXPECT().
+		NotifyFavoritesChanged(gomock.Any()).Return().AnyTimes()
 	kbfsops.favs.Initialize(ctx)
 	config.mockKbpki.EXPECT().FavoriteList(gomock.Any()).AnyTimes().
 		Return(keybase1.FavoritesResult{}, nil)

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -3979,6 +3979,18 @@ func (mr *MockReporterMockRecorder) Notify(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockReporter)(nil).Notify), arg0, arg1)
 }
 
+// NotifyFavoritesChanged mocks base method
+func (m *MockReporter) NotifyFavoritesChanged(arg0 context.Context) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyFavoritesChanged", arg0)
+}
+
+// NotifyFavoritesChanged indicates an expected call of NotifyFavoritesChanged
+func (mr *MockReporterMockRecorder) NotifyFavoritesChanged(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyFavoritesChanged", reflect.TypeOf((*MockReporter)(nil).NotifyFavoritesChanged), arg0)
+}
+
 // NotifyOverallSyncStatus mocks base method
 func (m *MockReporter) NotifyOverallSyncStatus(arg0 context.Context, arg1 keybase1.FolderSyncStatus) {
 	m.ctrl.T.Helper()

--- a/go/kbfs/libkbfs/reporter_simple.go
+++ b/go/kbfs/libkbfs/reporter_simple.go
@@ -108,6 +108,12 @@ func (r *ReporterSimple) NotifySyncStatus(_ context.Context,
 	// ignore notifications
 }
 
+// NotifyFavoritesChanged implements the Reporter interface for
+// ReporterSimple.
+func (r *ReporterSimple) NotifyFavoritesChanged(_ context.Context) {
+	// ignore notifications
+}
+
 // NotifyOverallSyncStatus implements the Reporter interface for
 // ReporterSimple.
 func (r *ReporterSimple) NotifyOverallSyncStatus(


### PR DESCRIPTION
We want to refresh the favorites list from the API server when we know the mtime has changed, but not too often, since that will lead to wasteful network/server usage.  So limit it to once every 5 seconds when we get new info about the edit history.

Similarly, don't send favorite changes notifications too fast -- buffer them in `ReporterKBPKI`, also for once every 5 seconds.

Finally, fix a bug where we were overwriting the mtime for the user's home directories with an mtime of 0.

Issue: KBFS-4174