### PR TITLE
backpressure_disk_limiter: set the sync cache limits properly

### DIFF
--- a/go/kbfs/libkbfs/backpressure_disk_limiter.go
+++ b/go/kbfs/libkbfs/backpressure_disk_limiter.go
@@ -757,8 +757,8 @@ func newBackpressureDiskLimiter(
 	// that the disk cache should consume. Add 0.5 for rounding.
 	diskCacheByteLimit := int64(
 		(float64(params.byteLimit) * params.diskCacheFrac) + 0.5)
-	syncCacheByteLimit := int64(
-		(float64(params.byteLimit) * params.syncCacheFrac) + 0.5)
+	// The byte limit doesn't apply to the sync cache.
+	syncCacheByteLimit := int64(math.MaxInt64)
 	overallByteTracker, err := newBackpressureTracker(
 		1.0, 1.0, 1.0, params.byteLimit, freeBytes)
 	if err != nil {
@@ -771,7 +771,7 @@ func newBackpressureDiskLimiter(
 		return nil, err
 	}
 	syncCacheByteTracker, err := newBackpressureTracker(
-		1.0, 1.0, params.diskCacheFrac, syncCacheByteLimit, freeBytes)
+		1.0, 1.0, params.syncCacheFrac, syncCacheByteLimit, freeBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/backpressure_disk_limiter_test.go
+++ b/go/kbfs/libkbfs/backpressure_disk_limiter_test.go
@@ -433,6 +433,7 @@ func makeTestBackpressureDiskLimiterParams() backpressureDiskLimiterParams {
 		quotaMaxThreshold: 1.2,
 		journalFrac:       0.25,
 		diskCacheFrac:     0.1,
+		syncCacheFrac:     1.0,
 		byteLimit:         400,
 		fileLimit:         40,
 		maxDelay:          8 * time.Second,


### PR DESCRIPTION
1. The sync cache doesn't need to abide by the 200 GB max set for the working set cache.
2. Use the right param for setting the sync limit fraction.