### PR TITLE
Fix nav2 header displaying on desktop

### DIFF
--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -79,19 +79,19 @@ class Header extends React.PureComponent<Props> {
       title = <PlainTitle title={opt.title} />
     }
 
-    if (typeof opt.headerTitle === 'function') {
+    if (opt.headerTitle) {
       const CustomTitle = opt.headerTitle
       title = <CustomTitle>{opt.title}</CustomTitle>
     }
 
     let rightActions = null
-    if (typeof opt.headerRightActions === 'function') {
+    if (opt.headerRightActions) {
       const CustomActions = opt.headerRightActions
       rightActions = <CustomActions />
     }
 
     let subHeader = null
-    if (typeof opt.subHeader === 'function') {
+    if (opt.subHeader) {
       const CustomSubHeader = opt.subHeader
       subHeader = <CustomSubHeader />
     }


### PR DESCRIPTION
@keybase/react-hackers 

Looks like React components stopped being functions and started being objects, perhaps in the newer React that came along with newer RN.  Haven't had a chance to investigate further but this PR looks fine on master to me.