### PR TITLE
fix nav2 header assumptions

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -153,6 +153,7 @@
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-gateway": "3.0.0",
+    "react-is": "16.8.6",
     "react-list": "0.8.11",
     "react-measure": "2.2.2",
     "react-native": "0.59.8",

--- a/shared/router-v2/header/index.desktop.js
+++ b/shared/router-v2/header/index.desktop.js
@@ -7,6 +7,7 @@ import * as Window from '../../util/window-management'
 import SyncingFolders from './syncing-folders'
 import flags from '../../util/feature-flags'
 import AppState from '../../app/app-state.desktop'
+import * as ReactIs from 'react-is'
 // A mobile-like header for desktop
 
 // Fix this as we figure out what this needs to be
@@ -79,19 +80,23 @@ class Header extends React.PureComponent<Props> {
       title = <PlainTitle title={opt.title} />
     }
 
-    if (typeof opt.headerTitle === 'function') {
-      const CustomTitle = opt.headerTitle
-      title = <CustomTitle>{opt.title}</CustomTitle>
+    if (opt.headerTitle) {
+      if (React.isValidElement(opt.headerTitle)) {
+        title = opt.headerTitle
+      } else if (ReactIs.isValidElementType(opt.headerTitle)) {
+        const CustomTitle = opt.headerTitle
+        title = <CustomTitle>{opt.title}</CustomTitle>
+      }
     }
 
     let rightActions = null
-    if (typeof opt.headerRightActions === 'function') {
+    if (ReactIs.isValidElementType(opt.headerRightActions)) {
       const CustomActions = opt.headerRightActions
       rightActions = <CustomActions />
     }
 
     let subHeader = null
-    if (typeof opt.subHeader === 'function') {
+    if (ReactIs.isValidElementType(opt.subHeader)) {
       const CustomSubHeader = opt.subHeader
       subHeader = <CustomSubHeader />
     }

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -12856,7 +12856,7 @@ react-inspector@^2.3.0, react-inspector@^2.3.1:
     is-dom "^1.0.9"
     prop-types "^15.6.1"
 
-react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.4, react-is@^16.8.6:
+react-is@16.8.6, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.4, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==


### PR DESCRIPTION
@keybase/react-hackers @cjb this replaces https://github.com/keybase/client/pull/17632 . Same fix but uses the ReactIs utilities (which were already a sub dep)