### PR TITLE
always stop click events from going through floating menu

### DIFF
--- a/shared/common-adapters/floating-menu/menu-layout/index.desktop.js
+++ b/shared/common-adapters/floating-menu/menu-layout/index.desktop.js
@@ -31,7 +31,6 @@ class MenuLayout extends Component<MenuLayoutProps> {
           if (this.props.closeOnClick && this.props.onHidden) {
             this.props.onHidden()
           }
-          event.stopPropagation()
         }}
       >
         {item.view}
@@ -84,7 +83,12 @@ class MenuLayout extends Component<MenuLayoutProps> {
     `
 
     return (
-      <Box>
+      <Box
+        onClick={event => {
+          // never allow a click to go through
+          event.stopPropagation()
+        }}
+      >
         <style>{realCSS}</style>
         <Box style={Styles.collapseStyles([styles.menuContainer, this.props.style])}>
           {/* Display header if there is one */}


### PR DESCRIPTION
Fixes clicking the inbox gear menu header selecting the conversation. r? @keybase/react-hackers 