### PR TITLE
types/fs: support '//' in paths more

### DIFF
--- a/shared/constants/types/fs.js
+++ b/shared/constants/types/fs.js
@@ -529,7 +529,8 @@ export const getPathFromRelative = (tlfName: string, tlfType: TlfType, inTlfPath
   '/keybase/' + tlfType + '/' + tlfName + '/' + inTlfPath
 export const stringToEditID = (s: string): EditID => s
 export const editIDToString = (s: EditID): string => s
-export const stringToPath = (s: string): Path => (s.indexOf('/') === 0 ? s : null)
+export const stringToPath = (s: string): Path =>
+  s.indexOf('/') === 0 ? s.replace(/\/+/g, '/').replace(/\/$/, '') : null
 export const pathToString = (p: Path): string => (!p ? '' : p)
 export const stringToLocalPath = (s: string): LocalPath => s
 export const localPathToString = (p: LocalPath): string => p


### PR DESCRIPTION
This is a response to an issue raised by @heronhaye about broken breadcrumbs.

Perhaps we should also trim `/` from the end of paths when coming from e.g. a chat link.