### PR TITLE
kbfs: print error stack traces in three cases

### DIFF
--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -785,7 +785,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 		h.GetCanonicalPath(), branch, create)
 	defer func() {
 		err = fs.transformReadError(ctx, h, err)
-		fs.deferLog.CDebugf(ctx, "Done: %#v", err)
+		fs.deferLog.CDebugf(ctx, "Done: %+v", err)
 	}()
 
 	if branch != data.MasterBranch && create {

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -459,7 +459,7 @@ func (k *SimpleFS) doneOp(ctx context.Context, opid keybase1.OpID, err error) {
 		w.done <- err
 		close(w.done)
 	}
-	k.log.CDebugf(ctx, "done op %X, status=%v", opid, err)
+	k.log.CDebugf(ctx, "done op %X, status=%+v", opid, err)
 	if ctx != nil {
 		libcontext.CleanupCancellationDelayer(ctx)
 	}
@@ -1350,7 +1350,7 @@ func (k *SimpleFS) startOpWrapContext(outer context.Context) (context.Context, e
 }
 
 func (k *SimpleFS) doneSyncOp(ctx context.Context, err error) {
-	k.log.CDebugf(ctx, "done sync op, status=%v", err)
+	k.log.CDebugf(ctx, "done sync op, status=%+v", err)
 	if ctx != nil {
 		libcontext.CleanupCancellationDelayer(ctx)
 	}


### PR DESCRIPTION
Noticed in a user log that is hard to debug.