### PR TITLE
libkbfs: add more debugging for "cannot open secret box" error

### DIFF
--- a/go/kbfs/libkbfs/key_manager.go
+++ b/go/kbfs/libkbfs/key_manager.go
@@ -194,6 +194,9 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 		tlfCryptKey, err =
 			kmd.GetHistoricTLFCryptKey(km.config.Codec(), keyGen, latestKey)
 		if err != nil {
+			km.log.CDebugf(
+				ctx, "Can't get historic TLF crypt key for id=%s, keyGen=%d",
+				tlfID, keyGen)
 			return kbfscrypto.TLFCryptKey{}, err
 		}
 	} else if err != nil {

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -652,6 +652,9 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 			pmd, err = crypto.DecryptPrivateMetadata(
 				encryptedPrivateMetadata, k)
 			if err != nil {
+				log.CDebugf(
+					ctx, "Failed to decrypt MD for id=%s, keygen=%d",
+					rmdToDecrypt.TlfID(), rmdToDecrypt.LatestKeyGeneration())
 				return PrivateMetadata{}, err
 			}
 		}
@@ -662,6 +665,10 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 		ctx, codec, bcache, bops, mode, rmdWithKeys.TlfID(),
 		&pmd, rmdWithKeys, log)
 	if err != nil {
+		log.CDebugf(
+			ctx, "Failed to re-embed block changes for id=%s, keygen=%d, info pointer=%v",
+			rmdToDecrypt.TlfID(), rmdToDecrypt.LatestKeyGeneration(),
+			pmd.Changes.Info)
 		return PrivateMetadata{}, err
 	}
 


### PR DESCRIPTION
Trying to narrow down the error path for the secret box error experienced by a user.

(The user is willing to run the Linux nightly build to get us more info on a broken TLF.)

Issue: KBFS-4181