### PR TITLE
customize ephemeral error message

### DIFF
--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -141,7 +141,6 @@ func (b *Boxer) detectPermanentError(err error, tlfName string) types.UnboxingEr
 		libkb.KeyMaskNotFoundError,
 		libkb.AssertionCheckError,
 		DecryptionKeyNotFoundError,
-		NotAuthenticatedForThisDeviceError,
 		InvalidMACError,
 		ImpteamBadteamError:
 		return NewPermanentUnboxingError(err)
@@ -688,7 +687,8 @@ func (b *Boxer) validatePairwiseMAC(ctx context.Context, boxed chat1.MessageBoxe
 	if !found {
 		// This is an error users will actually see when they've just joined a
 		// team or added a new device.
-		return nil, NewNotAuthenticatedForThisDeviceError()
+		return nil, ephemeral.NewNotAuthenticatedForThisDeviceError(b.G().MetaContext(ctx),
+			boxed.ClientHeader.Conv.Tlfid, boxed.ServerHeader.Ctime)
 	}
 
 	// Second, load the device encryption KID for the sender.

--- a/go/chat/boxer.go
+++ b/go/chat/boxer.go
@@ -141,6 +141,7 @@ func (b *Boxer) detectPermanentError(err error, tlfName string) types.UnboxingEr
 		libkb.KeyMaskNotFoundError,
 		libkb.AssertionCheckError,
 		DecryptionKeyNotFoundError,
+		NotAuthenticatedForThisDeviceError,
 		InvalidMACError,
 		ImpteamBadteamError:
 		return NewPermanentUnboxingError(err)
@@ -687,7 +688,7 @@ func (b *Boxer) validatePairwiseMAC(ctx context.Context, boxed chat1.MessageBoxe
 	if !found {
 		// This is an error users will actually see when they've just joined a
 		// team or added a new device.
-		return nil, ephemeral.NewNotAuthenticatedForThisDeviceError(b.G().MetaContext(ctx),
+		return nil, NewNotAuthenticatedForThisDeviceError(b.G().MetaContext(ctx),
 			boxed.ClientHeader.Conv.Tlfid, boxed.ServerHeader.Ctime)
 	}
 

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -337,7 +337,7 @@ func TestChatMessageUnboxWithPairwiseMacsMissing(t *testing.T) {
 	// Check that we get the right failure type.
 	permErr, ok := err.(PermanentUnboxingError)
 	require.True(t, ok)
-	_, ok = permErr.Inner().(EphemeralUnboxingError)
+	_, ok = permErr.Inner().(NotAuthenticatedForThisDeviceError)
 	require.True(t, ok)
 }
 

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -337,7 +337,7 @@ func TestChatMessageUnboxWithPairwiseMacsMissing(t *testing.T) {
 	// Check that we get the right failure type.
 	permErr, ok := err.(PermanentUnboxingError)
 	require.True(t, ok)
-	_, ok = permErr.Inner().(NotAuthenticatedForThisDeviceError)
+	_, ok = permErr.Inner().(EphemeralUnboxingError)
 	require.True(t, ok)
 }
 

--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -44,7 +44,7 @@ func (e PermanentUnboxingError) ExportType() chat1.MessageUnboxedErrorType {
 		return err.ExportType()
 	case EphemeralUnboxingError:
 		return chat1.MessageUnboxedErrorType_EPHEMERAL
-	case NotAuthenticatedForThisDeviceError, InvalidMACError:
+	case InvalidMACError:
 		return chat1.MessageUnboxedErrorType_PAIRWISE_MISSING
 	default:
 		return chat1.MessageUnboxedErrorType_MISC
@@ -198,18 +198,6 @@ func NewPublicTeamEphemeralKeyError() PublicTeamEphemeralKeyError {
 
 func (e PublicTeamEphemeralKeyError) Error() string {
 	return "Cannot use exploding messages for a public team."
-}
-
-//=============================================================================
-
-type NotAuthenticatedForThisDeviceError struct{}
-
-func NewNotAuthenticatedForThisDeviceError() NotAuthenticatedForThisDeviceError {
-	return NotAuthenticatedForThisDeviceError{}
-}
-
-func (e NotAuthenticatedForThisDeviceError) Error() string {
-	return "Message is not authenticated for this device"
 }
 
 //=============================================================================

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
 )
 
 type EKType string
@@ -26,8 +28,43 @@ type EphemeralKeyError struct {
 const (
 	DefaultHumanErrMsg                          = "This exploding message is not available to you"
 	DeviceProvisionedAfterContentCreationErrMsg = "this device was created after the message was sent"
+	MemberAddedAfterContentCreationErrMsg       = "you were added to the team after this message was sent"
 	DeviceCloneErrMsg                           = "cloned devices do not support exploding messages"
 )
+
+func NewNotAuthenticatedForThisDeviceError(mctx libkb.MetaContext, tlfID chat1.TLFID, contentCtime gregor1.Time) EphemeralKeyError {
+	var humanMsg string
+	memberCtime, err := memberCtime(mctx, tlfID)
+	if err != nil {
+		mctx.Debug("unable to get member ctime: %v", err)
+	} else if memberCtime != nil {
+		mctx.Debug("NotAuthenticatedForThisDeviceError: tlfID %v, memberCtime: %v, contentCtime: %v", tlfID, memberCtime.Time(), contentCtime.Time())
+		if contentCtime.Before(gregor1.Time(*memberCtime)) {
+			humanMsg = MemberAddedAfterContentCreationErrMsg
+		}
+	}
+	return newEphemeralKeyError("message not authenticated for device", humanMsg)
+}
+
+func memberCtime(mctx libkb.MetaContext, tlfID chat1.TLFID) (*keybase1.Time, error) {
+	teamID, err := keybase1.TeamIDFromString(tlfID.String())
+	if err != nil {
+		return nil, err
+	}
+	team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
+		ID: keybase1.TeamID(teamID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	upak, _, err := mctx.G().GetUPAKLoader().LoadV2(
+		libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(mctx.G().Env.GetUID()))
+	if err != nil {
+		return nil, err
+	}
+	uv := upak.Current.ToUserVersion()
+	return team.MemberCtime(mctx.Ctx(), uv), nil
+}
 
 func newEKUnboxErr(mctx libkb.MetaContext, boxType EKType, boxGeneration keybase1.EkGeneration,
 	missingType EKType, missingGeneration keybase1.EkGeneration, contentCtime *gregor1.Time) EphemeralKeyError {

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -57,12 +57,10 @@ func memberCtime(mctx libkb.MetaContext, tlfID chat1.TLFID) (*keybase1.Time, err
 	if err != nil {
 		return nil, err
 	}
-	upak, _, err := mctx.G().GetUPAKLoader().LoadV2(
-		libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(mctx.G().Env.GetUID()))
+	uv, err := mctx.G().GetMeUV(mctx.Ctx())
 	if err != nil {
 		return nil, err
 	}
-	uv := upak.Current.ToUserVersion()
 	return team.MemberCtime(mctx.Ctx(), uv), nil
 }
 

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -130,6 +130,14 @@ func (t TeamSigChainState) GetUserRoleAtSeqno(user keybase1.UserVersion, seqno k
 	return role, nil
 }
 
+func (t TeamSigChainState) MemberCtime(user keybase1.UserVersion) *keybase1.Time {
+	points := t.inner.UserLog[user]
+	if len(points) == 0 {
+		return nil
+	}
+	return &points[0].SigMeta.Time
+}
+
 func (t TeamSigChainState) GetUserLogPoint(user keybase1.UserVersion) *keybase1.UserLogPoint {
 	points := t.inner.UserLog[user]
 	if len(points) == 0 {

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -135,6 +135,17 @@ func (t TeamSigChainState) MemberCtime(user keybase1.UserVersion) *keybase1.Time
 	if len(points) == 0 {
 		return nil
 	}
+	// see if the user ever left the team so we return their most recent join
+	// time.
+	for i := len(points) - 1; i > 0; i-- {
+		// if we left the team at some point, return our later join time
+		if points[i].Role == keybase1.TeamRole_NONE {
+			if i < len(points)-1 && points[i+1].Role != keybase1.TeamRole_NONE {
+				return &points[i+1].SigMeta.Time
+			}
+		}
+	}
+	// we never left the team, give our original join time.
 	return &points[0].SigMeta.Time
 }
 

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -474,12 +474,13 @@ func TestMemberCtime(t *testing.T) {
 			},
 		})
 
-	// user joined later as an admin
+	// user left and joined later as an admin
 	tcs = newTeamChainState()
 	ctime = tcs.MemberCtime(uv)
 	require.NotNil(t, ctime)
 	require.EqualValues(t, 3, *ctime)
 
+	// user had a bunch of non-NONE roles, we should return the first join time
 	points = nil
 	for i := 0; i < 5; i++ {
 		points = append(points,

--- a/go/teams/chain_test.go
+++ b/go/teams/chain_test.go
@@ -428,3 +428,70 @@ func signerToX(uv *keybase1.UserVersion) *SignerX {
 	}
 	return &SignerX{signer: *uv}
 }
+
+func TestMemberCtime(t *testing.T) {
+	uv := NewUserVersion("foo", 1)
+	var points []keybase1.UserLogPoint
+	newTeamChainState := func() TeamSigChainState {
+		return TeamSigChainState{
+			inner: keybase1.TeamSigChainState{
+				UserLog: map[keybase1.UserVersion][]keybase1.UserLogPoint{
+					uv: points,
+				},
+			},
+		}
+	}
+
+	// nil points
+	tcs := newTeamChainState()
+	ctime := tcs.MemberCtime(uv)
+	require.Nil(t, ctime)
+
+	// user joined as a writer
+	points = append(points,
+		keybase1.UserLogPoint{
+			Role: keybase1.TeamRole_WRITER,
+			SigMeta: keybase1.SignatureMetadata{
+				Time: 1,
+			},
+		})
+	tcs = newTeamChainState()
+	ctime = tcs.MemberCtime(uv)
+	require.NotNil(t, ctime)
+	require.EqualValues(t, 1, *ctime)
+
+	points = append(points,
+		keybase1.UserLogPoint{
+			Role: keybase1.TeamRole_NONE,
+			SigMeta: keybase1.SignatureMetadata{
+				Time: 2,
+			},
+		},
+		keybase1.UserLogPoint{
+			Role: keybase1.TeamRole_ADMIN,
+			SigMeta: keybase1.SignatureMetadata{
+				Time: 3,
+			},
+		})
+
+	// user joined later as an admin
+	tcs = newTeamChainState()
+	ctime = tcs.MemberCtime(uv)
+	require.NotNil(t, ctime)
+	require.EqualValues(t, 3, *ctime)
+
+	points = nil
+	for i := 0; i < 5; i++ {
+		points = append(points,
+			keybase1.UserLogPoint{
+				Role: keybase1.TeamRole_WRITER,
+				SigMeta: keybase1.SignatureMetadata{
+					Time: keybase1.Time(i),
+				},
+			})
+		tcs = newTeamChainState()
+		ctime = tcs.MemberCtime(uv)
+		require.NotNil(t, ctime)
+		require.EqualValues(t, 0, *ctime)
+	}
+}

--- a/go/teams/loader_types.go
+++ b/go/teams/loader_types.go
@@ -132,6 +132,7 @@ func (i *SCChainLinkPayload) SignatureMetadata() keybase1.SignatureMetadata {
 	return keybase1.SignatureMetadata{
 		PrevMerkleRootSigned: i.Body.MerkleRoot.ToMerkleRootV2(),
 		SigChainLocation:     i.SigChainLocation(),
+		Time:                 keybase1.TimeFromSeconds(int64(i.Ctime)),
 	}
 }
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -220,6 +220,10 @@ func (t *Team) IsMember(ctx context.Context, uv keybase1.UserVersion) bool {
 	return true
 }
 
+func (t *Team) MemberCtime(ctx context.Context, uv keybase1.UserVersion) *keybase1.Time {
+	return t.chain().MemberCtime(uv)
+}
+
 func (t *Team) MemberRole(ctx context.Context, uv keybase1.UserVersion) (keybase1.TeamRole, error) {
 	return t.chain().GetUserRole(uv)
 }


### PR DESCRIPTION
improve error messaging when a pairwise mac is missing by detecting the team member ctime

before:
![Screen Shot 2019-05-20 at 3 09 25 PM](https://user-images.githubusercontent.com/1144020/58045751-60311280-7b11-11e9-9b6b-7ffbdfc006f8.png)

after:


![Screen Shot 2019-05-20 at 3 08 26 PM](https://user-images.githubusercontent.com/1144020/58045750-60311280-7b11-11e9-9867-19beac2201e7.png)