### PR TITLE
simplefs: implement the command for finishing a resolved conflict

### DIFF
--- a/go/client/cmd_simplefs.go
+++ b/go/client/cmd_simplefs.go
@@ -49,6 +49,7 @@ func NewCmdSimpleFS(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 			NewCmdSimpleFSRecover(cl, g),
 			NewCmdSimpleFSReset(cl, g),
 			NewCmdSimpleFSClearConflicts(cl, g),
+			NewCmdSimpleFSFinishResolvingConflicts(cl, g),
 			NewCmdSimpleFSSync(cl, g),
 		}, getBuildSpecificFSCommands(cl, g)...),
 	}

--- a/go/client/cmd_simplefs_finish_resolving_conflicts.go
+++ b/go/client/cmd_simplefs_finish_resolving_conflicts.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// CmdSimpleFSConflicts is the 'fs clear-conflicts' command.
+type CmdSimpleFSFinishResolvingConflicts struct {
+	libkb.Contextified
+	path keybase1.Path
+}
+
+// NewCmdSimpleFSFinishResolvingConflicts creates a new cli.Command.
+func NewCmdSimpleFSFinishResolvingConflicts(
+	cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "finish-resolving-conflicts",
+		ArgumentHelp: "<path-to-folder>",
+		Usage:        "indicate that a conflict has been resolved and its local state may be cleaned",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSFinishResolvingConflicts{
+				Contextified: libkb.NewContextified(g)}, "finish-resolving-conflicts", c)
+			cl.SetNoStandalone()
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSFinishResolvingConflicts) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	return cli.SimpleFSFinishResolvingConflict(context.TODO(), c.path)
+}
+
+// ParseArgv gets the path.
+func (c *CmdSimpleFSFinishResolvingConflicts) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		return fmt.Errorf("wrong number of arguments")
+	}
+
+	p, err := makeSimpleFSPath(ctx.Args()[0])
+	if err != nil {
+		return err
+	}
+	c.path = p
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSFinishResolvingConflicts) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -8658,7 +8658,7 @@ func (fbo *folderBranchOps) invalidateAllNodes(ctx context.Context) error {
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
 
-	fbo.log.CDebugf(ctx, "Inavlidating all nodes")
+	fbo.log.CDebugf(ctx, "Invalidating all nodes")
 	return fbo.invalidateAllNodesLocked(ctx, lState)
 }
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -527,6 +527,9 @@ type KBFSOps interface {
 	// ClearConflictView moves the conflict view of the given TLF out of the
 	// way and resets the state of the TLF.
 	ClearConflictView(ctx context.Context, tlfID tlf.ID) error
+	// FinishResolvingConflict removes the local view of a
+	// previously-cleared conflict.
+	FinishResolvingConflict(ctx context.Context, fb data.FolderBranch) error
 	// ForceStuckConflictForTesting forces the local view of the given
 	// TLF into a stuck conflict view, in order to test the above
 	// `ClearConflictView` method and related state changes.

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -1007,6 +1007,20 @@ func (mr *MockKBFSOpsMockRecorder) DeleteFavorite(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFavorite", reflect.TypeOf((*MockKBFSOps)(nil).DeleteFavorite), arg0, arg1)
 }
 
+// FinishResolvingConflict mocks base method
+func (m *MockKBFSOps) FinishResolvingConflict(arg0 context.Context, arg1 data.FolderBranch) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FinishResolvingConflict", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FinishResolvingConflict indicates an expected call of FinishResolvingConflict
+func (mr *MockKBFSOpsMockRecorder) FinishResolvingConflict(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishResolvingConflict", reflect.TypeOf((*MockKBFSOps)(nil).FinishResolvingConflict), arg0, arg1)
+}
+
 // FolderConflictStatus mocks base method
 func (m *MockKBFSOps) FolderConflictStatus(arg0 context.Context, arg1 data.FolderBranch) (keybase1.FolderConflictType, error) {
 	m.ctrl.T.Helper()

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -1483,4 +1483,14 @@ func TestFavoriteConflicts(t *testing.T) {
 	listResult, err := sfs.SimpleFSReadList(ctx, opid)
 	require.NoError(t, err)
 	require.Len(t, listResult.Entries, 12)
+
+	t.Log("Finish resolving the conflict")
+	err = sfs.SimpleFSFinishResolvingConflict(ctx, pathLocalView)
+	require.NoError(t, err)
+	favs, err = sfs.SimpleFSListFavorites(ctx)
+	require.NoError(t, err)
+	require.Len(t, favs.FavoriteFolders, 2)
+	for _, f := range favs.FavoriteFolders {
+		require.Nil(t, f.ConflictState)
+	}
 }


### PR DESCRIPTION
1. Invalidate any outstanding Nodes and shut down the FBO.
2. Stop the TLF journal.
3. Fake out the journal's entry in the cleared conflict map, to make sure we preserve the number of the conflict so that future conflicts on the same day get a new, larger number.
4. Delete the journal storage for the local conflict view.

Also adds a CLI command for finishing the resolved conflict.

Issue: KBFS-4139