### PR TITLE
Handle unused errors

### DIFF
--- a/go/bind/extension.go
+++ b/go/bind/extension.go
@@ -395,7 +395,7 @@ func getGregorClient(ctx context.Context, gc *globals.Context) (res chat1.Remote
 		func(nist *libkb.NIST) rpc.ConnectionHandler {
 			return newExtensionGregorHandler(gc, nist)
 		})
-	return chat1.RemoteClient{Cli: chat.NewRemoteClient(gc, conn.GetClient())}, nil
+	return chat1.RemoteClient{Cli: chat.NewRemoteClient(gc, conn.GetClient())}, err
 }
 
 func restoreName(gc *globals.Context, name string, membersType chat1.ConversationMembersType) string {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -5094,6 +5094,7 @@ func TestChatSrvSetConvMinWriterRole(t *testing.T) {
 				TlfVisibility: keybase1.TLFVisibility_PRIVATE,
 				MembersType:   chat1.ConversationMembersType_TEAM,
 			})
+		require.NoError(t, err)
 		channelInfo := channel.Conv.Info
 		consumeNewMsgRemote(t, listener1, chat1.MessageType_JOIN)
 		consumeNewConversation(t, listener1, channelInfo.Id)

--- a/go/chat/unfurl/unfurler.go
+++ b/go/chat/unfurl/unfurler.go
@@ -113,11 +113,11 @@ func (u *Unfurler) Status(ctx context.Context, outboxID chat1.OutboxID) (status 
 	task, err := u.getTask(ctx, outboxID)
 	if err != nil {
 		u.Debug(ctx, "Status: error finding task: outboxID: %s err: %s", outboxID, err)
-		return status, nil, err
+		return types.UnfurlerTaskStatusFailed, nil, err
 	}
 	found, err := u.G().GetKVStore().GetInto(&status, u.statusKey(outboxID))
 	if err != nil {
-		return status, nil, err
+		return types.UnfurlerTaskStatusFailed, nil, err
 	}
 	if !found {
 		u.Debug(ctx, "Status: failed to find status, using unfurling: outboxID: %s", outboxID)

--- a/go/chat/unfurl/unfurler_test.go
+++ b/go/chat/unfurl/unfurler_test.go
@@ -174,4 +174,5 @@ func TestUnfurler(t *testing.T) {
 	status, _, err = unfurler.Status(context.TODO(), outboxID)
 	require.Error(t, err)
 	require.IsType(t, libkb.NotFoundError{}, err)
+	require.Equal(t, types.UnfurlerTaskStatusFailed, status)
 }

--- a/go/chat/wallet/sender.go
+++ b/go/chat/wallet/sender.go
@@ -115,8 +115,11 @@ func (s *Sender) ParsePayments(ctx context.Context, uid gregor1.UID, convID chat
 		return nil
 	}
 
-	// FIXME error is ignored.
 	parts, membersType, err := s.getConvParseInfo(ctx, uid, convID)
+	if err != nil {
+		s.Debug(ctx, "ParsePayments: failed to getConvParseInfo %v", err)
+		return nil
+	}
 	for _, p := range parsed {
 		var username string
 		// The currency might be legit but `KnownCurrencyCodeInstant` may not have data yet.

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -596,7 +596,6 @@ func TestSimpleFSRemoteSrcDir(t *testing.T) {
 	pathType, err = destPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_LOCAL, pathType, "Expected remote path, got local")
-
 }
 
 func TestSimpleFSLocalExists(t *testing.T) {

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -596,6 +596,7 @@ func TestSimpleFSRemoteSrcDir(t *testing.T) {
 	pathType, err = destPath.PathType()
 	require.NoError(tc.T, err, "bad path type")
 	assert.Equal(tc.T, keybase1.PathType_LOCAL, pathType, "Expected remote path, got local")
+
 }
 
 func TestSimpleFSLocalExists(t *testing.T) {

--- a/go/emails/user_test.go
+++ b/go/emails/user_test.go
@@ -107,4 +107,5 @@ func TestEmailHappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	err = SetVisibilityEmail(mctx, oldPrimary, keybase1.IdentityVisibility_PUBLIC)
+	require.NoError(t, err)
 }

--- a/go/engine/bug_3964_repairman_test.go
+++ b/go/engine/bug_3964_repairman_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -205,11 +206,11 @@ func findLine(t *testing.T, haystack []string, needle string) []string {
 
 func checkAuditLogForBug3964Repair(t *testing.T, log []string, deviceID keybase1.DeviceID, dev1Key *libkb.DeviceKey) {
 	log = limitToTrace(log, "bug3964Repairman#Run")
-	if len(log) == 0 {
-		t.Fatal("Didn't find a repairman run")
-	}
+	require.NotZero(t, len(log))
 	log = findLine(t, log, "| Repairman wasn't short-circuited")
+	require.NotZero(t, len(log))
 	log = findLine(t, log, "+ bug3964Repairman#saveRepairmanVisit")
+	require.NotZero(t, len(log))
 }
 
 func logoutLogin(t *testing.T, user *FakeUser, dev libkb.TestContext) {

--- a/go/engine/passphrase_recover.go
+++ b/go/engine/passphrase_recover.go
@@ -251,6 +251,9 @@ func (e *PassphraseRecover) changePassword(mctx libkb.MetaContext) (err error) {
 	// We either have no server keys or the user is OK with resetting them
 	// Prompt the user for a new passphrase.
 	passphrase, err := e.promptPassphrase(mctx)
+	if err != nil {
+		return err
+	}
 
 	// ppres.Passphrase contains our new password
 	// Run passphrase change to finish the flow

--- a/go/engine/pgp_decrypt_test.go
+++ b/go/engine/pgp_decrypt_test.go
@@ -412,6 +412,7 @@ func TestPGPDecryptNonKeybase(t *testing.T) {
 	tcSigner := SetupEngineTest(t, "PGPDecrypt - Signer")
 	defer tcSigner.Cleanup()
 	keyA, err := tcSigner.MakePGPKey("keya@keybase.io")
+	require.NoError(t, err)
 
 	// find recipient key
 	ur, err := libkb.LoadUser(libkb.NewLoadUserByNameArg(tcSigner.G, recipient.Username))

--- a/go/engine/pgp_export_key.go
+++ b/go/engine/pgp_export_key.go
@@ -190,6 +190,9 @@ func GetPGPExportPassphrase(m libkb.MetaContext, ui libkb.SecretUI, desc string)
 
 	desc = "Please reenter your passphrase for confirmation"
 	pRes2, err := libkb.GetSecret(m, ui, "PGP key passphrase", desc, "", false)
+	if err != nil {
+		return keybase1.GetPassphraseRes{}, err
+	}
 	if pRes.Passphrase != pRes2.Passphrase {
 		return keybase1.GetPassphraseRes{}, errors.New("Passphrase mismatch")
 	}

--- a/go/engine/pgp_select_test.go
+++ b/go/engine/pgp_select_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSelectEngine(t *testing.T) {
@@ -53,6 +54,7 @@ func TestSelectEngine(t *testing.T) {
 	}
 	gpg := NewGPGImportKeyEngine(tc.G, &garg)
 	err = RunEngine2(m, gpg)
+	require.NoError(t, err)
 
 	// The GPGImportKeyEngine converts a multi select on the same key into
 	// an update, so our test checks that the update code ran, by counting

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -271,7 +271,7 @@ func TestDeviceEKStorageDeleteExpiredKeys(t *testing.T) {
 	expired := s.getExpiredGenerations(mctx, make(keyExpiryMap), now)
 	var expected []keybase1.EkGeneration
 	expected = nil
-	require.Equal(t, expected, expected)
+	require.Equal(t, expected, expired)
 
 	// Test with a single key that is not expired
 	keyMap := keyExpiryMap{

--- a/go/git/crypto_test.go
+++ b/go/git/crypto_test.go
@@ -47,6 +47,7 @@ func createRootTeam(tc libkb.TestContext) keybase1.TeamID {
 
 func createImplicitTeam(tc libkb.TestContext, public bool) keybase1.TeamID {
 	u, err := kbtest.CreateAndSignupFakeUser("c", tc.G)
+	require.NoError(tc.T, err)
 	team, _, _, err := teams.LookupOrCreateImplicitTeam(context.TODO(), tc.G, u.Username, public)
 	require.NoError(tc.T, err)
 	require.Equal(tc.T, public, team.ID.IsPublic())

--- a/go/kbfs/kbfsmd/root_metadata_v3_test.go
+++ b/go/kbfs/kbfsmd/root_metadata_v3_test.go
@@ -185,6 +185,7 @@ func TestRootMetadataPublicVersionV3(t *testing.T) {
 	require.Equal(t, SegregatedKeyBundlesVer, rmd.Version())
 
 	bh2, err := rmd.MakeBareTlfHandle(nil)
+	require.NoError(t, err)
 	require.Equal(t, bh, bh2)
 }
 
@@ -201,6 +202,7 @@ func TestRootMetadataSingleTeamVersionV3(t *testing.T) {
 	require.Equal(t, SegregatedKeyBundlesVer, rmd.Version())
 
 	bh2, err := rmd.MakeBareTlfHandle(nil)
+	require.NoError(t, err)
 	require.Equal(t, bh, bh2)
 }
 

--- a/go/kbfs/libkbfs/block_disk_store.go
+++ b/go/kbfs/libkbfs/block_disk_store.go
@@ -235,6 +235,9 @@ func (s *blockDiskStore) addRefsExclusive(
 	id kbfsblock.ID, contexts []kbfsblock.Context, status blockRefStatus,
 	tag string) error {
 	info, err := s.getInfo(id)
+	if err != nil {
+		return err
+	}
 
 	if len(info.Refs) > 0 {
 		// Check existing contexts, if any.

--- a/go/kbfs/libkbfs/disk_block_metadata_store_test.go
+++ b/go/kbfs/libkbfs/disk_block_metadata_store_test.go
@@ -38,6 +38,7 @@ func (t *testBlockMetadataStoreConfig) StorageRoot() string {
 func makeBlockMetadataStoreForTest(t *testing.T) (
 	blockMetadataStore BlockMetadataStore, tempdir string) {
 	tempdir, err := ioutil.TempDir(os.TempDir(), "xattr_test")
+	require.NoError(t, err)
 	config := testBlockMetadataStoreConfig{
 		codec:       kbfscodec.NewMsgpack(),
 		log:         logger.NewTestLogger(t),

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4236,6 +4236,7 @@ func TestKBFSOpsReadonlyFSNodes(t *testing.T) {
 	_, err = d.Write([]byte("ddata"))
 	require.NoError(t, err)
 	err = d.Close()
+	require.NoError(t, err)
 
 	name := "u1"
 	h, err := tlfhandle.ParseHandle(
@@ -4659,6 +4660,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	t.Log("Read it back out unencrypted")
 	config.ResetCaches()
 	syncConfig, err = kbfsOps.GetSyncConfig(ctx, h.TlfID())
+	require.NoError(t, err)
 	require.Equal(t, keybase1.FolderSyncMode_PARTIAL, syncConfig.Mode)
 	require.Len(t, syncConfig.Paths, len(pathsMap))
 	for _, p := range syncConfig.Paths {
@@ -4689,6 +4691,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	_, err = kbfsOps.SetSyncConfig(ctx, h.TlfID(), syncConfig)
 	require.NoError(t, err)
 	syncConfig, err = kbfsOps.GetSyncConfig(ctx, h.TlfID())
+	require.NoError(t, err)
 	require.Equal(t, keybase1.FolderSyncMode_PARTIAL, syncConfig.Mode)
 	require.Len(t, syncConfig.Paths, len(pathsMap))
 	for _, p := range syncConfig.Paths {
@@ -4936,6 +4939,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 
 	t.Log("Move a synced subdirectory somewhere else")
 	err = kbfsOps2.Rename(ctx, cNode, "e", dNode, "e")
+	require.NoError(t, err)
 	c, err = DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -1040,6 +1040,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
 
 	children, err := kbfsOps2Dev2.GetDirChildren(ctx, rootNode2Dev2)
+	require.NoError(t, err)
 	if _, ok := children["d"]; !ok {
 		t.Fatalf("Device 2 couldn't see the new dir entry")
 	}
@@ -1059,6 +1060,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	// Should still be seeing the old children, since the updates from
 	// the latest revision were never applied.
 	children, err = kbfsOps2.GetDirChildren(ctx, rootNode2)
+	require.NoError(t, err)
 	if _, ok := children["d"]; ok {
 		t.Fatalf("Found c unexpectedly: %v", children)
 	}
@@ -1284,6 +1286,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 	t.Log("User 2 device 2 reads user 1's file")
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
 	children2, err := kbfsOps2Dev2.GetDirChildren(ctx, root2dev2)
+	require.NoError(t, err)
 	if _, ok := children2["a"]; !ok {
 		t.Fatalf("Device 2 couldn't see user 1's dir entry")
 	}
@@ -1307,6 +1310,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 
 	t.Log("User 1 should be able to read the file that user 2 device 2 created")
 	children1, err := kbfsOps1.GetDirChildren(ctx, rootNode1)
+	require.NoError(t, err)
 	if _, ok := children1["b"]; !ok {
 		t.Fatalf("Device 1 couldn't see the new dir entry")
 	}
@@ -1317,6 +1321,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	session1, err := config1.KBPKI().GetCurrentSession(ctx)
+	require.NoError(t, err)
 
 	config1.SetMetadataVersion(ver)
 
@@ -1396,6 +1401,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	t.Log("User 2 device 2 reads user 1's file")
 	children2, err := kbfsOps2Dev2.GetDirChildren(ctx, root2dev2)
+	require.NoError(t, err)
 	if _, ok := children2["a"]; !ok {
 		t.Fatalf("Device 2 couldn't see user 1's dir entry")
 	}
@@ -1851,6 +1857,7 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.
 	rootNode1 = GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	children, err := kbfsOps1.GetDirChildren(ctx, rootNode1)
+	require.NoError(t, err)
 	if _, ok := children["b"]; !ok {
 		t.Fatalf("Device 1 couldn't see the new dir entry")
 	}
@@ -1967,6 +1974,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 
 	kbfsOps2 := config2Dev2.KBFSOps()
 	children, err := kbfsOps2.GetDirChildren(ctx, rootNode2Dev2)
+	require.NoError(t, err)
 	if _, ok := children["a"]; !ok {
 		t.Fatalf("Device 2 couldn't see the dir entry after rekey")
 	}
@@ -1987,6 +1995,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 		t.Fatalf("Couldn't sync from server: %+v", err)
 	}
 	children, err = kbfsOps1.GetDirChildren(ctx, rootNode1)
+	require.NoError(t, err)
 	if _, ok := children["b"]; !ok {
 		t.Fatalf("Device 2 couldn't see the dir entry after rekey")
 	}
@@ -2105,6 +2114,7 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 
 	kbfsOps2 := config2Dev2.KBFSOps()
 	children, err := kbfsOps2.GetDirChildren(ctx, rootNode2Dev2)
+	require.NoError(t, err)
 	if _, ok := children["a"]; !ok {
 		t.Fatalf("Device 2 couldn't see the dir entry after rekey")
 	}
@@ -2301,6 +2311,7 @@ func testKeyManagerRekeyMinimal(t *testing.T, ver kbfsmd.MetadataVer) {
 	}
 
 	children, err := kbfsOps2Dev2.GetDirChildren(ctx, root2Dev2)
+	require.NoError(t, err)
 	if _, ok := children["a"]; !ok {
 		t.Fatalf("Device 2 couldn't see the dir entry")
 	}
@@ -2414,6 +2425,7 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	_, latestKeyGen, err := config1.KBPKI().GetTeamTLFCryptKeys(
 		ctx, teamID, kbfsmd.UnspecifiedKeyGen,
 		keybase1.OfflineAvailability_NONE)
+	require.NoError(t, err)
 
 	rmd, err := makeInitialRootMetadata(config1.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -857,6 +857,7 @@ func testMDOpsPutPublicSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	require.NoError(t, err)
 	_, err = config.MDOps().Put(ctx, rmd, session.VerifyingKey,
 		nil, keybase1.MDPriorityNormal)
+	require.NoError(t, err)
 
 	rmds := mdServer.getLastRmds()
 	validatePutPublicRMDS(ctx, t, ver, config, rmd.bareMd, rmds)

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -928,6 +928,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 		BlockRequestWithPrefetch)
 	notifySyncCh(t, prefetchSyncCh)
 	err = <-ch
+	require.NoError(t, err)
 
 	t.Log("Release the prefetch for indirect block1.")
 	// Release 2 blocks
@@ -944,6 +945,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 		BlockRequestWithPrefetch)
 	notifySyncCh(t, prefetchSyncCh)
 	err = <-ch
+	require.NoError(t, err)
 
 	t.Log("Release the prefetch for indirect block2.")
 	// Release 2 blocks
@@ -960,6 +962,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 		BlockRequestWithPrefetch)
 	notifySyncCh(t, prefetchSyncCh)
 	err = <-ch
+	require.NoError(t, err)
 
 	t.Log("Fetch indirect block12 on-demand.")
 	block = &data.FileBlock{}
@@ -969,6 +972,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 		BlockRequestWithPrefetch)
 	notifySyncCh(t, prefetchSyncCh)
 	err = <-ch
+	require.NoError(t, err)
 
 	t.Log("Wait for the prefetch to finish.")
 	waitForPrefetchOrBust(
@@ -1224,6 +1228,7 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 		ctx, defaultOnDemandRequestPriority, kmd,
 		rootPtr, block, data.TransientEntry, BlockRequestWithPrefetch)
 	err = <-ch
+	require.NoError(t, err)
 
 	t.Log("Release all the blocks.")
 	go func() {
@@ -1379,6 +1384,8 @@ func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
 		ctx, defaultOnDemandRequestPriority, kmd,
 		rootPtr, block, data.TransientEntry, BlockRequestWithPrefetch)
 	err = <-ch
+	require.NoError(t, err)
+
 	// Notify the sync chan once for the canceled prefetch.
 	notifySyncCh(t, prefetchSyncCh)
 

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -532,7 +532,8 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	md := config.makeMD(kbfsmd.RevisionInitial, kbfsmd.ID{})
 	err = tlfJournal.doOnMDFlushAndRemoveFlushedMDEntry(
 		ctx, kbfsmd.ID{}, &RootMetadataSigned{RootMetadataSigned: kbfsmd.RootMetadataSigned{MD: md.bareMd}})
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Equal(t, "mdJournal unexpectedly empty", err.Error())
 
 	select {
 	case err := <-errCh:
@@ -573,7 +574,8 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	md := config.makeMD(kbfsmd.RevisionInitial, kbfsmd.ID{})
 	err = tlfJournal.doOnMDFlushAndRemoveFlushedMDEntry(
 		ctx, kbfsmd.ID{}, &RootMetadataSigned{RootMetadataSigned: kbfsmd.RootMetadataSigned{MD: md.bareMd}})
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Equal(t, "mdJournal unexpectedly empty", err.Error())
 
 	select {
 	case err := <-errCh:

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -532,6 +532,7 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	md := config.makeMD(kbfsmd.RevisionInitial, kbfsmd.ID{})
 	err = tlfJournal.doOnMDFlushAndRemoveFlushedMDEntry(
 		ctx, kbfsmd.ID{}, &RootMetadataSigned{RootMetadataSigned: kbfsmd.RootMetadataSigned{MD: md.bareMd}})
+	require.NoError(t, err)
 
 	select {
 	case err := <-errCh:
@@ -572,6 +573,7 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	md := config.makeMD(kbfsmd.RevisionInitial, kbfsmd.ID{})
 	err = tlfJournal.doOnMDFlushAndRemoveFlushedMDEntry(
 		ctx, kbfsmd.ID{}, &RootMetadataSigned{RootMetadataSigned: kbfsmd.RootMetadataSigned{MD: md.bareMd}})
+	require.NoError(t, err)
 
 	select {
 	case err := <-errCh:

--- a/go/kbfs/libpages/stathat.go
+++ b/go/kbfs/libpages/stathat.go
@@ -58,6 +58,9 @@ func (s *stathatReporter) activityStatsReportLoop() {
 		}
 		for i, d := range durations {
 			tlfs, hosts, err := getter.GetActives(d.Duration)
+			if err != nil {
+				s.logger.Warn("GetActives", zap.Error(err))
+			}
 			if err = s.reporter.PostEZValue(statNamesTlfs[i], s.ezKey,
 				float64(tlfs)); err != nil {
 				s.logger.Warn("PostEZValue", zap.Error(err))

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -87,6 +87,7 @@ func checkPendingOp(ctx context.Context,
 	}
 
 	ops, err := sfs.SimpleFSGetOps(ctx)
+	require.Error(t, err)
 
 	if !pending {
 		require.Len(t, ops, 0, "Expected zero pending operations")

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -87,7 +87,7 @@ func checkPendingOp(ctx context.Context,
 	}
 
 	ops, err := sfs.SimpleFSGetOps(ctx)
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	if !pending {
 		require.Len(t, ops, 0, "Expected zero pending operations")

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -87,7 +87,7 @@ func checkPendingOp(ctx context.Context,
 	}
 
 	ops, err := sfs.SimpleFSGetOps(ctx)
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	if !pending {
 		require.Len(t, ops, 0, "Expected zero pending operations")
@@ -135,7 +135,7 @@ func checkPendingOp(ctx context.Context,
 }
 
 func testListWithFilterAndUsername(
-	ctx context.Context, t *testing.T, sfs *SimpleFS, path keybase1.Path,
+	t *testing.T, ctx context.Context, sfs *SimpleFS, path keybase1.Path,
 	filter keybase1.ListFilter, username string, expectedEntries ...string) {
 	opid, err := sfs.SimpleFSMakeOpid(ctx)
 	require.NoError(t, err)
@@ -172,10 +172,10 @@ func testListWithFilterAndUsername(
 }
 
 func testList(
-	ctx context.Context, t *testing.T, sfs *SimpleFS, path keybase1.Path,
+	t *testing.T, ctx context.Context, sfs *SimpleFS, path keybase1.Path,
 	expectedEntries ...string) {
 	testListWithFilterAndUsername(
-		ctx, t, sfs, path, keybase1.ListFilter_NO_FILTER, "jdoe",
+		t, ctx, sfs, path, keybase1.ListFilter_NO_FILTER, "jdoe",
 		expectedEntries...)
 }
 
@@ -212,17 +212,17 @@ func TestList(t *testing.T) {
 
 	pathRoot := keybase1.NewPathWithKbfs(`/`)
 	testListWithFilterAndUsername(
-		ctx, t, sfs, pathRoot, keybase1.ListFilter_NO_FILTER, "",
+		t, ctx, sfs, pathRoot, keybase1.ListFilter_NO_FILTER, "",
 		"private", "public", "team")
 
 	pathPrivate := keybase1.NewPathWithKbfs(`/private`)
 	testListWithFilterAndUsername(
-		ctx, t, sfs, pathPrivate, keybase1.ListFilter_NO_FILTER, "",
+		t, ctx, sfs, pathPrivate, keybase1.ListFilter_NO_FILTER, "",
 		"jdoe")
 
 	t.Log("List directory before it's created")
 	path1 := keybase1.NewPathWithKbfs(`/private/jdoe`)
-	testList(ctx, t, sfs, path1)
+	testList(t, ctx, sfs, path1)
 
 	t.Log("Shouldn't have created the TLF")
 	h, err := tlfhandle.ParseHandle(
@@ -246,17 +246,17 @@ func TestList(t *testing.T) {
 	writeRemoteFile(ctx, t, sfs, pathAppend(path1, `.testfile`), []byte(`foo`))
 
 	testListWithFilterAndUsername(
-		ctx, t, sfs, path1, keybase1.ListFilter_FILTER_ALL_HIDDEN, "jdoe",
+		t, ctx, sfs, path1, keybase1.ListFilter_FILTER_ALL_HIDDEN, "jdoe",
 		"test1.txt", "test2.txt")
 
-	testList(ctx, t, sfs, pathAppend(path1, `test1.txt`), "test1.txt")
+	testList(t, ctx, sfs, pathAppend(path1, `test1.txt`), "test1.txt")
 
 	// Check for hidden files too.
 	testList(
-		ctx, t, sfs, path1, "test1.txt", "test2.txt", ".testfile")
+		t, ctx, sfs, path1, "test1.txt", "test2.txt", ".testfile")
 
 	// A single, requested hidden file shows up even if the filter is on.
-	testList(ctx, t, sfs, pathAppend(path1, `.testfile`), ".testfile")
+	testList(t, ctx, sfs, pathAppend(path1, `.testfile`), ".testfile")
 
 	// Test that the first archived revision shows no directory entries.
 	pathArchivedRev1 := keybase1.NewPathWithKbfsArchived(
@@ -264,14 +264,14 @@ func TestList(t *testing.T) {
 			Path:          `/private/jdoe`,
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRevision(1),
 		})
-	testList(ctx, t, sfs, pathArchivedRev1)
+	testList(t, ctx, sfs, pathArchivedRev1)
 
 	pathArchivedRev2 := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
 			Path:          `/private/jdoe`,
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRevision(2),
 		})
-	testList(ctx, t, sfs, pathArchivedRev2, "test1.txt")
+	testList(t, ctx, sfs, pathArchivedRev2, "test1.txt")
 
 	// Same test, with by-time archived paths.
 	pathArchivedTime := keybase1.NewPathWithKbfsArchived(
@@ -280,7 +280,7 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithTime(
 				keybase1.ToTime(rev1Time)),
 		})
-	testList(ctx, t, sfs, pathArchivedTime)
+	testList(t, ctx, sfs, pathArchivedTime)
 
 	pathArchivedTimeString := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
@@ -288,7 +288,7 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithTimeString(
 				rev1Time.String()),
 		})
-	testList(ctx, t, sfs, pathArchivedTimeString)
+	testList(t, ctx, sfs, pathArchivedTimeString)
 
 	pathArchivedRelTimeString := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
@@ -296,10 +296,10 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRelTimeString(
 				"45s"),
 		})
-	testList(ctx, t, sfs, pathArchivedRelTimeString)
+	testList(t, ctx, sfs, pathArchivedRelTimeString)
 
 	clock.Add(1 * time.Minute)
-	testList(ctx, t, sfs, pathArchivedRelTimeString, "test1.txt")
+	testList(t, ctx, sfs, pathArchivedRelTimeString, "test1.txt")
 }
 
 func TestListRecursive(t *testing.T) {
@@ -881,7 +881,7 @@ func TestRemove(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(ctx, t, sfs, pathKbfs, "test.txt")
+	testList(t, ctx, sfs, pathKbfs, "test.txt")
 
 	t.Log("Remove the file")
 	pathFile := keybase1.NewPathWithKbfs("/private/jdoe/test.txt")
@@ -899,7 +899,7 @@ func TestRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's gone")
-	testList(ctx, t, sfs, pathKbfs)
+	testList(t, ctx, sfs, pathKbfs)
 }
 
 func TestRemoveRecursive(t *testing.T) {
@@ -920,7 +920,7 @@ func TestRemoveRecursive(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the files are there")
-	testList(ctx, t, sfs, pathDir, "test1.txt", "test2.txt", "b")
+	testList(t, ctx, sfs, pathDir, "test1.txt", "test2.txt", "b")
 
 	t.Log("Remove dir without recursion, expect error")
 	opid, err := sfs.SimpleFSMakeOpid(ctx)
@@ -952,7 +952,7 @@ func TestRemoveRecursive(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's gone")
-	testList(ctx, t, sfs, pathKbfs)
+	testList(t, ctx, sfs, pathKbfs)
 }
 
 func TestMoveWithinTlf(t *testing.T) {
@@ -968,7 +968,7 @@ func TestMoveWithinTlf(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(ctx, t, sfs, pathKbfs, "test1.txt")
+	testList(t, ctx, sfs, pathKbfs, "test1.txt")
 
 	t.Log("Move the file")
 	pathFileOld := pathAppend(pathKbfs, "test1.txt")
@@ -988,7 +988,7 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(ctx, t, sfs, pathKbfs, "test2.txt")
+	testList(t, ctx, sfs, pathKbfs, "test2.txt")
 
 	t.Log("Move into subdir")
 	pathDir := pathAppend(pathKbfs, "a")
@@ -1010,8 +1010,8 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(ctx, t, sfs, pathKbfs, "a")
-	testList(ctx, t, sfs, pathDir, "test3.txt")
+	testList(t, ctx, sfs, pathKbfs, "a")
+	testList(t, ctx, sfs, pathDir, "test3.txt")
 
 	t.Log("Move into different, parallel subdir")
 	pathDirB := pathAppend(pathKbfs, "b")
@@ -1035,8 +1035,8 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(ctx, t, sfs, pathDir)
-	testList(ctx, t, sfs, pathDirC, "test3.txt")
+	testList(t, ctx, sfs, pathDir)
+	testList(t, ctx, sfs, pathDirC, "test3.txt")
 }
 
 func TestMoveBetweenTlfs(t *testing.T) {
@@ -1052,7 +1052,7 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(ctx, t, sfs, pathPrivate, "test1.txt")
+	testList(t, ctx, sfs, pathPrivate, "test1.txt")
 
 	t.Log("Move the file")
 	pathFileOld := pathAppend(pathPrivate, "test1.txt")
@@ -1074,8 +1074,8 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/public/jdoe")
 
 	t.Log("Make sure it's moved")
-	testList(ctx, t, sfs, pathPrivate)
-	testList(ctx, t, sfs, pathPublic, "test2.txt")
+	testList(t, ctx, sfs, pathPrivate)
+	testList(t, ctx, sfs, pathPublic, "test2.txt")
 
 	t.Log("Now move a whole populated directory")
 	pathDir := pathAppend(pathPrivate, "a")
@@ -1102,9 +1102,9 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/public/jdoe")
 
 	t.Log("Make sure it's moved (one file was overwritten)")
-	testList(ctx, t, sfs, pathPrivate)
-	testList(ctx, t, sfs, pathPublic, "test1.txt", "test2.txt", "b")
-	testList(ctx, t, sfs, pathAppend(pathPublic, "b"), "test3.txt")
+	testList(t, ctx, sfs, pathPrivate)
+	testList(t, ctx, sfs, pathPublic, "test1.txt", "test2.txt", "b")
+	testList(t, ctx, sfs, pathAppend(pathPublic, "b"), "test3.txt")
 	require.Equal(t, "2",
 		string(readRemoteFile(
 			ctx, t, sfs, pathAppend(pathPublic, "test2.txt"))))

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -135,7 +135,7 @@ func checkPendingOp(ctx context.Context,
 }
 
 func testListWithFilterAndUsername(
-	t *testing.T, ctx context.Context, sfs *SimpleFS, path keybase1.Path,
+	ctx context.Context, t *testing.T, sfs *SimpleFS, path keybase1.Path,
 	filter keybase1.ListFilter, username string, expectedEntries ...string) {
 	opid, err := sfs.SimpleFSMakeOpid(ctx)
 	require.NoError(t, err)
@@ -172,10 +172,10 @@ func testListWithFilterAndUsername(
 }
 
 func testList(
-	t *testing.T, ctx context.Context, sfs *SimpleFS, path keybase1.Path,
+	ctx context.Context, t *testing.T, sfs *SimpleFS, path keybase1.Path,
 	expectedEntries ...string) {
 	testListWithFilterAndUsername(
-		t, ctx, sfs, path, keybase1.ListFilter_NO_FILTER, "jdoe",
+		ctx, t, sfs, path, keybase1.ListFilter_NO_FILTER, "jdoe",
 		expectedEntries...)
 }
 
@@ -212,17 +212,17 @@ func TestList(t *testing.T) {
 
 	pathRoot := keybase1.NewPathWithKbfs(`/`)
 	testListWithFilterAndUsername(
-		t, ctx, sfs, pathRoot, keybase1.ListFilter_NO_FILTER, "",
+		ctx, t, sfs, pathRoot, keybase1.ListFilter_NO_FILTER, "",
 		"private", "public", "team")
 
 	pathPrivate := keybase1.NewPathWithKbfs(`/private`)
 	testListWithFilterAndUsername(
-		t, ctx, sfs, pathPrivate, keybase1.ListFilter_NO_FILTER, "",
+		ctx, t, sfs, pathPrivate, keybase1.ListFilter_NO_FILTER, "",
 		"jdoe")
 
 	t.Log("List directory before it's created")
 	path1 := keybase1.NewPathWithKbfs(`/private/jdoe`)
-	testList(t, ctx, sfs, path1)
+	testList(ctx, t, sfs, path1)
 
 	t.Log("Shouldn't have created the TLF")
 	h, err := tlfhandle.ParseHandle(
@@ -246,17 +246,17 @@ func TestList(t *testing.T) {
 	writeRemoteFile(ctx, t, sfs, pathAppend(path1, `.testfile`), []byte(`foo`))
 
 	testListWithFilterAndUsername(
-		t, ctx, sfs, path1, keybase1.ListFilter_FILTER_ALL_HIDDEN, "jdoe",
+		ctx, t, sfs, path1, keybase1.ListFilter_FILTER_ALL_HIDDEN, "jdoe",
 		"test1.txt", "test2.txt")
 
-	testList(t, ctx, sfs, pathAppend(path1, `test1.txt`), "test1.txt")
+	testList(ctx, t, sfs, pathAppend(path1, `test1.txt`), "test1.txt")
 
 	// Check for hidden files too.
 	testList(
-		t, ctx, sfs, path1, "test1.txt", "test2.txt", ".testfile")
+		ctx, t, sfs, path1, "test1.txt", "test2.txt", ".testfile")
 
 	// A single, requested hidden file shows up even if the filter is on.
-	testList(t, ctx, sfs, pathAppend(path1, `.testfile`), ".testfile")
+	testList(ctx, t, sfs, pathAppend(path1, `.testfile`), ".testfile")
 
 	// Test that the first archived revision shows no directory entries.
 	pathArchivedRev1 := keybase1.NewPathWithKbfsArchived(
@@ -264,14 +264,14 @@ func TestList(t *testing.T) {
 			Path:          `/private/jdoe`,
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRevision(1),
 		})
-	testList(t, ctx, sfs, pathArchivedRev1)
+	testList(ctx, t, sfs, pathArchivedRev1)
 
 	pathArchivedRev2 := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
 			Path:          `/private/jdoe`,
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRevision(2),
 		})
-	testList(t, ctx, sfs, pathArchivedRev2, "test1.txt")
+	testList(ctx, t, sfs, pathArchivedRev2, "test1.txt")
 
 	// Same test, with by-time archived paths.
 	pathArchivedTime := keybase1.NewPathWithKbfsArchived(
@@ -280,7 +280,7 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithTime(
 				keybase1.ToTime(rev1Time)),
 		})
-	testList(t, ctx, sfs, pathArchivedTime)
+	testList(ctx, t, sfs, pathArchivedTime)
 
 	pathArchivedTimeString := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
@@ -288,7 +288,7 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithTimeString(
 				rev1Time.String()),
 		})
-	testList(t, ctx, sfs, pathArchivedTimeString)
+	testList(ctx, t, sfs, pathArchivedTimeString)
 
 	pathArchivedRelTimeString := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
@@ -296,10 +296,10 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRelTimeString(
 				"45s"),
 		})
-	testList(t, ctx, sfs, pathArchivedRelTimeString)
+	testList(ctx, t, sfs, pathArchivedRelTimeString)
 
 	clock.Add(1 * time.Minute)
-	testList(t, ctx, sfs, pathArchivedRelTimeString, "test1.txt")
+	testList(ctx, t, sfs, pathArchivedRelTimeString, "test1.txt")
 }
 
 func TestListRecursive(t *testing.T) {
@@ -881,7 +881,7 @@ func TestRemove(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(t, ctx, sfs, pathKbfs, "test.txt")
+	testList(ctx, t, sfs, pathKbfs, "test.txt")
 
 	t.Log("Remove the file")
 	pathFile := keybase1.NewPathWithKbfs("/private/jdoe/test.txt")
@@ -899,7 +899,7 @@ func TestRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's gone")
-	testList(t, ctx, sfs, pathKbfs)
+	testList(ctx, t, sfs, pathKbfs)
 }
 
 func TestRemoveRecursive(t *testing.T) {
@@ -920,7 +920,7 @@ func TestRemoveRecursive(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the files are there")
-	testList(t, ctx, sfs, pathDir, "test1.txt", "test2.txt", "b")
+	testList(ctx, t, sfs, pathDir, "test1.txt", "test2.txt", "b")
 
 	t.Log("Remove dir without recursion, expect error")
 	opid, err := sfs.SimpleFSMakeOpid(ctx)
@@ -952,7 +952,7 @@ func TestRemoveRecursive(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's gone")
-	testList(t, ctx, sfs, pathKbfs)
+	testList(ctx, t, sfs, pathKbfs)
 }
 
 func TestMoveWithinTlf(t *testing.T) {
@@ -968,7 +968,7 @@ func TestMoveWithinTlf(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(t, ctx, sfs, pathKbfs, "test1.txt")
+	testList(ctx, t, sfs, pathKbfs, "test1.txt")
 
 	t.Log("Move the file")
 	pathFileOld := pathAppend(pathKbfs, "test1.txt")
@@ -988,7 +988,7 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(t, ctx, sfs, pathKbfs, "test2.txt")
+	testList(ctx, t, sfs, pathKbfs, "test2.txt")
 
 	t.Log("Move into subdir")
 	pathDir := pathAppend(pathKbfs, "a")
@@ -1010,8 +1010,8 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(t, ctx, sfs, pathKbfs, "a")
-	testList(t, ctx, sfs, pathDir, "test3.txt")
+	testList(ctx, t, sfs, pathKbfs, "a")
+	testList(ctx, t, sfs, pathDir, "test3.txt")
 
 	t.Log("Move into different, parallel subdir")
 	pathDirB := pathAppend(pathKbfs, "b")
@@ -1035,8 +1035,8 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(t, ctx, sfs, pathDir)
-	testList(t, ctx, sfs, pathDirC, "test3.txt")
+	testList(ctx, t, sfs, pathDir)
+	testList(ctx, t, sfs, pathDirC, "test3.txt")
 }
 
 func TestMoveBetweenTlfs(t *testing.T) {
@@ -1052,7 +1052,7 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(t, ctx, sfs, pathPrivate, "test1.txt")
+	testList(ctx, t, sfs, pathPrivate, "test1.txt")
 
 	t.Log("Move the file")
 	pathFileOld := pathAppend(pathPrivate, "test1.txt")
@@ -1074,8 +1074,8 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/public/jdoe")
 
 	t.Log("Make sure it's moved")
-	testList(t, ctx, sfs, pathPrivate)
-	testList(t, ctx, sfs, pathPublic, "test2.txt")
+	testList(ctx, t, sfs, pathPrivate)
+	testList(ctx, t, sfs, pathPublic, "test2.txt")
 
 	t.Log("Now move a whole populated directory")
 	pathDir := pathAppend(pathPrivate, "a")
@@ -1102,9 +1102,9 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/public/jdoe")
 
 	t.Log("Make sure it's moved (one file was overwritten)")
-	testList(t, ctx, sfs, pathPrivate)
-	testList(t, ctx, sfs, pathPublic, "test1.txt", "test2.txt", "b")
-	testList(t, ctx, sfs, pathAppend(pathPublic, "b"), "test3.txt")
+	testList(ctx, t, sfs, pathPrivate)
+	testList(ctx, t, sfs, pathPublic, "test1.txt", "test2.txt", "b")
+	testList(ctx, t, sfs, pathAppend(pathPublic, "b"), "test3.txt")
 	require.Equal(t, "2",
 		string(readRemoteFile(
 			ctx, t, sfs, pathAppend(pathPublic, "test2.txt"))))

--- a/go/kbfs/tlfhandle/handle_test.go
+++ b/go/kbfs/tlfhandle/handle_test.go
@@ -971,7 +971,7 @@ func TestHandleResolvesTo(t *testing.T) {
 
 	h2, err = ParseHandle(
 		ctx, kbpki, ConstIDGetter{idPub}, nil, name1, tlf.Public)
-	require.Error(t, err)
+	require.NoError(t, err)
 	info = tlf.HandleExtension{
 		Date:   100,
 		Number: 50,

--- a/go/kbfs/tlfhandle/handle_test.go
+++ b/go/kbfs/tlfhandle/handle_test.go
@@ -971,6 +971,7 @@ func TestHandleResolvesTo(t *testing.T) {
 
 	h2, err = ParseHandle(
 		ctx, kbpki, ConstIDGetter{idPub}, nil, name1, tlf.Public)
+	require.Error(t, err)
 	info = tlf.HandleExtension{
 		Date:   100,
 		Number: 50,

--- a/go/protocol/gregor1/factory.go
+++ b/go/protocol/gregor1/factory.go
@@ -21,11 +21,11 @@ func (o ObjFactory) MakeCategory(s string) (gregor.Category, error) { return Cat
 
 func castMsgID(msgid gregor.MsgID) (ret MsgID, err error) {
 	if msgid == nil {
-		return ret, err
+		return nil, nil
 	}
 	ret, ok := msgid.(MsgID)
 	if !ok {
-		err = errors.New("bad Msg ID; wrong type")
+		return nil, errors.New("bad Msg ID; wrong type")
 	}
 	return ret, nil
 }

--- a/go/systests/gregor_test.go
+++ b/go/systests/gregor_test.go
@@ -94,6 +94,7 @@ func TestGregorForwardToElectron(t *testing.T) {
 	require.NoError(t, signup.Run())
 
 	cli, xp, err := client.GetRPCClientWithContext(tc1.G)
+	require.NoError(t, err)
 	srv := rpc.NewServer(xp, nil)
 	em := newElectronMock(tc.G)
 	err = srv.Register(keybase1.GregorUIProtocol(em))

--- a/go/systests/teams_implicit_test.go
+++ b/go/systests/teams_implicit_test.go
@@ -239,6 +239,7 @@ func trySBSConsolidation(t *testing.T, impteamExpr string, public bool) {
 		})
 		require.NoError(t, err)
 		displayName, err := team.ImplicitTeamDisplayName(context.Background())
+		require.NoError(t, err)
 		t.Logf("Got team back: %q (waiting for %q)", displayName.String(), expectedTeamName)
 		return displayName.String() == expectedTeamName
 	})
@@ -342,6 +343,7 @@ func TestImplicitSBSPukless(t *testing.T) {
 		})
 		require.NoError(t, err)
 		displayName, err := team.ImplicitTeamDisplayName(context.Background())
+		require.NoError(t, err)
 		t.Logf("Got team back: %s", displayName.String())
 		return displayName.String() == expectedTeamName
 	})

--- a/go/teams/ftl_test.go
+++ b/go/teams/ftl_test.go
@@ -87,6 +87,7 @@ func TestFastLoaderKeyGen(t *testing.T) {
 	arg.NeedLatestKey = false
 	arg.KeyGenerationsNeeded = []keybase1.PerTeamKeyGeneration{keybase1.PerTeamKeyGeneration(4)}
 	team, err = tcs[1].G.GetFastTeamLoader().Load(m[1], arg)
+	require.NoError(t, err)
 	require.Equal(t, len(team.ApplicationKeys), 1)
 	require.Equal(t, team.ApplicationKeys[0].KeyGeneration, keybase1.PerTeamKeyGeneration(4))
 	require.True(t, teamName.Eq(team.Name))
@@ -95,6 +96,7 @@ func TestFastLoaderKeyGen(t *testing.T) {
 	arg.NeedLatestKey = true
 	arg.KeyGenerationsNeeded = []keybase1.PerTeamKeyGeneration{}
 	team, err = tcs[1].G.GetFastTeamLoader().Load(m[1], arg)
+	require.NoError(t, err)
 	require.Equal(t, len(team.ApplicationKeys), 1)
 	require.Equal(t, team.ApplicationKeys[0].KeyGeneration, keybase1.PerTeamKeyGeneration(4))
 	require.True(t, teamName.Eq(team.Name))

--- a/go/teams/get_test.go
+++ b/go/teams/get_test.go
@@ -130,6 +130,7 @@ func TestTeamDetailsAsImplicitAdmin(t *testing.T) {
 
 	t.Logf("loads the subteam")
 	team, err := Details(context.Background(), tcs[0].G, teamName.String()+".bbb")
+	require.NoError(t, err)
 	require.Len(t, team.Members.Owners, 0, "should be no team members in subteam")
 	require.Len(t, team.Members.Admins, 0, "should be no team members in subteam")
 	require.Len(t, team.Members.Writers, 0, "should be no team members in subteam")

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -779,9 +779,11 @@ func TestLoaderCORE_6230_2(t *testing.T) {
 
 	t.Logf("U0 adds a link to A")
 	_, err = AddMember(context.TODO(), tcs[0].G, rootName.String(), "foobar@rooter", keybase1.TeamRole_READER)
+	require.NoError(t, err)
 
 	t.Logf("U0 does an admin action to A.B")
 	_, err = AddMember(context.TODO(), tcs[0].G, subteamName.String(), fus[0].Username, keybase1.TeamRole_READER)
+	require.NoError(t, err)
 
 	t.Logf("U1 loads A.B")
 	_, err = Load(context.TODO(), tcs[1].G, keybase1.LoadTeamArg{

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -885,6 +885,7 @@ func TestLeaveAsReader(t *testing.T) {
 		ID:          teamID,
 		ForceRepoll: true,
 	})
+	require.NoError(t, err)
 
 	t.Logf("U0 loads the team from scratch")
 	_, err = Load(context.Background(), tcs[0].G, keybase1.LoadTeamArg{

--- a/go/teams/seitan_v2_test.go
+++ b/go/teams/seitan_v2_test.go
@@ -105,6 +105,7 @@ func TestSeitanBadSignatures(t *testing.T) {
 	defer tc.Cleanup()
 
 	user, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+	require.NoError(t, err)
 
 	ikey1, err := GenerateIKeyV2()
 	require.NoError(t, err)


### PR DESCRIPTION
https://staticcheck.io/docs/ seems like a useful tool and may be worth integrating into CI

ran `$ staticcheck -checks "SA4006" ./...  | grep "this value of err"` to handle unused errors. 