### PR TITLE
prefetcher: fire new requests if the block refnonce is different

### DIFF
--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -640,7 +640,7 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 	// If this is a new prefetch, or if we need to update the action,
 	// send a new request.
 	newAction := action.Combine(pre.req.action)
-	if !isPrefetchWaiting || pre.req.action != newAction {
+	if !isPrefetchWaiting || pre.req.action != newAction || pre.req.ptr != ptr {
 		// Update the action to prevent any early cancellation of a
 		// previous, non-deeply-synced request, and trigger a new
 		// request in case the previous request has already been
@@ -977,7 +977,7 @@ func (p *blockPrefetcher) handlePrefetchRequest(req *prefetchRequest) {
 		// This request was cancelled while it was waiting.
 		p.vlog.CLogf(context.Background(), libkb.VLog2,
 			"Request not processing because it was canceled already"+
-				": id=%v action=%v", req.ptr.ID, req.action)
+				": ptr=%s action=%v", req.ptr, req.action)
 		return
 	default:
 		p.markQueuedPrefetchDone(req.ptr)
@@ -1221,7 +1221,7 @@ func (p *blockPrefetcher) handlePrefetchRequest(req *prefetchRequest) {
 	}
 	if !isPrefetchWaiting {
 		p.vlog.CLogf(ctx, libkb.VLog2,
-			"adding block %s to the prefetch tree", req.ptr.ID)
+			"adding block %s to the prefetch tree", req.ptr)
 		// This block doesn't appear in the prefetch tree, so it's the
 		// root of a new prefetch tree. Add it to the tree.
 		p.prefetches[req.ptr.ID] = pre


### PR DESCRIPTION
This fixes the following race / test flake:
* A prefetch is started for block A, nonce 0.
* Block A, nonce N is created.
* Block A, nonce 0 is deleted.
* A prefetch is requested for block A, nonce N, but it doesn't trigger a fetch because the first request is still in the `prefetches` map.
* The cancel request for block A, nonce 0 is handled by the prefetcher, and so the nonce N request is never fulfilled.

This PR fixes the flake by always starting a block request for a new nonce (i.e., if the BlockPointer is different), to make sure it will be seen by the prefetcher after the cancel of the original nonce completes.

Also print out pointers more, instead of IDs, to make debugging things like this easier.

Issue: KBFS-4161