### PR TITLE
journal_manager: don't get full status to see if journal's enabled

### DIFF
--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -1017,6 +1017,13 @@ func (j *JournalManager) JournalStatus(tlfID tlf.ID) (
 	return tlfJournal.getJournalStatus()
 }
 
+// JournalEnabled returns true if the given TLF ID has a journal
+// enabled for it.
+func (j *JournalManager) JournalEnabled(tlfID tlf.ID) bool {
+	_, ok := j.getTLFJournal(tlfID, nil)
+	return ok
+}
+
 // JournalStatusWithPaths returns a TLFServerStatus object for the
 // given TLF suitable for diagnostics, including paths for all the
 // unflushed entries.

--- a/go/kbfs/libkbfs/journal_manager_util.go
+++ b/go/kbfs/libkbfs/journal_manager_util.go
@@ -30,8 +30,7 @@ func GetJournalManager(config Config) (*JournalManager, error) {
 // given TLF.
 func TLFJournalEnabled(config Config, tlfID tlf.ID) bool {
 	if jManager, err := GetJournalManager(config); err == nil {
-		_, err := jManager.JournalStatus(tlfID)
-		return err == nil
+		return jManager.JournalEnabled(tlfID)
 	}
 	return false
 }


### PR DESCRIPTION
There's no reason to construct a whole journal status (and depend on being able to take the TLF journal lock) just to see if the journal is enabled.

Issue: KBFS-4127