### PR TITLE
client/simplefs_test: don't use ToSlash to fix Windows

### DIFF
--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -591,7 +591,7 @@ func TestSimpleFSRemoteSrcDir(t *testing.T) {
 		true,
 		tempdir)
 	require.NoError(tc.T, err, "bad path type")
-	assert.Equal(tc.T, filepath.ToSlash(tempdir), destPath.Local())
+	assert.Equal(tc.T, tempdir, destPath.Local())
 
 	pathType, err = destPath.PathType()
 	require.NoError(tc.T, err, "bad path type")


### PR DESCRIPTION
The dest path should be exactly the same as what was passed in.