### PR TITLE
fix tsc pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     -   id: tsc
         name: tsc
         entry: shared/node_modules/.bin/tsc
+        args: ['-p', 'shared/tsconfig.json']
         language: node
         files: \.(ts|tsx)$
         pass_filenames: false


### PR DESCRIPTION
On master it prints the help text and exits. r? @keybase/react-hackers 