### PR TITLE
folder_branch_ops: new ctx for root block fetch on new sync config

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -9040,8 +9040,13 @@ func (fbo *folderBranchOps) SetSyncConfig(
 	}
 
 	if config.Mode == keybase1.FolderSyncMode_ENABLED {
-		fbo.log.CDebugf(ctx, "Starting full deep sync")
-		_ = fbo.kickOffRootBlockFetch(ctx, md)
+		// Make a new ctx for the root block fetch, since it will
+		// continue after this function returns.
+		rootBlockCtx := fbo.ctxWithFBOID(context.Background())
+		fbo.log.CDebugf(
+			ctx, "Starting full deep sync with a new context: FBOID=%s",
+			rootBlockCtx.Value(CtxFBOIDKey))
+		_ = fbo.kickOffRootBlockFetch(rootBlockCtx, md)
 	}
 
 	// Issue notifications to client when sync mode changes (or is partial).


### PR DESCRIPTION
Otherwise `ctx` can be canceled by the caller immediately after `SetSyncConfig` returns; in that case the root block fetch would fail and the prefetch would never be kicked off.