### PR TITLE
Fix inuse seqno clearing in general, remove pending payments instafail

### DIFF
--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -968,10 +968,10 @@ func SendMiniChatPayments(m libkb.MetaContext, walletState *WalletState, convID 
 			mcpResult.Error = prepared[i].Error
 		} else {
 			// submit the transaction
-			m.Debug("SEQNO ics %d submitting payment seqno %d", i, prepared[i].Seqno)
+			m.Debug("SEQNO ics %d submitting payment seqno %d (txid %s)", i, prepared[i].Seqno, prepared[i].TxID)
 
 			if err := walletState.AddPendingTx(m.Ctx(), senderAccountID, prepared[i].TxID, prepared[i].Seqno); err != nil {
-				m.Debug("error calling AddPendingTx: %s", err)
+				m.Debug("SEQNO ics %d error calling AddPendingTx: %s", i, err)
 			}
 
 			var submitRes stellar1.PaymentResult
@@ -987,6 +987,9 @@ func SendMiniChatPayments(m libkb.MetaContext, walletState *WalletState, convID 
 			if err != nil {
 				mcpResult.Error = err
 				m.Debug("SEQNO ics %d submit error for txid %s, seqno %d: %s", i, prepared[i].TxID, prepared[i].Seqno, err)
+				if rerr := walletState.RemovePendingTx(m.Ctx(), senderAccountID, prepared[i].TxID); rerr != nil {
+					m.Debug("SEQNO ics %d error calling RemovePendingTx: %s", i, rerr)
+				}
 			} else {
 				mcpResult.PaymentID = stellar1.NewPaymentID(submitRes.StellarID)
 				m.Debug("SEQNO ics %d submit success txid %s, seqno %d", i, prepared[i].TxID, prepared[i].Seqno)


### PR DESCRIPTION
if you only had a balance of 5 XLM and you did +10XLM ICS payment, it fails instantly.
your next payment would also fail, even with a sufficient balance (say +1XLM) because when the instafail happened, we weren't removing the pending transaction.

there was another bug where the "inuse" seqnos were being recorded off-by-one.