### PR TITLE
Change GetSecretKeyLocked to support multiple server synced keys

### DIFF
--- a/go/engine/id_test.go
+++ b/go/engine/id_test.go
@@ -149,7 +149,7 @@ func TestIdPGPNotEldest(t *testing.T) {
 	// create new user, then add pgp key
 	u := CreateAndSignupFakeUser(tc, "login")
 	uis := libkb.UIs{LogUI: tc.G.UI.GetLogUI(), SecretUI: u.NewSecretUI()}
-	_, _, key := armorKey(t, tc, u.Email)
+	_, _, key := genPGPKeyAndArmor(t, tc, u.Email)
 	eng, err := NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), true)
 	require.NoError(t, err)
 

--- a/go/engine/pgp_import_key_test.go
+++ b/go/engine/pgp_import_key_test.go
@@ -25,7 +25,7 @@ func TestPGPImportAndExport(t *testing.T) {
 
 	// try all four permutations of push options:
 
-	fp, _, key := armorKey(t, tc, u.Email)
+	fp, _, key := genPGPKeyAndArmor(t, tc, u.Email)
 	eng, err := NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), false)
 	if err != nil {
 		t.Fatal(err)
@@ -35,7 +35,7 @@ func TestPGPImportAndExport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fp, _, key = armorKey(t, tc, u.Email)
+	fp, _, key = genPGPKeyAndArmor(t, tc, u.Email)
 	eng, err = NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), true)
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +99,7 @@ func TestPGPImportPrivImport(t *testing.T) {
 	uis := libkb.UIs{LogUI: dev1.G.UI.GetLogUI(), SecretUI: secui}
 
 	// Import a private key into dev1
-	fp, _, key := armorKey(t, dev1, user.Email)
+	fp, _, key := genPGPKeyAndArmor(t, dev1, user.Email)
 	eng, err := NewPGPKeyImportEngineFromBytes(dev1.G, []byte(key), false)
 	if err != nil {
 		t.Fatal(err)
@@ -211,7 +211,7 @@ func TestPGPImportNotLoggedIn(t *testing.T) {
 	secui := &libkb.TestSecretUI{Passphrase: u.Passphrase}
 	uis := libkb.UIs{LogUI: tc.G.UI.GetLogUI(), SecretUI: secui}
 
-	_, _, key := armorKey(t, tc, u.Email)
+	_, _, key := genPGPKeyAndArmor(t, tc, u.Email)
 	eng, err := NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), false)
 	if err != nil {
 		t.Fatal(err)
@@ -328,7 +328,7 @@ func TestPGPImportPushSecretWithoutPassword(t *testing.T) {
 
 	secui := &libkb.TestSecretUI{}
 	uis := libkb.UIs{LogUI: tc.G.UI.GetLogUI(), SecretUI: secui}
-	_, _, key := armorKey(t, tc, user.Email)
+	_, _, key := genPGPKeyAndArmor(t, tc, user.Email)
 	eng, err := NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), true)
 	require.Nil(t, err, "engine initialization should succeed")
 	m := NewMetaContextForTest(tc).WithUIs(uis)
@@ -351,7 +351,7 @@ func numPrivateGPGKeys(g *libkb.GlobalContext) (int, error) {
 	return index.Len(), nil
 }
 
-func armorKey(t *testing.T, tc libkb.TestContext, email string) (libkb.PGPFingerprint, keybase1.KID, string) {
+func genPGPKeyAndArmor(t *testing.T, tc libkb.TestContext, email string) (libkb.PGPFingerprint, keybase1.KID, string) {
 	bundle, err := tc.MakePGPKey(email)
 	if err != nil {
 		t.Fatal(err)

--- a/go/engine/upak_loader_lite_test.go
+++ b/go/engine/upak_loader_lite_test.go
@@ -81,7 +81,7 @@ func TestLoadLiteBasicUser(t *testing.T) {
 
 	// add a new high link (a new PGP key) and test
 	uis := libkb.UIs{LogUI: tc.G.UI.GetLogUI(), SecretUI: fu.NewSecretUI()}
-	_, _, key := armorKey(t, tc, fu.Email)
+	_, _, key := genPGPKeyAndArmor(t, tc, fu.Email)
 	eng, err := NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), true)
 	require.NoError(t, err)
 	m := NewMetaContextForTest(tc).WithUIs(uis)


### PR DESCRIPTION
`GetSecretKeyLocked` shows non-deterministic behaviour when fetching multiple server synced keys. Add new `(u *User) SyncedSecretKeyWithSka` method to get all server synced keys with `GetSyncedSecretKeys` and use `SecretKeyArg` to select one of them to return.

This fixes `keybase pgp export -s -q KEYID` when user has more than one server synced secret key.