### PR TITLE
Reduce homedir priorities test flakes, standardize (ctx, t) order in test helpers

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -33,7 +33,6 @@ lint:
 		| grep -v runquiet.go \
 		| grep -v mocks_test\.go \
 		| grep -v mock_codec\.go \
-		| grep -v "_test\.go.*context\.Context should be the first parameter of a function" \
 		| grep -v "use underscores in Go names" \
 		&& exit 1 \
 		|| echo "Lint-free!" \

--- a/go/kbfs/data/dir_data_test.go
+++ b/go/kbfs/data/dir_data_test.go
@@ -144,7 +144,7 @@ func TestDirDataGetChildren(t *testing.T) {
 }
 
 func testDirDataCheckLookup(
-	t *testing.T, ctx context.Context, dd *DirData, name string, size uint64) {
+	ctx context.Context, t *testing.T, dd *DirData, name string, size uint64) {
 	de, err := dd.Lookup(ctx, name)
 	require.NoError(t, err)
 	require.Equal(t, size, de.Size)
@@ -164,7 +164,7 @@ func TestDirDataLookup(t *testing.T) {
 
 	t.Log("Single entry, direct block")
 	addFakeDirDataEntryToBlock(topBlock, "a", 1)
-	testDirDataCheckLookup(t, ctx, dd, "a", 1)
+	testDirDataCheckLookup(ctx, t, dd, "a", 1)
 	_, err = dd.Lookup(ctx, "b")
 	require.Equal(t, idutil.NoSuchNameError{Name: "b"}, err)
 
@@ -200,14 +200,14 @@ func TestDirDataLookup(t *testing.T) {
 	cleanBcache.Put(
 		ptr2, dd.tree.file.Tlf, block2, TransientEntry, SkipCacheHash)
 
-	testDirDataCheckLookup(t, ctx, dd, "a", 1)
-	testDirDataCheckLookup(t, ctx, dd, "b", 2)
-	testDirDataCheckLookup(t, ctx, dd, "z1", 3)
-	testDirDataCheckLookup(t, ctx, dd, "z2", 4)
+	testDirDataCheckLookup(ctx, t, dd, "a", 1)
+	testDirDataCheckLookup(ctx, t, dd, "b", 2)
+	testDirDataCheckLookup(ctx, t, dd, "z1", 3)
+	testDirDataCheckLookup(ctx, t, dd, "z2", 4)
 }
 
 func addFakeDirDataEntry(
-	t *testing.T, ctx context.Context, dd *DirData, name string, size uint64) {
+	ctx context.Context, t *testing.T, dd *DirData, name string, size uint64) {
 	_, err := dd.AddEntry(ctx, name, DirEntry{
 		EntryInfo: EntryInfo{
 			Size: size,
@@ -316,14 +316,14 @@ func TestDirDataAddEntry(t *testing.T) {
 		SkipCacheHash)
 
 	t.Log("Add first entry")
-	addFakeDirDataEntry(t, ctx, dd, "a", 1)
+	addFakeDirDataEntry(ctx, t, dd, "a", 1)
 	require.True(t, dirtyBcache.IsDirty(
 		dd.tree.file.Tlf, dd.rootBlockPointer(), MasterBranch))
 	require.Len(t, topBlock.Children, 1)
 
 	t.Log("Force a split")
-	addFakeDirDataEntry(t, ctx, dd, "b", 2)
-	addFakeDirDataEntry(t, ctx, dd, "c", 3)
+	addFakeDirDataEntry(ctx, t, dd, "b", 2)
+	addFakeDirDataEntry(ctx, t, dd, "c", 3)
 	expectedLeafs := []testDirDataLeaf{
 		{"", 1, true},
 		{"b", 2, true},
@@ -331,7 +331,7 @@ func TestDirDataAddEntry(t *testing.T) {
 	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
 
 	t.Log("Fill in the first block")
-	addFakeDirDataEntry(t, ctx, dd, "a1", 4)
+	addFakeDirDataEntry(ctx, t, dd, "a1", 4)
 	expectedLeafs = []testDirDataLeaf{
 		{"", 2, true},
 		{"b", 2, true},
@@ -339,7 +339,7 @@ func TestDirDataAddEntry(t *testing.T) {
 	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
 
 	t.Log("Shift a block over")
-	addFakeDirDataEntry(t, ctx, dd, "a2", 5)
+	addFakeDirDataEntry(ctx, t, dd, "a2", 5)
 	expectedLeafs = []testDirDataLeaf{
 		{"", 1, true},
 		{"a1", 2, true},
@@ -349,7 +349,7 @@ func TestDirDataAddEntry(t *testing.T) {
 
 	t.Log("Clean up the cache and dirty just one leaf")
 	testDirDataCleanCache(dd, cleanBcache, dirtyBcache)
-	addFakeDirDataEntry(t, ctx, dd, "a0", 6)
+	addFakeDirDataEntry(ctx, t, dd, "a0", 6)
 	expectedLeafs = []testDirDataLeaf{
 		{"", 2, true},
 		{"a1", 2, false},
@@ -358,14 +358,14 @@ func TestDirDataAddEntry(t *testing.T) {
 	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
 
 	t.Log("Expand a bunch more")
-	addFakeDirDataEntry(t, ctx, dd, "a00", 7)
-	addFakeDirDataEntry(t, ctx, dd, "b1", 8)
-	addFakeDirDataEntry(t, ctx, dd, "d", 9)
-	addFakeDirDataEntry(t, ctx, dd, "a000", 10)
-	addFakeDirDataEntry(t, ctx, dd, "z", 11)
-	addFakeDirDataEntry(t, ctx, dd, "q", 12)
-	addFakeDirDataEntry(t, ctx, dd, "b2", 13)
-	addFakeDirDataEntry(t, ctx, dd, " 1", 14)
+	addFakeDirDataEntry(ctx, t, dd, "a00", 7)
+	addFakeDirDataEntry(ctx, t, dd, "b1", 8)
+	addFakeDirDataEntry(ctx, t, dd, "d", 9)
+	addFakeDirDataEntry(ctx, t, dd, "a000", 10)
+	addFakeDirDataEntry(ctx, t, dd, "z", 11)
+	addFakeDirDataEntry(ctx, t, dd, "q", 12)
+	addFakeDirDataEntry(ctx, t, dd, "b2", 13)
+	addFakeDirDataEntry(ctx, t, dd, " 1", 14)
 	expectedLeafs = []testDirDataLeaf{
 		{"", 2, true},    // " 1" and "a"
 		{"a0", 1, true},  // "a0"
@@ -380,20 +380,20 @@ func TestDirDataAddEntry(t *testing.T) {
 	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
 
 	t.Log("Verify lookups")
-	testDirDataCheckLookup(t, ctx, dd, "a", 1)
-	testDirDataCheckLookup(t, ctx, dd, "b", 2)
-	testDirDataCheckLookup(t, ctx, dd, "c", 3)
-	testDirDataCheckLookup(t, ctx, dd, "a1", 4)
-	testDirDataCheckLookup(t, ctx, dd, "a2", 5)
-	testDirDataCheckLookup(t, ctx, dd, "a0", 6)
-	testDirDataCheckLookup(t, ctx, dd, "a00", 7)
-	testDirDataCheckLookup(t, ctx, dd, "b1", 8)
-	testDirDataCheckLookup(t, ctx, dd, "d", 9)
-	testDirDataCheckLookup(t, ctx, dd, "a000", 10)
-	testDirDataCheckLookup(t, ctx, dd, "z", 11)
-	testDirDataCheckLookup(t, ctx, dd, "q", 12)
-	testDirDataCheckLookup(t, ctx, dd, "b2", 13)
-	testDirDataCheckLookup(t, ctx, dd, " 1", 14)
+	testDirDataCheckLookup(ctx, t, dd, "a", 1)
+	testDirDataCheckLookup(ctx, t, dd, "b", 2)
+	testDirDataCheckLookup(ctx, t, dd, "c", 3)
+	testDirDataCheckLookup(ctx, t, dd, "a1", 4)
+	testDirDataCheckLookup(ctx, t, dd, "a2", 5)
+	testDirDataCheckLookup(ctx, t, dd, "a0", 6)
+	testDirDataCheckLookup(ctx, t, dd, "a00", 7)
+	testDirDataCheckLookup(ctx, t, dd, "b1", 8)
+	testDirDataCheckLookup(ctx, t, dd, "d", 9)
+	testDirDataCheckLookup(ctx, t, dd, "a000", 10)
+	testDirDataCheckLookup(ctx, t, dd, "z", 11)
+	testDirDataCheckLookup(ctx, t, dd, "q", 12)
+	testDirDataCheckLookup(ctx, t, dd, "b2", 13)
+	testDirDataCheckLookup(ctx, t, dd, " 1", 14)
 
 	t.Log("Adding an existing name should error")
 	_, err := dd.AddEntry(ctx, "a", DirEntry{
@@ -413,29 +413,29 @@ func TestDirDataRemoveEntry(t *testing.T) {
 		SkipCacheHash)
 
 	t.Log("Make a simple dir and remove one entry")
-	addFakeDirDataEntry(t, ctx, dd, "a", 1)
-	addFakeDirDataEntry(t, ctx, dd, "z", 2)
+	addFakeDirDataEntry(ctx, t, dd, "a", 1)
+	addFakeDirDataEntry(ctx, t, dd, "z", 2)
 	_, err := dd.RemoveEntry(ctx, "z")
 	require.NoError(t, err)
 	require.Len(t, topBlock.Children, 1)
-	testDirDataCheckLookup(t, ctx, dd, "a", 1)
+	testDirDataCheckLookup(ctx, t, dd, "a", 1)
 	_, err = dd.Lookup(ctx, "z")
 	require.Equal(t, idutil.NoSuchNameError{Name: "z"}, err)
 
 	t.Log("Make a big complicated tree and remove an entry")
-	addFakeDirDataEntry(t, ctx, dd, "b", 2)
-	addFakeDirDataEntry(t, ctx, dd, "c", 3)
-	addFakeDirDataEntry(t, ctx, dd, "a1", 4)
-	addFakeDirDataEntry(t, ctx, dd, "a2", 5)
-	addFakeDirDataEntry(t, ctx, dd, "a0", 6)
-	addFakeDirDataEntry(t, ctx, dd, "a00", 7)
-	addFakeDirDataEntry(t, ctx, dd, "b1", 8)
-	addFakeDirDataEntry(t, ctx, dd, "d", 9)
-	addFakeDirDataEntry(t, ctx, dd, "a000", 10)
-	addFakeDirDataEntry(t, ctx, dd, "z", 11)
-	addFakeDirDataEntry(t, ctx, dd, "q", 12)
-	addFakeDirDataEntry(t, ctx, dd, "b2", 13)
-	addFakeDirDataEntry(t, ctx, dd, " 1", 14)
+	addFakeDirDataEntry(ctx, t, dd, "b", 2)
+	addFakeDirDataEntry(ctx, t, dd, "c", 3)
+	addFakeDirDataEntry(ctx, t, dd, "a1", 4)
+	addFakeDirDataEntry(ctx, t, dd, "a2", 5)
+	addFakeDirDataEntry(ctx, t, dd, "a0", 6)
+	addFakeDirDataEntry(ctx, t, dd, "a00", 7)
+	addFakeDirDataEntry(ctx, t, dd, "b1", 8)
+	addFakeDirDataEntry(ctx, t, dd, "d", 9)
+	addFakeDirDataEntry(ctx, t, dd, "a000", 10)
+	addFakeDirDataEntry(ctx, t, dd, "z", 11)
+	addFakeDirDataEntry(ctx, t, dd, "q", 12)
+	addFakeDirDataEntry(ctx, t, dd, "b2", 13)
+	addFakeDirDataEntry(ctx, t, dd, " 1", 14)
 	testDirDataCleanCache(dd, cleanBcache, dirtyBcache)
 
 	_, err = dd.RemoveEntry(ctx, "c")
@@ -463,29 +463,29 @@ func TestDirDataUpdateEntry(t *testing.T) {
 		SkipCacheHash)
 
 	t.Log("Make a simple dir and update one entry")
-	addFakeDirDataEntry(t, ctx, dd, "a", 1)
+	addFakeDirDataEntry(ctx, t, dd, "a", 1)
 	_, err := dd.UpdateEntry(ctx, "a", DirEntry{
 		EntryInfo: EntryInfo{
 			Size: 100,
 		},
 	})
 	require.NoError(t, err)
-	testDirDataCheckLookup(t, ctx, dd, "a", 100)
+	testDirDataCheckLookup(ctx, t, dd, "a", 100)
 
 	t.Log("Make a big complicated tree and update an entry")
-	addFakeDirDataEntry(t, ctx, dd, "b", 2)
-	addFakeDirDataEntry(t, ctx, dd, "c", 3)
-	addFakeDirDataEntry(t, ctx, dd, "a1", 4)
-	addFakeDirDataEntry(t, ctx, dd, "a2", 5)
-	addFakeDirDataEntry(t, ctx, dd, "a0", 6)
-	addFakeDirDataEntry(t, ctx, dd, "a00", 7)
-	addFakeDirDataEntry(t, ctx, dd, "b1", 8)
-	addFakeDirDataEntry(t, ctx, dd, "d", 9)
-	addFakeDirDataEntry(t, ctx, dd, "a000", 10)
-	addFakeDirDataEntry(t, ctx, dd, "z", 11)
-	addFakeDirDataEntry(t, ctx, dd, "q", 12)
-	addFakeDirDataEntry(t, ctx, dd, "b2", 13)
-	addFakeDirDataEntry(t, ctx, dd, " 1", 14)
+	addFakeDirDataEntry(ctx, t, dd, "b", 2)
+	addFakeDirDataEntry(ctx, t, dd, "c", 3)
+	addFakeDirDataEntry(ctx, t, dd, "a1", 4)
+	addFakeDirDataEntry(ctx, t, dd, "a2", 5)
+	addFakeDirDataEntry(ctx, t, dd, "a0", 6)
+	addFakeDirDataEntry(ctx, t, dd, "a00", 7)
+	addFakeDirDataEntry(ctx, t, dd, "b1", 8)
+	addFakeDirDataEntry(ctx, t, dd, "d", 9)
+	addFakeDirDataEntry(ctx, t, dd, "a000", 10)
+	addFakeDirDataEntry(ctx, t, dd, "z", 11)
+	addFakeDirDataEntry(ctx, t, dd, "q", 12)
+	addFakeDirDataEntry(ctx, t, dd, "b2", 13)
+	addFakeDirDataEntry(ctx, t, dd, " 1", 14)
 	testDirDataCleanCache(dd, cleanBcache, dirtyBcache)
 
 	_, err = dd.UpdateEntry(ctx, "c", DirEntry{
@@ -494,7 +494,7 @@ func TestDirDataUpdateEntry(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	testDirDataCheckLookup(t, ctx, dd, "c", 1000)
+	testDirDataCheckLookup(ctx, t, dd, "c", 1000)
 	expectedLeafs := []testDirDataLeaf{
 		{"", 2, false},    // " 1" and "a"
 		{"a0", 1, false},  // "a0"
@@ -526,9 +526,9 @@ func TestDirDataShifting(t *testing.T) {
 		SkipCacheHash)
 
 	for i := 0; i <= 10; i++ {
-		addFakeDirDataEntry(t, ctx, dd, strconv.Itoa(i), uint64(i+1))
+		addFakeDirDataEntry(ctx, t, dd, strconv.Itoa(i), uint64(i+1))
 	}
-	testDirDataCheckLookup(t, ctx, dd, "10", 11)
+	testDirDataCheckLookup(ctx, t, dd, "10", 11)
 	expectedLeafs := []testDirDataLeaf{
 		{"", 1, true},
 		{"1", 1, true},

--- a/go/kbfs/data/dirty_bcache_test.go
+++ b/go/kbfs/data/dirty_bcache_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func testDirtyBcachePut(
-	t *testing.T, ctx context.Context, id kbfsblock.ID,
+	ctx context.Context, t *testing.T, id kbfsblock.ID,
 	dirtyBcache DirtyBlockCache) {
 	block := NewFileBlock()
 	ptr := BlockPointer{ID: id}
@@ -43,7 +43,7 @@ func testDirtyBcachePut(
 }
 
 func testExpectedMissingDirty(
-	t *testing.T, ctx context.Context, id kbfsblock.ID,
+	ctx context.Context, t *testing.T, id kbfsblock.ID,
 	dirtyBcache DirtyBlockCache) {
 	expectedErr := NoSuchBlockError{id}
 	ptr := BlockPointer{ID: id}
@@ -61,7 +61,7 @@ func TestDirtyBcachePut(t *testing.T) {
 		&WallClock{}, log, libkb.NewVDebugLog(log), 5<<20, 10<<20, 5<<20)
 	defer dirtyBcache.Shutdown()
 	testDirtyBcachePut(
-		t, context.Background(), kbfsblock.FakeID(1), dirtyBcache)
+		context.Background(), t, kbfsblock.FakeID(1), dirtyBcache)
 }
 
 func TestDirtyBcachePutDuplicate(t *testing.T) {
@@ -88,7 +88,7 @@ func TestDirtyBcachePutDuplicate(t *testing.T) {
 	}
 
 	cleanBranch := MasterBranch
-	testExpectedMissingDirty(t, ctx, id1, dirtyBcache)
+	testExpectedMissingDirty(ctx, t, id1, dirtyBcache)
 	if !dirtyBcache.IsDirty(id, bp2, cleanBranch) {
 		t.Errorf("New refnonce block is now unexpectedly clean")
 	}
@@ -103,7 +103,7 @@ func TestDirtyBcachePutDuplicate(t *testing.T) {
 	}
 
 	// make sure the original dirty status is right
-	testExpectedMissingDirty(t, ctx, id1, dirtyBcache)
+	testExpectedMissingDirty(ctx, t, id1, dirtyBcache)
 	if !dirtyBcache.IsDirty(id, bp2, cleanBranch) {
 		t.Errorf("New refnonce block is now unexpectedly clean")
 	}
@@ -120,7 +120,7 @@ func TestDirtyBcacheDelete(t *testing.T) {
 
 	id1 := kbfsblock.FakeID(1)
 	ctx := context.Background()
-	testDirtyBcachePut(t, ctx, id1, dirtyBcache)
+	testDirtyBcachePut(ctx, t, id1, dirtyBcache)
 	newBranch := BranchName("dirtyBranch")
 	newBranchBlock := NewFileBlock()
 	id := tlf.FakeID(1, tlf.Private)
@@ -131,7 +131,7 @@ func TestDirtyBcacheDelete(t *testing.T) {
 	}
 
 	dirtyBcache.Delete(id, BlockPointer{ID: id1}, MasterBranch)
-	testExpectedMissingDirty(t, ctx, id1, dirtyBcache)
+	testExpectedMissingDirty(ctx, t, id1, dirtyBcache)
 	if !dirtyBcache.IsDirty(id, BlockPointer{ID: id1}, newBranch) {
 		t.Errorf("New branch block is now unexpectedly clean")
 	}

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -186,7 +186,7 @@ func addOneFileToRepo(t *testing.T, gitDir, filename, contents string) {
 		t, gitDir, filename, contents, "foo")
 }
 
-func testPushWithTemplate(t *testing.T, ctx context.Context,
+func testPushWithTemplate(ctx context.Context, t *testing.T,
 	config libkbfs.Config, gitDir string, refspecs []string,
 	outputTemplate, tlfName string) {
 	// Use the runner to push the local data into the KBFS repo.
@@ -229,13 +229,13 @@ func testPushWithTemplate(t *testing.T, ctx context.Context,
 	require.Equal(t, expectedOutputMap, outputMap)
 }
 
-func testPush(t *testing.T, ctx context.Context, config libkbfs.Config,
+func testPush(ctx context.Context, t *testing.T, config libkbfs.Config,
 	gitDir, refspec string) {
-	testPushWithTemplate(t, ctx, config, gitDir, []string{refspec},
+	testPushWithTemplate(ctx, t, config, gitDir, []string{refspec},
 		"ok %s\n\n", "user1")
 }
 
-func testListAndGetHeadsWithName(t *testing.T, ctx context.Context,
+func testListAndGetHeadsWithName(ctx context.Context, t *testing.T,
 	config libkbfs.Config, gitDir string, expectedRefs []string,
 	tlfName string) (heads []string) {
 	inputReader, inputWriter := io.Pipe()
@@ -272,11 +272,11 @@ func testListAndGetHeadsWithName(t *testing.T, ctx context.Context,
 	return heads
 }
 
-func testListAndGetHeads(t *testing.T, ctx context.Context,
+func testListAndGetHeads(ctx context.Context, t *testing.T,
 	config libkbfs.Config, gitDir string, expectedRefs []string) (
 	heads []string) {
 	return testListAndGetHeadsWithName(
-		t, ctx, config, gitDir, expectedRefs, "user1")
+		ctx, t, config, gitDir, expectedRefs, "user1")
 }
 
 // This tests pushing code to a bare repo stored in KBFS, and pulling
@@ -306,7 +306,7 @@ func testRunnerPushFetch(t *testing.T, cloning bool, secondRepoHasBranch bool) {
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
 
-	testPush(t, ctx, config, git1, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git1, "refs/heads/master:refs/heads/master")
 
 	git2, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
 	require.NoError(t, err)
@@ -317,7 +317,7 @@ func testRunnerPushFetch(t *testing.T, cloning bool, secondRepoHasBranch bool) {
 	gitExec(t, dotgit2, git2, "init")
 
 	// Find out the head hash.
-	heads := testListAndGetHeads(t, ctx, config, git2,
+	heads := testListAndGetHeads(ctx, t, config, git2,
 		[]string{"refs/heads/master", "HEAD"})
 
 	cloningStr := ""
@@ -387,16 +387,16 @@ func TestRunnerDeleteBranch(t *testing.T) {
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
 
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/test")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/test")
 
 	// Make sure there are 2 remote branches.
-	testListAndGetHeads(t, ctx, config, git,
+	testListAndGetHeads(ctx, t, config, git,
 		[]string{"refs/heads/master", "refs/heads/test", "HEAD"})
 
 	// Delete the test branch and make sure it goes away.
-	testPush(t, ctx, config, git, ":refs/heads/test")
-	testListAndGetHeads(t, ctx, config, git,
+	testPush(ctx, t, config, git, ":refs/heads/test")
+	testListAndGetHeads(ctx, t, config, git,
 		[]string{"refs/heads/master", "HEAD"})
 }
 
@@ -456,11 +456,11 @@ func TestForcePush(t *testing.T) {
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
 
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
 
 	// Push a second file.
 	addOneFileToRepo(t, git, "foo2", "hello2")
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
 
 	// Now revert to the old commit and add a different file.
 	dotgit := filepath.Join(git, ".git")
@@ -469,10 +469,10 @@ func TestForcePush(t *testing.T) {
 	addOneFileToRepo(t, git, "foo3", "hello3")
 	// A non-force push should fail.
 	testPushWithTemplate(
-		t, ctx, config, git, []string{"refs/heads/master:refs/heads/master"},
+		ctx, t, config, git, []string{"refs/heads/master:refs/heads/master"},
 		"error %s some refs were not updated\n\n", "user1")
 	// But a force push should work
-	testPush(t, ctx, config, git, "+refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "+refs/heads/master:refs/heads/master")
 }
 
 func TestPushAllWithPackedRefs(t *testing.T) {
@@ -495,12 +495,12 @@ func TestPushAllWithPackedRefs(t *testing.T) {
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
 
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
 
 	// Should be able to update the branch in a non-force way, even
 	// though it's a packed-ref.
 	addOneFileToRepo(t, git, "foo2", "hello2")
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
 }
 
 func TestPushSomeWithPackedRefs(t *testing.T) {
@@ -535,13 +535,13 @@ func TestPushSomeWithPackedRefs(t *testing.T) {
 	// Simulate a `git push --all`, and make sure `refs/test/ref`
 	// isn't pushed.
 	testPushWithTemplate(
-		t, ctx, config, git, []string{
+		ctx, t, config, git, []string{
 			"refs/heads/master:refs/heads/master",
 			"refs/heads/test:refs/heads/test",
 			"refs/tags/v0:refs/tags/v0",
 		},
 		"ok %s\nok %s\nok %s\n\n", "user1")
-	testListAndGetHeads(t, ctx, config, git,
+	testListAndGetHeads(ctx, t, config, git,
 		[]string{
 			"refs/heads/master",
 			"refs/heads/test",
@@ -551,11 +551,11 @@ func TestPushSomeWithPackedRefs(t *testing.T) {
 
 	// Make sure we can push over a packed-refs ref.
 	addOneFileToRepo(t, git, "foo4", "hello4")
-	testPush(t, ctx, config, git, "refs/heads/test:refs/heads/test")
+	testPush(ctx, t, config, git, "refs/heads/test:refs/heads/test")
 }
 
 func testCloneIntoNewLocalRepo(
-	t *testing.T, ctx context.Context, config libkbfs.Config,
+	ctx context.Context, t *testing.T, config libkbfs.Config,
 	tlfName string) string {
 	git, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
 	require.NoError(t, err)
@@ -569,7 +569,7 @@ func testCloneIntoNewLocalRepo(
 	dotgit := filepath.Join(git, ".git")
 	gitExec(t, dotgit, git, "init")
 
-	heads := testListAndGetHeadsWithName(t, ctx, config, git,
+	heads := testListAndGetHeadsWithName(ctx, t, config, git,
 		[]string{"refs/heads/master", "HEAD"}, tlfName)
 
 	inputReader, inputWriter := io.Pipe()
@@ -609,7 +609,7 @@ func TestRunnerReaderClone(t *testing.T) {
 	defer os.RemoveAll(git1)
 
 	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
-	testPushWithTemplate(t, ctx, config, git1,
+	testPushWithTemplate(ctx, t, config, git1,
 		[]string{"refs/heads/master:refs/heads/master"},
 		"ok %s\n\n", "user1#user2")
 
@@ -625,7 +625,7 @@ func TestRunnerReaderClone(t *testing.T) {
 		ctx, tempdir2, libkbfs.TLFJournalSingleOpBackgroundWorkEnabled)
 	require.NoError(t, err)
 
-	git2 := testCloneIntoNewLocalRepo(t, ctx, config2, "user1#user2")
+	git2 := testCloneIntoNewLocalRepo(ctx, t, config2, "user1#user2")
 	defer os.RemoveAll(git2)
 
 	data, err := ioutil.ReadFile(filepath.Join(git2, "foo"))
@@ -658,23 +658,23 @@ func TestRunnerDeletePackedRef(t *testing.T) {
 	require.NoError(t, err)
 
 	testPushWithTemplate(
-		t, ctx, config, git1, []string{
+		ctx, t, config, git1, []string{
 			"refs/heads/master:refs/heads/master",
 			"refs/heads/b:refs/heads/b",
 		},
 		"ok %s\nok %s\n\n", "user1")
 
-	testListAndGetHeadsWithName(t, ctx, config, git1,
+	testListAndGetHeadsWithName(ctx, t, config, git1,
 		[]string{"refs/heads/master", "refs/heads/b", "HEAD"}, "user1")
 
 	// Add a new file to the branch and push, to create a loose ref.
 	gitExec(t, dotgit1, git1, "checkout", "b")
 	addOneFileToRepo(t, git1, "foo3", "hello3")
-	testPush(t, ctx, config, git1, "refs/heads/b:refs/heads/b")
+	testPush(ctx, t, config, git1, "refs/heads/b:refs/heads/b")
 
 	// Now delete.
-	testPush(t, ctx, config, git1, ":refs/heads/b")
-	testListAndGetHeadsWithName(t, ctx, config, git1,
+	testPush(ctx, t, config, git1, ":refs/heads/b")
+	testListAndGetHeadsWithName(ctx, t, config, git1,
 		[]string{"refs/heads/master", "HEAD"}, "user1")
 }
 
@@ -723,10 +723,10 @@ func TestPackRefsAndOverwritePackedRef(t *testing.T) {
 
 	// Make shared repo with 2 branches.
 	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
-	testPushWithTemplate(t, ctx, config, git1,
+	testPushWithTemplate(ctx, t, config, git1,
 		[]string{"refs/heads/master:refs/heads/master"},
 		"ok %s\n\n", "user1,user2")
-	testPushWithTemplate(t, ctx, config, git1,
+	testPushWithTemplate(ctx, t, config, git1,
 		[]string{"refs/heads/master:refs/heads/test"},
 		"ok %s\n\n", "user1,user2")
 
@@ -746,7 +746,7 @@ func TestPackRefsAndOverwritePackedRef(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(git2)
 
-	heads := testListAndGetHeadsWithName(t, ctx, config2, git2,
+	heads := testListAndGetHeadsWithName(ctx, t, config2, git2,
 		[]string{"refs/heads/master", "refs/heads/test", "HEAD"}, "user1,user2")
 	require.Equal(t, heads[0], heads[1])
 
@@ -774,7 +774,7 @@ func TestPackRefsAndOverwritePackedRef(t *testing.T) {
 	// While the second user is stalled, have the first user update
 	// one of the refs.
 	addOneFileToRepo(t, git1, "foo2", "hello2")
-	testPushWithTemplate(t, ctx, config, git1,
+	testPushWithTemplate(ctx, t, config, git1,
 		[]string{"refs/heads/master:refs/heads/test"},
 		"ok %s\n\n", "user1,user2")
 
@@ -792,7 +792,7 @@ func TestPackRefsAndOverwritePackedRef(t *testing.T) {
 	err = config2.KBFSOps().SyncFromServer(
 		ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
-	heads = testListAndGetHeadsWithName(t, ctx, config2, git2,
+	heads = testListAndGetHeadsWithName(ctx, t, config2, git2,
 		[]string{"refs/heads/master", "refs/heads/test", "HEAD"}, "user1,user2")
 	require.NotEqual(t, heads[0], heads[1])
 }
@@ -811,10 +811,10 @@ func TestPackRefsAndDeletePackedRef(t *testing.T) {
 	// pack-refs file.
 	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
 	gitExec(t, dotgit1, git1, "pack-refs", "--all")
-	testPushWithTemplate(t, ctx, config, git1,
+	testPushWithTemplate(ctx, t, config, git1,
 		[]string{"refs/heads/master:refs/heads/master"},
 		"ok %s\n\n", "user1,user2")
-	testPushWithTemplate(t, ctx, config, git1,
+	testPushWithTemplate(ctx, t, config, git1,
 		[]string{"refs/heads/master:refs/heads/test"},
 		"ok %s\n\n", "user1,user2")
 
@@ -834,7 +834,7 @@ func TestPackRefsAndDeletePackedRef(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(git2)
 
-	heads := testListAndGetHeadsWithName(t, ctx, config2, git2,
+	heads := testListAndGetHeadsWithName(ctx, t, config2, git2,
 		[]string{"refs/heads/master", "refs/heads/test", "HEAD"}, "user1,user2")
 	require.Equal(t, heads[0], heads[1])
 
@@ -911,7 +911,7 @@ func TestPackRefsAndDeletePackedRef(t *testing.T) {
 	err = config2.KBFSOps().SyncFromServer(
 		ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
-	testListAndGetHeadsWithName(t, ctx, config2, git2,
+	testListAndGetHeadsWithName(ctx, t, config2, git2,
 		[]string{"refs/heads/master", "HEAD"}, "user1,user2")
 }
 
@@ -932,13 +932,13 @@ func TestRepackObjects(t *testing.T) {
 
 	// Make a few pushes to make a few object pack files.
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
 	addOneFileToRepo(t, git, "foo2", "hello2")
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
 	addOneFileToRepo(t, git, "foo3", "hello3")
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
 	addOneFileToRepo(t, git, "foo4", "hello4")
-	testPush(t, ctx, config, git, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git, "refs/heads/master:refs/heads/master")
 
 	fs, _, err := libgit.GetRepoAndID(ctx, config, h, "test", "")
 	require.NoError(t, err)
@@ -964,7 +964,7 @@ func TestRepackObjects(t *testing.T) {
 	require.Equal(t, 1, numObjectPacks)
 
 	// Check that a second clone looks correct.
-	git2 := testCloneIntoNewLocalRepo(t, ctx, config, "user1")
+	git2 := testCloneIntoNewLocalRepo(ctx, t, config, "user1")
 	defer os.RemoveAll(git2)
 
 	checkFile := func(name, expectedData string) {
@@ -978,7 +978,7 @@ func TestRepackObjects(t *testing.T) {
 	checkFile("foo4", "hello4")
 }
 
-func testHandlePushBatch(t *testing.T, ctx context.Context,
+func testHandlePushBatch(ctx context.Context, t *testing.T,
 	config libkbfs.Config, git, refspec, tlfName string) libgit.RefDataByName {
 	var input bytes.Buffer
 	var output bytes.Buffer
@@ -1014,7 +1014,7 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 		"We expect this to return no commits, since it should push the " +
 		"whole repository.")
 	makeLocalRepoWithOneFileCustomCommitMsg(t, git, "foo", "hello", "", "one")
-	refDataByName := testHandlePushBatch(t, ctx, config, git,
+	refDataByName := testHandlePushBatch(ctx, t, config, git,
 		"refs/heads/master:refs/heads/master", "user1")
 	require.Len(t, refDataByName, 1)
 	master := refDataByName["refs/heads/master"]
@@ -1026,7 +1026,7 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 	t.Log("Add a commit and push it. We expect the push batch to return " +
 		"one reference with one commit.")
 	addOneFileToRepoCustomCommitMsg(t, git, "foo2", "hello2", "two")
-	refDataByName = testHandlePushBatch(t, ctx, config, git,
+	refDataByName = testHandlePushBatch(ctx, t, config, git,
 		"refs/heads/master:refs/heads/master", "user1")
 	require.Len(t, refDataByName, 1)
 	master = refDataByName["refs/heads/master"]
@@ -1041,7 +1041,7 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 	addOneFileToRepoCustomCommitMsg(t, git, "foo3", "hello3", "three")
 	addOneFileToRepoCustomCommitMsg(t, git, "foo4", "hello4", "four")
 	addOneFileToRepoCustomCommitMsg(t, git, "foo5", "hello5", "five")
-	refDataByName = testHandlePushBatch(t, ctx, config, git,
+	refDataByName = testHandlePushBatch(ctx, t, config, git,
 		"refs/heads/master:refs/heads/master", "user1")
 	require.Len(t, refDataByName, 1)
 	master = refDataByName["refs/heads/master"]
@@ -1060,7 +1060,7 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 		msg := fmt.Sprintf("commit message %d", i+6)
 		addOneFileToRepoCustomCommitMsg(t, git, filename, content, msg)
 	}
-	refDataByName = testHandlePushBatch(t, ctx, config, git,
+	refDataByName = testHandlePushBatch(ctx, t, config, git,
 		"refs/heads/master:refs/heads/master", "user1")
 	require.Len(t, refDataByName, 1)
 	master = refDataByName["refs/heads/master"]
@@ -1070,7 +1070,7 @@ func TestRunnerHandlePushBatch(t *testing.T) {
 	require.Equal(t, libgit.CommitSentinelValue, commits[maxCommitsToVisitPerRef-1])
 
 	t.Log("Push a deletion.")
-	refDataByName = testHandlePushBatch(t, ctx, config, git,
+	refDataByName = testHandlePushBatch(ctx, t, config, git,
 		":refs/heads/master", "user1")
 	require.Len(t, refDataByName, 1)
 	master = refDataByName["refs/heads/master"]
@@ -1118,7 +1118,7 @@ func TestRunnerSubmodule(t *testing.T) {
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
-	testPush(t, ctx, config, git1, "refs/heads/master:refs/heads/master")
+	testPush(ctx, t, config, git1, "refs/heads/master:refs/heads/master")
 
 	t.Log("Use autogit to browse it")
 	rootFS, err := libfs.NewFS(

--- a/go/kbfs/libdokan/mount_test.go
+++ b/go/kbfs/libdokan/mount_test.go
@@ -55,11 +55,11 @@ func getDriveLetterLock(driveLetter byte) *sync.Mutex {
 	return nil
 }
 
-func makeFS(t testing.TB, ctx context.Context, config *libkbfs.ConfigLocal) (*compatMount, *FS, func()) {
-	return makeFSE(t, ctx, config, 'T')
+func makeFS(ctx context.Context, t testing.TB, config *libkbfs.ConfigLocal) (*compatMount, *FS, func()) {
+	return makeFSE(ctx, t, config, 'T')
 }
 
-func makeFSE(t testing.TB, ctx context.Context, config *libkbfs.ConfigLocal,
+func makeFSE(ctx context.Context, t testing.TB, config *libkbfs.ConfigLocal,
 	driveLetter byte) (*compatMount, *FS, func()) {
 	makeSuccess := false
 	lock := getDriveLetterLock(driveLetter)
@@ -153,7 +153,7 @@ func TestStatRoot(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -171,7 +171,7 @@ func TestStatPrivate(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -189,7 +189,7 @@ func TestStatPublic(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -207,7 +207,7 @@ func TestStatMyFolder(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -225,7 +225,7 @@ func TestStatNonexistentFolder(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -239,7 +239,7 @@ func TestStatAlias(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -269,7 +269,7 @@ func TestStatMyPublic(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -287,7 +287,7 @@ func TestReaddirRoot(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -303,7 +303,7 @@ func TestReaddirPrivate(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -328,7 +328,7 @@ func TestReaddirPublic(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -353,7 +353,7 @@ func TestReaddirMyFolderEmpty(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -396,7 +396,7 @@ func TestReaddirMyFolderWithFiles(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -447,7 +447,7 @@ func TestCreateThenRead(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -464,7 +464,7 @@ func TestMultipleCreateThenRead(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -479,7 +479,7 @@ func TestReadUnflushed(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -513,7 +513,7 @@ func TestMountAgain(t *testing.T) {
 	const input = "hello, world\n"
 	const filename = "myfile"
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -525,7 +525,7 @@ func TestMountAgain(t *testing.T) {
 	}()
 
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 		p := filepath.Join(mnt.Dir, PrivateName, "jdoe", filename)
@@ -544,7 +544,7 @@ func TestMkdir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -566,7 +566,7 @@ func TestMkdirNewFolder(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -597,7 +597,7 @@ func TestMkdirAndCreateDeep(t *testing.T) {
 	const input = "hello, world\n"
 
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -618,7 +618,7 @@ func TestMkdirAndCreateDeep(t *testing.T) {
 
 	// unmount to flush cache
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -641,7 +641,7 @@ func TestSymlink(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -653,7 +653,7 @@ func TestSymlink(t *testing.T) {
 
 	// unmount to flush cache
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -673,7 +673,7 @@ func TestRename(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -712,7 +712,7 @@ func TestRenameOverwrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -754,7 +754,7 @@ func TestRenameCrossDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -799,7 +799,7 @@ func TestRenameCrossFolder(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -852,7 +852,7 @@ func TestWriteThenRename(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -908,7 +908,7 @@ func TestWriteThenRenameCrossDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -971,7 +971,7 @@ func TestRemoveFile(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -999,7 +999,7 @@ func TestRemoveDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1025,7 +1025,7 @@ func TestRemoveDirNotEmpty(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1055,7 +1055,7 @@ func TestRemoveFileWhileOpenWriting(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1092,7 +1092,7 @@ func TestRemoveFileWhileOpenReading(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1139,13 +1139,13 @@ func TestRemoveFileWhileOpenReadingAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer config1.Shutdown(ctx)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer config2.Shutdown(ctx)
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -1198,13 +1198,13 @@ func TestRenameOverFileWhileOpenReadingAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer config1.Shutdown(ctx)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer config2.Shutdown(ctx)
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -1274,7 +1274,7 @@ func TestTruncateGrow(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1314,7 +1314,7 @@ func TestTruncateShrink(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1354,7 +1354,7 @@ func TestSetattrFileMtime(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1389,7 +1389,7 @@ func TestSetattrFileMtimeNow(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1433,7 +1433,7 @@ func TestSetattrDirMtime(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1466,7 +1466,7 @@ func TestSetattrDirMtimeNow(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1509,7 +1509,7 @@ func TestFsync(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1538,7 +1538,7 @@ func TestReaddirPrivateDeleteAndReaddFavorite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1576,7 +1576,7 @@ func TestReaddirMyPublic(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1602,7 +1602,7 @@ func TestReaddirOtherFolderAsReader(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -1617,7 +1617,7 @@ func TestReaddirOtherFolderAsReader(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1632,7 +1632,7 @@ func TestStatOtherFolder(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -1647,7 +1647,7 @@ func TestStatOtherFolder(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFSE(t, ctx, c2, 'U')
+	mnt, _, cancelFn := makeFSE(ctx, t, c2, 'U')
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1668,7 +1668,7 @@ func TestStatOtherFolderFirstUse(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFSE(t, ctx, c2, 'U')
+	mnt, _, cancelFn := makeFSE(ctx, t, c2, 'U')
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1686,7 +1686,7 @@ func TestStatOtherFolderPublic(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -1701,7 +1701,7 @@ func TestStatOtherFolderPublic(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFSE(t, ctx, c2, 'U')
+	mnt, _, cancelFn := makeFSE(ctx, t, c2, 'U')
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1724,7 +1724,7 @@ func TestReadPublicFile(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	const input = "hello, world\n"
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -1738,7 +1738,7 @@ func TestReadPublicFile(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFSE(t, ctx, c2, 'U')
+	mnt, _, cancelFn := makeFSE(ctx, t, c2, 'U')
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1758,7 +1758,7 @@ func TestReaddirOtherFolderPublicAsAnyone(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -1773,7 +1773,7 @@ func TestReaddirOtherFolderPublicAsAnyone(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFSE(t, ctx, c2, 'U')
+	mnt, _, cancelFn := makeFSE(ctx, t, c2, 'U')
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1789,7 +1789,7 @@ func TestReaddirOtherFolderAsAnyone(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -1804,7 +1804,7 @@ func TestReaddirOtherFolderAsAnyone(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFSE(t, ctx, c2, 'U')
+	mnt, _, cancelFn := makeFSE(ctx, t, c2, 'U')
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1840,10 +1840,10 @@ func TestInvalidateDataOnWrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
 	defer mnt1.Close()
 	defer cancelFn1()
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -1898,10 +1898,10 @@ func TestInvalidatePublicDataOnWrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
 	defer mnt1.Close()
 	defer cancelFn1()
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -1956,10 +1956,10 @@ func TestInvalidateDataOnTruncate(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
 	defer mnt1.Close()
 	defer cancelFn1()
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2014,7 +2014,7 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2078,10 +2078,10 @@ func TestInvalidateEntryOnDelete(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
 	defer mnt1.Close()
 	defer cancelFn1()
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2148,7 +2148,7 @@ func TestErrorFile(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	config.SetReporter(libkbfs.NewReporterSimple(config.Clock(), 0))
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2200,13 +2200,13 @@ func TestInvalidateAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2288,13 +2288,13 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2356,13 +2356,13 @@ func TestInvalidateRenameToUncachedDir(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2435,7 +2435,7 @@ func TestStatusFile(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2485,13 +2485,13 @@ func TestUnstageFile(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2594,12 +2594,12 @@ func TestSimpleCRNoConflict(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2749,12 +2749,12 @@ func TestSimpleCRConflictOnOpenFiles(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2938,12 +2938,12 @@ func TestSimpleCRConflictOnOpenMergedFile(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -3126,13 +3126,13 @@ func TestKbfsFileInfo(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config2, 'U')
+	mnt2, fs2, cancelFn2 := makeFSE(ctx, t, config2, 'U')
 	defer mnt2.Close()
 	defer cancelFn2()
 

--- a/go/kbfs/libdokan/noexec_test.go
+++ b/go/kbfs/libdokan/noexec_test.go
@@ -69,7 +69,7 @@ func testNoExec(t *testing.T, users []string) error {
 	// Background flushed needed for large files.
 	config.SetDoBackgroundFlushes(true)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 

--- a/go/kbfs/libfs/fs_test.go
+++ b/go/kbfs/libfs/fs_test.go
@@ -80,7 +80,7 @@ func makeFSWithJournal(t *testing.T, subdir string) (
 }
 
 func testCreateFile(
-	t *testing.T, ctx context.Context, fs *FS, file string,
+	ctx context.Context, t *testing.T, fs *FS, file string,
 	parent libkbfs.Node) {
 	f, err := fs.Create(file)
 	require.NoError(t, err)
@@ -127,8 +127,8 @@ func TestCreateFileInRoot(t *testing.T) {
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
 
-	testCreateFile(t, ctx, fs, "foo", rootNode)
-	testCreateFile(t, ctx, fs, "/bar", rootNode)
+	testCreateFile(ctx, t, fs, "foo", rootNode)
+	testCreateFile(ctx, t, fs, "/bar", rootNode)
 }
 
 func TestCreateFileInSubdir(t *testing.T) {
@@ -143,7 +143,7 @@ func TestCreateFileInSubdir(t *testing.T) {
 	bNode, _, err := fs.config.KBFSOps().CreateDir(ctx, aNode, "b")
 	require.NoError(t, err)
 
-	testCreateFile(t, ctx, fs, "a/b/foo", bNode)
+	testCreateFile(ctx, t, fs, "a/b/foo", bNode)
 }
 
 func TestCreateFileInMissingSubdir(t *testing.T) {
@@ -168,7 +168,7 @@ func TestAppendFile(t *testing.T) {
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
 
-	testCreateFile(t, ctx, fs, "foo", rootNode)
+	testCreateFile(ctx, t, fs, "foo", rootNode)
 	f, err := fs.OpenFile("foo", os.O_APPEND, 0600)
 	require.NoError(t, err)
 
@@ -204,7 +204,7 @@ func TestRecreateAndExcl(t *testing.T) {
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
 
-	testCreateFile(t, ctx, fs, "foo", rootNode)
+	testCreateFile(ctx, t, fs, "foo", rootNode)
 
 	// Re-create the same file.
 	f, err := fs.Create("foo")
@@ -238,7 +238,7 @@ func TestStat(t *testing.T) {
 	require.NoError(t, err)
 	aNode, _, err := fs.config.KBFSOps().CreateDir(ctx, rootNode, "a")
 	require.NoError(t, err)
-	testCreateFile(t, ctx, fs, "a/foo", aNode)
+	testCreateFile(ctx, t, fs, "a/foo", aNode)
 
 	// Check the dir
 	fi, err := fs.Stat("a")
@@ -290,7 +290,7 @@ func TestStat(t *testing.T) {
 	require.NoError(t, err)
 	aNode2, _, err := fs2U2.config.KBFSOps().CreateDir(ctx, rootNode2, "a")
 	require.NoError(t, err)
-	testCreateFile(t, ctx, fs2U2, "a/foo", aNode2)
+	testCreateFile(ctx, t, fs2U2, "a/foo", aNode2)
 
 	// Read as the reader.
 	fs2U1, err := NewFS(
@@ -314,7 +314,7 @@ func TestRename(t *testing.T) {
 	rootNode, _, err := fs.config.KBFSOps().GetRootNode(
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	testCreateFile(t, ctx, fs, "foo", rootNode)
+	testCreateFile(ctx, t, fs, "foo", rootNode)
 	err = fs.MkdirAll("a/b", os.FileMode(0600))
 	require.NoError(t, err)
 
@@ -352,7 +352,7 @@ func TestRemove(t *testing.T) {
 	rootNode, _, err := fs.config.KBFSOps().GetRootNode(
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	testCreateFile(t, ctx, fs, "foo", rootNode)
+	testCreateFile(ctx, t, fs, "foo", rootNode)
 	err = fs.MkdirAll("a/b", os.FileMode(0600))
 	require.NoError(t, err)
 
@@ -385,8 +385,8 @@ func TestReadDir(t *testing.T) {
 	require.NoError(t, err)
 	aNode, _, err := fs.config.KBFSOps().CreateDir(ctx, rootNode, "a")
 	require.NoError(t, err)
-	testCreateFile(t, ctx, fs, "a/foo", aNode)
-	testCreateFile(t, ctx, fs, "a/bar", aNode)
+	testCreateFile(ctx, t, fs, "a/foo", aNode)
+	testCreateFile(ctx, t, fs, "a/bar", aNode)
 	expectedNames := map[string]bool{
 		"foo": true,
 		"bar": true,
@@ -694,7 +694,7 @@ func TestArchivedByRevision(t *testing.T) {
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
 
-	testCreateFile(t, ctx, fs, "foo", rootNode)
+	testCreateFile(ctx, t, fs, "foo", rootNode)
 	fis, err := fs.ReadDir("")
 	require.NoError(t, err)
 	require.Len(t, fis, 1)

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -41,7 +41,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func makeFS(t testing.TB, ctx context.Context, config *libkbfs.ConfigLocal) (
+func makeFS(ctx context.Context, t testing.TB, config *libkbfs.ConfigLocal) (
 	*fstestutil.Mount, *FS, func()) {
 	log := logger.NewTestLogger(t)
 	debugLog := log.CloneWithAddedDepth(1)
@@ -170,7 +170,7 @@ func TestStatRoot(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -188,7 +188,7 @@ func TestStatPrivate(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -206,7 +206,7 @@ func TestStatPublic(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -224,7 +224,7 @@ func TestStatMyFolder(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -248,7 +248,7 @@ func TestStatNonexistentFolder(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -262,7 +262,7 @@ func TestStatAlias(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -291,7 +291,7 @@ func TestStatAliasCausesNoIdentifies(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer config.Shutdown(ctx)
 
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -320,7 +320,7 @@ func TestStatInvalidAliasFails(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer config.Shutdown(ctx)
 
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -337,7 +337,7 @@ func TestRemoveAlias(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -353,7 +353,7 @@ func TestStatMyPublic(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -377,7 +377,7 @@ func TestReaddirRoot(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -393,7 +393,7 @@ func TestReaddirPrivate(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -418,7 +418,7 @@ func TestReaddirPrivateDeleteAndReaddFavorite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, fs, cancelFn := makeFS(t, ctx, config)
+	mnt, fs, cancelFn := makeFS(ctx, t, config)
 	fs.execAfterDelay = func(d time.Duration, f func()) {
 		// this causes the entry added to fl.recentlyRemoved (in
 		// addToRecentlyRemove) to be removed instantly. this way we can avoid
@@ -462,7 +462,7 @@ func TestReaddirPublic(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -501,13 +501,13 @@ func TestReaddirPublicFailedIdentifyViaOSCall(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "u1", "u2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "u2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, _, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, _, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -546,7 +546,7 @@ func TestReaddirMyFolderEmpty(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -589,7 +589,7 @@ func TestReaddirMyFolderWithFiles(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -640,7 +640,7 @@ func TestCreateThenRead(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -657,7 +657,7 @@ func TestMultipleCreateThenRead(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -672,7 +672,7 @@ func TestReadUnflushed(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -706,7 +706,7 @@ func TestMountAgain(t *testing.T) {
 	const input = "hello, world\n"
 	const filename = "myfile"
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -718,7 +718,7 @@ func TestMountAgain(t *testing.T) {
 	}()
 
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 		p := path.Join(mnt.Dir, PrivateName, "jdoe", filename)
@@ -737,7 +737,7 @@ func TestCreateExecutable(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -760,7 +760,7 @@ func TestMkdir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -785,7 +785,7 @@ func TestMkdirAndCreateDeep(t *testing.T) {
 	const input = "hello, world\n"
 
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -806,7 +806,7 @@ func TestMkdirAndCreateDeep(t *testing.T) {
 
 	// unmount to flush cache
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -828,7 +828,7 @@ func TestSymlink(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -840,7 +840,7 @@ func TestSymlink(t *testing.T) {
 
 	// unmount to flush cache
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -860,7 +860,7 @@ func TestRename(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -900,7 +900,7 @@ func TestRenameOverwrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -942,7 +942,7 @@ func TestRenameCrossDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -987,7 +987,7 @@ func TestRenameCrossFolder(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1043,7 +1043,7 @@ func TestWriteThenRename(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1098,7 +1098,7 @@ func TestWriteThenRenameCrossDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1159,7 +1159,7 @@ func TestRemoveFile(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1185,7 +1185,7 @@ func TestRemoveTLF(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "pikachu")
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
@@ -1240,7 +1240,7 @@ func TestRemoveDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1265,7 +1265,7 @@ func TestRemoveDirNotEmpty(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1294,7 +1294,7 @@ func TestRemoveFileWhileOpenSetEx(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1339,7 +1339,7 @@ func TestRemoveFileWhileOpenWritingInTLFRoot(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1375,7 +1375,7 @@ func TestRemoveFileWhileOpenWritingInSubDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1416,7 +1416,7 @@ func TestRenameOverFileWhileOpenWritingInDifferentDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1468,7 +1468,7 @@ func TestRenameOverFileWhileOpenWritingInSameSubDir(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1520,7 +1520,7 @@ func TestRemoveFileWhileOpenReading(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1566,13 +1566,13 @@ func TestRemoveFileWhileOpenReadingAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -1629,13 +1629,13 @@ func TestRenameOverFileWhileOpenReadingAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -1709,7 +1709,7 @@ func TestTruncateGrow(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1748,7 +1748,7 @@ func TestTruncateShrink(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1787,7 +1787,7 @@ func TestChmodExec(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1816,7 +1816,7 @@ func TestChmodNonExec(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1845,7 +1845,7 @@ func TestChownFileIgnored(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1882,7 +1882,7 @@ func TestChmodDirIgnored(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1902,7 +1902,7 @@ func TestChownDirIgnored(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1937,7 +1937,7 @@ func TestSetattrFileMtime(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -1970,7 +1970,7 @@ func TestSetattrFileMtimeAfterWrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer config.Shutdown(ctx)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2021,7 +2021,7 @@ func TestSetattrFileMtimeNow(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2063,7 +2063,7 @@ func TestSetattrDirMtime(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2094,7 +2094,7 @@ func TestSetattrDirMtimeNow(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2134,7 +2134,7 @@ func TestFsync(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2163,7 +2163,7 @@ func TestReaddirMyPublic(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2189,7 +2189,7 @@ func TestReaddirOtherFolderAsReader(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -2204,7 +2204,7 @@ func TestReaddirOtherFolderAsReader(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2220,7 +2220,7 @@ func TestReaddirMissingOtherFolderAsReader(t *testing.T) {
 	defer config.Shutdown(ctx)
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2236,7 +2236,7 @@ func TestLookupMissingOtherFolderAsReader(t *testing.T) {
 	defer config.Shutdown(ctx)
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2252,7 +2252,7 @@ func TestStatOtherFolder(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -2267,7 +2267,7 @@ func TestStatOtherFolder(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2290,7 +2290,7 @@ func TestStatOtherFolderFirstUse(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2310,7 +2310,7 @@ func TestStatOtherFolderPublic(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -2325,7 +2325,7 @@ func TestStatOtherFolderPublic(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2347,7 +2347,7 @@ func TestReadPublicFile(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	const input = "hello, world\n"
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -2361,7 +2361,7 @@ func TestReadPublicFile(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2380,7 +2380,7 @@ func TestReaddirOtherFolderPublicAsAnyone(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -2395,7 +2395,7 @@ func TestReaddirOtherFolderPublicAsAnyone(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2411,7 +2411,7 @@ func TestReaddirMissingFolderPublicAsAnyone(t *testing.T) {
 	defer config.Shutdown(ctx)
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer c2.Shutdown(ctx)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2426,7 +2426,7 @@ func TestReaddirOtherFolderAsAnyone(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
-		mnt, _, cancelFn := makeFS(t, ctx, config)
+		mnt, _, cancelFn := makeFS(ctx, t, config)
 		defer mnt.Close()
 		defer cancelFn()
 
@@ -2441,7 +2441,7 @@ func TestReaddirOtherFolderAsAnyone(t *testing.T) {
 
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
-	mnt, _, cancelFn := makeFS(t, ctx, c2)
+	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2480,12 +2480,12 @@ func TestInvalidateDataOnWrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
 	defer mnt1.Close()
 	defer cancelFn1()
 	config2 := libkbfs.ConfigAsUser(config, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2544,12 +2544,12 @@ func TestInvalidatePublicDataOnWrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
 	defer mnt1.Close()
 	defer cancelFn1()
 	config2 := libkbfs.ConfigAsUser(config, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2608,12 +2608,12 @@ func TestInvalidateDataOnTruncate(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
 	defer mnt1.Close()
 	defer cancelFn1()
 	config2 := libkbfs.ConfigAsUser(config, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2672,7 +2672,7 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, fs, cancelFn := makeFS(t, ctx, config)
+	mnt, fs, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2741,10 +2741,10 @@ func TestInvalidateEntryOnDelete(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
 	defer mnt1.Close()
 	defer cancelFn1()
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2814,7 +2814,7 @@ func TestErrorFile(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	config.SetReporter(libkbfs.NewReporterSimple(config.Clock(), 0))
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -2864,13 +2864,13 @@ func TestInvalidateAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -2958,13 +2958,13 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -3030,13 +3030,13 @@ func TestInvalidateRenameToUncachedDir(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -3113,7 +3113,7 @@ func TestStatusFile(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 
@@ -3159,13 +3159,13 @@ func TestUnstageFile(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 
@@ -3273,13 +3273,13 @@ func TestSimpleCRNoConflict(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
@@ -3451,13 +3451,13 @@ func TestSimpleCRConflictOnOpenFiles(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
@@ -3652,13 +3652,13 @@ func TestSimpleCRConflictOnOpenMergedFile(t *testing.T) {
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
@@ -3853,13 +3853,13 @@ func TestKbfsFileInfo(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
@@ -3901,13 +3901,13 @@ func TestDirSyncAll(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
 
 	config2 := libkbfs.ConfigAsUser(config1, "user2")
-	mnt2, fs2, cancelFn2 := makeFS(t, ctx, config2)
+	mnt2, fs2, cancelFn2 := makeFS(ctx, t, config2)
 	defer mnt2.Close()
 	defer cancelFn2()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
@@ -3948,7 +3948,7 @@ func TestInodes(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
 	defer libcontext.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
-	mnt, _, cancelFn := makeFS(t, ctx, config)
+	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)

--- a/go/kbfs/libgit/autogit_manager_test.go
+++ b/go/kbfs/libgit/autogit_manager_test.go
@@ -87,15 +87,15 @@ func addFileToWorktree(
 }
 
 func addFileToWorktreeAndCommit(
-	t *testing.T, ctx context.Context, config libkbfs.Config,
+	ctx context.Context, t *testing.T, config libkbfs.Config,
 	h *tlfhandle.Handle, repo *gogit.Repository, worktreeFS billy.Filesystem,
 	name, data string) {
 	addFileToWorktree(t, repo, worktreeFS, name, data)
-	commitWorktree(t, ctx, config, h, worktreeFS)
+	commitWorktree(ctx, t, config, h, worktreeFS)
 }
 
 func commitWorktree(
-	t *testing.T, ctx context.Context, config libkbfs.Config,
+	ctx context.Context, t *testing.T, config libkbfs.Config,
 	h *tlfhandle.Handle, worktreeFS billy.Filesystem) {
 	err := worktreeFS.(*libfs.FS).SyncAll()
 	require.NoError(t, err)

--- a/go/kbfs/libgit/autogit_node_wrappers_test.go
+++ b/go/kbfs/libgit/autogit_node_wrappers_test.go
@@ -107,14 +107,14 @@ func TestAutogitRepoNode(t *testing.T) {
 	repo, err := gogit.Init(dotgitStorage, worktreeFS)
 	require.NoError(t, err)
 	addFileToWorktreeAndCommit(
-		t, ctx, config, h, repo, worktreeFS, "foo", "hello")
+		ctx, t, config, h, repo, worktreeFS, "foo", "hello")
 
 	t.Log("Use autogit to clone it using ReadDir")
 	checkAutogitOneFile(t, rootFS)
 
 	t.Log("Update the source repo and make sure the autogit repos update too")
 	addFileToWorktreeAndCommit(
-		t, ctx, config, h, repo, worktreeFS, "foo2", "hello2")
+		ctx, t, config, h, repo, worktreeFS, "foo2", "hello2")
 
 	t.Log("Force the source repo to update for the user")
 	srcRootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
@@ -143,7 +143,7 @@ func TestAutogitRepoNode(t *testing.T) {
 	})
 	require.NoError(t, err)
 	addFileToWorktreeAndCommit(
-		t, ctx, config, h, repo, worktreeFS, "foo3", "hello3")
+		ctx, t, config, h, repo, worktreeFS, "foo3", "hello3")
 	err = wt.Checkout(&gogit.CheckoutOptions{Branch: "refs/heads/master"})
 	require.NoError(t, err)
 	checkAutogitTwoFiles(t, rootFS)
@@ -209,7 +209,7 @@ func TestAutogitRepoNodeReadonly(t *testing.T) {
 	repo, err := gogit.Init(dotgitStorage, worktreeFS)
 	require.NoError(t, err)
 	addFileToWorktreeAndCommit(
-		t, ctx, config, h, repo, worktreeFS, "foo", "hello")
+		ctx, t, config, h, repo, worktreeFS, "foo", "hello")
 
 	t.Log("Use autogit to open it as another user.")
 	config2 := libkbfs.ConfigAsUser(config, "user2")
@@ -240,7 +240,7 @@ func TestAutogitRepoNodeReadonly(t *testing.T) {
 		}
 	}
 	t.Log("Repacking done")
-	commitWorktree(t, ctx, config, h, worktreeFS)
+	commitWorktree(ctx, t, config, h, worktreeFS)
 
 	t.Log("Force the source repo to update for the second user")
 	srcRootNode2, _, err := config2.KBFSOps().GetOrCreateRootNode(
@@ -297,7 +297,7 @@ func TestAutogitCommitFile(t *testing.T) {
 	time1 := time.Now()
 	hash1 := addFileToWorktreeWithInfo(
 		t, repo, worktreeFS, "foo", "hello", msg1, user1, email1, time1)
-	commitWorktree(t, ctx, config, h, worktreeFS)
+	commitWorktree(ctx, t, config, h, worktreeFS)
 
 	t.Log("Check the first commit -- no diff")
 	headerFormat := "commit %s\nAuthor: %s <%s>\nDate:   %s\n\n    %s\n"
@@ -320,7 +320,7 @@ func TestAutogitCommitFile(t *testing.T) {
 	time2 := time1.Add(1 * time.Minute)
 	hash2 := addFileToWorktreeWithInfo(
 		t, repo, worktreeFS, "foo", "hello world", msg2, user2, email2, time2)
-	commitWorktree(t, ctx, config, h, worktreeFS)
+	commitWorktree(ctx, t, config, h, worktreeFS)
 
 	commit1, err := repo.CommitObject(hash1)
 	require.NoError(t, err)

--- a/go/kbfs/libgit/browser_test.go
+++ b/go/kbfs/libgit/browser_test.go
@@ -63,9 +63,9 @@ func testBrowser(t *testing.T, sharedCache sharedInBrowserCache) {
 	require.Len(t, fis, 0)
 
 	addFileToWorktreeAndCommit(
-		t, ctx, config, h, repo, worktreeFS, "foo", "hello")
+		ctx, t, config, h, repo, worktreeFS, "foo", "hello")
 	addFileToWorktreeAndCommit(
-		t, ctx, config, h, repo, worktreeFS, "dir/foo", "olleh")
+		ctx, t, config, h, repo, worktreeFS, "dir/foo", "olleh")
 
 	t.Log("Browse the repo and verify the data.")
 	b, err = NewBrowser(dotgitFS, config.Clock(), "", sharedCache)

--- a/go/kbfs/libkbfs/block_disk_store_test.go
+++ b/go/kbfs/libkbfs/block_disk_store_test.go
@@ -35,7 +35,7 @@ func teardownBlockDiskStoreTest(t *testing.T, tempdir string) {
 }
 
 func putBlockDisk(
-	t *testing.T, ctx context.Context, s *blockDiskStore, data []byte) (
+	ctx context.Context, t *testing.T, s *blockDiskStore, data []byte) (
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
 	bID, err := kbfsblock.MakePermanentID(
 		data, kbfscrypto.EncryptionSecretboxWithKeyNonce)
@@ -57,7 +57,7 @@ func putBlockDisk(
 }
 
 func addBlockDiskRef(
-	t *testing.T, ctx context.Context, s *blockDiskStore,
+	ctx context.Context, t *testing.T, s *blockDiskStore,
 	bID kbfsblock.ID) kbfsblock.Context {
 	nonce, err := kbfsblock.MakeRefNonce()
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func addBlockDiskRef(
 }
 
 func getAndCheckBlockDiskData(
-	t *testing.T, ctx context.Context, s *blockDiskStore,
+	ctx context.Context, t *testing.T, s *blockDiskStore,
 	bID kbfsblock.ID, bCtx kbfsblock.Context, expectedData []byte,
 	expectedServerHalf kbfscrypto.BlockCryptKeyServerHalf) {
 	data, serverHalf, err := s.getDataWithContext(ctx, bID, bCtx)
@@ -89,24 +89,24 @@ func TestBlockDiskStoreBasic(t *testing.T) {
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
-	bID, bCtx, serverHalf := putBlockDisk(t, ctx, s, data)
+	bID, bCtx, serverHalf := putBlockDisk(ctx, t, s, data)
 
 	// Make sure we get the same block back.
-	getAndCheckBlockDiskData(t, ctx, s, bID, bCtx, data, serverHalf)
+	getAndCheckBlockDiskData(ctx, t, s, bID, bCtx, data, serverHalf)
 
 	// Add a reference.
-	bCtx2 := addBlockDiskRef(t, ctx, s, bID)
+	bCtx2 := addBlockDiskRef(ctx, t, s, bID)
 
 	// Make sure we get the same block via that reference.
-	getAndCheckBlockDiskData(t, ctx, s, bID, bCtx2, data, serverHalf)
+	getAndCheckBlockDiskData(ctx, t, s, bID, bCtx2, data, serverHalf)
 
 	// Shutdown and restart.
 	s = makeBlockDiskStore(s.codec, tempdir)
 
 	// Make sure we get the same block for both refs.
 
-	getAndCheckBlockDiskData(t, ctx, s, bID, bCtx, data, serverHalf)
-	getAndCheckBlockDiskData(t, ctx, s, bID, bCtx2, data, serverHalf)
+	getAndCheckBlockDiskData(ctx, t, s, bID, bCtx, data, serverHalf)
+	getAndCheckBlockDiskData(ctx, t, s, bID, bCtx2, data, serverHalf)
 }
 
 func TestBlockDiskStoreAddReference(t *testing.T) {
@@ -120,7 +120,7 @@ func TestBlockDiskStoreAddReference(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add a reference, which should succeed.
-	bCtx := addBlockDiskRef(t, ctx, s, bID)
+	bCtx := addBlockDiskRef(ctx, t, s, bID)
 
 	// Of course, the block get should still fail.
 	_, _, err = s.getDataWithContext(ctx, bID, bCtx)
@@ -134,10 +134,10 @@ func TestBlockDiskStoreArchiveReferences(t *testing.T) {
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
-	bID, bCtx, serverHalf := putBlockDisk(t, ctx, s, data)
+	bID, bCtx, serverHalf := putBlockDisk(ctx, t, s, data)
 
 	// Add a reference.
-	bCtx2 := addBlockDiskRef(t, ctx, s, bID)
+	bCtx2 := addBlockDiskRef(ctx, t, s, bID)
 
 	// Archive references.
 	err := s.archiveReferences(
@@ -145,7 +145,7 @@ func TestBlockDiskStoreArchiveReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get block should still succeed.
-	getAndCheckBlockDiskData(t, ctx, s, bID, bCtx, data, serverHalf)
+	getAndCheckBlockDiskData(ctx, t, s, bID, bCtx, data, serverHalf)
 }
 
 func TestBlockDiskStoreArchiveNonExistentReference(t *testing.T) {
@@ -175,10 +175,10 @@ func TestBlockDiskStoreRemoveReferences(t *testing.T) {
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
-	bID, bCtx, serverHalf := putBlockDisk(t, ctx, s, data)
+	bID, bCtx, serverHalf := putBlockDisk(ctx, t, s, data)
 
 	// Add a reference.
-	bCtx2 := addBlockDiskRef(t, ctx, s, bID)
+	bCtx2 := addBlockDiskRef(ctx, t, s, bID)
 
 	// Remove references.
 	liveCount, err := s.removeReferences(
@@ -204,7 +204,7 @@ func TestBlockDiskStoreRemove(t *testing.T) {
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
-	bID, bCtx, _ := putBlockDisk(t, ctx, s, data)
+	bID, bCtx, _ := putBlockDisk(ctx, t, s, data)
 
 	// Should not be removable.
 	err := s.remove(ctx, bID)

--- a/go/kbfs/libkbfs/block_journal_test.go
+++ b/go/kbfs/libkbfs/block_journal_test.go
@@ -128,7 +128,7 @@ func setupBlockJournalTest(t *testing.T) (
 	return ctx, cancel, tempdir, log, j
 }
 
-func teardownBlockJournalTest(t *testing.T, ctx context.Context,
+func teardownBlockJournalTest(ctx context.Context, t *testing.T,
 	cancel context.CancelFunc, tempdir string, j *blockJournal) {
 	cancel()
 
@@ -195,7 +195,7 @@ func getAndCheckBlockData(ctx context.Context, t *testing.T, j *blockJournal,
 
 func TestBlockJournalBasic(t *testing.T) {
 	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
@@ -226,7 +226,7 @@ func TestBlockJournalBasic(t *testing.T) {
 
 func TestBlockJournalDuplicatePut(t *testing.T) {
 	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	data := []byte{1, 2, 3, 4}
 
@@ -269,7 +269,7 @@ func TestBlockJournalDuplicatePut(t *testing.T) {
 
 func TestBlockJournalAddReference(t *testing.T) {
 	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(
@@ -286,7 +286,7 @@ func TestBlockJournalAddReference(t *testing.T) {
 
 func TestBlockJournalArchiveReferences(t *testing.T) {
 	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
@@ -307,7 +307,7 @@ func TestBlockJournalArchiveReferences(t *testing.T) {
 
 func TestBlockJournalArchiveNonExistentReference(t *testing.T) {
 	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	uid1 := keybase1.MakeTestUID(1)
 
@@ -327,7 +327,7 @@ func TestBlockJournalArchiveNonExistentReference(t *testing.T) {
 
 func TestBlockJournalRemoveReferences(t *testing.T) {
 	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
@@ -356,7 +356,7 @@ func TestBlockJournalRemoveReferences(t *testing.T) {
 
 func TestBlockJournalDuplicateRemove(t *testing.T) {
 	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
@@ -410,7 +410,7 @@ func testBlockJournalGCd(t *testing.T, j *blockJournal) {
 	require.Equal(t, blockAggregateInfo{}, j.aggregateInfo)
 }
 
-func goGCForTest(t *testing.T, ctx context.Context, j *blockJournal) (
+func goGCForTest(ctx context.Context, t *testing.T, j *blockJournal) (
 	int64, int64) {
 	length, earliest, latest, err := j.getDeferredGCRange()
 	require.NoError(t, err)
@@ -427,7 +427,7 @@ func goGCForTest(t *testing.T, ctx context.Context, j *blockJournal) (
 
 func TestBlockJournalFlush(t *testing.T) {
 	ctx, cancel, tempdir, log, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put a block.
 
@@ -487,7 +487,7 @@ func TestBlockJournalFlush(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, b, flushedBytes)
 
-		removedBytes, removedFiles = goGCForTest(t, ctx, j)
+		removedBytes, removedFiles = goGCForTest(ctx, t, j)
 		return flushedBytes, removedBytes, removedFiles
 	}
 
@@ -563,7 +563,7 @@ func flushBlockJournalOne(ctx context.Context, t *testing.T,
 	require.NoError(t, err)
 	require.Equal(t, b, flushedBytes)
 
-	removedBytes, removedFiles = goGCForTest(t, ctx, j)
+	removedBytes, removedFiles = goGCForTest(ctx, t, j)
 	require.NoError(t, err)
 
 	err = j.checkInSyncForTest()
@@ -573,7 +573,7 @@ func flushBlockJournalOne(ctx context.Context, t *testing.T,
 
 func TestBlockJournalFlushInterleaved(t *testing.T) {
 	ctx, cancel, tempdir, log, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put a block.
 
@@ -709,7 +709,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 
 func TestBlockJournalFlushMDRevMarker(t *testing.T) {
 	ctx, cancel, tempdir, log, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put a block.
 
@@ -744,7 +744,7 @@ func TestBlockJournalFlushMDRevMarker(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data)), flushedBytes)
 	require.Equal(t, b, flushedBytes)
-	removedBytes, removedFiles := goGCForTest(t, ctx, j)
+	removedBytes, removedFiles := goGCForTest(ctx, t, j)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data)), removedBytes)
 	require.Equal(t, int64(filesPerBlockMax), removedFiles)
@@ -754,7 +754,7 @@ func TestBlockJournalFlushMDRevMarker(t *testing.T) {
 
 func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 	ctx, cancel, tempdir, log, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put some blocks.
 
@@ -812,7 +812,7 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data1)+len(data4)), flushedBytes)
 	require.Equal(t, b, flushedBytes)
-	removedBytes, removedFiles := goGCForTest(t, ctx, j)
+	removedBytes, removedFiles := goGCForTest(ctx, t, j)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data1)+len(data2)+len(data3)+len(data4)),
 		removedBytes)
@@ -824,7 +824,7 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 
 func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	ctx, cancel, tempdir, log, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put a few blocks
 	data1 := []byte{1, 2, 3}
@@ -893,7 +893,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	require.Equal(t, b, flushedBytes)
 
 	// Flush everything.
-	removedBytes, removedFiles := goGCForTest(t, ctx, j)
+	removedBytes, removedFiles := goGCForTest(ctx, t, j)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(data1)+len(data2)+len(data3)+len(data4)),
 		removedBytes)
@@ -905,7 +905,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 
 func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	ctx, cancel, tempdir, log, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// Put a few blocks
 	data1 := []byte{1, 2, 3, 4}
@@ -1002,7 +1002,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	expectedBytes += 4
 	expectedFiles += filesPerBlockMax
 
-	removedBytes, removedFiles := goGCForTest(t, ctx, j)
+	removedBytes, removedFiles := goGCForTest(ctx, t, j)
 	require.NoError(t, err)
 	require.Equal(t, expectedBytes, removedBytes)
 	require.Equal(t, expectedFiles, removedFiles)
@@ -1025,7 +1025,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 
 func TestBlockJournalByteCounters(t *testing.T) {
 	ctx, cancel, tempdir, log, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	// In this test, stored bytes and unflushed bytes should
 	// change identically.
@@ -1153,7 +1153,7 @@ func TestBlockJournalByteCounters(t *testing.T) {
 
 func TestBlockJournalUnflushedBytesIgnore(t *testing.T) {
 	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
-	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
 
 	requireCounts := func(expectedStoredBytes, expectedUnflushedBytes,
 		expectedStoredFiles int) {

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -410,7 +410,7 @@ func testCRGetCROrBust(t *testing.T, config Config,
 func TestCRMergedChainsSimple(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -479,7 +479,7 @@ func TestCRMergedChainsSimple(t *testing.T) {
 func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -550,7 +550,7 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -656,7 +656,7 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -745,7 +745,7 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 func TestCRMergedChainsComplex(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -941,7 +941,7 @@ func TestCRMergedChainsComplex(t *testing.T) {
 func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	clock, now := clocktest.NewTestClockAndTimeNow()
 	config1.SetClock(clock)
@@ -1037,7 +1037,7 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 func TestCRMergedChainsConflictSimple(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -1116,7 +1116,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -1236,7 +1236,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 func TestCRDoActionsSimple(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -1334,7 +1334,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 func TestCRDoActionsWriteConflict(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -254,7 +254,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 }
 
 func testCRSharedFolderForUsers(
-	t *testing.T, ctx context.Context, name string, createAs keybase1.UID,
+	ctx context.Context, t *testing.T, name string, createAs keybase1.UID,
 	configs map[keybase1.UID]Config, dirs []string) map[keybase1.UID]Node {
 	nodes := make(map[keybase1.UID]Node)
 
@@ -425,7 +425,7 @@ func TestCRMergedChainsSimple(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodes := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dir"})
+	nodes := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dir"})
 	dir1 := nodes[uid1]
 	dir2 := nodes[uid2]
 	fb := dir1.GetFolderBranch()
@@ -494,9 +494,9 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirA"})
+	nodesA := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dirA"})
 	dirA1 := nodesA[uid1]
-	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirB"})
+	nodesB := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dirB"})
 	dirB1 := nodesB[uid1]
 	dirB2 := nodesB[uid2]
 	fb := dirA1.GetFolderBranch()
@@ -565,7 +565,7 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirA"})
+	nodesA := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dirA"})
 	dirA1 := nodesA[uid1]
 	fb := dirA1.GetFolderBranch()
 
@@ -573,10 +573,10 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	cr2 := testCRGetCROrBust(t, config2, fb)
 	cr2.Shutdown()
 
-	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesB := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirA", "dirB"})
 	dirB1 := nodesB[uid1]
-	nodesC := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesC := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirA", "dirB", "dirC"})
 	dirC2 := nodesC[uid2]
 	dirAPtr := cr1.fbo.nodeCache.PathFromNode(dirA1).TailPointer()
@@ -671,7 +671,7 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirA"})
+	nodesA := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dirA"})
 	dirA1 := nodesA[uid1]
 	fb := dirA1.GetFolderBranch()
 
@@ -679,10 +679,10 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 	cr2 := testCRGetCROrBust(t, config2, fb)
 	cr2.Shutdown()
 
-	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesB := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirA", "dirB"})
 	dirB1 := nodesB[uid1]
-	nodesC := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesC := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirA", "dirB", "dirC"})
 	dirC1 := nodesC[uid1]
 	dirC2 := nodesC[uid2]
@@ -766,7 +766,7 @@ func TestCRMergedChainsComplex(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirA"})
+	nodesA := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dirA"})
 	dirA1 := nodesA[uid1]
 	dirA2 := nodesA[uid2]
 	fb := dirA1.GetFolderBranch()
@@ -775,27 +775,27 @@ func TestCRMergedChainsComplex(t *testing.T) {
 	cr2 := testCRGetCROrBust(t, config2, fb)
 	cr2.Shutdown()
 
-	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesB := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirA", "dirB"})
 	dirB1 := nodesB[uid1]
 	dirB2 := nodesB[uid2]
-	nodesC := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesC := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirA", "dirB", "dirC"})
 	dirC2 := nodesC[uid2]
-	nodesD := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesD := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirA", "dirB", "dirD"})
 	dirD1 := nodesD[uid1]
 	dirD2 := nodesD[uid2]
-	nodesE := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirE"})
+	nodesE := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dirE"})
 	dirE1 := nodesE[uid1]
-	nodesF := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesF := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirE", "dirF"})
 	dirF2 := nodesF[uid2]
 	dirEPtr := cr2.fbo.nodeCache.PathFromNode(dirE1).TailPointer()
 	dirFPtr := cr2.fbo.nodeCache.PathFromNode(dirF2).TailPointer()
-	nodesG := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirG"})
+	nodesG := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dirG"})
 	dirG1 := nodesG[uid1]
-	nodesH := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesH := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"dirG", "dirH"})
 	dirH1 := nodesH[uid1]
 	dirH2 := nodesH[uid2]
@@ -959,16 +959,16 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesRoot := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"root"})
+	nodesRoot := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"root"})
 	dirRoot1 := nodesRoot[uid1]
 	dirRoot2 := nodesRoot[uid2]
 	fb := dirRoot1.GetFolderBranch()
 
-	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesA := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"root", "dirA"})
 	dirA1 := nodesA[uid1]
 
-	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
+	nodesB := testCRSharedFolderForUsers(ctx, t, name, uid1, configs,
 		[]string{"root", "dirB"})
 	dirB1 := nodesB[uid1]
 	dirB2 := nodesB[uid2]
@@ -1055,7 +1055,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesRoot := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"root"})
+	nodesRoot := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"root"})
 	dirRoot1 := nodesRoot[uid1]
 	dirRoot2 := nodesRoot[uid2]
 	fb := dirRoot1.GetFolderBranch()
@@ -1134,7 +1134,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesRoot := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"root"})
+	nodesRoot := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"root"})
 	dirRoot1 := nodesRoot[uid1]
 	dirRoot2 := nodesRoot[uid2]
 	fb := dirRoot1.GetFolderBranch()
@@ -1251,7 +1251,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodes := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dir"})
+	nodes := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dir"})
 	dir1 := nodes[uid1]
 	dir2 := nodes[uid2]
 	fb := dir1.GetFolderBranch()
@@ -1352,7 +1352,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodes := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dir"})
+	nodes := testCRSharedFolderForUsers(ctx, t, name, uid1, configs, []string{"dir"})
 	dir1 := nodes[uid1]
 	dir2 := nodes[uid2]
 	fb := dir1.GetFolderBranch()

--- a/go/kbfs/libkbfs/disk_block_cache_test.go
+++ b/go/kbfs/libkbfs/disk_block_cache_test.go
@@ -579,7 +579,7 @@ func TestDiskBlockCacheWithRetrievalQueue(t *testing.T) {
 	require.Equal(t, block1, block)
 }
 
-func seedDiskBlockCacheForTest(t *testing.T, ctx context.Context,
+func seedDiskBlockCacheForTest(ctx context.Context, t *testing.T,
 	cache *diskBlockCacheWrapped, config diskBlockCacheConfig, numTlfs,
 	numBlocksPerTlf int) {
 	t.Log("Seed the cache with some blocks.")
@@ -599,12 +599,12 @@ func seedDiskBlockCacheForTest(t *testing.T, ctx context.Context,
 }
 
 func testPutBlockWhenSyncCacheFull(
-	t *testing.T, ctx context.Context, putCache *DiskBlockCacheLocal,
+	ctx context.Context, t *testing.T, putCache *DiskBlockCacheLocal,
 	cache *diskBlockCacheWrapped, config *testDiskBlockCacheConfig) {
 	numTlfs := 10
 	numBlocksPerTlf := 5
 	numBlocks := numTlfs * numBlocksPerTlf
-	seedDiskBlockCacheForTest(t, ctx, cache, config, numTlfs, numBlocksPerTlf)
+	seedDiskBlockCacheForTest(ctx, t, cache, config, numTlfs, numBlocksPerTlf)
 
 	t.Log("Set the cache maximum bytes to the current total.")
 	require.Equal(t, 0, putCache.numBlocks)
@@ -632,7 +632,7 @@ func TestSyncBlockCacheStaticLimit(t *testing.T) {
 	defer shutdownDiskBlockCacheTest(cache)
 	ctx := context.Background()
 
-	testPutBlockWhenSyncCacheFull(t, ctx, cache.workingSetCache, cache, config)
+	testPutBlockWhenSyncCacheFull(ctx, t, cache.workingSetCache, cache, config)
 }
 
 func TestCrDirtyBlockCacheStaticLimit(t *testing.T) {
@@ -649,7 +649,7 @@ func TestCrDirtyBlockCacheStaticLimit(t *testing.T) {
 	err = crCache.WaitUntilStarted()
 	require.NoError(t, err)
 
-	testPutBlockWhenSyncCacheFull(t, ctx, crCache, cache, config)
+	testPutBlockWhenSyncCacheFull(ctx, t, crCache, cache, config)
 }
 
 func TestDiskBlockCacheLastUnrefPutAndGet(t *testing.T) {
@@ -710,7 +710,7 @@ func TestDiskBlockCacheUnsyncTlf(t *testing.T) {
 	// Use a real config, since we need the real SetTlfSyncState
 	// implementation.
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "u1")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	clock := clocktest.NewTestClockNow()
 	config.SetClock(clock)
@@ -728,7 +728,7 @@ func TestDiskBlockCacheUnsyncTlf(t *testing.T) {
 	numTlfs := 3
 	numBlocksPerTlf := 5
 	numBlocks := numTlfs * numBlocksPerTlf
-	seedDiskBlockCacheForTest(t, ctx, cache, config, numTlfs, numBlocksPerTlf)
+	seedDiskBlockCacheForTest(ctx, t, cache, config, numTlfs, numBlocksPerTlf)
 	require.Equal(t, numBlocks, standardCache.numBlocks)
 
 	standardCache.clearTickerDuration = 0
@@ -786,7 +786,7 @@ func TestDiskBlockCacheMoveBlock(t *testing.T) {
 // seedTlf seeds the cache with blocks from a given TLF ID. Notably,
 // it does NOT give them different times,
 // because that makes TLFs filled first more likely to face eviction.
-func seedTlf(t *testing.T, ctx context.Context,
+func seedTlf(ctx context.Context, t *testing.T,
 	cache *diskBlockCacheWrapped, config diskBlockCacheConfig, tlfID tlf.ID,
 	numBlocksPerTlf int) {
 	for j := 0; j < numBlocksPerTlf; j++ {
@@ -827,8 +827,8 @@ func TestDiskBlockCacheHomeDirPriorities(t *testing.T) {
 		homeTLF:       homeTLFBlocksEach,
 	}
 
-	seedTlf(t, ctx, cache, config, homePublicTLF, homeTLFBlocksEach)
-	seedTlf(t, ctx, cache, config, homeTLF, homeTLFBlocksEach)
+	seedTlf(ctx, t, cache, config, homePublicTLF, homeTLFBlocksEach)
+	seedTlf(ctx, t, cache, config, homeTLF, homeTLFBlocksEach)
 	totalBlocks += 2 * homeTLFBlocksEach
 	otherTlfIds := []tlf.ID{
 		tlf.FakeID(1, tlf.Private),
@@ -842,7 +842,7 @@ func TestDiskBlockCacheHomeDirPriorities(t *testing.T) {
 	// Use LOTS of blocks to get better statistical behavior.
 	nextTlfSize := 200
 	for _, tlfID := range otherTlfIds {
-		seedTlf(t, ctx, cache, config, tlfID, nextTlfSize)
+		seedTlf(ctx, t, cache, config, tlfID, nextTlfSize)
 		originalSizes[tlfID] = nextTlfSize
 		totalBlocks += nextTlfSize
 		nextTlfSize *= 2
@@ -916,7 +916,7 @@ func TestDiskBlockCacheMark(t *testing.T) {
 	numTlfs := 3
 	numBlocksPerTlf := 5
 	numBlocks := numTlfs * numBlocksPerTlf
-	seedDiskBlockCacheForTest(t, ctx, cache, config, numTlfs, numBlocksPerTlf)
+	seedDiskBlockCacheForTest(ctx, t, cache, config, numTlfs, numBlocksPerTlf)
 	require.Equal(t, numBlocks, standardCache.numBlocks)
 
 	t.Log("Generate some blocks we can mark.")

--- a/go/kbfs/libkbfs/disk_block_cache_test.go
+++ b/go/kbfs/libkbfs/disk_block_cache_test.go
@@ -859,12 +859,12 @@ func TestDiskBlockCacheHomeDirPriorities(t *testing.T) {
 
 	t.Log("Verify that the non-home TLFs have been reduced in size by about" +
 		" half")
-	// Allow a tolerance of .4, so 30-70% of the original size.
+	// Allow a tolerance of .5, so 25-75% of the original size.
 	for _, tlfID := range otherTlfIds {
 		original := originalSizes[tlfID]
 		current := cache.syncCache.tlfCounts[tlfID]
 		t.Logf("ID: %v, Current: %d, Original: %d", tlfID, current, original)
-		require.InEpsilon(t, original/2, current, 0.4)
+		require.InEpsilon(t, original/2, current, 0.5)
 	}
 	require.Equal(t, homeTLFBlocksEach, cache.syncCache.tlfCounts[homeTLF])
 	require.Equal(t, homeTLFBlocksEach, cache.syncCache.tlfCounts[homePublicTLF])

--- a/go/kbfs/libkbfs/folder_block_manager_test.go
+++ b/go/kbfs/libkbfs/folder_block_manager_test.go
@@ -455,7 +455,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	clock := clocktest.NewTestClockNow()
 	config1.SetClock(clock)
 
@@ -535,7 +535,7 @@ func (mtwqr modeTestWithQR) IsTestMode() bool {
 func TestQuotaReclamationMinHeadAge(t *testing.T) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	clock := clocktest.NewTestClockNow()
 	config1.SetClock(clock)
 	// Re-enable QR in test mode.

--- a/go/kbfs/libkbfs/folder_block_manager_test.go
+++ b/go/kbfs/libkbfs/folder_block_manager_test.go
@@ -35,7 +35,7 @@ func totalBlockRefs(m map[kbfsblock.ID]blockRefMap) int {
 // Test that quota reclamation works for a simple case where the user
 // does a few updates, then lets quota reclamation run, and we make
 // sure that all historical blocks have been deleted.
-func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
+func testQuotaReclamation(ctx context.Context, t *testing.T, config Config,
 	userName kbname.NormalizedUsername) (
 	ops *folderBranchOps, preBlocks map[kbfsblock.ID]blockRefMap) {
 	clock, now := clocktest.NewTestClockAndTimeNow()
@@ -97,7 +97,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 }
 
 func ensureFewerBlocksPostQR(
-	t *testing.T, ctx context.Context, config *ConfigLocal,
+	ctx context.Context, t *testing.T, config *ConfigLocal,
 	ops *folderBranchOps, preBlocks map[kbfsblock.ID]blockRefMap) {
 	ops.fbm.forceQuotaReclamation()
 	err := ops.fbm.waitForQuotaReclamations(ctx)
@@ -118,10 +118,10 @@ func ensureFewerBlocksPostQR(
 func TestQuotaReclamationSimple(t *testing.T) {
 	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
-	ops, preBlocks := testQuotaReclamation(t, ctx, config, userName)
-	ensureFewerBlocksPostQR(t, ctx, config, ops, preBlocks)
+	ops, preBlocks := testQuotaReclamation(ctx, t, config, userName)
+	ensureFewerBlocksPostQR(ctx, t, config, ops, preBlocks)
 }
 
 type modeTestWithNoTimedQR struct {
@@ -143,16 +143,16 @@ func (mtwmpl modeTestWithMaxPtrsLimit) MaxBlockPtrsToManageAtOnce() int {
 func TestQuotaReclamationConstrained(t *testing.T) {
 	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 	config.SetMode(modeTestWithNoTimedQR{config.Mode()})
 	originalMode := config.Mode()
 	config.SetMode(modeTestWithMaxPtrsLimit{originalMode})
 
-	ops, preBlocks := testQuotaReclamation(t, ctx, config, userName)
+	ops, preBlocks := testQuotaReclamation(ctx, t, config, userName)
 
 	// Unconstrain it for the final QR.
 	config.SetMode(originalMode)
-	ensureFewerBlocksPostQR(t, ctx, config, ops, preBlocks)
+	ensureFewerBlocksPostQR(ctx, t, config, ops, preBlocks)
 }
 
 // Just like the simple case, except tests that it unembeds large sets
@@ -160,13 +160,13 @@ func TestQuotaReclamationConstrained(t *testing.T) {
 func TestQuotaReclamationUnembedded(t *testing.T) {
 	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	config.bsplit.(*data.BlockSplitterSimple).
 		SetBlockChangeEmbedMaxSizeForTesting(32)
 
-	ops, preBlocks := testQuotaReclamation(t, ctx, config, userName)
-	ensureFewerBlocksPostQR(t, ctx, config, ops, preBlocks)
+	ops, preBlocks := testQuotaReclamation(ctx, t, config, userName)
+	ensureFewerBlocksPostQR(ctx, t, config, ops, preBlocks)
 
 	// Make sure the MD has an unembedded change block.
 	md, err := config.MDOps().GetForTLF(ctx, ops.id(), nil)
@@ -181,7 +181,7 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	now := time.Now()
 	var clock clocktest.TestClock
@@ -255,7 +255,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsInitNoMocks(t, u1, u2)
-	defer kbfsTestShutdownNoMocks(t, config1, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config1, cancel)
 
 	clock, now := clocktest.NewTestClockAndTimeNow()
 	config1.SetClock(clock)
@@ -648,7 +648,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 func TestQuotaReclamationGCOpsForGCOps(t *testing.T) {
 	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 	clock := clocktest.NewTestClockNow()
 	config.SetClock(clock)
 
@@ -728,7 +728,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 
 	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 	config.SetVLogLevel(libkb.VLog2String)
 
 	// Test the pointer-constraint logic.

--- a/go/kbfs/libkbfs/journal_block_server_test.go
+++ b/go/kbfs/libkbfs/journal_block_server_test.go
@@ -69,7 +69,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 }
 
 func teardownJournalBlockServerTest(
-	t *testing.T, tempdir string, ctx context.Context,
+	ctx context.Context, t *testing.T, tempdir string,
 	cancel context.CancelFunc, config Config) {
 	CheckConfigAndShutdown(ctx, t, config)
 	cancel()
@@ -83,7 +83,7 @@ func (shutdownOnlyBlockServer) Shutdown(context.Context) {}
 
 func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	tempdir, ctx, cancel, config, jManager := setupJournalBlockServerTest(t)
-	defer teardownJournalBlockServerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalBlockServerTest(ctx, t, tempdir, cancel, config)
 
 	// Use a shutdown-only BlockServer so that it errors if the
 	// journal tries to access it.

--- a/go/kbfs/libkbfs/journal_manager_test.go
+++ b/go/kbfs/libkbfs/journal_manager_test.go
@@ -79,7 +79,7 @@ func setupJournalManagerTest(t *testing.T) (
 }
 
 func teardownJournalManagerTest(
-	t *testing.T, tempdir string, ctx context.Context,
+	ctx context.Context, t *testing.T, tempdir string,
 	cancel context.CancelFunc, config Config) {
 	CheckConfigAndShutdown(ctx, t, config)
 	cancel()
@@ -146,7 +146,7 @@ func (qbs *quotaBlockServer) GetTeamQuotaInfo(
 func TestJournalManagerOverQuotaError(t *testing.T) {
 	tempdir, ctx, cancel, config, quotaUsage, jManager :=
 		setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	name := kbname.NormalizedUsername("t1")
 	subname := kbname.NormalizedUsername("t1.sub")
@@ -279,7 +279,7 @@ func (c tlfJournalConfigWithDiskLimitTimeout) diskLimitTimeout() time.Duration {
 func TestJournalManagerOverDiskLimitError(t *testing.T) {
 	tempdir, ctx, cancel, config, quotaUsage, jManager :=
 		setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	qbs := &quotaBlockServer{BlockServer: config.BlockServer()}
 	config.SetBlockServer(qbs)
@@ -372,7 +372,7 @@ func TestJournalManagerOverDiskLimitError(t *testing.T) {
 
 func TestJournalManagerRestart(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	// Use a shutdown-only BlockServer so that it errors if the
 	// journal tries to access it.
@@ -447,7 +447,7 @@ func TestJournalManagerRestart(t *testing.T) {
 
 func TestJournalManagerLogOutLogIn(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	// Use a shutdown-only BlockServer so that it errors if the
 	// journal tries to access it.
@@ -528,7 +528,7 @@ func TestJournalManagerLogOutLogIn(t *testing.T) {
 
 func TestJournalManagerLogOutDirtyOp(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	tlfID := tlf.FakeID(2, tlf.Private)
 	err := jManager.Enable(ctx, tlfID, nil, TLFJournalBackgroundWorkPaused)
@@ -557,7 +557,7 @@ func TestJournalManagerLogOutDirtyOp(t *testing.T) {
 
 func TestJournalManagerMultiUser(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	// Use a shutdown-only BlockServer so that it errors if the
 	// journal tries to access it.
@@ -729,7 +729,7 @@ func TestJournalManagerMultiUser(t *testing.T) {
 
 func TestJournalManagerEnableAuto(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	err := jManager.EnableAuto(ctx)
 	require.NoError(t, err)
@@ -788,7 +788,7 @@ func TestJournalManagerEnableAuto(t *testing.T) {
 
 func TestJournalManagerReaderTLFs(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	err := jManager.EnableAuto(ctx)
 	require.NoError(t, err)
@@ -852,7 +852,7 @@ func TestJournalManagerReaderTLFs(t *testing.T) {
 
 func TestJournalManagerNukeEmptyJournalsOnRestart(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	err := jManager.EnableAuto(ctx)
 	require.NoError(t, err)
@@ -914,7 +914,7 @@ func TestJournalManagerNukeEmptyJournalsOnRestart(t *testing.T) {
 
 func TestJournalManagerTeamTLFWithRestart(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	name := kbname.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config, name)
@@ -997,7 +997,7 @@ func TestJournalManagerTeamTLFWithRestart(t *testing.T) {
 
 func TestJournalQuotaStatus(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 
 	// Set initial quota usage and refresh quotaUsage's cache.
 	qbs := &quotaBlockServer{BlockServer: config.BlockServer()}
@@ -1016,7 +1016,7 @@ func TestJournalQuotaStatus(t *testing.T) {
 
 func TestJournalQuotaStatusForGitBlocks(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalManagerTest(t)
-	defer teardownJournalManagerTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalManagerTest(ctx, t, tempdir, cancel, config)
 	config.SetDefaultBlockType(keybase1.BlockType_GIT)
 
 	// Set initial quota usage and refresh quotaUsage's cache.

--- a/go/kbfs/libkbfs/journal_md_ops_test.go
+++ b/go/kbfs/libkbfs/journal_md_ops_test.go
@@ -73,7 +73,8 @@ func setupJournalMDOpsTest(t *testing.T) (
 	return tempdir, ctx, cancel, config, oldMDOps, jManager
 }
 
-func teardownJournalMDOpsTest(t *testing.T, tempdir string, ctx context.Context,
+func teardownJournalMDOpsTest(
+	ctx context.Context, t *testing.T, tempdir string,
 	cancel context.CancelFunc, config Config) {
 	CheckConfigAndShutdown(ctx, t, config)
 	cancel()
@@ -98,7 +99,7 @@ func makeMDForJournalMDOpsTest(
 
 func TestJournalMDOpsBasics(t *testing.T) {
 	tempdir, ctx, cancel, config, oldMDOps, jManager := setupJournalMDOpsTest(t)
-	defer teardownJournalMDOpsTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalMDOpsTest(ctx, t, tempdir, cancel, config)
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
@@ -277,7 +278,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 
 func TestJournalMDOpsPutUnmerged(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalMDOpsTest(t)
-	defer teardownJournalMDOpsTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalMDOpsTest(ctx, t, tempdir, cancel, config)
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
@@ -313,7 +314,7 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 
 func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalMDOpsTest(t)
-	defer teardownJournalMDOpsTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalMDOpsTest(ctx, t, tempdir, cancel, config)
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
@@ -347,7 +348,7 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 
 func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jManager := setupJournalMDOpsTest(t)
-	defer teardownJournalMDOpsTest(t, tempdir, ctx, cancel, config)
+	defer teardownJournalMDOpsTest(ctx, t, tempdir, cancel, config)
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/kbfs_cr_test.go
+++ b/go/kbfs/libkbfs/kbfs_cr_test.go
@@ -73,7 +73,7 @@ func TestBasicMDUpdate(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -117,7 +117,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -178,7 +178,7 @@ func TestMultipleMDUpdatesUnembedChanges(t *testing.T) {
 func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	// enable journaling to see patrick's error
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_for_gettlfcryptkeys")
@@ -276,7 +276,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -416,7 +416,7 @@ func TestMultiUserWrite(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -469,7 +469,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -603,7 +603,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	mdServ, chForMdServer2 := newMDServerLocalRecordingRegisterForUpdate(
@@ -688,7 +688,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -780,7 +780,7 @@ func TestBasicCRFailureAndFixing(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -949,7 +949,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -1035,7 +1035,7 @@ func TestCRDouble(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1177,7 +1177,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1321,7 +1321,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1456,7 +1456,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1588,7 +1588,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1704,7 +1704,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -1846,7 +1846,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1950,7 +1950,7 @@ func TestForceStuckConflict(t *testing.T) {
 
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	t.Log("Enable journaling")
 	err = config.EnableDiskLimiter(tempdir)

--- a/go/kbfs/libkbfs/kbfs_ops_concur_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_concur_test.go
@@ -66,8 +66,9 @@ func kbfsConcurTestShutdown(
 }
 
 // TODO: Get rid of all users of this.
-func kbfsConcurTestShutdownNoCheck(t *testing.T, config *ConfigLocal,
-	ctx context.Context, cancel context.CancelFunc) {
+func kbfsConcurTestShutdownNoCheck(
+	ctx context.Context, t *testing.T,
+	config *ConfigLocal, cancel context.CancelFunc) {
 	kbfsTestShutdownNoMocksNoCheck(ctx, t, config, cancel)
 }
 
@@ -427,7 +428,7 @@ func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	t.Skip("Broken test since Go 1.12.4 due to extra pending requests after test termination. Panic: unable to shutdown block ops.")
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	// TODO: Use kbfsConcurTestShutdown.
-	defer kbfsConcurTestShutdownNoCheck(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdownNoCheck(ctx, t, config, cancel)
 
 	// Turn off transient block caching.
 	config.SetBlockCache(kbfsdata.NewBlockCacheStandard(0, 1<<30))
@@ -548,7 +549,7 @@ func (km *mdRecordingKeyManager) Rekey(
 func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	// TODO: Use kbfsConcurTestShutdown.
-	defer kbfsConcurTestShutdownNoCheck(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdownNoCheck(ctx, t, config, cancel)
 
 	<-config.BlockOps().TogglePrefetcher(false)
 

--- a/go/kbfs/libkbfs/kbfs_ops_concur_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_concur_test.go
@@ -59,8 +59,9 @@ func kbfsOpsConcurInit(t *testing.T, users ...kbname.NormalizedUsername) (
 	return kbfsOpsInitNoMocks(t, users...)
 }
 
-func kbfsConcurTestShutdown(t *testing.T, config *ConfigLocal,
-	ctx context.Context, cancel context.CancelFunc) {
+func kbfsConcurTestShutdown(
+	ctx context.Context, t *testing.T,
+	config *ConfigLocal, cancel context.CancelFunc) {
 	kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 }
 
@@ -75,7 +76,7 @@ func kbfsConcurTestShutdownNoCheck(t *testing.T, config *ConfigLocal,
 // then get it from the MD cache.
 func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onGetStalledCh, getUnstallCh, ctxStallGetForTLF :=
 		StallMDOp(ctx, config, StallableMDGetForTLF, 1)
@@ -119,7 +120,7 @@ func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 // Test that a read can happen concurrently with a sync
 func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -177,7 +178,7 @@ func testCalcNumFileBlocks(
 func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	initialWriteBytes int, nOneByteWrites int, nFiles int) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -326,7 +327,7 @@ func TestKBFSOpsConcurWriteDuringSyncAllTenFiles(t *testing.T) {
 // to the same block, work correctly.
 func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -629,7 +630,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 // regression test for KBFS-558.
 func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	<-config.BlockOps().TogglePrefetcher(false)
 
@@ -845,7 +846,7 @@ func TestKBFSOpsTruncateAndOverwriteDeferredWithArchivedBlock(t *testing.T) {
 func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 	t.Skip("Broken test since Go 1.12.4 due to extra pending requests after test termination. Panic: unable to shutdown block ops.")
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// Turn off block caching.
 	config.SetBlockCache(kbfsdata.NewBlockCacheStandard(0, 1<<30))
@@ -900,7 +901,7 @@ func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 // Test that a write can survive a folder BlockPointer update
 func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -932,7 +933,7 @@ func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 // are multiple blocks in the file.
 func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -1112,7 +1113,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 		t.Skip("Skipping because we are not putting blocks in parallel.")
 	}
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// give it a remote block server with a fake client
 	log := config.MakeLogger("")
@@ -1253,7 +1254,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 // cancel the remaining puts.
 func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// give it a mock'd block server
 	ctr := NewSafeTestReporter(t)
@@ -1351,7 +1352,7 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 
 func testKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T, nFiles int) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// Use the smallest possible block size.
 	bsplitter, err := kbfsdata.NewBlockSplitterSimple(20, 8*1024, config.Codec())
@@ -1478,7 +1479,7 @@ func TestKBFSOpsMultiBlockWriteDuringRetriedSyncAllTwoFiles(t *testing.T) {
 // Regression test for KBFS-1508.
 func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// Use the smallest possible block size.
 	bsplitter, err := kbfsdata.NewBlockSplitterSimple(20, 8*1024, config.Codec())
@@ -1676,7 +1677,7 @@ func TestKBFSOpsMultiBlockWriteWithRetryAndErrorTwoFiles(t *testing.T) {
 // than the grace period in MD writes is introduced, Create should succeed.
 func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(context.Background(), config, StallableMDPut, 1)
@@ -1728,7 +1729,7 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 // Ctrl-C is able to interrupt the process eventually after the grace period.
 func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// This essentially fast-forwards the grace period timer, making cancellation
 	// happen much faster. This way we can avoid time.Sleep.
@@ -1800,7 +1801,7 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 // Test that a Sync that is canceled during a successful MD put works.
 func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -1886,7 +1887,7 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 // reasonable state where CR can succeed.  Regression for KBFS-1569.
 func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -1976,7 +1977,7 @@ func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
 // cancel.  Regression test for KBFS-727.
 func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -2059,7 +2060,7 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 	t.Skip("Broken pending KBFS-1261")
 
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -2141,7 +2142,7 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 
 func TestKBFSOpsCancelGetFavorites(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	serverConn, conn := rpc.MakeConnectionForTest(t)
 	daemon := newKeybaseDaemonRPCWithClient(
@@ -2188,7 +2189,7 @@ func (snc *stallingNodeCache) PathFromNode(node Node) kbfsdata.Path {
 func TestKBFSOpsLookupSyncRace(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -2312,7 +2313,7 @@ func TestKBFSOpsLookupSyncRace(t *testing.T) {
 // retried later, is successful.  Regression test for KBFS-2157.
 func TestKBFSOpsConcurMultiblockOverwriteWithCanceledSync(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDPut, 1)
@@ -2420,7 +2421,7 @@ func TestKBFSOpsConcurMultiblockOverwriteWithCanceledSync(t *testing.T) {
 // Regression test for KBFS-4165.
 func TestKBFSOpsConcurWriteOfNonsyncedFileDuringSync(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	kbfsOps := config.KBFSOps()
 
 	t.Log("Create and sync a 0-byte file")

--- a/go/kbfs/libkbfs/kbfs_ops_concur_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_concur_test.go
@@ -61,13 +61,13 @@ func kbfsOpsConcurInit(t *testing.T, users ...kbname.NormalizedUsername) (
 
 func kbfsConcurTestShutdown(t *testing.T, config *ConfigLocal,
 	ctx context.Context, cancel context.CancelFunc) {
-	kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 }
 
 // TODO: Get rid of all users of this.
 func kbfsConcurTestShutdownNoCheck(t *testing.T, config *ConfigLocal,
 	ctx context.Context, cancel context.CancelFunc) {
-	kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 }
 
 // Test that only one of two concurrent GetRootMD requests can end up
@@ -717,7 +717,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 // room.  This is a repro for KBFS-1846.
 func TestKBFSOpsTruncateAndOverwriteDeferredWithArchivedBlock(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	bsplitter, err := kbfsdata.NewBlockSplitterSimple(
 		kbfsdata.MaxBlockSizeBytesDefault, 8*1024, config.Codec())

--- a/go/kbfs/libkbfs/kbfs_ops_concur_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_concur_test.go
@@ -67,7 +67,7 @@ func kbfsConcurTestShutdown(t *testing.T, config *ConfigLocal,
 // TODO: Get rid of all users of this.
 func kbfsConcurTestShutdownNoCheck(t *testing.T, config *ConfigLocal,
 	ctx context.Context, cancel context.CancelFunc) {
-	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
+	kbfsTestShutdownNoMocksNoCheck(ctx, t, config, cancel)
 }
 
 // Test that only one of two concurrent GetRootMD requests can end up

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -186,9 +186,8 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	return mockCtrl, config, ctx, cancel
 }
 
-func kbfsTestShutdown(
-	t *testing.T, mockCtrl *gomock.Controller, config *ConfigMock,
-	ctx context.Context, cancel context.CancelFunc) {
+func kbfsTestShutdown(ctx context.Context,
+	t *testing.T, mockCtrl *gomock.Controller, config *ConfigMock, cancel context.CancelFunc) {
 	config.ctr.CheckForFailures()
 	err := config.conflictResolutionDB.Close()
 	require.NoError(t, err)
@@ -258,23 +257,23 @@ func kbfsOpsInitNoMocks(t *testing.T, users ...kbname.NormalizedUsername) (
 	return config, session.UID, ctx, cancel
 }
 
-func kbfsTestShutdownNoMocks(t *testing.T, config *ConfigLocal,
-	ctx context.Context, cancel context.CancelFunc) {
+func kbfsTestShutdownNoMocks(ctx context.Context, t *testing.T,
+	config *ConfigLocal, cancel context.CancelFunc) {
 	CheckConfigAndShutdown(ctx, t, config)
 	cancel()
 	libcontext.CleanupCancellationDelayer(ctx)
 }
 
 // TODO: Get rid of all users of this.
-func kbfsTestShutdownNoMocksNoCheck(t *testing.T, config *ConfigLocal,
-	ctx context.Context, cancel context.CancelFunc) {
+func kbfsTestShutdownNoMocksNoCheck(ctx context.Context, t *testing.T,
+	config *ConfigLocal, cancel context.CancelFunc) {
 	config.Shutdown(ctx)
 	cancel()
 	libcontext.CleanupCancellationDelayer(ctx)
 }
 
 func checkBlockCache(
-	t *testing.T, ctx context.Context, config *ConfigMock, id tlf.ID,
+	ctx context.Context, t *testing.T, config *ConfigMock, id tlf.ID,
 	expectedCleanBlocks []kbfsblock.ID,
 	expectedDirtyBlocks map[data.BlockPointer]data.BranchName) {
 	bcache := config.BlockCache().(*data.BlockCacheStandard)
@@ -326,7 +325,7 @@ func parseTlfHandleOrBust(t logger.TestLogBackend, config Config,
 
 func TestKBFSOpsGetFavoritesSuccess(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	handle1 := parseTlfHandleOrBust(t, config, "alice", tlf.Private, tlf.NullID)
 	handle2 := parseTlfHandleOrBust(
@@ -356,7 +355,7 @@ func TestKBFSOpsGetFavoritesSuccess(t *testing.T) {
 
 func TestKBFSOpsGetFavoritesFail(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	err := errors.New("Fake fail")
 
@@ -451,7 +450,7 @@ func injectNewRMD(t *testing.T, config *ConfigMock) (
 
 func TestKBFSOpsGetRootNodeCacheSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	_, id, rmd := injectNewRMD(t, config)
 	rmd.data.Dir.BlockPointer.ID = kbfsblock.FakeID(1)
@@ -480,7 +479,7 @@ func TestKBFSOpsGetRootNodeCacheSuccess(t *testing.T) {
 
 func TestKBFSOpsGetRootNodeReIdentify(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	_, id, rmd := injectNewRMD(t, config)
 	rmd.data.Dir.BlockPointer.ID = kbfsblock.FakeID(1)
@@ -543,7 +542,7 @@ func (kbpki failIdentifyKBPKI) Identify(
 
 func TestKBFSOpsGetRootNodeCacheIdentifyFail(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	_, id, rmd := injectNewRMD(t, config)
 
@@ -618,7 +617,7 @@ func fillInNewMD(t *testing.T, config *ConfigMock, rmd *RootMetadata) {
 
 func testKBFSOpsGetRootNodeCreateNewSuccess(t *testing.T, ty tlf.Type) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", ty)
 	fillInNewMD(t, config, rmd)
@@ -653,7 +652,7 @@ func TestKBFSOpsGetRootNodeCreateNewSuccessPrivate(t *testing.T) {
 
 func TestKBFSOpsGetRootMDForHandleExisting(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 	rmd.data.Dir = data.DirEntry{
@@ -779,7 +778,7 @@ func testPutBlockInCache(
 
 func TestKBFSOpsGetBaseDirChildrenHidesFiles(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -815,7 +814,7 @@ func TestKBFSOpsGetBaseDirChildrenHidesFiles(t *testing.T) {
 
 func TestKBFSOpsGetBaseDirChildrenCacheSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -851,7 +850,7 @@ func TestKBFSOpsGetBaseDirChildrenCacheSuccess(t *testing.T) {
 
 func TestKBFSOpsGetBaseDirChildrenUncachedSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -877,7 +876,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedSuccess(t *testing.T) {
 
 func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id := tlf.FakeID(1, tlf.Private)
 
@@ -922,7 +921,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 
 func TestKBFSOpsGetBaseDirChildrenUncachedFailMissingBlock(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -952,7 +951,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailMissingBlock(t *testing.T) {
 
 func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 
@@ -1000,7 +999,7 @@ func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 func TestKBFSOpsLookupSuccess(t *testing.T) {
 	t.Skip("Broken test since Go 1.12.4 due to extra pending requests after test termination. Panic: unable to shutdown block ops.")
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 
@@ -1054,7 +1053,7 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 
 func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 
@@ -1104,7 +1103,7 @@ func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 	t.Skip("Broken test since Go 1.12.4 due to extra pending requests after test termination. Panic: unable to shutdown block ops.")
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 
@@ -1150,7 +1149,7 @@ func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 
 func TestKBFSOpsReadNewDataVersionFail(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 
@@ -1215,7 +1214,7 @@ func TestKBFSOpsReadNewDataVersionFail(t *testing.T) {
 func TestKBFSOpsStatSuccess(t *testing.T) {
 	t.Skip("Broken test since Go 1.12.4 due to extra pending requests after test termination. Panic: unable to shutdown prefetcher.")
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 
@@ -1265,7 +1264,7 @@ func TestKBFSOpsStatSuccess(t *testing.T) {
 }
 
 func getBlockFromCache(
-	t *testing.T, ctx context.Context, config Config, id tlf.ID,
+	ctx context.Context, t *testing.T, config Config, id tlf.ID,
 	ptr data.BlockPointer, branch data.BranchName) data.Block {
 	if block, err := config.DirtyBlockCache().Get(
 		ctx, id, ptr, branch); err == nil {
@@ -1281,9 +1280,9 @@ func getBlockFromCache(
 }
 
 func getDirBlockFromCache(
-	t *testing.T, ctx context.Context, config Config, id tlf.ID,
+	ctx context.Context, t *testing.T, config Config, id tlf.ID,
 	ptr data.BlockPointer, branch data.BranchName) *data.DirBlock {
-	block := getBlockFromCache(t, ctx, config, id, ptr, branch)
+	block := getBlockFromCache(ctx, t, config, id, ptr, branch)
 	dblock, ok := block.(*data.DirBlock)
 	if !ok {
 		t.Errorf("Cached block %v, branch %s was not a DirBlock", ptr, branch)
@@ -1292,9 +1291,9 @@ func getDirBlockFromCache(
 }
 
 func getFileBlockFromCache(
-	t *testing.T, ctx context.Context, config Config, id tlf.ID,
+	ctx context.Context, t *testing.T, config Config, id tlf.ID,
 	ptr data.BlockPointer, branch data.BranchName) *data.FileBlock {
-	block := getBlockFromCache(t, ctx, config, id, ptr, branch)
+	block := getBlockFromCache(ctx, t, config, id, ptr, branch)
 	fblock, ok := block.(*data.FileBlock)
 	if !ok {
 		t.Errorf("Cached block %v, branch %s was not a FileBlock", ptr, branch)
@@ -1304,7 +1303,7 @@ func getFileBlockFromCache(
 
 func testCreateEntryFailDupName(t *testing.T, isDir bool) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -1358,7 +1357,7 @@ func TestCreateLinkFailDupName(t *testing.T) {
 
 func testCreateEntryFailNameTooLong(t *testing.T, isDir bool) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -1405,7 +1404,7 @@ func TestCreateLinkFailNameTooLong(t *testing.T) {
 
 func testCreateEntryFailKBFSPrefix(t *testing.T, et data.EntryType) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -1576,7 +1575,7 @@ func makeSym(dir data.Path, parentDirBlock *data.DirBlock, name string) {
 
 func TestRemoveDirFailNonEmpty(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -1602,7 +1601,7 @@ func testKBFSOpsRemoveFileMissingBlockSuccess(t *testing.T, et data.EntryType) {
 	require.NotEqual(t, et, data.Sym)
 
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 	config.noBGFlush = true
 
 	// create a file.
@@ -1662,7 +1661,7 @@ func TestKBFSOpsRemoveDirMissingBlockSuccess(t *testing.T) {
 
 func TestRemoveDirFailNoSuchName(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -1686,7 +1685,7 @@ func TestRemoveDirFailNoSuchName(t *testing.T) {
 
 func TestRenameFailAcrossTopLevelFolders(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id1 := tlf.FakeID(1, tlf.Private)
 	h1 := parseTlfHandleOrBust(t, config, "alice,bob", tlf.Private, id1)
@@ -1746,7 +1745,7 @@ func TestRenameFailAcrossTopLevelFolders(t *testing.T) {
 
 func TestKBFSOpsCacheReadFullSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -1784,7 +1783,7 @@ func TestKBFSOpsCacheReadFullSuccess(t *testing.T) {
 
 func TestKBFSOpsCacheReadPartialSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -1821,7 +1820,7 @@ func TestKBFSOpsCacheReadPartialSuccess(t *testing.T) {
 
 func TestKBFSOpsCacheReadFullMultiBlockSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -1885,7 +1884,7 @@ func TestKBFSOpsCacheReadFullMultiBlockSuccess(t *testing.T) {
 func TestKBFSOpsCacheReadPartialMultiBlockSuccess(t *testing.T) {
 	t.Skip("Broken test since Go 1.12.4 due to extra pending requests after test termination. Panic: unable to shutdown prefetcher.")
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -1946,7 +1945,7 @@ func TestKBFSOpsCacheReadPartialMultiBlockSuccess(t *testing.T) {
 
 func TestKBFSOpsCacheReadFailPastEnd(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -1981,7 +1980,7 @@ func TestKBFSOpsCacheReadFailPastEnd(t *testing.T) {
 
 func TestKBFSOpsServerReadFullSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -2018,7 +2017,7 @@ func TestKBFSOpsServerReadFullSuccess(t *testing.T) {
 
 func TestKBFSOpsServerReadFailNoSuchBlock(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -2088,7 +2087,7 @@ func checkSyncOpInCache(t *testing.T, codec kbfscodec.Codec,
 
 func TestKBFSOpsWriteNewBlockSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2134,10 +2133,10 @@ func TestKBFSOpsWriteNewBlockSuccess(t *testing.T) {
 	}
 
 	newFileBlock := getFileBlockFromCache(
-		t, ctx, config, id, fileNode.BlockPointer,
+		ctx, t, config, id, fileNode.BlockPointer,
 		p.Branch)
 	newRootBlock := getDirBlockFromCache(
-		t, ctx, config, id, node.BlockPointer, p.Branch)
+		ctx, t, config, id, node.BlockPointer, p.Branch)
 
 	if len(ops.nodeCache.PathFromNode(config.observer.localChange).Path) !=
 		len(p.Path) {
@@ -2156,7 +2155,7 @@ func TestKBFSOpsWriteNewBlockSuccess(t *testing.T) {
 			newRootBlock.Children["f"].Size)
 	}
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:     p.Branch,
 			fileNode.BlockPointer: p.Branch,
@@ -2167,7 +2166,7 @@ func TestKBFSOpsWriteNewBlockSuccess(t *testing.T) {
 
 func TestKBFSOpsWriteExtendSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2215,7 +2214,7 @@ func TestKBFSOpsWriteExtendSuccess(t *testing.T) {
 	}
 
 	newFileBlock := getFileBlockFromCache(
-		t, ctx, config, id, fileNode.BlockPointer, p.Branch)
+		ctx, t, config, id, fileNode.BlockPointer, p.Branch)
 
 	if len(ops.nodeCache.PathFromNode(config.observer.localChange).Path) !=
 		len(p.Path) {
@@ -2228,7 +2227,7 @@ func TestKBFSOpsWriteExtendSuccess(t *testing.T) {
 		t.Errorf("Wrote bad contents: %v", buf)
 	}
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:     p.Branch,
 			fileNode.BlockPointer: p.Branch,
@@ -2239,7 +2238,7 @@ func TestKBFSOpsWriteExtendSuccess(t *testing.T) {
 
 func TestKBFSOpsWritePastEndSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2287,7 +2286,7 @@ func TestKBFSOpsWritePastEndSuccess(t *testing.T) {
 	}
 
 	newFileBlock := getFileBlockFromCache(
-		t, ctx, config, id, fileNode.BlockPointer, p.Branch)
+		ctx, t, config, id, fileNode.BlockPointer, p.Branch)
 
 	if len(ops.nodeCache.PathFromNode(config.observer.localChange).Path) !=
 		len(p.Path) {
@@ -2300,7 +2299,7 @@ func TestKBFSOpsWritePastEndSuccess(t *testing.T) {
 		t.Errorf("Wrote bad contents: %v", buf)
 	}
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:     p.Branch,
 			fileNode.BlockPointer: p.Branch,
@@ -2311,7 +2310,7 @@ func TestKBFSOpsWritePastEndSuccess(t *testing.T) {
 
 func TestKBFSOpsWriteCauseSplit(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2408,7 +2407,7 @@ func TestKBFSOpsWriteCauseSplit(t *testing.T) {
 	}
 
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:            p.Branch,
 			fileNode.BlockPointer:        p.Branch,
@@ -2429,7 +2428,7 @@ func mergeUnrefCache(
 
 func TestKBFSOpsWriteOverMultipleBlocks(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 	rootID := kbfsblock.FakeID(42)
@@ -2508,9 +2507,9 @@ func TestKBFSOpsWriteOverMultipleBlocks(t *testing.T) {
 	}
 
 	newBlock1 := getFileBlockFromCache(
-		t, ctx, config, id, fileBlock.IPtrs[0].BlockPointer, p.Branch)
+		ctx, t, config, id, fileBlock.IPtrs[0].BlockPointer, p.Branch)
 	newBlock2 := getFileBlockFromCache(
-		t, ctx, config, id, fileBlock.IPtrs[1].BlockPointer, p.Branch)
+		ctx, t, config, id, fileBlock.IPtrs[1].BlockPointer, p.Branch)
 
 	if len(ops.nodeCache.PathFromNode(config.observer.localChange).Path) !=
 		len(p.Path) {
@@ -2532,7 +2531,7 @@ func TestKBFSOpsWriteOverMultipleBlocks(t *testing.T) {
 		[]WriteRange{{Off: 2, Len: uint64(len(buf))}})
 	mergeUnrefCache(ops, lState, p, rmd)
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID, id1, id2},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID, id1, id2},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:               p.Branch,
 			fileNode.BlockPointer:           p.Branch,
@@ -2546,7 +2545,7 @@ func TestKBFSOpsWriteOverMultipleBlocks(t *testing.T) {
 
 func TestKBFSOpsTruncateToZeroSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2588,9 +2587,9 @@ func TestKBFSOpsTruncateToZeroSuccess(t *testing.T) {
 	}
 
 	newFileBlock := getFileBlockFromCache(
-		t, ctx, config, id, fileNode.BlockPointer, p.Branch)
+		ctx, t, config, id, fileNode.BlockPointer, p.Branch)
 	newRootBlock := getDirBlockFromCache(
-		t, ctx, config, id, node.BlockPointer, p.Branch)
+		ctx, t, config, id, node.BlockPointer, p.Branch)
 
 	if len(ops.nodeCache.PathFromNode(config.observer.localChange).Path) !=
 		len(p.Path) {
@@ -2609,7 +2608,7 @@ func TestKBFSOpsTruncateToZeroSuccess(t *testing.T) {
 			newRootBlock.Children["f"].Size)
 	}
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:     p.Branch,
 			fileNode.BlockPointer: p.Branch,
@@ -2620,7 +2619,7 @@ func TestKBFSOpsTruncateToZeroSuccess(t *testing.T) {
 
 func TestKBFSOpsTruncateSameSize(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -2662,12 +2661,12 @@ func TestKBFSOpsTruncateSameSize(t *testing.T) {
 	} else if !bytes.Equal(data, fileBlock.Contents) {
 		t.Errorf("Wrote bad contents: %v", data)
 	}
-	checkBlockCache(t, ctx, config, id, []kbfsblock.ID{rootID, fileID}, nil)
+	checkBlockCache(ctx, t, config, id, []kbfsblock.ID{rootID, fileID}, nil)
 }
 
 func TestKBFSOpsTruncateSmallerSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2709,7 +2708,7 @@ func TestKBFSOpsTruncateSmallerSuccess(t *testing.T) {
 	}
 
 	newFileBlock := getFileBlockFromCache(
-		t, ctx, config, id, fileNode.BlockPointer, p.Branch)
+		ctx, t, config, id, fileNode.BlockPointer, p.Branch)
 
 	if len(ops.nodeCache.PathFromNode(config.observer.localChange).Path) !=
 		len(p.Path) {
@@ -2722,7 +2721,7 @@ func TestKBFSOpsTruncateSmallerSuccess(t *testing.T) {
 		t.Errorf("Wrote bad contents: %v", buf)
 	}
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:     p.Branch,
 			fileNode.BlockPointer: p.Branch,
@@ -2733,7 +2732,7 @@ func TestKBFSOpsTruncateSmallerSuccess(t *testing.T) {
 
 func TestKBFSOpsTruncateShortensLastBlock(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2788,11 +2787,11 @@ func TestKBFSOpsTruncateShortensLastBlock(t *testing.T) {
 	}
 
 	newPBlock := getFileBlockFromCache(
-		t, ctx, config, id, fileNode.BlockPointer, p.Branch)
+		ctx, t, config, id, fileNode.BlockPointer, p.Branch)
 	newBlock1 := getFileBlockFromCache(
-		t, ctx, config, id, fileBlock.IPtrs[0].BlockPointer, p.Branch)
+		ctx, t, config, id, fileBlock.IPtrs[0].BlockPointer, p.Branch)
 	newBlock2 := getFileBlockFromCache(
-		t, ctx, config, id, fileBlock.IPtrs[1].BlockPointer, p.Branch)
+		ctx, t, config, id, fileBlock.IPtrs[1].BlockPointer, p.Branch)
 
 	lState := makeFBOLockState()
 
@@ -2820,7 +2819,7 @@ func TestKBFSOpsTruncateShortensLastBlock(t *testing.T) {
 			rmd.UnrefBytes())
 	}
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID, id1, id2},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID, id1, id2},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:               p.Branch,
 			fileNode.BlockPointer:           p.Branch,
@@ -2830,7 +2829,7 @@ func TestKBFSOpsTruncateShortensLastBlock(t *testing.T) {
 
 func TestKBFSOpsTruncateRemovesABlock(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2885,9 +2884,9 @@ func TestKBFSOpsTruncateRemovesABlock(t *testing.T) {
 	}
 
 	newPBlock := getFileBlockFromCache(
-		t, ctx, config, id, fileNode.BlockPointer, p.Branch)
+		ctx, t, config, id, fileNode.BlockPointer, p.Branch)
 	newBlock1 := getFileBlockFromCache(
-		t, ctx, config, id, fileBlock.IPtrs[0].BlockPointer, p.Branch)
+		ctx, t, config, id, fileBlock.IPtrs[0].BlockPointer, p.Branch)
 
 	lState := makeFBOLockState()
 
@@ -2913,7 +2912,7 @@ func TestKBFSOpsTruncateRemovesABlock(t *testing.T) {
 			rmd.UnrefBytes())
 	}
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID, id1, id2},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID, id1, id2},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:               p.Branch,
 			fileNode.BlockPointer:           p.Branch,
@@ -2923,7 +2922,7 @@ func TestKBFSOpsTruncateRemovesABlock(t *testing.T) {
 
 func TestKBFSOpsTruncateBiggerSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -2970,7 +2969,7 @@ func TestKBFSOpsTruncateBiggerSuccess(t *testing.T) {
 	}
 
 	newFileBlock := getFileBlockFromCache(
-		t, ctx, config, id, fileNode.BlockPointer, p.Branch)
+		ctx, t, config, id, fileNode.BlockPointer, p.Branch)
 
 	if len(ops.nodeCache.PathFromNode(config.observer.localChange).Path) !=
 		len(p.Path) {
@@ -2983,7 +2982,7 @@ func TestKBFSOpsTruncateBiggerSuccess(t *testing.T) {
 		t.Errorf("Wrote bad contents: %v", buf)
 	}
 	checkBlockCache(
-		t, ctx, config, id, []kbfsblock.ID{rootID, fileID},
+		ctx, t, config, id, []kbfsblock.ID{rootID, fileID},
 		map[data.BlockPointer]data.BranchName{
 			node.BlockPointer:     p.Branch,
 			fileNode.BlockPointer: p.Branch,
@@ -2996,7 +2995,7 @@ func TestKBFSOpsTruncateBiggerSuccess(t *testing.T) {
 
 func TestSetExFailNoSuchName(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -3034,7 +3033,7 @@ func TestSetExFailNoSuchName(t *testing.T) {
 
 func TestSetMtimeNull(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -3073,12 +3072,12 @@ func TestSetMtimeNull(t *testing.T) {
 	} else if newP.Path[0].ID != p.Path[0].ID {
 		t.Errorf("Got back a changed path for null setmtime test: %v", newP)
 	}
-	checkBlockCache(t, ctx, config, id, nil, nil)
+	checkBlockCache(ctx, t, config, id, nil, nil)
 }
 
 func TestMtimeFailNoSuchName(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -3134,7 +3133,7 @@ func makeBlockStateDirty(config Config, kmd libkey.KeyMetadata, p data.Path,
 
 func TestSyncCleanSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	u, id, rmd := injectNewRMD(t, config)
 
@@ -3171,12 +3170,12 @@ func TestSyncCleanSuccess(t *testing.T) {
 			}
 		}
 	}
-	checkBlockCache(t, ctx, config, id, nil, nil)
+	checkBlockCache(ctx, t, config, id, nil, nil)
 }
 
 func TestKBFSOpsStatRootSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 
@@ -3204,7 +3203,7 @@ func TestKBFSOpsStatRootSuccess(t *testing.T) {
 
 func TestKBFSOpsFailingRootOps(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(t, mockCtrl, config, ctx, cancel)
+	defer kbfsTestShutdown(ctx, t, mockCtrl, config, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
 
@@ -3264,7 +3263,7 @@ func (t *testBGObserver) TlfHandleChange(ctx context.Context,
 // application does not.
 func TestKBFSOpsBackgroundFlush(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 	config.noBGFlush = true
 
 	// create a file.
@@ -3306,7 +3305,7 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 func TestKBFSOpsWriteRenameStat(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
 	// TODO: Use kbfsTestShutdownNoMocks.
-	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	// create a file.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -3354,7 +3353,7 @@ func TestKBFSOpsWriteRenameStat(t *testing.T) {
 func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
 	// TODO: Use kbfsTestShutdownNoMocks.
-	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	// create a file.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -3402,7 +3401,7 @@ func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 
 func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	// create a file.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -3436,7 +3435,7 @@ func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 
 func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	// Make the blocks small, with multiple levels of indirection, but
 	// make the unembedded size large, so we don't create thousands of
@@ -3516,7 +3515,7 @@ func (cbs corruptBlockServer) Get(
 
 func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 	config.SetBlockServer(&corruptBlockServer{
 		BlockServer: config.BlockServer(),
 	})
@@ -3547,7 +3546,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 // test ever fails, consult max or strib before merging.
 func TestKBFSOpsEmptyTlfSize(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	// Create a TLF.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -3576,7 +3575,7 @@ func (c cryptoFixedTlf) MakeRandomTlfID(t tlf.Type) (tlf.ID, error) {
 func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	config1, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "mallory")
 	// TODO: Use kbfsTestShutdownNoMocks.
-	defer kbfsTestShutdownNoMocksNoCheck(t, config1, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config1, cancel)
 	// Turn off tlf edit history because it messes with the FBO state
 	// asynchronously.
 	config1.SetMode(modeNoHistory{config1.Mode()})
@@ -3642,7 +3641,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 func TestGetTLFCryptKeysAfterFirstError(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice")
 	// TODO: Use kbfsTestShutdownNoMocks.
-	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	createErr := errors.New("Cannot create this TLF")
 	mdserver := &shimMDServer{
@@ -3671,7 +3670,7 @@ func TestGetTLFCryptKeysAfterFirstError(t *testing.T) {
 func TestForceFastForwardOnEmptyTLF(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
 	// TODO: Use kbfsTestShutdownNoMocks.
-	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocksNoCheck(ctx, t, config, cancel)
 
 	// Look up bob's public folder.
 	h, err := tlfhandle.ParseHandle(
@@ -3704,7 +3703,7 @@ func TestForceFastForwardOnEmptyTLF(t *testing.T) {
 // Regression test for KBFS-2161.
 func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 	kbfsOps := config.KBFSOps()
@@ -3772,7 +3771,7 @@ func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	var u1, u2, u3 kbname.NormalizedUsername = "u1", "u2", "u3"
 	config1, uid1, ctx, cancel := kbfsOpsInitNoMocks(t, u1, u2, u3)
-	defer kbfsTestShutdownNoMocks(t, config1, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -3882,7 +3881,7 @@ func (wrn wrappedReadonlyNode) WrapChild(child Node) Node {
 
 func TestKBFSOpsReadonlyNodes(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	config.AddRootNodeWrapper(func(root Node) Node {
 		return wrappedReadonlyNode{root}
@@ -3947,7 +3946,7 @@ func (wan wrappedAutocreateNode) ShouldCreateMissedLookup(
 
 func testKBFSOpsAutocreateNodes(t *testing.T, et data.EntryType, sympath string) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	config.AddRootNodeWrapper(func(root Node) Node {
 		return wrappedAutocreateNode{root, et, sympath}
@@ -4702,7 +4701,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 }
 
 func waitForPrefetchInTest(
-	t *testing.T, ctx context.Context, config Config, node Node) {
+	ctx context.Context, t *testing.T, config Config, node Node) {
 	t.Helper()
 	md, err := config.KBFSOps().GetNodeMetadata(ctx, node)
 	require.NoError(t, err)
@@ -4717,7 +4716,7 @@ func waitForPrefetchInTest(
 }
 
 func waitForIndirectPtrBlocksInTest(
-	t *testing.T, ctx context.Context, config Config, node Node,
+	ctx context.Context, t *testing.T, config Config, node Node,
 	kmd libkey.KeyMetadata) {
 	t.Helper()
 	md, err := config.KBFSOps().GetNodeMetadata(ctx, node)
@@ -4793,7 +4792,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	t.Log("Root block and 'a' block should be synced")
 	checkSyncCache := func(expectedBlocks uint64, nodesToWaitOn ...Node) {
 		for _, node := range nodesToWaitOn {
-			waitForPrefetchInTest(t, ctx, config, node)
+			waitForPrefetchInTest(ctx, t, config, node)
 		}
 
 		// We can't wait for root and `a` to be prefetched, because
@@ -4801,8 +4800,8 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 		// won't necessarily complete in this test.  Instead, wait for
 		// all their indirect pointers to be retrieved and cached, so
 		// the sync cache counts will be correct.
-		waitForIndirectPtrBlocksInTest(t, ctx, config, rootNode, kmd)
-		waitForIndirectPtrBlocksInTest(t, ctx, config, aNode, kmd)
+		waitForIndirectPtrBlocksInTest(ctx, t, config, rootNode, kmd)
+		waitForIndirectPtrBlocksInTest(ctx, t, config, aNode, kmd)
 
 		syncStatusMap := dbc.syncCache.Status(ctx)
 		require.Len(t, syncStatusMap, 1)
@@ -4999,8 +4998,8 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	require.NoError(t, err)
 
 	checkWorkingSetCache := func(expectedBlocks uint64) {
-		waitForPrefetchInTest(t, ctx, config, rootNode)
-		waitForPrefetchInTest(t, ctx, config, aNode)
+		waitForPrefetchInTest(ctx, t, config, rootNode)
+		waitForPrefetchInTest(ctx, t, config, aNode)
 
 		statusMap := dbc.workingSetCache.Status(ctx)
 		require.Len(t, statusMap, 1)

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -186,8 +186,9 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	return mockCtrl, config, ctx, cancel
 }
 
-func kbfsTestShutdown(ctx context.Context,
-	t *testing.T, mockCtrl *gomock.Controller, config *ConfigMock, cancel context.CancelFunc) {
+func kbfsTestShutdown(
+	ctx context.Context, t *testing.T, mockCtrl *gomock.Controller,
+	config *ConfigMock, cancel context.CancelFunc) {
 	config.ctr.CheckForFailures()
 	err := config.conflictResolutionDB.Close()
 	require.NoError(t, err)
@@ -257,7 +258,8 @@ func kbfsOpsInitNoMocks(t *testing.T, users ...kbname.NormalizedUsername) (
 	return config, session.UID, ctx, cancel
 }
 
-func kbfsTestShutdownNoMocks(ctx context.Context, t *testing.T,
+func kbfsTestShutdownNoMocks(
+	ctx context.Context, t *testing.T,
 	config *ConfigLocal, cancel context.CancelFunc) {
 	CheckConfigAndShutdown(ctx, t, config)
 	cancel()
@@ -3983,7 +3985,7 @@ func testKBFSOpsMigrateToImplicitTeam(
 	t *testing.T, ty tlf.Type, name string, initialMDVer kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	config1.SetMetadataVersion(initialMDVer)
 
 	config2 := ConfigAsUser(config1, u2)
@@ -4091,7 +4093,7 @@ func TestKBFSOpsMigratePublicV2ToImplicitTeam(t *testing.T) {
 func TestKBFSOpsArchiveBranchType(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	t.Log("Create a private folder for the master branch.")
 	name := "u1"
@@ -4214,7 +4216,7 @@ func (w testKBFSOpsRootWrapper) wrap(node Node) Node {
 func TestKBFSOpsReadonlyFSNodes(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	fs := memfs.New()
 	rw := testKBFSOpsRootWrapper{fs}
@@ -4293,7 +4295,7 @@ func (md mdServerShutdownOverride) isShutdown() bool {
 func TestKBFSOpsReset(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	md := &mdServerShutdownOverride{config.MDServer().(mdServerLocal), false}
 	config.SetMDServer(md)
 
@@ -4376,7 +4378,7 @@ func (dmc *diskMDCacheWithCommitChan) Commit(
 func TestKBFSOpsUnsyncedMDCommit(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	dmcLocal, tempdir := newDiskMDCacheLocalForTest(t)
 	defer shutdownDiskMDCacheTest(dmcLocal, tempdir)
@@ -4486,7 +4488,7 @@ func enableDiskCacheForTest(
 func TestKBFSOpsSyncedMDCommit(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	config2 := ConfigAsUser(config, u1)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -4605,7 +4607,7 @@ func TestKBFSOpsSyncedMDCommit(t *testing.T) {
 func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 
 	name := "u1"
 	h, err := tlfhandle.ParseHandle(
@@ -4740,7 +4742,7 @@ func waitForIndirectPtrBlocksInTest(
 func TestKBFSOpsPartialSync(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	config.SetVLogLevel(libkb.VLog2String)
 
 	name := "u1"
@@ -4958,7 +4960,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.
 	config.SetMode(modeTest{NewInitModeFromType(InitDefault)})
 	config.SetVLogLevel(libkb.VLog2String)

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -3305,7 +3305,7 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 func TestKBFSOpsWriteRenameStat(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
 	// TODO: Use kbfsTestShutdownNoMocks.
-	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
+	defer kbfsTestShutdownNoMocksNoCheck(ctx, t, config, cancel)
 
 	// create a file.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -3353,7 +3353,7 @@ func TestKBFSOpsWriteRenameStat(t *testing.T) {
 func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
 	// TODO: Use kbfsTestShutdownNoMocks.
-	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
+	defer kbfsTestShutdownNoMocksNoCheck(ctx, t, config, cancel)
 
 	// create a file.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
@@ -3575,7 +3575,7 @@ func (c cryptoFixedTlf) MakeRandomTlfID(t tlf.Type) (tlf.ID, error) {
 func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	config1, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "mallory")
 	// TODO: Use kbfsTestShutdownNoMocks.
-	defer kbfsTestShutdownNoMocks(ctx, t, config1, cancel)
+	defer kbfsTestShutdownNoMocksNoCheck(ctx, t, config1, cancel)
 	// Turn off tlf edit history because it messes with the FBO state
 	// asynchronously.
 	config1.SetMode(modeNoHistory{config1.Mode()})
@@ -3640,7 +3640,6 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 // KBFS-1929.
 func TestGetTLFCryptKeysAfterFirstError(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice")
-	// TODO: Use kbfsTestShutdownNoMocks.
 	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	createErr := errors.New("Cannot create this TLF")

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -854,7 +854,7 @@ func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver kbf
 func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	clock := clocktest.NewTestClockNow()
 	config1.SetClock(clock)
 
@@ -1113,7 +1113,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2, u3 kbname.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config1.SetMetadataVersion(ver)
 
@@ -1221,7 +1221,7 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.Metada
 func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config1.SetMetadataVersion(ver)
 
@@ -1315,7 +1315,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	session1, err := config1.KBPKI().GetCurrentSession(ctx)
 
 	config1.SetMetadataVersion(ver)
@@ -1404,7 +1404,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	clock := clocktest.NewTestClockNow()
 	config1.SetClock(clock)
 
@@ -1534,7 +1534,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	doShutdown1 := true
 	defer func() {
 		if doShutdown1 {
-			kbfsConcurTestShutdown(t, config1, ctx, cancel)
+			kbfsConcurTestShutdown(ctx, t, config1, cancel)
 		}
 	}()
 
@@ -1714,7 +1714,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	// Explicitly run the checks with config1 before the deferred shutdowns begin.
 	// This way the shared mdserver hasn't been shutdown.
-	kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	doShutdown1 = false
 }
 
@@ -1724,7 +1724,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	clock := clocktest.NewTestClockNow()
 	config1.SetClock(clock)
 
@@ -1882,7 +1882,7 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config1.SetMetadataVersion(ver)
 
@@ -1995,7 +1995,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	clock := clocktest.NewTestClockNow()
 	config1.SetClock(clock)
 
@@ -2122,7 +2122,7 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config1.SetMetadataVersion(ver)
 
@@ -2234,7 +2234,7 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver kbf
 func testKeyManagerRekeyMinimal(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	clock := clocktest.NewTestClockNow()
 	config1.SetClock(clock)
 
@@ -2329,7 +2329,7 @@ func (c *protectedContext) maybeReplaceContext(newCtx context.Context) {
 func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2)
@@ -2391,7 +2391,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2)

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -1498,7 +1498,7 @@ func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver kbfsmd.MetadataVer) {
 }
 
 func keyManagerTestSimulateSelfRekeyBit(
-	t *testing.T, ctx context.Context, config Config, tlfID tlf.ID) {
+	ctx context.Context, t *testing.T, config Config, tlfID tlf.ID) {
 	// Simulate the mdserver sending back this node's own rekey
 	// request.  This shouldn't increase the MD version.  Since this
 	// doesn't kick off a rekey request, we don't need to wait for the
@@ -1608,7 +1608,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	// Do it again, to simulate the mdserver sending back this node's
 	// own rekey request.
 	keyManagerTestSimulateSelfRekeyBit(
-		t, ctx, config2Dev2, rootNode1.GetFolderBranch().Tlf)
+		ctx, t, config2Dev2, rootNode1.GetFolderBranch().Tlf)
 
 	// user 1 syncs from server
 	err = kbfsOps1.SyncFromServer(ctx,
@@ -1939,7 +1939,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 	// Do it again, to simulate the mdserver sending back this node's
 	// own rekey request.
 	keyManagerTestSimulateSelfRekeyBit(
-		t, ctx, config2Dev2, rootNode1.GetFolderBranch().Tlf)
+		ctx, t, config2Dev2, rootNode1.GetFolderBranch().Tlf)
 
 	t.Log("Switching crypto")
 
@@ -2064,7 +2064,7 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 	// Do it again, to simulate the mdserver sending back this node's
 	// own rekey request.
 	keyManagerTestSimulateSelfRekeyBit(
-		t, ctx, config2Dev2, rootNode1.GetFolderBranch().Tlf)
+		ctx, t, config2Dev2, rootNode1.GetFolderBranch().Tlf)
 
 	// Simulate a restart after the rekey bit was set
 	ops := getOps(config2Dev2, rootNode1.GetFolderBranch().Tlf)

--- a/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
@@ -346,7 +346,7 @@ func truncateNotificationTimestamps(
 func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.
 	config1.SetMode(modeTest{NewInitModeFromType(InitDefault)})
 

--- a/go/kbfs/libkbfs/md_journal_test.go
+++ b/go/kbfs/libkbfs/md_journal_test.go
@@ -562,7 +562,7 @@ func testMDJournalGCd(t *testing.T, j *mdJournal) {
 }
 
 func flushAllMDs(
-	t *testing.T, ctx context.Context, signer kbfscrypto.Signer, j *mdJournal) {
+	ctx context.Context, t *testing.T, signer kbfscrypto.Signer, j *mdJournal) {
 	end, err := j.end()
 	require.NoError(t, err)
 	for {
@@ -616,7 +616,7 @@ func testMDJournalFlushAll(t *testing.T, ver kbfsmd.MetadataVer) {
 	err := ioutil.WriteFile(filepath.Join(j.dir, "extra_file"), nil, 0600)
 	require.NoError(t, err)
 
-	flushAllMDs(t, ctx, signer, j)
+	flushAllMDs(ctx, t, signer, j)
 
 	// The flush shouldn't remove the entire directory.
 	names = listDir(t, j.dir)
@@ -671,7 +671,7 @@ func testMDJournalBranchConversion(t *testing.T, ver kbfsmd.MetadataVer) {
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 
-	flushAllMDs(t, ctx, signer, j)
+	flushAllMDs(ctx, t, signer, j)
 
 	// Has the cache entry been replaced?
 	newlyCachedMd, err := mdcache.Get(id, firstRevision, bid)
@@ -734,7 +734,7 @@ func testMDJournalResolveAndClear(t *testing.T, ver kbfsmd.MetadataVer, bid kbfs
 	require.NoError(t, err)
 	require.Equal(t, md.Revision(), head.RevisionNumber())
 
-	flushAllMDs(t, ctx, signer, j)
+	flushAllMDs(ctx, t, signer, j)
 }
 
 func testMDJournalResolveAndClearRemoteBranch(t *testing.T, ver kbfsmd.MetadataVer) {
@@ -805,7 +805,7 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 
 	// Flush all MDs so we can check garbage collection.
-	flushAllMDs(t, ctx, signer, j)
+	flushAllMDs(ctx, t, signer, j)
 }
 
 type mdIDJournalEntryExtra struct {
@@ -867,7 +867,7 @@ func testMDJournalBranchConversionPreservesUnknownFields(t *testing.T, ver kbfsm
 	}
 	require.Equal(t, expectedEntries, entries)
 
-	flushAllMDs(t, ctx, signer, j)
+	flushAllMDs(ctx, t, signer, j)
 }
 
 func testMDJournalClear(t *testing.T, ver kbfsmd.MetadataVer) {
@@ -937,13 +937,13 @@ func testMDJournalClear(t *testing.T, ver kbfsmd.MetadataVer) {
 	require.NotEqual(t, kbfsmd.NullBranchID, j.branchID)
 
 	bid = j.branchID
-	flushAllMDs(t, ctx, signer, j)
+	flushAllMDs(ctx, t, signer, j)
 	require.Equal(t, bid, j.branchID)
 	err = j.clear(ctx, bid)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.NullBranchID, j.branchID)
 
-	flushAllMDs(t, ctx, signer, j)
+	flushAllMDs(ctx, t, signer, j)
 }
 
 func testMDJournalClearPendingWithMaster(t *testing.T, ver kbfsmd.MetadataVer) {
@@ -1023,7 +1023,7 @@ func testMDJournalRestart(t *testing.T, ver kbfsmd.MetadataVer) {
 	checkIBRMDRange(t, j.uid, j.key, codec,
 		ibrmds, firstRevision, firstPrevRoot, kbfsmd.Merged, kbfsmd.NullBranchID)
 
-	flushAllMDs(t, context.Background(), signer, j)
+	flushAllMDs(context.Background(), t, signer, j)
 }
 
 func testMDJournalRestartAfterBranchConversion(t *testing.T, ver kbfsmd.MetadataVer) {
@@ -1066,7 +1066,7 @@ func testMDJournalRestartAfterBranchConversion(t *testing.T, ver kbfsmd.Metadata
 	checkIBRMDRange(t, j.uid, j.key, codec,
 		ibrmds, firstRevision, firstPrevRoot, kbfsmd.Unmerged, ibrmds[0].BID())
 
-	flushAllMDs(t, ctx, signer, j)
+	flushAllMDs(ctx, t, signer, j)
 }
 
 func TestMDJournal(t *testing.T) {

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -986,7 +986,7 @@ func testMDOpsGetFinalSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 }
 
 func makeRealInitialRMDForTesting(
-	t *testing.T, ctx context.Context, config Config, h *tlfhandle.Handle,
+	ctx context.Context, t *testing.T, config Config, h *tlfhandle.Handle,
 	id tlf.ID) (*RootMetadata, *RootMetadataSigned) {
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
@@ -1016,7 +1016,7 @@ func makeRealInitialRMDForTesting(
 }
 
 func makeSuccessorRMDForTesting(
-	t *testing.T, ctx context.Context, config Config, currRMD *RootMetadata,
+	ctx context.Context, t *testing.T, config Config, currRMD *RootMetadata,
 	deviceToRevoke int) (
 	*RootMetadata, *RootMetadataSigned) {
 	mdID, err := kbfsmd.MakeID(config.Codec(), currRMD.bareMd)
@@ -1124,7 +1124,7 @@ func testMDOpsDecryptMerkleLeafPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 	t.Log("Making an initial RMD")
 	id := tlf.FakeID(1, tlf.Private)
 	h := parseTlfHandleOrBust(t, config, "u1", tlf.Private, id)
-	rmd, rmds := makeRealInitialRMDForTesting(t, ctx, config, h, id)
+	rmd, rmds := makeRealInitialRMDForTesting(ctx, t, config, h, id)
 
 	t.Log("Making an encrypted Merkle leaf")
 	root, _, mLeaf, leafBytes := makeEncryptedMerkleLeafForTesting(
@@ -1168,7 +1168,7 @@ func testMDOpsDecryptMerkleLeafPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 		}
 
 		rmd, rmds = makeSuccessorRMDForTesting(
-			t, ctx, config, rmd, deviceToRevoke)
+			ctx, t, config, rmd, deviceToRevoke)
 		allRMDs = append(allRMDs, rmd)
 		allRMDSs = append(allRMDSs, rmds)
 
@@ -1212,7 +1212,7 @@ func testMDOpsDecryptMerkleLeafTeam(t *testing.T, ver kbfsmd.MetadataVer) {
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config, "t1")
 	AddTeamWriterForTestOrBust(t, config, teamInfos[0].TID, session.UID)
 	h := parseTlfHandleOrBust(t, config, "t1", tlf.SingleTeam, id)
-	rmd, _ := makeRealInitialRMDForTesting(t, ctx, config, h, id)
+	rmd, _ := makeRealInitialRMDForTesting(ctx, t, config, h, id)
 
 	t.Log("Making an encrypted Merkle leaf")
 	root, _, mLeaf, leafBytes := makeEncryptedMerkleLeafForTesting(
@@ -1252,20 +1252,20 @@ func testMDOpsVerifyRevokedDeviceWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 	t.Log("Initial MD written by the device we will revoke")
 	id := tlf.FakeID(1, tlf.Private)
 	h := parseTlfHandleOrBust(t, config, "u1", tlf.Private, id)
-	rmd, rmds := makeRealInitialRMDForTesting(t, ctx, config2, h, id)
+	rmd, rmds := makeRealInitialRMDForTesting(ctx, t, config2, h, id)
 	mdServer.processRMDSes(rmds, rmd.extra)
 
 	t.Log("A few writes by a device that won't be revoked")
 	allRMDs := []*RootMetadata{rmd}
 	allRMDSs := []*RootMetadataSigned{rmds}
 	for i := 2; i < 5; i++ {
-		rmd, rmds = makeSuccessorRMDForTesting(t, ctx, config, rmd, -1)
+		rmd, rmds = makeSuccessorRMDForTesting(ctx, t, config, rmd, -1)
 		allRMDs = append(allRMDs, rmd)
 		allRMDSs = append(allRMDSs, rmds)
 	}
 
 	t.Log("A write after the revoke happens")
-	rmd, rmds = makeSuccessorRMDForTesting(t, ctx, config, rmd, extraDevice)
+	rmd, rmds = makeSuccessorRMDForTesting(ctx, t, config, rmd, extraDevice)
 	allRMDs = append(allRMDs, rmd)
 	allRMDSs = append(allRMDSs, rmds)
 	mdServer.processRMDSes(rmds, rmd.extra)
@@ -1359,7 +1359,7 @@ func testMDOpsVerifyRemovedUserWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 	AddTeamWriterForTestOrBust(t, config, tid, session2.UID)
 	AddTeamWriterForTestOrBust(t, config2, tid, session2.UID)
 	h := parseTlfHandleOrBust(t, config, "t1", tlf.SingleTeam, id)
-	rmd, rmds := makeRealInitialRMDForTesting(t, ctx, config, h, id)
+	rmd, rmds := makeRealInitialRMDForTesting(ctx, t, config, h, id)
 	mdServer.processRMDSes(rmds, rmd.extra)
 
 	RemoveTeamWriterForTestOrBust(t, config, tid, session.UID)
@@ -1369,7 +1369,7 @@ func testMDOpsVerifyRemovedUserWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 	allRMDs := []*RootMetadata{rmd}
 	allRMDSs := []*RootMetadataSigned{rmds}
 	for i := 2; i < 5; i++ {
-		rmd, rmds = makeSuccessorRMDForTesting(t, ctx, config2, rmd, -1)
+		rmd, rmds = makeSuccessorRMDForTesting(ctx, t, config2, rmd, -1)
 		allRMDs = append(allRMDs, rmd)
 		allRMDSs = append(allRMDSs, rmds)
 	}
@@ -1390,7 +1390,7 @@ func testMDOpsVerifyRemovedUserWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 	require.NoError(t, err)
 
 	t.Log("Try another write by the removed user and make sure it fails")
-	rmd, rmds = makeSuccessorRMDForTesting(t, ctx, config, rmd, -1)
+	rmd, rmds = makeSuccessorRMDForTesting(ctx, t, config, rmd, -1)
 	allRMDs = append(allRMDs, rmd)
 	allRMDSs = append(allRMDSs, rmds)
 	mdServer.processRMDSes(rmds, rmd.extra)

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -1108,7 +1108,7 @@ func makeEncryptedMerkleLeafForTesting(
 func testMDOpsDecryptMerkleLeafPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	config.SetMetadataVersion(ver)
 
 	mdServer := makeKeyBundleMDServer(config.MDServer())
@@ -1201,7 +1201,7 @@ func testMDOpsDecryptMerkleLeafTeam(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	config.SetMetadataVersion(ver)
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
@@ -1232,7 +1232,7 @@ func testMDOpsDecryptMerkleLeafTeam(t *testing.T, ver kbfsmd.MetadataVer) {
 func testMDOpsVerifyRevokedDeviceWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	config.SetMetadataVersion(ver)
 	clock := clocktest.NewTestClockNow()
 	config.SetClock(clock)
@@ -1334,7 +1334,7 @@ func testMDOpsVerifyRemovedUserWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	config.SetMetadataVersion(ver)
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)

--- a/go/kbfs/libkbfs/md_util_test.go
+++ b/go/kbfs/libkbfs/md_util_test.go
@@ -104,7 +104,7 @@ func TestReembedBlockChanges(t *testing.T) {
 func TestGetRevisionByTime(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, u1)
-	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+	defer kbfsTestShutdownNoMocks(ctx, t, config, cancel)
 
 	clock, t1 := clocktest.NewTestClockAndTimeNow()
 	config.SetClock(clock)

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -144,7 +144,7 @@ func getStack() string {
 }
 
 func waitForPrefetchOrBust(
-	t *testing.T, ctx context.Context, pre Prefetcher, ptr data.BlockPointer) {
+	ctx context.Context, t *testing.T, pre Prefetcher, ptr data.BlockPointer) {
 	t.Helper()
 	ch, err := pre.WaitChannelForBlockPrefetch(ctx, ptr)
 	require.NoError(t, err)
@@ -221,9 +221,9 @@ func TestPrefetcherIndirectFileBlock(t *testing.T) {
 	continueChIndBlock2 <- nil
 
 	t.Log("Wait for the prefetch to finish.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[0].BlockPointer)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[1].BlockPointer)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), ptrs[0].BlockPointer)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), ptrs[1].BlockPointer)
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootBlock,
@@ -273,9 +273,9 @@ func TestPrefetcherIndirectDirBlock(t *testing.T) {
 	continueChIndBlock2 <- nil
 
 	t.Log("Wait for the prefetch to finish.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[0].BlockPointer)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[1].BlockPointer)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), ptrs[0].BlockPointer)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), ptrs[1].BlockPointer)
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootBlock,
@@ -330,13 +330,13 @@ func testPrefetcherIndirectDirBlockTail(
 	}
 
 	t.Log("Wait for the prefetch to finish.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	rootStatus := NoPrefetch
 	if withSync {
-		waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[0].BlockPointer)
-		waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[1].BlockPointer)
+		waitForPrefetchOrBust(ctx, t, q.Prefetcher(), ptrs[0].BlockPointer)
+		waitForPrefetchOrBust(ctx, t, q.Prefetcher(), ptrs[1].BlockPointer)
 		rootStatus = TriggeredPrefetch
 		testPrefetcherCheckGet(t, config.BlockCache(), ptrs[0].BlockPointer,
 			indBlock1, NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
@@ -411,9 +411,9 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 	continueChDirB <- nil
 	continueChFileA <- context.Canceled
 	t.Log("Wait for the prefetch to finish.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 	waitForPrefetchOrBust(
-		t, ctx, q.Prefetcher(), rootDir.Children["c"].BlockPointer)
+		ctx, t, q.Prefetcher(), rootDir.Children["c"].BlockPointer)
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
@@ -477,7 +477,7 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 	t.Log("Release the prefetch for dirA.")
 	continueChDirA <- nil
 	t.Log("Wait for the prefetch to finish.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 
 	t.Log("Ensure that the prefetched block is in the cache.")
 	block, err = cache.Get(rootDir.Children["a"].BlockPointer)
@@ -503,9 +503,9 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 	continueChFileB <- nil
 	t.Log("Wait for the prefetch to finish.")
 	waitForPrefetchOrBust(
-		t, ctx, q.Prefetcher(), rootDir.Children["a"].BlockPointer)
+		ctx, t, q.Prefetcher(), rootDir.Children["a"].BlockPointer)
 	waitForPrefetchOrBust(
-		t, ctx, q.Prefetcher(), rootDir.Children["b"].BlockPointer)
+		ctx, t, q.Prefetcher(), rootDir.Children["b"].BlockPointer)
 
 	testPrefetcherCheckGet(t, cache, dirA.Children["b"].BlockPointer, fileB,
 		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
@@ -532,7 +532,7 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 
 	t.Log("Wait for the prefetch to finish.")
 	waitForPrefetchOrBust(
-		t, ctx, q.Prefetcher(), rootDir.Children["a"].BlockPointer)
+		ctx, t, q.Prefetcher(), rootDir.Children["a"].BlockPointer)
 }
 
 func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
@@ -571,7 +571,7 @@ func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
 
 	t.Log("Wait for the prefetch to finish, then verify that the prefetched " +
 		"block is in the cache.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrA)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), ptrA)
 	testPrefetcherCheckGet(
 		t, config.BlockCache(), ptrA, fileA, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
@@ -594,7 +594,7 @@ func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
 		"block is still not in the cache.")
 	_, err = cache.Get(ptrA)
 	require.EqualError(t, err, data.NoSuchBlockError{ID: ptrA.ID}.Error())
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 }
 
 func TestPrefetcherEmptyDirectDirBlock(t *testing.T) {
@@ -626,7 +626,7 @@ func TestPrefetcherEmptyDirectDirBlock(t *testing.T) {
 
 	t.Log("Wait for prefetching to complete.")
 	notifySyncCh(t, prefetchSyncCh)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 
 	t.Log("Ensure that the directory block is in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
@@ -809,7 +809,7 @@ func testPrefetcherForSyncedTLF(
 	// To make CI work again, we close the `prefetchSyncCh` which unblocks all
 	// prefetches.
 	close(prefetchSyncCh)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
 		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
@@ -909,7 +909,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Wait for the prefetch to finish.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
@@ -972,7 +972,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 
 	t.Log("Wait for the prefetch to finish.")
 	waitForPrefetchOrBust(
-		t, ctx, q.Prefetcher(), indBlock1.IPtrs[1].BlockPointer)
+		ctx, t, q.Prefetcher(), indBlock1.IPtrs[1].BlockPointer)
 
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
@@ -1122,7 +1122,7 @@ func TestPrefetcherBackwardPrefetch(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Wait for the prefetch to finish.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
@@ -1253,7 +1253,7 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 	// Release after prefetching aab
 	notifySyncCh(t, prefetchSyncCh)
 	// Then we wait for the pending prefetches to complete.
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
@@ -1383,7 +1383,7 @@ func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Prefetching shouldn't happen because the disk caches are full.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 }
 
 func TestPrefetcherBasicUnsyncedPrefetch(t *testing.T) {
@@ -1437,7 +1437,7 @@ func TestPrefetcherBasicUnsyncedPrefetch(t *testing.T) {
 		kmd.TlfID(), config.DiskBlockCache())
 
 	// Then we wait for the pending prefetches to complete.
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 }
 
 func TestPrefetcherBasicUnsyncedBackwardPrefetch(t *testing.T) {
@@ -1495,7 +1495,7 @@ func TestPrefetcherBasicUnsyncedBackwardPrefetch(t *testing.T) {
 		kmd.TlfID(), config.DiskBlockCache())
 
 	// Then we wait for the pending prefetches to complete.
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 }
 
 func TestPrefetcherUnsyncedPrefetchEvicted(t *testing.T) {
@@ -1583,7 +1583,7 @@ func TestPrefetcherUnsyncedPrefetchEvicted(t *testing.T) {
 
 	// Then we wait for the pending prefetches to complete.
 	close(prefetchSyncCh)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 }
 
 func TestPrefetcherUnsyncedPrefetchChildCanceled(t *testing.T) {
@@ -1705,7 +1705,7 @@ func TestPrefetcherUnsyncedPrefetchChildCanceled(t *testing.T) {
 
 	// Then we wait for the pending prefetches to complete.
 	close(prefetchSyncCh)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 }
 
 func TestPrefetcherUnsyncedPrefetchParentCanceled(t *testing.T) {
@@ -1822,10 +1822,10 @@ func TestPrefetcherUnsyncedPrefetchParentCanceled(t *testing.T) {
 
 	// Then we wait for the pending prefetches to complete.
 	close(prefetchSyncCh)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 }
 
-func waitDoneCh(t *testing.T, ctx context.Context, doneCh <-chan struct{}) {
+func waitDoneCh(ctx context.Context, t *testing.T, doneCh <-chan struct{}) {
 	t.Helper()
 	select {
 	case <-doneCh:
@@ -1928,7 +1928,7 @@ func TestPrefetcherReschedules(t *testing.T) {
 
 	t.Log("Release reschedule request of root.")
 	notifySyncCh(t, prefetchSyncCh)
-	waitDoneCh(t, ctx, prefetchDoneCh)
+	waitDoneCh(ctx, t, prefetchDoneCh)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
 		NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
@@ -1938,13 +1938,13 @@ func TestPrefetcherReschedules(t *testing.T) {
 
 	t.Log("Handle root's prefetch request")
 	notifySyncCh(t, prefetchSyncCh)
-	waitDoneCh(t, ctx, prefetchDoneCh)
+	waitDoneCh(ctx, t, prefetchDoneCh)
 
 	t.Log("Handle two child prefetch requests (a and b)")
 	notifySyncCh(t, prefetchSyncCh)
-	waitDoneCh(t, ctx, prefetchDoneCh)
+	waitDoneCh(ctx, t, prefetchDoneCh)
 	notifySyncCh(t, prefetchSyncCh)
-	waitDoneCh(t, ctx, prefetchDoneCh)
+	waitDoneCh(ctx, t, prefetchDoneCh)
 
 	blockA := &data.DirBlock{}
 	chA := q.Request(
@@ -1972,9 +1972,9 @@ func TestPrefetcherReschedules(t *testing.T) {
 
 	t.Log("Process requests of two more children (aa and ab)")
 	notifySyncCh(t, prefetchSyncCh)
-	waitDoneCh(t, ctx, prefetchDoneCh)
+	waitDoneCh(ctx, t, prefetchDoneCh)
 	notifySyncCh(t, prefetchSyncCh)
-	waitDoneCh(t, ctx, prefetchDoneCh)
+	waitDoneCh(ctx, t, prefetchDoneCh)
 
 	t.Log("Make room in the cache again.")
 	setLimiterLimits(limiter, math.MaxInt64, math.MaxInt64)
@@ -1991,7 +1991,7 @@ func TestPrefetcherReschedules(t *testing.T) {
 		}
 	}()
 
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
 		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
@@ -2064,7 +2064,7 @@ func TestPrefetcherWithDedupBlocks(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Wait for the prefetch to finish.")
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr)
 
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
@@ -2193,7 +2193,7 @@ func TestPrefetcherWithCanceledDedupBlocks(t *testing.T) {
 	testPrefetcherCheckGet(t, config.BlockCache(), a2Ptr, a2Block,
 		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), a2Ptr)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), a2Ptr)
 }
 
 func TestPrefetcherCancelTlfPrefetches(t *testing.T) {
@@ -2299,5 +2299,5 @@ func TestPrefetcherCancelTlfPrefetches(t *testing.T) {
 	t.Log("Now we should be able to wait for the prefetcher to " +
 		"complete with only a single notify, for root2's child.")
 	notifySyncCh(t, prefetchSyncCh)
-	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr2)
+	waitForPrefetchOrBust(ctx, t, q.Prefetcher(), rootPtr2)
 }

--- a/go/kbfs/libkbfs/rekey_queue_test.go
+++ b/go/kbfs/libkbfs/rekey_queue_test.go
@@ -16,7 +16,7 @@ import (
 func TestRekeyQueueBasic(t *testing.T) {
 	var u1, u2, u3, u4 kbname.NormalizedUsername = "u1", "u2", "u3", "u4"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3, u4)
-	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+	defer kbfsConcurTestShutdown(ctx, t, config1, cancel)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer config2.Shutdown(ctx)

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -312,7 +312,7 @@ func setupTLFJournalTest(
 }
 
 func teardownTLFJournalTest(
-	tempdir string, config *testTLFJournalConfig, ctx context.Context,
+	ctx context.Context, tempdir string, config *testTLFJournalConfig,
 	cancel context.CancelFunc, tlfJournal *tlfJournal,
 	delegate testBWDelegate) {
 	// Shutdown first so we don't get the Done() signal (from the
@@ -353,7 +353,7 @@ func testTLFJournalBasic(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	putOneMD(ctx, config, tlfJournal)
 
@@ -367,7 +367,7 @@ func testTLFJournalPauseResume(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.pauseBackgroundWork()
 	delegate.requireNextState(ctx, bwPaused)
@@ -386,7 +386,7 @@ func testTLFJournalPauseShutdown(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.pauseBackgroundWork()
 	delegate.requireNextState(ctx, bwPaused)
@@ -433,7 +433,7 @@ func testTLFJournalBlockOpBasic(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4})
 	numFlushed, rev, converted, err :=
@@ -448,7 +448,7 @@ func testTLFJournalBlockOpBusyPause(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	bs := hangingBlockServer{tlfJournal.delegateBlockServer,
 		make(chan struct{})}
@@ -469,7 +469,7 @@ func testTLFJournalBlockOpBusyShutdown(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	bs := hangingBlockServer{tlfJournal.delegateBlockServer,
 		make(chan struct{})}
@@ -487,7 +487,7 @@ func testTLFJournalSecondBlockOpWhileBusy(t *testing.T, ver kbfsmd.MetadataVer) 
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	bs := hangingBlockServer{tlfJournal.delegateBlockServer,
 		make(chan struct{})}
@@ -506,7 +506,7 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, math.MaxInt64-6, 0, 0, tlfJournal.uid.AsUserOrTeam())
@@ -545,7 +545,7 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, 0, 0, math.MaxInt64-2*filesPerBlockMax+1,
@@ -585,7 +585,7 @@ func testTLFJournalBlockOpDiskQuotaLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, 0, math.MaxInt64-6, 0, tlfJournal.uid.AsUserOrTeam())
@@ -632,7 +632,7 @@ func testTLFJournalBlockOpDiskQuotaLimitResolve(t *testing.T, ver kbfsmd.Metadat
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, 0, math.MaxInt64-6, 0, tlfJournal.uid.AsUserOrTeam())
@@ -693,7 +693,7 @@ func testTLFJournalBlockOpDiskLimitDuplicate(t *testing.T, ver kbfsmd.MetadataVe
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, math.MaxInt64-8, 0, math.MaxInt64-2*filesPerBlockMax,
@@ -719,7 +719,7 @@ func testTLFJournalBlockOpDiskLimitCancel(t *testing.T, ver kbfsmd.MetadataVer) 
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, math.MaxInt64, 0, 0, tlfJournal.uid.AsUserOrTeam())
@@ -737,7 +737,7 @@ func testTLFJournalBlockOpDiskLimitTimeout(t *testing.T, ver kbfsmd.MetadataVer)
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, math.MaxInt64, 0, math.MaxInt64-1, tlfJournal.uid.AsUserOrTeam())
@@ -760,7 +760,7 @@ func testTLFJournalBlockOpDiskLimitPutFailure(t *testing.T, ver kbfsmd.MetadataV
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, math.MaxInt64-6, 0, math.MaxInt64-filesPerBlockMax,
@@ -803,7 +803,7 @@ func testTLFJournalMDServerBusyPause(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	mdserver := hangingMDServer{config.MDServer(), make(chan struct{})}
 	config.mdserver = mdserver
@@ -825,7 +825,7 @@ func testTLFJournalMDServerBusyShutdown(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	mdserver := hangingMDServer{config.MDServer(), make(chan struct{})}
 	config.mdserver = mdserver
@@ -844,7 +844,7 @@ func testTLFJournalBlockOpWhileBusy(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	mdserver := hangingMDServer{config.MDServer(), make(chan struct{})}
 	config.mdserver = mdserver
@@ -930,7 +930,7 @@ func testTLFJournalFlushMDBasic(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	firstRevision := kbfsmd.Revision(10)
 	firstPrevRoot := kbfsmd.FakeID(1)
@@ -975,7 +975,7 @@ func testTLFJournalFlushMDConflict(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	firstRevision := kbfsmd.Revision(10)
 	firstPrevRoot := kbfsmd.FakeID(1)
@@ -1108,7 +1108,7 @@ func testTLFJournalFlushOrdering(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	bid1, bCtx1, serverHalf1 := config.makeBlock([]byte{1})
 	bid2, bCtx2, serverHalf2 := config.makeBlock([]byte{2})
@@ -1196,7 +1196,7 @@ func testTLFJournalFlushOrderingAfterSquashAndCR(
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 	tlfJournal.forcedSquashByBytes = 20
 
 	firstRev := kbfsmd.Revision(10)
@@ -1335,7 +1335,7 @@ func testTLFJournalFlushInterleaving(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	var lock sync.Mutex
 	var puts []interface{}
@@ -1433,8 +1433,8 @@ func (tbcl testBranchChangeListener) onTLFBranchChange(_ tlf.ID, _ kbfsmd.Branch
 	tbcl.c <- struct{}{}
 }
 
-func testTLFJournalPauseBlocksAndConvertBranch(t *testing.T,
-	ctx context.Context, tlfJournal *tlfJournal, config *testTLFJournalConfig) (
+func testTLFJournalPauseBlocksAndConvertBranch(ctx context.Context,
+	t *testing.T, tlfJournal *tlfJournal, config *testTLFJournalConfig) (
 	firstRev kbfsmd.Revision, firstRoot kbfsmd.ID,
 	retUnpauseBlockPutCh chan<- struct{}, retErrCh <-chan error,
 	blocksLeftAfterFlush uint64, mdsLeftAfterFlush uint64) {
@@ -1519,10 +1519,10 @@ func testTLFJournalConvertWhileFlushing(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	_, _, unpauseBlockPutCh, errCh, blocksLeftAfterFlush, mdsLeftAfterFlush :=
-		testTLFJournalPauseBlocksAndConvertBranch(t, ctx, tlfJournal, config)
+		testTLFJournalPauseBlocksAndConvertBranch(ctx, t, tlfJournal, config)
 
 	// Now finish the block put, and let the flush finish.  We
 	// should be on a local squash branch after this.
@@ -1545,11 +1545,11 @@ func testTLFJournalSquashWhileFlushing(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	firstRev, firstPrevRoot, unpauseBlockPutCh, errCh,
 		blocksLeftAfterFlush, _ :=
-		testTLFJournalPauseBlocksAndConvertBranch(t, ctx, tlfJournal, config)
+		testTLFJournalPauseBlocksAndConvertBranch(ctx, t, tlfJournal, config)
 
 	// While it's paused, resolve the branch.
 	resolveMD := config.makeMD(firstRev, firstPrevRoot)
@@ -1590,7 +1590,7 @@ func testTLFJournalFlushRetry(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	// Stop the current background loop; replace with one that retries
 	// immediately.
@@ -1640,7 +1640,7 @@ func testTLFJournalResolveBranch(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	var bids []kbfsblock.ID
 	for i := 0; i < 3; i++ {
@@ -1722,7 +1722,7 @@ func testTLFJournalSquashByBytes(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 	tlfJournal.forcedSquashByBytes = 10
 
 	data := make([]byte, tlfJournal.forcedSquashByBytes+1)
@@ -1756,7 +1756,7 @@ func testTLFJournalFirstRevNoSquash(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 	tlfJournal.forcedSquashByBytes = 10
 
 	data := make([]byte, tlfJournal.forcedSquashByBytes+1)
@@ -1806,7 +1806,7 @@ func testTLFJournalSingleOp(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalSingleOpBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
-		tempdir, config, ctx, cancel, tlfJournal, delegate)
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
 
 	var mdserver shimMDServer
 	config.mdserver = &mdserver

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -134,7 +134,7 @@ func checkPendingOp(ctx context.Context,
 }
 
 func testListWithFilterAndUsername(
-	t *testing.T, ctx context.Context, sfs *SimpleFS, path keybase1.Path,
+	ctx context.Context, t *testing.T, sfs *SimpleFS, path keybase1.Path,
 	filter keybase1.ListFilter, username string, expectedEntries ...string) {
 	opid, err := sfs.SimpleFSMakeOpid(ctx)
 	require.NoError(t, err)
@@ -171,10 +171,10 @@ func testListWithFilterAndUsername(
 }
 
 func testList(
-	t *testing.T, ctx context.Context, sfs *SimpleFS, path keybase1.Path,
+	ctx context.Context, t *testing.T, sfs *SimpleFS, path keybase1.Path,
 	expectedEntries ...string) {
 	testListWithFilterAndUsername(
-		t, ctx, sfs, path, keybase1.ListFilter_NO_FILTER, "jdoe",
+		ctx, t, sfs, path, keybase1.ListFilter_NO_FILTER, "jdoe",
 		expectedEntries...)
 }
 
@@ -211,17 +211,17 @@ func TestList(t *testing.T) {
 
 	pathRoot := keybase1.NewPathWithKbfs(`/`)
 	testListWithFilterAndUsername(
-		t, ctx, sfs, pathRoot, keybase1.ListFilter_NO_FILTER, "",
+		ctx, t, sfs, pathRoot, keybase1.ListFilter_NO_FILTER, "",
 		"private", "public", "team")
 
 	pathPrivate := keybase1.NewPathWithKbfs(`/private`)
 	testListWithFilterAndUsername(
-		t, ctx, sfs, pathPrivate, keybase1.ListFilter_NO_FILTER, "",
+		ctx, t, sfs, pathPrivate, keybase1.ListFilter_NO_FILTER, "",
 		"jdoe")
 
 	t.Log("List directory before it's created")
 	path1 := keybase1.NewPathWithKbfs(`/private/jdoe`)
-	testList(t, ctx, sfs, path1)
+	testList(ctx, t, sfs, path1)
 
 	t.Log("Shouldn't have created the TLF")
 	h, err := tlfhandle.ParseHandle(
@@ -245,17 +245,17 @@ func TestList(t *testing.T) {
 	writeRemoteFile(ctx, t, sfs, pathAppend(path1, `.testfile`), []byte(`foo`))
 
 	testListWithFilterAndUsername(
-		t, ctx, sfs, path1, keybase1.ListFilter_FILTER_ALL_HIDDEN, "jdoe",
+		ctx, t, sfs, path1, keybase1.ListFilter_FILTER_ALL_HIDDEN, "jdoe",
 		"test1.txt", "test2.txt")
 
-	testList(t, ctx, sfs, pathAppend(path1, `test1.txt`), "test1.txt")
+	testList(ctx, t, sfs, pathAppend(path1, `test1.txt`), "test1.txt")
 
 	// Check for hidden files too.
 	testList(
-		t, ctx, sfs, path1, "test1.txt", "test2.txt", ".testfile")
+		ctx, t, sfs, path1, "test1.txt", "test2.txt", ".testfile")
 
 	// A single, requested hidden file shows up even if the filter is on.
-	testList(t, ctx, sfs, pathAppend(path1, `.testfile`), ".testfile")
+	testList(ctx, t, sfs, pathAppend(path1, `.testfile`), ".testfile")
 
 	// Test that the first archived revision shows no directory entries.
 	pathArchivedRev1 := keybase1.NewPathWithKbfsArchived(
@@ -263,14 +263,14 @@ func TestList(t *testing.T) {
 			Path:          `/private/jdoe`,
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRevision(1),
 		})
-	testList(t, ctx, sfs, pathArchivedRev1)
+	testList(ctx, t, sfs, pathArchivedRev1)
 
 	pathArchivedRev2 := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
 			Path:          `/private/jdoe`,
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRevision(2),
 		})
-	testList(t, ctx, sfs, pathArchivedRev2, "test1.txt")
+	testList(ctx, t, sfs, pathArchivedRev2, "test1.txt")
 
 	// Same test, with by-time archived paths.
 	pathArchivedTime := keybase1.NewPathWithKbfsArchived(
@@ -279,7 +279,7 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithTime(
 				keybase1.ToTime(rev1Time)),
 		})
-	testList(t, ctx, sfs, pathArchivedTime)
+	testList(ctx, t, sfs, pathArchivedTime)
 
 	pathArchivedTimeString := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
@@ -287,7 +287,7 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithTimeString(
 				rev1Time.String()),
 		})
-	testList(t, ctx, sfs, pathArchivedTimeString)
+	testList(ctx, t, sfs, pathArchivedTimeString)
 
 	pathArchivedRelTimeString := keybase1.NewPathWithKbfsArchived(
 		keybase1.KBFSArchivedPath{
@@ -295,10 +295,10 @@ func TestList(t *testing.T) {
 			ArchivedParam: keybase1.NewKBFSArchivedParamWithRelTimeString(
 				"45s"),
 		})
-	testList(t, ctx, sfs, pathArchivedRelTimeString)
+	testList(ctx, t, sfs, pathArchivedRelTimeString)
 
 	clock.Add(1 * time.Minute)
-	testList(t, ctx, sfs, pathArchivedRelTimeString, "test1.txt")
+	testList(ctx, t, sfs, pathArchivedRelTimeString, "test1.txt")
 }
 
 func TestListRecursive(t *testing.T) {
@@ -880,7 +880,7 @@ func TestRemove(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(t, ctx, sfs, pathKbfs, "test.txt")
+	testList(ctx, t, sfs, pathKbfs, "test.txt")
 
 	t.Log("Remove the file")
 	pathFile := keybase1.NewPathWithKbfs("/private/jdoe/test.txt")
@@ -898,7 +898,7 @@ func TestRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's gone")
-	testList(t, ctx, sfs, pathKbfs)
+	testList(ctx, t, sfs, pathKbfs)
 }
 
 func TestRemoveRecursive(t *testing.T) {
@@ -919,7 +919,7 @@ func TestRemoveRecursive(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the files are there")
-	testList(t, ctx, sfs, pathDir, "test1.txt", "test2.txt", "b")
+	testList(ctx, t, sfs, pathDir, "test1.txt", "test2.txt", "b")
 
 	t.Log("Remove dir without recursion, expect error")
 	opid, err := sfs.SimpleFSMakeOpid(ctx)
@@ -951,7 +951,7 @@ func TestRemoveRecursive(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's gone")
-	testList(t, ctx, sfs, pathKbfs)
+	testList(ctx, t, sfs, pathKbfs)
 }
 
 func TestMoveWithinTlf(t *testing.T) {
@@ -967,7 +967,7 @@ func TestMoveWithinTlf(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(t, ctx, sfs, pathKbfs, "test1.txt")
+	testList(ctx, t, sfs, pathKbfs, "test1.txt")
 
 	t.Log("Move the file")
 	pathFileOld := pathAppend(pathKbfs, "test1.txt")
@@ -987,7 +987,7 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(t, ctx, sfs, pathKbfs, "test2.txt")
+	testList(ctx, t, sfs, pathKbfs, "test2.txt")
 
 	t.Log("Move into subdir")
 	pathDir := pathAppend(pathKbfs, "a")
@@ -1009,8 +1009,8 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(t, ctx, sfs, pathKbfs, "a")
-	testList(t, ctx, sfs, pathDir, "test3.txt")
+	testList(ctx, t, sfs, pathKbfs, "a")
+	testList(ctx, t, sfs, pathDir, "test3.txt")
 
 	t.Log("Move into different, parallel subdir")
 	pathDirB := pathAppend(pathKbfs, "b")
@@ -1034,8 +1034,8 @@ func TestMoveWithinTlf(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Make sure it's moved")
-	testList(t, ctx, sfs, pathDir)
-	testList(t, ctx, sfs, pathDirC, "test3.txt")
+	testList(ctx, t, sfs, pathDir)
+	testList(ctx, t, sfs, pathDirC, "test3.txt")
 }
 
 func TestMoveBetweenTlfs(t *testing.T) {
@@ -1051,7 +1051,7 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/private/jdoe")
 
 	t.Log("Make sure the file is there")
-	testList(t, ctx, sfs, pathPrivate, "test1.txt")
+	testList(ctx, t, sfs, pathPrivate, "test1.txt")
 
 	t.Log("Move the file")
 	pathFileOld := pathAppend(pathPrivate, "test1.txt")
@@ -1073,8 +1073,8 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/public/jdoe")
 
 	t.Log("Make sure it's moved")
-	testList(t, ctx, sfs, pathPrivate)
-	testList(t, ctx, sfs, pathPublic, "test2.txt")
+	testList(ctx, t, sfs, pathPrivate)
+	testList(ctx, t, sfs, pathPublic, "test2.txt")
 
 	t.Log("Now move a whole populated directory")
 	pathDir := pathAppend(pathPrivate, "a")
@@ -1101,9 +1101,9 @@ func TestMoveBetweenTlfs(t *testing.T) {
 	syncFS(ctx, t, sfs, "/public/jdoe")
 
 	t.Log("Make sure it's moved (one file was overwritten)")
-	testList(t, ctx, sfs, pathPrivate)
-	testList(t, ctx, sfs, pathPublic, "test1.txt", "test2.txt", "b")
-	testList(t, ctx, sfs, pathAppend(pathPublic, "b"), "test3.txt")
+	testList(ctx, t, sfs, pathPrivate)
+	testList(ctx, t, sfs, pathPublic, "test1.txt", "test2.txt", "b")
+	testList(ctx, t, sfs, pathAppend(pathPublic, "b"), "test3.txt")
 	require.Equal(t, "2",
 		string(readRemoteFile(
 			ctx, t, sfs, pathAppend(pathPublic, "test2.txt"))))


### PR DESCRIPTION
The former due to some CI flakes, the latter because `go-lint` was being annoying about the former.