### PR TITLE
favorites: adjust TLF mtimes based on the edit history times

### DIFF
--- a/go/kbfs/libkbfs/favorites.go
+++ b/go/kbfs/libkbfs/favorites.go
@@ -331,11 +331,8 @@ func (f *Favorites) crossCheckWithEditHistory() {
 		if minTime == 0 || h.ServerTime < minTime {
 			minTime = h.ServerTime
 		}
-		// Seems like the mtime in the favorites list is incorrectly
-		// in seconds, rather than milliseconds as a `keybase1.Time`
-		// is supposed to be.
-		if data.TlfMtime == nil || (*data.TlfMtime)*1000 > h.ServerTime {
-			t := h.ServerTime / 1000
+		if data.TlfMtime == nil || *data.TlfMtime > h.ServerTime {
+			t := h.ServerTime
 			data.TlfMtime = &t
 			f.favCache[fav] = data
 		}
@@ -346,8 +343,8 @@ func (f *Favorites) crossCheckWithEditHistory() {
 	// history.
 	if minTime > 0 {
 		for fav, data := range tlfsWithNoHistory {
-			if (*data.TlfMtime)*1000 > minTime {
-				t := minTime/1000 - 1
+			if *data.TlfMtime > minTime {
+				t := minTime - 1
 				data.TlfMtime = &t
 				f.favCache[fav] = data
 			}

--- a/go/kbfs/libkbfs/favorites.go
+++ b/go/kbfs/libkbfs/favorites.go
@@ -309,9 +309,14 @@ func (f *Favorites) crossCheckWithEditHistory() {
 	// weirdness here though, it might be worth revisiting that
 	// assumption.
 
-	// Fix the favorite times to be the latest known edit history
-	// times, if possible.  If not possible, set them to be lower than
-	// the minimum known time, if they're not already.
+	// The mtime attached to the favorites data returned by the API
+	// server is updated both on git activity, background collection,
+	// and pure deletion ops, none of which add new interesting
+	// content to the TLF.  So, fix the favorite times to be the
+	// latest known edit history times, if possible.  If not possible,
+	// that means the TLF is definitely not included in the latest
+	// list of TLF edit activity; so set these to be lower than the
+	// minimum known time, if they're not already.
 	var minTime keybase1.Time
 	uh := f.config.UserHistory()
 	tlfsWithNoHistory := make(map[favorites.Folder]favorites.Data)


### PR DESCRIPTION
To avoid counting GC and git modifications in the favorite mtimes used to sort folders, cross-check them with the time of of the corresponding edit history.  If the favorites time is newer, we can safely set it to the edit history time.  If we don't yet know the edit history of the TLF, that means it's not in the most recent edit history list, and we can just set the time to be below the oldest known time, to keep it below the most-recently-edited TLFs in the sorted list.

Apparently the favorite mtime is incorrectly in seconds, rather than in milliseconds, so some math is required.

Issue: KBFS-4200