### PR TITLE
First pass at removing unnecessary @ts-ignore comments

### DIFF
--- a/shared/actions/__tests__/add-new-device.tsx
+++ b/shared/actions/__tests__/add-new-device.tsx
@@ -211,7 +211,6 @@ describe('reply with device type', () => {
     expect(() =>
       makeInit({
         initialStore: {
-          // @ts-ignore codemod issue
           provision: Constants.makeState({
             codePageOtherDeviceType: 'backup',
           } as any),

--- a/shared/actions/__tests__/provision.test.tsx
+++ b/shared/actions/__tests__/provision.test.tsx
@@ -57,7 +57,6 @@ const startReduxSaga = (initialStore = undefined) => {
     },
   })
   const store = createStore(rootReducer, initialStore, applyMiddleware(sagaMiddleware))
-  // @ts-ignore codemod-issue
   const getState: () => any = store.getState
   const dispatch = store.dispatch
   sagaMiddleware.run(provisionSaga)
@@ -196,7 +195,6 @@ describe('device name empty', () => {
     payload: {errorMessage: '', existingDevices: null},
   })
 
-  // @ts-ignore codemod-issue
   const {getState}: {getState: () => any} = init
   expect(getState().provision.existingDevices).toEqual(existingDevices)
   expect(getState().provision.error).toEqual(noError)

--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -7,7 +7,6 @@ import * as RPCChatTypes from '../constants/types/rpc-chat-gen'
 import * as Types from '../constants/types/chat2'
 import * as TeamsTypes from '../constants/types/teams'
 import HiddenString from '../util/hidden-string'
-// @ts-ignore until constants is converted
 import {RetentionPolicy} from '../constants/types/retention-policy'
 
 // Constants

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -26,7 +26,6 @@ import chatTeamBuildingSaga from './team-building'
 import * as TeamsConstants from '../../constants/teams'
 import logger from '../../logger'
 import {isMobile} from '../../constants/platform'
-// @ts-ignore codemod-issue
 import {NotifyPopup} from '../../native/notifications'
 import {saveAttachmentToCameraRoll, showShareActionSheetFromFile} from '../platform-specific'
 import {downloadFilePath} from '../../util/file'
@@ -1122,7 +1121,6 @@ function* loadMoreMessages(
       incomingCallMap: {
         // @ts-ignore
         'chat.1.chatUi.chatThreadCached': p => onGotThread(p, 'cached'),
-        // @ts-ignore
         'chat.1.chatUi.chatThreadFull': p => onGotThread(p, 'full'),
       },
       params: {
@@ -2700,7 +2698,6 @@ const setMinWriterRole = (_, action: Chat2Gen.SetMinWriterRolePayload, logger) =
   logger.info(`Setting minWriterRole to ${role} for convID ${conversationIDKey}`)
   return RPCChatTypes.localSetConvMinWriterRoleLocalRpcPromise({
     convID: Types.keyToConversationID(conversationIDKey),
-    // @ts-ignore for now while constants is untyped codemod-issue
     role: RPCTypes.TeamRole[role],
   }).then(() => {})
 }
@@ -2803,7 +2800,6 @@ const onChatCommandMarkdown = (status, action: EngineGen.Chat1ChatUiChatCommandM
 }
 
 const onChatMaybeMentionUpdate = (state, action: EngineGen.Chat1ChatUiChatMaybeMentionUpdatePayload) => {
-  // @ts-ignore codemod issue - investigate
   const {teamName, channel, info} = action.payload.params
   return Chat2Gen.createSetMaybeMentionInfo({
     info,

--- a/shared/actions/fs/common.native.tsx
+++ b/shared/actions/fs/common.native.tsx
@@ -4,11 +4,9 @@ import * as Types from '../../constants/types/fs'
 import * as Saga from '../../util/saga'
 import * as Flow from '../../util/flow'
 import {TypedState} from '../../constants/reducer'
-// @ts-ignore codemod-issue
 import ImagePicker from 'react-native-image-picker'
 import {isIOS} from '../../constants/platform'
 import {makeRetriableErrorHandler} from './shared'
-// @ts-ignore
 import {saveAttachmentDialog, showShareActionSheetFromURL} from '../platform-specific'
 import {types} from '@babel/core'
 
@@ -65,7 +63,6 @@ const downloadSuccess = (state, action: FsGen.DownloadSuccessPayload) => {
     case Types.DownloadIntent.None:
       return
     default:
-      // @ts-ignore codemod-issue
       Flow.ifFlowComplainsAboutThisFunctionYouHaventHandledAllCasesInASwitch(intent)
   }
 }

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -271,11 +271,13 @@ function* folderList(_, action: FsGen.FolderListLoadPayload | FsGen.EditSuccessP
   }
 
   try {
+    // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
     yield Saga.put(FsGen.createLoadingPath({done: false, id: loadingPathID, path: rootPath}))
 
     const opID = Constants.makeUUID()
     const pathElems = Types.getPathElements(rootPath)
     if (pathElems.length < 3) {
+      // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
       yield* Saga.callPromise(RPCTypes.SimpleFSSimpleFSListRpcPromise, {
         filter: RPCTypes.ListFilter.filterSystemHidden,
         opID,
@@ -283,6 +285,7 @@ function* folderList(_, action: FsGen.FolderListLoadPayload | FsGen.EditSuccessP
         refreshSubscription: !!refreshTag,
       })
     } else {
+      // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
       yield* Saga.callPromise(RPCTypes.SimpleFSSimpleFSListRecursiveToDepthRpcPromise, {
         depth: 1,
         filter: RPCTypes.ListFilter.filterSystemHidden,
@@ -292,8 +295,10 @@ function* folderList(_, action: FsGen.FolderListLoadPayload | FsGen.EditSuccessP
       })
     }
 
+    // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
     yield* Saga.callPromise(RPCTypes.SimpleFSSimpleFSWaitRpcPromise, {opID})
 
+    // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
     const result = yield* Saga.callPromise(RPCTypes.SimpleFSSimpleFSReadListRpcPromise, {opID})
     const entries = result.entries || []
     const childMap = entries.reduce((m, d) => {
@@ -356,6 +361,7 @@ function* folderList(_, action: FsGen.FolderListLoadPayload | FsGen.EditSuccessP
   } catch (error) {
     yield makeRetriableErrorHandler(action, rootPath)(error).map(action => Saga.put(action))
   } finally {
+    // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
     yield Saga.put(FsGen.createLoadingPath({done: true, id: loadingPathID, path: rootPath}))
   }
 }
@@ -410,12 +416,14 @@ function* download(state, action: FsGen.DownloadPayload | FsGen.ShareNativePaylo
       intent,
       key,
       localPath,
+      // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
       opID,
       path,
       // Omit entryType to let reducer figure out.
     })
   )
 
+  // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
   yield* Saga.callPromise(RPCTypes.SimpleFSSimpleFSCopyRecursiveRpcPromise, {
     dest: {
       PathType: RPCTypes.PathType.local,
@@ -427,7 +435,9 @@ function* download(state, action: FsGen.DownloadPayload | FsGen.ShareNativePaylo
 
   try {
     yield Saga.race({
+      // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
       monitor: Saga.callUntyped(monitorDownloadProgress, key, opID),
+      // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
       wait: Saga.callUntyped(RPCTypes.SimpleFSSimpleFSWaitRpcPromise, {opID}),
     })
 
@@ -466,6 +476,7 @@ function* upload(_, action: FsGen.UploadPayload) {
 
   // TODO: confirm overwrites?
   // TODO: what about directory merges?
+  // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
   yield* Saga.callPromise(RPCTypes.SimpleFSSimpleFSCopyRecursiveRpcPromise, {
     dest: Constants.pathToRPCPath(path),
     opID,
@@ -476,6 +487,7 @@ function* upload(_, action: FsGen.UploadPayload) {
   })
 
   try {
+    // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
     yield* Saga.callPromise(RPCTypes.SimpleFSSimpleFSWaitRpcPromise, {opID})
     yield Saga.put(FsGen.createUploadWritingSuccess({path}))
   } catch (error) {
@@ -703,6 +715,7 @@ const commitEdit = (state, action: FsGen.CommitEditPayload): Promise<Saga.MaybeA
       return RPCTypes.SimpleFSSimpleFSOpenRpcPromise({
         dest: Constants.pathToRPCPath(Types.pathConcat(parentPath, name)),
         flags: RPCTypes.OpenFlags.directory,
+        // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
         opID: Constants.makeUUID(),
       })
         .then(() => FsGen.createEditSuccess({editID, parentPath}))
@@ -764,10 +777,12 @@ const deleteFile = (state, action: FsGen.DeleteFilePayload) => {
   const opID = Constants.makeUUID()
   return (
     RPCTypes.SimpleFSSimpleFSRemoveRpcPromise({
+      // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
       opID,
       path: Constants.pathToRPCPath(action.payload.path),
       recursive: true,
     })
+      // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
       .then(() => RPCTypes.SimpleFSSimpleFSWaitRpcPromise({opID}))
       .catch(makeRetriableErrorHandler(action, action.payload.path))
   )
@@ -787,6 +802,7 @@ const moveOrCopy = (state, action: FsGen.MovePayload | FsGen.CopyPayload) => {
         // We use the local path name here since we only care about file name.
       )
     ),
+    // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
     opID: Constants.makeUUID() as string,
     src:
       state.fs.destinationPicker.source.type === Types.DestinationPickerSource.MoveOrCopy

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -4,7 +4,6 @@
     "import * as Types from '../constants/types/chat2'",
     "import * as TeamsTypes from '../constants/types/teams'",
     "import HiddenString from '../util/hidden-string'",
-    "// @ts-ignore until constants is converted",
     "import {RetentionPolicy} from '../constants/types/retention-policy'"
   ],
   "actions": {

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -2,7 +2,6 @@
   "prelude": [
     "import * as ChatTypes from '../constants/types/chat2'",
     "import * as Types from '../constants/types/teams'",
-    "// @ts-ignore until constants is converted",
     "import {RetentionPolicy} from '../constants/types/retention-policy'"
   ],
   "actions": {

--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -7,7 +7,6 @@ import * as SafeElectron from '../../util/safe-electron.desktop'
 import * as Saga from '../../util/saga'
 import logger from '../../logger'
 import path from 'path'
-// @ts-ignore codemod-issue
 import {NotifyPopup} from '../../native/notifications'
 import {execFile} from 'child_process'
 import {getEngine} from '../../engine'
@@ -267,7 +266,6 @@ const onOutOfDate = (_, action: EngineGen.Keybase1NotifySessionClientOutOfDatePa
 const prepareLogSend = (_, action: EngineGen.Keybase1LogsendPrepareLogsendPayload) => {
   const response = action.payload.response
   dumpLogs().then(() => {
-    // @ts-ignore codemod-issue
     response && response.result()
   })
 }

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -5,7 +5,6 @@ import * as I from 'immutable'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as ChatTypes from '../constants/types/chat2'
 import * as Types from '../constants/types/teams'
-// @ts-ignore until constants is converted
 import {RetentionPolicy} from '../constants/types/retention-policy'
 
 // Constants

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -206,7 +206,6 @@ const saveTeamRetentionPolicy = (state, action: TeamsGen.SaveTeamRetentionPolicy
     throw new Error(errMsg)
   }
 
-  // @ts-ignore codemod-issue
   let servicePolicy: RPCChatTypes.RetentionPolicy
   try {
     servicePolicy = Constants.retentionPolicyToServiceRetentionPolicy(policy)
@@ -245,7 +244,6 @@ function* inviteByEmail(_, action: TeamsGen.InviteToTeamByEmailPayload, logger) 
       {
         emails: invitees,
         name: teamname,
-        // @ts-ignore codemod-issue
         role: (role ? RPCTypes.TeamRole[role] : RPCTypes.TeamRole.none) as any,
       },
       [Constants.teamWaitingKey(teamname), Constants.addToTeamByEmailWaitingKey(teamname)]
@@ -307,7 +305,6 @@ const addToTeam = (_, action: TeamsGen.AddToTeamPayload) => {
     {
       email: '',
       name: teamname,
-      // @ts-ignore codemod fix when constants is typed
       role: role ? RPCTypes.TeamRole[role] : RPCTypes.TeamRole.none,
       sendChatNotification,
       username,
@@ -374,7 +371,6 @@ const editMembership = (_, action: TeamsGen.EditMembershipPayload) => {
   return RPCTypes.teamsTeamEditMemberRpcPromise(
     {
       name: teamname,
-      // @ts-ignore codemod fix when constants is typed
       role: role ? RPCTypes.TeamRole[role] : RPCTypes.TeamRole.none,
       username,
     },
@@ -434,7 +430,6 @@ const inviteToTeamByPhone = (_, action: TeamsGen.InviteToTeamByPhonePayload, log
     {
       label: {sms: {f: fullName || '', n: phoneNumber} as RPCTypes.SeitanKeyLabelSms, t: 1},
       name: teamname,
-      // @ts-ignore codemod fix when constants is typed
       role: (!!role && RPCTypes.TeamRole[role]) || RPCTypes.TeamRole.none,
     },
     Constants.teamWaitingKey(teamname)
@@ -544,7 +539,6 @@ function* getDetails(_, action: TeamsGen.GetDetailsPayload, logger) {
     if (Constants.getCanPerform(state, teamname).manageMembers) {
       // TODO (DESKTOP-6478) move this somewhere else
       requests = yield* Saga.callPromise(
-        // @ts-ignore codemod issue
         RPCTypes.teamsTeamListRequestsRpcPromise as (arg: any) => any,
         {
           teamName: teamname,
@@ -597,7 +591,6 @@ function* getDetails(_, action: TeamsGen.GetDetailsPayload, logger) {
 
     // Get the subteam map for this team.
     const {entries} = yield* Saga.callPromise(
-      // @ts-ignore codemod-issue
       RPCTypes.teamsTeamGetSubteamsRpcPromise as (args: any) => any,
       {name: {parts: teamname.split('.')}},
       waitingKeys
@@ -631,7 +624,6 @@ function* addUserToTeams(state, action: TeamsGen.AddUserToTeamsPayload) {
   for (const team of teams) {
     try {
       yield* Saga.callPromise(
-        // @ts-ignore codemod-issue
         RPCTypes.teamsTeamAddMemberRpcPromise as (args: any) => any,
         {
           email: '',
@@ -1053,7 +1045,6 @@ function* setPublicity(state, action: TeamsGen.SetPublicityPayload) {
           {
             name: teamname,
             settings: {
-              // @ts-ignore codemod fix when constants is typed
               joinAs: RPCTypes.TeamRole[settings.openTeamRole],
               open: settings.openTeam,
             },
@@ -1257,7 +1248,6 @@ function* addTeamWithChosenChannels(state, action: TeamsGen.AddTeamWithChosenCha
     logger.info(`${logPrefix} Creating teamsWithChosenChannels`)
   }
   yield* Saga.callPromise(
-    // @ts-ignore codemod-issue
     RPCTypes.gregorUpdateCategoryRpcPromise as (args: any) => any,
     {
       body: JSON.stringify(teams),

--- a/shared/chat/conversation/input-area/normal/index.stories.tsx
+++ b/shared/chat/conversation/input-area/normal/index.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as Sb from '../../../../stories/storybook'
 import {List, Set} from 'immutable'
-// @ts-ignore
 import {Box2} from '../../../../common-adapters/box'
 import {platformStyles} from '../../../../styles'
 import Input, {Props as InputProps} from '.'

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import * as Kb from '../../../../common-adapters'
 import * as Styles from '../../../../styles'
 import {Picker} from 'emoji-mart'
-// @ts-ignore
 import {backgroundImageFn} from '../../../../common-adapters/emoji'
 import SetExplodingMessagePopup from '../../messages/set-explode-popup/container'
 import {formatDurationShort} from '../../../../util/timestamp'

--- a/shared/chat/conversation/input-area/suggestors/index.stories.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.stories.tsx
@@ -72,7 +72,6 @@ const typingTests = () => {
   test = <TestArea {...extraJunk} />
 
   const testAreaFunc = (props: TestAreaProps) => {}
-  // @ts-ignore should error (not a class)
   AddSuggestors(testAreaFunc)
 }
 

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -109,10 +109,8 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
       // @ts-ignore thinks this is ready only: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
       this._attachmentRef.current = r
       if (typeof this.props.forwardedRef === 'function') {
-        // @ts-ignore thinks this is ready only: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
         this.props.forwardedRef(r)
       } else if (this.props.forwardedRef && typeof this.props.forwardedRef !== 'string') {
-        // @ts-ignore thinks this is ready only: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
         this.props.forwardedRef.current = r
       } // intentionally not supporting string refs
     }

--- a/shared/chat/conversation/list-area/normal/container.tsx
+++ b/shared/chat/conversation/list-area/normal/container.tsx
@@ -95,7 +95,6 @@ export default compose(
     mergeProps
   ),
   withStateHandlers(
-    // @ts-ignore don't use recompose
     {
       _conversationIDKey: Constants.noConversationIDKey,
       _lastLoadMoreOrdinalTime: Date.now(),

--- a/shared/chat/conversation/maybe-mention/index.tsx
+++ b/shared/chat/conversation/maybe-mention/index.tsx
@@ -3,7 +3,6 @@ import * as Styles from '../../../styles'
 import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
 import * as Constants from '../../../constants/chat2'
 import * as Chat2Gen from '../../../actions/chat2-gen'
-// @ts-ignore
 import Text from '../../../common-adapters/text'
 import {namedConnect} from '../../../util/container'
 import Mention from '../../../common-adapters/mention-container'

--- a/shared/chat/conversation/maybe-mention/team.tsx
+++ b/shared/chat/conversation/maybe-mention/team.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
-// @ts-ignore
 import Text from '../../../common-adapters/text'
-// @ts-ignore
 import {Box2} from '../../../common-adapters/box'
 import * as Styles from '../../../styles'
 import TeamInfo from '../../../profile/user/teams/teaminfo'

--- a/shared/chat/conversation/maybe-mention/unknown.tsx
+++ b/shared/chat/conversation/maybe-mention/unknown.tsx
@@ -1,11 +1,7 @@
 import React from 'react'
-// @ts-ignore
 import Text from '../../../common-adapters/text'
-// @ts-ignore
 import Button from '../../../common-adapters/button'
-// @ts-ignore
 import {Box2} from '../../../common-adapters/box'
-// @ts-ignore
 import FloatingMenu from '../../../common-adapters/floating-menu'
 import * as Styles from '../../../styles'
 

--- a/shared/chat/conversation/messages/message-popup/attachment/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment/container.tsx
@@ -7,7 +7,6 @@ import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import {getCanPerform} from '../../../../../constants/teams'
 import {connect} from '../../../../../util/container'
 import {isMobile, isIOS} from '../../../../../constants/platform'
-// @ts-ignore
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
 import {StylesCrossPlatform} from '../../../../../styles/css'
 import Attachment from '.'

--- a/shared/chat/conversation/messages/message-popup/attachment/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment/index.tsx
@@ -3,7 +3,6 @@ import MessagePopupHeader from '../header'
 import {FloatingMenu} from '../../../../../common-adapters/'
 import {fileUIName, StylesCrossPlatform} from '../../../../../styles'
 import {DeviceType} from '../../../../../constants/types/devices'
-// @ts-ignore
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
 
 type Props = {

--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -8,7 +8,6 @@ import * as FsGen from '../../../../../actions/fs-gen'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import {namedConnect, isMobile} from '../../../../../util/container'
 import {isIOS} from '../../../../../constants/platform'
-// @ts-ignore
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
 import {StylesCrossPlatform} from '../../../../../styles/css'
 import Exploding from '.'

--- a/shared/chat/conversation/messages/message-popup/exploding/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/index.tsx
@@ -14,10 +14,8 @@ import {
 import * as Styles from '../../../../../styles'
 import {formatTimeForPopup, formatTimeForRevoked, msToDHMS} from '../../../../../util/timestamp'
 import {addTicker, removeTicker, TickerID} from '../../../../../util/second-timer'
-// @ts-ignore
 import {MenuItem} from '../../../../../common-adapters/floating-menu/menu-layout'
 import {DeviceType} from '../../../../../constants/types/devices'
-// @ts-ignore
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
 
 const headerIconType = Styles.isMobile ? 'icon-fancy-bomb-mobile-226-96' : 'icon-fancy-bomb-desktop-150-72'

--- a/shared/chat/conversation/messages/message-popup/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/index.tsx
@@ -4,7 +4,6 @@ import AttachmentMessage from './attachment/container'
 import TextMessage from './text/container'
 import ExplodingMessage from './exploding/container'
 import PaymentMessage from './payment/container'
-// @ts-ignore
 import {Position} from '../../../../common-adapters/relative-popup-hoc.types'
 import {StylesCrossPlatform} from '../../../../styles/css'
 

--- a/shared/chat/conversation/messages/message-popup/payment/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/container.tsx
@@ -8,7 +8,6 @@ import * as WalletGen from '../../../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import {formatTimeForMessages} from '../../../../../util/timestamp'
 import PaymentPopup from '.'
-// @ts-ignore
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
 import {StylesCrossPlatform} from '../../../../../styles/css'
 

--- a/shared/chat/conversation/messages/message-popup/payment/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/index.tsx
@@ -1,23 +1,14 @@
 import * as React from 'react'
 import {toUpper, upperFirst} from 'lodash-es'
 import * as Styles from '../../../../../styles'
-// @ts-ignore
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
-// @ts-ignore
 import {Box2} from '../../../../../common-adapters/box'
-// @ts-ignore
 import Text from '../../../../../common-adapters/text'
-// @ts-ignore
 import Icon, {castPlatformStyles as iconCastPlatformStyles} from '../../../../../common-adapters/icon'
-// @ts-ignore
 import Avatar from '../../../../../common-adapters/avatar'
-// @ts-ignore
 import ConnectedUsernames from '../../../../../common-adapters/usernames/container'
-// @ts-ignore
 import ProgressIndicator from '../../../../../common-adapters/progress-indicator'
-// @ts-ignore
 import Divider from '../../../../../common-adapters/divider'
-// @ts-ignore
 import FloatingMenu from '../../../../../common-adapters/floating-menu'
 
 // This is actually a dependency of common-adapters/markdown so we have to treat it like a common-adapter, no * import allowed

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -7,7 +7,6 @@ import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import * as Container from '../../../../../util/container'
 import {createShowUserProfile} from '../../../../../actions/profile-gen'
 import {getCanPerform} from '../../../../../constants/teams'
-// @ts-ignore
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
 import {StylesCrossPlatform} from '../../../../../styles/css'
 import Text from '.'

--- a/shared/chat/conversation/messages/message-popup/text/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import MessagePopupHeader from '../header'
 import {FloatingMenu} from '../../../../../common-adapters/'
 import {DeviceType} from '../../../../../constants/types/devices'
-// @ts-ignore
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
 import {StylesCrossPlatform} from '../../../../../styles/css'
 

--- a/shared/chat/conversation/messages/react-button/picker.desktop.tsx
+++ b/shared/chat/conversation/messages/react-button/picker.desktop.tsx
@@ -44,9 +44,7 @@ class Picker extends React.Component<Props> {
   }
 
   render() {
-    // @ts-ignore the type definition is actually incorrect
     const imageFn: any = this.props.backgroundImageFn
-    // @ts-ignore
     const clickFn: any = this.props.onClick
     return (
       <EmojiPicker

--- a/shared/chat/new-team-dialog-container.tsx
+++ b/shared/chat/new-team-dialog-container.tsx
@@ -41,10 +41,8 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 export default Container.compose(
   Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({...o, ...s, ...d})),
   Container.withStateHandlers(
-    // @ts-ignore NO recompose
     {name: ''},
     {
-      // @ts-ignore NO recompose
       onNameChange: () => (name: string) => ({name}),
       // @ts-ignore NO recompose
       onSubmit: (_, {_onCreateNewTeam}) => teamname => {

--- a/shared/chat/payments/status/error.tsx
+++ b/shared/chat/payments/status/error.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react'
 import * as Styles from '../../../styles'
-// @ts-ignore
 import {Box2} from '../../../common-adapters/box'
-// @ts-ignore
 import Divider from '../../../common-adapters/divider'
-// @ts-ignore
 import Text from '../../../common-adapters/text'
-// @ts-ignore
 import FloatingMenu from '../../../common-adapters/floating-menu'
 
 // This is actually a dependency of common-adapters/markdown so we have to treat it like a common-adapter, no * import allowed

--- a/shared/chat/payments/status/index.tsx
+++ b/shared/chat/payments/status/index.tsx
@@ -4,11 +4,8 @@ import * as Types from '../../../constants/types/chat2'
 import * as WalletTypes from '../../../constants/types/wallets'
 import {SendPaymentPopup} from '../../conversation/messages/message-popup/payment/container'
 import PaymentStatusError from './error'
-// @ts-ignore
 import Text from '../../../common-adapters/text'
-// @ts-ignore
 import {Box2} from '../../../common-adapters/box'
-// @ts-ignore
 import Icon from '../../../common-adapters/icon'
 
 // This is actually a dependency of common-adapters/markdown so we have to treat it like a common-adapter, no * import allowed

--- a/shared/common-adapters/confirm-modal/index.tsx
+++ b/shared/common-adapters/confirm-modal/index.tsx
@@ -4,7 +4,6 @@ import {Box, Box2} from '../box'
 import HeaderOrPopup from '../header-or-popup'
 import ButtonBar from '../button-bar'
 import Icon from '../icon'
-// @ts-ignore
 import ScrollView from '../scroll-view'
 import Text from '../text'
 import * as Styles from '../../styles'

--- a/shared/common-adapters/copy-text.tsx
+++ b/shared/common-adapters/copy-text.tsx
@@ -4,7 +4,6 @@ import {Box2} from './box'
 import Icon from './icon'
 import Button, {Props as ButtonProps} from './button'
 import Text from './text'
-// @ts-ignore
 import Toast from './toast'
 import HOCTimers, {PropsWithTimer} from './hoc-timers'
 import * as Styles from '../styles'

--- a/shared/common-adapters/copyable-text.native.tsx
+++ b/shared/common-adapters/copyable-text.native.tsx
@@ -97,5 +97,4 @@ const styleCopyToastText = {
   color: globalColors.white,
 }
 
-// @ts-ignore HOCTimers typing is wrong
 export default HOCTimers(CopyableText)

--- a/shared/common-adapters/dropdown.tsx
+++ b/shared/common-adapters/dropdown.tsx
@@ -3,10 +3,8 @@ import Box, {Box2} from './box'
 import ClickableBox from './clickable-box'
 import Text from './text'
 import Overlay from './overlay'
-// @ts-ignore
 import ScrollView from './scroll-view'
 import OverlayParentHOC, {OverlayParentProps} from './overlay/parent-hoc'
-// @ts-ignore
 import {Position} from './relative-popup-hoc.types'
 import Icon from './icon'
 import * as Styles from '../styles'

--- a/shared/common-adapters/error-boundary.tsx
+++ b/shared/common-adapters/error-boundary.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import Box from './box'
-// @ts-ignore
 import ScrollView from './scroll-view'
 import Text from './text'
 import Icon from './icon'

--- a/shared/common-adapters/floating-box/index.types.d.ts
+++ b/shared/common-adapters/floating-box/index.types.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {StylesCrossPlatform} from '../../styles/css'
-// @ts-ignore
 import {Position} from '../relative-popup-hoc.types'
 
 // GatewayDests:

--- a/shared/common-adapters/floating-menu/index.tsx
+++ b/shared/common-adapters/floating-menu/index.tsx
@@ -5,9 +5,7 @@
 // components inside of a popup have access to the mocked out Provider component
 
 import * as React from 'react'
-// @ts-ignore
 import Overlay from '../overlay'
-// @ts-ignore
 import {Position} from '../relative-popup-hoc.types'
 import MenuLayout, {MenuItem} from './menu-layout'
 import {StylesCrossPlatform} from '../../styles'

--- a/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
@@ -5,7 +5,6 @@ import Box, {Box2} from '../../box'
 import Text from '../../text'
 import Meta from '../../meta'
 import Divider from '../../divider'
-// @ts-ignore
 import ScrollView from '../../scroll-view'
 import {isLargeScreen} from '../../../constants/platform'
 import {MenuItem, MenuLayoutProps} from '.'

--- a/shared/common-adapters/form-with-checkbox.d.ts
+++ b/shared/common-adapters/form-with-checkbox.d.ts
@@ -1,7 +1,6 @@
 import React, {Component} from 'react'
 import {StylesCrossPlatform} from '../styles'
 import {Props as CheckboxProps} from './checkbox'
-// @ts-ignore
 import {Props as InputProps} from './input'
 
 // TODO: Do we really need this as a common component? It's used in

--- a/shared/common-adapters/form-with-checkbox.desktop.tsx
+++ b/shared/common-adapters/form-with-checkbox.desktop.tsx
@@ -1,7 +1,6 @@
 import React, {Component} from 'react'
 import Checkbox, {Props as CheckboxProps} from './checkbox'
 import {Props} from './form-with-checkbox'
-// @ts-ignore
 import Input from './input'
 import Box from './box'
 import Text from './text'

--- a/shared/common-adapters/form-with-checkbox.native.tsx
+++ b/shared/common-adapters/form-with-checkbox.native.tsx
@@ -1,6 +1,5 @@
 import Box from './box'
 import Checkbox, {Props as CheckboxProps} from './checkbox'
-// @ts-ignore
 import Input from './input'
 import React, {Component} from 'react'
 import {Props} from './form-with-checkbox'

--- a/shared/common-adapters/form-with-checkbox.stories.tsx
+++ b/shared/common-adapters/form-with-checkbox.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {Props as CheckboxProps} from './checkbox'
-// @ts-ignore
 import {Props as InputProps} from './input'
 import FormWithCheckbox from './form-with-checkbox'
 import {action, storiesOf} from '../stories/storybook'

--- a/shared/common-adapters/header-hoc/index.desktop.tsx
+++ b/shared/common-adapters/header-hoc/index.desktop.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import Text from '../text'
-// @ts-ignore
 import BackButton from '../back-button'
 import Box from '../box'
 import Icon from '../icon'

--- a/shared/common-adapters/header-hoc/index.native.tsx
+++ b/shared/common-adapters/header-hoc/index.native.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react'
 import Text from '../text'
-// @ts-ignore
 import BackButton from '../back-button'
 import Box from '../box'
 import FloatingMenu from '../floating-menu'
 import Icon from '../icon'
-// @ts-ignore
 import SafeAreaView, {SafeAreaViewTop} from '../safe-area-view'
 import * as Styles from '../../styles'
 import {Action, Props, LeftActionProps} from './types'

--- a/shared/common-adapters/header-or-popup.tsx
+++ b/shared/common-adapters/header-or-popup.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import {isMobile} from '../util/container'
 import HeaderHoc, {HeaderHocHeader} from './header-hoc'
-// @ts-ignore
 import PopupDialog from './popup-dialog'
 import * as Styles from '../styles'
 import {Props} from './header-or-popup.d'

--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -140,8 +140,6 @@ class Icon extends Component<Props, void> {
           <span
             style={Styles.collapseStyles([
               style,
-              // @ts-ignore the TS compiler doesn't know enough about symbols to
-              // know whether they can be used as keys - see https://github.com/Microsoft/TypeScript/issues/24587
               this.props.padding && Shared.paddingStyles[this.props.padding],
             ])}
             className={Styles.classNames(

--- a/shared/common-adapters/icon.native.tsx
+++ b/shared/common-adapters/icon.native.tsx
@@ -171,8 +171,6 @@ const _Icon = (p: Props, ref: any) => {
       activeOpacity={0.8}
       underlayColor={p.underlayColor || Styles.globalColors.white}
       ref={ref}
-      // @ts-ignore the TS compiler doesn't know enough about symbols to
-      // know whether they can be used as keys - see https://github.com/Microsoft/TypeScript/issues/24587
       style={Styles.collapseStyles([p.style, p.padding && Shared.paddingStyles[p.padding]])}
     >
       {icon}

--- a/shared/common-adapters/info-note.tsx
+++ b/shared/common-adapters/info-note.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Box, {Box2} from './box'
-// @ts-ignore not converted
 import Icon from './icon'
 import * as Styles from '../styles'
 

--- a/shared/common-adapters/input.d.ts
+++ b/shared/common-adapters/input.d.ts
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import {StylesCrossPlatform} from '../styles'
-// @ts-ignore not converted
 import {TextType} from './text'
-// @ts-ignore not converted
 import {TextContentType} from './plain-input'
 
 /**

--- a/shared/common-adapters/input.desktop.tsx
+++ b/shared/common-adapters/input.desktop.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Box from './box'
 import Text, {getStyle as getTextStyle} from './text.desktop'
 import {collapseStyles, globalStyles, globalColors, globalMargins, platformStyles} from '../styles'

--- a/shared/common-adapters/input.native.tsx
+++ b/shared/common-adapters/input.native.tsx
@@ -1,9 +1,7 @@
 // Known issues:
 // When input gets focus it shifts down 1 pixel when the cursor appears. This happens with a naked TextInput on RN...
 import React, {Component} from 'react'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import Text, {getStyle as getTextStyle} from './text.native'
 import {NativeTextInput} from './native-wrappers.native'
 import {collapseStyles, globalStyles, globalColors, styleSheetCreate} from '../styles'

--- a/shared/common-adapters/input.stories.tsx
+++ b/shared/common-adapters/input.stories.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import * as Sb from '../stories/storybook'
 import Button from './button'
 import Input, {Props} from './input'
-// @ts-ignore not converted
 import Box from './box'
 import {globalStyles} from '../styles'
 

--- a/shared/common-adapters/list-item.desktop.tsx
+++ b/shared/common-adapters/list-item.desktop.tsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react'
-// @ts-ignore not converted
 import Box from './box'
 import {globalStyles, desktopStyles} from '../styles'
 import {Props} from './list-item'

--- a/shared/common-adapters/list-item.native.tsx
+++ b/shared/common-adapters/list-item.native.tsx
@@ -1,8 +1,6 @@
 import React, {Component} from 'react'
 import {Props} from './list-item'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import ClickableBox from './clickable-box'
 import {globalStyles} from '../styles'
 

--- a/shared/common-adapters/list-item.stories.tsx
+++ b/shared/common-adapters/list-item.stories.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
 import * as Sb from '../stories/storybook'
 import ListItem from './list-item'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import Text from './text'
 import Button from './button'
 import {globalColors} from '../styles'

--- a/shared/common-adapters/list-item2.stories.tsx
+++ b/shared/common-adapters/list-item2.stories.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react'
 import * as Sb from '../stories/storybook'
 import ListItem from './list-item2'
-// @ts-ignore not converted
 import {Box2} from './box'
-// @ts-ignore not converted
 import Text from './text'
-// @ts-ignore not converted
 import Icon from './icon'
 import Button from './button'
 import {globalColors} from '../styles'

--- a/shared/common-adapters/list-item2.tsx
+++ b/shared/common-adapters/list-item2.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import * as Styles from '../styles'
-// @ts-ignore not converted
 import ClickableBox from './clickable-box'
-// @ts-ignore not converted
 import {Box2} from './box'
 import BoxGrow from './box-grow'
 import Divider from './divider'

--- a/shared/common-adapters/list.stories.tsx
+++ b/shared/common-adapters/list.stories.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react'
 import Button from './button'
-// @ts-ignore not converted
 import Box, {Box2} from './box'
-// @ts-ignore not converted
 import Text from './text'
-// @ts-ignore not converted
 import List2 from './list2'
 import * as Sb from '../stories/storybook'
 import * as Styles from '../styles'

--- a/shared/common-adapters/loading-line.desktop.tsx
+++ b/shared/common-adapters/loading-line.desktop.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore not converted
 import Box from './box'
 import * as React from 'react'
 import * as Styles from '../styles'

--- a/shared/common-adapters/loading-wrapper.native.tsx
+++ b/shared/common-adapters/loading-wrapper.native.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {Animated} from 'react-native'
-// @ts-ignore not converted
 import Box from './box'
 
 type Props = {

--- a/shared/common-adapters/markdown/react.tsx
+++ b/shared/common-adapters/markdown/react.tsx
@@ -5,7 +5,6 @@ import Text from '../text'
 import KbfsPath from './kbfs-path-container'
 import {MarkdownMeta, StyleOverride} from '.'
 import Box from '../box'
-// @ts-ignore
 import Emoji, {Props as EmojiProps} from '../emoji'
 import {emojiIndexByName} from './emoji-gen'
 import ServiceDecoration from './service-decoration'

--- a/shared/common-adapters/maybe-popup.tsx
+++ b/shared/common-adapters/maybe-popup.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import * as RouteTreeGen from '../actions/route-tree-gen'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import PopupDialog from './popup-dialog'
 import {connect} from '../util/container'
 import {collapseStyles, globalColors, isMobile} from '../styles'

--- a/shared/common-adapters/mention.tsx
+++ b/shared/common-adapters/mention.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-// @ts-ignore not converted
 import Text from './text'
 import * as Styles from '../styles'
 

--- a/shared/common-adapters/meta.stories.tsx
+++ b/shared/common-adapters/meta.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import {Box2} from './box'
 import Meta from './meta'
 import {storiesOf} from '../stories/storybook'

--- a/shared/common-adapters/meta.tsx
+++ b/shared/common-adapters/meta.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import Text from './text'
 import {
   globalColors,

--- a/shared/common-adapters/name-with-icon/index.tsx
+++ b/shared/common-adapters/name-with-icon/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import * as Styles from '../../styles'
 import Avatar, {AvatarSize} from '../avatar'
 import Box from '../box'
-// @ts-ignore
 import ClickableBox from '../clickable-box'
 import Icon, {castPlatformStyles, IconType} from '../icon'
 import Text, {TextType} from '../text'

--- a/shared/common-adapters/new-input.stories.tsx
+++ b/shared/common-adapters/new-input.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import Icon from './icon'
 import {action, storiesOf} from '../stories/storybook'
 import {globalColors} from '../styles'

--- a/shared/common-adapters/new-input.tsx
+++ b/shared/common-adapters/new-input.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import PlainInput, {PropsWithInput, KeyboardType} from './plain-input'
-// @ts-ignore not converted
 import Box, {Box2} from './box'
-// @ts-ignore not converted
 import Icon, {IconType, castPlatformStyles} from './icon'
-// @ts-ignore not converted
 import {getStyle as getTextStyle, TextType} from './text'
 import {
   StylesCrossPlatform,

--- a/shared/common-adapters/overlay/index.d.ts
+++ b/shared/common-adapters/overlay/index.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore
 import {Position} from '../relative-popup-hoc.types'
 import {StylesCrossPlatform} from '../../styles/css'
 

--- a/shared/common-adapters/placeholder.stories.tsx
+++ b/shared/common-adapters/placeholder.stories.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import * as Sb from '../stories/storybook'
 import Placeholder from './placeholder'
 import * as Styles from '../styles'
-// @ts-ignore not converted
 import Box from './box'
 
 const load = () => {

--- a/shared/common-adapters/placeholder.tsx
+++ b/shared/common-adapters/placeholder.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as Styles from '../styles'
-// @ts-ignore not converted
 import Box from './box'
 
 type PlaceholderProps = {

--- a/shared/common-adapters/plain-input.d.ts
+++ b/shared/common-adapters/plain-input.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {StylesCrossPlatform} from '../styles'
-// @ts-ignore not converted
 import {TextType} from './text'
 
 export type KeyboardType =

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react'
-// @ts-ignore not converted
 import {getStyle as getTextStyle} from './text'
 import {NativeTextInput} from './native-wrappers.native'
 import {collapseStyles, globalColors, platformStyles, styleSheetCreate} from '../styles'

--- a/shared/common-adapters/plain-input.stories.tsx
+++ b/shared/common-adapters/plain-input.stories.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react'
 import PlainInput from './plain-input'
-// @ts-ignore not converted
 import Box, {Box2} from './box'
 import Button from './button'
 import ButtonBar from './button-bar'
-// @ts-ignore not converted
 import Text from './text'
 import {action, scrollViewDecorator, storiesOf} from '../stories/storybook'
 import {globalColors, globalMargins} from '../styles'

--- a/shared/common-adapters/platform-icon.tsx
+++ b/shared/common-adapters/platform-icon.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import {PlatformsExpandedType} from '../constants/types/more'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import Icon, {IconType} from './icon'
 import {isMobile} from '../constants/platform'
 

--- a/shared/common-adapters/popup-dialog.desktop.tsx
+++ b/shared/common-adapters/popup-dialog.desktop.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import Icon from './icon'
 import {EscapeHandler} from '../util/key-event-handler.desktop'
 import * as Styles from '../styles'

--- a/shared/common-adapters/popup-dialog.native.tsx
+++ b/shared/common-adapters/popup-dialog.native.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Box from './box'
 import {NativeTouchableWithoutFeedback} from './native-wrappers.native'
 import {globalColors, globalMargins, globalStyles} from '../styles'

--- a/shared/common-adapters/popup-dialog.stories.tsx
+++ b/shared/common-adapters/popup-dialog.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Box from './box'
-// @ts-ignore not converted
 import Text from './text'
 import PopupDialog from './popup-dialog'
 import {action, storiesOf} from '../stories/storybook'

--- a/shared/common-adapters/popup-header-text.tsx
+++ b/shared/common-adapters/popup-header-text.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Text from './text'
 import * as Styles from '../styles'
 

--- a/shared/common-adapters/progress-bar.tsx
+++ b/shared/common-adapters/progress-bar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Box from './box'
 import {globalColors, isMobile} from '../styles'
 

--- a/shared/common-adapters/progress-indicator.desktop.tsx
+++ b/shared/common-adapters/progress-indicator.desktop.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore not converted
 import Icon from './icon'
 import * as React from 'react'
 import {Props} from './progress-indicator'

--- a/shared/common-adapters/qr-lines.tsx
+++ b/shared/common-adapters/qr-lines.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import {Box} from './box'
 import * as Styles from '../styles'
 

--- a/shared/common-adapters/qr-not-authorized.tsx
+++ b/shared/common-adapters/qr-not-authorized.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react'
 import * as ConfigGen from '../actions/config-gen'
 import {namedConnect} from '../util/container'
-// @ts-ignore not converted
 import Text from './text'
-// @ts-ignore not converted
 import {Box2} from './box'
-// @ts-ignore not converted
 import Icon from './icon'
 import {styleSheetCreate, globalColors} from '../styles'
 

--- a/shared/common-adapters/radio-button.desktop.tsx
+++ b/shared/common-adapters/radio-button.desktop.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore not converted
 import Text from './text'
 import {Props} from './radio-button'
 import {globalStyles, globalColors, transition, desktopStyles, styled} from '../styles'

--- a/shared/common-adapters/radio-button.stories.tsx
+++ b/shared/common-adapters/radio-button.stories.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore not converted
 import Box from './box'
 import RadioButton from './radio-button'
 import React from 'react'

--- a/shared/common-adapters/search-filter.tsx
+++ b/shared/common-adapters/search-filter.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import Box, {Box2} from './box'
-// @ts-ignore
 import ClickableBox from './clickable-box'
 import NewInput from './new-input'
 import PlainInput from './plain-input'

--- a/shared/common-adapters/section-divider.tsx
+++ b/shared/common-adapters/section-divider.tsx
@@ -4,7 +4,6 @@ import {Box2} from './box'
 import Text from './text'
 import Icon from './icon'
 import ProgressIndicator from './progress-indicator'
-// @ts-ignore todo
 import ClickableBox from './clickable-box'
 
 const Kb = {

--- a/shared/common-adapters/switch.stories.tsx
+++ b/shared/common-adapters/switch.stories.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import Box, {Box2} from './box'
 import Text from './text'
 import Icon from './icon'
-// @ts-ignore todo
 import ClickableBox from './clickable-box'
 import Switch from './switch'
 import * as Sb from '../stories/storybook'

--- a/shared/common-adapters/switch.tsx
+++ b/shared/common-adapters/switch.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as Styles from '../styles'
-// @ts-ignore todo
 import ClickableBox from './clickable-box'
 import Box, {Box2} from './box'
 import ProgressIndicator from './progress-indicator'

--- a/shared/common-adapters/tabs.tsx
+++ b/shared/common-adapters/tabs.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import Box from './box'
-// @ts-ignore todo
 import ClickableBox from './clickable-box'
 import Divider from './divider'
 import {

--- a/shared/common-adapters/text.desktop.tsx
+++ b/shared/common-adapters/text.desktop.tsx
@@ -13,7 +13,6 @@ class Text extends React.Component<Props> {
   highlightText() {
     const el = this._spanRef.current
     const range = document.createRange()
-    // @ts-ignore
     range.selectNodeContents(el)
 
     const sel = window.getSelection()

--- a/shared/common-adapters/text.stories.tsx
+++ b/shared/common-adapters/text.stories.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import * as Sb from '../stories/storybook'
-// @ts-ignore
 import Box from './box'
-// @ts-ignore
 import Icon from './icon'
 import Text, {allTextTypes, TextType} from './text'
 import {globalColors, globalMargins, globalStyles, isMobile, platformStyles} from '../styles'

--- a/shared/common-adapters/with-tooltip.native.tsx
+++ b/shared/common-adapters/with-tooltip.native.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
 import {Dimensions, View} from 'react-native'
-// @ts-ignore remove when typed
 import FloatingBox from './floating-box'
 import hOCTimers, {PropsWithTimer} from './hoc-timers'
-// @ts-ignore remove when typed
 import ClickableBox from './clickable-box'
 import Text from './text'
 import Animated from './animated'

--- a/shared/constants/router2.tsx
+++ b/shared/constants/router2.tsx
@@ -4,7 +4,6 @@ export const _setNavigator = (navigator: any) => {
   _navigator = navigator
   if (__DEV__) {
     if (require('./platform').isMobile) {
-      // @ts-ignore
       global.DEBUGNavigator = _navigator
     } else {
       // @ts-ignore

--- a/shared/constants/types/fs.tsx
+++ b/shared/constants/types/fs.tsx
@@ -6,7 +6,6 @@ import * as TeamsTypes from '../../constants/types/teams'
 // TODO importing FsGen causes an import loop
 import * as FsGen from '../../actions/fs-gen'
 import {IconType} from '../../common-adapters/icon.constants'
-// @ts-ignore TODO: remove this ignore when common-adapters are TSed
 import {TextType} from '../../common-adapters/text'
 import {isWindows} from '../platform'
 import {memoize} from '../../util/memoize'

--- a/shared/engine/index-impl.tsx
+++ b/shared/engine/index-impl.tsx
@@ -1,5 +1,4 @@
 // Handles sending requests to the daemon
-// @ts-ignore codemode issue
 import logger from '../logger'
 import Session, {CancelHandlerType} from './session'
 import {initEngine, initEngineSaga} from './require'
@@ -50,7 +49,6 @@ class Engine {
   _throttledDispatchWaitingAction = throttle(() => {
     const changes = this._queuedChanges
     this._queuedChanges = []
-    // @ts-ignore codemod-issue
     Engine._dispatch(createBatchChangeWaiting({changes}))
   }, 500)
 
@@ -161,9 +159,7 @@ class Engine {
 
   // An incoming rpc call
   _rpcIncoming(payload: {method: MethodKey; param: Array<Object>; response: Object | null}) {
-    // @ts-ignore codemode issue
     const {method, param: incomingParam, response} = payload
-    // @ts-ignore codemode issue
     const param = incomingParam && incomingParam.length ? incomingParam[0] : {}
     // @ts-ignore codemode issue
     const {seqid, cancelled} = response || {cancelled: false, seqid: 0}

--- a/shared/engine/index.d.ts
+++ b/shared/engine/index.d.ts
@@ -1,6 +1,5 @@
 import Session from './session'
 import {RPCError} from '../util/errors'
-// @ts-ignore codemode issue
 import {IncomingCallMapType, CustomResponseIncomingCallMapType} from '../constants/types/rpc-all-gen'
 
 type WaitingKey = string | Array<string>

--- a/shared/engine/index.platform.desktop.tsx
+++ b/shared/engine/index.platform.desktop.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore codemode issue
 import net from 'net'
 import logger from '../logger'
 import {TransportShared, sharedCreateClient, rpcLog} from './transport-shared'
@@ -10,7 +9,6 @@ class NativeTransport extends TransportShared {
   constructor(incomingRPCCallback, connectCallback, disconnectCallback) {
     console.log('Transport using', socketPath)
     super({path: socketPath}, connectCallback, disconnectCallback, incomingRPCCallback)
-    // @ts-ignore codemode issue
     this.needsConnect = true
   }
 
@@ -38,7 +36,6 @@ class NativeTransport extends TransportShared {
     if (printRPCBytes) {
       logger.debug('[RPC] Read', m.length, 'bytes:', m.toString('hex'))
     }
-    // @ts-ignore codemode issue
     super.packetize_data(m)
   }
 }
@@ -50,7 +47,6 @@ function windowsHack() {
   // hangs until other random net module operations, at which point it
   // unblocks.  Could be Electron, could be a node-framed-msgpack-rpc
   // bug, who knows.
-  // @ts-ignore codemode issue
   if (!isWindows || process.type !== 'renderer') {
     return
   }

--- a/shared/engine/index.platform.native.tsx
+++ b/shared/engine/index.platform.native.tsx
@@ -25,7 +25,6 @@ class NativeTransport extends TransportShared {
     super({}, connectCallback, disconnectCallback, incomingRPCCallback)
 
     // We're connected locally so we never get disconnected
-    // @ts-ignore codemode issue
     this.needsConnect = false
   }
 

--- a/shared/engine/session-impl.tsx
+++ b/shared/engine/session-impl.tsx
@@ -183,14 +183,11 @@ class Session {
       return false
     }
 
-    // @ts-ignore codemode issue
     if (response && response.seqid) {
       this._seqIDResponded[String(response.seqid)] = false
     }
 
-    // @ts-ignore codemode issue
     const waitingHandler = this._makeWaitingHandler(false, method, response && response.seqid)
-    // @ts-ignore codemode issue
     const incomingRequest = new IncomingRequest(method, param, response, waitingHandler, handler)
     this._incomingRequests.push(incomingRequest)
     const actions = incomingRequest.handle()

--- a/shared/engine/transport-shared.tsx
+++ b/shared/engine/transport-shared.tsx
@@ -89,7 +89,6 @@ class TransportShared extends RobustTransport {
     // @ts-ignore codemode issue
     this.hooks = {
       connected: () => {
-        // @ts-ignore codemode issue
         this.needsConnect = false
         connectCallback && connectCallback()
       },

--- a/shared/menubar/index.desktop.tsx
+++ b/shared/menubar/index.desktop.tsx
@@ -9,7 +9,6 @@ import FilesPreview from './files-container.desktop'
 import {isDarwin} from '../constants/platform'
 import * as SafeElectron from '../util/safe-electron.desktop'
 import OutOfDate from './out-of-date'
-// @ts-ignore codemod issue
 import Upload from '../fs/footer/upload'
 import UploadCountdownHOC, {UploadCountdownHOCProps} from '../fs/footer/upload-countdown-hoc'
 import {Loading} from '../fs/simple-screens'

--- a/shared/people/follow-suggestions/index.stories.tsx
+++ b/shared/people/follow-suggestions/index.stories.tsx
@@ -66,10 +66,8 @@ const props2 = {
   ].map(Constants.makeFollowSuggestion),
 }
 
-// @ts-ignore codemod issue
 const props3 = {
   suggestions: props2.suggestions.concat(
-    // @ts-ignore codemod issue
     props2.suggestions.map(suggestion => suggestion.set('username', suggestion.username + '1'))
   ),
 }

--- a/shared/people/follow-suggestions/index.tsx
+++ b/shared/people/follow-suggestions/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore codemod issue
 import * as Types from '../../constants/types/people'
 import {Box, ConnectedNameWithIcon, ScrollView, Text} from '../../common-adapters'
 import * as Styles from '../../styles'

--- a/shared/people/index.d.ts
+++ b/shared/people/index.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react'
-// @ts-ignore codemod issue
 import * as Types from '../constants/types/people'
 
 export type Props = {

--- a/shared/people/todo/container.tsx
+++ b/shared/people/todo/container.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import {Task} from '.'
 import * as PeopleGen from '../../actions/people-gen'
-// @ts-ignore codemod issue
 import * as Types from '../../constants/types/people'
 import * as Tabs from '../../constants/tabs'
 import * as SettingsTabs from '../../constants/settings'
@@ -171,40 +170,28 @@ const TeamShowcaseConnector = connect(
 
 const TaskChooser = (props: TodoOwnProps) => {
   switch (props.todoType) {
-    // @ts-ignore codemod issue
     case todoTypes.avatarTeam:
       return <AvatarTeamConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.avatarUser:
       return <AvatarUserConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.bio:
       return <BioConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.proof:
       return <ProofConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.device:
       return <DeviceConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.follow:
       return <FollowConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.chat:
       return <ChatConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.paperkey:
       return <PaperKeyConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.team:
       return <TeamConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.folder:
       return <FolderConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.gitRepo:
       return <GitRepoConnector {...props} />
-    // @ts-ignore codemod issue
     case todoTypes.teamShowcase:
       return <TeamShowcaseConnector {...props} />
   }

--- a/shared/profile/edit-avatar/index.desktop.tsx
+++ b/shared/profile/edit-avatar/index.desktop.tsx
@@ -87,7 +87,6 @@ class EditAvatar extends React.Component<_Props, State> {
       ? Array.prototype.map
           .call(fileList, (f: File) => {
             // We rely on path being here, even though it's not part of the File spec.
-            // @ts-ignore
             const path: string = f.path
             return path
           })
@@ -471,5 +470,4 @@ const styles = Styles.styleSheetCreate({
   },
 })
 
-// @ts-ignore HOCTimers typing is wrong
 export default HOCTimers(EditAvatar)

--- a/shared/profile/user/teams/teaminfo.tsx
+++ b/shared/profile/user/teams/teaminfo.tsx
@@ -5,9 +5,7 @@ import OpenMeta from './openmeta'
 import FloatingMenu from '../../../common-adapters/floating-menu'
 import ConnectedUsernames from '../../../common-adapters/usernames/container'
 import NameWithIcon from '../../../common-adapters/name-with-icon'
-// @ts-ignore codemode issue
 import Text from '../../../common-adapters/text'
-// @ts-ignore codemode issue
 import {Box2} from '../../../common-adapters/box'
 import WaitingButton from '../../../common-adapters/waiting-button'
 

--- a/shared/provision/code-page/index.stories.tsx
+++ b/shared/provision/code-page/index.stories.tsx
@@ -59,7 +59,6 @@ const load = () => {
     Sb.createPropProviderWithCommon({
       // @ts-ignore codemode issue
       QRScan: QRScanProps,
-      // @ts-ignore codemode issue
       QRScanNotAuthorized: {
         // @ts-ignore codemode issue
         onOpenSettings: Sb.action('onOpenSettings'),

--- a/shared/provision/code-page/qr-scan/container.tsx
+++ b/shared/provision/code-page/qr-scan/container.tsx
@@ -27,7 +27,6 @@ const mergeProps = (stateProps, dispatchProps) => ({
 })
 
 export default compose(
-  // @ts-ignore codemode issue
   namedConnect(mapStateToProps, mapDispatchToProps, mergeProps, 'QRScan'),
   safeSubmit(['onSubmitTextCode'], ['error']),
   withStateHandlers(

--- a/shared/provision/gpg-sign/index.desktop.tsx
+++ b/shared/provision/gpg-sign/index.desktop.tsx
@@ -1,5 +1,4 @@
 // TODO remove Container
-// @ts-ignore codemode issue
 import Container from '../../login/forms/container'
 import * as React from 'react'
 import Row, {RowCSS} from './row.desktop'

--- a/shared/provision/password/index.desktop.tsx
+++ b/shared/provision/password/index.desktop.tsx
@@ -1,5 +1,4 @@
 // TODO remove Container
-// @ts-ignore codemode issue
 import Container from '../../login/forms/container'
 import * as React from 'react'
 import {Text, Input, Button, UserCard} from '../../common-adapters'

--- a/shared/provision/password/index.native.tsx
+++ b/shared/provision/password/index.native.tsx
@@ -1,5 +1,4 @@
 // TODO remove Container
-// @ts-ignore codemode issue
 import Container from '../../login/forms/container'
 import * as React from 'react'
 import {Button, UserCard, Text, FormWithCheckbox} from '../../common-adapters'

--- a/shared/provision/username-or-email/index.tsx
+++ b/shared/provision/username-or-email/index.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
-// @ts-ignore codemode issue
 import Container from '../../login/forms/container'
 import * as Constants from '../../constants/provision'
 

--- a/shared/reducers/fs.tsx
+++ b/shared/reducers/fs.tsx
@@ -168,6 +168,7 @@ const withFsErrorBar = (state: Types.State, action: FsGen.FsErrorPayload): Types
     return state
   }
   logger.error('error (fs)', fsError.erroredAction.type, fsError.errorMessage)
+  // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
   return state.update('errors', errors => errors.set(Constants.makeUUID(), fsError))
 }
 

--- a/shared/reducers/fs.tsx
+++ b/shared/reducers/fs.tsx
@@ -168,7 +168,6 @@ const withFsErrorBar = (state: Types.State, action: FsGen.FsErrorPayload): Types
     return state
   }
   logger.error('error (fs)', fsError.erroredAction.type, fsError.errorMessage)
-  // @ts-ignore TS is correct here. TODO fix we're passing buffers as strings
   return state.update('errors', errors => errors.set(Constants.makeUUID(), fsError))
 }
 

--- a/shared/reducers/settings.tsx
+++ b/shared/reducers/settings.tsx
@@ -56,7 +56,6 @@ function reducer(state: Types.State = initialState, action: SettingsGen.Actions)
       return state.update('notifications', notifications =>
         notifications.merge({
           allowEdit: false,
-          // @ts-ignore codemod issue
           groups: state.notifications.groups.merge(I.Map(changed)) as any,
         })
       )

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -9,7 +9,6 @@ import {createBottomTabNavigator} from 'react-navigation-tabs'
 import {createStackNavigator} from 'react-navigation-stack'
 import * as Tabs from '../constants/tabs'
 import {modalRoutes, routes, loggedOutRoutes, tabRoots} from './routes'
-// @ts-ignore
 import {LeftAction} from '../common-adapters/header-hoc'
 import * as Constants from '../constants/router2'
 import * as Shared from './router.shared'

--- a/shared/search/user-input/autosize-input.desktop.tsx
+++ b/shared/search/user-input/autosize-input.desktop.tsx
@@ -1,6 +1,5 @@
 import React, {Component} from 'react'
 import {globalStyles, globalColors} from '../../styles'
-// @ts-ignore
 import {getStyle as getTextStyle} from '../../common-adapters/text'
 
 type Props = {

--- a/shared/search/user-input/index.desktop.tsx
+++ b/shared/search/user-input/index.desktop.tsx
@@ -1,12 +1,10 @@
 import {trim, last} from 'lodash-es'
 import React, {Component} from 'react'
-// @ts-ignore
 import {Box, Text, Icon} from '../../common-adapters'
 import AutosizeInput from './autosize-input.desktop'
 import {globalColors, globalMargins, globalStyles, platformStyles, collapseStyles} from '../../styles'
 import IconOrAvatar from '../icon-or-avatar'
 import {followingStateToStyle} from '../shared'
-// @ts-ignore
 import {getStyle as getTextStyle} from '../../common-adapters/text'
 import {UserDetails, Props} from '.'
 

--- a/shared/search/user-input/index.native.tsx
+++ b/shared/search/user-input/index.native.tsx
@@ -1,12 +1,10 @@
 import {last} from 'lodash-es'
 import React, {Component} from 'react'
 import {TextInput, Animated} from 'react-native'
-// @ts-ignore
 import {Box, Text, Icon, ClickableBox} from '../../common-adapters'
 import {globalColors, globalMargins, globalStyles, platformStyles} from '../../styles'
 import IconOrAvatar from '../icon-or-avatar'
 import {followingStateToStyle} from '../shared'
-// @ts-ignore
 import {getStyle as getTextStyle} from '../../common-adapters/text'
 import {UserDetails, Props} from './'
 

--- a/shared/settings/feedback/container.native.tsx
+++ b/shared/settings/feedback/container.native.tsx
@@ -2,7 +2,6 @@ import logger from '../../logger'
 import * as React from 'react'
 import {HOCTimers, PropsWithTimer} from '../../common-adapters'
 import Feedback from './index'
-// @ts-ignore not typed yet
 import logSend from '../../native/log-send'
 import {compose, connect, RouteProps} from '../../util/container'
 import {isAndroid, version, logFileName, pprofDir} from '../../constants/platform'

--- a/shared/settings/payment/container.tsx
+++ b/shared/settings/payment/container.tsx
@@ -106,7 +106,6 @@ export default connect(
     },
   }),
   (stateProps, dispatchProps, ownProps: OwnProps) => {
-    // @ts-ignore codemod issue
     if (stateProps.bootstrapDone === false) {
       return {
         bootstrapDone: false,
@@ -117,7 +116,6 @@ export default connect(
     return {
       bootstrapDone: true,
       originalProps: {
-        // @ts-ignore codemod issue
         ...stateProps.originalProps,
         clearBillingError: dispatchProps.clearBillingError,
         onSubmit: (

--- a/shared/settings/routes.desktop.tsx
+++ b/shared/settings/routes.desktop.tsx
@@ -2,7 +2,6 @@ import * as Constants from '../constants/settings'
 import * as Kb from '../common-adapters'
 import * as React from 'react'
 import {createNavigator, StackRouter, SceneView} from '@react-navigation/core'
-// @ts-ignore not typed yet
 import * as Shim from '../router-v2/shim'
 
 const settingsSubRoutes = {

--- a/shared/settings/screenprotector.native.tsx
+++ b/shared/settings/screenprotector.native.tsx
@@ -1,7 +1,6 @@
 import React, {Component} from 'react'
 import {globalStyles, globalMargins} from '../styles'
 import {Box, Text, Checkbox, HeaderHoc} from '../common-adapters'
-// @ts-ignore not typed yet
 import {getSecureFlagSetting, setSecureFlagSetting} from '../native/screenprotector'
 import {isAndroid} from '../constants/platform'
 

--- a/shared/stories/storybook.shared.tsx
+++ b/shared/stories/storybook.shared.tsx
@@ -5,11 +5,8 @@ import {Provider} from 'react-redux'
 import {createStore} from 'redux'
 import {GatewayProvider, GatewayDest} from 'react-gateway'
 import {action} from '@storybook/addon-actions'
-// @ts-ignore
 import Box from '../common-adapters/box'
-// @ts-ignore
 import Text from '../common-adapters/text'
-// @ts-ignore
 import ClickableBox from '../common-adapters/clickable-box'
 import RandExp from 'randexp'
 
@@ -92,7 +89,6 @@ class StorybookErrorBoundary extends React.Component<
 
     // Disallow catching errors when snapshot testing
     if (!__STORYSHOT__) {
-      // @ts-ignore
       this.componentDidCatch = (
         error: Error,
         info: {
@@ -102,7 +98,6 @@ class StorybookErrorBoundary extends React.Component<
         this.setState({error, hasError: true, info})
       }
     } else {
-      // @ts-ignore
       this.componentDidCatch = undefined
     }
   }

--- a/shared/styles/shared.tsx
+++ b/shared/styles/shared.tsx
@@ -1,7 +1,6 @@
 import globalColors from './colors'
 import {isMobile, isIOS, isAndroid, isElectron} from '../constants/platform'
 import {_StylesCrossPlatform, _StylesMobile, _StylesDesktop} from './css'
-// @ts-ignore
 import {Background} from '../common-adapters/text'
 
 /* eslint-disable sort-keys */

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -14,7 +14,6 @@ import {parseUserId} from '../util/platforms'
 import {followStateHelperWithId} from '../constants/team-building'
 import {memoizeShallow, memoize} from '../util/memoize'
 import {ServiceIdWithContact, User, SearchResults} from '../constants/types/team-building'
-// @ts-ignore codemode issue
 import {Props as HeaderHocProps} from '../common-adapters/header-hoc/types'
 
 type OwnProps = {

--- a/shared/team-building/user-bubble.tsx
+++ b/shared/team-building/user-bubble.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as Kb from '../common-adapters/index'
 import * as Styles from '../styles'
-// @ts-ignore codemode issue
 import DesktopStyle from '../common-adapters/desktop-style'
 import {serviceIdToIconFont, serviceIdToAccentColor} from './shared'
 import {ServiceIdWithContact} from '../constants/types/team-building'

--- a/shared/teams/role-picker/index.tsx
+++ b/shared/teams/role-picker/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import {map, capitalize} from 'lodash-es'
-// @ts-ignore not typed yet
 import {Position} from '../../common-adapters/relative-popup-hoc.types'
 import {TeamRoleType as Role} from '../../constants/types/teams'
 import {StylesCrossPlatform} from '../../styles/css'

--- a/shared/teams/team/menu-container.tsx
+++ b/shared/teams/team/menu-container.tsx
@@ -4,7 +4,6 @@ import * as FsConstants from '../../constants/fs'
 import * as FsTypes from '../../constants/types/fs'
 import {connect} from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
-// @ts-ignore not typed yet
 import {MenuItem} from '../../common-adapters/floating-menu/menu-layout'
 import {FloatingMenu} from '../../common-adapters'
 

--- a/shared/teams/team/settings-tab/container.tsx
+++ b/shared/teams/team/settings-tab/container.tsx
@@ -1,6 +1,5 @@
 import * as Constants from '../../../constants/teams'
 import * as Types from '../../../constants/types/teams'
-// @ts-ignore not typed yet
 import {RetentionPolicy} from '../../../constants/types/retention-policy'
 import * as TeamsGen from '../../../actions/teams-gen'
 import {connect} from '../../../util/container'

--- a/shared/teams/team/settings-tab/index.tsx
+++ b/shared/teams/team/settings-tab/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as Types from '../../../constants/types/teams'
-// @ts-ignore not typed yet
 import {RetentionPolicy} from '../../../constants/types/retention-policy'
 import {Box2, Box, Button, Checkbox, Text} from '../../../common-adapters'
 import {InlineDropdown} from '../../../common-adapters/dropdown'

--- a/shared/teams/team/settings-tab/retention/container.tsx
+++ b/shared/teams/team/settings-tab/retention/container.tsx
@@ -9,7 +9,6 @@ import {
   hasCanPerform,
 } from '../../../../constants/teams'
 import {getConversationRetentionPolicy} from '../../../../constants/chat2/meta'
-// @ts-ignore not typed yet
 import {RetentionPolicy} from '../../../../constants/types/retention-policy'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
 import {ConversationIDKey} from '../../../../constants/types/chat2'

--- a/shared/teams/team/settings-tab/retention/index.tsx
+++ b/shared/teams/team/settings-tab/retention/index.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
 import * as Styles from '../../../../styles'
 import * as Kb from '../../../../common-adapters'
-// @ts-ignore not typed yet
 import {MenuItem} from '../../../../common-adapters/floating-menu/menu-layout'
-// @ts-ignore not typed yet
 import {RetentionPolicy} from '../../../../constants/types/retention-policy'
 import {retentionPolicies, baseRetentionPolicies} from '../../../../constants/teams'
 import SaveIndicator from '../../../../common-adapters/save-indicator'

--- a/shared/teams/team/settings-tab/retention/warning/container.tsx
+++ b/shared/teams/team/settings-tab/retention/warning/container.tsx
@@ -2,7 +2,6 @@ import * as Container from '../../../../../util/container'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import RetentionWarning from '.'
 import {RetentionEntityType} from '..'
-// @ts-ignore not typed yet
 import {RetentionPolicy} from '../../../../../constants/types/retention-policy'
 
 type OwnProps = Container.RouteProps<

--- a/shared/util/clipboard.desktop.tsx
+++ b/shared/util/clipboard.desktop.tsx
@@ -1,5 +1,4 @@
 import * as SafeElectron from './safe-electron.desktop'
-// @ts-ignore codemod-issue
 import fs from 'fs'
 import {tmpRandFile} from './file.desktop'
 

--- a/shared/util/forward-logs.desktop.tsx
+++ b/shared/util/forward-logs.desktop.tsx
@@ -2,7 +2,6 @@ import {LogLineWithLevelISOTimestamp} from '../logger/types'
 import {isWindows, logFileName} from '../constants/platform.desktop'
 import fs from 'fs'
 import {mkdirp} from '../util/file.desktop'
-// @ts-ignore codemod-issue
 import path from 'path'
 
 const fileDoesNotExist = err => {

--- a/shared/util/teams.tsx
+++ b/shared/util/teams.tsx
@@ -1,5 +1,4 @@
 import {publicAdminsLimit} from '../constants/teams'
-// @ts-ignore codemod-issue
 import {RetentionPolicy} from '../constants/types/retention-policy'
 
 type SortedAdmins = {

--- a/shared/util/testing.tsx
+++ b/shared/util/testing.tsx
@@ -19,7 +19,6 @@ export const makeStartReduxSaga = (
       },
     })
     const store = createStore(rootReducer, is || initialStore, applyMiddleware(sagaMiddleware))
-    // @ts-ignore codemod-issue
     const getState: () => any = store.getState
     const dispatch = store.dispatch
     sagaMiddleware.run(rootSaga)

--- a/shared/wallets/banner/index.tsx
+++ b/shared/wallets/banner/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {Box2, Text} from '../../common-adapters'
-// @ts-ignore not typed yet
 import {Background} from '../../common-adapters/text'
 import * as Styles from '../../styles'
 

--- a/shared/wallets/routes.tsx
+++ b/shared/wallets/routes.tsx
@@ -2,7 +2,6 @@ import {isMobile} from '../constants/platform'
 import * as Kb from '../common-adapters'
 import * as React from 'react'
 import {createNavigator, StackRouter, SceneView} from '@react-navigation/core'
-// @ts-ignore not typed yet
 import * as Shim from '../router-v2/shim'
 
 const sharedRoutes = {


### PR DESCRIPTION
@keybase/react-hackers 

Unlike Flow, TS isn't able to determine whether a ts-ignore line is useless: that is, whether it's silencing an error that wouldn't actually exist if the comment was missing.  We used ts-ignore a lot to mean "this error is temporary because we haven't migrated some files from Flow to TS yet" during the migration.

So I wrote a script that removes all ts-ignores, runs tsc once, and then reinserts the comments that used to be on lines that have become errors.  We can keep running the script occasionally.

Stats: Removed 259 out of 547 ts-ignore lines on master (47%).

You can verify that the removals are safe by noticing that tsc still reports 0 errors after applying this PR.