### PR TITLE
modes: enable edit history for mobile

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1312,7 +1312,8 @@ func (fbo *folderBranchOps) kickOffPartialSyncIfNeeded(
 		// If we're not syncing the TLF at all, start a partial "sync"
 		// using the recently-edited files list, storing the blocks in
 		// the working set cache.
-		if !fbo.config.Mode().TLFEditHistoryEnabled() {
+		if !fbo.config.Mode().TLFEditHistoryEnabled() ||
+			fbo.config.Mode().DefaultBlockRequestAction() == BlockRequestSolo {
 			return
 		}
 		err := fbo.editActivity.Wait(ctx)

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -455,10 +455,6 @@ func (mc modeConstrained) ServiceKeepaliveEnabled() bool {
 	return false
 }
 
-func (mc modeConstrained) TLFEditHistoryEnabled() bool {
-	return false
-}
-
 func (mc modeConstrained) SendEditNotificationsEnabled() bool {
 	return true
 }
@@ -507,6 +503,10 @@ func (mml modeMemoryLimited) LocalHTTPServerEnabled() bool {
 
 func (mml modeMemoryLimited) MaxCleanBlockCacheCapacity() uint64 {
 	return 1 * (1 << 20) // 1 MB
+}
+
+func (mml modeMemoryLimited) TLFEditHistoryEnabled() bool {
+	return false
 }
 
 // Wrapper for tests.


### PR DESCRIPTION
But don't enable default prefetching of recently-edited files.

This will fix sort-TLF-by-mtime on mobile, along with #17819.

(NOTE: this seems safe enough to me to do shortly before the release, since I turned off the recent file prefetching.  But we should get it in soon, just in case.)

Issue: KBFS-4200