### PR TITLE
force the video control to believe video source is network

### DIFF
--- a/shared/chat/conversation/messages/attachment/image/image-render.native.tsx
+++ b/shared/chat/conversation/messages/attachment/image/image-render.native.tsx
@@ -27,8 +27,9 @@ export class ImageRender extends React.Component<Props, State> {
 
   render() {
     if (this.props.inlineVideoPlayable && this.props.videoSrc.length > 0) {
+      const uri = this.props.videoSrc.length > 0 ? this.props.videoSrc : 'https://'
       const source = {
-        uri: `${this.props.videoSrc}&contentforce=true&poster=${encodeURIComponent(this.props.src)}`,
+        uri: `${uri}&contentforce=true&poster=${encodeURIComponent(this.props.src)}`,
       }
       // poster not working correctly so we need this box
       // https://github.com/react-native-community/react-native-video/issues/1509

--- a/shared/chat/conversation/messages/wrapper/unfurl/generic/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/unfurl/generic/index.tsx
@@ -78,7 +78,7 @@ class UnfurlGeneric extends React.Component<Props> {
           {showBottomImage && !this.props.isCollapsed && (
             <Kb.Box2 direction="vertical" fullWidth={true}>
               <UnfurlImage
-                url={this.props.imageURL || ''} // showBottomImage checks all these, this is to pass Flow.
+                url={this.props.imageURL || ''}
                 linkURL={this.props.url}
                 height={this.props.imageHeight || 0}
                 width={this.props.imageWidth || 0}

--- a/shared/chat/conversation/messages/wrapper/unfurl/image/video.native.tsx
+++ b/shared/chat/conversation/messages/wrapper/unfurl/image/video.native.tsx
@@ -21,8 +21,9 @@ export class Video extends React.Component<Props, State> {
   }
 
   render() {
+    const uri = this.props.url.length > 0 ? this.props.url : 'https://'
     const source = {
-      uri: `${this.props.url}&autoplay=${this.props.autoPlay ? 'true' : 'false'}&contentforce=true`,
+      uri: `${uri}&autoplay=${this.props.autoPlay ? 'true' : 'false'}&contentforce=true`,
     }
     return (
       <Kb.ClickableBox

--- a/shared/chat/conversation/messages/wrapper/unfurl/image/video.native.tsx
+++ b/shared/chat/conversation/messages/wrapper/unfurl/image/video.native.tsx
@@ -21,6 +21,12 @@ export class Video extends React.Component<Props, State> {
   }
 
   render() {
+    /*
+    The react-native-video library thinks any URI that doesn't start with /https?:// to be an asset bundled
+    with the app, and will straight crash of that is not true. Solution here is if we somehow end up with a
+    blank URL in a native video component, then just put some bogus string in there that at least doesn't
+    send the library down the crasher path.
+    */
     const uri = this.props.url.length > 0 ? this.props.url : 'https://'
     const source = {
       uri: `${uri}&autoplay=${this.props.autoPlay ? 'true' : 'false'}&contentforce=true`,


### PR DESCRIPTION
I'm not totally happy with this, I don't understand how we could ever be showing a blank URL in these components. The react-native-video library thinks any URI that doesn't start with `/https?://` to be an asset bundled with the app, and will straight crash of that is not true. Solution here is if we somehow end up with a blank URL in a native video component, then just put some bogus string in there that at least doesn't send the library down the crasher path. 