### PR TITLE
Support a value prop in plain-input native

### DIFF
--- a/shared/common-adapters/kb-text-input.native.tsx
+++ b/shared/common-adapters/kb-text-input.native.tsx
@@ -63,7 +63,7 @@ if (isAndroid) {
           // @ts-ignore no RN types
           onTextInput={this._onTextInput}
           // @ts-ignore no RN types
-          text={this.props.value || this.props.text || this.props.defaultValue || ''}
+          text={this.props.value || this.props.defaultValue || ''}
           children={children}
           // @ts-ignore no RN types
           disableFullscreenUI={this.props.disableFullscreenUI}

--- a/shared/common-adapters/kb-text-input.native.tsx
+++ b/shared/common-adapters/kb-text-input.native.tsx
@@ -24,8 +24,9 @@ if (isAndroid) {
 
       // @ts-ignore no RN types
       props.style = [this.props.style]
-      props.autoCapitalize =
-        UIManager.AndroidTextInput.Constants.AutoCapitalizationType[props.autoCapitalize || 'sentences']
+      props.autoCapitalize = UIManager.getViewManagerConfig(
+        'AndroidTextInput'
+      ).Constants.AutoCapitalizationType[props.autoCapitalize || 'sentences']
       /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This comment
        * suppresses an error when upgrading Flow's support for React. To see the
        * error delete this comment and run Flow. */

--- a/shared/common-adapters/kb-text-input.native.tsx
+++ b/shared/common-adapters/kb-text-input.native.tsx
@@ -63,7 +63,7 @@ if (isAndroid) {
           // @ts-ignore no RN types
           onTextInput={this._onTextInput}
           // @ts-ignore no RN types
-          text={this.props.text || this.props.defaultValue || ''}
+          text={this.props.value || this.props.text || this.props.defaultValue || ''}
           children={children}
           // @ts-ignore no RN types
           disableFullscreenUI={this.props.disableFullscreenUI}

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -258,7 +258,7 @@ class PlainInput extends Component<InternalProps, State> {
     if (props.value) {
       this._lastNativeText = props.value
     }
-    return <NativeTextInput {...props} />
+    return <NativeTextInput {...props} text={props.value} />
   }
 }
 

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -258,7 +258,7 @@ class PlainInput extends Component<InternalProps, State> {
     if (props.value) {
       this._lastNativeText = props.value
     }
-    return <NativeTextInput {...props} text={props.value} />
+    return <NativeTextInput {...props} />
   }
 }
 

--- a/shared/wallets/send-form/participants/container.tsx
+++ b/shared/wallets/send-form/participants/container.tsx
@@ -55,27 +55,12 @@ const ConnectedParticipantsKeybaseUser = namedConnect(
   'ParticipantsKeybaseUser'
 )(ParticipantsKeybaseUser)
 
-// This thing has internal state to handle typing, but under some circumstances we want it to blow away all that data
-// and just take in the props again (aka remount) so, in order to achieve this in the least invasive way we'll watch the
-// route and we'll increment out key if we become topmost again
-let keyCounter = 1
-// let lastPath = ''
-
 const mapStateToPropsStellarPublicKey = state => {
   const build = state.wallets.building
   const built = build.isRequest ? state.wallets.builtRequest : state.wallets.builtPayment
 
-  // const curPath = RouteTree.getPath(state.routeTree.routeState, [Constants.rootWalletTab]).last()
-  // // looking at the form now, but wasn't before
-  // if (curPath === Constants.sendRequestFormRouteKey && curPath !== lastPath) {
-  // keyCounter++
-  // }
-
-  // lastPath = curPath
-
   return {
     errorMessage: built.toErrMsg,
-    keyCounter,
     recipientPublicKey: build.to,
   }
 }

--- a/shared/wallets/send-form/participants/index.stories.tsx
+++ b/shared/wallets/send-form/participants/index.stories.tsx
@@ -154,7 +154,6 @@ const keybaseUserProps = {
 }
 
 const stellarPublicKeyProps = {
-  keyCounter: 0,
   onChangeRecipient: Sb.action('onChangeRecipient'),
   onScanQRCode: Sb.action('onScanQRCode'),
   recipientPublicKey: '',

--- a/shared/wallets/send-form/participants/index.tsx
+++ b/shared/wallets/send-form/participants/index.tsx
@@ -18,7 +18,7 @@ const ParticipantsKeybaseUser = (props: ToKeybaseUserProps) => (
 
 const ParticipantsStellarPublicKey = (props: ToStellarPublicKeyProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
-    <ToStellarPublicKey key={props.keyCounter} {...props} />
+    <ToStellarPublicKey {...props} />
   </Kb.Box2>
 )
 

--- a/shared/wallets/send-form/participants/to-field.tsx
+++ b/shared/wallets/send-form/participants/to-field.tsx
@@ -94,6 +94,15 @@ class ToStellarPublicKey extends React.Component<ToStellarPublicKeyProps, ToStel
     this._propsOnChangeRecipient(recipientPublicKey)
   }
 
+  componentDidUpdate(prevProps: ToStellarPublicKeyProps, prevState: ToStellarPublicKeyState) {
+    if (
+      this.props.recipientPublicKey !== prevProps.recipientPublicKey &&
+      this.props.recipientPublicKey !== this.state.recipientPublicKey
+    ) {
+      this.setState({recipientPublicKey: this.props.recipientPublicKey})
+    }
+  }
+
   render = () => (
     <ParticipantsRow
       heading="To"

--- a/shared/wallets/send-form/participants/to-field.tsx
+++ b/shared/wallets/send-form/participants/to-field.tsx
@@ -78,7 +78,6 @@ export type ToStellarPublicKeyProps = {
   onChangeRecipient: (recipient: string) => void
   onScanQRCode: (() => void) | null
   setReadyToReview: (ready: boolean) => void
-  keyCounter: number
 }
 
 type ToStellarPublicKeyState = {


### PR DESCRIPTION
@keybase/react-hackers CC @keybase/picnicsquad 

Maybe someone who's been in `<PlainInput />` more recently can help figure out what's happened here-- we use `<Kb.NewInput value='foo' />` in a bunch of places, and that gets passed through to `<Kb.PlainInput value='foo' />` and ultimately `<RN.NativeTextInput value='foo' />`, but that native component seems to want `text=` instead of `value=`?  Still trying to figure out when/how this broke.

This PR fixes the Stellar QR code scanner not updating the To: public key after a scan.