### PR TITLE
fix menubar icon on OSX light mode

### DIFF
--- a/shared/desktop/app/menu-bar.desktop.tsx
+++ b/shared/desktop/app/menu-bar.desktop.tsx
@@ -37,7 +37,7 @@ export default function(menubarWindowIDCallback: (id: number) => void) {
   })
 
   const updateIcon = selected => {
-    mb.tray.setImage(resolveImage('menubarIcon', selected ? icon : selectedIcon))
+    mb.tray.setImage(resolveImage('menubarIcon', selected ? selectedIcon : icon))
   }
   const setIcons = (regular, selected) => {
     icon = regular


### PR DESCRIPTION
Ternary operators are dumb eom

thanks for finding this, @patrickxb 