### PR TITLE
Have links to the info panel take you to the right tab

### DIFF
--- a/shared/chat/conversation/messages/retention-notice/container.tsx
+++ b/shared/chat/conversation/messages/retention-notice/container.tsx
@@ -39,7 +39,12 @@ const mapDispatchToProps = (dispatch, ownProps: OwnProps) => ({
   onChange: () =>
     dispatch(
       RouteTreeGen.createNavigateAppend({
-        path: [{props: {conversationIDKey: ownProps.conversationIDKey}, selected: 'chatInfoPanel'}],
+        path: [
+          {
+            props: {conversationIDKey: ownProps.conversationIDKey, tab: 'settings'},
+            selected: 'chatInfoPanel',
+          },
+        ],
       })
     ),
 })

--- a/shared/chat/conversation/messages/system-added-to-team/container.tsx
+++ b/shared/chat/conversation/messages/system-added-to-team/container.tsx
@@ -30,7 +30,7 @@ const mapDispatchToProps = dispatch => ({
   _onManageNotifications: conversationIDKey =>
     dispatch(
       RouteTreeGen.createNavigateAppend({
-        path: [{props: {conversationIDKey: conversationIDKey}, selected: 'chatInfoPanel'}],
+        path: [{props: {conversationIDKey: conversationIDKey, tab: 'settings'}, selected: 'chatInfoPanel'}],
       })
     ),
   _onViewTeam: (teamname: string) => {

--- a/shared/chat/conversation/messages/system-change-retention/container.tsx
+++ b/shared/chat/conversation/messages/system-change-retention/container.tsx
@@ -40,7 +40,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   _onManageRetention: conversationIDKey =>
     dispatch(
       RouteTreeGen.createNavigateAppend({
-        path: [{props: {conversationIDKey}, selected: 'chatInfoPanel'}],
+        path: [{props: {conversationIDKey, tab: 'settings'}, selected: 'chatInfoPanel'}],
       })
     ),
 })

--- a/shared/chat/conversation/messages/system-joined/container.tsx
+++ b/shared/chat/conversation/messages/system-joined/container.tsx
@@ -31,7 +31,7 @@ const mapDispatchToProps = dispatch => ({
   _onManageNotifications: conversationIDKey =>
     dispatch(
       RouteTreeGen.createNavigateAppend({
-        path: [{props: {conversationIDKey: conversationIDKey}, selected: 'chatInfoPanel'}],
+        path: [{props: {conversationIDKey: conversationIDKey, tab: 'settings'}, selected: 'chatInfoPanel'}],
       })
     ),
 })


### PR DESCRIPTION
Changes links in chat to "manage notifications" and "manage retention" take you to the settings tab of the info panel. r? @keybase/react-hackers 