### PR TITLE
View RPC model 1: No side effects to initial call

### DIFF
--- a/shared/actions/wallets-ui.tsx
+++ b/shared/actions/wallets-ui.tsx
@@ -1,0 +1,17 @@
+import * as Constants from '../constants/wallets'
+import * as Types from '../constants/types/wallets'
+import * as WalletsGen from './wallets-gen'
+import * as RPCStellarGen from '../constants/types/rpc-stellar-gen'
+
+export const changeAccountName = (params: {accountID: Types.AccountID; newName: string}, dispatch) => {
+  const {accountID, newName} = params
+  return RPCStellarGen.localChangeWalletAccountNameLocalRpcPromise(
+    {accountID, newName},
+    Constants.changeAccountNameWaitingKey
+  )
+    .then(() => dispatch(WalletsGen.createChangedAccountName({accountID})))
+    .catch(error => {
+      dispatch(WalletsGen.createChangedAccountNameError({error: error.message, name: newName}))
+      throw error
+    })
+}

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -679,10 +679,7 @@ const createdOrLinkedAccount = (
   return RouteTreeGen.createNavigateUp()
 }
 
-const navigateUp = (
-  state,
-  action: WalletsGen.DidSetAccountAsDefaultPayload | WalletsGen.ChangedAccountNamePayload
-) => {
+const navigateUp = (state, action: WalletsGen.DidSetAccountAsDefaultPayload) => {
   if (actionHasError(action)) {
     // we don't want to nav on error
     return
@@ -1201,8 +1198,8 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
     navigateToTransaction,
     'navigateToTransaction'
   )
-  yield* Saga.chainAction<WalletsGen.DidSetAccountAsDefaultPayload | WalletsGen.ChangedAccountNamePayload>(
-    [WalletsGen.didSetAccountAsDefault, WalletsGen.changedAccountName],
+  yield* Saga.chainAction<WalletsGen.DidSetAccountAsDefaultPayload>(
+    [WalletsGen.didSetAccountAsDefault],
     navigateUp,
     'navigateUp'
   )

--- a/shared/wallets/wallet/settings/popups/rename-account/container.tsx
+++ b/shared/wallets/wallet/settings/popups/rename-account/container.tsx
@@ -4,6 +4,7 @@ import * as Constants from '../../../../../constants/wallets'
 import * as Types from '../../../../../constants/types/wallets'
 import * as WalletsGen from '../../../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
+import {changeAccountName} from '../../../../../actions/wallets-ui'
 import {anyWaiting} from '../../../../../constants/waiting'
 import RenameAccount from '.'
 
@@ -32,8 +33,8 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 const mapDispatchToProps = dispatch => ({
-  _onChangeAccountName: (accountID: Types.AccountID, name: string) =>
-    dispatch(WalletsGen.createChangeAccountName({accountID, name})),
+  _onChangeAccountName: (accountID: Types.AccountID, newName: string) =>
+    changeAccountName({accountID, newName}, dispatch),
   onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),
   onClearErrors: () => dispatch(WalletsGen.createClearErrors()),
   onDone: (name: string) => {


### PR DESCRIPTION
Has the view more or less directly call the RPC.

- The RPC call lives in a different module because side effects for success / error may still exist, and it's not the view's job to know what those are.
- No side effects of the initial call avoids problems with multiple listeners trying to fulfill the same promise.

I implemented a PoC in wallets rename-account - I think this is a good example of a typical use case.

- Nothing else needs to know we're making the call to validate the account name or do the rename.
- It's awkward to encode in the store that the validation succeeded and that we should make the rename call.