### PR TITLE
Show profile folder actions on mobile

### DIFF
--- a/shared/profile/user/actions/index.tsx
+++ b/shared/profile/user/actions/index.tsx
@@ -132,8 +132,8 @@ const DropdownButton = Kb.OverlayParentHOC((p: Kb.PropsWithOverlay<DropdownProps
     {onClick: p.onAddToTeam, title: 'Add to team...'},
     {newTag: true, onClick: p.onSendLumens, title: 'Send Lumens (XLM)'},
     {newTag: true, onClick: p.onRequestLumens, title: 'Request Lumens (XLM)'},
-    !Styles.isMobile ? {onClick: p.onOpenPrivateFolder, title: 'Open private folder'} : null,
-    !Styles.isMobile ? {onClick: p.onBrowsePublicFolder, title: 'Browse public folder'} : null,
+    {onClick: p.onOpenPrivateFolder, title: 'Open private folder'},
+    {onClick: p.onBrowsePublicFolder, title: 'Browse public folder'},
     p.onUnfollow && {onClick: p.onUnfollow && p.onUnfollow, style: {borderTopWidth: 0}, title: 'Unfollow'},
   ].filter(Boolean)
 


### PR DESCRIPTION
\+ @songgao this seems to work on ios simulator. If it's more complicated, I can leave it for the ticket cecile said you know about.

![image](https://user-images.githubusercontent.com/705646/59132531-73324800-8943-11e9-8e16-0ed7fb9cd287.png)
