### PR TITLE
data: implement a per-node string obfuscator

### DIFF
--- a/go/kbfs/data/interfaces.go
+++ b/go/kbfs/data/interfaces.go
@@ -304,3 +304,10 @@ type DirtyBlockCache interface {
 	// returns an error if there are any unsynced blocks.
 	Shutdown() error
 }
+
+// Obfuscator can transform a given plaintext string into a
+// securely-obfuscated, but still human-readable, string.
+type Obfuscator interface {
+	// Obfuscate returns an obfuscated version of `plaintext`.
+	Obfuscate(plaintext string) string
+}

--- a/go/kbfs/data/node_obfuscator.go
+++ b/go/kbfs/data/node_obfuscator.go
@@ -1,0 +1,145 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package data
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/keybase/client/go/libkb"
+)
+
+const (
+	separator = "-"
+)
+
+// NodeObfuscatorSecret is a byte slice wrapper for a secret that can
+// be passed to `NodeObfuscator`.  It overrides `String` so there's no
+// chance of the secret being accidentally logged.
+type NodeObfuscatorSecret []byte
+
+// String implements the `fmt.Stringer` interface for NodeObfuscatorSecret.
+func (nos NodeObfuscatorSecret) String() string {
+	return fmt.Sprintf("{private %d bytes}", len(nos))
+}
+
+// NodeObfuscator takes a secret, and uses it to create obfuscate
+// strings based on BIP-0039 dictionary words.  It remembers previous
+// obfuscations, and if there happens to be a collision on the
+// obfuscated text for a new plaintext string, it appends a numeric
+// suffix to the new obfuscation.
+type NodeObfuscator struct {
+	secret NodeObfuscatorSecret
+
+	lock     sync.RWMutex
+	obsCache map[string]string
+	usedObs  map[string]bool
+}
+
+var _ Obfuscator = (*NodeObfuscator)(nil)
+
+// NewNodeObfuscator creates a new `NodeObfuscator` instance.
+func NewNodeObfuscator(secret NodeObfuscatorSecret) *NodeObfuscator {
+	return &NodeObfuscator{
+		secret: secret,
+		// Don't initialize caches yet, for memory reasons, in case
+		// they're never used.
+	}
+}
+
+func (no *NodeObfuscator) checkCacheIfExistsLocked(
+	plaintext string) (string, bool) {
+	if no.obsCache == nil {
+		return "", false
+	}
+
+	obs, ok := no.obsCache[plaintext]
+	return obs, ok
+}
+
+func (no *NodeObfuscator) checkCacheIfExists(plaintext string) (string, bool) {
+	no.lock.RLock()
+	defer no.lock.RUnlock()
+	return no.checkCacheIfExistsLocked(plaintext)
+}
+
+func (no *NodeObfuscator) obfuscateWithHasher(
+	plaintext string, hasher func(string) []byte) string {
+	obs, ok := no.checkCacheIfExists(plaintext)
+	if ok {
+		return obs
+	}
+
+	no.lock.Lock()
+	defer no.lock.Unlock()
+	// See if it's been cached since we last released the lock.
+	obs, ok = no.checkCacheIfExistsLocked(plaintext)
+	if ok {
+		return obs
+	}
+
+	if no.obsCache == nil {
+		no.obsCache = make(map[string]string)
+		no.usedObs = make(map[string]bool)
+	}
+
+	// HMAC the plaintext with the secret, to get a hash.
+	buf := hasher(plaintext)
+
+	// Look up two words based on the first three bytes of the mac.
+	// (Each word takes 11 bits to lookup a unique word among the 2048
+	// secret words.)
+	first := int(buf[0])
+	// First 8 bits are from buf[0].
+	first <<= 3
+	// Last 3 bits are the first 3 bits of buf[1].
+	const first3 = 0x7 << 5
+	first |= ((int(buf[1]) & first3) >> 5)
+	if float64(first) >= math.Exp2(11) {
+		panic(fmt.Sprintf("Generated %d from 11 bits", first))
+	}
+
+	// First 5 bits are the last 5 bits of buf[1].
+	const last5 = 0x1f
+	second := int(buf[1]) & last5
+	second <<= 6
+	// Last 6 bits are the first 6 bits of buf[2].
+	const first6 = 0x3f << 2
+	second |= ((int(buf[2]) & first6) >> 2)
+	if float64(second) >= math.Exp2(11) {
+		panic(fmt.Sprintf("Generated %d from 11 bits", second))
+	}
+
+	firstWord := libkb.SecWord(first)
+	secondWord := libkb.SecWord(second)
+	obs = strings.Join([]string{firstWord, secondWord}, separator)
+
+	suffix := 1
+	for no.usedObs[obs] {
+		suffix++
+		obs = strings.Join(
+			[]string{firstWord, secondWord, strconv.Itoa(suffix)}, separator)
+	}
+
+	no.obsCache[plaintext] = obs
+	no.usedObs[obs] = true
+	return obs
+}
+
+func (no *NodeObfuscator) defaultHash(plaintext string) []byte {
+	mac := hmac.New(sha256.New, no.secret)
+	mac.Write([]byte(plaintext))
+	return mac.Sum(nil)
+}
+
+// Obfuscate implements the `Obfuscator` interface for NodeObfuscator.
+func (no *NodeObfuscator) Obfuscate(plaintext string) string {
+	return no.obfuscateWithHasher(plaintext, no.defaultHash)
+}

--- a/go/kbfs/data/node_obfuscator_test.go
+++ b/go/kbfs/data/node_obfuscator_test.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package data
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeObfuscatorBasic(t *testing.T) {
+	secret := NodeObfuscatorSecret([]byte{1, 2, 3, 4})
+	no := NewNodeObfuscator(secret)
+
+	t.Log("Obfuscate with the default hasher")
+	obs := no.Obfuscate("test")
+	require.NotEqual(t, "", obs)
+
+	t.Log("Make sure it has two valid sec words")
+	words := strings.Split(obs, separator)
+	require.Len(t, words, 2)
+	require.True(t, libkb.ValidSecWord(words[0]), words[0])
+	require.True(t, libkb.ValidSecWord(words[1]), words[1])
+
+	t.Log("Make sure caching works")
+	obs2 := no.obfuscateWithHasher("test", func(_ string) []byte {
+		panic("Hash called")
+	})
+	require.Equal(t, obs, obs2)
+}
+
+func TestNodeObfuscatorCollisions(t *testing.T) {
+	secret := NodeObfuscatorSecret([]byte{1, 2, 3, 4})
+	no := NewNodeObfuscator(secret)
+
+	t.Log("Obfuscate with a test hash to get a known string")
+	hasher1 := func(_ string) []byte {
+		return []byte{0, 0, 4} // first = 0, second = 1
+	}
+	obs := no.obfuscateWithHasher("test", hasher1)
+	first := libkb.SecWord(0)
+	second := libkb.SecWord(1)
+	expectedObs := strings.Join([]string{first, second}, separator)
+	require.Equal(t, expectedObs, obs)
+
+	t.Log("Obfuscate a new plaintext string with the same hash")
+	obs2 := no.obfuscateWithHasher("test2", hasher1)
+	expectedObs2 := strings.Join([]string{first, second, "2"}, separator)
+	require.Equal(t, expectedObs2, obs2)
+
+	t.Log("And one more, with a different hash but the same first 3 bytes")
+	hasher2 := func(_ string) []byte {
+		return []byte{0, 0, 7} // first = 0, second = 1
+	}
+	obs3 := no.obfuscateWithHasher("test3", hasher2)
+	expectedObs3 := strings.Join([]string{first, second, "3"}, separator)
+	require.Equal(t, expectedObs3, obs3)
+
+	t.Log("Make sure we get the original result again for the first string")
+	obs4 := no.obfuscateWithHasher("test", hasher1)
+	require.Equal(t, obs, obs4)
+}

--- a/go/kbfs/data/node_obfuscator_test.go
+++ b/go/kbfs/data/node_obfuscator_test.go
@@ -52,7 +52,7 @@ func TestNodeObfuscatorCollisions(t *testing.T) {
 	expectedObs2 := strings.Join([]string{first, second, "2"}, separator)
 	require.Equal(t, expectedObs2, obs2)
 
-	t.Log("And one more, with a different hash but the same first 3 bytes")
+	t.Log("And one more, with a different hash but the same first 22 bits")
 	hasher2 := func(_ string) []byte {
 		return []byte{0, 0, 7} // first = 0, second = 1
 	}

--- a/go/libkb/secwords.go
+++ b/go/libkb/secwords.go
@@ -63,6 +63,12 @@ func ValidSecWord(w string) bool {
 	return secwordSet[w]
 }
 
+// SecWord returns the n'th word from the BIP-0039 list, mod the size
+// of the list.
+func SecWord(n int) string {
+	return secwords[n%len(secwords)]
+}
+
 // Wordlist from BIP0039:
 //  https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt
 //


### PR DESCRIPTION
This obfuscator takes in a secret, and obfuscates a given plaintext
string this way:

* `strHash` = `sha256-hmac(secret, plaintext)`
* Use the first 3 bytes of `strHash` to index into the secwords (bip-0039) list in libkb/secwords.go, getting two words.
* Join those two words with a dash, to get `obfuscatedStr`.
* If this collides with a previously-obfuscated string created by this same node, a numeric suffix like "-2" is appended to the obfuscated string.

In a future PR, there will be one `NodeObfuscator` for each directory's `libkbfs.Node`, for obfuscating entry names within that directory.

cc: @keybase/hotpotatosquad 

Issue: HOTPOT-55