### PR TITLE
load teams on naving in. clear badges on naving away

### DIFF
--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -48,9 +48,7 @@
       "_description": "Fetches the channel information for all channels in a team from the server. Should only be called for components that need the full list.",
       "teamname": "string"
     },
-    "getTeams": {
-      "clearNavBadges?": "boolean"
-    },
+    "getTeams": {},
     "getDetails": {
       "teamname": "string"
     },

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -161,7 +161,7 @@ type _GetTeamOperationsPayload = {readonly teamname: string}
 type _GetTeamProfileAddListPayload = {readonly username: string}
 type _GetTeamPublicityPayload = {readonly teamname: string}
 type _GetTeamRetentionPolicyPayload = {readonly teamname: string}
-type _GetTeamsPayload = {readonly clearNavBadges?: boolean}
+type _GetTeamsPayload = void
 type _IgnoreRequestPayload = {readonly teamname: string; readonly username: string}
 type _InviteToTeamByEmailPayload = {
   readonly destSubPath?: I.List<string>
@@ -406,10 +406,7 @@ export const createGetTeamPublicity = (payload: _GetTeamPublicityPayload): GetTe
   payload,
   type: getTeamPublicity,
 })
-export const createGetTeams = (payload: _GetTeamsPayload = Object.freeze({})): GetTeamsPayload => ({
-  payload,
-  type: getTeams,
-})
+export const createGetTeams = (payload: _GetTeamsPayload): GetTeamsPayload => ({payload, type: getTeams})
 export const createIgnoreRequest = (payload: _IgnoreRequestPayload): IgnoreRequestPayload => ({
   payload,
   type: ignoreRequest,

--- a/shared/git/new-repo/container.tsx
+++ b/shared/git/new-repo/container.tsx
@@ -22,7 +22,7 @@ const mapStateToProps = (state, {routeProps, navigation}) => ({
 })
 
 const mapDispatchToProps = (dispatch: any, {navigateAppend, navigateUp, routeProps, navigation}) => ({
-  loadTeams: () => dispatch(TeamsGen.createGetTeams({clearNavBadges: false})),
+  loadTeams: () => dispatch(TeamsGen.createGetTeams()),
   onCancel: () => dispatch(navigateUp()),
   onClose: () => dispatch(navigateUp()),
   onCreate: (name: string, teamname: string | null, notifyTeam: boolean) => {

--- a/shared/profile/showcase-team-offer/container.tsx
+++ b/shared/profile/showcase-team-offer/container.tsx
@@ -26,7 +26,7 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = dispatch => ({
-  loadTeams: teamname => dispatch(TeamsGen.createGetTeams({clearNavBadges: false})),
+  loadTeams: teamname => dispatch(TeamsGen.createGetTeams()),
   onCancel: (you: string) => {
     // sadly a little racy, doing this for now
     setTimeout(() => {

--- a/shared/profile/showcased-team-info/container.tsx
+++ b/shared/profile/showcased-team-info/container.tsx
@@ -52,7 +52,7 @@ const mapDispatchToProps = (dispatch, {team}: OwnProps) => {
   const teamname = team.fqName
   return {
     _checkRequestedAccess: () => dispatch(TeamsGen.createCheckRequestedAccess({teamname})),
-    _loadTeams: () => dispatch(TeamsGen.createGetTeams({clearNavBadges: false})),
+    _loadTeams: () => dispatch(TeamsGen.createGetTeams()),
     _onSetTeamJoinError: (error: string) => dispatch(TeamsGen.createSetTeamJoinError({error})),
     _onSetTeamJoinSuccess: (success: boolean) =>
       dispatch(TeamsGen.createSetTeamJoinSuccess({success, teamname: ''})),

--- a/shared/teams/invite-by-email/container.desktop.tsx
+++ b/shared/teams/invite-by-email/container.desktop.tsx
@@ -29,7 +29,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   onInvite: (invitees: string, role: Types.TeamRoleType) => {
     const teamname = getRouteProps(ownProps, 'teamname')
     dispatch(TeamsGen.createInviteToTeamByEmail({invitees, role, teamname}))
-    dispatch(TeamsGen.createGetTeams({clearNavBadges: false}))
+    dispatch(TeamsGen.createGetTeams())
   },
 })
 

--- a/shared/teams/invite-by-email/container.native.tsx
+++ b/shared/teams/invite-by-email/container.native.tsx
@@ -64,7 +64,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         teamname,
       })
     )
-    dispatch(TeamsGen.createGetTeams({clearNavBadges: false}))
+    dispatch(TeamsGen.createGetTeams())
   },
   onInvitePhone: ({invitee, role, fullName = ''}) => {
     dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))
@@ -76,7 +76,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         teamname: getRouteProps(ownProps, 'teamname'),
       })
     )
-    dispatch(TeamsGen.createGetTeams({clearNavBadges: false}))
+    dispatch(TeamsGen.createGetTeams())
   },
   onUninvite: (invitee: string, id?: string) => {
     dispatch(TeamsGen.createSetEmailInviteError({malformed: [], message: ''}))


### PR DESCRIPTION
@keybase/react-hackers @keybase/hotpotatosquad this changes how team badging gets cleared.
before when you loaded it'd clear (but this only happened once due to how the tab nav worked)
instead it's more like a chat convo in that when the root gets mounted it loads and when it gets unmounted it clears. We could do a more granular thing where the individual badges get cleared as you go into them or whatever later. this is small and should unblock the issue for release.