### PR TITLE
Fix 'unsubscribe all' notifications checkboxes persisting in settings

### DIFF
--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -348,7 +348,7 @@ function* refreshNotifications() {
   const groups = results.notifications
   const notifications = mapValues(groups, group => ({
     settings: group.settings.map(settingsToPayload),
-    unsub: group.unsub,
+    unsubscribedFromAll: group.unsub,
   }))
 
   yield Saga.put(


### PR DESCRIPTION
Seems to have been broken for a long time. r? @keybase/react-hackers 