### PR TITLE
Show currency symbol on send form

### DIFF
--- a/shared/wallets/send-form/asset-input/container.tsx
+++ b/shared/wallets/send-form/asset-input/container.tsx
@@ -11,7 +11,7 @@ const mapStateToProps = state => {
   return {
     bottomLabel: '', // TODO
     currencyLoading: currency === '',
-    displayUnit: currency,
+    displayUnit: Constants.getCurrencyAndSymbol(state, currency) || currency,
     // TODO differentiate between an asset (7 digits) and a display currency (2 digits) below
     inputPlaceholder: currency !== 'XLM' ? '0.00' : '0.0000000',
     numDecimalsAllowed: currency !== 'XLM' ? 2 : 7,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/705646/59216229-38215600-8b89-11e9-903a-86013a2d459a.png)
Technically it could be missing if state `currencies` hasn't loaded. In that case it would show just "NOK". I haven't been able to elicit that state, so hopefully it's rare.