### PR TITLE
favorites: fix shutdown race in two ways

### DIFF
--- a/go/kbfs/libkbfs/favorites.go
+++ b/go/kbfs/libkbfs/favorites.go
@@ -613,7 +613,8 @@ func (f *Favorites) loop() {
 			select {
 			case req, ok := <-f.bufferedReqChan:
 				if !ok {
-					return
+					// Still need to close out any regular requests.
+					continue
 				}
 				// Don't block the wait group on buffered requests
 				// until we're actually processing one.

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1903,9 +1903,9 @@ type InitMode interface {
 	// OldStorageRootCleaningEnabled indicates whether we should clean
 	// old temporary storage root directories.
 	OldStorageRootCleaningEnabled() bool
-	// DoRefreshCachedFavorites indicates whether we should refresh
+	// DoRefreshFavoritesOnInit indicates whether we should refresh
 	// our cached versions of the favorites immediately upon a login.
-	DoRefreshCachedFavorites() bool
+	DoRefreshFavoritesOnInit() bool
 }
 
 type initModeGetter interface {

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1903,6 +1903,9 @@ type InitMode interface {
 	// OldStorageRootCleaningEnabled indicates whether we should clean
 	// old temporary storage root directories.
 	OldStorageRootCleaningEnabled() bool
+	// DoRefreshCachedFavorites indicates whether we should refresh
+	// our cached versions of the favorites immediately upon a login.
+	DoRefreshCachedFavorites() bool
 }
 
 type initModeGetter interface {

--- a/go/kbfs/libkbfs/keybase_service_util.go
+++ b/go/kbfs/libkbfs/keybase_service_util.go
@@ -123,7 +123,10 @@ func serviceLoggedIn(ctx context.Context, config Config, session idutil.SessionI
 		go bServer.RefreshAuthToken(context.Background())
 	}
 
-	config.KBFSOps().RefreshCachedFavorites(ctx, FavoritesRefreshModeInMainFavoritesLoop)
+	if config.Mode().DoRefreshCachedFavorites() {
+		config.KBFSOps().RefreshCachedFavorites(
+			ctx, FavoritesRefreshModeInMainFavoritesLoop)
+	}
 	config.KBFSOps().PushStatusChange()
 	return wg
 }

--- a/go/kbfs/libkbfs/keybase_service_util.go
+++ b/go/kbfs/libkbfs/keybase_service_util.go
@@ -123,7 +123,7 @@ func serviceLoggedIn(ctx context.Context, config Config, session idutil.SessionI
 		go bServer.RefreshAuthToken(context.Background())
 	}
 
-	if config.Mode().DoRefreshCachedFavorites() {
+	if config.Mode().DoRefreshFavoritesOnInit() {
 		config.KBFSOps().RefreshCachedFavorites(
 			ctx, FavoritesRefreshModeInMainFavoritesLoop)
 	}

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -164,7 +164,7 @@ func (md modeDefault) OldStorageRootCleaningEnabled() bool {
 	return true
 }
 
-func (md modeDefault) DoRefreshCachedFavorites() bool {
+func (md modeDefault) DoRefreshFavoritesOnInit() bool {
 	return true
 }
 
@@ -311,7 +311,7 @@ func (mm modeMinimal) OldStorageRootCleaningEnabled() bool {
 	return false
 }
 
-func (mm modeMinimal) DoRefreshCachedFavorites() bool {
+func (mm modeMinimal) DoRefreshFavoritesOnInit() bool {
 	return false
 }
 
@@ -387,7 +387,7 @@ func (mso modeSingleOp) OldStorageRootCleaningEnabled() bool {
 	return false
 }
 
-func (mso modeSingleOp) DoRefreshCachedFavorites() bool {
+func (mso modeSingleOp) DoRefreshFavoritesOnInit() bool {
 	return false
 }
 

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -164,6 +164,10 @@ func (md modeDefault) OldStorageRootCleaningEnabled() bool {
 	return true
 }
 
+func (md modeDefault) DoRefreshCachedFavorites() bool {
+	return true
+}
+
 // Minimal mode:
 
 type modeMinimal struct {
@@ -307,6 +311,10 @@ func (mm modeMinimal) OldStorageRootCleaningEnabled() bool {
 	return false
 }
 
+func (mm modeMinimal) DoRefreshCachedFavorites() bool {
+	return false
+}
+
 // Single op mode:
 
 type modeSingleOp struct {
@@ -376,6 +384,10 @@ func (mso modeSingleOp) LocalHTTPServerEnabled() bool {
 }
 
 func (mso modeSingleOp) OldStorageRootCleaningEnabled() bool {
+	return false
+}
+
+func (mso modeSingleOp) DoRefreshCachedFavorites() bool {
 	return false
 }
 


### PR DESCRIPTION
1. When a favorites operation triggers with a long timeout (like the background favorites refresh done on login), the main favorites loop can get blocked on it, and then when it finishes, it will check for buffered, timer-based requests (once every 5 seconds).  If it finds the buffered channel is closed (because `Shutdown` has already been called) then it returned immediately, without letting any of the requests buffered in the other channel complete, leading to a hang in the `Shutdown` code while waiting on the request group.

2. The above race happens in git because `Shutdown` is called on the critical path.  But there's no reason for git code to be refreshing favorites in the background, because it doesn't even have a proper favorites DB since a fresh directory is used for every operation.  So don't bother refreshing the favorites when in that mode.

Issue: HOTPOT-73