### PR TITLE
clear log send data on resend

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -284,6 +284,7 @@ func LogSend(statusJSON string, feedback string, sendLogs bool, uiLogPath, trace
 	logSendContext.Logs.CPUProfile = cpuProfileDir
 
 	logSendID, err := logSendContext.LogSend(sendLogs, status.LogSendDefaultBytesMobile, true /* mergeExtendedStatus */)
+	logSendContext.Clear()
 	return string(logSendID), err
 }
 

--- a/go/status/log_send.go
+++ b/go/status/log_send.go
@@ -283,20 +283,6 @@ func (l *LogSendContext) LogSend(sendLogs bool, numBytes int, mergeExtendedStatu
 			l.StatusJSON = l.mergeExtendedStatus(l.StatusJSON)
 		}
 		l.processesLog = keybaseProcessList()
-	} else {
-		l.svcLog = ""
-		l.ekLog = ""
-		l.kbfsLog = ""
-		l.desktopLog = ""
-		l.updaterLog = ""
-		l.startLog = ""
-		l.installLog = ""
-		l.systemLog = ""
-		l.gitLog = ""
-		l.watchdogLog = ""
-		l.traceBundle = []byte{}
-		l.cpuProfileBundle = []byte{}
-		l.processesLog = ""
 	}
 
 	return l.post(mctx)
@@ -310,4 +296,22 @@ func (l *LogSendContext) mergeExtendedStatus(status string) string {
 		return status
 	}
 	return MergeStatusJSON(extStatus, "extstatus", status)
+}
+
+// Clear removes any log data that we don't want to stick around until the
+// next time LogSend is called, in case sendLogs is false the next time.
+func (l *LogSendContext) Clear() {
+	l.svcLog = ""
+	l.ekLog = ""
+	l.kbfsLog = ""
+	l.desktopLog = ""
+	l.updaterLog = ""
+	l.startLog = ""
+	l.installLog = ""
+	l.systemLog = ""
+	l.gitLog = ""
+	l.watchdogLog = ""
+	l.traceBundle = []byte{}
+	l.cpuProfileBundle = []byte{}
+	l.processesLog = ""
 }

--- a/go/status/log_send.go
+++ b/go/status/log_send.go
@@ -283,6 +283,20 @@ func (l *LogSendContext) LogSend(sendLogs bool, numBytes int, mergeExtendedStatu
 			l.StatusJSON = l.mergeExtendedStatus(l.StatusJSON)
 		}
 		l.processesLog = keybaseProcessList()
+	} else {
+		l.svcLog = ""
+		l.ekLog = ""
+		l.kbfsLog = ""
+		l.desktopLog = ""
+		l.updaterLog = ""
+		l.startLog = ""
+		l.installLog = ""
+		l.systemLog = ""
+		l.gitLog = ""
+		l.watchdogLog = ""
+		l.traceBundle = []byte{}
+		l.cpuProfileBundle = []byte{}
+		l.processesLog = ""
 	}
 
 	return l.post(mctx)


### PR DESCRIPTION
Previously, if you sent a log with `sendLogs` checked and then sent another with it unchecked, some logs would still be sent.

cc @buoyad