### PR TITLE
force refresh team cache on subteam rename

### DIFF
--- a/go/chat/subteam_rename_test.go
+++ b/go/chat/subteam_rename_test.go
@@ -144,55 +144,23 @@ func TestChatSubteamRename(t *testing.T) {
 			require.Fail(t, "unexpected update")
 		case <-time.After(2 * time.Second):
 		}
+		ib, _, err := tc.ChatG.InboxSource.Read(context.TODO(), users[0].User.GetUID().ToBytes(),
+			types.ConversationLocalizerBlocking, types.InboxSourceDataSourceAll, nil,
+			&chat1.GetInboxLocalQuery{
+				ConvIDs: u1ExpectedUpdates,
+			}, nil)
+		require.NoError(t, err)
+		require.True(t, len(ib.Convs) >= len(u1ExpectedUpdates))
 
-		pollIB := func() *types.Inbox {
-			ib, _, err := tc.ChatG.InboxSource.Read(context.TODO(), users[0].User.GetUID().ToBytes(),
-				types.ConversationLocalizerBlocking, types.InboxSourceDataSourceAll, nil,
-				&chat1.GetInboxLocalQuery{
-					ConvIDs: u1ExpectedUpdates,
-				}, nil)
-			require.NoError(t, err)
-			require.True(t, len(ib.Convs) >= len(u1ExpectedUpdates))
-			for _, conv := range ib.Convs {
-				convID := conv.GetConvID()
-				if convID.Eq(subConv1.Id) || convID.Eq(subConv2.Id) {
-					if newSubteamName.String() != conv.Info.TlfName {
-						return nil
-					}
-				}
-				if convID.Eq(subSubConv1.Id) || convID.Eq(subSubConv2.Id) {
-					if newSubSubteamName.String() != conv.Info.TlfName {
-						return nil
-					}
-				}
-			}
-			return &ib
-		}
-
-		// Poll a few times to Read the inbox. Once gregor notifications come in that the teams changed, we'll
-		// get the right answer for the subteam name checks in the poll functions.  But until that happens
-		// we can retry.
-		var ib *types.Inbox
-		wait := 10 * time.Millisecond
-		for i := 0; i < 10; i++ {
-			ib = pollIB()
-			if ib != nil {
-				break
-			}
-			t.Logf("Polled for conversation name upgrades, but they weren't here yet, will wait %v and retry", wait)
-			time.Sleep(wait)
-			wait *= 2
-		}
-
-		// If this happened, we failed our poll many times in a row!
-		require.NotNil(t, ib)
-
+		numFound := 0
 		for _, conv := range ib.Convs {
 			convID := conv.GetConvID()
 			if convID.Eq(subConv1.Id) || convID.Eq(subConv2.Id) {
 				require.Equal(t, newSubteamName.String(), conv.Info.TlfName)
+				numFound++
 			} else if convID.Eq(subSubConv1.Id) || convID.Eq(subSubConv2.Id) {
 				require.Equal(t, newSubSubteamName.String(), conv.Info.TlfName)
+				numFound++
 			}
 			require.NotEqual(t, versMap[conv.GetConvID().String()], conv.Info.Version)
 
@@ -220,5 +188,6 @@ func TestChatSubteamRename(t *testing.T) {
 				require.True(t, msg.IsValid())
 			}
 		}
+		require.Equal(t, len(u1ExpectedUpdates), numFound)
 	})
 }


### PR DESCRIPTION
reverts part of https://github.com/keybase/client/pull/14090, lmk if you want cache bust in a different place @mmaxim 

addresses https://github.com/keybase/client/issues/17670

cc @keybase/hotpotatosquad 