### PR TITLE
data: implement PathPartString

### DIFF
--- a/go/kbfs/data/path_part_string.go
+++ b/go/kbfs/data/path_part_string.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package data
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	prefixToSkipObfsucation = ".kbfs_"
+	tarGzSuffix             = ".tar.gz"
+
+	// extRestoreMaxLen specifies the max length of an extension, such
+	// that it's restored to the obfuscated string.  It includes the
+	// leading dot.
+	extRestoreMaxLen = 5
+)
+
+// PathPartString returns an obfuscated version of part of a path,
+// preserving the suffixes if they're small enough or if it's a
+// conflicted copy of a file.  Two `PathPartString`s for the asme
+// plaintext data, created using the same `Obfuscator`, should pass
+// equality checks.
+type PathPartString struct {
+	plaintext  string
+	ext        string
+	obsfucator Obfuscator
+}
+
+var _ fmt.Stringer = PathPartString{}
+
+// NewPathPartString creates a new `PathPartString` instance, given a
+// plaintext string representing one part of a path, and a
+// `Obfuscator`.
+func NewPathPartString(
+	plaintext string, obfuscator Obfuscator) PathPartString {
+	_, ext := SplitFileExtension(plaintext)
+	if len(ext) > extRestoreMaxLen && ext != tarGzSuffix {
+		ext = ""
+	}
+	conflictedIndex := strings.LastIndex(plaintext, ".conflicted (")
+	if conflictedIndex > 0 {
+		ext = plaintext[conflictedIndex:]
+	}
+	return PathPartString{plaintext, ext, obfuscator}
+}
+
+func (pps PathPartString) String() string {
+	if strings.HasPrefix(pps.plaintext, prefixToSkipObfsucation) {
+		return pps.plaintext
+	}
+
+	obs := pps.obsfucator.Obfuscate(pps.plaintext)
+	return obs + pps.ext
+}
+
+// Plaintext returns the plaintext underlying this string part.
+func (pps PathPartString) Plaintext() string {
+	return pps.plaintext
+}
+
+var _ json.Marshaler = PathPartString{}
+
+// MarshalJSON implements the json.Marshaler interface for PathPartString.
+func (pps PathPartString) MarshalJSON() ([]byte, error) {
+	panic("Cannot marshal PathPartString; use `Plaintext()` instead")
+}
+
+var _ encoding.TextMarshaler = PathPartString{}
+
+// MarshalText implements the encoding.TextMarshaler interface for
+// PathPartString.
+func (pps PathPartString) MarshalText() ([]byte, error) {
+	panic("Cannot marshal PathPartString; use `Plaintext()` instead")
+}

--- a/go/kbfs/data/path_part_string.go
+++ b/go/kbfs/data/path_part_string.go
@@ -23,7 +23,7 @@ const (
 
 // PathPartString returns an obfuscated version of part of a path,
 // preserving the suffixes if they're small enough or if it's a
-// conflicted copy of a file.  Two `PathPartString`s for the asme
+// conflicted copy of a file.  Two `PathPartString`s for the same
 // plaintext data, created using the same `Obfuscator`, should pass
 // equality checks.
 type PathPartString struct {
@@ -40,6 +40,11 @@ var _ fmt.Stringer = PathPartString{}
 func NewPathPartString(
 	plaintext string, obfuscator Obfuscator) PathPartString {
 	_, ext := SplitFileExtension(plaintext)
+	// Treat the long tarball suffix specially, since it's already
+	// parsed specially by `SplitFileExtension`.  Otherwise, strictly
+	// filter for length,m so we don't accidentally expose suffixes
+	// that aren't common file suffixes, but instead part of the
+	// actual privately-named file (e.g., "this.file.is.secret").
 	if len(ext) > extRestoreMaxLen && ext != tarGzSuffix {
 		ext = ""
 	}

--- a/go/kbfs/data/path_part_string_test.go
+++ b/go/kbfs/data/path_part_string_test.go
@@ -1,0 +1,118 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package data
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathPartStringBasic(t *testing.T) {
+	secret := NodeObfuscatorSecret([]byte{1, 2, 3, 4})
+	no := NewNodeObfuscator(secret)
+
+	t.Log("Check String() without extensions")
+	pps := NewPathPartString("test", no)
+	obs := pps.String()
+	words := strings.Split(obs, separator)
+	require.Len(t, words, 2)
+	require.True(t, libkb.ValidSecWord(words[0]), words[0])
+	require.True(t, libkb.ValidSecWord(words[1]), words[1])
+
+	t.Log("Check String() with short extension")
+	pps2 := NewPathPartString("test.txt", no)
+	obs2 := pps2.String()
+	require.True(t, strings.HasSuffix(obs2, ".txt"))
+	words2 := strings.Split(strings.Replace(obs2, ".txt", "", 1), separator)
+	require.Len(t, words2, 2)
+	require.True(t, libkb.ValidSecWord(words2[0]), words2[0])
+	require.True(t, libkb.ValidSecWord(words2[1]), words2[1])
+	t.Log("Make sure that the words aren't the same")
+	require.False(t, words[0] == words2[0] && words[1] == words2[1])
+
+	t.Log("Check String() with longer, but still valid, extension")
+	pps3 := NewPathPartString("test.tar.gz", no)
+	obs3 := pps3.String()
+	require.True(t, strings.HasSuffix(obs3, ".tar.gz"))
+	words3 := strings.Split(strings.Replace(obs3, ".tar.gz", "", 1), separator)
+	require.Len(t, words3, 2)
+	require.True(t, libkb.ValidSecWord(words3[0]), words3[0])
+	require.True(t, libkb.ValidSecWord(words3[1]), words3[1])
+
+	t.Log("Check String() with a too-long extension")
+	pps4 := NewPathPartString("test.longextension", no)
+	obs4 := pps4.String()
+	require.False(t, strings.HasSuffix(obs4, ".longextension"))
+	words4 := strings.Split(obs4, separator)
+	require.Len(t, words4, 2)
+	require.True(t, libkb.ValidSecWord(words4[0]), words4[0])
+	require.True(t, libkb.ValidSecWord(words4[1]), words4[1])
+
+	t.Log("Check String() with a conflicted suffix")
+	cSuffix := ".conflicted (alice's device copy 2019-06-10).txt"
+	pps5 := NewPathPartString("test"+cSuffix, no)
+	obs5 := pps5.String()
+	require.True(t, strings.HasSuffix(obs5, cSuffix))
+	words5 := strings.Split(strings.Replace(obs5, cSuffix, "", 1), separator)
+	require.Len(t, words5, 2)
+	require.True(t, libkb.ValidSecWord(words5[0]), words5[0])
+	require.True(t, libkb.ValidSecWord(words5[1]), words5[1])
+}
+
+func TestPathPartStringEquality(t *testing.T) {
+	secret := NodeObfuscatorSecret([]byte{1, 2, 3, 4})
+	no := NewNodeObfuscator(secret)
+
+	t.Log("Check equal PathPartStrings")
+	pps1 := NewPathPartString("test", no)
+	pps2 := NewPathPartString("test", no)
+	require.True(t, pps1 == pps2)
+
+	t.Log("Check as a map key")
+	pps3 := NewPathPartString("test2", no)
+	val1 := 50
+	val3 := 100
+	m := map[PathPartString]int{
+		pps1: val1,
+		pps3: val3,
+	}
+	require.Equal(t, val1, m[pps1])
+	require.Equal(t, val1, m[pps2])
+	require.Equal(t, val3, m[pps3])
+
+	t.Log("Check unequal PathPartStrings with different strings")
+	pps1 = NewPathPartString("test", no)
+	pps2 = NewPathPartString("test2", no)
+	require.False(t, pps1 == pps2)
+
+	t.Log("Check unequal PathPartStrings with different obfuscators")
+	no2 := NewNodeObfuscator(secret)
+	pps1 = NewPathPartString("test", no)
+	pps2 = NewPathPartString("test", no2)
+	require.False(t, pps1 == pps2)
+
+}
+
+func TestPathPartStringMarshal(t *testing.T) {
+	secret := NodeObfuscatorSecret([]byte{1, 2, 3, 4})
+	no := NewNodeObfuscator(secret)
+	pps := NewPathPartString("test", no)
+	require.Panics(t, func() {
+		_, _ = json.Marshal(pps)
+	})
+
+	type m struct {
+		PPS   PathPartString
+		Other string
+	}
+	m1 := m{pps, "test"}
+	require.Panics(t, func() {
+		_, _ = json.Marshal(m1)
+	})
+}

--- a/go/kbfs/data/util.go
+++ b/go/kbfs/data/util.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package data
+
+// SplitFileExtension splits filename into a base name and the extension.
+func SplitFileExtension(path string) (string, string) {
+	for i := len(path) - 1; i > 0; i-- {
+		switch path[i] {
+		case '.':
+			// Handle some multipart extensions
+			if i >= 4 && path[i-4:i] == ".tar" {
+				i -= 4
+			}
+			// A leading dot is not an extension
+			if i == 0 || path[i-1] == '/' || path[i-1] == '\\' {
+				return path, ""
+			}
+			return path[:i], path[i:]
+		case '/', '\\', ' ':
+			return path, ""
+		}
+	}
+	return path, ""
+}

--- a/go/kbfs/data/util_test.go
+++ b/go/kbfs/data/util_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD
 // license that can be found in the LICENSE file.
 
-package libkbfs
+package data
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 
 func testSplitExtension(t *testing.T, s, base, ext string) {
 	//t.Logf("splitExtension(%q)", s)
-	a, b := splitExtension(s)
+	a, b := SplitFileExtension(s)
 	if a != base || b != ext {
 		t.Errorf("splitExtension(%q) => %q,%q, expected %q,%q", s, a, b, base, ext)
 	}

--- a/go/kbfs/libkbfs/conflict_renamer.go
+++ b/go/kbfs/libkbfs/conflict_renamer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -42,31 +43,10 @@ func (WriterDeviceDateConflictRenamer) ConflictRenameHelper(t time.Time, user, d
 	if device == "" {
 		device = "unknown"
 	}
-	base, ext := splitExtension(original)
+	base, ext := data.SplitFileExtension(original)
 	date := t.Format("2006-01-02")
 	return fmt.Sprintf("%s.conflicted (%s's %s copy %s)%s",
 		base, user, device, date, ext)
-}
-
-// splitExtension splits filename into a base name and the extension.
-func splitExtension(path string) (string, string) {
-	for i := len(path) - 1; i > 0; i-- {
-		switch path[i] {
-		case '.':
-			// Handle some multipart extensions
-			if i >= 4 && path[i-4:i] == ".tar" {
-				i -= 4
-			}
-			// A leading dot is not an extension
-			if i == 0 || path[i-1] == '/' || path[i-1] == '\\' {
-				return path, ""
-			}
-			return path[:i], path[i:]
-		case '/', '\\', ' ':
-			return path, ""
-		}
-	}
-	return path, ""
 }
 
 func newWriterInfo(

--- a/go/kbfs/libkbfs/cr_actions.go
+++ b/go/kbfs/libkbfs/cr_actions.go
@@ -149,7 +149,7 @@ func uniquifyName(
 		return "", err
 	}
 
-	base, ext := splitExtension(name)
+	base, ext := data.SplitFileExtension(name)
 	for i := 1; i <= 100; i++ {
 		newName := fmt.Sprintf("%s (%d)%s", base, i, ext)
 		_, err := dir.Lookup(ctx, newName)


### PR DESCRIPTION
This struct will be used in place of regular strings for parts of KBFS paths.  It uses an obfuscator to output `String()`, so that plaintext is never accidentally marshaled.

It cannot be marshaled directly for JSON; it must first be explicitly converted into plaintext.

Issue: HOTPOT-57