### PR TITLE
only show loading spinner at first time loading

### DIFF
--- a/shared/actions/fs-gen.tsx
+++ b/shared/actions/fs-gen.tsx
@@ -45,7 +45,6 @@ export const letResetUserBackIn = 'fs:letResetUserBackIn'
 export const loadPathMetadata = 'fs:loadPathMetadata'
 export const loadSettings = 'fs:loadSettings'
 export const loadTlfSyncConfig = 'fs:loadTlfSyncConfig'
-export const loadingPath = 'fs:loadingPath'
 export const localHTTPServerInfo = 'fs:localHTTPServerInfo'
 export const move = 'fs:move'
 export const newFolderName = 'fs:newFolderName'
@@ -163,7 +162,6 @@ type _LetResetUserBackInPayload = {readonly id: RPCTypes.TeamID; readonly userna
 type _LoadPathMetadataPayload = {readonly path: Types.Path; readonly refreshTag?: Types.RefreshTag | null}
 type _LoadSettingsPayload = void
 type _LoadTlfSyncConfigPayload = {readonly tlfPath: Types.Path}
-type _LoadingPathPayload = {readonly path: Types.Path; readonly id: string; readonly done: boolean}
 type _LocalHTTPServerInfoPayload = {readonly address: string; readonly token: string}
 type _MovePayload = {readonly destinationParentPath: Types.Path}
 type _NewFolderNamePayload = {readonly editID: Types.EditID; readonly name: string}
@@ -355,10 +353,6 @@ export const createLoadSettings = (payload: _LoadSettingsPayload): LoadSettingsP
 export const createLoadTlfSyncConfig = (payload: _LoadTlfSyncConfigPayload): LoadTlfSyncConfigPayload => ({
   payload,
   type: loadTlfSyncConfig,
-})
-export const createLoadingPath = (payload: _LoadingPathPayload): LoadingPathPayload => ({
-  payload,
-  type: loadingPath,
 })
 export const createLocalHTTPServerInfo = (
   payload: _LocalHTTPServerInfoPayload
@@ -655,7 +649,6 @@ export type LoadTlfSyncConfigPayload = {
   readonly payload: _LoadTlfSyncConfigPayload
   readonly type: 'fs:loadTlfSyncConfig'
 }
-export type LoadingPathPayload = {readonly payload: _LoadingPathPayload; readonly type: 'fs:loadingPath'}
 export type LocalHTTPServerInfoPayload = {
   readonly payload: _LocalHTTPServerInfoPayload
   readonly type: 'fs:localHTTPServerInfo'
@@ -890,7 +883,6 @@ export type Actions =
   | LoadPathMetadataPayload
   | LoadSettingsPayload
   | LoadTlfSyncConfigPayload
-  | LoadingPathPayload
   | LocalHTTPServerInfoPayload
   | MovePayload
   | NewFolderNamePayload

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -259,7 +259,6 @@ function* folderList(_, action: FsGen.FolderListLoadPayload | FsGen.EditSuccessP
     action.type === FsGen.editSuccess
       ? {refreshTag: undefined, rootPath: action.payload.parentPath}
       : {refreshTag: action.payload.refreshTag, rootPath: action.payload.path}
-  const loadingPathID = Constants.makeUUID()
 
   if (refreshTag) {
     if (folderListRefreshTags.get(refreshTag) === rootPath) {
@@ -271,8 +270,6 @@ function* folderList(_, action: FsGen.FolderListLoadPayload | FsGen.EditSuccessP
   }
 
   try {
-    yield Saga.put(FsGen.createLoadingPath({done: false, id: loadingPathID, path: rootPath}))
-
     const opID = Constants.makeUUID()
     const pathElems = Types.getPathElements(rootPath)
     if (pathElems.length < 3) {
@@ -355,8 +352,6 @@ function* folderList(_, action: FsGen.FolderListLoadPayload | FsGen.EditSuccessP
     }
   } catch (error) {
     yield makeRetriableErrorHandler(action, rootPath)(error).map(action => Saga.put(action))
-  } finally {
-    yield Saga.put(FsGen.createLoadingPath({done: true, id: loadingPathID, path: rootPath}))
   }
 }
 

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -15,11 +15,6 @@
       "path": "Types.Path",
       "pathItems": "I.Map<Types.Path, Types.PathItem>"
     },
-    "loadingPath": {
-      "path": "Types.Path",
-      "id": "string",
-      "done": "boolean"
-    },
     "favoritesLoad": {},
     "favoritesLoaded": {
       "private": "I.Map<string, Types.Tlf>",

--- a/shared/constants/fs.tsx
+++ b/shared/constants/fs.tsx
@@ -314,7 +314,6 @@ export const makeState: I.Record.Factory<Types._State> = I.Record({
   folderViewFilter: '',
   kbfsDaemonStatus: makeKbfsDaemonStatus(),
   lastPublicBannerClosedTlf: '',
-  loadingPaths: I.Map(),
   localHTTPServerInfo: makeLocalHTTPServer(),
   overallSyncStatus: makeOverallSyncStatus(),
   pathItemActionMenu: makePathItemActionMenu(),

--- a/shared/constants/types/fs.tsx
+++ b/shared/constants/types/fs.tsx
@@ -591,7 +591,6 @@ export type _State = {
   folderViewFilter: string
   kbfsDaemonStatus: KbfsDaemonStatus
   lastPublicBannerClosedTlf: string
-  loadingPaths: I.Map<Path, I.Set<string>>
   localHTTPServerInfo: LocalHTTPServer
   overallSyncStatus: OverallSyncStatus
   pathItemActionMenu: PathItemActionMenu

--- a/shared/fs/top-bar/index.stories.tsx
+++ b/shared/fs/top-bar/index.stories.tsx
@@ -14,7 +14,7 @@ export const topBarProvider = {
     waiting: false,
   }),
   TopBarLoading: () => ({
-    loading: true,
+    show: true,
   }),
   TopBarSort: ({path}: {path: Types.Path}) => ({
     sortByNameAsc: path === Constants.defaultPath ? undefined : Sb.action('sortByNameAsc'),

--- a/shared/fs/top-bar/loading.tsx
+++ b/shared/fs/top-bar/loading.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import {namedConnect} from '../../util/container'
 import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
+import * as Constants from '../../constants/fs'
 import * as Kb from '../../common-adapters'
 
 type OwnProps = {
@@ -10,14 +11,28 @@ type OwnProps = {
 
 const mapStateToProps = (state, {path}: OwnProps) => ({
   _loadingPaths: state.fs.loadingPaths,
+  _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
 })
 
 const emptySet = I.Set()
 
-const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => ({
-  loading: stateProps._loadingPaths.get(path, emptySet).size > 0,
-})
+const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => {
+  // Only show the loading spinner when we are first-time loading a pathItem.
+  // If we already have content to show, just don't show spinner anymore even
+  // if we are loading.
+  if (stateProps._pathItem.type === Types.PathType.Unknown) {
+    return {show: true}
+  }
+  if (
+    stateProps._pathItem.type === Types.PathType.Folder &&
+    stateProps._pathItem.progress === Types.ProgressType.Pending &&
+    stateProps._loadingPaths.get(path, emptySet).size > 0
+  ) {
+    return {show: true}
+  }
+  return {show: false}
+}
 
-const Loading = props => props.loading && <Kb.ProgressIndicator type="Small" />
+const Loading = props => props.show && <Kb.ProgressIndicator type="Small" />
 
 export default namedConnect(mapStateToProps, () => ({}), mergeProps, 'TopBarLoading')(Loading)

--- a/shared/fs/top-bar/loading.tsx
+++ b/shared/fs/top-bar/loading.tsx
@@ -7,7 +7,7 @@ import * as Kb from '../../common-adapters'
 import * as Flow from '../../util/flow'
 
 // The behavior is to only show spinner when user first time lands on a screen
-// and when don't have the data thar drives it yet. Since RPCs happen
+// and when don't have the data that drives it yet. Since RPCs happen
 // automatically, we are just relying on whether data is available from the
 // redux store.
 

--- a/shared/fs/top-bar/loading.tsx
+++ b/shared/fs/top-bar/loading.tsx
@@ -4,33 +4,52 @@ import * as I from 'immutable'
 import * as Types from '../../constants/types/fs'
 import * as Constants from '../../constants/fs'
 import * as Kb from '../../common-adapters'
+import * as Flow from '../../util/flow'
+
+// The behavior is to only show spinner when user first time lands on a screen
+// and when don't have the data thar drives it yet. Since RPCs happen
+// automatically, we are just relying on whether data is available from the
+// redux store.
 
 type OwnProps = {
   path: Types.Path
 }
 
 const mapStateToProps = (state, {path}: OwnProps) => ({
-  _loadingPaths: state.fs.loadingPaths,
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
+  _tlfsLoaded: !!state.fs.tlfs.private.size,
 })
 
 const emptySet = I.Set()
 
 const mergeProps = (stateProps, dispatchProps, {path}: OwnProps) => {
-  // Only show the loading spinner when we are first-time loading a pathItem.
-  // If we already have content to show, just don't show spinner anymore even
-  // if we are loading.
-  if (stateProps._pathItem.type === Types.PathType.Unknown) {
-    return {show: true}
+  const parsedPath = Constants.parsePath(path)
+  switch (parsedPath.kind) {
+    case Types.PathKind.Root:
+      return {show: false}
+    case Types.PathKind.TlfList:
+      return {show: !stateProps._tlfsLoaded}
+    case Types.PathKind.TeamTlf:
+    case Types.PathKind.GroupTlf:
+    case Types.PathKind.InTeamTlf:
+    case Types.PathKind.InGroupTlf:
+      // Only show the loading spinner when we are first-time loading a pathItem.
+      // If we already have content to show, just don't show spinner anymore even
+      // if we are loading.
+      if (stateProps._pathItem.type === Types.PathType.Unknown) {
+        return {show: true}
+      }
+      if (
+        stateProps._pathItem.type === Types.PathType.Folder &&
+        stateProps._pathItem.progress === Types.ProgressType.Pending
+      ) {
+        return {show: true}
+      }
+      return {show: false}
+    default:
+      Flow.ifFlowComplainsAboutThisFunctionYouHaventHandledAllCasesInASwitch(parsedPath)
+      return {show: false}
   }
-  if (
-    stateProps._pathItem.type === Types.PathType.Folder &&
-    stateProps._pathItem.progress === Types.ProgressType.Pending &&
-    stateProps._loadingPaths.get(path, emptySet).size > 0
-  ) {
-    return {show: true}
-  }
-  return {show: false}
 }
 
 const Loading = props => props.show && <Kb.ProgressIndicator type="Small" />

--- a/shared/reducers/fs.tsx
+++ b/shared/reducers/fs.tsx
@@ -240,10 +240,6 @@ export default function(state: Types.State = initialState, action: FsGen.Actions
         state.pathItems.withMutations(pathItems => pathItems.deleteAll(toRemove).merge(toMerge))
       )
     }
-    case FsGen.loadingPath:
-      return state.updateIn(['loadingPaths', action.payload.path], set =>
-        action.payload.done ? set && set.delete(action.payload.id) : (set || I.Set()).add(action.payload.id)
-      )
     case FsGen.favoritesLoaded:
       return state.update('tlfs', tlfs =>
         tlfs.withMutations(tlfsMutable =>


### PR DESCRIPTION
This is motivated by the issue where when a path is being synced, we'd load folder list every second, which results in the spinner being shown every second. I talked to Cécile and we decided to only show it when first time loading a thing. This means even if a folder content itself changes, we'll just show the changed content and no spinner, which seems fine.

I was slightly wrong when I said this wouldn't be triggered outside admin mode. It actually gets triggered too if user enables sync from CLI. So perhaps it still makes sense to get it into this release.