### PR TITLE
modes: disable TLF edit history loading on mobile

### DIFF
--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -475,6 +475,10 @@ func (mc modeConstrained) LocalHTTPServerEnabled() bool {
 	return true
 }
 
+func (mc modeConstrained) TLFEditHistoryEnabled() bool {
+	return false
+}
+
 // Memory limited mode
 
 type modeMemoryLimited struct {


### PR DESCRIPTION
Which will cause the TLF lists to be sorted in weird ways.

This might reduce memory and CPU usage at startup.