### PR TITLE
allow full log sends

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -277,7 +277,7 @@ func (s serviceCn) NewChat(config libkbfs.Config, params libkbfs.InitParams, ctx
 }
 
 // LogSend sends a log to Keybase
-func LogSend(statusJSON string, feedback string, sendLogs bool, uiLogPath, traceDir, cpuProfileDir string) (res string, err error) {
+func LogSend(statusJSON string, feedback string, sendLogs, sendMaxBytes bool, uiLogPath, traceDir, cpuProfileDir string) (res string, err error) {
 	defer func() { err = flattenError(err) }()
 	env := kbCtx.Env
 	logSendContext.UID = env.GetUID()
@@ -287,8 +287,12 @@ func LogSend(statusJSON string, feedback string, sendLogs bool, uiLogPath, trace
 	logSendContext.Logs.Desktop = uiLogPath
 	logSendContext.Logs.Trace = traceDir
 	logSendContext.Logs.CPUProfile = cpuProfileDir
+	numBytes := status.LogSendDefaultBytesMobile
+	if sendMaxBytes {
+		numBytes = status.LogSendMaxBytes
+	}
 
-	logSendID, err := logSendContext.LogSend(sendLogs, status.LogSendDefaultBytesMobile, true /* mergeExtendedStatus */)
+	logSendID, err := logSendContext.LogSend(sendLogs, numBytes, true /* mergeExtendedStatus */)
 	logSendContext.Clear()
 	return string(logSendID), err
 }

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1848,7 +1848,7 @@ func (e *Env) GetLogFileConfig(filename string) *logger.LogFileConfig {
 	var maxSize int64
 
 	if e.GetAppType() == MobileAppType && !e.GetFeatureFlags().Admin(e.GetUID()) {
-		maxKeepFiles = 1
+		maxKeepFiles = 2
 		maxSize = 16 * opt.MiB // NOTE: If you decrease this, check go/bind/keybase.go:LogSend to make sure we aren't sending more than we store.
 	} else {
 		maxKeepFiles = 3

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -784,10 +784,11 @@ type GetFullStatusArg struct {
 }
 
 type LogSendArg struct {
-	SessionID  int    `codec:"sessionID" json:"sessionID"`
-	StatusJSON string `codec:"statusJSON" json:"statusJSON"`
-	Feedback   string `codec:"feedback" json:"feedback"`
-	SendLogs   bool   `codec:"sendLogs" json:"sendLogs"`
+	SessionID    int    `codec:"sessionID" json:"sessionID"`
+	StatusJSON   string `codec:"statusJSON" json:"statusJSON"`
+	Feedback     string `codec:"feedback" json:"feedback"`
+	SendLogs     bool   `codec:"sendLogs" json:"sendLogs"`
+	SendMaxBytes bool   `codec:"sendMaxBytes" json:"sendMaxBytes"`
 }
 
 type GetAllProvisionedUsernamesArg struct {

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -144,8 +144,13 @@ func (h ConfigHandler) LogSend(ctx context.Context, arg keybase1.LogSendArg) (re
 	}
 	statusJSON := status.MergeStatusJSON(fstatus, "fstatus", arg.StatusJSON)
 
+	numBytes := status.LogSendDefaultBytesDesktop
+	if arg.SendMaxBytes {
+		numBytes = status.LogSendMaxBytes
+	}
+
 	logSendContext := status.NewLogSendContext(h.G(), fstatus, statusJSON, arg.Feedback)
-	return logSendContext.LogSend(arg.SendLogs, status.LogSendDefaultBytesDesktop,
+	return logSendContext.LogSend(arg.SendLogs, numBytes,
 		false /* mergeExtendedStatus */)
 }
 

--- a/go/status/log_send.go
+++ b/go/status/log_send.go
@@ -5,11 +5,13 @@ package status
 
 import (
 	"bytes"
+	"fmt"
 	"mime/multipart"
 	"os"
 	"regexp"
 	"strings"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -229,8 +231,10 @@ func (l *LogSendContext) post(mctx libkb.MetaContext) (keybase1.LogSendID, error
 
 // LogSend sends the tails of log files to kb, and also the last few trace
 // output files.
-func (l *LogSendContext) LogSend(sendLogs bool, numBytes int, mergeExtendedStatus bool) (keybase1.LogSendID, error) {
+func (l *LogSendContext) LogSend(sendLogs bool, numBytes int, mergeExtendedStatus bool) (id keybase1.LogSendID, err error) {
 	mctx := libkb.NewMetaContextBackground(l.G()).WithLogTag("LOGSEND")
+	defer mctx.TraceTimed(fmt.Sprintf("LogSend sendLogs: %v numBytes: %s",
+		sendLogs, humanize.Bytes(uint64(numBytes))), func() error { return err })()
 
 	if numBytes < 1 {
 		numBytes = LogSendDefaultBytesDesktop

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -152,7 +152,7 @@ protocol config {
 
   @typedef("string")  record LogSendID {}
   LogSendID logSend(int sessionID, string statusJSON, string feedback,
-    boolean sendLogs);
+    boolean sendLogs, boolean sendMaxBytes);
 
   record AllProvisionedUsernames {
     string defaultUsername;

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -806,6 +806,10 @@
         {
           "name": "sendLogs",
           "type": "boolean"
+        },
+        {
+          "name": "sendMaxBytes",
+          "type": "boolean"
         }
       ],
       "response": "LogSendID"

--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -127,7 +127,8 @@
     },
     "sendFeedback": {
       "feedback": "string",
-      "sendLogs": "boolean"
+      "sendLogs": "boolean",
+      "sendMaxBytes": "boolean"
     },
     "feedbackSent": {
       "_description": "An error occurred while trying to send feedback to Keybase",

--- a/shared/actions/settings-gen.tsx
+++ b/shared/actions/settings-gen.tsx
@@ -99,7 +99,11 @@ type _OnUpdatePGPSettingsPayload = void
 type _OnUpdatePasswordErrorPayload = {readonly error: Error}
 type _OnUpdatedPGPSettingsPayload = {readonly hasKeys: boolean}
 type _ProcessorProfilePayload = {readonly durationSeconds: number}
-type _SendFeedbackPayload = {readonly feedback: string; readonly sendLogs: boolean}
+type _SendFeedbackPayload = {
+  readonly feedback: string
+  readonly sendLogs: boolean
+  readonly sendMaxBytes: boolean
+}
 type _SetAllowDeleteAccountPayload = {readonly allow: boolean}
 type _StopPayload = {readonly exitCode: RPCTypes.ExitCode}
 type _TracePayload = {readonly durationSeconds: number}

--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -443,7 +443,7 @@ const setLockdownMode = (state, action: SettingsGen.OnChangeLockdownModePayload)
     .catch(() => SettingsGen.createLoadLockdownMode())
 
 const sendFeedback = (state, action: SettingsGen.SendFeedbackPayload): Promise<Saga.MaybeAction> => {
-  const {feedback, sendLogs} = action.payload
+  const {feedback, sendLogs, sendMaxBytes} = action.payload
   const maybeDump = sendLogs ? logger.dump().then(writeLogLinesToFile) : Promise.resolve()
   const status = {version}
   return maybeDump
@@ -453,7 +453,8 @@ const sendFeedback = (state, action: SettingsGen.SendFeedbackPayload): Promise<S
       return RPCTypes.configLogSendRpcPromise(
         {
           feedback: feedback || '',
-          sendLogs: sendLogs,
+          sendLogs,
+          sendMaxBytes,
           statusJSON: JSON.stringify(extra),
         },
         Constants.sendFeedbackWaitingKey

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/modules/LogSend.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/modules/LogSend.java
@@ -21,9 +21,9 @@ public class LogSend extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void logSend(String status, String feedback, boolean sendLogs, String logFilePath, String traceDir, String cpuProfileDir, Promise promise) {
+    public void logSend(String status, String feedback, boolean sendLogs, boolean sendMaxBytes, String logFilePath, String traceDir, String cpuProfileDir, Promise promise) {
         try {
-          final String logID = Keybase.logSend(status, feedback, sendLogs, logFilePath, traceDir, cpuProfileDir);
+          final String logID = Keybase.logSend(status, feedback, sendLogs, sendMaxBytes, logFilePath, traceDir, cpuProfileDir);
             promise.resolve(logID);
         } catch (Exception e) {
             promise.reject(e);

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -360,7 +360,7 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.config.logSend': {
-    inParam: {readonly statusJSON: String; readonly feedback: String; readonly sendLogs: Boolean}
+    inParam: {readonly statusJSON: String; readonly feedback: String; readonly sendLogs: Boolean; readonly sendMaxBytes: Boolean}
     outParam: LogSendID
   }
   'keybase.1.config.setRememberPassphrase': {

--- a/shared/ios/Keybase/Fs.m
+++ b/shared/ios/Keybase/Fs.m
@@ -134,21 +134,12 @@
   NSString* serviceLogFile = skipLogFile ? @"" : [logPath stringByAppendingString:@"/ios.log"];
 
   if (!skipLogFile) {
-      // migrate old log files to the new location
+      // cleanup old log files
       NSFileManager* fm = [NSFileManager defaultManager];
-      NSError* error = nil;
       NSArray<NSString*>* logs = @[@"/ios.log", @"/ios.log.ek"];
       for (NSString* file in logs) {
           NSString* oldPath = [oldLogPath stringByAppendingString:file];
-          NSString* newPath = [logPath stringByAppendingString:file];
-          NSLog(@"[LogFileMigration] Moving: %@ to %@", oldPath, newPath);
-          if (![fm moveItemAtPath:oldPath toPath:newPath error:&error]) {
-            if ([error code] == NSFileWriteFileExistsError) {
-                NSLog(@"[LogFileMigration] File exists, removing oldPath: %@", oldPath);
-                [fm removeItemAtPath:oldPath error:NULL];
-            }
-            NSLog(@"[LogFileMigration] Error moving file: %@ error: %@", oldPath, error);
-          }
+          [fm removeItemAtPath:oldPath error:NULL];
       }
   }
 

--- a/shared/ios/Keybase/Fs.m
+++ b/shared/ios/Keybase/Fs.m
@@ -128,12 +128,12 @@
   // Setup app level directories
   NSString* levelDBPath = [@"~/Library/Application Support/Keybase/keybase.leveldb" stringByExpandingTildeInPath];
   NSString* chatLevelDBPath = [@"~/Library/Application Support/Keybase/keybase.chat.leveldb" stringByExpandingTildeInPath];
-  NSString* logPath = [@"~/Library/Caches/Keybase" stringByExpandingTildeInPath];
+  NSString* logPath = [@"~/Library/Caches/Keybase/logs" stringByExpandingTildeInPath];
   NSString* serviceLogFile = skipLogFile ? @"" : [logPath stringByAppendingString:@"/ios.log"];
   // Create LevelDB and log directories with a slightly lower data protection mode so we can use them in the background
   [self createBackgroundReadableDirectory:chatLevelDBPath setAllFiles:YES];
   [self createBackgroundReadableDirectory:levelDBPath setAllFiles:YES];
-  [self createBackgroundReadableDirectory:logPath setAllFiles:NO];
+  [self createBackgroundReadableDirectory:logPath setAllFiles:YES];
 
   return @{@"home": home,
            @"sharedHome": sharedHome,

--- a/shared/ios/Keybase/LogSend.m
+++ b/shared/ios/Keybase/LogSend.m
@@ -15,6 +15,7 @@ RCT_REMAP_METHOD(logSend,
                  status:(NSString*)status
                  feedback:(NSString*)feedback
                  sendLogs:(BOOL)sendLogs
+                 sendMaxBytes:(BOOL)sendMaxBytes
                  logPath:(NSString*)logPath
                  traceDir:(NSString*)traceDir
                  cpuProfileDir:(NSString*)cpuProfileDir
@@ -24,7 +25,7 @@ RCT_REMAP_METHOD(logSend,
 
   NSString *logId = nil;
   NSError *err = nil;
-  logId = KeybaseLogSend(status, feedback, sendLogs, logPath, traceDir, cpuProfileDir, &err);
+  logId = KeybaseLogSend(status, feedback, sendLogs, sendMaxBytes, logPath, traceDir, cpuProfileDir, &err);
   if (err == nil) {
     resolve(logId);
   } else {

--- a/shared/native/log-send.d.ts
+++ b/shared/native/log-send.d.ts
@@ -1,7 +1,8 @@
 declare function logSend(
   status: string,
   feedback: string,
-  includeLogs: boolean,
+  sendLogs: boolean,
+  sendMaxBytes: boolean,
   path: string,
   traceDir: string,
   cpuProfileDir: string

--- a/shared/settings/feedback/container.desktop.tsx
+++ b/shared/settings/feedback/container.desktop.tsx
@@ -15,7 +15,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
-  onSendFeedback: (feedback, sendLogs) => dispatch(SettingsGen.createSendFeedback({feedback, sendLogs})),
+  onSendFeedback: (feedback, sendLogs, sendMaxBytes) =>
+    dispatch(SettingsGen.createSendFeedback({feedback, sendLogs, sendMaxBytes})),
 })
 
 const mergeProps = (s, d, o: OwnProps) => ({

--- a/shared/settings/feedback/container.native.tsx
+++ b/shared/settings/feedback/container.native.tsx
@@ -48,7 +48,7 @@ class FeedbackContainer extends React.Component<Props, State> {
     this.mounted = true
   }
 
-  _onSendFeedback = (feedback: string, sendLogs: boolean) => {
+  _onSendFeedback = (feedback: string, sendLogs: boolean, sendMaxBytes: boolean) => {
     this.setState({sending: true, sentFeedback: false})
 
     this.props.setTimeout(() => {
@@ -64,7 +64,15 @@ class FeedbackContainer extends React.Component<Props, State> {
             : this.props.status
           const traceDir = pprofDir
           const cpuProfileDir = traceDir
-          return logSend(JSON.stringify(extra), feedback || '', sendLogs, logPath, traceDir, cpuProfileDir)
+          return logSend(
+            JSON.stringify(extra),
+            feedback || '',
+            sendLogs,
+            sendMaxBytes,
+            logPath,
+            traceDir,
+            cpuProfileDir
+          )
         })
         .then(logSendId => {
           logger.info('logSendId is', logSendId)


### PR DESCRIPTION
patch does the following:

- adds a hidden option to send 'full logs' (128mb)
- moves the ios logs into a subdir that has background readable permissions so logs can properly rotate
- keep a second log file on mobile when not admin so we can get logs after a rotation

cc @keybase/hotpotatosquad 