### PR TITLE
team: support for hidden chain rotations

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -590,13 +590,14 @@ const (
 )
 
 const (
-	EncryptionReasonChatLocalStorage       EncryptionReason = "Keybase-Chat-Local-Storage-1"
-	EncryptionReasonChatMessage            EncryptionReason = "Keybase-Chat-Message-1"
-	EncryptionReasonChatIndexerTokenKey    EncryptionReason = "Keybase-Chat-IndexerTokenKey-1"
-	EncryptionReasonChatIndexerAliasKey    EncryptionReason = "Keybase-Chat-IndexerAliasKey-1"
-	EncryptionReasonTeamsLocalStorage      EncryptionReason = "Keybase-Teams-Local-Storage-1"
-	EncryptionReasonTeamsFTLLocalStorage   EncryptionReason = "Keybase-Teams-FTL-Local-Storage-1"
-	EncryptionReasonErasableKVLocalStorage EncryptionReason = "Keybase-Erasable-KV-Local-Storage-1"
+	EncryptionReasonChatLocalStorage        EncryptionReason = "Keybase-Chat-Local-Storage-1"
+	EncryptionReasonChatMessage             EncryptionReason = "Keybase-Chat-Message-1"
+	EncryptionReasonChatIndexerTokenKey     EncryptionReason = "Keybase-Chat-IndexerTokenKey-1"
+	EncryptionReasonChatIndexerAliasKey     EncryptionReason = "Keybase-Chat-IndexerAliasKey-1"
+	EncryptionReasonTeamsLocalStorage       EncryptionReason = "Keybase-Teams-Local-Storage-1"
+	EncryptionReasonTeamsFTLLocalStorage    EncryptionReason = "Keybase-Teams-FTL-Local-Storage-1"
+	EncryptionReasonTeamsHiddenLocalStorage EncryptionReason = "Keybase-Teams-Hidden-Local-Storage-1"
+	EncryptionReasonErasableKVLocalStorage  EncryptionReason = "Keybase-Erasable-KV-Local-Storage-1"
 )
 
 type DeriveReason string
@@ -669,6 +670,7 @@ const (
 	TeamGitMetadataDerivationString      = "Keybase-Derived-Team-NaCl-GitMetadata-1"
 	TeamSeitanTokenDerivationString      = "Keybase-Derived-Team-NaCl-SeitanInviteToken-1"
 	TeamStellarRelayDerivationString     = "Keybase-Derived-Team-NaCl-StellarRelay-1"
+	TeamKeySeedCheckDerivationString     = "Keybase-Derived-Team-Seedcheck-1"
 )
 
 func CurrentSaltpackVersion() saltpack.Version {

--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -92,6 +92,14 @@ func (m MetaContext) TraceTimed(msg string, f func() error) func() {
 func (m MetaContext) TraceOK(msg string, f func() bool) func() {
 	return CTraceOK(m.ctx, m.g.Log.CloneWithAddedDepth(1), msg, f)
 }
+func (m MetaContext) TimeBuckets() (MetaContext, *profiling.TimeBuckets) {
+	var ret *profiling.TimeBuckets
+	m.ctx, ret = m.G().CTimeBuckets(m.ctx)
+	return m, ret
+}
+func (m MetaContext) TimeTracer(label string, enabled bool) profiling.TimeTracer {
+	return m.G().CTimeTracer(m.Ctx(), label, enabled)
+}
 
 func (m MetaContext) Debug(f string, args ...interface{}) {
 	m.g.Log.CloneWithAddedDepth(1).CDebugf(m.ctx, f, args...)

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -21,6 +21,7 @@ const (
 	DBTeamChain         = 0x10
 	DBUserPlusAllKeysV1 = 0x19
 
+	DBHiddenChainStorage             = 0xb9
 	DBContactResolution              = 0xba
 	DBBoxAuditorPermanent            = 0xbb
 	DBBoxAuditor                     = 0xbc

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -72,32 +72,33 @@ type GlobalContext struct {
 	IdentifyDispatch *IdentifyDispatch    // get notified of identify successes
 	Identify3State   *Identify3State      // keep track of Identify3 sessions
 
-	cacheMu          *sync.RWMutex   // protects all caches
-	ProofCache       *ProofCache     // where to cache proof results
-	trackCache       *TrackCache     // cache of IdentifyOutcomes for tracking purposes
-	identify2Cache   Identify2Cacher // cache of Identify2 results for fast-pathing identify2 RPCS
-	linkCache        *LinkCache      // cache of ChainLinks
-	upakLoader       UPAKLoader      // Load flat users with the ability to hit the cache
-	teamLoader       TeamLoader      // Play back teams for id/name properties
-	fastTeamLoader   FastTeamLoader  // Play back team in "fast" mode for keys and names only
-	IDLocktab        LockTable
-	loadUserLockTab  LockTable
-	teamAuditor      TeamAuditor
-	teamBoxAuditor   TeamBoxAuditor
-	stellar          Stellar          // Stellar related ops
-	deviceEKStorage  DeviceEKStorage  // Store device ephemeral keys
-	userEKBoxStorage UserEKBoxStorage // Store user ephemeral key boxes
-	teamEKBoxStorage TeamEKBoxStorage // Store team ephemeral key boxes
-	ekLib            EKLib            // Wrapper to call ephemeral key methods
-	itciCacher       LRUer            // Cacher for implicit team conflict info
-	iteamCacher      MemLRUer         // In memory cacher for implicit teams
-	cardCache        *UserCardCache   // cache of keybase1.UserCard objects
-	fullSelfer       FullSelfer       // a loader that gets the full self object
-	pvlSource        MerkleStore      // a cache and fetcher for pvl
-	paramProofStore  MerkleStore      // a cache and fetcher for param proofs
-	externalURLStore MerkleStore      // a cache and fetcher for external urls
-	PayloadCache     *PayloadCache    // cache of ChainLink payload json wrappers
-	Pegboard         *Pegboard
+	cacheMu                *sync.RWMutex   // protects all caches
+	ProofCache             *ProofCache     // where to cache proof results
+	trackCache             *TrackCache     // cache of IdentifyOutcomes for tracking purposes
+	identify2Cache         Identify2Cacher // cache of Identify2 results for fast-pathing identify2 RPCS
+	linkCache              *LinkCache      // cache of ChainLinks
+	upakLoader             UPAKLoader      // Load flat users with the ability to hit the cache
+	teamLoader             TeamLoader      // Play back teams for id/name properties
+	fastTeamLoader         FastTeamLoader  // Play back team in "fast" mode for keys and names only
+	hiddenTeamChainManager HiddenTeamChainManager
+	IDLocktab              LockTable
+	loadUserLockTab        LockTable
+	teamAuditor            TeamAuditor
+	teamBoxAuditor         TeamBoxAuditor
+	stellar                Stellar          // Stellar related ops
+	deviceEKStorage        DeviceEKStorage  // Store device ephemeral keys
+	userEKBoxStorage       UserEKBoxStorage // Store user ephemeral key boxes
+	teamEKBoxStorage       TeamEKBoxStorage // Store team ephemeral key boxes
+	ekLib                  EKLib            // Wrapper to call ephemeral key methods
+	itciCacher             LRUer            // Cacher for implicit team conflict info
+	iteamCacher            MemLRUer         // In memory cacher for implicit teams
+	cardCache              *UserCardCache   // cache of keybase1.UserCard objects
+	fullSelfer             FullSelfer       // a loader that gets the full self object
+	pvlSource              MerkleStore      // a cache and fetcher for pvl
+	paramProofStore        MerkleStore      // a cache and fetcher for param proofs
+	externalURLStore       MerkleStore      // a cache and fetcher for external urls
+	PayloadCache           *PayloadCache    // cache of ChainLink payload json wrappers
+	Pegboard               *Pegboard
 
 	GpgClient        *GpgCLI        // A standard GPG-client (optional)
 	ShutdownHooks    []ShutdownHook // on shutdown, fire these...
@@ -227,6 +228,7 @@ func (g *GlobalContext) Init() *GlobalContext {
 	g.upakLoader = NewUncachedUPAKLoader(g)
 	g.teamLoader = newNullTeamLoader(g)
 	g.fastTeamLoader = newNullFastTeamLoader()
+	g.hiddenTeamChainManager = newNullHiddenTeamChainManager()
 	g.teamAuditor = newNullTeamAuditor()
 	g.teamBoxAuditor = newNullTeamBoxAuditor()
 	g.stellar = newNullStellar(g)
@@ -571,6 +573,18 @@ func (g *GlobalContext) GetFastTeamLoader() FastTeamLoader {
 	g.cacheMu.RLock()
 	defer g.cacheMu.RUnlock()
 	return g.fastTeamLoader
+}
+
+func (g *GlobalContext) GetHiddenTeamChainManager() HiddenTeamChainManager {
+	g.cacheMu.RLock()
+	defer g.cacheMu.RUnlock()
+	return g.hiddenTeamChainManager
+}
+
+func (g *GlobalContext) SetHiddenTeamChainManager(h HiddenTeamChainManager) {
+	g.cacheMu.Lock()
+	defer g.cacheMu.Unlock()
+	g.hiddenTeamChainManager = h
 }
 
 func (g *GlobalContext) GetTeamAuditor() TeamAuditor {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -682,7 +682,7 @@ type TeamLoader interface {
 	ImplicitAdmins(ctx context.Context, teamID keybase1.TeamID) (impAdmins []keybase1.UserVersion, err error)
 	MapTeamAncestors(ctx context.Context, f func(t keybase1.TeamSigChainState) error, teamID keybase1.TeamID, reason string, forceFullReloadOnceToAssert func(t keybase1.TeamSigChainState) bool) error
 	NotifyTeamRename(ctx context.Context, id keybase1.TeamID, newName string) error
-	Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, error)
+	Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, *keybase1.HiddenTeamChain, error)
 	// Freezing a team clears most data and forces a full reload when the team
 	// is loaded again. The team loader checks that the previous tail is
 	// contained within the new chain post-freeze. In particular, since we load
@@ -717,14 +717,17 @@ type FastTeamLoader interface {
 type HiddenTeamChainManager interface {
 	// We got gossip about what the latest chain-tail should be, so racthet the
 	// chain forward; the next call to Advance() has to match.
-	Ratchet(MetaContext, keybase1.TeamID, keybase1.LinkTriple) error
+	Ratchet(MetaContext, keybase1.TeamID, keybase1.HiddenTeamChainRatchet) error
 	// We got a bunch of new links downloaded via slow or fast loader, so add them
-	// onto the HiddenTeamChain state.
-	Advance(MetaContext, keybase1.HiddenTeamChainData) error
+	// onto the HiddenTeamChain state. Ensure that the udpated state is at least up to the
+	// given ratchet value.
+	Advance(mctx MetaContext, update keybase1.HiddenTeamChain) error
 	// Acceess the previously advanced state; lookup a PerTeamKey given the PerTeamKeyGeneration
 	PerTeamKeyAtGeneration(MetaContext, keybase1.TeamID, keybase1.PerTeamKeyGeneration) (*keybase1.PerTeamKey, error)
 	// Access the tail of the HiddenTeamChain, for embedding into gossip vectors.
 	Tail(MetaContext, keybase1.TeamID) (*keybase1.LinkTriple, error)
+	// Load the latest data for the given team ID, and just return it wholesale.
+	Load(MetaContext, keybase1.TeamID) (dat *keybase1.HiddenTeamChain, err error)
 }
 
 type TeamAuditor interface {

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -733,7 +733,7 @@ func (u *User) UpdateEmailProof(m MetaContext, key GenericKey, newEmail string) 
 }
 
 type SigMultiItem struct {
-	Sig3       string                  `json:"sig3,omitempty"`
+	Sig3       *Sig3                   `json:"sig3,omitempty"`
 	Sig        string                  `json:"sig,omitempty"`
 	SigningKID keybase1.KID            `json:"signing_kid"`
 	Type       string                  `json:"type"`
@@ -747,6 +747,12 @@ type SigMultiItem struct {
 type SigMultiItemPublicKeys struct {
 	Encryption keybase1.KID `json:"encryption"`
 	Signing    keybase1.KID `json:"signing"`
+}
+
+type Sig3 struct {
+	Inner string `json:"i,omitempty"`
+	Outer string `json:"o,omitempty"`
+	Sig   string `json:"s,omitempty"`
 }
 
 // PerUserKeyProof creates a proof introducing a new per-user-key generation.

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -47,8 +47,8 @@ func (n nullTeamLoader) NotifyTeamRename(ctx context.Context, id keybase1.TeamID
 	return nil
 }
 
-func (n nullTeamLoader) Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, error) {
-	return nil, fmt.Errorf("null team loader")
+func (n nullTeamLoader) Load(context.Context, keybase1.LoadTeamArg) (*keybase1.TeamData, *keybase1.HiddenTeamChain, error) {
+	return nil, nil, fmt.Errorf("null team loader")
 }
 
 func (n nullTeamLoader) Freeze(context.Context, keybase1.TeamID) error {
@@ -154,3 +154,29 @@ func (n nullTeamBoxAuditor) Attempt(m MetaContext, id keybase1.TeamID, rotateBef
 	return *attemptNullBoxAuditor()
 }
 func newNullTeamBoxAuditor() nullTeamBoxAuditor { return nullTeamBoxAuditor{} }
+
+type nullHiddenTeamChainManager struct{}
+
+var _ HiddenTeamChainManager = nullHiddenTeamChainManager{}
+
+func (n nullHiddenTeamChainManager) Tail(mctx MetaContext, id keybase1.TeamID) (*keybase1.LinkTriple, error) {
+	return nil, nil
+}
+
+func (n nullHiddenTeamChainManager) Ratchet(MetaContext, keybase1.TeamID, keybase1.HiddenTeamChainRatchet) error {
+	return nil
+}
+func (n nullHiddenTeamChainManager) Advance(MetaContext, keybase1.HiddenTeamChain) error {
+	return nil
+}
+func (n nullHiddenTeamChainManager) PerTeamKeyAtGeneration(MetaContext, keybase1.TeamID, keybase1.PerTeamKeyGeneration) (*keybase1.PerTeamKey, error) {
+	return nil, fmt.Errorf("null hidden team chain manager")
+}
+
+func (n nullHiddenTeamChainManager) Load(MetaContext, keybase1.TeamID) (*keybase1.HiddenTeamChain, error) {
+	return nil, fmt.Errorf("null hidden team chain manager")
+}
+
+func newNullHiddenTeamChainManager() nullHiddenTeamChainManager {
+	return nullHiddenTeamChainManager{}
+}

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -980,6 +980,7 @@ type UserForSignatures struct {
 func (u UserForSignatures) GetUID() keybase1.UID                  { return u.uid }
 func (u UserForSignatures) GetName() string                       { return u.name.String() }
 func (u UserForSignatures) GetEldestKID() keybase1.KID            { return u.eldestKID }
+func (u UserForSignatures) GetEldestSeqno() keybase1.Seqno        { return u.eldestSeqno }
 func (u UserForSignatures) GetNormalizedName() NormalizedUsername { return u.name }
 func (u UserForSignatures) ToUserVersion() keybase1.UserVersion {
 	return keybase1.UserVersion{Uid: u.uid, EldestSeqno: u.eldestSeqno}

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -112,6 +112,17 @@ func (o LinkID) DeepCopy() LinkID {
 	return o
 }
 
+type BinaryLinkID []byte
+
+func (o BinaryLinkID) DeepCopy() BinaryLinkID {
+	return (func(x []byte) []byte {
+		if x == nil {
+			return nil
+		}
+		return append([]byte{}, x...)
+	})(o)
+}
+
 type BinaryKID []byte
 
 func (o BinaryKID) DeepCopy() BinaryKID {
@@ -337,26 +348,32 @@ func (o Seqno) DeepCopy() Seqno {
 type SeqType int
 
 const (
-	SeqType_NONE        SeqType = 0
-	SeqType_PUBLIC      SeqType = 1
-	SeqType_PRIVATE     SeqType = 2
-	SeqType_SEMIPRIVATE SeqType = 3
+	SeqType_NONE                SeqType = 0
+	SeqType_PUBLIC              SeqType = 1
+	SeqType_PRIVATE             SeqType = 2
+	SeqType_SEMIPRIVATE         SeqType = 3
+	SeqType_USER_PRIVATE_HIDDEN SeqType = 16
+	SeqType_TEAM_PRIVATE_HIDDEN SeqType = 17
 )
 
 func (o SeqType) DeepCopy() SeqType { return o }
 
 var SeqTypeMap = map[string]SeqType{
-	"NONE":        0,
-	"PUBLIC":      1,
-	"PRIVATE":     2,
-	"SEMIPRIVATE": 3,
+	"NONE":                0,
+	"PUBLIC":              1,
+	"PRIVATE":             2,
+	"SEMIPRIVATE":         3,
+	"USER_PRIVATE_HIDDEN": 16,
+	"TEAM_PRIVATE_HIDDEN": 17,
 }
 
 var SeqTypeRevMap = map[SeqType]string{
-	0: "NONE",
-	1: "PUBLIC",
-	2: "PRIVATE",
-	3: "SEMIPRIVATE",
+	0:  "NONE",
+	1:  "PUBLIC",
+	2:  "PRIVATE",
+	3:  "SEMIPRIVATE",
+	16: "USER_PRIVATE_HIDDEN",
+	17: "TEAM_PRIVATE_HIDDEN",
 }
 
 func (e SeqType) String() string {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -375,6 +375,10 @@ func DeviceIDFromSlice(b []byte) (DeviceID, error) {
 	return DeviceIDFromBytes(x), nil
 }
 
+func LinkIDFromByte32(b [32]byte) LinkID {
+	return LinkID(hex.EncodeToString(b[:]))
+}
+
 func DeviceIDFromString(s string) (DeviceID, error) {
 	if len(s) != hex.EncodedLen(DeviceIDLen) {
 		return "", fmt.Errorf("Bad Device ID length: %d", len(s))
@@ -412,6 +416,10 @@ func (l LinkID) Eq(l2 LinkID) bool {
 
 func (l LinkID) IsNil() bool {
 	return len(l) == 0
+}
+
+func (l LinkID) String() string {
+	return string(l)
 }
 
 func NilTeamID() TeamID { return TeamID("") }
@@ -2688,6 +2696,14 @@ func (d FastTeamData) IsPublic() bool {
 	return d.Chain.Public
 }
 
+func (d HiddenTeamChain) ID() TeamID {
+	return d.Id
+}
+
+func (d HiddenTeamChain) IsPublic() bool {
+	return d.Public
+}
+
 func (f FullName) String() string {
 	return string(f)
 }
@@ -2763,4 +2779,261 @@ func (fct *FolderConflictType) UnmarshalText(text []byte) error {
 		return errors.New(fmt.Sprintf("Unknown conflict type: %s", text))
 	}
 	return nil
+}
+
+func (h *HiddenTeamChain) Tail() *HiddenTeamChainLink {
+	last := h.Last
+	if last == Seqno(0) {
+		return nil
+	}
+	ret, ok := h.Inner[last]
+	if !ok {
+		return nil
+	}
+	return &ret
+}
+
+func (s Signer) UserVersion() UserVersion {
+	return UserVersion{
+		Uid:         s.U,
+		EldestSeqno: s.E,
+	}
+}
+
+func (p PerTeamSeedCheck) Hash() (*PerTeamSeedCheckPostImage, error) {
+	if p.Version != PerTeamSeedCheckVersion_V1 {
+		return nil, errors.New("can only handle PerTeamKeySeedCheck V1")
+	}
+	ret := sha256.Sum256(p.Value[:])
+	return &PerTeamSeedCheckPostImage{
+		Version: PerTeamSeedCheckVersion_V1,
+		Value:   PerTeamSeedCheckValuePostImage(ret[:]),
+	}, nil
+}
+
+func (p PerTeamSeedCheckPostImage) Eq(p2 PerTeamSeedCheckPostImage) bool {
+	return (p.Version == p2.Version) && hmac.Equal(p.Value[:], p2.Value[:])
+}
+
+func (r HiddenTeamChainRatchet) Flat() []LinkTripleAndTime {
+	var ret []LinkTripleAndTime
+	add := func(p *LinkTripleAndTime) {
+		if p != nil {
+			ret = append(ret, *p)
+		}
+	}
+	add(r.Main)
+	add(r.Blinded)
+	add(r.Self)
+	return ret
+}
+
+func (r HiddenTeamChainRatchet) Max() Seqno {
+	var ret Seqno
+	visit := func(p *LinkTripleAndTime) {
+		if p != nil && p.Triple.Seqno > ret {
+			ret = p.Triple.Seqno
+		}
+	}
+	visit(r.Main)
+	visit(r.Blinded)
+	visit(r.Self)
+	return ret
+}
+
+func (r HiddenTeamChainRatchet) MaxTriple() (ret *LinkTriple) {
+	visit := func(p *LinkTripleAndTime) {
+		if p != nil && (ret == nil || p.Triple.Seqno > ret.Seqno) {
+			ret = &p.Triple
+		}
+	}
+	visit(r.Main)
+	visit(r.Blinded)
+	visit(r.Self)
+	return ret
+}
+
+func (d *HiddenTeamChain) RemoveLink(i Seqno) {
+	inner, ok := d.Inner[i]
+	if ok {
+		ptk, ok := inner.Ptk[PTKType_READER]
+		if ok {
+			delete(d.ReaderPerTeamKeys, ptk.Ptk.Gen)
+		}
+	}
+	delete(d.Inner, i)
+	delete(d.Outer, i)
+	if d.Last == i {
+		d.Last--
+	}
+}
+
+func (r *HiddenTeamChainRatchet) Merge(r2 HiddenTeamChainRatchet) (updated bool) {
+	visit := func(l1 **LinkTripleAndTime, l2 *LinkTripleAndTime) {
+		if l2 != nil && (*l1 == nil || (*l1).Triple.Seqno < l2.Triple.Seqno) {
+			*l1 = l2
+			updated = true
+		}
+	}
+	visit(&r.Main, r2.Main)
+	visit(&r.Blinded, r2.Blinded)
+	visit(&r.Self, r2.Self)
+	return updated
+}
+
+func (r LinkTripleAndTime) Clashes(r2 LinkTripleAndTime) bool {
+	l1 := r.Triple
+	l2 := r2.Triple
+	return (l1.Seqno == l2.Seqno && l1.SeqType == l2.SeqType && !l1.LinkID.Eq(l2.LinkID))
+}
+
+func (d *HiddenTeamChain) Merge(newData HiddenTeamChain) (updated bool, err error) {
+
+	for seqno, link := range newData.Outer {
+		existing, ok := d.Outer[seqno]
+		if ok && !existing.Eq(link) {
+			return false, fmt.Errorf("bad merge since at seqno %d, link clash: %s != %s", seqno, existing, link)
+		}
+		if ok {
+			continue
+		}
+		d.Outer[seqno] = link
+		updated = true
+		if seqno > d.Last {
+			d.Last = seqno
+		}
+	}
+
+	for q, i := range newData.Inner {
+		_, found := d.Inner[q]
+		if found {
+			continue
+		}
+		d.Inner[q] = i
+		if ptk, ok := i.Ptk[PTKType_READER]; ok {
+			d.ReaderPerTeamKeys[ptk.Ptk.Gen] = q
+		}
+		updated = true
+	}
+	if newData.Last > d.Last {
+		d.Last = newData.Last
+	}
+
+	for k, v := range newData.LastPerTeamKeys {
+		existing, ok := d.LastPerTeamKeys[k]
+		if !ok || existing < v {
+			d.LastPerTeamKeys[k] = v
+		}
+	}
+
+	return updated, nil
+}
+
+func (h HiddenTeamChain) HasSeqno(s Seqno) bool {
+	_, found := h.Outer[s]
+	return found
+}
+
+func NewHiddenTeamChain(id TeamID) *HiddenTeamChain {
+	return &HiddenTeamChain{
+		Id:                id,
+		LastPerTeamKeys:   make(map[PTKType]Seqno),
+		ReaderPerTeamKeys: make(map[PerTeamKeyGeneration]Seqno),
+		Outer:             make(map[Seqno]LinkID),
+		Inner:             make(map[Seqno]HiddenTeamChainLink),
+	}
+}
+
+func (h HiddenTeamChain) LastReaderPerTeamKeyLinkID() (ret LinkID) {
+	seqno, ok := h.LastPerTeamKeys[PTKType_READER]
+	if !ok {
+		return ret
+	}
+	tmp, ok := h.Outer[seqno]
+	if !ok {
+		return ret
+	}
+	return tmp
+}
+
+func (h *HiddenTeamChain) GetReaderPerTeamKeyAtGeneration(g PerTeamKeyGeneration) (ret PerTeamKey, found bool) {
+	if h == nil {
+		return ret, false
+	}
+	q, ok := h.ReaderPerTeamKeys[g]
+	if !ok {
+		return ret, false
+	}
+	inner, ok := h.Inner[q]
+	if !ok {
+		return ret, false
+	}
+	key, ok := inner.Ptk[PTKType_READER]
+	if !ok {
+		return ret, false
+	}
+	return key.Ptk, true
+}
+
+func (h *HiddenTeamChain) MaxReaderPerTeamKey() *PerTeamKey {
+	if h == nil {
+		return nil
+	}
+	seqno, ok := h.LastPerTeamKeys[PTKType_READER]
+	if !ok {
+		return nil
+	}
+	inner, ok := h.Inner[seqno]
+	if !ok {
+		return nil
+	}
+	ptk, ok := inner.Ptk[PTKType_READER]
+	if !ok {
+		return nil
+	}
+	return &ptk.Ptk
+}
+
+func (h *HiddenTeamChain) MaxReaderPerTeamKeyGeneration() PerTeamKeyGeneration {
+	k := h.MaxReaderPerTeamKey()
+	if k == nil {
+		return PerTeamKeyGeneration(0)
+	}
+	return k.Gen
+}
+
+func (h *HiddenTeamChain) KeySummary() string {
+	if h == nil {
+		return "Ø"
+	}
+	return fmt.Sprintf("{last:%d, lastPerTeamKeys:%+v, readerPerTeamKeys: %+v}", h.Last, h.LastPerTeamKeys, h.ReaderPerTeamKeys)
+}
+
+func (h *TeamData) KeySummary() string {
+	if h == nil {
+		return "Ø"
+	}
+	var p []PerTeamKeyGeneration
+	for k := range h.PerTeamKeySeedsUnverified {
+		p = append(p, k)
+	}
+	m := make(map[PerTeamKeyGeneration]bool)
+	for _, v := range h.ReaderKeyMasks {
+		for k := range v {
+			m[k] = true
+		}
+	}
+	var r []PerTeamKeyGeneration
+	for k := range m {
+		r = append(r, k)
+	}
+	return fmt.Sprintf("{ptksu:%v, rkms:%v, sigchain:%s}", p, r, h.Chain.KeySummary())
+}
+
+func (s TeamSigChainState) KeySummary() string {
+	var v []PerTeamKeyGeneration
+	for k := range s.PerTeamKeys {
+		v = append(v, k)
+	}
+	return fmt.Sprintf("{maxPTK:%d, ptk:%v}", s.MaxPerTeamKeyGeneration, v)
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -143,6 +143,75 @@ func (e PTKType) String() string {
 	return ""
 }
 
+type PerTeamSeedCheckVersion int
+
+const (
+	PerTeamSeedCheckVersion_V1 PerTeamSeedCheckVersion = 1
+)
+
+func (o PerTeamSeedCheckVersion) DeepCopy() PerTeamSeedCheckVersion { return o }
+
+var PerTeamSeedCheckVersionMap = map[string]PerTeamSeedCheckVersion{
+	"V1": 1,
+}
+
+var PerTeamSeedCheckVersionRevMap = map[PerTeamSeedCheckVersion]string{
+	1: "V1",
+}
+
+func (e PerTeamSeedCheckVersion) String() string {
+	if v, ok := PerTeamSeedCheckVersionRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type PerTeamSeedCheck struct {
+	Version PerTeamSeedCheckVersion `codec:"version" json:"version"`
+	Value   PerTeamSeedCheckValue   `codec:"value" json:"value"`
+}
+
+func (o PerTeamSeedCheck) DeepCopy() PerTeamSeedCheck {
+	return PerTeamSeedCheck{
+		Version: o.Version.DeepCopy(),
+		Value:   o.Value.DeepCopy(),
+	}
+}
+
+type PerTeamSeedCheckValue []byte
+
+func (o PerTeamSeedCheckValue) DeepCopy() PerTeamSeedCheckValue {
+	return (func(x []byte) []byte {
+		if x == nil {
+			return nil
+		}
+		return append([]byte{}, x...)
+	})(o)
+}
+
+type PerTeamSeedCheckValuePostImage []byte
+
+func (o PerTeamSeedCheckValuePostImage) DeepCopy() PerTeamSeedCheckValuePostImage {
+	return (func(x []byte) []byte {
+		if x == nil {
+			return nil
+		}
+		return append([]byte{}, x...)
+	})(o)
+}
+
+type PerTeamSeedCheckPostImage struct {
+	Value   PerTeamSeedCheckValuePostImage `codec:"h" json:"h"`
+	Version PerTeamSeedCheckVersion        `codec:"v" json:"v"`
+}
+
+func (o PerTeamSeedCheckPostImage) DeepCopy() PerTeamSeedCheckPostImage {
+	return PerTeamSeedCheckPostImage{
+		Value:   o.Value.DeepCopy(),
+		Version: o.Version.DeepCopy(),
+	}
+}
+
 type TeamApplicationKey struct {
 	Application   TeamApplication      `codec:"application" json:"application"`
 	KeyGeneration PerTeamKeyGeneration `codec:"keyGeneration" json:"keyGeneration"`
@@ -204,6 +273,18 @@ func (o PerTeamKey) DeepCopy() PerTeamKey {
 	}
 }
 
+type PerTeamKeyAndCheck struct {
+	Ptk   PerTeamKey                `codec:"ptk" json:"ptk"`
+	Check PerTeamSeedCheckPostImage `codec:"check" json:"check"`
+}
+
+func (o PerTeamKeyAndCheck) DeepCopy() PerTeamKeyAndCheck {
+	return PerTeamKeyAndCheck{
+		Ptk:   o.Ptk.DeepCopy(),
+		Check: o.Check.DeepCopy(),
+	}
+}
+
 type PerTeamKeySeed [32]byte
 
 func (o PerTeamKeySeed) DeepCopy() PerTeamKeySeed {
@@ -216,6 +297,7 @@ type PerTeamKeySeedItem struct {
 	Seed       PerTeamKeySeed       `codec:"seed" json:"seed"`
 	Generation PerTeamKeyGeneration `codec:"generation" json:"generation"`
 	Seqno      Seqno                `codec:"seqno" json:"seqno"`
+	Check      *PerTeamSeedCheck    `codec:"check,omitempty" json:"check,omitempty"`
 }
 
 func (o PerTeamKeySeedItem) DeepCopy() PerTeamKeySeedItem {
@@ -223,6 +305,13 @@ func (o PerTeamKeySeedItem) DeepCopy() PerTeamKeySeedItem {
 		Seed:       o.Seed.DeepCopy(),
 		Generation: o.Generation.DeepCopy(),
 		Seqno:      o.Seqno.DeepCopy(),
+		Check: (func(x *PerTeamSeedCheck) *PerTeamSeedCheck {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Check),
 	}
 }
 
@@ -656,16 +745,18 @@ func (o TeamData) DeepCopy() TeamData {
 }
 
 type FastTeamData struct {
-	Frozen                    bool                                                 `codec:"frozen" json:"frozen"`
-	Tombstoned                bool                                                 `codec:"tombstoned" json:"tombstoned"`
-	Name                      TeamName                                             `codec:"name" json:"name"`
-	Chain                     FastTeamSigChainState                                `codec:"chain" json:"chain"`
-	PerTeamKeySeedsUnverified map[PerTeamKeyGeneration]PerTeamKeySeed              `codec:"perTeamKeySeeds" json:"perTeamKeySeedsUnverified"`
-	LatestKeyGeneration       PerTeamKeyGeneration                                 `codec:"latestKeyGeneration" json:"latestKeyGeneration"`
-	ReaderKeyMasks            map[TeamApplication]map[PerTeamKeyGeneration]MaskB64 `codec:"readerKeyMasks" json:"readerKeyMasks"`
-	LatestSeqnoHint           Seqno                                                `codec:"latestSeqnoHint" json:"latestSeqnoHint"`
-	CachedAt                  Time                                                 `codec:"cachedAt" json:"cachedAt"`
-	LoadedLatest              bool                                                 `codec:"loadedLatest" json:"loadedLatest"`
+	Frozen                     bool                                                 `codec:"frozen" json:"frozen"`
+	Tombstoned                 bool                                                 `codec:"tombstoned" json:"tombstoned"`
+	Name                       TeamName                                             `codec:"name" json:"name"`
+	Chain                      FastTeamSigChainState                                `codec:"chain" json:"chain"`
+	PerTeamKeySeedsUnverified  map[PerTeamKeyGeneration]PerTeamKeySeed              `codec:"perTeamKeySeeds" json:"perTeamKeySeedsUnverified"`
+	MaxContinuousPTKGeneration PerTeamKeyGeneration                                 `codec:"maxContinuousPTKGeneration" json:"maxContinuousPTKGeneration"`
+	SeedChecks                 map[PerTeamKeyGeneration]PerTeamSeedCheck            `codec:"seedChecks" json:"seedChecks"`
+	LatestKeyGeneration        PerTeamKeyGeneration                                 `codec:"latestKeyGeneration" json:"latestKeyGeneration"`
+	ReaderKeyMasks             map[TeamApplication]map[PerTeamKeyGeneration]MaskB64 `codec:"readerKeyMasks" json:"readerKeyMasks"`
+	LatestSeqnoHint            Seqno                                                `codec:"latestSeqnoHint" json:"latestSeqnoHint"`
+	CachedAt                   Time                                                 `codec:"cachedAt" json:"cachedAt"`
+	LoadedLatest               bool                                                 `codec:"loadedLatest" json:"loadedLatest"`
 }
 
 func (o FastTeamData) DeepCopy() FastTeamData {
@@ -686,6 +777,19 @@ func (o FastTeamData) DeepCopy() FastTeamData {
 			}
 			return ret
 		})(o.PerTeamKeySeedsUnverified),
+		MaxContinuousPTKGeneration: o.MaxContinuousPTKGeneration.DeepCopy(),
+		SeedChecks: (func(x map[PerTeamKeyGeneration]PerTeamSeedCheck) map[PerTeamKeyGeneration]PerTeamSeedCheck {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[PerTeamKeyGeneration]PerTeamSeedCheck, len(x))
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v.DeepCopy()
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.SeedChecks),
 		LatestKeyGeneration: o.LatestKeyGeneration.DeepCopy(),
 		ReaderKeyMasks: (func(x map[TeamApplication]map[PerTeamKeyGeneration]MaskB64) map[TeamApplication]map[PerTeamKeyGeneration]MaskB64 {
 			if x == nil {
@@ -716,19 +820,73 @@ func (o FastTeamData) DeepCopy() FastTeamData {
 	}
 }
 
-type HiddenTeamChainData struct {
-	ID     TeamID                        `codec:"ID" json:"ID"`
-	Public bool                          `codec:"public" json:"public"`
-	Last   Seqno                         `codec:"last" json:"last"`
-	Outer  map[Seqno]LinkID              `codec:"outer" json:"outer"`
-	Inner  map[Seqno]HiddenTeamChainLink `codec:"inner" json:"inner"`
+type HiddenTeamChainRatchet struct {
+	Main    *LinkTripleAndTime `codec:"main,omitempty" json:"main,omitempty"`
+	Blinded *LinkTripleAndTime `codec:"blinded,omitempty" json:"blinded,omitempty"`
+	Self    *LinkTripleAndTime `codec:"self,omitempty" json:"self,omitempty"`
 }
 
-func (o HiddenTeamChainData) DeepCopy() HiddenTeamChainData {
-	return HiddenTeamChainData{
-		ID:     o.ID.DeepCopy(),
-		Public: o.Public,
-		Last:   o.Last.DeepCopy(),
+func (o HiddenTeamChainRatchet) DeepCopy() HiddenTeamChainRatchet {
+	return HiddenTeamChainRatchet{
+		Main: (func(x *LinkTripleAndTime) *LinkTripleAndTime {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Main),
+		Blinded: (func(x *LinkTripleAndTime) *LinkTripleAndTime {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Blinded),
+		Self: (func(x *LinkTripleAndTime) *LinkTripleAndTime {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Self),
+	}
+}
+
+type HiddenTeamChain struct {
+	Id                TeamID                         `codec:"id" json:"id"`
+	Subversion        int                            `codec:"subversion" json:"subversion"`
+	Public            bool                           `codec:"public" json:"public"`
+	Frozen            bool                           `codec:"frozen" json:"frozen"`
+	Tombstoned        bool                           `codec:"tombstoned" json:"tombstoned"`
+	Last              Seqno                          `codec:"last" json:"last"`
+	LastPerTeamKeys   map[PTKType]Seqno              `codec:"lastPerTeamKeys" json:"lastPerTeamKeys"`
+	Outer             map[Seqno]LinkID               `codec:"outer" json:"outer"`
+	Inner             map[Seqno]HiddenTeamChainLink  `codec:"inner" json:"inner"`
+	ReaderPerTeamKeys map[PerTeamKeyGeneration]Seqno `codec:"readerPerTeamKeys" json:"readerPerTeamKeys"`
+	Ratchet           HiddenTeamChainRatchet         `codec:"ratchet" json:"ratchet"`
+	CachedAt          Time                           `codec:"cachedAt" json:"cachedAt"`
+}
+
+func (o HiddenTeamChain) DeepCopy() HiddenTeamChain {
+	return HiddenTeamChain{
+		Id:         o.Id.DeepCopy(),
+		Subversion: o.Subversion,
+		Public:     o.Public,
+		Frozen:     o.Frozen,
+		Tombstoned: o.Tombstoned,
+		Last:       o.Last.DeepCopy(),
+		LastPerTeamKeys: (func(x map[PTKType]Seqno) map[PTKType]Seqno {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[PTKType]Seqno, len(x))
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v.DeepCopy()
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.LastPerTeamKeys),
 		Outer: (func(x map[Seqno]LinkID) map[Seqno]LinkID {
 			if x == nil {
 				return nil
@@ -753,22 +911,7 @@ func (o HiddenTeamChainData) DeepCopy() HiddenTeamChainData {
 			}
 			return ret
 		})(o.Inner),
-	}
-}
-
-type HiddenTeamChain struct {
-	Subversion  int                            `codec:"v" json:"v"`
-	Data        HiddenTeamChainData            `codec:"data" json:"data"`
-	PerTeamKeys map[PerTeamKeyGeneration]Seqno `codec:"perTeamKeys" json:"perTeamKeys"`
-	Ratchet     *LinkTriple                    `codec:"ratchet,omitempty" json:"ratchet,omitempty"`
-	CachedAt    Time                           `codec:"cachedAt" json:"cachedAt"`
-}
-
-func (o HiddenTeamChain) DeepCopy() HiddenTeamChain {
-	return HiddenTeamChain{
-		Subversion: o.Subversion,
-		Data:       o.Data.DeepCopy(),
-		PerTeamKeys: (func(x map[PerTeamKeyGeneration]Seqno) map[PerTeamKeyGeneration]Seqno {
+		ReaderPerTeamKeys: (func(x map[PerTeamKeyGeneration]Seqno) map[PerTeamKeyGeneration]Seqno {
 			if x == nil {
 				return nil
 			}
@@ -779,14 +922,8 @@ func (o HiddenTeamChain) DeepCopy() HiddenTeamChain {
 				ret[kCopy] = vCopy
 			}
 			return ret
-		})(o.PerTeamKeys),
-		Ratchet: (func(x *LinkTriple) *LinkTriple {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.Ratchet),
+		})(o.ReaderPerTeamKeys),
+		Ratchet:  o.Ratchet.DeepCopy(),
 		CachedAt: o.CachedAt.DeepCopy(),
 	}
 }
@@ -802,6 +939,18 @@ func (o LinkTriple) DeepCopy() LinkTriple {
 		Seqno:   o.Seqno.DeepCopy(),
 		SeqType: o.SeqType.DeepCopy(),
 		LinkID:  o.LinkID.DeepCopy(),
+	}
+}
+
+type LinkTripleAndTime struct {
+	Triple LinkTriple `codec:"triple" json:"triple"`
+	Time   Time       `codec:"time" json:"time"`
+}
+
+func (o LinkTripleAndTime) DeepCopy() LinkTripleAndTime {
+	return LinkTripleAndTime{
+		Triple: o.Triple.DeepCopy(),
+		Time:   o.Time.DeepCopy(),
 	}
 }
 
@@ -850,10 +999,10 @@ func (o Signer) DeepCopy() Signer {
 }
 
 type HiddenTeamChainLink struct {
-	MerkleRoot  MerkleRootV2           `codec:"m" json:"m"`
-	ParentChain LinkTriple             `codec:"p" json:"p"`
-	Signer      Signer                 `codec:"s" json:"s"`
-	Ptk         map[PTKType]PerTeamKey `codec:"k" json:"k"`
+	MerkleRoot  MerkleRootV2                   `codec:"m" json:"m"`
+	ParentChain LinkTriple                     `codec:"p" json:"p"`
+	Signer      Signer                         `codec:"s" json:"s"`
+	Ptk         map[PTKType]PerTeamKeyAndCheck `codec:"k" json:"k"`
 }
 
 func (o HiddenTeamChainLink) DeepCopy() HiddenTeamChainLink {
@@ -861,11 +1010,11 @@ func (o HiddenTeamChainLink) DeepCopy() HiddenTeamChainLink {
 		MerkleRoot:  o.MerkleRoot.DeepCopy(),
 		ParentChain: o.ParentChain.DeepCopy(),
 		Signer:      o.Signer.DeepCopy(),
-		Ptk: (func(x map[PTKType]PerTeamKey) map[PTKType]PerTeamKey {
+		Ptk: (func(x map[PTKType]PerTeamKeyAndCheck) map[PTKType]PerTeamKeyAndCheck {
 			if x == nil {
 				return nil
 			}
-			ret := make(map[PTKType]PerTeamKey, len(x))
+			ret := make(map[PTKType]PerTeamKeyAndCheck, len(x))
 			for k, v := range x {
 				kCopy := k.DeepCopy()
 				vCopy := v.DeepCopy()
@@ -1344,32 +1493,33 @@ func (o TeamLegacyTLFUpgradeChainInfo) DeepCopy() TeamLegacyTLFUpgradeChainInfo 
 }
 
 type TeamSigChainState struct {
-	Reader           UserVersion                                       `codec:"reader" json:"reader"`
-	Id               TeamID                                            `codec:"id" json:"id"`
-	Implicit         bool                                              `codec:"implicit" json:"implicit"`
-	Public           bool                                              `codec:"public" json:"public"`
-	RootAncestor     TeamName                                          `codec:"rootAncestor" json:"rootAncestor"`
-	NameDepth        int                                               `codec:"nameDepth" json:"nameDepth"`
-	NameLog          []TeamNameLogPoint                                `codec:"nameLog" json:"nameLog"`
-	LastSeqno        Seqno                                             `codec:"lastSeqno" json:"lastSeqno"`
-	LastLinkID       LinkID                                            `codec:"lastLinkID" json:"lastLinkID"`
-	LastHighSeqno    Seqno                                             `codec:"lastHighSeqno" json:"lastHighSeqno"`
-	LastHighLinkID   LinkID                                            `codec:"lastHighLinkID" json:"lastHighLinkID"`
-	ParentID         *TeamID                                           `codec:"parentID,omitempty" json:"parentID,omitempty"`
-	UserLog          map[UserVersion][]UserLogPoint                    `codec:"userLog" json:"userLog"`
-	SubteamLog       map[TeamID][]SubteamLogPoint                      `codec:"subteamLog" json:"subteamLog"`
-	PerTeamKeys      map[PerTeamKeyGeneration]PerTeamKey               `codec:"perTeamKeys" json:"perTeamKeys"`
-	PerTeamKeyCTime  UnixTime                                          `codec:"perTeamKeyCTime" json:"perTeamKeyCTime"`
-	LinkIDs          map[Seqno]LinkID                                  `codec:"linkIDs" json:"linkIDs"`
-	StubbedLinks     map[Seqno]bool                                    `codec:"stubbedLinks" json:"stubbedLinks"`
-	ActiveInvites    map[TeamInviteID]TeamInvite                       `codec:"activeInvites" json:"activeInvites"`
-	ObsoleteInvites  map[TeamInviteID]TeamInvite                       `codec:"obsoleteInvites" json:"obsoleteInvites"`
-	Open             bool                                              `codec:"open" json:"open"`
-	OpenTeamJoinAs   TeamRole                                          `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
-	TlfIDs           []TLFID                                           `codec:"tlfIDs" json:"tlfIDs"`
-	TlfLegacyUpgrade map[TeamApplication]TeamLegacyTLFUpgradeChainInfo `codec:"tlfLegacyUpgrade" json:"tlfLegacyUpgrade"`
-	HeadMerkle       *MerkleRootV2                                     `codec:"headMerkle,omitempty" json:"headMerkle,omitempty"`
-	MerkleRoots      map[Seqno]MerkleRootV2                            `codec:"merkleRoots" json:"merkleRoots"`
+	Reader                  UserVersion                                       `codec:"reader" json:"reader"`
+	Id                      TeamID                                            `codec:"id" json:"id"`
+	Implicit                bool                                              `codec:"implicit" json:"implicit"`
+	Public                  bool                                              `codec:"public" json:"public"`
+	RootAncestor            TeamName                                          `codec:"rootAncestor" json:"rootAncestor"`
+	NameDepth               int                                               `codec:"nameDepth" json:"nameDepth"`
+	NameLog                 []TeamNameLogPoint                                `codec:"nameLog" json:"nameLog"`
+	LastSeqno               Seqno                                             `codec:"lastSeqno" json:"lastSeqno"`
+	LastLinkID              LinkID                                            `codec:"lastLinkID" json:"lastLinkID"`
+	LastHighSeqno           Seqno                                             `codec:"lastHighSeqno" json:"lastHighSeqno"`
+	LastHighLinkID          LinkID                                            `codec:"lastHighLinkID" json:"lastHighLinkID"`
+	ParentID                *TeamID                                           `codec:"parentID,omitempty" json:"parentID,omitempty"`
+	UserLog                 map[UserVersion][]UserLogPoint                    `codec:"userLog" json:"userLog"`
+	SubteamLog              map[TeamID][]SubteamLogPoint                      `codec:"subteamLog" json:"subteamLog"`
+	PerTeamKeys             map[PerTeamKeyGeneration]PerTeamKey               `codec:"perTeamKeys" json:"perTeamKeys"`
+	MaxPerTeamKeyGeneration PerTeamKeyGeneration                              `codec:"maxPerTeamKeyGeneration" json:"maxPerTeamKeyGeneration"`
+	PerTeamKeyCTime         UnixTime                                          `codec:"perTeamKeyCTime" json:"perTeamKeyCTime"`
+	LinkIDs                 map[Seqno]LinkID                                  `codec:"linkIDs" json:"linkIDs"`
+	StubbedLinks            map[Seqno]bool                                    `codec:"stubbedLinks" json:"stubbedLinks"`
+	ActiveInvites           map[TeamInviteID]TeamInvite                       `codec:"activeInvites" json:"activeInvites"`
+	ObsoleteInvites         map[TeamInviteID]TeamInvite                       `codec:"obsoleteInvites" json:"obsoleteInvites"`
+	Open                    bool                                              `codec:"open" json:"open"`
+	OpenTeamJoinAs          TeamRole                                          `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
+	TlfIDs                  []TLFID                                           `codec:"tlfIDs" json:"tlfIDs"`
+	TlfLegacyUpgrade        map[TeamApplication]TeamLegacyTLFUpgradeChainInfo `codec:"tlfLegacyUpgrade" json:"tlfLegacyUpgrade"`
+	HeadMerkle              *MerkleRootV2                                     `codec:"headMerkle,omitempty" json:"headMerkle,omitempty"`
+	MerkleRoots             map[Seqno]MerkleRootV2                            `codec:"merkleRoots" json:"merkleRoots"`
 }
 
 func (o TeamSigChainState) DeepCopy() TeamSigChainState {
@@ -1458,7 +1608,8 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 			}
 			return ret
 		})(o.PerTeamKeys),
-		PerTeamKeyCTime: o.PerTeamKeyCTime.DeepCopy(),
+		MaxPerTeamKeyGeneration: o.MaxPerTeamKeyGeneration.DeepCopy(),
+		PerTeamKeyCTime:         o.PerTeamKeyCTime.DeepCopy(),
 		LinkIDs: (func(x map[Seqno]LinkID) map[Seqno]LinkID {
 			if x == nil {
 				return nil

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
+	teamStorage "github.com/keybase/client/go/teams/storage"
 	"github.com/keybase/client/go/tlfupgrade"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
@@ -162,7 +163,7 @@ func (h *KBFSHandler) UpgradeTLF(ctx context.Context, arg keybase1.UpgradeTLFArg
 // favorites.
 func (h *KBFSHandler) getKeyFn() func(context.Context) ([32]byte, error) {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return teams.GetLocalStorageSecretBoxKeyGeneric(ctx, h.G(), favoritesEncryptionReason)
+		return teamStorage.GetLocalStorageSecretBoxKeyGeneric(ctx, h.G(), favoritesEncryptionReason)
 	}
 	return keyFn
 }

--- a/go/sig3/errors.go
+++ b/go/sig3/errors.go
@@ -28,5 +28,17 @@ func newSig3Error(f string, a ...interface{}) error {
 	return Sig3Error{m: fmt.Sprintf(f, a...)}
 }
 
+type SequenceError struct {
+	m string
+}
+
+func newSequenceError(f string, a ...interface{}) error {
+	return SequenceError{m: fmt.Sprintf(f, a...)}
+}
+
+func (e SequenceError) Error() string {
+	return fmt.Sprintf("sig3 sequencing error: %s", e.m)
+}
+
 var _ error = ParseError{}
 var _ error = Sig3Error{}

--- a/go/sig3/exim.go
+++ b/go/sig3/exim.go
@@ -1,0 +1,123 @@
+package sig3
+
+import (
+	"encoding/hex"
+	"fmt"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+func (p PerTeamKey) Export(q keybase1.Seqno) keybase1.PerTeamKeyAndCheck {
+	return keybase1.PerTeamKeyAndCheck{
+		Ptk: keybase1.PerTeamKey{
+			Gen:    p.Generation,
+			Seqno:  q,
+			SigKID: p.SigningKID.ToKID(),
+			EncKID: p.EncryptionKID.ToKID(),
+		},
+		Check: p.SeedCheck,
+	}
+}
+
+func (l *LinkID) Export() keybase1.LinkID {
+	if l == nil {
+		return keybase1.LinkID("")
+	}
+	return keybase1.LinkID(hex.EncodeToString(l[:]))
+}
+
+func (u UID) Export() keybase1.UID {
+	return keybase1.UID(hex.EncodeToString(u[:]))
+}
+
+func (r RotateKey) Export() (ret *keybase1.HiddenTeamChainLink, err error) {
+	m := make(map[keybase1.PTKType]keybase1.PerTeamKeyAndCheck)
+	readerKey := r.ReaderKey()
+	if readerKey == nil {
+		return nil, fmt.Errorf("cannot export RotateKey, since no known reeader key")
+	}
+
+	m[keybase1.PTKType_READER] = readerKey.Export(r.Seqno())
+	return &keybase1.HiddenTeamChainLink{
+		MerkleRoot:  r.Base.inner.MerkleRoot.Export(),
+		ParentChain: r.Base.inner.ParentChain.Export(),
+		Signer:      r.Base.inner.Signer.Export(),
+		Ptk:         m,
+	}, nil
+}
+
+func (m MerkleRoot) Export() keybase1.MerkleRootV2 {
+	return keybase1.MerkleRootV2{
+		Seqno:    m.Seqno,
+		HashMeta: m.Hash,
+	}
+}
+
+func (t Tail) Export() keybase1.LinkTriple {
+	return keybase1.LinkTriple{
+		Seqno:   t.Seqno,
+		SeqType: t.ChainType,
+		LinkID:  t.Hash.Export(),
+	}
+}
+
+func (s Signer) Export() keybase1.Signer {
+	return keybase1.Signer{
+		E: s.EldestSeqno,
+		K: s.KID.ToKID(),
+		U: s.UID.Export(),
+	}
+}
+
+func ExportToPrevLinkTriple(g Generic) keybase1.LinkTriple {
+	return keybase1.LinkTriple{
+		Seqno:   g.Seqno() - 1,
+		SeqType: g.Outer().ChainType,
+		LinkID:  g.Prev().Export(),
+	}
+}
+
+func ImportLinkID(l keybase1.LinkID) (*LinkID, error) {
+	if len(l) != 64 {
+		return nil, fmt.Errorf("failed to import linkID; wrong length: %d", len(l))
+	}
+	tmp, err := hex.DecodeString(string(l))
+	if err != nil {
+		return nil, err
+	}
+	var ret LinkID
+	copy(ret[:], tmp)
+	return &ret, nil
+}
+
+func ImportTail(l keybase1.LinkTriple) (*Tail, error) {
+	hash, err := ImportLinkID(l.LinkID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Tail{
+		Seqno:     l.Seqno,
+		ChainType: l.SeqType,
+		Hash:      *hash,
+	}, nil
+}
+
+func ImportUID(u keybase1.UID) (ret UID) {
+	tmp := u.ToBytes()
+	copy(ret[:], tmp)
+	return ret
+}
+
+func ImportKID(k keybase1.KID) (ret KID) {
+	return KID(k.ToBinaryKID())
+}
+
+func ImportTeamID(t keybase1.TeamID) (*TeamID, error) {
+	tmp, err := hex.DecodeString(string(t))
+	if err != nil {
+		return nil, err
+	}
+	var ret TeamID
+	copy(ret[:], tmp)
+	return &ret, nil
+}

--- a/go/sig3/sig3.go
+++ b/go/sig3/sig3.go
@@ -2,14 +2,14 @@ package sig3
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"github.com/keybase/client/go/kbcrypto"
 	"github.com/keybase/client/go/msgpack"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-crypto/ed25519"
 )
-
-//
 
 // Generic sig3 wrapper class, should implement the following interface.
 type Generic interface {
@@ -66,6 +66,19 @@ func NewRotateKey(o OuterLink, i InnerLink, b RotateKeyBody) *RotateKey {
 func (r *RotateKey) rkb() *RotateKeyBody {
 	ret, _ := r.Base.inner.Body.(*RotateKeyBody)
 	return ret
+}
+
+func (r *RotateKey) PTKs() []PerTeamKey {
+	return r.rkb().PTKs
+}
+
+func (r *RotateKey) ReaderKey() *PerTeamKey {
+	for _, k := range r.rkb().PTKs {
+		if k.PTKType == keybase1.PTKType_READER {
+			return &k
+		}
+	}
+	return nil
 }
 
 func (b *Base) setVerifiedBit() {
@@ -126,11 +139,19 @@ func (b Base) verify() error {
 }
 
 func (i InnerLink) hash() (LinkID, error) {
+	return hashInterface(i)
+}
+
+func hashInterface(i interface{}) (LinkID, error) {
 	b, err := msgpack.Encode(i)
 	if err != nil {
 		return LinkID{}, err
 	}
 	return hash(b), nil
+}
+
+func (o OuterLink) Hash() (LinkID, error) {
+	return hashInterface(o)
 }
 
 func (r RotateKey) verify() error {
@@ -201,7 +222,7 @@ func (l LinkID) eq(m LinkID) bool {
 	return hmac.Equal(l[:], m[:])
 }
 
-func (s Sig3ExportJSON) parseSig() (*Base, error) {
+func (s ExportJSON) parseSig() (*Base, error) {
 	var out Base
 	if s.Sig == "" {
 		return &out, nil
@@ -218,7 +239,7 @@ func (s Sig3ExportJSON) parseSig() (*Base, error) {
 	return &out, nil
 }
 
-func (s Sig3ExportJSON) parseOuter(in Base) (*Base, error) {
+func (s ExportJSON) parseOuter(in Base) (*Base, error) {
 	if s.Outer == "" {
 		return nil, newParseError("outer cannot be nil")
 	}
@@ -243,7 +264,7 @@ func (s Sig3ExportJSON) parseOuter(in Base) (*Base, error) {
 	return &in, nil
 }
 
-func (s *Sig3ExportJSON) parseInner(in Base) (Generic, error) {
+func (s *ExportJSON) parseInner(in Base) (Generic, error) {
 	var out Generic
 
 	if (s.Inner == "") != (in.sig == nil) {
@@ -279,7 +300,7 @@ func (s *Sig3ExportJSON) parseInner(in Base) (Generic, error) {
 	return out, nil
 }
 
-func (s Sig3ExportJSON) parse() (out Generic, err error) {
+func (s ExportJSON) parse() (out Generic, err error) {
 	var tmp *Base
 	tmp, err = s.parseSig()
 	if err != nil {
@@ -296,10 +317,10 @@ func (s Sig3ExportJSON) parse() (out Generic, err error) {
 	return out, nil
 }
 
-// Import from Sig3ExportJSON format (as sucked down from the server) into a Generic link type,
+// Import from ExportJSON format (as sucked down from the server) into a Generic link type,
 // that can be casted into the supported link types (like RotateKey). Returns an error if we
 // failed to parse the input data, or if signature validation failed.
-func (s Sig3ExportJSON) Import() (Generic, error) {
+func (s ExportJSON) Import() (Generic, error) {
 	out, err := s.parse()
 	if err != nil {
 		return nil, err
@@ -329,6 +350,22 @@ type KeyPair struct {
 	pub  KID
 }
 
+func NewKeyPair(priv kbcrypto.NaclSigningKeyPrivate, pub KID) *KeyPair {
+	return &KeyPair{priv, pub}
+}
+
+func genRandomBytes(i int) ([]byte, error) {
+	ret := make([]byte, i, i)
+	n, err := rand.Reader.Read(ret[:])
+	if err != nil {
+		return nil, err
+	}
+	if n != i {
+		return nil, newSig3Error("short random entropy read")
+	}
+	return ret, nil
+}
+
 // Sign the RotateKey structure, with the given user's keypair (outer), and with the new
 // PTKs (inner). Return a Sig3Bundle, which was the exportable information, that you can
 // export either to local storage or up to the server.
@@ -343,6 +380,12 @@ func (r RotateKey) Sign(outer KeyPair, inners []KeyPair) (ret *Sig3Bundle, err e
 	o.LinkType = LinkTypeRotateKey
 	o.ChainType = ChainTypeTeamPrivateHidden
 	i.Signer.KID = outer.pub
+	if i.Entropy == nil {
+		i.Entropy, err = genRandomBytes(16)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	for j := range r.rkb().PTKs {
 		ptk := &r.rkb().PTKs[j]
@@ -386,7 +429,7 @@ func signGeneric(g Generic, privkey kbcrypto.NaclSigningKeyPrivate) (ret *Sig3Bu
 }
 
 // Export a sig3 up to the server in base64'ed JSON format, as in a POST request.
-func (s Sig3Bundle) Export() (ret Sig3ExportJSON, err error) {
+func (s Sig3Bundle) Export() (ret ExportJSON, err error) {
 	enc := func(i interface{}) (string, error) {
 		b, err := msgpack.Encode(i)
 		if err != nil {
@@ -405,7 +448,42 @@ func (s Sig3Bundle) Export() (ret Sig3ExportJSON, err error) {
 		}
 	}
 	if s.Sig != nil {
-		ret.Sig = base64.StdEncoding.EncodeToString(s.Sig[:])
+		ret.Sig, err = enc(s.Sig[:])
+		if err != nil {
+			return ret, nil
+		}
 	}
 	return ret, nil
+}
+
+func IsStubbed(g Generic) bool {
+	return g.Inner() == nil
+}
+
+func Hash(g Generic) (LinkID, error) {
+	return g.Outer().Hash()
+}
+
+func CheckLinkSequence(v []Generic) error {
+	if len(v) == 0 {
+		return nil
+	}
+	prev := v[0]
+	for _, link := range v[1:] {
+		if prev.Seqno()+keybase1.Seqno(1) != link.Seqno() {
+			return newSequenceError("seqno mismatch at link %d", link.Seqno())
+		}
+		hsh, err := Hash(prev)
+		if err != nil {
+			return newSequenceError("bad prev hash computation at %d: %s", link.Seqno(), err.Error())
+		}
+		if link.Prev() == nil {
+			return newSequenceError("bad nil prev at %d", link.Seqno())
+		}
+		if !hsh.eq(*link.Prev()) {
+			return newSequenceError("prev hash mismatch at %d", link.Seqno())
+		}
+		prev = link
+	}
+	return nil
 }

--- a/go/sig3/sig3_test.go
+++ b/go/sig3/sig3_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"github.com/keybase/client/go/msgpack"
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-crypto/ed25519"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -37,9 +36,7 @@ func makeKID(key []byte, typ byte) KID {
 }
 
 func randomBytes(t *testing.T, i int) []byte {
-	ret := make([]byte, i, i)
-	n, err := rand.Reader.Read(ret[:])
-	require.Equal(t, n, i)
+	ret, err := genRandomBytes(i)
 	require.NoError(t, err)
 	return ret
 }
@@ -65,16 +62,17 @@ func randomLinkIDPointer(t *testing.T) *LinkID {
 	return &ret
 }
 
-func genTest(t *testing.T, n int) (bun *Sig3Bundle, ex Sig3ExportJSON, rk *RotateKey, outerKey KeyPair, innerKey []KeyPair) {
+func genTest(t *testing.T, n int) (bun *Sig3Bundle, ex ExportJSON, rk *RotateKey, outerKey KeyPair, innerKey []KeyPair) {
+	now := TimeSec(time.Now().Unix())
 	inner := InnerLink{
-		Ctime:   keybase1.ToTime(time.Now()),
+		Ctime:   now,
 		Entropy: randomBytes(t, 16),
 		ClientInfo: &ClientInfo{
 			Desc:    "foo",
 			Version: "1.0.0-1",
 		},
-		MerkleRoot: &MerkleRoot{
-			Ctime: keybase1.ToTime(time.Now()),
+		MerkleRoot: MerkleRoot{
+			Ctime: now,
 			Seqno: 100,
 			Hash:  randomBytes(t, 32),
 		},

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1739,7 +1739,7 @@ func TestForceRepollState(t *testing.T) {
 	found := false
 	w := 10 * time.Millisecond
 	for i := 0; i < 10; i++ {
-		found = tt.users[0].tc.G.GetTeamLoader().(*teams.TeamLoader).InForceRepollMode(context.TODO())
+		found = tt.users[0].tc.G.GetTeamLoader().(*teams.TeamLoader).InForceRepollMode(mctx)
 		if found {
 			break
 		}

--- a/go/teams/TODO.md
+++ b/go/teams/TODO.md
@@ -1,0 +1,13 @@
+- [ ] check seeds in FTL and slow load
+- [ ] back track hidden chain load to where it's first pinned
+- [x] test case that works for hidden rotation
+- [ ] test case where alice and bob rotate the team and they each take turns
+- [ ] precheck that a link will be accepted by the server (as does chain3)
+- [ ] feature-flag this for almost everything except for blessed prod teams (by team ID) (server + client)
+- [ ] alert in laoder2.go / addSecrets -- add back later
+- [ ] fix addSecrets to take a Teamer
+- [x] try to figure out refreshing and cache-bust store for chain17
+  - idea: merkle/path.json:
+    - you're allowed to know if there's something bigger than a given linkID, without explicitly checking membership:
+    - select 1 from sig3_team where (team_id,seqno)=(select team_id,seqno+1 from sig3_team where link_id='1YRrMgK+VkhvG/owg+iwYoGLmHGuBlQkObn9Yz0Xvlo');
+

--- a/go/teams/appkeys.go
+++ b/go/teams/appkeys.go
@@ -8,11 +8,11 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func AllApplicationKeys(mctx libkb.MetaContext, teamData *keybase1.TeamData,
+func AllApplicationKeys(mctx libkb.MetaContext, team Teamer,
 	application keybase1.TeamApplication, latestGen keybase1.PerTeamKeyGeneration) (res []keybase1.TeamApplicationKey, err error) {
 	defer mctx.TraceTimed("teams.AllApplicationKeys", func() error { return err })()
 	for gen := keybase1.PerTeamKeyGeneration(1); gen <= latestGen; gen++ {
-		appKey, err := ApplicationKeyAtGeneration(mctx, teamData, application, gen)
+		appKey, err := ApplicationKeyAtGeneration(mctx, team, application, gen)
 		if err != nil {
 			return res, err
 		}
@@ -22,13 +22,13 @@ func AllApplicationKeys(mctx libkb.MetaContext, teamData *keybase1.TeamData,
 
 }
 
-func AllApplicationKeysWithKBFS(mctx libkb.MetaContext, teamData *keybase1.TeamData,
+func AllApplicationKeysWithKBFS(mctx libkb.MetaContext, team Teamer,
 	application keybase1.TeamApplication, latestGen keybase1.PerTeamKeyGeneration) (res []keybase1.TeamApplicationKey, err error) {
-	teamKeys, err := AllApplicationKeys(mctx, teamData, application, latestGen)
+	teamKeys, err := AllApplicationKeys(mctx, team, application, latestGen)
 	if err != nil {
 		return res, err
 	}
-	kbfsKeys := teamData.TlfCryptKeys[application]
+	kbfsKeys := team.MainChain().TlfCryptKeys[application]
 	if len(kbfsKeys) > 0 {
 		latestKBFSGen := kbfsKeys[len(kbfsKeys)-1].Generation()
 		for _, k := range kbfsKeys {
@@ -51,17 +51,17 @@ func AllApplicationKeysWithKBFS(mctx libkb.MetaContext, teamData *keybase1.TeamD
 	return res, nil
 }
 
-func ApplicationKeyAtGeneration(mctx libkb.MetaContext, teamData *keybase1.TeamData,
+func ApplicationKeyAtGeneration(mctx libkb.MetaContext, team Teamer,
 	application keybase1.TeamApplication, generation keybase1.PerTeamKeyGeneration) (res keybase1.TeamApplicationKey, err error) {
 
-	item, err := GetAndVerifyPerTeamKey(mctx, teamData, generation)
+	item, err := GetAndVerifyPerTeamKey(mctx, team, generation)
 	if err != nil {
 		return res, err
 	}
 
 	var rkm *keybase1.ReaderKeyMask
 	if UseRKMForApp(application) {
-		rkmReal, err := readerKeyMask(teamData, application, generation)
+		rkmReal, err := readerKeyMask(team.MainChain(), application, generation)
 		if err != nil {
 			return res, err
 		}
@@ -79,10 +79,10 @@ func ApplicationKeyAtGeneration(mctx libkb.MetaContext, teamData *keybase1.TeamD
 	return applicationKeyForMask(*rkm, item.Seed)
 }
 
-func ApplicationKeyAtGenerationWithKBFS(mctx libkb.MetaContext, teamData *keybase1.TeamData,
+func ApplicationKeyAtGenerationWithKBFS(mctx libkb.MetaContext, team Teamer,
 	application keybase1.TeamApplication, generation keybase1.PerTeamKeyGeneration) (res keybase1.TeamApplicationKey, err error) {
 
-	kbfsKeys := teamData.TlfCryptKeys[application]
+	kbfsKeys := team.MainChain().TlfCryptKeys[application]
 	if len(kbfsKeys) > 0 {
 		latestKBFSGen := keybase1.PerTeamKeyGeneration(kbfsKeys[len(kbfsKeys)-1].Generation())
 		for _, k := range kbfsKeys {
@@ -94,13 +94,13 @@ func ApplicationKeyAtGenerationWithKBFS(mctx libkb.MetaContext, teamData *keybas
 				}, nil
 			}
 		}
-		if res, err = ApplicationKeyAtGeneration(mctx, teamData, application, generation-latestKBFSGen); err != nil {
+		if res, err = ApplicationKeyAtGeneration(mctx, team, application, generation-latestKBFSGen); err != nil {
 			return res, err
 		}
 		res.KeyGeneration += latestKBFSGen
 		return res, nil
 	}
-	return ApplicationKeyAtGeneration(mctx, teamData, application, generation)
+	return ApplicationKeyAtGeneration(mctx, team, application, generation)
 }
 
 func UseRKMForApp(application keybase1.TeamApplication) bool {

--- a/go/teams/box_audit.go
+++ b/go/teams/box_audit.go
@@ -11,6 +11,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/libkb"
+	storage "github.com/keybase/client/go/teams/storage"
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -1016,7 +1017,7 @@ func keySetToTeamIDs(dbKeySet libkb.DBKeySet) ([]keybase1.TeamID, error) {
 	seen := make(map[keybase1.TeamID]bool)
 	teamIDs := make([]keybase1.TeamID, 0, len(dbKeySet))
 	for dbKey := range dbKeySet {
-		teamID, err := ParseTeamIDDBKey(dbKey.Key)
+		teamID, err := storage.ParseTeamIDDBKey(dbKey.Key)
 		if err != nil {
 			return nil, err
 		}

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -89,6 +89,7 @@ type SCPerTeamKey struct {
 	EncKID     keybase1.KID                  `json:"encryption_kid"`
 	SigKID     keybase1.KID                  `json:"signing_kid"`
 	ReverseSig string                        `json:"reverse_sig"`
+	SeedCheck  string                        `json:"seed_check,omitempty"`
 }
 
 type SCTeamSettings struct {

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -161,7 +161,7 @@ func makeSigAndPostRootTeam(ctx context.Context, g *libkb.GlobalContext, me libk
 	}
 
 	// These boxes will get posted along with the sig below.
-	m, err := NewTeamKeyManager(mctx.G())
+	m, err := NewTeamKeyManager(mctx.G(), teamID)
 	if err != nil {
 		return err
 	}
@@ -537,7 +537,7 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 	}
 
 	// These boxes will get posted along with the sig below.
-	m, err := NewTeamKeyManager(g)
+	m, err := NewTeamKeyManager(g, subteamID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -532,3 +532,9 @@ func isStaleBoxError(err error) bool {
 	_, ok := err.(StaleBoxError)
 	return ok
 }
+
+type NeedHiddenChainRotationError struct{}
+
+func (e NeedHiddenChainRotationError) Error() string {
+	return "need hidden chain rotation"
+}

--- a/go/teams/hidden/hidden.go
+++ b/go/teams/hidden/hidden.go
@@ -1,0 +1,506 @@
+package hidden
+
+import (
+	"fmt"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/sig3"
+)
+
+func importChain(mctx libkb.MetaContext, raw []sig3.ExportJSON) (ret []sig3.Generic, err error) {
+	ret = make([]sig3.Generic, 0, len(raw))
+	for _, s := range raw {
+		g, err := s.Import()
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, g)
+	}
+	return ret, nil
+}
+
+func populateLink(mctx libkb.MetaContext, ret *keybase1.HiddenTeamChain, link sig3.Generic) (err error) {
+	hsh, err := sig3.Hash(link)
+	if err != nil {
+		return err
+	}
+	q := link.Seqno()
+	ret.Outer[q] = hsh.Export()
+	if q > ret.Last {
+		ret.Last = q
+	}
+	if sig3.IsStubbed(link) {
+		return nil
+	}
+	rotateKey, ok := link.(*sig3.RotateKey)
+	if !ok {
+		return nil
+	}
+	rkex, err := rotateKey.Export()
+	if err != nil {
+		return err
+	}
+	ret.Inner[q] = *rkex
+
+	// For each PTK (right now we really only expect one - the Reader PTK),
+	// update our maximum PTK generation
+	for _, ptk := range rotateKey.PTKs() {
+		max, ok := ret.LastPerTeamKeys[ptk.PTKType]
+		if !ok || max < q {
+			ret.LastPerTeamKeys[ptk.PTKType] = q
+		}
+		if ptk.PTKType == keybase1.PTKType_READER {
+			ret.ReaderPerTeamKeys[ptk.Generation] = q
+		}
+	}
+
+	return nil
+}
+
+type GenerateKeyRotationParams struct {
+	TeamID           keybase1.TeamID
+	IsPublic         bool
+	IsImplicit       bool
+	MerkleRoot       *libkb.MerkleRoot
+	Me               libkb.UserForSignatures
+	SigningKey       libkb.GenericKey
+	MainPrev         keybase1.LinkTriple
+	HiddenPrev       *keybase1.LinkTriple
+	Gen              keybase1.PerTeamKeyGeneration
+	NewSigningKey    libkb.NaclSigningKeyPair
+	NewEncryptionKey libkb.NaclDHKeyPair
+	Check            keybase1.PerTeamSeedCheck
+}
+
+func GenerateKeyRotation(mctx libkb.MetaContext, p GenerateKeyRotationParams) (ret *libkb.SigMultiItem, ratchet *keybase1.HiddenTeamChainRatchet, err error) {
+
+	s3, ratchet, err := generateKeyRotationSig3(mctx, p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sigMultiItem := &libkb.SigMultiItem{
+		SigningKID: p.SigningKey.GetKID(),
+		Type:       "team.rotate_key_hidden",
+		SeqType:    sig3.ChainTypeTeamPrivateHidden,
+		TeamID:     p.TeamID,
+		Sig3: &libkb.Sig3{
+			Inner: s3.Inner,
+			Outer: s3.Outer,
+			Sig:   s3.Sig,
+		},
+		PublicKeys: &libkb.SigMultiItemPublicKeys{
+			Encryption: p.NewEncryptionKey.GetKID(),
+			Signing:    p.NewSigningKey.GetKID(),
+		},
+		Version: 3,
+	}
+
+	return sigMultiItem, ratchet, nil
+}
+
+func generateKeyRotationSig3(mctx libkb.MetaContext, p GenerateKeyRotationParams) (ret *sig3.ExportJSON, ratchet *keybase1.HiddenTeamChainRatchet, err error) {
+
+	outer := sig3.OuterLink{}
+	if p.HiddenPrev != nil {
+		outer.Seqno = p.HiddenPrev.Seqno + 1
+		if !p.HiddenPrev.LinkID.IsNil() {
+			tmp, err := sig3.ImportLinkID(p.HiddenPrev.LinkID)
+			if err != nil {
+				return nil, nil, err
+			}
+			outer.Prev = tmp
+		}
+	} else {
+		outer.Seqno = keybase1.Seqno(1)
+	}
+	tmp, err := sig3.ImportTail(p.MainPrev)
+	if err != nil {
+		return nil, nil, err
+	}
+	rsq := p.MerkleRoot.Seqno()
+	if rsq == nil {
+		return nil, nil, fmt.Errorf("cannot work with a nil merkle root seqno")
+	}
+	teamIDimport, err := sig3.ImportTeamID(p.TeamID)
+	if err != nil {
+		return nil, nil, err
+	}
+	now := mctx.G().Clock().Now()
+	inner := sig3.InnerLink{
+		Ctime: sig3.TimeSec(now.Unix()),
+		ClientInfo: &sig3.ClientInfo{
+			Desc:    libkb.GoClientID,
+			Version: libkb.Version,
+		},
+		MerkleRoot: sig3.MerkleRoot{
+			Ctime: sig3.TimeSec(p.MerkleRoot.Ctime()),
+			Hash:  p.MerkleRoot.HashMeta(),
+			Seqno: *rsq,
+		},
+		ParentChain: *tmp,
+		Signer: sig3.Signer{
+			UID:         sig3.ImportUID(p.Me.GetUID()),
+			KID:         sig3.ImportKID(p.SigningKey.GetKID()),
+			EldestSeqno: p.Me.GetEldestSeqno(),
+		},
+		Team: &sig3.Team{
+			TeamID:     *teamIDimport,
+			IsPublic:   p.IsPublic,
+			IsImplicit: p.IsImplicit,
+		},
+	}
+	checkPostImage, err := p.Check.Hash()
+	if err != nil {
+		return nil, nil, err
+	}
+	rkb := sig3.RotateKeyBody{
+		PTKs: []sig3.PerTeamKey{
+			sig3.PerTeamKey{
+				AppkeyDerivationVersion: sig3.AppkeyDerivationXOR,
+				Generation:              p.Gen,
+				SeedCheck:               *checkPostImage,
+				EncryptionKID:           sig3.KID(p.NewEncryptionKey.GetBinaryKID()),
+				SigningKID:              sig3.KID(p.NewSigningKey.GetBinaryKID()),
+				PTKType:                 keybase1.PTKType_READER,
+			},
+		},
+	}
+
+	keyPair := func(g libkb.GenericKey) (*sig3.KeyPair, error) {
+		signing, ok := g.(libkb.NaclSigningKeyPair)
+		if !ok {
+			return nil, fmt.Errorf("bad key pair, wrong type: %T", g)
+		}
+		if signing.Private == nil {
+			return nil, fmt.Errorf("bad key pair, got null private key")
+		}
+		return sig3.NewKeyPair(*signing.Private, sig3.KID(g.GetBinaryKID())), nil
+	}
+
+	rk := sig3.NewRotateKey(outer, inner, rkb)
+	outerKeyPair, err := keyPair(p.SigningKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	innerKeyPair, err := keyPair(p.NewSigningKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sig, err := rk.Sign(*outerKeyPair, []sig3.KeyPair{*innerKeyPair})
+	if err != nil {
+		return nil, nil, err
+	}
+	bun, err := sig.Export()
+	if err != nil {
+		return nil, nil, err
+	}
+	outer = sig.Outer
+	outerHash, err := outer.Hash()
+	if err != nil {
+		return nil, nil, err
+	}
+	ratchet = &keybase1.HiddenTeamChainRatchet{
+		Self: &keybase1.LinkTripleAndTime{
+			Triple: keybase1.LinkTriple{
+				Seqno:   outer.Seqno,
+				SeqType: sig3.ChainTypeTeamPrivateHidden,
+				LinkID:  outerHash.Export(),
+			},
+			Time: keybase1.ToTime(now),
+		},
+	}
+	return &bun, ratchet, nil
+}
+
+// LoaderPackage contains a snapshot of the hidden team chain, used during the process of loading a team.
+// It additionally can have new chain links loaded from the server, since it might need to be queried
+// in the process of loading the team as if the new links were already commited to the data store.
+type LoaderPackage struct {
+	id               keybase1.TeamID
+	encKID           keybase1.KID
+	lastMainChainGen keybase1.PerTeamKeyGeneration
+	data             *keybase1.HiddenTeamChain
+	newData          *keybase1.HiddenTeamChain
+	links            []sig3.Generic
+	isFresh          bool
+}
+
+func NewLoaderPackage(id keybase1.TeamID, e keybase1.KID, g keybase1.PerTeamKeyGeneration) *LoaderPackage {
+	return &LoaderPackage{id: id, encKID: e, lastMainChainGen: g, isFresh: true}
+}
+
+func (l *LoaderPackage) Load(mctx libkb.MetaContext) (err error) {
+	l.data, err = mctx.G().GetHiddenTeamChainManager().Load(mctx, l.id)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (l *LoaderPackage) MerkleLoadArg(mctx libkb.MetaContext) (ret *libkb.LookupTeamHiddenArg, err error) {
+	if tail := l.LastReaderPerTeamKeyLinkID(); !tail.IsNil() {
+		return &libkb.LookupTeamHiddenArg{LastKnownHidden: tail}, nil
+	}
+	if !l.encKID.IsNil() && l.lastMainChainGen > keybase1.PerTeamKeyGeneration(0) {
+		return &libkb.LookupTeamHiddenArg{PTKEncryptionKID: l.encKID, PTKGeneration: l.lastMainChainGen}, nil
+	}
+	return nil, nil
+}
+
+func (l *LoaderPackage) LastReaderPerTeamKeyLinkID() (ret keybase1.LinkID) {
+	if l.data == nil {
+		return ret
+	}
+	return l.data.LastReaderPerTeamKeyLinkID()
+}
+
+func (l *LoaderPackage) SetIsFresh(b bool) {
+	l.isFresh = b
+}
+
+func (l *LoaderPackage) IsFresh() bool {
+	return l.isFresh
+}
+
+func (l *LoaderPackage) checkPrev(mctx libkb.MetaContext, first sig3.Generic) (err error) {
+	q := first.Seqno()
+	prev := first.Prev()
+	if q == keybase1.Seqno(1) && prev != nil {
+		return fmt.Errorf("bad link that had seqno=1 and non=nil prev")
+	}
+	if prev == nil {
+		return nil
+	}
+	if l.data == nil {
+		return fmt.Errorf("didn't get prior data and update was for a chain middle")
+	}
+	link, ok := l.data.Outer[q-1]
+	if !ok {
+		return fmt.Errorf("previous link wasn't found")
+	}
+	if !link.Eq(prev.Export()) {
+		return fmt.Errorf("prev mismatch at %d", q)
+	}
+	return nil
+}
+
+func (l *LoaderPackage) checkExpectedHighSeqno(mctx libkb.MetaContext, links []sig3.Generic) (err error) {
+	last := l.LastSeqno()
+	max := l.MaxRatchet()
+	if max <= last {
+		return nil
+	}
+	if len(links) > 0 && links[len(links)-1].Seqno() >= max {
+		return nil
+	}
+	return fmt.Errorf("Server promised a hidden chain up to %d, but never recevied; is it withholding?", max)
+}
+
+func (l *LoaderPackage) checkRatchet(mctx libkb.MetaContext, update *keybase1.HiddenTeamChain, ratchet keybase1.LinkTripleAndTime) (err error) {
+	q := ratchet.Triple.Seqno
+	link, ok := update.Outer[q]
+	if ok && !link.Eq(ratchet.Triple.LinkID) {
+		mctx.Debug("Dump %+v %+v", *l.data, *update)
+		return fmt.Errorf("update data failed to match ratchet %+v v %s", ratchet, link)
+	}
+	return nil
+}
+
+func (l *LoaderPackage) checkRatchets(mctx libkb.MetaContext, update *keybase1.HiddenTeamChain) (err error) {
+	if l.data == nil {
+		return nil
+	}
+	for _, r := range l.data.Ratchet.Flat() {
+		err = l.checkRatchet(mctx, update, r)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *LoaderPackage) Update(mctx libkb.MetaContext, update []sig3.ExportJSON) (err error) {
+	defer mctx.Trace(fmt.Sprintf("LoaderPackage#Update(%s)", l.id), func() error { return err })()
+
+	var data *keybase1.HiddenTeamChain
+	data, err = l.updatePrecheck(mctx, update)
+	if err != nil {
+		return err
+	}
+	err = l.storeData(mctx, data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (l *LoaderPackage) updatePrecheck(mctx libkb.MetaContext, update []sig3.ExportJSON) (ret *keybase1.HiddenTeamChain, err error) {
+	var links []sig3.Generic
+	links, err = importChain(mctx, update)
+	if err != nil {
+		return nil, err
+	}
+
+	err = sig3.CheckLinkSequence(links)
+	if err != nil {
+		return nil, err
+	}
+
+	err = l.checkExpectedHighSeqno(mctx, links)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(links) == 0 {
+		mctx.Debug("short-circuting since no update")
+		return nil, nil
+	}
+
+	err = l.checkPrev(mctx, links[0])
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := l.toHiddenTeamChain(mctx, links)
+	if err != nil {
+		return nil, err
+	}
+
+	err = l.checkRatchets(mctx, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (l *LoaderPackage) LastRotator(mctx libkb.MetaContext, typ keybase1.PTKType) *keybase1.Signer {
+	if l.data == nil {
+		return nil
+	}
+	last, ok := l.data.LastPerTeamKeys[typ]
+	if !ok {
+		return nil
+	}
+	inner, ok := l.data.Inner[last]
+	if !ok {
+		return nil
+	}
+	return &inner.Signer
+}
+
+func (l *LoaderPackage) LastReaderKeyRotator(mctx libkb.MetaContext) *keybase1.Signer {
+	return l.LastRotator(mctx, keybase1.PTKType_READER)
+}
+
+func (l *LoaderPackage) storeData(mctx libkb.MetaContext, newData *keybase1.HiddenTeamChain) (err error) {
+	l.newData = newData
+	if l.data == nil {
+		l.data = newData
+		return nil
+	}
+	tmp := l.data.DeepCopy()
+	if newData != nil {
+		_, err = tmp.Merge(*newData)
+		if err != nil {
+			return err
+		}
+	}
+	l.data = &tmp
+	return nil
+}
+
+func (l *LoaderPackage) toHiddenTeamChain(mctx libkb.MetaContext, links []sig3.Generic) (ret *keybase1.HiddenTeamChain, err error) {
+	ret = keybase1.NewHiddenTeamChain(l.id)
+	ret.Public = l.id.IsPublic()
+	for _, link := range links {
+		err = populateLink(mctx, ret, link)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+func checkUpdateAgainstSeed(mctx libkb.MetaContext, seeds map[keybase1.PerTeamKeyGeneration]keybase1.PerTeamKeySeedItem, update keybase1.HiddenTeamChainLink) (err error) {
+	readerKey, ok := update.Ptk[keybase1.PTKType_READER]
+	if !ok {
+		// No reader key found in link, so no need to check it.
+		return nil
+	}
+	gen := readerKey.Ptk.Gen
+	seed, ok := seeds[gen]
+	if !ok {
+		return fmt.Errorf("seed at generation %d wasn't found", gen)
+	}
+	if seed.Check == nil {
+		return fmt.Errorf("seed check at generation %d was nil", gen)
+	}
+	hash, err := seed.Check.Hash()
+	if err != nil {
+		return err
+	}
+	if readerKey.Check.Version != keybase1.PerTeamSeedCheckVersion_V1 {
+		return fmt.Errorf("can only handle seed check version 1; got %s", readerKey.Check.Version)
+	}
+	if !hash.Eq(readerKey.Check) {
+		return fmt.Errorf("wrong seed check at generation %d", gen)
+	}
+	return nil
+}
+
+func (l *LoaderPackage) CheckUpdatesAgainstSeeds(mctx libkb.MetaContext, seeds map[keybase1.PerTeamKeyGeneration]keybase1.PerTeamKeySeedItem) (err error) {
+	if l.newData == nil {
+		return nil
+	}
+	for _, update := range l.newData.Inner {
+		err = checkUpdateAgainstSeed(mctx, seeds, update)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *LoaderPackage) LastSeqno() keybase1.Seqno {
+	if l.data == nil {
+		return keybase1.Seqno(0)
+	}
+	return l.data.Last
+}
+
+func (l *LoaderPackage) MaxRatchet() keybase1.Seqno {
+	if l.data == nil {
+		return keybase1.Seqno(0)
+	}
+	return l.data.Ratchet.Max()
+}
+
+func (l *LoaderPackage) HasReaderPerTeamKeyAtGeneration(gen keybase1.PerTeamKeyGeneration) bool {
+	if l.data == nil {
+		return false
+	}
+	_, ok := l.data.ReaderPerTeamKeys[gen]
+	return ok
+}
+
+func (l *LoaderPackage) Commit(mctx libkb.MetaContext) error {
+	if l.newData == nil {
+		return nil
+	}
+	err := mctx.G().GetHiddenTeamChainManager().Advance(mctx, *l.newData)
+	return err
+}
+
+func (l *LoaderPackage) ChainData() *keybase1.HiddenTeamChain {
+	return l.data
+}
+
+func (l *LoaderPackage) MaxReaderPerTeamKeyGeneration() keybase1.PerTeamKeyGeneration {
+	if l.data == nil {
+		return keybase1.PerTeamKeyGeneration(0)
+	}
+	return l.data.MaxReaderPerTeamKeyGeneration()
+}

--- a/go/teams/hidden/manager.go
+++ b/go/teams/hidden/manager.go
@@ -1,0 +1,264 @@
+package hidden
+
+import (
+	"fmt"
+	libkb "github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	sig3 "github.com/keybase/client/go/sig3"
+	storage "github.com/keybase/client/go/teams/storage"
+)
+
+type ChainManager struct {
+	// single-flight lock on TeamID
+	locktab libkb.LockTable
+
+	// Hold onto FastTeamLoad by-products as long as we have room, and store
+	// them persistently to disk.
+	storage *storage.HiddenStorage
+}
+
+var _ libkb.HiddenTeamChainManager = (*ChainManager)(nil)
+
+type loadArg struct {
+	id     keybase1.TeamID
+	mutate func(libkb.MetaContext, *keybase1.HiddenTeamChain) (bool, error)
+}
+
+func (m *ChainManager) Tail(mctx libkb.MetaContext, id keybase1.TeamID) (*keybase1.LinkTriple, error) {
+	mctx = withLogTag(mctx)
+	state, err := m.loadAndMutate(mctx, loadArg{id: id})
+	if err != nil {
+		return nil, err
+	}
+	if state == nil {
+		return nil, nil
+	}
+	return state.Ratchet.MaxTriple(), nil
+}
+
+func (m *ChainManager) loadLocked(mctx libkb.MetaContext, arg loadArg) (ret *keybase1.HiddenTeamChain, err error) {
+	state, frozen, tombstoned := m.storage.Get(mctx, arg.id, arg.id.IsPublic())
+	if frozen {
+		return nil, fmt.Errorf("cannot load hidden chain for frozen team")
+	}
+	if tombstoned {
+		return nil, fmt.Errorf("cannot load hidden chain for tombstoned team")
+	}
+	return state, nil
+}
+
+func withLogTag(mctx libkb.MetaContext) libkb.MetaContext {
+	return mctx.WithLogTag("HTCM")
+}
+
+func (m *ChainManager) Load(mctx libkb.MetaContext, id keybase1.TeamID) (ret *keybase1.HiddenTeamChain, err error) {
+	mctx = withLogTag(mctx)
+	ret, err = m.loadAndMutate(mctx, loadArg{id: id})
+	return ret, err
+}
+
+func (m *ChainManager) loadAndMutate(mctx libkb.MetaContext, arg loadArg) (state *keybase1.HiddenTeamChain, err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("ChainManager#load(%+v)", arg), func() error { return err })()
+	lock := m.locktab.AcquireOnName(mctx.Ctx(), mctx.G(), arg.id.String())
+	defer lock.Release(mctx.Ctx())
+
+	state, err = m.loadLocked(mctx, arg)
+	if err != nil {
+		return nil, err
+	}
+
+	if arg.mutate != nil {
+		var changed bool
+		if state == nil {
+			state = keybase1.NewHiddenTeamChain(arg.id)
+		}
+		changed, err = arg.mutate(mctx, state)
+		if err != nil {
+			return nil, err
+		}
+		if changed {
+			state.CachedAt = keybase1.ToTime(mctx.G().Clock().Now())
+			m.storage.Put(mctx, state)
+		}
+	}
+
+	return state, nil
+}
+
+func (m *ChainManager) checkRatchet(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain, ratchet keybase1.LinkTripleAndTime) (changed bool, err error) {
+	if ratchet.Triple.SeqType != sig3.ChainTypeTeamPrivateHidden {
+		return false, fmt.Errorf("bad chain type: %s", ratchet.Triple.SeqType)
+	}
+
+	// The new ratchet can't clash the existing accepted ratchets
+	for _, accepted := range state.Ratchet.Flat() {
+		if accepted.Clashes(ratchet) {
+			return false, fmt.Errorf("bad ratchet, clashes existing pin: %+v != %v", accepted, accepted)
+		}
+	}
+
+	q := ratchet.Triple.Seqno
+	link, ok := state.Outer[q]
+
+	// If either the ratchet didn't match a known link, or equals what's already there, great.
+	if !ok || link.Eq(ratchet.Triple.LinkID) {
+		return false, nil
+	}
+
+	// If the ratchet clashes with links we have already accepted, something is really wrong, and we
+	// have to bail out. Likely this team is totally hosed.
+	if ratchet.Triple.Seqno <= state.Ratchet.Max() {
+		return false, fmt.Errorf("Ratchet failed to match a currently accepted chainlink: %+v", ratchet)
+	}
+
+	// We can recover in a case in which we held provisional links that came after the last known Ratchet.
+	// We just have to remove those links though and then start again.
+	for i := state.Last; i >= ratchet.Triple.Seqno; i-- {
+		mctx.Warning("Removing link at %d, since it is in front of a ratchet that it clashes with (%+v)", ratchet)
+		state.RemoveLink(i)
+	}
+
+	return true, nil
+}
+
+func (m *ChainManager) checkRatchets(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain, ratchet keybase1.HiddenTeamChainRatchet) (changed bool, err error) {
+	for _, r := range ratchet.Flat() {
+		tmp, err := m.checkRatchet(mctx, state, r)
+		if err != nil {
+			return false, err
+		}
+		if tmp {
+			changed = true
+		}
+	}
+	return changed, nil
+}
+
+func (m *ChainManager) ratchet(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain, ratchet keybase1.HiddenTeamChainRatchet) (ret bool, err error) {
+	var provisionalLinksDeleted bool
+	provisionalLinksDeleted, err = m.checkRatchets(mctx, state, ratchet)
+	if err != nil {
+		return false, err
+	}
+	updated := state.Ratchet.Merge(ratchet)
+	return (updated || provisionalLinksDeleted), nil
+}
+
+func (m *ChainManager) Ratchet(mctx libkb.MetaContext, id keybase1.TeamID, ratchet keybase1.HiddenTeamChainRatchet) (err error) {
+	mctx = withLogTag(mctx)
+	defer mctx.Trace(fmt.Sprintf("hidden.ChainManager#Ratchet(%s, %+v)", id, ratchet), func() error { return err })()
+	arg := loadArg{
+		id: id,
+		mutate: func(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain) (bool, error) {
+			return m.ratchet(mctx, state, ratchet)
+		},
+	}
+	_, err = m.loadAndMutate(mctx, arg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ChainManager) advance(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain, newData keybase1.HiddenTeamChain) (update bool, err error) {
+	err = m.checkRatchetsOnAdvance(mctx, state.Ratchet, newData)
+	if err != nil {
+		return false, err
+	}
+	update, err = state.Merge(newData)
+	if err != nil {
+		return false, err
+	}
+	return update, nil
+}
+
+func (m *ChainManager) checkRatchetOnAdvance(mctx libkb.MetaContext, r keybase1.LinkTripleAndTime, newData keybase1.HiddenTeamChain) (err error) {
+	q := r.Triple.Seqno
+	link, ok := newData.Outer[q]
+	if ok && !link.Eq(r.Triple.LinkID) {
+		return fmt.Errorf("update data failed to match ratchet %+v", r)
+	}
+	return nil
+}
+
+func (m *ChainManager) checkRatchetsOnAdvance(mctx libkb.MetaContext, ratchet keybase1.HiddenTeamChainRatchet, newData keybase1.HiddenTeamChain) (err error) {
+	for _, r := range ratchet.Flat() {
+		err = m.checkRatchetOnAdvance(mctx, r, newData)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *ChainManager) Advance(mctx libkb.MetaContext, dat keybase1.HiddenTeamChain) (err error) {
+	mctx = withLogTag(mctx)
+	defer mctx.Trace(fmt.Sprintf("hidden.ChainManager#Advance(%s)", dat.ID()), func() error { return err })()
+	arg := loadArg{
+		id: dat.ID(),
+		mutate: func(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain) (bool, error) {
+			return m.advance(mctx, state, dat)
+		},
+	}
+	_, err = m.loadAndMutate(mctx, arg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ChainManager) PerTeamKeyAtGeneration(mctx libkb.MetaContext, id keybase1.TeamID, ptkg keybase1.PerTeamKeyGeneration) (ret *keybase1.PerTeamKey, err error) {
+	mctx = withLogTag(mctx)
+	defer mctx.Trace(fmt.Sprintf("hidden.ChainManager#PerTeamKeyGeneration(%s)", id), func() error { return err })()
+	arg := loadArg{id: id}
+	state, err := m.loadAndMutate(mctx, arg)
+	if err != nil {
+		return nil, err
+	}
+	if state == nil {
+		mctx.Debug("no state found for team")
+		return nil, nil
+	}
+	q, ok := state.ReaderPerTeamKeys[ptkg]
+	if !ok {
+		mctx.Debug("no link found for generation")
+		return nil, nil
+	}
+	i, ok := state.Inner[q]
+	if !ok {
+		mctx.Debug("no inner link for for seqno %d", q)
+		return nil, nil
+	}
+	ptk, ok := i.Ptk[keybase1.PTKType_READER]
+	if !ok {
+		mctx.Debug("no reader key found at seqno %d", q)
+		return nil, nil
+	}
+	return &ptk.Ptk, nil
+}
+
+func NewChainMananger(g *libkb.GlobalContext) *ChainManager {
+	return &ChainManager{
+		storage: storage.NewHiddenStorage(g),
+	}
+}
+
+func NewChainManagerAndInstall(g *libkb.GlobalContext) *ChainManager {
+	ret := NewChainMananger(g)
+	g.SetHiddenTeamChainManager(ret)
+	g.AddLogoutHook(ret, "HiddenTeamChainManager")
+	g.AddDbNukeHook(ret, "HiddenTeamChainManager")
+	return ret
+}
+
+// OnLogout is called when the user logs out, which purges the LRU.
+func (m *ChainManager) OnLogout(mctx libkb.MetaContext) error {
+	m.storage.ClearMem()
+	return nil
+}
+
+// OnDbNuke is called when the disk cache is cleared, which purges the LRU.
+func (m *ChainManager) OnDbNuke(mctx libkb.MetaContext) error {
+	m.storage.ClearMem()
+	return nil
+}

--- a/go/teams/init.go
+++ b/go/teams/init.go
@@ -2,6 +2,7 @@ package teams
 
 import (
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/teams/hidden"
 )
 
 func ServiceInit(g *libkb.GlobalContext) {
@@ -11,4 +12,5 @@ func ServiceInit(g *libkb.GlobalContext) {
 	NewBoxAuditorAndInstall(g)
 	NewImplicitTeamConflictInfoCacheAndInstall(g)
 	NewImplicitTeamCacheAndInstall(g)
+	hidden.NewChainManagerAndInstall(g)
 }

--- a/go/teams/keys.go
+++ b/go/teams/keys.go
@@ -17,21 +17,19 @@ import (
 )
 
 // Get a PTK seed and verify against the sigchain that is the correct key.
-func GetAndVerifyPerTeamKey(mctx libkb.MetaContext, teamData *keybase1.TeamData,
-	gen keybase1.PerTeamKeyGeneration) (ret keybase1.PerTeamKeySeedItem, err error) {
+func GetAndVerifyPerTeamKey(mctx libkb.MetaContext, team Teamer, gen keybase1.PerTeamKeyGeneration) (ret keybase1.PerTeamKeySeedItem, err error) {
 
-	ret, ok := teamData.PerTeamKeySeedsUnverified[gen]
+	ret, ok := team.MainChain().PerTeamKeySeedsUnverified[gen]
 	if !ok {
 		return ret, libkb.NotFoundError{
 			Msg: fmt.Sprintf("no team secret found at generation %v", gen)}
 	}
-
-	km, err := NewTeamKeyManagerWithSecret(ret.Seed, gen)
+	km, err := NewTeamKeyManagerWithSeedItem(team.MainChain().ID(), ret)
 	if err != nil {
 		return ret, err
 	}
 
-	chainKey, err := TeamSigChainState{inner: teamData.Chain}.GetPerTeamKeyAtGeneration(gen)
+	chainKey, err := newTeamSigChainState(team).GetPerTeamKeyAtGeneration(gen)
 	if err != nil {
 		return ret, err
 	}
@@ -82,23 +80,38 @@ type PerTeamSharedSecretBox struct {
 type TeamKeyManager struct {
 	sharedSecret keybase1.PerTeamKeySeed
 	generation   keybase1.PerTeamKeyGeneration
+	check        keybase1.PerTeamSeedCheck
+	id           keybase1.TeamID
 
 	encryptionKey *libkb.NaclDHKeyPair
 	signingKey    *libkb.NaclSigningKeyPair
 }
 
-func NewTeamKeyManager(g *libkb.GlobalContext) (*TeamKeyManager, error) {
+func NewTeamKeyManager(g *libkb.GlobalContext, id keybase1.TeamID) (*TeamKeyManager, error) {
 	sharedSecret, err := newSharedSecret()
 	if err != nil {
 		return nil, err
 	}
-	return NewTeamKeyManagerWithSecret(sharedSecret, 1)
+	check, err := computeSeedCheck(id, sharedSecret, nil)
+	if err != nil {
+		return nil, err
+	}
+	return NewTeamKeyManagerWithSecret(id, sharedSecret, 1, check)
 }
 
-func NewTeamKeyManagerWithSecret(secret keybase1.PerTeamKeySeed, generation keybase1.PerTeamKeyGeneration) (*TeamKeyManager, error) {
+func NewTeamKeyManagerWithSeedItem(id keybase1.TeamID, si keybase1.PerTeamKeySeedItem) (*TeamKeyManager, error) {
+	return NewTeamKeyManagerWithSecret(id, si.Seed, si.Generation, si.Check)
+}
+
+func NewTeamKeyManagerWithSecret(id keybase1.TeamID, secret keybase1.PerTeamKeySeed, generation keybase1.PerTeamKeyGeneration, check *keybase1.PerTeamSeedCheck) (*TeamKeyManager, error) {
+	if check == nil {
+		return nil, fmt.Errorf("unexpected nil check item")
+	}
 	return &TeamKeyManager{
 		sharedSecret: secret,
 		generation:   generation,
+		check:        *check,
+		id:           id,
 	}, nil
 }
 
@@ -117,6 +130,14 @@ func (t *TeamKeyManager) SigningKey() (libkb.NaclSigningKeyPair, error) {
 		t.signingKey = &key
 	}
 	return *t.signingKey, nil
+}
+
+func (t *TeamKeyManager) Check() keybase1.PerTeamSeedCheck {
+	return t.check
+}
+
+func (t *TeamKeyManager) Generation() keybase1.PerTeamKeyGeneration {
+	return t.generation
 }
 
 // EncryptionKey returns the derived NaclDHKeyPair from the team's shared secret.
@@ -182,7 +203,10 @@ func (t *TeamKeyManager) RotateSharedSecretBoxes(mctx libkb.MetaContext, senderK
 	}
 
 	// make the recipient boxes with the new secret and the incrementing nonce24
-	t.setNextSharedSecret(mctx, nextSecret)
+	err = t.setNextSharedSecret(mctx, nextSecret)
+	if err != nil {
+		return nil, nil, err
+	}
 	boxes, err = t.sharedBoxes(t.sharedSecret, t.generation, nonce, senderKey, recipients)
 	if err != nil {
 		return nil, nil, err
@@ -283,8 +307,15 @@ func (t *TeamKeyManager) perTeamKeySection() (*SCPerTeamKey, error) {
 	}, nil
 }
 
-func (t *TeamKeyManager) setNextSharedSecret(mctx libkb.MetaContext, secret keybase1.PerTeamKeySeed) {
+func (t *TeamKeyManager) setNextSharedSecret(mctx libkb.MetaContext, secret keybase1.PerTeamKeySeed) (err error) {
+
+	check, err := computeSeedCheck(t.id, secret, &t.check)
+	if err != nil {
+		return err
+	}
+
 	t.sharedSecret = secret
+	t.check = *check
 
 	// bump generation number
 	t.generation = t.generation + 1
@@ -294,6 +325,8 @@ func (t *TeamKeyManager) setNextSharedSecret(mctx libkb.MetaContext, secret keyb
 	t.encryptionKey = nil
 
 	mctx.Debug("TeamKeyManager: set next shared secret, generation %d", t.generation)
+
+	return nil
 }
 
 type prevKeySealedDecoded struct {
@@ -380,4 +413,89 @@ func decryptPrevSingle(ctx context.Context,
 	}
 	ret, err := keybase1.PerTeamKeySeedFromBytes(opened)
 	return &ret, err
+}
+
+func computeSeedCheck(id keybase1.TeamID, seed keybase1.PerTeamKeySeed, prev *keybase1.PerTeamSeedCheck) (*keybase1.PerTeamSeedCheck, error) {
+
+	var prevValue keybase1.PerTeamSeedCheckValue
+	switch {
+	case prev == nil:
+		tmp := []byte(libkb.TeamKeySeedCheckDerivationString)
+		tmp = append(tmp, byte(0))
+		tmp = append(tmp, id.ToBytes()...)
+		prevValue = keybase1.PerTeamSeedCheckValue(tmp)
+	case prev != nil && prev.Version != keybase1.PerTeamSeedCheckVersion_V1:
+		return nil, fmt.Errorf("cannot handle PerTeamSeedCheck version > 1")
+	case prev != nil && prev.Version == keybase1.PerTeamSeedCheckVersion_V1:
+		prevValue = prev.Value
+	}
+
+	g := func(seed keybase1.PerTeamKeySeed, prev keybase1.PerTeamSeedCheckValue) keybase1.PerTeamSeedCheckValue {
+		digest := hmac.New(sha512.New, seed[:])
+		digest.Write([]byte(prev))
+		return keybase1.PerTeamSeedCheckValue(digest.Sum(nil)[:32])
+	}
+
+	return &keybase1.PerTeamSeedCheck{
+		Version: keybase1.PerTeamSeedCheckVersion_V1,
+		Value:   g(seed, prevValue),
+	}, nil
+}
+
+// computeSeedChecks looks at a sequence of checks, newest to oldest, trying to find the first nil. Once it finds
+// such a nil, it goes forward and fills in the checks, based on the current seeds. There's an unfortunately level
+// of indirection since we need the same code to work over slow and fast team loading; thus we have setters and getters
+// as functions. But the idea is the same in both cases. Not that we're assuming there aren't "holes". That the nils
+// are at the back of the sequence and not interspersed throughout. This is valid so long as we always compute
+// these checks on load of new links.
+func computeSeedChecks(ctx context.Context, teamID keybase1.TeamID, latestChainGen keybase1.PerTeamKeyGeneration, getter func(g keybase1.PerTeamKeyGeneration) (*keybase1.PerTeamSeedCheck, keybase1.PerTeamKeySeed, error), setter func(g keybase1.PerTeamKeyGeneration, c keybase1.PerTeamSeedCheck)) error {
+
+	var firstNonNilCheck keybase1.PerTeamKeyGeneration
+	var foundLinkToUpdate bool
+
+	for i := latestChainGen; i >= 1; i-- {
+		check, _, err := getter(i)
+		if err != nil {
+			return err
+		}
+		if check != nil {
+			firstNonNilCheck = i
+			break
+		}
+		foundLinkToUpdate = true
+	}
+
+	if !foundLinkToUpdate {
+		// NoOp, we're all up-to-date
+		return nil
+	}
+
+	var prev *keybase1.PerTeamSeedCheck
+
+	if firstNonNilCheck > keybase1.PerTeamKeyGeneration(0) {
+		var err error
+		prev, _, err = getter(firstNonNilCheck)
+		if err != nil {
+			return err
+		}
+		if prev == nil {
+			return fmt.Errorf("unexpected nil PerTeamKeySeedsUnverified.Check at %d", firstNonNilCheck)
+		}
+	}
+
+	start := firstNonNilCheck + keybase1.PerTeamKeyGeneration(1)
+
+	for i := start; i <= latestChainGen; i++ {
+		_, seed, err := getter(i)
+		if err != nil {
+			return err
+		}
+		check, err := computeSeedCheck(teamID, seed, prev)
+		if err != nil {
+			return err
+		}
+		setter(i, *check)
+		prev = check
+	}
+	return nil
 }

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -13,6 +13,8 @@ import (
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	hidden "github.com/keybase/client/go/teams/hidden"
+	storage "github.com/keybase/client/go/teams/storage"
 )
 
 // Show detailed team profiling
@@ -38,11 +40,11 @@ const freshnessLimit = time.Duration(1) * time.Hour
 // Load a Team from the TeamLoader.
 // Can be called from inside the teams package.
 func Load(ctx context.Context, g *libkb.GlobalContext, lArg keybase1.LoadTeamArg) (*Team, error) {
-	teamData, err := g.GetTeamLoader().Load(ctx, lArg)
+	teamData, hidden, err := g.GetTeamLoader().Load(ctx, lArg)
 	if err != nil {
 		return nil, err
 	}
-	ret := NewTeam(ctx, g, teamData)
+	ret := NewTeam(ctx, g, teamData, hidden)
 
 	if lArg.RefreshUIDMapper {
 		// If we just loaded the group, then inform the UIDMapper of any UID->EldestSeqno
@@ -61,7 +63,7 @@ func Load(ctx context.Context, g *libkb.GlobalContext, lArg keybase1.LoadTeamArg
 type TeamLoader struct {
 	libkb.Contextified
 	world   LoaderContext
-	storage *Storage
+	storage *storage.Storage
 	// Single-flight locks per team ID.
 	// (Private and public loads of the same ID will block each other, should be fine)
 	locktab libkb.LockTable
@@ -80,7 +82,7 @@ type TeamLoader struct {
 
 var _ libkb.TeamLoader = (*TeamLoader)(nil)
 
-func NewTeamLoader(g *libkb.GlobalContext, world LoaderContext, storage *Storage) *TeamLoader {
+func NewTeamLoader(g *libkb.GlobalContext, world LoaderContext, storage *storage.Storage) *TeamLoader {
 	return &TeamLoader{
 		Contextified:         libkb.NewContextified(g),
 		world:                world,
@@ -92,7 +94,7 @@ func NewTeamLoader(g *libkb.GlobalContext, world LoaderContext, storage *Storage
 // NewTeamLoaderAndInstall creates a new loader and installs it into G.
 func NewTeamLoaderAndInstall(g *libkb.GlobalContext) *TeamLoader {
 	world := NewLoaderContextFromG(g)
-	st := NewStorage(g)
+	st := storage.NewStorage(g)
 	l := NewTeamLoader(g, world, st)
 	g.SetTeamLoader(l)
 	g.AddLogoutHook(l, "teamLoader")
@@ -100,13 +102,13 @@ func NewTeamLoaderAndInstall(g *libkb.GlobalContext) *TeamLoader {
 	return l
 }
 
-func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *keybase1.TeamData, err error) {
+func (l *TeamLoader) Load(ctx context.Context, lArg keybase1.LoadTeamArg) (res *keybase1.TeamData, hidden *keybase1.HiddenTeamChain, err error) {
 	me, err := l.world.getMe(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if me.IsNil() && !lArg.Public {
-		return nil, libkb.NewLoginRequiredError("login required to load a private team")
+		return nil, nil, libkb.NewLoginRequiredError("login required to load a private team")
 	}
 	return l.load1(ctx, me, lArg)
 }
@@ -250,17 +252,18 @@ func (l *TeamLoader) makeNameLookupBurstCacheLoader(ctx context.Context, g *libk
 
 // Load1 unpacks the loadArg, calls load2, and does some final checks.
 // The key difference between load1 and load2 is that load2 is recursive (for subteams).
-func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg keybase1.LoadTeamArg) (*keybase1.TeamData, error) {
+func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg keybase1.LoadTeamArg) (*keybase1.TeamData, *keybase1.HiddenTeamChain, error) {
+	mctx := libkb.NewMetaContext(ctx, l.G())
 	err := l.checkArg(ctx, lArg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var teamName *keybase1.TeamName
 	if len(lArg.Name) > 0 {
 		teamNameParsed, err := keybase1.TeamNameFromString(lArg.Name)
 		if err != nil {
-			return nil, fmt.Errorf("invalid team name: %v", err)
+			return nil, nil, fmt.Errorf("invalid team name: %v", err)
 		}
 		teamName = &teamNameParsed
 	}
@@ -272,19 +275,19 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 	if !teamID.Exists() {
 		teamID, err = l.ResolveNameToIDUntrusted(ctx, *teamName, lArg.Public, lArg.AllowNameLookupBurstCache)
 		if err != nil {
-			l.G().Log.CDebugf(ctx, "TeamLoader looking up team by name failed: %v -> %v", *teamName, err)
+			mctx.Debug("TeamLoader looking up team by name failed: %v -> %v", *teamName, err)
 			if code, ok := libkb.GetAppStatusCode(err); ok && code == keybase1.StatusCode_SCTeamNotFound {
-				l.G().Log.CDebugf(ctx, "replacing error: %v", err)
-				return nil, NewTeamDoesNotExistError(lArg.Public, teamName.String())
+				mctx.Debug("replacing error: %v", err)
+				return nil, nil, NewTeamDoesNotExistError(lArg.Public, teamName.String())
 			}
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	mungedForceRepoll := lArg.ForceRepoll
 	mungedWantMembers, err := l.mungeWantMembers(ctx, lArg.Refreshers.WantMembers)
 	if err != nil {
-		l.G().Log.CDebugf(ctx, "TeamLoader munge failed: %v", err)
+		mctx.Debug("TeamLoader munge failed: %v", err)
 		// drop the error and just force a repoll.
 		mungedForceRepoll = true
 		mungedWantMembers = nil
@@ -313,27 +316,27 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 	switch err := err.(type) {
 	case TeamDoesNotExistError:
 		if teamName == nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// Replace the not found error so that it has a name instead of team ID.
 		// If subteams are involved the name might not correspond to the ID
 		// but it's better to have this understandable error message that's accurate
 		// most of the time than one with an ID that's always accurate.
-		l.G().Log.CDebugf(ctx, "replacing error: %v", err)
-		return nil, NewTeamDoesNotExistError(lArg.Public, teamName.String())
+		mctx.Debug("replacing error: %v", err)
+		return nil, nil, NewTeamDoesNotExistError(lArg.Public, teamName.String())
 	case nil:
 	default:
-		return nil, err
+		return nil, nil, err
 	}
 	if ret == nil {
-		return nil, fmt.Errorf("team loader fault: got nil from load2")
+		return nil, nil, fmt.Errorf("team loader fault: got nil from load2")
 	}
 
 	// Only public teams are allowed to be behind on secrets.
 	// This is allowed because you can load a public team you're not in.
-	if !l.hasSyncedSecrets(&ret.team) && !ret.team.Chain.Public {
+	if !l.hasSyncedSecrets(mctx, ret.teamShim()) && !ret.team.Chain.Public {
 		// this should not happen
-		return nil, fmt.Errorf("missing secrets for team")
+		return nil, nil, fmt.Errorf("missing secrets for team")
 	}
 
 	// Check team name on the way out
@@ -342,21 +345,20 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 	if teamName != nil {
 		// (TODO: this won't work for renamed level 3 teams or above. There's work on this in miles/teamloader-names)
 		if !teamName.Eq(ret.team.Name) {
-			return nil, fmt.Errorf("team name mismatch: %v != %v", ret.team.Name, teamName.String())
+			return nil, nil, fmt.Errorf("team name mismatch: %v != %v", ret.team.Name, teamName.String())
 		}
 	}
 
-	mctx := libkb.NewMetaContext(ctx, l.G())
 	if ShouldRunBoxAudit(mctx) {
 		newMctx, shouldReload := VerifyBoxAudit(mctx, teamID)
 		if shouldReload {
 			return l.load1(newMctx.Ctx(), me, lArg)
 		}
 	} else {
-		l.G().Log.CDebugf(ctx, "Box auditor feature flagged off; not checking jail during team load...")
+		mctx.Debug("Box auditor feature flagged off; not checking jail during team load...")
 	}
 
-	return &ret.team, nil
+	return &ret.team, &ret.hidden, nil
 }
 
 func (l *TeamLoader) checkArg(ctx context.Context, lArg keybase1.LoadTeamArg) error {
@@ -391,12 +393,13 @@ type load2ArgT struct {
 	needKBFSKeyGeneration                 keybase1.TeamKBFSKeyRefresher
 	// wantMembers here is different from wantMembers on LoadTeamArg:
 	// The EldestSeqno's should not be 0.
-	wantMembers     []keybase1.UserVersion
-	wantMembersRole keybase1.TeamRole
-	forceFullReload bool
-	forceRepoll     bool
-	staleOK         bool
-	public          bool
+	wantMembers         []keybase1.UserVersion
+	wantMembersRole     keybase1.TeamRole
+	forceFullReload     bool
+	forceRepoll         bool
+	staleOK             bool
+	public              bool
+	rotatingHiddenChain bool
 
 	needSeqnos []keybase1.Seqno
 	// Non-nil if we are loading an ancestor for the greater purpose of
@@ -413,7 +416,12 @@ type load2ArgT struct {
 
 type load2ResT struct {
 	team      keybase1.TeamData
+	hidden    keybase1.HiddenTeamChain
 	didRepoll bool
+}
+
+func (l load2ResT) teamShim() *TeamShim {
+	return &TeamShim{Data: &l.team, Hidden: &l.hidden}
 }
 
 // Load2 does the rest of the work loading a team.
@@ -481,6 +489,7 @@ func (l *TeamLoader) load2InnerLocked(ctx context.Context, arg load2ArgT) (res *
 
 func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (*load2ResT, error) {
 	ctx, tbs := l.G().CTimeBuckets(ctx)
+	mctx := libkb.NewMetaContext(ctx, l.G())
 	tracer := l.G().CTimeTracer(ctx, "TeamLoader.load2ILR", teamEnv.Profile)
 	defer tracer.Finish()
 
@@ -492,7 +501,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 
 	// Fetch from cache
 	tracer.Stage("cache load")
-	tailCheckRet, frozen, tombstoned := l.storage.Get(libkb.NewMetaContext(ctx, l.G()), arg.teamID, arg.public)
+	tailCheckRet, frozen, tombstoned := l.storage.Get(mctx, arg.teamID, arg.public)
 	if tombstoned {
 		return nil, NewTeamTombstonedError()
 	}
@@ -506,7 +515,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	if ret != nil && !ret.Chain.Reader.Eq(arg.me) {
 		// Check that we are the same person as when this team was last loaded as a courtesy.
 		// This should never happen. We shouldn't be able to decrypt someone else's snapshot.
-		l.G().Log.CWarningf(ctx, "TeamLoader discarding snapshot for wrong user: (%v, %v) != (%v, %v)",
+		mctx.Warning("TeamLoader discarding snapshot for wrong user: (%v, %v) != (%v, %v)",
 			arg.me.Uid, arg.me.EldestSeqno, ret.Chain.Reader.Uid, ret.Chain.Reader.EldestSeqno)
 		ret = nil
 	}
@@ -516,8 +525,17 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		cachedName = &ret.Name
 	}
 
+	hiddenPackage, err := l.hiddenPackage(mctx, arg.teamID, ret)
+	if err != nil {
+		return nil, err
+	}
+
+	teamShim := func() *TeamShim {
+		return &TeamShim{Data: ret, Hidden: hiddenPackage.ChainData()}
+	}
+
 	// Determine whether to repoll merkle.
-	discardCache, repoll := l.load2DecideRepoll(ctx, arg, ret)
+	discardCache, repoll := l.load2DecideRepoll(mctx, arg, teamShim())
 	if discardCache {
 		ret = nil
 		repoll = true
@@ -532,19 +550,29 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		tmp := ret.DeepCopy()
 		ret = &tmp
 	} else {
-		l.G().Log.CDebugf(ctx, "TeamLoader not using snapshot")
+		mctx.Debug("TeamLoader not using snapshot")
 	}
 
 	tracer.Stage("merkle")
 	var lastSeqno keybase1.Seqno
 	var lastLinkID keybase1.LinkID
+
 	if (ret == nil) || repoll {
-		l.G().Log.CDebugf(ctx, "TeamLoader looking up merkle leaf (force:%v)", arg.forceRepoll)
-		// Reference the merkle tree to fetch the sigchain tail leaf for the team.
-		lastSeqno, lastLinkID, err = l.world.merkleLookup(ctx, arg.teamID, arg.public)
+		mctx.Debug("TeamLoader looking up merkle leaf (force:%v)", arg.forceRepoll)
+		// Request also, without an additional RTT, freshness information about the hidden chain;
+		// we're going to send up information we know about the visible and hidden chains to both prove
+		// membership and show what we know about.
+		harg, err := hiddenPackage.MerkleLoadArg(mctx)
 		if err != nil {
 			return nil, err
 		}
+		var hif bool // hidden is fresh
+		// Reference the merkle tree to fetch the sigchain tail leaf for the team.
+		lastSeqno, lastLinkID, hif, err = l.world.merkleLookupWithHidden(ctx, arg.teamID, arg.public, harg)
+		if err != nil {
+			return nil, err
+		}
+		hiddenPackage.SetIsFresh(hif)
 		didRepoll = true
 	} else {
 		lastSeqno = ret.Chain.LastSeqno
@@ -565,7 +593,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	tracer.Stage("backfill")
 	if ret != nil && len(arg.needSeqnos) > 0 {
 		ret, proofSet, parentChildOperations, err = l.fillInStubbedLinks(
-			ctx, arg.me, arg.teamID, ret, arg.needSeqnos, readSubteamID, proofSet, parentChildOperations, lkc)
+			ctx, arg.me, arg.teamID, ret, hiddenPackage.ChainData(), arg.needSeqnos, readSubteamID, proofSet, parentChildOperations, lkc)
 		if err != nil {
 			return nil, err
 		}
@@ -574,44 +602,48 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	tracer.Stage("pre-fetch")
 	var fetchLinksAndOrSecrets bool
 	if ret == nil {
-		l.G().Log.CDebugf(ctx, "TeamLoader fetching: no cache")
+		mctx.Debug("TeamLoader fetching: no cache")
 		// We have no cache
 		fetchLinksAndOrSecrets = true
 	} else if ret.Chain.LastSeqno < lastSeqno {
-		l.G().Log.CDebugf(ctx, "TeamLoader fetching: chain update")
+		mctx.Debug("TeamLoader fetching: chain update")
 		// The cache is definitely behind
 		fetchLinksAndOrSecrets = true
-	} else if !l.hasSyncedSecrets(ret) {
+	} else if !hiddenPackage.IsFresh() {
+		mctx.Debug("TeamLoader fetching: hidden chain wasn't fresh")
+		fetchLinksAndOrSecrets = true
+	} else if !l.hasSyncedSecrets(mctx, teamShim()) {
 		// The cached secrets are behind the cached chain.
 		// We may need to hit the server for secrets, even though there are no new links.
 		if arg.needAdmin {
-			l.G().Log.CDebugf(ctx, "TeamLoader fetching: NeedAdmin")
+			mctx.Debug("TeamLoader fetching: NeedAdmin")
 			// Admins should always have up-to-date secrets. But not necessarily RKMs.
 			fetchLinksAndOrSecrets = true
 		}
-		if err := l.satisfiesNeedKeyGeneration(ctx, arg.needKeyGeneration, ret); err != nil {
-			l.G().Log.CDebugf(ctx, "TeamLoader fetching: NeedKeyGeneration: %v", err)
+		if err := l.satisfiesNeedKeyGeneration(mctx, arg.needKeyGeneration, teamShim()); err != nil {
+			mctx.Debug("TeamLoader fetching: NeedKeyGeneration: %v", err)
 			fetchLinksAndOrSecrets = true
 		}
-		if err := l.satisfiesNeedsKBFSKeyGeneration(ctx, arg.needKBFSKeyGeneration, ret); err != nil {
-			l.G().Log.CDebugf(ctx, "TeamLoader fetching: KBFSNeedKeyGeneration: %v", err)
+		if err := l.satisfiesNeedsKBFSKeyGeneration(mctx, arg.needKBFSKeyGeneration, teamShim()); err != nil {
+			mctx.Debug("TeamLoader fetching: KBFSNeedKeyGeneration: %v", err)
 			fetchLinksAndOrSecrets = true
 		}
 		if arg.readSubteamID == nil {
 			// This is not a recursive load. We should have the keys.
 			// This may be an extra round trip for public teams you're not in.
-			l.G().Log.CDebugf(ctx, "TeamLoader fetching: primary load")
+			mctx.Debug("TeamLoader fetching: primary load")
 			fetchLinksAndOrSecrets = true
 		}
 	}
 	// hasSyncedSecrets does not account for RKMs. So check RKM refreshers separeately.
-	if err := l.satisfiesNeedApplicationsAtGenerations(ctx, arg.needApplicationsAtGenerations, ret); err != nil {
-		l.G().Log.CDebugf(ctx, "TeamLoader fetching: NeedApplicationsAtGenerations: %v", err)
+
+	if err := l.satisfiesNeedApplicationsAtGenerations(mctx, arg.needApplicationsAtGenerations, teamShim()); err != nil {
+		mctx.Debug("TeamLoader fetching: NeedApplicationsAtGenerations: %v", err)
 		fetchLinksAndOrSecrets = true
 	}
-	if err := l.satisfiesNeedApplicationsAtGenerationsWithKBFS(ctx,
-		arg.needApplicationsAtGenerationsWithKBFS, ret); err != nil {
-		l.G().Log.CDebugf(ctx, "TeamLoader fetching: NeedApplicationsAtGenerationsWithKBFS: %v", err)
+	if err := l.satisfiesNeedApplicationsAtGenerationsWithKBFS(mctx,
+		arg.needApplicationsAtGenerationsWithKBFS, teamShim()); err != nil {
+		mctx.Debug("TeamLoader fetching: NeedApplicationsAtGenerationsWithKBFS: %v", err)
 		fetchLinksAndOrSecrets = true
 	}
 
@@ -619,13 +651,13 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	tracer.Stage("fetch")
 	var teamUpdate *rawTeam
 	if fetchLinksAndOrSecrets {
-		lows := l.lows(ctx, ret)
-		l.G().Log.CDebugf(ctx, "TeamLoader getting links from server (%+v)", lows)
+		lows := l.lows(mctx, ret, hiddenPackage)
+		mctx.Debug("TeamLoader getting links from server (%+v)", lows)
 		teamUpdate, err = l.world.getNewLinksFromServer(ctx, arg.teamID, lows, arg.readSubteamID)
 		if err != nil {
 			return nil, err
 		}
-		l.G().Log.CDebugf(ctx, "TeamLoader got %v links", len(teamUpdate.Chain))
+		mctx.Debug("TeamLoader got %v links", len(teamUpdate.Chain))
 	}
 
 	tracer.Stage("unpack")
@@ -635,7 +667,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	}
 	var prev libkb.LinkID
 	if ret != nil {
-		prev, err = TeamSigChainState{ret.Chain}.GetLatestLibkbLinkID()
+		prev, err = TeamSigChainState{inner: ret.Chain}.GetLatestLibkbLinkID()
 		if err != nil {
 			return nil, err
 		}
@@ -652,7 +684,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		}
 	}
 	if fullVerifyCutoff > 0 {
-		l.G().Log.CDebugf(ctx, "fullVerifyCutoff: %v", fullVerifyCutoff)
+		mctx.Debug("fullVerifyCutoff: %v", fullVerifyCutoff)
 	}
 
 	tracer.Stage("userPreload enable:%v parallel:%v wait:%v",
@@ -668,10 +700,16 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	suppressLoggingUpto := len(links) - 5
 	for i, link := range links {
 		var err error
-		ret, prev, err = l.doOneLink(ctx, arg, ret, link, i, suppressLoggingStart, suppressLoggingUpto, lastSeqno, &parentChildOperations, prev, fullVerifyCutoff, readSubteamID, proofSet, lkc, &parentsCache)
+		ret, prev, err = l.doOneLink(ctx, arg, ret, hiddenPackage.ChainData(), link, i, suppressLoggingStart, suppressLoggingUpto, lastSeqno, &parentChildOperations, prev, fullVerifyCutoff, readSubteamID, proofSet, lkc, &parentsCache)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// Be sure to update the hidden chain after the main chain, since the latter can "ratchet" the former
+	err = hiddenPackage.Update(mctx, teamUpdate.GetHiddenChain())
+	if err != nil {
+		return nil, err
 	}
 
 	preloadCancel()
@@ -685,7 +723,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 			tbs.Log(ctx, "CachedUPAKLoader.LoadKeyV2") // note LoadKeyV2 calls Load2
 			tbs.Log(ctx, "CachedUPAKLoader.LoadV2")
 			tbs.Log(ctx, "CachedUPAKLoader.DeepCopy")
-			l.G().Log.CDebugf(ctx, "TeamLoader lkc cache hits: %v", lkc.cacheHits)
+			mctx.Debug("TeamLoader lkc cache hits: %v", lkc.cacheHits)
 		}
 	}
 
@@ -725,6 +763,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 
 	tracer.Stage("secrets")
 	if teamUpdate != nil {
+
 		if teamUpdate.SubteamReader {
 			// Only allow subteam-reader results if we are in a recursive load.
 			if arg.readSubteamID == nil {
@@ -734,19 +773,37 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 			// Add the secrets.
 			// If it's a public team, there might not be secrets. (If we're not in the team)
 			if !ret.Chain.Public || (teamUpdate.Box != nil) {
-				err = l.addSecrets(ctx, ret, arg.me, teamUpdate.Box, teamUpdate.Prevs, teamUpdate.ReaderKeyMasks)
+				err = l.addSecrets(mctx, ret, arg.me, teamUpdate.Box, teamUpdate.Prevs, teamUpdate.ReaderKeyMasks, hiddenPackage)
 				if err != nil {
 					return nil, fmt.Errorf("loading team secrets: %v", err)
 				}
 
+				err = l.computeSeedChecks(ctx, ret)
+				if err != nil {
+					return nil, err
+				}
+
 				if teamUpdate.LegacyTLFUpgrade != nil {
-					err = l.addKBFSCryptKeys(ctx, ret, teamUpdate.LegacyTLFUpgrade)
+					err = l.addKBFSCryptKeys(mctx, teamShim(), teamUpdate.LegacyTLFUpgrade)
 					if err != nil {
 						return nil, fmt.Errorf("loading KBFS crypt keys: %v", err)
 					}
 				}
 			}
 		}
+	}
+
+	// Note that we might have done so just above after adding secrets, but before adding
+	// KBFS crypt keys. But it's cheap to run this method twice in a row.
+	tracer.Stage("computeSeedChecks")
+	err = l.computeSeedChecks(ctx, ret)
+	if err != nil {
+		return nil, err
+	}
+
+	err = hiddenPackage.CheckUpdatesAgainstSeeds(mctx, ret.PerTeamKeySeedsUnverified)
+	if err != nil {
+		return nil, err
 	}
 
 	// Make sure public works out
@@ -777,6 +834,17 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		ret.Name = newName
 	}
 
+	var needHiddenRotate bool
+	needHiddenRotate, err = l.checkNeedRotate(mctx, ret, arg.me, hiddenPackage)
+	if err != nil {
+		return nil, err
+	}
+
+	err = hiddenPackage.Commit(mctx)
+	if err != nil {
+		return nil, err
+	}
+
 	l.logIfUnsyncedSecrets(ctx, ret)
 
 	// Mutating this field is safe because only TeamLoader
@@ -796,7 +864,11 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 
 	// Cache the validated result
 	tracer.Stage("put")
-	l.storage.Put(libkb.NewMetaContext(ctx, l.G()), ret)
+	l.storage.Put(mctx, ret)
+
+	if needHiddenRotate {
+		return nil, NeedHiddenChainRotationError{}
+	}
 
 	tracer.Stage("notify")
 	if cachedName != nil && !cachedName.Eq(newName) {
@@ -813,18 +885,118 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 
 	// Check request constraints
 	tracer.Stage("postcheck")
-	err = l.load2CheckReturn(ctx, arg, ret)
+	err = l.load2CheckReturn(mctx, arg, teamShim())
 	if err != nil {
 		return nil, err
 	}
 
-	return &load2ResT{
+	load2res := load2ResT{
 		team:      *ret,
 		didRepoll: didRepoll,
-	}, nil
+	}
+
+	if hd := hiddenPackage.ChainData(); hd != nil {
+		load2res.hidden = *hd
+	}
+
+	return &load2res, nil
 }
 
-func (l *TeamLoader) doOneLink(ctx context.Context, arg load2ArgT, ret *keybase1.TeamData, link *ChainLinkUnpacked, i int, suppressLoggingStart int, suppressLoggingUpto int, lastSeqno keybase1.Seqno, parentChildOperations *[](*parentChildOperation), prev libkb.LinkID, fullVerifyCutoff keybase1.Seqno, readSubteamID keybase1.TeamID, proofSet *proofSetT, lkc *loadKeyCache, parentsCache *parentChainCache) (*keybase1.TeamData, libkb.LinkID, error) {
+func (l *TeamLoader) hiddenPackage(mctx libkb.MetaContext, id keybase1.TeamID, team *keybase1.TeamData) (ret *hidden.LoaderPackage, err error) {
+	var encKID keybase1.KID
+	var gen keybase1.PerTeamKeyGeneration
+	if team != nil {
+		ptk, err := TeamSigChainState{inner: team.Chain}.GetLatestPerTeamKey()
+		if err != nil {
+			return nil, err
+		}
+		encKID = ptk.EncKID
+		gen = ptk.Gen
+	}
+	ret = hidden.NewLoaderPackage(id, encKID, gen)
+	err = ret.Load(mctx)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (l *TeamLoader) isAllowedKeyerOf(mctx libkb.MetaContext, chain *keybase1.TeamData, me keybase1.UserVersion, them keybase1.UserVersion) (ret bool, err error) {
+	state := TeamSigChainState{inner: chain.Chain}
+	mctx = mctx.WithLogTag("IAKO")
+	defer mctx.Trace(fmt.Sprintf("TeamLoader#isAllowedKeyerOf(%s, %s)", state.GetID(), them), func() error { return err })()
+
+	role, err := state.GetUserRole(them)
+	if err != nil {
+		return false, err
+	}
+	if role == keybase1.TeamRole_ADMIN || role == keybase1.TeamRole_WRITER || role == keybase1.TeamRole_OWNER {
+		mctx.Debug("user fits explicit role (%s)", role)
+		return true, nil
+	}
+
+	// now check implict adminship
+	yes, err := l.isImplicitAdminOf(mctx.Ctx(), state.GetID(), state.GetParentID(), me, them)
+	if err != nil {
+		return false, err
+	}
+
+	if yes {
+		mctx.Debug("user is an implicit admin of the team")
+		return true, err
+	}
+
+	mctx.Debug("user is not an allowed keyer of the team")
+
+	return false, nil
+
+}
+
+func (l *TeamLoader) checkNeedRotate(mctx libkb.MetaContext, chain *keybase1.TeamData, me keybase1.UserVersion, hiddenPackage *hidden.LoaderPackage) (ret bool, err error) {
+	signer := hiddenPackage.LastReaderKeyRotator(mctx)
+	if signer == nil {
+		mctx.Debug("not checking need rotate, since last signer of hidden chain was nil")
+		return false, nil
+	}
+	return l.checkNeedRotateWithSigner(mctx, chain, me, *signer)
+}
+
+func (l *TeamLoader) checkNeedRotateWithSigner(mctx libkb.MetaContext, chain *keybase1.TeamData, me keybase1.UserVersion, signer keybase1.Signer) (ret bool, err error) {
+
+	uv := signer.UserVersion()
+
+	var isKeyer bool
+	isKeyer, err = l.isAllowedKeyerOf(mctx, chain, me, uv)
+	if err != nil {
+		return false, err
+	}
+
+	if !isKeyer {
+		return true, nil
+	}
+
+	var found bool
+	var revokedAt *keybase1.KeybaseTime
+
+	found, revokedAt, _, err = mctx.G().GetUPAKLoader().CheckKIDForUID(mctx.Ctx(), uv.Uid, signer.K)
+	if err != nil {
+		return false, err
+	}
+
+	if !found {
+		var s string
+		if revokedAt != nil {
+			tm := revokedAt.Unix.Time()
+			s = fmt.Sprintf(" (revoked at %s [%s ago])", tm, mctx.G().Clock().Now().Sub(tm))
+		}
+		mctx.Debug("KID %s wasn't found for %+v%s", signer.K, s)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (l *TeamLoader) doOneLink(ctx context.Context, arg load2ArgT, ret *keybase1.TeamData, hidden *keybase1.HiddenTeamChain, link *ChainLinkUnpacked, i int, suppressLoggingStart int, suppressLoggingUpto int, lastSeqno keybase1.Seqno, parentChildOperations *[](*parentChildOperation), prev libkb.LinkID, fullVerifyCutoff keybase1.Seqno, readSubteamID keybase1.TeamID, proofSet *proofSetT, lkc *loadKeyCache, parentsCache *parentChainCache) (*keybase1.TeamData, libkb.LinkID, error) {
 
 	var nilPrev libkb.LinkID
 
@@ -858,7 +1030,7 @@ func (l *TeamLoader) doOneLink(ctx context.Context, arg load2ArgT, ret *keybase1
 
 	var signer *SignerX
 	var err error
-	signer, err = l.verifyLink(ctx, arg.teamID, ret, arg.me, link, fullVerifyCutoff,
+	signer, err = l.verifyLink(ctx, arg.teamID, ret, hidden, arg.me, link, fullVerifyCutoff,
 		readSubteamID, proofSet, lkc, *parentsCache)
 	if err != nil {
 		return nil, nilPrev, err
@@ -872,7 +1044,7 @@ func (l *TeamLoader) doOneLink(ctx context.Context, arg load2ArgT, ret *keybase1
 		*parentChildOperations = append(*parentChildOperations, pco)
 	}
 
-	ret, err = l.applyNewLink(ctx, ret, link, signer, arg.me)
+	ret, err = l.applyNewLink(ctx, ret, hidden, link, signer, arg.me)
 	if err != nil {
 		return nil, nilPrev, err
 	}
@@ -940,17 +1112,17 @@ func (l *TeamLoader) userPreload(ctx context.Context, links []*ChainLinkUnpacked
 // - JustUpdated
 // - If this user is in global "force repoll" mode, where it would be too spammy to
 //   push out individual team changed notifications, so all team loads need a repoll.
-func (l *TeamLoader) load2DecideRepoll(ctx context.Context, arg load2ArgT, fromCache *keybase1.TeamData) (discardCache bool, repoll bool) {
+func (l *TeamLoader) load2DecideRepoll(mctx libkb.MetaContext, arg load2ArgT, fromCache Teamer) (discardCache bool, repoll bool) {
 	var reason string
 	defer func() {
 		if discardCache || repoll || reason != "" {
-			l.G().Log.CDebugf(ctx, "load2DecideRepoll -> (discardCache:%v, repoll:%v) %v", discardCache, repoll, reason)
+			mctx.Debug("load2DecideRepoll -> (discardCache:%v, repoll:%v) %v", discardCache, repoll, reason)
 		}
 	}()
 	// NeedAdmin is a special constraint where we start from scratch.
 	// Because of admin-only invite links.
 	if arg.needAdmin {
-		if !l.satisfiesNeedAdmin(ctx, arg.me, fromCache) {
+		if !l.satisfiesNeedAdmin(mctx, arg.me, fromCache) {
 			// Start from scratch if we are newly admin
 			reason = "!satisfiesNeedAdmin"
 			return true, true
@@ -963,34 +1135,34 @@ func (l *TeamLoader) load2DecideRepoll(ctx context.Context, arg load2ArgT, fromC
 	}
 
 	// Repoll if the server has previously hinted that the team has new links.
-	if fromCache != nil && fromCache.Chain.LastSeqno < fromCache.LatestSeqnoHint {
+	if fromCache != nil && fromCache.MainChain() != nil && fromCache.MainChain().Chain.LastSeqno < fromCache.MainChain().LatestSeqnoHint {
 		reason = "behind seqno hint"
 		return false, true
 	}
 
 	// Repoll to get a new key generation
 	if arg.needKeyGeneration > 0 {
-		if err := l.satisfiesNeedKeyGeneration(ctx, arg.needKeyGeneration, fromCache); err != nil {
+		if err := l.satisfiesNeedKeyGeneration(mctx, arg.needKeyGeneration, fromCache); err != nil {
 			reason = fmt.Sprintf("satisfiesNeedKeyGeneration -> %v", err)
 			return false, true
 		}
 	}
 	// Repoll to get new applications at generations
 	if len(arg.needApplicationsAtGenerations) > 0 {
-		if err := l.satisfiesNeedApplicationsAtGenerations(ctx, arg.needApplicationsAtGenerations, fromCache); err != nil {
+		if err := l.satisfiesNeedApplicationsAtGenerations(mctx, arg.needApplicationsAtGenerations, fromCache); err != nil {
 			reason = fmt.Sprintf("satisfiesNeedApplicationsAtGenerations -> %v", err)
 			return false, true
 		}
 	}
 	if arg.needKBFSKeyGeneration.Generation > 0 {
-		if err := l.satisfiesNeedsKBFSKeyGeneration(ctx, arg.needKBFSKeyGeneration, fromCache); err != nil {
+		if err := l.satisfiesNeedsKBFSKeyGeneration(mctx, arg.needKBFSKeyGeneration, fromCache); err != nil {
 			reason = fmt.Sprintf("satisfiesNeedsKBFSKeyGeneration -> %v", err)
 			return false, true
 		}
 	}
 
 	if len(arg.needApplicationsAtGenerationsWithKBFS) > 0 {
-		if err := l.satisfiesNeedApplicationsAtGenerationsWithKBFS(ctx,
+		if err := l.satisfiesNeedApplicationsAtGenerationsWithKBFS(mctx,
 			arg.needApplicationsAtGenerationsWithKBFS, fromCache); err != nil {
 			reason = fmt.Sprintf("satisfiesNeedApplicationsAtGenerationsWithKBFS -> %v", err)
 			return false, true
@@ -999,7 +1171,7 @@ func (l *TeamLoader) load2DecideRepoll(ctx context.Context, arg load2ArgT, fromC
 
 	// Repoll because it might help get the wanted members
 	if len(arg.wantMembers) > 0 {
-		if err := l.satisfiesWantMembers(ctx, arg.wantMembers, arg.wantMembersRole, fromCache); err != nil {
+		if err := l.satisfiesWantMembers(mctx, arg.wantMembers, arg.wantMembersRole, fromCache); err != nil {
 			reason = fmt.Sprintf("satisfiesWantMembers -> %v", err)
 			return false, true
 		}
@@ -1008,23 +1180,23 @@ func (l *TeamLoader) load2DecideRepoll(ctx context.Context, arg load2ArgT, fromC
 	// Repoll if we need a seqno not in the cache.
 	// Does not force a repoll if we just need to fill in previous links
 	if len(arg.needSeqnos) > 0 {
-		if fromCache == nil {
+		if fromCache == nil || fromCache.MainChain() == nil {
 			reason = "need seqnos and no cache"
 			return false, true
 		}
-		if fromCache.Chain.LastSeqno < l.seqnosMax(arg.needSeqnos) {
+		if fromCache.MainChain().Chain.LastSeqno < l.seqnosMax(arg.needSeqnos) {
 			reason = "need seqnos"
 			return false, true
 		}
 	}
 
-	if fromCache == nil {
+	if fromCache == nil || fromCache.MainChain() == nil {
 		reason = "no cache"
 		// We need a merkle leaf when starting from scratch.
 		return false, true
 	}
 
-	cacheIsOld := (fromCache != nil) && !l.isFresh(ctx, fromCache.CachedAt)
+	cacheIsOld := !l.isFresh(mctx, fromCache.MainChain().CachedAt)
 	if cacheIsOld && !arg.staleOK {
 		// We need a merkle leaf
 		reason = "cacheIsOld"
@@ -1032,7 +1204,7 @@ func (l *TeamLoader) load2DecideRepoll(ctx context.Context, arg load2ArgT, fromC
 	}
 
 	// InForceRepoll needs to a acquire a lock, so avoid it by checking it last.
-	if l.InForceRepollMode(ctx) {
+	if l.InForceRepollMode(mctx) {
 		reason = "InForceRepollMode"
 		return false, true
 	}
@@ -1047,39 +1219,38 @@ func (l *TeamLoader) load2DecideRepoll(ctx context.Context, arg load2ArgT, fromC
 // - NeedAdmin
 // - NeedKeyGeneration
 // - NeedSeqnos
-func (l *TeamLoader) load2CheckReturn(ctx context.Context, arg load2ArgT, res *keybase1.TeamData) error {
+func (l *TeamLoader) load2CheckReturn(mctx libkb.MetaContext, arg load2ArgT, shim Teamer) error {
 	if arg.needAdmin {
-		if !l.satisfiesNeedAdmin(ctx, arg.me, res) {
-			l.G().Log.CDebugf(ctx, "user %v is not an admin of team %v at seqno:%v",
-				arg.me, arg.teamID, res.Chain.LastSeqno)
+		if !l.satisfiesNeedAdmin(mctx, arg.me, shim) {
+			mctx.Debug("user %v is not an admin of team %v at seqno:%v", arg.me, arg.teamID, shim.MainChain().Chain.LastSeqno)
 			return fmt.Errorf("user %v is not an admin of the team", arg.me)
 		}
 	}
 
 	// Repoll to get a new key generation
 	if arg.needKeyGeneration > 0 {
-		if err := l.satisfiesNeedKeyGeneration(ctx, arg.needKeyGeneration, res); err != nil {
+		if err := l.satisfiesNeedKeyGeneration(mctx, arg.needKeyGeneration, shim); err != nil {
 			return err
 		}
 	}
 	if len(arg.needApplicationsAtGenerations) > 0 {
-		if err := l.satisfiesNeedApplicationsAtGenerations(ctx, arg.needApplicationsAtGenerations, res); err != nil {
+		if err := l.satisfiesNeedApplicationsAtGenerations(mctx, arg.needApplicationsAtGenerations, shim); err != nil {
 			return err
 		}
 	}
 	if arg.needKBFSKeyGeneration.Generation > 0 {
-		if err := l.satisfiesNeedsKBFSKeyGeneration(ctx, arg.needKBFSKeyGeneration, res); err != nil {
+		if err := l.satisfiesNeedsKBFSKeyGeneration(mctx, arg.needKBFSKeyGeneration, shim); err != nil {
 			return err
 		}
 	}
 	if len(arg.needApplicationsAtGenerationsWithKBFS) > 0 {
-		if err := l.satisfiesNeedApplicationsAtGenerationsWithKBFS(ctx, arg.needApplicationsAtGenerationsWithKBFS, res); err != nil {
+		if err := l.satisfiesNeedApplicationsAtGenerationsWithKBFS(mctx, arg.needApplicationsAtGenerationsWithKBFS, shim); err != nil {
 			return err
 		}
 	}
 
 	if len(arg.needSeqnos) > 0 {
-		if err := l.checkNeededSeqnos(ctx, res, arg.needSeqnos); err != nil {
+		if err := l.checkNeededSeqnos(mctx.Ctx(), shim.MainChain(), arg.needSeqnos); err != nil {
 			return err
 		}
 	}
@@ -1088,29 +1259,29 @@ func (l *TeamLoader) load2CheckReturn(ctx context.Context, arg load2ArgT, res *k
 }
 
 // Whether the user is an admin at the snapshot, and there are no stubbed links, and keys are up to date.
-func (l *TeamLoader) satisfiesNeedAdmin(ctx context.Context, me keybase1.UserVersion, teamData *keybase1.TeamData) bool {
-	if teamData == nil {
+func (l *TeamLoader) satisfiesNeedAdmin(mctx libkb.MetaContext, me keybase1.UserVersion, team Teamer) bool {
+	if team == nil || team.MainChain() == nil {
 		return false
 	}
-	if (TeamSigChainState{inner: teamData.Chain}.HasAnyStubbedLinks()) {
+	state := newTeamSigChainState(team)
+	if state.HasAnyStubbedLinks() {
 		return false
 	}
-	if !l.hasSyncedSecrets(teamData) {
+	if !l.hasSyncedSecrets(mctx, team) {
 		return false
 	}
-	state := TeamSigChainState{inner: teamData.Chain}
 	role, err := state.GetUserRole(me)
 	if err != nil {
-		l.G().Log.CDebugf(ctx, "TeamLoader error getting my role: %v", err)
+		mctx.Debug("TeamLoader error getting my role: %v", err)
 		return false
 	}
 	if !role.IsAdminOrAbove() {
 		if !state.IsSubteam() {
 			return false
 		}
-		yes, err := l.isImplicitAdminOf(ctx, state.GetID(), state.GetParentID(), me, me)
+		yes, err := l.isImplicitAdminOf(mctx.Ctx(), state.GetID(), state.GetParentID(), me, me)
 		if err != nil {
-			l.G().Log.CDebugf(ctx, "TeamLoader error getting checking implicit admin: %s", err)
+			mctx.Debug("TeamLoader error getting checking implicit admin: %s", err)
 			return false
 		}
 		if !yes {
@@ -1197,8 +1368,8 @@ func (l *TeamLoader) isImplicitAdminOf(ctx context.Context, teamID keybase1.Team
 	return false, nil
 }
 
-func (l *TeamLoader) satisfiesNeedsKBFSKeyGeneration(ctx context.Context,
-	kbfs keybase1.TeamKBFSKeyRefresher, state *keybase1.TeamData) error {
+func (l *TeamLoader) satisfiesNeedsKBFSKeyGeneration(mctx libkb.MetaContext,
+	kbfs keybase1.TeamKBFSKeyRefresher, state Teamer) error {
 	if kbfs.Generation == 0 {
 		return nil
 	}
@@ -1206,7 +1377,7 @@ func (l *TeamLoader) satisfiesNeedsKBFSKeyGeneration(ctx context.Context,
 		return fmt.Errorf("nil team does not contain KBFS key generation: %#v", kbfs)
 	}
 
-	gen, err := TeamSigChainState{inner: state.Chain}.GetLatestKBFSGeneration(kbfs.AppType)
+	gen, err := newTeamSigChainState(state).GetLatestKBFSGeneration(kbfs.AppType)
 	if err != nil {
 		return err
 	}
@@ -1217,21 +1388,21 @@ func (l *TeamLoader) satisfiesNeedsKBFSKeyGeneration(ctx context.Context,
 }
 
 // Whether the snapshot has loaded at least up to the key generation and has the secret.
-func (l *TeamLoader) satisfiesNeedKeyGeneration(ctx context.Context, needKeyGeneration keybase1.PerTeamKeyGeneration, state *keybase1.TeamData) error {
+func (l *TeamLoader) satisfiesNeedKeyGeneration(mctx libkb.MetaContext, needKeyGeneration keybase1.PerTeamKeyGeneration, state Teamer) error {
 	if needKeyGeneration == 0 {
 		return nil
 	}
 	if state == nil {
 		return fmt.Errorf("nil team does not contain key generation: %v", needKeyGeneration)
 	}
-	key, err := TeamSigChainState{inner: state.Chain}.GetLatestPerTeamKey()
+	key, err := newTeamSigChainState(state).GetLatestPerTeamKey()
 	if err != nil {
 		return err
 	}
 	if needKeyGeneration > key.Gen {
 		return fmt.Errorf("team key generation too low: %v < %v", key.Gen, needKeyGeneration)
 	}
-	_, ok := state.PerTeamKeySeedsUnverified[needKeyGeneration]
+	_, ok := state.MainChain().PerTeamKeySeedsUnverified[needKeyGeneration]
 	if !ok {
 		return fmt.Errorf("team key secret missing for generation: %v", needKeyGeneration)
 	}
@@ -1240,17 +1411,17 @@ func (l *TeamLoader) satisfiesNeedKeyGeneration(ctx context.Context, needKeyGene
 
 // Whether the snapshot has loaded the reader key masks and key generations we
 // need.
-func (l *TeamLoader) satisfiesNeedApplicationsAtGenerations(ctx context.Context,
-	needApplicationsAtGenerations map[keybase1.PerTeamKeyGeneration][]keybase1.TeamApplication, state *keybase1.TeamData) error {
+func (l *TeamLoader) satisfiesNeedApplicationsAtGenerations(mctx libkb.MetaContext,
+	needApplicationsAtGenerations map[keybase1.PerTeamKeyGeneration][]keybase1.TeamApplication, team Teamer) error {
 	if len(needApplicationsAtGenerations) == 0 {
 		return nil
 	}
-	if state == nil {
+	if team == nil || team.MainChain() == nil {
 		return fmt.Errorf("nil team does not contain applications: %v", needApplicationsAtGenerations)
 	}
 	for ptkGen, apps := range needApplicationsAtGenerations {
 		for _, app := range apps {
-			if _, err := ApplicationKeyAtGeneration(libkb.NewMetaContext(ctx, l.G()), state, app, ptkGen); err != nil {
+			if _, err := ApplicationKeyAtGeneration(mctx, team, app, ptkGen); err != nil {
 				return err
 			}
 		}
@@ -1258,9 +1429,9 @@ func (l *TeamLoader) satisfiesNeedApplicationsAtGenerations(ctx context.Context,
 	return nil
 }
 
-func (l *TeamLoader) satisfiesNeedApplicationsAtGenerationsWithKBFS(ctx context.Context,
+func (l *TeamLoader) satisfiesNeedApplicationsAtGenerationsWithKBFS(mctx libkb.MetaContext,
 	needApplicationsAtGenerations map[keybase1.PerTeamKeyGeneration][]keybase1.TeamApplication,
-	state *keybase1.TeamData) error {
+	state Teamer) error {
 	if len(needApplicationsAtGenerations) == 0 {
 		return nil
 	}
@@ -1269,8 +1440,7 @@ func (l *TeamLoader) satisfiesNeedApplicationsAtGenerationsWithKBFS(ctx context.
 	}
 	for ptkGen, apps := range needApplicationsAtGenerations {
 		for _, app := range apps {
-			if _, err := ApplicationKeyAtGenerationWithKBFS(libkb.NewMetaContext(ctx, l.G()), state, app,
-				ptkGen); err != nil {
+			if _, err := ApplicationKeyAtGenerationWithKBFS(mctx, state, app, ptkGen); err != nil {
 				return err
 			}
 		}
@@ -1279,8 +1449,8 @@ func (l *TeamLoader) satisfiesNeedApplicationsAtGenerationsWithKBFS(ctx context.
 }
 
 // Whether the snapshot has each of `wantMembers` as a member.
-func (l *TeamLoader) satisfiesWantMembers(ctx context.Context,
-	wantMembers []keybase1.UserVersion, wantMembersRole keybase1.TeamRole, state *keybase1.TeamData) error {
+func (l *TeamLoader) satisfiesWantMembers(mctx libkb.MetaContext,
+	wantMembers []keybase1.UserVersion, wantMembersRole keybase1.TeamRole, state Teamer) error {
 
 	if wantMembersRole == keybase1.TeamRole_NONE {
 		// Default to writer.
@@ -1293,7 +1463,7 @@ func (l *TeamLoader) satisfiesWantMembers(ctx context.Context,
 		return fmt.Errorf("nil team does not have wanted members")
 	}
 	for _, uv := range wantMembers {
-		role, err := TeamSigChainState{inner: state.Chain}.GetUserRole(uv)
+		role, err := newTeamSigChainState(state).GetUserRole(uv)
 		if err != nil {
 			return fmt.Errorf("could not get wanted user role: %v", err)
 		}
@@ -1342,26 +1512,33 @@ func (l *TeamLoader) seqnosMax(seqnos []keybase1.Seqno) (ret keybase1.Seqno) {
 }
 
 // Whether a TeamData from the cache is fresh.
-func (l *TeamLoader) isFresh(ctx context.Context, cachedAt keybase1.Time) bool {
+func (l *TeamLoader) isFresh(mctx libkb.MetaContext, cachedAt keybase1.Time) bool {
 	if cachedAt.IsZero() {
 		// This should never happen.
-		l.G().Log.CWarningf(ctx, "TeamLoader encountered zero cached time")
+		mctx.Warning("TeamLoader encountered zero cached time")
 		return false
 	}
-	diff := l.G().Clock().Now().Sub(cachedAt.Time())
+	diff := mctx.G().Clock().Now().Sub(cachedAt.Time())
 	fresh := (diff <= freshnessLimit)
 	if !fresh {
-		l.G().Log.CDebugf(ctx, "TeamLoader cached snapshot is old: %v", diff)
+		mctx.Debug("TeamLoader cached snapshot is old: %v", diff)
 	}
 	return fresh
 }
 
 // Whether the teams secrets are synced to the same point as its sigchain
 // Does not check RKMs.
-func (l *TeamLoader) hasSyncedSecrets(state *keybase1.TeamData) bool {
-	onChainGen := keybase1.PerTeamKeyGeneration(len(state.Chain.PerTeamKeys))
-	offChainGen := keybase1.PerTeamKeyGeneration(len(state.PerTeamKeySeedsUnverified))
-	return onChainGen == offChainGen
+func (l *TeamLoader) hasSyncedSecrets(mctx libkb.MetaContext, team Teamer) bool {
+	state := team.MainChain()
+	n := len(team.MainChain().Chain.PerTeamKeys)
+	offChainGen := len(state.PerTeamKeySeedsUnverified)
+	mctx.Debug("TeamLoader#hasSyncedSecrets: found %d PTKs on the main chain (versus %d seeds)", n, offChainGen)
+	if team.HiddenChain() != nil {
+		m := len(team.HiddenChain().ReaderPerTeamKeys)
+		mctx.Debug("TeamLoader#hasSyncedSecrets: found another %d PTKs on the hidden chain", m)
+		n += m
+	}
+	return (n == offChainGen)
 }
 
 func (l *TeamLoader) logIfUnsyncedSecrets(ctx context.Context, state *keybase1.TeamData) {
@@ -1372,7 +1549,7 @@ func (l *TeamLoader) logIfUnsyncedSecrets(ctx context.Context, state *keybase1.T
 	}
 }
 
-func (l *TeamLoader) lows(ctx context.Context, state *keybase1.TeamData) getLinksLows {
+func (l *TeamLoader) lows(mctx libkb.MetaContext, state *keybase1.TeamData, hp *hidden.LoaderPackage) getLinksLows {
 	var lows getLinksLows
 	if state != nil {
 		chain := TeamSigChainState{inner: state.Chain}
@@ -1386,22 +1563,25 @@ func (l *TeamLoader) lows(ctx context.Context, state *keybase1.TeamData) getLink
 			lows.ReaderKeyMask = keybase1.PerTeamKeyGeneration(len(rkms))
 		}
 	}
+	if hp != nil {
+		lows.HiddenChainSeqno = hp.LastSeqno()
+	}
 	return lows
 }
 
 func (l *TeamLoader) OnLogout(mctx libkb.MetaContext) error {
-	l.storage.clearMem()
+	l.storage.ClearMem()
 	return nil
 }
 
 func (l *TeamLoader) OnDbNuke(mctx libkb.MetaContext) error {
-	l.storage.clearMem()
+	l.storage.ClearMem()
 	return nil
 }
 
 // Clear the in-memory cache.
 func (l *TeamLoader) ClearMem() {
-	l.storage.clearMem()
+	l.storage.ClearMem()
 }
 
 func (l *TeamLoader) VerifyTeamName(ctx context.Context, id keybase1.TeamID, name keybase1.TeamName) error {
@@ -1411,7 +1591,7 @@ func (l *TeamLoader) VerifyTeamName(ctx context.Context, id keybase1.TeamID, nam
 		}
 		return nil
 	}
-	teamData, err := l.Load(ctx, keybase1.LoadTeamArg{
+	teamData, _, err := l.Load(ctx, keybase1.LoadTeamArg{
 		ID:     id,
 		Public: id.IsPublic(),
 	})
@@ -1463,7 +1643,7 @@ func (l *TeamLoader) MapTeamAncestors(ctx context.Context, f func(t keybase1.Tea
 	}
 
 	// Load the argument team
-	team, err := l.load1(ctx, me, keybase1.LoadTeamArg{
+	team, _, err := l.load1(ctx, me, keybase1.LoadTeamArg{
 		ID:      teamID,
 		Public:  teamID.IsPublic(),
 		StaleOK: true, // We only use immutable fields.
@@ -1661,14 +1841,14 @@ func (l *TeamLoader) ForceRepollUntil(ctx context.Context, dtime gregor.TimeOrOf
 	return nil
 }
 
-func (l *TeamLoader) InForceRepollMode(ctx context.Context) bool {
+func (l *TeamLoader) InForceRepollMode(mctx libkb.MetaContext) bool {
 	l.forceRepollMutex.Lock()
 	defer l.forceRepollMutex.Unlock()
 	if l.forceRepollUntil == nil {
 		return false
 	}
-	if !l.forceRepollUntil.Before(l.G().Clock().Now()) {
-		l.G().Log.CDebugf(ctx, "TeamLoader#InForceRepollMode: returning true")
+	if !l.forceRepollUntil.Before(mctx.G().Clock().Now()) {
+		mctx.Debug("TeamLoader#InForceRepollMode: returning true")
 		return true
 	}
 	l.forceRepollUntil = nil

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams/hidden"
 	"github.com/keybase/go-codec/codec"
 )
 
@@ -24,7 +25,7 @@ import (
 // Does not ask for any links above state's seqno, those will be fetched by getNewLinksFromServer.
 func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 	me keybase1.UserVersion, teamID keybase1.TeamID, state *keybase1.TeamData,
-	needSeqnos []keybase1.Seqno, readSubteamID keybase1.TeamID,
+	hiddenState *keybase1.HiddenTeamChain, needSeqnos []keybase1.Seqno, readSubteamID keybase1.TeamID,
 	proofSet *proofSetT, parentChildOperations []*parentChildOperation, lkc *loadKeyCache) (
 	*keybase1.TeamData, *proofSetT, []*parentChildOperation, error) {
 
@@ -64,7 +65,7 @@ func (l *TeamLoader) fillInStubbedLinks(ctx context.Context,
 
 		var signer *SignerX
 		var fullVerifyCutoff keybase1.Seqno // Always fullVerify when inflating. No reasoning has been done on whether it could be skipped.
-		signer, err = l.verifyLink(ctx, teamID, state, me, link, fullVerifyCutoff, readSubteamID,
+		signer, err = l.verifyLink(ctx, teamID, state, hiddenState, me, link, fullVerifyCutoff, readSubteamID,
 			proofSet, lkc, parentsCache)
 		if err != nil {
 			return state, proofSet, parentChildOperations, err
@@ -99,6 +100,10 @@ type getLinksLows struct {
 	PerTeamKey keybase1.PerTeamKeyGeneration
 	// Latest RKM semi-secret we have
 	ReaderKeyMask keybase1.PerTeamKeyGeneration
+	// Latest hidden chain seqno on file
+	HiddenChainSeqno keybase1.Seqno
+	// Ratcheted chain tail
+	HiddenChainRatchet keybase1.Seqno
 }
 
 // checkStubbed checks if it's OK if a link is stubbed.
@@ -198,7 +203,7 @@ func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID k
 // - Check the rest of the format of the inner link
 // Returns the signer, or nil if the link was stubbed
 func (l *TeamLoader) verifyLink(ctx context.Context,
-	teamID keybase1.TeamID, state *keybase1.TeamData, me keybase1.UserVersion, link *ChainLinkUnpacked,
+	teamID keybase1.TeamID, state *keybase1.TeamData, hiddenState *keybase1.HiddenTeamChain, me keybase1.UserVersion, link *ChainLinkUnpacked,
 	fullVerifyCutoff keybase1.Seqno, readSubteamID keybase1.TeamID, proofSet *proofSetT, lkc *loadKeyCache,
 	parentsCache parentChainCache) (*SignerX, error) {
 	ctx, tbs := l.G().CTimeBuckets(ctx)
@@ -311,7 +316,7 @@ func (l *TeamLoader) loadUserAndKeyFromLinkInnerAndVerify(ctx context.Context, t
 // Verify that the user had the explicit on-chain role just before this `link`.
 func (l *TeamLoader) verifyExplicitPermission(ctx context.Context, state *keybase1.TeamData,
 	link *ChainLinkUnpacked, uv keybase1.UserVersion, atOrAbove keybase1.TeamRole) error {
-	return (TeamSigChainState{state.Chain}).AssertWasRoleOrAboveAt(uv, atOrAbove, link.SigChainLocation().Sub1())
+	return (TeamSigChainState{inner: state.Chain}).AssertWasRoleOrAboveAt(uv, atOrAbove, link.SigChainLocation().Sub1())
 }
 
 type parentChainCache map[keybase1.TeamID]*keybase1.TeamData
@@ -478,7 +483,7 @@ func (l *TeamLoader) toParentChildOperation(ctx context.Context,
 // `state` is moved into this function. There must exist no live references into it from now on.
 // `signer` may be nil iff link is stubbed.
 func (l *TeamLoader) applyNewLink(ctx context.Context,
-	state *keybase1.TeamData, link *ChainLinkUnpacked,
+	state *keybase1.TeamData, hiddenChainState *keybase1.HiddenTeamChain, link *ChainLinkUnpacked,
 	signer *SignerX, me keybase1.UserVersion) (*keybase1.TeamData, error) {
 	ctx, tbs := l.G().CTimeBuckets(ctx)
 	defer tbs.Record("TeamLoader.applyNewLink")()
@@ -498,7 +503,7 @@ func (l *TeamLoader) applyNewLink(ctx context.Context,
 			ReaderKeyMasks:            make(map[keybase1.TeamApplication]map[keybase1.PerTeamKeyGeneration]keybase1.MaskB64),
 		}
 	} else {
-		chainState = &TeamSigChainState{inner: state.Chain}
+		chainState = &TeamSigChainState{inner: state.Chain, hidden: hiddenChainState}
 		newState = state
 		state = nil
 	}
@@ -667,17 +672,15 @@ func (l *TeamLoader) unboxKBFSCryptKeys(ctx context.Context, key keybase1.TeamAp
 }
 
 // AddKBFSCryptKeys mutates `state`
-func (l *TeamLoader) addKBFSCryptKeys(ctx context.Context, state *keybase1.TeamData,
-	upgrades []keybase1.TeamGetLegacyTLFUpgrade) error {
+func (l *TeamLoader) addKBFSCryptKeys(mctx libkb.MetaContext, team Teamer, upgrades []keybase1.TeamGetLegacyTLFUpgrade) error {
 	m := make(map[keybase1.TeamApplication][]keybase1.CryptKey)
 	for _, upgrade := range upgrades {
-		key, err := ApplicationKeyAtGeneration(libkb.NewMetaContext(ctx, l.G()), state, upgrade.AppType,
-			keybase1.PerTeamKeyGeneration(upgrade.TeamGeneration))
+		key, err := ApplicationKeyAtGeneration(mctx, team, upgrade.AppType, keybase1.PerTeamKeyGeneration(upgrade.TeamGeneration))
 		if err != nil {
 			return err
 		}
 
-		chainInfo, ok := state.Chain.TlfLegacyUpgrade[upgrade.AppType]
+		chainInfo, ok := team.MainChain().Chain.TlfLegacyUpgrade[upgrade.AppType]
 		if !ok {
 			return errors.New("legacy tlf upgrade payload present without chain link")
 		}
@@ -686,7 +689,7 @@ func (l *TeamLoader) addKBFSCryptKeys(ctx context.Context, state *keybase1.TeamD
 				chainInfo.TeamGeneration, upgrade.TeamGeneration)
 		}
 
-		cryptKeys, err := l.unboxKBFSCryptKeys(ctx, key, chainInfo.KeysetHash, upgrade.EncryptedKeyset)
+		cryptKeys, err := l.unboxKBFSCryptKeys(mctx.Ctx(), key, chainInfo.KeysetHash, upgrade.EncryptedKeyset)
 		if err != nil {
 			return err
 		}
@@ -697,7 +700,7 @@ func (l *TeamLoader) addKBFSCryptKeys(ctx context.Context, state *keybase1.TeamD
 
 		m[upgrade.AppType] = cryptKeys
 	}
-	state.TlfCryptKeys = m
+	team.MainChain().TlfCryptKeys = m
 	return nil
 }
 
@@ -707,54 +710,50 @@ func (l *TeamLoader) addKBFSCryptKeys(ctx context.Context, state *keybase1.TeamD
 // Checks that the off-chain data ends up exactly in sync with the chain, generation-wise.
 // Does _not_ check that keys match the sigchain.
 // Mutates `state`
-func (l *TeamLoader) addSecrets(ctx context.Context,
+func (l *TeamLoader) addSecrets(mctx libkb.MetaContext,
 	state *keybase1.TeamData, me keybase1.UserVersion, box *TeamBox, prevs map[keybase1.PerTeamKeyGeneration]prevKeySealedEncoded,
-	readerKeyMasks []keybase1.ReaderKeyMask) error {
+	readerKeyMasks []keybase1.ReaderKeyMask, hiddenPackage *hidden.LoaderPackage) error {
 
-	latestReceivedGen, seeds, err := l.unboxPerTeamSecrets(ctx, box, prevs)
+	latestReceivedGen, seeds, err := l.unboxPerTeamSecrets(mctx, box, prevs)
 	if err != nil {
 		return err
 	}
+	mctx.Debug("TeamLoader#addSecrets at %d", latestReceivedGen)
+
 	// Earliest generation received.
 	earliestReceivedGen := latestReceivedGen - keybase1.PerTeamKeyGeneration(len(seeds)-1)
+
 	// Latest generation from the sigchain
-	latestChainGen := keybase1.PerTeamKeyGeneration(len(state.Chain.PerTeamKeys))
-
-	l.G().Log.CDebugf(ctx, "TeamLoader.addSecrets: received:%v->%v nseeds:%v nprevs:%v",
-		earliestReceivedGen, latestReceivedGen, len(seeds), len(prevs))
-
-	if latestReceivedGen != latestChainGen {
-		return fmt.Errorf("wrong latest key generation: %v != %v",
-			latestReceivedGen, latestChainGen)
+	latestChainGen := state.Chain.MaxPerTeamKeyGeneration
+	// .. Or from the hidden chain
+	h := hiddenPackage.MaxReaderPerTeamKeyGeneration()
+	if h > latestChainGen {
+		latestChainGen = h
 	}
 
+	mctx.Debug("TeamLoader.addSecrets: received:%v->%v nseeds:%v nprevs:%v",
+		earliestReceivedGen, latestReceivedGen, len(seeds), len(prevs))
+
 	// Check that each key matches the chain.
-	var gotOldKeys bool
 	for i, seed := range seeds {
 		gen := int(latestReceivedGen) + i + 1 - len(seeds)
 		if gen < 1 {
 			return fmt.Errorf("gen < 1")
 		}
 
-		if gen <= int(latestChainGen) {
-			gotOldKeys = true
-		}
+		ptkGen := keybase1.PerTeamKeyGeneration(gen)
 
-		chainKey, err := TeamSigChainState{inner: state.Chain}.GetPerTeamKeyAtGeneration(keybase1.PerTeamKeyGeneration(gen))
+		chainKey, err := TeamSigChainState{inner: state.Chain, hidden: hiddenPackage.ChainData()}.GetPerTeamKeyAtGeneration(ptkGen)
 		if err != nil {
 			return err
 		}
 
 		// Add it to the snapshot
-		state.PerTeamKeySeedsUnverified[chainKey.Gen] = keybase1.PerTeamKeySeedItem{
+		state.PerTeamKeySeedsUnverified[ptkGen] = keybase1.PerTeamKeySeedItem{
 			Seed:       seed,
-			Generation: chainKey.Gen,
+			Generation: ptkGen,
 			Seqno:      chainKey.Seqno,
 		}
-	}
-
-	if gotOldKeys {
-		l.G().Log.CDebugf(ctx, "TeamLoader got old keys, re-checking as if new")
 	}
 
 	// Make sure there is not a gap between the latest local key and the earliest received key.
@@ -792,23 +791,23 @@ func (l *TeamLoader) addSecrets(ctx context.Context,
 				checkMaskGens[rkm.Generation-1] = true
 			}
 		}
-		l.G().Log.CDebugf(ctx, "TeamLoader.addSecrets: loop1")
+		mctx.Debug("TeamLoader.addSecrets: loop1")
 		// Check that we are all the way up to date
 		checkMaskGens[latestChainGen] = true
 		for gen := range checkMaskGens {
-			err = l.checkReaderKeyMaskCoverage(ctx, state, gen)
+			err = l.checkReaderKeyMaskCoverage(mctx, state, gen)
 			if err != nil {
 				return err
 			}
 		}
-		l.G().Log.CDebugf(ctx, "TeamLoader.addSecrets: loop2")
+		mctx.Debug("TeamLoader.addSecrets: loop2")
 	} else {
 		// Discard all cached reader key masks if we are not an explicit member of the team.
 		state.ReaderKeyMasks = make(map[keybase1.TeamApplication]map[keybase1.PerTeamKeyGeneration]keybase1.MaskB64)
 
 		// Also we shouldn't have gotten any from the server.
 		if len(readerKeyMasks) > 0 {
-			l.G().Log.CWarningf(ctx, "TeamLoader got %v reader-key-masks but not an explicit member",
+			mctx.Warning("TeamLoader got %v reader-key-masks but not an explicit member",
 				len(readerKeyMasks))
 		}
 	}
@@ -816,7 +815,7 @@ func (l *TeamLoader) addSecrets(ctx context.Context,
 }
 
 // Check that the RKMs for a generation are covered for all apps.
-func (l *TeamLoader) checkReaderKeyMaskCoverage(ctx context.Context,
+func (l *TeamLoader) checkReaderKeyMaskCoverage(mctx libkb.MetaContext,
 	state *keybase1.TeamData, gen keybase1.PerTeamKeyGeneration) error {
 
 	for _, app := range keybase1.TeamApplicationMap {
@@ -841,10 +840,10 @@ func (l *TeamLoader) checkReaderKeyMaskCoverage(ctx context.Context,
 // TODO: return the signer and have the caller check it. Not critical because the public half is checked anyway.
 // Returns the generation of the box (the greatest generation),
 // and a list of the seeds in ascending generation order.
-func (l *TeamLoader) unboxPerTeamSecrets(ctx context.Context,
+func (l *TeamLoader) unboxPerTeamSecrets(mctx libkb.MetaContext,
 	box *TeamBox, prevs map[keybase1.PerTeamKeyGeneration]prevKeySealedEncoded) (keybase1.PerTeamKeyGeneration, []keybase1.PerTeamKeySeed, error) {
 
-	return unboxPerTeamSecrets(libkb.NewMetaContext(ctx, l.G()), l.world, box, prevs)
+	return unboxPerTeamSecrets(mctx, l.world, box, prevs)
 }
 
 func unboxPerTeamSecrets(m libkb.MetaContext, world LoaderContext, box *TeamBox, prevs map[keybase1.PerTeamKeyGeneration]prevKeySealedEncoded) (keybase1.PerTeamKeyGeneration, []keybase1.PerTeamKeySeed, error) {
@@ -967,4 +966,32 @@ func (l *TeamLoader) calculateName(ctx context.Context,
 	}
 
 	return newName, nil
+}
+
+// computeSeedChecks looks at the PerTeamKeySeedsUnverified for the the given team and adds the
+// PerTeamSeedChecks to the sequence. We make the assumption that, potentially, all such links are
+// null because it's a legacy team. OR only the new links are null since they were just added.
+// In either case, after this function runs, all seeds get seed checks computed.
+func (l *TeamLoader) computeSeedChecks(ctx context.Context, state *keybase1.TeamData) (err error) {
+	mctx := libkb.NewMetaContext(ctx, l.G())
+	defer mctx.Trace(fmt.Sprintf("TeamLoader#computeSeedChecks(%s)", state.ID()), func() error { return err })()
+
+	latestChainGen := keybase1.PerTeamKeyGeneration(len(state.PerTeamKeySeedsUnverified))
+	return computeSeedChecks(
+		ctx,
+		state.ID(),
+		latestChainGen,
+		func(g keybase1.PerTeamKeyGeneration) (*keybase1.PerTeamSeedCheck, keybase1.PerTeamKeySeed, error) {
+			ptksu, ok := state.PerTeamKeySeedsUnverified[g]
+			if !ok {
+				return nil, keybase1.PerTeamKeySeed{}, fmt.Errorf("unexpected nil PerTeamKeySeedsUnverified at %d", g)
+			}
+			return ptksu.Check, ptksu.Seed, nil
+		},
+		func(g keybase1.PerTeamKeyGeneration, check keybase1.PerTeamSeedCheck) {
+			ptksu := state.PerTeamKeySeedsUnverified[g]
+			ptksu.Check = &check
+			state.PerTeamKeySeedsUnverified[g] = ptksu
+		},
+	)
 }

--- a/go/teams/loader_chain_test.go
+++ b/go/teams/loader_chain_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	storage "github.com/keybase/client/go/teams/storage"
 
 	jsonw "github.com/keybase/go-jsonw"
 )
@@ -173,7 +174,7 @@ func runUnit(t *testing.T, unit TestCase) (lastLoadRet *Team) {
 		// Install a loader with a mock interface to the outside world.
 		t.Logf("install mock loader")
 		mock := NewMockLoaderContext(t, tc.G, unit)
-		storage := NewStorage(tc.G)
+		storage := storage.NewStorage(tc.G)
 		loader := NewTeamLoader(tc.G, mock, storage)
 		tc.G.SetTeamLoader(loader)
 

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/sig3"
 )
 
 // Things TeamLoader uses that are mocked out for tests.
@@ -28,6 +29,7 @@ type LoaderContext interface {
 	// Get the current user's per-user-key's derived encryption key (full).
 	perUserEncryptionKey(ctx context.Context, userSeqno keybase1.Seqno) (*libkb.NaclDHKeyPair, error)
 	merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error)
+	merkleLookupWithHidden(ctx context.Context, teamID keybase1.TeamID, public bool, harg *libkb.LookupTeamHiddenArg) (r1 keybase1.Seqno, r2 keybase1.LinkID, hiddenIsFresh bool, err error)
 	merkleLookupTripleInPast(ctx context.Context, isPublic bool, leafID keybase1.UserOrTeamID, root keybase1.MerkleRootV2) (triple *libkb.MerkleTriple, err error)
 	forceLinkMapRefreshForUser(ctx context.Context, uid keybase1.UID) (linkMap linkMapT, err error)
 	loadKeyV2(ctx context.Context, uid keybase1.UID, kid keybase1.KID, lkc *loadKeyCache) (keybase1.UserVersion, *keybase1.PublicKeyV2NaCl, linkMapT, error)
@@ -65,10 +67,18 @@ type rawTeam struct {
 	SubteamReader    bool                               `json:"subteam_reader"`
 	Showcase         keybase1.TeamShowcase              `json:"showcase"`
 	LegacyTLFUpgrade []keybase1.TeamGetLegacyTLFUpgrade `json:"legacy_tlf_upgrade"`
+	HiddenChain      []sig3.ExportJSON                  `json:"hidden"`
 }
 
 func (r *rawTeam) GetAppStatus() *libkb.AppStatus {
 	return &r.Status
+}
+
+func (r *rawTeam) GetHiddenChain() []sig3.ExportJSON {
+	if r == nil {
+		return nil
+	}
+	return r.HiddenChain
 }
 
 func (r *rawTeam) unpackLinks(ctx context.Context) ([]*ChainLinkUnpacked, error) {
@@ -141,6 +151,7 @@ func (l *LoaderContextG) getLinksFromServerCommon(ctx context.Context,
 		// At some point to save bandwidth these could be hooked up.
 		// "per_team_key_low":    libkb.I{Val: int(lows.PerTeamKey)},
 		// "reader_key_mask_low": libkb.I{Val: int(lows.PerTeamKey)},
+		arg.Args["hidden_low"] = libkb.I{Val: int(lows.HiddenChainSeqno)}
 	}
 	if len(requestSeqnos) > 0 {
 		arg.Args["seqnos"] = libkb.S{Val: seqnosToString(requestSeqnos)}
@@ -199,27 +210,39 @@ func perUserEncryptionKey(m libkb.MetaContext, userSeqno keybase1.Seqno) (*libkb
 	return kr.GetEncryptionKeyBySeqnoOrSync(m, userSeqno)
 }
 
+func (l *LoaderContextG) merkleLookupWithHidden(ctx context.Context, teamID keybase1.TeamID, public bool, harg *libkb.LookupTeamHiddenArg) (r1 keybase1.Seqno, r2 keybase1.LinkID, hiddenIsFresh bool, err error) {
+	leaf, err := l.G().GetMerkleClient().LookupTeamWithHidden(l.MetaContext(ctx), teamID, harg)
+	r1, r2, hiddenIsFresh, err = l.processMerkleReply(ctx, teamID, public, leaf, err)
+	return r1, r2, hiddenIsFresh, err
+}
+
 func (l *LoaderContextG) merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error) {
 	leaf, err := l.G().GetMerkleClient().LookupTeam(l.MetaContext(ctx), teamID)
-	if err != nil {
-		return r1, r2, err
+	r1, r2, _, err = l.processMerkleReply(ctx, teamID, public, leaf, err)
+	return r1, r2, err
+}
+
+func (l *LoaderContextG) processMerkleReply(ctx context.Context, teamID keybase1.TeamID, public bool, leaf *libkb.MerkleTeamLeaf, ein error) (r1 keybase1.Seqno, r2 keybase1.LinkID, hiddenIsFresh bool, err error) {
+	if ein != nil {
+		return r1, r2, false, ein
 	}
+
 	if !leaf.TeamID.Eq(teamID) {
-		return r1, r2, fmt.Errorf("merkle returned wrong leaf: %v != %v", leaf.TeamID.String(), teamID.String())
+		return r1, r2, false, fmt.Errorf("merkle returned wrong leaf: %v != %v", leaf.TeamID.String(), teamID.String())
 	}
 
 	if public {
 		if leaf.Public == nil {
 			l.G().Log.CDebugf(ctx, "TeamLoader hidden error: merkle returned nil leaf")
-			return r1, r2, NewTeamDoesNotExistError(public, teamID.String())
+			return r1, r2, false, NewTeamDoesNotExistError(public, teamID.String())
 		}
-		return leaf.Public.Seqno, leaf.Public.LinkID.Export(), nil
+		return leaf.Public.Seqno, leaf.Public.LinkID.Export(), leaf.HiddenIsFresh, nil
 	}
 	if leaf.Private == nil {
 		l.G().Log.CDebugf(ctx, "TeamLoader hidden error: merkle returned nil leaf")
-		return r1, r2, NewTeamDoesNotExistError(public, teamID.String())
+		return r1, r2, false, NewTeamDoesNotExistError(public, teamID.String())
 	}
-	return leaf.Private.Seqno, leaf.Private.LinkID.Export(), nil
+	return leaf.Private.Seqno, leaf.Private.LinkID.Export(), leaf.HiddenIsFresh, nil
 }
 
 func (l *LoaderContextG) getCachedCheckpointLookup(leafID keybase1.UserOrTeamID, seqno keybase1.Seqno) *libkb.MerkleGenericLeaf {

--- a/go/teams/loader_ctx_test.go
+++ b/go/teams/loader_ctx_test.go
@@ -226,6 +226,11 @@ func (l *MockLoaderContext) perUserEncryptionKey(ctx context.Context, userSeqno 
 	return key, err
 }
 
+func (l *MockLoaderContext) merkleLookupWithHidden(ctx context.Context, teamID keybase1.TeamID, public bool, harg *libkb.LookupTeamHiddenArg) (r1 keybase1.Seqno, r2 keybase1.LinkID, isFresh bool, err error) {
+	r1, r2, err = l.merkleLookup(ctx, teamID, public)
+	return r1, r2, true, err
+}
+
 func (l *MockLoaderContext) merkleLookup(ctx context.Context, teamID keybase1.TeamID, public bool) (r1 keybase1.Seqno, r2 keybase1.LinkID, err error) {
 	key := fmt.Sprintf("%s", teamID)
 	if l.state.loadSpec.Upto > 0 {

--- a/go/teams/loader_test.go
+++ b/go/teams/loader_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +26,7 @@ func TestLoaderBasic(t *testing.T) {
 	teamName, teamID := createTeam2(tc)
 
 	t.Logf("load the team")
-	team, err := tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -33,7 +34,7 @@ func TestLoaderBasic(t *testing.T) {
 	require.True(t, teamName.Eq(team.Name))
 
 	t.Logf("load the team again")
-	team, err = tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err = tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -57,7 +58,7 @@ func TestLoaderStaleNoUpdates(t *testing.T) {
 	teamName, teamID := createTeam2(tc)
 
 	t.Logf("load the team")
-	team, err := tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:     teamID,
 		Public: public,
 	})
@@ -78,7 +79,7 @@ func TestLoaderStaleNoUpdates(t *testing.T) {
 	t.Logf("cache post-set cachedAt:%v", team.CachedAt.Time())
 
 	t.Logf("load the team again")
-	team, err = tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err = tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:     teamID,
 		Public: public,
 	})
@@ -100,7 +101,7 @@ func TestLoaderByName(t *testing.T) {
 	teamName, teamID := createTeam2(tc)
 
 	t.Logf("load the team")
-	team, err := tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		Name: teamName.String(),
 	})
 	require.NoError(t, err)
@@ -130,7 +131,7 @@ func TestLoaderKeyGen(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("B's first load at gen 1")
-	team, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -149,7 +150,7 @@ func TestLoaderKeyGen(t *testing.T) {
 	}
 
 	t.Logf("load as A to check the progression")
-	team, err = tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err = tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:          teamID,
 		ForceRepoll: true,
 	})
@@ -159,7 +160,7 @@ func TestLoaderKeyGen(t *testing.T) {
 	require.Len(t, team.ReaderKeyMasks[keybase1.TeamApplication_KBFS], 4, "number of kbfs rkms")
 
 	t.Logf("B loads and hits its cache")
-	team, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -168,7 +169,7 @@ func TestLoaderKeyGen(t *testing.T) {
 	require.Len(t, team.ReaderKeyMasks[keybase1.TeamApplication_KBFS], 1, "number of kbfs rkms")
 
 	t.Logf("B loads with NeedKeyGeneration")
-	team, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 		Refreshers: keybase1.TeamRefreshers{
 			NeedKeyGeneration: 3,
@@ -299,7 +300,7 @@ func TestLoaderWantMembers(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads and caches")
-	team, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -310,7 +311,7 @@ func TestLoaderWantMembers(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads and hits the cache")
-	team, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -318,7 +319,7 @@ func TestLoaderWantMembers(t *testing.T) {
 
 	t.Logf("U1 loads with WantMembers=U2 and that causes a repoll but no error")
 	loadAsU1WantU2 := func() *keybase1.TeamData {
-		team, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+		team, _, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 			ID: teamID,
 			Refreshers: keybase1.TeamRefreshers{
 				WantMembers: []keybase1.UserVersion{fus[2].GetUserVersion()},
@@ -363,7 +364,7 @@ func TestLoaderParentEasy(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("load the parent")
-	team, err := tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:          teamID,
 		ForceRepoll: true,
 	})
@@ -372,7 +373,7 @@ func TestLoaderParentEasy(t *testing.T) {
 	require.False(t, TeamSigChainState{inner: team.Chain}.HasAnyStubbedLinks(), "team has stubbed links")
 	subteamName, err := TeamSigChainState{inner: team.Chain}.GetSubteamName(*subteamID)
 	if err != nil {
-		t.Logf("seqno: %v", TeamSigChainState{team.Chain}.GetLatestSeqno())
+		t.Logf("seqno: %v", TeamSigChainState{inner: team.Chain}.GetLatestSeqno())
 		t.Logf("subteam log: %v", spew.Sdump(team.Chain.SubteamLog))
 		require.NoError(t, err)
 	}
@@ -394,7 +395,7 @@ func TestLoaderSubteamEasy(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("load the subteam")
-	team, err := tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: *subteamID,
 	})
 	require.NoError(t, err)
@@ -425,7 +426,7 @@ func TestLoaderFillStubbed(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads the parent")
-	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: parentID,
 	})
 	require.NoError(t, err)
@@ -437,7 +438,7 @@ func TestLoaderFillStubbed(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads the subteam")
-	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: *subteamID,
 	})
 	require.NoError(t, err)
@@ -463,7 +464,7 @@ func TestLoaderNotInParent(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads the subteam")
-	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: *subteamID,
 	})
 	require.NoError(t, err)
@@ -496,7 +497,7 @@ func TestLoaderMultilevel(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("load the subteam")
-	team, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: *subsubteamID,
 	})
 	require.NoError(t, err)
@@ -523,7 +524,7 @@ func TestLoaderInferWantMembers(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads and caches")
-	team, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -534,7 +535,7 @@ func TestLoaderInferWantMembers(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads and hits the cache")
-	team, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -542,7 +543,7 @@ func TestLoaderInferWantMembers(t *testing.T) {
 
 	t.Logf("U1 loads with WantMembers=U2 which infers the eldestseqno and repolls")
 	loadAsU1WantU2 := func() *keybase1.TeamData {
-		team, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+		team, _, err := tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 			ID: teamID,
 			Refreshers: keybase1.TeamRefreshers{
 				WantMembers: []keybase1.UserVersion{keybase1.UserVersion{
@@ -842,7 +843,7 @@ func TestInflateAfterPermissionsChange(t *testing.T) {
 	require.NotNil(t, rootData, "root team should be cached")
 	require.False(t, frozen)
 	require.False(t, tombstoned)
-	require.True(t, (TeamSigChainState{rootData.Chain}).HasAnyStubbedLinks(), "root team should have a stubbed link")
+	require.True(t, (TeamSigChainState{inner: rootData.Chain}).HasAnyStubbedLinks(), "root team should have a stubbed link")
 
 	t.Logf("U0 adds U2 to lair")
 	_, err = AddMember(context.Background(), tcs[0].G, subteamLairName.String(), fus[2].Username, keybase1.TeamRole_WRITER)
@@ -1024,7 +1025,7 @@ func TestLoaderUpgradeMerkleHead(t *testing.T) {
 	teamName, teamID := createTeam2(tc)
 
 	t.Logf("load the team")
-	team, err := tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err := tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -1032,7 +1033,7 @@ func TestLoaderUpgradeMerkleHead(t *testing.T) {
 	require.True(t, teamName.Eq(team.Name))
 
 	t.Logf("load the team again")
-	team, err = tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	team, _, err = tc.G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	require.NoError(t, err)
@@ -1155,7 +1156,7 @@ func randomTlfID(t *testing.T) keybase1.TLFID {
 	return keybase1.TLFID(hex.EncodeToString(idBytes))
 }
 
-func getFastStorageFromG(g *libkb.GlobalContext) *FTLStorage {
+func getFastStorageFromG(g *libkb.GlobalContext) *storage.FTLStorage {
 	tl := g.GetFastTeamLoader().(*FastTeamChainLoader)
 	return tl.storage
 }
@@ -1211,7 +1212,7 @@ func freezeTest(t *testing.T, freezeAction freezeF, unfreezeAction freezeF) {
 	require.NoError(t, err)
 
 	// Load chains again, forcing repoll
-	_, err = tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:     rootID,
 		Public: rootID.IsPublic(),
 	})
@@ -1302,7 +1303,7 @@ func TestTombstoneViaDelete(t *testing.T) {
 	require.NotNil(t, ftd.Chain.Last)
 
 	// Load chains again, should error due to tombstone
-	_, err = tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[0].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:     rootID,
 		Public: rootID.IsPublic(),
 	})

--- a/go/teams/rename_test.go
+++ b/go/teams/rename_test.go
@@ -93,7 +93,7 @@ func TestRenameInflateSubteamAfterRenameParent(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads A.B1 (will have stubbed link and new name)")
-	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:          *subteamID,
 		ForceRepoll: true,
 	})
@@ -104,7 +104,7 @@ func TestRenameInflateSubteamAfterRenameParent(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads A.B2.C which will cause it to inflate the new_subteam link in A.B2")
-	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:          *subsubteamID,
 		ForceRepoll: true,
 	})
@@ -145,7 +145,7 @@ func TestRenameIntoMovedSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads R")
-	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:          parentName.ToPrivateTeamID(),
 		ForceRepoll: true,
 	})
@@ -169,7 +169,7 @@ func TestRenameIntoMovedSubteam(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("U1 loads R")
-	_, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
+	_, _, err = tcs[1].G.GetTeamLoader().Load(context.TODO(), keybase1.LoadTeamArg{
 		ID:          parentName.ToPrivateTeamID(),
 		ForceRepoll: true,
 	})

--- a/go/teams/rotate_hidden_test.go
+++ b/go/teams/rotate_hidden_test.go
@@ -1,0 +1,62 @@
+package teams
+
+import (
+	"context"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRotateHiddenSelf(t *testing.T) {
+	tc, owner, other, _, name := memberSetupMultiple(t)
+	defer tc.Cleanup()
+
+	err := SetRoleWriter(context.TODO(), tc.G, name, other.Username)
+	require.NoError(t, err)
+	team, err := GetForTestByStringName(context.TODO(), tc.G, name)
+	require.NoError(t, err)
+	require.Equal(t, keybase1.PerTeamKeyGeneration(1), team.Generation())
+
+	secretBefore := team.Data.PerTeamKeySeedsUnverified[team.Generation()].Seed.ToBytes()
+	keys1, err := team.AllApplicationKeys(context.TODO(), keybase1.TeamApplication_CHAT)
+	require.NoError(t, err)
+	require.Equal(t, len(keys1), 1)
+	require.Equal(t, keys1[0].KeyGeneration, keybase1.PerTeamKeyGeneration(1))
+
+	err = team.Rotate(context.TODO())
+	require.NoError(t, err)
+	after, err := GetForTestByStringName(context.TODO(), tc.G, name)
+	require.NoError(t, err)
+	require.Equal(t, keybase1.PerTeamKeyGeneration(2), after.Generation())
+	secretAfter := after.Data.PerTeamKeySeedsUnverified[after.Generation()].Seed.ToBytes()
+	require.False(t, libkb.SecureByteArrayEq(secretAfter, secretBefore))
+	assertRole(tc, name, owner.Username, keybase1.TeamRole_OWNER)
+	assertRole(tc, name, other.Username, keybase1.TeamRole_WRITER)
+
+	keys2, err := after.AllApplicationKeys(context.TODO(), keybase1.TeamApplication_CHAT)
+	require.NoError(t, err)
+	require.Equal(t, len(keys2), 2)
+	require.Equal(t, keys2[0].KeyGeneration, keybase1.PerTeamKeyGeneration(1))
+	require.Equal(t, keys1[0].Key, keys2[0].Key)
+
+	for i := 0; i < 3; i++ {
+		team, err = GetForTestByStringName(context.TODO(), tc.G, name)
+		require.NoError(t, err)
+		err = team.RotateHidden(context.TODO())
+		require.NoError(t, err)
+		team, err = GetForTestByStringName(context.TODO(), tc.G, name)
+		require.NoError(t, err)
+		err = team.Rotate(context.TODO())
+		require.NoError(t, err)
+		team, err = GetForTestByStringName(context.TODO(), tc.G, name)
+		require.NoError(t, err)
+	}
+
+	keys3, err := team.AllApplicationKeys(context.TODO(), keybase1.TeamApplication_CHAT)
+	require.NoError(t, err)
+	require.Equal(t, len(keys3), 8)
+	require.Equal(t, keys3[0].KeyGeneration, keybase1.PerTeamKeyGeneration(1))
+	require.Equal(t, keys1[0].Key, keys3[0].Key)
+	require.Equal(t, keys2[1].Key, keys3[1].Key)
+}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1277,7 +1277,7 @@ func apiArg(endpoint string) libkb.APIArg {
 }
 
 func GetRootID(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (keybase1.TeamID, error) {
-	team, err := g.GetTeamLoader().Load(ctx, keybase1.LoadTeamArg{
+	team, _, err := g.GetTeamLoader().Load(ctx, keybase1.LoadTeamArg{
 		ID:      id,
 		Public:  id.IsPublic(),
 		StaleOK: true,

--- a/go/teams/sig.go
+++ b/go/teams/sig.go
@@ -264,12 +264,14 @@ func seqTypeForTeamPublicness(public bool) keybase1.SeqType {
 }
 
 func precheckLinkToPost(ctx context.Context, g *libkb.GlobalContext,
-	sigMultiItem libkb.SigMultiItem, state *TeamSigChainState, me keybase1.UserVersion) (err error) {
+	sigMultiItem libkb.SigMultiItem, state *TeamSigChainState,
+	me keybase1.UserVersion) (err error) {
 	return precheckLinksToPost(ctx, g, []libkb.SigMultiItem{sigMultiItem}, state, me)
 }
 
 func precheckLinksToPost(ctx context.Context, g *libkb.GlobalContext,
-	sigMultiItems []libkb.SigMultiItem, state *TeamSigChainState, me keybase1.UserVersion) (err error) {
+	sigMultiItems []libkb.SigMultiItem, state *TeamSigChainState,
+	me keybase1.UserVersion) (err error) {
 
 	defer g.CTraceTimed(ctx, "precheckLinksToPost", func() error { return err })()
 

--- a/go/teams/storage/ftl.go
+++ b/go/teams/storage/ftl.go
@@ -1,4 +1,4 @@
-package teams
+package storage
 
 import (
 	"fmt"

--- a/go/teams/storage/generic.go
+++ b/go/teams/storage/generic.go
@@ -1,4 +1,4 @@
-package teams
+package storage
 
 import (
 	"fmt"
@@ -70,8 +70,12 @@ func (s *storageGeneric) get(mctx libkb.MetaContext, teamID keybase1.TeamID, pub
 }
 
 // Clear the in-memory storage.
-func (s *storageGeneric) clearMem() {
+func (s *storageGeneric) ClearMem() {
 	s.mem.clear()
+}
+
+func (s *storageGeneric) MemSize() int {
+	return s.mem.lru.Len()
 }
 
 // --------------------------------------------------

--- a/go/teams/storage/hidden.go
+++ b/go/teams/storage/hidden.go
@@ -1,0 +1,70 @@
+package storage
+
+import (
+	"fmt"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// HiddenStorage stores Hidden state to disk or memory.
+type HiddenStorage struct {
+	*storageGeneric
+}
+
+// Increment to invalidate the disk cache.
+const hiddenDiskStorageVersion = 1
+const hiddenMemCacheLRUSize = 200
+
+type hiddenDiskStorageItem struct {
+	Version int                       `codec:"V"`
+	State   *keybase1.HiddenTeamChain `codec:"S"`
+}
+
+var _ teamDataGeneric = (*keybase1.HiddenTeamChain)(nil)
+var _ diskItemGeneric = (*hiddenDiskStorageItem)(nil)
+
+func (d *hiddenDiskStorageItem) version() int {
+	return d.Version
+}
+func (d *hiddenDiskStorageItem) value() teamDataGeneric {
+	return d.State
+}
+func (d *hiddenDiskStorageItem) setVersion(i int) {
+	d.Version = i
+}
+func (d *hiddenDiskStorageItem) setValue(v teamDataGeneric) error {
+	typed, ok := v.(*keybase1.HiddenTeamChain)
+	if !ok {
+		return fmt.Errorf("teams.HiddenStorage#Put: Bad object for setValue; got type %T", v)
+	}
+	d.State = typed
+	return nil
+}
+
+func NewHiddenStorage(g *libkb.GlobalContext) *HiddenStorage {
+	s := newStorageGeneric(g, hiddenMemCacheLRUSize, hiddenDiskStorageVersion, libkb.DBHiddenChainStorage, libkb.EncryptionReasonTeamsHiddenLocalStorage, "hidden", func() diskItemGeneric { return &hiddenDiskStorageItem{} })
+	return &HiddenStorage{s}
+}
+
+func (s *HiddenStorage) Put(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain) {
+	s.storageGeneric.put(mctx, state)
+}
+
+// Can return nil.
+func (s *HiddenStorage) Get(mctx libkb.MetaContext, teamID keybase1.TeamID, public bool) (state *keybase1.HiddenTeamChain, frozen bool, tombstoned bool) {
+	vp := s.storageGeneric.get(mctx, teamID, public)
+	if vp == nil {
+		return nil, false, false
+	}
+	ret, ok := vp.(*keybase1.HiddenTeamChain)
+	if !ok {
+		mctx.Debug("teams.HiddenStorage#Get cast error: %T is wrong type", vp)
+	}
+	if ret.Frozen {
+		mctx.Debug("returning frozen hidden team data")
+	}
+	if ret.Tombstoned {
+		mctx.Debug("returning tombstoned hidden team data")
+	}
+	return ret, ret.Frozen, ret.Tombstoned
+}

--- a/go/teams/storage/std.go
+++ b/go/teams/storage/std.go
@@ -1,4 +1,4 @@
-package teams
+package storage
 
 import (
 	"fmt"

--- a/go/teams/storage_test.go
+++ b/go/teams/storage_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	storage "github.com/keybase/client/go/teams/storage"
 	"github.com/stretchr/testify/require"
 )
 
-func getStorageFromG(g *libkb.GlobalContext) *Storage {
+func getStorageFromG(g *libkb.GlobalContext) *storage.Storage {
 	tl := g.GetTeamLoader().(*TeamLoader)
 	return tl.storage
 }
@@ -66,7 +67,7 @@ func TestStorageDisk(t *testing.T) {
 		require.Nil(t, res)
 		st.Put(mctx, &obj)
 		t.Logf("throwing out mem storage")
-		st.mem.lru.Purge()
+		st.ClearMem()
 		res, _, _ = st.Get(mctx, teamID, public)
 		require.NotNil(t, res, "cache miss")
 		require.False(t, res == &obj, "should be the a different object read from disk")
@@ -101,7 +102,7 @@ func TestStorageLogout(t *testing.T) {
 		t.Logf("logout")
 		tc.G.Logout(context.TODO())
 
-		require.Equal(t, 0, st.mem.lru.Len(), "mem cache still populated")
+		require.Equal(t, 0, st.MemSize(), "mem cache still populated")
 
 		res, _, _ = st.Get(mctx, teamID, public)
 		require.Nil(t, res, "got from cache, but should be gone")

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -17,8 +17,14 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	hidden "github.com/keybase/client/go/teams/hidden"
 	jsonw "github.com/keybase/go-jsonw"
 )
+
+type Teamer interface {
+	MainChain() *keybase1.TeamData
+	HiddenChain() *keybase1.HiddenTeamChain
+}
 
 // A snapshot of a team's state.
 // Not threadsafe.
@@ -35,13 +41,18 @@ type Team struct {
 	rotated bool
 }
 
-func NewTeam(ctx context.Context, g *libkb.GlobalContext, teamData *keybase1.TeamData) *Team {
-	chain := TeamSigChainState{teamData.Chain}
+func (t *Team) MainChain() *keybase1.TeamData          { return t.Data }
+func (t *Team) HiddenChain() *keybase1.HiddenTeamChain { return t.Hidden }
+
+var _ Teamer = (*Team)(nil)
+
+func NewTeam(ctx context.Context, g *libkb.GlobalContext, teamData *keybase1.TeamData, hidden *keybase1.HiddenTeamChain) *Team {
 	return &Team{
 		Contextified: libkb.NewContextified(g),
 
-		ID:   chain.GetID(),
-		Data: teamData,
+		ID:     teamData.ID(),
+		Data:   teamData,
+		Hidden: hidden,
 	}
 }
 
@@ -82,7 +93,7 @@ func (t *Team) CanSkipKeyRotation() bool {
 }
 
 func (t *Team) chain() *TeamSigChainState {
-	return &TeamSigChainState{inner: t.Data.Chain}
+	return &TeamSigChainState{inner: t.Data.Chain, hidden: t.Hidden}
 }
 
 func (t *Team) Name() keybase1.TeamName {
@@ -132,11 +143,11 @@ func (t *Team) KBFSCryptKeys(ctx context.Context, appType keybase1.TeamApplicati
 func (t *Team) getKeyManager(ctx context.Context) (km *TeamKeyManager, err error) {
 	if t.keyManager == nil {
 		gen := t.chain().GetLatestGeneration()
-		item, err := GetAndVerifyPerTeamKey(libkb.NewMetaContext(ctx, t.G()), t.Data, gen)
+		item, err := GetAndVerifyPerTeamKey(t.MetaContext(ctx), t, gen)
 		if err != nil {
 			return nil, err
 		}
-		t.keyManager, err = NewTeamKeyManagerWithSecret(item.Seed, gen)
+		t.keyManager, err = NewTeamKeyManagerWithSeedItem(t.ID, item)
 		if err != nil {
 			return nil, err
 		}
@@ -198,11 +209,11 @@ func (t *Team) EncryptionKey(ctx context.Context) (key libkb.NaclDHKeyPair, err 
 }
 
 func (t *Team) encryptionKeyAtGen(ctx context.Context, gen keybase1.PerTeamKeyGeneration) (key libkb.NaclDHKeyPair, err error) {
-	item, err := GetAndVerifyPerTeamKey(libkb.NewMetaContext(ctx, t.G()), t.Data, gen)
+	item, err := GetAndVerifyPerTeamKey(libkb.NewMetaContext(ctx, t.G()), t, gen)
 	if err != nil {
 		return key, err
 	}
-	keyManager, err := NewTeamKeyManagerWithSecret(item.Seed, gen)
+	keyManager, err := NewTeamKeyManagerWithSeedItem(t.ID, item)
 	if err != nil {
 		return key, err
 	}
@@ -426,11 +437,11 @@ func (t *Team) CurrentSeqno() keybase1.Seqno {
 }
 
 func (t *Team) AllApplicationKeys(ctx context.Context, application keybase1.TeamApplication) (res []keybase1.TeamApplicationKey, err error) {
-	return AllApplicationKeys(t.MetaContext(ctx), t.Data, application, t.chain().GetLatestGeneration())
+	return AllApplicationKeys(t.MetaContext(ctx), t, application, t.chain().GetLatestGeneration())
 }
 
 func (t *Team) AllApplicationKeysWithKBFS(ctx context.Context, application keybase1.TeamApplication) (res []keybase1.TeamApplicationKey, err error) {
-	return AllApplicationKeysWithKBFS(t.MetaContext(ctx), t.Data, application,
+	return AllApplicationKeysWithKBFS(t.MetaContext(ctx), t, application,
 		t.chain().GetLatestGeneration())
 }
 
@@ -442,12 +453,12 @@ func (t *Team) ApplicationKey(ctx context.Context, application keybase1.TeamAppl
 
 func (t *Team) ApplicationKeyAtGeneration(ctx context.Context,
 	application keybase1.TeamApplication, generation keybase1.PerTeamKeyGeneration) (res keybase1.TeamApplicationKey, err error) {
-	return ApplicationKeyAtGeneration(t.MetaContext(ctx), t.Data, application, generation)
+	return ApplicationKeyAtGeneration(t.MetaContext(ctx), t, application, generation)
 }
 
 func (t *Team) ApplicationKeyAtGenerationWithKBFS(ctx context.Context,
 	application keybase1.TeamApplication, generation keybase1.PerTeamKeyGeneration) (res keybase1.TeamApplicationKey, err error) {
-	return ApplicationKeyAtGenerationWithKBFS(t.MetaContext(ctx), t.Data, application, generation)
+	return ApplicationKeyAtGenerationWithKBFS(t.MetaContext(ctx), t, application, generation)
 }
 
 func addSummaryHash(section *SCTeamSection, boxes *PerTeamSharedSecretBoxes) error {
@@ -467,14 +478,20 @@ func (t *Team) Rotate(ctx context.Context) (err error) {
 	return t.rotate(ctx, false /* hidden */)
 }
 
+func (t *Team) RotateHidden(ctx context.Context) (err error) {
+	return t.rotate(ctx, true)
+}
+
 func (t *Team) rotate(ctx context.Context, hidden bool) (err error) {
+	mctx := t.MetaContext(ctx).WithLogTag("ROT")
+	defer mctx.Trace(fmt.Sprintf("Team#rotate(%s,%v)", t.ID, hidden), func() error { return err })()
 
 	// initialize key manager
-	if _, err := t.SharedSecret(ctx); err != nil {
+	if _, err := t.SharedSecret(mctx.Ctx()); err != nil {
 		return err
 	}
 
-	mr, err := t.G().MerkleClient.FetchRootFromServer(t.MetaContext(ctx), libkb.TeamMerkleFreshnessForAdmin)
+	mr, err := t.G().MerkleClient.FetchRootFromServer(mctx, libkb.TeamMerkleFreshnessForAdmin)
 	if err != nil {
 		return err
 	}
@@ -484,13 +501,13 @@ func (t *Team) rotate(ctx context.Context, hidden bool) (err error) {
 
 	// Try to get the admin perms if they are available, if not, proceed anyway
 	var admin *SCTeamAdmin
-	admin, err = t.getAdminPermission(ctx)
+	admin, err = t.getAdminPermission(mctx.Ctx())
 	if err != nil {
-		t.G().Log.CDebugf(ctx, "Rotate: unable to get admin permission: %v, attempting without admin section", err)
+		mctx.Debug("Rotate: unable to get admin permission: %v, attempting without admin section", err)
 		admin = nil
 	}
 
-	if err := t.ForceMerkleRootUpdate(ctx); err != nil {
+	if err := t.ForceMerkleRootUpdate(mctx.Ctx()); err != nil {
 		return err
 	}
 
@@ -508,7 +525,7 @@ func (t *Team) rotate(ctx context.Context, hidden bool) (err error) {
 	}
 
 	// rotate the team key for all current members
-	secretBoxes, perTeamKeySection, teamEKPayload, err := t.rotateBoxes(ctx, memSet)
+	secretBoxes, perTeamKeySection, teamEKPayload, err := t.rotateBoxes(mctx.Ctx(), memSet)
 	if err != nil {
 		return err
 	}
@@ -526,15 +543,15 @@ func (t *Team) rotate(ctx context.Context, hidden bool) (err error) {
 	}
 
 	if !hidden {
-		err = t.rotatePostVisible(ctx, section, mr, payloadArgs)
+		err = t.rotatePostVisible(mctx.Ctx(), section, mr, payloadArgs)
 	} else {
-		err = t.rotatePostHidden(ctx, section, mr, payloadArgs)
+		err = t.rotatePostHidden(mctx.Ctx(), section, mr, payloadArgs)
 	}
 	if err != nil {
 		return err
 	}
 
-	t.storeTeamEKPayload(ctx, teamEKPayload)
+	t.storeTeamEKPayload(mctx.Ctx(), teamEKPayload)
 
 	return nil
 }
@@ -549,7 +566,83 @@ func (t *Team) rotatePostVisible(ctx context.Context, section SCTeamSection, mr 
 }
 
 func (t *Team) rotatePostHidden(ctx context.Context, section SCTeamSection, mr *libkb.MerkleRoot, payloadArgs sigPayloadArgs) error {
-	return errors.New("Team@rotatePostHidden unimplemented")
+	mctx := libkb.NewMetaContext(ctx, t.G())
+
+	// Generate a "sig multi item" that we POST up to the API endpoint
+	smi, ratchet, err := t.rotateHiddenGenerateSigMultiItem(mctx, section, mr)
+	if err != nil {
+		return err
+	}
+
+	// Combine the "sig multi item" above with the various off-chain items, like boxes.
+	payload := t.sigPayload([]libkb.SigMultiItem{*smi}, payloadArgs)
+
+	// Post the changes up to the server
+	err = t.postMulti(mctx, payload)
+	if err != nil {
+		return err
+	}
+
+	// Inform local caching that we've ratcheted forward the hidden chain with a change
+	// that we made.
+	tmp := mctx.G().GetHiddenTeamChainManager().Ratchet(mctx, t.ID, *ratchet)
+	if tmp != nil {
+		mctx.Warning("Failed to ratchet forward team chain: %s", tmp.Error())
+	}
+
+	return err
+}
+
+func (t *Team) rotateHiddenGenerateSigMultiItem(mctx libkb.MetaContext, section SCTeamSection, mr *libkb.MerkleRoot) (ret *libkb.SigMultiItem, ratchet *keybase1.HiddenTeamChainRatchet, err error) {
+
+	currentSeqno := t.CurrentSeqno()
+	lastLinkID := t.chain().GetLatestLinkID()
+
+	mainChainPrev := keybase1.LinkTriple{
+		Seqno:   currentSeqno,
+		SeqType: keybase1.SeqType_SEMIPRIVATE,
+		LinkID:  lastLinkID,
+	}
+
+	me, err := loadMeForSignatures(mctx.Ctx(), mctx.G())
+	if err != nil {
+		return nil, nil, err
+	}
+	deviceSigningKey, err := t.G().ActiveDevice.SigningKey()
+	if err != nil {
+		return nil, nil, err
+	}
+	hiddenPrev, err := t.G().GetHiddenTeamChainManager().Tail(mctx, t.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sk, err := t.keyManager.SigningKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ek, err := t.keyManager.EncryptionKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ret, ratchet, err = hidden.GenerateKeyRotation(mctx, hidden.GenerateKeyRotationParams{
+		TeamID:           t.ID,
+		IsPublic:         t.IsPublic(),
+		IsImplicit:       t.IsImplicit(),
+		MerkleRoot:       mr,
+		Me:               me,
+		SigningKey:       deviceSigningKey,
+		MainPrev:         mainChainPrev,
+		HiddenPrev:       hiddenPrev,
+		Gen:              t.keyManager.Generation(),
+		NewSigningKey:    sk,
+		NewEncryptionKey: ek,
+		Check:            t.keyManager.Check(),
+	})
+
+	return ret, ratchet, err
 }
 
 func (t *Team) isAdminOrOwner(m keybase1.UserVersion) (res bool, err error) {
@@ -2174,4 +2267,21 @@ func TombstoneTeam(mctx libkb.MetaContext, teamID keybase1.TeamID) error {
 		mctx.Debug("error tombstoning in fast team cache: %v", err2)
 	}
 	return libkb.CombineErrors(err1, err2)
+}
+
+type TeamShim struct {
+	Data   *keybase1.TeamData
+	Hidden *keybase1.HiddenTeamChain
+}
+
+func (t *TeamShim) MainChain() *keybase1.TeamData          { return t.Data }
+func (t *TeamShim) HiddenChain() *keybase1.HiddenTeamChain { return t.Hidden }
+
+var _ Teamer = (*TeamShim)(nil)
+
+func KeySummary(t Teamer) string {
+	if t == nil {
+		return "Ø"
+	}
+	return fmt.Sprintf("{main:%s, hidden:%s}", t.MainChain().KeySummary(), t.HiddenChain().KeySummary())
 }

--- a/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/ptk_future.json
+++ b/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/ptk_future.json
@@ -217,7 +217,7 @@
                 {
                     "force_last_box": true,
                     "error": true,
-                    "error_substr": "wrong latest key generation"
+                    "error_substr": "per-team-key not found for generation"
                 }
             ]
         }

--- a/protocol/avdl/keybase1/common.avdl
+++ b/protocol/avdl/keybase1/common.avdl
@@ -55,6 +55,9 @@ protocol Common {
   @typedef("string")
   record LinkID {}
 
+  @typedef("bytes")
+  record BinaryLinkID {}
+
   // But sometimes we need binary kids...
   @typedef("bytes")
   record BinaryKID {}
@@ -115,7 +118,9 @@ protocol Common {
     NONE_0,
     PUBLIC_1,
     PRIVATE_2,
-    SEMIPRIVATE_3
+    SEMIPRIVATE_3,
+    USER_PRIVATE_HIDDEN_16,
+    TEAM_PRIVATE_HIDDEN_17
   }
 
   fixed Bytes32(32);

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -41,6 +41,39 @@ protocol teams {
     READER_0
   }
 
+  enum PerTeamSeedCheckVersion {
+    V1_1
+  }
+
+  // Version1 of PerTeamSeedCheck is computed as follows:
+  //
+  //   Let g(key,data) = HMAC-SHA512(key,data)[0:32]
+  //       f(1) = g(s_1, "Kebase-Derived-Team-Seedcheck-1\x00" + teamID)
+  //       f(2) = g(s_2, f(1))
+  //       ...
+  //       f(i) = g(s_i, f(i-1))
+  //
+  record PerTeamSeedCheck {
+     PerTeamSeedCheckVersion version;
+     PerTeamSeedCheckValue value; // f(i) for generation i
+  }
+
+  @typedef("bytes")
+  record PerTeamSeedCheckValue {}
+
+  @typedef("bytes")
+  record PerTeamSeedCheckValuePostImage {}
+
+  // Teamlinks that the server can see don't get PerTeamSeedCheck, since it would allow the
+  // server to fabricate new ones. The server gets to see the postimage of these checks
+  // after a SHA256 one-way function.
+  record PerTeamSeedCheckPostImage {
+     @mpackkey("h") @jsonkey("h")
+     PerTeamSeedCheckValuePostImage value; // SHA256(f(i)) for generation i
+     @mpackkey("v") @jsonkey("v")
+     PerTeamSeedCheckVersion version;
+  }
+
   record TeamApplicationKey {
     TeamApplication application;
     PerTeamKeyGeneration keyGeneration;
@@ -62,9 +95,15 @@ protocol teams {
   @lint("ignore")
   record PerTeamKey {
     PerTeamKeyGeneration gen;
-    Seqno seqno;
+    Seqno seqno; // 0 if in the hidden chain
     KID sigKID;
     KID encKID;
+  }
+
+  @lint("ignore")
+  record PerTeamKeyAndCheck {
+     PerTeamKey ptk;
+     PerTeamSeedCheckPostImage check;
   }
 
   fixed PerTeamKeySeed(32);
@@ -73,7 +112,12 @@ protocol teams {
   record PerTeamKeySeedItem {
     PerTeamKeySeed seed;
     PerTeamKeyGeneration generation;
+
+    // This might be optional, for PTKSeeds that come from the hidden chain
     Seqno seqno;
+
+    // This was added 2019-06, so earlier-cached teams might not have this.
+    union { null, PerTeamSeedCheck } check;
   }
 
   record TeamMember {
@@ -216,6 +260,19 @@ protocol teams {
     @mpackkey("perTeamKeySeeds")
     map<PerTeamKeyGeneration,PerTeamKeySeed> perTeamKeySeedsUnverified;
 
+    // If we're counting up from 1, what's the maximum PTK generation
+    // we get to before we hit a gap. For historical reasons, this might
+    // be a number other than latestKeyGeneration, since we used to be happy
+    // with situations where there were holes. Once this value is set, it shoud
+    // be equivalent to latestKeyGeneration.
+    @lint("ignore")
+    PerTeamKeyGeneration maxContinuousPTKGeneration;
+
+    // A rolling hash of all seeds, so that whoever rekeys needs to prove
+    // knowledge of all keys. Entirely derivable from the above field,
+    // but we cache it here for performance.
+    map<PerTeamKeyGeneration,PerTeamSeedCheck> seedChecks;
+
     PerTeamKeyGeneration latestKeyGeneration;
 
     // application -> generation -> mask
@@ -235,11 +292,26 @@ protocol teams {
     boolean loadedLatest;
   }
 
-  record HiddenTeamChainData {
-    @lint("ignore") TeamID ID;
+  record HiddenTeamChainRatchet{
+    union { null, LinkTripleAndTime } main;
+    union { null, LinkTripleAndTime } blinded;
+    union { null, LinkTripleAndTime } self; // if we actually bumped something locally, then this ratchet moves forward
+  }
+
+  record HiddenTeamChain {
+    TeamID id;
+
+    int subversion;
+
     boolean public;
+    boolean frozen;
+    boolean tombstoned;
 
     Seqno last;
+
+    // For each PTK type (right now only 'reader'), say where the last seqno of
+    // the type is in the chain.
+    map<PTKType, Seqno> lastPerTeamKeys;
 
     // Chain links based on outer objects.
     map<Seqno, LinkID> outer;
@@ -248,23 +320,14 @@ protocol teams {
     // parent chain pointer info, and also PTK information (inner data);
     map<Seqno, HiddenTeamChainLink> inner;
 
-  }
-
-  // Snapshot of a hidden team load
-  record HiddenTeamChain {
-    @mpackkey("v") @jsonkey("v")
-    int subversion;
-
-    HiddenTeamChainData data;
-
-    // Maps a PTK Generation to the chain seqno it showed up in; more info there as
+    // Maps a Reader PTK Generation to the chain seqno it showed up in; more info there as
     // to what the PTK is, etc.
-    map<PerTeamKeyGeneration, Seqno> perTeamKeys;
+    map<PerTeamKeyGeneration, Seqno> readerPerTeamKeys;
 
     // This is the latest hidden chain tail link known for this team;
     // the existence of a known ratchet means the team better be at least up to this
     // point, and maybe beyond it.
-    union { null, LinkTriple } ratchet;
+    HiddenTeamChainRatchet ratchet;
 
     // Should only be used by TeamLoader (because it is mutable, not threadsafe to read)
     Time cachedAt;
@@ -274,6 +337,11 @@ protocol teams {
     Seqno seqno;
     SeqType seqType;
     LinkID linkID;
+  }
+
+  record LinkTripleAndTime {
+     LinkTriple triple;
+     Time time;
   }
 
   record UpPointer {
@@ -310,7 +378,7 @@ protocol teams {
 
     // The PTK that's getting signed in.
     @jsonkey("k") @mpackkey("k")
-    map<PTKType, PerTeamKey>  ptk;
+    map<PTKType, PerTeamKeyAndCheck> ptk;
   }
 
   // FastTeamSigChainState is the state computed by doing a fast reply of the
@@ -521,6 +589,7 @@ protocol teams {
 
     // Keyed by per-team-key generation
     map<PerTeamKeyGeneration, PerTeamKey> perTeamKeys;
+    PerTeamKeyGeneration maxPerTeamKeyGeneration;
 
     // Creation time of latest PerTeamKey, based on CTime from the
     // link key appeared in.

--- a/protocol/json/keybase1/common.json
+++ b/protocol/json/keybase1/common.json
@@ -109,6 +109,12 @@
     },
     {
       "type": "record",
+      "name": "BinaryLinkID",
+      "fields": [],
+      "typedef": "bytes"
+    },
+    {
+      "type": "record",
       "name": "BinaryKID",
       "fields": [],
       "typedef": "bytes"
@@ -241,7 +247,9 @@
         "NONE_0",
         "PUBLIC_1",
         "PRIVATE_2",
-        "SEMIPRIVATE_3"
+        "SEMIPRIVATE_3",
+        "USER_PRIVATE_HIDDEN_16",
+        "TEAM_PRIVATE_HIDDEN_17"
       ]
     },
     {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -49,6 +49,57 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "PerTeamSeedCheckVersion",
+      "symbols": [
+        "V1_1"
+      ]
+    },
+    {
+      "type": "record",
+      "name": "PerTeamSeedCheck",
+      "fields": [
+        {
+          "type": "PerTeamSeedCheckVersion",
+          "name": "version"
+        },
+        {
+          "type": "PerTeamSeedCheckValue",
+          "name": "value"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "PerTeamSeedCheckValue",
+      "fields": [],
+      "typedef": "bytes"
+    },
+    {
+      "type": "record",
+      "name": "PerTeamSeedCheckValuePostImage",
+      "fields": [],
+      "typedef": "bytes"
+    },
+    {
+      "type": "record",
+      "name": "PerTeamSeedCheckPostImage",
+      "fields": [
+        {
+          "type": "PerTeamSeedCheckValuePostImage",
+          "name": "value",
+          "mpackkey": "h",
+          "jsonkey": "h"
+        },
+        {
+          "type": "PerTeamSeedCheckVersion",
+          "name": "version",
+          "mpackkey": "v",
+          "jsonkey": "v"
+        }
+      ]
+    },
+    {
       "type": "record",
       "name": "TeamApplicationKey",
       "fields": [
@@ -120,6 +171,21 @@
       "lint": "ignore"
     },
     {
+      "type": "record",
+      "name": "PerTeamKeyAndCheck",
+      "fields": [
+        {
+          "type": "PerTeamKey",
+          "name": "ptk"
+        },
+        {
+          "type": "PerTeamSeedCheckPostImage",
+          "name": "check"
+        }
+      ],
+      "lint": "ignore"
+    },
+    {
       "type": "fixed",
       "name": "PerTeamKeySeed",
       "size": "32"
@@ -139,6 +205,13 @@
         {
           "type": "Seqno",
           "name": "seqno"
+        },
+        {
+          "type": [
+            null,
+            "PerTeamSeedCheck"
+          ],
+          "name": "check"
         }
       ]
     },
@@ -503,6 +576,19 @@
         },
         {
           "type": "PerTeamKeyGeneration",
+          "name": "maxContinuousPTKGeneration",
+          "lint": "ignore"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "PerTeamSeedCheck",
+            "keys": "PerTeamKeyGeneration"
+          },
+          "name": "seedChecks"
+        },
+        {
+          "type": "PerTeamKeyGeneration",
           "name": "latestKeyGeneration"
         },
         {
@@ -533,20 +619,66 @@
     },
     {
       "type": "record",
-      "name": "HiddenTeamChainData",
+      "name": "HiddenTeamChainRatchet",
+      "fields": [
+        {
+          "type": [
+            null,
+            "LinkTripleAndTime"
+          ],
+          "name": "main"
+        },
+        {
+          "type": [
+            null,
+            "LinkTripleAndTime"
+          ],
+          "name": "blinded"
+        },
+        {
+          "type": [
+            null,
+            "LinkTripleAndTime"
+          ],
+          "name": "self"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "HiddenTeamChain",
       "fields": [
         {
           "type": "TeamID",
-          "name": "ID",
-          "lint": "ignore"
+          "name": "id"
+        },
+        {
+          "type": "int",
+          "name": "subversion"
         },
         {
           "type": "boolean",
           "name": "public"
         },
         {
+          "type": "boolean",
+          "name": "frozen"
+        },
+        {
+          "type": "boolean",
+          "name": "tombstoned"
+        },
+        {
           "type": "Seqno",
           "name": "last"
+        },
+        {
+          "type": {
+            "type": "map",
+            "values": "Seqno",
+            "keys": "PTKType"
+          },
+          "name": "lastPerTeamKeys"
         },
         {
           "type": {
@@ -563,22 +695,6 @@
             "keys": "Seqno"
           },
           "name": "inner"
-        }
-      ]
-    },
-    {
-      "type": "record",
-      "name": "HiddenTeamChain",
-      "fields": [
-        {
-          "type": "int",
-          "name": "subversion",
-          "mpackkey": "v",
-          "jsonkey": "v"
-        },
-        {
-          "type": "HiddenTeamChainData",
-          "name": "data"
         },
         {
           "type": {
@@ -586,13 +702,10 @@
             "values": "Seqno",
             "keys": "PerTeamKeyGeneration"
           },
-          "name": "perTeamKeys"
+          "name": "readerPerTeamKeys"
         },
         {
-          "type": [
-            null,
-            "LinkTriple"
-          ],
+          "type": "HiddenTeamChainRatchet",
           "name": "ratchet"
         },
         {
@@ -616,6 +729,20 @@
         {
           "type": "LinkID",
           "name": "linkID"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "LinkTripleAndTime",
+      "fields": [
+        {
+          "type": "LinkTriple",
+          "name": "triple"
+        },
+        {
+          "type": "Time",
+          "name": "time"
         }
       ]
     },
@@ -702,7 +829,7 @@
         {
           "type": {
             "type": "map",
-            "values": "PerTeamKey",
+            "values": "PerTeamKeyAndCheck",
             "keys": "PTKType"
           },
           "name": "ptk",
@@ -1184,6 +1311,10 @@
             "keys": "PerTeamKeyGeneration"
           },
           "name": "perTeamKeys"
+        },
+        {
+          "type": "PerTeamKeyGeneration",
+          "name": "maxPerTeamKeyGeneration"
         },
         {
           "type": "UnixTime",

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1546,6 +1546,10 @@ export enum PathType {
   kbfsArchived = 2,
 }
 
+export enum PerTeamSeedCheckVersion {
+  v1 = 1,
+}
+
 export enum PrefetchStatus {
   notStarted = 0,
   inProgress = 1,
@@ -1718,6 +1722,8 @@ export enum SeqType {
   public = 1,
   private = 2,
   semiprivate = 3,
+  userPrivateHidden = 16,
+  teamPrivateHidden = 17,
 }
 
 export enum SignMode {
@@ -2074,6 +2080,7 @@ export type AvatarUrl = String
 export type BadgeConversationInfo = {readonly convID: ChatConversationID; readonly badgeCounts: {[key: string]: Int}; readonly unreadMessages: Int}
 export type BadgeState = {readonly newTlfs: Int; readonly rekeysNeeded: Int; readonly newFollowers: Int; readonly inboxVers: Int; readonly homeTodoItems: Int; readonly newDevices?: Array<DeviceID> | null; readonly revokedDevices?: Array<DeviceID> | null; readonly conversations?: Array<BadgeConversationInfo> | null; readonly newGitRepoGlobalUniqueIDs?: Array<String> | null; readonly newTeamNames?: Array<String> | null; readonly deletedTeams?: Array<DeletedTeamInfo> | null; readonly newTeamAccessRequests?: Array<String> | null; readonly teamsWithResetUsers?: Array<TeamMemberOutReset> | null; readonly unreadWalletAccounts?: Array<WalletAccountInfo> | null; readonly resetState: ResetState}
 export type BinaryKID = Bytes
+export type BinaryLinkID = Bytes
 export type BlockIdCombo = {readonly blockHash: String; readonly chargedTo: UserOrTeamID; readonly blockType: BlockType}
 export type BlockIdCount = {readonly id: BlockIdCombo; readonly liveCount: Int}
 export type BlockPingResponse = {}
@@ -2155,7 +2162,7 @@ export type FSPathSyncStatus = {readonly folderType: FolderType; readonly path: 
 export type FSSettings = {readonly spaceAvailableNotificationThreshold: Int64}
 export type FSSyncStatus = {readonly totalSyncingBytes: Int64; readonly syncingPaths?: Array<String> | null; readonly endEstimate?: Time | null}
 export type FSSyncStatusRequest = {readonly requestID: Int}
-export type FastTeamData = {readonly frozen: Boolean; readonly tombstoned: Boolean; readonly name: TeamName; readonly chain: FastTeamSigChainState; readonly perTeamKeySeeds: /* perTeamKeySeedsUnverified */ {[key: string]: PerTeamKeySeed}; readonly latestKeyGeneration: PerTeamKeyGeneration; readonly readerKeyMasks: {[key: string]: {[key: string]: MaskB64}}; readonly latestSeqnoHint: Seqno; readonly cachedAt: Time; readonly loadedLatest: Boolean}
+export type FastTeamData = {readonly frozen: Boolean; readonly tombstoned: Boolean; readonly name: TeamName; readonly chain: FastTeamSigChainState; readonly perTeamKeySeeds: /* perTeamKeySeedsUnverified */ {[key: string]: PerTeamKeySeed}; readonly maxContinuousPTKGeneration: PerTeamKeyGeneration; readonly seedChecks: {[key: string]: PerTeamSeedCheck}; readonly latestKeyGeneration: PerTeamKeyGeneration; readonly readerKeyMasks: {[key: string]: {[key: string]: MaskB64}}; readonly latestSeqnoHint: Seqno; readonly cachedAt: Time; readonly loadedLatest: Boolean}
 export type FastTeamLoadArg = {readonly ID: TeamID; readonly public: Boolean; readonly assertTeamName?: TeamName | null; readonly applications?: Array<TeamApplication> | null; readonly keyGenerationsNeeded?: Array<PerTeamKeyGeneration> | null; readonly needLatestKey: Boolean; readonly forceRefresh: Boolean}
 export type FastTeamLoadRes = {readonly name: TeamName; readonly applicationKeys?: Array<TeamApplicationKey> | null}
 export type FastTeamSigChainState = {readonly ID: TeamID; readonly public: Boolean; readonly rootAncestor: TeamName; readonly nameDepth: Int; readonly last?: LinkTriple | null; readonly perTeamKeys: {[key: string]: PerTeamKey}; readonly perTeamKeySeedsVerified: {[key: string]: PerTeamKeySeed}; readonly downPointers: {[key: string]: DownPointer}; readonly lastUpPointer?: UpPointer | null; readonly perTeamKeyCTime: UnixTime; readonly linkIDs: {[key: string]: LinkID}; readonly merkleInfo: {[key: string]: MerkleRootV2}}
@@ -2202,9 +2209,9 @@ export type HasServerKeysRes = {readonly hasServerKeys: Boolean}
 export type HashMeta = Bytes
 export type Hello2Res = {readonly encryptionKey: KID; readonly sigPayload: HelloRes; readonly deviceEkKID: KID}
 export type HelloRes = String
-export type HiddenTeamChain = {readonly v: /* subversion */ Int; readonly data: HiddenTeamChainData; readonly perTeamKeys: {[key: string]: Seqno}; readonly ratchet?: LinkTriple | null; readonly cachedAt: Time}
-export type HiddenTeamChainData = {readonly ID: TeamID; readonly public: Boolean; readonly last: Seqno; readonly outer: {[key: string]: LinkID}; readonly inner: {[key: string]: HiddenTeamChainLink}}
-export type HiddenTeamChainLink = {readonly m: /* merkleRoot */ MerkleRootV2; readonly p: /* parentChain */ LinkTriple; readonly s: /* signer */ Signer; readonly k: /* ptk */ {[key: string]: PerTeamKey}}
+export type HiddenTeamChain = {readonly id: TeamID; readonly subversion: Int; readonly public: Boolean; readonly frozen: Boolean; readonly tombstoned: Boolean; readonly last: Seqno; readonly lastPerTeamKeys: {[key: string]: Seqno}; readonly outer: {[key: string]: LinkID}; readonly inner: {[key: string]: HiddenTeamChainLink}; readonly readerPerTeamKeys: {[key: string]: Seqno}; readonly ratchet: HiddenTeamChainRatchet; readonly cachedAt: Time}
+export type HiddenTeamChainLink = {readonly m: /* merkleRoot */ MerkleRootV2; readonly p: /* parentChain */ LinkTriple; readonly s: /* signer */ Signer; readonly k: /* ptk */ {[key: string]: PerTeamKeyAndCheck}}
+export type HiddenTeamChainRatchet = {readonly main?: LinkTripleAndTime | null; readonly blinded?: LinkTripleAndTime | null; readonly self?: LinkTripleAndTime | null}
 export type HomeScreen = {readonly lastViewed: Time; readonly version: Int; readonly visits: Int; readonly items?: Array<HomeScreenItem> | null; readonly followSuggestions?: Array<HomeUserSummary> | null; readonly announcementsVersion: Int}
 export type HomeScreenAnnouncement = {readonly id: HomeScreenAnnouncementID; readonly version: HomeScreenAnnouncementVersion; readonly appLink: AppLinkType; readonly confirmLabel: String; readonly dismissable: Boolean; readonly iconUrl: String; readonly text: String; readonly url: String}
 export type HomeScreenAnnouncementID = Int
@@ -2257,6 +2264,7 @@ export type LeaseID = String
 export type LinkCheckResult = {readonly proofId: Int; readonly proofResult: ProofResult; readonly snoozedResult: ProofResult; readonly torWarning: Boolean; readonly tmpTrackExpireTime: Time; readonly cached?: CheckResult | null; readonly diff?: TrackDiff | null; readonly remoteDiff?: TrackDiff | null; readonly hint?: SigHint | null; readonly breaksTracking: Boolean}
 export type LinkID = String
 export type LinkTriple = {readonly seqno: Seqno; readonly seqType: SeqType; readonly linkID: LinkID}
+export type LinkTripleAndTime = {readonly triple: LinkTriple; readonly time: Time}
 export type ListArgs = {readonly opID: OpID; readonly path: Path; readonly filter: ListFilter}
 export type ListResult = {readonly files?: Array<File> | null}
 export type ListToDepthArgs = {readonly opID: OpID; readonly path: Path; readonly filter: ListFilter; readonly depth: Int}
@@ -2310,9 +2318,14 @@ export type ParamProofUsernameConfig = {readonly re: String; readonly min: Int; 
 export type PassphraseStream = {readonly passphraseStream: Bytes; readonly generation: Int}
 export type Path = {PathType: PathType.local; local: String | null} | {PathType: PathType.kbfs; kbfs: String | null} | {PathType: PathType.kbfsArchived; kbfsArchived: KBFSArchivedPath | null}
 export type PerTeamKey = {readonly gen: PerTeamKeyGeneration; readonly seqno: Seqno; readonly sigKID: KID; readonly encKID: KID}
+export type PerTeamKeyAndCheck = {readonly ptk: PerTeamKey; readonly check: PerTeamSeedCheckPostImage}
 export type PerTeamKeyGeneration = Int
 export type PerTeamKeySeed = string | null
-export type PerTeamKeySeedItem = {readonly seed: PerTeamKeySeed; readonly generation: PerTeamKeyGeneration; readonly seqno: Seqno}
+export type PerTeamKeySeedItem = {readonly seed: PerTeamKeySeed; readonly generation: PerTeamKeyGeneration; readonly seqno: Seqno; readonly check?: PerTeamSeedCheck | null}
+export type PerTeamSeedCheck = {readonly version: PerTeamSeedCheckVersion; readonly value: PerTeamSeedCheckValue}
+export type PerTeamSeedCheckPostImage = {readonly h: /* value */ PerTeamSeedCheckValuePostImage; readonly v: /* version */ PerTeamSeedCheckVersion}
+export type PerTeamSeedCheckValue = Bytes
+export type PerTeamSeedCheckValuePostImage = Bytes
 export type PerUserKey = {readonly gen: Int; readonly seqno: Seqno; readonly sigKID: KID; readonly encKID: KID; readonly signedByKID: KID}
 export type PerUserKeyBox = {readonly generation: PerUserKeyGeneration; readonly box: String; readonly receiverKID: KID}
 export type PerUserKeyGeneration = Int
@@ -2484,7 +2497,7 @@ export type TeamSeitanMsg = {readonly teamID: TeamID; readonly seitans?: Array<T
 export type TeamSeitanRequest = {readonly inviteID: TeamInviteID; readonly uid: UID; readonly eldestSeqno: Seqno; readonly akey: SeitanAKey; readonly role: TeamRole; readonly unixCTime: Int64}
 export type TeamSettings = {readonly open: Boolean; readonly joinAs: TeamRole}
 export type TeamShowcase = {readonly isShowcased: Boolean; readonly description?: String | null; readonly setByUID?: UID | null; readonly anyMemberShowcase: Boolean}
-export type TeamSigChainState = {readonly reader: UserVersion; readonly id: TeamID; readonly implicit: Boolean; readonly public: Boolean; readonly rootAncestor: TeamName; readonly nameDepth: Int; readonly nameLog?: Array<TeamNameLogPoint> | null; readonly lastSeqno: Seqno; readonly lastLinkID: LinkID; readonly lastHighSeqno: Seqno; readonly lastHighLinkID: LinkID; readonly parentID?: TeamID | null; readonly userLog: {[key: string]: Array<UserLogPoint> | null}; readonly subteamLog: {[key: string]: Array<SubteamLogPoint> | null}; readonly perTeamKeys: {[key: string]: PerTeamKey}; readonly perTeamKeyCTime: UnixTime; readonly linkIDs: {[key: string]: LinkID}; readonly stubbedLinks: {[key: string]: Boolean}; readonly activeInvites: {[key: string]: TeamInvite}; readonly obsoleteInvites: {[key: string]: TeamInvite}; readonly open: Boolean; readonly openTeamJoinAs: TeamRole; readonly tlfIDs?: Array<TLFID> | null; readonly tlfLegacyUpgrade: {[key: string]: TeamLegacyTLFUpgradeChainInfo}; readonly headMerkle?: MerkleRootV2 | null; readonly merkleRoots: {[key: string]: MerkleRootV2}}
+export type TeamSigChainState = {readonly reader: UserVersion; readonly id: TeamID; readonly implicit: Boolean; readonly public: Boolean; readonly rootAncestor: TeamName; readonly nameDepth: Int; readonly nameLog?: Array<TeamNameLogPoint> | null; readonly lastSeqno: Seqno; readonly lastLinkID: LinkID; readonly lastHighSeqno: Seqno; readonly lastHighLinkID: LinkID; readonly parentID?: TeamID | null; readonly userLog: {[key: string]: Array<UserLogPoint> | null}; readonly subteamLog: {[key: string]: Array<SubteamLogPoint> | null}; readonly perTeamKeys: {[key: string]: PerTeamKey}; readonly maxPerTeamKeyGeneration: PerTeamKeyGeneration; readonly perTeamKeyCTime: UnixTime; readonly linkIDs: {[key: string]: LinkID}; readonly stubbedLinks: {[key: string]: Boolean}; readonly activeInvites: {[key: string]: TeamInvite}; readonly obsoleteInvites: {[key: string]: TeamInvite}; readonly open: Boolean; readonly openTeamJoinAs: TeamRole; readonly tlfIDs?: Array<TLFID> | null; readonly tlfLegacyUpgrade: {[key: string]: TeamLegacyTLFUpgradeChainInfo}; readonly headMerkle?: MerkleRootV2 | null; readonly merkleRoots: {[key: string]: MerkleRootV2}}
 export type TeamTreeEntry = {readonly name: TeamName; readonly admin: Boolean}
 export type TeamTreeResult = {readonly entries?: Array<TeamTreeEntry> | null}
 export type Test = {readonly reply: String}


### PR DESCRIPTION
- introduce sig3 for chain17 links
- hidden team rotations implemented, only in test thus far
- hidden team rotations can be digested by the slow loader
- one simple test but lots more tests needed