### PR TITLE
Tweak username taken/deleted error messages

### DIFF
--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -39,7 +39,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 		return libkb.AppStatusError{
 			Code: libkb.SCBadSignupUsernameTaken,
 			Name: "BAD_SIGNUP_USERNAME_TAKEN",
-			Desc: "This username is already taken! Please pick another one",
+			Desc: "This username is already taken! Please pick another one.",
 		}
 	case libkb.AppStatusError:
 		switch err.Name {
@@ -50,7 +50,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 			return libkb.AppStatusError{
 				Code: libkb.SCBadSignupUsernameDeleted,
 				Name: "BAD_SIGNUP_USERNAME_DELETED",
-				Desc: "This username has been deleted! Please pick another one",
+				Desc: "This username has been deleted! Please pick another one.",
 			}
 		}
 		return err

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -39,7 +39,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 		return libkb.AppStatusError{
 			Code: libkb.SCBadSignupUsernameTaken,
 			Name: "BAD_SIGNUP_USERNAME_TAKEN",
-			Desc: "This username is already taken! Please pick another one.",
+			Desc: "This username is already taken! Please pick another one",
 		}
 	case libkb.AppStatusError:
 		switch err.Name {
@@ -50,7 +50,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 			return libkb.AppStatusError{
 				Code: libkb.SCBadSignupUsernameDeleted,
 				Name: "BAD_SIGNUP_USERNAME_DELETED",
-				Desc: "This username has been deleted! Please pick another one.",
+				Desc: "This username has been deleted! Please pick another one",
 			}
 		}
 		return err

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -4,8 +4,6 @@
 package service
 
 import (
-	"fmt"
-
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -41,7 +39,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 		return libkb.AppStatusError{
 			Code: libkb.SCBadSignupUsernameTaken,
 			Name: "BAD_SIGNUP_USERNAME_TAKEN",
-			Desc: fmt.Sprintf("Username '%s' is taken", arg.Username),
+			Desc: "This username is already taken! Please pick another one.",
 		}
 	case libkb.AppStatusError:
 		switch err.Name {
@@ -52,7 +50,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 			return libkb.AppStatusError{
 				Code: libkb.SCBadSignupUsernameDeleted,
 				Name: "BAD_SIGNUP_USERNAME_DELETED",
-				Desc: fmt.Sprintf("Username '%s' has been deleted", arg.Username),
+				Desc: "This username has been deleted! Please pick another one.",
 			}
 		}
 		return err

--- a/shared/actions/signup.tsx
+++ b/shared/actions/signup.tsx
@@ -98,10 +98,7 @@ const checkUsername = (state: TypedState, _, logger) => {
       })
       .catch(err => {
         logger.warn(`${state.signup.username} error: ${err.message}`)
-        const error =
-          err.code === RPCTypes.StatusCode.scinputerror
-            ? Constants.usernameHint
-            : `Sorry, there was a problem: ${err.desc}`
+        const error = err.code === RPCTypes.StatusCode.scinputerror ? Constants.usernameHint : err.desc
         return SignupGen.createCheckedUsername({
           // Don't set error if it's 'username taken', we show a banner in that case
           error: err.code === RPCTypes.StatusCode.scbadsignupusernametaken ? '' : error,


### PR DESCRIPTION
note the frontend uses there own message in the username taken case:

![image-20190614-191149](https://user-images.githubusercontent.com/1144020/59532754-a29f0280-8eb7-11e9-8c03-e3d2db808f08.png)

![image-20190614-191613](https://user-images.githubusercontent.com/1144020/59532785-b3e80f00-8eb7-11e9-84ec-09a8e157a9f4.png)



cc @cecileboucheron 