### PR TITLE
fix avatar/attachment caching when cachedir changes

### DIFF
--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -28,7 +28,7 @@ func CreateSourceFromEnvAndInstall(g *libkb.GlobalContext) (s Source) {
 		s = NewURLCachingSource(time.Hour /* staleThreshold */, 20000)
 	case "full":
 		maxSize := 10000
-		if g.GetAppType() == libkb.MobileAppType {
+		if g.IsMobileAppType() {
 			maxSize = 2000
 		}
 		// When changing staleThreshold here, serverside avatar change

--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -706,13 +706,21 @@ func (c *CachingAttachmentFetcher) createAttachmentFile(ctx context.Context) (*o
 	return os.OpenFile(path, os.O_RDWR, os.ModeAppend)
 }
 
+// normalizeFilenameFromCache substitutes the existing cache dir value into the
+// file path since it's possible for the path to the cache dir to change,
+// especially on mobile.
+func (c *CachingAttachmentFetcher) normalizeFilenameFromCache(file string) string {
+	file = filepath.Base(file)
+	return filepath.Join(c.getCacheDir(), file)
+}
+
 func (c *CachingAttachmentFetcher) localAssetPath(ctx context.Context, asset chat1.Asset) (found bool, path string, err error) {
 	found, entry, err := c.diskLRU.Get(ctx, c.G(), c.cacheKey(asset))
 	if err != nil {
 		return found, path, err
 	}
 	if found {
-		path = entry.Value.(string)
+		path = c.normalizeFilenameFromCache(entry.Value.(string))
 	}
 	return found, path, nil
 }
@@ -791,7 +799,7 @@ func (c *CachingAttachmentFetcher) putFileInLRU(ctx context.Context, filename st
 		return err
 	}
 	if evicted != nil {
-		path := evicted.Value.(string)
+		path := c.normalizeFilenameFromCache(evicted.Value.(string))
 		os.Remove(path)
 	}
 	return nil

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -357,9 +357,9 @@ func (u *Uploader) getBaseDir() string {
 // normalizeFilenameFromCache substitutes the existing cache dir value into the
 // file path since it's possible for the path to the cache dir to change,
 // especially on mobile.
-func (u *Uploader) normalizeFilenameFromCache(file string) string {
+func (u *Uploader) normalizeFilenameFromCache(dir, file string) string {
 	file = filepath.Base(file)
-	return filepath.Join(u.getBaseDir(), file)
+	return filepath.Join(dir, file)
 }
 
 func (u *Uploader) uploadFile(ctx context.Context, diskLRU *disklru.DiskLRU, dirname, prefix string) (f *os.File, err error) {
@@ -381,7 +381,7 @@ func (u *Uploader) uploadFile(ctx context.Context, diskLRU *disklru.DiskLRU, dir
 		return nil, err
 	}
 	if evicted != nil {
-		path := u.normalizeFilenameFromCache(evicted.Value.(string))
+		path := u.normalizeFilenameFromCache(dir, evicted.Value.(string))
 		if oerr := os.Remove(path); oerr != nil {
 			u.Debug(ctx, "failed to remove file at %s, %v", path, oerr)
 		}

--- a/go/lru/disk_lru.go
+++ b/go/lru/disk_lru.go
@@ -149,6 +149,12 @@ func NewDiskLRU(name string, version, maxSize int) *DiskLRU {
 	}
 }
 
+func (d *DiskLRU) MaxSize() int {
+	d.Lock()
+	defer d.Unlock()
+	return d.maxSize
+}
+
 func (d *DiskLRU) debug(ctx context.Context, lctx libkb.LRUContext, msg string, args ...interface{}) {
 	lctx.GetLog().CDebugf(ctx, fmt.Sprintf("DiskLRU: %s(%d): ", d.name, d.version)+msg, args...)
 }


### PR DESCRIPTION
fixes an issue where the path to the cache dir would change allowing disk backed LRUs to exceed their capacity, strand files, and unnecessarily miss


cc @keybase/hotpotatosquad 