### PR TITLE
Wallet send form disallows negative inputs

### DIFF
--- a/shared/wallets/send-form/asset-input/index.tsx
+++ b/shared/wallets/send-form/asset-input/index.tsx
@@ -7,6 +7,9 @@ const commasToPeriods = s => s.replace(/,/, '.')
 
 const isValidAmount = (amt, numDecimalsAllowed) => {
   if (!isNaN(Number(amt)) || amt === '.') {
+    if (amt && amt.startsWith && amt.startsWith('-')) {
+      return false
+    }
     // This is a valid number. Now check the number of decimal places
     const split = amt.split('.')
     if (split.length === 1) {


### PR DESCRIPTION
The problem was you could paste "-1" into the amount field and then get stuck in a weird state. Now pasting "-1" does not change the value, like "1.1.1.1".