### PR TITLE
Workaround react-native-push-notification subdep migrating to androidX

### DIFF
--- a/shared/android/app/build.gradle
+++ b/shared/android/app/build.gradle
@@ -229,16 +229,13 @@ dependencies {
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.android.support:multidex:1.0.3"
     implementation "com.google.firebase:firebase-messaging:17.3.0" // sync with firebaseVersion in gradle.properties
-    implementation "com.google.android.gms:play-services-gcm:16.0.0"
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "com.facebook.fresco:animated-gif:1.13.0"
     implementation "com.facebook.fresco:fresco:1.13.0"
     implementation "com.evernote:android-job:1.2.6"
     implementation 'org.msgpack:msgpack:0.6.12'
     implementation project(':keybaselib')
-    implementation(project(':react-native-push-notification'), {
-      exclude group: "com.google.android.gms"
-    })
+    implementation project(':react-native-push-notification')
     implementation project(':react-native-camera')
     implementation project(':react-native-image-picker')
     implementation project(':react-native-fetch-blob')

--- a/shared/android/app/build.gradle
+++ b/shared/android/app/build.gradle
@@ -228,7 +228,8 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.android.support:multidex:1.0.3"
-    implementation "com.google.firebase:firebase-messaging:17.3.0"
+    implementation "com.google.firebase:firebase-messaging:17.3.0" // sync with firebaseVersion in gradle.properties
+    implementation "com.google.android.gms:play-services-gcm:16.0.0"
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "com.facebook.fresco:animated-gif:1.13.0"
     implementation "com.facebook.fresco:fresco:1.13.0"
@@ -237,7 +238,6 @@ dependencies {
     implementation project(':keybaselib')
     implementation(project(':react-native-push-notification'), {
       exclude group: "com.google.android.gms"
-      exclude group: "com.google.firebase"
     })
     implementation project(':react-native-camera')
     implementation project(':react-native-image-picker')

--- a/shared/android/app/build.gradle
+++ b/shared/android/app/build.gradle
@@ -235,7 +235,10 @@ dependencies {
     implementation "com.evernote:android-job:1.2.6"
     implementation 'org.msgpack:msgpack:0.6.12'
     implementation project(':keybaselib')
-    implementation project(':react-native-push-notification')
+    implementation(project(':react-native-push-notification'), {
+      exclude group: "com.google.android.gms"
+      exclude group: "com.google.firebase"
+    })
     implementation project(':react-native-camera')
     implementation project(':react-native-image-picker')
     implementation project(':react-native-fetch-blob')

--- a/shared/android/gradle.properties
+++ b/shared/android/gradle.properties
@@ -29,4 +29,6 @@ KB_SERVICE_ACCT_JSON=./for-ci/google-services.json
 
 # Override react-native-push-notifications version
 # same as com.google.firebase:firebase-messaging version in app/build.gradle
-firebaseVersion=17.3.0
+firebaseVersion=17.3.0 # react-native-push-notification
+googlePlayServicesVisionVersion=17.0.2 # react-native-push-notification
+googlePlayServicesVersion=16.0.0 # react-native-camera

--- a/shared/android/gradle.properties
+++ b/shared/android/gradle.properties
@@ -26,3 +26,7 @@ KB_RELEASE_STORE_PASSWORD=''
 KB_RELEASE_KEY_PASSWORD=''
 # This is a dummy file for CI
 KB_SERVICE_ACCT_JSON=./for-ci/google-services.json
+
+# Override react-native-push-notifications version
+# same as com.google.firebase:firebase-messaging version in app/build.gradle
+firebaseVersion=17.3.0

--- a/shared/android/gradle.properties
+++ b/shared/android/gradle.properties
@@ -29,6 +29,7 @@ KB_SERVICE_ACCT_JSON=./for-ci/google-services.json
 
 # Override react-native-push-notifications version
 # same as com.google.firebase:firebase-messaging version in app/build.gradle
-firebaseVersion=17.3.0 # react-native-push-notification
-googlePlayServicesVisionVersion=17.0.2 # react-native-push-notification
-googlePlayServicesVersion=16.0.0 # react-native-camera
+firebaseVersion=17.3.0
+googlePlayServicesVisionVersion=17.0.2
+# react-native-camera
+googlePlayServicesVersion=16.0.0


### PR DESCRIPTION
`com.google.firebase` released a version that migrated to androidX, see [here](https://android-developers.googleblog.com/2019/06/google-play-services-and-firebase.html) and [here](https://firebase.google.com/support/release-notes/android#update_-_june_17_2019)

`react-native-push-notification`'s build pulls in the latest version, override to fix. 

I'll ticket migrating to androidX, we will need to to upgrade RN to 0.60.