### PR TITLE
PGP Push secret when local secret is already present

### DIFF
--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -148,16 +148,6 @@ func (e *PGPKeyImportEngine) checkPregenPrivate() error {
 }
 
 func (e *PGPKeyImportEngine) checkExistingKey(m libkb.MetaContext) error {
-	// Check if the secret key already exists
-	// if _, err := m.G().Keyrings.GetSecretKeyLocked(m, libkb.SecretKeyArg{
-	// 	Me:       e.me,
-	// 	KeyType:  libkb.PGPKeyType,
-	// 	KeyQuery: e.GetKID().String(),
-	// }); err == nil {
-	// 	// There's a secret key, so let the engine return an error later
-	// 	return nil
-	// }
-
 	// Check if we have a public key that matches
 	pgps := e.me.GetActivePGPKeys(false)
 	for _, key := range pgps {
@@ -235,7 +225,7 @@ func (e *PGPKeyImportEngine) Run(m libkb.MetaContext) (err error) {
 		if err = e.exportToGPG(m); err != nil {
 			return GPGExportingError{err, true /* inPGPGen */}
 		}
-	} else if e.arg.OnlySave && e.arg.PushSecret {
+	} else if e.arg.PushSecret {
 		if err = e.pushSecretOnly(m); err != nil {
 			return err
 		}

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -149,14 +149,14 @@ func (e *PGPKeyImportEngine) checkPregenPrivate() error {
 
 func (e *PGPKeyImportEngine) checkExistingKey(m libkb.MetaContext) error {
 	// Check if the secret key already exists
-	if _, err := m.G().Keyrings.GetSecretKeyLocked(m, libkb.SecretKeyArg{
-		Me:       e.me,
-		KeyType:  libkb.PGPKeyType,
-		KeyQuery: e.GetKID().String(),
-	}); err == nil {
-		// There's a secret key, so let the engine return an error later
-		return nil
-	}
+	// if _, err := m.G().Keyrings.GetSecretKeyLocked(m, libkb.SecretKeyArg{
+	// 	Me:       e.me,
+	// 	KeyType:  libkb.PGPKeyType,
+	// 	KeyQuery: e.GetKID().String(),
+	// }); err == nil {
+	// 	// There's a secret key, so let the engine return an error later
+	// 	return nil
+	// }
 
 	// Check if we have a public key that matches
 	pgps := e.me.GetActivePGPKeys(false)
@@ -234,6 +234,10 @@ func (e *PGPKeyImportEngine) Run(m libkb.MetaContext) (err error) {
 		}
 		if err = e.exportToGPG(m); err != nil {
 			return GPGExportingError{err, true /* inPGPGen */}
+		}
+	} else if e.arg.OnlySave && e.arg.PushSecret {
+		if err = e.pushSecretOnly(m); err != nil {
+			return err
 		}
 	}
 
@@ -415,6 +419,28 @@ func (e *PGPKeyImportEngine) push(m libkb.MetaContext) (err error) {
 		m.UIs().LogUI.Info("  %s", line)
 	}
 
+	return nil
+}
+
+func (e *PGPKeyImportEngine) pushSecretOnly(m libkb.MetaContext) (err error) {
+	defer m.Trace("PGP#PushSecretOnly", func() error { return err })()
+
+	m.UIs().LogUI.Info("Only pushing encrypted private key to Keybase server")
+
+	hargs := libkb.HTTPArgs{
+		"private_key": libkb.S{Val: e.epk},
+	}
+	arg := libkb.APIArg{
+		Endpoint:    "key/add",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		Args:        hargs,
+	}
+	_, err = m.G().API.Post(m, arg)
+	if err != nil {
+		return err
+	}
+
+	m.UIs().LogUI.Info("Success! Pushed encrypted private key")
 	return nil
 }
 

--- a/go/engine/pgp_import_key_test.go
+++ b/go/engine/pgp_import_key_test.go
@@ -89,8 +89,8 @@ func TestPGPImportAndExport(t *testing.T) {
 	}
 }
 
-// TestPGPImportPrivImport - import the same key twice, only importing the private key
-// the second time / on the second device (CORE-10562).
+// TestPGPImportPrivImport - import the same key twice, only importing the
+// private key the second time / on the second device (CORE-10562).
 func TestPGPImportPrivImport(t *testing.T) {
 	user, dev1, dev2, cleanup := SetupTwoDevices(t, "login")
 	defer cleanup()
@@ -186,6 +186,40 @@ func TestPGPImportPrivImport(t *testing.T) {
 	if len(xe.Results()) != 1 {
 		t.Fatalf("Expected 1 key back out")
 	}
+}
+
+func TestPGPImportLocalPrivateThenServer(t *testing.T) {
+	tc := SetupEngineTest(t, "pgpsave")
+	defer tc.Cleanup()
+
+	user := CreateAndSignupFakeUser(tc, "login")
+	secui := &libkb.TestSecretUI{Passphrase: user.Passphrase}
+	uis := libkb.UIs{LogUI: tc.G.UI.GetLogUI(), SecretUI: secui}
+
+	_, _, key := genPGPKeyAndArmor(t, tc, user.Email)
+
+	// Import a private key locally first.
+	eng, err := NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), false /* pushSecret*/)
+	require.NoError(t, err)
+	mctx := NewMetaContextForTest(tc).WithUIs(uis)
+	err = RunEngine2(mctx, eng)
+	require.NoError(t, err)
+
+	kid := eng.GetKID()
+
+	// Try to import with push secret afterwards - user also wants
+	// to have this key available online.
+	eng, err = NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), true /* pushSecret*/)
+	require.NoError(t, err)
+	mctx = NewMetaContextForTest(tc).WithUIs(uis)
+	err = RunEngine2(mctx, eng)
+	require.NoError(t, err)
+
+	ss, err := mctx.ActiveDevice().SyncSecretsForce(mctx)
+	require.NoError(t, err)
+	privKey, ok := ss.FindPrivateKey(kid.String())
+	require.True(t, ok)
+	require.NotEmpty(t, privKey.Bundle)
 }
 
 // Test for issue 325.

--- a/go/engine/pgp_import_key_test.go
+++ b/go/engine/pgp_import_key_test.go
@@ -205,6 +205,13 @@ func TestPGPImportLocalPrivateThenServer(t *testing.T) {
 	err = RunEngine2(mctx, eng)
 	require.NoError(t, err)
 
+	// Can we import locally twice?
+	eng, err = NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), false /* pushSecret*/)
+	require.NoError(t, err)
+	mctx = NewMetaContextForTest(tc).WithUIs(uis)
+	err = RunEngine2(mctx, eng)
+	require.NoError(t, err)
+
 	kid := eng.GetKID()
 
 	ss, err := mctx.ActiveDevice().SyncSecretsForce(mctx)

--- a/go/engine/pgp_import_key_test.go
+++ b/go/engine/pgp_import_key_test.go
@@ -207,6 +207,11 @@ func TestPGPImportLocalPrivateThenServer(t *testing.T) {
 
 	kid := eng.GetKID()
 
+	ss, err := mctx.ActiveDevice().SyncSecretsForce(mctx)
+	require.NoError(t, err)
+	_, ok := ss.FindPrivateKey(kid.String())
+	require.False(t, ok)
+
 	// Try to import with push secret afterwards - user also wants
 	// to have this key available online.
 	eng, err = NewPGPKeyImportEngineFromBytes(tc.G, []byte(key), true /* pushSecret*/)
@@ -215,7 +220,7 @@ func TestPGPImportLocalPrivateThenServer(t *testing.T) {
 	err = RunEngine2(mctx, eng)
 	require.NoError(t, err)
 
-	ss, err := mctx.ActiveDevice().SyncSecretsForce(mctx)
+	ss, err = mctx.ActiveDevice().SyncSecretsForce(mctx)
 	require.NoError(t, err)
 	privKey, ok := ss.FindPrivateKey(kid.String())
 	require.True(t, ok)

--- a/go/engine/pgp_select_test.go
+++ b/go/engine/pgp_select_test.go
@@ -5,6 +5,8 @@ package engine
 
 import (
 	"fmt"
+	"io/ioutil"
+	"path"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
@@ -68,4 +70,58 @@ func TestSelectEngine(t *testing.T) {
 	if !key.GetFingerprint().Eq(gpg.duplicatedFingerprints[0]) {
 		tc.T.Fatal("Our fingerprint ID wasn't returned as up to date")
 	}
+}
+
+func TestPGPSelectThenPushSecret(t *testing.T) {
+	tc := SetupEngineTest(t, "select")
+	defer tc.Cleanup()
+
+	user := CreateAndSignupFakeUser(tc, "selc")
+	secUI := &libkb.TestSecretUI{Passphrase: user.Passphrase}
+
+	err := tc.GenerateGPGKeyring(user.Email)
+	require.NoError(t, err)
+
+	uis := libkb.UIs{
+		LogUI:    tc.G.UI.GetLogUI(),
+		SecretUI: secUI,
+		GPGUI:    &gpgtestui{},
+	}
+	mctx := tc.MetaContext().WithUIs(uis)
+
+	// PGP Select the key, without importing to local keyring.
+	garg := GPGImportKeyArg{
+		HasProvisionedDevice: true,
+		AllowMulti:           false,
+		SkipImport:           true,
+		OnlyImport:           false,
+	}
+	gpgEng := NewGPGImportKeyEngine(tc.G, &garg)
+	err = RunEngine2(mctx, gpgEng)
+	require.NoError(t, err)
+
+	kid := gpgEng.last.GetKID()
+
+	// Secret key should not be available on the server.
+	ss, err := mctx.ActiveDevice().SyncSecretsForce(mctx)
+	require.NoError(t, err)
+	_, ok := ss.FindPrivateKey(kid.String())
+	require.False(t, ok)
+
+	// Import secret key afterwards with pushing to the server.
+	keyBytes, err := ioutil.ReadFile(path.Join(tc.Tp.GPGHome, "secring.gpg"))
+	require.NoError(t, err)
+	pgpEng, err := NewPGPKeyImportEngineFromBytes(tc.G, keyBytes, true /* pushSecret*/)
+	require.NoError(t, err)
+	mctx = tc.MetaContext().WithUIs(uis)
+	err = RunEngine2(mctx, pgpEng)
+	require.NoError(t, err)
+
+	// Secret key should *be* available on the server (pushSecret=true in GPG
+	// import engine above).
+	ss, err = mctx.ActiveDevice().SyncSecretsForce(mctx)
+	require.NoError(t, err)
+	privKey, ok := ss.FindPrivateKey(kid.String())
+	require.True(t, ok)
+	require.NotEmpty(t, privKey.Bundle)
 }


### PR DESCRIPTION
This PR changes `PGPKeyImportEngine` to be able to only push secret key through `key/add` endpoint when public key is already present in the sigchain.

This fixes the following use cases:

**Use case A:**
1) User imports their key using `keybase pgp select`, with or without importing private key to local keyring.
2) User imports their secret key using `keybase pgp import --push-secret` with the intention for the secret key to be pushed to Keybase servers.

(previously it would have been not pushed to keybase servers, secret key would only be available locally).

**Use case B:**
1) User imports their key using `keybase pgp import` with the intention for the secret key to only be available locally.
2) User changes their mind and uses `keybase pgp import --push-secret` to also push the secret key to the servers.

(previously would fail with "This key is already active. You can't add it twice." error)

There is a new test for use case A in `TestPGPSelectThenPushSecret` and new test for B in `TestPGPImportLocalPrivateThenServer`.