### PR TITLE
libkbfs: obfuscate file and dir names in logs

### DIFF
--- a/go/kbfs/data/file_data_test.go
+++ b/go/kbfs/data/file_data_test.go
@@ -30,7 +30,11 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 		DirectType: DirectBlock,
 	}
 	id := tlf.FakeID(1, tlf.Private)
-	file := Path{FolderBranch{Tlf: id}, []PathNode{{ptr, "file"}}}
+	file := Path{
+		FolderBranch{Tlf: id},
+		[]PathNode{{ptr, NewPathPartString("file", nil)}},
+		nil,
+	}
 	chargedTo := keybase1.MakeTestUID(1).AsUserOrTeam()
 	bsplit := &BlockSplitterSimple{maxBlockSize, maxPtrsPerBlock, 10, 0}
 	kmd := libkeytest.NewEmptyKeyMetadata(id, 1)

--- a/go/kbfs/data/path_part_string.go
+++ b/go/kbfs/data/path_part_string.go
@@ -105,6 +105,11 @@ func (pps PathPartString) Plaintext() string {
 	return pps.plaintext
 }
 
+// Obfuscator returns this string's obfuscator.
+func (pps PathPartString) Obfuscator() Obfuscator {
+	return pps.obfuscator
+}
+
 var _ json.Marshaler = PathPartString{}
 
 // MarshalJSON implements the json.Marshaler interface for PathPartString.

--- a/go/kbfs/fsrpc/fs.go
+++ b/go/kbfs/fsrpc/fs.go
@@ -62,7 +62,7 @@ func (f fs) tlf(ctx context.Context, path Path) (keybase1.ListResult, error) {
 
 		// For entryInfo: for name, entryInfo := range children
 		for name := range children {
-			dirPath, err := path.Join(name)
+			dirPath, err := path.Join(name.Plaintext())
 			if err != nil {
 				return keybase1.ListResult{}, err
 			}

--- a/go/kbfs/fsrpc/path.go
+++ b/go/kbfs/fsrpc/path.go
@@ -298,7 +298,8 @@ func (p Path) GetNode(ctx context.Context, config libkbfs.Config) (libkbfs.Node,
 	}
 
 	for _, component := range p.TLFComponents {
-		lookupNode, lookupEntryInfo, lookupErr := config.KBFSOps().Lookup(ctx, node, component)
+		lookupNode, lookupEntryInfo, lookupErr := config.KBFSOps().Lookup(
+			ctx, node, node.ChildName(component))
 		if lookupErr != nil {
 			return nil, data.EntryInfo{}, lookupErr
 		}

--- a/go/kbfs/idutil/errors.go
+++ b/go/kbfs/idutil/errors.go
@@ -78,21 +78,31 @@ func (e TlfNameNotCanonical) Error() string {
 // NoSuchNameError indicates that the user tried to access a
 // subdirectory entry that doesn't exist.
 type NoSuchNameError struct {
-	Name string
+	Name      string
+	NameToLog string
 }
 
 // Error implements the error interface for NoSuchNameError
 func (e NoSuchNameError) Error() string {
-	return fmt.Sprintf("%s doesn't exist", e.Name)
+	n := e.Name
+	if len(e.NameToLog) > 0 {
+		n = e.NameToLog
+	}
+	return fmt.Sprintf("%s doesn't exist", n)
 }
 
 // BadTLFNameError indicates a top-level folder name that has an
 // incorrect format.
 type BadTLFNameError struct {
-	Name string
+	Name      string
+	NameToLog string
 }
 
 // Error implements the error interface for BadTLFNameError.
 func (e BadTLFNameError) Error() string {
-	return fmt.Sprintf("TLF name %s is in an incorrect format", e.Name)
+	n := e.Name
+	if len(e.NameToLog) > 0 {
+		n = e.NameToLog
+	}
+	return fmt.Sprintf("TLF name %s is in an incorrect format", n)
 }

--- a/go/kbfs/idutil/tlf_names.go
+++ b/go/kbfs/idutil/tlf_names.go
@@ -55,7 +55,7 @@ func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
 		return strings.ToLower(s), nil
 	}
 
-	return "", BadTLFNameError{s}
+	return "", BadTLFNameError{Name: s}
 }
 
 // normalizeNames normalizes a slice of names and returns

--- a/go/kbfs/kbfstool/ls.go
+++ b/go/kbfs/kbfstool/ls.go
@@ -148,7 +148,7 @@ func lsHelper(ctx context.Context, config libkbfs.Config, p fsrpc.Path, hasMulti
 				printHeader(p)
 			}
 			for name, entryInfo := range children {
-				handleEntry(name, entryInfo.Type)
+				handleEntry(name.Plaintext(), entryInfo.Type)
 			}
 		} else {
 			_, name, err := p.DirAndBasename()

--- a/go/kbfs/kbfstool/mkdir.go
+++ b/go/kbfs/kbfstool/mkdir.go
@@ -22,7 +22,8 @@ func maybePrintPath(path string, err error, verbose bool) {
 }
 
 func createDir(ctx context.Context, kbfsOps libkbfs.KBFSOps, parentNode libkbfs.Node, dirname, path string, verbose bool) (libkbfs.Node, error) {
-	childNode, _, err := kbfsOps.CreateDir(ctx, parentNode, dirname)
+	childNode, _, err := kbfsOps.CreateDir(
+		ctx, parentNode, parentNode.ChildName(dirname))
 	maybePrintPath(path, err, verbose)
 	return childNode, err
 }
@@ -62,7 +63,8 @@ func mkdirOne(ctx context.Context, config libkbfs.Config, dirPathStr string, cre
 
 			nextNode, err := createDir(ctx, kbfsOps, currNode, dirname, currP.String(), verbose)
 			if err == (data.NameExistsError{Name: dirname}) {
-				nextNode, _, err = kbfsOps.Lookup(ctx, currNode, dirname)
+				nextNode, _, err = kbfsOps.Lookup(
+					ctx, currNode, currNode.ChildName(dirname))
 			}
 			if err != nil {
 				return err

--- a/go/kbfs/kbfstool/write.go
+++ b/go/kbfs/kbfstool/write.go
@@ -93,7 +93,8 @@ func writeHelper(ctx context.Context, config libkbfs.Config, args []string) (err
 	// The operations below are racy, but that is inherent to a
 	// distributed FS.
 
-	fileNode, de, err := kbfsOps.Lookup(ctx, parentNode, filename)
+	filenamePPS := parentNode.ChildName(filename)
+	fileNode, de, err := kbfsOps.Lookup(ctx, parentNode, filenamePPS)
 	if err != nil && err != noSuchFileErr {
 		return err
 	}
@@ -105,7 +106,8 @@ func writeHelper(ctx context.Context, config libkbfs.Config, args []string) (err
 		if *verbose {
 			fmt.Fprintf(os.Stderr, "Creating %s\n", p)
 		}
-		fileNode, _, err = kbfsOps.CreateFile(ctx, parentNode, filename, false, libkbfs.NoExcl)
+		fileNode, _, err = kbfsOps.CreateFile(
+			ctx, parentNode, filenamePPS, false, libkbfs.NoExcl)
 		if err != nil {
 			return err
 		}

--- a/go/kbfs/libdokan/dir.go
+++ b/go/kbfs/libdokan/dir.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/libkb"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -209,12 +210,16 @@ func (f *Folder) resolve(ctx context.Context) (*tlfhandle.Handle, error) {
 		handle, err := tlfhandle.ParseHandlePreferred(
 			ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(), f.fs.config,
 			string(f.hPreferredName), f.h.Type())
-		if err != nil {
+		switch errors.Cause(err).(type) {
+		case nil:
+			f.TlfHandleChange(ctx, handle)
+			return handle, nil
+		case idutil.NoSuchNameError, idutil.BadTLFNameError,
+			tlf.NoSuchUserError, idutil.NoSuchUserError:
+			return nil, dokan.ErrObjectNameNotFound
+		default:
 			return nil, err
 		}
-		// Update the handle.
-		f.TlfHandleChange(ctx, handle)
-		return handle, nil
 	}
 
 	// In case there were any unresolved assertions, try them again on
@@ -289,7 +294,7 @@ func isSafeFolder(ctx context.Context, f *Folder) bool {
 
 // open tries to open a file.
 func (d *Dir) open(ctx context.Context, oc *openContext, path []string) (dokan.File, dokan.CreateStatus, error) {
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir openDir %v", path)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir openDir %s", path)
 
 	specialNode := handleTLFSpecialFile(lastStr(path), d.folder)
 	if specialNode != nil {
@@ -461,13 +466,14 @@ func getExclFromOpenContext(oc *openContext) libkbfs.Excl {
 }
 
 func (d *Dir) create(ctx context.Context, oc *openContext, name string) (f dokan.File, cst dokan.CreateStatus, err error) {
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", name)
+	namePPS := d.node.ChildName(name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", namePPS)
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
 	isExec := false // Windows lacks executable modes.
 	excl := getExclFromOpenContext(oc)
 	newNode, _, err := d.folder.fs.config.KBFSOps().CreateFile(
-		ctx, d.node, d.node.ChildName(name), isExec, excl)
+		ctx, d.node, namePPS, isExec, excl)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -479,11 +485,12 @@ func (d *Dir) create(ctx context.Context, oc *openContext, name string) (f dokan
 
 func (d *Dir) mkdir(ctx context.Context, oc *openContext, name string) (
 	f *Dir, cst dokan.CreateStatus, err error) {
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", name)
+	namePPS := d.node.ChildName(name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", namePPS)
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
 	newNode, _, err := d.folder.fs.config.KBFSOps().CreateDir(
-		ctx, d.node, d.node.ChildName(name))
+		ctx, d.node, namePPS)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -545,12 +552,13 @@ func (d *Dir) CanDeleteDirectory(ctx context.Context, fi *dokan.FileInfo) (err e
 // If Cleanup is called with non-nil FileInfo that has IsDeleteOnClose()
 // no libdokan locks should be held prior to the call.
 func (d *Dir) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
+	namePPS := d.node.ChildName(d.name)
 	var err error
 	if fi != nil {
-		d.folder.fs.logEnterf(ctx, "Dir Cleanup %q delete=%v", d.name,
+		d.folder.fs.logEnterf(ctx, "Dir Cleanup %s delete=%v", namePPS,
 			fi.IsDeleteOnClose())
 	} else {
-		d.folder.fs.logEnterf(ctx, "Dir Cleanup %q", d.name)
+		d.folder.fs.logEnterf(ctx, "Dir Cleanup %s", namePPS)
 	}
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
@@ -559,10 +567,9 @@ func (d *Dir) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 		d.folder.fs.renameAndDeletionLock.Lock()
 		defer d.folder.fs.renameAndDeletionLock.Unlock()
 		d.folder.fs.vlog.CLogf(
-			ctx, libkb.VLog1, "Removing (Delete) dir in cleanup %s", d.name)
+			ctx, libkb.VLog1, "Removing (Delete) dir in cleanup %s", namePPS)
 
-		err = d.folder.fs.config.KBFSOps().RemoveDir(
-			ctx, d.parent, d.parent.ChildName(d.name))
+		err = d.folder.fs.config.KBFSOps().RemoveDir(ctx, d.parent, namePPS)
 	}
 
 	if d.refcount.Decrease() {

--- a/go/kbfs/libdokan/file.go
+++ b/go/kbfs/libdokan/file.go
@@ -64,7 +64,8 @@ func (f *File) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 		f.folder.fs.vlog.CLogf(
 			ctx, libkb.VLog1, "Removing (Delete) file in cleanup %s", f.name)
 
-		err = f.folder.fs.config.KBFSOps().RemoveEntry(ctx, f.parent, f.name)
+		err = f.folder.fs.config.KBFSOps().RemoveEntry(
+			ctx, f.parent, f.parent.ChildName(f.name))
 	}
 
 	if f.refcount.Decrease() {

--- a/go/kbfs/libdokan/file.go
+++ b/go/kbfs/libdokan/file.go
@@ -44,7 +44,8 @@ func (f *File) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (a *d
 // CanDeleteFile - return just nil
 // TODO check for permissions here.
 func (f *File) CanDeleteFile(ctx context.Context, fi *dokan.FileInfo) error {
-	f.folder.fs.logEnterf(ctx, "File CanDeleteFile for %q", f.name)
+	namePPS := f.parent.ChildName(f.name)
+	f.folder.fs.logEnterf(ctx, "File CanDeleteFile for %s", namePPS)
 	return nil
 }
 
@@ -61,11 +62,12 @@ func (f *File) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 		// renameAndDeletionLock should be the first lock to be grabbed in libdokan.
 		f.folder.fs.renameAndDeletionLock.Lock()
 		defer f.folder.fs.renameAndDeletionLock.Unlock()
+		namePPS := f.parent.ChildName(f.name)
 		f.folder.fs.vlog.CLogf(
-			ctx, libkb.VLog1, "Removing (Delete) file in cleanup %s", f.name)
+			ctx, libkb.VLog1, "Removing (Delete) file in cleanup %s", namePPS)
 
 		err = f.folder.fs.config.KBFSOps().RemoveEntry(
-			ctx, f.parent, f.parent.ChildName(f.name))
+			ctx, f.parent, namePPS)
 	}
 
 	if f.refcount.Decrease() {

--- a/go/kbfs/libdokan/file.go
+++ b/go/kbfs/libdokan/file.go
@@ -5,6 +5,7 @@
 package libdokan
 
 import (
+	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/dokan"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/libkb"
@@ -41,11 +42,14 @@ func (f *File) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (a *d
 	return a, err
 }
 
+func (f *File) namePPS() data.PathPartString {
+	return f.parent.ChildName(f.name)
+}
+
 // CanDeleteFile - return just nil
 // TODO check for permissions here.
 func (f *File) CanDeleteFile(ctx context.Context, fi *dokan.FileInfo) error {
-	namePPS := f.parent.ChildName(f.name)
-	f.folder.fs.logEnterf(ctx, "File CanDeleteFile for %s", namePPS)
+	f.folder.fs.logEnterf(ctx, "File CanDeleteFile for %s", f.namePPS())
 	return nil
 }
 
@@ -62,7 +66,7 @@ func (f *File) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 		// renameAndDeletionLock should be the first lock to be grabbed in libdokan.
 		f.folder.fs.renameAndDeletionLock.Lock()
 		defer f.folder.fs.renameAndDeletionLock.Unlock()
-		namePPS := f.parent.ChildName(f.name)
+		namePPS := f.namePPS()
 		f.folder.fs.vlog.CLogf(
 			ctx, libkb.VLog1, "Removing (Delete) file in cleanup %s", namePPS)
 

--- a/go/kbfs/libdokan/folderlist.go
+++ b/go/kbfs/libdokan/folderlist.go
@@ -151,7 +151,9 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 				ctx, libkb.VLog1, "FL Lookup set alias: %q -> %q",
 				name, aliasTarget)
 			if !fl.isValidAliasTarget(ctx, aliasTarget) {
-				fl.fs.log.CDebugf(ctx, "FL Refusing alias to non-valid target %q", aliasTarget)
+				fl.fs.vlog.CLogf(
+					ctx, libkb.VLog1,
+					"FL Refusing alias to non-valid target %q", aliasTarget)
 				return nil, 0, dokan.ErrObjectNameNotFound
 			}
 			fl.mu.Lock()
@@ -168,7 +170,8 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 			path[0] = aliasTarget
 			continue
 
-		case idutil.NoSuchNameError, idutil.BadTLFNameError:
+		case idutil.NoSuchNameError, idutil.BadTLFNameError,
+			tlf.NoSuchUserError, idutil.NoSuchUserError:
 			return nil, 0, dokan.ErrObjectNameNotFound
 
 		default:

--- a/go/kbfs/libdokan/fs.go
+++ b/go/kbfs/libdokan/fs.go
@@ -555,7 +555,8 @@ func (f *FS) MoveFile(ctx context.Context, src dokan.File, sourceFI *dokan.FileI
 		ctx, libkb.VLog1, "FS MoveFile KBFSOps().Rename(ctx,%v,%v,%v,%v)",
 		srcParent, srcName, ddst.node, dstName)
 	if err := srcFolder.fs.config.KBFSOps().Rename(
-		ctx, srcParent, srcName, ddst.node, dstName); err != nil {
+		ctx, srcParent, srcParent.ChildName(srcName), ddst.node,
+		ddst.node.ChildName(dstName)); err != nil {
 		f.log.CDebugf(ctx, "FS MoveFile KBFSOps().Rename FAILED %v", err)
 		return err
 	}

--- a/go/kbfs/libdokan/mount_test.go
+++ b/go/kbfs/libdokan/mount_test.go
@@ -2051,7 +2051,7 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", tlf.Private)
 
 		ops := config.KBFSOps()
-		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
+		myfile, _, err := ops.Lookup(ctx, jdoe, jdoe.ChildName("myfile"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2325,7 +2325,7 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config1, "user1,user2", tlf.Private)
 
 		ops := config1.KBFSOps()
-		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
+		myfile, _, err := ops.Lookup(ctx, jdoe, jdoe.ChildName("myfile"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/kbfs/libdokan/mount_test.go
+++ b/go/kbfs/libdokan/mount_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/dokan"
-	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
@@ -2159,7 +2158,7 @@ func TestErrorFile(t *testing.T) {
 	}
 
 	// Make sure the root error file reads as expected
-	expectedErr := idutil.NoSuchUserError{Input: "janedoe"}
+	expectedErr := dokan.ErrObjectNameNotFound
 
 	// test both the root error file and one in a directory
 	testForErrorText(t, filepath.Join(mnt.Dir, libkbfs.ErrorFile),
@@ -2172,7 +2171,6 @@ func TestErrorFile(t *testing.T) {
 		expectedErr, "dir")
 	testForErrorText(t, filepath.Join(mnt.Dir, PrivateName, "jdoe", libkbfs.ErrorFile),
 		expectedErr, "dir")
-
 }
 
 type testMountObserver struct {

--- a/go/kbfs/libdokan/symlink.go
+++ b/go/kbfs/libdokan/symlink.go
@@ -30,7 +30,8 @@ func (s *Symlink) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (a
 	s.parent.folder.fs.logEnter(ctx, "Symlink GetFileInformation")
 	defer func() { s.parent.folder.reportErr(ctx, libkbfs.ReadMode, err) }()
 
-	_, _, err = s.parent.folder.fs.config.KBFSOps().Lookup(ctx, s.parent.node, s.name)
+	_, _, err = s.parent.folder.fs.config.KBFSOps().Lookup(
+		ctx, s.parent.node, s.parent.node.ChildName(s.name))
 	if err != nil {
 		return nil, errToDokan(err)
 	}

--- a/go/kbfs/libfs/file_info_file.go
+++ b/go/kbfs/libfs/file_info_file.go
@@ -22,7 +22,7 @@ type fileInfoFile struct {
 func GetFileInfo(
 	ctx context.Context, config libkbfs.Config, dir libkbfs.Node, name string) (
 	data []byte, t time.Time, err error) {
-	node, ei, err := config.KBFSOps().Lookup(ctx, dir, name)
+	node, ei, err := config.KBFSOps().Lookup(ctx, dir, dir.ChildName(name))
 	if err != nil {
 		return nil, time.Time{}, err
 	}

--- a/go/kbfs/libfs/fs.go
+++ b/go/kbfs/libfs/fs.go
@@ -846,7 +846,7 @@ func (fs *FS) Lstat(filename string) (fi os.FileInfo, err error) {
 // Symlink implements the billy.Filesystem interface for FS.
 func (fs *FS) Symlink(target, link string) (err error) {
 	fs.log.CDebugf(fs.ctx, "Symlink target=%s link=%s",
-		fs.pathForLogging(target), link)
+		fs.pathForLogging(target), fs.root.ChildName(link))
 	defer func() {
 		fs.deferLog.CDebugf(fs.ctx, "Symlink done: %+v", err)
 		err = translateErr(err)
@@ -867,7 +867,7 @@ func (fs *FS) Symlink(target, link string) (err error) {
 	}
 
 	_, err = fs.config.KBFSOps().CreateLink(
-		fs.ctx, n, n.ChildName(base), target)
+		fs.ctx, n, n.ChildName(base), n.ChildName(target))
 	return err
 }
 

--- a/go/kbfs/libfs/fs_test.go
+++ b/go/kbfs/libfs/fs_test.go
@@ -88,7 +88,7 @@ func testCreateFile(
 
 	children, err := fs.config.KBFSOps().GetDirChildren(ctx, parent)
 	require.NoError(t, err)
-	require.Contains(t, children, path.Base(file))
+	require.Contains(t, children, testPPS(path.Base(file)))
 
 	// Write to the file.
 	data := []byte{1}
@@ -131,6 +131,10 @@ func TestCreateFileInRoot(t *testing.T) {
 	testCreateFile(ctx, t, fs, "/bar", rootNode)
 }
 
+func testPPS(s string) data.PathPartString {
+	return data.NewPathPartString(s, nil)
+}
+
 func TestCreateFileInSubdir(t *testing.T) {
 	ctx, h, fs := makeFS(t, "")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, fs.config)
@@ -138,9 +142,9 @@ func TestCreateFileInSubdir(t *testing.T) {
 	rootNode, _, err := fs.config.KBFSOps().GetRootNode(
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	aNode, _, err := fs.config.KBFSOps().CreateDir(ctx, rootNode, "a")
+	aNode, _, err := fs.config.KBFSOps().CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
-	bNode, _, err := fs.config.KBFSOps().CreateDir(ctx, aNode, "b")
+	bNode, _, err := fs.config.KBFSOps().CreateDir(ctx, aNode, testPPS("b"))
 	require.NoError(t, err)
 
 	testCreateFile(ctx, t, fs, "a/b/foo", bNode)
@@ -236,7 +240,7 @@ func TestStat(t *testing.T) {
 	rootNode, _, err := fs.config.KBFSOps().GetRootNode(
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	aNode, _, err := fs.config.KBFSOps().CreateDir(ctx, rootNode, "a")
+	aNode, _, err := fs.config.KBFSOps().CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	testCreateFile(ctx, t, fs, "a/foo", aNode)
 
@@ -288,7 +292,8 @@ func TestStat(t *testing.T) {
 	rootNode2, _, err := fs2U2.config.KBFSOps().GetRootNode(
 		ctx, h2, data.MasterBranch)
 	require.NoError(t, err)
-	aNode2, _, err := fs2U2.config.KBFSOps().CreateDir(ctx, rootNode2, "a")
+	aNode2, _, err := fs2U2.config.KBFSOps().CreateDir(
+		ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	testCreateFile(ctx, t, fs2U2, "a/foo", aNode2)
 
@@ -383,7 +388,7 @@ func TestReadDir(t *testing.T) {
 	rootNode, _, err := fs.config.KBFSOps().GetRootNode(
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	aNode, _, err := fs.config.KBFSOps().CreateDir(ctx, rootNode, "a")
+	aNode, _, err := fs.config.KBFSOps().CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	testCreateFile(ctx, t, fs, "a/foo", aNode)
 	testCreateFile(ctx, t, fs, "a/bar", aNode)

--- a/go/kbfs/libfs/httpfs.go
+++ b/go/kbfs/libfs/httpfs.go
@@ -109,14 +109,14 @@ func (fod fileOrDir) Stat() (fi os.FileInfo, err error) {
 			fs:   fod.file.fs,
 			ei:   fod.ei,
 			node: fod.file.node,
-			name: fod.file.node.GetBasename(),
+			name: fod.file.node.GetBasename().Plaintext(),
 		}, nil
 	} else if fod.dir != nil {
 		return &FileInfo{
 			fs:   fod.dir.fs,
 			ei:   fod.ei,
 			node: fod.dir.node,
-			name: fod.dir.node.GetBasename(),
+			name: fod.dir.node.GetBasename().Plaintext(),
 		}, nil
 	}
 	return nil, errors.New("invalid fod")
@@ -133,7 +133,7 @@ var _ http.FileSystem = httpFileSystem{}
 // Open implements the http.FileSystem interface.
 func (hfs httpFileSystem) Open(filename string) (entry http.File, err error) {
 	hfs.fs.log.CDebugf(
-		hfs.fs.ctx, "hfs.Open %s", filename)
+		hfs.fs.ctx, "hfs.Open %s", hfs.fs.pathForLogging(filename))
 	defer func() {
 		hfs.fs.deferLog.CDebugf(hfs.fs.ctx, "hfs.Open done: %+v", err)
 		if err != nil {
@@ -150,7 +150,7 @@ func (hfs httpFileSystem) Open(filename string) (entry http.File, err error) {
 		return fileOrDir{
 			file: &File{
 				fs:       hfs.fs,
-				filename: n.GetBasename(),
+				filename: n.GetBasename().Plaintext(),
 				node:     n,
 				readOnly: true,
 				offset:   0,
@@ -161,7 +161,7 @@ func (hfs httpFileSystem) Open(filename string) (entry http.File, err error) {
 	return fileOrDir{
 		dir: &dir{
 			fs:      hfs.fs,
-			dirname: n.GetBasename(),
+			dirname: n.GetBasename().Plaintext(),
 			node:    n,
 		},
 		ei: ei,

--- a/go/kbfs/libfs/node_wrappers.go
+++ b/go/kbfs/libfs/node_wrappers.go
@@ -60,13 +60,13 @@ var perTlfWrappedNodeNames = map[string]bool{
 // ShouldCreateMissedLookup implements the Node interface for
 // specialFileNode.
 func (sfn *specialFileNode) ShouldCreateMissedLookup(
-	ctx context.Context, name string) (
+	ctx context.Context, name data.PathPartString) (
 	bool, context.Context, data.EntryType, os.FileInfo, string) {
-	if !perTlfWrappedNodeNames[name] {
+	if !perTlfWrappedNodeNames[name.Plaintext()] {
 		return sfn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
 
-	switch name {
+	switch name.Plaintext() {
 	case StatusFileName:
 		sfn := &statusFileNode{
 			Node:   nil,
@@ -85,7 +85,7 @@ func (sfn *specialFileNode) ShouldCreateMissedLookup(
 // WrapChild implements the Node interface for specialFileNode.
 func (sfn *specialFileNode) WrapChild(child libkbfs.Node) libkbfs.Node {
 	child = sfn.Node.WrapChild(child)
-	name := child.GetBasename()
+	name := child.GetBasename().Plaintext()
 	if !perTlfWrappedNodeNames[name] {
 		if child.EntryType() == data.Dir {
 			// Wrap this child too, so we can look up special files in

--- a/go/kbfs/libfs/node_wrappers.go
+++ b/go/kbfs/libfs/node_wrappers.go
@@ -61,7 +61,7 @@ var perTlfWrappedNodeNames = map[string]bool{
 // specialFileNode.
 func (sfn *specialFileNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	if !perTlfWrappedNodeNames[name.Plaintext()] {
 		return sfn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -75,7 +75,8 @@ func (sfn *specialFileNode) ShouldCreateMissedLookup(
 			log:    sfn.log,
 		}
 		f := sfn.GetFile(ctx)
-		return true, ctx, data.FakeFile, f.(*wrappedReadFile).GetInfo(), ""
+		return true, ctx, data.FakeFile, f.(*wrappedReadFile).GetInfo(),
+			data.PathPartString{}
 	default:
 		panic(fmt.Sprintf("Name %s was in map, but not in switch", name))
 	}

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -539,11 +539,12 @@ func (d *Dir) makeFile(node libkbfs.Node) (file *File) {
 
 // Lookup implements the fs.NodeRequestLookuper interface for Dir.
 func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.LookupResponse) (node fs.Node, err error) {
+	namePPS := d.node.ChildName(req.Name)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Lookup",
-		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
+		fmt.Sprintf("%s %s", d.node.GetBasename(), namePPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Lookup %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Lookup %s", namePPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -567,7 +568,7 @@ func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 	}
 
 	newNode, de, err := d.folder.fs.config.KBFSOps().Lookup(
-		ctx, d.node, d.node.ChildName(req.Name))
+		ctx, d.node, namePPS)
 	if err != nil {
 		if _, ok := err.(idutil.NoSuchNameError); ok {
 			return nil, fuse.ENOENT
@@ -625,17 +626,18 @@ func getEXCLFromCreateRequest(req *fuse.CreateRequest) libkbfs.Excl {
 
 // Create implements the fs.NodeCreater interface for Dir.
 func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (node fs.Node, handle fs.Handle, err error) {
+	namePPS := d.node.ChildName(req.Name)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Create",
-		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
+		fmt.Sprintf("%s %s", d.node.GetBasename(), namePPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", namePPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	isExec := (req.Mode.Perm() & 0100) != 0
 	excl := getEXCLFromCreateRequest(req)
 	newNode, ei, err := d.folder.fs.config.KBFSOps().CreateFile(
-		ctx, d.node, d.node.ChildName(req.Name), isExec, excl)
+		ctx, d.node, namePPS, isExec, excl)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -661,11 +663,12 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 // Mkdir implements the fs.NodeMkdirer interface for Dir.
 func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 	node fs.Node, err error) {
+	namePPS := d.node.ChildName(req.Name)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Mkdir",
-		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
+		fmt.Sprintf("%s %s", d.node.GetBasename(), namePPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", namePPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -676,7 +679,7 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 	}
 
 	newNode, _, err := d.folder.fs.config.KBFSOps().CreateDir(
-		ctx, d.node, d.node.ChildName(req.Name))
+		ctx, d.node, namePPS)
 	if err != nil {
 		return nil, err
 	}
@@ -691,13 +694,14 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 // Symlink implements the fs.NodeSymlinker interface for Dir.
 func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	node fs.Node, err error) {
+	namePPS := d.node.ChildName(req.NewName)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Symlink",
 		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
-			req.NewName, req.Target))
+			namePPS, req.Target))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.vlog.CLogf(
-		ctx, libkb.VLog1, "Dir Symlink %s -> %s", req.NewName, req.Target)
+		ctx, libkb.VLog1, "Dir Symlink %s -> %s", namePPS, req.Target)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -708,7 +712,7 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	}
 
 	if _, err := d.folder.fs.config.KBFSOps().CreateLink(
-		ctx, d.node, d.node.ChildName(req.NewName), req.Target); err != nil {
+		ctx, d.node, namePPS, req.Target); err != nil {
 		return nil, err
 	}
 
@@ -723,13 +727,18 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 // Rename implements the fs.NodeRenamer interface for Dir.
 func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 	newDir fs.Node) (err error) {
+	oldNamePPS := d.node.ChildName(req.OldName)
+	// We need to log the new name before we have the new node, so
+	// just obfuscate it with the old node for now, it's the best we
+	// can do.
+	newNameLoggingPPS := d.node.ChildName(req.NewName)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Rename",
 		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
-			req.OldName, req.NewName))
+			oldNamePPS, newNameLoggingPPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.vlog.CLogf(
-		ctx, libkb.VLog1, "Dir Rename %s -> %s", req.OldName, req.NewName)
+		ctx, libkb.VLog1, "Dir Rename %s -> %s", oldNamePPS, newNameLoggingPPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	var realNewDir *Dir
@@ -755,7 +764,7 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 	}
 
 	err = d.folder.fs.config.KBFSOps().Rename(ctx,
-		d.node, d.node.ChildName(req.OldName), realNewDir.node,
+		d.node, oldNamePPS, realNewDir.node,
 		realNewDir.node.ChildName(req.NewName))
 
 	switch e := err.(type) {
@@ -777,11 +786,12 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 
 // Remove implements the fs.NodeRemover interface for Dir.
 func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
+	namePPS := d.node.ChildName(req.Name)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Remove",
-		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
+		fmt.Sprintf("%s %s", d.node.GetBasename(), namePPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Remove %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Remove %s", namePPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -793,7 +803,6 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
 
 	// node will be removed from Folder.nodes, if it is there in the
 	// first place, by its Forget
-	namePPS := d.node.ChildName(req.Name)
 	if req.Dir {
 		err = d.folder.fs.config.KBFSOps().RemoveDir(ctx, d.node, namePPS)
 	} else {

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -695,9 +695,9 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	node fs.Node, err error) {
 	namePPS := d.node.ChildName(req.NewName)
+	targetPPS := d.node.ChildName(req.Target)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Symlink",
-		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
-			namePPS, req.Target))
+		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(), namePPS, targetPPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.vlog.CLogf(
@@ -712,7 +712,7 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	}
 
 	if _, err := d.folder.fs.config.KBFSOps().CreateLink(
-		ctx, d.node, namePPS, req.Target); err != nil {
+		ctx, d.node, namePPS, targetPPS); err != nil {
 		return nil, err
 	}
 

--- a/go/kbfs/libfuse/file.go
+++ b/go/kbfs/libfuse/file.go
@@ -88,7 +88,7 @@ func (f *File) fillAttrWithMode(
 // Attr implements the fs.Node interface for File.
 func (f *File) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 	ctx = f.folder.fs.config.MaybeStartTrace(
-		ctx, "File.Attr", f.node.GetBasename())
+		ctx, "File.Attr", f.node.GetBasename().String())
 	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	f.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "File Attr")
@@ -134,7 +134,7 @@ var _ fs.NodeAccesser = (*File)(nil)
 // executable" UTI.
 func (f *File) Access(ctx context.Context, r *fuse.AccessRequest) (err error) {
 	ctx = f.folder.fs.config.MaybeStartTrace(
-		ctx, "File.Access", f.node.GetBasename())
+		ctx, "File.Access", f.node.GetBasename().String())
 	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	if int(r.Uid) != os.Getuid() &&
@@ -193,7 +193,7 @@ func (f *File) sync(ctx context.Context) error {
 // Fsync implements the fs.NodeFsyncer interface for File.
 func (f *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) (err error) {
 	ctx = f.folder.fs.config.MaybeStartTrace(
-		ctx, "File.Fsync", f.node.GetBasename())
+		ctx, "File.Fsync", f.node.GetBasename().String())
 	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	f.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "File Fsync")

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -212,8 +212,9 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 		}
 		return n, nil
 
-	case idutil.NoSuchNameError, idutil.BadTLFNameError:
-		// Invalid public TLF.
+	case idutil.NoSuchNameError, idutil.BadTLFNameError,
+		tlf.NoSuchUserError, idutil.NoSuchUserError:
+		// Invalid TLF.
 		return nil, fuse.ENOENT
 
 	default:
@@ -313,6 +314,11 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 
 	case idutil.TlfNameNotCanonical:
 		return nil
+
+	case idutil.NoSuchNameError, idutil.BadTLFNameError,
+		tlf.NoSuchUserError, idutil.NoSuchUserError:
+		// Invalid TLF.
+		return fuse.ENOENT
 
 	default:
 		return err

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -1989,7 +1989,7 @@ func TestSetattrFileMtimeAfterWrite(t *testing.T) {
 		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", tlf.Private)
 
 		ops := config.KBFSOps()
-		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
+		myfile, _, err := ops.Lookup(ctx, jdoe, jdoe.ChildName("myfile"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2711,7 +2711,7 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 
 		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", tlf.Private)
 		ops := config.KBFSOps()
-		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
+		myfile, _, err := ops.Lookup(ctx, jdoe, jdoe.ChildName("myfile"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2999,7 +2999,7 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config1, "user1,user2", tlf.Private)
 
 		ops := config1.KBFSOps()
-		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
+		myfile, _, err := ops.Lookup(ctx, jdoe, jdoe.ChildName("myfile"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -24,7 +24,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
-	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
@@ -2825,7 +2824,7 @@ func TestErrorFile(t *testing.T) {
 	}
 
 	// Make sure the root error file reads as expected
-	expectedErr := idutil.NoSuchUserError{Input: "janedoe"}
+	expectedErr := fuse.ENOENT
 
 	// test both the root error file and one in a directory
 	testForErrorText(t, path.Join(mnt.Dir, libkbfs.ErrorFile),

--- a/go/kbfs/libfuse/symlink.go
+++ b/go/kbfs/libfuse/symlink.go
@@ -39,7 +39,8 @@ func (s *Symlink) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 	s.parent.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Symlink Attr")
 	defer func() { err = s.parent.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
-	_, de, err := s.parent.folder.fs.config.KBFSOps().Lookup(ctx, s.parent.node, s.name)
+	_, de, err := s.parent.folder.fs.config.KBFSOps().Lookup(
+		ctx, s.parent.node, s.parent.node.ChildName(s.name))
 	if err != nil {
 		if _, ok := err.(idutil.NoSuchNameError); ok {
 			return fuse.ESTALE
@@ -60,7 +61,8 @@ func (s *Symlink) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (link
 	s.parent.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Symlink Readlink")
 	defer func() { err = s.parent.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
-	_, de, err := s.parent.folder.fs.config.KBFSOps().Lookup(ctx, s.parent.node, s.name)
+	_, de, err := s.parent.folder.fs.config.KBFSOps().Lookup(
+		ctx, s.parent.node, s.parent.node.ChildName(s.name))
 	if err != nil {
 		return "", err
 	}

--- a/go/kbfs/libgit/autogit_node_wrappers.go
+++ b/go/kbfs/libgit/autogit_node_wrappers.go
@@ -137,7 +137,7 @@ var _ libkbfs.Node = (*repoDirNode)(nil)
 // repoDirNode.
 func (rdn *repoDirNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	namePlain := name.Plaintext()
 	switch {
 	case strings.HasPrefix(namePlain, AutogitBranchPrefix):
@@ -148,7 +148,7 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 		// It's difficult to tell if a given name is a legitimate
 		// prefix for a branch name or not, so just accept everything.
 		// If it's not legit, trying to read the data will error out.
-		return true, ctx, data.FakeDir, nil, ""
+		return true, ctx, data.FakeDir, nil, data.PathPartString{}
 	case strings.HasPrefix(namePlain, AutogitCommitPrefix):
 		commit := strings.TrimPrefix(namePlain, AutogitCommitPrefix)
 		if len(commit) == 0 {
@@ -167,7 +167,8 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 			rdn.am.log.CDebugf(ctx, "Error getting commit file")
 			return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 		}
-		return true, ctx, data.FakeFile, f.(*diffFile).GetInfo(), ""
+		return true, ctx, data.FakeFile, f.(*diffFile).GetInfo(),
+			data.PathPartString{}
 	default:
 		return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -315,7 +316,7 @@ var _ libkbfs.Node = (*rootNode)(nil)
 // rootNode.
 func (rn *rootNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	if name.Plaintext() != AutogitRoot {
 		return rn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -344,7 +345,7 @@ func (rn *rootNode) ShouldCreateMissedLookup(
 		}
 		rn.fs = fs
 	}
-	return true, ctx, data.FakeDir, nil, ""
+	return true, ctx, data.FakeDir, nil, data.PathPartString{}
 }
 
 // WrapChild implements the Node interface for rootNode.

--- a/go/kbfs/libgit/repo.go
+++ b/go/kbfs/libgit/repo.go
@@ -388,10 +388,10 @@ func createNewRepoAndID(
 
 func lookupOrCreateDir(ctx context.Context, config libkbfs.Config,
 	n libkbfs.Node, name string) (libkbfs.Node, error) {
-	newNode, _, err := config.KBFSOps().Lookup(ctx, n, name)
+	newNode, _, err := config.KBFSOps().Lookup(ctx, n, n.ChildName(name))
 	switch errors.Cause(err).(type) {
 	case idutil.NoSuchNameError:
-		newNode, _, err = config.KBFSOps().CreateDir(ctx, n, name)
+		newNode, _, err = config.KBFSOps().CreateDir(ctx, n, n.ChildName(name))
 		if err != nil {
 			return nil, err
 		}
@@ -441,7 +441,8 @@ func getOrCreateRepoAndID(
 		return nil, NullID, err
 	}
 
-	_, repoEI, err := config.KBFSOps().Lookup(ctx, repoDir, normalizedRepoName)
+	repoNamePPS := repoDir.ChildName(normalizedRepoName)
+	_, repoEI, err := config.KBFSOps().Lookup(ctx, repoDir, repoNamePPS)
 	switch errors.Cause(err).(type) {
 	case idutil.NoSuchNameError:
 		if op == getOnly {
@@ -459,7 +460,7 @@ func getOrCreateRepoAndID(
 			config.MakeLogger("").CDebugf(
 				ctx, "Overwriting symlink for repo %s with a new repo",
 				normalizedRepoName)
-			err = config.KBFSOps().RemoveEntry(ctx, repoDir, normalizedRepoName)
+			err = config.KBFSOps().RemoveEntry(ctx, repoDir, repoNamePPS)
 			if err != nil {
 				return nil, NullID, err
 			}
@@ -608,12 +609,14 @@ func DeleteRepo(
 	}
 	normalizedRepoName := normalizeRepoName(repoName)
 
-	repoNode, _, err := kbfsOps.Lookup(ctx, rootNode, kbfsRepoDir)
+	repoNode, _, err := kbfsOps.Lookup(
+		ctx, rootNode, rootNode.ChildName(kbfsRepoDir))
 	if err != nil {
 		return castNoSuchNameError(err, repoName)
 	}
 
-	_, _, err = kbfsOps.Lookup(ctx, repoNode, normalizedRepoName)
+	repoNamePPS := repoNode.ChildName(normalizedRepoName)
+	_, _, err = kbfsOps.Lookup(ctx, repoNode, repoNamePPS)
 	if err != nil {
 		return castNoSuchNameError(err, repoName)
 	}
@@ -631,8 +634,8 @@ func DeleteRepo(
 	dirSuffix := fmt.Sprintf(
 		"%s-%d", session.VerifyingKey.String(), config.Clock().Now().UnixNano())
 	return kbfsOps.Rename(
-		ctx, repoNode, normalizedRepoName, deletedReposNode,
-		normalizedRepoName+dirSuffix)
+		ctx, repoNode, repoNamePPS, deletedReposNode,
+		deletedReposNode.ChildName(normalizedRepoName+dirSuffix))
 }
 
 func renameRepoInConfigFile(
@@ -692,13 +695,15 @@ func RenameRepo(
 	normalizedOldRepoName := normalizeRepoName(oldRepoName)
 	normalizedNewRepoName := normalizeRepoName(newRepoName)
 
-	repoNode, _, err := kbfsOps.Lookup(ctx, rootNode, kbfsRepoDir)
+	repoNode, _, err := kbfsOps.Lookup(
+		ctx, rootNode, rootNode.ChildName(kbfsRepoDir))
 	if err != nil {
 		return err
 	}
 
 	// Does the old repo definitely exist?
-	_, _, err = kbfsOps.Lookup(ctx, repoNode, normalizedOldRepoName)
+	_, _, err = kbfsOps.Lookup(
+		ctx, repoNode, repoNode.ChildName(normalizedOldRepoName))
 	if err != nil {
 		return err
 	}
@@ -748,7 +753,8 @@ func RenameRepo(
 	}
 
 	// Does the new repo not exist yet?
-	_, ei, err := kbfsOps.Lookup(ctx, repoNode, normalizedNewRepoName)
+	repoNamePPS := repoNode.ChildName(normalizedNewRepoName)
+	_, ei, err := kbfsOps.Lookup(ctx, repoNode, repoNamePPS)
 	switch errors.Cause(err).(type) {
 	case idutil.NoSuchNameError:
 		// The happy path.
@@ -757,8 +763,7 @@ func RenameRepo(
 			config.MakeLogger("").CDebugf(
 				ctx, "Overwriting symlink for repo %s with a new repo",
 				normalizedNewRepoName)
-			err = config.KBFSOps().RemoveEntry(
-				ctx, repoNode, normalizedNewRepoName)
+			err = config.KBFSOps().RemoveEntry(ctx, repoNode, repoNamePPS)
 			if err != nil {
 				return err
 			}

--- a/go/kbfs/libgit/repo.go
+++ b/go/kbfs/libgit/repo.go
@@ -441,7 +441,8 @@ func getOrCreateRepoAndID(
 		return nil, NullID, err
 	}
 
-	repoNamePPS := repoDir.ChildName(normalizedRepoName)
+	// No need to obfuscate the repo name.
+	repoNamePPS := data.NewPathPartString(normalizedRepoName, nil)
 	_, repoEI, err := config.KBFSOps().Lookup(ctx, repoDir, repoNamePPS)
 	switch errors.Cause(err).(type) {
 	case idutil.NoSuchNameError:
@@ -615,7 +616,8 @@ func DeleteRepo(
 		return castNoSuchNameError(err, repoName)
 	}
 
-	repoNamePPS := repoNode.ChildName(normalizedRepoName)
+	// No need to obfuscate the repo name.
+	repoNamePPS := data.NewPathPartString(normalizedRepoName, nil)
 	_, _, err = kbfsOps.Lookup(ctx, repoNode, repoNamePPS)
 	if err != nil {
 		return castNoSuchNameError(err, repoName)
@@ -752,8 +754,8 @@ func RenameRepo(
 			keybase1.GitPushType_RENAMEREPO, oldRepoName, nil)
 	}
 
-	// Does the new repo not exist yet?
-	repoNamePPS := repoNode.ChildName(normalizedNewRepoName)
+	// Does the new repo not exist yet? No need to obfuscate the repo name.
+	repoNamePPS := data.NewPathPartString(normalizedNewRepoName, nil)
 	_, ei, err := kbfsOps.Lookup(ctx, repoNode, repoNamePPS)
 	switch errors.Cause(err).(type) {
 	case idutil.NoSuchNameError:

--- a/go/kbfs/libgit/repo_test.go
+++ b/go/kbfs/libgit/repo_test.go
@@ -286,14 +286,15 @@ func TestDeleteRepo(t *testing.T) {
 	err = DeleteRepo(ctx, config, h, "Repo1")
 	require.NoError(t, err)
 
-	gitNode, _, err := config.KBFSOps().Lookup(ctx, rootNode, kbfsRepoDir)
+	gitNode, _, err := config.KBFSOps().Lookup(
+		ctx, rootNode, rootNode.ChildName(kbfsRepoDir))
 	require.NoError(t, err)
 	children, err := config.KBFSOps().GetDirChildren(ctx, gitNode)
 	require.NoError(t, err)
 	require.Len(t, children, 0) // .kbfs_deleted_repos is hidden
 
 	deletedReposNode, _, err := config.KBFSOps().Lookup(
-		ctx, gitNode, kbfsDeletedReposDir)
+		ctx, gitNode, gitNode.ChildName(kbfsDeletedReposDir))
 	require.NoError(t, err)
 	children, err = config.KBFSOps().GetDirChildren(ctx, deletedReposNode)
 	require.NoError(t, err)

--- a/go/kbfs/libhttpserver/server_test.go
+++ b/go/kbfs/libhttpserver/server_test.go
@@ -50,7 +50,8 @@ func makeTestKBFSConfig(t *testing.T) (
 
 	root, _, err := cfg.KBFSOps().GetOrCreateRootNode(ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	_, _, err = cfg.KBFSOps().CreateFile(ctx, root, "test.txt", false, false)
+	_, _, err = cfg.KBFSOps().CreateFile(
+		ctx, root, root.ChildName("test.txt"), false, false)
 	require.NoError(t, err)
 
 	return cfg, shutdown

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -1500,7 +1500,8 @@ outer:
 					invertCreate)
 			}
 			cr.log.CDebugf(ctx, "Putting new merged rename info "+
-				"%v -> %v (symPath: %v)", ptr, newInfo, symPath)
+				"%v -> %v (symPath: %v)", ptr, newInfo,
+				data.NewPathPartString(symPath, chain.obfuscator))
 			mergedChains.renamedOriginals[ptr] = newInfo
 
 			// Fix up the corresponding rmOp to make sure
@@ -1761,8 +1762,8 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 			// since this createOp must have been created
 			// as part of conflict resolution.
 			symPath := "./" + strings.Repeat("../", walkBack)
-			cr.log.CDebugf(ctx, "Creating symlink %s at "+
-				"merged path %s", symPath, mergedPath)
+			cr.log.CDebugf(ctx, "Creating symlink %s at merged path %s",
+				data.NewPathPartString(symPath, chain.obfuscator), mergedPath)
 
 			err = cr.convertCreateIntoSymlinkOrCopy(ctx, ptr, info, chain,
 				unmergedChains, mergedChains, symPath)

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -2304,6 +2304,8 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	dirtyBcache data.DirtyBlockCacheSimple) (data.BlockPointer, error) {
 	kmd := chains.mostRecentChainMDInfo
 
+	// Use a `nil` childObfuscator here, since this is for a file and
+	// files can't have children to obfuscate, by defintion.
 	file := parentPath.ChildPath(name, ptr, nil)
 	oldInfos, err := cr.fbo.blocks.getIndirectFileBlockInfosLocked(
 		ctx, lState, kmd, file)

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -469,8 +469,8 @@ func TestCRMergedChainsSimple(t *testing.T) {
 	mergedPaths[expectedUnmergedPath.TailPointer()] = mergedPath
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dir2.ChildName("file2"), dir2.ChildName("file2"), "", false, false,
-			data.DirEntry{}, nil}},
+			dir2.ChildName("file2"), dir2.ChildName("file2"),
+			dir2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
 		mergedPaths, nil, expectedActions)
@@ -543,8 +543,8 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	mergedPaths[expectedUnmergedPath.TailPointer()] = mergedPath
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dirB2.ChildName("file2"), dirB2.ChildName("file2"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirB2.ChildName("file2"), dirB2.ChildName("file2"),
+			dirB2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
 		mergedPaths, nil, expectedActions)
@@ -646,14 +646,15 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	dirAPtr1 := cr1.fbo.nodeCache.PathFromNode(dirA1).TailPointer()
 	expectedActions := map[data.BlockPointer]crActionList{
 		dirCPtr: {&copyUnmergedEntryAction{
-			dirC2.ChildName("file2"), dirC2.ChildName("file2"), "",
-			false, false, data.DirEntry{}, nil}},
+			dirC2.ChildName("file2"), dirC2.ChildName("file2"),
+			dirC2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		dirBPtr: {&copyUnmergedEntryAction{
-			dirB1.ChildName("dirC"), dirB1.ChildName("dirC"), "", false, false,
+			dirB1.ChildName("dirC"), dirB1.ChildName("dirC"),
+			dirB1.ChildName(""), false, false,
 			data.DirEntry{}, nil}},
 		dirAPtr1: {&copyUnmergedEntryAction{
-			dirA1.ChildName("dirB"), dirA1.ChildName("dirB"), "", false, false,
-			data.DirEntry{}, nil}},
+			dirA1.ChildName("dirB"), dirA1.ChildName("dirB"),
+			dirA1.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
@@ -745,8 +746,8 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dirC2.ChildName("file2"), dirC2.ChildName("file2"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirC2.ChildName("file2"), dirC2.ChildName("file2"),
+			dirC2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
@@ -944,17 +945,17 @@ func TestCRMergedChainsComplex(t *testing.T) {
 	mergedPathE := cr1.fbo.nodeCache.PathFromNode(dirE1)
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPathA.TailPointer(): {&copyUnmergedEntryAction{
-			dirA2.ChildName("dirJ"), dirA2.ChildName("dirJ"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirA2.ChildName("dirJ"), dirA2.ChildName("dirJ"),
+			dirA2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathE.TailPointer(): {&copyUnmergedEntryAction{
-			dirE1.ChildName("dirF"), dirE1.ChildName("dirF"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirE1.ChildName("dirF"), dirE1.ChildName("dirF"),
+			dirE1.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathF.TailPointer(): {&copyUnmergedEntryAction{
-			dirF2.ChildName("file3"), dirF2.ChildName("file3"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirF2.ChildName("file3"), dirF2.ChildName("file3"),
+			dirF2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathH.TailPointer(): {&copyUnmergedEntryAction{
-			dirH2.ChildName("file4"), dirH2.ChildName("file4"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirH2.ChildName("file4"), dirH2.ChildName("file4"),
+			dirH2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathB.TailPointer(): {&rmMergedEntryAction{
 			dirB2.ChildName("dirD")}},
 	}
@@ -1058,8 +1059,8 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPathRoot.TailPointer(): {&dropUnmergedAction{ro}},
 		mergedPathB.TailPointer(): {&copyUnmergedEntryAction{
-			dirB2.ChildName("dirA"), dirB2.ChildName("dirA"), "./../", false,
-			false, data.DirEntry{}, nil}},
+			dirB2.ChildName("dirA"), dirB2.ChildName("dirA"),
+			dirB2.ChildName("./../"), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathRoot, unmergedPathB},
@@ -1139,7 +1140,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 			dirRoot1.ChildName("file1"),
 			dirRoot1.ChildName(cre.ConflictRenameHelper(
 				now, "u2", "dev1", "file1")),
-			"", 0, false, data.ZeroPtr, data.ZeroPtr}},
+			dirRoot1.ChildName(""), 0, false, data.ZeroPtr, data.ZeroPtr}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathRoot},
@@ -1261,7 +1262,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 			dirRoot1.ChildName("file"),
 			dirRoot2.ChildName(cre.ConflictRenameHelper(
 				now, "u2", "dev1", "file")),
-			"", 0, false, data.ZeroPtr, data.ZeroPtr}},
+			dirRoot1.ChildName(""), 0, false, data.ZeroPtr, data.ZeroPtr}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathFile},

--- a/go/kbfs/libkbfs/cr_actions.go
+++ b/go/kbfs/libkbfs/cr_actions.go
@@ -23,8 +23,8 @@ import (
 // this action may copy the /merged/ entry instead of the unmerged
 // one.
 type copyUnmergedEntryAction struct {
-	fromName      string
-	toName        string
+	fromName      data.PathPartString
+	toName        data.PathPartString
 	symPath       string
 	sizeOnly      bool
 	unique        bool
@@ -134,35 +134,38 @@ func (cuea *copyUnmergedEntryAction) swapUnmergedBlock(
 	if err != nil {
 		return false, data.ZeroPtr, err
 	}
-	cuea.fromName = newName
+	cuea.fromName = data.NewPathPartString(newName, cuea.fromName.Obfuscator())
 	return true, parentMostRecent, nil
 }
 
 func uniquifyName(
-	ctx context.Context, dir *data.DirData, name string) (string, error) {
+	ctx context.Context, dir *data.DirData, name data.PathPartString) (
+	data.PathPartString, error) {
 	_, err := dir.Lookup(ctx, name)
 	switch errors.Cause(err).(type) {
 	case nil:
 	case idutil.NoSuchNameError:
 		return name, nil
 	default:
-		return "", err
+		return data.PathPartString{}, err
 	}
 
-	base, ext := data.SplitFileExtension(name)
+	base, ext := data.SplitFileExtension(name.Plaintext())
 	for i := 1; i <= 100; i++ {
-		newName := fmt.Sprintf("%s (%d)%s", base, i, ext)
+		newName := data.NewPathPartString(
+			fmt.Sprintf("%s (%d)%s", base, i, ext), name.Obfuscator())
 		_, err := dir.Lookup(ctx, newName)
 		switch errors.Cause(err).(type) {
 		case nil:
 		case idutil.NoSuchNameError:
 			return newName, nil
 		default:
-			return "", err
+			return data.PathPartString{}, err
 		}
 	}
 
-	return "", fmt.Errorf("Couldn't find a unique name for %s", name)
+	return data.PathPartString{}, fmt.Errorf(
+		"Couldn't find a unique name for %s", name)
 }
 
 func (cuea *copyUnmergedEntryAction) do(
@@ -240,6 +243,9 @@ func prependOpsToChain(mostRecent data.BlockPointer, chains *crChains,
 		chain = chains.byMostRecent[mostRecent]
 		chain.ops = nil // will prepend it below
 	}
+	for _, op := range newOps {
+		chain.ensurePath(op, mostRecent)
+	}
 	// prepend it
 	chain.ops = append(newOps, chain.ops...)
 	return nil
@@ -247,7 +253,7 @@ func prependOpsToChain(mostRecent data.BlockPointer, chains *crChains,
 
 func crActionConvertSymlink(unmergedMostRecent data.BlockPointer,
 	mergedMostRecent data.BlockPointer, unmergedChain *crChain,
-	mergedChains *crChains, fromName string, toName string) error {
+	mergedChains *crChains, toName string) error {
 	co, err := newCreateOp(toName, mergedMostRecent, data.Sym)
 	if err != nil {
 		return err
@@ -260,6 +266,7 @@ func crActionConvertSymlink(unmergedMostRecent data.BlockPointer,
 	// `makeLocalRenameOpForCopyAction()`).
 	chain, ok := mergedChains.byMostRecent[mergedMostRecent]
 	if ok {
+		chain.ensurePath(co, mergedMostRecent)
 		chain.ops = append(chain.ops, co)
 	} else {
 		err := prependOpsToChain(mergedMostRecent, mergedChains, co)
@@ -324,18 +331,21 @@ func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
 	mostRecentTargetPtr data.BlockPointer, unmergedChain *crChain,
 	unmergedChains *crChains) {
 	trackSyncPtrChangesInCreate(
-		mostRecentTargetPtr, unmergedChain, unmergedChains, cuea.toName)
+		mostRecentTargetPtr, unmergedChain, unmergedChains,
+		cuea.toName.Plaintext())
 }
 
 func makeLocalRenameOpForCopyAction(
-	ctx context.Context, mergedMostRecent data.BlockPointer, mergedDir *data.DirData,
-	mergedChains *crChains, fromName, toName string) error {
+	ctx context.Context, mergedMostRecent data.BlockPointer,
+	mergedDir *data.DirData, mergedChains *crChains, fromName,
+	toName data.PathPartString) error {
 	newMergedEntry, err := mergedDir.Lookup(ctx, toName)
 	if err != nil {
 		return err
 	}
 
-	rop, err := newRenameOp(fromName, mergedMostRecent, toName,
+	rop, err := newRenameOp(
+		fromName.Plaintext(), mergedMostRecent, toName.Plaintext(),
 		mergedMostRecent, newMergedEntry.BlockPointer,
 		newMergedEntry.Type)
 	if err != nil {
@@ -359,7 +369,7 @@ func (cuea *copyUnmergedEntryAction) updateOps(
 
 	if cuea.symPath != "" && !unmergedChain.isFile() {
 		err := crActionConvertSymlink(unmergedMostRecent, mergedMostRecent,
-			unmergedChain, mergedChains, cuea.fromName, cuea.toName)
+			unmergedChain, mergedChains, cuea.toName.Plaintext())
 		if err != nil {
 			return err
 		}
@@ -369,10 +379,10 @@ func (cuea *copyUnmergedEntryAction) updateOps(
 	// with the new name.
 	// The merged ops don't change, though later we may have to
 	// manipulate the block pointers in the original ops.
-	if cuea.fromName != cuea.toName {
-		unmergedChain.ops =
-			fixupNamesInOps(cuea.fromName, cuea.toName, unmergedChain.ops,
-				unmergedChains)
+	if cuea.fromName.Plaintext() != cuea.toName.Plaintext() {
+		unmergedChain.ops = fixupNamesInOps(
+			cuea.fromName.Plaintext(), cuea.toName.Plaintext(),
+			unmergedChain.ops, unmergedChains)
 
 		if cuea.unique || cuea.symPath != "" {
 			// If a directory was renamed locally, either because of a
@@ -409,8 +419,8 @@ func (cuea *copyUnmergedEntryAction) String() string {
 // unmerged entry for the given name should be copied directly into
 // the merged version of the directory; there should be no conflict.
 type copyUnmergedAttrAction struct {
-	fromName string
-	toName   string
+	fromName data.PathPartString
+	toName   data.PathPartString
 	attr     []attrChange
 	moved    bool // move this action to the parent at most one time
 }
@@ -462,10 +472,10 @@ func (cuaa *copyUnmergedAttrAction) updateOps(
 	// with the new name.
 	// The merged ops don't change, though later we may have to
 	// manipulate the block pointers in the original ops.
-	if cuaa.fromName != cuaa.toName {
-		unmergedChain.ops =
-			fixupNamesInOps(cuaa.fromName, cuaa.toName, unmergedChain.ops,
-				unmergedChains)
+	if cuaa.fromName.Plaintext() != cuaa.toName.Plaintext() {
+		unmergedChain.ops = fixupNamesInOps(
+			cuaa.fromName.Plaintext(), cuaa.toName.Plaintext(),
+			unmergedChain.ops, unmergedChains)
 	}
 	return nil
 }
@@ -478,7 +488,7 @@ func (cuaa *copyUnmergedAttrAction) String() string {
 // rmMergedEntryAction says that the merged entry for the given name
 // should be deleted.
 type rmMergedEntryAction struct {
-	name string
+	name data.PathPartString
 }
 
 func (rmea *rmMergedEntryAction) swapUnmergedBlock(
@@ -510,8 +520,8 @@ func (rmea *rmMergedEntryAction) String() string {
 // renameUnmergedAction says that the unmerged copy of a file needs to
 // be renamed, and the file blocks should be copied.
 type renameUnmergedAction struct {
-	fromName     string
-	toName       string
+	fromName     data.PathPartString
+	toName       data.PathPartString
 	symPath      string
 	causedByAttr attrChange // was this rename caused by a setAttr?
 	moved        bool       // move this action to the parent at most one time
@@ -524,12 +534,13 @@ type renameUnmergedAction struct {
 
 func crActionCopyFile(
 	ctx context.Context, copier fileBlockDeepCopier,
-	fromName, toName, toSymPath string, fromDir, toDir *data.DirData) (
-	data.BlockPointer, string, []data.BlockInfo, error) {
+	fromName, toName data.PathPartString, toSymPath string,
+	fromDir, toDir *data.DirData) (
+	data.BlockPointer, data.PathPartString, []data.BlockInfo, error) {
 	// Find the source entry.
 	fromEntry, err := fromDir.Lookup(ctx, fromName)
 	if err != nil {
-		return data.BlockPointer{}, "", nil, err
+		return data.BlockPointer{}, data.PathPartString{}, nil, err
 	}
 
 	if toSymPath != "" {
@@ -540,7 +551,7 @@ func crActionCopyFile(
 	// We only rename files (or make symlinks to directories).
 	if fromEntry.Type == data.Dir {
 		// Just fill in the last path node, we don't have the full path.
-		return data.BlockPointer{}, "", nil, NotFileError{
+		return data.BlockPointer{}, data.PathPartString{}, nil, NotFileError{
 			data.Path{Path: []data.PathNode{{
 				BlockPointer: fromEntry.BlockPointer,
 				Name:         fromName,
@@ -550,7 +561,7 @@ func crActionCopyFile(
 	// Make sure the name is unique.
 	name, err := uniquifyName(ctx, toDir, toName)
 	if err != nil {
-		return data.BlockPointer{}, "", nil, err
+		return data.BlockPointer{}, data.PathPartString{}, nil, err
 	}
 
 	var ptr data.BlockPointer
@@ -559,7 +570,7 @@ func crActionCopyFile(
 		var err error
 		ptr, err = copier(ctx, name, fromEntry.BlockPointer)
 		if err != nil {
-			return data.BlockPointer{}, "", nil, err
+			return data.BlockPointer{}, data.PathPartString{}, nil, err
 		}
 	}
 
@@ -568,7 +579,7 @@ func crActionCopyFile(
 	fromEntry.BlockPointer = ptr
 	unrefs, err := toDir.SetEntry(ctx, name, fromEntry)
 	if err != nil {
-		return data.BlockPointer{}, "", nil, err
+		return data.BlockPointer{}, data.PathPartString{}, nil, err
 	}
 	return oldPointer, name, unrefs, nil
 }
@@ -624,16 +635,16 @@ func (rua *renameUnmergedAction) updateOps(
 
 	if rua.symPath != "" && !unmergedChain.isFile() {
 		err := crActionConvertSymlink(unmergedMostRecent, mergedMostRecent,
-			unmergedChain, mergedChains, rua.fromName, rua.toName)
+			unmergedChain, mergedChains, rua.toName.Plaintext())
 		if err != nil {
 			return err
 		}
 	}
 
 	// Rename all operations with the old name to the new name.
-	unmergedChain.ops =
-		fixupNamesInOps(rua.fromName, rua.toName, unmergedChain.ops,
-			unmergedChains)
+	unmergedChain.ops = fixupNamesInOps(
+		rua.fromName.Plaintext(), rua.toName.Plaintext(), unmergedChain.ops,
+		unmergedChains)
 
 	// The newly renamed entry:
 	newMergedEntry, err := mergedDir.Lookup(ctx, rua.toName)
@@ -709,10 +720,11 @@ func (rua *renameUnmergedAction) updateOps(
 	}
 
 	_, mergedRename := mergedChains.renamedOriginals[original]
-	if rua.toName == rua.fromName && mergedRename {
+	if rua.toName.Plaintext() == rua.fromName.Plaintext() && mergedRename {
 		// The merged copy is the one changing its name, so turn the
 		// merged rename op into just a create by removing the rmOp.
-		removeRmOpFromChain(unmergedChain.original, mergedChains, rua.toName)
+		removeRmOpFromChain(
+			unmergedChain.original, mergedChains, rua.toName.Plaintext())
 		if rua.symPath == "" {
 			// Pretend to write to the new, deduplicated unmerged
 			// copy, to update its pointer in the node cache.
@@ -731,9 +743,9 @@ func (rua *renameUnmergedAction) updateOps(
 	} else {
 		// The unmerged copy is changing its name, so make a local
 		// rename op for it, and a create op for the merged version.
-		rop, err := newRenameOp(rua.fromName, mergedMostRecent, rua.toName,
-			mergedMostRecent, newMergedEntry.BlockPointer,
-			newMergedEntry.Type)
+		rop, err := newRenameOp(
+			rua.fromName.Plaintext(), mergedMostRecent, rua.toName.Plaintext(),
+			mergedMostRecent, newMergedEntry.BlockPointer, newMergedEntry.Type)
 		if err != nil {
 			return err
 		}
@@ -745,7 +757,8 @@ func (rua *renameUnmergedAction) updateOps(
 			rop.AddUpdate(
 				unmergedEntry.BlockPointer, newMergedEntry.BlockPointer)
 		}
-		co, err := newCreateOp(rua.fromName, mergedMostRecent, mergedEntry.Type)
+		co, err := newCreateOp(
+			rua.fromName.Plaintext(), mergedMostRecent, mergedEntry.Type)
 		if err != nil {
 			return err
 		}
@@ -761,7 +774,7 @@ func (rua *renameUnmergedAction) updateOps(
 	var co *createOp
 	for _, op := range unmergedChain.ops {
 		var ok bool
-		if co, ok = op.(*createOp); ok && co.NewName == rua.toName {
+		if co, ok = op.(*createOp); ok && co.NewName == rua.toName.Plaintext() {
 			found = true
 			if len(co.RefBlocks) > 0 {
 				co.RefBlocks[0] = newMergedEntry.BlockPointer
@@ -770,7 +783,8 @@ func (rua *renameUnmergedAction) updateOps(
 		}
 	}
 	if !found {
-		co, err = newCreateOp(rua.toName, unmergedMostRecent, mergedEntry.Type)
+		co, err = newCreateOp(
+			rua.toName.Plaintext(), unmergedMostRecent, mergedEntry.Type)
 		if err != nil {
 			return err
 		}
@@ -788,7 +802,8 @@ func (rua *renameUnmergedAction) updateOps(
 	// because we just did a copy of a node still in use in the
 	// merged branch.
 	if unmergedEntry.BlockPointer != newMergedEntry.BlockPointer &&
-		rua.fromName != rua.toName && rua.symPath == "" {
+		rua.fromName.Plaintext() != rua.toName.Plaintext() &&
+		rua.symPath == "" {
 		co.AddUnrefBlock(unmergedEntry.BlockPointer)
 	}
 
@@ -810,8 +825,8 @@ func (rua *renameUnmergedAction) String() string {
 // Note that symPath below refers to the unmerged entry that is being
 // copied into the merged block.
 type renameMergedAction struct {
-	fromName string
-	toName   string
+	fromName data.PathPartString
+	toName   data.PathPartString
 	symPath  string
 }
 
@@ -872,7 +887,7 @@ func (rma *renameMergedAction) updateOps(
 
 	if rma.symPath != "" && !unmergedChain.isFile() {
 		err := crActionConvertSymlink(unmergedMostRecent, mergedMostRecent,
-			unmergedChain, mergedChains, rma.fromName, rma.fromName)
+			unmergedChain, mergedChains, rma.fromName.Plaintext())
 		if err != nil {
 			return err
 		}
@@ -881,9 +896,9 @@ func (rma *renameMergedAction) updateOps(
 	// Rename all operations with the old name to the new name.
 	mergedChain := mergedChains.byMostRecent[mergedMostRecent]
 	if mergedChain != nil {
-		mergedChain.ops =
-			fixupNamesInOps(rma.fromName, rma.toName, mergedChain.ops,
-				mergedChains)
+		mergedChain.ops = fixupNamesInOps(
+			rma.fromName.Plaintext(), rma.toName.Plaintext(), mergedChain.ops,
+			mergedChains)
 	}
 
 	if !unmergedChain.isFile() {
@@ -895,8 +910,10 @@ func (rma *renameMergedAction) updateOps(
 
 		// Prepend a rename for the merged copy to the unmerged set of
 		// operations.
-		rop, err := newRenameOp(rma.fromName, unmergedMostRecent, rma.toName,
-			unmergedMostRecent, mergedEntry.BlockPointer, mergedEntry.Type)
+		rop, err := newRenameOp(
+			rma.fromName.Plaintext(), unmergedMostRecent,
+			rma.toName.Plaintext(), unmergedMostRecent,
+			mergedEntry.BlockPointer, mergedEntry.Type)
 		if err != nil {
 			return err
 		}
@@ -910,14 +927,16 @@ func (rma *renameMergedAction) updateOps(
 		found := false
 		if mergedChain != nil {
 			for _, op := range mergedChain.ops {
-				if co, ok := op.(*createOp); ok && co.NewName == rma.toName {
+				if co, ok := op.(*createOp); ok &&
+					co.NewName == rma.toName.Plaintext() {
 					found = true
 					break
 				}
 			}
 		}
 		if !found {
-			co, err := newCreateOp(rma.toName, mergedMostRecent, mergedEntry.Type)
+			co, err := newCreateOp(
+				rma.toName.Plaintext(), mergedMostRecent, mergedEntry.Type)
 			if err != nil {
 				return err
 			}
@@ -1025,18 +1044,21 @@ func (cal crActionList) collapse() crActionList {
 
 		// Unmerged actions:
 		case *renameUnmergedAction:
-			setTopAction(action, action.fromName, i, infoMap, indicesToRemove)
+			setTopAction(
+				action, action.fromName.Plaintext(), i, infoMap,
+				indicesToRemove)
 		case *copyUnmergedEntryAction:
-			untypedTopAction := infoMap[action.fromName].topAction
+			untypedTopAction := infoMap[action.fromName.Plaintext()].topAction
 			switch untypedTopAction.(type) {
 			case *renameUnmergedAction:
 				indicesToRemove[i] = true
 			default:
-				setTopAction(action, action.fromName, i, infoMap,
+				setTopAction(
+					action, action.fromName.Plaintext(), i, infoMap,
 					indicesToRemove)
 			}
 		case *copyUnmergedAttrAction:
-			untypedTopAction := infoMap[action.fromName].topAction
+			untypedTopAction := infoMap[action.fromName.Plaintext()].topAction
 			switch topAction := untypedTopAction.(type) {
 			case *renameUnmergedAction:
 				indicesToRemove[i] = true
@@ -1059,7 +1081,8 @@ func (cal crActionList) collapse() crActionList {
 				}
 				indicesToRemove[i] = true
 			default:
-				setTopAction(action, action.fromName, i, infoMap,
+				setTopAction(
+					action, action.fromName.Plaintext(), i, infoMap,
 					indicesToRemove)
 			}
 
@@ -1067,7 +1090,8 @@ func (cal crActionList) collapse() crActionList {
 		case *renameMergedAction:
 			// Prefix merged actions with a reserved prefix to keep
 			// them separate from the unmerged actions.
-			setTopAction(action, ".kbfs_merged_"+action.fromName, i, infoMap,
+			setTopAction(
+				action, ".kbfs_merged_"+action.fromName.Plaintext(), i, infoMap,
 				indicesToRemove)
 		}
 	}

--- a/go/kbfs/libkbfs/cr_actions_test.go
+++ b/go/kbfs/libkbfs/cr_actions_test.go
@@ -11,15 +11,24 @@ import (
 	"github.com/keybase/client/go/kbfs/data"
 )
 
+func testPPS(s string) data.PathPartString {
+	return data.NewPathPartString(s, nil)
+}
+
 func TestCRActionsCollapseNoChange(t *testing.T) {
 	al := crActionList{
-		&copyUnmergedEntryAction{"old1", "new1", "", false, false,
+		&copyUnmergedEntryAction{
+			testPPS("old1"), testPPS("new1"), "", false, false,
 			data.DirEntry{}, nil},
-		&copyUnmergedEntryAction{"old2", "new2", "", false, false,
+		&copyUnmergedEntryAction{
+			testPPS("old2"), testPPS("new2"), "", false, false,
 			data.DirEntry{}, nil},
-		&renameUnmergedAction{"old3", "new3", "", 0, false, data.ZeroPtr, data.ZeroPtr},
-		&renameMergedAction{"old4", "new4", ""},
-		&copyUnmergedAttrAction{"old5", "new5", []attrChange{mtimeAttr}, false},
+		&renameUnmergedAction{
+			testPPS("old3"), testPPS("new3"), "", 0, false, data.ZeroPtr,
+			data.ZeroPtr},
+		&renameMergedAction{testPPS("old4"), testPPS("new4"), ""},
+		&copyUnmergedAttrAction{
+			testPPS("old5"), testPPS("new5"), []attrChange{mtimeAttr}, false},
 	}
 
 	newList := al.collapse()
@@ -30,10 +39,14 @@ func TestCRActionsCollapseNoChange(t *testing.T) {
 
 func TestCRActionsCollapseEntry(t *testing.T) {
 	al := crActionList{
-		&copyUnmergedAttrAction{"old", "new", []attrChange{mtimeAttr}, false},
-		&copyUnmergedEntryAction{"old", "new", "", false, false,
+		&copyUnmergedAttrAction{
+			testPPS("old"), testPPS("new"), []attrChange{mtimeAttr}, false},
+		&copyUnmergedEntryAction{
+			testPPS("old"), testPPS("new"), "", false, false,
 			data.DirEntry{}, nil},
-		&renameUnmergedAction{"old", "new", "", 0, false, data.ZeroPtr, data.ZeroPtr},
+		&renameUnmergedAction{
+			testPPS("old"), testPPS("new"), "", 0, false, data.ZeroPtr,
+			data.ZeroPtr},
 	}
 
 	expected := crActionList{
@@ -67,13 +80,17 @@ func TestCRActionsCollapseEntry(t *testing.T) {
 }
 func TestCRActionsCollapseAttr(t *testing.T) {
 	al := crActionList{
-		&copyUnmergedAttrAction{"old", "new", []attrChange{mtimeAttr}, false},
-		&copyUnmergedAttrAction{"old", "new", []attrChange{exAttr}, false},
-		&copyUnmergedAttrAction{"old", "new", []attrChange{mtimeAttr}, false},
+		&copyUnmergedAttrAction{
+			testPPS("old"), testPPS("new"), []attrChange{mtimeAttr}, false},
+		&copyUnmergedAttrAction{
+			testPPS("old"), testPPS("new"), []attrChange{exAttr}, false},
+		&copyUnmergedAttrAction{
+			testPPS("old"), testPPS("new"), []attrChange{mtimeAttr}, false},
 	}
 
 	expected := crActionList{
-		&copyUnmergedAttrAction{"old", "new", []attrChange{mtimeAttr, exAttr},
+		&copyUnmergedAttrAction{
+			testPPS("old"), testPPS("new"), []attrChange{mtimeAttr, exAttr},
 			false},
 	}
 

--- a/go/kbfs/libkbfs/cr_actions_test.go
+++ b/go/kbfs/libkbfs/cr_actions_test.go
@@ -18,15 +18,15 @@ func testPPS(s string) data.PathPartString {
 func TestCRActionsCollapseNoChange(t *testing.T) {
 	al := crActionList{
 		&copyUnmergedEntryAction{
-			testPPS("old1"), testPPS("new1"), "", false, false,
+			testPPS("old1"), testPPS("new1"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&copyUnmergedEntryAction{
-			testPPS("old2"), testPPS("new2"), "", false, false,
+			testPPS("old2"), testPPS("new2"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&renameUnmergedAction{
-			testPPS("old3"), testPPS("new3"), "", 0, false, data.ZeroPtr,
-			data.ZeroPtr},
-		&renameMergedAction{testPPS("old4"), testPPS("new4"), ""},
+			testPPS("old3"), testPPS("new3"), testPPS(""), 0, false,
+			data.ZeroPtr, data.ZeroPtr},
+		&renameMergedAction{testPPS("old4"), testPPS("new4"), testPPS("")},
 		&copyUnmergedAttrAction{
 			testPPS("old5"), testPPS("new5"), []attrChange{mtimeAttr}, false},
 	}
@@ -42,10 +42,10 @@ func TestCRActionsCollapseEntry(t *testing.T) {
 		&copyUnmergedAttrAction{
 			testPPS("old"), testPPS("new"), []attrChange{mtimeAttr}, false},
 		&copyUnmergedEntryAction{
-			testPPS("old"), testPPS("new"), "", false, false,
+			testPPS("old"), testPPS("new"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&renameUnmergedAction{
-			testPPS("old"), testPPS("new"), "", 0, false, data.ZeroPtr,
+			testPPS("old"), testPPS("new"), testPPS(""), 0, false, data.ZeroPtr,
 			data.ZeroPtr},
 	}
 

--- a/go/kbfs/libkbfs/cr_chains.go
+++ b/go/kbfs/libkbfs/cr_chains.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/libkey"
+	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
@@ -29,6 +30,8 @@ type crChain struct {
 	ops                  []op
 	original, mostRecent data.BlockPointer
 	file                 bool
+	obfuscator           data.Obfuscator
+	tlfID                tlf.ID
 }
 
 // collapse finds complementary pairs of operations that cancel each
@@ -311,7 +314,7 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 		FolderBranch: fbo.folderBranch,
 		Path: []data.PathNode{{
 			BlockPointer: parentMostRecent,
-			Name:         "",
+			Name:         data.PathPartString{},
 		}},
 	}
 	parentDD, cleanupFn := fbo.newDirDataWithDBM(
@@ -394,6 +397,27 @@ func (cc *crChain) hasSetAttrOp() bool {
 	return false
 }
 
+func (cc *crChain) ensurePath(op op, ptr data.BlockPointer) {
+	if op.getFinalPath().IsValid() {
+		return
+	}
+
+	// Use the same obfuscator for both the node's name and it's
+	// children, because it's too complicated to try to get the real
+	// parent obfuscator from the chain.
+	op.setFinalPath(data.Path{
+		FolderBranch: data.FolderBranch{
+			Tlf:    cc.tlfID,
+			Branch: data.MasterBranch,
+		},
+		Path: []data.PathNode{{
+			BlockPointer: ptr,
+			Name:         data.NewPathPartString("", cc.obfuscator),
+		}},
+		ChildObfuscator: cc.obfuscator,
+	})
+}
+
 type renameInfo struct {
 	originalOldParent data.BlockPointer
 	oldName           string
@@ -447,6 +471,9 @@ type crChains struct {
 
 	// All the resolution ops from the branch, in order.
 	resOps []*resolutionOp
+
+	// Make per-chain obfuscators.
+	makeObfuscator func() data.Obfuscator
 }
 
 func (ccs *crChains) addOp(ptr data.BlockPointer, op op) error {
@@ -455,6 +482,8 @@ func (ccs *crChains) addOp(ptr data.BlockPointer, op op) error {
 		return errors.Errorf("Could not find chain for most recent ptr %v", ptr)
 	}
 
+	// Make sure this op has a valid path with an obfuscator.
+	currChain.ensurePath(op, ptr)
 	currChain.ops = append(currChain.ops, op)
 	return nil
 }
@@ -471,7 +500,12 @@ func (ccs *crChains) addNoopChain(ptr data.BlockPointer) {
 	if _, ok := ccs.originals[ptr]; ok {
 		return
 	}
-	chain := &crChain{original: ptr, mostRecent: ptr}
+	chain := &crChain{
+		original:   ptr,
+		mostRecent: ptr,
+		obfuscator: ccs.makeObfuscator(),
+		tlfID:      ccs.mostRecentChainMDInfo.TlfID(),
+	}
 	ccs.byOriginal[ptr] = chain
 	ccs.byMostRecent[ptr] = chain
 }
@@ -491,7 +525,11 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		chain, ok := ccs.byMostRecent[update.Unref]
 		if !ok {
 			// No matching chain means it's time to start a new chain
-			chain = &crChain{original: update.Unref}
+			chain = &crChain{
+				original:   update.Unref,
+				obfuscator: ccs.makeObfuscator(),
+				tlfID:      ccs.mostRecentChainMDInfo.TlfID(),
+			}
 			ccs.byOriginal[update.Unref] = chain
 		}
 		if chain.mostRecent.IsInitialized() {
@@ -591,9 +629,8 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		if len(realOp.Unrefs()) > 0 {
 			// Something was overwritten; make an explicit rm for it
 			// so we can check for conflicts.
-			roOverwrite, err := newRmOp(realOp.NewName, ndu,
-
-				data.File)
+			roOverwrite, err := newRmOp(
+				realOp.NewName, ndu, data.File)
 			if err != nil {
 				return err
 			}
@@ -673,7 +710,12 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		_, ok := ccs.byMostRecent[realOp.File]
 		if !ok {
 			// pointer didn't change, so most recent is the same:
-			chain := &crChain{original: realOp.File, mostRecent: realOp.File}
+			chain := &crChain{
+				original:   realOp.File,
+				mostRecent: realOp.File,
+				obfuscator: ccs.makeObfuscator(),
+				tlfID:      ccs.mostRecentChainMDInfo.TlfID(),
+			}
 			ccs.byOriginal[realOp.File] = chain
 			ccs.byMostRecent[realOp.File] = chain
 		}
@@ -819,7 +861,7 @@ func (ccs *crChains) renamedParentAndName(original data.BlockPointer) (
 	return info.originalNewParent, info.newName, true
 }
 
-func newCRChainsEmpty() *crChains {
+func newCRChainsEmpty(makeObfuscator func() data.Obfuscator) *crChains {
 	return &crChains{
 		byOriginal:          make(map[data.BlockPointer]*crChain),
 		byMostRecent:        make(map[data.BlockPointer]*crChain),
@@ -830,6 +872,7 @@ func newCRChainsEmpty() *crChains {
 		toUnrefPointers:     make(map[data.BlockPointer]bool),
 		doNotUnrefPointers:  make(map[data.BlockPointer]bool),
 		originals:           make(map[data.BlockPointer]data.BlockPointer),
+		makeObfuscator:      makeObfuscator,
 	}
 }
 
@@ -885,7 +928,14 @@ func newCRChains(
 	ctx context.Context, codec kbfscodec.Codec, osg idutil.OfflineStatusGetter,
 	chainMDs []chainMetadata, fbo *folderBlockOps, identifyTypes bool) (
 	ccs *crChains, err error) {
-	ccs = newCRChainsEmpty()
+	if fbo != nil {
+		ccs = newCRChainsEmpty(fbo.obfuscatorMaker())
+	} else {
+		ccs = newCRChainsEmpty(func() data.Obfuscator { return nil })
+	}
+
+	mostRecentMD := chainMDs[len(chainMDs)-1]
+	ccs.mostRecentChainMDInfo = mostRecentMD
 
 	// For each MD update, turn each update in each op into map
 	// entries and create chains for the BlockPointers that are
@@ -923,8 +973,9 @@ func newCRChains(
 					FolderBranch: fbo.folderBranch,
 					Path: []data.PathNode{{
 						BlockPointer: ptr,
-						Name: fmt.Sprintf(
-							"<MD rev %d>", chainMD.Revision()),
+						Name: data.NewPathPartString(
+							fmt.Sprintf("<MD rev %d>", chainMD.Revision()),
+							nil),
 					}},
 				})
 			if err != nil {
@@ -948,8 +999,6 @@ func newCRChains(
 		}
 	}
 
-	mostRecentMD := chainMDs[len(chainMDs)-1]
-
 	for _, chain := range ccs.byOriginal {
 		toUnrefs := chain.collapse(ccs.createdOriginals, ccs.originals)
 		for _, unref := range toUnrefs {
@@ -971,7 +1020,6 @@ func newCRChains(
 		}
 	}
 
-	ccs.mostRecentChainMDInfo = mostRecentMD
 	return ccs, nil
 }
 
@@ -1146,8 +1194,11 @@ func (ccs *crChains) findPathForDeleted(mostRecent data.BlockPointer) data.Path 
 					p := ro.getFinalPath()
 					if !p.IsValid() {
 						p = ccs.findPathForDeleted(ptr)
+						ro.setFinalPath(p)
 					}
-					return p.ChildPath(ro.OldName, mostRecent)
+					return p.ChildPath(
+						ro.obfuscatedOldName(), mostRecent,
+						ccs.makeObfuscator())
 				}
 			}
 		}
@@ -1171,7 +1222,8 @@ func (ccs *crChains) findPathForDeleted(mostRecent data.BlockPointer) data.Path 
 		},
 		Path: []data.PathNode{{
 			BlockPointer: rootMostRecent,
-			Name:         mostRecent.String(),
+			Name: data.NewPathPartString(
+				mostRecent.String(), ccs.makeObfuscator()),
 		}},
 	}
 }
@@ -1192,8 +1244,11 @@ func (ccs *crChains) findPathForCreated(createdChain *crChain) data.Path {
 					p := co.getFinalPath()
 					if !p.IsValid() {
 						p = ccs.findPathForCreated(chain)
+						co.setFinalPath(p)
 					}
-					return p.ChildPath(co.NewName, mostRecent)
+					return p.ChildPath(
+						co.obfuscatedNewName(), mostRecent,
+						ccs.makeObfuscator())
 				}
 			}
 		}
@@ -1217,7 +1272,8 @@ func (ccs *crChains) findPathForCreated(createdChain *crChain) data.Path {
 		},
 		Path: []data.PathNode{{
 			BlockPointer: rootMostRecent,
-			Name:         mostRecent.String(),
+			Name: data.NewPathPartString(
+				mostRecent.String(), ccs.makeObfuscator()),
 		}},
 	}
 }
@@ -1401,8 +1457,9 @@ func (ccs *crChains) revertRenames(oldOps []op) {
 			for i, newOp := range newChain.ops {
 				if cop, ok := newOp.(*createOp); ok &&
 					cop.renamed && cop.NewName == rop.NewName {
-					rop.setFinalPath(cop.getFinalPath())
-					newChain.ops[i] = rop
+					ropCopy := rop.deepCopy()
+					ropCopy.setFinalPath(cop.getFinalPath())
+					newChain.ops[i] = ropCopy
 					break
 				}
 			}

--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -68,7 +68,7 @@ func (e InvalidParentPathError) Error() string {
 // DirNotEmptyError indicates that the user tried to unlink a
 // subdirectory that was not empty.
 type DirNotEmptyError struct {
-	Name string
+	Name data.PathPartString
 }
 
 // Error implements the error interface for DirNotEmptyError

--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -662,16 +662,17 @@ func (e InvalidOpError) Error() string {
 // NoSuchFolderListError indicates that the user tried to access a
 // subdirectory of /keybase that doesn't exist.
 type NoSuchFolderListError struct {
-	Name     string
-	PrivName string
-	PubName  string
+	Name      string
+	NameToLog string
+	PrivName  string
+	PubName   string
 }
 
 // Error implements the error interface for NoSuchFolderListError
 func (e NoSuchFolderListError) Error() string {
 	return fmt.Sprintf("/keybase/%s is not a Keybase folder. "+
 		"All folders begin with /keybase/%s or /keybase/%s.",
-		e.Name, e.PrivName, e.PubName)
+		e.NameToLog, e.PrivName, e.PubName)
 }
 
 // UnexpectedUnmergedPutError indicates that we tried to do an

--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -584,7 +584,7 @@ func (e NoChainFoundError) Error() string {
 // DisallowedPrefixError indicates that the user attempted to create
 // an entry using a name with a disallowed prefix.
 type DisallowedPrefixError struct {
-	name   string
+	name   data.PathPartString
 	prefix string
 }
 

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -4257,9 +4257,6 @@ func checkDisallowedPrefixes(
 					return nil
 				}
 			}
-			// Put the plaintext in the error if it starts with a
-			// disallowed prefix -- there's no expectation of privacy
-			// in that case.
 			return DisallowedPrefixError{name, prefix}
 		}
 	}

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -4260,7 +4260,7 @@ func checkDisallowedPrefixes(
 			// Put the plaintext in the error if it starts with a
 			// disallowed prefix -- there's no expectation of privacy
 			// in that case.
-			return DisallowedPrefixError{name.Plaintext(), prefix}
+			return DisallowedPrefixError{name, prefix}
 		}
 	}
 	return nil

--- a/go/kbfs/libkbfs/folder_branch_status.go
+++ b/go/kbfs/libkbfs/folder_branch_status.go
@@ -332,11 +332,9 @@ func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context,
 
 	var jStatus TLFJournalStatus
 	if blocks != nil {
-		jStatus, err =
-			jManager.JournalStatusWithPaths(ctx, tlfID, blocks)
+		jStatus, err = jManager.JournalStatusWithPaths(ctx, tlfID, blocks)
 	} else {
-		jStatus, err =
-			jManager.JournalStatus(tlfID)
+		jStatus, err = jManager.JournalStatus(tlfID)
 	}
 	if err != nil {
 		log := fbsk.config.MakeLogger("")

--- a/go/kbfs/libkbfs/folder_branch_status_test.go
+++ b/go/kbfs/libkbfs/folder_branch_status_test.go
@@ -61,7 +61,8 @@ func TestFBStatusSignal(t *testing.T) {
 	}
 
 	n := newMockNode(mockCtrl)
-	p1 := data.Path{Path: []data.PathNode{{Name: "a1"}, {Name: "b1"}}}
+	p1 := data.Path{
+		Path: []data.PathNode{{Name: testPPS("a1")}, {Name: testPPS("b1")}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n}).AnyTimes().Return(p1)
 
 	fbsk.addDirtyNode(n)
@@ -129,10 +130,12 @@ func TestFBStatusAllFields(t *testing.T) {
 
 	// make two nodes with expected PathFromNode calls
 	n1 := newMockNode(mockCtrl)
-	p1 := data.Path{Path: []data.PathNode{{Name: "a1"}, {Name: "b1"}}}
+	p1 := data.Path{
+		Path: []data.PathNode{{Name: testPPS("a1")}, {Name: testPPS("b1")}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n1}).AnyTimes().Return(p1)
 	n2 := newMockNode(mockCtrl)
-	p2 := data.Path{Path: []data.PathNode{{Name: "a2"}, {Name: "b2"}}}
+	p2 := data.Path{
+		Path: []data.PathNode{{Name: testPPS("a2")}, {Name: testPPS("b2")}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
 	fbsk.setRootMetadata(

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -660,11 +660,6 @@ func doInit(
 			return lg
 		}, params.StorageRoot, params.DiskCacheMode, kbCtx)
 	config.SetVLogLevel(kbCtx.GetVDebugSetting())
-	if mode == InitConstrained {
-		// Until we have a way to turn on debug logging for mobile,
-		// log everything.
-		config.SetVLogLevel(libkb.VLog1String)
-	}
 
 	if params.CleanBlockCacheCapacity > 0 {
 		log.CDebugf(

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -190,7 +190,7 @@ type Node interface {
 	// `true` on its own.
 	ShouldCreateMissedLookup(ctx context.Context, name data.PathPartString) (
 		shouldCreate bool, newCtx context.Context, et data.EntryType,
-		fi os.FileInfo, sympath string)
+		fi os.FileInfo, sympath data.PathPartString)
 	// ShouldRetryOnDirRead is called for Nodes representing
 	// directories, whenever a `Lookup` or `GetDirChildren` is done on
 	// them.  It should return true to instruct the caller that it
@@ -372,11 +372,16 @@ type KBFSOps interface {
 		excl Excl) (Node, data.EntryInfo, error)
 	// CreateLink creates a new symlink under the given node, if the
 	// logged-in user has write permission to the top-level folder.
-	// Returns the new entry info for the created symlink.  This
-	// is a remote-sync operation.
+	// Returns the new entry info for the created symlink.  The
+	// symlink is represented as a single `data.PathPartString`
+	// (generally obfuscated by `dir`'s Obfuscator) to avoid
+	// accidental logging, even though it could point outside of the
+	// directory.  The deobfuscate command will inspect symlinks when
+	// deobfuscating to make this easier to debug.  This is a
+	// remote-sync operation.
 	CreateLink(
-		ctx context.Context, dir Node, fromName data.PathPartString,
-		toPath string) (data.EntryInfo, error)
+		ctx context.Context, dir Node, fromName, toPath data.PathPartString) (
+		data.EntryInfo, error)
 	// RemoveDir removes the subdirectory represented by the given
 	// node, if the logged-in user has write permission to the
 	// top-level folder.  Will return an error if the subdirectory is

--- a/go/kbfs/libkbfs/kbfs_cr_test.go
+++ b/go/kbfs/libkbfs/kbfs_cr_test.go
@@ -29,7 +29,7 @@ func readAndCompareData(ctx context.Context, t *testing.T, config Config,
 	rootNode := GetRootNodeOrBust(ctx, t, config, name, tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.Lookup(ctx, rootNode, "a")
+	fileNode, _, err := kbfsOps.Lookup(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	data := make([]byte, 1)
 	_, err = kbfsOps.Read(ctx, fileNode, data, 0)
@@ -89,7 +89,7 @@ func TestBasicMDUpdate(t *testing.T) {
 
 	// user 1 creates a file
 	kbfsOps1 := config1.KBFSOps()
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestBasicMDUpdate(t *testing.T) {
 	entries, err := kbfsOps2.GetDirChildren(ctx, rootNode2)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(entries))
-	_, ok := entries["a"]
+	_, ok := entries[rootNode2.ChildName("a")]
 	require.True(t, ok)
 
 	// The status should have fired as well (though in this case the
@@ -137,7 +137,8 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 
 	kbfsOps1 := config1.KBFSOps()
 	// user 1 creates a file
-	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -146,9 +147,9 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	// now user 1 renames the old file, and creates a new one
-	err = kbfsOps1.Rename(ctx, rootNode1, "a", rootNode1, "b")
+	err = kbfsOps1.Rename(ctx, rootNode1, testPPS("a"), rootNode1, testPPS("b"))
 	require.NoError(t, err)
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "c", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("c"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -161,9 +162,9 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	entries, err := kbfsOps2.GetDirChildren(ctx, rootNode2)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(entries))
-	_, ok := entries["b"]
+	_, ok := entries[rootNode2.ChildName("b")]
 	require.True(t, ok)
-	_, ok = entries["c"]
+	_, ok = entries[rootNode2.ChildName("c")]
 	require.True(t, ok)
 }
 
@@ -206,7 +207,8 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	fileNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	fileNode1, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -223,7 +225,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	data2 := []byte{2}
 	err = kbfsOps2.Write(ctx, fileNode2, data2, 0)
@@ -287,7 +289,8 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	fileNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	fileNode1, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -300,7 +303,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	data2 := []byte{2}
 	err = kbfsOps2.Write(ctx, fileNode2, data2, 0)
@@ -342,7 +345,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	rootNode1B := GetRootNodeOrBust(ctx, t, config1B, name, tlf.Private)
 
 	kbfsOps1B := config1B.KBFSOps()
-	fileNode1B, _, err := kbfsOps1B.Lookup(ctx, rootNode1B, "a")
+	fileNode1B, _, err := kbfsOps1B.Lookup(ctx, rootNode1B, testPPS("a"))
 	require.NoError(t, err)
 
 	readAndCompareData(ctx, t, config1B, name, data1, userName1)
@@ -427,7 +430,8 @@ func TestMultiUserWrite(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -436,7 +440,7 @@ func TestMultiUserWrite(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 
 	data2 := []byte{2}
@@ -491,7 +495,8 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -500,7 +505,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
+	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 
 	// disable updates on user 2
@@ -510,13 +515,15 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	require.NoError(t, err)
 
 	// User 1 makes a new file
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "b", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 makes a new different file
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "c", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(
+		ctx, rootNode2, testPPS("c"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -546,7 +553,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	assert.Equal(t, len(expectedChildren), len(children1))
 
 	for _, child := range expectedChildren {
-		_, ok := children1[child]
+		_, ok := children1[rootNode1.ChildName(child)]
 		assert.True(t, ok)
 	}
 
@@ -617,9 +624,9 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
+	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, testPPS("a"))
 	require.NoError(t, err)
-	fileB1, _, err := kbfsOps1.CreateFile(ctx, dirA1, "b", false, NoExcl)
+	fileB1, _, err := kbfsOps1.CreateFile(ctx, dirA1, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -628,9 +635,9 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
-	fileB2, _, err := kbfsOps2.Lookup(ctx, dirA2, "b")
+	fileB2, _, err := kbfsOps2.Lookup(ctx, dirA2, testPPS("b"))
 	require.NoError(t, err)
 
 	// disable updates on user 2
@@ -702,9 +709,10 @@ func TestBasicCRFileConflict(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
+	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, testPPS("a"))
 	require.NoError(t, err)
-	fileB1, _, err := kbfsOps1.CreateFile(ctx, dirA1, "b", false, NoExcl)
+	fileB1, _, err := kbfsOps1.CreateFile(
+		ctx, dirA1, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -713,9 +721,9 @@ func TestBasicCRFileConflict(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
-	fileB2, _, err := kbfsOps2.Lookup(ctx, dirA2, "b")
+	fileB2, _, err := kbfsOps2.Lookup(ctx, dirA2, testPPS("b"))
 	require.NoError(t, err)
 
 	// disable updates on user 2
@@ -767,7 +775,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	assert.Equal(t, len(expectedChildren), len(children1))
 
 	for _, child := range expectedChildren {
-		_, ok := children1[child]
+		_, ok := children1[dirA1.ChildName(child)]
 		assert.True(t, ok)
 	}
 
@@ -808,9 +816,10 @@ func TestBasicCRFailureAndFixing(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
+	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, testPPS("a"))
 	require.NoError(t, err)
-	fileB1, _, err := kbfsOps1.CreateFile(ctx, dirA1, "b", false, NoExcl)
+	fileB1, _, err := kbfsOps1.CreateFile(
+		ctx, dirA1, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -819,9 +828,9 @@ func TestBasicCRFailureAndFixing(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
-	fileB2, _, err := kbfsOps2.Lookup(ctx, dirA2, "b")
+	fileB2, _, err := kbfsOps2.Lookup(ctx, dirA2, testPPS("b"))
 	require.NoError(t, err)
 
 	err = SetCRFailureForTesting(ctx, config2, rootNode2.GetFolderBranch(),
@@ -867,8 +876,8 @@ func TestBasicCRFailureAndFixing(t *testing.T) {
 	t.Log("Write a bunch more files as user 2, creating more conflicts.")
 	for i := 0; i < maxConflictResolutionAttempts; i++ {
 		fileName := fmt.Sprintf("file%d", i)
-		newFile, _, err := kbfsOps2.CreateFile(ctx, dirA2, fileName, false,
-			NoExcl)
+		newFile, _, err := kbfsOps2.CreateFile(
+			ctx, dirA2, testPPS(fileName), false, NoExcl)
 		require.NoError(t, err, "Loop %d", i)
 		err = kbfsOps2.SyncAll(ctx, newFile.GetFolderBranch())
 		require.NoError(t, err, "Loop %d", i)
@@ -891,9 +900,10 @@ func TestBasicCRFailureAndFixing(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Trigger CR and wait for it to resolve.")
-	dirA2, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
+	dirA2, _, err = kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
-	_, _, err = kbfsOps2.CreateFile(ctx, dirA2, "newFile", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(
+		ctx, dirA2, testPPS("newFile"), false, NoExcl)
 	require.NoError(t, err)
 
 	err = kbfsOps2.SyncAll(ctx, dirA2.GetFolderBranch())
@@ -931,9 +941,9 @@ func TestBasicCRFailureAndFixing(t *testing.T) {
 
 	rootNodeConflict, _, err := kbfsOps2.GetRootNode(ctx, h, b)
 	require.NoError(t, err)
-	dirAConflict, _, err := kbfsOps2.Lookup(ctx, rootNodeConflict, "a")
+	dirAConflict, _, err := kbfsOps2.Lookup(ctx, rootNodeConflict, testPPS("a"))
 	require.NoError(t, err)
-	fileBConflict, _, err := kbfsOps2.Lookup(ctx, dirAConflict, "b")
+	fileBConflict, _, err := kbfsOps2.Lookup(ctx, dirAConflict, testPPS("b"))
 	require.NoError(t, err)
 
 	gotData2 := make([]byte, len(data2))
@@ -962,7 +972,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
+	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -971,7 +981,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	// disable updates and CR on user 2
 	c, err := DisableUpdatesForTesting(config2, rootNode2.GetFolderBranch())
@@ -980,13 +990,14 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	// User 1 creates a file
-	_, _, err = kbfsOps1.CreateFile(ctx, dirA1, "b", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, dirA1, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 creates the same file, and writes to it.
-	fileB2, _, err := kbfsOps2.CreateFile(ctx, dirA2, "b", false, NoExcl)
+	fileB2, _, err := kbfsOps2.CreateFile(
+		ctx, dirA2, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1023,7 +1034,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	assert.Equal(t, len(expectedChildren), len(children1))
 
 	for _, child := range expectedChildren {
-		_, ok := children1[child]
+		_, ok := children1[dirA1.ChildName(child)]
 		assert.True(t, ok)
 	}
 
@@ -1050,7 +1061,7 @@ func TestCRDouble(t *testing.T) {
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -1059,7 +1070,7 @@ func TestCRDouble(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
+	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	// disable updates and CR on user 2
 	c, err := DisableUpdatesForTesting(config2, rootNode2.GetFolderBranch())
@@ -1068,13 +1079,14 @@ func TestCRDouble(t *testing.T) {
 	require.NoError(t, err)
 
 	// User 1 creates a new file to start a conflict.
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "b", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 makes a couple revisions
-	fileNodeC, _, err := kbfsOps2.CreateFile(ctx, rootNode2, "c", false, NoExcl)
+	fileNodeC, _, err := kbfsOps2.CreateFile(
+		ctx, rootNode2, testPPS("c"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1120,11 +1132,11 @@ func TestCRDouble(t *testing.T) {
 	require.NoError(t, err)
 
 	// A few merged revisions
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "e", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("e"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "f", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("f"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1144,17 +1156,17 @@ func TestCRDouble(t *testing.T) {
 	require.NoError(t, err)
 	err = DisableCRForTesting(config2, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "g", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, testPPS("g"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 makes a couple unmerged revisions
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "h", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("h"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "i", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("i"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1194,9 +1206,10 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
+	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, testPPS("a"))
 	require.NoError(t, err)
-	fileB1, _, err := kbfsOps1.CreateFile(ctx, dirA1, "b", false, NoExcl)
+	fileB1, _, err := kbfsOps1.CreateFile(
+		ctx, dirA1, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -1205,9 +1218,9 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
-	fileB2, _, err := kbfsOps2.Lookup(ctx, dirA2, "b")
+	fileB2, _, err := kbfsOps2.Lookup(ctx, dirA2, testPPS("b"))
 	require.NoError(t, err)
 
 	config2Dev2 := ConfigAsUser(config1, userName2)
@@ -1286,7 +1299,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
-	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
+	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, testPPS("a"))
 	require.NoError(t, err)
 
 	cre := WriterDeviceDateConflictRenamer{}
@@ -1307,7 +1320,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	assert.Equal(t, len(expectedChildren), len(children1))
 
 	for _, child := range expectedChildren {
-		_, ok := children1[child]
+		_, ok := children1[dirA1.ChildName(child)]
 		assert.True(t, ok)
 	}
 
@@ -1337,9 +1350,10 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
+	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, testPPS("a"))
 	require.NoError(t, err)
-	fileB1, _, err := kbfsOps1.CreateFile(ctx, dirA1, "b", false, NoExcl)
+	fileB1, _, err := kbfsOps1.CreateFile(
+		ctx, dirA1, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -1348,7 +1362,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 
 	config2Dev2 := ConfigAsUser(config1, userName2)
@@ -1420,7 +1434,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
-	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
+	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, testPPS("a"))
 	require.NoError(t, err)
 
 	// Make sure they all see the same set of children
@@ -1439,7 +1453,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	assert.Equal(t, len(expectedChildren), len(children1))
 
 	for _, child := range expectedChildren {
-		_, ok := children1[child]
+		_, ok := children1[dirA1.ChildName(child)]
 		assert.True(t, ok)
 	}
 
@@ -1479,7 +1493,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -1488,7 +1502,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
+	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	// disable updates and CR on user 2
 	c, err := DisableUpdatesForTesting(config2, rootNode2.GetFolderBranch())
@@ -1497,13 +1511,14 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// User 1 creates a new file to start a conflict.
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "b", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 does one successful operation to create the first unmerged MD.
-	fileNodeB, _, err := kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	fileNodeB, _, err := kbfsOps2.CreateFile(
+		ctx, rootNode2, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1604,7 +1619,8 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
-	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	aNode1, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	data := []byte{1, 2, 3, 4, 5}
 	err = kbfsOps1.Write(ctx, aNode1, data, 0)
@@ -1616,7 +1632,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	aNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	aNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	// disable updates and CR on user 2
 	c, err := DisableUpdatesForTesting(config2, rootNode2.GetFolderBranch())
@@ -1668,7 +1684,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Do a second operation and complete the resolution.
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1693,7 +1709,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, len(expectedChildren), len(children2))
 	for _, child := range expectedChildren {
-		_, ok := children2[child]
+		_, ok := children2[rootNode2.ChildName(child)]
 		assert.True(t, ok)
 	}
 }
@@ -1715,9 +1731,9 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
-	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
+	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, testPPS("a"))
 	require.NoError(t, err)
-	_, _, err = kbfsOps1.CreateFile(ctx, dirA1, "b", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, dirA1, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -1728,9 +1744,9 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	kbfsOps2 := config2.KBFSOps()
 	ops2 := getOps(config2, rootNode2.GetFolderBranch().Tlf)
 	ops2.cr.maxRevsThreshold = 2
-	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
-	_, _, err = kbfsOps2.Lookup(ctx, dirA2, "b")
+	_, _, err = kbfsOps2.Lookup(ctx, dirA2, testPPS("b"))
 	require.NoError(t, err)
 
 	// disable updates on user 2
@@ -1740,17 +1756,17 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	require.NoError(t, err)
 
 	// One write for user 1
-	_, _, err = kbfsOps1.CreateFile(ctx, dirA1, "c", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, dirA1, testPPS("c"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, dirA1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// Two writes for user 2
-	_, _, err = kbfsOps2.CreateFile(ctx, dirA2, "d", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, dirA2, testPPS("d"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	_, _, err = kbfsOps2.CreateFile(ctx, dirA2, "e", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, dirA2, testPPS("e"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1790,7 +1806,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	wg.Wait()
 
 	// Pretend that CR was canceled by another write.
-	_, _, err = kbfsOps2.CreateFile(ctx, dirA2, "f", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, dirA2, testPPS("f"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1814,7 +1830,8 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// Now try to write again
 	writeErrCh := make(chan error, 1)
 	go func() {
-		_, _, err := kbfsOps2.CreateFile(ctx, dirA2, "g", false, NoExcl)
+		_, _, err := kbfsOps2.CreateFile(
+			ctx, dirA2, testPPS("g"), false, NoExcl)
 		assert.NoError(t, err)
 		err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 		require.NoError(t, err)
@@ -1860,7 +1877,8 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
-	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	aNode1, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	data := []byte{1, 2, 3, 4, 5}
 	err = kbfsOps1.Write(ctx, aNode1, data, 0)
@@ -1872,7 +1890,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
-	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
+	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	// disable updates and CR on user 2
 	c, err := DisableUpdatesForTesting(config2, rootNode2.GetFolderBranch())
@@ -1887,7 +1905,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	require.NoError(t, err)
 
 	// User 2 creates a file to start a conflict branch.
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -1900,7 +1918,8 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, _, err = kbfsOps2.CreateFile(putCtx, rootNode2, "c", false, NoExcl)
+		_, _, err = kbfsOps2.CreateFile(
+			putCtx, rootNode2, testPPS("c"), false, NoExcl)
 		require.NoError(t, err)
 		err = kbfsOps2.SyncAll(putCtx, rootNode2.GetFolderBranch())
 		// Even though internally folderBranchOps ignores the
@@ -1938,7 +1957,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, len(expectedChildren), len(children2))
 	for _, child := range expectedChildren {
-		_, ok := children2[child]
+		_, ok := children2[rootNode2.ChildName(child)]
 		assert.True(t, ok)
 	}
 }
@@ -1972,7 +1991,7 @@ func TestForceStuckConflict(t *testing.T) {
 	t.Log("Initialize the TLF")
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
+	_, _, err = kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -1043,7 +1043,7 @@ func (fs *KBFSOpsStandard) GetRootNode(
 
 // GetDirChildren implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) GetDirChildren(ctx context.Context, dir Node) (
-	map[string]data.EntryInfo, error) {
+	map[data.PathPartString]data.EntryInfo, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -1052,7 +1052,8 @@ func (fs *KBFSOpsStandard) GetDirChildren(ctx context.Context, dir Node) (
 }
 
 // Lookup implements the KBFSOps interface for KBFSOpsStandard
-func (fs *KBFSOpsStandard) Lookup(ctx context.Context, dir Node, name string) (
+func (fs *KBFSOpsStandard) Lookup(
+	ctx context.Context, dir Node, name data.PathPartString) (
 	Node, data.EntryInfo, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
@@ -1073,7 +1074,8 @@ func (fs *KBFSOpsStandard) Stat(ctx context.Context, node Node) (
 
 // CreateDir implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) CreateDir(
-	ctx context.Context, dir Node, name string) (Node, data.EntryInfo, error) {
+	ctx context.Context, dir Node, name data.PathPartString) (
+	Node, data.EntryInfo, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -1083,8 +1085,8 @@ func (fs *KBFSOpsStandard) CreateDir(
 
 // CreateFile implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) CreateFile(
-	ctx context.Context, dir Node, name string, isExec bool, excl Excl) (
-	Node, data.EntryInfo, error) {
+	ctx context.Context, dir Node, name data.PathPartString, isExec bool,
+	excl Excl) (Node, data.EntryInfo, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -1094,8 +1096,8 @@ func (fs *KBFSOpsStandard) CreateFile(
 
 // CreateLink implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) CreateLink(
-	ctx context.Context, dir Node, fromName string, toPath string) (
-	data.EntryInfo, error) {
+	ctx context.Context, dir Node, fromName data.PathPartString,
+	toPath string) (data.EntryInfo, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -1105,7 +1107,7 @@ func (fs *KBFSOpsStandard) CreateLink(
 
 // RemoveDir implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) RemoveDir(
-	ctx context.Context, dir Node, name string) error {
+	ctx context.Context, dir Node, name data.PathPartString) error {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -1115,7 +1117,7 @@ func (fs *KBFSOpsStandard) RemoveDir(
 
 // RemoveEntry implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) RemoveEntry(
-	ctx context.Context, dir Node, name string) error {
+	ctx context.Context, dir Node, name data.PathPartString) error {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -1125,8 +1127,8 @@ func (fs *KBFSOpsStandard) RemoveEntry(
 
 // Rename implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) Rename(
-	ctx context.Context, oldParent Node, oldName string, newParent Node,
-	newName string) error {
+	ctx context.Context, oldParent Node, oldName data.PathPartString,
+	newParent Node, newName data.PathPartString) error {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -75,7 +75,7 @@ func NewKBFSOpsStandard(appStateUpdater env.AppStateUpdater, config Config) *KBF
 		ops:                   make(map[data.FolderBranch]*folderBranchOps),
 		opsByFav:              make(map[favorites.Folder]*folderBranchOps),
 		reIdentifyControlChan: make(chan chan<- struct{}),
-		favs:                  NewFavorites(config),
+		favs: NewFavorites(config),
 		quotaUsage: NewEventuallyConsistentQuotaUsage(
 			config, quLog, config.MakeVLogger(quLog)),
 		longOperationDebugDumper: NewImpatientDebugDumper(
@@ -1096,8 +1096,8 @@ func (fs *KBFSOpsStandard) CreateFile(
 
 // CreateLink implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) CreateLink(
-	ctx context.Context, dir Node, fromName data.PathPartString,
-	toPath string) (data.EntryInfo, error) {
+	ctx context.Context, dir Node, fromName, toPath data.PathPartString) (
+	data.EntryInfo, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 

--- a/go/kbfs/libkbfs/kbfs_ops_concur_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_concur_test.go
@@ -130,7 +130,8 @@ func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	data := []byte{1}
 	err = kbfsOps.Write(ctx, fileNode, data, 0)
@@ -197,7 +198,7 @@ func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	for i := 0; i < nFiles; i++ {
 		name := fmt.Sprintf("file%d", i)
 		fileNode, _, err := kbfsOps.CreateFile(
-			ctx, rootNode, name, false, NoExcl)
+			ctx, rootNode, testPPS(name), false, NoExcl)
 		require.NoError(t, err, "Couldn't create file %s: %v", name, err)
 		fileNodes[i] = fileNode
 	}
@@ -342,7 +343,8 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	var data []byte
 	// Write 2 blocks worth of data
@@ -437,7 +439,8 @@ func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err, "Couldn't sync file: %v", err)
@@ -571,7 +574,8 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	// Write to file to mark it dirty.
@@ -653,7 +657,8 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	// Write to file to mark it dirty.
@@ -739,7 +744,8 @@ func TestKBFSOpsTruncateAndOverwriteDeferredWithArchivedBlock(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %+v", err)
 
 	err = kbfsOps.Truncate(ctx, fileNode, 131072)
@@ -773,7 +779,8 @@ func TestKBFSOpsTruncateAndOverwriteDeferredWithArchivedBlock(t *testing.T) {
 		t.Fatalf("Couldn't sync from server")
 	}
 
-	fileNode2, _, err := kbfsOps.CreateFile(ctx, rootNode, "b", false, NoExcl)
+	fileNode2, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("b"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %+v", err)
 
 	err = kbfsOps.Truncate(ctx, fileNode2, 131072)
@@ -868,7 +875,8 @@ func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	// Write to file to make an indirect block.
 	data := make([]byte, bsplitter.MaxSize()+1)
@@ -915,14 +923,15 @@ func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	data := []byte{1}
 	err = kbfsOps.Write(ctx, fileNode, data, 0)
 	require.NoError(t, err, "Couldn't write file: %v", err)
 
 	// Now update the folder pointer in some other way
-	_, _, err = kbfsOps.CreateFile(ctx, rootNode, "b", false, NoExcl)
+	_, _, err = kbfsOps.CreateFile(ctx, rootNode, testPPS("b"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	// Now sync the original file and see make sure the write survived
@@ -958,7 +967,8 @@ func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err, "Couldn't sync file: %v", err)
@@ -1141,7 +1151,8 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	// Two initial blocks, then maxParallelBlockPuts blocks that
 	// will be processed but discarded, then three extra blocks
@@ -1250,7 +1261,8 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 		t.Fatalf("Second sync failed: %v", err)
 	}
 
-	if _, _, err := kbfsOps.CreateFile(ctx, rootNode, "b", false, NoExcl); err != nil {
+	if _, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("b"), false, NoExcl); err != nil {
 		t.Fatalf("Couldn't create file after sync: %v", err)
 	}
 
@@ -1291,7 +1303,8 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	// 15 blocks
 	var data []byte
@@ -1379,7 +1392,7 @@ func testKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T, nFiles int) {
 	fileNodes := make([]Node, nFiles)
 
 	fileNodes[0], _, err = kbfsOps.CreateFile(
-		ctx, rootNode, "file0", false, NoExcl)
+		ctx, rootNode, testPPS("file0"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	firstData := make([]byte, 30)
@@ -1395,14 +1408,14 @@ func testKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T, nFiles int) {
 	require.NoError(t, err, "First sync failed: %v", err)
 
 	// Remove the first file, and wait for the archiving to complete.
-	err = kbfsOps.RemoveEntry(ctx, rootNode, "file0")
+	err = kbfsOps.RemoveEntry(ctx, rootNode, testPPS("file0"))
 	require.NoError(t, err, "Couldn't remove file: %v", err)
 
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err, "Couldn't sync from server: %v", err)
 
 	fileNode2, _, err := kbfsOps.CreateFile(
-		ctx, rootNode, "file0", false, NoExcl)
+		ctx, rootNode, testPPS("file0"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	// Now write the identical first block and sync it.
@@ -1413,7 +1426,7 @@ func testKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T, nFiles int) {
 	for i := 1; i < nFiles; i++ {
 		name := fmt.Sprintf("file%d", i)
 		fileNode, _, err := kbfsOps.CreateFile(
-			ctx, rootNode, name, false, NoExcl)
+			ctx, rootNode, testPPS(name), false, NoExcl)
 		require.NoError(t, err, "Couldn't create file: %v", err)
 		data := make([]byte, 30)
 		// Write 2 blocks worth of data
@@ -1509,7 +1522,7 @@ func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 	kbfsOps := config.KBFSOps()
 	fileNodes := make([]Node, nFiles)
 	fileNodes[0], _, err = kbfsOps.CreateFile(
-		ctx, rootNode, "file0", false, NoExcl)
+		ctx, rootNode, testPPS("file0"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	var data []byte
 
@@ -1533,7 +1546,7 @@ func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 	require.NoError(t, err, "Couldn't get the pointer map for file0: %+v", err)
 
 	t.Log("Remove that file")
-	err = kbfsOps.RemoveEntry(ctx, rootNode, "file0")
+	err = kbfsOps.RemoveEntry(ctx, rootNode, testPPS("file0"))
 	require.NoError(t, err, "Couldn't remove file: %v", err)
 
 	t.Log("Sync from server, waiting for the archiving to complete")
@@ -1554,7 +1567,7 @@ func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 
 	t.Log("Create file0 again")
 	fileNode2, _, err := kbfsOps.CreateFile(
-		ctx, rootNode, "file0", false, NoExcl)
+		ctx, rootNode, testPPS("file0"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	t.Log("Now write the identical first block, plus a new block and sync it.")
@@ -1568,7 +1581,7 @@ func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 	for i := 1; i < nFiles; i++ {
 		name := fmt.Sprintf("Create file%d", i)
 		fileNode, _, err := kbfsOps.CreateFile(
-			ctx, rootNode, name, false, NoExcl)
+			ctx, rootNode, testPPS(name), false, NoExcl)
 		require.NoError(t, err, "Couldn't create file: %v", err)
 		data := make([]byte, 30)
 		// Write 2 blocks worth of data
@@ -1702,7 +1715,8 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 	kbfsOps := config.KBFSOps()
 	errChan := make(chan error, 1)
 	go func() {
-		_, _, err := kbfsOps.CreateFile(putCtx, rootNode, "a", false, WithExcl)
+		_, _, err := kbfsOps.CreateFile(
+			putCtx, rootNode, testPPS("a"), false, WithExcl)
 		errChan <- err
 	}()
 
@@ -1726,7 +1740,7 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 	ctx2 := libcontext.BackgroundContextWithCancellationDelayer()
 	defer libcontext.CleanupCancellationDelayer(ctx2)
 	if _, _, err = kbfsOps.Lookup(
-		ctx2, rootNode, "a"); err != nil {
+		ctx2, rootNode, testPPS("a")); err != nil {
 		t.Fatalf("Lookup returned error: %v", err)
 	}
 }
@@ -1758,7 +1772,8 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 	kbfsOps := config.KBFSOps()
 	errChan := make(chan error, 1)
 	go func() {
-		_, _, err := kbfsOps.CreateFile(putCtx, rootNode, "a", false, WithExcl)
+		_, _, err := kbfsOps.CreateFile(
+			putCtx, rootNode, testPPS("a"), false, WithExcl)
 		errChan <- err
 	}()
 
@@ -1801,7 +1816,7 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 	// do another Op, which generates a new revision, to make sure
 	// CheckConfigAndShutdown doesn't get stuck
 	if _, _, err = kbfsOps.CreateFile(ctx2,
-		rootNode, "b", false, NoExcl); err != nil {
+		rootNode, testPPS("b"), false, NoExcl); err != nil {
 		t.Fatalf("throwaway op failed: %v", err)
 	}
 }
@@ -1823,7 +1838,8 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err, "Couldn't sync file: %v", err)
@@ -1909,7 +1925,8 @@ func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err, "Couldn't sync file: %v", err)
@@ -1991,13 +2008,13 @@ func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	_, _, err := kbfsOps.CreateFile(ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err, "Couldn't sync file: %v", err)
 
 	// Remove that file, and wait for the archiving to complete
-	err = kbfsOps.RemoveEntry(ctx, rootNode, "a")
+	err = kbfsOps.RemoveEntry(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err, "Couldn't remove file: %v", err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err, "Couldn't sync file: %v", err)
@@ -2005,7 +2022,8 @@ func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err, "Couldn't sync from server: %v", err)
 
-	fileNode2, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode2, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	var data []byte
@@ -2074,7 +2092,8 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	// Write over the dirty amount of data.  TODO: make this
@@ -2229,7 +2248,7 @@ func TestKBFSOpsLookupSyncRace(t *testing.T) {
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
 	fileNodeA1, _, err := kbfsOps1.CreateFile(
-		ctx, rootNode1, "a", false, NoExcl)
+		ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err, "Couldn't sync file: %v", err)
@@ -2258,7 +2277,7 @@ func TestKBFSOpsLookupSyncRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		var err error
-		fileNodeA2, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
+		fileNodeA2, _, err = kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 		require.NoError(t, err, "Couldn't lookup a: %v", err)
 	}()
 	// Wait for the lookup to block.
@@ -2335,7 +2354,8 @@ func TestKBFSOpsConcurMultiblockOverwriteWithCanceledSync(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err, "Couldn't create file: %v", err)
 
 	data := make([]byte, 30)
@@ -2436,7 +2456,7 @@ func TestKBFSOpsConcurWriteOfNonsyncedFileDuringSync(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 	fileA := "a"
 	fileANode, _, err := kbfsOps.CreateFile(
-		ctx, rootNode, fileA, false, NoExcl)
+		ctx, rootNode, testPPS(fileA), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -2447,7 +2467,7 @@ func TestKBFSOpsConcurWriteOfNonsyncedFileDuringSync(t *testing.T) {
 
 	fileB := "b"
 	fileBNode, _, err := kbfsOps.CreateFile(
-		ctx, rootNode, fileB, false, NoExcl)
+		ctx, rootNode, testPPS(fileB), false, NoExcl)
 	require.NoError(t, err)
 	dataB := []byte{1, 2, 3}
 	err = kbfsOps.Write(ctx, fileBNode, dataB, 0)

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -790,7 +790,7 @@ func TestKBFSOpsGetBaseDirChildrenHidesFiles(t *testing.T) {
 	dirBlock.Children[".kbfs_git"] = data.DirEntry{EntryInfo: data.EntryInfo{Type: data.Dir}}
 	blockPtr := makeBP(rootID, rmd, config, u)
 	rmd.data.Dir.BlockPointer = blockPtr
-	node := data.PathNode{BlockPointer: blockPtr, Name: "p"}
+	node := data.PathNode{BlockPointer: blockPtr, Name: testPPS("p")}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
 		Path:         []data.PathNode{node},
@@ -806,7 +806,7 @@ func TestKBFSOpsGetBaseDirChildrenHidesFiles(t *testing.T) {
 		t.Errorf("Got bad children back: %v", children)
 	}
 	for c, ei := range children {
-		if de, ok := dirBlock.Children[c]; !ok {
+		if de, ok := dirBlock.Children[c.Plaintext()]; !ok {
 			t.Errorf("No such child: %s", c)
 		} else if !de.EntryInfo.Eq(ei) {
 			t.Errorf("Wrong EntryInfo for child %s: %v", c, ei)
@@ -826,7 +826,7 @@ func TestKBFSOpsGetBaseDirChildrenCacheSuccess(t *testing.T) {
 	dirBlock.Children["b"] = data.DirEntry{EntryInfo: data.EntryInfo{Type: data.Dir}}
 	blockPtr := makeBP(rootID, rmd, config, u)
 	rmd.data.Dir.BlockPointer = blockPtr
-	node := data.PathNode{BlockPointer: blockPtr, Name: "p"}
+	node := data.PathNode{BlockPointer: blockPtr, Name: testPPS("p")}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
 		Path:         []data.PathNode{node},
@@ -842,7 +842,7 @@ func TestKBFSOpsGetBaseDirChildrenCacheSuccess(t *testing.T) {
 		t.Errorf("Got bad children back: %v", children)
 	}
 	for c, ei := range children {
-		if de, ok := dirBlock.Children[c]; !ok {
+		if de, ok := dirBlock.Children[c.Plaintext()]; !ok {
 			t.Errorf("No such child: %s", c)
 		} else if !de.EntryInfo.Eq(ei) {
 			t.Errorf("Wrong EntryInfo for child %s: %v", c, ei)
@@ -860,7 +860,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedSuccess(t *testing.T) {
 	dirBlock := data.NewDirBlock().(*data.DirBlock)
 	blockPtr := makeBP(rootID, rmd, config, u)
 	rmd.data.Dir.BlockPointer = blockPtr
-	node := data.PathNode{BlockPointer: blockPtr, Name: "p"}
+	node := data.PathNode{BlockPointer: blockPtr, Name: testPPS("p")}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
 		Path:         []data.PathNode{node},
@@ -898,7 +898,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 	rootID := kbfsblock.FakeID(42)
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, session.UID.AsUserOrTeam()),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -931,7 +931,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailMissingBlock(t *testing.T) {
 	dirBlock := data.NewDirBlock().(*data.DirBlock)
 	blockPtr := makeBP(rootID, rmd, config, u)
 	rmd.data.Dir.BlockPointer = blockPtr
-	node := data.PathNode{BlockPointer: blockPtr, Name: "p"}
+	node := data.PathNode{BlockPointer: blockPtr, Name: testPPS("p")}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
 		Path:         []data.PathNode{node},
@@ -971,9 +971,11 @@ func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 	dirBlock.Children["b"] = data.DirEntry{EntryInfo: data.EntryInfo{Type: data.Sym}}
 	blockPtr := makeBP(rootID, rmd, config, u)
 	rmd.data.Dir.BlockPointer = blockPtr
-	node := data.PathNode{BlockPointer: blockPtr, Name: "p"}
-	aNode := data.PathNode{BlockPointer: makeBP(aID, rmd, config, u), Name: "a"}
-	bNode := data.PathNode{BlockPointer: makeBP(bID, rmd, config, u), Name: "b"}
+	node := data.PathNode{BlockPointer: blockPtr, Name: testPPS("p")}
+	aNode := data.PathNode{
+		BlockPointer: makeBP(aID, rmd, config, u), Name: testPPS("a")}
+	bNode := data.PathNode{
+		BlockPointer: makeBP(bID, rmd, config, u), Name: testPPS("b")}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
 		Path:         []data.PathNode{node, aNode, bNode},
@@ -990,7 +992,7 @@ func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 	}
 
 	for c, ei := range children {
-		if de, ok := dirBlock.Children[c]; !ok {
+		if de, ok := dirBlock.Children[c.Plaintext()]; !ok {
 			t.Errorf("No such child: %s", c)
 		} else if !de.EntryInfo.Eq(ei) {
 			t.Errorf("Wrong EntryInfo for child %s: %v", c, ei)
@@ -1023,9 +1025,10 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 	}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
-	aNode := data.PathNode{BlockPointer: makeBP(aID, rmd, config, u), Name: "a"}
+	aNode := data.PathNode{
+		BlockPointer: makeBP(aID, rmd, config, u), Name: testPPS("a")}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
 		Path:         []data.PathNode{node, aNode},
@@ -1034,14 +1037,14 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, dirBlock)
 
-	bn, ei, err := config.KBFSOps().Lookup(ctx, n, "b")
+	bn, ei, err := config.KBFSOps().Lookup(ctx, n, testPPS("b"))
 	if err != nil {
 		t.Errorf("Error on Lookup: %+v", err)
 	}
 	bPath := ops.nodeCache.PathFromNode(bn)
 	expectedBNode := data.PathNode{
 		BlockPointer: makeBP(bID, rmd, config, u),
-		Name:         "b",
+		Name:         testPPS("b"),
 	}
 	expectedBNode.KeyGen = kbfsmd.FirstValidKeyGen
 	if !ei.Eq(dirBlock.Children["b"].EntryInfo) {
@@ -1076,11 +1079,11 @@ func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 	}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode := data.PathNode{
 		BlockPointer: makeBP(aID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1090,7 +1093,7 @@ func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, dirBlock)
 
-	bn, ei, err := config.KBFSOps().Lookup(ctx, n, "b")
+	bn, ei, err := config.KBFSOps().Lookup(ctx, n, testPPS("b"))
 	if err != nil {
 		t.Errorf("Error on Lookup: %+v", err)
 	}
@@ -1126,11 +1129,11 @@ func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 	}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode := data.PathNode{
 		BlockPointer: makeBP(aID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1141,7 +1144,7 @@ func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, dirBlock)
 
 	expectedErr := idutil.NoSuchNameError{Name: "c"}
-	_, _, err := config.KBFSOps().Lookup(ctx, n, "c")
+	_, _, err := config.KBFSOps().Lookup(ctx, n, testPPS("c"))
 	if err == nil {
 		t.Error("No error as expected on Lookup")
 	} else if err != expectedErr {
@@ -1174,15 +1177,15 @@ func TestKBFSOpsReadNewDataVersionFail(t *testing.T) {
 	}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode := data.PathNode{
 		BlockPointer: makeBP(aID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	bNode := data.PathNode{
 		BlockPointer: makeBP(bID, rmd, config, u),
-		Name:         "b",
+		Name:         testPPS("b"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1199,7 +1202,7 @@ func TestKBFSOpsReadNewDataVersionFail(t *testing.T) {
 		bInfo.DataVer,
 	}
 
-	n, _, err := config.KBFSOps().Lookup(ctx, n, "b")
+	n, _, err := config.KBFSOps().Lookup(ctx, n, testPPS("b"))
 	if err != nil {
 		t.Error("Unexpected error found on lookup")
 	}
@@ -1237,15 +1240,15 @@ func TestKBFSOpsStatSuccess(t *testing.T) {
 	}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode := data.PathNode{
 		BlockPointer: makeBP(aID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	bNode := data.PathNode{
 		BlockPointer: dirBlock.Children["b"].BlockPointer,
-		Name:         "b",
+		Name:         testPPS("b"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1320,7 +1323,7 @@ func testCreateEntryFailDupName(t *testing.T, isDir bool) {
 	}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1336,9 +1339,9 @@ func testCreateEntryFailDupName(t *testing.T, isDir bool) {
 	var err error
 	// dir and link have different checks for dup name
 	if isDir {
-		_, _, err = config.KBFSOps().CreateDir(ctx, n, "a")
+		_, _, err = config.KBFSOps().CreateDir(ctx, n, testPPS("a"))
 	} else {
-		_, err = config.KBFSOps().CreateLink(ctx, n, "a", "b")
+		_, err = config.KBFSOps().CreateLink(ctx, n, testPPS("a"), "b")
 	}
 	if err == nil {
 		t.Errorf("Got no expected error on create")
@@ -1367,7 +1370,7 @@ func testCreateEntryFailNameTooLong(t *testing.T, isDir bool) {
 	rootBlock := data.NewDirBlock().(*data.DirBlock)
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1385,9 +1388,9 @@ func testCreateEntryFailNameTooLong(t *testing.T, isDir bool) {
 	var err error
 	// dir and link have different checks for dup name
 	if isDir {
-		_, _, err = config.KBFSOps().CreateDir(ctx, n, name)
+		_, _, err = config.KBFSOps().CreateDir(ctx, n, testPPS(name))
 	} else {
-		_, err = config.KBFSOps().CreateLink(ctx, n, name, "b")
+		_, err = config.KBFSOps().CreateLink(ctx, n, testPPS(name), "b")
 	}
 	if err == nil {
 		t.Errorf("Got no expected error on create")
@@ -1421,7 +1424,7 @@ func testCreateEntryFailKBFSPrefix(t *testing.T, et data.EntryType) {
 	}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1437,13 +1440,15 @@ func testCreateEntryFailKBFSPrefix(t *testing.T, et data.EntryType) {
 	// dir and link have different checks for dup name
 	switch et {
 	case data.Dir:
-		_, _, err = config.KBFSOps().CreateDir(ctx, n, name)
+		_, _, err = config.KBFSOps().CreateDir(ctx, n, testPPS(name))
 	case data.Sym:
-		_, err = config.KBFSOps().CreateLink(ctx, n, name, "a")
+		_, err = config.KBFSOps().CreateLink(ctx, n, testPPS(name), "a")
 	case data.Exec:
-		_, _, err = config.KBFSOps().CreateFile(ctx, n, name, true, NoExcl)
+		_, _, err = config.KBFSOps().CreateFile(
+			ctx, n, testPPS(name), true, NoExcl)
 	case data.File:
-		_, _, err = config.KBFSOps().CreateFile(ctx, n, name, false, NoExcl)
+		_, _, err = config.KBFSOps().CreateFile(
+			ctx, n, testPPS(name), false, NoExcl)
 	}
 	if err == nil {
 		t.Errorf("Got no expected error on create")
@@ -1495,7 +1500,8 @@ func makeDirTree(id tlf.ID, uid keybase1.UserOrTeamID, components ...string) (
 			Type: data.Dir,
 		},
 	}
-	nodes := []data.PathNode{{BlockPointer: bi.BlockPointer, Name: "{root}"}}
+	nodes := []data.PathNode{{
+		BlockPointer: bi.BlockPointer, Name: testPPS("{root}")}}
 	rootBlock := data.NewDirBlock().(*data.DirBlock)
 	rootBlock.SetEncodedSize(bi.EncodedSize)
 	blocks := []*data.DirBlock{rootBlock}
@@ -1514,7 +1520,7 @@ func makeDirTree(id tlf.ID, uid keybase1.UserOrTeamID, components ...string) (
 		}
 		nodes = append(nodes, data.PathNode{
 			BlockPointer: bi.BlockPointer,
-			Name:         component,
+			Name:         testPPS(component),
 		})
 		dirBlock := data.NewDirBlock().(*data.DirBlock)
 		dirBlock.SetEncodedSize(bi.EncodedSize)
@@ -1547,7 +1553,7 @@ func makeFile(
 		},
 	}
 
-	p := dir.ChildPath(name, bi.BlockPointer)
+	p := dir.ChildPath(testPPS(name), bi.BlockPointer, nil)
 	return p, data.NewFileBlock().(*data.FileBlock)
 }
 
@@ -1563,7 +1569,7 @@ func makeDir(dir data.Path, parentDirBlock *data.DirBlock, name string) (
 		},
 	}
 
-	p := dir.ChildPath(name, bi.BlockPointer)
+	p := dir.ChildPath(testPPS(name), bi.BlockPointer, nil)
 	return p, data.NewDirBlock().(*data.DirBlock)
 }
 
@@ -1595,7 +1601,7 @@ func TestRemoveDirFailNonEmpty(t *testing.T) {
 	n := nodeFromPath(t, ops, *p.ParentPath().ParentPath())
 
 	expectedErr := DirNotEmptyError{p.ParentPath().TailName()}
-	err := config.KBFSOps().RemoveDir(ctx, n, "d")
+	err := config.KBFSOps().RemoveDir(ctx, n, testPPS("d"))
 	require.Equal(t, expectedErr, err)
 }
 
@@ -1613,7 +1619,7 @@ func testKBFSOpsRemoveFileMissingBlockSuccess(t *testing.T, et data.EntryType) {
 	var nodeA Node
 	var err error
 	if et == data.Dir {
-		nodeA, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
+		nodeA, _, err = kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 		require.NoError(t, err)
 		err = kbfsOps.SyncAll(ctx, nodeA.GetFolderBranch())
 		require.NoError(t, err)
@@ -1623,7 +1629,8 @@ func testKBFSOpsRemoveFileMissingBlockSuccess(t *testing.T, et data.EntryType) {
 			exec = true
 		}
 
-		nodeA, _, err = kbfsOps.CreateFile(ctx, rootNode, "a", exec, NoExcl)
+		nodeA, _, err = kbfsOps.CreateFile(
+			ctx, rootNode, testPPS("a"), exec, NoExcl)
 		require.NoError(t, err)
 
 		data := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
@@ -1639,7 +1646,7 @@ func testKBFSOpsRemoveFileMissingBlockSuccess(t *testing.T, et data.EntryType) {
 		[]data.BlockPointer{ops.nodeCache.PathFromNode(nodeA).TailPointer()})
 	config.ResetCaches()
 
-	err = config.KBFSOps().RemoveEntry(ctx, rootNode, "a")
+	err = config.KBFSOps().RemoveEntry(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -1681,7 +1688,7 @@ func TestRemoveDirFailNoSuchName(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 
 	expectedErr := idutil.NoSuchNameError{Name: "nonexistent"}
-	err := config.KBFSOps().RemoveDir(ctx, n, "nonexistent")
+	err := config.KBFSOps().RemoveDir(ctx, n, testPPS("nonexistent"))
 	require.Equal(t, expectedErr, err)
 }
 
@@ -1706,11 +1713,11 @@ func TestRenameFailAcrossTopLevelFolders(t *testing.T) {
 	aID1 := kbfsblock.FakeID(42)
 	node1 := data.PathNode{
 		BlockPointer: makeBP(rootID1, rmd1, config, uid1),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode1 := data.PathNode{
 		BlockPointer: makeBP(aID1, rmd1, config, uid1),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p1 := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id1},
@@ -1723,11 +1730,11 @@ func TestRenameFailAcrossTopLevelFolders(t *testing.T) {
 	aID2 := kbfsblock.FakeID(39)
 	node2 := data.PathNode{
 		BlockPointer: makeBP(rootID2, rmd2, config, uid2),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode2 := data.PathNode{
 		BlockPointer: makeBP(aID2, rmd2, config, uid2),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p2 := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id2},
@@ -1738,7 +1745,8 @@ func TestRenameFailAcrossTopLevelFolders(t *testing.T) {
 
 	expectedErr := RenameAcrossDirsError{}
 
-	if err := config.KBFSOps().Rename(ctx, n1, "b", n2, "c"); err == nil {
+	if err := config.KBFSOps().Rename(
+		ctx, n1, testPPS("b"), n2, testPPS("c")); err == nil {
 		t.Errorf("Got no expected error on rename")
 	} else if err.Error() != expectedErr.Error() {
 		t.Errorf("Got unexpected error on rename: %+v", err)
@@ -1757,11 +1765,11 @@ func TestKBFSOpsCacheReadFullSuccess(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, u),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1795,11 +1803,11 @@ func TestKBFSOpsCacheReadPartialSuccess(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, u),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1850,11 +1858,11 @@ func TestKBFSOpsCacheReadFullMultiBlockSuccess(t *testing.T) {
 	block4.Contents = []byte{20, 19, 18, 17, 16}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1914,11 +1922,11 @@ func TestKBFSOpsCacheReadPartialMultiBlockSuccess(t *testing.T) {
 	block4.Contents = []byte{20, 19, 18, 17, 16}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1957,11 +1965,11 @@ func TestKBFSOpsCacheReadFailPastEnd(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, u),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -1992,10 +2000,10 @@ func TestKBFSOpsServerReadFullSuccess(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileBlockPtr := makeBP(fileID, rmd, config, u)
-	fileNode := data.PathNode{BlockPointer: fileBlockPtr, Name: "f"}
+	fileNode := data.PathNode{BlockPointer: fileBlockPtr, Name: testPPS("f")}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
 		Path:         []data.PathNode{node, fileNode},
@@ -2029,10 +2037,10 @@ func TestKBFSOpsServerReadFailNoSuchBlock(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileBlockPtr := makeBP(fileID, rmd, config, u)
-	fileNode := data.PathNode{BlockPointer: fileBlockPtr, Name: "f"}
+	fileNode := data.PathNode{BlockPointer: fileBlockPtr, Name: testPPS("f")}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
 		Path:         []data.PathNode{node, fileNode},
@@ -2108,11 +2116,11 @@ func TestKBFSOpsWriteNewBlockSuccess(t *testing.T) {
 	fileBlock := data.NewFileBlock().(*data.FileBlock)
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2188,11 +2196,11 @@ func TestKBFSOpsWriteExtendSuccess(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2260,11 +2268,11 @@ func TestKBFSOpsWritePastEndSuccess(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2332,11 +2340,11 @@ func TestKBFSOpsWriteCauseSplit(t *testing.T) {
 	fileBlock.Contents = []byte{}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2465,11 +2473,11 @@ func TestKBFSOpsWriteOverMultipleBlocks(t *testing.T) {
 	block2.Contents = []byte{10, 9, 8, 7, 6}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2567,11 +2575,11 @@ func TestKBFSOpsTruncateToZeroSuccess(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2638,11 +2646,11 @@ func TestKBFSOpsTruncateSameSize(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, u),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2688,11 +2696,11 @@ func TestKBFSOpsTruncateSmallerSuccess(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2762,11 +2770,11 @@ func TestKBFSOpsTruncateShortensLastBlock(t *testing.T) {
 	block2.Contents = []byte{10, 9, 8, 7, 6}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2859,11 +2867,11 @@ func TestKBFSOpsTruncateRemovesABlock(t *testing.T) {
 	block2.Contents = []byte{10, 9, 8, 7, 6}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -2944,11 +2952,11 @@ func TestKBFSOpsTruncateBiggerSuccess(t *testing.T) {
 	fileBlock.Contents = []byte{1, 2, 3, 4, 5}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, uid),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	fileNode := data.PathNode{
 		BlockPointer: makeBP(fileID, rmd, config, uid),
-		Name:         "f",
+		Name:         testPPS("f"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -3007,11 +3015,11 @@ func TestSetExFailNoSuchName(t *testing.T) {
 	rootBlock := data.NewDirBlock().(*data.DirBlock)
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode := data.PathNode{
 		BlockPointer: makeBP(aID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -3021,7 +3029,7 @@ func TestSetExFailNoSuchName(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
-	expectedErr := idutil.NoSuchNameError{Name: p.TailName()}
+	expectedErr := idutil.NoSuchNameError{Name: p.TailName().Plaintext()}
 
 	// chmod a+x a
 	if err := config.KBFSOps().SetEx(ctx, n, true); err == nil {
@@ -3052,11 +3060,11 @@ func TestSetMtimeNull(t *testing.T) {
 	}
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode := data.PathNode{
 		BlockPointer: makeBP(aID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -3089,11 +3097,11 @@ func TestMtimeFailNoSuchName(t *testing.T) {
 	rootBlock := data.NewDirBlock().(*data.DirBlock)
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode := data.PathNode{
 		BlockPointer: makeBP(aID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -3103,7 +3111,7 @@ func TestMtimeFailNoSuchName(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
-	expectedErr := idutil.NoSuchNameError{Name: p.TailName()}
+	expectedErr := idutil.NoSuchNameError{Name: p.TailName().Plaintext()}
 
 	newMtime := time.Now()
 	if err := config.KBFSOps().SetMtime(ctx, n, &newMtime); err == nil {
@@ -3144,11 +3152,11 @@ func TestSyncCleanSuccess(t *testing.T) {
 	aID := kbfsblock.FakeID(43)
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	aNode := data.PathNode{
 		BlockPointer: makeBP(aID, rmd, config, u),
-		Name:         "a",
+		Name:         testPPS("a"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -3189,7 +3197,7 @@ func TestKBFSOpsStatRootSuccess(t *testing.T) {
 	rootID := kbfsblock.FakeID(42)
 	node := data.PathNode{
 		BlockPointer: makeBP(rootID, rmd, config, u),
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -3218,7 +3226,7 @@ func TestKBFSOpsFailingRootOps(t *testing.T) {
 	rmd.data.Dir.BlockPointer = makeBP(rootID, rmd, config, u)
 	node := data.PathNode{
 		BlockPointer: rmd.data.Dir.BlockPointer,
-		Name:         "p",
+		Name:         testPPS("p"),
 	}
 	p := data.Path{
 		FolderBranch: data.FolderBranch{Tlf: id},
@@ -3272,7 +3280,8 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "alice,bob", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	nodeA, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	nodeA, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -3313,7 +3322,8 @@ func TestKBFSOpsWriteRenameStat(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -3335,7 +3345,7 @@ func TestKBFSOpsWriteRenameStat(t *testing.T) {
 	}
 
 	// Rename it.
-	err = kbfsOps.Rename(ctx, rootNode, "a", rootNode, "b")
+	err = kbfsOps.Rename(ctx, rootNode, testPPS("a"), rootNode, testPPS("b"))
 	if err != nil {
 		t.Fatalf("Couldn't rename; %+v", err)
 	}
@@ -3361,7 +3371,8 @@ func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -3383,7 +3394,7 @@ func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 	}
 
 	// Rename it.
-	err = kbfsOps.Rename(ctx, rootNode, "a", rootNode, "b")
+	err = kbfsOps.Rename(ctx, rootNode, testPPS("a"), rootNode, testPPS("b"))
 	if err != nil {
 		t.Fatalf("Couldn't rename; %+v", err)
 	}
@@ -3394,10 +3405,10 @@ func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 		t.Fatalf("Couldn't stat file: %+v", err)
 	}
 	// CTime is allowed to change after a rename, but nothing else.
-	if newEi := eis["b"]; ei.Type != newEi.Type || ei.Size != newEi.Size ||
-		ei.Mtime != newEi.Mtime {
+	if newEi := eis[rootNode.ChildName("b")]; ei.Type != newEi.Type ||
+		ei.Size != newEi.Size || ei.Mtime != newEi.Mtime {
 		t.Errorf("Entry info unexpectedly changed from %+v to %+v",
-			ei, eis["b"])
+			ei, eis[rootNode.ChildName("b")])
 	}
 }
 
@@ -3409,13 +3420,13 @@ func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	_, _, err := kbfsOps.CreateFile(ctx, rootNode, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
 
 	// Remove the file, which will archive the block
-	err = kbfsOps.RemoveEntry(ctx, rootNode, "a")
+	err = kbfsOps.RemoveEntry(ctx, rootNode, testPPS("a"))
 	if err != nil {
 		t.Fatalf("Couldn't remove file: %+v", err)
 	}
@@ -3429,7 +3440,7 @@ func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 	// Create a second file, which will use the same initial block ID
 	// from the cache, even though it's been archived, and will be
 	// forced to try again.
-	_, _, err = kbfsOps.CreateFile(ctx, rootNode, "b", false, NoExcl)
+	_, _, err = kbfsOps.CreateFile(ctx, rootNode, testPPS("b"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create second file: %+v", err)
 	}
@@ -3451,7 +3462,8 @@ func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	fileNode, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -3526,7 +3538,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
-	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	_, _, err := kbfsOps.CreateFile(ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
@@ -3588,7 +3600,8 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 
 	kbfsOps1 := config1.KBFSOps()
 
-	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "dummy.txt", false, NoExcl)
+	_, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("dummy.txt"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -3613,11 +3626,11 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	// Add some operations to get mallory's TLF to have a higher
 	// MetadataVersion.
 	_, _, err = kbfsOps2.CreateFile(
-		ctx, rootNode2, "dummy.txt", false, NoExcl)
+		ctx, rootNode2, testPPS("dummy.txt"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.RemoveEntry(ctx, rootNode2, "dummy.txt")
+	err = kbfsOps2.RemoveEntry(ctx, rootNode2, testPPS("dummy.txt"))
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -3713,15 +3726,15 @@ func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 	config.BlockOps().Prefetcher().Shutdown()
 
 	// Create a/b/c.
-	nodeA, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
+	nodeA, _, err := kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
-	nodeB, _, err := kbfsOps.CreateDir(ctx, nodeA, "b")
+	nodeB, _, err := kbfsOps.CreateDir(ctx, nodeA, testPPS("b"))
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
-	nodeC, _, err := kbfsOps.CreateFile(ctx, nodeB, "c", false, NoExcl)
+	nodeC, _, err := kbfsOps.CreateFile(ctx, nodeB, testPPS("c"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -3735,7 +3748,7 @@ func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove c.
-	err = kbfsOps.RemoveEntry(ctx, nodeB, "c")
+	err = kbfsOps.RemoveEntry(ctx, nodeB, testPPS("c"))
 	require.NoError(t, err)
 
 	// Now a/b should be dirty.
@@ -3745,7 +3758,7 @@ func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 	require.Equal(t, "test_user/a/b", status.DirtyPaths[0])
 
 	// Now remove b, and make sure a/b is no longer dirty.
-	err = kbfsOps.RemoveDir(ctx, nodeA, "b")
+	err = kbfsOps.RemoveDir(ctx, nodeA, testPPS("b"))
 	require.NoError(t, err)
 	status, _, err = kbfsOps.FolderStatus(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -3754,7 +3767,7 @@ func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 
 	// Also make sure we can no longer create anything in the removed
 	// directory.
-	_, _, err = kbfsOps.CreateDir(ctx, nodeB, "d")
+	_, _, err = kbfsOps.CreateDir(ctx, nodeB, testPPS("d"))
 	require.IsType(t, UnsupportedOpInUnlinkedDirError{}, errors.Cause(err))
 
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
@@ -3819,7 +3832,8 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Create a small file.")
-	nodeA1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	nodeA1, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	buf := []byte{1}
 	err = kbfsOps1.Write(ctx, nodeA1, buf, 0)
@@ -3832,14 +3846,14 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	rootNode2, _, err := kbfsOps2.GetOrCreateRootNode(
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	nodeA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	nodeA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	gotData2 := make([]byte, len(buf))
 	_, err = kbfsOps2.Read(ctx, nodeA2, gotData2, 0)
 	require.NoError(t, err)
 	require.True(t, bytes.Equal(buf, gotData2))
 	t.Log("And also should be able to write.")
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -3849,13 +3863,13 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	rootNode3, _, err := kbfsOps3.GetOrCreateRootNode(
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	nodeA3, _, err := kbfsOps3.Lookup(ctx, rootNode3, "a")
+	nodeA3, _, err := kbfsOps3.Lookup(ctx, rootNode3, testPPS("a"))
 	require.NoError(t, err)
 	gotData3 := make([]byte, len(buf))
 	_, err = kbfsOps3.Read(ctx, nodeA3, gotData3, 0)
 	require.NoError(t, err)
 	require.True(t, bytes.Equal(buf, gotData3))
-	_, _, err = kbfsOps3.CreateFile(ctx, rootNode3, "c", false, NoExcl)
+	_, _, err = kbfsOps3.CreateFile(ctx, rootNode3, testPPS("c"), false, NoExcl)
 	require.IsType(t, tlfhandle.WriteAccessError{}, errors.Cause(err))
 
 	// Verify that "a" has the correct writer.
@@ -3891,12 +3905,12 @@ func TestKBFSOpsReadonlyNodes(t *testing.T) {
 	// Not read-only, should work.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 	kbfsOps := config.KBFSOps()
-	_, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
+	_, _, err := kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 
 	// Read-only, shouldn't work.
 	readonlyCtx := context.WithValue(ctx, wrappedReadonlyTestID, 1)
-	_, _, err = kbfsOps.CreateDir(readonlyCtx, rootNode, "b")
+	_, _, err = kbfsOps.CreateDir(readonlyCtx, rootNode, testPPS("b"))
 	require.IsType(t, WriteToReadonlyNodeError{}, errors.Cause(err))
 }
 
@@ -3940,7 +3954,7 @@ type wrappedAutocreateNode struct {
 }
 
 func (wan wrappedAutocreateNode) ShouldCreateMissedLookup(
-	ctx context.Context, _ string) (
+	ctx context.Context, _ data.PathPartString) (
 	bool, context.Context, data.EntryType, os.FileInfo, string) {
 	return true, ctx, wan.et, &fakeFileInfo{wan.et}, wan.sympath
 }
@@ -3955,7 +3969,7 @@ func testKBFSOpsAutocreateNodes(t *testing.T, et data.EntryType, sympath string)
 
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 	kbfsOps := config.KBFSOps()
-	n, ei, err := kbfsOps.Lookup(ctx, rootNode, "a")
+	n, ei, err := kbfsOps.Lookup(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	if et != data.Sym {
 		require.NotNil(t, n)
@@ -4001,7 +4015,7 @@ func testKBFSOpsMigrateToImplicitTeam(
 	rootNode1, _, err := kbfsOps1.GetOrCreateRootNode(
 		ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	_, _, err = kbfsOps1.CreateDir(ctx, rootNode1, "a")
+	_, _, err = kbfsOps1.CreateDir(ctx, rootNode1, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -4014,7 +4028,7 @@ func testKBFSOpsMigrateToImplicitTeam(
 	eis, err := kbfsOps2.GetDirChildren(ctx, rootNode2)
 	require.NoError(t, err)
 	require.Len(t, eis, 1)
-	_, ok := eis["a"]
+	_, ok := eis[rootNode2.ChildName("a")]
 	require.True(t, ok)
 
 	// These are deterministic, and should add the same
@@ -4035,7 +4049,7 @@ func testKBFSOpsMigrateToImplicitTeam(
 	t.Log("Starting migration to implicit team")
 	err = kbfsOps1.MigrateToImplicitTeam(ctx, h.TlfID())
 	require.NoError(t, err)
-	_, _, err = kbfsOps1.CreateDir(ctx, rootNode1, "b")
+	_, _, err = kbfsOps1.CreateDir(ctx, rootNode1, testPPS("b"))
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -4046,9 +4060,9 @@ func testKBFSOpsMigrateToImplicitTeam(
 	eis, err = kbfsOps2.GetDirChildren(ctx, rootNode2)
 	require.NoError(t, err)
 	require.Len(t, eis, 2)
-	_, ok = eis["a"]
+	_, ok = eis[rootNode2.ChildName("a")]
 	require.True(t, ok)
-	_, ok = eis["b"]
+	_, ok = eis[rootNode2.ChildName("b")]
 	require.True(t, ok)
 
 	t.Log("Make sure the new MD really is keyed for the implicit team")
@@ -4107,7 +4121,7 @@ func TestKBFSOpsArchiveBranchType(t *testing.T) {
 	fb := rootNode.GetFolderBranch()
 
 	t.Log("Make a new revision")
-	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
+	_, _, err = kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -4159,12 +4173,12 @@ func (n testKBFSOpsMemFSNode) GetFS(_ context.Context) billy.Filesystem {
 func (n testKBFSOpsMemFSNode) WrapChild(child Node) Node {
 	child = n.Node.WrapChild(child)
 	name := child.GetBasename()
-	fi, err := n.fs.Lstat(name)
+	fi, err := n.fs.Lstat(name.Plaintext())
 	if err != nil {
 		return child
 	}
 	if fi.IsDir() {
-		childFS, err := n.fs.Chroot(name)
+		childFS, err := n.fs.Chroot(name.Plaintext())
 		if err != nil {
 			return child
 		}
@@ -4176,7 +4190,7 @@ func (n testKBFSOpsMemFSNode) WrapChild(child Node) Node {
 	return &testKBFSOpsMemFileNode{
 		Node: child,
 		fs:   n.fs,
-		name: name,
+		name: name.Plaintext(),
 	}
 }
 
@@ -4186,9 +4200,9 @@ type testKBFSOpsRootNode struct {
 }
 
 func (n testKBFSOpsRootNode) ShouldCreateMissedLookup(
-	ctx context.Context, name string) (
+	ctx context.Context, name data.PathPartString) (
 	bool, context.Context, data.EntryType, os.FileInfo, string) {
-	if name == "memfs" {
+	if name.Plaintext() == "memfs" {
 		return true, ctx, data.FakeDir, nil, ""
 	}
 	return n.Node.ShouldCreateMissedLookup(ctx, name)
@@ -4196,7 +4210,7 @@ func (n testKBFSOpsRootNode) ShouldCreateMissedLookup(
 
 func (n testKBFSOpsRootNode) WrapChild(child Node) Node {
 	child = n.Node.WrapChild(child)
-	if child.GetBasename() == "memfs" {
+	if child.GetBasename().Plaintext() == "memfs" {
 		return &testKBFSOpsMemFSNode{
 			Node: &ReadonlyNode{Node: child},
 			fs:   n.fs,
@@ -4246,25 +4260,25 @@ func TestKBFSOpsReadonlyFSNodes(t *testing.T) {
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, data.MasterBranch)
 	require.NoError(t, err)
 
-	fsNode, _, err := kbfsOps.Lookup(ctx, rootNode, "memfs")
+	fsNode, _, err := kbfsOps.Lookup(ctx, rootNode, testPPS("memfs"))
 	require.NoError(t, err)
 	children, err := kbfsOps.GetDirChildren(ctx, fsNode)
 	require.NoError(t, err)
 	require.Len(t, children, 2)
 
-	aNode, _, err := kbfsOps.Lookup(ctx, fsNode, "a")
+	aNode, _, err := kbfsOps.Lookup(ctx, fsNode, testPPS("a"))
 	require.NoError(t, err)
 	children, err = kbfsOps.GetDirChildren(ctx, aNode)
 	require.NoError(t, err)
 	require.Len(t, children, 1)
 
-	bNode, _, err := kbfsOps.Lookup(ctx, aNode, "b")
+	bNode, _, err := kbfsOps.Lookup(ctx, aNode, testPPS("b"))
 	require.NoError(t, err)
 	children, err = kbfsOps.GetDirChildren(ctx, bNode)
 	require.NoError(t, err)
 	require.Len(t, children, 1)
 
-	cNode, _, err := kbfsOps.Lookup(ctx, bNode, "c")
+	cNode, _, err := kbfsOps.Lookup(ctx, bNode, testPPS("c"))
 	require.NoError(t, err)
 	data := make([]byte, 5)
 	n, err := kbfsOps.Read(ctx, cNode, data, 0)
@@ -4272,7 +4286,7 @@ func TestKBFSOpsReadonlyFSNodes(t *testing.T) {
 	require.Equal(t, int64(5), n)
 	require.Equal(t, "cdata", string(data))
 
-	dNode, _, err := kbfsOps.Lookup(ctx, fsNode, "d")
+	dNode, _, err := kbfsOps.Lookup(ctx, fsNode, testPPS("d"))
 	require.NoError(t, err)
 	data = make([]byte, 5)
 	n, err = kbfsOps.Read(ctx, dNode, data, 0)
@@ -4314,7 +4328,7 @@ func TestKBFSOpsReset(t *testing.T) {
 
 	oldID := h.TlfID()
 	t.Logf("Make a new revision for TLF ID %s", oldID)
-	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
+	_, _, err = kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -4334,7 +4348,7 @@ func TestKBFSOpsReset(t *testing.T) {
 	children, err := kbfsOps.GetDirChildren(ctx, rootNode)
 	require.NoError(t, err)
 	require.Len(t, children, 0)
-	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "b")
+	_, _, err = kbfsOps.CreateDir(ctx, rootNode, testPPS("b"))
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -4402,7 +4416,7 @@ func TestKBFSOpsUnsyncedMDCommit(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
+	_, _, err = kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -4419,7 +4433,7 @@ func TestKBFSOpsUnsyncedMDCommit(t *testing.T) {
 	kbfsOps2 := config2.KBFSOps()
 	rootNode2, _, err := kbfsOps2.GetOrCreateRootNode(ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	_, _, err = kbfsOps2.CreateDir(ctx, rootNode2, "b")
+	_, _, err = kbfsOps2.CreateDir(ctx, rootNode2, testPPS("b"))
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -4521,7 +4535,7 @@ func TestKBFSOpsSyncedMDCommit(t *testing.T) {
 		ctx, rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
 			Mode: keybase1.FolderSyncMode_ENABLED,
 		})
-	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
+	_, _, err = kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -4547,7 +4561,7 @@ func TestKBFSOpsSyncedMDCommit(t *testing.T) {
 	kbfsOps2 := config2.KBFSOps()
 	rootNode2, _, err := kbfsOps2.GetOrCreateRootNode(ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	_, _, err = kbfsOps2.CreateDir(ctx, rootNode2, "b")
+	_, _, err = kbfsOps2.CreateDir(ctx, rootNode2, testPPS("b"))
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -4578,7 +4592,7 @@ func TestKBFSOpsSyncedMDCommit(t *testing.T) {
 	}()
 
 	t.Log("Write again, and this time read the MD to force a commit")
-	_, _, err = kbfsOps2.CreateDir(ctx, rootNode2, "c")
+	_, _, err = kbfsOps2.CreateDir(ctx, rootNode2, testPPS("c"))
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -4642,7 +4656,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	t.Log("Initialize the TLF")
 	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
+	_, _, err = kbfsOps.CreateDir(ctx, rootNode, testPPS("a"))
 	require.NoError(t, err)
 
 	t.Log("Set a partial sync config")
@@ -4772,7 +4786,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	t.Log("Initialize the TLF")
 	rootNode2, _, err := kbfsOps2.GetOrCreateRootNode(ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	aNode, _, err := kbfsOps2.CreateDir(ctx, rootNode2, "a")
+	aNode, _, err := kbfsOps2.CreateDir(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -4816,15 +4830,15 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	checkSyncCache(2, rootNode, aNode)
 
 	t.Log("First device completes synced path, along with others")
-	bNode, _, err := kbfsOps2.CreateDir(ctx, aNode, "b")
+	bNode, _, err := kbfsOps2.CreateDir(ctx, aNode, testPPS("b"))
 	require.NoError(t, err)
-	b2Node, _, err := kbfsOps2.CreateDir(ctx, aNode, "b2")
+	b2Node, _, err := kbfsOps2.CreateDir(ctx, aNode, testPPS("b2"))
 	require.NoError(t, err)
-	cNode, _, err := kbfsOps2.CreateDir(ctx, bNode, "c")
+	cNode, _, err := kbfsOps2.CreateDir(ctx, bNode, testPPS("c"))
 	require.NoError(t, err)
-	_, _, err = kbfsOps2.CreateDir(ctx, b2Node, "c2")
+	_, _, err = kbfsOps2.CreateDir(ctx, b2Node, testPPS("c2"))
 	require.NoError(t, err)
-	dNode, _, err := kbfsOps2.CreateDir(ctx, rootNode2, "d")
+	dNode, _, err := kbfsOps2.CreateDir(ctx, rootNode2, testPPS("d"))
 	require.NoError(t, err)
 	c, err := DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -4866,9 +4880,10 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	checkStatus(cNode, FinishedPrefetch)
 
 	t.Log("Add more data under prefetched path")
-	eNode, _, err := kbfsOps2.CreateDir(ctx, cNode, "e")
+	eNode, _, err := kbfsOps2.CreateDir(ctx, cNode, testPPS("e"))
 	require.NoError(t, err)
-	fNode, _, err := kbfsOps2.CreateFile(ctx, eNode, "f", false, NoExcl)
+	fNode, _, err := kbfsOps2.CreateFile(
+		ctx, eNode, testPPS("f"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.Write(ctx, fNode, []byte("fdata"), 0)
 	require.NoError(t, err)
@@ -4890,7 +4905,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	checkStatus(fNode, FinishedPrefetch)
 
 	t.Log("Add something that's not synced")
-	gNode, _, err := kbfsOps2.CreateDir(ctx, dNode, "g")
+	gNode, _, err := kbfsOps2.CreateDir(ctx, dNode, testPPS("g"))
 	require.NoError(t, err)
 	c, err = DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -4938,7 +4953,7 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	checkStatus(gNode, NoPrefetch)
 
 	t.Log("Move a synced subdirectory somewhere else")
-	err = kbfsOps2.Rename(ctx, cNode, "e", dNode, "e")
+	err = kbfsOps2.Rename(ctx, cNode, testPPS("e"), dNode, testPPS("e"))
 	require.NoError(t, err)
 	c, err = DisableUpdatesForTesting(config, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -4991,7 +5006,7 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	t.Log("Initialize the TLF")
 	rootNode2, _, err := kbfsOps2.GetOrCreateRootNode(ctx, h, data.MasterBranch)
 	require.NoError(t, err)
-	aNode, _, err := kbfsOps2.CreateDir(ctx, rootNode2, "a")
+	aNode, _, err := kbfsOps2.CreateDir(ctx, rootNode2, testPPS("a"))
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
@@ -5023,7 +5038,8 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	checkStatus(aNode, FinishedPrefetch)
 
 	t.Log("Writer adds a file, which gets prefetched")
-	bNode, _, err := kbfsOps2.CreateFile(ctx, aNode, "b", false, NoExcl)
+	bNode, _, err := kbfsOps2.CreateFile(
+		ctx, aNode, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.Write(ctx, bNode, []byte("bdata"), 0)
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -1434,7 +1434,7 @@ func testCreateEntryFailKBFSPrefix(t *testing.T, et data.EntryType) {
 	n := nodeFromPath(t, ops, p)
 
 	name := ".kbfs_status"
-	expectedErr := DisallowedPrefixError{name, ".kbfs"}
+	expectedErr := DisallowedPrefixError{testPPS(name), ".kbfs"}
 
 	var err error
 	// dir and link have different checks for dup name

--- a/go/kbfs/libkbfs/key_manager.go
+++ b/go/kbfs/libkbfs/key_manager.go
@@ -64,8 +64,8 @@ func (km *KeyManagerStandard) GetTLFCryptKeyForBlockDecryption(
 func (km *KeyManagerStandard) GetFirstTLFCryptKey(
 	ctx context.Context, kmd libkey.KeyMetadata) (
 	kbfscrypto.TLFCryptKey, error) {
-	return km.getTLFCryptKeyUsingCurrentDevice(
-		ctx, kmd, kbfsmd.FirstValidKeyGen, false)
+	return km.getTLFCryptKey(
+		ctx, kmd, kbfsmd.FirstValidKeyGen, getTLFCryptKeyAnyDevice)
 }
 
 // GetTLFCryptKeyOfAllGenerations implements the KeyManager interface for

--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -876,7 +876,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	kbfsOps1 := config1.KBFSOps()
 
 	// user 1 creates a file
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -890,7 +890,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	kbfsOps2 := config2.KBFSOps()
 
 	// user 2 creates a file
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("b"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -954,7 +954,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	}
 
 	// user 2 creates another file
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "c", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("c"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1017,7 +1017,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	}
 
 	// force re-encryption of the root dir
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "d", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("d"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1041,7 +1041,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 
 	children, err := kbfsOps2Dev2.GetDirChildren(ctx, rootNode2Dev2)
 	require.NoError(t, err)
-	if _, ok := children["d"]; !ok {
+	if _, ok := children[rootNode2Dev2.ChildName("d")]; !ok {
 		t.Fatalf("Device 2 couldn't see the new dir entry")
 	}
 
@@ -1061,7 +1061,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	// the latest revision were never applied.
 	children, err = kbfsOps2.GetDirChildren(ctx, rootNode2)
 	require.NoError(t, err)
-	if _, ok := children["d"]; ok {
+	if _, ok := children[rootNode2.ChildName("d")]; ok {
 		t.Fatalf("Found c unexpectedly: %v", children)
 	}
 
@@ -1070,7 +1070,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	rootNode2Dev3 := GetRootNodeOrBust(ctx, t, config2Dev3, name, tlf.Private)
 
 	kbfsOps2Dev3 := config2Dev3.KBFSOps()
-	aNode, _, err := kbfsOps2Dev3.Lookup(ctx, rootNode2Dev3, "a")
+	aNode, _, err := kbfsOps2Dev3.Lookup(ctx, rootNode2Dev3, testPPS("a"))
 	if err != nil {
 		t.Fatalf("Device 3 couldn't lookup a: %+v", err)
 	}
@@ -1081,7 +1081,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 		t.Fatalf("Device 3 couldn't read a: %+v", err)
 	}
 
-	bNode, _, err := kbfsOps2Dev3.Lookup(ctx, rootNode2Dev3, "b")
+	bNode, _, err := kbfsOps2Dev3.Lookup(ctx, rootNode2Dev3, testPPS("b"))
 	if err != nil {
 		t.Fatalf("Device 3 couldn't lookup b: %+v", err)
 	}
@@ -1146,7 +1146,7 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.Metada
 	kbfsOps1 := config1.KBFSOps()
 
 	// user 1 creates a file
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1243,7 +1243,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 	kbfsOps1 := config1.KBFSOps()
 
 	t.Log("User 1 creates a file")
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1287,12 +1287,13 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
 	children2, err := kbfsOps2Dev2.GetDirChildren(ctx, root2dev2)
 	require.NoError(t, err)
-	if _, ok := children2["a"]; !ok {
+	if _, ok := children2[root2dev2.ChildName("a")]; !ok {
 		t.Fatalf("Device 2 couldn't see user 1's dir entry")
 	}
 
 	t.Log("User 2 device 2 creates a file")
-	_, _, err = kbfsOps2Dev2.CreateFile(ctx, root2dev2, "b", false, NoExcl)
+	_, _, err = kbfsOps2Dev2.CreateFile(
+		ctx, root2dev2, testPPS("b"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1311,7 +1312,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 	t.Log("User 1 should be able to read the file that user 2 device 2 created")
 	children1, err := kbfsOps1.GetDirChildren(ctx, rootNode1)
 	require.NoError(t, err)
-	if _, ok := children1["b"]; !ok {
+	if _, ok := children1[rootNode1.ChildName("b")]; !ok {
 		t.Fatalf("Device 1 couldn't see the new dir entry")
 	}
 }
@@ -1341,7 +1342,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 	kbfsOps1 := config1.KBFSOps()
 
 	t.Log("User 1 creates a file")
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1402,7 +1403,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 	t.Log("User 2 device 2 reads user 1's file")
 	children2, err := kbfsOps2Dev2.GetDirChildren(ctx, root2dev2)
 	require.NoError(t, err)
-	if _, ok := children2["a"]; !ok {
+	if _, ok := children2[root2dev2.ChildName("a")]; !ok {
 		t.Fatalf("Device 2 couldn't see user 1's dir entry")
 	}
 }
@@ -1439,7 +1440,7 @@ func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver kbfsmd.MetadataVer) {
 	kbfsOps1 := config1.KBFSOps()
 
 	t.Log("User 1 creates a file")
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1574,7 +1575,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	kbfsOps1 := config1.KBFSOps()
 
 	// user 1 creates a file
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1641,7 +1642,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
 
 	// look for the file
-	aNode, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
+	aNode, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, testPPS("a"))
 	if err != nil {
 		t.Fatalf("Device 2 couldn't lookup a: %+v", err)
 	}
@@ -1706,7 +1707,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	rootNode3Dev2 := GetRootNodeOrBust(ctx, t, config3Dev2, name, tlf.Private)
 
 	// look for the file
-	a2Node, _, err := kbfsOps3Dev2.Lookup(ctx, rootNode3Dev2, "a")
+	a2Node, _, err := kbfsOps3Dev2.Lookup(ctx, rootNode3Dev2, testPPS("a"))
 	if err != nil {
 		t.Fatalf("Device 3 couldn't lookup a: %+v", err)
 	}
@@ -1752,7 +1753,7 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.
 	kbfsOps1 := config1.KBFSOps()
 
 	// user 1 creates a file
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1838,7 +1839,8 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.
 	}
 
 	// force re-encryption of the root dir
-	_, _, err = kbfsOps2Dev2.CreateFile(ctx, root2Dev2, "b", false, NoExcl)
+	_, _, err = kbfsOps2Dev2.CreateFile(
+		ctx, root2Dev2, testPPS("b"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1858,7 +1860,7 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.
 
 	children, err := kbfsOps1.GetDirChildren(ctx, rootNode1)
 	require.NoError(t, err)
-	if _, ok := children["b"]; !ok {
+	if _, ok := children[rootNode1.ChildName("b")]; !ok {
 		t.Fatalf("Device 1 couldn't see the new dir entry")
 	}
 }
@@ -1909,7 +1911,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 	kbfsOps1 := config1.KBFSOps()
 
 	// user 1 creates a file
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1975,11 +1977,12 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 	kbfsOps2 := config2Dev2.KBFSOps()
 	children, err := kbfsOps2.GetDirChildren(ctx, rootNode2Dev2)
 	require.NoError(t, err)
-	if _, ok := children["a"]; !ok {
+	if _, ok := children[rootNode2Dev2.ChildName("a")]; !ok {
 		t.Fatalf("Device 2 couldn't see the dir entry after rekey")
 	}
 	// user 2 creates another file to make a new revision
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2Dev2, "b", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(
+		ctx, rootNode2Dev2, testPPS("b"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -1996,7 +1999,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 	}
 	children, err = kbfsOps1.GetDirChildren(ctx, rootNode1)
 	require.NoError(t, err)
-	if _, ok := children["b"]; !ok {
+	if _, ok := children[rootNode1.ChildName("b")]; !ok {
 		t.Fatalf("Device 2 couldn't see the dir entry after rekey")
 	}
 }
@@ -2026,7 +2029,7 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 	kbfsOps1 := config1.KBFSOps()
 
 	// user 1 creates a file
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -2115,11 +2118,12 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 	kbfsOps2 := config2Dev2.KBFSOps()
 	children, err := kbfsOps2.GetDirChildren(ctx, rootNode2Dev2)
 	require.NoError(t, err)
-	if _, ok := children["a"]; !ok {
+	if _, ok := children[rootNode2Dev2.ChildName("a")]; !ok {
 		t.Fatalf("Device 2 couldn't see the dir entry after rekey")
 	}
 	// user 2 creates another file to make a new revision
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2Dev2, "b", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(
+		ctx, rootNode2Dev2, testPPS("b"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -2267,7 +2271,7 @@ func testKeyManagerRekeyMinimal(t *testing.T, ver kbfsmd.MetadataVer) {
 	kbfsOps1 := config1.KBFSOps()
 
 	// user 1 creates a file
-	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, testPPS("a"), false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
@@ -2312,7 +2316,7 @@ func testKeyManagerRekeyMinimal(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	children, err := kbfsOps2Dev2.GetDirChildren(ctx, root2Dev2)
 	require.NoError(t, err)
-	if _, ok := children["a"]; !ok {
+	if _, ok := children[root2Dev2.ChildName("a")]; !ok {
 		t.Fatalf("Device 2 couldn't see the dir entry")
 	}
 }

--- a/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc_test.go
@@ -363,7 +363,8 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 
 	// user 1 creates a file
 	kbfsOps1 := config1.KBFSOps()
-	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	_, _, err := kbfsOps1.CreateFile(
+		ctx, rootNode1, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
@@ -375,7 +376,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	clock.Add(1 * time.Minute)
 	second := clock.Now()
 
-	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, testPPS("b"), false, NoExcl)
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -947,7 +947,7 @@ func (mr *MockKBFSOpsMockRecorder) ClearPrivateFolderMD(arg0 interface{}) *gomoc
 }
 
 // CreateDir mocks base method
-func (m *MockKBFSOps) CreateDir(arg0 context.Context, arg1 Node, arg2 string) (Node, data.EntryInfo, error) {
+func (m *MockKBFSOps) CreateDir(arg0 context.Context, arg1 Node, arg2 data.PathPartString) (Node, data.EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDir", arg0, arg1, arg2)
 	ret0, _ := ret[0].(Node)
@@ -963,7 +963,7 @@ func (mr *MockKBFSOpsMockRecorder) CreateDir(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // CreateFile mocks base method
-func (m *MockKBFSOps) CreateFile(arg0 context.Context, arg1 Node, arg2 string, arg3 bool, arg4 Excl) (Node, data.EntryInfo, error) {
+func (m *MockKBFSOps) CreateFile(arg0 context.Context, arg1 Node, arg2 data.PathPartString, arg3 bool, arg4 Excl) (Node, data.EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFile", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(Node)
@@ -979,7 +979,7 @@ func (mr *MockKBFSOpsMockRecorder) CreateFile(arg0, arg1, arg2, arg3, arg4 inter
 }
 
 // CreateLink mocks base method
-func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2, arg3 string) (data.EntryInfo, error) {
+func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2 data.PathPartString, arg3 string) (data.EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLink", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(data.EntryInfo)
@@ -1079,10 +1079,10 @@ func (mr *MockKBFSOpsMockRecorder) ForceStuckConflictForTesting(arg0, arg1 inter
 }
 
 // GetDirChildren mocks base method
-func (m *MockKBFSOps) GetDirChildren(arg0 context.Context, arg1 Node) (map[string]data.EntryInfo, error) {
+func (m *MockKBFSOps) GetDirChildren(arg0 context.Context, arg1 Node) (map[data.PathPartString]data.EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDirChildren", arg0, arg1)
-	ret0, _ := ret[0].(map[string]data.EntryInfo)
+	ret0, _ := ret[0].(map[data.PathPartString]data.EntryInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1306,7 +1306,7 @@ func (mr *MockKBFSOpsMockRecorder) KickoffAllOutstandingRekeys() *gomock.Call {
 }
 
 // Lookup mocks base method
-func (m *MockKBFSOps) Lookup(arg0 context.Context, arg1 Node, arg2 string) (Node, data.EntryInfo, error) {
+func (m *MockKBFSOps) Lookup(arg0 context.Context, arg1 Node, arg2 data.PathPartString) (Node, data.EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Lookup", arg0, arg1, arg2)
 	ret0, _ := ret[0].(Node)
@@ -1411,7 +1411,7 @@ func (mr *MockKBFSOpsMockRecorder) RefreshEditHistory(arg0 interface{}) *gomock.
 }
 
 // RemoveDir mocks base method
-func (m *MockKBFSOps) RemoveDir(arg0 context.Context, arg1 Node, arg2 string) error {
+func (m *MockKBFSOps) RemoveDir(arg0 context.Context, arg1 Node, arg2 data.PathPartString) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveDir", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1425,7 +1425,7 @@ func (mr *MockKBFSOpsMockRecorder) RemoveDir(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // RemoveEntry mocks base method
-func (m *MockKBFSOps) RemoveEntry(arg0 context.Context, arg1 Node, arg2 string) error {
+func (m *MockKBFSOps) RemoveEntry(arg0 context.Context, arg1 Node, arg2 data.PathPartString) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveEntry", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1439,7 +1439,7 @@ func (mr *MockKBFSOpsMockRecorder) RemoveEntry(arg0, arg1, arg2 interface{}) *go
 }
 
 // Rename mocks base method
-func (m *MockKBFSOps) Rename(arg0 context.Context, arg1 Node, arg2 string, arg3 Node, arg4 string) error {
+func (m *MockKBFSOps) Rename(arg0 context.Context, arg1 Node, arg2 data.PathPartString, arg3 Node, arg4 data.PathPartString) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Rename", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -3422,6 +3422,20 @@ func (m *MockNode) EXPECT() *MockNodeMockRecorder {
 	return m.recorder
 }
 
+// ChildName mocks base method
+func (m *MockNode) ChildName(arg0 string) data.PathPartString {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChildName", arg0)
+	ret0, _ := ret[0].(data.PathPartString)
+	return ret0
+}
+
+// ChildName indicates an expected call of ChildName
+func (mr *MockNodeMockRecorder) ChildName(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChildName", reflect.TypeOf((*MockNode)(nil).ChildName), arg0)
+}
+
 // EntryType mocks base method
 func (m *MockNode) EntryType() data.EntryType {
 	m.ctrl.T.Helper()
@@ -3449,10 +3463,10 @@ func (mr *MockNodeMockRecorder) FillCacheDuration(arg0 interface{}) *gomock.Call
 }
 
 // GetBasename mocks base method
-func (m *MockNode) GetBasename() string {
+func (m *MockNode) GetBasename() data.PathPartString {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBasename")
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(data.PathPartString)
 	return ret0
 }
 
@@ -3561,7 +3575,7 @@ func (mr *MockNodeMockRecorder) Readonly(arg0 interface{}) *gomock.Call {
 }
 
 // RemoveDir mocks base method
-func (m *MockNode) RemoveDir(arg0 context.Context, arg1 string) (bool, error) {
+func (m *MockNode) RemoveDir(arg0 context.Context, arg1 data.PathPartString) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveDir", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -3576,7 +3590,7 @@ func (mr *MockNodeMockRecorder) RemoveDir(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // ShouldCreateMissedLookup mocks base method
-func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 string) (bool, context.Context, data.EntryType, os.FileInfo, string) {
+func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldCreateMissedLookup", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -3713,7 +3727,7 @@ func (mr *MockNodeCacheMockRecorder) Get(arg0 interface{}) *gomock.Call {
 }
 
 // GetOrCreate mocks base method
-func (m *MockNodeCache) GetOrCreate(arg0 data.BlockPointer, arg1 string, arg2 Node, arg3 data.EntryType) (Node, error) {
+func (m *MockNodeCache) GetOrCreate(arg0 data.BlockPointer, arg1 data.PathPartString, arg2 Node, arg3 data.EntryType) (Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrCreate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(Node)
@@ -3742,7 +3756,7 @@ func (mr *MockNodeCacheMockRecorder) IsUnlinked(arg0 interface{}) *gomock.Call {
 }
 
 // Move mocks base method
-func (m *MockNodeCache) Move(arg0 data.BlockRef, arg1 Node, arg2 string) (func(), error) {
+func (m *MockNodeCache) Move(arg0 data.BlockRef, arg1 Node, arg2 data.PathPartString) (func(), error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Move", arg0, arg1, arg2)
 	ret0, _ := ret[0].(func())

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -979,7 +979,7 @@ func (mr *MockKBFSOpsMockRecorder) CreateFile(arg0, arg1, arg2, arg3, arg4 inter
 }
 
 // CreateLink mocks base method
-func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2 data.PathPartString, arg3 string) (data.EntryInfo, error) {
+func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2, arg3 data.PathPartString) (data.EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLink", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(data.EntryInfo)
@@ -3590,14 +3590,14 @@ func (mr *MockNodeMockRecorder) RemoveDir(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // ShouldCreateMissedLookup mocks base method
-func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, string) {
+func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldCreateMissedLookup", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(context.Context)
 	ret2, _ := ret[2].(data.EntryType)
 	ret3, _ := ret[3].(os.FileInfo)
-	ret4, _ := ret[4].(string)
+	ret4, _ := ret[4].(data.PathPartString)
 	return ret0, ret1, ret2, ret3, ret4
 }
 

--- a/go/kbfs/libkbfs/md_journal_test.go
+++ b/go/kbfs/libkbfs/md_journal_test.go
@@ -44,6 +44,12 @@ func (g singleEncryptionKeyGetter) GetTLFCryptKeyForMDDecryption(
 	return g.k, nil
 }
 
+func (g singleEncryptionKeyGetter) GetFirstTLFCryptKey(
+	ctx context.Context, kmd libkey.KeyMetadata) (
+	kbfscrypto.TLFCryptKey, error) {
+	return g.k, nil
+}
+
 func setupMDJournalTest(t testing.TB, ver kbfsmd.MetadataVer) (
 	codec kbfscodec.Codec, crypto CryptoCommon, tlfID tlf.ID,
 	signer kbfscrypto.Signer, ekg singleEncryptionKeyGetter,

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -202,6 +202,8 @@ func verifyMDForPrivateHelper(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().Return(nil)
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes()
+	config.mockKeyman.EXPECT().GetFirstTLFCryptKey(gomock.Any(), gomock.Any()).
+		AnyTimes().Return(kbfscrypto.TLFCryptKey{}, nil)
 }
 
 func verifyMDForPrivate(

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -713,7 +713,16 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 		obfuscator = makeMDObfuscatorFromSecret(secret, mode)
 	}
 	for _, op := range pmd.Changes.Ops {
-		// Add a temporary path with an obfuscator.
+		// Add a temporary path with an obfuscator.  When we
+		// deserialize the ops from the raw byte buffer of the MD
+		// object, they don't have proper `data.Path`s set in them yet
+		// -- that's an unexported field. The path is required for
+		// obfuscation, so here we're just making sure that they all
+		// have one. In places where a perfectly-accurate path is
+		// required (like in conflict resolution), the code there will
+		// need to add a proper path. Note that here the level of the
+		// obfuscator might be wrong, and so might result in
+		// inconsistent suffixes for obfuscated names that conflict.
 		if !op.getFinalPath().IsValid() {
 			op.setFinalPath(data.Path{Path: []data.PathNode{{
 				BlockPointer: data.ZeroPtr,

--- a/go/kbfs/libkbfs/md_util_test.go
+++ b/go/kbfs/libkbfs/md_util_test.go
@@ -122,7 +122,8 @@ func TestGetRevisionByTime(t *testing.T) {
 	t.Log("Create revision 2")
 	t2 := t1.Add(1 * time.Minute)
 	clock.Set(t2)
-	nodeA, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	nodeA, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, testPPS("a"), false, NoExcl)
 	require.NoError(t, err)
 	data := []byte{1}
 	err = kbfsOps.Write(ctx, nodeA, data, 0)

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"fmt"
 	"math"
+	"os"
 	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -556,5 +557,5 @@ func (mt modeTest) QuotaReclamationMinHeadAge() time.Duration {
 }
 
 func (mt modeTest) DoLogObfuscation() bool {
-	return false
+	return os.Getenv("KEYBASE_TEST_OBFUSCATE_LOGS") != ""
 }

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -557,5 +558,6 @@ func (mt modeTest) QuotaReclamationMinHeadAge() time.Duration {
 }
 
 func (mt modeTest) DoLogObfuscation() bool {
-	return os.Getenv("KEYBASE_TEST_OBFUSCATE_LOGS") != ""
+	e := os.Getenv("KEYBASE_TEST_OBFUSCATE_LOGS")
+	return e != "" && e != "0" && strings.ToLower(e) != "false"
 }

--- a/go/kbfs/libkbfs/node.go
+++ b/go/kbfs/libkbfs/node.go
@@ -29,7 +29,7 @@ type nodeCore struct {
 }
 
 func newNodeCore(
-	ptr data.BlockPointer, name string, parent Node,
+	ptr data.BlockPointer, name data.PathPartString, parent Node,
 	cache *nodeCacheStandard, et data.EntryType) *nodeCore {
 	return &nodeCore{
 		pathNode: &data.PathNode{
@@ -43,7 +43,7 @@ func newNodeCore(
 }
 
 func newNodeCoreForDir(
-	ptr data.BlockPointer, name string, parent Node,
+	ptr data.BlockPointer, name data.PathPartString, parent Node,
 	cache *nodeCacheStandard, obfuscator data.Obfuscator) *nodeCore {
 	nc := newNodeCore(ptr, name, parent, cache, data.Dir)
 	nc.obfuscator = obfuscator
@@ -96,10 +96,10 @@ func (n *nodeStandard) GetFolderBranch() data.FolderBranch {
 	return n.core.cache.folderBranch
 }
 
-func (n *nodeStandard) GetBasename() string {
+func (n *nodeStandard) GetBasename() data.PathPartString {
 	if len(n.core.cachedPath.Path) > 0 {
 		// Must be unlinked.
-		return ""
+		return data.PathPartString{}
 	}
 	return n.core.pathNode.Name
 }
@@ -108,7 +108,8 @@ func (n *nodeStandard) Readonly(_ context.Context) bool {
 	return false
 }
 
-func (n *nodeStandard) ShouldCreateMissedLookup(ctx context.Context, _ string) (
+func (n *nodeStandard) ShouldCreateMissedLookup(
+	ctx context.Context, _ data.PathPartString) (
 	bool, context.Context, data.EntryType, os.FileInfo, string) {
 	return false, ctx, data.File, nil, ""
 }
@@ -117,7 +118,7 @@ func (n *nodeStandard) ShouldRetryOnDirRead(ctx context.Context) bool {
 	return false
 }
 
-func (n *nodeStandard) RemoveDir(_ context.Context, _ string) (
+func (n *nodeStandard) RemoveDir(_ context.Context, _ data.PathPartString) (
 	removeHandled bool, err error) {
 	return false, nil
 }
@@ -146,4 +147,11 @@ func (n *nodeStandard) FillCacheDuration(d *time.Duration) {}
 
 func (n *nodeStandard) Obfuscator() data.Obfuscator {
 	return n.core.obfuscator
+}
+
+func (n *nodeStandard) ChildName(name string) data.PathPartString {
+	if n.core.entryType != data.Dir {
+		panic("Only dirs can have child names")
+	}
+	return data.NewPathPartString(name, n.core.obfuscator)
 }

--- a/go/kbfs/libkbfs/node.go
+++ b/go/kbfs/libkbfs/node.go
@@ -110,8 +110,8 @@ func (n *nodeStandard) Readonly(_ context.Context) bool {
 
 func (n *nodeStandard) ShouldCreateMissedLookup(
 	ctx context.Context, _ data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
-	return false, ctx, data.File, nil, ""
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
+	return false, ctx, data.File, nil, data.PathPartString{}
 }
 
 func (n *nodeStandard) ShouldRetryOnDirRead(ctx context.Context) bool {

--- a/go/kbfs/libkbfs/node_cache.go
+++ b/go/kbfs/libkbfs/node_cache.go
@@ -98,8 +98,8 @@ func (ncs *nodeCacheStandard) makeNodeStandardForEntryLocked(
 
 // GetOrCreate implements the NodeCache interface for nodeCacheStandard.
 func (ncs *nodeCacheStandard) GetOrCreate(
-	ptr data.BlockPointer, name string, parent Node, et data.EntryType) (
-	n Node, err error) {
+	ptr data.BlockPointer, name data.PathPartString, parent Node,
+	et data.EntryType) (n Node, err error) {
 	var rootWrappers []func(Node) Node
 	defer func() {
 		if n != nil {
@@ -113,7 +113,7 @@ func (ncs *nodeCacheStandard) GetOrCreate(
 		panic(InvalidBlockRefError{ptr.Ref()})
 	}
 
-	if name == "" {
+	if name.Plaintext() == "" {
 		return nil, EmptyNameError{ptr.Ref()}
 	}
 
@@ -220,7 +220,8 @@ func (ncs *nodeCacheStandard) UpdatePointer(
 
 // Move implements the NodeCache interface for nodeCacheStandard.
 func (ncs *nodeCacheStandard) Move(
-	ref data.BlockRef, newParent Node, newName string) (undoFn func(), err error) {
+	ref data.BlockRef, newParent Node, newName data.PathPartString) (
+	undoFn func(), err error) {
 	if ref == (data.BlockRef{}) {
 		return nil, nil
 	}
@@ -231,7 +232,7 @@ func (ncs *nodeCacheStandard) Move(
 		panic(InvalidBlockRefError{ref})
 	}
 
-	if newName == "" {
+	if newName.Plaintext() == "" {
 		return nil, EmptyNameError{ref}
 	}
 
@@ -290,7 +291,7 @@ func (ncs *nodeCacheStandard) Unlink(
 	entry.core.cachedPath = oldPath
 	entry.core.cachedDe = oldDe
 	entry.core.parent = nil
-	entry.core.pathNode.Name = ""
+	entry.core.pathNode.Name = data.PathPartString{}
 
 	return func() {
 		entry.core.cachedPath = data.Path{}
@@ -353,6 +354,8 @@ func (ncs *nodeCacheStandard) PathFromNode(node Node) (p data.Path) {
 		p.Path = nil
 		return
 	}
+
+	p.ChildObfuscator = ns.core.obfuscator
 
 	for ns != nil {
 		core := ns.core

--- a/go/kbfs/libkbfs/ops.go
+++ b/go/kbfs/libkbfs/ops.go
@@ -22,7 +22,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-// op represents a single file-system remote-sync operation
+// op represents a single file-system remote-sync operation. Note that
+// ops store and marshal any filenames in plaintext fields, so the
+// accessed fields must be handled carefully.  `String()` prints
+// obfuscated filenames, however.
 type op interface {
 	AddRefBlock(ptr data.BlockPointer)
 	DelRefBlock(ptr data.BlockPointer)
@@ -34,6 +37,7 @@ type op interface {
 	Refs() []data.BlockPointer
 	Unrefs() []data.BlockPointer
 	String() string
+	Plaintext() string
 	StringWithRefs(indent string) string
 	setWriterInfo(writerInfo)
 	getWriterInfo() writerInfo
@@ -267,6 +271,10 @@ func (oc *OpCommon) getFinalPath() data.Path {
 	return oc.finalPath
 }
 
+func (oc *OpCommon) obfuscatedName(name string) data.PathPartString {
+	return data.NewPathPartString(name, oc.finalPath.Obfuscator())
+}
+
 func (oc *OpCommon) setLocalTimestamp(t time.Time) {
 	oc.localTimestamp = t
 }
@@ -399,7 +407,19 @@ func (co *createOp) checkValid() error {
 	return co.checkUpdatesValid()
 }
 
+func (co *createOp) obfuscatedNewName() data.PathPartString {
+	return co.obfuscatedName(co.NewName)
+}
+
 func (co *createOp) String() string {
+	res := fmt.Sprintf("create %s (%s)", co.obfuscatedNewName(), co.Type)
+	if co.renamed {
+		res += " (renamed)"
+	}
+	return res
+}
+
+func (co *createOp) Plaintext() string {
 	res := fmt.Sprintf("create %s (%s)", co.NewName, co.Type)
 	if co.renamed {
 		res += " (renamed)"
@@ -434,8 +454,8 @@ func (co *createOp) checkConflict(
 					return nil, err
 				}
 				return &renameMergedAction{
-					fromName: co.NewName,
-					toName:   toName,
+					fromName: co.obfuscatedNewName(),
+					toName:   co.obfuscatedName(toName),
 					symPath:  co.crSymPath,
 				}, nil
 			}
@@ -446,8 +466,8 @@ func (co *createOp) checkConflict(
 				return nil, err
 			}
 			return &renameUnmergedAction{
-				fromName: co.NewName,
-				toName:   toName,
+				fromName: co.obfuscatedNewName(),
+				toName:   co.obfuscatedName(toName),
 				symPath:  co.crSymPath,
 			}, nil
 		}
@@ -467,8 +487,8 @@ func (co *createOp) checkConflict(
 				return nil, err
 			}
 			return &copyUnmergedEntryAction{
-				fromName: co.NewName,
-				toName:   toName,
+				fromName: co.obfuscatedNewName(),
+				toName:   co.obfuscatedName(toName),
 				symPath:  co.crSymPath,
 				unique:   true,
 			}, nil
@@ -480,16 +500,17 @@ func (co *createOp) checkConflict(
 }
 
 func (co *createOp) getDefaultAction(mergedPath data.Path) crAction {
+	newName := co.obfuscatedNewName()
 	if co.forceCopy {
 		return &renameUnmergedAction{
-			fromName: co.NewName,
-			toName:   co.NewName,
+			fromName: newName,
+			toName:   newName,
 			symPath:  co.crSymPath,
 		}
 	}
 	return &copyUnmergedEntryAction{
-		fromName: co.NewName,
-		toName:   co.NewName,
+		fromName: newName,
+		toName:   newName,
 		symPath:  co.crSymPath,
 	}
 }
@@ -522,8 +543,8 @@ func (co *createOp) ToEditNotification(
 	rev kbfsmd.Revision, revTime time.Time, device kbfscrypto.VerifyingKey,
 	uid keybase1.UID, tlfID tlf.ID) *kbfsedits.NotificationMessage {
 	n := makeBaseEditNotification(rev, revTime, device, uid, tlfID, co.Type)
-	n.Filename = co.getFinalPath().ChildPathNoPtr(co.NewName).
-		CanonicalPathString()
+	n.Filename = co.getFinalPath().ChildPathNoPtr(co.obfuscatedNewName(), nil).
+		CanonicalPathPlaintext()
 	n.Type = kbfsedits.NotificationCreate
 	return &n
 }
@@ -594,7 +615,15 @@ func (ro *rmOp) checkValid() error {
 	return ro.checkUpdatesValid()
 }
 
+func (ro *rmOp) obfuscatedOldName() data.PathPartString {
+	return ro.obfuscatedName(ro.OldName)
+}
+
 func (ro *rmOp) String() string {
+	return fmt.Sprintf("rm %s", ro.obfuscatedOldName())
+}
+
+func (ro *rmOp) Plaintext() string {
 	return fmt.Sprintf("rm %s", ro.OldName)
 }
 
@@ -630,7 +659,7 @@ func (ro *rmOp) getDefaultAction(mergedPath data.Path) crAction {
 	if ro.dropThis {
 		return &dropUnmergedAction{op: ro}
 	}
-	return &rmMergedEntryAction{name: ro.OldName}
+	return &rmMergedEntryAction{name: ro.obfuscatedOldName()}
 }
 
 func (ro *rmOp) ToEditNotification(
@@ -638,8 +667,8 @@ func (ro *rmOp) ToEditNotification(
 	uid keybase1.UID, tlfID tlf.ID) *kbfsedits.NotificationMessage {
 	n := makeBaseEditNotification(
 		rev, revTime, device, uid, tlfID, ro.RemovedType)
-	n.Filename = ro.getFinalPath().ChildPathNoPtr(ro.OldName).
-		CanonicalPathString()
+	n.Filename = ro.getFinalPath().ChildPathNoPtr(ro.obfuscatedOldName(), nil).
+		CanonicalPathPlaintext()
 	n.Type = kbfsedits.NotificationDelete
 	return &n
 }
@@ -747,7 +776,20 @@ func (ro *renameOp) checkValid() error {
 	return ro.checkUpdatesValid()
 }
 
+func (ro *renameOp) obfuscatedOldName() data.PathPartString {
+	return ro.obfuscatedName(ro.OldName)
+}
+
+func (ro *renameOp) obfuscatedNewName() data.PathPartString {
+	return ro.obfuscatedName(ro.NewName)
+}
+
 func (ro *renameOp) String() string {
+	return fmt.Sprintf("rename %s -> %s (%s)",
+		ro.obfuscatedOldName(), ro.obfuscatedNewName(), ro.RenamedType)
+}
+
+func (ro *renameOp) Plaintext() string {
 	return fmt.Sprintf("rename %s -> %s (%s)",
 		ro.OldName, ro.NewName, ro.RenamedType)
 }
@@ -782,12 +824,12 @@ func (ro *renameOp) ToEditNotification(
 	uid keybase1.UID, tlfID tlf.ID) *kbfsedits.NotificationMessage {
 	n := makeBaseEditNotification(
 		rev, revTime, device, uid, tlfID, ro.RenamedType)
-	n.Filename = ro.getFinalPath().ChildPathNoPtr(ro.NewName).
-		CanonicalPathString()
+	n.Filename = ro.getFinalPath().ChildPathNoPtr(ro.obfuscatedNewName(), nil).
+		CanonicalPathPlaintext()
 	n.Type = kbfsedits.NotificationRename
 	n.Params = &kbfsedits.NotificationParams{
-		OldFilename: ro.oldFinalPath.ChildPathNoPtr(ro.OldName).
-			CanonicalPathString(),
+		OldFilename: ro.oldFinalPath.ChildPathNoPtr(
+			ro.obfuscatedOldName(), nil).CanonicalPathPlaintext(),
 	}
 	return &n
 }
@@ -928,6 +970,10 @@ func (so *syncOp) String() string {
 	return fmt.Sprintf("sync [%s]", strings.Join(writes, ", "))
 }
 
+func (so *syncOp) Plaintext() string {
+	return so.String()
+}
+
 func (so *syncOp) StringWithRefs(indent string) string {
 	res := so.String() + "\n"
 	res += indent + fmt.Sprintf("File: %v -> %v\n", so.File.Unref, so.File.Ref)
@@ -944,18 +990,18 @@ func (so *syncOp) checkConflict(
 		// type-specific intelligent conflict resolvers for file
 		// contents?)
 		toName, err := renamer.ConflictRename(
-			ctx, so, mergedOp.getFinalPath().TailName())
+			ctx, so, mergedOp.getFinalPath().TailName().Plaintext())
 		if err != nil {
 			return nil, err
 		}
 
 		if so.keepUnmergedTailName {
-			toName = so.getFinalPath().TailName()
+			toName = so.getFinalPath().TailName().Plaintext()
 		}
 
 		return &renameUnmergedAction{
 			fromName:                 so.getFinalPath().TailName(),
-			toName:                   toName,
+			toName:                   so.obfuscatedName(toName),
 			unmergedParentMostRecent: so.getFinalPath().ParentPath().TailPointer(),
 			mergedParentMostRecent: mergedOp.getFinalPath().ParentPath().
 				TailPointer(),
@@ -984,7 +1030,7 @@ func (so *syncOp) ToEditNotification(
 	rev kbfsmd.Revision, revTime time.Time, device kbfscrypto.VerifyingKey,
 	uid keybase1.UID, tlfID tlf.ID) *kbfsedits.NotificationMessage {
 	n := makeBaseEditNotification(rev, revTime, device, uid, tlfID, data.File)
-	n.Filename = so.getFinalPath().CanonicalPathString()
+	n.Filename = so.getFinalPath().CanonicalPathPlaintext()
 	n.Type = kbfsedits.NotificationModify
 	var mods []kbfsedits.ModifyRange
 	for _, w := range so.Writes {
@@ -1211,7 +1257,16 @@ func (sao *setAttrOp) checkValid() error {
 	return sao.checkUpdatesValid()
 }
 
+func (sao *setAttrOp) obfuscatedEntryName() data.PathPartString {
+	return data.NewPathPartString(
+		sao.Name, sao.finalPath.ParentPath().Obfuscator())
+}
+
 func (sao *setAttrOp) String() string {
+	return fmt.Sprintf("setAttr %s (%s)", sao.obfuscatedEntryName(), sao.Attr)
+}
+
+func (sao *setAttrOp) Plaintext() string {
 	return fmt.Sprintf("setAttr %s (%s)", sao.Name, sao.Attr)
 }
 
@@ -1235,25 +1290,28 @@ func (sao *setAttrOp) checkConflict(
 				// A directory has a conflict on an mtime attribute.
 				// Create a symlink entry with the unmerged mtime
 				// pointing to the merged entry.
-				symPath = mergedOp.getFinalPath().TailName()
+				symPath = mergedOp.getFinalPath().TailName().Plaintext()
 				causedByAttr = sao.Attr
 			}
 
 			// A set attr for the same attribute on the same file is a
 			// conflict.
 			fromName := sao.getFinalPath().TailName()
-			toName, err := renamer.ConflictRename(ctx, sao, fromName)
+			toName, err := renamer.ConflictRename(
+				ctx, sao, fromName.Plaintext())
 			if err != nil {
 				return nil, err
 			}
 
 			if sao.keepUnmergedTailName {
-				toName = sao.getFinalPath().TailName()
+				toName = sao.getFinalPath().TailName().Plaintext()
 			}
 
+			toNamePPS := data.NewPathPartString(
+				toName, sao.finalPath.ParentPath().Obfuscator())
 			return &renameUnmergedAction{
 				fromName:                 fromName,
-				toName:                   toName,
+				toName:                   toNamePPS,
 				symPath:                  symPath,
 				causedByAttr:             causedByAttr,
 				unmergedParentMostRecent: sao.getFinalPath().ParentPath().TailPointer(),
@@ -1324,6 +1382,10 @@ func (ro *resolutionOp) String() string {
 	return "resolution"
 }
 
+func (ro *resolutionOp) Plaintext() string {
+	return ro.String()
+}
+
 func (ro *resolutionOp) StringWithRefs(indent string) string {
 	res := ro.String() + "\n"
 	res += ro.stringWithRefs(indent)
@@ -1382,6 +1444,10 @@ func (ro *rekeyOp) checkValid() error {
 
 func (ro *rekeyOp) String() string {
 	return "rekey"
+}
+
+func (ro *rekeyOp) Plaintext() string {
+	return ro.String()
 }
 
 func (ro *rekeyOp) StringWithRefs(indent string) string {
@@ -1443,6 +1509,11 @@ func (gco *GCOp) checkValid() error {
 
 func (gco *GCOp) String() string {
 	return fmt.Sprintf("gc %d", gco.LatestRev)
+}
+
+// Plaintext implements op.
+func (gco *GCOp) Plaintext() string {
+	return gco.String()
 }
 
 // StringWithRefs implements the op interface for GCOp.
@@ -1518,7 +1589,7 @@ func invertOpForLocalNotifications(oldOp op) (newOp op, err error) {
 	case *rekeyOp:
 		newOp = newRekeyOp()
 	}
-
+	newOp.setFinalPath(oldOp.getFinalPath())
 	// Now reverse all the block updates.  Don't bother with bare Refs
 	// and Unrefs since they don't matter for local notification
 	// purposes.

--- a/go/kbfs/libkbfs/ops.go
+++ b/go/kbfs/libkbfs/ops.go
@@ -456,7 +456,7 @@ func (co *createOp) checkConflict(
 				return &renameMergedAction{
 					fromName: co.obfuscatedNewName(),
 					toName:   co.obfuscatedName(toName),
-					symPath:  co.crSymPath,
+					symPath:  co.obfuscatedName(co.crSymPath),
 				}, nil
 			}
 			// Otherwise rename the unmerged entry (guaranteed to be a file).
@@ -468,7 +468,7 @@ func (co *createOp) checkConflict(
 			return &renameUnmergedAction{
 				fromName: co.obfuscatedNewName(),
 				toName:   co.obfuscatedName(toName),
-				symPath:  co.crSymPath,
+				symPath:  co.obfuscatedName(co.crSymPath),
 			}, nil
 		}
 
@@ -489,7 +489,7 @@ func (co *createOp) checkConflict(
 			return &copyUnmergedEntryAction{
 				fromName: co.obfuscatedNewName(),
 				toName:   co.obfuscatedName(toName),
-				symPath:  co.crSymPath,
+				symPath:  co.obfuscatedName(co.crSymPath),
 				unique:   true,
 			}, nil
 		}
@@ -505,13 +505,13 @@ func (co *createOp) getDefaultAction(mergedPath data.Path) crAction {
 		return &renameUnmergedAction{
 			fromName: newName,
 			toName:   newName,
-			symPath:  co.crSymPath,
+			symPath:  co.obfuscatedName(co.crSymPath),
 		}
 	}
 	return &copyUnmergedEntryAction{
 		fromName: newName,
 		toName:   newName,
-		symPath:  co.crSymPath,
+		symPath:  co.obfuscatedName(co.crSymPath),
 	}
 }
 
@@ -1000,8 +1000,8 @@ func (so *syncOp) checkConflict(
 		}
 
 		return &renameUnmergedAction{
-			fromName:                 so.getFinalPath().TailName(),
-			toName:                   so.obfuscatedName(toName),
+			fromName: so.getFinalPath().TailName(),
+			toName:   so.obfuscatedName(toName),
 			unmergedParentMostRecent: so.getFinalPath().ParentPath().TailPointer(),
 			mergedParentMostRecent: mergedOp.getFinalPath().ParentPath().
 				TailPointer(),
@@ -1022,7 +1022,7 @@ func (so *syncOp) getDefaultAction(mergedPath data.Path) crAction {
 	return &copyUnmergedEntryAction{
 		fromName: so.getFinalPath().TailName(),
 		toName:   mergedPath.TailName(),
-		symPath:  "",
+		symPath:  so.obfuscatedName(""),
 	}
 }
 
@@ -1312,7 +1312,7 @@ func (sao *setAttrOp) checkConflict(
 			return &renameUnmergedAction{
 				fromName:                 fromName,
 				toName:                   toNamePPS,
-				symPath:                  symPath,
+				symPath:                  sao.obfuscatedName(symPath),
 				causedByAttr:             causedByAttr,
 				unmergedParentMostRecent: sao.getFinalPath().ParentPath().TailPointer(),
 				mergedParentMostRecent: mergedOp.getFinalPath().ParentPath().

--- a/go/kbfs/libkbfs/rekey_queue_test.go
+++ b/go/kbfs/libkbfs/rekey_queue_test.go
@@ -57,7 +57,8 @@ func TestRekeyQueueBasic(t *testing.T) {
 		// user 1 creates the directory
 		rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 		// user 1 creates a file
-		_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+		_, _, err = kbfsOps1.CreateFile(
+			ctx, rootNode1, testPPS("a"), false, NoExcl)
 		if err != nil {
 			t.Fatalf("Couldn't create file: %v", err)
 		}

--- a/go/kbfs/libkbfs/reporter_kbpki.go
+++ b/go/kbfs/libkbfs/reporter_kbpki.go
@@ -514,7 +514,9 @@ func fileRenameNotification(oldFile data.Path, newFile data.Path, writer keybase
 	localTime time.Time) *keybase1.FSNotification {
 	n := baseFileEditNotification(newFile, writer, localTime)
 	n.NotificationType = keybase1.FSNotificationType_FILE_RENAMED
-	n.Params = map[string]string{errorParamRenameOldFilename: oldFile.CanonicalPathString()}
+	n.Params = map[string]string{
+		errorParamRenameOldFilename: oldFile.CanonicalPathPlaintext(),
+	}
 	return n
 }
 
@@ -537,7 +539,7 @@ func baseNotification(file data.Path, finish bool) *keybase1.FSNotification {
 	}
 
 	return &keybase1.FSNotification{
-		Filename:   file.CanonicalPathString(),
+		Filename:   file.CanonicalPathPlaintext(),
 		StatusCode: code,
 	}
 }

--- a/go/kbfs/libkbfs/root_metadata.go
+++ b/go/kbfs/libkbfs/root_metadata.go
@@ -226,6 +226,11 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 		return nil, err
 	}
 
+	// Preserve all the final op paths in the copy.
+	for i, op := range md.data.Changes.Ops {
+		rmd.data.Changes.Ops[i].setFinalPath(op.getFinalPath())
+	}
+
 	return rmd, nil
 }
 
@@ -525,7 +530,8 @@ func (md *RootMetadata) loadCachedBlockChanges(
 			Tlf: md.TlfID(), Branch: data.MasterBranch},
 		Path: []data.PathNode{{
 			BlockPointer: md.data.cachedChanges.Info.BlockPointer,
-			Name:         fmt.Sprintf("<MD with revision %d>", md.Revision()),
+			Name: data.NewPathPartString(
+				fmt.Sprintf("<MD with revision %d>", md.Revision()), nil),
 		}},
 	}
 	fd := data.NewFileData(file, id, nil, md.ReadOnly(),

--- a/go/kbfs/libkbfs/state_checker.go
+++ b/go/kbfs/libkbfs/state_checker.go
@@ -88,7 +88,7 @@ func (sc *StateChecker) findAllBlocksInPath(ctx context.Context,
 		}
 
 		blockSizes[de.BlockPointer] = de.EncodedSize
-		p := dir.ChildPath(name, de.BlockPointer)
+		p := dir.ChildPath(name, de.BlockPointer, ops.makeObfuscator())
 
 		if de.Type == data.Dir {
 			err := sc.findAllBlocksInPath(ctx, lState, ops, kmd, p, blockSizes)
@@ -212,8 +212,8 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlfID tlf.ID) erro
 					Tlf: tlfID, Branch: data.MasterBranch},
 				Path: []data.PathNode{{
 					BlockPointer: info.BlockPointer,
-					Name: fmt.Sprintf(
-						"<MD with revision %d>", rmd.Revision()),
+					Name: data.NewPathPartString(fmt.Sprintf(
+						"<MD with revision %d>", rmd.Revision()), nil),
 				}}}
 			err := sc.findAllFileBlocks(ctx, lState, ops, rmd.ReadOnly(),
 				file, actualLiveBlocks)

--- a/go/kbfs/libkbfs/unflushed_path_cache.go
+++ b/go/kbfs/libkbfs/unflushed_path_cache.go
@@ -157,10 +157,15 @@ type unflushedPathMDInfo struct {
 // blocks will need to be fetched.
 func addUnflushedPaths(ctx context.Context,
 	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
-	log logger.Logger, osg idutil.OfflineStatusGetter, mdInfos []unflushedPathMDInfo,
-	cpp chainsPathPopulator, unflushedPaths unflushedPathsMap) error {
+	log logger.Logger, osg idutil.OfflineStatusGetter,
+	mdInfos []unflushedPathMDInfo, cpp chainsPathPopulator,
+	unflushedPaths unflushedPathsMap) error {
 	// Make chains over the entire range to get the unflushed files.
-	chains := newCRChainsEmpty()
+	chains := newCRChainsEmpty(cpp.obfuscatorMaker())
+	if len(mdInfos) > 0 {
+		mostRecentMDInfo := mdInfos[len(mdInfos)-1]
+		chains.mostRecentChainMDInfo = mostRecentMDInfo.kmd
+	}
 	processedOne := false
 	for _, mdInfo := range mdInfos {
 		offline := keybase1.OfflineAvailability_NONE
@@ -190,9 +195,6 @@ func addUnflushedPaths(ctx context.Context,
 		return nil
 	}
 
-	mostRecentMDInfo := mdInfos[len(mdInfos)-1]
-	chains.mostRecentChainMDInfo = mostRecentMDInfo.kmd
-
 	// Does the last op already have a valid path in each chain?  If
 	// so, we don't need to bother populating the paths, which can
 	// take a fair amount of CPU since the node cache isn't already
@@ -201,7 +203,8 @@ func addUnflushedPaths(ctx context.Context,
 	populatePaths := false
 	for _, chain := range chains.byOriginal {
 		if len(chain.ops) > 0 &&
-			!chain.ops[len(chain.ops)-1].getFinalPath().IsValid() {
+			!chain.ops[len(chain.ops)-1].getFinalPath().
+				IsValidForNotification() {
 			populatePaths = true
 			break
 		}
@@ -217,8 +220,11 @@ func addUnflushedPaths(ctx context.Context,
 	for _, chain := range chains.byOriginal {
 		if len(chain.ops) > 0 {
 			// Use the same final path from the chain for all ops.
+			// Use the plaintext here, since this will be included
+			// directly in the `.kbfs_status` output for unflushed
+			// paths.
 			finalPath := chain.ops[len(chain.ops)-1].getFinalPath().
-				CanonicalPathString()
+				CanonicalPathPlaintext()
 			for _, op := range chain.ops {
 				revPaths, ok := unflushedPaths[op.getWriterInfo().revision]
 				if !ok {

--- a/go/kbfs/test/engine_libkbfs.go
+++ b/go/kbfs/test/engine_libkbfs.go
@@ -392,13 +392,15 @@ func (k *LibKBFS) CreateFileExcl(u User, parentDir Node, name string) (file Node
 }
 
 // CreateLink implements the Engine interface.
-func (k *LibKBFS) CreateLink(u User, parentDir Node, fromName, toPath string) (err error) {
+func (k *LibKBFS) CreateLink(
+	u User, parentDir Node, fromName, toPath string) (err error) {
 	config := u.(*libkbfs.ConfigLocal)
 	kbfsOps := config.KBFSOps()
 	ctx, cancel := k.newContext(u)
 	defer cancel()
 	n := parentDir.(libkbfs.Node)
-	_, err = kbfsOps.CreateLink(ctx, n, n.ChildName(fromName), toPath)
+	_, err = kbfsOps.CreateLink(
+		ctx, n, n.ChildName(fromName), n.ChildName(toPath))
 	return err
 }
 


### PR DESCRIPTION
This commit changes the interface for `dirData` and `KBFSOps` to only allow for `data.PathPartString` instances instead of raw strings for file and directory names.  Doing so ensures, at a compiler level, that if log obfuscation is turned on, then those names will be logged as obfuscated instead of in plaintext.

This requires a lot of changes:
* The `NodeCache` creates a new obfuscator for every new `Node`.
* Each `data.Path` needs to have a `ChildObfuscator`, so that `dirData` can use it to obfuscate all the child names of the directory.
* Every `op` needs to have a final path set, so the path's obfuscator can be used on the plaintext filenames stored in the op.  Note that we can't just use `data.PathPartString`s in the op's fields directly, because `op` is a data structure that is marshaled directly into bytes that are stored on the server.
* We no longer log file paths when sending notifications up to the service; these are just plaintext strings so they'd be hard to obfuscate, and it doesn't seem worthwhile.

This commit also obfuscates filenames in `libfs.FS`.

Note that in some places, especially during conflict resolution, it is very hard making sure that a consistent obfuscator is used for each directory, and sometimes it just wasn't possible and we make a new obfuscator for a directory that might have another obfuscator floating around somewhere.  In practice this means that obfuscation collisions in the directory could use different suffixes ("-2") for different files.  This seems like it should be so rare that it won't matter, but it's something to be aware of.

This commit does NOT do the following things, which will be handled in subsequent work:

* Obfuscate filenames logged directly by libfuse/libdokan/simplefs.
* Obfuscate symlink targets.
* Obfuscating any filenames logged by the service or GUI.

Issue: HOTPOT-60