### PR TITLE
Wallet compose offline experience

### DIFF
--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -432,7 +432,6 @@ func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (res *ht
 	}
 
 	return nil, nil, fmt.Errorf("doRetry failed, attempts: %d, timeout %s, last err: %s", retries, timeout, lastErr)
-
 }
 
 // doTimeout does the http request with a timeout. It returns the response from making the HTTP request,

--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -136,7 +136,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 				bannerTheir = fmt.Sprintf("%s's", recipient.User.Username)
 				recipientUV = recipient.User.UV
 			}
-			if recipient.AccountID == nil && !fromPrimaryAccount {
+			if recipient.AccountID == nil && fromInfo.available && !fromPrimaryAccount {
 				// This would have been a relay from a non-primary account.
 				// We cannot allow that.
 				res.Banners = append(res.Banners, stellar1.SendBannerLocal{
@@ -178,7 +178,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 						}
 					}
 				}
-				if selfSendErr == nil && !sendingToSelf && !fromPrimaryAccount {
+				if fromInfo.available && !sendingToSelf && !fromPrimaryAccount {
 					res.Banners = append(res.Banners, stellar1.SendBannerLocal{
 						Level:   "info",
 						Message: "Your Keybase username will not be linked to this transaction.",

--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -866,12 +866,12 @@ func buildPaymentAmountHelper(mctx libkb.MetaContext, bpc BuildPaymentCache, arg
 			res.worthInfo = ""
 		}
 
-		res.displayAmountXLM, err = FormatAmountDescriptionXLM(mctx, arg.Amount)
-		if err != nil {
-			log("error formatting xlm %q: %s", arg.Amount, err)
-			res.displayAmountXLM = ""
-		}
 		if arg.Amount != "" {
+			res.displayAmountXLM, err = FormatAmountDescriptionXLM(mctx, arg.Amount)
+			if err != nil {
+				log("error formatting xlm %q: %s", arg.Amount, err)
+				res.displayAmountXLM = ""
+			}
 			res.displayAmountFiat, err = FormatCurrencyWithCodeSuffix(mctx, outsideAmount, xrate.Currency, stellarnet.Round)
 			if err != nil {
 				log("error formatting fiat %q / %v: %s", outsideAmount, xrate.Currency, err)

--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -80,10 +80,10 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 	if arg.FromPrimaryAccount {
 		primaryAccountID, err := bpc.PrimaryAccount(mctx)
 		if err != nil {
-			log("PrimaryAccount -> err:%v", err)
+			log("PrimaryAccount -> err:[%T] %v", err, err)
 			res.Banners = append(res.Banners, stellar1.SendBannerLocal{
 				Level:   "error",
-				Message: "Could not find primary account.",
+				Message: fmt.Sprintf("Could not find primary account.%v", msgMore(err)),
 			})
 		} else {
 			fromInfo.from = primaryAccountID
@@ -92,10 +92,10 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 	} else {
 		owns, fromPrimary, err := bpc.OwnsAccount(mctx, arg.From)
 		if err != nil || !owns {
-			log("OwnsAccount (from) -> owns:%v err:%v", owns, err)
+			log("OwnsAccount (from) -> owns:%v err:[%T] %v", owns, err, err)
 			res.Banners = append(res.Banners, stellar1.SendBannerLocal{
 				Level:   "error",
-				Message: "Could not find source account.",
+				Message: fmt.Sprintf("Could not find source account.%v", msgMore(err)),
 			})
 		} else {
 			fromInfo.from = arg.From
@@ -178,7 +178,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 						}
 					}
 				}
-				if !sendingToSelf && !fromPrimaryAccount {
+				if selfSendErr == nil && !sendingToSelf && !fromPrimaryAccount {
 					res.Banners = append(res.Banners, stellar1.SendBannerLocal{
 						Level:   "info",
 						Message: "Your Keybase username will not be linked to this transaction.",
@@ -678,7 +678,7 @@ func BuildRequestLocal(mctx libkb.MetaContext, arg stellar1.BuildRequestLocalArg
 		log("PrimaryAccount -> err:%v", err)
 		res.Banners = append(res.Banners, stellar1.SendBannerLocal{
 			Level:   "error",
-			Message: "Could not find primary account.",
+			Message: fmt.Sprintf("Could not find primary account.%v", msgMore(err)),
 		})
 	} else {
 		bpaArg.From = &primaryAccountID
@@ -991,4 +991,13 @@ func (b *buildPaymentData) CheckReadyToSend(arg stellar1.SendPaymentLocalArg) er
 		return fmt.Errorf("mismatched asset: %v != %v", arg.Asset, b.Frozen.Asset)
 	}
 	return nil
+}
+
+func msgMore(err error) string {
+	switch err.(type) {
+	case libkb.APINetError, *libkb.APINetError:
+		return " Please check your network and try again."
+	default:
+		return ""
+	}
 }

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -253,7 +253,6 @@ protocol local {
   string getWalletAccountPublicKeyLocal(int sessionID, AccountID accountID);
   SecretKey getWalletAccountSecretKeyLocal(int sessionID, AccountID accountID);
 
-  // Not implemented. CORE-8087
   // Get the non-XLM assets for sending.
   array<SendAssetChoiceLocal> getSendAssetChoicesLocal(
     int sessionID,

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -461,9 +461,13 @@ const loadSendAssetChoices = (state, action: WalletsGen.LoadSendAssetChoicesPayl
   RPCStellarTypes.localGetSendAssetChoicesLocalRpcPromise({
     from: action.payload.from,
     to: action.payload.to,
-  }).then(res => {
-    res && WalletsGen.createSendAssetChoicesReceived({sendAssetChoices: res})
   })
+    .then(res => {
+      res && WalletsGen.createSendAssetChoicesReceived({sendAssetChoices: res})
+    })
+    .catch(err => {
+      logger.warn(`Error: ${err.desc}`)
+    })
 
 const loadDisplayCurrency = (state, action: WalletsGen.LoadDisplayCurrencyPayload) => {
   let accountID = action.payload.accountID

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -463,6 +463,7 @@ const loadSendAssetChoices = (state, action: WalletsGen.LoadSendAssetChoicesPayl
     to: action.payload.to,
   })
     .then(res => {
+      // The result is dropped here. See PICNIC-84 for fixing it.
       res && WalletsGen.createSendAssetChoicesReceived({sendAssetChoices: res})
     })
     .catch(err => {

--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -166,7 +166,7 @@ export const buildPaymentResultToBuiltPayment = (b: RPCTypes.BuildPaymentResLoca
     builtBanners: b.banners,
     displayAmountFiat: b.displayAmountFiat,
     displayAmountXLM: b.displayAmountXLM,
-    from: Types.stringToAccountID(b.from),
+    from: b.from ? Types.stringToAccountID(b.from) : Types.noAccountID,
     publicMemoErrMsg: new HiddenString(b.publicMemoErrMsg),
     readyToReview: b.readyToReview,
     secretNoteErrMsg: new HiddenString(b.secretNoteErrMsg),

--- a/shared/wallets/send-form/footer/container.tsx
+++ b/shared/wallets/send-form/footer/container.tsx
@@ -18,7 +18,10 @@ const mapStateToProps = state => {
   const currencyWaiting = anyWaiting(state, Constants.getDisplayCurrencyWaitingKey(accountID))
   const thisDeviceIsLockedOut = Constants.getAccount(state, accountID).deviceReadOnly
   return {
-    calculating: !!state.wallets.building.amount,
+    calculating:
+      !!state.wallets.building.amount &&
+      (anyWaiting(state, Constants.buildPaymentWaitingKey) ||
+        anyWaiting(state, Constants.requestPaymentWaitingKey)),
     disabled: !isReady || currencyWaiting || thisDeviceIsLockedOut,
     isRequest,
     thisDeviceIsLockedOut,


### PR DESCRIPTION
Improve the experience of fiddling with the wallet send/request form while offline. There should be fewer nonsense banners and no global errors. Does not extend through hitting the final Send or Request button.