### PR TITLE
init: enable the disk limiter before the disk block cache

### DIFF
--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -228,7 +228,7 @@ func DefaultInitParams(ctx Context) InitParams {
 		DiskCacheMode:                  DiskCacheModeLocal,
 		DiskBlockCacheFraction:         0.10,
 		SyncBlockCacheFraction:         1.00,
-		Mode: InitDefaultString,
+		Mode:                           InitDefaultString,
 	}
 }
 
@@ -791,6 +791,12 @@ func doInit(
 	config.SetDiskBlockCacheFraction(params.DiskBlockCacheFraction)
 	config.SetSyncBlockCacheFraction(params.SyncBlockCacheFraction)
 
+	err = config.EnableDiskLimiter(params.StorageRoot)
+	if err != nil {
+		log.CWarningf(ctx, "Could not enable disk limiter: %+v", err)
+		return nil, err
+	}
+
 	err = config.MakeDiskBlockCacheIfNotExists()
 	if err != nil {
 		log.CWarningf(ctx, "Could not initialize disk cache: %+v", err)
@@ -860,11 +866,6 @@ func doInit(
 		}
 	}
 
-	err = config.EnableDiskLimiter(params.StorageRoot)
-	if err != nil {
-		log.CWarningf(ctx, "Could not enable disk limiter: %+v", err)
-		return nil, err
-	}
 	ctx10s, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	// TODO: Don't turn on journaling if either -bserver or


### PR DESCRIPTION
Since `DiskBlockCache.Status()` depends on the disk limiter existing.