### PR TITLE
dont make bootstrap calls when unreachable goes from unknown -> yes

### DIFF
--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -51,6 +51,8 @@ const onDisconnected = () => {
   return ConfigGen.createDaemonError({daemonError: new Error('Disconnected')})
 }
 
+// set to true so we reget status when we're reachable again
+let wasUnreachable = false
 function* loadDaemonBootstrapStatus(
   state,
   action:
@@ -62,6 +64,10 @@ function* loadDaemonBootstrapStatus(
   // Ignore the 'fake' loggedIn cause we'll get the daemonHandshake and we don't want to do this twice
   if (action.type === ConfigGen.loggedIn && action.payload.causedByStartup) {
     return
+  }
+
+  if (action.type === GregorGen.updateReachable && action.payload.reachable === RPCTypes.Reachable.no) {
+    wasUnreachable = true
   }
 
   function* makeCall() {
@@ -114,7 +120,8 @@ function* loadDaemonBootstrapStatus(
       )
       break
     case GregorGen.updateReachable:
-      if (action.payload.reachable) {
+      if (action.payload.reachable === RPCTypes.Reachable.yes && wasUnreachable) {
+        wasUnreachable = false // reset it
         yield* makeCall()
       }
       break


### PR DESCRIPTION
@keybase/react-hackers this fixes an extra set of calls on startup. This has actually always been wrong. the enum shouldn't be treated as a bool

cc: @mmaxim 