### PR TITLE
libfuse/libdokan/simplefs: don't log filenames in normal debugging

### DIFF
--- a/go/kbfs/idutil/errors.go
+++ b/go/kbfs/idutil/errors.go
@@ -78,21 +78,31 @@ func (e TlfNameNotCanonical) Error() string {
 // NoSuchNameError indicates that the user tried to access a
 // subdirectory entry that doesn't exist.
 type NoSuchNameError struct {
-	Name string
+	Name      string
+	NameToLog string
 }
 
 // Error implements the error interface for NoSuchNameError
 func (e NoSuchNameError) Error() string {
-	return fmt.Sprintf("%s doesn't exist", e.Name)
+	n := e.Name
+	if len(e.NameToLog) > 0 {
+		n = e.NameToLog
+	}
+	return fmt.Sprintf("%s doesn't exist", n)
 }
 
 // BadTLFNameError indicates a top-level folder name that has an
 // incorrect format.
 type BadTLFNameError struct {
-	Name string
+	Name      string
+	NameToLog string
 }
 
 // Error implements the error interface for BadTLFNameError.
 func (e BadTLFNameError) Error() string {
-	return fmt.Sprintf("TLF name %s is in an incorrect format", e.Name)
+	n := e.Name
+	if len(e.NameToLog) > 0 {
+		n = e.NameToLog
+	}
+	return fmt.Sprintf("TLF name %s is in an incorrect format", n)
 }

--- a/go/kbfs/idutil/tlf_names.go
+++ b/go/kbfs/idutil/tlf_names.go
@@ -55,7 +55,7 @@ func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
 		return strings.ToLower(s), nil
 	}
 
-	return "", BadTLFNameError{s}
+	return "", BadTLFNameError{Name: s}
 }
 
 // normalizeNames normalizes a slice of names and returns

--- a/go/kbfs/libdokan/dir.go
+++ b/go/kbfs/libdokan/dir.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/libkb"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -209,12 +210,16 @@ func (f *Folder) resolve(ctx context.Context) (*tlfhandle.Handle, error) {
 		handle, err := tlfhandle.ParseHandlePreferred(
 			ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(), f.fs.config,
 			string(f.hPreferredName), f.h.Type())
-		if err != nil {
+		switch errors.Cause(err).(type) {
+		case nil:
+			f.TlfHandleChange(ctx, handle)
+			return handle, nil
+		case idutil.NoSuchNameError, idutil.BadTLFNameError,
+			tlf.NoSuchUserError, idutil.NoSuchUserError:
+			return nil, dokan.ErrObjectNameNotFound
+		default:
 			return nil, err
 		}
-		// Update the handle.
-		f.TlfHandleChange(ctx, handle)
-		return handle, nil
 	}
 
 	// In case there were any unresolved assertions, try them again on
@@ -289,7 +294,7 @@ func isSafeFolder(ctx context.Context, f *Folder) bool {
 
 // open tries to open a file.
 func (d *Dir) open(ctx context.Context, oc *openContext, path []string) (dokan.File, dokan.CreateStatus, error) {
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir openDir %v", path)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir openDir %s", path)
 
 	specialNode := handleTLFSpecialFile(lastStr(path), d.folder)
 	if specialNode != nil {
@@ -461,13 +466,14 @@ func getExclFromOpenContext(oc *openContext) libkbfs.Excl {
 }
 
 func (d *Dir) create(ctx context.Context, oc *openContext, name string) (f dokan.File, cst dokan.CreateStatus, err error) {
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", name)
+	namePPS := d.node.ChildName(name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", namePPS)
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
 	isExec := false // Windows lacks executable modes.
 	excl := getExclFromOpenContext(oc)
 	newNode, _, err := d.folder.fs.config.KBFSOps().CreateFile(
-		ctx, d.node, d.node.ChildName(name), isExec, excl)
+		ctx, d.node, namePPS, isExec, excl)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -479,11 +485,12 @@ func (d *Dir) create(ctx context.Context, oc *openContext, name string) (f dokan
 
 func (d *Dir) mkdir(ctx context.Context, oc *openContext, name string) (
 	f *Dir, cst dokan.CreateStatus, err error) {
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", name)
+	namePPS := d.node.ChildName(name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", namePPS)
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
 	newNode, _, err := d.folder.fs.config.KBFSOps().CreateDir(
-		ctx, d.node, d.node.ChildName(name))
+		ctx, d.node, namePPS)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -545,12 +552,13 @@ func (d *Dir) CanDeleteDirectory(ctx context.Context, fi *dokan.FileInfo) (err e
 // If Cleanup is called with non-nil FileInfo that has IsDeleteOnClose()
 // no libdokan locks should be held prior to the call.
 func (d *Dir) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
+	namePPS := d.node.ChildName(d.name)
 	var err error
 	if fi != nil {
-		d.folder.fs.logEnterf(ctx, "Dir Cleanup %q delete=%v", d.name,
+		d.folder.fs.logEnterf(ctx, "Dir Cleanup %s delete=%v", namePPS,
 			fi.IsDeleteOnClose())
 	} else {
-		d.folder.fs.logEnterf(ctx, "Dir Cleanup %q", d.name)
+		d.folder.fs.logEnterf(ctx, "Dir Cleanup %s", namePPS)
 	}
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
@@ -559,10 +567,9 @@ func (d *Dir) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 		d.folder.fs.renameAndDeletionLock.Lock()
 		defer d.folder.fs.renameAndDeletionLock.Unlock()
 		d.folder.fs.vlog.CLogf(
-			ctx, libkb.VLog1, "Removing (Delete) dir in cleanup %s", d.name)
+			ctx, libkb.VLog1, "Removing (Delete) dir in cleanup %s", namePPS)
 
-		err = d.folder.fs.config.KBFSOps().RemoveDir(
-			ctx, d.parent, d.parent.ChildName(d.name))
+		err = d.folder.fs.config.KBFSOps().RemoveDir(ctx, d.parent, namePPS)
 	}
 
 	if d.refcount.Decrease() {

--- a/go/kbfs/libdokan/file.go
+++ b/go/kbfs/libdokan/file.go
@@ -44,7 +44,8 @@ func (f *File) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (a *d
 // CanDeleteFile - return just nil
 // TODO check for permissions here.
 func (f *File) CanDeleteFile(ctx context.Context, fi *dokan.FileInfo) error {
-	f.folder.fs.logEnterf(ctx, "File CanDeleteFile for %q", f.name)
+	namePPS := f.parent.ChildName(f.name)
+	f.folder.fs.logEnterf(ctx, "File CanDeleteFile for %s", namePPS)
 	return nil
 }
 
@@ -61,11 +62,12 @@ func (f *File) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 		// renameAndDeletionLock should be the first lock to be grabbed in libdokan.
 		f.folder.fs.renameAndDeletionLock.Lock()
 		defer f.folder.fs.renameAndDeletionLock.Unlock()
+		namePPS := f.parent.ChildName(f.name)
 		f.folder.fs.vlog.CLogf(
-			ctx, libkb.VLog1, "Removing (Delete) file in cleanup %s", f.name)
+			ctx, libkb.VLog1, "Removing (Delete) file in cleanup %s", namePPS)
 
 		err = f.folder.fs.config.KBFSOps().RemoveEntry(
-			ctx, f.parent, f.parent.ChildName(f.name))
+			ctx, f.parent, namePPS)
 	}
 
 	if f.refcount.Decrease() {

--- a/go/kbfs/libdokan/file.go
+++ b/go/kbfs/libdokan/file.go
@@ -5,6 +5,7 @@
 package libdokan
 
 import (
+	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/dokan"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/libkb"
@@ -41,11 +42,14 @@ func (f *File) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (a *d
 	return a, err
 }
 
+func (f *File) namePPS() data.PathPartString {
+	return f.parent.ChildName(f.name)
+}
+
 // CanDeleteFile - return just nil
 // TODO check for permissions here.
 func (f *File) CanDeleteFile(ctx context.Context, fi *dokan.FileInfo) error {
-	namePPS := f.parent.ChildName(f.name)
-	f.folder.fs.logEnterf(ctx, "File CanDeleteFile for %s", namePPS)
+	f.folder.fs.logEnterf(ctx, "File CanDeleteFile for %s", f.namePPS())
 	return nil
 }
 
@@ -62,7 +66,7 @@ func (f *File) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 		// renameAndDeletionLock should be the first lock to be grabbed in libdokan.
 		f.folder.fs.renameAndDeletionLock.Lock()
 		defer f.folder.fs.renameAndDeletionLock.Unlock()
-		namePPS := f.parent.ChildName(f.name)
+		namePPS := f.namePPS()
 		f.folder.fs.vlog.CLogf(
 			ctx, libkb.VLog1, "Removing (Delete) file in cleanup %s", namePPS)
 

--- a/go/kbfs/libdokan/folderlist.go
+++ b/go/kbfs/libdokan/folderlist.go
@@ -151,7 +151,9 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 				ctx, libkb.VLog1, "FL Lookup set alias: %q -> %q",
 				name, aliasTarget)
 			if !fl.isValidAliasTarget(ctx, aliasTarget) {
-				fl.fs.log.CDebugf(ctx, "FL Refusing alias to non-valid target %q", aliasTarget)
+				fl.fs.vlog.CLogf(
+					ctx, libkb.VLog1,
+					"FL Refusing alias to non-valid target %q", aliasTarget)
 				return nil, 0, dokan.ErrObjectNameNotFound
 			}
 			fl.mu.Lock()
@@ -168,7 +170,8 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 			path[0] = aliasTarget
 			continue
 
-		case idutil.NoSuchNameError, idutil.BadTLFNameError:
+		case idutil.NoSuchNameError, idutil.BadTLFNameError,
+			tlf.NoSuchUserError, idutil.NoSuchUserError:
 			return nil, 0, dokan.ErrObjectNameNotFound
 
 		default:

--- a/go/kbfs/libdokan/mount_test.go
+++ b/go/kbfs/libdokan/mount_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/dokan"
-	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
@@ -2159,7 +2158,7 @@ func TestErrorFile(t *testing.T) {
 	}
 
 	// Make sure the root error file reads as expected
-	expectedErr := idutil.NoSuchUserError{Input: "janedoe"}
+	expectedErr := dokan.ErrObjectNameNotFound
 
 	// test both the root error file and one in a directory
 	testForErrorText(t, filepath.Join(mnt.Dir, libkbfs.ErrorFile),
@@ -2172,7 +2171,6 @@ func TestErrorFile(t *testing.T) {
 		expectedErr, "dir")
 	testForErrorText(t, filepath.Join(mnt.Dir, PrivateName, "jdoe", libkbfs.ErrorFile),
 		expectedErr, "dir")
-
 }
 
 type testMountObserver struct {

--- a/go/kbfs/libfs/fs.go
+++ b/go/kbfs/libfs/fs.go
@@ -846,7 +846,7 @@ func (fs *FS) Lstat(filename string) (fi os.FileInfo, err error) {
 // Symlink implements the billy.Filesystem interface for FS.
 func (fs *FS) Symlink(target, link string) (err error) {
 	fs.log.CDebugf(fs.ctx, "Symlink target=%s link=%s",
-		fs.pathForLogging(target), link)
+		fs.pathForLogging(target), fs.root.ChildName(link))
 	defer func() {
 		fs.deferLog.CDebugf(fs.ctx, "Symlink done: %+v", err)
 		err = translateErr(err)
@@ -867,7 +867,7 @@ func (fs *FS) Symlink(target, link string) (err error) {
 	}
 
 	_, err = fs.config.KBFSOps().CreateLink(
-		fs.ctx, n, n.ChildName(base), target)
+		fs.ctx, n, n.ChildName(base), n.ChildName(target))
 	return err
 }
 

--- a/go/kbfs/libfs/node_wrappers.go
+++ b/go/kbfs/libfs/node_wrappers.go
@@ -61,7 +61,7 @@ var perTlfWrappedNodeNames = map[string]bool{
 // specialFileNode.
 func (sfn *specialFileNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	if !perTlfWrappedNodeNames[name.Plaintext()] {
 		return sfn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -75,7 +75,8 @@ func (sfn *specialFileNode) ShouldCreateMissedLookup(
 			log:    sfn.log,
 		}
 		f := sfn.GetFile(ctx)
-		return true, ctx, data.FakeFile, f.(*wrappedReadFile).GetInfo(), ""
+		return true, ctx, data.FakeFile, f.(*wrappedReadFile).GetInfo(),
+			data.PathPartString{}
 	default:
 		panic(fmt.Sprintf("Name %s was in map, but not in switch", name))
 	}

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -539,11 +539,12 @@ func (d *Dir) makeFile(node libkbfs.Node) (file *File) {
 
 // Lookup implements the fs.NodeRequestLookuper interface for Dir.
 func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.LookupResponse) (node fs.Node, err error) {
+	namePPS := d.node.ChildName(req.Name)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Lookup",
-		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
+		fmt.Sprintf("%s %s", d.node.GetBasename(), namePPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Lookup %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Lookup %s", namePPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.ReadMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -567,7 +568,7 @@ func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 	}
 
 	newNode, de, err := d.folder.fs.config.KBFSOps().Lookup(
-		ctx, d.node, d.node.ChildName(req.Name))
+		ctx, d.node, namePPS)
 	if err != nil {
 		if _, ok := err.(idutil.NoSuchNameError); ok {
 			return nil, fuse.ENOENT
@@ -625,17 +626,18 @@ func getEXCLFromCreateRequest(req *fuse.CreateRequest) libkbfs.Excl {
 
 // Create implements the fs.NodeCreater interface for Dir.
 func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (node fs.Node, handle fs.Handle, err error) {
+	namePPS := d.node.ChildName(req.Name)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Create",
-		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
+		fmt.Sprintf("%s %s", d.node.GetBasename(), namePPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Create %s", namePPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	isExec := (req.Mode.Perm() & 0100) != 0
 	excl := getEXCLFromCreateRequest(req)
 	newNode, ei, err := d.folder.fs.config.KBFSOps().CreateFile(
-		ctx, d.node, d.node.ChildName(req.Name), isExec, excl)
+		ctx, d.node, namePPS, isExec, excl)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -661,11 +663,12 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 // Mkdir implements the fs.NodeMkdirer interface for Dir.
 func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 	node fs.Node, err error) {
+	namePPS := d.node.ChildName(req.Name)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Mkdir",
-		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
+		fmt.Sprintf("%s %s", d.node.GetBasename(), namePPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Mkdir %s", namePPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -676,7 +679,7 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 	}
 
 	newNode, _, err := d.folder.fs.config.KBFSOps().CreateDir(
-		ctx, d.node, d.node.ChildName(req.Name))
+		ctx, d.node, namePPS)
 	if err != nil {
 		return nil, err
 	}
@@ -691,13 +694,14 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 // Symlink implements the fs.NodeSymlinker interface for Dir.
 func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	node fs.Node, err error) {
+	namePPS := d.node.ChildName(req.NewName)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Symlink",
 		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
-			req.NewName, req.Target))
+			namePPS, req.Target))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.vlog.CLogf(
-		ctx, libkb.VLog1, "Dir Symlink %s -> %s", req.NewName, req.Target)
+		ctx, libkb.VLog1, "Dir Symlink %s -> %s", namePPS, req.Target)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -708,7 +712,7 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	}
 
 	if _, err := d.folder.fs.config.KBFSOps().CreateLink(
-		ctx, d.node, d.node.ChildName(req.NewName), req.Target); err != nil {
+		ctx, d.node, namePPS, req.Target); err != nil {
 		return nil, err
 	}
 
@@ -723,13 +727,18 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 // Rename implements the fs.NodeRenamer interface for Dir.
 func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 	newDir fs.Node) (err error) {
+	oldNamePPS := d.node.ChildName(req.OldName)
+	// We need to log the new name before we have the new node, so
+	// just obfuscate it with the old node for now, it's the best we
+	// can do.
+	newNameLoggingPPS := d.node.ChildName(req.NewName)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Rename",
 		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
-			req.OldName, req.NewName))
+			oldNamePPS, newNameLoggingPPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.vlog.CLogf(
-		ctx, libkb.VLog1, "Dir Rename %s -> %s", req.OldName, req.NewName)
+		ctx, libkb.VLog1, "Dir Rename %s -> %s", oldNamePPS, newNameLoggingPPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	var realNewDir *Dir
@@ -755,7 +764,7 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 	}
 
 	err = d.folder.fs.config.KBFSOps().Rename(ctx,
-		d.node, d.node.ChildName(req.OldName), realNewDir.node,
+		d.node, oldNamePPS, realNewDir.node,
 		realNewDir.node.ChildName(req.NewName))
 
 	switch e := err.(type) {
@@ -777,11 +786,12 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 
 // Remove implements the fs.NodeRemover interface for Dir.
 func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
+	namePPS := d.node.ChildName(req.Name)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Remove",
-		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
+		fmt.Sprintf("%s %s", d.node.GetBasename(), namePPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
-	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Remove %s", req.Name)
+	d.folder.fs.vlog.CLogf(ctx, libkb.VLog1, "Dir Remove %s", namePPS)
 	defer func() { err = d.folder.processError(ctx, libkbfs.WriteMode, err) }()
 
 	// This fits in situation 1 as described in libkbfs/delayed_cancellation.go
@@ -793,7 +803,6 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
 
 	// node will be removed from Folder.nodes, if it is there in the
 	// first place, by its Forget
-	namePPS := d.node.ChildName(req.Name)
 	if req.Dir {
 		err = d.folder.fs.config.KBFSOps().RemoveDir(ctx, d.node, namePPS)
 	} else {

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -695,9 +695,9 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	node fs.Node, err error) {
 	namePPS := d.node.ChildName(req.NewName)
+	targetPPS := d.node.ChildName(req.Target)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Symlink",
-		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
-			namePPS, req.Target))
+		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(), namePPS, targetPPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.vlog.CLogf(
@@ -712,7 +712,7 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	}
 
 	if _, err := d.folder.fs.config.KBFSOps().CreateLink(
-		ctx, d.node, namePPS, req.Target); err != nil {
+		ctx, d.node, namePPS, targetPPS); err != nil {
 		return nil, err
 	}
 

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -212,8 +212,9 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 		}
 		return n, nil
 
-	case idutil.NoSuchNameError, idutil.BadTLFNameError:
-		// Invalid public TLF.
+	case idutil.NoSuchNameError, idutil.BadTLFNameError,
+		tlf.NoSuchUserError, idutil.NoSuchUserError:
+		// Invalid TLF.
 		return nil, fuse.ENOENT
 
 	default:
@@ -313,6 +314,11 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 
 	case idutil.TlfNameNotCanonical:
 		return nil
+
+	case idutil.NoSuchNameError, idutil.BadTLFNameError,
+		tlf.NoSuchUserError, idutil.NoSuchUserError:
+		// Invalid TLF.
+		return fuse.ENOENT
 
 	default:
 		return err

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -24,7 +24,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
-	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libfs"
@@ -2825,7 +2824,7 @@ func TestErrorFile(t *testing.T) {
 	}
 
 	// Make sure the root error file reads as expected
-	expectedErr := idutil.NoSuchUserError{Input: "janedoe"}
+	expectedErr := fuse.ENOENT
 
 	// test both the root error file and one in a directory
 	testForErrorText(t, path.Join(mnt.Dir, libkbfs.ErrorFile),

--- a/go/kbfs/libgit/autogit_node_wrappers.go
+++ b/go/kbfs/libgit/autogit_node_wrappers.go
@@ -137,7 +137,7 @@ var _ libkbfs.Node = (*repoDirNode)(nil)
 // repoDirNode.
 func (rdn *repoDirNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	namePlain := name.Plaintext()
 	switch {
 	case strings.HasPrefix(namePlain, AutogitBranchPrefix):
@@ -148,7 +148,7 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 		// It's difficult to tell if a given name is a legitimate
 		// prefix for a branch name or not, so just accept everything.
 		// If it's not legit, trying to read the data will error out.
-		return true, ctx, data.FakeDir, nil, ""
+		return true, ctx, data.FakeDir, nil, data.PathPartString{}
 	case strings.HasPrefix(namePlain, AutogitCommitPrefix):
 		commit := strings.TrimPrefix(namePlain, AutogitCommitPrefix)
 		if len(commit) == 0 {
@@ -167,7 +167,8 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 			rdn.am.log.CDebugf(ctx, "Error getting commit file")
 			return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 		}
-		return true, ctx, data.FakeFile, f.(*diffFile).GetInfo(), ""
+		return true, ctx, data.FakeFile, f.(*diffFile).GetInfo(),
+			data.PathPartString{}
 	default:
 		return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -315,7 +316,7 @@ var _ libkbfs.Node = (*rootNode)(nil)
 // rootNode.
 func (rn *rootNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	if name.Plaintext() != AutogitRoot {
 		return rn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -344,7 +345,7 @@ func (rn *rootNode) ShouldCreateMissedLookup(
 		}
 		rn.fs = fs
 	}
-	return true, ctx, data.FakeDir, nil, ""
+	return true, ctx, data.FakeDir, nil, data.PathPartString{}
 }
 
 // WrapChild implements the Node interface for rootNode.

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -1500,7 +1500,8 @@ outer:
 					invertCreate)
 			}
 			cr.log.CDebugf(ctx, "Putting new merged rename info "+
-				"%v -> %v (symPath: %v)", ptr, newInfo, symPath)
+				"%v -> %v (symPath: %v)", ptr, newInfo,
+				data.NewPathPartString(symPath, chain.obfuscator))
 			mergedChains.renamedOriginals[ptr] = newInfo
 
 			// Fix up the corresponding rmOp to make sure
@@ -1761,8 +1762,8 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 			// since this createOp must have been created
 			// as part of conflict resolution.
 			symPath := "./" + strings.Repeat("../", walkBack)
-			cr.log.CDebugf(ctx, "Creating symlink %s at "+
-				"merged path %s", symPath, mergedPath)
+			cr.log.CDebugf(ctx, "Creating symlink %s at merged path %s",
+				data.NewPathPartString(symPath, chain.obfuscator), mergedPath)
 
 			err = cr.convertCreateIntoSymlinkOrCopy(ctx, ptr, info, chain,
 				unmergedChains, mergedChains, symPath)

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -469,8 +469,8 @@ func TestCRMergedChainsSimple(t *testing.T) {
 	mergedPaths[expectedUnmergedPath.TailPointer()] = mergedPath
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dir2.ChildName("file2"), dir2.ChildName("file2"), "", false, false,
-			data.DirEntry{}, nil}},
+			dir2.ChildName("file2"), dir2.ChildName("file2"),
+			dir2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
 		mergedPaths, nil, expectedActions)
@@ -543,8 +543,8 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	mergedPaths[expectedUnmergedPath.TailPointer()] = mergedPath
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dirB2.ChildName("file2"), dirB2.ChildName("file2"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirB2.ChildName("file2"), dirB2.ChildName("file2"),
+			dirB2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
 		mergedPaths, nil, expectedActions)
@@ -646,14 +646,15 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	dirAPtr1 := cr1.fbo.nodeCache.PathFromNode(dirA1).TailPointer()
 	expectedActions := map[data.BlockPointer]crActionList{
 		dirCPtr: {&copyUnmergedEntryAction{
-			dirC2.ChildName("file2"), dirC2.ChildName("file2"), "",
-			false, false, data.DirEntry{}, nil}},
+			dirC2.ChildName("file2"), dirC2.ChildName("file2"),
+			dirC2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		dirBPtr: {&copyUnmergedEntryAction{
-			dirB1.ChildName("dirC"), dirB1.ChildName("dirC"), "", false, false,
+			dirB1.ChildName("dirC"), dirB1.ChildName("dirC"),
+			dirB1.ChildName(""), false, false,
 			data.DirEntry{}, nil}},
 		dirAPtr1: {&copyUnmergedEntryAction{
-			dirA1.ChildName("dirB"), dirA1.ChildName("dirB"), "", false, false,
-			data.DirEntry{}, nil}},
+			dirA1.ChildName("dirB"), dirA1.ChildName("dirB"),
+			dirA1.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
@@ -745,8 +746,8 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dirC2.ChildName("file2"), dirC2.ChildName("file2"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirC2.ChildName("file2"), dirC2.ChildName("file2"),
+			dirC2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
@@ -944,17 +945,17 @@ func TestCRMergedChainsComplex(t *testing.T) {
 	mergedPathE := cr1.fbo.nodeCache.PathFromNode(dirE1)
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPathA.TailPointer(): {&copyUnmergedEntryAction{
-			dirA2.ChildName("dirJ"), dirA2.ChildName("dirJ"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirA2.ChildName("dirJ"), dirA2.ChildName("dirJ"),
+			dirA2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathE.TailPointer(): {&copyUnmergedEntryAction{
-			dirE1.ChildName("dirF"), dirE1.ChildName("dirF"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirE1.ChildName("dirF"), dirE1.ChildName("dirF"),
+			dirE1.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathF.TailPointer(): {&copyUnmergedEntryAction{
-			dirF2.ChildName("file3"), dirF2.ChildName("file3"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirF2.ChildName("file3"), dirF2.ChildName("file3"),
+			dirF2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathH.TailPointer(): {&copyUnmergedEntryAction{
-			dirH2.ChildName("file4"), dirH2.ChildName("file4"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirH2.ChildName("file4"), dirH2.ChildName("file4"),
+			dirH2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathB.TailPointer(): {&rmMergedEntryAction{
 			dirB2.ChildName("dirD")}},
 	}
@@ -1058,8 +1059,8 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPathRoot.TailPointer(): {&dropUnmergedAction{ro}},
 		mergedPathB.TailPointer(): {&copyUnmergedEntryAction{
-			dirB2.ChildName("dirA"), dirB2.ChildName("dirA"), "./../", false,
-			false, data.DirEntry{}, nil}},
+			dirB2.ChildName("dirA"), dirB2.ChildName("dirA"),
+			dirB2.ChildName("./../"), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathRoot, unmergedPathB},
@@ -1139,7 +1140,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 			dirRoot1.ChildName("file1"),
 			dirRoot1.ChildName(cre.ConflictRenameHelper(
 				now, "u2", "dev1", "file1")),
-			"", 0, false, data.ZeroPtr, data.ZeroPtr}},
+			dirRoot1.ChildName(""), 0, false, data.ZeroPtr, data.ZeroPtr}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathRoot},
@@ -1261,7 +1262,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 			dirRoot1.ChildName("file"),
 			dirRoot2.ChildName(cre.ConflictRenameHelper(
 				now, "u2", "dev1", "file")),
-			"", 0, false, data.ZeroPtr, data.ZeroPtr}},
+			dirRoot1.ChildName(""), 0, false, data.ZeroPtr, data.ZeroPtr}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathFile},

--- a/go/kbfs/libkbfs/cr_actions_test.go
+++ b/go/kbfs/libkbfs/cr_actions_test.go
@@ -18,15 +18,15 @@ func testPPS(s string) data.PathPartString {
 func TestCRActionsCollapseNoChange(t *testing.T) {
 	al := crActionList{
 		&copyUnmergedEntryAction{
-			testPPS("old1"), testPPS("new1"), "", false, false,
+			testPPS("old1"), testPPS("new1"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&copyUnmergedEntryAction{
-			testPPS("old2"), testPPS("new2"), "", false, false,
+			testPPS("old2"), testPPS("new2"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&renameUnmergedAction{
-			testPPS("old3"), testPPS("new3"), "", 0, false, data.ZeroPtr,
-			data.ZeroPtr},
-		&renameMergedAction{testPPS("old4"), testPPS("new4"), ""},
+			testPPS("old3"), testPPS("new3"), testPPS(""), 0, false,
+			data.ZeroPtr, data.ZeroPtr},
+		&renameMergedAction{testPPS("old4"), testPPS("new4"), testPPS("")},
 		&copyUnmergedAttrAction{
 			testPPS("old5"), testPPS("new5"), []attrChange{mtimeAttr}, false},
 	}
@@ -42,10 +42,10 @@ func TestCRActionsCollapseEntry(t *testing.T) {
 		&copyUnmergedAttrAction{
 			testPPS("old"), testPPS("new"), []attrChange{mtimeAttr}, false},
 		&copyUnmergedEntryAction{
-			testPPS("old"), testPPS("new"), "", false, false,
+			testPPS("old"), testPPS("new"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&renameUnmergedAction{
-			testPPS("old"), testPPS("new"), "", 0, false, data.ZeroPtr,
+			testPPS("old"), testPPS("new"), testPPS(""), 0, false, data.ZeroPtr,
 			data.ZeroPtr},
 	}
 

--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -662,16 +662,17 @@ func (e InvalidOpError) Error() string {
 // NoSuchFolderListError indicates that the user tried to access a
 // subdirectory of /keybase that doesn't exist.
 type NoSuchFolderListError struct {
-	Name     string
-	PrivName string
-	PubName  string
+	Name      string
+	NameToLog string
+	PrivName  string
+	PubName   string
 }
 
 // Error implements the error interface for NoSuchFolderListError
 func (e NoSuchFolderListError) Error() string {
 	return fmt.Sprintf("/keybase/%s is not a Keybase folder. "+
 		"All folders begin with /keybase/%s or /keybase/%s.",
-		e.Name, e.PrivName, e.PubName)
+		e.NameToLog, e.PrivName, e.PubName)
 }
 
 // UnexpectedUnmergedPutError indicates that we tried to do an

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3255,7 +3255,7 @@ func (fbo *folderBranchOps) makeFakeDirEntry(
 
 func (fbo *folderBranchOps) makeFakeFileEntry(
 	ctx context.Context, dir Node, name data.PathPartString, fi os.FileInfo,
-	sympath string) (de data.DirEntry, err error) {
+	sympath data.PathPartString) (de data.DirEntry, err error) {
 	fbo.vlog.CLogf(ctx, libkb.VLog1, "Faking file entry for %s", name)
 	id, err := fbo.makeFakeEntryID(ctx, dir, name)
 	if err != nil {
@@ -3272,7 +3272,7 @@ func (fbo *folderBranchOps) makeFakeFileEntry(
 		EntryInfo: data.EntryInfoFromFileInfo(fi),
 	}
 	if de.Type == data.Sym {
-		de.SymPath = sympath
+		de.SymPath = sympath.Plaintext()
 	}
 	return de, nil
 }
@@ -3309,7 +3309,8 @@ func (fbo *folderBranchOps) processMissedLookup(
 		return node, de.EntryInfo, nil
 	}
 
-	if (sympath != "" && et != data.Sym) || (sympath == "" && et == data.Sym) {
+	if (sympath.Plaintext() != "" && et != data.Sym) ||
+		(sympath.Plaintext() == "" && et == data.Sym) {
 		return nil, data.EntryInfo{}, errors.Errorf(
 			"Invalid sympath %s for entry type %s", sympath, et)
 	}
@@ -3370,10 +3371,11 @@ func (fbo *folderBranchOps) statUsingFS(
 	}
 
 	if fi.Mode()&os.ModeSymlink != 0 {
-		sympath, err = fs.Readlink(name.Plaintext())
+		sympathPlain, err := fs.Readlink(name.Plaintext())
 		if err != nil {
 			return data.DirEntry{}, false, err
 		}
+		sympath = node.ChildName(sympathPlain)
 	}
 
 	de, err = fbo.makeFakeFileEntry(ctx, node, name, fi, sympath)
@@ -4780,7 +4782,7 @@ func (fbo *folderBranchOps) notifyAndSyncOrSignal(
 
 func (fbo *folderBranchOps) createLinkLocked(
 	ctx context.Context, lState *kbfssync.LockState, dir Node,
-	fromName data.PathPartString, toPath string) (data.DirEntry, error) {
+	fromName, toPath data.PathPartString) (data.DirEntry, error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
 	if err := checkDisallowedPrefixes(ctx, fromName); err != nil {
@@ -4833,11 +4835,12 @@ func (fbo *folderBranchOps) createLinkLocked(
 
 	// Create a direntry for the link, and then sync
 	now := fbo.nowUnixNano()
+	toPathPlain := toPath.Plaintext()
 	de := data.DirEntry{
 		EntryInfo: data.EntryInfo{
 			Type:    data.Sym,
-			Size:    uint64(len(toPath)),
-			SymPath: toPath,
+			Size:    uint64(len(toPathPlain)),
+			SymPath: toPathPlain,
 			Mtime:   now,
 			Ctime:   now,
 		},
@@ -4858,8 +4861,8 @@ func (fbo *folderBranchOps) createLinkLocked(
 }
 
 func (fbo *folderBranchOps) CreateLink(
-	ctx context.Context, dir Node, fromName data.PathPartString,
-	toPath string) (ei data.EntryInfo, err error) {
+	ctx context.Context, dir Node, fromName, toPath data.PathPartString) (
+	ei data.EntryInfo, err error) {
 	startTime, timer := fbo.startOp(ctx, "CreateLink %s %s -> %s",
 		getNodeIDStr(dir), fromName, toPath)
 	defer func() {

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -660,11 +660,6 @@ func doInit(
 			return lg
 		}, params.StorageRoot, params.DiskCacheMode, kbCtx)
 	config.SetVLogLevel(kbCtx.GetVDebugSetting())
-	if mode == InitConstrained {
-		// Until we have a way to turn on debug logging for mobile,
-		// log everything.
-		config.SetVLogLevel(libkb.VLog1String)
-	}
 
 	if params.CleanBlockCacheCapacity > 0 {
 		log.CDebugf(

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -190,7 +190,7 @@ type Node interface {
 	// `true` on its own.
 	ShouldCreateMissedLookup(ctx context.Context, name data.PathPartString) (
 		shouldCreate bool, newCtx context.Context, et data.EntryType,
-		fi os.FileInfo, sympath string)
+		fi os.FileInfo, sympath data.PathPartString)
 	// ShouldRetryOnDirRead is called for Nodes representing
 	// directories, whenever a `Lookup` or `GetDirChildren` is done on
 	// them.  It should return true to instruct the caller that it
@@ -372,11 +372,16 @@ type KBFSOps interface {
 		excl Excl) (Node, data.EntryInfo, error)
 	// CreateLink creates a new symlink under the given node, if the
 	// logged-in user has write permission to the top-level folder.
-	// Returns the new entry info for the created symlink.  This
-	// is a remote-sync operation.
+	// Returns the new entry info for the created symlink.  The
+	// symlink is represented as a single `data.PathPartString`
+	// (generally obfuscated by `dir`'s Obfuscator) to avoid
+	// accidental logging, even though it could point outside of the
+	// directory.  The deobfuscate command will inspect symlinks when
+	// deobfuscating to make this easier to debug.  This is a
+	// remote-sync operation.
 	CreateLink(
-		ctx context.Context, dir Node, fromName data.PathPartString,
-		toPath string) (data.EntryInfo, error)
+		ctx context.Context, dir Node, fromName, toPath data.PathPartString) (
+		data.EntryInfo, error)
 	// RemoveDir removes the subdirectory represented by the given
 	// node, if the logged-in user has write permission to the
 	// top-level folder.  Will return an error if the subdirectory is

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -75,7 +75,7 @@ func NewKBFSOpsStandard(appStateUpdater env.AppStateUpdater, config Config) *KBF
 		ops:                   make(map[data.FolderBranch]*folderBranchOps),
 		opsByFav:              make(map[favorites.Folder]*folderBranchOps),
 		reIdentifyControlChan: make(chan chan<- struct{}),
-		favs:                  NewFavorites(config),
+		favs: NewFavorites(config),
 		quotaUsage: NewEventuallyConsistentQuotaUsage(
 			config, quLog, config.MakeVLogger(quLog)),
 		longOperationDebugDumper: NewImpatientDebugDumper(
@@ -1096,8 +1096,8 @@ func (fs *KBFSOpsStandard) CreateFile(
 
 // CreateLink implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) CreateLink(
-	ctx context.Context, dir Node, fromName data.PathPartString,
-	toPath string) (data.EntryInfo, error) {
+	ctx context.Context, dir Node, fromName, toPath data.PathPartString) (
+	data.EntryInfo, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -979,7 +979,7 @@ func (mr *MockKBFSOpsMockRecorder) CreateFile(arg0, arg1, arg2, arg3, arg4 inter
 }
 
 // CreateLink mocks base method
-func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2 data.PathPartString, arg3 string) (data.EntryInfo, error) {
+func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2, arg3 data.PathPartString) (data.EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLink", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(data.EntryInfo)
@@ -3590,14 +3590,14 @@ func (mr *MockNodeMockRecorder) RemoveDir(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // ShouldCreateMissedLookup mocks base method
-func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, string) {
+func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldCreateMissedLookup", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(context.Context)
 	ret2, _ := ret[2].(data.EntryType)
 	ret3, _ := ret[3].(os.FileInfo)
-	ret4, _ := ret[4].(string)
+	ret4, _ := ret[4].(data.PathPartString)
 	return ret0, ret1, ret2, ret3, ret4
 }
 

--- a/go/kbfs/libkbfs/node.go
+++ b/go/kbfs/libkbfs/node.go
@@ -110,8 +110,8 @@ func (n *nodeStandard) Readonly(_ context.Context) bool {
 
 func (n *nodeStandard) ShouldCreateMissedLookup(
 	ctx context.Context, _ data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
-	return false, ctx, data.File, nil, ""
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
+	return false, ctx, data.File, nil, data.PathPartString{}
 }
 
 func (n *nodeStandard) ShouldRetryOnDirRead(ctx context.Context) bool {

--- a/go/kbfs/libkbfs/ops.go
+++ b/go/kbfs/libkbfs/ops.go
@@ -456,7 +456,7 @@ func (co *createOp) checkConflict(
 				return &renameMergedAction{
 					fromName: co.obfuscatedNewName(),
 					toName:   co.obfuscatedName(toName),
-					symPath:  co.crSymPath,
+					symPath:  co.obfuscatedName(co.crSymPath),
 				}, nil
 			}
 			// Otherwise rename the unmerged entry (guaranteed to be a file).
@@ -468,7 +468,7 @@ func (co *createOp) checkConflict(
 			return &renameUnmergedAction{
 				fromName: co.obfuscatedNewName(),
 				toName:   co.obfuscatedName(toName),
-				symPath:  co.crSymPath,
+				symPath:  co.obfuscatedName(co.crSymPath),
 			}, nil
 		}
 
@@ -489,7 +489,7 @@ func (co *createOp) checkConflict(
 			return &copyUnmergedEntryAction{
 				fromName: co.obfuscatedNewName(),
 				toName:   co.obfuscatedName(toName),
-				symPath:  co.crSymPath,
+				symPath:  co.obfuscatedName(co.crSymPath),
 				unique:   true,
 			}, nil
 		}
@@ -505,13 +505,13 @@ func (co *createOp) getDefaultAction(mergedPath data.Path) crAction {
 		return &renameUnmergedAction{
 			fromName: newName,
 			toName:   newName,
-			symPath:  co.crSymPath,
+			symPath:  co.obfuscatedName(co.crSymPath),
 		}
 	}
 	return &copyUnmergedEntryAction{
 		fromName: newName,
 		toName:   newName,
-		symPath:  co.crSymPath,
+		symPath:  co.obfuscatedName(co.crSymPath),
 	}
 }
 
@@ -1000,8 +1000,8 @@ func (so *syncOp) checkConflict(
 		}
 
 		return &renameUnmergedAction{
-			fromName:                 so.getFinalPath().TailName(),
-			toName:                   so.obfuscatedName(toName),
+			fromName: so.getFinalPath().TailName(),
+			toName:   so.obfuscatedName(toName),
 			unmergedParentMostRecent: so.getFinalPath().ParentPath().TailPointer(),
 			mergedParentMostRecent: mergedOp.getFinalPath().ParentPath().
 				TailPointer(),
@@ -1022,7 +1022,7 @@ func (so *syncOp) getDefaultAction(mergedPath data.Path) crAction {
 	return &copyUnmergedEntryAction{
 		fromName: so.getFinalPath().TailName(),
 		toName:   mergedPath.TailName(),
-		symPath:  "",
+		symPath:  so.obfuscatedName(""),
 	}
 }
 
@@ -1312,7 +1312,7 @@ func (sao *setAttrOp) checkConflict(
 			return &renameUnmergedAction{
 				fromName:                 fromName,
 				toName:                   toNamePPS,
-				symPath:                  symPath,
+				symPath:                  sao.obfuscatedName(symPath),
 				causedByAttr:             causedByAttr,
 				unmergedParentMostRecent: sao.getFinalPath().ParentPath().TailPointer(),
 				mergedParentMostRecent: mergedOp.getFinalPath().ParentPath().

--- a/go/kbfs/test/engine_libkbfs.go
+++ b/go/kbfs/test/engine_libkbfs.go
@@ -392,13 +392,15 @@ func (k *LibKBFS) CreateFileExcl(u User, parentDir Node, name string) (file Node
 }
 
 // CreateLink implements the Engine interface.
-func (k *LibKBFS) CreateLink(u User, parentDir Node, fromName, toPath string) (err error) {
+func (k *LibKBFS) CreateLink(
+	u User, parentDir Node, fromName, toPath string) (err error) {
 	config := u.(*libkbfs.ConfigLocal)
 	kbfsOps := config.KBFSOps()
 	ctx, cancel := k.newContext(u)
 	defer cancel()
 	n := parentDir.(libkbfs.Node)
-	_, err = kbfsOps.CreateLink(ctx, n, n.ChildName(fromName), toPath)
+	_, err = kbfsOps.CreateLink(
+		ctx, n, n.ChildName(fromName), n.ChildName(toPath))
 	return err
 }
 


### PR DESCRIPTION
(Depends on #17979 -- review that one first.)

Either obfuscate filenames when using `CDebugf`, or change those statements that do log plaintext filenames to use the vlogger at a level of vlog1.

Also no longer require mobile to use vlog 1, to avoid logging these filenames by default.

Issue: HOTPOT-62