### PR TITLE
support /keybase/.kbfs_status in GUI and subscription fixes

### DIFF
--- a/go/kbfs/libfs/httpfs.go
+++ b/go/kbfs/libfs/httpfs.go
@@ -1,3 +1,7 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
 package libfs
 
 import (

--- a/go/kbfs/libfs/httprootfs.go
+++ b/go/kbfs/libfs/httprootfs.go
@@ -1,0 +1,52 @@
+package libfs
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	billy "gopkg.in/src-d/go-billy.v4"
+)
+
+type httpRootFileSystem struct {
+	rfs *RootFS
+}
+
+var _ http.FileSystem = httpRootFileSystem{}
+
+type fileOnly struct {
+	billy.File
+	rfs *RootFS
+}
+
+// Readdir implements the http.File interface.
+func (fo fileOnly) Readdir(count int) ([]os.FileInfo, error) {
+	return nil, errors.New("not supported")
+}
+
+// Stat implements the http.File interface.
+func (fo fileOnly) Stat() (os.FileInfo, error) {
+	return fo.rfs.Stat(fo.File.Name())
+}
+
+func (hrfs httpRootFileSystem) Open(filename string) (entry http.File, err error) {
+	hrfs.rfs.log.CDebugf(hrfs.rfs.ctx, "hfs.Open %s", filename)
+	defer func() {
+		hrfs.rfs.log.CDebugf(hrfs.rfs.ctx, "hfs.Open done: %+v", err)
+		if err != nil {
+			err = translateErr(err)
+		}
+	}()
+
+	if strings.HasPrefix(filename, "/") {
+		filename = filename[1:]
+	}
+
+	f, err := hrfs.rfs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return fileOnly{File: f, rfs: hrfs.rfs}, nil
+}

--- a/go/kbfs/libfs/httprootfs.go
+++ b/go/kbfs/libfs/httprootfs.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
 package libfs
 
 import (
@@ -31,9 +35,7 @@ func (fo fileOnly) Stat() (os.FileInfo, error) {
 }
 
 func (hrfs httpRootFileSystem) Open(filename string) (entry http.File, err error) {
-	hrfs.rfs.log.CDebugf(hrfs.rfs.ctx, "hfs.Open %s", filename)
 	defer func() {
-		hrfs.rfs.log.CDebugf(hrfs.rfs.ctx, "hfs.Open done: %+v", err)
 		if err != nil {
 			err = translateErr(err)
 		}

--- a/go/kbfs/libfs/root_fs.go
+++ b/go/kbfs/libfs/root_fs.go
@@ -23,10 +23,6 @@ import (
 type RootFS struct {
 	config libkbfs.Config
 	log    logger.Logger
-	// Yes, storing ctx in a struct is a mortal sin, but the
-	// billy.Filesystem interface doesn't give us a way to accept ctxs
-	// any other way.
-	ctx context.Context
 }
 
 // NewRootFS creates a new RootFS instance.
@@ -34,7 +30,6 @@ func NewRootFS(config libkbfs.Config) *RootFS {
 	return &RootFS{
 		config: config,
 		log:    config.MakeLogger(""),
-		ctx:    context.Background(),
 	}
 }
 
@@ -185,11 +180,10 @@ func (rfs *RootFS) Symlink(_, _ string) (err error) {
 
 // ToHTTPFileSystem calls fs.WithCtx with ctx to create a *RootFS with the new
 // ctx, and returns a wrapper around it that satisfies the http.FileSystem
-// interface.
+// interface. ctx is ignored here.
 func (rfs *RootFS) ToHTTPFileSystem(ctx context.Context) http.FileSystem {
 	return httpRootFileSystem{rfs: &RootFS{
 		config: rfs.config,
 		log:    rfs.log,
-		ctx:    ctx,
 	}}
 }

--- a/go/kbfs/libhttpserver/server.go
+++ b/go/kbfs/libhttpserver/server.go
@@ -8,14 +8,13 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"io"
 	"net/http"
 	"path"
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/env"
 	"github.com/keybase/client/go/kbfs/libfs"
@@ -94,7 +93,7 @@ func (s *Server) getHTTPFileSystem(ctx context.Context, requestPath string) (
 	toStrip string, fs http.FileSystem, err error) {
 	fields := strings.Split(requestPath, "/")
 	if len(fields) < 2 {
-		return "", nil, errors.New("bad path")
+		return "", libfs.NewRootFS(s.config).ToHTTPFileSystem(ctx), nil
 	}
 
 	tlfType, err := tlf.ParseTlfTypeFromPath(fields[0])

--- a/shared/common-adapters/markdown/index.stories.tsx
+++ b/shared/common-adapters/markdown/index.stories.tsx
@@ -100,6 +100,7 @@ a = 1
       /keybaseprivate
       /keybaseprivate/team
       /keybase/teamaa/keybase
+      /keybase/.kbfs_status
       /foo
       /keybase`,
   nonemoji: `:party-parrot:`,

--- a/shared/common-adapters/markdown/shared.tsx
+++ b/shared/common-adapters/markdown/shared.tsx
@@ -16,7 +16,8 @@ function createKbfsPathRegex(): RegExp | null {
   const tlfType = `/(?:private|public|team)`
   const tlf = `/(?:(?:private|public)/${usernames}(#${usernames})?|team/${teamName})`
   const inTlf = `/(?:\\\\\\\\|\\\\ |\\S)+`
-  return new RegExp(`^(/keybase(?:(?:${tlf}(${inTlf})?)|(?:${tlfType}))?/?)(?=\\s|$)`)
+  const specialFiles = `/(?:.kbfs_.+)`
+  return new RegExp(`^(/keybase(?:(?:${tlf}(${inTlf})?)|(?:${tlfType})|(?:${specialFiles}))?/?)(?=\\s|$)`)
 }
 
 const kbfsPathMatcher = SimpleMarkdown.inlineRegex(createKbfsPathRegex())

--- a/shared/constants/fs.tsx
+++ b/shared/constants/fs.tsx
@@ -1101,6 +1101,9 @@ export const getSoftError = (softErrors: Types.SoftErrors, path: Types.Path): Ty
   return tlfPath ? softErrors.tlfErrors.get(tlfPath) : null
 }
 
+export const hasSpecialFileElement = (path: Types.Path): boolean =>
+  Types.getPathElements(path).some(elem => elem.startsWith('.kbfs'))
+
 export const erroredActionToMessage = (action: FsGen.Actions, error: string): string => {
   // We have FsError.expectedIfOffline now to take care of real offline
   // scenarios, but we still need to keep this timeout check here in case we

--- a/shared/fs/browser/rows/load-files-when-needed.tsx
+++ b/shared/fs/browser/rows/load-files-when-needed.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import {namedConnect} from '../../../util/container'
 import * as FsGen from '../../../actions/fs-gen'
 import * as Types from '../../../constants/types/fs'
+import * as Constants from '../../../constants/fs'
 
 type OwnProps = {
   path: Types.Path
@@ -55,14 +56,11 @@ type Props = {
 class LoadFilesWhenNeeded extends React.PureComponent<Props> {
   _load = withRefreshTag => {
     const pathLevel = Types.getPathLevel(this.props.path)
-    if (pathLevel < 2) {
-      return
-    }
-    pathLevel > 2
+    pathLevel > 2 || Constants.hasSpecialFileElement(this.props.path)
       ? withRefreshTag
         ? this.props.loadFolderListWithRefreshTag()
         : this.props.loadFolderListWithoutRefreshTag()
-      : this.props.loadFavorites()
+      : pathLevel === 2 && this.props.loadFavorites()
   }
   componentDidMount() {
     this._load(true)
@@ -89,9 +87,6 @@ class LoadFilesWhenNeeded extends React.PureComponent<Props> {
   }
 }
 
-export default namedConnect(
-  mapStateToProps,
-  mapDispatchToProps,
-  mergeProps,
-  'LoadFilesWhenNeeded'
-)(LoadFilesWhenNeeded) as any
+export default namedConnect(mapStateToProps, mapDispatchToProps, mergeProps, 'LoadFilesWhenNeeded')(
+  LoadFilesWhenNeeded
+) as any

--- a/shared/fs/container.tsx
+++ b/shared/fs/container.tsx
@@ -35,7 +35,7 @@ const mapDispatchToProps = dispatch => ({
 
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
   const path = getRouteProps(ownProps, 'path') || Constants.defaultPath
-  const isDefinitelyFolder = Types.getPathElements(path).length <= 3
+  const isDefinitelyFolder = Types.getPathElements(path).length <= 3 && !Constants.hasSpecialFileElement(path)
   return {
     emitBarePreview: () => dispatchProps._emitBarePreview(path),
     kbfsDaemonStatus: stateProps.kbfsDaemonStatus,


### PR DESCRIPTION
This turns out to be more than just a markdown change. The http server needs to handle RootFS separately, so I made a `httpRootFS` for that.

When making these changes, I realized that we could potentially be stuck in a state where we think we are subscribed to a TLF and never do another RPC for that particular path, when in fact we are subscribed to a different one. This is because we compare paths for different tags separately, while kbfs daemon keeps a single subscribed TLF for notifications. So instead, add a `lastSubscribedTlf` to track that, and extract all refreshTags related stuff into a separate function for better clarity.