### PR TITLE
TODO items for imp tofu

### DIFF
--- a/go/home/home.go
+++ b/go/home/home.go
@@ -1,3 +1,6 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package home
 
 import (
@@ -35,12 +38,8 @@ type Home struct {
 }
 
 type rawGetHome struct {
-	Status libkb.AppStatus     `json:"status"`
-	Home   keybase1.HomeScreen `json:"home"`
-}
-
-func (r *rawGetHome) GetAppStatus() *libkb.AppStatus {
-	return &r.Status
+	libkb.AppStatusEmbed
+	Home keybase1.HomeScreen `json:"home"`
 }
 
 func NewHome(g *libkb.GlobalContext) *Home {

--- a/go/protocol/keybase1/home.go
+++ b/go/protocol/keybase1/home.go
@@ -255,6 +255,11 @@ const (
 	HomeScreenTodoType_TEAM_SHOWCASE           HomeScreenTodoType = 10
 	HomeScreenTodoType_AVATAR_USER             HomeScreenTodoType = 11
 	HomeScreenTodoType_AVATAR_TEAM             HomeScreenTodoType = 12
+	HomeScreenTodoType_ADD_PHONE_NUMBER        HomeScreenTodoType = 13
+	HomeScreenTodoType_VERIFY_ALL_PHONE_NUMBER HomeScreenTodoType = 14
+	HomeScreenTodoType_VERIFY_ALL_EMAIL        HomeScreenTodoType = 15
+	HomeScreenTodoType_LEGACY_EMAIL_VISIBILITY HomeScreenTodoType = 16
+	HomeScreenTodoType_ADD_EMAIL               HomeScreenTodoType = 17
 	HomeScreenTodoType_ANNONCEMENT_PLACEHOLDER HomeScreenTodoType = 10000
 )
 
@@ -274,6 +279,11 @@ var HomeScreenTodoTypeMap = map[string]HomeScreenTodoType{
 	"TEAM_SHOWCASE":           10,
 	"AVATAR_USER":             11,
 	"AVATAR_TEAM":             12,
+	"ADD_PHONE_NUMBER":        13,
+	"VERIFY_ALL_PHONE_NUMBER": 14,
+	"VERIFY_ALL_EMAIL":        15,
+	"LEGACY_EMAIL_VISIBILITY": 16,
+	"ADD_EMAIL":               17,
 	"ANNONCEMENT_PLACEHOLDER": 10000,
 }
 
@@ -291,6 +301,11 @@ var HomeScreenTodoTypeRevMap = map[HomeScreenTodoType]string{
 	10:    "TEAM_SHOWCASE",
 	11:    "AVATAR_USER",
 	12:    "AVATAR_TEAM",
+	13:    "ADD_PHONE_NUMBER",
+	14:    "VERIFY_ALL_PHONE_NUMBER",
+	15:    "VERIFY_ALL_EMAIL",
+	16:    "LEGACY_EMAIL_VISIBILITY",
+	17:    "ADD_EMAIL",
 	10000: "ANNONCEMENT_PLACEHOLDER",
 }
 
@@ -301,14 +316,88 @@ func (e HomeScreenTodoType) String() string {
 	return ""
 }
 
+// Most of TODO items do not carry additional data, but some do. e.g. TODO
+// item to tell user to verify their email address will carry that email
+// address.
+//
+// This data does not come from the server.
 type HomeScreenTodo struct {
-	T__ HomeScreenTodoType `codec:"t" json:"t"`
+	T__                     HomeScreenTodoType `codec:"t" json:"t"`
+	VerifyAllPhoneNumber__  *PhoneNumber       `codec:"verifyAllPhoneNumber,omitempty" json:"verifyAllPhoneNumber,omitempty"`
+	VerifyAllEmail__        *EmailAddress      `codec:"verifyAllEmail,omitempty" json:"verifyAllEmail,omitempty"`
+	LegacyEmailVisibility__ *EmailAddress      `codec:"legacyEmailVisibility,omitempty" json:"legacyEmailVisibility,omitempty"`
 }
 
 func (o *HomeScreenTodo) T() (ret HomeScreenTodoType, err error) {
 	switch o.T__ {
+	case HomeScreenTodoType_VERIFY_ALL_PHONE_NUMBER:
+		if o.VerifyAllPhoneNumber__ == nil {
+			err = errors.New("unexpected nil value for VerifyAllPhoneNumber__")
+			return ret, err
+		}
+	case HomeScreenTodoType_VERIFY_ALL_EMAIL:
+		if o.VerifyAllEmail__ == nil {
+			err = errors.New("unexpected nil value for VerifyAllEmail__")
+			return ret, err
+		}
+	case HomeScreenTodoType_LEGACY_EMAIL_VISIBILITY:
+		if o.LegacyEmailVisibility__ == nil {
+			err = errors.New("unexpected nil value for LegacyEmailVisibility__")
+			return ret, err
+		}
 	}
 	return o.T__, nil
+}
+
+func (o HomeScreenTodo) VerifyAllPhoneNumber() (res PhoneNumber) {
+	if o.T__ != HomeScreenTodoType_VERIFY_ALL_PHONE_NUMBER {
+		panic("wrong case accessed")
+	}
+	if o.VerifyAllPhoneNumber__ == nil {
+		return
+	}
+	return *o.VerifyAllPhoneNumber__
+}
+
+func (o HomeScreenTodo) VerifyAllEmail() (res EmailAddress) {
+	if o.T__ != HomeScreenTodoType_VERIFY_ALL_EMAIL {
+		panic("wrong case accessed")
+	}
+	if o.VerifyAllEmail__ == nil {
+		return
+	}
+	return *o.VerifyAllEmail__
+}
+
+func (o HomeScreenTodo) LegacyEmailVisibility() (res EmailAddress) {
+	if o.T__ != HomeScreenTodoType_LEGACY_EMAIL_VISIBILITY {
+		panic("wrong case accessed")
+	}
+	if o.LegacyEmailVisibility__ == nil {
+		return
+	}
+	return *o.LegacyEmailVisibility__
+}
+
+func NewHomeScreenTodoWithVerifyAllPhoneNumber(v PhoneNumber) HomeScreenTodo {
+	return HomeScreenTodo{
+		T__:                    HomeScreenTodoType_VERIFY_ALL_PHONE_NUMBER,
+		VerifyAllPhoneNumber__: &v,
+	}
+}
+
+func NewHomeScreenTodoWithVerifyAllEmail(v EmailAddress) HomeScreenTodo {
+	return HomeScreenTodo{
+		T__:              HomeScreenTodoType_VERIFY_ALL_EMAIL,
+		VerifyAllEmail__: &v,
+	}
+}
+
+func NewHomeScreenTodoWithLegacyEmailVisibility(v EmailAddress) HomeScreenTodo {
+	return HomeScreenTodo{
+		T__:                     HomeScreenTodoType_LEGACY_EMAIL_VISIBILITY,
+		LegacyEmailVisibility__: &v,
+	}
 }
 
 func NewHomeScreenTodoDefault(t HomeScreenTodoType) HomeScreenTodo {
@@ -320,6 +409,27 @@ func NewHomeScreenTodoDefault(t HomeScreenTodoType) HomeScreenTodo {
 func (o HomeScreenTodo) DeepCopy() HomeScreenTodo {
 	return HomeScreenTodo{
 		T__: o.T__.DeepCopy(),
+		VerifyAllPhoneNumber__: (func(x *PhoneNumber) *PhoneNumber {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.VerifyAllPhoneNumber__),
+		VerifyAllEmail__: (func(x *EmailAddress) *EmailAddress {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.VerifyAllEmail__),
+		LegacyEmailVisibility__: (func(x *EmailAddress) *EmailAddress {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.LegacyEmailVisibility__),
 	}
 }
 

--- a/go/systests/home_test.go
+++ b/go/systests/home_test.go
@@ -146,8 +146,6 @@ func pollForTrue(t *testing.T, g *libkb.GlobalContext, poller func(i int) bool) 
 }
 
 func TestHome(t *testing.T) {
-	t.Skip("zapu: needs to merrge todo changes from PR")
-
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
@@ -163,7 +161,10 @@ func TestHome(t *testing.T) {
 	initialVersion := home.Version
 
 	require.True(t, (initialVersion > 0), "initial version should be > 0")
-	assertTodoPresent(t, home, keybase1.HomeScreenTodoType_BIO, true)
+	// Our first todo is VERIFY_ALL_EMAIL, that's badged
+	assertTodoPresent(t, home, keybase1.HomeScreenTodoType_VERIFY_ALL_EMAIL, true /* isBadged */)
+	// followed by BIO todo
+	assertTodoPresent(t, home, keybase1.HomeScreenTodoType_BIO, false /* isBadged */)
 
 	var countPre int
 	pollForTrue(t, g, func(i int) bool {

--- a/protocol/avdl/keybase1/home.avdl
+++ b/protocol/avdl/keybase1/home.avdl
@@ -61,10 +61,25 @@ protocol home {
     TEAM_SHOWCASE_10,
     AVATAR_USER_11,
     AVATAR_TEAM_12,
+    ADD_PHONE_NUMBER_13,
+    VERIFY_ALL_PHONE_NUMBER_14,
+    VERIFY_ALL_EMAIL_15,
+    LEGACY_EMAIL_VISIBILITY_16,
+    ADD_EMAIL_17,
     ANNONCEMENT_PLACEHOLDER_10000
   }
 
+  /**
+    Most of TODO items do not carry additional data, but some do. e.g. TODO
+    item to tell user to verify their email address will carry that email
+    address.
+
+    This data does not come from the server.
+  */
   variant HomeScreenTodo switch (HomeScreenTodoType t) {
+    case VERIFY_ALL_PHONE_NUMBER: PhoneNumber;
+    case VERIFY_ALL_EMAIL: EmailAddress;
+    case LEGACY_EMAIL_VISIBILITY: EmailAddress;
     default: void;
   }
 

--- a/protocol/json/keybase1/home.json
+++ b/protocol/json/keybase1/home.json
@@ -136,6 +136,11 @@
         "TEAM_SHOWCASE_10",
         "AVATAR_USER_11",
         "AVATAR_TEAM_12",
+        "ADD_PHONE_NUMBER_13",
+        "VERIFY_ALL_PHONE_NUMBER_14",
+        "VERIFY_ALL_EMAIL_15",
+        "LEGACY_EMAIL_VISIBILITY_16",
+        "ADD_EMAIL_17",
         "ANNONCEMENT_PLACEHOLDER_10000"
       ]
     },
@@ -149,11 +154,33 @@
       "cases": [
         {
           "label": {
+            "name": "VERIFY_ALL_PHONE_NUMBER",
+            "def": false
+          },
+          "body": "PhoneNumber"
+        },
+        {
+          "label": {
+            "name": "VERIFY_ALL_EMAIL",
+            "def": false
+          },
+          "body": "EmailAddress"
+        },
+        {
+          "label": {
+            "name": "LEGACY_EMAIL_VISIBILITY",
+            "def": false
+          },
+          "body": "EmailAddress"
+        },
+        {
+          "label": {
             "def": true
           },
           "body": null
         }
-      ]
+      ],
+      "doc": "Most of TODO items do not carry additional data, but some do. e.g. TODO\n    item to tell user to verify their email address will carry that email\n    address.\n\n    This data does not come from the server."
     },
     {
       "type": "enum",

--- a/shared/actions/people.tsx
+++ b/shared/actions/people.tsx
@@ -42,18 +42,24 @@ const getPeopleData = (state, action: PeopleGen.GetPeopleDataPayload) => {
         .reduce(Constants.reduceRPCItemToPeopleItem, I.List())
 
       if (debugTodo) {
-        const allTodos: Array<Types.TodoType> = Object.values(Constants.todoTypeEnumToType)
-        allTodos.forEach(todoType => {
+        const allTodos: Array<RPCTypes.HomeScreenTodoType> = Object.values(RPCTypes.HomeScreenTodoType)
+        allTodos.forEach(avdlType => {
+          const todoType = Constants.todoTypeEnumToType[avdlType]
           if (newItems.some(t => t.type === 'todo' && t.todoType === todoType)) {
             return
           }
+          const instructions = Constants.makeDescriptionForTodoItem({
+            legacyEmailVisibility: 'user@example.com',
+            t: avdlType,
+            verifyAllEmail: 'user@example.com',
+            verifyAllPhoneNumber: '+1555000111',
+          } as any)
           newItems = newItems.push(
             Constants.makeTodo({
               badged: true,
               confirmLabel: Constants.todoTypeToConfirmLabel[todoType],
-              dismissable: Constants.todoTypeToDismissable[todoType],
               icon: Constants.todoTypeToIcon[todoType],
-              instructions: Constants.todoTypeToInstructions[todoType],
+              instructions,
               todoType,
               type: 'todo',
             })

--- a/shared/constants/people.tsx
+++ b/shared/constants/people.tsx
@@ -13,6 +13,8 @@ export const todoTypeEnumToType = invert(RPCTypes.HomeScreenTodoType) as {
 }
 
 export const todoTypes: {[K in Types.TodoType]: Types.TodoType} = {
+  addEmail: 'addEmail',
+  addPhoneNumber: 'addPhoneNumber',
   annoncementPlaceholder: 'annoncementPlaceholder', // misspelled in protocol
   avatarTeam: 'avatarTeam',
   avatarUser: 'avatarUser',
@@ -22,14 +24,19 @@ export const todoTypes: {[K in Types.TodoType]: Types.TodoType} = {
   folder: 'folder',
   follow: 'follow',
   gitRepo: 'gitRepo',
+  legacyEmailVisibility: 'legacyEmailVisibility',
   none: 'none',
   paperkey: 'paperkey',
   proof: 'proof',
   team: 'team',
   teamShowcase: 'teamShowcase',
+  verifyAllEmail: 'verifyAllEmail',
+  verifyAllPhoneNumber: 'verifyAllPhoneNumber',
 }
 
 export const todoTypeToInstructions: {[K in Types.TodoType]: string} = {
+  addEmail: 'Add an email address for security purposes, and to get important notifications.',
+  addPhoneNumber: 'Add your phone number so your friends can find you.',
   annoncementPlaceholder: '',
   avatarTeam: 'NEW! Change your team’s avatar from within the Keybase app.',
   avatarUser: 'NEW! Change your avatar from within the Keybase app.',
@@ -43,7 +50,8 @@ export const todoTypeToInstructions: {[K in Types.TodoType]: string} = {
   follow:
     'Follow at least one person on Keybase. A "follow" is a signed snapshot of someone. It strengthens Keybase and your own security.',
   gitRepo:
-    'Create an encrypted Git repository! Only you will be able to decrypt any of it. And it’s so easy!',
+    'Create an encrypted Git repository! Only you (and teammates) will be able to decrypt any of it. And it’s so easy!',
+  legacyEmailVisibility: '',
   none: '',
   paperkey:
     'Please make a paper key. Unlike your account password, paper keys can provision new devices and recover data, for ultimate safety.',
@@ -51,8 +59,12 @@ export const todoTypeToInstructions: {[K in Types.TodoType]: string} = {
   team:
     'Create a team! Keybase team chats are end-to-end encrypted - unlike Slack - and work for any kind of group, from casual friends to large communities.',
   teamShowcase: `Tip: Keybase team chats are private, but you can choose to publish that you're an admin. Check out the team settings on any team you manage.`,
+  verifyAllEmail: '',
+  verifyAllPhoneNumber: '',
 }
 export const todoTypeToConfirmLabel: {[K in Types.TodoType]: string} = {
+  addEmail: 'Add email',
+  addPhoneNumber: 'Add number',
   annoncementPlaceholder: '',
   avatarTeam: 'Edit team avatar',
   avatarUser: 'Edit avatar',
@@ -60,31 +72,21 @@ export const todoTypeToConfirmLabel: {[K in Types.TodoType]: string} = {
   chat: 'Start a chat',
   device: isMobile ? 'Get the download link' : 'Get the app',
   folder: 'Open a private folder',
-  follow: 'Browse people',
+  follow: '',
   gitRepo: isMobile ? 'Create a repo' : 'Create a personal git repo',
+  legacyEmailVisibility: '',
   none: '',
   paperkey: 'Create a paper key',
   proof: 'Prove your identities',
   team: 'Create a team!',
   teamShowcase: 'Set publicity settings',
+  verifyAllEmail: 'Verify',
+  verifyAllPhoneNumber: 'Verify',
 }
-export const todoTypeToDismissable: {[K in Types.TodoType]: boolean} = {
-  annoncementPlaceholder: false,
-  avatarTeam: false,
-  avatarUser: false,
-  bio: false,
-  chat: true,
-  device: true,
-  folder: true,
-  follow: true,
-  gitRepo: true,
-  none: false,
-  paperkey: false,
-  proof: true,
-  team: true,
-  teamShowcase: true,
-}
+
 export const todoTypeToIcon: {[K in Types.TodoType]: IconType} = {
+  addEmail: 'icon-onboarding-email-add-48',
+  addPhoneNumber: 'icon-onboarding-phone-48',
   annoncementPlaceholder: 'iconfont-close',
   avatarTeam: 'icon-onboarding-team-avatar-48',
   avatarUser: 'icon-onboarding-user-avatar-48',
@@ -94,12 +96,32 @@ export const todoTypeToIcon: {[K in Types.TodoType]: IconType} = {
   folder: 'icon-onboarding-folder-48',
   follow: 'icon-onboarding-follow-48',
   gitRepo: 'icon-onboarding-git-48',
+  legacyEmailVisibility: 'icon-onboarding-email-searchable-48',
   none: 'iconfont-close',
   paperkey: 'icon-onboarding-paper-key-48',
   proof: 'icon-onboarding-proofs-48',
   team: 'icon-onboarding-team-48',
   teamShowcase: 'icon-onboarding-team-publicity-48',
+  verifyAllEmail: 'icon-onboarding-email-verify-48',
+  verifyAllPhoneNumber: 'icon-onboarding-number-verify-48',
 } as const
+
+export function makeDescriptionForTodoItem(todo: RPCTypes.HomeScreenTodo) {
+  const T = RPCTypes.HomeScreenTodoType
+  switch (todo.t) {
+    case T.legacyEmailVisibility:
+      return `Allow friends to find you using *${todo.legacyEmailVisibility}*`
+    case T.verifyAllEmail:
+      return `Your email address *${todo.verifyAllEmail}* is unverified.`
+    case T.verifyAllPhoneNumber:
+      return `Your number *${todo.verifyAllPhoneNumber}* is unverified.`
+    default:
+      // @ts-ignore this variant compilation seems wrong. ts todo.t can only be
+      // of 3 types but that's not what we do in avdl.
+      const type = todoTypeEnumToType[todo.t]
+      return todoTypeToInstructions[type]
+  }
+}
 
 export const reduceRPCItemToPeopleItem = (
   list: I.List<Types.PeopleScreenItem>,
@@ -108,15 +130,14 @@ export const reduceRPCItemToPeopleItem = (
   const badged = item.badged
   if (item.data.t === RPCTypes.HomeScreenItemType.todo) {
     // Todo item
-    // @ts-ignore todo is actually typed as void?
+    // @ts-ignore todo is actually typed as void? (variant miscompilation)
     const todoType = todoTypeEnumToType[(item.data.todo && item.data.todo.t) || 0]
     return list.push(
       makeTodo({
         badged: badged,
         confirmLabel: todoTypeToConfirmLabel[todoType],
-        dismissable: todoTypeToDismissable[todoType],
         icon: todoTypeToIcon[todoType],
-        instructions: todoTypeToInstructions[todoType],
+        instructions: makeDescriptionForTodoItem(item.data.todo),
         todoType,
         type: 'todo',
       })

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1449,6 +1449,11 @@ export enum HomeScreenTodoType {
   teamShowcase = 10,
   avatarUser = 11,
   avatarTeam = 12,
+  addPhoneNumber = 13,
+  verifyAllPhoneNumber = 14,
+  verifyAllEmail = 15,
+  legacyEmailVisibility = 16,
+  addEmail = 17,
   annoncementPlaceholder = 10000,
 }
 
@@ -2286,7 +2291,7 @@ export type HomeScreenItemID = String
 export type HomeScreenPeopleNotification = {t: HomeScreenPeopleNotificationType.followed; followed: HomeScreenPeopleNotificationFollowed | null} | {t: HomeScreenPeopleNotificationType.followedMulti; followedMulti: HomeScreenPeopleNotificationFollowedMulti | null}
 export type HomeScreenPeopleNotificationFollowed = {readonly followTime: Time; readonly followedBack: Boolean; readonly user: UserSummary}
 export type HomeScreenPeopleNotificationFollowedMulti = {readonly followers?: Array<HomeScreenPeopleNotificationFollowed> | null; readonly numOthers: Int}
-export type HomeScreenTodo = void
+export type HomeScreenTodo = {t: HomeScreenTodoType.verifyAllPhoneNumber; verifyAllPhoneNumber: PhoneNumber | null} | {t: HomeScreenTodoType.verifyAllEmail; verifyAllEmail: EmailAddress | null} | {t: HomeScreenTodoType.legacyEmailVisibility; legacyEmailVisibility: EmailAddress | null}
 export type HomeUserSummary = {readonly uid: UID; readonly username: String; readonly bio: String; readonly fullName: String; readonly pics?: Pics | null}
 export type Identify2Res = {readonly upk: UserPlusKeys; readonly identifiedAt: Time; readonly trackBreaks?: IdentifyTrackBreaks | null}
 export type Identify2ResUPK2 = {readonly upk: UserPlusKeysV2AllIncarnations; readonly identifiedAt: Time; readonly trackBreaks?: IdentifyTrackBreaks | null}

--- a/shared/people/index.shared.tsx
+++ b/shared/people/index.shared.tsx
@@ -21,9 +21,10 @@ export const itemToComponent: (item: Types.PeopleScreenItem, props: Props) => Re
           todoType={item.todoType}
           instructions={item.instructions}
           confirmLabel={item.confirmLabel}
-          dismissable={item.dismissable}
           icon={item.icon}
           key={item.todoType}
+          subText={''}
+          buttons={[]}
         />
       )
     case 'notification':

--- a/shared/people/todo/container.tsx
+++ b/shared/people/todo/container.tsx
@@ -46,7 +46,7 @@ function makeDefaultButtons(onConfirm, confirmLabel, onDismiss?, dismissLabel?) 
 const AddEmailConnector = connect(
   mapStateToProps,
   dispatch => ({
-    onConfirm: () => {},
+    onConfirm: () => {}, // TODO: See Y2K-187.
     onDismiss: onSkipTodo('addEmail', dispatch),
   }),
   (_, d, o: TodoOwnProps) => ({
@@ -58,7 +58,7 @@ const AddEmailConnector = connect(
 const AddPhoneNumberConnector = connect(
   mapStateToProps,
   dispatch => ({
-    onConfirm: () => {},
+    onConfirm: () => {}, // TODO: See Y2K-187.
     onDismiss: onSkipTodo('addPhoneNumber', dispatch),
   }),
   (_, d, o: TodoOwnProps) => ({
@@ -252,7 +252,7 @@ const TeamShowcaseConnector = connect(
 const VerifyAllEmailConnector = connect(
   mapStateToProps,
   dispatch => ({
-    onConfirm: () => {},
+    onConfirm: () => {}, // TODO: See Y2K-187.
     onManage: () => dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.settingsTab})),
   }),
   (stateProps, dispatchProps, ownProps: TodoOwnProps) => ({
@@ -275,7 +275,7 @@ const VerifyAllEmailConnector = connect(
 const VerifyAllPhoneNumberConnector = connect(
   mapStateToProps,
   dispatch => ({
-    onConfirm: () => {},
+    onConfirm: () => {}, // TODO: See Y2K-187.
     onManage: () => dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.settingsTab})),
   }),
   (stateProps, dispatchProps, ownProps: TodoOwnProps) => ({
@@ -298,7 +298,7 @@ const VerifyAllPhoneNumberConnector = connect(
 const LegacyEmailVisibilityConnector = connect(
   mapStateToProps,
   dispatch => ({
-    onConfirm: () => {},
+    onConfirm: () => {}, // TODO: See Y2K-187.
     onDismiss: onSkipTodo('legacyEmailVisibility', dispatch),
   }),
   (stateProps, dispatchProps, ownProps: TodoOwnProps) => ({

--- a/shared/people/todo/index.stories.tsx
+++ b/shared/people/todo/index.stories.tsx
@@ -1,129 +1,199 @@
 import * as React from 'react'
 import {storiesOf, action} from '../../stories/storybook'
-import {Task} from '.'
+import {Task, TaskButton} from '.'
 import {Provider as SearchBarProvider} from '../../profile/search/index.stories'
+import {
+  todoTypes,
+  todoTypeToConfirmLabel,
+  todoTypeToIcon,
+  makeDescriptionForTodoItem,
+} from '../../constants/people'
+import * as RPCTypes from '../../constants/types/rpc-gen'
 
-const actionProps = {
-  onConfirm: action('onConfirm'),
-  onDismiss: action('onDismiss'),
-} as const
+const defaultButtons = (label, dismissLabel?) => {
+  const ret = [
+    {
+      label: label,
+      onClick: action('onConfirm'),
+    },
+  ] as Array<TaskButton>
+  if (dismissLabel) {
+    ret.push({
+      label: dismissLabel,
+      mode: 'Secondary',
+      onClick: action('onDismiss'),
+    })
+  }
+  return ret
+}
 
 const avatarTeamTaskProps = {
   badged: true,
-  confirmLabel: 'Edit team avatar',
-  dismissable: false,
-  icon: 'icon-onboarding-team-avatar-32',
+  buttons: defaultButtons('Edit team avatar'),
+  icon: 'icon-onboarding-team-avatar-48',
   instructions: 'NEW! Change your team’s avatar from within the Keybase app.',
-  ...actionProps,
 } as const
 
 const avatarUserTaskProps = {
   badged: true,
-  confirmLabel: 'Edit avatar',
-  dismissable: false,
-  icon: 'icon-onboarding-user-avatar-32',
+  buttons: defaultButtons('Edit avatar'),
+  icon: 'icon-onboarding-user-avatar-48',
   instructions: 'NEW! Change your photo from within the Keybase app.',
-  ...actionProps,
 } as const
 
 const bioTaskProps = {
   badged: true,
-  confirmLabel: 'Edit profile',
-  dismissable: false,
-  icon: 'icon-onboarding-user-info-32',
+  buttons: defaultButtons('Edit profile'),
+  icon: 'icon-onboarding-user-info-48',
   instructions: 'Add your name, bio, and location to complete your profile.',
-  ...actionProps,
 } as const
 
 const proofTaskProps = {
   badged: true,
-  confirmLabel: 'Prove your identities',
-  dismissable: true,
-  icon: 'icon-onboarding-proofs-32',
+  buttons: defaultButtons('Prove your identities', 'Later'),
+  icon: 'icon-onboarding-proofs-48',
   instructions:
     'Add some proofs to your profile. The more you have, the stronger your cryptographic identity.',
-  ...actionProps,
 } as const
 
 const installTaskProps = {
   badged: true,
-  confirmLabel: 'Get the download link',
-  dismissable: true,
-  icon: 'icon-onboarding-phone-32',
+  buttons: defaultButtons('Get the download link', 'Later'),
+  icon: 'icon-onboarding-phone-48',
   instructions: 'Install Keybase on your phone. Until you have at least 2 devices, you risk losing data.',
-  ...actionProps,
 } as const
 
 const followTaskProps = {
   badged: true,
-  confirmLabel: 'Browse people',
-  dismissable: true,
-  icon: 'icon-onboarding-follow-32',
+  buttons: [
+    {
+      label: 'Follow later',
+      mode: 'Secondary',
+      onClick: action('onDismiss'),
+    },
+  ] as Array<TaskButton>,
+  icon: 'icon-onboarding-follow-48',
   instructions:
     'Follow at least one person on Keybase. A "follow" is a signed snapshot of someone. It strengthens Keybase and your own security.',
-  ...actionProps,
 } as const
 
 const chatTaskProps = {
   badged: true,
-  confirmLabel: 'Start a chat',
-  dismissable: true,
-  icon: 'icon-onboarding-chat-32',
+  buttons: defaultButtons('Start a chat', 'Later'),
+  icon: 'icon-onboarding-chat-48',
   instructions: 'Start a chat! All conversations on Keybase are end-to-end encrypted.',
-  ...actionProps,
 } as const
 
 const paperKeyTaskProps = {
   badged: true,
-  confirmLabel: 'Create a paper key',
-  dismissable: false,
-  icon: 'icon-onboarding-paper-key-32',
+  buttons: defaultButtons('Create a paper key'),
+  icon: 'icon-onboarding-paper-key-48',
   instructions:
     'Please make a paper key. Unlike your account password, paper keys can provision new devices and recover data, for ultimate safety.',
-  ...actionProps,
 } as const
 
 const teamTaskProps = {
   badged: true,
-  confirmLabel: 'Create a team',
-  dismissable: true,
-  icon: 'icon-onboarding-team-32',
+  buttons: defaultButtons('Create a team', 'Later'),
+  icon: 'icon-onboarding-team-48',
   instructions:
     'Create a team! Keybase team chats are end-to-end encrypted - unlike Slack - and work for any kind of group, from casual friends to large communities.',
-  ...actionProps,
 } as const
 
 const folderTaskProps = {
   badged: true,
-  confirmLabel: 'Open a private folder',
-  dismissable: true,
-  icon: 'icon-onboarding-folder-32',
+  buttons: defaultButtons('Open a private folder', 'Later'),
+  icon: 'icon-onboarding-folder-48',
   instructions:
     'Open an encrypted private folder with someone! They’ll only get notified once you drop files in it.',
-  ...actionProps,
 } as const
 
 const gitTaskProps = {
   badged: true,
-  confirmLabel: 'Create a personal git repo',
-  dismissable: true,
-  icon: 'icon-onboarding-git-32',
+  buttons: [
+    {
+      label: 'Create a personal repo',
+      onClick: action('onPersonalRepo'),
+    },
+    {
+      label: 'Create a team repo',
+      onClick: action('onTeamRepo'),
+    },
+    {
+      label: 'Later',
+      mode: 'Secondary',
+      onClick: action('onDismiss'),
+    },
+  ] as Array<TaskButton>,
+  icon: 'icon-onboarding-git-48',
   instructions:
-    'Create an encrypted Git repository! Only you will be able to decrypt any of it. And it’s so easy!',
-  ...actionProps,
+    'Create an encrypted Git repository! Only you (and teammates) will be able to decrypt any of it. And it’s so easy!',
 } as const
 
 const publicityTaskProps = {
   badged: true,
-  confirmLabel: 'Set publicity settings',
-  dismissable: true,
-  icon: 'icon-onboarding-team-publicity-32',
+  buttons: defaultButtons('Set publicity settings', 'Later'),
+  icon: 'icon-onboarding-team-publicity-48',
   instructions: `Tip: Keybase team chats are private, but you can choose to publish that you're an admin. Check out “Publicity settings" on any team you manage.`,
-  ...actionProps,
+} as const
+
+const verifyEmailProps = {
+  badged: true,
+  buttons: [
+    {
+      label: 'Verify',
+      onClick: action('onConfirm'),
+      type: 'Success',
+    },
+    {
+      label: 'Manage emails',
+      mode: 'Secondary',
+      onClick: action('onManage'),
+    },
+  ] as Array<TaskButton>,
+  icon: 'icon-onboarding-email-verify-48',
+  instructions: `Your email address *test@example.com* is unverified.`,
+} as const
+
+const verifyPhoneNumberProps = {
+  badged: true,
+  buttons: [
+    {
+      label: 'Verify',
+      onClick: action('onConfirm'),
+      type: 'Success',
+    },
+    {
+      label: 'Manage numbers',
+      mode: 'Secondary',
+      onClick: action('onManage'),
+    },
+  ] as Array<TaskButton>,
+  icon: 'icon-onboarding-number-verify-48',
+  instructions: `Your number *+1555000111* is unverified.`,
+} as const
+
+const legacyEmailVisibilityProps = {
+  badged: true,
+  buttons: [
+    {
+      label: 'Make searchable',
+      onClick: action('onConfirm'),
+      type: 'Success',
+    },
+    {
+      label: 'No',
+      mode: 'Secondary',
+      onClick: action('onDismiss'),
+    },
+  ] as Array<TaskButton>,
+  icon: 'icon-onboarding-email-searchable-48',
+  instructions: `Allow friends to find you using *test@example.com*`,
+  subText: 'Your email will never appear on your public profile.',
 } as const
 
 const load = () => {
-  storiesOf('People/Todos', module)
+  const stories = storiesOf('People/Todos', module)
     .addDecorator(SearchBarProvider)
     .add('Edit team avatar', () => <Task {...avatarTeamTaskProps} />)
     .add('Edit avatar', () => <Task {...avatarUserTaskProps} />)
@@ -138,6 +208,9 @@ const load = () => {
     .add('Make a folder', () => <Task {...folderTaskProps} />)
     .add('Make a git', () => <Task {...gitTaskProps} />)
     .add('Set publicity', () => <Task {...publicityTaskProps} />)
+    .add('Verify phone number', () => <Task {...verifyPhoneNumberProps} />)
+    .add('Verify email', () => <Task {...verifyEmailProps} />)
+    .add('Legacy email discoverability', () => <Task {...legacyEmailVisibilityProps} />)
 }
 
 export default load

--- a/shared/people/todo/index.tsx
+++ b/shared/people/todo/index.tsx
@@ -3,37 +3,34 @@ import PeopleItem from '../item'
 import * as Kb from '../../common-adapters'
 import PeopleSearch from '../../profile/search/bar-container'
 import * as Styles from '../../styles'
+import {Props as ButtonProps} from '../../common-adapters/button'
+
+export type TaskButton = {
+  label: string
+  onClick: () => void
+  type?: ButtonProps['type']
+  mode?: ButtonProps['mode']
+}
 
 export type Props = {
   badged: boolean
   icon: Kb.IconType
   instructions: string
-  confirmLabel: string
-  dismissable: boolean
-  onConfirm: () => void
-  onDismiss: () => void
+  subText?: string
   showSearchBar?: boolean
+  buttons: Array<TaskButton>
 }
 
 export const Task = (props: Props) => (
   <PeopleItem format="multi" badged={props.badged} icon={<Kb.Icon type={props.icon} />}>
-    <Kb.Text type="Body" style={styles.instructions}>
-      {props.instructions}
-    </Kb.Text>
+    <Kb.Markdown style={styles.instructions}>{props.instructions}</Kb.Markdown>
+    {props.subText && <Kb.Text type="BodySmall">{props.subText}</Kb.Text>}
     <Kb.Box style={styles.actionContainer}>
-      {props.showSearchBar ? (
-        <PeopleSearch style={styles.search} />
-      ) : (
-        <Kb.Button
-          small={true}
-          label={props.confirmLabel}
-          onClick={props.onConfirm}
-          style={{marginRight: Styles.globalMargins.small}}
-        />
-      )}
-      {props.dismissable && (
-        <Kb.Button small={true} label="Later" mode="Secondary" onClick={props.onDismiss} />
-      )}
+      {props.showSearchBar && <PeopleSearch style={styles.search} />}
+      {props.buttons.length > 0 &&
+        props.buttons.map(b => (
+          <Kb.Button key={b.label} small={true} style={{marginRight: Styles.globalMargins.tiny}} {...b} />
+        ))}
     </Kb.Box>
   </PeopleItem>
 )

--- a/shared/settings/landing/container.tsx
+++ b/shared/settings/landing/container.tsx
@@ -11,16 +11,21 @@ const mapStateToProps = state => {
   const {emails} = state.settings.email
   const {rememberPassword} = state.settings.password
   let accountProps
+  let email = ''
+  let isVerified = false
   if (emails && emails.first()) {
-    const {email, isVerified} = emails.first()
-    accountProps = {
-      email,
-      hasRandomPW: state.settings.password.randomPW,
-      isVerified,
-      onChangeEmail: () => logger.debug('todo'),
-      onChangePassword: () => logger.debug('todo'),
-      rememberPassword,
-    }
+    const firstEmail = emails.first()
+    email = firstEmail.email
+    isVerified = firstEmail.isVerified
+  }
+
+  accountProps = {
+    email,
+    hasRandomPW: state.settings.password.randomPW,
+    isVerified,
+    onChangeEmail: () => logger.debug('todo'),
+    onChangePassword: () => logger.debug('todo'),
+    rememberPassword,
   }
 
   // const {

--- a/shared/settings/landing/index.desktop.tsx
+++ b/shared/settings/landing/index.desktop.tsx
@@ -281,14 +281,13 @@ function AccountFirstEmail({onChangeEmail}: {onChangeEmail: () => void}) {
       style={{
         ...globalStyles.flexBoxRow,
         alignItems: 'center',
-        justifyContent: 'space-between',
         minHeight: ROW_HEIGHT,
       }}
     >
-      <Text type="Body">
+      <Text type="Body" style={{marginRight: globalMargins.xtiny}}>
         Email address:
-        <Button label="Add an email address" type="Dim" small={true} onClick={onChangeEmail} />
       </Text>
+      <Button label="Add an email address" type="Dim" small={true} onClick={onChangeEmail} />
     </Box>
   )
 }


### PR DESCRIPTION
This PR adds 5 new todo items: "add phone number", "verify phone number", "verify email", "make email discoverable", and "add email".

To implement these, the following things had to change:
- TODOs now can carry additional information besides todo type. This depends on the todo type. For example, "verify phone number" item will carry the phone number that's to be verified. This data does not come from the server, but is fetched by service when home screen is being prepared. See `go/home/userdata.go`.
- The number of buttons and buton labels vary between the TODOs now. Some also have different styles than the others. Instead of adding more constants in `shared/constants/people.tsx`, `buttons: Array<TaskButton>` was added to `TodoOwnProps`. `todo/container.tsx` will defines buttons for each todo type when defining the todo connectors. Therefore, `todoTypeToDismissable` was redundant and was removed. TODO is dismissable when the connector has a dismiss button.
- `Task` component now has a `subText` (needed for `legacyEmailDiscoverability` todo), and the text itself is a `Kb.Markdown`. This was needed because some TODO items needs the text formatted, e.g. bold phone number or email.