### PR TITLE
add unread payments to newPayments for blue highlighting

### DIFF
--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -99,6 +99,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
       )
     case WalletsGen.recentPaymentsReceived:
       const newPayments = I.Map(action.payload.payments.map(p => [p.id, Constants.makePayment().merge(p)]))
+      const unreadPaymentIDs = I.Set.fromKeys(newPayments.filter(p => p.unread))
       return state
         .updateIn(['paymentsMap', action.payload.accountID], (paymentsMap = I.Map()) =>
           paymentsMap.merge(newPayments)
@@ -108,6 +109,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
           cursor => cursor || action.payload.paymentCursor
         )
         .setIn(['paymentOldestUnreadMap', action.payload.accountID], action.payload.oldestUnread)
+        .setIn(['newPayments', action.payload.accountID], unreadPaymentIDs)
     case WalletsGen.displayCurrenciesReceived:
       return state.merge({currencies: I.List(action.payload.currencies)})
     case WalletsGen.displayCurrencyReceived: {


### PR DESCRIPTION
unread payments (currently the server is only sending a subset of the expected ones) are supposed to be highlighted in blue above the orange line. It looked to me like all the code was there to highlight them, but nothing was setting new payments as actually being `new` so none were highlighted. 
