### PR TITLE
teams: precheck for sig3 posts

### DIFF
--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -33,6 +33,14 @@ func NewLoaderPackage(mctx libkb.MetaContext, id keybase1.TeamID, getter func() 
 	return ret, nil
 }
 
+func NewLoaderPackageForPrecheck(mctx libkb.MetaContext, id keybase1.TeamID, data *keybase1.HiddenTeamChain) *LoaderPackage {
+	return &LoaderPackage{
+		id:      id,
+		data:    data,
+		isFresh: true,
+	}
+}
+
 // newLoaderPackage creates an object used to load the hidden team chain along with the
 // slow or fast team loader. It manages internal state during the loading process. Pass an
 // encryption KID from the main chain for authentication purposes, that we can prove to the server
@@ -97,7 +105,7 @@ func (l *LoaderPackage) checkPrev(mctx libkb.MetaContext, first sig3.Generic) (e
 	q := first.Seqno()
 	prev := first.Prev()
 	if (q == keybase1.Seqno(1)) != (prev == nil) {
- 		return NewLoaderError("bad link; seqno=%d, prev=%v (want 1 and nil or >1 and non-nil)", q, prev)
+		return NewLoaderError("bad link; seqno=%d, prev=%v (want 1 and nil or >1 and non-nil)", q, prev)
 	}
 	if q == keybase1.Seqno(1) {
 		return nil

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -358,7 +358,7 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 		mctx.Debug("Box auditor feature flagged off; not checking jail during team load...")
 	}
 
-	return &ret.team, &ret.hidden, nil
+	return &ret.team, ret.hidden, nil
 }
 
 func (l *TeamLoader) checkArg(ctx context.Context, lArg keybase1.LoadTeamArg) error {
@@ -415,12 +415,12 @@ type load2ArgT struct {
 
 type load2ResT struct {
 	team      keybase1.TeamData
-	hidden    keybase1.HiddenTeamChain
+	hidden    *keybase1.HiddenTeamChain
 	didRepoll bool
 }
 
 func (l load2ResT) teamShim() *TeamShim {
-	return &TeamShim{Data: &l.team, Hidden: &l.hidden}
+	return &TeamShim{Data: &l.team, Hidden: l.hidden}
 }
 
 // Load2 does the rest of the work loading a team.
@@ -895,7 +895,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	}
 
 	if hd := hiddenPackage.ChainData(); hd != nil {
-		load2res.hidden = *hd
+		load2res.hidden = hd
 	}
 
 	return &load2res, nil

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -584,8 +584,15 @@ func (t *Team) rotatePostHidden(ctx context.Context, section SCTeamSection, mr *
 		return err
 	}
 
+	links := []libkb.SigMultiItem{*smi}
+
+	err = t.precheckLinksToPost(ctx, links)
+	if err != nil {
+		return err
+	}
+
 	// Combine the "sig multi item" above with the various off-chain items, like boxes.
-	payload := t.sigPayload([]libkb.SigMultiItem{*smi}, payloadArgs)
+	payload := t.sigPayload(links, payloadArgs)
 
 	// Post the changes up to the server
 	err = t.postMulti(mctx, payload)


### PR DESCRIPTION
- as in the main chain, check that a sig3 post to the hidden chain will fail the checks we use in the loader
  - (but not the seed checks, since that requires data not in the loader at this time)