### PR TITLE
data: a couple enhancements to `PathPartString`

### DIFF
--- a/go/kbfs/data/path_part_string.go
+++ b/go/kbfs/data/path_part_string.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	prefixToSkipObfsucation = ".kbfs_"
+	prefixFileInfo          = ".kbfs_fileinfo_"
 	tarGzSuffix             = ".tar.gz"
 
 	// extRestoreMaxLen specifies the max length of an extension, such
@@ -56,13 +57,20 @@ func NewPathPartString(
 }
 
 func (pps PathPartString) String() string {
-	if strings.HasPrefix(pps.plaintext, prefixToSkipObfsucation) ||
-		pps.obfuscator == nil {
-		return pps.plaintext
+	prefix := ""
+	p := pps.plaintext
+	if pps.obfuscator == nil {
+		return p
+	} else if strings.HasPrefix(p, prefixFileInfo) {
+		// Obfuscate the suffix part for fileInfo paths.
+		prefix = prefixFileInfo
+		p = strings.TrimPrefix(p, prefix)
+	} else if strings.HasPrefix(p, prefixToSkipObfsucation) {
+		return p
 	}
 
-	ob := pps.obfuscator.Obfuscate(pps.plaintext)
-	return ob + pps.ext
+	ob := pps.obfuscator.Obfuscate(p)
+	return prefix + ob + pps.ext
 }
 
 // Plaintext returns the plaintext underlying this string part.

--- a/go/kbfs/data/path_part_string_test.go
+++ b/go/kbfs/data/path_part_string_test.go
@@ -99,6 +99,30 @@ func TestPathPartStringEquality(t *testing.T) {
 
 }
 
+func TestPathPartStringPrefix(t *testing.T) {
+	secret := NodeObfuscatorSecret([]byte{1, 2, 3, 4})
+	no := NewNodeObfuscator(secret)
+
+	t.Log("Check that special .kbfs_ files are ignored")
+	status := ".kbfs_status"
+	pps1 := NewPathPartString(status, no)
+	ob1 := pps1.String()
+	require.Equal(t, status, ob1)
+
+	t.Log("Check that .kbfs_fileinfo files are still partially obfuscated")
+	fileinfo := ".kbfs_fileinfo_test.txt"
+	pps2 := NewPathPartString(fileinfo, no)
+	ob2 := pps2.String()
+	require.True(t, strings.HasPrefix(ob2, ".kbfs_fileinfo_"))
+	require.True(t, strings.HasSuffix(ob2, ".txt"))
+	words2 := strings.Split(
+		strings.TrimSuffix(strings.TrimPrefix(ob2, ".kbfs_fileinfo_"), ".txt"),
+		separator)
+	require.Len(t, words2, 2)
+	require.True(t, libkb.ValidSecWord(words2[0]), words2[0])
+	require.True(t, libkb.ValidSecWord(words2[1]), words2[1])
+}
+
 func TestPathPartStringMarshal(t *testing.T) {
 	secret := NodeObfuscatorSecret([]byte{1, 2, 3, 4})
 	no := NewNodeObfuscator(secret)

--- a/go/kbfs/data/path_part_string_test.go
+++ b/go/kbfs/data/path_part_string_test.go
@@ -61,8 +61,8 @@ func TestPathPartStringBasic(t *testing.T) {
 	require.True(t, strings.HasSuffix(ob5, cSuffix))
 	words5 := strings.Split(strings.Replace(ob5, cSuffix, "", 1), separator)
 	require.Len(t, words5, 2)
-	require.True(t, libkb.ValidSecWord(words5[0]), words5[0])
-	require.True(t, libkb.ValidSecWord(words5[1]), words5[1])
+	require.Equal(t, words2[0], words5[0])
+	require.Equal(t, words2[1], words5[1])
 }
 
 func TestPathPartStringEquality(t *testing.T) {
@@ -96,7 +96,6 @@ func TestPathPartStringEquality(t *testing.T) {
 	pps1 = NewPathPartString("test", no)
 	pps2 = NewPathPartString("test", no2)
 	require.False(t, pps1 == pps2)
-
 }
 
 func TestPathPartStringPrefix(t *testing.T) {
@@ -121,6 +120,19 @@ func TestPathPartStringPrefix(t *testing.T) {
 	require.Len(t, words2, 2)
 	require.True(t, libkb.ValidSecWord(words2[0]), words2[0])
 	require.True(t, libkb.ValidSecWord(words2[1]), words2[1])
+
+	t.Log("Check file info with a conflicted suffix")
+	cSuffix := ".conflicted (alice's device copy 2019-06-10).txt"
+	pps3 := NewPathPartString(".kbfs_fileinfo_test"+cSuffix, no)
+	ob3 := pps3.String()
+	require.True(t, strings.HasPrefix(ob3, ".kbfs_fileinfo_"))
+	require.True(t, strings.HasSuffix(ob3, cSuffix))
+	words3 := strings.Split(
+		strings.TrimSuffix(strings.TrimPrefix(ob3, ".kbfs_fileinfo_"), cSuffix),
+		separator)
+	require.Len(t, words3, 2)
+	require.Equal(t, words2[0], words3[0])
+	require.Equal(t, words2[1], words3[1])
 }
 
 func TestPathPartStringMarshal(t *testing.T) {


### PR DESCRIPTION
1. `PathPartString` should still obfuscate fileinfo paths
2. Don't obfuscate over conflict suffixes, since it's nice to be able to see in the logs which conflict file corresponds to which actual file.