### PR TITLE
Tweaks on Teams banner

### DIFF
--- a/shared/teams/main/banner.tsx
+++ b/shared/teams/main/banner.tsx
@@ -12,14 +12,14 @@ const Banner = ({onReadMore, onHideChatBanner}: Props) => (
     <Kb.Icon type={Styles.isMobile ? 'icon-illustration-teams-216' : 'icon-illustration-teams-180'} />
     <Kb.Box style={styles.containerHeader}>
       <Kb.Text negative={true} type="Header" style={styles.header}>
-        Now supporting teams!
+        Create a team on Keybase
       </Kb.Text>
       <Kb.Text center={Styles.isMobile} negative={true} type="BodySmallSemibold" style={styles.text}>
         Keybase team chats are encrypted - unlike Slack - and work for any size group, from casual friends to
         large communities.
       </Kb.Text>
       <Kb.Text negative={true} type="BodySmallSemiboldPrimaryLink" className="underline" onClick={onReadMore}>
-        Read our announcement
+        Read more
       </Kb.Text>
     </Kb.Box>
     <Kb.Box style={styles.closeIconContainer}>
@@ -56,16 +56,18 @@ const styles = Styles.styleSheetCreate({
       alignItems: 'center',
       backgroundColor: Styles.globalColors.blue,
       flexShrink: 0,
-      justifyContent: 'center',
       position: 'relative',
       width: '100%',
     },
     isElectron: {
       ...Styles.globalStyles.flexBoxRow,
       height: 212,
+      justifyContent: 'flex-start',
+      paddingLeft: 48,
     },
     isMobile: {
       ...Styles.globalStyles.flexBoxColumn,
+      justifyContent: 'center',
       padding: 24,
     },
   }),

--- a/shared/teams/main/banner.tsx
+++ b/shared/teams/main/banner.tsx
@@ -9,7 +9,10 @@ export type Props = {
 
 const Banner = ({onReadMore, onHideChatBanner}: Props) => (
   <Kb.Box style={styles.containerBanner}>
-    <Kb.Icon type={Styles.isMobile ? 'icon-illustration-teams-216' : 'icon-illustration-teams-180'} />
+    <Kb.Icon
+      style={styles.illustration}
+      type={Styles.isMobile ? 'icon-illustration-teams-216' : 'icon-illustration-teams-180'}
+    />
     <Kb.Box style={styles.containerHeader}>
       <Kb.Text negative={true} type="Header" style={styles.header}>
         Create a team on Keybase
@@ -63,7 +66,6 @@ const styles = Styles.styleSheetCreate({
       ...Styles.globalStyles.flexBoxRow,
       height: 212,
       justifyContent: 'flex-start',
-      paddingLeft: 48,
     },
     isMobile: {
       ...Styles.globalStyles.flexBoxColumn,
@@ -76,8 +78,7 @@ const styles = Styles.styleSheetCreate({
       ...Styles.globalStyles.flexBoxColumn,
     },
     isElectron: {
-      marginLeft: Styles.globalMargins.medium,
-      maxWidth: 330,
+      maxWidth: 360,
     },
     isMobile: {
       alignItems: 'center',
@@ -87,6 +88,12 @@ const styles = Styles.styleSheetCreate({
     marginBottom: 15,
     marginTop: 15,
   },
+  illustration: Styles.platformStyles({
+    isElectron: {
+      paddingLeft: Styles.globalMargins.large,
+      paddingRight: Styles.globalMargins.large,
+    },
+  }),
   text: Styles.platformStyles({
     common: {
       marginBottom: Styles.globalMargins.small,

--- a/shared/teams/main/banner.tsx
+++ b/shared/teams/main/banner.tsx
@@ -98,6 +98,9 @@ const styles = Styles.styleSheetCreate({
     common: {
       marginBottom: Styles.globalMargins.small,
     },
+    isElectron: {
+      marginRight: Styles.globalMargins.large,
+    },
   }),
 })
 

--- a/shared/teams/main/banner.tsx
+++ b/shared/teams/main/banner.tsx
@@ -66,6 +66,7 @@ const styles = Styles.styleSheetCreate({
       ...Styles.globalStyles.flexBoxRow,
       height: 212,
       justifyContent: 'flex-start',
+      paddingRight: Styles.globalMargins.large,
     },
     isMobile: {
       ...Styles.globalStyles.flexBoxColumn,
@@ -97,9 +98,6 @@ const styles = Styles.styleSheetCreate({
   text: Styles.platformStyles({
     common: {
       marginBottom: Styles.globalMargins.small,
-    },
-    isElectron: {
-      marginRight: Styles.globalMargins.large,
     },
   }),
 })


### PR DESCRIPTION
@keybase/react-hackers 
cc @malgorithms @adamjspooner I changed the copy a bit since it's no longer new and left-aligned the content on desktop. 
<img width="1143" alt="Screen Shot 2019-06-20 at 5 19 52 PM" src="https://user-images.githubusercontent.com/2807426/59889125-ba76fa80-937f-11e9-9711-0f6dd3c3d503.png">

