### PR TITLE
init: increase EnableJournals timeout

### DIFF
--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -866,13 +866,13 @@ func doInit(
 		}
 	}
 
-	ctx10s, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx60s, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 	// TODO: Don't turn on journaling if either -bserver or
 	// -mdserver point to local implementations.
 	if params.EnableJournal && config.Mode().JournalEnabled() {
 		journalRoot := filepath.Join(params.StorageRoot, "kbfs_journal")
-		err = config.EnableJournaling(ctx10s, journalRoot,
+		err = config.EnableJournaling(ctx60s, journalRoot,
 			params.TLFJournalBackgroundWorkStatus)
 		if err != nil {
 			log.CWarningf(ctx, "Could not initialize journal server: %+v", err)


### PR DESCRIPTION
It turns out that properly enabling all waiting journals is very important.  If there's a journal on disk with MDs on it, but for whatever reason we time out while trying to initialize it (slow disk, etc), and then the user or a background process tries to write something to the TLF, it will make a successor to the server's head revision, rather than the journal's head revision.  But then, if the journal does become enabled, the write of the new MD to the journal will fail because it's not a proper successor to the journal's head, and everything will break.

So as a quick fix, give a lot more time when initializing.  I think we limited this in the past for admin users who had tons of existing journals and things were a lot slower, but things should be a lot faster now and it'snot worth the risk of hitting slow disks.

Issue: HOTPOT-193
Issue: KBFS-3639
Issue: #17994