### PR TITLE
fix a bunch of fs load bugs

### DIFF
--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -307,10 +307,11 @@ const refreshTagRpc = (
   const pathIsSubscribed = tags.get(refreshTag) === path
   tags.set(refreshTag, path)
 
-  // If we are not subscribed to the same TLF, always do RPC, and refresh
-  // subscription to this TLF.
   const tlfPath = Constants.getTlfPath(path)
   if (tlfPath !== lastSubscribedTlf[opType]) {
+    // We were subscribed to a different TLF. Don't skip, and tell KBFS that we
+    // want to refresh subscription to this TLF.
+    lastSubscribedTlf[opType] = tlfPath
     return {
       refreshSubscription: true,
       skipRpc: false,

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -304,25 +304,30 @@ const refreshTagRpc = (
 
   // We've got a refreshTag. Set it regardless.
   const tags = opType === 'folderList' ? folderListRefreshTags : pathMetadataRefreshTags
+  const pathIsSubscribed = tags.get(refreshTag) === path
   tags.set(refreshTag, path)
 
-  // If we are subscribed to the same TLF, just skip. When we have
-  // notifications coming in, we'll know to trigger RPCs for the right paths.
+  // If we are not subscribed to the same TLF, always do RPC, and refresh
+  // subscription to this TLF.
   const tlfPath = Constants.getTlfPath(path)
-  if (tlfPath === lastSubscribedTlf[opType]) {
+  if (tlfPath !== lastSubscribedTlf[opType]) {
     return {
-      refreshSubscription: false,
-      skipRpc: true,
+      refreshSubscription: true,
+      skipRpc: false,
     }
   }
 
-  // We were subscribed to a different TLF. Don't skip, and tell KBFS that we
-  // want to refresh subscription to this TLF.
-  lastSubscribedTlf[opType] = tlfPath
-  return {
-    refreshSubscription: true,
-    skipRpc: false,
-  }
+  // Otherwise, check if the subscribed path is the same. If it's not the same,
+  // do RPC and refresh subscription path.
+  return pathIsSubscribed
+    ? {
+        refreshSubscription: true,
+        skipRpc: true,
+      }
+    : {
+        refreshSubscription: true,
+        skipRpc: false,
+      }
 }
 
 function* folderList(_, action: FsGen.FolderListLoadPayload | FsGen.EditSuccessPayload) {

--- a/shared/fs/common/use-fs-load-effect.tsx
+++ b/shared/fs/common/use-fs-load-effect.tsx
@@ -28,13 +28,15 @@ const useFsLoadEffect = ({
     [dispatch, path, isPathItem]
   )
 
-  const online = Container.useSelector(state => state.fs.kbfsDaemonStatus.online)
+  const kbfsDaemonConnected =
+    Container.useSelector(state => state.fs.kbfsDaemonStatus.rpcStatus) ===
+    Types.KbfsDaemonRpcStatus.Connected
   const load = React.useCallback(
     (refreshTag?: Types.RefreshTag) => {
-      online && wantPathMetadata && loadPathMetadata(refreshTag)
-      online && wantChildren && loadChildren(refreshTag)
+      kbfsDaemonConnected && wantPathMetadata && loadPathMetadata(refreshTag)
+      kbfsDaemonConnected && wantChildren && loadChildren(refreshTag)
     },
-    [online, wantChildren, wantPathMetadata, loadPathMetadata, loadChildren]
+    [kbfsDaemonConnected, wantChildren, wantPathMetadata, loadPathMetadata, loadChildren]
   )
 
   React.useEffect(() => load(refreshTag), [load, refreshTag])

--- a/shared/fs/container.tsx
+++ b/shared/fs/container.tsx
@@ -78,12 +78,12 @@ const ChooseComponent = (props: ChooseComponentProps) => {
     bare && emitBarePreview()
   }, [bare, emitBarePreview])
 
-  const isOnline = props.kbfsDaemonStatus.rpcStatus !== Types.KbfsDaemonRpcStatus.Connected
+  const isConnected = props.kbfsDaemonStatus.rpcStatus !== Types.KbfsDaemonRpcStatus.Connected
   React.useEffect(() => {
     // Always triggers whenever something changes if we are not connected.
     // Saga deduplicates redundant checks.
-    isOnline && waitForKbfsDaemon()
-  }, [isOnline, waitForKbfsDaemon])
+    isConnected && waitForKbfsDaemon()
+  }, [isConnected, waitForKbfsDaemon])
 
   useFsLoadEffect({
     path: props.path,


### PR DESCRIPTION
This fixes two fs load bugs that cause immortal spinners:

1. We were using "whether we are connected to MD server" rather than "whether kbfsDaemon is connected to us" as a guard for whether to fire load RPCs. This caused the mobile-only bug where Files folder list just didn't load because we don't have offline mode turned on for mobile yet, so that `online` field is just never populated.

2. In the refresh tags logic, I forgot to check if the actual subscription path equals. So it was only checking if the subscribed TLF is the same. This caused the immortal spinner in file preview because we already had subscribed to the same TLF, but didn't have the mimeType which needed the loadPathMetadata to retrieve.