### PR TITLE
block_journal: during CR, ignore errors about corrupt entries

### DIFF
--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -1064,9 +1064,10 @@ func (j *tlfJournal) checkServerForConflicts(ctx context.Context,
 		return nil
 	}
 
-	j.vlog.CLogf(
-		ctx, libkb.VLog1, "Server is ahead of local journal (rev=%d), "+
-			"indicating a conflict", currHead.MD.RevisionNumber())
+	j.log.CDebugf(
+		ctx, "Server is ahead of local journal (rev=%d, nextMD=%d), "+
+			"indicating a conflict",
+		currHead.MD.RevisionNumber(), nextMDToFlush)
 	return j.convertMDsToBranch(ctx)
 }
 


### PR DESCRIPTION
If we can't read a particular entry while ignoring old revisions, the entry might be corrupt.  But returning an error is harsh and dangerous because at that point a new MD revision has already been appended to the MD journal; if we error to the caller then they won't write another marker and on a restart the whole MD journal can be flushed without waiting for the corresponding blocks to flush.  So instead, log the error and keep going in that case.  If the entry continues to be unreadable during flush, then the journal (and eventually another round of conflict resolution) will become stuck and the error will surface up to the user.

Issue: HOTPOT-193
issue: #17994