### PR TITLE
libkbfs: use `data.PathPartString` to obfuscate symlinks

### DIFF
--- a/go/kbfs/libfs/fs.go
+++ b/go/kbfs/libfs/fs.go
@@ -846,7 +846,7 @@ func (fs *FS) Lstat(filename string) (fi os.FileInfo, err error) {
 // Symlink implements the billy.Filesystem interface for FS.
 func (fs *FS) Symlink(target, link string) (err error) {
 	fs.log.CDebugf(fs.ctx, "Symlink target=%s link=%s",
-		fs.pathForLogging(target), link)
+		fs.pathForLogging(target), fs.root.ChildName(link))
 	defer func() {
 		fs.deferLog.CDebugf(fs.ctx, "Symlink done: %+v", err)
 		err = translateErr(err)
@@ -867,7 +867,7 @@ func (fs *FS) Symlink(target, link string) (err error) {
 	}
 
 	_, err = fs.config.KBFSOps().CreateLink(
-		fs.ctx, n, n.ChildName(base), target)
+		fs.ctx, n, n.ChildName(base), n.ChildName(target))
 	return err
 }
 

--- a/go/kbfs/libfs/node_wrappers.go
+++ b/go/kbfs/libfs/node_wrappers.go
@@ -61,7 +61,7 @@ var perTlfWrappedNodeNames = map[string]bool{
 // specialFileNode.
 func (sfn *specialFileNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	if !perTlfWrappedNodeNames[name.Plaintext()] {
 		return sfn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -75,7 +75,8 @@ func (sfn *specialFileNode) ShouldCreateMissedLookup(
 			log:    sfn.log,
 		}
 		f := sfn.GetFile(ctx)
-		return true, ctx, data.FakeFile, f.(*wrappedReadFile).GetInfo(), ""
+		return true, ctx, data.FakeFile, f.(*wrappedReadFile).GetInfo(),
+			data.PathPartString{}
 	default:
 		panic(fmt.Sprintf("Name %s was in map, but not in switch", name))
 	}

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -695,9 +695,9 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	node fs.Node, err error) {
 	namePPS := d.node.ChildName(req.NewName)
+	targetPPS := d.node.ChildName(req.Target)
 	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Symlink",
-		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
-			namePPS, req.Target))
+		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(), namePPS, targetPPS))
 	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.vlog.CLogf(
@@ -712,7 +712,7 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	}
 
 	if _, err := d.folder.fs.config.KBFSOps().CreateLink(
-		ctx, d.node, namePPS, req.Target); err != nil {
+		ctx, d.node, namePPS, targetPPS); err != nil {
 		return nil, err
 	}
 

--- a/go/kbfs/libgit/autogit_node_wrappers.go
+++ b/go/kbfs/libgit/autogit_node_wrappers.go
@@ -137,7 +137,7 @@ var _ libkbfs.Node = (*repoDirNode)(nil)
 // repoDirNode.
 func (rdn *repoDirNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	namePlain := name.Plaintext()
 	switch {
 	case strings.HasPrefix(namePlain, AutogitBranchPrefix):
@@ -148,7 +148,7 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 		// It's difficult to tell if a given name is a legitimate
 		// prefix for a branch name or not, so just accept everything.
 		// If it's not legit, trying to read the data will error out.
-		return true, ctx, data.FakeDir, nil, ""
+		return true, ctx, data.FakeDir, nil, data.PathPartString{}
 	case strings.HasPrefix(namePlain, AutogitCommitPrefix):
 		commit := strings.TrimPrefix(namePlain, AutogitCommitPrefix)
 		if len(commit) == 0 {
@@ -167,7 +167,8 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 			rdn.am.log.CDebugf(ctx, "Error getting commit file")
 			return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 		}
-		return true, ctx, data.FakeFile, f.(*diffFile).GetInfo(), ""
+		return true, ctx, data.FakeFile, f.(*diffFile).GetInfo(),
+			data.PathPartString{}
 	default:
 		return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -315,7 +316,7 @@ var _ libkbfs.Node = (*rootNode)(nil)
 // rootNode.
 func (rn *rootNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	if name.Plaintext() != AutogitRoot {
 		return rn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -344,7 +345,7 @@ func (rn *rootNode) ShouldCreateMissedLookup(
 		}
 		rn.fs = fs
 	}
-	return true, ctx, data.FakeDir, nil, ""
+	return true, ctx, data.FakeDir, nil, data.PathPartString{}
 }
 
 // WrapChild implements the Node interface for rootNode.

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -1500,7 +1500,8 @@ outer:
 					invertCreate)
 			}
 			cr.log.CDebugf(ctx, "Putting new merged rename info "+
-				"%v -> %v (symPath: %v)", ptr, newInfo, symPath)
+				"%v -> %v (symPath: %v)", ptr, newInfo,
+				data.NewPathPartString(symPath, chain.obfuscator))
 			mergedChains.renamedOriginals[ptr] = newInfo
 
 			// Fix up the corresponding rmOp to make sure
@@ -1761,8 +1762,8 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 			// since this createOp must have been created
 			// as part of conflict resolution.
 			symPath := "./" + strings.Repeat("../", walkBack)
-			cr.log.CDebugf(ctx, "Creating symlink %s at "+
-				"merged path %s", symPath, mergedPath)
+			cr.log.CDebugf(ctx, "Creating symlink %s at merged path %s",
+				data.NewPathPartString(symPath, chain.obfuscator), mergedPath)
 
 			err = cr.convertCreateIntoSymlinkOrCopy(ctx, ptr, info, chain,
 				unmergedChains, mergedChains, symPath)

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -469,8 +469,8 @@ func TestCRMergedChainsSimple(t *testing.T) {
 	mergedPaths[expectedUnmergedPath.TailPointer()] = mergedPath
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dir2.ChildName("file2"), dir2.ChildName("file2"), "", false, false,
-			data.DirEntry{}, nil}},
+			dir2.ChildName("file2"), dir2.ChildName("file2"),
+			dir2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
 		mergedPaths, nil, expectedActions)
@@ -543,8 +543,8 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	mergedPaths[expectedUnmergedPath.TailPointer()] = mergedPath
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dirB2.ChildName("file2"), dirB2.ChildName("file2"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirB2.ChildName("file2"), dirB2.ChildName("file2"),
+			dirB2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
 		mergedPaths, nil, expectedActions)
@@ -646,14 +646,15 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	dirAPtr1 := cr1.fbo.nodeCache.PathFromNode(dirA1).TailPointer()
 	expectedActions := map[data.BlockPointer]crActionList{
 		dirCPtr: {&copyUnmergedEntryAction{
-			dirC2.ChildName("file2"), dirC2.ChildName("file2"), "",
-			false, false, data.DirEntry{}, nil}},
+			dirC2.ChildName("file2"), dirC2.ChildName("file2"),
+			dirC2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		dirBPtr: {&copyUnmergedEntryAction{
-			dirB1.ChildName("dirC"), dirB1.ChildName("dirC"), "", false, false,
+			dirB1.ChildName("dirC"), dirB1.ChildName("dirC"),
+			dirB1.ChildName(""), false, false,
 			data.DirEntry{}, nil}},
 		dirAPtr1: {&copyUnmergedEntryAction{
-			dirA1.ChildName("dirB"), dirA1.ChildName("dirB"), "", false, false,
-			data.DirEntry{}, nil}},
+			dirA1.ChildName("dirB"), dirA1.ChildName("dirB"),
+			dirA1.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
@@ -745,8 +746,8 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPath.TailPointer(): {&copyUnmergedEntryAction{
-			dirC2.ChildName("file2"), dirC2.ChildName("file2"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirC2.ChildName("file2"), dirC2.ChildName("file2"),
+			dirC2.ChildName(""), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{expectedUnmergedPath},
@@ -944,17 +945,17 @@ func TestCRMergedChainsComplex(t *testing.T) {
 	mergedPathE := cr1.fbo.nodeCache.PathFromNode(dirE1)
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPathA.TailPointer(): {&copyUnmergedEntryAction{
-			dirA2.ChildName("dirJ"), dirA2.ChildName("dirJ"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirA2.ChildName("dirJ"), dirA2.ChildName("dirJ"),
+			dirA2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathE.TailPointer(): {&copyUnmergedEntryAction{
-			dirE1.ChildName("dirF"), dirE1.ChildName("dirF"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirE1.ChildName("dirF"), dirE1.ChildName("dirF"),
+			dirE1.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathF.TailPointer(): {&copyUnmergedEntryAction{
-			dirF2.ChildName("file3"), dirF2.ChildName("file3"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirF2.ChildName("file3"), dirF2.ChildName("file3"),
+			dirF2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathH.TailPointer(): {&copyUnmergedEntryAction{
-			dirH2.ChildName("file4"), dirH2.ChildName("file4"), "", false,
-			false, data.DirEntry{}, nil}},
+			dirH2.ChildName("file4"), dirH2.ChildName("file4"),
+			dirH2.ChildName(""), false, false, data.DirEntry{}, nil}},
 		mergedPathB.TailPointer(): {&rmMergedEntryAction{
 			dirB2.ChildName("dirD")}},
 	}
@@ -1058,8 +1059,8 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	expectedActions := map[data.BlockPointer]crActionList{
 		mergedPathRoot.TailPointer(): {&dropUnmergedAction{ro}},
 		mergedPathB.TailPointer(): {&copyUnmergedEntryAction{
-			dirB2.ChildName("dirA"), dirB2.ChildName("dirA"), "./../", false,
-			false, data.DirEntry{}, nil}},
+			dirB2.ChildName("dirA"), dirB2.ChildName("dirA"),
+			dirB2.ChildName("./../"), false, false, data.DirEntry{}, nil}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathRoot, unmergedPathB},
@@ -1139,7 +1140,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 			dirRoot1.ChildName("file1"),
 			dirRoot1.ChildName(cre.ConflictRenameHelper(
 				now, "u2", "dev1", "file1")),
-			"", 0, false, data.ZeroPtr, data.ZeroPtr}},
+			dirRoot1.ChildName(""), 0, false, data.ZeroPtr, data.ZeroPtr}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathRoot},
@@ -1261,7 +1262,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 			dirRoot1.ChildName("file"),
 			dirRoot2.ChildName(cre.ConflictRenameHelper(
 				now, "u2", "dev1", "file")),
-			"", 0, false, data.ZeroPtr, data.ZeroPtr}},
+			dirRoot1.ChildName(""), 0, false, data.ZeroPtr, data.ZeroPtr}},
 	}
 
 	testCRCheckPathsAndActions(t, cr2, []data.Path{unmergedPathFile},

--- a/go/kbfs/libkbfs/cr_actions_test.go
+++ b/go/kbfs/libkbfs/cr_actions_test.go
@@ -18,15 +18,15 @@ func testPPS(s string) data.PathPartString {
 func TestCRActionsCollapseNoChange(t *testing.T) {
 	al := crActionList{
 		&copyUnmergedEntryAction{
-			testPPS("old1"), testPPS("new1"), "", false, false,
+			testPPS("old1"), testPPS("new1"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&copyUnmergedEntryAction{
-			testPPS("old2"), testPPS("new2"), "", false, false,
+			testPPS("old2"), testPPS("new2"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&renameUnmergedAction{
-			testPPS("old3"), testPPS("new3"), "", 0, false, data.ZeroPtr,
-			data.ZeroPtr},
-		&renameMergedAction{testPPS("old4"), testPPS("new4"), ""},
+			testPPS("old3"), testPPS("new3"), testPPS(""), 0, false,
+			data.ZeroPtr, data.ZeroPtr},
+		&renameMergedAction{testPPS("old4"), testPPS("new4"), testPPS("")},
 		&copyUnmergedAttrAction{
 			testPPS("old5"), testPPS("new5"), []attrChange{mtimeAttr}, false},
 	}
@@ -42,10 +42,10 @@ func TestCRActionsCollapseEntry(t *testing.T) {
 		&copyUnmergedAttrAction{
 			testPPS("old"), testPPS("new"), []attrChange{mtimeAttr}, false},
 		&copyUnmergedEntryAction{
-			testPPS("old"), testPPS("new"), "", false, false,
+			testPPS("old"), testPPS("new"), testPPS(""), false, false,
 			data.DirEntry{}, nil},
 		&renameUnmergedAction{
-			testPPS("old"), testPPS("new"), "", 0, false, data.ZeroPtr,
+			testPPS("old"), testPPS("new"), testPPS(""), 0, false, data.ZeroPtr,
 			data.ZeroPtr},
 	}
 

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3255,7 +3255,7 @@ func (fbo *folderBranchOps) makeFakeDirEntry(
 
 func (fbo *folderBranchOps) makeFakeFileEntry(
 	ctx context.Context, dir Node, name data.PathPartString, fi os.FileInfo,
-	sympath string) (de data.DirEntry, err error) {
+	sympath data.PathPartString) (de data.DirEntry, err error) {
 	fbo.vlog.CLogf(ctx, libkb.VLog1, "Faking file entry for %s", name)
 	id, err := fbo.makeFakeEntryID(ctx, dir, name)
 	if err != nil {
@@ -3272,7 +3272,7 @@ func (fbo *folderBranchOps) makeFakeFileEntry(
 		EntryInfo: data.EntryInfoFromFileInfo(fi),
 	}
 	if de.Type == data.Sym {
-		de.SymPath = sympath
+		de.SymPath = sympath.Plaintext()
 	}
 	return de, nil
 }
@@ -3309,7 +3309,8 @@ func (fbo *folderBranchOps) processMissedLookup(
 		return node, de.EntryInfo, nil
 	}
 
-	if (sympath != "" && et != data.Sym) || (sympath == "" && et == data.Sym) {
+	if (sympath.Plaintext() != "" && et != data.Sym) ||
+		(sympath.Plaintext() == "" && et == data.Sym) {
 		return nil, data.EntryInfo{}, errors.Errorf(
 			"Invalid sympath %s for entry type %s", sympath, et)
 	}
@@ -3370,10 +3371,11 @@ func (fbo *folderBranchOps) statUsingFS(
 	}
 
 	if fi.Mode()&os.ModeSymlink != 0 {
-		sympath, err = fs.Readlink(name.Plaintext())
+		sympathPlain, err := fs.Readlink(name.Plaintext())
 		if err != nil {
 			return data.DirEntry{}, false, err
 		}
+		sympath = node.ChildName(sympathPlain)
 	}
 
 	de, err = fbo.makeFakeFileEntry(ctx, node, name, fi, sympath)
@@ -4780,7 +4782,7 @@ func (fbo *folderBranchOps) notifyAndSyncOrSignal(
 
 func (fbo *folderBranchOps) createLinkLocked(
 	ctx context.Context, lState *kbfssync.LockState, dir Node,
-	fromName data.PathPartString, toPath string) (data.DirEntry, error) {
+	fromName, toPath data.PathPartString) (data.DirEntry, error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
 	if err := checkDisallowedPrefixes(ctx, fromName); err != nil {
@@ -4833,11 +4835,12 @@ func (fbo *folderBranchOps) createLinkLocked(
 
 	// Create a direntry for the link, and then sync
 	now := fbo.nowUnixNano()
+	toPathPlain := toPath.Plaintext()
 	de := data.DirEntry{
 		EntryInfo: data.EntryInfo{
 			Type:    data.Sym,
-			Size:    uint64(len(toPath)),
-			SymPath: toPath,
+			Size:    uint64(len(toPathPlain)),
+			SymPath: toPathPlain,
 			Mtime:   now,
 			Ctime:   now,
 		},
@@ -4858,8 +4861,8 @@ func (fbo *folderBranchOps) createLinkLocked(
 }
 
 func (fbo *folderBranchOps) CreateLink(
-	ctx context.Context, dir Node, fromName data.PathPartString,
-	toPath string) (ei data.EntryInfo, err error) {
+	ctx context.Context, dir Node, fromName, toPath data.PathPartString) (
+	ei data.EntryInfo, err error) {
 	startTime, timer := fbo.startOp(ctx, "CreateLink %s %s -> %s",
 		getNodeIDStr(dir), fromName, toPath)
 	defer func() {

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -190,7 +190,7 @@ type Node interface {
 	// `true` on its own.
 	ShouldCreateMissedLookup(ctx context.Context, name data.PathPartString) (
 		shouldCreate bool, newCtx context.Context, et data.EntryType,
-		fi os.FileInfo, sympath string)
+		fi os.FileInfo, sympath data.PathPartString)
 	// ShouldRetryOnDirRead is called for Nodes representing
 	// directories, whenever a `Lookup` or `GetDirChildren` is done on
 	// them.  It should return true to instruct the caller that it
@@ -372,11 +372,16 @@ type KBFSOps interface {
 		excl Excl) (Node, data.EntryInfo, error)
 	// CreateLink creates a new symlink under the given node, if the
 	// logged-in user has write permission to the top-level folder.
-	// Returns the new entry info for the created symlink.  This
-	// is a remote-sync operation.
+	// Returns the new entry info for the created symlink.  The
+	// symlink is represented as a single `data.PathPartString`
+	// (generally obfuscated by `dir`'s Obfuscator) to avoid
+	// accidental logging, even though it could point outside of the
+	// directory.  The deobfuscate command will inspect symlinks when
+	// deobfuscating to make this easier to debug.  This is a
+	// remote-sync operation.
 	CreateLink(
-		ctx context.Context, dir Node, fromName data.PathPartString,
-		toPath string) (data.EntryInfo, error)
+		ctx context.Context, dir Node, fromName, toPath data.PathPartString) (
+		data.EntryInfo, error)
 	// RemoveDir removes the subdirectory represented by the given
 	// node, if the logged-in user has write permission to the
 	// top-level folder.  Will return an error if the subdirectory is

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -75,7 +75,7 @@ func NewKBFSOpsStandard(appStateUpdater env.AppStateUpdater, config Config) *KBF
 		ops:                   make(map[data.FolderBranch]*folderBranchOps),
 		opsByFav:              make(map[favorites.Folder]*folderBranchOps),
 		reIdentifyControlChan: make(chan chan<- struct{}),
-		favs:                  NewFavorites(config),
+		favs: NewFavorites(config),
 		quotaUsage: NewEventuallyConsistentQuotaUsage(
 			config, quLog, config.MakeVLogger(quLog)),
 		longOperationDebugDumper: NewImpatientDebugDumper(
@@ -1096,8 +1096,8 @@ func (fs *KBFSOpsStandard) CreateFile(
 
 // CreateLink implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) CreateLink(
-	ctx context.Context, dir Node, fromName data.PathPartString,
-	toPath string) (data.EntryInfo, error) {
+	ctx context.Context, dir Node, fromName, toPath data.PathPartString) (
+	data.EntryInfo, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -979,7 +979,7 @@ func (mr *MockKBFSOpsMockRecorder) CreateFile(arg0, arg1, arg2, arg3, arg4 inter
 }
 
 // CreateLink mocks base method
-func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2 data.PathPartString, arg3 string) (data.EntryInfo, error) {
+func (m *MockKBFSOps) CreateLink(arg0 context.Context, arg1 Node, arg2, arg3 data.PathPartString) (data.EntryInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLink", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(data.EntryInfo)
@@ -3590,14 +3590,14 @@ func (mr *MockNodeMockRecorder) RemoveDir(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // ShouldCreateMissedLookup mocks base method
-func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, string) {
+func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldCreateMissedLookup", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(context.Context)
 	ret2, _ := ret[2].(data.EntryType)
 	ret3, _ := ret[3].(os.FileInfo)
-	ret4, _ := ret[4].(string)
+	ret4, _ := ret[4].(data.PathPartString)
 	return ret0, ret1, ret2, ret3, ret4
 }
 

--- a/go/kbfs/libkbfs/node.go
+++ b/go/kbfs/libkbfs/node.go
@@ -110,8 +110,8 @@ func (n *nodeStandard) Readonly(_ context.Context) bool {
 
 func (n *nodeStandard) ShouldCreateMissedLookup(
 	ctx context.Context, _ data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, string) {
-	return false, ctx, data.File, nil, ""
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
+	return false, ctx, data.File, nil, data.PathPartString{}
 }
 
 func (n *nodeStandard) ShouldRetryOnDirRead(ctx context.Context) bool {

--- a/go/kbfs/libkbfs/ops.go
+++ b/go/kbfs/libkbfs/ops.go
@@ -456,7 +456,7 @@ func (co *createOp) checkConflict(
 				return &renameMergedAction{
 					fromName: co.obfuscatedNewName(),
 					toName:   co.obfuscatedName(toName),
-					symPath:  co.crSymPath,
+					symPath:  co.obfuscatedName(co.crSymPath),
 				}, nil
 			}
 			// Otherwise rename the unmerged entry (guaranteed to be a file).
@@ -468,7 +468,7 @@ func (co *createOp) checkConflict(
 			return &renameUnmergedAction{
 				fromName: co.obfuscatedNewName(),
 				toName:   co.obfuscatedName(toName),
-				symPath:  co.crSymPath,
+				symPath:  co.obfuscatedName(co.crSymPath),
 			}, nil
 		}
 
@@ -489,7 +489,7 @@ func (co *createOp) checkConflict(
 			return &copyUnmergedEntryAction{
 				fromName: co.obfuscatedNewName(),
 				toName:   co.obfuscatedName(toName),
-				symPath:  co.crSymPath,
+				symPath:  co.obfuscatedName(co.crSymPath),
 				unique:   true,
 			}, nil
 		}
@@ -505,13 +505,13 @@ func (co *createOp) getDefaultAction(mergedPath data.Path) crAction {
 		return &renameUnmergedAction{
 			fromName: newName,
 			toName:   newName,
-			symPath:  co.crSymPath,
+			symPath:  co.obfuscatedName(co.crSymPath),
 		}
 	}
 	return &copyUnmergedEntryAction{
 		fromName: newName,
 		toName:   newName,
-		symPath:  co.crSymPath,
+		symPath:  co.obfuscatedName(co.crSymPath),
 	}
 }
 
@@ -1000,8 +1000,8 @@ func (so *syncOp) checkConflict(
 		}
 
 		return &renameUnmergedAction{
-			fromName:                 so.getFinalPath().TailName(),
-			toName:                   so.obfuscatedName(toName),
+			fromName: so.getFinalPath().TailName(),
+			toName:   so.obfuscatedName(toName),
 			unmergedParentMostRecent: so.getFinalPath().ParentPath().TailPointer(),
 			mergedParentMostRecent: mergedOp.getFinalPath().ParentPath().
 				TailPointer(),
@@ -1022,7 +1022,7 @@ func (so *syncOp) getDefaultAction(mergedPath data.Path) crAction {
 	return &copyUnmergedEntryAction{
 		fromName: so.getFinalPath().TailName(),
 		toName:   mergedPath.TailName(),
-		symPath:  "",
+		symPath:  so.obfuscatedName(""),
 	}
 }
 
@@ -1312,7 +1312,7 @@ func (sao *setAttrOp) checkConflict(
 			return &renameUnmergedAction{
 				fromName:                 fromName,
 				toName:                   toNamePPS,
-				symPath:                  symPath,
+				symPath:                  sao.obfuscatedName(symPath),
 				causedByAttr:             causedByAttr,
 				unmergedParentMostRecent: sao.getFinalPath().ParentPath().TailPointer(),
 				mergedParentMostRecent: mergedOp.getFinalPath().ParentPath().

--- a/go/kbfs/test/engine_libkbfs.go
+++ b/go/kbfs/test/engine_libkbfs.go
@@ -392,13 +392,15 @@ func (k *LibKBFS) CreateFileExcl(u User, parentDir Node, name string) (file Node
 }
 
 // CreateLink implements the Engine interface.
-func (k *LibKBFS) CreateLink(u User, parentDir Node, fromName, toPath string) (err error) {
+func (k *LibKBFS) CreateLink(
+	u User, parentDir Node, fromName, toPath string) (err error) {
 	config := u.(*libkbfs.ConfigLocal)
 	kbfsOps := config.KBFSOps()
 	ctx, cancel := k.newContext(u)
 	defer cancel()
 	n := parentDir.(libkbfs.Node)
-	_, err = kbfsOps.CreateLink(ctx, n, n.ChildName(fromName), toPath)
+	_, err = kbfsOps.CreateLink(
+		ctx, n, n.ChildName(fromName), n.ChildName(toPath))
 	return err
 }
 


### PR DESCRIPTION
(Based on #18014, which should be reviewed first.)

Wherever possible, use a `data.PathPartString` to represent a symlink, and obfuscate directly when that's not possible.

Issue: HOTPOT-63