### PR TITLE
signup: add checkbox for email visibility

### DIFF
--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -36,7 +36,7 @@
       "email": "string",
       "delete?": "boolean",
       "makePrimary?": "boolean",
-      "toggleSearchable?": "boolean",
+      "makeSearchable?": "boolean | null",
       "verify?": "boolean"
     },
     "editPhone": {

--- a/shared/actions/json/signup.json
+++ b/shared/actions/json/signup.json
@@ -31,6 +31,7 @@
       "error": "string"
     },
     "checkEmail": {
+      "allowSearch": "boolean",
       "email": "string"
     },
     "requestInvite": {
@@ -50,7 +51,7 @@
     "restartSignup": {},
     "signedup": {
       "canError": {
-        "error": "RPCError | null",
+        "error": "RPCError | null"
       }
     },
     "checkDevicename": {

--- a/shared/actions/settings-gen.tsx
+++ b/shared/actions/settings-gen.tsx
@@ -93,7 +93,7 @@ type _EditEmailPayload = {
   readonly email: string
   readonly delete?: boolean
   readonly makePrimary?: boolean
-  readonly toggleSearchable?: boolean
+  readonly makeSearchable?: boolean | null
   readonly verify?: boolean
 }
 type _EditPhonePayload = {

--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -410,7 +410,7 @@ const editEmail = (state, action: SettingsGen.EditEmailPayload, logger) => {
   if (action.payload.verify) {
     return RPCTypes.emailsSendVerificationEmailRpcPromise({email: action.payload.email})
   }
-  if (action.payload.makeSearchable != null) {
+  if (action.payload.makeSearchable !== undefined && action.payload.makeSearchable !== null) {
     return RPCTypes.emailsSetVisibilityEmailRpcPromise({
       email: action.payload.email,
       visibility: action.payload.makeSearchable

--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -410,14 +410,12 @@ const editEmail = (state, action: SettingsGen.EditEmailPayload, logger) => {
   if (action.payload.verify) {
     return RPCTypes.emailsSendVerificationEmailRpcPromise({email: action.payload.email})
   }
-  if (action.payload.toggleSearchable) {
-    const currentSettings = state.settings.email.emails.get(action.payload.email)
-    const newVisibility = currentSettings
-      ? flipVis(currentSettings.visibility)
-      : ChatTypes.Keybase1.IdentityVisibility.private
+  if (action.payload.makeSearchable != null) {
     return RPCTypes.emailsSetVisibilityEmailRpcPromise({
       email: action.payload.email,
-      visibility: newVisibility,
+      visibility: action.payload.makeSearchable
+        ? ChatTypes.Keybase1.IdentityVisibility.public
+        : ChatTypes.Keybase1.IdentityVisibility.private,
     })
   }
   logger.warn('Empty editEmail action')

--- a/shared/actions/signup-gen.tsx
+++ b/shared/actions/signup-gen.tsx
@@ -24,7 +24,7 @@ export const signedup = 'signup:signedup'
 
 // Payload Types
 type _CheckDevicenamePayload = {readonly devicename: string}
-type _CheckEmailPayload = {readonly email: string}
+type _CheckEmailPayload = {readonly allowSearch: boolean; readonly email: string}
 type _CheckInviteCodePayload = {readonly inviteCode: string}
 type _CheckPasswordPayload = {readonly pass1: HiddenString; readonly pass2: HiddenString}
 type _CheckUsernamePayload = {readonly username: string}

--- a/shared/actions/signup.tsx
+++ b/shared/actions/signup.tsx
@@ -55,7 +55,7 @@ const showErrorOrCleanupAfterSignup = (state: TypedState) =>
 const setEmailVisibilityAfterSignup = (state: TypedState) =>
   noErrors(state) &&
   state.signup.emailVisible &&
-  SettingsGen.createEditEmail({email: state.signup.email, toggleSearchable: true})
+  SettingsGen.createEditEmail({email: state.signup.email, makeSearchable: true})
 
 // Validation side effects ///////////////////////////////////////////////////////////
 const checkInviteCode = (state: TypedState) =>

--- a/shared/actions/signup.tsx
+++ b/shared/actions/signup.tsx
@@ -9,6 +9,7 @@ import {loginTab} from '../constants/tabs'
 import * as RouteTreeGen from '../actions/route-tree-gen'
 import {RPCError} from '../util/errors'
 import {TypedState} from '../constants/reducer'
+import * as SettingsGen from './settings-gen'
 
 // Helpers ///////////////////////////////////////////////////////////
 // returns true if there are no errors, we check all errors at every transition just to be extra careful
@@ -49,6 +50,12 @@ const showErrorOrCleanupAfterSignup = (state: TypedState) =>
   noErrors(state)
     ? SignupGen.createRestartSignup()
     : RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupError']})
+
+// If the email was set to be visible during signup, we need to set that with a separate RPC.
+const setEmailVisibilityAfterSignup = (state: TypedState) =>
+  noErrors(state) &&
+  state.signup.emailVisible &&
+  SettingsGen.createEditEmail({email: state.signup.email, toggleSearchable: true})
 
 // Validation side effects ///////////////////////////////////////////////////////////
 const checkInviteCode = (state: TypedState) =>
@@ -199,6 +206,7 @@ const signupSaga = function*(): Saga.SagaGenerator<any, any> {
   )
   yield* Saga.chainAction<SignupGen.CheckedInviteCodePayload>(SignupGen.checkedInviteCode, showUserOnNoErrors)
   yield* Saga.chainAction<SignupGen.SignedupPayload>(SignupGen.signedup, showErrorOrCleanupAfterSignup)
+  yield* Saga.chainAction<SignupGen.SignedupPayload>(SignupGen.signedup, setEmailVisibilityAfterSignup)
 
   // actually make the signup call
   yield* Saga.chainGenerator<SignupGen.CheckedDevicenamePayload>(

--- a/shared/constants/signup.tsx
+++ b/shared/constants/signup.tsx
@@ -21,6 +21,7 @@ export const makeState = I.Record<Types._State>({
   devicenameError: '',
   email: '',
   emailError: '',
+  emailVisible: false,
   inviteCode: '',
   inviteCodeError: '',
   name: '',

--- a/shared/constants/types/signup.tsx
+++ b/shared/constants/types/signup.tsx
@@ -9,6 +9,7 @@ export type _State = {
   devicenameError: string
   email: string
   emailError: string
+  emailVisible: boolean
   inviteCode: string
   inviteCodeError: string
   name: string

--- a/shared/reducers/signup.tsx
+++ b/shared/reducers/signup.tsx
@@ -43,9 +43,10 @@ export default function(state: Types.State = initialState, action: SignupGen.Act
       return username === state.username ? state.merge({usernameError, usernameTaken}) : state
     }
     case SignupGen.checkEmail: {
-      const {email} = action.payload
+      const {email, allowSearch} = action.payload
+      const emailVisible = allowSearch
       const emailError = isValidEmail(email)
-      return state.merge({email, emailError})
+      return state.merge({email, emailError, emailVisible})
     }
     case SignupGen.requestInvite: {
       const {email, name} = action.payload

--- a/shared/settings/account/email-phone-row.tsx
+++ b/shared/settings/account/email-phone-row.tsx
@@ -161,12 +161,14 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => ({
 })
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch, ownProps: OwnProps) => ({
+  _onMakeNotSearchable: () =>
+    dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makeSearchable: false})),
+  _onMakeSearchable: () =>
+    dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makeSearchable: true})),
   email: {
     onDelete: () => dispatch(SettingsGen.createEditEmail({delete: true, email: ownProps.contactKey})),
     onMakePrimary: () =>
       dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makePrimary: true})),
-    onToggleSearchable: () =>
-      dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, toggleSearchable: true})),
     onVerify: () => dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, verify: true})),
   },
   phone: {
@@ -193,11 +195,13 @@ const ConnectedEmailPhoneRow = Container.namedConnect(
         verified: stateProps._phoneRow.verified,
       }
     } else if (stateProps._emailRow) {
+      const searchable = stateProps._emailRow.visibility === RPCTypes.IdentityVisibility.public
       return {
         ...dispatchProps.email,
         address: stateProps._emailRow.email,
+        onToggleSearchable: searchable ? dispatchProps._onMakeNotSearchable : dispatchProps._onMakeSearchable,
         primary: stateProps._emailRow.isPrimary,
-        searchable: stateProps._emailRow.visibility === RPCTypes.IdentityVisibility.public,
+        searchable,
         type: 'email' as const,
         verified: stateProps._emailRow.isVerified,
       }

--- a/shared/signup/email/container.tsx
+++ b/shared/signup/email/container.tsx
@@ -16,7 +16,8 @@ const mapStateToProps = (state: Container.TypedState) => ({
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onBack: () => dispatch(SignupGen.createGoBackAndClearErrors()),
-  onFinish: (email: string) => dispatch(SignupGen.createCheckEmail({email})),
+  onFinish: (email: string, allowSearch: boolean) =>
+    dispatch(SignupGen.createCheckEmail({allowSearch, email})),
 })
 
 const ConnectedEnterEmail = Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o: OwnProps) => ({

--- a/shared/signup/email/index.tsx
+++ b/shared/signup/email/index.tsx
@@ -49,14 +49,12 @@ const EnterEmail = (props: Props) => {
             textContentType="emailAddress"
             value={email}
           />
-          {
-            <Kb.Checkbox
-              label="Allow friends to find you by this email address"
-              checked={allowSearch}
-              onCheck={onChangeAllowSearch}
-              style={styles.checkbox}
-            />
-          }
+          <Kb.Checkbox
+            label="Allow friends to find you by this email address"
+            checked={allowSearch}
+            onCheck={onChangeAllowSearch}
+            style={styles.checkbox}
+          />
         </Kb.Box2>
       </Kb.Box2>
     </SignupScreen>

--- a/shared/signup/email/index.tsx
+++ b/shared/signup/email/index.tsx
@@ -5,21 +5,19 @@ import {SignupScreen, errorBanner} from '../common'
 import {ButtonType} from '../../common-adapters/button'
 
 type Props = {
-  allowSearch: boolean
   error: string
   initialEmail?: string
   onBack?: () => void
-  onChangeAllowSearch?: (allow: boolean) => void
-  onFinish: (email: string) => void
+  onFinish: (email: string, allowSearch: boolean) => void
   onSkip?: () => void
 }
-
 // Parts that are commented out allow skipping entering an email, we don't want
 // to allow skipping for now. TODO Y2K-57 allow skipping.
 const EnterEmail = (props: Props) => {
   const [email, onChangeEmail] = React.useState(props.initialEmail || '')
+  const [allowSearch, onChangeAllowSearch] = React.useState(true)
   const disabled = !email
-  const onContinue = () => (disabled ? {} : props.onFinish(email))
+  const onContinue = () => (disabled ? {} : props.onFinish(email, allowSearch))
   return (
     <SignupScreen
       banners={errorBanner(props.error)}
@@ -51,13 +49,14 @@ const EnterEmail = (props: Props) => {
             textContentType="emailAddress"
             value={email}
           />
-          {/* TODO hook in to "add an email" settings
-          <Kb.Checkbox
-          label="Allow friends to find you by this email address"
-          checked={props.allowSearch}
-          onCheck={props.onChangeAllowSearch}
-          style={styles.checkbox}
-        /> */}
+          {
+            <Kb.Checkbox
+              label="Allow friends to find you by this email address"
+              checked={allowSearch}
+              onCheck={onChangeAllowSearch}
+              style={styles.checkbox}
+            />
+          }
         </Kb.Box2>
       </Kb.Box2>
     </SignupScreen>


### PR DESCRIPTION
Add (uncomment, thanks danny!) a checkbox to the email form during signup, and fire off an additional RPC when signup succeeds if it is checked.

Issue: Y2K-66

CC @keybase/y2ksquad 