### PR TITLE
simplefs: add a debug command for path obfuscation

### DIFF
--- a/go/client/cmd_simplefs_debug.go
+++ b/go/client/cmd_simplefs_debug.go
@@ -1,57 +1,24 @@
-// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
 package client
 
 import (
-	"golang.org/x/net/context"
-
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
-	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
-// CmdSimpleFSDebug is the 'fs debug' command.
-type CmdSimpleFSDebug struct {
-	libkb.Contextified
-	path    keybase1.Path
-	recurse bool
-}
-
-// NewCmdSimpleFSDebug creates a new cli.Command.
-func NewCmdSimpleFSDebug(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+// NewCmdSimpleFSDebug creates the debug command, which is just a
+// holder for subcommands.
+func NewCmdSimpleFSDebug(
+	cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:  "debug",
-		Usage: "Dump debugging info to the file system log",
-		Action: func(c *cli.Context) {
-			cl.ChooseCommand(&CmdSimpleFSDebug{
-				Contextified: libkb.NewContextified(g)}, "debug", c)
-			cl.SetNoStandalone()
-		},
-	}
-}
-
-// Run runs the command in client/server mode.
-func (c *CmdSimpleFSDebug) Run() error {
-	cli, err := GetSimpleFSClient(c.G())
-	if err != nil {
-		return err
-	}
-
-	return cli.SimpleFSDumpDebuggingInfo(context.TODO())
-}
-
-// ParseArgv gets the optional -r switch
-func (c *CmdSimpleFSDebug) ParseArgv(ctx *cli.Context) error {
-	return nil
-}
-
-// GetUsage says what this command needs to operate.
-func (c *CmdSimpleFSDebug) GetUsage() libkb.Usage {
-	return libkb.Usage{
-		Config:    true,
-		KbKeyring: true,
-		API:       true,
+		Usage: "Debug utilities",
+		Subcommands: append([]cli.Command{
+			NewCmdSimpleFSDebugDump(cl, g),
+			NewCmdSimpleFSDebugObfuscate(cl, g),
+		}),
 	}
 }

--- a/go/client/cmd_simplefs_debug_dump.go
+++ b/go/client/cmd_simplefs_debug_dump.go
@@ -1,0 +1,54 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+// CmdSimpleFSDebugDump is the 'fs debug dump' command.
+type CmdSimpleFSDebugDump struct {
+	libkb.Contextified
+}
+
+// NewCmdSimpleFSDebugDump creates a new cli.Command.
+func NewCmdSimpleFSDebugDump(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "dump",
+		Usage: "Dump debugging info to the file system log",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSDebugDump{
+				Contextified: libkb.NewContextified(g)}, "dump", c)
+			cl.SetNoStandalone()
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSDebugDump) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	return cli.SimpleFSDumpDebuggingInfo(context.TODO())
+}
+
+// ParseArgv gets the optional -r switch
+func (c *CmdSimpleFSDebugDump) ParseArgv(ctx *cli.Context) error {
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSDebugDump) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/cmd_simplefs_debug_obfuscate.go
+++ b/go/client/cmd_simplefs_debug_obfuscate.go
@@ -1,0 +1,85 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+	"path"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+// CmdSimpleFSDebugObfuscate is the 'fs debug obfuscate' command.
+type CmdSimpleFSDebugObfuscate struct {
+	libkb.Contextified
+	paths []keybase1.Path
+}
+
+// NewCmdSimpleFSDebugObfuscate creates a new cli.Command.
+func NewCmdSimpleFSDebugObfuscate(
+	cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "obfuscate",
+		ArgumentHelp: "<path> [<path2> <path3>...]",
+		Usage:        "Returns the obfuscated path for a given keybase path",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSDebugObfuscate{
+				Contextified: libkb.NewContextified(g)}, "obfuscate", c)
+			cl.SetNoStandalone()
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSDebugObfuscate) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	ui := c.G().UI.GetTerminalUI()
+	for _, p := range c.paths {
+		res, err := cli.SimpleFSObfuscatePath(context.TODO(), p)
+		if err != nil {
+			return err
+		}
+
+		if len(c.paths) == 1 {
+			ui.Printf("%s\n", res)
+		} else {
+			ui.Printf("%s: %s\n", path.Join(mountDir, p.String()), res)
+		}
+	}
+	return nil
+}
+
+// ParseArgv gets the optional -r switch
+func (c *CmdSimpleFSDebugObfuscate) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		return errors.New("obfuscate requires at least one KBFS path argument")
+	}
+
+	for _, p := range ctx.Args() {
+		kp, err := makeSimpleFSPath(p)
+		if err != nil {
+			return err
+		}
+		c.paths = append(c.paths, kp)
+	}
+
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSDebugObfuscate) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -291,6 +291,12 @@ func (s SimpleFSMock) SimpleFSSetNotificationThreshold(_ context.Context, _ int6
 	return nil
 }
 
+// SimpleFSObfuscatePath implements the SimpleFSInterface.
+func (s SimpleFSMock) SimpleFSObfuscatePath(
+	_ context.Context, _ keybase1.Path) (string, error) {
+	return "", nil
+}
+
 /*
  file source cases:
  1. file

--- a/go/kbfs/libfs/fs.go
+++ b/go/kbfs/libfs/fs.go
@@ -307,6 +307,10 @@ func (fs *FS) PathForLogging(filename string) string {
 		return filename
 	}
 
+	if filename == "." {
+		return ""
+	}
+
 	parts := strings.Split(filename, "/")
 	if len(parts) == 0 {
 		return ""

--- a/go/kbfs/libfs/httpfs.go
+++ b/go/kbfs/libfs/httpfs.go
@@ -133,7 +133,7 @@ var _ http.FileSystem = httpFileSystem{}
 // Open implements the http.FileSystem interface.
 func (hfs httpFileSystem) Open(filename string) (entry http.File, err error) {
 	hfs.fs.log.CDebugf(
-		hfs.fs.ctx, "hfs.Open %s", hfs.fs.pathForLogging(filename))
+		hfs.fs.ctx, "hfs.Open %s", hfs.fs.PathForLogging(filename))
 	defer func() {
 		hfs.fs.deferLog.CDebugf(hfs.fs.ctx, "hfs.Open done: %+v", err)
 		if err != nil {

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -2626,7 +2626,6 @@ func (k *SimpleFS) SimpleFSObfuscatePath(
 		return "", errors.Errorf("FS was not a KBFS file system: %T", fs)
 	}
 	p := fs.Join(midPath, finalElem)
-	k.log.CDebugf(ctx, "Looking up %s", p)
 	return stdpath.Join(
 		tlfHandle.GetCanonicalPath(), asLibFS.PathForLogging(p)), nil
 }

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1426,6 +1426,10 @@ type SimpleFSSetNotificationThresholdArg struct {
 	Threshold int64 `codec:"threshold" json:"threshold"`
 }
 
+type SimpleFSObfuscatePathArg struct {
+	Path Path `codec:"path" json:"path"`
+}
+
 type SimpleFSInterface interface {
 	// Begin list of items in directory at path.
 	// Retrieve results with readList().
@@ -1542,6 +1546,7 @@ type SimpleFSInterface interface {
 	SimpleFSSetDebugLevel(context.Context, string) error
 	SimpleFSSettings(context.Context) (FSSettings, error)
 	SimpleFSSetNotificationThreshold(context.Context, int64) error
+	SimpleFSObfuscatePath(context.Context, Path) (string, error)
 }
 
 func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
@@ -2138,6 +2143,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return
 				},
 			},
+			"simpleFSObfuscatePath": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSObfuscatePathArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SimpleFSObfuscatePathArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SimpleFSObfuscatePathArg)(nil), args)
+						return
+					}
+					ret, err = i.SimpleFSObfuscatePath(ctx, typedArgs[0].Path)
+					return
+				},
+			},
 		},
 	}
 }
@@ -2446,5 +2466,11 @@ func (c SimpleFSClient) SimpleFSSettings(ctx context.Context) (res FSSettings, e
 func (c SimpleFSClient) SimpleFSSetNotificationThreshold(ctx context.Context, threshold int64) (err error) {
 	__arg := SimpleFSSetNotificationThresholdArg{Threshold: threshold}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetNotificationThreshold", []interface{}{__arg}, nil)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSObfuscatePath(ctx context.Context, path Path) (res string, err error) {
+	__arg := SimpleFSObfuscatePathArg{Path: path}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSObfuscatePath", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -554,3 +554,15 @@ func (s *SimpleFSHandler) SimpleFSSetNotificationThreshold(
 	}
 	return cli.SimpleFSSetNotificationThreshold(ctx, threshold)
 }
+
+// SimpleFSObfuscatePath implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSObfuscatePath(
+	ctx context.Context, path keybase1.Path) (res string, err error) {
+	ctx, cancel := s.wrapContextWithTimeout(ctx)
+	defer cancel()
+	cli, err := s.client()
+	if err != nil {
+		return "", err
+	}
+	return cli.SimpleFSObfuscatePath(ctx, path)
+}

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -532,4 +532,7 @@ protocol SimpleFS {
   FSSettings simpleFSSettings();
 
   void simpleFSSetNotificationThreshold(int64 threshold);
+
+  // simpleFSObfuscatePath returns an obfuscated path for the given KBFS path.
+  string simpleFSObfuscatePath(Path path);
 }

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -1223,6 +1223,15 @@
         }
       ],
       "response": null
+    },
+    "simpleFSObfuscatePath": {
+      "request": [
+        {
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "response": "string"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -3344,6 +3344,7 @@ export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.u
 // 'keybase.1.SimpleFS.simpleFSGetUserQuotaUsage'
 // 'keybase.1.SimpleFS.simpleFSGetTeamQuotaUsage'
 // 'keybase.1.SimpleFS.simpleFSReset'
+// 'keybase.1.SimpleFS.simpleFSObfuscatePath'
 // 'keybase.1.streamUi.close'
 // 'keybase.1.streamUi.read'
 // 'keybase.1.streamUi.reset'


### PR DESCRIPTION
And move the existing `fs debug` command to `fs debug dump`.

Sample output:

```sh
$ keybase fs debug obfuscate /keybase/private/strib/tmp/trezor-bridge-2.0.13.pkg
/keybase/private/strib/entry-voyage/physical-exit.pkg

$ keybase fs debug obfuscate /keybase/private/strib/tmp/z9 /keybase/private/strib/tmp/a
/keybase/private/strib/tmp/z9: /keybase/private/strib/entry-voyage/sign-reduce
/keybase/private/strib/tmp/a: /keybase/private/strib/entry-voyage/skull-robot
```

Issue: HOTPOT-65