### PR TITLE
Wallet badging: accept more changes

### DIFF
--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -963,10 +963,8 @@ func detailsChanged(a, b *stellar1.AccountDetails) bool {
 	if a.Available != b.Available {
 		return true
 	}
-	if a.ReadTransactionID != nil && b.ReadTransactionID != nil {
-		if *a.ReadTransactionID != *b.ReadTransactionID {
-			return true
-		}
+	if b.ReadTransactionID != nil && (a.ReadTransactionID == nil || *a.ReadTransactionID != *b.ReadTransactionID) {
+		return true
 	}
 	if a.SubentryCount != b.SubentryCount {
 		return true


### PR DESCRIPTION
I don't know that this ever happens, just seems like this is more forgiving. For when `!a && b`