### PR TITLE
Fix reacji error

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -1876,7 +1876,7 @@ const onUpdateUserReacjis = state => {
   // service into a frequency map that will appease the lib.
   let i = 0
   let reacjis = {}
-  userReacjis.topReacjis.forEach(el => {
+  ;(userReacjis.topReacjis || []).forEach(el => {
     i++
     reacjis[el] = userReacjis.topReacjis.length - i
   })


### PR DESCRIPTION
This global errored on `nil` (or whatever) when logging in for the first time since restarting.

The semicolon keeps it from trying to _call_ `{}`