### PR TITLE
simplefs: add a debug command for path deobfuscation

### DIFF
--- a/go/client/cmd_simplefs_debug.go
+++ b/go/client/cmd_simplefs_debug.go
@@ -19,6 +19,7 @@ func NewCmdSimpleFSDebug(
 		Subcommands: append([]cli.Command{
 			NewCmdSimpleFSDebugDump(cl, g),
 			NewCmdSimpleFSDebugObfuscate(cl, g),
+			NewCmdSimpleFSDebugDeobfuscate(cl, g),
 		}),
 	}
 }

--- a/go/client/cmd_simplefs_debug_deobfuscate.go
+++ b/go/client/cmd_simplefs_debug_deobfuscate.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+	"path"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+// CmdSimpleFSDebugDeobfuscate is the 'fs debug deobfuscate' command.
+type CmdSimpleFSDebugDeobfuscate struct {
+	libkb.Contextified
+	paths []keybase1.Path
+}
+
+// NewCmdSimpleFSDebugDeobfuscate creates a new cli.Command.
+func NewCmdSimpleFSDebugDeobfuscate(
+	cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "deobfuscate",
+		ArgumentHelp: "<path> [<path2> <path3>...]",
+		Usage:        "Returns the possible plaintext paths for a given keybase path",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSDebugDeobfuscate{
+				Contextified: libkb.NewContextified(g)}, "deobfuscate", c)
+			cl.SetNoStandalone()
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSDebugDeobfuscate) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	ui := c.G().UI.GetTerminalUI()
+	for i, p := range c.paths {
+		res, err := cli.SimpleFSDeobfuscatePath(context.TODO(), p)
+		if err != nil {
+			return err
+		}
+
+		tab := ""
+		if len(c.paths) > 1 {
+			ui.Printf("%s:\n", path.Join(mountDir, p.String()))
+			tab = "  "
+		}
+		for _, r := range res {
+			ui.Printf("%s%s\n", tab, r)
+		}
+		if i+1 != len(c.paths) {
+			ui.Printf("\n")
+		}
+	}
+	return nil
+}
+
+// ParseArgv gets the optional -r switch
+func (c *CmdSimpleFSDebugDeobfuscate) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		return errors.New("obfuscate requires at least one KBFS path argument")
+	}
+
+	for _, p := range ctx.Args() {
+		kp, err := makeSimpleFSPath(p)
+		if err != nil {
+			return err
+		}
+		c.paths = append(c.paths, kp)
+	}
+
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSDebugDeobfuscate) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/cmd_simplefs_debug_deobfuscate.go
+++ b/go/client/cmd_simplefs_debug_deobfuscate.go
@@ -43,16 +43,24 @@ func (c *CmdSimpleFSDebugDeobfuscate) Run() error {
 	}
 
 	ui := c.G().UI.GetTerminalUI()
+	var errors []error
 	for i, p := range c.paths {
 		res, err := cli.SimpleFSDeobfuscatePath(context.TODO(), p)
 		if err != nil {
-			return err
+			if len(c.paths) == 0 {
+				return err
+			}
+			errors = append(errors, err)
 		}
 
 		tab := ""
 		if len(c.paths) > 1 {
 			ui.Printf("%s:\n", path.Join(mountDir, p.String()))
 			tab = "  "
+			if err != nil {
+				ui.Printf("%sError: %v\n\n", tab, err)
+				continue
+			}
 		}
 		for _, r := range res {
 			ui.Printf("%s%s\n", tab, r)
@@ -60,6 +68,9 @@ func (c *CmdSimpleFSDebugDeobfuscate) Run() error {
 		if i+1 != len(c.paths) {
 			ui.Printf("\n")
 		}
+	}
+	if len(errors) == len(c.paths) && len(errors) > 0 {
+		return errors[0]
 	}
 	return nil
 }

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -297,6 +297,12 @@ func (s SimpleFSMock) SimpleFSObfuscatePath(
 	return "", nil
 }
 
+// SimpleFSDeobfuscatePath implements the SimpleFSInterface.
+func (s SimpleFSMock) SimpleFSDeobfuscatePath(
+	_ context.Context, _ keybase1.Path) ([]string, error) {
+	return nil, nil
+}
+
 /*
  file source cases:
  1. file

--- a/go/kbfs/libfs/util.go
+++ b/go/kbfs/libfs/util.go
@@ -6,7 +6,11 @@ package libfs
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path"
+	"regexp"
+	"strings"
 
 	billy "gopkg.in/src-d/go-billy.v4"
 )
@@ -47,4 +51,75 @@ func RecursiveDelete(
 	}
 
 	return fs.Remove(fi.Name())
+}
+
+var obsConflictRegexp = regexp.MustCompile(`-([[:digit:]]+)(\.|$)`)
+
+func stripObfuscatedConflictSuffix(s string) string {
+	replace := ""
+	if strings.Contains(s, ".") {
+		replace = "."
+	}
+	return obsConflictRegexp.ReplaceAllString(s, replace)
+}
+
+func deobfuscate(
+	ctx context.Context, fs *FS, p []string) (res []string, err error) {
+	if len(p) == 0 {
+		return nil, nil
+	}
+
+	fis, err := fs.ReadDir("")
+	if err != nil {
+		return nil, err
+	}
+
+	elem := stripObfuscatedConflictSuffix(p[0])
+	for _, fi := range fis {
+		name := fi.Name()
+		obsName := stripObfuscatedConflictSuffix(fs.PathForLogging(name))
+		if obsName == elem {
+			if len(p) == 1 || !fi.IsDir() {
+				res = append(res, name)
+			} else {
+				childFS, err := fs.ChrootAsLibFS(name)
+				if err != nil {
+					return nil, err
+				}
+
+				children, err := deobfuscate(ctx, childFS, p[1:])
+				if err != nil {
+					return nil, err
+				}
+				for _, c := range children {
+					res = append(res, path.Join(name, c))
+				}
+			}
+		}
+
+		if fi.Mode()&os.ModeSymlink > 0 {
+			link, err := fs.Readlink(name)
+			if err != nil {
+				return nil, err
+			}
+			obsName := fs.RootNode().ChildName(link).String()
+			if obsName == elem {
+				res = append(res, fmt.Sprintf("%s (%s)", name, link))
+			}
+		}
+	}
+	return res, nil
+}
+
+// Deobfuscate returns a set of possible plaintext paths, given an
+// obfuscated path as input.  The set is ambiguous because of possible
+// conflicts in the obfuscated name.  If the last element of the
+// obfuscated path matches the obfuscated version of a symlink target
+// within the target directory, the returned string includes the
+// symlink itself, followed by the target name in parentheses like
+// `/keybase/private/me/link (/etc/passwd)`.
+func Deobfuscate(
+	ctx context.Context, fs *FS, obfuscatedPath string) ([]string, error) {
+	s := strings.Split(obfuscatedPath, "/")
+	return deobfuscate(ctx, fs, s)
 }

--- a/go/kbfs/libfs/util.go
+++ b/go/kbfs/libfs/util.go
@@ -64,8 +64,8 @@ func stripObfuscatedConflictSuffix(s string) string {
 }
 
 func deobfuscate(
-	ctx context.Context, fs *FS, p []string) (res []string, err error) {
-	if len(p) == 0 {
+	ctx context.Context, fs *FS, pathParts []string) (res []string, err error) {
+	if len(pathParts) == 0 {
 		return nil, nil
 	}
 
@@ -74,12 +74,12 @@ func deobfuscate(
 		return nil, err
 	}
 
-	elem := stripObfuscatedConflictSuffix(p[0])
+	elem := stripObfuscatedConflictSuffix(pathParts[0])
 	for _, fi := range fis {
 		name := fi.Name()
 		obsName := stripObfuscatedConflictSuffix(fs.PathForLogging(name))
 		if obsName == elem {
-			if len(p) == 1 || !fi.IsDir() {
+			if len(pathParts) == 1 {
 				res = append(res, name)
 			} else {
 				childFS, err := fs.ChrootAsLibFS(name)
@@ -87,7 +87,7 @@ func deobfuscate(
 					return nil, err
 				}
 
-				children, err := deobfuscate(ctx, childFS, p[1:])
+				children, err := deobfuscate(ctx, childFS, pathParts[1:])
 				if err != nil {
 					return nil, err
 				}

--- a/go/kbfs/libfs/util_test.go
+++ b/go/kbfs/libfs/util_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeobfuscate(t *testing.T) {
+	os.Setenv("KEYBASE_TEST_OBFUSCATE_LOGS", "true")
+	ctx, _, fs := makeFS(t, "")
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, fs.config)
+
+	t.Log("Check basic obfuscate->deobfuscate path")
+	p := "a/b"
+	err := fs.MkdirAll(p, os.FileMode(0600))
+	require.NoError(t, err)
+	obsPath := fs.PathForLogging(p)
+	require.NotEqual(t, p, obsPath)
+	res, err := Deobfuscate(ctx, fs, obsPath)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, p, res[0])
+
+	t.Log("Check conflict suffix with no extension")
+	res, err = Deobfuscate(ctx, fs, obsPath+"-2")
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, p, res[0])
+
+	t.Log("Check conflict suffix with extension")
+	file := "a/foo.txt"
+	f, err := fs.Create(file)
+	require.NoError(t, err)
+	f.Close()
+	obsPathFile := fs.PathForLogging(file)
+	require.NotEqual(t, p, obsPathFile)
+	res, err = Deobfuscate(ctx, fs, obsPathFile)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, file, res[0])
+	obsPathFileSuffix := strings.Replace(obsPathFile, ".txt", "-2.txt", 1)
+	res, err = Deobfuscate(ctx, fs, obsPathFileSuffix)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, file, res[0])
+
+	t.Log("Check symlink")
+	p2 := "a/c"
+	err = fs.Symlink("b", p2)
+	require.NoError(t, err)
+	res, err = Deobfuscate(ctx, fs, obsPath)
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+	require.Contains(t, res, p)
+	require.Contains(t, res, p2+" (b)")
+}

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -2668,5 +2668,8 @@ func (k *SimpleFS) SimpleFSDeobfuscatePath(
 	for _, r := range resWithoutPrefix {
 		res = append(res, stdpath.Join(tlfHandle.GetCanonicalPath(), r))
 	}
+	if len(res) == 0 {
+		return nil, errors.New("Found no matching paths")
+	}
 	return res, nil
 }

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1430,6 +1430,10 @@ type SimpleFSObfuscatePathArg struct {
 	Path Path `codec:"path" json:"path"`
 }
 
+type SimpleFSDeobfuscatePathArg struct {
+	Path Path `codec:"path" json:"path"`
+}
+
 type SimpleFSInterface interface {
 	// Begin list of items in directory at path.
 	// Retrieve results with readList().
@@ -1547,6 +1551,7 @@ type SimpleFSInterface interface {
 	SimpleFSSettings(context.Context) (FSSettings, error)
 	SimpleFSSetNotificationThreshold(context.Context, int64) error
 	SimpleFSObfuscatePath(context.Context, Path) (string, error)
+	SimpleFSDeobfuscatePath(context.Context, Path) ([]string, error)
 }
 
 func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
@@ -2158,6 +2163,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return
 				},
 			},
+			"simpleFSDeobfuscatePath": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSDeobfuscatePathArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SimpleFSDeobfuscatePathArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SimpleFSDeobfuscatePathArg)(nil), args)
+						return
+					}
+					ret, err = i.SimpleFSDeobfuscatePath(ctx, typedArgs[0].Path)
+					return
+				},
+			},
 		},
 	}
 }
@@ -2472,5 +2492,11 @@ func (c SimpleFSClient) SimpleFSSetNotificationThreshold(ctx context.Context, th
 func (c SimpleFSClient) SimpleFSObfuscatePath(ctx context.Context, path Path) (res string, err error) {
 	__arg := SimpleFSObfuscatePathArg{Path: path}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSObfuscatePath", []interface{}{__arg}, &res)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSDeobfuscatePath(ctx context.Context, path Path) (res []string, err error) {
+	__arg := SimpleFSDeobfuscatePathArg{Path: path}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDeobfuscatePath", []interface{}{__arg}, &res)
 	return
 }

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -566,3 +566,15 @@ func (s *SimpleFSHandler) SimpleFSObfuscatePath(
 	}
 	return cli.SimpleFSObfuscatePath(ctx, path)
 }
+
+// SimpleFSDeobfuscatePath implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSDeobfuscatePath(
+	ctx context.Context, path keybase1.Path) (res []string, err error) {
+	ctx, cancel := s.wrapContextWithTimeout(ctx)
+	defer cancel()
+	cli, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	return cli.SimpleFSDeobfuscatePath(ctx, path)
+}

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -535,4 +535,8 @@ protocol SimpleFS {
 
   // simpleFSObfuscatePath returns an obfuscated path for the given KBFS path.
   string simpleFSObfuscatePath(Path path);
+
+  // simpleFSDeobfuscatePath returns a set of plaintext paths for the given
+  // obfuscated KBFS path.
+  array<string> simpleFSDeobfuscatePath(Path path);
 }

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -1232,6 +1232,18 @@
         }
       ],
       "response": "string"
+    },
+    "simpleFSDeobfuscatePath": {
+      "request": [
+        {
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "string"
+      }
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -3345,6 +3345,7 @@ export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.u
 // 'keybase.1.SimpleFS.simpleFSGetTeamQuotaUsage'
 // 'keybase.1.SimpleFS.simpleFSReset'
 // 'keybase.1.SimpleFS.simpleFSObfuscatePath'
+// 'keybase.1.SimpleFS.simpleFSDeobfuscatePath'
 // 'keybase.1.streamUi.close'
 // 'keybase.1.streamUi.read'
 // 'keybase.1.streamUi.reset'


### PR DESCRIPTION
This can show multiple paths per obfuscated path, since conflict
suffixes and symlinks make this possible.

Sample output:
```sh
$ keybase fs debug deobfuscate /keybase/private/strib/entry-voyage/physical-exit.pkg
/keybase/private/strib/tmp/trezor-bridge-2.0.13.pkg

$ keybase fs debug deobfuscate /keybase/private/strib/entry-voyage/physical-exit-85487.pkg /keybase/private/strib/entry-voyage/sign-reduce-2
/keybase/private/strib/entry-voyage/physical-exit-85487.pkg:
  /keybase/private/strib/tmp/trezor-bridge-2.0.13.pkg

/keybase/private/strib/entry-voyage/sign-reduce-2:
  /keybase/private/strib/tmp/z9

```

Issue: HOTPOT-66