### PR TITLE
Trustlines: Integrate new canAddTrustline bool

### DIFF
--- a/shared/constants/types/wallets.tsx
+++ b/shared/constants/types/wallets.tsx
@@ -52,6 +52,7 @@ export type _Assets = {
   availableToSendWorth: string
   balanceAvailableToSend: string
   balanceTotal: string
+  canAddTrustline: boolean
   infoUrl: string
   infoUrlText: string
   issuerAccountID: string

--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -224,6 +224,7 @@ export const makeAssets = I.Record<Types._Assets>({
   availableToSendWorth: '',
   balanceAvailableToSend: '',
   balanceTotal: '',
+  canAddTrustline: false,
   infoUrl: '',
   infoUrlText: '',
   issuerAccountID: '',
@@ -241,6 +242,7 @@ export const assetsResultToAssets = (w: RPCTypes.AccountAssetLocal) =>
     availableToSendWorth: w.availableToSendWorth,
     balanceAvailableToSend: w.balanceAvailableToSend,
     balanceTotal: w.balanceTotal,
+    canAddTrustline: w.canAddTrustline,
     infoUrl: w.infoUrl,
     infoUrlText: w.infoUrlText,
     issuerAccountID: w.issuerAccountID,
@@ -622,6 +624,13 @@ export const getExternalPartners = (state: TypedState, accountID: Types.AccountI
 
 export const getAssets = (state: TypedState, accountID: Types.AccountID) =>
   state.wallets.assetsMap.get(accountID, I.List())
+
+export const getCanAddTrustline = (state: TypedState, accountID: Types.AccountID) => {
+  // We'd prefer this to be a field on account, rather than assets.
+  // Until then, pull it out of XLM assets.
+  const xlm = getAssets(state, accountID).find(a => a.assetCode === 'XLM')
+  return xlm ? xlm.canAddTrustline : false
+}
 
 export const getFederatedAddress = (state: TypedState, accountID: Types.AccountID) => {
   const account = state.wallets.accountMap.get(accountID, unknownAccount)

--- a/shared/wallets/trustline/container.tsx
+++ b/shared/wallets/trustline/container.tsx
@@ -14,16 +14,17 @@ type OwnProps = Container.RouteProps<
   {}
 >
 
-const mapStateToProps = (state, ownProps: OwnProps) => ({
-  accountAssets: Constants.getAssets(
-    state,
-    Container.getRouteProps(ownProps, 'accountID') || Types.noAccountID
-  ),
-  trustline: state.wallets.trustline,
-  waitingSearch: Waiting.anyWaiting(state, Constants.searchTrustlineAssetsWaitingKey),
-})
+const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
+  const accountID = Container.getRouteProps(ownProps, 'accountID') || Types.noAccountID
+  return {
+    accountAssets: Constants.getAssets(state, accountID),
+    canAddTrustline: Constants.getCanAddTrustline(state, accountID),
+    trustline: state.wallets.trustline,
+    waitingSearch: Waiting.anyWaiting(state, Constants.searchTrustlineAssetsWaitingKey),
+  }
+}
 
-const mapDispatchToProps = (dispatch, ownProps: OwnProps) => ({
+const mapDispatchToProps = (dispatch: Container.TypedDispatch, ownProps: OwnProps) => ({
   clearTrustlineModal: () => dispatch(WalletsGen.createClearTrustlineSearchResults()),
   onDone: () => dispatch(RouteTreeGen.createNavigateUp()),
   onSearchChange: debounce((text: string) => dispatch(WalletsGen.createSetTrustlineSearchText({text})), 500),
@@ -47,6 +48,7 @@ const mergeProps = (s, d, o: OwnProps) => {
       undefined,
       emptyAccountAsset
     ).balanceAvailableToSend,
+    canAddTrustline: s.canAddTrustline,
     clearTrustlineModal: d.clearTrustlineModal,
     loaded: s.trustline.loaded,
     popularAssets: s.trustline.popularAssets.filter(assetID => !acceptedAssets.has(assetID)).toArray(),

--- a/shared/wallets/trustline/index.stories.tsx
+++ b/shared/wallets/trustline/index.stories.tsx
@@ -60,7 +60,8 @@ const assets = {
 const commonTrustlineProps = {
   acceptedAssets: ['issuer1-KEYZ'],
   accountID: Types.noAccountID,
-  balanceAvailableToSend: 2,
+  balanceAvailableToSend: '2',
+  canAddTrustline: true,
   clearTrustlineModal: Sb.action('clearTrustlineModal'),
   loaded: true,
   onDone: Sb.action('onDone'),
@@ -129,7 +130,8 @@ const load = () => {
     .add('Trustline - search', () => (
       <Trustline {...commonTrustlineProps} searchingAssets={['issuer1-USD', 'issuer2-USD']} />
     ))
-    .add('Trustline - error', () => <Trustline {...commonTrustlineProps} balanceAvailableToSend={0.2} />)
+    .add('Trustline - error', () => <Trustline {...commonTrustlineProps} balanceAvailableToSend="0.2" />)
+    .add('Trustline - unable to add', () => <Trustline {...commonTrustlineProps} balanceAvailableToSend="0.2" canAddTrustline={false} />)
     .add('Trustline - loading', () => <Trustline {...commonTrustlineProps} loaded={false} />)
 }
 

--- a/shared/wallets/trustline/index.tsx
+++ b/shared/wallets/trustline/index.tsx
@@ -4,13 +4,13 @@ import * as Styles from '../../styles'
 import * as Kb from '../../common-adapters'
 import * as Types from '../../constants/types/wallets'
 import * as Constants from '../../constants/wallets'
-import {memoize} from '../../util/memoize'
 import Asset from './asset-container'
 
 type _Props = {
   accountID: Types.AccountID
   acceptedAssets: Array<Types.AssetID>
-  balanceAvailableToSend: number
+  balanceAvailableToSend: string
+  canAddTrustline: boolean
   clearTrustlineModal: () => void
   errorMessage?: string
   loaded: boolean
@@ -76,10 +76,6 @@ const sectionHeader = section =>
     </Kb.Box2>
   )
 
-const haveEnoughBalanceToAccept = memoize(
-  (props: BodyProps) => props.balanceAvailableToSend >= Constants.trustlineHoldingBalance
-)
-
 const ListUpdateOnMount = (props: BodyProps) => {
   // hack to get `ReactList` to render more than one item on initial mount.
   // Somehow we need two updates here.
@@ -98,7 +94,7 @@ const ListUpdateOnMount = (props: BodyProps) => {
           accountID={props.accountID}
           firstItem={index === 0}
           assetID={item}
-          cannotAccept={!haveEnoughBalanceToAccept(props)}
+          cannotAccept={!props.canAddTrustline}
         />
       )}
       renderSectionHeader={({section}) => sectionHeader(section)}
@@ -128,7 +124,7 @@ const Body = (props: BodyProps) => {
             />
           </Kb.Box2>
           <Kb.Divider />
-          {!haveEnoughBalanceToAccept(props) && (
+          {!props.canAddTrustline && (
             <Kb.Banner
               color="red"
               text={`Stellar holds ${


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers

Fixes being unable to add a trustline to an account with >three digits of XLM in, because there was a string >= number compare happening.