### PR TITLE
Airdrop: allow selecting the airdrop row in the wallets nav

### DIFF
--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -5,6 +5,7 @@ import * as Styles from '../styles'
 import {AllowedColors} from '../common-adapters/text'
 import * as Tabs from './tabs'
 import * as Flow from '../util/flow'
+import * as Router2Constants from './router2'
 import * as SettingsConstants from './settings'
 import {invert} from 'lodash-es'
 import {TypedState} from './reducer'
@@ -585,6 +586,11 @@ export const searchTrustlineAssetsWaitingKey = 'wallets:searchTrustlineAssets'
 export const getAccountIDs = (state: TypedState) => state.wallets.accountMap.keySeq().toList()
 
 export const getAccounts = (state: TypedState) => state.wallets.accountMap.valueSeq().toList()
+
+export const getAirdropSelected = (state: TypedState) => {
+  const path = Router2Constants.getVisibleScreen().routeName
+  return path === 'airdrop' || path === 'airdropQualify'
+}
 
 export const getSelectedAccount = (state: TypedState) => state.wallets.selectedAccount
 

--- a/shared/wallets/airdrop/index.tsx
+++ b/shared/wallets/airdrop/index.tsx
@@ -150,7 +150,12 @@ class Airdrop extends React.Component<Props> {
             ))}
           </Kb.Box2>
           {!p.signedUp && (
-            <Kb.Button type="Success" label="See if you qualify" onClick={this._onCheckQualify} />
+            <Kb.Button
+              style={styles.qualifyButton}
+              type="Success"
+              label="See if you qualify"
+              onClick={this._onCheckQualify}
+            />
           )}
           <Kb.Box2 direction="vertical" style={styles.grow} />
           <Kb.Box2
@@ -269,6 +274,10 @@ const styles = Styles.styleSheetCreate({
   progress: {
     height: 20,
     width: 20,
+  },
+  qualifyButton: {
+    marginLeft: Styles.globalMargins.tiny,
+    marginRight: Styles.globalMargins.tiny,
   },
   scrollView: {
     height: '100%',

--- a/shared/wallets/nav-header/container.tsx
+++ b/shared/wallets/nav-header/container.tsx
@@ -6,6 +6,7 @@ import {HeaderTitle as _HeaderTitle, HeaderRightActions as _HeaderRightActions} 
 
 const mapStateToPropsHeaderTitle = state => ({
   _account: Constants.getSelectedAccountData(state),
+  airdropSelected: Constants.getAirdropSelected(state),
   noDisclaimer: !state.wallets.acceptedDisclaimer,
   username: state.config.username,
 })
@@ -13,6 +14,7 @@ const mapStateToPropsHeaderTitle = state => ({
 const mergePropsHeaderTitle = s => ({
   accountID: s._account.accountID,
   accountName: s._account.name,
+  airdropSelected: s.airdropSelected,
   isDefault: s._account.isDefault,
   loading: s._account.accountID === Types.noAccountID,
   noDisclaimer: s.noDisclaimer,
@@ -28,6 +30,7 @@ export const HeaderTitle = Container.namedConnect(
 
 const mapStateToPropsHeaderRightActions = state => ({
   _accountID: Constants.getSelectedAccount(state),
+  airdropSelected: Constants.getAirdropSelected(state),
   noDisclaimer: !state.wallets.acceptedDisclaimer,
 })
 const mapDispatchToPropsHeaderRightActions = dispatch => ({
@@ -44,6 +47,7 @@ const mapDispatchToPropsHeaderRightActions = dispatch => ({
     ),
 })
 const mergePropsHeaderRightActions = (s, d, o) => ({
+  airdropSelected: s.airdropSelected,
   noDisclaimer: s.noDisclaimer,
   onReceive: () => d._onReceive(s._accountID),
 })

--- a/shared/wallets/nav-header/index.tsx
+++ b/shared/wallets/nav-header/index.tsx
@@ -8,6 +8,7 @@ import AddAccount from './add-account'
 type HeaderTitleProps = {
   accountID: Types.AccountID
   accountName: string
+  airdropSelected: boolean
   isDefault: boolean
   loading: boolean
   noDisclaimer: boolean
@@ -18,11 +19,17 @@ export const HeaderTitle = (props: HeaderTitleProps) =>
   props.noDisclaimer ? null : (
     <Kb.Box2 direction="horizontal">
       <Kb.Box2 alignItems="flex-end" direction="horizontal" style={styles.left}>
-        <AddAccount />
+        {!props.airdropSelected && <AddAccount />}
       </Kb.Box2>
       <Kb.Box2 direction="vertical" alignItems="flex-start" style={styles.accountInfo}>
         {props.loading ? (
           <Kb.ProgressIndicator type={'Small'} style={styles.loading} />
+        ) : props.airdropSelected ? (
+          <Kb.Box2 direction="horizontal">
+            <Kb.Text selectable={false} type="Header">
+              Airdrop
+            </Kb.Text>
+          </Kb.Box2>
         ) : (
           <>
             <Kb.Box2
@@ -44,12 +51,13 @@ export const HeaderTitle = (props: HeaderTitleProps) =>
   )
 
 type HeaderRightActionsProps = {
+  airdropSelected: boolean
   noDisclaimer: boolean
   onReceive: () => void
 }
 
 export const HeaderRightActions = (props: HeaderRightActionsProps) =>
-  props.noDisclaimer ? null : (
+  props.noDisclaimer || props.airdropSelected ? null : (
     <Kb.Box2 alignItems="flex-end" direction="horizontal" gap="tiny" style={styles.rightActions}>
       <SendButton small={true} />
       <Kb.Button type="Wallet" mode="Secondary" label="Receive" small={true} onClick={props.onReceive} />

--- a/shared/wallets/wallet-list/container.tsx
+++ b/shared/wallets/wallet-list/container.tsx
@@ -3,21 +3,18 @@ import * as Constants from '../../constants/wallets'
 import * as Container from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Styles from '../../styles'
-import openURL from '../../util/open-url'
 import {anyWaiting} from '../../constants/waiting'
 
 type OwnProps = {
   style: Styles.StylesCrossPlatform
 }
 
-const mapStateToProps = (state: Container.TypedState) => {
-  return {
-    accounts: Constants.getAccountIDs(state),
-    airdropSelected: false, // TODO path === 'airdrop' || path === 'airdropQualify',
-    inAirdrop: state.wallets.airdropState === 'accepted',
-    loading: anyWaiting(state, Constants.loadAccountsWaitingKey),
-  }
-}
+const mapStateToProps = (state: Container.TypedState) => ({
+  accounts: Constants.getAccountIDs(state),
+  airdropSelected: Constants.getAirdropSelected(state),
+  inAirdrop: state.wallets.airdropState === 'accepted',
+  loading: anyWaiting(state, Constants.loadAccountsWaitingKey),
+})
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onAddNew: () => {

--- a/shared/wallets/wallet-list/wallet-row/container.tsx
+++ b/shared/wallets/wallet-list/wallet-row/container.tsx
@@ -1,6 +1,6 @@
 import {WalletRow, Props} from '.'
 import {namedConnect, isMobile} from '../../../util/container'
-import {getAccount, getSelectedAccount} from '../../../constants/wallets'
+import {getAccount, getAirdropSelected, getSelectedAccount} from '../../../constants/wallets'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import {AccountID} from '../../../constants/types/wallets'
@@ -22,10 +22,9 @@ const mapStateToProps = (
   const me = state.config.username || ''
   const keybaseUser = account.isDefault ? me : ''
   const selectedAccount = getSelectedAccount(state)
-  // const path = RouteTree.getPath(state.routeTree.routeState).last()
-  const airdropSelected = false // TODO path === 'airdrop' || path === 'airdropQualify'
-
+  const airdropSelected = getAirdropSelected(state)
   return {
+    airdropSelected,
     contents: account.balanceDescription,
     isSelected: !airdropSelected && selectedAccount === ownProps.accountID,
     keybaseUser,
@@ -46,6 +45,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps): Props => ({
+  airdropSelected: stateProps.airdropSelected,
   contents: stateProps.contents,
   isSelected: !isMobile && stateProps.isSelected,
   keybaseUser: stateProps.keybaseUser,

--- a/shared/wallets/wallet-list/wallet-row/index.stories.tsx
+++ b/shared/wallets/wallet-list/wallet-row/index.stories.tsx
@@ -14,6 +14,7 @@ const load = () => {
     ))
     .add('Default', () => (
       <WalletRow
+        airdropSelected={false}
         contents="280.0871234 XLM + more"
         isSelected={true}
         keybaseUser="cecileb"
@@ -24,6 +25,7 @@ const load = () => {
     ))
     .add('Secondary', () => (
       <WalletRow
+        airdropSelected={false}
         contents="56.9618203 XLM"
         isSelected={false}
         keybaseUser=""
@@ -34,6 +36,7 @@ const load = () => {
     ))
     .add('Badged', () => (
       <WalletRow
+        airdropSelected={false}
         contents="56.9618203 XLM"
         isSelected={false}
         keybaseUser=""
@@ -44,6 +47,7 @@ const load = () => {
     ))
     .add('Long', () => (
       <WalletRow
+        airdropSelected={false}
         contents="56.9618203 XLM"
         isSelected={false}
         keybaseUser=""

--- a/shared/wallets/wallet-list/wallet-row/index.tsx
+++ b/shared/wallets/wallet-list/wallet-row/index.tsx
@@ -5,6 +5,7 @@ import * as Styles from '../../../styles'
 // TODO: This is now desktop-only, so remove references to isMobile.
 
 export type Props = {
+  airdropSelected: boolean
   contents: string
   isSelected: boolean
   keybaseUser: string


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

Before this PR, selecting the Airdrop row in the wallet subnav on desktop made it look like you were still inside an account view: an account was still shown in the nav underneath the new page.  This PR teaches the nav that `airdropSelected` means that you're just showing that, not any other account.