### PR TITLE
Trustlines: fix loading the add dialog on zero-balance accounts

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1092,7 +1092,7 @@ const refreshTrustlineAcceptedAssets = (state, {payload: {accountID}}) =>
     {accountID},
     Constants.refreshTrustlineAcceptedAssetsWaitingKey(accountID)
   ).then(balances => {
-    const {assets, limitsMutable} = balances.reduce(
+    const {assets, limitsMutable} = (balances || []).reduce(
       ({assets, limitsMutable}, balance) => {
         const assetDescription = rpcAssetToAssetDescription(balance.asset)
         return {


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers

The getTrustlinesLocal RPC can return null, e.g. for an account with zero balance.  Before this PR, we'd black bar on null.reduce().