### PR TITLE
fix panicky FBO error

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3023,9 +3023,15 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	node Node, ei data.EntryInfo, handle *tlfhandle.Handle, err error) {
 	startTime, timer := fbo.startOp(ctx, "getRootNode")
 	defer func() {
-		fbo.endOp(
-			ctx, startTime, timer, "getRootNode done: %s %p %+v",
-			getNodeIDStr(node), node.Obfuscator(), err)
+		if node != nil {
+			fbo.endOp(
+				ctx, startTime, timer, "getRootNode done: %s %p %+v",
+				getNodeIDStr(node), node.Obfuscator(), err)
+		} else {
+			fbo.endOp(
+				ctx, startTime, timer, "getRootNode done: %s <no node> %+v",
+				getNodeIDStr(node), err)
+		}
 	}()
 
 	lState := makeFBOLockState()


### PR DESCRIPTION
If `getRootNode` would return an error and not finish, the `node` it was returning would be `nil`. This would lead to the deferred end log calling `.Obfuscator()` on the nil node, resulting in a panic instead of an error.