### PR TITLE
fix AreWeConnectedToMDServer black by retrying up to 12s

### DIFF
--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -64,60 +64,62 @@ const loadFavorites = (
   action: FsGen.FavoritesLoadPayload | EngineGen.Keybase1NotifyFSFSFavoritesChangedPayload
 ) =>
   state.fs.kbfsDaemonStatus.rpcStatus === Types.KbfsDaemonRpcStatus.Connected &&
-  RPCTypes.SimpleFSSimpleFSListFavoritesRpcPromise().then(results => {
-    const mutablePayload = [
-      ...(results.favoriteFolders
-        ? [{folders: results.favoriteFolders, isFavorite: true, isIgnored: false, isNew: false}]
-        : []),
-      ...(results.ignoredFolders
-        ? [{folders: results.ignoredFolders, isFavorite: false, isIgnored: true, isNew: false}]
-        : []),
-      ...(results.newFolders
-        ? [{folders: results.newFolders, isFavorite: true, isIgnored: false, isNew: true}]
-        : []),
-    ].reduce(
-      (mutablePayload, {folders, isFavorite, isIgnored, isNew}) =>
-        folders.reduce((mutablePayload, folder) => {
-          const tlfType = rpcFolderTypeToTlfType(folder.folderType)
-          const tlfName =
-            tlfType === Types.TlfType.Private || tlfType === Types.TlfType.Public
-              ? tlfToPreferredOrder(folder.name, state.config.username)
-              : folder.name
-          return !tlfType
-            ? mutablePayload
-            : {
-                ...mutablePayload,
-                [tlfType]: mutablePayload[tlfType].set(
-                  tlfName,
-                  Constants.makeTlf({
-                    conflictState: rpcConflictStateToConflictState(folder.conflictState),
-                    isFavorite,
-                    isIgnored,
-                    isNew,
-                    name: tlfName,
-                    resetParticipants: I.List((folder.reset_members || []).map(({username}) => username)),
-                    syncConfig: getSyncConfigFromRPC(tlfName, tlfType, folder.syncConfig),
-                    teamId: folder.team_id || '',
-                    tlfMtime: folder.mtime || 0,
-                  })
-                ),
-              }
-        }, mutablePayload),
-      {
-        private: I.Map().asMutable(),
-        public: I.Map().asMutable(),
-        team: I.Map().asMutable(),
-      }
-    )
-    return FsGen.createFavoritesLoaded({
-      // @ts-ignore asImmutable returns a weak type
-      private: mutablePayload.private.asImmutable(),
-      // @ts-ignore asImmutable returns a weak type
-      public: mutablePayload.public.asImmutable(),
-      // @ts-ignore asImmutable returns a weak type
-      team: mutablePayload.team.asImmutable(),
+  RPCTypes.SimpleFSSimpleFSListFavoritesRpcPromise()
+    .then(results => {
+      const mutablePayload = [
+        ...(results.favoriteFolders
+          ? [{folders: results.favoriteFolders, isFavorite: true, isIgnored: false, isNew: false}]
+          : []),
+        ...(results.ignoredFolders
+          ? [{folders: results.ignoredFolders, isFavorite: false, isIgnored: true, isNew: false}]
+          : []),
+        ...(results.newFolders
+          ? [{folders: results.newFolders, isFavorite: true, isIgnored: false, isNew: true}]
+          : []),
+      ].reduce(
+        (mutablePayload, {folders, isFavorite, isIgnored, isNew}) =>
+          folders.reduce((mutablePayload, folder) => {
+            const tlfType = rpcFolderTypeToTlfType(folder.folderType)
+            const tlfName =
+              tlfType === Types.TlfType.Private || tlfType === Types.TlfType.Public
+                ? tlfToPreferredOrder(folder.name, state.config.username)
+                : folder.name
+            return !tlfType
+              ? mutablePayload
+              : {
+                  ...mutablePayload,
+                  [tlfType]: mutablePayload[tlfType].set(
+                    tlfName,
+                    Constants.makeTlf({
+                      conflictState: rpcConflictStateToConflictState(folder.conflictState),
+                      isFavorite,
+                      isIgnored,
+                      isNew,
+                      name: tlfName,
+                      resetParticipants: I.List((folder.reset_members || []).map(({username}) => username)),
+                      syncConfig: getSyncConfigFromRPC(tlfName, tlfType, folder.syncConfig),
+                      teamId: folder.team_id || '',
+                      tlfMtime: folder.mtime || 0,
+                    })
+                  ),
+                }
+          }, mutablePayload),
+        {
+          private: I.Map().asMutable(),
+          public: I.Map().asMutable(),
+          team: I.Map().asMutable(),
+        }
+      )
+      return FsGen.createFavoritesLoaded({
+        // @ts-ignore asImmutable returns a weak type
+        private: mutablePayload.private.asImmutable(),
+        // @ts-ignore asImmutable returns a weak type
+        public: mutablePayload.public.asImmutable(),
+        // @ts-ignore asImmutable returns a weak type
+        team: mutablePayload.team.asImmutable(),
+      })
     })
-  })
+    .catch(makeRetriableErrorHandler(action))
 
 const getSyncConfigFromRPC = (
   tlfName: string,
@@ -1019,14 +1021,32 @@ const finishManualCR = (state, action) =>
     path: Constants.pathToRPCPath(action.payload.localViewTlfPath),
   }).then(() => FsGen.createFavoritesLoad())
 
+// At start-up we might have a race where we get connected to a kbfs daemon
+// which dies soon after, and we get an EOF here. So retry for a few times
+// until we get through. After each try we delay for 2s, so this should give us
+// e.g. 12s when n == 6. If it still doesn't work after 12s, something's wrong
+// and we deserve a black bar.
+const checkIfWeReConnectedToMDServerUpToNTimes = (n: number) =>
+  RPCTypes.SimpleFSSimpleFSAreWeConnectedToMDServerRpcPromise()
+    .then(connectedToMDServer => FsGen.createKbfsDaemonOnlineStatusChanged({online: connectedToMDServer}))
+    .catch(
+      n > 0
+        ? error => {
+            logger.warn(`failed to check if we are connected to MDServer: ${error}; n=${n}`)
+            return Saga.delay(2000).then(() => checkIfWeReConnectedToMDServerUpToNTimes(n - 1))
+          }
+        : error => {
+            logger.warn(`failed to check if we are connected to MDServer : ${error}; n=${n}, throwing`)
+            throw error
+          }
+    )
+
 const updateKbfsDaemonOnlineStatus = (
   state,
   action: FsGen.KbfsDaemonRpcStatusChangedPayload | ConfigGen.OsNetworkStatusChangedPayload
 ) =>
   state.fs.kbfsDaemonStatus.rpcStatus === Types.KbfsDaemonRpcStatus.Connected && state.config.osNetworkOnline
-    ? RPCTypes.SimpleFSSimpleFSAreWeConnectedToMDServerRpcPromise().then(connectedToMDServer =>
-        FsGen.createKbfsDaemonOnlineStatusChanged({online: connectedToMDServer})
-      )
+    ? checkIfWeReConnectedToMDServerUpToNTimes(6)
     : Promise.resolve(FsGen.createKbfsDaemonOnlineStatusChanged({online: false}))
 
 // We don't trigger the reachability check at init. Reachability checks cause
@@ -1036,9 +1056,9 @@ const updateKbfsDaemonOnlineStatus = (
 // after we're up.
 const checkKbfsServerReachabilityIfNeeded = (state, action: ConfigGen.OsNetworkStatusChangedPayload) => {
   if (!action.payload.isInit) {
-    return RPCTypes.SimpleFSSimpleFSCheckReachabilityRpcPromise()
-      .then(() => {})
-      .catch(err => logger.warn(`failed to check KBFS reachability: ${err.message}`))
+    return RPCTypes.SimpleFSSimpleFSCheckReachabilityRpcPromise().catch(err =>
+      logger.warn(`failed to check KBFS reachability: ${err.message}`)
+    )
   }
 }
 

--- a/shared/actions/fs/shared.tsx
+++ b/shared/actions/fs/shared.tsx
@@ -2,6 +2,7 @@ import * as Types from '../../constants/types/fs'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as Constants from '../../constants/fs'
 import * as FsGen from '../fs-gen'
+import * as EngineGen from '../engine-gen-gen'
 import {TypedActions} from '../typed-actions-gen'
 
 const expectedOfflineErrorMatchers = [
@@ -12,9 +13,11 @@ const expectedOfflineErrorMatchers = [
 
 const expectedOfflineErrorCodes = [RPCTypes.StatusCode.scapinetworkerror, RPCTypes.StatusCode.scstreameof]
 
-const makeErrorHandler = (action: FsGen.Actions, path: Types.Path | null, retriable: boolean) => (
-  error: any
-): Array<TypedActions> => {
+const makeErrorHandler = (
+  action: FsGen.Actions | EngineGen.Actions,
+  path: Types.Path | null,
+  retriable: boolean
+) => (error: any): Array<TypedActions> => {
   const errorDesc = typeof error.desc === 'string' ? error.desc : ''
   if (path && errorDesc) {
     // TODO: KBFS-4143 add and use proper error code for all these
@@ -62,8 +65,8 @@ const makeErrorHandler = (action: FsGen.Actions, path: Types.Path | null, retria
   ]
 }
 
-export const makeRetriableErrorHandler = (action: FsGen.Actions, path?: Types.Path) =>
+export const makeRetriableErrorHandler = (action: FsGen.Actions | EngineGen.Actions, path?: Types.Path) =>
   makeErrorHandler(action, path, true)
 
-export const makeUnretriableErrorHandler = (action: FsGen.Actions, path?: Types.Path) =>
+export const makeUnretriableErrorHandler = (action: FsGen.Actions | EngineGen.Actions, path?: Types.Path) =>
   makeErrorHandler(action, path, false)

--- a/shared/constants/fs.tsx
+++ b/shared/constants/fs.tsx
@@ -3,6 +3,7 @@ import * as Types from './types/fs'
 import * as RPCTypes from './types/rpc-gen'
 import * as ChatConstants from './chat2'
 import * as FsGen from '../actions/fs-gen'
+import * as EngineGen from '../actions/engine-gen-gen'
 import * as Flow from '../util/flow'
 import * as Tabs from './tabs'
 import * as SettingsConstants from './settings'
@@ -222,8 +223,8 @@ const _makeError: I.Record.Factory<Types._FsError> = I.Record({
 type _MakeErrorArgs = {
   time?: number
   error: any
-  erroredAction: FsGen.Actions
-  retriableAction?: FsGen.Actions
+  erroredAction: FsGen.Actions | EngineGen.Actions
+  retriableAction?: FsGen.Actions | EngineGen.Actions
 }
 export const makeError = (args?: _MakeErrorArgs): I.RecordOf<Types._FsError> => {
   // TS Issue: https://github.com/microsoft/TypeScript/issues/26235
@@ -1105,7 +1106,7 @@ export const getSoftError = (softErrors: Types.SoftErrors, path: Types.Path): Ty
 export const hasSpecialFileElement = (path: Types.Path): boolean =>
   Types.getPathElements(path).some(elem => elem.startsWith('.kbfs'))
 
-export const erroredActionToMessage = (action: FsGen.Actions, error: string): string => {
+export const erroredActionToMessage = (action: FsGen.Actions | EngineGen.Actions, error: string): string => {
   // We have FsError.expectedIfOffline now to take care of real offline
   // scenarios, but we still need to keep this timeout check here in case we
   // get a timeout error when we think we think we're online. In this case it's

--- a/shared/constants/types/fs.tsx
+++ b/shared/constants/types/fs.tsx
@@ -5,6 +5,7 @@ import * as Devices from './devices'
 import * as TeamsTypes from '../../constants/types/teams'
 // TODO importing FsGen causes an import loop
 import * as FsGen from '../../actions/fs-gen'
+import * as EngineGen from '../../actions/engine-gen-gen'
 import {IconType} from '../../common-adapters/icon.constants'
 import {TextType} from '../../common-adapters/text'
 import {isWindows} from '../platform'
@@ -29,8 +30,8 @@ export enum ProgressType {
 export type _FsError = {
   time: number
   errorMessage: string
-  erroredAction: FsGen.Actions
-  retriableAction?: FsGen.Actions | null
+  erroredAction: FsGen.Actions | EngineGen.Actions
+  retriableAction?: FsGen.Actions | EngineGen.Actions | null
 }
 export type FsError = I.RecordOf<_FsError>
 

--- a/shared/fs/simple-screens/oops.tsx
+++ b/shared/fs/simple-screens/oops.tsx
@@ -124,9 +124,12 @@ const mapDispatchToProps = (dispatch, props: OwnPropsWithSafeNavigation) => ({
 })
 
 export default Container.withSafeNavigation(
-  Container.namedConnect(() => ({}), mapDispatchToProps, (s, d, o: OwnProps) => ({...o, ...s, ...d}), 'Oops')(
-    Oops
-  )
+  Container.namedConnect(
+    () => ({}),
+    mapDispatchToProps,
+    (s, d, o: OwnPropsWithSafeNavigation) => ({...o, ...s, ...d}),
+    'Oops'
+  )(Oops)
 ) as any
 
 const styles = Styles.styleSheetCreate({


### PR DESCRIPTION
I think the root cause of this is still the race that GUI comes up before the old KBFS instance dies. But this should fix the symptoms in short term before root cause is fixed.