### PR TITLE
remove duplicates from defaults

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -6609,6 +6609,9 @@ func TestReacjiStore(t *testing.T) {
 		}
 
 		expectedData := storage.NewReacjiInternalStorage()
+		for _, el := range storage.DefaultTopReacjis {
+			expectedData.FrequencyMap[el] = 0
+		}
 		conv := mustCreateConversationForTest(t, ctc, user, chat1.TopicType_CHAT, mt)
 		// if the user has no history we return the default list
 		userReacjis := tc.G.ChatHelper.UserReacjis(ctx, uid)
@@ -6637,6 +6640,8 @@ func TestReacjiStore(t *testing.T) {
 			info := consumeReactionUpdate(t, listener)
 			expected.TopReacjis = append([]string{reaction}, expected.TopReacjis...)
 			if i < 5 {
+				// remove defaults as user values are added
+				delete(expectedData.FrequencyMap, storage.DefaultTopReacjis[len(storage.DefaultTopReacjis)-i-1])
 				expected.TopReacjis = append(expected.TopReacjis, storage.DefaultTopReacjis...)[:len(storage.DefaultTopReacjis)]
 			}
 			assertReacjiStore(info.UserReacjis, expected, expectedData)

--- a/go/chat/storage/reacjis.go
+++ b/go/chat/storage/reacjis.go
@@ -20,7 +20,7 @@ const reacjiDiskVersion = 3
 var codeMap map[string]string
 
 // If the user has less than 5 favorite reacjis we stuff these defaults in.
-var DefaultTopReacjis = []string{":+1:", ":-1:", ":tada:", ":joy:", ":sunglasses:"}
+var DefaultTopReacjis = []string{":+1:", ":-1:", ":joy:", ":sunglasses:", ":tada:"}
 
 type ReacjiInternalStorage struct {
 	FrequencyMap map[string]int
@@ -50,7 +50,7 @@ func (i *reacjiMemCacheImpl) Get(uid gregor1.UID) (bool, *ReacjiInternalStorage)
 	i.RLock()
 	defer i.RUnlock()
 	if !uid.Eq(i.uid) {
-		return false, nil
+		return false, NewReacjiInternalStorage()
 	}
 	return true, i.data
 }
@@ -203,6 +203,16 @@ func (s *ReacjiStore) UserReacjis(ctx context.Context, uid gregor1.UID) keybase1
 
 	cache := s.populateCacheLocked(ctx, uid)
 	pairs := []reacjiPair{}
+	// add defaults if needed so we always return some values
+	for _, el := range DefaultTopReacjis {
+		if len(cache.FrequencyMap) >= len(DefaultTopReacjis) {
+			break
+		}
+		if _, ok := cache.FrequencyMap[el]; !ok {
+			cache.FrequencyMap[el] = 0
+		}
+	}
+
 	for name, freq := range cache.FrequencyMap {
 		pairs = append(pairs, reacjiPair{name: name, freq: freq})
 	}
@@ -216,11 +226,13 @@ func (s *ReacjiStore) UserReacjis(ctx context.Context, uid gregor1.UID) keybase1
 
 	reacjis := []string{}
 	for _, p := range pairs {
-		reacjis = append(reacjis, p.name)
+		if len(reacjis) >= len(DefaultTopReacjis) && p.freq == 0 {
+			delete(cache.FrequencyMap, p.name)
+		} else {
+			reacjis = append(reacjis, p.name)
+		}
 	}
-	if len(reacjis) < len(DefaultTopReacjis) {
-		reacjis = append(reacjis, DefaultTopReacjis[:len(DefaultTopReacjis)-len(reacjis)]...)
-	}
+
 	return keybase1.UserReacjis{
 		TopReacjis: reacjis,
 		SkinTone:   cache.SkinTone,


### PR DESCRIPTION
fixes an issue where we return duplicate `topReacjis` when the preferred reacjis were the defaults and user had `< len(DefaultTopReacjis)` preferences

cc @keybase/hotpotatosquad 