### PR TITLE
Fix PICNIC-98 so that when a new user clicks on the wallet tab it takes them to the wallet tab

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -913,7 +913,7 @@ const maybeNavToLinkExisting = (state, action: WalletsGen.CheckDisclaimerPayload
   })
 
 const rejectDisclaimer = (state, action: WalletsGen.RejectDisclaimerPayload) =>
-  isMobile ? RouteTreeGen.createNavigateUp() : RouteTreeGen.createClearModals()
+  isMobile ? RouteTreeGen.createNavigateUp() : RouteTreeGen.createSwitchTab({tab: Tabs.peopleTab})
 
 const loadMobileOnlyMode = (
   state,

--- a/shared/router-v2/tab-bar/container.desktop.tsx
+++ b/shared/router-v2/tab-bar/container.desktop.tsx
@@ -39,11 +39,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     if (ownProps.selectedTab !== Tabs.chatTab && tab === Tabs.chatTab) {
       dispatch(Chat2Gen.createTabSelected())
     }
-    if (ownProps.selectedTab !== Tabs.walletsTab && tab === Tabs.walletsTab && !walletsAcceptedDisclaimer) {
-      // haven't accepted disclaimer, show onboarding and bail
-      dispatch(RouteTreeGen.createNavigateAppend({path: ['walletOnboarding']}))
-      return
-    }
     if (ownProps.selectedTab === tab) {
       ownProps.navigation.navigate(tabRoots[tab])
     } else {


### PR DESCRIPTION
Prior to this commit, when a new user clicked on the wallet tab they would see the introduction/warning modal but the highlighted tab would stay the same as the one they were previously on. This PR changes it so that it correctly navigates them to the wallet tab (though the background stays blank). `navigateUp` did not appear to work correctly to navigate away from the wallet tab so now when a new user exits out of the introduction modal they will simply be sent to the first tab (the people tab).

Note that this also changes the code not to directly navigate to the `walletOnboarding` modal since the Wallet tab will automatically bring it up if necessary. 

![after](https://user-images.githubusercontent.com/5304541/60208647-cbfc4e80-9826-11e9-93d5-7dcf6b4e1c0c.png)