### PR TITLE
leveldb: wait up to 10s if leveldbs are open by another process

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -29,7 +29,6 @@ import (
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/storage"
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 )
@@ -1444,7 +1443,7 @@ func (c *ConfigLocal) MakeBlockMetadataStoreIfNotExists() (err error) {
 
 func (c *ConfigLocal) openConfigLevelDB(configName string) (*LevelDb, error) {
 	dbPath := filepath.Join(c.storageRoot, configName)
-	stor, err := storage.OpenFile(dbPath, false)
+	stor, err := openLevelDBStorage(nil, dbPath, c.MakeLogger(""))
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3777,10 +3777,12 @@ func openCRDBInternal(config Config) (*LevelDb, error) {
 		return nil, err
 	}
 
-	stor, err := storage.OpenFile(sysPath.Join(config.StorageRoot(),
-		conflictResolverRecordsDir, conflictResolverRecordsVersionString,
-		conflictResolverRecordsDB), false)
-
+	stor, err := openLevelDBStorage(
+		nil,
+		sysPath.Join(config.StorageRoot(),
+			conflictResolverRecordsDir, conflictResolverRecordsVersionString,
+			conflictResolverRecordsDB),
+		config.MakeLogger(""))
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -313,7 +313,7 @@ func newDiskBlockCacheLocal(config diskBlockCacheConfig,
 		return nil, err
 	}
 	blockDbPath := filepath.Join(versionPath, blockDbFilename)
-	blockStorage, err := storage.OpenFile(blockDbPath, false)
+	blockStorage, err := openLevelDBStorage(nil, blockDbPath, log)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +323,7 @@ func newDiskBlockCacheLocal(config diskBlockCacheConfig,
 		}
 	}()
 	metaDbPath := filepath.Join(versionPath, metaDbFilename)
-	metadataStorage, err := storage.OpenFile(metaDbPath, false)
+	metadataStorage, err := openLevelDBStorage(nil, metaDbPath, log)
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +333,7 @@ func newDiskBlockCacheLocal(config diskBlockCacheConfig,
 		}
 	}()
 	tlfDbPath := filepath.Join(versionPath, tlfDbFilename)
-	tlfStorage, err := storage.OpenFile(tlfDbPath, false)
+	tlfStorage, err := openLevelDBStorage(nil, tlfDbPath, log)
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func newDiskBlockCacheLocal(config diskBlockCacheConfig,
 		}
 	}()
 	lastUnrefDbPath := filepath.Join(versionPath, lastUnrefDbFilename)
-	lastUnrefStorage, err := storage.OpenFile(lastUnrefDbPath, false)
+	lastUnrefStorage, err := openLevelDBStorage(nil, lastUnrefDbPath, log)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/disk_md_cache.go
+++ b/go/kbfs/libkbfs/disk_md_cache.go
@@ -190,7 +190,7 @@ func newDiskMDCacheLocal(
 		return nil, err
 	}
 	headsDbPath := filepath.Join(versionPath, headsDbFilename)
-	headsStorage, err := storage.OpenFile(headsDbPath, false)
+	headsStorage, err := openLevelDBStorage(nil, headsDbPath, log)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/disk_quota_cache.go
+++ b/go/kbfs/libkbfs/disk_quota_cache.go
@@ -178,7 +178,7 @@ func newDiskQuotaCacheLocal(
 		return nil, err
 	}
 	dbPath := filepath.Join(versionPath, quotaDbFilename)
-	quotaStorage, err := storage.OpenFile(dbPath, false)
+	quotaStorage, err := openLevelDBStorage(nil, dbPath, log)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/settings_db.go
+++ b/go/kbfs/libkbfs/settings_db.go
@@ -52,7 +52,8 @@ func openSettingsDBInternal(config Config) (*LevelDb, error) {
 		return nil, err
 	}
 
-	stor, err := storage.OpenFile(path.Join(dbPath, settingsDBName), false)
+	stor, err := openLevelDBStorage(
+		nil, path.Join(dbPath, settingsDBName), config.MakeLogger(""))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If the supervisor process hasn't completely killed the previous kbfs process yet, this affords us a little buffer time to wait for that process to fully die before we give up and fail to open the caches.

Issue: HOTPOT-214