### PR TITLE
Don't remove modals immediately when deleting an account

### DIFF
--- a/shared/wallets/wallet/settings/popups/really-remove-account/container.tsx
+++ b/shared/wallets/wallet/settings/popups/really-remove-account/container.tsx
@@ -30,14 +30,12 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch, {navigateUp}) => ({
   _onClose: (accountID: Types.AccountID) => dispatch(RouteTreeGen.createNavigateUp()),
   _onCopyKey: (secretKey: string) => dispatch(ConfigGen.createCopyToClipboard({text: secretKey})),
-  _onFinish: (accountID: Types.AccountID) => {
+  _onFinish: (accountID: Types.AccountID) =>
     dispatch(
       WalletsGen.createDeleteAccount({
         accountID,
       })
-    )
-    dispatch(RouteTreeGen.createClearModals())
-  },
+    ),
   _onLoadSecretKey: (accountID: Types.AccountID) => dispatch(WalletsGen.createExportSecretKey({accountID})),
   _onSecretKeySeen: (accountID: Types.AccountID) => dispatch(WalletsGen.createSecretKeySeen({accountID})),
 })


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers @mlsteele 

On master when you delete a Stellar account, this happens:

1. you click the Remove button
2. the deleteAccount saga starts
3. clear modals fires immediately (now you're on Wallet->Settings)
4. finish deleting account
5. deletedAccount action fires
6. clear modals again
7. nav to wallet root

This means that while the deletion's happening, you're looking at the Settings screen.  Then at some point it re-selects the default account, and then you're looking at that account's settings screen, and then the setting screen is nav'd up away from.

I ran out of time trying to make the entire nav to the wallet root be one action, so that we never transition visibly through the Settings screen.  But at least if we remove step 3 altogether (what this PR does), you'll see the spinner on the really-remove component while the deletion is happening, as you should, and the momentary nav through Settings at the end will be much shorter.

The reason I couldn't get just one nav action going is that clearModals() stops working once you've nav'd away from the screen with the modals on.  So:

1. clear modals (wallets->settings->remove->really-remove => wallets->settings)
2. nav up (wallets->settings => wallets)

works, but

1. nav up (wallets->settings => wallets)
2. clear modals action now fails to leave you on wallets

I'd like to understand and make this nav flow better, but.. like I said, out of time for experimenting.