### PR TITLE
Increase default log send size when on wifi

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -287,7 +287,13 @@ func LogSend(statusJSON string, feedback string, sendLogs, sendMaxBytes bool, ui
 	logSendContext.Logs.Desktop = uiLogPath
 	logSendContext.Logs.Trace = traceDir
 	logSendContext.Logs.CPUProfile = cpuProfileDir
-	numBytes := status.LogSendDefaultBytesMobile
+	var numBytes int
+	switch kbCtx.MobileNetState.State() {
+	case keybase1.MobileNetworkState_WIFI:
+		numBytes = status.LogSendDefaultBytesMobileWifi
+	default:
+		numBytes = status.LogSendDefaultBytesMobileNoWifi
+	}
 	if sendMaxBytes {
 		numBytes = status.LogSendMaxBytes
 	}

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -1928,7 +1928,7 @@ func (e *Env) GetLogFileConfig(filename string) *logger.LogFileConfig {
 
 	if e.GetAppType() == MobileAppType && !e.GetFeatureFlags().Admin(e.GetUID()) {
 		maxKeepFiles = 2
-		maxSize = 16 * opt.MiB // NOTE: If you decrease this, check go/bind/keybase.go:LogSend to make sure we aren't sending more than we store.
+		maxSize = 16 * opt.MiB
 	} else {
 		maxKeepFiles = 3
 		maxSize = 128 * opt.MiB

--- a/go/status/log_send.go
+++ b/go/status/log_send.go
@@ -17,12 +17,15 @@ import (
 )
 
 const (
-	LogSendDefaultBytesDesktop = 1024 * 1024 * 16
-	// NOTE: If you increase LogSendDefaultBytesMobile, check
-	// go/libkb/env.go:Env.GetLogFileConfig to make sure we store at least that
-	// much.
-	LogSendDefaultBytesMobile = 1024 * 1024 * 10
-	LogSendMaxBytes           = 1024 * 1024 * 128
+	// After gzipping the logs we compress by this factor on avg. We use this
+	// to calculate the amount of raw log bytes we should read when sending.
+	AvgCompressionRatio        = 10
+	LogSendDefaultBytesDesktop = 1024 * 1024 * 16 * AvgCompressionRatio
+	// NOTE: On mobile we may store less than the number of bytes we attempt to
+	// send. See go/libkb/env.go:Env.GetLogFileConfig
+	LogSendDefaultBytesMobileWifi   = 1024 * 1024 * 10 * AvgCompressionRatio
+	LogSendDefaultBytesMobileNoWifi = 1024 * 1024 * 1 * AvgCompressionRatio
+	LogSendMaxBytes                 = 1024 * 1024 * 128 * AvgCompressionRatio
 )
 
 // Logs is the struct to specify the path of log files


### PR DESCRIPTION
calculated avg compression ratio from ~50 logs i had downloaded

- [x] verify on mobile

cc @keybase/hotpotatosquad 