### PR TITLE
fix reply styling on mobile

### DIFF
--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -139,6 +139,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
           : {onClick: dispatchProps._onShowInFinder, title: 'Show in finder'}
       )
     }
+    items.push({onClick: dispatchProps._onReply, title: 'Reply'})
   } else {
     if (stateProps._canEdit) {
       items.push({onClick: dispatchProps._onEdit, title: 'Edit'})

--- a/shared/chat/conversation/messages/text/index.tsx
+++ b/shared/chat/conversation/messages/text/index.tsx
@@ -99,7 +99,7 @@ const MessageText = ({isEditing, message, reply, text, type}: Props) => {
   )
 
   return Styles.isMobile ? (
-    <Kb.Box2 direction="vertical" style={styles.wrapper}>
+    <Kb.Box2 direction="vertical" style={styles.wrapper} fullWidth={true}>
       {content}
     </Kb.Box2>
   ) : (


### PR DESCRIPTION
Without this, replies on mobile get sized down to not take up the full width of the thread. Since `styles.wrapper` has `flex: 1`, I'm pretty sure this is necessary, but happy to hear about any other ideas.