### PR TITLE
teams: integrate hidden ratchets

### DIFF
--- a/go/libkb/context.go
+++ b/go/libkb/context.go
@@ -150,6 +150,11 @@ func (m MetaContext) WithDelegatedIdentifyUI(u IdentifyUI) MetaContext {
 	return m
 }
 
+func (m MetaContext) WithContext(ctx context.Context) MetaContext {
+	m.ctx = ctx
+	return m
+}
+
 func (m MetaContext) WithContextCancel() (MetaContext, func()) {
 	var f func()
 	m.ctx, f = context.WithCancel(m.ctx)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -723,7 +723,7 @@ type FastTeamLoader interface {
 type HiddenTeamChainManager interface {
 	// We got gossip about what the latest chain-tail should be, so ratchet the
 	// chain forward; the next call to Advance() has to match.
-	Ratchet(MetaContext, keybase1.TeamID, keybase1.HiddenTeamChainRatchet) error
+	Ratchet(MetaContext, keybase1.TeamID, keybase1.HiddenTeamChainRatchetSet) error
 	// We got a bunch of new links downloaded via slow or fast loader, so add them
 	// onto the HiddenTeamChain state. Ensure that the updated state is at least up to the
 	// given ratchet value.

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -163,7 +163,7 @@ func (n nullHiddenTeamChainManager) Tail(mctx MetaContext, id keybase1.TeamID) (
 	return nil, nil
 }
 
-func (n nullHiddenTeamChainManager) Ratchet(MetaContext, keybase1.TeamID, keybase1.HiddenTeamChainRatchet) error {
+func (n nullHiddenTeamChainManager) Ratchet(MetaContext, keybase1.TeamID, keybase1.HiddenTeamChainRatchetSet) error {
 	return nil
 }
 func (n nullHiddenTeamChainManager) Advance(MetaContext, keybase1.HiddenTeamChain, *keybase1.LinkTriple) error {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2797,6 +2797,22 @@ func (h *HiddenTeamChain) Tail() *HiddenTeamChainLink {
 	return &ret
 }
 
+func (h *HiddenTeamChain) TailTriple() *LinkTriple {
+	last := h.Last
+	if last == Seqno(0) {
+		return nil
+	}
+	link, ok := h.Outer[last]
+	if !ok {
+		return nil
+	}
+	return &LinkTriple{
+		Seqno:   last,
+		LinkID:  link,
+		SeqType: SeqType_TEAM_PRIVATE_HIDDEN,
+	}
+}
+
 func (s Signer) UserVersion() UserVersion {
 	return UserVersion{
 		Uid:         s.U,
@@ -2819,55 +2835,92 @@ func (p PerTeamSeedCheckPostImage) Eq(p2 PerTeamSeedCheckPostImage) bool {
 	return (p.Version == p2.Version) && hmac.Equal(p.Value[:], p2.Value[:])
 }
 
-func (r HiddenTeamChainRatchet) Flat() []LinkTripleAndTime {
+func (r HiddenTeamChainRatchetSet) Flat() []LinkTripleAndTime {
+	if r.Ratchets == nil {
+		return nil
+	}
 	var ret []LinkTripleAndTime
-	add := func(p *LinkTripleAndTime) {
-		if p != nil {
-			ret = append(ret, *p)
-		}
+	for _, v := range r.Ratchets {
+		ret = append(ret, v)
 	}
-	add(r.Main)
-	add(r.Blinded)
-	add(r.Self)
 	return ret
 }
 
-func (r HiddenTeamChainRatchet) Max() Seqno {
+func (r HiddenTeamChainRatchetSet) IsEmpty() bool {
+	return r.Ratchets == nil || len(r.Ratchets) == 0
+}
+
+func (r HiddenTeamChainRatchetSet) Max() Seqno {
 	var ret Seqno
-	visit := func(p *LinkTripleAndTime) {
-		if p != nil && p.Triple.Seqno > ret {
-			ret = p.Triple.Seqno
+	if r.Ratchets == nil {
+		return ret
+	}
+	for _, v := range r.Ratchets {
+		if v.Triple.Seqno > ret {
+			ret = v.Triple.Seqno
 		}
 	}
-	visit(r.Main)
-	visit(r.Blinded)
-	visit(r.Self)
 	return ret
 }
 
-func (r HiddenTeamChainRatchet) MaxTriple() (ret *LinkTriple) {
-	visit := func(p *LinkTripleAndTime) {
-		if p != nil && (ret == nil || p.Triple.Seqno > ret.Seqno) {
-			ret = &p.Triple
+func (r HiddenTeamChainRatchetSet) MaxTriple() *LinkTriple {
+	if r.Ratchets == nil {
+		return nil
+	}
+	var out LinkTriple
+	for _, v := range r.Ratchets {
+		if v.Triple.Seqno > out.Seqno {
+			out = v.Triple
 		}
 	}
-	visit(r.Main)
-	visit(r.Blinded)
-	visit(r.Self)
-	return ret
+	return &out
 }
 
-func (r *HiddenTeamChainRatchet) Merge(r2 HiddenTeamChainRatchet) (updated bool) {
-	visit := func(l1 **LinkTripleAndTime, l2 *LinkTripleAndTime) {
-		if l2 != nil && l2.Triple.SeqType == SeqType_TEAM_PRIVATE_HIDDEN && (*l1 == nil || (*l1).Triple.Seqno < l2.Triple.Seqno) {
-			*l1 = l2
+func (r *HiddenTeamChain) MaxTriple() *LinkTriple {
+	tail := r.TailTriple()
+	rat := r.RatchetSet.MaxTriple()
+	if rat == nil && tail == nil {
+		return nil
+	}
+	if rat == nil {
+		return tail
+	}
+	if tail == nil {
+		return rat
+	}
+	if tail.Seqno > rat.Seqno {
+		return tail
+	}
+	return rat
+}
+
+func (r *HiddenTeamChainRatchetSet) init() {
+	if r.Ratchets == nil {
+		r.Ratchets = make(map[RatchetType]LinkTripleAndTime)
+	}
+}
+
+func (r *HiddenTeamChainRatchetSet) Merge(r2 HiddenTeamChainRatchetSet) (updated bool) {
+	r.init()
+	if r2.Ratchets == nil {
+		return false
+	}
+	for k, v := range r2.Ratchets {
+		if r.Add(k, v) {
 			updated = true
 		}
 	}
-	visit(&r.Main, r2.Main)
-	visit(&r.Blinded, r2.Blinded)
-	visit(&r.Self, r2.Self)
 	return updated
+}
+
+func (r *HiddenTeamChainRatchetSet) Add(t RatchetType, v LinkTripleAndTime) (changed bool) {
+	r.init()
+	found, ok := r.Ratchets[t]
+	if (v.Triple.SeqType == SeqType_TEAM_PRIVATE_HIDDEN) && (!ok || v.Triple.Seqno > found.Triple.Seqno) {
+		r.Ratchets[t] = v
+		changed = true
+	}
+	return changed
 }
 
 func (r LinkTripleAndTime) Clashes(r2 LinkTripleAndTime) bool {
@@ -2913,6 +2966,10 @@ func (d *HiddenTeamChain) Merge(newData HiddenTeamChain) (updated bool, err erro
 		if !ok || existing < v {
 			d.LastPerTeamKeys[k] = v
 		}
+	}
+
+	if d.RatchetSet.Merge(newData.RatchetSet) {
+		updated = true
 	}
 
 	return updated, nil

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -822,35 +822,53 @@ func (o FastTeamData) DeepCopy() FastTeamData {
 	}
 }
 
-type HiddenTeamChainRatchet struct {
-	Main    *LinkTripleAndTime `codec:"main,omitempty" json:"main,omitempty"`
-	Blinded *LinkTripleAndTime `codec:"blinded,omitempty" json:"blinded,omitempty"`
-	Self    *LinkTripleAndTime `codec:"self,omitempty" json:"self,omitempty"`
+type RatchetType int
+
+const (
+	RatchetType_MAIN    RatchetType = 0
+	RatchetType_BLINDED RatchetType = 1
+	RatchetType_SELF    RatchetType = 2
+)
+
+func (o RatchetType) DeepCopy() RatchetType { return o }
+
+var RatchetTypeMap = map[string]RatchetType{
+	"MAIN":    0,
+	"BLINDED": 1,
+	"SELF":    2,
 }
 
-func (o HiddenTeamChainRatchet) DeepCopy() HiddenTeamChainRatchet {
-	return HiddenTeamChainRatchet{
-		Main: (func(x *LinkTripleAndTime) *LinkTripleAndTime {
+var RatchetTypeRevMap = map[RatchetType]string{
+	0: "MAIN",
+	1: "BLINDED",
+	2: "SELF",
+}
+
+func (e RatchetType) String() string {
+	if v, ok := RatchetTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type HiddenTeamChainRatchetSet struct {
+	Ratchets map[RatchetType]LinkTripleAndTime `codec:"ratchets" json:"ratchets"`
+}
+
+func (o HiddenTeamChainRatchetSet) DeepCopy() HiddenTeamChainRatchetSet {
+	return HiddenTeamChainRatchetSet{
+		Ratchets: (func(x map[RatchetType]LinkTripleAndTime) map[RatchetType]LinkTripleAndTime {
 			if x == nil {
 				return nil
 			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.Main),
-		Blinded: (func(x *LinkTripleAndTime) *LinkTripleAndTime {
-			if x == nil {
-				return nil
+			ret := make(map[RatchetType]LinkTripleAndTime, len(x))
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := v.DeepCopy()
+				ret[kCopy] = vCopy
 			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.Blinded),
-		Self: (func(x *LinkTripleAndTime) *LinkTripleAndTime {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.Self),
+			return ret
+		})(o.Ratchets),
 	}
 }
 
@@ -866,7 +884,7 @@ type HiddenTeamChain struct {
 	Outer             map[Seqno]LinkID               `codec:"outer" json:"outer"`
 	Inner             map[Seqno]HiddenTeamChainLink  `codec:"inner" json:"inner"`
 	ReaderPerTeamKeys map[PerTeamKeyGeneration]Seqno `codec:"readerPerTeamKeys" json:"readerPerTeamKeys"`
-	Ratchet           HiddenTeamChainRatchet         `codec:"ratchet" json:"ratchet"`
+	RatchetSet        HiddenTeamChainRatchetSet      `codec:"ratchetSet" json:"ratchetSet"`
 	CachedAt          Time                           `codec:"cachedAt" json:"cachedAt"`
 }
 
@@ -927,8 +945,8 @@ func (o HiddenTeamChain) DeepCopy() HiddenTeamChain {
 			}
 			return ret
 		})(o.ReaderPerTeamKeys),
-		Ratchet:  o.Ratchet.DeepCopy(),
-		CachedAt: o.CachedAt.DeepCopy(),
+		RatchetSet: o.RatchetSet.DeepCopy(),
+		CachedAt:   o.CachedAt.DeepCopy(),
 	}
 }
 

--- a/go/teams/chain_parse.go
+++ b/go/teams/chain_parse.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams/hidden"
 )
 
 type SCTeamName string
@@ -28,21 +29,22 @@ type SCTeamMember keybase1.UserVersion
 type SCMapInviteIDToUV map[keybase1.TeamInviteID]keybase1.UserVersionPercentForm
 
 type SCTeamSection struct {
-	ID               SCTeamID              `json:"id"`
-	Name             *SCTeamName           `json:"name,omitempty"`
-	Members          *SCTeamMembers        `json:"members,omitempty"`
-	Parent           *SCTeamParent         `json:"parent,omitempty"`
-	Subteam          *SCSubteam            `json:"subteam,omitempty"`
-	PerTeamKey       *SCPerTeamKey         `json:"per_team_key,omitempty"`
-	Admin            *SCTeamAdmin          `json:"admin,omitempty"`
-	Invites          *SCTeamInvites        `json:"invites,omitempty"`
-	CompletedInvites SCMapInviteIDToUV     `json:"completed_invites,omitempty"`
-	Implicit         bool                  `json:"is_implicit,omitempty"`
-	Public           bool                  `json:"is_public,omitempty"`
-	Entropy          SCTeamEntropy         `json:"entropy,omitempty"`
-	Settings         *SCTeamSettings       `json:"settings,omitempty"`
-	KBFS             *SCTeamKBFS           `json:"kbfs,omitempty"`
-	BoxSummaryHash   *SCTeamBoxSummaryHash `json:"box_summary_hash,omitempty"`
+	ID               SCTeamID               `json:"id"`
+	Name             *SCTeamName            `json:"name,omitempty"`
+	Members          *SCTeamMembers         `json:"members,omitempty"`
+	Parent           *SCTeamParent          `json:"parent,omitempty"`
+	Subteam          *SCSubteam             `json:"subteam,omitempty"`
+	PerTeamKey       *SCPerTeamKey          `json:"per_team_key,omitempty"`
+	Admin            *SCTeamAdmin           `json:"admin,omitempty"`
+	Invites          *SCTeamInvites         `json:"invites,omitempty"`
+	CompletedInvites SCMapInviteIDToUV      `json:"completed_invites,omitempty"`
+	Implicit         bool                   `json:"is_implicit,omitempty"`
+	Public           bool                   `json:"is_public,omitempty"`
+	Entropy          SCTeamEntropy          `json:"entropy,omitempty"`
+	Settings         *SCTeamSettings        `json:"settings,omitempty"`
+	KBFS             *SCTeamKBFS            `json:"kbfs,omitempty"`
+	BoxSummaryHash   *SCTeamBoxSummaryHash  `json:"box_summary_hash,omitempty"`
+	Ratchets         []hidden.SCTeamRatchet `json:"ratchets,omitempty"`
 }
 
 type SCTeamMembers struct {
@@ -222,6 +224,14 @@ func (s SCChainLinkPayload) TeamAdmin() *SCTeamAdmin {
 		return nil
 	}
 	return t.Admin
+}
+
+func (s SCChainLinkPayload) Ratchets() []hidden.SCTeamRatchet {
+	t := s.Body.Team
+	if t == nil {
+		return nil
+	}
+	return t.Ratchets
 }
 
 func (s SCChainLinkPayload) TeamID() (keybase1.TeamID, error) {

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams/hidden"
 	jsonw "github.com/keybase/go-jsonw"
 )
 
@@ -383,7 +384,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 	// starts a root team, and so making that link is very similar to what the
 	// CreateTeamEngine does.
 
-	newSubteamSig, err := generateNewSubteamSigForParentChain(mctx, me, deviceSigningKey, parentTeam.chain(), subteamName, subteamID, admin)
+	newSubteamSig, ratchet, err := generateNewSubteamSigForParentChain(mctx, me, deviceSigningKey, parentTeam.chain(), subteamName, subteamID, admin)
 	if err != nil {
 		return nil, err
 	}
@@ -414,6 +415,7 @@ func CreateSubteam(ctx context.Context, g *libkb.GlobalContext, subteamBasename 
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []interface{}{newSubteamSig, subteamHeadSig}
 	payload["per_team_key"] = secretboxes
+	ratchet.AddToJSONPayload(payload)
 
 	_, err = g.API.PostJSON(mctx, libkb.APIArg{
 		Endpoint:    "sig/multi",
@@ -454,19 +456,19 @@ func makeRootTeamSection(teamName string, teamID keybase1.TeamID, members SCTeam
 	return teamSection, nil
 }
 
-func generateNewSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamName keybase1.TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
-	newSubteamSigBody, err := NewSubteamSig(m.G(), me, signingKey, parentTeam, subteamName, subteamID, admin)
+func generateNewSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamName keybase1.TeamName, subteamID keybase1.TeamID, admin *SCTeamAdmin) (item *libkb.SigMultiItem, r *hidden.Ratchet, err error) {
+	newSubteamSigBody, ratchet, err := NewSubteamSig(m, me, signingKey, parentTeam, subteamName, subteamID, admin)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	newSubteamSigJSON, err := newSubteamSigBody.Marshal()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	prevLinkID, err := libkb.ImportLinkID(parentTeam.GetLatestLinkID())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	seqType := seqTypeForTeamPublicness(parentTeam.IsPublic())
 
@@ -483,7 +485,7 @@ func generateNewSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserForSi
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	item = &libkb.SigMultiItem{
@@ -495,7 +497,7 @@ func generateNewSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserForSi
 		TeamID:     parentTeam.GetID(),
 		Version:    libkb.KeybaseSignatureV2,
 	}
-	return item, nil
+	return item, ratchet, nil
 }
 
 func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext, me libkb.UserForSignatures,

--- a/go/teams/hidden/errors.go
+++ b/go/teams/hidden/errors.go
@@ -45,3 +45,15 @@ func NewGenerateError(format string, args ...interface{}) GenerateError {
 }
 
 var _ error = GenerateError{}
+
+type RatchetError struct {
+	note string
+}
+
+func (e RatchetError) Error() string {
+	return fmt.Sprintf("hidden team ratchet error: %s", e.note)
+}
+
+func newRatchetError(format string, args ...interface{}) RatchetError {
+	return RatchetError{fmt.Sprintf(format, args...)}
+}

--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -450,6 +450,7 @@ func (l *LoaderPackage) SetRatchetBlindingKeySet(r *RatchetBlindingKeySet) {
 	l.rbks = r
 }
 
+// AddRatchets calls AddRatchet on each SCTeamRatchet in v.
 func (l *LoaderPackage) AddRatchets(mctx libkb.MetaContext, v []SCTeamRatchet, ctime int, typ keybase1.RatchetType) (err error) {
 	for _, r := range v {
 		err := l.AddRatchet(mctx, r, ctime, typ)
@@ -460,6 +461,11 @@ func (l *LoaderPackage) AddRatchets(mctx libkb.MetaContext, v []SCTeamRatchet, c
 	return nil
 }
 
+// AddRatchet is called whenever we pull a ratchet out of a visible team link. The first thing we'll need to
+// do is to make sure that we can look the unblinded ratchet up using the blinding keys we got down from the
+// server. Then we'll check the ratchets again the old (loaded) and new (downloaded) data. Finally, we'll
+// ensure that this ratchet doesn't clash another ratchet that came down in this update. If all checks work,
+// then add this ratchet to the set of all new ratchets, and also the max ratchet set that we're keeping locally.
 func (l *LoaderPackage) AddRatchet(mctx libkb.MetaContext, r SCTeamRatchet, ctime int, typ keybase1.RatchetType) (err error) {
 	tail := l.rbks.Get(r)
 	if tail == nil {

--- a/go/teams/hidden/ratchet.go
+++ b/go/teams/hidden/ratchet.go
@@ -1,0 +1,299 @@
+package hidden
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/msgpack"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/sig3"
+)
+
+type EncodedRatchetBlindingKeySet string
+
+func (e EncodedRatchetBlindingKeySet) IsNil() bool    { return len(e) == 0 }
+func (e EncodedRatchetBlindingKeySet) String() string { return string(e) }
+
+type BlindingKey [32]byte
+type SCTeamRatchet [32]byte
+
+type RatchetVersion int
+
+const RatchetVersion1 = RatchetVersion(1)
+
+type RatchetBlind struct {
+	Hash SCTeamRatchet `codec:"r"`
+	Key  BlindingKey   `codec:"k"`
+}
+
+type RatchetObj struct {
+	Body         sig3.Tail      `codec:"b"`
+	RatchetBlind RatchetBlind   `codec:"r"`
+	Version      RatchetVersion `codec:"v"`
+}
+
+type Ratchet struct {
+	encoded EncodedRatchetBlindingKeySet
+	decoded RatchetObj
+}
+
+type RatchetBlindingKeySet struct {
+	m map[SCTeamRatchet]RatchetObj
+}
+
+func (r SCTeamRatchet) String() string {
+	return hex.EncodeToString(r[:])
+}
+
+func (r *SCTeamRatchet) UnmarshalJSON(b []byte) error {
+	unquoted := keybase1.UnquoteBytes(b)
+	if len(unquoted) == 0 {
+		return nil
+	}
+	b, err := hex.DecodeString(string(unquoted))
+	if err != nil {
+		return err
+	}
+	if len(b) != len(*r) {
+		return newRatchetError("cannot decode team ratchet; wrong size")
+	}
+	copy((*r)[:], b[:])
+	return nil
+}
+
+func (r *RatchetBlindingKeySet) Get(ratchet SCTeamRatchet) *sig3.Tail {
+	if r == nil || r.m == nil {
+		return nil
+	}
+	obj, ok := r.m[ratchet]
+	if !ok {
+		return nil
+	}
+	return &obj.Body
+}
+
+func (r *RatchetBlindingKeySet) UnmarshalJSON(b []byte) error {
+	r.m = make(map[SCTeamRatchet]RatchetObj)
+	if string(b) == "null" {
+		return nil
+	}
+	unquoted := keybase1.UnquoteBytes(b)
+	if len(unquoted) == 0 {
+		return nil
+	}
+	b, err := base64.StdEncoding.DecodeString(string(unquoted))
+	if err != nil {
+		return err
+	}
+	var arr []RatchetObj
+	err = msgpack.Decode(&arr, b)
+	if err != nil {
+		return err
+	}
+	for _, e := range arr {
+		err = e.check()
+		if err != nil {
+			return err
+		}
+		r.m[e.RatchetBlind.Hash] = e
+	}
+	return err
+}
+
+func (r *SCTeamRatchet) MarshalJSON() ([]byte, error) {
+	s := hex.EncodeToString([]byte((*r)[:]))
+	b := keybase1.Quote(s)
+	return b, nil
+}
+
+func (r *Ratchet) ToTeamSection() []SCTeamRatchet {
+	if r == nil {
+		return nil
+	}
+	return []SCTeamRatchet{r.decoded.RatchetBlind.Hash}
+}
+
+func (r *Ratchet) ToSigPayload() (ret EncodedRatchetBlindingKeySet) {
+	if r == nil {
+		return ret
+	}
+	return r.encoded
+}
+
+func genRandomBytes(i int) ([]byte, error) {
+	ret := make([]byte, i, i)
+	n, err := rand.Reader.Read(ret[:])
+	if err != nil {
+		return nil, err
+	}
+	if n != i {
+		return nil, newRatchetError("short random entropy read")
+	}
+	return ret, nil
+}
+
+func generateBlindingKey() (BlindingKey, error) {
+	var ret BlindingKey
+	tmp, err := genRandomBytes(len(ret))
+	if err != nil {
+		return ret, err
+	}
+	copy(ret[:], tmp[:])
+	return ret, nil
+}
+
+func (r *RatchetBlind) computeToSelf(tail sig3.Tail) (err error) {
+	h, err := r.compute(tail)
+	if err != nil {
+		return err
+	}
+	r.Hash = h
+	return nil
+}
+
+func (r *RatchetObj) check() (err error) {
+	return r.RatchetBlind.check(r.Body)
+}
+
+func (r *RatchetBlind) check(tail sig3.Tail) (err error) {
+	computed, err := r.compute(tail)
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal(computed[:], r.Hash[:]) {
+		return newRatchetError("blinding check failed")
+	}
+	return nil
+}
+
+func (r *RatchetBlind) compute(tail sig3.Tail) (ret SCTeamRatchet, err error) {
+
+	b, err := msgpack.Encode(tail)
+	if err != nil {
+		return ret, err
+	}
+	h := hmac.New(sha512.New, r.Key[:])
+	h.Write(b)
+	d := h.Sum(nil)[0:32]
+	copy(ret[:], d)
+	return ret, nil
+}
+
+func (r *RatchetObj) generate(mctx libkb.MetaContext) (err error) {
+	r.RatchetBlind.Key, err = generateBlindingKey()
+	if err != nil {
+		return err
+	}
+	err = r.RatchetBlind.computeToSelf(r.Body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *Ratchet) generate(mctx libkb.MetaContext) (err error) {
+	arr := []RatchetObj{r.decoded}
+	b, err := msgpack.Encode(arr)
+	if err != nil {
+		return err
+	}
+	r.encoded = EncodedRatchetBlindingKeySet(base64.StdEncoding.EncodeToString(b))
+	return nil
+}
+
+func generateRatchet(mctx libkb.MetaContext, b sig3.Tail) (ret *Ratchet, err error) {
+	ret = &Ratchet{
+		decoded: RatchetObj{
+			Version: RatchetVersion1,
+			Body:    b,
+		},
+	}
+	err = ret.decoded.generate(mctx)
+	if err != nil {
+		return nil, err
+	}
+	err = ret.generate(mctx)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func MakeRatchet(mctx libkb.MetaContext, id keybase1.TeamID) (*Ratchet, error) {
+
+	err := CheckFeatureGateForSupport(mctx, id, true /* isWrite */)
+	if err != nil {
+		mctx.VLogf(libkb.VLog0, "skipping ratchet for team id %s due to feature-flag", id)
+		return nil, nil
+	}
+
+	tail, err := mctx.G().GetHiddenTeamChainManager().Tail(mctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if tail == nil || tail.Seqno == keybase1.Seqno(0) {
+		return nil, err
+	}
+	itail, err := sig3.ImportTail(*tail)
+	if err != nil {
+		return nil, err
+	}
+	ret, err := generateRatchet(mctx, *itail)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (e EncodedRatchetBlindingKeySet) AddToJSONPayload(p libkb.JSONPayload) {
+	if e.IsNil() {
+		return
+	}
+	p["ratchet_blinding_keys"] = e.String()
+}
+
+func (r *Ratchet) AddToJSONPayload(p libkb.JSONPayload) {
+	if r == nil {
+		return
+	}
+	r.ToSigPayload().AddToJSONPayload(p)
+}
+
+func checkRatchet(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain, ratchet keybase1.LinkTripleAndTime) (err error) {
+	if state == nil {
+		return nil
+	}
+	if ratchet.Triple.SeqType != sig3.ChainTypeTeamPrivateHidden {
+		return newRatchetError("bad chain type: %s", ratchet.Triple.SeqType)
+	}
+
+	// The new ratchet can't clash the existing accepted ratchets
+	for _, accepted := range state.RatchetSet.Flat() {
+		if accepted.Clashes(ratchet) {
+			return newRatchetError("bad ratchet, clashes existing pin: %+v != %v", accepted, accepted)
+		}
+	}
+
+	q := ratchet.Triple.Seqno
+	link, ok := state.Outer[q]
+
+	// If either the ratchet didn't match a known link, or equals what's already there, great.
+	if ok && !link.Eq(ratchet.Triple.LinkID) {
+		return newRatchetError("Ratchet failed to match a currently accepted chainlink: %+v", ratchet)
+	}
+
+	return nil
+}
+
+func checkRatchets(mctx libkb.MetaContext, state *keybase1.HiddenTeamChain, ratchets keybase1.HiddenTeamChainRatchetSet) (err error) {
+	for _, r := range ratchets.Flat() {
+		err = checkRatchet(mctx, state, r)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/teams/hidden/ratchet.go
+++ b/go/teams/hidden/ratchet.go
@@ -2,7 +2,6 @@ package hidden
 
 import (
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
@@ -171,21 +170,9 @@ func (r *Ratchet) ToSigPayload() (ret EncodedRatchetBlindingKeySet) {
 	return r.encoded
 }
 
-func genRandomBytes(i int) ([]byte, error) {
-	ret := make([]byte, i, i)
-	n, err := rand.Reader.Read(ret[:])
-	if err != nil {
-		return nil, err
-	}
-	if n != i {
-		return nil, newRatchetError("short random entropy read")
-	}
-	return ret, nil
-}
-
 func generateBlindingKey() (BlindingKey, error) {
 	var ret BlindingKey
-	tmp, err := genRandomBytes(len(ret))
+	tmp, err := libkb.RandBytes(len(ret))
 	if err != nil {
 		return ret, err
 	}
@@ -292,7 +279,7 @@ func MakeRatchet(mctx libkb.MetaContext, id keybase1.TeamID) (*Ratchet, error) {
 		return nil, err
 	}
 	if tail == nil || tail.Seqno == keybase1.Seqno(0) {
-		return nil, err
+		return nil, nil
 	}
 	itail, err := sig3.ImportTail(*tail)
 	if err != nil {

--- a/go/teams/hidden/ratchet.go
+++ b/go/teams/hidden/ratchet.go
@@ -120,7 +120,7 @@ func (r *RatchetBlindingKeySet) Get(ratchet SCTeamRatchet) *sig3.Tail {
 	return &obj.Body
 }
 
-// UnmarshalJSON is implicitly used in rawTeam-based API calles to move RatchetBlindingKeySets into and out of JSON
+// UnmarshalJSON is implicitly used in rawTeam-based API calls to move RatchetBlindingKeySets into and out of JSON
 // from the hidden team chain.
 func (r *RatchetBlindingKeySet) UnmarshalJSON(b []byte) error {
 	r.m = make(map[SCTeamRatchet]RatchetObj)

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams/hidden"
 	"github.com/keybase/go-codec/codec"
 )
 
@@ -992,4 +993,12 @@ func (l *TeamLoader) computeSeedChecks(ctx context.Context, state *keybase1.Team
 			state.PerTeamKeySeedsUnverified[g] = ptksu
 		},
 	)
+}
+
+func consumeRatchets(mctx libkb.MetaContext, hiddenPackage *hidden.LoaderPackage, link *ChainLinkUnpacked) (err error) {
+	if link.isStubbed() {
+		return nil
+	}
+	err = hiddenPackage.AddRatchets(mctx, link.inner.Ratchets(), link.inner.Ctime, keybase1.RatchetType_MAIN)
+	return err
 }

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -995,6 +995,10 @@ func (l *TeamLoader) computeSeedChecks(ctx context.Context, state *keybase1.Team
 	)
 }
 
+// consumeRatchets finds the hidden chain ratchets in the given link (if it's not stubbed), and adds them
+// into the hidden.LoaderPackage via the AddRatchets call. This call, in turn, attempts to unblind the ratchet
+// and then checks the ratchets against current state and ratchets. Thus, it can fail in many ways if the server
+// is buggy or dishonest.
 func consumeRatchets(mctx libkb.MetaContext, hiddenPackage *hidden.LoaderPackage, link *ChainLinkUnpacked) (err error) {
 	if link.isStubbed() {
 		return nil

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/sig3"
+	"github.com/keybase/client/go/teams/hidden"
 )
 
 // Things TeamLoader uses that are mocked out for tests.
@@ -64,10 +65,11 @@ type rawTeam struct {
 	ReaderKeyMasks []keybase1.ReaderKeyMask                               `json:"reader_key_masks"`
 	// Whether the user is only being allowed to view the chain
 	// because they are a member of a descendent team.
-	SubteamReader    bool                               `json:"subteam_reader"`
-	Showcase         keybase1.TeamShowcase              `json:"showcase"`
-	LegacyTLFUpgrade []keybase1.TeamGetLegacyTLFUpgrade `json:"legacy_tlf_upgrade"`
-	HiddenChain      []sig3.ExportJSON                  `json:"hidden"`
+	SubteamReader         bool                               `json:"subteam_reader"`
+	Showcase              keybase1.TeamShowcase              `json:"showcase"`
+	LegacyTLFUpgrade      []keybase1.TeamGetLegacyTLFUpgrade `json:"legacy_tlf_upgrade"`
+	HiddenChain           []sig3.ExportJSON                  `json:"hidden"`
+	RatchetBlindingKeySet *hidden.RatchetBlindingKeySet      `json:"ratchet_blinding_keys"`
 }
 
 func (r *rawTeam) GetAppStatus() *libkb.AppStatus {

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -329,7 +329,7 @@ func TestMemberAddHasBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* skipKeyRotation */)
+	_, boxes, _, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* skipKeyRotation */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +362,7 @@ func TestMemberChangeRoleNoBoxes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, boxes, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* skipKeyRotation */)
+	_, boxes, _, _, _, _, err := tm.changeMembershipSection(context.TODO(), req, false /* skipKeyRotation */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/teams/rotate_hidden_test.go
+++ b/go/teams/rotate_hidden_test.go
@@ -106,6 +106,11 @@ func TestRotateHiddenOther(t *testing.T) {
 		rotate(i%2 == 0)
 		check()
 	}
+
+	mctx1 := libkb.NewMetaContext(ctx, tcs[1].G)
+	ch, err := tcs[1].G.GetHiddenTeamChainManager().Load(mctx1, teamID)
+	require.NoError(t, err)
+	require.Equal(t, keybase1.Seqno(2), ch.RatchetSet.Ratchets[keybase1.RatchetType_MAIN].Triple.Seqno)
 }
 
 func TestRotateHiddenOtherFTL(t *testing.T) {
@@ -161,6 +166,11 @@ func TestRotateHiddenOtherFTL(t *testing.T) {
 
 	// Also test the gregor-powered refresh mechanism. We're going to mock out the gregor message for now.
 	rotate(true)
-	tcs[1].G.GetHiddenTeamChainManager().HintLatestSeqno(libkb.NewMetaContext(ctx, tcs[1].G), teamID, keybase1.Seqno(4))
+	mctx1 := libkb.NewMetaContext(ctx, tcs[1].G)
+	tcs[1].G.GetHiddenTeamChainManager().HintLatestSeqno(mctx1, teamID, keybase1.Seqno(4))
 	checkForUser(1, false)
+
+	ch, err := tcs[1].G.GetHiddenTeamChainManager().Load(mctx1, teamID)
+	require.NoError(t, err)
+	require.Equal(t, keybase1.Seqno(2), ch.RatchetSet.Ratchets[keybase1.RatchetType_MAIN].Triple.Seqno)
 }

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -563,6 +563,13 @@ func (t *Team) rotate(ctx context.Context, rt keybase1.RotationType) (err error)
 }
 
 func (t *Team) rotatePostVisible(ctx context.Context, section SCTeamSection, mr *libkb.MerkleRoot, payloadArgs sigPayloadArgs) error {
+	ratchet, err := t.makeRatchet(ctx)
+	if err != nil {
+		return err
+	}
+	section.Ratchets = ratchet.ToTeamSection()
+	payloadArgs.ratchetBlindingKeys = ratchet.ToSigPayload()
+
 	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeRotateKey, mr, payloadArgs)
 	if err != nil {
 		return err
@@ -609,7 +616,7 @@ func (t *Team) rotatePostHidden(ctx context.Context, section SCTeamSection, mr *
 	return err
 }
 
-func (t *Team) rotateHiddenGenerateSigMultiItem(mctx libkb.MetaContext, section SCTeamSection, mr *libkb.MerkleRoot) (ret *libkb.SigMultiItem, ratchet *keybase1.HiddenTeamChainRatchet, err error) {
+func (t *Team) rotateHiddenGenerateSigMultiItem(mctx libkb.MetaContext, section SCTeamSection, mr *libkb.MerkleRoot) (ret *libkb.SigMultiItem, ratchets *keybase1.HiddenTeamChainRatchetSet, err error) {
 
 	currentSeqno := t.CurrentSeqno()
 	lastLinkID := t.chain().GetLatestLinkID()
@@ -643,7 +650,7 @@ func (t *Team) rotateHiddenGenerateSigMultiItem(mctx libkb.MetaContext, section 
 		return nil, nil, err
 	}
 
-	ret, ratchet, err = hidden.GenerateKeyRotation(mctx, hidden.GenerateKeyRotationParams{
+	ret, ratchets, err = hidden.GenerateKeyRotation(mctx, hidden.GenerateKeyRotationParams{
 		TeamID:           t.ID,
 		IsPublic:         t.IsPublic(),
 		IsImplicit:       t.IsImplicit(),
@@ -658,7 +665,7 @@ func (t *Team) rotateHiddenGenerateSigMultiItem(mctx libkb.MetaContext, section 
 		Check:            t.keyManager.Check(),
 	})
 
-	return ret, ratchet, err
+	return ret, ratchets, err
 }
 
 func (t *Team) isAdminOrOwner(m keybase1.UserVersion) (res bool, err error) {
@@ -720,7 +727,7 @@ func (t *Team) ChangeMembershipWithOptions(ctx context.Context, req keybase1.Tea
 	}
 
 	// create the change membership section + secretBoxes
-	section, secretBoxes, implicitAdminBoxes, teamEKPayload, memberSet, err := t.changeMembershipSection(ctx, req, opts.SkipKeyRotation)
+	section, secretBoxes, implicitAdminBoxes, teamEKPayload, memberSet, ratchet, err := t.changeMembershipSection(ctx, req, opts.SkipKeyRotation)
 	if err != nil {
 		return err
 	}
@@ -755,10 +762,11 @@ func (t *Team) ChangeMembershipWithOptions(ctx context.Context, req keybase1.Tea
 	}
 	// post the change to the server
 	sigPayloadArgs := sigPayloadArgs{
-		secretBoxes:        secretBoxes,
-		implicitAdminBoxes: implicitAdminBoxes,
-		lease:              lease,
-		teamEKPayload:      teamEKPayload,
+		secretBoxes:         secretBoxes,
+		implicitAdminBoxes:  implicitAdminBoxes,
+		lease:               lease,
+		teamEKPayload:       teamEKPayload,
+		ratchetBlindingKeys: ratchet.ToSigPayload(),
 	}
 
 	if opts.Permanent {
@@ -819,6 +827,10 @@ func (t *Team) downgradeIfOwnerOrAdmin(ctx context.Context) (needsReload bool, e
 	return false, nil
 }
 
+func (t *Team) makeRatchet(ctx context.Context) (ret *hidden.Ratchet, err error) {
+	return hidden.MakeRatchet(libkb.NewMetaContext(ctx, t.G()), t.ID)
+}
+
 func (t *Team) Leave(ctx context.Context, permanent bool) error {
 	// If we are owner or admin, we have to downgrade ourselves first.
 	needsReload, err := t.downgradeIfOwnerOrAdmin(ctx)
@@ -850,14 +862,21 @@ func (t *Team) Leave(ctx context.Context, permanent bool) error {
 		}
 	}
 
+	ratchet, err := t.makeRatchet(ctx)
+	if err != nil {
+		return err
+	}
+
 	section := SCTeamSection{
 		ID:       SCTeamID(t.ID),
 		Implicit: t.IsImplicit(),
 		Public:   t.IsPublic(),
+		Ratchets: ratchet.ToTeamSection(),
 	}
 
 	sigPayloadArgs := sigPayloadArgs{
-		prePayload: libkb.JSONPayload{"permanent": permanent},
+		prePayload:          libkb.JSONPayload{"permanent": permanent},
+		ratchetBlindingKeys: ratchet.ToSigPayload(),
 	}
 	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeLeave, nil, sigPayloadArgs)
 	if err != nil {
@@ -896,10 +915,13 @@ func (t *Team) deleteRoot(ctx context.Context, ui keybase1.TeamsUiInterface) err
 		return errors.New("team delete not confirmed")
 	}
 
+	ratchet, err := t.makeRatchet(ctx)
+
 	teamSection := SCTeamSection{
 		ID:       SCTeamID(t.ID),
 		Implicit: t.IsImplicit(),
 		Public:   t.IsPublic(),
+		Ratchets: ratchet.ToTeamSection(),
 	}
 
 	mr, err := t.G().MerkleClient.FetchRootFromServer(t.MetaContext(ctx), libkb.TeamMerkleFreshnessForAdmin)
@@ -915,7 +937,10 @@ func (t *Team) deleteRoot(ctx context.Context, ui keybase1.TeamsUiInterface) err
 		return err
 	}
 
-	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs{})
+	sigPayloadArgs := sigPayloadArgs{
+		ratchetBlindingKeys: ratchet.ToSigPayload(),
+	}
+	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs)
 	err = t.postMulti(m, payload)
 	if err != nil {
 		return err
@@ -965,15 +990,20 @@ func (t *Team) deleteSubteam(ctx context.Context, ui keybase1.TeamsUiInterface) 
 	if err != nil {
 		return err
 	}
+	ratchet, err := t.makeRatchet(ctx)
+	if err != nil {
+		return err
+	}
 	parentSection := SCTeamSection{
 		ID: SCTeamID(parentTeam.ID),
 		Subteam: &SCSubteam{
 			ID:   SCTeamID(t.ID),
 			Name: subteamName, // weird this is required
 		},
-		Admin:   admin,
-		Public:  t.IsPublic(),
-		Entropy: entropy,
+		Admin:    admin,
+		Public:   t.IsPublic(),
+		Entropy:  entropy,
+		Ratchets: ratchet.ToTeamSection(),
 	}
 
 	mr, err := t.G().MerkleClient.FetchRootFromServer(t.MetaContext(ctx), libkb.TeamMerkleFreshnessForAdmin)
@@ -1007,6 +1037,7 @@ func (t *Team) deleteSubteam(ctx context.Context, ui keybase1.TeamsUiInterface) 
 
 	payload := make(libkb.JSONPayload)
 	payload["sigs"] = []interface{}{sigParent, sigSub}
+	ratchet.AddToJSONPayload(payload)
 	err = t.postMulti(m, payload)
 	if err != nil {
 		return err
@@ -1293,6 +1324,11 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 		return err
 	}
 
+	ratchet, err := t.makeRatchet(ctx)
+	if err != nil {
+		return err
+	}
+
 	teamSection := SCTeamSection{
 		ID:       SCTeamID(t.ID),
 		Admin:    admin,
@@ -1300,6 +1336,7 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 		Implicit: t.IsImplicit(),
 		Public:   t.IsPublic(),
 		Entropy:  entropy,
+		Ratchets: ratchet.ToTeamSection(),
 	}
 
 	mr, err := t.G().MerkleClient.FetchRootFromServer(t.MetaContext(ctx), libkb.TeamMerkleFreshnessForAdmin)
@@ -1321,7 +1358,11 @@ func (t *Team) postTeamInvites(ctx context.Context, invites SCTeamInvites) error
 		return err
 	}
 
-	payload := t.sigPayload(sigMulti, sigPayloadArgs{})
+	sigPayloadArgs := sigPayloadArgs{
+		ratchetBlindingKeys: ratchet.ToSigPayload(),
+	}
+
+	payload := t.sigPayload(sigMulti, sigPayloadArgs)
 	err = t.postMulti(m, payload)
 	if err != nil {
 		return err
@@ -1382,25 +1423,30 @@ func (t *Team) getAdminPermission(ctx context.Context) (admin *SCTeamAdmin, err 
 	return &ret, nil
 }
 
-func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamChangeReq, skipKeyRotation bool) (SCTeamSection, *PerTeamSharedSecretBoxes, map[keybase1.TeamID]*PerTeamSharedSecretBoxes, *teamEKPayload, *memberSet, error) {
+func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamChangeReq, skipKeyRotation bool) (SCTeamSection, *PerTeamSharedSecretBoxes, map[keybase1.TeamID]*PerTeamSharedSecretBoxes, *teamEKPayload, *memberSet, *hidden.Ratchet, error) {
 	// initialize key manager
 	if _, err := t.SharedSecret(ctx); err != nil {
-		return SCTeamSection{}, nil, nil, nil, nil, err
+		return SCTeamSection{}, nil, nil, nil, nil, nil, err
 	}
 
 	admin, err := t.getAdminPermission(ctx)
 	if err != nil {
-		return SCTeamSection{}, nil, nil, nil, nil, err
+		return SCTeamSection{}, nil, nil, nil, nil, nil, err
 	}
 
 	if t.IsSubteam() && len(req.Owners) > 0 {
-		return SCTeamSection{}, nil, nil, nil, nil, NewSubteamOwnersError()
+		return SCTeamSection{}, nil, nil, nil, nil, nil, NewSubteamOwnersError()
 	}
 
 	// load the member set specified in req
 	memSet, err := newMemberSetChange(ctx, t.G(), req)
 	if err != nil {
-		return SCTeamSection{}, nil, nil, nil, nil, err
+		return SCTeamSection{}, nil, nil, nil, nil, nil, err
+	}
+
+	ratchet, err := t.makeRatchet(ctx)
+	if err != nil {
+		return SCTeamSection{}, nil, nil, nil, nil, nil, err
 	}
 
 	section := SCTeamSection{
@@ -1408,24 +1454,25 @@ func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamCha
 		Admin:    admin,
 		Implicit: t.IsImplicit(),
 		Public:   t.IsPublic(),
+		Ratchets: ratchet.ToTeamSection(),
 	}
 
 	section.Members, err = memSet.Section()
 	if err != nil {
-		return SCTeamSection{}, nil, nil, nil, nil, err
+		return SCTeamSection{}, nil, nil, nil, nil, nil, err
 	}
 
 	// create secret boxes for recipients, possibly rotating the key
 	secretBoxes, implicitAdminBoxes, perTeamKeySection, teamEKPayload, err := t.recipientBoxes(ctx, memSet, skipKeyRotation)
 	if err != nil {
-		return SCTeamSection{}, nil, nil, nil, nil, err
+		return SCTeamSection{}, nil, nil, nil, nil, nil, err
 	}
 
 	section.PerTeamKey = perTeamKeySection
 
 	err = addSummaryHash(&section, secretBoxes)
 	if err != nil {
-		return SCTeamSection{}, nil, nil, nil, nil, err
+		return SCTeamSection{}, nil, nil, nil, nil, nil, err
 	}
 
 	section.CompletedInvites = req.CompletedInvites
@@ -1439,7 +1486,7 @@ func (t *Team) changeMembershipSection(ctx context.Context, req keybase1.TeamCha
 		section.Members = &SCTeamMembers{}
 	}
 
-	return section, secretBoxes, implicitAdminBoxes, teamEKPayload, memSet, nil
+	return section, secretBoxes, implicitAdminBoxes, teamEKPayload, memSet, ratchet, nil
 }
 
 func (t *Team) changeItemPayload(ctx context.Context, section SCTeamSection, linkType libkb.LinkType, merkleRoot *libkb.MerkleRoot, sigPayloadArgs sigPayloadArgs) (libkb.JSONPayload, keybase1.Seqno, error) {
@@ -1737,13 +1784,14 @@ func (t *Team) storeTeamEKPayload(ctx context.Context, teamEKPayload *teamEKPayl
 }
 
 type sigPayloadArgs struct {
-	secretBoxes        *PerTeamSharedSecretBoxes
-	implicitAdminBoxes map[keybase1.TeamID]*PerTeamSharedSecretBoxes
-	lease              *libkb.Lease
-	prePayload         libkb.JSONPayload
-	legacyTLFUpgrade   *keybase1.TeamGetLegacyTLFUpgrade
-	teamEKBoxes        *[]keybase1.TeamEkBoxMetadata
-	teamEKPayload      *teamEKPayload
+	secretBoxes         *PerTeamSharedSecretBoxes
+	implicitAdminBoxes  map[keybase1.TeamID]*PerTeamSharedSecretBoxes
+	lease               *libkb.Lease
+	prePayload          libkb.JSONPayload
+	legacyTLFUpgrade    *keybase1.TeamGetLegacyTLFUpgrade
+	teamEKBoxes         *[]keybase1.TeamEkBoxMetadata
+	teamEKPayload       *teamEKPayload
+	ratchetBlindingKeys hidden.EncodedRatchetBlindingKeySet
 }
 
 func (t *Team) sigPayload(sigMulti []libkb.SigMultiItem, args sigPayloadArgs) libkb.JSONPayload {
@@ -1765,6 +1813,7 @@ func (t *Team) sigPayload(sigMulti []libkb.SigMultiItem, args sigPayloadArgs) li
 	if args.legacyTLFUpgrade != nil {
 		payload["legacy_tlf_upgrade"] = args.legacyTLFUpgrade
 	}
+	args.ratchetBlindingKeys.AddToJSONPayload(payload)
 	if args.teamEKBoxes != nil && len(*args.teamEKBoxes) > 0 {
 		payload["team_ek_rebox"] = libkb.JSONPayload{
 			"boxes":   args.teamEKBoxes,
@@ -1908,15 +1957,23 @@ func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSetti
 		return err
 	}
 
+	ratchet, err := t.makeRatchet(ctx)
+	if err != nil {
+		return err
+	}
+
 	section := SCTeamSection{
 		ID:       SCTeamID(t.ID),
 		Admin:    admin,
 		Settings: &scSettings,
 		Implicit: t.IsImplicit(),
 		Public:   t.IsPublic(),
+		Ratchets: ratchet.ToTeamSection(),
 	}
 
-	payloadArgs := sigPayloadArgs{}
+	payloadArgs := sigPayloadArgs{
+		ratchetBlindingKeys: ratchet.ToSigPayload(),
+	}
 	var maybeEKPayload *teamEKPayload
 	if rotate {
 		// Create empty Members section. We are not changing memberships, but
@@ -2055,6 +2112,11 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		return err
 	}
 
+	ratchet, err := t.makeRatchet(ctx)
+	if err != nil {
+		return err
+	}
+
 	upgrade := SCTeamKBFSLegacyUpgrade{
 		AppType:          appType,
 		KeysetHash:       hash,
@@ -2068,6 +2130,7 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 		KBFS: &SCTeamKBFS{
 			Keyset: &upgrade,
 		},
+		Ratchets: ratchet.ToTeamSection(),
 	}
 
 	mr, err := m.G().MerkleClient.FetchRootFromServer(m, libkb.TeamMerkleFreshnessForAdmin)
@@ -2090,6 +2153,7 @@ func (t *Team) AssociateWithTLFKeyset(ctx context.Context, tlfID keybase1.TLFID,
 			TeamGeneration:   latestKey.KeyGeneration,
 			AppType:          appType,
 		},
+		ratchetBlindingKeys: ratchet.ToSigPayload(),
 	})
 
 	err = t.postMulti(m, payload)
@@ -2110,6 +2174,11 @@ func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (er
 		return nil
 	}
 
+	ratchet, err := t.makeRatchet(ctx)
+	if err != nil {
+		return err
+	}
+
 	teamSection := SCTeamSection{
 		ID:       SCTeamID(t.ID),
 		Implicit: t.IsImplicit(),
@@ -2119,6 +2188,7 @@ func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (er
 				ID: tlfID,
 			},
 		},
+		Ratchets: ratchet.ToTeamSection(),
 	}
 
 	mr, err := m.G().MerkleClient.FetchRootFromServer(m, libkb.TeamMerkleFreshnessForAdmin)
@@ -2134,7 +2204,10 @@ func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (er
 		return err
 	}
 
-	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs{})
+	sigPayloadArgs := sigPayloadArgs{
+		ratchetBlindingKeys: ratchet.ToSigPayload(),
+	}
+	payload := t.sigPayload([]libkb.SigMultiItem{sigMultiItem}, sigPayloadArgs)
 	err = t.postMulti(libkb.NewMetaContext(ctx, t.G()), payload)
 	if err != nil {
 		return err

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams/hidden"
 )
 
 // AddMemberTx helps build a transaction that may contain multiple
@@ -705,14 +706,26 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 	var sections []SCTeamSection
 	memSet := newMemberSet()
 	var sectionsWithBoxSummaries []int
+	var ratchet *hidden.Ratchet
 
 	// Transform payloads to SCTeamSections.
 	for i, p := range tx.payloads {
+
 		section := SCTeamSection{
 			ID:       SCTeamID(team.ID),
 			Admin:    admin,
 			Implicit: team.IsImplicit(),
 			Public:   team.IsPublic(),
+		}
+
+		// Only add a ratchet to the first link in the sequence, it doesn't make sense
+		// to add more than one, and it may as well be the first.
+		if ratchet == nil {
+			ratchet, err = hidden.MakeRatchet(mctx, team.ID)
+			if err != nil {
+				return err
+			}
+			section.Ratchets = ratchet.ToTeamSection()
 		}
 
 		switch p.Tag {
@@ -861,11 +874,12 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 	}
 
 	payloadArgs := sigPayloadArgs{
-		secretBoxes:        secretBoxes,
-		lease:              lease,
-		implicitAdminBoxes: implicitAdminBoxes,
-		teamEKPayload:      teamEKPayload,
-		teamEKBoxes:        teamEKBoxes,
+		secretBoxes:         secretBoxes,
+		lease:               lease,
+		implicitAdminBoxes:  implicitAdminBoxes,
+		teamEKPayload:       teamEKPayload,
+		teamEKBoxes:         teamEKBoxes,
+		ratchetBlindingKeys: ratchet.ToSigPayload(),
 	}
 	payload := team.sigPayload(readySigs, payloadArgs)
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -298,16 +298,18 @@ protocol teams {
     boolean loadedLatest;
   }
 
-  record HiddenTeamChainRatchet{
+  enum RatchetType {
     // Ratchets that come as "down pointers" from the main team chean.
-    union { null, LinkTripleAndTime } main;
-
+    MAIN_0,
     // Ratchets that come from the blinded merkle tree for this team.
-    union { null, LinkTripleAndTime } blinded;
-
+    BLINDED_1,
     // When we make changes to the hidden chain ourselves, then we bump this
     // ratchet.
-    union { null, LinkTripleAndTime } self;
+    SELF_2
+  }
+
+  record HiddenTeamChainRatchetSet{
+    map<RatchetType,LinkTripleAndTime> ratchets;
   }
 
   record HiddenTeamChain {
@@ -344,7 +346,7 @@ protocol teams {
     // This is the latest hidden chain tail link known for this team;
     // the existence of a known ratchet means the team better be at least up to this
     // point, and maybe beyond it.
-    HiddenTeamChainRatchet ratchet;
+    HiddenTeamChainRatchetSet ratchetSet;
 
     // Should only be used by TeamLoader (because it is mutable, not threadsafe to read)
     Time cachedAt;

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -622,29 +622,25 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "RatchetType",
+      "symbols": [
+        "MAIN_0",
+        "BLINDED_1",
+        "SELF_2"
+      ]
+    },
+    {
       "type": "record",
-      "name": "HiddenTeamChainRatchet",
+      "name": "HiddenTeamChainRatchetSet",
       "fields": [
         {
-          "type": [
-            null,
-            "LinkTripleAndTime"
-          ],
-          "name": "main"
-        },
-        {
-          "type": [
-            null,
-            "LinkTripleAndTime"
-          ],
-          "name": "blinded"
-        },
-        {
-          "type": [
-            null,
-            "LinkTripleAndTime"
-          ],
-          "name": "self"
+          "type": {
+            "type": "map",
+            "values": "LinkTripleAndTime",
+            "keys": "RatchetType"
+          },
+          "name": "ratchets"
         }
       ]
     },
@@ -713,8 +709,8 @@
           "name": "readerPerTeamKeys"
         },
         {
-          "type": "HiddenTeamChainRatchet",
-          "name": "ratchet"
+          "type": "HiddenTeamChainRatchetSet",
+          "name": "ratchetSet"
         },
         {
           "type": "Time",

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1744,6 +1744,12 @@ export enum PushReason {
   newData = 2,
 }
 
+export enum RatchetType {
+  main = 0,
+  blinded = 1,
+  self = 2,
+}
+
 export enum Reachable {
   unknown = 0,
   yes = 1,
@@ -2323,9 +2329,9 @@ export type HasServerKeysRes = {readonly hasServerKeys: Boolean}
 export type HashMeta = Bytes
 export type Hello2Res = {readonly encryptionKey: KID; readonly sigPayload: HelloRes; readonly deviceEkKID: KID}
 export type HelloRes = String
-export type HiddenTeamChain = {readonly id: TeamID; readonly subversion: Int; readonly public: Boolean; readonly frozen: Boolean; readonly tombstoned: Boolean; readonly last: Seqno; readonly latestSeqnoHint: Seqno; readonly lastPerTeamKeys: {[key: string]: Seqno}; readonly outer: {[key: string]: LinkID}; readonly inner: {[key: string]: HiddenTeamChainLink}; readonly readerPerTeamKeys: {[key: string]: Seqno}; readonly ratchet: HiddenTeamChainRatchet; readonly cachedAt: Time}
+export type HiddenTeamChain = {readonly id: TeamID; readonly subversion: Int; readonly public: Boolean; readonly frozen: Boolean; readonly tombstoned: Boolean; readonly last: Seqno; readonly latestSeqnoHint: Seqno; readonly lastPerTeamKeys: {[key: string]: Seqno}; readonly outer: {[key: string]: LinkID}; readonly inner: {[key: string]: HiddenTeamChainLink}; readonly readerPerTeamKeys: {[key: string]: Seqno}; readonly ratchetSet: HiddenTeamChainRatchetSet; readonly cachedAt: Time}
 export type HiddenTeamChainLink = {readonly m: /* merkleRoot */ MerkleRootV2; readonly p: /* parentChain */ LinkTriple; readonly s: /* signer */ Signer; readonly k: /* ptk */ {[key: string]: PerTeamKeyAndCheck}}
-export type HiddenTeamChainRatchet = {readonly main?: LinkTripleAndTime | null; readonly blinded?: LinkTripleAndTime | null; readonly self?: LinkTripleAndTime | null}
+export type HiddenTeamChainRatchetSet = {readonly ratchets: {[key: string]: LinkTripleAndTime}}
 export type HomeScreen = {readonly lastViewed: Time; readonly version: Int; readonly visits: Int; readonly items?: Array<HomeScreenItem> | null; readonly followSuggestions?: Array<HomeUserSummary> | null; readonly announcementsVersion: Int}
 export type HomeScreenAnnouncement = {readonly id: HomeScreenAnnouncementID; readonly version: HomeScreenAnnouncementVersion; readonly appLink: AppLinkType; readonly confirmLabel: String; readonly dismissable: Boolean; readonly iconUrl: String; readonly text: String; readonly url: String}
 export type HomeScreenAnnouncementID = Int


### PR DESCRIPTION
- for FTL and slow loader, pull down ratchets, with blinding keys
- persist those ratchets to the local store
- some small happy-path testing, but took a lot of fiddling to get everything to work (since the server does a lot of error checking)