### PR TITLE
do less in background when on mobile data

### DIFF
--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/storage"
@@ -112,6 +113,7 @@ type BackgroundConvLoader struct {
 	resumeCh      chan struct{}
 	loadCh        chan *clTask
 	identNotifier types.IdentifyNotifier
+	eg            errgroup.Group
 
 	clock      clockwork.Clock
 	resumeWait time.Duration
@@ -142,6 +144,7 @@ func NewBackgroundConvLoader(g *globals.Context) *BackgroundConvLoader {
 	b.identNotifier.ResetOnGUIConnect()
 	b.newQueue()
 	go b.monitorAppState()
+	go b.monitorNetState()
 
 	return b
 }
@@ -156,31 +159,63 @@ func (b *BackgroundConvLoader) removeActiveLoadLocked(key string) {
 	delete(b.activeLoads, key)
 }
 
-func (b *BackgroundConvLoader) monitorAppState() {
+func (b *BackgroundConvLoader) monitorAppState() error {
 	ctx := context.Background()
-	suspended := false
 	b.Debug(ctx, "monitorAppState: starting up")
+
+	suspended := false
 	state := keybase1.MobileAppState_FOREGROUND
 	for {
-		state = <-b.G().MobileAppState.NextUpdate(&state)
-		switch state {
-		case keybase1.MobileAppState_FOREGROUND, keybase1.MobileAppState_BACKGROUNDACTIVE:
-			b.Debug(ctx, "monitorAppState: active state: %v", state)
-			// Only resume if we had suspended earlier (frontend can spam us with these)
-			if suspended {
-				b.Debug(ctx, "monitorAppState: resuming load thread")
-				b.Resume(ctx)
-				suspended = false
-			}
-		case keybase1.MobileAppState_BACKGROUND:
-			b.Debug(ctx, "monitorAppState: backgrounded, suspending load thread")
-			if !suspended {
-				b.Suspend(ctx)
-				suspended = true
+		select {
+		case state = <-b.G().MobileAppState.NextUpdate(&state):
+			switch state {
+			case keybase1.MobileAppState_FOREGROUND, keybase1.MobileAppState_BACKGROUNDACTIVE:
+				b.Debug(ctx, "monitorAppState: active state: %v", state)
+				// Only resume if we had suspended earlier (frontend can spam us with these)
+				if suspended {
+					b.Debug(ctx, "monitorAppState: resuming load thread")
+					b.Resume(ctx)
+					suspended = false
+				}
+			case keybase1.MobileAppState_BACKGROUND:
+				b.Debug(ctx, "monitorAppState: backgrounded, suspending load thread")
+				if !suspended {
+					b.Suspend(ctx)
+					suspended = true
+				}
 			}
 		}
 		if b.appStateCh != nil {
 			b.appStateCh <- struct{}{}
+		}
+	}
+}
+
+func (b *BackgroundConvLoader) monitorNetState() error {
+	ctx := context.Background()
+	b.Debug(ctx, "monitorNetState: starting up")
+
+	suspended := false
+	state := keybase1.MobileNetworkState_WIFI
+	for {
+		select {
+		case state = <-b.G().MobileNetState.NextUpdate(&state):
+			switch state {
+			case keybase1.MobileNetworkState_WIFI:
+				b.Debug(ctx, "monitorNetState: connected to wifi: %v")
+				// Only resume if we had suspended earlier (frontend can spam us with these)
+				if suspended {
+					b.Debug(ctx, "monitorNetState: resuming load thread")
+					b.Resume(ctx)
+					suspended = false
+				}
+			default:
+				b.Debug(ctx, "monitorNetState: %v, suspending load thread", state)
+				if !suspended {
+					b.Suspend(ctx)
+					suspended = true
+				}
+			}
 		}
 	}
 }
@@ -201,8 +236,8 @@ func (b *BackgroundConvLoader) Start(ctx context.Context, uid gregor1.UID) {
 	b.newQueue()
 	b.started = true
 	b.uid = uid
-	go b.loop()
-	go b.loadLoop()
+	b.eg.Go(b.loop)
+	b.eg.Go(b.loadLoop)
 }
 
 func (b *BackgroundConvLoader) Stop(ctx context.Context) chan struct{} {
@@ -215,8 +250,13 @@ func (b *BackgroundConvLoader) Stop(ctx context.Context) chan struct{} {
 		close(b.stopCh)
 		b.stopCh = make(chan struct{})
 		b.started = false
+		go func() {
+			b.eg.Wait()
+			close(ch)
+		}()
+	} else {
+		close(ch)
 	}
-	close(ch)
 	return ch
 }
 
@@ -305,7 +345,7 @@ func (b *BackgroundConvLoader) enqueue(ctx context.Context, task clTask) error {
 	return b.queue.Push(task)
 }
 
-func (b *BackgroundConvLoader) loop() {
+func (b *BackgroundConvLoader) loop() error {
 	bgctx := context.Background()
 	uid := b.uid
 	b.Debug(bgctx, "loop: starting conv loader loop for %s", uid)
@@ -363,7 +403,7 @@ func (b *BackgroundConvLoader) loop() {
 			case ch := <-b.suspendCh:
 				b.Debug(bgctx, "loop: pulled queue task, but suspended, so waiting")
 				if !waitForResume(ch) {
-					return
+					return nil
 				}
 			}
 			b.Debug(bgctx, "loop: pulled queued task: %s", task.job)
@@ -375,16 +415,16 @@ func (b *BackgroundConvLoader) loop() {
 		case ch := <-b.suspendCh:
 			b.Debug(bgctx, "loop: received suspend")
 			if !waitForResume(ch) {
-				return
+				return nil
 			}
 		case <-stopCh:
 			b.Debug(bgctx, "loop: shutting down for %s", uid)
-			return
+			return nil
 		}
 	}
 }
 
-func (b *BackgroundConvLoader) loadLoop() {
+func (b *BackgroundConvLoader) loadLoop() error {
 	bgctx := context.Background()
 	uid := b.uid
 	b.Debug(bgctx, "loadLoop: starting for uid: %s", uid)
@@ -404,7 +444,7 @@ func (b *BackgroundConvLoader) loadLoop() {
 				}
 			}
 		case <-stopCh:
-			return
+			return nil
 		}
 	}
 }

--- a/go/chat/convloader.go
+++ b/go/chat/convloader.go
@@ -144,7 +144,6 @@ func NewBackgroundConvLoader(g *globals.Context) *BackgroundConvLoader {
 	b.identNotifier.ResetOnGUIConnect()
 	b.newQueue()
 	go b.monitorAppState()
-	go b.monitorNetState()
 
 	return b
 }
@@ -187,34 +186,6 @@ func (b *BackgroundConvLoader) monitorAppState() error {
 		}
 		if b.appStateCh != nil {
 			b.appStateCh <- struct{}{}
-		}
-	}
-}
-
-func (b *BackgroundConvLoader) monitorNetState() error {
-	ctx := context.Background()
-	b.Debug(ctx, "monitorNetState: starting up")
-
-	suspended := false
-	state := keybase1.MobileNetworkState_WIFI
-	for {
-		select {
-		case state = <-b.G().MobileNetState.NextUpdate(&state):
-			if state.IsLimited() {
-				b.Debug(ctx, "monitorNetState: %v, suspending load thread", state)
-				if !suspended {
-					b.Suspend(ctx)
-					suspended = true
-				}
-			} else {
-				b.Debug(ctx, "monitorNetState: attempting resume: %v", state)
-				// Only resume if we had suspended earlier (frontend can spam us with these)
-				if suspended {
-					b.Debug(ctx, "monitorNetState: resuming load thread")
-					b.Resume(ctx)
-					suspended = false
-				}
-			}
 		}
 	}
 }

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -727,9 +727,9 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 	var bgEnqueued int
 	// Limit the number of jobs we enqueue when on a limited data connection in
 	// mobile.
-	maxBgEnqueued := 50
+	maxBgEnqueued := 10
 	if s.G().MobileNetState.State().IsLimited() {
-		maxBgEnqueued = 10
+		maxBgEnqueued = 3
 	}
 
 	for _, conv := range ib.Inbox.Full().Conversations {

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -724,7 +724,14 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 		return types.Inbox{}, err
 	}
 
-	bgEnqueued := 0
+	var bgEnqueued int
+	// Limit the number of jobs we enqueue when on a limited data connection in
+	// mobile.
+	maxBgEnqueued := 50
+	if s.G().MobileNetState.State().IsLimited() {
+		maxBgEnqueued = 10
+	}
+
 	for _, conv := range ib.Inbox.Full().Conversations {
 		// Retention policy expunge
 		expunge := conv.GetExpunge()
@@ -735,12 +742,12 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 			continue
 		}
 		// Queue all these convs up to be loaded by the background loader. Only
-		// load first 100 non KBFS convs, ACTIVE convs so we don't get the conv
-		// loader too backed up.
+		// load first maxBgEnqueued non KBFS convs, ACTIVE convs so we don't
+		// get the conv loader too backed up.
 		if conv.Metadata.MembersType != chat1.ConversationMembersType_KBFS &&
 			(conv.HasMemberStatus(chat1.ConversationMemberStatus_ACTIVE) ||
 				conv.HasMemberStatus(chat1.ConversationMemberStatus_PREVIEW)) &&
-			bgEnqueued < 50 {
+			bgEnqueued < maxBgEnqueued {
 			job := types.NewConvLoaderJob(conv.GetConvID(), nil /* query */, &chat1.Pagination{Num: 50},
 				types.ConvLoaderPriorityMedium, nil)
 			if err := s.G().ConvLoader.Queue(ctx, job); err != nil {

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -151,9 +151,7 @@ func (idx *Indexer) SyncLoop(ctx context.Context, uid gregor1.UID) {
 		}
 	}
 	attemptSync := func(ctx context.Context) {
-		switch netState {
-		case keybase1.MobileNetworkState_WIFI:
-		default:
+		if netState.IsLimited() {
 			return
 		}
 		l.Lock()
@@ -203,10 +201,8 @@ func (idx *Indexer) SyncLoop(ctx context.Context, uid gregor1.UID) {
 				cancelSync()
 			}
 		case netState = <-idx.G().MobileNetState.NextUpdate(&netState):
-			switch netState {
-			case keybase1.MobileNetworkState_WIFI:
-			// if we switch off of wifi cancel any running syncs
-			default:
+			if netState.IsLimited() {
+				// if we switch off of wifi cancel any running syncs
 				cancelSync()
 			}
 		case ch := <-suspendCh:

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -138,7 +138,8 @@ func (idx *Indexer) SyncLoop(ctx context.Context, uid gregor1.UID) {
 
 	ticker := libkb.NewBgTicker(time.Hour)
 	after := time.After(idx.startSyncDelay)
-	state := keybase1.MobileAppState_FOREGROUND
+	appState := keybase1.MobileAppState_FOREGROUND
+	netState := keybase1.MobileNetworkState_WIFI
 	var cancelFn context.CancelFunc
 	var l sync.Mutex
 	cancelSync := func() {
@@ -189,10 +190,17 @@ func (idx *Indexer) SyncLoop(ctx context.Context, uid gregor1.UID) {
 			attemptSync(ctx)
 		case <-ticker.C:
 			attemptSync(ctx)
-		case state = <-idx.G().MobileAppState.NextUpdate(&state):
-			switch state {
+		case appState = <-idx.G().MobileAppState.NextUpdate(&appState):
+			switch appState {
 			case keybase1.MobileAppState_FOREGROUND:
 			// if we enter any state besides foreground cancel any running syncs
+			default:
+				cancelSync()
+			}
+		case netState = <-idx.G().MobileNetState.NextUpdate(&netState):
+			switch netState {
+			case keybase1.MobileNetworkState_WIFI:
+			// if we switch off of wifi cancel any running syncs
 			default:
 				cancelSync()
 			}

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -151,6 +151,11 @@ func (idx *Indexer) SyncLoop(ctx context.Context, uid gregor1.UID) {
 		}
 	}
 	attemptSync := func(ctx context.Context) {
+		switch netState {
+		case keybase1.MobileNetworkState_WIFI:
+		default:
+			return
+		}
 		l.Lock()
 		defer l.Unlock()
 		if cancelFn != nil {

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -285,7 +285,6 @@ func (s *Syncer) shouldUnboxSyncConv(conv chat1.Conversation) bool {
 	switch conv.Metadata.Status {
 	case chat1.ConversationStatus_BLOCKED,
 		chat1.ConversationStatus_IGNORED,
-		chat1.ConversationStatus_MUTED,
 		chat1.ConversationStatus_REPORTED:
 		return false
 	}

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -273,22 +273,41 @@ func (s *Syncer) getShouldUnboxSyncConvMap(ctx context.Context, convs []chat1.Co
 		if m[conv.GetConvID().String()] {
 			continue
 		}
-		if conv.Metadata.Status == chat1.ConversationStatus_BLOCKED {
-			continue
-		}
-		switch conv.GetMembersType() {
-		case chat1.ConversationMembersType_TEAM:
-			// include if this is a simple team, or the topic name has changed
-			if conv.GetTopicType() != chat1.TopicType_CHAT ||
-				conv.Metadata.TeamType != chat1.TeamType_COMPLEX ||
-				conv.GetConvID().Eq(s.GetSelectedConversation()) {
-				m[conv.GetConvID().String()] = true
-			}
-		default:
+		if s.shouldUnboxSyncConv(conv) {
 			m[conv.GetConvID().String()] = true
 		}
 	}
 	return m
+}
+
+func (s *Syncer) shouldUnboxSyncConv(conv chat1.Conversation) bool {
+	// Skips convs we don't care for.
+	switch conv.Metadata.Status {
+	case chat1.ConversationStatus_BLOCKED,
+		chat1.ConversationStatus_IGNORED,
+		chat1.ConversationStatus_MUTED,
+		chat1.ConversationStatus_REPORTED:
+		return false
+	}
+	// Only let through ACTIVE/PREVIEW convs.
+	if conv.ReaderInfo != nil {
+		switch conv.ReaderInfo.Status {
+		case chat1.ConversationMemberStatus_ACTIVE,
+			chat1.ConversationMemberStatus_PREVIEW:
+		default:
+			return false
+		}
+	}
+	switch conv.GetMembersType() {
+	case chat1.ConversationMembersType_TEAM:
+		// include if this is a simple team or we are currently viewing the
+		// conv.
+		return conv.GetTopicType() != chat1.TopicType_CHAT ||
+			conv.Metadata.TeamType != chat1.TeamType_COMPLEX ||
+			conv.GetConvID().Eq(s.GetSelectedConversation())
+	default:
+		return true
+	}
 }
 
 func (s *Syncer) notifyIncrementalSync(ctx context.Context, uid gregor1.UID,
@@ -440,6 +459,12 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 			}
 		}
 
+		var queuedConvs, maxConvs int
+		state := s.G().MobileNetState.State()
+		if state.IsLimited() {
+			maxConvs = 3
+		}
+
 		// Dispatch background jobs
 		for _, rc := range iboxSyncRes.FilteredConvs {
 			conv := rc.Conv
@@ -465,13 +490,20 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 				if err := s.G().ConvLoader.Queue(ctx, job); err != nil {
 					s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
 				}
+				queuedConvs++
 			} else {
+				// If we are a limited data connection only queue selected
+				// convs up to maxConvs
+				if state.IsLimited() && (queuedConvs >= maxConvs || !s.shouldUnboxSyncConv(conv)) {
+					continue
+				}
 				// Everything else just queue up here
 				job := types.NewConvLoaderJob(conv.GetConvID(), nil /* query */, &chat1.Pagination{Num: 50},
 					types.ConvLoaderPriorityHigh, newConvLoaderPagebackHook(s.G(), 0, 5))
 				if err := s.G().ConvLoader.Queue(ctx, job); err != nil {
 					s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
 				}
+				queuedConvs++
 			}
 		}
 	}

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -162,7 +162,7 @@ func TestSyncerConnected(t *testing.T) {
 	require.Equal(t, len(convs), len(iconvs))
 
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
-		mconv.Metadata.Status = chat1.ConversationStatus_MUTED
+		mconv.Metadata.Status = chat1.ConversationStatus_FAVORITE
 		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
 			Vers:  100,
 			Convs: []chat1.Conversation{mconv},
@@ -192,7 +192,7 @@ func TestSyncerConnected(t *testing.T) {
 	require.Equal(t, len(convs), len(iconvs))
 	for _, ic := range iconvs {
 		if ic.GetConvID().Eq(mconv.GetConvID()) {
-			require.Equal(t, chat1.ConversationStatus_MUTED, ic.Conv.Metadata.Status)
+			require.Equal(t, chat1.ConversationStatus_FAVORITE, ic.Conv.Metadata.Status)
 		}
 	}
 	require.Equal(t, chat1.ConversationStatus_UNFILED, convs[1].Metadata.Status)

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -162,7 +162,7 @@ func TestSyncerConnected(t *testing.T) {
 	require.Equal(t, len(convs), len(iconvs))
 
 	ri.SyncInboxFunc = func(m *kbtest.ChatRemoteMock, ctx context.Context, vers chat1.InboxVers) (chat1.SyncInboxRes, error) {
-		mconv.Metadata.Status = chat1.ConversationStatus_FAVORITE
+		mconv.Metadata.Status = chat1.ConversationStatus_MUTED
 		return chat1.NewSyncInboxResWithIncremental(chat1.SyncIncrementalRes{
 			Vers:  100,
 			Convs: []chat1.Conversation{mconv},
@@ -192,7 +192,7 @@ func TestSyncerConnected(t *testing.T) {
 	require.Equal(t, len(convs), len(iconvs))
 	for _, ic := range iconvs {
 		if ic.GetConvID().Eq(mconv.GetConvID()) {
-			require.Equal(t, chat1.ConversationStatus_FAVORITE, ic.Conv.Metadata.Status)
+			require.Equal(t, chat1.ConversationStatus_MUTED, ic.Conv.Metadata.Status)
 		}
 	}
 	require.Equal(t, chat1.ConversationStatus_UNFILED, convs[1].Metadata.Status)

--- a/go/engine/merkle_audit.go
+++ b/go/engine/merkle_audit.go
@@ -101,9 +101,7 @@ func (e *MerkleAudit) Run(mctx libkb.MetaContext) (err error) {
 	}
 	if mctx.G().IsMobileAppType() {
 		state := mctx.G().MobileNetState.State()
-		switch state {
-		case keybase1.MobileNetworkState_WIFI:
-		default:
+		if state.IsLimited() {
 			mctx.Debug("merkle audit skipping without wifi, network state: %v", state)
 			return nil
 		}

--- a/go/engine/merkle_audit.go
+++ b/go/engine/merkle_audit.go
@@ -94,11 +94,21 @@ func (e *MerkleAudit) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 // Returns immediately, kicks off a background goroutine.
-func (e *MerkleAudit) Run(m libkb.MetaContext) (err error) {
-	if m.G().GetEnv().GetDisableMerkleAuditor() {
-		m.G().Log.CDebugf(m.Ctx(), "merkle audit disabled, aborting run")
+func (e *MerkleAudit) Run(mctx libkb.MetaContext) (err error) {
+	if mctx.G().GetEnv().GetDisableMerkleAuditor() {
+		mctx.Debug("merkle audit disabled, aborting run")
+		return nil
 	}
-	return RunEngine2(m, e.task)
+	if mctx.G().IsMobileAppType() {
+		state := mctx.G().MobileNetState.State()
+		switch state {
+		case keybase1.MobileNetworkState_WIFI:
+		default:
+			mctx.Debug("merkle audit skipping without wifi, network state: %v", state)
+			return nil
+		}
+	}
+	return RunEngine2(mctx, e.task)
 }
 
 func (e *MerkleAudit) Shutdown() {

--- a/go/libkb/appstate.go
+++ b/go/libkb/appstate.go
@@ -113,7 +113,7 @@ type MobileNetState struct {
 func NewMobileNetState(g *GlobalContext) *MobileNetState {
 	return &MobileNetState{
 		Contextified: NewContextified(g),
-		state:        keybase1.MobileNetworkState_WIFI,
+		state:        keybase1.MobileNetworkState_NOTAVAILABLE,
 	}
 }
 

--- a/go/libkb/appstate.go
+++ b/go/libkb/appstate.go
@@ -113,7 +113,7 @@ type MobileNetState struct {
 func NewMobileNetState(g *GlobalContext) *MobileNetState {
 	return &MobileNetState{
 		Contextified: NewContextified(g),
-		state:        keybase1.MobileNetworkState_NONE,
+		state:        keybase1.MobileNetworkState_WIFI,
 	}
 }
 

--- a/go/protocol/keybase1/appstate.go
+++ b/go/protocol/keybase1/appstate.go
@@ -43,19 +43,21 @@ func (e MobileAppState) String() string {
 type MobileNetworkState int
 
 const (
-	MobileNetworkState_NONE    MobileNetworkState = 0
-	MobileNetworkState_WIFI    MobileNetworkState = 1
-	MobileNetworkState_CELLUAR MobileNetworkState = 2
-	MobileNetworkState_UNKNOWN MobileNetworkState = 3
+	MobileNetworkState_NONE         MobileNetworkState = 0
+	MobileNetworkState_WIFI         MobileNetworkState = 1
+	MobileNetworkState_CELLUAR      MobileNetworkState = 2
+	MobileNetworkState_UNKNOWN      MobileNetworkState = 3
+	MobileNetworkState_NOTAVAILABLE MobileNetworkState = 4
 )
 
 func (o MobileNetworkState) DeepCopy() MobileNetworkState { return o }
 
 var MobileNetworkStateMap = map[string]MobileNetworkState{
-	"NONE":    0,
-	"WIFI":    1,
-	"CELLUAR": 2,
-	"UNKNOWN": 3,
+	"NONE":         0,
+	"WIFI":         1,
+	"CELLUAR":      2,
+	"UNKNOWN":      3,
+	"NOTAVAILABLE": 4,
 }
 
 var MobileNetworkStateRevMap = map[MobileNetworkState]string{
@@ -63,6 +65,7 @@ var MobileNetworkStateRevMap = map[MobileNetworkState]string{
 	1: "WIFI",
 	2: "CELLUAR",
 	3: "UNKNOWN",
+	4: "NOTAVAILABLE",
 }
 
 func (e MobileNetworkState) String() string {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3187,3 +3187,13 @@ func (k TeamEphemeralKeyType) IsTeambot() bool {
 func (k TeamEphemeralKeyType) IsTeam() bool {
 	return k == TeamEphemeralKeyType_TEAM
 }
+
+// IsLimited returns if the network is considered limited based on the type.
+func (s MobileNetworkState) IsLimited() bool {
+	switch s {
+	case MobileNetworkState_WIFI, MobileNetworkState_NOTAVAILABLE:
+		return false
+	default:
+		return true
+	}
+}

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -67,13 +67,10 @@ func getAuditParams(m libkb.MetaContext) libkb.TeamAuditParams {
 		return devParams
 	}
 	if libkb.IsMobilePlatform() {
-		state := m.G().MobileNetState.State()
-		switch state {
-		case keybase1.MobileNetworkState_WIFI:
-			return mobileParamsWifi
-		default:
+		if m.G().MobileNetState.State().IsLimited() {
 			return mobileParamsNoWifi
 		}
+		return mobileParamsWifi
 	}
 	return desktopParams
 }

--- a/go/teams/audit.go
+++ b/go/teams/audit.go
@@ -28,11 +28,20 @@ var desktopParams = libkb.TeamAuditParams{
 	LRUSize:               1000,
 }
 
-var mobileParams = libkb.TeamAuditParams{
+var mobileParamsWifi = libkb.TeamAuditParams{
 	RootFreshness:         10 * time.Minute,
 	MerkleMovementTrigger: keybase1.Seqno(100000),
 	NumPreProbes:          10,
 	NumPostProbes:         10,
+	Parallelism:           3,
+	LRUSize:               500,
+}
+
+var mobileParamsNoWifi = libkb.TeamAuditParams{
+	RootFreshness:         15 * time.Minute,
+	MerkleMovementTrigger: keybase1.Seqno(150000),
+	NumPreProbes:          5,
+	NumPostProbes:         5,
 	Parallelism:           3,
 	LRUSize:               500,
 }
@@ -58,7 +67,13 @@ func getAuditParams(m libkb.MetaContext) libkb.TeamAuditParams {
 		return devParams
 	}
 	if libkb.IsMobilePlatform() {
-		return mobileParams
+		state := m.G().MobileNetState.State()
+		switch state {
+		case keybase1.MobileNetworkState_WIFI:
+			return mobileParamsWifi
+		default:
+			return mobileParamsNoWifi
+		}
 	}
 	return desktopParams
 }

--- a/go/teams/box_audit.go
+++ b/go/teams/box_audit.go
@@ -25,9 +25,7 @@ func ShouldRunBoxAudit(mctx libkb.MetaContext) bool {
 
 	if mctx.G().IsMobileAppType() {
 		netState := mctx.G().MobileNetState.State()
-		switch netState {
-		case keybase1.MobileNetworkState_WIFI:
-		default:
+		if netState.IsLimited() {
 			mctx.Debug("ShouldRunBoxAudit: skipping box audit, network state: %v", netState)
 			return false
 		}

--- a/go/teams/box_audit.go
+++ b/go/teams/box_audit.go
@@ -24,9 +24,16 @@ func ShouldRunBoxAudit(mctx libkb.MetaContext) bool {
 	}
 
 	if mctx.G().IsMobileAppType() {
-		state, stateMtime := mctx.G().MobileAppState.StateAndMtime()
-		mctx.Debug("ShouldRunBoxAudit: mobileAppState=%+v, stateMtime=%+v", state, stateMtime)
-		if stateMtime == nil || state != keybase1.MobileAppState_FOREGROUND || time.Now().Sub(*stateMtime) < 3*time.Minute {
+		netState := mctx.G().MobileNetState.State()
+		switch netState {
+		case keybase1.MobileNetworkState_WIFI:
+		default:
+			mctx.Debug("ShouldRunBoxAudit: skipping box audit, network state: %v", netState)
+			return false
+		}
+		appState, stateMtime := mctx.G().MobileAppState.StateAndMtime()
+		mctx.Debug("ShouldRunBoxAudit: mobileAppState=%+v, stateMtime=%+v", appState, stateMtime)
+		if stateMtime == nil || appState != keybase1.MobileAppState_FOREGROUND || time.Now().Sub(*stateMtime) < 3*time.Minute {
 			mctx.Debug("ShouldRunBoxAudit: mobile and backgrounded")
 			return false
 		}

--- a/protocol/avdl/keybase1/appstate.avdl
+++ b/protocol/avdl/keybase1/appstate.avdl
@@ -12,7 +12,9 @@ protocol appState {
     NONE_0,
     WIFI_1,
     CELLUAR_2,
-    UNKNOWN_3
+    UNKNOWN_3,
+    // Default for desktop, not treated as a 'limited' connection
+    NOTAVAILABLE_4
   }
 
   // gui -> service

--- a/protocol/json/keybase1/appstate.json
+++ b/protocol/json/keybase1/appstate.json
@@ -19,7 +19,8 @@
         "NONE_0",
         "WIFI_1",
         "CELLUAR_2",
-        "UNKNOWN_3"
+        "UNKNOWN_3",
+        "NOTAVAILABLE_4"
       ]
     }
   ],

--- a/shared/actions/config-gen.tsx
+++ b/shared/actions/config-gen.tsx
@@ -1,7 +1,7 @@
 // NOTE: This file is GENERATED from json files in actions/json. Run 'yarn build-actions' to regenerate
 import * as I from 'immutable'
 import * as RPCTypes from '../constants/types/rpc-gen'
-import {ConnectionType} from '@react-native-community/netinfo'
+import {ConnectionType} from '../constants/types/config'
 import * as Tabs from '../constants/tabs'
 import * as ChatTypes from '../constants/types/chat2'
 import * as FsTypes from '../constants/types/fs'

--- a/shared/actions/json/config.json
+++ b/shared/actions/json/config.json
@@ -1,6 +1,6 @@
 {
   "prelude": [
-    "import {ConnectionType} from '@react-native-community/netinfo'",
+    "import {ConnectionType} from '../constants/types/config'",
     "import * as Tabs from '../constants/tabs'",
     "import * as ChatTypes from '../constants/types/chat2'",
     "import * as FsTypes from '../constants/types/fs'",

--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -204,7 +204,7 @@ function* checkRPCOwnership(_, action: ConfigGen.DaemonHandshakePayload) {
 }
 
 const initOsNetworkStatus = (state, action) =>
-  ConfigGen.createOsNetworkStatusChanged({isInit: true, online: navigator.onLine, type: 'wifi'})
+  ConfigGen.createOsNetworkStatusChanged({isInit: true, online: navigator.onLine, type: 'notavailable'})
 
 function* setupReachabilityWatcher() {
   const channel = Saga.eventChannel(emitter => {
@@ -215,7 +215,9 @@ function* setupReachabilityWatcher() {
 
   while (true) {
     const status = yield Saga.take(channel)
-    yield Saga.put(ConfigGen.createOsNetworkStatusChanged({online: status === 'online', type: 'wifi'}))
+    yield Saga.put(
+      ConfigGen.createOsNetworkStatusChanged({online: status === 'online', type: 'notavailable'})
+    )
   }
 }
 

--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -204,7 +204,7 @@ function* checkRPCOwnership(_, action: ConfigGen.DaemonHandshakePayload) {
 }
 
 const initOsNetworkStatus = (state, action) =>
-  ConfigGen.createOsNetworkStatusChanged({isInit: true, online: navigator.onLine, type: 'unknown'})
+  ConfigGen.createOsNetworkStatusChanged({isInit: true, online: navigator.onLine, type: 'wifi'})
 
 function* setupReachabilityWatcher() {
   const channel = Saga.eventChannel(emitter => {
@@ -215,7 +215,7 @@ function* setupReachabilityWatcher() {
 
   while (true) {
     const status = yield Saga.take(channel)
-    yield Saga.put(ConfigGen.createOsNetworkStatusChanged({online: status === 'online', type: 'unknown'}))
+    yield Saga.put(ConfigGen.createOsNetworkStatusChanged({online: status === 'online', type: 'wifi'}))
   }
 }
 

--- a/shared/constants/types/config.tsx
+++ b/shared/constants/types/config.tsx
@@ -4,6 +4,7 @@ import {ConversationIDKey} from './chat2'
 import {Tab} from '../tabs'
 import {RPCError} from '../../util/errors'
 import {LocalPath} from '../../constants/types/fs'
+import * as NetInfo from '@react-native-community/netinfo'
 
 export type _OutOfDate = {
   critical: boolean
@@ -13,6 +14,8 @@ export type _OutOfDate = {
 export type OutOfDate = I.RecordOf<_OutOfDate>
 export type DaemonHandshakeState = 'starting' | 'waitingForWaiters' | 'done'
 export type AppOutOfDateStatus = 'critical' | 'suggested' | 'ok' | 'checking'
+// 'notavailable' is the desktop default
+export type ConnectionType = NetInfo.ConnectionType | 'notavailable'
 
 export type _State = {
   appFocused: boolean

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1598,6 +1598,7 @@ export enum MobileNetworkState {
   wifi = 1,
   celluar = 2,
   unknown = 3,
+  notavailable = 4,
 }
 
 export enum OfflineAvailability {


### PR DESCRIPTION
patch does the following:

- change default network state on desktop to `notavailable`
- cancel/prevent indexer syncs when on mobile data
- limit convload (from`Syncer` and `InboxSource`) when on mobile data
- skip merkle audits on mobile data
- loosen team audit params on mobile data 
- skip team box audits on mobile data

cc @keybase/hotpotatosquad 