### PR TITLE
Add the selectedValue as a key to Kb.FloatingPicker in order to force a remount

### DIFF
--- a/shared/common-adapters/floating-picker.native.tsx
+++ b/shared/common-adapters/floating-picker.native.tsx
@@ -11,7 +11,7 @@ const FloatingPicker = <T extends string | number>(props: Props<T>) => {
     return null
   }
   return (
-    <Overlay onHidden={props.onHidden}>
+    <Overlay onHidden={props.onHidden} key={props.selectedValue}>
       <Box2 direction="vertical" fullWidth={true} style={styles.menu}>
         {props.header}
         <Box2 direction="horizontal" fullWidth={true} style={styles.actionButtons}>


### PR DESCRIPTION
Debugging showed that the FloatingPicker component was properly getting re-rendered when a currency was selected but that the change wasn't making it to the virtual DOM. react-native Picker seems to have a lot of bugs similar to this ([this SO question](https://stackoverflow.com/questions/53396292/reactnative-picker-doesnt-update-selected-value) seems to match almost exactly) but none of the solutions I found online worked. Given that this will only remount the FloatingPicker and will only do so when a new option is selected, the performance impact seem reasonable. 

Fixes [PICNIC-122](https://keybase.atlassian.net/browse/PICNIC-122). 