### PR TITLE
SEP7 fixes

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -282,7 +282,7 @@ const acceptSEP7Tx = (state, action: WalletsGen.AcceptSEP7TxPayload) =>
       inputURI: state.wallets.sep7ConfirmURI,
     },
     Constants.sep7WaitingKey
-  ).then(_ => RouteTreeGen.createClearModals())
+  ).then(_ => [RouteTreeGen.createClearModals(), RouteTreeGen.createSwitchTab({tab: Tabs.walletsTab})])
 
 const acceptSEP7Pay = (state, action: WalletsGen.AcceptSEP7PayPayload) =>
   RPCStellarTypes.localApprovePayURILocalRpcPromise(
@@ -292,7 +292,7 @@ const acceptSEP7Pay = (state, action: WalletsGen.AcceptSEP7PayPayload) =>
       inputURI: state.wallets.sep7ConfirmURI,
     },
     Constants.sep7WaitingKey
-  ).then(_ => RouteTreeGen.createClearModals())
+  ).then(_ => [RouteTreeGen.createClearModals(), RouteTreeGen.createSwitchTab({tab: Tabs.walletsTab})])
 
 const clearBuiltPayment = () => WalletsGen.createClearBuiltPayment()
 const clearBuiltRequest = () => WalletsGen.createClearBuiltRequest()

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -263,11 +263,9 @@ const stopPayment = (state, action: WalletsGen.AbandonPaymentPayload) =>
 const validateSEP7Link = (state, action: WalletsGen.ValidateSEP7LinkPayload) =>
   RPCStellarTypes.localValidateStellarURILocalRpcPromise({inputURI: action.payload.link})
     .then(tx => [
-      // Important to clear the modal first, since sep7-confirm doesn't like
-      // sep7confirmInfo becoming null while it's mounted.
-      RouteTreeGen.createClearModals(),
       WalletsGen.createSetSEP7Tx({confirmURI: action.payload.link, tx: Constants.makeSEP7ConfirmInfo(tx)}),
       WalletsGen.createValidateSEP7LinkError({error: ''}),
+      RouteTreeGen.createClearModals(),
       RouteTreeGen.createNavigateAppend({path: ['sep7Confirm']}),
     ])
     .catch(error => [

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -273,7 +273,7 @@ const validateSEP7Link = (state, action: WalletsGen.ValidateSEP7LinkPayload) =>
         error: error.desc,
       }),
       RouteTreeGen.createClearModals(),
-      RouteTreeGen.createNavigateAppend({path: ['sep7Confirm']}),
+      RouteTreeGen.createNavigateAppend({path: ['sep7ConfirmError']}),
     ])
 
 const acceptSEP7Tx = (state, action: WalletsGen.AcceptSEP7TxPayload) =>

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -263,9 +263,11 @@ const stopPayment = (state, action: WalletsGen.AbandonPaymentPayload) =>
 const validateSEP7Link = (state, action: WalletsGen.ValidateSEP7LinkPayload) =>
   RPCStellarTypes.localValidateStellarURILocalRpcPromise({inputURI: action.payload.link})
     .then(tx => [
+      // Important to clear the modal first, since sep7-confirm doesn't like
+      // sep7confirmInfo becoming null while it's mounted.
+      RouteTreeGen.createClearModals(),
       WalletsGen.createSetSEP7Tx({confirmURI: action.payload.link, tx: Constants.makeSEP7ConfirmInfo(tx)}),
       WalletsGen.createValidateSEP7LinkError({error: ''}),
-      RouteTreeGen.createClearModals(),
       RouteTreeGen.createNavigateAppend({path: ['sep7Confirm']}),
     ])
     .catch(error => [

--- a/shared/desktop/app/node.desktop.tsx
+++ b/shared/desktop/app/node.desktop.tsx
@@ -8,7 +8,7 @@ import * as SafeElectron from '../../util/safe-electron.desktop'
 import {setupExecuteActionsListener, executeActionsForContext} from '../../util/quit-helper.desktop'
 import {allowMultipleInstances} from '../../local-debug.desktop'
 import startWinService from './start-win-service.desktop'
-import {isDarwin, isWindows, cacheRoot} from '../../constants/platform.desktop'
+import {isDarwin, isLinux, isWindows, cacheRoot} from '../../constants/platform.desktop'
 import {sendToMainWindow} from '../remote/util.desktop'
 import * as ConfigGen from '../../actions/config-gen'
 import logger from '../../logger'
@@ -67,7 +67,7 @@ const focusSelfOnAnotherInstanceLaunching = (_, commandLine) => {
   }
 
   mainWindow.show()
-  if (isWindows) {
+  if (isWindows || isLinux) {
     mainWindow.window && mainWindow.window.focus()
   }
 

--- a/shared/reducers/config.tsx
+++ b/shared/reducers/config.tsx
@@ -245,12 +245,18 @@ export default function(state: Types.State = initialState, action: Actions): Typ
       })
     case ConfigGen.osNetworkStatusChanged:
       return state.set('osNetworkOnline', action.payload.online)
+    case ConfigGen.link:
+      // Clear out old state, isn't necessary but seems like a good idea.
+      return state.merge({
+        sep7ConfirmError: '',
+        sep7ConfirmInfo: null,
+        sep7ConfirmURI: '',
+      })
     // Saga only actions
     case ConfigGen.loadTeamAvatars:
     case ConfigGen.loadAvatars:
     case ConfigGen.dumpLogs:
     case ConfigGen.logout:
-    case ConfigGen.link:
     case ConfigGen.mobileAppState:
     case ConfigGen.openAppSettings:
     case ConfigGen.showMain:

--- a/shared/reducers/config.tsx
+++ b/shared/reducers/config.tsx
@@ -245,18 +245,12 @@ export default function(state: Types.State = initialState, action: Actions): Typ
       })
     case ConfigGen.osNetworkStatusChanged:
       return state.set('osNetworkOnline', action.payload.online)
-    case ConfigGen.link:
-      // Clear out old state, isn't necessary but seems like a good idea.
-      return state.merge({
-        sep7ConfirmError: '',
-        sep7ConfirmInfo: null,
-        sep7ConfirmURI: '',
-      })
     // Saga only actions
     case ConfigGen.loadTeamAvatars:
     case ConfigGen.loadAvatars:
     case ConfigGen.dumpLogs:
     case ConfigGen.logout:
+    case ConfigGen.link:
     case ConfigGen.mobileAppState:
     case ConfigGen.openAppSettings:
     case ConfigGen.showMain:

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -382,6 +382,13 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         airdropQualifications: I.List(action.payload.airdropQualifications),
         airdropState: action.payload.airdropState,
       })
+    case WalletsGen.validateSEP7Link:
+      // Clear out old state just in case.
+      return state.merge({
+        sep7ConfirmError: '',
+        sep7ConfirmInfo: null,
+        sep7ConfirmURI: '',
+      })
     case WalletsGen.validateSEP7LinkError:
       return state.merge({sep7ConfirmError: action.payload.error})
     case WalletsGen.setSEP7Tx:
@@ -482,7 +489,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.loadExternalPartners:
     case WalletsGen.acceptSEP7Pay:
     case WalletsGen.acceptSEP7Tx:
-    case WalletsGen.validateSEP7Link:
     case WalletsGen.refreshTrustlineAcceptedAssets:
     case WalletsGen.refreshTrustlinePopularAssets:
       return state

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -382,13 +382,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         airdropQualifications: I.List(action.payload.airdropQualifications),
         airdropState: action.payload.airdropState,
       })
-    case WalletsGen.validateSEP7Link:
-      // Clear out old state, isn't necessary but seems like a good idea.
-      return state.merge({
-        sep7ConfirmError: '',
-        sep7ConfirmInfo: null,
-        sep7ConfirmURI: '',
-      })
     case WalletsGen.validateSEP7LinkError:
       return state.merge({sep7ConfirmError: action.payload.error})
     case WalletsGen.setSEP7Tx:
@@ -489,6 +482,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.loadExternalPartners:
     case WalletsGen.acceptSEP7Pay:
     case WalletsGen.acceptSEP7Tx:
+    case WalletsGen.validateSEP7Link:
     case WalletsGen.refreshTrustlineAcceptedAssets:
     case WalletsGen.refreshTrustlinePopularAssets:
       return state

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -382,13 +382,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         airdropQualifications: I.List(action.payload.airdropQualifications),
         airdropState: action.payload.airdropState,
       })
-    case WalletsGen.validateSEP7Link:
-      // Clear out old state, isn't necessary but seems like a good idea.
-      return state.merge({
-        sep7ConfirmError: '',
-        sep7ConfirmInfo: null,
-        sep7ConfirmURI: '',
-      })
     case WalletsGen.validateSEP7LinkError:
       return state.merge({sep7ConfirmError: action.payload.error})
     case WalletsGen.setSEP7Tx:

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -382,6 +382,13 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         airdropQualifications: I.List(action.payload.airdropQualifications),
         airdropState: action.payload.airdropState,
       })
+    case WalletsGen.validateSEP7Link:
+      // Clear out old state, isn't necessary but seems like a good idea.
+      return state.merge({
+        sep7ConfirmError: '',
+        sep7ConfirmInfo: null,
+        sep7ConfirmURI: '',
+      })
     case WalletsGen.validateSEP7LinkError:
       return state.merge({sep7ConfirmError: action.payload.error})
     case WalletsGen.setSEP7Tx:

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -382,6 +382,13 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         airdropQualifications: I.List(action.payload.airdropQualifications),
         airdropState: action.payload.airdropState,
       })
+    case WalletsGen.validateSEP7Link:
+      // Clear out old state, isn't necessary but seems like a good idea.
+      return state.merge({
+        sep7ConfirmError: '',
+        sep7ConfirmInfo: null,
+        sep7ConfirmURI: '',
+      })
     case WalletsGen.validateSEP7LinkError:
       return state.merge({sep7ConfirmError: action.payload.error})
     case WalletsGen.setSEP7Tx:
@@ -482,7 +489,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.loadExternalPartners:
     case WalletsGen.acceptSEP7Pay:
     case WalletsGen.acceptSEP7Tx:
-    case WalletsGen.validateSEP7Link:
     case WalletsGen.refreshTrustlineAcceptedAssets:
     case WalletsGen.refreshTrustlinePopularAssets:
       return state

--- a/shared/wallets/routes.tsx
+++ b/shared/wallets/routes.tsx
@@ -84,6 +84,7 @@ export const newModalRoutes = {
   removeAccount: {getScreen: () => require('./wallet/settings/popups').RemoveAccountPopup, upgraded: true},
   renameAccount: {getScreen: () => require('./wallet/settings/popups').RenameAccountPopup, upgraded: true},
   sep7Confirm: {getScreen: () => require('./sep7-confirm/container').default, upgraded: true},
+  sep7ConfirmError: {getScreen: () => require('./sep7-confirm/error').default, upgraded: true},
   setDefaultAccount: {
     getScreen: () => require('./wallet/settings/popups').SetDefaultAccountPopup,
     upgraded: true,

--- a/shared/wallets/sep7-confirm/asset-input-container.tsx
+++ b/shared/wallets/sep7-confirm/asset-input-container.tsx
@@ -3,6 +3,11 @@ import * as React from 'react'
 import * as Constants from '../../constants/wallets'
 import * as Container from '../../util/container'
 
+type OwnProps = {
+  amount: string
+  onChangeAmount: (amount: string) => void
+}
+
 const mapStateToProps = (state: Container.TypedState) => {
   const currency = 'XLM'
   return {
@@ -21,21 +26,18 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onChangeDisplayUnit: undefined, // Add when non-native assets are supported
 })
 
-const AssetInputWrapper = (props: Omit<Props, 'onChangeAmount' | 'value'>) => {
-  const [amount, onChangeAmount] = React.useState('')
-  return <AssetInput {...props} value={amount} onChangeAmount={onChangeAmount} />
-}
-
 export default Container.connect(
   mapStateToProps,
   mapDispatchToProps,
-  (stateProps, dispatchProps, ownProps) => ({
+  (stateProps, dispatchProps, ownProps: OwnProps) => ({
     bottomLabel: stateProps.bottomLabel,
     currencyLoading: stateProps.currencyLoading,
     displayUnit: stateProps.displayUnit,
     inputPlaceholder: stateProps.inputPlaceholder,
     numDecimalsAllowed: stateProps.numDecimalsAllowed,
+    onChangeAmount: ownProps.onChangeAmount,
     onChangeDisplayUnit: dispatchProps.onChangeDisplayUnit,
     topLabel: stateProps.topLabel,
+    value: ownProps.amount,
   })
-)(AssetInputWrapper)
+)(AssetInput)

--- a/shared/wallets/sep7-confirm/container.tsx
+++ b/shared/wallets/sep7-confirm/container.tsx
@@ -1,12 +1,11 @@
-import * as React from 'react'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as Constants from '../../constants/wallets'
 import * as Container from '../../util/container'
-import SEP7Confirm, {Props} from '.'
+import SEP7Confirm from '.'
 
 const mapStateToProps = (state: Container.TypedState) => ({
-  inputURI: state.wallets.sep7ConfirmURI,
+  _inputURI: state.wallets.sep7ConfirmURI,
   loading: !state.wallets.sep7ConfirmInfo,
   sep7ConfirmInfo: state.wallets.sep7ConfirmInfo,
   waitingKey: Constants.sep7WaitingKey,
@@ -19,55 +18,64 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onClose: () => dispatch(RouteTreeGen.createNavigateUp()),
 })
 
-const SEP7ConfirmWrapper = (props: Props) => {
-  const [userAmount, onChangeAmount] = React.useState('')
-  return <SEP7Confirm {...props} userAmount={userAmount} onChangeAmount={onChangeAmount} />
-}
-
-export default Container.connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  (stateProps, dispatchProps, ownProps) => {
-    const {
-      amount,
-      assetCode,
-      availableToSendFiat,
-      availableToSendNative,
-      assetIssuer,
-      callbackURL,
-      displayAmountFiat,
-      memo,
-      memoType,
-      message,
-      operation,
-      originDomain,
-      recipient,
-      summary,
-      xdr,
-    } = stateProps.sep7ConfirmInfo
+const Connected = Container.connect(mapStateToProps, mapDispatchToProps, (stateProps, dispatchProps) => {
+  if (stateProps.loading) {
     return {
-      ...ownProps,
-      amount,
-      assetCode,
-      assetIssuer,
-      availableToSendFiat,
-      availableToSendNative,
-      callbackURL,
-      displayAmountFiat,
-      inputURI: stateProps.inputURI,
-      loading: stateProps.loading,
-      memo,
-      memoType,
-      message,
-      onAcceptPay: (amount: string) => dispatchProps._onAcceptPay(stateProps.inputURI, amount),
-      onAcceptTx: () => dispatchProps._onAcceptTx(stateProps.inputURI),
+      amount: null,
+      availableToSendNative: '',
+      callbackURL: null,
+      displayAmountFiat: '',
+      loading: true,
+      memo: null,
+      memoType: null,
+      message: null,
+      onAcceptPay: (amount: string) => null,
+      onAcceptTx: () => null,
       onBack: dispatchProps.onClose,
-      operation,
-      originDomain,
-      recipient,
-      summary,
+      operation: 'pay',
+      originDomain: '',
+      recipient: null,
+      summary: {
+        fee: '',
+        memo: '',
+        memoType: '',
+        operations: [],
+        source: '',
+      },
       waitingKey: stateProps.waitingKey,
-      xdr,
     }
   }
-)(SEP7ConfirmWrapper)
+  const {
+    amount,
+    availableToSendNative,
+    callbackURL,
+    displayAmountFiat,
+    memo,
+    memoType,
+    message,
+    operation,
+    originDomain,
+    recipient,
+    summary,
+  } = stateProps.sep7ConfirmInfo
+  return {
+    amount,
+    availableToSendNative,
+    callbackURL,
+    displayAmountFiat,
+    loading: stateProps.loading,
+    memo,
+    memoType,
+    message,
+    onAcceptPay: (amount: string) => dispatchProps._onAcceptPay(stateProps._inputURI, amount),
+    onAcceptTx: () => dispatchProps._onAcceptTx(stateProps._inputURI),
+    onBack: dispatchProps.onClose,
+    operation,
+    originDomain,
+    recipient,
+    summary,
+    waitingKey: stateProps.waitingKey,
+  }
+})(SEP7Confirm)
+
+export default Connected

--- a/shared/wallets/sep7-confirm/container.tsx
+++ b/shared/wallets/sep7-confirm/container.tsx
@@ -3,20 +3,14 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as Constants from '../../constants/wallets'
 import * as Container from '../../util/container'
-import SEP7Confirm from '.'
+import SEP7Confirm, {Props} from '.'
 
-const mapStateToProps = (state: Container.TypedState) => {
-  const error = state.wallets.sep7ConfirmError
-  if (error) {
-    return {error}
-  }
-  return {
-    inputURI: state.wallets.sep7ConfirmURI,
-    loading: !state.wallets.sep7ConfirmInfo,
-    sep7ConfirmInfo: state.wallets.sep7ConfirmInfo,
-    waitingKey: Constants.sep7WaitingKey,
-  }
-}
+const mapStateToProps = (state: Container.TypedState) => ({
+  inputURI: state.wallets.sep7ConfirmURI,
+  loading: !state.wallets.sep7ConfirmInfo,
+  sep7ConfirmInfo: state.wallets.sep7ConfirmInfo,
+  waitingKey: Constants.sep7WaitingKey,
+})
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   _onAcceptPay: (inputURI: string, amount: string) =>
@@ -24,6 +18,11 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   _onAcceptTx: (inputURI: string) => dispatch(WalletsGen.createAcceptSEP7Tx({inputURI})),
   onClose: () => dispatch(RouteTreeGen.createNavigateUp()),
 })
+
+const SEP7ConfirmWrapper = (props: Props) => {
+  const [userAmount, onChangeAmount] = React.useState('')
+  return <SEP7Confirm {...props} userAmount={userAmount} onChangeAmount={onChangeAmount} />
+}
 
 export default Container.connect(
   mapStateToProps,
@@ -55,7 +54,6 @@ export default Container.connect(
       availableToSendNative,
       callbackURL,
       displayAmountFiat,
-      error: stateProps.error,
       inputURI: stateProps.inputURI,
       loading: stateProps.loading,
       memo,
@@ -72,4 +70,4 @@ export default Container.connect(
       xdr,
     }
   }
-)(SEP7Confirm)
+)(SEP7ConfirmWrapper)

--- a/shared/wallets/sep7-confirm/error.tsx
+++ b/shared/wallets/sep7-confirm/error.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import * as Container from '../../util/container'
+import * as Kb from '../../common-adapters'
+import * as RouteTreeGen from '../../actions/route-tree-gen'
+import * as Styles from '../../styles'
+
+const Error = () => {
+  const error = Container.useSelector(s => s.wallets.sep7ConfirmError)
+  const dispatch = Container.useDispatch()
+  const onBack = () => dispatch(RouteTreeGen.createNavigateUp())
+
+  return (
+    <Kb.MaybePopup onClose={onBack}>
+      <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
+        <Kb.Box2 direction="vertical" centerChildren={true} fullWidth={true} style={styles.dialog}>
+          <Kb.Text style={styles.text} type="Body">
+            {error}
+          </Kb.Text>
+        </Kb.Box2>
+      </Kb.Box2>
+    </Kb.MaybePopup>
+  )
+}
+
+const styles = Styles.styleSheetCreate({
+  container: Styles.platformStyles({
+    common: {
+      backgroundColor: Styles.globalColors.white,
+    },
+    isElectron: {
+      height: 560,
+      width: 400,
+    },
+    isMobile: {
+      flexGrow: 1,
+      flexShrink: 1,
+      maxHeight: '100%',
+      width: '100%',
+    },
+  }),
+  dialog: {
+    backgroundColor: Styles.globalColors.red,
+    marginTop: Styles.globalMargins.small,
+    minHeight: 40,
+    paddingBottom: Styles.globalMargins.tiny,
+    paddingLeft: Styles.globalMargins.large,
+    paddingRight: Styles.globalMargins.large,
+    paddingTop: Styles.globalMargins.tiny,
+  },
+  text: {
+    color: Styles.globalColors.white,
+  },
+})
+
+export default Error

--- a/shared/wallets/sep7-confirm/index.stories.tsx
+++ b/shared/wallets/sep7-confirm/index.stories.tsx
@@ -18,6 +18,7 @@ const commonProps = {
   onAcceptTx: Sb.action('onAcceptTx'),
   onBack: Sb.action('onBack'),
   onChangeAmount: Sb.action('onChangeAmount'),
+  userAmount: '',
   waiting: false,
   waitingKey: 'false',
 }

--- a/shared/wallets/sep7-confirm/index.tsx
+++ b/shared/wallets/sep7-confirm/index.tsx
@@ -12,7 +12,7 @@ type Summary = {
   source: string
 }
 
-type Props = {
+export type Props = {
   amount: string | null
   availableToSendNative: string
   callbackURL: string | null
@@ -31,6 +31,7 @@ type Props = {
   originDomain: string
   recipient: string | null
   summary: Summary
+  userAmount: string
   waitingKey: string
 }
 
@@ -43,17 +44,6 @@ const CallbackURLBanner = (props: CallbackURLBannerProps) => (
       The payment will be sent to {props.callbackURL}.
     </Kb.Text>
   </Kb.Box2>
-)
-
-type ErrorProps = {error: string; onBack: () => void}
-const Error = (props: ErrorProps) => (
-  <Kb.MaybePopup onClose={props.onBack}>
-    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
-      <Kb.Box2 direction="vertical" centerChildren={true} fullWidth={true} style={styles.dialog}>
-        <Kb.Text type="Body">{props.error}</Kb.Text>
-      </Kb.Box2>
-    </Kb.Box2>
-  </Kb.MaybePopup>
 )
 
 type LoadingProps = {onBack: () => void}
@@ -145,6 +135,7 @@ type PaymentInfoProps = {
   message: string | null
   onChangeAmount: (amount: string) => void
   recipient: string
+  userAmount: string
 }
 const PaymentInfo = (props: PaymentInfoProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
@@ -169,7 +160,7 @@ const PaymentInfo = (props: PaymentInfoProps) => (
         </>
       )}
     </Kb.Box2>
-    {!props.amount && <AssetInput />}
+    {!props.amount && <AssetInput amount={props.userAmount} onChangeAmount={props.onChangeAmount} />}
     {!!props.memo && <InfoRow headerText="Memo" bodyText={props.memo} />}
     {!!props.message && <InfoRow headerText="Message" bodyText={props.message} />}
     {!!props.recipient && (
@@ -198,8 +189,6 @@ const TxInfo = (props: TxInfoProps) => (
 const SEP7Confirm = (props: Props) =>
   props.loading ? (
     <Loading onBack={props.onBack} />
-  ) : props.error ? (
-    <Error error={props.error} onBack={props.onBack} />
   ) : (
     <Kb.MaybePopup onClose={props.onBack}>
       <Kb.Box2 direction="vertical" fullHeight={!Styles.isMobile} fullWidth={true} style={styles.container}>
@@ -219,6 +208,7 @@ const SEP7Confirm = (props: Props) =>
               message={props.message}
               onChangeAmount={props.onChangeAmount}
               recipient={props.recipient}
+              userAmount={props.userAmount}
             />
           ) : (
             <TxInfo
@@ -238,7 +228,11 @@ const SEP7Confirm = (props: Props) =>
         >
           <Kb.WaitingButton
             type="Success"
-            onClick={props.operation === 'pay' ? () => props.onAcceptPay(props.amount) : props.onAcceptTx}
+            onClick={
+              props.operation === 'pay'
+                ? () => props.onAcceptPay(props.amount || props.userAmount)
+                : props.onAcceptTx
+            }
             waitingKey={props.waitingKey}
             fullWidth={true}
             style={styles.button}


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

* Fix user-controlled inputs by moving the hooks wrapper up a level

* Fix the error screen, container was destructuring sep7ConfirmInfo when it was null. Simplified it by adding a new route for SEP7ConfirmError so that SEP7Confirm can trust that sep7ConfirmInfo has been set.

* Style the error screen with a banner

* Focus on SEP7 link on Linux, like we already had on Windows

* Nav to the Wallets tab after approving a SEP7 payment/tx.