### PR TITLE
[Y2K-133] no zIndex needed for people page loading indicator

### DIFF
--- a/shared/people/index.desktop.tsx
+++ b/shared/people/index.desktop.tsx
@@ -27,7 +27,6 @@ const styles = Styles.styleSheetCreate({
     position: 'absolute',
     top: 9,
     width: 18,
-    zIndex: 2,
   },
   searchContainer: {paddingBottom: Styles.globalMargins.xsmall},
   sectionTitle: {flexGrow: 1},


### PR DESCRIPTION
Well that was easy once I understood what was going on.

cc @keybase/y2ksquad 
Loading indicator no longer appears above the modal header:
<img width="646" alt="Screen Shot 2019-06-27 at 6 03 06 PM" src="https://user-images.githubusercontent.com/59594/60310067-e527fc80-9905-11e9-8db8-f50eb616617c.png">

But it still shows on the people page:
<img width="334" alt="Screen Shot 2019-06-27 at 6 03 23 PM" src="https://user-images.githubusercontent.com/59594/60310069-e527fc80-9905-11e9-9e49-5e2d3a7f58a5.png">

