### PR TITLE
Remove proxysettings component for the release

### DIFF
--- a/shared/settings/advanced/index.tsx
+++ b/shared/settings/advanced/index.tsx
@@ -97,6 +97,7 @@ const Advanced = (props: Props) => {
             />
           </Kb.Box>
         )}
+        {/* Removed for this release. Will add back in later. */}
         {/* <ProxySettings {...props} /> */}
         <Developer {...props} />
       </Kb.Box>

--- a/shared/settings/advanced/index.tsx
+++ b/shared/settings/advanced/index.tsx
@@ -97,7 +97,7 @@ const Advanced = (props: Props) => {
             />
           </Kb.Box>
         )}
-        <ProxySettings {...props} />
+        {/* <ProxySettings {...props} /> */}
         <Developer {...props} />
       </Kb.Box>
     </Kb.ScrollView>


### PR DESCRIPTION
Since TCP proxy support isn't going to land in time for the release, let's remove the GUI so people don't think that the feature is fully complete. 