### PR TITLE
status: add kbfs block cache db stats

### DIFF
--- a/go/client/cmd_status.go
+++ b/go/client/cmd_status.go
@@ -130,17 +130,19 @@ type jsonStatus struct {
 		Log string
 	}
 
-	DefaultUsername      string
-	ProvisionedUsernames []string
-	ConfiguredAccounts   []keybase1.ConfiguredAccount
-	Clients              []keybase1.ClientStatus
-	PlatformInfo         keybase1.PlatformInfo
-	OSVersion            string
-	DeviceEKNames        []string
-	LocalDbStats         []string
-	LocalChatDbStats     []string
-	CacheDirSizeInfo     []keybase1.DirSizeInfo
-	UIRouterMapping      map[string]int
+	DefaultUsername        string
+	ProvisionedUsernames   []string
+	ConfiguredAccounts     []keybase1.ConfiguredAccount
+	Clients                []keybase1.ClientStatus
+	PlatformInfo           keybase1.PlatformInfo
+	OSVersion              string
+	DeviceEKNames          []string
+	LocalDbStats           []string
+	LocalChatDbStats       []string
+	LocalBlockCacheDbStats []string `json:",omitempty"`
+	LocalSyncCacheDbStats  []string `json:",omitempty"`
+	CacheDirSizeInfo       []keybase1.DirSizeInfo
+	UIRouterMapping        map[string]int
 }
 
 func (c *CmdStatus) outputJSON(fstatus *keybase1.FullStatus) error {
@@ -172,6 +174,8 @@ func (c *CmdStatus) outputJSON(fstatus *keybase1.FullStatus) error {
 	status.DeviceEKNames = fstatus.ExtStatus.DeviceEkNames
 	status.LocalDbStats = fstatus.ExtStatus.LocalDbStats
 	status.LocalChatDbStats = fstatus.ExtStatus.LocalChatDbStats
+	status.LocalBlockCacheDbStats = fstatus.ExtStatus.LocalBlockCacheDbStats
+	status.LocalSyncCacheDbStats = fstatus.ExtStatus.LocalSyncCacheDbStats
 	status.CacheDirSizeInfo = fstatus.ExtStatus.CacheDirSizeInfo
 	status.UIRouterMapping = fstatus.ExtStatus.UiRouterMapping
 
@@ -295,6 +299,8 @@ func (c *CmdStatus) outputTerminal(status *keybase1.FullStatus) error {
 	dui.Printf("    %s \n", strings.Join(extStatus.DeviceEkNames, "\n    "))
 	dui.Printf("LocalDbStats:\n%s \n", strings.Join(extStatus.LocalDbStats, "\n"))
 	dui.Printf("LocalChatDbStats:\n%s \n", strings.Join(extStatus.LocalChatDbStats, "\n"))
+	dui.Printf("LocalBlockCacheDbStats:\n%s \n", strings.Join(extStatus.LocalBlockCacheDbStats, "\n"))
+	dui.Printf("LocalSyncCacheDbStats:\n%s \n", strings.Join(extStatus.LocalSyncCacheDbStats, "\n"))
 	dui.Printf("CacheDirSizeInfo:\n")
 	for _, dirInfo := range extStatus.CacheDirSizeInfo {
 		dui.Printf("%s: %s, (%d files)\n", dirInfo.Name, dirInfo.HumanSize, dirInfo.NumFiles)

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -303,6 +303,12 @@ func (s SimpleFSMock) SimpleFSDeobfuscatePath(
 	return nil, nil
 }
 
+// SimpleFSGetStats implements the SimpleFSInterface.
+func (s SimpleFSMock) SimpleFSGetStats(_ context.Context) (
+	keybase1.SimpleFSStats, error) {
+	return keybase1.SimpleFSStats{}, nil
+}
+
 /*
  file source cases:
  1. file

--- a/go/kbfs/libkbfs/leveldb.go
+++ b/go/kbfs/libkbfs/leveldb.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/logger"
@@ -96,6 +97,15 @@ func (ldb *LevelDb) PutWithMeter(key, value []byte, putMeter *CountMeter) (
 		}
 	}()
 	return ldb.Put(key, value, nil)
+}
+
+// StatStrings returns newline-split leveldb stats, suitable for JSONification.
+func (ldb *LevelDb) StatStrings() ([]string, error) {
+	stats, err := ldb.GetProperty("leveldb.stats")
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(stats, "\n"), nil
 }
 
 // openLevelDB opens or recovers a leveldb.DB with a passed-in storage.Storage

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -2673,3 +2673,22 @@ func (k *SimpleFS) SimpleFSDeobfuscatePath(
 	}
 	return res, nil
 }
+
+// SimpleFSGetStats implements the SimpleFSInterface.
+func (k *SimpleFS) SimpleFSGetStats(ctx context.Context) (
+	res keybase1.SimpleFSStats, err error) {
+	ctx = k.makeContext(ctx)
+	dbc := k.config.DiskBlockCache()
+	if dbc == nil {
+		return keybase1.SimpleFSStats{}, nil
+	}
+
+	statusMap := dbc.Status(ctx)
+	if status, ok := statusMap["SyncBlockCache"]; ok {
+		res.SyncCacheDbStats = status.BlockDBStats
+	}
+	if status, ok := statusMap["WorkingSetBlockCache"]; ok {
+		res.BlockCacheDbStats = status.BlockDBStats
+	}
+	return res, nil
+}

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -159,6 +159,8 @@ type ExtendedStatus struct {
 	DefaultDeviceID        DeviceID            `codec:"defaultDeviceID" json:"defaultDeviceID"`
 	LocalDbStats           []string            `codec:"localDbStats" json:"localDbStats"`
 	LocalChatDbStats       []string            `codec:"localChatDbStats" json:"localChatDbStats"`
+	LocalBlockCacheDbStats []string            `codec:"localBlockCacheDbStats" json:"localBlockCacheDbStats"`
+	LocalSyncCacheDbStats  []string            `codec:"localSyncCacheDbStats" json:"localSyncCacheDbStats"`
 	CacheDirSizeInfo       []DirSizeInfo       `codec:"cacheDirSizeInfo" json:"cacheDirSizeInfo"`
 	UiRouterMapping        map[string]int      `codec:"uiRouterMapping" json:"uiRouterMapping"`
 }
@@ -266,6 +268,28 @@ func (o ExtendedStatus) DeepCopy() ExtendedStatus {
 			}
 			return ret
 		})(o.LocalChatDbStats),
+		LocalBlockCacheDbStats: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			ret := make([]string, len(x))
+			for i, v := range x {
+				vCopy := v
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.LocalBlockCacheDbStats),
+		LocalSyncCacheDbStats: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			ret := make([]string, len(x))
+			for i, v := range x {
+				vCopy := v
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.LocalSyncCacheDbStats),
 		CacheDirSizeInfo: (func(x []DirSizeInfo) []DirSizeInfo {
 			if x == nil {
 				return nil

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1233,6 +1233,38 @@ func (o FSSettings) DeepCopy() FSSettings {
 	}
 }
 
+type SimpleFSStats struct {
+	BlockCacheDbStats []string `codec:"blockCacheDbStats" json:"blockCacheDbStats"`
+	SyncCacheDbStats  []string `codec:"syncCacheDbStats" json:"syncCacheDbStats"`
+}
+
+func (o SimpleFSStats) DeepCopy() SimpleFSStats {
+	return SimpleFSStats{
+		BlockCacheDbStats: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			ret := make([]string, len(x))
+			for i, v := range x {
+				vCopy := v
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.BlockCacheDbStats),
+		SyncCacheDbStats: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			ret := make([]string, len(x))
+			for i, v := range x {
+				vCopy := v
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.SyncCacheDbStats),
+	}
+}
+
 type SimpleFSListArg struct {
 	OpID                OpID       `codec:"opID" json:"opID"`
 	Path                Path       `codec:"path" json:"path"`
@@ -1434,6 +1466,9 @@ type SimpleFSDeobfuscatePathArg struct {
 	Path Path `codec:"path" json:"path"`
 }
 
+type SimpleFSGetStatsArg struct {
+}
+
 type SimpleFSInterface interface {
 	// Begin list of items in directory at path.
 	// Retrieve results with readList().
@@ -1552,6 +1587,7 @@ type SimpleFSInterface interface {
 	SimpleFSSetNotificationThreshold(context.Context, int64) error
 	SimpleFSObfuscatePath(context.Context, Path) (string, error)
 	SimpleFSDeobfuscatePath(context.Context, Path) ([]string, error)
+	SimpleFSGetStats(context.Context) (SimpleFSStats, error)
 }
 
 func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
@@ -2178,6 +2214,16 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return
 				},
 			},
+			"simpleFSGetStats": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSGetStatsArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.SimpleFSGetStats(ctx)
+					return
+				},
+			},
 		},
 	}
 }
@@ -2498,5 +2544,10 @@ func (c SimpleFSClient) SimpleFSObfuscatePath(ctx context.Context, path Path) (r
 func (c SimpleFSClient) SimpleFSDeobfuscatePath(ctx context.Context, path Path) (res []string, err error) {
 	__arg := SimpleFSDeobfuscatePathArg{Path: path}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDeobfuscatePath", []interface{}{__arg}, &res)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSGetStats(ctx context.Context) (res SimpleFSStats, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetStats", []interface{}{SimpleFSGetStatsArg{}}, &res)
 	return
 }

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -578,3 +578,15 @@ func (s *SimpleFSHandler) SimpleFSDeobfuscatePath(
 	}
 	return cli.SimpleFSDeobfuscatePath(ctx, path)
 }
+
+// SimpleFSGetStats implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSGetStats(ctx context.Context) (
+	keybase1.SimpleFSStats, error) {
+	ctx, cancel := s.wrapContextWithTimeout(ctx)
+	defer cancel()
+	cli, err := s.client()
+	if err != nil {
+		return keybase1.SimpleFSStats{}, err
+	}
+	return cli.SimpleFSGetStats(ctx)
+}

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/db.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/db.go
@@ -1070,9 +1070,7 @@ func (db *DB) Stats(s *DBStats) error {
 
 	for level, tables := range v.levels {
 		duration, read, write := db.compStats.getStat(level)
-		if len(tables) == 0 && duration == 0 {
-			continue
-		}
+
 		s.LevelDurations = append(s.LevelDurations, duration)
 		s.LevelRead = append(s.LevelRead, read)
 		s.LevelWrite = append(s.LevelWrite, write)

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -1115,76 +1115,76 @@
 			"revisionTime": "2019-03-04T09:57:49Z"
 		},
 		{
-			"checksumSHA1": "4NTmfUj7H5J59M2wCnp3/8FWt1I=",
+			"checksumSHA1": "FavASzhzj5uawgAyMG+00Vcx0po=",
 			"path": "github.com/syndtr/goleveldb/leveldb",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "mPNraL2edpk/2FYq26rSXfMHbJg=",
 			"path": "github.com/syndtr/goleveldb/leveldb/cache",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "UA+PKDKWlDnE2OZblh23W6wZwbY=",
 			"path": "github.com/syndtr/goleveldb/leveldb/comparer",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "1DRAxdlWzS4U0xKN/yQ/fdNN7f0=",
 			"path": "github.com/syndtr/goleveldb/leveldb/errors",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "iBorxU3FBbau81WSyVa8KwcutzA=",
 			"path": "github.com/syndtr/goleveldb/leveldb/filter",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "hPyFsMiqZ1OB7MX+6wIAA6nsdtc=",
 			"path": "github.com/syndtr/goleveldb/leveldb/iterator",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "gJY7bRpELtO0PJpZXgPQ2BYFJ88=",
 			"path": "github.com/syndtr/goleveldb/leveldb/journal",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "2ncG38FDk2thSlrHd7JFmiuvnxA=",
 			"path": "github.com/syndtr/goleveldb/leveldb/memdb",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "o2TorI3z+vc+EBMJ8XeFoUmXBtU=",
 			"path": "github.com/syndtr/goleveldb/leveldb/opt",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "ZHT9cKerJeQfP0QRxEo6w/hNTYo=",
 			"path": "github.com/syndtr/goleveldb/leveldb/storage",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "DS0i9KReIeZn3T1Bpu31xPMtzio=",
 			"path": "github.com/syndtr/goleveldb/leveldb/table",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "V/Dh7NV0/fy/5jX1KaAjmGcNbzI=",
 			"path": "github.com/syndtr/goleveldb/leveldb/util",
-			"revision": "c3a204f8e96543bb0cc090385c001078f184fc46",
-			"revisionTime": "2019-03-18T03:00:20Z"
+			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
+			"revisionTime": "2019-06-25T01:02:20Z"
 		},
 		{
 			"checksumSHA1": "vU2ORasZstZrpzj13Y1pQM2Yqsc=",

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -86,6 +86,8 @@ protocol config {
                                                in the config file. */
     array<string> localDbStats;
     array<string> localChatDbStats;
+    array<string> localBlockCacheDbStats;
+    array<string> localSyncCacheDbStats;
     array<DirSizeInfo> cacheDirSizeInfo;
     map<int> uiRouterMapping;
   }

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -539,4 +539,11 @@ protocol SimpleFS {
   // simpleFSDeobfuscatePath returns a set of plaintext paths for the given
   // obfuscated KBFS path.
   array<string> simpleFSDeobfuscatePath(Path path);
+
+  record SimpleFSStats {
+    array<string> blockCacheDbStats;
+    array<string> syncCacheDbStats;
+  }
+
+  SimpleFSStats simpleFSGetStats();
 }

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -299,6 +299,20 @@
         {
           "type": {
             "type": "array",
+            "items": "string"
+          },
+          "name": "localBlockCacheDbStats"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "localSyncCacheDbStats"
+        },
+        {
+          "type": {
+            "type": "array",
             "items": "DirSizeInfo"
           },
           "name": "cacheDirSizeInfo"

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -718,6 +718,26 @@
           "name": "spaceAvailableNotificationThreshold"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "SimpleFSStats",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "blockCacheDbStats"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "syncCacheDbStats"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1244,6 +1264,10 @@
         "type": "array",
         "items": "string"
       }
+    },
+    "simpleFSGetStats": {
+      "request": [],
+      "response": "SimpleFSStats"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2222,7 +2222,7 @@ export type EmailLookupResult = {readonly email: EmailAddress; readonly uid?: UI
 export type EncryptedBytes32 = string | null
 export type EncryptedGitMetadata = {readonly v: Int; readonly e: Bytes; readonly n: BoxNonce; readonly gen: PerTeamKeyGeneration}
 export type ErrorNum = Int
-export type ExtendedStatus = {readonly standalone: Boolean; readonly passphraseStreamCached: Boolean; readonly tsecCached: Boolean; readonly deviceSigKeyCached: Boolean; readonly deviceEncKeyCached: Boolean; readonly paperSigKeyCached: Boolean; readonly paperEncKeyCached: Boolean; readonly storedSecret: Boolean; readonly secretPromptSkip: Boolean; readonly rememberPassphrase: Boolean; readonly device?: Device | null; readonly deviceErr?: LoadDeviceErr | null; readonly logDir: String; readonly session?: SessionStatus | null; readonly defaultUsername: String; readonly provisionedUsernames?: Array<String> | null; readonly configuredAccounts?: Array<ConfiguredAccount> | null; readonly Clients?: Array<ClientStatus> | null; readonly deviceEkNames?: Array<String> | null; readonly platformInfo: PlatformInfo; readonly defaultDeviceID: DeviceID; readonly localDbStats?: Array<String> | null; readonly localChatDbStats?: Array<String> | null; readonly cacheDirSizeInfo?: Array<DirSizeInfo> | null; readonly uiRouterMapping: {[key: string]: Int}}
+export type ExtendedStatus = {readonly standalone: Boolean; readonly passphraseStreamCached: Boolean; readonly tsecCached: Boolean; readonly deviceSigKeyCached: Boolean; readonly deviceEncKeyCached: Boolean; readonly paperSigKeyCached: Boolean; readonly paperEncKeyCached: Boolean; readonly storedSecret: Boolean; readonly secretPromptSkip: Boolean; readonly rememberPassphrase: Boolean; readonly device?: Device | null; readonly deviceErr?: LoadDeviceErr | null; readonly logDir: String; readonly session?: SessionStatus | null; readonly defaultUsername: String; readonly provisionedUsernames?: Array<String> | null; readonly configuredAccounts?: Array<ConfiguredAccount> | null; readonly Clients?: Array<ClientStatus> | null; readonly deviceEkNames?: Array<String> | null; readonly platformInfo: PlatformInfo; readonly defaultDeviceID: DeviceID; readonly localDbStats?: Array<String> | null; readonly localChatDbStats?: Array<String> | null; readonly localBlockCacheDbStats?: Array<String> | null; readonly localSyncCacheDbStats?: Array<String> | null; readonly cacheDirSizeInfo?: Array<DirSizeInfo> | null; readonly uiRouterMapping: {[key: string]: Int}}
 export type ExternalServiceConfig = {readonly schemaVersion: Int; readonly display?: ServiceDisplayConfig | null; readonly config?: ParamProofServiceConfig | null}
 export type FSEditListRequest = {readonly folder: Folder; readonly requestID: Int}
 export type FSFolderEditHistory = {readonly folder: Folder; readonly serverTime: Time; readonly history?: Array<FSFolderWriterEditHistory> | null}
@@ -2494,6 +2494,7 @@ export type SignupRes = {readonly passphraseOk: Boolean; readonly postOk: Boolea
 export type SimpleFSGetHTTPAddressAndTokenResponse = {readonly address: String; readonly token: String}
 export type SimpleFSListResult = {readonly entries?: Array<Dirent> | null; readonly progress: Progress}
 export type SimpleFSQuotaUsage = {readonly usageBytes: Int64; readonly archiveBytes: Int64; readonly limitBytes: Int64; readonly gitUsageBytes: Int64; readonly gitArchiveBytes: Int64; readonly gitLimitBytes: Int64}
+export type SimpleFSStats = {readonly blockCacheDbStats?: Array<String> | null; readonly syncCacheDbStats?: Array<String> | null}
 export type SizedImage = {readonly path: String; readonly width: Int}
 export type SocialAssertion = {readonly user: String; readonly service: SocialAssertionService}
 export type SocialAssertionService = String
@@ -3346,6 +3347,7 @@ export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.u
 // 'keybase.1.SimpleFS.simpleFSReset'
 // 'keybase.1.SimpleFS.simpleFSObfuscatePath'
 // 'keybase.1.SimpleFS.simpleFSDeobfuscatePath'
+// 'keybase.1.SimpleFS.simpleFSGetStats'
 // 'keybase.1.streamUi.close'
 // 'keybase.1.streamUi.read'
 // 'keybase.1.streamUi.reset'


### PR DESCRIPTION
This adds disk cache stats to both `.kbfs_status` and `keybase status`, via the existing leveldb `GetProperty` method and a new SimpleFS protocol method.

Here's what it looks like in `keybase status`:
```
LocalBlockCacheDbStats:
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   1   |          2 |      86.30259 |       0.25316 |      86.30692 |      86.30259
   2   |         26 |     975.83061 |       0.00000 |       0.00000 |       0.00000
   3   |        128 |    6457.72204 |       0.00000 |       0.00000 |       0.00000
-------+------------+---------------+---------------+---------------+---------------
 Total |        156 |    7519.85524 |       0.25316 |      86.30692 |      86.30259
 
LocalSyncCacheDbStats:
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   2   |          1 |      48.86962 |       0.19820 |      48.88650 |      48.88648
   3   |         22 |    1030.87769 |       1.80434 |     519.91253 |     519.91252
   4   |         16 |     792.89463 |       0.00000 |       0.00000 |       0.00000
-------+------------+---------------+---------------+---------------+---------------
 Total |         39 |    1872.64194 |       2.00254 |     568.79903 |     568.79900
```

Issue: HOTPOT-171