### PR TITLE
Don't modify error results after tx finishes

### DIFF
--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -150,7 +150,7 @@ func (w *walletAPIHandler) batch(ctx context.Context, c Call, wr io.Writer) erro
 	arg := stellar1.BatchLocalArg{
 		BatchID:     opts.BatchID,
 		TimeoutSecs: opts.Timeout,
-		UseMulti:    true,
+		UseMulti:    false,
 	}
 	for _, p := range opts.Payments {
 		arg.Payments = append(arg.Payments, stellar1.BatchPaymentArg{Recipient: p.Recipient, Amount: p.Amount, Message: p.Message})

--- a/go/stellar/batch_multi.go
+++ b/go/stellar/batch_multi.go
@@ -110,6 +110,12 @@ func BatchMulti(mctx libkb.MetaContext, walletState *WalletState, arg stellar1.B
 		// make all ther results have success
 		now := stellar1.ToTimeMs(time.Now())
 		for i := 0; i < len(results); i++ {
+			if results[i].Status == stellar1.PaymentStatus_ERROR {
+				// some of the results have already been marked as an
+				// error, so skip those.
+				continue
+			}
+
 			results[i].TxID = submitRes.TxID
 			results[i].Status = stellar1.PaymentStatus_COMPLETED
 			results[i].EndTime = now


### PR DESCRIPTION
Some results are marked as errors before the tx happens.  The code before was marking everything as successful when the multi-op tx finished.  This fixes that.

@malgorithms this should fix your test.