### PR TITLE
Improve overflow behavior on the airdrop page for narrow desktop windows

### DIFF
--- a/shared/wallets/airdrop/index.tsx
+++ b/shared/wallets/airdrop/index.tsx
@@ -244,6 +244,8 @@ const styles = Styles.styleSheetCreate({
   },
   friendContainer: {
     backgroundColor: Styles.globalColors.blueLighter3,
+    display: 'flex',
+    flexWrap: 'wrap',
     paddingLeft: Styles.globalMargins.medium,
     paddingRight: Styles.globalMargins.medium,
   },


### PR DESCRIPTION
Prior to this PR, wrapping problems started happening at a width of around 850px. The below screenshot is at a window width of 700px prior to this change:

![before-700](https://user-images.githubusercontent.com/5304541/60370113-b5d7c500-99c3-11e9-91f5-5af906fda084.png)

The next screenshot is after this change at a width of 625px which is the minimum width before wrapping issues start to happen again:

![after-625](https://user-images.githubusercontent.com/5304541/60370154-d6078400-99c3-11e9-97d1-edf836d9fde3.png)

And finally a normal width screenshot after the change:

![image](https://user-images.githubusercontent.com/5304541/60370200-fdf6e780-99c3-11e9-9599-a136705b9507.png)

And a mobile screenshot:

![Screenshot_20190628-165601](https://user-images.githubusercontent.com/5304541/60371008-05b78b80-99c6-11e9-9143-5f63b20fc4e1.png)
