### PR TITLE
Wallet badging changes

### DIFF
--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -168,6 +168,7 @@ func transformPaymentStellar(mctx libkb.MetaContext, acctID stellar1.AccountID, 
 	loc.IsAdvanced = p.IsAdvanced
 	loc.SummaryAdvanced = p.SummaryAdvanced
 	loc.Operations = p.Operations
+	loc.Unread = p.Unread
 	loc.Trustline = p.Trustline
 
 	return loc, nil

--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -32,11 +32,6 @@
       "_description": "We received an updated account record",
       "account": "Types.Account"
     },
-    "addNewPayment": {
-      "_description": "Mark a payment we were just notified about as being unseen",
-      "accountID": "Types.AccountID",
-      "paymentID": "Types.PaymentID"
-    },
     "assetsReceived": {
       "_description": "Update our store of assets data",
       "accountID": "Types.AccountID",
@@ -75,10 +70,6 @@
     },
     "clearErrors": {
       "_description": "Clear errors from the store at times like opening or closing a form dialog."
-    },
-    "clearNewPayments": {
-      "_description": "Clear our idea of which payments have not been seen by the user yet",
-      "accountID": "Types.AccountID"
     },
     "cancelRequest": {
       "_description": "Cancel a request. Optionally delete an associated message",

--- a/shared/actions/wallets-gen.tsx
+++ b/shared/actions/wallets-gen.tsx
@@ -15,7 +15,6 @@ export const acceptSEP7Pay = 'wallets:acceptSEP7Pay'
 export const acceptSEP7Tx = 'wallets:acceptSEP7Tx'
 export const accountUpdateReceived = 'wallets:accountUpdateReceived'
 export const accountsReceived = 'wallets:accountsReceived'
-export const addNewPayment = 'wallets:addNewPayment'
 export const addTrustline = 'wallets:addTrustline'
 export const assetsReceived = 'wallets:assetsReceived'
 export const badgesUpdated = 'wallets:badgesUpdated'
@@ -37,7 +36,6 @@ export const clearBuildingAdvanced = 'wallets:clearBuildingAdvanced'
 export const clearBuiltPayment = 'wallets:clearBuiltPayment'
 export const clearBuiltRequest = 'wallets:clearBuiltRequest'
 export const clearErrors = 'wallets:clearErrors'
-export const clearNewPayments = 'wallets:clearNewPayments'
 export const clearTrustlineSearchResults = 'wallets:clearTrustlineSearchResults'
 export const createNewAccount = 'wallets:createNewAccount'
 export const createdNewAccount = 'wallets:createdNewAccount'
@@ -139,7 +137,6 @@ type _AcceptSEP7PayPayload = {readonly amount: string; readonly inputURI: string
 type _AcceptSEP7TxPayload = {readonly inputURI: string}
 type _AccountUpdateReceivedPayload = {readonly account: Types.Account}
 type _AccountsReceivedPayload = {readonly accounts: Array<Types.Account>}
-type _AddNewPaymentPayload = {readonly accountID: Types.AccountID; readonly paymentID: Types.PaymentID}
 type _AddTrustlinePayload = {readonly accountID: Types.AccountID; readonly assetID: Types.AssetID}
 type _AssetsReceivedPayload = {readonly accountID: Types.AccountID; readonly assets: Array<Types.Assets>}
 type _BadgesUpdatedPayload = {readonly accounts: Array<RPCTypes.WalletAccountInfo>}
@@ -166,7 +163,6 @@ type _ClearBuildingPayload = void
 type _ClearBuiltPaymentPayload = void
 type _ClearBuiltRequestPayload = void
 type _ClearErrorsPayload = void
-type _ClearNewPaymentsPayload = {readonly accountID: Types.AccountID}
 type _ClearTrustlineSearchResultsPayload = void
 type _CreateNewAccountPayload = {
   readonly name: string
@@ -505,13 +501,6 @@ export const createSecretKeySeen = (payload: _SecretKeySeenPayload): SecretKeySe
   type: secretKeySeen,
 })
 /**
- * Clear our idea of which payments have not been seen by the user yet
- */
-export const createClearNewPayments = (payload: _ClearNewPaymentsPayload): ClearNewPaymentsPayload => ({
-  payload,
-  type: clearNewPayments,
-})
-/**
  * Close the send form and show the user their transactions so they can review.
  */
 export const createExitFailedPayment = (payload: _ExitFailedPaymentPayload): ExitFailedPaymentPayload => ({
@@ -598,13 +587,6 @@ export const createLoadDisplayCurrencies = (
 export const createLoadWalletDisclaimer = (
   payload: _LoadWalletDisclaimerPayload
 ): LoadWalletDisclaimerPayload => ({payload, type: loadWalletDisclaimer})
-/**
- * Mark a payment we were just notified about as being unseen
- */
-export const createAddNewPayment = (payload: _AddNewPaymentPayload): AddNewPaymentPayload => ({
-  payload,
-  type: addNewPayment,
-})
 /**
  * Mark the given payment ID and anything older as read.
  */
@@ -1106,10 +1088,6 @@ export type AccountsReceivedPayload = {
   readonly payload: _AccountsReceivedPayload
   readonly type: typeof accountsReceived
 }
-export type AddNewPaymentPayload = {
-  readonly payload: _AddNewPaymentPayload
-  readonly type: typeof addNewPayment
-}
 export type AddTrustlinePayload = {readonly payload: _AddTrustlinePayload; readonly type: typeof addTrustline}
 export type AssetsReceivedPayload = {
   readonly payload: _AssetsReceivedPayload
@@ -1190,10 +1168,6 @@ export type ClearBuiltRequestPayload = {
   readonly type: typeof clearBuiltRequest
 }
 export type ClearErrorsPayload = {readonly payload: _ClearErrorsPayload; readonly type: typeof clearErrors}
-export type ClearNewPaymentsPayload = {
-  readonly payload: _ClearNewPaymentsPayload
-  readonly type: typeof clearNewPayments
-}
 export type ClearTrustlineSearchResultsPayload = {
   readonly payload: _ClearTrustlineSearchResultsPayload
   readonly type: typeof clearTrustlineSearchResults
@@ -1580,7 +1554,6 @@ export type Actions =
   | AcceptSEP7TxPayload
   | AccountUpdateReceivedPayload
   | AccountsReceivedPayload
-  | AddNewPaymentPayload
   | AddTrustlinePayload
   | AssetsReceivedPayload
   | BadgesUpdatedPayload
@@ -1603,7 +1576,6 @@ export type Actions =
   | ClearBuiltPaymentPayload
   | ClearBuiltRequestPayload
   | ClearErrorsPayload
-  | ClearNewPaymentsPayload
   | ClearTrustlineSearchResultsPayload
   | CreateNewAccountPayload
   | CreatedNewAccountPayload

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -895,23 +895,6 @@ const paymentReviewed = (_, action: EngineGen.Stellar1UiPaymentReviewedPayload) 
 // maybe just clear always?
 const maybeClearErrors = state => WalletsGen.createClearErrors()
 
-const maybeClearNewTxs = (state, action: RouteTreeGen.SwitchToPayload) => {
-  // TODO fix
-  // const rootTab = I.List(action.payload.path).first()
-  // // If we're leaving from the Wallets tab, and the Wallets tab route
-  // // was the main transaction list for an account, clear new txs.
-  // if (
-  // state.routeTree.previousTab === Constants.rootWalletTab &&
-  // rootTab !== Constants.rootWalletTab
-  // // Constants.isLookingAtWallet(state.routeTree.routeState)
-  // ) {
-  // const accountID = state.wallets.selectedAccount
-  // if (accountID !== Types.noAccountID) {
-  // return WalletsGen.createClearNewPayments({accountID})
-  // }
-  // }
-}
-
 const receivedBadgeState = (state, action: NotificationsGen.ReceivedBadgeStatePayload) =>
   WalletsGen.createBadgesUpdated({accounts: action.payload.badgeState.unreadWalletAccounts || []})
 
@@ -1617,12 +1600,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
     RouteTreeGen.navigateUp,
     maybeClearErrors,
     'maybeClearErrors'
-  )
-  // TODO fix
-  yield* Saga.chainAction<RouteTreeGen.SwitchToPayload>(
-    RouteTreeGen.switchTo,
-    maybeClearNewTxs,
-    'maybeClearNewTxs'
   )
 
   yield* Saga.chainAction<NotificationsGen.ReceivedBadgeStatePayload>(

--- a/shared/constants/types/wallets.tsx
+++ b/shared/constants/types/wallets.tsx
@@ -375,7 +375,7 @@ export type _State = {
   inflationDestinationError: string
   lastSentXLM: boolean
   linkExistingAccountError: string
-  newPayments: I.Map<AccountID, I.Set<PaymentID>>
+  newPayments: I.Map<AccountID, I.Set<PaymentID>> // xxx todo remove this field, might be unused
   paymentsMap: I.Map<AccountID, I.Map<PaymentID, Payment>>
   paymentCursorMap: I.Map<AccountID, StellarRPCTypes.PageCursor | null>
   paymentLoadingMoreMap: I.Map<AccountID, boolean>

--- a/shared/constants/types/wallets.tsx
+++ b/shared/constants/types/wallets.tsx
@@ -375,7 +375,6 @@ export type _State = {
   inflationDestinationError: string
   lastSentXLM: boolean
   linkExistingAccountError: string
-  newPayments: I.Map<AccountID, I.Set<PaymentID>> // xxx todo remove this field, might be unused
   paymentsMap: I.Map<AccountID, I.Map<PaymentID, Payment>>
   paymentCursorMap: I.Map<AccountID, StellarRPCTypes.PageCursor | null>
   paymentLoadingMoreMap: I.Map<AccountID, boolean>

--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -232,7 +232,6 @@ export const makeState = I.Record<Types._State>({
   lastSentXLM: false,
   linkExistingAccountError: '',
   mobileOnlyMap: I.Map(),
-  newPayments: I.Map(),
   paymentCursorMap: I.Map(),
   paymentLoadingMoreMap: I.Map(),
   paymentOldestUnreadMap: I.Map(),
@@ -739,15 +738,6 @@ export const isAccountLoaded = (state: TypedState, accountID: Types.AccountID) =
   state.wallets.accountMap.has(accountID)
 
 export const isFederatedAddress = (address: string | null) => (address ? address.includes('*') : false)
-
-export const isPaymentUnread = (
-  state: TypedState,
-  accountID: Types.AccountID,
-  paymentID: Types.PaymentID
-) => {
-  const newPaymentsForAccount = state.wallets.newPayments.get(accountID, false)
-  return newPaymentsForAccount && newPaymentsForAccount.has(paymentID)
-}
 
 export const displayCurrenciesLoaded = (state: TypedState) => state.wallets.currencies.size > 0
 

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -111,7 +111,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
       )
     case WalletsGen.recentPaymentsReceived:
       const newPayments = I.Map(action.payload.payments.map(p => [p.id, Constants.makePayment().merge(p)]))
-      const unreadPaymentIDs = I.Set.fromKeys(newPayments.filter(p => p.unread))
       return state
         .updateIn(['paymentsMap', action.payload.accountID], (paymentsMap = I.Map()) =>
           paymentsMap.merge(newPayments)
@@ -121,7 +120,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
           cursor => cursor || action.payload.paymentCursor
         )
         .setIn(['paymentOldestUnreadMap', action.payload.accountID], action.payload.oldestUnread)
-        .setIn(['newPayments', action.payload.accountID], unreadPaymentIDs)
     case WalletsGen.displayCurrenciesReceived:
       return state.merge({currencies: I.List(action.payload.currencies)})
     case WalletsGen.displayCurrencyReceived: {
@@ -335,13 +333,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         secretKeyError: actionHasError(action) ? action.payload.error : '',
         secretKeyValidationState: actionHasError(action) ? 'error' : 'valid',
       })
-    case WalletsGen.addNewPayment:
-      const {accountID, paymentID} = action.payload
-      return state.updateIn(['newPayments', accountID], newTxs =>
-        newTxs ? newTxs.add(paymentID) : I.Set([paymentID])
-      )
-    case WalletsGen.clearNewPayments:
-      return state.setIn(['newPayments', action.payload.accountID], I.Set())
     case WalletsGen.clearErrors:
       return state.merge({
         accountName: '',

--- a/shared/wallets/transaction/container.tsx
+++ b/shared/wallets/transaction/container.tsx
@@ -14,7 +14,6 @@ export type OwnProps = {
 const mapStateToProps = (state, ownProps: OwnProps) => ({
   _oldestUnread: Constants.getOldestUnread(state, ownProps.accountID),
   _transaction: Constants.getPayment(state, ownProps.accountID, ownProps.paymentID),
-  _unread: Constants.isPaymentUnread(state, ownProps.accountID, ownProps.paymentID),
   _you: state.config.username,
 })
 
@@ -73,7 +72,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     summaryAdvanced: tx.summaryAdvanced,
     timestamp: tx.time ? new Date(tx.time) : null,
     trustline: tx.trustline,
-    unread: stateProps._unread,
+    unread: tx.unread,
     yourRole,
   }
 }

--- a/shared/wallets/wallet-list/wallet-row/container.tsx
+++ b/shared/wallets/wallet-list/wallet-row/container.tsx
@@ -35,7 +35,6 @@ const mapStateToProps = (
 }
 
 const mapDispatchToProps = dispatch => ({
-  _onClearNewPayments: (accountID: AccountID) => dispatch(WalletsGen.createClearNewPayments({accountID})),
   _onSelectAccount: (accountID: AccountID) => {
     if (!isMobile) {
       dispatch(RouteTreeGen.createNavUpToScreen({routeName: 'wallet'}))
@@ -52,7 +51,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps): Props => ({
   name: stateProps.name,
   onSelect: () => {
     // First clear any new payments on the currently selected acct.
-    dispatchProps._onClearNewPayments(stateProps.selectedAccount)
     dispatchProps._onSelectAccount(ownProps.accountID)
   },
   unreadPayments: stateProps.unreadPayments,

--- a/shared/wallets/wallet/header/wallet-switcher/wallet-row/container.tsx
+++ b/shared/wallets/wallet/header/wallet-switcher/wallet-row/container.tsx
@@ -31,7 +31,6 @@ const mapStateToProps = (
 }
 
 const mapDispatchToProps = dispatch => ({
-  _onClearNewPayments: (accountID: AccountID) => dispatch(WalletsGen.createClearNewPayments({accountID})),
   _onSelectAccount: (accountID: AccountID) =>
     dispatch(WalletsGen.createSelectAccount({accountID, reason: 'user-selected', show: true})),
 })
@@ -44,7 +43,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps): Props => ({
 
   onSelect: () => {
     // First clear any new payments on the currently selected acct.
-    dispatchProps._onClearNewPayments(stateProps.selectedAccount)
     dispatchProps._onSelectAccount(ownProps.accountID)
     ownProps.hideMenu()
   },


### PR DESCRIPTION
There's a server side too. The flows are pretty rough without stellarmond, but hopefully will be better on prod.

Use `unread` from the service for the blue background. The `newPayments` thing in the store didn't make much sense to me. I figured since were bugs, and it's probably simpler for the service to be the source of truth, it's ok to throw it out.

![image](https://user-images.githubusercontent.com/705646/60372514-d0fa0300-99ca-11e9-95d7-05790dac9ab6.png)

