### PR TITLE
don't make favoritesLoaded if rpc respons is empty or we're loggedOut

### DIFF
--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -64,6 +64,7 @@ const loadFavorites = (
   action: FsGen.FavoritesLoadPayload | EngineGen.Keybase1NotifyFSFSFavoritesChangedPayload
 ) =>
   state.fs.kbfsDaemonStatus.rpcStatus === Types.KbfsDaemonRpcStatus.Connected &&
+  state.config.loggedIn &&
   RPCTypes.SimpleFSSimpleFSListFavoritesRpcPromise()
     .then(results => {
       const mutablePayload = [
@@ -110,14 +111,17 @@ const loadFavorites = (
           team: I.Map().asMutable(),
         }
       )
-      return FsGen.createFavoritesLoaded({
-        // @ts-ignore asImmutable returns a weak type
-        private: mutablePayload.private.asImmutable(),
-        // @ts-ignore asImmutable returns a weak type
-        public: mutablePayload.public.asImmutable(),
-        // @ts-ignore asImmutable returns a weak type
-        team: mutablePayload.team.asImmutable(),
-      })
+      return (
+        mutablePayload.private.size &&
+        FsGen.createFavoritesLoaded({
+          // @ts-ignore asImmutable returns a weak type
+          private: mutablePayload.private.asImmutable(),
+          // @ts-ignore asImmutable returns a weak type
+          public: mutablePayload.public.asImmutable(),
+          // @ts-ignore asImmutable returns a weak type
+          team: mutablePayload.team.asImmutable(),
+        })
+      )
     })
     .catch(makeRetriableErrorHandler(action))
 


### PR DESCRIPTION
After strib's fix in https://github.com/keybase/client/pull/18175 there's still a bug in GUI. When we get an empty response we'd think we already have the favorites list (`state.fs.tlfs.loaded === true`) so next time user goes into Files tab we won't load it. The symptom is if user had just logged in, they can't see any TLF and Files tab would just show an eternal spinner in any of [private, public, team]

Fix it by 1) don't trigger favoritesLoad on notification if user is logged out, and 2) check the RPC response and see if it really has favorites, and don't make a `favoritedLoaded` action if it's empty.