### PR TITLE
kbfs_ops: towards better startup performance on mobile

### DIFF
--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1935,6 +1935,13 @@ type InitMode interface {
 	// DoLogObfuscation indicates whether senstive data like filenames
 	// should be obfuscated in log messages.
 	DoLogObfuscation() bool
+	// InitialDelayForBackgroundWork indicates how long non-critical
+	// work that happens in the background on startup should wait
+	// before it begins.
+	InitialDelayForBackgroundWork() time.Duration
+	// BackgroundWorkPeriod indicates how long to wait between
+	// non-critical background work tasks.
+	BackgroundWorkPeriod() time.Duration
 }
 
 type initModeGetter interface {

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -203,6 +203,7 @@ func (fs *KBFSOpsStandard) PushConnectionStatusChange(
 		fs.log.CDebugf(nil, "Asking for an edit re-init after reconnection")
 		fs.editActivity.Add(1)
 		go fs.initTlfsForEditHistories()
+		go fs.initSyncedTlfs()
 	}
 }
 
@@ -213,6 +214,7 @@ func (fs *KBFSOpsStandard) PushStatusChange() {
 	fs.log.CDebugf(nil, "Asking for an edit re-init after status change")
 	fs.editActivity.Add(1)
 	go fs.initTlfsForEditHistories()
+	go fs.initSyncedTlfs()
 }
 
 // ClearPrivateFolderMD implements the KBFSOps interface for
@@ -1872,6 +1874,10 @@ func (fs *KBFSOpsStandard) startInitSync() (
 }
 
 func (fs *KBFSOpsStandard) initSyncedTlfs() {
+	if fs.config.MDServer() == nil {
+		return
+	}
+
 	tlfs := fs.config.GetAllSyncedTlfs()
 	if len(tlfs) == 0 {
 		return

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -174,6 +174,14 @@ func (md modeDefault) DoLogObfuscation() bool {
 	return true
 }
 
+func (md modeDefault) InitialDelayForBackgroundWork() time.Duration {
+	return 0
+}
+
+func (md modeDefault) BackgroundWorkPeriod() time.Duration {
+	return 0
+}
+
 // Minimal mode:
 
 type modeMinimal struct {
@@ -325,6 +333,16 @@ func (mm modeMinimal) DoLogObfuscation() bool {
 	return true
 }
 
+func (mm modeMinimal) InitialDelayForBackgroundWork() time.Duration {
+	// No background work
+	return math.MaxInt64
+}
+
+func (mm modeMinimal) BackgroundWorkPeriod() time.Duration {
+	// No background work
+	return math.MaxInt64
+}
+
 // Single op mode:
 
 type modeSingleOp struct {
@@ -399,6 +417,16 @@ func (mso modeSingleOp) OldStorageRootCleaningEnabled() bool {
 
 func (mso modeSingleOp) DoRefreshFavoritesOnInit() bool {
 	return false
+}
+
+func (mso modeSingleOp) InitialDelayForBackgroundWork() time.Duration {
+	// No background work
+	return math.MaxInt64
+}
+
+func (mso modeSingleOp) BackgroundWorkPeriod() time.Duration {
+	// No background work
+	return math.MaxInt64
 }
 
 // Constrained mode:
@@ -487,6 +515,14 @@ func (mc modeConstrained) SendEditNotificationsEnabled() bool {
 
 func (mc modeConstrained) LocalHTTPServerEnabled() bool {
 	return true
+}
+
+func (mc modeConstrained) InitialDelayForBackgroundWork() time.Duration {
+	return 10 * time.Second
+}
+
+func (mc modeConstrained) BackgroundWorkPeriod() time.Duration {
+	return 5 * time.Second
 }
 
 // Memory limited mode

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -478,7 +478,7 @@ func (mc modeConstrained) ServiceKeepaliveEnabled() bool {
 }
 
 func (mc modeConstrained) TLFEditHistoryEnabled() bool {
-	return false
+	return true
 }
 
 func (mc modeConstrained) SendEditNotificationsEnabled() bool {


### PR DESCRIPTION
[Not to be merged until after code freeze is over.]

* We were unnecessarily fully loading, including identifies, for edit history TLFs.  Now only fully load them if we need to do prefetching.
* Add delays for non-critical startup background work on mobile.
* Make sure we're only running one copy of each background startup routine.
* Not perf-related, but make sure we re-init the synced TLFs on login events.

cc: @keybase/hotpotatosquad 

Issue: HOTPOT-244