### PR TITLE
Wrap airdrop text on smaller phones

### DIFF
--- a/shared/wallets/airdrop/qualify/index.tsx
+++ b/shared/wallets/airdrop/qualify/index.tsx
@@ -334,7 +334,6 @@ const styles = Styles.styleSheetCreate({
     width: 120,
   },
   titleBox: {
-    height: 28,
     justifyContent: 'center',
     marginBottom: Styles.globalMargins.small,
     marginTop: Styles.globalMargins.medium,


### PR DESCRIPTION
On smaller phones, the "Sorry, you are not qualified to join." is cut off.

This was because we set an explicit height on the text. Removing this height allows the text to wrap.

Note: on desktop, the text would wrap anyways, regardless of what `height` was set to. I think it makes sense to remove height for all platforms to make it clear that the text should wrap in all cases if the container is not wide enough.

cc @keybase/react-hackers @keybase/picnicsquad 
