### PR TITLE
kbfsgit: fix exit early test by syncing partially-written data

### DIFF
--- a/go/kbfs/kbfsgit/runner.go
+++ b/go/kbfs/kbfsgit/runner.go
@@ -1894,6 +1894,8 @@ func (r *runner) processCommand(
 func (r *runner) processCommands(ctx context.Context) (err error) {
 	r.log.CDebugf(ctx, "Ready to process")
 	reader := bufio.NewReader(r.input)
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// Allow the creation of .kbfs_git within KBFS.
@@ -1905,7 +1907,9 @@ func (r *runner) processCommands(ctx context.Context) (err error) {
 	// interrupted).
 	commandChan := make(chan string, 100)
 	processorErrChan := make(chan error, 1)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		processorErrChan <- r.processCommand(ctx, commandChan)
 	}()
 

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -437,6 +437,9 @@ func TestRunnerExitEarlyOnEOF(t *testing.T) {
 	// Make sure we don't hang when EOF comes early.
 	err = r.processCommands(ctx)
 	require.NoError(t, err)
+
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 }
 
 func TestForcePush(t *testing.T) {


### PR DESCRIPTION
If the test purposely EOFs when there's still dirty data in the disk block cache, the shutdown checks will fail.  So fully sync after the command processing is finished.

And add some waiting to make sure the processing is fully done by the time `processCommands` returns.