### PR TITLE
Speed up BuildPayment by caching OwnAccount

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -15,7 +15,6 @@ package libkb
 import (
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	"golang.org/x/net/context"
@@ -790,7 +789,6 @@ type Stellar interface {
 	GetServerDefinitions(context.Context) (stellar1.StellarServerDefinitions, error)
 	KickAutoClaimRunner(MetaContext, gregor.MsgID)
 	UpdateUnreadCount(ctx context.Context, accountID stellar1.AccountID, unread int) error
-	GetMigrationLock() *sync.Mutex
 	SpecMiniChatPayments(mctx MetaContext, payments []MiniChatPayment) (*MiniChatPaymentSummary, error)
 	SendMiniChatPayments(mctx MetaContext, convID chat1.ConversationID, payments []MiniChatPayment) ([]MiniChatPaymentResult, error)
 	HandleOobm(context.Context, gregor.OutOfBandMessage) (bool, error)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -794,6 +794,7 @@ type Stellar interface {
 	HandleOobm(context.Context, gregor.OutOfBandMessage) (bool, error)
 	RemovePendingTx(mctx MetaContext, accountID stellar1.AccountID, txID stellar1.TransactionID) error
 	KnownCurrencyCodeInstant(ctx context.Context, code string) (known, ok bool)
+	InformBundle(MetaContext, stellar1.BundleRevision, []stellar1.BundleEntry)
 }
 
 type DeviceEKStorage interface {

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -38,8 +37,6 @@ func (n *nullStellar) KickAutoClaimRunner(MetaContext, gregor.MsgID) {}
 func (n *nullStellar) UpdateUnreadCount(context.Context, stellar1.AccountID, int) error {
 	return errors.New("nullStellar UpdateUnreadCount")
 }
-
-func (n *nullStellar) GetMigrationLock() *sync.Mutex { return new(sync.Mutex) }
 
 func (n *nullStellar) SendMiniChatPayments(mctx MetaContext, convID chat1.ConversationID, payments []MiniChatPayment) ([]MiniChatPaymentResult, error) {
 	return nil, errors.New("nullStellar SendMiniChatPayments")

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -57,3 +57,5 @@ func (n *nullStellar) RemovePendingTx(MetaContext, stellar1.AccountID, stellar1.
 func (n *nullStellar) KnownCurrencyCodeInstant(context.Context, string) (bool, bool) {
 	return false, false
 }
+
+func (n *nullStellar) InformBundle(MetaContext, stellar1.BundleRevision, []stellar1.BundleEntry) {}

--- a/go/stellar/bpc.go
+++ b/go/stellar/bpc.go
@@ -16,7 +16,6 @@ import (
 // Methods should err on the side of performance rather at the cost of serialization.
 // CORE-8119: But they don't yet.
 type BuildPaymentCache interface {
-	OwnsAccount(libkb.MetaContext, stellar1.AccountID) (own bool, primary bool, err error)
 	PrimaryAccount(libkb.MetaContext) (stellar1.AccountID, error)
 	// AccountSeqno should be cached _but_ it should also be busted asap.
 	// Because it is used to prevent users from sending payments twice in a row.
@@ -57,11 +56,6 @@ func newBuildPaymentCache(remoter remote.Remoter) *buildPaymentCache {
 		lookupRecipientCache:         lookupRecipientCache,
 		shouldOfferAdvancedSendCache: shouldOfferAdvancedSendCache,
 	}
-}
-
-func (c *buildPaymentCache) OwnsAccount(mctx libkb.MetaContext,
-	accountID stellar1.AccountID) (bool, bool, error) {
-	return OwnAccount(mctx, accountID)
 }
 
 func (c *buildPaymentCache) PrimaryAccount(mctx libkb.MetaContext) (stellar1.AccountID, error) {

--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -173,7 +173,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 		from      stellar1.AccountID
 	}{}
 	if arg.FromPrimaryAccount != arg.From.IsNil() {
-		// Exactly one of `from` and `fromPrimaryAccount` must be set.
+		// Exactly one of `arg.From` and `arg.FromPrimaryAccount` must be set.
 		return res, fmt.Errorf("invalid build payment parameters")
 	}
 	fromPrimaryAccount := arg.FromPrimaryAccount
@@ -190,7 +190,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 			fromInfo.available = true
 		}
 	} else {
-		owns, fromPrimary, err := bpc.OwnsAccount(mctx, arg.From)
+		owns, fromPrimary, err := getGlobal(mctx.G()).OwnAccountCached(mctx, arg.From)
 		if err != nil || !owns {
 			log("OwnsAccount (from) -> owns:%v err:[%T] %v", owns, err, err)
 			res.Banners = append(res.Banners, stellar1.SendBannerLocal{
@@ -258,7 +258,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 					minAmountXLM = "2.01"
 					addMinBanner(bannerTheir, minAmountXLM)
 				} else {
-					sendingToSelf, _, selfSendErr = bpc.OwnsAccount(mctx, stellar1.AccountID(recipient.AccountID.String()))
+					sendingToSelf, _, selfSendErr = getGlobal(mctx.G()).OwnAccountCached(mctx, stellar1.AccountID(recipient.AccountID.String()))
 					isFunded, err := bpc.IsAccountFunded(mctx, stellar1.AccountID(recipient.AccountID.String()))
 					if err != nil {
 						log("error checking recipient funding status %v: %v", *recipient.AccountID, err)

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -58,6 +58,9 @@ type Stellar struct {
 	disclaimerLock     sync.Mutex
 	disclaimerAccepted *keybase1.UserVersion // A UV who has accepted the disclaimer.
 
+	accountsLock sync.Mutex
+	accounts     *AccountsCache
+
 	// Slot for build payments that do not use BuildPaymentID.
 	buildPaymentSlot *slotctx.PrioritySlot
 
@@ -78,6 +81,12 @@ func NewStellar(g *libkb.GlobalContext, walletState *WalletState, badger *badges
 		buildPaymentSlot: slotctx.NewPriority(),
 		badger:           badger,
 	}
+}
+
+type AccountsCache struct {
+	Stored   time.Time
+	Revision stellar1.BundleRevision
+	Accounts []stellar1.BundleEntry
 }
 
 func (s *Stellar) CreateWalletSoft(ctx context.Context) {
@@ -103,6 +112,7 @@ func (s *Stellar) Clear(mctx libkb.MetaContext) {
 	s.deleteBpc()
 	s.deleteDisclaimer()
 	s.clearBids()
+	s.clearAccounts()
 }
 
 func (s *Stellar) shutdownAutoClaimRunner() {
@@ -135,6 +145,12 @@ func (s *Stellar) clearBids() {
 		bid.Slot.Stop()
 	}
 	s.bids = nil
+}
+
+func (s *Stellar) clearAccounts() {
+	s.accountsLock.Lock()
+	defer s.accountsLock.Unlock()
+	s.accounts = nil
 }
 
 func (s *Stellar) GetServerDefinitions(ctx context.Context) (ret stellar1.StellarServerDefinitions, err error) {
@@ -551,6 +567,46 @@ func (s *Stellar) RemovePendingTx(mctx libkb.MetaContext, accountID stellar1.Acc
 // BaseFee returns the server-suggested base fee per operation.
 func (s *Stellar) BaseFee(mctx libkb.MetaContext) uint64 {
 	return s.walletState.BaseFee(mctx)
+}
+
+func (s *Stellar) InformBundle(mctx libkb.MetaContext, rev stellar1.BundleRevision, accounts []stellar1.BundleEntry) {
+	go func() {
+		err := libkb.AcquireWithContextAndTimeout(mctx.Ctx(), &s.accountsLock, 5*time.Second)
+		if err != nil {
+			mctx.Debug("InformBundle: error acquiring lock")
+			return
+		}
+		defer s.accountsLock.Unlock()
+		if s.accounts != nil && rev < s.accounts.Revision {
+			return
+		}
+		s.accounts = &AccountsCache{
+			Stored:   mctx.G().Clock().Now(),
+			Revision: rev,
+			Accounts: accounts,
+		}
+	}()
+}
+
+func (s *Stellar) OwnAccountCached(mctx libkb.MetaContext, accountID stellar1.AccountID) (own, isPrimary bool, err error) {
+	err = libkb.AcquireWithContextAndTimeout(mctx.Ctx(), &s.accountsLock, 5*time.Second)
+	if err != nil {
+		mctx.Debug("OwnAccountCached: error acquiring lock")
+		return
+	}
+	if s.accounts != nil && mctx.G().Clock().Now().Sub(s.accounts.Stored.Round(0)) < 2*time.Minute {
+		mctx.Debug("xxx OwnAccountCached hit")
+		for _, acc := range s.accounts.Accounts {
+			if acc.AccountID.Eq(accountID) {
+				s.accountsLock.Unlock()
+				return true, acc.IsPrimary, nil
+			}
+		}
+		s.accountsLock.Unlock()
+		return false, false, nil
+	}
+	s.accountsLock.Unlock()
+	return OwnAccount(mctx, accountID)
 }
 
 // getFederationClient is a helper function used during

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -137,10 +137,6 @@ func (s *Stellar) clearBids() {
 	s.bids = nil
 }
 
-func (s *Stellar) GetMigrationLock() *sync.Mutex {
-	return &s.migrationLock
-}
-
 func (s *Stellar) GetServerDefinitions(ctx context.Context) (ret stellar1.StellarServerDefinitions, err error) {
 	s.serverConfLock.Lock()
 	defer s.serverConfLock.Unlock()

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -195,7 +195,12 @@ func fetchBundleForAccount(mctx libkb.MetaContext, accountID *stellar1.AccountID
 	}
 
 	finder := &pukFinder{}
-	return bundle.DecodeAndUnbox(mctx, finder, apiRes.BundleEncoded)
+	b, bv, pukGen, accountGens, err = bundle.DecodeAndUnbox(mctx, finder, apiRes.BundleEncoded)
+	if err != nil {
+		return b, bv, pukGen, accountGens, err
+	}
+	mctx.G().GetStellar().InformBundle(mctx, b.Revision, b.Accounts)
+	return b, bv, pukGen, accountGens, err
 }
 
 // FetchSecretlessBundle gets an account bundle from the server and decrypts it

--- a/go/stellar/util.go
+++ b/go/stellar/util.go
@@ -59,6 +59,7 @@ type ownAccountLookupCacheImpl struct {
 }
 
 // NewOwnAccountLookupCache fetches the list of accounts in the background and stores them.
+// Was created before Stellar.accounts, and could probably benefit from using that cache.
 func NewOwnAccountLookupCache(mctx libkb.MetaContext) OwnAccountLookupCache {
 	c := &ownAccountLookupCacheImpl{
 		accounts: make(map[stellar1.AccountID]*string),


### PR DESCRIPTION
Get rid of one api call that always went out in build payment