### PR TITLE
Use console.log on android. It's 3x faster

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
@@ -15,6 +15,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 public class NativeLogger extends ReactContextBaseJavaModule {
@@ -98,16 +100,17 @@ public class NativeLogger extends ReactContextBaseJavaModule {
     @ReactMethod
     public void dump(String tagPrefix, Promise promise) {
         try {
-            String cmd = "logcat -m 10000 -d " + tagPrefix + NAME + ":I *:S";
+            String cmd = "logcat -m 10000 -d " + "ReactNativeJS" + ":I *:S";
 
             Process process = Runtime.getRuntime().exec(cmd);
             BufferedReader r = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line;
             final WritableArray totalArray = Arguments.createArray();
+            final Pattern pattern = Pattern.compile(".*" + tagPrefix + NAME + ": (.*)");
             while ((line = r.readLine()) != null) {
-                final int startIdx = line.indexOf(tagPrefix + NAME);
-                if (startIdx > 0) {
-                    totalArray.pushString(line.substring(startIdx + tagPrefix.length() + NAME.length() + 2)); // + 2 for the ': ' part
+                Matcher m = pattern.matcher(line);
+                if (m.matches()) {
+                    totalArray.pushString(m.group(1));
                 }
             }
             promise.resolve(totalArray);

--- a/shared/logger/index.tsx
+++ b/shared/logger/index.tsx
@@ -105,7 +105,7 @@ const devLoggers = () => ({
   action: new TeeLogger(new RingLogger(100), new ConsoleLogger('log', 'Dispatching Action')),
   debug: new TeeLogger(
     isMobile
-      ? new NativeLogger('e')
+      ? new NativeLogger('d')
       : new DumpPeriodicallyLogger(new RingLogger(10000), 1 * 60e3, writeLogLinesToFile, 'Info'),
     new ConsoleLogger('log', 'DEBUG:')
   ),

--- a/shared/logger/native-logger.tsx
+++ b/shared/logger/native-logger.tsx
@@ -1,4 +1,4 @@
-import {log, dump} from '../native/logger'
+import {log, dump, flush} from '../native/logger'
 import {Logger, LogLine, LogLevel, Timestamp} from './types'
 import {toStringForLog} from '../util/string'
 
@@ -50,8 +50,8 @@ class NativeLogger implements Logger {
   }
 
   flush() {
-    const p: Promise<void> = Promise.resolve()
-    return p
+    flush()
+    return Promise.resolve()
   }
 }
 

--- a/shared/native/logger.d.ts
+++ b/shared/native/logger.d.ts
@@ -3,5 +3,6 @@ export type NativeLogDump = (tagPrefix: string) => Promise<Array<string>>
 
 declare const log: NativeLog
 declare const dump: NativeLogDump
+declare const flush: () => void
 
-export {log, dump}
+export {log, dump, flush}

--- a/shared/native/logger.native.tsx
+++ b/shared/native/logger.native.tsx
@@ -1,15 +1,36 @@
 import {NativeModules} from 'react-native'
 import {NativeLogDump} from './logger'
 import {debounce} from 'lodash-es'
+import {isAndroid} from '../constants/platform'
 
 export type RealNativeLog = (tagsAndLogs: Array<Array<string>>) => void
-const _log: RealNativeLog = __STORYBOOK__ ? tagsAndLogs => {} : NativeModules.KBNativeLogger.log
+const _log: RealNativeLog = __STORYBOOK__ || isAndroid ? tagsAndLogs => {} : NativeModules.KBNativeLogger.log
 
 // Don't send over the wire immediately. That has horrible performance
 const actuallyLog = debounce(() => {
-  _log(toSend)
+  if (isAndroid) {
+    // Using console.log on android is ~3x faster.
+    for (let i = 0; i < toSend.length; i++) {
+      const [tagPrefix, toLog] = toSend[i]
+      const formatted = `${tagPrefix}KBNativeLogger: ${toLog}`
+      switch (tagPrefix) {
+        case 'w':
+          console.warn(formatted)
+          continue
+        case 'e':
+          console.error(formatted)
+          continue
+        default:
+          console.log(formatted)
+          continue
+      }
+    }
+  } else {
+    // iOS is using lumberjack for logging, so keep this for now
+    _log(toSend)
+  }
   toSend = []
-}, 5 * 1000)
+}, 5000)
 
 let toSend = []
 
@@ -23,6 +44,11 @@ const dump: NativeLogDump = __STORYBOOK__
       const p: Promise<Array<string>> = Promise.resolve([])
       return p
     }
-  : NativeModules.KBNativeLogger.dump
+  : (...args) => {
+      actuallyLog.flush()
+      return NativeModules.KBNativeLogger.dump(...args)
+    }
 
-export {log, dump}
+const flush = actuallyLog.flush
+
+export {log, dump, flush}


### PR DESCRIPTION
After some quick experiments with JSI and logging I found that `console.log` is about as fast as a JSI implementation. 

The test was to log `"Logging from RN via xxxxxx!"` a million times in a loop with a JSI backed logger, our existing bridge logger, and console.log.

| Logger Impl | Time (ms) |
|-------------|------------|
| JSI | 43,284 |
| console.log | 42,284 |
| BridgeLogger | 122,586 |
