### PR TITLE
refactor teamEK storage with variant

### DIFF
--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -36,10 +36,21 @@ func verifyUserEK(t *testing.T, metadata keybase1.UserEkMetadata, ek keybase1.Us
 	require.Equal(t, metadata.Kid, keypair.GetKID())
 }
 
-func verifyTeamEK(t *testing.T, metadata keybase1.TeamEkMetadata, ek keybase1.TeamEk) {
-	seed := TeamEKSeed(ek.Seed)
+func verifyTeamEK(t *testing.T, metadata keybase1.TeamEphemeralKeyMetadata,
+	ek keybase1.TeamEphemeralKey) {
+	typ, err := metadata.KeyType()
+	require.NoError(t, err)
+	require.Equal(t, keybase1.TeamEphemeralKeyType_TEAM, typ)
+	teamEKMetadata := metadata.Team()
+
+	typ, err = ek.KeyType()
+	require.NoError(t, err)
+	require.Equal(t, keybase1.TeamEphemeralKeyType_TEAM, typ)
+	teamEK := ek.Team()
+
+	seed := TeamEKSeed(teamEK.Seed)
 	keypair := seed.DeriveDHKey()
-	require.Equal(t, metadata.Kid, keypair.GetKID())
+	require.Equal(t, teamEKMetadata.Kid, keypair.GetKID())
 }
 
 func TestEphemeralCloneError(t *testing.T) {

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -33,6 +33,21 @@ const (
 	DeviceCloneErrMsg                           = "cloned devices do not support exploding messages"
 )
 
+type IncorrectTeamEphemeralKeyTypeError struct {
+	expected, actual keybase1.TeamEphemeralKeyType
+}
+
+func (e IncorrectTeamEphemeralKeyTypeError) Error() string {
+	return fmt.Sprintf("Incorrect team ephemeral key type received. Expected: %v, actual %v", e.expected, e.actual)
+}
+
+func NewIncorrectTeamEphemeralKeyTypeError(expected, actual keybase1.TeamEphemeralKeyType) IncorrectTeamEphemeralKeyTypeError {
+	return IncorrectTeamEphemeralKeyTypeError{
+		expected: expected,
+		actual:   actual,
+	}
+}
+
 func NewNotAuthenticatedForThisDeviceError(mctx libkb.MetaContext, tlfID chat1.TLFID, contentCtime gregor1.Time) EphemeralKeyError {
 	var humanMsg string
 	memberCtime, err := memberCtime(mctx, tlfID)

--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -8,7 +8,8 @@ import (
 func NewEphemeralStorageAndInstall(mctx libkb.MetaContext) {
 	mctx.G().SetDeviceEKStorage(NewDeviceEKStorage(mctx))
 	mctx.G().SetUserEKBoxStorage(NewUserEKBoxStorage())
-	mctx.G().SetTeamEKBoxStorage(NewTeamEKBoxStorage())
+	mctx.G().SetTeamEKBoxStorage(NewTeamEKBoxStorage(NewTeamEphemeralKeyer()))
+	mctx.G().SetTeambotEKBoxStorage(NewTeamEKBoxStorage(NewTeambotEphemeralKeyer("")))
 	ekLib := NewEKLib(mctx)
 	mctx.G().SetEKLib(ekLib)
 	mctx.G().AddLoginHook(ekLib)

--- a/go/ephemeral/interfaces.go
+++ b/go/ephemeral/interfaces.go
@@ -1,0 +1,17 @@
+package ephemeral
+
+import (
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type EphemeralKeyer interface {
+	PublishNewEK(mctx libkb.MetaContext, teamID keybase1.TeamID, merkleRoot libkb.MerkleRoot) (keybase1.TeamEphemeralKeyMetadata, error)
+	Fetch(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEphemeralKeyBoxed, error)
+	Unbox(mctx libkb.MetaContext, boxed keybase1.TeamEphemeralKeyBoxed, contentCtime *gregor1.Time) (keybase1.TeamEphemeralKey, error)
+	Type() keybase1.TeamEphemeralKeyType
+}
+
+var _ EphemeralKeyer = (*TeambotEphemeralKeyer)(nil)
+var _ EphemeralKeyer = (*TeamEphemeralKeyer)(nil)

--- a/go/ephemeral/selfprovision_test.go
+++ b/go/ephemeral/selfprovision_test.go
@@ -54,8 +54,12 @@ func TestEphemeralSelfProvision(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mctx.ActiveDevice().Name(), newName)
 
-	teamEK2, err := g.GetTeamEKBoxStorage().Get(mctx, teamID, teamEK1.Metadata.Generation, nil)
+	ek2, err := g.GetTeamEKBoxStorage().Get(mctx, teamID, teamEK1.Metadata.Generation, nil)
 	require.NoError(t, err)
+	typ, err := ek2.KeyType()
+	require.NoError(t, err)
+	require.True(t, typ.IsTeam())
+	teamEK2 := ek2.Team()
 	require.Equal(t, teamEK1, teamEK2)
 
 	// After self provisioning we should only have a single deviceEK, and have

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keybase/client/go/kbcrypto"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
 )
@@ -32,7 +33,17 @@ func (s *TeamEKSeed) DeriveDHKey() *libkb.NaclDHKeyPair {
 	return deriveDHKey(keybase1.Bytes32(*s), libkb.DeriveReasonTeamEKEncryption)
 }
 
-func postNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, sig string,
+type TeamEphemeralKeyer struct{}
+
+func NewTeamEphemeralKeyer() *TeamEphemeralKeyer {
+	return &TeamEphemeralKeyer{}
+}
+
+func (k *TeamEphemeralKeyer) Type() keybase1.TeamEphemeralKeyType {
+	return keybase1.TeamEphemeralKeyType_TEAM
+}
+
+func (k *TeamEphemeralKeyer) postNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, sig string,
 	boxes *[]keybase1.TeamEkBoxMetadata) (err error) {
 	defer mctx.TraceTimed("postNewTeamEK", func() error { return err })()
 
@@ -117,8 +128,8 @@ func prepareNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	return sig, boxes, metadata, myTeamEKBoxed, nil
 }
 
-func publishNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
-	merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
+func (k *TeamEphemeralKeyer) PublishNewEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
+	merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEphemeralKeyMetadata, err error) {
 	defer mctx.TraceTimed("publishNewTeamEK", func() error { return err })()
 
 	team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
@@ -141,12 +152,12 @@ func publishNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
 		return metadata, err
 	}
 
-	sig, boxes, metadata, myBox, err := prepareNewTeamEK(mctx, teamID, signingKey, membersMetadata, merkleRoot)
+	sig, boxes, teamEKMetadata, myBox, err := prepareNewTeamEK(mctx, teamID, signingKey, membersMetadata, merkleRoot)
 	if err != nil {
 		return metadata, err
 	}
 
-	if err = postNewTeamEK(mctx, teamID, sig, boxes); err != nil {
+	if err = k.postNewTeamEK(mctx, teamID, sig, boxes); err != nil {
 		return metadata, err
 	}
 
@@ -154,11 +165,119 @@ func publishNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
 		mctx.Debug("No box made for own teamEK")
 	} else {
 		storage := mctx.G().GetTeamEKBoxStorage()
-		if err = storage.Put(mctx, teamID, metadata.Generation, *myBox); err != nil {
+		boxed := keybase1.NewTeamEphemeralKeyBoxedWithTeam(*myBox)
+		if err = storage.Put(mctx, teamID, teamEKMetadata.Generation, boxed); err != nil {
 			return metadata, err
 		}
 	}
-	return metadata, nil
+	return keybase1.NewTeamEphemeralKeyMetadataWithTeam(teamEKMetadata), nil
+}
+
+func (k *TeamEphemeralKeyer) Fetch(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (teamEK keybase1.TeamEphemeralKeyBoxed, err error) {
+	apiArg := libkb.APIArg{
+		Endpoint:    "team/team_ek_box",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		Args: libkb.HTTPArgs{
+			"team_id":    libkb.S{Val: string(teamID)},
+			"generation": libkb.U{Val: uint64(generation)},
+		},
+	}
+
+	var result TeamEKBoxedResponse
+	res, err := mctx.G().GetAPI().Get(mctx, apiArg)
+	if err != nil {
+		err = errFromAppStatus(err)
+		return teamEK, err
+	}
+
+	err = res.Body.UnmarshalAgain(&result)
+	if err != nil {
+		return teamEK, err
+	}
+
+	if result.Result == nil {
+		err = newEKMissingBoxErr(mctx, TeamEKStr, generation)
+		return teamEK, err
+	}
+
+	// Although we verify the signature is valid, it's possible that this key
+	// was signed with a PTK that is not our latest and greatest. We allow this
+	// when we are using this ek for *decryption*. When getting a key for
+	// *encryption* callers are responsible for verifying the signature is
+	// signed by the latest PTK or generating a new EK. This logic currently
+	// lives in ephemeral/lib.go#GetOrCreateLatestTeamEK (#newTeamEKNeeded)
+	_, teamEKStatement, err := extractTeamEKStatementFromSig(result.Result.Sig)
+	if err != nil {
+		return teamEK, err
+	} else if teamEKStatement == nil { // shouldn't happen
+		return teamEK, fmt.Errorf("unable to fetch valid teamEKStatement")
+	}
+
+	teamEKMetadata := teamEKStatement.CurrentTeamEkMetadata
+	if generation != teamEKMetadata.Generation {
+		// sanity check that we go the right generation
+		return teamEK, newEKCorruptedErr(mctx, TeamEKStr, generation, teamEKMetadata.Generation)
+	}
+	teamEKBoxed := keybase1.TeamEkBoxed{
+		Box:              result.Result.Box,
+		UserEkGeneration: result.Result.UserEKGeneration,
+		Metadata:         teamEKMetadata,
+	}
+
+	return keybase1.NewTeamEphemeralKeyBoxedWithTeam(teamEKBoxed), nil
+}
+
+func (k *TeamEphemeralKeyer) Unbox(mctx libkb.MetaContext, boxed keybase1.TeamEphemeralKeyBoxed,
+	contentCtime *gregor1.Time) (ek keybase1.TeamEphemeralKey, err error) {
+	defer mctx.TraceTimed(fmt.Sprintf("TeamEKBoxStorage#unbox: teamEKGeneration: %v", boxed.Generation()),
+		func() error { return err })()
+
+	typ, err := boxed.KeyType()
+	if err != nil {
+		return ek, err
+	}
+	if !typ.IsTeam() {
+		return ek, NewIncorrectTeamEphemeralKeyTypeError(typ, keybase1.TeamEphemeralKeyType_TEAM)
+	}
+
+	teamEKBoxed := boxed.Team()
+	teamEKGeneration := teamEKBoxed.Metadata.Generation
+	userEKBoxStorage := mctx.G().GetUserEKBoxStorage()
+	userEK, err := userEKBoxStorage.Get(mctx, teamEKBoxed.UserEkGeneration, contentCtime)
+	if err != nil {
+		mctx.Debug("unable to get from userEKStorage %v", err)
+		switch err.(type) {
+		case EphemeralKeyError:
+			return ek, newEKUnboxErr(mctx, TeamEKStr, teamEKGeneration, UserEKStr,
+				teamEKBoxed.UserEkGeneration, contentCtime)
+		}
+		return ek, err
+	}
+
+	userSeed := UserEKSeed(userEK.Seed)
+	userKeypair := userSeed.DeriveDHKey()
+
+	msg, _, err := userKeypair.DecryptFromString(teamEKBoxed.Box)
+	if err != nil {
+		mctx.Debug("unable to decrypt teamEKBoxed %v", err)
+		return ek, newEKUnboxErr(mctx, TeamEKStr, teamEKGeneration, UserEKStr,
+			teamEKBoxed.UserEkGeneration, contentCtime)
+	}
+
+	seed, err := newTeamEKSeedFromBytes(msg)
+	if err != nil {
+		return ek, err
+	}
+
+	keypair := seed.DeriveDHKey()
+	if !keypair.GetKID().Equal(teamEKBoxed.Metadata.Kid) {
+		return ek, fmt.Errorf("Failed to verify server given seed against signed KID %s", teamEKBoxed.Metadata.Kid)
+	}
+
+	return keybase1.NewTeamEphemeralKeyWithTeam(keybase1.TeamEk{
+		Seed:     keybase1.Bytes32(seed),
+		Metadata: teamEKBoxed.Metadata,
+	}), nil
 }
 
 // There are plenty of race conditions where the PTK or teamEK or
@@ -194,10 +313,11 @@ func teamEKRetryWrapper(mctx libkb.MetaContext, retryFn func() error) (err error
 }
 
 func ForcePublishNewTeamEKForTesting(mctx libkb.MetaContext, teamID keybase1.TeamID,
-	merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
+	merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEphemeralKeyMetadata, err error) {
 	defer mctx.TraceTimed("ForcePublishNewTeamEKForTesting", func() error { return err })()
+	keyer := NewTeamEphemeralKeyer()
 	err = teamEKRetryWrapper(mctx, func() error {
-		metadata, err = publishNewTeamEK(mctx, teamID, merkleRoot)
+		metadata, err = keyer.PublishNewEK(mctx, teamID, merkleRoot)
 		return err
 	})
 	return metadata, err

--- a/go/ephemeral/team_ek_box_storage_test.go
+++ b/go/ephemeral/team_ek_box_storage_test.go
@@ -57,8 +57,9 @@ func TestTeamEKBoxStorage(t *testing.T) {
 	botS := tc.G.GetTeambotEKBoxStorage()
 	botNonexistant, err := botS.Get(mctx, teamID, teamEKMetadata.Generation, nil)
 	require.Error(t, err)
-	_, ok = err.(EphemeralKeyError)
-	require.False(t, ok)
+	require.IsType(t, EphemeralKeyError{}, err)
+	ekErr := err.(EphemeralKeyError)
+	require.Equal(t, DefaultHumanErrMsg, ekErr.HumanError())
 	require.Equal(t, keybase1.TeamEphemeralKey{}, botNonexistant)
 
 	verifyTeamEK(t, metadata, ek)
@@ -67,7 +68,7 @@ func TestTeamEKBoxStorage(t *testing.T) {
 	nonexistent, err := s.Get(mctx, teamID, teamEKMetadata.Generation+1, nil)
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
-	ekErr := err.(EphemeralKeyError)
+	ekErr = err.(EphemeralKeyError)
 	require.Equal(t, DefaultHumanErrMsg, ekErr.HumanError())
 	require.Equal(t, keybase1.TeamEphemeralKey{}, nonexistent)
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -90,6 +90,7 @@ type GlobalContext struct {
 	deviceEKStorage        DeviceEKStorage  // Store device ephemeral keys
 	userEKBoxStorage       UserEKBoxStorage // Store user ephemeral key boxes
 	teamEKBoxStorage       TeamEKBoxStorage // Store team ephemeral key boxes
+	teambotEKBoxStorage    TeamEKBoxStorage // Store team bot ephemeral key boxes
 	ekLib                  EKLib            // Wrapper to call ephemeral key methods
 	itciCacher             LRUer            // Cacher for implicit team conflict info
 	iteamCacher            MemLRUer         // In memory cacher for implicit teams
@@ -623,6 +624,12 @@ func (g *GlobalContext) GetTeamEKBoxStorage() TeamEKBoxStorage {
 	g.cacheMu.RLock()
 	defer g.cacheMu.RUnlock()
 	return g.teamEKBoxStorage
+}
+
+func (g *GlobalContext) GetTeambotEKBoxStorage() TeamEKBoxStorage {
+	g.cacheMu.RLock()
+	defer g.cacheMu.RUnlock()
+	return g.teambotEKBoxStorage
 }
 
 func (g *GlobalContext) GetImplicitTeamConflictInfoCacher() LRUer {
@@ -1235,6 +1242,12 @@ func (g *GlobalContext) SetTeamEKBoxStorage(s TeamEKBoxStorage) {
 	g.cacheMu.Lock()
 	defer g.cacheMu.Unlock()
 	g.teamEKBoxStorage = s
+}
+
+func (g *GlobalContext) SetTeambotEKBoxStorage(s TeamEKBoxStorage) {
+	g.cacheMu.Lock()
+	defer g.cacheMu.Unlock()
+	g.teambotEKBoxStorage = s
 }
 
 func (g *GlobalContext) LoadUserByUID(uid keybase1.UID) (*User, error) {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -821,8 +821,8 @@ type UserEKBoxStorage interface {
 }
 
 type TeamEKBoxStorage interface {
-	Put(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEkBoxed) error
-	Get(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEk, error)
+	Put(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, teamEKBoxed keybase1.TeamEphemeralKeyBoxed) error
+	Get(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEphemeralKey, error)
 	MaxGeneration(mctx MetaContext, teamID keybase1.TeamID, includeErrs bool) (keybase1.EkGeneration, error)
 	DeleteExpired(mctx MetaContext, teamID keybase1.TeamID, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	PurgeCacheForTeamID(mctx MetaContext, teamID keybase1.TeamID) error

--- a/go/protocol/keybase1/ephemeral.go
+++ b/go/protocol/keybase1/ephemeral.go
@@ -4,6 +4,7 @@
 package keybase1
 
 import (
+	"errors"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
 
@@ -240,6 +241,260 @@ func (o TeambotEk) DeepCopy() TeambotEk {
 	return TeambotEk{
 		Seed:     o.Seed.DeepCopy(),
 		Metadata: o.Metadata.DeepCopy(),
+	}
+}
+
+type TeamEphemeralKeyType int
+
+const (
+	TeamEphemeralKeyType_TEAM    TeamEphemeralKeyType = 0
+	TeamEphemeralKeyType_TEAMBOT TeamEphemeralKeyType = 1
+)
+
+func (o TeamEphemeralKeyType) DeepCopy() TeamEphemeralKeyType { return o }
+
+var TeamEphemeralKeyTypeMap = map[string]TeamEphemeralKeyType{
+	"TEAM":    0,
+	"TEAMBOT": 1,
+}
+
+var TeamEphemeralKeyTypeRevMap = map[TeamEphemeralKeyType]string{
+	0: "TEAM",
+	1: "TEAMBOT",
+}
+
+func (e TeamEphemeralKeyType) String() string {
+	if v, ok := TeamEphemeralKeyTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type TeamEphemeralKey struct {
+	KeyType__ TeamEphemeralKeyType `codec:"keyType" json:"keyType"`
+	Team__    *TeamEk              `codec:"team,omitempty" json:"team,omitempty"`
+	Teambot__ *TeambotEk           `codec:"teambot,omitempty" json:"teambot,omitempty"`
+}
+
+func (o *TeamEphemeralKey) KeyType() (ret TeamEphemeralKeyType, err error) {
+	switch o.KeyType__ {
+	case TeamEphemeralKeyType_TEAM:
+		if o.Team__ == nil {
+			err = errors.New("unexpected nil value for Team__")
+			return ret, err
+		}
+	case TeamEphemeralKeyType_TEAMBOT:
+		if o.Teambot__ == nil {
+			err = errors.New("unexpected nil value for Teambot__")
+			return ret, err
+		}
+	}
+	return o.KeyType__, nil
+}
+
+func (o TeamEphemeralKey) Team() (res TeamEk) {
+	if o.KeyType__ != TeamEphemeralKeyType_TEAM {
+		panic("wrong case accessed")
+	}
+	if o.Team__ == nil {
+		return
+	}
+	return *o.Team__
+}
+
+func (o TeamEphemeralKey) Teambot() (res TeambotEk) {
+	if o.KeyType__ != TeamEphemeralKeyType_TEAMBOT {
+		panic("wrong case accessed")
+	}
+	if o.Teambot__ == nil {
+		return
+	}
+	return *o.Teambot__
+}
+
+func NewTeamEphemeralKeyWithTeam(v TeamEk) TeamEphemeralKey {
+	return TeamEphemeralKey{
+		KeyType__: TeamEphemeralKeyType_TEAM,
+		Team__:    &v,
+	}
+}
+
+func NewTeamEphemeralKeyWithTeambot(v TeambotEk) TeamEphemeralKey {
+	return TeamEphemeralKey{
+		KeyType__: TeamEphemeralKeyType_TEAMBOT,
+		Teambot__: &v,
+	}
+}
+
+func (o TeamEphemeralKey) DeepCopy() TeamEphemeralKey {
+	return TeamEphemeralKey{
+		KeyType__: o.KeyType__.DeepCopy(),
+		Team__: (func(x *TeamEk) *TeamEk {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Team__),
+		Teambot__: (func(x *TeambotEk) *TeambotEk {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Teambot__),
+	}
+}
+
+type TeamEphemeralKeyBoxed struct {
+	KeyType__ TeamEphemeralKeyType `codec:"keyType" json:"keyType"`
+	Team__    *TeamEkBoxed         `codec:"team,omitempty" json:"team,omitempty"`
+	Teambot__ *TeambotEkBoxed      `codec:"teambot,omitempty" json:"teambot,omitempty"`
+}
+
+func (o *TeamEphemeralKeyBoxed) KeyType() (ret TeamEphemeralKeyType, err error) {
+	switch o.KeyType__ {
+	case TeamEphemeralKeyType_TEAM:
+		if o.Team__ == nil {
+			err = errors.New("unexpected nil value for Team__")
+			return ret, err
+		}
+	case TeamEphemeralKeyType_TEAMBOT:
+		if o.Teambot__ == nil {
+			err = errors.New("unexpected nil value for Teambot__")
+			return ret, err
+		}
+	}
+	return o.KeyType__, nil
+}
+
+func (o TeamEphemeralKeyBoxed) Team() (res TeamEkBoxed) {
+	if o.KeyType__ != TeamEphemeralKeyType_TEAM {
+		panic("wrong case accessed")
+	}
+	if o.Team__ == nil {
+		return
+	}
+	return *o.Team__
+}
+
+func (o TeamEphemeralKeyBoxed) Teambot() (res TeambotEkBoxed) {
+	if o.KeyType__ != TeamEphemeralKeyType_TEAMBOT {
+		panic("wrong case accessed")
+	}
+	if o.Teambot__ == nil {
+		return
+	}
+	return *o.Teambot__
+}
+
+func NewTeamEphemeralKeyBoxedWithTeam(v TeamEkBoxed) TeamEphemeralKeyBoxed {
+	return TeamEphemeralKeyBoxed{
+		KeyType__: TeamEphemeralKeyType_TEAM,
+		Team__:    &v,
+	}
+}
+
+func NewTeamEphemeralKeyBoxedWithTeambot(v TeambotEkBoxed) TeamEphemeralKeyBoxed {
+	return TeamEphemeralKeyBoxed{
+		KeyType__: TeamEphemeralKeyType_TEAMBOT,
+		Teambot__: &v,
+	}
+}
+
+func (o TeamEphemeralKeyBoxed) DeepCopy() TeamEphemeralKeyBoxed {
+	return TeamEphemeralKeyBoxed{
+		KeyType__: o.KeyType__.DeepCopy(),
+		Team__: (func(x *TeamEkBoxed) *TeamEkBoxed {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Team__),
+		Teambot__: (func(x *TeambotEkBoxed) *TeambotEkBoxed {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Teambot__),
+	}
+}
+
+type TeamEphemeralKeyMetadata struct {
+	KeyType__ TeamEphemeralKeyType `codec:"keyType" json:"keyType"`
+	Team__    *TeamEkMetadata      `codec:"team,omitempty" json:"team,omitempty"`
+	Teambot__ *TeambotEkMetadata   `codec:"teambot,omitempty" json:"teambot,omitempty"`
+}
+
+func (o *TeamEphemeralKeyMetadata) KeyType() (ret TeamEphemeralKeyType, err error) {
+	switch o.KeyType__ {
+	case TeamEphemeralKeyType_TEAM:
+		if o.Team__ == nil {
+			err = errors.New("unexpected nil value for Team__")
+			return ret, err
+		}
+	case TeamEphemeralKeyType_TEAMBOT:
+		if o.Teambot__ == nil {
+			err = errors.New("unexpected nil value for Teambot__")
+			return ret, err
+		}
+	}
+	return o.KeyType__, nil
+}
+
+func (o TeamEphemeralKeyMetadata) Team() (res TeamEkMetadata) {
+	if o.KeyType__ != TeamEphemeralKeyType_TEAM {
+		panic("wrong case accessed")
+	}
+	if o.Team__ == nil {
+		return
+	}
+	return *o.Team__
+}
+
+func (o TeamEphemeralKeyMetadata) Teambot() (res TeambotEkMetadata) {
+	if o.KeyType__ != TeamEphemeralKeyType_TEAMBOT {
+		panic("wrong case accessed")
+	}
+	if o.Teambot__ == nil {
+		return
+	}
+	return *o.Teambot__
+}
+
+func NewTeamEphemeralKeyMetadataWithTeam(v TeamEkMetadata) TeamEphemeralKeyMetadata {
+	return TeamEphemeralKeyMetadata{
+		KeyType__: TeamEphemeralKeyType_TEAM,
+		Team__:    &v,
+	}
+}
+
+func NewTeamEphemeralKeyMetadataWithTeambot(v TeambotEkMetadata) TeamEphemeralKeyMetadata {
+	return TeamEphemeralKeyMetadata{
+		KeyType__: TeamEphemeralKeyType_TEAMBOT,
+		Teambot__: &v,
+	}
+}
+
+func (o TeamEphemeralKeyMetadata) DeepCopy() TeamEphemeralKeyMetadata {
+	return TeamEphemeralKeyMetadata{
+		KeyType__: o.KeyType__.DeepCopy(),
+		Team__: (func(x *TeamEkMetadata) *TeamEkMetadata {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Team__),
+		Teambot__: (func(x *TeambotEkMetadata) *TeambotEkMetadata {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Teambot__),
 	}
 }
 

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3062,3 +3062,71 @@ func (h *HiddenTeamChain) IsStale() bool {
 	_, fresh := h.Outer[h.LatestSeqnoHint]
 	return !fresh
 }
+
+func (k TeamEphemeralKey) Ctime() Time {
+	typ, err := k.KeyType()
+	if err != nil {
+		return 0
+	}
+	switch typ {
+	case TeamEphemeralKeyType_TEAM:
+		return k.Team().Metadata.Ctime
+	case TeamEphemeralKeyType_TEAMBOT:
+		return k.Teambot().Metadata.Ctime
+	default:
+		return 0
+	}
+}
+
+func (k TeamEphemeralKeyBoxed) Ctime() Time {
+	typ, err := k.KeyType()
+	if err != nil {
+		return 0
+	}
+	switch typ {
+	case TeamEphemeralKeyType_TEAM:
+		return k.Team().Metadata.Ctime
+	case TeamEphemeralKeyType_TEAMBOT:
+		return k.Teambot().Metadata.Ctime
+	default:
+		return 0
+	}
+}
+
+func (k TeamEphemeralKeyBoxed) Generation() EkGeneration {
+	typ, err := k.KeyType()
+	if err != nil {
+		return 0
+	}
+	switch typ {
+	case TeamEphemeralKeyType_TEAM:
+		return k.Team().Metadata.Generation
+	case TeamEphemeralKeyType_TEAMBOT:
+		return k.Teambot().Metadata.Generation
+	default:
+		return 0
+	}
+}
+
+func (k TeamEphemeralKeyMetadata) Generation() EkGeneration {
+	typ, err := k.KeyType()
+	if err != nil {
+		return 0
+	}
+	switch typ {
+	case TeamEphemeralKeyType_TEAM:
+		return k.Team().Generation
+	case TeamEphemeralKeyType_TEAMBOT:
+		return k.Teambot().Generation
+	default:
+		return 0
+	}
+}
+
+func (k TeamEphemeralKeyType) IsTeambot() bool {
+	return k == TeamEphemeralKeyType_TEAMBOT
+}
+
+func (k TeamEphemeralKeyType) IsTeam() bool {
+	return k == TeamEphemeralKeyType_TEAM
+}

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -1729,7 +1729,8 @@ func (t *Team) storeTeamEKPayload(ctx context.Context, teamEKPayload *teamEKPayl
 	// Add the new teamEK box to local storage, if it was created above.
 	if teamEKPayload != nil && teamEKPayload.box != nil {
 		mctx := libkb.NewMetaContext(ctx, t.G())
-		if err := t.G().GetTeamEKBoxStorage().Put(mctx, t.ID, teamEKPayload.metadata.Generation, *teamEKPayload.box); err != nil {
+		boxed := keybase1.NewTeamEphemeralKeyBoxedWithTeam(*teamEKPayload.box)
+		if err := t.G().GetTeamEKBoxStorage().Put(mctx, t.ID, teamEKPayload.metadata.Generation, boxed); err != nil {
 			t.G().Log.CErrorf(ctx, "error while saving teamEK box: %s", err)
 		}
 	}

--- a/protocol/avdl/keybase1/ephemeral.avdl
+++ b/protocol/avdl/keybase1/ephemeral.avdl
@@ -136,4 +136,26 @@ protocol ephemeral {
     Bytes32 seed;
     TeambotEkMetadata metadata;
   }
+
+  ////////////////////////////////////////////////////////////////////////
+
+  enum TeamEphemeralKeyType {
+    TEAM_0,
+    TEAMBOT_1
+  }
+
+  variant TeamEphemeralKey switch (TeamEphemeralKeyType keyType) {
+    case TEAM: TeamEk;
+    case TEAMBOT: TeambotEk;
+  }
+
+  variant TeamEphemeralKeyBoxed switch (TeamEphemeralKeyType keyType) {
+    case TEAM: TeamEkBoxed;
+    case TEAMBOT: TeambotEkBoxed;
+  }
+
+  variant TeamEphemeralKeyMetadata switch (TeamEphemeralKeyType keyType) {
+    case TEAM: TeamEkMetadata;
+    case TEAMBOT: TeambotEkMetadata;
+  }
 }

--- a/protocol/json/keybase1/ephemeral.json
+++ b/protocol/json/keybase1/ephemeral.json
@@ -321,6 +321,86 @@
           "name": "metadata"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "TeamEphemeralKeyType",
+      "symbols": [
+        "TEAM_0",
+        "TEAMBOT_1"
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "TeamEphemeralKey",
+      "switch": {
+        "type": "TeamEphemeralKeyType",
+        "name": "keyType"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "TEAM",
+            "def": false
+          },
+          "body": "TeamEk"
+        },
+        {
+          "label": {
+            "name": "TEAMBOT",
+            "def": false
+          },
+          "body": "TeambotEk"
+        }
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "TeamEphemeralKeyBoxed",
+      "switch": {
+        "type": "TeamEphemeralKeyType",
+        "name": "keyType"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "TEAM",
+            "def": false
+          },
+          "body": "TeamEkBoxed"
+        },
+        {
+          "label": {
+            "name": "TEAMBOT",
+            "def": false
+          },
+          "body": "TeambotEkBoxed"
+        }
+      ]
+    },
+    {
+      "type": "variant",
+      "name": "TeamEphemeralKeyMetadata",
+      "switch": {
+        "type": "TeamEphemeralKeyType",
+        "name": "keyType"
+      },
+      "cases": [
+        {
+          "label": {
+            "name": "TEAM",
+            "def": false
+          },
+          "body": "TeamEkMetadata"
+        },
+        {
+          "label": {
+            "name": "TEAMBOT",
+            "def": false
+          },
+          "body": "TeambotEkMetadata"
+        }
+      ]
     }
   ],
   "messages": {},

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2062,6 +2062,11 @@ export enum TeamApplication {
   stellarRelay = 6,
 }
 
+export enum TeamEphemeralKeyType {
+  team = 0,
+  teambot = 1,
+}
+
 export enum TeamInviteCategory {
   none = 0,
   unknown = 1,
@@ -2556,6 +2561,9 @@ export type TeamEkMetadata = {readonly kid: KID; readonly hashMeta: HashMeta; re
 export type TeamEkStatement = {readonly currentTeamEkMetadata: TeamEkMetadata}
 export type TeamEncryptedKBFSKeyset = {readonly v: Int; readonly e: Bytes; readonly n: Bytes}
 export type TeamEncryptedKBFSKeysetHash = String
+export type TeamEphemeralKey = {keyType: TeamEphemeralKeyType.team; team: TeamEk | null} | {keyType: TeamEphemeralKeyType.teambot; teambot: TeambotEk | null}
+export type TeamEphemeralKeyBoxed = {keyType: TeamEphemeralKeyType.team; team: TeamEkBoxed | null} | {keyType: TeamEphemeralKeyType.teambot; teambot: TeambotEkBoxed | null}
+export type TeamEphemeralKeyMetadata = {keyType: TeamEphemeralKeyType.team; team: TeamEkMetadata | null} | {keyType: TeamEphemeralKeyType.teambot; teambot: TeambotEkMetadata | null}
 export type TeamExitRow = {readonly id: TeamID}
 export type TeamGetLegacyTLFUpgrade = {readonly encryptedKeyset: String; readonly teamGeneration: PerTeamKeyGeneration; readonly legacyGeneration: Int; readonly appType: TeamApplication}
 export type TeamID = String


### PR DESCRIPTION
surgery on the `TeamEKBoxStorage` to store a new variant `TeamEphemeralKey`. This allows us to interact with regular `TeamEKs` as well as new `TeambotEKs`.

cc @keybase/hotpotatosquad 