### PR TITLE
Add remember password checkbox to Settings > Advanced

### DIFF
--- a/shared/settings/advanced/container.tsx
+++ b/shared/settings/advanced/container.tsx
@@ -6,7 +6,9 @@ import {
   createLoadHasRandomPw,
   createOnChangeLockdownMode,
   createOnChangeUseNativeFrame,
+  createOnChangeRememberPassword,
   createLoadProxyData,
+  createLoadRememberPassword,
   createSaveProxyData,
   createCertificatePinningToggled,
 } from '../../actions/settings-gen'
@@ -17,11 +19,11 @@ import * as Constants from '../../constants/settings'
 import {anyErrors, anyWaiting} from '../../constants/waiting'
 import {compose} from 'recompose'
 import Advanced from './index'
-import {connect, lifecycle} from '../../util/container'
+import {connect, lifecycle, TypedState} from '../../util/container'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 
 type OwnProps = {}
-const mapStateToProps = state => {
+const mapStateToProps = (state: TypedState) => {
   const settingLockdownMode = anyWaiting(state, Constants.setLockdownModeWaitingKey)
   const setLockdownModeError = anyErrors(state, Constants.setLockdownModeWaitingKey)
   return {
@@ -31,6 +33,7 @@ const mapStateToProps = state => {
     openAtLogin: state.config.openAtLogin,
     processorProfileInProgress: Constants.processorProfileInProgress(state),
     proxyData: state.settings.proxyData,
+    rememberPassword: state.settings.password.rememberPassword,
     setLockdownModeError: (setLockdownModeError && setLockdownModeError.message) || '',
     settingLockdownMode,
     traceInProgress: Constants.traceInProgress(state),
@@ -42,9 +45,12 @@ const mapDispatchToProps = dispatch => ({
   _loadHasRandomPW: () => dispatch(createLoadHasRandomPw()),
   _loadLockdownMode: () => dispatch(createLoadLockdownMode()),
   _loadProxyData: () => dispatch(createLoadProxyData()),
+  _loadRememberPassword: () => dispatch(createLoadRememberPassword()),
   _resetCertPinningToggle: () => dispatch(createCertificatePinningToggled({toggled: null})),
   onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
   onChangeLockdownMode: (checked: boolean) => dispatch(createOnChangeLockdownMode({enabled: checked})),
+  onChangeRememberPassword: (checked: boolean) =>
+    dispatch(createOnChangeRememberPassword({remember: checked})),
   onChangeUseNativeFrame: (checked: boolean) => dispatch(createOnChangeUseNativeFrame({enabled: checked})),
   onDBNuke: () => dispatch(RouteTreeGen.createNavigateAppend({path: ['dbNukeConfirm']})),
   onDisableCertPinning: () =>
@@ -68,6 +74,7 @@ export default compose(
       this.props._loadLockdownMode()
       this.props._loadHasRandomPW()
       this.props._loadProxyData()
+      this.props._loadRememberPassword()
     },
     componentWillUnmount() {
       this.props._resetCertPinningToggle()

--- a/shared/settings/advanced/index.tsx
+++ b/shared/settings/advanced/index.tsx
@@ -32,6 +32,8 @@ type Props = {
   saveProxyData: (proxyData: RPCTypes.ProxyData) => void
   onEnableCertPinning: () => void
   allowTlsMitmToggle: boolean
+  rememberPassword: boolean
+  onChangeRememberPassword: (checked: boolean) => void
 }
 
 const stateUseNativeFrame = new AppState().state.useNativeFrame
@@ -79,7 +81,6 @@ const Advanced = (props: Props) => {
               (props.hasRandomPW ? ' (you need to set a password first)' : '')
             }
             onCheck={props.onChangeLockdownMode}
-            style={styles.checkbox}
           />
         </Kb.Box>
         {!!props.setLockdownModeError && (
@@ -87,9 +88,18 @@ const Advanced = (props: Props) => {
             {props.setLockdownModeError}
           </Kb.Text>
         )}
+        {!props.hasRandomPW && (
+          <Kb.Box style={styles.checkboxContainer}>
+            <Kb.Checkbox
+              checked={props.rememberPassword}
+              label="Remember your password"
+              onCheck={props.onChangeRememberPassword}
+            />
+          </Kb.Box>
+        )}
         {isLinux && <UseNativeFrame {...props} />}
         {!Styles.isMobile && !isLinux && (
-          <Kb.Box style={styles.openAtLoginCheckboxContainer}>
+          <Kb.Box style={styles.checkboxContainer}>
             <Kb.Checkbox
               label="Open Keybase on startup"
               checked={props.openAtLogin}
@@ -362,6 +372,7 @@ const styles = Styles.styleSheetCreate({
     paddingBottom: Styles.globalMargins.medium,
     paddingLeft: Styles.globalMargins.medium,
     paddingRight: Styles.globalMargins.medium,
+    width: '100%',
   },
   checkbox: {
     flex: 1,
@@ -373,6 +384,7 @@ const styles = Styles.styleSheetCreate({
     alignItems: 'center',
     maxHeight: 48,
     minHeight: 48,
+    width: '100%',
   },
   developerButtons: {
     marginTop: Styles.globalMargins.small,
@@ -402,11 +414,6 @@ const styles = Styles.styleSheetCreate({
     flexShrink: 0,
     flexWrap: 'wrap',
     marginTop: Styles.globalMargins.tiny,
-  },
-  openAtLoginCheckboxContainer: {
-    ...Styles.globalStyles.flexBoxColumn,
-    alignItems: 'flex-start',
-    flex: 1,
   },
   progressContainer: {
     ...Styles.globalStyles.flexBoxRow,

--- a/shared/settings/advanced/index.tsx
+++ b/shared/settings/advanced/index.tsx
@@ -51,7 +51,6 @@ const UseNativeFrame = (props: Props) => {
             checked={!props.useNativeFrame}
             label={'Hide system window frame'}
             onCheck={x => props.onChangeUseNativeFrame(!x)}
-            style={styles.checkbox}
           />
         </Kb.Box>
         {initialUseNativeFrame !== props.useNativeFrame && (
@@ -92,7 +91,14 @@ const Advanced = (props: Props) => {
           <Kb.Box style={styles.checkboxContainer}>
             <Kb.Checkbox
               checked={props.rememberPassword}
-              label="Remember your password"
+              labelComponent={
+                <Kb.Box2 direction="vertical" style={Styles.globalStyles.flexOne}>
+                  <Kb.Text type="Body">Always stay logged in</Kb.Text>
+                  <Kb.Text type="BodySmall">
+                    You won't be asked for your password when restarting the app or your device.
+                  </Kb.Text>
+                </Kb.Box2>
+              }
               onCheck={props.onChangeRememberPassword}
             />
           </Kb.Box>
@@ -374,16 +380,11 @@ const styles = Styles.styleSheetCreate({
     paddingRight: Styles.globalMargins.medium,
     width: '100%',
   },
-  checkbox: {
-    flex: 1,
-    paddingBottom: Styles.globalMargins.small,
-    paddingTop: Styles.globalMargins.small,
-  },
   checkboxContainer: {
     ...Styles.globalStyles.flexBoxRow,
     alignItems: 'center',
-    maxHeight: 48,
-    minHeight: 48,
+    paddingBottom: Styles.globalMargins.tiny,
+    paddingTop: Styles.globalMargins.tiny,
     width: '100%',
   },
   developerButtons: {


### PR DESCRIPTION
Lot of cleanup could be done here but limited this to just adding the checkbox. The `width` changes are to fix another problem where the checkbox labels wouldn't wrap and would overflow off screen.

r? @keybase/react-hackers cc @heronhaye @zapu 