### PR TITLE
logsend: tweak warnings now that filenames aren't logged

### DIFF
--- a/go/client/cmd_log_send.go
+++ b/go/client/cmd_log_send.go
@@ -125,8 +125,8 @@ func (c *CmdLogSend) confirm() error {
 	ui.Printf("This command will send recent keybase log entries to keybase.io\n")
 	ui.Printf("for debugging purposes only.\n\n")
 	ui.Printf("These logs don’t include your private keys or encrypted data,\n")
-	ui.Printf("but they will include filenames and other metadata keybase normally\n")
-	ui.Printf("can’t read, for debugging purposes.\n\n")
+	ui.Printf("but they will include metadata keybase normally can't read\n")
+	ui.Printf("(like file sizes and git repo names), for debugging purposes.\n\n")
 	return ui.PromptForConfirmation("Continue sending logs to keybase.io?")
 }
 

--- a/go/client/cmd_log_send.go
+++ b/go/client/cmd_log_send.go
@@ -124,8 +124,8 @@ func (c *CmdLogSend) confirm() error {
 	ui := c.G().UI.GetTerminalUI()
 	ui.Printf("This command will send recent keybase log entries to keybase.io\n")
 	ui.Printf("for debugging purposes only.\n\n")
-	ui.Printf("These logs don’t include your private keys or encrypted data,\n")
-	ui.Printf("but they will include metadata keybase normally can't read\n")
+	ui.Printf("These logs don’t include your private keys, encrypted data or file names,\n")
+	ui.Printf("but they will include metadata Keybase normally can't read\n")
 	ui.Printf("(like file sizes and git repo names), for debugging purposes.\n\n")
 	return ui.PromptForConfirmation("Continue sending logs to keybase.io?")
 }

--- a/go/client/cmd_simplefs_set_debug_level.go
+++ b/go/client/cmd_simplefs_set_debug_level.go
@@ -36,6 +36,13 @@ func NewCmdSimpleFSSetDebugLevel(
 
 // Run runs the command in client/server mode.
 func (c *CmdSimpleFSSetDebugLevel) Run() error {
+	if c.level > libkb.VLog0String {
+		ui := c.G().UI.GetTerminalUI()
+		ui.Printf("WARNING: this will make file and directory names visible in your logs.\n")
+		ui.Printf("If you send the logs to Keybase for debugging, those names will be\n")
+		ui.Printf("visible to Keybase employees as well.  File contents will remain private.\n")
+	}
+
 	cli, err := GetSimpleFSClient(c.G())
 	if err != nil {
 		return err

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -117,7 +117,7 @@ class Feedback extends React.Component<Props, State> {
               <Kb.Box2 direction="vertical" style={styles.textBox}>
                 <Kb.Text type="Body">Include your logs</Kb.Text>
                 <Kb.Text type="BodySmall" onClick={this._onLabelClick} style={styles.text}>
-                  This includes some private metadata info (e.g., file sizes, but not contents) but it will
+                  This includes some private metadata info (e.g., file sizes, but not names or contents) but it will
                   help the developers fix bugs more quickly.
                 </Kb.Text>
               </Kb.Box2>

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -117,7 +117,7 @@ class Feedback extends React.Component<Props, State> {
               <Kb.Box2 direction="vertical" style={styles.textBox}>
                 <Kb.Text type="Body">Include your logs</Kb.Text>
                 <Kb.Text type="BodySmall" onClick={this._onLabelClick} style={styles.text}>
-                  This includes some private metadata info (e.g., filenames, but not contents) but it will
+                  This includes some private metadata info (e.g., file sizes, but not contents) but it will
                   help the developers fix bugs more quickly.
                 </Kb.Text>
               </Kb.Box2>


### PR DESCRIPTION
Unless vlog1 or higher is set.

Older logs will still have filenames, but this change won't go out until the next release, at which point most older logs won't be sent as part of a `keybase log send` anymore, due to natural rotation.