### PR TITLE
Disable trustline changes on desktop for mobile-only accounts.

### DIFF
--- a/shared/wallets/trustline/asset-container.tsx
+++ b/shared/wallets/trustline/asset-container.tsx
@@ -21,6 +21,7 @@ const mapStateToProps = (state, ownProps: OwnProps) => ({
   ),
   asset: state.wallets.trustline.assetMap.get(ownProps.assetID, Constants.emptyAssetDescription),
   expandedAssets: state.wallets.trustline.expandedAssets,
+  thisDeviceIsLockedOut: Constants.getAccount(state, ownProps.accountID).deviceReadOnly,
   waitingRefresh: Waiting.anyWaiting(
     state,
     Constants.refreshTrustlineAcceptedAssetsWaitingKey(ownProps.accountID)
@@ -62,6 +63,7 @@ const mergeProps = (s, d, o: OwnProps) => ({
   onExpand: d.onExpand,
   onOpenInfoUrl: s.asset.infoUrl ? () => openUrl(s.asset.infoUrl) : undefined,
   onRemove: d.onRemove,
+  thisDeviceIsLockedOut: s.thisDeviceIsLockedOut,
   trusted: !!s.acceptedAssets.get(o.assetID, 0),
   waitingAdd: s.waitingAdd,
   waitingDelete: s.waitingDelete,

--- a/shared/wallets/trustline/asset.tsx
+++ b/shared/wallets/trustline/asset.tsx
@@ -10,6 +10,7 @@ export type Props = {
   infoUrlText: string
   issuerAccountID: string
   issuerVerifiedDomain: string
+  thisDeviceIsLockedOut: boolean
   trusted: boolean // TODO add limit when we support it in GUI
 
   onAccept: () => void
@@ -71,45 +72,54 @@ const bodyExpanded = (props: Props) => (
   </Kb.Box2>
 )
 
-const Asset = (props: Props) => (
-  <Kb.ListItem2
-    firstItem={props.firstItem}
-    type="Small"
-    height={props.expanded ? expandedHeight : undefined}
-    body={
-      // We use this instead of the action prop on ListItem2 so that it
-      // "floats" on top of the content and the account ID can extend below it
-      // rather than being cut off by the action container's left border.
-      <Kb.Box2 direction="horizontal" fullWidth={true} fullHeight={true}>
-        {props.expanded ? bodyExpanded(props) : bodyCollapsed(props)}
-        <Kb.Box2 direction="vertical" style={styles.actions} centerChildren={true}>
-          {props.trusted ? (
-            <Kb.WaitingButton
-              mode="Secondary"
-              type="Danger"
-              small={true}
-              label="Remove"
-              onClick={stopPropagation(props.onRemove)}
-              disabled={props.waitingRefresh}
-              waitingKey={props.waitingKeyDelete}
-            />
-          ) : (
-            <Kb.WaitingButton
-              mode="Primary"
-              type="Success"
-              small={true}
-              label="Accept"
-              onClick={stopPropagation(props.onAccept)}
-              disabled={props.cannotAccept || props.waitingRefresh}
-              waitingKey={props.waitingKeyAdd}
-            />
-          )}
+const Asset = (props: Props) => {
+  const button = props.trusted ? (
+    <Kb.WaitingButton
+      mode="Secondary"
+      type="Danger"
+      small={true}
+      label="Remove"
+      onClick={stopPropagation(props.onRemove)}
+      disabled={props.waitingRefresh || props.thisDeviceIsLockedOut}
+      waitingKey={props.waitingKeyDelete}
+    />
+  ) : (
+    <Kb.WaitingButton
+      mode="Primary"
+      type="Success"
+      small={true}
+      label="Accept"
+      onClick={stopPropagation(props.onAccept)}
+      disabled={props.cannotAccept || props.waitingRefresh || props.thisDeviceIsLockedOut}
+      waitingKey={props.waitingKeyAdd}
+    />
+  )
+  return (
+    <Kb.ListItem2
+      firstItem={props.firstItem}
+      type="Small"
+      height={props.expanded ? expandedHeight : undefined}
+      body={
+        // We use this instead of the action prop on ListItem2 so that it
+        // "floats" on top of the content and the account ID can extend below it
+        // rather than being cut off by the action container's left border.
+        <Kb.Box2 direction="horizontal" fullWidth={true} fullHeight={true}>
+          {props.expanded ? bodyExpanded(props) : bodyCollapsed(props)}
+          <Kb.Box2 direction="vertical" style={styles.actions} centerChildren={true}>
+            {props.thisDeviceIsLockedOut ? (
+              <Kb.WithTooltip text="You can only send from a mobile device more than 7 days old.">
+                {button}
+              </Kb.WithTooltip>
+            ) : (
+              button
+            )}
+          </Kb.Box2>
         </Kb.Box2>
-      </Kb.Box2>
-    }
-    onClick={props.expanded ? props.onCollapse : props.onExpand}
-  />
-)
+      }
+      onClick={props.expanded ? props.onCollapse : props.onExpand}
+    />
+  )
+}
 
 const nonExpandedHeight = Styles.isMobile ? 56 : 48
 const expandedHeight = Styles.isMobile ? 160 : 140


### PR DESCRIPTION
Passes the `thisDeviceIsLockedOut` boolean property to trustline assets, disabling them and displaying a tooltip if the account is changed to mobile only. Note that this case only happens if the trustlines popup is open and then the account is changed to mobile-only; the button in wallet settings to manage trustlines is disabled if the account is mobile-only.

Example of the tooltip:
![Screen Shot 2019-07-03 at 12 12 36 PM](https://user-images.githubusercontent.com/5677971/60608467-8ba05180-9d8d-11e9-80e3-61ecca715cd4.png)
