### PR TITLE
More caching in buildpayment

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -795,6 +795,7 @@ type Stellar interface {
 	RemovePendingTx(mctx MetaContext, accountID stellar1.AccountID, txID stellar1.TransactionID) error
 	KnownCurrencyCodeInstant(ctx context.Context, code string) (known, ok bool)
 	InformBundle(MetaContext, stellar1.BundleRevision, []stellar1.BundleEntry)
+	InformDefaultCurrencyChange(MetaContext)
 }
 
 type DeviceEKStorage interface {

--- a/go/libkb/stellar_stub.go
+++ b/go/libkb/stellar_stub.go
@@ -59,3 +59,5 @@ func (n *nullStellar) KnownCurrencyCodeInstant(context.Context, string) (bool, b
 }
 
 func (n *nullStellar) InformBundle(MetaContext, stellar1.BundleRevision, []stellar1.BundleEntry) {}
+
+func (n *nullStellar) InformDefaultCurrencyChange(MetaContext) {}

--- a/go/stellar/bpc.go
+++ b/go/stellar/bpc.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/stellar/remote"
@@ -20,12 +19,13 @@ type BuildPaymentCache interface {
 	// AccountSeqno should be cached _but_ it should also be busted asap.
 	// Because it is used to prevent users from sending payments twice in a row.
 	AccountSeqno(libkb.MetaContext, stellar1.AccountID) (string, error)
-	IsAccountFunded(libkb.MetaContext, stellar1.AccountID) (bool, error)
+	IsAccountFunded(libkb.MetaContext, stellar1.AccountID, stellar1.BuildPaymentID) (bool, error)
 	LookupRecipient(libkb.MetaContext, stellarcommon.RecipientInput) (stellarcommon.Recipient, error)
 	GetOutsideExchangeRate(libkb.MetaContext, stellar1.OutsideCurrencyCode) (stellar1.OutsideExchangeRate, error)
 	AvailableXLMToSend(libkb.MetaContext, stellar1.AccountID) (string, error)
-	GetOutsideCurrencyPreference(libkb.MetaContext, stellar1.AccountID) (stellar1.OutsideCurrencyCode, error)
+	GetOutsideCurrencyPreference(libkb.MetaContext, stellar1.AccountID, stellar1.BuildPaymentID) (stellar1.OutsideCurrencyCode, error)
 	ShouldOfferAdvancedSend(mctx libkb.MetaContext, from, to stellar1.AccountID) (stellar1.AdvancedBanner, error)
+	InformDefaultCurrencyChange(mctx libkb.MetaContext)
 }
 
 // Each instance is tied to a UV login. Must be discarded when switching users.
@@ -35,26 +35,21 @@ type buildPaymentCache struct {
 	sync.Mutex
 	remoter remote.Remoter
 
-	lookupRecipientLocktab libkb.LockTable
-	lookupRecipientCache   *lru.Cache
-
-	shouldOfferAdvancedSendLocktab libkb.LockTable
-	shouldOfferAdvancedSendCache   *lru.Cache
+	accountFundedCache             *TimeCache
+	lookupRecipientCache           *TimeCache
+	shouldOfferAdvancedSendCache   *TimeCache
+	currencyPreferenceCache        *TimeCache
+	currencyPreferenceForeverCache *TimeCache
 }
 
 func newBuildPaymentCache(remoter remote.Remoter) *buildPaymentCache {
-	lookupRecipientCache, err := lru.New(50)
-	if err != nil {
-		panic(err)
-	}
-	shouldOfferAdvancedSendCache, err := lru.New(50)
-	if err != nil {
-		panic(err)
-	}
 	return &buildPaymentCache{
-		remoter:                      remoter,
-		lookupRecipientCache:         lookupRecipientCache,
-		shouldOfferAdvancedSendCache: shouldOfferAdvancedSendCache,
+		remoter:                        remoter,
+		accountFundedCache:             NewTimeCache("accountFundedCache", 20, 0 /*forever*/),
+		lookupRecipientCache:           NewTimeCache("lookupRecipient", 20, time.Minute),
+		shouldOfferAdvancedSendCache:   NewTimeCache("shouldOfferAdvancedSend", 20, time.Minute),
+		currencyPreferenceCache:        NewTimeCache("currencyPreference", 20, 5*time.Minute),
+		currencyPreferenceForeverCache: NewTimeCache("currencyPreferenceForever", 20, 0 /*forever*/),
 	}
 }
 
@@ -69,73 +64,35 @@ func (c *buildPaymentCache) AccountSeqno(mctx libkb.MetaContext,
 }
 
 func (c *buildPaymentCache) IsAccountFunded(mctx libkb.MetaContext,
-	accountID stellar1.AccountID) (bool, error) {
-	return isAccountFunded(mctx.Ctx(), c.remoter, accountID)
-}
-
-type lookupRecipientCacheEntry struct {
-	Recipient stellarcommon.Recipient
-	Time      time.Time
+	accountID stellar1.AccountID, bid stellar1.BuildPaymentID) (res bool, err error) {
+	fill := func() (interface{}, error) {
+		return isAccountFunded(mctx.Ctx(), c.remoter, accountID)
+	}
+	if !bid.IsNil() {
+		key := fmt.Sprintf("%v:%v", accountID, bid)
+		err = c.accountFundedCache.GetWithFill(mctx, key, &res, fill)
+		return res, err
+	}
+	_, err = fill()
+	return res, err
 }
 
 func (c *buildPaymentCache) LookupRecipient(mctx libkb.MetaContext,
 	to stellarcommon.RecipientInput) (res stellarcommon.Recipient, err error) {
-	lock := c.lookupRecipientLocktab.AcquireOnName(mctx.Ctx(), mctx.G(), string(to))
-	defer lock.Release(mctx.Ctx())
-	if val, ok := c.lookupRecipientCache.Get(to); ok {
-		if entry, ok := val.(lookupRecipientCacheEntry); ok {
-			if mctx.G().GetClock().Now().Sub(entry.Time) <= time.Minute {
-				// Cache hit
-				mctx.Debug("bpc.LookupRecipient cache hit")
-				return entry.Recipient, nil
-			}
-		} else {
-			mctx.Debug("bpc.LookupRecipient bad cached type: %T", val)
-		}
-		c.lookupRecipientCache.Remove(to)
+	fill := func() (interface{}, error) {
+		return LookupRecipient(mctx, to, false /* isCLI */)
 	}
-	res, err = LookupRecipient(mctx, to, false /* isCLI */)
-	if err != nil {
-		return res, err
-	}
-	c.lookupRecipientCache.Add(to, lookupRecipientCacheEntry{
-		Time:      time.Now().Round(0),
-		Recipient: res,
-	})
-	return res, nil
+	err = c.lookupRecipientCache.GetWithFill(mctx, string(to), &res, fill)
+	return res, err
 }
 
-type shouldOfferAdvancedSendCacheEntry struct {
-	res  stellar1.AdvancedBanner
-	time time.Time
-}
-
-func (c *buildPaymentCache) ShouldOfferAdvancedSend(mctx libkb.MetaContext, from, to stellar1.AccountID) (stellar1.AdvancedBanner, error) {
-	fromTo := from.String() + ":" + to.String()
-
-	lock := c.shouldOfferAdvancedSendLocktab.AcquireOnName(mctx.Ctx(), mctx.G(), fromTo)
-	defer lock.Release(mctx.Ctx())
-	if val, ok := c.shouldOfferAdvancedSendCache.Get(fromTo); ok {
-		if entry, ok := val.(shouldOfferAdvancedSendCacheEntry); ok {
-			if mctx.G().GetClock().Now().Sub(entry.time) <= time.Minute {
-				// Cache hit
-				mctx.Debug("bpc.ShouldOfferAdvancedSend cache hit")
-				return entry.res, nil
-			}
-		} else {
-			mctx.Debug("bpc.ShouldOfferAdvancedSend bad cached type: %T", val)
-		}
-		c.shouldOfferAdvancedSendCache.Remove(fromTo)
+func (c *buildPaymentCache) ShouldOfferAdvancedSend(mctx libkb.MetaContext, from, to stellar1.AccountID) (res stellar1.AdvancedBanner, err error) {
+	key := from.String() + ":" + to.String()
+	fill := func() (interface{}, error) {
+		return ShouldOfferAdvancedSend(mctx, c.remoter, from, to)
 	}
-	res, err := ShouldOfferAdvancedSend(mctx, c.remoter, from, to)
-	if err != nil {
-		return res, err
-	}
-	c.shouldOfferAdvancedSendCache.Add(fromTo, shouldOfferAdvancedSendCacheEntry{
-		time: time.Now().Round(0),
-		res:  res,
-	})
-	return res, nil
+	err = c.shouldOfferAdvancedSendCache.GetWithFill(mctx, key, &res, fill)
+	return res, err
 }
 
 func (c *buildPaymentCache) GetOutsideExchangeRate(mctx libkb.MetaContext,
@@ -157,7 +114,25 @@ func (c *buildPaymentCache) AvailableXLMToSend(mctx libkb.MetaContext,
 }
 
 func (c *buildPaymentCache) GetOutsideCurrencyPreference(mctx libkb.MetaContext,
-	accountID stellar1.AccountID) (stellar1.OutsideCurrencyCode, error) {
-	cr, err := GetCurrencySetting(mctx, accountID)
-	return cr.Code, err
+	accountID stellar1.AccountID, bid stellar1.BuildPaymentID) (res stellar1.OutsideCurrencyCode, err error) {
+	fillInner := func() (interface{}, error) {
+		cr, err := GetCurrencySetting(mctx, accountID)
+		return cr.Code, err
+	}
+	fillOuter := func() (interface{}, error) {
+		err := c.currencyPreferenceCache.GetWithFill(mctx, accountID.String(), &res, fillInner)
+		return res, err
+	}
+	if !bid.IsNil() {
+		foreverKey := fmt.Sprintf("%v:%v", accountID, bid)
+		err = c.currencyPreferenceForeverCache.GetWithFill(mctx, foreverKey, &res, fillOuter)
+		return res, err
+	}
+	_, err = fillOuter()
+	return res, err
+}
+
+func (c *buildPaymentCache) InformDefaultCurrencyChange(mctx libkb.MetaContext) {
+	c.currencyPreferenceCache.Clear()
+	c.currencyPreferenceForeverCache.Clear()
 }

--- a/go/stellar/bpc.go
+++ b/go/stellar/bpc.go
@@ -66,7 +66,9 @@ func (c *buildPaymentCache) AccountSeqno(mctx libkb.MetaContext,
 func (c *buildPaymentCache) IsAccountFunded(mctx libkb.MetaContext,
 	accountID stellar1.AccountID, bid stellar1.BuildPaymentID) (res bool, err error) {
 	fill := func() (interface{}, error) {
-		return isAccountFunded(mctx.Ctx(), c.remoter, accountID)
+		funded, err := isAccountFunded(mctx.Ctx(), c.remoter, accountID)
+		res = funded
+		return funded, err
 	}
 	if !bid.IsNil() {
 		key := fmt.Sprintf("%v:%v", accountID, bid)

--- a/go/stellar/build.go
+++ b/go/stellar/build.go
@@ -259,7 +259,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 					addMinBanner(bannerTheir, minAmountXLM)
 				} else {
 					sendingToSelf, _, selfSendErr = getGlobal(mctx.G()).OwnAccountCached(mctx, stellar1.AccountID(recipient.AccountID.String()))
-					isFunded, err := bpc.IsAccountFunded(mctx, stellar1.AccountID(recipient.AccountID.String()))
+					isFunded, err := bpc.IsAccountFunded(mctx, stellar1.AccountID(recipient.AccountID.String()), arg.Bid)
 					if err != nil {
 						log("error checking recipient funding status %v: %v", *recipient.AccountID, err)
 					} else if !isFunded {
@@ -291,7 +291,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 					if err == nil {
 						if offerAdvancedForm != stellar1.AdvancedBanner_NO_BANNER {
 							res.Banners = append(res.Banners, stellar1.SendBannerLocal{
-								Level:                 "info",
+								Level: "info",
 								OfferAdvancedSendForm: offerAdvancedForm,
 							})
 						}
@@ -307,6 +307,7 @@ func BuildPaymentLocal(mctx libkb.MetaContext, arg stellar1.BuildPaymentLocalArg
 
 	tracer.Stage("amount + asset")
 	bpaArg := buildPaymentAmountArg{
+		Bid:      arg.Bid,
 		Amount:   arg.Amount,
 		Currency: arg.Currency,
 		Asset:    arg.Asset,
@@ -831,6 +832,7 @@ func BuildRequestLocal(mctx libkb.MetaContext, arg stellar1.BuildRequestLocalArg
 
 type buildPaymentAmountArg struct {
 	// See buildPaymentLocal in avdl from which these args are copied.
+	Bid      stellar1.BuildPaymentID
 	Amount   string
 	Currency *stellar1.OutsideCurrencyCode
 	Asset    *stellar1.Asset
@@ -952,7 +954,7 @@ func buildPaymentAmountHelper(mctx libkb.MetaContext, bpc BuildPaymentCache, arg
 			log("missing from address so can't convert XLM amount")
 			return res
 		}
-		currency, err := bpc.GetOutsideCurrencyPreference(mctx, *arg.From)
+		currency, err := bpc.GetOutsideCurrencyPreference(mctx, *arg.From, arg.Bid)
 		if err != nil {
 			log("error getting preferred currency for %v: %v", *arg.From, err)
 			return res

--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -64,8 +64,6 @@ type Stellar struct {
 	// Slot for build payments that do not use BuildPaymentID.
 	buildPaymentSlot *slotctx.PrioritySlot
 
-	migrationLock sync.Mutex
-
 	badger *badges.Badger
 }
 
@@ -585,6 +583,12 @@ func (s *Stellar) InformBundle(mctx libkb.MetaContext, rev stellar1.BundleRevisi
 			Revision: rev,
 			Accounts: accounts,
 		}
+	}()
+}
+
+func (s *Stellar) InformDefaultCurrencyChange(mctx libkb.MetaContext) {
+	go func() {
+		s.getBuildPaymentCache().InformDefaultCurrencyChange(mctx)
 	}()
 }
 

--- a/go/stellar/remote/remote.go
+++ b/go/stellar/remote/remote.go
@@ -681,6 +681,7 @@ func SetAccountDefaultCurrency(ctx context.Context, g *libkb.GlobalContext, acco
 		},
 	}
 	_, err = mctx.G().API.Post(mctx, apiArg)
+	mctx.G().GetStellar().InformDefaultCurrencyChange(mctx)
 	return err
 }
 

--- a/go/stellar/time_cache.go
+++ b/go/stellar/time_cache.go
@@ -1,0 +1,107 @@
+package stellar
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/keybase/client/go/libkb"
+)
+
+// Threadsafe cache with expiration and singleflighting.
+type TimeCache struct {
+	name    string // name for logging
+	maxAge  time.Duration
+	lockTab libkb.LockTable
+	cache   *lru.Cache
+}
+
+type timeCacheEntry struct {
+	val  interface{}
+	time time.Time
+}
+
+func NewTimeCache(name string, size int, maxAge time.Duration) *TimeCache {
+	if size <= 0 {
+		size = 10
+	}
+	cache, err := lru.New(size)
+	if err != nil {
+		panic(err)
+	}
+	return &TimeCache{
+		name:   name,
+		maxAge: maxAge,
+		cache:  cache,
+	}
+}
+
+type cacheFillFunc = func() (interface{}, error)
+
+func (c *TimeCache) Get(mctx libkb.MetaContext, key string, into interface{}) (ok bool) {
+	return c.getHelper(mctx, key, into, nil) == nil
+}
+
+// GetWithFill is prefereable to Get because it holds a locktab lock during the fill.
+// Which prevents concurrent accesses from doing the extra work of running fill at the same time.
+func (c *TimeCache) GetWithFill(mctx libkb.MetaContext, key string, into interface{}, fill cacheFillFunc) error {
+	return c.getHelper(mctx, key, into, fill)
+}
+
+func (c *TimeCache) getHelper(mctx libkb.MetaContext, key string, into interface{}, fill cacheFillFunc) error {
+	lock, err := c.lockTab.AcquireOnNameWithContextAndTimeout(mctx.Ctx(), mctx.G(), key, time.Minute)
+	if err != nil {
+		return fmt.Errorf("could not acquire cache lock for key %v", key)
+	}
+	defer lock.Release(mctx.Ctx())
+	storeResult := func(val interface{}) (ok bool) {
+		target := reflect.Indirect(reflect.ValueOf(into))
+		if target.CanSet() && reflect.TypeOf(val).AssignableTo(reflect.TypeOf(target.Interface())) {
+			target.Set(reflect.ValueOf(val))
+			return true
+		}
+		// Would indicate the caller used the wrong types.
+		return false
+	}
+	if val, ok := c.cache.Get(key); ok {
+		if entry, ok := val.(timeCacheEntry); ok {
+			if c.maxAge <= 0 || mctx.G().GetClock().Now().Sub(entry.time) <= c.maxAge {
+				// Cache hit
+				mctx.Debug("TimeCache %v cache hit", c.name)
+				if storeResult(entry.val) {
+					return nil
+				}
+				mctx.Debug("TimeCache %v target does not match", c.name)
+			}
+		} else {
+			// Would indicate a bug in TimeCache.
+			mctx.Debug("TimeCache %v bad cached type: %T", c.name, val)
+		}
+		// Remove the expired or corrupt entry.
+		c.cache.Remove(key)
+	}
+	if fill != nil {
+		val, err := fill()
+		if err != nil {
+			return err
+		}
+		c.Put(mctx, key, val)
+		if storeResult(val) {
+			return nil
+		}
+		return fmt.Errorf("value cannot be stored")
+	}
+	return fmt.Errorf("value not found for '%v'", key)
+}
+
+func (c *TimeCache) Put(mctx libkb.MetaContext, key string, val interface{}) {
+	c.cache.Add(key, timeCacheEntry{
+		val:  val,
+		time: time.Now().Round(0),
+	})
+}
+
+func (c *TimeCache) Clear() {
+	c.cache.Purge()
+}

--- a/go/stellar/time_cache_test.go
+++ b/go/stellar/time_cache_test.go
@@ -1,0 +1,75 @@
+package stellar
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeCache(t *testing.T) {
+	tc := libkb.SetupTest(t, "loaderclean", 1)
+	defer tc.Cleanup()
+
+	var a int
+	c := NewTimeCache("xyz", 50, time.Minute)
+	c.Put(tc.MetaContext(), "k", 1)
+	ok := c.Get(tc.MetaContext(), "k", &a)
+	require.True(t, ok)
+	require.Equal(t, 1, a)
+
+	fill2 := func() (interface{}, error) {
+		return 2, nil
+	}
+	fillErr := func() (interface{}, error) {
+		return 3, fmt.Errorf("eek")
+	}
+	err := c.GetWithFill(tc.MetaContext(), "l", &a, fill2)
+	require.NoError(t, err)
+	require.Equal(t, 2, a)
+	err = c.GetWithFill(tc.MetaContext(), "l", &a, fillErr)
+	require.NoError(t, err)
+	require.Equal(t, 2, a)
+
+	err = c.GetWithFill(tc.MetaContext(), "m", &a, fillErr)
+	require.Error(t, err)
+	require.Equal(t, 2, a)
+}
+
+func TestTimeCacheWrongType(t *testing.T) {
+	tc := libkb.SetupTest(t, "loaderclean", 1)
+	defer tc.Cleanup()
+
+	var a int
+	c := NewTimeCache("xyz", 50, time.Minute)
+	c.Put(tc.MetaContext(), "k", "b")
+	t.Logf("+ t1")
+	ok := c.Get(tc.MetaContext(), "k", &a)
+	require.False(t, ok)
+
+	t.Logf("+ t2")
+	c.Put(tc.MetaContext(), "k", "b")
+	ok = c.Get(tc.MetaContext(), "k", a)
+	require.False(t, ok)
+
+	t.Logf("+ t3")
+	c.Put(tc.MetaContext(), "k", "b")
+	ok = c.Get(tc.MetaContext(), "k", "z")
+	require.False(t, ok)
+}
+
+func TestTimeCacheWrongTypeStructs(t *testing.T) {
+	tc := libkb.SetupTest(t, "loaderclean", 1)
+	defer tc.Cleanup()
+
+	type T1 struct{ x int }
+	type T2 struct{ y string }
+
+	var a T1
+	c := NewTimeCache("xyz", 50, time.Minute)
+	c.Put(tc.MetaContext(), "k", T2{y: "b"})
+	ok := c.Get(tc.MetaContext(), "k", &a)
+	require.False(t, ok)
+}


### PR DESCRIPTION
Some more of `BuildPaymentCache`'s methods now actually have a cache. Reflecty attempt at a generic cache to avoid copypasta bugs.