### PR TITLE
turn off KBFS disk cache on mobile

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -14,16 +14,12 @@ import (
 	"runtime"
 	"runtime/debug"
 	"runtime/trace"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/globals"
-	"github.com/keybase/client/go/status"
-	"golang.org/x/sync/errgroup"
-
-	"strings"
-
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbfs/env"
 	"github.com/keybase/client/go/kbfs/fsrpc"
@@ -36,9 +32,11 @@ import (
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/service"
+	"github.com/keybase/client/go/status"
 	"github.com/keybase/client/go/uidmap"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
 )
 
 var kbCtx *libkb.GlobalContext
@@ -241,6 +239,7 @@ func Init(homeDir, mobileSharedHome, logFile, runModeStr string,
 		// before KBFS-on-mobile is ready.
 		kbfsParams.Debug = true                         // false
 		kbfsParams.Mode = libkbfs.InitConstrainedString // libkbfs.InitMinimalString
+		kbfsParams.DiskCacheMode = libkbfs.DiskCacheModeOff
 		kbfsConfig, _ = libkbfs.Init(
 			context.Background(), kbfsCtx, kbfsParams, serviceCn{}, func() error { return nil },
 			kbCtx.Log)


### PR DESCRIPTION
I think the parameters given to how LevelDB is opened in KBFS make it so that the size of the disk cache is over 100MB on mobile, seemingly even with blank KBFS data. After thinking about it, it seems to me like the cache isn't even needed on mobile, and given that it is causing a lot of extra memory overhead, it seem appropriate to disable it until it is more customized to exist on mobile devices.

Note, I also think we should consider this for the current release. 

cc @maxtaco @malgorithms @chrisnojima 