### PR TITLE
shortenAccountID passes through bogus input

### DIFF
--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -752,7 +752,13 @@ export const getSecretKey = (state: TypedState, accountID: Types.AccountID) =>
     ? state.wallets.exportedSecretKey
     : new HiddenString('')
 
-export const shortenAccountID = (id: Types.AccountID) => id.substring(0, 8) + '...' + id.substring(48)
+export const shortenAccountID = (id: Types.AccountID) => {
+  if (id) {
+    return id.substring(0, 8) + '...' + id.substring(48)
+  } else {
+    return id
+  }
+}
 
 export const isAccountLoaded = (state: TypedState, accountID: Types.AccountID) =>
   state.wallets.accountMap.has(accountID)


### PR DESCRIPTION
TransactionDetails was crashing [here](https://github.com/keybase/client/blob/master/shared/wallets/transaction-details/index.tsx#L324) for relay payments which don't have those path-payment fields set