### PR TITLE
Wrap button in Box2, so it is not full width

### DIFF
--- a/shared/wallets/airdrop/index.tsx
+++ b/shared/wallets/airdrop/index.tsx
@@ -150,12 +150,14 @@ class Airdrop extends React.Component<Props> {
             ))}
           </Kb.Box2>
           {!p.signedUp && (
-            <Kb.Button
-              style={styles.qualifyButton}
-              type="Success"
-              label="See if you qualify"
-              onClick={this._onCheckQualify}
-            />
+            <Kb.Box2 direction="horizontal">
+              <Kb.Button
+                style={styles.qualifyButton}
+                type="Success"
+                label="See if you qualify"
+                onClick={this._onCheckQualify}
+              />
+            </Kb.Box2>
           )}
           <Kb.Box2 direction="vertical" style={styles.grow} />
           <Kb.Box2


### PR DESCRIPTION
Wraps an airdrop button in a box so it is not full width, as per design.

@keybase/react-hackers 