### PR TITLE
leveldb: on mobile, use smaller write buffer sizes

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1376,7 +1376,7 @@ func (c *ConfigLocal) MakeDiskBlockCacheIfNotExists() error {
 }
 
 func (c *ConfigLocal) resetDiskMDCacheLocked() error {
-	dmc, err := newDiskMDCacheLocal(c, c.storageRoot)
+	dmc, err := newDiskMDCacheLocal(c, c.storageRoot, c.mode)
 	if err != nil {
 		return err
 	}
@@ -1399,7 +1399,7 @@ func (c *ConfigLocal) MakeDiskMDCacheIfNotExists() error {
 }
 
 func (c *ConfigLocal) resetDiskQuotaCacheLocked() error {
-	dqc, err := newDiskQuotaCacheLocal(c, c.storageRoot)
+	dqc, err := newDiskQuotaCacheLocal(c, c.storageRoot, c.mode)
 	if err != nil {
 		return err
 	}
@@ -1432,7 +1432,7 @@ func (c *ConfigLocal) MakeBlockMetadataStoreIfNotExists() (err error) {
 	if c.blockMetadataStore != nil {
 		return nil
 	}
-	c.blockMetadataStore, err = newDiskBlockMetadataStore(c)
+	c.blockMetadataStore, err = newDiskBlockMetadataStore(c, c.mode)
 	if err != nil {
 		// TODO (KBFS-3659): when we can open levelDB read-only,
 		//  do that instead of returning a Noop version.
@@ -1448,7 +1448,7 @@ func (c *ConfigLocal) openConfigLevelDB(configName string) (*LevelDb, error) {
 	if err != nil {
 		return nil, err
 	}
-	return openLevelDB(stor)
+	return openLevelDB(stor, c.mode)
 }
 
 func (c *ConfigLocal) loadSyncedTlfsLocked() (err error) {

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3431,7 +3431,7 @@ func (cr *ConflictResolver) makeDiskBlockCache(ctx context.Context) (
 			}
 		}
 		dbc, err = newDiskBlockCacheLocal(
-			cr.config, crDirtyBlockCacheLimitTrackerType, tempDir)
+			cr.config, crDirtyBlockCacheLimitTrackerType, tempDir, cr.config.Mode())
 		if err != nil {
 			dirCleanupFn(ctx)
 			return nil, nil, err
@@ -3768,7 +3768,7 @@ func (cr *ConflictResolver) clearConflictRecords(ctx context.Context) error {
 
 func openCRDBInternal(config Config) (*LevelDb, error) {
 	if config.IsTestMode() {
-		return openLevelDB(storage.NewMemStorage())
+		return openLevelDB(storage.NewMemStorage(), config.Mode())
 	}
 	err := os.MkdirAll(sysPath.Join(config.StorageRoot(),
 		conflictResolverRecordsDir, conflictResolverRecordsVersionString),
@@ -3785,7 +3785,7 @@ func openCRDBInternal(config Config) (*LevelDb, error) {
 		return nil, err
 	}
 
-	return openLevelDB(stor)
+	return openLevelDB(stor, config.Mode())
 }
 
 func openCRDB(config Config) (db *LevelDb) {

--- a/go/kbfs/libkbfs/disk_block_cache_wrapped.go
+++ b/go/kbfs/libkbfs/disk_block_cache_wrapped.go
@@ -71,8 +71,8 @@ func (cache *diskBlockCacheWrapped) enableCache(
 			cache.config, typ)
 	} else {
 		cacheStorageRoot := filepath.Join(cache.storageRoot, cacheFolder)
-		*cachePtr, err = newDiskBlockCacheLocal(cache.config, typ,
-			cacheStorageRoot)
+		*cachePtr, err = newDiskBlockCacheLocal(
+			cache.config, typ, cacheStorageRoot, mode)
 	}
 	return err
 }

--- a/go/kbfs/libkbfs/disk_block_metadata_store.go
+++ b/go/kbfs/libkbfs/disk_block_metadata_store.go
@@ -42,6 +42,7 @@ type diskBlockMetadataStoreConfig interface {
 	Codec() kbfscodec.Codec
 	MakeLogger(module string) logger.Logger
 	StorageRoot() string
+	Mode() InitMode
 }
 
 // diskBlockMetadataStore interacts with BlockMetadata data storage on disk.
@@ -61,10 +62,12 @@ type diskBlockMetadataStore struct {
 
 // newDiskBlockMetadataStore creates a new disk BlockMetadata storage.
 func newDiskBlockMetadataStore(
-	config diskBlockMetadataStoreConfig) (BlockMetadataStore, error) {
+	config diskBlockMetadataStoreConfig, mode InitMode) (
+	BlockMetadataStore, error) {
 	log := config.MakeLogger("BMS")
-	db, err := openVersionedLevelDB(log, config.StorageRoot(),
-		blockMetadataFolderName, currentBlockMetadataStoreVersion, blockMetadataDbFilename)
+	db, err := openVersionedLevelDB(
+		log, config.StorageRoot(), blockMetadataFolderName,
+		currentBlockMetadataStoreVersion, blockMetadataDbFilename, mode)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/libkbfs/disk_block_metadata_store_test.go
+++ b/go/kbfs/libkbfs/disk_block_metadata_store_test.go
@@ -34,6 +34,9 @@ func (t *testBlockMetadataStoreConfig) MakeLogger(
 func (t *testBlockMetadataStoreConfig) StorageRoot() string {
 	return t.storageRoot
 }
+func (t *testBlockMetadataStoreConfig) Mode() InitMode {
+	return modeTest{modeDefault{}}
+}
 
 func makeBlockMetadataStoreForTest(t *testing.T) (
 	blockMetadataStore BlockMetadataStore, tempdir string) {
@@ -44,7 +47,7 @@ func makeBlockMetadataStoreForTest(t *testing.T) (
 		log:         logger.NewTestLogger(t),
 		storageRoot: tempdir,
 	}
-	s, err := newDiskBlockMetadataStore(&config)
+	s, err := newDiskBlockMetadataStore(&config, modeTest{modeDefault{}})
 	require.NoError(t, err)
 	return s, tempdir
 }

--- a/go/kbfs/libkbfs/disk_md_cache.go
+++ b/go/kbfs/libkbfs/disk_md_cache.go
@@ -112,7 +112,7 @@ type DiskMDCacheStatus struct {
 // with the passed-in storage.Storage interfaces as storage layers for each
 // cache.
 func newDiskMDCacheLocalFromStorage(
-	config diskMDCacheConfig, headsStorage storage.Storage) (
+	config diskMDCacheConfig, headsStorage storage.Storage, mode InitMode) (
 	cache *DiskMDCacheLocal, err error) {
 	log := config.MakeLogger("DMC")
 	closers := make([]io.Closer, 0, 1)
@@ -130,10 +130,10 @@ func newDiskMDCacheLocalFromStorage(
 			closer()
 		}
 	}()
-	mdDbOptions := *leveldbOptions
+	mdDbOptions := leveldbOptionsFromMode(mode)
 	mdDbOptions.CompactionTableSize = defaultMDCacheTableSize
 	mdDbOptions.Filter = filter.NewBloomFilter(16)
-	headsDb, err := openLevelDBWithOptions(headsStorage, &mdDbOptions)
+	headsDb, err := openLevelDBWithOptions(headsStorage, mdDbOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func newDiskMDCacheLocalFromStorage(
 // newDiskMDCacheLocal creates a new *DiskMDCacheLocal with a
 // specified directory on the filesystem as storage.
 func newDiskMDCacheLocal(
-	config diskBlockCacheConfig, dirPath string) (
+	config diskBlockCacheConfig, dirPath string, mode InitMode) (
 	cache *DiskMDCacheLocal, err error) {
 	log := config.MakeLogger("DMC")
 	defer func() {
@@ -199,7 +199,7 @@ func newDiskMDCacheLocal(
 			headsStorage.Close()
 		}
 	}()
-	return newDiskMDCacheLocalFromStorage(config, headsStorage)
+	return newDiskMDCacheLocalFromStorage(config, headsStorage, mode)
 }
 
 // WaitUntilStarted waits until this cache has started.

--- a/go/kbfs/libkbfs/disk_md_cache_test.go
+++ b/go/kbfs/libkbfs/disk_md_cache_test.go
@@ -30,7 +30,7 @@ func newDiskMDCacheLocalForTestWithStorage(
 	cache, err := newDiskMDCacheLocalFromStorage(&testDiskMDCacheConfig{
 		newTestCodecGetter(),
 		newTestLogMaker(t),
-	}, s)
+	}, s, modeTest{modeDefault{}})
 	require.NoError(t, err)
 	err = cache.WaitUntilStarted()
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/disk_quota_cache.go
+++ b/go/kbfs/libkbfs/disk_quota_cache.go
@@ -100,7 +100,7 @@ type DiskQuotaCacheStatus struct {
 // with the passed-in storage.Storage interfaces as storage layers for each
 // cache.
 func newDiskQuotaCacheLocalFromStorage(
-	config diskQuotaCacheConfig, quotaStorage storage.Storage) (
+	config diskQuotaCacheConfig, quotaStorage storage.Storage, mode InitMode) (
 	cache *DiskQuotaCacheLocal, err error) {
 	log := config.MakeLogger("DQC")
 	closers := make([]io.Closer, 0, 1)
@@ -118,10 +118,10 @@ func newDiskQuotaCacheLocalFromStorage(
 			closer()
 		}
 	}()
-	quotaDbOptions := *leveldbOptions
+	quotaDbOptions := leveldbOptionsFromMode(mode)
 	quotaDbOptions.CompactionTableSize = defaultQuotaCacheTableSize
 	quotaDbOptions.Filter = filter.NewBloomFilter(16)
-	db, err := openLevelDBWithOptions(quotaStorage, &quotaDbOptions)
+	db, err := openLevelDBWithOptions(quotaStorage, quotaDbOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func newDiskQuotaCacheLocalFromStorage(
 // newDiskQuotaCacheLocal creates a new *DiskQuotaCacheLocal with a
 // specified directory on the filesystem as storage.
 func newDiskQuotaCacheLocal(
-	config diskBlockCacheConfig, dirPath string) (
+	config diskBlockCacheConfig, dirPath string, mode InitMode) (
 	cache *DiskQuotaCacheLocal, err error) {
 	log := config.MakeLogger("DQC")
 	defer func() {
@@ -187,7 +187,7 @@ func newDiskQuotaCacheLocal(
 			quotaStorage.Close()
 		}
 	}()
-	return newDiskQuotaCacheLocalFromStorage(config, quotaStorage)
+	return newDiskQuotaCacheLocalFromStorage(config, quotaStorage, mode)
 }
 
 // WaitUntilStarted waits until this cache has started.

--- a/go/kbfs/libkbfs/disk_quota_cache_test.go
+++ b/go/kbfs/libkbfs/disk_quota_cache_test.go
@@ -28,7 +28,7 @@ func newDiskQuotaCacheLocalForTestWithStorage(
 	cache, err := newDiskQuotaCacheLocalFromStorage(&testDiskQuotaCacheConfig{
 		newTestCodecGetter(),
 		newTestLogMaker(t),
-	}, s)
+	}, s, modeTest{modeDefault{}})
 	require.NoError(t, err)
 	err = cache.WaitUntilStarted()
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/favorites.go
+++ b/go/kbfs/libkbfs/favorites.go
@@ -169,11 +169,11 @@ func (f *Favorites) readCacheFromDisk(ctx context.Context) error {
 	var db *LevelDb
 	var err error
 	if f.config.IsTestMode() {
-		db, err = openLevelDB(storage.NewMemStorage())
+		db, err = openLevelDB(storage.NewMemStorage(), f.config.Mode())
 	} else {
 		db, err = openVersionedLevelDB(f.log, f.config.StorageRoot(),
 			kbfsFavoritesCacheSubfolder, favoritesDiskCacheStorageVersion,
-			favoritesDiskCacheFilename)
+			favoritesDiskCacheFilename, f.config.Mode())
 	}
 	if err != nil {
 		return err

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1942,6 +1942,10 @@ type InitMode interface {
 	// BackgroundWorkPeriod indicates how long to wait between
 	// non-critical background work tasks.
 	BackgroundWorkPeriod() time.Duration
+	// DiskCacheWriteBufferSize indicates how large the write buffer
+	// should be on disk caches -- this also controls how big the
+	// on-disk tables are before compaction.
+	DiskCacheWriteBufferSize() int
 }
 
 type initModeGetter interface {

--- a/go/kbfs/libkbfs/keybase_service_util.go
+++ b/go/kbfs/libkbfs/keybase_service_util.go
@@ -103,6 +103,7 @@ func serviceLoggedIn(ctx context.Context, config Config, session idutil.SessionI
 			wg = jManager.MakeFBOsForExistingJournals(newCtx)
 		}
 	}
+
 	err := config.MakeDiskBlockCacheIfNotExists()
 	if err != nil {
 		log.CWarningf(ctx, "serviceLoggedIn: Failed to enable disk cache: "+

--- a/go/kbfs/libkbfs/leveldb.go
+++ b/go/kbfs/libkbfs/leveldb.go
@@ -37,6 +37,12 @@ var leveldbOptions = &opt.Options{
 	OpenFilesCacheCapacity: 10,
 }
 
+func leveldbOptionsFromMode(mode InitMode) *opt.Options {
+	o := *leveldbOptions
+	o.WriteBuffer = mode.DiskCacheWriteBufferSize()
+	return &o
+}
+
 // LevelDb is a libkbfs wrapper for leveldb.DB.
 type LevelDb struct {
 	*leveldb.DB
@@ -102,6 +108,7 @@ func (ldb *LevelDb) PutWithMeter(key, value []byte, putMeter *CountMeter) (
 // as its underlying storage layer, and with the options specified.
 func openLevelDBWithOptions(stor storage.Storage, options *opt.Options) (
 	*LevelDb, error) {
+	fmt.Printf("OPTIONS: %#v\n", options)
 	db, err := leveldb.Open(stor, options)
 	if ldberrors.IsCorrupted(err) {
 		// There's a possibility that if the leveldb wasn't closed properly
@@ -120,10 +127,10 @@ func openLevelDBWithOptions(stor storage.Storage, options *opt.Options) (
 
 // openLevelDB opens or recovers a leveldb.DB with a passed-in storage.Storage
 // as its underlying storage layer.
-func openLevelDB(stor storage.Storage) (*LevelDb, error) {
-	options := *leveldbOptions
+func openLevelDB(stor storage.Storage, mode InitMode) (*LevelDb, error) {
+	options := leveldbOptionsFromMode(mode)
 	options.Filter = filter.NewBloomFilter(16)
-	return openLevelDBWithOptions(stor, &options)
+	return openLevelDBWithOptions(stor, options)
 }
 
 func versionPathFromVersion(dirPath string, version uint64) string {
@@ -209,8 +216,9 @@ func getVersionedPathForDiskCache(
 // under storageRoot. The path include dbFolderName and dbFilename. Note that
 // dbFilename is actually created as a folder; it's just where raw LevelDb
 // lives.
-func openVersionedLevelDB(log logger.Logger, storageRoot string,
-	dbFolderName string, currentDiskCacheVersion uint64, dbFilename string) (
+func openVersionedLevelDB(
+	log logger.Logger, storageRoot string, dbFolderName string,
+	currentDiskCacheVersion uint64, dbFilename string, mode InitMode) (
 	db *LevelDb, err error) {
 	dbPath := filepath.Join(storageRoot, dbFolderName)
 	versionPath, err := getVersionedPathForDiskCache(
@@ -229,8 +237,8 @@ func openVersionedLevelDB(log logger.Logger, storageRoot string,
 			storage.Close()
 		}
 	}()
-	options := *leveldbOptions
-	if db, err = openLevelDBWithOptions(storage, &options); err != nil {
+	options := leveldbOptionsFromMode(mode)
+	if db, err = openLevelDBWithOptions(storage, options); err != nil {
 		return nil, err
 	}
 	return db, nil

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
 // NewInitModeFromType returns an InitMode object corresponding to the
@@ -182,6 +183,10 @@ func (md modeDefault) BackgroundWorkPeriod() time.Duration {
 	return 0
 }
 
+func (md modeDefault) DiskCacheWriteBufferSize() int {
+	return 10 * opt.MiB // 10 MB
+}
+
 // Minimal mode:
 
 type modeMinimal struct {
@@ -341,6 +346,10 @@ func (mm modeMinimal) InitialDelayForBackgroundWork() time.Duration {
 func (mm modeMinimal) BackgroundWorkPeriod() time.Duration {
 	// No background work
 	return math.MaxInt64
+}
+
+func (mm modeMinimal) DiskCacheWriteBufferSize() int {
+	return 1 * opt.KiB // 1 KB
 }
 
 // Single op mode:
@@ -525,6 +534,10 @@ func (mc modeConstrained) BackgroundWorkPeriod() time.Duration {
 	return 5 * time.Second
 }
 
+func (mc modeConstrained) DiskCacheWriteBufferSize() int {
+	return 100 * opt.KiB // 100 KB
+}
+
 // Memory limited mode
 
 type modeMemoryLimited struct {
@@ -569,6 +582,10 @@ func (mml modeMemoryLimited) MaxCleanBlockCacheCapacity() uint64 {
 
 func (mml modeMemoryLimited) TLFEditHistoryEnabled() bool {
 	return false
+}
+
+func (mml modeMemoryLimited) DiskCacheWriteBufferSize() int {
+	return 1 * opt.KiB // 1 KB
 }
 
 // Wrapper for tests.

--- a/go/kbfs/libkbfs/settings_db.go
+++ b/go/kbfs/libkbfs/settings_db.go
@@ -43,7 +43,7 @@ type SettingsDB struct {
 
 func openSettingsDBInternal(config Config) (*LevelDb, error) {
 	if config.IsTestMode() {
-		return openLevelDB(storage.NewMemStorage())
+		return openLevelDB(storage.NewMemStorage(), config.Mode())
 	}
 	dbPath := path.Join(config.StorageRoot(), settingsDBDir,
 		settingsDBVersionString)
@@ -57,7 +57,7 @@ func openSettingsDBInternal(config Config) (*LevelDb, error) {
 		return nil, err
 	}
 
-	return openLevelDB(stor)
+	return openLevelDB(stor, config.Mode())
 }
 
 func openSettingsDB(config Config) *SettingsDB {


### PR DESCRIPTION
Each leveldb instance pre-allocates a full write buffer worth of space when it's opened.  Using 10 MB for each one is wasteful on mobile, so dial it back to 100 KB, except for the disk block cache.  If the disk block cache's buffer it too low, it causes too many tables to be written to disk before compaction, and can result in a "too many open files" error during a restart.

cc: @mmaxim 	

Issue: HOTPOT-279