### PR TITLE
fix windows electron 5

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
@@ -63,7 +63,8 @@
     <PostBuildEvent>if /I "$(ConfigurationName)" == "Release" "%25SIGNTOOL%25" sign /v /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 /i "%25CERTISSUER%25" "$(TargetDir)$(TargetFileName)"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>"%25WIX%25bin\heat" dir %25GOPATH%25\src\github.com\keybase\client\shared\desktop\release\win32-x64\Keybase-win32-x64 -cg GuiComps -ag -sfrag -template fragment  -var var.GuiSourceDir  -dr INSTALLFOLDER -t $(ProjectDir)\gui.xsl -out $(ProjectDir)\gui.wxs
+      <PreBuildEvent>echo "ignore" > "$(ProjrectDir)\ignore.txt"
+"%25WIX%25bin\heat" dir %25GOPATH%25\src\github.com\keybase\client\shared\desktop\release\win32-x64\Keybase-win32-x64 -cg GuiComps -ag -sfrag -template fragment  -var var.GuiSourceDir  -dr INSTALLFOLDER -t $(ProjectDir)\gui.xsl -out $(ProjectDir)\gui.wxs
 echo "Dumping gui.wsx"
 type "$(ProjectDir)\gui.wxs"
 cd /d "$(ProjectDir)"

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
@@ -63,7 +63,8 @@
     <PostBuildEvent>if /I "$(ConfigurationName)" == "Release" "%25SIGNTOOL%25" sign /v /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 /i "%25CERTISSUER%25" "$(TargetDir)$(TargetFileName)"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-      <PreBuildEvent>echo "ignore" > "$(ProjectDir)ignore.txt"
+      <PreBuildEvent>
+echo ignore > "$(ProjectDir)ignore.txt"
 "%25WIX%25bin\heat" dir %25GOPATH%25\src\github.com\keybase\client\shared\desktop\release\win32-x64\Keybase-win32-x64 -cg GuiComps -ag -sfrag -template fragment  -var var.GuiSourceDir  -dr INSTALLFOLDER -t $(ProjectDir)\gui.xsl -out $(ProjectDir)\gui.wxs
 echo "Dumping gui.wsx"
 type "$(ProjectDir)\gui.wxs"

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
@@ -64,6 +64,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>"%25WIX%25bin\heat" dir %25GOPATH%25\src\github.com\keybase\client\shared\desktop\release\win32-x64\Keybase-win32-x64 -cg GuiComps -ag -sfrag -template fragment  -var var.GuiSourceDir  -dr INSTALLFOLDER -t $(ProjectDir)\gui.xsl -out $(ProjectDir)\gui.wxs
+echo "Dumping gui.wsx"
+type "$(ProjectDir)\gui.wxs"
 cd /d "$(ProjectDir)"
 if NOT exist Redist\dokan-dev\1.2.2.1000\DokanSetup_redist.exe (
       if NOT exist Redist\ mkdir Redist

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wixproj
@@ -63,7 +63,7 @@
     <PostBuildEvent>if /I "$(ConfigurationName)" == "Release" "%25SIGNTOOL%25" sign /v /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 /i "%25CERTISSUER%25" "$(TargetDir)$(TargetFileName)"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-      <PreBuildEvent>echo "ignore" > "$(ProjrectDir)\ignore.txt"
+      <PreBuildEvent>echo "ignore" > "$(ProjectDir)ignore.txt"
 "%25WIX%25bin\heat" dir %25GOPATH%25\src\github.com\keybase\client\shared\desktop\release\win32-x64\Keybase-win32-x64 -cg GuiComps -ag -sfrag -template fragment  -var var.GuiSourceDir  -dr INSTALLFOLDER -t $(ProjectDir)\gui.xsl -out $(ProjectDir)\gui.wxs
 echo "Dumping gui.wsx"
 type "$(ProjectDir)\gui.wxs"

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -12,7 +12,7 @@
     <Property Id="EXECUTABLETARGET" Value="bin"/>
     <Property Id="MsiLogging" Value="oicewarmup"/>
     <PropertyRef Id="WIX_IS_NETFRAMEWORK_452_OR_LATER_INSTALLED"/>
-    <MajorUpgrade DowngradeErrorMessage="A newer version of Keybase is already installed." AllowSameVersionUpgrades="yes"  />	
+    <MajorUpgrade DowngradeErrorMessage="A newer version of Keybase is already installed." AllowSameVersionUpgrades="yes"  />
 
     <Condition Message="This application requires .NET Framework 4.5.2. Please install the .NET Framework then run this installer again.">
       <![CDATA[Installed OR WIX_IS_NETFRAMEWORK_452_OR_LATER_INSTALLED]]>
@@ -67,15 +67,12 @@
       <Directory Id="ProgramMenuFolder" Name="ProgramMenu" />
     </Directory>
   </Fragment>
-  
+
 	<Fragment>
 		<ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-			<Component Id="keybase.exe" Guid="88737432-0E15-413D-B23C-4B18D06EDC2C">				
+			<Component Id="keybase.exe" Guid="88737432-0E15-413D-B23C-4B18D06EDC2C">
         <CreateFolder />
         <RemoveFolder Id="RemoveMyApp" On="uninstall" />
-        <!-- The heat tool output (which generates gui.wxs) won't work if there are directories with only subdirectories
-        and no removable components, so we have to special-case them here and in the xsl transform (gui.xsl) -->
-        <RemoveFolder Id="GuiResourcesDirRemove" On="uninstall" Directory="GuiResourcesDir"/>
         <RegistryKey Root="HKCU" Key="Software\Keybase\Keybase">
           <RegistryValue Name="KeybaseExe" Value="1" KeyPath="yes" Type="integer" />
         </RegistryKey>
@@ -98,7 +95,7 @@
         </RegistryKey>
         <File Id='KbfsDokanExe' DiskId='1' Source="$(env.GOPATH)\src\github.com\keybase\client\go\kbfs\kbfsdokan\kbfsdokan.exe" />
       </Component>
-			
+
       <Component Id="GitHelperExe" Guid="{d8938a5b-c45f-4942-b552-a357a5563329}">
         <CreateFolder />
         <RemoveFolder Id="RemoveGitHelper" On="uninstall" />
@@ -108,7 +105,7 @@
         <File Id='GitHelperExe' DiskId='1' Source="$(env.GOPATH)\src\github.com\keybase\client\go\kbfs\kbfsgit\git-remote-keybase\git-remote-keybase.exe" />
         <Environment Id="PATH" Name="PATH" Value="[INSTALLFOLDER]" Permanent="no" Part="last" Action="set" System="no" />
       </Component>
-      
+
       <Component Id="upd.exe" Guid="{65C18DA3-BCD5-4E18-9C80-AC66471B433A}">
         <CreateFolder />
         <RemoveFolder Id="RemoveUpdater" On="uninstall" />
@@ -139,7 +136,7 @@
           <RegistryValue Name="ShortCutStartUp" Type="integer" Value="1" KeyPath="yes"  />
         </RegistryKey>
       </Component>
-    </ComponentGroup>    
+    </ComponentGroup>
   </Fragment>
   <Fragment>
     <ComponentGroup Id="GuiStartMenuTileColors" Directory="GuiDir">
@@ -151,12 +148,12 @@
         </RegistryKey>
         <File Id="GUIShortcutVisualElementManifest.xml" Source="$(env.GOPATH)\src\github.com\keybase\client\packaging\windows\WIXInstallers\KeybaseApps\Keybase.visualelementsmanifest.xml" Checksum="yes"/>
       </Component>
-    </ComponentGroup>    
+    </ComponentGroup>
   </Fragment>
-  
+
   <Fragment>
     <ComponentGroup Id="BrowserExtensionKbnm" Directory="INSTALLFOLDER">
-      
+
       <Component Id="kbnm.exe" Guid="{FE0C96E0-FFC8-4256-A600-50FFFCF58349}">
         <CreateFolder />
         <RemoveFolder Id="RemoveMyBrowserExtensionExe" On="uninstall" />
@@ -203,7 +200,7 @@
               Directory="INSTALLFOLDER"
               ExeCommand="[INSTALLFOLDER]keybaserq.exe &quot;[INSTALLFOLDER]keybase.exe&quot; --log-format=file --log-prefix=&quot;[INSTALLFOLDER]watchdog.&quot; ctl watchdog2"
               Execute="commit"
-              Return="ignore"/>    
+              Return="ignore"/>
   </Fragment>
   <Fragment>
     <CustomAction Id="StopMainApp"

--- a/packaging/windows/WIXInstallers/KeybaseApps/gui.xsl
+++ b/packaging/windows/WIXInstallers/KeybaseApps/gui.xsl
@@ -11,13 +11,11 @@
     <xsl:template match="wix:Directory[@Name='Keybase-win32-x64']/@Name">
         <xsl:attribute name="Name">Gui</xsl:attribute>
     </xsl:template>
-    <xsl:template match="wix:Directory[@Name='resources']/@Id">
-        <xsl:template match="wix:Component">
-            <xsl:copy>
-                <xsl:apply-templates select="@*"/>
-                <wix:RemoveFolder Id="{@Id}" On="uninstall" />
-                <xsl:apply-templates select="node()"/>
-            </xsl:copy>
-        </xsl:template>
+    <xsl:template match="wix:Component">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <wix:RemoveFolder Id="{@Id}" On="uninstall" />
+            <xsl:apply-templates select="node()"/>
+        </xsl:copy>
     </xsl:template>
 </xsl:stylesheet>

--- a/packaging/windows/WIXInstallers/KeybaseApps/gui.xsl
+++ b/packaging/windows/WIXInstallers/KeybaseApps/gui.xsl
@@ -12,4 +12,12 @@
  <xsl:template match="wix:Directory[@Name='Keybase-win32-x64']/@Name">
   <xsl:attribute name="Name">Gui</xsl:attribute>
  </xsl:template>
+ <xsl:template match="wix:Directory[@Name='resources']/@Id">
+  <xsl:template match="wix:Component">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <wix:RemoveFolder Id="{@Id}" On="uninstall" />
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/packaging/windows/WIXInstallers/KeybaseApps/gui.xsl
+++ b/packaging/windows/WIXInstallers/KeybaseApps/gui.xsl
@@ -1,23 +1,23 @@
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"  xmlns:wix="http://schemas.microsoft.com/wix/2006/wi">
- <xsl:output omit-xml-declaration="yes" indent="yes"/>
- <xsl:template match="node()|@*">
-  <xsl:copy>
-   <xsl:apply-templates select="node()|@*"/>
-  </xsl:copy>
- </xsl:template>
-
- <xsl:template match="wix:Directory[@Name='Keybase-win32-x64']/@Id">
-  <xsl:attribute name="Id">GuiDir</xsl:attribute>
- </xsl:template>
- <xsl:template match="wix:Directory[@Name='Keybase-win32-x64']/@Name">
-  <xsl:attribute name="Name">Gui</xsl:attribute>
- </xsl:template>
- <xsl:template match="wix:Directory[@Name='resources']/@Id">
-  <xsl:template match="wix:Component">
-    <xsl:copy>
-      <xsl:apply-templates select="@*"/>
-      <wix:RemoveFolder Id="{@Id}" On="uninstall" />
-      <xsl:apply-templates select="node()"/>
-    </xsl:copy>
-  </xsl:template>
+    <xsl:output omit-xml-declaration="yes" indent="yes"/>
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="wix:Directory[@Name='Keybase-win32-x64']/@Id">
+        <xsl:attribute name="Id">GuiDir</xsl:attribute>
+    </xsl:template>
+    <xsl:template match="wix:Directory[@Name='Keybase-win32-x64']/@Name">
+        <xsl:attribute name="Name">Gui</xsl:attribute>
+    </xsl:template>
+    <xsl:template match="wix:Directory[@Name='resources']/@Id">
+        <xsl:template match="wix:Component">
+            <xsl:copy>
+                <xsl:apply-templates select="@*"/>
+                <wix:RemoveFolder Id="{@Id}" On="uninstall" />
+                <xsl:apply-templates select="node()"/>
+            </xsl:copy>
+        </xsl:template>
+    </xsl:template>
 </xsl:stylesheet>

--- a/packaging/windows/WIXInstallers/KeybaseApps/gui.xsl
+++ b/packaging/windows/WIXInstallers/KeybaseApps/gui.xsl
@@ -4,7 +4,7 @@
   <xsl:copy>
    <xsl:apply-templates select="node()|@*"/>
   </xsl:copy>
- </xsl:template>  
+ </xsl:template>
 
  <xsl:template match="wix:Directory[@Name='Keybase-win32-x64']/@Id">
   <xsl:attribute name="Id">GuiDir</xsl:attribute>
@@ -12,16 +12,4 @@
  <xsl:template match="wix:Directory[@Name='Keybase-win32-x64']/@Name">
   <xsl:attribute name="Name">Gui</xsl:attribute>
  </xsl:template>
- <xsl:template match="wix:Directory[@Name='resources']/@Id">
-  <xsl:attribute name="Id">GuiResourcesDir</xsl:attribute>
- </xsl:template>
-  
-  <xsl:template match="wix:Component">
-    <xsl:copy>
-      <xsl:apply-templates select="@*"/>
-      <wix:RemoveFolder Id="{@Id}" On="uninstall" />
-      <xsl:apply-templates select="node()"/>
-    </xsl:copy>
-  </xsl:template> 
-  
 </xsl:stylesheet>


### PR DESCRIPTION
The flow is
1. Run heat which generates an xml file
1. Run the xml file through gui.xsl as an xslt transform to build a file wix uses. If we find a directory called 'resources' we give it a special id
1. Have special code to uninstall this due to some weird issue w/ wix (code comment: ` The heat tool output (which generates gui.wxs) won't work if there are directories with only subdirectories
        and no removable components, so we have to special-case them here and in the xsl transform (gui.xsl) `
1. To work around this above comment we just inject a dummy file into that directory

The above seems to work given my light testing and lack of expertise