### PR TITLE
add a payment popup for pending transactions

### DIFF
--- a/shared/chat/conversation/messages/message-popup/payment/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/container.tsx
@@ -77,7 +77,9 @@ const sendMapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
 })
 
 const getTopLineUser = (paymentInfo, sender, you: string) => {
-  if (paymentInfo.fromUsername === you) {
+  if (paymentInfo.status === 'pending') {
+    return 'pending'
+  } else if (paymentInfo.fromUsername === you) {
     return 'you sent'
   } else if (paymentInfo.toUsername === you) {
     return 'you received'
@@ -130,6 +132,7 @@ const sendMergeProps = (
     onSeeDetails:
       (paymentInfo.status === 'completed' ||
         paymentInfo.status === 'error' ||
+        paymentInfo.status === 'pending' ||
         paymentInfo.status === 'claimable' ||
         paymentInfo.status === 'canceled') &&
       (youAreSender || youAreReceiver)
@@ -138,7 +141,7 @@ const sendMergeProps = (
     position: ownProps.position,
     sender: ownProps.message.author,
     senderDeviceName: ownProps.message.deviceName,
-    status: '',
+    status: paymentInfo.status,
     style: ownProps.style,
     timestamp: formatTimeForMessages(ownProps.message.timestamp),
     topLine: `${getTopLineUser(paymentInfo, ownProps.message.author, you)}${

--- a/shared/chat/conversation/messages/message-popup/payment/index.stories.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/index.stories.tsx
@@ -128,6 +128,12 @@ const youSendXLMProps = {
   txVerb: 'sent',
 } as Props
 
+const pendingPaymentProps = {
+  ...youSendXLMProps,
+  topLine: 'pending',
+  status: 'pending',
+}
+
 const loadingProps = {
   ...commonProps,
   amountNominal: '',
@@ -160,6 +166,7 @@ const load = () => {
     .add('You receive BTC', () => <PaymentPopupMoved {...youReceiveBTCProps} />)
     .add('You send BTC', () => <PaymentPopupMoved {...youSendBTCProps} />)
     .add('You send XLM', () => <PaymentPopupMoved {...youSendXLMProps} />)
+    .add('Pending', () => <PaymentPopupMoved {...pendingPaymentProps} />)
     .add('Completed request', () => <PaymentPopupMoved {...completedProps} />)
     .add('Canceled request', () => <PaymentPopupMoved {...canceledProps} />)
     .add('Loading', () => <PaymentPopupMoved {...loadingProps} />)

--- a/shared/chat/conversation/messages/message-popup/payment/index.stories.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/index.stories.tsx
@@ -130,8 +130,8 @@ const youSendXLMProps = {
 
 const pendingPaymentProps = {
   ...youSendXLMProps,
-  topLine: 'pending',
   status: 'pending',
+  topLine: 'pending',
 }
 
 const loadingProps = {

--- a/shared/chat/conversation/messages/message-popup/payment/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/index.tsx
@@ -227,20 +227,6 @@ const styles = Styles.styleSheetCreate({
       marginTop: Styles.globalMargins.small,
     },
   }),
-  pendingHeaderIcon: Styles.platformStyles({
-    common: {height: pendingIconSize},
-    isAndroid: {
-      marginTop: Styles.globalMargins.tiny,
-    },
-    isElectron: {
-      marginBottom: Styles.globalMargins.small,
-      display: 'inline-block',
-    },
-    isMobile: {
-      marginBottom: Styles.globalMargins.small,
-      marginTop: Styles.globalMargins.small,
-    },
-  }),
   headerTextNotPending: {color: Styles.globalColors.white},
   headerTextPending: {color: Styles.globalColors.black_50},
   headerTop: Styles.platformStyles({
@@ -272,6 +258,20 @@ const styles = Styles.styleSheetCreate({
     paddingLeft: Styles.globalMargins.small,
     paddingRight: Styles.globalMargins.small,
   },
+  pendingHeaderIcon: Styles.platformStyles({
+    common: {height: pendingIconSize},
+    isAndroid: {
+      marginTop: Styles.globalMargins.tiny,
+    },
+    isElectron: {
+      display: 'inline-block',
+      marginBottom: Styles.globalMargins.small,
+    },
+    isMobile: {
+      marginBottom: Styles.globalMargins.small,
+      marginTop: Styles.globalMargins.small,
+    },
+  }),
   pendingHeaderTop: Styles.platformStyles({
     common: {
       alignItems: 'center',

--- a/shared/chat/conversation/messages/message-popup/payment/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/index.tsx
@@ -73,7 +73,7 @@ const Header = (props: HeaderProps) =>
     </Kb.Box2>
   ) : (
     <Kb.Box2 fullWidth={true} gap="small" gapEnd={true} direction="vertical" style={styles.popupContainer}>
-      <Kb.Box2 direction="vertical" fullWidth={true} style={styles.headerTop}>
+      <Kb.Box2 direction="vertical" fullWidth={true} style={headerTop(props)}>
         <Kb.Icon
           type={props.icon === 'sending' ? sendIcon : receiveIcon}
           style={Kb.iconCastPlatformStyles(styles.headerIcon)}
@@ -225,6 +225,16 @@ const styles = Styles.styleSheetCreate({
       paddingTop: Styles.globalMargins.small,
     },
   }),
+  pendingHeaderTop: Styles.platformStyles({
+    common: {
+      alignItems: 'center',
+      backgroundColor: Styles.globalColors.black_20,
+      paddingBottom: Styles.globalMargins.small,
+    },
+    isElectron: {
+      paddingTop: Styles.globalMargins.small,
+    },
+  }),
   loadingHeaderTop: Styles.platformStyles({
     common: {
       backgroundColor: Styles.globalColors.purpleDark,
@@ -248,5 +258,9 @@ const styles = Styles.styleSheetCreate({
     isElectron: {maxWidth: 240, minWidth: 200},
   }),
 })
+
+const headerTop = (props: HeaderProps) => {
+  return props.status === 'pending' ? styles.pendingHeaderTop : styles.headerTop
+}
 
 export default PaymentPopup

--- a/shared/chat/conversation/messages/message-popup/payment/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/index.tsx
@@ -34,6 +34,7 @@ const receiveIcon = Styles.isMobile
   : 'icon-fancy-stellar-receiving-desktop-98-86'
 
 const headerIconHeight = Styles.isMobile ? 129 : 86
+const pendingIconSize = 40
 
 type HeaderProps = {
   amountNominal: string
@@ -64,6 +65,21 @@ export type Props = {
   visible: boolean
 } & HeaderProps
 
+const headerIcon = (props: HeaderProps) =>
+  props.status === 'pending' ? (
+    <Kb.Icon
+      type="iconfont-time"
+      color={Styles.globalColors.black_50}
+      fontSize={pendingIconSize}
+      style={Kb.iconCastPlatformStyles(styles.pendingHeaderIcon)}
+    />
+  ) : (
+    <Kb.Icon
+      type={props.icon === 'sending' ? sendIcon : receiveIcon}
+      style={Kb.iconCastPlatformStyles(styles.headerIcon)}
+    />
+  )
+
 const Header = (props: HeaderProps) =>
   props.loading ? (
     <Kb.Box2 direction="vertical" fullWidth={true} style={styles.popupContainer}>
@@ -74,10 +90,7 @@ const Header = (props: HeaderProps) =>
   ) : (
     <Kb.Box2 fullWidth={true} gap="small" gapEnd={true} direction="vertical" style={styles.popupContainer}>
       <Kb.Box2 direction="vertical" fullWidth={true} style={headerTop(props)}>
-        <Kb.Icon
-          type={props.icon === 'sending' ? sendIcon : receiveIcon}
-          style={Kb.iconCastPlatformStyles(styles.headerIcon)}
-        />
+        {headerIcon(props)}
         <Kb.Text type="BodyTiny" style={headerTextStyle(props)}>
           {toUpper(props.topLine)}
         </Kb.Text>
@@ -209,6 +222,20 @@ const styles = Styles.styleSheetCreate({
       marginTop: Styles.globalMargins.tiny,
     },
     isElectron: {marginBottom: Styles.globalMargins.small},
+    isMobile: {
+      marginBottom: Styles.globalMargins.small,
+      marginTop: Styles.globalMargins.small,
+    },
+  }),
+  pendingHeaderIcon: Styles.platformStyles({
+    common: {height: pendingIconSize},
+    isAndroid: {
+      marginTop: Styles.globalMargins.tiny,
+    },
+    isElectron: {
+      marginBottom: Styles.globalMargins.small,
+      display: 'inline-block',
+    },
     isMobile: {
       marginBottom: Styles.globalMargins.small,
       marginTop: Styles.globalMargins.small,

--- a/shared/chat/conversation/messages/message-popup/payment/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/index.tsx
@@ -78,19 +78,19 @@ const Header = (props: HeaderProps) =>
           type={props.icon === 'sending' ? sendIcon : receiveIcon}
           style={Kb.iconCastPlatformStyles(styles.headerIcon)}
         />
-        <Kb.Text type="BodyTiny" style={styles.colorWhite}>
+        <Kb.Text type="BodyTiny" style={headerTextStyle(props)}>
           {toUpper(props.topLine)}
         </Kb.Text>
-        <Kb.Text type="HeaderExtrabold" style={styles.colorWhite}>
+        <Kb.Text type="HeaderExtrabold" style={headerTextStyle(props)}>
           {props.amountNominal}
         </Kb.Text>
         {!!props.bottomLine && (
-          <Kb.Text type="BodyTiny" style={styles.colorWhite}>
+          <Kb.Text type="BodyTiny" style={headerTextStyle(props)}>
             {toUpper(props.bottomLine)}
           </Kb.Text>
         )}
         {!!props.approxWorth && (
-          <Kb.Text type="BodyTiny" style={styles.colorWhite}>
+          <Kb.Text type="BodyTiny" style={headerTextStyle(props)}>
             (APPROXIMATELY {props.approxWorth})
           </Kb.Text>
         )}
@@ -198,7 +198,6 @@ const PaymentPopup = (props: Props) => {
 }
 
 const styles = Styles.styleSheetCreate({
-  colorWhite: {color: Styles.globalColors.white},
   errorDetails: {
     maxWidth: 200,
     paddingLeft: Styles.globalMargins.tiny,
@@ -215,20 +214,12 @@ const styles = Styles.styleSheetCreate({
       marginTop: Styles.globalMargins.small,
     },
   }),
+  headerTextNotPending: {color: Styles.globalColors.white},
+  headerTextPending: {color: Styles.globalColors.black_50},
   headerTop: Styles.platformStyles({
     common: {
       alignItems: 'center',
       backgroundColor: Styles.globalColors.purpleDark,
-      paddingBottom: Styles.globalMargins.small,
-    },
-    isElectron: {
-      paddingTop: Styles.globalMargins.small,
-    },
-  }),
-  pendingHeaderTop: Styles.platformStyles({
-    common: {
-      alignItems: 'center',
-      backgroundColor: Styles.globalColors.black_20,
       paddingBottom: Styles.globalMargins.small,
     },
     isElectron: {
@@ -254,6 +245,16 @@ const styles = Styles.styleSheetCreate({
     paddingLeft: Styles.globalMargins.small,
     paddingRight: Styles.globalMargins.small,
   },
+  pendingHeaderTop: Styles.platformStyles({
+    common: {
+      alignItems: 'center',
+      backgroundColor: Styles.globalColors.black_05,
+      paddingBottom: Styles.globalMargins.small,
+    },
+    isElectron: {
+      paddingTop: Styles.globalMargins.small,
+    },
+  }),
   popupContainer: Styles.platformStyles({
     isElectron: {maxWidth: 240, minWidth: 200},
   }),
@@ -261,6 +262,10 @@ const styles = Styles.styleSheetCreate({
 
 const headerTop = (props: HeaderProps) => {
   return props.status === 'pending' ? styles.pendingHeaderTop : styles.headerTop
+}
+
+const headerTextStyle = (props: HeaderProps) => {
+  return props.status === 'pending' ? styles.headerTextPending : styles.headerTextNotPending
 }
 
 export default PaymentPopup

--- a/shared/chat/payments/status/container.tsx
+++ b/shared/chat/payments/status/container.tsx
@@ -38,7 +38,7 @@ export default namedConnect(
       : (paymentInfo === null || paymentInfo === undefined ? undefined : paymentInfo.status) || 'pending'
     return {
       allowFontScaling: ownProps.allowFontScaling,
-      allowPopup: status === 'completed' || message.author === state.config.username,
+      allowPopup: status === 'completed' || status === 'pending' || message.author === state.config.username,
       errorDetail:
         error || (paymentInfo === null || paymentInfo === undefined ? undefined : paymentInfo.statusDetail), // Auto generated from flowToTs. Please clean me!
       isSendError: !!error,


### PR DESCRIPTION
### before
pending transactions are unclickable. when it's only in this state for a second or two, it's hard to notice and not a big thing. but if it ever takes longer (or if we're having issues propagating tx state correctly), the user experience can be sub-optimal.

### after
do something really similar to how it normally works and err on the side of showing more information rather than less. i took a stab at a design that follows the same pattern of pending being grey instead of purple, and putting the word `pending` in there really obviously. and again, when everything is working normally, this will only be visible like this for a few seconds. 

<img width="201" alt="Screen Shot 2019-07-11 at 12 11 10 PM" src="https://user-images.githubusercontent.com/1275828/61067218-0f34f080-a3d5-11e9-930f-7a544d4e08b0.png">
