### PR TITLE
Add generic encrypteddb.GetSecretBoxKey

### DIFF
--- a/go/chat/storage/crypt.go
+++ b/go/chat/storage/crypt.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/encrypteddb"
 	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
 )
@@ -13,23 +13,5 @@ import (
 const cryptoVersion = 1
 
 func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI) (fkey [32]byte, err error) {
-	// Get secret device key
-	encKey, err := engine.GetMySecretKey(ctx, g, getSecretUI, libkb.DeviceEncryptionKeyType,
-		"encrypt chat message")
-	if err != nil {
-		return fkey, err
-	}
-	kp, ok := encKey.(libkb.NaclDHKeyPair)
-	if !ok || kp.Private == nil {
-		return fkey, libkb.KeyCannotDecryptError{}
-	}
-
-	// Derive symmetric key from device key
-	skey, err := encKey.SecretSymmetricKey(libkb.EncryptionReasonChatLocalStorage)
-	if err != nil {
-		return fkey, err
-	}
-
-	copy(fkey[:], skey[:])
-	return fkey, nil
+	return encrypteddb.GetSecretBoxKey(ctx, g, getSecretUI, libkb.EncryptionReasonChatLocalStorage, "encrypt chat message")
 }

--- a/go/contacts/cache.go
+++ b/go/contacts/cache.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/encrypteddb"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -28,10 +27,12 @@ func (s *ContactCacheStore) dbKey(uid keybase1.UID) libkb.DbKey {
 	}
 }
 
-// NewContactCacheStore creates new ContactCacheStore for given global context.
+// NewContactCacheStore creates new ContactCacheStore for global context. The
+// store is used to securely store cached contact resolutions.
 func NewContactCacheStore(g *libkb.GlobalContext) *ContactCacheStore {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return storage.GetSecretBoxKey(ctx, g, storage.DefaultSecretUI)
+		return encrypteddb.GetSecretBoxKey(ctx, g, encrypteddb.DefaultSecretUI,
+			libkb.EncryptionReasonContactsLocalStorage, "encrypting contact resolution cache")
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalDb

--- a/go/contacts/cache.go
+++ b/go/contacts/cache.go
@@ -135,11 +135,13 @@ func (c *CachedContactsProvider) LookupAll(mctx libkb.MetaContext, emails []keyb
 	var conCache lookupResultCache
 	cacheKey := c.Store.dbKey(mctx.CurrentUID())
 	found, cerr := c.Store.encryptedDB.Get(mctx.Ctx(), cacheKey, &conCache)
-	if cerr != nil {
-		mctx.Warning("Unable to pull cache: %s", cerr)
-	} else if !found {
+	if cerr != nil || !found {
+		if cerr != nil {
+			mctx.Warning("Unable to pull cache: %s", cerr)
+		} else if !found {
+			mctx.Debug("There was no cache, making a new cache object")
+		}
 		conCache = makeNewLookupResultCache()
-		mctx.Debug("There was no cache, making a new cache object")
 	} else {
 		mctx.Debug("Fetched cache, current cache size: %d", len(conCache.Lookups))
 	}

--- a/go/contacts/phonebook.go
+++ b/go/contacts/phonebook.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/encrypteddb"
 
 	"github.com/keybase/client/go/libkb"
@@ -22,9 +21,12 @@ type SavedContactsStore struct {
 	encryptedDB *encrypteddb.EncryptedDB
 }
 
+// NewSavedContactsStore creates a new SavedContactsStore for global context.
+// The store is used to securely store list of resolved contacts.
 func NewSavedContactsStore(g *libkb.GlobalContext) *SavedContactsStore {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return storage.GetSecretBoxKey(ctx, g, storage.DefaultSecretUI)
+		return encrypteddb.GetSecretBoxKey(ctx, g, encrypteddb.DefaultSecretUI,
+			libkb.EncryptionReasonContactsLocalStorage, "encrypting local contact list")
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalDb

--- a/go/encrypteddb/secretkeys.go
+++ b/go/encrypteddb/secretkeys.go
@@ -1,7 +1,7 @@
 package encrypteddb
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
@@ -32,11 +32,14 @@ func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI fu
 	return fkey, nil
 }
 
-type SecretUI struct {
+// NoSecretUI is the default SecretUI for GetSecretBoxKey, because we don't
+// expect to do any interactive key unlocking there. GetSecretBoxKey should
+// only be used where device key is present and unlocked.
+type NoSecretUI struct {
 }
 
-func (d SecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
-	return keybase1.GetPassphraseRes{}, fmt.Errorf("no secret UI available")
+func (d NoSecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, errors.New("no secret UI available")
 }
 
-var DefaultSecretUI = func() libkb.SecretUI { return SecretUI{} }
+var DefaultSecretUI = func() libkb.SecretUI { return NoSecretUI{} }

--- a/go/encrypteddb/secretkeys.go
+++ b/go/encrypteddb/secretkeys.go
@@ -1,0 +1,42 @@
+package encrypteddb
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI,
+	reason libkb.EncryptionReason, reasonStr string) (fkey [32]byte, err error) {
+	// Get secret device key
+	encKey, err := engine.GetMySecretKey(ctx, g, getSecretUI, libkb.DeviceEncryptionKeyType,
+		reasonStr)
+	if err != nil {
+		return fkey, err
+	}
+	kp, ok := encKey.(libkb.NaclDHKeyPair)
+	if !ok || kp.Private == nil {
+		return fkey, libkb.KeyCannotDecryptError{}
+	}
+
+	// Derive symmetric key from device key
+	skey, err := encKey.SecretSymmetricKey(reason)
+	if err != nil {
+		return fkey, err
+	}
+
+	copy(fkey[:], skey[:])
+	return fkey, nil
+}
+
+type SecretUI struct {
+}
+
+func (d SecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
+	return keybase1.GetPassphraseRes{}, fmt.Errorf("no secret UI available")
+}
+
+var DefaultSecretUI = func() libkb.SecretUI { return SecretUI{} }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -599,6 +599,7 @@ const (
 	EncryptionReasonTeamsHiddenLocalStorage EncryptionReason = "Keybase-Teams-Hidden-Local-Storage-1"
 	EncryptionReasonErasableKVLocalStorage  EncryptionReason = "Keybase-Erasable-KV-Local-Storage-1"
 	EncryptionReasonTeambotEphemeralKey     EncryptionReason = "Keybase-Teambot-Ephemeral-Key-1"
+	EncryptionReasonContactsLocalStorage    EncryptionReason = "Keybase-Contacts-Local-Storage-1"
 )
 
 type DeriveReason string

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -600,6 +600,7 @@ const (
 	EncryptionReasonErasableKVLocalStorage  EncryptionReason = "Keybase-Erasable-KV-Local-Storage-1"
 	EncryptionReasonTeambotEphemeralKey     EncryptionReason = "Keybase-Teambot-Ephemeral-Key-1"
 	EncryptionReasonContactsLocalStorage    EncryptionReason = "Keybase-Contacts-Local-Storage-1"
+	EncryptionReasonKBFSFavorites           EncryptionReason = "kbfs.favorites" // legacy bad choice of encryption reason, kept as is
 )
 
 type DeriveReason string

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -600,7 +600,7 @@ const (
 	EncryptionReasonErasableKVLocalStorage  EncryptionReason = "Keybase-Erasable-KV-Local-Storage-1"
 	EncryptionReasonTeambotEphemeralKey     EncryptionReason = "Keybase-Teambot-Ephemeral-Key-1"
 	EncryptionReasonContactsLocalStorage    EncryptionReason = "Keybase-Contacts-Local-Storage-1"
-	EncryptionReasonKBFSFavorites           EncryptionReason = "kbfs.favorites" // legacy bad choice of encryption reason, kept as is
+	EncryptionReasonKBFSFavorites           EncryptionReason = "kbfs.favorites" // legacy const for kbfs favorites
 )
 
 type DeriveReason string

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -18,12 +18,9 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
-	teamStorage "github.com/keybase/client/go/teams/storage"
 	"github.com/keybase/client/go/tlfupgrade"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
-
-const favoritesEncryptionReason = "kbfs.favorites"
 
 type KBFSHandler struct {
 	*BaseHandler
@@ -163,7 +160,8 @@ func (h *KBFSHandler) UpgradeTLF(ctx context.Context, arg keybase1.UpgradeTLFArg
 // favorites.
 func (h *KBFSHandler) getKeyFn() func(context.Context) ([32]byte, error) {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return teamStorage.GetLocalStorageSecretBoxKeyGeneric(ctx, h.G(), favoritesEncryptionReason)
+		return encrypteddb.GetSecretBoxKey(ctx, h.G(), encrypteddb.DefaultSecretUI,
+			libkb.EncryptionReasonKBFSFavorites, "encrypting kbfs favorites")
 	}
 	return keyFn
 }


### PR DESCRIPTION
Replace code that used to call chat/storage.GetSecretBoxKey but was not related to chat. Add "generic" function to aid with encrypting local storage. Note that this is **not new crypto**, it's merely a function that was already being present in two places (`go/chat/storage/crypt.go` and `go/teams/storage/generic.go`) that's now copied into third place. It should be used by anyone who wants to encrypt leveldb data instead of making their own variant.
 
There was a mixup on how we were doing encrypted caches. `chat/storage.GetSecretBoxKey` was being used outside of chat, and once it's been used once, more occurrences followed by people finding that call site and doing it similar way. I don't have the exact timeline here and it doesn't matter.

Contact cache will not be encrypted using key derived with `ChatLocalStorage` string anymore. Added new derivation string for contacts: `EncryptionReasonContactsLocalStorage = "Keybase-Contacts-Local-Storage-1"`

Use the new function in `go/offline/rpc_cache.go` but keep `EncryptionReasonChatLocalStorage` so users will not lose cached data.