### PR TITLE
Fix wallet disappearing orange line

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -239,6 +239,7 @@
     "paymentsReceived": {
       "_description": "Update our store of payments data",
       "accountID": "Types.AccountID",
+      "allowClearOldestUnread": "boolean",
       "paymentCursor": "StellarRPCTypes.PageCursor | null",
       "oldestUnread": "Types.PaymentID",
       "payments": "Array<Types.PaymentResult>",

--- a/shared/actions/wallets-gen.tsx
+++ b/shared/actions/wallets-gen.tsx
@@ -244,6 +244,7 @@ type _PaymentDetailReceivedPayload = {
 }
 type _PaymentsReceivedPayload = {
   readonly accountID: Types.AccountID
+  readonly allowClearOldestUnread: boolean
   readonly paymentCursor: StellarRPCTypes.PageCursor | null
   readonly oldestUnread: Types.PaymentID
   readonly payments: Array<Types.PaymentResult>

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -425,9 +425,10 @@ const loadAssets = (
   }
 }
 
-const createPaymentsReceived = (accountID, payments, pending) =>
+const createPaymentsReceived = (accountID, payments, pending, allowClearOldestUnread) =>
   WalletsGen.createPaymentsReceived({
     accountID,
+    allowClearOldestUnread,
     oldestUnread: payments.oldestUnread
       ? Types.rpcPaymentIDToPaymentID(payments.oldestUnread)
       : Types.noPaymentID,
@@ -462,7 +463,9 @@ const loadPayments = (state, action: LoadPaymentsActions, logger) => {
     Promise.all([
       RPCStellarTypes.localGetPendingPaymentsLocalRpcPromise({accountID: action.payload.accountID}),
       RPCStellarTypes.localGetPaymentsLocalRpcPromise({accountID: action.payload.accountID}),
-    ]).then(([pending, payments]) => createPaymentsReceived(action.payload.accountID, payments, pending))
+    ]).then(([pending, payments]) =>
+      createPaymentsReceived(action.payload.accountID, payments, pending, true)
+    )
   )
 }
 
@@ -475,7 +478,7 @@ const loadMorePayments = (state, action: WalletsGen.LoadMorePaymentsPayload, log
   return (
     cursor &&
     RPCStellarTypes.localGetPaymentsLocalRpcPromise({accountID: action.payload.accountID, cursor}).then(
-      payments => createPaymentsReceived(action.payload.accountID, payments, [])
+      payments => createPaymentsReceived(action.payload.accountID, payments, [], false)
     )
   )
 }

--- a/shared/docs/android/setup.md
+++ b/shared/docs/android/setup.md
@@ -151,7 +151,8 @@ instructions](https://facebook.github.io/react-native/docs/running-on-device.htm
 plug in your device via USB and tap 'OK' on the 'Allow USB debugging?'
 prompt if it appears. After that, `adb devices` should list your
 device. If it says 'unauthorized' next to your device, then you likely
-haven't tapped 'OK' on the prompt yet.
+haven't tapped 'OK' on the prompt yet. If you saw no prompt, try
+revoking (https://stackoverflow.com/a/25546300/670659).
 
 **Turn off Instant Run**
 


### PR DESCRIPTION
The orange line under the latest unread transaction was disappearing whenever the user scrolled to the end of the history page. Or, on Android, when scrolling at all.

The server (via GetPaymentsLocal) erroneously returns an empty oldestUnread value when a non-latest page is requested and oldestUnread points into the latest page. Because the server only considers the page it's returning. Fixing the server would be ideal, but I haven't thought of a way to do that that's comparable to the amount of work to this client-side fix.