### PR TITLE
folder_branch_ops: don't assume offline mode when trying to lock

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -7377,7 +7377,7 @@ func (fbo *folderBranchOps) SyncFromServer(ctx context.Context,
 		timedOut = true
 	default:
 	}
-	if timedOut || !mdserver.IsConnected() {
+	if lockBeforeGet == nil && (timedOut || !mdserver.IsConnected()) {
 		fbo.vlog.CLogf(
 			ctx, libkb.VLog1, "Not fetching new updates while offline")
 		return nil


### PR DESCRIPTION
For offline mode, we put in a quick check in `SyncFromServer()` that bails out early if there's a long timeout trying to reach the mdserver.  However, this function is used for real during git operations, and if `SyncFromServer()` returns `nil`, it's assumed that a lock was taken at the server.  So if a client takes too long in pinging the mdserver and doesn't actually take the lock, the later `Put` to the mdserver will fail.  If this is the first put for initializing a repo, the repo will be left in a weird state where the initial config file was written, but none of the initial git repo files, and future actions will fail.

So instead, just don't test the timeout logic when we're trying to take a lock.

Issue: #18300