### PR TITLE
teams: feature-flagging for hidden chain rotation on a per-team basis

### DIFF
--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -74,6 +74,7 @@ const (
 	FeatureIMPTOFU            = Feature("imptofu")
 	FeatureBoxAuditor         = Feature("box_auditor2")
 	ExperimentalGenericProofs = Feature("experimental_generic_proofs")
+	FeatureAdmin              = Feature("admin")
 )
 
 // NewFeatureFlagSet makes a new set of feature flags.

--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -70,11 +70,11 @@ type FeatureFlagSet struct {
 }
 
 const (
-	FeatureFTL                = Feature("ftl")
-	FeatureIMPTOFU            = Feature("imptofu")
-	FeatureBoxAuditor         = Feature("box_auditor2")
-	ExperimentalGenericProofs = Feature("experimental_generic_proofs")
-	FeatureAdmin              = Feature("admin")
+	FeatureFTL                        = Feature("ftl")
+	FeatureIMPTOFU                    = Feature("imptofu")
+	FeatureBoxAuditor                 = Feature("box_auditor2")
+	ExperimentalGenericProofs         = Feature("experimental_generic_proofs")
+	FeatureCheckForHiddenChainSupport = Feature("check_for_hidden_chain_support")
 )
 
 // NewFeatureFlagSet makes a new set of feature flags.

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -3023,6 +3023,7 @@ type RotationType int
 const (
 	RotationType_VISIBLE RotationType = 0
 	RotationType_HIDDEN  RotationType = 1
+	RotationType_CLKR    RotationType = 2
 )
 
 func (o RotationType) DeepCopy() RotationType { return o }
@@ -3030,11 +3031,13 @@ func (o RotationType) DeepCopy() RotationType { return o }
 var RotationTypeMap = map[string]RotationType{
 	"VISIBLE": 0,
 	"HIDDEN":  1,
+	"CLKR":    2,
 }
 
 var RotationTypeRevMap = map[RotationType]string{
 	0: "VISIBLE",
 	1: "HIDDEN",
+	2: "CLKR",
 }
 
 func (e RotationType) String() string {

--- a/go/teams/hidden/errors.go
+++ b/go/teams/hidden/errors.go
@@ -2,6 +2,7 @@ package hidden
 
 import (
 	"fmt"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type ManagerError struct {
@@ -56,4 +57,16 @@ func (e RatchetError) Error() string {
 
 func newRatchetError(format string, args ...interface{}) RatchetError {
 	return RatchetError{fmt.Sprintf(format, args...)}
+}
+
+type HiddenRotationNotSupportedError struct {
+	teamID keybase1.TeamID
+}
+
+func NewHiddenRotationNotSupportedError(teamID keybase1.TeamID) HiddenRotationNotSupportedError {
+	return HiddenRotationNotSupportedError{teamID: teamID}
+}
+
+func (e HiddenRotationNotSupportedError) Error() string {
+	return fmt.Sprintf("hidden team rotation is not enabled for team %s", e.teamID)
 }

--- a/go/teams/hidden/hidden.go
+++ b/go/teams/hidden/hidden.go
@@ -269,7 +269,7 @@ func featureGateForTeamFromServer(mctx libkb.MetaContext, teamID keybase1.TeamID
 }
 
 func checkFeatureGateForSupport(mctx libkb.MetaContext, teamID keybase1.TeamID, isWrite bool) (ok bool, err error) {
-	admin := mctx.G().FeatureFlags.Enabled(mctx, libkb.FeatureAdmin)
+	admin := mctx.G().FeatureFlags.Enabled(mctx, libkb.FeatureCheckForHiddenChainSupport)
 	runmode := mctx.G().Env.GetRunMode()
 	if runmode != libkb.ProductionRunMode {
 		return true, nil

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -485,11 +485,9 @@ func (t *Team) rotate(ctx context.Context, rt keybase1.RotationType) (err error)
 	mctx := t.MetaContext(ctx).WithLogTag("ROT")
 	defer mctx.Trace(fmt.Sprintf("Team#rotate(%s,%s)", t.ID, rt), func() error { return err })()
 
-	if rt == keybase1.RotationType_HIDDEN {
-		err = hidden.CheckFeatureGateForSupport(mctx, t.ID, true /* isWrite */)
-		if err != nil {
-			return err
-		}
+	rt, err = hidden.CheckFeatureGateForSupportWithRotationType(mctx, t.ID, true /* isWrite */, rt)
+	if err != nil {
+		return err
 	}
 
 	// initialize key manager

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1266,7 +1266,8 @@ protocol teams {
 
   enum RotationType {
     VISIBLE_0,
-    HIDDEN_1
+    HIDDEN_1,
+    CLKR_2
   }
 
   void teamRotateKey(TeamID teamID, RotationType rt);

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2711,7 +2711,8 @@
       "name": "RotationType",
       "symbols": [
         "VISIBLE_0",
-        "HIDDEN_1"
+        "HIDDEN_1",
+        "CLKR_2"
       ]
     },
     {

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1805,6 +1805,7 @@ export enum RevisionSpanType {
 export enum RotationType {
   visible = 0,
   hidden = 1,
+  clkr = 2,
 }
 
 export enum RuntimeGroup {


### PR DESCRIPTION
- for now, don't hook CLKR into this, we'll be doing that in future PRs (since tests don't currently pass)
- if an admin on prod, hit the server and ask if we can use hidden links for this team