### PR TITLE
Support ephemeral.teambot_ek_needed notification 

### DIFF
--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -97,6 +97,11 @@ func newEKMissingBoxErr(mctx libkb.MetaContext, boxType EKType, boxGeneration ke
 	return newEphemeralKeyError(debugMsg, "")
 }
 
+func newTeambotEKWrongKIDErr(mctx libkb.MetaContext, ctime, now keybase1.Time) EphemeralKeyError {
+	debugMsg := fmt.Sprintf("Wrong KID for %v, first seen at %v, now %v", TeambotEKStr, ctime.Time(), now.Time())
+	return newEphemeralKeyError(debugMsg, "")
+}
+
 func newEKCorruptedErr(mctx libkb.MetaContext, boxType EKType,
 	expectedGeneration, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
 	debugMsg := fmt.Sprintf("Storage error for %s@generation:%v, got generation %v instead", boxType, boxGeneration, expectedGeneration)

--- a/go/ephemeral/handler.go
+++ b/go/ephemeral/handler.go
@@ -24,3 +24,34 @@ func HandleNewTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID, generati
 	mctx.G().NotifyRouter.HandleNewTeambotEK(mctx.Ctx(), teamID, generation)
 	return nil
 }
+
+// HandleTeambotEKNeeded forces a teambot ek to be generated since the bot does
+// not have access. All team members are notified and race to publish the
+// requested key.
+func HandleTeambotEKNeeded(mctx libkb.MetaContext, teamID keybase1.TeamID, botUID keybase1.UID,
+	generation keybase1.EkGeneration) (err error) {
+	defer mctx.TraceTimed("HandleTeambotEKNeeded", func() error { return err })()
+	defer func() {
+		if err == nil {
+			mctx.G().NotifyRouter.HandleTeambotEKNeeded(mctx.Ctx(), teamID, botUID, generation)
+		}
+	}()
+
+	if ekLib := mctx.G().GetEKLib(); ekLib != nil {
+		// Bot user needs the latest key
+		if generation == 0 {
+			// clear our caches here so we can force publish a key
+			ekLib.PurgeTeamEKCachesForTeamID(mctx, teamID)
+			ekLib.PurgeAllTeambotMetadataCaches(mctx)
+			_, _, err = ekLib.GetOrCreateLatestTeambotEK(mctx, teamID, botUID.ToBytes())
+			return err
+		}
+
+		// Bot needs a specific generation
+		ekLib.PurgeTeamEKCachesForTeamIDAndGeneration(mctx, teamID, generation)
+		ekLib.PurgeTeambotMetadataCache(mctx, teamID, botUID, generation)
+		_, err = ekLib.GetTeambotEK(mctx, teamID, botUID.ToBytes(), generation, nil)
+		return err
+	}
+	return nil
+}

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -471,11 +471,14 @@ func (e *EKLib) PurgeTeambotEKCachesForTeamIDAndGeneration(mctx libkb.MetaContex
 }
 
 func (e *EKLib) PurgeAllTeambotMetadataCaches(mctx libkb.MetaContext) {
+	mctx.Debug("PurgeAllTeambotMetadataCaches")
 	e.teambotEKMetadataCache.Purge()
 }
 
 func (e *EKLib) PurgeTeambotMetadataCache(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	botUID keybase1.UID, generation keybase1.EkGeneration) {
+	mctx.Debug("PurgeTeambotMetadataCache: teamID: %v, botUID: %v generation: %v",
+		teamID, botUID, generation)
 	cacheKey := e.teambotCacheKey(teamID, botUID, generation)
 	e.teambotEKMetadataCache.Remove(cacheKey)
 }

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -118,7 +118,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	ekLib := NewEKLib(mctx)
 	defer ekLib.Shutdown()
 	fc := clockwork.NewFakeClockAt(time.Now())
-	ekLib.setClock(fc)
+	ekLib.SetClock(fc)
 	deviceEKStorage := tc.G.GetDeviceEKStorage()
 	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
 	teamEKBoxStorage := tc.G.GetTeamEKBoxStorage()
@@ -292,13 +292,13 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	}
 
 	// First we ensure that we don't do background generation for expired teamEKs.
-	fc.Advance(cacheEntryLifetime) // expire our cache
+	fc.Advance(LibCacheEntryLifetime) // expire our cache
 	forceEKCtime(expectedTeamEKGen, -libkb.EphemeralKeyGenInterval)
 	expectedTeamEKGen++
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, true /*created*/, false /* teamEKCreationInProgress */)
 
 	// If we are *almost* expired, background generation is possible.
-	fc.Advance(cacheEntryLifetime) // expire our cache
+	fc.Advance(LibCacheEntryLifetime) // expire our cache
 	forceEKCtime(expectedTeamEKGen, -libkb.EphemeralKeyGenInterval+30*time.Minute)
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /*created*/, true /* teamEKCreationInProgress */)
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /*created*/, true /* teamEKCreationInProgress */)

--- a/go/ephemeral/teambot_ek.go
+++ b/go/ephemeral/teambot_ek.go
@@ -363,11 +363,12 @@ func (*TeambotEphemeralKeyer) Fetch(mctx libkb.MetaContext, teamID keybase1.Team
 func notifyTeambotEKNeeded(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (err error) {
 	defer mctx.TraceTimed("notifyTeambotEKNeeded", func() error { return err })()
 	apiArg := libkb.APIArg{
-		Endpoint:    "teambot/ek_needed",
+		Endpoint:    "teambot/key_needed",
 		SessionType: libkb.APISessionTypeREQUIRED,
 		Args: libkb.HTTPArgs{
-			"team_id":    libkb.S{Val: string(teamID)},
-			"generation": libkb.U{Val: uint64(generation)},
+			"team_id":      libkb.S{Val: string(teamID)},
+			"generation":   libkb.U{Val: uint64(generation)},
+			"is_ephemeral": libkb.B{Val: true},
 		},
 	}
 	_, err = mctx.G().GetAPI().Post(mctx, apiArg)

--- a/go/ephemeral/teambot_ek.go
+++ b/go/ephemeral/teambot_ek.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/keybase/client/go/kbcrypto"
 	"github.com/keybase/client/go/libkb"
@@ -158,7 +159,7 @@ type teambotEKResp struct {
 	} `json:"result"`
 }
 
-func fetchLatestTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID) (metadata *keybase1.TeambotEkMetadata, err error) {
+func fetchLatestTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID) (metadata *keybase1.TeambotEkMetadata, wrongKID bool, err error) {
 	defer mctx.TraceTimed("fetchLatestTeambotEK", func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -171,15 +172,15 @@ func fetchLatestTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID) (metad
 	}
 	res, err := mctx.G().GetAPI().Get(mctx, apiArg)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	parsedResponse := teambotEKResp{}
 	if err = res.Body.UnmarshalAgain(&parsedResponse); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if parsedResponse.Result == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	return verifyTeambotSigWithLatestPTK(mctx, teamID, parsedResponse.Result.Sig)
@@ -200,19 +201,20 @@ func extractTeambotEKMetadataFromSig(sig string) (*kbcrypto.NaclSigningKeyPublic
 
 // Verify that the blob is validly signed, and that the signing key is the
 // given team's latest PTK, then parse its contents.
-func verifyTeambotSigWithLatestPTK(mctx libkb.MetaContext, teamID keybase1.TeamID, sig string) (metadata *keybase1.TeambotEkMetadata, err error) {
+func verifyTeambotSigWithLatestPTK(mctx libkb.MetaContext, teamID keybase1.TeamID, sig string) (
+	metadata *keybase1.TeambotEkMetadata, wrongKID bool, err error) {
 	defer mctx.TraceTimed("verifyTeambotSigWithLatestPTK", func() error { return err })()
 
 	signerKey, metadata, err := extractTeambotEKMetadataFromSig(sig)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
 		ID: teamID,
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// Verify the signing key corresponds to the latest PTK. We load the team's
@@ -221,7 +223,7 @@ func verifyTeambotSigWithLatestPTK(mctx libkb.MetaContext, teamID keybase1.TeamI
 	// after the reload do we complain.
 	teamSigningKID, err := team.SigningKID(mctx.Ctx())
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if !teamSigningKID.Equal(signerKey.GetKID()) {
 		// The latest PTK might be stale. Force a reload, then check this over again.
@@ -230,20 +232,21 @@ func verifyTeambotSigWithLatestPTK(mctx libkb.MetaContext, teamID keybase1.TeamI
 			ForceRepoll: true,
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		teamSigningKID, err = team.SigningKID(mctx.Ctx())
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		// return the metdata with wrongKID=true
 		if !teamSigningKID.Equal(signerKey.GetKID()) {
-			return nil, fmt.Errorf("teambotEK returned for PTK signing KID %s, but latest is %s",
+			return metadata, true, fmt.Errorf("teambotEK returned for PTK signing KID %s, but latest is %s",
 				signerKey.GetKID(), teamSigningKID)
 		}
 	}
 
 	// If we didn't short circuit above, then the signing key is correct.
-	return metadata, nil
+	return metadata, false, nil
 }
 
 func (k *TeambotEphemeralKeyer) Unbox(mctx libkb.MetaContext, boxed keybase1.TeamEphemeralKeyBoxed,
@@ -337,8 +340,8 @@ func (*TeambotEphemeralKeyer) Fetch(mctx libkb.MetaContext, teamID keybase1.Team
 	// was signed with a PTK that is not our latest and greatest. We allow this
 	// when we are using this ek for *decryption*. When getting a key for
 	// *encryption* callers are responsible for verifying the signature is
-	// signed by the latest PTK or generating a new EK. (TODO) This logic currently
-	// lives in ephemeral/lib.go#GetOrCreateLatestTeamEK (#newTeamEKNeeded)
+	// signed by the latest PTK or generating a new EK. This logic currently
+	// lives in ephemeral/lib.go#getLatestTeambotEK
 	_, metadata, err := extractTeambotEKMetadataFromSig(resp.Result.Sig)
 	if err != nil {
 		return teambotEK, err
@@ -355,4 +358,51 @@ func (*TeambotEphemeralKeyer) Fetch(mctx libkb.MetaContext, teamID keybase1.Team
 		Metadata: *metadata,
 	}
 	return keybase1.NewTeamEphemeralKeyBoxedWithTeambot(teambotEKBoxed), nil
+}
+
+func notifyTeambotEKNeeded(mctx libkb.MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration) (err error) {
+	defer mctx.TraceTimed("notifyTeambotEKNeeded", func() error { return err })()
+	apiArg := libkb.APIArg{
+		Endpoint:    "teambot/ek_needed",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		Args: libkb.HTTPArgs{
+			"team_id":    libkb.S{Val: string(teamID)},
+			"generation": libkb.U{Val: uint64(generation)},
+		},
+	}
+	_, err = mctx.G().GetAPI().Post(mctx, apiArg)
+	return err
+}
+
+const teambotEKWrongKIDDBVersion = 1
+const MaxTeambotEKWrongKIDPermitted = time.Hour * 24
+
+func TeambotEKWrongKIDCacheKey(teamID keybase1.TeamID, botUID keybase1.UID,
+	generation keybase1.EkGeneration) libkb.DbKey {
+	key := fmt.Sprintf("teambotWrongKID-%s-%s-%d-%d", teamID, botUID,
+		generation, teambotEKWrongKIDDBVersion)
+	return libkb.DbKey{
+		Typ: libkb.DBTeambotEKWrongKID,
+		Key: key,
+	}
+}
+
+// teambotWrongKIDPermitted checks if we can use a teambotEK which is signed by
+// an old PTK. Since bot members cannot create a new teambot EK, we allow old
+// teambotEKs to be used for a short window, allowing a member to generate a
+// new key signed by the latest PTK.
+func TeambotWrongKIDPermitted(mctx libkb.MetaContext, teamID keybase1.TeamID,
+	botUID keybase1.UID, generation keybase1.EkGeneration, now keybase1.Time) (bool, keybase1.Time, error) {
+	key := TeambotEKWrongKIDCacheKey(teamID, botUID, generation)
+	var ctime keybase1.Time
+	found, err := mctx.G().GetKVStore().GetInto(&ctime, key)
+	if err != nil {
+		return false, 0, err
+	}
+	if !found {
+		// Store when we first noticed wrongKID was set.
+		err = mctx.G().GetKVStore().PutObj(key, nil, now)
+		return true, 0, err
+	}
+	return now.Time().Sub(ctime.Time()) < MaxTeambotEKWrongKIDPermitted, ctime, nil
 }

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -117,8 +117,8 @@ func IsPermDbKey(typ ObjType) bool {
 		DBChatIndex,
 		DBBoxAuditorPermanent,
 		DBSavedContacts,
-		DBContactResolution:
-	DBTeambotEKWrongKID:
+		DBContactResolution,
+		DBTeambotEKWrongKID:
 		return true
 	default:
 		return false

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -21,6 +21,7 @@ const (
 	DBTeamChain         = 0x10
 	DBUserPlusAllKeysV1 = 0x19
 
+	DBTeambotEKWrongKID              = 0xb5
 	DBChatBotCommands                = 0xb6
 	DBSavedContacts                  = 0xb7
 	DBChatLocation                   = 0xb8
@@ -102,7 +103,7 @@ func DbKeyNotificationDismiss(prefix string, username NormalizedUsername) DbKey 
 }
 
 // IsPermDbKey returns true for keys ignored by the leveldb cleaner and always
-// persisted to disk.  Ideally these keys handling some cleanup/size bounding
+// persisted to disk. Ideally these keys handling some cleanup/size bounding
 // themselves.
 func IsPermDbKey(typ ObjType) bool {
 	switch typ {
@@ -117,6 +118,7 @@ func IsPermDbKey(typ ObjType) bool {
 		DBBoxAuditorPermanent,
 		DBSavedContacts,
 		DBContactResolution:
+	DBTeambotEKWrongKID:
 		return true
 	default:
 		return false

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -847,6 +847,8 @@ type EKLib interface {
 	GetTeambotEK(mctx MetaContext, teamID keybase1.TeamID, botUID gregor1.UID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEphemeralKey, error)
 	PurgeTeambotEKCachesForTeamIDAndGeneration(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration)
 	PurgeTeambotEKCachesForTeamID(mctx MetaContext, teamID keybase1.TeamID)
+	PurgeAllTeambotMetadataCaches(mctx MetaContext)
+	PurgeTeambotMetadataCache(mctx MetaContext, teamID keybase1.TeamID, botUID keybase1.UID, generation keybase1.EkGeneration)
 
 	NewEphemeralSeed() (keybase1.Bytes32, error)
 	DeriveDeviceDHKey(seed keybase1.Bytes32) *NaclDHKeyPair

--- a/go/protocol/keybase1/notify_ephemeral.go
+++ b/go/protocol/keybase1/notify_ephemeral.go
@@ -18,9 +18,16 @@ type NewTeambotEkArg struct {
 	Generation EkGeneration `codec:"generation" json:"generation"`
 }
 
+type TeambotEkNeededArg struct {
+	Id         TeamID       `codec:"id" json:"id"`
+	Uid        UID          `codec:"uid" json:"uid"`
+	Generation EkGeneration `codec:"generation" json:"generation"`
+}
+
 type NotifyEphemeralInterface interface {
 	NewTeamEk(context.Context, NewTeamEkArg) error
 	NewTeambotEk(context.Context, NewTeambotEkArg) error
+	TeambotEkNeeded(context.Context, TeambotEkNeededArg) error
 }
 
 func NotifyEphemeralProtocol(i NotifyEphemeralInterface) rpc.Protocol {
@@ -57,6 +64,21 @@ func NotifyEphemeralProtocol(i NotifyEphemeralInterface) rpc.Protocol {
 					return
 				},
 			},
+			"teambotEkNeeded": {
+				MakeArg: func() interface{} {
+					var ret [1]TeambotEkNeededArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]TeambotEkNeededArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]TeambotEkNeededArg)(nil), args)
+						return
+					}
+					err = i.TeambotEkNeeded(ctx, typedArgs[0])
+					return
+				},
+			},
 		},
 	}
 }
@@ -72,5 +94,10 @@ func (c NotifyEphemeralClient) NewTeamEk(ctx context.Context, __arg NewTeamEkArg
 
 func (c NotifyEphemeralClient) NewTeambotEk(ctx context.Context, __arg NewTeambotEkArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.NotifyEphemeral.newTeambotEk", []interface{}{__arg}, nil)
+	return
+}
+
+func (c NotifyEphemeralClient) TeambotEkNeeded(ctx context.Context, __arg TeambotEkNeededArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.NotifyEphemeral.teambotEkNeeded", []interface{}{__arg}, nil)
 	return
 }

--- a/go/service/ephemeral_handler.go
+++ b/go/service/ephemeral_handler.go
@@ -93,18 +93,18 @@ func (r *ekHandler) newTeambotEK(ctx context.Context, cli gregor1.IncomingInterf
 }
 
 func (r *ekHandler) teambotEKNeeded(ctx context.Context, cli gregor1.IncomingInterface, item gregor.Item) error {
-	r.G().Log.CDebugf(ctx, "ekHandler: ephemeral.teambot_ek_needed received")
+	r.G().Log.CDebugf(ctx, "ekHandler: ephemeral.teambot_key_needed received")
 	var msg keybase1.TeambotEkNeededArg
 	if err := json.Unmarshal(item.Body().Bytes(), &msg); err != nil {
-		r.G().Log.CDebugf(ctx, "error unmarshaling ephemeral.teambot_ek_needed item: %s", err)
+		r.G().Log.CDebugf(ctx, "error unmarshaling ephemeral.teambot_key_needed item: %s", err)
 		return err
 	}
-	r.G().Log.CDebugf(ctx, "ephemeral.teambot_ek_needed unmarshaled: %+v", msg)
+	r.G().Log.CDebugf(ctx, "ephemeral.teambot_key_needed unmarshaled: %+v", msg)
 
 	if err := ephemeral.HandleTeambotEKNeeded(r.MetaContext(ctx), msg.Id, msg.Uid, msg.Generation); err != nil {
 		return err
 	}
 
-	r.G().Log.CDebugf(ctx, "dismissing ephemeral.teambot_ek_needed item since action succeeded")
+	r.G().Log.CDebugf(ctx, "dismissing ephemeral.teambot_key_needed item since action succeeded")
 	return r.G().GregorState.DismissItem(ctx, cli, item.Metadata().MsgID())
 }

--- a/go/service/ephemeral_handler.go
+++ b/go/service/ephemeral_handler.go
@@ -36,7 +36,7 @@ func (r *ekHandler) Create(ctx context.Context, cli gregor1.IncomingInterface, c
 		return true, r.newTeamEK(ctx, cli, item)
 	case "ephemeral.new_teambot_key":
 		return true, r.newTeambotEK(ctx, cli, item)
-	case "ephemeral.teambot_ek_needed":
+	case "ephemeral.teambot_key_needed":
 		return true, r.teambotEKNeeded(ctx, cli, item)
 	default:
 		if strings.HasPrefix(category, "ephemeral.") {

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -135,6 +135,10 @@ func TestEphemeralTeambotEK(t *testing.T) {
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 	user1.addTeamMember(teamName.String(), botua.username, keybase1.TeamRole_BOT)
 
+	// grab the latest teamEK and make sure the generation lines up with the teambotEK
+	teamEK, _, err := ekLib1.GetOrCreateLatestTeamEK(mctx1, teamID)
+	require.NoError(t, err)
+
 	// initial get, bot has no key to access
 	_, created, err := ekLib3.GetOrCreateLatestTeambotEK(mctx3, teamID, botuaUID)
 	require.Error(t, err)
@@ -156,10 +160,6 @@ func TestEphemeralTeambotEK(t *testing.T) {
 		Generation: 1,
 	}
 	checkNewTeambotEKNotifications(botua.tc, botua.notifications, newEkArg)
-
-	// grab the latest teamEK and make sure the generation lines up with the teambotEK
-	teamEK, _, err := ekLib1.GetOrCreateLatestTeamEK(mctx1, teamID)
-	require.NoError(t, err)
 
 	// now created = false since we published after receiving the teambot_key_needed notif
 	teambotEK, created, err := ekLib1.GetOrCreateLatestTeambotEK(mctx1, teamID, botuaUID)

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -161,7 +161,7 @@ func TestEphemeralTeambotEK(t *testing.T) {
 	teamEK, _, err := ekLib1.GetOrCreateLatestTeamEK(mctx1, teamID)
 	require.NoError(t, err)
 
-	// now created = false since we published after receiving the teambot_ek_needed notif
+	// now created = false since we published after receiving the teambot_key_needed notif
 	teambotEK, created, err := ekLib1.GetOrCreateLatestTeambotEK(mctx1, teamID, botuaUID)
 	require.NoError(t, err)
 	require.False(t, created)
@@ -218,12 +218,16 @@ func TestEphemeralTeambotEK(t *testing.T) {
 	teambotEK3, created, err := ekLib3.GetOrCreateLatestTeambotEK(mctx3, teamID, botuaUID)
 	require.NoError(t, err)
 	require.False(t, created)
+	noTeambotEKNeeded(user1.tc, user1.notifications)
+	noTeambotEKNeeded(user2.tc, user2.notifications)
+	noNewTeambotEKNotification(botua.tc, botua.notifications)
 
 	// another PTK rotation happens, this time the bot proceeded with a key
 	// signed by the old PTK since the wrongKID cache did not expire
 	user1.removeTeamMember(teamName.String(), user2.username)
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 	user2.waitForNewlyAddedToTeamByID(teamID)
+	botua.waitForNewlyAddedToTeamByID(teamID)
 
 	// bot can access the old teambotEK, but asks for a new one to
 	// be created since it was signed by the old PTK

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1024,22 +1024,24 @@ func GetTeamForTestByID(ctx context.Context, g *libkb.GlobalContext, id keybase1
 }
 
 type teamNotifyHandler struct {
-	changeCh         chan keybase1.TeamChangedByIDArg
-	abandonCh        chan keybase1.TeamID
-	badgeCh          chan keybase1.BadgeState
-	newTeamEKCh      chan keybase1.NewTeamEkArg
-	newTeambotEKCh   chan keybase1.NewTeambotEkArg
-	newlyAddedToTeam chan keybase1.TeamID
+	changeCh          chan keybase1.TeamChangedByIDArg
+	abandonCh         chan keybase1.TeamID
+	badgeCh           chan keybase1.BadgeState
+	newTeamEKCh       chan keybase1.NewTeamEkArg
+	newTeambotEKCh    chan keybase1.NewTeambotEkArg
+	teambotEKNeededCh chan keybase1.TeambotEkNeededArg
+	newlyAddedToTeam  chan keybase1.TeamID
 }
 
 func newTeamNotifyHandler() *teamNotifyHandler {
 	return &teamNotifyHandler{
-		changeCh:         make(chan keybase1.TeamChangedByIDArg, 10),
-		abandonCh:        make(chan keybase1.TeamID, 10),
-		badgeCh:          make(chan keybase1.BadgeState, 10),
-		newTeamEKCh:      make(chan keybase1.NewTeamEkArg, 10),
-		newTeambotEKCh:   make(chan keybase1.NewTeambotEkArg, 10),
-		newlyAddedToTeam: make(chan keybase1.TeamID, 10),
+		changeCh:          make(chan keybase1.TeamChangedByIDArg, 10),
+		abandonCh:         make(chan keybase1.TeamID, 10),
+		badgeCh:           make(chan keybase1.BadgeState, 10),
+		newTeamEKCh:       make(chan keybase1.NewTeamEkArg, 10),
+		newTeambotEKCh:    make(chan keybase1.NewTeambotEkArg, 10),
+		teambotEKNeededCh: make(chan keybase1.TeambotEkNeededArg, 10),
+		newlyAddedToTeam:  make(chan keybase1.TeamID, 10),
 	}
 }
 
@@ -1082,6 +1084,11 @@ func (n *teamNotifyHandler) NewTeamEk(ctx context.Context, arg keybase1.NewTeamE
 
 func (n *teamNotifyHandler) NewTeambotEk(ctx context.Context, arg keybase1.NewTeambotEkArg) error {
 	n.newTeambotEKCh <- arg
+	return nil
+}
+
+func (n *teamNotifyHandler) TeambotEkNeeded(ctx context.Context, arg keybase1.TeambotEkNeededArg) error {
+	n.teambotEKNeededCh <- arg
 	return nil
 }
 

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -459,7 +459,7 @@ func (u *userPlusDevice) readInviteEmails(email string) []string {
 		u.tc.T.Fatal(err)
 	}
 	if n == 0 {
-		u.tc.T.Fatalf("no invite tokens for %s", email)
+		require.Fail(u.tc.T, fmt.Sprintf("no invite tokens for %s", email))
 	}
 
 	exp := make([]string, n)
@@ -555,7 +555,7 @@ func (u *userPlusDevice) waitForTeamChangedGregor(teamID keybase1.TeamID, toSeqn
 		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
-	u.tc.T.Fatalf("timed out waiting for team rotate %s", teamID)
+	require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team rotate %s", teamID))
 }
 
 func (u *userPlusDevice) waitForBadgeStateWithReset(numReset int) keybase1.BadgeState {
@@ -615,7 +615,7 @@ func (u *userPlusDevice) waitForAnyRotateByID(teamID keybase1.TeamID, toSeqno ke
 		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
-	u.tc.T.Fatalf("timed out waiting for team rotate %s", teamID)
+	require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team rotate %s", teamID))
 }
 
 func (u *userPlusDevice) waitForTeamChangedAndRotated(teamID keybase1.TeamID, toSeqno keybase1.Seqno) {
@@ -632,7 +632,7 @@ func (u *userPlusDevice) waitForTeamChangedAndRotated(teamID keybase1.TeamID, to
 		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
 		}
 	}
-	u.tc.T.Fatalf("timed out waiting for team rotate %s", teamID)
+	require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team rotate %s", teamID))
 }
 
 func (u *userPlusDevice) waitForTeamChangeRenamed(teamID keybase1.TeamID) {
@@ -685,7 +685,7 @@ func (u *userPlusDevice) pollForTeamSeqnoLink(team string, toSeqno keybase1.Seqn
 			ForceRepoll: true,
 		})
 		if err != nil {
-			u.tc.T.Fatalf("error while loading team %q: %v", team, err)
+			require.Fail(u.tc.T, fmt.Sprintf("error while loading team %q: %v", team, err))
 		}
 
 		if after.CurrentSeqno() >= toSeqno {
@@ -696,7 +696,7 @@ func (u *userPlusDevice) pollForTeamSeqnoLink(team string, toSeqno keybase1.Seqn
 		time.Sleep(500 * time.Millisecond * libkb.CITimeMultiplier(u.tc.G))
 	}
 
-	u.tc.T.Fatalf("timed out waiting for team rotate %s", team)
+	require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team rotate %s", team))
 }
 
 func (u *userPlusDevice) pollForTeamSeqnoLinkWithLoadArgs(args keybase1.LoadTeamArg, toSeqno keybase1.Seqno) {
@@ -704,7 +704,7 @@ func (u *userPlusDevice) pollForTeamSeqnoLinkWithLoadArgs(args keybase1.LoadTeam
 	for i := 0; i < 20; i++ {
 		details, err := teams.Load(context.Background(), u.tc.G, args)
 		if err != nil {
-			u.tc.T.Fatalf("error while loading team %v: %v", args, err)
+			require.Fail(u.tc.T, fmt.Sprintf("error while loading team %v: %v", args, err))
 		}
 
 		if details.CurrentSeqno() >= toSeqno {
@@ -715,7 +715,7 @@ func (u *userPlusDevice) pollForTeamSeqnoLinkWithLoadArgs(args keybase1.LoadTeam
 		time.Sleep(500 * time.Millisecond * libkb.CITimeMultiplier(u.tc.G))
 	}
 
-	u.tc.T.Fatalf("timed out waiting for team %v seqno link %d", args, toSeqno)
+	require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team %v seqno link %d", args, toSeqno))
 }
 
 func (u *userPlusDevice) proveRooter() {

--- a/go/teams/ftl.go
+++ b/go/teams/ftl.go
@@ -1290,16 +1290,20 @@ func makeState(arg fastLoadArg, s *keybase1.FastTeamData) *keybase1.FastTeamData
 func (f *FastTeamChainLoader) hiddenPackage(m libkb.MetaContext, arg fastLoadArg, state *keybase1.FastTeamData) (hp *hidden.LoaderPackage, err error) {
 	defer m.Trace(fmt.Sprintf("FastTeamChainLoader#hiddenPackage(%+v)", arg), func() error { return err })()
 	return hidden.NewLoaderPackage(m, arg.ID,
-		func() (encKID keybase1.KID, gen keybase1.PerTeamKeyGeneration, err error) {
+		func() (encKID keybase1.KID, gen keybase1.PerTeamKeyGeneration, role keybase1.TeamRole, err error) {
+			// Always return TeamRole_NONE since ftl does not have access to
+			// member roles. The hidden chain uses the role to skip checks bot
+			// members are not able to perform. Bot members should never FTL,
+			// however since they don't have key access.
 			if state == nil || len(state.Chain.PerTeamKeys) == 0 {
-				return encKID, gen, nil
+				return encKID, gen, keybase1.TeamRole_NONE, nil
 			}
 			var ptk keybase1.PerTeamKey
 			for _, tmp := range state.Chain.PerTeamKeys {
 				ptk = tmp
 				break
 			}
-			return ptk.EncKID, ptk.Gen, nil
+			return ptk.EncKID, ptk.Gen, keybase1.TeamRole_NONE, nil
 		})
 }
 

--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -344,7 +344,6 @@ func checkUpdateAgainstSeed(mctx libkb.MetaContext, getSeed func(keybase1.PerTea
 	gen := readerKey.Ptk.Gen
 	check := getSeed(gen)
 	if check == nil {
-		//		return nil
 		return NewLoaderError("seed check at generation %d wasn't found", gen)
 	}
 	hash, err := check.Hash()

--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -2,6 +2,7 @@ package hidden
 
 import (
 	"fmt"
+
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/sig3"
@@ -343,6 +344,7 @@ func checkUpdateAgainstSeed(mctx libkb.MetaContext, getSeed func(keybase1.PerTea
 	gen := readerKey.Ptk.Gen
 	check := getSeed(gen)
 	if check == nil {
+		//		return nil
 		return NewLoaderError("seed check at generation %d wasn't found", gen)
 	}
 	hash, err := check.Hash()

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -527,7 +527,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		cachedName = &ret.Name
 	}
 
-	hiddenPackage, err := l.hiddenPackage(mctx, arg.teamID, ret)
+	hiddenPackage, err := l.hiddenPackage(mctx, arg.teamID, ret, arg.me)
 	if err != nil {
 		return nil, err
 	}
@@ -912,17 +912,24 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	return &load2res, nil
 }
 
-func (l *TeamLoader) hiddenPackage(mctx libkb.MetaContext, id keybase1.TeamID, team *keybase1.TeamData) (ret *hidden.LoaderPackage, err error) {
+func (l *TeamLoader) hiddenPackage(mctx libkb.MetaContext, id keybase1.TeamID, team *keybase1.TeamData, me keybase1.UserVersion) (ret *hidden.LoaderPackage, err error) {
 	return hidden.NewLoaderPackage(mctx, id,
-		func() (encKID keybase1.KID, gen keybase1.PerTeamKeyGeneration, err error) {
+		func() (encKID keybase1.KID, gen keybase1.PerTeamKeyGeneration,
+			role keybase1.TeamRole, err error) {
 			if team == nil {
-				return encKID, gen, nil
+				return encKID, gen, keybase1.TeamRole_NONE, nil
 			}
-			ptk, err := TeamSigChainState{inner: team.Chain}.GetLatestPerTeamKey(mctx)
+			state := TeamSigChainState{inner: team.Chain}
+
+			ptk, err := state.GetLatestPerTeamKey(mctx)
 			if err != nil {
-				return encKID, gen, err
+				return encKID, gen, keybase1.TeamRole_NONE, err
 			}
-			return ptk.EncKID, ptk.Gen, nil
+			role, err = state.GetUserRole(me)
+			if err != nil {
+				return encKID, gen, keybase1.TeamRole_NONE, err
+			}
+			return ptk.EncKID, ptk.Gen, role, nil
 		})
 }
 

--- a/protocol/avdl/keybase1/notify_ephemeral.avdl
+++ b/protocol/avdl/keybase1/notify_ephemeral.avdl
@@ -5,4 +5,5 @@ protocol NotifyEphemeral {
   @notify("")
   void newTeamEk(TeamID id, EkGeneration generation);
   void newTeambotEk(TeamID id, EkGeneration generation);
+  void teambotEkNeeded(TeamID id, UID uid, EkGeneration generation);
 }

--- a/protocol/json/keybase1/notify_ephemeral.json
+++ b/protocol/json/keybase1/notify_ephemeral.json
@@ -34,6 +34,23 @@
         }
       ],
       "response": null
+    },
+    "teambotEkNeeded": {
+      "request": [
+        {
+          "name": "id",
+          "type": "TeamID"
+        },
+        {
+          "name": "uid",
+          "type": "UID"
+        },
+        {
+          "name": "generation",
+          "type": "EkGeneration"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/shared/actions/engine-gen-gen.tsx
+++ b/shared/actions/engine-gen-gen.tsx
@@ -124,6 +124,7 @@ export const keybase1NotifyEmailAddressEmailAddressVerified =
 export const keybase1NotifyEmailAddressEmailsChanged = 'engine-gen:keybase1NotifyEmailAddressEmailsChanged'
 export const keybase1NotifyEphemeralNewTeamEk = 'engine-gen:keybase1NotifyEphemeralNewTeamEk'
 export const keybase1NotifyEphemeralNewTeambotEk = 'engine-gen:keybase1NotifyEphemeralNewTeambotEk'
+export const keybase1NotifyEphemeralTeambotEkNeeded = 'engine-gen:keybase1NotifyEphemeralTeambotEkNeeded'
 export const keybase1NotifyFSFSActivity = 'engine-gen:keybase1NotifyFSFSActivity'
 export const keybase1NotifyFSFSEditListResponse = 'engine-gen:keybase1NotifyFSFSEditListResponse'
 export const keybase1NotifyFSFSFavoritesChanged = 'engine-gen:keybase1NotifyFSFSFavoritesChanged'
@@ -1055,6 +1056,17 @@ type _Keybase1NotifyEphemeralNewTeambotEkPayload = {
   response: {
     error: keybase1Types.IncomingErrorCallback
     result: (param: keybase1Types.MessageTypes['keybase.1.NotifyEphemeral.newTeambotEk']['outParam']) => void
+  }
+}
+type _Keybase1NotifyEphemeralTeambotEkNeededPayload = {
+  readonly params: keybase1Types.MessageTypes['keybase.1.NotifyEphemeral.teambotEkNeeded']['inParam'] & {
+    sessionID: number
+  }
+  response: {
+    error: keybase1Types.IncomingErrorCallback
+    result: (
+      param: keybase1Types.MessageTypes['keybase.1.NotifyEphemeral.teambotEkNeeded']['outParam']
+    ) => void
   }
 }
 type _Keybase1NotifyFSFSActivityPayload = {
@@ -2081,6 +2093,9 @@ export const createKeybase1NotifyEphemeralNewTeamEk = (
 export const createKeybase1NotifyEphemeralNewTeambotEk = (
   payload: _Keybase1NotifyEphemeralNewTeambotEkPayload
 ): Keybase1NotifyEphemeralNewTeambotEkPayload => ({payload, type: keybase1NotifyEphemeralNewTeambotEk})
+export const createKeybase1NotifyEphemeralTeambotEkNeeded = (
+  payload: _Keybase1NotifyEphemeralTeambotEkNeededPayload
+): Keybase1NotifyEphemeralTeambotEkNeededPayload => ({payload, type: keybase1NotifyEphemeralTeambotEkNeeded})
 export const createKeybase1NotifyFSFSActivity = (
   payload: _Keybase1NotifyFSFSActivityPayload
 ): Keybase1NotifyFSFSActivityPayload => ({payload, type: keybase1NotifyFSFSActivity})
@@ -2791,6 +2806,10 @@ export type Keybase1NotifyEphemeralNewTeambotEkPayload = {
   readonly payload: _Keybase1NotifyEphemeralNewTeambotEkPayload
   readonly type: typeof keybase1NotifyEphemeralNewTeambotEk
 }
+export type Keybase1NotifyEphemeralTeambotEkNeededPayload = {
+  readonly payload: _Keybase1NotifyEphemeralTeambotEkNeededPayload
+  readonly type: typeof keybase1NotifyEphemeralTeambotEkNeeded
+}
 export type Keybase1NotifyFSFSActivityPayload = {
   readonly payload: _Keybase1NotifyFSFSActivityPayload
   readonly type: typeof keybase1NotifyFSFSActivity
@@ -3211,6 +3230,7 @@ export type Actions =
   | Keybase1NotifyEmailAddressEmailsChangedPayload
   | Keybase1NotifyEphemeralNewTeamEkPayload
   | Keybase1NotifyEphemeralNewTeambotEkPayload
+  | Keybase1NotifyEphemeralTeambotEkNeededPayload
   | Keybase1NotifyFSFSActivityPayload
   | Keybase1NotifyFSFSEditListResponsePayload
   | Keybase1NotifyFSFSFavoritesChangedPayload

--- a/shared/actions/json/engine-gen.json
+++ b/shared/actions/json/engine-gen.json
@@ -325,6 +325,9 @@
         "keybase1NotifyEphemeralNewTeambotEk": {
             "params": "keybase1Types.MessageTypes['keybase.1.NotifyEphemeral.newTeambotEk']['inParam'] & {sessionID: number}, response: {error: keybase1Types.IncomingErrorCallback, result: (param: keybase1Types.MessageTypes['keybase.1.NotifyEphemeral.newTeambotEk']['outParam']) => void}"
         },
+        "keybase1NotifyEphemeralTeambotEkNeeded": {
+            "params": "keybase1Types.MessageTypes['keybase.1.NotifyEphemeral.teambotEkNeeded']['inParam'] & {sessionID: number}, response: {error: keybase1Types.IncomingErrorCallback, result: (param: keybase1Types.MessageTypes['keybase.1.NotifyEphemeral.teambotEkNeeded']['outParam']) => void}"
+        },
         "keybase1NotifyFavoritesFavoritesChanged": {
             "params": "keybase1Types.MessageTypes['keybase.1.NotifyFavorites.favoritesChanged']['inParam'] & {sessionID: number}"
         },

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -63,6 +63,10 @@ export type MessageTypes = {
     inParam: {readonly id: TeamID; readonly generation: EkGeneration}
     outParam: void
   }
+  'keybase.1.NotifyEphemeral.teambotEkNeeded': {
+    inParam: {readonly id: TeamID; readonly uid: UID; readonly generation: EkGeneration}
+    outParam: void
+  }
   'keybase.1.NotifyFS.FSActivity': {
     inParam: {readonly notification: FSNotification}
     outParam: void
@@ -2760,6 +2764,7 @@ export type IncomingCallMapType = {
   'keybase.1.NotifyEmailAddress.emailsChanged'?: (params: MessageTypes['keybase.1.NotifyEmailAddress.emailsChanged']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyEphemeral.newTeamEk'?: (params: MessageTypes['keybase.1.NotifyEphemeral.newTeamEk']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyEphemeral.newTeambotEk'?: (params: MessageTypes['keybase.1.NotifyEphemeral.newTeambotEk']['inParam'] & {sessionID: number}) => IncomingReturn
+  'keybase.1.NotifyEphemeral.teambotEkNeeded'?: (params: MessageTypes['keybase.1.NotifyEphemeral.teambotEkNeeded']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyFavorites.favoritesChanged'?: (params: MessageTypes['keybase.1.NotifyFavorites.favoritesChanged']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyFS.FSActivity'?: (params: MessageTypes['keybase.1.NotifyFS.FSActivity']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyFS.FSPathUpdated'?: (params: MessageTypes['keybase.1.NotifyFS.FSPathUpdated']['inParam'] & {sessionID: number}) => IncomingReturn
@@ -2879,6 +2884,7 @@ export type CustomResponseIncomingCallMap = {
   'keybase.1.NotifyEmailAddress.emailAddressVerified'?: (params: MessageTypes['keybase.1.NotifyEmailAddress.emailAddressVerified']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyEmailAddress.emailAddressVerified']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyEmailAddress.emailsChanged'?: (params: MessageTypes['keybase.1.NotifyEmailAddress.emailsChanged']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyEmailAddress.emailsChanged']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyEphemeral.newTeambotEk'?: (params: MessageTypes['keybase.1.NotifyEphemeral.newTeambotEk']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyEphemeral.newTeambotEk']['outParam']) => void}) => IncomingReturn
+  'keybase.1.NotifyEphemeral.teambotEkNeeded'?: (params: MessageTypes['keybase.1.NotifyEphemeral.teambotEkNeeded']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyEphemeral.teambotEkNeeded']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyFS.FSSyncActivity'?: (params: MessageTypes['keybase.1.NotifyFS.FSSyncActivity']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyFS.FSSyncActivity']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyFS.FSEditListResponse'?: (params: MessageTypes['keybase.1.NotifyFS.FSEditListResponse']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyFS.FSEditListResponse']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyFS.FSSyncStatusResponse'?: (params: MessageTypes['keybase.1.NotifyFS.FSSyncStatusResponse']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyFS.FSSyncStatusResponse']['outParam']) => void}) => IncomingReturn
@@ -3317,6 +3323,7 @@ export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.u
 // 'keybase.1.NotifyEmailAddress.emailsChanged'
 // 'keybase.1.NotifyEphemeral.newTeamEk'
 // 'keybase.1.NotifyEphemeral.newTeambotEk'
+// 'keybase.1.NotifyEphemeral.teambotEkNeeded'
 // 'keybase.1.NotifyFavorites.favoritesChanged'
 // 'keybase.1.NotifyFS.FSActivity'
 // 'keybase.1.NotifyFS.FSPathUpdated'


### PR DESCRIPTION
patch does the following:
- when bot members do not have access to a particular teambotEK generation, ping the API server to get a member to create the box
- if the current box is signed by a non-current PTK KID, continue use the old box for a short period while requesting a member to create a new one. after the window expires key fetching will error out
- support the notification for non-bot members to create the requested/latest teambotEK


depends on https://github.com/keybase/client/pull/18290, https://github.com/keybase/client/pull/18206, and https://github.com/keybase/keybase/pull/4033. will bring out of draft once the other client PRs are through ci/review

cc @keybase/hotpotatosquad 