### PR TITLE
Airdrop global banner for desktop

### DIFF
--- a/shared/__mocks__/electron.tsx
+++ b/shared/__mocks__/electron.tsx
@@ -28,8 +28,7 @@ export const systemPreferences = {}
 export const ipcMain = {on: () => {}}
 export const app = {getPath: () => '', on: () => {}}
 export const screen = {}
-
-export const BrowserWindow = {}
+export const BrowserWindow = {getFocusedWindow: () => {}}
 export const Menu = {}
 export const powerMonitor = {}
 export const powerSaveBlocker = {}

--- a/shared/constants/platform.d.ts
+++ b/shared/constants/platform.d.ts
@@ -10,6 +10,7 @@ export const isDarwin: boolean
 export const isWindows: boolean
 export const isLinux: boolean
 export const isIPhoneX: boolean
+export const isMac: boolean
 export const isAndroidNewerThanN: boolean
 export const defaultUseNativeFrame: boolean
 

--- a/shared/constants/platform.desktop.tsx
+++ b/shared/constants/platform.desktop.tsx
@@ -11,6 +11,7 @@ export const isDarwin = platform === 'darwin'
 export const isWindows = platform === 'win32'
 export const isLinux = platform === 'linux'
 export const isAndroidNewerThanN = false
+export const isMac = isDarwin && !isIOS
 export const shortcutSymbol = isDarwin ? '⌘' : 'Ctrl-'
 
 export const defaultUseNativeFrame = isDarwin || isLinux

--- a/shared/constants/platform.native.tsx
+++ b/shared/constants/platform.native.tsx
@@ -24,6 +24,7 @@ export const isDarwin = false
 export const isElectron = false
 export const isLinux = false
 export const isWindows = false
+export const isMac = false
 export const defaultUseNativeFrame = true
 export const fileUIName = 'File Explorer'
 export const mobileOsVersion = Platform.Version

--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -10,6 +10,7 @@ import * as SettingsConstants from './settings'
 import {invert} from 'lodash-es'
 import {TypedState} from './reducer'
 import HiddenString from '../util/hidden-string'
+import flags from '../util/feature-flags'
 
 export const balanceDeltaToString = invert(RPCTypes.BalanceDelta) as {
   [K in RPCTypes.BalanceDelta]: keyof typeof RPCTypes.BalanceDelta
@@ -804,3 +805,9 @@ export const rootWalletTab = Styles.isMobile ? Tabs.settingsTab : Tabs.walletsTa
 export const rootWalletPath = [rootWalletTab, ...(Styles.isMobile ? [SettingsConstants.walletsTab] : [])] // path to wallets
 export const walletPath = Styles.isMobile ? rootWalletPath : [...rootWalletPath, 'wallet'] // path to wallet
 export const trustlineHoldingBalance = 0.5
+
+export const getShowAirdropBanner = (state: TypedState) =>
+  flags.airdrop &&
+  state.wallets.airdropDetails.isPromoted &&
+  state.wallets.airdropShowBanner &&
+  (state.wallets.airdropState === 'qualified' || state.wallets.airdropState === 'unqualified')

--- a/shared/people/index.shared.tsx
+++ b/shared/people/index.shared.tsx
@@ -69,7 +69,7 @@ const EmailVerificationBanner = ({email, clearJustSignedUpEmail}) => {
 
 export const PeoplePageList = (props: Props) => (
   <Kb.Box style={{...Styles.globalStyles.flexBoxColumn, position: 'relative', width: '100%'}}>
-    {Styles.isMobile && <AirdropBanner />}
+    {Styles.isMobile && <AirdropBanner showSystemButtons={false} />}
     {!!props.signupEmail && (
       <EmailVerificationBanner
         email={props.signupEmail}

--- a/shared/router-v2/header/index.d.ts
+++ b/shared/router-v2/header/index.d.ts
@@ -1,3 +1,5 @@
 import * as React from 'react'
 
 export default class extends React.PureComponent<any> {}
+
+export class SystemButtons extends React.PureComponent<any> {}

--- a/shared/router-v2/header/index.desktop.tsx
+++ b/shared/router-v2/header/index.desktop.tsx
@@ -294,14 +294,10 @@ const styles = Styles.styleSheetCreate({
   topRightContainer: {flex: 1, justifyContent: 'flex-end'},
 })
 
-const mapStateToProps = (state: Container.TypedState) => ({
-  airdropWillShowBanner: WalletsConstants.getShowAirdropBanner(state),
-})
-
-const mapDispatchToProps = () => ({})
-
-export default Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({
-  ...s,
-  ...d,
-  ...o,
-}))(Header)
+export default Container.connect(
+  (state: Container.TypedState) => ({
+    airdropWillShowBanner: WalletsConstants.getShowAirdropBanner(state),
+  }),
+  () => ({}),
+  (stateProps, dispatchProps, ownProps) => ({...stateProps, ...dispatchProps, ...ownProps})
+)(Header)

--- a/shared/router-v2/header/index.desktop.tsx
+++ b/shared/router-v2/header/index.desktop.tsx
@@ -138,13 +138,10 @@ class Header extends React.PureComponent<Props> {
     }
 
     // Normally this component is responsible for rendering the system buttons,
-    // but if we're showing a banner then that component needs to do it.
-    const airdropShowSystemButtons =
-      flags.airdrop &&
-      this.props.loggedIn &&
-      this.props.airdropWillShowBanner &&
-      !Platform.isMac &&
-      !initialUseNativeFrame
+    // but if we're showing a banner then that banner component needs to do it.
+    const windowDecorationsAreNeeded = !Platform.isMac && !initialUseNativeFrame
+    const windowDecorationsDrawnByBanner =
+      windowDecorationsAreNeeded && flags.airdrop && this.props.loggedIn && this.props.airdropWillShowBanner
 
     // We normally have the back arrow at the top of the screen. It doesn't overlap with the system
     // icons (minimize etc) because the left nav bar pushes it to the right -- unless you're logged
@@ -165,7 +162,7 @@ class Header extends React.PureComponent<Props> {
     return (
       <Kb.Box2 noShrink={true} direction="vertical" fullWidth={true}>
         {flags.airdrop && this.props.loggedIn && (
-          <AirdropBanner showSystemButtons={airdropShowSystemButtons} />
+          <AirdropBanner showSystemButtons={windowDecorationsDrawnByBanner} />
         )}
         <Kb.Box2
           noShrink={true}
@@ -206,7 +203,7 @@ class Header extends React.PureComponent<Props> {
                 />
               )}
               {!title && rightActions}
-              {!airdropShowSystemButtons && !Platform.isMac && <SystemButtons />}
+              {windowDecorationsAreNeeded && !windowDecorationsDrawnByBanner && <SystemButtons />}
             </Kb.Box2>
           </Kb.Box2>
           <Kb.Box2

--- a/shared/router-v2/header/index.desktop.tsx
+++ b/shared/router-v2/header/index.desktop.tsx
@@ -15,7 +15,14 @@ import * as ReactIs from 'react-is'
 // A mobile-like header for desktop
 
 // Fix this as we figure out what this needs to be
-type Props = any
+type Props = {
+  allowBack: boolean
+  airdropWillShowBanner: boolean
+  loggedIn: boolean
+  onPop: () => void
+  options: any
+  style?: any
+}
 
 const useNativeFrame = new AppState().state.useNativeFrame
 const initialUseNativeFrame =

--- a/shared/router-v2/header/index.desktop.tsx
+++ b/shared/router-v2/header/index.desktop.tsx
@@ -294,10 +294,14 @@ const styles = Styles.styleSheetCreate({
   topRightContainer: {flex: 1, justifyContent: 'flex-end'},
 })
 
-export default Container.connect(
-  (state: Container.TypedState) => ({
-    airdropWillShowBanner: WalletsConstants.getShowAirdropBanner(state),
-  }),
-  () => ({}),
-  (stateProps, dispatchProps, ownProps) => ({...stateProps, ...dispatchProps, ...ownProps})
-)(Header)
+const mapStateToProps = (state: Container.TypedState) => ({
+  airdropWillShowBanner: WalletsConstants.getShowAirdropBanner(state),
+})
+
+const mapDispatchToProps = () => ({})
+
+export default Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o) => ({
+  ...s,
+  ...d,
+  ...o,
+}))(Header)

--- a/shared/router-v2/header/index.native.tsx
+++ b/shared/router-v2/header/index.native.tsx
@@ -1,1 +1,3 @@
 export default () => null // TODO
+
+export const SystemButtons = () => null // unused

--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -73,6 +73,8 @@ class AppView extends React.PureComponent<any> {
           style={selectedTab ? styles.contentArea : styles.contentAreaLogin}
         >
           {scene}
+          {/*
+          // @ts-ignore Header typing not finished yet */}
           <Header
             loggedIn={!!selectedTab}
             options={descriptor.options}

--- a/shared/wallets/airdrop/banner/container.tsx
+++ b/shared/wallets/airdrop/banner/container.tsx
@@ -3,24 +3,28 @@ import * as WalletsGen from '../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as Constants from '../../../constants/wallets'
 import * as Container from '../../../util/container'
-import flags from '../../../util/feature-flags'
+import * as Platform from '../../../constants/platform'
 
-type OwnProps = {}
+type OwnProps = {
+  showSystemButtons: boolean
+}
 
 const mapStateToProps = (state: Container.TypedState) => ({
   headerBody: state.wallets.airdropDetails.details.header.body,
-  show:
-    flags.airdrop &&
-    state.wallets.airdropDetails.isPromoted &&
-    state.wallets.airdropShowBanner &&
-    (state.wallets.airdropState === 'qualified' || state.wallets.airdropState === 'unqualified'),
+  show: Constants.getShowAirdropBanner(state),
 })
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onCancel: () => dispatch(WalletsGen.createHideAirdropBanner()),
-  onCheckQualify: () => dispatch(RouteTreeGen.createNavigateTo({path: [...Constants.walletPath, 'airdrop']})),
+  onCheckQualify: () => {
+    // Switch to the wallet tab to make sure the disclaimer appears.
+    dispatch(RouteTreeGen.createSwitchTab({tab: Constants.rootWalletTab}))
+    dispatch(RouteTreeGen.createNavigateTo({path: [...Constants.walletPath, 'airdrop']}))
+  },
 })
 
-export default Container.connect(mapStateToProps, mapDispatchToProps, (s, d, _: OwnProps) => ({...s, ...d}))(
-  Qualify
-)
+export default Container.connect(mapStateToProps, mapDispatchToProps, (s, d, o: OwnProps) => ({
+  ...s,
+  ...d,
+  ...o,
+}))(Qualify)

--- a/shared/wallets/airdrop/banner/container.tsx
+++ b/shared/wallets/airdrop/banner/container.tsx
@@ -6,7 +6,7 @@ import * as Container from '../../../util/container'
 import * as Platform from '../../../constants/platform'
 
 type OwnProps = {
-  showSystemButtons?: boolean
+  showSystemButtons: boolean
 }
 
 const mapStateToProps = (state: Container.TypedState) => ({

--- a/shared/wallets/airdrop/banner/container.tsx
+++ b/shared/wallets/airdrop/banner/container.tsx
@@ -6,7 +6,7 @@ import * as Container from '../../../util/container'
 import * as Platform from '../../../constants/platform'
 
 type OwnProps = {
-  showSystemButtons: boolean
+  showSystemButtons?: boolean
 }
 
 const mapStateToProps = (state: Container.TypedState) => ({

--- a/shared/wallets/airdrop/banner/index.stories.tsx
+++ b/shared/wallets/airdrop/banner/index.stories.tsx
@@ -8,6 +8,7 @@ const props = {
   onCancel: Sb.action('onCancel'),
   onCheckQualify: Sb.action('onCheckQualify'),
   show: true,
+  showSystemButtons: false,
 }
 
 const load = () => {

--- a/shared/wallets/airdrop/banner/index.tsx
+++ b/shared/wallets/airdrop/banner/index.tsx
@@ -1,22 +1,31 @@
 import * as React from 'react'
 import * as Kb from '../../../common-adapters'
+import * as Platform from '../../../constants/platform'
 import * as Styles from '../../../styles'
+import {SystemButtons} from '../../../router-v2/header/index'
 
 type Props = {
   headerBody: string
   onCheckQualify: () => void
   onCancel: () => void
   show: boolean
+  showSystemButtons: boolean
 }
 
 const Banner = (p: Props) => {
   if (!p.show) return null
 
   const join = (
-    <Kb.Button backgroundColor="purple" label="Join the airdrop" onClick={p.onCheckQualify} small={true} />
+    <Kb.Button
+      backgroundColor="purple"
+      label="Join the airdrop"
+      onClick={p.onCheckQualify}
+      small={true}
+      style={styles.button}
+    />
   )
 
-  const textAndButtons = Styles.isMobile ? (
+  const textAndButtons = (
     <Kb.Box2 direction="horizontal" style={styles.grow}>
       <Kb.Box2 direction="vertical" fullWidth={true}>
         <Kb.Markdown styleOverride={markdownOverride} style={styles.markdown}>
@@ -30,24 +39,15 @@ const Banner = (p: Props) => {
             label="Later"
             onClick={p.onCancel}
             small={true}
+            style={styles.button}
           />
         </Kb.Box2>
       </Kb.Box2>
-    </Kb.Box2>
-  ) : (
-    <Kb.Box2
-      direction="horizontal"
-      style={styles.grow}
-      centerChildren={true}
-      alignItems="flex-start"
-      gap="small"
-    >
-      <Kb.Markdown styleOverride={markdownOverride} style={styles.markdown}>
-        {p.headerBody}
-      </Kb.Markdown>
-      {join}
-      <Kb.Box2 direction="vertical" style={styles.grow} />
-      <Kb.Icon type="iconfont-close" onClick={p.onCancel} style={styles.close} />
+      {p.showSystemButtons && (
+        <Kb.Box2 direction="horizontal" style={{alignSelf: 'flex-start'}}>
+          <SystemButtons />
+        </Kb.Box2>
+      )}
     </Kb.Box2>
   )
 
@@ -74,6 +74,9 @@ const markdownOverride = {
 }
 
 const styles = Styles.styleSheetCreate({
+  button: Styles.platformStyles({
+    isElectron: Styles.desktopStyles.windowDraggingClickable,
+  }),
   buttonContainer: Styles.platformStyles({
     common: {
       alignSelf: 'flex-start',
@@ -85,12 +88,22 @@ const styles = Styles.styleSheetCreate({
     },
   }),
   close: {padding: Styles.globalMargins.xxtiny},
-  container: {
-    backgroundColor: Styles.globalColors.purple,
-    padding: Styles.globalMargins.tiny,
-  },
+  container: Styles.platformStyles({
+    common: {
+      backgroundColor: Styles.globalColors.purple,
+      padding: Styles.globalMargins.tiny,
+    },
+    isElectron: Styles.desktopStyles.windowDragging,
+  }),
   grow: {flexGrow: 1, flexShrink: 1},
-  markdown: {alignSelf: 'center'},
+  markdown: Styles.platformStyles({
+    isElectron: {
+      alignSelf: 'flex-start',
+      maxWidth: Platform.isMac ? undefined : 400,
+      paddingBottom: Styles.globalMargins.tiny,
+    },
+    isMobile: {alignSelf: 'center'},
+  }),
   textContainer: {
     flexGrow: 1,
     flexShrink: 1,


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers @keybase/design 

Here's the main desktop airdrop banner.  I tried having the macOS version of the banner fit on a single row as in the Zeplin design -- the reason it didn't work is that we have a macOS-only Electron bug where the pointer doesn't turn into a hand if a clickable area is inside the top 40px or so of the screen.  So I don't think that'd make for good UX.

This PR means the nav header's connected now, so it can see whether there's a live airdrop.  That header already included other connected components (the KBFS uploading status) so I think that's okay.