### PR TITLE
teams: bugfixes for hidden team chain rotations

### DIFF
--- a/go/sig3/prot.go
+++ b/go/sig3/prot.go
@@ -75,9 +75,16 @@ type Signer struct {
 }
 
 type Team struct {
-	TeamID     TeamID `codec:"i"`
-	IsImplicit bool   `codec:"m"`
-	IsPublic   bool   `codec:"p"`
+	Admin      *ChainLocation `codec:"a,omitempty"` // If working as an implicit admin, where that permission comes from
+	TeamID     TeamID         `codec:"i"`
+	IsImplicit bool           `codec:"m"`
+	IsPublic   bool           `codec:"p"`
+}
+
+type ChainLocation struct {
+	TeamID    TeamID    `codec:"i"`
+	Seqno     Seqno     `codec:"s"`
+	ChainType ChainType `codec:"t"`
 }
 
 type MerkleRoot struct {

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -78,7 +78,15 @@ func HandleRotateRequest(ctx context.Context, g *libkb.GlobalContext, msg keybas
 		}
 
 		g.Log.CDebugf(ctx, "rotating team %s (%s)", team.Name(), teamID)
-		if err := team.Rotate(ctx, keybase1.RotationType_VISIBLE); err != nil {
+
+		// Setting rotationType to CLKR in dev still breaks TestMemberAddRace, which we will fix in a subsequent PR
+		brokenTestMemberAddRace := true
+		rotationType := keybase1.RotationType_CLKR
+		if teamID.IsPublic() || brokenTestMemberAddRace {
+			rotationType = keybase1.RotationType_VISIBLE
+		}
+
+		if err := team.Rotate(ctx, rotationType); err != nil {
 			g.Log.CDebugf(ctx, "rotating team %s (%s) error: %s", team.Name(), teamID, err)
 			return err
 		}

--- a/go/teams/hidden/hidden.go
+++ b/go/teams/hidden/hidden.go
@@ -72,6 +72,7 @@ type GenerateKeyRotationParams struct {
 	NewSigningKey    libkb.NaclSigningKeyPair
 	NewEncryptionKey libkb.NaclDHKeyPair
 	Check            keybase1.PerTeamSeedCheck
+	Admin            *sig3.ChainLocation
 }
 
 // GenerateKeyRotation generates and signs a new sig3 KeyRotation. The result can be passed to
@@ -150,6 +151,7 @@ func generateKeyRotationSig3(mctx libkb.MetaContext, p GenerateKeyRotationParams
 			EldestSeqno: p.Me.GetEldestSeqno(),
 		},
 		Team: &sig3.Team{
+			Admin:      p.Admin,
 			TeamID:     *teamIDimport,
 			IsPublic:   p.IsPublic,
 			IsImplicit: p.IsImplicit,

--- a/go/teams/rotate_hidden_test.go
+++ b/go/teams/rotate_hidden_test.go
@@ -174,3 +174,13 @@ func TestRotateHiddenOtherFTL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, keybase1.Seqno(2), ch.RatchetSet.Ratchets[keybase1.RatchetType_MAIN].Triple.Seqno)
 }
+
+func TestRotateHiddenImplicitAdmin(t *testing.T) {
+	tc, _, _, _, _, sub := memberSetupSubteam(t)
+	defer tc.Cleanup()
+	team, err := GetForTestByStringName(context.TODO(), tc.G, sub)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, team.Generation())
+	err = team.Rotate(context.TODO(), keybase1.RotationType_HIDDEN)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
- don't attempt to rotate public teams
- add a test for using hidden rotations as an implicit admin
- use implicit admin pinning as visible rotations do, to fix broken functionality
- still don't flip the switch on hidden teams in dev via clkr, since we still have to fix TestMemberAddRace