### PR TITLE
Disable back button when airdrop is selected in wallet row

### DIFF
--- a/shared/router-v2/router.shared.tsx
+++ b/shared/router-v2/router.shared.tsx
@@ -42,7 +42,6 @@ export const oldActionToNewActions = (action: any, navigation: any, allowAppendD
       if (!navigation) {
         return
       }
-      console.log('hi nathan', action.payload)
       const p = action.payload.path.last
         ? action.payload.path.last()
         : action.payload.path[action.payload.path.length - 1]
@@ -82,7 +81,6 @@ export const oldActionToNewActions = (action: any, navigation: any, allowAppendD
       }
 
       if (action.payload.replace) {
-        console.log('replacing with', routeName)
         return [StackActions.replace({params, routeName})]
       }
 

--- a/shared/router-v2/router.shared.tsx
+++ b/shared/router-v2/router.shared.tsx
@@ -42,6 +42,7 @@ export const oldActionToNewActions = (action: any, navigation: any, allowAppendD
       if (!navigation) {
         return
       }
+      console.log('hi nathan', action.payload)
       const p = action.payload.path.last
         ? action.payload.path.last()
         : action.payload.path[action.payload.path.length - 1]
@@ -81,6 +82,7 @@ export const oldActionToNewActions = (action: any, navigation: any, allowAppendD
       }
 
       if (action.payload.replace) {
+        console.log('replacing with', routeName)
         return [StackActions.replace({params, routeName})]
       }
 

--- a/shared/wallets/wallet-list/container.tsx
+++ b/shared/wallets/wallet-list/container.tsx
@@ -26,7 +26,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
     )
   },
   onJoinAirdrop: () => {
-    dispatch(RouteTreeGen.createNavigateAppend({path: ['airdrop']}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: ['airdrop'], replace: !Container.isMobile}))
   },
   onLinkExisting: () => {
     dispatch(

--- a/shared/wallets/wallet-list/container.tsx
+++ b/shared/wallets/wallet-list/container.tsx
@@ -26,7 +26,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
     )
   },
   onJoinAirdrop: () => {
-    dispatch(RouteTreeGen.createNavigateAppend({path: ['airdrop'], replace: !Container.isMobile}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: ['airdrop'], replace: true}))
   },
   onLinkExisting: () => {
     dispatch(


### PR DESCRIPTION
Modifies the `onJoinAirdrop` prop in the wallets list to set the airdrop page on the same level as the wallets page, disabling the back button for the airdrop page.

The back button was a source of errors due to the fact that a routing change from the back button does not trigger an action. Since component props like the header title are derived from this selector
```ts
export const getAirdropSelected = (state: TypedState) => {
  const path = Router2Constants.getVisibleScreen().routeName
  return path === 'airdrop' || path === 'airdropQualify'
}
```
this lack of an action led to some weird states until a rerender was triggered.

Note that routing for mobile is unchanged, since it doesn't have this issue.

@keybase/react-hackers @keybase/picnicsquad 
