### PR TITLE
Downcase search result usernames

### DIFF
--- a/go/service/usersearch.go
+++ b/go/service/usersearch.go
@@ -60,6 +60,15 @@ func doSearchRequest(mctx libkb.MetaContext, arg keybase1.UserSearchArg) (res []
 	if err != nil {
 		return nil, err
 	}
+	// Downcase usernames
+	for i, row := range response.List {
+		if row.Keybase != nil {
+			response.List[i].Keybase.Username = strings.ToLower(row.Keybase.Username)
+		}
+		if row.Service != nil {
+			response.List[i].Service.Username = strings.ToLower(row.Service.Username)
+		}
+	}
 	return response.List, nil
 }
 


### PR DESCRIPTION
Downcase user search results so nobody has to think about malgorithms != maIgorithms

![image](https://user-images.githubusercontent.com/705646/61083160-0ce48d80-a3f9-11e9-8f4f-e215b58cae34.png)
