### PR TITLE
Add path payments to wallet api

### DIFF
--- a/go/client/cmd_wallet_send_path_payment.go
+++ b/go/client/cmd_wallet_send_path_payment.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
@@ -65,11 +64,11 @@ func (c *CmdWalletSendPathPayment) ParseArgv(ctx *cli.Context) error {
 	c.Note = ctx.String("message")
 	c.FromAccountID = stellar1.AccountID(ctx.String("from"))
 	var err error
-	c.SourceAsset, err = c.parseAssetFlag(ctx.String("source-asset"))
+	c.SourceAsset, err = parseAssetString(ctx.String("source-asset"))
 	if err != nil {
 		return err
 	}
-	c.DestinationAsset, err = c.parseAssetFlag(ctx.String("destination-asset"))
+	c.DestinationAsset, err = parseAssetString(ctx.String("destination-asset"))
 	if err != nil {
 		return err
 	}
@@ -137,23 +136,4 @@ func (c *CmdWalletSendPathPayment) GetUsage() libkb.Usage {
 		API:       true,
 		KbKeyring: true,
 	}
-}
-
-func (c *CmdWalletSendPathPayment) parseAssetFlag(f string) (stellar1.Asset, error) {
-	if f == "native" {
-		return stellar1.AssetNative(), nil
-	}
-	pieces := strings.Split(f, "/")
-	if len(pieces) != 2 {
-		return stellar1.Asset{}, errors.New("invalid asset string")
-	}
-	t, err := stellar1.CreateNonNativeAssetType(pieces[0])
-	if err != nil {
-		return stellar1.Asset{}, err
-	}
-	return stellar1.Asset{
-		Type:   t,
-		Code:   pieces[0],
-		Issuer: pieces[1],
-	}, nil
 }

--- a/go/client/wallet_api_doc.go
+++ b/go/client/wallet_api_doc.go
@@ -19,7 +19,7 @@ Lookup the primary Stellar account ID for a user:
 Get the inflation destination for an account:
     {"method": "get-inflation", "params": {"options": {"account-id": "GDUKZH6Q3U5WQD4PDGZXYLJE3P76BDRDWPSALN4OUFEESI2QL5UZHCK4"}}}
 
-Set the inflation destination for an account to the lumenaut pool:
+Set the inflation destination for an account to the Lumenaut pool:
     {"method": "set-inflation", "params": {"options": {"account-id": "GDUKZH6Q3U5WQD4PDGZXYLJE3P76BDRDWPSALN4OUFEESI2QL5UZHCK4", "destination": "lumenaut"}}}
 
 Set the inflation destination for an account to some other account:
@@ -28,14 +28,17 @@ Set the inflation destination for an account to some other account:
 Set the inflation destination for an account to itself:
     {"method": "set-inflation", "params": {"options": {"account-id": "GDUKZH6Q3U5WQD4PDGZXYLJE3P76BDRDWPSALN4OUFEESI2QL5UZHCK4", "destination": "self"}}}
 
-Send XLM to a keybase user (there is no confirmation so be careful):
+Send XLM to a Keybase user (there is no confirmation so be careful):
     {"method": "send", "params": {"options": {"recipient": "patrick", "amount": "1"}}}
 
-Send $10 USD worth of XLM to a keybase user:
+Send $10 USD worth of XLM to a Keybase user:
     {"method": "send", "params": {"options": {"recipient": "patrick", "amount": "10", "currency": "USD", "message": "here's the money I owe you"}}}
 
-If you send XLM to a keybase user who has not established a wallet yet, you can 
-cancel the payment before the recipient claims it and the XLM will be returned 
+Send 10 AnchorUSD to a Keybase user as a path payment by converting XLM:
+    {"method": "send-path-payment", "params": {"options": {"recipient": "patrick", "amount": "10", "source-asset": "native", "destination-asset": "USD/GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"}}}
+
+If you send XLM to a keybase user who has not established a wallet yet, you can
+cancel the payment before the recipient claims it and the XLM will be returned
 to your account:
     {"method": "cancel", "params": {"options": {"txid": "e5334601b9dc2a24e031ffeec2fce37bb6a8b4b51fc711d16dec04d3e64976c4"}}}
 

--- a/go/client/wallet_api_doc.go
+++ b/go/client/wallet_api_doc.go
@@ -37,7 +37,7 @@ Send $10 USD worth of XLM to a Keybase user:
 Send 10 AnchorUSD to a Keybase user as a path payment by converting XLM:
     {"method": "send-path-payment", "params": {"options": {"recipient": "patrick", "amount": "10", "source-asset": "native", "destination-asset": "USD/GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"}}}
 
-If you send XLM to a keybase user who has not established a wallet yet, you can
+If you send XLM to a Keybase user who has not established a wallet yet, you can
 cancel the payment before the recipient claims it and the XLM will be returned
 to your account:
     {"method": "cancel", "params": {"options": {"txid": "e5334601b9dc2a24e031ffeec2fce37bb6a8b4b51fc711d16dec04d3e64976c4"}}}

--- a/go/client/wallet_api_doc.go
+++ b/go/client/wallet_api_doc.go
@@ -34,8 +34,11 @@ Send XLM to a Keybase user (there is no confirmation so be careful):
 Send $10 USD worth of XLM to a Keybase user:
     {"method": "send", "params": {"options": {"recipient": "patrick", "amount": "10", "currency": "USD", "message": "here's the money I owe you"}}}
 
-Send 10 AnchorUSD to a Keybase user as a path payment by converting XLM:
-    {"method": "send-path-payment", "params": {"options": {"recipient": "patrick", "amount": "10", "source-asset": "native", "destination-asset": "USD/GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"}}}
+Find a payment path to a Keybase user between two assets:
+    {"method": "find-payment-path", "params": {"options": {"recipient": "patrick", "amount": "10", "source-asset": "native", "destination-asset": "USD/GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"}}}
+
+Send 10 AnchorUSD to a Keybase user as a path payment by converting at most 120 XLM (there is no confirmation so be careful):
+    {"method": "send-path-payment", "params": {"options": {"recipient": "patrick", "amount": "10", "source-max-amount": "120", "source-asset": "native", "destination-asset": "USD/GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"}}}
 
 If you send XLM to a Keybase user who has not established a wallet yet, you can
 cancel the payment before the recipient claims it and the XLM will be returned

--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -39,6 +39,9 @@ var ErrMessageTooLong = errors.New("message is too long")
 // ErrInvalidAmount is for invalid payment amounts.
 var ErrInvalidAmount = errors.New("invalid amount")
 
+// ErrInvalidAsset is for invalid asset strings.
+var ErrInvalidAsset = errors.New("invalid asset string")
+
 // ErrMemoTextTooLong is for lengthy memos.
 var ErrMemoTextTooLong = errors.New("memo text is too long (max 28 characters)")
 
@@ -77,6 +80,7 @@ const (
 	lookupMethod       = "lookup"
 	sendMethod         = "send"
 	setInflationMethod = "set-inflation"
+	sendPathPayment    = "send-path-payment"
 )
 
 // validWalletMethodsV1 is a map of the valid V1 methods for quick lookup.
@@ -91,6 +95,7 @@ var validWalletMethodsV1 = map[string]bool{
 	lookupMethod:       true,
 	sendMethod:         true,
 	setInflationMethod: true,
+	sendPathPayment:    true,
 }
 
 // handleV1 processes Call for version 1 of the wallet JSON API.
@@ -126,6 +131,8 @@ func (w *walletAPIHandler) handleV1(ctx context.Context, c Call, wr io.Writer) e
 		return w.send(ctx, c, wr)
 	case setInflationMethod:
 		return w.setInflation(ctx, c, wr)
+	case sendPathPayment:
+		return w.sendPathPayment(ctx, c, wr)
 	default:
 		return ErrInvalidMethod{name: c.Method, version: 1}
 	}
@@ -326,6 +333,57 @@ func (w *walletAPIHandler) setInflation(ctx context.Context, c Call, wr io.Write
 	return w.encodeResult(c, inflation, wr)
 }
 
+func (w *walletAPIHandler) sendPathPayment(ctx context.Context, c Call, wr io.Writer) error {
+	var opts sendPathPaymentOptions
+	if err := unmarshalOptions(c, &opts); err != nil {
+		return w.encodeErr(c, err, wr)
+	}
+
+	sourceAsset, err := parseAsset(opts.SourceAsset)
+	if err != nil {
+		return w.encodeErr(c, err, wr)
+	}
+	destinationAsset, err := parseAsset(opts.DestinationAsset)
+	if err != nil {
+		return w.encodeErr(c, err, wr)
+	}
+	from := stellar1.AccountID(opts.FromAccountID)
+
+	if err := w.registerIdentifyUI(); err != nil {
+		return w.encodeErr(c, err, wr)
+	}
+
+	findArg := stellar1.FindPaymentPathLocalArg{
+		From:             from,
+		To:               opts.Recipient,
+		SourceAsset:      sourceAsset,
+		DestinationAsset: destinationAsset,
+		Amount:           opts.Amount,
+	}
+	path, err := w.cli.FindPaymentPathLocal(ctx, findArg)
+	if err != nil {
+		return w.encodeErr(c, err, wr)
+	}
+
+	sendArg := stellar1.SendPathCLILocalArg{
+		Source:     from,
+		Recipient:  opts.Recipient,
+		Path:       path.FullPath,
+		Note:       opts.Message,
+		PublicNote: opts.MemoText,
+	}
+	res, err := w.cli.SendPathCLILocal(ctx, sendArg)
+	if err != nil {
+		return w.encodeErr(c, err, wr)
+	}
+
+	detail, err := w.cli.PaymentDetailCLILocal(ctx, string(res.TxID))
+	if err != nil {
+		return w.encodeErr(c, err, wr)
+	}
+	return w.encodeResult(c, detail, wr)
+}
+
 // encodeResult JSON encodes a successful result to the wr writer.
 func (w *walletAPIHandler) encodeResult(call Call, result interface{}, wr io.Writer) error {
 	return encodeResult(call, result, wr, w.indent)
@@ -511,4 +569,67 @@ func (c *batchOptions) Check() error {
 	}
 
 	return nil
+}
+
+type sendPathPaymentOptions struct {
+	Recipient        string `json:"recipient"`
+	Amount           string `json:"amount"`
+	SourceAsset      string `json:"source-asset"`
+	DestinationAsset string `json:"destination-asset"`
+	FromAccountID    string `json:"from-account-id"`
+	Message          string `json:"message"`
+	MemoText         string `json:"memo-text"`
+}
+
+func (c *sendPathPaymentOptions) Check() error {
+	// Note: we don't validate assets in here, since we need the parsed asset values in `sendPathPayment`
+
+	if strings.TrimSpace(c.Recipient) == "" {
+		return ErrRecipientMissing
+	}
+	if strings.TrimSpace(c.Amount) == "" {
+		return ErrAmountMissing
+	}
+
+	namt, err := stellarnet.ParseStellarAmount(c.Amount)
+	if err != nil {
+		return ErrInvalidAmount
+	}
+	if namt < 0 {
+		return ErrInvalidAmount
+	}
+
+	if c.FromAccountID != "" {
+		_, err := strkey.Decode(strkey.VersionByteAccountID, c.FromAccountID)
+		if err != nil {
+			return ErrInvalidAccountID
+		}
+	}
+	if len(c.Message) > libkb.MaxStellarPaymentNoteLength {
+		return ErrMessageTooLong
+	}
+	if len(c.MemoText) > libkb.MaxStellarPaymentPublicNoteLength {
+		return ErrMemoTextTooLong
+	}
+
+	return nil
+}
+
+func parseAsset(s string) (stellar1.Asset, error) {
+	if s == "native" {
+		return stellar1.AssetNative(), nil
+	}
+	pieces := strings.Split(s, "/")
+	if len(pieces) != 2 {
+		return stellar1.Asset{}, ErrInvalidAsset
+	}
+	t, err := stellar1.CreateNonNativeAssetType(pieces[0])
+	if err != nil {
+		return stellar1.Asset{}, err
+	}
+	return stellar1.Asset{
+		Type:   t,
+		Code:   pieces[0],
+		Issuer: pieces[1],
+	}, nil
 }

--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -39,6 +39,10 @@ var ErrMessageTooLong = errors.New("message is too long")
 // ErrInvalidAmount is for invalid payment amounts.
 var ErrInvalidAmount = errors.New("invalid amount")
 
+// ErrInvalidSourceMax is for invalid source asset maximum amounts
+var ErrInvalidSourceMax = errors.New("invalid source asset maximum amount")
+
+// ErrInvalidSourceMax is for when a payment path would exceed the source asset maximum
 var ErrPathMaxExceeded = errors.New("payment path could exceed source asset limit")
 
 // ErrMemoTextTooLong is for lengthy memos.
@@ -679,10 +683,10 @@ func (c *sendPathPaymentOptions) Check() error {
 
 	sourceMax, err := stellarnet.ParseStellarAmount(c.SourceMaxAmount)
 	if err != nil {
-		return ErrInvalidAmount
+		return ErrInvalidSourceMax
 	}
 	if sourceMax < 0 {
-		return ErrInvalidAmount
+		return ErrInvalidSourceMax
 	}
 
 	if c.FromAccountID != "" {

--- a/go/client/wallet_common.go
+++ b/go/client/wallet_common.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/keybase/client/go/protocol/stellar1"
+)
+
+func parseAssetString(s string) (stellar1.Asset, error) {
+	if s == "native" {
+		return stellar1.AssetNative(), nil
+	}
+	pieces := strings.Split(s, "/")
+	if len(pieces) != 2 {
+		return stellar1.Asset{}, errors.New("invalid asset string")
+	}
+	t, err := stellar1.CreateNonNativeAssetType(pieces[0])
+	if err != nil {
+		return stellar1.Asset{}, err
+	}
+	return stellar1.Asset{
+		Type:   t,
+		Code:   pieces[0],
+		Issuer: pieces[1],
+	}, nil
+}


### PR DESCRIPTION
Title. Example payment:
```
keybase wallet api -m '{"method": "send-path-payment", "params": {"options": {"recipient": "nathunsmitty", "amount": "10", "source-asset": "native", "destination-asset": "USD/GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"}}}'
```