### PR TITLE
Format contact phone numbers more successfully

### DIFF
--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -507,6 +507,7 @@ async function manageContactsCache(
 
   // feature enabled and permission granted
   const contacts = await Contacts.getContactsAsync()
+  const defaultCountryCode = await NativeModules.Utils.getDefaultCountryCode()
   const mapped = contacts.data.reduce((ret: Array<RPCTypes.Contact>, contact) => {
     const {name, phoneNumbers = [], emails = []} = contact
 
@@ -514,7 +515,7 @@ async function manageContactsCache(
       // TODO this fails on many phone numbers, contact data from native may
       // not include countryCode. Make better guesses at properly formatting
       // this.
-      const formatted = getE164(pn.countryCode || '', pn.number || '')
+      const formatted = getE164(pn.countryCode || defaultCountryCode, pn.number || '')
       if (formatted) {
         res.push({
           label: pn.label,

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -29,7 +29,7 @@ import pushSaga, {getStartupDetailsFromInitialPush} from './push.native'
 import ImagePicker from 'react-native-image-picker'
 import {TypedActions, TypedState} from '../../util/container'
 import * as Contacts from 'expo-contacts'
-import {phoneUtil, PhoneNumberFormat} from '../../util/phone-numbers'
+import {phoneUtil, PhoneNumberFormat, ValidationResult} from '../../util/phone-numbers'
 
 type NextURI = string
 
@@ -547,6 +547,10 @@ async function manageContactsCache(
 const getE164 = (countryCode: string, phoneNumber: string) => {
   try {
     const parsed = phoneUtil.parse(phoneNumber, countryCode)
+    const reason = phoneUtil.isPossibleNumberWithReason(parsed)
+    if (reason !== ValidationResult.IS_POSSIBLE) {
+      return null
+    }
     return phoneUtil.format(parsed, PhoneNumberFormat.E164) as string
   } catch (e) {
     return null

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KBReactPackage.java
@@ -19,6 +19,7 @@ import io.keybase.ossifrage.modules.NativeLogger;
 import io.keybase.ossifrage.modules.NativeSettings;
 import io.keybase.ossifrage.modules.ScreenProtector;
 import io.keybase.ossifrage.modules.ShareFiles;
+import io.keybase.ossifrage.modules.Utils;
 
 public class KBReactPackage implements com.facebook.react.ReactPackage {
     private List<KillableModule> killableModules = new ArrayList<>();
@@ -39,6 +40,7 @@ public class KBReactPackage implements com.facebook.react.ReactPackage {
         final NativeLogger nativeLogger = new NativeLogger(reactApplicationContext);
         final ShareFiles shareFiles = new ShareFiles(reactApplicationContext);
         final IntentHandler intentHandler = new IntentHandler(reactApplicationContext);
+        final Utils utils = new Utils(reactApplicationContext);
 
         killableModules.add(kbEngine);
 
@@ -50,6 +52,7 @@ public class KBReactPackage implements com.facebook.react.ReactPackage {
         modules.add(nativeLogger);
         modules.add(shareFiles);
         modules.add(intentHandler);
+        modules.add(utils);
 
         return modules;
     }

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/modules/Utils.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/modules/Utils.java
@@ -1,0 +1,29 @@
+package io.keybase.ossifrage.modules;
+
+import android.content.Context;
+import android.telephony.TelephonyManager;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class Utils extends ReactContextBaseJavaModule {
+    private static final String NAME = "Utils";
+
+    public Utils(final ReactApplicationContext reactContext) { super(reactContext); }
+
+    @Override
+    public String getName() { return NAME; }
+
+    @ReactMethod
+    public void getDefaultCountryCode(Promise promise) {
+        try {
+            TelephonyManager tm = (TelephonyManager) this.getReactApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
+            String countryCode = tm.getNetworkCountryIso();
+            promise.resolve(countryCode);
+        } catch (Exception e) {
+            promise.reject(e);
+        }
+    }
+}

--- a/shared/ios/Keybase/Engine.m
+++ b/shared/ios/Keybase/Engine.m
@@ -157,7 +157,6 @@ RCT_EXPORT_METHOD(start) {
 
 - (NSDictionary *)constantsToExport {
   [self setupServerConfig];
-  NSString * testVal = [Utils areWeBeingUnitTested] ? @"1" : @"";
 #if TARGET_IPHONE_SIMULATOR
   NSString * simulatorVal = @"1";
 #else
@@ -170,7 +169,6 @@ RCT_EXPORT_METHOD(start) {
   return @{ @"eventName": eventName,
             @"metaEventName": metaEventName,
             @"metaEventEngineReset": metaEventEngineReset,
-            @"test": testVal,
             @"appVersionName": appVersionString,
             @"appVersionCode": appBuildString,
             @"usingSimulator": simulatorVal,

--- a/shared/ios/Keybase/Utils.h
+++ b/shared/ios/Keybase/Utils.h
@@ -9,6 +9,5 @@
 #import <Foundation/Foundation.h>
 
 @interface Utils : NSObject
-+ (BOOL)areWeBeingUnitTested; // in a test context
-+ (BOOL)areWeBeingUnitTestedRightNow; // currently in a test
++ (NSString*)getDefaultCountryCode;
 @end

--- a/shared/ios/Keybase/Utils.h
+++ b/shared/ios/Keybase/Utils.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
 
-@interface Utils : NSObject
-+ (NSString*)getDefaultCountryCode;
+@interface Utils : NSObject<RCTBridgeModule>
 @end

--- a/shared/ios/Keybase/Utils.m
+++ b/shared/ios/Keybase/Utils.m
@@ -12,39 +12,18 @@
 
 @implementation Utils
 
-+ (NSString*)getDefaultCountryCode {
+RCT_EXPORT_MODULE();
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+RCT_REMAP_METHOD(getDefaultCountryCode, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   CTTelephonyNetworkInfo *network_Info = [CTTelephonyNetworkInfo new];
   CTCarrier *carrier = network_Info.subscriberCellularProvider;
   
-  return carrier.isoCountryCode;
+  resolve(carrier.isoCountryCode);
 }
-
-// Returns YES if we are currently in a unit test context
-+ (BOOL)areWeBeingUnitTested {
-  BOOL answer = NO;
-  Class testProbeClass;
-  testProbeClass = NSClassFromString(@"XCTestProbe");
-  if (testProbeClass != Nil) {
-    answer = YES;
-  }
-  return answer;
-}
-
-// Returns YES if we are currently being unittested.
-+ (BOOL)areWeBeingUnitTestedRightNow {
-  BOOL answer = NO;
-  Class testProbeClass;
-  testProbeClass = NSClassFromString(@"XCTestProbe");
-  if (testProbeClass != Nil) {
-    SEL selector = NSSelectorFromString(@"isTesting");
-    NSMethodSignature *sig = [testProbeClass methodSignatureForSelector:selector];
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
-    [invocation setSelector:selector];
-    [invocation invokeWithTarget:testProbeClass];
-    [invocation getReturnValue:&answer];
-  }
-  return answer;
-}
-
 
 @end

--- a/shared/ios/Keybase/Utils.m
+++ b/shared/ios/Keybase/Utils.m
@@ -7,8 +7,17 @@
 //
 
 #import "Utils.h"
+#import <CoreTelephony/CTCarrier.h>
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
 
 @implementation Utils
+
++ (NSString*)getDefaultCountryCode {
+  CTTelephonyNetworkInfo *network_Info = [CTTelephonyNetworkInfo new];
+  CTCarrier *carrier = network_Info.subscriberCellularProvider;
+  
+  return carrier.isoCountryCode;
+}
 
 // Returns YES if we are currently in a unit test context
 + (BOOL)areWeBeingUnitTested {

--- a/shared/util/phone-numbers/index.tsx
+++ b/shared/util/phone-numbers/index.tsx
@@ -5,9 +5,7 @@ import supportedCodes from './sms-support/data.json'
 import {emojiIndexByChar} from '../../common-adapters/markdown/emoji-gen'
 
 const PNF = libphonenumber.PhoneNumberFormat
-export enum PhoneNumberFormat {
-  E164 = PNF.E164,
-}
+export const PhoneNumberFormat = PNF
 
 export const phoneUtil = libphonenumber.PhoneNumberUtil.getInstance()
 const supported = phoneUtil.getSupportedRegions()

--- a/shared/util/phone-numbers/index.tsx
+++ b/shared/util/phone-numbers/index.tsx
@@ -8,6 +8,7 @@ const PNF = libphonenumber.PhoneNumberFormat
 export const PhoneNumberFormat = PNF
 
 export const phoneUtil = libphonenumber.PhoneNumberUtil.getInstance()
+export const ValidationResult = libphonenumber.PhoneNumberUtil.ValidationResult
 const supported = phoneUtil.getSupportedRegions()
 
 export type CountryData = {


### PR DESCRIPTION
- Fetch country code from phone carrier info
- Use as default for contacts with no country code data
- Validate phone numbers in a way more similar to the server

cc @keybase/y2ksquad 