### PR TITLE
Fix some send form styling

### DIFF
--- a/shared/wallets/send-form/body/shared.tsx
+++ b/shared/wallets/send-form/body/shared.tsx
@@ -5,13 +5,10 @@ export const sharedStyles = Styles.styleSheetCreate({
     flexGrow: 1,
     flexShrink: 1,
   },
-  scrollView: Styles.platformStyles({
-    common: {
-      flexGrow: 1,
-      flexShrink: 1,
-      width: '100%',
-    },
-    isElectron: {minHeight: '100%'},
-  }),
+  scrollView: {
+    flexGrow: 1,
+    flexShrink: 1,
+    width: '100%',
+  },
   spinnerContainer: {...Styles.globalStyles.fillAbsolute},
 })

--- a/shared/wallets/send-form/index.stories.tsx
+++ b/shared/wallets/send-form/index.stories.tsx
@@ -23,12 +23,12 @@ const provider = banner =>
       amountErrMsg: '',
     }),
     Banner: props => ({}),
-    ConnectedPublicMemo: props => ({onChangePublicMemo: Sb.action('onChangePublicMemo')}),
+    ConnectedPublicMemo: props => ({onChangePublicMemo: Sb.action('onChangePublicMemo'), maxLength: 28}),
     ConnectedRequestBody: props => ({
       banners: [],
       isProcessing: props.isProcessing,
     }),
-    ConnectedSecretNote: props => ({onChangeSecretNote: Sb.action('onChangeSecretNote')}),
+    ConnectedSecretNote: props => ({onChangeSecretNote: Sb.action('onChangeSecretNote'), maxLength: 500}),
     ConnectedSendBody: props => ({
       banners: JSON.stringify(banner) === '{}' ? [] : [banner],
       isProcessing: props.isProcessing,

--- a/shared/wallets/send-form/index.stories.tsx
+++ b/shared/wallets/send-form/index.stories.tsx
@@ -23,12 +23,12 @@ const provider = banner =>
       amountErrMsg: '',
     }),
     Banner: props => ({}),
-    ConnectedPublicMemo: props => ({onChangePublicMemo: Sb.action('onChangePublicMemo'), maxLength: 28}),
+    ConnectedPublicMemo: props => ({maxLength: 28, onChangePublicMemo: Sb.action('onChangePublicMemo')}),
     ConnectedRequestBody: props => ({
       banners: [],
       isProcessing: props.isProcessing,
     }),
-    ConnectedSecretNote: props => ({onChangeSecretNote: Sb.action('onChangeSecretNote'), maxLength: 500}),
+    ConnectedSecretNote: props => ({maxLength: 500, onChangeSecretNote: Sb.action('onChangeSecretNote')}),
     ConnectedSendBody: props => ({
       banners: JSON.stringify(banner) === '{}' ? [] : [banner],
       isProcessing: props.isProcessing,


### PR DESCRIPTION
Fixes an issue with the send form on desktop where the send button was placed below the rest of the send form content as a result of the height of the body of the send form being longer than it should be.

Story: http://localhost:6006/?path=/story/wallets-sendform--send

Note that the mobile send form is unchanged.