### PR TITLE
libkbfs: load cached MD changes under journal lock

### DIFF
--- a/go/kbfs/data/interfaces.go
+++ b/go/kbfs/data/interfaces.go
@@ -214,6 +214,8 @@ type BlockPutState interface {
 		ctx context.Context, blockPtr BlockPointer, block Block,
 		readyBlockData ReadyBlockData, syncedCb func() error) error
 	SaveOldPtr(ctx context.Context, oldPtr BlockPointer) error
+	Ptrs() []BlockPointer
+	GetBlock(ctx context.Context, blockPtr BlockPointer) (Block, error)
 }
 
 // DirtyBlockCacheSimple is a bare-bones interface for a dirty block

--- a/go/kbfs/kbfstool/md_force_qr.go
+++ b/go/kbfs/kbfstool/md_force_qr.go
@@ -72,8 +72,8 @@ func mdForceQROne(
 		return err
 	}
 
-	newIrmd, err := config.MDOps().Put(ctx, rmdNext, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	newIrmd, err := config.MDOps().Put(
+		ctx, rmdNext, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/kbfstool/md_reset.go
+++ b/go/kbfs/kbfstool/md_reset.go
@@ -105,8 +105,8 @@ func mdResetOne(
 		return err
 	}
 
-	newIrmd, err := config.MDOps().Put(ctx, rmdNext, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	newIrmd, err := config.MDOps().Put(
+		ctx, rmdNext, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/libkbfs/block_journal.go
+++ b/go/kbfs/libkbfs/block_journal.go
@@ -632,13 +632,13 @@ func (be blockEntriesToFlush) revIsLocalSquash(rev kbfsmd.Revision) bool {
 }
 
 func (be blockEntriesToFlush) markFlushingBlockIDs(ids map[kbfsblock.ID]bool) {
-	for _, ptr := range be.puts.ptrs() {
+	for _, ptr := range be.puts.Ptrs() {
 		ids[ptr.ID] = true
 	}
 }
 
 func (be blockEntriesToFlush) clearFlushingBlockIDs(ids map[kbfsblock.ID]bool) {
-	for _, ptr := range be.puts.ptrs() {
+	for _, ptr := range be.puts.Ptrs() {
 		delete(ids, ptr.ID)
 	}
 }

--- a/go/kbfs/libkbfs/block_journal_test.go
+++ b/go/kbfs/libkbfs/block_journal_test.go
@@ -875,7 +875,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	require.Equal(t, 2, entries.puts.numBlocks())
 	require.Equal(t, 0, entries.adds.numBlocks())
 	require.Len(t, entries.other, 5)
-	ptrs := entries.puts.ptrs()
+	ptrs := entries.puts.Ptrs()
 	ids := make([]kbfsblock.ID, len(ptrs))
 	for i, ptr := range ptrs {
 		ids[i] = ptr.ID

--- a/go/kbfs/libkbfs/block_put_state_disk.go
+++ b/go/kbfs/libkbfs/block_put_state_disk.go
@@ -63,7 +63,7 @@ func (bps *blockPutStateDisk) AddNewBlock(
 		ctx, blockPtr, nil, data.ReadyBlockData{}, syncedCb)
 }
 
-func (bps *blockPutStateDisk) getBlock(
+func (bps *blockPutStateDisk) GetBlock(
 	ctx context.Context, blockPtr data.BlockPointer) (data.Block, error) {
 	blockData, serverHalf, _, err := bps.diskCache.Get(
 		ctx, bps.kmd.TlfID(), blockPtr.ID)

--- a/go/kbfs/libkbfs/block_put_state_memory.go
+++ b/go/kbfs/libkbfs/block_put_state_memory.go
@@ -115,7 +115,7 @@ func (bps *blockPutStateMemory) removeOtherBps(
 	return nil
 }
 
-func (bps *blockPutStateMemory) ptrs() []data.BlockPointer {
+func (bps *blockPutStateMemory) Ptrs() []data.BlockPointer {
 	ret := make([]data.BlockPointer, len(bps.blockStates))
 	i := 0
 	for ptr := range bps.blockStates {
@@ -125,7 +125,7 @@ func (bps *blockPutStateMemory) ptrs() []data.BlockPointer {
 	return ret
 }
 
-func (bps *blockPutStateMemory) getBlock(
+func (bps *blockPutStateMemory) GetBlock(
 	_ context.Context, blockPtr data.BlockPointer) (data.Block, error) {
 	bs, ok := bps.blockStates[blockPtr]
 	if ok {

--- a/go/kbfs/libkbfs/block_util.go
+++ b/go/kbfs/libkbfs/block_util.go
@@ -89,7 +89,7 @@ func doOneBlockPut(ctx context.Context, bserv BlockServer, reporter Reporter,
 		err = bps.synced(ptr)
 	}
 	if err != nil && isRecoverableBlockError(err) {
-		block, blockErr := bps.getBlock(ctx, ptr)
+		block, blockErr := bps.GetBlock(ctx, ptr)
 		if blockErr == nil {
 			fblock, ok := block.(*data.FileBlock)
 			if ok && !fblock.IsInd {
@@ -145,7 +145,7 @@ func doBlockPuts(ctx context.Context, bserv BlockServer, bcache data.BlockCache,
 		eg.Go(worker)
 	}
 
-	for _, ptr := range bps.ptrs() {
+	for _, ptr := range bps.Ptrs() {
 		blocks <- ptr
 	}
 	close(blocks)
@@ -159,7 +159,7 @@ func doBlockPuts(ctx context.Context, bserv BlockServer, bcache data.BlockCache,
 			// Let the caller know which blocks shouldn't be
 			// retried.
 			blocksToRemove = append(blocksToRemove, ptr)
-			if block, err := bps.getBlock(ctx, ptr); err == nil {
+			if block, err := bps.GetBlock(ctx, ptr); err == nil {
 				if fblock, ok := block.(*data.FileBlock); ok {
 					// Remove each problematic block from the cache so
 					// the redo can just make a new block instead.

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -291,7 +291,7 @@ func (fbm *folderBlockManager) cleanUpBlockState(
 		bdType:  bdType,
 		backoff: expBackoff,
 	}
-	toDelete.blocks = append(toDelete.blocks, bps.ptrs()...)
+	toDelete.blocks = append(toDelete.blocks, bps.Ptrs()...)
 	fbm.enqueueBlocksToDelete(toDelete)
 }
 

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -2942,7 +2942,7 @@ func (fbo *folderBlockOps) cleanUpUnusedBlocks(ctx context.Context,
 		}
 
 		failedBps := newBlockPutStateMemory(oldMD.bps.numBlocks())
-		for _, ptr := range oldMD.bps.ptrs() {
+		for _, ptr := range oldMD.bps.Ptrs() {
 			if ptr == data.ZeroPtr {
 				panic("Unexpected zero block ptr in an old sync MD revision")
 			}

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -2749,18 +2749,12 @@ func (fbo *folderBranchOps) initMDLocked(
 		mdOps = jManager.delegateMDOps
 	}
 	irmd, err := mdOps.Put(
-		ctx, md, session.VerifyingKey, nil, keybase1.MDPriorityNormal)
+		ctx, md, session.VerifyingKey, nil, keybase1.MDPriorityNormal, bps)
 	isConflict := isRevisionConflict(err)
 	if err != nil && !isConflict {
 		return err
 	} else if isConflict {
 		return RekeyConflictError{err}
-	}
-
-	md, irmd, err = fbo.loadCachedMDChanges(ctx, bps,
-		session.VerifyingKey, md, irmd)
-	if err != nil {
-		return err
 	}
 
 	fbo.headLock.Lock(lState)
@@ -3638,13 +3632,13 @@ func (fbo *folderBranchOps) finalizeBlocks(
 		return nil
 	}
 	bcache := fbo.config.BlockCache()
-	for _, newPtr := range bps.ptrs() {
+	for _, newPtr := range bps.Ptrs() {
 		// only cache this block if we made a brand new block, not if
 		// we just incref'd some other block.
 		if !newPtr.IsFirstRef() {
 			continue
 		}
-		block, err := bps.getBlock(ctx, newPtr)
+		block, err := bps.GetBlock(ctx, newPtr)
 		if err != nil {
 			fbo.log.CDebugf(ctx, "Error getting block for %v: %+v", newPtr, err)
 		}
@@ -3817,25 +3811,6 @@ func (fbo *folderBranchOps) handleUnflushedEditNotifications(
 	return nil
 }
 
-func (fbo *folderBranchOps) loadCachedMDChanges(ctx context.Context,
-	bps blockPutState, key kbfscrypto.VerifyingKey, md *RootMetadata,
-	irmd ImmutableRootMetadata) (*RootMetadata, ImmutableRootMetadata, error) {
-	md, copied := md.loadCachedBlockChanges(
-		ctx, bps, fbo.log, fbo.vlog, fbo.config.Codec())
-
-	if copied {
-		irmd = MakeImmutableRootMetadata(
-			md, key, irmd.mdID, fbo.config.Clock().Now(), irmd.putToServer)
-
-		err := fbo.config.MDCache().Replace(irmd, irmd.BID())
-		if err != nil {
-			return nil, ImmutableRootMetadata{}, err
-		}
-	}
-	return md, irmd, nil
-
-}
-
 func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 	lState *kbfssync.LockState, md *RootMetadata, bps blockPutState, excl Excl,
 	notifyFn func(ImmutableRootMetadata) error) (
@@ -3897,7 +3872,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 	if isMerged {
 		// only do a normal Put if we're not already staged.
 		irmd, err = mdops.Put(
-			ctx, md, session.VerifyingKey, nil, keybase1.MDPriorityNormal)
+			ctx, md, session.VerifyingKey, nil, keybase1.MDPriorityNormal, bps)
 		if doUnmergedPut = isRevisionConflict(err); doUnmergedPut {
 			fbo.log.CDebugf(ctx, "Conflict: %v", err)
 			mergedRev = md.Revision()
@@ -3925,7 +3900,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 	if doUnmergedPut {
 		// We're out of date, and this is not an exclusive write, so put it as an
 		// unmerged MD.
-		irmd, err = mdops.PutUnmerged(ctx, md, session.VerifyingKey)
+		irmd, err = mdops.PutUnmerged(ctx, md, session.VerifyingKey, bps)
 		if isRevisionConflict(err) {
 			// Self-conflicts are retried in `doMDWriteWithRetry`.
 			return UnmergedSelfConflictError{err}
@@ -3982,12 +3957,6 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 			// theoretically possible.
 			defer fbo.config.RekeyQueue().Enqueue(md.TlfID())
 		}
-	}
-
-	md, irmd, err = fbo.loadCachedMDChanges(ctx, bps,
-		session.VerifyingKey, md, irmd)
-	if err != nil {
-		return err
 	}
 
 	rebased := (oldPrevRoot != md.PrevRoot())
@@ -4114,7 +4083,7 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 		key = session.VerifyingKey
 	}
 
-	irmd, err := mdOps.Put(ctx, md, key, nil, keybase1.MDPriorityNormal)
+	irmd, err := mdOps.Put(ctx, md, key, nil, keybase1.MDPriorityNormal, nil)
 	isConflict := isRevisionConflict(err)
 	if err != nil && !isConflict {
 		return err
@@ -4137,11 +4106,6 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 		unmergedBID := md.BID()
 		fbo.setBranchIDLocked(lState, unmergedBID)
 		fbo.cr.Resolve(ctx, md.Revision(), kbfsmd.RevisionUninitialized)
-	}
-
-	md, irmd, err = fbo.loadCachedMDChanges(ctx, nil, key, md, irmd)
-	if err != nil {
-		return err
 	}
 
 	fbo.headLock.Lock(lState)
@@ -4195,7 +4159,7 @@ func (fbo *folderBranchOps) finalizeGCOpLocked(
 
 	// finally, write out the new metadata
 	irmd, err := fbo.config.MDOps().Put(
-		ctx, md, session.VerifyingKey, nil, keybase1.MDPriorityNormal)
+		ctx, md, session.VerifyingKey, nil, keybase1.MDPriorityNormal, bps)
 	if err != nil {
 		// Don't allow garbage collection to put us into a conflicting
 		// state; just wait for the next period.
@@ -4203,12 +4167,6 @@ func (fbo *folderBranchOps) finalizeGCOpLocked(
 	}
 
 	fbo.setBranchIDLocked(lState, kbfsmd.NullBranchID)
-
-	md, irmd, err = fbo.loadCachedMDChanges(ctx, bps,
-		session.VerifyingKey, md, irmd)
-	if err != nil {
-		return err
-	}
 
 	rebased := (oldPrevRoot != md.PrevRoot())
 	if rebased {
@@ -8037,8 +7995,10 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	irmd, err := fbo.config.MDOps().ResolveBranch(ctx, fbo.id(), fbo.unmergedBID,
-		blocksToDelete, md, session.VerifyingKey)
+	irmd, err := fbo.config.MDOps().ResolveBranch(
+		ctx, fbo.id(), fbo.unmergedBID, blocksToDelete, md,
+		session.VerifyingKey, bps)
+	md = irmd.ReadOnlyRootMetadata.RootMetadata // un-read-onlyify
 	doUnmergedPut := isRevisionConflict(err)
 	if doUnmergedPut {
 		fbo.log.CDebugf(ctx, "Got a conflict after resolution; aborting CR")
@@ -8051,12 +8011,6 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	// Queue a rekey if the bit was set.
 	if md.IsRekeySet() {
 		defer fbo.config.RekeyQueue().Enqueue(md.TlfID())
-	}
-
-	md, irmd, err = fbo.loadCachedMDChanges(ctx, bps,
-		session.VerifyingKey, md, irmd)
-	if err != nil {
-		return err
 	}
 
 	// Set the head to the new MD.

--- a/go/kbfs/libkbfs/folder_update_prepper.go
+++ b/go/kbfs/libkbfs/folder_update_prepper.go
@@ -580,8 +580,8 @@ func (fup *folderUpdatePrepper) updateResolutionUsageLockedCache(
 	md.SetMDDiskUsage(mostRecentMergedMD.MDDiskUsage())
 
 	localBlocks := make(map[data.BlockPointer]data.Block)
-	for _, ptr := range bps.ptrs() {
-		if block, err := bps.getBlock(ctx, ptr); err == nil && block != nil {
+	for _, ptr := range bps.Ptrs() {
+		if block, err := bps.GetBlock(ctx, ptr); err == nil && block != nil {
 			localBlocks[ptr] = block
 		}
 	}
@@ -1427,7 +1427,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 
 	if len(unmergedChains.resOps) > 0 {
 		newBlocks := make(map[data.BlockPointer]bool)
-		for _, ptr := range bps.ptrs() {
+		for _, ptr := range bps.Ptrs() {
 			newBlocks[ptr] = true
 		}
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1320,9 +1320,10 @@ type MDOps interface {
 	// that journalMDOps doesn't support any priority other than
 	// MDPriorityNormal for now. If journaling is enabled, use FinishSinbleOp
 	// to override priority.
-	Put(ctx context.Context, rmd *RootMetadata,
-		verifyingKey kbfscrypto.VerifyingKey,
-		lockContext *keybase1.LockContext, priority keybase1.MDPriority) (
+	Put(
+		ctx context.Context, rmd *RootMetadata,
+		verifyingKey kbfscrypto.VerifyingKey, lockContext *keybase1.LockContext,
+		priority keybase1.MDPriority, bps data.BlockPutState) (
 		ImmutableRootMetadata, error)
 
 	// PutUnmerged is the same as the above but for unmerged metadata
@@ -1332,8 +1333,10 @@ type MDOps interface {
 	// the verifying key, which might not be the same as the local
 	// user's verifying key if the MD has been copied from a previous
 	// update.
-	PutUnmerged(ctx context.Context, rmd *RootMetadata,
-		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
+	PutUnmerged(
+		ctx context.Context, rmd *RootMetadata,
+		verifyingKey kbfscrypto.VerifyingKey, bps data.BlockPutState) (
+		ImmutableRootMetadata, error)
 
 	// PruneBranch prunes all unmerged history for the given TLF
 	// branch.
@@ -1348,9 +1351,11 @@ type MDOps interface {
 	// ImmutableRootMetadata requires knowing the verifying key, which
 	// might not be the same as the local user's verifying key if the
 	// MD has been copied from a previous update.
-	ResolveBranch(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID,
+	ResolveBranch(
+		ctx context.Context, id tlf.ID, bid kbfsmd.BranchID,
 		blocksToDelete []kbfsblock.ID, rmd *RootMetadata,
-		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
+		verifyingKey kbfscrypto.VerifyingKey, bps data.BlockPutState) (
+		ImmutableRootMetadata, error)
 
 	// GetLatestHandleForTLF returns the server's idea of the latest
 	// handle for the TLF, which may not yet be reflected in the MD if
@@ -2379,8 +2384,6 @@ type Chat interface {
 type blockPutState interface {
 	data.BlockPutState
 	oldPtr(ctx context.Context, blockPtr data.BlockPointer) (data.BlockPointer, error)
-	ptrs() []data.BlockPointer
-	getBlock(ctx context.Context, blockPtr data.BlockPointer) (data.Block, error)
 	getReadyBlockData(
 		ctx context.Context, blockPtr data.BlockPointer) (data.ReadyBlockData, error)
 	synced(blockPtr data.BlockPointer) error

--- a/go/kbfs/libkbfs/journal_manager_test.go
+++ b/go/kbfs/libkbfs/journal_manager_test.go
@@ -414,8 +414,8 @@ func TestJournalManagerRestart(t *testing.T) {
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 
-	_, err = mdOps.Put(ctx, rmd, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	_, err = mdOps.Put(
+		ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	require.NoError(t, err)
 
 	// Simulate a restart.
@@ -489,8 +489,8 @@ func TestJournalManagerLogOutLogIn(t *testing.T) {
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 
-	_, err = mdOps.Put(ctx, rmd, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	_, err = mdOps.Put(
+		ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	require.NoError(t, err)
 
 	// Simulate a log out.
@@ -602,8 +602,8 @@ func TestJournalManagerMultiUser(t *testing.T) {
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 
-	_, err = mdOps.Put(ctx, rmd1, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	_, err = mdOps.Put(
+		ctx, rmd1, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	require.NoError(t, err)
 
 	// Log in user 2.
@@ -654,8 +654,8 @@ func TestJournalManagerMultiUser(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, rekeyDone)
 
-	_, err = mdOps.Put(ctx, rmd2, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	_, err = mdOps.Put(
+		ctx, rmd2, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	require.NoError(t, err)
 
 	// Log out.
@@ -958,8 +958,8 @@ func TestJournalManagerTeamTLFWithRestart(t *testing.T) {
 	require.NoError(t, err)
 	rmd.bareMd.SetLatestKeyGenerationForTeamTLF(kbfsmd.FirstValidKeyGen)
 
-	_, err = mdOps.Put(ctx, rmd, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	_, err = mdOps.Put(
+		ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	require.NoError(t, err)
 
 	// Simulate a restart.

--- a/go/kbfs/libkbfs/journal_md_ops_test.go
+++ b/go/kbfs/libkbfs/journal_md_ops_test.go
@@ -129,8 +129,8 @@ func TestJournalMDOpsBasics(t *testing.T) {
 
 	rmd := makeMDForJournalMDOpsTest(t, config, id, h, kbfsmd.Revision(1))
 
-	irmd, err = mdOps.Put(ctx, rmd, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	irmd, err = mdOps.Put(
+		ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	require.NoError(t, err)
 	prevRoot := irmd.mdID
 
@@ -138,8 +138,8 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	for i := kbfsmd.Revision(2); i < 8; i++ {
 		rmd.SetRevision(kbfsmd.Revision(i))
 		rmd.SetPrevRoot(prevRoot)
-		irmd, err := mdOps.Put(ctx, rmd, session.VerifyingKey,
-			nil, keybase1.MDPriorityNormal)
+		irmd, err := mdOps.Put(
+			ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 		require.NoError(t, err, "i=%d", i)
 		prevRoot = irmd.mdID
 	}
@@ -171,15 +171,15 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	rmd.SetPrevRoot(prevRoot)
 	resolveMD, err := rmd.deepCopy(config.Codec())
 	require.NoError(t, err)
-	_, err = oldMDOps.Put(ctx, rmd, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	_, err = oldMDOps.Put(
+		ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	require.NoError(t, err)
 
 	for i := kbfsmd.Revision(8); i <= 10; i++ {
 		rmd.SetRevision(kbfsmd.Revision(i))
 		rmd.SetPrevRoot(prevRoot)
-		irmd, err := mdOps.Put(ctx, rmd, session.VerifyingKey,
-			nil, keybase1.MDPriorityNormal)
+		irmd, err := mdOps.Put(
+			ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 		require.NoError(t, err, "i=%d", i)
 		prevRoot = irmd.mdID
 	}
@@ -213,7 +213,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	for i := kbfsmd.Revision(11); i < 41; i++ {
 		rmd.SetRevision(kbfsmd.Revision(i))
 		rmd.SetPrevRoot(prevRoot)
-		irmd, err := mdOps.PutUnmerged(ctx, rmd, session.VerifyingKey)
+		irmd, err := mdOps.PutUnmerged(ctx, rmd, session.VerifyingKey, nil)
 		require.NoError(t, err, "i=%d", i)
 		prevRoot = irmd.mdID
 		require.Equal(t, bid, rmd.BID())
@@ -245,7 +245,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 
 	// (7) resolve the branch
 	_, err = mdOps.ResolveBranch(
-		ctx, id, bid, nil, resolveMD, session.VerifyingKey)
+		ctx, id, bid, nil, resolveMD, session.VerifyingKey, nil)
 	require.NoError(t, err)
 
 	// (8) verify head is pruned
@@ -308,7 +308,7 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 	rmd.SetPrevRoot(kbfsmd.FakeID(1))
 	rmd.SetBranchID(kbfsmd.FakeBranchID(1))
 
-	_, err = mdOps.PutUnmerged(ctx, rmd, session.VerifyingKey)
+	_, err = mdOps.PutUnmerged(ctx, rmd, session.VerifyingKey, nil)
 	require.NoError(t, err)
 }
 
@@ -342,7 +342,7 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 
 	rmd := makeMDForJournalMDOpsTest(t, config, id, h, kbfsmd.Revision(1))
 
-	_, err = mdOps.PutUnmerged(ctx, rmd, session.VerifyingKey)
+	_, err = mdOps.PutUnmerged(ctx, rmd, session.VerifyingKey, nil)
 	require.Error(t, err, "Unmerged put with rmd.BID() == j.branchID == kbfsmd.NullBranchID")
 }
 

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -2963,48 +2963,48 @@ func (mr *MockMDOpsMockRecorder) PruneBranch(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // Put mocks base method
-func (m *MockMDOps) Put(arg0 context.Context, arg1 *RootMetadata, arg2 kbfscrypto.VerifyingKey, arg3 *keybase1.LockContext, arg4 keybase1.MDPriority) (ImmutableRootMetadata, error) {
+func (m *MockMDOps) Put(arg0 context.Context, arg1 *RootMetadata, arg2 kbfscrypto.VerifyingKey, arg3 *keybase1.LockContext, arg4 keybase1.MDPriority, arg5 data.BlockPutState) (ImmutableRootMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(ImmutableRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Put indicates an expected call of Put
-func (mr *MockMDOpsMockRecorder) Put(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) Put(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockMDOps)(nil).Put), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockMDOps)(nil).Put), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // PutUnmerged mocks base method
-func (m *MockMDOps) PutUnmerged(arg0 context.Context, arg1 *RootMetadata, arg2 kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error) {
+func (m *MockMDOps) PutUnmerged(arg0 context.Context, arg1 *RootMetadata, arg2 kbfscrypto.VerifyingKey, arg3 data.BlockPutState) (ImmutableRootMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutUnmerged", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PutUnmerged", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(ImmutableRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PutUnmerged indicates an expected call of PutUnmerged
-func (mr *MockMDOpsMockRecorder) PutUnmerged(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) PutUnmerged(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUnmerged", reflect.TypeOf((*MockMDOps)(nil).PutUnmerged), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUnmerged", reflect.TypeOf((*MockMDOps)(nil).PutUnmerged), arg0, arg1, arg2, arg3)
 }
 
 // ResolveBranch mocks base method
-func (m *MockMDOps) ResolveBranch(arg0 context.Context, arg1 tlf.ID, arg2 kbfsmd.BranchID, arg3 []kbfsblock.ID, arg4 *RootMetadata, arg5 kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error) {
+func (m *MockMDOps) ResolveBranch(arg0 context.Context, arg1 tlf.ID, arg2 kbfsmd.BranchID, arg3 []kbfsblock.ID, arg4 *RootMetadata, arg5 kbfscrypto.VerifyingKey, arg6 data.BlockPutState) (ImmutableRootMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveBranch", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "ResolveBranch", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(ImmutableRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ResolveBranch indicates an expected call of ResolveBranch
-func (mr *MockMDOpsMockRecorder) ResolveBranch(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockMDOpsMockRecorder) ResolveBranch(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBranch", reflect.TypeOf((*MockMDOps)(nil).ResolveBranch), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBranch", reflect.TypeOf((*MockMDOps)(nil).ResolveBranch), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // ValidateLatestHandleNotFinal mocks base method

--- a/go/kbfs/libkbfs/md_ops_test.go
+++ b/go/kbfs/libkbfs/md_ops_test.go
@@ -857,8 +857,8 @@ func testMDOpsPutPublicSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
-	_, err = config.MDOps().Put(ctx, rmd, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal)
+	_, err = config.MDOps().Put(
+		ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal, nil)
 	require.NoError(t, err)
 
 	rmds := mdServer.getLastRmds()
@@ -880,8 +880,8 @@ func testMDOpsPutPrivateSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	putMDForPrivate(config, rmd)
 
 	key := kbfscrypto.MakeFakeVerifyingKeyOrBust("test key")
-	if _, err := config.MDOps().Put(ctx, rmd, key,
-		nil, keybase1.MDPriorityNormal); err != nil {
+	if _, err := config.MDOps().Put(
+		ctx, rmd, key, nil, keybase1.MDPriorityNormal, nil); err != nil {
 		t.Errorf("Got error on put: %v", err)
 	}
 }
@@ -916,8 +916,9 @@ func testMDOpsPutFailEncode(t *testing.T, ver kbfsmd.MetadataVer) {
 	err = errors.New("Fake fail")
 	config.SetCodec(failEncodeCodec{config.Codec(), err})
 
-	if _, err2 := config.MDOps().Put(ctx, rmd, session.VerifyingKey,
-		nil, keybase1.MDPriorityNormal); err2 != err {
+	if _, err2 := config.MDOps().Put(
+		ctx, rmd, session.VerifyingKey, nil, keybase1.MDPriorityNormal,
+		nil); err2 != err {
 		t.Errorf("Got bad error on put: %v", err2)
 	}
 }


### PR DESCRIPTION
The MDOps interface is usually responsible for putting a completed MD into the MD cache.  The reason is that the journal needs to do so under its own lock, to avoid racing with itself when it detects a conflict, transforms the MD into a branch MD, and replaces it in the cache.  If something else races with the journal's branch conversion, it could end up looking like the local MD version is the real MD for the merged branch, which isn't true when there's a conflict.

There was one place where this was missing, however; in the code that re-embeds block changes after the MD was put to the server or the journal.  This code re-embeds the changes, and then replaces the MD in the cache, which could race with journal conflict detection.

This commit changes the flow so that the block changes are re-embeded by the MDOps implementation.  This requires passing a `blockPutState` around to more places, but it guarantees that `folderBranchOps` won't race against the journal and put an unmerged MD back into the cache as a merged one.

Issue: HOTPOT-324