### PR TITLE
fix a bug in processing wallet events

### DIFF
--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -311,12 +311,13 @@ func (s *Stellar) handlePaymentStatus(mctx libkb.MetaContext, obm gregor.OutOfBa
 	}
 
 	paymentID := stellar1.NewPaymentID(msg.TxID)
-	if err = s.refreshPaymentFromNotification(mctx, msg.AccountID, paymentID); err != nil {
+	notifiedAccountID, err := s.refreshPaymentFromNotification(mctx, paymentID)
+	if err != nil {
 		mctx.Debug("refreshPaymentFromNotification error: %s", err)
 		return
 	}
 
-	s.G().NotifyRouter.HandleWalletPaymentStatusNotification(mctx.Ctx(), msg.AccountID, paymentID)
+	s.G().NotifyRouter.HandleWalletPaymentStatusNotification(mctx.Ctx(), notifiedAccountID, paymentID)
 }
 
 func (s *Stellar) handlePaymentNotification(mctx libkb.MetaContext, obm gregor.OutOfBandMessage) {
@@ -328,21 +329,58 @@ func (s *Stellar) handlePaymentNotification(mctx libkb.MetaContext, obm gregor.O
 		return
 	}
 
-	if err = s.refreshPaymentFromNotification(mctx, msg.AccountID, msg.PaymentID); err != nil {
+	notifiedAccountID, err := s.refreshPaymentFromNotification(mctx, msg.PaymentID)
+	if err != nil {
 		mctx.Debug("refreshPaymentFromNotification error: %s", err)
 		return
 	}
-	s.G().NotifyRouter.HandleWalletPaymentNotification(mctx.Ctx(), msg.AccountID, msg.PaymentID)
+	s.G().NotifyRouter.HandleWalletPaymentNotification(mctx.Ctx(), notifiedAccountID, msg.PaymentID)
 }
 
-func (s *Stellar) refreshPaymentFromNotification(mctx libkb.MetaContext, accountID stellar1.AccountID, paymentID stellar1.PaymentID) error {
-	// load the payment and then refresh the wallet state for the account.
-	DefaultLoader(s.G()).LoadPaymentSync(mctx.Ctx(), paymentID)
-	if err := s.walletState.Refresh(mctx, accountID, "notification received"); err != nil {
-		return err
+func (s *Stellar) findAccountFromPayment(mctx libkb.MetaContext, payment *stellar1.PaymentLocal) (stellar1.AccountID, error) {
+	var emptyAccountID stellar1.AccountID
+	ok, _, err := getGlobal(mctx.G()).OwnAccountCached(mctx, payment.FromAccountID)
+	if err != nil {
+		return emptyAccountID, err
 	}
+	if ok {
+		// the running user is the sender of this payment
+		return payment.FromAccountID, nil
+	}
+	if payment.ToAccountID == nil {
+		return emptyAccountID, ErrAccountNotFound
+	}
+	ok, _, err = getGlobal(mctx.G()).OwnAccountCached(mctx, *payment.ToAccountID)
+	if err != nil {
+		return emptyAccountID, err
+	}
+	if ok {
+		// the running user is the recipient of this payment
+		return *payment.ToAccountID, nil
+	}
+	return emptyAccountID, ErrAccountNotFound
+}
 
-	return nil
+func (s *Stellar) refreshPaymentFromNotification(mctx libkb.MetaContext, paymentID stellar1.PaymentID) (notifiedAccountID stellar1.AccountID, err error) {
+	var emptyAccountID stellar1.AccountID
+
+	// load the payment
+	loader := DefaultLoader(s.G())
+	loader.LoadPaymentSync(mctx.Ctx(), paymentID)
+	payment, ok := loader.GetPaymentLocal(mctx.Ctx(), paymentID)
+	if !ok {
+		return emptyAccountID, fmt.Errorf("couldn't find the payment immediately after loading it %v", paymentID)
+	}
+	// find the accountID for the running user in the payment (could be sender, recipient, neither)
+	notifiedAccountID, err = s.findAccountFromPayment(mctx, payment)
+	if err != nil {
+		return emptyAccountID, err
+	}
+	// refresh the wallet state for this accountID
+	if err := s.walletState.Refresh(mctx, notifiedAccountID, "notification received"); err != nil {
+		return notifiedAccountID, err
+	}
+	return notifiedAccountID, nil
 }
 
 func (s *Stellar) handleRequestStatus(mctx libkb.MetaContext, obm gregor.OutOfBandMessage) {

--- a/go/stellar/loader.go
+++ b/go/stellar/loader.go
@@ -89,6 +89,11 @@ func DefaultLoader(g *libkb.GlobalContext) *Loader {
 	return defaultLoader
 }
 
+func (p *Loader) GetPaymentLocal(ctx context.Context, paymentID stellar1.PaymentID) (*stellar1.PaymentLocal, bool) {
+	pmt, ok := p.payments[paymentID]
+	return pmt, ok
+}
+
 func (p *Loader) LoadPayment(ctx context.Context, convID chat1.ConversationID, msgID chat1.MessageID, senderUsername string, paymentID stellar1.PaymentID) *chat1.UIPaymentInfo {
 	defer libkb.CTrace(ctx, p.G().GetLog(), fmt.Sprintf("Loader.LoadPayment(cid=%s,mid=%s,pid=%s)", convID, msgID, paymentID), func() error { return nil })()
 
@@ -120,7 +125,7 @@ func (p *Loader) LoadPayment(ctx context.Context, convID chat1.ConversationID, m
 		m.Warning("existing payment message info does not match load info: (%v, %v) != (%v, %v)", msg.convID, msg.msgID, convID, msgID)
 	}
 
-	payment, ok := p.payments[paymentID]
+	payment, ok := p.GetPaymentLocal(ctx, paymentID)
 	if ok {
 		info := p.uiPaymentInfo(m, payment, msg)
 		p.G().NotifyRouter.HandleChatPaymentInfo(m.Ctx(), p.G().ActiveDevice.UID(), convID, msgID, *info)


### PR DESCRIPTION
when a payment status updates, gregor sends an update message to the user with the paymentID and the accountID. the accountID is relevant (although not necessary) because it's used in, for example, transaction details to show a lumen payment denominated in the correct currency. among other things, this message triggers new notifications to `keybase chat api-listen --wallet`. this codepath expects the accountID to be findable for the user receiving the message. 

when alice sends bob a payment, and then it transitions from `pending` to `completed`, gregor sends the exact same message to both of them in the conversation alice,bob. this is a problem for bob, because the accountID on the message belongs to alice. if bob is listening for wallet events, there will be an account-not-found error which gets swallowed, and it looks like the payment is left on the floor. this is what i was seeing with my smsbot. 

so here's what i did:
1. ignore the accountID that gets sent in `stellar.payment_status` and `stellar.payment_notification` messages. instead, load the payment and then see which of the accountIDs on it (sender or recipient) belongs to the running user. use that accountID instead of erroring.
2. making change 1 resulted in a lot of duplicate messages being sent to `keybase chat api-listen --wallet`, so i added a little thing to dedupe on `{txID}:{status}`.

these two changes should make building on top of this cli command WAY nicer. 