### PR TITLE
Fix trustline threshold

### DIFF
--- a/go/stellar/trustlines.go
+++ b/go/stellar/trustlines.go
@@ -112,7 +112,7 @@ func DeleteTrustlineLocal(mctx libkb.MetaContext, arg stellar1.DeleteTrustlineLo
 				return err
 			}
 			if currentAmount != 0 {
-				return fmt.Errorf("cannot delete a trustline with a balance")
+				return fmt.Errorf("Cannot delete a trustline with a balance.")
 			}
 			found = true
 			break

--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -473,6 +473,11 @@
       "accountID": "Types.AccountID",
       "assetID": "Types.AssetID"
     },
+    "changedTrustline": {
+      "canError": {
+        "error": "string"
+      }
+    },
     "setTrustlineAcceptedAssets": {
       "accountID": "Types.AccountID",
       "assets": "Array<Types.AssetDescription>",

--- a/shared/actions/wallets-gen.tsx
+++ b/shared/actions/wallets-gen.tsx
@@ -30,6 +30,7 @@ export const changeAirdrop = 'wallets:changeAirdrop'
 export const changeDisplayCurrency = 'wallets:changeDisplayCurrency'
 export const changeMobileOnlyMode = 'wallets:changeMobileOnlyMode'
 export const changedAccountName = 'wallets:changedAccountName'
+export const changedTrustline = 'wallets:changedTrustline'
 export const checkDisclaimer = 'wallets:checkDisclaimer'
 export const clearBuilding = 'wallets:clearBuilding'
 export const clearBuildingAdvanced = 'wallets:clearBuildingAdvanced'
@@ -158,6 +159,8 @@ type _ChangeDisplayCurrencyPayload = {readonly accountID: Types.AccountID; reado
 type _ChangeMobileOnlyModePayload = {readonly accountID: Types.AccountID; readonly enabled: boolean}
 type _ChangedAccountNamePayload = {readonly accountID: Types.AccountID}
 type _ChangedAccountNamePayloadError = {readonly name: string; readonly error: string}
+type _ChangedTrustlinePayload = void
+type _ChangedTrustlinePayloadError = {readonly error: string}
 type _CheckDisclaimerPayload = {readonly nextScreen: Types.NextScreenAfterAcceptance}
 type _ClearBuildingAdvancedPayload = void
 type _ClearBuildingPayload = void
@@ -994,6 +997,13 @@ export const createAddTrustline = (payload: _AddTrustlinePayload): AddTrustlineP
 export const createCalculateBuildingAdvanced = (
   payload: _CalculateBuildingAdvancedPayload
 ): CalculateBuildingAdvancedPayload => ({payload, type: calculateBuildingAdvanced})
+export const createChangedTrustline = (payload: _ChangedTrustlinePayload): ChangedTrustlinePayload => ({
+  payload,
+  type: changedTrustline,
+})
+export const createChangedTrustlineError = (
+  payload: _ChangedTrustlinePayloadError
+): ChangedTrustlinePayloadError => ({error: true, payload, type: changedTrustline})
 export const createClearTrustlineSearchResults = (
   payload: _ClearTrustlineSearchResultsPayload
 ): ClearTrustlineSearchResultsPayload => ({payload, type: clearTrustlineSearchResults})
@@ -1159,6 +1169,15 @@ export type ChangedAccountNamePayloadError = {
   readonly error: true
   readonly payload: _ChangedAccountNamePayloadError
   readonly type: typeof changedAccountName
+}
+export type ChangedTrustlinePayload = {
+  readonly payload: _ChangedTrustlinePayload
+  readonly type: typeof changedTrustline
+}
+export type ChangedTrustlinePayloadError = {
+  readonly error: true
+  readonly payload: _ChangedTrustlinePayloadError
+  readonly type: typeof changedTrustline
 }
 export type CheckDisclaimerPayload = {
   readonly payload: _CheckDisclaimerPayload
@@ -1587,6 +1606,8 @@ export type Actions =
   | ChangeMobileOnlyModePayload
   | ChangedAccountNamePayload
   | ChangedAccountNamePayloadError
+  | ChangedTrustlinePayload
+  | ChangedTrustlinePayloadError
   | CheckDisclaimerPayload
   | ClearBuildingAdvancedPayload
   | ClearBuildingPayload

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1256,6 +1256,7 @@ const refreshTrustlinePopularAssets = () =>
 
 const addTrustline = (state: TypedState, {payload: {accountID, assetID}}) => {
   const asset = state.wallets.trustline.assetMap.get(assetID, Constants.emptyAssetDescription)
+  const refresh = WalletsGen.createRefreshTrustlineAcceptedAssets({accountID})
   return (
     asset !== Constants.emptyAssetDescription &&
     RPCStellarTypes.localAddTrustlineLocalRpcPromise(
@@ -1265,12 +1266,18 @@ const addTrustline = (state: TypedState, {payload: {accountID, assetID}}) => {
         trustline: {assetCode: asset.code, issuer: asset.issuerAccountID},
       },
       Constants.addTrustlineWaitingKey(accountID, assetID)
-    ).then(() => WalletsGen.createRefreshTrustlineAcceptedAssets({accountID}))
+    )
+      .then(() => [WalletsGen.createChangedTrustline(), refresh])
+      .catch(err => {
+        logger.warn(`Error: ${err.desc}`)
+        return [WalletsGen.createChangedTrustlineError({error: err.desc}), refresh]
+      })
   )
 }
 
 const deleteTrustline = (state: TypedState, {payload: {accountID, assetID}}) => {
   const asset = state.wallets.trustline.assetMap.get(assetID, Constants.emptyAssetDescription)
+  const refresh = WalletsGen.createRefreshTrustlineAcceptedAssets({accountID})
   return (
     asset !== Constants.emptyAssetDescription &&
     RPCStellarTypes.localDeleteTrustlineLocalRpcPromise(
@@ -1279,7 +1286,12 @@ const deleteTrustline = (state: TypedState, {payload: {accountID, assetID}}) => 
         trustline: {assetCode: asset.code, issuer: asset.issuerAccountID},
       },
       Constants.deleteTrustlineWaitingKey(accountID, assetID)
-    ).then(() => WalletsGen.createRefreshTrustlineAcceptedAssets({accountID}))
+    )
+      .then(() => [WalletsGen.createChangedTrustline(), refresh])
+      .catch(err => {
+        logger.warn(`Error: ${err.desc}`)
+        return [WalletsGen.createChangedTrustlineError({error: err.desc}), refresh]
+      })
   )
 }
 

--- a/shared/constants/types/wallets.tsx
+++ b/shared/constants/types/wallets.tsx
@@ -379,20 +379,22 @@ export type _State = {
   builtPayment: BuiltPayment
   builtPaymentAdvanced: BuiltPaymentAdvanced
   builtRequest: BuiltRequest
+  changeTrustlineError: string
   createNewAccountError: string
   currencies: I.List<Currency>
-  externalPartners: I.List<PartnerUrl>
   exportedSecretKey: HiddenString
   exportedSecretKeyAccountID: AccountID
-  inflationDestinations: I.List<InflationDestination>
-  inflationDestinationMap: I.Map<AccountID, AccountInflationDestination>
+  externalPartners: I.List<PartnerUrl>
   inflationDestinationError: string
+  inflationDestinationMap: I.Map<AccountID, AccountInflationDestination>
+  inflationDestinations: I.List<InflationDestination>
   lastSentXLM: boolean
   linkExistingAccountError: string
-  paymentsMap: I.Map<AccountID, I.Map<PaymentID, Payment>>
+  mobileOnlyMap: I.Map<AccountID, boolean>
   paymentCursorMap: I.Map<AccountID, StellarRPCTypes.PageCursor | null>
   paymentLoadingMoreMap: I.Map<AccountID, boolean>
   paymentOldestUnreadMap: I.Map<AccountID, PaymentID>
+  paymentsMap: I.Map<AccountID, I.Map<PaymentID, Payment>>
   reviewCounter: number // increments when we call reviewPayment,
   reviewLastSeqno: number | null // last UIPaymentReviewed.seqno received from the active review,
   secretKey: HiddenString
@@ -407,7 +409,6 @@ export type _State = {
   staticConfig: StaticConfig | null
   trustline: Trustline
   unreadPaymentsMap: I.Map<string, number>
-  mobileOnlyMap: I.Map<AccountID, boolean>
 }
 
 export type State = I.RecordOf<_State>

--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -229,6 +229,7 @@ export const makeState = I.Record<Types._State>({
   builtPayment: makeBuiltPayment(),
   builtPaymentAdvanced: emptyBuiltPaymentAdvanced,
   builtRequest: makeBuiltRequest(),
+  changeTrustlineError: '',
   createNewAccountError: '',
   currencies: I.List(),
   exportedSecretKey: new HiddenString(''),

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -363,12 +363,17 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         secretKeyError: actionHasError(action) ? action.payload.error : '',
         secretKeyValidationState: actionHasError(action) ? 'error' : 'valid',
       })
+    case WalletsGen.changedTrustline:
+      return actionHasError(action)
+        ? state.merge({changeTrustlineError: action.payload.error})
+        : state.merge({changeTrustlineError: ''})
     case WalletsGen.clearErrors:
       return state.merge({
         accountName: '',
         accountNameError: '',
         accountNameValidationState: 'none',
         builtPayment: state.get('builtPayment').merge({readyToSend: 'spinning'}),
+        changeTrustlineError: '',
         createNewAccountError: '',
         linkExistingAccountError: '',
         secretKey: new HiddenString(''),
@@ -383,6 +388,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
             accountName: '',
             accountNameError: '',
             accountNameValidationState: 'none',
+            changeTrustlineError: '',
             createNewAccountError: '',
             linkExistingAccountError: '',
             secretKey: new HiddenString(''),

--- a/shared/wallets/trustline/container.tsx
+++ b/shared/wallets/trustline/container.tsx
@@ -7,13 +7,14 @@ import * as Waiting from '../../constants/waiting'
 import {debounce} from 'lodash-es'
 import Trustline from '.'
 
-type OwnProps = Container.RouteProps< { accountID: Types.AccountID } >
+type OwnProps = Container.RouteProps<{accountID: Types.AccountID}>
 
 const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
   const accountID = Container.getRouteProps(ownProps, 'accountID') || Types.noAccountID
   return {
     accountAssets: Constants.getAssets(state, accountID),
     canAddTrustline: Constants.getAccount(state, accountID).canAddTrustline,
+    error: state.wallets.changeTrustlineError,
     trustline: state.wallets.trustline,
     waitingSearch: Waiting.anyWaiting(state, Constants.searchTrustlineAssetsWaitingKey),
   }
@@ -45,6 +46,7 @@ const mergeProps = (s, d, o: OwnProps) => {
     ).balanceAvailableToSend,
     canAddTrustline: s.canAddTrustline,
     clearTrustlineModal: d.clearTrustlineModal,
+    error: s.error,
     loaded: s.trustline.loaded,
     popularAssets: s.trustline.popularAssets.filter(assetID => !acceptedAssets.has(assetID)).toArray(),
     searchingAssets: s.trustline.searchingAssets && s.trustline.searchingAssets.toArray(),

--- a/shared/wallets/trustline/index.stories.tsx
+++ b/shared/wallets/trustline/index.stories.tsx
@@ -65,6 +65,7 @@ const commonTrustlineProps = {
   balanceAvailableToSend: '2',
   canAddTrustline: true,
   clearTrustlineModal: Sb.action('clearTrustlineModal'),
+  error: '',
   loaded: true,
   onDone: Sb.action('onDone'),
   onSearchChange: Sb.action('onSearchChange'),

--- a/shared/wallets/trustline/index.tsx
+++ b/shared/wallets/trustline/index.tsx
@@ -6,12 +6,12 @@ import * as Constants from '../../constants/wallets'
 import Asset from './asset-container'
 
 type _Props = {
-  accountID: Types.AccountID
   acceptedAssets: Array<Types.AssetID>
+  accountID: Types.AccountID
   balanceAvailableToSend: string
   canAddTrustline: boolean
   clearTrustlineModal: () => void
-  errorMessage?: string
+  error: string
   loaded: boolean
   onSearchChange: (text: string) => void
   popularAssets: Array<Types.AssetID>
@@ -135,6 +135,12 @@ const Body = (props: BodyProps) => {
                   props.balanceAvailableToSend
                 } XLM.`}
               />
+            </Kb.Banner>
+          )}
+          {!props.canAddTrustline && !!props.error && <Kb.Divider />}
+          {!!props.error && (
+            <Kb.Banner color="red">
+              <Kb.BannerParagraph bannerColor="red" content={props.error} />
             </Kb.Banner>
           )}
           {props.searchingAssets && !props.searchingAssets.length ? (


### PR DESCRIPTION
An account with 1.51 XLM and one existing trust line cannot add another trust line. Previously this offered that they could.