### PR TITLE
quick fix: more aggressively hide the cancel button

### DIFF
--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -313,13 +313,18 @@ func transformPaymentRelay(mctx libkb.MetaContext, acctID stellar1.AccountID, p 
 		}
 	}
 	if p.Claim != nil {
-		loc.ShowCancel = false // if there's a claim in either direction, it's too late to cancel
 		loc.StatusSimplified = p.Claim.ToPaymentStatus()
 		loc.ToAccountID = &p.Claim.ToStellar
 		loc.ToType = stellar1.ParticipantType_STELLAR
 		loc.ToUsername = ""
 		loc.ToAccountName = ""
-		if p.Claim.ToPaymentStatus() == stellar1.PaymentStatus_CANCELED {
+		claimStatus := p.Claim.ToPaymentStatus()
+		if claimStatus != stellar1.PaymentStatus_ERROR {
+			// if there's a claim and it's not currently erroring, then hide the
+			// `cancel` button
+			loc.ShowCancel = false
+		}
+		if claimStatus == stellar1.PaymentStatus_CANCELED {
 			// canceled payment. blank out toAssertion and stow in originalToAssertion
 			// set delta to what it would have been had the payment completed
 			loc.ToAssertion = ""

--- a/go/stellar/transform.go
+++ b/go/stellar/transform.go
@@ -313,6 +313,7 @@ func transformPaymentRelay(mctx libkb.MetaContext, acctID stellar1.AccountID, p 
 		}
 	}
 	if p.Claim != nil {
+		loc.ShowCancel = false // if there's a claim in either direction, it's too late to cancel
 		loc.StatusSimplified = p.Claim.ToPaymentStatus()
 		loc.ToAccountID = &p.Claim.ToStellar
 		loc.ToType = stellar1.ParticipantType_STELLAR
@@ -334,7 +335,6 @@ func transformPaymentRelay(mctx libkb.MetaContext, acctID stellar1.AccountID, p 
 		}
 		if p.Claim.TxStatus == stellar1.TransactionStatus_SUCCESS {
 			// If the claim succeeded, the relay payment is done.
-			loc.ShowCancel = false
 			loc.StatusDetail = ""
 		} else {
 			claimantUsername, err := lookupUsername(mctx, p.Claim.To.Uid)


### PR DESCRIPTION
canceling a relay payment doesn't correctly disable (or mark as waiting, or remove completely) the cancel button. 

i kind of think the nicest behavior here would be rearchitecting how we wait in cancellation, and passing additional data from the service so the front-end understands this additional state (requested cancellation but that process is still pending) which i guess we never really handled explicitly. but that's kind of a lot of work and just doing this (removing the button more aggressively) seems to solve the issue in a fairly intuitive way. the downside is that it's the same UI for pending. but if you just clicked on the cancel button, you're not going to be confused. 