### PR TITLE
Format phone numbers in settings

### DIFF
--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -405,10 +405,8 @@ const loadSettings = (
       logger.warn(`Error loading settings: ${e.message}`)
     })
 
-const flipVis = (visibility: ChatTypes.Keybase1.IdentityVisibility): ChatTypes.Keybase1.IdentityVisibility =>
-  visibility === ChatTypes.Keybase1.IdentityVisibility.private
-    ? ChatTypes.Keybase1.IdentityVisibility.public
-    : ChatTypes.Keybase1.IdentityVisibility.private
+const flipVis = (searchable: boolean): ChatTypes.Keybase1.IdentityVisibility =>
+  searchable ? ChatTypes.Keybase1.IdentityVisibility.private : ChatTypes.Keybase1.IdentityVisibility.public
 
 const editEmail = (state, action: SettingsGen.EditEmailPayload, logger: Saga.SagaLogger) => {
   // TODO: consider allowing more than one action here
@@ -443,7 +441,7 @@ const editPhone = (state, action: SettingsGen.EditPhonePayload, logger: Saga.Sag
   if (action.payload.toggleSearchable) {
     const currentSettings = state.settings.phoneNumbers.phones.get(action.payload.phone)
     const newVisibility = currentSettings
-      ? flipVis(currentSettings.visibility)
+      ? flipVis(currentSettings.searchable)
       : ChatTypes.Keybase1.IdentityVisibility.private
     return RPCTypes.phoneNumbersSetVisibilityPhoneNumberRpcPromise({
       phoneNumber: action.payload.phone,

--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -393,7 +393,7 @@ const loadSettings = (
         (settings.emails || []).map(row => [row.email, Constants.makeEmailRow(row)])
       )
       const phoneMap: I.Map<string, Types.PhoneRow> = I.Map(
-        (settings.phoneNumbers || []).map(row => [row.phoneNumber, Constants.makePhoneRow(row)])
+        (settings.phoneNumbers || []).map(row => [row.phoneNumber, Constants.toPhoneRow(row)])
       )
       const loadedAction = SettingsGen.createLoadedSettings({
         emails: emailMap,

--- a/shared/constants/chat2/meta.tsx
+++ b/shared/constants/chat2/meta.tsx
@@ -299,10 +299,12 @@ export const inboxUIItemToConversationMeta = (i: RPCChatTypes.InboxUIItem, allow
     notificationsGlobalIgnoreMentions,
     notificationsMobile,
     participantToContactName: I.Map(
-      (i.participants || []).reduce<{[key: string]: string}>(
-        (map, part) => (part.contactName ? {...map, [part.assertion]: part.contactName} : map),
-        {}
-      )
+      (i.participants || []).reduce<{[key: string]: string}>((map, part) => {
+        if (part.contactName) {
+          map[part.assertion] = part.contactName
+        }
+        return map
+      }, {})
     ),
     participants: I.List((i.participants || []).map(part => part.assertion)),
     readMsgID: i.readMsgID,

--- a/shared/constants/settings.tsx
+++ b/shared/constants/settings.tsx
@@ -5,6 +5,8 @@ import * as I from 'immutable'
 import * as WaitingConstants from './waiting'
 import {getMeta} from './chat2/meta'
 import * as RPCTypes from './types/rpc-gen'
+import {e164ToDisplay} from '../util/phone-numbers'
+
 export const makeNotificationsGroup = I.Record<Types._NotificationsGroupState>({
   settings: I.List(),
   unsubscribedFromAll: false,
@@ -41,12 +43,21 @@ export const makeEmailRow = I.Record<Types._EmailRow>({
 })
 
 export const makePhoneRow = I.Record<Types._PhoneRow>({
-  ctime: 0,
-  phoneNumber: '',
+  displayNumber: '',
+  e164: '',
+  searchable: false,
   superseded: false,
   verified: false,
-  visibility: RPCTypes.IdentityVisibility.private,
 })
+
+export const toPhoneRow = (p: RPCTypes.UserPhoneNumber) =>
+  makePhoneRow({
+    displayNumber: e164ToDisplay(p.phoneNumber),
+    e164: p.phoneNumber,
+    searchable: p.visibility === RPCTypes.IdentityVisibility.public,
+    superseded: p.superseded,
+    verified: p.verified,
+  })
 
 export const makeFeedback = I.Record<Types._FeedbackState>({
   error: null,

--- a/shared/constants/types/settings.tsx
+++ b/shared/constants/types/settings.tsx
@@ -80,7 +80,13 @@ export type _EmailState = {
 }
 export type EmailState = I.RecordOf<_EmailState>
 
-export type _PhoneRow = RPCTypes.UserPhoneNumber
+export type _PhoneRow = {
+  displayNumber: string
+  e164: string
+  searchable: boolean
+  superseded: boolean
+  verified: boolean
+}
 export type PhoneRow = I.RecordOf<_PhoneRow>
 
 export type _FeedbackState = {

--- a/shared/settings/account/add-modals.tsx
+++ b/shared/settings/account/add-modals.tsx
@@ -9,6 +9,7 @@ import {EnterEmailBody} from '../../signup/email/'
 import {EnterPhoneNumberBody} from '../../signup/phone-number/'
 import {VerifyBody} from '../../signup/phone-number/verify'
 import {Props as HeaderHocProps} from '../../common-adapters/header-hoc/types'
+import {e164ToDisplay} from '../../util/phone-numbers'
 
 export const Email = () => {
   const dispatch = Container.useDispatch()
@@ -30,7 +31,7 @@ export const Email = () => {
       // success
       dispatch(RouteTreeGen.createClearModals())
     }
-  }, [addedEmail, dispatch])
+  }, [addEmailInProgress, addedEmail, dispatch])
 
   const onClose = React.useCallback(() => dispatch(RouteTreeGen.createNavigateUp()), [dispatch])
   const onContinue = React.useCallback(() => {
@@ -201,7 +202,7 @@ export const VerifyPhone = () => {
 
   const onResend = React.useCallback(
     () => dispatch(SettingsGen.createResendVerificationForPhoneNumber({phoneNumber: pendingVerification})),
-    [dispatch]
+    [dispatch, pendingVerification]
   )
   const onClose = React.useCallback(() => {
     dispatch(SettingsGen.createClearPhoneNumberAdd())
@@ -212,6 +213,8 @@ export const VerifyPhone = () => {
     [dispatch, code, pendingVerification]
   )
   const disabled = !code
+
+  const displayPhone = e164ToDisplay(pendingVerification)
   return (
     <Kb.Modal
       onClose={onClose}
@@ -220,7 +223,7 @@ export const VerifyPhone = () => {
         style: styles.blueBackground,
         title: (
           <Kb.Text type="BodySmall" negative={true}>
-            {pendingVerification || 'Unknown number'}
+            {displayPhone || 'Unknown number'}
           </Kb.Text>
         ),
       }}

--- a/shared/settings/account/email-phone-row.tsx
+++ b/shared/settings/account/email-phone-row.tsx
@@ -29,7 +29,7 @@ const badge = (backgroundColor: string, menuItem: boolean = false) => (
     style={Styles.collapseStyles([
       styles.badge,
       menuItem ? styles.badgeMenuItem : styles.badgeGearIcon,
-      {backgroundColor},
+      { backgroundColor },
     ])}
   />
 )
@@ -98,7 +98,7 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
 
   return (
     <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true} style={styles.container}>
-      <Kb.Box2 alignItems="flex-start" direction="vertical" style={{...Styles.globalStyles.flexOne}}>
+      <Kb.Box2 alignItems="flex-start" direction="vertical" style={{ ...Styles.globalStyles.flexOne }}>
         <Kb.Text type="BodySemibold">{props.address}</Kb.Text>
         {(!!subtitle || !props.verified) && (
           <Kb.Box2 direction="horizontal" alignItems="flex-start" gap="xtiny" fullWidth={true}>
@@ -152,8 +152,8 @@ const styles = Styles.styleSheetCreate({
   menuHeader: {
     height: 64,
   },
-  menuNoGrow: Styles.platformStyles({isElectron: {width: 220}}),
-  positionRelative: {position: 'relative'},
+  menuNoGrow: Styles.platformStyles({ isElectron: { width: 220 } }),
+  positionRelative: { position: 'relative' },
 })
 
 // props exported for stories
@@ -170,34 +170,34 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => ({
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch, ownProps: OwnProps) => ({
   _onMakeNotSearchable: () =>
-    dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makeSearchable: false})),
+    dispatch(SettingsGen.createEditEmail({ email: ownProps.contactKey, makeSearchable: false })),
   _onMakeSearchable: () =>
-    dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makeSearchable: true})),
+    dispatch(SettingsGen.createEditEmail({ email: ownProps.contactKey, makeSearchable: true })),
   email: {
     onDelete: () =>
       dispatch(
         RouteTreeGen.createNavigateAppend({
-          path: [{props: {address: ownProps.contactKey, type: 'email'}, selected: 'settingsDeleteAddress'}],
+          path: [{ props: { address: ownProps.contactKey, type: 'email' }, selected: 'settingsDeleteAddress' }],
         })
       ),
     onMakePrimary: () =>
-      dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makePrimary: true})),
-    onVerify: () => dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, verify: true})),
+      dispatch(SettingsGen.createEditEmail({ email: ownProps.contactKey, makePrimary: true })),
+    onVerify: () => dispatch(SettingsGen.createEditEmail({ email: ownProps.contactKey, verify: true })),
   },
   phone: {
     _onVerify: phoneNumber => {
-      dispatch(SettingsGen.createResendVerificationForPhoneNumber({phoneNumber}))
-      dispatch(RouteTreeGen.createNavigateAppend({path: ['settingsVerifyPhone']}))
+      dispatch(SettingsGen.createResendVerificationForPhoneNumber({ phoneNumber }))
+      dispatch(RouteTreeGen.createNavigateAppend({ path: ['settingsVerifyPhone'] }))
     },
     onDelete: () =>
       dispatch(
         RouteTreeGen.createNavigateAppend({
-          path: [{props: {address: ownProps.contactKey, type: 'phone'}, selected: 'settingsDeleteAddress'}],
+          path: [{ props: { address: ownProps.contactKey, type: 'phone' }, selected: 'settingsDeleteAddress' }],
         })
       ),
-    onMakePrimary: () => {}, // this is not a supported phone action
+    onMakePrimary: () => { }, // this is not a supported phone action
     onToggleSearchable: () =>
-      dispatch(SettingsGen.createEditPhone({phone: ownProps.contactKey, toggleSearchable: true})),
+      dispatch(SettingsGen.createEditPhone({ phone: ownProps.contactKey, toggleSearchable: true })),
   },
 })
 
@@ -206,16 +206,14 @@ const ConnectedEmailPhoneRow = Container.namedConnect(
   mapDispatchToProps,
   (stateProps, dispatchProps, _: OwnProps) => {
     if (stateProps._phoneRow) {
-      const searchable = stateProps._phoneRow.visibility === RPCTypes.IdentityVisibility.public
       return {
-        address: stateProps._phoneRow.phoneNumber,
+        address: stateProps._phoneRow.displayNumber,
         onDelete: dispatchProps.phone.onDelete,
         onMakePrimary: dispatchProps.phone.onMakePrimary,
         onToggleSearchable: dispatchProps.phone.onToggleSearchable,
-        onVerify: () =>
-          stateProps._phoneRow && dispatchProps.phone._onVerify(stateProps._phoneRow.phoneNumber),
+        onVerify: () => dispatchProps.phone._onVerify(stateProps._phoneRow.e164),
         primary: false,
-        searchable,
+        searchable: stateProps._phoneRow.searchable,
         type: 'phone' as const,
         verified: stateProps._phoneRow.verified,
       }
@@ -233,10 +231,10 @@ const ConnectedEmailPhoneRow = Container.namedConnect(
     } else
       return {
         address: '',
-        onDelete: () => {},
-        onMakePrimary: () => {},
-        onToggleSearchable: () => {},
-        onVerify: () => {},
+        onDelete: () => { },
+        onMakePrimary: () => { },
+        onToggleSearchable: () => { },
+        onVerify: () => { },
         primary: false,
         searchable: false,
         type: 'phone' as const,

--- a/shared/settings/account/email-phone-row.tsx
+++ b/shared/settings/account/email-phone-row.tsx
@@ -29,7 +29,7 @@ const badge = (backgroundColor: string, menuItem: boolean = false) => (
     style={Styles.collapseStyles([
       styles.badge,
       menuItem ? styles.badgeMenuItem : styles.badgeGearIcon,
-      { backgroundColor },
+      {backgroundColor},
     ])}
   />
 )
@@ -98,7 +98,7 @@ const _EmailPhoneRow = (props: Kb.PropsWithOverlay<Props>) => {
 
   return (
     <Kb.Box2 direction="horizontal" alignItems="center" fullWidth={true} style={styles.container}>
-      <Kb.Box2 alignItems="flex-start" direction="vertical" style={{ ...Styles.globalStyles.flexOne }}>
+      <Kb.Box2 alignItems="flex-start" direction="vertical" style={{...Styles.globalStyles.flexOne}}>
         <Kb.Text type="BodySemibold">{props.address}</Kb.Text>
         {(!!subtitle || !props.verified) && (
           <Kb.Box2 direction="horizontal" alignItems="flex-start" gap="xtiny" fullWidth={true}>
@@ -152,8 +152,8 @@ const styles = Styles.styleSheetCreate({
   menuHeader: {
     height: 64,
   },
-  menuNoGrow: Styles.platformStyles({ isElectron: { width: 220 } }),
-  positionRelative: { position: 'relative' },
+  menuNoGrow: Styles.platformStyles({isElectron: {width: 220}}),
+  positionRelative: {position: 'relative'},
 })
 
 // props exported for stories
@@ -170,34 +170,34 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => ({
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch, ownProps: OwnProps) => ({
   _onMakeNotSearchable: () =>
-    dispatch(SettingsGen.createEditEmail({ email: ownProps.contactKey, makeSearchable: false })),
+    dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makeSearchable: false})),
   _onMakeSearchable: () =>
-    dispatch(SettingsGen.createEditEmail({ email: ownProps.contactKey, makeSearchable: true })),
+    dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makeSearchable: true})),
   email: {
     onDelete: () =>
       dispatch(
         RouteTreeGen.createNavigateAppend({
-          path: [{ props: { address: ownProps.contactKey, type: 'email' }, selected: 'settingsDeleteAddress' }],
+          path: [{props: {address: ownProps.contactKey, type: 'email'}, selected: 'settingsDeleteAddress'}],
         })
       ),
     onMakePrimary: () =>
-      dispatch(SettingsGen.createEditEmail({ email: ownProps.contactKey, makePrimary: true })),
-    onVerify: () => dispatch(SettingsGen.createEditEmail({ email: ownProps.contactKey, verify: true })),
+      dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, makePrimary: true})),
+    onVerify: () => dispatch(SettingsGen.createEditEmail({email: ownProps.contactKey, verify: true})),
   },
   phone: {
     _onVerify: phoneNumber => {
-      dispatch(SettingsGen.createResendVerificationForPhoneNumber({ phoneNumber }))
-      dispatch(RouteTreeGen.createNavigateAppend({ path: ['settingsVerifyPhone'] }))
+      dispatch(SettingsGen.createResendVerificationForPhoneNumber({phoneNumber}))
+      dispatch(RouteTreeGen.createNavigateAppend({path: ['settingsVerifyPhone']}))
     },
     onDelete: () =>
       dispatch(
         RouteTreeGen.createNavigateAppend({
-          path: [{ props: { address: ownProps.contactKey, type: 'phone' }, selected: 'settingsDeleteAddress' }],
+          path: [{props: {address: ownProps.contactKey, type: 'phone'}, selected: 'settingsDeleteAddress'}],
         })
       ),
-    onMakePrimary: () => { }, // this is not a supported phone action
+    onMakePrimary: () => {}, // this is not a supported phone action
     onToggleSearchable: () =>
-      dispatch(SettingsGen.createEditPhone({ phone: ownProps.contactKey, toggleSearchable: true })),
+      dispatch(SettingsGen.createEditPhone({phone: ownProps.contactKey, toggleSearchable: true})),
   },
 })
 
@@ -232,10 +232,10 @@ const ConnectedEmailPhoneRow = Container.namedConnect(
     } else
       return {
         address: '',
-        onDelete: () => { },
-        onMakePrimary: () => { },
-        onToggleSearchable: () => { },
-        onVerify: () => { },
+        onDelete: () => {},
+        onMakePrimary: () => {},
+        onToggleSearchable: () => {},
+        onVerify: () => {},
         primary: false,
         searchable: false,
         type: 'phone' as const,

--- a/shared/settings/account/email-phone-row.tsx
+++ b/shared/settings/account/email-phone-row.tsx
@@ -206,16 +206,17 @@ const ConnectedEmailPhoneRow = Container.namedConnect(
   mapDispatchToProps,
   (stateProps, dispatchProps, _: OwnProps) => {
     if (stateProps._phoneRow) {
+      const pr = stateProps._phoneRow
       return {
-        address: stateProps._phoneRow.displayNumber,
+        address: pr.displayNumber,
         onDelete: dispatchProps.phone.onDelete,
         onMakePrimary: dispatchProps.phone.onMakePrimary,
         onToggleSearchable: dispatchProps.phone.onToggleSearchable,
-        onVerify: () => dispatchProps.phone._onVerify(stateProps._phoneRow.e164),
+        onVerify: () => dispatchProps.phone._onVerify(pr.e164),
         primary: false,
-        searchable: stateProps._phoneRow.searchable,
+        searchable: pr.searchable,
         type: 'phone' as const,
-        verified: stateProps._phoneRow.verified,
+        verified: pr.verified,
       }
     } else if (stateProps._emailRow) {
       const searchable = stateProps._emailRow.visibility === RPCTypes.IdentityVisibility.public

--- a/shared/signup/phone-number/verify.tsx
+++ b/shared/signup/phone-number/verify.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import {SignupScreen} from '../common'
+import {e164ToDisplay} from '../../util/phone-numbers'
 
 export type Props = {
   error: string
@@ -17,6 +18,7 @@ const VerifyPhoneNumber = (props: Props) => {
   const [code, onChangeCode] = React.useState('')
   const disabled = !code
   const onContinue = () => (disabled ? {} : props.onContinue(code))
+  const displayPhone = e164ToDisplay(props.phoneNumber)
   return (
     <SignupScreen
       onBack={props.onBack}
@@ -32,7 +34,7 @@ const VerifyPhoneNumber = (props: Props) => {
       buttons={[{label: 'Continue', onClick: onContinue, type: 'Success', waiting: props.verifyWaiting}]}
       titleComponent={
         <Kb.Text type="BodyTinySemibold" style={styles.headerText} center={true}>
-          {props.phoneNumber}
+          {displayPhone}
         </Kb.Text>
       }
       containerStyle={styles.container}
@@ -43,7 +45,7 @@ const VerifyPhoneNumber = (props: Props) => {
             Back
           </Kb.Text>
           <Kb.Text type="BodyTinySemibold" style={styles.headerText} center={true}>
-            {props.phoneNumber}
+            {displayPhone}
           </Kb.Text>
           <Kb.Box2 direction="horizontal" style={Styles.globalStyles.flexOne} />
         </Kb.Box2>

--- a/shared/util/phone-numbers/index.tsx
+++ b/shared/util/phone-numbers/index.tsx
@@ -1,8 +1,8 @@
-import {isMobile} from '../../constants/platform'
+import { isMobile } from '../../constants/platform'
 import libphonenumber from 'google-libphonenumber'
 import countries from './country-data/countries.json'
 import supportedCodes from './sms-support/data.json'
-import {emojiIndexByChar} from '../../common-adapters/markdown/emoji-gen'
+import { emojiIndexByChar } from '../../common-adapters/markdown/emoji-gen'
 
 const PNF = libphonenumber.PhoneNumberFormat
 export const PhoneNumberFormat = PNF
@@ -21,8 +21,8 @@ export type CountryData = {
   pickerText: string
 }
 
-let countryDataRaw: {[key: string]: CountryData} = {}
-let codeToCountryRaw: {[key: string]: string} = {}
+let countryDataRaw: { [key: string]: CountryData } = {}
+let codeToCountryRaw: { [key: string]: string } = {}
 
 countries.forEach(curr => {
   if (
@@ -52,8 +52,8 @@ countries.forEach(curr => {
   }
 })
 
-export const countryData: {[key: string]: CountryData} = countryDataRaw
-export const codeToCountry: {[key: string]: string} = codeToCountryRaw
+export const countryData: { [key: string]: CountryData } = countryDataRaw
+export const codeToCountry: { [key: string]: string } = codeToCountryRaw
 
 const canadianAreaCodes = {
   '204': true,
@@ -111,7 +111,7 @@ export const validateNumber = (rawNumber: string, region?: string) => {
       valid,
     }
   } catch (e) {
-    return {e164: '', valid: false}
+    return { e164: '', valid: false }
   }
 }
 
@@ -119,6 +119,17 @@ export const formatPhoneNumber = (rawNumber: string) => {
   // TODO: support non-US numbers
   const number = phoneUtil.parse(rawNumber, 'US')
   return `+${number.getCountryCode()} ${phoneUtil.format(number, PNF.NATIONAL)}`
+}
+
+// Return phone number in international format, e.g. +1 (800) 555 0123
+// or e.164 if parsing fails
+export const e164ToDisplay = (e164: string) => {
+  try {
+    const number = phoneUtil.parse(e164)
+    return phoneUtil.format(number, PNF.INTERNATIONAL)
+  } catch (e) {
+    return e164
+  }
 }
 
 export const AsYouTypeFormatter = libphonenumber.AsYouTypeFormatter

--- a/shared/util/phone-numbers/index.tsx
+++ b/shared/util/phone-numbers/index.tsx
@@ -1,8 +1,8 @@
-import { isMobile } from '../../constants/platform'
+import {isMobile} from '../../constants/platform'
 import libphonenumber from 'google-libphonenumber'
 import countries from './country-data/countries.json'
 import supportedCodes from './sms-support/data.json'
-import { emojiIndexByChar } from '../../common-adapters/markdown/emoji-gen'
+import {emojiIndexByChar} from '../../common-adapters/markdown/emoji-gen'
 
 const PNF = libphonenumber.PhoneNumberFormat
 export const PhoneNumberFormat = PNF
@@ -21,8 +21,8 @@ export type CountryData = {
   pickerText: string
 }
 
-let countryDataRaw: { [key: string]: CountryData } = {}
-let codeToCountryRaw: { [key: string]: string } = {}
+let countryDataRaw: {[key: string]: CountryData} = {}
+let codeToCountryRaw: {[key: string]: string} = {}
 
 countries.forEach(curr => {
   if (
@@ -52,8 +52,8 @@ countries.forEach(curr => {
   }
 })
 
-export const countryData: { [key: string]: CountryData } = countryDataRaw
-export const codeToCountry: { [key: string]: string } = codeToCountryRaw
+export const countryData: {[key: string]: CountryData} = countryDataRaw
+export const codeToCountry: {[key: string]: string} = codeToCountryRaw
 
 const canadianAreaCodes = {
   '204': true,
@@ -111,7 +111,7 @@ export const validateNumber = (rawNumber: string, region?: string) => {
       valid,
     }
   } catch (e) {
-    return { e164: '', valid: false }
+    return {e164: '', valid: false}
   }
 }
 


### PR DESCRIPTION
- Transform phone numbers in settings to store both e164 and display formats.
- Use display formats in Settings > Account and in modals

Second part will format them in chat, it's a bit more complicated there. cc @keybase/y2ksquad 