### PR TITLE
Fix fontTerminalSemibold on Android.

### DIFF
--- a/shared/styles/index.native.tsx
+++ b/shared/styles/index.native.tsx
@@ -22,7 +22,7 @@ const font = isIOS
       fontRegular: {fontFamily: 'keybase-medium', fontWeight: 'normal'},
       fontSemibold: {fontFamily: 'keybase-semibold', fontWeight: 'normal'},
       fontTerminal: {fontFamily: 'SourceCodePro-Medium', fontWeight: 'normal'},
-      fontTerminalSemibold: {fontFamily: 'SourceCodePro-Semi', fontWeight: 'bold'},
+      fontTerminalSemibold: {fontFamily: 'SourceCodePro-Semibold', fontWeight: 'normal'},
       italic: {fontStyle: 'italic'},
     }
 


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review.