### PR TITLE
remove old route actions

### DIFF
--- a/shared/actions/__tests__/add-new-device.tsx
+++ b/shared/actions/__tests__/add-new-device.tsx
@@ -58,8 +58,8 @@ const startReduxSaga = (initialStore?: TypedState) => {
   const dispatch = store.dispatch
   sagaMiddleware.run(provisionSaga)
 
-  dispatch(RouteTreeGen.createSwitchRouteDef({loggedIn: true}))
-  dispatch(RouteTreeGen.createNavigateTo({path: [Tabs.devicesTab]}))
+  dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
+  dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.devicesTab]}))
 
   return {
     dispatch,

--- a/shared/actions/__tests__/devices.test.tsx
+++ b/shared/actions/__tests__/devices.test.tsx
@@ -125,8 +125,8 @@ const details = [
 ]
 
 const startOnDevicesTab = dispatch => {
-  dispatch(RouteTreeGen.createSwitchRouteDef({loggedIn: true}))
-  dispatch(RouteTreeGen.createNavigateTo({path: [Tabs.devicesTab]}))
+  dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
+  dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.devicesTab]}))
 }
 
 const startReduxSaga = Testing.makeStartReduxSaga(devicesSaga, initialStore, startOnDevicesTab)

--- a/shared/actions/__tests__/git.test.tsx
+++ b/shared/actions/__tests__/git.test.tsx
@@ -125,8 +125,8 @@ const loadedStore = {
 }
 
 const startOnGitTab = dispatch => {
-  dispatch(RouteTreeGen.createSwitchRouteDef({loggedIn: true}))
-  dispatch(RouteTreeGen.createNavigateTo({path: [Tabs.gitTab]}))
+  dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
+  dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.gitTab]}))
 }
 
 const startReduxSaga = Testing.makeStartReduxSaga(gitSaga, initialStore, startOnGitTab)

--- a/shared/actions/__tests__/provision.test.tsx
+++ b/shared/actions/__tests__/provision.test.tsx
@@ -61,8 +61,8 @@ const startReduxSaga = (initialStore?: Object) => {
   const dispatch = store.dispatch
   sagaMiddleware.run(provisionSaga)
 
-  dispatch(RouteTreeGen.createSwitchRouteDef({loggedIn: true}))
-  dispatch(RouteTreeGen.createNavigateTo({path: [Tabs.loginTab]}))
+  dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
+  dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.loginTab]}))
 
   return {
     dispatch,
@@ -669,8 +669,8 @@ describe('final errors show', () => {
 
   it('shows the final error page (devices add)', () => {
     const {getState, dispatch} = startReduxSaga()
-    dispatch(RouteTreeGen.createSwitchRouteDef({loggedIn: true}))
-    dispatch(RouteTreeGen.createNavigateTo({path: [Tabs.devicesTab]}))
+    dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.devicesTab]}))
     // expect(getRoutePath()).toEqual(I.List([Tabs.devicesTab]))
     const error = new RPCError('something bad happened', 1, [])
     dispatch(ProvisionGen.createShowFinalErrorPage({finalError: error, fromDeviceAdd: true}))
@@ -680,8 +680,8 @@ describe('final errors show', () => {
 
   it('ignore cancel (devices add)', () => {
     const {getState, dispatch} = startReduxSaga()
-    dispatch(RouteTreeGen.createSwitchRouteDef({loggedIn: true}))
-    dispatch(RouteTreeGen.createNavigateTo({path: [Tabs.devicesTab]}))
+    dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.devicesTab]}))
     const error = new RPCError('Input canceled', RPCTypes.StatusCode.scinputcanceled)
     dispatch(ProvisionGen.createShowFinalErrorPage({finalError: error, fromDeviceAdd: true}))
     expect(getState().provision.finalError).toEqual(null)

--- a/shared/actions/__tests__/signup.test.tsx
+++ b/shared/actions/__tests__/signup.test.tsx
@@ -53,7 +53,7 @@ describe('requestAutoInvite', () => {
     const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.inviteCode).toEqual(action.payload.inviteCode)
     expect(_testing.showInviteScreen()).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupInviteCode']})
+      RouteTreeGen.createNavigateAppend({path: ['signupInviteCode']})
     )
   })
 
@@ -62,7 +62,7 @@ describe('requestAutoInvite', () => {
     const nextState = makeTypedState(reducer(state, action))
     expect(nextState).toEqual(makeTypedState(state))
     expect(_testing.showInviteScreen()).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupInviteCode']})
+      RouteTreeGen.createNavigateAppend({path: ['signupInviteCode']})
     )
   })
 })
@@ -82,7 +82,7 @@ describe('requestInvite', () => {
     expect(nextState.signup.email).toEqual(action.payload.email)
     expect(nextState.signup.name).toEqual(action.payload.name)
     expect(_testing.showInviteSuccessOnNoErrors(nextState)).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupRequestInviteSuccess']})
+      RouteTreeGen.createNavigateAppend({path: ['signupRequestInviteSuccess']})
     )
   })
 
@@ -132,7 +132,7 @@ describe('checkInviteCode', () => {
     // leaves state alone
     expect(nextState).toEqual(makeTypedState(state))
     // expect(_testing.showUserOnNoErrors(nextState)).toEqual(
-    // RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupUsernameAndEmail']})
+    // RouteTreeGen.createNavigateAppend({ path: ['signupUsernameAndEmail']})
     // )
   })
   it("shows error on fail: must match invite code. doesn't go to next screen", () => {
@@ -212,7 +212,7 @@ describe('checkedUsername', () => {
     })
     const nextState = makeTypedState(reducer(state, action))
     expect(_testing.showDeviceScreenOnNoErrors(nextState)).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupEnterDevicename']})
+      RouteTreeGen.createNavigateAppend({path: ['signupEnterDevicename']})
     )
   })
 })
@@ -343,7 +343,7 @@ describe('actually sign up', () => {
     const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.signupError).toEqual(action.payload.error)
     expect(_testing.showErrorOrCleanupAfterSignup(nextState)).toEqual(
-      RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupError']})
+      RouteTreeGen.createNavigateAppend({path: ['signupError']})
     )
   })
 

--- a/shared/actions/__tests__/wallets.test.tsx
+++ b/shared/actions/__tests__/wallets.test.tsx
@@ -24,8 +24,8 @@ const initialStore = {
 }
 
 const startOnWalletsTab = dispatch => {
-  dispatch(RouteTreeGen.createSwitchRouteDef({loggedIn: true}))
-  dispatch(RouteTreeGen.createNavigateTo({path: [Tabs.walletsTab]}))
+  dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
+  dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.walletsTab]}))
 }
 
 const startReduxSaga = Testing.makeStartReduxSaga(walletsSaga, initialStore, startOnWalletsTab)

--- a/shared/actions/devices.tsx
+++ b/shared/actions/devices.tsx
@@ -85,23 +85,23 @@ const navigateAfterRevoked = (state, action: DevicesGen.RevokedPayload) => {
     })
   }
 
-  return RouteTreeGen.createNavigateTo({
+  return RouteTreeGen.createNavigateAppend({
     path: action.payload.wasCurrentDevice ? [Tabs.loginTab] : [...Constants.devicesTabLocation],
   })
 }
 
 const showRevokePage = (_, {payload: {deviceID}}) =>
-  RouteTreeGen.createNavigateTo({
+  RouteTreeGen.createNavigateAppend({
     path: [...Constants.devicesTabLocation, 'devicePage', {props: {deviceID}, selected: 'deviceRevoke'}],
   })
 
 const showDevicePage = (_, {payload: {deviceID}}) =>
-  RouteTreeGen.createNavigateTo({
+  RouteTreeGen.createNavigateAppend({
     path: [...Constants.devicesTabLocation, {props: {deviceID}, selected: 'devicePage'}],
   })
 
 const showPaperKeyPage = () =>
-  RouteTreeGen.createNavigateTo({path: [...Constants.devicesTabLocation, 'devicePaperKey']})
+  RouteTreeGen.createNavigateAppend({path: [...Constants.devicesTabLocation, 'devicePaperKey']})
 
 const clearNavBadges = state => RPCTypes.deviceDismissDeviceChangeNotificationsRpcPromise().catch(logError)
 

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -894,7 +894,7 @@ const closeDestinationPicker = (state: TypedState, action: FsGen.CloseDestinatio
   return [
     // TODO use as const
     FsGen.createClearRefreshTag({refreshTag: Types.RefreshTag.DestinationPicker}),
-    RouteTreeGen.createNavigateTo({path: newRoute}),
+    RouteTreeGen.createNavigateAppend({path: newRoute}),
   ]
 }
 

--- a/shared/actions/fs/platform-specific.desktop.tsx
+++ b/shared/actions/fs/platform-specific.desktop.tsx
@@ -387,7 +387,7 @@ const openFilesFromWidget = (state, {payload: {path, type}}) => [
   ConfigGen.createShowMain(),
   ...(path
     ? [Constants.makeActionForOpenPathInFilesTab(path)]
-    : [RouteTreeGen.createSwitchTo({path: [Tabs.fsTab]})]),
+    : [RouteTreeGen.createNavigateAppend({path: [Tabs.fsTab]})]),
 ]
 
 const changedFocus = (state, action: ConfigGen.ChangedFocusPayload) =>

--- a/shared/actions/json/route-tree.json
+++ b/shared/actions/json/route-tree.json
@@ -1,24 +1,9 @@
 {
   "prelude": ["import * as Tabs from '../constants/tabs'"],
   "actions": {
-    "switchRouteDef": {
-      "_description": "TODO for this whole json. replace all these actions with a cleaned up version",
-      "loggedIn": "boolean",
-      "path?": "any"
-    },
-    "switchTo": {
-      "path": "any",
-      "parentPath?": "any"
-    },
-    "navigateTo": {
-      "path": "any",
-      "parentPath?": "any",
-      "replace?": "boolean"
-    },
     "navigateAppend": {
       "fromKey?": "string",
       "path": "any",
-      "parentPath?": "any",
       "replace?": "boolean"
     },
     "navigateUp": {"fromKey?": "string"},
@@ -28,6 +13,10 @@
     "navUpToScreen": {
       "_description": "ONLY used by the new nav. Navigates up to this route if it already exists, noops otherwise.",
       "routeName": "string"
+    },
+    "switchLoggedIn": {
+      "_description": "ONLY used by the new nav. Switch login stacks",
+      "loggedIn": "boolean"
     },
     "switchTab": {
       "_description": "ONLY used by the new nav. Switch to a different tab.",

--- a/shared/actions/platform-specific/push.native.tsx
+++ b/shared/actions/platform-specific/push.native.tsx
@@ -60,13 +60,14 @@ const listenForNativeAndroidIntentNotifications = emitter => {
   // FIXME: sometimes this doubles up on a cold start--we've already executed the previous code.
   RNEmitter.addListener('onShareData', evt => {
     logger.debug('[ShareDataIntent]', evt)
-    emitter(RouteTreeGen.createSwitchRouteDef({loggedIn: true, path: FsConstants.fsRootRouteForNav1}))
+    emitter(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
+    emitter(RouteTreeGen.createNavigateAppend({path: FsConstants.fsRootRouteForNav1}))
     emitter(FsGen.createSetIncomingShareLocalPath({localPath: FsTypes.stringToLocalPath(evt.localPath)}))
     emitter(FsGen.createShowIncomingShare({initialDestinationParentPath: FsTypes.stringToPath('/keybase')}))
   })
   RNEmitter.addListener('onShareText', evt => {
     logger.debug('[ShareTextIntent]', evt)
-    emitter(RouteTreeGen.createNavigateTo({path: FsConstants.fsRootRouteForNav1}))
+    emitter(RouteTreeGen.createNavigateAppend({path: FsConstants.fsRootRouteForNav1}))
     // TODO: implement
   })
 }

--- a/shared/actions/profile/index.tsx
+++ b/shared/actions/profile/index.tsx
@@ -12,9 +12,9 @@ import openURL from '../../util/open-url'
 import {RPCError} from '../../util/errors'
 import {pgpSaga} from './pgp'
 import {proofsSaga} from './proofs'
-import {isMobile} from '../../constants/platform'
+import {TypedState, isMobile} from '../../util/container'
 
-const editProfile = (state, action: ProfileGen.EditProfilePayload) =>
+const editProfile = (state: TypedState, action: ProfileGen.EditProfilePayload) =>
   RPCTypes.userProfileEditRpcPromise(
     {
       bio: action.payload.bio,
@@ -24,7 +24,7 @@ const editProfile = (state, action: ProfileGen.EditProfilePayload) =>
     TrackerConstants.waitingKey
   ).then(() => Tracker2Gen.createShowUser({asTracker: false, username: state.config.username}))
 
-const uploadAvatar = (_, action: ProfileGen.UploadAvatarPayload) =>
+const uploadAvatar = (_: TypedState, action: ProfileGen.UploadAvatarPayload) =>
   RPCTypes.userUploadUserAvatarRpcPromise(
     {
       crop: action.payload.crop,
@@ -38,7 +38,7 @@ const uploadAvatar = (_, action: ProfileGen.UploadAvatarPayload) =>
       logger.warn(`Error uploading user avatar: ${e.message}`)
     })
 
-const finishRevoking = state => [
+const finishRevoking = (state: TypedState) => [
   Tracker2Gen.createShowUser({asTracker: false, username: state.config.username}),
   Tracker2Gen.createLoad({
     assertion: state.config.username,
@@ -49,7 +49,7 @@ const finishRevoking = state => [
   ProfileGen.createRevokeFinish(),
 ]
 
-const showUserProfile = (state, action: ProfileGen.ShowUserProfilePayload) => {
+const showUserProfile = (state: TypedState, action: ProfileGen.ShowUserProfilePayload) => {
   const {username: userId} = action.payload
   // TODO search itself should handle this
   const username = SearchConstants.maybeUpgradeSearchResultIdToKeybaseId(
@@ -63,7 +63,7 @@ const showUserProfile = (state, action: ProfileGen.ShowUserProfilePayload) => {
   ]
 }
 
-const onClickAvatar = (_, action: ProfileGen.OnClickAvatarPayload) => {
+const onClickAvatar = (_: TypedState, action: ProfileGen.OnClickAvatarPayload) => {
   if (!action.payload.username) {
     return
   }
@@ -75,7 +75,7 @@ const onClickAvatar = (_, action: ProfileGen.OnClickAvatarPayload) => {
   }
 }
 
-const submitRevokeProof = (state, action: ProfileGen.SubmitRevokeProofPayload) => {
+const submitRevokeProof = (state: TypedState, action: ProfileGen.SubmitRevokeProofPayload) => {
   const you = TrackerConstants.getDetails(state, state.config.username)
   if (!you || !you.assertions) return null
   const proof = you.assertions.find(a => a.sigID === action.payload.proofId)
@@ -98,7 +98,7 @@ const submitRevokeProof = (state, action: ProfileGen.SubmitRevokeProofPayload) =
   }
 }
 
-const submitBlockUser = (state, action: ProfileGen.SubmitBlockUserPayload) => {
+const submitBlockUser = (_: TypedState, action: ProfileGen.SubmitBlockUserPayload) => {
   return RPCTypes.userBlockUserRpcPromise({username: action.payload.username}, Constants.blockUserWaitingKey)
     .then(() => [
       ProfileGen.createFinishBlockUser(),
@@ -117,7 +117,7 @@ const submitBlockUser = (state, action: ProfileGen.SubmitBlockUserPayload) => {
     })
 }
 
-const submitUnblockUser = (state, action: ProfileGen.SubmitUnblockUserPayload) => {
+const submitUnblockUser = (_: TypedState, action: ProfileGen.SubmitUnblockUserPayload) => {
   return RPCTypes.userUnblockUserRpcPromise(
     {username: action.payload.username},
     Constants.blockUserWaitingKey

--- a/shared/actions/profile/pgp.tsx
+++ b/shared/actions/profile/pgp.tsx
@@ -27,7 +27,7 @@ function* generatePgp(state) {
   const onShouldPushPrivate = ({prompt}, response) => {
     return Saga.callUntyped(function*() {
       yield Saga.put(
-        RouteTreeGen.createNavigateTo({
+        RouteTreeGen.createNavigateAppend({
           path: [
             peopleTab,
             'profile',
@@ -48,7 +48,7 @@ function* generatePgp(state) {
   const onFinished = () => {}
 
   yield Saga.put(
-    RouteTreeGen.createNavigateTo({
+    RouteTreeGen.createNavigateAppend({
       path: [peopleTab, 'profile', 'profilePgp', 'profileProvideInfo', 'profileGenerate'],
     })
   )

--- a/shared/actions/profile/proofs.tsx
+++ b/shared/actions/profile/proofs.tsx
@@ -38,7 +38,6 @@ const checkProof = (state: TypedState, _: ProfileGen.CheckProofPayload) => {
             ? []
             : [
                 RouteTreeGen.createNavigateAppend({
-                  parentPath: [peopleTab],
                   path: ['profileConfirmOrPending'],
                 }),
               ]),
@@ -67,18 +66,14 @@ function* addProof(state: TypedState, action: ProfileGen.AddProofPayload) {
   // Special cases
   switch (service) {
     case 'dnsOrGenericWebSite':
-      yield Saga.put(
-        RouteTreeGen.createNavigateTo({parentPath: [peopleTab], path: ['profileProveWebsiteChoice']})
-      )
+      yield Saga.put(RouteTreeGen.createNavigateAppend({path: ['profileProveWebsiteChoice']}))
       return
     case 'zcash': //  fallthrough
     case 'btc':
-      yield Saga.put(
-        RouteTreeGen.createNavigateTo({parentPath: [peopleTab], path: ['profileProveEnterUsername']})
-      )
+      yield Saga.put(RouteTreeGen.createNavigateAppend({path: ['profileProveEnterUsername']}))
       return
     case 'pgp':
-      yield Saga.put(RouteTreeGen.createNavigateTo({parentPath: [peopleTab], path: ['profilePgp']}))
+      yield Saga.put(RouteTreeGen.createNavigateAppend({path: ['profilePgp']}))
       return
   }
 
@@ -138,7 +133,7 @@ function* addProof(state: TypedState, action: ProfileGen.AddProofPayload) {
             errorText: '',
           })
         )
-        const state : TypedState = yield* Saga.selectState()
+        const state: TypedState = yield* Saga.selectState()
         _promptUsernameResponse.result(state.profile.username)
         // eslint is confused i think
         // eslint-disable-next-line require-atomic-updates
@@ -162,11 +157,7 @@ function* addProof(state: TypedState, action: ProfileGen.AddProofPayload) {
       )
     }
     if (service) {
-      actions.push(
-        Saga.put(
-          RouteTreeGen.createNavigateTo({parentPath: [peopleTab], path: ['profileProveEnterUsername']})
-        )
-      )
+      actions.push(Saga.put(RouteTreeGen.createNavigateAppend({path: ['profileProveEnterUsername']})))
     } else if (genericService && parameters) {
       actions.push(
         Saga.put(ProfileGen.createProofParamsReceived({params: Constants.toProveGenericParams(parameters)}))
@@ -200,9 +191,7 @@ function* addProof(state: TypedState, action: ProfileGen.AddProofPayload) {
 
     if (service) {
       actions.push(Saga.put(ProfileGen.createUpdateProofText({proof})))
-      actions.push(
-        Saga.put(RouteTreeGen.createNavigateAppend({parentPath: [peopleTab], path: ['profilePostProof']}))
-      )
+      actions.push(Saga.put(RouteTreeGen.createNavigateAppend({path: ['profilePostProof']})))
     } else if (proof) {
       actions.push(Saga.put(ProfileGen.createUpdatePlatformGenericURL({url: proof})))
       openURL(proof)
@@ -309,7 +298,7 @@ const submitCryptoAddress = (
   )
     .then(() => [
       ProfileGen.createUpdateProofStatus({found: true, status: RPCTypes.ProofStatus.ok}),
-      RouteTreeGen.createNavigateAppend({parentPath: [peopleTab], path: ['profileConfirmOrPending']}),
+      RouteTreeGen.createNavigateAppend({path: ['profileConfirmOrPending']}),
     ])
     .catch((error: RPCError) => {
       logger.warn('Error making proof')

--- a/shared/actions/provision.tsx
+++ b/shared/actions/provision.tsx
@@ -339,7 +339,6 @@ class ProvisioningManager {
 
   showCodePage = () =>
     RouteTreeGen.createNavigateAppend({
-      parentPath: this._addingANewDevice ? devicesRoot : [Tabs.loginTab],
       path: ['codePage'],
       replace: true,
     })
@@ -434,7 +433,7 @@ function* addNewDevice(state) {
     ProvisioningManager.getSingleton().done('add device success')
     // Now refresh and nav back
     yield Saga.put(DevicesGen.createLoad())
-    yield Saga.put(RouteTreeGen.createNavigateTo({parentPath: [], path: devicesRoot}))
+    yield Saga.put(RouteTreeGen.createNavigateAppend({path: devicesRoot}))
     yield Saga.put(RouteTreeGen.createClearModals())
   } catch (finalError) {
     ProvisioningManager.getSingleton().done(finalError.message)
@@ -461,12 +460,11 @@ const maybeCancelProvision = (state: TypedState) =>
 
 const showDeviceListPage = state =>
   !state.provision.error.stringValue() &&
-  RouteTreeGen.createNavigateAppend({parentPath: [Tabs.loginTab], path: ['selectOtherDevice'], replace: true})
+  RouteTreeGen.createNavigateAppend({path: ['selectOtherDevice'], replace: true})
 
 const showNewDeviceNamePage = state =>
   !state.provision.error.stringValue() &&
   RouteTreeGen.createNavigateAppend({
-    parentPath: [Tabs.loginTab],
     path: ['setPublicName'],
     replace: true,
   })
@@ -476,15 +474,15 @@ const showCodePage = state =>
 
 const showGPGPage = state =>
   !state.provision.error.stringValue() &&
-  RouteTreeGen.createNavigateAppend({parentPath: [Tabs.loginTab], path: ['gpgSign'], replace: true})
+  RouteTreeGen.createNavigateAppend({path: ['gpgSign'], replace: true})
 
 const showPasswordPage = state =>
   !state.provision.error.stringValue() &&
-  RouteTreeGen.createNavigateAppend({parentPath: [Tabs.loginTab], path: ['password'], replace: true})
+  RouteTreeGen.createNavigateAppend({path: ['password'], replace: true})
 
 const showPaperkeyPage = state =>
   !state.provision.error.stringValue() &&
-  RouteTreeGen.createNavigateAppend({parentPath: [Tabs.loginTab], path: ['paperkey'], replace: true})
+  RouteTreeGen.createNavigateAppend({path: ['paperkey'], replace: true})
 
 const showFinalErrorPage = (state, action: ProvisionGen.ShowFinalErrorPagePayload) => {
   const parentPath = action.payload.fromDeviceAdd ? devicesRoot : ['login']
@@ -495,11 +493,10 @@ const showFinalErrorPage = (state, action: ProvisionGen.ShowFinalErrorPagePayloa
     path = []
   }
 
-  return RouteTreeGen.createNavigateTo({path: [...parentPath, ...path], replace: true})
+  return RouteTreeGen.createNavigateAppend({path: [...parentPath, ...path], replace: true})
 }
 
-const showUsernameEmailPage = () =>
-  RouteTreeGen.createNavigateAppend({parentPath: [Tabs.loginTab], path: ['username']})
+const showUsernameEmailPage = () => RouteTreeGen.createNavigateAppend({path: ['username']})
 
 const forgotUsername = (state, action: ProvisionGen.ForgotUsernamePayload) =>
   RPCTypes.accountRecoverUsernameWithEmailRpcPromise(

--- a/shared/actions/route-tree-gen.tsx
+++ b/shared/actions/route-tree-gen.tsx
@@ -8,28 +8,19 @@ export const typePrefix = 'route-tree:'
 export const clearModals = 'route-tree:clearModals'
 export const navUpToScreen = 'route-tree:navUpToScreen'
 export const navigateAppend = 'route-tree:navigateAppend'
-export const navigateTo = 'route-tree:navigateTo'
 export const navigateUp = 'route-tree:navigateUp'
 export const resetStack = 'route-tree:resetStack'
-export const switchRouteDef = 'route-tree:switchRouteDef'
+export const switchLoggedIn = 'route-tree:switchLoggedIn'
 export const switchTab = 'route-tree:switchTab'
-export const switchTo = 'route-tree:switchTo'
 
 // Payload Types
 type _ClearModalsPayload = void
 type _NavUpToScreenPayload = {readonly routeName: string}
-type _NavigateAppendPayload = {
-  readonly fromKey?: string
-  readonly path: any
-  readonly parentPath?: any
-  readonly replace?: boolean
-}
-type _NavigateToPayload = {readonly path: any; readonly parentPath?: any; readonly replace?: boolean}
+type _NavigateAppendPayload = {readonly fromKey?: string; readonly path: any; readonly replace?: boolean}
 type _NavigateUpPayload = {readonly fromKey?: string}
 type _ResetStackPayload = {readonly tab: Tabs.AppTab; readonly actions: Array<any>; readonly index: number}
-type _SwitchRouteDefPayload = {readonly loggedIn: boolean; readonly path?: any}
+type _SwitchLoggedInPayload = {readonly loggedIn: boolean}
 type _SwitchTabPayload = {readonly tab: Tabs.AppTab}
-type _SwitchToPayload = {readonly path: any; readonly parentPath?: any}
 
 // Action Creators
 /**
@@ -38,6 +29,13 @@ type _SwitchToPayload = {readonly path: any; readonly parentPath?: any}
 export const createNavUpToScreen = (payload: _NavUpToScreenPayload): NavUpToScreenPayload => ({
   payload,
   type: navUpToScreen,
+})
+/**
+ * ONLY used by the new nav. Switch login stacks
+ */
+export const createSwitchLoggedIn = (payload: _SwitchLoggedInPayload): SwitchLoggedInPayload => ({
+  payload,
+  type: switchLoggedIn,
 })
 /**
  * ONLY used by the new nav. Switch to a different tab.
@@ -57,26 +55,14 @@ export const createResetStack = (payload: _ResetStackPayload): ResetStackPayload
   payload,
   type: resetStack,
 })
-/**
- * TODO for this whole json. replace all these actions with a cleaned up version
- */
-export const createSwitchRouteDef = (payload: _SwitchRouteDefPayload): SwitchRouteDefPayload => ({
-  payload,
-  type: switchRouteDef,
-})
 export const createNavigateAppend = (payload: _NavigateAppendPayload): NavigateAppendPayload => ({
   payload,
   type: navigateAppend,
-})
-export const createNavigateTo = (payload: _NavigateToPayload): NavigateToPayload => ({
-  payload,
-  type: navigateTo,
 })
 export const createNavigateUp = (payload: _NavigateUpPayload = Object.freeze({})): NavigateUpPayload => ({
   payload,
   type: navigateUp,
 })
-export const createSwitchTo = (payload: _SwitchToPayload): SwitchToPayload => ({payload, type: switchTo})
 
 // Action Payloads
 export type ClearModalsPayload = {readonly payload: _ClearModalsPayload; readonly type: typeof clearModals}
@@ -88,15 +74,13 @@ export type NavigateAppendPayload = {
   readonly payload: _NavigateAppendPayload
   readonly type: typeof navigateAppend
 }
-export type NavigateToPayload = {readonly payload: _NavigateToPayload; readonly type: typeof navigateTo}
 export type NavigateUpPayload = {readonly payload: _NavigateUpPayload; readonly type: typeof navigateUp}
 export type ResetStackPayload = {readonly payload: _ResetStackPayload; readonly type: typeof resetStack}
-export type SwitchRouteDefPayload = {
-  readonly payload: _SwitchRouteDefPayload
-  readonly type: typeof switchRouteDef
+export type SwitchLoggedInPayload = {
+  readonly payload: _SwitchLoggedInPayload
+  readonly type: typeof switchLoggedIn
 }
 export type SwitchTabPayload = {readonly payload: _SwitchTabPayload; readonly type: typeof switchTab}
-export type SwitchToPayload = {readonly payload: _SwitchToPayload; readonly type: typeof switchTo}
 
 // All Actions
 // prettier-ignore
@@ -104,10 +88,8 @@ export type Actions =
   | ClearModalsPayload
   | NavUpToScreenPayload
   | NavigateAppendPayload
-  | NavigateToPayload
   | NavigateUpPayload
   | ResetStackPayload
-  | SwitchRouteDefPayload
+  | SwitchLoggedInPayload
   | SwitchTabPayload
-  | SwitchToPayload
   | {type: 'common:resetStore', payload: {}}

--- a/shared/actions/signup.tsx
+++ b/shared/actions/signup.tsx
@@ -30,27 +30,24 @@ const goBackAndClearErrors = () => RouteTreeGen.createNavigateUp()
 const showUserOnNoErrors = (state: TypedState) =>
   noErrors(state) && [
     RouteTreeGen.createNavigateUp(),
-    RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupEnterUsername']}),
+    RouteTreeGen.createNavigateAppend({path: ['signupEnterUsername']}),
   ]
 
-const showInviteScreen = () =>
-  RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupInviteCode']})
+const showInviteScreen = () => RouteTreeGen.createNavigateAppend({path: ['signupInviteCode']})
 
 const showInviteSuccessOnNoErrors = (state: TypedState) =>
-  noErrors(state) &&
-  RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupRequestInviteSuccess']})
+  noErrors(state) && RouteTreeGen.createNavigateAppend({path: ['signupRequestInviteSuccess']})
 
 const showEmailScreenOnNoErrors = (state: TypedState) =>
   noErrors(state) && RouteTreeGen.createNavigateAppend({path: ['signupEnterEmail']})
 
 const showDeviceScreenOnNoErrors = (state: TypedState) =>
-  noErrors(state) &&
-  RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupEnterDevicename']})
+  noErrors(state) && RouteTreeGen.createNavigateAppend({path: ['signupEnterDevicename']})
 
 const showErrorOrCleanupAfterSignup = (state: TypedState) =>
   noErrors(state)
     ? SignupGen.createRestartSignup()
-    : RouteTreeGen.createNavigateAppend({parentPath: [loginTab], path: ['signupError']})
+    : RouteTreeGen.createNavigateAppend({path: ['signupError']})
 
 // If the email was set to be visible during signup, we need to set that with a separate RPC.
 const setEmailVisibilityAfterSignup = (state: TypedState) =>

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -999,7 +999,7 @@ const checkDisclaimer = (state: TypedState, _: WalletsGen.CheckDisclaimerPayload
 
 const maybeNavToLinkExisting = (_: TypedState, action: WalletsGen.CheckDisclaimerPayload) =>
   action.payload.nextScreen === 'linkExisting' &&
-  RouteTreeGen.createNavigateTo({
+  RouteTreeGen.createNavigateAppend({
     path: [...Constants.rootWalletPath, ...(isMobile ? ['linkExisting'] : ['wallet', 'linkExisting'])],
   })
 

--- a/shared/app/global-errors/container.tsx
+++ b/shared/app/global-errors/container.tsx
@@ -22,10 +22,9 @@ const mapDispatchToProps = dispatch => ({
     dispatch(ConfigGen.createGlobalError({globalError: null}))
     if (loggedIn) {
       dispatch(RouteTreeGen.createClearModals())
-      dispatch(RouteTreeGen.createSwitchTo({path: [settingsTab]}))
+      dispatch(RouteTreeGen.createNavigateAppend({path: [settingsTab]}))
       dispatch(
-        RouteTreeGen.createNavigateTo({
-          parentPath: [settingsTab],
+        RouteTreeGen.createNavigateAppend({
           path: [
             {
               props: {heading: 'Oh no, a bug!'},

--- a/shared/chat/conversation/messages/message-popup/payment/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/container.tsx
@@ -69,8 +69,8 @@ const sendMapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onClaimLumens: () =>
     dispatch(
       Container.isMobile
-        ? RouteTreeGen.createNavigateTo({path: WalletConstants.rootWalletPath})
-        : RouteTreeGen.createSwitchTo({path: WalletConstants.rootWalletPath})
+        ? RouteTreeGen.createNavigateAppend({path: WalletConstants.rootWalletPath})
+        : RouteTreeGen.createNavigateAppend({path: WalletConstants.rootWalletPath})
     ),
   onSeeDetails: (accountID: WalletTypes.AccountID, paymentID: WalletTypes.PaymentID) =>
     dispatch(WalletGen.createShowTransaction({accountID, paymentID})),

--- a/shared/chat/conversation/messages/system-added-to-team/container.tsx
+++ b/shared/chat/conversation/messages/system-added-to-team/container.tsx
@@ -34,7 +34,7 @@ const mapDispatchToProps = dispatch => ({
       })
     ),
   _onViewTeam: (teamname: string) => {
-    dispatch(RouteTreeGen.createNavigateTo({path: [teamsTab, {props: {teamname}, selected: 'team'}]}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [teamsTab, {props: {teamname}, selected: 'team'}]}))
   },
 })
 

--- a/shared/chat/conversation/messages/system-invite-accepted/container.tsx
+++ b/shared/chat/conversation/messages/system-invite-accepted/container.tsx
@@ -16,7 +16,7 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = dispatch => ({
   _onViewTeam: (teamname: string) => {
-    dispatch(RouteTreeGen.createNavigateTo({path: [teamsTab, {props: {teamname}, selected: 'team'}]}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [teamsTab, {props: {teamname}, selected: 'team'}]}))
   },
 })
 

--- a/shared/chat/conversation/messages/system-joined/container.tsx
+++ b/shared/chat/conversation/messages/system-joined/container.tsx
@@ -20,8 +20,7 @@ const mapDispatchToProps = dispatch => ({
   _onManageChannels: (teamname: string) =>
     isMobile
       ? dispatch(
-          RouteTreeGen.createNavigateTo({
-            parentPath: [chatTab],
+          RouteTreeGen.createNavigateAppend({
             path: [{props: {teamname}, selected: 'chatManageChannels'}],
           })
         )

--- a/shared/chat/conversation/messages/system-simple-to-complex/container.tsx
+++ b/shared/chat/conversation/messages/system-simple-to-complex/container.tsx
@@ -18,7 +18,7 @@ const mapDispatchToProps = dispatch => ({
       RouteTreeGen.createNavigateAppend({path: [{props: {teamname}, selected: 'chatManageChannels'}]})
     ),
   onViewTeam: (teamname: string) => {
-    dispatch(RouteTreeGen.createNavigateTo({path: [teamsTab, {props: {teamname}, selected: 'team'}]}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [teamsTab, {props: {teamname}, selected: 'team'}]}))
   },
 })
 

--- a/shared/chat/inbox/row/big-team-header/container.tsx
+++ b/shared/chat/inbox/row/big-team-header/container.tsx
@@ -18,7 +18,7 @@ const mapStateToProps = (state, {teamname, conversationIDKey}: OwnProps) => ({
 
 const mapDispatchToProps = (dispatch, {teamname}: OwnProps) => ({
   onClick: () =>
-    dispatch(RouteTreeGen.createNavigateTo({path: [teamsTab, {props: {teamname}, selected: 'team'}]})),
+    dispatch(RouteTreeGen.createNavigateAppend({path: [teamsTab, {props: {teamname}, selected: 'team'}]})),
 })
 
 const mergeProps = (stateProps, dispatchProps) => ({

--- a/shared/chat/manage-channels/container.tsx
+++ b/shared/chat/manage-channels/container.tsx
@@ -105,8 +105,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, ownProps: OwnProp
     onClose: () => dispatch(RouteTreeGen.createNavigateUp()),
     onCreate: () =>
       dispatch(
-        RouteTreeGen.createNavigateTo({
-          parentPath: [],
+        RouteTreeGen.createNavigateAppend({
           path: [{props: {teamname}, selected: 'chatCreateChannel'}],
         })
       ),

--- a/shared/common-adapters/name-with-icon/container.tsx
+++ b/shared/common-adapters/name-with-icon/container.tsx
@@ -17,7 +17,7 @@ const mapDispatchToProps = dispatch => ({
   onOpenTeamProfile: (teamname: string) => {
     dispatch(RouteTreeGen.createClearModals())
     dispatch(
-      RouteTreeGen.createNavigateTo({path: [teamsTab, {props: {teamname: teamname}, selected: 'team'}]})
+      RouteTreeGen.createNavigateAppend({path: [teamsTab, {props: {teamname: teamname}, selected: 'team'}]})
     )
   },
   onOpenTracker: (username: string) => dispatch(Tracker2Gen.createShowUser({asTracker: true, username})),

--- a/shared/fs/common/errs-container.tsx
+++ b/shared/fs/common/errs-container.tsx
@@ -16,16 +16,10 @@ const mapDispatchToProps = dispatch => ({
   _dismiss: (key: string) => dispatch(FsGen.createDismissFsError({key})),
   _onFeedback: (loggedIn: boolean) => {
     if (loggedIn) {
-      dispatch(RouteTreeGen.createSwitchTo({path: [settingsTab]}))
+      dispatch(RouteTreeGen.createNavigateAppend({path: [settingsTab]}))
       dispatch(
-        RouteTreeGen.createNavigateTo({
-          parentPath: [settingsTab],
-          path: [
-            {
-              props: {heading: 'Oh no, a bug!'},
-              selected: feedbackTab,
-            },
-          ],
+        RouteTreeGen.createNavigateAppend({
+          path: [{props: {heading: 'Oh no, a bug!'}, selected: feedbackTab}],
         })
       )
     } else {

--- a/shared/fs/common/path-item-action/menu-container.tsx
+++ b/shared/fs/common/path-item-action/menu-container.tsx
@@ -42,8 +42,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, {mode, path, rout
   _copyPath: () => dispatch(ConfigGen.createCopyToClipboard({text: Constants.escapePath(path)})),
   _delete: () => {
     dispatch(
-      RouteTreeGen.createNavigateTo({
-        parentPath: [fsTab],
+      RouteTreeGen.createNavigateAppend({
         path: [{props: {mode, path}, selected: 'confirmDelete'}],
       })
     )

--- a/shared/git/new-repo/container.tsx
+++ b/shared/git/new-repo/container.tsx
@@ -29,7 +29,7 @@ const mapDispatchToProps = (dispatch: any, {navigateAppend, navigateUp, routePro
     dispatch(createAction)
     dispatch(navigateUp())
   },
-  onNewTeam: () => dispatch(RouteTreeGen.createNavigateTo({path: [teamsTab, 'teamNewTeamDialog']})),
+  onNewTeam: () => dispatch(RouteTreeGen.createNavigateAppend({path: [teamsTab, 'teamNewTeamDialog']})),
 })
 
 export default connect(

--- a/shared/git/row/container.tsx
+++ b/shared/git/row/container.tsx
@@ -34,7 +34,6 @@ const mapDispatchToProps = dispatch => ({
   _onOpenChannelSelection: (repoID: string, teamname: string | null, selected: string) =>
     dispatch(
       RouteTreeGen.createNavigateAppend({
-        parentPath: isMobile ? [settingsTab, settingsGitTab] : [gitTab],
         path: [{props: {repoID, selected, teamname}, selected: 'gitSelectChannel'}],
       })
     ),

--- a/shared/logger/action-transformer.tsx
+++ b/shared/logger/action-transformer.tsx
@@ -11,17 +11,7 @@ import * as EntitiesGen from '../actions/entities-gen'
 import {TypedState} from '../constants/reducer'
 
 // If you use nullTransform it'll not be logged at all
-const nullTransform = action => {
-  return null
-}
-
-const pathActionTransformer = (action, oldState) => {
-  const path = Array.from(action.payload.path.map(p => (typeof p === 'string' ? p : p.selected)))
-  return {
-    payload: {path},
-    type: action.type,
-  }
-}
+const nullTransform = () => null
 
 const entityTransformer = (
   action:
@@ -38,9 +28,16 @@ const defaultTransformer = ({type}) => ({type})
 const fullOutput = a => a
 
 const actionTransformMap = {
-  [RouteTreeGen.switchTo]: pathActionTransformer,
-  [RouteTreeGen.navigateTo]: pathActionTransformer,
-  [RouteTreeGen.navigateAppend]: pathActionTransformer,
+  [RouteTreeGen.switchTab]: fullOutput,
+  [RouteTreeGen.switchLoggedIn]: fullOutput,
+  [RouteTreeGen.navigateAppend]: action => ({
+    payload: {
+      fromKey: action.payload.fromKey,
+      path: Array.from(action.payload.path.map(p => (typeof p === 'string' ? p : p.selected))),
+      replace: action.payload.replace,
+    },
+    type: action.type,
+  }),
 
   [EntitiesGen.deleteEntity]: entityTransformer,
   [EntitiesGen.mergeEntity]: entityTransformer,

--- a/shared/menubar/remote-container.desktop.tsx
+++ b/shared/menubar/remote-container.desktop.tsx
@@ -27,7 +27,7 @@ const mapDispatchToProps = dispatch => ({
   },
   logIn: () => {
     dispatch(ConfigGen.createShowMain())
-    dispatch(RouteTreeGen.createNavigateTo({path: [loginTab]}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [loginTab]}))
   },
   onHideDiskSpaceBanner: dispatch(FsGen.createShowHideDiskSpaceBanner({show: false})),
   onRekey: () => {

--- a/shared/people/announcement/container.tsx
+++ b/shared/people/announcement/container.tsx
@@ -32,37 +32,41 @@ const mapDispatchToProps = dispatch => ({
       case RPCTypes.AppLinkType.people:
         break
       case RPCTypes.AppLinkType.chat:
-        dispatch(RouteTree.createSwitchTo({path: [Tabs.chatTab]}))
+        dispatch(RouteTree.createNavigateAppend({path: [Tabs.chatTab]}))
         break
       case RPCTypes.AppLinkType.files:
         dispatch(
-          RouteTree.createSwitchTo({path: isMobile ? [Tabs.settingsTab, SettingsTabs.fsTab] : [Tabs.fsTab]})
+          RouteTree.createNavigateAppend({
+            path: isMobile ? [Tabs.settingsTab, SettingsTabs.fsTab] : [Tabs.fsTab],
+          })
         )
         break
       case RPCTypes.AppLinkType.wallet:
         dispatch(
-          RouteTree.createSwitchTo({
+          RouteTree.createNavigateAppend({
             path: isMobile ? [Tabs.settingsTab, SettingsTabs.walletsTab] : [Tabs.walletsTab],
           })
         )
         break
       case RPCTypes.AppLinkType.git:
         dispatch(
-          RouteTree.createSwitchTo({path: isMobile ? [Tabs.settingsTab, SettingsTabs.gitTab] : [Tabs.gitTab]})
+          RouteTree.createNavigateAppend({
+            path: isMobile ? [Tabs.settingsTab, SettingsTabs.gitTab] : [Tabs.gitTab],
+          })
         )
         break
       case RPCTypes.AppLinkType.devices:
         dispatch(
-          RouteTree.createSwitchTo({
+          RouteTree.createNavigateAppend({
             path: isMobile ? [Tabs.settingsTab, SettingsTabs.devicesTab] : [Tabs.devicesTab],
           })
         )
         break
       case RPCTypes.AppLinkType.settings:
-        dispatch(RouteTree.createSwitchTo({path: [Tabs.settingsTab]}))
+        dispatch(RouteTree.createNavigateAppend({path: [Tabs.settingsTab]}))
         break
       case RPCTypes.AppLinkType.teams:
-        dispatch(RouteTree.createSwitchTo({path: [Tabs.teamsTab]}))
+        dispatch(RouteTree.createNavigateAppend({path: [Tabs.teamsTab]}))
         break
     }
     dispatch(PeopleGen.createDismissAnnouncement({id}))

--- a/shared/people/todo/container.tsx
+++ b/shared/people/todo/container.tsx
@@ -189,8 +189,8 @@ const TeamConnector = connect(
   () => ({}),
   dispatch => ({
     onConfirm: () => {
-      dispatch(RouteTreeGen.createNavigateAppend({parentPath: [Tabs.teamsTab], path: ['teamNewTeamDialog']}))
-      dispatch(RouteTreeGen.createSwitchTo({path: [Tabs.teamsTab]}))
+      dispatch(RouteTreeGen.createNavigateAppend({path: ['teamNewTeamDialog']}))
+      dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.teamsTab]}))
     },
     onDismiss: onSkipTodo('team', dispatch),
   }),

--- a/shared/router-v2/router.shared.tsx
+++ b/shared/router-v2/router.shared.tsx
@@ -36,8 +36,6 @@ export const desktopTabs = [
 // actual routing actions (or make RouteTreeGen append/up the only action)
 export const oldActionToNewActions = (action: any, navigation: any, allowAppendDupe?: boolean) => {
   switch (action.type) {
-    case RouteTreeGen.navigateTo: // fallthrough
-    case RouteTreeGen.switchTo: // fallthrough
     case RouteTreeGen.navigateAppend: {
       if (!navigation) {
         return
@@ -89,37 +87,8 @@ export const oldActionToNewActions = (action: any, navigation: any, allowAppendD
     case RouteTreeGen.switchTab: {
       return [NavigationActions.navigate({routeName: action.payload.tab})]
     }
-    case RouteTreeGen.switchRouteDef: {
-      // used to tell if its the login one or app one. this will all change when we deprecate the old routing
-      const routeName = action.payload.loggedIn ? 'loggedIn' : 'loggedOut'
-
-      // You're logged out
-      if (routeName === 'loggedOut') {
-        return [NavigationActions.navigate({params: undefined, routeName: 'loggedOut'})]
-      }
-
-      // When we restore state we want the following stacks
-      let sa = [NavigationActions.navigate({params: undefined, routeName: 'loggedIn'})]
-
-      if (action.payload.path) {
-        const p = action.payload.path.last
-          ? action.payload.path.last()
-          : action.payload.path[action.payload.path.length - 1]
-
-        sa.push(NavigationActions.navigate({params: undefined, routeName: p}))
-      }
-
-      // validate sa
-      if (
-        !sa.every(
-          a => a.routeName === 'loggedIn' || !!routes[a.routeName] || mobileTabs.includes(a.routeName)
-        )
-      ) {
-        logger.error('Invalid route found, bailing on push', sa)
-        sa = []
-      }
-
-      return sa
+    case RouteTreeGen.switchLoggedIn: {
+      return [NavigationActions.navigate({routeName: action.payload.loggedIn ? 'loggedIn' : 'loggedOut'})]
     }
     case RouteTreeGen.clearModals: {
       const numModals = getNumModals(navigation)

--- a/shared/settings/index.tsx
+++ b/shared/settings/index.tsx
@@ -36,7 +36,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, ownProps: OwnProp
     if (ownProps.routeSelected === Constants.accountTab && tab !== Constants.accountTab) {
       dispatch(SettingsGen.createClearAddedEmail())
     }
-    dispatch(RouteTreeGen.createSwitchTo({path: [tab]}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [tab]}))
   },
 })
 

--- a/shared/teams/team/header/add-people-how/container.tsx
+++ b/shared/teams/team/header/add-people-how/container.tsx
@@ -22,12 +22,11 @@ export default Container.connect(
       },
       onInvite: () => {
         dispatch(
-          RouteTreeGen.createNavigateTo({
-            parentPath: [teamsTab],
+          RouteTreeGen.createNavigateAppend({
             path: [{props: {teamname}, selected: 'team'}, {props: {teamname}, selected: 'teamInviteByEmail'}],
           })
         )
-        dispatch(RouteTreeGen.createSwitchTo({path: [teamsTab]}))
+        dispatch(RouteTreeGen.createNavigateAppend({path: [teamsTab]}))
       },
       onSlackImport: () => openURL(`https://keybase.io/slack-importer/${teamname}`),
     }

--- a/shared/teams/team/settings-tab/retention/container.tsx
+++ b/shared/teams/team/settings-tab/retention/container.tsx
@@ -127,7 +127,7 @@ const mapDispatchToProps = (
   _loadTeamPolicy: () => teamname && dispatch(TeamsGen.createGetTeamRetentionPolicy({teamname})),
   _onShowWarning: (policy: RetentionPolicy, onConfirm: () => void, onCancel: () => void) => {
     dispatch(
-      RouteTreeGen.createNavigateTo({
+      RouteTreeGen.createNavigateAppend({
         path: [
           {
             props: {entityType, onCancel, onConfirm, policy},

--- a/shared/tracker2/bio/container.tsx
+++ b/shared/tracker2/bio/container.tsx
@@ -28,7 +28,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
   onLearnMore: () => {
     dispatch(RouteTreeGen.createSwitchTab({tab: WalletsConstants.rootWalletTab}))
-    dispatch(RouteTreeGen.createNavigateTo({path: [...WalletsConstants.walletPath, 'airdrop']}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [...WalletsConstants.walletPath, 'airdrop']}))
   },
 })
 

--- a/shared/wallets/airdrop/banner/container.tsx
+++ b/shared/wallets/airdrop/banner/container.tsx
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onCheckQualify: () => {
     // Switch to the wallet tab to make sure the disclaimer appears.
     dispatch(RouteTreeGen.createSwitchTab({tab: Constants.rootWalletTab}))
-    dispatch(RouteTreeGen.createNavigateTo({path: [...Constants.walletPath, 'airdrop']}))
+    dispatch(RouteTreeGen.createNavigateAppend({path: [...Constants.walletPath, 'airdrop']}))
   },
 })
 


### PR DESCRIPTION
I was trying to track down some routing errors and wanted to update the logging. Along the way I cleaned up the old route actions. There's a ticket to rethink them but short term  just collapsed the ones we treat as the same and removed params we ignore

- [x] `navigateTo` / `switchTo` => `navigateAppend`
- [x] removed parentPath
- [x] `switchRouteDef` => `switchLoggedIn`