### PR TITLE
Handle role==none is more places in wallets view

### DIFF
--- a/shared/wallets/transaction/index.tsx
+++ b/shared/wallets/transaction/index.tsx
@@ -271,6 +271,13 @@ const Detail = (props: DetailProps) => {
         </Text>
       )
     }
+    case 'none': {
+      return (
+        <Text type={textType} style={{...styles.breakWord, ...textStyle}}>
+        {props.summaryAdvanced || 'This account was involved in a complex transaction.'}
+      </Text>
+      )
+    }
     default:
       throw new Error(`Unexpected role ${props.yourRole}`)
   }
@@ -310,6 +317,7 @@ const getAmount = (role: Types.Role, amount: string, sourceAmount?: string): str
     case 'receiverOnly':
       return `+ ${amount}`
     case 'senderAndReceiver':
+    case 'none':
       return '0 XLM'
     default:
       throw new Error(`Unexpected role ${role}`)


### PR DESCRIPTION
@keybase/react-hackers 

A Stellar dev reported a crash loading their Wallets tab, and it's while rendering a tx (we don't know which one) where `yourRole` is `none`.  They use "Set Options" txs quite a lot.  We handled this `none` case in some switch statements but not all of them.  It'd be better to understand their crash exactly but this seems like a good change to put it in the meantime.