### PR TITLE
rpccache: key on UID too

### DIFF
--- a/go/offline/rpc_cache.go
+++ b/go/offline/rpc_cache.go
@@ -44,12 +44,15 @@ func NewRPCCache(g *libkb.GlobalContext) *RPCCache {
 	}
 }
 
+type hashStruct struct {
+	UID     keybase1.UID
+	RPCName string
+	Arg     interface{}
+}
+
 func hash(rpcName string, uid keybase1.UID, arg interface{}) ([]byte, error) {
 	h := sha256.New()
-	h.Write(uid.ToBytes())
-	h.Write([]byte(rpcName))
-	h.Write([]byte{0})
-	raw, err := msgpack.Encode(arg)
+	raw, err := msgpack.Encode(hashStruct{uid, rpcName, arg})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When switching between users that had synced folders, users would not be able to decrypt entries others left in the RPC cache. This led to a broken KBFS after user switching in some cases.

CC @joshblum @strib @keybase/y2ksquad 

Issue: Y2K-191