### PR TITLE
runtimestats: include leveldb compaction active status

### DIFF
--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -39,13 +39,15 @@ func (c *CmdShowNotifications) Run() error {
 		keybase1.NotifyFSProtocol(display),
 		keybase1.NotifyTrackingProtocol(display),
 		keybase1.NotifyAuditProtocol(display),
+		keybase1.NotifyRuntimeStatsProtocol(display),
 	}
 	channels := keybase1.NotificationChannels{
-		Session:  true,
-		Users:    true,
-		Kbfs:     true,
-		Tracking: true,
-		Audit:    true,
+		Session:      true,
+		Users:        true,
+		Kbfs:         true,
+		Tracking:     true,
+		Audit:        true,
+		Runtimestats: true,
 	}
 
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
@@ -178,4 +180,34 @@ func (d *notificationDisplay) RootAuditError(_ context.Context, msg string) (err
 
 func (d *notificationDisplay) BoxAuditError(_ context.Context, msg string) (err error) {
 	return d.printf("Box audit error (report with `keybase log send`): %s\n", msg)
+}
+
+func (d *notificationDisplay) RuntimeStatsUpdate(
+	_ context.Context, stats *keybase1.RuntimeStats) (err error) {
+	err = d.printf(
+		"Runtime stats: Goheap=%s, Goheapsys=%s, Goreleased=%s ",
+		stats.Goheap, stats.Goheapsys, stats.Goreleased)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range stats.DbStats {
+		var name string
+		switch s.Type {
+		case keybase1.DbType_MAIN:
+			name = "dbMain"
+		case keybase1.DbType_CHAT:
+			name = "dbChat"
+		case keybase1.DbType_FS_BLOCK_CACHE:
+			name = "dbFSBlockCache"
+		case keybase1.DbType_FS_SYNC_BLOCK_CACHE:
+			name = "dbFSSyncBlockCache"
+		}
+		err = d.printf(
+			"%s=[M:%t T:%t] ", name, s.MemCompActive, s.TableCompActive)
+		if err != nil {
+			return err
+		}
+	}
+	return d.printf("\n")
 }

--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -185,13 +185,17 @@ func (d *notificationDisplay) BoxAuditError(_ context.Context, msg string) (err 
 func (d *notificationDisplay) RuntimeStatsUpdate(
 	_ context.Context, stats *keybase1.RuntimeStats) (err error) {
 	err = d.printf(
-		"Runtime stats: Goheap=%s, Goheapsys=%s, Goreleased=%s ",
+		"Runtime stats: Goheap=%s, Goheapsys=%s, Goreleased=%s",
 		stats.Goheap, stats.Goheapsys, stats.Goreleased)
 	if err != nil {
 		return err
 	}
 
 	for _, s := range stats.DbStats {
+		if !s.MemCompActive && !s.TableCompActive {
+			continue
+		}
+
 		var name string
 		switch s.Type {
 		case keybase1.DbType_MAIN:
@@ -200,11 +204,15 @@ func (d *notificationDisplay) RuntimeStatsUpdate(
 			name = "dbChat"
 		case keybase1.DbType_FS_BLOCK_CACHE:
 			name = "dbFSBlockCache"
+		case keybase1.DbType_FS_BLOCK_CACHE_META:
+			name = "dbFSMetaBlockCache"
 		case keybase1.DbType_FS_SYNC_BLOCK_CACHE:
 			name = "dbFSSyncBlockCache"
+		case keybase1.DbType_FS_SYNC_BLOCK_CACHE_META:
+			name = "dbFSMetaSyncBlockCache"
 		}
 		err = d.printf(
-			"%s=[M:%t T:%t] ", name, s.MemCompActive, s.TableCompActive)
+			", %s=[M:%t T:%t] ", name, s.MemCompActive, s.TableCompActive)
 		if err != nil {
 			return err
 		}

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -170,10 +170,14 @@ type DiskBlockCacheStatus struct {
 	LocalDiskBytesAvailable uint64
 	LocalDiskBytesTotal     uint64
 
-	BlockDBStats   []string `json:",omitempty"`
-	MetaDBStats    []string `json:",omitempty"`
-	TLFDBStats     []string `json:",omitempty"`
-	LastUnrefStats []string `json:",omitempty"`
+	BlockDBStats        []string `json:",omitempty"`
+	MetaDBStats         []string `json:",omitempty"`
+	TLFDBStats          []string `json:",omitempty"`
+	LastUnrefStats      []string `json:",omitempty"`
+	MemCompActive       bool     `json:",omitempty"`
+	TableCompActive     bool     `json:",omitempty"`
+	MetaMemCompActive   bool     `json:",omitempty"`
+	MetaTableCompActive bool     `json:",omitempty"`
 }
 
 type lastUnrefEntry struct {
@@ -1255,6 +1259,8 @@ func (cache *DiskBlockCacheLocal) Status(
 	defer cache.lock.RUnlock()
 
 	var blockStats, metaStats, tlfStats, lastUnrefStats []string
+	var memCompActive, tableCompActive bool
+	var metaMemCompActive, metaTableCompActive bool
 	if err := cache.checkCacheLocked("Block(Status)"); err == nil {
 		blockStats, err = cache.blockDb.StatStrings()
 		if err != nil {
@@ -1272,6 +1278,21 @@ func (cache *DiskBlockCacheLocal) Status(
 		if err != nil {
 			cache.log.CDebugf(ctx, "Couldn't get last unref db stats: %+v", err)
 		}
+		var dbStats leveldb.DBStats
+		err = cache.blockDb.Stats(&dbStats)
+		if err != nil {
+			cache.log.CDebugf(
+				ctx, "Couldn't get block db compaction stats: %+v", err)
+		}
+		memCompActive, tableCompActive =
+			dbStats.MemCompactionActive, dbStats.TableCompactionActive
+		err = cache.metaDb.Stats(&dbStats)
+		if err != nil {
+			cache.log.CDebugf(
+				ctx, "Couldn't get meta db compaction stats: %+v", err)
+		}
+		metaMemCompActive, metaTableCompActive =
+			dbStats.MemCompactionActive, dbStats.TableCompactionActive
 	}
 
 	// The disk cache status doesn't depend on the chargedTo ID, and
@@ -1295,6 +1316,10 @@ func (cache *DiskBlockCacheLocal) Status(
 			LocalDiskBytesTotal:     totalBytes,
 			BlockDBStats:            blockStats,
 			MetaDBStats:             metaStats,
+			MemCompActive:           memCompActive,
+			TableCompActive:         tableCompActive,
+			MetaMemCompActive:       metaMemCompActive,
+			MetaTableCompActive:     metaTableCompActive,
 			TLFDBStats:              tlfStats,
 			LastUnrefStats:          lastUnrefStats,
 		},

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -2699,9 +2699,34 @@ func (k *SimpleFS) SimpleFSGetStats(ctx context.Context) (
 	statusMap := dbc.Status(ctx)
 	if status, ok := statusMap["SyncBlockCache"]; ok {
 		res.SyncCacheDbStats = status.BlockDBStats
+
+		res.RuntimeDbStats = append(res.RuntimeDbStats,
+			keybase1.DbStats{
+				Type:            keybase1.DbType_FS_SYNC_BLOCK_CACHE,
+				MemCompActive:   status.MemCompActive,
+				TableCompActive: status.TableCompActive,
+			})
+		res.RuntimeDbStats = append(res.RuntimeDbStats,
+			keybase1.DbStats{
+				Type:            keybase1.DbType_FS_SYNC_BLOCK_CACHE_META,
+				MemCompActive:   status.MetaMemCompActive,
+				TableCompActive: status.MetaTableCompActive,
+			})
 	}
 	if status, ok := statusMap["WorkingSetBlockCache"]; ok {
 		res.BlockCacheDbStats = status.BlockDBStats
+		res.RuntimeDbStats = append(res.RuntimeDbStats,
+			keybase1.DbStats{
+				Type:            keybase1.DbType_FS_BLOCK_CACHE,
+				MemCompActive:   status.MemCompActive,
+				TableCompActive: status.TableCompActive,
+			})
+		res.RuntimeDbStats = append(res.RuntimeDbStats,
+			keybase1.DbStats{
+				Type:            keybase1.DbType_FS_BLOCK_CACHE_META,
+				MemCompActive:   status.MetaMemCompActive,
+				TableCompActive: status.MetaTableCompActive,
+			})
 	}
 	return res, nil
 }

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -260,6 +260,9 @@ func (j *JSONLocalDb) Close() error           { return j.engine.Close() }
 func (j *JSONLocalDb) Nuke() (string, error)  { return j.engine.Nuke() }
 func (j *JSONLocalDb) Clean(force bool) error { return j.engine.Clean(force) }
 func (j *JSONLocalDb) Stats() string          { return j.engine.Stats() }
+func (j *JSONLocalDb) CompactionStats() (bool, bool, error) {
+	return j.engine.CompactionStats()
+}
 func (j *JSONLocalDb) KeysWithPrefixes(prefixes ...[]byte) (DBKeySet, error) {
 	return j.engine.KeysWithPrefixes(prefixes...)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -151,6 +151,7 @@ type LocalDb interface {
 	LocalDbOps
 	Open() error
 	Stats() string
+	CompactionStats() (bool, bool, error)
 	ForceOpen() error
 	Close() error
 	Nuke() (string, error)

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -242,6 +242,16 @@ func (l *LevelDb) Stats() (stats string) {
 	return stats
 }
 
+func (l *LevelDb) CompactionStats() (memActive, tableActive bool, err error) {
+	var dbStats leveldb.DBStats
+	if err := l.doWhileOpenAndNukeIfCorrupted(func() (err error) {
+		return l.db.Stats(&dbStats)
+	}); err != nil {
+		return false, false, err
+	}
+	return dbStats.MemCompactionActive, dbStats.TableCompactionActive, nil
+}
+
 func (l *LevelDb) GetFilename() string {
 	if len(l.filename) == 0 {
 		l.G().Log.Fatalf("DB filename empty")

--- a/go/libkb/memdb.go
+++ b/go/libkb/memdb.go
@@ -22,8 +22,11 @@ func NewMemDb(size int) *MemDb {
 	}
 }
 
-func (m *MemDb) Open() error      { return nil }
-func (m *MemDb) Stats() string    { return "" }
+func (m *MemDb) Open() error   { return nil }
+func (m *MemDb) Stats() string { return "" }
+func (m *MemDb) CompactionStats() (bool, bool, error) {
+	return false, false, nil
+}
 func (m *MemDb) ForceOpen() error { return nil }
 func (m *MemDb) Close() error {
 	m.lru.Purge()

--- a/go/protocol/keybase1/ctl.go
+++ b/go/protocol/keybase1/ctl.go
@@ -40,26 +40,32 @@ func (e ExitCode) String() string {
 type DbType int
 
 const (
-	DbType_MAIN                DbType = 0
-	DbType_CHAT                DbType = 1
-	DbType_FS_BLOCK_CACHE      DbType = 2
-	DbType_FS_SYNC_BLOCK_CACHE DbType = 3
+	DbType_MAIN                     DbType = 0
+	DbType_CHAT                     DbType = 1
+	DbType_FS_BLOCK_CACHE           DbType = 2
+	DbType_FS_BLOCK_CACHE_META      DbType = 3
+	DbType_FS_SYNC_BLOCK_CACHE      DbType = 4
+	DbType_FS_SYNC_BLOCK_CACHE_META DbType = 5
 )
 
 func (o DbType) DeepCopy() DbType { return o }
 
 var DbTypeMap = map[string]DbType{
-	"MAIN":                0,
-	"CHAT":                1,
-	"FS_BLOCK_CACHE":      2,
-	"FS_SYNC_BLOCK_CACHE": 3,
+	"MAIN":                     0,
+	"CHAT":                     1,
+	"FS_BLOCK_CACHE":           2,
+	"FS_BLOCK_CACHE_META":      3,
+	"FS_SYNC_BLOCK_CACHE":      4,
+	"FS_SYNC_BLOCK_CACHE_META": 5,
 }
 
 var DbTypeRevMap = map[DbType]string{
 	0: "MAIN",
 	1: "CHAT",
 	2: "FS_BLOCK_CACHE",
-	3: "FS_SYNC_BLOCK_CACHE",
+	3: "FS_BLOCK_CACHE_META",
+	4: "FS_SYNC_BLOCK_CACHE",
+	5: "FS_SYNC_BLOCK_CACHE_META",
 }
 
 func (e DbType) String() string {

--- a/go/protocol/keybase1/ctl.go
+++ b/go/protocol/keybase1/ctl.go
@@ -40,20 +40,26 @@ func (e ExitCode) String() string {
 type DbType int
 
 const (
-	DbType_MAIN DbType = 0
-	DbType_CHAT DbType = 1
+	DbType_MAIN                DbType = 0
+	DbType_CHAT                DbType = 1
+	DbType_FS_BLOCK_CACHE      DbType = 2
+	DbType_FS_SYNC_BLOCK_CACHE DbType = 3
 )
 
 func (o DbType) DeepCopy() DbType { return o }
 
 var DbTypeMap = map[string]DbType{
-	"MAIN": 0,
-	"CHAT": 1,
+	"MAIN":                0,
+	"CHAT":                1,
+	"FS_BLOCK_CACHE":      2,
+	"FS_SYNC_BLOCK_CACHE": 3,
 }
 
 var DbTypeRevMap = map[DbType]string{
 	0: "MAIN",
 	1: "CHAT",
+	2: "FS_BLOCK_CACHE",
+	3: "FS_SYNC_BLOCK_CACHE",
 }
 
 func (e DbType) String() string {

--- a/go/protocol/keybase1/notify_runtimestats.go
+++ b/go/protocol/keybase1/notify_runtimestats.go
@@ -37,6 +37,20 @@ func (e StatsSeverityLevel) String() string {
 	return ""
 }
 
+type DbStats struct {
+	Type            DbType `codec:"type" json:"type"`
+	MemCompActive   bool   `codec:"memCompActive" json:"memCompActive"`
+	TableCompActive bool   `codec:"tableCompActive" json:"tableCompActive"`
+}
+
+func (o DbStats) DeepCopy() DbStats {
+	return DbStats{
+		Type:            o.Type.DeepCopy(),
+		MemCompActive:   o.MemCompActive,
+		TableCompActive: o.TableCompActive,
+	}
+}
+
 type RuntimeStats struct {
 	Cpu                 string             `codec:"cpu" json:"cpu"`
 	Resident            string             `codec:"resident" json:"resident"`
@@ -47,21 +61,33 @@ type RuntimeStats struct {
 	Goreleased          string             `codec:"goreleased" json:"goreleased"`
 	CpuSeverity         StatsSeverityLevel `codec:"cpuSeverity" json:"cpuSeverity"`
 	ResidentSeverity    StatsSeverityLevel `codec:"residentSeverity" json:"residentSeverity"`
+	DbStats             []DbStats          `codec:"dbStats" json:"dbStats"`
 	ConvLoaderActive    bool               `codec:"convLoaderActive" json:"convLoaderActive"`
 	SelectiveSyncActive bool               `codec:"selectiveSyncActive" json:"selectiveSyncActive"`
 }
 
 func (o RuntimeStats) DeepCopy() RuntimeStats {
 	return RuntimeStats{
-		Cpu:                 o.Cpu,
-		Resident:            o.Resident,
-		Virt:                o.Virt,
-		Free:                o.Free,
-		Goheap:              o.Goheap,
-		Goheapsys:           o.Goheapsys,
-		Goreleased:          o.Goreleased,
-		CpuSeverity:         o.CpuSeverity.DeepCopy(),
-		ResidentSeverity:    o.ResidentSeverity.DeepCopy(),
+		Cpu:              o.Cpu,
+		Resident:         o.Resident,
+		Virt:             o.Virt,
+		Free:             o.Free,
+		Goheap:           o.Goheap,
+		Goheapsys:        o.Goheapsys,
+		Goreleased:       o.Goreleased,
+		CpuSeverity:      o.CpuSeverity.DeepCopy(),
+		ResidentSeverity: o.ResidentSeverity.DeepCopy(),
+		DbStats: (func(x []DbStats) []DbStats {
+			if x == nil {
+				return nil
+			}
+			ret := make([]DbStats, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.DbStats),
 		ConvLoaderActive:    o.ConvLoaderActive,
 		SelectiveSyncActive: o.SelectiveSyncActive,
 	}

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1234,8 +1234,9 @@ func (o FSSettings) DeepCopy() FSSettings {
 }
 
 type SimpleFSStats struct {
-	BlockCacheDbStats []string `codec:"blockCacheDbStats" json:"blockCacheDbStats"`
-	SyncCacheDbStats  []string `codec:"syncCacheDbStats" json:"syncCacheDbStats"`
+	BlockCacheDbStats []string  `codec:"blockCacheDbStats" json:"blockCacheDbStats"`
+	SyncCacheDbStats  []string  `codec:"syncCacheDbStats" json:"syncCacheDbStats"`
+	RuntimeDbStats    []DbStats `codec:"runtimeDbStats" json:"runtimeDbStats"`
 }
 
 func (o SimpleFSStats) DeepCopy() SimpleFSStats {
@@ -1262,6 +1263,17 @@ func (o SimpleFSStats) DeepCopy() SimpleFSStats {
 			}
 			return ret
 		})(o.SyncCacheDbStats),
+		RuntimeDbStats: (func(x []DbStats) []DbStats {
+			if x == nil {
+				return nil
+			}
+			ret := make([]DbStats, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.RuntimeDbStats),
 	}
 }
 

--- a/go/runtimestats/stats.go
+++ b/go/runtimestats/stats.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/sync/errgroup"
 )
@@ -85,6 +86,20 @@ func (r *Runner) statsLoop(stopCh chan struct{}) error {
 	}
 }
 
+func (r *Runner) addDbStats(
+	ctx context.Context, dbType keybase1.DbType, db *libkb.JSONLocalDb,
+	stats *keybase1.RuntimeStats) {
+	var s keybase1.DbStats
+	s.Type = dbType
+	var err error
+	s.MemCompActive, s.TableCompActive, err = db.CompactionStats()
+	if err != nil {
+		r.debug(ctx, "Couldn't get compaction stats for %s: %+v", err)
+		return
+	}
+	stats.DbStats = append(stats.DbStats, s)
+}
+
 func (r *Runner) updateStats(ctx context.Context) {
 	var memstats runtime.MemStats
 	stats := getStats().Export()
@@ -94,6 +109,11 @@ func (r *Runner) updateStats(ctx context.Context) {
 	stats.Goreleased = utils.PresentBytes(int64(memstats.HeapReleased))
 	stats.ConvLoaderActive = r.G().ConvLoader.IsBackgroundActive()
 	stats.SelectiveSyncActive = r.G().Indexer.IsBackgroundActive()
+
+	stats.DbStats = make([]keybase1.DbStats, 0, 2)
+	r.addDbStats(ctx, keybase1.DbType_MAIN, r.G().LocalDb, &stats)
+	r.addDbStats(ctx, keybase1.DbType_CHAT, r.G().LocalChatDb, &stats)
+
 	r.G().NotifyRouter.HandleRuntimeStatsUpdate(ctx, &stats)
 	r.debug(ctx, "update: %+v", stats)
 }

--- a/go/service/ctl.go
+++ b/go/service/ctl.go
@@ -59,7 +59,7 @@ func (c *CtlHandler) DbClean(ctx context.Context, arg keybase1.DbCleanArg) error
 	case keybase1.DbType_CHAT:
 		return c.G().LocalChatDb.Clean(arg.Force)
 	default:
-		return libkb.NewDBError("no such DB type")
+		return libkb.NewDBError("unsupported DB type")
 	}
 }
 

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/db_compaction.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/db_compaction.go
@@ -759,10 +759,18 @@ func (db *DB) mCompaction() {
 	}()
 
 	for {
+		db.compActiveLk.Lock()
+		db.memCompActive = false
+		db.compActiveLk.Unlock()
+
 		select {
 		case x = <-db.mcompCmdC:
 			switch x.(type) {
 			case cAuto:
+				db.compActiveLk.Lock()
+				db.memCompActive = true
+				db.compActiveLk.Unlock()
+
 				db.memCompaction()
 				x.ack(nil)
 				x = nil
@@ -798,6 +806,10 @@ func (db *DB) tCompaction() {
 	}()
 
 	for {
+		db.compActiveLk.Lock()
+		db.tableCompActive = false
+		db.compActiveLk.Unlock()
+
 		if db.tableNeedCompaction() {
 			select {
 			case x = <-db.tcompCmdC:
@@ -831,6 +843,9 @@ func (db *DB) tCompaction() {
 				return
 			}
 		}
+		db.compActiveLk.Lock()
+		db.tableCompActive = true
+		db.compActiveLk.Unlock()
 		if x != nil {
 			switch cmd := x.(type) {
 			case cAuto:

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -1121,76 +1121,88 @@
 			"revisionTime": "2019-03-04T09:57:49Z"
 		},
 		{
-			"checksumSHA1": "FavASzhzj5uawgAyMG+00Vcx0po=",
+			"checksumSHA1": "d4mLiETrXMWWswlcAlioiLF8I5o=",
+			"origin": "github.com/keybase/goleveldb/leveldb",
 			"path": "github.com/syndtr/goleveldb/leveldb",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "mPNraL2edpk/2FYq26rSXfMHbJg=",
+			"origin": "github.com/keybase/goleveldb/leveldb/cache",
 			"path": "github.com/syndtr/goleveldb/leveldb/cache",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "UA+PKDKWlDnE2OZblh23W6wZwbY=",
+			"origin": "github.com/keybase/goleveldb/leveldb/comparer",
 			"path": "github.com/syndtr/goleveldb/leveldb/comparer",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "1DRAxdlWzS4U0xKN/yQ/fdNN7f0=",
+			"origin": "github.com/keybase/goleveldb/leveldb/errors",
 			"path": "github.com/syndtr/goleveldb/leveldb/errors",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "iBorxU3FBbau81WSyVa8KwcutzA=",
+			"origin": "github.com/keybase/goleveldb/leveldb/filter",
 			"path": "github.com/syndtr/goleveldb/leveldb/filter",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "hPyFsMiqZ1OB7MX+6wIAA6nsdtc=",
+			"origin": "github.com/keybase/goleveldb/leveldb/iterator",
 			"path": "github.com/syndtr/goleveldb/leveldb/iterator",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "gJY7bRpELtO0PJpZXgPQ2BYFJ88=",
+			"origin": "github.com/keybase/goleveldb/leveldb/journal",
 			"path": "github.com/syndtr/goleveldb/leveldb/journal",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "2ncG38FDk2thSlrHd7JFmiuvnxA=",
+			"origin": "github.com/keybase/goleveldb/leveldb/memdb",
 			"path": "github.com/syndtr/goleveldb/leveldb/memdb",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "o2TorI3z+vc+EBMJ8XeFoUmXBtU=",
+			"origin": "github.com/keybase/goleveldb/leveldb/opt",
 			"path": "github.com/syndtr/goleveldb/leveldb/opt",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "ZHT9cKerJeQfP0QRxEo6w/hNTYo=",
+			"origin": "github.com/keybase/goleveldb/leveldb/storage",
 			"path": "github.com/syndtr/goleveldb/leveldb/storage",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "DS0i9KReIeZn3T1Bpu31xPMtzio=",
+			"origin": "github.com/keybase/goleveldb/leveldb/table",
 			"path": "github.com/syndtr/goleveldb/leveldb/table",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "V/Dh7NV0/fy/5jX1KaAjmGcNbzI=",
+			"origin": "github.com/keybase/goleveldb/leveldb/util",
 			"path": "github.com/syndtr/goleveldb/leveldb/util",
-			"revision": "02440ea7a28525b3079783ad9c27083994a42366",
-			"revisionTime": "2019-06-25T01:02:20Z"
+			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
+			"revisionTime": "2019-07-17T20:47:18Z"
 		},
 		{
 			"checksumSHA1": "vU2ORasZstZrpzj13Y1pQM2Yqsc=",

--- a/protocol/avdl/keybase1/ctl.avdl
+++ b/protocol/avdl/keybase1/ctl.avdl
@@ -12,7 +12,9 @@ protocol ctl {
 
   enum DbType {
     MAIN_0,
-    CHAT_1
+    CHAT_1,
+    FS_BLOCK_CACHE_2,
+    FS_SYNC_BLOCK_CACHE_3
   }
 
   record DbKey {

--- a/protocol/avdl/keybase1/ctl.avdl
+++ b/protocol/avdl/keybase1/ctl.avdl
@@ -14,7 +14,9 @@ protocol ctl {
     MAIN_0,
     CHAT_1,
     FS_BLOCK_CACHE_2,
-    FS_SYNC_BLOCK_CACHE_3
+    FS_BLOCK_CACHE_META_3,
+    FS_SYNC_BLOCK_CACHE_4,
+    FS_SYNC_BLOCK_CACHE_META_5
   }
 
   record DbKey {

--- a/protocol/avdl/keybase1/notify_runtimestats.avdl
+++ b/protocol/avdl/keybase1/notify_runtimestats.avdl
@@ -7,6 +7,13 @@ protocol NotifyRuntimeStats {
     WARNING_1,
     SEVERE_2
   }
+
+  record DbStats {
+    DbType type;
+    boolean memCompActive;
+    boolean tableCompActive;
+  }
+
   record RuntimeStats {
     string cpu;
     string resident;
@@ -17,6 +24,7 @@ protocol NotifyRuntimeStats {
     string goreleased;
     StatsSeverityLevel cpuSeverity;
     StatsSeverityLevel residentSeverity;
+    array<DbStats> dbStats;
 
     // Chat specific
     boolean convLoaderActive;

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -543,6 +543,7 @@ protocol SimpleFS {
   record SimpleFSStats {
     array<string> blockCacheDbStats;
     array<string> syncCacheDbStats;
+    array<DbStats> runtimeDbStats;
   }
 
   SimpleFSStats simpleFSGetStats();

--- a/protocol/json/keybase1/ctl.json
+++ b/protocol/json/keybase1/ctl.json
@@ -21,7 +21,9 @@
       "name": "DbType",
       "symbols": [
         "MAIN_0",
-        "CHAT_1"
+        "CHAT_1",
+        "FS_BLOCK_CACHE_2",
+        "FS_SYNC_BLOCK_CACHE_3"
       ]
     },
     {

--- a/protocol/json/keybase1/ctl.json
+++ b/protocol/json/keybase1/ctl.json
@@ -23,7 +23,9 @@
         "MAIN_0",
         "CHAT_1",
         "FS_BLOCK_CACHE_2",
-        "FS_SYNC_BLOCK_CACHE_3"
+        "FS_BLOCK_CACHE_META_3",
+        "FS_SYNC_BLOCK_CACHE_4",
+        "FS_SYNC_BLOCK_CACHE_META_5"
       ]
     },
     {

--- a/protocol/json/keybase1/notify_runtimestats.json
+++ b/protocol/json/keybase1/notify_runtimestats.json
@@ -18,6 +18,24 @@
     },
     {
       "type": "record",
+      "name": "DbStats",
+      "fields": [
+        {
+          "type": "DbType",
+          "name": "type"
+        },
+        {
+          "type": "boolean",
+          "name": "memCompActive"
+        },
+        {
+          "type": "boolean",
+          "name": "tableCompActive"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "RuntimeStats",
       "fields": [
         {
@@ -55,6 +73,13 @@
         {
           "type": "StatsSeverityLevel",
           "name": "residentSeverity"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "DbStats"
+          },
+          "name": "dbStats"
         },
         {
           "type": "boolean",

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -736,6 +736,13 @@
             "items": "string"
           },
           "name": "syncCacheDbStats"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "DbStats"
+          },
+          "name": "runtimeDbStats"
         }
       ]
     }

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1336,6 +1336,8 @@ export enum ConflictStateType {
 export enum DbType {
   main = 0,
   chat = 1,
+  fsBlockCache = 2,
+  fsSyncBlockCache = 3,
 }
 
 export enum DeviceType {
@@ -2263,6 +2265,7 @@ export type Cryptocurrency = {readonly rowId: Int; readonly pkhash: Bytes; reado
 export type CsrfToken = String
 export type CurrentStatus = {readonly configured: Boolean; readonly registered: Boolean; readonly loggedIn: Boolean; readonly sessionIsValid: Boolean; readonly user?: User | null}
 export type DbKey = {readonly dbType: DbType; readonly objType: Int; readonly key: String}
+export type DbStats = {readonly type: DbType; readonly memCompActive: Boolean; readonly tableCompActive: Boolean}
 export type DbValue = Bytes
 export type DeletedTeamInfo = {readonly teamName: String; readonly deletedBy: String; readonly id: Gregor1.MsgID}
 export type DesktopStatus = {readonly version: String; readonly running: Boolean; readonly log: String}
@@ -2521,7 +2524,7 @@ export type ResolveIdentifyImplicitTeamRes = {readonly displayName: String; read
 export type RevokeWarning = {readonly endangeredTLFs?: Array<TLF> | null}
 export type RevokedKey = {readonly key: PublicKey; readonly time: KeybaseTime; readonly by: KID}
 export type RevokedProof = {readonly proof: RemoteProof; readonly diff: TrackDiff; readonly snoozed: Boolean}
-export type RuntimeStats = {readonly cpu: String; readonly resident: String; readonly virt: String; readonly free: String; readonly goheap: String; readonly goheapsys: String; readonly goreleased: String; readonly cpuSeverity: StatsSeverityLevel; readonly residentSeverity: StatsSeverityLevel; readonly convLoaderActive: Boolean; readonly selectiveSyncActive: Boolean}
+export type RuntimeStats = {readonly cpu: String; readonly resident: String; readonly virt: String; readonly free: String; readonly goheap: String; readonly goheapsys: String; readonly goreleased: String; readonly cpuSeverity: StatsSeverityLevel; readonly residentSeverity: StatsSeverityLevel; readonly dbStats?: Array<DbStats> | null; readonly convLoaderActive: Boolean; readonly selectiveSyncActive: Boolean}
 export type SHA512 = Bytes
 export type SaltpackDecryptOptions = {readonly interactive: Boolean; readonly forceRemoteCheck: Boolean; readonly usePaperKey: Boolean}
 export type SaltpackEncryptOptions = {readonly recipients?: Array<String> | null; readonly teamRecipients?: Array<String> | null; readonly authenticityType: AuthenticityType; readonly useEntityKeys: Boolean; readonly useDeviceKeys: Boolean; readonly usePaperKeys: Boolean; readonly noSelfEncrypt: Boolean; readonly binary: Boolean; readonly saltpackVersion: Int; readonly useKBFSKeysOnlyForTesting: Boolean}

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1337,7 +1337,9 @@ export enum DbType {
   main = 0,
   chat = 1,
   fsBlockCache = 2,
-  fsSyncBlockCache = 3,
+  fsBlockCacheMeta = 3,
+  fsSyncBlockCache = 4,
+  fsSyncBlockCacheMeta = 5,
 }
 
 export enum DeviceType {
@@ -2567,7 +2569,7 @@ export type SignupRes = {readonly passphraseOk: Boolean; readonly postOk: Boolea
 export type SimpleFSGetHTTPAddressAndTokenResponse = {readonly address: String; readonly token: String}
 export type SimpleFSListResult = {readonly entries?: Array<Dirent> | null; readonly progress: Progress}
 export type SimpleFSQuotaUsage = {readonly usageBytes: Int64; readonly archiveBytes: Int64; readonly limitBytes: Int64; readonly gitUsageBytes: Int64; readonly gitArchiveBytes: Int64; readonly gitLimitBytes: Int64}
-export type SimpleFSStats = {readonly blockCacheDbStats?: Array<String> | null; readonly syncCacheDbStats?: Array<String> | null}
+export type SimpleFSStats = {readonly blockCacheDbStats?: Array<String> | null; readonly syncCacheDbStats?: Array<String> | null; readonly runtimeDbStats?: Array<DbStats> | null}
 export type SizedImage = {readonly path: String; readonly width: Int}
 export type SocialAssertion = {readonly user: String; readonly service: SocialAssertionService}
 export type SocialAssertionService = String


### PR DESCRIPTION
This adds whether or not leveldb compaction is currently active for the major leveldb tables in both the service and KBFS.  Note that there are two types of compaction, "memory" and "table", so this includes two bools for each DB.

This focuses on the main DBs likely to be active: the main core db, the chat db, the KBFS transient block cache, and the KBFS sync block cache.  Each of the two latter DBs actually has two separate leveldb instances that might see heavy use -- the block cache, and the block metadata cache.

This also adds runtimestats support to `keybase show-notifications`.  For example, when I run that during a KBFS write/upload to an unsynced TLF, which finishes after a few seconds:

```sh
$ ./keybase --run-mode=prod show-notifications | grep Runtime
Runtime stats: Goheap=117.25MB, Goheapsys=382.16MB, Goreleased=0, dbFSBlockCache=[M:false T:true] 
Runtime stats: Goheap=199.93MB, Goheapsys=382.06MB, Goreleased=0, dbFSBlockCache=[M:true T:true] 
Runtime stats: Goheap=206.74MB, Goheapsys=382.00MB, Goreleased=0, dbFSBlockCache=[M:false T:true] 
Runtime stats: Goheap=208.18MB, Goheapsys=382.00MB, Goreleased=0
Runtime stats: Goheap=209.30MB, Goheapsys=382.00MB, Goreleased=0
Runtime stats: Goheap=209.35MB, Goheapsys=382.00MB, Goreleased=0
```

This vendors in https://github.com/keybase/goleveldb/pull/1 -- I'll update the `vendor.json` in this PR with the right hashes once that one is merged.

cc: @keybase/hotpotatosquad 	