### PR TITLE
nomerge - 4.2.1 hotfix branch

### DIFF
--- a/go/client/fork_server.go
+++ b/go/client/fork_server.go
@@ -144,6 +144,7 @@ func makeServerCommandLine(g *libkb.GlobalContext, cl libkb.CommandLine,
 		"no-debug",
 		"api-dump-unsafe",
 		"plain-logging",
+		"disable-cert-pinning",
 	}
 
 	strings := []string{
@@ -166,7 +167,6 @@ func makeServerCommandLine(g *libkb.GlobalContext, cl libkb.CommandLine,
 		"tor-proxy",
 		"tor-hidden-address",
 		"proxy-type",
-		"disable-cert-pinning",
 	}
 	args = append(args, arg0)
 

--- a/go/libkb/version.go
+++ b/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "4.2.0"
+const Version = "4.2.1"


### PR DESCRIPTION
…er spawn

Service was immediately failing because of the incorrect syntax but this wasn't logged because it was forked. I don't have any ideas on how to test this or even add a relevant log.

One idea is that we could make the lists `[]cli.BoolFlag` and `[]cli.StringFlag`, that would at least prevent this specific bug in the future.

ref: https://github.com/keybase/client/issues/18452