### PR TITLE
rethink some of the wallet RPCs to be more direct

### DIFF
--- a/go/client/cmd_wallet_rename.go
+++ b/go/client/cmd_wallet_rename.go
@@ -52,7 +52,7 @@ func (c *cmdWalletRename) Run() (err error) {
 	if err != nil {
 		return err
 	}
-	err = cli.ChangeWalletAccountNameLocal(context.TODO(), stellar1.ChangeWalletAccountNameLocalArg{
+	_, err = cli.ChangeWalletAccountNameLocal(context.TODO(), stellar1.ChangeWalletAccountNameLocalArg{
 		AccountID: c.AccountID,
 		NewName:   c.Name,
 	})

--- a/go/client/cmd_wallet_set_primary.go
+++ b/go/client/cmd_wallet_set_primary.go
@@ -48,7 +48,7 @@ func (c *cmdWalletSetPrimary) Run() (err error) {
 		AccountID: stellar1.AccountID(c.accountID),
 	}
 
-	if err := cli.SetWalletAccountAsDefaultLocal(context.Background(), arg); err != nil {
+	if _, err := cli.SetWalletAccountAsDefaultLocal(context.Background(), arg); err != nil {
 		return err
 	}
 

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -1683,7 +1683,7 @@ type LocalInterface interface {
 	ValidateAccountIDLocal(context.Context, ValidateAccountIDLocalArg) error
 	ValidateSecretKeyLocal(context.Context, ValidateSecretKeyLocalArg) error
 	ValidateAccountNameLocal(context.Context, ValidateAccountNameLocalArg) error
-	ChangeWalletAccountNameLocal(context.Context, ChangeWalletAccountNameLocalArg) error
+	ChangeWalletAccountNameLocal(context.Context, ChangeWalletAccountNameLocalArg) (WalletAccountLocal, error)
 	SetWalletAccountAsDefaultLocal(context.Context, SetWalletAccountAsDefaultLocalArg) error
 	DeleteWalletAccountLocal(context.Context, DeleteWalletAccountLocalArg) error
 	LinkNewWalletAccountLocal(context.Context, LinkNewWalletAccountLocalArg) (AccountID, error)
@@ -1946,7 +1946,7 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[1]ChangeWalletAccountNameLocalArg)(nil), args)
 						return
 					}
-					err = i.ChangeWalletAccountNameLocal(ctx, typedArgs[0])
+					ret, err = i.ChangeWalletAccountNameLocal(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -2970,8 +2970,8 @@ func (c LocalClient) ValidateAccountNameLocal(ctx context.Context, __arg Validat
 	return
 }
 
-func (c LocalClient) ChangeWalletAccountNameLocal(ctx context.Context, __arg ChangeWalletAccountNameLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.changeWalletAccountNameLocal", []interface{}{__arg}, nil)
+func (c LocalClient) ChangeWalletAccountNameLocal(ctx context.Context, __arg ChangeWalletAccountNameLocalArg) (res WalletAccountLocal, err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.changeWalletAccountNameLocal", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -1684,7 +1684,7 @@ type LocalInterface interface {
 	ValidateSecretKeyLocal(context.Context, ValidateSecretKeyLocalArg) error
 	ValidateAccountNameLocal(context.Context, ValidateAccountNameLocalArg) error
 	ChangeWalletAccountNameLocal(context.Context, ChangeWalletAccountNameLocalArg) (WalletAccountLocal, error)
-	SetWalletAccountAsDefaultLocal(context.Context, SetWalletAccountAsDefaultLocalArg) error
+	SetWalletAccountAsDefaultLocal(context.Context, SetWalletAccountAsDefaultLocalArg) ([]WalletAccountLocal, error)
 	DeleteWalletAccountLocal(context.Context, DeleteWalletAccountLocalArg) error
 	LinkNewWalletAccountLocal(context.Context, LinkNewWalletAccountLocalArg) (AccountID, error)
 	CreateWalletAccountLocal(context.Context, CreateWalletAccountLocalArg) (AccountID, error)
@@ -1961,7 +1961,7 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[1]SetWalletAccountAsDefaultLocalArg)(nil), args)
 						return
 					}
-					err = i.SetWalletAccountAsDefaultLocal(ctx, typedArgs[0])
+					ret, err = i.SetWalletAccountAsDefaultLocal(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -2975,8 +2975,8 @@ func (c LocalClient) ChangeWalletAccountNameLocal(ctx context.Context, __arg Cha
 	return
 }
 
-func (c LocalClient) SetWalletAccountAsDefaultLocal(ctx context.Context, __arg SetWalletAccountAsDefaultLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.setWalletAccountAsDefaultLocal", []interface{}{__arg}, nil)
+func (c LocalClient) SetWalletAccountAsDefaultLocal(ctx context.Context, __arg SetWalletAccountAsDefaultLocalArg) (res []WalletAccountLocal, err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.setWalletAccountAsDefaultLocal", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -1688,7 +1688,7 @@ type LocalInterface interface {
 	DeleteWalletAccountLocal(context.Context, DeleteWalletAccountLocalArg) error
 	LinkNewWalletAccountLocal(context.Context, LinkNewWalletAccountLocalArg) (AccountID, error)
 	CreateWalletAccountLocal(context.Context, CreateWalletAccountLocalArg) (AccountID, error)
-	ChangeDisplayCurrencyLocal(context.Context, ChangeDisplayCurrencyLocalArg) error
+	ChangeDisplayCurrencyLocal(context.Context, ChangeDisplayCurrencyLocalArg) (CurrencyLocal, error)
 	GetDisplayCurrencyLocal(context.Context, GetDisplayCurrencyLocalArg) (CurrencyLocal, error)
 	HasAcceptedDisclaimerLocal(context.Context, int) (bool, error)
 	AcceptDisclaimerLocal(context.Context, int) error
@@ -2021,7 +2021,7 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[1]ChangeDisplayCurrencyLocalArg)(nil), args)
 						return
 					}
-					err = i.ChangeDisplayCurrencyLocal(ctx, typedArgs[0])
+					ret, err = i.ChangeDisplayCurrencyLocal(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -2995,8 +2995,8 @@ func (c LocalClient) CreateWalletAccountLocal(ctx context.Context, __arg CreateW
 	return
 }
 
-func (c LocalClient) ChangeDisplayCurrencyLocal(ctx context.Context, __arg ChangeDisplayCurrencyLocalArg) (err error) {
-	err = c.Cli.Call(ctx, "stellar.1.local.changeDisplayCurrencyLocal", []interface{}{__arg}, nil)
+func (c LocalClient) ChangeDisplayCurrencyLocal(ctx context.Context, __arg ChangeDisplayCurrencyLocalArg) (res CurrencyLocal, err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.changeDisplayCurrencyLocal", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -540,7 +540,7 @@ func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.
 	return stellar.WalletAccount(mctx, s.remoter, arg.AccountID)
 }
 
-func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (err error) {
+func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (accts []stellar1.WalletAccountLocal, err error) {
 	mctx, fin, err := s.Preamble(ctx, preambleArg{
 		RPCName:       "SetWalletAccountAsDefaultLocal",
 		Err:           &err,
@@ -548,15 +548,19 @@ func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar
 	})
 	defer fin()
 	if err != nil {
-		return err
+		return accts, err
 	}
 
 	if arg.AccountID.IsNil() {
 		mctx.Debug("SetWalletAccountAsDefaultLocal called with an empty account id")
-		return ErrAccountIDMissing
+		return accts, ErrAccountIDMissing
 	}
 
-	return stellar.SetAccountAsPrimary(mctx, s.walletState, arg.AccountID)
+	err = stellar.SetAccountAsPrimary(mctx, s.walletState, arg.AccountID)
+	if err != nil {
+		return accts, err
+	}
+	return stellar.AllWalletAccounts(mctx, s.remoter)
 }
 
 func (s *Server) DeleteWalletAccountLocal(ctx context.Context, arg stellar1.DeleteWalletAccountLocalArg) (err error) {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -517,7 +517,7 @@ func (s *Server) ValidateAccountNameLocal(ctx context.Context, arg stellar1.Vali
 	return nil
 }
 
-func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.ChangeWalletAccountNameLocalArg) (err error) {
+func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.ChangeWalletAccountNameLocalArg) (acct stellar1.WalletAccountLocal, err error) {
 	mctx, fin, err := s.Preamble(ctx, preambleArg{
 		RPCName:       "ChangeWalletAccountNameLocal",
 		Err:           &err,
@@ -525,15 +525,19 @@ func (s *Server) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.
 	})
 	defer fin()
 	if err != nil {
-		return err
+		return acct, err
 	}
 
 	if arg.AccountID.IsNil() {
 		mctx.Debug("ChangeWalletAccountNameLocal called with an empty account id")
-		return ErrAccountIDMissing
+		return acct, ErrAccountIDMissing
 	}
 
-	return stellar.ChangeAccountName(mctx, s.walletState, arg.AccountID, arg.NewName)
+	err = stellar.ChangeAccountName(mctx, s.walletState, arg.AccountID, arg.NewName)
+	if err != nil {
+		return acct, err
+	}
+	return stellar.WalletAccount(mctx, s.remoter, arg.AccountID)
 }
 
 func (s *Server) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (err error) {

--- a/go/stellar/stellarsvc/frontend.go
+++ b/go/stellar/stellarsvc/frontend.go
@@ -578,7 +578,7 @@ func (s *Server) DeleteWalletAccountLocal(ctx context.Context, arg stellar1.Dele
 	return stellar.DeleteAccount(mctx, arg.AccountID)
 }
 
-func (s *Server) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.ChangeDisplayCurrencyLocalArg) (err error) {
+func (s *Server) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.ChangeDisplayCurrencyLocalArg) (res stellar1.CurrencyLocal, err error) {
 	mctx, fin, err := s.Preamble(ctx, preambleArg{
 		RPCName:       "ChangeDisplayCurrencyLocal",
 		Err:           &err,
@@ -586,13 +586,17 @@ func (s *Server) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.Ch
 	})
 	defer fin()
 	if err != nil {
-		return err
+		return res, err
 	}
 
 	if arg.AccountID.IsNil() {
-		return ErrAccountIDMissing
+		return res, ErrAccountIDMissing
 	}
-	return remote.SetAccountDefaultCurrency(mctx.Ctx(), s.G(), arg.AccountID, string(arg.Currency))
+	err = remote.SetAccountDefaultCurrency(mctx.Ctx(), s.G(), arg.AccountID, string(arg.Currency))
+	if err != nil {
+		return res, err
+	}
+	return stellar.GetCurrencySetting(mctx, arg.AccountID)
 }
 
 func (s *Server) GetDisplayCurrencyLocal(ctx context.Context, arg stellar1.GetDisplayCurrencyLocalArg) (res stellar1.CurrencyLocal, err error) {

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -352,11 +352,12 @@ func TestChangeWalletName(t *testing.T) {
 	chk("", "name required")
 	chk("office lunch money", "")
 	chk("savings", "")
-	err = tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
+	res, err := tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
 		AccountID: accs[0].AccountID,
 		NewName:   "office lunch money",
 	})
 	require.NoError(t, err)
+	require.Equal(t, "office lunch money", res.Name)
 	chk("office lunch money", "you already have an account with that name")
 	chk("career debter", "")
 
@@ -372,7 +373,7 @@ func TestChangeWalletName(t *testing.T) {
 
 	// Try invalid argument
 	invalidAccID, _ := randomStellarKeypair()
-	err = tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
+	_, err = tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
 		AccountID: invalidAccID,
 		NewName:   "savings",
 	})
@@ -739,7 +740,7 @@ func TestGetPaymentsLocal(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = srvSender.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
+	_, err = srvSender.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
 		AccountID: accountIDSender,
 		NewName:   "office lunch money",
 	})
@@ -1066,7 +1067,7 @@ func TestSendToSelf(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
+	_, err = tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
 		AccountID: accountID1,
 		NewName:   "office lunch money",
 	})
@@ -1078,7 +1079,7 @@ func TestSendToSelf(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
+	_, err = tcs[0].Srv.ChangeWalletAccountNameLocal(context.Background(), stellar1.ChangeWalletAccountNameLocalArg{
 		AccountID: accountID2,
 		NewName:   "savings",
 	})

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -193,11 +193,12 @@ func TestGetAccountAssetsLocalWithCHFBalance(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+	curr, err := tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
 		AccountID: accountID,
 		Currency:  stellar1.OutsideCurrencyCode("CHF"),
 	})
 	require.NoError(t, err)
+	require.Equal(t, stellar1.OutsideCurrencyCode("CHF"), curr.Code)
 
 	tcs[0].Backend.ImportAccountsForUser(tcs[0])
 
@@ -575,14 +576,14 @@ func TestChangeDisplayCurrency(t *testing.T) {
 	accID := getPrimaryAccountID(tcs[0])
 
 	// Try invalid currency first.
-	err := tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+	_, err := tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
 		AccountID: accID,
 		Currency:  stellar1.OutsideCurrencyCode("ZZZ"),
 	})
 	require.Error(t, err)
 
 	// Try empty account id.
-	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+	_, err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
 		AccountID: stellar1.AccountID(""),
 		Currency:  stellar1.OutsideCurrencyCode("USD"),
 	})
@@ -590,7 +591,7 @@ func TestChangeDisplayCurrency(t *testing.T) {
 
 	// Try non-existant account id.
 	invalidAccID, _ := randomStellarKeypair()
-	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+	_, err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
 		AccountID: invalidAccID,
 		Currency:  stellar1.OutsideCurrencyCode("USD"),
 	})
@@ -601,18 +602,19 @@ func TestChangeDisplayCurrency(t *testing.T) {
 	acceptDisclaimer(tcs[1])
 	tcs[1].Backend.ImportAccountsForUser(tcs[1])
 	accID2 := getPrimaryAccountID(tcs[1])
-	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+	_, err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
 		AccountID: accID2,
 		Currency:  stellar1.OutsideCurrencyCode("EUR"),
 	})
 	require.Error(t, err)
 
 	// Finally, a happy path.
-	err = tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
+	res, err := tcs[0].Srv.ChangeDisplayCurrencyLocal(context.Background(), stellar1.ChangeDisplayCurrencyLocalArg{
 		AccountID: accID,
 		Currency:  stellar1.OutsideCurrencyCode("EUR"),
 	})
 	require.NoError(t, err)
+	require.Equal(t, stellar1.OutsideCurrencyCode("EUR"), res.Code)
 
 	// Check both CLI and Frontend RPCs.
 	accs, err := tcs[0].Srv.WalletGetAccountsCLILocal(context.Background())

--- a/go/stellar/stellarsvc/frontend_test.go
+++ b/go/stellar/stellarsvc/frontend_test.go
@@ -400,10 +400,11 @@ func TestSetAccountAsDefault(t *testing.T) {
 
 	// Should work for accounts that are already primary and not post
 	// a bundle.
-	err = tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), stellar1.SetWalletAccountAsDefaultLocalArg{
+	res, err := tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), stellar1.SetWalletAccountAsDefaultLocalArg{
 		AccountID: accs[0].AccountID,
 	})
 	require.NoError(t, err)
+	require.Equal(t, accs[0].AccountID, res[0].AccountID)
 
 	mctx := libkb.NewMetaContextBackground(tcs[0].G)
 	bundle, err := remote.FetchSecretlessBundle(mctx)
@@ -412,12 +413,12 @@ func TestSetAccountAsDefault(t *testing.T) {
 
 	// Test invalid arguments
 	invalidAccID, _ := randomStellarKeypair()
-	err = tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), stellar1.SetWalletAccountAsDefaultLocalArg{
+	_, err = tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), stellar1.SetWalletAccountAsDefaultLocalArg{
 		AccountID: invalidAccID,
 	})
 	require.Error(t, err)
 
-	err = tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), stellar1.SetWalletAccountAsDefaultLocalArg{
+	_, err = tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), stellar1.SetWalletAccountAsDefaultLocalArg{
 		AccountID: stellar1.AccountID(""),
 	})
 	require.Error(t, err)
@@ -441,7 +442,7 @@ func TestSetAccountAsDefault(t *testing.T) {
 		arg := stellar1.SetWalletAccountAsDefaultLocalArg{
 			AccountID: v,
 		}
-		err := tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), arg)
+		_, err := tcs[0].Srv.SetWalletAccountAsDefaultLocal(context.Background(), arg)
 		require.NoError(t, err)
 
 		accs, err := tcs[0].Srv.WalletGetAccountsCLILocal(context.Background())

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -954,10 +954,12 @@ func TestBundleFlows(t *testing.T) {
 	assertFetchAccountBundles(t, tcs[0], a2)
 
 	// switch which account is primary
-	err = tcs[0].Srv.SetWalletAccountAsDefaultLocal(ctx, stellar1.SetWalletAccountAsDefaultLocalArg{
+	defaultChangeRes, err := tcs[0].Srv.SetWalletAccountAsDefaultLocal(ctx, stellar1.SetWalletAccountAsDefaultLocalArg{
 		AccountID: a1,
 	})
 	require.NoError(t, err)
+	require.Equal(t, a1, defaultChangeRes[0].AccountID)
+	require.True(t, defaultChangeRes[0].IsDefault)
 	assertFetchAccountBundles(t, tcs[0], a1)
 
 	fullBundle, err := fetchWholeBundleForTesting(mctx)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -981,11 +981,12 @@ func TestBundleFlows(t *testing.T) {
 	require.EqualValues(t, s2, privKey)
 
 	// ChangeAccountName
-	err = tcs[0].Srv.ChangeWalletAccountNameLocal(ctx, stellar1.ChangeWalletAccountNameLocalArg{
+	res, err := tcs[0].Srv.ChangeWalletAccountNameLocal(ctx, stellar1.ChangeWalletAccountNameLocalArg{
 		AccountID: a2,
 		NewName:   "rename",
 	})
 	require.NoError(t, err)
+	require.Equal(t, "rename", res.Name)
 	bundle, err = remote.FetchAccountBundle(mctx, a2)
 	require.NoError(t, err)
 	for _, acc := range bundle.Accounts {

--- a/go/systests/stellar_client_test.go
+++ b/go/systests/stellar_client_test.go
@@ -138,14 +138,14 @@ func (s *stellarRetryClient) ChangeWalletAccountNameLocal(ctx context.Context, a
 	return acct, err
 }
 
-func (s *stellarRetryClient) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (err error) {
+func (s *stellarRetryClient) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (accts []stellar1.WalletAccountLocal, err error) {
 	for i := 0; i < retryCount; i++ {
-		err = s.cli.SetWalletAccountAsDefaultLocal(ctx, arg)
+		accts, err = s.cli.SetWalletAccountAsDefaultLocal(ctx, arg)
 		if err == nil {
 			break
 		}
 	}
-	return err
+	return accts, err
 }
 
 func (s *stellarRetryClient) DeleteWalletAccountLocal(ctx context.Context, arg stellar1.DeleteWalletAccountLocalArg) (err error) {

--- a/go/systests/stellar_client_test.go
+++ b/go/systests/stellar_client_test.go
@@ -178,14 +178,14 @@ func (s *stellarRetryClient) CreateWalletAccountLocal(ctx context.Context, arg s
 	return res, err
 }
 
-func (s *stellarRetryClient) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.ChangeDisplayCurrencyLocalArg) (err error) {
+func (s *stellarRetryClient) ChangeDisplayCurrencyLocal(ctx context.Context, arg stellar1.ChangeDisplayCurrencyLocalArg) (res stellar1.CurrencyLocal, err error) {
 	for i := 0; i < retryCount; i++ {
-		err = s.cli.ChangeDisplayCurrencyLocal(ctx, arg)
+		res, err = s.cli.ChangeDisplayCurrencyLocal(ctx, arg)
 		if err == nil {
 			break
 		}
 	}
-	return err
+	return res, err
 }
 
 func (s *stellarRetryClient) GetDisplayCurrencyLocal(ctx context.Context, arg stellar1.GetDisplayCurrencyLocalArg) (res stellar1.CurrencyLocal, err error) {

--- a/go/systests/stellar_client_test.go
+++ b/go/systests/stellar_client_test.go
@@ -128,14 +128,14 @@ func (s *stellarRetryClient) ValidateAccountNameLocal(ctx context.Context, arg s
 	return err
 }
 
-func (s *stellarRetryClient) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.ChangeWalletAccountNameLocalArg) (err error) {
+func (s *stellarRetryClient) ChangeWalletAccountNameLocal(ctx context.Context, arg stellar1.ChangeWalletAccountNameLocalArg) (acct stellar1.WalletAccountLocal, err error) {
 	for i := 0; i < retryCount; i++ {
-		err = s.cli.ChangeWalletAccountNameLocal(ctx, arg)
+		acct, err = s.cli.ChangeWalletAccountNameLocal(ctx, arg)
 		if err == nil {
 			break
 		}
 	}
-	return err
+	return acct, err
 }
 
 func (s *stellarRetryClient) SetWalletAccountAsDefaultLocal(ctx context.Context, arg stellar1.SetWalletAccountAsDefaultLocalArg) (err error) {

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -212,7 +212,7 @@ protocol local {
 
   // OutsideCurrencyCode examples: "USD", "EUR". Has to be one of
   // supported currencies, returned from getDisplayCurrenciesLocal.
-  void changeDisplayCurrencyLocal(int sessionID, AccountID accountID, OutsideCurrencyCode currency);
+  CurrencyLocal changeDisplayCurrencyLocal(int sessionID, AccountID accountID, OutsideCurrencyCode currency);
   // Gets display currency for primary account if no accountID is given.
   CurrencyLocal getDisplayCurrencyLocal(int sessionID, union { null, AccountID } accountID);
 

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -198,7 +198,7 @@ protocol local {
   void validateAccountNameLocal(int sessionID, string name);
 
   WalletAccountLocal changeWalletAccountNameLocal(int sessionID, AccountID accountID, string newName);
-  void setWalletAccountAsDefaultLocal(int sessionID, AccountID accountID);
+  array<WalletAccountLocal> setWalletAccountAsDefaultLocal(int sessionID, AccountID accountID);
 
   // Deleting an account is irreversible, even with Keybase, Inc. help.
   // Consumer of this API should always prompt the user and warn that if

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -197,7 +197,7 @@ protocol local {
   // If there is an error getting account names, the error is suppressed.
   void validateAccountNameLocal(int sessionID, string name);
 
-  void changeWalletAccountNameLocal(int sessionID, AccountID accountID, string newName);
+  WalletAccountLocal changeWalletAccountNameLocal(int sessionID, AccountID accountID, string newName);
   void setWalletAccountAsDefaultLocal(int sessionID, AccountID accountID);
 
   // Deleting an account is irreversible, even with Keybase, Inc. help.

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -1630,7 +1630,7 @@
           "type": "string"
         }
       ],
-      "response": null
+      "response": "WalletAccountLocal"
     },
     "setWalletAccountAsDefaultLocal": {
       "request": [

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -1707,7 +1707,7 @@
           "type": "OutsideCurrencyCode"
         }
       ],
-      "response": null
+      "response": "CurrencyLocal"
     },
     "getDisplayCurrencyLocal": {
       "request": [

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -1643,7 +1643,10 @@
           "type": "AccountID"
         }
       ],
-      "response": null
+      "response": {
+        "type": "array",
+        "items": "WalletAccountLocal"
+      }
     },
     "deleteWalletAccountLocal": {
       "request": [

--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -189,9 +189,10 @@
     },
     "changedAccountName": {
       "_description": "A response from the service after an account's name is changed",
-      "accountID": "Types.AccountID",
+      "account": "Types.Account",
       "canError": {
         "name": "string",
+        "account": "Types.Account",
         "error": "string"
       }
     },

--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -202,7 +202,7 @@
     },
     "didSetAccountAsDefault": {
       "_description": "A response from the service after an account is set as the default",
-      "accountID": "Types.AccountID"
+      "accounts": "Array<Types.Account>"
     },
     "deleteAccount": {
       "_description": "Delete an account",

--- a/shared/actions/wallets-gen.tsx
+++ b/shared/actions/wallets-gen.tsx
@@ -188,7 +188,7 @@ type _CreatedNewAccountPayloadError = {readonly name: string; readonly error: st
 type _DeleteAccountPayload = {readonly accountID: Types.AccountID}
 type _DeleteTrustlinePayload = {readonly accountID: Types.AccountID; readonly assetID: Types.AssetID}
 type _DeletedAccountPayload = void
-type _DidSetAccountAsDefaultPayload = {readonly accountID: Types.AccountID}
+type _DidSetAccountAsDefaultPayload = {readonly accounts: Array<Types.Account>}
 type _DisplayCurrenciesReceivedPayload = {readonly currencies: Array<Types.Currency>}
 type _DisplayCurrencyReceivedPayload = {
   readonly accountID: Types.AccountID | null

--- a/shared/actions/wallets-gen.tsx
+++ b/shared/actions/wallets-gen.tsx
@@ -159,8 +159,12 @@ type _ChangeAccountNamePayload = {readonly accountID: Types.AccountID; readonly 
 type _ChangeAirdropPayload = {readonly accept: boolean}
 type _ChangeDisplayCurrencyPayload = {readonly accountID: Types.AccountID; readonly code: Types.CurrencyCode}
 type _ChangeMobileOnlyModePayload = {readonly accountID: Types.AccountID; readonly enabled: boolean}
-type _ChangedAccountNamePayload = {readonly accountID: Types.AccountID}
-type _ChangedAccountNamePayloadError = {readonly name: string; readonly error: string}
+type _ChangedAccountNamePayload = {readonly account: Types.Account}
+type _ChangedAccountNamePayloadError = {
+  readonly name: string
+  readonly account: Types.Account
+  readonly error: string
+}
 type _ChangedTrustlinePayload = void
 type _ChangedTrustlinePayloadError = {readonly error: string}
 type _CheckDisclaimerPayload = {readonly nextScreen: Types.NextScreenAfterAcceptance}

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1037,10 +1037,10 @@ const loadMobileOnlyMode = (
   return RPCStellarTypes.localIsAccountMobileOnlyLocalRpcPromise({
     accountID,
   })
-    .then(res =>
+    .then(isMobileOnly =>
       WalletsGen.createLoadedMobileOnlyMode({
-        accountID,
-        enabled: res,
+        accountID: accountID,
+        enabled: isMobileOnly,
       })
     )
     .catch(err => handleSelectAccountError(action, 'loading mobile only mode', err))
@@ -1051,10 +1051,12 @@ const changeMobileOnlyMode = (_: TypedState, action: WalletsGen.ChangeMobileOnly
   let f = action.payload.enabled
     ? RPCStellarTypes.localSetAccountMobileOnlyLocalRpcPromise
     : RPCStellarTypes.localSetAccountAllDevicesLocalRpcPromise
-  return f({accountID}, Constants.setAccountMobileOnlyWaitingKey(accountID)).then(() => [
-    WalletsGen.createLoadedMobileOnlyMode({accountID, enabled: action.payload.enabled}),
-    WalletsGen.createLoadMobileOnlyMode({accountID}),
-  ])
+  return f({accountID}, Constants.setAccountMobileOnlyWaitingKey(accountID)).then(() =>
+    WalletsGen.createLoadedMobileOnlyMode({
+      accountID: accountID,
+      enabled: action.payload.enabled,
+    })
+  )
 }
 
 const writeLastSentXLM = (

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -935,11 +935,10 @@ const accountDetailsUpdate = (_: TypedState, action: EngineGen.Stellar1NotifyAcc
 
 const accountsUpdate = (
   _: TypedState,
-  action: EngineGen.Stellar1NotifyRecentPaymentsUpdatePayload,
+  action: EngineGen.Stellar1NotifyAccountsUpdatePayload,
   logger: Saga.SagaLogger
 ) =>
   WalletsGen.createAccountsReceived({
-    // @ts-ignore codemod-issue
     accounts: (action.payload.params.accounts || []).map(account => {
       if (!account.accountID) {
         logger.error(`Found empty accountID, name: ${account.name} isDefault: ${String(account.isDefault)}`)

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -641,7 +641,6 @@ const setAccountAsDefault = (_: TypedState, action: WalletsGen.SetAccountAsDefau
     Constants.setAccountAsDefaultWaitingKey
   ).then(accountsAfterUpdate =>
     WalletsGen.createDidSetAccountAsDefault({
-      // @ts-ignore codemod-issue
       accounts: (accountsAfterUpdate || []).map(account => {
         if (!account.accountID) {
           logger.error(`Found empty accountID, name: ${account.name} isDefault: ${String(account.isDefault)}`)

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -639,7 +639,17 @@ const setAccountAsDefault = (_: TypedState, action: WalletsGen.SetAccountAsDefau
   RPCStellarTypes.localSetWalletAccountAsDefaultLocalRpcPromise(
     {accountID: action.payload.accountID},
     Constants.setAccountAsDefaultWaitingKey
-  ).then(() => WalletsGen.createDidSetAccountAsDefault({accountID: action.payload.accountID}))
+  ).then(accountsAfterUpdate =>
+    WalletsGen.createDidSetAccountAsDefault({
+      // @ts-ignore codemod-issue
+      accounts: (accountsAfterUpdate || []).map(account => {
+        if (!account.accountID) {
+          logger.error(`Found empty accountID, name: ${account.name} isDefault: ${String(account.isDefault)}`)
+        }
+        return Constants.accountResultToAccount(account)
+      }),
+    })
+  )
 
 const loadPaymentDetail = (
   _: TypedState,

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -610,7 +610,13 @@ const changeDisplayCurrency = (_: TypedState, action: WalletsGen.ChangeDisplayCu
       currency: action.payload.code, // called currency, though it is a code
     },
     Constants.changeDisplayCurrencyWaitingKey
-  ).then(_ => WalletsGen.createLoadDisplayCurrency({accountID: action.payload.accountID}))
+  ).then(currencyRes => {
+    WalletsGen.createDisplayCurrencyReceived({
+      accountID: action.payload.accountID,
+      currency: Constants.makeCurrency(currencyRes),
+      setBuildingCurrency: false,
+    })
+  })
 
 const changeAccountName = (_: TypedState, action: WalletsGen.ChangeAccountNamePayload) =>
   RPCStellarTypes.localChangeWalletAccountNameLocalRpcPromise(

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -335,7 +335,6 @@ const loadAccounts = (
     | WalletsGen.LoadAccountsPayload
     | WalletsGen.CreatedNewAccountPayload
     | WalletsGen.LinkedExistingAccountPayload
-    | WalletsGen.ChangedAccountNamePayload
     | WalletsGen.DeletedAccountPayload,
   logger: Saga.SagaLogger
 ) => {
@@ -625,7 +624,7 @@ const changeAccountName = (_: TypedState, action: WalletsGen.ChangeAccountNamePa
       newName: action.payload.name,
     },
     Constants.changeAccountNameWaitingKey
-  ).then(() => WalletsGen.createChangedAccountName({accountID: action.payload.accountID}))
+  ).then(res => WalletsGen.createChangedAccountName({account: Constants.accountResultToAccount(res)}))
 
 const deleteAccount = (_: TypedState, action: WalletsGen.DeleteAccountPayload) =>
   RPCStellarTypes.localDeleteWalletAccountLocalRpcPromise(
@@ -1519,14 +1518,12 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
     | WalletsGen.LoadAccountsPayload
     | WalletsGen.CreatedNewAccountPayload
     | WalletsGen.LinkedExistingAccountPayload
-    | WalletsGen.ChangedAccountNamePayload
     | WalletsGen.DeletedAccountPayload
   >(
     [
       WalletsGen.loadAccounts,
       WalletsGen.createdNewAccount,
       WalletsGen.linkedExistingAccount,
-      WalletsGen.changedAccountName,
       WalletsGen.deletedAccount,
     ],
     loadAccounts,

--- a/shared/constants/types/rpc-stellar-gen.tsx
+++ b/shared/constants/types/rpc-stellar-gen.tsx
@@ -213,7 +213,7 @@ export type MessageTypes = {
   }
   'stellar.1.local.setWalletAccountAsDefaultLocal': {
     inParam: {readonly accountID: AccountID}
-    outParam: void
+    outParam: Array<WalletAccountLocal> | null
   }
   'stellar.1.local.startBuildPaymentLocal': {
     inParam: void

--- a/shared/constants/types/rpc-stellar-gen.tsx
+++ b/shared/constants/types/rpc-stellar-gen.tsx
@@ -73,7 +73,7 @@ export type MessageTypes = {
   }
   'stellar.1.local.changeDisplayCurrencyLocal': {
     inParam: {readonly accountID: AccountID; readonly currency: OutsideCurrencyCode}
-    outParam: void
+    outParam: CurrencyLocal
   }
   'stellar.1.local.changeWalletAccountNameLocal': {
     inParam: {readonly accountID: AccountID; readonly newName: String}

--- a/shared/constants/types/rpc-stellar-gen.tsx
+++ b/shared/constants/types/rpc-stellar-gen.tsx
@@ -77,7 +77,7 @@ export type MessageTypes = {
   }
   'stellar.1.local.changeWalletAccountNameLocal': {
     inParam: {readonly accountID: AccountID; readonly newName: String}
-    outParam: void
+    outParam: WalletAccountLocal
   }
   'stellar.1.local.createWalletAccountLocal': {
     inParam: {readonly name: String}

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -30,6 +30,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
       )
       return state.merge({accountMap: accountMap})
     }
+    case WalletsGen.changedAccountName:
     case WalletsGen.accountUpdateReceived:
       // accept the updated account if we've loaded it already
       // this is because we get the sort order from the full accounts load,
@@ -559,7 +560,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.changeDisplayCurrency:
     case WalletsGen.changeAccountName:
     case WalletsGen.checkDisclaimer:
-    case WalletsGen.changedAccountName:
     case WalletsGen.deleteAccount:
     case WalletsGen.deletedAccount:
     case WalletsGen.loadAccounts:

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -24,6 +24,7 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
   switch (action.type) {
     case WalletsGen.resetStore:
       return initialState
+    case WalletsGen.didSetAccountAsDefault:
     case WalletsGen.accountsReceived: {
       const accountMap: I.OrderedMap<Types.AccountID, Types.Account> = I.OrderedMap(
         action.payload.accounts.map(account => [account.accountID, account])
@@ -545,7 +546,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
     case WalletsGen.changeAirdrop:
     case WalletsGen.updateAirdropState:
     case WalletsGen.rejectDisclaimer:
-    case WalletsGen.didSetAccountAsDefault:
     case WalletsGen.cancelPayment:
     case WalletsGen.cancelRequest:
     case WalletsGen.createNewAccount:


### PR DESCRIPTION
some of the wallet RPCs make changes and then wait for other things to happen (e.g. gregor notifications or subsequent RPCs) to push the updates back into the front end. here, i'm trying to pass back the updates directly with the RPC and then handle the new data synchronously. 

i strongly suggest reviewing this PR commit-by-commit.

- change currency
- change account name
- not really any lift from inflation setting
- setting to and from mobile-only