### PR TITLE
Fix airdrop banner display for users who haven't accepted the disclaimer yet

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1184,6 +1184,12 @@ const updateAirdropState = (
     })
     .catch(e => {
       logger.info(e)
+      if (e.name === 'STELLAR_NEED_DISCLAIMER') {
+        return WalletsGen.createUpdatedAirdropState({
+          airdropQualifications: [],
+          airdropState: 'needDisclaimer',
+        })
+      }
     })
 
 const hideAirdropBanner = (): TypedActions =>

--- a/shared/constants/types/wallets.tsx
+++ b/shared/constants/types/wallets.tsx
@@ -301,7 +301,8 @@ export type AccountInflationDestination = I.RecordOf<_AccountInflationDestinatio
 
 export type ValidationState = 'none' | 'waiting' | 'error' | 'valid'
 
-export type AirdropState = 'loading' | 'accepted' | 'qualified' | 'unqualified'
+export type AirdropState = 'loading' | 'accepted' | 'qualified' | 'unqualified' | 'needDisclaimer'
+
 export type _AirdropQualification = {
   title: string
   subTitle: string

--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -812,4 +812,6 @@ export const getShowAirdropBanner = (state: TypedState) =>
   flags.airdrop &&
   state.wallets.airdropDetails.isPromoted &&
   state.wallets.airdropShowBanner &&
-  (state.wallets.airdropState === 'qualified' || state.wallets.airdropState === 'unqualified')
+  (state.wallets.airdropState === 'qualified' ||
+    state.wallets.airdropState === 'unqualified' ||
+    state.wallets.airdropState === 'needDisclaimer')


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

The RPC for finding out your airdrop status fails if you haven't accepted the disclaimer.  We were only showing the airdrop banner if you're qualified or unqualified to join -- we don't want to show it if you're already in the airdrop.  But since we'd never find out your airdrop status, we just never showed the banner in the case where you haven't accepted the disclaimer yet.  This PR catches that error so that we can show the banner in that case too.