### PR TITLE
wallet-switcher uses FloatingList

### DIFF
--- a/shared/wallets/wallet/header/maybe-switcher.tsx
+++ b/shared/wallets/wallet/header/maybe-switcher.tsx
@@ -8,7 +8,7 @@ type Props = React.PropsWithChildren<{}>
 // @ts-ignore to fix wrap in fragment
 const NoSwitcher: React.FunctionComponent<Props> = props => props.children
 
-const _Switcher: React.FunctionComponent<Props & Kb.OverlayParentProps> = props => (
+const _Switcher: React.FunctionComponent<Kb.PropsWithOverlay<Props>> = props => (
   <Kb.ClickableBox onClick={props.toggleShowingMenu} ref={props.setAttachmentRef}>
     {props.children}
     <WalletSwitcher

--- a/shared/wallets/wallet/header/wallet-switcher/index.native.tsx
+++ b/shared/wallets/wallet/header/wallet-switcher/index.native.tsx
@@ -1,223 +1,83 @@
 import * as React from 'react'
 import WalletRow from './wallet-row/container'
-import * as Types from '../../../../constants/types/wallets'
-import * as Kb from '../../../../common-adapters/mobile.native'
-import * as Flow from '../../../../util/flow'
+import * as Kb from '../../../../common-adapters'
 import * as Styles from '../../../../styles'
 import flags from '../../../../util/feature-flags'
 import {Props} from '.'
 
-type RowProps = {
-  children: React.ReactNode
-  isLast?: boolean
-  onPress?: () => void
-  containerStyle?: Styles.StylesCrossPlatform
-  style?: Styles.StylesCrossPlatform
-}
-
-const Row = (props: RowProps) => (
-  <Kb.Box2 direction="vertical" style={Styles.collapseStyles([styles.rowContainer, props.containerStyle])}>
-    <Kb.NativeTouchableOpacity
-      onPress={props.onPress}
-      style={Styles.collapseStyles([styles.row, props.isLast && styles.lastRow, props.style])}
-    >
-      {props.children}
-    </Kb.NativeTouchableOpacity>
-  </Kb.Box2>
-)
-
-type MenuItem =
-  | {
-      key: string
-      onPress: () => void
-      title: string
-      type: 'item'
-    }
-  | {
-      key: Types.AccountID
-      accountID: Types.AccountID
-      type: 'wallet'
-    }
-  | {
-      key: string
-      onPress: () => void
-      title: string
-      type: 'airdrop'
-    }
-
-const renderItem = (item: MenuItem, isLast: boolean, hideMenu: () => void) => {
-  switch (item.type) {
-    case 'airdrop': {
-      const onPress = () => {
-        hideMenu()
-        item.onPress()
-      }
-      return (
-        <Row isLast={isLast} key={item.key} onPress={onPress}>
-          <Kb.Box2 direction="horizontal" alignItems="center" gap="tiny">
-            <Kb.Icon type="icon-airdrop-star-32" />
-            <Kb.Text center={true} type="BodyBig" style={{color: Styles.globalColors.blueDark}}>
-              {item.title}
-            </Kb.Text>
-          </Kb.Box2>
-        </Row>
-      )
-    }
-    case 'item': {
-      const onPress = () => {
-        hideMenu()
-        item.onPress()
-      }
-      return (
-        <Row isLast={isLast} key={item.key} onPress={onPress}>
-          <Kb.Text center={true} type="BodyBig" style={{color: Styles.globalColors.blueDark}}>
-            {item.title}
-          </Kb.Text>
-        </Row>
-      )
-    }
-    case 'wallet':
-      // No need to pass down onPress.
-      return (
-        <Row isLast={isLast} key={item.key}>
-          <WalletRow accountID={item.accountID} hideMenu={hideMenu} />
-        </Row>
-      )
-    default:
-      throw new Error(`Invalid type ${item} passed to renderItem`)
-  }
-}
-
-const bottomPadding = 8
-const cancelRowHeight = 48
-const infoTextRowHeight = 48
-const rowHeight = 56
-
 export const WalletSwitcher = (props: Props) => {
-  if (!props.showingMenu) {
-    return null
-  }
-
-  const menuItems: MenuItem[] = [
-    ...(flags.airdrop && props.airdropIsLive
-      ? ([
-          {
-            key: 'airdrop',
-            onPress: props.onJoinAirdrop,
-            title: props.inAirdrop ? 'Airdrop' : 'Join the airdrop',
-            type: 'airdrop',
-          },
-        ] as const)
-      : []),
-    {
-      key: 'newAccount',
-      onPress: props.onAddNew,
-      title: 'Create a new account',
-      type: 'item',
-    },
-    {
-      key: 'linkAccount',
-      onPress: props.onLinkExisting,
-      title: 'Link an existing Stellar account',
-      type: 'item',
-    },
-    ...props.accountIDs.map(
-      (accountID: Types.AccountID) =>
-        ({
-          accountID,
-          key: accountID,
-          type: 'wallet',
-        } as const)
-    ),
-  ]
-
-  // Kind of a pain we have to calculate the height manually.
-  const dividerHeight = 2 * bottomPadding + 1
-  const cancelRowHeightWithPadding = cancelRowHeight + bottomPadding
-  const height = infoTextRowHeight + rowHeight * menuItems.length + dividerHeight + cancelRowHeightWithPadding
-
-  const whatOnPress = () => {
+  const onWhatIsStellar = () => {
     props.hideMenu()
     props.onWhatIsStellar()
   }
+  const header: Kb.MenuItem = {
+    onClick: props.onWhatIsStellar,
+    title: 'What is Stellar?',
+    view: (
+      <Kb.ClickableBox onClick={onWhatIsStellar}>
+        <Kb.Box2 centerChildren={true} direction="horizontal" style={styles.infoTextRowContainer}>
+          <Kb.Icon type="iconfont-info" />
+          <Kb.Text style={styles.infoText} type="BodySemibold">
+            What is Stellar?
+          </Kb.Text>
+        </Kb.Box2>
+      </Kb.ClickableBox>
+    ),
+  }
+  let items: Array<Kb.MenuItem> = []
+  if (flags.airdrop && props.airdropIsLive) {
+    items.push({
+      onClick: props.onJoinAirdrop,
+      title: props.inAirdrop ? 'Airdrop' : 'Join the airdrop',
+      view: (
+        <Kb.Box2 direction="horizontal" alignItems="center" gap="tiny">
+          <Kb.Icon type="icon-airdrop-star-32" />
+          <Kb.Text center={true} type="BodyBig" style={{color: Styles.globalColors.blueDark}}>
+            {props.inAirdrop ? 'Airdrop' : 'Join the airdrop'}
+          </Kb.Text>
+        </Kb.Box2>
+      ),
+    })
+  }
+  items.push(
+    {
+      onClick: props.onAddNew,
+      title: 'Create a new account',
+    },
+    {
+      onClick: props.onLinkExisting,
+      title: 'Link an existing Stellar account',
+    }
+  )
+  props.accountIDs.forEach(accountID => {
+    items.push({
+      title: `Account ${accountID}`,
+      view: <WalletRow accountID={accountID} hideMenu={() => {}} />,
+    })
+  })
 
   return (
-    <Kb.Overlay
-      position="bottom center"
-      onHidden={props.hideMenu}
-      visible={props.showingMenu}
+    <Kb.FloatingMenu
+      closeOnSelect={true}
       attachTo={props.getAttachmentRef}
-    >
-      <Kb.Box2
-        direction="vertical"
-        style={Styles.collapseStyles([styles.container, {height}])}
-        fullWidth={true}
-      >
-        <Row onPress={whatOnPress} containerStyle={styles.infoTextRowContainer} style={styles.infoTextRow}>
-          <Kb.Box2 centerChildren={true} direction="horizontal">
-            <Kb.Icon type="iconfont-info" />
-            <Kb.Text style={styles.infoText} type="BodySemibold">
-              What is Stellar?
-            </Kb.Text>
-          </Kb.Box2>
-        </Row>
-        <Kb.List
-          items={menuItems}
-          renderItem={(index, item) => renderItem(item, index === menuItems.length - 1, props.hideMenu)}
-          bounces={false}
-        />
-        <Kb.Divider style={styles.divider} />
-        <Row onPress={props.hideMenu} style={styles.cancelRow}>
-          <Kb.Text center={true} type={'BodyBig'} style={{color: Styles.globalColors.blueDark}}>
-            Cancel
-          </Kb.Text>
-        </Row>
-      </Kb.Box2>
-    </Kb.Overlay>
+      header={header}
+      items={items}
+      onHidden={props.hideMenu}
+      position="bottom right"
+      visible={props.showingMenu}
+    />
   )
 }
 
 const styles = Styles.styleSheetCreate({
-  cancelRow: {
-    height: cancelRowHeight,
-    marginBottom: bottomPadding,
-  },
-  container: {
-    backgroundColor: Styles.globalColors.white,
-    justifyContent: 'flex-end',
-    // Leave some space for the status bar.
-    maxHeight: '95%',
-  },
-  divider: {
-    backgroundColor: Styles.globalColors.black_05,
-    marginBottom: bottomPadding,
-  },
   infoText: {
     color: Styles.globalColors.black_50,
     paddingLeft: Styles.globalMargins.tiny,
   },
-  infoTextRow: {
-    height: infoTextRowHeight,
-  },
   infoTextRowContainer: {
     backgroundColor: Styles.globalColors.greyLight,
-  },
-  lastRow: {
-    // Have this instead of a top margin on the divider to maximize
-    // the area of the scrollview.
-    marginBottom: bottomPadding,
-  },
-  row: {
-    ...Styles.globalStyles.flexBoxColumn,
-    alignItems: 'stretch',
-    borderColor: Styles.globalColors.black_10,
-    height: rowHeight,
-    justifyContent: 'center',
-  },
-  rowContainer: {
-    ...Styles.globalStyles.flexBoxColumn,
-    alignItems: 'stretch',
-    backgroundColor: Styles.globalColors.white,
+    paddingBottom: Styles.globalMargins.small,
+    paddingTop: Styles.globalMargins.small,
     width: '100%',
   },
 })


### PR DESCRIPTION
Wallet-switcher had bespoke stuff doing a similar job to FloatingList. One way it differed was that it had too small a margin between the cancel button and iphone X bar. This patch switches wallet-switcher to use FloatingList.