### PR TITLE
Fixup disklru cleaning

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -87,7 +87,7 @@ func (c *FullCachingSource) StartBackgroundTasks(m libkb.MetaContext) {
 	for i := 0; i < 10; i++ {
 		go c.populateCacheWorker(m)
 	}
-	go lru.CleanAfterDelay(m, c.diskLRU, c.getCacheDir(m), 10*time.Second)
+	go lru.CleanOutOfSyncWithDelay(m, c.diskLRU, c.getCacheDir(m), 10*time.Second)
 }
 
 func (c *FullCachingSource) StopBackgroundTasks(m libkb.MetaContext) {
@@ -394,7 +394,7 @@ func (c *FullCachingSource) ClearCacheForName(m libkb.MetaContext, name string, 
 
 func (c *FullCachingSource) OnDbNuke(m libkb.MetaContext) error {
 	if c.diskLRU != nil {
-		if err := c.diskLRU.Clean(m, c.getCacheDir(m)); err != nil {
+		if err := c.diskLRU.CleanOutOfSync(m, c.getCacheDir(m)); err != nil {
 			c.debug(m, "unable to run clean: %v", err)
 		}
 	}

--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -882,12 +882,12 @@ func (c *CachingAttachmentFetcher) DeleteAssets(ctx context.Context,
 }
 
 func (c *CachingAttachmentFetcher) OnStart(mctx libkb.MetaContext) {
-	go disklru.CleanAfterDelay(mctx, c.diskLRU, c.getCacheDir(), 10*time.Second)
+	go disklru.CleanOutOfSyncWithDelay(mctx, c.diskLRU, c.getCacheDir(), 10*time.Second)
 }
 
 func (c *CachingAttachmentFetcher) OnDbNuke(mctx libkb.MetaContext) error {
 	if c.diskLRU != nil {
-		if err := c.diskLRU.Clean(mctx, c.getCacheDir()); err != nil {
+		if err := c.diskLRU.CleanOutOfSync(mctx, c.getCacheDir()); err != nil {
 			c.Debug(mctx.Ctx(), "unable to run clean: %v", err)
 		}
 	}

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -633,11 +633,11 @@ func (u *Uploader) GetUploadTempFile(ctx context.Context, outboxID chat1.OutboxI
 func (u *Uploader) OnDbNuke(mctx libkb.MetaContext) error {
 	baseDir := u.getBaseDir()
 	previewsDir := filepath.Join(baseDir, uploadedPreviewsDir)
-	if err := u.previewsLRU.Clean(mctx, previewsDir); err != nil {
+	if err := u.previewsLRU.CleanOutOfSync(mctx, previewsDir); err != nil {
 		u.Debug(mctx.Ctx(), "unable to run clean for uploadedPreviews: %v", err)
 	}
 	fullsDir := filepath.Join(baseDir, uploadedFullsDir)
-	if err := u.fullsLRU.Clean(mctx, fullsDir); err != nil {
+	if err := u.fullsLRU.CleanOutOfSync(mctx, fullsDir); err != nil {
 		u.Debug(mctx.Ctx(), "unable to run clean for uploadedFulls: %v", err)
 	}
 	return nil

--- a/go/lru/disk_lru_test.go
+++ b/go/lru/disk_lru_test.go
@@ -173,7 +173,7 @@ func TestDiskLRUClean(t *testing.T) {
 	_, err = l.Put(ctx, tc.G, k, v)
 	require.NoError(t, err)
 	mctx := libkb.NewMetaContextForTest(tc)
-	err = l.Clean(mctx, cacheDir)
+	err = l.CleanOutOfSync(mctx, cacheDir)
 	require.NoError(t, err)
 	exists, err := libkb.FileExists(file.Name())
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestDiskLRUClean(t *testing.T) {
 	// File is cleaned now that the lru no longer has that key.
 	err = l.Remove(ctx, tc.G, k)
 	require.NoError(t, err)
-	err = l.Clean(mctx, cacheDir)
+	err = l.CleanOutOfSync(mctx, cacheDir)
 	require.NoError(t, err)
 	exists, err = libkb.FileExists(file.Name())
 	require.NoError(t, err)


### PR DESCRIPTION
patch does the following:

- normalize the filepath during the clean method, previously we would wipe out valid entries from disk and create a discrepancy between the cache and the fs
- add a batch param to clean to minimize time holding the lru lock