### PR TITLE
Use user/username_available for signup username check

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -236,6 +236,7 @@ const (
 	SCRateLimit                                 = int(keybase1.StatusCode_SCRateLimit)
 	SCBadSignupUsernameTaken                    = int(keybase1.StatusCode_SCBadSignupUsernameTaken)
 	SCBadInvitationCode                         = int(keybase1.StatusCode_SCBadInvitationCode)
+	SCBadSignupTeamName                         = int(keybase1.StatusCode_SCBadSignupTeamName)
 	SCFeatureFlag                               = int(keybase1.StatusCode_SCFeatureFlag)
 	SCMissingResult                             = int(keybase1.StatusCode_SCMissingResult)
 	SCKeyNotFound                               = int(keybase1.StatusCode_SCKeyNotFound)

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -43,6 +43,7 @@ const (
 	StatusCode_SCRateLimit                                 StatusCode = 602
 	StatusCode_SCBadSignupUsernameTaken                    StatusCode = 701
 	StatusCode_SCBadInvitationCode                         StatusCode = 707
+	StatusCode_SCBadSignupTeamName                         StatusCode = 711
 	StatusCode_SCFeatureFlag                               StatusCode = 712
 	StatusCode_SCMissingResult                             StatusCode = 801
 	StatusCode_SCKeyNotFound                               StatusCode = 901
@@ -261,6 +262,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCRateLimit":                602,
 	"SCBadSignupUsernameTaken":   701,
 	"SCBadInvitationCode":        707,
+	"SCBadSignupTeamName":        711,
 	"SCFeatureFlag":              712,
 	"SCMissingResult":            801,
 	"SCKeyNotFound":              901,
@@ -477,6 +479,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	602:  "SCRateLimit",
 	701:  "SCBadSignupUsernameTaken",
 	707:  "SCBadInvitationCode",
+	711:  "SCBadSignupTeamName",
 	712:  "SCFeatureFlag",
 	801:  "SCMissingResult",
 	901:  "SCKeyNotFound",

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -69,7 +69,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 		return libkb.AppStatusError{
 			Code: libkb.SCBadSignupTeamName,
 			Name: "BAD_SIGNUP_TEAM_NAME",
-			Desc: "This username is already taken by a team. Please pick another one.",
+			Desc: "This username is already taken. Please pick another one.",
 		}
 	default:
 		return libkb.AppStatusError{

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -23,39 +23,60 @@ func NewSignupHandler(xp rpc.Transporter, g *libkb.GlobalContext) *SignupHandler
 	}
 }
 
+type usernameAvailableRes struct {
+	libkb.AppStatusEmbed
+	Available bool   `json:"available"`
+	Reason    string `json:"reason"`
+}
+
 func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1.CheckUsernameAvailableArg) error {
 	mctx := libkb.NewMetaContext(ctx, h.G())
-	_, err := mctx.G().API.Get(mctx, libkb.APIArg{
-		Endpoint:    "user/lookup",
+	var apiRes usernameAvailableRes
+	err := mctx.G().API.GetDecode(mctx, libkb.APIArg{
+		Endpoint:    "user/username_available",
 		SessionType: libkb.APISessionTypeNONE,
 		Args: libkb.HTTPArgs{
 			"username": libkb.S{Val: arg.Username},
-			"fields":   libkb.S{Val: "basics"},
 		},
-	})
-	switch err := err.(type) {
-	case nil:
+	}, &apiRes)
+	if err != nil {
+		return err
+	}
+	if apiRes.Available {
+		return nil
+	}
+	switch apiRes.Reason {
+	case "invalid":
+		return libkb.AppStatusError{
+			Code: libkb.SCBadUsername,
+			Name: "BAD_USERNAME",
+			Desc: "This is not a valid username. Please pick another one.",
+		}
+	case "user":
 		// User found, so the name is taken.
 		return libkb.AppStatusError{
 			Code: libkb.SCBadSignupUsernameTaken,
 			Name: "BAD_SIGNUP_USERNAME_TAKEN",
 			Desc: "This username is already taken! Please pick another one.",
 		}
-	case libkb.AppStatusError:
-		switch err.Name {
-		case "NOT_FOUND":
-			// User not found, name is available.
-			return nil
-		case "DELETED":
-			return libkb.AppStatusError{
-				Code: libkb.SCBadSignupUsernameDeleted,
-				Name: "BAD_SIGNUP_USERNAME_DELETED",
-				Desc: "This username has been deleted! Please pick another one.",
-			}
+	case "user_deleted":
+		return libkb.AppStatusError{
+			Code: libkb.SCBadSignupUsernameDeleted,
+			Name: "BAD_SIGNUP_USERNAME_DELETED",
+			Desc: "This username has been deleted! Please pick another one.",
 		}
-		return err
+	case "team":
+		return libkb.AppStatusError{
+			Code: libkb.SCBadSignupTeamName,
+			Name: "BAD_SIGNUP_TEAM_NAME",
+			Desc: "This username is already taken by a team. Please pick another one.",
+		}
 	default:
-		return err
+		return libkb.AppStatusError{
+			Code: libkb.SCGenericAPIError,
+			Name: "GENERIC",
+			Desc: "This username is not available.",
+		}
 	}
 }
 

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -35,6 +35,7 @@ protocol constants {
     SCRateLimit_602,
     SCBadSignupUsernameTaken_701,
     SCBadInvitationCode_707,
+    SCBadSignupTeamName_711,
     SCFeatureFlag_712,
     SCMissingResult_801,
     SCKeyNotFound_901,

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -39,6 +39,7 @@
         "SCRateLimit_602",
         "SCBadSignupUsernameTaken_701",
         "SCBadInvitationCode_707",
+        "SCBadSignupTeamName_711",
         "SCFeatureFlag_712",
         "SCMissingResult_801",
         "SCKeyNotFound_901",

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1911,6 +1911,7 @@ export enum StatusCode {
   scratelimit = 602,
   scbadsignupusernametaken = 701,
   scbadinvitationcode = 707,
+  scbadsignupteamname = 711,
   scfeatureflag = 712,
   scmissingresult = 801,
   sckeynotfound = 901,


### PR DESCRIPTION
Trying to sign up with a username already taken by a team name will now provide earlier feedback.