### PR TITLE
permanent/transient ephemeral errors

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -175,7 +175,9 @@ func (e EphemeralAlreadyExpiredError) InternalError() string {
 
 //=============================================================================
 
-type EphemeralUnboxingError struct{ inner ephemeral.EphemeralKeyError }
+type EphemeralUnboxingError struct {
+	inner ephemeral.EphemeralKeyError
+}
 
 func NewEphemeralUnboxingError(inner ephemeral.EphemeralKeyError) EphemeralUnboxingError {
 	return EphemeralUnboxingError{inner}

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -213,7 +213,7 @@ func (s *DeviceEKStorage) Put(mctx libkb.MetaContext, generation keybase1.EkGene
 
 	// sanity check that we got the right generation
 	if deviceEK.Metadata.Generation != generation {
-		return newEKCorruptedErr(mctx, DeviceEKStr, generation, deviceEK.Metadata.Generation)
+		return newEKCorruptedErr(mctx, DeviceEKKind, generation, deviceEK.Metadata.Generation)
 	}
 
 	key, err := s.key(mctx, generation)
@@ -289,7 +289,7 @@ func (s *DeviceEKStorage) get(mctx libkb.MetaContext, generation keybase1.EkGene
 	}
 	// sanity check that we got the right generation
 	if deviceEK.Metadata.Generation != generation {
-		return deviceEK, newEKCorruptedErr(mctx, DeviceEKStr, generation, deviceEK.Metadata.Generation)
+		return deviceEK, newEKCorruptedErr(mctx, DeviceEKKind, generation, deviceEK.Metadata.Generation)
 	}
 	return deviceEK, nil
 }

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -84,7 +84,7 @@ func TestDeviceEKStorage(t *testing.T) {
 	require.Error(t, err)
 	require.IsType(t, EphemeralKeyError{}, err)
 	ekErr := err.(EphemeralKeyError)
-	expectedErr := newEKCorruptedErr(mctx, DeviceEKStr, corruptedGeneration, 100)
+	expectedErr := newEKCorruptedErr(mctx, DeviceEKKind, corruptedGeneration, 100)
 	require.Equal(t, expectedErr.Error(), ekErr.Error())
 	require.Equal(t, DefaultHumanErrMsg, ekErr.HumanError())
 

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -3,6 +3,7 @@ package ephemeral
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
@@ -11,19 +12,72 @@ import (
 	"github.com/keybase/client/go/teams"
 )
 
-type EKType string
+type EphemeralKeyKind string
 
 const (
-	DeviceEKStr  EKType = "deviceEK"
-	UserEKStr    EKType = "userEK"
-	TeamEKStr    EKType = "teamEK"
-	TeambotEKStr EKType = "teambotEK"
+	DeviceEKKind  EphemeralKeyKind = "deviceEK"
+	UserEKKind    EphemeralKeyKind = "userEK"
+	TeamEKKind    EphemeralKeyKind = "teamEK"
+	TeambotEKKind EphemeralKeyKind = "teambotEK"
+)
+
+type EphemeralKeyErrorKind int
+
+const (
+	EphemeralKeyErrorKind_DEVICENOTAUTHENTICATED EphemeralKeyErrorKind = iota
+	EphemeralKeyErrorKind_UNBOX
+	EphemeralKeyErrorKind_MISSINGBOX
+	EphemeralKeyErrorKind_WRONGKID
+	EphemeralKeyErrorKind_CORRUPTEDGEN
+	EphemeralKeyErrorKind_DEVICEAFTEREK
+	EphemeralKeyErrorKind_MEMBERAFTEREK
+	EphemeralKeyErrorKind_DEVICESTALE
+	EphemeralKeyErrorKind_USERSTALE
 )
 
 type EphemeralKeyError struct {
-	DebugMsg   string
-	HumanMsg   string
-	StatusCode int
+	DebugMsg    string
+	HumanMsg    string
+	StatusCode  int
+	Ctime       gregor1.Time
+	ErrKind     EphemeralKeyErrorKind
+	EKKind      EphemeralKeyKind
+	IsTransient bool
+}
+
+func (e EphemeralKeyError) HumanError() string {
+	return e.HumanMsg
+}
+
+func (e EphemeralKeyError) Error() string {
+	return e.DebugMsg
+}
+
+// AllowTransient determines if we allow the given error to be downgraded to a
+// transient error. If we encounter a MISSINGBOX  error for a TeambotEK we
+// allow this to be marked as transient for a 24 hour window. The intention is
+// to allow a chat message to be retried on send for this period instead of
+// permanently failing.
+func (e EphemeralKeyError) AllowTransient() bool {
+	return (e.EKKind == TeambotEKKind &&
+		e.ErrKind == EphemeralKeyErrorKind_MISSINGBOX &&
+		time.Now().Sub(e.Ctime.Time()) < time.Hour*24)
+}
+
+func (e EphemeralKeyError) IsPermanent() bool {
+	return !e.IsTransient
+}
+
+func newTransientEphemeralKeyError(err EphemeralKeyError) EphemeralKeyError {
+	return EphemeralKeyError{
+		DebugMsg:    err.DebugMsg,
+		HumanMsg:    err.HumanMsg,
+		StatusCode:  err.StatusCode,
+		Ctime:       err.Ctime,
+		ErrKind:     err.ErrKind,
+		EKKind:      err.EKKind,
+		IsTransient: true,
+	}
 }
 
 const (
@@ -59,7 +113,8 @@ func NewNotAuthenticatedForThisDeviceError(mctx libkb.MetaContext, tlfID chat1.T
 			humanMsg = MemberAddedAfterContentCreationErrMsg
 		}
 	}
-	return newEphemeralKeyError("message not authenticated for device", humanMsg)
+	return newEphemeralKeyError("message not authenticated for device", humanMsg,
+		EphemeralKeyErrorKind_DEVICENOTAUTHENTICATED, DeviceEKKind)
 }
 
 func memberCtime(mctx libkb.MetaContext, tlfID chat1.TLFID) (*keybase1.Time, error) {
@@ -80,32 +135,33 @@ func memberCtime(mctx libkb.MetaContext, tlfID chat1.TLFID) (*keybase1.Time, err
 	return team.MemberCtime(mctx.Ctx(), uv), nil
 }
 
-func newEKUnboxErr(mctx libkb.MetaContext, boxType EKType, boxGeneration keybase1.EkGeneration,
-	missingType EKType, missingGeneration keybase1.EkGeneration, contentCtime *gregor1.Time) EphemeralKeyError {
-	debugMsg := fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", boxType, boxGeneration, missingType, missingGeneration)
+func newEKUnboxErr(mctx libkb.MetaContext, ekKind EphemeralKeyKind, boxGeneration keybase1.EkGeneration,
+	missingKind EphemeralKeyKind, missingGeneration keybase1.EkGeneration, contentCtime *gregor1.Time) EphemeralKeyError {
+	debugMsg := fmt.Sprintf("Error unboxing %s@generation:%v missing %s@generation:%v", ekKind, boxGeneration, missingKind, missingGeneration)
 	var humanMsg string
 	if deviceProvisionedAfterContentCreation(mctx, contentCtime) {
 		humanMsg = DeviceProvisionedAfterContentCreationErrMsg
 	} else if deviceIsCloned(mctx) {
 		humanMsg = DeviceCloneErrMsg
 	}
-	return newEphemeralKeyError(debugMsg, humanMsg)
+	return newEphemeralKeyError(debugMsg, humanMsg,
+		EphemeralKeyErrorKind_UNBOX, missingKind)
 }
 
-func newEKMissingBoxErr(mctx libkb.MetaContext, boxType EKType, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
-	debugMsg := fmt.Sprintf("Missing box for %s@generation:%v", boxType, boxGeneration)
-	return newEphemeralKeyError(debugMsg, "")
+func newEKMissingBoxErr(mctx libkb.MetaContext, ekKind EphemeralKeyKind, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
+	debugMsg := fmt.Sprintf("Missing box for %s@generation:%v", ekKind, boxGeneration)
+	return newEphemeralKeyError(debugMsg, "", EphemeralKeyErrorKind_MISSINGBOX, ekKind)
 }
 
 func newTeambotEKWrongKIDErr(mctx libkb.MetaContext, ctime, now keybase1.Time) EphemeralKeyError {
-	debugMsg := fmt.Sprintf("Wrong KID for %v, first seen at %v, now %v", TeambotEKStr, ctime.Time(), now.Time())
-	return newEphemeralKeyError(debugMsg, "")
+	debugMsg := fmt.Sprintf("Wrong KID for %v, first seen at %v, now %v", TeambotEKKind, ctime.Time(), now.Time())
+	return newEphemeralKeyError(debugMsg, "", EphemeralKeyErrorKind_WRONGKID, TeambotEKKind)
 }
 
-func newEKCorruptedErr(mctx libkb.MetaContext, boxType EKType,
+func newEKCorruptedErr(mctx libkb.MetaContext, ekKind EphemeralKeyKind,
 	expectedGeneration, boxGeneration keybase1.EkGeneration) EphemeralKeyError {
-	debugMsg := fmt.Sprintf("Storage error for %s@generation:%v, got generation %v instead", boxType, boxGeneration, expectedGeneration)
-	return newEphemeralKeyError(debugMsg, "")
+	debugMsg := fmt.Sprintf("Storage error for %s@generation:%v, got generation %v instead", ekKind, boxGeneration, expectedGeneration)
+	return newEphemeralKeyError(debugMsg, "", EphemeralKeyErrorKind_CORRUPTEDGEN, ekKind)
 }
 
 func humanMsgWithPrefix(humanMsg string) string {
@@ -117,28 +173,42 @@ func humanMsgWithPrefix(humanMsg string) string {
 	return humanMsg
 }
 
-func newEphemeralKeyError(debugMsg, humanMsg string) EphemeralKeyError {
+func newEphemeralKeyError(debugMsg, humanMsg string, errKind EphemeralKeyErrorKind,
+	ekKind EphemeralKeyKind) EphemeralKeyError {
 	humanMsg = humanMsgWithPrefix(humanMsg)
 	return EphemeralKeyError{
 		DebugMsg: debugMsg,
 		HumanMsg: humanMsg,
+		Ctime:    gregor1.ToTime(time.Now()),
+		ErrKind:  errKind,
+		EKKind:   ekKind,
 	}
 }
 func newEphemeralKeyErrorFromStatus(e libkb.AppStatusError) EphemeralKeyError {
 	humanMsg := humanMsgWithPrefix(e.Desc)
+	var errKind EphemeralKeyErrorKind
+	var ekKind EphemeralKeyKind
+	switch e.Code {
+	case libkb.SCEphemeralDeviceAfterEK:
+		errKind = EphemeralKeyErrorKind_DEVICEAFTEREK
+		ekKind = DeviceEKKind
+	case libkb.SCEphemeralMemberAfterEK:
+		ekKind = TeamEKKind
+	case libkb.SCEphemeralDeviceStale:
+		errKind = EphemeralKeyErrorKind_DEVICESTALE
+		ekKind = DeviceEKKind
+	case libkb.SCEphemeralUserStale:
+		errKind = EphemeralKeyErrorKind_USERSTALE
+		ekKind = UserEKKind
+	}
 	return EphemeralKeyError{
 		DebugMsg:   e.Desc,
 		HumanMsg:   humanMsg,
 		StatusCode: e.Code,
+		Ctime:      gregor1.ToTime(time.Now()),
+		ErrKind:    errKind,
+		EKKind:     ekKind,
 	}
-}
-
-func (e EphemeralKeyError) HumanError() string {
-	return e.HumanMsg
-}
-
-func (e EphemeralKeyError) Error() string {
-	return e.DebugMsg
 }
 
 func errFromAppStatus(e error) error {

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -701,6 +701,14 @@ func (e *EKLib) GetOrCreateLatestTeambotEK(mctx libkb.MetaContext, teamID keybas
 				if err2 := teambot.NotifyTeambotEKNeeded(mctx, teamID, 0); err2 != nil {
 					mctx.Debug("Unable to NotifyTeambotEKNeeded %v", err2)
 				}
+				// See if we should downgrade this to a transient error. Since
+				// bot members get a key when added to the team this should
+				// only happen in a tight race before the key is created or if
+				// the TeamEK has been purged and we don't have a new one.
+				ekErr := err.(EphemeralKeyError)
+				if ekErr.AllowTransient() {
+					err = newTransientEphemeralKeyError(ekErr)
+				}
 			}
 			return ek, false, err
 		}
@@ -832,7 +840,7 @@ func (e *EKLib) getLatestTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamI
 	// was signed by the latest PTK and otherwise fails with wrongKID set.
 	metadata, wrongKID, err := fetchLatestTeambotEK(mctx, teamID)
 	if metadata == nil {
-		err = newEKMissingBoxErr(mctx, TeambotEKStr, -1)
+		err = newEKMissingBoxErr(mctx, TeambotEKKind, -1)
 		return ek, err
 	} else if wrongKID {
 		now := keybase1.ToTime(e.clock.Now())
@@ -890,6 +898,10 @@ func (e *EKLib) GetTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID, gBo
 				if err2 := teambot.NotifyTeambotEKNeeded(mctx, teamID, generation); err2 != nil {
 					mctx.Debug("Unable to NotifyTeambotEKNeeded %v", err2)
 				}
+				// NOTE we don't downgrade this errors to transient since a bot
+				// should have access to keys for decryption unless there is a
+				// bug, members check that the key is created before encrypting
+				// content.
 			}
 			return ek, err
 		}

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -198,7 +198,7 @@ func (k *TeamEphemeralKeyer) Fetch(mctx libkb.MetaContext, teamID keybase1.TeamI
 	}
 
 	if result.Result == nil {
-		err = newEKMissingBoxErr(mctx, TeamEKStr, generation)
+		err = newEKMissingBoxErr(mctx, TeamEKKind, generation)
 		return teamEK, err
 	}
 
@@ -218,7 +218,7 @@ func (k *TeamEphemeralKeyer) Fetch(mctx libkb.MetaContext, teamID keybase1.TeamI
 	teamEKMetadata := teamEKStatement.CurrentTeamEkMetadata
 	if generation != teamEKMetadata.Generation {
 		// sanity check that we got the right generation
-		return teamEK, newEKCorruptedErr(mctx, TeamEKStr, generation, teamEKMetadata.Generation)
+		return teamEK, newEKCorruptedErr(mctx, TeamEKKind, generation, teamEKMetadata.Generation)
 	}
 	teamEKBoxed := keybase1.TeamEkBoxed{
 		Box:              result.Result.Box,
@@ -250,7 +250,7 @@ func (k *TeamEphemeralKeyer) Unbox(mctx libkb.MetaContext, boxed keybase1.TeamEp
 		mctx.Debug("unable to get from userEKStorage %v", err)
 		switch err.(type) {
 		case EphemeralKeyError:
-			return ek, newEKUnboxErr(mctx, TeamEKStr, teamEKGeneration, UserEKStr,
+			return ek, newEKUnboxErr(mctx, TeamEKKind, teamEKGeneration, UserEKKind,
 				teamEKBoxed.UserEkGeneration, contentCtime)
 		}
 		return ek, err
@@ -262,7 +262,7 @@ func (k *TeamEphemeralKeyer) Unbox(mctx libkb.MetaContext, boxed keybase1.TeamEp
 	msg, _, err := userKeypair.DecryptFromString(teamEKBoxed.Box)
 	if err != nil {
 		mctx.Debug("unable to decrypt teamEKBoxed %v", err)
-		return ek, newEKUnboxErr(mctx, TeamEKStr, teamEKGeneration, UserEKStr,
+		return ek, newEKUnboxErr(mctx, TeamEKKind, teamEKGeneration, UserEKKind,
 			teamEKBoxed.UserEkGeneration, contentCtime)
 	}
 

--- a/go/ephemeral/teambot_ek.go
+++ b/go/ephemeral/teambot_ek.go
@@ -260,7 +260,7 @@ func (k *TeambotEphemeralKeyer) Unbox(mctx libkb.MetaContext, boxed keybase1.Tea
 		mctx.Debug("unable to get from userEKStorage %v", err)
 		switch err.(type) {
 		case EphemeralKeyError:
-			return ek, newEKUnboxErr(mctx, TeambotEKStr, teambotEKGeneration, UserEKStr,
+			return ek, newEKUnboxErr(mctx, TeambotEKKind, teambotEKGeneration, UserEKKind,
 				teambotEKBoxed.Metadata.UserEkGeneration, contentCtime)
 		}
 		return ek, err
@@ -272,7 +272,7 @@ func (k *TeambotEphemeralKeyer) Unbox(mctx libkb.MetaContext, boxed keybase1.Tea
 	msg, _, err := userKeypair.DecryptFromString(teambotEKBoxed.Box)
 	if err != nil {
 		mctx.Debug("unable to decrypt teambotEKBoxed %v", err)
-		return ek, newEKUnboxErr(mctx, TeambotEKStr, teambotEKGeneration, UserEKStr,
+		return ek, newEKUnboxErr(mctx, TeambotEKKind, teambotEKGeneration, UserEKKind,
 			teambotEKBoxed.Metadata.UserEkGeneration, contentCtime)
 	}
 
@@ -316,7 +316,7 @@ func (k *TeambotEphemeralKeyer) Fetch(mctx libkb.MetaContext, teamID keybase1.Te
 	}
 
 	if resp.Result == nil {
-		err = newEKMissingBoxErr(mctx, TeambotEKStr, generation)
+		err = newEKMissingBoxErr(mctx, TeambotEKKind, generation)
 		return teambotEK, err
 	}
 
@@ -335,7 +335,7 @@ func (k *TeambotEphemeralKeyer) Fetch(mctx libkb.MetaContext, teamID keybase1.Te
 
 	if generation != metadata.Generation {
 		// sanity check that we got the right generation
-		return teambotEK, newEKCorruptedErr(mctx, TeambotEKStr, generation, metadata.Generation)
+		return teambotEK, newEKCorruptedErr(mctx, TeambotEKKind, generation, metadata.Generation)
 	}
 	teambotEKBoxed := keybase1.TeambotEkBoxed{
 		Box:      resp.Result.Box,

--- a/go/ephemeral/user_ek_box_storage.go
+++ b/go/ephemeral/user_ek_box_storage.go
@@ -11,37 +11,31 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-const userEKBoxStorageDBVersion = 3
+const userEKBoxStorageDBVersion = 4
 
 type userEKBoxCacheItem struct {
 	UserEKBoxed keybase1.UserEkBoxed
-	ErrMsg      string
-	HumanMsg    string
+	Err         *EphemeralKeyError
 }
 
 func newUserEKBoxCacheItem(userEKBoxed keybase1.UserEkBoxed, err error) userEKBoxCacheItem {
-	errMsg := ""
-	humanMsg := ""
-	if err != nil {
-		errMsg = err.Error()
-		if ekErr, ok := err.(EphemeralKeyError); ok {
-			humanMsg = ekErr.HumanError()
-		}
+	var ekErr *EphemeralKeyError
+	if e, ok := err.(EphemeralKeyError); ok {
+		ekErr = &e
 	}
 	return userEKBoxCacheItem{
 		UserEKBoxed: userEKBoxed,
-		ErrMsg:      errMsg,
-		HumanMsg:    humanMsg,
+		Err:         ekErr,
 	}
 }
 
 func (c userEKBoxCacheItem) HasError() bool {
-	return c.ErrMsg != ""
+	return c.Err != nil
 }
 
 func (c userEKBoxCacheItem) Error() error {
 	if c.HasError() {
-		return newEphemeralKeyError(c.ErrMsg, c.HumanMsg)
+		return *c.Err
 	}
 	return nil
 }
@@ -168,7 +162,7 @@ func (s *UserEKBoxStorage) fetchAndStore(mctx libkb.MetaContext, generation keyb
 	}
 
 	if result.Result == nil {
-		err = newEKMissingBoxErr(mctx, UserEKStr, generation)
+		err = newEKMissingBoxErr(mctx, UserEKKind, generation)
 		return userEK, err
 	}
 
@@ -188,7 +182,7 @@ func (s *UserEKBoxStorage) fetchAndStore(mctx libkb.MetaContext, generation keyb
 	userEKMetadata := userEKStatement.CurrentUserEkMetadata
 	if generation != userEKMetadata.Generation {
 		// sanity check that we got the right generation
-		return userEK, newEKCorruptedErr(mctx, UserEKStr, generation, userEKMetadata.Generation)
+		return userEK, newEKCorruptedErr(mctx, UserEKKind, generation, userEKMetadata.Generation)
 	}
 	userEKBoxed := keybase1.UserEkBoxed{
 		Box:                result.Result.Box,
@@ -225,7 +219,7 @@ func (s *UserEKBoxStorage) putLocked(mctx libkb.MetaContext, generation keybase1
 
 	// sanity check that we got the right generation
 	if userEKBoxed.Metadata.Generation != generation && ekErr == nil {
-		return newEKCorruptedErr(mctx, UserEKStr, generation, userEKBoxed.Metadata.Generation)
+		return newEKCorruptedErr(mctx, UserEKKind, generation, userEKBoxed.Metadata.Generation)
 	}
 
 	key, err := s.dbKey(mctx)
@@ -250,7 +244,7 @@ func (s *UserEKBoxStorage) unbox(mctx libkb.MetaContext, userEKGeneration keybas
 		mctx.Debug("unable to get from deviceEKStorage %v", err)
 		switch err.(type) {
 		case libkb.UnboxError:
-			return userEK, newEKUnboxErr(mctx, UserEKStr, userEKGeneration, DeviceEKStr,
+			return userEK, newEKUnboxErr(mctx, UserEKKind, userEKGeneration, DeviceEKKind,
 				userEKBoxed.DeviceEkGeneration, contentCtime)
 		}
 		return userEK, err
@@ -262,7 +256,7 @@ func (s *UserEKBoxStorage) unbox(mctx libkb.MetaContext, userEKGeneration keybas
 	msg, _, err := deviceKeypair.DecryptFromString(userEKBoxed.Box)
 	if err != nil {
 		mctx.Debug("unable to decrypt userEKBoxed %v", err)
-		return userEK, newEKUnboxErr(mctx, UserEKStr, userEKGeneration, DeviceEKStr,
+		return userEK, newEKUnboxErr(mctx, UserEKKind, userEKGeneration, DeviceEKKind,
 			userEKBoxed.DeviceEkGeneration, contentCtime)
 	}
 


### PR DESCRIPTION
marks specific ephemeral key errors as transient for teambotEKs so chat can retry 

cc @keybase/hotpotatosquad 