### PR TITLE
bkg teambot keygen

### DIFF
--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -48,7 +48,7 @@ func getTeamCryptKey(mctx libkb.MetaContext, team *teams.Team, generation keybas
 		return res, NewDecryptionKeyNotFoundError(int(generation), kbfsEncrypted, public)
 	}
 
-	appKey, err := team.ApplicationKeyAtGeneration(mctx.Ctx(), keybase1.TeamApplication_CHAT, generation)
+	appKey, err := team.ChatKeyAtGeneration(mctx.Ctx(), generation)
 	if err != nil {
 		return res, err
 	}

--- a/go/ephemeral/teambot_ek_test.go
+++ b/go/ephemeral/teambot_ek_test.go
@@ -40,21 +40,25 @@ func TestNewTeambotEK(t *testing.T) {
 	require.NoError(t, err)
 	merkleRoot := *merkleRootPtr
 
-	// Before we've published anything, should get back a nil botkey
-	nilMeta, wrongKID, err := fetchLatestTeambotEK(mctx2, teamID)
-	require.NoError(t, err)
-	require.Nil(t, nilMeta)
-	require.False(t, wrongKID)
-
-	ek, _, err := mctx.G().GetEKLib().GetOrCreateLatestTeamEK(mctx, teamID)
+	ek, _, err := mctx.G().GetEKLib().GetOrCreateLatestTeambotEK(mctx, teamID, botuaUID.ToBytes())
 	require.NoError(t, err)
 	typ, err := ek.KeyType()
 	require.NoError(t, err)
+	require.True(t, typ.IsTeambot())
+
+	metaPtr, wrongKID, err := fetchLatestTeambotEK(mctx2, teamID)
+	require.NoError(t, err)
+	require.NotNil(t, metaPtr)
+	require.False(t, wrongKID)
+	metadata := *metaPtr
+	require.Equal(t, ek.Teambot().Metadata, metadata)
+
+	ek, _, err = mctx.G().GetEKLib().GetOrCreateLatestTeamEK(mctx, teamID)
+	require.NoError(t, err)
+	typ, err = ek.KeyType()
+	require.NoError(t, err)
 	require.True(t, typ.IsTeam())
 	teamEK := ek.Team()
-
-	publishedMetadata, err := publishNewTeambotEK(mctx, teamID, botuaUID, teamEK, merkleRoot)
-	require.NoError(t, err)
 
 	// bot users don't have access to team secrets so they can't get the teamEK
 	_, _, err = mctx2.G().GetEKLib().GetOrCreateLatestTeamEK(mctx2, teamID)
@@ -64,14 +68,6 @@ func TestNewTeambotEK(t *testing.T) {
 	// either, even if we pass a valid teamEK from the non-bot
 	_, err = publishNewTeambotEK(mctx2, teamID, botuaUID, teamEK, merkleRoot)
 	require.Error(t, err)
-
-	metaPtr, wrongKID, err := fetchLatestTeambotEK(mctx2, teamID)
-	require.NoError(t, err)
-	require.NotNil(t, metaPtr)
-	require.False(t, wrongKID)
-	metadata := *metaPtr
-	require.Equal(t, publishedMetadata, metadata)
-	require.EqualValues(t, 1, metadata.Generation)
 
 	keyer := NewTeambotEphemeralKeyer()
 	teambotEKBoxed, err := keyer.Fetch(mctx2, teamID, metadata.Generation, nil)

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -867,6 +867,8 @@ type TeambotBotKeyer interface {
 	GetLatestTeambotKey(mctx MetaContext, teamID keybase1.TeamID) (keybase1.TeambotKey, error)
 	GetTeambotKeyAtGeneration(mctx MetaContext, teamID keybase1.TeamID,
 		generation keybase1.TeambotKeyGeneration) (keybase1.TeambotKey, error)
+
+	DeleteTeambotKeyForTest(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.TeambotKeyGeneration) error
 }
 
 type TeambotMemberKeyer interface {

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -136,12 +136,37 @@ func TestEphemeralTeambotEK(t *testing.T) {
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 	user1.addTeamMember(teamName.String(), botua.username, keybase1.TeamRole_BOT)
 
+	// bot gets a key on addition to the team
+	newEkArg := keybase1.NewTeambotEkArg{
+		Id:         teamID,
+		Generation: 1,
+	}
+	checkNewTeambotEKNotifications(botua.tc, botua.notifications, newEkArg)
+
 	// grab the latest teamEK and make sure the generation lines up with the teambotEK
 	teamEK, _, err := ekLib1.GetOrCreateLatestTeamEK(mctx1, teamID)
 	require.NoError(t, err)
 
+	// now created = false since we published on member addition
+	teambotEK, created, err := ekLib1.GetOrCreateLatestTeambotEK(mctx1, teamID, botuaUID)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.Equal(t, teamEK.Generation(), teambotEK.Generation())
+
+	teambotEK2, _, err := ekLib3.GetOrCreateLatestTeambotEK(mctx3, teamID, botuaUID)
+	require.NoError(t, err)
+	require.Equal(t, teambotEK2.Generation(), teambotEK.Generation())
+	require.Equal(t, teambotEK2.Material(), teambotEK.Material())
+	noTeambotEKNeeded(user1.tc, user1.notifications)
+	noTeambotEKNeeded(user2.tc, user2.notifications)
+	noNewTeambotEKNotification(botua.tc, botua.notifications)
+
+	// delete the initial key to check regeneration flows
+	err = teambot.DeleteTeambotEKForTest(mctx3, teamID, 1)
+	require.NoError(t, err)
+
 	// initial get, bot has no key to access
-	_, created, err := ekLib3.GetOrCreateLatestTeambotEK(mctx3, teamID, botuaUID)
+	_, created, err = ekLib3.GetOrCreateLatestTeambotEK(mctx3, teamID, botuaUID)
 	require.Error(t, err)
 	require.IsType(t, ephemeral.EphemeralKeyError{}, err)
 	require.False(t, created)
@@ -156,20 +181,14 @@ func TestEphemeralTeambotEK(t *testing.T) {
 	checkTeambotEKNeededNotifications(user2.tc, user2.notifications, ekNeededArg)
 
 	// and answered.
-	newEkArg := keybase1.NewTeambotEkArg{
+	newEkArg = keybase1.NewTeambotEkArg{
 		Id:         teamID,
 		Generation: 1,
 	}
 	checkNewTeambotEKNotifications(botua.tc, botua.notifications, newEkArg)
 
-	// now created = false since we published after receiving the teambot_key_needed notif
-	teambotEK, created, err := ekLib1.GetOrCreateLatestTeambotEK(mctx1, teamID, botuaUID)
-	require.NoError(t, err)
-	require.False(t, created)
-	require.Equal(t, teamEK.Generation(), teambotEK.Generation())
-
 	// bot can access the key
-	teambotEK2, created, err := ekLib3.GetOrCreateLatestTeambotEK(mctx3, teamID, botuaUID)
+	teambotEK2, created, err = ekLib3.GetOrCreateLatestTeambotEK(mctx3, teamID, botuaUID)
 	require.NoError(t, err)
 	require.False(t, created)
 	require.Equal(t, teambotEK, teambotEK2)
@@ -180,6 +199,17 @@ func TestEphemeralTeambotEK(t *testing.T) {
 	// force a PTK rotation
 	user2.revokePaperKey()
 	user1.waitForRotateByID(teamID, keybase1.Seqno(4))
+
+	// bot gets a new EK on rotation
+	newEkArg = keybase1.NewTeambotEkArg{
+		Id:         teamID,
+		Generation: 2,
+	}
+	checkNewTeambotEKNotifications(botua.tc, botua.notifications, newEkArg)
+
+	// delete to check regeneration flow
+	err = teambot.DeleteTeambotEKForTest(mctx3, teamID, 2)
+	require.NoError(t, err)
 
 	// Force a wrongKID error on the bot user by expiring the wrongKID cache
 	key := teambot.TeambotEKWrongKIDCacheKey(teamID, botua.uid, teambotEK2.Generation())
@@ -229,6 +259,17 @@ func TestEphemeralTeambotEK(t *testing.T) {
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 	user2.waitForNewlyAddedToTeamByID(teamID)
 	botua.waitForNewlyAddedToTeamByID(teamID)
+
+	// bot gets a new EK on rotation
+	newEkArg = keybase1.NewTeambotEkArg{
+		Id:         teamID,
+		Generation: 3,
+	}
+	checkNewTeambotEKNotifications(botua.tc, botua.notifications, newEkArg)
+
+	// delete to check regeneration flow
+	err = teambot.DeleteTeambotEKForTest(mctx3, teamID, 3)
+	require.NoError(t, err)
 
 	// bot can access the old teambotEK, but asks for a new one to
 	// be created since it was signed by the old PTK

--- a/go/teambot/handler.go
+++ b/go/teambot/handler.go
@@ -62,17 +62,16 @@ func HandleTeambotKeyNeeded(mctx libkb.MetaContext, teamID keybase1.TeamID, botU
 	}
 
 	// Clear out our caches so we can force publish a key
-	// only CHAT application is supported
 	var appKey keybase1.TeamApplicationKey
 	if generation == 0 { // Bot needs the latest key
 		keyer.PurgeCache(mctx)
-		appKey, err = team.ApplicationKey(mctx.Ctx(), keybase1.TeamApplication_CHAT)
+		appKey, err = team.ChatKey(mctx.Ctx())
 		if err != nil {
 			return err
 		}
 	} else { // Bot needs a specific generation
 		keyer.PurgeCacheAtGeneration(mctx, teamID, botUID, generation)
-		appKey, err = team.ApplicationKeyAtGeneration(mctx.Ctx(), keybase1.TeamApplication_CHAT,
+		appKey, err = team.ChatKeyAtGeneration(mctx.Ctx(),
 			keybase1.PerTeamKeyGeneration(generation))
 		if err != nil {
 			return err

--- a/go/teams/create.go
+++ b/go/teams/create.go
@@ -520,7 +520,7 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 	}
 
 	memSet := newMemberSet()
-	_, err = memSet.loadGroup(ctx, g, allParentAdmins, true /* store recipients */, true /* force poll */)
+	_, err = memSet.loadGroup(ctx, g, allParentAdmins, storeMemberKindRecipient, true /* force poll */)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -540,7 +540,7 @@ func generateHeadSigForSubteamChain(ctx context.Context, g *libkb.GlobalContext,
 		case keybase1.TeamRole_BOT:
 			return nil, nil, errors.New("Cannot add self as bot to a subteam")
 		}
-		memSet.loadMember(ctx, g, meUV, true /* store recipient */, false /* force poll */)
+		memSet.loadMember(ctx, g, meUV, storeMemberKindRecipient, false /* force poll */)
 	}
 
 	// These boxes will get posted along with the sig below.

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/sig3"
 	hidden "github.com/keybase/client/go/teams/hidden"
@@ -186,6 +187,10 @@ func (t *Team) SeitanInviteTokenKeyLatest(ctx context.Context) (keybase1.TeamApp
 
 func (t *Team) SaltpackEncryptionKeyLatest(ctx context.Context) (keybase1.TeamApplicationKey, error) {
 	return t.ApplicationKey(ctx, keybase1.TeamApplication_SALTPACK)
+}
+
+func (t *Team) ChatKeyAtGeneration(ctx context.Context, generation keybase1.PerTeamKeyGeneration) (keybase1.TeamApplicationKey, error) {
+	return t.ApplicationKeyAtGeneration(ctx, keybase1.TeamApplication_CHAT, generation)
 }
 
 func (t *Team) SaltpackEncryptionKeyAtGeneration(ctx context.Context, generation keybase1.PerTeamKeyGeneration) (keybase1.TeamApplicationKey, error) {
@@ -571,6 +576,7 @@ func (t *Team) rotate(ctx context.Context, rt keybase1.RotationType) (err error)
 	}
 
 	t.storeTeamEKPayload(mctx.Ctx(), teamEKPayload)
+	createTeambotKeys(t.G(), t.ID, memSet.botRecipientUids())
 
 	return nil
 }
@@ -817,12 +823,22 @@ func (t *Team) ChangeMembershipWithOptions(ctx context.Context, req keybase1.Tea
 		return err
 	}
 
-	var group []keybase1.UserVersion
+	var recipients, botRecipients []keybase1.UserVersion
 	for uv := range memberSet.recipients {
-		group = append(group, uv)
+		recipients = append(recipients, uv)
+	}
+	for uv := range memberSet.botRecipients {
+		botRecipients = append(botRecipients, uv)
 	}
 	newMemSet := newMemberSet()
-	_, err = newMemSet.loadGroup(ctx, t.G(), group, true, true)
+	_, err = newMemSet.loadGroup(ctx, t.G(), recipients, storeMemberKindRecipient, true)
+	if err != nil {
+		return err
+	}
+	_, err = newMemSet.loadGroup(ctx, t.G(), botRecipients, storeMemberKindBotRecipient, true)
+	if err != nil {
+		return err
+	}
 	if !memberSet.recipients.Eq(newMemSet.recipients) {
 		return BoxRaceError{inner: fmt.Errorf("team box summary changed during sig creation; retry required")}
 	}
@@ -833,6 +849,8 @@ func (t *Team) ChangeMembershipWithOptions(ctx context.Context, req keybase1.Tea
 	}
 
 	t.notify(ctx, keybase1.TeamChangeSet{MembershipChanged: true}, latestSeqno)
+	t.storeTeamEKPayload(ctx, teamEKPayload)
+	createTeambotKeys(t.G(), t.ID, memberSet.botRecipientUids())
 
 	return nil
 }
@@ -1682,7 +1700,9 @@ func (t *Team) sigTeamItemRaw(ctx context.Context, section SCTeamSection, linkTy
 	return sigMultiItem, keybase1.LinkID(newLinkID.String()), nil
 }
 
-func (t *Team) recipientBoxes(ctx context.Context, memSet *memberSet, skipKeyRotation bool) (*PerTeamSharedSecretBoxes, map[keybase1.TeamID]*PerTeamSharedSecretBoxes, *SCPerTeamKey, *teamEKPayload, error) {
+func (t *Team) recipientBoxes(ctx context.Context, memSet *memberSet, skipKeyRotation bool) (
+	*PerTeamSharedSecretBoxes, map[keybase1.TeamID]*PerTeamSharedSecretBoxes,
+	*SCPerTeamKey, *teamEKPayload, error) {
 
 	// get device key
 	deviceEncryptionKey, err := t.G().ActiveDevice.EncryptionKey()
@@ -1767,7 +1787,7 @@ func (t *Team) rotateBoxes(ctx context.Context, memSet *memberSet) (*PerTeamShar
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		_, err = memSet.loadGroup(ctx, t.G(), allParentAdmins, true, true)
+		_, err = memSet.loadGroup(ctx, t.G(), allParentAdmins, storeMemberKindRecipient, true)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1825,6 +1845,53 @@ func (t *Team) storeTeamEKPayload(ctx context.Context, teamEKPayload *teamEKPayl
 			t.G().Log.CErrorf(ctx, "error while saving teamEK box: %s", err)
 		}
 	}
+}
+
+// createTeambotKeys generates teambotKeys and teambotEKs for the given bot
+// member list. Runs in the background on member addition or team rotation.
+func createTeambotKeys(g *libkb.GlobalContext, teamID keybase1.TeamID, bots []keybase1.UID) {
+	mctx := libkb.NewMetaContextBackground(g)
+	go func() {
+		var err error
+		defer mctx.TraceTimed(fmt.Sprintf("createTeambotKeys: %d bot members", len(bots)), func() error { return err })()
+		if len(bots) == 0 {
+			return
+		}
+
+		// Load the team in case we need to grab the latest PTK generation after a rotation.
+		team, err := Load(mctx.Ctx(), g, keybase1.LoadTeamArg{
+			ID: teamID,
+		})
+		if err != nil {
+			return
+		}
+
+		ekLib := mctx.G().GetEKLib()
+		keyer := mctx.G().GetTeambotMemberKeyer()
+		appKey, err := team.ChatKey(mctx.Ctx())
+		if err != nil {
+			mctx.Debug("unable to get teamApplication key %v, aborting TeambotKey creation", err)
+			keyer = nil
+		}
+
+		for _, uid := range bots {
+			guid := gregor1.UID(uid.ToBytes())
+			if ekLib != nil {
+				if teambotEK, created, err := ekLib.GetOrCreateLatestTeambotEK(mctx, teamID, guid); err != nil {
+					mctx.Debug("unable to GetOrCreateLatestTeambotEK for %v, %v", guid, err)
+				} else {
+					mctx.Debug("published TeambotEK generation %d for %v, newly created: %v", teambotEK.Generation(), uid, created)
+				}
+			}
+			if keyer != nil {
+				if teambotKey, created, err := keyer.GetOrCreateTeambotKey(mctx, teamID, guid, appKey); err != nil {
+					mctx.Debug("unable to GetOrCreateTeambotKey for %v, %v", guid, err)
+				} else {
+					mctx.Debug("published TeambotKey generation %d for %v, newly created: %v", teambotKey.Generation(), uid, created)
+				}
+			}
+		}
+	}()
 }
 
 type sigPayloadArgs struct {
@@ -2019,6 +2086,7 @@ func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSetti
 		ratchetBlindingKeys: ratchet.ToSigPayload(),
 	}
 	var maybeEKPayload *teamEKPayload
+	var botMembers []keybase1.UID
 	if rotate {
 		// Create empty Members section. We are not changing memberships, but
 		// it's needed for key rotation.
@@ -2035,6 +2103,7 @@ func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSetti
 		payloadArgs.secretBoxes = secretBoxes
 		payloadArgs.teamEKPayload = teamEKPayload
 		maybeEKPayload = teamEKPayload // for storeTeamEKPayload, after post succeeds
+		botMembers = memSet.botRecipientUids()
 	}
 	latestSeqno, err := t.postChangeItem(ctx, section, libkb.LinkTypeSettings, mr, payloadArgs)
 	if err != nil {
@@ -2044,6 +2113,7 @@ func (t *Team) PostTeamSettings(ctx context.Context, settings keybase1.TeamSetti
 	if rotate {
 		t.notify(ctx, keybase1.TeamChangeSet{KeyRotated: true, Misc: true}, latestSeqno)
 		t.storeTeamEKPayload(ctx, maybeEKPayload)
+		createTeambotKeys(t.G(), t.ID, botMembers)
 	} else {
 		t.notify(ctx, keybase1.TeamChangeSet{Misc: true}, latestSeqno)
 	}

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -893,5 +893,7 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 	team.notify(mctx.Ctx(), keybase1.TeamChangeSet{MembershipChanged: true}, nextSeqno-1)
 
 	team.storeTeamEKPayload(mctx.Ctx(), teamEKPayload)
+	createTeambotKeys(team.G(), team.ID, memSet.botRecipientUids())
+
 	return nil
 }


### PR DESCRIPTION
adds background key generation for ephemeral and non-ephemeral teambot keys for bot members when added to the team or when the PTK is rotated. generation is best effort, if the generation fails or the bot wins a race to access the key they will notify that they need a new key and fail with a transient error or fall back to an older key if available.

depends on https://github.com/keybase/keybase/pull/4076

cc @keybase/hotpotatosquad 