### PR TITLE
kbfs: fix all golangci-lint outside of `libkbfs`

### DIFF
--- a/go/kbfs/data/bcache_test.go
+++ b/go/kbfs/data/bcache_test.go
@@ -155,12 +155,14 @@ func TestBlockCacheDeletePermanent(t *testing.T) {
 	testBcachePutWithBlock(t, id2, bcache, TransientEntry, block2)
 	testBcachePutWithBlock(t, id2, bcache, PermanentEntry, block2)
 
-	bcache.DeletePermanent(id1)
-	bcache.DeletePermanent(id2)
+	err := bcache.DeletePermanent(id1)
+	require.NoError(t, err)
+	err = bcache.DeletePermanent(id2)
+	require.NoError(t, err)
 	testExpectedMissing(t, id1, bcache)
 
 	// 2 should still be there
-	_, err := bcache.Get(BlockPointer{ID: id2})
+	_, err = bcache.Get(BlockPointer{ID: id2})
 	require.NoError(t, err)
 }
 

--- a/go/kbfs/data/block_tree.go
+++ b/go/kbfs/data/block_tree.go
@@ -173,7 +173,6 @@ func (bt *blockTree) getNextDirtyBlockAtOffsetAtLevel(ctx context.Context,
 		// since it contains `off`.
 		index := -1
 		nextBlockStartOff = nil
-		startOff = pblock.FirstOffset()
 		var prevPtr BlockPointer
 		if !checkedPrevBlock && i > 0 {
 			prevInfo, _ := pblock.IndirectPtr(i - 1)

--- a/go/kbfs/data/block_types.go
+++ b/go/kbfs/data/block_types.go
@@ -455,7 +455,7 @@ var _ BlockWithPtrs = (*FileBlock)(nil)
 // NewFileBlock creates a new, empty FileBlock.
 func NewFileBlock() Block {
 	return &FileBlock{
-		Contents: make([]byte, 0, 0),
+		Contents: make([]byte, 0),
 	}
 }
 

--- a/go/kbfs/data/data_types.go
+++ b/go/kbfs/data/data_types.go
@@ -182,14 +182,10 @@ var ZeroPtr BlockPointer
 // IsValid returns whether the block pointer is valid. A zero block
 // pointer is considered invalid.
 func (p BlockPointer) IsValid() bool {
-	if !p.ID.IsValid() {
-		return false
-	}
+	return p.ID.IsValid()
 
 	// TODO: Should also check KeyGen, Ver, and Creator. (A
 	// bunch of tests use invalid values for one of these.)
-
-	return true
 }
 
 func (p BlockPointer) String() string {

--- a/go/kbfs/data/dirty_file.go
+++ b/go/kbfs/data/dirty_file.go
@@ -143,18 +143,6 @@ func (df *DirtyFile) setBlockNotDirty(ptr BlockPointer) (
 	return
 }
 
-func (df *DirtyFile) isBlockSyncing(ptr BlockPointer) bool {
-	df.lock.Lock()
-	defer df.lock.Unlock()
-	return df.fileBlockStates[ptr].sync == blockSyncing
-}
-
-func (df *DirtyFile) isBlockDirty(ptr BlockPointer) bool {
-	df.lock.Lock()
-	defer df.lock.Unlock()
-	return df.fileBlockStates[ptr].copy == blockAlreadyCopied
-}
-
 // IsBlockOrphaned returns true if the block has been orphaned and can
 // no longer be reached in the file.
 func (df *DirtyFile) IsBlockOrphaned(ptr BlockPointer) bool {

--- a/go/kbfs/data/file_data.go
+++ b/go/kbfs/data/file_data.go
@@ -116,7 +116,6 @@ func (fd *FileData) getByteSlicesInOffsetRange(ctx context.Context,
 
 	// Find all the indirect pointers to leaf blocks in the offset range.
 	var iptrs []IndirectFilePtr
-	firstBlockOff := Int64Offset(-1)
 	endBlockOff := Int64Offset(-1)
 	nextBlockOff := Int64Offset(-1)
 	var blockMap map[BlockPointer]Block
@@ -136,9 +135,6 @@ func (fd *FileData) getByteSlicesInOffsetRange(ctx context.Context,
 			lowestAncestor := p[len(p)-1]
 			iptr := childFileIptr(lowestAncestor)
 			iptrs = append(iptrs, iptr)
-			if firstBlockOff < 0 {
-				firstBlockOff = iptr.Off
-			}
 			if i == len(pfr)-1 {
 				leafBlock := blockMap[iptr.BlockPointer].(*FileBlock)
 				endBlockOff = iptr.Off + Int64Offset(len(leafBlock.Contents))
@@ -149,7 +145,6 @@ func (fd *FileData) getByteSlicesInOffsetRange(ctx context.Context,
 			BlockInfo: BlockInfo{BlockPointer: fd.rootBlockPointer()},
 			Off:       0,
 		}}
-		firstBlockOff = 0
 		endBlockOff = Int64Offset(len(topBlock.Contents))
 		blockMap = map[BlockPointer]Block{fd.rootBlockPointer(): topBlock}
 	}
@@ -1117,9 +1112,6 @@ func (fd *FileData) DeepCopy(ctx context.Context, dataVer Ver) (
 	// Handle the single-level case first.
 	if !topBlock.IsInd {
 		newTopBlock := topBlock.DeepCopy()
-		if err != nil {
-			return ZeroPtr, nil, err
-		}
 
 		newTopPtr = fd.rootBlockPointer()
 		newTopPtr.RefNonce, err = kbfsblock.MakeRefNonce()

--- a/go/kbfs/data/file_data_test.go
+++ b/go/kbfs/data/file_data_test.go
@@ -283,9 +283,10 @@ func testFileDataWriteExtendEmptyFile(t *testing.T, maxBlockSize Int64Offset,
 	fd, cleanBcache, dirtyBcache, df := setupFileDataTest(
 		t, int64(maxBlockSize), maxPtrsPerBlock)
 	topBlock := NewFileBlock().(*FileBlock)
-	cleanBcache.Put(
+	err := cleanBcache.Put(
 		fd.rootBlockPointer(), fd.tree.file.Tlf, topBlock, TransientEntry,
 		SkipCacheHash)
+	require.NoError(t, err)
 	de := DirEntry{}
 	data := make([]byte, fullDataLen)
 	for i := 0; i < int(fullDataLen); i++ {
@@ -413,8 +414,9 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *FileData,
 					BlockInfo: BlockInfo{ptr, 0},
 					Off:       off,
 				})
-				cleanBcache.Put(
+				err = cleanBcache.Put(
 					ptr, fd.tree.file.Tlf, child, TransientEntry, SkipCacheHash)
+				require.NoError(t, err)
 			}
 			prevChildIndex = newIndex
 			level = append(level, fblock)
@@ -427,9 +429,10 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *FileData,
 		fd.tree.file.Path[len(fd.tree.file.Path)-1].DirectType = IndirectBlock
 	}
 
-	cleanBcache.Put(
+	err := cleanBcache.Put(
 		fd.rootBlockPointer(), fd.tree.file.Tlf, prevChildren[0],
 		TransientEntry, SkipCacheHash)
+	require.NoError(t, err)
 	return prevChildren[0], numLevels
 }
 

--- a/go/kbfs/data/node_obfuscator.go
+++ b/go/kbfs/data/node_obfuscator.go
@@ -120,7 +120,7 @@ func (no *NodeObfuscator) obfuscateWithHasher(
 
 func (no *NodeObfuscator) defaultHash(plaintext string) []byte {
 	mac := hmac.New(sha256.New, no.secret)
-	mac.Write([]byte(plaintext))
+	_, _ = mac.Write([]byte(plaintext))
 	return mac.Sum(nil)
 }
 

--- a/go/kbfs/dokan/debug_none.go
+++ b/go/kbfs/dokan/debug_none.go
@@ -6,7 +6,7 @@
 
 package dokan
 
-const isDebug = false
+const isDebug = false //nolint
 
-func debug(...interface{})          {}
-func debugf(string, ...interface{}) {}
+func debug(...interface{})          {} // nolint
+func debugf(string, ...interface{}) {} // nolint

--- a/go/kbfs/dokan/dokan.go
+++ b/go/kbfs/dokan/dokan.go
@@ -56,7 +56,7 @@ func (m *MountHandle) BlockTillDone() error {
 	// Two cases:
 	// 1) Mount got send from Mounted hook (nil) and we wait for the ctx.Run case
 	// 2) Mount got send from Mount (which errored) and closed the channel
-	err, _ := <-m.errChan
+	err := <-m.errChan
 	return err
 }
 

--- a/go/kbfs/dokan/dummy.go
+++ b/go/kbfs/dokan/dummy.go
@@ -52,6 +52,6 @@ const (
 	kbfsLibdokanUseFindFilesWithPattern
 )
 
-func currentProcessUserSid() (*winacl.SID, error) {
+func currentProcessUserSid() (*winacl.SID, error) { // nolint
 	return nil, errNotWindows
 }

--- a/go/kbfs/dokan/error_file.go
+++ b/go/kbfs/dokan/error_file.go
@@ -12,7 +12,7 @@ import (
 	"github.com/keybase/client/go/kbfs/dokan/winacl"
 )
 
-type errorFile struct {
+type errorFile struct { // nolint
 	fs FileSystem
 }
 

--- a/go/kbfs/dokan/pointertable.go
+++ b/go/kbfs/dokan/pointertable.go
@@ -16,9 +16,9 @@ import (
 
 var fsTableLock sync.Mutex
 var fsTable = make([]fsTableEntry, 0, 2)
-var fiTableLock sync.Mutex
-var fiTable = map[uint32]File{}
-var fiIdx uint32
+var fiTableLock sync.Mutex      // nolint
+var fiTable = map[uint32]File{} // nolint
+var fiIdx uint32                // nolint
 
 type fsTableEntry struct {
 	fs        FileSystem
@@ -41,7 +41,7 @@ func fsTableStore(fs FileSystem, ec chan error) uint32 {
 	return uint32(len(fsTable) - 1)
 }
 
-func fsTableFree(slot uint32) {
+func fsTableFree(slot uint32) { // nolint
 	fsTableLock.Lock()
 	defer fsTableLock.Unlock()
 	if int(slot) < len(fsTable) {
@@ -49,13 +49,13 @@ func fsTableFree(slot uint32) {
 	}
 }
 
-func fsTableGet(slot uint32) FileSystem {
+func fsTableGet(slot uint32) FileSystem { // nolint
 	fsTableLock.Lock()
 	defer fsTableLock.Unlock()
 	return fsTable[slot].fs
 }
 
-func fsTableGetErrChan(slot uint32) chan error {
+func fsTableGetErrChan(slot uint32) chan error { // nolint
 	fsTableLock.Lock()
 	defer fsTableLock.Unlock()
 	return fsTable[slot].errChan
@@ -67,7 +67,7 @@ func fsTableGetFileCount(slot uint32) uint32 {
 	return fsTable[slot].fileCount
 }
 
-func fiTableStoreFile(global uint32, fi File) uint32 {
+func fiTableStoreFile(global uint32, fi File) uint32 { // nolint
 	fsTableLock.Lock()
 	fsTable[global].fileCount++
 	fsTableLock.Unlock()
@@ -91,7 +91,7 @@ func fiTableStoreFile(global uint32, fi File) uint32 {
 	}
 }
 
-func fiTableGetFile(file uint32) File {
+func fiTableGetFile(file uint32) File { // nolint
 	fiTableLock.Lock()
 	var fi = fiTable[file]
 	fiTableLock.Unlock()
@@ -99,7 +99,7 @@ func fiTableGetFile(file uint32) File {
 	return fi
 }
 
-func fiTableFreeFile(global uint32, file uint32) {
+func fiTableFreeFile(global uint32, file uint32) { // nolint
 	fsTableLock.Lock()
 	fsTable[global].fileCount--
 	fsTableLock.Unlock()

--- a/go/kbfs/dokan/unsafe.go
+++ b/go/kbfs/dokan/unsafe.go
@@ -10,7 +10,7 @@ import (
 )
 
 // bufToSlice returns a byte slice aliasing the pointer and length given as arguments.
-func bufToSlice(ptr unsafe.Pointer, nbytes uint32) []byte {
+func bufToSlice(ptr unsafe.Pointer, nbytes uint32) []byte { // nolint
 	if ptr == nil || nbytes == 0 {
 		return nil
 	}

--- a/go/kbfs/dokan/winacl/ace.go
+++ b/go/kbfs/dokan/winacl/ace.go
@@ -9,16 +9,6 @@ import (
 	"unsafe"
 )
 
-type aclHeader struct {
-	Revision, pad1    byte
-	Size, Count, pad2 uint16
-}
-
-type aceHeader struct {
-	Type, Flags byte
-	Size        uint16
-}
-
 // ACL is the type for access control lists.
 type ACL struct {
 	raw      []byte

--- a/go/kbfs/env/context.go
+++ b/go/kbfs/env/context.go
@@ -89,10 +89,22 @@ func NewContextFromGlobalContext(g *libkb.GlobalContext) *KBFSContext {
 // main functions.
 func NewContext() *KBFSContext {
 	g := libkb.NewGlobalContextInit()
-	g.ConfigureConfig()
-	g.ConfigureLogging()
-	g.ConfigureCaches()
-	g.ConfigureMerkleClient()
+	err := g.ConfigureConfig()
+	if err != nil {
+		panic(err)
+	}
+	err = g.ConfigureLogging()
+	if err != nil {
+		panic(err)
+	}
+	err = g.ConfigureCaches()
+	if err != nil {
+		panic(err)
+	}
+	err = g.ConfigureMerkleClient()
+	if err != nil {
+		panic(err)
+	}
 	return NewContextFromGlobalContext(g)
 }
 

--- a/go/kbfs/idutil/daemon_local.go
+++ b/go/kbfs/idutil/daemon_local.go
@@ -54,15 +54,6 @@ type localTeamSettingsMap map[keybase1.TeamID]keybase1.KBFSTeamSettings
 
 type localImplicitTeamMap map[keybase1.TeamID]ImplicitTeamInfo
 
-func (m localImplicitTeamMap) getLocalImplicitTeam(
-	tid keybase1.TeamID) (ImplicitTeamInfo, error) {
-	team, ok := m[tid]
-	if !ok {
-		return ImplicitTeamInfo{}, NoSuchTeamError{tid.String()}
-	}
-	return team, nil
-}
-
 // DaemonLocal implements KeybaseDaemon using an in-memory user
 // and session store, and a given favorite store.
 type DaemonLocal struct {
@@ -541,17 +532,6 @@ func (dl *DaemonLocal) ChangeTeamNameForTest(
 	dl.asserts[newAssert] = id
 	delete(dl.asserts, oldAssert)
 	return tid, nil
-}
-
-// changeTeamNameForTestOrBust is like changeTeamNameForTest, but
-// panics if there's an error.
-func (dl *DaemonLocal) changeTeamNameForTestOrBust(
-	oldName, newName string) keybase1.TeamID {
-	tid, err := dl.ChangeTeamNameForTest(oldName, newName)
-	if err != nil {
-		panic(err)
-	}
-	return tid
 }
 
 // RemoveAssertionForTest removes the given assertion.  Should only be

--- a/go/kbfs/kbfscodec/codec_msgpack.go
+++ b/go/kbfs/kbfscodec/codec_msgpack.go
@@ -177,11 +177,19 @@ func (c *CodecMsgpack) Encode(obj interface{}) (buf []byte, err error) {
 
 // RegisterType implements the Codec interface for CodecMsgpack
 func (c *CodecMsgpack) RegisterType(rt reflect.Type, code ExtCode) {
-	c.h.(*codec.MsgpackHandle).SetExt(rt, uint64(code), ext{c.ExtCodec})
+	err := c.h.(*codec.MsgpackHandle).SetBytesExt(
+		rt, uint64(code), ext{c.ExtCodec})
+	if err != nil {
+		panic(err)
+	}
 }
 
 // RegisterIfaceSliceType implements the Codec interface for CodecMsgpack
-func (c *CodecMsgpack) RegisterIfaceSliceType(rt reflect.Type, code ExtCode,
-	typer func(interface{}) reflect.Value) {
-	c.h.(*codec.MsgpackHandle).SetExt(rt, uint64(code), extSlice{c, typer})
+func (c *CodecMsgpack) RegisterIfaceSliceType(
+	rt reflect.Type, code ExtCode, typer func(interface{}) reflect.Value) {
+	err := c.h.(*codec.MsgpackHandle).SetBytesExt(
+		rt, uint64(code), extSlice{c, typer})
+	if err != nil {
+		panic(err)
+	}
 }

--- a/go/kbfs/kbfscodec/unknown_fields_test_util.go
+++ b/go/kbfs/kbfscodec/unknown_fields_test_util.go
@@ -30,7 +30,7 @@ type Extra struct {
 // given prefix.
 func MakeExtraOrBust(prefix string, t require.TestingT) Extra {
 	mac := hmac.New(sha256.New, []byte("fake extra key"))
-	mac.Write([]byte("fake extra buf"))
+	_, _ = mac.Write([]byte("fake extra buf"))
 	h := mac.Sum(nil)
 	return Extra{
 		Extra1: fakeEncryptedData{

--- a/go/kbfs/kbfscrypto/crypto_key_types.go
+++ b/go/kbfs/kbfscrypto/crypto_key_types.go
@@ -42,7 +42,7 @@ func (k kidContainer) MarshalBinary() (data []byte, err error) {
 	// TODO: Use the more stringent checks from
 	// KIDFromStringChecked instead.
 	if !k.kid.IsValid() {
-		return nil, errors.WithStack(InvalidKIDError{k.kid})
+		return nil, errors.WithStack(InvalidKIDError(k))
 	}
 
 	return k.kid.ToBytes(), nil
@@ -700,7 +700,7 @@ type BlockHashKey struct {
 func MakeBlockHashKey(
 	serverHalf BlockCryptKeyServerHalf, key TLFCryptKey) BlockHashKey {
 	mac := hmac.New(sha512.New, key.Bytes())
-	mac.Write(serverHalf.Bytes())
+	_, _ = mac.Write(serverHalf.Bytes())
 	hash := mac.Sum(nil)
 	var hash64 [64]byte
 	copy(hash64[:], hash)

--- a/go/kbfs/kbfsedits/user_history.go
+++ b/go/kbfs/kbfsedits/user_history.go
@@ -5,6 +5,7 @@
 package kbfsedits
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -56,8 +57,9 @@ func NewUserHistory(log logger.Logger, vlog *libkb.VDebugLog) *UserHistory {
 func (uh *UserHistory) UpdateHistory(
 	tlfName tlf.CanonicalName, tlfType tlf.Type, tlfHistory *TlfHistory,
 	loggedInUser string) {
-	uh.vlog.CLogf(nil, libkb.VLog1, "Updating user history for TLF %s, "+
-		"user %s", tlfName, loggedInUser)
+	uh.vlog.CLogf(
+		context.TODO(), libkb.VLog1, "Updating user history for TLF %s, "+
+			"user %s", tlfName, loggedInUser)
 	history := tlfHistory.getHistory(loggedInUser)
 	key := tlfKey{tlfName, tlfType}
 
@@ -166,7 +168,8 @@ func (uh *UserHistory) Get(loggedInUser string) (
 	history []keybase1.FSFolderEditHistory) {
 	uh.lock.RLock()
 	defer uh.lock.RUnlock()
-	uh.vlog.CLogf(nil, libkb.VLog1, "User history requested: %s", loggedInUser)
+	uh.vlog.CLogf(
+		context.TODO(), libkb.VLog1, "User history requested: %s", loggedInUser)
 	var clusters historyClusters
 	for key := range uh.histories {
 		history := uh.getTlfHistoryLocked(key.tlfName, key.tlfType)

--- a/go/kbfs/kbfsedits/user_history_test.go
+++ b/go/kbfs/kbfsedits/user_history_test.go
@@ -142,6 +142,7 @@ func TestUserHistorySimple(t *testing.T) {
 			require.Equal(t, expected[i].serverTime, wh.ServerTime)
 			require.Equal(t, expected[i].writer, wh.History[0].WriterName)
 			require.Len(t, wh.History[0].Edits, expected[i].num)
+			require.Len(t, wh.History[0].Deletes, expected[i].numDeletes)
 		}
 	}
 	check(expected)

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -48,7 +48,7 @@ func TestRunnerCapabilities(t *testing.T) {
 	inputReader, inputWriter := io.Pipe()
 	defer inputWriter.Close()
 	go func() {
-		inputWriter.Write([]byte("capabilities\n\n"))
+		_, _ = inputWriter.Write([]byte("capabilities\n\n"))
 	}()
 
 	var output bytes.Buffer
@@ -94,7 +94,7 @@ func testRunnerInitRepo(t *testing.T, tlfType tlf.Type, typeString string) {
 	inputReader, inputWriter := io.Pipe()
 	defer inputWriter.Close()
 	go func() {
-		inputWriter.Write([]byte("list\n\n"))
+		_, _ = inputWriter.Write([]byte("list\n\n"))
 	}()
 
 	h, err := tlfhandle.ParseHandle(
@@ -194,9 +194,9 @@ func testPushWithTemplate(ctx context.Context, t *testing.T,
 	defer inputWriter.Close()
 	go func() {
 		for _, refspec := range refspecs {
-			inputWriter.Write([]byte(fmt.Sprintf("push %s\n", refspec)))
+			_, _ = inputWriter.Write([]byte(fmt.Sprintf("push %s\n", refspec)))
 		}
-		inputWriter.Write([]byte("\n\n"))
+		_, _ = inputWriter.Write([]byte("\n\n"))
 	}()
 
 	var output bytes.Buffer
@@ -241,7 +241,7 @@ func testListAndGetHeadsWithName(ctx context.Context, t *testing.T,
 	inputReader, inputWriter := io.Pipe()
 	defer inputWriter.Close()
 	go func() {
-		inputWriter.Write([]byte("list\n\n"))
+		_, _ = inputWriter.Write([]byte("list\n\n"))
 	}()
 
 	var output bytes.Buffer
@@ -333,7 +333,7 @@ func testRunnerPushFetch(t *testing.T, cloning bool, secondRepoHasBranch bool) {
 	inputReader, inputWriter := io.Pipe()
 	defer inputWriter.Close()
 	go func() {
-		inputWriter.Write([]byte(fmt.Sprintf(
+		_, _ = inputWriter.Write([]byte(fmt.Sprintf(
 			"%sfetch %s refs/heads/master\n\n\n", cloningStr, heads[0])))
 	}()
 
@@ -578,7 +578,7 @@ func testCloneIntoNewLocalRepo(
 	inputReader, inputWriter := io.Pipe()
 	defer inputWriter.Close()
 	go func() {
-		inputWriter.Write([]byte(fmt.Sprintf(
+		_, _ = inputWriter.Write([]byte(fmt.Sprintf(
 			"option cloning true\n"+
 				"fetch %s refs/heads/master\n\n\n", heads[0])))
 	}()
@@ -695,7 +695,7 @@ func TestPushcertOptions(t *testing.T) {
 		inputReader, inputWriter := io.Pipe()
 		defer inputWriter.Close()
 		go func() {
-			inputWriter.Write([]byte(fmt.Sprintf(
+			_, _ = inputWriter.Write([]byte(fmt.Sprintf(
 				"option pushcert %s\n\n", option)))
 		}()
 
@@ -870,8 +870,8 @@ func TestPackRefsAndDeletePackedRef(t *testing.T) {
 	inputReader, inputWriter := io.Pipe()
 	defer inputWriter.Close()
 	go func() {
-		inputWriter.Write([]byte("push :refs/heads/test\n"))
-		inputWriter.Write([]byte("\n\n"))
+		_, _ = inputWriter.Write([]byte("push :refs/heads/test\n"))
+		_, _ = inputWriter.Write([]byte("\n\n"))
 	}()
 
 	var output bytes.Buffer

--- a/go/kbfs/kbfshash/hash.go
+++ b/go/kbfs/kbfshash/hash.go
@@ -303,7 +303,10 @@ var _ encoding.TextUnmarshaler = (*HMAC)(nil)
 // using the default hash.
 func DefaultHMAC(key, buf []byte) (HMAC, error) {
 	mac := hmac.New(DefaultHashNew, key)
-	mac.Write(buf)
+	_, err := mac.Write(buf)
+	if err != nil {
+		return HMAC{}, err
+	}
 	h, err := HashFromRaw(DefaultHashType, mac.Sum(nil))
 	if err != nil {
 		return HMAC{}, err

--- a/go/kbfs/kbfsmd/merkle_leaf.go
+++ b/go/kbfs/kbfsmd/merkle_leaf.go
@@ -13,7 +13,7 @@ import (
 
 // MerkleLeaf is the value of a Merkle leaf node.
 type MerkleLeaf struct {
-	_struct   bool `codec:",toarray"`
+	_struct   bool `codec:",toarray"` // nolint
 	Revision  Revision
 	Hash      MerkleHash // hash of the signed metadata object
 	Timestamp int64
@@ -29,7 +29,7 @@ func (l MerkleLeaf) Construct() interface{} {
 
 // EncryptedMerkleLeaf is an encrypted Merkle leaf.
 type EncryptedMerkleLeaf struct {
-	_struct       bool `codec:",toarray"`
+	_struct       bool `codec:",toarray"` // nolint
 	Version       kbfscrypto.EncryptionVer
 	EncryptedData []byte
 }

--- a/go/kbfs/kbfsmd/root_metadata_test.go
+++ b/go/kbfs/kbfsmd/root_metadata_test.go
@@ -69,28 +69,3 @@ func runTestsOverMetadataVers(t *testing.T, prefix string,
 		})
 	}
 }
-
-// runBenchmarkOverMetadataVers runs the given benchmark function over
-// all metadata versions to test. Example use:
-//
-// func BenchmarkFoo(b *testing.B) {
-//	runBenchmarkOverMetadataVers(b, testFoo)
-// }
-//
-// func benchmarkFoo(b *testing.B, ver MetadataVer) {
-//	...
-// 	brmd, err := MakeInitialRootMetadata(ver, ...)
-//	...
-// }
-func runBenchmarkOverMetadataVers(
-	b *testing.B, f func(b *testing.B, ver MetadataVer)) {
-	for _, ver := range testMetadataVers {
-		ver := ver // capture range variable.
-		b.Run(ver.String(), func(b *testing.B) {
-			f(b, ver)
-		})
-	}
-}
-
-// TODO: Add way to test with all possible (ver, maxVer) combos,
-// e.g. for upconversion tests.

--- a/go/kbfs/kbfsmd/root_metadata_v2_test.go
+++ b/go/kbfs/kbfsmd/root_metadata_v2_test.go
@@ -704,35 +704,6 @@ func TestRevokeLastDeviceV2(t *testing.T) {
 	require.Equal(t, expectedRKeys, brmd.RKeys)
 }
 
-type userDeviceSet UserDevicePublicKeys
-
-// union returns the union of the user's keys in uds and other. For a
-// particular user, it's assumed that that user's keys in uds and
-// other are disjoint.
-func (uds userDeviceSet) union(other userDeviceSet) userDeviceSet {
-	u := make(userDeviceSet)
-	for uid, keys := range uds {
-		u[uid] = make(DevicePublicKeys)
-		for key := range keys {
-			u[uid][key] = true
-		}
-	}
-	for uid, keys := range other {
-		if u[uid] == nil {
-			u[uid] = make(DevicePublicKeys)
-		}
-		for key := range keys {
-			if u[uid][key] {
-				panic(fmt.Sprintf(
-					"uid=%s key=%s exists in both",
-					uid, key))
-			}
-			u[uid][key] = true
-		}
-	}
-	return u
-}
-
 // userDevicePrivateKeys is a map from users to that user's set of
 // device private keys.
 type userDevicePrivateKeys map[keybase1.UID]map[kbfscrypto.CryptPrivateKey]bool

--- a/go/kbfs/kbfssync/leveled_mutex_test.go
+++ b/go/kbfs/kbfssync/leveled_mutex_test.go
@@ -29,7 +29,6 @@ const (
 	testFirst  testMutexLevel = 1
 	testSecond testMutexLevel = 2
 	testThird  testMutexLevel = 3
-	testFourth testMutexLevel = 4
 )
 
 func (o testMutexLevel) String() string {

--- a/go/kbfs/kbfssync/semaphore_test.go
+++ b/go/kbfs/kbfssync/semaphore_test.go
@@ -255,10 +255,10 @@ func TestAcquirePanic(t *testing.T) {
 	s := NewSemaphore()
 	ctx := context.Background()
 	require.Panics(t, func() {
-		s.Acquire(ctx, 0)
+		_, _ = s.Acquire(ctx, 0)
 	})
 	require.Panics(t, func() {
-		s.Acquire(ctx, -1)
+		_, _ = s.Acquire(ctx, -1)
 	})
 }
 

--- a/go/kbfs/kbfstool/common.go
+++ b/go/kbfs/kbfstool/common.go
@@ -7,9 +7,6 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/keybase/client/go/kbfs/idutil"
-	"github.com/keybase/client/go/kbfs/tlf"
 )
 
 const (
@@ -17,8 +14,6 @@ const (
 	publicName  = "public"
 	privateName = "private"
 )
-
-const publicSuffix = tlf.ReaderSep + idutil.PublicUIDName
 
 func byteCountStr(n int) string {
 	if n == 1 {

--- a/go/kbfs/kbfstool/md_common.go
+++ b/go/kbfs/kbfstool/md_common.go
@@ -17,7 +17,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-var mdInputRegexp = regexp.MustCompile("^(.+?)(?::(.*?))?(?:\\^(.*?)(?:-(.*?))?)?$")
+var mdInputRegexp = regexp.MustCompile(
+	`^(.+?)(?::(.*?))?(?:\^(.*?)(?:-(.*?))?)?$`)
 
 func mdSplitInput(input string) (
 	tlfStr, branchStr, startStr, stopStr string, err error) {

--- a/go/kbfs/kbpagesconfig/main.go
+++ b/go/kbfs/kbpagesconfig/main.go
@@ -27,5 +27,5 @@ func main() {
 		upgradeCmd,
 	}
 
-	app.Run(os.Args)
+	_ = app.Run(os.Args)
 }

--- a/go/kbfs/kbpagesd/main.go
+++ b/go/kbfs/kbpagesd/main.go
@@ -188,5 +188,5 @@ func main() {
 		StatsReporter:    statsReporter,
 	}
 
-	libpages.ListenAndServe(ctx, serverConfig, kbConfig)
+	_ = libpages.ListenAndServe(ctx, serverConfig, kbConfig)
 }

--- a/go/kbfs/libcontext/delayed_cancellation_test.go
+++ b/go/kbfs/libcontext/delayed_cancellation_test.go
@@ -134,7 +134,10 @@ func TestDelayedCancellationEnabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := makeContextWithDelayedCancellation(t)
-	EnableDelayedCancellationWithGracePeriod(ctx, 50*time.Millisecond)
+	err := EnableDelayedCancellationWithGracePeriod(ctx, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("EnableDelayedCancellationWithGracePeriod failed: %v", err)
+	}
 
 	cancel()
 

--- a/go/kbfs/libdokan/dir.go
+++ b/go/kbfs/libdokan/dir.go
@@ -308,13 +308,16 @@ func (d *Dir) open(ctx context.Context, oc *openContext, path []string) (dokan.F
 		if c := lowerTranslateCandidate(oc, path[0]); c != "" {
 			var hit string
 			var nhits int
-			d.FindFiles(ctx, nil, c, func(ns *dokan.NamedStat) error {
+			err := d.FindFiles(ctx, nil, c, func(ns *dokan.NamedStat) error {
 				if strings.ToLower(ns.Name) == c {
 					hit = ns.Name
 					nhits++
 				}
 				return nil
 			})
+			if err != nil {
+				return nil, 0, dokan.ErrObjectNameNotFound
+			}
 			if nhits != 1 {
 				return nil, 0, dokan.ErrObjectNameNotFound
 			}
@@ -364,7 +367,7 @@ func (d *Dir) open(ctx context.Context, oc *openContext, path []string) (dokan.F
 
 		if newNode != nil {
 			d.folder.mu.Lock()
-			f, _ := d.folder.nodes[newNode.GetID()]
+			f := d.folder.nodes[newNode.GetID()]
 			d.folder.mu.Unlock()
 			// Symlinks don't have stored nodes, so they are impossible here.
 			switch x := f.(type) {

--- a/go/kbfs/libdokan/folderlist.go
+++ b/go/kbfs/libdokan/folderlist.go
@@ -63,13 +63,6 @@ func (fl *FolderList) reportErr(ctx context.Context,
 
 }
 
-func (fl *FolderList) addToFavorite(ctx context.Context, h *tlfhandle.Handle) (err error) {
-	cName := h.GetCanonicalName()
-	fl.fs.vlog.CLogf(ctx, libkb.VLog1, "adding %s to favorites", cName)
-	return fl.fs.config.KBFSOps().AddFavorite(ctx, h.ToFavorite(),
-		h.FavoriteData())
-}
-
 // open tries to open the correct thing. Following aliases and deferring to
 // Dir.open as necessary.
 func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) (f dokan.File, cst dokan.CreateStatus, err error) {

--- a/go/kbfs/libdokan/fs.go
+++ b/go/kbfs/libdokan/fs.go
@@ -264,10 +264,6 @@ func (oc *openContext) returnFileNoCleanup(f dokan.File) (
 	return f, dokan.ExistingFile, nil
 }
 
-func (oc *openContext) mayNotBeDirectory() bool {
-	return oc.CreateOptions&dokan.FileNonDirectoryFile != 0
-}
-
 func newSyntheticOpenContext() *openContext {
 	var oc openContext
 	oc.CreateData = &dokan.CreateData{}

--- a/go/kbfs/libdokan/fso.go
+++ b/go/kbfs/libdokan/fso.go
@@ -15,7 +15,7 @@ import (
 
 // FSO is a common type for file system objects, i.e. Dirs or Files.
 type FSO struct {
-	refcount refcount
+	refcount refcount // nolint -- it's used when embedded in dir/file
 	name     string
 	folder   *Folder
 	node     libkbfs.Node

--- a/go/kbfs/libdokan/mounter.go
+++ b/go/kbfs/libdokan/mounter.go
@@ -31,7 +31,11 @@ func (m *mounter) Mount() (err error) {
 		// Sleep two times 800ms, 1.6s, 3.2s, ...
 		time.Sleep(time.Duration(i) * 100 * time.Millisecond)
 		if m.options.ForceMount {
-			dokan.Unmount(m.options.DokanConfig.Path)
+			err = dokan.Unmount(m.options.DokanConfig.Path)
+			if err != nil {
+				m.log.Errorf("Failed to unmount dokan filesystem (i=%d): %v",
+					i, err)
+			}
 			time.Sleep(time.Duration(i) * 100 * time.Millisecond)
 		}
 	}

--- a/go/kbfs/libdokan/start.go
+++ b/go/kbfs/libdokan/start.go
@@ -140,7 +140,10 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 			// Abort on error if we were force mounting, otherwise continue.
 			if options.ForceMount {
 				// Cleanup when exiting in case the mount got dirty.
-				mi.Done()
+				err = mi.Done()
+				if err != nil {
+					log.CErrorf(ctx, "Couldn't mount: %v", err)
+				}
 				return libfs.MountError(err.Error())
 			}
 			log.CErrorf(ctx, "Running KBFS without a filesystem mount due to: %v", err)

--- a/go/kbfs/libfs/file_info.go
+++ b/go/kbfs/libfs/file_info.go
@@ -223,5 +223,5 @@ func EnableFastMode(ctx context.Context) context.Context {
 // info. All *FS created under this ctx will also be in fast mode.
 func IsFastModeEnabled(ctx context.Context) bool {
 	v, ok := ctx.Value(ctxFastModeKey{}).(bool)
-	return ok && v == true
+	return ok && v
 }

--- a/go/kbfs/libfs/fs.go
+++ b/go/kbfs/libfs/fs.go
@@ -66,7 +66,7 @@ type fsInner struct {
 	// this is a naive append without and path clean.
 	lockNamespace []byte
 
-	eventsLock sync.RWMutex
+	eventsLock sync.RWMutex // nolint
 	events     map[chan<- FSEvent]bool
 }
 

--- a/go/kbfs/libfs/fs_test.go
+++ b/go/kbfs/libfs/fs_test.go
@@ -217,7 +217,7 @@ func TestRecreateAndExcl(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to create it with EXCL, and fail.
-	f, err = fs.OpenFile("foo", os.O_CREATE|os.O_EXCL, 0600)
+	_, err = fs.OpenFile("foo", os.O_CREATE|os.O_EXCL, 0600)
 	require.NotNil(t, err)
 
 	// Creating a different file exclusively should work though.
@@ -501,19 +501,19 @@ func TestSymlink(t *testing.T) {
 	require.NoError(t, err)
 	err = fs.Symlink("y", "x")
 	require.NoError(t, err)
-	bar, err = fs.Open("x")
+	_, err = fs.Open("x")
 	require.NotNil(t, err)
 
 	t.Log("Symlink that tries to break chroot")
 	err = fs.Symlink("../../a", "a/breakout")
 	require.NoError(t, err)
-	bar, err = fs.Open("a/breakout")
+	_, err = fs.Open("a/breakout")
 	require.NotNil(t, err)
 
 	t.Log("Symlink to absolute path")
 	err = fs.Symlink("/etc/passwd", "absolute")
 	require.NoError(t, err)
-	bar, err = fs.Open("absolute")
+	_, err = fs.Open("absolute")
 	require.NotNil(t, err)
 
 	t.Log("Readlink")

--- a/go/kbfs/libfs/httprootfs.go
+++ b/go/kbfs/libfs/httprootfs.go
@@ -41,9 +41,7 @@ func (hrfs httpRootFileSystem) Open(filename string) (entry http.File, err error
 		}
 	}()
 
-	if strings.HasPrefix(filename, "/") {
-		filename = filename[1:]
-	}
+	filename = strings.TrimPrefix(filename, "/")
 
 	f, err := hrfs.rfs.Open(filename)
 	if err != nil {

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -143,7 +143,12 @@ func (f *Folder) forgetNode(node libkbfs.Node) {
 	delete(f.nodes, node.GetID())
 	if len(f.nodes) == 0 {
 		ctx := libcontext.BackgroundContextWithCancellationDelayer()
-		defer libcontext.CleanupCancellationDelayer(ctx)
+		defer func() {
+			err := libcontext.CleanupCancellationDelayer(ctx)
+			if err != nil {
+				f.fs.log.CDebugf(ctx, "Coudn't cleanup ctx: %+v", err)
+			}
+		}()
 		f.unsetFolderBranch(ctx)
 		f.list.forgetFolder(string(f.name()))
 	}

--- a/go/kbfs/libfuse/external_file.go
+++ b/go/kbfs/libfuse/external_file.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func newExternalFile(path string) (*SpecialReadFile, error) {
+func newExternalFile(path string) (*SpecialReadFile, error) { // nolint
 	if path == "" {
 		return nil, fmt.Errorf("No path for external file")
 	}

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -37,9 +36,6 @@ type FolderList struct {
 
 	mu      sync.Mutex
 	folders map[string]*TLF
-
-	muRecentlyRemoved sync.RWMutex
-	recentlyRemoved   map[tlf.CanonicalName]bool
 }
 
 var _ fs.NodeAccesser = (*FolderList)(nil)
@@ -90,47 +86,6 @@ func (fl *FolderList) processError(ctx context.Context,
 	// important ones.
 	fl.fs.errLog.CDebugf(ctx, err.Error())
 	return filterError(err)
-}
-
-func (fl *FolderList) addToRecentlyRemoved(name tlf.CanonicalName) {
-	func() {
-		fl.muRecentlyRemoved.Lock()
-		defer fl.muRecentlyRemoved.Unlock()
-		if fl.recentlyRemoved == nil {
-			fl.recentlyRemoved = make(map[tlf.CanonicalName]bool)
-		}
-		fl.recentlyRemoved[name] = true
-	}()
-	fl.fs.execAfterDelay(time.Second, func() {
-		fl.muRecentlyRemoved.Lock()
-		defer fl.muRecentlyRemoved.Unlock()
-		delete(fl.recentlyRemoved, name)
-	})
-}
-
-func (fl *FolderList) isRecentlyRemoved(name tlf.CanonicalName) bool {
-	fl.muRecentlyRemoved.RLock()
-	defer fl.muRecentlyRemoved.RUnlock()
-	return fl.recentlyRemoved != nil && fl.recentlyRemoved[name]
-}
-
-func (fl *FolderList) addToFavorite(ctx context.Context, h *tlfhandle.Handle) (err error) {
-	cName := h.GetCanonicalName()
-
-	// `rmdir` command on macOS does a lookup after removing the dir. if the
-	// TLF is recently removed, it's likely that this lookup is issued by the
-	// `rmdir` command, and the lookup should not result in adding the dir to
-	// favorites.
-	if !fl.isRecentlyRemoved(cName) {
-		fl.fs.vlog.CLogf(ctx, libkb.VLog1, "adding %s to favorites", cName)
-		fl.fs.config.KBFSOps().AddFavorite(ctx, h.ToFavorite(), h.FavoriteData())
-	} else {
-		fl.fs.vlog.CLogf(
-			ctx, libkb.VLog1, "recently removed; will skip adding %s to "+
-				"favorites and return ENOENT", cName)
-		return fuse.ENOENT
-	}
-	return nil
 }
 
 // PathType returns PathType for this folder
@@ -323,11 +278,6 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 	default:
 		return err
 	}
-}
-
-func isTlfNameNotCanonical(err error) bool {
-	_, ok := errors.Cause(err).(idutil.TlfNameNotCanonical)
-	return ok
 }
 
 func (fl *FolderList) updateTlfName(ctx context.Context, oldName string,

--- a/go/kbfs/libfuse/fs.go
+++ b/go/kbfs/libfuse/fs.go
@@ -177,10 +177,16 @@ type tcpKeepAliveListener struct {
 func (tkal tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 	tc, err := tkal.AcceptTCP()
 	if err != nil {
-		return
+		return nil, err
 	}
-	tc.SetKeepAlive(true)
-	tc.SetKeepAlivePeriod(3 * time.Minute)
+	err = tc.SetKeepAlive(true)
+	if err != nil {
+		return nil, err
+	}
+	err = tc.SetKeepAlivePeriod(3 * time.Minute)
+	if err != nil {
+		return nil, err
+	}
 	return tc, nil
 }
 

--- a/go/kbfs/libfuse/fs_default.go
+++ b/go/kbfs/libfuse/fs_default.go
@@ -14,7 +14,7 @@ import (
 
 var platformRootDirs []fuse.Dirent
 
-func shouldAppendPlatformRootDirs(parmas PlatformParams) bool {
+func shouldAppendPlatformRootDirs(parmas PlatformParams) bool { // nolint
 	return false
 }
 

--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/kbfs/test/clocktest"
 	"github.com/keybase/client/go/kbfs/tlf"
-	"github.com/keybase/client/go/kbfs/tlfhandle"
 	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -164,9 +163,14 @@ func timeEqualFuzzy(a, b time.Time, skew time.Duration) bool {
 	return !a.Before(b1) && !a.After(b2)
 }
 
+func testCleanupDelayer(ctx context.Context, t *testing.T) {
+	err := libcontext.CleanupCancellationDelayer(ctx)
+	require.NoError(t, err)
+}
+
 func TestStatRoot(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -184,7 +188,7 @@ func TestStatRoot(t *testing.T) {
 
 func TestStatPrivate(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -202,7 +206,7 @@ func TestStatPrivate(t *testing.T) {
 
 func TestStatPublic(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -220,7 +224,7 @@ func TestStatPublic(t *testing.T) {
 
 func TestStatMyFolder(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -244,7 +248,7 @@ func TestStatMyFolder(t *testing.T) {
 
 func TestStatNonexistentFolder(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -258,7 +262,7 @@ func TestStatNonexistentFolder(t *testing.T) {
 
 func TestStatAlias(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -286,9 +290,9 @@ func TestStatAlias(t *testing.T) {
 // calls (regression test for KBFS-531).
 func TestStatAliasCausesNoIdentifies(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
-	defer config.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
@@ -315,9 +319,9 @@ func TestStatAliasCausesNoIdentifies(t *testing.T) {
 
 func TestStatInvalidAliasFails(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
-	defer config.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
@@ -333,7 +337,7 @@ func TestStatInvalidAliasFails(t *testing.T) {
 
 func TestRemoveAlias(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -349,7 +353,7 @@ func TestRemoveAlias(t *testing.T) {
 
 func TestStatMyPublic(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -373,7 +377,7 @@ func TestStatMyPublic(t *testing.T) {
 
 func TestReaddirRoot(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -389,7 +393,7 @@ func TestReaddirRoot(t *testing.T) {
 
 func TestReaddirPrivate(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -398,7 +402,7 @@ func TestReaddirPrivate(t *testing.T) {
 
 	{
 		ctx := libcontext.BackgroundContextWithCancellationDelayer()
-		defer libcontext.CleanupCancellationDelayer(ctx)
+		defer testCleanupDelayer(ctx, t)
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
@@ -414,7 +418,7 @@ func TestReaddirPrivate(t *testing.T) {
 
 func TestReaddirPrivateDeleteAndReaddFavorite(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, fs, cancelFn := makeFS(ctx, t, config)
@@ -429,7 +433,7 @@ func TestReaddirPrivateDeleteAndReaddFavorite(t *testing.T) {
 
 	{
 		ctx := libcontext.BackgroundContextWithCancellationDelayer()
-		defer libcontext.CleanupCancellationDelayer(ctx)
+		defer testCleanupDelayer(ctx, t)
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
@@ -458,7 +462,7 @@ func TestReaddirPrivateDeleteAndReaddFavorite(t *testing.T) {
 
 func TestReaddirPublic(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "janedoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -467,7 +471,7 @@ func TestReaddirPublic(t *testing.T) {
 
 	{
 		ctx := libcontext.BackgroundContextWithCancellationDelayer()
-		defer libcontext.CleanupCancellationDelayer(ctx)
+		defer testCleanupDelayer(ctx, t)
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
@@ -497,7 +501,7 @@ func (k kbserviceBrokenIdentify) Identify(
 // respects errors from Open, not from ReadDirAll.)
 func TestReaddirPublicFailedIdentifyViaOSCall(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "u1", "u2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
 	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
@@ -542,7 +546,7 @@ func TestReaddirPublicFailedIdentifyViaOSCall(t *testing.T) {
 
 func TestReaddirMyFolderEmpty(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -556,7 +560,7 @@ func syncAll(t *testing.T, tlf string, ty tlf.Type, fs *FS) {
 	// golang doesn't let us sync on a directory handle, so if we need
 	// to sync all without a file, go through libkbfs directly.
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	root := libkbfs.GetRootNodeOrBust(ctx, t, fs.config, tlf, ty)
 	err := fs.config.KBFSOps().SyncAll(ctx, root.GetFolderBranch())
 	if err != nil {
@@ -585,7 +589,7 @@ func syncFilename(t *testing.T, name string) {
 
 func TestReaddirMyFolderWithFiles(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -636,7 +640,7 @@ func testOneCreateThenRead(t *testing.T, p string) {
 
 func TestCreateThenRead(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -653,7 +657,7 @@ func TestCreateThenRead(t *testing.T) {
 // with).
 func TestMultipleCreateThenRead(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -668,7 +672,7 @@ func TestMultipleCreateThenRead(t *testing.T) {
 
 func TestReadUnflushed(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -698,7 +702,7 @@ func TestReadUnflushed(t *testing.T) {
 
 func TestMountAgain(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
@@ -733,7 +737,7 @@ func TestMountAgain(t *testing.T) {
 
 func TestCreateExecutable(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -756,7 +760,7 @@ func TestCreateExecutable(t *testing.T) {
 
 func TestMkdir(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -778,7 +782,7 @@ func TestMkdir(t *testing.T) {
 
 func TestMkdirAndCreateDeep(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	const input = "hello, world\n"
@@ -822,7 +826,7 @@ func TestMkdirAndCreateDeep(t *testing.T) {
 
 func TestSymlink(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
@@ -856,7 +860,7 @@ func TestSymlink(t *testing.T) {
 
 func TestRename(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -896,7 +900,7 @@ func TestRename(t *testing.T) {
 
 func TestRenameOverwrite(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -938,7 +942,7 @@ func TestRenameOverwrite(t *testing.T) {
 
 func TestRenameCrossDir(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -983,7 +987,7 @@ func TestRenameCrossDir(t *testing.T) {
 
 func TestRenameCrossFolder(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1039,7 +1043,7 @@ func TestRenameCrossFolder(t *testing.T) {
 
 func TestWriteThenRename(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1094,7 +1098,7 @@ func TestWriteThenRename(t *testing.T) {
 
 func TestWriteThenRenameCrossDir(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1155,7 +1159,7 @@ func TestWriteThenRenameCrossDir(t *testing.T) {
 
 func TestRemoveFile(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1182,7 +1186,7 @@ func TestRemoveFile(t *testing.T) {
 
 func TestRemoveTLF(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "pikachu")
 	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
@@ -1236,7 +1240,7 @@ func TestRemoveTLF(t *testing.T) {
 
 func TestRemoveDir(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1261,7 +1265,7 @@ func TestRemoveDir(t *testing.T) {
 
 func TestRemoveDirNotEmpty(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1290,7 +1294,7 @@ func TestRemoveDirNotEmpty(t *testing.T) {
 
 func TestRemoveFileWhileOpenSetEx(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1335,7 +1339,7 @@ func TestRemoveFileWhileOpenSetEx(t *testing.T) {
 
 func TestRemoveFileWhileOpenWritingInTLFRoot(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1371,7 +1375,7 @@ func TestRemoveFileWhileOpenWritingInTLFRoot(t *testing.T) {
 
 func TestRemoveFileWhileOpenWritingInSubDir(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1412,7 +1416,7 @@ func TestRemoveFileWhileOpenWritingInSubDir(t *testing.T) {
 
 func TestRenameOverFileWhileOpenWritingInDifferentDir(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1464,7 +1468,7 @@ func TestRenameOverFileWhileOpenWritingInDifferentDir(t *testing.T) {
 
 func TestRenameOverFileWhileOpenWritingInSameSubDir(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1516,7 +1520,7 @@ func TestRenameOverFileWhileOpenWritingInSameSubDir(t *testing.T) {
 
 func TestRemoveFileWhileOpenReading(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1561,7 +1565,7 @@ func TestRemoveFileWhileOpenReading(t *testing.T) {
 
 func TestRemoveFileWhileOpenReadingAcrossMounts(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
@@ -1624,7 +1628,7 @@ func TestRemoveFileWhileOpenReadingAcrossMounts(t *testing.T) {
 
 func TestRenameOverFileWhileOpenReadingAcrossMounts(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
@@ -1705,7 +1709,7 @@ func TestRenameOverFileWhileOpenReadingAcrossMounts(t *testing.T) {
 
 func TestTruncateGrow(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1744,7 +1748,7 @@ func TestTruncateGrow(t *testing.T) {
 
 func TestTruncateShrink(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1783,7 +1787,7 @@ func TestTruncateShrink(t *testing.T) {
 
 func TestChmodExec(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1812,7 +1816,7 @@ func TestChmodExec(t *testing.T) {
 
 func TestChmodNonExec(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1841,7 +1845,7 @@ func TestChmodNonExec(t *testing.T) {
 
 func TestChownFileIgnored(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1878,7 +1882,7 @@ func TestChownFileIgnored(t *testing.T) {
 
 func TestChmodDirIgnored(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1898,7 +1902,7 @@ func TestChmodDirIgnored(t *testing.T) {
 
 func TestChownDirIgnored(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1933,7 +1937,7 @@ func TestChownDirIgnored(t *testing.T) {
 
 func TestSetattrFileMtime(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -1966,9 +1970,9 @@ func TestSetattrFileMtime(t *testing.T) {
 
 func TestSetattrFileMtimeAfterWrite(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
-	defer config.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()
 	defer cancelFn()
@@ -1983,7 +1987,7 @@ func TestSetattrFileMtimeAfterWrite(t *testing.T) {
 	const input2 = "second round of content"
 	{
 		ctx := libcontext.BackgroundContextWithCancellationDelayer()
-		defer libcontext.CleanupCancellationDelayer(ctx)
+		defer testCleanupDelayer(ctx, t)
 
 		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", tlf.Private)
 
@@ -2013,11 +2017,12 @@ func TestSetattrFileMtimeAfterWrite(t *testing.T) {
 	if g, e := fi.ModTime(), mtime; !libfs.TimeEqual(g, e) {
 		t.Errorf("wrong mtime: %v !~= %v", g, e)
 	}
+	syncFilename(t, p)
 }
 
 func TestSetattrFileMtimeNow(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -2059,7 +2064,7 @@ func TestSetattrFileMtimeNow(t *testing.T) {
 
 func TestSetattrDirMtime(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -2090,7 +2095,7 @@ func TestSetattrDirMtime(t *testing.T) {
 
 func TestSetattrDirMtimeNow(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -2130,7 +2135,7 @@ func TestSetattrDirMtimeNow(t *testing.T) {
 
 func TestFsync(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -2159,7 +2164,7 @@ func TestFsync(t *testing.T) {
 
 func TestReaddirMyPublic(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -2184,7 +2189,7 @@ func TestReaddirMyPublic(t *testing.T) {
 
 func TestReaddirOtherFolderAsReader(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
@@ -2214,11 +2219,11 @@ func TestReaddirOtherFolderAsReader(t *testing.T) {
 
 func TestReaddirMissingOtherFolderAsReader(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
-	defer config.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
-	defer c2.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
 	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
@@ -2230,11 +2235,11 @@ func TestReaddirMissingOtherFolderAsReader(t *testing.T) {
 
 func TestLookupMissingOtherFolderAsReader(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
-	defer config.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
-	defer c2.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
 	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
@@ -2247,7 +2252,7 @@ func TestLookupMissingOtherFolderAsReader(t *testing.T) {
 
 func TestStatOtherFolder(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
@@ -2282,7 +2287,7 @@ func TestStatOtherFolder(t *testing.T) {
 
 func TestStatOtherFolderFirstUse(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	// This triggers a different error than with the warmup.
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
@@ -2305,7 +2310,7 @@ func TestStatOtherFolderFirstUse(t *testing.T) {
 
 func TestStatOtherFolderPublic(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
@@ -2341,7 +2346,7 @@ func TestStatOtherFolderPublic(t *testing.T) {
 
 func TestReadPublicFile(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	const input = "hello, world\n"
@@ -2375,7 +2380,7 @@ func TestReadPublicFile(t *testing.T) {
 
 func TestReaddirOtherFolderPublicAsAnyone(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
@@ -2405,11 +2410,11 @@ func TestReaddirOtherFolderPublicAsAnyone(t *testing.T) {
 
 func TestReaddirMissingFolderPublicAsAnyone(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
-	defer config.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	c2 := libkbfs.ConfigAsUser(config, "wsmith")
-	defer c2.Shutdown(ctx)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, c2)
 	mnt, _, cancelFn := makeFS(ctx, t, c2)
 	defer mnt.Close()
 	defer cancelFn()
@@ -2421,7 +2426,7 @@ func TestReaddirMissingFolderPublicAsAnyone(t *testing.T) {
 
 func TestReaddirOtherFolderAsAnyone(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	func() {
@@ -2456,7 +2461,7 @@ func TestReaddirOtherFolderAsAnyone(t *testing.T) {
 
 func syncFolderToServerHelper(t *testing.T, tlf string, ty tlf.Type, fs *FS) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	root := libkbfs.GetRootNodeOrBust(ctx, t, fs.config, tlf, ty)
 	err := fs.config.KBFSOps().SyncFromServer(ctx,
 		root.GetFolderBranch(), nil)
@@ -2476,7 +2481,7 @@ func syncPublicFolderToServer(t *testing.T, name string, fs *FS) {
 
 func TestInvalidateDataOnWrite(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
@@ -2540,7 +2545,7 @@ func TestInvalidateDataOnWrite(t *testing.T) {
 
 func TestInvalidatePublicDataOnWrite(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
@@ -2604,7 +2609,7 @@ func TestInvalidatePublicDataOnWrite(t *testing.T) {
 
 func TestInvalidateDataOnTruncate(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
@@ -2668,7 +2673,7 @@ func TestInvalidateDataOnTruncate(t *testing.T) {
 
 func TestInvalidateDataOnLocalWrite(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, fs, cancelFn := makeFS(ctx, t, config)
@@ -2706,7 +2711,7 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 	const input2 = "second round of content"
 	{
 		ctx := libcontext.BackgroundContextWithCancellationDelayer()
-		defer libcontext.CleanupCancellationDelayer(ctx)
+		defer testCleanupDelayer(ctx, t)
 
 		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", tlf.Private)
 		ops := config.KBFSOps()
@@ -2737,7 +2742,7 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 
 func TestInvalidateEntryOnDelete(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt1, _, cancelFn1 := makeFS(ctx, t, config)
@@ -2809,7 +2814,7 @@ func testForErrorText(t *testing.T, path string, expectedErr error,
 
 func TestErrorFile(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	config.SetReporter(libkbfs.NewReporterSimple(config.Clock(), 0))
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
@@ -2839,27 +2844,9 @@ func TestErrorFile(t *testing.T) {
 		expectedErr, "dir")
 }
 
-type testMountObserver struct {
-	c chan<- struct{}
-}
-
-func (t *testMountObserver) LocalChange(ctx context.Context, node libkbfs.Node,
-	write libkbfs.WriteRange) {
-	// ignore
-}
-
-func (t *testMountObserver) BatchChanges(ctx context.Context,
-	changes []libkbfs.NodeChange) {
-	t.c <- struct{}{}
-}
-
-func (t *testMountObserver) TlfHandleChange(ctx context.Context,
-	newHandle *tlfhandle.Handle) {
-}
-
 func TestInvalidateAcrossMounts(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
@@ -2953,7 +2940,7 @@ func TestInvalidateAcrossMounts(t *testing.T) {
 
 func TestInvalidateAppendAcrossMounts(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
@@ -2993,7 +2980,7 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 	const input2 = "input round two"
 	{
 		ctx := libcontext.BackgroundContextWithCancellationDelayer()
-		defer libcontext.CleanupCancellationDelayer(ctx)
+		defer testCleanupDelayer(ctx, t)
 
 		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config1, "user1,user2", tlf.Private)
 
@@ -3025,7 +3012,7 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 
 func TestInvalidateRenameToUncachedDir(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
@@ -3109,7 +3096,7 @@ func TestInvalidateRenameToUncachedDir(t *testing.T) {
 
 func TestStatusFile(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	mnt, _, cancelFn := makeFS(ctx, t, config)
@@ -3135,7 +3122,8 @@ func TestStatusFile(t *testing.T) {
 		require.NoError(t, err)
 
 		var bufStatus libkbfs.FolderBranchStatus
-		json.Unmarshal(buf, &bufStatus)
+		err = json.Unmarshal(buf, &bufStatus)
+		require.NoError(t, err)
 
 		// Use a fuzzy check on the timestamps, since it could include
 		// monotonic clock stuff.
@@ -3154,7 +3142,7 @@ func TestStatusFile(t *testing.T) {
 // TODO: remove once we have automatic conflict resolution tests
 func TestUnstageFile(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
@@ -3269,7 +3257,7 @@ func TestUnstageFile(t *testing.T) {
 
 func TestSimpleCRNoConflict(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
@@ -3447,7 +3435,7 @@ func TestSimpleCRNoConflict(t *testing.T) {
 
 func TestSimpleCRConflictOnOpenFiles(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
@@ -3648,7 +3636,7 @@ func TestSimpleCRConflictOnOpenFiles(t *testing.T) {
 
 func TestSimpleCRConflictOnOpenMergedFile(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	mnt1, fs1, cancelFn1 := makeFS(ctx, t, config1)
@@ -3850,7 +3838,7 @@ func TestSimpleCRConflictOnOpenMergedFile(t *testing.T) {
 
 func TestKbfsFileInfo(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
 	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
@@ -3898,7 +3886,7 @@ func TestKbfsFileInfo(t *testing.T) {
 
 func TestDirSyncAll(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
 	mnt1, _, cancelFn1 := makeFS(ctx, t, config1)
 	defer mnt1.Close()
@@ -3945,7 +3933,7 @@ func TestDirSyncAll(t *testing.T) {
 // Regression test for KBFS-2853.
 func TestInodes(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
-	defer libcontext.CleanupCancellationDelayer(ctx)
+	defer testCleanupDelayer(ctx, t)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	mnt, _, cancelFn := makeFS(ctx, t, config)
 	defer mnt.Close()

--- a/go/kbfs/libfuse/mounter.go
+++ b/go/kbfs/libfuse/mounter.go
@@ -50,7 +50,7 @@ func (m *mounter) Mount() (err error) {
 
 	// Mount failed, let's try to unmount and then try mounting again, even
 	// if unmounting errors here.
-	m.Unmount()
+	_ = m.Unmount()
 
 	// In case we are on darwin, ask the installer to reinstall the mount dir
 	// and try again as the last resort. This specifically fixes a situation
@@ -146,18 +146,17 @@ func (m *mounter) Unmount() (err error) {
 	return
 }
 
-func (m *mounter) DeleteMountdirIfEmpty() (err error) {
+func (m *mounter) DeleteMountdirIfEmpty() {
 	m.log.Info("Deleting mountdir")
 	// os.Remove refuses to delete non-empty directories.
-	err = os.Remove(m.options.MountPoint)
+	err := os.Remove(m.options.MountPoint)
 	if err != nil {
 		m.log.Errorf("Unable to delete mountdir: %s", err)
 	}
-	return
 }
 
 // volumeName returns the first word of the directory (base) name
-func volumeName(dir string) (string, error) {
+func volumeName(dir string) (string, error) { // nolint
 	volName := path.Base(dir)
 	if volName == "." || volName == "/" {
 		err := fmt.Errorf("Bad volume name: %v", volName)

--- a/go/kbfs/libfuse/start.go
+++ b/go/kbfs/libfuse/start.go
@@ -163,7 +163,7 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 			// Abort on error if we were force mounting, otherwise continue.
 			if options.MountErrorIsFatal {
 				// If we exit we might want to clean a mount behind us.
-				mi.Done()
+				_ = mi.Done()
 				return libfs.MountError(err.Error())
 			}
 		}

--- a/go/kbfs/libfuse/symlink.go
+++ b/go/kbfs/libfuse/symlink.go
@@ -48,7 +48,11 @@ func (s *Symlink) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 		return err
 	}
 
-	s.parent.folder.fillAttrWithUIDAndWritePerm(ctx, s.parent.node, &de, a)
+	err = s.parent.folder.fillAttrWithUIDAndWritePerm(
+		ctx, s.parent.node, &de, a)
+	if err != nil {
+		return err
+	}
 	a.Mode = os.ModeSymlink | a.Mode | 0500
 	a.Inode = s.inode
 	return nil

--- a/go/kbfs/libgit/autogit_manager.go
+++ b/go/kbfs/libgit/autogit_manager.go
@@ -21,9 +21,6 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
-type getNewConfigFn func(context.Context) (
-	context.Context, libkbfs.Config, string, error)
-
 const (
 	// Debug tag ID for an individual autogit operation
 	ctxAutogitOpID = "AGID"
@@ -213,7 +210,8 @@ func (am *AutogitManager) registerRepoNode(
 	err := am.config.Notifier().RegisterForChanges(
 		[]data.FolderBranch{fb}, am)
 	if err != nil {
-		am.log.CWarningf(nil, "Error registering %s: +%v", fb.Tlf, err)
+		am.log.CWarningf(
+			context.TODO(), "Error registering %s: +%v", fb.Tlf, err)
 		return
 	}
 	am.registeredFBs[fb] = true
@@ -264,7 +262,8 @@ func (am *AutogitManager) clearInvalidatedBrowsers(
 		for _, nodeID := range repoNodeIDs {
 			if rootNodeID == nodeID {
 				am.log.CDebugf(
-					nil, "Invalidating browser for %s", v.repoFS.Root())
+					context.TODO(), "Invalidating browser for %s",
+					v.repoFS.Root())
 				am.browserCache.Remove(k)
 				break
 			}
@@ -283,7 +282,10 @@ func (am *AutogitManager) BatchChanges(
 		go func() {
 			ctx := libkbfs.CtxWithRandomIDReplayable(
 				context.Background(), ctxAutogitIDKey, ctxAutogitOpID, am.log)
-			am.config.KBFSOps().InvalidateNodeAndChildren(ctx, node)
+			err := am.config.KBFSOps().InvalidateNodeAndChildren(ctx, node)
+			if err != nil {
+				am.log.CDebugf(ctx, "Error invalidating children: %+v", err)
+			}
 		}()
 	}
 }

--- a/go/kbfs/libgit/autogit_node_wrappers.go
+++ b/go/kbfs/libgit/autogit_node_wrappers.go
@@ -82,7 +82,7 @@ func (rfn repoFileNode) GetFile(ctx context.Context) billy.File {
 	_, b, err := rfn.am.GetBrowserForRepo(
 		ctx, rfn.gitRootFS, rfn.repo, rfn.branch, rfn.subdir)
 	if err != nil {
-		rfn.am.log.CDebugf(nil, "Error getting browser: %+v", err)
+		rfn.am.log.CDebugf(ctx, "Error getting browser: %+v", err)
 		return nil
 	}
 
@@ -109,7 +109,7 @@ func (rcn repoCommitNode) GetFile(ctx context.Context) billy.File {
 		ctx, ctxAutogitIDKey, ctxAutogitOpID, rcn.am.log)
 	_, b, err := rcn.am.GetBrowserForRepo(ctx, rcn.gitRootFS, rcn.repo, "", "")
 	if err != nil {
-		rcn.am.log.CDebugf(nil, "Error getting browser: %+v", err)
+		rcn.am.log.CDebugf(ctx, "Error getting browser: %+v", err)
 		return nil
 	}
 
@@ -282,7 +282,7 @@ var _ libkbfs.Node = (*autogitRootNode)(nil)
 
 func (arn autogitRootNode) GetFS(ctx context.Context) billy.Filesystem {
 	ctx = libkbfs.CtxWithRandomIDReplayable(
-		context.Background(), ctxAutogitIDKey, ctxAutogitOpID, arn.am.log)
+		ctx, ctxAutogitIDKey, ctxAutogitOpID, arn.am.log)
 	return &wrappedRepoList{arn.fs.WithContext(ctx)}
 }
 
@@ -358,11 +358,11 @@ func (rn *rootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
 	rn.lock.RLock()
 	defer rn.lock.RUnlock()
 	if rn.fs == nil {
-		rn.am.log.CDebugf(nil, "FS not available on WrapChild")
+		rn.am.log.CDebugf(context.TODO(), "FS not available on WrapChild")
 		return child
 	}
 
-	rn.am.log.CDebugf(nil, "Making autogit root node")
+	rn.am.log.CDebugf(context.TODO(), "Making autogit root node")
 	return &autogitRootNode{
 		Node: &libkbfs.ReadonlyNode{Node: child},
 		am:   rn.am,

--- a/go/kbfs/libgit/id.go
+++ b/go/kbfs/libgit/id.go
@@ -16,9 +16,6 @@ import (
 const (
 	// idByteLen is the number of bytes in a git repo ID.
 	idByteLen = 16
-	// idStringLen is the number of characters in the string
-	// representation of a git repo ID.
-	idStringLen = 2 * idByteLen
 
 	idSuffix = 0x2c
 )

--- a/go/kbfs/libgit/init.go
+++ b/go/kbfs/libgit/init.go
@@ -107,7 +107,10 @@ func Init(ctx context.Context, gitKBFSParams libkbfs.InitParams,
 	// quota.
 	config.SetDefaultBlockType(keybase1.BlockType_GIT)
 
-	config.MakeDiskBlockCacheIfNotExists()
+	err = config.MakeDiskBlockCacheIfNotExists()
+	if err != nil {
+		log.CDebugf(ctx, "Couldn't initialize disk cache: %+v", err)
+	}
 
 	return ctx, config, nil
 }

--- a/go/kbfs/libgit/repo.go
+++ b/go/kbfs/libgit/repo.go
@@ -985,8 +985,7 @@ func GCRepo(
 	if err != nil {
 		return err
 	}
-	var fsStorage storage.Storer
-	fsStorage = fsStorer
+	var fsStorage storage.Storer = fsStorer
 
 	// Wrap it in an on-demand storer, so we don't try to read all the
 	// objects of big repos into memory at once.

--- a/go/kbfs/libgit/repo_test.go
+++ b/go/kbfs/libgit/repo_test.go
@@ -94,7 +94,8 @@ func TestGetOrCreateRepoAndID(t *testing.T) {
 	_, _, err = GetOrCreateRepoAndID(ctx, config, h, "repo(4)", "")
 	require.IsType(t, libkb.InvalidRepoNameError{}, errors.Cause(err))
 
-	fs.SyncAll()
+	err = fs.SyncAll()
+	require.NoError(t, err)
 
 	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
 		ctx, h, data.MasterBranch)

--- a/go/kbfs/libgit/rpc.go
+++ b/go/kbfs/libgit/rpc.go
@@ -95,6 +95,20 @@ func (rh *RPCHandler) waitForJournal(
 	return nil
 }
 
+func (rh *RPCHandler) doShutdown(
+	ctx context.Context, gitConfig libkbfs.Config, tempDir string) {
+	shutdownErr := gitConfig.Shutdown(ctx)
+	if shutdownErr != nil {
+		rh.log.CDebugf(
+			ctx, "Error shutting down git: %+v\n", shutdownErr)
+	}
+	rmErr := os.RemoveAll(tempDir)
+	if rmErr != nil {
+		rh.log.CDebugf(
+			ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
+	}
+}
+
 func (rh *RPCHandler) getHandleAndConfig(
 	ctx context.Context, folder keybase1.FolderHandle) (
 	newCtx context.Context, gitConfigRet libkbfs.Config,
@@ -106,12 +120,7 @@ func (rh *RPCHandler) getHandleAndConfig(
 	}
 	defer func() {
 		if err != nil {
-			gitConfig.Shutdown(ctx)
-			rmErr := os.RemoveAll(tempDir)
-			if rmErr != nil {
-				rh.log.CDebugf(
-					ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
-			}
+			rh.doShutdown(ctx, gitConfig, tempDir)
 		}
 	}()
 
@@ -145,14 +154,7 @@ func (rh *RPCHandler) CreateRepo(
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		rmErr := os.RemoveAll(tempDir)
-		if rmErr != nil {
-			rh.log.CDebugf(
-				ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
-		}
-	}()
-	defer gitConfig.Shutdown(ctx)
+	defer rh.doShutdown(ctx, gitConfig, tempDir)
 
 	ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, kbfsRepoDir)
 	gitID, err := CreateRepoAndID(ctx, gitConfig, tlfHandle, string(arg.Name))
@@ -179,18 +181,13 @@ func (rh *RPCHandler) scheduleCleaning(folder keybase1.FolderHandle) {
 		ctx, gitConfig, tlfHandle, tempDir, err := rh.getHandleAndConfig(
 			ctx, folder)
 		if err != nil {
-			log.CDebugf(nil, "Couldn't init for scheduled cleaning of %s: %+v",
+			log.CDebugf(
+				context.TODO(),
+				"Couldn't init for scheduled cleaning of %s: %+v",
 				folder.Name, err)
 			return
 		}
-		defer func() {
-			rmErr := os.RemoveAll(tempDir)
-			if rmErr != nil {
-				rh.log.CDebugf(
-					ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
-			}
-		}()
-		defer gitConfig.Shutdown(ctx)
+		defer rh.doShutdown(ctx, gitConfig, tempDir)
 
 		log.CDebugf(ctx, "Starting a scheduled repo clean for folder %s",
 			tlfHandle.GetCanonicalPath())
@@ -226,14 +223,7 @@ func (rh *RPCHandler) DeleteRepo(
 	if err != nil {
 		return err
 	}
-	defer func() {
-		rmErr := os.RemoveAll(tempDir)
-		if rmErr != nil {
-			rh.log.CDebugf(
-				ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
-		}
-	}()
-	defer gitConfig.Shutdown(ctx)
+	defer rh.doShutdown(ctx, gitConfig, tempDir)
 
 	err = DeleteRepo(ctx, gitConfig, tlfHandle, string(arg.Name))
 	if err != nil {
@@ -265,14 +255,7 @@ func (rh *RPCHandler) Gc(
 	if err != nil {
 		return err
 	}
-	defer func() {
-		rmErr := os.RemoveAll(tempDir)
-		if rmErr != nil {
-			rh.log.CDebugf(
-				ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
-		}
-	}()
-	defer gitConfig.Shutdown(ctx)
+	defer rh.doShutdown(ctx, gitConfig, tempDir)
 
 	gco := GCOptions{
 		MaxLooseRefs:         arg.Options.MaxLooseRefs,
@@ -305,14 +288,7 @@ func (rh *RPCHandler) RenameRepo(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	defer func() {
-		rmErr := os.RemoveAll(tempDir)
-		if rmErr != nil {
-			rh.log.CDebugf(
-				ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
-		}
-	}()
-	defer gitConfig.Shutdown(ctx)
+	defer rh.doShutdown(ctx, gitConfig, tempDir)
 
 	err = RenameRepo(ctx, gitConfig, tlfHandle, oldName, newName)
 	if err != nil {

--- a/go/kbfs/libhttpserver/server.go
+++ b/go/kbfs/libhttpserver/server.go
@@ -59,7 +59,7 @@ func (s *Server) NewToken() (token string, err error) {
 
 func (s *Server) handleInvalidToken(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusForbidden)
-	io.WriteString(w, `
+	_, _ = io.WriteString(w, `
     <html>
         <head>
             <title>KBFS HTTP Token Invalid</title>

--- a/go/kbfs/libhttpserver/server_test.go
+++ b/go/kbfs/libhttpserver/server_test.go
@@ -30,7 +30,7 @@ func makeTestKBFSConfig(t *testing.T) (
 	require.NoError(t, err)
 	defer func() {
 		if err != nil {
-			ioutil.RemoveAll(tempdir)
+			_ = ioutil.RemoveAll(tempdir)
 		}
 	}()
 	err = cfg.EnableDiskLimiter(tempdir)

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -27,8 +27,6 @@ import (
 const (
 	defaultBlockRetrievalWorkerQueueSize int = 100
 	defaultPrefetchWorkerQueueSize       int = 2
-	minimalBlockRetrievalWorkerQueueSize int = 2
-	minimalPrefetchWorkerQueueSize       int = 1
 	testBlockRetrievalWorkerQueueSize    int = 5
 	testPrefetchWorkerQueueSize          int = 1
 	defaultOnDemandRequestPriority       int = 1 << 30

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -32,8 +32,6 @@ import (
 )
 
 const (
-	// 10 GB maximum storage by default
-	defaultDiskBlockCacheMaxBytes   uint64 = 10 * (1 << 30)
 	defaultBlockCacheTableSize      int    = 50 * opt.MiB
 	defaultBlockCacheBlockSize      int    = 4 * opt.MiB
 	defaultBlockCacheCapacity       int    = 8 * opt.MiB

--- a/go/kbfs/libkbfs/disk_block_metadata_store.go
+++ b/go/kbfs/libkbfs/disk_block_metadata_store.go
@@ -15,13 +15,6 @@ import (
 	ldberrors "github.com/syndtr/goleveldb/leveldb/errors"
 )
 
-type blockMetadataType int
-
-const (
-	_ blockMetadataType = iota
-	blockMetadataXattr
-)
-
 // XattrType represents the xattr type.
 type XattrType int
 

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -40,10 +40,6 @@ const (
 	numPointersPerGCThresholdDefault = 100
 	// The most revisions to consider for each QR run.
 	numMaxRevisionsPerQR = 100
-
-	// The delay to wait for before trying a failed block deletion
-	// again. Used by enqueueBlocksToDeleteAfterShortDelay().
-	deleteBlocksRetryDelay = 10 * time.Millisecond
 )
 
 type blockDeleteType int
@@ -147,11 +143,11 @@ func newFolderBlockManager(
 	}
 
 	fbm := &folderBlockManager{
-		appStateUpdater:           appStateUpdater,
-		config:                    config,
-		log:                       log,
-		shutdownChan:              make(chan struct{}),
-		id:                        fb.Tlf,
+		appStateUpdater: appStateUpdater,
+		config:          config,
+		log:             log,
+		shutdownChan:    make(chan struct{}),
+		id:              fb.Tlf,
 		numPointersPerGCThreshold: numPointersPerGCThresholdDefault,
 		archiveChan:               make(chan ReadOnlyRootMetadata, 500),
 		archivePauseChan:          make(chan (<-chan struct{})),

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -64,25 +64,20 @@ const (
 type branchType int
 
 const (
-	standard       branchType = iota // an online, read-write branch
-	archive                          // an online, read-only branch
-	offline                          // an offline, read-write branch
-	archiveOffline                   // an offline, read-only branch
-	conflict                         // a cleared, local conflict branch
+	standard branchType = iota // an online, read-write branch
+	archive                    // an online, read-only branch
+	offline                    // an offline, read-write branch
+	conflict                   // a cleared, local conflict branch
 )
 
 // Constants used in this file.  TODO: Make these configurable?
 const (
 	// Maximum number of blocks that can be sent in parallel
 	maxParallelBlockPuts = 100
-	// Maximum number of blocks that can be fetched in parallel
-	maxParallelBlockGets = 10
 	// Max response size for a single DynamoDB query is 1MB.
 	maxMDsAtATime = 10
 	// Cap the number of times we retry after a recoverable error
 	maxRetriesOnRecoverableErrors = 10
-	// When the number of dirty bytes exceeds this level, force a sync.
-	dirtyBytesThreshold = maxParallelBlockPuts * data.MaxBlockSizeBytesDefault
 	// If it's been more than this long since our last update, check
 	// the current head before downloading all of the new revisions.
 	fastForwardTimeThresh = 15 * time.Minute

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -26,7 +26,6 @@ import (
 const (
 	updatePointerPrefetchPriority int           = 1
 	prefetchTimeout               time.Duration = 24 * time.Hour
-	maxNumPrefetches              int           = 10000
 	overallSyncStatusInterval     time.Duration = 1 * time.Second
 )
 

--- a/go/kbfs/libkbfs/reporter_kbpki.go
+++ b/go/kbfs/libkbfs/reporter_kbpki.go
@@ -26,7 +26,6 @@ const (
 	// error param keys
 	errorParamTlf                 = "tlf"
 	errorParamMode                = "mode"
-	errorParamFeature             = "feature"
 	errorParamUsername            = "username"
 	errorParamRekeySelf           = "rekeyself"
 	errorParamUsageBytes          = "usageBytes"
@@ -41,39 +40,10 @@ const (
 	// error operation modes
 	errorModeRead  = "read"
 	errorModeWrite = "write"
-
-	// features that aren't ready yet
-	errorFeatureFileLimit = "2gbFileLimit"
-	errorFeatureDirLimit  = "512kbDirLimit"
 )
 
 const connectionStatusConnected keybase1.FSStatusCode = keybase1.FSStatusCode_START
 const connectionStatusDisconnected keybase1.FSStatusCode = keybase1.FSStatusCode_ERROR
-
-// noErrorNames are lookup names that should not result in an error
-// notification.  These should all be reserved or illegal Keybase
-// usernames that will never be associated with a real account.
-var noErrorNames = map[string]bool{
-	"objects":        true, // git shells
-	"gemfile":        true, // rvm
-	"Gemfile":        true, // rvm
-	"devfs":          true, // lsof?  KBFS-823
-	"_mtn":           true, // emacs on Linux
-	"_MTN":           true, // emacs on Linux
-	"docker-machine": true, // docker shell stuff
-	"HEAD":           true, // git shell
-	"Keybase.app":    true, // some OSX mount thing
-	"DCIM":           true, // looking for digital pic folder
-	"Thumbs.db":      true, // Windows mounts
-	"config":         true, // Windows, possibly 7-Zip?
-	"m4root":         true, // OS X, iMovie?
-	"BDMV":           true, // OS X, iMovie?
-	"node_modules":   true, // Some npm shell configuration
-	"folder":         true, // Dolphin?  keybase/client#7304
-	"avchd":          true, // Sony PlayMemories Home, keybase/client#6801
-	"avchd_bk":       true, // Sony PlayMemories Home, keybase/client#6801
-	"sony":           true, // Sony PlayMemories Home, keybase/client#6801
-}
 
 // ReporterKBPKI implements the Notify function of the Reporter
 // interface in addition to embedding ReporterSimple for error

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -104,9 +104,6 @@ const (
 	// unsquashed MD bytes in the journal that will trigger an
 	// automatic branch conversion (and subsequent resolution).
 	ForcedBranchSquashBytesThresholdDefault = uint64(25 << 20) // 25 MB
-	// Maximum number of blocks to delete from the local saved block
-	// journal at a time while holding the lock.
-	maxSavedBlockRemovalsAtATime = uint64(500)
 	// How often to check the server for conflicts while flushing.
 	tlfJournalServerMDCheckInterval = 1 * time.Minute
 

--- a/go/kbfs/libkbfs/unflushed_path_cache.go
+++ b/go/kbfs/libkbfs/unflushed_path_cache.go
@@ -5,7 +5,6 @@
 package libkbfs
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -61,8 +60,6 @@ type unflushedPathCache struct {
 	chainsPopulator chainsPathPopulator
 	queue           []upcQueuedOp
 }
-
-var errUPCNotInitialized = errors.New("The unflushed path cache is not yet initialized")
 
 // getUnflushedPaths returns a copy of the unflushed path cache if it
 // has been initialized, otherwise nil.  It must be called under the

--- a/go/kbfs/libkey/key_server_local_test.go
+++ b/go/kbfs/libkey/key_server_local_test.go
@@ -145,11 +145,11 @@ func TestKeyServerLocalTLFCryptKeyServerHalves(t *testing.T) {
 
 	require.Equal(t, serverHalf3, half3)
 
-	half4, err := ko1.GetTLFCryptKeyServerHalf(ctx, serverHalfID4, publicKey1)
+	_, err = ko1.GetTLFCryptKeyServerHalf(ctx, serverHalfID4, publicKey1)
 	require.IsType(t, kbfsmd.ServerErrorUnauthorized{}, err)
 
 	// try to get uid2's key now as uid2
-	half4, err = ko2.GetTLFCryptKeyServerHalf(ctx, serverHalfID4, publicKey2)
+	half4, err := ko2.GetTLFCryptKeyServerHalf(ctx, serverHalfID4, publicKey2)
 	require.NoError(t, err)
 
 	require.Equal(t, serverHalf4, half4)

--- a/go/kbfs/redirector/main.go
+++ b/go/kbfs/redirector/main.go
@@ -423,7 +423,7 @@ func main() {
 	restartChan := make(chan os.Signal, 1)
 	signal.Notify(restartChan, syscall.SIGUSR1)
 	go func() {
-		_ = <-restartChan
+		<-restartChan
 
 		fmt.Printf("Relaunching after an upgrade\n")
 
@@ -460,5 +460,5 @@ func main() {
 			return context.Background()
 		},
 	})
-	srv.Serve(r)
+	_ = srv.Serve(r)
 }

--- a/go/kbfs/test/dsl_test.go
+++ b/go/kbfs/test/dsl_test.go
@@ -842,14 +842,6 @@ func disableUpdates() fileOp {
 	}, IsInit, "disableUpdates()"}
 }
 
-func stallDelegateOnMDPut() fileOp {
-	return fileOp{func(c *ctx) error {
-		// TODO: Allow test to pass in a more precise maxStalls limit.
-		c.staller.StallMDOp(libkbfs.StallableMDPut, 100, true)
-		return nil
-	}, Defaults, "stallDelegateOnMDPut()"}
-}
-
 func stallOnMDPut() fileOp {
 	return fileOp{func(c *ctx) error {
 		// TODO: Allow test to pass in a more precise maxStalls limit.
@@ -865,26 +857,11 @@ func waitForStalledMDPut() fileOp {
 	}, IsInit, "waitForStalledMDPut()"}
 }
 
-func unstallOneMDPut() fileOp {
-	return fileOp{func(c *ctx) error {
-		c.staller.UnstallOneMDOp(libkbfs.StallableMDPut)
-		return nil
-	}, IsInit, "unstallOneMDPut()"}
-}
-
 func undoStallOnMDPut() fileOp {
 	return fileOp{func(c *ctx) error {
 		c.staller.UndoStallMDOp(libkbfs.StallableMDPut)
 		return nil
 	}, IsInit, "undoStallOnMDPut()"}
-}
-
-func stallDelegateOnMDGetForTLF() fileOp {
-	return fileOp{func(c *ctx) error {
-		// TODO: Allow test to pass in a more precise maxStalls limit.
-		c.staller.StallMDOp(libkbfs.StallableMDGetForTLF, 100, true)
-		return nil
-	}, Defaults, "stallDelegateOnMDGetForTLF()"}
 }
 
 func stallOnMDGetForTLF() fileOp {
@@ -916,14 +893,6 @@ func undoStallOnMDGetForTLF() fileOp {
 	}, IsInit, "undoStallOnMDGetForTLF()"}
 }
 
-func stallDelegateOnMDGetRange() fileOp {
-	return fileOp{func(c *ctx) error {
-		// TODO: Allow test to pass in a more precise maxStalls limit.
-		c.staller.StallMDOp(libkbfs.StallableMDGetRange, 100, true)
-		return nil
-	}, Defaults, "stallDelegateOnMDGetRange()"}
-}
-
 func stallOnMDGetRange() fileOp {
 	return fileOp{func(c *ctx) error {
 		// TODO: Allow test to pass in a more precise maxStalls limit.
@@ -951,14 +920,6 @@ func undoStallOnMDGetRange() fileOp {
 		c.staller.UndoStallMDOp(libkbfs.StallableMDGetRange)
 		return nil
 	}, IsInit, "undoStallOnMDGetRange()"}
-}
-
-func stallDelegateOnMDResolveBranch() fileOp {
-	return fileOp{func(c *ctx) error {
-		// TODO: Allow test to pass in a more precise maxStalls limit.
-		c.staller.StallMDOp(libkbfs.StallableMDResolveBranch, 100, true)
-		return nil
-	}, Defaults, "stallDelegateOnMDResolveBranch()"}
 }
 
 func stallOnMDResolveBranch() fileOp {
@@ -1144,12 +1105,6 @@ func checkDirtyPaths(expectedPaths []string) fileOp {
 		}
 		return nil
 	}, IsInit, fmt.Sprintf("checkDirtyPaths(%s)", expectedPaths)}
-}
-
-func disablePrefetch() fileOp {
-	return fileOp{func(c *ctx) error {
-		return c.engine.TogglePrefetch(c.user, false)
-	}, IsInit, "disablePrefetch()"}
 }
 
 func forceConflict() fileOp {

--- a/go/kbfs/test/engine_fs_test.go
+++ b/go/kbfs/test/engine_fs_test.go
@@ -31,21 +31,22 @@ import (
 	"golang.org/x/net/context"
 )
 
-type createUserFn func(tb testing.TB, ith int, config *libkbfs.ConfigLocal,
+type createUserFn func( // nolint
+	tb testing.TB, ith int, config *libkbfs.ConfigLocal,
 	opTimeout time.Duration) *fsUser
 
-type fsEngine struct {
+type fsEngine struct { // nolint
 	name       string
 	tb         testing.TB
 	createUser createUserFn
 	// journal directory
 	journalDir string
 }
-type fsNode struct {
+type fsNode struct { // nolint
 	path string
 }
 
-type fsUser struct {
+type fsUser struct { // nolint
 	mntDir   string
 	username kbname.NormalizedUsername
 	config   *libkbfs.ConfigLocal
@@ -76,7 +77,7 @@ func (e *fsEngine) GetUID(user User) keybase1.UID {
 	return session.UID
 }
 
-func buildRootPath(u *fsUser, t tlf.Type) string {
+func buildRootPath(u *fsUser, t tlf.Type) string { // nolint
 	var path string
 	switch t {
 	case tlf.Public:
@@ -93,7 +94,7 @@ func buildRootPath(u *fsUser, t tlf.Type) string {
 	return path
 }
 
-func buildTlfPath(u *fsUser, tlfName string, t tlf.Type) string {
+func buildTlfPath(u *fsUser, tlfName string, t tlf.Type) string { // nolint
 	return filepath.Join(buildRootPath(u, t), tlfName)
 }
 
@@ -641,7 +642,7 @@ func (*fsEngine) GetMtime(u User, file Node) (mtime time.Time, err error) {
 	return fi.ModTime(), err
 }
 
-type prevRevisions struct {
+type prevRevisions struct { // nolint
 	PrevRevisions data.PrevRevisions
 }
 
@@ -686,7 +687,7 @@ func (e *fsEngine) SyncAll(
 	return u.config.KBFSOps().SyncAll(ctx, dir.GetFolderBranch())
 }
 
-func fiTypeString(fi os.FileInfo) string {
+func fiTypeString(fi os.FileInfo) string { // nolint
 	m := fi.Mode()
 	switch {
 	case m&os.ModeSymlink != 0:
@@ -763,8 +764,11 @@ func (e *fsEngine) InitTest(ver kbfsmd.MetadataVer,
 			if err != nil {
 				panic(fmt.Sprintf("No disk limiter for %d: %+v", i, err))
 			}
-			c.EnableJournaling(context.Background(),
+			err = c.EnableJournaling(context.Background(),
 				journalRoot, libkbfs.TLFJournalBackgroundWorkEnabled)
+			if err != nil {
+				panic(fmt.Sprintf("Couldn't enable journaling: %+v", err))
+			}
 			jManager, err := libkbfs.GetJournalManager(c)
 			if err != nil {
 				panic(fmt.Sprintf("No journal server for %d: %+v", i, err))
@@ -785,7 +789,7 @@ func (e *fsEngine) InitTest(ver kbfsmd.MetadataVer,
 	return res
 }
 
-func nameToUID(t testing.TB, config libkbfs.Config) keybase1.UID {
+func nameToUID(t testing.TB, config libkbfs.Config) keybase1.UID { // nolint
 	session, err := config.KBPKI().GetCurrentSession(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/go/kbfs/test/engine_libkbfs.go
+++ b/go/kbfs/test/engine_libkbfs.go
@@ -99,8 +99,11 @@ func (k *LibKBFS) InitTest(ver kbfsmd.MetadataVer,
 			if err != nil {
 				panic(fmt.Sprintf("No disk limiter for %s: %+v", name, err))
 			}
-			config.EnableJournaling(context.Background(), journalRoot,
+			err = config.EnableJournaling(context.Background(), journalRoot,
 				libkbfs.TLFJournalBackgroundWorkEnabled)
+			if err != nil {
+				panic(fmt.Sprintf("Couldn't enable journaling: %+v", err))
+			}
 			jManager, err := libkbfs.GetJournalManager(config)
 			if err != nil {
 				panic(fmt.Sprintf("No journal server for %s: %+v", name, err))
@@ -183,7 +186,10 @@ func (k *LibKBFS) newContext(u User) (context.Context, context.CancelFunc) {
 	}
 
 	return ctx, func() {
-		libcontext.CleanupCancellationDelayer(ctx)
+		err := libcontext.CleanupCancellationDelayer(ctx)
+		if err != nil {
+			panic(err)
+		}
 		cancel()
 	}
 }

--- a/go/kbfs/test/journal_test.go
+++ b/go/kbfs/test/journal_test.go
@@ -515,7 +515,6 @@ func TestJournalCoalescingCreatesPlusMultiCR(t *testing.T) {
 	busyWork2 := []fileOp{noSyncEnd()}
 	listing := m{}
 	iters := libkbfs.ForcedBranchSquashRevThreshold + 1
-	unflushedPaths := []string{"/keybase/private/alice,bob/a"}
 	targetMtime := time.Now().Add(1 * time.Minute)
 	for i := 0; i < iters; i++ {
 		name := fmt.Sprintf("%d", i)
@@ -525,8 +524,6 @@ func TestJournalCoalescingCreatesPlusMultiCR(t *testing.T) {
 		busyWork2 = append(busyWork2, rename("a/"+name+".tmp", "a/"+name))
 
 		listing["^"+name+"$"] = "FILE"
-		unflushedPaths = append(
-			unflushedPaths, "/keybase/private/alice,bob/a/"+name)
 	}
 	busyWork = append(busyWork, setmtime("a", targetMtime))
 

--- a/go/kbfs/tlf/id.go
+++ b/go/kbfs/tlf/id.go
@@ -19,9 +19,6 @@ import (
 const (
 	// idByteLen is the number of bytes in a top-level folder ID
 	idByteLen = 16
-	// idStringLen is the number of characters in the string
-	// representation of a top-level folder ID
-	idStringLen = 2 * idByteLen
 	// idSuffix is the last byte of a private top-level folder ID
 	idSuffix = 0x16
 	// pubIDSuffix is the last byte of a public top-level folder ID

--- a/go/kbfs/tlfhandle/handle_test.go
+++ b/go/kbfs/tlfhandle/handle_test.go
@@ -428,7 +428,7 @@ func TestHandleConflictInfo(t *testing.T) {
 		Actual:   &info,
 	}
 	info.Date = 101
-	h, err = h.WithUpdatedConflictInfo(codec, &info)
+	_, err = h.WithUpdatedConflictInfo(codec, &info)
 	require.Equal(t, expectedErr, err)
 	// A strange error message, since the difference doesn't show
 	// up in the strings. Oh, well.
@@ -938,7 +938,7 @@ func TestHandleResolvesTo(t *testing.T) {
 	h1, err = h1.WithUpdatedConflictInfo(codec, &info)
 	require.NoError(t, err)
 
-	resolvesTo, partialResolvedH1, err =
+	resolvesTo, _, err =
 		h1.ResolvesTo(ctx, codec, kbpki, ConstIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
@@ -962,7 +962,7 @@ func TestHandleResolvesTo(t *testing.T) {
 	}
 	h1.SetFinalizedInfo(&info)
 
-	resolvesTo, partialResolvedH1, err =
+	resolvesTo, _, err =
 		h1.ResolvesTo(ctx, codec, kbpki, ConstIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
@@ -980,7 +980,7 @@ func TestHandleResolvesTo(t *testing.T) {
 	h2, err = h2.WithUpdatedConflictInfo(codec, &info)
 	require.NoError(t, err)
 
-	resolvesTo, partialResolvedH1, err =
+	_, _, err =
 		h1.ResolvesTo(ctx, codec, kbpki, ConstIDGetter{idPub}, nil, *h2)
 	require.Error(t, err)
 
@@ -1021,8 +1021,6 @@ func TestHandleResolvesTo(t *testing.T) {
 
 	// Test negative resolution cases.
 
-	name1 = "u1,u2@twitter,u5#u3,u4@twitter"
-
 	for _, tc := range []testCase{
 		{"u1,u5#u3,u4@twitter", "u2"},
 		{"u1,u2,u5#u3,u4@twitter", "u1"},
@@ -1034,7 +1032,7 @@ func TestHandleResolvesTo(t *testing.T) {
 
 		daemon.AddNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
-		resolvesTo, partialResolvedH1, err =
+		resolvesTo, _, err =
 			h1.ResolvesTo(ctx, codec, kbpki, ConstIDGetter{id}, nil, *h2)
 		require.NoError(t, err)
 		assert.False(t, resolvesTo, tc.name2)

--- a/go/kbfs/tlfhandle/identify_util.go
+++ b/go/kbfs/tlfhandle/identify_util.go
@@ -290,15 +290,6 @@ func identifyUser(ctx context.Context, nug idutil.NormalizedUsernameGetter,
 	return nil
 }
 
-// identifyUserToChan calls identifyUser and plugs the result into the error channnel.
-func identifyUserToChan(
-	ctx context.Context, nug idutil.NormalizedUsernameGetter,
-	identifier idutil.Identifier, name kbname.NormalizedUsername,
-	id keybase1.UserOrTeamID, t tlf.Type, offline keybase1.OfflineAvailability,
-	errChan chan error) {
-	errChan <- identifyUser(ctx, nug, identifier, name, id, t, offline)
-}
-
 // identifyUsers identifies the users in the given maps.
 func identifyUsers(
 	ctx context.Context, nug idutil.NormalizedUsernameGetter,


### PR DESCRIPTION
I think this takes care of all the non-libkbfs lint (and a few minor libkbfs lint things as well) caught by the golangci-lint tool.  Once I get through the libkbfs lint, I'll add these checks to CI.

cc: @keybase/hotpotatosquad 

Issue: HOTPOT-398