### PR TITLE
Tweaks to imp tofu search

### DIFF
--- a/go/protocol/keybase1/contacts.go
+++ b/go/protocol/keybase1/contacts.go
@@ -68,7 +68,6 @@ type ProcessedContact struct {
 	Assertion    string           `codec:"assertion" json:"assertion"`
 	DisplayName  string           `codec:"displayName" json:"displayName"`
 	DisplayLabel string           `codec:"displayLabel" json:"displayLabel"`
-	RawScore     float64          `codec:"rawScore" json:"rawScore"`
 }
 
 func (o ProcessedContact) DeepCopy() ProcessedContact {
@@ -84,7 +83,6 @@ func (o ProcessedContact) DeepCopy() ProcessedContact {
 		Assertion:    o.Assertion,
 		DisplayName:  o.DisplayName,
 		DisplayLabel: o.DisplayLabel,
-		RawScore:     o.RawScore,
 	}
 }
 

--- a/go/protocol/keybase1/usersearch.go
+++ b/go/protocol/keybase1/usersearch.go
@@ -100,6 +100,7 @@ type APIUserSearchResult struct {
 	Service         *APIUserServiceResult                                 `codec:"service,omitempty" json:"service,omitempty"`
 	Contact         *ProcessedContact                                     `codec:"contact,omitempty" json:"contact,omitempty"`
 	ServicesSummary map[APIUserServiceIDWithContact]APIUserServiceSummary `codec:"servicesSummary" json:"services_summary"`
+	RawScore        float64                                               `codec:"rawScore" json:"rawScore"`
 }
 
 func (o APIUserSearchResult) DeepCopy() APIUserSearchResult {
@@ -138,6 +139,7 @@ func (o APIUserSearchResult) DeepCopy() APIUserSearchResult {
 			}
 			return ret
 		})(o.ServicesSummary),
+		RawScore: o.RawScore,
 	}
 }
 

--- a/protocol/avdl/keybase1/contacts.avdl
+++ b/protocol/avdl/keybase1/contacts.avdl
@@ -47,9 +47,6 @@ protocol contacts {
         // Keybase full name, and contact name, depending what's available.
         string displayName;
         string displayLabel;
-
-        // If ProcessedContact comes from people search, raw match score goes here.
-        double rawScore;
     }
 
     // lookupContactList transforms contact list (where every contact may have

--- a/protocol/avdl/keybase1/usersearch.avdl
+++ b/protocol/avdl/keybase1/usersearch.avdl
@@ -46,6 +46,7 @@ protocol userSearch {
         union { null, ProcessedContact } contact;
         @jsonkey("services_summary")
         map<APIUserServiceIDWithContact, APIUserServiceSummary> servicesSummary;
+        double rawScore;
     }
 
     array<APIUserSearchResult> userSearch(int sessionID, string query, string service, int maxResults, boolean includeServicesSummary, boolean includeContacts);

--- a/protocol/json/keybase1/contacts.json
+++ b/protocol/json/keybase1/contacts.json
@@ -95,10 +95,6 @@
         {
           "type": "string",
           "name": "displayLabel"
-        },
-        {
-          "type": "double",
-          "name": "rawScore"
         }
       ]
     }

--- a/protocol/json/keybase1/usersearch.json
+++ b/protocol/json/keybase1/usersearch.json
@@ -156,6 +156,10 @@
           },
           "name": "servicesSummary",
           "jsonkey": "services_summary"
+        },
+        {
+          "type": "double",
+          "name": "rawScore"
         }
       ]
     },

--- a/shared/constants/team-building.tsx
+++ b/shared/constants/team-building.tsx
@@ -79,7 +79,7 @@ const parseRawResultToUser = (
       id: result.contact.assertion,
       label: result.contact.displayLabel,
       prettyName: result.contact.displayName,
-      serviceMap,
+      serviceMap: {...serviceMap, keybase: result.contact.username},
     }
   } else if (result.service) {
     if (result.service.serviceName !== service) {

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2234,7 +2234,7 @@ export enum UserOrTeamResult {
 }
 export type APIRes = {readonly status: String; readonly body: String; readonly httpStatus: Int; readonly appStatus: String}
 export type APIUserKeybaseResult = {readonly username: String; readonly uid: UID; readonly pictureUrl?: String | null; readonly fullName?: String | null; readonly rawScore: Double; readonly stellar?: String | null; readonly isFollowee: Boolean}
-export type APIUserSearchResult = {readonly score: Double; readonly keybase?: APIUserKeybaseResult | null; readonly service?: APIUserServiceResult | null; readonly contact?: ProcessedContact | null; readonly servicesSummary: {[key: string]: APIUserServiceSummary}}
+export type APIUserSearchResult = {readonly score: Double; readonly keybase?: APIUserKeybaseResult | null; readonly service?: APIUserServiceResult | null; readonly contact?: ProcessedContact | null; readonly servicesSummary: {[key: string]: APIUserServiceSummary}; readonly rawScore: Double}
 export type APIUserServiceIDWithContact = String
 export type APIUserServiceResult = {readonly serviceName: APIUserServiceIDWithContact; readonly username: String; readonly pictureUrl: String; readonly bio: String; readonly location: String; readonly fullName: String; readonly confirmed?: Boolean | null}
 export type APIUserServiceSummary = {readonly serviceName: APIUserServiceIDWithContact; readonly username: String}
@@ -2514,7 +2514,7 @@ export type ProblemSetDevices = {readonly problemSet: ProblemSet; readonly devic
 export type ProblemTLF = {readonly tlf: TLF; readonly score: Int; readonly solution_kids?: Array<KID> | null}
 export type Process = {readonly pid: String; readonly command: String; readonly fileDescriptors?: Array<FileDescriptor> | null}
 export type ProcessRuntimeStats = {readonly type: ProcessType; readonly cpu: String; readonly resident: String; readonly virt: String; readonly free: String; readonly goheap: String; readonly goheapsys: String; readonly goreleased: String; readonly cpuSeverity: StatsSeverityLevel; readonly residentSeverity: StatsSeverityLevel}
-export type ProcessedContact = {readonly contactIndex: Int; readonly contactName: String; readonly component: ContactComponent; readonly resolved: Boolean; readonly uid: UID; readonly username: String; readonly fullName: String; readonly following: Boolean; readonly assertion: String; readonly displayName: String; readonly displayLabel: String; readonly rawScore: Double}
+export type ProcessedContact = {readonly contactIndex: Int; readonly contactName: String; readonly component: ContactComponent; readonly resolved: Boolean; readonly uid: UID; readonly username: String; readonly fullName: String; readonly following: Boolean; readonly assertion: String; readonly displayName: String; readonly displayLabel: String}
 export type ProfileTeamLoadRes = {readonly loadTimeNsec: Long}
 export type Progress = Int
 export type ProofResult = {readonly state: ProofState; readonly status: ProofStatus; readonly desc: String}


### PR DESCRIPTION
- Do a better job of merging two lists - keybase users and contacts - also deduplicate by username if a search yields both a keybase user and a contact resolving to same user. The precedence of which is displayed depends on the "search score", so how well the query matched an entry.
- Change frontend search rows to be aware of resolved contacts and display coloured username (blue or green depending on a follow)
- Plumb matched value from contact entry to the frontend label for resolved user. So if someone's searching for phone number and we matched a contact that resolves to a user, make sure that phone number appears as label in the results.