### PR TITLE
right click a message for popup

### DIFF
--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -335,6 +335,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
           },
           'WrapperMessage-hoverBox'
         ),
+        onContextMenu: this.props.toggleShowingMenu,
         onMouseOver: this._onMouseOver,
         // attach popups to the message itself
         ref: this.props.setAttachmentRef,


### PR DESCRIPTION
The "..." menu on desktop on chat messages has a couple problems:

1. The dots are small and subtle, and just generally hard to notice or discern a purpose for.
2. The dots are extremely far away from the text in a lot of cases. They also suffer from the same problem as the reacji bar. The bar is so far away from the content, and it is so easy to move focus to other messages by accident, that my eyes are constantly darting back and forth to make sure I am still selecting the right message. If my task is to copy text (almost impossible by highlighting it), or reply, I want that to be something I don't need a lot of precision for.

This patch adds the ability to right click anywhere on a message and have the bar pop up. It still pops up on the right hand side, but it comes with some advantages:

1. I can hit anywhere in the message to toggle the menu.
2. The menu is locked in position once its up, I don't need to worry about the message focus bouncing around.

cc @malgorithms @cecileboucheron @adamjspooner 