### PR TITLE
Make the profile page work with a banner

### DIFF
--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as Constants from '../../constants/tracker2'
+import {getShowAirdropBanner} from '../../constants/wallets'
 import * as Container from '../../util/container'
 import * as ProfileGen from '../../actions/profile-gen'
 import * as Tracker2Gen from '../../actions/tracker2-gen'
@@ -13,7 +14,7 @@ import {RouteProps} from '../../route-tree/render-route'
 import ProfileSearch from '../search/bar'
 import flags from '../../util/feature-flags'
 
-type OwnProps = RouteProps< { username: string } >
+type OwnProps = RouteProps<{username: string}>
 
 const headerBackgroundColorType = (state, followThem) => {
   if (['broken', 'error'].includes(state)) {
@@ -37,6 +38,7 @@ const mapStateToProps = (state, ownProps) => {
     (!notAUser && state.tracker2.usernameToDetails.getIn([username, 'followersCount'])) || 0
   const followingCount =
     (!notAUser && state.tracker2.usernameToDetails.getIn([username, 'followingCount'])) || 0
+  const showAirdropBanner = getShowAirdropBanner(state)
 
   return {
     _assertions: d.assertions,
@@ -49,6 +51,7 @@ const mapStateToProps = (state, ownProps) => {
     followingCount,
     guiID: d.guiID,
     reason: d.reason,
+    showAirdropBanner,
     state: d.state,
     userIsYou,
     username,
@@ -112,6 +115,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     onReload,
     onSearch: dispatchProps.onSearch,
     reason: stateProps.reason,
+    showAirdropBanner: stateProps.showAirdropBanner,
     state: stateProps.state,
     suggestionKeys: stateProps._suggestionKeys
       ? stateProps._suggestionKeys

--- a/shared/profile/user/index.tsx
+++ b/shared/profile/user/index.tsx
@@ -375,7 +375,8 @@ class User extends React.Component<Props, State> {
           fullWidth={true}
           fullHeight={true}
           style={Styles.collapseStyles([
-            {...styles.container, paddingTop},
+            styles.container,
+            {paddingTop},
             colorTypeToStyle(this.props.backgroundColorType),
           ])}
         >

--- a/shared/profile/user/index.tsx
+++ b/shared/profile/user/index.tsx
@@ -32,6 +32,7 @@ export type Props = {
   onSearch: () => void
   onEditAvatar: (() => void) | null
   reason: string
+  showAirdropBanner: boolean
   state: Types.DetailsState
   suggestionKeys: Array<string> | null
   userIsYou: boolean
@@ -359,6 +360,8 @@ class User extends React.Component<Props, State> {
       }
     }
 
+    const paddingTop = styles.container.paddingTop + (this.props.showAirdropBanner ? 70 : 0)
+
     return (
       <Kb.Reloadable
         reloadOnMount={true}
@@ -371,7 +374,10 @@ class User extends React.Component<Props, State> {
           direction="vertical"
           fullWidth={true}
           fullHeight={true}
-          style={Styles.collapseStyles([styles.container, colorTypeToStyle(this.props.backgroundColorType)])}
+          style={Styles.collapseStyles([
+            {...styles.container, paddingTop},
+            colorTypeToStyle(this.props.backgroundColorType),
+          ])}
         >
           <Kb.Box2 direction="vertical" style={styles.innerContainer}>
             {!Styles.isMobile && <Measure onMeasured={this._onMeasured} />}
@@ -426,7 +432,7 @@ export const styles = Styles.styleSheetCreate({
   backgroundColor: {
     ...Styles.globalStyles.fillAbsolute,
     bottom: undefined,
-    height: (avatarSize / 2) + Styles.globalMargins.tiny,
+    height: avatarSize / 2 + Styles.globalMargins.tiny,
   },
   bio: Styles.platformStyles({
     common: {alignSelf: 'flex-start'},

--- a/shared/router-v2/header/index.desktop.tsx
+++ b/shared/router-v2/header/index.desktop.tsx
@@ -168,9 +168,6 @@ class Header extends React.PureComponent<Props> {
 
     return (
       <Kb.Box2 noShrink={true} direction="vertical" fullWidth={true}>
-        {flags.airdrop && this.props.loggedIn && (
-          <AirdropBanner showSystemButtons={windowDecorationsDrawnByBanner} />
-        )}
         <Kb.Box2
           noShrink={true}
           direction="vertical"
@@ -182,6 +179,9 @@ class Header extends React.PureComponent<Props> {
             opt.headerStyle,
           ])}
         >
+          {flags.airdrop && this.props.loggedIn && (
+            <AirdropBanner showSystemButtons={windowDecorationsDrawnByBanner} />
+          )}
           <Kb.Box2
             key="topBar"
             direction="horizontal"


### PR DESCRIPTION
Tweaks some CSS styles on desktop to ensure that the airdrop banner works with the profile page. The issue with the profile page was the use of absolute positioning to achieve the effect of coloring the top of the header.

My solution to this was to make the banner part of the top header, and have the profile page adjust the size of the padding it would use if the banner is present.

Note this only affects desktop as the banner is not shown on any page but the people page on mobile.