### PR TITLE
White backgroundColor on reaction tooltip

### DIFF
--- a/shared/chat/conversation/messages/reaction-tooltip/index.tsx
+++ b/shared/chat/conversation/messages/reaction-tooltip/index.tsx
@@ -181,6 +181,7 @@ const styles = Styles.styleSheetCreate({
   }),
   overlay: Styles.platformStyles({
     isElectron: {
+      backgroundColor: Styles.globalColors.white,
       margin: Styles.globalMargins.tiny,
     },
   }),


### PR DESCRIPTION
On master when the reaction tooltip is scrollable what's underneath can peek through when scrolled to the bottom. Fix by adding a backgroundColor to the overlay. 