### PR TITLE
Always load configured accounts on daemon handshare/loggedin/loggedout

### DIFF
--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -223,15 +223,12 @@ function* loadDaemonAccounts(
       )
     }
 
-    // only reload in the user-switching case
-    const loadConfiguredAccountsAgain = state.config.loggedIn && flags.fastAccountSwitch
-    if (loadConfiguredAccountsAgain) {
-      const configuredAccounts: Array<
-        RPCTypes.ConfiguredAccount
-      > = yield RPCTypes.loginGetConfiguredAccountsRpcPromise()
-      const loadedAction = ConfigGen.createSetAccounts({configuredAccounts})
-      yield Saga.put(loadedAction)
-    }
+    const configuredAccounts: Array<
+      RPCTypes.ConfiguredAccount
+    > = yield RPCTypes.loginGetConfiguredAccountsRpcPromise()
+    const loadedAction = ConfigGen.createSetAccounts({configuredAccounts})
+    yield Saga.put(loadedAction)
+
     if (handshakeWait) {
       // someone dismissed this already?
       const newState: Container.TypedState = yield* Saga.selectState()


### PR DESCRIPTION
Fix getting to the relogin screen on mobile. cc @keybase/y2ksquad