### PR TITLE
Fix double gapu in keybase status

### DIFF
--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -110,11 +110,7 @@ func NewSecretStore(g *GlobalContext, username NormalizedUsername) SecretStore {
 	return nil
 }
 
-func GetConfiguredAccounts(m MetaContext, s SecretStoreAll) ([]keybase1.ConfiguredAccount, error) {
-	currentUsername, allUsernames, err := GetAllProvisionedUsernames(m)
-	if err != nil {
-		return nil, err
-	}
+func GetConfiguredAccountsFromProvisionedUsernames(m MetaContext, s SecretStoreAll, currentUsername NormalizedUsername, allUsernames []NormalizedUsername) ([]keybase1.ConfiguredAccount, error) {
 	if !currentUsername.IsNil() {
 		allUsernames = append(allUsernames, currentUsername)
 	}
@@ -183,6 +179,14 @@ func GetConfiguredAccounts(m MetaContext, s SecretStoreAll) ([]keybase1.Configur
 	}
 
 	return configuredAccounts, nil
+}
+
+func GetConfiguredAccounts(m MetaContext, s SecretStoreAll) ([]keybase1.ConfiguredAccount, error) {
+	currentUsername, allUsernames, err := GetAllProvisionedUsernames(m)
+	if err != nil {
+		return nil, err
+	}
+	return GetConfiguredAccountsFromProvisionedUsernames(m, s, currentUsername, allUsernames)
 }
 
 func ClearStoredSecret(m MetaContext, username NormalizedUsername) error {

--- a/go/status/status.go
+++ b/go/status/status.go
@@ -98,7 +98,7 @@ func GetExtendedStatus(mctx libkb.MetaContext) (res keybase1.ExtendedStatus, err
 	}
 	res.ProvisionedUsernames = p
 
-	accounts, err := libkb.GetConfiguredAccounts(mctx, mctx.G().SecretStore())
+	accounts, err := libkb.GetConfiguredAccountsFromProvisionedUsernames(mctx, mctx.G().SecretStore(), current, all)
 	if err != nil {
 		mctx.Debug("| died in GetConfiguredAccounts()")
 		return res, err


### PR DESCRIPTION
We were calling GAPU twice in keybase status, this is slow on machines with a lot of provisioned users.