### PR TITLE
Calculate whether to show the unread shortcut more often on desktop

### DIFF
--- a/shared/chat/inbox/index.desktop.tsx
+++ b/shared/chat/inbox/index.desktop.tsx
@@ -136,9 +136,13 @@ class Inbox extends React.PureComponent<T.Props, State> {
     this.setState(old => (old.showFloating !== showFloating ? {showFloating} : null))
   }
 
-  _onItemsRendered = debounce(({visibleStartIndex, visibleStopIndex}) => {
+  _onItemsRendered = ({visibleStartIndex, visibleStopIndex}) => {
     this._lastVisibleIdx = visibleStopIndex
     this._calculateShowUnreadShortcut()
+    this._onItemsRenderedDebounced({visibleStartIndex, visibleStopIndex})
+  }
+
+  _onItemsRenderedDebounced = debounce(({visibleStartIndex, visibleStopIndex}) => {
     const toUnbox = this.props.rows
       .slice(visibleStartIndex, visibleStopIndex + 1)
       .reduce<Array<Types.ConversationIDKey>>((arr, r) => {

--- a/shared/chat/inbox/index.desktop.tsx
+++ b/shared/chat/inbox/index.desktop.tsx
@@ -10,7 +10,7 @@ import {makeRow} from './row'
 import BuildTeam from './row/build-team/container'
 import BigTeamsDivider from './row/big-teams-divider/container'
 import TeamsDivider from './row/teams-divider/container'
-import {debounce} from 'lodash-es'
+import {debounce, throttle} from 'lodash-es'
 import * as T from './index.types.d'
 import UnreadShortcut from './unread-shortcut'
 import {virtualListMarks} from '../../local-debug'
@@ -123,6 +123,8 @@ class Inbox extends React.PureComponent<T.Props, State> {
     }
   }
 
+  _calculateShowUnreadShortcutThrottled = throttle(this._calculateShowUnreadShortcut, 100)
+
   _calculateShowFloating = () => {
     if (this._lastVisibleIdx < 0) {
       return
@@ -138,7 +140,7 @@ class Inbox extends React.PureComponent<T.Props, State> {
 
   _onItemsRendered = ({visibleStartIndex, visibleStopIndex}) => {
     this._lastVisibleIdx = visibleStopIndex
-    this._calculateShowUnreadShortcut()
+    this._calculateShowUnreadShortcutThrottled()
     this._onItemsRenderedDebounced({visibleStartIndex, visibleStopIndex})
   }
 


### PR DESCRIPTION
@malgorithms noticed an issue: if you try to find unread team conversations by scrolling until the unread shortcut disappears, it won't work because of the long delay between scrolling and the shortcut updating. This patch moves the unread shortcut calculation out of the debounced function so it will run on every `onItemsRendered`. cc @keybase/y2ksquad 