### PR TITLE
Fix undefined fcn call in select-other-device

### DIFF
--- a/shared/provision/select-other-device/container.tsx
+++ b/shared/provision/select-other-device/container.tsx
@@ -1,42 +1,41 @@
 import * as ProvisionGen from '../../actions/provision-gen'
 import * as LoginGen from '../../actions/login-gen'
+import * as RouteTreeGen from '../../actions/route-tree-gen'
 import SelectOtherDevice from '.'
-import {connect, compose, safeSubmitPerMount, TypedDispatch, TypedState} from '../../util/container'
+import * as Container from '../../util/container'
 import {RouteProps} from '../../route-tree/render-route'
 import HiddenString from '../../util/hidden-string'
 
 type OwnProps = RouteProps
 
-const mapStateToProps = (state: TypedState) => ({
+const mapStateToProps = (state: Container.TypedState) => ({
   configuredAccounts: state.config.configuredAccounts,
   devices: state.provision.devices,
 })
-const mapDispatchToProps = (dispatch: TypedDispatch, ownProps: OwnProps) => ({
+const mapDispatchToProps = (dispatch: Container.TypedDispatch, _: OwnProps) => ({
   onLogIn: (username: string) => dispatch(LoginGen.createLogin({password: new HiddenString(''), username})),
   onResetAccount: () => {
     dispatch(LoginGen.createLaunchAccountResetWebPage())
-    dispatch(ownProps.navigateUp())
+    dispatch(RouteTreeGen.createNavigateUp())
   },
   onSelect: (name: string) => {
     dispatch(ProvisionGen.createSubmitDeviceSelect({name}))
   },
 })
 
-export default compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-    (stateProps, dispatchProps, _: OwnProps) => {
-      const loggedInAccounts = stateProps.configuredAccounts
-        .filter(account => account.hasStoredSecret)
-        .map(account => account.username)
-      return {
-        devices: stateProps.devices.toArray(),
-        onBack: loggedInAccounts.size > 0 ? () => dispatchProps.onLogIn(loggedInAccounts.get(0) || '') : null,
-        onResetAccount: dispatchProps.onResetAccount,
-        onSelect: dispatchProps.onSelect,
-      }
+export default Container.connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  (stateProps, dispatchProps, _: OwnProps) => {
+    const loggedInAccounts = stateProps.configuredAccounts
+      .filter(account => account.hasStoredSecret)
+      .map(account => account.username)
+    return {
+      devices: stateProps.devices.toArray(),
+      onBack:
+        loggedInAccounts.size > 0 ? () => dispatchProps.onLogIn(loggedInAccounts.get(0) || '') : undefined,
+      onResetAccount: dispatchProps.onResetAccount,
+      onSelect: dispatchProps.onSelect,
     }
-  ),
-  safeSubmitPerMount(['onSelect', 'onBack'])
-)(SelectOtherDevice)
+  }
+)(Container.safeSubmitPerMount(['onSelect', 'onBack'])(SelectOtherDevice))

--- a/shared/provision/select-other-device/index.tsx
+++ b/shared/provision/select-other-device/index.tsx
@@ -7,7 +7,7 @@ type Props = {
   devices: Array<Types.Device>
   onSelect: (name: string) => void
   onResetAccount: () => void
-  onBack: () => void
+  onBack?: () => void
 }
 
 class SelectOtherDevice extends React.Component<Props> {


### PR DESCRIPTION
Fixes crasher on selecting "reset your account" on the select-other-device page in provisioning. cc @keybase/y2ksquad 