### PR TITLE
handle stellar partner icon names better

### DIFF
--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -33,7 +33,7 @@ class Icon extends Component<Props, void> {
       return null
     }
 
-    if (!iconMeta[iconType]) {
+    if (!Shared.isValidIconType(iconType)) {
       logger.warn('Unknown icontype passed', iconType)
       throw new Error('Unknown icontype passed ' + iconType)
     }

--- a/shared/common-adapters/icon.native.tsx
+++ b/shared/common-adapters/icon.native.tsx
@@ -127,7 +127,7 @@ const _Icon = (p: Props, ref: any) => {
     logger.warn('Null iconType passed')
     return null
   }
-  if (!iconMeta[iconType]) {
+  if (!Shared.isValidIconType(iconType)) {
     logger.warn(`Invalid icon type passed in: ${iconType}`)
     return null
   }

--- a/shared/common-adapters/icon.shared.tsx
+++ b/shared/common-adapters/icon.shared.tsx
@@ -76,6 +76,11 @@ export function fontSize(type: IconType): {fontSize: number} | null {
   }
 }
 
+export function isValidIconType(inputType: IconType): boolean {
+  let iconType = typeToIconMapper(inputType)
+  return !!iconType && !!iconMeta[iconType]
+}
+
 export function typeToFontSize(sizeType: SizeType) {
   switch (sizeType) {
     case 'Huge':

--- a/shared/wallets/wallet/settings/container.tsx
+++ b/shared/wallets/wallet/settings/container.tsx
@@ -3,6 +3,8 @@ import * as Container from '../../../util/container'
 import {anyWaiting} from '../../../constants/waiting'
 import * as I from 'immutable'
 import * as Constants from '../../../constants/wallets'
+import {IconType} from '../../../common-adapters/icon.constants'
+import * as IconUtils from '../../../common-adapters/icon.shared'
 import * as Types from '../../../constants/types/wallets'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
@@ -15,6 +17,15 @@ type OwnProps = Container.RouteProps
 const transformUrl = (accountID: string, url: string, username: string): string =>
   url.replace('%{accountId}', accountID).replace('%{username}', username)
 
+const toIconType = (iconFilename: string): IconType => {
+  const iconType = iconFilename as IconType
+  if (IconUtils.isValidIconType(iconType)) {
+    return iconType
+  } else {
+    return 'icon-stellar-logo-grey-32'
+  }
+}
+
 const prepareExternalPartners = (
   externalPartners: I.List<Types.PartnerUrl>,
   accountID: string,
@@ -25,7 +36,7 @@ const prepareExternalPartners = (
       adminOnly: partner.adminOnly,
       description: partner.description,
       extra: partner.extra,
-      iconFilename: partner.iconFilename,
+      iconFilename: toIconType(partner.iconFilename),
       showDivider: index > 0,
       title: partner.title,
       url: transformUrl(accountID, partner.url, username),

--- a/shared/wallets/wallet/settings/index.stories.tsx
+++ b/shared/wallets/wallet/settings/index.stories.tsx
@@ -43,7 +43,7 @@ const externalPartner = {
   adminOnly: false,
   description: 'Example description.',
   extra: 'Example extra.',
-  iconFilename: '',
+  iconFilename: 'icon-stellar-logo-grey-32',
   showDivider: false,
   title: 'Example title.',
   url: 'https://example.com/%{accountId}',

--- a/shared/wallets/wallet/settings/index.tsx
+++ b/shared/wallets/wallet/settings/index.tsx
@@ -5,6 +5,7 @@ import * as Styles from '../../../styles'
 import * as Types from '../../../constants/types/wallets'
 import {AccountPageHeader} from '../../common'
 import DisplayCurrencyDropdown from './display-currency-dropdown'
+import {IconType} from '../../../common-adapters/icon.constants'
 import WalletSettingTrustline from './trustline/container'
 import openUrl from '../../../util/open-url'
 
@@ -49,13 +50,13 @@ const Divider = () => <Kb.Divider style={styles.divider} />
 type PartnerRowProps = {
   extra: string
   description: string
-  iconFilename: string
+  iconFilename: IconType
   title: string
   url: string
 }
 const PartnerRow = (props: PartnerRowProps) => (
   <Kb.Box2 direction="horizontal" fullWidth={true} gap="tiny">
-    <Kb.Icon type="icon-stellar-logo-grey-32" style={styles.partnerIcon} />
+    <Kb.Icon type={props.iconFilename} style={styles.partnerIcon} />
     <Kb.Box2 direction="vertical" fullWidth={true} style={styles.yesShrink}>
       <Kb.ClickableBox
         className="hover-underline-container"
@@ -120,11 +121,24 @@ class AccountSettings extends React.Component<SettingsProps> {
             <Divider />
             <Kb.Box2 direction="vertical" gap="tiny" style={styles.section} fullWidth={true}>
               <Kb.Text type="BodySmallSemibold">Secret Key</Kb.Text>
-              <Kb.Banner color="yellow" inline={true}>Only paste your secret key in 100% safe places. Anyone with this key could steal your Stellar&nbsp;account.</Kb.Banner>
+              <Kb.Banner color="yellow" inline={true}>
+                Only paste your secret key in 100% safe places. Anyone with this key could steal your
+                Stellar&nbsp;account.
+              </Kb.Banner>
               <Kb.Box2 direction="vertical" fullWidth={true} style={styles.secretKeyContainer}>
-                <Kb.CopyText containerStyle={styles.copyTextContainer} multiline={true} withReveal={true} text={this.props.secretKey} />
+                <Kb.CopyText
+                  containerStyle={styles.copyTextContainer}
+                  multiline={true}
+                  withReveal={true}
+                  text={this.props.secretKey}
+                />
                 {!this.props.secretKey && (
-                  <Kb.Box2 direction="horizontal" gap="tiny" fullWidth={true} style={styles.progressContainer}>
+                  <Kb.Box2
+                    direction="horizontal"
+                    gap="tiny"
+                    fullWidth={true}
+                    style={styles.progressContainer}
+                  >
                     <Kb.ProgressIndicator style={styles.progressIndicator} type="Small" />
                     <Kb.Text type="BodySmall">fetching and decrypting secret key...</Kb.Text>
                   </Kb.Box2>
@@ -241,7 +255,7 @@ class AccountSettings extends React.Component<SettingsProps> {
                       <PartnerRow
                         description={partner.description}
                         extra={partner.extra}
-                        iconFilename={partner.iconFilename}
+                        iconFilename={partner.iconFilename as IconType}
                         title={partner.title}
                         url={partner.url}
                       />


### PR DESCRIPTION
1. show an icon based on the partnerURL object instead of hardcoded to the grey stellar icon
2. if an empty or invalid icon name is passed in, default it to the grey stellar icon

in building a demo for external urls (see https://github.com/keybase/keybase/pull/4087), i discovered the icon system didn't really work. when i made it work, i discovered that it crashes hard when the icon name is invalid. 

i pushed some of this logic down closer to the icon object (and reused it a couple places). i think that makes sense, but i could definitely very easily be convinced otherwise. 

and here's what a few of these things look like in the app

<img width="250" alt="Screen Shot 2019-07-23 at 2 33 48 PM" src="https://user-images.githubusercontent.com/1275828/61737778-ead2ff80-ad56-11e9-9cc8-3cce82e8abf9.png">

things to note: one of those default images is from an empty iconFilename and the other is from an invalid one