### PR TITLE
reply swipe touchup

### DIFF
--- a/shared/chat/conversation/messages/wrapper/long-pressable/index.native.tsx
+++ b/shared/chat/conversation/messages/wrapper/long-pressable/index.native.tsx
@@ -23,6 +23,7 @@ const LongPressable = (props: {children: React.ElementType; onSwipeLeft: () => v
       ref={swipeable}
       renderRightActions={_renderRightActions}
       onSwipeableRightWillOpen={onRightOpen}
+      failOffsetX={0}
     >
       <Kb.NativeTouchableHighlight key="longPressbale" {...rest}>
         <Kb.NativeView style={styles.view}>{children}</Kb.NativeView>
@@ -33,7 +34,7 @@ const LongPressable = (props: {children: React.ElementType; onSwipeLeft: () => v
 
 const styles = Styles.styleSheetCreate({
   replyIcon: {
-    padding: Styles.globalMargins.xtiny,
+    paddingRight: Styles.globalMargins.small,
   },
   view: {
     ...Styles.globalStyles.flexBoxColumn,


### PR DESCRIPTION
I believe this gets swiping right to get back to the inbox on par with the release version. The prop `failOffsetX` is part of `PanGestureHandler` (which is what `Swipeable` uses), and is used to early out the underlying `UIGestureRecognizer` if the translation on the X axis is outside some range. Giving 0 seems to block any swipe right from triggering this recognizer, which makes it so the touches don't get cancelled. 

Also increase padding on the reply arrow.