### PR TITLE
libkb: don't use `poll=10` when loading upaks for chat, etc

### DIFF
--- a/go/engine/merkle_audit.go
+++ b/go/engine/merkle_audit.go
@@ -27,7 +27,7 @@ var (
 var MerkleAuditSettings = BackgroundTaskSettings{
 	Start:        5 * time.Minute,
 	StartStagger: 1 * time.Hour,
-	Interval:     6 * time.Hour,
+	Interval:     24 * time.Hour,
 	Limit:        1 * time.Minute,
 }
 

--- a/go/engine/merkle_client_historical_test.go
+++ b/go/engine/merkle_client_historical_test.go
@@ -18,7 +18,7 @@ func TestMerkleClientHistorical(t *testing.T) {
 	q := libkb.NewHTTPArgs()
 	q.Add("uid", libkb.UIDArg(fu.UID()))
 	mc := tc.G.MerkleClient
-	leaf, err := mc.LookupUser(m, q, nil)
+	leaf, err := mc.LookupUser(m, q, nil, libkb.MerkleOpts{})
 
 	require.NoError(t, err)
 	root := mc.LastRoot(m)

--- a/go/engine/upak_loader_test.go
+++ b/go/engine/upak_loader_test.go
@@ -349,7 +349,7 @@ func TestLoadAfterAcctReset1(t *testing.T) {
 
 	loadUpak := func() error {
 		t.Logf("loadUpak: using username:%+v", fu.Username)
-		loadArg := libkb.NewLoadUserArg(tc.G).WithUID(fu.UID()).WithNetContext(context.TODO()).WithStaleOK(false)
+		loadArg := libkb.NewLoadUserArg(tc.G).WithUID(fu.UID()).WithNetContext(context.TODO()).WithStaleOK(false).WithForceMerkleServerPolling(true)
 
 		upak, _, err := tc.G.GetUPAKLoader().Load(loadArg)
 		if err != nil {

--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -119,7 +119,7 @@ func (m *CachedFullSelf) maybeClearCache(ctx context.Context, arg *LoadUserArg) 
 	var sigHints *SigHints
 	var leaf *MerkleUserLeaf
 
-	sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(NewMetaContext(ctx, m.G()), arg.uid, true)
+	sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(NewMetaContext(ctx, m.G()), arg.uid, true, MerkleOpts{})
 	if err != nil {
 		m.me = nil
 		return err

--- a/go/libkb/upak_lite.go
+++ b/go/libkb/upak_lite.go
@@ -17,7 +17,7 @@ func LoadUPAKLite(arg LoadUserArg) (ret *keybase1.UPKLiteV1AllIncarnations, err 
 	if err != nil {
 		return nil, err
 	}
-	leaf, err := lookupMerkleLeaf(m, uid, false, nil)
+	leaf, err := lookupMerkleLeaf(m, uid, false, nil, MerkleOpts{NoServerPolling: false})
 	if err != nil {
 		return nil, err
 	}

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -418,7 +418,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		var sigHints *SigHints
 		var leaf *MerkleUserLeaf
 
-		sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(m, arg.uid, true, MerkleOpts{NoServerPolling: (!arg.forcePoll && !arg.forceReload)})
+		sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(m, arg.uid, true, arg.ToMerkleOpts())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -418,7 +418,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		var sigHints *SigHints
 		var leaf *MerkleUserLeaf
 
-		sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(m, arg.uid, true)
+		sigHints, leaf, err = lookupSigHintsAndMerkleLeaf(m, arg.uid, true, MerkleOpts{NoServerPolling: (!arg.forcePoll && !arg.forceReload)})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/merklestore/store.go
+++ b/go/merklestore/store.go
@@ -281,7 +281,7 @@ func (s *MerkleStoreImpl) refreshRoot(m libkb.MetaContext) error {
 		uid = libkb.TAliceUID
 	}
 	q.Add("uid", libkb.UIDArg(uid))
-	_, err := s.G().MerkleClient.LookupUser(m, q, nil)
+	_, err := s.G().MerkleClient.LookupUser(m, q, nil, libkb.MerkleOpts{})
 	return err
 }
 


### PR DESCRIPTION
I'm trying to reduce the DB load of that polling query, and it bubbles all the way back to the client. It would be nice to disable server polling in more places, but a lot of tests depend upon it. Sigh.