### PR TITLE
teams: fix flake in TestRotateRace on windows CI

### DIFF
--- a/go/teams/rotate_test.go
+++ b/go/teams/rotate_test.go
@@ -304,7 +304,7 @@ func TestRotateRace(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 10; i++ {
 		t.Logf("round %v", i)
 
 		errCh1 := rotate(0)


### PR DESCRIPTION
- repro'ed the failure by adding random sleeps into the rotate goroutines
- fixed by allowing another retry condition, when we fail to prepend a hidden link due to a race
- we could potentially move this check into the test, since we typically shouldn't hit it, but that's ok for now