### PR TITLE
libkb: raise timeout on UPAK loads from 10minutes to 1 hour

### DIFF
--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -127,11 +127,12 @@ const (
 	Identify2CacheShortTimeout  = 1 * time.Minute
 
 	// How long we'll go without rerequesting hints/merkle seqno. This is used in both
-	// CachedUPAKLoader and FullSelfCacher. Note that this timeout has to exceed the
+	// the FullSelfCacher. Note that this timeout has to exceed the
 	// dtime value for Gregor IBMs that deal with user and key family changed notifications.
 	// Because if the client is offline for more than that amount of time, then our cache
 	// could be stale.
-	CachedUserTimeout = 10 * time.Minute
+	CachedSelfTimeout = 10 * time.Minute
+	CachedUPAKTimeout = 60 * time.Minute
 
 	LinkCacheSize     = 4000
 	LinkCacheCleanDur = 1 * time.Minute

--- a/go/libkb/full_self_cacher.go
+++ b/go/libkb/full_self_cacher.go
@@ -111,7 +111,7 @@ func (m *CachedFullSelf) maybeClearCache(ctx context.Context, arg *LoadUserArg) 
 	now := m.G().Clock().Now()
 	diff := now.Sub(m.cachedAt)
 
-	if diff < CachedUserTimeout && !arg.forcePoll {
+	if diff < CachedSelfTimeout && !arg.forcePoll {
 		m.G().Log.CDebugf(ctx, "| was fresh, last loaded %s ago", diff)
 		return nil
 	}

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -608,8 +608,8 @@ func (g *GlobalContext) configureMemCachesLocked(isFlush bool) {
 	}
 
 	g.Log.Debug("made a new full self cache")
-	g.upakLoader = NewCachedUPAKLoader(g, CachedUserTimeout)
-	g.Log.Debug("made a new cached UPAK loader (timeout=%v)", CachedUserTimeout)
+	g.upakLoader = NewCachedUPAKLoader(g, CachedUPAKTimeout)
+	g.Log.Debug("made a new cached UPAK loader (timeout=%v)", CachedUPAKTimeout)
 	g.PayloadCache = NewPayloadCache(g, g.Env.GetPayloadCacheSize())
 }
 

--- a/go/libkb/upak_loader_test.go
+++ b/go/libkb/upak_loader_test.go
@@ -46,7 +46,7 @@ func TestCachedUserLoad(t *testing.T) {
 		t.Fatalf("wrong info: %+v", info)
 	}
 
-	fakeClock.Advance(CachedUserTimeout / 100)
+	fakeClock.Advance(CachedUPAKTimeout / 100)
 	info = CachedUserLoadInfo{}
 	upk, user, err := tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil, true)
 	checkLoad(upk, err)
@@ -58,7 +58,7 @@ func TestCachedUserLoad(t *testing.T) {
 		t.Fatalf("wrong info: %+v", info)
 	}
 
-	fakeClock.Advance(2 * CachedUserTimeout)
+	fakeClock.Advance(2 * CachedUPAKTimeout)
 	info = CachedUserLoadInfo{}
 	upk, user, err = tc.G.GetUPAKLoader().(*CachedUPAKLoader).loadWithInfo(arg, &info, nil, true)
 	checkLoad(upk, err)


### PR DESCRIPTION
- this should have a big impact on server load
- this should have a small impact on mobile performance, but a positive one
- it's slightly worse for security, since it'll take longer to realize that a key has been revoked (up to an hour)