### PR TITLE
Persist staticConfig for chat and wallet on logout

### DIFF
--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -411,7 +411,9 @@ const rootReducer = (
 ): Types.State => {
   switch (action.type) {
     case Chat2Gen.resetStore:
-      return initialState
+      return initialState.merge({
+        staticConfig: state.staticConfig,
+      })
     case Chat2Gen.setInboxShowIsNew:
       return state.merge({inboxShowNew: action.payload.isNew})
     case Chat2Gen.toggleSmallTeamsExpanded:

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -23,7 +23,9 @@ const reduceAssetMap = (
 export default function(state: Types.State = initialState, action: WalletsGen.Actions): Types.State {
   switch (action.type) {
     case WalletsGen.resetStore:
-      return initialState
+      return initialState.merge({
+        staticConfig: state.staticConfig,
+      })
     case WalletsGen.didSetAccountAsDefault:
     case WalletsGen.accountsReceived: {
       const accountMap: I.OrderedMap<Types.AccountID, Types.Account> = I.OrderedMap(


### PR DESCRIPTION
Fixes an issue where constant data such as the maximum length of a payment message would be reset on logout.

props to @patrickxb for noticing this bug