### PR TITLE
Refresh airdrop details/state on new login

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1122,10 +1122,11 @@ type AirdropDetailsJSONType = {
 } | null
 
 const updateAirdropDetails = (
-  _: TypedState,
+  state: TypedState,
   __: WalletsGen.UpdateAirdropStatePayload | ConfigGen.DaemonHandshakeDonePayload,
   logger: Saga.SagaLogger
 ) =>
+  state.config.loggedIn &&
   RPCStellarTypes.localAirdropDetailsLocalRpcPromise(undefined, Constants.airdropWaitingKey)
     .then(response => {
       const json: AirdropDetailsJSONType = JSON.parse(response.details)
@@ -1160,10 +1161,11 @@ const updateAirdropDetails = (
     })
 
 const updateAirdropState = (
-  _: TypedState,
+  state: TypedState,
   __: WalletsGen.UpdateAirdropStatePayload | ConfigGen.DaemonHandshakeDonePayload,
   logger: Saga.SagaLogger
 ) =>
+  state.config.loggedIn &&
   RPCStellarTypes.localAirdropStatusLocalRpcPromise(undefined, Constants.airdropWaitingKey)
     .then(({state, rows}) => {
       let airdropState = 'loading'
@@ -1915,12 +1917,12 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
       'changeAirdrop'
     )
     yield* Saga.chainAction<WalletsGen.UpdateAirdropStatePayload | ConfigGen.DaemonHandshakeDonePayload>(
-      [WalletsGen.updateAirdropDetails, ConfigGen.daemonHandshakeDone],
+      [WalletsGen.updateAirdropDetails, ConfigGen.daemonHandshakeDone, ConfigGen.loggedIn],
       updateAirdropDetails,
       'updateAirdropDetails'
     )
     yield* Saga.chainAction<WalletsGen.UpdateAirdropStatePayload | ConfigGen.DaemonHandshakeDonePayload>(
-      [WalletsGen.updateAirdropState, ConfigGen.daemonHandshakeDone],
+      [WalletsGen.updateAirdropState, ConfigGen.daemonHandshakeDone, ConfigGen.loggedIn],
       updateAirdropState,
       'updateAirdropState'
     )

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1123,7 +1123,7 @@ type AirdropDetailsJSONType = {
 
 const updateAirdropDetails = (
   state: TypedState,
-  __: WalletsGen.UpdateAirdropStatePayload | ConfigGen.DaemonHandshakeDonePayload,
+  _: WalletsGen.UpdateAirdropStatePayload | ConfigGen.DaemonHandshakeDonePayload,
   logger: Saga.SagaLogger
 ) =>
   state.config.loggedIn &&
@@ -1162,7 +1162,7 @@ const updateAirdropDetails = (
 
 const updateAirdropState = (
   state: TypedState,
-  __: WalletsGen.UpdateAirdropStatePayload | ConfigGen.DaemonHandshakeDonePayload,
+  _: WalletsGen.UpdateAirdropStatePayload | ConfigGen.DaemonHandshakeDonePayload,
   logger: Saga.SagaLogger
 ) =>
   state.config.loggedIn &&


### PR DESCRIPTION
@keybase/picnicsquad 

In this flow:

* app starts up logged out
* you sign up as a new user

The airdropDetails and airdropState RPCs will both fail during startup (they require a logged in user), but they won't be retried after the login happens.  The result is that a new user who should be seeing the airdrop banner doesn't see it until they restart their app.  This PR fixes it by hooking those RPCs up to ConfigGen.loggedIn.

Also, since those RPCs require login, there's no point making them if we know we aren't logged in.