### PR TITLE
Misc changes for phone + contacts

### DIFF
--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -497,6 +497,11 @@ async function manageContactsCache(
   let defaultCountryCode: string
   try {
     defaultCountryCode = await NativeModules.Utils.getDefaultCountryCode()
+    if (__DEV__ && !defaultCountryCode) {
+      // behavior of parsing can be unexpectedly different with no country code.
+      // iOS sim + android emu don't supply country codes, so use this one.
+      defaultCountryCode = 'us'
+    }
   } catch (e) {
     logger.warn(`Error loading default country code: ${e.message}`)
   }

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -71,7 +71,7 @@ const TabBarIcon = ({badgeNumber, focused, routeName}) => (
   </Kb.NativeView>
 )
 
-const settingsTabChildren = [Tabs.gitTab, Tabs.devicesTab, Tabs.walletsTab]
+const settingsTabChildren = [Tabs.gitTab, Tabs.devicesTab, Tabs.walletsTab, Tabs.settingsTab]
 
 type OwnProps = {focused: boolean; routeName: Tabs.Tab}
 const ConnectedTabBarIcon = connect(

--- a/shared/settings/account/add-modals.tsx
+++ b/shared/settings/account/add-modals.tsx
@@ -98,7 +98,7 @@ export const Phone = () => {
 
   const [phoneNumber, onChangeNumber] = React.useState('')
   const [valid, onChangeValidity] = React.useState(false)
-  const [allowSearch, onChangeAllowSearch] = React.useState(false)
+  const [allowSearch, onChangeAllowSearch] = React.useState(true)
   const disabled = !valid
 
   const error = Container.useSelector(state => state.settings.phoneNumbers.error)

--- a/shared/util/feature-flags.desktop.tsx
+++ b/shared/util/feature-flags.desktop.tsx
@@ -23,7 +23,7 @@ const ff: FeatureFlags = {
   outOfDateBanner: false,
   plansEnabled: false,
   proofProviders: true,
-  sbsContacts: false,
+  sbsContacts: true,
   stellarExternalPartners: true,
 }
 


### PR DESCRIPTION
- Add a fallback `defaultCountryCode` in dev
- Fix badge for unverified emails/phones bubbling up to the tab on mobile
- Default "Allow friends to find me" on in add-phone modal (already the same for add-email)
- `sbsContacts` flag on on desktop for real

cc @keybase/y2ksquad 