### PR TITLE
Disable asset picking buttons while payment is built

### DIFF
--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -281,6 +281,7 @@ const PickAssetButton = (props: PickAssetButtonProps) => {
   const {isSender} = props
   const goToPickAsset = useGoToPickAssetCallback(_buildingAdvanced, isSender)
   const asset = isSender ? _buildingAdvanced.senderAsset : _buildingAdvanced.recipientAsset
+  const isLoading = Container.useAnyWaiting(Constants.calculateBuildingAdvancedWaitingKey)
   return (
     <Kb.Box style={styles.pickAssetButtonOverlayOuter}>
       <Kb.Box style={styles.pickAssetButtonOverlayInner}>
@@ -292,8 +293,8 @@ const PickAssetButton = (props: PickAssetButtonProps) => {
           style={styles.pickAssetButton}
         >
           <Kb.ClickableBox
-            onClick={goToPickAsset || undefined}
-            style={!goToPickAsset ? styles.disabled : undefined}
+            onClick={!isLoading && goToPickAsset ? goToPickAsset : undefined}
+            style={!goToPickAsset || isLoading ? styles.disabled : undefined}
           >
             <Kb.Box2 direction="horizontal" centerChildren={true} gap="tiny" alignSelf="flex-end">
               <Kb.Text


### PR DESCRIPTION
Disables changing the source or destination asset while a payment path is being constructed. Previously, a user could get the UI into a weird state where the built path was not the same as their currently selected assets if they selected different assets while the path was loading.

Another option I considered was to reset the built payment if it came back and the assets differed from the UI state, but I ultimately decided it'd be better UX to just not give the users the option to change the assets until their current path has loaded.
