### PR TITLE
Add section headers to search recommendations + alphabet index on mobile

### DIFF
--- a/shared/actions/team-building.tsx
+++ b/shared/actions/team-building.tsx
@@ -171,6 +171,7 @@ const fetchUserRecs = (state: TypedState, {payload: {namespace}}: NSAction) =>
       const contactUsernames = new Set(contactRes.map(x => x.username).filter(Boolean))
       const contacts = contactRes.map(
         (x): TeamBuildingTypes.User => ({
+          contact: true,
           id: x.assertion,
           label: x.displayLabel,
           prettyName: x.displayName,

--- a/shared/common-adapters/section-divider.tsx
+++ b/shared/common-adapters/section-divider.tsx
@@ -27,7 +27,9 @@ const SectionDivider = (props: Props) => {
     <Kb.Box2 direction="horizontal" gap="xtiny" alignItems="center" fullWidth={true} style={styles.container}>
       {typeof props.label === 'string' ? (
         <Kb.Text type="BodySmallSemibold">{props.label}</Kb.Text>
-      ) : (props.label)}
+      ) : (
+        props.label
+      )}
       {collapsible && (
         <Kb.Icon sizeType="Tiny" type={props.collapsed ? 'iconfont-caret-right' : 'iconfont-caret-down'} />
       )}
@@ -42,20 +44,15 @@ const SectionDivider = (props: Props) => {
     children
   )
 }
+const height = Styles.isMobile ? 40 : 32
+SectionDivider.height = height
 
 const styles = Styles.styleSheetCreate({
-  container: Styles.platformStyles({
-    common: {
-      ...Styles.padding(Styles.globalMargins.xtiny, Styles.globalMargins.tiny),
-      backgroundColor: Styles.globalColors.blueLighter3,
-    },
-    isElectron: {
-      height: 32,
-    },
-    isMobile: {
-      height: 40,
-    },
-  }),
+  container: {
+    ...Styles.padding(Styles.globalMargins.xtiny, Styles.globalMargins.tiny),
+    backgroundColor: Styles.globalColors.blueLighter3,
+    height,
+  },
   fullWidth: {
     width: '100%',
   },

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -24,6 +24,7 @@ export type User = {
   id: UserID
   prettyName: string
   label?: string
+  contact?: boolean // not a keybase user, a phone / email from our contacts
 }
 
 // Treating this as a tuple

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -2,7 +2,7 @@ import logger from '../logger'
 import * as React from 'react'
 import * as I from 'immutable'
 import {debounce, trim} from 'lodash-es'
-import TeamBuilding, {RolePickerProps, SearchRecSection} from '.'
+import TeamBuilding, {RolePickerProps, SearchRecSection, numSectionLabel} from '.'
 import RolePickerHeaderAction from './role-picker-header-action'
 import * as WaitingConstants from '../constants/waiting'
 import * as ChatConstants from '../constants/chat2'
@@ -341,7 +341,7 @@ const sortAndSplitRecommendations = memoize(
         if (!sections[27]) {
           sections[27] = {
             data: [],
-            label: '0-9',
+            label: numSectionLabel,
             shortcut: true,
           }
         }

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -330,7 +330,7 @@ const sortAndSplitRecommendations = memoize(
         if (!sections[index]) {
           sections[index] = {
             data: [],
-            label: letter,
+            label: letter.toUpperCase(),
             shortcut: true,
           }
         }
@@ -348,7 +348,7 @@ const sortAndSplitRecommendations = memoize(
         sections[27].data.push(rec)
       }
     })
-    return sections
+    return sections.filter(Boolean)
   }
 )
 

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -300,8 +300,10 @@ const deriveRolePickerArrowKeyFns = memoize(
 )
 
 const alphabet = 'abcdefghijklmnopqrstuvwxyz'
-const isAlpha = (letter: string) => alphabet.includes(letter)
-const letterToAlphaIndex = (letter: string) => alphabet.indexOf(letter)
+const aCharCode = alphabet.charCodeAt(0)
+const alphaSet = new Set(alphabet)
+const isAlpha = (letter: string) => alphaSet.has(letter)
+const letterToAlphaIndex = (letter: string) => letter.charCodeAt(0) - aCharCode
 
 // Returns array with 28 entries
 // 0 - "Recommendations" section
@@ -309,7 +311,7 @@ const letterToAlphaIndex = (letter: string) => alphabet.indexOf(letter)
 // 27 - 0-9 section
 const sortAndSplitRecommendations = memoize(
   (results: Unpacked<typeof deriveSearchResults>): Array<SearchRecSection> | null => {
-    if (!results) return results
+    if (!results) return null
 
     const sections: Array<SearchRecSection> = [
       {
@@ -323,29 +325,29 @@ const sortAndSplitRecommendations = memoize(
         sections[0].data.push(rec)
         return
       }
-      const letter = (rec.prettyName || rec.displayLabel || '')[0].toLowerCase()
-      if (isAlpha(letter)) {
-        // offset 1 to skip recommendations
-        const index = letterToAlphaIndex(letter) + 1
-        if (!sections[index]) {
-          sections[index] = {
-            data: [],
-            label: letter.toUpperCase(),
-            shortcut: true,
+      if (rec.prettyName || rec.displayLabel) {
+        const letter = (rec.prettyName || rec.displayLabel)[0].toLowerCase()
+        if (isAlpha(letter)) {
+          // offset 1 to skip recommendations
+          const sectionIdx = letterToAlphaIndex(letter) + 1
+          if (!sections[sectionIdx]) {
+            sections[sectionIdx] = {
+              data: [],
+              label: letter.toUpperCase(),
+              shortcut: true,
+            }
           }
-        }
-        sections[index].data.push(rec)
-      } else if (!letter) {
-        // skip
-      } else {
-        if (!sections[27]) {
-          sections[27] = {
-            data: [],
-            label: numSectionLabel,
-            shortcut: true,
+          sections[sectionIdx].data.push(rec)
+        } else {
+          if (!sections[27]) {
+            sections[27] = {
+              data: [],
+              label: numSectionLabel,
+              shortcut: true,
+            }
           }
+          sections[27].data.push(rec)
         }
-        sections[27].data.push(rec)
       }
     })
     return sections.filter(Boolean)

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -249,7 +249,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       )
     }
     if (this.props.showRecs && this.props.recommendations) {
-      // TODO: Scroll on desktop when keyboard nav goes off screen
+      // TODO: Scroll on desktop when keyboard nav goes off screen (Y2K-364)
       return (
         <Kb.Box2
           direction="vertical"

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -153,7 +153,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
                 <Kb.Text type="BodyTiny" onClick={() => this._onScrollToSection(section.label)}>
                   {section.label}
                 </Kb.Text>
-                <Kb.Box style={{height: Styles.globalMargins.xtiny, flexShrink: 1}} />
+                <Kb.Box style={styles.shrinkingGap} />
               </React.Fragment>
             ) : null
           )}
@@ -170,6 +170,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
           this.props.recommendations.findIndex(section => section.label === label)) ||
         -1
       if (sectionIndex >= 0 && Styles.isMobile) {
+        // @ts-ignore due to no RN types
         ref.scrollToLocation({
           itemIndex: 0,
           sectionIndex,
@@ -197,11 +198,12 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       const indexInSection = indexInList - currSectionHeaderIdx
       if (indexInSection < s.data.length) {
         // we are in this data
-        numData += indexInSection - 1
+        numData += indexInSection
         break
       }
       // we're not in this section
       numData += s.data.length
+      currSectionHeaderIdx += s.data.length + 1
     }
     const offset = numSections * 40 + numData * 64
     return {index: indexInList, length, offset}
@@ -376,10 +378,9 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
 
 const styles = Styles.styleSheetCreate({
   alphabetIndex: {
-    bottom: 0,
     position: 'absolute',
     right: Styles.globalMargins.xtiny,
-    top: 0,
+    top: Styles.globalMargins.xtiny,
     width: 15,
   },
   banner: {
@@ -469,6 +470,7 @@ const styles = Styles.styleSheetCreate({
   mobileFlex: Styles.platformStyles({
     isMobile: {flex: 1},
   }),
+  shrinkingGap: {flexShrink: 1, height: Styles.globalMargins.xtiny},
   waiting: {
     ...Styles.globalStyles.fillAbsolute,
     backgroundColor: Styles.globalColors.black_20,

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -22,6 +22,12 @@ type SearchResult = {
   followingState: FollowingState
 }
 
+export type SearchRecSection = {
+  label: string
+  shortcut: boolean
+  data: Array<SearchResult>
+}
+
 export type RolePickerProps = {
   onSelectRole: (role: TeamRoleType) => void
   sendNotification: boolean
@@ -42,7 +48,7 @@ type ContactProps = {
   onLoadContactsSetting: () => void
 }
 
-type Props = ContactProps & {
+export type Props = ContactProps & {
   fetchUserRecs: () => void
   highlightedIndex: number | null
   onAdd: (userId: string) => void
@@ -56,7 +62,7 @@ type Props = ContactProps & {
   onRemove: (userId: string) => void
   onSearchForMore: () => void
   onUpArrowKeyDown: () => void
-  recommendations: Array<SearchResult> | null
+  recommendations: Array<SearchRecSection> | null
   searchResults: Array<SearchResult> | null
   searchString: string
   selectedService: ServiceIdWithContact
@@ -175,9 +181,13 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         </Kb.Box2>
       )
     }
+    if (this.props.showRecs) {
+      // TODO sectionlist
+      return <Kb.Text type="HeaderBig">Hey</Kb.Text>
+    }
     return (
       <Kb.List
-        items={this.props.showRecs ? this.props.recommendations || [] : this.props.searchResults || []}
+        items={this.props.searchResults || []}
         selectedIndex={this.props.highlightedIndex || 0}
         style={styles.list}
         contentContainerStyle={styles.listContentContainer}

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -142,6 +142,14 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
     this.props.fetchUserRecs()
   }
 
+  _alphabetIndex = () => {
+    return (
+      <Kb.Text type="BodySmall" style={{position: 'absolute', right: 5, top: 5}}>
+        A
+      </Kb.Text>
+    )
+  }
+
   _listBody = () => {
     const showRecPending = !this.props.searchString && !this.props.recommendations
     const showLoading = !!this.props.searchString && !this.props.searchResults
@@ -182,8 +190,35 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       )
     }
     if (this.props.showRecs) {
-      // TODO sectionlist
-      return <Kb.Text type="HeaderBig">Hey</Kb.Text>
+      return (
+        <Kb.Box2
+          direction="vertical"
+          fullWidth={true}
+          style={Styles.collapseStyles([Styles.globalStyles.flexOne, {position: 'relative'}])}
+        >
+          <Kb.SectionList
+            sections={this.props.recommendations}
+            renderItem={({index, item: result}) => (
+              <UserResult
+                resultForService={this.props.selectedService}
+                fixedHeight={400}
+                username={result.username}
+                prettyName={result.prettyName}
+                displayLabel={result.displayLabel}
+                services={result.services}
+                inTeam={result.inTeam}
+                isPreExistingTeamMember={result.isPreExistingTeamMember}
+                followingState={result.followingState}
+                highlight={!Styles.isMobile && index === this.props.highlightedIndex}
+                onAdd={() => this.props.onAdd(result.userId)}
+                onRemove={() => this.props.onRemove(result.userId)}
+              />
+            )}
+            renderSectionHeader={({section: {label}}) => <Kb.SectionDivider label={label} />}
+          />
+          {this._alphabetIndex()}
+        </Kb.Box2>
+      )
     }
     return (
       <Kb.List

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -146,7 +146,6 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
   }
 
   _alphabetIndex = () => {
-    const gap = <Kb.Box style={styles.shrinkingGap} />
     const showNumSection =
       this.props.recommendations &&
       this.props.recommendations[this.props.recommendations.length - 1].label === numSectionLabel
@@ -155,15 +154,33 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         {this.props.recommendations &&
           this.props.recommendations.map(section =>
             section.label && section.label.length === 1 ? (
-              <React.Fragment key={section.label}>
-                <Kb.Text type="BodyTiny" onClick={() => this._onScrollToSection(section.label)}>
+              <Kb.ClickableBox
+                key={section.label}
+                onClick={() => this._onScrollToSection(section.label)}
+                style={styles.gapAlphaIndices}
+              >
+                <Kb.Text
+                  key={section.label}
+                  type="BodyTiny"
+                  onClick={() => this._onScrollToSection(section.label)}
+                >
                   {section.label}
                 </Kb.Text>
-                {gap}
-              </React.Fragment>
+              </Kb.ClickableBox>
             ) : null
           )}
-        {/* TODO get 0-9 section down here */}
+        {showNumSection &&
+          ['0', '•', '9'].map(char => (
+            <Kb.ClickableBox
+              key={char}
+              onClick={() => this._onScrollToSection(numSectionLabel)}
+              style={styles.gapAlphaIndices}
+            >
+              <Kb.Text key={char} type="BodyTiny">
+                {char}
+              </Kb.Text>
+            </Kb.ClickableBox>
+          ))}
       </Kb.Box2>
     )
   }
@@ -382,10 +399,10 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
 
 const styles = Styles.styleSheetCreate({
   alphabetIndex: {
+    maxHeight: '80%',
     position: 'absolute',
-    right: Styles.globalMargins.xtiny,
-    top: Styles.globalMargins.medium,
-    width: 15,
+    right: 0,
+    top: Styles.globalMargins.large,
   },
   banner: {
     backgroundColor: Styles.globalColors.blue,
@@ -442,6 +459,10 @@ const styles = Styles.styleSheetCreate({
       maxWidth: '80%',
     },
   }),
+  gapAlphaIndices: {
+    ...Styles.padding(2, 6, 2, 2),
+    flexShrink: 1,
+  },
   list: Styles.platformStyles({
     common: {
       paddingBottom: Styles.globalMargins.small,

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -11,6 +11,8 @@ import {ServiceIdWithContact, FollowingState} from '../constants/types/team-buil
 import {Props as OriginalRolePickerProps} from '../teams/role-picker'
 import {TeamRoleType} from '../constants/types/teams'
 
+export const numSectionLabel = '0-9'
+
 type SearchResult = {
   userId: string
   username: string
@@ -144,16 +146,20 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
   }
 
   _alphabetIndex = () => {
+    const gap = <Kb.Box style={styles.shrinkingGap} />
+    const showNumSection =
+      this.props.recommendations &&
+      this.props.recommendations[this.props.recommendations.length - 1].label === numSectionLabel
     return (
       <Kb.Box2 direction="vertical" centerChildren={true} style={styles.alphabetIndex}>
         {this.props.recommendations &&
           this.props.recommendations.map(section =>
-            section.label && section.label.length <= 3 ? (
+            section.label && section.label.length === 1 ? (
               <React.Fragment key={section.label}>
                 <Kb.Text type="BodyTiny" onClick={() => this._onScrollToSection(section.label)}>
                   {section.label}
                 </Kb.Text>
-                <Kb.Box style={styles.shrinkingGap} />
+                {gap}
               </React.Fragment>
             ) : null
           )}
@@ -376,10 +382,9 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
 
 const styles = Styles.styleSheetCreate({
   alphabetIndex: {
-    height: '100%',
     position: 'absolute',
     right: Styles.globalMargins.xtiny,
-    top: Styles.globalMargins.xtiny,
+    top: Styles.globalMargins.medium,
     width: 15,
   },
   banner: {

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -138,16 +138,48 @@ const ContactsBanner = (props: ContactProps & {onRedoSearch: () => void; onRedoR
 }
 
 class TeamBuilding extends React.PureComponent<Props, {}> {
+  sectionListRef = React.createRef<Kb.SectionList>()
   componentDidMount = () => {
     this.props.fetchUserRecs()
   }
 
   _alphabetIndex = () => {
     return (
-      <Kb.Text type="BodySmall" style={{position: 'absolute', right: 5, top: 5}}>
-        A
-      </Kb.Text>
+      <Kb.Box2 direction="vertical" centerChildren={true} style={styles.alphabetIndex}>
+        {this.props.recommendations &&
+          this.props.recommendations.map(section =>
+            section.label && section.label.length <= 3 ? (
+              <React.Fragment key={section.label}>
+                <Kb.Text type="BodyTiny" onClick={() => this._onScrollToSection(section.label)}>
+                  {section.label}
+                </Kb.Text>
+                <Kb.Box style={{height: Styles.globalMargins.xtiny, flexShrink: 1}} />
+              </React.Fragment>
+            ) : null
+          )}
+        {/* TODO get 0-9 section down here */}
+      </Kb.Box2>
     )
+  }
+
+  _onScrollToSection = (label: string) => {
+    if (this.sectionListRef && this.sectionListRef.current) {
+      const ref = this.sectionListRef.current
+      const sectionIndex =
+        (this.props.recommendations &&
+          this.props.recommendations.findIndex(section => section.label === label)) ||
+        -1
+      if (sectionIndex >= 0 && Styles.isMobile) {
+        ref.scrollToLocation({
+          itemIndex: 0,
+          sectionIndex,
+        })
+      }
+    }
+  }
+
+  _getRecLayout = () => {
+    debugger
   }
 
   _listBody = () => {
@@ -190,6 +222,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       )
     }
     if (this.props.showRecs) {
+      // TODO: Scroll on desktop when keyboard nav goes off screen
       return (
         <Kb.Box2
           direction="vertical"
@@ -197,7 +230,9 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
           style={Styles.collapseStyles([Styles.globalStyles.flexOne, {position: 'relative'}])}
         >
           <Kb.SectionList
+            ref={this.sectionListRef}
             sections={this.props.recommendations}
+            getItemLayout={this._getRecLayout}
             renderItem={({index, item: result}) => (
               <UserResult
                 resultForService={this.props.selectedService}
@@ -216,7 +251,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
             )}
             renderSectionHeader={({section: {label}}) => <Kb.SectionDivider label={label} />}
           />
-          {this._alphabetIndex()}
+          {Styles.isMobile && this._alphabetIndex()}
         </Kb.Box2>
       )
     }
@@ -315,6 +350,13 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
 }
 
 const styles = Styles.styleSheetCreate({
+  alphabetIndex: {
+    bottom: 0,
+    position: 'absolute',
+    right: Styles.globalMargins.xtiny,
+    top: 0,
+    width: 15,
+  },
   banner: {
     backgroundColor: Styles.globalColors.blue,
     padding: Styles.globalMargins.tiny,

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -263,7 +263,6 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
             renderItem={({index, item: result}) => (
               <UserResult
                 resultForService={this.props.selectedService}
-                fixedHeight={400}
                 username={result.username}
                 prettyName={result.prettyName}
                 displayLabel={result.displayLabel}
@@ -293,7 +292,6 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         renderItem={(index, result) => (
           <UserResult
             resultForService={this.props.selectedService}
-            fixedHeight={400}
             username={result.username}
             prettyName={result.prettyName}
             displayLabel={result.displayLabel}
@@ -378,6 +376,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
 
 const styles = Styles.styleSheetCreate({
   alphabetIndex: {
+    height: '100%',
     position: 'absolute',
     right: Styles.globalMargins.xtiny,
     top: Styles.globalMargins.xtiny,

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -136,11 +136,75 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
     this.props.fetchUserRecs()
   }
 
+  _listBody = () => {
+    const showRecPending = !this.props.searchString && !this.props.recommendations
+    const showLoading = !!this.props.searchString && !this.props.searchResults
+    if (showRecPending || showLoading) {
+      return (
+        <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny" style={styles.loadingContainer}>
+          <Kb.Icon style={Kb.iconCastPlatformStyles(styles.loadingIcon)} type="icon-progress-grey-animated" />
+          <Kb.Text type="BodySmallSemibold">Loading</Kb.Text>
+        </Kb.Box2>
+      )
+    }
+    if (!this.props.showRecs && !this.props.showServiceResultCount && !!this.props.selectedService) {
+      return (
+        <Kb.Box2
+          alignSelf="center"
+          centerChildren={true}
+          direction="vertical"
+          fullHeight={true}
+          fullWidth={true}
+          gap="tiny"
+          style={styles.emptyContainer}
+        >
+          <Kb.Icon
+            fontSize={Styles.isMobile ? 48 : 64}
+            type={serviceIdToIconFont(this.props.selectedService)}
+            style={Styles.collapseStyles([
+              !!this.props.selectedService && {color: serviceIdToAccentColor(this.props.selectedService)},
+            ])}
+          />
+          <Kb.Text center={true} type="BodyBig">
+            Enter a {serviceIdToLabel(this.props.selectedService)} username above.
+          </Kb.Text>
+          <Kb.Text center={true} type="BodySmall">
+            Start a Keybase chat with anyone on {serviceIdToLabel(this.props.selectedService)}, even if they
+            don’t have a Keybase account.
+          </Kb.Text>
+        </Kb.Box2>
+      )
+    }
+    return (
+      <Kb.List
+        items={this.props.showRecs ? this.props.recommendations || [] : this.props.searchResults || []}
+        selectedIndex={this.props.highlightedIndex || 0}
+        style={styles.list}
+        contentContainerStyle={styles.listContentContainer}
+        keyProperty={'key'}
+        onEndReached={this.props.onSearchForMore}
+        renderItem={(index, result) => (
+          <UserResult
+            resultForService={this.props.selectedService}
+            fixedHeight={400}
+            username={result.username}
+            prettyName={result.prettyName}
+            displayLabel={result.displayLabel}
+            services={result.services}
+            inTeam={result.inTeam}
+            isPreExistingTeamMember={result.isPreExistingTeamMember}
+            followingState={result.followingState}
+            highlight={!Styles.isMobile && index === this.props.highlightedIndex}
+            onAdd={() => this.props.onAdd(result.userId)}
+            onRemove={() => this.props.onRemove(result.userId)}
+          />
+        )}
+      />
+    )
+  }
+
   render = () => {
     const props = this.props
-    const showRecPending = !props.searchString && !props.recommendations
-    const showLoading = !!props.searchString && !props.searchResults
-    const showRecs = props.showRecs
     return (
       <Kb.Box2 direction="vertical" style={styles.container} fullWidth={true}>
         {Styles.isMobile ? (
@@ -194,65 +258,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
             onRedoRecs={props.fetchUserRecs}
           />
         )}
-        {showRecPending || showLoading ? (
-          <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny" style={styles.loadingContainer}>
-            <Kb.Icon
-              style={Kb.iconCastPlatformStyles(styles.loadingIcon)}
-              type="icon-progress-grey-animated"
-            />
-            <Kb.Text type="BodySmallSemibold">Loading</Kb.Text>
-          </Kb.Box2>
-        ) : !showRecs && !props.showServiceResultCount && !!props.selectedService ? (
-          <Kb.Box2
-            alignSelf="center"
-            centerChildren={true}
-            direction="vertical"
-            fullHeight={true}
-            fullWidth={true}
-            gap="tiny"
-            style={styles.emptyContainer}
-          >
-            <Kb.Icon
-              fontSize={Styles.isMobile ? 48 : 64}
-              type={serviceIdToIconFont(props.selectedService)}
-              style={Styles.collapseStyles([
-                !!props.selectedService && {color: serviceIdToAccentColor(props.selectedService)},
-              ])}
-            />
-            <Kb.Text center={true} type="BodyBig">
-              Enter a {serviceIdToLabel(props.selectedService)} username above.
-            </Kb.Text>
-            <Kb.Text center={true} type="BodySmall">
-              Start a Keybase chat with anyone on {serviceIdToLabel(props.selectedService)}, even if they
-              don’t have a Keybase account.
-            </Kb.Text>
-          </Kb.Box2>
-        ) : (
-          <Kb.List
-            items={showRecs ? props.recommendations || [] : props.searchResults || []}
-            selectedIndex={props.highlightedIndex || 0}
-            style={styles.list}
-            contentContainerStyle={styles.listContentContainer}
-            keyProperty={'key'}
-            onEndReached={props.onSearchForMore}
-            renderItem={(index, result) => (
-              <UserResult
-                resultForService={props.selectedService}
-                fixedHeight={400}
-                username={result.username}
-                prettyName={result.prettyName}
-                displayLabel={result.displayLabel}
-                services={result.services}
-                inTeam={result.inTeam}
-                isPreExistingTeamMember={result.isPreExistingTeamMember}
-                followingState={result.followingState}
-                highlight={!Styles.isMobile && index === props.highlightedIndex}
-                onAdd={() => props.onAdd(result.userId)}
-                onRemove={() => props.onRemove(result.userId)}
-              />
-            )}
-          />
-        )}
+        {this._listBody()}
         {props.waitingForCreate && (
           <Kb.Box2 direction="vertical" style={styles.waiting} alignItems="center">
             <Kb.ProgressIndicator type="Small" white={true} style={styles.waitingProgress} />

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -178,8 +178,33 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
     }
   }
 
-  _getRecLayout = () => {
-    debugger
+  _getRecLayout = (
+    sections: Array<SearchRecSection>,
+    indexInList: number
+  ): {index: number; length: number; offset: number} => {
+    let numSections = 0
+    let numData = 0
+    let length: 40 | 64 = 64
+    let currSectionHeaderIdx = 0
+    for (let i = 0; i < sections.length; i++) {
+      const s = sections[i]
+      if (indexInList === currSectionHeaderIdx) {
+        // we are the section header
+        length = 40
+        break
+      }
+      numSections++
+      const indexInSection = indexInList - currSectionHeaderIdx
+      if (indexInSection < s.data.length) {
+        // we are in this data
+        numData += indexInSection - 1
+        break
+      }
+      // we're not in this section
+      numData += s.data.length
+    }
+    const offset = numSections * 40 + numData * 64
+    return {index: indexInList, length, offset}
   }
 
   _listBody = () => {
@@ -221,7 +246,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         </Kb.Box2>
       )
     }
-    if (this.props.showRecs) {
+    if (this.props.showRecs && this.props.recommendations) {
       // TODO: Scroll on desktop when keyboard nav goes off screen
       return (
         <Kb.Box2

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -4,7 +4,7 @@ import * as Styles from '../styles'
 import * as Container from '../util/container'
 import TeamBox from './team-box'
 import ServiceTabBar from './service-tab-bar'
-import UserResult from './user-result'
+import UserResult, {userResultHeight} from './user-result'
 import Flags from '../util/feature-flags'
 import {serviceIdToAccentColor, serviceIdToIconFont, serviceIdToLabel} from './shared'
 import {ServiceIdWithContact, FollowingState} from '../constants/types/team-building'
@@ -153,7 +153,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       <Kb.Box2 direction="vertical" centerChildren={true} style={styles.alphabetIndex}>
         {this.props.recommendations &&
           this.props.recommendations.map(section =>
-            section.label && section.label.length === 1 ? (
+            section.label.length === 1 ? (
               <Kb.ClickableBox
                 key={section.label}
                 onClick={() => this._onScrollToSection(section.label)}
@@ -208,13 +208,13 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
   ): {index: number; length: number; offset: number} => {
     let numSections = 0
     let numData = 0
-    let length: 40 | 64 = 64
+    let length = userResultHeight
     let currSectionHeaderIdx = 0
     for (let i = 0; i < sections.length; i++) {
       const s = sections[i]
       if (indexInList === currSectionHeaderIdx) {
         // we are the section header
-        length = 40
+        length = Kb.SectionDivider.height
         break
       }
       numSections++

--- a/shared/team-building/user-result.d.ts
+++ b/shared/team-building/user-result.d.ts
@@ -16,4 +16,6 @@ export type Props = {
   onRemove: () => void
 }
 
+export const userResultHeight: number
+
 export default class extends React.PureComponent<Props> {}

--- a/shared/team-building/user-result.d.ts
+++ b/shared/team-building/user-result.d.ts
@@ -9,7 +9,6 @@ export type Props = {
   prettyName: string
   displayLabel: string
   services: {[K in Types.ServiceIdWithContact]?: string}
-  fixedHeight?: number
   inTeam: boolean
   followingState: Types.FollowingState
   highlight: boolean

--- a/shared/team-building/user-result.desktop.tsx
+++ b/shared/team-building/user-result.desktop.tsx
@@ -242,6 +242,7 @@ const AlreadyAddedIconButton = () => (
 )
 
 const ActionButtonSize = Styles.isMobile ? 40 : 32
+export const userResultHeight = 50
 const styles = Styles.styleSheetCreate({
   actionButton: Styles.platformStyles({
     common: {
@@ -293,7 +294,7 @@ const styles = Styles.styleSheetCreate({
       paddingTop: Styles.globalMargins.tiny,
     },
     isElectron: {
-      height: 50,
+      height: userResultHeight,
       paddingLeft: Styles.globalMargins.tiny,
       paddingRight: Styles.globalMargins.tiny,
     },

--- a/shared/team-building/user-result.native.tsx
+++ b/shared/team-building/user-result.native.tsx
@@ -131,7 +131,9 @@ const Username = (props: {
           {props.username}
         </Kb.Text>
         {props.isPreExistingTeamMember ? (
-          <Kb.Text type="BodySmall">{isPreExistingTeamMemberText(props.prettyName)}</Kb.Text>
+          <Kb.Text type="BodySmall" lineClamp={1}>
+            {isPreExistingTeamMemberText(props.prettyName)}
+          </Kb.Text>
         ) : (
           <FormatPrettyName
             displayLabel={props.displayLabel}
@@ -206,10 +208,8 @@ const styles = Styles.styleSheetCreate({
     width: ActionButtonSize,
   },
   rowContainer: {
-    paddingBottom: Styles.globalMargins.tiny,
-    paddingLeft: Styles.globalMargins.xsmall,
-    paddingRight: Styles.globalMargins.xsmall,
-    paddingTop: Styles.globalMargins.tiny,
+    ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.xsmall),
+    height: Styles.globalMargins.xlarge,
   },
   serviceIcon: {
     marginLeft: Styles.globalMargins.xtiny,

--- a/shared/team-building/user-result.native.tsx
+++ b/shared/team-building/user-result.native.tsx
@@ -187,6 +187,7 @@ const AlreadyAddedIconButton = () => (
 )
 
 const ActionButtonSize = 40
+export const userResultHeight = Styles.globalMargins.xlarge
 const styles = Styles.styleSheetCreate({
   actionButton: {
     height: ActionButtonSize,
@@ -209,7 +210,7 @@ const styles = Styles.styleSheetCreate({
   },
   rowContainer: {
     ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.xsmall),
-    height: Styles.globalMargins.xlarge,
+    height: userResultHeight,
   },
   serviceIcon: {
     marginLeft: Styles.globalMargins.xtiny,


### PR DESCRIPTION
Known issues:
- Desktop suggestions no longer scroll if you keyboard nav to an item off screen (Y2K-364)
- Alphabet index can move vertically when keyboard appears
- [x] 0-9 section of index doesn't match design
- [ ] Contacts are not sorted within sections

I could only test this with real data on an iPhone X, if someone has a smaller-screened phone with lots of contacts that would be a useful test case.

![fancy-list](https://user-images.githubusercontent.com/11968340/61964572-34605c00-af9c-11e9-8f96-fb3521bc5544.gif)


cc @keybase/y2ksquad 