### PR TITLE
Plumb through loading state to right buttons

### DIFF
--- a/shared/wallets/nav-header/container.tsx
+++ b/shared/wallets/nav-header/container.tsx
@@ -49,6 +49,7 @@ const mapDispatchToPropsHeaderRightActions = dispatch => ({
 })
 const mergePropsHeaderRightActions = (s, d, _) => ({
   airdropSelected: s.airdropSelected,
+  loading: s._accountID === Types.noAccountID,
   noDisclaimer: s.noDisclaimer,
   onReceive: () => d._onReceive(s._accountID),
   onSettings: d.onSettings,

--- a/shared/wallets/nav-header/index.tsx
+++ b/shared/wallets/nav-header/index.tsx
@@ -52,6 +52,7 @@ export const HeaderTitle = (props: HeaderTitleProps) =>
 
 type HeaderRightActionsProps = {
   airdropSelected: boolean
+  loading: boolean
   noDisclaimer: boolean
   onReceive: () => void
   onSettings: () => void
@@ -61,12 +62,20 @@ export const HeaderRightActions = (props: HeaderRightActionsProps) =>
   props.noDisclaimer || props.airdropSelected ? null : (
     <Kb.Box2 alignItems="flex-end" direction="horizontal" gap="tiny" style={styles.rightActions}>
       <SendButton small={true} />
-      <Kb.Button type="Wallet" mode="Secondary" label="Receive" small={true} onClick={props.onReceive} />
+      <Kb.Button
+        type="Wallet"
+        mode="Secondary"
+        label="Receive"
+        small={true}
+        onClick={props.onReceive}
+        disabled={props.loading}
+      />
       <Kb.Button
         onClick={props.onSettings}
         mode="Secondary"
         small={true}
         type="Wallet"
+        disabled={props.loading}
       >
         <Kb.Icon type="iconfont-gear" style={styles.gear} />
       </Kb.Button>


### PR DESCRIPTION
Addresses an issue where going to the wallet settings screen and attempting to view your account's secret key before the account is totally loaded would result in a black bar. Since you can't really get/change any useful settings before the account is loaded, it seemed best to just disable the settings button completely while loading. I figured it also made sense to disable the recieve button since it's hard to receive if your account id isn't loaded. 

@keybase/react-hackers 