### PR TITLE
Remove header on mobile for the proxy settings page

### DIFF
--- a/shared/settings/proxy/container.tsx
+++ b/shared/settings/proxy/container.tsx
@@ -51,5 +51,5 @@ const ProxySettings = connect(
   mapStateToProps,
   mapDispatchToProps,
   mergeProps
-)(HeaderHoc(ProxySettingsComponent))
+)(ProxySettingsComponent)
 export {ProxySettings}


### PR DESCRIPTION
While refactoring, I accidentally added a header to the proxy settings on mobile. 