### PR TITLE
fix chat header overflow on mobile

### DIFF
--- a/shared/chat/conversation/header-area/normal/index.native.tsx
+++ b/shared/chat/conversation/header-area/normal/index.native.tsx
@@ -70,7 +70,7 @@ const ChannelHeader = (props: Props) => (
     </Box2>
     {!props.smallTeam && (
       <Box2 direction="horizontal" style={styles.channelHeaderContainer}>
-        <Text type="BodyBig" style={styles.channelName}>
+        <Text type="BodyBig" style={styles.channelName} lineClamp={1} ellipsizeMode="tail">
           #{props.channelName}
         </Text>
         {props.muted && <ShhIcon onClick={props.unMuteConversation} />}
@@ -85,8 +85,9 @@ const UsernameHeader = (props: Props) => (
       <ConnectedUsernames
         colorFollowing={true}
         inline={false}
+        lineClamp={props.participants.length > 2 ? 2 : 1}
         commaColor={Styles.globalColors.black_50}
-        type="BodyBig"
+        type={props.participants.length > 2 ? 'BodyTiny' : 'BodyBig'}
         usernames={props.participants}
         containerStyle={styles.center}
         onUsernameClicked={props.onShowProfile}
@@ -119,7 +120,12 @@ const styles = Styles.styleSheetCreate({
     justifyContent: 'center',
     textAlign: 'center',
   },
-  channelHeaderContainer: {alignItems: 'center', alignSelf: 'center'},
+  channelHeaderContainer: {
+    alignItems: 'center',
+    alignSelf: 'center',
+    paddingLeft: Styles.globalMargins.tiny,
+    paddingRight: Styles.globalMargins.tiny,
+  },
   channelName: {
     color: Styles.globalColors.black,
   },

--- a/shared/chat/conversation/header-area/normal/index.stories.tsx
+++ b/shared/chat/conversation/header-area/normal/index.stories.tsx
@@ -25,12 +25,41 @@ const contactNames = {'+15558675309@phone': 'Max Goodman'}
 const load = () => {
   Sb.storiesOf('Chat/Header', module)
     .add('Username Header', () => <UsernameHeader {...defaultProps} />)
+    .add('Username Header - long', () => (
+      <UsernameHeader {...defaultProps} participants={['sjdfiowehfuihewfbdfjkvbeiuwewriovunweoi']} />
+    ))
+    .add('Usernames Header', () => (
+      <UsernameHeader {...defaultProps} participants={['apple', 'banana', 'cherry']} />
+    ))
+    .add('Usernames Header - long', () => (
+      <UsernameHeader
+        {...defaultProps}
+        participants={[
+          'apple',
+          'banana',
+          'cherry',
+          'dragon_fruit',
+          'eggfruit',
+          'fig',
+          'grapefruit',
+          'honeydew',
+          'indian_prune',
+          'jackfruit',
+        ]}
+      />
+    ))
     .add('Username Header with info panel open', () => (
       <UsernameHeader {...defaultProps} infoPanelOpen={true} />
     ))
     .add('Username Header muted', () => <UsernameHeader {...defaultProps} muted={true} />)
     .add('Channel Header for small team', () => <ChannelHeader {...defaultProps} />)
+    .add('Channel Header for small team - long', () => (
+      <ChannelHeader {...defaultProps} teamName="fuewihfioewuhiowvhiowefhuweifohioweu" />
+    ))
     .add('Channel Header for big team', () => <ChannelHeader {...defaultProps} smallTeam={false} />)
+    .add('Channel Header for big team - long', () => (
+      <ChannelHeader {...defaultProps} smallTeam={false} channelName="uweiohfiwehfiowehfioweuhf" />
+    ))
     .add('Phone header', () => (
       <PhoneOrEmailHeader {...defaultProps} participants={phones} contactNames={contactNames} />
     ))

--- a/shared/common-adapters/header-hoc/index.native.tsx
+++ b/shared/common-adapters/header-hoc/index.native.tsx
@@ -322,6 +322,7 @@ const styles = Styles.styleSheetCreate({
       ...Styles.globalStyles.flexBoxColumn,
       alignItems: 'center',
       flexGrow: 1,
+      flexShrink: 2,
       justifyContent: 'center',
     },
     isAndroid: {

--- a/shared/common-adapters/usernames/index.tsx
+++ b/shared/common-adapters/usernames/index.tsx
@@ -26,6 +26,7 @@ export type BaseUsernamesProps = {
   inline?: boolean
   inlineGrammar?: boolean
   joinerStyle?: Styles.StylesCrossPlatform
+  lineClamp?: number
   prefix?: string | null
   redColor?: string
   selectable?: boolean
@@ -159,6 +160,7 @@ class Usernames extends React.Component<Props> {
         style={Styles.collapseStyles([containerStyle, this.props.containerStyle])}
         title={this.props.title}
         ellipsizeMode="tail"
+        lineClamp={this.props.lineClamp}
         {...(this.props.inline ? inlineProps : {})}
       >
         {!!this.props.prefix && (


### PR DESCRIPTION
This is not exactly the same as the new design, but I thought it'd be a good temporary solution for long conversation names on mobile. At least this makes sure the "i" icon is usable.

I didn't end up doing the popup thing as I mentioned in the squad meeting, since the usernames are already clickable.

More specifically, for 1:1 convo, or big team, this keeps original font size, but turns overflown part into `...`. For small team that has more than 2 participants, use BodyTiny, and use `lineClamp=2`.

Some screenshots:

![image](https://user-images.githubusercontent.com/255797/61987857-c41efe00-afce-11e9-83ad-e0085061dac2.png)
![image](https://user-images.githubusercontent.com/255797/61987859-cb460c00-afce-11e9-8d63-f0c90f42b5ac.png)
![image](https://user-images.githubusercontent.com/255797/61987860-d305b080-afce-11e9-9349-26e9b3eb59c0.png)
![image](https://user-images.githubusercontent.com/255797/61987864-dac55500-afce-11e9-98d7-ddedda15f540.png)
![image](https://user-images.githubusercontent.com/255797/61987921-ab631800-afcf-11e9-901e-e699bb1a5b90.png)
![image](https://user-images.githubusercontent.com/255797/61987922-b4ec8000-afcf-11e9-85c9-f5c2eab80c4d.png)

cc @cecileboucheron @adamjspooner @keybase/hotpotatosquad 