### PR TITLE
Better handling of sending non-native assets without an exchange

### DIFF
--- a/shared/chat/conversation/messages/account-payment/container.tsx
+++ b/shared/chat/conversation/messages/account-payment/container.tsx
@@ -58,6 +58,8 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
         return loadingProps
       }
 
+      console.log('paymentInfo:', paymentInfo)
+
       // find the other participant's username
       const conv = Constants.getMeta(state, ownProps.message.conversationIDKey)
       const theirUsername = conv.participants.find(p => p !== you) || ''

--- a/shared/chat/conversation/messages/account-payment/container.tsx
+++ b/shared/chat/conversation/messages/account-payment/container.tsx
@@ -58,8 +58,6 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
         return loadingProps
       }
 
-      console.log('paymentInfo:', paymentInfo)
-
       // find the other participant's username
       const conv = Constants.getMeta(state, ownProps.message.conversationIDKey)
       const theirUsername = conv.participants.find(p => p !== you) || ''

--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -71,13 +71,18 @@ export const AssetInputRecipientAdvanced = (_: EmptyProps) => {
 const LeftBlock = (_: EmptyProps) => {
   const buildingAdvanced = Container.useSelector(state => state.wallets.buildingAdvanced)
   const builtPaymentAdvanced = Container.useSelector(state => state.wallets.builtPaymentAdvanced)
-  const hasTrivialPath = isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset)
+  const hasTrivialPath =
+    buildingAdvanced.senderAsset === 'native'
+      ? isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset)
+      : buildingAdvanced.senderAsset.issuerAccountID !== Types.noAccountID &&
+        isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset) &&
+        !!buildingAdvanced.recipientAmount
 
   if (hasTrivialPath) {
     return (
       <Kb.Box2 direction="vertical" alignItems="flex-start" style={{maxWidth: '40%'}}>
         <Kb.Text type="HeaderBigExtrabold">{buildingAdvanced.recipientAmount}</Kb.Text>
-        {buildingAdvanced.recipientAmount &&
+        {!!buildingAdvanced.recipientAmount &&
           (buildingAdvanced.recipientAsset === 'native' ? (
             <Kb.Text type="BodyTiny">Stellar Lumens</Kb.Text>
           ) : (

--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -464,7 +464,7 @@ const styles = Styles.styleSheetCreate({
   // We need this to make the PickAssetButton on top of other stuff so amount
   // error can extend below it.
   pickAssetButtonOverlayInner: {position: 'absolute', right: 0, top: 0},
-  pickAssetButtonOverlayOuter: {flexShrink: 0, position: 'relative'},
+  pickAssetButtonOverlayOuter: {position: 'relative'},
   pickAssetButtonTopText: Styles.platformStyles({
     isElectron: {lineHeight: '24px'},
     isMobile: {lineHeight: 32},

--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -72,15 +72,14 @@ const LeftBlock = (_: EmptyProps) => {
   const buildingAdvanced = Container.useSelector(state => state.wallets.buildingAdvanced)
   const builtPaymentAdvanced = Container.useSelector(state => state.wallets.builtPaymentAdvanced)
   const hasTrivialPath =
-    buildingAdvanced.senderAsset === 'native'
-      ? isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset)
-      : buildingAdvanced.senderAsset.issuerAccountID !== Types.noAccountID &&
-        isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset) &&
-        !!buildingAdvanced.recipientAmount
+    !!buildingAdvanced.recipientAmount &&
+    isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset) &&
+    (buildingAdvanced.senderAsset === 'native' ||
+      buildingAdvanced.senderAsset.issuerAccountID !== Types.noAccountID)
 
   if (hasTrivialPath) {
     return (
-      <Kb.Box2 direction="vertical" alignItems="flex-start" style={{maxWidth: '40%'}}>
+      <Kb.Box2 direction="vertical" alignItems="flex-start" style={styles.leftBlockContainer}>
         <Kb.Text type="HeaderBigExtrabold">{buildingAdvanced.recipientAmount}</Kb.Text>
         {!!buildingAdvanced.recipientAmount &&
           (buildingAdvanced.recipientAsset === 'native' ? (
@@ -447,6 +446,9 @@ const styles = Styles.styleSheetCreate({
   },
   intermediateTopCircleContainer: {
     top: -Styles.globalMargins.medium,
+  },
+  leftBlockContainer: {
+    maxWidth: '40%',
   },
   noShrink: {
     flexShrink: 0,

--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -71,10 +71,6 @@ export const AssetInputRecipientAdvanced = (_: EmptyProps) => {
 const LeftBlock = (_: EmptyProps) => {
   const buildingAdvanced = Container.useSelector(state => state.wallets.buildingAdvanced)
   const builtPaymentAdvanced = Container.useSelector(state => state.wallets.builtPaymentAdvanced)
-
-  console.log('buildingAdvanced:', buildingAdvanced)
-  console.log('builtPaymentAdvanced:', builtPaymentAdvanced)
-
   const hasTrivialPath = isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset)
 
   if (hasTrivialPath) {
@@ -123,12 +119,8 @@ export const AssetInputSenderAdvanced = (_: EmptyProps) => {
   const buildingAdvanced = Container.useSelector(state => state.wallets.buildingAdvanced)
   const accountMap = Container.useSelector(state => state.wallets.accountMap)
   const senderAccount = accountMap.get(buildingAdvanced.senderAccountID)
-
-  console.log('buildingAdvanced:', buildingAdvanced)
   const hasTrivialPath = isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset)
-
   const sendText = ` will send${hasTrivialPath ? '' : ' approximately'}:`
-
   return (
     <Kb.Box2
       direction="vertical"

--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -87,7 +87,7 @@ const LeftBlock = (_: EmptyProps) => {
           ) : (
             <React.Fragment>
               <Kb.Text type="BodyTiny">{buildingAdvanced.recipientAsset.issuerName}</Kb.Text>
-              <Kb.Text type="BodyTiny" lineClamp={1}>
+              <Kb.Text type="BodyTiny" lineClamp={1} ellipsizeMode="tail">
                 {buildingAdvanced.recipientAsset.code}/{buildingAdvanced.recipientAsset.issuerAccountID}
               </Kb.Text>
             </React.Fragment>

--- a/shared/wallets/send-form/calculate-advanced-button.tsx
+++ b/shared/wallets/send-form/calculate-advanced-button.tsx
@@ -22,7 +22,6 @@ const CalculateAdvancedButton = (props: CalculateAdvancedButtonProps) => {
     buildingAdvanced.recipientAsset === Constants.emptyAssetDescription ||
     buildingAdvanced.senderAsset === Constants.emptyAssetDescription
   const builtPaymentAdvanced = Container.useSelector(state => state.wallets.builtPaymentAdvanced)
-
   const hasTrivialPath = isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset)
   return !isLoading ? (
     props.isIcon ? (

--- a/shared/wallets/send-form/calculate-advanced-button.tsx
+++ b/shared/wallets/send-form/calculate-advanced-button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import {isEqual} from 'lodash-es'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import * as Container from '../../util/container'
@@ -21,6 +22,8 @@ const CalculateAdvancedButton = (props: CalculateAdvancedButtonProps) => {
     buildingAdvanced.recipientAsset === Constants.emptyAssetDescription ||
     buildingAdvanced.senderAsset === Constants.emptyAssetDescription
   const builtPaymentAdvanced = Container.useSelector(state => state.wallets.builtPaymentAdvanced)
+
+  const hasTrivialPath = isEqual(buildingAdvanced.senderAsset, buildingAdvanced.recipientAsset)
   return !isLoading ? (
     props.isIcon ? (
       builtPaymentAdvanced.findPathError ? (
@@ -42,7 +45,7 @@ const CalculateAdvancedButton = (props: CalculateAdvancedButtonProps) => {
     ) : (
       <Kb.Button
         type="Wallet"
-        label="Calculate"
+        label={hasTrivialPath ? 'Confirm details' : 'Calculate'}
         children={
           <Kb.Icon type="iconfont-calculator" color={Styles.globalColors.white} style={styles.icon} />
         }

--- a/shared/wallets/transaction-details/index.stories.tsx
+++ b/shared/wallets/transaction-details/index.stories.tsx
@@ -211,7 +211,22 @@ const load = () => {
         sourceConvRate="22.4474953"
       />
     ))
-    .add('Sent path payment (Asset -> Asset)', () => (
+    .add('Sent path payment (Asset -> Same Asset)', () => (
+      <TransactionDetails
+        {...props}
+        counterpartyMeta="Addie Stokes"
+        counterpartyType="keybaseUser"
+        amountXLM="1 FROG"
+        assetCode="FROG"
+        sourceAmount="1"
+        sourceAsset="FROG"
+        sourceIssuer="froggycoin.io"
+        issuerDescription="froggycoin.io"
+        sourceConvRate="1.000000"
+        pathIntermediate={[]}
+      />
+    ))
+    .add('Sent path payment (Asset -> Different Asset)', () => (
       <TransactionDetails
         {...props}
         counterpartyMeta="Addie Stokes"

--- a/shared/wallets/transaction-details/index.tsx
+++ b/shared/wallets/transaction-details/index.tsx
@@ -311,7 +311,7 @@ const ConvertedCurrencyLabel = (props: ConvertedCurrencyLabelProps) => (
 const TransactionDetails = (props: NotLoadingProps) => {
   const {sender, receiver} = propsToParties(props)
 
-  const isPathPayment = !!props.sourceAmount
+  const hasNontrivialPath = !!props.sourceAmount && props.pathIntermediate.length > 0
 
   // If we don't have a sourceAsset, the source is native Lumens
   const sourceIssuer =
@@ -364,7 +364,7 @@ const TransactionDetails = (props: NotLoadingProps) => {
       </Kb.Box2>
       <Kb.Divider />
       <Kb.Box2 direction="vertical" gap="small" fullWidth={true} style={styles.container}>
-        {isPathPayment && (
+        {hasNontrivialPath && (
           <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
             <Kb.Text type="BodySmallSemibold">Payment path:</Kb.Text>
             <PaymentPath
@@ -377,7 +377,7 @@ const TransactionDetails = (props: NotLoadingProps) => {
           </Kb.Box2>
         )}
 
-        {isPathPayment && (
+        {hasNontrivialPath && (
           <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
             <Kb.Text type="BodySmallSemibold">Conversion rate:</Kb.Text>
             <Kb.Box2 direction="horizontal" gap="small" fullWidth={true}>
@@ -386,7 +386,12 @@ const TransactionDetails = (props: NotLoadingProps) => {
                 assetCode={props.sourceAsset}
                 issuerDescription={sourceIssuer}
               />
-              <Kb.Box2 direction="horizontal" alignSelf="flex-start" centerChildren={true} style={styles.equals}>
+              <Kb.Box2
+                direction="horizontal"
+                alignSelf="flex-start"
+                centerChildren={true}
+                style={styles.equals}
+              >
                 <Kb.Text type="BodyBig">=</Kb.Text>
               </Kb.Box2>
               <ConvertedCurrencyLabel

--- a/shared/wallets/transaction-details/index.tsx
+++ b/shared/wallets/transaction-details/index.tsx
@@ -311,7 +311,11 @@ const ConvertedCurrencyLabel = (props: ConvertedCurrencyLabelProps) => (
 const TransactionDetails = (props: NotLoadingProps) => {
   const {sender, receiver} = propsToParties(props)
 
-  const hasNontrivialPath = !!props.sourceAmount && props.pathIntermediate.length > 0
+  const hasNontrivialPath =
+    !!props.sourceAmount &&
+    props.assetCode !== props.sourceAsset &&
+    props.issuerAccountID !== props.sourceIssuerAccountID &&
+    props.issuerDescription !== props.sourceIssuer
 
   // If we don't have a sourceAsset, the source is native Lumens
   const sourceIssuer =


### PR DESCRIPTION
![out](https://user-images.githubusercontent.com/5677971/62143691-78b26b80-b2be-11e9-99ae-2afe3aeca8a1.gif)

Also updates the transaction details page to hide the conversion rate and payment path for these "trivial path" cases, since seeing a conversion rate of 1 = 1 isn't super helpful.

Note that removing the "by converting..." message in chat is unchanged; we need to plumb through some additional data in that RPC unless we want to remove that text completely, so that'd probably best be handled in a separate PR.

@keybase/react-hackers 
@keybase/picnicsquad 