### PR TITLE
drop golangci-lint from precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,3 @@ repos:
     -   id: go-fmt
     -   id: go-vet
     -   id: go-lint
-    -   id: golangci-lint


### PR DESCRIPTION
sorry i didn't realize you wanted me to test this @strib. This check seemed to scan the whole repo and not just the staged changes, going to drop until other modules are fixed.