### PR TITLE
Fixes to in chat send

### DIFF
--- a/go/chat/wallet/decorate.go
+++ b/go/chat/wallet/decorate.go
@@ -9,6 +9,7 @@ import (
 
 func DecorateWithPayments(ctx context.Context, body string, payments []chat1.TextPayment) string {
 	var added int
+	seen := make(map[string]struct{})
 	paymentMap := make(map[string]chat1.TextPayment)
 	for _, p := range payments {
 		paymentMap[p.PaymentText] = p
@@ -20,6 +21,10 @@ func DecorateWithPayments(ctx context.Context, body string, payments []chat1.Tex
 		if !ok {
 			continue
 		}
+		if _, ok := seen[p.Full]; ok {
+			continue
+		}
+		seen[p.Full] = struct{}{}
 		body, added = utils.DecorateBody(ctx, body, p.Position[0]+offset, p.Position[1]-p.Position[0],
 			chat1.NewUITextDecorationWithPayment(payment))
 		offset += added

--- a/go/chat/wallet/sender.go
+++ b/go/chat/wallet/sender.go
@@ -143,8 +143,13 @@ func (s *Sender) ParsePayments(ctx context.Context, uid gregor1.UID, convID chat
 			continue
 		}
 		seen[p.Full] = struct{}{}
+		normalizedUn := libkb.NewNormalizedUsername(username)
+		if _, ok := seen[normalizedUn.String()]; ok {
+			continue
+		}
+		seen[normalizedUn.String()] = struct{}{}
 		res = append(res, types.ParsedStellarPayment{
-			Username: libkb.NewNormalizedUsername(username),
+			Username: normalizedUn,
 			Amount:   p.Amount,
 			Currency: p.CurrencyCode,
 			Full:     p.Full,

--- a/go/chat/wallet/sender.go
+++ b/go/chat/wallet/sender.go
@@ -120,6 +120,7 @@ func (s *Sender) ParsePayments(ctx context.Context, uid gregor1.UID, convID chat
 		s.Debug(ctx, "ParsePayments: failed to getConvParseInfo %v", err)
 		return nil
 	}
+	seen := make(map[string]struct{})
 	for _, p := range parsed {
 		var username string
 		// The currency might be legit but `KnownCurrencyCodeInstant` may not have data yet.
@@ -138,6 +139,10 @@ func (s *Sender) ParsePayments(ctx context.Context, uid gregor1.UID, convID chat
 			s.Debug(ctx, "ParsePayments: skipping mention for not being in conv")
 			continue
 		}
+		if _, ok := seen[p.Full]; ok {
+			continue
+		}
+		seen[p.Full] = struct{}{}
 		res = append(res, types.ParsedStellarPayment{
 			Username: libkb.NewNormalizedUsername(username),
 			Amount:   p.Amount,

--- a/shared/chat/conversation/messages/message-popup/payment/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/container.tsx
@@ -66,12 +66,7 @@ const sendMapStateToProps = (state: Container.TypedState, ownProps: SendOwnProps
 
 const sendMapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onCancel: (paymentID: WalletTypes.PaymentID) => dispatch(WalletGen.createCancelPayment({paymentID})),
-  onClaimLumens: () =>
-    dispatch(
-      Container.isMobile
-        ? RouteTreeGen.createNavigateAppend({path: WalletConstants.rootWalletPath})
-        : RouteTreeGen.createNavigateAppend({path: WalletConstants.rootWalletPath})
-    ),
+  onClaimLumens: () => dispatch(RouteTreeGen.createNavigateAppend({path: ['walletOnboarding']})),
   onSeeDetails: (accountID: WalletTypes.AccountID, paymentID: WalletTypes.PaymentID) =>
     dispatch(WalletGen.createShowTransaction({accountID, paymentID})),
 })

--- a/shared/chat/conversation/messages/text/container.tsx
+++ b/shared/chat/conversation/messages/text/container.tsx
@@ -90,7 +90,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, {message}: OwnPro
 })
 
 const mergeClaimProps = (stateProps, dispatchProps): ClaimProps => {
-  return !!stateProps.claim ? {onClaim: dispatchProps._onClaim, ...stateProps.claim} : undefined
+  return stateProps.claim ? {onClaim: dispatchProps._onClaim, ...stateProps.claim} : undefined
 }
 
 type MsgType = Props['type']

--- a/shared/chat/conversation/messages/text/container.tsx
+++ b/shared/chat/conversation/messages/text/container.tsx
@@ -1,7 +1,7 @@
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
-import TextMessage, {Props} from '.'
+import TextMessage, {Props, ClaimProps} from '.'
 import * as Container from '../../../../util/container'
 import * as WalletConstants from '../../../../constants/wallets'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
@@ -89,17 +89,16 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, {message}: OwnPro
     ),
 })
 
+const mergeClaimProps = (stateProps, dispatchProps): ClaimProps => {
+  return !!stateProps.claim ? {onClaim: dispatchProps._onClaim, ...stateProps.claim} : undefined
+}
+
 type MsgType = Props['type']
 export default Container.namedConnect(
   mapStateToProps,
   mapDispatchToProps,
   (stateProps, dispatchProps, ownProps: OwnProps) => ({
-    claim: stateProps.claim
-      ? {
-          onClaim: dispatchProps._onClaim,
-          ...stateProps.claim,
-        }
-      : undefined,
+    claim: mergeClaimProps(stateProps, dispatchProps),
     isEditing: stateProps.isEditing,
     message: ownProps.message,
     reply: getReplyProps(ownProps.message.replyTo || undefined, dispatchProps._onReplyClick),

--- a/shared/chat/conversation/messages/text/index.tsx
+++ b/shared/chat/conversation/messages/text/index.tsx
@@ -74,7 +74,27 @@ const Reply = (props: ReplyProps) => {
   )
 }
 
+type ClaimProps = {
+  amount: number
+  label: string
+  onClaim: () => void
+}
+
+const Claim = (props: ClaimProps) => {
+  return (
+    <Kb.Button type="Wallet" onClick={props.onClaim} small={true} style={styles.claimButton}>
+      <Kb.Text style={styles.claimLabel} type="BodySemibold">
+        {props.label}{' '}
+        <Kb.Text style={styles.claimLabel} type="BodyExtrabold">
+          {props.amount}
+        </Kb.Text>
+      </Kb.Text>
+    </Kb.Button>
+  )
+}
+
 export type Props = {
+  claim?: ClaimProps
   isEditing: boolean
   // eslint-disable-next-line
   message: Types.MessageText
@@ -83,7 +103,7 @@ export type Props = {
   type: 'error' | 'pending' | 'sent'
 }
 
-const MessageText = ({isEditing, message, reply, text, type}: Props) => {
+const MessageText = ({claim, isEditing, message, reply, text, type}: Props) => {
   const markdown = (
     <Kb.Markdown
       style={getStyle(type, isEditing)}
@@ -98,6 +118,7 @@ const MessageText = ({isEditing, message, reply, text, type}: Props) => {
     <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
       {!!reply && <Reply {...reply} />}
       {markdown}
+      {!!claim && <Claim {...claim} />}
     </Kb.Box2>
   )
 
@@ -150,6 +171,13 @@ const pendingFailEditing = {
   ...editing,
 }
 const styles = Styles.styleSheetCreate({
+  claimButton: {
+    alignSelf: 'flex-start',
+    marginTop: Styles.globalMargins.xtiny,
+  },
+  claimLabel: {
+    color: Styles.globalColors.white,
+  },
   editing,
   pendingFail,
   pendingFailEditing,

--- a/shared/chat/conversation/messages/text/index.tsx
+++ b/shared/chat/conversation/messages/text/index.tsx
@@ -74,7 +74,7 @@ const Reply = (props: ReplyProps) => {
   )
 }
 
-type ClaimProps = {
+export type ClaimProps = {
   amount: number
   label: string
   onClaim: () => void

--- a/shared/chat/payments/status/container.tsx
+++ b/shared/chat/payments/status/container.tsx
@@ -15,6 +15,7 @@ type Status = Props['status']
 const reduceStatus = (status: string): Status => {
   switch (status) {
     case 'claimable':
+      return 'claimable'
     case 'completed':
       return 'completed'
     case 'pending':
@@ -38,7 +39,11 @@ export default namedConnect(
       : (paymentInfo === null || paymentInfo === undefined ? undefined : paymentInfo.status) || 'pending'
     return {
       allowFontScaling: ownProps.allowFontScaling,
-      allowPopup: status === 'completed' || status === 'pending' || message.author === state.config.username,
+      allowPopup:
+        status === 'completed' ||
+        status === 'pending' ||
+        status === 'claimable' ||
+        message.author === state.config.username,
       errorDetail:
         error || (paymentInfo === null || paymentInfo === undefined ? undefined : paymentInfo.statusDetail), // Auto generated from flowToTs. Please clean me!
       isSendError: !!error,

--- a/shared/chat/payments/status/index.tsx
+++ b/shared/chat/payments/status/index.tsx
@@ -15,7 +15,7 @@ const Kb = {
   Text,
 }
 
-type Status = 'error' | 'pending' | 'completed'
+type Status = 'error' | 'pending' | 'completed' | 'claimable'
 
 type State = {
   showPopup: boolean
@@ -36,6 +36,8 @@ const getIcon = status => {
   switch (status) {
     case 'completed':
       return 'iconfont-success'
+    case 'claimable':
+      return 'iconfont-time'
     case 'pending':
       return 'iconfont-time'
     case 'error':
@@ -119,6 +121,12 @@ class PaymentStatus extends React.Component<Props, State> {
 }
 
 const styles = Styles.styleSheetCreate({
+  claimable: {
+    backgroundColor: Styles.globalColors.black_05,
+    borderRadius: Styles.globalMargins.xxtiny,
+    color: Styles.globalColors.black_50,
+  },
+  claimableIcon: {},
   completed: {
     backgroundColor: Styles.globalColors.purple_10,
     borderRadius: Styles.globalMargins.xxtiny,

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -48,7 +48,7 @@ export const getRequestMessageInfo = (
 
 export const getPaymentMessageInfo = (
   state: TypedState,
-  message: Types.MessageSendPayment
+  message: Types.MessageSendPayment | Types.MessageText
 ): MessageTypes.ChatPaymentInfo | null => {
   const maybePaymentInfo = state.chat2.accountsInfoMap.getIn([message.conversationIDKey, message.id], null)
   if (!maybePaymentInfo) {
@@ -204,6 +204,7 @@ export const makeMessageText = I.Record<MessageTypes._MessageText>({
   mentionsAt: I.Set(),
   mentionsChannel: 'none',
   mentionsChannelName: I.Map(),
+  paymentInfo: null,
   reactions: I.Map(),
   replyTo: null,
   submitState: null,

--- a/shared/constants/types/chat2/message.tsx
+++ b/shared/constants/types/chat2/message.tsx
@@ -117,6 +117,7 @@ export type _MessageText = {
   // eslint-disable-next-line no-use-before-define
   replyTo: Message | null
   text: HiddenString
+  paymentInfo: ChatPaymentInfo | null // If null, we are waiting on this from the service,
   timestamp: number
   unfurls: UnfurlMap
   type: 'text'


### PR DESCRIPTION
fixes the following issues:

- ICS popup not shown when claimable
- claim button not shown for ICS
- duplicate sends per user
- duplicate decoration in chat

in action:

<img width="221" alt="Screen Shot 2019-07-29 at 2 16 56 PM" src="https://user-images.githubusercontent.com/1144020/62097935-83391a80-b256-11e9-8cdf-79796832aa94.png">
<img width="394" alt="Screen Shot 2019-07-29 at 6 42 36 PM" src="https://user-images.githubusercontent.com/1144020/62097937-83391a80-b256-11e9-9aa4-3649c2ab498d.png">


cc @keybase/hotpotatosquad 
