### PR TITLE
downgrate gui config migrate err to dbg

### DIFF
--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -482,7 +482,7 @@ func (g *GlobalContext) ConfigureGUIConfig() error {
 			// old GUI config values from the main config file best-effort.
 			serviceConfig := g.Env.GetConfig()
 			if migrateErr := migrateGUIConfig(serviceConfig, guiConfig); migrateErr != nil {
-				g.Log.Warning("Failed to migrate config to new GUI config file: %s", migrateErr)
+				g.Log.Debug("Failed to migrate config to new GUI config file: %s", migrateErr)
 			}
 
 		}


### PR DESCRIPTION
This wouldn't fix the issue you had. I just couldn't figure out where it could possibly have originated from, since that error was never being returned anywhere (and the warning was wrapped with context anyway).