### PR TITLE
Simplify conv localizer code for contacts

### DIFF
--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -997,7 +997,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 				errMsg, conversationRemote, unverifiedTLFName, chat1.ConversationErrorType_TRANSIENT, nil)
 			return conversationLocal
 		}
-		conversationLocal.Info.Participants = utils.AttachContactNames(s.G().MetaContext(ctx), conversationLocal.Info.Participants)
+		utils.AttachContactNames(s.G().MetaContext(ctx), conversationLocal.Info.Participants)
 	default:
 		conversationLocal.Error = chat1.NewConversationErrorLocal(
 			"unknown members type", conversationRemote, unverifiedTLFName,

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -213,8 +213,8 @@ func AttachContactNames(mctx libkb.MetaContext, participants []chat1.Conversatio
 				contactsFetched = true
 			}
 			participant.ContactName = findContactName(contacts, participant.Username)
+			participants[i] = participant
 		}
-		participants[i] = participant
 	}
 }
 

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -444,3 +444,81 @@ func TestPresentConversationParticipantsLocal(t *testing.T) {
 	require.Equal(t, res[3].Assertion, "example@twitter")
 	require.Equal(t, res[3].Type, chat1.UIParticipantType_USER)
 }
+
+type contactStoreMock struct {
+	contacts []keybase1.ProcessedContact
+}
+
+func (c *contactStoreMock) SaveProcessedContacts(libkb.MetaContext, []keybase1.ProcessedContact) error {
+	return errors.New("contactStoreMock not impl")
+}
+
+func (c *contactStoreMock) RetrieveContacts(libkb.MetaContext) ([]keybase1.ProcessedContact, error) {
+	return c.contacts, nil
+}
+
+func TestAttachContactNames(t *testing.T) {
+	tc := externalstest.SetupTest(t, "chat-utils", 0)
+	defer tc.Cleanup()
+
+	var email keybase1.EmailAddress = "tofurkey@example.com"
+	var phone keybase1.RawPhoneNumber = "+18005558638"
+	contacts := []keybase1.ProcessedContact{
+		keybase1.ProcessedContact{
+			ContactIndex: 0,
+			ContactName:  "Tofu R-Key",
+			Component: keybase1.ContactComponent{
+				Email: &email,
+			},
+			Assertion: "[tofurkey@example.com]@email",
+		},
+		keybase1.ProcessedContact{
+			ContactIndex: 1,
+			ContactName:  "Alice",
+			Component: keybase1.ContactComponent{
+				PhoneNumber: &phone,
+			},
+			Assertion: "18005558638@phone",
+		},
+	}
+
+	mock := &contactStoreMock{contacts}
+	tc.G.SyncedContactList = mock
+
+	rawParticipants := []chat1.ConversationLocalParticipant{
+		chat1.ConversationLocalParticipant{
+			Username: "[tofurkey@example.com]@email",
+		},
+		chat1.ConversationLocalParticipant{
+			Username: "18005558638@phone",
+		},
+		chat1.ConversationLocalParticipant{
+			Username: "ayoubd",
+		},
+		chat1.ConversationLocalParticipant{
+			Username: "example@twitter",
+		},
+	}
+
+	AttachContactNames(tc.MetaContext(), rawParticipants)
+	require.NotNil(t, rawParticipants[0].ContactName)
+	require.Equal(t, "Tofu R-Key", *rawParticipants[0].ContactName)
+	require.NotNil(t, rawParticipants[1].ContactName)
+	require.Equal(t, "Alice", *rawParticipants[1].ContactName)
+	require.Nil(t, rawParticipants[2].ContactName)
+	require.Nil(t, rawParticipants[3].ContactName)
+
+	// Add new contact that has same phone number as alice. AttachContactNames
+	// should no longer attach name for that number because of ambiguity.
+	bob := contacts[1]
+	bob.ContactIndex = 2
+	bob.ContactName = "Bob"
+	mock.contacts = append(mock.contacts, bob)
+
+	AttachContactNames(tc.MetaContext(), rawParticipants)
+	require.NotNil(t, rawParticipants[0].ContactName)
+	require.Equal(t, "Tofu R-Key", *rawParticipants[0].ContactName)
+	require.Nil(t, rawParticipants[1].ContactName)
+	require.Nil(t, rawParticipants[2].ContactName)
+	require.Nil(t, rawParticipants[3].ContactName)
+}


### PR DESCRIPTION
No need to parse the assertion there. Every processed contact will have assertion field that's generated during syncing and it has to match chat assertions because they are used to create these SBS chat convos.

Pass participant list as argument and modify participants in place rather than returning new list.

Fix `contactsFetched` not being set to `true` in the loop, causing contacts to be reloaded for every participant in the list.

Another change - the subject of the ticket - is not to localize participant name if more than one contact matches an assertion. Because we are not saving which contact exactly was used to make the conversation, we can't risk picking the wrong one and confusing the user.