### PR TITLE
Fix highlighting, scrolling, and selecting in "new chat" section list

### DIFF
--- a/shared/common-adapters/section-list.d.ts
+++ b/shared/common-adapters/section-list.d.ts
@@ -1,9 +1,15 @@
 import * as React from 'react'
 import {SectionList} from 'react-native'
 
+// Desktop specific props. `selectedIndex` is used for SectionList with item
+// selecting, where the scroll should follow selected item.
+type DesktopProps = {
+  selectedIndex: number | undefined
+}
+
 // This resolves to 'any'
 // check https://facebook.github.io/react-native/docs/sectionlist#props for the time being
 // TODO import the type from react-native
-export type Props = React.ComponentProps<typeof SectionList>
+export type Props = React.ComponentProps<typeof SectionList> & DesktopProps
 
 export default class extends React.Component<Props> {}

--- a/shared/common-adapters/section-list.desktop.tsx
+++ b/shared/common-adapters/section-list.desktop.tsx
@@ -29,6 +29,17 @@ class SectionList extends React.Component<Props, State> {
       // sections changed so let's also reset the onEndReached call
       this._onEndReached = once(() => this.props.onEndReached && this.props.onEndReached())
     }
+    if (
+      this.props.selectedIndex !== -1 &&
+      this.props.selectedIndex !== prevProps.selectedIndex &&
+      this.props.selectedIndex !== undefined &&
+      this._listRef &&
+      this._listRef.current
+    ) {
+      const index = this._itemIndexToFlatIndex(this.props.selectedIndex)
+      // If index is 1, scroll to 0 instead to show the first section header as well.
+      this._listRef.current.scrollAround(index === 1 ? 0 : index)
+    }
   }
 
   componentWillUnmount() {
@@ -187,6 +198,23 @@ class SectionList extends React.Component<Props, State> {
       return arr
     }, [])
   })
+
+  _itemIndexToFlatIndex = (index: number) => {
+    if (index < 0) {
+      return 0
+    }
+    for (let i = 0; i < this._flat.length; i++) {
+      const item = this._flat[i]
+      if (item.type === 'body') {
+        // are we there yet?
+        if (index === 0) {
+          return i // yes
+        }
+        --index // no
+      }
+    }
+    return this._flat.length - 1
+  }
 
   render() {
     this._flatten(this.props.sections)

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -2,7 +2,7 @@ import logger from '../logger'
 import * as React from 'react'
 import * as I from 'immutable'
 import {debounce, trim} from 'lodash-es'
-import TeamBuilding, {RolePickerProps, SearchRecSection, numSectionLabel} from '.'
+import TeamBuilding, {RolePickerProps, SearchResult, SearchRecSection, numSectionLabel} from '.'
 import RolePickerHeaderAction from './role-picker-header-action'
 import * as WaitingConstants from '../constants/waiting'
 import * as ChatConstants from '../constants/chat2'
@@ -380,6 +380,20 @@ const sortAndSplitRecommendations = memoize(
   }
 )
 
+// Flatten list of recommendation sections. After recommendations are organized
+// in sections, we also need a flat list of all recommendations to be able to
+// know how many we have in total (including "fake" "import contacts" row), and
+// which one is currently highlighted, to support keyboard events.
+//
+// Resulting list may have nulls in place of fake rows.
+const flattenRecommendations = memoize((recommendations: Array<SearchRecSection>) => {
+  const result: Array<SearchResult | null> = []
+  for (const section of recommendations) {
+    result.push(...section.data.map(rec => ('isImportButton' in rec ? null : rec)))
+  }
+  return result
+})
+
 const mergeProps = (
   stateProps: ReturnType<typeof mapStateToProps>,
   dispatchProps: ReturnType<typeof mapDispatchToProps>,
@@ -417,7 +431,10 @@ const mergeProps = (
   }
 
   const showRecs = !ownProps.searchString && !!recommendations && ownProps.selectedService === 'keybase'
-  const userResultsToShow = showRecs ? recommendations : searchResults
+  const recommendationsSections = showRecs
+    ? sortAndSplitRecommendations(recommendations, showingContactsButton)
+    : null
+  const userResultsToShow = showRecs ? flattenRecommendations(recommendationsSections || []) : searchResults
 
   const onChangeText = deriveOnChangeText(
     ownProps.onChangeText,
@@ -520,7 +537,7 @@ const mergeProps = (
       ownProps.showRolePicker && rolePickerArrowKeyFns
         ? rolePickerArrowKeyFns.upArrow
         : ownProps.decHighlightIndex,
-    recommendations: sortAndSplitRecommendations(recommendations, showingContactsButton),
+    recommendations: recommendationsSections,
     rolePickerProps,
     searchResults,
     searchString: ownProps.searchString,

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -268,18 +268,18 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
     (
       highlightedIndex: number | null,
       sections: SearchRecSection[] | null
-    ): [SearchRecSection | null, number] => {
+    ): {index: number; section: SearchRecSection} | null => {
       if (highlightedIndex !== null && sections !== null) {
         let index = highlightedIndex
-        for (const s of sections) {
-          if (index >= s.data.length) {
-            index -= s.data.length
+        for (const section of sections) {
+          if (index >= section.data.length) {
+            index -= section.data.length
           } else {
-            return [s, index]
+            return {index, section}
           }
         }
       }
-      return [null, 0]
+      return null
     }
   )
 
@@ -323,7 +323,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       )
     }
     if (this.props.showRecs && this.props.recommendations) {
-      const [highlightedSection, localIndex] = this._listIndexToSectionAndLocalIndex(
+      const highlightDetails = this._listIndexToSectionAndLocalIndex(
         this.props.highlightedIndex,
         this.props.recommendations
       )
@@ -353,9 +353,9 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
                   followingState={result.followingState}
                   highlight={
                     !Styles.isMobile &&
-                    !!highlightedSection &&
-                    highlightedSection === section &&
-                    localIndex === index
+                    !!highlightDetails &&
+                    highlightDetails.section === section &&
+                    highlightDetails.index === index
                   }
                   onAdd={() => this.props.onAdd(result.userId)}
                   onRemove={() => this.props.onRemove(result.userId)}

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -263,6 +263,20 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
     return {index: indexInList, length, offset}
   }
 
+  _listIndexToSectionAndLocalIndex = (): [SearchRecSection | null, number] => {
+    if (this.props.recommendations && this.props.highlightedIndex !== null) {
+      let index = this.props.highlightedIndex
+      for (const s of this.props.recommendations) {
+        if (index >= s.data.length) {
+          index -= s.data.length
+        } else {
+          return [s, index]
+        }
+      }
+    }
+    return [null, 0]
+  }
+
   _listBody = () => {
     const showRecPending = !this.props.searchString && !this.props.recommendations
     const showLoading = !!this.props.searchString && !this.props.searchResults
@@ -303,6 +317,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       )
     }
     if (this.props.showRecs && this.props.recommendations) {
+      const [highlightedSection, localIndex] = this._listIndexToSectionAndLocalIndex()
       // TODO: Scroll on desktop when keyboard nav goes off screen (Y2K-364)
       return (
         <Kb.Box2
@@ -314,7 +329,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
             ref={this.sectionListRef}
             sections={this.props.recommendations}
             getItemLayout={this._getRecLayout}
-            renderItem={({index, item: result}) =>
+            renderItem={({index, item: result, section}) =>
               result.isImportButton ? (
                 <ContactsImportButton {...this.props} />
               ) : (
@@ -327,7 +342,12 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
                   inTeam={result.inTeam}
                   isPreExistingTeamMember={result.isPreExistingTeamMember}
                   followingState={result.followingState}
-                  highlight={!Styles.isMobile && index === this.props.highlightedIndex}
+                  highlight={
+                    !Styles.isMobile &&
+                    !!highlightedSection &&
+                    highlightedSection === section &&
+                    localIndex === index
+                  }
                   onAdd={() => this.props.onAdd(result.userId)}
                   onRemove={() => this.props.onRemove(result.userId)}
                 />

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -14,7 +14,7 @@ import {memoize} from '../util/memoize'
 
 export const numSectionLabel = '0-9'
 
-type SearchResult = {
+export type SearchResult = {
   userId: string
   username: string
   prettyName: string

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -173,7 +173,6 @@ const ContactsImportButton = (props: ContactProps) => {
 
 class TeamBuilding extends React.PureComponent<Props, {}> {
   sectionListRef = React.createRef<Kb.SectionList>()
-
   componentDidMount = () => {
     this.props.fetchUserRecs()
   }

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -335,7 +335,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         >
           <Kb.SectionList
             ref={this.sectionListRef}
-            selectedIndex={this.props.highlightedIndex || 0}
+            selectedIndex={Styles.isMobile ? undefined : this.props.highlightedIndex || 0}
             sections={this.props.recommendations}
             getItemLayout={this._getRecLayout}
             renderItem={({index, item: result, section}) =>

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -327,7 +327,6 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         this.props.highlightedIndex,
         this.props.recommendations
       )
-      // TODO: Scroll on desktop when keyboard nav goes off screen (Y2K-364)
       return (
         <Kb.Box2
           direction="vertical"


### PR DESCRIPTION
To highlight selected row properly in "new chat" section list, we need to do some calculations to be able to go from "selected index" to "section, index within section". For scrolling (on desktop), we need to be able to go from "selected index" to "index in flat list", where flat list contains rows, sections, and placeholders.

Pressing "enter" key also did not work correctly because to determine which item was highlighted it was using the list from before transforming it into sections. So I made it keep an additional list of flattened sections, that keeps the order within sections but all items are in one list for easy access.