### PR TITLE
Improving contact + keybase search mixing

### DIFF
--- a/go/service/contacts_test.go
+++ b/go/service/contacts_test.go
@@ -103,8 +103,13 @@ func TestContactSyncAndSearch(t *testing.T) {
 	}
 
 	{
-		// When searching for "alice" in contacts, Keybase user comes first.
-		// Contacts results are sorted separately and appended to result list.
+		// When searching for "alice" in contacts, contact comes first because
+		// it's a better match than `alice2` user.
+
+		// NOTE: This test is very unrealistic because contact resolves to user
+		// `alice` but that user is not provided by mocked search provider. If
+		// it was, Keybase result would have precedence, and the first result
+		// would not be SBS contact result.
 		res, err := all.searchHandler.UserSearch(context.Background(), keybase1.UserSearchArg{
 			IncludeContacts: true,
 			Service:         "keybase",
@@ -114,10 +119,10 @@ func TestContactSyncAndSearch(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, res, 2)
 		pres := pluckAllSearchResultForTest(res)
-		require.Equal(t, "alice2", pres[0].id)
-		require.Equal(t, "alice2", pres[0].keybaseUsername)
-		require.Equal(t, "48111222333@phone", pres[1].id)
-		require.Equal(t, "alice", pres[1].keybaseUsername)
+		require.Equal(t, "48111222333@phone", pres[0].id)
+		require.Equal(t, "alice", pres[0].keybaseUsername)
+		require.Equal(t, "alice2", pres[1].id)
+		require.Equal(t, "alice2", pres[1].keybaseUsername)
 	}
 
 	{

--- a/go/service/usersearch.go
+++ b/go/service/usersearch.go
@@ -398,10 +398,6 @@ func (h *UserSearchHandler) UserSearch(ctx context.Context, arg keybase1.UserSea
 		if err != nil {
 			mctx.Warning("Failed to do contacts search: %s", err)
 		} else {
-			sort.Slice(contactsRes, func(i, j int) bool {
-				return contactsRes[i].RawScore > contactsRes[j].RawScore
-			})
-
 			// Filter contacts - If we have a username match coming from the
 			// service, prefer it instead of contact result for the same user
 			// but with SBS assertion in it.
@@ -427,6 +423,10 @@ func (h *UserSearchHandler) UserSearch(ctx context.Context, arg keybase1.UserSea
 				}
 				res = append(res, contact)
 			}
+
+			sort.Slice(res, func(i, j int) bool {
+				return res[i].RawScore > res[j].RawScore
+			})
 
 			for i := range res {
 				res[i].Score = 1.0 / float64(1+i)


### PR DESCRIPTION
New way of appending contact results to keybase results is no good because for some common phrases like "anna" you won't even see your contacts because there are 10s of `anna`s on Keybase.

So after @heronhaye fixed textsearchd scores for followees, we can try to toy with mixing and sorting results from both sources together.