### PR TITLE
Fix the selected tab changing while in 'What is Stellar?' from airdrop

### DIFF
--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -705,8 +705,14 @@ export const getAccountIDs = (state: TypedState) => state.wallets.accountMap.key
 export const getAccounts = (state: TypedState) => state.wallets.accountMap.valueSeq().toList()
 
 export const getAirdropSelected = () => {
-  const path = Router2Constants.getVisibleScreen().routeName
-  return path === 'airdrop' || path === 'airdropQualify'
+  const path = Router2Constants.getFullRoute()
+  const topPath = path[path.length - 1].routeName
+  const nextPathDown = path[path.length - 2].routeName
+  return (
+    topPath === 'airdrop' ||
+    topPath === 'airdropQualify' ||
+    (topPath === 'whatIsStellarModal' && nextPathDown === 'airdrop')
+  )
 }
 
 export const getSelectedAccount = (state: TypedState) => state.wallets.selectedAccount


### PR DESCRIPTION
@keybase/picnicsquad 

The Airdrop option in the wallet account switcher isn't a real account, so we fake its selection in the account list by looking to see if the current route is the Airdrop page. That works up until you go to the "What is Stellar?" modal from that Airdrop page, at which point it's not the current route anymore.

Here's a fix for that, though seems like we'll also want to change this up to make it less brittle.