### PR TITLE
Update proxy support for release

### DIFF
--- a/go/libkb/proxy.go
+++ b/go/libkb/proxy.go
@@ -50,6 +50,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -220,10 +221,20 @@ func (s *httpConnectProxy) Dial(network string, addr string) (net.Conn, error) {
 	return proxyConn, nil
 }
 
-// Must be called in order for the proxy library to support HTTP connect proxies
+var registerLock = sync.Mutex{}
+var hasBeenRegistered = false
+
+// Must be called in order for the proxy library to support HTTP connect proxies. The proxy library uses a map to store
+// this information which can lead to a `fatal error: concurrent map writes` so we use a lock to serialize it and a
+// bool to make it so we only register once (avoid acquiring a lock every time we start a proxy connection).
 func registerHTTPConnectProxies() {
-	proxy.RegisterDialerType("http", newHTTPConnectProxy)
-	proxy.RegisterDialerType("https", newHTTPConnectProxy)
+	if !hasBeenRegistered {
+		registerLock.Lock()
+		proxy.RegisterDialerType("http", newHTTPConnectProxy)
+		proxy.RegisterDialerType("https", newHTTPConnectProxy)
+		hasBeenRegistered = true
+		registerLock.Unlock()
+	}
 }
 
 type ProxyDialOpts struct {

--- a/shared/constants/settings.tsx
+++ b/shared/constants/settings.tsx
@@ -100,7 +100,7 @@ export const makeState = I.Record<Types._State>({
   chat: makeChat(),
   checkPasswordIsCorrect: null,
   contacts: makeContacts(),
-  didToggleCertificatePinning: false,
+  didToggleCertificatePinning: null,
   email: makeEmail(),
   feedback: makeFeedback(),
   invites: makeInvites(),

--- a/shared/constants/types/settings.tsx
+++ b/shared/constants/types/settings.tsx
@@ -139,7 +139,7 @@ export type _State = {
   chat: ChatState
   checkPasswordIsCorrect: boolean | null
   proxyData: RPCTypes.ProxyData | null
-  didToggleCertificatePinning: boolean
+  didToggleCertificatePinning: boolean | null
 }
 export type State = I.RecordOf<_State>
 

--- a/shared/reducers/settings.tsx
+++ b/shared/reducers/settings.tsx
@@ -123,7 +123,7 @@ function reducer(state: Types.State = initialState, action: Actions): Types.Stat
     case SettingsGen.loadedProxyData:
       return state.merge({proxyData: action.payload.proxyData})
     case SettingsGen.certificatePinningToggled:
-      return state.merge({didToggleCertificatePinning: action.payload.toggled || false})
+      return state.merge({didToggleCertificatePinning: action.payload.toggled})
     case SettingsGen.onChangeNewPasswordConfirm:
       return state.update('password', password =>
         password.merge({error: null, newPasswordConfirm: action.payload.password})

--- a/shared/settings/advanced/container.tsx
+++ b/shared/settings/advanced/container.tsx
@@ -7,9 +7,7 @@ import {
   createOnChangeLockdownMode,
   createOnChangeUseNativeFrame,
   createOnChangeRememberPassword,
-  createLoadProxyData,
   createLoadRememberPassword,
-  createSaveProxyData,
   createCertificatePinningToggled,
   createToggleRuntimeStats,
 } from '../../actions/settings-gen'
@@ -21,7 +19,6 @@ import {anyErrors, anyWaiting} from '../../constants/waiting'
 import {compose} from 'recompose'
 import Advanced from './index'
 import {connect, lifecycle, TypedState} from '../../util/container'
-import * as RPCTypes from '../../constants/types/rpc-gen'
 
 type OwnProps = {}
 const mapStateToProps = (state: TypedState) => {
@@ -33,7 +30,6 @@ const mapStateToProps = (state: TypedState) => {
     lockdownModeEnabled: state.settings.lockdownModeEnabled,
     openAtLogin: state.config.openAtLogin,
     processorProfileInProgress: Constants.processorProfileInProgress(state),
-    proxyData: state.settings.proxyData,
     rememberPassword: state.settings.password.rememberPassword,
     setLockdownModeError: (setLockdownModeError && setLockdownModeError.message) || '',
     settingLockdownMode,
@@ -45,9 +41,7 @@ const mapStateToProps = (state: TypedState) => {
 const mapDispatchToProps = dispatch => ({
   _loadHasRandomPW: () => dispatch(createLoadHasRandomPw()),
   _loadLockdownMode: () => dispatch(createLoadLockdownMode()),
-  _loadProxyData: () => dispatch(createLoadProxyData()),
   _loadRememberPassword: () => dispatch(createLoadRememberPassword()),
-  _resetCertPinningToggle: () => dispatch(createCertificatePinningToggled({toggled: null})),
   onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
   onChangeLockdownMode: (checked: boolean) => dispatch(createOnChangeLockdownMode({enabled: checked})),
   onChangeRememberPassword: (checked: boolean) =>
@@ -62,24 +56,19 @@ const mapDispatchToProps = dispatch => ({
   onSetOpenAtLogin: (open: boolean) => dispatch(ConfigGen.createSetOpenAtLogin({open, writeFile: true})),
   onToggleRuntimeStats: () => dispatch(createToggleRuntimeStats()),
   onTrace: (durationSeconds: number) => dispatch(createTrace({durationSeconds})),
-  saveProxyData: (proxyData: RPCTypes.ProxyData) => dispatch(createSaveProxyData({proxyData})),
 })
 
 export default compose(
   connect(
     mapStateToProps,
     mapDispatchToProps,
-      (s, d, o: OwnProps) => ({...o, ...s, ...d})
+    (s, d, o: OwnProps) => ({...o, ...s, ...d})
   ),
   lifecycle({
     componentDidMount() {
       this.props._loadLockdownMode()
       this.props._loadHasRandomPW()
-      this.props._loadProxyData()
       this.props._loadRememberPassword()
-    },
-    componentWillUnmount() {
-      this.props._resetCertPinningToggle()
     },
   } as any),
   HeaderHoc

--- a/shared/settings/proxy/index.tsx
+++ b/shared/settings/proxy/index.tsx
@@ -18,7 +18,9 @@ type State = {
 }
 
 type Props = {
-  allowTlsMitmToggle: boolean
+  _loadProxyData: () => void
+  _resetCertPinningToggle: () => void
+  allowTlsMitmToggle: boolean | null
   onBack: () => void
   onDisableCertPinning: () => void
   onEnableCertPinning: () => void
@@ -45,6 +47,14 @@ class ProxySettings extends React.Component<Props, State> {
       const proxyType = RPCTypes.ProxyType[this.props.proxyData.proxyType]
       this.setState({address, port, proxyType})
     }
+  }
+
+  componentDidMount() {
+    this.props._loadProxyData()
+  }
+
+  componentWillUnmount() {
+    this.props._resetCertPinningToggle()
   }
 
   toggleCertPinning = () => {


### PR DESCRIPTION
The scrict null ts migration caused the cert pinning toggle to stop working. This corrects the types for that state object to be `boolean | null` since null is used to signal that the user has not yet edited the toggle.

In addition, I made two other small tweaks. First, I noticed that when moving the proxy settings component to another file I accidentally left the lifecycle methods in the advanced settings container. I moved these to the proxy settings container where they should be. Second, I discovered while retesting proxy support that the `proxy.RegisterDialerType` method is not threadsafe. If it is called concurrently, it will lead to a `fatal error: concurrent map writes` exception. I added a lock around our usage of that method in order to ensure we don't run into that bug.

I also have now retested proxy support with:
- Socks proxy
- Socks proxy with username and password
- HTTP connect proxy
- HTTP connect proxy with username and password
- HTTP connect proxy with TLS (aka a "https" proxy)

For all of the above tests I simulated a network where the only internet connection is via a proxy (done via a ufw rule that blocked all other connections). I tested chat, files, kbfs, stellar, attachments, unfurling, and profiles.