### PR TITLE
Make nonsuperseded numbers beat superseded ones

### DIFF
--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -379,6 +379,16 @@ const deleteAccountForever = (state: TypedState) => {
   )
 }
 
+const comparePhoneRows = (
+  row1: ChatTypes.Keybase1.UserPhoneNumber,
+  row2: ChatTypes.Keybase1.UserPhoneNumber
+) => {
+  if (row1.superseded !== row2.superseded) {
+    return row1.superseded ? -1 : 1
+  }
+  return row1.phoneNumber.localeCompare(row2.phoneNumber)
+}
+
 const loadSettings = (
   state: TypedState,
   _: SettingsGen.LoadSettingsPayload | ConfigGen.BootstrapStatusLoadedPayload,
@@ -391,7 +401,12 @@ const loadSettings = (
         (settings.emails || []).map(row => [row.email, Constants.makeEmailRow(row)])
       )
       const phoneMap: I.Map<string, Types.PhoneRow> = I.Map(
-        (settings.phoneNumbers || []).map(row => [row.phoneNumber, Constants.toPhoneRow(row)])
+        // Sort the superseded numbers first, so that if a number exxists in both
+        // superseded and non-superseded form, the non-superseded version ends up
+        // in the map.
+        (settings.phoneNumbers || [])
+          .sort(comparePhoneRows)
+          .map(row => [row.phoneNumber, Constants.toPhoneRow(row)])
       )
       const loadedAction = SettingsGen.createLoadedSettings({
         emails: emailMap,


### PR DESCRIPTION
If you try to add a phone number that was previously superseded to your account, it might not appear because there are now two copies of the phone number, one superseded and one not, and the superseded one might be the one that makes it into the redux store. This PR makes the superseded one always lose.


Issue: Y2K-423

cc @keybase/y2ksquad 