### PR TITLE
Move asset links to expanded view

### DIFF
--- a/shared/wallets/asset/index.tsx
+++ b/shared/wallets/asset/index.tsx
@@ -89,7 +89,7 @@ export default class Asset extends React.Component<Props, State> {
           </Kb.Box2>
         </Kb.ClickableBox>
         {this.state.expanded && (
-          <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.expandedRowContainer}>
+          <Kb.Box2 direction="vertical" fullWidth={true} style={styles.expandedRowContainer}>
             {this.props.isNative && (
               <BalanceSummary
                 availableToSend={this.props.availableToSend}
@@ -178,8 +178,8 @@ const BalanceSummary = (props: BalanceSummaryProps) => (
               multiline={true}
             >
               <Kb.Icon
-                fontSize={Styles.isMobile ? 18 : 12}
                 onClick={Styles.isMobile ? props.openStellarURL : null}
+                sizeType="Small"
                 style={styles.questionMark}
                 type="iconfont-question-mark"
               />
@@ -232,7 +232,8 @@ const styles = Styles.styleSheetCreate({
       flexShrink: 1,
     },
     isElectron: {
-      flexBasis: '355px',
+      alignSelf: 'flex-end',
+      width: 355,
     },
   }),
   caret: Styles.platformStyles({

--- a/shared/wallets/asset/index.tsx
+++ b/shared/wallets/asset/index.tsx
@@ -112,6 +112,7 @@ export default class Asset extends React.Component<Props, State> {
                         label={this.props.depositButtonText}
                         onClick={this.props.onDeposit}
                         small={true}
+                        type="Wallet"
                       />
                     </>
                   )}
@@ -123,6 +124,7 @@ export default class Asset extends React.Component<Props, State> {
                         label={this.props.withdrawButtonText}
                         onClick={this.props.onWithdraw}
                         small={true}
+                        type="Wallet"
                       />
                     </>
                   )}
@@ -132,6 +134,7 @@ export default class Asset extends React.Component<Props, State> {
                       label={this.props.infoUrlText}
                       onClick={this.props.openInfoURL}
                       small={true}
+                      type="Wallet"
                     />
                   )}
                 </Kb.ButtonBar>

--- a/shared/wallets/asset/index.tsx
+++ b/shared/wallets/asset/index.tsx
@@ -77,36 +77,6 @@ export default class Asset extends React.Component<Props, State> {
               </Kb.Text>
 
               <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.equivContainer}>
-                {!!this.props.depositButtonText && (
-                  <>
-                    <Kb.Text
-                      type="BodySmallSecondaryLink"
-                      lineClamp={1}
-                      onClick={this.props.onDeposit ? this._onDeposit : undefined}
-                    >
-                      {this.props.depositButtonText}
-                    </Kb.Text>
-                    <Kb.Text style={styles.equivDivider} type="BodySmall">
-                      |
-                    </Kb.Text>
-                  </>
-                )}
-
-                {!!this.props.withdrawButtonText && (
-                  <>
-                    <Kb.Text
-                      type="BodySmallSecondaryLink"
-                      lineClamp={1}
-                      onClick={this.props.onWithdraw ? this._onWithdraw : undefined}
-                    >
-                      {this.props.withdrawButtonText}
-                    </Kb.Text>
-                    <Kb.Text style={styles.equivDivider} type="BodySmall">
-                      |
-                    </Kb.Text>
-                  </>
-                )}
-
                 <Kb.Text
                   type="BodySmallSecondaryLink"
                   lineClamp={1}
@@ -129,7 +99,44 @@ export default class Asset extends React.Component<Props, State> {
                 openStellarURL={this.props.openStellarURL}
               />
             )}
-            {!!this.props.issuerAccountID && <IssuerAccountID issuerAccountID={this.props.issuerAccountID} />}
+            <Kb.Box2 direction="vertical" fullWidth={true}>
+              {!!this.props.issuerAccountID && (
+                <IssuerAccountID issuerAccountID={this.props.issuerAccountID} />
+              )}
+              <Kb.Box2 direction="horizontal" fullWidth={true}>
+                <Kb.ButtonBar direction="row" align="flex-start" small={true}>
+                  {!!this.props.depositButtonText && (
+                    <>
+                      <Kb.Button
+                        mode="Secondary"
+                        label={this.props.depositButtonText}
+                        onClick={this.props.onDeposit}
+                        small={true}
+                      />
+                    </>
+                  )}
+
+                  {!!this.props.withdrawButtonText && (
+                    <>
+                      <Kb.Button
+                        mode="Secondary"
+                        label={this.props.withdrawButtonText}
+                        onClick={this.props.onWithdraw}
+                        small={true}
+                      />
+                    </>
+                  )}
+                  {!!this.props.infoUrlText && (
+                    <Kb.Button
+                      mode="Secondary"
+                      label={this.props.infoUrlText}
+                      onClick={this.props.openInfoURL}
+                      small={true}
+                    />
+                  )}
+                </Kb.ButtonBar>
+              </Kb.Box2>
+            </Kb.Box2>
           </Kb.Box2>
         )}
       </Kb.Box2>
@@ -204,8 +211,8 @@ type IssuerAccountIDProps = {
 
 const IssuerAccountID = (props: IssuerAccountIDProps) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
-    <Kb.Text type="Body">Issuer:</Kb.Text>
-    <Kb.Text type="Body" selectable={true} lineClamp={3}>
+    <Kb.Text type="BodySmall">Issuer:</Kb.Text>
+    <Kb.Text type="BodySmall" selectable={true} lineClamp={3}>
       {props.issuerAccountID}
     </Kb.Text>
   </Kb.Box2>


### PR DESCRIPTION
I moved the links to the expanded view and made them buttons. I kept the Exchange one to the right but I would gladly ditch it if Patrick agrees (I think it clutters the view).

![image](https://user-images.githubusercontent.com/2807426/62402649-9e00dd00-b53d-11e9-92d6-1f0b6c00ab5b.png)

It's a bit tight on iPhone SE though. It should be okay on bigger devices.
![image](https://user-images.githubusercontent.com/2807426/62403030-9c381900-b53f-11e9-9af4-ccc62be186e6.png)

@keybase/react-hackers @patrickxb 