### PR TITLE
Change assertion colors for profile pages

### DIFF
--- a/go/engine/buffered_identify_ui.go
+++ b/go/engine/buffered_identify_ui.go
@@ -92,15 +92,15 @@ func (b *bufferedIdentifyUI) flush(m libkb.MetaContext, trackingBroke bool) (err
 		}
 	}
 
-	for _, k := range b.keys {
-		err = b.raw.DisplayKey(m, k)
+	if b.lastTrack != nil {
+		err = b.raw.ReportLastTrack(m, *b.lastTrack)
 		if err != nil {
 			return err
 		}
 	}
 
-	if b.lastTrack != nil {
-		err = b.raw.ReportLastTrack(m, *b.lastTrack)
+	for _, k := range b.keys {
+		err = b.raw.DisplayKey(m, k)
 		if err != nil {
 			return err
 		}

--- a/go/engine/buffered_identify_ui.go
+++ b/go/engine/buffered_identify_ui.go
@@ -92,15 +92,15 @@ func (b *bufferedIdentifyUI) flush(m libkb.MetaContext, trackingBroke bool) (err
 		}
 	}
 
-	if b.lastTrack != nil {
-		err = b.raw.ReportLastTrack(m, *b.lastTrack)
+	for _, k := range b.keys {
+		err = b.raw.DisplayKey(m, k)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, k := range b.keys {
-		err = b.raw.DisplayKey(m, k)
+	if b.lastTrack != nil {
+		err = b.raw.ReportLastTrack(m, *b.lastTrack)
 		if err != nil {
 			return err
 		}

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -800,14 +800,14 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	if err = iui.Start(m, e.them.GetName(), e.arg.Reason, e.arg.ForceDisplay); err != nil {
 		return err
 	}
+	m.Debug("| IdentifyUI.ReportLastTrack(%s)", e.them.GetName())
+	if err = iui.ReportLastTrack(m, libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName())); err != nil {
+		return err
+	}
 	for _, k := range e.identifyKeys {
 		if err = iui.DisplayKey(m, k); err != nil {
 			return err
 		}
-	}
-	m.Debug("| IdentifyUI.ReportLastTrack(%s)", e.them.GetName())
-	if err = iui.ReportLastTrack(m, libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName())); err != nil {
-		return err
 	}
 	m.Debug("| IdentifyUI.LaunchNetworkChecks(%s)", e.them.GetName())
 	if err = iui.LaunchNetworkChecks(m, e.state.ExportToUncheckedIdentity(m), e.them.Export()); err != nil {

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -800,14 +800,14 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	if err = iui.Start(m, e.them.GetName(), e.arg.Reason, e.arg.ForceDisplay); err != nil {
 		return err
 	}
-	m.Debug("| IdentifyUI.ReportLastTrack(%s)", e.them.GetName())
-	if err = iui.ReportLastTrack(m, libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName())); err != nil {
-		return err
-	}
 	for _, k := range e.identifyKeys {
 		if err = iui.DisplayKey(m, k); err != nil {
 			return err
 		}
+	}
+	m.Debug("| IdentifyUI.ReportLastTrack(%s)", e.them.GetName())
+	if err = iui.ReportLastTrack(m, libkb.ExportTrackSummary(e.state.TrackLookup(), e.them.GetName())); err != nil {
+		return err
 	}
 	m.Debug("| IdentifyUI.LaunchNetworkChecks(%s)", e.them.GetName())
 	if err = iui.LaunchNetworkChecks(m, e.state.ExportToUncheckedIdentity(m), e.them.Export()); err != nil {

--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -148,10 +148,8 @@ func (i *UIAdapter) priority(key string) int {
 	return p
 }
 
-func (i *UIAdapter) getColorForValid() keybase1.Identify3RowColor {
-	// This depends on i.iFollowThem being populated beforehand by
-	// ReportLastTrack.
-	if i.iFollowThem {
+func (i *UIAdapter) getColorForValid(following bool) keybase1.Identify3RowColor {
+	if following {
 		return keybase1.Identify3RowColor_GREEN
 	}
 	return keybase1.Identify3RowColor_BLUE
@@ -167,7 +165,7 @@ func (i *UIAdapter) setRowStatus(mctx libkb.MetaContext, arg *keybase1.Identify3
 	switch {
 	// The proof worked, and either we tracked it as working, or we didn't track it at all.
 	case (lcr.ProofResult.State == keybase1.ProofState_OK && (lcr.RemoteDiff == nil || lcr.RemoteDiff.Type == keybase1.TrackDiffType_NONE)):
-		arg.Color = i.getColorForValid()
+		arg.Color = i.getColorForValid(lcr.RemoteDiff != nil)
 		arg.State = keybase1.Identify3RowState_VALID
 
 	// The proof worked, and it's new to us.
@@ -367,7 +365,7 @@ func (i *UIAdapter) displayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey)
 	switch {
 	case key.TrackDiff == nil || key.TrackDiff.Type == keybase1.TrackDiffType_NONE:
 		arg.State = keybase1.Identify3RowState_VALID
-		arg.Color = i.getColorForValid()
+		arg.Color = i.getColorForValid(key.TrackDiff != nil)
 	case key.TrackDiff != nil && (key.TrackDiff.Type == keybase1.TrackDiffType_REVOKED || key.TrackDiff.Type == keybase1.TrackDiffType_NEW_ELDEST):
 		arg.State = keybase1.Identify3RowState_REVOKED
 		arg.Color = keybase1.Identify3RowColor_RED
@@ -491,7 +489,7 @@ func (i *UIAdapter) plumbCryptocurrency(mctx libkb.MetaContext, crypto keybase1.
 		Value:        crypto.Address,
 		Priority:     i.priority(key),
 		State:        keybase1.Identify3RowState_VALID,
-		Color:        i.getColorForValid(),
+		Color:        i.getColorForValid(i.iFollowThem),
 		SigID:        crypto.SigID,
 		Ctime:        0,
 		SiteURL:      i.makeSigchainViewURL(mctx, crypto.SigID),
@@ -507,7 +505,7 @@ func (i *UIAdapter) plumbStellarAccount(mctx libkb.MetaContext, str keybase1.Ste
 		Value:        str.FederationAddress,
 		Priority:     i.priority("stellar"),
 		State:        keybase1.Identify3RowState_VALID,
-		Color:        i.getColorForValid(),
+		Color:        i.getColorForValid(i.iFollowThem),
 		SigID:        str.SigID,
 		Ctime:        0,
 		SiteURL:      i.makeSigchainViewURL(mctx, str.SigID),

--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -148,6 +148,15 @@ func (i *UIAdapter) priority(key string) int {
 	return p
 }
 
+func (i *UIAdapter) getColorForValid() keybase1.Identify3RowColor {
+	// This depends on i.iFollowThem being populated beforehand by
+	// ReportLastTrack.
+	if i.iFollowThem {
+		return keybase1.Identify3RowColor_GREEN
+	}
+	return keybase1.Identify3RowColor_BLUE
+}
+
 // return true if we need an upgrade
 func (i *UIAdapter) setRowStatus(mctx libkb.MetaContext, arg *keybase1.Identify3Row, lcr keybase1.LinkCheckResult) bool {
 
@@ -156,10 +165,9 @@ func (i *UIAdapter) setRowStatus(mctx libkb.MetaContext, arg *keybase1.Identify3
 		lcr, lcr.Cached, lcr.Diff, lcr.RemoteDiff, lcr.Hint)
 
 	switch {
-
 	// The proof worked, and either we tracked it as working, or we didn't track it at all.
 	case (lcr.ProofResult.State == keybase1.ProofState_OK && (lcr.RemoteDiff == nil || lcr.RemoteDiff.Type == keybase1.TrackDiffType_NONE)):
-		arg.Color = keybase1.Identify3RowColor_GREEN
+		arg.Color = i.getColorForValid()
 		arg.State = keybase1.Identify3RowState_VALID
 
 	// The proof worked, and it's new to us.
@@ -359,7 +367,7 @@ func (i *UIAdapter) displayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey)
 	switch {
 	case key.TrackDiff == nil || key.TrackDiff.Type == keybase1.TrackDiffType_NONE:
 		arg.State = keybase1.Identify3RowState_VALID
-		arg.Color = keybase1.Identify3RowColor_GREEN
+		arg.Color = i.getColorForValid()
 	case key.TrackDiff != nil && (key.TrackDiff.Type == keybase1.TrackDiffType_REVOKED || key.TrackDiff.Type == keybase1.TrackDiffType_NEW_ELDEST):
 		arg.State = keybase1.Identify3RowState_REVOKED
 		arg.Color = keybase1.Identify3RowColor_RED
@@ -483,7 +491,7 @@ func (i *UIAdapter) plumbCryptocurrency(mctx libkb.MetaContext, crypto keybase1.
 		Value:        crypto.Address,
 		Priority:     i.priority(key),
 		State:        keybase1.Identify3RowState_VALID,
-		Color:        keybase1.Identify3RowColor_GREEN,
+		Color:        i.getColorForValid(),
 		SigID:        crypto.SigID,
 		Ctime:        0,
 		SiteURL:      i.makeSigchainViewURL(mctx, crypto.SigID),
@@ -499,7 +507,7 @@ func (i *UIAdapter) plumbStellarAccount(mctx libkb.MetaContext, str keybase1.Ste
 		Value:        str.FederationAddress,
 		Priority:     i.priority("stellar"),
 		State:        keybase1.Identify3RowState_VALID,
-		Color:        keybase1.Identify3RowColor_GREEN,
+		Color:        i.getColorForValid(),
 		SigID:        str.SigID,
 		Ctime:        0,
 		SiteURL:      i.makeSigchainViewURL(mctx, str.SigID),

--- a/go/identify3/identify3_test.go
+++ b/go/identify3/identify3_test.go
@@ -127,7 +127,7 @@ func findRows(t *testing.T, haystack []keybase1.Identify3Row, needles []keybase1
 			return
 		}
 	}
-	t.Fatalf("didn't find all wanted rows")
+	require.Fail(t, "didn't find all wanted rows")
 }
 
 func addBTCAddr(tc libkb.TestContext, u *kbtest.FakeUser, addr string) {
@@ -188,34 +188,34 @@ func TestFollowUnfollowTracy(t *testing.T) {
 	require.NoError(t, err)
 
 	mctx := libkb.NewMetaContextForTest(tc)
-	res := runID3(t, mctx, "t_tracy", true)
+	res := runID3(t, mctx, "t_tracy", true /* follow */)
 	require.Equal(t, res.resultType, keybase1.Identify3ResultType_OK)
 	require.Equal(t, len(res.rows), 9)
 	require.Equal(t, len(res.cards), 1)
 	require.False(t, res.cards[0].YouFollowThem)
 
 	findRows(t, res.rows, []keybase1.Identify3Row{
-		keybase1.Identify3Row{
+		{
 			Key:   "twitter",
 			Value: "tacovontaco",
 			State: keybase1.Identify3RowState_CHECKING,
 			Color: keybase1.Identify3RowColor_GRAY,
 		},
-		keybase1.Identify3Row{
+		{
 			Key:   "twitter",
 			Value: "tacovontaco",
 			State: keybase1.Identify3RowState_VALID,
-			Color: keybase1.Identify3RowColor_GREEN,
+			Color: keybase1.Identify3RowColor_BLUE,
 		},
 	})
 	findRows(t, res.rows, []keybase1.Identify3Row{
-		keybase1.Identify3Row{
+		{
 			Key:   "https",
 			Value: "keybase.io",
 			State: keybase1.Identify3RowState_CHECKING,
 			Color: keybase1.Identify3RowColor_GRAY,
 		},
-		keybase1.Identify3Row{
+		{
 			Key:   "https",
 			Value: "keybase.io",
 			State: keybase1.Identify3RowState_WARNING,
@@ -224,7 +224,7 @@ func TestFollowUnfollowTracy(t *testing.T) {
 		},
 	})
 
-	res = runID3(t, mctx, "t_tracy", false)
+	res = runID3(t, mctx, "t_tracy", false /* follow */)
 	require.Equal(t, res.resultType, keybase1.Identify3ResultType_OK)
 	require.Equal(t, len(res.rows), 9)
 	require.Equal(t, len(res.cards), 1)

--- a/shared/tracker2/assertion/index.tsx
+++ b/shared/tracker2/assertion/index.tsx
@@ -90,6 +90,25 @@ const stateToValueTextStyle = state => {
   }
 }
 
+const assertionColorToTextColor = (c: Types.AssertionColor) => {
+  switch (c) {
+    case 'blue':
+      return Styles.globalColors.blueDark
+    case 'red':
+      return Styles.globalColors.redDark
+    case 'black':
+      return Styles.globalColors.black
+    case 'green':
+      return Styles.globalColors.greenDark
+    case 'gray':
+      return Styles.globalColors.black_50
+    case 'yellow': // fallthrough
+    case 'orange':
+    default:
+      return Styles.globalColors.redDark
+  }
+}
+
 const assertionColorToColor = (c: Types.AssertionColor) => {
   switch (c) {
     case 'blue':
@@ -132,7 +151,7 @@ class _StellarValue extends React.PureComponent<
     return Styles.isMobile ? (
       <Kb.Text
         type="BodyPrimaryLink"
-        style={Styles.collapseStyles([styles.username, {color: assertionColorToColor(this.props.color)}])}
+        style={Styles.collapseStyles([styles.username, {color: assertionColorToTextColor(this.props.color)}])}
       >
         {this.props.value}
       </Kb.Text>
@@ -142,7 +161,10 @@ class _StellarValue extends React.PureComponent<
           <Kb.Text
             type="BodyPrimaryLink"
             onClick={this.props.toggleShowingMenu}
-            style={Styles.collapseStyles([styles.username, {color: assertionColorToColor(this.props.color)}])}
+            style={Styles.collapseStyles([
+              styles.username,
+              {color: assertionColorToTextColor(this.props.color)},
+            ])}
           >
             {this.props.value}
           </Kb.Text>
@@ -191,7 +213,7 @@ const Value = (p: Props) => {
         style={Styles.collapseStyles([
           style,
           stateToValueTextStyle(p.state),
-          {color: assertionColorToColor(p.color)},
+          {color: assertionColorToTextColor(p.color)},
         ])}
       >
         {str}

--- a/shared/tracker2/index.stories.desktop.tsx
+++ b/shared/tracker2/index.stories.desktop.tsx
@@ -141,49 +141,56 @@ const teams = [
   },
 ]
 
-const provider = Sb.createPropProviderWithCommon({
+const Assertion = p => {
+  const a = allAssertions.find(a => a.assertion === p.assertionKey)
+  if (!a) {
+    throw new Error('cant happen')
+  }
+  const parts = a.assertion.split(':')
+  return {
+    color: a.color,
+    metas: a.metas,
+    onClickBadge: Sb.action('onClickBadge'),
+    onShowProof: Sb.action('onShowProof'),
+    onShowSite: Sb.action('onShowSite'),
+    onShowUserOnSite: Sb.action('onShowUserOnSite'),
+    proofURL: a.proofURL,
+    siteIcon: a.siteIcon,
+    siteURL: a.siteURL,
+    state: a.state,
+    type: a.type,
+    value: parts[1],
+    ...p.storyProps,
+  }
+}
+
+const Bio = p => ({
+  ...props,
+  ...p,
+  bio:
+    p.username === 'longbio'
+      ? 'This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very long bio'
+      : props.bio,
+  followersCount: p.username === 'nofollowcounts' ? null : props.followersCount,
+  followingCount: p.username === 'nofollowcounts' ? null : props.followingCount,
+  fullname:
+    p.username === 'longfullname'
+      ? 'mr longlonlonglonlonglonlonglonlonglonggggglonglonglongnarm squire the third'
+      : p.username === 'nofullname'
+      ? null
+      : props.fullname,
+  location:
+    p.username === 'longlocation'
+      ? 'This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very long location'
+      : props.location,
+})
+
+const provider = Sb.createPropProviderWithCommon({Assertion, Bio})
+const providerGreenAssertion = Sb.createPropProviderWithCommon({
   Assertion: p => {
-    const a = allAssertions.find(a => a.assertion === p.assertionKey)
-    if (!a) {
-      throw new Error('cant happen')
-    }
-    const parts = a.assertion.split(':')
-    return {
-      color: a.color,
-      metas: a.metas,
-      onClickBadge: Sb.action('onClickBadge'),
-      onShowProof: Sb.action('onShowProof'),
-      onShowSite: Sb.action('onShowSite'),
-      onShowUserOnSite: Sb.action('onShowUserOnSite'),
-      proofURL: a.proofURL,
-      siteIcon: a.siteIcon,
-      siteURL: a.siteURL,
-      state: a.state,
-      type: a.type,
-      value: parts[1],
-      ...p.storyProps,
-    }
+    return {...Assertion(p), color: 'green'}
   },
-  Bio: p => ({
-    ...props,
-    ...p,
-    bio:
-      p.username === 'longbio'
-        ? 'This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very long bio'
-        : props.bio,
-    followersCount: p.username === 'nofollowcounts' ? null : props.followersCount,
-    followingCount: p.username === 'nofollowcounts' ? null : props.followingCount,
-    fullname:
-      p.username === 'longfullname'
-        ? 'mr longlonlonglonlonglonlonglonlonglonggggglonglonglongnarm squire the third'
-        : p.username === 'nofullname'
-        ? null
-        : props.fullname,
-    location:
-      p.username === 'longlocation'
-        ? 'This is a very very very very very very very very very very very very very very very very very very very very very very very very very very very very long location'
-        : props.location,
-  }),
+  Bio,
 })
 
 const trackerProps = username => ({
@@ -205,11 +212,7 @@ const trackerProps = username => ({
 const load = () => {
   Sb.storiesOf('Tracker2', module)
     .addDecorator(provider)
-    .addDecorator(story => (
-      <Kb.Box2 direction="vertical" style={wrapper}>
-        {story()}
-      </Kb.Box2>
-    ))
+    .addDecorator(vertical)
     .add('Normal', () => <Tracker {...trackerProps('darksim905')} />)
     .add('Long reason', () => <Tracker {...trackerProps('longreason')} />)
     .add('Long bio', () => <Tracker {...trackerProps('longbio')} />)
@@ -220,11 +223,21 @@ const load = () => {
     .add('No followcounts', () => <Tracker {...trackerProps('nofollowcounts')} />)
     .add('OneProof', () => <Tracker {...trackerProps('oneProof')} />)
     .add('NoProofs', () => <Tracker {...trackerProps('noProofs')} />)
-    .add('Green', () => <Tracker {...trackerProps('green')} />)
     .add('Red', () => <Tracker {...trackerProps('red')} />)
     .add('Teams', () => <Tracker {...trackerProps('teams')} />)
     .add('Your username', () => <Tracker {...trackerProps('yourUsername')} />)
+
+  Sb.storiesOf('Tracker2', module)
+    .addDecorator(providerGreenAssertion)
+    .addDecorator(vertical)
+    .add('Green', () => <Tracker {...trackerProps('green')} />)
 }
+
+const vertical = story => (
+  <Kb.Box2 direction="vertical" style={wrapper}>
+    {story()}
+  </Kb.Box2>
+)
 
 const wrapper = {
   height: 470,


### PR DESCRIPTION
There is an unfortunate change where it has to do `ReportLastTrack` first because `DisplayKey` and other proofs depend on whether user is tracked or not. This visibly changes the text order during console `keybase id` command, but does not seem to have any other side effects.

Also changed UI text colors to `dark` variants.