### PR TITLE
Fix airdrop<->disclaimer routing on mobile

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1009,7 +1009,7 @@ const acceptDisclaimer = (_: TypedState) =>
     }
   )
 
-const checkDisclaimer = (_: TypedState, __: WalletsGen.CheckDisclaimerPayload, logger: Saga.SagaLogger) =>
+const checkDisclaimer = (_: TypedState, action: WalletsGen.CheckDisclaimerPayload, logger: Saga.SagaLogger) =>
   RPCStellarTypes.localHasAcceptedDisclaimerLocalRpcPromise()
     .then(accepted => {
       const actions: Array<Action> = [WalletsGen.createWalletDisclaimerReceived({accepted})]
@@ -1018,18 +1018,21 @@ const checkDisclaimer = (_: TypedState, __: WalletsGen.CheckDisclaimerPayload, l
         actions.push(RouteTreeGen.createClearModals())
         actions.push(RouteTreeGen.createSwitchTab({tab: isMobile ? Tabs.settingsTab : Tabs.walletsTab}))
         if (isMobile) {
-          actions.push(RouteTreeGen.createNavigateAppend({path: [SettingsConstants.walletsTab]}))
+          if (action.payload.nextScreen === 'airdrop') {
+            actions.push(
+              RouteTreeGen.createNavigateAppend({
+                path: [...Constants.rootWalletPath, ...(isMobile ? ['airdrop'] : ['wallet', 'airdrop'])],
+              })
+            )
+          }
+          else {
+            actions.push(RouteTreeGen.createNavigateAppend({path: [SettingsConstants.walletsTab]}))
+          }
         }
       }
       return actions
     })
     .catch(err => logger.error(`Error checking wallet disclaimer: ${err.message}`))
-
-const maybeNavToLinkExisting = (_: TypedState, action: WalletsGen.CheckDisclaimerPayload) =>
-  action.payload.nextScreen === 'linkExisting' &&
-  RouteTreeGen.createNavigateAppend({
-    path: [...Constants.rootWalletPath, ...(isMobile ? ['linkExisting'] : ['wallet', 'linkExisting'])],
-  })
 
 const rejectDisclaimer = (_: TypedState, __: WalletsGen.RejectDisclaimerPayload) =>
   isMobile ? RouteTreeGen.createNavigateUp() : RouteTreeGen.createSwitchTab({tab: Tabs.peopleTab})
@@ -1898,11 +1901,6 @@ function* walletsSaga(): Saga.SagaGenerator<any, any> {
     WalletsGen.checkDisclaimer,
     checkDisclaimer,
     'checkDisclaimer'
-  )
-  yield* Saga.chainAction<WalletsGen.CheckDisclaimerPayload>(
-    WalletsGen.checkDisclaimer,
-    maybeNavToLinkExisting,
-    'maybeNavToLinkExisting'
   )
   yield* Saga.chainAction<WalletsGen.RejectDisclaimerPayload>(
     WalletsGen.rejectDisclaimer,

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1024,8 +1024,7 @@ const checkDisclaimer = (_: TypedState, action: WalletsGen.CheckDisclaimerPayloa
                 path: [...Constants.rootWalletPath, ...(isMobile ? ['airdrop'] : ['wallet', 'airdrop'])],
               })
             )
-          }
-          else {
+          } else {
             actions.push(RouteTreeGen.createNavigateAppend({path: [SettingsConstants.walletsTab]}))
           }
         }

--- a/shared/constants/types/wallets.tsx
+++ b/shared/constants/types/wallets.tsx
@@ -3,7 +3,7 @@ import HiddenString from '../../util/hidden-string'
 import * as StellarRPCTypes from './rpc-stellar-gen'
 
 // When accepting the Stellar disclaimer, next path after acceptance
-export type NextScreenAfterAcceptance = '' | 'linkExisting' | 'openWallet'
+export type NextScreenAfterAcceptance = 'airdrop' | 'openWallet'
 
 // Possible roles given an account and a
 // transaction. senderAndReceiver means a transaction sending money

--- a/shared/wallets/airdrop/container.tsx
+++ b/shared/wallets/airdrop/container.tsx
@@ -6,8 +6,8 @@ import * as Container from '../../util/container'
 import Onboarding from '../onboarding/container'
 
 const mapStateToProps = (state: Container.TypedState) => ({
-  acceptedDisclaimer: state.wallets.acceptedDisclaimer,
   _details: state.wallets.airdropDetails.details,
+  acceptedDisclaimer: state.wallets.acceptedDisclaimer,
   loading: state.wallets.airdropState === 'loading',
   signedUp: state.wallets.airdropState === 'accepted',
 })

--- a/shared/wallets/airdrop/container.tsx
+++ b/shared/wallets/airdrop/container.tsx
@@ -24,7 +24,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
 
 export type Props = AirdropProps & {acceptedDisclaimer: boolean}
 const AirdropOrOnboarding = (props: Props) =>
-  props.acceptedDisclaimer ? <Airdrop {...props} /> : <Onboarding nextScreen={'airdrop' as const} />
+  props.acceptedDisclaimer ? <Airdrop {...props} /> : <Onboarding nextScreen="airdrop" />
 
 const ConnectedAirdrop = Container.connect(
   mapStateToProps,

--- a/shared/wallets/airdrop/container.tsx
+++ b/shared/wallets/airdrop/container.tsx
@@ -1,17 +1,18 @@
-import Airdrop from '.'
+import * as React from 'react'
+import Airdrop, {Props as AirdropProps} from '.'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Container from '../../util/container'
+import Onboarding from '../onboarding/container'
 
-type OwnProps = Container.RouteProps
-
-const mapStateToProps = state => ({
+const mapStateToProps = (state: Container.TypedState) => ({
+  acceptedDisclaimer: state.wallets.acceptedDisclaimer,
   _details: state.wallets.airdropDetails.details,
   loading: state.wallets.airdropState === 'loading',
   signedUp: state.wallets.airdropState === 'accepted',
 })
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
   onCheckQualify: () => dispatch(RouteTreeGen.createNavigateAppend({path: ['airdropQualify']})),
   onLoad: () => {
@@ -21,24 +22,33 @@ const mapDispatchToProps = dispatch => ({
   onReject: () => dispatch(WalletsGen.createChangeAirdrop({accept: false})),
 })
 
-const mergeProps = (stateProps, dispatchProps, _: OwnProps) => ({
-  headerBody: stateProps._details.header.body,
-  headerTitle: stateProps._details.header.title,
-  loading: stateProps.loading,
-  onBack: dispatchProps.onBack,
-  onCheckQualify: dispatchProps.onCheckQualify,
-  onLoad: dispatchProps.onLoad,
-  onReject: dispatchProps.onReject,
-  sections: stateProps._details.sections.toArray().map(s => ({
-    icon: s.icon,
-    lines: s.lines.toArray().map(l => ({
-      bullet: l.bullet,
-      text: l.text,
-    })),
-    section: s.section,
-  })),
-  signedUp: stateProps.signedUp,
-  title: 'Airdrop',
-})
+export type Props = AirdropProps & {acceptedDisclaimer: boolean}
+const AirdropOrOnboarding = (props: Props) =>
+  props.acceptedDisclaimer ? <Airdrop {...props} /> : <Onboarding nextScreen={'airdrop' as const} />
 
-export default Container.connect(mapStateToProps, mapDispatchToProps, mergeProps)(Airdrop)
+const ConnectedAirdrop = Container.connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  (stateProps, dispatchProps) => ({
+    acceptedDisclaimer: stateProps.acceptedDisclaimer,
+    headerBody: stateProps._details.header.body,
+    headerTitle: stateProps._details.header.title,
+    loading: stateProps.loading,
+    onBack: dispatchProps.onBack,
+    onCheckQualify: dispatchProps.onCheckQualify,
+    onLoad: dispatchProps.onLoad,
+    onReject: dispatchProps.onReject,
+    sections: stateProps._details.sections.toArray().map(s => ({
+      icon: s.icon,
+      lines: s.lines.toArray().map(l => ({
+        bullet: l.bullet,
+        text: l.text,
+      })),
+      section: s.section,
+    })),
+    signedUp: stateProps.signedUp,
+    title: 'Airdrop',
+  })
+)(AirdropOrOnboarding)
+
+export default ConnectedAirdrop

--- a/shared/wallets/airdrop/index.tsx
+++ b/shared/wallets/airdrop/index.tsx
@@ -5,7 +5,7 @@ import * as Styles from '../../styles'
 import {iconMeta} from '../../common-adapters/icon.constants'
 import openURL from '../../util/open-url'
 
-type Props = {
+export type Props = {
   loading: boolean
   onBack: () => void
   onLoad: () => void

--- a/shared/wallets/onboarding/container.tsx
+++ b/shared/wallets/onboarding/container.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import {connect} from '../../util/container'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as Constants from '../../constants/wallets'
 import * as Container from '../../util/container'
@@ -26,7 +25,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onClose: () => dispatch(WalletsGen.createRejectDisclaimer()),
 })
 
-const ConnectedOnboarding = connect(
+const ConnectedOnboarding = Container.connect(
   mapStateToProps,
   mapDispatchToProps,
   (stateProps, dispatchProps, ownProps: OwnProps) => ({

--- a/shared/wallets/onboarding/container.tsx
+++ b/shared/wallets/onboarding/container.tsx
@@ -43,7 +43,7 @@ const ConnectedOnboarding = connect(
 // routed case and <Onboarding /> case.
 type RoutedOnboardingProps = Container.RouteProps<OwnProps>
 export const RoutedOnboarding = (ownProps: RoutedOnboardingProps) => (
-  <ConnectedOnboarding nextScreen={Container.getRouteProps(ownProps, 'nextScreen', 'openWallet' as const)} />
+  <ConnectedOnboarding nextScreen={Container.getRouteProps(ownProps, 'nextScreen', 'openWallet')} />
 )
 
 export default ConnectedOnboarding

--- a/shared/wallets/onboarding/container.tsx
+++ b/shared/wallets/onboarding/container.tsx
@@ -1,13 +1,17 @@
+import * as React from 'react'
 import {connect} from '../../util/container'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as Constants from '../../constants/wallets'
+import * as Container from '../../util/container'
 import * as Types from '../../constants/types/wallets'
 import {anyErrors} from '../../constants/waiting'
 import Onboarding from '.'
 
-type OwnProps = {}
+type OwnProps = {
+  nextScreen: Types.NextScreenAfterAcceptance
+}
 
-const mapStateToProps = state => {
+const mapStateToProps = (state: Container.TypedState) => {
   const error = anyErrors(state, Constants.acceptDisclaimerWaitingKey)
   return {
     acceptDisclaimerError: error && error.message ? error.message : '',
@@ -15,23 +19,31 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
   onAcceptDisclaimer: () => dispatch(WalletsGen.createAcceptDisclaimer()),
   onCheckDisclaimer: (nextScreen: Types.NextScreenAfterAcceptance) =>
     dispatch(WalletsGen.createCheckDisclaimer({nextScreen})),
   onClose: () => dispatch(WalletsGen.createRejectDisclaimer()),
 })
 
-const mergeProps = (stateProps, dispatchProps, _: OwnProps) => ({
-  acceptDisclaimerError: stateProps.acceptDisclaimerError,
-  acceptingDisclaimerDelay: stateProps.acceptingDisclaimerDelay,
-  onAcceptDisclaimer: dispatchProps.onAcceptDisclaimer,
-  onCheckDisclaimer: dispatchProps.onCheckDisclaimer,
-  onClose: dispatchProps.onClose,
-})
-
-export default connect(
+const ConnectedOnboarding = connect(
   mapStateToProps,
   mapDispatchToProps,
-  mergeProps
+  (stateProps, dispatchProps, ownProps: OwnProps) => ({
+    acceptDisclaimerError: stateProps.acceptDisclaimerError,
+    acceptingDisclaimerDelay: stateProps.acceptingDisclaimerDelay,
+    nextScreen: ownProps.nextScreen,
+    onAcceptDisclaimer: dispatchProps.onAcceptDisclaimer,
+    onCheckDisclaimer: dispatchProps.onCheckDisclaimer,
+    onClose: dispatchProps.onClose,
+  })
 )(Onboarding)
+
+// A wrapper to harmonize the type of OwnProps between the
+// routed case and <Onboarding /> case.
+type RoutedOnboardingProps = Container.RouteProps<OwnProps>
+export const RoutedOnboarding = (ownProps: RoutedOnboardingProps) => (
+  <ConnectedOnboarding nextScreen={Container.getRouteProps(ownProps, 'nextScreen', 'openWallet' as const)} />
+)
+
+export default ConnectedOnboarding

--- a/shared/wallets/onboarding/index.stories.tsx
+++ b/shared/wallets/onboarding/index.stories.tsx
@@ -18,7 +18,7 @@ const load = () => {
         {story()}
       </Box>
     ))
-    .add('Intro', () => <Intro onClose={action('onClose')} setNextScreen={action('setNextScreen')} />)
+    .add('Intro', () => <Intro onClose={action('onClose')} onSeenIntro={action('onSeenIntro')} />)
     .add('Disclaimer', () => (
       <Disclaimer {...actions} acceptDisclaimerError="" acceptingDisclaimerDelay={false} />
     ))

--- a/shared/wallets/onboarding/index.tsx
+++ b/shared/wallets/onboarding/index.tsx
@@ -6,23 +6,24 @@ import Intro from './intro'
 type OnboardingProps = {
   acceptDisclaimerError: string
   acceptingDisclaimerDelay: boolean
+  nextScreen: Types.NextScreenAfterAcceptance
   onAcceptDisclaimer: () => void
   onCheckDisclaimer: (nextScreen: Types.NextScreenAfterAcceptance) => void
   onClose: () => void
 }
 
 type OnboardingState = {
-  nextScreen: '' | 'openWallet' | 'linkExisting'
+  seenIntro: boolean
 }
 
 class Onboarding extends React.Component<OnboardingProps, OnboardingState> {
-  state = {nextScreen: '' as const}
-  _setNextScreen = (nextScreen: Types.NextScreenAfterAcceptance) => {
-    this.setState({nextScreen})
+  state = {seenIntro: false}
+  _seenIntro = () => {
+    this.setState({seenIntro: true})
   }
   render() {
-    if (!this.state.nextScreen) {
-      return <Intro onClose={this.props.onClose} setNextScreen={this._setNextScreen} />
+    if (!this.state.seenIntro) {
+      return <Intro onClose={this.props.onClose} onSeenIntro={this._seenIntro} />
     } else {
       return (
         <Disclaimer
@@ -30,7 +31,7 @@ class Onboarding extends React.Component<OnboardingProps, OnboardingState> {
           acceptingDisclaimerDelay={this.props.acceptingDisclaimerDelay}
           onAcceptDisclaimer={this.props.onAcceptDisclaimer}
           onCheckDisclaimer={() => {
-            this.props.onCheckDisclaimer(this.state.nextScreen)
+            this.props.onCheckDisclaimer(this.props.nextScreen)
           }}
           onNotNow={this.props.onClose}
         />

--- a/shared/wallets/onboarding/intro.tsx
+++ b/shared/wallets/onboarding/intro.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
-import * as Types from '../../constants/types/wallets'
 import * as Styles from '../../styles'
 import {WalletPopup} from '../common'
 
 type IntroProps = {
   onClose: () => void
-  setNextScreen: (nextScreen: Types.NextScreenAfterAcceptance) => void
+  onSeenIntro: () => void
 }
 
 const Intro = (props: IntroProps) => {
@@ -16,7 +15,7 @@ const Intro = (props: IntroProps) => {
       fullWidth={true}
       key={0}
       type="Dim"
-      onClick={() => props.setNextScreen('openWallet')}
+      onClick={props.onSeenIntro}
       label="Open your wallet"
       labelStyle={styles.labelStyle}
     />,

--- a/shared/wallets/routes.tsx
+++ b/shared/wallets/routes.tsx
@@ -17,7 +17,7 @@ import Receive from './receive-modal/container'
 import Sep7Confirm from './sep7-confirm/container'
 import KeybaseLinkError from '../deeplinks/error'
 import Trustline from './trustline/container'
-import WalletOnboarding from './onboarding/container'
+import {RoutedOnboarding} from './onboarding/container'
 import WhatIsStellarModal from './what-is-stellar-modal'
 import Airdrop from './airdrop/container'
 import Settings from './wallet/settings/container'
@@ -119,7 +119,9 @@ export const newModalRoutes = {
     getScreen: (): typeof InflationDestination => require('./wallet/settings/popups').InflationDestination,
   },
   trustline: {getScreen: (): typeof Trustline => require('./trustline/container').default},
-  walletOnboarding: {getScreen: (): typeof WalletOnboarding => require('./onboarding/container').default},
+  walletOnboarding: {
+    getScreen: (): typeof RoutedOnboarding => require('./onboarding/container').RoutedOnboarding,
+  },
   whatIsStellarModal: {
     getScreen: (): typeof WhatIsStellarModal => require('./what-is-stellar-modal').default,
   },

--- a/shared/wallets/wallet/container.tsx
+++ b/shared/wallets/wallet/container.tsx
@@ -47,7 +47,7 @@ const WalletOrOnboarding = (props: Props) =>
   !Container.isMobile || props.acceptedDisclaimer ? (
     <Wallet {...props} />
   ) : (
-    <Onboarding nextScreen={'openWallet' as const} />
+    <Onboarding nextScreen="openWallet" />
   )
 
 export default Container.connect(

--- a/shared/wallets/wallet/container.tsx
+++ b/shared/wallets/wallet/container.tsx
@@ -44,65 +44,73 @@ const sortAndStripTimestamps = (
 // On desktop it's impossible to get here without accepting the
 // disclaimer (from the wallet list).
 const WalletOrOnboarding = (props: Props) =>
-  !Container.isMobile || props.acceptedDisclaimer ? <Wallet {...props} /> : <Onboarding />
+  !Container.isMobile || props.acceptedDisclaimer ? (
+    <Wallet {...props} />
+  ) : (
+    <Onboarding nextScreen={'openWallet' as const} />
+  )
 
-    export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProps, dispatchProps, _: OwnProps) => {
-  const sections: Props['sections'] = []
-  // layout is
-  // 1. assets header and list of assets
-  // 2. transactions header and transactions
-  // Formatted in a SectionList
-  const assets =
-    stateProps.assets.count() > 0 ? stateProps.assets.map((_, index) => index).toArray() : ['notLoadedYet']
-  sections.push({
-    data: assets,
-    title: (
-      <AssetSectionTitle
-        onSetupTrustline={() => dispatchProps.onSetupTrustline(stateProps.accountID)}
-        thisDeviceIsLockedOut={stateProps.thisDeviceIsLockedOut}
-      />
-    ),
-  })
-
-  // split into pending & history
-  let mostRecentID
-  const paymentsList = stateProps.payments && stateProps.payments.toList().toArray()
-  const [_history, _pending] = partition(paymentsList, p => p.section === 'history')
-  const mapItem = p => ({paymentID: p.id, timestamp: p.time})
-  let history: any = _history.map(mapItem)
-  const pending = _pending.map(mapItem)
-
-  if (history.length) {
-    history = sortAndStripTimestamps(history)
-    mostRecentID = history[0].paymentID
-  } else {
-    history = [stateProps.payments ? 'noPayments' : 'notLoadedYet']
-  }
-
-  if (pending.length) {
+export default Container.connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  (stateProps, dispatchProps, _: OwnProps) => {
+    const sections: Props['sections'] = []
+    // layout is
+    // 1. assets header and list of assets
+    // 2. transactions header and transactions
+    // Formatted in a SectionList
+    const assets =
+      stateProps.assets.count() > 0 ? stateProps.assets.map((_, index) => index).toArray() : ['notLoadedYet']
     sections.push({
-      data: sortAndStripTimestamps(pending),
-      stripeHeader: true,
-      title: 'Pending',
+      data: assets,
+      title: (
+        <AssetSectionTitle
+          onSetupTrustline={() => dispatchProps.onSetupTrustline(stateProps.accountID)}
+          thisDeviceIsLockedOut={stateProps.thisDeviceIsLockedOut}
+        />
+      ),
     })
-  }
 
-  sections.push({
-    data: history,
-    title: 'History',
-  })
+    // split into pending & history
+    let mostRecentID
+    const paymentsList = stateProps.payments && stateProps.payments.toList().toArray()
+    const [_history, _pending] = partition(paymentsList, p => p.section === 'history')
+    const mapItem = p => ({paymentID: p.id, timestamp: p.time})
+    let history: any = _history.map(mapItem)
+    const pending = _pending.map(mapItem)
 
-  return {
-    acceptedDisclaimer: stateProps.acceptedDisclaimer,
-    accountID: stateProps.accountID,
-    loadingMore: stateProps.loadingMore,
-    onBack: dispatchProps.onBack,
-    onLoadMore: () => dispatchProps._onLoadMore(stateProps.accountID),
-    onMarkAsRead: () => {
-      if (mostRecentID) {
-        dispatchProps._onMarkAsRead(stateProps.accountID, mostRecentID)
-      }
-    },
-    sections,
+    if (history.length) {
+      history = sortAndStripTimestamps(history)
+      mostRecentID = history[0].paymentID
+    } else {
+      history = [stateProps.payments ? 'noPayments' : 'notLoadedYet']
+    }
+
+    if (pending.length) {
+      sections.push({
+        data: sortAndStripTimestamps(pending),
+        stripeHeader: true,
+        title: 'Pending',
+      })
+    }
+
+    sections.push({
+      data: history,
+      title: 'History',
+    })
+
+    return {
+      acceptedDisclaimer: stateProps.acceptedDisclaimer,
+      accountID: stateProps.accountID,
+      loadingMore: stateProps.loadingMore,
+      onBack: dispatchProps.onBack,
+      onLoadMore: () => dispatchProps._onLoadMore(stateProps.accountID),
+      onMarkAsRead: () => {
+        if (mostRecentID) {
+          dispatchProps._onMarkAsRead(stateProps.accountID, mostRecentID)
+        }
+      },
+      sections,
+    }
   }
-})(WalletOrOnboarding)
+)(WalletOrOnboarding)

--- a/shared/wallets/wallets-and-details/container.tsx
+++ b/shared/wallets/wallets-and-details/container.tsx
@@ -11,7 +11,11 @@ type Props = {
 }
 
 const WalletsOrOnboarding = (props: Props) =>
-  props.acceptedDisclaimer ? <WalletsAndDetails>{props.children}</WalletsAndDetails> : <Onboarding />
+  props.acceptedDisclaimer ? (
+    <WalletsAndDetails>{props.children}</WalletsAndDetails>
+  ) : (
+    <Onboarding nextScreen={'openWallet' as const} />
+  )
 
 export default connect(
   state => ({acceptedDisclaimer: state.wallets.acceptedDisclaimer}),

--- a/shared/wallets/wallets-and-details/container.tsx
+++ b/shared/wallets/wallets-and-details/container.tsx
@@ -14,7 +14,7 @@ const WalletsOrOnboarding = (props: Props) =>
   props.acceptedDisclaimer ? (
     <WalletsAndDetails>{props.children}</WalletsAndDetails>
   ) : (
-    <Onboarding nextScreen={'openWallet' as const} />
+    <Onboarding nextScreen="openWallet" />
   )
 
 export default connect(


### PR DESCRIPTION
@keybase/picnicsquad CC @xgess @keybase/react-hackers 

When we click "Join the Airdrop" from a banner with the disclaimer not yet accepted, something needs to handle is being temporarily redirected to the disclaimer, and then back to the Airdrop page afterwards.

On desktop, that behavior fell out of the WalletsSubNav bar, but there was nothing to do it on mobile.

So, this PR adds a new `<AirdropOrOnboarding />` component. When somewhere else wants to go to the Airdrop it routes here, and when this component needs to hand off to onboarding it includes a `nextScreen="airdrop"'` that makes it in to the saga for accepting the disclaimer, which routes to the Airdrop page if it's set.

Also some cleanup of the onboarding component: it used to give you the choice between making a new wallet or importing an existing account.  This option's long gone so the code can be simplified.  Added some typing that was missing from existing container components too.

(This is partially based on @xgess's WIP branch.)