### PR TITLE
Close profile airdrop popup on select

### DIFF
--- a/shared/tracker2/bio/index.tsx
+++ b/shared/tracker2/bio/index.tsx
@@ -38,7 +38,7 @@ const _AirdropPopup = (p: Kb.PropsWithOverlay<AirdropPopupProps>) => (
     <Kb.Icon color={Styles.globalColors.yellowDark} type="iconfont-identity-stellar" style={styles.star} />
     <Kb.FloatingMenu
       attachTo={p.getAttachmentRef}
-      closeOnSelect={false}
+      closeOnSelect={true}
       containerStyle={styles.floatingContainer}
       listStyle={styles.floatingContainer}
       backgroundColor={Styles.globalColors.purple}


### PR DESCRIPTION
Fixes an issue @xgess noted where the popup remained even after a selection.