### PR TITLE
Plumb through error messages on trivial path payments

### DIFF
--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -79,19 +79,29 @@ const LeftBlock = (_: EmptyProps) => {
 
   if (hasTrivialPath) {
     return (
-      <Kb.Box2 direction="vertical" alignItems="flex-start" style={styles.leftBlockContainer}>
-        <Kb.Text type="HeaderBigExtrabold">{buildingAdvanced.recipientAmount}</Kb.Text>
+      <Kb.Box2 direction="vertical" alignItems="flex-start">
+        <Kb.Text
+          type="HeaderBigExtrabold"
+          style={builtPaymentAdvanced.amountError ? styles.error : undefined}
+        >
+          {buildingAdvanced.recipientAmount}
+        </Kb.Text>
         {!!buildingAdvanced.recipientAmount &&
           (buildingAdvanced.recipientAsset === 'native' ? (
             <Kb.Text type="BodyTiny">Stellar Lumens</Kb.Text>
           ) : (
             <React.Fragment>
               <Kb.Text type="BodyTiny">{buildingAdvanced.recipientAsset.issuerName}</Kb.Text>
-              <Kb.Text type="BodyTiny" lineClamp={1} ellipsizeMode="tail">
+              <Kb.Text type="BodyTiny" lineClamp={1} ellipsizeMode="tail" style={styles.assetIDContainer}>
                 {buildingAdvanced.recipientAsset.code}/{buildingAdvanced.recipientAsset.issuerAccountID}
               </Kb.Text>
             </React.Fragment>
           ))}
+        {!!builtPaymentAdvanced.amountError && (
+          <Kb.Text type="BodySmall" style={styles.error} lineClamp={3}>
+            {builtPaymentAdvanced.amountError}
+          </Kb.Text>
+        )}
       </Kb.Box2>
     )
   } else if (builtPaymentAdvanced.sourceDisplay) {
@@ -448,7 +458,7 @@ const styles = Styles.styleSheetCreate({
   intermediateTopCircleContainer: {
     top: -Styles.globalMargins.medium,
   },
-  leftBlockContainer: {
+  assetIDContainer: {
     maxWidth: '40%',
   },
   noShrink: {

--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -369,6 +369,9 @@ const styles = Styles.styleSheetCreate({
     height: 20,
     width: 20,
   },
+  assetIDContainer: {
+    maxWidth: '40%',
+  },
   assetPathContainer: {
     backgroundColor: Styles.globalColors.blueGrey,
     padding: Styles.globalMargins.small,
@@ -457,9 +460,6 @@ const styles = Styles.styleSheetCreate({
   },
   intermediateTopCircleContainer: {
     top: -Styles.globalMargins.medium,
-  },
-  assetIDContainer: {
-    maxWidth: '40%',
   },
   noShrink: {
     flexShrink: 0,


### PR DESCRIPTION
Plumb through amount error messages so users know why they can't send payments. The red text is what was added. This same type of error message is shown for non-trivial path payments.

<img width="454" alt="Screen Shot 2019-08-05 at 11 51 39 AM" src="https://user-images.githubusercontent.com/5677971/62487734-6ed5b000-b777-11e9-8d3c-8f0cfc3fd89d.png">
