### PR TITLE
Debounce the onLoadMore function so that it only fires once per scroll event

### DIFF
--- a/shared/wallets/wallet/index.tsx
+++ b/shared/wallets/wallet/index.tsx
@@ -128,7 +128,12 @@ class Wallet extends React.Component<Props> {
     )
 
   _onEndReached = () => {
-    this.props.onLoadMore()
+    // React native's SectionList seems to call the onEndReached method twice each time it hits the end of the list
+    // so only dispatch the action if we aren't already waiting for more data
+    if (!this.props.loadingMore) {
+      console.log('onLoadMore()')
+      this.props.onLoadMore()
+    }
   }
 
   render() {

--- a/shared/wallets/wallet/index.tsx
+++ b/shared/wallets/wallet/index.tsx
@@ -131,7 +131,6 @@ class Wallet extends React.Component<Props> {
     // React native's SectionList seems to call the onEndReached method twice each time it hits the end of the list
     // so only dispatch the action if we aren't already waiting for more data
     if (!this.props.loadingMore) {
-      console.log('onLoadMore()')
       this.props.onLoadMore()
     }
   }


### PR DESCRIPTION
react-native's SectionList seems to have a bug where it calls the `onLoadMore` function twice instead of once. This causes an unnecessary RPC call. Adds an if so as to skip this if we're already waiting on the results of an RPC call.

Closes PICNIC-215 which I was not able to fully reproduce (instead just discovered this which I decided was worth fixing). 