### PR TITLE
Don't spam search while scrolling results

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3348,3 +3348,16 @@ func (k TeambotKey) Generation() int {
 func (k TeambotKey) Material() Bytes32 {
 	return k.Seed
 }
+
+func (r APIUserSearchResult) GetStringIDForCompare() string {
+	switch {
+	case r.Contact != nil:
+		return fmt.Sprintf("%s%s", r.Contact.DisplayName, r.Contact.DisplayLabel)
+	case r.Imptofu != nil:
+		return fmt.Sprintf("%s%s", r.Imptofu.PrettyName, r.Imptofu.Label)
+	case r.Keybase != nil:
+		return r.Keybase.Username
+	default:
+		return ""
+	}
+}

--- a/go/service/usersearch.go
+++ b/go/service/usersearch.go
@@ -434,6 +434,14 @@ func (h *UserSearchHandler) UserSearch(ctx context.Context, arg keybase1.UserSea
 			}
 
 			sort.Slice(res, func(i, j int) bool {
+				// Float comparasion - we expect exact floats here when multiple
+				// results match in same way and yield identical score thorugh
+				// same scoring operations.
+				if res[i].RawScore == res[j].RawScore {
+					idI := res[i].GetStringIDForCompare()
+					idJ := res[j].GetStringIDForCompare()
+					return idI > idJ
+				}
 				return res[i].RawScore > res[j].RawScore
 			})
 

--- a/shared/common-adapters/list.d.ts
+++ b/shared/common-adapters/list.d.ts
@@ -15,6 +15,7 @@ export type Props<Item> = {
   keyboardShouldPersistTaps?: 'never' | 'always' | 'handled' // mobile only,
   windowSize?: number // Mobile only, has a non-RN default,
   onEndReached?: () => void
+  onEndReachedThreshold?: number // mobile only
   ListHeaderComponent?: React.ReactNode // mobile only
 }
 

--- a/shared/common-adapters/list.native.tsx
+++ b/shared/common-adapters/list.native.tsx
@@ -50,6 +50,7 @@ class List extends PureComponent<Props<any>> {
             keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps}
             ListHeaderComponent={this.props.ListHeaderComponent}
             onEndReached={this.props.onEndReached}
+            onEndReachedThreshold={this.props.onEndReachedThreshold}
             windowSize={this.props.windowSize || 10}
             debug={false /* set to true to debug the list */}
           />

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -1,7 +1,7 @@
 import logger from '../logger'
 import * as React from 'react'
 import * as I from 'immutable'
-import {debounce, trim, throttle} from 'lodash-es'
+import {debounce, trim} from 'lodash-es'
 import TeamBuilding, {RolePickerProps, SearchResult, SearchRecSection, numSectionLabel} from '.'
 import RolePickerHeaderAction from './role-picker-header-action'
 import * as WaitingConstants from '../constants/waiting'
@@ -252,12 +252,13 @@ const deriveOnEnterKeyDown = memoizeShallow(
   }
 )
 
-const deriveOnSearchForMore = ({search, searchResults, searchString, selectedService}) =>
-  throttle(() => {
+const deriveOnSearchForMore = memoizeShallow(
+  ({search, searchResults, searchString, selectedService}) => () => {
     if (searchResults && searchResults.length >= 10) {
       search(searchString, selectedService, searchResults.length + 20)
     }
-  }, 500)
+  }
+)
 
 const deriveOnAdd = memoize(
   (userFromUserId, dispatchOnAdd, changeText, resetHighlightIndex) => (userId: string) => {

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -1,7 +1,7 @@
 import logger from '../logger'
 import * as React from 'react'
 import * as I from 'immutable'
-import {debounce, trim} from 'lodash-es'
+import {debounce, trim, throttle} from 'lodash-es'
 import TeamBuilding, {RolePickerProps, SearchResult, SearchRecSection, numSectionLabel} from '.'
 import RolePickerHeaderAction from './role-picker-header-action'
 import * as WaitingConstants from '../constants/waiting'
@@ -252,13 +252,12 @@ const deriveOnEnterKeyDown = memoizeShallow(
   }
 )
 
-const deriveOnSearchForMore = memoizeShallow(
-  ({search, searchResults, searchString, selectedService}) => () => {
+const deriveOnSearchForMore = ({search, searchResults, searchString, selectedService}) =>
+  throttle(() => {
     if (searchResults && searchResults.length >= 10) {
       search(searchString, selectedService, searchResults.length + 20)
     }
-  }
-)
+  }, 500)
 
 const deriveOnAdd = memoize(
   (userFromUserId, dispatchOnAdd, changeText, resetHighlightIndex) => (userId: string) => {

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -348,6 +348,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
           <Kb.SectionList
             ref={this.sectionListRef}
             keyboardDismissMode="on-drag"
+            keyboardShouldPersistTaps="handled"
             selectedIndex={Styles.isMobile ? undefined : this.props.highlightedIndex || 0}
             sections={this.props.recommendations}
             getItemLayout={this._getRecLayout}
@@ -387,6 +388,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         selectedIndex={this.props.highlightedIndex || 0}
         style={styles.list}
         contentContainerStyle={styles.listContentContainer}
+        keyboardShouldPersistTaps="handled"
         keyProperty={'key'}
         onEndReached={this._onEndReached}
         onEndReachedThreshold={0.1}

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -11,6 +11,7 @@ import {ServiceIdWithContact, FollowingState} from '../constants/types/team-buil
 import {Props as OriginalRolePickerProps} from '../teams/role-picker'
 import {TeamRoleType} from '../constants/types/teams'
 import {memoize} from '../util/memoize'
+import {throttle} from 'lodash-es'
 
 export const numSectionLabel = '0-9'
 
@@ -387,7 +388,8 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         style={styles.list}
         contentContainerStyle={styles.listContentContainer}
         keyProperty={'key'}
-        onEndReached={this.props.onSearchForMore}
+        onEndReached={this._onEndReached}
+        onEndReachedThreshold={0.1}
         renderItem={(index, result) => (
           <UserResult
             resultForService={this.props.selectedService}
@@ -406,6 +408,10 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       />
     )
   }
+
+  _onEndReached = throttle(() => {
+    this.props.onSearchForMore()
+  }, 500)
 
   render = () => {
     const props = this.props


### PR DESCRIPTION
- Fix `onEndReached` spam by reducing `onEndReachedThreshold` & throttling the call
- Add `keyboardShouldPersistTaps="handled"` to recs / results lists so you don't have to tap twice to select a row.
- Make search result ordering deterministic (by @zapu)

cc @keybase/y2ksquad 