### PR TITLE
Fix airdrop join modal on android

### DIFF
--- a/shared/wallets/airdrop/qualify/index.tsx
+++ b/shared/wallets/airdrop/qualify/index.tsx
@@ -177,6 +177,7 @@ class Qualified extends React.PureComponent<Props, State> {
           'fade-anim-enter': true,
           'fade-anim-enter-active': this.props.state !== 'accepted',
         })}
+        contentContainerStyle={styles.scrollViewContent}
       >
         <Kb.Box2 noShrink={true} direction="vertical" fullWidth={true} gap="tiny" style={styles.content}>
           <>
@@ -325,6 +326,9 @@ const styles = Styles.styleSheetCreate({
     marginRight: Styles.globalMargins.medium,
   },
   scrollView: {...Styles.globalStyles.fillAbsolute},
+  scrollViewContent: {
+    flex: 1,
+  },
   star: {
     alignSelf: 'center',
     height: 120,


### PR DESCRIPTION
On android the view inside of the scrollview did not take up the full height of the screen.
This led to the buttons overflowing past the end of the view and not being visible. Fixed
by adding `flex: 1` to the scrollview's view via the `contentContainerStyle` prop.

Tested on android and desktop