### PR TITLE
teams: don't deref nil team state pointer before the team is loaded

### DIFF
--- a/go/teams/appkeys.go
+++ b/go/teams/appkeys.go
@@ -28,7 +28,10 @@ func AllApplicationKeysWithKBFS(mctx libkb.MetaContext, team Teamer,
 	if err != nil {
 		return res, err
 	}
-	kbfsKeys := team.MainChain().TlfCryptKeys[application]
+	var kbfsKeys []keybase1.CryptKey
+	if team.MainChain() != nil {
+		kbfsKeys = team.MainChain().TlfCryptKeys[application]
+	}
 	if len(kbfsKeys) > 0 {
 		latestKBFSGen := kbfsKeys[len(kbfsKeys)-1].Generation()
 		for _, k := range kbfsKeys {
@@ -82,7 +85,10 @@ func ApplicationKeyAtGeneration(mctx libkb.MetaContext, team Teamer,
 func ApplicationKeyAtGenerationWithKBFS(mctx libkb.MetaContext, team Teamer,
 	application keybase1.TeamApplication, generation keybase1.PerTeamKeyGeneration) (res keybase1.TeamApplicationKey, err error) {
 
-	kbfsKeys := team.MainChain().TlfCryptKeys[application]
+	var kbfsKeys []keybase1.CryptKey
+	if team.MainChain() != nil {
+		kbfsKeys = team.MainChain().TlfCryptKeys[application]
+	}
 	if len(kbfsKeys) > 0 {
 		latestKBFSGen := keybase1.PerTeamKeyGeneration(kbfsKeys[len(kbfsKeys)-1].Generation())
 		for _, k := range kbfsKeys {
@@ -156,6 +162,10 @@ func applicationKeyForMask(mask keybase1.ReaderKeyMask, secret keybase1.PerTeamK
 
 func readerKeyMask(teamData *keybase1.TeamData,
 	application keybase1.TeamApplication, generation keybase1.PerTeamKeyGeneration) (res keybase1.ReaderKeyMask, err error) {
+
+	if teamData == nil {
+		return res, NewKeyMaskNotFoundErrorForApplication(application)
+	}
 
 	m2, ok := teamData.ReaderKeyMasks[application]
 	if !ok {

--- a/go/teams/keys.go
+++ b/go/teams/keys.go
@@ -19,7 +19,12 @@ import (
 // Get a PTK seed and verify against the sigchain that is the correct key.
 func GetAndVerifyPerTeamKey(mctx libkb.MetaContext, team Teamer, gen keybase1.PerTeamKeyGeneration) (ret keybase1.PerTeamKeySeedItem, err error) {
 
-	ret, ok := team.MainChain().PerTeamKeySeedsUnverified[gen]
+	if team.MainChain() == nil {
+		return ret, libkb.NotFoundError{Msg: fmt.Sprintf("no team secret found at generation %v, since inner team was nil", gen)}
+	}
+
+	var ok bool
+	ret, ok = team.MainChain().PerTeamKeySeedsUnverified[gen]
 	if !ok {
 		return ret, libkb.NotFoundError{
 			Msg: fmt.Sprintf("no team secret found at generation %v", gen)}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -1487,7 +1487,7 @@ func (l *TeamLoader) satisfiesNeedApplicationsAtGenerationsWithKBFS(mctx libkb.M
 	if len(needApplicationsAtGenerations) == 0 {
 		return nil
 	}
-	if state == nil {
+	if state == nil || state.MainChain() == nil {
 		return fmt.Errorf("nil team does not contain applications: %v", needApplicationsAtGenerations)
 	}
 	for ptkGen, apps := range needApplicationsAtGenerations {


### PR DESCRIPTION
@ddworken found a path through the code where his cache was empty, but he still was asking the loader if he had to load the team for KBFS refreshers (for an upgrade maybe?). Fixed with more careful `nil` checking, and while we're at it, guard against a `nil` entry in a `TeamShim` object in more places. This got more complicated since a team now has two chains, so therefore, we might need two `nil` checks.