### PR TITLE
Fix incorrect jsonkey in AVDL

### DIFF
--- a/go/protocol/chat1/api.go
+++ b/go/protocol/chat1/api.go
@@ -505,7 +505,7 @@ func (o ChatList) DeepCopy() ChatList {
 
 type SendRes struct {
 	Message          string                        `codec:"message" json:"message"`
-	MessageID        *MessageID                    `codec:"messageID,omitempty" json:"message_id,omitempty"`
+	MessageID        *MessageID                    `codec:"messageID,omitempty" json:"id,omitempty"`
 	OutboxID         *OutboxID                     `codec:"outboxID,omitempty" json:"outbox_id,omitempty"`
 	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identify_failures"`
 	RateLimits       []RateLimitRes                `codec:"rateLimits" json:"ratelimits"`

--- a/protocol/avdl/chat1/api.avdl
+++ b/protocol/avdl/chat1/api.avdl
@@ -210,7 +210,7 @@ protocol api {
   record SendRes {
     @jsonkey("message")
     string message;
-    @jsonkey("message_id")
+    @jsonkey("id")
     union { null, MessageID } messageID;
     @jsonkey("outbox_id")
     union { null, OutboxID } outboxID;

--- a/protocol/json/chat1/api.json
+++ b/protocol/json/chat1/api.json
@@ -589,7 +589,7 @@
             "MessageID"
           ],
           "name": "messageID",
-          "jsonkey": "message_id"
+          "jsonkey": "id"
         },
         {
           "type": [


### PR DESCRIPTION
In #18623, `SendRes` was defined to have a message id value with key `message_id`. That key should be `id`. I noticed this while writing tests for the go bot library.