### PR TITLE
Add Take Video on Android in Chat

### DIFF
--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.tsx
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.tsx
@@ -42,6 +42,12 @@ class FilePickerPopup extends React.Component<Props> {
           },
           {
             onClick: () => {
+              this.props.onSelect('video', 'camera')
+            },
+            title: 'Take video',
+          },
+          {
+            onClick: () => {
               this.props.onSelect('photo', 'library')
             },
             title: 'Photo from Library',


### PR DESCRIPTION
@keybase/react-hackers let's dogfood this with our devices before we decide to merge it.

For me I tied three devices:

Emulator (API 28): Can crash app, times are wrong, you can't preview video. Very Buggy.
Nexus 5 (API 23): Fails to save video (Your preview is black & blank). 
Pixel (API 28): Works OK.