### PR TITLE
Don't autofocus phone input during signup

### DIFF
--- a/shared/signup/phone-number/index.tsx
+++ b/shared/signup/phone-number/index.tsx
@@ -49,7 +49,7 @@ const EnterPhoneNumber = (props: Props) => {
       <EnterPhoneNumberBody
         // the push prompt might be overlaying us
         // TODO Y2K-57 move phone number earlier and check that email won't have this problem
-        autoFocus={false}
+        autoFocus={!Styles.isMobile}
         onChangeNumber={onChangePhoneNumber}
         onChangeValidity={onChangeValidity}
         onContinue={onContinue}

--- a/shared/signup/phone-number/index.tsx
+++ b/shared/signup/phone-number/index.tsx
@@ -47,6 +47,7 @@ const EnterPhoneNumber = (props: Props) => {
       showHeaderInfoicon={true}
     >
       <EnterPhoneNumberBody
+        autoFocus={false} // the push prompt might be overlaying us
         onChangeNumber={onChangePhoneNumber}
         onChangeValidity={onChangeValidity}
         onContinue={onContinue}
@@ -58,6 +59,7 @@ const EnterPhoneNumber = (props: Props) => {
 }
 
 type BodyProps = {
+  autoFocus: boolean
   onChangeNumber: (phoneNumber: string) => void
   onChangeValidity: (valid: boolean) => void
   onContinue: () => void
@@ -78,6 +80,7 @@ export const EnterPhoneNumberBody = (props: BodyProps) => {
       {props.icon}
       <Kb.Box2 direction="vertical" gap="tiny" gapStart={Styles.isMobile} style={styles.inputBox}>
         <PhoneInput
+          autoFocus={props.autoFocus}
           style={styles.input}
           onChangeNumber={props.onChangeNumber}
           onChangeValidity={props.onChangeValidity}
@@ -96,6 +99,9 @@ export const EnterPhoneNumberBody = (props: BodyProps) => {
       </Kb.Box2>
     </Kb.Box2>
   )
+}
+EnterPhoneNumberBody.defaultProps = {
+  autoFocus: true,
 }
 
 const styles = Styles.styleSheetCreate({

--- a/shared/signup/phone-number/index.tsx
+++ b/shared/signup/phone-number/index.tsx
@@ -47,7 +47,9 @@ const EnterPhoneNumber = (props: Props) => {
       showHeaderInfoicon={true}
     >
       <EnterPhoneNumberBody
-        autoFocus={false} // the push prompt might be overlaying us
+        // the push prompt might be overlaying us
+        // TODO Y2K-57 move phone number earlier and check that email won't have this problem
+        autoFocus={false}
         onChangeNumber={onChangePhoneNumber}
         onChangeValidity={onChangeValidity}
         onContinue={onContinue}

--- a/shared/signup/phone-number/phone-input.tsx
+++ b/shared/signup/phone-number/phone-input.tsx
@@ -213,6 +213,7 @@ class CountrySelector extends React.Component<CountrySelectorProps, CountrySelec
 }
 
 type Props = {
+  autoFocus?: boolean
   defaultCountry?: string
   onChangeNumber: (phoneNumber: string) => void
   onChangeValidity: (valid: boolean) => void
@@ -422,7 +423,7 @@ class _PhoneInput extends React.Component<Kb.PropsWithOverlay<Props>, State> {
             style={Styles.collapseStyles([styles.phoneNumberContainer, styles.fakeInput])}
           >
             <Kb.PlainInput
-              autoFocus={true}
+              autoFocus={this.props.autoFocus}
               style={Styles.collapseStyles([styles.plainInput])}
               flexable={true}
               keyboardType={isIOS ? 'number-pad' : 'numeric'}


### PR DESCRIPTION
The push permissions prompt works outside of the app's routing, it renders on top of the root of the router. After signup we open the add-phone modal with an autofocused input, but the push prompt renders on top but below the keyboard, softlocking the app. Fixed by removing the autofocus during signup.

I think nav2 lets us handle the push prompt more like other screens, I'll ticket moving it to a modal. cc @keybase/y2ksquad 