### PR TITLE
Add contentContainerStyle to success too

### DIFF
--- a/shared/wallets/airdrop/qualify/index.tsx
+++ b/shared/wallets/airdrop/qualify/index.tsx
@@ -25,6 +25,7 @@ const Accepted = p =>
         'fade-anim-enter': true,
         'fade-anim-enter-active': p.state === 'accepted',
       })}
+      contentContainerStyle={styles.scrollViewContent}
     >
       <Kb.Box2 noShrink={true} fullWidth={true} direction="vertical" style={styles.content} gap="medium">
         <Kb.Box2 direction="vertical" style={styles.grow} />


### PR DESCRIPTION
There's no close button on the Accepted interface on android.

I think this will fix that.  It's the same fix that was on the join interface.