### PR TITLE
GetVerifiedConv shouldnt get stuck on localizer suspend

### DIFF
--- a/go/chat/globals/context.go
+++ b/go/chat/globals/context.go
@@ -196,6 +196,13 @@ func CtxAddLocalizerCancelable(ctx context.Context) context.Context {
 	return context.WithValue(ctx, localizerCancelableKey, true)
 }
 
+func CtxRemoveLocalizerCancelable(ctx context.Context) context.Context {
+	if IsLocalizerCancelableCtx(ctx) {
+		return context.WithValue(ctx, localizerCancelableKey, false)
+	}
+	return ctx
+}
+
 func ChatCtx(ctx context.Context, g *Context, mode keybase1.TLFIdentifyBehavior,
 	breaks *[]keybase1.TLFIdentifyFailure, notifier types.IdentifyNotifier) context.Context {
 	if breaks == nil {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -2380,7 +2380,9 @@ func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 
 func GetVerifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 	convID chat1.ConversationID, dataSource types.InboxSourceDataSourceTyp) (res chat1.ConversationLocal, err error) {
-
+	// in case we are being called from within some cancelable context, remove it for the purposes
+	// of this call, since whatever this is is likely a side effect we don't want to get stuck
+	ctx = globals.CtxRemoveLocalizerCancelable(ctx)
 	inbox, _, err := g.InboxSource.Read(ctx, uid, types.ConversationLocalizerBlocking, dataSource, nil,
 		&chat1.GetInboxLocalQuery{
 			ConvIDs: []chat1.ConversationID{convID},


### PR DESCRIPTION
We try to interrupt unboxing inbox items if a fetch of a thread comes in. However, it is possible that we can get stuck outside of deadlock detection's grasp if we try to do a simple load from within a cancelable context like a `GetInboxNonblock` that triggers a thread expunge (from a retention policy). 

cc @joshblum 