### PR TITLE
store assertion -> contact name in phonebook for chat localizer

### DIFF
--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -500,15 +500,4 @@ func TestAttachContactNames(t *testing.T) {
 	require.Equal(t, "Alice", *rawParticipants[1].ContactName)
 	require.Nil(t, rawParticipants[2].ContactName)
 	require.Nil(t, rawParticipants[3].ContactName)
-
-	// Add new contact that has same phone number as alice. AttachContactNames
-	// should no longer attach name for that number because of ambiguity.
-	delete(mock.assertionToName, "18005558638@phone")
-
-	AttachContactNames(tc.MetaContext(), rawParticipants)
-	require.NotNil(t, rawParticipants[0].ContactName)
-	require.Equal(t, "Tofu R-Key", *rawParticipants[0].ContactName)
-	require.Nil(t, rawParticipants[1].ContactName)
-	require.Nil(t, rawParticipants[2].ContactName)
-	require.Nil(t, rawParticipants[3].ContactName)
 }

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -446,7 +446,7 @@ func TestPresentConversationParticipantsLocal(t *testing.T) {
 }
 
 type contactStoreMock struct {
-	contacts []keybase1.ProcessedContact
+	assertionToName map[string]string
 }
 
 func (c *contactStoreMock) SaveProcessedContacts(libkb.MetaContext, []keybase1.ProcessedContact) error {
@@ -454,7 +454,11 @@ func (c *contactStoreMock) SaveProcessedContacts(libkb.MetaContext, []keybase1.P
 }
 
 func (c *contactStoreMock) RetrieveContacts(libkb.MetaContext) ([]keybase1.ProcessedContact, error) {
-	return c.contacts, nil
+	return nil, errors.New("contactStoreMock not impl")
+}
+
+func (c *contactStoreMock) RetrieveAssertionToName(libkb.MetaContext) (map[string]string, error) {
+	return c.assertionToName, nil
 }
 
 func (c *contactStoreMock) UnresolveContactsWithComponent(mctx libkb.MetaContext,
@@ -466,28 +470,12 @@ func TestAttachContactNames(t *testing.T) {
 	tc := externalstest.SetupTest(t, "chat-utils", 0)
 	defer tc.Cleanup()
 
-	var email keybase1.EmailAddress = "tofurkey@example.com"
-	var phone keybase1.RawPhoneNumber = "+18005558638"
-	contacts := []keybase1.ProcessedContact{
-		keybase1.ProcessedContact{
-			ContactIndex: 0,
-			ContactName:  "Tofu R-Key",
-			Component: keybase1.ContactComponent{
-				Email: &email,
-			},
-			Assertion: "[tofurkey@example.com]@email",
-		},
-		keybase1.ProcessedContact{
-			ContactIndex: 1,
-			ContactName:  "Alice",
-			Component: keybase1.ContactComponent{
-				PhoneNumber: &phone,
-			},
-			Assertion: "18005558638@phone",
-		},
+	assertionToName := map[string]string{
+		"[tofurkey@example.com]@email": "Tofu R-Key",
+		"18005558638@phone":            "Alice",
 	}
 
-	mock := &contactStoreMock{contacts}
+	mock := &contactStoreMock{assertionToName}
 	tc.G.SyncedContactList = mock
 
 	rawParticipants := []chat1.ConversationLocalParticipant{
@@ -515,10 +503,7 @@ func TestAttachContactNames(t *testing.T) {
 
 	// Add new contact that has same phone number as alice. AttachContactNames
 	// should no longer attach name for that number because of ambiguity.
-	bob := contacts[1]
-	bob.ContactIndex = 2
-	bob.ContactName = "Bob"
-	mock.contacts = append(mock.contacts, bob)
+	delete(mock.assertionToName, "18005558638@phone")
 
 	AttachContactNames(tc.MetaContext(), rawParticipants)
 	require.NotNil(t, rawParticipants[0].ContactName)

--- a/go/contacts/phonebook.go
+++ b/go/contacts/phonebook.go
@@ -56,6 +56,20 @@ type savedContactsCache struct {
 
 const savedContactsCurrentVer = 1
 
+func assertionToNameDbKey(uid keybase1.UID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBSavedContacts,
+		Key: fmt.Sprintf("lookup:%v", uid),
+	}
+}
+
+type assertionToNameCache struct {
+	AssertionToName map[string]string
+	Version         int
+}
+
+const assertionToNameCurrentVer = 1
+
 func ResolveAndSaveContacts(mctx libkb.MetaContext, provider ContactsProvider, contacts []keybase1.Contact) (err error) {
 	results, err := ResolveContacts(mctx, provider, contacts, keybase1.RegionCode(""))
 	if err != nil {
@@ -68,10 +82,35 @@ func ResolveAndSaveContacts(mctx libkb.MetaContext, provider ContactsProvider, c
 func (s *SavedContactsStore) SaveProcessedContacts(mctx libkb.MetaContext, contacts []keybase1.ProcessedContact) (err error) {
 	val := savedContactsCache{
 		Contacts: contacts,
+		Version:  savedContactsCurrentVer,
 	}
-	val.Version = savedContactsCurrentVer
+
 	cacheKey := savedContactsDbKey(mctx.CurrentUID())
 	err = s.encryptedDB.Put(mctx.Ctx(), cacheKey, val)
+	if err != nil {
+		return err
+	}
+
+	assertionToName := make(map[string]string)
+	toRemove := make(map[string]struct{})
+	for _, contact := range contacts {
+		if _, ok := assertionToName[contact.Assertion]; ok {
+			// multiple contacts match this assertion, remove once we're done
+			toRemove[contact.Assertion] = struct{}{}
+			continue
+		}
+		assertionToName[contact.Assertion] = contact.ContactName
+	}
+	for remove := range toRemove {
+		delete(assertionToName, remove)
+	}
+	lookupVal := assertionToNameCache{
+		AssertionToName: assertionToName,
+		Version:         assertionToNameCurrentVer,
+	}
+
+	cacheKey = assertionToNameDbKey(mctx.CurrentUID())
+	err = s.encryptedDB.Put(mctx.Ctx(), cacheKey, lookupVal)
 	return err
 }
 
@@ -91,6 +130,24 @@ func (s *SavedContactsStore) RetrieveContacts(mctx libkb.MetaContext) (ret []key
 		return ret, nil
 	}
 	return cache.Contacts, nil
+}
+
+func (s *SavedContactsStore) RetrieveAssertionToName(mctx libkb.MetaContext) (ret map[string]string, err error) {
+	cacheKey := assertionToNameDbKey(mctx.CurrentUID())
+	var cache assertionToNameCache
+	found, err := s.encryptedDB.Get(mctx.Ctx(), cacheKey, &cache)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return ret, nil
+	}
+	if cache.Version != assertionToNameCurrentVer {
+		mctx.Warning("assertion to name found but had an old version (found: %d, need: %d), returning empty map",
+			cache.Version, assertionToNameCurrentVer)
+		return ret, nil
+	}
+	return cache.AssertionToName, nil
 }
 
 func (s *SavedContactsStore) UnresolveContactsWithComponent(mctx libkb.MetaContext,

--- a/go/contacts/phonebook_test.go
+++ b/go/contacts/phonebook_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package contacts
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeAssertionToName(t *testing.T) {
+	contacts := []keybase1.ProcessedContact{
+		keybase1.ProcessedContact{
+			Assertion:   "[example@example.com]@email",
+			ContactName: "Example 1",
+		},
+		keybase1.ProcessedContact{
+			Assertion:   "1234567890@phone",
+			ContactName: "Mr. Contact",
+		},
+		keybase1.ProcessedContact{
+			Assertion:   "[example@example.com]@email",
+			ContactName: "Example 2",
+		},
+	}
+	assertionToName := makeAssertionToName(contacts)
+
+	require.Contains(t, assertionToName, "1234567890@phone")
+	// Exclude ambiguous email
+	require.NotContains(t, assertionToName, "[example@example.com]@email")
+}

--- a/go/contacts/phonebook_test.go
+++ b/go/contacts/phonebook_test.go
@@ -12,15 +12,15 @@ import (
 
 func TestMakeAssertionToName(t *testing.T) {
 	contacts := []keybase1.ProcessedContact{
-		keybase1.ProcessedContact{
+		{
 			Assertion:   "[example@example.com]@email",
 			ContactName: "Example 1",
 		},
-		keybase1.ProcessedContact{
+		{
 			Assertion:   "1234567890@phone",
 			ContactName: "Mr. Contact",
 		},
-		keybase1.ProcessedContact{
+		{
 			Assertion:   "[example@example.com]@email",
 			ContactName: "Example 2",
 		},

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -1095,5 +1095,6 @@ type StandaloneChatConnector interface {
 type SyncedContactListProvider interface {
 	SaveProcessedContacts(MetaContext, []keybase1.ProcessedContact) error
 	RetrieveContacts(MetaContext) ([]keybase1.ProcessedContact, error)
+	RetrieveAssertionToName(MetaContext) (map[string]string, error)
 	UnresolveContactsWithComponent(MetaContext, *keybase1.PhoneNumber, *keybase1.EmailAddress)
 }


### PR DESCRIPTION
- Add `assertionToName` in phonebook for faster contact name lookups
- Use in chat `AttachContactNames`

cc @keybase/y2ksquad 