### PR TITLE
[Y2K-408] Normalize out diacritics from contact sorting

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -180,6 +180,7 @@
     "simple-markdown": "0.4.4",
     "tlds": "1.203.1",
     "typedarray-to-buffer": "3.1.5",
+    "unidecode": "^0.1.8",
     "url-parse": "1.4.4",
     "uuid": "3.3.2",
     "whatwg-url": "7.0.0"

--- a/shared/team-building/__test__/team-building.test.tsx
+++ b/shared/team-building/__test__/team-building.test.tsx
@@ -144,20 +144,21 @@ describe('team building list', () => {
       userId: '',
       username: '',
     }
-    const makeTest = (name: string, expect: string) => ({
-      expect,
-      result: {...testSearchResult, prettyName: name},
-    })
-    const tests = [
-      makeTest('James', 'J'),
-      makeTest('Łukasz', 'L'),
-      makeTest('高嵩', 'G'),
-      makeTest('Über Foo', 'U'),
-      makeTest('Этери', 'E'),
-      makeTest('हिन्दी', 'H'),
-      makeTest('தமிழ்', 'T'),
-      makeTest('తెలుగు', 'T'),
-    ]
+    const makeTests = (arr: Array<[string, string]>) =>
+      arr.map(([name, expect]) => ({
+        expect,
+        result: {...testSearchResult, prettyName: name},
+      }))
+    const tests = makeTests([
+      ['James', 'J'],
+      ['Łukasz', 'L'],
+      ['高嵩', 'G'],
+      ['Über Foo', 'U'],
+      ['Этери', 'E'],
+      ['हिन्दी', 'H'],
+      ['தமிழ்', 'T'],
+      ['తెలుగు', 'T'],
+    ])
     const sections = sortAndSplitRecommendations(tests.map(t => t.result), false) || []
     const sectionMap = {}
     for (const s of sections) {

--- a/shared/team-building/__test__/team-building.test.tsx
+++ b/shared/team-building/__test__/team-building.test.tsx
@@ -165,10 +165,7 @@ describe('team building list', () => {
       sectionMap[s.label] = s.data
     }
     for (const t of tests) {
-      expect(sectionMap[t.expect]).toContainEqual({
-        ...testSearchResult,
-        prettyName: t.result.prettyName || '',
-      })
+      expect(sectionMap[t.expect]).toContainEqual(t.result)
     }
   })
 })

--- a/shared/team-building/__test__/team-building.test.tsx
+++ b/shared/team-building/__test__/team-building.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import TeamBuilding, {SearchResult, SearchRecSection} from '../index'
+import {sortAndSplitRecommendations} from '../container'
 import {userResultHeight} from '../user-result'
 import {SectionDivider} from '../../common-adapters/index'
 
@@ -129,5 +130,44 @@ describe('team building list', () => {
       length: 0,
       offset: 3 * sectionDividerHeight + 8 * dataRowHeight,
     })
+  })
+  it('sorts recommendations by romanized first ascii character', () => {
+    const testSearchResult = {
+      contact: true,
+      displayLabel: '',
+      followingState: 'NotFollowing' as const,
+      inTeam: false,
+      isPreExistingTeamMember: false,
+      key: '',
+      prettyName: '',
+      services: {},
+      userId: '',
+      username: '',
+    }
+    const makeTest = (name: string, expect: string) => ({
+      expect,
+      result: {...testSearchResult, prettyName: name},
+    })
+    const tests = [
+      makeTest('James', 'J'),
+      makeTest('Łukasz', 'L'),
+      makeTest('高嵩', 'G'),
+      makeTest('Über Foo', 'U'),
+      makeTest('Этери', 'E'),
+      makeTest('हिन्दी', 'H'),
+      makeTest('தமிழ்', 'T'),
+      makeTest('తెలుగు', 'T'),
+    ]
+    const sections = sortAndSplitRecommendations(tests.map(t => t.result), false) || []
+    const sectionMap = {}
+    for (const s of sections) {
+      sectionMap[s.label] = s.data
+    }
+    for (const t of tests) {
+      expect(sectionMap[t.expect]).toContainEqual({
+        ...testSearchResult,
+        prettyName: t.result.prettyName || '',
+      })
+    }
   })
 })

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -1,6 +1,7 @@
 import logger from '../logger'
 import * as React from 'react'
 import * as I from 'immutable'
+import unidecode from 'unidecode'
 import {debounce, trim} from 'lodash-es'
 import TeamBuilding, {RolePickerProps, SearchResult, SearchRecSection, numSectionLabel} from '.'
 import RolePickerHeaderAction from './role-picker-header-action'
@@ -355,12 +356,7 @@ const sortAndSplitRecommendations = memoize(
       if (rec.prettyName || rec.displayLabel) {
         // Use the first letter of the name we will display, but first normalize out
         // any diacritics.
-        const letter = (rec.prettyName || rec.displayLabel)[0]
-          .toLowerCase()
-          .normalize('NFD')
-          .replace(/[\u0300-\u036f]/, '')
-          // And special-case ł because it's a speciał snowfłake.
-          .replace('ł', 'l')
+        const letter = unidecode(rec.prettyName || rec.displayLabel)[0].toLowerCase()
         if (isAlpha(letter)) {
           // offset 1 to skip recommendations
           const sectionIdx = letterToAlphaIndex(letter) + recSectionIdx + 1

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -358,9 +358,9 @@ const sortAndSplitRecommendations = memoize(
         const letter = (rec.prettyName || rec.displayLabel)[0]
           .toLowerCase()
           .normalize('NFD')
-          .replace(/[\u0300-\u036f]/g, '')
+          .replace(/[\u0300-\u036f]/, '')
           // And special-case ł because it's a speciał snowfłake.
-          .replace(/ł/g, 'l')
+          .replace('ł', 'l')
         if (isAlpha(letter)) {
           // offset 1 to skip recommendations
           const sectionIdx = letterToAlphaIndex(letter) + recSectionIdx + 1

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -353,7 +353,12 @@ const sortAndSplitRecommendations = memoize(
         return
       }
       if (rec.prettyName || rec.displayLabel) {
-        const letter = (rec.prettyName || rec.displayLabel)[0].toLowerCase()
+        // Use the first letter of the name we will display, but first normalize out
+        // any diacritics.
+        const letter = (rec.prettyName || rec.displayLabel)[0]
+          .toLowerCase()
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
         if (isAlpha(letter)) {
           // offset 1 to skip recommendations
           const sectionIdx = letterToAlphaIndex(letter) + recSectionIdx + 1

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -359,6 +359,8 @@ const sortAndSplitRecommendations = memoize(
           .toLowerCase()
           .normalize('NFD')
           .replace(/[\u0300-\u036f]/g, '')
+          // And special-case ł because it's a speciał snowfłake.
+          .replace(/ł/g, 'l')
         if (isAlpha(letter)) {
           // offset 1 to skip recommendations
           const sectionIdx = letterToAlphaIndex(letter) + recSectionIdx + 1

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -323,7 +323,7 @@ const letterToAlphaIndex = (letter: string) => letter.charCodeAt(0) - aCharCode
 // 0 - "Recommendations" section
 // 1-26 - a-z sections
 // 27 - 0-9 section
-const sortAndSplitRecommendations = memoize(
+export const sortAndSplitRecommendations = memoize(
   (
     results: Unpacked<typeof deriveSearchResults>,
     showingContactsButton: boolean

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -15996,6 +15996,11 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
   integrity sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==
 
+unidecode@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz#efbb301538bc45246a9ac8c559d72f015305053e"
+  integrity sha1-77swFTi8RSRqmsjFWdcvAVMFBT4=
+
 unified@^7.0.2:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-7.1.0.tgz#5032f1c1ee3364bd09da12e27fdd4a7553c7be13"


### PR DESCRIPTION
cc @keybase/y2ksquad 

* [ ] - blocked on validating the unidecode library

before: 
![6b5fdfa1-7c2a-4b01-8ee9-73c20ba4a1f4](https://user-images.githubusercontent.com/59594/62657928-65397d00-b91c-11e9-9df8-492773a8ffac.png)

after:
![d9bf9352-56f1-41e3-bc23-7fdf18e7de4d](https://user-images.githubusercontent.com/59594/62657932-69659a80-b91c-11e9-8ba7-9218402cbc0d.png)

