### PR TITLE
Delete superseded phone number on add

### DIFF
--- a/go/phonenumbers/user.go
+++ b/go/phonenumbers/user.go
@@ -11,21 +11,7 @@ import (
 
 // AddPhoneNumber calls API to add phone number to currently logged in account.
 func AddPhoneNumber(mctx libkb.MetaContext, phoneNumber keybase1.PhoneNumber, visibility keybase1.IdentityVisibility) error {
-	payload := make(libkb.JSONPayload)
-	payload["phone_number"] = phoneNumber
-	payload["visibility"] = visibility
-
-	arg := libkb.APIArg{
-		Endpoint:    "user/phone_numbers",
-		JSONPayload: payload,
-		SessionType: libkb.APISessionTypeREQUIRED,
-	}
-
-	_, err := mctx.G().API.PostJSON(mctx, arg)
-	if err != nil {
-		return err
-	}
-
+	// First try to delete if we have a superseded item for this phone number already
 	nums, err := GetPhoneNumbers(mctx)
 	if err == nil {
 		for _, num := range nums {
@@ -39,7 +25,19 @@ func AddPhoneNumber(mctx libkb.MetaContext, phoneNumber keybase1.PhoneNumber, vi
 	} else {
 		mctx.Warning("error fetching numbers on add: %s", err)
 	}
-	return nil
+
+	payload := make(libkb.JSONPayload)
+	payload["phone_number"] = phoneNumber
+	payload["visibility"] = visibility
+
+	arg := libkb.APIArg{
+		Endpoint:    "user/phone_numbers",
+		JSONPayload: payload,
+		SessionType: libkb.APISessionTypeREQUIRED,
+	}
+
+	_, err = mctx.G().API.PostJSON(mctx, arg)
+	return err
 }
 
 // VerifyPhoneNumber calls API to verify previously added phone number using

--- a/go/phonenumbers/user.go
+++ b/go/phonenumbers/user.go
@@ -22,7 +22,24 @@ func AddPhoneNumber(mctx libkb.MetaContext, phoneNumber keybase1.PhoneNumber, vi
 	}
 
 	_, err := mctx.G().API.PostJSON(mctx, arg)
-	return err
+	if err != nil {
+		return err
+	}
+
+	nums, err := GetPhoneNumbers(mctx)
+	if err == nil {
+		for _, num := range nums {
+			if num.Superseded && num.PhoneNumber == phoneNumber {
+				err = DeletePhoneNumber(mctx, num.PhoneNumber)
+				if err != nil {
+					mctx.Warning("error deleting superseded number on add: %s", err)
+				}
+			}
+		}
+	} else {
+		mctx.Warning("error fetching numbers on add: %s", err)
+	}
+	return nil
 }
 
 // VerifyPhoneNumber calls API to verify previously added phone number using

--- a/go/phonenumbers/user_test.go
+++ b/go/phonenumbers/user_test.go
@@ -59,6 +59,15 @@ func TestSetPhoneNumber(t *testing.T) {
 	require.Len(t, resp, 0)
 }
 
+func TestDeleteSupersededNumber(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestPhoneNumbers", 1)
+	defer tc.Cleanup()
+
+	_, err := kbtest.CreateAndSignupFakeUser("phon", tc.G)
+	require.NoError(t, err)
+
+}
+
 func TestBadPhoneNumbers(t *testing.T) {
 	tc := libkb.SetupTest(t, "TestPhoneNumbers", 1)
 	defer tc.Cleanup()

--- a/go/phonenumbers/user_test.go
+++ b/go/phonenumbers/user_test.go
@@ -63,9 +63,45 @@ func TestDeleteSupersededNumber(t *testing.T) {
 	tc := libkb.SetupTest(t, "TestPhoneNumbers", 1)
 	defer tc.Cleanup()
 
-	_, err := kbtest.CreateAndSignupFakeUser("phon", tc.G)
+	mctx := libkb.NewMetaContextForTest(tc)
+
+	user1, err := kbtest.CreateAndSignupFakeUser("user1", tc.G)
 	require.NoError(t, err)
 
+	phoneNumber := keybase1.PhoneNumber("+15550123456")
+
+	err = AddPhoneNumber(mctx, phoneNumber, keybase1.IdentityVisibility_PRIVATE)
+	require.NoError(t, err)
+
+	// Verify phone on another user
+	_, err = kbtest.CreateAndSignupFakeUser("user2", tc.G)
+	require.NoError(t, err)
+	err = AddPhoneNumber(mctx, phoneNumber, keybase1.IdentityVisibility_PRIVATE)
+	require.NoError(t, err)
+
+	code, err := kbtest.GetPhoneVerificationCode(mctx, phoneNumber)
+	require.NoError(t, err)
+	t.Logf("Got verification code: %q", code)
+	err = VerifyPhoneNumber(mctx, phoneNumber, code)
+	require.NoError(t, err)
+
+	// Check it's superseded on user1
+	kbtest.Logout(tc)
+	err = user1.Login(tc.G)
+	require.NoError(t, err)
+
+	numbers, err := GetPhoneNumbers(mctx)
+	require.NoError(t, err)
+	require.Len(t, numbers, 1)
+	require.True(t, numbers[0].Superseded)
+
+	// Try adding again; superseded one should be deleted
+	err = AddPhoneNumber(mctx, phoneNumber, keybase1.IdentityVisibility_PRIVATE)
+	require.NoError(t, err)
+	numbers, err = GetPhoneNumbers(mctx)
+	require.NoError(t, err)
+	require.Len(t, numbers, 1)
+	require.False(t, numbers[0].Superseded)
 }
 
 func TestBadPhoneNumbers(t *testing.T) {

--- a/shared/settings/account/container.tsx
+++ b/shared/settings/account/container.tsx
@@ -8,24 +8,14 @@ import AccountSettings from '.'
 import {isMobile} from '../../styles'
 
 type OwnProps = {}
-const mapStateToProps = (state: TypedState) => {
-  const supersededPhoneNumberRecord =
-    state.settings.phoneNumbers.phones &&
-    state.settings.phoneNumbers.phones.find(phoneNumber => phoneNumber.superseded)
-
-  return {
-    _emails: state.settings.email.emails,
-    _phones: state.settings.phoneNumbers.phones,
-    _supersededPhoneNumberKey: supersededPhoneNumberRecord && supersededPhoneNumberRecord.e164,
-    addedEmail: state.settings.email.addedEmail,
-    bootstrapDone: state.settings.email.emails !== null && state.settings.phoneNumbers.phones !== null,
-    hasPassword: !state.settings.password.randomPW,
-    supersededPhoneNumber: supersededPhoneNumberRecord
-      ? supersededPhoneNumberRecord.displayNumber
-      : undefined,
-    waiting: anyWaiting(state, Constants.loadSettingsWaitingKey),
-  }
-}
+const mapStateToProps = (state: TypedState) => ({
+  _emails: state.settings.email.emails,
+  _phones: state.settings.phoneNumbers.phones,
+  addedEmail: state.settings.email.addedEmail,
+  bootstrapDone: state.settings.email.emails !== null && state.settings.phoneNumbers.phones !== null,
+  hasPassword: !state.settings.password.randomPW,
+  waiting: anyWaiting(state, Constants.loadSettingsWaitingKey),
+})
 
 const mapDispatchToProps = (dispatch: TypedDispatch) => ({
   _onClearSupersededPhoneNumber: phone => dispatch(SettingsGen.createEditPhone({delete: true, phone})),
@@ -48,21 +38,24 @@ const mapDispatchToProps = (dispatch: TypedDispatch) => ({
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-  (stateProps, dispatchProps, _: OwnProps) => ({
-    ...dispatchProps,
-    addedEmail: stateProps.addedEmail,
-    contactKeys: I.List([
-      ...(stateProps._emails ? stateProps._emails.keys() : []),
-      ...(stateProps._phones ? stateProps._phones.keys() : []),
-    ]),
-    hasPassword: stateProps.hasPassword,
-    onClearSupersededPhoneNumber: () =>
-      stateProps._supersededPhoneNumberKey &&
-      dispatchProps._onClearSupersededPhoneNumber(stateProps._supersededPhoneNumberKey),
-    supersededPhoneNumber: stateProps.supersededPhoneNumber,
-    title: 'Your account',
-    tooManyEmails: !!stateProps._emails && stateProps._emails.size >= 10, // If you change this, also change in keybase/config/prod/email.iced
-    tooManyPhones: !!stateProps._phones && stateProps._phones.size >= 10, // If you change this, also change in keybase/config/prod/phone_numbers.iced
-    waiting: stateProps.waiting,
-  })
+  (stateProps, dispatchProps, _: OwnProps) => {
+    const supersededPhoneNumber = stateProps._phones && stateProps._phones.find(p => p.superseded)
+    const supersededKey = supersededPhoneNumber && supersededPhoneNumber.e164
+    return {
+      ...dispatchProps,
+      addedEmail: stateProps.addedEmail,
+      contactKeys: I.List([
+        ...(stateProps._emails ? stateProps._emails.keys() : []),
+        ...(stateProps._phones ? stateProps._phones.keys() : []),
+      ]),
+      hasPassword: stateProps.hasPassword,
+      onClearSupersededPhoneNumber: () =>
+        supersededKey && dispatchProps._onClearSupersededPhoneNumber(supersededKey),
+      supersededPhoneNumber: supersededPhoneNumber ? supersededPhoneNumber.displayNumber : undefined,
+      title: 'Your account',
+      tooManyEmails: !!stateProps._emails && stateProps._emails.size >= 10, // If you change this, also change in keybase/config/prod/email.iced
+      tooManyPhones: !!stateProps._phones && stateProps._phones.size >= 10, // If you change this, also change in keybase/config/prod/phone_numbers.iced
+      waiting: stateProps.waiting,
+    }
+  }
 )(AccountSettings)

--- a/shared/settings/account/index.tsx
+++ b/shared/settings/account/index.tsx
@@ -143,7 +143,7 @@ const AccountSettings = (props: Props) => (
         <Kb.Banner color="yellow" onClose={props.onClearSupersededPhoneNumber}>
           <Kb.BannerParagraph
             bannerColor="yellow"
-            content={`Your unverified phone number ${
+            content={`Your phone number ${
               props.supersededPhoneNumber
             } is now associated with another Keybase user.`}
           />


### PR DESCRIPTION
On adding a phone number, check if we currently have a superseded item for that phone number. If it exists, delete it. This makes the yellow banner on account setting disappear. 

Also did some cleanup while looking around this code.
cc @keybase/y2ksquad 