### PR TITLE
Y2K-383 normalize emails

### DIFF
--- a/go/contacts/contacts.go
+++ b/go/contacts/contacts.go
@@ -19,14 +19,14 @@ func AssertionFromComponent(actx libkb.AssertionContext, c keybase1.ContactCompo
 		value = coercedValue
 	} else {
 		value = c.ValueString()
-		if key == "phone" {
-			// ContactComponent has the PhoneNumber type which is E164 phone
-			// number starting with `+`, we need to remove all non-digits for
-			// the assertion.
-			value = keybase1.PhoneNumberToAssertionValue(value)
-		} else {
-			value = strings.TrimSpace(value)
-		}
+	}
+	if key == "phone" {
+		// ContactComponent has the PhoneNumber type which is E164 phone
+		// number starting with `+`, we need to remove all non-digits for
+		// the assertion.
+		value = keybase1.PhoneNumberToAssertionValue(value)
+	} else {
+		value = strings.ToLower(strings.TrimSpace(value))
 	}
 	if key == "" || value == "" {
 		return "", errors.New("invalid variant value in contact component")

--- a/go/contacts/contacts.go
+++ b/go/contacts/contacts.go
@@ -19,14 +19,14 @@ func AssertionFromComponent(actx libkb.AssertionContext, c keybase1.ContactCompo
 		value = coercedValue
 	} else {
 		value = c.ValueString()
-	}
-	if key == "phone" {
-		// ContactComponent has the PhoneNumber type which is E164 phone
-		// number starting with `+`, we need to remove all non-digits for
-		// the assertion.
-		value = keybase1.PhoneNumberToAssertionValue(value)
-	} else {
-		value = strings.TrimSpace(strings.ToLower(value))
+		if key == "phone" {
+			// ContactComponent has the PhoneNumber type which is E164 phone
+			// number starting with `+`, we need to remove all non-digits for
+			// the assertion.
+			value = keybase1.PhoneNumberToAssertionValue(value)
+		} else {
+			value = strings.TrimSpace(value)
+		}
 	}
 	if key == "" || value == "" {
 		return "", errors.New("invalid variant value in contact component")

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -130,6 +130,10 @@ func NameCmp(n1, n2 string) bool {
 	return NameTrim(n1) == NameTrim(n2)
 }
 
+func IsLowercase(s string) bool {
+	return strings.ToLower(s) == s
+}
+
 func PickFirstError(errors ...error) error {
 	for _, e := range errors {
 		if e != nil {

--- a/go/service/usersearch.go
+++ b/go/service/usersearch.go
@@ -266,7 +266,7 @@ func imptofuQueryToAssertion(typ keybase1.ImpTofuSearchType, val string) (string
 	case keybase1.ImpTofuSearchType_PHONE:
 		return fmt.Sprintf("%s@phone", keybase1.PhoneNumberToAssertionValue(val)), nil
 	case keybase1.ImpTofuSearchType_EMAIL:
-		return fmt.Sprintf("[%s]@email", strings.TrimSpace(val)), nil
+		return fmt.Sprintf("[%s]@email", strings.ToLower(strings.TrimSpace(val))), nil
 	default:
 		return "", errors.New("invalid keybase1.ImpTofuSearchType enum value")
 	}

--- a/go/service/usersearch.go
+++ b/go/service/usersearch.go
@@ -266,7 +266,7 @@ func imptofuQueryToAssertion(typ keybase1.ImpTofuSearchType, val string) (string
 	case keybase1.ImpTofuSearchType_PHONE:
 		return fmt.Sprintf("%s@phone", keybase1.PhoneNumberToAssertionValue(val)), nil
 	case keybase1.ImpTofuSearchType_EMAIL:
-		return fmt.Sprintf("[%s]@email", strings.TrimSpace(strings.ToLower(val))), nil
+		return fmt.Sprintf("[%s]@email", strings.TrimSpace(val)), nil
 	default:
 		return "", errors.New("invalid keybase1.ImpTofuSearchType enum value")
 	}

--- a/go/service/usersearch_test.go
+++ b/go/service/usersearch_test.go
@@ -605,6 +605,7 @@ func TestUserSearchDirectTofu(t *testing.T) {
 		require.Nil(t, res[0].Contact)
 		require.NotNil(t, res[0].Imptofu)
 		require.Empty(t, res[0].Imptofu.KeybaseUsername)
+		// Assertion should be lowercased for display names.
 		require.Equal(t, "[test@keyba.se]@email", res[0].Imptofu.Assertion)
 		require.Equal(t, "TEST@keyba.se", res[0].Imptofu.PrettyName)
 		require.Empty(t, res[0].Imptofu.Label)

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -239,7 +239,7 @@ func lookupImplicitTeamAndConflicts(ctx context.Context, g *libkb.GlobalContext,
 	return team, team.Name(), impTeamName, conflicts, nil
 }
 
-func isDupImplicitTeamError(ctx context.Context, err error) bool {
+func isDupImplicitTeamError(err error) bool {
 	if err != nil {
 		if aerr, ok := err.(libkb.AppStatusError); ok {
 			code := keybase1.StatusCode(aerr.Code)
@@ -276,7 +276,7 @@ func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, dis
 			var teamID keybase1.TeamID
 			teamID, teamName, err = CreateImplicitTeam(ctx, g, impTeamName)
 			if err != nil {
-				if isDupImplicitTeamError(ctx, err) {
+				if isDupImplicitTeamError(err) {
 					g.Log.CDebugf(ctx, "LookupOrCreateImplicitTeam: duplicate team, trying to lookup again: err: %s", err)
 					res, teamName, impTeamName, _, err = lookupImplicitTeamAndConflicts(ctx, g, displayName,
 						lookupName, ImplicitTeamOptions{})

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -738,17 +738,21 @@ func TestInvalidPhoneNumberAssertion(t *testing.T) {
 	}
 }
 
-func TestCaseSensitiveEmails(t *testing.T) {
+func TestCaseSensitiveDisplayNames(t *testing.T) {
 	fus, tcs, cleanup := setupNTests(t, 1)
 	defer cleanup()
 
-	displayNameInput := fmt.Sprintf("%s,[%s]@email", fus[0].Username, strings.ToUpper(fus[0].Email))
-	teamObj, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayNameInput, false /*isPublic*/)
-	require.NoError(t, err)
-	spew.Dump(teamObj.ID)
-	spew.Dump(teamObj.GetActiveAndObsoleteInvites())
+	upEmail := strings.ToUpper(fus[0].Email)
+	displayNameInput := fmt.Sprintf("%s,[%s]@email", fus[0].Username, upEmail)
+	_, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayNameInput, false /*isPublic*/)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Display name is not normalized")
+	require.Contains(t, err.Error(), upEmail)
 
-	_, _, teamName, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, strings.ToLower(displayNameInput), false /*isPublic*/)
-	require.NoError(t, err)
-	spew.Dump(teamName)
+	rooter := fmt.Sprintf("%s@hackernews", strings.ToUpper(fus[0].Username))
+	displayNameInput = fmt.Sprintf("%s,%s", fus[0].Username, rooter)
+	_, _, _, err = LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayNameInput, false /*isPublic*/)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Display name is not normalized")
+	require.Contains(t, err.Error(), rooter)
 }

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -737,3 +737,18 @@ func TestInvalidPhoneNumberAssertion(t *testing.T) {
 		require.Contains(t, err.Error(), "Invalid phone number")
 	}
 }
+
+func TestCaseSensitiveEmails(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 1)
+	defer cleanup()
+
+	displayNameInput := fmt.Sprintf("%s,[%s]@email", fus[0].Username, strings.ToUpper(fus[0].Email))
+	teamObj, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, displayNameInput, false /*isPublic*/)
+	require.NoError(t, err)
+	spew.Dump(teamObj.ID)
+	spew.Dump(teamObj.GetActiveAndObsoleteInvites())
+
+	_, _, teamName, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, strings.ToLower(displayNameInput), false /*isPublic*/)
+	require.NoError(t, err)
+	spew.Dump(teamName)
+}

--- a/go/teams/list.go
+++ b/go/teams/list.go
@@ -244,7 +244,7 @@ func ListTeamsVerified(ctx context.Context, g *libkb.GlobalContext,
 		if team.IsImplicit() {
 			displayName, err := team.ImplicitTeamDisplayNameString(ctx)
 			if err != nil {
-				m.Debug("| Failed to get ImplicitTeamDisplayNameString() for team %q: %v", team.ID, err)
+				m.Warning("| Failed to get ImplicitTeamDisplayNameString() for team %q: %v", team.ID, err)
 			} else {
 				anMemberInfo.ImpTeamDisplayName = displayName
 			}


### PR DESCRIPTION
This doesn't do much. We are already normalizing e-mails manually in both processing contacts and user search. I was initially going for a rework of how some types work and introduce a `NormalizedEmail` type so it's obvious what's going on. Ideally I'd like to be consistent with stuff like `go/externals/proof_service_*.go` `NormalizeUsername` functions. But I ran into some issues with mixed casing names w.r.t display names and SBS handling and didn't get to this in time.