### PR TITLE
Less printing by default

### DIFF
--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -56,7 +56,7 @@ let config = {
 
 // Developer settings
 if (__DEV__) {
-  config.enableActionLogging = false
+  config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
@@ -65,7 +65,7 @@ if (__DEV__) {
   config.printOutstandingRPCs = false
   config.printOutstandingTimerListeners = false
   config.printRPCWaitingSession = false
-  config.printRPC = false
+  config.printRPC = true
   config.printRPCStats = false
   config.reduxSagaLoggerMasked = false
   config.userTimings = false

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -56,17 +56,17 @@ let config = {
 
 // Developer settings
 if (__DEV__) {
-  config.enableActionLogging = true
-  config.enableStoreLogging = true
+  config.enableActionLogging = false
+  config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
   config.isDevApplePushToken = true
-  config.printOutstandingRPCs = true
-  config.printOutstandingTimerListeners = true
+  config.printOutstandingRPCs = false
+  config.printOutstandingTimerListeners = false
   config.printRPCWaitingSession = false
-  config.printRPC = true
-  config.printRPCStats = true
+  config.printRPC = false
+  config.printRPCStats = false
   config.reduxSagaLoggerMasked = false
   config.userTimings = false
 


### PR DESCRIPTION
I've been using this locally. Maybe we should reconsider all the default logging we have in dev mode? This is mostly just for discussion.