### PR TITLE
Fix KBTextInput on Android

### DIFF
--- a/shared/common-adapters/kb-text-input.native.tsx
+++ b/shared/common-adapters/kb-text-input.native.tsx
@@ -11,64 +11,87 @@ import {
 } from 'react-native'
 import {isAndroid} from '../constants/platform'
 
-class KBInputText extends RNTextInput {
-  private nativeTextInput = isAndroid ? requireNativeComponent('KBTextInput') : {}
+let KBInputText = RNTextInput
 
-  render() {
-    // @ts-ignore we added this
-    const {forwardedRef} = this.props
-    if (!isAndroid) {
-      return <RNTextInput {...this.props} ref={forwardedRef} />
-    }
-    const p = {
-      ...this.props,
-    }
-
-    p.style = [this.props.style]
-    // @ts-ignore TS doesn't know about this method
-    p.autoCapitalize = UIManager.getViewManagerConfig('AndroidTextInput').Constants.AutoCapitalizationType[
-      p.autoCapitalize || 'sentences'
-    ]
-
-    let children = p.children
-    let childCount = 0
-    React.Children.forEach(children, () => ++childCount)
-    if (childCount > 1) {
-      children = <Text>{children}</Text>
-    }
-
-    if (p.selection && p.selection.end == null) {
-      p.selection = {
-        end: p.selection.start,
-        start: p.selection.start,
+if (isAndroid) {
+  const NativeTextInput = isAndroid ? requireNativeComponent('KBTextInput') : {}
+  class _KBInputText extends RNTextInput {
+    render() {
+      // @ts-ignore we added this
+      const {forwardedRef} = this.props
+      if (!isAndroid) {
+        return <RNTextInput {...this.props} ref={forwardedRef} />
       }
+      const p = {
+        ...this.props,
+      }
+
+      p.style = [this.props.style]
+      // @ts-ignore TS doesn't know about this method
+      p.autoCapitalize = UIManager.getViewManagerConfig('AndroidTextInput').Constants.AutoCapitalizationType[
+        p.autoCapitalize || 'sentences'
+      ]
+
+      let children = p.children
+      let childCount = 0
+      React.Children.forEach(children, () => ++childCount)
+      if (childCount > 1) {
+        children = <Text>{children}</Text>
+      }
+
+      if (p.selection && p.selection.end == null) {
+        p.selection = {
+          end: p.selection.start,
+          start: p.selection.start,
+        }
+      }
+
+      const textContainer = (
+        <NativeTextInput
+          // @ts-ignore This neets
+          ref={this._setNativeRef}
+          {...p}
+          mostRecentEventCount={0}
+          text={p.value || p.defaultValue || ''}
+          children={children}
+          disableFullscreenUI={p.disableFullscreenUI}
+          textBreakStrategy={p.textBreakStrategy}
+          // @ts-ignore no RN types
+          onFocus={this._onFocus}
+          // @ts-ignore no RN types
+          onBlur={this._onBlur}
+          // @ts-ignore no RN types
+          onChange={this._onChange}
+          // @ts-ignore no RN types
+          onSelectionChange={this._onSelectionChange}
+          // @ts-ignore no RN types
+          onTextInput={this._onTextInput}
+          // @ts-ignore no RN types
+          onScroll={this._onScroll}
+        />
+      )
+
+      return (
+        // @ts-ignore
+        <TouchableWithoutFeedback
+          onLayout={p.onLayout}
+          accessible={p.accessible}
+          accessibilityLabel={p.accessibilityLabel}
+          // @ts-ignore
+          onPress={this._onPress}
+          accessibilityRole={p.accessibilityRole}
+          accessibilityStates={p.accessibilityStates}
+          // @ts-ignore no RN types
+          nativeID={this.props.nativeID}
+          // @ts-ignore no RN types
+          testID={this.props.testID}
+        >
+          {textContainer}
+        </TouchableWithoutFeedback>
+      )
     }
-
-    const textContainer = (
-      <this.nativeTextInput
-        {...p}
-        ref={forwardedRef}
-        mostRecentEventCount={0}
-        text={p.value || p.defaultValue || ''}
-        children={children}
-        disableFullscreenUI={p.disableFullscreenUI}
-        textBreakStrategy={p.textBreakStrategy}
-      />
-    )
-
-    return (
-      <TouchableWithoutFeedback
-        onLayout={p.onLayout}
-        accessible={p.accessible}
-        accessibilityLabel={p.accessibilityLabel}
-        accessibilityRole={p.accessibilityRole}
-        accessibilityStates={p.accessibilityStates}
-        testID={p.testID}
-      >
-        {textContainer}
-      </TouchableWithoutFeedback>
-    )
   }
+  KBInputText = _KBInputText
 }
 
 export default (React.forwardRef<RNTextInput>((props, ref) => (

--- a/shared/common-adapters/kb-text-input.native.tsx
+++ b/shared/common-adapters/kb-text-input.native.tsx
@@ -94,7 +94,4 @@ if (isAndroid) {
   KBInputText = _KBInputText
 }
 
-export default (React.forwardRef<RNTextInput>((props, ref) => (
-  // @ts-ignore
-  <KBInputText {...props} forwardedRef={ref} />
-)) as unknown) as typeof RNTextInput
+export default (KBInputText as unknown) as typeof RNTextInput


### PR DESCRIPTION
@keybase/react-hackers 

There's a lot of setup we have to do with KBTextInput native component on Android.

This is kind of confusing because for Android we are essentially recreating RNTextInput so we have to wire it up to the native events. I don't see how forwardRef would work here (looking at the RN source for textinput code as well it ignores ref) so I'm removing that too. 