### PR TITLE
undo auto clicking in avatars

### DIFF
--- a/shared/chat/conversation/messages/message-popup/exploding/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/index.tsx
@@ -88,7 +88,7 @@ class ExplodingPopupHeader extends React.Component<PropsWithTimer<Props>, State>
           <Box2 direction="horizontal">
             <Text type="BodySmall">by</Text>
             <Box2 direction="horizontal" gap="xtiny" gapStart={true} style={styles.user}>
-              <Avatar username={author} size={16} />
+              <Avatar username={author} size={16} onClick="profile" />
               <ConnectedUsernames
                 onUsernameClicked="profile"
                 colorFollowing={true}

--- a/shared/chat/conversation/messages/message-popup/header.tsx
+++ b/shared/chat/conversation/messages/message-popup/header.tsx
@@ -66,7 +66,7 @@ const MessagePopupHeader = (props: {
           by
         </Kb.Text>
         <Kb.Box2 direction="horizontal" gap="xtiny" gapStart={true} style={styles.alignItemsCenter}>
-          <Kb.Avatar username={author} size={16} />
+          <Kb.Avatar username={author} size={16} onClick="profile" />
           <Kb.ConnectedUsernames
             onUsernameClicked="profile"
             colorFollowing={true}

--- a/shared/chat/conversation/messages/message-popup/payment/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/payment/index.tsx
@@ -116,7 +116,7 @@ const Header = (props: HeaderProps) =>
       >
         <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} centerChildren={true}>
           <Kb.Text type="BodySmall">{upperFirst(props.txVerb)} by</Kb.Text>
-          <Kb.Avatar size={16} username={props.sender} />
+          <Kb.Avatar size={16} username={props.sender} onClick="profile" />
           <Kb.ConnectedUsernames
             onUsernameClicked="profile"
             colorFollowing={true}

--- a/shared/common-adapters/avatar.tsx
+++ b/shared/common-adapters/avatar.tsx
@@ -19,7 +19,7 @@ export type OwnProps = {
   editable?: boolean
   isTeam?: boolean
   loadingColor?: string
-  onClick?: (e?: React.BaseSyntheticEvent) => void
+  onClick?: ((e?: React.BaseSyntheticEvent) => void) | 'profile'
   onEditAvatarClick?: (e?: React.BaseSyntheticEvent) => void
   opacity?: number
   size: AvatarSize
@@ -92,15 +92,20 @@ const ConnectedAvatar = Container.connect(
     _httpSrvAddress: state.config.httpSrvAddress,
     _httpSrvToken: state.config.httpSrvToken,
   }),
-  (dispatch, ownProps: OwnProps) => ({
+  dispatch => ({
     _goToProfile: (username: string) => dispatch(ProfileGen.createShowUserProfile({username})),
-    onClick: ownProps.onEditAvatarClick ? ownProps.onEditAvatarClick : ownProps.onClick,
   }),
   (stateProps, dispatchProps, ownProps: OwnProps) => {
     const {username} = ownProps
     const isTeam = ownProps.isTeam || !!ownProps.teamname
-    const onClick =
-      dispatchProps.onClick || (username ? () => dispatchProps._goToProfile(username) : undefined)
+
+    const opClick =
+      ownProps.onClick === 'profile'
+        ? username
+          ? () => dispatchProps._goToProfile(username)
+          : undefined
+        : ownProps.onClick
+    const onClick = ownProps.onEditAvatarClick || opClick
     const name = isTeam ? ownProps.teamname : username
     const urlMap = [960, 256, 192].reduce((m, size: number) => {
       m[size] = `http://${stateProps._httpSrvAddress}/av?typ=${
@@ -143,7 +148,11 @@ const mockOwnToViewProps = (
   const following = username && follows.includes(username)
   const followsYou = username && followers.includes(username)
   const isTeam = ownProps.isTeam || !!ownProps.teamname
-  const onClick = ownProps.onClick || (username ? () => action('onClickToProfile') : undefined)
+
+  const opClick =
+    ownProps.onClick === 'profile' ? (username ? action('onClickToProfile') : undefined) : ownProps.onClick
+  const onClick = ownProps.onEditAvatarClick || opClick
+
   const url = iconTypeToImgSet(isTeam ? teamPlaceHolders : avatarPlaceHolders, ownProps.size)
   const name = isTeam ? ownProps.teamname : username
   const iconInfo = followIconHelper(


### PR DESCRIPTION
in my avatar cleanup (https://github.com/keybase/client/pull/18824) i made the avatar onClick mostly go to profile (removed the tracker code etc). originally i was like 'it won't hurt to go to the profile more' but its annoying to click inbox rows and have it go to the profile. so instead onClick can be a function or 'profile' and if its profile it'll go there, bringing back the old behavior (before it had an additional prop)

