### PR TITLE
don't ignore the next resize when switching convs

### DIFF
--- a/shared/chat/conversation/list-area/normal/index.desktop.tsx
+++ b/shared/chat/conversation/list-area/normal/index.desktop.tsx
@@ -195,7 +195,6 @@ class Thread extends React.PureComponent<Props, State> {
       // don't do any of the below if just state changes
       return
     }
-    const list = this._listRef.current
 
     // conversation changed
     if (this.props.conversationIDKey !== prevProps.conversationIDKey) {
@@ -228,6 +227,7 @@ class Thread extends React.PureComponent<Props, State> {
     }
 
     // Adjust scrolling if locked to the bottom
+    const list = this._listRef.current
     // if locked to the bottom, and we have the most recent message, then scroll to the bottom
     if (this._isLockedToBottom() && this.props.conversationIDKey === prevProps.conversationIDKey) {
       // maintain scroll to bottom?

--- a/shared/chat/conversation/list-area/normal/index.desktop.tsx
+++ b/shared/chat/conversation/list-area/normal/index.desktop.tsx
@@ -200,11 +200,7 @@ class Thread extends React.PureComponent<Props, State> {
     // conversation changed
     if (this.props.conversationIDKey !== prevProps.conversationIDKey) {
       this._cleanupDebounced()
-      this._scrollHeight = 0
       this.setState(p => (p.lockedToBottom ? null : {lockedToBottom: true}))
-      if (list) {
-        this._onResize({scroll: {height: list.scrollHeight}})
-      }
       this._scrollToBottom('componentDidUpdate-change-convo')
       return
     }

--- a/shared/chat/conversation/list-area/normal/index.desktop.tsx
+++ b/shared/chat/conversation/list-area/normal/index.desktop.tsx
@@ -195,12 +195,16 @@ class Thread extends React.PureComponent<Props, State> {
       // don't do any of the below if just state changes
       return
     }
+    const list = this._listRef.current
 
     // conversation changed
     if (this.props.conversationIDKey !== prevProps.conversationIDKey) {
       this._cleanupDebounced()
       this._scrollHeight = 0
       this.setState(p => (p.lockedToBottom ? null : {lockedToBottom: true}))
+      if (list) {
+        this._onResize({scroll: {height: list.scrollHeight}})
+      }
       this._scrollToBottom('componentDidUpdate-change-convo')
       return
     }
@@ -228,7 +232,6 @@ class Thread extends React.PureComponent<Props, State> {
     }
 
     // Adjust scrolling if locked to the bottom
-    const list = this._listRef.current
     // if locked to the bottom, and we have the most recent message, then scroll to the bottom
     if (this._isLockedToBottom() && this.props.conversationIDKey === prevProps.conversationIDKey) {
       // maintain scroll to bottom?


### PR DESCRIPTION
If you switch convs on desktop, there is a chance the view is not scrolled all the way to the bottom. The reason is often times the size of the content changes after the thread loads. If we ignore the next resize as a result of switching convs, we might just miss that resize and do nothing, causing the scroll position to be incorrect.