### PR TITLE
av: play sound when iOS is silenced

### DIFF
--- a/shared/common-adapters/av.native.tsx
+++ b/shared/common-adapters/av.native.tsx
@@ -3,7 +3,7 @@ import {Props} from './av'
 import Box from './box'
 import * as Styles from '../styles'
 import {useVideoSizer, CheckURL} from './av.shared'
-import {Video as ExpoVideo} from 'expo-av'
+import {Video as ExpoVideo, Audio as ExpoAudio} from 'expo-av'
 import {StatusBar} from 'react-native'
 import logger from '../logger'
 
@@ -13,6 +13,20 @@ const Kb = {
 
 export const Video = (props: Props) => {
   const [videoSize, setContainerSize, setVideoNaturalSize] = useVideoSizer()
+  React.useEffect(() => {
+    ExpoAudio.setAudioModeAsync({
+      allowsRecordingIOS: false,
+      interruptionModeAndroid: ExpoAudio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
+      interruptionModeIOS: ExpoAudio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
+      playThroughEarpieceAndroid: true,
+      playsInSilentModeIOS: true,
+      shouldDuckAndroid: false,
+      staysActiveInBackground: false,
+    }).then(() =>
+      // setIsEnabledAsync needs to happen after setting the mode.
+      ExpoAudio.setIsEnabledAsync(true)
+    )
+  }, [])
   return (
     <CheckURL url={props.url}>
       <Kb.Box


### PR DESCRIPTION
I got stuck on this for a long time and assumed it was an `expo-av` bug before realizing it just didn't work with simulator + bluetooth headphones. 🤷🏻‍♂️