### PR TITLE
Don't close a modal if a click that ended outside the modal started inside it

### DIFF
--- a/shared/common-adapters/popup-dialog.desktop.tsx
+++ b/shared/common-adapters/popup-dialog.desktop.tsx
@@ -5,7 +5,7 @@ import {EscapeHandler} from '../util/key-event-handler.desktop'
 import * as Styles from '../styles'
 import {Props} from './popup-dialog'
 
-function stopBubbling(ev) {
+function stopBubbling(ev: React.MouseEvent) {
   ev.stopPropagation()
 }
 
@@ -23,13 +23,31 @@ export function PopupDialog({
   styleClipContainer,
   allowClipBubbling,
 }: Props) {
+  let sourceElem, targetElem
   return (
     <EscapeHandler onESC={!immuneToEscape ? onClose || null : null}>
       <Box
+        id="clickCatcher"
         style={Styles.collapseStyles([styles.cover, styleCover])}
-        onClick={onClose}
-        onMouseUp={onMouseUp}
-        onMouseDown={onMouseDown}
+        onMouseUp={(ev: React.MouseEvent) => {
+          targetElem = ev.target
+          onMouseUp && onMouseUp(ev)
+          if (
+            sourceElem &&
+            targetElem &&
+            sourceElem.id === 'clickCatcher' &&
+            targetElem.id === 'clickCatcher' &&
+            onClose
+          ) {
+            onClose()
+          }
+          sourceElem = null
+          targetElem = null
+        }}
+        onMouseDown={(ev: React.MouseEvent) => {
+          sourceElem = ev.target
+          onMouseDown && onMouseDown(ev)
+        }}
         onMouseMove={onMouseMove}
       >
         <Box style={Styles.collapseStyles([styles.container, fill && styles.containerFill, styleContainer])}>


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

When we're showing a modal, we stop onClicks from inside the modal bubbling up to the "cover" opaque background.  Clicking on that background closes the modal.

But if a click starts inside the modal and ends on that background element, the onClick for the background fires.  So if you click and drag to select some text inside a modal but end outside of it, the modal closes.

Since onClick's not going to work, I went with using onMouseDown and onMouseUp and only treating it as a modal close if the click both started and ended inside the background element.

Am open to better ways of doing it, I was surprised I couldn't find anything more obvious to do.