### PR TITLE
add a wallet merge cli command

### DIFF
--- a/go/client/cmd_wallet.go
+++ b/go/client/cmd_wallet.go
@@ -24,6 +24,7 @@ func newCmdWallet(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 		newCmdWalletHistory(cl, g),
 		newCmdWalletImport(cl, g),
 		newCmdWalletLookup(cl, g),
+		newCmdWalletMerge(cl, g),
 		newCmdWalletPopularAssets(cl, g),
 		newCmdWalletRename(cl, g),
 		newCmdWalletRequest(cl, g),

--- a/go/client/cmd_wallet_merge.go
+++ b/go/client/cmd_wallet_merge.go
@@ -80,11 +80,10 @@ func (c *CmdWalletMerge) Run() (err error) {
 	if c.To == "" {
 		// if unspecified, default the target account to the user's primary
 		c.To = primary.AccountID.String()
-		ui.Printf("defaulting target to your primary account (%s): %v\n", primary.Name, ColorString(c.G(), "green", c.To))
+		ui.Printf("defaulting target to your primary account (%s: %v)\n", primary.Name, ColorString(c.G(), "green", c.To))
 	}
 
-	confirmationMsg := fmt.Sprintf("%s the secret key for %s\nand merge its assets into %s?", ColorString(c.G(), "red", "PERMANENTLY DELETE"),
-		ColorString(c.G(), "yellow", c.FromAccountID.String()), ColorString(c.G(), "green", c.To))
+	confirmationMsg := fmt.Sprintf("Merge all of the assets from %s into %s?", ColorString(c.G(), "yellow", c.FromAccountID.String()), ColorString(c.G(), "green", c.To))
 	if err := ui.PromptForConfirmation(confirmationMsg); err != nil {
 		return err
 	}

--- a/go/client/cmd_wallet_merge.go
+++ b/go/client/cmd_wallet_merge.go
@@ -1,0 +1,124 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"golang.org/x/net/context"
+)
+
+type CmdWalletMerge struct {
+	libkb.Contextified
+	FromAccountID stellar1.AccountID
+	To            string
+}
+
+func newCmdWalletMerge(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := []cli.Flag{
+		cli.StringFlag{
+			Name:  "to",
+			Usage: "Specify into which account or user the merge will happen (defaults to your primary account).",
+		},
+	}
+	cmd := &CmdWalletMerge{
+		Contextified: libkb.NewContextified(g),
+	}
+	return cli.Command{
+		Name:         "merge",
+		Usage:        "Delete an account by merging XLM and any other assets to another stellar address",
+		ArgumentHelp: "<from-account-id> [--to account-id/user]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "merge", c)
+		},
+		Flags: flags,
+	}
+}
+
+func (c *CmdWalletMerge) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		return errors.New("expecting one argument for the account to be merged away")
+	}
+	from, err := libkb.ParseStellarAccountID(ctx.Args()[0])
+	if err != nil {
+		return err
+	}
+	c.FromAccountID = from
+	c.To = ctx.String("to")
+	return nil
+}
+
+func (c *CmdWalletMerge) Run() (err error) {
+	defer transformStellarCLIError(&err)
+	cli, err := GetWalletClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	protocols := []rpc.Protocol{
+		NewIdentifyUIProtocol(c.G()),
+	}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+	ui := c.G().UI.GetTerminalUI()
+
+	primary, err := getPrimaryAccount(cli)
+	if err != nil {
+		return err
+	}
+	if c.FromAccountID == primary.AccountID {
+		// this works on the stellar level, but the primary account won't be removed from the bundle,
+		// so that step will error and the account will stick around with no funds. we could easily
+		// bypass this check and catch that specific error if there's ever a usecase for this.
+		return fmt.Errorf("cannot merge away your primary account")
+	}
+	if c.To == "" {
+		// if unspecified, default the target account to the user's primary
+		c.To = primary.AccountID.String()
+		ui.Printf("defaulting target to your primary account (%s): %v\n", primary.Name, ColorString(c.G(), "green", c.To))
+	}
+
+	confirmationMsg := fmt.Sprintf("Merge %s into %s?\nIt will also be removed from your bundle.", ColorString(c.G(), "yellow", c.FromAccountID.String()), ColorString(c.G(), "green", c.To))
+	if err := ui.PromptForConfirmation(confirmationMsg); err != nil {
+		return err
+	}
+
+	arg := stellar1.AccountMergeCLILocalArg{
+		From: c.FromAccountID,
+		To:   c.To,
+	}
+	txID, err := cli.AccountMergeCLILocal(context.Background(), arg)
+	if err != nil {
+		return err
+	}
+
+	ui.Printf("Sent!\nStellar Transaction ID: %v\n", txID)
+
+	return nil
+}
+
+func (c *CmdWalletMerge) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}
+
+func getPrimaryAccount(cli stellar1.LocalClient) (acct stellar1.WalletAccountLocal, err error) {
+	accounts, err := cli.GetWalletAccountsLocal(context.Background(), 0)
+	if err != nil {
+		return acct, err
+	}
+	for _, account := range accounts {
+		if account.IsDefault {
+			return account, nil
+		}
+	}
+	return acct, fmt.Errorf("couldn't find your primary account")
+}

--- a/go/client/cmd_wallet_merge.go
+++ b/go/client/cmd_wallet_merge.go
@@ -83,7 +83,8 @@ func (c *CmdWalletMerge) Run() (err error) {
 		ui.Printf("defaulting target to your primary account (%s): %v\n", primary.Name, ColorString(c.G(), "green", c.To))
 	}
 
-	confirmationMsg := fmt.Sprintf("Merge %s into %s?\nIt will also be removed from your bundle.", ColorString(c.G(), "yellow", c.FromAccountID.String()), ColorString(c.G(), "green", c.To))
+	confirmationMsg := fmt.Sprintf("%s the secret key for %s\nand merge its assets into %s?", ColorString(c.G(), "red", "PERMANENTLY DELETE"),
+		ColorString(c.G(), "yellow", c.FromAccountID.String()), ColorString(c.G(), "green", c.To))
 	if err := ui.PromptForConfirmation(confirmationMsg); err != nil {
 		return err
 	}

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -5,7 +5,6 @@ package keybase1
 
 import (
 	"errors"
-
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -1608,8 +1608,9 @@ type SendPathCLILocalArg struct {
 }
 
 type AccountMergeCLILocalArg struct {
-	From AccountID `codec:"from" json:"from"`
-	To   string    `codec:"to" json:"to"`
+	FromAccountID AccountID  `codec:"fromAccountID" json:"fromAccountID"`
+	FromSecretKey *SecretKey `codec:"fromSecretKey,omitempty" json:"fromSecretKey,omitempty"`
+	To            string     `codec:"to" json:"to"`
 }
 
 type ClaimCLILocalArg struct {

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -1607,6 +1607,11 @@ type SendPathCLILocalArg struct {
 	PublicNote string      `codec:"publicNote" json:"publicNote"`
 }
 
+type AccountMergeCLILocalArg struct {
+	From AccountID `codec:"from" json:"from"`
+	To   string    `codec:"to" json:"to"`
+}
+
 type ClaimCLILocalArg struct {
 	TxID string     `codec:"txID" json:"txID"`
 	Into *AccountID `codec:"into,omitempty" json:"into,omitempty"`
@@ -1774,6 +1779,7 @@ type LocalInterface interface {
 	BalancesLocal(context.Context, AccountID) ([]Balance, error)
 	SendCLILocal(context.Context, SendCLILocalArg) (SendResultCLILocal, error)
 	SendPathCLILocal(context.Context, SendPathCLILocalArg) (SendResultCLILocal, error)
+	AccountMergeCLILocal(context.Context, AccountMergeCLILocalArg) (TransactionID, error)
 	ClaimCLILocal(context.Context, ClaimCLILocalArg) (RelayClaimResult, error)
 	RecentPaymentsCLILocal(context.Context, *AccountID) ([]PaymentOrErrorCLILocal, error)
 	PaymentDetailCLILocal(context.Context, string) (PaymentCLILocal, error)
@@ -2658,6 +2664,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 					return
 				},
 			},
+			"accountMergeCLILocal": {
+				MakeArg: func() interface{} {
+					var ret [1]AccountMergeCLILocalArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]AccountMergeCLILocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]AccountMergeCLILocalArg)(nil), args)
+						return
+					}
+					ret, err = i.AccountMergeCLILocal(ctx, typedArgs[0])
+					return
+				},
+			},
 			"claimCLILocal": {
 				MakeArg: func() interface{} {
 					var ret [1]ClaimCLILocalArg
@@ -3278,6 +3299,11 @@ func (c LocalClient) SendCLILocal(ctx context.Context, __arg SendCLILocalArg) (r
 
 func (c LocalClient) SendPathCLILocal(ctx context.Context, __arg SendPathCLILocalArg) (res SendResultCLILocal, err error) {
 	err = c.Cli.Call(ctx, "stellar.1.local.sendPathCLILocal", []interface{}{__arg}, &res)
+	return
+}
+
+func (c LocalClient) AccountMergeCLILocal(ctx context.Context, __arg AccountMergeCLILocalArg) (res TransactionID, err error) {
+	err = c.Cli.Call(ctx, "stellar.1.local.accountMergeCLILocal", []interface{}{__arg}, &res)
 	return
 }
 

--- a/go/stellar/accountmerge.go
+++ b/go/stellar/accountmerge.go
@@ -1,0 +1,40 @@
+package stellar
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/stellar1"
+	"github.com/keybase/client/go/stellar/stellarcommon"
+	"github.com/keybase/stellarnet"
+)
+
+func AccountMerge(mctx libkb.MetaContext, walletState *WalletState, arg stellar1.AccountMergeCLILocalArg) (res stellarnet.SignResult, from stellar1.AccountID, err error) {
+	baseFee := walletState.BaseFee(mctx)
+	sp, unlock := NewClaimSeqnoProvider(mctx, walletState)
+	defer unlock()
+	tb, err := getTimeboundsForSending(mctx, walletState)
+	if err != nil {
+		return res, from, err
+	}
+
+	bundleEntry, accountBundle, err := LookupSender(mctx, arg.From)
+	if err != nil {
+		return res, from, fmt.Errorf("account merge error looking up <from>: %v", err)
+	}
+	fromSeed := stellarnet.SeedStr(accountBundle.Signers[0].SecureNoLogString())
+	mctx.Debug("account merge <from> lookup complete: %s -> %s", arg.From, bundleEntry.AccountID)
+
+	recipient, err := LookupRecipient(mctx, stellarcommon.RecipientInput(arg.To), true /* isCLI */)
+	if err != nil {
+		return res, from, fmt.Errorf("account merge error looking up <to>: %v", err)
+	}
+	toAddr := stellarnet.AddressStr(*recipient.AccountID)
+	mctx.Debug("account merge <to> lookup complete: %s -> %s", arg.To, toAddr)
+
+	signedTx, err := stellarnet.AccountMergeTransaction(fromSeed, toAddr, sp, tb, baseFee)
+	if err != nil {
+		return res, from, err
+	}
+	return signedTx, bundleEntry.AccountID, nil
+}

--- a/go/stellar/accountmerge.go
+++ b/go/stellar/accountmerge.go
@@ -29,10 +29,10 @@ func AccountMerge(mctx libkb.MetaContext, walletState *WalletState, arg stellar1
 	if err != nil {
 		return res, from, fmt.Errorf("account merge error looking up <to>: %v", err)
 	}
-	toAddr := stellarnet.AddressStr(*recipient.AccountID)
+	toAddr := recipient.AccountID
 	mctx.Debug("account merge <to> lookup complete: %s -> %s", arg.To, toAddr)
 
-	signedTx, err := stellarnet.AccountMergeTransaction(fromSeed, toAddr, sp, tb, baseFee)
+	signedTx, err := stellarnet.AccountMergeTransaction(fromSeed, *toAddr, sp, tb, baseFee)
 	if err != nil {
 		return res, from, err
 	}

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1590,21 +1590,6 @@ func SetAccountAsPrimary(m libkb.MetaContext, walletState *WalletState, accountI
 	return walletState.UpdateAccountEntriesWithBundle(m, "set account as primary", &nextBundle)
 }
 
-func DeleteAccountIfEmpty(mctx libkb.MetaContext, remoter remote.Remoter, accountID stellar1.AccountID) error {
-	funded, err := isAccountFunded(mctx.Ctx(), remoter, accountID)
-	if err != nil {
-		return err
-	}
-	if funded {
-		return fmt.Errorf("not deleting this account because it has lumens")
-	}
-	err = DeleteAccount(mctx, accountID)
-	if err != nil {
-		return fmt.Errorf("error deleting account: %+v", err)
-	}
-	return nil
-}
-
 func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {
 	if accountID.IsNil() {
 		return errors.New("passed empty AccountID")

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1590,6 +1590,21 @@ func SetAccountAsPrimary(m libkb.MetaContext, walletState *WalletState, accountI
 	return walletState.UpdateAccountEntriesWithBundle(m, "set account as primary", &nextBundle)
 }
 
+func DeleteAccountIfEmpty(mctx libkb.MetaContext, remoter remote.Remoter, accountID stellar1.AccountID) error {
+	funded, err := isAccountFunded(mctx.Ctx(), remoter, accountID)
+	if err != nil {
+		return err
+	}
+	if funded {
+		return fmt.Errorf("not deleting this account because it has lumens")
+	}
+	err = DeleteAccount(mctx, accountID)
+	if err != nil {
+		return fmt.Errorf("error deleting account: %+v", err)
+	}
+	return nil
+}
+
 func DeleteAccount(m libkb.MetaContext, accountID stellar1.AccountID) error {
 	if accountID.IsNil() {
 		return errors.New("passed empty AccountID")

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -235,7 +235,7 @@ func (s *Server) AccountMergeCLILocal(ctx context.Context, arg stellar1.AccountM
 	}
 	mctx = mctx.WithUIs(uis)
 
-	signRes, mergedAwayAccountID, err := stellar.AccountMerge(mctx, s.walletState, arg)
+	signRes, _, err := stellar.AccountMerge(mctx, s.walletState, arg)
 	if err != nil {
 		mctx.Debug("error building account-merge transaction for %s into %s: %v", arg.From, arg.To, err)
 		return res, err
@@ -246,14 +246,9 @@ func (s *Server) AccountMergeCLILocal(ctx context.Context, arg stellar1.AccountM
 		return res, err
 	}
 	mctx.Debug("posted account merge transaction for %s into %s", arg.From, arg.To)
-	err = s.walletState.Refresh(mctx, mergedAwayAccountID, "merged away assets")
+	err = s.walletState.RefreshAll(mctx, "account merge")
 	if err != nil {
-		return res, err
-	}
-	err = stellar.DeleteAccountIfEmpty(mctx, s.remoter, mergedAwayAccountID)
-	if err != nil {
-		mctx.Debug("error removing %s from wallet bundle after merge: %v", arg.From, err)
-		return res, err
+		mctx.Debug("error refreshing accounts after successfully processing a merge")
 	}
 	return stellar1.TransactionID(signRes.TxHash), nil
 }

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -235,17 +235,17 @@ func (s *Server) AccountMergeCLILocal(ctx context.Context, arg stellar1.AccountM
 	}
 	mctx = mctx.WithUIs(uis)
 
-	signRes, _, err := stellar.AccountMerge(mctx, s.walletState, arg)
+	signRes, err := stellar.AccountMerge(mctx, s.walletState, arg)
 	if err != nil {
-		mctx.Debug("error building account-merge transaction for %s into %s: %v", arg.From, arg.To, err)
+		mctx.Debug("error building account-merge transaction for %s into %s: %v", arg.FromAccountID, arg.To, err)
 		return res, err
 	}
 	err = s.remoter.PostAnyTransaction(mctx, signRes.Signed)
 	if err != nil {
-		mctx.Debug("error posting account-merge transaction for %s into %s: %v", arg.From, arg.To, err)
+		mctx.Debug("error posting account-merge transaction for %s into %s: %v", arg.FromAccountID, arg.To, err)
 		return res, err
 	}
-	mctx.Debug("posted account merge transaction for %s into %s", arg.From, arg.To)
+	mctx.Debug("posted account merge transaction for %s into %s", arg.FromAccountID, arg.To)
 	err = s.walletState.RefreshAll(mctx, "account merge")
 	if err != nil {
 		mctx.Debug("error refreshing accounts after successfully processing a merge")

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -220,6 +220,44 @@ func (s *Server) SendCLILocal(ctx context.Context, arg stellar1.SendCLILocalArg)
 	}, nil
 }
 
+func (s *Server) AccountMergeCLILocal(ctx context.Context, arg stellar1.AccountMergeCLILocalArg) (res stellar1.TransactionID, err error) {
+	mctx, fin, err := s.Preamble(ctx, preambleArg{
+		RPCName:       "AccountMergeCLILocal",
+		Err:           &err,
+		RequireWallet: true,
+	})
+	defer fin()
+	if err != nil {
+		return res, err
+	}
+	uis := libkb.UIs{
+		IdentifyUI: s.uiSource.IdentifyUI(s.G(), 0),
+	}
+	mctx = mctx.WithUIs(uis)
+
+	signRes, mergedAwayAccountID, err := stellar.AccountMerge(mctx, s.walletState, arg)
+	if err != nil {
+		mctx.Debug("error building account-merge transaction for %s into %s: %v", arg.From, arg.To, err)
+		return res, err
+	}
+	err = s.remoter.PostAnyTransaction(mctx, signRes.Signed)
+	if err != nil {
+		mctx.Debug("error posting account-merge transaction for %s into %s: %v", arg.From, arg.To, err)
+		return res, err
+	}
+	mctx.Debug("posted account merge transaction for %s into %s", arg.From, arg.To)
+	err = s.walletState.Refresh(mctx, mergedAwayAccountID, "merged away assets")
+	if err != nil {
+		return res, err
+	}
+	err = stellar.DeleteAccountIfEmpty(mctx, s.remoter, mergedAwayAccountID)
+	if err != nil {
+		mctx.Debug("error removing %s from wallet bundle after merge: %v", arg.From, err)
+		return res, err
+	}
+	return stellar1.TransactionID(signRes.TxHash), nil
+}
+
 func (s *Server) SendPathCLILocal(ctx context.Context, arg stellar1.SendPathCLILocalArg) (res stellar1.SendResultCLILocal, err error) {
 	mctx, fin, err := s.Preamble(ctx, preambleArg{
 		RPCName:       "SendPathCLILocal",

--- a/go/systests/stellar_client_test.go
+++ b/go/systests/stellar_client_test.go
@@ -604,6 +604,16 @@ func (s *stellarRetryClient) BatchLocal(ctx context.Context, arg stellar1.BatchL
 	return res, err
 }
 
+func (s *stellarRetryClient) AccountMergeCLILocal(ctx context.Context, arg stellar1.AccountMergeCLILocalArg) (res stellar1.TransactionID, err error) {
+	for i := 0; i < retryCount; i++ {
+		res, err = s.cli.AccountMergeCLILocal(ctx, arg)
+		if err == nil {
+			return res, nil
+		}
+	}
+	return res, err
+}
+
 func (s *stellarRetryClient) AirdropDetailsLocal(ctx context.Context, sessionID int) (res stellar1.AirdropDetails, err error) {
 	for i := 0; i < retryCount; i++ {
 		res, err = s.cli.AirdropDetailsLocal(ctx, sessionID)

--- a/go/systests/stellar_test.go
+++ b/go/systests/stellar_test.go
@@ -434,7 +434,7 @@ func TestAccountMerge(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("merged the second into the first")
 
-	err = walletState.Refresh(alice.tc.MetaContext(), firstAccountID, "test")
+	err = walletState.RefreshAll(alice.tc.MetaContext(), "test")
 	require.NoError(t, err)
 	endingBalances, err := walletState.Balances(ctx, firstAccountID)
 	require.NoError(t, err)
@@ -444,10 +444,4 @@ func TestAccountMerge(t *testing.T) {
 	lowerBoundFinalExpectedAmount := int64(stellarnet.StroopsPerLumen * 9999.999)
 	require.True(t, actualFinalAmount > lowerBoundFinalExpectedAmount)
 	t.Logf("value of the second account was merged into the first account")
-
-	accts, err := alice.stellarClient.GetWalletAccountsLocal(ctx, 0)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(accts))
-	require.Equal(t, firstAccountID, accts[0].AccountID)
-	t.Logf("the merged away account is no longer in the wallet bundle")
 }

--- a/go/systests/stellar_test.go
+++ b/go/systests/stellar_test.go
@@ -416,9 +416,12 @@ func TestAccountMerge(t *testing.T) {
 	}
 	require.NoError(t, err)
 
-	walletState.Refresh(alice.tc.MetaContext(), firstAccountID, "test")
-	walletState.Refresh(alice.tc.MetaContext(), secondAccountID, "test")
+	err = walletState.Refresh(alice.tc.MetaContext(), firstAccountID, "test")
+	require.NoError(t, err)
+	err = walletState.Refresh(alice.tc.MetaContext(), secondAccountID, "test")
+	require.NoError(t, err)
 	secondAcctBalances, err := walletState.Balances(ctx, secondAccountID)
+	require.NoError(t, err)
 	require.Equal(t, secondAcctBalances[0].Amount, "50.0000000")
 	t.Logf("10k lumens split into two accounts: ~99,949.999 and 50")
 
@@ -434,6 +437,7 @@ func TestAccountMerge(t *testing.T) {
 	err = walletState.Refresh(alice.tc.MetaContext(), firstAccountID, "test")
 	require.NoError(t, err)
 	endingBalances, err := walletState.Balances(ctx, firstAccountID)
+	require.NoError(t, err)
 	require.Len(t, endingBalances, 1)
 	actualFinalAmount, err := stellarnet.ParseStellarAmount(endingBalances[0].Amount)
 	require.NoError(t, err)

--- a/go/systests/stellar_test.go
+++ b/go/systests/stellar_test.go
@@ -384,3 +384,66 @@ func acceptDisclaimer(u *userPlusDevice) {
 	err := u.stellarClient.AcceptDisclaimerLocal(context.Background(), 0)
 	require.NoError(u.tc.T, err)
 }
+
+func TestAccountMerge(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+	useStellarTestNet(t)
+	ctx := context.Background()
+	alice := tt.addUser("alice")
+
+	t.Logf("fund two accounts for alice from one friendbot gift for 10k lumens")
+	acceptDisclaimer(alice)
+	walletState := alice.tc.G.GetStellar().(*stellar.Stellar).WalletStateForTest()
+	getRes, err := alice.stellarClient.GetWalletAccountsLocal(context.Background(), 0)
+	firstAccountID := getRes[0].AccountID
+	require.NoError(t, err)
+	secondAccountID, err := alice.stellarClient.CreateWalletAccountLocal(ctx, stellar1.CreateWalletAccountLocalArg{Name: "second"})
+	require.NoError(t, err)
+	gift(t, firstAccountID)
+
+	attachIdentifyUI(t, alice.tc.G, newSimpleIdentifyUI())
+	sendCmd := client.CmdWalletSend{
+		Contextified: libkb.NewContextified(alice.tc.G),
+		Recipient:    secondAccountID.String(),
+		Amount:       "50",
+	}
+	for i := 0; i < retryCount; i++ {
+		err = sendCmd.Run()
+		if err == nil {
+			break
+		}
+	}
+	require.NoError(t, err)
+
+	walletState.Refresh(alice.tc.MetaContext(), firstAccountID, "test")
+	walletState.Refresh(alice.tc.MetaContext(), secondAccountID, "test")
+	secondAcctBalances, err := walletState.Balances(ctx, secondAccountID)
+	require.Equal(t, secondAcctBalances[0].Amount, "50.0000000")
+	t.Logf("10k lumens split into two accounts: ~99,949.999 and 50")
+
+	mergeCmd := client.CmdWalletMerge{
+		Contextified:  libkb.NewContextified(alice.tc.G),
+		FromAccountID: secondAccountID,
+		To:            firstAccountID.String(),
+	}
+	err = mergeCmd.Run()
+	require.NoError(t, err)
+	t.Logf("merged the second into the first")
+
+	err = walletState.Refresh(alice.tc.MetaContext(), firstAccountID, "test")
+	require.NoError(t, err)
+	endingBalances, err := walletState.Balances(ctx, firstAccountID)
+	require.Len(t, endingBalances, 1)
+	actualFinalAmount, err := stellarnet.ParseStellarAmount(endingBalances[0].Amount)
+	require.NoError(t, err)
+	lowerBoundFinalExpectedAmount := int64(stellarnet.StroopsPerLumen * 9999.999)
+	require.True(t, actualFinalAmount > lowerBoundFinalExpectedAmount)
+	t.Logf("value of the second account was merged into the first account")
+
+	accts, err := alice.stellarClient.GetWalletAccountsLocal(ctx, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(accts))
+	require.Equal(t, firstAccountID, accts[0].AccountID)
+	t.Logf("the merged away account is no longer in the wallet bundle")
+}

--- a/go/vendor/github.com/keybase/stellarnet/errors.go
+++ b/go/vendor/github.com/keybase/stellarnet/errors.go
@@ -47,6 +47,9 @@ var ErrTxOpFull = errors.New("tx cannot hold more operations")
 // ErrNoOps means a Tx has no operations.
 var ErrNoOps = errors.New("no operations in tx")
 
+// ErrAssetAlreadyExists means an asset cannot be created because it already exists
+var ErrAssetAlreadyExists = errors.New("asset already exists")
+
 // Error provides a hopefully user-friendly default in Error()
 // but with some details that might actually help debug in Verbose().
 type Error struct {

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -776,10 +776,10 @@
 			"revisionTime": "2018-08-09T16:02:10Z"
 		},
 		{
-			"checksumSHA1": "xlc9p8YtRJqYx487QZAonCYNwfg=",
+			"checksumSHA1": "O2pMKCLN0cVTYoSQumA11Xh6rEQ=",
 			"path": "github.com/keybase/stellarnet",
-			"revision": "810876e4a1f9d92a5f4b2fdc4c341d9019b2c2d5",
-			"revisionTime": "2019-08-02T20:38:12Z"
+			"revision": "a10a61194d3cba1622c1061f1a214ed6b6504d84",
+			"revisionTime": "2019-08-12T19:14:27Z"
 		},
 		{
 			"checksumSHA1": "B/Qlhpd96i6Sx0DdhSzbHUdG47U=",

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -586,6 +586,7 @@ protocol local {
                                   string publicNote, AccountID fromAccountID);
 
   SendResultCLILocal sendPathCLILocal(AccountID source, string recipient, PaymentPath path, string note, string publicNote);
+  TransactionID accountMergeCLILocal(AccountID from, string to);
 
   // Claim a relay payment
   // `txID` is the kbTxID of the relay payment. Can also be the txID of the funding tx.

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -586,7 +586,7 @@ protocol local {
                                   string publicNote, AccountID fromAccountID);
 
   SendResultCLILocal sendPathCLILocal(AccountID source, string recipient, PaymentPath path, string note, string publicNote);
-  TransactionID accountMergeCLILocal(AccountID from, string to);
+  TransactionID accountMergeCLILocal(AccountID fromAccountID, union { null, SecretKey } fromSecretKey, string to);
 
   // Claim a relay payment
   // `txID` is the kbTxID of the relay payment. Can also be the txID of the funding tx.

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -2482,6 +2482,19 @@
       ],
       "response": "SendResultCLILocal"
     },
+    "accountMergeCLILocal": {
+      "request": [
+        {
+          "name": "from",
+          "type": "AccountID"
+        },
+        {
+          "name": "to",
+          "type": "string"
+        }
+      ],
+      "response": "TransactionID"
+    },
     "claimCLILocal": {
       "request": [
         {

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -2485,8 +2485,15 @@
     "accountMergeCLILocal": {
       "request": [
         {
-          "name": "from",
+          "name": "fromAccountID",
           "type": "AccountID"
+        },
+        {
+          "name": "fromSecretKey",
+          "type": [
+            null,
+            "SecretKey"
+          ]
         },
         {
           "name": "to",

--- a/shared/constants/types/rpc-stellar-gen.tsx
+++ b/shared/constants/types/rpc-stellar-gen.tsx
@@ -561,6 +561,7 @@ export const localValidateStellarURILocalRpcPromise = (params: MessageTypes['ste
 // 'stellar.1.local.balancesLocal'
 // 'stellar.1.local.sendCLILocal'
 // 'stellar.1.local.sendPathCLILocal'
+// 'stellar.1.local.accountMergeCLILocal'
 // 'stellar.1.local.claimCLILocal'
 // 'stellar.1.local.recentPaymentsCLILocal'
 // 'stellar.1.local.paymentDetailCLILocal'


### PR DESCRIPTION
pulls in new stellarnet command from here https://github.com/keybase/stellarnet/pull/74

looks like this:
```
keybase wallet merge GA6WYO...XTME
```
* optionally takes `--to`. this parameter can be any other account or another user, and it defaults to your primary account. 
* the from side can also be a secret key. if it's an address, then it needs to be in your wallet. but you can use this as a command to merge anything into anything. :)

notes:
* currently blocking the merge of your primary account. this seems like it would be more likely a mistake than anything else, but if you wanted to do it, just go into another account and do it from there. 
* if you want to merge away an account with assets, the target account also needs to have trustlines to those assets. i thought about automating this if it's going into one of your other accounts, but i didn't. it would either mean multiple transactions or a much more complicated one (multiple signers on the operations). 
* i added a single test here that exercises the simplest happy path (more is done over in stellarnet)
* i didn't add it to the `keybase wallet api`. 