### PR TITLE
fix identify success caching for FS_GUI

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1266,7 +1266,6 @@ func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_CLI,
 		TLFIdentifyBehavior_CHAT_GUI,
-		TLFIdentifyBehavior_FS_GUI,
 		TLFIdentifyBehavior_SALTPACK,
 		TLFIdentifyBehavior_KBFS_CHAT,
 		TLFIdentifyBehavior_GUI_PROFILE:


### PR DESCRIPTION
We only return cached identify result when AlwaysIdentify() is `false`: https://github.com/keybase/client/blob/8283633e9626ae34a29792b0f6695e507702de8a/go/kbfs/libkbfs/folder_branch_ops.go#L2173

so it was incorrect to make FS_GUI's AlwaysIdentify() return `true`, which caused tons of identifies each time a folder is accessed in GUI.

cc @maxtaco 
