### PR TITLE
Handle errors in contact import

### DIFF
--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -48,7 +48,7 @@
     "editPhone": {
       "phone": "string",
       "delete?": "boolean",
-      "setSearchable?": "boolean",
+      "setSearchable?": "boolean"
     },
     "sentVerificationEmail": {
       "email": "string"
@@ -70,7 +70,8 @@
     },
     "importContactsLater": {},
     "setContactImportedCount": {
-      "count": "number | null"
+      "count": "number | null",
+      "error?": "string"
     },
     "loadedUserCountryCode": {
       "code": "string | null"

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -520,7 +520,7 @@ async function manageContactsCache(
     })
   } catch (e) {
     logger.error(`error loading contacts: ${e.message}`)
-    return false
+    return SettingsGen.createSetContactImportedCount({count: null, error: e.message})
   }
   let defaultCountryCode: string = ''
   try {

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -513,7 +513,15 @@ async function manageContactsCache(
   }
 
   // feature enabled and permission granted
-  const contacts = await Contacts.getContactsAsync()
+  let contacts: Contacts.ContactResponse
+  try {
+    contacts = await Contacts.getContactsAsync({
+      fields: [Contacts.Fields.Name, Contacts.Fields.PhoneNumbers, Contacts.Fields.Emails],
+    })
+  } catch (e) {
+    logger.error(`error loading contacts: ${e.message}`)
+    return false
+  }
   let defaultCountryCode: string = ''
   try {
     defaultCountryCode = await NativeModules.Utils.getDefaultCountryCode()

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -570,6 +570,7 @@ async function manageContactsCache(
     }
   } catch (e) {
     logger.error('Error saving contacts list: ', e.message)
+    actions.push(SettingsGen.createSetContactImportedCount({count: null, error: e.message}))
   }
   return actions
 }

--- a/shared/actions/settings-gen.tsx
+++ b/shared/actions/settings-gen.tsx
@@ -165,7 +165,7 @@ type _SendFeedbackPayload = {
 }
 type _SentVerificationEmailPayload = {readonly email: string}
 type _SetAllowDeleteAccountPayload = {readonly allow: boolean}
-type _SetContactImportedCountPayload = {readonly count: number | null}
+type _SetContactImportedCountPayload = {readonly count: number | null; readonly error?: string}
 type _StopPayload = {readonly exitCode: RPCTypes.ExitCode}
 type _ToggleRuntimeStatsPayload = void
 type _TracePayload = {readonly durationSeconds: number}

--- a/shared/constants/settings.tsx
+++ b/shared/constants/settings.tsx
@@ -90,6 +90,7 @@ export const makePhoneNumbers = I.Record<Types._PhoneNumbersState>({
 
 export const makeContacts = I.Record<Types._ContactsState>({
   importEnabled: null,
+  importError: '',
   importPromptDismissed: false,
   importedCount: null,
   permissionStatus: 'unknown',

--- a/shared/constants/types/settings.tsx
+++ b/shared/constants/types/settings.tsx
@@ -114,13 +114,14 @@ export type _PhoneNumbersState = {
 }
 export type PhoneNumbersState = I.RecordOf<_PhoneNumbersState>
 
+export type PermissionStatus = 'granted' | 'never_ask_again' | 'undetermined' | 'unknown'
 export type _ContactsState = {
   importEnabled: boolean | null
   importError: string
   importPromptDismissed: boolean
   importedCount: number | null
   // OS permissions. 'undetermined' -> we can show the prompt; 'unknown' -> we haven't checked
-  permissionStatus: 'granted' | 'never_ask_again' | 'undetermined' | 'unknown'
+  permissionStatus: PermissionStatus
   userCountryCode: string | null
 }
 export type ContactsState = I.RecordOf<_ContactsState>

--- a/shared/constants/types/settings.tsx
+++ b/shared/constants/types/settings.tsx
@@ -116,6 +116,7 @@ export type PhoneNumbersState = I.RecordOf<_PhoneNumbersState>
 
 export type _ContactsState = {
   importEnabled: boolean | null
+  importError: string
   importPromptDismissed: boolean
   importedCount: number | null
   // OS permissions. 'undetermined' -> we can show the prompt; 'unknown' -> we haven't checked

--- a/shared/reducers/settings.tsx
+++ b/shared/reducers/settings.tsx
@@ -204,7 +204,9 @@ function reducer(state: Types.State = initialState, action: Actions): Types.Stat
     case SettingsGen.loadedContactPermissions:
       return state.update('contacts', contacts => contacts.merge({permissionStatus: action.payload.status}))
     case SettingsGen.setContactImportedCount:
-      return state.update('contacts', contacts => contacts.set('importedCount', action.payload.count))
+      return state.update('contacts', contacts =>
+        contacts.merge({importError: action.payload.error, importedCount: action.payload.count})
+      )
     case SettingsGen.importContactsLater:
       return state.update('contacts', contacts => contacts.set('importPromptDismissed', true))
     case SettingsGen.loadedUserCountryCode:

--- a/shared/settings/feedback/container.desktop.tsx
+++ b/shared/settings/feedback/container.desktop.tsx
@@ -5,7 +5,7 @@ import * as SettingsGen from '../../actions/settings-gen'
 import {anyWaiting} from '../../constants/waiting'
 import * as Constants from '../../constants/settings'
 
-type OwnProps = Container.RouteProps<{feedback: string}>
+type OwnProps = Container.RouteProps<{heading: string; feedback: string}>
 
 export default Container.namedConnect(
   state => ({

--- a/shared/settings/feedback/container.native.tsx
+++ b/shared/settings/feedback/container.native.tsx
@@ -1,7 +1,7 @@
 import logger from '../../logger'
 import * as React from 'react'
-import {HOCTimers, PropsWithTimer} from '../../common-adapters'
-import Feedback from './index'
+import * as Kb from '../../common-adapters'
+import Feedback from '.'
 import logSend from '../../native/log-send'
 import * as Container from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
@@ -10,14 +10,14 @@ import {writeLogLinesToFile} from '../../util/forward-logs'
 import {Platform, NativeModules} from 'react-native'
 import {getExtraChatLogsForLogSend, getPushTokenForLogSend} from '../../constants/settings'
 
-type OwnProps = Container.RouteProps<{feedback: string}>
+type OwnProps = Container.RouteProps<{heading: string; feedback: string}>
 
 export type State = {
   sentFeedback: boolean
   sending: boolean
   sendError: Error | null
 }
-export type Props = PropsWithTimer<{
+export type Props = Kb.PropsWithTimer<{
   chat: Object
   loggedOut: boolean
   push: Object
@@ -106,14 +106,17 @@ class FeedbackContainer extends React.Component<Props, State> {
 
   render() {
     return (
-      <Feedback
-        onSendFeedback={this._onSendFeedback}
-        sending={this.state.sending}
-        sendError={this.state.sendError}
-        loggedOut={this.props.loggedOut}
-        showInternalSuccessBanner={true}
-        onFeedbackDone={() => null}
-      />
+      <Kb.Box2 direction="vertical" fullWidth={true}>
+        <Kb.HeaderHocHeader onBack={this.props.onBack} title={this.props.title} />
+        <Feedback
+          onSendFeedback={this._onSendFeedback}
+          sending={this.state.sending}
+          sendError={this.state.sendError}
+          loggedOut={this.props.loggedOut}
+          showInternalSuccessBanner={true}
+          onFeedbackDone={() => null}
+        />
+      </Kb.Box2>
     )
   }
 }
@@ -139,15 +142,15 @@ const connected = Container.compose(
     }),
     dispatch => ({
       onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
-      title: 'Feedback',
     }),
     (s, d, o: OwnProps) => ({
       ...s,
       ...d,
       feedback: Container.getRouteProps(o, 'feedback', ''),
+      title: Container.getRouteProps(o, 'heading', 'Feedback'),
     })
   ),
-  HOCTimers
+  Kb.HOCTimers
 )(FeedbackContainer)
 
 export default connected

--- a/shared/settings/feedback/container.native.tsx
+++ b/shared/settings/feedback/container.native.tsx
@@ -19,6 +19,7 @@ export type State = {
 }
 export type Props = Kb.PropsWithTimer<{
   chat: Object
+  feedback: string
   loggedOut: boolean
   push: Object
   onBack: () => void
@@ -115,6 +116,7 @@ class FeedbackContainer extends React.Component<Props, State> {
           loggedOut={this.props.loggedOut}
           showInternalSuccessBanner={true}
           onFeedbackDone={() => null}
+          feedback={this.props.feedback}
         />
       </Kb.Box2>
     )

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -91,7 +91,7 @@ class Feedback extends React.Component<Props, State> {
     const {sending, sendError} = this.props
     return (
       <Kb.Box2 direction="vertical" fullWidth={true} alignItems="center">
-        <Kb.ScrollView>
+        <Kb.ScrollView alwaysBounceVertical={false}>
           {this.state.showSuccessBanner && (
             <Kb.Banner color="green">
               <Kb.BannerParagraph bannerColor="green" content="Thanks! Your feedback was sent." />

--- a/shared/settings/manage-contacts.native.tsx
+++ b/shared/settings/manage-contacts.native.tsx
@@ -79,8 +79,12 @@ const ManageContactsBanner = () => {
     dispatch(appendNewChatBuilder())
   }, [dispatch])
   const onSendFeedback = React.useCallback(() => {
-    dispatch(RouteTreeGen.createNavigateAppend({path: [Constants.feedbackTab]}))
-  }, [dispatch])
+    dispatch(
+      RouteTreeGen.createNavigateAppend({
+        path: [{props: {feedback: `Contact import failed\n${error}\n\n`}, selected: Constants.feedbackTab}],
+      })
+    )
+  }, [dispatch, error])
 
   return (
     <>

--- a/shared/settings/manage-contacts.native.tsx
+++ b/shared/settings/manage-contacts.native.tsx
@@ -71,11 +71,15 @@ const ManageContactsBanner = () => {
   const status = Container.useSelector(s => s.settings.contacts.permissionStatus)
   const contactsImported = Container.useSelector(s => s.settings.contacts.importEnabled)
   const importedCount = Container.useSelector(s => s.settings.contacts.importedCount)
+  const error = Container.useSelector(s => s.settings.contacts.importError)
 
   const onOpenAppSettings = React.useCallback(() => dispatch(ConfigGen.createOpenAppSettings()), [dispatch])
   const onStartChat = React.useCallback(() => {
     dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.chatTab}))
     dispatch(appendNewChatBuilder())
+  }, [dispatch])
+  const onSendFeedback = React.useCallback(() => {
+    dispatch(RouteTreeGen.createNavigateAppend({path: [Constants.feedbackTab]}))
   }, [dispatch])
 
   return (
@@ -96,6 +100,18 @@ const ManageContactsBanner = () => {
                 : "Keybase doesn't have permission to access your contacts. ",
               {onClick: onOpenAppSettings, text: 'Enable in settings'},
               '.',
+            ]}
+          />
+        </Kb.Banner>
+      )}
+      {!!error && (
+        <Kb.Banner color="red">
+          <Kb.BannerParagraph
+            bannerColor="red"
+            content={[
+              'There was an error importing your contacts. ',
+              {onClick: onSendFeedback, text: 'Send feedback'},
+              ' if the problem continues.',
             ]}
           />
         </Kb.Banner>

--- a/shared/settings/manage-contacts.native.tsx
+++ b/shared/settings/manage-contacts.native.tsx
@@ -106,13 +106,10 @@ const ManageContactsBanner = () => {
       )}
       {!!error && (
         <Kb.Banner color="red">
+          <Kb.BannerParagraph bannerColor="red" content="There was an error importing your contacts." />
           <Kb.BannerParagraph
             bannerColor="red"
-            content={[
-              'There was an error importing your contacts. ',
-              {onClick: onSendFeedback, text: 'Send feedback'},
-              ' if the problem continues.',
-            ]}
+            content={[{onClick: onSendFeedback, text: 'Send us feedback.'}]}
           />
         </Kb.Banner>
       )}

--- a/shared/settings/manage-contacts.native.tsx
+++ b/shared/settings/manage-contacts.native.tsx
@@ -10,21 +10,15 @@ import * as Styles from '../styles'
 import {appendNewChatBuilder} from '../actions/typed-routes'
 import {SettingsSection} from './account/'
 
-type Props = {
-  contactsImported: boolean
-  onToggleImport: () => void
-}
-
 const enabledDescription = 'Your phone contacts are being synced on this device.'
 const disabledDescription = 'Import your phone contacts and start encrypted chats with your friends.'
 
-const ManageContacts = (_: Props) => {
+const ManageContacts = () => {
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
 
   const status = Container.useSelector(s => s.settings.contacts.permissionStatus)
   const contactsImported = Container.useSelector(s => s.settings.contacts.importEnabled)
-  const importedCount = Container.useSelector(s => s.settings.contacts.importedCount)
   const waiting = Container.useAnyWaiting(Constants.importContactsWaitingKey)
 
   if (contactsImported === null) {
@@ -41,39 +35,12 @@ const ManageContacts = (_: Props) => {
       ),
     [dispatch, contactsImported, status]
   )
-  const onOpenAppSettings = React.useCallback(() => dispatch(ConfigGen.createOpenAppSettings()), [dispatch])
-  const onStartChat = React.useCallback(() => {
-    dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.chatTab}))
-    dispatch(appendNewChatBuilder())
-  }, [dispatch])
 
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.positionRelative}>
       <Kb.HeaderHocHeader title="Contacts" onBack={onBack} />
       <Kb.BoxGrow>
-        {importedCount !== null && (
-          <Kb.Banner color="green">
-            <Kb.BannerParagraph bannerColor="green" content={[`You imported ${importedCount} contacts.`]} />
-            <Kb.BannerParagraph
-              bannerColor="green"
-              content={[{onClick: onStartChat, text: 'Start a chat'}]}
-            />
-          </Kb.Banner>
-        )}
-        {(status === 'never_ask_again' || (Styles.isAndroid && status !== 'granted' && contactsImported)) && (
-          <Kb.Banner color="red">
-            <Kb.BannerParagraph
-              bannerColor="red"
-              content={[
-                contactsImported
-                  ? "Contact importing is paused because Keybase doesn't have permission to access your contacts. "
-                  : "Keybase doesn't have permission to access your contacts. ",
-                {onClick: onOpenAppSettings, text: 'Enable in settings'},
-                '.',
-              ]}
-            />
-          </Kb.Banner>
-        )}
+        <ManageContactsBanner />
         <SettingsSection>
           <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true}>
             <Kb.Text type="Header">Phone contacts</Kb.Text>
@@ -95,6 +62,45 @@ const ManageContacts = (_: Props) => {
         </SettingsSection>
       </Kb.BoxGrow>
     </Kb.Box2>
+  )
+}
+
+const ManageContactsBanner = () => {
+  const dispatch = Container.useDispatch()
+
+  const status = Container.useSelector(s => s.settings.contacts.permissionStatus)
+  const contactsImported = Container.useSelector(s => s.settings.contacts.importEnabled)
+  const importedCount = Container.useSelector(s => s.settings.contacts.importedCount)
+
+  const onOpenAppSettings = React.useCallback(() => dispatch(ConfigGen.createOpenAppSettings()), [dispatch])
+  const onStartChat = React.useCallback(() => {
+    dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.chatTab}))
+    dispatch(appendNewChatBuilder())
+  }, [dispatch])
+
+  return (
+    <>
+      {importedCount !== null && (
+        <Kb.Banner color="green">
+          <Kb.BannerParagraph bannerColor="green" content={[`You imported ${importedCount} contacts.`]} />
+          <Kb.BannerParagraph bannerColor="green" content={[{onClick: onStartChat, text: 'Start a chat'}]} />
+        </Kb.Banner>
+      )}
+      {(status === 'never_ask_again' || (Styles.isAndroid && status !== 'granted' && contactsImported)) && (
+        <Kb.Banner color="red">
+          <Kb.BannerParagraph
+            bannerColor="red"
+            content={[
+              contactsImported
+                ? "Contact importing is paused because Keybase doesn't have permission to access your contacts. "
+                : "Keybase doesn't have permission to access your contacts. ",
+              {onClick: onOpenAppSettings, text: 'Enable in settings'},
+              '.',
+            ]}
+          />
+        </Kb.Banner>
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
- Fix 'unparseable date' errors by not requesting that field from expo-contacts (I couldn't repro the error but this is reportedly a solution)
- Add error red banner to manage-contacts instead of black barring. "Send us feedback" link to log send.
- Add header to feedback page on mobile

<img width="400" alt="image" src="https://user-images.githubusercontent.com/11968340/63048950-98908480-bea5-11e9-9408-6702878dc5df.png">

cc @keybase/y2ksquad 