### PR TITLE
golangci-lint: disable `elseif` rule

### DIFF
--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -2,6 +2,7 @@ linters-settings:
   gocritic:
     disabled-checks:
       - ifElseChain
+      - elseif
 
 linters:
   enable:


### PR DESCRIPTION
By popular demand.