### PR TITLE
Add optional key decorators in chat api output

### DIFF
--- a/go/protocol/chat1/api.go
+++ b/go/protocol/chat1/api.go
@@ -29,8 +29,8 @@ type ChatChannel struct {
 	Name        string `codec:"name" json:"name"`
 	Public      bool   `codec:"public" json:"public"`
 	MembersType string `codec:"membersType" json:"members_type"`
-	TopicType   string `codec:"topicType" json:"topic_type"`
-	TopicName   string `codec:"topicName" json:"topic_name"`
+	TopicType   string `codec:"topicType,omitempty" json:"topic_type,omitempty"`
+	TopicName   string `codec:"topicName,omitempty" json:"topic_name,omitempty"`
 }
 
 func (o ChatChannel) DeepCopy() ChatChannel {
@@ -55,9 +55,9 @@ func (o ChatMessage) DeepCopy() ChatMessage {
 
 type MsgSender struct {
 	Uid        string `codec:"uid" json:"uid"`
-	Username   string `codec:"username" json:"username"`
+	Username   string `codec:"username,omitempty" json:"username,omitempty"`
 	DeviceID   string `codec:"deviceID" json:"device_id"`
-	DeviceName string `codec:"deviceName" json:"device_name"`
+	DeviceName string `codec:"deviceName,omitempty" json:"device_name,omitempty"`
 }
 
 func (o MsgSender) DeepCopy() MsgSender {
@@ -231,17 +231,17 @@ type MsgSummary struct {
 	Content             MsgContent               `codec:"content" json:"content"`
 	Prev                []MessagePreviousPointer `codec:"prev" json:"prev"`
 	Unread              bool                     `codec:"unread" json:"unread"`
-	RevokedDevice       bool                     `codec:"revokedDevice" json:"revoked_device"`
-	Offline             bool                     `codec:"offline" json:"offline"`
-	KbfsEncrypted       bool                     `codec:"kbfsEncrypted" json:"kbfs_encrypted"`
-	IsEphemeral         bool                     `codec:"isEphemeral" json:"is_ephemeral"`
-	IsEphemeralExpired  bool                     `codec:"isEphemeralExpired" json:"is_ephemeral_expired"`
-	ETime               gregor1.Time             `codec:"eTime" json:"e_time"`
+	RevokedDevice       bool                     `codec:"revokedDevice,omitempty" json:"revoked_device,omitempty"`
+	Offline             bool                     `codec:"offline,omitempty" json:"offline,omitempty"`
+	KbfsEncrypted       bool                     `codec:"kbfsEncrypted,omitempty" json:"kbfs_encrypted,omitempty"`
+	IsEphemeral         bool                     `codec:"isEphemeral,omitempty" json:"is_ephemeral,omitempty"`
+	IsEphemeralExpired  bool                     `codec:"isEphemeralExpired,omitempty" json:"is_ephemeral_expired,omitempty"`
+	ETime               gregor1.Time             `codec:"eTime,omitempty" json:"e_time,omitempty"`
 	Reactions           *ReactionMap             `codec:"reactions,omitempty" json:"reactions,omitempty"`
-	HasPairwiseMacs     bool                     `codec:"hasPairwiseMacs" json:"has_pairwise_macs"`
-	AtMentionUsernames  []string                 `codec:"atMentionUsernames" json:"at_mention_usernames"`
-	ChannelMention      string                   `codec:"channelMention" json:"channel_mention"`
-	ChannelNameMentions []UIChannelNameMention   `codec:"channelNameMentions" json:"channel_name_mentions"`
+	HasPairwiseMacs     bool                     `codec:"hasPairwiseMacs,omitempty" json:"has_pairwise_macs,omitempty"`
+	AtMentionUsernames  []string                 `codec:"atMentionUsernames,omitempty" json:"at_mention_usernames,omitempty"`
+	ChannelMention      string                   `codec:"channelMention,omitempty" json:"channel_mention,omitempty"`
+	ChannelNameMentions []UIChannelNameMention   `codec:"channelNameMentions,omitempty" json:"channel_name_mentions,omitempty"`
 }
 
 func (o MsgSummary) DeepCopy() MsgSummary {
@@ -332,9 +332,9 @@ func (o Message) DeepCopy() Message {
 type Thread struct {
 	Messages         []Message                     `codec:"messages" json:"messages"`
 	Pagination       *Pagination                   `codec:"pagination,omitempty" json:"pagination,omitempty"`
-	Offline          bool                          `codec:"offline" json:"offline"`
-	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identify_failures"`
-	RateLimits       []RateLimitRes                `codec:"rateLimits" json:"ratelimits"`
+	Offline          bool                          `codec:"offline,omitempty" json:"offline,omitempty"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures,omitempty" json:"identify_failures,omitempty"`
+	RateLimits       []RateLimitRes                `codec:"rateLimits,omitempty" json:"ratelimits,omitempty"`
 }
 
 func (o Thread) DeepCopy() Thread {
@@ -452,9 +452,9 @@ func (o ConvSummary) DeepCopy() ConvSummary {
 type ChatList struct {
 	Conversations    []ConvSummary                 `codec:"conversations" json:"conversations"`
 	Offline          bool                          `codec:"offline" json:"offline"`
-	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identify_failures"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures,omitempty" json:"identify_failures,omitempty"`
 	Pagination       *Pagination                   `codec:"pagination,omitempty" json:"pagination,omitempty"`
-	RateLimits       []RateLimitRes                `codec:"rateLimits" json:"ratelimits"`
+	RateLimits       []RateLimitRes                `codec:"rateLimits,omitempty" json:"ratelimits,omitempty"`
 }
 
 func (o ChatList) DeepCopy() ChatList {
@@ -507,8 +507,8 @@ type SendRes struct {
 	Message          string                        `codec:"message" json:"message"`
 	MessageID        *MessageID                    `codec:"messageID,omitempty" json:"id,omitempty"`
 	OutboxID         *OutboxID                     `codec:"outboxID,omitempty" json:"outbox_id,omitempty"`
-	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identify_failures"`
-	RateLimits       []RateLimitRes                `codec:"rateLimits" json:"ratelimits"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures,omitempty" json:"identify_failures,omitempty"`
+	RateLimits       []RateLimitRes                `codec:"rateLimits,omitempty" json:"ratelimits,omitempty"`
 }
 
 func (o SendRes) DeepCopy() SendRes {
@@ -555,8 +555,8 @@ func (o SendRes) DeepCopy() SendRes {
 
 type SearchInboxResOutput struct {
 	Results          *ChatSearchInboxResults       `codec:"results,omitempty" json:"results,omitempty"`
-	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identify_failures"`
-	RateLimits       []RateLimitRes                `codec:"rateLimits" json:"ratelimits"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures,omitempty" json:"identify_failures,omitempty"`
+	RateLimits       []RateLimitRes                `codec:"rateLimits,omitempty" json:"ratelimits,omitempty"`
 }
 
 func (o SearchInboxResOutput) DeepCopy() SearchInboxResOutput {
@@ -595,8 +595,8 @@ func (o SearchInboxResOutput) DeepCopy() SearchInboxResOutput {
 
 type RegexpRes struct {
 	Hits             []ChatSearchHit               `codec:"hits" json:"hits"`
-	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identify_failures"`
-	RateLimits       []RateLimitRes                `codec:"rateLimits" json:"ratelimits"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures,omitempty" json:"identify_failures,omitempty"`
+	RateLimits       []RateLimitRes                `codec:"rateLimits,omitempty" json:"ratelimits,omitempty"`
 }
 
 func (o RegexpRes) DeepCopy() RegexpRes {
@@ -639,8 +639,8 @@ func (o RegexpRes) DeepCopy() RegexpRes {
 
 type NewConvRes struct {
 	Id               string                        `codec:"id" json:"id"`
-	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identify_failures"`
-	RateLimits       []RateLimitRes                `codec:"rateLimits" json:"ratelimits"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures,omitempty" json:"identify_failures,omitempty"`
+	RateLimits       []RateLimitRes                `codec:"rateLimits,omitempty" json:"ratelimits,omitempty"`
 }
 
 func (o NewConvRes) DeepCopy() NewConvRes {
@@ -673,7 +673,7 @@ func (o NewConvRes) DeepCopy() NewConvRes {
 
 type ListCommandsRes struct {
 	Commands   []UserBotCommandOutput `codec:"commands" json:"commands"`
-	RateLimits []RateLimitRes         `codec:"rateLimits" json:"ratelimits"`
+	RateLimits []RateLimitRes         `codec:"rateLimits,omitempty" json:"ratelimits,omitempty"`
 }
 
 func (o ListCommandsRes) DeepCopy() ListCommandsRes {
@@ -704,7 +704,7 @@ func (o ListCommandsRes) DeepCopy() ListCommandsRes {
 }
 
 type EmptyRes struct {
-	RateLimits []RateLimitRes `codec:"rateLimits" json:"ratelimits"`
+	RateLimits []RateLimitRes `codec:"rateLimits,omitempty" json:"ratelimits,omitempty"`
 }
 
 func (o EmptyRes) DeepCopy() EmptyRes {

--- a/protocol/avdl/chat1/api.avdl
+++ b/protocol/avdl/chat1/api.avdl
@@ -24,8 +24,10 @@ protocol api {
     @jsonkey("members_type")
     string membersType;
     @jsonkey("topic_type")
+    @optional(true)
     string topicType;
     @jsonkey("topic_name")
+    @optional(true)
     string topicName;
   }
 
@@ -40,10 +42,12 @@ protocol api {
     @jsonkey("uid")
     string uid;
     @jsonkey("username")
+    @optional(true)
     string username;
     @jsonkey("device_id")
     string deviceID;
     @jsonkey("device_name")
+    @optional(true)
     string deviceName;
   }
 
@@ -116,26 +120,36 @@ protocol api {
     @jsonkey("unread")
     boolean unread;
     @jsonkey("revoked_device")
+    @optional(true)
     boolean revokedDevice;
     @jsonkey("offline")
+    @optional(true)
     boolean offline;
     @jsonkey("kbfs_encrypted")
+    @optional(true)
     boolean kbfsEncrypted;
     @jsonkey("is_ephemeral")
+    @optional(true)
     boolean isEphemeral;
+    @optional(true)
     @jsonkey("is_ephemeral_expired")
     boolean isEphemeralExpired;
     @jsonkey("e_time")
+    @optional(true)
     gregor1.Time eTime;
     @jsonkey("reactions")
     union { null, ReactionMap } reactions;
     @jsonkey("has_pairwise_macs")
+    @optional(true)
     boolean hasPairwiseMacs;
     @jsonkey("at_mention_usernames")
+    @optional(true)
     array<string> atMentionUsernames;
     @jsonkey("channel_mention")
+    @optional(true)
     string channelMention;
     @jsonkey("channel_name_mentions")
+    @optional(true)
     array<UIChannelNameMention> channelNameMentions;
   }
 
@@ -155,10 +169,13 @@ protocol api {
     @jsonkey("pagination")
     union { null, Pagination } pagination;
     @jsonkey("offline")
+    @optional(true)
     boolean offline;
     @jsonkey("identify_failures")
+    @optional(true)
     array<keybase1.TLFIdentifyFailure> identifyFailures;
     @jsonkey("ratelimits")
+    @optional(true)
     array<RateLimitRes> rateLimits;
   }
 
@@ -199,10 +216,12 @@ protocol api {
     @jsonkey("offline")
     boolean offline;
     @jsonkey("identify_failures")
+    @optional(true)
     array<keybase1.TLFIdentifyFailure> identifyFailures;
     @jsonkey("pagination")
     union { null, Pagination } pagination;
     @jsonkey("ratelimits")
+    @optional(true)
     array<RateLimitRes> rateLimits;
   }
 
@@ -215,8 +234,10 @@ protocol api {
     @jsonkey("outbox_id")
     union { null, OutboxID } outboxID;
     @jsonkey("identify_failures")
+    @optional(true)
     array<keybase1.TLFIdentifyFailure> identifyFailures;
     @jsonkey("ratelimits")
+    @optional(true)
     array<RateLimitRes> rateLimits;
   }
 
@@ -224,8 +245,10 @@ protocol api {
     @jsonkey("results")
     union { null, ChatSearchInboxResults } results;
     @jsonkey("identify_failures")
+    @optional(true)
     array<keybase1.TLFIdentifyFailure> identifyFailures;
     @jsonkey("ratelimits")
+    @optional(true)
     array<RateLimitRes> rateLimits;
   }
 
@@ -233,8 +256,10 @@ protocol api {
     @jsonkey("hits")
     array<ChatSearchHit> hits;
     @jsonkey("identify_failures")
+    @optional(true)
     array<keybase1.TLFIdentifyFailure> identifyFailures;
     @jsonkey("ratelimits")
+    @optional(true)
     array<RateLimitRes> rateLimits;
   }
 
@@ -242,8 +267,10 @@ protocol api {
     @jsonkey("id")
     string id;
     @jsonkey("identify_failures")
+    @optional(true)
     array<keybase1.TLFIdentifyFailure> identifyFailures;
     @jsonkey("ratelimits")
+    @optional(true)
     array<RateLimitRes> rateLimits;
   }
 
@@ -251,12 +278,14 @@ protocol api {
     @jsonkey("commands")
     array<UserBotCommandOutput> commands;
     @jsonkey("ratelimits")
+    @optional(true)
     array<RateLimitRes> rateLimits;
   }
 
   // EmptyRes is used for JSON output of a boring command.
   record EmptyRes {
     @jsonkey("ratelimits")
+    @optional(true)
     array<RateLimitRes> rateLimits;
   }
 

--- a/protocol/json/chat1/api.json
+++ b/protocol/json/chat1/api.json
@@ -73,12 +73,14 @@
         {
           "type": "string",
           "name": "topicType",
-          "jsonkey": "topic_type"
+          "jsonkey": "topic_type",
+          "optional": true
         },
         {
           "type": "string",
           "name": "topicName",
-          "jsonkey": "topic_name"
+          "jsonkey": "topic_name",
+          "optional": true
         }
       ]
     },
@@ -105,7 +107,8 @@
         {
           "type": "string",
           "name": "username",
-          "jsonkey": "username"
+          "jsonkey": "username",
+          "optional": true
         },
         {
           "type": "string",
@@ -115,7 +118,8 @@
         {
           "type": "string",
           "name": "deviceName",
-          "jsonkey": "device_name"
+          "jsonkey": "device_name",
+          "optional": true
         }
       ]
     },
@@ -326,32 +330,38 @@
         {
           "type": "boolean",
           "name": "revokedDevice",
-          "jsonkey": "revoked_device"
+          "jsonkey": "revoked_device",
+          "optional": true
         },
         {
           "type": "boolean",
           "name": "offline",
-          "jsonkey": "offline"
+          "jsonkey": "offline",
+          "optional": true
         },
         {
           "type": "boolean",
           "name": "kbfsEncrypted",
-          "jsonkey": "kbfs_encrypted"
+          "jsonkey": "kbfs_encrypted",
+          "optional": true
         },
         {
           "type": "boolean",
           "name": "isEphemeral",
-          "jsonkey": "is_ephemeral"
+          "jsonkey": "is_ephemeral",
+          "optional": true
         },
         {
           "type": "boolean",
           "name": "isEphemeralExpired",
+          "optional": true,
           "jsonkey": "is_ephemeral_expired"
         },
         {
           "type": "gregor1.Time",
           "name": "eTime",
-          "jsonkey": "e_time"
+          "jsonkey": "e_time",
+          "optional": true
         },
         {
           "type": [
@@ -364,7 +374,8 @@
         {
           "type": "boolean",
           "name": "hasPairwiseMacs",
-          "jsonkey": "has_pairwise_macs"
+          "jsonkey": "has_pairwise_macs",
+          "optional": true
         },
         {
           "type": {
@@ -372,12 +383,14 @@
             "items": "string"
           },
           "name": "atMentionUsernames",
-          "jsonkey": "at_mention_usernames"
+          "jsonkey": "at_mention_usernames",
+          "optional": true
         },
         {
           "type": "string",
           "name": "channelMention",
-          "jsonkey": "channel_mention"
+          "jsonkey": "channel_mention",
+          "optional": true
         },
         {
           "type": {
@@ -385,7 +398,8 @@
             "items": "UIChannelNameMention"
           },
           "name": "channelNameMentions",
-          "jsonkey": "channel_name_mentions"
+          "jsonkey": "channel_name_mentions",
+          "optional": true
         }
       ]
     },
@@ -434,7 +448,8 @@
         {
           "type": "boolean",
           "name": "offline",
-          "jsonkey": "offline"
+          "jsonkey": "offline",
+          "optional": true
         },
         {
           "type": {
@@ -442,7 +457,8 @@
             "items": "keybase1.TLFIdentifyFailure"
           },
           "name": "identifyFailures",
-          "jsonkey": "identify_failures"
+          "jsonkey": "identify_failures",
+          "optional": true
         },
         {
           "type": {
@@ -450,7 +466,8 @@
             "items": "RateLimitRes"
           },
           "name": "rateLimits",
-          "jsonkey": "ratelimits"
+          "jsonkey": "ratelimits",
+          "optional": true
         }
       ]
     },
@@ -554,7 +571,8 @@
             "items": "keybase1.TLFIdentifyFailure"
           },
           "name": "identifyFailures",
-          "jsonkey": "identify_failures"
+          "jsonkey": "identify_failures",
+          "optional": true
         },
         {
           "type": [
@@ -570,7 +588,8 @@
             "items": "RateLimitRes"
           },
           "name": "rateLimits",
-          "jsonkey": "ratelimits"
+          "jsonkey": "ratelimits",
+          "optional": true
         }
       ]
     },
@@ -605,7 +624,8 @@
             "items": "keybase1.TLFIdentifyFailure"
           },
           "name": "identifyFailures",
-          "jsonkey": "identify_failures"
+          "jsonkey": "identify_failures",
+          "optional": true
         },
         {
           "type": {
@@ -613,7 +633,8 @@
             "items": "RateLimitRes"
           },
           "name": "rateLimits",
-          "jsonkey": "ratelimits"
+          "jsonkey": "ratelimits",
+          "optional": true
         }
       ]
     },
@@ -635,7 +656,8 @@
             "items": "keybase1.TLFIdentifyFailure"
           },
           "name": "identifyFailures",
-          "jsonkey": "identify_failures"
+          "jsonkey": "identify_failures",
+          "optional": true
         },
         {
           "type": {
@@ -643,7 +665,8 @@
             "items": "RateLimitRes"
           },
           "name": "rateLimits",
-          "jsonkey": "ratelimits"
+          "jsonkey": "ratelimits",
+          "optional": true
         }
       ]
     },
@@ -665,7 +688,8 @@
             "items": "keybase1.TLFIdentifyFailure"
           },
           "name": "identifyFailures",
-          "jsonkey": "identify_failures"
+          "jsonkey": "identify_failures",
+          "optional": true
         },
         {
           "type": {
@@ -673,7 +697,8 @@
             "items": "RateLimitRes"
           },
           "name": "rateLimits",
-          "jsonkey": "ratelimits"
+          "jsonkey": "ratelimits",
+          "optional": true
         }
       ]
     },
@@ -692,7 +717,8 @@
             "items": "keybase1.TLFIdentifyFailure"
           },
           "name": "identifyFailures",
-          "jsonkey": "identify_failures"
+          "jsonkey": "identify_failures",
+          "optional": true
         },
         {
           "type": {
@@ -700,7 +726,8 @@
             "items": "RateLimitRes"
           },
           "name": "rateLimits",
-          "jsonkey": "ratelimits"
+          "jsonkey": "ratelimits",
+          "optional": true
         }
       ]
     },
@@ -722,7 +749,8 @@
             "items": "RateLimitRes"
           },
           "name": "rateLimits",
-          "jsonkey": "ratelimits"
+          "jsonkey": "ratelimits",
+          "optional": true
         }
       ]
     },
@@ -736,7 +764,8 @@
             "items": "RateLimitRes"
           },
           "name": "rateLimits",
-          "jsonkey": "ratelimits"
+          "jsonkey": "ratelimits",
+          "optional": true
         }
       ]
     },


### PR DESCRIPTION
After #18623 was merged, new fields like `is_ephemeral` and `identify_failures` on returned objects appeared with values of `null`. This is because the go avdl compiler didn't put the `omitempty` json struct tag on fields that previously had it. This PR fixes that by introducing a new decorator, `@optional(true)` which will result in an `omitempty` on that field. 

Corresponding node-avdl-compiler PR: keybase/node-avdl-compiler#28