### PR TITLE
misc teambot fixes

### DIFF
--- a/go/chat/errors.go
+++ b/go/chat/errors.go
@@ -296,6 +296,22 @@ func (e BoxingError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
 
 //=============================================================================
 
+type RestrictedBotChannelError struct{}
+
+func NewRestrictedBotChannelError() RestrictedBotChannelError {
+	return RestrictedBotChannelError{}
+}
+
+func (e RestrictedBotChannelError) Error() string {
+	return "bot restricted from sending to this channel"
+}
+
+func (e RestrictedBotChannelError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
+	return chat1.OutboxErrorType_RESTRICTEDBOT, true
+}
+
+//=============================================================================
+
 type BoxingCryptKeysError struct {
 	Err error
 }

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -894,7 +894,7 @@ func (s *BlockingSender) applyTeamBotSettings(ctx context.Context, uid gregor1.U
 		// If the bot is the sender encrypt only for them.
 		if msg.ClientHeader.Sender.Eq(botUID) {
 			if !isMatch {
-				return nil, fmt.Errorf("Unable to send, bot restricted from this channel")
+				return nil, NewRestrictedBotChannelError()
 			}
 			return []gregor1.UID{botUID}, nil
 		}
@@ -1149,7 +1149,8 @@ type DelivererInfoError interface {
 	IsImmediateFail() (chat1.OutboxErrorType, bool)
 }
 
-// delivererExpireError is used when a message fails because it has languished in the outbox for too long.
+// delivererExpireError is used when a message fails because it has languished
+// in the outbox for too long.
 type delivererExpireError struct{}
 
 func (e delivererExpireError) Error() string {

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -856,9 +856,6 @@ func (s *BlockingSender) applyTeamBotSettings(ctx context.Context, uid gregor1.U
 		return []gregor1.UID{*botUID}, nil
 	}
 
-	// TODO HOTPOT-117 short circuit check if no RESTRICTEDBOT members are in
-	// the conv.
-
 	// Fetch the bot settings, if any
 	teamID, err := keybase1.TeamIDFromString(conv.Info.Triple.Tlfid.String())
 	if err != nil {

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -6935,8 +6935,16 @@ func TestTeamBotSettings(t *testing.T) {
 			listener := newServerChatListener()
 			ctc.as(t, users[0]).h.G().NotifyRouter.AddListener(listener)
 			ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
+
 			botua := users[1]
 			botua2 := users[2]
+
+			botuaListener := newServerChatListener()
+			ctc.as(t, botua).h.G().NotifyRouter.AddListener(botuaListener)
+			ctc.world.Tcs[botua.Username].ChatG.Syncer.(*Syncer).isConnected = true
+			botuaListener2 := newServerChatListener()
+			ctc.as(t, botua2).h.G().NotifyRouter.AddListener(botuaListener2)
+			ctc.world.Tcs[botua2.Username].ChatG.Syncer.(*Syncer).isConnected = true
 			ctx := context.TODO()
 
 			var err error
@@ -6958,33 +6966,37 @@ func TestTeamBotSettings(t *testing.T) {
 				keybase1.TeamRole_RESTRICTEDBOT, &botSettings)
 			require.NoError(t, err)
 
-			// TODO remove
-			_, err = teams.AddMember(ctx, tc.m.G(), team.Name().String(), botua2.Username,
-				keybase1.TeamRole_BOT, nil)
-			require.NoError(t, err)
-
 			botSettings2 := keybase1.TeamBotSettings{
 				Mentions: true,
 			}
-			err = teams.EditMember(ctx, tc.m.G(), team.Name().String(), botua2.Username,
+			_, err = teams.AddMember(ctx, tc.m.G(), team.Name().String(), botua2.Username,
 				keybase1.TeamRole_RESTRICTEDBOT, &botSettings2)
 			require.NoError(t, err)
 
 			var unboxed chat1.UIMessage
-			consumeBotMessage := func(botUID *gregor1.UID, msgTyp chat1.MessageType) {
+			consumeBotMessage := func(botUID *gregor1.UID, msgTyp chat1.MessageType, l *serverChatListener) {
 				select {
-				case info := <-listener.newMessageRemote:
+				case info := <-l.newMessageRemote:
 					unboxed = info.Message
 					require.True(t, unboxed.IsValid(), "invalid message")
+					require.Equal(t, msgTyp, unboxed.GetMessageType(), "invalid type")
 					if botUID == nil {
 						require.Nil(t, unboxed.Valid().BotUID)
 					} else {
 						require.NotNil(t, unboxed.Valid().BotUID)
 						require.EqualValues(t, *botUID, *unboxed.Valid().BotUID)
 					}
-					require.Equal(t, msgTyp, unboxed.GetMessageType(), "invalid type")
 				case <-time.After(20 * time.Second):
 					require.Fail(t, "no event received")
+				}
+			}
+
+			assertNoMessage := func(l *serverChatListener) {
+				select {
+				case info := <-l.newMessageRemote:
+					unboxed = info.Message
+					require.Fail(t, "unexpected message received type %v", unboxed.GetMessageType())
+				default:
 				}
 			}
 
@@ -6999,7 +7011,9 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(tc.startCtx, arg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(&botuaUID, chat1.MessageType_TEXT)
+			consumeBotMessage(&botuaUID, chat1.MessageType_TEXT, listener)
+			consumeBotMessage(&botuaUID, chat1.MessageType_TEXT, botuaListener)
+			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_TEXT)
 
 			t.Logf("send ephemeral message")
@@ -7007,7 +7021,9 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(tc.startCtx, arg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(&botuaUID, chat1.MessageType_TEXT)
+			consumeBotMessage(&botuaUID, chat1.MessageType_TEXT, listener)
+			consumeBotMessage(&botuaUID, chat1.MessageType_TEXT, botuaListener)
+			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_TEXT)
 
 			textUnboxed := unboxed
@@ -7026,7 +7042,9 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostReactionNonblock(tc.startCtx, rarg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(&botuaUID, chat1.MessageType_REACTION)
+			consumeBotMessage(&botuaUID, chat1.MessageType_REACTION, listener)
+			consumeBotMessage(&botuaUID, chat1.MessageType_REACTION, botuaListener)
+			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_REACTION)
 
 			t.Logf("edit the message")
@@ -7045,7 +7063,9 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostEditNonblock(tc.startCtx, earg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(&botuaUID, chat1.MessageType_EDIT)
+			consumeBotMessage(&botuaUID, chat1.MessageType_EDIT, listener)
+			consumeBotMessage(&botuaUID, chat1.MessageType_EDIT, botuaListener)
+			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_EDIT)
 
 			// Repost a reaction and ensure it is deleted
@@ -7053,7 +7073,9 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostReactionNonblock(tc.startCtx, rarg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(&botuaUID, chat1.MessageType_DELETE)
+			consumeBotMessage(&botuaUID, chat1.MessageType_DELETE, listener)
+			consumeBotMessage(&botuaUID, chat1.MessageType_DELETE, botuaListener)
+			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_DELETE)
 
 			t.Logf("delete the message")
@@ -7067,7 +7089,9 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostDeleteNonblock(tc.startCtx, darg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(&botuaUID, chat1.MessageType_DELETE)
+			consumeBotMessage(&botuaUID, chat1.MessageType_DELETE, listener)
+			consumeBotMessage(&botuaUID, chat1.MessageType_DELETE, botuaListener)
+			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_DELETE)
 
 			t.Logf("post headline")
@@ -7082,7 +7106,9 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostHeadlineNonblock(tc.startCtx, harg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(nil, chat1.MessageType_HEADLINE)
+			consumeBotMessage(nil, chat1.MessageType_HEADLINE, listener)
+			assertNoMessage(botuaListener)
+			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_HEADLINE)
 
 			team, err = teams.Load(ctx, tc.m.G(), keybase1.LoadTeamArg{
@@ -7102,7 +7128,7 @@ func TestTeamBotSettings(t *testing.T) {
 				select {
 				case teamChange := <-listener.teamChangedByID:
 					if teamChange.TeamID == team.ID &&
-						teamChange.LatestSeqno == 7 &&
+						teamChange.LatestSeqno == 6 &&
 						teamChange.Changes.Misc &&
 						teamChange.ImplicitTeam == (mt != chat1.ConversationMembersType_TEAM) {
 						found = true
@@ -7122,7 +7148,9 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(tc.startCtx, arg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(&botuaUID2, chat1.MessageType_TEXT)
+			consumeBotMessage(&botuaUID2, chat1.MessageType_TEXT, listener)
+			consumeBotMessage(&botuaUID2, chat1.MessageType_TEXT, botuaListener2)
+			assertNoMessage(botuaListener)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_TEXT)
 
 			// send as a bot
@@ -7142,7 +7170,9 @@ func TestTeamBotSettings(t *testing.T) {
 
 			_, err = ctc.as(t, botua2).chatLocalHandler().PostLocal(ctc.as(t, botua2).startCtx, larg)
 			require.NoError(t, err)
-			consumeBotMessage(&botuaUID2, chat1.MessageType_TEXT)
+			consumeBotMessage(&botuaUID2, chat1.MessageType_TEXT, listener)
+			consumeBotMessage(&botuaUID2, chat1.MessageType_TEXT, botuaListener2)
+			assertNoMessage(botuaListener)
 
 			// ensure gregor withholds messages for restricted bot members
 			// unless it is specifically keyed for them.
@@ -7198,12 +7228,16 @@ func TestTeamBotSettings(t *testing.T) {
 			_, err = ctc.as(t, users[0]).chatLocalHandler().PostTextNonblock(tc.startCtx, arg)
 			require.NoError(t, err)
 			consumeNewPendingMsg(t, listener)
-			consumeBotMessage(nil, chat1.MessageType_TEXT)
+			consumeBotMessage(nil, chat1.MessageType_TEXT, listener)
+			consumeBotMessage(nil, chat1.MessageType_TEXT, botuaListener2)
+			assertNoMessage(botuaListener)
 
 			// botua2 can send without issue
 			_, err = ctc.as(t, botua2).chatLocalHandler().PostLocal(ctc.as(t, botua2).startCtx, larg)
 			require.NoError(t, err)
-			consumeBotMessage(nil, chat1.MessageType_TEXT)
+			consumeBotMessage(nil, chat1.MessageType_TEXT, listener)
+			consumeBotMessage(nil, chat1.MessageType_TEXT, botuaListener2)
+			assertNoMessage(botuaListener)
 		})
 	})
 }

--- a/go/client/chat_cli_flag_utils.go
+++ b/go/client/chat_cli_flag_utils.go
@@ -285,7 +285,7 @@ func makeChatCLIInboxFetcherActivitySorted(ctx *cli.Context) (fetcher chatCLIInb
 		fetcher.query.Status = utils.VisibleChatConversationStatuses()
 	}
 
-	return fetcher, err
+	return fetcher, nil
 }
 
 func makeChatCLIInboxFetcherUnreadFirst(ctx *cli.Context) (fetcher chatCLIInboxFetcher, err error) {

--- a/go/client/chat_resolver.go
+++ b/go/client/chat_resolver.go
@@ -180,6 +180,13 @@ func (r *chatConversationResolver) create(ctx context.Context, req chatConversat
 	return &ncres.Conv, nil
 }
 
+func formatConversationName(req chatConversationResolvingRequest) string {
+	if req.TopicName != "" {
+		return fmt.Sprintf("%s#%s", req.TlfName, req.TopicName)
+	}
+	return req.TlfName
+}
+
 func (r *chatConversationResolver) Resolve(ctx context.Context, req chatConversationResolvingRequest, behavior chatConversationResolvingBehavior) (
 	conversation *chat1.ConversationLocal, userChosen bool, err error) {
 	conversations, err := r.resolveWithService(ctx, req, behavior.IdentifyBehavior)
@@ -200,7 +207,8 @@ func (r *chatConversationResolver) Resolve(ctx context.Context, req chatConversa
 			}
 			return conversation, false, nil
 		}
-		return nil, false, errors.New("no conversation found")
+		convName := formatConversationName(req)
+		return nil, false, fmt.Errorf("no conversation found %s", convName)
 	case 1:
 		conversation := conversations[0]
 		info := conversation.Info

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -521,6 +521,10 @@ func (c *chatServiceHandler) formatMessages(ctx context.Context, messages []chat
 			ChannelMention:      strings.ToLower(mv.ChannelMention.String()),
 			ChannelNameMentions: utils.PresentChannelNameMentions(ctx, mv.ChannelNameMentions),
 		}
+		if mv.ClientHeader.BotUID != nil {
+			botUID := mv.ClientHeader.BotUID.String()
+			msg.BotUID = &botUID
+		}
 		if mv.Reactions.Reactions != nil {
 			msg.Reactions = &mv.Reactions
 		}

--- a/go/client/cmd_chat_add_bot_member.go
+++ b/go/client/cmd_chat_add_bot_member.go
@@ -1,0 +1,158 @@
+package client
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	isatty "github.com/mattn/go-isatty"
+	context "golang.org/x/net/context"
+)
+
+type CmdChatAddBotMember struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	username         string
+	role             keybase1.TeamRole
+	botSettings      *keybase1.TeamBotSettings
+	hasTTY           bool
+}
+
+func NewCmdChatAddBotMemberRunner(g *libkb.GlobalContext) *CmdChatAddBotMember {
+	return &CmdChatAddBotMember{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatAddBotMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := append(getConversationResolverFlags(), botSettingsFlags...)
+	flags = append(flags, cli.StringFlag{
+		Name:  "u, user",
+		Usage: "username",
+	}, cli.StringFlag{
+		Name:  "r, role",
+		Usage: "team role (bot, restricted)",
+	})
+	return cli.Command{
+		Name:         "add-bot-member",
+		Usage:        "Add a bot or a restricted bot to a conversation",
+		ArgumentHelp: "[conversation]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatAddBotMemberRunner(g), "add-bot-member", c)
+			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
+		},
+		Flags: flags,
+	}
+}
+
+func resolveConversationForBotMember(g *libkb.GlobalContext, resolvingRequest chatConversationResolvingRequest,
+	hasTTY bool) (resolver *chatConversationResolver, res chat1.ConversationInfoLocal, err error) {
+	ui := NewChatCLIUI(g)
+	protocols := []rpc.Protocol{
+		chat1.ChatUiProtocol(ui),
+	}
+	if err := RegisterProtocolsWithContext(protocols, g); err != nil {
+		return nil, res, err
+	}
+	// if no tlfname specified, request one
+	if resolvingRequest.TlfName == "" {
+		resolvingRequest.TlfName, err = g.UI.GetTerminalUI().Prompt(PromptDescriptorEnterChatTLFName,
+			"Specify a team name, a single receiving user, or a comma-separated list of users (e.g. alice,bob,charlie) to continue: ")
+		if err != nil {
+			return nil, res, err
+		}
+		if resolvingRequest.TlfName == "" {
+			return nil, res, fmt.Errorf("no user or team name specified")
+		}
+	}
+
+	if err = annotateResolvingRequest(g, &resolvingRequest); err != nil {
+		return nil, res, err
+	}
+
+	resolver, err = newChatConversationResolver(g)
+	if err != nil {
+		return nil, res, err
+	}
+	conversation, _, err := resolver.Resolve(context.TODO(), resolvingRequest, chatConversationResolvingBehavior{
+		CreateIfNotExists: false,
+		MustNotExist:      false,
+		Interactive:       hasTTY,
+		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	})
+	switch err.(type) {
+	case nil:
+	case libkb.ResolutionError:
+		return nil, res, fmt.Errorf("could not resolve `%s` into Keybase user(s) or a team", resolvingRequest.TlfName)
+	default:
+		return nil, res, err
+	}
+	conversationInfo := conversation.Info
+
+	if conversationInfo.MembersType == chat1.ConversationMembersType_KBFS {
+		return nil, res, fmt.Errorf("Cannot have bot members in a KBFS type chat.")
+	}
+	return resolver, conversationInfo, nil
+}
+
+func (c *CmdChatAddBotMember) Run() (err error) {
+	resolver, conversationInfo, err := resolveConversationForBotMember(c.G(), c.resolvingRequest, c.hasTTY)
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateBotSettingsConvs(c.G(), conversationInfo.TlfName, conversationInfo.MembersType, c.botSettings); err != nil {
+		return err
+	}
+
+	if err = resolver.ChatClient.AddBotMember(context.TODO(), chat1.AddBotMemberArg{
+		TlfName:     conversationInfo.TlfName,
+		Username:    c.username,
+		Role:        c.role,
+		BotSettings: c.botSettings,
+		MembersType: conversationInfo.MembersType,
+		TlfPublic:   conversationInfo.Visibility == keybase1.TLFVisibility_PUBLIC,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdChatAddBotMember) ParseArgv(ctx *cli.Context) (err error) {
+	c.role, err = ParseRole(ctx)
+	if err != nil {
+		return err
+	}
+	c.username, err = ParseUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	if c.role.IsRestrictedBot() {
+		c.botSettings = ParseBotSettings(ctx)
+	}
+	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())
+
+	var tlfName string
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) >= 1 {
+		tlfName = ctx.Args().Get(0)
+	}
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdChatAddBotMember) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_chat_bot_member_settings.go
+++ b/go/client/cmd_chat_bot_member_settings.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"os"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	isatty "github.com/mattn/go-isatty"
+	context "golang.org/x/net/context"
+)
+
+type CmdChatBotMemberSettings struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	username         string
+	botSettings      *keybase1.TeamBotSettings
+	hasTTY           bool
+}
+
+func NewCmdChatBotMemberSettingsRunner(g *libkb.GlobalContext) *CmdChatBotMemberSettings {
+	return &CmdChatBotMemberSettings{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatBotMemberSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := append(getConversationResolverFlags(), botSettingsFlags...)
+	flags = append(flags, cli.StringFlag{
+		Name:  "u, user",
+		Usage: "username",
+	})
+	return cli.Command{
+		Name:         "bot-member-settings",
+		Usage:        "View or modify a restricted bot's isolation settings",
+		ArgumentHelp: "[conversation]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatBotMemberSettingsRunner(g), "bot-member-settings", c)
+			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
+		},
+		Flags: flags,
+	}
+}
+
+func (c *CmdChatBotMemberSettings) Run() (err error) {
+	resolver, conversationInfo, err := resolveConversationForBotMember(c.G(), c.resolvingRequest, c.hasTTY)
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateBotSettingsConvs(c.G(), conversationInfo.TlfName,
+		conversationInfo.MembersType, c.botSettings); err != nil {
+		return err
+	}
+
+	var botSettings keybase1.TeamBotSettings
+	if c.botSettings == nil {
+		botSettings, err = resolver.ChatClient.GetBotMemberSettings(context.TODO(), chat1.GetBotMemberSettingsArg{
+			TlfName:     conversationInfo.TlfName,
+			Username:    c.username,
+			MembersType: conversationInfo.MembersType,
+			TlfPublic:   conversationInfo.Visibility == keybase1.TLFVisibility_PUBLIC,
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		botSettings = *c.botSettings
+		if err = resolver.ChatClient.SetBotMemberSettings(context.TODO(), chat1.SetBotMemberSettingsArg{
+			TlfName:     conversationInfo.TlfName,
+			Username:    c.username,
+			BotSettings: botSettings,
+			MembersType: conversationInfo.MembersType,
+			TlfPublic:   conversationInfo.Visibility == keybase1.TLFVisibility_PUBLIC,
+		}); err != nil {
+			return err
+		}
+	}
+	if err := renderBotSettings(c.G(), c.username, botSettings); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CmdChatBotMemberSettings) ParseArgv(ctx *cli.Context) (err error) {
+	c.username, err = ParseUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.botSettings = ParseBotSettings(ctx)
+	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())
+
+	var tlfName string
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) >= 1 {
+		tlfName = ctx.Args().Get(0)
+	}
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdChatBotMemberSettings) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_chat_edit_bot_member.go
+++ b/go/client/cmd_chat_edit_bot_member.go
@@ -1,0 +1,106 @@
+package client
+
+import (
+	"os"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	isatty "github.com/mattn/go-isatty"
+	context "golang.org/x/net/context"
+)
+
+type CmdChatEditBotMember struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	username         string
+	role             keybase1.TeamRole
+	botSettings      *keybase1.TeamBotSettings
+	hasTTY           bool
+}
+
+func NewCmdChatEditBotMemberRunner(g *libkb.GlobalContext) *CmdChatEditBotMember {
+	return &CmdChatEditBotMember{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatEditBotMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := append(getConversationResolverFlags(), botSettingsFlags...)
+	flags = append(flags, cli.StringFlag{
+		Name:  "u, user",
+		Usage: "username",
+	}, cli.StringFlag{
+		Name:  "r, role",
+		Usage: "team role (bot, restricted)",
+	})
+	return cli.Command{
+		Name:         "edit-bot-member",
+		Usage:        "Edit the role bot or a restricted bot in a conversation",
+		ArgumentHelp: "[conversation]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatEditBotMemberRunner(g), "edit-bot-member", c)
+			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
+		},
+		Flags: flags,
+	}
+}
+
+func (c *CmdChatEditBotMember) Run() (err error) {
+	resolver, conversationInfo, err := resolveConversationForBotMember(c.G(), c.resolvingRequest, c.hasTTY)
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateBotSettingsConvs(c.G(), conversationInfo.TlfName, conversationInfo.MembersType, c.botSettings); err != nil {
+		return err
+	}
+
+	if err = resolver.ChatClient.EditBotMember(context.TODO(), chat1.EditBotMemberArg{
+		TlfName:     conversationInfo.TlfName,
+		Username:    c.username,
+		Role:        c.role,
+		BotSettings: c.botSettings,
+		MembersType: conversationInfo.MembersType,
+		TlfPublic:   conversationInfo.Visibility == keybase1.TLFVisibility_PUBLIC,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdChatEditBotMember) ParseArgv(ctx *cli.Context) (err error) {
+	c.role, err = ParseRole(ctx)
+	if err != nil {
+		return err
+	}
+	c.username, err = ParseUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	if c.role.IsRestrictedBot() {
+		c.botSettings = ParseBotSettings(ctx)
+	}
+	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())
+
+	var tlfName string
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) >= 1 {
+		tlfName = ctx.Args().Get(0)
+	}
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdChatEditBotMember) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_chat_list.go
+++ b/go/client/cmd_chat_list.go
@@ -37,7 +37,8 @@ func (c *cmdChatList) Run() error {
 	if err != nil {
 		return err
 	}
-	if err = conversationListView(conversations).show(c.G(), string(c.G().Env.GetUsername()), c.showDeviceName); err != nil {
+	if err = conversationListView(conversations).show(c.G(), c.G().Env.GetUsername().String(),
+		c.showDeviceName); err != nil {
 		return err
 	}
 

--- a/go/client/cmd_chat_min_writer_role.go
+++ b/go/client/cmd_chat_min_writer_role.go
@@ -49,7 +49,8 @@ Disable a previously set policy
 		},
 		Flags: append(getConversationResolverFlags(), []cli.Flag{
 			cli.StringFlag{
-				Name:  "r, role",
+				Name: "r, role",
+				// TODO HOTPOT-599 add bot (but not restricted bot) role
 				Usage: "team role (owner, admin, writer, reader, none)",
 			},
 		}...),

--- a/go/client/cmd_chat_remove_bot_member.go
+++ b/go/client/cmd_chat_remove_bot_member.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"os"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	isatty "github.com/mattn/go-isatty"
+	context "golang.org/x/net/context"
+)
+
+type CmdChatRemoveBotMember struct {
+	libkb.Contextified
+	resolvingRequest chatConversationResolvingRequest
+	username         string
+	hasTTY           bool
+}
+
+func NewCmdChatRemoveBotMemberRunner(g *libkb.GlobalContext) *CmdChatRemoveBotMember {
+	return &CmdChatRemoveBotMember{
+		Contextified: libkb.NewContextified(g),
+	}
+}
+
+func newCmdChatRemoveBotMember(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := append(getConversationResolverFlags(), botSettingsFlags...)
+	flags = append(flags, cli.StringFlag{
+		Name:  "u, user",
+		Usage: "username",
+	}, cli.StringFlag{
+		Name:  "r, role",
+		Usage: "team role (bot, restricted)",
+	})
+	return cli.Command{
+		Name:         "remove-bot-member",
+		Usage:        "Remove a bot or a restricted bot from a conversation",
+		ArgumentHelp: "[conversation]",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdChatRemoveBotMemberRunner(g), "remove-bot-member", c)
+			cl.SetNoStandalone()
+			cl.SetLogForward(libcmdline.LogForwardNone)
+		},
+		Flags: flags,
+	}
+}
+
+func (c *CmdChatRemoveBotMember) Run() (err error) {
+	resolver, conversationInfo, err := resolveConversationForBotMember(c.G(), c.resolvingRequest, c.hasTTY)
+	if err != nil {
+		return err
+	}
+
+	if err = resolver.ChatClient.RemoveBotMember(context.TODO(), chat1.RemoveBotMemberArg{
+		TlfName:     conversationInfo.TlfName,
+		Username:    c.username,
+		MembersType: conversationInfo.MembersType,
+		TlfPublic:   conversationInfo.Visibility == keybase1.TLFVisibility_PUBLIC,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdChatRemoveBotMember) ParseArgv(ctx *cli.Context) (err error) {
+	c.username, err = ParseUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())
+
+	var tlfName string
+	// Get the TLF name from the first position arg
+	if len(ctx.Args()) >= 1 {
+		tlfName = ctx.Args().Get(0)
+	}
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CmdChatRemoveBotMember) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/cmd_team.go
+++ b/go/client/cmd_team.go
@@ -10,29 +10,31 @@ import (
 )
 
 func NewCmdTeam(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	subcommands := []cli.Command{
+		newCmdTeamCreate(cl, g),
+		newCmdTeamAddMember(cl, g),
+		newCmdTeamAddMembersBulk(cl, g),
+		newCmdTeamRemoveMember(cl, g),
+		newCmdTeamEditMember(cl, g),
+		newCmdTeamListMemberships(cl, g),
+		newCmdTeamShowTree(cl, g),
+		newCmdTeamRename(cl, g),
+		newCmdTeamRequestAccess(cl, g),
+		newCmdTeamListRequests(cl, g),
+		newCmdTeamIgnoreRequest(cl, g),
+		newCmdTeamAcceptInvite(cl, g),
+		newCmdTeamLeave(cl, g),
+		newCmdTeamDelete(cl, g),
+		newCmdTeamAPI(cl, g),
+		newCmdTeamSettings(cl, g),
+		newCmdTeamProfileLoad(cl, g),
+		newCmdTeamFTL(cl, g),
+	}
+	subcommands = append(subcommands, getBuildSpecificTeamCommands(cl, g)...)
 	return cli.Command{
 		Name:         "team",
 		Usage:        "Manage teams",
 		ArgumentHelp: "[arguments...]",
-		Subcommands: []cli.Command{
-			newCmdTeamCreate(cl, g),
-			newCmdTeamAddMember(cl, g),
-			newCmdTeamAddMembersBulk(cl, g),
-			newCmdTeamRemoveMember(cl, g),
-			newCmdTeamEditMember(cl, g),
-			newCmdTeamListMemberships(cl, g),
-			newCmdTeamShowTree(cl, g),
-			newCmdTeamRename(cl, g),
-			newCmdTeamRequestAccess(cl, g),
-			newCmdTeamListRequests(cl, g),
-			newCmdTeamIgnoreRequest(cl, g),
-			newCmdTeamAcceptInvite(cl, g),
-			newCmdTeamLeave(cl, g),
-			newCmdTeamDelete(cl, g),
-			newCmdTeamAPI(cl, g),
-			newCmdTeamSettings(cl, g),
-			newCmdTeamProfileLoad(cl, g),
-			newCmdTeamFTL(cl, g),
-		},
+		Subcommands:  subcommands,
 	}
 }

--- a/go/client/cmd_team_bot_settings.go
+++ b/go/client/cmd_team_bot_settings.go
@@ -141,6 +141,9 @@ func getConvNames(g *libkb.GlobalContext, botSettings keybase1.TeamBotSettings) 
 		if err != nil {
 			return nil, err
 		}
+		if convID.IsNil() {
+			continue
+		}
 		fetcher.query.ConvIDs = append(fetcher.query.ConvIDs, convID)
 	}
 	conversations, err := fetcher.fetch(context.TODO(), g)
@@ -169,9 +172,9 @@ EXAMPLES:
 
 View current bot settings:
 
-    keybase team bot-settings acme alice
+    keybase team bot-settings acme -u alice
 
 Specify new bot settings:
 
-    keybase team bot-settings acme alice --allow-mentions --triggers foo --triggers bar --allowed-convs #general
+    keybase team bot-settings acme -u alice --allow-mentions --triggers foo --triggers bar --allowed-convs #general
 `

--- a/go/client/cmd_team_bot_settings.go
+++ b/go/client/cmd_team_bot_settings.go
@@ -1,0 +1,177 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+)
+
+type CmdTeamBotSettings struct {
+	libkb.Contextified
+	Team        string
+	Username    string
+	BotSettings *keybase1.TeamBotSettings
+}
+
+func newCmdTeamBotSettings(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := botSettingsFlags
+	return cli.Command{
+		Name:         "bot-settings",
+		ArgumentHelp: "<team name>",
+		Usage:        "Modify the bot settings of the given user. User must be a member of the given team with role restrictedbot",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(NewCmdTeamBotSettingsRunner(g), "bot-settings", c)
+		},
+		Flags: append(flags,
+			cli.StringFlag{
+				Name:  "u, user",
+				Usage: "username",
+			}),
+		Description: teamBotSettingsDoc,
+	}
+}
+
+func NewCmdTeamBotSettingsRunner(g *libkb.GlobalContext) *CmdTeamBotSettings {
+	return &CmdTeamBotSettings{Contextified: libkb.NewContextified(g)}
+}
+
+func (c *CmdTeamBotSettings) ParseArgv(ctx *cli.Context) error {
+	var err error
+	c.Team, err = ParseOneTeamName(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.Username, err = ParseUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.BotSettings = ParseBotSettings(ctx)
+	return nil
+}
+
+func (c *CmdTeamBotSettings) Run() error {
+	cli, err := GetTeamsClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateBotSettingsConvs(c.G(), c.Team,
+		chat1.ConversationMembersType_TEAM, c.BotSettings); err != nil {
+		return err
+	}
+
+	var botSettings keybase1.TeamBotSettings
+	if c.BotSettings == nil {
+		arg := keybase1.TeamGetBotSettingsArg{
+			Name:     c.Team,
+			Username: c.Username,
+		}
+		botSettings, err = cli.TeamGetBotSettings(context.Background(), arg)
+		if err != nil {
+			return err
+		}
+	} else {
+		botSettings = *c.BotSettings
+		arg := keybase1.TeamSetBotSettingsArg{
+			Name:        c.Team,
+			Username:    c.Username,
+			BotSettings: botSettings,
+		}
+		if err := cli.TeamSetBotSettings(context.Background(), arg); err != nil {
+			return err
+		}
+	}
+	if err := renderBotSettings(c.G(), c.Username, botSettings); err != nil {
+		return err
+	}
+	return nil
+}
+
+func renderBotSettings(g *libkb.GlobalContext, username string, botSettings keybase1.TeamBotSettings) error {
+	var output string
+	if botSettings.Cmds {
+		// TODO HOTPOT-661 call bot advertise list for public commands, build output
+		output += "\t- command messages\n"
+	}
+
+	if botSettings.Mentions {
+		output += "\t- when @-mentioned\n"
+	}
+
+	if len(botSettings.Triggers) > 0 {
+		output += "\t- messages that match the following:\n\t\t"
+		for _, trigger := range botSettings.Triggers {
+			output += fmt.Sprintf("%q\n\t\t", trigger)
+		}
+		output += "\n"
+	}
+
+	dui := g.UI.GetDumbOutputUI()
+	if len(output) == 0 {
+		dui.Printf("%s will not receive any messages with the current bot settings\n", username)
+	} else {
+		dui.Printf("%s will receive messages in the follow cases:\n%s", username, output)
+	}
+	if len(botSettings.Convs) == 0 {
+		dui.Printf("%s can send/receive into all conversations", username)
+	} else {
+		dui.Printf("%s can send/receive into the following conversations:\n\t", username)
+		convNames, err := getConvNames(g, botSettings)
+		if err != nil {
+			return err
+		}
+		dui.Printf(strings.Join(convNames, "\n\t"))
+	}
+	dui.Printf("\n")
+	return nil
+}
+
+func getConvNames(g *libkb.GlobalContext, botSettings keybase1.TeamBotSettings) (convNames []string, err error) {
+	fetcher := chatCLIInboxFetcher{}
+	for _, convIDStr := range botSettings.Convs {
+		convID, err := chat1.MakeConvID(convIDStr)
+		if err != nil {
+			return nil, err
+		}
+		fetcher.query.ConvIDs = append(fetcher.query.ConvIDs, convID)
+	}
+	conversations, err := fetcher.fetch(context.TODO(), g)
+	if err != nil {
+		return nil, err
+	}
+	v := conversationListView(conversations)
+	for _, conv := range v {
+		convNames = append(convNames, v.convName(g, conv, g.Env.GetUsername().String()))
+	}
+
+	return convNames, nil
+}
+
+func (c *CmdTeamBotSettings) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}
+
+const teamBotSettingsDoc = `"keybase team bot-settings" allows you to view and modify the bot settings for restrictedbot team members.
+
+EXAMPLES:
+
+View current bot settings:
+
+    keybase team bot-settings acme alice
+
+Specify new bot settings:
+
+    keybase team bot-settings acme alice --allow-mentions --triggers foo --triggers bar --allowed-convs #general
+`

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -41,6 +41,17 @@ func getBuildSpecificChatCommands(cl *libcmdline.CommandLine, g *libkb.GlobalCon
 		newCmdChatSetRetentionDev(cl, g),
 		newCmdChatKBFSUpgrade(cl, g),
 		newCmdChatProfileSearchDev(cl, g),
+		newCmdChatAddBotMember(cl, g),
+		newCmdChatRemoveBotMember(cl, g),
+		newCmdChatEditBotMember(cl, g),
+		newCmdChatBotMemberSettings(cl, g),
+	}
+}
+
+func getBuildSpecificTeamCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
+	return []cli.Command{
+		// TODO HOTPOT-599 move to production
+		newCmdTeamBotSettings(cl, g),
 	}
 }
 

--- a/go/client/commands_production.go
+++ b/go/client/commands_production.go
@@ -21,6 +21,10 @@ func getBuildSpecificChatCommands(cl *libcmdline.CommandLine, g *libkb.GlobalCon
 	return []cli.Command{}
 }
 
+func getBuildSpecificTeamCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
+	return []cli.Command{}
+}
+
 func getBuildSpecificAccountCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Command {
 	return []cli.Command{}
 }

--- a/go/protocol/chat1/api.go
+++ b/go/protocol/chat1/api.go
@@ -245,6 +245,7 @@ type MsgSummary struct {
 	AtMentionUsernames  []string                 `codec:"atMentionUsernames,omitempty" json:"at_mention_usernames,omitempty"`
 	ChannelMention      string                   `codec:"channelMention,omitempty" json:"channel_mention,omitempty"`
 	ChannelNameMentions []UIChannelNameMention   `codec:"channelNameMentions,omitempty" json:"channel_name_mentions,omitempty"`
+	BotUID              *string                  `codec:"botUID,omitempty" json:"bot_uid,omitempty"`
 }
 
 func (o MsgSummary) DeepCopy() MsgSummary {
@@ -305,6 +306,13 @@ func (o MsgSummary) DeepCopy() MsgSummary {
 			}
 			return ret
 		})(o.ChannelNameMentions),
+		BotUID: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.BotUID),
 	}
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1659,6 +1659,7 @@ const (
 	OutboxErrorType_TOOMANYATTEMPTS OutboxErrorType = 6
 	OutboxErrorType_ALREADY_DELETED OutboxErrorType = 7
 	OutboxErrorType_UPLOADFAILED    OutboxErrorType = 8
+	OutboxErrorType_RESTRICTEDBOT   OutboxErrorType = 9
 )
 
 func (o OutboxErrorType) DeepCopy() OutboxErrorType { return o }
@@ -1673,6 +1674,7 @@ var OutboxErrorTypeMap = map[string]OutboxErrorType{
 	"TOOMANYATTEMPTS": 6,
 	"ALREADY_DELETED": 7,
 	"UPLOADFAILED":    8,
+	"RESTRICTEDBOT":   9,
 }
 
 var OutboxErrorTypeRevMap = map[OutboxErrorType]string{
@@ -1685,6 +1687,7 @@ var OutboxErrorTypeRevMap = map[OutboxErrorType]string{
 	6: "TOOMANYATTEMPTS",
 	7: "ALREADY_DELETED",
 	8: "UPLOADFAILED",
+	9: "RESTRICTEDBOT",
 }
 
 func (e OutboxErrorType) String() string {
@@ -4187,6 +4190,7 @@ type GetInboxSummaryForCLILocalQuery struct {
 	Before              string                 `codec:"before" json:"before"`
 	Visibility          keybase1.TLFVisibility `codec:"visibility" json:"visibility"`
 	Status              []ConversationStatus   `codec:"status" json:"status"`
+	ConvIDs             []ConversationID       `codec:"convIDs" json:"convIDs"`
 	UnreadFirst         bool                   `codec:"unreadFirst" json:"unreadFirst"`
 	UnreadFirstLimit    UnreadFirstNumLimit    `codec:"unreadFirstLimit" json:"unreadFirstLimit"`
 	ActivitySortedLimit int                    `codec:"activitySortedLimit" json:"activitySortedLimit"`
@@ -4209,6 +4213,17 @@ func (o GetInboxSummaryForCLILocalQuery) DeepCopy() GetInboxSummaryForCLILocalQu
 			}
 			return ret
 		})(o.Status),
+		ConvIDs: (func(x []ConversationID) []ConversationID {
+			if x == nil {
+				return nil
+			}
+			ret := make([]ConversationID, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.ConvIDs),
 		UnreadFirst:         o.UnreadFirst,
 		UnreadFirstLimit:    o.UnreadFirstLimit.DeepCopy(),
 		ActivitySortedLimit: o.ActivitySortedLimit,
@@ -6051,6 +6066,46 @@ type IgnorePinnedMessageArg struct {
 	ConvID ConversationID `codec:"convID" json:"convID"`
 }
 
+type AddBotMemberArg struct {
+	TlfName     string                    `codec:"tlfName" json:"tlfName"`
+	Username    string                    `codec:"username" json:"username"`
+	BotSettings *keybase1.TeamBotSettings `codec:"botSettings,omitempty" json:"botSettings,omitempty"`
+	Role        keybase1.TeamRole         `codec:"role" json:"role"`
+	MembersType ConversationMembersType   `codec:"membersType" json:"membersType"`
+	TlfPublic   bool                      `codec:"tlfPublic" json:"tlfPublic"`
+}
+
+type EditBotMemberArg struct {
+	TlfName     string                    `codec:"tlfName" json:"tlfName"`
+	Username    string                    `codec:"username" json:"username"`
+	BotSettings *keybase1.TeamBotSettings `codec:"botSettings,omitempty" json:"botSettings,omitempty"`
+	Role        keybase1.TeamRole         `codec:"role" json:"role"`
+	MembersType ConversationMembersType   `codec:"membersType" json:"membersType"`
+	TlfPublic   bool                      `codec:"tlfPublic" json:"tlfPublic"`
+}
+
+type RemoveBotMemberArg struct {
+	TlfName     string                  `codec:"tlfName" json:"tlfName"`
+	Username    string                  `codec:"username" json:"username"`
+	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+	TlfPublic   bool                    `codec:"tlfPublic" json:"tlfPublic"`
+}
+
+type SetBotMemberSettingsArg struct {
+	TlfName     string                   `codec:"tlfName" json:"tlfName"`
+	Username    string                   `codec:"username" json:"username"`
+	BotSettings keybase1.TeamBotSettings `codec:"botSettings" json:"botSettings"`
+	MembersType ConversationMembersType  `codec:"membersType" json:"membersType"`
+	TlfPublic   bool                     `codec:"tlfPublic" json:"tlfPublic"`
+}
+
+type GetBotMemberSettingsArg struct {
+	TlfName     string                  `codec:"tlfName" json:"tlfName"`
+	Username    string                  `codec:"username" json:"username"`
+	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+	TlfPublic   bool                    `codec:"tlfPublic" json:"tlfPublic"`
+}
+
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetCachedThread(context.Context, GetCachedThreadArg) (GetThreadLocalRes, error)
@@ -6131,6 +6186,11 @@ type LocalInterface interface {
 	PinMessage(context.Context, PinMessageArg) (PinMessageRes, error)
 	UnpinMessage(context.Context, ConversationID) (PinMessageRes, error)
 	IgnorePinnedMessage(context.Context, ConversationID) error
+	AddBotMember(context.Context, AddBotMemberArg) error
+	EditBotMember(context.Context, EditBotMemberArg) error
+	RemoveBotMember(context.Context, RemoveBotMemberArg) error
+	SetBotMemberSettings(context.Context, SetBotMemberSettingsArg) error
+	GetBotMemberSettings(context.Context, GetBotMemberSettingsArg) (keybase1.TeamBotSettings, error)
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -7282,6 +7342,81 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 					return
 				},
 			},
+			"addBotMember": {
+				MakeArg: func() interface{} {
+					var ret [1]AddBotMemberArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]AddBotMemberArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]AddBotMemberArg)(nil), args)
+						return
+					}
+					err = i.AddBotMember(ctx, typedArgs[0])
+					return
+				},
+			},
+			"editBotMember": {
+				MakeArg: func() interface{} {
+					var ret [1]EditBotMemberArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]EditBotMemberArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]EditBotMemberArg)(nil), args)
+						return
+					}
+					err = i.EditBotMember(ctx, typedArgs[0])
+					return
+				},
+			},
+			"removeBotMember": {
+				MakeArg: func() interface{} {
+					var ret [1]RemoveBotMemberArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]RemoveBotMemberArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]RemoveBotMemberArg)(nil), args)
+						return
+					}
+					err = i.RemoveBotMember(ctx, typedArgs[0])
+					return
+				},
+			},
+			"setBotMemberSettings": {
+				MakeArg: func() interface{} {
+					var ret [1]SetBotMemberSettingsArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SetBotMemberSettingsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SetBotMemberSettingsArg)(nil), args)
+						return
+					}
+					err = i.SetBotMemberSettings(ctx, typedArgs[0])
+					return
+				},
+			},
+			"getBotMemberSettings": {
+				MakeArg: func() interface{} {
+					var ret [1]GetBotMemberSettingsArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]GetBotMemberSettingsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]GetBotMemberSettingsArg)(nil), args)
+						return
+					}
+					ret, err = i.GetBotMemberSettings(ctx, typedArgs[0])
+					return
+				},
+			},
 		},
 	}
 }
@@ -7698,5 +7833,30 @@ func (c LocalClient) UnpinMessage(ctx context.Context, convID ConversationID) (r
 func (c LocalClient) IgnorePinnedMessage(ctx context.Context, convID ConversationID) (err error) {
 	__arg := IgnorePinnedMessageArg{ConvID: convID}
 	err = c.Cli.Call(ctx, "chat.1.local.ignorePinnedMessage", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) AddBotMember(ctx context.Context, __arg AddBotMemberArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.addBotMember", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) EditBotMember(ctx context.Context, __arg EditBotMemberArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.editBotMember", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) RemoveBotMember(ctx context.Context, __arg RemoveBotMemberArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.removeBotMember", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) SetBotMemberSettings(ctx context.Context, __arg SetBotMemberSettingsArg) (err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.setBotMemberSettings", []interface{}{__arg}, nil)
+	return
+}
+
+func (c LocalClient) GetBotMemberSettings(ctx context.Context, __arg GetBotMemberSettingsArg) (res keybase1.TeamBotSettings, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.getBotMemberSettings", []interface{}{__arg}, &res)
 	return
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -3371,6 +3371,19 @@ type TeamEditMemberArg struct {
 	BotSettings *TeamBotSettings `codec:"botSettings,omitempty" json:"botSettings,omitempty"`
 }
 
+type TeamGetBotSettingsArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Name      string `codec:"name" json:"name"`
+	Username  string `codec:"username" json:"username"`
+}
+
+type TeamSetBotSettingsArg struct {
+	SessionID   int             `codec:"sessionID" json:"sessionID"`
+	Name        string          `codec:"name" json:"name"`
+	Username    string          `codec:"username" json:"username"`
+	BotSettings TeamBotSettings `codec:"botSettings" json:"botSettings"`
+}
+
 type TeamRenameArg struct {
 	SessionID int      `codec:"sessionID" json:"sessionID"`
 	PrevName  TeamName `codec:"prevName" json:"prevName"`
@@ -3586,6 +3599,8 @@ type TeamsInterface interface {
 	TeamRemoveMember(context.Context, TeamRemoveMemberArg) error
 	TeamLeave(context.Context, TeamLeaveArg) error
 	TeamEditMember(context.Context, TeamEditMemberArg) error
+	TeamGetBotSettings(context.Context, TeamGetBotSettingsArg) (TeamBotSettings, error)
+	TeamSetBotSettings(context.Context, TeamSetBotSettingsArg) error
 	TeamRename(context.Context, TeamRenameArg) error
 	TeamAcceptInvite(context.Context, TeamAcceptInviteArg) error
 	TeamRequestAccess(context.Context, TeamRequestAccessArg) (TeamRequestAccessResult, error)
@@ -3881,6 +3896,36 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					err = i.TeamEditMember(ctx, typedArgs[0])
+					return
+				},
+			},
+			"teamGetBotSettings": {
+				MakeArg: func() interface{} {
+					var ret [1]TeamGetBotSettingsArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]TeamGetBotSettingsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]TeamGetBotSettingsArg)(nil), args)
+						return
+					}
+					ret, err = i.TeamGetBotSettings(ctx, typedArgs[0])
+					return
+				},
+			},
+			"teamSetBotSettings": {
+				MakeArg: func() interface{} {
+					var ret [1]TeamSetBotSettingsArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]TeamSetBotSettingsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]TeamSetBotSettingsArg)(nil), args)
+						return
+					}
+					err = i.TeamSetBotSettings(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -4509,6 +4554,16 @@ func (c TeamsClient) TeamLeave(ctx context.Context, __arg TeamLeaveArg) (err err
 
 func (c TeamsClient) TeamEditMember(ctx context.Context, __arg TeamEditMemberArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamEditMember", []interface{}{__arg}, nil)
+	return
+}
+
+func (c TeamsClient) TeamGetBotSettings(ctx context.Context, __arg TeamGetBotSettingsArg) (res TeamBotSettings, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetBotSettings", []interface{}{__arg}, &res)
+	return
+}
+
+func (c TeamsClient) TeamSetBotSettings(ctx context.Context, __arg TeamSetBotSettingsArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamSetBotSettings", []interface{}{__arg}, nil)
 	return
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -373,6 +373,26 @@ func (h *TeamsHandler) TeamEditMember(ctx context.Context, arg keybase1.TeamEdit
 	return teams.EditMember(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.Role, arg.BotSettings)
 }
 
+func (h *TeamsHandler) TeamSetBotSettings(ctx context.Context, arg keybase1.TeamSetBotSettingsArg) (err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamSetBotSettings(%s,%s,%v)", arg.Name, arg.Username, arg.BotSettings),
+		func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return err
+	}
+	return teams.SetBotSettings(ctx, h.G().ExternalG(), arg.Name, arg.Username, arg.BotSettings)
+}
+
+func (h *TeamsHandler) TeamGetBotSettings(ctx context.Context, arg keybase1.TeamGetBotSettingsArg) (res keybase1.TeamBotSettings, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamGetBotSettings(%s,%s)", arg.Name, arg.Username),
+		func() error { return err })()
+	if err := h.assertLoggedIn(ctx); err != nil {
+		return res, err
+	}
+	return teams.GetBotSettings(ctx, h.G().ExternalG(), arg.Name, arg.Username)
+}
+
 func (h *TeamsHandler) TeamLeave(ctx context.Context, arg keybase1.TeamLeaveArg) (err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamLeave(%s)", arg.Name), func() error { return err })()

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -666,6 +666,25 @@ func TestBotMember(t *testing.T) {
 	require.Len(t, members.RestrictedBots, 1)
 	require.Equal(t, restrictedBotua.User.GetUID(), members.RestrictedBots[0].Uid)
 
+	// we can change bot memberships, but cannot have a non-bot like role
+	err = EditMemberByID(context.TODO(), tcs[0].G, teamObj.ID, botua.Username, keybase1.TeamRole_RESTRICTEDBOT, &keybase1.TeamBotSettings{})
+	require.NoError(t, err)
+
+	err = EditMemberByID(context.TODO(), tcs[0].G, teamObj.ID, restrictedBotua.Username, keybase1.TeamRole_WRITER, nil)
+	require.Error(t, err)
+
+	err = EditMemberByID(context.TODO(), tcs[0].G, teamObj.ID, restrictedBotua.Username, keybase1.TeamRole_BOT, nil)
+	require.NoError(t, err)
+
+	team, err = Load(context.Background(), tcs[0].G, keybase1.LoadTeamArg{ID: teamObj.ID})
+	require.NoError(t, err)
+	members, err = team.Members()
+	require.NoError(t, err)
+	require.Len(t, members.Bots, 1)
+	require.Equal(t, restrictedBotua.User.GetUID(), members.Bots[0].Uid)
+	require.Len(t, members.RestrictedBots, 1)
+	require.Equal(t, botua.User.GetUID(), members.RestrictedBots[0].Uid)
+
 	err = RemoveMemberByID(context.TODO(), tcs[0].G, teamObj.ID, botua.Username)
 	require.NoError(t, err)
 	err = RemoveMemberByID(context.TODO(), tcs[0].G, teamObj.ID, restrictedBotua.Username)

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -821,6 +821,14 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 					}
 				}
 			}
+			if role.IsRestrictedBot() {
+				// Clear out any secrets we may have had in memory if we were a
+				// previous role that had PTK access.
+				state := teamShim().MainChain()
+				state.PerTeamKeySeedsUnverified = make(map[keybase1.PerTeamKeyGeneration]keybase1.PerTeamKeySeedItem)
+				state.ReaderKeyMasks = make(map[keybase1.TeamApplication]map[keybase1.PerTeamKeyGeneration]keybase1.MaskB64)
+				state.TlfCryptKeys = make(map[keybase1.TeamApplication][]keybase1.CryptKey)
+			}
 		}
 	}
 

--- a/go/teams/member_set.go
+++ b/go/teams/member_set.go
@@ -69,7 +69,9 @@ func newMemberSetChange(ctx context.Context, g *libkb.GlobalContext, req keybase
 	if err := set.loadMembers(ctx, g, req, true /* forcePoll*/); err != nil {
 		return nil, err
 	}
-	set.restrictedBotSettings = req.RestrictedBots
+	for uv, settings := range req.RestrictedBots {
+		set.restrictedBotSettings[uv] = settings
+	}
 	return set, nil
 }
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1575,9 +1575,9 @@ func GetKBFSTeamSettings(ctx context.Context, g *libkb.GlobalContext, isPublic b
 
 func CanUserPerform(ctx context.Context, g *libkb.GlobalContext, teamname string) (ret keybase1.TeamOperation, err error) {
 	team, err := Load(ctx, g, keybase1.LoadTeamArg{
-		Name:    teamname,
-		StaleOK: true,
-		Public:  false, // assume private team
+		Name:                      teamname,
+		StaleOK:                   true,
+		Public:                    false, // assume private team
 		AllowNameLookupBurstCache: true,
 	})
 	if err != nil {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -250,10 +250,7 @@ func (t *Team) IsMember(ctx context.Context, uv keybase1.UserVersion) bool {
 		t.G().Log.CDebugf(ctx, "error getting user role: %s", err)
 		return false
 	}
-	if role == keybase1.TeamRole_NONE {
-		return false
-	}
-	return true
+	return role != keybase1.TeamRole_NONE
 }
 
 func (t *Team) MemberCtime(ctx context.Context, uv keybase1.UserVersion) *keybase1.Time {

--- a/protocol/avdl/chat1/api.avdl
+++ b/protocol/avdl/chat1/api.avdl
@@ -160,6 +160,8 @@ protocol api {
     @jsonkey("channel_name_mentions")
     @optional(true)
     array<UIChannelNameMention> channelNameMentions;
+    @jsonkey("bot_uid")
+    union { null, string } botUID;
   }
 
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -263,7 +263,8 @@ protocol local {
     EXPIRED_5,
     TOOMANYATTEMPTS_6,
     ALREADY_DELETED_7,
-    UPLOADFAILED_8
+    UPLOADFAILED_8,
+    RESTRICTEDBOT_9
   }
 
   record OutboxStateError {
@@ -819,6 +820,7 @@ protocol local {
 
     // If left empty, default is to show all.
     array<ConversationStatus> status;
+    array<ConversationID> convIDs;
 
     boolean unreadFirst;
     UnreadFirstNumLimit unreadFirstLimit;
@@ -1180,4 +1182,10 @@ protocol local {
   PinMessageRes pinMessage(ConversationID convID, MessageID msgID);
   PinMessageRes unpinMessage(ConversationID convID);
   void ignorePinnedMessage(ConversationID convID);
+
+  void addBotMember(string tlfName, string username, union { null, keybase1.TeamBotSettings } botSettings, keybase1.TeamRole role, ConversationMembersType membersType, boolean tlfPublic);
+  void editBotMember(string tlfName, string username, union { null, keybase1.TeamBotSettings } botSettings, keybase1.TeamRole role, ConversationMembersType membersType, boolean tlfPublic);
+  void removeBotMember(string tlfName, string username, ConversationMembersType membersType, boolean tlfPublic);
+  void setBotMemberSettings(string tlfName, string username, keybase1.TeamBotSettings botSettings, ConversationMembersType membersType, boolean tlfPublic);
+  keybase1.TeamBotSettings getBotMemberSettings(string tlfName, string username, ConversationMembersType membersType, boolean tlfPublic);
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1169,6 +1169,9 @@ protocol teams {
 
   void teamEditMember(int sessionID, string name, string username, TeamRole role, union { null, TeamBotSettings } botSettings);
 
+  TeamBotSettings teamGetBotSettings(int sessionID, string name, string username);
+  void teamSetBotSettings(int sessionID, string name, string username, TeamBotSettings botSettings);
+
   void teamRename(int sessionID, TeamName prevName, TeamName newName);
 
   void teamAcceptInvite(int sessionID, string token);

--- a/protocol/json/chat1/api.json
+++ b/protocol/json/chat1/api.json
@@ -404,6 +404,14 @@
           "name": "channelNameMentions",
           "jsonkey": "channel_name_mentions",
           "optional": true
+        },
+        {
+          "type": [
+            null,
+            "string"
+          ],
+          "name": "botUID",
+          "jsonkey": "bot_uid"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -922,7 +922,8 @@
         "EXPIRED_5",
         "TOOMANYATTEMPTS_6",
         "ALREADY_DELETED_7",
-        "UPLOADFAILED_8"
+        "UPLOADFAILED_8",
+        "RESTRICTEDBOT_9"
       ]
     },
     {
@@ -2531,6 +2532,13 @@
             "items": "ConversationStatus"
           },
           "name": "status"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "ConversationID"
+          },
+          "name": "convIDs"
         },
         {
           "type": "boolean",
@@ -5032,6 +5040,137 @@
         }
       ],
       "response": null
+    },
+    "addBotMember": {
+      "request": [
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "botSettings",
+          "type": [
+            null,
+            "keybase1.TeamBotSettings"
+          ]
+        },
+        {
+          "name": "role",
+          "type": "keybase1.TeamRole"
+        },
+        {
+          "name": "membersType",
+          "type": "ConversationMembersType"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        }
+      ],
+      "response": null
+    },
+    "editBotMember": {
+      "request": [
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "botSettings",
+          "type": [
+            null,
+            "keybase1.TeamBotSettings"
+          ]
+        },
+        {
+          "name": "role",
+          "type": "keybase1.TeamRole"
+        },
+        {
+          "name": "membersType",
+          "type": "ConversationMembersType"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        }
+      ],
+      "response": null
+    },
+    "removeBotMember": {
+      "request": [
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "membersType",
+          "type": "ConversationMembersType"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        }
+      ],
+      "response": null
+    },
+    "setBotMemberSettings": {
+      "request": [
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "botSettings",
+          "type": "keybase1.TeamBotSettings"
+        },
+        {
+          "name": "membersType",
+          "type": "ConversationMembersType"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        }
+      ],
+      "response": null
+    },
+    "getBotMemberSettings": {
+      "request": [
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "membersType",
+          "type": "ConversationMembersType"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        }
+      ],
+      "response": "keybase1.TeamBotSettings"
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -3225,6 +3225,44 @@
       ],
       "response": null
     },
+    "teamGetBotSettings": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        }
+      ],
+      "response": "TeamBotSettings"
+    },
+    "teamSetBotSettings": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "botSettings",
+          "type": "TeamBotSettings"
+        }
+      ],
+      "response": null
+    },
     "teamRename": {
       "request": [
         {

--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -7,6 +7,7 @@ import * as ProfileGen from '../../../../actions/profile-gen'
 import * as Tracker2Gen from '../../../../actions/tracker2-gen'
 import * as Types from '../../../../constants/types/chat2'
 import * as Container from '../../../../util/container'
+import * as RPCChatTypes from '../../../../constants/types/rpc-chat-gen'
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey
@@ -119,23 +120,28 @@ const getUsernameToShow = (
 
 const getFailureDescriptionAllowCancel = (message, you) => {
   let failureDescription = ''
-  let allowCancelRetry = false
+  let allowCancel = false
+  let allowRetry = false
   let resolveByEdit = false
   if ((message.type === 'text' || message.type === 'attachment') && message.errorReason) {
     failureDescription = message.errorReason
     if (you && ['pending', 'failed'].includes(message.submitState)) {
       // This is a message still in the outbox, we can retry/edit to fix, but
       // for flip messages, don't allow retry/cancel
-      allowCancelRetry = message.type === 'attachment' || !message.flipGameID
+      allowCancel = allowRetry = message.type === 'attachment' || !message.flipGameID
       const messageType = message.type === 'attachment' ? 'attachment' : 'message'
       failureDescription = `This ${messageType} failed to send`
-      resolveByEdit = !!message.outboxID && !!you && message.errorReason === 'message is too long'
+      resolveByEdit = !!message.outboxID && !!you && message.errorTyp === RPCChatTypes.OutboxErrorType.toolong
       if (resolveByEdit) {
         failureDescription += `, ${message.errorReason}`
       }
+      if (!!message.outboxID && !!you && message.errorTyp === RPCChatTypes.OutboxErrorType.restrictedbot) {
+        failureDescription = `Unable to send, ${message.errorReason}`
+        allowRetry = false
+      }
     }
   }
-  return {allowCancelRetry, failureDescription, resolveByEdit}
+  return {allowCancel, allowRetry, failureDescription, resolveByEdit}
 }
 
 const getDecorate = message => {
@@ -157,7 +163,7 @@ export default Container.namedConnect(
     let showUsername = getUsernameToShow(message, previous, _you, stateProps.orangeLineAbove)
     // TODO type guard
     const outboxID: Types.OutboxID | null = (message as any).outboxID || null
-    let {allowCancelRetry, resolveByEdit, failureDescription} = getFailureDescriptionAllowCancel(
+    let {allowCancel, allowRetry, resolveByEdit, failureDescription} = getFailureDescriptionAllowCancel(
       message,
       _you
     )
@@ -165,11 +171,11 @@ export default Container.namedConnect(
     // show send only if its possible we sent while you're looking at it
     const showSendIndicator = _you === message.author && message.ordinal !== message.id
     const decorate = getDecorate(message)
-    const onCancel = allowCancelRetry
+    const onCancel = allowCancel
       ? () => dispatchProps._onCancel(message.conversationIDKey, message.ordinal)
       : undefined
     const onRetry =
-      allowCancelRetry && !resolveByEdit && outboxID
+      allowRetry && !resolveByEdit && outboxID
         ? () => dispatchProps._onRetry(message.conversationIDKey, outboxID)
         : undefined
 

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -162,6 +162,7 @@ const makeMessageCommon = {
   deviceRevokedAt: null,
   deviceType: 'mobile' as DeviceTypes.DeviceType,
   errorReason: null,
+  errorTyp: null,
   hasBeenEdited: false,
   outboxID: Types.stringToOutboxID(''),
 }
@@ -933,6 +934,8 @@ export const rpcErrorToString = (error: RPCChatTypes.OutboxStateError) => {
       return 'message already sent'
     case RPCChatTypes.OutboxErrorType.expired:
       return 'took too long to send'
+    case RPCChatTypes.OutboxErrorType.restrictedbot:
+      return 'bot is restricted from sending to this conversation'
     default:
       return `${error.message || ''} (code: ${error.typ})`
   }
@@ -946,6 +949,10 @@ const outboxUIMessagetoMessage = (
   const errorReason =
     o.state && o.state.state === RPCChatTypes.OutboxStateType.error && o.state.error
       ? rpcErrorToString(o.state.error)
+      : null
+  const errorTyp =
+    o.state && o.state.state === RPCChatTypes.OutboxStateType.error && o.state.error
+      ? o.state.error.typ
       : null
 
   switch (o.messageType) {
@@ -974,7 +981,8 @@ const outboxUIMessagetoMessage = (
         pre,
         Types.stringToOutboxID(o.outboxID),
         Types.numberToOrdinal(o.ordinal),
-        errorReason
+        errorReason,
+        errorTyp
       )
     }
     case RPCChatTypes.MessageType.flip:
@@ -986,6 +994,7 @@ const outboxUIMessagetoMessage = (
         deviceName: state.config.deviceName || '',
         deviceType: isMobile ? 'mobile' : 'desktop',
         errorReason,
+        errorTyp,
         exploding: o.isEphemeral,
         flipGameID: o.flipGameID,
         ordinal: Types.numberToOrdinal(o.ordinal),
@@ -1113,6 +1122,7 @@ export const makePendingAttachmentMessage = (
   outboxID: Types.OutboxID,
   inOrdinal: Types.Ordinal | null,
   errorReason: string | null,
+  errorTyp: number | null,
   explodeTime?: number
 ) => {
   const lastOrdinal = (state.chat2.messageOrdinals.get(conversationIDKey) || I.OrderedSet<number>()).last(
@@ -1129,6 +1139,7 @@ export const makePendingAttachmentMessage = (
     deviceName: '',
     deviceType: isMobile ? 'mobile' : 'desktop',
     errorReason: errorReason,
+    errorTyp: errorTyp,
     fileName: fileName,
     id: Types.numberToMessageID(0),
     isCollapsed: false,

--- a/shared/constants/types/chat2/message.tsx
+++ b/shared/constants/types/chat2/message.tsx
@@ -83,6 +83,7 @@ export type _MessageDeleted = {
   deviceType: DeviceType
   hasBeenEdited: boolean
   errorReason: string | null
+  errorTyp: number | null
   outboxID: OutboxID | null
   timestamp: number
   type: 'deleted'
@@ -97,6 +98,7 @@ export type _MessageText = {
   deviceRevokedAt: number | null
   deviceType: DeviceType
   errorReason: string | null
+  errorTyp: number | null
   exploded: boolean
   explodedBy: string // only if 'explode now' happened,
   exploding: boolean
@@ -154,6 +156,7 @@ export type _MessageAttachment = {
   deviceType: DeviceType
   downloadPath: string | null // string if downloaded,
   errorReason: string | null
+  errorTyp: number | null
   exploded: boolean
   explodedBy: string // only if 'explode now' happened,
   exploding: boolean
@@ -202,6 +205,7 @@ export type _MessageRequestPayment = {
   deviceRevokedAt: number | null
   deviceType: DeviceType
   errorReason: string | null
+  errorTyp: number | null
   hasBeenEdited: boolean
   note: HiddenString
   outboxID: OutboxID | null
@@ -242,6 +246,7 @@ export type _MessageSendPayment = {
   deviceRevokedAt: number | null
   deviceType: DeviceType
   errorReason: string | null
+  errorTyp: number | null
   hasBeenEdited: boolean
   outboxID: OutboxID | null
   reactions: Reactions

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -739,6 +739,7 @@ export enum OutboxErrorType {
   toomanyattempts = 6,
   alreadyDeleted = 7,
   uploadfailed = 8,
+  restrictedbot = 9,
 }
 
 export enum OutboxStateType {
@@ -1003,7 +1004,7 @@ export type GetInboxByTLFIDRemoteRes = {readonly convs?: Array<Conversation> | n
 export type GetInboxLocalQuery = {readonly name?: NameQuery | null; readonly topicName?: String | null; readonly convIDs?: Array<ConversationID> | null; readonly topicType?: TopicType | null; readonly tlfVisibility?: Keybase1.TLFVisibility | null; readonly before?: Gregor1.Time | null; readonly after?: Gregor1.Time | null; readonly oneChatTypePerTLF?: Boolean | null; readonly status?: Array<ConversationStatus> | null; readonly memberStatus?: Array<ConversationMemberStatus> | null; readonly unreadOnly: Boolean; readonly readOnly: Boolean; readonly computeActiveList: Boolean}
 export type GetInboxQuery = {readonly convID?: ConversationID | null; readonly topicType?: TopicType | null; readonly tlfID?: TLFID | null; readonly tlfVisibility?: Keybase1.TLFVisibility | null; readonly before?: Gregor1.Time | null; readonly after?: Gregor1.Time | null; readonly oneChatTypePerTLF?: Boolean | null; readonly topicName?: String | null; readonly status?: Array<ConversationStatus> | null; readonly memberStatus?: Array<ConversationMemberStatus> | null; readonly existences?: Array<ConversationExistence> | null; readonly membersTypes?: Array<ConversationMembersType> | null; readonly convIDs?: Array<ConversationID> | null; readonly unreadOnly: Boolean; readonly readOnly: Boolean; readonly computeActiveList: Boolean; readonly summarizeMaxMsgs: Boolean; readonly skipBgLoads: Boolean}
 export type GetInboxRemoteRes = {readonly inbox: InboxView; readonly rateLimit?: RateLimit | null}
-export type GetInboxSummaryForCLILocalQuery = {readonly topicType: TopicType; readonly after: String; readonly before: String; readonly visibility: Keybase1.TLFVisibility; readonly status?: Array<ConversationStatus> | null; readonly unreadFirst: Boolean; readonly unreadFirstLimit: UnreadFirstNumLimit; readonly activitySortedLimit: Int}
+export type GetInboxSummaryForCLILocalQuery = {readonly topicType: TopicType; readonly after: String; readonly before: String; readonly visibility: Keybase1.TLFVisibility; readonly status?: Array<ConversationStatus> | null; readonly convIDs?: Array<ConversationID> | null; readonly unreadFirst: Boolean; readonly unreadFirstLimit: UnreadFirstNumLimit; readonly activitySortedLimit: Int}
 export type GetInboxSummaryForCLILocalRes = {readonly conversations?: Array<ConversationLocal> | null; readonly offline: Boolean; readonly rateLimits?: Array<RateLimit> | null}
 export type GetMessageBeforeRes = {readonly msgID: MessageID; readonly rateLimit?: RateLimit | null}
 export type GetMessagesLocalRes = {readonly messages?: Array<MessageUnboxed> | null; readonly offline: Boolean; readonly rateLimits?: Array<RateLimit> | null; readonly identifyFailures?: Array<Keybase1.TLFIdentifyFailure> | null}
@@ -1099,7 +1100,7 @@ export type MsgEphemeralMetadata = {readonly l: /* lifetime */ Gregor1.DurationS
 export type MsgFlipContent = {readonly text: String; readonly gameID: String; readonly flipConvID: String; readonly userMentions?: Array<KnownUserMention> | null; readonly teamMentions?: Array<KnownTeamMention> | null}
 export type MsgNotification = {readonly type: String; readonly source: String; readonly msg?: MsgSummary | null; readonly error?: String | null; readonly pagination?: UIPagination | null}
 export type MsgSender = {readonly uid: String; readonly username: String; readonly deviceID: String; readonly deviceName: String}
-export type MsgSummary = {readonly id: MessageID; readonly convID: String; readonly channel: ChatChannel; readonly sender: MsgSender; readonly sentAt: Int64; readonly sentAtMs: Int64; readonly content: MsgContent; readonly prev?: Array<MessagePreviousPointer> | null; readonly unread: Boolean; readonly revokedDevice: Boolean; readonly offline: Boolean; readonly kbfsEncrypted: Boolean; readonly isEphemeral: Boolean; readonly isEphemeralExpired: Boolean; readonly eTime: Gregor1.Time; readonly reactions?: ReactionMap | null; readonly hasPairwiseMacs: Boolean; readonly atMentionUsernames?: Array<String> | null; readonly channelMention: String; readonly channelNameMentions?: Array<UIChannelNameMention> | null}
+export type MsgSummary = {readonly id: MessageID; readonly convID: String; readonly channel: ChatChannel; readonly sender: MsgSender; readonly sentAt: Int64; readonly sentAtMs: Int64; readonly content: MsgContent; readonly prev?: Array<MessagePreviousPointer> | null; readonly unread: Boolean; readonly revokedDevice: Boolean; readonly offline: Boolean; readonly kbfsEncrypted: Boolean; readonly isEphemeral: Boolean; readonly isEphemeralExpired: Boolean; readonly eTime: Gregor1.Time; readonly reactions?: ReactionMap | null; readonly hasPairwiseMacs: Boolean; readonly atMentionUsernames?: Array<String> | null; readonly channelMention: String; readonly channelNameMentions?: Array<UIChannelNameMention> | null; readonly botUID?: String | null}
 export type NameQuery = {readonly name: String; readonly tlfID?: TLFID | null; readonly membersType: ConversationMembersType}
 export type NewConvRes = {readonly id: String; readonly identifyFailures?: Array<Keybase1.TLFIdentifyFailure> | null; readonly rateLimits?: Array<RateLimitRes> | null}
 export type NewConversationInfo = {readonly convID: ConversationID; readonly conv?: InboxUIItem | null}
@@ -1463,6 +1464,11 @@ export const localUpdateUnsentTextRpcPromise = (params: MessageTypes['chat.1.loc
 // 'chat.1.local.advertiseBotCommandsLocal'
 // 'chat.1.local.listBotCommandsLocal'
 // 'chat.1.local.clearBotCommandsLocal'
+// 'chat.1.local.addBotMember'
+// 'chat.1.local.editBotMember'
+// 'chat.1.local.removeBotMember'
+// 'chat.1.local.setBotMemberSettings'
+// 'chat.1.local.getBotMemberSettings'
 // 'chat.1.NotifyChat.NewChatActivity'
 // 'chat.1.NotifyChat.ChatIdentifyUpdate'
 // 'chat.1.NotifyChat.ChatTLFFinalize'

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -3600,6 +3600,8 @@ export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.u
 // 'keybase.1.teams.teamListSubteamsRecursive'
 // 'keybase.1.teams.teamChangeMembership'
 // 'keybase.1.teams.teamAddMembersMultiRole'
+// 'keybase.1.teams.teamGetBotSettings'
+// 'keybase.1.teams.teamSetBotSettings'
 // 'keybase.1.teams.teamAcceptInvite'
 // 'keybase.1.teams.teamRequestAccess'
 // 'keybase.1.teams.teamTree'


### PR DESCRIPTION
patch does the following:

chat: cc @mikem
- expands test coverage for teambots including bots sending
- fixes key finding bugs for teambots

teams: cc @mlsteele 
- correctly posts bot_settings link for change_membership
- clears in locally stored secrets if team role is changed to restricted bot
- boxes keys if role is changed from restricted bot


depends on https://github.com/keybase/keybase/pull/4185