### PR TITLE
common-adapters (A-F) dark mode support

### DIFF
--- a/shared/common-adapters/animated.stories.tsx
+++ b/shared/common-adapters/animated.stories.tsx
@@ -11,13 +11,13 @@ const load = () => {
   ))
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     backgroundColor: Styles.globalColors.red,
     height: 20,
     position: 'relative',
     width: 20,
   },
-})
+}))
 
 export default load

--- a/shared/common-adapters/av.desktop.tsx
+++ b/shared/common-adapters/av.desktop.tsx
@@ -69,7 +69,7 @@ export class Video extends React.PureComponent<Props, VideoState> {
 
 export const Audio = Video
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     ...Styles.globalStyles.flexBoxColumn,
     ...Styles.globalStyles.flexBoxCenter,
@@ -87,4 +87,4 @@ const styles = Styles.styleSheetCreate({
       position: 'absolute',
     },
   }),
-})
+}))

--- a/shared/common-adapters/av.native.tsx
+++ b/shared/common-adapters/av.native.tsx
@@ -66,7 +66,7 @@ export const Audio = (props: Props) => (
   />
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   audio: {
     ...Styles.globalStyles.fullWidth,
     backgroundColor: Styles.globalColors.black,
@@ -79,4 +79,4 @@ const styles = Styles.styleSheetCreate({
     justifyContent: 'center',
     width: '100%',
   },
-})
+}))

--- a/shared/common-adapters/av.stories.tsx
+++ b/shared/common-adapters/av.stories.tsx
@@ -25,7 +25,7 @@ const load = () => {
     ))
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   bigBox: {
     backgroundColor: Styles.globalColors.red,
   },
@@ -34,6 +34,6 @@ const styles = Styles.styleSheetCreate({
     height: 300,
     width: 300,
   },
-})
+}))
 
 export default load

--- a/shared/common-adapters/avatar-line.tsx
+++ b/shared/common-adapters/avatar-line.tsx
@@ -56,7 +56,7 @@ const styleMap = avatarSizes.reduce(
   (styles, size) => ({
     ...styles,
     [size]: {
-      horizontal: Styles.styleSheetCreate({
+      horizontal: Styles.styleSheetCreate(() => ({
         avatar: {
           marginRight: -size / 3,
         },
@@ -76,8 +76,8 @@ const styleMap = avatarSizes.reduce(
           color: Styles.globalColors.black_50,
           paddingRight: size / 5,
         },
-      }),
-      vertical: Styles.styleSheetCreate({
+      })),
+      vertical: Styles.styleSheetCreate(() => ({
         avatar: {
           marginBottom: -size / 3,
         },
@@ -97,7 +97,7 @@ const styleMap = avatarSizes.reduce(
           color: Styles.globalColors.black_50,
           paddingBottom: size / 5,
         },
-      }),
+      })),
     },
   }),
   {}

--- a/shared/common-adapters/avatar-line.tsx
+++ b/shared/common-adapters/avatar-line.tsx
@@ -39,7 +39,7 @@ const AvatarLine = (props: Props) => {
             size={props.size}
             username={username}
             key={username}
-            borderColor="white"
+            borderColor={Styles.globalColors.white}
             style={styles.avatar}
           />
         ))

--- a/shared/common-adapters/avatar.css
+++ b/shared/common-adapters/avatar.css
@@ -87,6 +87,10 @@
   top: 0;
 }
 
+.darkMode .avatar-background {
+  background-color: #0f0f0f;
+}
+
 .avatar-user-image {
   flex-shrink: 0;
   background-size: cover;
@@ -107,6 +111,14 @@
   top: 0;
 }
 
+.darkMode .avatar-border-team {
+  background: rgba(255, 255, 255, 0);
+}
+
 .avatar-border {
   background: rgba(0, 0, 0, 0);
+}
+
+.darkMode .avatar-border {
+  background: rgba(255, 255, 255, 0);
 }

--- a/shared/common-adapters/avatar.render.desktop.tsx
+++ b/shared/common-adapters/avatar.render.desktop.tsx
@@ -45,7 +45,7 @@ const Avatar = (props: Props) => {
   )
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   border: Styles.platformStyles({
     isElectron: {boxShadow: `0px 0px 0px 2px ${Styles.globalColors.black_10}}`},
   }),
@@ -63,6 +63,6 @@ const styles = Styles.styleSheetCreate({
     position: 'absolute',
     right: -18,
   },
-})
+}))
 
 export default Avatar

--- a/shared/common-adapters/avatar.render.native.tsx
+++ b/shared/common-adapters/avatar.render.native.tsx
@@ -98,7 +98,7 @@ const imageStyles = sizes.reduce((map, size) => {
   return map
 }, {})
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   ...boxStyles,
   ...iconStyles,
   ...imageStyles,
@@ -128,6 +128,6 @@ const styles = Styles.styleSheetCreate({
     position: 'absolute',
     right: -28,
   },
-})
+}))
 
 export default Avatar

--- a/shared/common-adapters/avatar.tsx
+++ b/shared/common-adapters/avatar.tsx
@@ -5,6 +5,7 @@ import {iconTypeToImgSet, urlsToImgSet, IconType, IconStyle} from './icon'
 import * as Container from '../util/container'
 import * as Styles from '../styles'
 import * as ProfileGen from '../actions/profile-gen'
+import './avatar.css'
 
 export type AvatarSize = 128 | 96 | 64 | 48 | 32 | 24 | 16
 type URLType = string

--- a/shared/common-adapters/back-button.native.tsx
+++ b/shared/common-adapters/back-button.native.tsx
@@ -32,7 +32,7 @@ export default class BackButton extends Component<Props> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   arrow: {marginRight: -3, marginTop: 2},
   container: {
     ...Styles.globalStyles.flexBoxRow,
@@ -42,6 +42,6 @@ const styles = Styles.styleSheetCreate({
     paddingLeft: Styles.globalMargins.small - 4,
     paddingRight: Styles.globalMargins.small,
   },
-})
+}))
 
 const iconFontSize = 24

--- a/shared/common-adapters/background-repeat-box/index.desktop.tsx
+++ b/shared/common-adapters/background-repeat-box/index.desktop.tsx
@@ -28,12 +28,12 @@ const BackgroundRepeatBox = (props: Props) => {
   )
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   backgroundRepeat: Styles.platformStyles({
     isElectron: {
       backgroundRepeat: 'repeat',
     },
   }),
-})
+}))
 
 export default BackgroundRepeatBox

--- a/shared/common-adapters/background-repeat-box/index.native.tsx
+++ b/shared/common-adapters/background-repeat-box/index.native.tsx
@@ -19,11 +19,11 @@ const BackgroundRepeatBox = (props: Props) => {
   )
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   backgroundImage: {...Styles.globalStyles.fillAbsolute, height: 'auto', width: 'auto'},
   container: {
     position: 'relative',
   },
-})
+}))
 
 export default BackgroundRepeatBox

--- a/shared/common-adapters/badge.tsx
+++ b/shared/common-adapters/badge.tsx
@@ -56,7 +56,7 @@ export default class Badge extends React.Component<Badge2Props> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   badge: {
     ...Styles.globalStyles.flexBoxRow,
     ...Styles.globalStyles.flexBoxCenter,
@@ -65,4 +65,4 @@ const styles = Styles.styleSheetCreate({
   text: {
     color: Styles.globalColors.white,
   },
-})
+}))

--- a/shared/common-adapters/box-grow.tsx
+++ b/shared/common-adapters/box-grow.tsx
@@ -18,12 +18,12 @@ class BoxGrow extends React.Component<Props> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   inner: {...Styles.globalStyles.fillAbsolute},
   outer: {
     flexGrow: 1,
     position: 'relative',
   },
-})
+}))
 
 export default BoxGrow

--- a/shared/common-adapters/box.desktop.tsx
+++ b/shared/common-adapters/box.desktop.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {intersperseFn} from '../util/arrays'
 import {Box2Props} from './box'
+import './box.css'
 
 class Box extends React.PureComponent<any> {
   render() {

--- a/shared/common-adapters/button.css
+++ b/shared/common-adapters/button.css
@@ -4,23 +4,38 @@
 .button__border {
   border: 1px solid rgba(0, 0, 0, 0.2);
 }
+.darkMode .button__border {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
 .button__border_blue:hover {
   border: 1px solid rgba(77, 142, 255, 0.3);
+}
+.darkMode .button__border_blue:hover {
+  border: 1px solid rgba(178, 113, 0, 0.3);
 }
 .button__border_red:hover {
   border: 1px solid rgba(255, 77, 97, 0.3);
 }
 .darkMode .button__border_red:hover {
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(0, 178, 158, 0.3);
 }
 .button__border_green:hover {
   border: 1px solid rgba(55, 189, 153, 0.3);
 }
+.darkMode .button__border_green:hover {
+  border: 1px solid rgba(200, 66, 102, 0.3);
+}
 .button__border_purple:hover {
   border: 1px solid rgba(112, 78, 186, 0.3);
 }
+.darkMode .button__border_purple:hover {
+  border: 1px solid rgba(143, 177, 69, 0.3);
+}
 .button__border_black:hover {
   border: 1px solid rgba(0, 0, 0, 0.3);
+}
+.darkMode .button__border_black:hover {
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 .button__underlay {
@@ -35,24 +50,42 @@
 .button__underlay_black10:hover {
   background-color: rgba(0, 0, 0, 0.1);
 }
+.darkMode .button__underlay_black10:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
 .button__underlay_blue:hover {
   background-color: rgba(76, 142, 255, 0.05);
+}
+.darkMode .button__underlay_blue:hover {
+  background-color: rgba(178, 113, 0, 0.05);
 }
 .button__underlay_red:hover {
   background-color: rgba(255, 77, 97, 0.05);
 }
 .darkMode .button__underlay_red:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(0, 178, 158, 0.05);
 }
 .button__underlay_green:hover {
   background-color: rgba(55, 189, 153, 0.05);
 }
+.darkMode .button__underlay_green:hover {
+  background-color: rgba(200, 66, 102, 0.05)
+}
 .button__underlay_purple:hover {
   background-color: rgba(112, 78, 186, 0.05);
+}
+.darkMode .button__underlay_purple:hover {
+  background-color: rgba(143, 177, 69, 0.05);
 }
 .button__underlay_black:hover {
   background-color: rgba(0, 0, 0, 0.05);
 }
+.darkMode .button__underlay_black:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
 .button__underlay_yellow:hover {
   background-color: rgba(255, 248, 90, 0.05);
+}
+.darkMode .button__underlay_yellow:hover {
+  background-color: rgba(0, 7, 165, 0.05);
 }

--- a/shared/common-adapters/button.tsx
+++ b/shared/common-adapters/button.tsx
@@ -5,6 +5,7 @@ import Icon, {castPlatformStyles} from './icon'
 import * as React from 'react'
 import Text from './text'
 import * as Styles from '../styles'
+import './button.css'
 
 const Kb = {
   Box,

--- a/shared/common-adapters/checkbox.desktop.tsx
+++ b/shared/common-adapters/checkbox.desktop.tsx
@@ -55,7 +55,7 @@ class Checkbox extends Component<Props> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   checkbox: {
     ...Styles.globalStyles.flexBoxColumn,
     ...Styles.transition('background'),
@@ -103,6 +103,6 @@ const styles = Styles.styleSheetCreate({
   transparent: {
     opacity: 0,
   },
-})
+}))
 
 export default Checkbox

--- a/shared/common-adapters/checkbox.native.tsx
+++ b/shared/common-adapters/checkbox.native.tsx
@@ -17,11 +17,11 @@ const Checkbox = (props: Props) => (
   />
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     paddingBottom: Styles.globalMargins.xtiny,
     paddingTop: Styles.globalMargins.xtiny,
   },
-})
+}))
 
 export default Checkbox

--- a/shared/common-adapters/choice-list.css
+++ b/shared/common-adapters/choice-list.css
@@ -1,26 +1,26 @@
 .cl-entry {
-    background-color: transparent;
+  background-color: transparent;
 }
 .cl-entry:hover {
-    /* blueLighter2 */
-    background-color: #EBF2FC;
+  /* blueLighter2 */
+  background-color: #ebf2fc;
 }
 .darkMode .cl-entry:hover {
-    background-color: #140D03;
+  background-color: #140d03;
 }
 
 .cl-icon {
-    transform-origin: center center;
-    transition: 0.5s transform;
+  transform-origin: center center;
+  transition: 0.5s transform;
 }
 .cl-entry:hover .cl-icon {
-    transform: translateX(25%);
+  transform: translateX(25%);
 }
 
 .cl-icon-container {
-    transition: 0.5s background;
-    border-radius: 50%;
+  transition: 0.5s background;
+  border-radius: 50%;
 }
 .cl-entry:hover .cl-icon-container {
-    background: transparent;
+  background: transparent;
 }

--- a/shared/common-adapters/choice-list.css
+++ b/shared/common-adapters/choice-list.css
@@ -1,0 +1,26 @@
+.cl-entry {
+    background-color: transparent;
+}
+.cl-entry:hover {
+    /* blueLighter2 */
+    background-color: #EBF2FC;
+}
+.darkMode .cl-entry:hover {
+    background-color: #140D03;
+}
+
+.cl-icon {
+    transform-origin: center center;
+    transition: 0.5s transform;
+}
+.cl-entry:hover .cl-icon {
+    transform: translateX(25%);
+}
+
+.cl-icon-container {
+    transition: 0.5s background;
+    border-radius: 50%;
+}
+.cl-entry:hover .cl-icon-container {
+    background: transparent;
+}

--- a/shared/common-adapters/choice-list.desktop.tsx
+++ b/shared/common-adapters/choice-list.desktop.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import {Box, Text, Icon, IconType} from '../common-adapters'
 import * as Styles from '../styles'
 import {Props} from './choice-list'
+import './choice-list.css'
 
 const ChoiceList = ({options}: Props) => {
   return (
@@ -48,16 +49,16 @@ const styles = Styles.styleSheetCreate(() => ({
     ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),
     width: '100%',
   },
-  iconContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: 80,
-    width: 80,
-    background: Styles.globalColors.greyLight,
-  },
   icon: {
     height: 48,
     width: 48,
+  },
+  iconContainer: {
+    alignItems: 'center',
+    background: Styles.globalColors.greyLight,
+    height: 80,
+    justifyContent: 'center',
+    width: 80,
   },
   infoContainer: {
     alignItems: 'flex-start',

--- a/shared/common-adapters/choice-list.desktop.tsx
+++ b/shared/common-adapters/choice-list.desktop.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import {Box, Text, Icon, IconType} from '../common-adapters'
-import {globalStyles, globalColors, globalMargins, desktopStyles} from '../styles'
+import * as Styles from '../styles'
 import {Props} from './choice-list'
+import { darkColors } from '../styles/colors';
 
 const ChoiceList = ({options}: Props) => {
   return (
@@ -11,17 +12,17 @@ const ChoiceList = ({options}: Props) => {
         // TODO is this okay?
         const iconType: IconType = op.icon as IconType
         return (
-          <Box style={styleEntry} key={idx} className="cl-entry" onClick={() => op.onClick()}>
-            <Box style={styleIconContainer} className="cl-icon-container">
+          <Box style={Styles.collapseStyles([Styles.globalStyles.flexBoxRow, Styles.desktopStyles.clickable, styles.entry])} key={idx} className="cl-entry" onClick={() => op.onClick()}>
+            <Box style={Styles.collapseStyles([Styles.globalStyles.flexBoxColumn, styles.iconContainer])} className="cl-icon-container">
               {typeof op.icon === 'string' ? (
-                <Icon style={styleIcon} type={iconType} className="cl-icon" />
+                <Icon style={styles.icon} type={iconType} className="cl-icon" />
               ) : (
-                <Box style={styleIcon} className="cl-icon">
+                <Box style={styles.icon} className="cl-icon">
                   {op.icon}
                 </Box>
               )}
             </Box>
-            <Box style={styleInfoContainer}>
+            <Box style={Styles.collapseStyles([Styles.globalStyles.flexBoxColumn, styles.infoContainer])}>
               <Text type="BodyBigLink">{op.title}</Text>
               <Text type="Body">{op.description}</Text>
             </Box>
@@ -37,7 +38,10 @@ const rawCSS = `
     background-color: transparent;
   }
   .cl-entry:hover {
-    background-color: ${globalColors.blueLighter2};
+    background-color: ${Styles.globalColors.blueLighter2};
+  }
+  .darkMode .cl-entry:hover {
+    background-color: ${darkColors.blueLighter2}
   }
 
   .cl-icon {
@@ -50,7 +54,6 @@ const rawCSS = `
 
   .cl-icon-container {
     transition: 0.5s background;
-    background: ${globalColors.greyLight};
     border-radius: 50%;
   }
   .cl-entry:hover .cl-icon-container {
@@ -58,33 +61,29 @@ const rawCSS = `
   }
 `
 
-const styleEntry = {
-  ...globalStyles.flexBoxRow,
-  ...desktopStyles.clickable,
-  padding: `${globalMargins.tiny}px ${globalMargins.small}px`,
-  width: '100%',
-}
-
-const styleIconContainer = {
-  ...globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  height: 80,
-  justifyContent: 'center',
-  width: 80,
-}
-
-const styleIcon = {
-  height: 48,
-  width: 48,
-}
-
-const styleInfoContainer = {
-  ...globalStyles.flexBoxColumn,
-  alignItems: 'flex-start',
-  flex: 1,
-  justifyContent: 'center',
-  marginLeft: globalMargins.small,
-  textAlign: 'left',
-}
+const styles = Styles.styleSheetCreate(() => ({
+  entry: {
+    padding: `${Styles.globalMargins.tiny}px ${Styles.globalMargins.small}px`,
+    width: '100%'
+  },
+  iconContainer: {
+    alignItems: 'center', 
+    justifyContent: 'center',
+    height: 80,
+    width: 80,
+    background: Styles.globalColors.greyLight,
+  },
+  icon: {
+    height: 48,
+    width: 48
+  },
+  infoContainer: {
+    alignItems: 'flex-start',
+    flex: 1,
+    justifyContent: 'center',
+    marginLeft: Styles.globalMargins.small,
+    textAlign: 'left', 
+  }
+}))
 
 export default ChoiceList

--- a/shared/common-adapters/choice-list.desktop.tsx
+++ b/shared/common-adapters/choice-list.desktop.tsx
@@ -2,18 +2,28 @@ import * as React from 'react'
 import {Box, Text, Icon, IconType} from '../common-adapters'
 import * as Styles from '../styles'
 import {Props} from './choice-list'
-import { darkColors } from '../styles/colors';
 
 const ChoiceList = ({options}: Props) => {
   return (
     <Box>
-      <style>{rawCSS}</style>
       {options.map((op, idx) => {
         // TODO is this okay?
         const iconType: IconType = op.icon as IconType
         return (
-          <Box style={Styles.collapseStyles([Styles.globalStyles.flexBoxRow, Styles.desktopStyles.clickable, styles.entry])} key={idx} className="cl-entry" onClick={() => op.onClick()}>
-            <Box style={Styles.collapseStyles([Styles.globalStyles.flexBoxColumn, styles.iconContainer])} className="cl-icon-container">
+          <Box
+            style={Styles.collapseStyles([
+              Styles.globalStyles.flexBoxRow,
+              Styles.desktopStyles.clickable,
+              styles.entry,
+            ])}
+            key={idx}
+            className="cl-entry"
+            onClick={() => op.onClick()}
+          >
+            <Box
+              style={Styles.collapseStyles([Styles.globalStyles.flexBoxColumn, styles.iconContainer])}
+              className="cl-icon-container"
+            >
               {typeof op.icon === 'string' ? (
                 <Icon style={styles.icon} type={iconType} className="cl-icon" />
               ) : (
@@ -33,41 +43,13 @@ const ChoiceList = ({options}: Props) => {
   )
 }
 
-const rawCSS = `
-  .cl-entry {
-    background-color: transparent;
-  }
-  .cl-entry:hover {
-    background-color: ${Styles.globalColors.blueLighter2};
-  }
-  .darkMode .cl-entry:hover {
-    background-color: ${darkColors.blueLighter2}
-  }
-
-  .cl-icon {
-    transform-origin: center center;
-    transition: 0.5s transform;
-  }
-  .cl-entry:hover .cl-icon {
-    transform: translateX(25%);
-  }
-
-  .cl-icon-container {
-    transition: 0.5s background;
-    border-radius: 50%;
-  }
-  .cl-entry:hover .cl-icon-container {
-    background: transparent;
-  }
-`
-
 const styles = Styles.styleSheetCreate(() => ({
   entry: {
-    padding: `${Styles.globalMargins.tiny}px ${Styles.globalMargins.small}px`,
-    width: '100%'
+    ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),
+    width: '100%',
   },
   iconContainer: {
-    alignItems: 'center', 
+    alignItems: 'center',
     justifyContent: 'center',
     height: 80,
     width: 80,
@@ -75,15 +57,15 @@ const styles = Styles.styleSheetCreate(() => ({
   },
   icon: {
     height: 48,
-    width: 48
+    width: 48,
   },
   infoContainer: {
     alignItems: 'flex-start',
     flex: 1,
     justifyContent: 'center',
     marginLeft: Styles.globalMargins.small,
-    textAlign: 'left', 
-  }
+    textAlign: 'left',
+  },
 }))
 
 export default ChoiceList

--- a/shared/common-adapters/confirm-modal/index.tsx
+++ b/shared/common-adapters/confirm-modal/index.tsx
@@ -117,7 +117,7 @@ class ConfirmModal extends React.PureComponent<Props> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   button: {
     flex: 1,
   },
@@ -138,6 +138,6 @@ const styles = Styles.styleSheetCreate({
     color: Styles.globalColors.black,
     margin: Styles.globalMargins.small,
   },
-})
+}))
 
 export default ConfirmModal

--- a/shared/common-adapters/copy-text.tsx
+++ b/shared/common-adapters/copy-text.tsx
@@ -139,7 +139,7 @@ const CopyText: React.ComponentClass<OwnProps> = compose(
 )(_CopyText)
 
 // border radii aren't literally so big, just sets it to maximum
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   button: Styles.platformStyles({
     common: {
       alignSelf: 'stretch',
@@ -218,6 +218,6 @@ const styles = Styles.styleSheetCreate({
       paddingTop: 5,
     },
   }),
-})
+}))
 
 export default CopyText

--- a/shared/common-adapters/drag-and-drop.desktop.tsx
+++ b/shared/common-adapters/drag-and-drop.desktop.tsx
@@ -98,7 +98,7 @@ class DragAndDrop extends React.PureComponent<Props, State> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   containerStyle: {
     position: 'relative',
   },
@@ -118,6 +118,6 @@ const styles = Styles.styleSheetCreate({
     height: 48,
     width: 48,
   },
-})
+}))
 
 export default DragAndDrop

--- a/shared/common-adapters/dropdown.stories.tsx
+++ b/shared/common-adapters/dropdown.stories.tsx
@@ -113,7 +113,7 @@ const load = () => {
     ))
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     ...Styles.globalStyles.flexBoxCenter,
     ...Styles.globalStyles.flexBoxColumn,
@@ -133,6 +133,6 @@ const styles = Styles.styleSheetCreate({
   space: {
     height: 200,
   },
-})
+}))
 
 export default load

--- a/shared/common-adapters/dropdown.tsx
+++ b/shared/common-adapters/dropdown.tsx
@@ -136,7 +136,7 @@ export const InlineDropdown = (props: InlineDropdownProps) => {
   )
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   inlineDropdown: {
     paddingRight: Styles.globalMargins.tiny,
   },
@@ -192,7 +192,7 @@ const styles = Styles.styleSheetCreate({
     isElectron: {minHeight: 32},
     isMobile: {minHeight: 48},
   }),
-})
+}))
 
 const ItemBox = Styles.styled(Box)({
   ...Styles.globalStyles.flexBoxRow,

--- a/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
@@ -128,7 +128,7 @@ const styleRowText = (props: {
   return {color, ...(props.disabled ? {opacity: 0.6} : {})}
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   badge: {
     alignSelf: 'center',
     marginLeft: Styles.globalMargins.tiny,
@@ -169,6 +169,6 @@ const styles = Styles.styleSheetCreate({
   safeArea: {
     backgroundColor: Styles.globalColors.white,
   },
-})
+}))
 
 export default MenuLayout

--- a/shared/common-adapters/floating-picker.native.tsx
+++ b/shared/common-adapters/floating-picker.native.tsx
@@ -41,7 +41,7 @@ const FloatingPicker = <T extends string | number>(props: Props<T>) => {
   )
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   actionButtons: {
     alignItems: 'stretch',
     height: 56,
@@ -82,6 +82,6 @@ const styles = Styles.styleSheetCreate({
   safeArea: {
     backgroundColor: Styles.globalColors.white,
   },
-})
+}))
 
 export default FloatingPicker

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -4,6 +4,7 @@
 @import '../../common-adapters/icon.css';
 @import '../../common-adapters/text.css';
 @import '../../common-adapters/button.css';
+@import '../../common-adapters/choice-list.css';
 
 /* Reset */
 /* http://meyerweb.com/eric/tools/css/reset/

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -1,10 +1,6 @@
 @import '~emoji-mart/css/emoji-mart.css';
-@import '../../common-adapters/avatar.css';
-@import '../../common-adapters/box.css';
 @import '../../common-adapters/icon.css';
 @import '../../common-adapters/text.css';
-@import '../../common-adapters/button.css';
-@import '../../common-adapters/choice-list.css';
 
 /* Reset */
 /* http://meyerweb.com/eric/tools/css/reset/


### PR DESCRIPTION
This PR updates the `common-adapters` components so they can handle theme changes. Most of these changes are just using a closure in calls to `Styles.styleSheetCreate` instead of an object, but there were a few cases where I needed to move other style declarations into a `styleSheetCreate` call.

@keybase/react-hackers