### PR TITLE
teams: fixes around hidden rotates and subteam renames

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3228,6 +3228,14 @@ func (h *HiddenTeamChain) KeySummary() string {
 	return fmt.Sprintf("{last:%d, lastPerTeamKeys:%+v, readerPerTeamKeys: %+v}", h.Last, h.LastPerTeamKeys, h.ReaderPerTeamKeys)
 }
 
+func (h *HiddenTeamChain) LinkAndKeySummary() string {
+	if h == nil {
+		return "empty"
+	}
+	ks := h.KeySummary()
+	return fmt.Sprintf("{nOuterlinks: %d, nInnerLinks:%d, keys:%s}", len(h.Outer), len(h.Inner), ks)
+}
+
 func (h *TeamData) KeySummary() string {
 	if h == nil {
 		return "Ø"

--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -216,6 +216,7 @@ func (l *LoaderPackage) CheckNoPTK(mctx libkb.MetaContext, g keybase1.PerTeamKey
 // the result local to this object.
 func (l *LoaderPackage) Update(mctx libkb.MetaContext, update []sig3.ExportJSON) (err error) {
 	defer mctx.Trace(fmt.Sprintf("LoaderPackage#Update(%s, %d)", l.id, len(update)), func() error { return err })()
+	mctx.Debug("LoaderPackage#Update pre: %s", l.data.LinkAndKeySummary())
 
 	var data *keybase1.HiddenTeamChain
 	data, err = l.updatePrecheck(mctx, update)
@@ -226,6 +227,8 @@ func (l *LoaderPackage) Update(mctx libkb.MetaContext, update []sig3.ExportJSON)
 	if err != nil {
 		return err
 	}
+
+	mctx.Debug("LoaderPackage#Update post: %s", l.data.LinkAndKeySummary())
 	return nil
 }
 
@@ -406,6 +409,7 @@ func (l *LoaderPackage) CheckUpdatesAgainstSeedsWithMap(mctx libkb.MetaContext, 
 // enforces equality and will error out if not. Through this check, a client can convince itself that the
 // recent keyers knew the old keys.
 func (l *LoaderPackage) CheckUpdatesAgainstSeeds(mctx libkb.MetaContext, f func(keybase1.PerTeamKeyGeneration) *keybase1.PerTeamSeedCheck) (err error) {
+	defer mctx.Trace("LoaderPackage#CheckUpdatesAgainstSeeds", func() error { return err })()
 	// BOTs are excluded since they do not have any seed access
 	if l.newData == nil || l.role.IsRestrictedBot() {
 		return nil

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -406,6 +406,7 @@ type load2ArgT struct {
 	public                    bool
 	skipAudit                 bool
 	skipNeedHiddenRotateCheck bool
+	skipSeedCheck             bool
 
 	needSeqnos []keybase1.Seqno
 	// Non-nil if we are loading an ancestor for the greater purpose of
@@ -831,9 +832,11 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		return nil, err
 	}
 
-	err = hiddenPackage.CheckUpdatesAgainstSeedsWithMap(mctx, ret.PerTeamKeySeedsUnverified)
-	if err != nil {
-		return nil, err
+	if !arg.skipSeedCheck {
+		err = hiddenPackage.CheckUpdatesAgainstSeedsWithMap(mctx, ret.PerTeamKeySeedsUnverified)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Make sure public works out

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -999,7 +999,6 @@ func (l *TeamLoader) computeSeedChecks(ctx context.Context, state *keybase1.Team
 	defer mctx.Trace(fmt.Sprintf("TeamLoader#computeSeedChecks(%s)", state.ID()), func() error { return err })()
 
 	latestChainGen := keybase1.PerTeamKeyGeneration(len(state.PerTeamKeySeedsUnverified))
-	mctx.Debug("FUCK %d %+v", latestChainGen, state.PerTeamKeySeedsUnverified)
 	err = computeSeedChecks(
 		ctx,
 		state.ID(),

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -594,6 +594,8 @@ func (l *TeamLoader) checkParentChildOperations(ctx context.Context,
 		forceFullReload:                       false,
 		forceRepoll:                           false,
 		staleOK:                               true, // stale is fine, as long as get those seqnos.
+		skipSeedCheck:                         true,
+		skipAudit:                             true,
 
 		needSeqnos:    needParentSeqnos,
 		readSubteamID: &readSubteamID,
@@ -997,7 +999,8 @@ func (l *TeamLoader) computeSeedChecks(ctx context.Context, state *keybase1.Team
 	defer mctx.Trace(fmt.Sprintf("TeamLoader#computeSeedChecks(%s)", state.ID()), func() error { return err })()
 
 	latestChainGen := keybase1.PerTeamKeyGeneration(len(state.PerTeamKeySeedsUnverified))
-	return computeSeedChecks(
+	mctx.Debug("FUCK %d %+v", latestChainGen, state.PerTeamKeySeedsUnverified)
+	err = computeSeedChecks(
 		ctx,
 		state.ID(),
 		latestChainGen,
@@ -1014,6 +1017,7 @@ func (l *TeamLoader) computeSeedChecks(ctx context.Context, state *keybase1.Team
 			state.PerTeamKeySeedsUnverified[g] = ptksu
 		},
 	)
+	return err
 }
 
 // consumeRatchets finds the hidden chain ratchets in the given link (if it's not stubbed), and adds them

--- a/go/teams/rename.go
+++ b/go/teams/rename.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams/hidden"
 )
 
 func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase1.TeamName, newName keybase1.TeamName) error {
@@ -72,19 +73,21 @@ func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase
 			return err
 		}
 
+		var ratchetBlindingKeys hidden.RatchetBlindingKeySet
+
 		// Subteam renaming involves two links, one `rename_subteam` in the parent
 		// team's chain, and one `rename_up_pointer` in the subteam's chain.
 
 		mctx.Debug("RenameSubteam make sigs")
 		renameSubteamSig, err := generateRenameSubteamSigForParentChain(
-			mctx, me, deviceSigningKey, parent.chain(), subteam.ID, newName, admin)
+			mctx, me, deviceSigningKey, parent.chain(), subteam.ID, newName, admin, &ratchetBlindingKeys)
 		if err != nil {
 			return err
 		}
 
 		renameUpPointerSig, err := generateRenameUpPointerSigForSubteamChain(
 			mctx,
-			me, deviceSigningKey, chainPair{parent: parent.chain(), subteam: subteam.chain()}, newName, admin)
+			me, deviceSigningKey, chainPair{parent: parent.chain(), subteam: subteam.chain()}, newName, admin, &ratchetBlindingKeys)
 		if err != nil {
 			return err
 		}
@@ -101,6 +104,7 @@ func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase
 
 		payload := make(libkb.JSONPayload)
 		payload["sigs"] = []interface{}{renameSubteamSig, renameUpPointerSig}
+		ratchetBlindingKeys.AddToJSONPayload(payload)
 
 		mctx.Debug("RenameSubteam post")
 		_, err = mctx.G().API.PostJSON(mctx, libkb.APIArg{
@@ -118,13 +122,12 @@ func RenameSubteam(ctx context.Context, g *libkb.GlobalContext, prevName keybase
 	})
 }
 
-func generateRenameSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamID keybase1.TeamID, newSubteamName keybase1.TeamName, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
+func generateRenameSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, parentTeam *TeamSigChainState, subteamID keybase1.TeamID, newSubteamName keybase1.TeamName, admin *SCTeamAdmin, rbk *hidden.RatchetBlindingKeySet) (item *libkb.SigMultiItem, err error) {
 
 	entropy, err := makeSCTeamEntropy()
 	if err != nil {
 		return nil, err
 	}
-
 	teamSection := SCTeamSection{
 		Admin: admin,
 		ID:    (SCTeamID)(parentTeam.GetID()),
@@ -133,6 +136,15 @@ func generateRenameSubteamSigForParentChain(m libkb.MetaContext, me libkb.UserFo
 			Name: (SCTeamName)(newSubteamName.String()),
 		},
 		Entropy: entropy,
+	}
+
+	ratchet, err := parentTeam.makeHiddenRatchet(m)
+	if err != nil {
+		return nil, err
+	}
+	if ratchet != nil {
+		teamSection.Ratchets = ratchet.ToTeamSection()
+		rbk.Add(*ratchet)
 	}
 
 	sigBody, err := RenameSubteamSig(m.G(), me, signingKey, parentTeam, teamSection)
@@ -181,7 +193,7 @@ type chainPair struct {
 	subteam *TeamSigChainState
 }
 
-func generateRenameUpPointerSigForSubteamChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, teams chainPair, newSubteamName keybase1.TeamName, admin *SCTeamAdmin) (item *libkb.SigMultiItem, err error) {
+func generateRenameUpPointerSigForSubteamChain(m libkb.MetaContext, me libkb.UserForSignatures, signingKey libkb.GenericKey, teams chainPair, newSubteamName keybase1.TeamName, admin *SCTeamAdmin, rbk *hidden.RatchetBlindingKeySet) (item *libkb.SigMultiItem, err error) {
 	newSubteamNameStr := newSubteamName.String()
 	teamSection := SCTeamSection{
 		Admin: admin,
@@ -192,6 +204,14 @@ func generateRenameUpPointerSigForSubteamChain(m libkb.MetaContext, me libkb.Use
 			Seqno:   teams.parent.GetLatestSeqno() + 1, // the seqno of the *new* parent link
 			SeqType: seqTypeForTeamPublicness(teams.parent.IsPublic()),
 		},
+	}
+	ratchet, err := teams.subteam.makeHiddenRatchet(m)
+	if err != nil {
+		return nil, err
+	}
+	if ratchet != nil {
+		teamSection.Ratchets = ratchet.ToTeamSection()
+		rbk.Add(*ratchet)
 	}
 
 	sigBody, err := RenameUpPointerSig(m.G(), me, signingKey, teams.subteam, teamSection)


### PR DESCRIPTION
- there was an unlikely test flake in TeamAPI systest that triggered a failure to upload a team
- introduce new tests that repro this and related problems 100% of the time
- fix, which is that rename sigs weren't ratcheting
- also, we have a case where >1 ratchets need to be uploaded, so fix the server to allow that