### PR TITLE
Use relative imports in avdl files

### DIFF
--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -2,9 +2,9 @@
 
 protocol chatUi {
 
-  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
-  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
-  import idl "github.com/keybase/client/go/protocol/stellar1" as stellar1;
+  import idl "../keybase1" as keybase1;
+  import idl "../gregor1" as gregor1;
+  import idl "../stellar1" as stellar1;
   import idl "common.avdl";
   import idl "unfurl.avdl";
   import idl "commands.avdl";

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -1,7 +1,7 @@
 @namespace("chat.1") protocol common {
 
-  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
-  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
+  import idl "../gregor1" as gregor1;
+  import idl "../keybase1" as keybase1;
 
   @typedef("bytes")  record ThreadID {}
   @typedef("uint") @lint("ignore") record MessageID {}

--- a/protocol/avdl/chat1/gregor.avdl
+++ b/protocol/avdl/chat1/gregor.avdl
@@ -1,8 +1,8 @@
 @namespace("chat.1")
 protocol gregor {
 
-    import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
-    import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
+    import idl "../gregor1" as gregor1;
+    import idl "../keybase1" as keybase1;
 
     record GenericPayload {
         @lint("ignore")

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -1,9 +1,9 @@
 @namespace("chat.1")
 
 protocol local {
-  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
-  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
-  import idl "github.com/keybase/client/go/protocol/stellar1" as stellar1;
+  import idl "../gregor1" as gregor1;
+  import idl "../keybase1" as keybase1;
+  import idl "../stellar1" as stellar1;
   import idl "common.avdl";
   import idl "chat_ui.avdl";
   import idl "unfurl.avdl";

--- a/protocol/avdl/chat1/notify.avdl
+++ b/protocol/avdl/chat1/notify.avdl
@@ -2,7 +2,7 @@
 
 protocol NotifyChat {
 
-  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
+  import idl "../keybase1" as keybase1;
 
   enum ChatActivitySource {
     LOCAL_0,

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -2,8 +2,8 @@
 @compression_type("gzip")
 protocol remote {
 
-  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
-  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
+  import idl "../gregor1" as gregor1;
+  import idl "../keybase1" as keybase1;
 
   record MessageBoxed {
     // This was not present in most V1 messages.
@@ -339,7 +339,7 @@ protocol remote {
   array<ExternalAPIKey> getExternalAPIKeys(array<ExternalAPIKeyTyp> typs);
 
   // Bot commands
-  @typedef("uint64") @lint("ignore") record CommandConvVers {} 
+  @typedef("uint64") @lint("ignore") record CommandConvVers {}
   record RemoteBotCommandsAdvertisementPublic {
     ConversationID convID;
   }
@@ -366,10 +366,10 @@ protocol remote {
   }
   record ClearBotCommandsRes {
     union { null, RateLimit } rateLimit;
-  } 
+  }
   AdvertiseBotCommandsRes advertiseBotCommands(array<RemoteBotCommandsAdvertisement> ads);
   ClearBotCommandsRes clearBotCommands();
-  
+
   enum BotInfoResponseTyp {
     UPTODATE_0,
     INFO_1
@@ -377,12 +377,12 @@ protocol remote {
   variant BotInfoResponse switch (BotInfoResponseTyp typ) {
     case UPTODATE: void;
     case INFO: BotInfo;
-  } 
+  }
   record GetBotInfoRes {
     BotInfoResponse response;
     union { null, RateLimit } rateLimit;
   }
   @typedef("bytes") record BotInfoHash {}
   GetBotInfoRes getBotInfo(ConversationID convID, BotInfoHash infoHash);
-  
+
 }

--- a/protocol/avdl/keybase1/account.avdl
+++ b/protocol/avdl/keybase1/account.avdl
@@ -2,7 +2,7 @@
 @namespace("keybase.1")
 protocol account {
   import idl "passphrase_common.avdl";
-  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+  import idl "../gregor1" as gregor1;
 
   /**
     Change the passphrase from old to new. If old isn't set, and force is false,

--- a/protocol/avdl/keybase1/gregor.avdl
+++ b/protocol/avdl/keybase1/gregor.avdl
@@ -1,7 +1,7 @@
 
 @namespace("keybase.1")
 protocol gregor {
-  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+  import idl "../gregor1" as gregor1;
   gregor1.State getState();
   gregor1.MsgID injectItem(string cat, string body, gregor1.TimeOrOffset dtime);
   void dismissCategory(gregor1.Category category);

--- a/protocol/avdl/keybase1/gregor_ui.avdl
+++ b/protocol/avdl/keybase1/gregor_ui.avdl
@@ -1,7 +1,7 @@
 
 @namespace("keybase.1")
 protocol gregorUI {
-  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+  import idl "../gregor1" as gregor1;
 
   enum PushReason {
     NONE_0,

--- a/protocol/avdl/keybase1/notify_badges.avdl
+++ b/protocol/avdl/keybase1/notify_badges.avdl
@@ -1,7 +1,7 @@
 @namespace("keybase.1")
 protocol NotifyBadges {
   import idl "common.avdl";
-  import idl "github.com/keybase/client/go/protocol/gregor1" as gregor1;
+  import idl "../gregor1" as gregor1;
 
   @typedef("bytes")  record ChatConversationID {}
 

--- a/protocol/avdl/stellar1/bundle.avdl
+++ b/protocol/avdl/stellar1/bundle.avdl
@@ -1,7 +1,7 @@
 @namespace("stellar.1")
 protocol bundle {
   import idl "common.avdl";
-  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
+  import idl "../keybase1" as keybase1;
 
   @typedef("uint64") @lint("ignore") record BundleRevision {}
 

--- a/protocol/avdl/stellar1/common.avdl
+++ b/protocol/avdl/stellar1/common.avdl
@@ -1,6 +1,6 @@
 @namespace("stellar.1")
 protocol common {
-  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
+  import idl "../keybase1" as keybase1;
 
   @typedef("string") record AccountID {}
   @typedef("string") record SecretKey {}

--- a/protocol/avdl/stellar1/remote.avdl
+++ b/protocol/avdl/stellar1/remote.avdl
@@ -1,7 +1,7 @@
 @namespace("stellar.1")
 protocol remote {
 
-  import idl "github.com/keybase/client/go/protocol/keybase1" as keybase1;
+  import idl "../keybase1" as keybase1;
   import idl "common.avdl";
 
   @typedef("string") record ChatConversationID {}

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -2,17 +2,17 @@
   "protocol": "chatUi",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/stellar1",
+      "path": "../stellar1",
       "type": "idl",
       "import_as": "stellar1"
     },

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -2,12 +2,12 @@
   "protocol": "common",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     }

--- a/protocol/json/chat1/gregor.json
+++ b/protocol/json/chat1/gregor.json
@@ -2,12 +2,12 @@
   "protocol": "gregor",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     }

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2,17 +2,17 @@
   "protocol": "local",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/stellar1",
+      "path": "../stellar1",
       "type": "idl",
       "import_as": "stellar1"
     },

--- a/protocol/json/chat1/notify.json
+++ b/protocol/json/chat1/notify.json
@@ -2,7 +2,7 @@
   "protocol": "NotifyChat",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     }

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -2,12 +2,12 @@
   "protocol": "remote",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     }

--- a/protocol/json/keybase1/account.json
+++ b/protocol/json/keybase1/account.json
@@ -6,7 +6,7 @@
       "type": "idl"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     }

--- a/protocol/json/keybase1/gregor.json
+++ b/protocol/json/keybase1/gregor.json
@@ -2,7 +2,7 @@
   "protocol": "gregor",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     }

--- a/protocol/json/keybase1/gregor_ui.json
+++ b/protocol/json/keybase1/gregor_ui.json
@@ -2,7 +2,7 @@
   "protocol": "gregorUI",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     }

--- a/protocol/json/keybase1/notify_badges.json
+++ b/protocol/json/keybase1/notify_badges.json
@@ -6,7 +6,7 @@
       "type": "idl"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/gregor1",
+      "path": "../gregor1",
       "type": "idl",
       "import_as": "gregor1"
     }

--- a/protocol/json/stellar1/bundle.json
+++ b/protocol/json/stellar1/bundle.json
@@ -6,7 +6,7 @@
       "type": "idl"
     },
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     }

--- a/protocol/json/stellar1/common.json
+++ b/protocol/json/stellar1/common.json
@@ -2,7 +2,7 @@
   "protocol": "common",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     }

--- a/protocol/json/stellar1/remote.json
+++ b/protocol/json/stellar1/remote.json
@@ -2,7 +2,7 @@
   "protocol": "remote",
   "imports": [
     {
-      "path": "github.com/keybase/client/go/protocol/keybase1",
+      "path": "../keybase1",
       "type": "idl",
       "import_as": "keybase1"
     },


### PR DESCRIPTION
Replaces our long GOPATH imports with relative imports. Depends on keybase/node-avdl-compiler#31

Note that no Go files are modified by this change as the compiler resolves relative imports in Go using the user's GOPATH as a base.