### PR TITLE
osx: bump installer and helper versions

### DIFF
--- a/osx/Helper/Info.plist
+++ b/osx/Helper/Info.plist
@@ -9,11 +9,11 @@
 	<key>CFBundleName</key>
 	<string>Helper</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.41</string>
+	<string>1.0.43</string>
 	<key>KBBuild</key>
 	<string>3</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.41</string>
+	<string>1.0.43</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = &quot;99229SGT5K&quot;) and (identifier &quot;keybase.Installer2&quot; or identifier &quot;keybase.Keybase&quot;)</string>

--- a/osx/Installer/Info.plist
+++ b/osx/Installer/Info.plist
@@ -15,19 +15,19 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.78</string>
+	<string>1.1.79</string>
 	<key>CFBundleSignature</key>
 	<string>KEYB</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.78</string>
+	<string>1.1.79</string>
 	<key>KBFuseBuild</key>
 	<string>3.10.0</string>
 	<key>KBFuseVersion</key>
 	<string>3.10.0</string>
 	<key>KBHelperBuild</key>
-	<string>1.0.42</string>
+	<string>1.0.43</string>
 	<key>KBHelperVersion</key>
-	<string>1.0.42</string>
+	<string>1.0.43</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/packaging/desktop/kbfuse.sh
+++ b/packaging/desktop/kbfuse.sh
@@ -15,7 +15,7 @@ cd $dir
 client_dir="$dir/../.."
 fuse_dir="$client_dir/osx/Fuse"
 tmp_dir="/tmp/desktop-kbfuse"
-installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.77-darwin.tgz"
+installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.79-darwin.tgz"
 
 if [ "$EUID" -ne 0 ]; then
   echo "Please run as root"

--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -92,7 +92,7 @@ shared_support_dir="$out_dir/Keybase.app/Contents/SharedSupport"
 resources_dir="$out_dir/Keybase.app/Contents/Resources/"
 
 # The KeybaseInstaller.app installs KBFuse, keybase.Helper, services and CLI via a native app
-installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.78-darwin.tgz"
+installer_url="https://prerelease.keybase.io/darwin-package/KeybaseInstaller-1.1.79-darwin.tgz"
 # KeybaseUpdater.app is the native updater UI (prompt dialogs)
 updater_url="https://prerelease.keybase.io/darwin-package/KeybaseUpdater-1.0.7-darwin.tgz"
 


### PR DESCRIPTION
The previous helper version wasn't updated in an important plist file.