### PR TITLE
fix style overriding in markdown-memo

### DIFF
--- a/shared/styles/index.native.tsx
+++ b/shared/styles/index.native.tsx
@@ -1,6 +1,5 @@
 import {StyleSheet, Dimensions} from 'react-native'
 import * as iPhoneXHelper from 'react-native-iphone-x-helper'
-import {isEmpty} from 'lodash-es'
 import {isIOS} from '../constants/platform'
 import globalColors from './colors'
 import styleSheetCreateProxy from './style-sheet-proxy'
@@ -58,25 +57,10 @@ export const hairlineWidth = StyleSheet.hairlineWidth
 // @ts-ignore TODO fix native styles
 export const styleSheetCreate = obj => styleSheetCreateProxy(obj, o => StyleSheet.create(o))
 export {isDarkMode} from './dark-mode'
-
-export const collapseStyles = (styles: ReadonlyArray<CollapsibleStyle>): Object | undefined | null => {
-  // fast path for a single style that passes. Often we do stuff like
-  // collapseStyle([styles.myStyle, this.props.something && {backgroundColor: 'red'}]), so in the false
-  // case we can just take styles.myStyle and not render thrash
-  const valid = styles.filter(Boolean)
-  if (valid.length === 1) {
-    const s = valid[0]
-    if (typeof s === 'object') {
-      return s as Object
-    }
-  }
-
-  const flattenedStyles = styles.reduce(
-    (a: Array<CollapsibleStyle>, e: CollapsibleStyle) => a.concat(e),
-    []
-  ) as Array<Object | null | false>
-  const style = flattenedStyles.reduce<Object>((o, e) => Object.assign(o, e), {})
-  return isEmpty(style) ? undefined : style
+export const collapseStyles = (
+  styles: ReadonlyArray<CollapsibleStyle>
+): ReadonlyArray<Object | null | false | void> => {
+  return styles
 }
 export const transition = () => ({})
 export const backgroundURL = () => ({})

--- a/shared/styles/index.native.tsx
+++ b/shared/styles/index.native.tsx
@@ -1,5 +1,6 @@
 import {StyleSheet, Dimensions} from 'react-native'
 import * as iPhoneXHelper from 'react-native-iphone-x-helper'
+import {isEmpty} from 'lodash-es'
 import {isIOS} from '../constants/platform'
 import globalColors from './colors'
 import styleSheetCreateProxy from './style-sheet-proxy'
@@ -57,10 +58,25 @@ export const hairlineWidth = StyleSheet.hairlineWidth
 // @ts-ignore TODO fix native styles
 export const styleSheetCreate = obj => styleSheetCreateProxy(obj, o => StyleSheet.create(o))
 export {isDarkMode} from './dark-mode'
-export const collapseStyles = (
-  styles: ReadonlyArray<CollapsibleStyle>
-): ReadonlyArray<Object | null | false | void> => {
-  return styles
+
+export const collapseStyles = (styles: ReadonlyArray<CollapsibleStyle>): Object | undefined | null => {
+  // fast path for a single style that passes. Often we do stuff like
+  // collapseStyle([styles.myStyle, this.props.something && {backgroundColor: 'red'}]), so in the false
+  // case we can just take styles.myStyle and not render thrash
+  const valid = styles.filter(Boolean)
+  if (valid.length === 1) {
+    const s = valid[0]
+    if (typeof s === 'object') {
+      return s as Object
+    }
+  }
+
+  const flattenedStyles = styles.reduce(
+    (a: Array<CollapsibleStyle>, e: CollapsibleStyle) => a.concat(e),
+    []
+  ) as Array<Object | null | false>
+  const style = flattenedStyles.reduce<Object>((o, e) => Object.assign(o, e), {})
+  return isEmpty(style) ? undefined : style
 }
 export const transition = () => ({})
 export const backgroundURL = () => ({})

--- a/shared/wallets/common/markdown-memo.tsx
+++ b/shared/wallets/common/markdown-memo.tsx
@@ -4,7 +4,7 @@ import * as Styles from '../../styles'
 import {StyleOverride} from '../../common-adapters/markdown'
 import {isMobile} from '../../constants/platform'
 
-const styleOverride = Styles.styleSheetCreate({
+const styleOverride: StyleOverride = {
   del: {
     color: Styles.globalColors.black,
   },
@@ -20,7 +20,7 @@ const styleOverride = Styles.styleSheetCreate({
   strong: {
     color: Styles.globalColors.black,
   },
-})
+}
 
 type Props = {
   memo: string
@@ -40,7 +40,7 @@ const MarkdownMemo = (props: Props) =>
       {!props.hideDivider && <Kb.Divider vertical={true} style={styles.quoteMarker} />}
       <Kb.Markdown
         style={styles.memo}
-        styleOverride={Styles.collapseStyles([isMobile ? styleOverride : undefined, props.styleOverride])}
+        styleOverride={{...(isMobile ? styleOverride : undefined), ...props.styleOverride}}
         allowFontScaling={true}
       >
         {props.memo}

--- a/shared/wallets/common/markdown-memo.tsx
+++ b/shared/wallets/common/markdown-memo.tsx
@@ -40,7 +40,10 @@ const MarkdownMemo = (props: Props) =>
       {!props.hideDivider && <Kb.Divider vertical={true} style={styles.quoteMarker} />}
       <Kb.Markdown
         style={styles.memo}
-        styleOverride={{...(isMobile ? styleOverride : undefined), ...props.styleOverride}}
+        styleOverride={{
+          ...(isMobile ? styleOverride : {}),
+          ...props.styleOverride,
+        }}
         allowFontScaling={true}
       >
         {props.memo}


### PR DESCRIPTION
the bug here was that style overriding wasn't actually working on mobile in the wallet transaction markdown memo (when it's an airdrop payment, the memo on the payment is supposed to be purple). it was purple on desktop but not mobile. 

