### PR TITLE
Do not validateImpTeamname in IMPTEAMNATIVE

### DIFF
--- a/go/chat/sbs_test.go
+++ b/go/chat/sbs_test.go
@@ -128,13 +128,6 @@ type sbsTestCase struct {
 }
 
 func runChatSBSScenario(t *testing.T, testCase sbsTestCase) {
-	//runChatSBSScenarioWithRevoke(t, testCase, false /* shouldRevoke */)
-	runChatSBSScenarioWithRevoke(t, testCase, true /* shouldRevoke */)
-}
-
-func runChatSBSScenarioWithRevoke(t *testing.T, testCase sbsTestCase, shouldRevoke bool) {
-	t.Logf("Starting runChatSBSScenarioWithRevoke shouldRevoke=%t", shouldRevoke)
-
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		runWithEphemeral(t, mt, func(ephemeralLifetime *gregor1.DurationSec) {
 			// Only run this test for imp teams

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -268,9 +268,6 @@ func (t *TeamLoader) loadTeam(ctx context.Context, tlfID chat1.TLFID,
 		if team, err = teams.Load(ctx, t.G(), ltarg(teamID)); err != nil {
 			return team, err
 		}
-		if err = t.validateImpTeamname(ctx, tlfName, public, team); err != nil {
-			return team, err
-		}
 		return team, nil
 	case chat1.ConversationMembersType_IMPTEAMUPGRADE:
 		teamID, err := tlfIDToTeamID.Lookup(mctx, tlfID, t.G().API)

--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -304,6 +304,8 @@ func (t *TeamLoader) loadTeam(ctx context.Context, tlfID chat1.TLFID,
 				return team, err
 			}
 		}
+		// In upgraded implicit teams, make sure to check that tlfName matches
+		// team display name.
 		if err = t.validateImpTeamname(ctx, tlfName, public, team); err != nil {
 			return team, err
 		}


### PR DESCRIPTION
This fixes not being able to unbox chat messages if chat started as an SBS conversation, which was then resolved, but later the SBS-ed in user revoked the SBS proof to start convo. Chat messages from before SBS-resolution would be unboxable because chat subsystem would not be able to verify conversation display name. These messages would still hold display name with SBS assertion, but since this assertion no longer resolves to that user, it will not match team's current display name anymore.