### PR TITLE
common-adapters (G-Q) dark mode support

### DIFF
--- a/shared/common-adapters/header-hoc/index.desktop.tsx
+++ b/shared/common-adapters/header-hoc/index.desktop.tsx
@@ -126,7 +126,7 @@ const _titleStyle = {
   top: 0,
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   action: Styles.platformStyles({
     common: {
       opacity: 1,
@@ -155,6 +155,6 @@ const styles = Styles.styleSheetCreate({
       paddingLeft: Styles.globalMargins.tiny,
     },
   }),
-})
+}))
 
 export default HeaderHoc

--- a/shared/common-adapters/header-hoc/index.native.tsx
+++ b/shared/common-adapters/header-hoc/index.native.tsx
@@ -242,7 +242,7 @@ function HeaderHoc<P extends {}>(WrappedComponent: React.ComponentType<P>) {
 // If layout is changed here, please make sure the Files header is updated as
 // well to match this. fs/nav-header/mobile-header.js
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   action: Styles.platformStyles({
     common: {
       opacity: 1,
@@ -349,6 +349,6 @@ const styles = Styles.styleSheetCreate({
   titleTextContainer: {
     ...Styles.globalStyles.fillAbsolute,
   },
-})
+}))
 
 export default HeaderHoc

--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -202,10 +202,10 @@ export function castPlatformStyles(styles: any) {
   return Shared.castPlatformStyles(styles)
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   // Needed because otherwise the containing box doesn't calculate the size of
   // the inner span (incl padding) properly
   flex: {display: 'flex'},
-})
+}))
 
 export default Icon

--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -8,8 +8,6 @@ import {resolveImageAsURL} from '../desktop/app/resolve-root.desktop'
 import {invert} from 'lodash-es'
 import {Props, IconType} from './icon'
 
-const invertedColors = invert(Styles.globalColors)
-
 class Icon extends Component<Props, void> {
   static defaultProps = {
     sizeType: 'Default',
@@ -110,6 +108,8 @@ class Icon extends Component<Props, void> {
           hoverColor: 'inherit',
         }
       } else {
+        // invert the colors here so it reflects the colors in current theme
+        const invertedColors = invert(Styles.globalColors)
         const hoverColorName = this.props.onClick ? invertedColors[hoverColor] : null
         hoverStyleName = hoverColorName ? `hover_color_${hoverColorName}` : ''
         const colorName = invertedColors[color]

--- a/shared/common-adapters/icon.native.tsx
+++ b/shared/common-adapters/icon.native.tsx
@@ -224,12 +224,12 @@ export function castPlatformStyles(styles: any) {
   return Shared.castPlatformStyles(styles)
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   text: {
     color: Styles.globalColors.black_50, // MUST set this or it can be inherited from outside text
     fontFamily: 'kb',
     fontWeight: 'normal', // MUST set this or it can be inherited from outside text
   },
-})
+}))
 
 export default Icon

--- a/shared/common-adapters/icon.shared.tsx
+++ b/shared/common-adapters/icon.shared.tsx
@@ -1,6 +1,7 @@
 import * as Styles from '../styles'
 import {IconType, SizeType} from './icon'
 import {iconMeta} from './icon.constants'
+import './icon.css'
 
 export function defaultColor(type: IconType): string | null {
   switch (type) {

--- a/shared/common-adapters/info-note.tsx
+++ b/shared/common-adapters/info-note.tsx
@@ -28,10 +28,10 @@ const InfoNote = (props: Props) => (
   </Box2>
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   alignCenter: {
     alignItems: 'center',
   },
-})
+}))
 
 export default InfoNote

--- a/shared/common-adapters/input.css
+++ b/shared/common-adapters/input.css
@@ -1,0 +1,4 @@
+.darkMode input,
+.darkMode textarea {
+  background-color: black;
+}

--- a/shared/common-adapters/input.desktop.tsx
+++ b/shared/common-adapters/input.desktop.tsx
@@ -389,24 +389,6 @@ const _bodyTextStyle: any = getTextStyle('Body')
 const _bodySmallTextStyle: any = getTextStyle('BodySmall')
 
 const styles = Styles.styleSheetCreate(() => ({
-  floatingStyle: Styles.platformStyles({
-    isElectron: {
-      color: Styles.globalColors.blueDark,
-      display: 'block',
-      minHeight: _bodySmallTextStyle.lineHeight,
-    },
-  }),
-  errorStyle: {
-    marginTop: Styles.globalMargins.xtiny,
-    width: '100%',
-  },
-  smallLabel: {
-    ...Styles.globalStyles.fontSemibold,
-    color: Styles.globalColors.blueDark,
-    fontSize: _bodySmallTextStyle.fontSize,
-    lineHeight: _lineHeight,
-    marginRight: 8,
-  },
   commonInput: {
     ...Styles.globalStyles.fontSemibold,
     backgroundColor: Styles.globalColors.transparent,
@@ -415,18 +397,36 @@ const styles = Styles.styleSheetCreate(() => ({
     flex: 1,
     outlineWidth: 0,
   },
-  commonInputSmall: {
-    fontSize: _bodyTextStyle.fontSize,
-    fontWeight: _bodyTextStyle.fontWeight,
-    lineHeight: _bodyTextStyle.lineHeight,
-    textAlign: 'left',
-  },
   commonInputRegular: {
     fontSize: _headerTextStyle.fontSize,
     fontWeight: _headerTextStyle.fontWeight,
     lineHeight: _headerTextStyle.lineHeight,
     minWidth: 333,
     textAlign: 'center',
+  },
+  commonInputSmall: {
+    fontSize: _bodyTextStyle.fontSize,
+    fontWeight: _bodyTextStyle.fontWeight,
+    lineHeight: _bodyTextStyle.lineHeight,
+    textAlign: 'left',
+  },
+  errorStyle: {
+    marginTop: Styles.globalMargins.xtiny,
+    width: '100%',
+  },
+  floatingStyle: Styles.platformStyles({
+    isElectron: {
+      color: Styles.globalColors.blueDark,
+      display: 'block',
+      minHeight: _bodySmallTextStyle.lineHeight,
+    },
+  }),
+  smallLabel: {
+    ...Styles.globalStyles.fontSemibold,
+    color: Styles.globalColors.blueDark,
+    fontSize: _bodySmallTextStyle.fontSize,
+    lineHeight: _lineHeight,
+    marginRight: 8,
   },
 }))
 

--- a/shared/common-adapters/input.desktop.tsx
+++ b/shared/common-adapters/input.desktop.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import Box from './box'
 import Text, {getStyle as getTextStyle} from './text.desktop'
-import {collapseStyles, globalStyles, globalColors, globalMargins, platformStyles} from '../styles'
+import * as Styles from '../styles'
 
 import {Props, Selection, TextInfo} from './input'
 import {checkTextInfo} from './input.shared'
@@ -230,14 +230,14 @@ class Input extends React.PureComponent<Props, State> {
 
   _underlineColor = () => {
     if (this.props.hideUnderline) {
-      return globalColors.transparent
+      return Styles.globalColors.transparent
     }
 
     if (this.props.errorText && this.props.errorText.length) {
-      return globalColors.red
+      return Styles.globalColors.red
     }
 
-    return this.state.focused ? globalColors.blue : globalColors.black_10
+    return this.state.focused ? Styles.globalColors.blue : Styles.globalColors.black_10
   }
 
   _rowsToHeight = rows => {
@@ -247,15 +247,15 @@ class Input extends React.PureComponent<Props, State> {
   _containerStyle = underlineColor => {
     return this.props.small
       ? {
-          ...globalStyles.flexBoxRow,
+          ...Styles.globalStyles.flexBoxRow,
           borderBottom: `1px solid ${underlineColor}`,
           width: '100%',
         }
       : {
-          ...globalStyles.flexBoxColumn,
+          ...Styles.globalStyles.flexBoxColumn,
           alignItems: 'center',
-          marginBottom: globalMargins.small,
-          marginTop: globalMargins.small,
+          marginBottom: Styles.globalMargins.small,
+          marginTop: Styles.globalMargins.small,
         }
   }
 
@@ -273,47 +273,30 @@ class Input extends React.PureComponent<Props, State> {
     const defaultRowsToShow = Math.min(2, this.props.rowsMax || 2)
     const containerStyle = this._containerStyle(underlineColor)
 
-    const commonInputStyle: any = {
-      ...globalStyles.fontSemibold,
-      backgroundColor: globalColors.transparent,
-      border: 'none',
-      color: globalColors.black,
-      flex: 1,
-      outlineWidth: 0,
-      ...(this.props.small
-        ? {
-            fontSize: _bodyTextStyle.fontSize,
-            fontWeight: _bodyTextStyle.fontWeight,
-            lineHeight: _bodyTextStyle.lineHeight,
-            textAlign: 'left',
-          }
-        : {
-            borderBottom: `1px solid ${underlineColor}`,
-            fontSize: _headerTextStyle.fontSize,
-            fontWeight: _headerTextStyle.fontWeight,
-            lineHeight: _headerTextStyle.lineHeight,
-            minWidth: 333,
-            textAlign: 'center',
-          }),
-    }
+    const inputStyle = Styles.collapseStyles([
+      styles.commonInput,
+      {
+        height: this.props.small ? 18 : 28,
+        maxWidth: 460,
+      },
+    ])
 
-    const inputStyle = {
-      ...commonInputStyle,
-      height: this.props.small ? 18 : 28,
-      maxWidth: 460,
-    }
-
-    const textareaStyle = {
-      ...commonInputStyle,
-      height: 'initial',
-      minHeight: this._rowsToHeight(this.props.rowsMin || defaultRowsToShow),
-      paddingBottom: 0,
-      paddingTop: 0,
-      resize: 'none',
-      width: '100%',
-      wrap: 'off',
-      ...(this.props.rowsMax ? {maxHeight: this._rowsToHeight(this.props.rowsMax)} : {overflowY: 'hidden'}),
-    }
+    const textareaStyle = Styles.collapseStyles([
+      styles.commonInput,
+      {
+        height: 'initial',
+        minHeight: this._rowsToHeight(this.props.rowsMin || defaultRowsToShow),
+        paddingBottom: 0,
+        paddingTop: 0,
+        resize: 'none',
+        width: '100%',
+        wrap: 'off',
+        ...(this.props.rowsMax ? {maxHeight: this._rowsToHeight(this.props.rowsMax)} : {overflowY: 'hidden'}),
+      },
+      this.props.small
+        ? styles.commonInputSmall
+        : {...styles.commonInputSmall, borderBottom: `1px solid ${underlineColor}`},
+    ])
 
     const value = this._getValue()
 
@@ -350,39 +333,31 @@ class Input extends React.PureComponent<Props, State> {
 
     const singlelineProps = {
       ...commonProps,
-      style: collapseStyles([inputStyle, this.props.inputStyle]),
+      style: Styles.collapseStyles([inputStyle, this.props.inputStyle]),
       type: this._propTypeToSingleLineType(),
     }
 
     const multilineProps = {
       ...commonProps,
       rows: this.props.rowsMin || defaultRowsToShow,
-      style: collapseStyles([textareaStyle, this.props.inputStyle]),
+      style: Styles.collapseStyles([textareaStyle, this.props.inputStyle]),
     }
-
-    const smallLabelStyle = collapseStyles([
-      globalStyles.fontSemibold,
-      {
-        color: globalColors.blueDark,
-        fontSize: _bodySmallTextStyle.fontSize,
-        lineHeight: `${_lineHeight}px`,
-        marginRight: 8,
-      },
-      this.props.smallLabelStyle,
-    ])
 
     const inputRealCSS = `::-webkit-input-placeholder { color: rgba(0,0,0,.4); }`
 
     return (
-      <Box style={collapseStyles([containerStyle, this.props.style])}>
+      <Box style={Styles.collapseStyles([containerStyle, this.props.style])}>
         <style>{inputRealCSS}</style>
         {!this.props.small && !this.props.hideLabel && (
-          <Text center={true} type="BodySmallSemibold" style={_floatingStyle}>
+          <Text center={true} type="BodySmallSemibold" style={styles.floatingStyle}>
             {floatingHintText}
           </Text>
         )}
         {!!this.props.small && !!this.props.smallLabel && !this.props.hideLabel && (
-          <Text type="BodySmall" style={smallLabelStyle}>
+          <Text
+            type="BodySmall"
+            style={Styles.collapseStyles([styles.smallLabel, this.props.smallLabelStyle])}
+          >
             {this.props.smallLabel}
           </Text>
         )}
@@ -398,7 +373,7 @@ class Input extends React.PureComponent<Props, State> {
           <Text
             center={true}
             type="BodySmallError"
-            style={collapseStyles([_errorStyle, this.props.errorStyle])}
+            style={Styles.collapseStyles([styles.errorStyle, this.props.errorStyle])}
           >
             {this.props.errorText}
           </Text>
@@ -413,17 +388,46 @@ const _headerTextStyle: any = getTextStyle('Header')
 const _bodyTextStyle: any = getTextStyle('Body')
 const _bodySmallTextStyle: any = getTextStyle('BodySmall')
 
-const _errorStyle = {
-  marginTop: globalMargins.xtiny,
-  width: '100%',
-}
-
-const _floatingStyle = platformStyles({
-  isElectron: {
-    color: globalColors.blueDark,
-    display: 'block',
-    minHeight: _bodySmallTextStyle.lineHeight,
+const styles = Styles.styleSheetCreate(() => ({
+  floatingStyle: Styles.platformStyles({
+    isElectron: {
+      color: Styles.globalColors.blueDark,
+      display: 'block',
+      minHeight: _bodySmallTextStyle.lineHeight,
+    },
+  }),
+  errorStyle: {
+    marginTop: Styles.globalMargins.xtiny,
+    width: '100%',
   },
-})
+  smallLabel: {
+    ...Styles.globalStyles.fontSemibold,
+    color: Styles.globalColors.blueDark,
+    fontSize: _bodySmallTextStyle.fontSize,
+    lineHeight: _lineHeight,
+    marginRight: 8,
+  },
+  commonInput: {
+    ...Styles.globalStyles.fontSemibold,
+    backgroundColor: Styles.globalColors.transparent,
+    border: 'none',
+    color: Styles.globalColors.black,
+    flex: 1,
+    outlineWidth: 0,
+  },
+  commonInputSmall: {
+    fontSize: _bodyTextStyle.fontSize,
+    fontWeight: _bodyTextStyle.fontWeight,
+    lineHeight: _bodyTextStyle.lineHeight,
+    textAlign: 'left',
+  },
+  commonInputRegular: {
+    fontSize: _headerTextStyle.fontSize,
+    fontWeight: _headerTextStyle.fontWeight,
+    lineHeight: _headerTextStyle.lineHeight,
+    minWidth: 333,
+    textAlign: 'center',
+  },
+}))
 
 export default Input

--- a/shared/common-adapters/input.desktop.tsx
+++ b/shared/common-adapters/input.desktop.tsx
@@ -295,7 +295,7 @@ class Input extends React.PureComponent<Props, State> {
       },
       this.props.small
         ? styles.commonInputSmall
-        : {...styles.commonInputSmall, borderBottom: `1px solid ${underlineColor}`},
+        : {...styles.commonInputRegular, borderBottom: `1px solid ${underlineColor}`},
     ])
 
     const value = this._getValue()

--- a/shared/common-adapters/input.native.tsx
+++ b/shared/common-adapters/input.native.tsx
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 import Box from './box'
 import Text, {getStyle as getTextStyle} from './text.native'
 import {NativeTextInput} from './native-wrappers.native'
-import {collapseStyles, globalStyles, globalColors, styleSheetCreate} from '../styles'
+import * as Styles from '../styles'
 import {isIOS, isAndroid} from '../constants/platform'
 import {TextInput} from 'react-native'
 import {KeyboardType, Props, Selection, TextInfo} from './input'
@@ -187,14 +187,14 @@ class Input extends Component<Props, State> {
 
   _underlineColor = () => {
     if (this.props.hideUnderline) {
-      return globalColors.transparent
+      return Styles.globalColors.transparent
     }
 
     if (this.props.errorText && this.props.errorText.length) {
-      return globalColors.red
+      return Styles.globalColors.red
     }
 
-    return this.state.focused ? globalColors.blue : globalColors.black_10_on_white
+    return this.state.focused ? Styles.globalColors.blue : Styles.globalColors.black_10_on_white
   }
 
   _rowsToHeight = rows => {
@@ -205,15 +205,15 @@ class Input extends Component<Props, State> {
   _containerStyle = underlineColor => {
     return this.props.small
       ? {
-          ...globalStyles.flexBoxRow,
-          backgroundColor: globalColors.fastBlank,
+          ...Styles.globalStyles.flexBoxRow,
+          backgroundColor: Styles.globalColors.fastBlank,
           borderBottomColor: underlineColor,
           borderBottomWidth: 1,
           flex: 1,
         }
       : {
-          ...globalStyles.flexBoxColumn,
-          backgroundColor: globalColors.fastBlank,
+          ...Styles.globalStyles.flexBoxColumn,
+          backgroundColor: Styles.globalColors.fastBlank,
           justifyContent: 'flex-start',
           maxWidth: 400,
         }
@@ -248,19 +248,19 @@ class Input extends Component<Props, State> {
     const containerStyle = this._containerStyle(underlineColor)
 
     const commonInputStyle = {
-      backgroundColor: globalColors.fastBlank,
+      backgroundColor: Styles.globalColors.fastBlank,
       borderWidth: 0,
-      color: globalColors.black_on_white,
+      color: Styles.globalColors.black_on_white,
       flexGrow: 1,
       lineHeight: lineHeight,
       ...(this.props.small
         ? {
-            ...globalStyles.fontRegular,
+            ...Styles.globalStyles.fontRegular,
             fontSize: _bodyTextStyle.fontSize,
             textAlign: 'left',
           }
         : {
-            ...globalStyles.fontSemibold,
+            ...Styles.globalStyles.fontSemibold,
             fontSize: _headerTextStyle.fontSize,
             minWidth: 200,
             textAlign: 'center',
@@ -339,7 +339,7 @@ class Input extends Component<Props, State> {
     const singlelineProps = {
       ...commonProps,
       multiline: false,
-      style: collapseStyles([singlelineStyle, this.props.inputStyle]),
+      style: Styles.collapseStyles([singlelineStyle, this.props.inputStyle]),
     }
 
     const multilineProps = {
@@ -347,7 +347,7 @@ class Input extends Component<Props, State> {
       blurOnSubmit: false,
       multiline: true,
       onContentSizeChange: this._onContentSizeChange,
-      style: collapseStyles([multilineStyle, this.props.inputStyle]),
+      style: Styles.collapseStyles([multilineStyle, this.props.inputStyle]),
       ...(this.props.rowsMax ? {maxHeight: this._rowsToHeight(this.props.rowsMax)} : {}),
     }
 
@@ -361,7 +361,7 @@ class Input extends Component<Props, State> {
         {!!this.props.small && !!this.props.smallLabel && !this.props.hideLabel && (
           <Text
             type="BodySmall"
-            style={collapseStyles([styles.smallLabel, {lineHeight}, this.props.smallLabelStyle])}
+            style={Styles.collapseStyles([styles.smallLabel, {lineHeight}, this.props.smallLabelStyle])}
           >
             {this.props.smallLabel}
           </Text>
@@ -380,7 +380,7 @@ class Input extends Component<Props, State> {
           <Text
             center={true}
             type="BodySmallError"
-            style={collapseStyles([styles.error, this.props.errorStyle])}
+            style={Styles.collapseStyles([styles.error, this.props.errorStyle])}
           >
             {this.props.errorText || ''}
           </Text>
@@ -395,24 +395,24 @@ const _bodyTextStyle: any = getTextStyle('Body')
 const _bodySmallTextStyle: any = getTextStyle('BodySmall')
 const _bodyErrorTextStyle: any = getTextStyle('BodySmallError')
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   error: {minHeight: _bodyErrorTextStyle.lineHeight},
   floating: {
-    color: globalColors.blueDark,
+    color: Styles.globalColors.blueDark,
     marginBottom: 9,
     minHeight: _bodySmallTextStyle.lineHeight,
   },
   inputContainer: {borderBottomWidth: 1},
   inputContainerSmall: {
-    backgroundColor: globalColors.fastBlank,
+    backgroundColor: Styles.globalColors.fastBlank,
     flex: 1,
   },
   smallLabel: {
-    ...globalStyles.fontSemibold,
-    color: globalColors.blueDark,
+    ...Styles.globalStyles.fontSemibold,
+    color: Styles.globalColors.blueDark,
     fontSize: _headerTextStyle.fontSize,
     marginRight: 8,
   },
-})
+}))
 
 export default Input

--- a/shared/common-adapters/input.native.tsx
+++ b/shared/common-adapters/input.native.tsx
@@ -247,41 +247,29 @@ class Input extends Component<Props, State> {
     const defaultRowsToShow = Math.min(2, this.props.rowsMax || 2)
     const containerStyle = this._containerStyle(underlineColor)
 
-    const commonInputStyle = {
-      backgroundColor: Styles.globalColors.fastBlank,
-      borderWidth: 0,
-      color: Styles.globalColors.black_on_white,
-      flexGrow: 1,
-      lineHeight: lineHeight,
-      ...(this.props.small
-        ? {
-            ...Styles.globalStyles.fontRegular,
-            fontSize: _bodyTextStyle.fontSize,
-            textAlign: 'left',
-          }
-        : {
-            ...Styles.globalStyles.fontSemibold,
-            fontSize: _headerTextStyle.fontSize,
-            minWidth: 200,
-            textAlign: 'center',
-          }),
-    }
+    const singlelineStyle = Styles.collapseStyles([
+      styles.commonInput,
+      {
+        lineHeight: lineHeight,
+        maxHeight: lineHeight, // ensure it doesn't grow or shrink
+        minHeight: lineHeight,
+        padding: 0,
+      },
+      this.props.small ? styles.commonInputSmall : styles.commonInputRegular,
+    ])
 
-    const singlelineStyle = {
-      ...commonInputStyle,
-      maxHeight: lineHeight, // ensure it doesn't grow or shrink
-      minHeight: lineHeight,
-      padding: 0,
-    }
-
-    const multilineStyle: any = {
-      ...commonInputStyle,
-      height: undefined,
-      minHeight: this._rowsToHeight(this.props.rowsMin || defaultRowsToShow),
-      paddingBottom: 0,
-      paddingTop: 0,
-      ...(this.props.rowsMax ? {maxHeight: this._rowsToHeight(this.props.rowsMax)} : null),
-    }
+    const multilineStyle: any = Styles.collapseStyles([
+      styles.commonInput,
+      {
+        height: undefined,
+        lineHeight: lineHeight,
+        minHeight: this._rowsToHeight(this.props.rowsMin || defaultRowsToShow),
+        paddingBottom: 0,
+        paddingTop: 0,
+        ...(this.props.rowsMax ? {maxHeight: this._rowsToHeight(this.props.rowsMax)} : null),
+      },
+      this.props.small ? styles.commonInputSmall : styles.commonInputRegular,
+    ])
 
     // Override height if we received an onContentSizeChange() earlier.
     if (isIOS && this.state.height) {
@@ -390,29 +378,48 @@ class Input extends Component<Props, State> {
   }
 }
 
-const _headerTextStyle: any = getTextStyle('Header')
-const _bodyTextStyle: any = getTextStyle('Body')
-const _bodySmallTextStyle: any = getTextStyle('BodySmall')
-const _bodyErrorTextStyle: any = getTextStyle('BodySmallError')
+const styles = Styles.styleSheetCreate(() => {
+  const _headerTextStyle: any = getTextStyle('Header')
+  const _bodyTextStyle: any = getTextStyle('Body')
+  const _bodySmallTextStyle: any = getTextStyle('BodySmall')
+  const _bodyErrorTextStyle: any = getTextStyle('BodySmallError')
+  return {
+    commonInput: {
+      backgroundColor: Styles.globalColors.fastBlank,
+      borderWidth: 0,
+      color: Styles.globalColors.black_on_white,
+      flexGrow: 1,
+    },
+    commonInputRegular: {
+      ...Styles.globalStyles.fontSemibold,
+      fontSize: _headerTextStyle.fontSize,
+      minWidth: 200,
+      textAlign: 'center',
+    },
+    commonInputSmall: {
+      ...Styles.globalStyles.fontRegular,
+      fontSize: _bodyTextStyle.fontSize,
+      textAlign: 'left',
+    },
 
-const styles = Styles.styleSheetCreate(() => ({
-  error: {minHeight: _bodyErrorTextStyle.lineHeight},
-  floating: {
-    color: Styles.globalColors.blueDark,
-    marginBottom: 9,
-    minHeight: _bodySmallTextStyle.lineHeight,
-  },
-  inputContainer: {borderBottomWidth: 1},
-  inputContainerSmall: {
-    backgroundColor: Styles.globalColors.fastBlank,
-    flex: 1,
-  },
-  smallLabel: {
-    ...Styles.globalStyles.fontSemibold,
-    color: Styles.globalColors.blueDark,
-    fontSize: _headerTextStyle.fontSize,
-    marginRight: 8,
-  },
-}))
+    error: {minHeight: _bodyErrorTextStyle.lineHeight},
+    floating: {
+      color: Styles.globalColors.blueDark,
+      marginBottom: 9,
+      minHeight: _bodySmallTextStyle.lineHeight,
+    },
+    inputContainer: {borderBottomWidth: 1},
+    inputContainerSmall: {
+      backgroundColor: Styles.globalColors.fastBlank,
+      flex: 1,
+    },
+    smallLabel: {
+      ...Styles.globalStyles.fontSemibold,
+      color: Styles.globalColors.blueDark,
+      fontSize: _headerTextStyle.fontSize,
+      marginRight: 8,
+    },
+  }
+})
 
 export default Input

--- a/shared/common-adapters/input.shared.tsx
+++ b/shared/common-adapters/input.shared.tsx
@@ -1,5 +1,6 @@
 // TODO: PlainInput depends on this file, so migrate it over if/when Input is deprecated.
 import {TextInfo} from './input'
+import './input.css'
 
 const checkTextInfo = ({text, selection}: TextInfo) => {
   if (selection.end === null) {

--- a/shared/common-adapters/list.desktop.tsx
+++ b/shared/common-adapters/list.desktop.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent} from 'react'
 import ReactList from 'react-list'
-import {globalStyles, collapseStyles, styleSheetCreate, platformStyles} from '../styles'
+import * as Styles from '../styles'
 import logger from '../logger'
 import {throttle, once} from 'lodash-es'
 import {renderElementOrComponentOrNot} from '../util/util'
@@ -93,10 +93,10 @@ class List extends PureComponent<Props<any>> {
 
   render() {
     return (
-      <div style={collapseStyles([styles.outerDiv, this.props.style])}>
-        <div style={globalStyles.fillAbsolute}>
+      <div style={Styles.collapseStyles([styles.outerDiv, this.props.style])}>
+        <div style={Styles.globalStyles.fillAbsolute}>
           <div
-            style={collapseStyles([styles.innerDiv, this.props.contentContainerStyle])}
+            style={Styles.collapseStyles([styles.innerDiv, this.props.contentContainerStyle])}
             onScroll={this.props.onEndReached ? this._onScroll : undefined}
           >
             {renderElementOrComponentOrNot(this.props.ListHeaderComponent)}
@@ -116,8 +116,8 @@ class List extends PureComponent<Props<any>> {
   }
 }
 
-const styles = styleSheetCreate({
-  innerDiv: platformStyles({
+const styles = Styles.styleSheetCreate(() => ({
+  innerDiv: Styles.platformStyles({
     isElectron: {
       height: '100%',
       overflowY: 'auto',
@@ -128,6 +128,6 @@ const styles = styleSheetCreate({
     flexGrow: 1,
     position: 'relative',
   },
-})
+}))
 
 export default List

--- a/shared/common-adapters/list.native.tsx
+++ b/shared/common-adapters/list.native.tsx
@@ -1,7 +1,6 @@
 import React, {PureComponent} from 'react'
 import {FlatList, View} from 'react-native'
-import {globalStyles, collapseStyles, styleSheetCreate} from '../styles'
-
+import * as Styles from '../styles'
 import {Props} from './list'
 
 class List<Item> extends PureComponent<Props<Item>> {
@@ -29,7 +28,7 @@ class List<Item> extends PureComponent<Props<Item>> {
 
   render() {
     return (
-      <View style={collapseStyles([styles.outerView, this.props.style])}>
+      <View style={Styles.collapseStyles([styles.outerView, this.props.style])}>
         {/* need windowSize so iphone 6 doesn't have OOM issues */}
         {/* We can use
             initialScrollIndex={this.props.fixedHeight ? this.props.selectedIndex : undefined}
@@ -39,7 +38,7 @@ class List<Item> extends PureComponent<Props<Item>> {
           rows below, and a touch will cause it to 'snap back' so that the
           end of the list is at the bottom.
        */}
-        <View style={globalStyles.fillAbsolute}>
+        <View style={Styles.globalStyles.fillAbsolute}>
           <FlatList
             bounces={this.props.bounces}
             // @ts-ignore TODO styles
@@ -61,11 +60,11 @@ class List<Item> extends PureComponent<Props<Item>> {
   }
 }
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   outerView: {
     flexGrow: 1,
     position: 'relative',
   },
-})
+}))
 
 export default List

--- a/shared/common-adapters/list.stories.tsx
+++ b/shared/common-adapters/list.stories.tsx
@@ -104,7 +104,7 @@ class PropsChangeTester extends React.PureComponent<
     )
   }
 }
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   listContainer: {
     backgroundColor: Styles.globalColors.red,
     height: 300,
@@ -118,6 +118,6 @@ const styles = Styles.styleSheetCreate({
     backgroundColor: Styles.globalColors.greyDark,
     height: 64,
   },
-})
+}))
 
 export default load

--- a/shared/common-adapters/list2.native.tsx
+++ b/shared/common-adapters/list2.native.tsx
@@ -62,11 +62,11 @@ class List2<T> extends PureComponent<Props<T>> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   outerView: {
     flexGrow: 1,
     position: 'relative',
   },
-})
+}))
 
 export default List2

--- a/shared/common-adapters/loading-line.desktop.tsx
+++ b/shared/common-adapters/loading-line.desktop.tsx
@@ -24,7 +24,7 @@ const LoadingLine = React.memo<{}>(() => {
   )
 })
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     left: 0,
     position: 'absolute',
@@ -35,6 +35,6 @@ const styles = Styles.styleSheetCreate({
     backgroundColor: Styles.globalColors.blue,
     height: 1,
   },
-})
+}))
 
 export default LoadingLine

--- a/shared/common-adapters/loading-line.native.tsx
+++ b/shared/common-adapters/loading-line.native.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {ReAnimated, ReAnimatedEasing} from './mobile.native'
-import {globalColors, styleSheetCreate} from '../styles'
+import * as Styles from '../styles'
 import {Props} from './loading-line'
 
 const R = ReAnimated
@@ -53,9 +53,9 @@ class LoadingLine extends React.Component<Props> {
   }
 }
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate({
   line: {
-    backgroundColor: globalColors.blue,
+    backgroundColor: Styles.globalColors.blue,
     height: 1,
     position: 'absolute',
     width: '100%',

--- a/shared/common-adapters/markdown/shared.tsx
+++ b/shared/common-adapters/markdown/shared.tsx
@@ -365,12 +365,12 @@ class SimpleMarkdownComponent extends PureComponent<
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   rootWrapper: Styles.platformStyles({
     isElectron: {
       whiteSpace: 'pre',
     },
   }),
-})
+}))
 
 export {SimpleMarkdownComponent, simpleMarkdownParser}

--- a/shared/common-adapters/mention.tsx
+++ b/shared/common-adapters/mention.tsx
@@ -25,7 +25,7 @@ export default ({username, theme, style, allowFontScaling, onClick}: Props) => (
   </Text>
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   follow: {
     backgroundColor: Styles.globalColors.greenLighter,
     borderRadius: 2,
@@ -53,4 +53,4 @@ const styles = Styles.styleSheetCreate({
       display: 'inline-block',
     },
   }),
-})
+}))

--- a/shared/common-adapters/meta.tsx
+++ b/shared/common-adapters/meta.tsx
@@ -1,18 +1,11 @@
 import * as React from 'react'
 import Box from './box'
 import Text from './text'
-import {
-  globalColors,
-  globalStyles,
-  platformStyles,
-  collapseStyles,
-  styleSheetCreate,
-  StylesCrossPlatform,
-} from '../styles'
+import * as Styles from '../styles'
 
 type Props = {
   title: string
-  style?: StylesCrossPlatform
+  style?: Styles.StylesCrossPlatform
   size?: 'Small'
   color?: string
   backgroundColor: string
@@ -22,7 +15,7 @@ type Props = {
 const Meta = (props: Props) => (
   <Box
     pointerEvents="none"
-    style={collapseStyles([
+    style={Styles.collapseStyles([
       styles.container,
       props.backgroundColor && {backgroundColor: props.backgroundColor},
       props.style,
@@ -31,7 +24,7 @@ const Meta = (props: Props) => (
   >
     <Text
       type="BodyTinyBold"
-      style={collapseStyles([
+      style={Styles.collapseStyles([
         styles.text,
         props.color && {color: props.color},
         props.size === 'Small' && styles.textSmall,
@@ -42,9 +35,9 @@ const Meta = (props: Props) => (
   </Box>
 )
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
-    ...globalStyles.flexBoxColumn,
+    ...Styles.globalStyles.flexBoxColumn,
     alignItems: 'center',
     alignSelf: 'flex-start',
     borderRadius: 2,
@@ -55,9 +48,9 @@ const styles = styleSheetCreate({
     paddingLeft: 2,
     paddingRight: 2,
   },
-  text: platformStyles({
+  text: Styles.platformStyles({
     common: {
-      color: globalColors.white,
+      color: Styles.globalColors.white,
       marginBottom: -1,
       marginTop: -1,
     },
@@ -65,7 +58,7 @@ const styles = styleSheetCreate({
       fontSize: 12,
     },
   }),
-  textSmall: platformStyles({
+  textSmall: Styles.platformStyles({
     isElectron: {
       fontSize: 10,
     },
@@ -73,6 +66,6 @@ const styles = styleSheetCreate({
       fontSize: 11,
     },
   }),
-})
+}))
 
 export default Meta

--- a/shared/common-adapters/modal/index.tsx
+++ b/shared/common-adapters/modal/index.tsx
@@ -117,79 +117,81 @@ const Footer = (props: FooterProps & {wide: boolean}) => (
   </Kb.Box2>
 )
 
-const headerCommon = {
-  borderBottomColor: Styles.globalColors.black_10,
-  borderBottomWidth: 1,
-  borderStyle: 'solid' as const,
-}
+const styles = Styles.styleSheetCreate(() => {
+  const headerCommon = {
+    borderBottomColor: Styles.globalColors.black_10,
+    borderBottomWidth: 1,
+    borderStyle: 'solid' as const,
+  }
 
-const styles = Styles.styleSheetCreate(() => ({
-  footer: Styles.platformStyles({
-    common: {
-      ...Styles.padding(Styles.globalMargins.xsmall, Styles.globalMargins.small),
-      minHeight: 56,
+  return {
+    footer: Styles.platformStyles({
+      common: {
+        ...Styles.padding(Styles.globalMargins.xsmall, Styles.globalMargins.small),
+        minHeight: 56,
+      },
+      isElectron: {
+        borderBottomLeftRadius: Styles.borderRadius,
+        borderBottomRightRadius: Styles.borderRadius,
+        overflow: 'hidden',
+      },
+    }),
+    footerBorder: {
+      borderStyle: 'solid',
+      borderTopColor: Styles.globalColors.black_10,
+      borderTopWidth: 1,
     },
-    isElectron: {
-      borderBottomLeftRadius: Styles.borderRadius,
-      borderBottomRightRadius: Styles.borderRadius,
-      overflow: 'hidden',
+    footerWide: {
+      ...Styles.padding(Styles.globalMargins.xsmall, Styles.globalMargins.medium),
     },
-  }),
-  footerBorder: {
-    borderStyle: 'solid',
-    borderTopColor: Styles.globalColors.black_10,
-    borderTopWidth: 1,
-  },
-  footerWide: {
-    ...Styles.padding(Styles.globalMargins.xsmall, Styles.globalMargins.medium),
-  },
-  header: {
-    ...headerCommon,
-    minHeight: 48,
-  },
-  headerCenter: {
-    flexGrow: 1,
-    flexShrink: 1,
-  },
-  headerHideBorder: {
-    borderWidth: 0,
-  },
-  headerLeft: {
-    flexGrow: 0,
-    flexShrink: 0,
-    justifyContent: 'flex-start',
-    paddingLeft: Styles.globalMargins.xsmall,
-    paddingRight: Styles.globalMargins.xsmall,
-  },
-  headerRight: {
-    flexGrow: 0,
-    flexShrink: 0,
-    justifyContent: 'flex-end',
-    paddingLeft: Styles.globalMargins.xsmall,
-    paddingRight: Styles.globalMargins.xsmall,
-  },
-  headerWithIcon: {
-    ...headerCommon,
-    minHeight: 64,
-  },
-  modeDefault: Styles.platformStyles({
-    isElectron: {
-      maxHeight: 560,
-      overflow: 'hidden',
-      width: 400,
+    header: {
+      ...headerCommon,
+      minHeight: 48,
     },
-  }),
-  modeWide: Styles.platformStyles({
-    isElectron: {
-      height: 400,
-      overflow: 'hidden',
-      width: 560,
+    headerCenter: {
+      flexGrow: 1,
+      flexShrink: 1,
     },
-  }),
-  scrollContentContainer: {...Styles.globalStyles.flexBoxColumn, flexGrow: 1, width: '100%'},
-  scrollWide: Styles.platformStyles({
-    isElectron: {...Styles.globalStyles.flexBoxColumn, flex: 1, position: 'relative'},
-  }),
-}))
+    headerHideBorder: {
+      borderWidth: 0,
+    },
+    headerLeft: {
+      flexGrow: 0,
+      flexShrink: 0,
+      justifyContent: 'flex-start',
+      paddingLeft: Styles.globalMargins.xsmall,
+      paddingRight: Styles.globalMargins.xsmall,
+    },
+    headerRight: {
+      flexGrow: 0,
+      flexShrink: 0,
+      justifyContent: 'flex-end',
+      paddingLeft: Styles.globalMargins.xsmall,
+      paddingRight: Styles.globalMargins.xsmall,
+    },
+    headerWithIcon: {
+      ...headerCommon,
+      minHeight: 64,
+    },
+    modeDefault: Styles.platformStyles({
+      isElectron: {
+        maxHeight: 560,
+        overflow: 'hidden',
+        width: 400,
+      },
+    }),
+    modeWide: Styles.platformStyles({
+      isElectron: {
+        height: 400,
+        overflow: 'hidden',
+        width: 560,
+      },
+    }),
+    scrollContentContainer: {...Styles.globalStyles.flexBoxColumn, flexGrow: 1, width: '100%'},
+    scrollWide: Styles.platformStyles({
+      isElectron: {...Styles.globalStyles.flexBoxColumn, flex: 1, position: 'relative'},
+    }),
+  }
+})
 
 export default Modal

--- a/shared/common-adapters/name-with-icon/index.tsx
+++ b/shared/common-adapters/name-with-icon/index.tsx
@@ -199,7 +199,7 @@ const TextOrComponent = (props: {
   return props.val
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   fullWidthText: Styles.platformStyles({
     isElectron: {display: 'unset', whiteSpace: 'nowrap', width: '100%', wordBreak: 'break-all'},
   }),
@@ -244,7 +244,7 @@ const styles = Styles.styleSheetCreate({
       textAlign: 'center',
     },
   }),
-})
+}))
 
 // Get props to pass to subcomponents (Text, Avatar, etc.)
 const getAdapterProps = (

--- a/shared/common-adapters/new-input.tsx
+++ b/shared/common-adapters/new-input.tsx
@@ -3,17 +3,10 @@ import PlainInput, {PropsWithInput} from './plain-input'
 import Box, {Box2} from './box'
 import Icon, {IconType, castPlatformStyles} from './icon'
 import {getStyle as getTextStyle} from './text'
-import {
-  StylesCrossPlatform,
-  collapseStyles,
-  globalColors,
-  globalMargins,
-  platformStyles,
-  styleSheetCreate,
-} from '../styles'
+import * as Styles from '../styles'
 
 export type _Props = {
-  containerStyle?: StylesCrossPlatform
+  containerStyle?: Styles.StylesCrossPlatform
   decoration?: React.ReactNode
   error?: boolean
   hideBorder?: boolean
@@ -55,7 +48,7 @@ class ReflessNewInput extends React.Component<Props & RefProps, State> {
     return (
       <Box2
         direction="horizontal"
-        style={collapseStyles([
+        style={Styles.collapseStyles([
           styles.container,
           this.state.focused && styles.focused,
           this.props.error && styles.error,
@@ -66,7 +59,7 @@ class ReflessNewInput extends React.Component<Props & RefProps, State> {
         {!!this.props.icon && (
           <Box style={styles.icon}>
             <Icon
-              color={globalColors.black_20}
+              color={Styles.globalColors.black_20} // not sure how to make this dynamic
               type={this.props.icon}
               fontSize={textStyle.fontSize}
               style={castPlatformStyles(styles.displayFlex)}
@@ -88,17 +81,17 @@ const NewInput = React.forwardRef<PlainInput, Props>((props, ref) => (
   <ReflessNewInput {...props} forwardedRef={ref} />
 ))
 
-const styles = styleSheetCreate({
-  container: platformStyles({
+const styles = Styles.styleSheetCreate(() => ({
+  container: Styles.platformStyles({
     common: {
       alignItems: 'center',
-      backgroundColor: globalColors.white,
-      borderColor: globalColors.black_10,
+      backgroundColor: Styles.globalColors.white,
+      borderColor: Styles.globalColors.black_10,
       borderRadius: 4,
       borderStyle: 'solid',
       borderWidth: 1,
       margin: 0,
-      padding: globalMargins.xtiny,
+      padding: Styles.globalMargins.xtiny,
     },
     isElectron: {width: '100%'},
   }),
@@ -106,17 +99,17 @@ const styles = styleSheetCreate({
     display: 'flex',
   },
   error: {
-    borderColor: globalColors.red,
+    borderColor: Styles.globalColors.red,
   },
   focused: {
-    borderColor: globalColors.blue,
+    borderColor: Styles.globalColors.blue,
   },
   hideBorder: {
     borderWidth: 0,
   },
   icon: {
-    marginRight: globalMargins.xtiny,
+    marginRight: Styles.globalMargins.xtiny,
   },
-})
+}))
 
 export default NewInput

--- a/shared/common-adapters/new-input.tsx
+++ b/shared/common-adapters/new-input.tsx
@@ -4,6 +4,7 @@ import Box, {Box2} from './box'
 import Icon, {IconType, castPlatformStyles} from './icon'
 import {getStyle as getTextStyle} from './text'
 import * as Styles from '../styles'
+import './input.css'
 
 export type _Props = {
   containerStyle?: Styles.StylesCrossPlatform

--- a/shared/common-adapters/overlay/index.desktop.tsx
+++ b/shared/common-adapters/overlay/index.desktop.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {Box2, FloatingBox} from '..'
 import {Props} from '.'
-import {collapseStyles, desktopStyles, platformStyles, styleSheetCreate} from '../../styles'
+import * as Styles from '../../styles'
 
 const Overlay = (props: Props) => {
   if (Object.prototype.hasOwnProperty.call(props, 'visible') && !props.visible) {
@@ -16,22 +16,22 @@ const Overlay = (props: Props) => {
       positionFallbacks={props.positionFallbacks}
       propagateOutsideClicks={props.propagateOutsideClicks}
     >
-      <Box2 direction="vertical" style={collapseStyles([styles.innerContainer, props.style])}>
+      <Box2 direction="vertical" style={Styles.collapseStyles([styles.innerContainer, props.style])}>
         {props.children}
       </Box2>
     </FloatingBox>
   )
 }
 
-const styles = styleSheetCreate({
-  innerContainer: platformStyles({
+const styles = Styles.styleSheetCreate(() => ({
+  innerContainer: Styles.platformStyles({
     isElectron: {
-      ...desktopStyles.boxShadow,
+      ...Styles.desktopStyles.boxShadow,
       borderRadius: 3,
       overflowX: 'hidden',
       overflowY: 'auto',
     },
   }),
-})
+}))
 
 export default Overlay

--- a/shared/common-adapters/overlay/index.native.tsx
+++ b/shared/common-adapters/overlay/index.native.tsx
@@ -3,7 +3,7 @@ import {NativeTouchableWithoutFeedback} from '../native-wrappers.native'
 import {Box, Box2} from '../box'
 import FloatingBox from '../floating-box'
 import {Props} from '.'
-import {collapseStyles, globalColors, globalStyles, styleSheetCreate} from '../../styles'
+import * as Styles from '../../styles'
 
 const Overlay = (props: Props) => {
   if (Object.prototype.hasOwnProperty.call(props, 'visible') && !props.visible) {
@@ -13,7 +13,7 @@ const Overlay = (props: Props) => {
     <FloatingBox onHidden={() => {}} dest={props.dest} hideKeyboard={true}>
       <Box2
         direction="vertical"
-        style={collapseStyles([styles.container, !!props.color && {color: props.color}])}
+        style={Styles.collapseStyles([styles.container, !!props.color && {color: props.color}])}
       >
         <NativeTouchableWithoutFeedback onPress={props.onHidden}>
           {/* This has to be a `Box` so `TouchableWithoutFeedback`'s touch responders get piped through to the `View` */}
@@ -25,16 +25,16 @@ const Overlay = (props: Props) => {
   )
 }
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
-    ...globalStyles.fillAbsolute,
+    ...Styles.globalStyles.fillAbsolute,
     alignItems: 'stretch',
-    backgroundColor: globalColors.black_50,
+    backgroundColor: Styles.globalColors.black_50,
     justifyContent: 'flex-end',
   },
   touchArea: {
-    ...globalStyles.fillAbsolute,
+    ...Styles.globalStyles.fillAbsolute,
   },
-})
+}))
 
 export default Overlay

--- a/shared/common-adapters/placeholder.tsx
+++ b/shared/common-adapters/placeholder.tsx
@@ -17,13 +17,13 @@ const Placeholder = (props: PlaceholderProps) => (
   />
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   placeholder: {
     backgroundColor: Styles.globalColors.greyLight,
     borderRadius: 5,
     height: 10,
     width: 200,
   },
-})
+}))
 
 export default Placeholder

--- a/shared/common-adapters/plain-input.desktop.tsx
+++ b/shared/common-adapters/plain-input.desktop.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import {getStyle as getTextStyle} from './text.desktop'
-import {collapseStyles, globalColors, styled, styleSheetCreate, platformStyles} from '../styles'
 import {pick} from 'lodash-es'
 import logger from '../logger'
-
 import {_StylesDesktop} from '../styles/css'
 import {InternalProps, TextInfo, Selection} from './plain-input'
 import {checkTextInfo} from './input.shared'
@@ -187,7 +186,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
     return {
       ...this._getCommonProps(),
       rows,
-      style: collapseStyles([
+      style: Styles.collapseStyles([
         styles.noChrome, // noChrome comes before because we want lineHeight set in multiline
         textStyle,
         styles.multiline,
@@ -201,7 +200,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
     const textStyle = getTextStyle(this.props.textType)
     return {
       ...this._getCommonProps(),
-      style: collapseStyles([
+      style: Styles.collapseStyles([
         textStyle,
         styles.noChrome, // noChrome comes after to unset lineHeight in singleline
         this.props.flexable && styles.flexable,
@@ -277,24 +276,24 @@ class PlainInput extends React.PureComponent<InternalProps> {
 // @ts-ignore this type is wrong
 const StyledTextArea = styled.textarea<'textarea', {placeholderColor: any}>(props => ({
   '&::-webkit-inner-spin-button': {WebkitAppearance: 'none', margin: 0},
-  '&::-webkit-input-placeholder': {color: props.placeholderColor || globalColors.black_50},
+  '&::-webkit-input-placeholder': {color: props.placeholderColor || Styles.globalColors.black_50},
   '&::-webkit-outer-spin-button': {WebkitAppearance: 'none', margin: 0},
 }))
 
 // @ts-ignore this type is wrong
 const StyledInput = styled.input<'input', {placeholderColor: any}>(props => ({
   '&::-webkit-inner-spin-button': {WebkitAppearance: 'none', margin: 0},
-  '&::-webkit-input-placeholder': {color: props.placeholderColor || globalColors.black_50},
+  '&::-webkit-input-placeholder': {color: props.placeholderColor || Styles.globalColors.black_50},
   '&::-webkit-outer-spin-button': {WebkitAppearance: 'none', margin: 0},
 }))
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   flexable: {
     flex: 1,
     minWidth: 0,
     width: '100%',
   },
-  multiline: platformStyles({
+  multiline: Styles.platformStyles({
     isElectron: {
       height: 'initial',
       paddingBottom: 0,
@@ -303,13 +302,13 @@ const styles = styleSheetCreate({
       width: '100%',
     },
   }),
-  noChrome: platformStyles({
+  noChrome: Styles.platformStyles({
     isElectron: {
       borderWidth: 0,
       lineHeight: 'unset',
       outline: 'none',
     },
   }),
-})
+}))
 
 export default PlainInput

--- a/shared/common-adapters/plain-input.desktop.tsx
+++ b/shared/common-adapters/plain-input.desktop.tsx
@@ -274,14 +274,14 @@ class PlainInput extends React.PureComponent<InternalProps> {
 }
 
 // @ts-ignore this type is wrong
-const StyledTextArea = styled.textarea<'textarea', {placeholderColor: any}>(props => ({
+const StyledTextArea = Styles.styled.textarea<'textarea', {placeholderColor: any}>(props => ({
   '&::-webkit-inner-spin-button': {WebkitAppearance: 'none', margin: 0},
   '&::-webkit-input-placeholder': {color: props.placeholderColor || Styles.globalColors.black_50},
   '&::-webkit-outer-spin-button': {WebkitAppearance: 'none', margin: 0},
 }))
 
 // @ts-ignore this type is wrong
-const StyledInput = styled.input<'input', {placeholderColor: any}>(props => ({
+const StyledInput = Styles.styled.input<'input', {placeholderColor: any}>(props => ({
   '&::-webkit-inner-spin-button': {WebkitAppearance: 'none', margin: 0},
   '&::-webkit-input-placeholder': {color: props.placeholderColor || Styles.globalColors.black_50},
   '&::-webkit-outer-spin-button': {WebkitAppearance: 'none', margin: 0},

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -259,7 +259,7 @@ class PlainInput extends Component<InternalProps, State> {
   }
 }
 
-const styles = styleSheetCreate({
+const styles = styleSheetCreate(() => ({
   common: {backgroundColor: globalColors.fastBlank, borderWidth: 0, flexGrow: 1},
   multiline: platformStyles({
     isMobile: {
@@ -271,6 +271,6 @@ const styles = styleSheetCreate({
     },
   }),
   singleline: {padding: 0},
-})
+}))
 
 export default PlainInput

--- a/shared/common-adapters/popup-header-text.tsx
+++ b/shared/common-adapters/popup-header-text.tsx
@@ -26,13 +26,13 @@ const PopupHeaderText = (props: HeaderTextProps) => (
   </Text>
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   text: {
     paddingBottom: Styles.globalMargins.tiny,
     paddingLeft: Styles.globalMargins.small,
     paddingRight: Styles.globalMargins.small,
     paddingTop: Styles.globalMargins.tiny,
   },
-})
+}))
 
 export default PopupHeaderText

--- a/shared/common-adapters/progress-indicator.desktop.tsx
+++ b/shared/common-adapters/progress-indicator.desktop.tsx
@@ -15,7 +15,7 @@ const ProgressIndicator = ({white, style, type}: Props) => (
   />
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   huge: {
     height: Styles.globalMargins.xlarge,
     width: Styles.globalMargins.xlarge,
@@ -28,6 +28,6 @@ const styles = Styles.styleSheetCreate({
     height: Styles.globalMargins.medium,
     width: Styles.globalMargins.medium,
   },
-})
+}))
 
 export default ProgressIndicator

--- a/shared/common-adapters/qr-lines.tsx
+++ b/shared/common-adapters/qr-lines.tsx
@@ -40,8 +40,8 @@ const GoodLines = ({color}: {color: Styles.Color}) => {
 const QRScanLines = ({canScan, color}: {canScan: boolean; color?: Styles.Color}) =>
   canScan ? <GoodLines color={color || Styles.globalColors.blue} /> : <BadLines />
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   common: {position: 'absolute'},
-})
+}))
 
 export default QRScanLines

--- a/shared/common-adapters/qr-not-authorized.tsx
+++ b/shared/common-adapters/qr-not-authorized.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react'
 import * as ConfigGen from '../actions/config-gen'
+import * as Styles from '../styles'
 import {namedConnect} from '../util/container'
 import Text from './text'
 import {Box2} from './box'
 import Icon from './icon'
-import {styleSheetCreate, globalColors} from '../styles'
-
 type OwnProps = {}
 
 const QRScanNotAuthorized = ({onOpenSettings}: {onOpenSettings: () => void}) => (
   <Box2 direction="vertical" style={styles.container} gap="tiny">
-    <Icon type="iconfont-camera" color={globalColors.white_40} />
+    <Icon type="iconfont-camera" color={Styles.globalColors.white_40} />
     <Text center={true} type="BodyTiny" style={styles.text}>
       You need to allow access to the camera.
     </Text>
@@ -20,15 +19,15 @@ const QRScanNotAuthorized = ({onOpenSettings}: {onOpenSettings: () => void}) => 
   </Box2>
 )
 
-const styles = styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     alignItems: 'center',
-    backgroundColor: globalColors.black,
+    backgroundColor: Styles.globalColors.black,
     flexGrow: 1,
     justifyContent: 'center',
   },
-  text: {color: globalColors.white_40},
-})
+  text: {color: Styles.globalColors.white_40},
+}))
 
 const mapDispatchToProps = dispatch => ({
   onOpenSettings: () => dispatch(ConfigGen.createOpenAppSettings()),

--- a/shared/common-adapters/qr-scanner.native.tsx
+++ b/shared/common-adapters/qr-scanner.native.tsx
@@ -52,10 +52,10 @@ const QRScanner = (p: Props): React.ReactElement<any> | null => {
   )
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   gettingPermissions: {
     backgroundColor: Styles.globalColors.greyLight,
   },
-})
+}))
 
 export default QRScanner

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -1,5 +1,4 @@
 @import '~emoji-mart/css/emoji-mart.css';
-@import '../../common-adapters/icon.css';
 @import '../../common-adapters/text.css';
 
 /* Reset */

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -226,10 +226,6 @@ body {
   overflow: hidden;
 }
 
-.darkMode input {
-  background-color: black;
-}
-
 #root {
   position: absolute;
   display: flex;


### PR DESCRIPTION
This PR updates the common adapters (G-Q) so they support our dark mode infrastructure. Most of this work is changing calls to `Styles.styleSheetCreate` so they use closures instead of passing a static object. This PR also contains some refactoring, primarily moving imports and styles from `desktop/renderer/style.css` to their own css files and importing them in relevant components.
@keybase/react-hackers 
@keybase/hotpotatosquad 