### PR TITLE
Clear read messages from notification msgCache

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -213,6 +213,11 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
                 }
                 break;
                 case "chat.readmessage": {
+                    String convID = bundle.getString("c");
+                    // Clear the cache of msgs for this conv id
+                    if (msgCache.containsKey(convID)) {
+                        msgCache.put(convID, new SmallMsgRingBuffer());
+                    }
                     // Cancel any push notifications.
                     NotificationManagerCompat notificationManager = NotificationManagerCompat.from(getApplicationContext());
                     notificationManager.cancelAll();


### PR DESCRIPTION
Clears the read messages from your message cache notification so they don't keep showing up in the notification. @keybase/react-hackers 