### PR TITLE
Fix edit profile img on Android

### DIFF
--- a/shared/profile/edit-avatar/index.native.tsx
+++ b/shared/profile/edit-avatar/index.native.tsx
@@ -75,6 +75,8 @@ class AvatarUpload extends React.Component<Props> {
   }
 
   render() {
+    const uri =
+      this.props.image && this.props.image.cancelled === false ? parseUri(this.props.image, true) : null
     return (
       <Kb.StandardScreen
         onCancel={this.props.onClose}
@@ -114,15 +116,9 @@ class AvatarUpload extends React.Component<Props> {
                   : null
               }
             >
-              <Kb.NativeFastImage
-                resizeMode="cover"
-                source={{
-                  uri: `${
-                    this.props.image && this.props.image.cancelled === false ? parseUri(this.props.image) : ''
-                  }`,
-                }}
-                style={this._imageDimensions()}
-              />
+              {uri && (
+                <Kb.NativeFastImage resizeMode="cover" source={{uri}} style={this._imageDimensions()} />
+              )}
             </Kb.ZoomableBox>
           </Kb.Box>
           <Kb.ButtonBar direction="column">

--- a/shared/util/expo-image-picker.tsx
+++ b/shared/util/expo-image-picker.tsx
@@ -2,7 +2,10 @@ import {isIOS} from '../constants/platform'
 import * as ImagePicker from 'expo-image-picker'
 import * as Permissions from 'expo-permissions'
 
-export const parseUri = (result: {uri: string}): string => {
+export const parseUri = (result: {uri: string}, withPrefix: boolean = false): string => {
+  if (withPrefix) {
+    return result.uri
+  }
   return isIOS ? result.uri.replace('file://', '') : result.uri.replace('file:', '')
 }
 


### PR DESCRIPTION
@keybase/react-hackers This crashed on android because it was missing the `file://` prefix for the uri.
