### PR TITLE
common-adapters (R-Z) dark mode support

### DIFF
--- a/shared/common-adapters/copyable-text.desktop.tsx
+++ b/shared/common-adapters/copyable-text.desktop.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import {globalStyles, globalColors, platformStyles} from '../styles'
+import * as Styles from '../styles'
 import {Props} from './copyable-text'
 
 const CopyableText = ({value, style}: Props) => {
   return (
     <textarea
-      style={{...styleBase, ...style}}
+      style={Styles.collapseStyles([styles.base, style])}
       readOnly={true}
       value={value}
       onClick={e => {
@@ -17,27 +17,29 @@ const CopyableText = ({value, style}: Props) => {
   )
 }
 
-const styleBase = platformStyles({
-  common: {
-    ...globalStyles.fontTerminal,
-    alignItems: 'flex-start',
-    backgroundColor: globalColors.greyLight,
-    borderRadius: 3,
-    color: globalColors.black,
-    fontSize: 13,
-    padding: 10,
-    textAlign: 'left',
-  },
-  isElectron: {
-    border: `solid 1px ${globalColors.black_10}`,
-    justifyContent: 'stretch',
-    lineHeight: '17px',
-    overflowX: 'hidden',
-    overflowY: 'auto',
-    resize: 'none',
-    whiteSpace: 'pre-wrap',
-    wordWrap: 'break-word',
-  },
-})
+const styles = Styles.styleSheetCreate(() => ({
+  base: Styles.platformStyles({
+    common: {
+      ...Styles.globalStyles.fontTerminal,
+      alignItems: 'flex-start',
+      backgroundColor: Styles.globalColors.greyLight,
+      borderRadius: 3,
+      color: Styles.globalColors.black,
+      fontSize: 13,
+      padding: 10,
+      textAlign: 'left',
+    },
+    isElectron: {
+      border: `solid 1px ${Styles.globalColors.black_10}`,
+      justifyContent: 'stretch',
+      lineHeight: '17px',
+      overflowX: 'hidden',
+      overflowY: 'auto',
+      resize: 'none',
+      whiteSpace: 'pre-wrap',
+      wordWrap: 'break-word',
+    },
+  }),
+}))
 
 export default CopyableText

--- a/shared/common-adapters/markdown/service-decoration.tsx
+++ b/shared/common-adapters/markdown/service-decoration.tsx
@@ -31,7 +31,10 @@ type KeybaseLinkProps = {
 
 const KeybaseLink = (props: KeybaseLinkProps) => {
   const dispatch = Container.useDispatch()
-  const onClick = React.useCallback(() => dispatch(DeeplinksGen.createLink({link: props.link})), [dispatch])
+  const onClick = React.useCallback(() => dispatch(DeeplinksGen.createLink({link: props.link})), [
+    dispatch,
+    props.link,
+  ])
 
   return (
     <Text

--- a/shared/common-adapters/radio-button.desktop.tsx
+++ b/shared/common-adapters/radio-button.desktop.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import Text from './text'
 import {Props} from './radio-button'
-import {globalStyles, globalColors, transition, desktopStyles, styled} from '../styles'
+
+const Kb = {
+  Text,
+}
 
 export const RADIOBUTTON_SIZE = 14
 export const RADIOBUTTON_MARGIN = 8
 
 // @ts-ignore this type is wrong
-const StyledRadio = styled.div(
+const StyledRadio = Styles.styled.div(
   {
-    ...transition('background'),
+    ...Styles.transition('background'),
     // @ts-ignore
     borderRadius: '100%',
     height: RADIOBUTTON_SIZE,
@@ -18,9 +22,9 @@ const StyledRadio = styled.div(
     width: RADIOBUTTON_SIZE,
   },
   ({disabled, selected}) => ({
-    '&:hover': {border: (selected || !disabled) && `solid 1px ${globalColors.blue}`},
-    backgroundColor: selected ? globalColors.blue : 'inherit',
-    border: `solid 1px ${globalColors.black_20}`,
+    '&:hover': {border: (selected || !disabled) && `solid 1px ${Styles.globalColors.blue}`},
+    backgroundColor: selected ? Styles.globalColors.blue : 'inherit',
+    border: `solid 1px ${Styles.globalColors.black_20}`,
     opacity: disabled ? 0.4 : 1,
   })
 )
@@ -28,35 +32,36 @@ const StyledRadio = styled.div(
 const RadioButton = ({disabled, label, onSelect, selected, style}: Props) => (
   <div
     // @ts-ignore clash between StylesCrossPlatform and React.CSSProperties
-    style={{...styleContainer, ...(disabled ? {} : desktopStyles.clickable), ...style}}
+    style={{...styles.container, ...(disabled ? {} : Styles.desktopStyles.clickable), ...style}}
     onClick={disabled ? undefined : () => onSelect(!selected)}
   >
     <StyledRadio disabled={disabled} selected={selected}>
       <div
         // @ts-ignore clash between StylesCrossPlatform and React.CSSProperties
-        style={styleRadio}
+        style={styles.radio}
       />
     </StyledRadio>
-    <Text type="Body" style={{color: globalColors.black}}>
+    <Kb.Text type="Body" style={{color: Styles.globalColors.black}}>
       {label}
-    </Text>
+    </Kb.Text>
   </div>
 )
 
-const styleContainer = {
-  ...globalStyles.flexBoxRow,
-  alignItems: 'center',
-}
-
-const styleRadio = {
-  ...transition('opacity'),
-  border: `solid 3px ${globalColors.white}`,
-  borderRadius: '100%',
-  color: globalColors.white,
-  hoverColor: globalColors.white,
-  left: 3,
-  position: 'absolute',
-  top: 3,
-}
+const styles = Styles.styleSheetCreate(() => ({
+  container: {
+    ...Styles.globalStyles.flexBoxRow,
+    alignItems: 'center',
+  },
+  radio: {
+    ...Styles.transition('opacity'),
+    border: `solid 3px ${Styles.globalColors.white}`,
+    borderRadius: 100,
+    color: Styles.globalColors.white,
+    hoverColor: Styles.globalColors.white,
+    left: 3,
+    position: 'absolute',
+    top: 3,
+  },
+}))
 
 export default RadioButton

--- a/shared/common-adapters/radio-button.native.tsx
+++ b/shared/common-adapters/radio-button.native.tsx
@@ -4,6 +4,11 @@ import Text from './text'
 import * as Styles from '../styles'
 import {Props} from './radio-button'
 
+const Kb = {
+  ClickableBox,
+  Text,
+}
+
 export const RADIOBUTTON_SIZE = 22
 export const RADIOBUTTON_MARGIN = 8
 
@@ -39,24 +44,26 @@ const RadioInnerCircle = Styles.styled<typeof ClickableBox, ExtraProps>(Clickabl
 )
 
 const RadioButton = ({disabled, label, onSelect, selected, style}: Props) => (
-  <ClickableBox
-    style={{...styleContainer, ...style}}
+  <Kb.ClickableBox
+    style={{...styles.container, ...style}}
     onClick={disabled ? undefined : () => onSelect(!selected)}
   >
     <RadioOuterCircle disabled={disabled} selected={selected}>
       <RadioInnerCircle selected={selected} />
     </RadioOuterCircle>
-    <Text type="Body" style={{color: Styles.globalColors.black}}>
+    <Kb.Text type="Body" style={{color: Styles.globalColors.black}}>
       {label}
-    </Text>
-  </ClickableBox>
+    </Kb.Text>
+  </Kb.ClickableBox>
 )
 
-const styleContainer = {
-  ...Styles.globalStyles.flexBoxRow,
-  alignItems: 'center' as 'center',
-  paddingBottom: Styles.globalMargins.xtiny,
-  paddingTop: Styles.globalMargins.xtiny,
-}
+const styles = Styles.styleSheetCreate(() => ({
+  container: {
+    ...Styles.globalStyles.flexBoxRow,
+    alignItems: 'center',
+    paddingBottom: Styles.globalMargins.xtiny,
+    paddingTop: Styles.globalMargins.xtiny,
+  },
+}))
 
 export default RadioButton

--- a/shared/common-adapters/radio-button.stories.tsx
+++ b/shared/common-adapters/radio-button.stories.tsx
@@ -3,6 +3,11 @@ import RadioButton from './radio-button'
 import React from 'react'
 import {storiesOf, action} from '../stories/storybook'
 
+const Kb = {
+  Box,
+  RadioButton,
+}
+
 const commonProps = {
   disabled: false,
   onSelect: newSelectedValue => action(`Got selected: ${newSelectedValue ? 'true' : 'false'}`),
@@ -11,17 +16,22 @@ const commonProps = {
 
 const load = () => {
   storiesOf('Common', module).add('RadioButton', () => (
-    <Box style={{flex: 1}}>
-      <RadioButton {...commonProps} label="RadioButton Unselected Enabled" selected={false} />
-      <RadioButton {...commonProps} label="RadioButton Selected Enabled" selected={true} />
-      <RadioButton
+    <Kb.Box style={{flex: 1}}>
+      <Kb.RadioButton {...commonProps} label="RadioButton Unselected Enabled" selected={false} />
+      <Kb.RadioButton {...commonProps} label="RadioButton Selected Enabled" selected={true} />
+      <Kb.RadioButton
         {...commonProps}
         label="RadioButton Unselected Disabled"
         selected={false}
         disabled={true}
       />
-      <RadioButton {...commonProps} label="RadioButton Selected Disabled" selected={true} disabled={true} />
-    </Box>
+      <Kb.RadioButton
+        {...commonProps}
+        label="RadioButton Selected Disabled"
+        selected={true}
+        disabled={true}
+      />
+    </Kb.Box>
   ))
 }
 

--- a/shared/common-adapters/relative-popup-hoc.desktop.tsx
+++ b/shared/common-adapters/relative-popup-hoc.desktop.tsx
@@ -1,11 +1,15 @@
 import logger from '../logger'
 import * as React from 'react'
+import * as Styles from '../styles'
 import {includes, throttle, without} from 'lodash-es'
 import Box from './box'
 import ReactDOM from 'react-dom'
 import {EscapeHandler} from '../util/key-event-handler.desktop'
-import {StylesCrossPlatform, collapseStyles} from '../styles'
 import {Position} from './relative-popup-hoc.types'
+
+const Kb = {
+  Box,
+}
 
 const getModalRoot = () => document.getElementById('modal-root')
 class Modal extends React.Component<{
@@ -257,7 +261,7 @@ type ModalPositionRelativeProps<PP> = {
   matchDimension?: boolean
   onClosePopup: () => void
   propagateOutsideClicks?: boolean
-  style?: StylesCrossPlatform
+  style?: Styles.StylesCrossPlatform
 } & PP
 
 function ModalPositionRelative<PP>(
@@ -287,7 +291,7 @@ function ModalPositionRelative<PP>(
         return
       }
 
-      const style = collapseStyles([
+      const style = Styles.collapseStyles([
         computePopupStyle(
           this.props.position,
           targetRect,
@@ -361,14 +365,14 @@ function ModalPositionRelative<PP>(
     render() {
       return (
         <Modal setNode={this._setRef}>
-          <Box style={this.state.style}>
+          <Kb.Box style={this.state.style}>
             {this.props.onClosePopup && (
               <EscapeHandler onESC={this.props.onClosePopup}>
                 <WrappedComponent {...this.props as PP} />
               </EscapeHandler>
             )}
             {!this.props.onClosePopup && <WrappedComponent {...this.props as PP} />}
-          </Box>
+          </Kb.Box>
         </Modal>
       )
     }

--- a/shared/common-adapters/reload.stories.tsx
+++ b/shared/common-adapters/reload.stories.tsx
@@ -4,6 +4,12 @@ import Reloadable from './reload'
 import Text from './text'
 import {Box2} from './box'
 
+const Kb = {
+  Box2,
+  Reloadable,
+  Text,
+}
+
 const provider = Sb.createPropProviderWithCommon({
   Reloadable: p => ({
     children: p.children,
@@ -16,7 +22,7 @@ const provider = Sb.createPropProviderWithCommon({
   }),
 })
 
-const Child = () => <Text type="Body">I dont need reload</Text>
+const Child = () => <Kb.Text type="Body">I dont need reload</Kb.Text>
 
 const props = {
   onReload: Sb.action('onReload'),
@@ -29,31 +35,31 @@ const load = () => {
   Sb.storiesOf('Common/Reload', module)
     .addDecorator(provider)
     .addDecorator(story => (
-      <Box2 direction="vertical" fullWidth={true} fullHeight={true}>
+      <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
         {story()}
-      </Box2>
+      </Kb.Box2>
     ))
     .add('No reload', () => (
       // @ts-ignore need that helper thats not merged yet
-      <Reloadable {...props} needsReload={false} reason="">
+      <Kb.Reloadable {...props} needsReload={false} reason="">
         <Child />
-      </Reloadable>
+      </Kb.Reloadable>
     ))
     .add('Reload', () => (
       // @ts-ignore need that helper thats not merged yet
-      <Reloadable {...props} needsReload={true} reason="reason field">
+      <Kb.Reloadable {...props} needsReload={true} reason="reason field">
         <Child />
-      </Reloadable>
+      </Kb.Reloadable>
     ))
     .add('Reload long', () => (
       // @ts-ignore need that helper thats not merged yet
-      <Reloadable {...props} needsReload={true} reason={longReason}>
+      <Kb.Reloadable {...props} needsReload={true} reason={longReason}>
         <Child />
-      </Reloadable>
+      </Kb.Reloadable>
     ))
     .add('Reload with back', () => (
       // @ts-ignore need that helper thats not merged yet
-      <Reloadable
+      <Kb.Reloadable
         {...props}
         onBack={Sb.action('onBack')}
         needsReload={true}
@@ -61,7 +67,7 @@ const load = () => {
         title="Title"
       >
         <Child />
-      </Reloadable>
+      </Kb.Reloadable>
     ))
 }
 

--- a/shared/common-adapters/reload.tsx
+++ b/shared/common-adapters/reload.tsx
@@ -84,7 +84,7 @@ class Reloadable extends React.PureComponent<Props> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   details: Styles.platformStyles({
     common: {
       flexGrow: 1,
@@ -119,7 +119,7 @@ const styles = Styles.styleSheetCreate({
     maxWidth: '100%',
     width: '100%',
   },
-})
+}))
 
 export type OwnProps = {
   children: React.ReactNode

--- a/shared/common-adapters/reload.tsx
+++ b/shared/common-adapters/reload.tsx
@@ -11,6 +11,14 @@ import Icon from './icon'
 import {namedConnect} from '../util/container'
 import {RPCError} from '../util/errors'
 
+const Kb = {
+  Box2,
+  Button,
+  Icon,
+  ScrollView,
+  Text,
+}
+
 type ReloadProps = {
   onBack?: () => void
   onReload: () => void
@@ -28,24 +36,24 @@ class Reload extends React.PureComponent<
   _toggle = () => this.setState(p => ({expanded: !p.expanded}))
   render() {
     return (
-      <Box2 direction="vertical" centerChildren={true} style={styles.reload} gap="small">
+      <Kb.Box2 direction="vertical" centerChildren={true} style={styles.reload} gap="small">
         <Icon type="icon-skull-64" />
-        <Text center={true} type="Header">
+        <Kb.Text center={true} type="Header">
           We're having a hard time loading this page.
-        </Text>
+        </Kb.Text>
         {this.state.expanded && (
-          <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollInside}>
-            <Text type="Terminal" style={styles.details}>
+          <Kb.ScrollView style={styles.scroll} contentContainerStyle={styles.scrollInside}>
+            <Kb.Text type="Terminal" style={styles.details}>
               {this.props.reason}
-            </Text>
-          </ScrollView>
+            </Kb.Text>
+          </Kb.ScrollView>
         )}
-        <Text type="BodySecondaryLink" onClick={this._toggle}>
+        <Kb.Text type="BodySecondaryLink" onClick={this._toggle}>
           {this.state.expanded ? 'Hide details' : 'Show details'}
-        </Text>
+        </Kb.Text>
 
-        <Button label="Retry" onClick={this.props.onReload} />
-      </Box2>
+        <Kb.Button label="Retry" onClick={this.props.onReload} />
+      </Kb.Box2>
     )
   }
 }

--- a/shared/common-adapters/rounded-box.tsx
+++ b/shared/common-adapters/rounded-box.tsx
@@ -25,39 +25,41 @@ const RoundedBox = (props: Props) => (
   </Kb.Box2>
 )
 
-const roundedBox: Styles.StylesCrossPlatform = {
-  alignSelf: 'stretch',
-  backgroundColor: Styles.globalColors.white,
-  borderBottomWidth: 1,
-  borderColor: Styles.globalColors.greyDark,
-  borderLeftWidth: 1,
-  borderRadius: Styles.borderRadius,
-  borderRightWidth: 1,
-  borderStyle: 'solid',
-  borderTopWidth: 1,
-  padding: Styles.globalMargins.small,
-}
+const styles = Styles.styleSheetCreate(() => {
+  const roundedBox: Styles.StylesCrossPlatform = {
+    alignSelf: 'stretch',
+    backgroundColor: Styles.globalColors.white,
+    borderBottomWidth: 1,
+    borderColor: Styles.globalColors.greyDark,
+    borderLeftWidth: 1,
+    borderRadius: Styles.borderRadius,
+    borderRightWidth: 1,
+    borderStyle: 'solid',
+    borderTopWidth: 1,
+    padding: Styles.globalMargins.small,
+  }
 
-const styles = Styles.styleSheetCreate({
-  bottom: {
-    ...roundedBox,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    borderTopWidth: 0,
-  },
-  default: {
-    ...roundedBox,
-  },
-  middle: {
-    ...roundedBox,
-    borderRadius: 0,
-    borderTopWidth: 0,
-  },
-  top: {
-    ...roundedBox,
-    borderBottomLeftRadius: 0,
-    borderBottomRightRadius: 0,
-  },
+  return {
+    bottom: {
+      ...roundedBox,
+      borderTopLeftRadius: 0,
+      borderTopRightRadius: 0,
+      borderTopWidth: 0,
+    },
+    default: {
+      ...roundedBox,
+    },
+    middle: {
+      ...roundedBox,
+      borderRadius: 0,
+      borderTopWidth: 0,
+    },
+    top: {
+      ...roundedBox,
+      borderBottomLeftRadius: 0,
+      borderBottomRightRadius: 0,
+    },
+  }
 })
 
 export default RoundedBox

--- a/shared/common-adapters/safe-area-view.native.tsx
+++ b/shared/common-adapters/safe-area-view.native.tsx
@@ -11,7 +11,7 @@ export const SafeAreaViewTop = ({style, children}: Props) =>
     <SafeAreaView style={Styles.collapseStyles([styles.topSafeArea, style])}>{children}</SafeAreaView>
   )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   androidTopSafeArea: {
     backgroundColor: Styles.globalColors.white,
     flexShrink: 0,
@@ -19,6 +19,6 @@ const styles = Styles.styleSheetCreate({
     paddingTop: StatusBar.currentHeight,
   },
   topSafeArea: {backgroundColor: Styles.globalColors.white, flexGrow: 0},
-})
+}))
 
 export default SafeAreaView

--- a/shared/common-adapters/save-indicator.stories.tsx
+++ b/shared/common-adapters/save-indicator.stories.tsx
@@ -1,16 +1,21 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import SaveIndicator from './save-indicator'
 import {storiesOf, action} from '../stories/storybook'
-import {globalStyles} from '../styles'
 import Box from './box'
 import Button from './button'
+
+const Kb = {
+  Box,
+  Button,
+}
 
 type State = {
   saving: boolean
 }
 
 const containerStyle = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'flex-start',
 }
 
@@ -28,8 +33,8 @@ class SaveIndicatorContainer extends React.Component<{}, State> {
 
   render() {
     return (
-      <Box style={containerStyle}>
-        <Button
+      <Kb.Box style={containerStyle}>
+        <Kb.Button
           label={this.state.saving ? 'Stop save' : 'Start save'}
           onClick={this._toggleSave}
           style={{alignSelf: 'flex-start'}}
@@ -40,7 +45,7 @@ class SaveIndicatorContainer extends React.Component<{}, State> {
           savedTimeoutMs={3000}
           debugLog={action('debugLog')}
         />
-      </Box>
+      </Kb.Box>
     )
   }
 }

--- a/shared/common-adapters/save-indicator.tsx
+++ b/shared/common-adapters/save-indicator.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import Box from './box'
 import HOCTimers, {PropsWithTimer} from './hoc-timers'
 import Icon from './icon'
 import ProgressIndicator from './progress-indicator'
 import Text from './text'
 import * as Flow from '../util/flow'
-import {collapseStyles, globalColors, globalMargins, globalStyles, StylesCrossPlatform} from '../styles'
+
+const Kb = {
+  Box,
+  Icon,
+  ProgressIndicator,
+  Text,
+}
 
 // States of the state machine for the save indicator:
 //
@@ -30,7 +37,7 @@ type SaveState = 'steady' | 'saving' | 'savingHysteresis' | 'justSaved'
 
 export type _Props = {
   saving: boolean
-  style?: StylesCrossPlatform
+  style?: Styles.StylesCrossPlatform
   // Minimum duration to stay in saving or savingHysteresis.
   minSavingTimeMs: number
   // Minimum duration to stay in justSaved.
@@ -106,9 +113,9 @@ const computeNextState = (props: _Props, state: State, now: Date): null | SaveSt
 }
 
 const defaultStyle = {
-  ...globalStyles.flexBoxRow,
+  ...Styles.globalStyles.flexBoxRow,
   alignItems: 'center',
-  height: globalMargins.medium,
+  height: Styles.globalMargins.medium,
   justifyContent: 'center',
 }
 
@@ -177,14 +184,14 @@ class SaveIndicator extends React.Component<Props, State> {
         return null
       case 'saving':
       case 'savingHysteresis':
-        return <ProgressIndicator style={{width: globalMargins.medium}} />
+        return <Kb.ProgressIndicator style={{width: Styles.globalMargins.medium}} />
       case 'justSaved':
         return (
           <React.Fragment>
-            <Icon type="iconfont-check" color={globalColors.green} />
-            <Text type="BodySmall" style={{color: globalColors.greenDark}}>
+            <Kb.Icon type="iconfont-check" color={Styles.globalColors.green} />
+            <Kb.Text type="BodySmall" style={{color: Styles.globalColors.greenDark}}>
               &nbsp; Saved
-            </Text>
+            </Kb.Text>
           </React.Fragment>
         )
       default:
@@ -194,7 +201,9 @@ class SaveIndicator extends React.Component<Props, State> {
   }
 
   render = () => {
-    return <Box style={collapseStyles([defaultStyle, this.props.style])}>{this._getChildren()}</Box>
+    return (
+      <Kb.Box style={Styles.collapseStyles([defaultStyle, this.props.style])}>{this._getChildren()}</Kb.Box>
+    )
   }
 }
 

--- a/shared/common-adapters/scroll-view.desktop.tsx
+++ b/shared/common-adapters/scroll-view.desktop.tsx
@@ -44,7 +44,7 @@ const ScrollView = (props: Props) => {
   )
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   overflowAuto: {
     overflow: 'auto',
   },
@@ -52,6 +52,6 @@ const styles = Styles.styleSheetCreate({
     overflowX: 'hidden',
     overflowY: 'auto',
   },
-})
+}))
 
 export default ScrollView

--- a/shared/common-adapters/search-filter.stories.tsx
+++ b/shared/common-adapters/search-filter.stories.tsx
@@ -5,24 +5,31 @@ import Text from './text'
 import SearchFilter from './search-filter'
 import * as Styles from '../styles'
 
+const Kb = {
+  Box,
+  Box2,
+  SearchFilter,
+  Text,
+}
+
 const load = () => {
   Sb.storiesOf('Common', module)
     .addDecorator(Sb.scrollViewDecorator)
     .add('SearchFilter', () => (
-      <Box2 direction="vertical" fullWidth={true} gap="small" gapStart={true}>
-        <Box2 direction="horizontal" fullWidth={true} gap="small" alignItems="center">
-          <Text type="Body">Small</Text>
-          <SearchFilter
+      <Kb.Box2 direction="vertical" fullWidth={true} gap="small" gapStart={true}>
+        <Kb.Box2 direction="horizontal" fullWidth={true} gap="small" alignItems="center">
+          <Kb.Text type="Body">Small</Kb.Text>
+          <Kb.SearchFilter
             hotkey="k"
             icon="iconfont-search"
             placeholderText="Search in the universe"
             onChange={Sb.action('onChange')}
             waiting={true}
           />
-        </Box2>
-        <Box2 direction="horizontal" fullWidth={true} gap="small" alignItems="center">
-          <Text type="Body">Full-width</Text>
-          <SearchFilter
+        </Kb.Box2>
+        <Kb.Box2 direction="horizontal" fullWidth={true} gap="small" alignItems="center">
+          <Kb.Text type="Body">Full-width</Kb.Text>
+          <Kb.SearchFilter
             hotkey="k"
             icon="iconfont-search"
             placeholderText="Search in the universe"
@@ -30,10 +37,10 @@ const load = () => {
             fullWidth={true}
             waiting={true}
           />
-        </Box2>
-        <Box2 direction="horizontal" fullWidth={true} gap="small" alignItems="center">
-          <Text type="Body">with onClick</Text>
-          <SearchFilter
+        </Kb.Box2>
+        <Kb.Box2 direction="horizontal" fullWidth={true} gap="small" alignItems="center">
+          <Kb.Text type="Body">with onClick</Kb.Text>
+          <Kb.SearchFilter
             hotkey="k"
             icon="iconfont-search"
             placeholderText="Search in the universe"
@@ -42,16 +49,16 @@ const load = () => {
             fullWidth={true}
             waiting={true}
           />
-        </Box2>
-        <SearchFilter
+        </Kb.Box2>
+        <Kb.SearchFilter
           hotkey="k"
           icon="iconfont-search"
           placeholderText="Search in the universe (by itself in a column flex box)"
           onChange={Sb.action('onChange')}
           fullWidth={true}
         />
-        <Box style={{backgroundColor: Styles.globalColors.blue, padding: Styles.globalMargins.large}}>
-          <SearchFilter
+        <Kb.Box style={{backgroundColor: Styles.globalColors.blue, padding: Styles.globalMargins.large}}>
+          <Kb.SearchFilter
             hotkey="k"
             icon="iconfont-search"
             waiting={true}
@@ -59,36 +66,36 @@ const load = () => {
             placeholderText="Search in the universe"
             onChange={Sb.action('onChange')}
           />
-        </Box>
-      </Box2>
+        </Kb.Box>
+      </Kb.Box2>
     ))
     .add('SearchFilter - Mobile', () => (
-      <Box2 direction="vertical" fullWidth={true} gap="small" gapStart={true}>
-        <SearchFilter icon="iconfont-search" placeholderText="Search" onChange={Sb.action('onChange')} />
-        <SearchFilter
+      <Kb.Box2 direction="vertical" fullWidth={true} gap="small" gapStart={true}>
+        <Kb.SearchFilter icon="iconfont-search" placeholderText="Search" onChange={Sb.action('onChange')} />
+        <Kb.SearchFilter
           icon="iconfont-search"
           placeholderText="Search"
           onChange={Sb.action('onChange')}
           waiting={true}
         />
-        <Box style={{backgroundColor: Styles.globalColors.blue}}>
-          <SearchFilter
+        <Kb.Box style={{backgroundColor: Styles.globalColors.blue}}>
+          <Kb.SearchFilter
             icon="iconfont-search"
             placeholderText="Search"
             onChange={Sb.action('onChange')}
             negative={true}
           />
-        </Box>
-        <Box style={{backgroundColor: Styles.globalColors.blue}}>
-          <SearchFilter
+        </Kb.Box>
+        <Kb.Box style={{backgroundColor: Styles.globalColors.blue}}>
+          <Kb.SearchFilter
             icon="iconfont-search"
             placeholderText="Search"
             onChange={Sb.action('onChange')}
             waiting={true}
             negative={true}
           />
-        </Box>
-      </Box2>
+        </Kb.Box>
+      </Kb.Box2>
     ))
 }
 

--- a/shared/common-adapters/search-filter.tsx
+++ b/shared/common-adapters/search-filter.tsx
@@ -273,7 +273,7 @@ class SearchFilter extends React.PureComponent<Props, State> {
 
 export default SearchFilter
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: Styles.platformStyles({
     common: {
       ...Styles.globalStyles.flexBoxRow,
@@ -356,4 +356,4 @@ const styles = Styles.styleSheetCreate({
   textNegative: {
     color: Styles.globalColors.white,
   },
-})
+}))

--- a/shared/common-adapters/section-list.desktop.tsx
+++ b/shared/common-adapters/section-list.desktop.tsx
@@ -248,7 +248,7 @@ class SectionList extends React.Component<Props, State> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   box: {
     alignSelf: 'stretch',
     flexShrink: 0,
@@ -265,6 +265,6 @@ const styles = Styles.styleSheetCreate({
     position: 'absolute',
     top: 0,
   },
-})
+}))
 
 export default SectionList

--- a/shared/common-adapters/section-list.desktop.tsx
+++ b/shared/common-adapters/section-list.desktop.tsx
@@ -8,6 +8,11 @@ import {debounce, throttle, once} from 'lodash-es'
 import {memoize} from '../util/memoize'
 import {renderElementOrComponentOrNot} from '../util/util'
 
+const Kb = {
+  Box2,
+  ScrollView,
+}
+
 /*
  * How this works: We take in the same data structure as RN does Array<Section> and flatten it into an array (this._flat)
  * We make 2 types 'body' and 'header' and bookkeep which header body parts are in. We then feed this into a react-list
@@ -79,10 +84,10 @@ class SectionList extends React.Component<Props, State> {
         item.flatSectionIndex === 0
       ) {
         // don't render the first one since its always there
-        return <Box2 direction="vertical" key="stickyPlaceholder" />
+        return <Kb.Box2 direction="vertical" key="stickyPlaceholder" />
       }
       return (
-        <Box2
+        <Kb.Box2
           direction="vertical"
           key={`${renderingSticky ? 'sticky:' : ''}${item.key}:`}
           style={
@@ -95,11 +100,11 @@ class SectionList extends React.Component<Props, State> {
           fullWidth={true}
         >
           {this.props.renderSectionHeader({section: section.section})}
-        </Box2>
+        </Kb.Box2>
       )
     } else if (item.type === 'placeholder') {
       return (
-        <Box2
+        <Kb.Box2
           direction="vertical"
           key={`blankPlaceholder${item.flatSectionIndex}`}
           style={{height: 1}}
@@ -108,13 +113,13 @@ class SectionList extends React.Component<Props, State> {
       )
     } else {
       return (
-        <Box2 direction="vertical" key={`${section.key}:${item.key}`} style={styles.box}>
+        <Kb.Box2 direction="vertical" key={`${section.key}:${item.key}`} style={styles.box}>
           {(section.section.renderItem || this.props.renderItem)({
             index: item.indexWithinSection,
             item: item.item,
             section: section.section,
           })}
-        </Box2>
+        </Kb.Box2>
       )
     }
   }
@@ -224,9 +229,9 @@ class SectionList extends React.Component<Props, State> {
       this._itemRenderer(this.state.currentSectionFlatIndex, this.state.currentSectionFlatIndex, true)
 
     return (
-      <Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.container}>
+      <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.container}>
         {this.props.disableAbsoluteStickyHeader && stickyHeader}
-        <ScrollView
+        <Kb.ScrollView
           style={Styles.collapseStyles([styles.scroll, this.props.style])}
           onScroll={this._onScroll}
         >
@@ -241,9 +246,9 @@ class SectionList extends React.Component<Props, State> {
             ref={this._listRef}
             type="variable"
           />
-        </ScrollView>
+        </Kb.ScrollView>
         {!this.props.disableAbsoluteStickyHeader && stickyHeader}
-      </Box2>
+      </Kb.Box2>
     )
   }
 }

--- a/shared/common-adapters/section-list.stories.tsx
+++ b/shared/common-adapters/section-list.stories.tsx
@@ -84,10 +84,10 @@ const load = () => {
     ))
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   header: {backgroundColor: 'grey'},
   otherHeader: {backgroundColor: 'orange'},
   text: {width: '100%'},
-})
+}))
 
 export default load

--- a/shared/common-adapters/section-list.stories.tsx
+++ b/shared/common-adapters/section-list.stories.tsx
@@ -5,26 +5,32 @@ import SectionList from './section-list'
 import * as Sb from '../stories/storybook'
 import * as Styles from '../styles'
 
+const Kb = {
+  Box2,
+  SectionList,
+  Text,
+}
+
 const simpleRender = ({item}) => (
-  <Text type="Body" style={styles.text}>
+  <Kb.Text type="Body" style={styles.text}>
     {item}
-  </Text>
+  </Kb.Text>
 )
 const simpleHeaderRender = ({section}) => (
-  <Box2
+  <Kb.Box2
     direction="vertical"
     fullWidth={true}
     style={section.data.length % 2 ? styles.otherHeader : styles.header}
   >
-    <Text type="Header" style={styles.text}>
+    <Kb.Text type="Header" style={styles.text}>
       {section.title}
-    </Text>
-  </Box2>
+    </Kb.Text>
+  </Kb.Box2>
 )
 const customRowRender = ({item}) => (
-  <Text type="BodySemibold" style={styles.text}>
+  <Kb.Text type="BodySemibold" style={styles.text}>
     SPECIAL: {item}
-  </Text>
+  </Kb.Text>
 )
 
 const small: Array<unknown> = []
@@ -53,18 +59,22 @@ customRow[2] = {...customRow[2], renderItem: customRowRender}
 const load = () => {
   Sb.storiesOf('Common/SectionList', module)
     .addDecorator(story => (
-      <Box2 direction="vertical" style={{height: 300, width: '100%'}}>
+      <Kb.Box2 direction="vertical" style={{height: 300, width: '100%'}}>
         {story()}
-      </Box2>
+      </Kb.Box2>
     ))
     .add('Small', () => (
-      <SectionList sections={small} renderItem={simpleRender} renderSectionHeader={simpleHeaderRender} />
+      <Kb.SectionList sections={small} renderItem={simpleRender} renderSectionHeader={simpleHeaderRender} />
     ))
     .add('CustomRowRender', () => (
-      <SectionList sections={customRow} renderItem={simpleRender} renderSectionHeader={simpleHeaderRender} />
+      <Kb.SectionList
+        sections={customRow}
+        renderItem={simpleRender}
+        renderSectionHeader={simpleHeaderRender}
+      />
     ))
     .add('CustomKeys', () => (
-      <SectionList
+      <Kb.SectionList
         sections={customRow}
         renderItem={simpleRender}
         renderSectionHeader={simpleHeaderRender}
@@ -72,10 +82,10 @@ const load = () => {
       />
     ))
     .add('Large', () => (
-      <SectionList sections={large} renderItem={simpleRender} renderSectionHeader={simpleHeaderRender} />
+      <Kb.SectionList sections={large} renderItem={simpleRender} renderSectionHeader={simpleHeaderRender} />
     ))
     .add('LargeSticky', () => (
-      <SectionList
+      <Kb.SectionList
         stickySectionHeadersEnabled={true}
         sections={large}
         renderItem={simpleRender}

--- a/shared/common-adapters/simple-toast.tsx
+++ b/shared/common-adapters/simple-toast.tsx
@@ -31,6 +31,6 @@ const SimpleToast = (props: Props) => (
 
 export default SimpleToast
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   toastText: {color: Styles.globalColors.white},
-})
+}))

--- a/shared/common-adapters/standard-screen.desktop.tsx
+++ b/shared/common-adapters/standard-screen.desktop.tsx
@@ -1,92 +1,89 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import Box from './box'
 import Text from './text'
 import HeaderHoc from './header-hoc'
-import {globalStyles, globalColors, globalMargins, desktopStyles, collapseStyles} from '../styles'
 import {Props, NotificationType} from './standard-screen'
 
-const StandardScreen = ({theme = 'light', ...props}: Props) => {
+const Kb = {
+  Box,
+  Text,
+}
+
+const StandardScreen = (props: Props) => {
   const topStack = [
     !!props.notification && (
-      <Box key="banner" style={{...styleBanner(props.notification.type), ...props.styleBanner}}>
+      <Kb.Box key="banner" style={{...styleBanner(props.notification.type), ...props.styleBanner}}>
         {typeof props.notification.message === 'string' ? (
-          <Text style={styleBannerText} type="BodySmallSemibold">
+          <Kb.Text style={styles.bannerText} type="BodySmallSemibold">
             {props.notification.message}
-          </Text>
+          </Kb.Text>
         ) : (
           props.notification.message
         )}
-      </Box>
+      </Kb.Box>
     ),
   ]
   const topStackCount = topStack.reduce((acc, x) => acc + (x ? 1 : 0), 0)
   return (
-    <Box style={{...styleContainer, ...backgroundColorThemed[theme]}}>
-      <Box style={styleTopStack}>{topStack}</Box>
-      <Box style={{...styleInnerContainer, paddingBottom: topStackCount * globalMargins.large}}>
-        <Box style={collapseStyles([styleContentContainer, props.style])}>{props.children}</Box>
-      </Box>
-    </Box>
+    <Kb.Box style={Styles.collapseStyles([Styles.desktopStyles.scrollable, styles.container])}>
+      <Kb.Box style={styleTopStack}>{topStack}</Kb.Box>
+      <Kb.Box style={{...styles.innerContainer, paddingBottom: topStackCount * Styles.globalMargins.large}}>
+        <Kb.Box style={Styles.collapseStyles([styles.contentContainer, props.style])}>
+          {props.children}
+        </Kb.Box>
+      </Kb.Box>
+    </Kb.Box>
   )
 }
 
-const styleContainer = {
-  ...globalStyles.flexBoxColumn,
-  ...desktopStyles.scrollable,
-  alignItems: 'stretch',
-  flex: 1,
-  position: 'relative',
-}
-
 const styleTopStack = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'stretch',
   position: 'relative',
   width: '100%',
 }
 
-const backgroundColorThemed = {
-  dark: {
-    backgroundColor: globalColors.blueDarker2,
-  },
-  light: {
-    backgroundColor: globalColors.white,
-  },
-}
-
 const styleBanner = (notificationType: NotificationType) => ({
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'center',
-  backgroundColor: notificationType === 'error' ? globalColors.red : globalColors.green,
+  backgroundColor: notificationType === 'error' ? Styles.globalColors.red : Styles.globalColors.green,
   justifyContent: 'center',
-  minHeight: globalMargins.large,
-  paddingBottom: globalMargins.tiny,
-  paddingLeft: globalMargins.xlarge,
-  paddingRight: globalMargins.xlarge,
-  paddingTop: globalMargins.tiny,
+  minHeight: Styles.globalMargins.large,
+  paddingBottom: Styles.globalMargins.tiny,
+  paddingLeft: Styles.globalMargins.xlarge,
+  paddingRight: Styles.globalMargins.xlarge,
+  paddingTop: Styles.globalMargins.tiny,
   textAlign: 'center',
   width: '100%',
   zIndex: 1,
 })
 
-const styleBannerText = {
-  color: globalColors.white,
-}
-
-const styleInnerContainer = {
-  ...globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  flex: 1,
-  position: 'relative',
-}
-
-const styleContentContainer = {
-  ...globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  flex: 1,
-  justifyContent: 'center',
-  margin: globalMargins.large,
-  textAlign: 'center',
-}
+const styles = Styles.styleSheetCreate(() => ({
+  bannerText: {
+    color: Styles.globalColors.white,
+  },
+  container: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'stretch',
+    backgroundColor: Styles.globalColors.white,
+    flex: 1,
+    position: 'relative',
+  },
+  contentContainer: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    margin: Styles.globalMargins.large,
+    textAlign: 'center',
+  },
+  innerContainer: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'center',
+    flex: 1,
+    position: 'relative',
+  },
+}))
 
 export default HeaderHoc(StandardScreen)

--- a/shared/common-adapters/standard-screen.native.tsx
+++ b/shared/common-adapters/standard-screen.native.tsx
@@ -39,7 +39,7 @@ const StandardScreen = (props: Props) => {
 }
 
 const MIN_BANNER_HEIGHT = 40
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     ...Styles.globalStyles.flexBoxColumn,
     backgroundColor: Styles.globalColors.white,
@@ -52,6 +52,6 @@ const styles = Styles.styleSheetCreate({
     paddingRight: Styles.globalMargins.medium,
   },
   contentMargin: {marginTop: MIN_BANNER_HEIGHT},
-})
+}))
 
 export default HeaderHoc(StandardScreen)

--- a/shared/common-adapters/standard-screen.stories.tsx
+++ b/shared/common-adapters/standard-screen.stories.tsx
@@ -1,26 +1,34 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import StandardScreen from './standard-screen'
 import Text from './text'
 import Box from './box'
 import {action, storiesOf} from '../stories/storybook'
-import {globalStyles} from '../styles'
 
-const Wrapper = ({children}) => <Box style={{...globalStyles.flexBoxRow, height: 578}}>{children}</Box>
+const Kb = {
+  Box,
+  StandardScreen,
+  Text,
+}
+
+const Wrapper = ({children}) => (
+  <Kb.Box style={{...Styles.globalStyles.flexBoxRow, height: 578}}>{children}</Kb.Box>
+)
 const props = {
   children: (
-    <Text center={true} type="Header">
+    <Kb.Text center={true} type="Header">
       Whoa, look at this centered thing
-    </Text>
+    </Kb.Text>
   ),
   onClose: action('onClose'),
 }
 
 const load = () => {
   storiesOf('Common/StandardScreen', module)
-    .add('Normal', () => <StandardScreen {...props} />)
+    .add('Normal', () => <Kb.StandardScreen {...props} />)
     .add('Error', () => (
       <Wrapper>
-        <StandardScreen
+        <Kb.StandardScreen
           {...props}
           notification={{
             message: 'Something went horribly wrong! :-(',
@@ -31,12 +39,12 @@ const load = () => {
     ))
     .add('Back Button', () => (
       <Wrapper>
-        <StandardScreen {...props} onClose={undefined} onBack={action('onBack')} />
+        <Kb.StandardScreen {...props} onClose={undefined} onBack={action('onBack')} />
       </Wrapper>
     ))
     .add('Error w/ Back Button', () => (
       <Wrapper>
-        <StandardScreen
+        <Kb.StandardScreen
           {...props}
           onClose={undefined}
           onBack={action('onBack')}

--- a/shared/common-adapters/switch-toggle.desktop.tsx
+++ b/shared/common-adapters/switch-toggle.desktop.tsx
@@ -21,7 +21,7 @@ export default SwitchToggle
 
 const disabledOffset = 2
 const enabledOffset = 10
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   inner: {
     backgroundColor: Styles.globalColors.white,
     borderRadius: 6,
@@ -41,4 +41,4 @@ const styles = Styles.styleSheetCreate({
       width: 24,
     },
   }),
-})
+}))

--- a/shared/common-adapters/switch-toggle.native.tsx
+++ b/shared/common-adapters/switch-toggle.native.tsx
@@ -48,7 +48,7 @@ export default SwitchToggle
 const disabledOffset = 2
 const enabledOffset = 22
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   inner: {
     backgroundColor: Styles.globalColors.white,
     borderRadius: 12,
@@ -63,4 +63,4 @@ const styles = Styles.styleSheetCreate({
     height: 28,
     width: 48,
   },
-})
+}))

--- a/shared/common-adapters/switch.tsx
+++ b/shared/common-adapters/switch.tsx
@@ -95,7 +95,7 @@ const Switch = React.forwardRef<ClickableBox, Props>((props: Props, ref) =>
 
 export default Switch
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: Styles.platformStyles({
     common: {
       alignItems: 'center',
@@ -132,4 +132,4 @@ const styles = Styles.styleSheetCreate({
       marginLeft: 12,
     },
   }),
-})
+}))

--- a/shared/common-adapters/tab-bar.desktop.tsx
+++ b/shared/common-adapters/tab-bar.desktop.tsx
@@ -10,6 +10,15 @@ import shallowEqual from 'shallowequal'
 import {Props, ItemProps, TabBarButtonProps} from './tab-bar'
 import * as Styles from '../styles'
 
+const Kb = {
+  Avatar,
+  Badge,
+  Box,
+  Icon,
+  Meta,
+  Text,
+}
+
 // TODO this thing does 4 different things. a lot of the main nav logic is in here which isn't used by anything else. Split this apart!
 
 class TabBarItem extends React.Component<ItemProps> {
@@ -33,7 +42,7 @@ class SimpleTabBarButton extends React.Component<ItemProps> {
     const borderLocation = this.props.onBottom ? 'borderTop' : 'borderBottom'
     const underlineStyle = this.props.underlined ? {textDecoration: 'underlined'} : {}
     return (
-      <Box
+      <Kb.Box
         style={{
           ...Styles.desktopStyles.clickable,
           [borderLocation]: `solid 2px ${this.props.selected ? selectedColor : 'transparent'}`,
@@ -41,7 +50,7 @@ class SimpleTabBarButton extends React.Component<ItemProps> {
           ...this.props.style,
         }}
       >
-        <Text
+        <Kb.Text
           type="BodySmallSemibold"
           style={Styles.platformStyles({
             common: {
@@ -54,14 +63,14 @@ class SimpleTabBarButton extends React.Component<ItemProps> {
           })}
         >
           {this.props.label}
-        </Text>
-      </Box>
+        </Kb.Text>
+      </Kb.Box>
     )
   }
 }
 
 const HighlightLine = () => (
-  <Box
+  <Kb.Box
     style={{
       ...Styles.globalStyles.fillAbsolute,
       backgroundColor: Styles.globalColors.white,
@@ -98,7 +107,7 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
   _renderAvatar(_: string, badgeNumber: number) {
     if (this.props.source.type !== 'avatar') return null // needed to make flow happy
     return (
-      <Box
+      <Kb.Box
         className={Styles.classNames('nav-item-avatar', {selected: this.props.selected})}
         style={Styles.platformStyles({
           isElectron: {
@@ -113,21 +122,21 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
         onClick={this.props.onClick}
       >
         {this.props.selected && <HighlightLine />}
-        <Avatar
+        <Kb.Avatar
           size={32}
           onClick={this.props.onClick}
           username={this.props.source.username}
           loadingColor={Styles.globalColors.blueLighter_40}
         />
         {badgeNumber > 0 && (
-          <Box style={{display: 'flex', width: 0}}>
-            <Box style={styleBadgeAvatar}>
-              <Badge badgeNumber={badgeNumber} badgeStyle={{marginLeft: 0, marginRight: 0}} />
-            </Box>
-          </Box>
+          <Kb.Box style={{display: 'flex', width: 0}}>
+            <Kb.Box style={styleBadgeAvatar}>
+              <Kb.Badge badgeNumber={badgeNumber} badgeStyle={{marginLeft: 0, marginRight: 0}} />
+            </Kb.Box>
+          </Kb.Box>
         )}
         {!!this.props.label && (
-          <Text
+          <Kb.Text
             center={true}
             className="title"
             type="BodyTinySemibold"
@@ -140,52 +149,57 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
             }}
           >
             {this.props.label}
-          </Text>
+          </Kb.Text>
         )}
-      </Box>
+      </Kb.Box>
     )
   }
 
   _renderNav(badgeNumber: number, isNew: boolean) {
     if (this.props.source.type !== 'nav') return null // needed to make flow happy
     return (
-      <Box onClick={this.props.onClick}>
+      <Kb.Box onClick={this.props.onClick}>
         <style>{navRealCSS}</style>
-        <Box
+        <Kb.Box
           style={{...stylesTabBarNavIcon, ...this.props.style}}
           className={'nav-item' + (this.props.selected ? ' selected' : '')}
         >
           {this.props.selected && <HighlightLine />}
-          <Icon type={this.props.source.icon} style={this.props.styleIcon} className="img" sizeType="Big" />
+          <Kb.Icon
+            type={this.props.source.icon}
+            style={this.props.styleIcon}
+            className="img"
+            sizeType="Big"
+          />
           {badgeNumber > 0 && (
-            <Box style={styleBadgeNav}>
-              <Badge
+            <Kb.Box style={styleBadgeNav}>
+              <Kb.Badge
                 badgeNumber={badgeNumber}
                 badgeStyle={{marginLeft: 0, marginRight: Styles.globalMargins.tiny}}
               />
-            </Box>
+            </Kb.Box>
           )}
           {isNew && (
-            <Box style={styleBadgeNav}>
-              <Meta
+            <Kb.Box style={styleBadgeNav}>
+              <Kb.Meta
                 title="new"
                 size="Small"
                 style={{alignSelf: 'center', marginRight: 4}}
                 backgroundColor={Styles.globalColors.blueLight}
               />
-            </Box>
+            </Kb.Box>
           )}
           {!!this.props.label && (
-            <Text
+            <Kb.Text
               type="BodySmallSemibold"
               style={{color: undefined, ...stylesNavText, ...this.props.styleLabel}}
               className="title"
             >
               {this.props.label}
-            </Text>
+            </Kb.Text>
           )}
-        </Box>
-      </Box>
+        </Kb.Box>
+      </Kb.Box>
     )
   }
 
@@ -193,34 +207,34 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
     if (this.props.source.type !== 'icon') return null // needed to make flow happy
     const backgroundColor = Styles.globalColors.blueDarker2
     return (
-      <Box
+      <Kb.Box
         style={{...stylesTabBarButtonIcon, backgroundColor, ...this.props.style}}
         onClick={this.props.onClick}
       >
-        <Icon
+        <Kb.Icon
           type={this.props.source.icon}
           style={Styles.collapseStyles([stylesIcon, this.props.styleIcon])}
           color={color}
         />
         {!!this.props.label && (
-          <Text
+          <Kb.Text
             type="BodySemibold"
             center={true}
             style={{color, ...Styles.desktopStyles.clickable, ...this.props.styleLabel}}
           >
             {this.props.label}
-          </Text>
+          </Kb.Text>
         )}
         {badgeNumber > 0 && (
-          <Box style={{...styleBadgeIcon, ...this.props.styleBadgeContainer}}>
-            <Badge
+          <Kb.Box style={{...styleBadgeIcon, ...this.props.styleBadgeContainer}}>
+            <Kb.Badge
               badgeNumber={badgeNumber}
               badgeStyle={this.props.styleBadge}
               badgeNumberStyle={this.props.styleBadgeNumber}
             />
-          </Box>
+          </Kb.Box>
         )}
-      </Box>
+      </Kb.Box>
     )
   }
 
@@ -255,9 +269,9 @@ class TabBar extends React.Component<Props> {
     return React.Children.toArray(this.props.children || []).map((item: {props: ItemProps}, i) => {
       const key = item.props.label || get(item, 'props.tabBarButton.props.label') || i
       return (
-        <Box key={key} style={item.props.styleContainer} onClick={item.props.onClick}>
+        <Kb.Box key={key} style={item.props.styleContainer} onClick={item.props.onClick}>
           {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
-        </Box>
+        </Kb.Box>
       )
     })
   }
@@ -268,7 +282,7 @@ class TabBar extends React.Component<Props> {
 
   render() {
     const tabBarButtons = (
-      <Box
+      <Kb.Box
         style={{
           ...Styles.globalStyles.flexBoxRow,
           borderBottom: `solid 1px ${Styles.globalColors.black_10}`,
@@ -277,14 +291,14 @@ class TabBar extends React.Component<Props> {
         }}
       >
         {this._labels()}
-      </Box>
+      </Kb.Box>
     )
     return (
-      <Box style={{...stylesContainer, ...this.props.style}}>
+      <Kb.Box style={{...stylesContainer, ...this.props.style}}>
         {!this.props.tabBarOnBottom && tabBarButtons}
         {this._content()}
         {this.props.tabBarOnBottom && tabBarButtons}
-      </Box>
+      </Kb.Box>
     )
   }
 }

--- a/shared/common-adapters/tab-bar.desktop.tsx
+++ b/shared/common-adapters/tab-bar.desktop.tsx
@@ -130,7 +130,7 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
         />
         {badgeNumber > 0 && (
           <Kb.Box style={{display: 'flex', width: 0}}>
-            <Kb.Box style={styleBadgeAvatar}>
+            <Kb.Box style={styles.badgeAvatar}>
               <Kb.Badge badgeNumber={badgeNumber} badgeStyle={{marginLeft: 0, marginRight: 0}} />
             </Kb.Box>
           </Kb.Box>
@@ -141,7 +141,7 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
             className="title"
             type="BodyTinySemibold"
             style={{
-              ...stylesNavText,
+              ...styles.navText,
               color: undefined,
               marginTop: 3,
               ...Styles.desktopStyles.clickable,
@@ -161,7 +161,7 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
       <Kb.Box onClick={this.props.onClick}>
         <style>{navRealCSS}</style>
         <Kb.Box
-          style={{...stylesTabBarNavIcon, ...this.props.style}}
+          style={{...styles.tabBarNavIcon, ...this.props.style}}
           className={'nav-item' + (this.props.selected ? ' selected' : '')}
         >
           {this.props.selected && <HighlightLine />}
@@ -172,7 +172,7 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
             sizeType="Big"
           />
           {badgeNumber > 0 && (
-            <Kb.Box style={styleBadgeNav}>
+            <Kb.Box style={styles.badgeNav}>
               <Kb.Badge
                 badgeNumber={badgeNumber}
                 badgeStyle={{marginLeft: 0, marginRight: Styles.globalMargins.tiny}}
@@ -180,7 +180,7 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
             </Kb.Box>
           )}
           {isNew && (
-            <Kb.Box style={styleBadgeNav}>
+            <Kb.Box style={styles.badgeNav}>
               <Kb.Meta
                 title="new"
                 size="Small"
@@ -192,7 +192,7 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
           {!!this.props.label && (
             <Kb.Text
               type="BodySmallSemibold"
-              style={{color: undefined, ...stylesNavText, ...this.props.styleLabel}}
+              style={{color: undefined, ...styles.navText, ...this.props.styleLabel}}
               className="title"
             >
               {this.props.label}
@@ -208,12 +208,12 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
     const backgroundColor = Styles.globalColors.blueDarker2
     return (
       <Kb.Box
-        style={{...stylesTabBarButtonIcon, backgroundColor, ...this.props.style}}
+        style={{...styles.tabBarButtonIcon, backgroundColor, ...this.props.style}}
         onClick={this.props.onClick}
       >
         <Kb.Icon
           type={this.props.source.icon}
-          style={Styles.collapseStyles([stylesIcon, this.props.styleIcon])}
+          style={Styles.collapseStyles([styles.icon, this.props.styleIcon])}
           color={color}
         />
         {!!this.props.label && (
@@ -226,7 +226,7 @@ class TabBarButton extends React.Component<TabBarButtonProps> {
           </Kb.Text>
         )}
         {badgeNumber > 0 && (
-          <Kb.Box style={{...styleBadgeIcon, ...this.props.styleBadgeContainer}}>
+          <Kb.Box style={{...styles.badgeIcon, ...this.props.styleBadgeContainer}}>
             <Kb.Badge
               badgeNumber={badgeNumber}
               badgeStyle={this.props.styleBadge}
@@ -294,47 +294,13 @@ class TabBar extends React.Component<Props> {
       </Kb.Box>
     )
     return (
-      <Kb.Box style={{...stylesContainer, ...this.props.style}}>
+      <Kb.Box style={{...styles.container, ...this.props.style}}>
         {!this.props.tabBarOnBottom && tabBarButtons}
         {this._content()}
         {this.props.tabBarOnBottom && tabBarButtons}
       </Kb.Box>
     )
   }
-}
-
-const stylesContainer = {
-  ...Styles.globalStyles.flexBoxColumn,
-}
-
-const stylesTabBarButtonIcon = {
-  ...Styles.globalStyles.flexBoxRow,
-  ...Styles.desktopStyles.clickable,
-  alignItems: 'center',
-  flex: 1,
-  paddingLeft: 20,
-  position: 'relative',
-}
-
-const stylesIcon = Styles.platformStyles({
-  common: {
-    height: 14,
-    lineHeight: 16,
-    marginBottom: 2,
-    paddingRight: 6,
-    textAlign: 'center',
-  },
-})
-
-const stylesTabBarNavIcon = {
-  ...Styles.globalStyles.flexBoxColumn,
-  ...Styles.desktopStyles.clickable,
-  alignItems: 'center',
-  flex: 1,
-  height: 58,
-  justifyContent: 'center',
-  position: 'relative',
-  width: 80,
 }
 
 const navRealCSS = `
@@ -351,27 +317,58 @@ const navRealCSS = `
   }; opacity: 1.0;}
 `
 
-const stylesNavText = {
-  fontSize: 11,
-  marginTop: 2,
-}
-
-const styleBadgeAvatar = {
-  left: 46,
-  position: 'absolute',
-  top: 4,
-}
-
-const styleBadgeNav = {
-  position: 'absolute',
-  right: 12,
-  top: 4,
-}
-
-const styleBadgeIcon = {
-  marginLeft: 'auto',
-  marginRight: 8,
-}
+const styles = Styles.styleSheetCreate(() => ({
+  badgeAvatar: {
+    left: 46,
+    position: 'absolute',
+    top: 4,
+  },
+  badgeIcon: {
+    marginLeft: 'auto',
+    marginRight: 8,
+  },
+  badgeNav: {
+    position: 'absolute',
+    right: 12,
+    top: 4,
+  },
+  container: Styles.globalStyles.flexBoxColumn,
+  icon: Styles.platformStyles({
+    common: {
+      height: 14,
+      lineHeight: 16,
+      marginBottom: 2,
+      paddingRight: 6,
+      textAlign: 'center',
+    },
+  }),
+  navText: {
+    fontSize: 11,
+    marginTop: 2,
+  },
+  tabBarButtonIcon: Styles.collapseStyles([
+    Styles.globalStyles.flexBoxRow,
+    Styles.desktopStyles.clickable,
+    {
+      alignItems: 'center',
+      flex: 1,
+      paddingLeft: 20,
+      position: 'relative',
+    },
+  ]),
+  tabBarNavIcon: Styles.collapseStyles([
+    Styles.globalStyles.flexBoxColumn,
+    Styles.desktopStyles.clickable,
+    {
+      alignItems: 'center',
+      flex: 1,
+      height: 58,
+      justifyContent: 'center',
+      position: 'relative',
+      width: 80,
+    },
+  ]),
+}))
 
 export {TabBarItem, TabBarButton}
 export default TabBar

--- a/shared/common-adapters/tab-bar.native.tsx
+++ b/shared/common-adapters/tab-bar.native.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import {get} from 'lodash-es'
 import {Props, ItemProps, TabBarButtonProps} from './tab-bar'
 import {NativeTouchableWithoutFeedback, NativeStyleSheet} from './native-wrappers.native'
@@ -7,7 +8,14 @@ import Box from './box'
 import Icon from './icon'
 import Meta from './meta'
 import Text from './text'
-import {globalStyles, globalColors, globalMargins} from '../styles'
+
+const Kb = {
+  Badge,
+  Box,
+  Icon,
+  Meta,
+  Text,
+}
 
 class TabBarItem extends React.Component<ItemProps> {
   render() {
@@ -17,25 +25,28 @@ class TabBarItem extends React.Component<ItemProps> {
 
 class SimpleTabBarButton extends React.Component<ItemProps> {
   render() {
-    const selectedColor = this.props.selectedColor || globalColors.blue
+    const selectedColor = this.props.selectedColor || Styles.globalColors.blue
     return (
-      <Box style={{...stylesTab, ...this.props.style}}>
-        <Text
+      <Kb.Box style={{...stylesTab, ...this.props.style}}>
+        <Kb.Text
           type="BodySmallSemibold"
-          style={{...stylesLabel, color: this.props.selected ? globalColors.black : globalColors.black_50}}
+          style={{
+            ...stylesLabel,
+            color: this.props.selected ? Styles.globalColors.black : Styles.globalColors.black_50,
+          }}
         >
           {!!this.props.label && this.props.label.toUpperCase()}
-        </Text>
-        <Box style={this.props.selected ? stylesSelectedUnderline(selectedColor) : stylesUnselected} />
-      </Box>
+        </Kb.Text>
+        <Kb.Box style={this.props.selected ? stylesSelectedUnderline(selectedColor) : stylesUnselected} />
+      </Kb.Box>
     )
   }
 }
 
 const UnderlineHighlight = () => (
-  <Box
+  <Kb.Box
     style={{
-      backgroundColor: globalColors.white,
+      backgroundColor: Styles.globalColors.white,
       borderTopLeftRadius: 3,
       borderTopRightRadius: 3,
       bottom: 0,
@@ -54,16 +65,16 @@ const TabBarButton = (props: TabBarButtonProps) => {
   if (props.badgeNumber) {
     if (props.badgePosition === 'top-right') {
       badgeComponent = (
-        <Badge badgeNumber={props.badgeNumber} badgeStyle={{left: '52%', position: 'absolute', top: 2}} />
+        <Kb.Badge badgeNumber={props.badgeNumber} badgeStyle={{left: '52%', position: 'absolute', top: 2}} />
       )
     } else {
-      badgeComponent = <Badge badgeNumber={badgeNumber} badgeStyle={{marginLeft: 5}} />
+      badgeComponent = <Kb.Badge badgeNumber={badgeNumber} badgeStyle={{marginLeft: 5}} />
     }
   }
 
   const content = (
-    <Box style={{...stylesTabBarButtonIcon, ...props.style, flexGrow: 1}}>
-      <Icon
+    <Kb.Box style={{...stylesTabBarButtonIcon, ...props.style, flexGrow: 1}}>
+      <Kb.Icon
         type={
           // @ts-ignore
           props.source.icon
@@ -75,23 +86,23 @@ const TabBarButton = (props: TabBarButtonProps) => {
         sizeType="Big"
       />
       {!!props.label && (
-        <Text center={true} type="BodySemibold" style={{...props.styleLabel}}>
+        <Kb.Text center={true} type="BodySemibold" style={{...props.styleLabel}}>
           {props.label}
-        </Text>
+        </Kb.Text>
       )}
       {badgeComponent}
       {props.isNew && (
-        <Box style={styleBadgeNav}>
-          <Meta
+        <Kb.Box style={styleBadgeNav}>
+          <Kb.Meta
             title="new"
             size="Small"
             style={{alignSelf: 'center', marginRight: 4}}
-            backgroundColor={globalColors.blueLight}
+            backgroundColor={Styles.globalColors.blueLight}
           />
-        </Box>
+        </Kb.Box>
       )}
       {props.underlined && <UnderlineHighlight />}
-    </Box>
+    </Kb.Box>
   )
   if (props.onClick) {
     return (
@@ -111,11 +122,11 @@ class TabBar extends React.Component<Props> {
       const key = item.props.label || get(item, 'props.tabBarButton.props.label') || i
       return (
         <NativeTouchableWithoutFeedback key={key} onPress={item.props.onClick || (() => {})}>
-          <Box style={{flex: 1}}>
-            <Box style={item.props.styleContainer}>
+          <Kb.Box style={{flex: 1}}>
+            <Kb.Box style={item.props.styleContainer}>
               {item.props.tabBarButton || <SimpleTabBarButton {...item.props} />}
-            </Box>
-          </Box>
+            </Kb.Box>
+          </Kb.Box>
         </NativeTouchableWithoutFeedback>
       )
     })
@@ -127,17 +138,19 @@ class TabBar extends React.Component<Props> {
 
   render() {
     const tabBarButtons = (
-      <Box style={globalStyles.flexBoxColumn}>
-        <Box style={{...globalStyles.flexBoxRow, ...this.props.styleTabBar}}>{this._labels()}</Box>
-        {this.props.underlined && <Box style={stylesUnderline} />}
-      </Box>
+      <Kb.Box style={Styles.globalStyles.flexBoxColumn}>
+        <Kb.Box style={{...Styles.globalStyles.flexBoxRow, ...this.props.styleTabBar}}>
+          {this._labels()}
+        </Kb.Box>
+        {this.props.underlined && <Kb.Box style={stylesUnderline} />}
+      </Kb.Box>
     )
     return (
-      <Box style={{...stylesContainer, ...this.props.style}}>
+      <Kb.Box style={{...stylesContainer, ...this.props.style}}>
         {!this.props.tabBarOnBottom && tabBarButtons}
         {this._content()}
         {this.props.tabBarOnBottom && tabBarButtons}
-      </Box>
+      </Kb.Box>
     )
   }
 }
@@ -149,19 +162,19 @@ const styleBadgeNav = {
 }
 
 const stylesContainer = {
-  ...globalStyles.flexBoxColumn,
-  ...globalStyles.fullHeight,
+  ...Styles.globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.fullHeight,
 }
 
 const stylesTab = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'center',
   flexGrow: 1,
   justifyContent: 'flex-end',
 }
 
 const stylesTabBarButtonIcon = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'center',
   flexGrow: 1,
   justifyContent: 'center',
@@ -169,7 +182,7 @@ const stylesTabBarButtonIcon = {
 }
 
 const stylesLabel = {
-  height: globalMargins.small,
+  height: Styles.globalMargins.small,
   marginBottom: 11,
   marginTop: 11,
 }
@@ -187,7 +200,7 @@ const stylesUnselected = {
 
 const stylesUnderline = {
   alignSelf: 'stretch',
-  backgroundColor: globalColors.black_10,
+  backgroundColor: Styles.globalColors.black_10,
   height: NativeStyleSheet.hairlineWidth,
 }
 

--- a/shared/common-adapters/tab-bar.native.tsx
+++ b/shared/common-adapters/tab-bar.native.tsx
@@ -27,17 +27,17 @@ class SimpleTabBarButton extends React.Component<ItemProps> {
   render() {
     const selectedColor = this.props.selectedColor || Styles.globalColors.blue
     return (
-      <Kb.Box style={{...stylesTab, ...this.props.style}}>
+      <Kb.Box style={{...styles.tab, ...this.props.style}}>
         <Kb.Text
           type="BodySmallSemibold"
           style={{
-            ...stylesLabel,
+            ...styles.label,
             color: this.props.selected ? Styles.globalColors.black : Styles.globalColors.black_50,
           }}
         >
           {!!this.props.label && this.props.label.toUpperCase()}
         </Kb.Text>
-        <Kb.Box style={this.props.selected ? stylesSelectedUnderline(selectedColor) : stylesUnselected} />
+        <Kb.Box style={this.props.selected ? stylesSelectedUnderline(selectedColor) : styles.unselected} />
       </Kb.Box>
     )
   }
@@ -73,7 +73,7 @@ const TabBarButton = (props: TabBarButtonProps) => {
   }
 
   const content = (
-    <Kb.Box style={{...stylesTabBarButtonIcon, ...props.style, flexGrow: 1}}>
+    <Kb.Box style={{...styles.tabBarButtonIcon, ...props.style, flexGrow: 1}}>
       <Kb.Icon
         type={
           // @ts-ignore
@@ -92,7 +92,7 @@ const TabBarButton = (props: TabBarButtonProps) => {
       )}
       {badgeComponent}
       {props.isNew && (
-        <Kb.Box style={styleBadgeNav}>
+        <Kb.Box style={styles.badgeNav}>
           <Kb.Meta
             title="new"
             size="Small"
@@ -142,49 +142,17 @@ class TabBar extends React.Component<Props> {
         <Kb.Box style={{...Styles.globalStyles.flexBoxRow, ...this.props.styleTabBar}}>
           {this._labels()}
         </Kb.Box>
-        {this.props.underlined && <Kb.Box style={stylesUnderline} />}
+        {this.props.underlined && <Kb.Box style={styles.underline} />}
       </Kb.Box>
     )
     return (
-      <Kb.Box style={{...stylesContainer, ...this.props.style}}>
+      <Kb.Box style={{...styles.container, ...this.props.style}}>
         {!this.props.tabBarOnBottom && tabBarButtons}
         {this._content()}
         {this.props.tabBarOnBottom && tabBarButtons}
       </Kb.Box>
     )
   }
-}
-
-const styleBadgeNav = {
-  position: 'absolute',
-  right: 12,
-  top: 4,
-}
-
-const stylesContainer = {
-  ...Styles.globalStyles.flexBoxColumn,
-  ...Styles.globalStyles.fullHeight,
-}
-
-const stylesTab = {
-  ...Styles.globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  flexGrow: 1,
-  justifyContent: 'flex-end',
-}
-
-const stylesTabBarButtonIcon = {
-  ...Styles.globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  flexGrow: 1,
-  justifyContent: 'center',
-  position: 'relative',
-}
-
-const stylesLabel = {
-  height: Styles.globalMargins.small,
-  marginBottom: 11,
-  marginTop: 11,
 }
 
 const stylesSelectedUnderline = color => ({
@@ -194,15 +162,44 @@ const stylesSelectedUnderline = color => ({
   marginBottom: -1,
 })
 
-const stylesUnselected = {
-  height: 2,
-}
-
-const stylesUnderline = {
-  alignSelf: 'stretch',
-  backgroundColor: Styles.globalColors.black_10,
-  height: NativeStyleSheet.hairlineWidth,
-}
+const styles = Styles.styleSheetCreate(() => ({
+  badgeNav: {
+    position: 'absolute',
+    right: 12,
+    top: 4,
+  },
+  container: Styles.collapseStyles([Styles.globalStyles.flexBoxColumn, Styles.globalStyles.fullHeight]),
+  label: {
+    height: Styles.globalMargins.small,
+    marginBottom: 11,
+    marginTop: 11,
+  },
+  tab: Styles.collapseStyles([
+    Styles.globalStyles.flexBoxColumn,
+    {
+      alignItems: 'center',
+      flexGrow: 1,
+      justifyContent: 'flex-end',
+    },
+  ]),
+  tabBarButtonIcon: Styles.collapseStyles([
+    Styles.globalStyles.flexBoxColumn,
+    {
+      alignItems: 'center',
+      flexGrow: 1,
+      justifyContent: 'center',
+      position: 'relative',
+    },
+  ]),
+  underline: {
+    alignSelf: 'stretch',
+    backgroundColor: Styles.globalColors.black_10,
+    height: NativeStyleSheet.hairlineWidth,
+  },
+  unselected: {
+    height: 2,
+  },
+}))
 
 export {TabBarItem, TabBarButton}
 

--- a/shared/common-adapters/tabs.tsx
+++ b/shared/common-adapters/tabs.tsx
@@ -49,7 +49,7 @@ const Tabs = ({clickableBoxStyle, tabs, selected, onSelect, style, tabStyle}: Pr
   )
 }
 
-const styles = styleSheetCreate({
+const styles = styleSheetCreate(() => ({
   container: {
     ...globalStyles.flexBoxRow,
     alignItems: 'flex-start',
@@ -85,6 +85,6 @@ const styles = styleSheetCreate({
   tabSelected: {
     color: globalColors.black,
   },
-})
+}))
 
 export default Tabs

--- a/shared/common-adapters/tabs.tsx
+++ b/shared/common-adapters/tabs.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import Box from './box'
 import ClickableBox from './clickable-box'
 import Divider from './divider'
-import {
-  collapseStyles,
-  globalColors,
-  globalMargins,
-  globalStyles,
-  isMobile,
-  platformStyles,
-  styleSheetCreate,
-} from '../styles'
+
+const Kb = {
+  Box,
+  ClickableBox,
+  Divider,
+}
 
 type Props = {
   clickableBoxStyle?: any
@@ -23,57 +21,60 @@ type Props = {
 
 const Tabs = ({clickableBoxStyle, tabs, selected, onSelect, style, tabStyle}: Props) => {
   return (
-    <Box style={collapseStyles([styles.container, style])}>
+    <Kb.Box style={Styles.collapseStyles([styles.container, style])}>
       {tabs.map((t, idx) => {
         // @ts-ignore
         const key: string = (t && t.key) || idx
         return (
-          <ClickableBox onClick={() => onSelect(t)} key={key} style={clickableBoxStyle}>
-            <Box style={styles.tabContainer}>
-              <Box style={collapseStyles([styles.tab, t === selected && styles.tabSelected, tabStyle])}>
+          <Kb.ClickableBox onClick={() => onSelect(t)} key={key} style={clickableBoxStyle}>
+            <Kb.Box style={styles.tabContainer}>
+              <Kb.Box
+                style={Styles.collapseStyles([styles.tab, t === selected && styles.tabSelected, tabStyle])}
+              >
                 {t}
-              </Box>
-              <Divider
-                style={collapseStyles([
+              </Kb.Box>
+              <Kb.Divider
+                style={Styles.collapseStyles([
                   styles.divider,
                   {
-                    backgroundColor: t === selected ? globalColors.blue : globalColors.transparent,
+                    backgroundColor:
+                      t === selected ? Styles.globalColors.blue : Styles.globalColors.transparent,
                   },
                 ])}
               />
-            </Box>
-          </ClickableBox>
+            </Kb.Box>
+          </Kb.ClickableBox>
         )
       })}
-    </Box>
+    </Kb.Box>
   )
 }
 
-const styles = styleSheetCreate(() => ({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
-    ...globalStyles.flexBoxRow,
+    ...Styles.globalStyles.flexBoxRow,
     alignItems: 'flex-start',
-    borderBottomColor: globalColors.black_10,
+    borderBottomColor: Styles.globalColors.black_10,
     borderBottomWidth: 1,
     borderStyle: 'solid',
     flex: 1,
-    maxHeight: isMobile ? 48 : 40,
+    maxHeight: Styles.isMobile ? 48 : 40,
     width: '100%',
   },
   divider: {
-    ...globalStyles.flexBoxRow,
+    ...Styles.globalStyles.flexBoxRow,
     minHeight: 2,
   },
   tab: {
     flex: 1,
-    paddingBottom: globalMargins.xtiny,
-    paddingLeft: globalMargins.small,
-    paddingRight: globalMargins.small,
-    paddingTop: globalMargins.small,
+    paddingBottom: Styles.globalMargins.xtiny,
+    paddingLeft: Styles.globalMargins.small,
+    paddingRight: Styles.globalMargins.small,
+    paddingTop: Styles.globalMargins.small,
   },
-  tabContainer: platformStyles({
+  tabContainer: Styles.platformStyles({
     common: {
-      ...globalStyles.flexBoxColumn,
+      ...Styles.globalStyles.flexBoxColumn,
     },
     isElectron: {
       height: 40,
@@ -83,7 +84,7 @@ const styles = styleSheetCreate(() => ({
     },
   }),
   tabSelected: {
-    color: globalColors.black,
+    color: Styles.globalColors.black,
   },
 }))
 

--- a/shared/common-adapters/text.meta.desktop.tsx
+++ b/shared/common-adapters/text.meta.desktop.tsx
@@ -1,15 +1,15 @@
-import {globalStyles, globalColors, isDarkMode} from '../styles'
+import * as Styles from '../styles'
 import {MetaType, TextType, Background} from './text'
 
 export function defaultColor(backgroundMode: Background | null) {
   return {
-    Announcements: globalColors.white,
-    Documentation: globalColors.white,
-    HighRisk: globalColors.white,
-    Information: globalColors.brown_75,
-    Normal: globalColors.white,
-    Success: globalColors.white,
-    Terminal: globalColors.white,
+    Announcements: Styles.globalColors.white,
+    Documentation: Styles.globalColors.white,
+    HighRisk: Styles.globalColors.white,
+    Information: Styles.globalColors.brown_75,
+    Normal: Styles.globalColors.white,
+    Success: Styles.globalColors.white,
+    Terminal: Styles.globalColors.white,
   }[backgroundMode || 'Normal']
 }
 
@@ -41,46 +41,46 @@ export function fontSizeToSizeStyle(fontSize: number): Object | null {
 
 const _metaData = (): {[K in TextType]: MetaType} => {
   const whiteNegative = {
-    negative: globalColors.white,
-    positive: globalColors.black,
+    negative: Styles.globalColors.white,
+    positive: Styles.globalColors.black,
   }
 
   const _blueLink = {
-    negative: globalColors.white,
-    positive: globalColors.blue,
+    negative: Styles.globalColors.white,
+    positive: Styles.globalColors.blue,
   }
   return {
     Body: {
       colorForBackground: whiteNegative,
       fontSize: 14,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodyBig: {
       colorForBackground: whiteNegative,
       fontSize: 15,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodyBigExtrabold: {
       colorForBackground: whiteNegative,
       fontSize: 15,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodyBigLink: {
       colorForBackground: _blueLink,
       fontSize: 15,
       isLink: true,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodyExtrabold: {
       colorForBackground: whiteNegative,
       fontSize: 14,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodyItalic: {
       colorForBackground: whiteNegative,
       fontSize: 14,
       styleOverride: {
-        ...globalStyles.fontRegular,
+        ...Styles.globalStyles.fontRegular,
         fontStyle: 'italic',
       },
     },
@@ -88,24 +88,24 @@ const _metaData = (): {[K in TextType]: MetaType} => {
       colorForBackground: _blueLink,
       fontSize: 14,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySecondaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 14,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySemibold: {
       colorForBackground: whiteNegative,
       fontSize: 14,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodySemiboldItalic: {
       colorForBackground: whiteNegative,
       fontSize: 14,
       styleOverride: {
-        ...globalStyles.fontSemibold,
+        ...Styles.globalStyles.fontSemibold,
         fontStyle: 'italic',
       },
     },
@@ -113,154 +113,154 @@ const _metaData = (): {[K in TextType]: MetaType} => {
       colorForBackground: _blueLink,
       fontSize: 14,
       isLink: true,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodySmall: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallBold: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     BodySmallError: {
-      colorForBackground: {...whiteNegative, positive: globalColors.red},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.red},
       fontSize: 13,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallExtrabold: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodySmallExtraboldSecondaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 13,
       isLink: true,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodySmallItalic: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 13,
       styleOverride: {
-        ...globalStyles.fontRegular,
+        ...Styles.globalStyles.fontRegular,
         fontStyle: 'italic',
       },
     },
     BodySmallPrimaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.blue},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.blue},
       fontSize: 13,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallSecondaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 13,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallSemibold: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 13,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodySmallSemiboldItalic: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 13,
-      styleOverride: {...globalStyles.fontSemibold, fontStyle: 'italic'},
+      styleOverride: {...Styles.globalStyles.fontSemibold, fontStyle: 'italic'},
     },
     BodySmallSemiboldPrimaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.blue},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.blue},
       fontSize: 13,
       isLink: true,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodySmallSemiboldSecondaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 13,
       isLink: true,
-      styleOverride: {...globalStyles.fontSemibold, textDecoration: undefined},
+      styleOverride: {...Styles.globalStyles.fontSemibold, textDecoration: undefined},
     },
     BodySmallSuccess: {
-      colorForBackground: {...whiteNegative, positive: globalColors.green},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.green},
       fontSize: 13,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallWallet: {
-      colorForBackground: {...whiteNegative, positive: globalColors.purple},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.purple},
       fontSize: 13,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodyTiny: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 12,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodyTinyBold: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 12,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     BodyTinyExtrabold: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 12,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodyTinyLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 12,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodyTinySemibold: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 12,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodyTinySemiboldItalic: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 12,
       styleOverride: {
-        ...globalStyles.fontSemibold,
+        ...Styles.globalStyles.fontSemibold,
         fontStyle: 'italic',
       },
     },
     Header: {
       colorForBackground: whiteNegative,
       fontSize: 18,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     HeaderBig: {
       colorForBackground: whiteNegative,
       fontSize: 24,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     HeaderBigExtrabold: {
       colorForBackground: whiteNegative,
       fontSize: 24,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     HeaderExtrabold: {
       colorForBackground: whiteNegative,
       fontSize: 18,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     HeaderItalic: {
       colorForBackground: whiteNegative,
       fontSize: 18,
       styleOverride: {
-        ...globalStyles.fontBold,
+        ...Styles.globalStyles.fontBold,
         fontStyle: 'italic',
       },
     },
@@ -268,48 +268,48 @@ const _metaData = (): {[K in TextType]: MetaType} => {
       colorForBackground: _blueLink,
       fontSize: 18,
       isLink: true,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     Terminal: {
       colorForBackground: {
-        negative: globalColors.blueLighter,
-        positive: globalColors.blueLighter,
+        negative: Styles.globalColors.blueLighter,
+        positive: Styles.globalColors.blueLighter,
       },
       fontSize: 13,
       styleOverride: {
-        ...globalStyles.fontTerminal,
+        ...Styles.globalStyles.fontTerminal,
         lineHeight: '20px',
       },
     },
     TerminalComment: {
       colorForBackground: {
-        negative: globalColors.blueLighter_40,
-        positive: globalColors.blueLighter_40,
+        negative: Styles.globalColors.blueLighter_40,
+        positive: Styles.globalColors.blueLighter_40,
       },
       fontSize: 13,
       styleOverride: {
-        ...globalStyles.fontTerminal,
+        ...Styles.globalStyles.fontTerminal,
         lineHeight: '20px',
       },
     },
     TerminalEmpty: {
       colorForBackground: {
-        negative: globalColors.blueLighter_40,
-        positive: globalColors.blueLighter_40,
+        negative: Styles.globalColors.blueLighter_40,
+        positive: Styles.globalColors.blueLighter_40,
       },
       fontSize: 13,
       styleOverride: {
-        ...globalStyles.fontTerminal,
+        ...Styles.globalStyles.fontTerminal,
         height: 20,
         lineHeight: '20px',
       },
     },
     TerminalInline: {
-      colorForBackground: {...whiteNegative, positive: globalColors.blueDarker},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.blueDarker},
       fontSize: 13,
       styleOverride: {
-        ...globalStyles.fontTerminal,
-        backgroundColor: globalColors.blueLighter2,
+        ...Styles.globalStyles.fontTerminal,
+        backgroundColor: Styles.globalColors.blueLighter2,
         borderRadius: 2,
         display: 'inline-block',
         height: 17,
@@ -325,7 +325,7 @@ let _darkMetaData: {[K in TextType]: MetaType} | undefined
 let _lightMetaData: {[K in TextType]: MetaType} | undefined
 
 export const metaData = (): {[K in TextType]: MetaType} => {
-  if (isDarkMode()) {
+  if (Styles.isDarkMode()) {
     _darkMetaData = _darkMetaData || _metaData()
     return _darkMetaData
   } else {

--- a/shared/common-adapters/text.meta.native.tsx
+++ b/shared/common-adapters/text.meta.native.tsx
@@ -1,16 +1,15 @@
-import {globalStyles, globalColors, isDarkMode} from '../styles'
-
+import * as Styles from '../styles'
 import {MetaType, TextType, Background} from './text'
 
 export function defaultColor(backgroundMode: Background | null) {
   return {
-    Announcements: globalColors.white,
-    Documentation: globalColors.white,
-    HighRisk: globalColors.white,
-    Information: globalColors.brown_75,
-    Normal: globalColors.white,
-    Success: globalColors.white,
-    Terminal: globalColors.white,
+    Announcements: Styles.globalColors.white,
+    Documentation: Styles.globalColors.white,
+    HighRisk: Styles.globalColors.white,
+    Information: Styles.globalColors.brown_75,
+    Normal: Styles.globalColors.white,
+    Success: Styles.globalColors.white,
+    Terminal: Styles.globalColors.white,
   }[backgroundMode || 'Normal']
 }
 
@@ -40,74 +39,74 @@ export function fontSizeToSizeStyle(fontSize: number): {fontSize: number; lineHe
 
 const _metaData = (): {[K in TextType]: MetaType} => {
   const whiteNegative = {
-    negative: globalColors.white,
-    positive: globalColors.black,
+    negative: Styles.globalColors.white,
+    positive: Styles.globalColors.black,
   }
 
   const _blueLink = {
-    negative: globalColors.white,
-    positive: globalColors.blue,
+    negative: Styles.globalColors.white,
+    positive: Styles.globalColors.blue,
   }
   return {
     Body: {
       colorForBackground: whiteNegative,
       fontSize: 16,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodyBig: {
       colorForBackground: whiteNegative,
       fontSize: 17,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodyBigExtrabold: {
       colorForBackground: whiteNegative,
       fontSize: 17,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodyBigLink: {
       colorForBackground: _blueLink,
       fontSize: 17,
       isLink: true,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodyExtrabold: {
       colorForBackground: whiteNegative,
       fontSize: 16,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodyItalic: {
       colorForBackground: whiteNegative,
       fontSize: 16,
       styleOverride: {
-        ...globalStyles.fontRegular,
+        ...Styles.globalStyles.fontRegular,
         fontStyle: 'italic',
       },
     },
     BodyPrimaryLink: {
       colorForBackground: {
         ..._blueLink,
-        negative: globalColors.white,
+        negative: Styles.globalColors.white,
       },
       fontSize: 16,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySecondaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 16,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySemibold: {
       colorForBackground: whiteNegative,
       fontSize: 16,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodySemiboldItalic: {
       colorForBackground: whiteNegative,
       fontSize: 16,
       styleOverride: {
-        ...globalStyles.fontSemibold,
+        ...Styles.globalStyles.fontSemibold,
         fontStyle: 'italic',
       },
     },
@@ -115,51 +114,51 @@ const _metaData = (): {[K in TextType]: MetaType} => {
       colorForBackground: _blueLink,
       fontSize: 16,
       isLink: true,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodySmall: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 15,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallBold: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 15,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     BodySmallError: {
-      colorForBackground: {...whiteNegative, positive: globalColors.red},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.red},
       fontSize: 15,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallExtrabold: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 15,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodySmallExtraboldSecondaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 15,
       isLink: true,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodySmallItalic: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 15,
       styleOverride: {
-        ...globalStyles.fontRegular,
+        ...Styles.globalStyles.fontRegular,
         fontStyle: 'italic',
       },
     },
@@ -167,129 +166,129 @@ const _metaData = (): {[K in TextType]: MetaType} => {
       colorForBackground: _blueLink,
       fontSize: 15,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallSecondaryLink: {
-      colorForBackground: {...whiteNegative, positive: globalColors.black_50},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.black_50},
       fontSize: 15,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallSemibold: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 15,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodySmallSemiboldItalic: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 15,
-      styleOverride: {...globalStyles.fontSemibold, fontStyle: 'italic'},
+      styleOverride: {...Styles.globalStyles.fontSemibold, fontStyle: 'italic'},
     },
     BodySmallSemiboldPrimaryLink: {
       colorForBackground: _blueLink,
       fontSize: 15,
       isLink: true,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodySmallSemiboldSecondaryLink: {
       colorForBackground: _blueLink,
       fontSize: 15,
       isLink: true,
-      styleOverride: {...globalStyles.fontSemibold, textDecorationLine: undefined},
+      styleOverride: {...Styles.globalStyles.fontSemibold, textDecorationLine: undefined},
     },
     BodySmallSuccess: {
-      colorForBackground: {...whiteNegative, positive: globalColors.green},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.green},
       fontSize: 15,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodySmallWallet: {
-      colorForBackground: {...whiteNegative, positive: globalColors.purple},
+      colorForBackground: {...whiteNegative, positive: Styles.globalColors.purple},
       fontSize: 15,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodyTiny: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodyTinyBold: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     BodyTinyExtrabold: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     BodyTinyLink: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
       isLink: true,
-      styleOverride: globalStyles.fontRegular,
+      styleOverride: Styles.globalStyles.fontRegular,
     },
     BodyTinySemibold: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
-      styleOverride: globalStyles.fontSemibold,
+      styleOverride: Styles.globalStyles.fontSemibold,
     },
     BodyTinySemiboldItalic: {
       colorForBackground: {
         ...whiteNegative,
-        positive: globalColors.black_50,
+        positive: Styles.globalColors.black_50,
       },
       fontSize: 13,
       styleOverride: {
-        ...globalStyles.fontSemibold,
+        ...Styles.globalStyles.fontSemibold,
         fontStyle: 'italic',
       },
     },
     Header: {
       colorForBackground: whiteNegative,
       fontSize: 20,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     HeaderBig: {
       colorForBackground: whiteNegative,
       fontSize: 28,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     HeaderBigExtrabold: {
       colorForBackground: whiteNegative,
       fontSize: 28,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     HeaderExtrabold: {
       colorForBackground: whiteNegative,
       fontSize: 20,
-      styleOverride: globalStyles.fontExtrabold,
+      styleOverride: Styles.globalStyles.fontExtrabold,
     },
     HeaderItalic: {
       colorForBackground: whiteNegative,
       fontSize: 20,
       styleOverride: {
-        ...globalStyles.fontBold,
+        ...Styles.globalStyles.fontBold,
         fontStyle: 'italic',
       },
     },
@@ -297,51 +296,51 @@ const _metaData = (): {[K in TextType]: MetaType} => {
       colorForBackground: _blueLink,
       fontSize: 20,
       isLink: true,
-      styleOverride: globalStyles.fontBold,
+      styleOverride: Styles.globalStyles.fontBold,
     },
     Terminal: {
       colorForBackground: {
-        negative: globalColors.blueDarker,
-        positive: globalColors.blueLighter,
+        negative: Styles.globalColors.blueDarker,
+        positive: Styles.globalColors.blueLighter,
       },
       fontSize: 15,
       styleOverride: {
-        ...globalStyles.fontTerminal,
+        ...Styles.globalStyles.fontTerminal,
         lineHeight: 20,
       },
     },
     TerminalComment: {
       colorForBackground: {
-        negative: globalColors.blueLighter_40,
-        positive: globalColors.blueLighter_40,
+        negative: Styles.globalColors.blueLighter_40,
+        positive: Styles.globalColors.blueLighter_40,
       },
       fontSize: 15,
       styleOverride: {
-        ...globalStyles.fontTerminal,
+        ...Styles.globalStyles.fontTerminal,
         lineHeight: 20,
       },
     },
     TerminalEmpty: {
       colorForBackground: {
-        negative: globalColors.blueLighter_40,
-        positive: globalColors.blueLighter_40,
+        negative: Styles.globalColors.blueLighter_40,
+        positive: Styles.globalColors.blueLighter_40,
       },
       fontSize: 15,
       styleOverride: {
-        ...globalStyles.fontTerminal,
+        ...Styles.globalStyles.fontTerminal,
         height: 20,
         lineHeight: 20,
       },
     },
     TerminalInline: {
       colorForBackground: {
-        negative: globalColors.blueDarker,
-        positive: globalColors.blueDarker,
+        negative: Styles.globalColors.blueDarker,
+        positive: Styles.globalColors.blueDarker,
       },
       fontSize: 15,
       styleOverride: {
-        ...globalStyles.fontTerminal,
-        backgroundColor: globalColors.blueLighter2,
+        ...Styles.globalStyles.fontTerminal,
+        backgroundColor: Styles.globalColors.blueLighter2,
         borderRadius: 2,
         height: 20,
         lineHeight: 20,
@@ -355,7 +354,7 @@ let _darkMetaData: {[K in TextType]: MetaType} | undefined
 let _lightMetaData: {[K in TextType]: MetaType} | undefined
 
 export const metaData = (): {[K in TextType]: MetaType} => {
-  if (isDarkMode()) {
+  if (Styles.isDarkMode()) {
     _darkMetaData = _darkMetaData || _metaData()
     return _darkMetaData
   } else {

--- a/shared/common-adapters/text.stories.tsx
+++ b/shared/common-adapters/text.stories.tsx
@@ -1,15 +1,21 @@
 import * as React from 'react'
 import * as Sb from '../stories/storybook'
+import * as Styles from '../styles'
 import Box from './box'
 import Icon from './icon'
 import Text, {allTextTypes, TextType} from './text'
-import {globalColors, globalMargins, globalStyles, isMobile, platformStyles} from '../styles'
 
-const SmallGap = () => <Box style={{minHeight: 24}} />
-const LargeGap = () => <Box style={{minHeight: 36}} />
+const Kb = {
+  Box,
+  Icon,
+  Text,
+}
+
+const SmallGap = () => <Kb.Box style={{minHeight: 24}} />
+const LargeGap = () => <Kb.Box style={{minHeight: 36}} />
 
 const displayBlock = {
-  style: platformStyles({
+  style: Styles.platformStyles({
     isElectron: {
       display: 'block',
     },
@@ -19,33 +25,33 @@ const hidden = {
   style: {opacity: 0},
 }
 const SecondaryColorBox = () => (
-  <Box
+  <Kb.Box
     style={{
-      ...globalStyles.flexBoxRow,
-      ...globalStyles.fillAbsolute,
+      ...Styles.globalStyles.flexBoxRow,
+      ...Styles.globalStyles.fillAbsolute,
       bottom: undefined,
       flex: 1,
       height: 30,
     }}
   >
-    <Box style={{backgroundColor: globalColors.blueDarker2, flex: 1}} />
-    <Box style={{backgroundColor: globalColors.blue, flex: 1}} />
-    <Box style={{backgroundColor: globalColors.red, flex: 1}} />
-    <Box style={{backgroundColor: globalColors.green, flex: 1}} />
-    <Box style={{backgroundColor: globalColors.blueDarker, flex: 1}} />
-  </Box>
+    <Kb.Box style={{backgroundColor: Styles.globalColors.blueDarker2, flex: 1}} />
+    <Kb.Box style={{backgroundColor: Styles.globalColors.blue, flex: 1}} />
+    <Kb.Box style={{backgroundColor: Styles.globalColors.red, flex: 1}} />
+    <Kb.Box style={{backgroundColor: Styles.globalColors.green, flex: 1}} />
+    <Kb.Box style={{backgroundColor: Styles.globalColors.blueDarker, flex: 1}} />
+  </Kb.Box>
 )
 
 const Container = ({backgroundColor, children}) => (
-  <Box
+  <Kb.Box
     style={{
       backgroundColor,
-      padding: isMobile ? 10 : 90,
+      padding: Styles.isMobile ? 10 : 90,
       position: 'relative',
     }}
   >
     {children}
-  </Box>
+  </Kb.Box>
 )
 
 const groups: Array<Array<{label: string; action?: boolean; type: TextType; normalOnly?: boolean}>> = [
@@ -94,7 +100,7 @@ const mapText = (secondary: boolean) => {
   groups.forEach((group, gidx) => {
     group.forEach(types => {
       const item = key => (
-        <Text
+        <Kb.Text
           type={types.type}
           onClick={types.action ? Sb.action(`${types.type} clicked`) : undefined}
           key={key}
@@ -105,7 +111,7 @@ const mapText = (secondary: boolean) => {
           }}
         >
           {types.label}
-        </Text>
+        </Kb.Text>
       )
       items.push(item(types.type + '1'))
       items.push(item(types.type + '2'))
@@ -124,62 +130,62 @@ const load = () => {
   Sb.storiesOf('Common', module)
     .addDecorator(Sb.scrollViewDecorator)
     .add('Text', () => (
-      <Box style={outerStyle}>
-        <Container backgroundColor={globalColors.white}>{mapText(false)}</Container>
-        <Container backgroundColor={globalColors.blue}>
+      <Kb.Box style={outerStyle}>
+        <Container backgroundColor={Styles.globalColors.white}>{mapText(false)}</Container>
+        <Container backgroundColor={Styles.globalColors.blue}>
           <SecondaryColorBox />
           {mapText(true)}
         </Container>
-      </Box>
+      </Kb.Box>
     ))
     .add('Text all', () => (
       <>
         {Object.keys(allTextTypes).map((t: any) => (
-          <Box key={t}>
-            <Text type={t}>{t}</Text>
-          </Box>
+          <Kb.Box key={t}>
+            <Kb.Text type={t}>{t}</Kb.Text>
+          </Kb.Box>
         ))}
       </>
     ))
     .add('Text centered', () => (
-      <Box style={{backgroundColor: 'red', width: 100}}>
-        <Text type="Header" center={true}>
+      <Kb.Box style={{backgroundColor: 'red', width: 100}}>
+        <Kb.Text type="Header" center={true}>
           This is centered
-        </Text>
-      </Box>
+        </Kb.Text>
+      </Kb.Box>
     ))
     .add('Text lineclamp', () => (
-      <Box style={{...globalStyles.flexBoxColumn, maxWidth: 600}}>
-        <Text type="Body">Lineclamp = 1</Text>
-        <Box style={{...globalStyles.flexBoxRow, flex: 1}}>
-          <Text type="BodySemibold" lineClamp={1}>
+      <Kb.Box style={{...Styles.globalStyles.flexBoxColumn, maxWidth: 600}}>
+        <Kb.Text type="Body">Lineclamp = 1</Kb.Text>
+        <Kb.Box style={{...Styles.globalStyles.flexBoxRow, flex: 1}}>
+          <Kb.Text type="BodySemibold" lineClamp={1}>
             {longText}
-          </Text>
-        </Box>
+          </Kb.Text>
+        </Kb.Box>
 
-        <Text type="Body" style={{marginTop: globalMargins.small}}>
+        <Kb.Text type="Body" style={{marginTop: Styles.globalMargins.small}}>
           Lineclamp = 1 with content to the right
-        </Text>
-        <Box style={{...globalStyles.flexBoxRow, flex: 1}}>
-          <Text type="BodySemibold" lineClamp={1} style={{flex: 1}}>
+        </Kb.Text>
+        <Kb.Box style={{...Styles.globalStyles.flexBoxRow, flex: 1}}>
+          <Kb.Text type="BodySemibold" lineClamp={1} style={{flex: 1}}>
             {longText}
-          </Text>
+          </Kb.Text>
           <Icon type="iconfont-edit" />
-        </Box>
+        </Kb.Box>
 
-        <Text type="Body" style={{marginTop: globalMargins.small}}>
+        <Kb.Text type="Body" style={{marginTop: Styles.globalMargins.small}}>
           Lineclamp = 4
-        </Text>
-        <Box style={{...globalStyles.flexBoxRow, flex: 1}}>
-          <Text type="BodySemibold" lineClamp={4}>
+        </Kb.Text>
+        <Kb.Box style={{...Styles.globalStyles.flexBoxRow, flex: 1}}>
+          <Kb.Text type="BodySemibold" lineClamp={4}>
             {longText}
-          </Text>
-        </Box>
-      </Box>
+          </Kb.Text>
+        </Kb.Box>
+      </Kb.Box>
     ))
 }
 
-const outerStyle = isMobile
+const outerStyle = Styles.isMobile
   ? {}
   : {display: 'grid', flex: 1, gridTemplateColumns: 'repeat(2, 1fr)', overflow: 'auto'}
 

--- a/shared/common-adapters/timeline-marker.tsx
+++ b/shared/common-adapters/timeline-marker.tsx
@@ -20,7 +20,7 @@ const TimelineMarker = ({idx, max, type, style}: Props) => (
 
 const circleSize = 8
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   circleClosed: Styles.platformStyles({
     common: {
       backgroundColor: timeline_grey,
@@ -61,6 +61,6 @@ const styles = Styles.styleSheetCreate({
       height: 8,
     },
   }),
-})
+}))
 
 export default TimelineMarker

--- a/shared/common-adapters/timeline-marker.tsx
+++ b/shared/common-adapters/timeline-marker.tsx
@@ -3,6 +3,10 @@ import Box from './box'
 import * as Styles from '../styles'
 import {timeline_grey} from './timeline-marker.meta'
 
+const Kb = {
+  Box,
+}
+
 export type Props = {
   idx: number
   max: number
@@ -11,11 +15,11 @@ export type Props = {
 }
 
 const TimelineMarker = ({idx, max, type, style}: Props) => (
-  <Box style={{...Styles.globalStyles.flexBoxColumn, alignItems: 'center', marginRight: 16, ...style}}>
-    <Box style={{...styles.line, opacity: idx ? 1 : 0}} />
-    {type === 'closed' ? <Box style={styles.circleClosed} /> : <Box style={styles.circleOpen} />}
-    <Box style={{...styles.line, opacity: idx < max ? 1 : 0}} />
-  </Box>
+  <Kb.Box style={{...Styles.globalStyles.flexBoxColumn, alignItems: 'center', marginRight: 16, ...style}}>
+    <Kb.Box style={{...styles.line, opacity: idx ? 1 : 0}} />
+    {type === 'closed' ? <Kb.Box style={styles.circleClosed} /> : <Kb.Box style={styles.circleOpen} />}
+    <Kb.Box style={{...styles.line, opacity: idx < max ? 1 : 0}} />
+  </Kb.Box>
 )
 
 const circleSize = 8

--- a/shared/common-adapters/toast.desktop.tsx
+++ b/shared/common-adapters/toast.desktop.tsx
@@ -3,6 +3,10 @@ import {Props} from './toast'
 import FloatingBox from './floating-box'
 import * as Styles from '../styles'
 
+const Kb = {
+  FloatingBox,
+}
+
 // @ts-ignore codemod-issue
 const FadeBox = Styles.styled.div({
   ...Styles.transition('opacity'),
@@ -13,14 +17,14 @@ const FadeBox = Styles.styled.div({
 })
 
 export default (props: Props) => (
-  <FloatingBox attachTo={props.attachTo} propagateOutsideClicks={true} position={props.position}>
+  <Kb.FloatingBox attachTo={props.attachTo} propagateOutsideClicks={true} position={props.position}>
     <FadeBox
       className={Styles.classNames({visible: props.visible}, props.className)}
       style={Styles.collapseStyles([styles.container, props.containerStyle])}
     >
       {props.children}
     </FadeBox>
-  </FloatingBox>
+  </Kb.FloatingBox>
 )
 
 const styles = Styles.styleSheetCreate(() => ({

--- a/shared/common-adapters/toast.desktop.tsx
+++ b/shared/common-adapters/toast.desktop.tsx
@@ -23,7 +23,7 @@ export default (props: Props) => (
   </FloatingBox>
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     alignItems: 'center',
     backgroundColor: Styles.globalColors.black,
@@ -36,4 +36,4 @@ const styles = Styles.styleSheetCreate({
     paddingRight: Styles.globalMargins.tiny,
     paddingTop: Styles.globalMargins.xtiny,
   },
-})
+}))

--- a/shared/common-adapters/toast.native.tsx
+++ b/shared/common-adapters/toast.native.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import FloatingBox from './floating-box'
 import Box from './box'
 import {useTimeout} from './use-timers'
-import {collapseStyles, globalColors, globalMargins, styleSheetCreate} from '../styles'
 import {NativeAnimated, NativeEasing} from './native-wrappers.native'
 import {Props} from './toast'
+
+const Kb = {
+  Box,
+  FloatingBox,
+}
 
 const noop = () => {}
 
@@ -45,32 +50,36 @@ const Toast = (props: Props) => {
     return noop
   }, [shouldRender])
   return shouldRender ? (
-    <FloatingBox>
-      <Box pointerEvents="none" style={styles.wrapper}>
+    <Kb.FloatingBox>
+      <Kb.Box pointerEvents="none" style={styles.wrapper}>
         <NativeAnimated.View
-          style={collapseStyles([styles.container, props.containerStyle, {opacity: opacityRef.current}])}
+          style={Styles.collapseStyles([
+            styles.container,
+            props.containerStyle,
+            {opacity: opacityRef.current},
+          ])}
         >
           {props.children}
         </NativeAnimated.View>
-      </Box>
-    </FloatingBox>
+      </Kb.Box>
+    </Kb.FloatingBox>
   ) : null
 }
 
-const styles = styleSheetCreate(() => ({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     alignItems: 'center',
-    backgroundColor: globalColors.black,
+    backgroundColor: Styles.globalColors.black,
     borderRadius: 70,
     borderWidth: 0,
     display: 'flex',
     height: 140,
     justifyContent: 'center',
-    margin: globalMargins.xtiny,
-    paddingBottom: globalMargins.xtiny,
-    paddingLeft: globalMargins.tiny,
-    paddingRight: globalMargins.tiny,
-    paddingTop: globalMargins.xtiny,
+    margin: Styles.globalMargins.xtiny,
+    paddingBottom: Styles.globalMargins.xtiny,
+    paddingLeft: Styles.globalMargins.tiny,
+    paddingRight: Styles.globalMargins.tiny,
+    paddingTop: Styles.globalMargins.xtiny,
     width: 140,
   },
   wrapper: {

--- a/shared/common-adapters/toast.native.tsx
+++ b/shared/common-adapters/toast.native.tsx
@@ -57,7 +57,7 @@ const Toast = (props: Props) => {
   ) : null
 }
 
-const styles = styleSheetCreate({
+const styles = styleSheetCreate(() => ({
   container: {
     alignItems: 'center',
     backgroundColor: globalColors.black,
@@ -82,6 +82,6 @@ const styles = styleSheetCreate({
     right: 0,
     top: 0,
   },
-})
+}))
 
 export default Toast

--- a/shared/common-adapters/tooltip.stories.tsx
+++ b/shared/common-adapters/tooltip.stories.tsx
@@ -79,7 +79,7 @@ const load = () => {
     ))
 }
 
-const styles = styleSheetCreate({
+const styles = styleSheetCreate(() => ({
   box: {
     backgroundColor: globalColors.purple_40,
     color: globalColors.white,
@@ -90,6 +90,6 @@ const styles = styleSheetCreate({
   container: {
     margin: globalMargins.xlarge,
   },
-})
+}))
 
 export default load

--- a/shared/common-adapters/tooltip.stories.tsx
+++ b/shared/common-adapters/tooltip.stories.tsx
@@ -1,94 +1,101 @@
 import * as React from 'react'
 import * as Sb from '../stories/storybook'
+import * as Styles from '../styles'
 import Box, {Box2} from './box'
 import Text from './text'
 import WithTooltip from './with-tooltip'
-import {globalMargins, globalColors, styleSheetCreate} from '../styles'
+
+const Kb = {
+  Box,
+  Box2,
+  Text,
+  WithTooltip,
+}
 
 const load = () => {
   Sb.storiesOf('Common', module)
     .addDecorator(Sb.scrollViewDecorator)
     .add('Tooltip', () => (
-      <Box2 direction="horizontal" style={{flexWrap: 'wrap'}}>
-        <WithTooltip text="Here's a tooltip" containerStyle={styles.container} showOnPressMobile={true}>
-          <Box style={styles.box}>
-            <Text type="Body">Hover me for a short tooltip</Text>
-          </Box>
-        </WithTooltip>
-        <WithTooltip
+      <Kb.Box2 direction="horizontal" style={{flexWrap: 'wrap'}}>
+        <Kb.WithTooltip text="Here's a tooltip" containerStyle={styles.container} showOnPressMobile={true}>
+          <Kb.Box style={styles.box}>
+            <Kb.Text type="Body">Hover me for a short tooltip</Kb.Text>
+          </Kb.Box>
+        </Kb.WithTooltip>
+        <Kb.WithTooltip
           containerStyle={styles.container}
           text="Here's a multiline tooltip lalala blahblah wejoif jewiofj weoifjwof iwjeoif jweoifj weoifj woief"
           multiline={true}
           showOnPressMobile={true}
         >
-          <Box style={styles.box}>
-            <Text type="Body">Hover me for a long tooltip</Text>
-          </Box>
-        </WithTooltip>
-        <WithTooltip
+          <Kb.Box style={styles.box}>
+            <Kb.Text type="Body">Hover me for a long tooltip</Kb.Text>
+          </Kb.Box>
+        </Kb.WithTooltip>
+        <Kb.WithTooltip
           containerStyle={styles.container}
           text="Here's a short tooltip"
           position="bottom center"
           showOnPressMobile={true}
         >
-          <Box style={styles.box}>
-            <Text type="Body">Hover me for [bottom center]</Text>
-          </Box>
-        </WithTooltip>
-        <WithTooltip
+          <Kb.Box style={styles.box}>
+            <Kb.Text type="Body">Hover me for [bottom center]</Kb.Text>
+          </Kb.Box>
+        </Kb.WithTooltip>
+        <Kb.WithTooltip
           containerStyle={styles.container}
           text="Here's a short tooltip"
           position="top left"
           showOnPressMobile={true}
         >
-          <Box style={styles.box}>
-            <Text type="Body">Hover me for [top left]</Text>
-          </Box>
-        </WithTooltip>
-        <WithTooltip
+          <Kb.Box style={styles.box}>
+            <Kb.Text type="Body">Hover me for [top left]</Kb.Text>
+          </Kb.Box>
+        </Kb.WithTooltip>
+        <Kb.WithTooltip
           containerStyle={styles.container}
           text="Here's a short tooltip"
           position="top right"
           showOnPressMobile={true}
         >
-          <Box style={styles.box}>
-            <Text type="Body">Hover me for [top right]</Text>
-          </Box>
-        </WithTooltip>
-        <WithTooltip
+          <Kb.Box style={styles.box}>
+            <Kb.Text type="Body">Hover me for [top right]</Kb.Text>
+          </Kb.Box>
+        </Kb.WithTooltip>
+        <Kb.WithTooltip
           containerStyle={styles.container}
           text="Here's a short tooltip"
           position="bottom left"
           showOnPressMobile={true}
         >
-          <Box style={styles.box}>
-            <Text type="Body">Hover me for [bottom left]</Text>
-          </Box>
-        </WithTooltip>
-        <WithTooltip
+          <Kb.Box style={styles.box}>
+            <Kb.Text type="Body">Hover me for [bottom left]</Kb.Text>
+          </Kb.Box>
+        </Kb.WithTooltip>
+        <Kb.WithTooltip
           containerStyle={styles.container}
           text="Here's a short tooltip"
           position="bottom right"
           showOnPressMobile={true}
         >
-          <Box style={styles.box}>
-            <Text type="Body">Hover me for [bottom right]</Text>
-          </Box>
-        </WithTooltip>
-      </Box2>
+          <Kb.Box style={styles.box}>
+            <Kb.Text type="Body">Hover me for [bottom right]</Kb.Text>
+          </Kb.Box>
+        </Kb.WithTooltip>
+      </Kb.Box2>
     ))
 }
 
-const styles = styleSheetCreate(() => ({
+const styles = Styles.styleSheetCreate(() => ({
   box: {
-    backgroundColor: globalColors.purple_40,
-    color: globalColors.white,
-    padding: globalMargins.xtiny,
+    backgroundColor: Styles.globalColors.purple_40,
+    color: Styles.globalColors.white,
+    padding: Styles.globalMargins.xtiny,
     textAlign: 'center',
     width: 'auto',
   },
   container: {
-    margin: globalMargins.xlarge,
+    margin: Styles.globalMargins.xlarge,
   },
 }))
 

--- a/shared/common-adapters/user-card.desktop.tsx
+++ b/shared/common-adapters/user-card.desktop.tsx
@@ -11,28 +11,29 @@ const Kb = {
 const avatarSize = 128
 
 const UserCard = ({outerStyle, onAvatarClicked, username, style, children}: Props) => (
-  <div style={{...styleContainer, ...outerStyle}}>
+  <div style={Styles.collapseStyles([styles.container, outerStyle])}>
     <Kb.Avatar size={avatarSize} onClick={onAvatarClicked} username={username} />
-    <div style={{...styleInside, ...style}}>{children}</div>
+    <div style={Styles.collapseStyles([styles.inside, style])}>{children}</div>
   </div>
 )
 
-const styleContainer = {
-  ...Styles.globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  height: 430,
-  width: 410,
-}
-
-const styleInside = {
-  ...Styles.globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  alignSelf: 'stretch',
-  backgroundColor: Styles.globalColors.white,
-  borderRadius: 4,
-  marginTop: -avatarSize / 2,
-  padding: 30,
-  paddingTop: 30 + avatarSize / 2,
-}
+const styles = Styles.styleSheetCreate(() => ({
+  container: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'center',
+    height: 430,
+    width: 410,
+  },
+  inside: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    backgroundColor: Styles.globalColors.white,
+    borderRadius: 4,
+    marginTop: -avatarSize / 2,
+    padding: 30,
+    paddingTop: 30 + avatarSize / 2,
+  },
+}))
 
 export default UserCard

--- a/shared/common-adapters/user-card.desktop.tsx
+++ b/shared/common-adapters/user-card.desktop.tsx
@@ -1,30 +1,34 @@
 import Avatar from './avatar'
 import * as React from 'react'
-import {globalStyles, globalColors} from '../styles'
+import * as Styles from '../styles'
 
 import {Props} from './user-card'
+
+const Kb = {
+  Avatar,
+}
 
 const avatarSize = 128
 
 const UserCard = ({outerStyle, onAvatarClicked, username, style, children}: Props) => (
   <div style={{...styleContainer, ...outerStyle}}>
-    <Avatar size={avatarSize} onClick={onAvatarClicked} username={username} />
+    <Kb.Avatar size={avatarSize} onClick={onAvatarClicked} username={username} />
     <div style={{...styleInside, ...style}}>{children}</div>
   </div>
 )
 
 const styleContainer = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'center',
   height: 430,
   width: 410,
 }
 
 const styleInside = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'center',
   alignSelf: 'stretch',
-  backgroundColor: globalColors.white,
+  backgroundColor: Styles.globalColors.white,
   borderRadius: 4,
   marginTop: -avatarSize / 2,
   padding: 30,

--- a/shared/common-adapters/user-card.native.tsx
+++ b/shared/common-adapters/user-card.native.tsx
@@ -13,42 +13,41 @@ const Kb = {
 const avatarSize = 96
 
 const UserCard = ({outerStyle, onAvatarClicked, username, style, children}: Props) => (
-  <Kb.Box style={{...styleContainer, ...outerStyle}}>
-    <Kb.Box style={styleAvatar}>
-      <Kb.Box style={styleAvatarBackground} />
+  <Kb.Box style={Styles.collapseStyles([styles.container, outerStyle])}>
+    <Kb.Box style={styles.avatar}>
+      <Kb.Box style={styles.avatarBackground} />
       <Kb.Avatar size={avatarSize} onClick={onAvatarClicked} username={username} />
     </Kb.Box>
-    <Kb.Box style={{...styleInside, ...style}}>{children}</Kb.Box>
+    <Kb.Box style={Styles.collapseStyles([styles.inside, style])}>{children}</Kb.Box>
   </Kb.Box>
 )
 
-const styleContainer = {
-  ...Styles.globalStyles.flexBoxColumn,
-  alignItems: 'stretch',
-}
-
-const styleInside = {
-  ...Styles.globalStyles.flexBoxColumn,
-  alignItems: 'stretch',
-  backgroundColor: Styles.globalColors.white,
-  justifyContent: 'flex-start',
-  padding: 16,
-}
-
-const styleAvatar = {
-  ...Styles.globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  alignSelf: 'stretch',
-  marginTop: 0,
-}
-
-const styleAvatarBackground = {
-  backgroundColor: Styles.globalColors.white,
-  height: avatarSize / 2,
-  left: 0,
-  position: 'absolute',
-  right: 0,
-  top: avatarSize / 2,
-}
+const styles = Styles.styleSheetCreate(() => ({
+  avatar: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    marginTop: 0,
+  },
+  avatarBackground: {
+    backgroundColor: Styles.globalColors.white,
+    height: avatarSize / 2,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: avatarSize / 2,
+  },
+  container: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'stretch',
+  },
+  inside: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'stretch',
+    backgroundColor: Styles.globalColors.white,
+    justifyContent: 'flex-start',
+    padding: 16,
+  },
+}))
 
 export default UserCard

--- a/shared/common-adapters/user-card.native.tsx
+++ b/shared/common-adapters/user-card.native.tsx
@@ -1,44 +1,49 @@
-import Avatar from './avatar'
 import * as React from 'react'
+import * as Styles from '../styles'
+import Avatar from './avatar'
 import Box from './box'
-import {globalStyles, globalColors} from '../styles'
 
 import {Props} from './user-card'
+
+const Kb = {
+  Avatar,
+  Box,
+}
 
 const avatarSize = 96
 
 const UserCard = ({outerStyle, onAvatarClicked, username, style, children}: Props) => (
-  <Box style={{...styleContainer, ...outerStyle}}>
-    <Box style={styleAvatar}>
-      <Box style={styleAvatarBackground} />
-      <Avatar size={avatarSize} onClick={onAvatarClicked} username={username} />
-    </Box>
-    <Box style={{...styleInside, ...style}}>{children}</Box>
-  </Box>
+  <Kb.Box style={{...styleContainer, ...outerStyle}}>
+    <Kb.Box style={styleAvatar}>
+      <Kb.Box style={styleAvatarBackground} />
+      <Kb.Avatar size={avatarSize} onClick={onAvatarClicked} username={username} />
+    </Kb.Box>
+    <Kb.Box style={{...styleInside, ...style}}>{children}</Kb.Box>
+  </Kb.Box>
 )
 
 const styleContainer = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'stretch',
 }
 
 const styleInside = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'stretch',
-  backgroundColor: globalColors.white,
+  backgroundColor: Styles.globalColors.white,
   justifyContent: 'flex-start',
   padding: 16,
 }
 
 const styleAvatar = {
-  ...globalStyles.flexBoxColumn,
+  ...Styles.globalStyles.flexBoxColumn,
   alignItems: 'center',
   alignSelf: 'stretch',
   marginTop: 0,
 }
 
 const styleAvatarBackground = {
-  backgroundColor: globalColors.white,
+  backgroundColor: Styles.globalColors.white,
   height: avatarSize / 2,
   left: 0,
   position: 'absolute',

--- a/shared/common-adapters/waiting-button.tsx
+++ b/shared/common-adapters/waiting-button.tsx
@@ -3,6 +3,10 @@ import Button from './button'
 import {namedConnect} from '../util/container'
 import * as WaitingConstants from '../constants/waiting'
 
+const Kb = {
+  Button,
+}
+
 type ButtonProps = React.ComponentProps<typeof Button>
 
 export type OwnProps = {
@@ -16,7 +20,7 @@ export type Props = {
   waitingKey: string | null
 } & ButtonProps
 
-/* Waiting button is a <Button /> with handling of waiting states.
+/* Waiting button is a <Kb.Button /> with handling of waiting states.
  *
  * There are two forms:
  *  waitingKey is null: The spinner activates as soon as the button is clicked,
@@ -49,7 +53,7 @@ class WaitingButton extends React.Component<Props, {localWaiting: boolean}> {
     const waiting = this.props.storeWaiting || this.state.localWaiting
     const {onlyDisable, storeWaiting, waitingKey, ...buttonProps} = this.props
     return (
-      <Button
+      <Kb.Button
         {...buttonProps}
         onClick={this._onClick}
         disabled={this.props.onlyDisable ? waiting || this.props.disabled : this.props.disabled}

--- a/shared/common-adapters/with-tooltip.desktop.tsx
+++ b/shared/common-adapters/with-tooltip.desktop.tsx
@@ -5,6 +5,12 @@ import Toast from './toast'
 import Text from './text'
 import {Props} from './with-tooltip'
 
+const Kb = {
+  Box,
+  Text,
+  Toast,
+}
+
 type State = {
   mouseIn: boolean
   visible: boolean
@@ -38,7 +44,7 @@ class WithTooltip extends React.Component<Props, State> {
   render() {
     return (
       <>
-        <Box
+        <Kb.Box
           style={this.props.containerStyle}
           forwardedRef={this._setAttachmentRef}
           onMouseOver={this._onMouseEnter}
@@ -46,9 +52,9 @@ class WithTooltip extends React.Component<Props, State> {
           className={this.props.className}
         >
           {this.props.children}
-        </Box>
+        </Kb.Box>
         {!this.props.disabled && this.state.mouseIn && (
-          <Toast
+          <Kb.Toast
             containerStyle={Styles.collapseStyles([
               styles.container,
               this.props.multiline && styles.containerMultiline,
@@ -58,14 +64,14 @@ class WithTooltip extends React.Component<Props, State> {
             position={this.props.position || 'top center'}
             className={this.props.toastClassName}
           >
-            <Text
+            <Kb.Text
               center={!Styles.isMobile}
               type="BodySmall"
               style={Styles.collapseStyles([styles.text, this.props.textStyle])}
             >
               {this.props.text}
-            </Text>
-          </Toast>
+            </Kb.Text>
+          </Kb.Toast>
         )}
       </>
     )

--- a/shared/common-adapters/with-tooltip.desktop.tsx
+++ b/shared/common-adapters/with-tooltip.desktop.tsx
@@ -72,7 +72,7 @@ class WithTooltip extends React.Component<Props, State> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: Styles.platformStyles({
     isElectron: {
       borderRadius: Styles.borderRadius,
@@ -90,6 +90,6 @@ const styles = Styles.styleSheetCreate({
       wordBreak: 'break-word',
     },
   }),
-})
+}))
 
 export default WithTooltip

--- a/shared/common-adapters/with-tooltip.native.tsx
+++ b/shared/common-adapters/with-tooltip.native.tsx
@@ -122,7 +122,7 @@ const WithTooltip = (props: Props) => {
 
 export default WithTooltip
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     backgroundColor: Styles.globalColors.black_60,
     borderRadius: Styles.borderRadius,
@@ -132,4 +132,4 @@ const styles = Styles.styleSheetCreate({
   text: {
     color: Styles.globalColors.white,
   },
-})
+}))

--- a/shared/common-adapters/zoomable-box.android.tsx
+++ b/shared/common-adapters/zoomable-box.android.tsx
@@ -9,6 +9,10 @@ import Box from './box'
 import {clamp} from 'lodash-es'
 import {Props} from './zoomable-box'
 
+const Kb = {
+  Box,
+}
+
 const distance = (a: NativeTouchEvent, b: NativeTouchEvent): number => {
   return Math.sqrt(Math.pow(a.pageX - b.pageX, 2) + Math.pow(a.pageY - b.pageY, 2))
 }
@@ -204,7 +208,7 @@ class ZoomableBox extends React.Component<Props, State> {
   render() {
     const panHandlers = this._panResponder ? this._panResponder.panHandlers : {}
     return (
-      <Box
+      <Kb.Box
         {...this.props}
         {...panHandlers}
         onLayout={this._onLayout}

--- a/shared/common-adapters/zoomable-box.ios.tsx
+++ b/shared/common-adapters/zoomable-box.ios.tsx
@@ -2,8 +2,12 @@ import * as React from 'react'
 import ScrollView from './scroll-view'
 import {Props} from './zoomable-box'
 
+const Kb = {
+  ScrollView,
+}
+
 export const ZoomableBox = (props: Props) => (
-  <ScrollView
+  <Kb.ScrollView
     alwaysBounceVertical={false}
     bounces={props.bounces}
     children={props.children}

--- a/shared/common-adapters/zoomable-image.native.tsx
+++ b/shared/common-adapters/zoomable-image.native.tsx
@@ -169,7 +169,7 @@ class ZoomableBox extends React.Component<Props, {height: number; width: number}
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   container: {
     alignItems: 'center',
     backgroundColor: Styles.globalColors.black,
@@ -182,6 +182,6 @@ const styles = Styles.styleSheetCreate({
     height: '100%',
     width: '100%',
   },
-})
+}))
 
 export default ZoomableBox


### PR DESCRIPTION
You know the drill at this point, mostly changes to `styleSheetCreate` calls so they use closures, refactors to `Styles` references, and now refactors to add a `Kb` object so our common-adapter references stay consistent across the app.

@keybase/react-hackers @keybase/hotpotatosquad 