### PR TITLE
cr_chains: handle renames correctly for deleted entries

### DIFF
--- a/go/kbfs/kbfsedits/tlf_history_test.go
+++ b/go/kbfs/kbfsedits/tlf_history_test.go
@@ -27,10 +27,10 @@ func checkTlfHistory(t *testing.T, th *TlfHistory, expected writersByRevision,
 		require.Equal(t, e.writerName, history[i].writerName)
 		require.Len(t, history[i].notifications, len(e.notifications))
 		for j, n := range e.notifications {
-			require.Equal(t, n, history[i].notifications[j])
+			require.Equal(t, n, history[i].notifications[j], i)
 		}
 		if len(e.notifications) < maxEditsPerWriter {
-			require.Contains(t, writersWhoNeedMore, e.writerName)
+			require.Contains(t, writersWhoNeedMore, e.writerName, i)
 		}
 	}
 }
@@ -437,6 +437,63 @@ func TestTlfHistoryRenameParentSimple(t *testing.T) {
 	expected = writersByRevision{
 		{aliceName, nil, []NotificationMessage{aliceDeleteB}},
 	}
+	checkTlfHistory(t, th, expected, aliceName)
+}
+
+// Regression test for HOTPOT-616.
+func TestTlfHistoryRenameDirAndReuseNameForFile(t *testing.T) {
+	aliceName, bobName := "alice", "bob"
+	aliceUID, bobUID := keybase1.MakeTestUID(1), keybase1.MakeTestUID(2)
+	tlfID, err := tlf.MakeRandomID(tlf.Private)
+	require.NoError(t, err)
+
+	var aliceMessages, bobMessages []string
+	nn := nextNotification{1, 0, tlfID, nil}
+
+	// Alice creates file "x".   (Use truncated Keybase canonical
+	// paths because renames only matter beyond the TLF name.)
+	aliceCreateA := nn.make(
+		"/k/p/a,b/x", NotificationCreate, aliceUID, nil, time.Time{})
+	aliceMessages = append(aliceMessages, nn.encode(t))
+
+	// Alice creates modifies existing file "a/b".
+	aliceModifyB := nn.make(
+		"/k/p/a,b/a/b", NotificationModify, aliceUID, nil, time.Time{})
+	aliceMessages = append(aliceMessages, nn.encode(t))
+
+	// Bob renames "a" to "c".
+	bobRename := nn.makeWithType(
+		"/k/p/a,b/c", NotificationRename, bobUID, &NotificationParams{
+			OldFilename: "/k/p/a,b/a",
+		}, time.Time{}, EntryTypeDir)
+	bobMessages = append(bobMessages, nn.encode(t))
+	aliceModifyB.Filename = "/k/p/a,b/c/b"
+
+	// Alice renames x to a.
+	_ = nn.makeWithType(
+		"/k/p/a,b/a", NotificationRename, aliceUID, &NotificationParams{
+			OldFilename: "/k/p/a,b/x",
+		}, time.Time{}, EntryTypeFile)
+	aliceMessages = append(aliceMessages, nn.encode(t))
+	aliceCreateA.Filename = "/k/p/a,b/a"
+
+	// Alice creates modifies file "a".
+	aliceModifyA := nn.make(
+		"/k/p/a,b/a", NotificationModify, aliceUID, nil, time.Time{})
+	aliceMessages = append(aliceMessages, nn.encode(t))
+
+	expected := writersByRevision{
+		{aliceName, []NotificationMessage{aliceModifyA, aliceModifyB}, nil},
+	}
+
+	// Alice, then Bob.
+	th := NewTlfHistory()
+	rev, err := th.AddNotifications(aliceName, aliceMessages)
+	require.NoError(t, err)
+	require.Equal(t, aliceModifyA.Revision, rev)
+	rev, err = th.AddNotifications(bobName, bobMessages)
+	require.NoError(t, err)
+	require.Equal(t, bobRename.Revision, rev)
 	checkTlfHistory(t, th, expected, aliceName)
 }
 

--- a/go/kbfs/kbfsedits/tlf_history_test.go
+++ b/go/kbfs/kbfsedits/tlf_history_test.go
@@ -456,7 +456,7 @@ func TestTlfHistoryRenameDirAndReuseNameForFile(t *testing.T) {
 		"/k/p/a,b/x", NotificationCreate, aliceUID, nil, time.Time{})
 	aliceMessages = append(aliceMessages, nn.encode(t))
 
-	// Alice creates modifies existing file "a/b".
+	// Alice modifies existing file "a/b".
 	aliceModifyB := nn.make(
 		"/k/p/a,b/a/b", NotificationModify, aliceUID, nil, time.Time{})
 	aliceMessages = append(aliceMessages, nn.encode(t))
@@ -469,7 +469,7 @@ func TestTlfHistoryRenameDirAndReuseNameForFile(t *testing.T) {
 	bobMessages = append(bobMessages, nn.encode(t))
 	aliceModifyB.Filename = "/k/p/a,b/c/b"
 
-	// Alice renames x to a.
+	// Alice renames "x" to "a".
 	_ = nn.makeWithType(
 		"/k/p/a,b/a", NotificationRename, aliceUID, &NotificationParams{
 			OldFilename: "/k/p/a,b/x",
@@ -477,7 +477,7 @@ func TestTlfHistoryRenameDirAndReuseNameForFile(t *testing.T) {
 	aliceMessages = append(aliceMessages, nn.encode(t))
 	aliceCreateA.Filename = "/k/p/a,b/a"
 
-	// Alice creates modifies file "a".
+	// Alice modifies file "a".
 	aliceModifyA := nn.make(
 		"/k/p/a,b/a", NotificationModify, aliceUID, nil, time.Time{})
 	aliceMessages = append(aliceMessages, nn.encode(t))

--- a/go/kbfs/test/edit_history_test.go
+++ b/go/kbfs/test/edit_history_test.go
@@ -515,3 +515,47 @@ func TestEditHistoryRenameParentAcrossDirs(t *testing.T) {
 		),
 	)
 }
+
+// Regression test for HOTPOT-616.
+func TestEditHistoryRenameDirAndReuseNameForFile(t *testing.T) {
+	// Alice creates a dir and puts files in it, creates a file,
+	// renames the dir to something new, renames the file to
+	// the old dir name, and then nukes the old directory.
+	expectedEdits := []expectedEdit{
+		{
+			"alice",
+			keybase1.FolderType_PRIVATE,
+			"alice",
+			[]string{"/keybase/private/alice/a"},
+			[]string{
+				"/keybase/private/alice/b/c/d",
+				"/keybase/private/alice/b/b",
+			},
+		},
+	}
+
+	test(t, batchSize(20),
+		users("alice"),
+		as(alice,
+			mkdir("a"),
+			mkfile("a/b", ""),
+			pwriteBSSync("a/b", []byte("hello"), 0, false),
+			mkdir("a/c"),
+			mkfile("a/c/d", ""),
+			pwriteBSSync("a/c/d", []byte("hello"), 0, false),
+		),
+		as(alice,
+			mkfile("e", ""),
+			pwriteBSSync("e", []byte("world"), 0, false),
+			rename("a", "b"),
+			rename("e", "a"),
+			rm("b/c/d"),
+			rmdir("b/c"),
+			rm("b/b"),
+			rmdir("b"),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits),
+		),
+	)
+}


### PR DESCRIPTION
When sending out edit notifications using the list of ops in a MD update, the `crChains` instance does a trick where it combines separate delete+create ops back into rename operations, so that they can be faithfully reported as renames in the edit notifications chat stream.

However, this wasn't working correctly for entries that were renamed, and then deleted, within the same update.  In that case, there was no original create op still left in the ops list, and so the rename op wasn't getting added back into the resulting list.

This causes problems for the edit history.  Say there is a directory with modified files inside it.  If the directory is renamed to something else, and then the whole directory structure is deleted, the edit history processor won't know to ignore those old modifications of those files when they were in the old directory name, because it never saw the rename operation and so thinks those old files are still there.

This led to a panic in the case where someone created a directory, added files to it, then renamed it and created a file with the same old name as the directory.  The old modified files were still in the recent history list, but now it looks like they are somehow subentries under a file entry, which is impossible. The `folderBranchOps` partial sync code wasn't expecting this and panicked.

So the fix for the future is to make sure that the rename op always shows up properly in the edit notification stream.

Also: fix the panic itself by not allowing lookups in non-dir nodes.

Issue: HOTPOT-616