### PR TITLE
ephemeral: keygenIfNeeded in background on login in case user is offline

### DIFF
--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -185,6 +185,8 @@ func NewChatMockWorld(t *testing.T, name string, numUsers int) (world *kbtest.Ch
 		teams.ServiceInit(w.G)
 		mctx := libkb.NewMetaContextTODO(w.G)
 		ephemeral.ServiceInit(mctx)
+		err := mctx.G().GetEKLib().KeygenIfNeeded(mctx)
+		require.NoError(t, err)
 		teambot.ServiceInit(mctx)
 		contacts.ServiceInit(w.G)
 	}

--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -19,6 +19,8 @@ func ephemeralKeyTestSetup(t *testing.T) (libkb.TestContext, libkb.MetaContext, 
 
 	user, err := kbtest.CreateAndSignupFakeUser("t", tc.G)
 	require.NoError(t, err)
+	err = mctx.G().GetEKLib().KeygenIfNeeded(mctx)
+	require.NoError(t, err)
 
 	return tc, mctx, user
 }

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -1098,9 +1098,11 @@ func (e *EKLib) ClearCaches(mctx libkb.MetaContext) {
 }
 
 func (e *EKLib) OnLogin(mctx libkb.MetaContext) error {
-	if err := e.KeygenIfNeeded(mctx); err != nil {
-		mctx.Debug("OnLogin error: %v", err)
-	}
+	go func() {
+		if err := e.KeygenIfNeeded(mctx); err != nil {
+			mctx.Debug("OnLogin error: %v", err)
+		}
+	}()
 	if deviceEKStorage := mctx.G().GetDeviceEKStorage(); deviceEKStorage != nil {
 		deviceEKStorage.SetLogPrefix(mctx)
 	}

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -30,6 +30,8 @@ func TestKeygenIfNeeded(t *testing.T) {
 	defer ekLib.Shutdown()
 	deviceEKStorage := tc.G.GetDeviceEKStorage()
 	userEKBoxStorage := tc.G.GetUserEKBoxStorage()
+	err := ekLib.KeygenIfNeeded(mctx)
+	require.NoError(t, err)
 
 	expectedDeviceEKGen, err := deviceEKStorage.MaxGeneration(mctx, false)
 	require.NoError(t, err)

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -66,6 +66,9 @@ func TestNewUserEK(t *testing.T) {
 	kbtest.ResetAccount(tc, user)
 	err = user.Login(tc.G)
 	require.NoError(t, err)
+	// create a new device ek
+	err = mctx.G().GetEKLib().KeygenIfNeeded(mctx)
+	require.NoError(t, err)
 
 	publishAndVerifyUserEK(mctx, t, merkleRoot, uid)
 }
@@ -92,6 +95,8 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 	// Include a paper key with this test user, so that we have something to
 	// revoke.
 	user, err := kbtest.CreateAndSignupFakeUserPaper("e", tc.G)
+	require.NoError(t, err)
+	err = mctx.G().GetEKLib().KeygenIfNeeded(mctx)
 	require.NoError(t, err)
 
 	// Confirm that the user has a userEK.

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -557,9 +557,11 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	bob := tt.addUserWithPaper("bob")
 
 	annMctx := ann.MetaContext()
-	initEphemeralForTests(t, annMctx)
+	err := annMctx.G().GetEKLib().KeygenIfNeeded(annMctx)
+	require.NoError(t, err)
 	bobMctx := bob.MetaContext()
-	initEphemeralForTests(t, bobMctx)
+	err = bobMctx.G().GetEKLib().KeygenIfNeeded(bobMctx)
+	require.NoError(t, err)
 
 	teamID, teamName := ann.createTeam2()
 
@@ -601,9 +603,11 @@ func TestEphemeralRotateSkipTeamEKRoll(t *testing.T) {
 	bob := tt.addUserWithPaper("bob")
 
 	annMctx := ann.MetaContext()
-	initEphemeralForTests(t, annMctx)
+	err := annMctx.G().GetEKLib().KeygenIfNeeded(annMctx)
+	require.NoError(t, err)
 	bobMctx := bob.MetaContext()
-	initEphemeralForTests(t, bobMctx)
+	err = bobMctx.G().GetEKLib().KeygenIfNeeded(bobMctx)
+	require.NoError(t, err)
 
 	teamID, teamName := ann.createTeam2()
 
@@ -656,8 +660,9 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 	teamID, _ := ann.createTeam2()
 
 	annMctx := ann.MetaContext()
-	initEphemeralForTests(t, annMctx)
 	ekLib := annMctx.G().GetEKLib()
+	err := ekLib.KeygenIfNeeded(annMctx)
+	require.NoError(t, err)
 
 	_, created, err := ekLib.GetOrCreateLatestTeamEK(annMctx, teamID)
 	require.NoError(t, err)
@@ -726,10 +731,14 @@ func readdToTeamWithEKs(t *testing.T, leave bool) {
 	user2.waitForNewlyAddedToTeamByID(teamID)
 
 	mctx1 := user1.MetaContext()
-	initEphemeralForTests(t, mctx1)
-	mctx2 := user2.MetaContext()
-	initEphemeralForTests(t, mctx2)
 	ekLib := mctx1.G().GetEKLib()
+	err := ekLib.KeygenIfNeeded(mctx1)
+	require.NoError(t, err)
+
+	mctx2 := user2.MetaContext()
+	err = mctx2.G().GetEKLib().KeygenIfNeeded(mctx2)
+	require.NoError(t, err)
+
 	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(mctx1, teamID)
 	require.NoError(t, err)
 	require.True(t, created)
@@ -784,7 +793,8 @@ func TestEphemeralAfterEKError(t *testing.T) {
 	teamID, teamName := user1.createTeam2()
 	g1 := user1.tc.G
 	mctx1 := user1.MetaContext()
-	initEphemeralForTests(t, mctx1)
+	err := mctx1.G().GetEKLib().KeygenIfNeeded(mctx1)
+	require.NoError(t, err)
 	merkleRoot, err := g1.GetMerkleClient().FetchRootFromServer(mctx1, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	// Force two team EKs to be created and then create/add u2 to the team.
@@ -797,7 +807,8 @@ func TestEphemeralAfterEKError(t *testing.T) {
 
 	user2 := tt.addUserWithPaper("u2")
 	mctx2 := user2.MetaContext()
-	initEphemeralForTests(t, mctx2)
+	err = mctx2.G().GetEKLib().KeygenIfNeeded(mctx2)
+	require.NoError(t, err)
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 	user2.waitForNewlyAddedToTeamByID(teamID)
 

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -14,19 +14,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func initEphemeralForTests(t *testing.T, mctx libkb.MetaContext) {
+	ephemeral.ServiceInit(mctx)
+	err := mctx.G().GetEKLib().KeygenIfNeeded(mctx)
+	require.NoError(t, err)
+}
+
 func TestEphemeralNewTeamEKNotif(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
 	user1 := tt.addUser("one")
 	user2 := tt.addUser("wtr")
-	mctx := libkb.NewMetaContextForTest(*user1.tc)
+	mctx := user1.MetaContext()
+	ekLib := user1.tc.G.GetEKLib()
+	err := ekLib.KeygenIfNeeded(mctx)
+	require.NoError(t, err)
+
+	mctx2 := user2.MetaContext()
+	err = mctx2.G().GetEKLib().KeygenIfNeeded(mctx2)
+	require.NoError(t, err)
 
 	teamID, teamName := user1.createTeam2()
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
-
-	ephemeral.ServiceInit(mctx)
-	ekLib := user1.tc.G.GetEKLib()
 
 	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(mctx, teamID)
 	require.NoError(t, err)
@@ -58,13 +68,17 @@ func TestEphemeralNewTeambotEKNotif(t *testing.T) {
 	user1 := tt.addUser("one")
 	botua := tt.addUser("botua")
 	botuaUID := gregor1.UID(botua.uid.ToBytes())
-	mctx := libkb.NewMetaContextForTest(*user1.tc)
+	mctx := user1.MetaContext()
+	ekLib := user1.tc.G.GetEKLib()
+	err := ekLib.KeygenIfNeeded(mctx)
+	require.NoError(t, err)
+
+	botuaMctx := botua.MetaContext()
+	err = botuaMctx.G().GetEKLib().KeygenIfNeeded(botuaMctx)
+	require.NoError(t, err)
 
 	teamID, teamName := user1.createTeam2()
 	user1.addRestrictedBotTeamMember(teamName.String(), botua.username, keybase1.TeamBotSettings{})
-
-	ephemeral.ServiceInit(mctx)
-	ekLib := user1.tc.G.GetEKLib()
 
 	teambotEK, created, err := ekLib.GetOrCreateLatestTeambotEK(mctx, teamID, botuaUID)
 	require.NoError(t, err)
@@ -124,13 +138,19 @@ func TestEphemeralTeambotEK(t *testing.T) {
 	user2 := tt.addUserWithPaper("two")
 	botua := tt.addUser("botua")
 	botuaUID := gregor1.UID(botua.uid.ToBytes())
-	mctx1 := libkb.NewMetaContextForTest(*user1.tc)
-	mctx2 := libkb.NewMetaContextForTest(*user2.tc)
-	mctx3 := libkb.NewMetaContextForTest(*botua.tc)
+	mctx1 := user1.MetaContext()
+	mctx2 := user2.MetaContext()
+	mctx3 := botua.MetaContext()
 	ekLib1 := mctx1.G().GetEKLib()
 	ekLib2 := mctx2.G().GetEKLib()
 	ekLib3 := mctx3.G().GetEKLib().(*ephemeral.EKLib)
 	ekLib3.SetClock(fc)
+	err := ekLib1.KeygenIfNeeded(mctx1)
+	require.NoError(t, err)
+	err = ekLib2.KeygenIfNeeded(mctx2)
+	require.NoError(t, err)
+	err = ekLib3.KeygenIfNeeded(mctx3)
+	require.NoError(t, err)
 
 	teamID, teamName := user1.createTeam2()
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
@@ -382,9 +402,9 @@ func runAddMember(t *testing.T, createTeamEK bool) {
 	bob.signup()
 
 	annMctx := ann.MetaContext()
-	ephemeral.ServiceInit(annMctx)
+	initEphemeralForTests(t, annMctx)
 	bobMctx := bob.MetaContext()
-	ephemeral.ServiceInit(bobMctx)
+	initEphemeralForTests(t, bobMctx)
 
 	team := ann.createTeam([]*smuUser{})
 	teamName, err := keybase1.TeamNameFromString(team.name)
@@ -444,11 +464,11 @@ func TestEphemeralResetMember(t *testing.T) {
 	joe.signup()
 
 	annMctx := ann.MetaContext()
-	ephemeral.ServiceInit(annMctx)
+	initEphemeralForTests(t, annMctx)
 	bobMctx := bob.MetaContext()
-	ephemeral.ServiceInit(bobMctx)
+	initEphemeralForTests(t, bobMctx)
 	joeMctx := joe.MetaContext()
-	ephemeral.ServiceInit(joeMctx)
+	initEphemeralForTests(t, joeMctx)
 
 	team := ann.createTeam([]*smuUser{bob})
 	teamName, err := keybase1.TeamNameFromString(team.name)
@@ -479,6 +499,10 @@ func TestEphemeralResetMember(t *testing.T) {
 	// team after resetting.
 	bob.loginAfterReset(10)
 	bobMctx = bob.MetaContext()
+	// make sure bob has new EKs
+	err = bobMctx.G().GetEKLib().KeygenIfNeeded(bobMctx)
+	require.NoError(t, err)
+
 	bobTeamEK, bobErr := getTeamEK(bobMctx, teamID, expectedGeneration)
 	require.Error(t, bobErr)
 	require.IsType(t, libkb.AppStatusError{}, bobErr)
@@ -533,9 +557,9 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	bob := tt.addUserWithPaper("bob")
 
 	annMctx := ann.MetaContext()
-	ephemeral.ServiceInit(annMctx)
+	initEphemeralForTests(t, annMctx)
 	bobMctx := bob.MetaContext()
-	ephemeral.ServiceInit(bobMctx)
+	initEphemeralForTests(t, bobMctx)
 
 	teamID, teamName := ann.createTeam2()
 
@@ -577,9 +601,9 @@ func TestEphemeralRotateSkipTeamEKRoll(t *testing.T) {
 	bob := tt.addUserWithPaper("bob")
 
 	annMctx := ann.MetaContext()
-	ephemeral.ServiceInit(annMctx)
+	initEphemeralForTests(t, annMctx)
 	bobMctx := bob.MetaContext()
-	ephemeral.ServiceInit(bobMctx)
+	initEphemeralForTests(t, bobMctx)
 
 	teamID, teamName := ann.createTeam2()
 
@@ -616,7 +640,7 @@ func TestEphemeralRotateSkipTeamEKRoll(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, needed)
 
-	merkleRoot, err := annMctx.G().GetMerkleClient().FetchRootFromServer(libkb.NewMetaContextForTest(*ann.tc), libkb.EphemeralKeyMerkleFreshness)
+	merkleRoot, err := annMctx.G().GetMerkleClient().FetchRootFromServer(ann.MetaContext(), libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	metadata, err := ephemeral.ForcePublishNewTeamEKForTesting(annMctx, teamID, *merkleRoot)
 	require.NoError(t, err)
@@ -632,7 +656,7 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 	teamID, _ := ann.createTeam2()
 
 	annMctx := ann.MetaContext()
-	ephemeral.ServiceInit(annMctx)
+	initEphemeralForTests(t, annMctx)
 	ekLib := annMctx.G().GetEKLib()
 
 	_, created, err := ekLib.GetOrCreateLatestTeamEK(annMctx, teamID)
@@ -659,7 +683,7 @@ func TestEphemeralNewUserEKAndTeamEKAfterRevokes(t *testing.T) {
 		LogUI:    annMctx.G().Log,
 		SecretUI: ann.newSecretUI(),
 	}
-	m := libkb.NewMetaContextForTest(*ann.tc).WithUIs(uis)
+	m := ann.MetaContext().WithUIs(uis)
 	err = engine.RunEngine2(m, revokeEngine)
 	require.NoError(t, err)
 
@@ -702,7 +726,9 @@ func readdToTeamWithEKs(t *testing.T, leave bool) {
 	user2.waitForNewlyAddedToTeamByID(teamID)
 
 	mctx1 := user1.MetaContext()
-	ephemeral.ServiceInit(mctx1)
+	initEphemeralForTests(t, mctx1)
+	mctx2 := user2.MetaContext()
+	initEphemeralForTests(t, mctx2)
 	ekLib := mctx1.G().GetEKLib()
 	teamEK, created, err := ekLib.GetOrCreateLatestTeamEK(mctx1, teamID)
 	require.NoError(t, err)
@@ -758,7 +784,7 @@ func TestEphemeralAfterEKError(t *testing.T) {
 	teamID, teamName := user1.createTeam2()
 	g1 := user1.tc.G
 	mctx1 := user1.MetaContext()
-	ephemeral.ServiceInit(mctx1)
+	initEphemeralForTests(t, mctx1)
 	merkleRoot, err := g1.GetMerkleClient().FetchRootFromServer(mctx1, libkb.EphemeralKeyMerkleFreshness)
 	require.NoError(t, err)
 	// Force two team EKs to be created and then create/add u2 to the team.
@@ -770,10 +796,11 @@ func TestEphemeralAfterEKError(t *testing.T) {
 	require.NoError(t, err)
 
 	user2 := tt.addUserWithPaper("u2")
+	mctx2 := user2.MetaContext()
+	initEphemeralForTests(t, mctx2)
 	user1.addTeamMember(teamName.String(), user2.username, keybase1.TeamRole_WRITER)
 	user2.waitForNewlyAddedToTeamByID(teamID)
 
-	mctx2 := libkb.NewMetaContextForTest(*user2.tc)
 	_, err = mctx2.G().GetTeamEKBoxStorage().Get(mctx2, teamID, teamEKMetadata1.Generation, nil)
 	require.Error(t, err)
 	require.IsType(t, ephemeral.EphemeralKeyError{}, err)


### PR DESCRIPTION
Should fix @zapu's issue where service timed out starting up on Linux (systemd wants to be notified of a successful startup quickly, which happens at the end of Service.Run after loginhooks are called.