### PR TITLE
Add measureKey to signal AlphabetIndex remeasuring

### DIFF
--- a/shared/team-building/alphabet-index.tsx
+++ b/shared/team-building/alphabet-index.tsx
@@ -12,6 +12,7 @@ const updateMeasure = (m: typeof initMeasureRef, newM: typeof initMeasureRef) =>
 type Props = {
   labels: Array<string>
   showNumSection: boolean
+  measureKey?: any // change this when the position of AlphabetIndex on the screen changes
   onScroll: (label: string) => void
   style?: Styles.StylesCrossPlatform
 }
@@ -31,7 +32,7 @@ const AlphabetIndex = (props: Props) => {
       })
     }
   }, 200)
-  React.useEffect(storeMeasure, [])
+  React.useEffect(storeMeasure, [props.measureKey])
 
   const {labels, onScroll, showNumSection} = props
   const handleTouch = React.useCallback(

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -200,6 +200,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
         showNumSection={showNumSection}
         onScroll={this._onScrollToSection}
         style={styles.alphabetIndex}
+        measureKey={!!this.props.teamSoFar.length}
       />
     )
   }


### PR DESCRIPTION
Previously, `AlphabetIndex` would only ever measure on mount. Because we use `pageY` to calculate which section is being tapped, those measurements are invalidated when it shifts down because `TeamBox` is rendered when someone's added. This plumbs whether `TeamBox` is being rendered through so we can remeasure. cc @keybase/y2ksquad 