### PR TITLE
Misc new chat

### DIFF
--- a/shared/actions/__tests__/team-building.test.tsx
+++ b/shared/actions/__tests__/team-building.test.tsx
@@ -226,7 +226,7 @@ describe('Search Actions', () => {
     const userToAdd = parsedSearchResults['marcopolo']['keybase'].getIn(['marcopolo', 'keybase'], [])[0]
     dispatch(TeamBuildingGen.createAddUsersToTeamSoFar({namespace: testNamespace, users: [userToAdd]}))
     return Testing.flushPromises().then(() => {
-      expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.Set([userToAdd]))
+      expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.OrderedSet([userToAdd]))
     })
   })
 
@@ -236,7 +236,7 @@ describe('Search Actions', () => {
     dispatch(TeamBuildingGen.createAddUsersToTeamSoFar({namespace: testNamespace, users: [userToAdd]}))
     dispatch(TeamBuildingGen.createRemoveUsersFromTeamSoFar({namespace: testNamespace, users: ['marcopolo']}))
     return Testing.flushPromises().then(() => {
-      expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.Set())
+      expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.OrderedSet())
     })
   })
 
@@ -246,8 +246,8 @@ describe('Search Actions', () => {
     dispatch(TeamBuildingGen.createAddUsersToTeamSoFar({namespace: testNamespace, users: [userToAdd]}))
     dispatch(TeamBuildingGen.createFinishedTeamBuilding({namespace: testNamespace}))
     return Testing.flushPromises().then(() => {
-      expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.Set())
-      expect(getState().chat2.teamBuilding.teamBuildingFinishedTeam).toEqual(I.Set([userToAdd]))
+      expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.OrderedSet())
+      expect(getState().chat2.teamBuilding.teamBuildingFinishedTeam).toEqual(I.OrderedSet([userToAdd]))
     })
   })
 
@@ -257,8 +257,8 @@ describe('Search Actions', () => {
     dispatch(TeamBuildingGen.createAddUsersToTeamSoFar({namespace: testNamespace, users: [userToAdd]}))
     dispatch(TeamBuildingGen.createCancelTeamBuilding({namespace: testNamespace}))
     return Testing.flushPromises().then(() => {
-      expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.Set())
-      expect(getState().chat2.teamBuilding.teamBuildingFinishedTeam).toEqual(I.Set())
+      expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.OrderedSet())
+      expect(getState().chat2.teamBuilding.teamBuildingFinishedTeam).toEqual(I.OrderedSet())
     })
   })
 })

--- a/shared/constants/team-building.tsx
+++ b/shared/constants/team-building.tsx
@@ -45,7 +45,7 @@ const SubStateFactory = I.Record<Types._TeamBuildingSubState>({
   teamBuildingEmailSearchQuery: '',
   teamBuildingFinishedSelectedRole: 'writer',
   teamBuildingFinishedSendNotification: true,
-  teamBuildingFinishedTeam: I.Set(),
+  teamBuildingFinishedTeam: I.OrderedSet(),
   teamBuildingLabelsSeen: false,
   teamBuildingSearchLimit: 11,
   teamBuildingSearchQuery: '',

--- a/shared/constants/team-building.tsx
+++ b/shared/constants/team-building.tsx
@@ -54,7 +54,7 @@ const SubStateFactory = I.Record<Types._TeamBuildingSubState>({
   teamBuildingSelectedService: 'keybase',
   teamBuildingSendNotification: true,
   teamBuildingServiceResultCount: I.Map(),
-  teamBuildingTeamSoFar: I.Set(),
+  teamBuildingTeamSoFar: I.OrderedSet(),
   teamBuildingUserRecs: null,
 })
 

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -40,7 +40,7 @@ export type _TeamBuildingSubState = {
   teamBuildingTeamSoFar: I.OrderedSet<User>
   teamBuildingSearchResults: SearchResults
   teamBuildingServiceResultCount: ServiceResultCount
-  teamBuildingFinishedTeam: I.Set<User>
+  teamBuildingFinishedTeam: I.OrderedSet<User>
   teamBuildingFinishedSelectedRole: TeamRoleType
   teamBuildingFinishedSendNotification: boolean
   teamBuildingSearchQuery: Query

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -37,7 +37,7 @@ export type _TeamBuildingSubState = {
   teamBuildingEmailSearchQuery: Query
   teamBuildingEmailIsSearching: boolean
   teamBuildingEmailResult: User | null
-  teamBuildingTeamSoFar: I.Set<User>
+  teamBuildingTeamSoFar: I.OrderedSet<User>
   teamBuildingSearchResults: SearchResults
   teamBuildingServiceResultCount: ServiceResultCount
   teamBuildingFinishedTeam: I.Set<User>

--- a/shared/reducers/team-building.tsx
+++ b/shared/reducers/team-building.tsx
@@ -26,7 +26,7 @@ export default function(
     case TeamBuildingGen.changeSendNotification:
       return state.set('teamBuildingSendNotification', action.payload.sendNotification)
     case TeamBuildingGen.addUsersToTeamSoFar:
-      return state.mergeIn(['teamBuildingTeamSoFar'], I.Set(action.payload.users))
+      return state.update('teamBuildingTeamSoFar', teamSoFar => teamSoFar.merge(action.payload.users))
     case TeamBuildingGen.removeUsersFromTeamSoFar: {
       const setToRemove = I.Set(action.payload.users)
       return state.update('teamBuildingTeamSoFar', teamSoFar => teamSoFar.filter(u => !setToRemove.has(u.id)))

--- a/shared/team-building/team-box.tsx
+++ b/shared/team-building/team-box.tsx
@@ -57,18 +57,13 @@ class UserBubbleCollection extends React.PureComponent<{
 const TeamBox = (props: Props) => {
   // Scroll to the end when a new user is added so they are visible.
   const scrollViewRef = React.useRef<Kb.ScrollView>(null)
-  const teamLength = props.teamSoFar.length
-  const prevTeamLength = Container.usePrevious(teamLength)
+  const last = !!props.teamSoFar.length && props.teamSoFar[props.teamSoFar.length - 1].userId
+  const prevLast = Container.usePrevious(last)
   React.useEffect(() => {
-    if (
-      Styles.isMobile &&
-      prevTeamLength !== undefined &&
-      prevTeamLength !== teamLength &&
-      scrollViewRef.current
-    ) {
+    if (Styles.isMobile && prevLast !== undefined && prevLast !== last && scrollViewRef.current) {
       scrollViewRef.current.scrollToEnd({animated: true})
     }
-  }, [prevTeamLength, teamLength])
+  }, [prevLast, last])
 
   const addMorePrompt = props.teamSoFar.length === 1 && (
     <Kb.Text type="BodyTiny" style={styles.addMorePrompt}>


### PR DESCRIPTION
- Only scroll `TeamBox` to end if the last entry changes. So you don't scroll to remove the first entry and then get scrolled to the end.
- Use `OrderedSet` for `teamBuildingTeamSoFar`. Fixed some ordering instability that can happen with a lot of participants

cc @keybase/y2ksquad 