### PR TITLE
New convo tab bar tweaks

### DIFF
--- a/shared/team-building/service-tab-bar.desktop.tsx
+++ b/shared/team-building/service-tab-bar.desktop.tsx
@@ -35,7 +35,12 @@ const ServiceIcon = (props: IconProps) => {
             style={Styles.collapseStyles([styles.serviceIcon, {color}])}
             boxStyle={styles.serviceIconBox}
           />
-          <Kb.Text type="BodyTiny" center={true} lineClamp={2} style={styles.label}>
+          <Kb.Text
+            type="BodyTiny"
+            center={true}
+            lineClamp={2}
+            style={Styles.collapseStyles([styles.label, {color}])}
+          >
             {props.label}
           </Kb.Text>
           {!!props.showCount &&

--- a/shared/team-building/service-tab-bar.native.tsx
+++ b/shared/team-building/service-tab-bar.native.tsx
@@ -49,10 +49,7 @@ const ServiceIcon = (props: IconProps) => {
           direction="vertical"
           style={Styles.collapseStyles([
             styles.labelContainer,
-            {
-              marginTop: Styles.globalMargins.xtiny,
-              overflow: 'hidden',
-            },
+            {height: labelHeight * props.labelPresence, marginTop: Styles.globalMargins.xtiny},
           ])}
         >
           <Kb.Box2 direction="vertical" style={{height: labelHeight, width: 74}}>

--- a/shared/team-building/service-tab-bar.native.tsx
+++ b/shared/team-building/service-tab-bar.native.tsx
@@ -47,12 +47,13 @@ const ServiceIcon = (props: IconProps) => {
         <Kb.Icon fontSize={18} type={serviceIdToIconFont(props.service)} color={color} />
         <Kb.Box2
           direction="vertical"
-          style={{
-            height: labelHeight * props.labelPresence,
-            marginTop: Styles.globalMargins.xtiny,
-            opacity: props.labelPresence,
-            overflow: 'hidden',
-          }}
+          style={Styles.collapseStyles([
+            styles.labelContainer,
+            {
+              marginTop: Styles.globalMargins.xtiny,
+              overflow: 'hidden',
+            },
+          ])}
         >
           <Kb.Box2 direction="vertical" style={{height: labelHeight, width: 74}}>
             <Kb.Text type="BodyTiny" center={true} lineClamp={2} style={{color}}>
@@ -162,6 +163,10 @@ const styles = Styles.styleSheetCreate(() => ({
     borderBottomWidth: 1,
     borderColor: Styles.globalColors.black_10,
     height: 2,
+  },
+  labelContainer: {
+    marginTop: Styles.globalMargins.xtiny,
+    overflow: 'hidden',
   },
   pendingIcon: {height: 17, width: 17},
   serviceIconContainer: {

--- a/shared/team-building/service-tab-bar.native.tsx
+++ b/shared/team-building/service-tab-bar.native.tsx
@@ -33,6 +33,7 @@ const serviceMinWidthWhenSmall = (containerWidth: number) => {
 const ServiceIcon = (props: IconProps) => {
   const smallWidth = serviceMinWidthWhenSmall(Styles.dimensionWidth)
   const bigWidth = Math.max(smallWidth, 92)
+  const color = props.isActive ? serviceIdToAccentColor(props.service) : inactiveServiceAccentColor
   return (
     <Kb.ClickableBox onClick={props.onClick}>
       <Kb.Box2
@@ -43,21 +44,18 @@ const ServiceIcon = (props: IconProps) => {
           {width: mapRange(props.labelPresence, 0, 1, smallWidth, bigWidth)},
         ])}
       >
-        <Kb.Icon
-          fontSize={18}
-          type={serviceIdToIconFont(props.service)}
-          color={props.isActive ? serviceIdToAccentColor(props.service) : inactiveServiceAccentColor}
-        />
+        <Kb.Icon fontSize={18} type={serviceIdToIconFont(props.service)} color={color} />
         <Kb.Box2
           direction="vertical"
           style={{
             height: labelHeight * props.labelPresence,
+            marginTop: Styles.globalMargins.xtiny,
             opacity: props.labelPresence,
             overflow: 'hidden',
           }}
         >
           <Kb.Box2 direction="vertical" style={{height: labelHeight, width: 74}}>
-            <Kb.Text type="BodyTiny" center={true} lineClamp={2}>
+            <Kb.Text type="BodyTiny" center={true} lineClamp={2} style={{color}}>
               {props.label}
             </Kb.Text>
           </Kb.Box2>

--- a/shared/team-building/service-tab-bar.native.tsx
+++ b/shared/team-building/service-tab-bar.native.tsx
@@ -50,7 +50,13 @@ const ServiceIcon = (props: IconProps) => {
           style={Styles.collapseStyles([styles.labelContainer, {height: labelHeight * props.labelPresence}])}
         >
           <Kb.Box2 direction="vertical" style={{height: labelHeight, width: 74}}>
-            <Kb.Text type="BodyTiny" center={true} lineClamp={2} style={{color}}>
+            <Kb.Text
+              type="BodyTiny"
+              center={true}
+              lineClamp={2}
+              // @ts-ignore: we need to allow any color here for various services
+              style={{color}}
+            >
               {props.label}
             </Kb.Text>
           </Kb.Box2>

--- a/shared/team-building/service-tab-bar.native.tsx
+++ b/shared/team-building/service-tab-bar.native.tsx
@@ -47,10 +47,7 @@ const ServiceIcon = (props: IconProps) => {
         <Kb.Icon fontSize={18} type={serviceIdToIconFont(props.service)} color={color} />
         <Kb.Box2
           direction="vertical"
-          style={Styles.collapseStyles([
-            styles.labelContainer,
-            {height: labelHeight * props.labelPresence, marginTop: Styles.globalMargins.xtiny},
-          ])}
+          style={Styles.collapseStyles([styles.labelContainer, {height: labelHeight * props.labelPresence}])}
         >
           <Kb.Box2 direction="vertical" style={{height: labelHeight, width: 74}}>
             <Kb.Text type="BodyTiny" center={true} lineClamp={2} style={{color}}>

--- a/shared/team-building/shared.tsx
+++ b/shared/team-building/shared.tsx
@@ -12,7 +12,7 @@ const services: {
     longLabel: 'A contact',
   },
   email: {
-    color: '#000',
+    color: '#4C8EFF',
     icon: 'iconfont-mention',
     label: 'Email', // TODO: rethink this for the empty state when we're actually using it
     longLabel: 'An email address',


### PR DESCRIPTION
- Color labels the same color as the icons and accents
- Add some top margin to labels on mobile
- Make email icon color same as Keybase and Phone number