### PR TITLE
Add highlighting to the phone input component

### DIFF
--- a/shared/signup/phone-number/phone-input.tsx
+++ b/shared/signup/phone-number/phone-input.tsx
@@ -226,11 +226,13 @@ type State = {
   country: string
   prefix: string
   formatted: string
+  focused: boolean
 }
 
 class _PhoneInput extends React.Component<Kb.PropsWithOverlay<Props>, State> {
   state = {
     country: this.props.defaultCountry || defaultCountry,
+    focused: false,
     formatted: '',
     prefix: getCallingCode(this.props.defaultCountry || defaultCountry).slice(1),
   }
@@ -376,7 +378,10 @@ class _PhoneInput extends React.Component<Kb.PropsWithOverlay<Props>, State> {
 
   render() {
     return (
-      <Kb.Box2 direction={isMobile ? 'vertical' : 'horizontal'} style={styles.container}>
+      <Kb.Box2
+        direction={isMobile ? 'vertical' : 'horizontal'}
+        style={Styles.collapseStyles([styles.container, !isMobile && this.state.focused && styles.highlight])}
+      >
         <Kb.Box2
           alignItems="center"
           direction="horizontal"
@@ -420,7 +425,11 @@ class _PhoneInput extends React.Component<Kb.PropsWithOverlay<Props>, State> {
           <Kb.Box2
             alignItems="center"
             direction="horizontal"
-            style={Styles.collapseStyles([styles.phoneNumberContainer, styles.fakeInput])}
+            style={Styles.collapseStyles([
+              styles.phoneNumberContainer,
+              styles.fakeInput,
+              isMobile && this.state.focused && styles.highlight,
+            ])}
           >
             <Kb.PlainInput
               autoFocus={this.props.autoFocus}
@@ -430,6 +439,8 @@ class _PhoneInput extends React.Component<Kb.PropsWithOverlay<Props>, State> {
               placeholder={getPlaceholder(this.state.country)}
               onChangeText={x => this._reformatPhoneNumber(x, false)}
               onEnterKeyDown={this.props.onEnterKeyDown}
+              onFocus={() => this.setState({focused: true})}
+              onBlur={() => this.setState({focused: false})}
               value={this.state.formatted}
               disabled={this.state.country === ''}
               ref={this._phoneInputRef}
@@ -515,6 +526,7 @@ const styles = Styles.styleSheetCreate({
     },
   }),
   fullWidth: {width: '100%'},
+  highlight: {borderColor: Styles.globalColors.blue, borderWidth: 1},
   menuItem: {
     ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.xtiny),
   },


### PR DESCRIPTION
Makes it so the phone input component is highlighted when in focus. Being in focus is determined by whether the input box for typing in a number is in focus. Because of how the phone input component is implemented with `fakeInput` I implemented this directly instead of relying on the code in NewInput. 

Note that this also means the phone input component always has highlighting which will apply to the settings page and the signup screen. @cecileboucheron can you confirm that is intended? Or do you only want this change for the new conversation mode? 

Note that this completes PICNIC-386 since the two other changes were already fixed in master. 