### PR TITLE
Handle both chat notifications the same way [Android]

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -388,6 +388,10 @@ func Version() string {
 	return libkb.VersionString()
 }
 
+func IsAppStateForeground() bool {
+	return kbCtx.MobileAppState.State() == keybase1.MobileAppState_FOREGROUND
+}
+
 func SetAppStateForeground() {
 	if !isInited() {
 		return

--- a/go/bind/notifications.go
+++ b/go/bind/notifications.go
@@ -27,11 +27,12 @@ type Person struct {
 }
 
 type Message struct {
-	ID        int
-	Kind      string // "Text" | "Reaction"
-	Plaintext string
-	From      *Person
-	At        int64
+	ID            int
+	Kind          string // "Text" | "Reaction"
+	Plaintext     string
+	ServerMessage string // This is the server's suggested display message for the notification
+	From          *Person
+	At            int64
 }
 
 type ChatNotification struct {
@@ -61,7 +62,7 @@ func HandlePostTextReply(strConvID, tlfName string, body string) (err error) {
 	return err
 }
 
-func HandleBackgroundNotification(strConvID, body string, intMembersType int, displayPlaintext bool,
+func HandleBackgroundNotification(strConvID, body, serverMessageBody string, intMembersType int, displayPlaintext bool,
 	intMessageID int, pushID string, badgeCount, unixTime int, soundName string, pusher PushNotifier) (err error) {
 	if err := waitForInit(5 * time.Second); err != nil {
 		return nil
@@ -106,7 +107,8 @@ func HandleBackgroundNotification(strConvID, body string, intMembersType int, di
 	chatNotification := ChatNotification{
 		IsPlaintext: displayPlaintext,
 		Message: &Message{
-			ID: intMessageID,
+			ID:            intMessageID,
+			ServerMessage: serverMessageBody,
 			From: &Person{
 				KeybaseUsername: username,
 				IsBot:           isBot,

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/ChatBroadcastReceiver.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/ChatBroadcastReceiver.java
@@ -40,13 +40,8 @@ public class ChatBroadcastReceiver extends BroadcastReceiver {
         .setSmallIcon(R.drawable.ic_notif);
 
       try {
-        Keybase.setAppStateBackgroundActive();
-        Keybase.handlePostTextReply(convData.convID, convData.tlfName, messageBody);
-        if (Keybase.appDidEnterBackground()) {
-          Keybase.appBeginBackgroundTaskNonblock(new KBPushNotifier(context, new Bundle()));
-        } else {
-          Keybase.setAppStateBackground();
-        }
+        WithBackgroundActive withBackgroundActive = () -> Keybase.handlePostTextReply(convData.convID, convData.tlfName, messageBody);
+        withBackgroundActive.whileActive(context);
         repliedNotification.setContentText("Replied");
       } catch (Exception e) {
         repliedNotification.setContentText("Couldn't send reply");

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KBPushNotifier.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KBPushNotifier.java
@@ -47,12 +47,12 @@ public class KBPushNotifier implements PushNotifier {
     return style;
   }
 
-  public KBPushNotifier(Context ctx, Bundle bundle) {
+  KBPushNotifier(Context ctx, Bundle bundle) {
     this.context = ctx;
     this.bundle = bundle;
   }
 
-  public void setMsgCache(SmallMsgRingBuffer convMsgCache) {
+  void setMsgCache(SmallMsgRingBuffer convMsgCache) {
     this.convMsgCache = convMsgCache;
   }
 
@@ -175,7 +175,10 @@ public class KBPushNotifier implements PushNotifier {
     Person fromPerson = personBuilder.build();
 
     if (this.convMsgCache != null) {
-      String msgText = chatNotification.getIsPlaintext() ? chatNotification.getMessage().getPlaintext() : "Encrypted Message...";
+      String msgText = chatNotification.getIsPlaintext() ? chatNotification.getMessage().getPlaintext() : "";
+      if (msgText.isEmpty()) {
+        msgText = chatNotification.getMessage().getServerMessage();
+      }
       convMsgCache.add(new MessagingStyle.Message(msgText, msg.getAt(), fromPerson));
     }
 

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -5,6 +5,7 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.RequiresApi;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationCompat.MessagingStyle;
 import android.support.v4.app.NotificationManagerCompat;
@@ -15,7 +16,6 @@ import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
@@ -59,18 +59,6 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
 
         return style;
     }
-
-    private void cacheMsg(String convID, MessagingStyle.Message msg) {
-        SmallMsgRingBuffer buf = msgCache.get(convID);
-        if (buf != null) {
-            buf.add(msg);
-        } else {
-            buf = new SmallMsgRingBuffer();
-            buf.add(msg);
-            msgCache.put(convID, buf);
-        }
-    }
-
 
     @Override
     public void onCreate() {
@@ -142,6 +130,7 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
         }
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB_MR1)
     @Override
     public void onMessageReceived(RemoteMessage message) {
         final Bundle bundle = new Bundle();
@@ -176,31 +165,24 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
             String payload = bundle.getString("m");
             KBPushNotifier notifier = new KBPushNotifier(getApplicationContext(), bundle);
             switch (type) {
+                case "chat.newmessage":
                 case "chat.newmessageSilent_2": {
-                    boolean displayPlaintext = "true".equals(bundle.getString("n"));
-                    int membersType = Integer.parseInt(bundle.getString("t"));
-                    String convID = bundle.getString("c");
-                    int messageId = Integer.parseInt(bundle.getString("d"));
-                    JSONArray pushes = parseJSONArray(bundle.getString("p"));
-                    String pushId = pushes.getString(0);
-                    int badgeCount = Integer.parseInt(bundle.getString("b"));
-                    long unixTime = Integer.parseInt(bundle.getString("x"));
-                    String soundName = bundle.getString("s");
+                    NotificationData n = new NotificationData(type, bundle);
 
                     // Blow the cache if we aren't displaying plaintext
-                    if (!msgCache.containsKey(convID) || !displayPlaintext) {
-                        msgCache.put(convID, new SmallMsgRingBuffer());
+                    if (!msgCache.containsKey(n.convID) || !n.displayPlaintext) {
+                        msgCache.put(n.convID, new SmallMsgRingBuffer());
                     }
 
                     // We've shown this notification already
-                    if (seenChatNotifications.contains(convID + messageId)) {
+                    if (seenChatNotifications.contains(n.convID + n.messageId)) {
                         return;
                     }
 
-                    notifier.setMsgCache(msgCache.get(convID));
-
-                    Keybase.handleBackgroundNotification(convID, payload, membersType, displayPlaintext, messageId, pushId, badgeCount, unixTime, soundName, notifier);
-                    seenChatNotifications.add(convID + messageId);
+                    notifier.setMsgCache(msgCache.get(n.convID));
+                    WithBackgroundActive withBackgroundActive = () -> Keybase.handleBackgroundNotification(n.convID, payload, n.serverMessageBody, n.membersType, n.displayPlaintext, n.messageId, n.pushId, n.badgeCount, n.unixTime, n.soundName, notifier);
+                    withBackgroundActive.whileActive(getApplicationContext());
+                    seenChatNotifications.add(n.convID + n.messageId);
                 }
                 break;
                 case "follow": {
@@ -223,34 +205,9 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
                     notificationManager.cancelAll();
                 }
                 break;
-                case "chat.newmessage": {
-                    // The server will send us this if we didn't ack the chat.newmessageSilent_2 within
-                    String convID = bundle.getString("convID");
-                    int membersType = Integer.parseInt(bundle.getString("t"));
-                    int messageId = Integer.parseInt(bundle.getString("msgID"));
-                    // TODO should we just check if this is an exploding message and only show it then?
-                    String messageBody = bundle.getString("message");
-
-                    // We've shown this notification already
-                    if (seenChatNotifications.contains(convID + messageId)) {
-                        return;
-                    } else {
-                        seenChatNotifications.add(convID + messageId);
-                    }
-                    // TODO handle this case better. Right now this isn't as pretty as the notifs
-                    // above. We should use the engine to get more metadata. Making this ugly for now.
-                    // This is only used in exploding messages.
-                    if (messageBody != null && !messageBody.isEmpty()) {
-                        notifier.genericNotification(convID, "", messageBody, bundle, KeybasePushNotificationListenerService.CHAT_CHANNEL_ID);
-                    }
-
-                }
-                break;
                 default:
                     notifier.generalNotification();
             }
-        } catch (JSONException jex) {
-            NativeLogger.error("Couldn't parse json: " + jex.getMessage());
         } catch (Exception ex) {
             NativeLogger.error("Couldn't handle background notification: " + ex.getMessage());
         }
@@ -265,13 +222,6 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
         }
     }
 
-    private JSONArray parseJSONArray(String str) {
-        try {
-            return new JSONArray(str);
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }
 
 class SmallMsgRingBuffer {
@@ -287,4 +237,71 @@ class SmallMsgRingBuffer {
     public List<MessagingStyle.Message> summary() {
         return buffer;
     }
+}
+
+class NotificationData {
+    final boolean displayPlaintext;
+    final int membersType;
+    final String convID;
+    final int messageId;
+    final String pushId;
+    final int badgeCount;
+    final long unixTime;
+    final String soundName;
+    final String serverMessageBody;
+
+    // Derived from go/gregord/chatpush/push.go
+    @RequiresApi(api = Build.VERSION_CODES.HONEYCOMB_MR1)
+    NotificationData(String type, Bundle bundle) {
+        displayPlaintext = "true".equals(bundle.getString("n"));
+        membersType = Integer.parseInt(bundle.getString("t"));
+        badgeCount = Integer.parseInt(bundle.getString("b", "0"));
+        soundName = bundle.getString("s", "");
+        serverMessageBody = bundle.getString("message", "");
+
+        if (type.equals("chat.newmessage")) {
+            messageId = Integer.parseInt(bundle.getString("msgID", "0"));
+            convID = bundle.getString("convID");
+            // TODO consolidate this with below when new server code goes in
+            unixTime = ((new Date()).getTime() / 1000);
+        } else if (type.equals("chat.newmessageSilent_2"))  {
+            messageId = Integer.parseInt(bundle.getString("d", ""));
+            convID = bundle.getString("c");
+            unixTime = Long.parseLong(bundle.getString("x", "0"));
+        } else {
+            throw new Error("Tried to parse notification of unhandled type: " + type );
+        }
+
+        String pushIdTmp = "";
+        try {
+            JSONArray pushes = new JSONArray(bundle.getString("p"));
+            pushIdTmp = pushes.getString(0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        pushId = pushIdTmp;
+    }
+}
+
+// Interface to run some task while in backgroundActive.
+// If already foreground, just runs the task.
+interface WithBackgroundActive {
+    abstract void task() throws Exception;
+
+    default void whileActive(Context context) throws Exception {
+        // We are foreground we don't need to change to background active
+        if (Keybase.isAppStateForeground()) {
+            this.task();
+        } else {
+          Keybase.setAppStateBackgroundActive();
+          this.task();
+          if (Keybase.appDidEnterBackground()) {
+              Keybase.appBeginBackgroundTaskNonblock(new KBPushNotifier(context, new Bundle()));
+          } else {
+              Keybase.setAppStateBackground();
+          }
+        }
+    }
+
+
 }

--- a/shared/ios/Keybase/AppDelegate.m
+++ b/shared/ios/Keybase/AppDelegate.m
@@ -156,7 +156,7 @@
       PushNotifier* pusher = [[PushNotifier alloc] init];
       // This always tries to unbox the notification and adds a plaintext
       // notification if displayPlaintext is set.
-      KeybaseHandleBackgroundNotification(convID, body, membersType, displayPlaintext,
+      KeybaseHandleBackgroundNotification(convID, body, @"", membersType, displayPlaintext,
             messageID, pushID, badgeCount, unixTime, soundName, pusher, &err);
       if (err != nil) {
         NSLog(@"Failed to handle in engine: %@", err);
@@ -171,7 +171,7 @@
       NSString* body = notification[@"m"];
       int membersType = [notification[@"t"] intValue];
       int messageID = [notification[@"msgID"] intValue];
-      KeybaseHandleBackgroundNotification(convID, body, membersType, false,
+      KeybaseHandleBackgroundNotification(convID, body, @"", membersType, false,
                                           messageID, @"", 0, 0, @"", nil, &err);
       if (err != nil) {
         NSLog(@"Failed to handle in engine: %@", err);


### PR DESCRIPTION
@jzila @joshblum @keybase/react-hackers 

We have `chat.newmessage` and `chat.newmessageSilent_2`. The silent version carries more data (can contain the encrypted message payload).

Before we were handling this in two different ways so `chat.newmessage` would keep the old style android notifications. This changes it so that it's consistent and keeps the new style on both flows.

This also:
 * preserves the server rendered notification display message for when we don't have a plaintext to display.
* Handle the case where we don't have a boxed message so that we always call the notifier. (this way native code doesn't have to catch an exception and try to figure out what notification to show).
* Parses the username from the given server message (when we don't have a msg to unbox) to keep the notification UI consistent. This is pretty hacky right now, but will change when there is server support for it.
* Preloads the message from the notification by unboxing it in both cases