### PR TITLE
keybase_service_base: assure the current device can migrate

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -8393,6 +8393,17 @@ func (fbo *folderBranchOps) getMDForMigrationLocked(
 	return md, nil
 }
 
+// CheckMigrationPerms implements the KBFSOps interface for folderBranchOps.
+func (fbo *folderBranchOps) CheckMigrationPerms(
+	ctx context.Context, id tlf.ID) (err error) {
+	lState := makeFBOLockState()
+	fbo.mdWriterLock.Lock(lState)
+	defer fbo.mdWriterLock.Unlock(lState)
+
+	_, err = fbo.getMDForMigrationLocked(ctx, lState)
+	return err
+}
+
 // MigrateToImplicitTeam implements the KBFSOps interface for folderBranchOps.
 func (fbo *folderBranchOps) MigrateToImplicitTeam(
 	ctx context.Context, id tlf.ID) (err error) {

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -536,6 +536,9 @@ type KBFSOps interface {
 	// TeamAbandoned indicates that a team has been abandoned, and
 	// shouldn't be referred to by its previous name anymore.
 	TeamAbandoned(ctx context.Context, tid keybase1.TeamID)
+	// CheckMigrationPerms returns an error if this device cannot
+	// perform implicit team migration for the given TLF.
+	CheckMigrationPerms(ctx context.Context, id tlf.ID) (err error)
 	// MigrateToImplicitTeam migrates the given folder from a private-
 	// or public-keyed folder, to a team-keyed folder.  If it's
 	// already a private/public team-keyed folder, nil is returned.

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -1476,6 +1476,19 @@ func (fs *KBFSOpsStandard) TeamAbandoned(
 	}
 }
 
+// CheckMigrationPerms implements the KBFSOps interface for folderBranchOps.
+func (fs *KBFSOpsStandard) CheckMigrationPerms(
+	ctx context.Context, id tlf.ID) (err error) {
+	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
+	defer timeTrackerDone()
+
+	// We currently only migrate on the master branch of a TLF.
+	ops := fs.getOps(
+		ctx, data.FolderBranch{Tlf: id, Branch: data.MasterBranch},
+		FavoritesOpNoChange)
+	return ops.CheckMigrationPerms(ctx, id)
+}
+
 // MigrateToImplicitTeam implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) MigrateToImplicitTeam(
 	ctx context.Context, id tlf.ID) error {

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1356,7 +1356,15 @@ func (k *KeybaseServiceBase) StartMigration(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	return k.config.MDServer().StartImplicitTeamMigration(ctx, handle.TlfID())
+	// Before taking the lock, first make sure this device can handle
+	// the migration.
+	tlfID := handle.TlfID()
+	err = k.config.KBFSOps().CheckMigrationPerms(ctx, tlfID)
+	if err != nil {
+		k.log.CDebugf(ctx, "This device cannot migrate %s: %+v", tlfID, err)
+		return err
+	}
+	return k.config.MDServer().StartImplicitTeamMigration(ctx, tlfID)
 }
 
 // FinalizeMigration implements keybase1.ImplicitTeamMigrationInterface for

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -908,6 +908,20 @@ func (mr *MockKBFSOpsMockRecorder) AddRootNodeWrapper(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRootNodeWrapper", reflect.TypeOf((*MockKBFSOps)(nil).AddRootNodeWrapper), arg0)
 }
 
+// CheckMigrationPerms mocks base method
+func (m *MockKBFSOps) CheckMigrationPerms(arg0 context.Context, arg1 tlf.ID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckMigrationPerms", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckMigrationPerms indicates an expected call of CheckMigrationPerms
+func (mr *MockKBFSOpsMockRecorder) CheckMigrationPerms(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckMigrationPerms", reflect.TypeOf((*MockKBFSOps)(nil).CheckMigrationPerms), arg0, arg1)
+}
+
 // ClearCachedFavorites mocks base method
 func (m *MockKBFSOps) ClearCachedFavorites(arg0 context.Context) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Before taking the migration lock on the server, assure ourselves that the current device has read access to the TLF and thus can perform the migration.  Right now it's possible for a new device, that hasn't been keyed for the TLF yet, to get the migration request, take the lock, and then fail to perform the migration.  This locks out any future rekeys that would make the TLF readable, since there's nothing that automatically releases the lock when the migration rekey fails to happen.

Issue: HOTPOT-552