### PR TITLE
Fix crash when sharing on gboard

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -240,9 +240,11 @@ public class MainActivity extends ReactFragmentActivity {
           this.context = context;
         }
 
-        public void run() {
+        private void run() {
           KeybaseEngine engine = context.getNativeModule(KeybaseEngine.class);
-          engine.setInitialIntent(Arguments.fromBundle(bundleFromNotification));
+          if (bundleFromNotification != null) {
+            engine.setInitialIntent(Arguments.fromBundle(bundleFromNotification));
+          }
 
           assert emitter != null;
           // If there are any other bundle sources we care about, emit them here


### PR DESCRIPTION
@keybase/react-hackers Fixes crash with gboard gif. Doesn't insert the gif into chat (you end up in the files tab currently (?))