### PR TITLE
Fix contact search results and service map rendering

### DIFF
--- a/shared/actions/team-building.tsx
+++ b/shared/actions/team-building.tsx
@@ -21,6 +21,15 @@ const apiSearch = async (
   impTofuQuery: RPCTypes.ImpTofuQuery | null,
   includeContacts: boolean
 ): Promise<Array<TeamBuildingTypes.User>> => {
+  switch (service) {
+    // These services should not be queried through the API.
+    // TODO: Y2K-552 change types in this function so it can't be called with
+    // invalid services.
+    case 'phone':
+    case 'contact':
+    case 'email':
+      return []
+  }
   try {
     const results = await RPCTypes.userSearchUserSearchRpcPromise({
       impTofuQuery,
@@ -53,7 +62,7 @@ function* searchResultCounts(state: TypedState, {payload: {namespace}}: NSAction
   // Filter on `services` so we only get what's searchable through API.
   // Also filter out if we already have that result cached.
   const servicesToSearch = Constants.services
-    .filter(s => s !== teamBuildingSelectedService && ['contact', 'phone', 'email'].indexOf(s) === -1)
+    .filter(s => s !== teamBuildingSelectedService && !['contact', 'phone', 'email'].includes(s))
     .filter(s => !teamBuildingState.teamBuildingSearchResults.hasIn([teamBuildingSearchQuery, s]))
 
   const isStillInSameQuery = (state: TypedState): boolean => {

--- a/shared/actions/team-building.tsx
+++ b/shared/actions/team-building.tsx
@@ -21,10 +21,6 @@ const apiSearch = async (
   impTofuQuery: RPCTypes.ImpTofuQuery | null,
   includeContacts: boolean
 ): Promise<Array<TeamBuildingTypes.User>> => {
-  if (service === 'phone') {
-    return []
-  }
-
   try {
     const results = await RPCTypes.userSearchUserSearchRpcPromise({
       impTofuQuery,
@@ -54,10 +50,10 @@ function* searchResultCounts(state: TypedState, {payload: {namespace}}: NSAction
     return
   }
 
-  // filter out the service we are searching for and contact
-  // Also filter out if we already have that result cached
+  // Filter on `services` so we only get what's searchable through API.
+  // Also filter out if we already have that result cached.
   const servicesToSearch = Constants.services
-    .filter(s => s !== teamBuildingSelectedService && s !== 'contact')
+    .filter(s => s !== teamBuildingSelectedService && ['contact', 'phone', 'email'].indexOf(s) === -1)
     .filter(s => !teamBuildingState.teamBuildingSearchResults.hasIn([teamBuildingSearchQuery, s]))
 
   const isStillInSameQuery = (state: TypedState): boolean => {

--- a/shared/team-building/shared.tsx
+++ b/shared/team-building/shared.tsx
@@ -1,7 +1,8 @@
 import * as Styles from '../styles'
-import {ServiceIdWithContact} from '../constants/types/team-building'
+import {ServiceIdWithContact, ServiceMap} from '../constants/types/team-building'
 import {IconType} from '../common-adapters/icon.constants'
 import Flags from '../util/feature-flags'
+import {allServices} from '../constants/team-building'
 
 const services: {
   [K in ServiceIdWithContact]: {
@@ -98,6 +99,8 @@ const serviceIdToWonderland = (service: ServiceIdWithContact): boolean =>
 
 const inactiveServiceAccentColor = Styles.globalColors.black
 
+const serviceMapToArray = (services: ServiceMap) => allServices.filter(x => x !== 'keybase' && x in services)
+
 export {
   serviceIdToIconFont,
   serviceIdToAccentColor,
@@ -106,4 +109,5 @@ export {
   serviceIdToLongLabel,
   serviceIdToSearchPlaceholder,
   serviceIdToWonderland,
+  serviceMapToArray,
 }

--- a/shared/team-building/user-result.desktop.tsx
+++ b/shared/team-building/user-result.desktop.tsx
@@ -4,7 +4,7 @@ import * as Styles from '../styles'
 import * as Types from '../constants/types/team-building'
 import {followingStateToStyle} from '../search/shared'
 import {Props} from './user-result'
-import {serviceIdToIconFont, serviceIdToAccentColor} from './shared'
+import {serviceIdToIconFont, serviceIdToAccentColor, serviceMapToArray} from './shared'
 
 // TODO
 // * Use ListItem2
@@ -67,7 +67,7 @@ class Row extends React.Component<Props, LocalState> {
           />
           <Services
             keybaseResult={keybaseResult}
-            services={this.props.services}
+            services={serviceMapToArray(this.props.services)}
             keybaseUsername={keybaseUsername}
             followingState={this.props.followingState}
           />
@@ -154,7 +154,7 @@ const Services = ({
   keybaseUsername,
   followingState,
 }: {
-  services: {[K in Types.ServiceIdWithContact]?: string}
+  services: Array<Types.ServiceIdWithContact>
   keybaseResult: boolean
   keybaseUsername: string | null
   followingState: Types.FollowingState
@@ -162,16 +162,14 @@ const Services = ({
   if (keybaseResult) {
     return (
       <Kb.Box2 direction="horizontal" style={styles.services}>
-        {Object.keys(services)
-          .filter(s => s !== 'keybase')
-          .map(service => (
-            <Kb.WithTooltip key={service} text={services[service]} position="top center">
-              <Kb.Icon
-                type={serviceIdToIconFont(service as Types.ServiceIdWithContact)}
-                style={Kb.iconCastPlatformStyles(styles.serviceIcon)}
-              />
-            </Kb.WithTooltip>
-          ))}
+        {services.map(service => (
+          <Kb.WithTooltip key={service} text={services[service]} position="top center">
+            <Kb.Icon
+              type={serviceIdToIconFont(service as Types.ServiceIdWithContact)}
+              style={Kb.iconCastPlatformStyles(styles.serviceIcon)}
+            />
+          </Kb.WithTooltip>
+        ))}
       </Kb.Box2>
     )
   } else if (keybaseUsername) {

--- a/shared/team-building/user-result.native.tsx
+++ b/shared/team-building/user-result.native.tsx
@@ -4,7 +4,7 @@ import * as Styles from '../styles'
 import * as Types from '../constants/types/team-building'
 import {followingStateToStyle} from '../search/shared'
 import {Props} from './user-result'
-import {serviceIdToIconFont, serviceIdToAccentColor} from './shared'
+import {serviceIdToIconFont, serviceIdToAccentColor, serviceMapToArray} from './shared'
 
 // TODO
 // * Use ListItem2
@@ -86,7 +86,7 @@ const FormatPrettyName = (props: {
   keybaseResult: boolean
   keybaseUsername: string | null
   prettyName: string
-  services: [Types.ServiceIdWithContact]
+  services: Array<Types.ServiceIdWithContact>
 }) =>
   props.keybaseResult ? (
     <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.services}>
@@ -139,9 +139,7 @@ const Username = (props: {
             keybaseResult={props.keybaseResult}
             keybaseUsername={props.keybaseUsername}
             prettyName={props.prettyName}
-            services={
-              Object.keys(props.services).filter(s => s !== 'keybase') as [Types.ServiceIdWithContact]
-            }
+            services={serviceMapToArray(props.services)}
           />
         )}
       </>


### PR DESCRIPTION
This should fix a non-deterministic search result bug that @malgorithms has ran into, where if you have results with the same score coming from contact search, scrolling down the list to fetch new results would yield a list with these contact new results not being at the end.

Also fix service icons in user result rows to always show up in specific ordering.