### PR TITLE
Import contacts banner tweaks

### DIFF
--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -170,6 +170,7 @@ const ContactsImportButton = (props: ContactProps) => {
   if (
     props.contactsImported === null ||
     props.contactsImported ||
+    !props.isImportPromptDismissed ||
     props.contactsPermissionStatus === 'never_ask_again'
   )
     return null
@@ -411,7 +412,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
                 />
               )
             }
-            renderSectionHeader={({section: {label}}) => <Kb.SectionDivider label={label} />}
+            renderSectionHeader={({section: {label}}) => (label ? <Kb.SectionDivider label={label} /> : null)}
           />
           {Styles.isMobile && this._alphabetIndex()}
         </Kb.Box2>


### PR DESCRIPTION
- Only displays the import contacts banner on the "Keybase & Contacts" tab
- Hides section headers without titles
- Hides the import contacts button until the banner is hidden

@keybase/react-hackers 