### PR TITLE
🌶️ Rabbit in empty chat inbox

### DIFF
--- a/shared/chat/conversation/no-conversation.tsx
+++ b/shared/chat/conversation/no-conversation.tsx
@@ -1,22 +1,20 @@
 import * as React from 'react'
-import {Box, Icon, Text} from '../../common-adapters'
-import {globalStyles, globalColors, globalMargins} from '../../styles'
+import {Box2, Icon, Text} from '../../common-adapters'
+import * as Styles from '../../styles'
 
 const NoConversation = () => (
-  <Box style={containerStyle}>
-    <Icon type="icon-fancy-chat-72-x-52" style={{marginBottom: globalMargins.small}} />
-    <Text type="BodySmallSemibold" negative={true} style={{color: globalColors.black_50}}>
-      All conversations are end-to-end encrypted.
-    </Text>
-  </Box>
+  <Box2 direction="vertical" gap="xsmall" centerChildren={true} style={styles.noConvoText}>
+    <Icon type="icon-fancy-encrypted-computer-desktop-150-72" />
+    <Text type="BodySmall">All conversations are end-to-end encrypted.</Text>
+  </Box2>
 )
 
-const containerStyle = {
-  ...globalStyles.flexBoxColumn,
-  alignItems: 'center',
-  backgroundColor: globalColors.white,
-  flex: 1,
-  justifyContent: 'center',
-}
+const styles = Styles.styleSheetCreate(() => ({
+  noConvoText: {
+    alignSelf: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+}))
 
 export default NoConversation

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -19,20 +19,23 @@ import Flags from '../../util/feature-flags'
 const NoChats = (props: {onNewChat: () => void}) => (
   <Kb.Box2
     direction="vertical"
-    gap="xsmall"
+    gap="small"
     style={{
       ...Styles.globalStyles.fillAbsolute,
       alignItems: 'center',
       flex: 1,
       justifyContent: 'center',
-      marginLeft: Styles.globalMargins.large,
-      marginRight: Styles.globalMargins.large,
     }}
   >
     <Kb.Icon type="icon-fancy-encrypted-phone-mobile-226-96" />
-    <Kb.Text type="BodySmall" style={{textAlign: 'center'}}>
-      All conversations are end-to-end encrypted.
-    </Kb.Text>
+    <Kb.Box2 direction="vertical">
+      <Kb.Text type="BodySmall" style={{textAlign: 'center'}}>
+        All conversations are
+      </Kb.Text>
+      <Kb.Text type="BodySmall" style={{textAlign: 'center'}}>
+        end-to-end encrypted.
+      </Kb.Text>
+    </Kb.Box2>
     <Kb.Button
       onClick={props.onNewChat}
       mode="Primary"

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -29,7 +29,7 @@ const NoChats = (props: {onNewChat: () => void}) => (
       marginRight: Styles.globalMargins.large,
     }}
   >
-    <Kb.Icon type="icon-fancy-encrypted-computer-mobile-226-96" />
+    <Kb.Icon type="icon-fancy-encrypted-phone-mobile-226-96" />
     <Kb.Text type="BodySmall" style={{textAlign: 'center'}}>
       All conversations are end-to-end encrypted.
     </Kb.Text>

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -14,30 +14,31 @@ import * as RowSizes from './row/sizes'
 import InboxSearch from '../inbox-search/container'
 import * as T from './index.types.d'
 import * as Types from '../../constants/types/chat2'
+import Flags from '../../util/feature-flags'
 
 const NoChats = (props: {onNewChat: () => void}) => (
-  <Kb.Box
+  <Kb.Box2
+    direction="vertical"
+    gap="xsmall"
     style={{
-      ...Styles.globalStyles.flexBoxColumn,
       ...Styles.globalStyles.fillAbsolute,
       alignItems: 'center',
+      flex: 1,
       justifyContent: 'center',
+      marginLeft: Styles.globalMargins.large,
+      marginRight: Styles.globalMargins.large,
     }}
   >
-    <Kb.Text type="BodySmall" negative={true} style={styles.text}>
-      All conversations are
-    </Kb.Text>
-    <Kb.Text type="BodySmall" negative={true} style={styles.text}>
-      end-to-end encrypted.
+    <Kb.Icon type="icon-fancy-encrypted-computer-mobile-226-96" />
+    <Kb.Text type="BodySmall" style={{textAlign: 'center'}}>
+      All conversations are end-to-end encrypted.
     </Kb.Text>
     <Kb.Button
       onClick={props.onNewChat}
-      type="Success"
       mode="Primary"
-      label="Start a new chat"
-      style={{marginTop: Styles.globalMargins.small}}
+      label={Flags.wonderland ? 'Start a new chat 🐇' : 'Start a new chat'}
     />
-  </Kb.Box>
+  </Kb.Box2>
 )
 
 type State = {
@@ -278,9 +279,6 @@ const styles = Styles.styleSheetCreate({
     backgroundColor: Styles.globalColors.fastBlank,
     flex: 1,
     position: 'relative',
-  },
-  text: {
-    color: Styles.globalColors.black_50,
   },
 })
 

--- a/shared/chat/inbox/row/start-new-chat.tsx
+++ b/shared/chat/inbox/row/start-new-chat.tsx
@@ -27,12 +27,16 @@ const StartNewChat = (props: Props) => {
   }
   return (
     <Kb.Box2 direction="horizontal" fullWidth={true}>
-      <Kb.Button
-        label={Flags.wonderland ? 'Start a new chat 🐇' : 'Start a new chat'}
-        onClick={props.onNewChat}
-        style={styles.button}
-        small={true}
-      />
+      <Kb.Button onClick={props.onNewChat} style={styles.button} small={true}>
+        <Kb.Text type="BodyBig" style={styles.startNewChatText}>
+          Start a new chat
+        </Kb.Text>
+        {Flags.wonderland && (
+          <Kb.Text type="BodyBig" style={styles.rabbitEmoji}>
+            <Kb.Emoji size={16} emojiName=":rabbit2:" />
+          </Kb.Text>
+        )}
+      </Kb.Button>
     </Kb.Box2>
   )
 }
@@ -77,6 +81,12 @@ const styles = Styles.styleSheetCreate({
       padding: Styles.globalMargins.xtiny,
     },
   }),
+  rabbitEmoji: {
+    marginLeft: Styles.globalMargins.xtiny,
+  },
+  startNewChatText: {
+    color: Styles.globalColors.white,
+  },
 })
 
 export default StartNewChat

--- a/shared/chat/inbox/row/start-new-chat.tsx
+++ b/shared/chat/inbox/row/start-new-chat.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
+import Flags from '../../../util/feature-flags'
 
 type Props = {
   onBack: () => void
@@ -26,9 +27,12 @@ const StartNewChat = (props: Props) => {
   }
   return (
     <Kb.Box2 direction="horizontal" fullWidth={true}>
-      <Kb.Button label="Start a new chat" onClick={props.onNewChat} style={styles.button} small={true}>
-        <Kb.Icon type="iconfont-compose" color={Styles.globalColors.white} style={styles.buttonIcon} />
-      </Kb.Button>
+      <Kb.Button
+        label={Flags.wonderland ? 'Start a new chat 🐇' : 'Start a new chat'}
+        onClick={props.onNewChat}
+        style={styles.button}
+        small={true}
+      />
     </Kb.Box2>
   )
 }


### PR DESCRIPTION
@keybase/react-hackers 
This adds the 🐇to the empty chat state on desktop and mobile + brings a few visual tweaks:
![image](https://user-images.githubusercontent.com/2807426/63730873-edc38300-c821-11e9-97e0-b64ea96ca1c3.png)
![image](https://user-images.githubusercontent.com/2807426/63731235-8e667280-c823-11e9-9898-8375643fbc39.png)
