### PR TITLE
folder_branch_ops: fix symlinks that end up as historical paths

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1181,6 +1181,15 @@ pathLoop:
 				return err
 			}
 
+			if currNode == nil {
+				// This can happen if an old bug (HOTPOT-616) kept a
+				// deleted path in the history that has since been
+				// changed into a symlink.
+				fbo.vlog.CLogf(
+					ctx, libkb.VLog1, "Ignoring symlink path %s", p)
+				continue pathLoop
+			}
+
 			// Use `PrefetchTail` for directories, to make sure that
 			// any child blocks in the directory itself get
 			// prefetched.


### PR DESCRIPTION
Similar to #19033, an old bug could cause a historical path to contain a symlink, which will end up crashing the partial syncing code.  Catch that and ignore any symlink paths.

Issue: #19151