### PR TITLE
kbfs_ops: allow a user to reset to a particular TLF ID

### DIFF
--- a/go/client/cmd_simplefs_reset.go
+++ b/go/client/cmd_simplefs_reset.go
@@ -16,7 +16,8 @@ import (
 // CmdSimpleFSReset is the 'fs reset' command.
 type CmdSimpleFSReset struct {
 	libkb.Contextified
-	path keybase1.Path
+	path  keybase1.Path
+	tlfID string
 }
 
 // NewCmdSimpleFSReset creates a new cli.Command.
@@ -30,6 +31,12 @@ func NewCmdSimpleFSReset(
 			cl.ChooseCommand(&CmdSimpleFSReset{
 				Contextified: libkb.NewContextified(g)}, "reset", c)
 			cl.SetNoStandalone()
+		},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "id",
+				Usage: "the ID to which to reset the folder (experts only!)",
+			},
 		},
 	}
 }
@@ -57,7 +64,11 @@ func (c *CmdSimpleFSReset) Run() error {
 		return err
 	}
 
-	err = cli.SimpleFSReset(context.TODO(), c.path)
+	arg := keybase1.SimpleFSResetArg{
+		Path:  c.path,
+		TlfID: c.tlfID,
+	}
+	err = cli.SimpleFSReset(context.TODO(), arg)
 	if err != nil {
 		return err
 	}
@@ -76,6 +87,7 @@ func (c *CmdSimpleFSReset) ParseArgv(ctx *cli.Context) error {
 		return err
 	}
 	c.path = p
+	c.tlfID = ctx.String("id")
 	return nil
 }
 

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -208,7 +208,8 @@ func (s SimpleFSMock) SimpleFSFolderEditHistory(
 }
 
 // SimpleFSReset implements the SimpleFSInterface.
-func (s SimpleFSMock) SimpleFSReset(_ context.Context, _ keybase1.Path) error {
+func (s SimpleFSMock) SimpleFSReset(
+	_ context.Context, _ keybase1.SimpleFSResetArg) error {
 	return nil
 }
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -564,8 +564,12 @@ type KBFSOps interface {
 	ForceStuckConflictForTesting(ctx context.Context, tlfID tlf.ID) error
 	// Reset completely resets the given folder.  Should only be
 	// called after explicit user confirmation.  After the call,
-	// `handle` has the new TLF ID.
-	Reset(ctx context.Context, handle *tlfhandle.Handle) error
+	// `handle` has the new TLF ID.  If `*newTlfID` is non-nil, that
+	// will be the new TLF ID of the reset TLF, if it already points
+	// to a MD object that matches the same handle as the original TLF
+	// (see HOTPOT-685 for an example of how this can happen -- it
+	// should be very rare).
+	Reset(ctx context.Context, handle *tlfhandle.Handle, newTlfID *tlf.ID) error
 
 	// GetSyncConfig returns the sync state configuration for the
 	// given TLF.

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -647,7 +647,8 @@ func (fs *KBFSOpsStandard) getOpsByHandle(ctx context.Context,
 	return ops
 }
 
-func (fs *KBFSOpsStandard) resetTlfID(ctx context.Context, h *tlfhandle.Handle) error {
+func (fs *KBFSOpsStandard) resetTlfID(
+	ctx context.Context, h *tlfhandle.Handle, newTlfID *tlf.ID) error {
 	if !h.IsBackedByTeam() {
 		return errors.WithStack(NonExistentTeamForHandleError{h})
 	}
@@ -657,26 +658,33 @@ func (fs *KBFSOpsStandard) resetTlfID(ctx context.Context, h *tlfhandle.Handle) 
 		return err
 	}
 
-	matches, epoch, err := h.TlfID().GetEpochFromTeamTLF(teamID)
-	if err != nil {
-		return err
-	}
-	if matches {
-		epoch++
+	var tlfID tlf.ID
+	if newTlfID != nil {
+		tlfID = *newTlfID
+		fs.log.CDebugf(ctx, "Resetting to TLF ID %s for TLF %s, %s",
+			tlfID, teamID, h.GetCanonicalName())
 	} else {
-		epoch = 0
-	}
+		matches, epoch, err := h.TlfID().GetEpochFromTeamTLF(teamID)
+		if err != nil {
+			return err
+		}
+		if matches {
+			epoch++
+		} else {
+			epoch = 0
+		}
 
-	// When creating a new TLF for an implicit team, always start with
-	// epoch 0.  A different path will handle TLF resets with an
-	// increased epoch, if necessary.
-	tlfID, err := tlf.MakeIDFromTeam(h.Type(), teamID, epoch)
-	if err != nil {
-		return err
-	}
+		// When creating a new TLF for an implicit team, always start with
+		// epoch 0.  A different path will handle TLF resets with an
+		// increased epoch, if necessary.
+		tlfID, err = tlf.MakeIDFromTeam(h.Type(), teamID, epoch)
+		if err != nil {
+			return err
+		}
 
-	fs.log.CDebugf(ctx, "Creating new TLF ID %s for team %s, %s",
-		tlfID, teamID, h.GetCanonicalName())
+		fs.log.CDebugf(ctx, "Creating new TLF ID %s for TLF %s, %s",
+			tlfID, teamID, h.GetCanonicalName())
+	}
 
 	err = fs.config.KBPKI().CreateTeamTLF(ctx, teamID, tlfID)
 	if err != nil {
@@ -697,7 +705,7 @@ func (fs *KBFSOpsStandard) createAndStoreTlfIDIfNeeded(
 		return nil
 	}
 
-	return fs.resetTlfID(ctx, h)
+	return fs.resetTlfID(ctx, h, nil)
 }
 
 func (fs *KBFSOpsStandard) transformReadError(
@@ -1597,7 +1605,7 @@ func (fs *KBFSOpsStandard) NewNotificationChannel(
 
 // Reset implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) Reset(
-	ctx context.Context, handle *tlfhandle.Handle) error {
+	ctx context.Context, handle *tlfhandle.Handle, newTlfID *tlf.ID) error {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
@@ -1607,15 +1615,32 @@ func (fs *KBFSOpsStandard) Reset(
 	if err != nil {
 		return err
 	}
-	id, _, err := fs.config.MDServer().GetForHandle(
-		ctx, bareHandle, kbfsmd.Merged, nil)
-	if err == nil {
-		fs.log.CDebugf(ctx, "Folder %s can't be reset; still has ID %s",
-			handle.GetCanonicalPath(), id)
-		return errors.WithStack(FolderNotResetOnServer{handle})
-	} else if _, ok := errors.Cause(err).(kbfsmd.ServerErrorClassicTLFDoesNotExist); !ok {
-		// Return errors if they don't indicate the folder is new.
-		return err
+
+	if newTlfID != nil {
+		oldPath := handle.GetCanonicalPath()
+		fs.log.CDebugf(
+			ctx, "Checking that %s is an appropriate ID for TLF %s after reset",
+			*newTlfID, oldPath)
+		md, err := fs.config.MDOps().GetForTLF(ctx, *newTlfID, nil)
+		if err != nil {
+			return err
+		}
+		newPath := md.GetTlfHandle().GetCanonicalPath()
+		if newPath != oldPath {
+			return errors.Errorf("Cannot reset %s (%s) to TLF %s (%s)",
+				oldPath, handle.TlfID(), newPath, *newTlfID)
+		}
+	} else {
+		id, _, err := fs.config.MDServer().GetForHandle(
+			ctx, bareHandle, kbfsmd.Merged, nil)
+		if err == nil {
+			fs.log.CDebugf(ctx, "Folder %s can't be reset; still has ID %s",
+				handle.GetCanonicalPath(), id)
+			return errors.WithStack(FolderNotResetOnServer{handle})
+		} else if _, ok := errors.Cause(err).(kbfsmd.ServerErrorClassicTLFDoesNotExist); !ok {
+			// Return errors if they don't indicate the folder is new.
+			return err
+		}
 	}
 
 	fs.opsLock.Lock()
@@ -1624,6 +1649,8 @@ func (fs *KBFSOpsStandard) Reset(
 	fb := data.FolderBranch{Tlf: handle.TlfID(), Branch: data.MasterBranch}
 	ops, ok := fs.ops[fb]
 	if ok {
+		fs.config.MDServer().CancelRegistration(ctx, handle.TlfID())
+
 		err := ops.Reset(ctx, handle)
 		if err != nil {
 			return err
@@ -1640,7 +1667,7 @@ func (fs *KBFSOpsStandard) Reset(
 	// Reset the TLF by overwriting the TLF ID in the sigchain.  This
 	// assumes that the server is in implicit team mode for new TLFs,
 	// which at this point it should always be.
-	return fs.resetTlfID(ctx, handle)
+	return fs.resetTlfID(ctx, handle, newTlfID)
 }
 
 // ClearConflictView resets a TLF's journal and conflict DB to a non

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4265,7 +4265,7 @@ func TestKBFSOpsReset(t *testing.T) {
 	// Pretend the mdserver is shutdown, to avoid checking merged
 	// state when shutting down the FBO (which causes a deadlock).
 	md.override = true
-	err = kbfsOps.Reset(ctx, h)
+	err = kbfsOps.Reset(ctx, h, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, oldID, h.TlfID())
 	md.override = false
@@ -4283,6 +4283,21 @@ func TestKBFSOpsReset(t *testing.T) {
 	children, err = kbfsOps.GetDirChildren(ctx, rootNode)
 	require.NoError(t, err)
 	require.Len(t, children, 1)
+
+	t.Logf("Reset it back")
+	md.override = true
+	err = kbfsOps.Reset(ctx, h, &oldID)
+	require.NoError(t, err)
+	require.Equal(t, oldID, oldID)
+	md.override = false
+
+	t.Logf("Check that the old revision is back")
+	rootNode, _, err = kbfsOps.GetOrCreateRootNode(ctx, h, data.MasterBranch)
+	require.NoError(t, err)
+	children, err = kbfsOps.GetDirChildren(ctx, rootNode)
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	require.Contains(t, children, testPPS("a"))
 }
 
 // diskMDCacheWithCommitChan notifies a channel whenever an MD is committed.

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4288,7 +4288,7 @@ func TestKBFSOpsReset(t *testing.T) {
 	md.override = true
 	err = kbfsOps.Reset(ctx, h, &oldID)
 	require.NoError(t, err)
-	require.Equal(t, oldID, oldID)
+	require.Equal(t, oldID, h.TlfID())
 	md.override = false
 
 	t.Logf("Check that the old revision is back")

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -1479,17 +1479,17 @@ func (mr *MockKBFSOpsMockRecorder) RequestRekey(arg0, arg1 interface{}) *gomock.
 }
 
 // Reset mocks base method
-func (m *MockKBFSOps) Reset(arg0 context.Context, arg1 *tlfhandle.Handle) error {
+func (m *MockKBFSOps) Reset(arg0 context.Context, arg1 *tlfhandle.Handle, arg2 *tlf.ID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reset", arg0, arg1)
+	ret := m.ctrl.Call(m, "Reset", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Reset indicates an expected call of Reset
-func (mr *MockKBFSOpsMockRecorder) Reset(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKBFSOpsMockRecorder) Reset(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockKBFSOps)(nil).Reset), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockKBFSOps)(nil).Reset), arg0, arg1, arg2)
 }
 
 // SetEx mocks base method

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -2321,8 +2321,8 @@ func (k *SimpleFS) SimpleFSFolderEditHistory(
 
 // SimpleFSReset resets the given TLF.
 func (k *SimpleFS) SimpleFSReset(
-	ctx context.Context, path keybase1.Path) error {
-	t, tlfName, _, _, err := remoteTlfAndPath(path)
+	ctx context.Context, arg keybase1.SimpleFSResetArg) error {
+	t, tlfName, _, _, err := remoteTlfAndPath(arg.Path)
 	if err != nil {
 		return err
 	}
@@ -2332,7 +2332,16 @@ func (k *SimpleFS) SimpleFSReset(
 		return err
 	}
 
-	return k.config.KBFSOps().Reset(ctx, tlfHandle)
+	var newTlfID *tlf.ID
+	if arg.TlfID != "" {
+		tlfID, err := tlf.ParseID(arg.TlfID)
+		if err != nil {
+			return err
+		}
+		newTlfID = &tlfID
+	}
+
+	return k.config.KBFSOps().Reset(ctx, tlfHandle, newTlfID)
 }
 
 var _ libkbfs.Observer = (*SimpleFS)(nil)

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1520,7 +1520,8 @@ type SimpleFSGetTeamQuotaUsageArg struct {
 }
 
 type SimpleFSResetArg struct {
-	Path Path `codec:"path" json:"path"`
+	Path  Path   `codec:"path" json:"path"`
+	TlfID string `codec:"tlfID" json:"tlfID"`
 }
 
 type SimpleFSFolderSyncConfigAndStatusArg struct {
@@ -1691,7 +1692,7 @@ type SimpleFSInterface interface {
 	SimpleFSGetTeamQuotaUsage(context.Context, TeamName) (SimpleFSQuotaUsage, error)
 	// simpleFSReset completely resets the KBFS folder referenced in `path`.
 	// It should only be called after explicit user confirmation.
-	SimpleFSReset(context.Context, Path) error
+	SimpleFSReset(context.Context, SimpleFSResetArg) error
 	SimpleFSFolderSyncConfigAndStatus(context.Context, Path) (FolderSyncConfigAndStatus, error)
 	SimpleFSSetFolderSyncConfig(context.Context, SimpleFSSetFolderSyncConfigArg) error
 	SimpleFSSyncConfigAndStatus(context.Context, *TLFIdentifyBehavior) (SyncConfigAndStatusRes, error)
@@ -2198,7 +2199,7 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[1]SimpleFSResetArg)(nil), args)
 						return
 					}
-					err = i.SimpleFSReset(ctx, typedArgs[0].Path)
+					err = i.SimpleFSReset(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -2654,8 +2655,7 @@ func (c SimpleFSClient) SimpleFSGetTeamQuotaUsage(ctx context.Context, teamName 
 
 // simpleFSReset completely resets the KBFS folder referenced in `path`.
 // It should only be called after explicit user confirmation.
-func (c SimpleFSClient) SimpleFSReset(ctx context.Context, path Path) (err error) {
-	__arg := SimpleFSResetArg{Path: path}
+func (c SimpleFSClient) SimpleFSReset(ctx context.Context, __arg SimpleFSResetArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReset", []interface{}{__arg}, nil)
 	return
 }

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -388,14 +388,14 @@ func (s *SimpleFSHandler) SimpleFSFolderEditHistory(
 
 // SimpleFSReset implements the SimpleFSInterface.
 func (s *SimpleFSHandler) SimpleFSReset(
-	ctx context.Context, path keybase1.Path) (err error) {
+	ctx context.Context, arg keybase1.SimpleFSResetArg) (err error) {
 	ctx, cancel := s.wrapContextWithTimeout(ctx)
 	defer cancel()
 	cli, err := s.client()
 	if err != nil {
 		return err
 	}
-	return cli.SimpleFSReset(ctx, path)
+	return cli.SimpleFSReset(ctx, arg)
 }
 
 // SimpleFSGetUserQuotaUsage implements the SimpleFSInterface.

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -473,7 +473,7 @@ protocol SimpleFS {
    simpleFSReset completely resets the KBFS folder referenced in `path`.
    It should only be called after explicit user confirmation.
    */
-  void simpleFSReset(Path path);
+  void simpleFSReset(Path path, string tlfID);
 
   enum FolderSyncMode {
     DISABLED_0,

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -1228,6 +1228,10 @@
         {
           "name": "path",
           "type": "Path"
+        },
+        {
+          "name": "tlfID",
+          "type": "string"
         }
       ],
       "response": null,


### PR DESCRIPTION
Thee have been cases where a user reset their folder long ago, but it got written into their team sigchain still, even while they continued to use the post-reset TLF ID as their folder.  Then later, they upgraded their software or something and they can no longer access the new folder, because they get the old ID from the sigchain.

To save the new data, we need to force the client to sign that TLF ID into the team sigchain, like we do in resets.  This lets us accept a TLF ID from the command line, so experts can guide someone in this situation through to overwriting the old TLF ID with the new one.

Issue: HOTPOT-685
Issue: #19133