### PR TITLE
switch relogin dropdown away from "Someone else..." after selecting

### DIFF
--- a/shared/login/relogin/dropdown.native.tsx
+++ b/shared/login/relogin/dropdown.native.tsx
@@ -64,6 +64,7 @@ class Dropdown extends React.Component<Props, State> {
       } else {
         logger.warn('otherValue selected, yet no onOther handler')
       }
+      this.setState({value: this.props.options[0] || ''})
     } else if (this.props.onClick) {
       this.props.onClick(this.state.value || '', (this.props.options || []).indexOf(this.state.value || ''))
     }


### PR DESCRIPTION
Keeps "someone else..." from showing up in the dropdown if you cancel provisioning on mobile. cc @keybase/y2ksquad 