### PR TITLE
fix typo on mobile netstate

### DIFF
--- a/go/protocol/keybase1/appstate.go
+++ b/go/protocol/keybase1/appstate.go
@@ -45,7 +45,7 @@ type MobileNetworkState int
 const (
 	MobileNetworkState_NONE         MobileNetworkState = 0
 	MobileNetworkState_WIFI         MobileNetworkState = 1
-	MobileNetworkState_CELLUAR      MobileNetworkState = 2
+	MobileNetworkState_CELLULAR     MobileNetworkState = 2
 	MobileNetworkState_UNKNOWN      MobileNetworkState = 3
 	MobileNetworkState_NOTAVAILABLE MobileNetworkState = 4
 )
@@ -55,7 +55,7 @@ func (o MobileNetworkState) DeepCopy() MobileNetworkState { return o }
 var MobileNetworkStateMap = map[string]MobileNetworkState{
 	"NONE":         0,
 	"WIFI":         1,
-	"CELLUAR":      2,
+	"CELLULAR":     2,
 	"UNKNOWN":      3,
 	"NOTAVAILABLE": 4,
 }
@@ -63,7 +63,7 @@ var MobileNetworkStateMap = map[string]MobileNetworkState{
 var MobileNetworkStateRevMap = map[MobileNetworkState]string{
 	0: "NONE",
 	1: "WIFI",
-	2: "CELLUAR",
+	2: "CELLULAR",
 	3: "UNKNOWN",
 	4: "NOTAVAILABLE",
 }

--- a/protocol/avdl/keybase1/appstate.avdl
+++ b/protocol/avdl/keybase1/appstate.avdl
@@ -11,7 +11,7 @@ protocol appState {
   enum MobileNetworkState {
     NONE_0,
     WIFI_1,
-    CELLUAR_2,
+    CELLULAR_2,
     UNKNOWN_3,
     // Default for desktop, not treated as a 'limited' connection
     NOTAVAILABLE_4

--- a/protocol/json/keybase1/appstate.json
+++ b/protocol/json/keybase1/appstate.json
@@ -18,7 +18,7 @@
       "symbols": [
         "NONE_0",
         "WIFI_1",
-        "CELLUAR_2",
+        "CELLULAR_2",
         "UNKNOWN_3",
         "NOTAVAILABLE_4"
       ]

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1669,7 +1669,7 @@ export enum MobileAppState {
 export enum MobileNetworkState {
   none = 0,
   wifi = 1,
-  celluar = 2,
+  cellular = 2,
   unknown = 3,
   notavailable = 4,
 }


### PR DESCRIPTION
noticed this in the log:
```
2019-08-29T01:15:04.107635Z ▶ [DEBU keybase appstate.go:41] 53a54 UpdateMobileNetState(cellular)
2019-08-29T01:15:04.107680Z ▶ [DEBU keybase appstate.go:138] 53a55 + MobileNetState.Update(UNKNOWN)
2019-08-29T01:15:04.107699Z ▶ [DEBU keybase appstate.go:142] 53a56 MobileNetState.Update: useful update: UNKNOWN, we are currently in state: WIFI
2019-08-29T01:15:04.107717Z ▶ [DEBU keybase appstate.go:57] 53a57 - MobileNetState.Update(UNKNOWN) -> ok
```

none of our current checks are broken but fixes any future checks tath explicitly look for `cellular` 
