### PR TITLE
Modal title centering desktop / mobile

### DIFF
--- a/shared/common-adapters/modal/index.stories.tsx
+++ b/shared/common-adapters/modal/index.stories.tsx
@@ -159,6 +159,23 @@ const load = () => {
         {filler}
       </Modal>
     ))
+    .add('Long title, small sides', () => (
+      <Modal
+        onClose={onClose}
+        header={{
+          leftButton: <Kb.Icon type="iconfont-add" />,
+          rightButton: (
+            <Kb.Box2 direction="horizontal" gap="tiny">
+              <Kb.Icon type="iconfont-file" />
+              <Kb.Icon type="iconfont-info" />
+            </Kb.Box2>
+          ),
+          title: 'Do one of a few possibilities for things',
+        }}
+      >
+        {filler}
+      </Modal>
+    ))
 }
 
 const generateColorFromSeed = s => `rgba(${s * 4}, ${s * 4}, ${s * 4}, 0.7)`

--- a/shared/common-adapters/modal/index.tsx
+++ b/shared/common-adapters/modal/index.tsx
@@ -156,15 +156,13 @@ const styles = Styles.styleSheetCreate(() => {
       borderWidth: 0,
     },
     headerLeft: {
-      flexGrow: 0,
-      flexShrink: 0,
+      flex: 1,
       justifyContent: 'flex-start',
       paddingLeft: Styles.globalMargins.xsmall,
       paddingRight: Styles.globalMargins.xsmall,
     },
     headerRight: {
-      flexGrow: 0,
-      flexShrink: 0,
+      flex: 1,
       justifyContent: 'flex-end',
       paddingLeft: Styles.globalMargins.xsmall,
       paddingRight: Styles.globalMargins.xsmall,

--- a/shared/common-adapters/modal/index.tsx
+++ b/shared/common-adapters/modal/index.tsx
@@ -158,7 +158,7 @@ const Footer = (props: FooterProps & {wide: boolean}) => (
     fullWidth={true}
     style={Styles.collapseStyles([
       styles.footer,
-      props.wide && styles.footerWide,
+      props.wide && !Styles.isMobile && styles.footerWide,
       !props.hideBorder && styles.footerBorder,
       props.style,
     ])}

--- a/shared/settings/account/add-modals.tsx
+++ b/shared/settings/account/add-modals.tsx
@@ -52,7 +52,11 @@ export const Email = () => {
     <Kb.Modal
       onClose={onClose}
       header={{
-        leftButton: Styles.isMobile ? <Kb.Icon type="iconfont-arrow-left" onClick={onClose} /> : null,
+        leftButton: Styles.isMobile ? (
+          <Kb.Text type="BodySemiboldLink" onClick={onClose}>
+            Close
+          </Kb.Text>
+        ) : null,
         title: Styles.isMobile ? 'Add email address' : 'Add an email address',
       }}
       footer={{
@@ -143,7 +147,11 @@ export const Phone = () => {
     <Kb.Modal
       onClose={onClose}
       header={{
-        leftButton: Styles.isMobile ? <Kb.Icon type="iconfont-arrow-left" onClick={onClose} /> : null,
+        leftButton: Styles.isMobile ? (
+          <Kb.Text type="BodySemiboldLink" onClick={onClose}>
+            Close
+          </Kb.Text>
+        ) : null,
         title: Styles.isMobile ? 'Add phone number' : 'Add a phone number',
       }}
       footer={{


### PR DESCRIPTION
- Fix centering title on desktop by making both sides have `flex: 1` again.
- Fix centering title on mobile by making it smart
  - Our desktop trick doesn't work
  - Defer rendering `title`
  - Measure which of `leftButton` and `rightButton` is wider; store in state
  - Once we've measured, set that as the `width` on both sides and make them inflexible
  - Now render title with `flex: 1` in the center
- Make back icon say "Close" on mobile add phone/email (we couldn't before because of this)

cc @jakob223 here's some native measurement code
@mmaxim the desktop fix we talked about