### PR TITLE
Don't emit initial intents.

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -245,6 +245,27 @@ public class MainActivity extends ReactFragmentActivity {
           if (bundleFromNotification != null) {
             engine.setInitialIntent(Arguments.fromBundle(bundleFromNotification));
           }
+
+          assert emitter != null;
+          // If there are any other bundle sources we care about, emit them here
+          if (bundleFromNotification != null) {
+            emitter.emit("initialIntentFromNotification", Arguments.fromBundle(bundleFromNotification));
+          }
+
+          if (!finalFromShareText.isEmpty()) {
+            WritableMap args = Arguments.createMap();
+            args.putString("text", finalFromShareText);
+            emitter.emit("onShareText", args);
+          }
+
+          if (uri != null) {
+            String filePath = readFileFromUri(getReactContext(), uri);
+            if (filePath != null) {
+              WritableMap args = Arguments.createMap();
+              args.putString("localPath", filePath);
+              emitter.emit("onShareData", args);
+            }
+          }
         }
       }
 

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -215,15 +215,18 @@ public class MainActivity extends ReactFragmentActivity {
       // Here we are just reading from the notification bundle.
       // If other sources start the app, we can get their intent data the same way.
       Bundle bundleFromNotification = intent.getBundleExtra("notification");
+      intent.removeExtra("notification");
 
       // TODO this doesn't work and didn't work before
       String fromShareText = intent.getStringExtra(Intent.EXTRA_TEXT);
+      intent.removeExtra(Intent.EXTRA_TEXT);
       if (fromShareText == null) {
         fromShareText = "";
       }
       String finalFromShareText = fromShareText;
 
       Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+      intent.removeExtra(Intent.EXTRA_STREAM);
 
       // If there isn't any data we care about, let's just return
       if (bundleFromNotification == null && fromShareText.isEmpty() && uri == null) {

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -245,27 +245,6 @@ public class MainActivity extends ReactFragmentActivity {
           if (bundleFromNotification != null) {
             engine.setInitialIntent(Arguments.fromBundle(bundleFromNotification));
           }
-
-          assert emitter != null;
-          // If there are any other bundle sources we care about, emit them here
-          if (bundleFromNotification != null) {
-            emitter.emit("initialIntentFromNotification", Arguments.fromBundle(bundleFromNotification));
-          }
-
-          if (!finalFromShareText.isEmpty()) {
-            WritableMap args = Arguments.createMap();
-            args.putString("text", finalFromShareText);
-            emitter.emit("onShareText", args);
-          }
-
-          if (uri != null) {
-            String filePath = readFileFromUri(getReactContext(), uri);
-            if (filePath != null) {
-              WritableMap args = Arguments.createMap();
-              args.putString("localPath", filePath);
-              emitter.emit("onShareData", args);
-            }
-          }
         }
       }
 


### PR DESCRIPTION
This clears the intent data so we don't end up using stale intent data.
@keybase/react-hackers 