### PR TITLE
include padding when autoresizing multiline inputs

### DIFF
--- a/shared/chat/conversation/attachment-get-titles/index.tsx
+++ b/shared/chat/conversation/attachment-get-titles/index.tsx
@@ -115,6 +115,7 @@ class GetTitles extends React.Component<Props, State> {
                 placeholder={titleHint}
                 multiline={true}
                 rowsMin={2}
+                padding="tiny"
                 value={info.title}
                 onEnterKeyDown={this._onNext}
                 onChangeText={this._updateTitle}
@@ -204,10 +205,10 @@ const styles = Styles.styleSheetCreate({
       borderWidth: 1,
       marginBottom: Styles.globalMargins.tiny,
       // RN wasn't obeying `padding: Styles.globalMargins.tiny`.
-      paddingBottom: Styles.globalMargins.tiny,
-      paddingLeft: Styles.globalMargins.tiny,
-      paddingRight: Styles.globalMargins.tiny,
-      paddingTop: Styles.globalMargins.tiny,
+      // paddingBottom: Styles.globalMargins.tiny,
+      // paddingLeft: Styles.globalMargins.tiny,
+      // paddingRight: Styles.globalMargins.tiny,
+      // paddingTop: Styles.globalMargins.tiny,
       width: '100%',
     },
     isElectron: {maxHeight: 100},

--- a/shared/chat/conversation/attachment-get-titles/index.tsx
+++ b/shared/chat/conversation/attachment-get-titles/index.tsx
@@ -204,11 +204,6 @@ const styles = Styles.styleSheetCreate({
       borderRadius: Styles.borderRadius,
       borderWidth: 1,
       marginBottom: Styles.globalMargins.tiny,
-      // RN wasn't obeying `padding: Styles.globalMargins.tiny`.
-      // paddingBottom: Styles.globalMargins.tiny,
-      // paddingLeft: Styles.globalMargins.tiny,
-      // paddingRight: Styles.globalMargins.tiny,
-      // paddingTop: Styles.globalMargins.tiny,
       width: '100%',
     },
     isElectron: {maxHeight: 100},

--- a/shared/common-adapters/plain-input.d.ts
+++ b/shared/common-adapters/plain-input.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StylesCrossPlatform} from '../styles'
+import {StylesCrossPlatform, globalMargins} from '../styles'
 import {TextType} from './text'
 
 export type KeyboardType =
@@ -72,6 +72,7 @@ export type Props = {
   onBlur?: () => void
   onChangeText?: (text: string) => void
   onFocus?: () => void
+  padding?: keyof typeof globalMargins
   placeholder?: string
   placeholderColor?: string
   rowsMin?: number

--- a/shared/common-adapters/plain-input.d.ts
+++ b/shared/common-adapters/plain-input.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StylesCrossPlatform, globalMargins} from '../styles'
+import {StylesCrossPlatform, globalMargins, StylesCrossPlatformWithSomeDisallowed} from '../styles'
 import {TextType} from './text'
 
 export type KeyboardType =
@@ -55,6 +55,12 @@ export type Selection = {
   end: number | null
 }
 
+export type DisallowedStyles = {
+  padding?: never
+}
+
+export type InputStyle = StylesCrossPlatformWithSomeDisallowed<DisallowedStyles>
+
 export type Props = {
   autoFocus?: boolean
   // Enable if you want this to always have focus (desktop only)
@@ -72,12 +78,12 @@ export type Props = {
   onBlur?: () => void
   onChangeText?: (text: string) => void
   onFocus?: () => void
-  padding?: keyof typeof globalMargins
+  padding?: keyof typeof globalMargins | 0 // globalMargins does not have an option for 0
   placeholder?: string
   placeholderColor?: string
   rowsMin?: number
   rowsMax?: number
-  style?: StylesCrossPlatform
+  style?: InputStyle
   textType?: TextType
   type?: 'password' | 'text'
   value?: string // Makes this a controlled input when passed. Also disables mutating value via `transformText`, see note at component API,

--- a/shared/common-adapters/plain-input.desktop.tsx
+++ b/shared/common-adapters/plain-input.desktop.tsx
@@ -48,10 +48,22 @@ class PlainInput extends React.PureComponent<InternalProps> {
       // no resizing height on single-line inputs
       return
     }
+
     const n = this._input
     if (!n) {
       return
     }
+
+    const computedStyle = getComputedStyle(n)
+    const paddingTop = maybeParseInt(computedStyle.paddingTop || 0, 10)
+    const paddingBottom = maybeParseInt(computedStyle.paddingBottom || 0, 10)
+
+    if (n.scrollHeight < maybeParseInt(n.style.minHeight || 0, 10) + paddingBottom + paddingTop) {
+      // don't resize if the scrollheight is smaller than rowsMin
+      // padding needs to be accounted for here because the getMultilineProps logic doesn't include padding
+      return
+    }
+
     n.style.height = '1px'
     n.style.height = `${n.scrollHeight}px`
   }
@@ -176,7 +188,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
     const rows = this.props.rowsMin || Math.min(2, this.props.rowsMax || 2)
     const textStyle: any = getTextStyle(this.props.textType)
     const heightStyles: any = {
-      minHeight: rows * (textStyle.fontSize || 20),
+      minHeight: rows * (maybeParseInt(textStyle.lineHeight, 10) || 20),
     }
     if (this.props.rowsMax) {
       heightStyles.maxHeight = this.props.rowsMax * (maybeParseInt(textStyle.lineHeight, 10) || 20)

--- a/shared/common-adapters/plain-input.desktop.tsx
+++ b/shared/common-adapters/plain-input.desktop.tsx
@@ -48,19 +48,8 @@ class PlainInput extends React.PureComponent<InternalProps> {
       // no resizing height on single-line inputs
       return
     }
-
     const n = this._input
     if (!n) {
-      return
-    }
-
-    const computedStyle = getComputedStyle(n)
-    const paddingTop = maybeParseInt(computedStyle.paddingTop || 0, 10)
-    const paddingBottom = maybeParseInt(computedStyle.paddingBottom || 0, 10)
-
-    if (n.scrollHeight < maybeParseInt(n.style.minHeight || 0, 10) + paddingBottom + paddingTop) {
-      // don't resize if the scrollheight is smaller than rowsMin
-      // padding needs to be accounted for here because the getMultilineProps logic doesn't include padding
       return
     }
 
@@ -188,13 +177,19 @@ class PlainInput extends React.PureComponent<InternalProps> {
     const rows = this.props.rowsMin || Math.min(2, this.props.rowsMax || 2)
     const textStyle: any = getTextStyle(this.props.textType)
     const heightStyles: any = {
-      minHeight: rows * (maybeParseInt(textStyle.lineHeight, 10) || 20),
+      minHeight:
+        rows * (maybeParseInt(textStyle.lineHeight, 10) || 20) +
+        (this.props.padding ? Styles.globalMargins[this.props.padding] * 2 : 0),
     }
     if (this.props.rowsMax) {
       heightStyles.maxHeight = this.props.rowsMax * (maybeParseInt(textStyle.lineHeight, 10) || 20)
     } else {
       heightStyles.overflowY = 'hidden'
     }
+
+    const paddingStyles: any = this.props.padding
+      ? Styles.padding(Styles.globalMargins[this.props.padding])
+      : {}
     return {
       ...this._getCommonProps(),
       rows,
@@ -203,6 +198,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
         textStyle,
         styles.multiline,
         heightStyles,
+        paddingStyles,
         this.props.style,
       ]),
     }

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -2,7 +2,14 @@ import React, {Component} from 'react'
 import {TextInput} from 'react-native'
 import {getStyle as getTextStyle} from './text'
 import {NativeTextInput} from './native-wrappers.native'
-import {collapseStyles, globalColors, platformStyles, styleSheetCreate} from '../styles'
+import {
+  collapseStyles,
+  globalColors,
+  platformStyles,
+  styleSheetCreate,
+  padding,
+  globalMargins,
+} from '../styles'
 import {isIOS} from '../constants/platform'
 import {checkTextInfo} from './input.shared'
 import {pick} from 'lodash-es'
@@ -186,6 +193,7 @@ class PlainInput extends Component<InternalProps, State> {
   _getMultilineStyle = () => {
     const defaultRowsToShow = Math.min(2, this.props.rowsMax || 2)
     const lineHeight = this._lineHeight()
+    const paddingStyles: any = this.props.padding ? padding(globalMargins[this.props.padding]) : {}
     return collapseStyles([
       styles.multiline,
       {
@@ -193,6 +201,7 @@ class PlainInput extends Component<InternalProps, State> {
       },
       !!this.props.rowsMax && {maxHeight: this.props.rowsMax * lineHeight},
       isIOS && !!this.state.height && {height: this.state.height},
+      paddingStyles,
     ])
   }
 
@@ -260,9 +269,6 @@ const styles = styleSheetCreate(() => ({
   multiline: platformStyles({
     isMobile: {
       height: undefined,
-      // TODO: Maybe remove these paddings?
-      paddingBottom: 0,
-      paddingTop: 0,
       textAlignVertical: 'top', // android centers by default
     },
   }),

--- a/shared/wallets/send-form/note-and-memo/index.tsx
+++ b/shared/wallets/send-form/note-and-memo/index.tsx
@@ -168,6 +168,7 @@ class PublicMemo extends React.Component<PublicMemoProps, PublicMemoState> {
         <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
           <Kb.PlainInput
             multiline={true}
+            padding={0}
             placeholder="Add a public memo (on Stellar)"
             placeholderColor={placeholderColor}
             style={styles.input}
@@ -223,7 +224,6 @@ const styles = Styles.styleSheetCreate(() => ({
   input: {
     backgroundColor: Styles.globalColors.white,
     color: Styles.globalColors.black_on_white,
-    padding: 0,
   },
 }))
 


### PR DESCRIPTION
Fixes an issue where the attachment caption text box would shrink to one line after typing in it due to its `minHeight` being less than `rowsMin` + padding. 

@keybase/react-hackers 
@keybase/hotpotatosquad 