### PR TITLE
Add 'addtochannel' chat api method

### DIFF
--- a/go/client/chat_api_doc.go
+++ b/go/client/chat_api_doc.go
@@ -85,6 +85,9 @@ Join a team conversation:
 Leave a team conversation:
     {"method": "leave", "params": {"options": {"channel": {"name": "treehouse", "members_type": "team", "topic_name": "random"}}}}
 
+Add one or more users to a team conversation:
+    {"method": "addtochannel", "params": {"options": {"channel": {"name": "treehouse", "members_type": "team", "topic_name": "random"}, "usernames": ["alice", "bob", "charlie"]}}}
+
 Load a flip's result:
     {"method": "loadflip", "params": {"options": {"conversation_id": "...", "flip_conversation_id": "...", "msg_id": 72, "game_id": "..."}}}
 

--- a/go/client/chat_api_test.go
+++ b/go/client/chat_api_test.go
@@ -33,6 +33,7 @@ type handlerTracker struct {
 	listConvsOnNameV1   int
 	joinV1              int
 	leaveV1             int
+	addToChannelV1      int
 	loadFlipV1          int
 	getUnfurlSettingsV1 int
 	setUnfurlSettingsV1 int
@@ -123,6 +124,11 @@ func (h *handlerTracker) JoinV1(context.Context, Call, io.Writer) error {
 
 func (h *handlerTracker) LeaveV1(context.Context, Call, io.Writer) error {
 	h.leaveV1++
+	return nil
+}
+
+func (h *handlerTracker) AddToChannelV1(context.Context, Call, io.Writer) error {
+	h.addToChannelV1++
 	return nil
 }
 
@@ -233,6 +239,10 @@ func (c *chatEcho) LeaveV1(context.Context, leaveOptionsV1) Reply {
 	return Reply{Result: echoOK}
 }
 
+func (c *chatEcho) AddToChannelV1(context.Context, addToChannelOptionsV1) Reply {
+	return Reply{Result: echoOK}
+}
+
 func (c *chatEcho) LoadFlipV1(context.Context, loadFlipOptionsV1) Reply {
 	return Reply{Result: echoOK}
 }
@@ -272,6 +282,7 @@ type topTest struct {
 	searchRegexpV1    int
 	joinV1            int
 	leaveV1           int
+	addToChannelV1    int
 	listConvsOnNameV1 int
 }
 
@@ -360,6 +371,9 @@ func TestChatAPIVersionHandlerTop(t *testing.T) {
 		}
 		if h.leaveV1 != test.leaveV1 {
 			t.Errorf("test %d: input %s => leaveV1 = %d, expected %d", i, test.input, h.leaveV1, test.leaveV1)
+		}
+		if h.addToChannelV1 != test.addToChannelV1 {
+			t.Errorf("test %d: input %s => addToChannelV1 = %d, expected %d", i, test.input, h.addToChannelV1, test.addToChannelV1)
 		}
 		if h.listConvsOnNameV1 != test.listConvsOnNameV1 {
 			t.Errorf("test %d: input %s => listConvsOnNameV1 = %d, expected %d",

--- a/go/client/chat_api_version_handler.go
+++ b/go/client/chat_api_version_handler.go
@@ -64,6 +64,8 @@ func (d *ChatAPIVersionHandler) handleV1(ctx context.Context, c Call, w io.Write
 		return d.handler.JoinV1(ctx, c, w)
 	case methodLeave:
 		return d.handler.LeaveV1(ctx, c, w)
+	case methodAddToChannel:
+		return d.handler.AddToChannelV1(ctx, c, w)
 	case methodLoadFlip:
 		return d.handler.LoadFlipV1(ctx, c, w)
 	case methodGetUnfurlSettings:

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -37,6 +37,7 @@ type ChatServiceHandler interface {
 	ListConvsOnNameV1(context.Context, listConvsOnNameOptionsV1) Reply
 	JoinV1(context.Context, joinOptionsV1) Reply
 	LeaveV1(context.Context, leaveOptionsV1) Reply
+	AddToChannelV1(context.Context, addToChannelOptionsV1) Reply
 	LoadFlipV1(context.Context, loadFlipOptionsV1) Reply
 	GetUnfurlSettingsV1(context.Context) Reply
 	SetUnfurlSettingsV1(context.Context, setUnfurlSettingsOptionsV1) Reply
@@ -193,6 +194,25 @@ func (c *chatServiceHandler) LeaveV1(ctx context.Context, opts leaveOptionsV1) R
 		RateLimits: c.aggRateLimits(allLimits),
 	}
 	return Reply{Result: cres}
+}
+
+func (c *chatServiceHandler) AddToChannelV1(ctx context.Context, opts addToChannelOptionsV1) Reply {
+	client, err := GetChatLocalClient(c.G())
+	if err != nil {
+		return c.errReply(err)
+	}
+	convID, _, err := c.resolveAPIConvID(ctx, opts.ConversationID, opts.Channel)
+	if err != nil {
+		return c.errReply(err)
+	}
+	err = client.BulkAddToConv(ctx, chat1.BulkAddToConvArg{
+		Usernames: opts.Usernames,
+		ConvID:    convID,
+	})
+	if err != nil {
+		return c.errReply(err)
+	}
+	return Reply{Result: true}
 }
 
 func (c *chatServiceHandler) LoadFlipV1(ctx context.Context, opts loadFlipOptionsV1) Reply {


### PR DESCRIPTION
Kind of an extension of #18877

Adds a new chat api method that allows for adding users to a channel for a given team:
```
{"method": "addtochannel", "params": {"options": {"channel": {"name": "treehouse", "members_type": "team", "topic_name": "random"}, "usernames": ["alice", "bob", "charlie"]}}}
```