### PR TITLE
fix end to end flash on loading convo

### DIFF
--- a/shared/chat/conversation/messages/special-top-message.tsx
+++ b/shared/chat/conversation/messages/special-top-message.tsx
@@ -127,9 +127,10 @@ export default Container.namedConnect(
         pendingState = 'done'
         break
     }
-    const loadMoreType = state.chat2.moreToLoadMap.get(ownProps.conversationIDKey)
-      ? ('moreToLoad' as const)
-      : ('noMoreToLoad' as const)
+    const loadMoreType =
+      state.chat2.moreToLoadMap.get(ownProps.conversationIDKey) !== false
+        ? ('moreToLoad' as const)
+        : ('noMoreToLoad' as const)
     const showTeamOffer =
       hasLoadedEver &&
       loadMoreType === 'noMoreToLoad' &&


### PR DESCRIPTION
when a convo loads the 'do we need to load more' info isn't bookkept and this code (ancient) assumed that meant not, but really we want to assume yes. This makes seeing the blue card not happen

cc: @mmaxim @cecileboucheron 