### PR TITLE
Some small protocol changes

### DIFF
--- a/go/protocol/chat1/api.go
+++ b/go/protocol/chat1/api.go
@@ -25,10 +25,12 @@ func (o RateLimitRes) DeepCopy() RateLimitRes {
 	}
 }
 
+// A Keybase chat channel. This can be a channel in a team, or just an informal channel between two users.
+// name: the name of the team or comma-separated list of participants
 type ChatChannel struct {
 	Name        string `codec:"name" json:"name"`
-	Public      bool   `codec:"public" json:"public"`
-	MembersType string `codec:"membersType" json:"members_type"`
+	Public      bool   `codec:"public,omitempty" json:"public,omitempty"`
+	MembersType string `codec:"membersType,omitempty" json:"members_type,omitempty"`
 	TopicType   string `codec:"topicType,omitempty" json:"topic_type,omitempty"`
 	TopicName   string `codec:"topicName,omitempty" json:"topic_name,omitempty"`
 }
@@ -43,6 +45,7 @@ func (o ChatChannel) DeepCopy() ChatChannel {
 	}
 }
 
+// A chat message. The content goes in the `body` property!
 type ChatMessage struct {
 	Body string `codec:"body" json:"body"`
 }
@@ -383,6 +386,7 @@ func (o Thread) DeepCopy() Thread {
 	}
 }
 
+// A chat conversation. This is essentially a chat channel plus some additional metadata.
 type ConvSummary struct {
 	Id           string                    `codec:"id" json:"id"`
 	Channel      ChatChannel               `codec:"channel" json:"channel"`

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -583,11 +583,11 @@ func (e ConversationMemberStatus) String() string {
 }
 
 type Pagination struct {
-	Next           []byte `codec:"next" json:"next"`
-	Previous       []byte `codec:"previous" json:"previous"`
+	Next           []byte `codec:"next,omitempty" json:"next,omitempty"`
+	Previous       []byte `codec:"previous,omitempty" json:"previous,omitempty"`
 	Num            int    `codec:"num" json:"num"`
-	Last           bool   `codec:"last" json:"last"`
-	ForceFirstPage bool   `codec:"forceFirstPage" json:"forceFirstPage"`
+	Last           bool   `codec:"last,omitempty" json:"last,omitempty"`
+	ForceFirstPage bool   `codec:"forceFirstPage,omitempty" json:"forceFirstPage,omitempty"`
 }
 
 func (o Pagination) DeepCopy() Pagination {

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/constants.avdl
 
 package keybase1

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -1,4 +1,4 @@
-// Auto-generated to Go types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/constants.avdl
 
 package keybase1

--- a/protocol/avdl/chat1/api.avdl
+++ b/protocol/avdl/chat1/api.avdl
@@ -15,13 +15,18 @@ protocol api {
     int gas;
   }
 
-  // Channel represents a channel through which chat happens.
+  /**
+   A Keybase chat channel. This can be a channel in a team, or just an informal channel between two users.
+   name: the name of the team or comma-separated list of participants
+   */
   record ChatChannel {
     @jsonkey("name")
     string name;
     @jsonkey("public")
+    @optional(true)
     boolean public;
     @jsonkey("members_type")
+    @optional(true)
     string membersType;
     @jsonkey("topic_type")
     @optional(true)
@@ -31,6 +36,10 @@ protocol api {
     string topicName;
   }
 
+
+  /**
+   A chat message. The content goes in the `body` property!
+   */
   record ChatMessage {
     @jsonkey("body")
     string body;
@@ -179,7 +188,9 @@ protocol api {
     array<RateLimitRes> rateLimits;
   }
 
-  // ConvSummary is used for JSON output of a conversation in the inbox.
+  /**
+   A chat conversation. This is essentially a chat channel plus some additional metadata.
+   */
   record ConvSummary {
     @jsonkey("id")
     string id;

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -163,10 +163,14 @@
   }
 
   record Pagination {
+    @optional(true)
     bytes next;
+    @optional(true)
     bytes previous;
     int num; // Number of items requested when argument, and number returned when result
+    @optional(true)
     boolean last; // Will be true if the number of results is less than requested
+    @optional(true)
     boolean forceFirstPage; // Let downstream consumers of this Pagination know this is an initial request
   }
 

--- a/protocol/json/chat1/api.json
+++ b/protocol/json/chat1/api.json
@@ -63,12 +63,14 @@
         {
           "type": "boolean",
           "name": "public",
-          "jsonkey": "public"
+          "jsonkey": "public",
+          "optional": true
         },
         {
           "type": "string",
           "name": "membersType",
-          "jsonkey": "members_type"
+          "jsonkey": "members_type",
+          "optional": true
         },
         {
           "type": "string",
@@ -82,7 +84,8 @@
           "jsonkey": "topic_name",
           "optional": true
         }
-      ]
+      ],
+      "doc": "A Keybase chat channel. This can be a channel in a team, or just an informal channel between two users.\n   name: the name of the team or comma-separated list of participants"
     },
     {
       "type": "record",
@@ -93,7 +96,8 @@
           "name": "body",
           "jsonkey": "body"
         }
-      ]
+      ],
+      "doc": "A chat message. The content goes in the `body` property!"
     },
     {
       "type": "record",
@@ -546,7 +550,8 @@
           "jsonkey": "error",
           "optional": true
         }
-      ]
+      ],
+      "doc": "A chat conversation. This is essentially a chat channel plus some additional metadata."
     },
     {
       "type": "record",

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -331,11 +331,13 @@
       "fields": [
         {
           "type": "bytes",
-          "name": "next"
+          "name": "next",
+          "optional": true
         },
         {
           "type": "bytes",
-          "name": "previous"
+          "name": "previous",
+          "optional": true
         },
         {
           "type": "int",
@@ -343,11 +345,13 @@
         },
         {
           "type": "boolean",
-          "name": "last"
+          "name": "last",
+          "optional": true
         },
         {
           "type": "boolean",
-          "name": "forceFirstPage"
+          "name": "forceFirstPage",
+          "optional": true
         }
       ]
     },


### PR DESCRIPTION
Does two things:
1. Moves some description comments from the TypeScript bot library into the avdl in anticipation for generated bot type support.
2. Marks some fields optional in the `Pagination` and `ChatChannel` types. These fields aren't necessary when the types are used as input.