### PR TITLE
go back to inbox on bad chat team loads

### DIFF
--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -240,6 +240,7 @@ type _InboxRefreshPayload = {
     | 'joinedAConversation'
     | 'leftAConversation'
     | 'teamTypeChanged'
+    | 'maybeKickedFromTeam'
 }
 type _InboxSearchMoveSelectedIndexPayload = {readonly increment: boolean}
 type _InboxSearchNameResultsPayload = {

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -100,7 +100,8 @@
         "'inboxSyncedUnknown'",
         "'joinedAConversation'",
         "'leftAConversation'",
-        "'teamTypeChanged'"
+        "'teamTypeChanged'",
+        "'maybeKickedFromTeam'"
       ]
     },
     // We want to unbox an inbox row


### PR DESCRIPTION
Alice is desktop , bob is phone, T is team
1. Bob adds Alice to T
1. Alice goes offline
1. Bob removes Alice from T
1. Alice comes back online

Before:
Several black bars about not being in the team
After:
Inbox refreshes and that team should no longer be listed