### PR TITLE
provision view dark mode

### DIFF
--- a/shared/common-adapters/text.css
+++ b/shared/common-adapters/text.css
@@ -482,7 +482,7 @@
   font-family: Source Code Pro;
 }
 .darkMode .text_Terminal {
-  color: #f00;
+  color: #4c8eff;
 }
 
 .text_TerminalComment {

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -353,7 +353,7 @@ body {
   background: #191919;
 }
 .darkMode .emoji-mart-search input {
-  background-color: #000;
+  background-color: #191919;
   border: 1px solid #101010;
   color: rgba(255, 255, 255, 0.85);
 }

--- a/shared/provision/code-page/index.tsx
+++ b/shared/provision/code-page/index.tsx
@@ -318,7 +318,7 @@ const Instructions = (p: Props) => (
   </Kb.Box2>
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   backButton: Styles.platformStyles({
     isElectron: {
       marginLeft: Styles.globalMargins.medium,
@@ -521,5 +521,5 @@ const styles = Styles.styleSheetCreate({
       paddingTop: 20,
     },
   }),
-})
+}))
 export default CodePage2

--- a/shared/provision/code-page/qr-scan/index.desktop.tsx
+++ b/shared/provision/code-page/qr-scan/index.desktop.tsx
@@ -11,7 +11,7 @@ const QRScan = (props: Props) => (
   </Box2>
 )
 
-const styles = styleSheetCreate({
+const styles = styleSheetCreate(() => ({
   container: {
     alignSelf: 'stretch',
     backgroundColor: globalColors.black,
@@ -22,6 +22,6 @@ const styles = styleSheetCreate({
   waiting: {
     alignSelf: 'center',
   },
-})
+}))
 
 export default QRScan

--- a/shared/provision/code-page/qr-scan/index.native.tsx
+++ b/shared/provision/code-page/qr-scan/index.native.tsx
@@ -17,7 +17,7 @@ const QRScan = (props: Props) => (
   </Kb.Box2>
 )
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   camera: {
     flexGrow: 1,
   },
@@ -31,6 +31,6 @@ const styles = Styles.styleSheetCreate({
   waiting: {
     ...Styles.globalStyles.fillAbsolute,
   },
-})
+}))
 
 export default QRScan

--- a/shared/provision/error/index.tsx
+++ b/shared/provision/error/index.tsx
@@ -243,7 +243,7 @@ const Render = ({error, onBack, onAccountReset, onPasswordReset, onKBHome}: Prop
   }
 }
 
-const styles = styleSheetCreate({
+const styles = styleSheetCreate(() => ({
   container: {
     maxWidth: 550,
   },
@@ -258,6 +258,6 @@ const styles = styleSheetCreate({
     ...globalStyles.flexBoxColumn,
     maxWidth: 460,
   },
-})
+}))
 
 export default Render

--- a/shared/provision/forgot-username/index.tsx
+++ b/shared/provision/forgot-username/index.tsx
@@ -49,7 +49,7 @@ class ForgotUsername extends React.Component<Props, State> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   button: Styles.platformStyles({
     common: {
       alignSelf: 'center',
@@ -88,6 +88,6 @@ const styles = Styles.styleSheetCreate({
   outerStyle: {
     backgroundColor: Styles.globalColors.white,
   },
-})
+}))
 
 export default ForgotUsername

--- a/shared/provision/gpg-sign/index.desktop.tsx
+++ b/shared/provision/gpg-sign/index.desktop.tsx
@@ -1,7 +1,7 @@
 // TODO remove Container
 import Container from '../../login/forms/container'
 import * as React from 'react'
-import Row, {RowCSS} from './row.desktop'
+import Row from './row.desktop'
 import {Text, Box2} from '../../common-adapters'
 
 import {Props} from '.'
@@ -10,7 +10,6 @@ class GPGSign extends React.Component<Props> {
   render() {
     return (
       <Container style={styles.container} onBack={() => this.props.onBack()}>
-        <RowCSS />
         {this.props.importError && (
           <Box2 direction="vertical" centerChildren={true}>
             <Text type="Header" style={styles.header}>

--- a/shared/provision/gpg-sign/row.css
+++ b/shared/provision/gpg-sign/row.css
@@ -1,0 +1,22 @@
+.register-row {
+  background-color: #ffffff;
+}
+.darkMode .register-row {
+  background-color: #191919;
+}
+
+.register-row:hover {
+  background-color: #ebf2fc; /* blueLighter2 */
+}
+
+.darkMode .register-row:hover {
+  background-color: rgba(24, 45, 110, 0.5); /* blueLighter2 */
+}
+
+.register-row:hover .register-background {
+  opacity: 0;
+}
+
+.register-row:hover .register-icon {
+  transform: translateX(15px);
+}

--- a/shared/provision/gpg-sign/row.desktop.tsx
+++ b/shared/provision/gpg-sign/row.desktop.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
-import {globalStyles, globalColors, transition, desktopStyles} from '../../styles'
+import * as Styles from '../../styles'
+
+import './row.css'
 
 type Props = {
   onClick: () => void
@@ -11,34 +13,25 @@ type Props = {
   children?: any
 }
 
-const realCSS = `
-  .register-row { background-color: ${globalColors.white}; }
-  .register-row:hover { background-color: ${globalColors.blueLighter2}; }
-
-  .register-row .register-background {  }
-  .register-row:hover .register-background { opacity: 0 }
-
-  .register-row:hover .register-icon { transform: translateX(15px)}
-
-`
-
-const RowCSS = () => <style>{realCSS}</style>
-
 const Row = ({onClick, icon, title, subTitle, children, style}: Props) => {
   return (
-    <div className="register-row" style={{...stylesRowContainer, ...style}} onClick={onClick}>
-      <div style={stylesIconContainer}>
-        <div className="register-background" style={stylesIconBackground} />
+    <div
+      className="register-row"
+      style={Styles.collapseStyles([Styles.desktopStyles.clickable, styles.rowContainer, style])}
+      onClick={onClick}
+    >
+      <div style={styles.iconContainer}>
+        <div className="register-background" style={styles.iconBackground} />
         <Kb.Icon
           className="register-icon"
           type={icon}
-          style={stylesIcon}
-          color={globalColors.black}
+          style={styles.icon}
+          color={Styles.globalColors.black}
           fontSize={35}
         />
       </div>
       <div>
-        <Kb.Text type="Header" style={stylesHeader}>
+        <Kb.Text type="Header" style={styles.header}>
           {title}
         </Kb.Text>
         <Kb.Text type="BodySmall">{subTitle}</Kb.Text>
@@ -48,48 +41,48 @@ const Row = ({onClick, icon, title, subTitle, children, style}: Props) => {
   )
 }
 
-const stylesRowContainer = {
-  ...globalStyles.flexBoxRow,
-  ...desktopStyles.clickable,
-  alignItems: 'center',
-  maxHeight: 100,
-  minHeight: 100,
-  padding: 20,
-  transition: 'background 0.1s ease-out',
-} as any
-const stylesHeader = {
-  color: globalColors.blueDark,
-}
-const stylesIconContainer = {
-  ...globalStyles.flexBoxRow,
-  alignItems: 'center',
-  justifyContent: 'center',
-  marginRight: 25,
-  maxHeight: 80,
-  maxWidth: 80,
-  minHeight: 80,
-  minWidth: 80,
-  position: 'relative' as const,
-}
-const stylesIcon = {
-  ...transition('transform'),
-  height: 'inherit',
-  textAlign: 'center',
-  width: 'inherit',
-  zIndex: 1,
-} as const
-const stylesIconBackground = {
-  ...transition('opacity'),
-  backgroundColor: globalColors.greyLight,
-  borderRadius: 40,
-  left: 0,
-  maxHeight: 80,
-  maxWidth: 80,
-  minHeight: 80,
-  minWidth: 80,
-  position: 'absolute' as const,
-  top: 0,
-}
+const styles = Styles.styleSheetCreate(() => ({
+  header: {
+    color: Styles.globalColors.blueDark,
+  },
+  icon: {
+    ...Styles.transition('transform'),
+    height: 'inherit',
+    textAlign: 'center',
+    width: 'inherit',
+    zIndex: 1,
+  },
+  iconBackground: {
+    ...Styles.transition('opacity'),
+    backgroundColor: Styles.globalColors.greyLight,
+    borderRadius: 40,
+    left: 0,
+    maxHeight: 80,
+    maxWidth: 80,
+    minHeight: 80,
+    minWidth: 80,
+    position: 'absolute',
+    top: 0,
+  },
+  iconContainer: {
+    ...Styles.globalStyles.flexBoxRow,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 25,
+    maxHeight: 80,
+    maxWidth: 80,
+    minHeight: 80,
+    minWidth: 80,
+    position: 'relative',
+  },
+  rowContainer: {
+    ...Styles.globalStyles.flexBoxRow,
+    alignItems: 'center',
+    maxHeight: 100,
+    minHeight: 100,
+    padding: 20,
+    transition: 'background 0.1s ease-out',
+  },
+}))
 
 export default Row
-export {RowCSS}

--- a/shared/provision/paper-key/index.tsx
+++ b/shared/provision/paper-key/index.tsx
@@ -61,7 +61,7 @@ class PaperKey extends React.Component<Props, {paperKey: string}> {
   }
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   backButton: Styles.platformStyles({
     isElectron: {
       marginLeft: Styles.globalMargins.medium,
@@ -93,6 +93,6 @@ const styles = Styles.styleSheetCreate({
     padding: Styles.globalMargins.small,
     width: '100%',
   },
-})
+}))
 
 export default PaperKey

--- a/shared/provision/password/index.desktop.tsx
+++ b/shared/provision/password/index.desktop.tsx
@@ -1,25 +1,25 @@
 // TODO remove Container
 import Container from '../../login/forms/container'
 import * as React from 'react'
-import {Text, Input, Button, UserCard} from '../../common-adapters'
-import {globalColors} from '../../styles'
+import * as Styles from '../../styles'
+import * as Kb from '../../common-adapters'
 import {Props} from '.'
 
 class Password extends React.Component<Props> {
   render() {
     return (
       <Container
-        style={stylesContainer}
-        outerStyle={{backgroundColor: globalColors.white}}
+        style={styles.container}
+        outerStyle={{backgroundColor: Styles.globalColors.white}}
         onBack={() => this.props.onBack()}
       >
-        <UserCard style={stylesCard} username={this.props.username}>
-          <Text type="HeaderBig" style={{color: globalColors.orange}}>
+        <Kb.UserCard style={styles.card} username={this.props.username}>
+          <Kb.Text type="HeaderBig" style={{color: Styles.globalColors.orange}}>
             {this.props.username}
-          </Text>
-          <Input
+          </Kb.Text>
+          <Kb.Input
             autoFocus={true}
-            style={stylesInput}
+            style={styles.input}
             type="password"
             hintText="Password"
             onEnterKeyDown={() => this.props.onSubmit()}
@@ -27,36 +27,38 @@ class Password extends React.Component<Props> {
             value={this.props.password}
             errorText={this.props.error}
           />
-          <Button
+          <Kb.Button
             waiting={this.props.waitingForResponse}
             label="Continue"
             onClick={() => this.props.onSubmit()}
             disabled={!(this.props.password && this.props.password.length)}
           />
-          <Text style={stylesForgot} type="BodySmallSecondaryLink" onClick={this.props.onForgotPassword}>
+          <Kb.Text style={styles.forgot} type="BodySmallSecondaryLink" onClick={this.props.onForgotPassword}>
             Forgot password?
-          </Text>
-        </UserCard>
+          </Kb.Text>
+        </Kb.UserCard>
       </Container>
     )
   }
 }
 
-const stylesContainer = {
-  alignItems: 'center',
-  flex: 1,
-  justifyContent: 'center',
-  marginTop: 40,
-}
-const stylesInput = {
-  marginBottom: 48,
-  marginTop: 40,
-}
-const stylesForgot = {
-  marginTop: 20,
-}
-const stylesCard = {
-  alignSelf: 'stretch',
-}
+const styles = Styles.styleSheetCreate(() => ({
+  card: {
+    alignSelf: 'stretch',
+  },
+  container: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    marginTop: 40,
+  },
+  forgot: {
+    marginTop: 20,
+  },
+  input: {
+    marginBottom: 48,
+    marginTop: 40,
+  },
+}))
 
 export default Password

--- a/shared/provision/password/index.native.tsx
+++ b/shared/provision/password/index.native.tsx
@@ -1,8 +1,8 @@
 // TODO remove Container
 import Container from '../../login/forms/container'
 import * as React from 'react'
-import {Button, UserCard, Text, FormWithCheckbox} from '../../common-adapters'
-import {globalColors, globalMargins} from '../../styles'
+import * as Styles from '../../styles'
+import * as Kb from '../../common-adapters'
 import {Props} from '.'
 
 class Password extends React.Component<Props> {
@@ -11,15 +11,15 @@ class Password extends React.Component<Props> {
 
     return (
       <Container
-        style={stylesContainer}
-        outerStyle={{backgroundColor: globalColors.white, padding: 0}}
+        style={styles.container}
+        outerStyle={{backgroundColor: Styles.globalColors.white, padding: 0}}
         onBack={this.props.onBack}
       >
-        <UserCard style={stylesCard} username={this.props.username}>
-          <Text center={true} type="Header" style={{color: globalColors.orange}}>
+        <Kb.UserCard style={styles.card} username={this.props.username}>
+          <Kb.Text center={true} type="Header" style={{color: Styles.globalColors.orange}}>
             {this.props.username}
-          </Text>
-          <FormWithCheckbox
+          </Kb.Text>
+          <Kb.FormWithCheckbox
             inputProps={{
               autoFocus: true,
               errorText: this.props.error,
@@ -33,36 +33,38 @@ class Password extends React.Component<Props> {
             checkboxesProps={[{checked: !!showTyping, label: 'Show typing', onCheck: toggleShowTyping}]}
           />
 
-          <Button
+          <Kb.Button
             fullWidth={true}
             waiting={this.props.waitingForResponse}
             label="Continue"
             onClick={this.props.onSubmit}
             disabled={!(this.props.password && this.props.password.length)}
           />
-          <Text
+          <Kb.Text
             center={true}
-            style={stylesForgot}
+            style={styles.forgot}
             type="BodySmallSecondaryLink"
             onClick={this.props.onForgotPassword}
           >
             Forgot password?
-          </Text>
-        </UserCard>
+          </Kb.Text>
+        </Kb.UserCard>
       </Container>
     )
   }
 }
 
-const stylesContainer = {
-  flex: 1,
-}
-const stylesForgot = {
-  flex: 1,
-  marginTop: globalMargins.medium,
-}
-const stylesCard = {
-  alignItems: 'stretch',
-}
+const styles = Styles.styleSheetCreate(() => ({
+  container: {
+    flex: 1,
+  },
+  forgot: {
+    flex: 1,
+    marginTop: Styles.globalMargins.medium,
+  },
+  card: {
+    alignItems: 'stretch',
+  },
+}))
 
 export default Password

--- a/shared/provision/password/index.native.tsx
+++ b/shared/provision/password/index.native.tsx
@@ -55,15 +55,15 @@ class Password extends React.Component<Props> {
 }
 
 const styles = Styles.styleSheetCreate(() => ({
+  card: {
+    alignItems: 'stretch',
+  },
   container: {
     flex: 1,
   },
   forgot: {
     flex: 1,
     marginTop: Styles.globalMargins.medium,
-  },
-  card: {
-    alignItems: 'stretch',
   },
 }))
 

--- a/shared/provision/select-other-device/index.tsx
+++ b/shared/provision/select-other-device/index.tsx
@@ -106,7 +106,7 @@ const Troubleshooting = ({onResetAccount}) => (
   </Kb.Box2>
 )
 
-const styles = styleSheetCreate({
+const styles = styleSheetCreate(() => ({
   backButton: platformStyles({
     isElectron: {
       marginLeft: globalMargins.medium,
@@ -142,6 +142,6 @@ const styles = styleSheetCreate({
     paddingRight: globalMargins.small,
     paddingTop: globalMargins.small,
   },
-})
+}))
 
 export default SelectOtherDevice

--- a/shared/provision/set-public-name/index.tsx
+++ b/shared/provision/set-public-name/index.tsx
@@ -51,7 +51,7 @@ const SetPublicName = (props: Props) => {
   )
 }
 
-const styles = styleSheetCreate({
+const styles = styleSheetCreate(() => ({
   backButton: platformStyles({
     isElectron: {
       marginLeft: globalMargins.medium,
@@ -81,7 +81,7 @@ const styles = styleSheetCreate({
       width: '100%',
     },
   }),
-})
+}))
 
 SetPublicName.navigationOptions = {
   header: null,

--- a/shared/provision/username-or-email/index.tsx
+++ b/shared/provision/username-or-email/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
-import { maxUsernameLength } from '../../constants/signup'
-import { SignupScreen, errorBanner } from '../../signup/common'
+import {maxUsernameLength} from '../../constants/signup'
+import {SignupScreen, errorBanner} from '../../signup/common'
 
 type Props = {
   error: string
@@ -29,20 +29,20 @@ const Username = (props: Props) => {
         ...errorBanner(props.error),
         ...(props.inlineSignUpLink
           ? [
-            <Kb.Banner key="usernameTaken" color="blue">
-              <Kb.BannerParagraph
-                bannerColor="blue"
-                content={[
-                  "This username doesn't exist. Did you mean to ",
-                  {
-                    onClick: () => props.inlineSignUpLink && props.onGoToSignup(),
-                    text: 'create a new account',
-                  },
-                  '?',
-                ]}
-              />
-            </Kb.Banner>,
-          ]
+              <Kb.Banner key="usernameTaken" color="blue">
+                <Kb.BannerParagraph
+                  bannerColor="blue"
+                  content={[
+                    "This username doesn't exist. Did you mean to ",
+                    {
+                      onClick: () => props.inlineSignUpLink && props.onGoToSignup(),
+                      text: 'create a new account',
+                    },
+                    '?',
+                  ]}
+                />
+              </Kb.Banner>,
+            ]
           : []),
       ]}
       buttons={[
@@ -110,7 +110,7 @@ const styles = Styles.styleSheetCreate(() => ({
       paddingRight: 0,
     },
   }),
-  error: { paddingTop: Styles.globalMargins.tiny, textAlign: 'center' },
+  error: {paddingTop: Styles.globalMargins.tiny, textAlign: 'center'},
   errorLink: {
     color: Styles.globalColors.redDark,
     textDecorationLine: 'underline',
@@ -167,7 +167,7 @@ const styles = Styles.styleSheetCreate(() => ({
 
 Username.navigationOptions = {
   header: null,
-  headerBottomStyle: { height: undefined },
+  headerBottomStyle: {height: undefined},
   headerLeft: null, // no back button
 }
 

--- a/shared/provision/username-or-email/index.tsx
+++ b/shared/provision/username-or-email/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
-import {maxUsernameLength} from '../../constants/signup'
-import {SignupScreen, errorBanner} from '../../signup/common'
+import { maxUsernameLength } from '../../constants/signup'
+import { SignupScreen, errorBanner } from '../../signup/common'
 
 type Props = {
   error: string
@@ -29,20 +29,20 @@ const Username = (props: Props) => {
         ...errorBanner(props.error),
         ...(props.inlineSignUpLink
           ? [
-              <Kb.Banner key="usernameTaken" color="blue">
-                <Kb.BannerParagraph
-                  bannerColor="blue"
-                  content={[
-                    "This username doesn't exist. Did you mean to ",
-                    {
-                      onClick: () => props.inlineSignUpLink && props.onGoToSignup(),
-                      text: 'create a new account',
-                    },
-                    '?',
-                  ]}
-                />
-              </Kb.Banner>,
-            ]
+            <Kb.Banner key="usernameTaken" color="blue">
+              <Kb.BannerParagraph
+                bannerColor="blue"
+                content={[
+                  "This username doesn't exist. Did you mean to ",
+                  {
+                    onClick: () => props.inlineSignUpLink && props.onGoToSignup(),
+                    text: 'create a new account',
+                  },
+                  '?',
+                ]}
+              />
+            </Kb.Banner>,
+          ]
           : []),
       ]}
       buttons={[
@@ -90,7 +90,7 @@ const Username = (props: Props) => {
   )
 }
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   button: Styles.platformStyles({
     common: {
       alignSelf: 'center',
@@ -110,7 +110,7 @@ const styles = Styles.styleSheetCreate({
       paddingRight: 0,
     },
   }),
-  error: {paddingTop: Styles.globalMargins.tiny, textAlign: 'center'},
+  error: { paddingTop: Styles.globalMargins.tiny, textAlign: 'center' },
   errorLink: {
     color: Styles.globalColors.redDark,
     textDecorationLine: 'underline',
@@ -163,11 +163,11 @@ const styles = Styles.styleSheetCreate({
       width: '100%',
     },
   }),
-})
+}))
 
 Username.navigationOptions = {
   header: null,
-  headerBottomStyle: {height: undefined},
+  headerBottomStyle: { height: undefined },
   headerLeft: null, // no back button
 }
 

--- a/shared/signup/common.tsx
+++ b/shared/signup/common.tsx
@@ -210,7 +210,7 @@ export const errorBanner = (error: string) =>
       ]
     : []
 
-const styles = Styles.styleSheetCreate({
+const styles = Styles.styleSheetCreate(() => ({
   backButton: {
     bottom: Styles.globalMargins.small,
     left: Styles.globalMargins.small,
@@ -291,4 +291,4 @@ const styles = Styles.styleSheetCreate({
     borderBottomWidth: 1,
     borderStyle: 'solid',
   },
-})
+}))


### PR DESCRIPTION
![a hand is hitting a button labeled "closures"](https://user-images.githubusercontent.com/54032873/64211425-255eaa80-ce74-11e9-8a8e-6892557e534a.jpg)

nb: also updates some incorrect dark mode styles that affected the provisioning views, and changes`signup/common.tsx` so it uses stylesheetcreate closures.

@keybase/react-hackers 
@keybase/hotpotatosquad 