### PR TITLE
wrap incoming engine calls in batch

### DIFF
--- a/shared/engine/index-impl.tsx
+++ b/shared/engine/index-impl.tsx
@@ -12,7 +12,8 @@ import engineSaga from './saga'
 import {throttle} from 'lodash-es'
 import {CustomResponseIncomingCallMapType, IncomingCallMapType} from '.'
 import {SessionID, SessionIDKey, WaitingHandlerType, MethodKey} from './types'
-import {TypedState, Dispatch} from '../util/container'
+import {TypedActions, TypedState, Dispatch} from '../util/container'
+import {batch} from 'react-redux'
 
 type WaitingKey = string | Array<string>
 
@@ -35,8 +36,31 @@ class Engine {
   _hasConnected: boolean = isMobile // mobile is always connected
   // App tells us when the sagas are done loading so we can start emitting events
   _sagasAreReady: boolean = false
+
+  static _realDispatch: Dispatch
+
+  static _dispatchTimer: undefined | NodeJS.Timeout = undefined
+  static _dispatchDeque = () => {
+    Engine._dispatchTimer && clearTimeout(Engine._dispatchTimer)
+    Engine._dispatchTimer = undefined
+    if (!Engine._dispatchQueue.length) return
+
+    const toDispatch = Engine._dispatchQueue
+    Engine._dispatchQueue = []
+    batch(() => {
+      toDispatch.forEach(d => Engine._realDispatch(d))
+    })
+  }
+  static _dispatchQueue: Array<TypedActions> = []
+
   // So we can dispatch actions
-  static _dispatch: Dispatch
+  static _dispatch: Dispatch = (a: TypedActions) => {
+    Engine._dispatchQueue.push(a)
+
+    if (!Engine._dispatchTimer) {
+      Engine._dispatchTimer = setTimeout(Engine._dispatchDeque, 32)
+    }
+  }
   // Temporary helper for incoming call maps
   static _getState: () => TypedState
 
@@ -63,7 +87,7 @@ class Engine {
 
   constructor(dispatch: Dispatch, getState: () => TypedState) {
     // setup some static vars
-    Engine._dispatch = dispatch
+    Engine._realDispatch = dispatch
     Engine._getState = getState
     this._rpcClient = createClient(
       payload => this._rpcIncoming(payload),

--- a/shared/store/configure-store.tsx
+++ b/shared/store/configure-store.tsx
@@ -76,6 +76,8 @@ const errorCatching = () => next => action => {
     if (lastError.message === error.message) {
       return
     }
+    // eslint-disable-next-line
+    debugger
     lastError = error
     logger.warn(`Caught a middleware exception`)
     logger.debug(`Caught a middleware exception`, error)

--- a/shared/store/configure-store.tsx
+++ b/shared/store/configure-store.tsx
@@ -76,8 +76,6 @@ const errorCatching = () => next => action => {
     if (lastError.message === error.message) {
       return
     }
-    // eslint-disable-next-line
-    debugger
     lastError = error
     logger.warn(`Caught a middleware exception`)
     logger.debug(`Caught a middleware exception`, error)


### PR DESCRIPTION
@keybase/react-hackers this wraps dispatches from the engine in react/redux's batch. I believe this will slightly reduce renders when we have a ton of incoming rpcs. I actually was hosing the app by settings breakpoints and toggling wifi on/off. SetState would overflow due to incoming rpcs and react would die. This stop that from happening also