### PR TITLE
input monitor as state machine

### DIFF
--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -86,9 +86,9 @@ function* handleWindowFocusEvents(): Iterable<any> {
 }
 
 function* initializeInputMonitor(): Iterable<any> {
+  const inputMonitor = new InputMonitor()
   const channel = Saga.eventChannel(emitter => {
-    // eslint-disable-next-line no-new
-    new InputMonitor(isActive => emitter(isActive ? 'active' : 'inactive'))
+    inputMonitor.notifyActive = isActive => emitter(isActive ? 'active' : 'inactive')
     return () => {}
   }, Saga.buffers.expanding(1))
 

--- a/shared/actions/platform-specific/input-monitor.desktop.tsx
+++ b/shared/actions/platform-specific/input-monitor.desktop.tsx
@@ -5,10 +5,10 @@ type NotifyActiveFunction = (isActive: boolean) => void
 type Reason = 'blur' | 'focus' | 'mouseKeyboard' | 'timeout'
 type State = 'appActive' | 'afterActiveCheck' | 'appInactive' | 'blurred' | 'focused'
 // State machine
-// appActive: User is active. In 5 minutes go to 'afterActiveCheck'. If blur go 'appInactive' immediately
+// appActive: User is active. Tell redux we're active. In 5 minutes go to 'afterActiveCheck'. If blur go 'appInactive' immediately
 // afterActiveCheck: User was 'appActive', in a window of 1 minute see if any keyboard / mouse happens. If so go to 'appInactive', else go appActive
-// appInactive: Wait for focus or keyboard/mouse, then go to 'appActive'
-// blurred: App in background, wait for focus
+// appInactive: Wait for focus or keyboard/mouse, then go to 'appActive'. Tell redux we're inactive
+// blurred: App in background, wait for focus. Tell redux we're inactive
 // focused: App in foreground but no input yet, wait for keyboard/mouse
 
 class InputMonitor {
@@ -53,6 +53,9 @@ class InputMonitor {
     switch (next) {
       case 'focused':
         this.listenForMouseKeyboard()
+        break
+      case 'blurred':
+        this.notifyActive && this.notifyActive(false)
         break
       case 'appActive':
         this.notifyActive && this.notifyActive(true)


### PR DESCRIPTION
This updates the input monitor to be a state machine.
While debugging a ton of stuff i was getting my input monitor into some racy states. this should make the state of the thing more explicit and easier to understand
Also moves the callback out of the constructor