### PR TITLE
prevent channel desc input overflow on mobile

### DIFF
--- a/shared/chat/create-channel/index.native.tsx
+++ b/shared/chat/create-channel/index.native.tsx
@@ -27,7 +27,7 @@ const CreateChannel = (props: Props) => (
           autoCapitalize="sentences"
           multiline={true}
           rowsMin={1}
-          rowsMax={4}
+          rowsMax={2}
           // From go/chat/msgchecker/constants.go#HeadlineMaxLength
           maxLength={280}
           hintText="Description or topic (optional)"

--- a/shared/chat/manage-channels/edit-channel.tsx
+++ b/shared/chat/manage-channels/edit-channel.tsx
@@ -110,7 +110,7 @@ class _EditChannel extends React.Component<Props, State> {
             value={this.state.newTopic}
             multiline={true}
             rowsMin={1}
-            rowsMax={isMobile ? 4 : 10}
+            rowsMax={isMobile ? 2 : 10}
             autoCorrect={true}
             autoCapitalize="sentences"
             // From go/chat/msgchecker/constants.go#HeadlineMaxLength


### PR DESCRIPTION
This PR restricts the maximum rows on the channel description inputs to 2 lines to prevent the input from overflowing behind the cancel and save buttons.

@keybase/react-hackers 
@keybase/hotpotatosquad 