### PR TITLE
Handle multiple UIs in JSON api

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -809,7 +809,7 @@ func (h *Server) PostLocal(ctx context.Context, arg chat1.PostLocalArg) (res cha
 	}
 
 	// Run Stellar UI on any payments in the body
-	if arg.Msg.MessageBody, err = h.runStellarSendUI(ctx, 0, uid, arg.ConversationID,
+	if arg.Msg.MessageBody, err = h.runStellarSendUI(ctx, arg.SessionID, uid, arg.ConversationID,
 		arg.Msg.MessageBody); err != nil {
 		return res, err
 	}

--- a/go/chat/utils/dummy_chat_ui.go
+++ b/go/chat/utils/dummy_chat_ui.go
@@ -9,6 +9,8 @@ import (
 
 type DummyChatUI struct{}
 
+var _ chat1.ChatUiInterface = (*DummyChatUI)(nil)
+
 func (r DummyChatUI) ChatAttachmentDownloadStart(ctx context.Context, sessionID int) error {
 	return nil
 }
@@ -144,6 +146,8 @@ func (r DummyChatUI) TriggerContactSync(context.Context, int) error {
 }
 
 type DummyChatNotifications struct{}
+
+var _ chat1.NotifyChatInterface = (*DummyChatNotifications)(nil)
 
 func (d DummyChatNotifications) NewChatActivity(ctx context.Context, arg chat1.NewChatActivityArg) error {
 	return nil

--- a/go/client/chat_api_handler.go
+++ b/go/client/chat_api_handler.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/protocol/keybase1"
 
 	"github.com/keybase/client/go/libkb"
@@ -696,7 +697,7 @@ func (a *ChatAPI) AttachV1(ctx context.Context, c Call, w io.Writer) error {
 	}
 
 	// opts are valid for attach v1
-	return a.encodeReply(c, a.svcHandler.AttachV1(ctx, opts, NewChatAPIUI(), NewChatAPINotifications()), w)
+	return a.encodeReply(c, a.svcHandler.AttachV1(ctx, opts, NewChatAPIUI(), utils.DummyChatNotifications{}), w)
 }
 
 func (a *ChatAPI) DownloadV1(ctx context.Context, c Call, w io.Writer) error {

--- a/go/client/chat_api_ui.go
+++ b/go/client/chat_api_ui.go
@@ -8,8 +8,11 @@ import (
 
 type ChatAPIUI struct {
 	utils.DummyChatUI
+	sessionID            int
 	allowStellarPayments bool
 }
+
+var _ chat1.ChatUiInterface = (*ChatAPIUI)(nil)
 
 func AllowStellarPayments(enabled bool) func(*ChatAPIUI) {
 	return func(c *ChatAPIUI) {
@@ -20,6 +23,7 @@ func AllowStellarPayments(enabled bool) func(*ChatAPIUI) {
 func NewChatAPIUI(opts ...func(*ChatAPIUI)) *ChatAPIUI {
 	c := &ChatAPIUI{
 		DummyChatUI: utils.DummyChatUI{},
+		sessionID:   randSessionID(),
 	}
 	for _, o := range opts {
 		o(c)
@@ -33,14 +37,4 @@ func (u *ChatAPIUI) ChatStellarDataConfirm(ctx context.Context, arg chat1.ChatSt
 
 func (u *ChatAPIUI) SetAllowStellarPayments(enabled bool) {
 	u.allowStellarPayments = enabled
-}
-
-type ChatAPINotifications struct {
-	utils.DummyChatNotifications
-}
-
-func NewChatAPINotifications() *ChatAPINotifications {
-	return &ChatAPINotifications{
-		DummyChatNotifications: utils.DummyChatNotifications{},
-	}
 }

--- a/go/client/chat_cli_ui.go
+++ b/go/client/chat_cli_ui.go
@@ -24,6 +24,8 @@ type ChatCLINotifications struct {
 	lastAttachmentPercent int
 }
 
+var _ chat1.NotifyChatInterface = (*ChatCLINotifications)(nil)
+
 func NewChatCLINotifications(g *libkb.GlobalContext) *ChatCLINotifications {
 	return &ChatCLINotifications{
 		Contextified: libkb.NewContextified(g),
@@ -63,12 +65,16 @@ type ChatCLIUI struct {
 	// duplicate output.
 	noThreadSearch                          bool
 	lastAttachmentPercent, lastIndexPercent int
+	sessionID                               int
 }
+
+var _ chat1.ChatUiInterface = (*ChatCLIUI)(nil)
 
 func NewChatCLIUI(g *libkb.GlobalContext) *ChatCLIUI {
 	return &ChatCLIUI{
 		Contextified: libkb.NewContextified(g),
 		terminal:     g.UI.GetTerminalUI(),
+		sessionID:    randSessionID(),
 	}
 }
 

--- a/go/client/chat_ui_delegate.go
+++ b/go/client/chat_ui_delegate.go
@@ -1,0 +1,299 @@
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"math/big"
+	"sync"
+
+	"github.com/keybase/client/go/protocol/chat1"
+)
+
+type DelegateChatUI struct {
+	sync.Mutex
+	// sessionID -> chatUI
+	chatUIs map[int]chat1.ChatUiInterface
+}
+
+var _ chat1.ChatUiInterface = (*DelegateChatUI)(nil)
+
+func newDelegateChatUI() *DelegateChatUI {
+	return &DelegateChatUI{
+		chatUIs: make(map[int]chat1.ChatUiInterface),
+	}
+}
+
+func getSessionID(chatUI chat1.ChatUiInterface) int {
+	switch ui := chatUI.(type) {
+	case *ChatAPIUI:
+		return ui.sessionID
+	case *ChatCLIUI:
+		return ui.sessionID
+	default:
+		return 0
+	}
+}
+
+func randSessionID() int {
+	sessionID, err := rand.Int(rand.Reader, big.NewInt(int64(1<<32)))
+	if err != nil {
+		return 0
+	}
+	return int(sessionID.Int64())
+}
+
+func (c *DelegateChatUI) RegisterChatUI(chatUI chat1.ChatUiInterface) {
+	c.Lock()
+	defer c.Unlock()
+	sessionID := getSessionID(chatUI)
+	c.chatUIs[sessionID] = chatUI
+}
+
+func (c *DelegateChatUI) DeregisterChatUI(chatUI chat1.ChatUiInterface) {
+	c.Lock()
+	defer c.Unlock()
+	sessionID := getSessionID(chatUI)
+	delete(c.chatUIs, sessionID)
+}
+
+func (c *DelegateChatUI) getChatUI(sessionID int) *chat1.ChatUiInterface {
+	c.Lock()
+	defer c.Unlock()
+	if chatUI, ok := c.chatUIs[sessionID]; ok {
+		return &chatUI
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatAttachmentDownloadStart(ctx context.Context, sessionID int) error {
+	if chatUI := c.getChatUI(sessionID); chatUI != nil {
+		return (*chatUI).ChatAttachmentDownloadStart(ctx, sessionID)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatAttachmentDownloadProgress(ctx context.Context,
+	arg chat1.ChatAttachmentDownloadProgressArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatAttachmentDownloadProgress(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatAttachmentDownloadDone(ctx context.Context, sessionID int) error {
+	if chatUI := c.getChatUI(sessionID); chatUI != nil {
+		return (*chatUI).ChatAttachmentDownloadDone(ctx, sessionID)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatInboxConversation(ctx context.Context, arg chat1.ChatInboxConversationArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatInboxConversation(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatInboxFailed(ctx context.Context, arg chat1.ChatInboxFailedArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatInboxFailed(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatInboxUnverified(ctx context.Context, arg chat1.ChatInboxUnverifiedArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatInboxUnverified(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatThreadCached(ctx context.Context, arg chat1.ChatThreadCachedArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatThreadCached(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatThreadFull(ctx context.Context, arg chat1.ChatThreadFullArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatThreadFull(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatThreadStatus(ctx context.Context, arg chat1.ChatThreadStatusArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatThreadStatus(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatConfirmChannelDelete(ctx context.Context, arg chat1.ChatConfirmChannelDeleteArg) (bool, error) {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatConfirmChannelDelete(ctx, arg)
+	}
+	return true, nil
+}
+
+func (c *DelegateChatUI) ChatSearchHit(ctx context.Context, arg chat1.ChatSearchHitArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatSearchHit(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatSearchDone(ctx context.Context, arg chat1.ChatSearchDoneArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatSearchDone(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatSearchInboxStart(ctx context.Context, sessionID int) error {
+	if chatUI := c.getChatUI(sessionID); chatUI != nil {
+		return (*chatUI).ChatSearchInboxStart(ctx, sessionID)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatSearchInboxHit(ctx context.Context, arg chat1.ChatSearchInboxHitArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatSearchInboxHit(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatSearchInboxDone(ctx context.Context, arg chat1.ChatSearchInboxDoneArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatSearchInboxDone(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatSearchIndexStatus(ctx context.Context, arg chat1.ChatSearchIndexStatusArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatSearchIndexStatus(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatSearchConvHits(ctx context.Context, arg chat1.ChatSearchConvHitsArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatSearchConvHits(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatStellarDataConfirm(ctx context.Context, arg chat1.ChatStellarDataConfirmArg) (bool, error) {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatStellarDataConfirm(ctx, arg)
+	}
+	return true, nil
+}
+
+func (c *DelegateChatUI) ChatStellarShowConfirm(ctx context.Context, sessionID int) error {
+	if chatUI := c.getChatUI(sessionID); chatUI != nil {
+		return (*chatUI).ChatStellarShowConfirm(ctx, sessionID)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatStellarDataError(ctx context.Context, arg chat1.ChatStellarDataErrorArg) (bool, error) {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatStellarDataError(ctx, arg)
+	}
+	return false, nil
+}
+
+func (c *DelegateChatUI) ChatStellarDone(ctx context.Context, arg chat1.ChatStellarDoneArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatStellarDone(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatGiphySearchResults(ctx context.Context, arg chat1.ChatGiphySearchResultsArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatGiphySearchResults(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatGiphyToggleResultWindow(ctx context.Context,
+	arg chat1.ChatGiphyToggleResultWindowArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatGiphyToggleResultWindow(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatShowManageChannels(ctx context.Context, arg chat1.ChatShowManageChannelsArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatShowManageChannels(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatCoinFlipStatus(ctx context.Context, arg chat1.ChatCoinFlipStatusArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatCoinFlipStatus(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatCommandMarkdown(ctx context.Context, arg chat1.ChatCommandMarkdownArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatCommandMarkdown(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatMaybeMentionUpdate(ctx context.Context, arg chat1.ChatMaybeMentionUpdateArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatMaybeMentionUpdate(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatLoadGalleryHit(ctx context.Context, arg chat1.ChatLoadGalleryHitArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatLoadGalleryHit(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatWatchPosition(ctx context.Context, arg chat1.ChatWatchPositionArg) (chat1.LocationWatchID, error) {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatWatchPosition(ctx, arg)
+	}
+	return chat1.LocationWatchID(0), nil
+}
+
+func (c *DelegateChatUI) ChatClearWatch(ctx context.Context, arg chat1.ChatClearWatchArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatClearWatch(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatCommandStatus(ctx context.Context, arg chat1.ChatCommandStatusArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatCommandStatus(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) ChatBotCommandsUpdateStatus(ctx context.Context, arg chat1.ChatBotCommandsUpdateStatusArg) error {
+	if chatUI := c.getChatUI(arg.SessionID); chatUI != nil {
+		return (*chatUI).ChatBotCommandsUpdateStatus(ctx, arg)
+	}
+	return nil
+}
+
+func (c *DelegateChatUI) TriggerContactSync(ctx context.Context, sessionID int) error {
+	if chatUI := c.getChatUI(sessionID); chatUI != nil {
+		return (*chatUI).TriggerContactSync(ctx, sessionID)
+	}
+	return nil
+}

--- a/go/libkb/socket.go
+++ b/go/libkb/socket.go
@@ -40,10 +40,10 @@ type SocketWrapper struct {
 
 func (g *GlobalContext) MakeLoopbackServer() (l net.Listener, err error) {
 	g.socketWrapperMu.Lock()
+	defer g.socketWrapperMu.Unlock()
 	g.LoopbackListener = NewLoopbackListener(g)
 	l = g.LoopbackListener
-	g.socketWrapperMu.Unlock()
-	return
+	return l, err
 }
 
 func (g *GlobalContext) BindToSocket() (net.Listener, error) {
@@ -56,19 +56,21 @@ func NewTransportFromSocket(g *GlobalContext, s net.Conn) rpc.Transporter {
 
 // ResetSocket clears and returns a new socket
 func (g *GlobalContext) ResetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error) {
-	g.SocketWrapper = nil
-	return g.GetSocket(clearError)
-}
-
-func (g *GlobalContext) GetSocket(clearError bool) (conn net.Conn, xp rpc.Transporter, isNew bool, err error) {
-
-	g.Trace("GetSocket", func() error { return err })()
-
-	// Protect all global socket wrapper manipulation with a
-	// lock to prevent race conditions.
 	g.socketWrapperMu.Lock()
 	defer g.socketWrapperMu.Unlock()
 
+	g.SocketWrapper = nil
+	return g.getSocketLocked(clearError)
+}
+
+func (g *GlobalContext) GetSocket(clearError bool) (conn net.Conn, xp rpc.Transporter, isNew bool, err error) {
+	g.Trace("GetSocket", func() error { return err })()
+	g.socketWrapperMu.Lock()
+	defer g.socketWrapperMu.Unlock()
+	return g.getSocketLocked(clearError)
+}
+
+func (g *GlobalContext) getSocketLocked(clearError bool) (conn net.Conn, xp rpc.Transporter, isNew bool, err error) {
 	needWrapper := false
 	if g.SocketWrapper == nil {
 		needWrapper = true

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -5569,6 +5569,7 @@ type GetInboxNonblockLocalArg struct {
 }
 
 type PostLocalArg struct {
+	SessionID        int                          `codec:"sessionID" json:"sessionID"`
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
 	Msg              MessagePlaintext             `codec:"msg" json:"msg"`
 	ReplyTo          *MessageID                   `codec:"replyTo,omitempty" json:"replyTo,omitempty"`

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -753,7 +753,7 @@ protocol local {
 
   NonblockFetchRes getInboxNonblockLocal(int sessionID, union { null, int } maxUnbox, boolean skipUnverified, union { null, GetInboxLocalQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
 
-  PostLocalRes postLocal(ConversationID conversationID, MessagePlaintext msg, union { null, MessageID }  replyTo, keybase1.TLFIdentifyBehavior identifyBehavior);
+  PostLocalRes postLocal(int sessionID, ConversationID conversationID, MessagePlaintext msg, union { null, MessageID }  replyTo, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalRes {
     array<RateLimit> rateLimits;
     MessageID messageID;

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3676,6 +3676,10 @@
     "postLocal": {
       "request": [
         {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
           "name": "conversationID",
           "type": "ConversationID"
         },


### PR DESCRIPTION
fixes an issue where the JSON api would use the first chatUI what was registered regardless of what the caller tried to regegister. `ChatAPIUI` and `ChatCLIUI` (both used within the API) now have a random sessionID parameter which delegates ui rpc calls via the sessionID 