### PR TITLE
cr: handle case when unmerged file overwrites a file with mtime set

### DIFF
--- a/go/kbfs/libkbfs/cr_actions.go
+++ b/go/kbfs/libkbfs/cr_actions.go
@@ -806,6 +806,11 @@ func (rua *renameUnmergedAction) updateOps(
 		rua.fromName.Plaintext() != rua.toName.Plaintext() &&
 		rua.symPath.Plaintext() == "" {
 		co.AddUnrefBlock(unmergedEntry.BlockPointer)
+		orig, ok := unmergedChains.originals[unmergedEntry.BlockPointer]
+		if !ok {
+			orig = unmergedEntry.BlockPointer
+		}
+		unmergedChains.deletedOriginals[orig] = true
 	}
 
 	return nil


### PR DESCRIPTION
A user had the follow pattern in their logs:

1. Files 1 and 2 exist.
2. User A sets the mtime of file 1.
3. Simultaneously, user B sets the mtime of file 1, sets the mtime of file 2, and renames file 2 over file 1.

The conflict resolution code broke in this case with a "not a dir block" error.  This was because, during the creation of the unmerged chains, the renamed-over file 1 was missing from the unmerged directory and the chains code couldn't identify it as a file.  So later, it was treated as a directory, causing the above error.

Instead, we now attempt to find deleted entry type from an `rmOp` in the parent chain.

The regression test also exposed another issue with bookkeeping the block pointers after the resolution, where an update to a now-deleted pointer was finding its way into the `resolutionOp`.  We now mark that pointer as deleted to avoid the problem.

Issue: HOTPOT-719