### PR TITLE
fix scrolling in reactions tooltip on desktop

### DIFF
--- a/shared/chat/conversation/messages/reaction-tooltip/index.tsx
+++ b/shared/chat/conversation/messages/reaction-tooltip/index.tsx
@@ -163,6 +163,7 @@ const styles = Styles.styleSheetCreate({
   },
   list: Styles.platformStyles({
     isElectron: {
+      flex: 1,
       paddingBottom: Styles.globalMargins.small,
     },
   }),


### PR DESCRIPTION
Before:
![reacji-tooltip-before](https://user-images.githubusercontent.com/11968340/64348241-d4a99780-cfc2-11e9-956c-358a8e811736.gif)

After:
![reacji-tooltip-after](https://user-images.githubusercontent.com/11968340/64348250-d8d5b500-cfc2-11e9-831b-58f5f5ace32a.gif)

cc @keybase/y2ksquad 