### PR TITLE
if we fail to fetch locally with placeholders, try again from most recent cached

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -716,8 +716,12 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 	rc := storage.NewHoleyResultCollector(maxPlaceholders, newPullLocalResultCollector(baseRC))
 	tv, err = s.fetchMaybeNotify(ctx, convID, uid, rc, iboxMaxMsgID, query, pagination)
 	if err != nil {
-		s.Debug(ctx, "PullLocalOnly: failed to fetch local messages: %s", err.Error())
-		return chat1.ThreadView{}, err
+		s.Debug(ctx, "PullLocalOnly: failed to fetch local messages with iboxMaxMsgID: %s, trying again with local max", err)
+		tv, err = s.fetchMaybeNotify(ctx, convID, uid, rc, 0, query, pagination)
+		if err != nil {
+			s.Debug(ctx, "PullLocalOnly: failed to fetch local messages with local max: %s", err)
+			return chat1.ThreadView{}, err
+		}
 	}
 	return tv, nil
 }

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -716,7 +716,7 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 	rc := storage.NewHoleyResultCollector(maxPlaceholders, newPullLocalResultCollector(baseRC))
 	tv, err = s.fetchMaybeNotify(ctx, convID, uid, rc, iboxMaxMsgID, query, pagination)
 	if err != nil {
-		s.Debug(ctx, "PullLocalOnly: failed to fetch local messages with iboxMaxMsgID: %s, trying again with local max", err)
+		s.Debug(ctx, "PullLocalOnly: failed to fetch local messages with iboxMaxMsgID: %v: err %s, trying again with local max", iboxMaxMsgID, err)
 		tv, err = s.fetchMaybeNotify(ctx, convID, uid, rc, 0, query, pagination)
 		if err != nil {
 			s.Debug(ctx, "PullLocalOnly: failed to fetch local messages with local max: %s", err)


### PR DESCRIPTION
Otherwise we show a blank screen when loading the thread.