### PR TITLE
Split team building service types by usage

### DIFF
--- a/shared/actions/json/team-building.json
+++ b/shared/actions/json/team-building.json
@@ -15,10 +15,6 @@
       "service": "Types.ServiceId",
       "limit?": "number"
     },
-    "searchEmailAddress": {
-      "namespace": "Types.AllowedNamespace",
-      "query": "string"
-    },
     "addUsersToTeamSoFar": {"namespace": "Types.AllowedNamespace", "users": "Array<Types.User>"},
     "removeUsersFromTeamSoFar": {
       "namespace": "Types.AllowedNamespace",
@@ -29,11 +25,6 @@
       "users": "Array<Types.User>",
       "query": "string",
       "service": "Types.ServiceIdWithContact"
-    },
-    "searchEmailAddressResultLoaded": {
-      "namespace": "Types.AllowedNamespace",
-      "user": "Types.User",
-      "query": "string"
     },
     "selectRole": {
       "namespace": "'teams'",

--- a/shared/actions/json/team-building.json
+++ b/shared/actions/json/team-building.json
@@ -12,7 +12,7 @@
       "includeContacts": "boolean",
       "namespace": "Types.AllowedNamespace",
       "query": "string",
-      "service": "Types.ServiceIdWithContact",
+      "service": "Types.ServiceId",
       "limit?": "number"
     },
     "searchEmailAddress": {

--- a/shared/actions/team-building-gen.tsx
+++ b/shared/actions/team-building-gen.tsx
@@ -15,8 +15,6 @@ export const finishedTeamBuilding = 'team-building:finishedTeamBuilding'
 export const labelsSeen = 'team-building:labelsSeen'
 export const removeUsersFromTeamSoFar = 'team-building:removeUsersFromTeamSoFar'
 export const search = 'team-building:search'
-export const searchEmailAddress = 'team-building:searchEmailAddress'
-export const searchEmailAddressResultLoaded = 'team-building:searchEmailAddressResultLoaded'
 export const searchResultsLoaded = 'team-building:searchResultsLoaded'
 export const selectRole = 'team-building:selectRole'
 
@@ -34,12 +32,6 @@ type _LabelsSeenPayload = {readonly namespace: Types.AllowedNamespace}
 type _RemoveUsersFromTeamSoFarPayload = {
   readonly namespace: Types.AllowedNamespace
   readonly users: Array<Types.UserID>
-}
-type _SearchEmailAddressPayload = {readonly namespace: Types.AllowedNamespace; readonly query: string}
-type _SearchEmailAddressResultLoadedPayload = {
-  readonly namespace: Types.AllowedNamespace
-  readonly user: Types.User
-  readonly query: string
 }
 type _SearchPayload = {
   readonly includeContacts: boolean
@@ -86,13 +78,6 @@ export const createRemoveUsersFromTeamSoFar = (
   payload: _RemoveUsersFromTeamSoFarPayload
 ): RemoveUsersFromTeamSoFarPayload => ({payload, type: removeUsersFromTeamSoFar})
 export const createSearch = (payload: _SearchPayload): SearchPayload => ({payload, type: search})
-export const createSearchEmailAddress = (payload: _SearchEmailAddressPayload): SearchEmailAddressPayload => ({
-  payload,
-  type: searchEmailAddress,
-})
-export const createSearchEmailAddressResultLoaded = (
-  payload: _SearchEmailAddressResultLoadedPayload
-): SearchEmailAddressResultLoadedPayload => ({payload, type: searchEmailAddressResultLoaded})
 export const createSearchResultsLoaded = (
   payload: _SearchResultsLoadedPayload
 ): SearchResultsLoadedPayload => ({payload, type: searchResultsLoaded})
@@ -131,14 +116,6 @@ export type RemoveUsersFromTeamSoFarPayload = {
   readonly payload: _RemoveUsersFromTeamSoFarPayload
   readonly type: typeof removeUsersFromTeamSoFar
 }
-export type SearchEmailAddressPayload = {
-  readonly payload: _SearchEmailAddressPayload
-  readonly type: typeof searchEmailAddress
-}
-export type SearchEmailAddressResultLoadedPayload = {
-  readonly payload: _SearchEmailAddressResultLoadedPayload
-  readonly type: typeof searchEmailAddressResultLoaded
-}
 export type SearchPayload = {readonly payload: _SearchPayload; readonly type: typeof search}
 export type SearchResultsLoadedPayload = {
   readonly payload: _SearchResultsLoadedPayload
@@ -157,8 +134,6 @@ export type Actions =
   | FinishedTeamBuildingPayload
   | LabelsSeenPayload
   | RemoveUsersFromTeamSoFarPayload
-  | SearchEmailAddressPayload
-  | SearchEmailAddressResultLoadedPayload
   | SearchPayload
   | SearchResultsLoadedPayload
   | SelectRolePayload

--- a/shared/actions/team-building-gen.tsx
+++ b/shared/actions/team-building-gen.tsx
@@ -45,7 +45,7 @@ type _SearchPayload = {
   readonly includeContacts: boolean
   readonly namespace: Types.AllowedNamespace
   readonly query: string
-  readonly service: Types.ServiceIdWithContact
+  readonly service: Types.ServiceId
   readonly limit?: number
 }
 type _SearchResultsLoadedPayload = {

--- a/shared/actions/team-building.tsx
+++ b/shared/actions/team-building.tsx
@@ -1,6 +1,5 @@
 import logger from '../logger'
 import * as Constants from '../constants/team-building'
-import * as Types from '../constants/types/team-building'
 import * as TeamBuildingTypes from '../constants/types/team-building'
 import * as TeamBuildingGen from './team-building-gen'
 import * as RouteTreeGen from './route-tree-gen'
@@ -23,14 +22,17 @@ const apiSearch = async (
   includeContacts: boolean
 ): Promise<Array<TeamBuildingTypes.User>> => {
   try {
-    const results = await RPCTypes.userSearchUserSearchRpcPromise({
-      impTofuQuery,
-      includeContacts: service === 'keybase' && includeContacts,
-      includeServicesSummary,
-      maxResults,
-      query,
-      service,
-    })
+    const results = await RPCTypes.userSearchUserSearchRpcPromise(
+      {
+        impTofuQuery,
+        includeContacts: service === 'keybase' && includeContacts,
+        includeServicesSummary,
+        maxResults,
+        query,
+        service,
+      },
+      Constants.searchWaitingKey
+    )
     return (results || []).reduce<Array<TeamBuildingTypes.User>>((arr, r) => {
       const u = Constants.parseRawResultToUser(r, service)
       u && arr.push(u)
@@ -39,76 +41,6 @@ const apiSearch = async (
   } catch (err) {
     logger.error(`Error in searching for ${query} on ${service}. ${err.message}`)
     return []
-  }
-}
-
-function* searchResultCounts(state: TypedState, {payload: {namespace}}: NSAction) {
-  const teamBuildingState = state[namespace].teamBuilding
-  const {teamBuildingSearchQuery, teamBuildingSelectedService} = teamBuildingState
-  const teamBuildingSearchLimit = 11 // Hard coded since this happens for background tabs
-
-  if (teamBuildingSearchQuery === '') {
-    return
-  }
-
-  // Filter on `services` so we only get what's searchable through API.
-  // Also filter out if we already have that result cached.
-  const servicesToSearch = Constants.allServices
-    .filter(s => s !== teamBuildingSelectedService && !Types.isContactServiceId(s))
-    .filter(s => !teamBuildingState.teamBuildingSearchResults.hasIn([teamBuildingSearchQuery, s]))
-
-  const isStillInSameQuery = (state: TypedState): boolean => {
-    const teamBuildingState = state[namespace].teamBuilding
-
-    return (
-      teamBuildingState.teamBuildingSearchQuery === teamBuildingSearchQuery &&
-      teamBuildingState.teamBuildingSelectedService === teamBuildingSelectedService
-    )
-  }
-
-  // Defer so we aren't conflicting with the main search
-  yield Saga.callUntyped(Saga.delay, 100)
-
-  // Change this to control how many requests are in flight at a time
-  const parallelRequestsCount = 2
-
-  // Channel to interact with workers. Initial buffer size to handle all the messages we'll put
-  // + 1 because we'll put the END message at the end when we close
-  const serviceChannel = yield Saga.callUntyped(
-    Saga.channel,
-    Saga.buffers.expanding(servicesToSearch.length + 1)
-  )
-  servicesToSearch.forEach(service => serviceChannel.put(service))
-  // After the workers pull all the services they can stop
-  serviceChannel.close()
-
-  for (let i = 0; i < parallelRequestsCount; i++) {
-    yield Saga.spawn(function*() {
-      // The loop will exit when we run out of services
-      while (true) {
-        const service = yield Saga.take(serviceChannel)
-        // if we aren't in the same query, let's stop
-        if (!isStillInSameQuery(yield* Saga.selectState())) {
-          break
-        }
-        const action = yield apiSearch(
-          teamBuildingSearchQuery,
-          service,
-          teamBuildingSearchLimit,
-          true,
-          null,
-          false
-        ).then(users =>
-          TeamBuildingGen.createSearchResultsLoaded({
-            namespace,
-            query: teamBuildingSearchQuery,
-            service,
-            users,
-          })
-        )
-        yield Saga.put(action)
-      }
-    })
   }
 }
 
@@ -188,18 +120,6 @@ const fetchUserRecs = async (
   }
 }
 
-async function searchEmailAddress(state: TypedState, {payload: {namespace}}: SearchOrRecAction) {
-  const query = state[namespace].teamBuilding.teamBuildingEmailSearchQuery
-  const impTofuQuery = makeImpTofuQuery(query, null)
-
-  const users = await apiSearch(query, 'keybase', 1, true, impTofuQuery, false)
-  return TeamBuildingGen.createSearchEmailAddressResultLoaded({
-    namespace,
-    query,
-    user: users[0],
-  })
-}
-
 export function filterForNs<S, A, L, R>(
   namespace: TeamBuildingTypes.AllowedNamespace,
   fn: (s: S, a: A & NSAction, l: L) => R
@@ -212,27 +132,11 @@ export function filterForNs<S, A, L, R>(
   }
 }
 
-function filterGenForNs<S, A, L>(
-  namespace: TeamBuildingTypes.AllowedNamespace,
-  fn: (s: S, a: A & NSAction, l: L) => Iterable<any>
-) {
-  return function*(s, a, l) {
-    if (a && a.payload && a.payload.namespace === namespace) {
-      yield* fn(s, a, l)
-    }
-  }
-}
-
 export default function* commonSagas(
   namespace: TeamBuildingTypes.AllowedNamespace
 ): Saga.SagaGenerator<any, any> {
   yield* Saga.chainAction2(TeamBuildingGen.search, filterForNs(namespace, search))
   yield* Saga.chainAction2(TeamBuildingGen.fetchUserRecs, filterForNs(namespace, fetchUserRecs))
-  yield* Saga.chainGenerator<TeamBuildingGen.SearchPayload>(
-    TeamBuildingGen.search,
-    filterGenForNs(namespace, searchResultCounts)
-  )
-  yield* Saga.chainAction2(TeamBuildingGen.searchEmailAddress, filterForNs(namespace, searchEmailAddress))
   // Navigation, before creating
   yield* Saga.chainAction2(
     [TeamBuildingGen.cancelTeamBuilding, TeamBuildingGen.finishedTeamBuilding],

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -769,11 +769,9 @@ export type TypedActionsMap = {
   'team-building:finishedTeamBuilding': teambuilding.FinishedTeamBuildingPayload
   'team-building:cancelTeamBuilding': teambuilding.CancelTeamBuildingPayload
   'team-building:search': teambuilding.SearchPayload
-  'team-building:searchEmailAddress': teambuilding.SearchEmailAddressPayload
   'team-building:addUsersToTeamSoFar': teambuilding.AddUsersToTeamSoFarPayload
   'team-building:removeUsersFromTeamSoFar': teambuilding.RemoveUsersFromTeamSoFarPayload
   'team-building:searchResultsLoaded': teambuilding.SearchResultsLoadedPayload
-  'team-building:searchEmailAddressResultLoaded': teambuilding.SearchEmailAddressResultLoadedPayload
   'team-building:selectRole': teambuilding.SelectRolePayload
   'team-building:changeSendNotification': teambuilding.ChangeSendNotificationPayload
   'team-building:labelsSeen': teambuilding.LabelsSeenPayload

--- a/shared/constants/team-building.tsx
+++ b/shared/constants/team-building.tsx
@@ -5,11 +5,11 @@ import * as RPCTypes from './types/rpc-gen'
 
 const searchServices: Array<Types.ServiceId> = [
   'keybase',
+  'twitter',
   'facebook',
   'github',
-  'hackernews',
   'reddit',
-  'twitter',
+  'hackernews',
 ]
 // Order here determines order of tabs in team building
 export const allServices: Array<Types.ServiceIdWithContact> = [

--- a/shared/constants/team-building.tsx
+++ b/shared/constants/team-building.tsx
@@ -3,29 +3,32 @@ import * as I from 'immutable'
 import * as Types from './types/team-building'
 import * as RPCTypes from './types/rpc-gen'
 
-const allServices: Array<Types.ServiceIdWithContact> = [
+const searchServices: Array<Types.ServiceId> = [
   'keybase',
-  'phone',
-  'contact',
-  'email',
-  'twitter',
   'facebook',
   'github',
-  'reddit',
   'hackernews',
-  'pgp',
+  'reddit',
+  'twitter',
+]
+// Order here determines order of tabs in team building
+export const allServices: Array<Types.ServiceIdWithContact> = [
+  ...searchServices.slice(0, 1),
+  'phone',
+  'email',
+  ...searchServices.slice(1),
+]
+const searchServicesWithEmail: Array<Types.ServiceIdWithContact> = [
+  ...searchServices.slice(0, 1),
+  'email',
+  ...searchServices.slice(1),
 ]
 
-// We don't search pgp explicitly, and contact isn't implemented yet
-const services: Array<Types.ServiceIdWithContact> = allServices.filter(s => s !== 'contact' && s !== 'pgp')
-
-const servicesWithoutPhone: Array<Types.ServiceIdWithContact> = services.filter(s => s !== 'phone')
-
-function servicesForNamespace(namespace: Types.AllowedNamespace): Array<Types.ServiceIdWithContact> {
+export function servicesForNamespace(namespace: Types.AllowedNamespace): Array<Types.ServiceIdWithContact> {
   if (namespace === 'teams') {
-    return servicesWithoutPhone
+    return searchServicesWithEmail
   }
-  return services
+  return allServices
 }
 
 function isKeybaseUserId(userId: string) {
@@ -33,7 +36,7 @@ function isKeybaseUserId(userId: string) {
   return userId.indexOf('@') < 0
 }
 
-function followStateHelperWithId(
+export function followStateHelperWithId(
   me: string,
   followingState: Set<string>,
   userId: string = ''
@@ -66,9 +69,9 @@ const SubStateFactory = I.Record<Types._TeamBuildingSubState>({
   teamBuildingUserRecs: null,
 })
 
-const makeSubState = (): Types.TeamBuildingSubState => SubStateFactory()
+export const makeSubState = (): Types.TeamBuildingSubState => SubStateFactory()
 
-const parseRawResultToUser = (
+export const parseRawResultToUser = (
   result: RPCTypes.APIUserSearchResult,
   service: Types.ServiceIdWithContact
 ): Types.User | null => {
@@ -94,20 +97,23 @@ const parseRawResultToUser = (
       username: result.keybase.username,
     }
   } else if (service === 'keybase' && result.contact) {
+    const serviceId = result.contact.component.phoneNumber ? 'phone' : 'email'
     return {
+      contact: true,
       id: result.contact.assertion,
       label: result.contact.displayLabel,
       prettyName: result.contact.displayName,
-      serviceId: 'contact' as const,
+      serviceId,
       serviceMap: {...result.contact.serviceMap, keybase: result.contact.username},
       username: result.contact.component.email || result.contact.component.phoneNumber || '',
     }
   } else if (result.imptofu) {
+    const serviceId = result.imptofu.assertionKey === 'phone' ? 'phone' : 'email'
     return {
       id: result.imptofu.assertion,
       label: result.imptofu.label,
       prettyName: result.imptofu.prettyName,
-      serviceId: 'contact' as const,
+      serviceId,
       serviceMap: {...serviceMap, keybase: result.imptofu.keybaseUsername},
       username: result.imptofu.assertionValue,
     }
@@ -144,7 +150,7 @@ const parseRawResultToUser = (
   }
 }
 
-const selfToUser = (you: string): Types.User => ({
+export const selfToUser = (you: string): Types.User => ({
   id: you,
   prettyName: you,
   serviceId: 'keybase' as const,
@@ -152,17 +158,17 @@ const selfToUser = (you: string): Types.User => ({
   username: you,
 })
 
-const contactToUser = (contact: RPCTypes.ProcessedContact): Types.User => ({
+export const contactToUser = (contact: RPCTypes.ProcessedContact): Types.User => ({
   contact: true,
   id: contact.assertion,
   label: contact.displayLabel,
   prettyName: contact.displayName,
-  serviceId: 'contact' as const,
+  serviceId: contact.component.phoneNumber ? 'phone' : 'email',
   serviceMap: {keybase: contact.username},
   username: contact.component.email || contact.component.phoneNumber || '',
 })
 
-const interestingPersonToUser = (person: RPCTypes.InterestingPerson): Types.User => {
+export const interestingPersonToUser = (person: RPCTypes.InterestingPerson): Types.User => {
   const {username, fullname} = person
   return {
     id: username,
@@ -171,16 +177,4 @@ const interestingPersonToUser = (person: RPCTypes.InterestingPerson): Types.User
     serviceMap: {keybase: username},
     username: username,
   }
-}
-
-export {
-  followStateHelperWithId,
-  makeSubState,
-  allServices,
-  services,
-  servicesForNamespace,
-  parseRawResultToUser,
-  selfToUser,
-  contactToUser,
-  interestingPersonToUser,
 }

--- a/shared/constants/team-building.tsx
+++ b/shared/constants/team-building.tsx
@@ -52,9 +52,6 @@ export function followStateHelperWithId(
 }
 
 const SubStateFactory = I.Record<Types._TeamBuildingSubState>({
-  teamBuildingEmailIsSearching: false,
-  teamBuildingEmailResult: null,
-  teamBuildingEmailSearchQuery: '',
   teamBuildingFinishedSelectedRole: 'writer',
   teamBuildingFinishedSendNotification: true,
   teamBuildingFinishedTeam: I.OrderedSet(),
@@ -178,3 +175,5 @@ export const interestingPersonToUser = (person: RPCTypes.InterestingPerson): Typ
     username: username,
   }
 }
+
+export const searchWaitingKey = 'teamBuilding:search'

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -5,7 +5,14 @@ import {ServiceId} from '../../util/platforms'
 export type AllowedNamespace = 'chat2' | 'teams'
 export type FollowingState = 'Following' | 'NotFollowing' | 'NoState' | 'You'
 
-export type ServiceIdWithContact = ServiceId | 'contact'
+// These are the services we can pass to apiSearch
+export type ServiceId = ServiceId
+
+export type ContactServiceId = 'email' | 'phone'
+// These are the possible tabs in team building
+export type ServiceIdWithContact = ServiceId | ContactServiceId
+
+export const isContactServiceId = (id: string): id is ContactServiceId => id === 'email' || id === 'phone'
 
 export type SearchString = string
 type UsernameOnService = string
@@ -44,7 +51,7 @@ export type _TeamBuildingSubState = {
   teamBuildingFinishedSelectedRole: TeamRoleType
   teamBuildingFinishedSendNotification: boolean
   teamBuildingSearchQuery: Query
-  teamBuildingSelectedService: ServiceIdWithContact
+  teamBuildingSelectedService: ServiceId
   teamBuildingSearchLimit: number
   teamBuildingUserRecs: Array<User> | null
   teamBuildingSelectedRole: TeamRoleType

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -41,9 +41,6 @@ export type ServiceResultCount = I.Map<SearchString, I.Map<ServiceIdWithContact,
 
 // TODO remove teamBuilding prefix
 export type _TeamBuildingSubState = {
-  teamBuildingEmailSearchQuery: Query
-  teamBuildingEmailIsSearching: boolean
-  teamBuildingEmailResult: User | null
   teamBuildingTeamSoFar: I.OrderedSet<User>
   teamBuildingSearchResults: SearchResults
   teamBuildingServiceResultCount: ServiceResultCount

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -1427,8 +1427,6 @@ const rootReducer = (
     case TeamBuildingGen.fetchedUserRecs:
     case TeamBuildingGen.fetchUserRecs:
     case TeamBuildingGen.search:
-    case TeamBuildingGen.searchEmailAddress:
-    case TeamBuildingGen.searchEmailAddressResultLoaded:
     case TeamBuildingGen.selectRole:
     case TeamBuildingGen.labelsSeen:
     case TeamBuildingGen.changeSendNotification:

--- a/shared/reducers/team-building.tsx
+++ b/shared/reducers/team-building.tsx
@@ -60,25 +60,6 @@ export default function(
         teamBuildingSelectedService: service,
       })
     }
-    case TeamBuildingGen.searchEmailAddress: {
-      const {query} = action.payload
-      return state.merge({
-        teamBuildingEmailIsSearching: true,
-        teamBuildingEmailResult: null,
-        teamBuildingEmailSearchQuery: query.trim(),
-      })
-    }
-    case TeamBuildingGen.searchEmailAddressResultLoaded: {
-      const {user, query} = action.payload
-      if (query !== state.teamBuildingEmailSearchQuery) {
-        return state
-      }
-      return state.merge({
-        teamBuildingEmailIsSearching: false,
-        teamBuildingEmailResult: user,
-      })
-    }
-
     case TeamBuildingGen.fetchUserRecs:
       return state
 

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -145,8 +145,6 @@ const rootReducer = (
     case TeamBuildingGen.fetchedUserRecs:
     case TeamBuildingGen.fetchUserRecs:
     case TeamBuildingGen.search:
-    case TeamBuildingGen.searchEmailAddress:
-    case TeamBuildingGen.searchEmailAddressResultLoaded:
     case TeamBuildingGen.selectRole:
     case TeamBuildingGen.labelsSeen:
     case TeamBuildingGen.changeSendNotification:

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -10,10 +10,10 @@ import * as ChatConstants from '../constants/chat2'
 import * as TeamBuildingGen from '../actions/team-building-gen'
 import * as SettingsGen from '../actions/settings-gen'
 import * as Container from '../util/container'
+import * as Constants from '../constants/team-building'
 import * as Types from '../constants/types/team-building'
 import {requestIdleCallback} from '../util/idle-callback'
 import {HeaderHoc, PopupDialogHoc, Button} from '../common-adapters'
-import {followStateHelperWithId} from '../constants/team-building'
 import {memoizeShallow, memoize} from '../util/memoize'
 import {TeamRoleType, MemberInfo, DisabledReasonsForRolePicker} from '../constants/types/teams'
 import {getDisabledReasonsForRolePicker} from '../constants/teams'
@@ -71,7 +71,11 @@ const deriveSearchResults = memoize(
       return {
         contact: !!info.contact,
         displayLabel: formatAnyPhoneNumbers(label),
-        followingState: followStateHelperWithId(myUsername, followingState, info.serviceMap.keybase),
+        followingState: Constants.followStateHelperWithId(
+          myUsername,
+          followingState,
+          info.serviceMap.keybase
+        ),
         inTeam: teamSoFar.some(u => u.id === info.id),
         isPreExistingTeamMember: preExistingTeamMembers.has(info.id),
         key: [info.id, info.prettyName, info.label, String(!!info.contact)].join('&'),
@@ -348,6 +352,19 @@ const deriveRolePickerArrowKeyFns = memoize(
   })
 )
 
+const deriveOnChangeService = memoize(
+  (
+    onChangeService: OwnProps['onChangeService'],
+    search: (text: string, service: Types.ServiceIdWithContact) => void,
+    searchString: string
+  ) => (service: Types.ServiceIdWithContact) => {
+    onChangeService(service)
+    if (!Types.isContactServiceId(service)) {
+      search(searchString, service)
+    }
+  }
+)
+
 const alphabet = 'abcdefghijklmnopqrstuvwxyz'
 const aCharCode = alphabet.charCodeAt(0)
 const alphaSet = new Set(alphabet)
@@ -566,7 +583,7 @@ const mergeProps = (
         ],
         title,
       }
-    : {}
+    : emptyObj
 
   return {
     ...headerHocProps,
@@ -579,7 +596,11 @@ const mergeProps = (
     onAdd,
     onAddRaw: dispatchProps._onAdd,
     onBackspace: deriveOnBackspace(ownProps.searchString, teamSoFar, dispatchProps.onRemove),
-    onChangeService: ownProps.onChangeService,
+    onChangeService: deriveOnChangeService(
+      ownProps.onChangeService,
+      dispatchProps._search,
+      ownProps.searchString
+    ),
     onChangeText,
     onClear,
     onClosePopup: dispatchProps._onCancelTeamBuilding,

--- a/shared/team-building/email-input/index.stories.tsx
+++ b/shared/team-building/email-input/index.stories.tsx
@@ -4,23 +4,32 @@ import EmailInput from '.'
 
 const namespace = 'chat2'
 
-const storeCommon = Sb.createStoreWithCommon()
-const store = {
-  ...storeCommon,
-  [namespace]: storeCommon[namespace].setIn(['teamBuilding', 'teamBuildingEmailResult'], {
-    id: '[max@keybase.io]@email',
-    label: '',
-    prettyName: 'max@keybase.io',
-    serviceId: 'contact',
-    serviceMap: {keybase: 'max'},
-    username: 'max@keybase',
-  }),
-}
+const store = Sb.createStoreWithCommon()
 
 const load = () => {
   Sb.storiesOf('Team-Building', module)
     .addDecorator((story: any) => <Sb.MockStore store={store}>{story()}</Sb.MockStore>)
-    .add('Email address', () => <EmailInput namespace={namespace} />)
+    .add('Email address', () => (
+      <EmailInput
+        search={Sb.action('search')}
+        namespace={namespace}
+        teamBuildingSearchResults={{
+          // @ts-ignore
+          ['max@keybase.io']: {
+            keybase: [
+              {
+                id: '[max@keybase.io]@email',
+                label: '',
+                prettyName: 'max@keybase.io',
+                serviceId: 'email',
+                serviceMap: {keybase: 'max'},
+                username: 'max@keybase.io',
+              },
+            ],
+          },
+        }}
+      />
+    ))
 }
 
 export default load

--- a/shared/team-building/email-input/index.tsx
+++ b/shared/team-building/email-input/index.tsx
@@ -1,36 +1,38 @@
 import * as React from 'react'
-import {debounce} from 'lodash-es'
 import * as Container from '../../util/container'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import * as TeamBuildingGen from '../../actions/team-building-gen'
+import * as Constants from '../../constants/team-building'
+import * as Types from '../../constants/types/team-building'
 import {AllowedNamespace} from '../../constants/types/team-building'
 import {validateEmailAddress} from '../../util/email-address'
+import {UserMatchMention} from '../phone-search'
 import ContinueButton from '../continue-button'
 
 type EmailInputProps = {
   namespace: AllowedNamespace
+  search: (query: string, service: 'email') => void
+  teamBuildingSearchResults: {[query: string]: {[service in Types.ServiceIdWithContact]: Array<Types.User>}}
 }
 
-const EmailInput = ({namespace}: EmailInputProps) => {
+const EmailInput = ({namespace, search, teamBuildingSearchResults}: EmailInputProps) => {
   const [isEmailValid, setEmailValidity] = React.useState(false)
   const [emailString, setEmailString] = React.useState('')
+  const waiting = Container.useAnyWaiting(Constants.searchWaitingKey)
   const dispatch = Container.useDispatch()
-  const user = Container.useSelector(state => {
-    return state[namespace].teamBuilding.teamBuildingEmailResult
-  })
-  const isSearching = Container.useSelector(
-    state => state[namespace].teamBuilding.teamBuildingEmailIsSearching
-  )
-  const canSubmit = user !== null && !isSearching && isEmailValid
-  const emailHasKeybaseAccount =
-    user !== null && user.serviceMap.keybase !== '' && emailString === user.username
 
-  // TODO use search from container instead
-  const debouncedSearch = React.useCallback(
-    debounce((query: string) => dispatch(TeamBuildingGen.createSearchEmailAddress({namespace, query})), 200),
-    [dispatch, namespace]
-  )
+  let user: Types.User | undefined
+  if (
+    teamBuildingSearchResults &&
+    teamBuildingSearchResults[emailString] &&
+    teamBuildingSearchResults[emailString].keybase &&
+    teamBuildingSearchResults[emailString].keybase[0]
+  ) {
+    user = teamBuildingSearchResults[emailString].keybase[0]
+  }
+  const canSubmit = !!user && !waiting && isEmailValid
+  const emailHasKeybaseAccount = user && user.serviceMap.keybase !== ''
 
   const onChange = React.useCallback(
     text => {
@@ -42,14 +44,14 @@ const EmailInput = ({namespace}: EmailInputProps) => {
         setEmailValidity(isNewInputValid)
       }
       if (isNewInputValid) {
-        debouncedSearch(text)
+        search(text, 'email')
       }
     },
-    [isEmailValid, debouncedSearch]
+    [isEmailValid, search]
   )
 
   const onSubmit = React.useCallback(() => {
-    if (user === null || !canSubmit) {
+    if (!user || !canSubmit) {
       return
     }
 
@@ -71,26 +73,13 @@ const EmailInput = ({namespace}: EmailInputProps) => {
           textContentType="emailAddress"
           value={emailString}
         />
-        {isSearching && (
+        {waiting && (
           <Kb.Box2 direction="horizontal" fullWidth={true}>
             <Kb.ProgressIndicator type="Small" />
           </Kb.Box2>
         )}
-        {user !== null && canSubmit && emailHasKeybaseAccount && user.serviceMap.keybase && (
-          <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.userMatchMention}>
-            <Kb.Icon type="iconfont-check" sizeType="Tiny" color={Styles.globalColors.greenDark} />
-            <Kb.Text type="BodySmall">
-              Great! That's{' '}
-              <Kb.ConnectedUsernames
-                colorFollowing={true}
-                inline={true}
-                onUsernameClicked="profile"
-                type="BodySmallSemibold"
-                usernames={[user.serviceMap.keybase]}
-              />{' '}
-              on Keybase.
-            </Kb.Text>
-          </Kb.Box2>
+        {!!user && canSubmit && emailHasKeybaseAccount && user.serviceMap.keybase && (
+          <UserMatchMention username={user.serviceMap.keybase} />
         )}
         {/* TODO: add support for multiple emails  */}
       </Kb.Box2>

--- a/shared/team-building/email-input/index.tsx
+++ b/shared/team-building/email-input/index.tsx
@@ -26,6 +26,7 @@ const EmailInput = ({namespace}: EmailInputProps) => {
   const emailHasKeybaseAccount =
     user !== null && user.serviceMap.keybase !== '' && emailString === user.username
 
+  // TODO use search from container instead
   const debouncedSearch = React.useCallback(
     debounce((query: string) => dispatch(TeamBuildingGen.createSearchEmailAddress({namespace, query})), 200),
     [dispatch, namespace]

--- a/shared/team-building/index.stories.tsx
+++ b/shared/team-building/index.stories.tsx
@@ -622,7 +622,7 @@ const load = () => {
   Sb.storiesOf('Team-Building/Service Tab Bar', module)
     .add('With Service Results counts', () => (
       <ServiceTabBar
-        services={Constants.services}
+        services={Constants.allServices}
         selectedService="keybase"
         onChangeService={Sb.action('onChangeService')}
         serviceResultCount={{
@@ -635,7 +635,7 @@ const load = () => {
     ))
     .add('Pending results', () => (
       <ServiceTabBar
-        services={Constants.services}
+        services={Constants.allServices}
         selectedService="keybase"
         onChangeService={Sb.action('onChangeService')}
         serviceResultCount={{}}
@@ -656,7 +656,7 @@ const load = () => {
   servicesToDisplay.forEach(service => {
     Sb.storiesOf('Team-Building/Service Tab Bar', module).add(`${service} selected`, () => (
       <ServiceTabBar
-        services={Constants.services}
+        services={Constants.allServices}
         selectedService={service}
         onChangeService={Sb.action('onChangeService')}
         serviceResultCount={{}}

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -464,7 +464,13 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
     let content
     switch (props.selectedService) {
       case 'email':
-        content = <EmailInput namespace={props.namespace} />
+        content = (
+          <EmailInput
+            namespace={props.namespace}
+            teamBuildingSearchResults={props.teamBuildingSearchResults}
+            search={props.search}
+          />
+        )
         break
       case 'phone':
         content = (

--- a/shared/team-building/phone-search.tsx
+++ b/shared/team-building/phone-search.tsx
@@ -2,12 +2,14 @@ import * as React from 'react'
 import * as Kb from '../common-adapters/index'
 import PhoneInput from '../signup/phone-number/phone-input'
 import * as Styles from '../styles'
+import * as Constants from '../constants/team-building'
+import * as Container from '../util/container'
 import {ServiceIdWithContact, User} from 'constants/types/team-building'
 import ContinueButton from './continue-button'
 
 type PhoneSearchProps = {
   onContinue: (user: User) => void
-  search: (query: string, service: ServiceIdWithContact) => void
+  search: (query: string, service: 'phone') => void
   teamBuildingSearchResults: {[query: string]: {[service in ServiceIdWithContact]: Array<User>}}
 }
 
@@ -18,6 +20,7 @@ const PhoneSearch = (props: PhoneSearchProps) => {
   const [validity, setValidity] = React.useState<boolean>(false)
   const [phoneNumber, setPhoneNumber] = React.useState<string>('')
   const [phoneInputKey, setPhoneInputKey] = React.useState<number>(0)
+  const waiting = Container.useAnyWaiting(Constants.searchWaitingKey)
 
   const onChangeNumberCb = (phoneNumber: string, validity: boolean) => {
     setValidity(validity)
@@ -50,7 +53,7 @@ const PhoneSearch = (props: PhoneSearchProps) => {
       state = 'resolved'
     }
   }
-  if (state === 'none' && validity && props.teamBuildingSearchResults[phoneNumber] === undefined) {
+  if (state === 'none' && waiting) {
     state = 'loading'
   }
   if (state === 'none' && validity && props.teamBuildingSearchResults[phoneNumber] !== undefined) {
@@ -90,22 +93,7 @@ const PhoneSearch = (props: PhoneSearchProps) => {
             onChangeNumber={onChangeNumberCb}
             onEnterKeyDown={_onContinue}
           />
-          {state === 'resolved' && !!user && (
-            <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.userMatchMention} centerChildren={true}>
-              <Kb.Icon type="iconfont-check" sizeType="Tiny" color={Styles.globalColors.greenDark} />
-              <Kb.Text type="BodySmall">
-                Great! That's{' '}
-                <Kb.ConnectedUsernames
-                  colorFollowing={true}
-                  inline={true}
-                  onUsernameClicked="profile"
-                  type="BodySmallSemibold"
-                  usernames={[user.username]}
-                />{' '}
-                on Keybase.
-              </Kb.Text>
-            </Kb.Box2>
-          )}
+          {state === 'resolved' && !!user && <UserMatchMention username={user.username} />}
           {state === 'loading' && <Kb.ProgressIndicator type="Small" style={styles.loading} />}
         </Kb.Box2>
         <Kb.Box style={styles.spaceFillingBox} />
@@ -114,6 +102,26 @@ const PhoneSearch = (props: PhoneSearchProps) => {
     </>
   )
 }
+
+type UserMatchMentionProps = {
+  username: string
+}
+export const UserMatchMention = ({username}: UserMatchMentionProps) => (
+  <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.userMatchMention} centerChildren={true}>
+    <Kb.Icon type="iconfont-check" sizeType="Tiny" color={Styles.globalColors.greenDark} />
+    <Kb.Text type="BodySmall">
+      Great! That's{' '}
+      <Kb.ConnectedUsernames
+        colorFollowing={true}
+        inline={true}
+        onUsernameClicked="profile"
+        type="BodySmallSemibold"
+        usernames={[username]}
+      />{' '}
+      on Keybase.
+    </Kb.Text>
+  </Kb.Box2>
+)
 
 const styles = Styles.styleSheetCreate(
   () =>

--- a/shared/team-building/phone-search.tsx
+++ b/shared/team-building/phone-search.tsx
@@ -23,8 +23,7 @@ const PhoneSearch = (props: PhoneSearchProps) => {
     setValidity(validity)
     setPhoneNumber(phoneNumber)
     if (validity) {
-      // TODO: Is this okay to reuse the 'keybase' service name? Or should we add a 'phone' one to iced?
-      props.search(phoneNumber, 'keybase')
+      props.search(phoneNumber, 'phone')
     }
   }
 

--- a/shared/team-building/shared.tsx
+++ b/shared/team-building/shared.tsx
@@ -14,13 +14,6 @@ const services: {
     wonderland?: boolean
   }
 } = {
-  contact: {
-    color: '#000',
-    icon: 'iconfont-identity-twitter',
-    label: 'Your contacts', // TODO: rethink this for the empty state when we're actually using it
-    longLabel: 'A contact',
-    searchPlaceholder: 'contacts',
-  },
   email: {
     color: '#3663ea',
     icon: 'iconfont-mention',
@@ -56,13 +49,6 @@ const services: {
     label: 'Keybase and contacts',
     longLabel: Styles.isMobile ? 'Keybase & Contacts' : 'A Keybase user',
     searchPlaceholder: Styles.isMobile ? 'Keybase & contacts' : 'Keybase',
-  },
-  pgp: {
-    color: '#000',
-    icon: 'iconfont-identity-pgp',
-    label: 'PGP',
-    longLabel: 'A PGP user',
-    searchPlaceholder: 'PGP',
   },
   phone: {
     color: '#3663ea',

--- a/shared/team-building/team-box.tsx
+++ b/shared/team-building/team-box.tsx
@@ -28,7 +28,6 @@ const formatNameForUserBubble = (u: SelectedUser) => {
   let displayName: string
   switch (u.service) {
     case 'keybase':
-    case 'phone':
     case 'email':
       displayName = u.username
       break

--- a/shared/team-building/team-box.tsx
+++ b/shared/team-building/team-box.tsx
@@ -28,7 +28,7 @@ const formatNameForUserBubble = (u: SelectedUser) => {
   let displayName: string
   switch (u.service) {
     case 'keybase':
-    case 'contact': // do not display "michal@keyba.se on email" or similar
+    case 'phone':
     case 'email':
       displayName = u.username
       break

--- a/shared/team-building/user-result.desktop.tsx
+++ b/shared/team-building/user-result.desktop.tsx
@@ -96,7 +96,7 @@ const Avatar = ({
 }) => {
   if (keybaseUsername) {
     return <Kb.Avatar size={AvatarSize} username={keybaseUsername} />
-  } else if (resultForService === 'keybase' || resultForService === 'contact') {
+  } else if (resultForService === 'keybase' || Types.isContactServiceId(resultForService)) {
     return <Kb.Avatar size={AvatarSize} username="invalid username for placeholder avatar" />
   }
 

--- a/shared/team-building/user-result.native.tsx
+++ b/shared/team-building/user-result.native.tsx
@@ -64,7 +64,7 @@ const Avatar = ({
 }) => {
   if (keybaseUsername) {
     return <Kb.Avatar size={AvatarSize} username={keybaseUsername} />
-  } else if (resultForService === 'keybase' || resultForService === 'contact') {
+  } else if (resultForService === 'keybase' || Types.isContactServiceId(resultForService)) {
     return <Kb.Avatar size={AvatarSize} username="invalid username for placeholder avatar" />
   }
 

--- a/shared/util/platforms.tsx
+++ b/shared/util/platforms.tsx
@@ -1,29 +1,6 @@
 import {PlatformsExpandedType} from '../constants/types/more'
 import {IconType} from '../common-adapters/icon.constants-gen' // do NOT pull in all of common-adapters
 
-const ProveMessages = {
-  btc: 'Set a Bitcoin address',
-  dns: 'Prove your website',
-  dnsOrGenericWebSite: 'Prove your website',
-  facebook: 'Prove your Facebook',
-  github: 'Prove your GitHub',
-  hackernews: 'Prove your Hacker News',
-  http: 'Prove your HTTP website',
-  https: 'Prove your HTTPS website',
-  keybase: '',
-  none: '',
-  pgp: 'Add a PGP key',
-  reddit: 'Prove your Reddit',
-  rooter: 'Prove your Rooter',
-  twitter: 'Prove your Twitter',
-  web: 'Prove your website',
-  zcash: 'Set a Zcash address',
-}
-
-export function proveMessage(platform: PlatformsExpandedType) {
-  return ProveMessages[platform]
-}
-
 export function subtitle(platform: PlatformsExpandedType): string | null {
   switch (platform) {
     case 'zcash':
@@ -39,25 +16,14 @@ export function subtitle(platform: PlatformsExpandedType): string | null {
   }
 }
 
-export type ServiceId =
-  | 'email'
-  | 'facebook'
-  | 'github'
-  | 'hackernews'
-  | 'keybase'
-  | 'pgp'
-  | 'reddit'
-  | 'twitter'
-  | 'phone'
+export type ServiceId = 'facebook' | 'github' | 'hackernews' | 'keybase' | 'reddit' | 'twitter'
 
 export function serviceIdToIcon(service: ServiceId): IconType {
   return ({
-    email: 'iconfont-mention',
     facebook: 'iconfont-identity-facebook',
     github: 'iconfont-identity-github',
     hackernews: 'iconfont-identity-hn',
     keybase: 'iconfont-identity-devices',
-    pgp: 'iconfont-identity-pgp',
     reddit: 'iconfont-identity-reddit',
     twitter: 'iconfont-identity-twitter',
   } as const)[service]
@@ -65,12 +31,10 @@ export function serviceIdToIcon(service: ServiceId): IconType {
 
 export function serviceIdToLogo24(service: ServiceId): IconType {
   return ({
-    email: 'icon-keybase-logo-24',
     facebook: 'icon-facebook-logo-24',
     github: 'icon-github-logo-24',
     hackernews: 'icon-hacker-news-logo-24',
     keybase: 'icon-keybase-logo-24',
-    pgp: 'icon-pgp-key-24',
     reddit: 'icon-reddit-logo-24',
     twitter: 'icon-twitter-logo-24',
   } as const)[service]
@@ -82,12 +46,10 @@ export type UserId = string
 
 export function serviceIdFromString(val: string): ServiceId {
   switch (val) {
-    case 'email':
     case 'facebook':
     case 'github':
     case 'hackernews':
     case 'keybase':
-    case 'pgp':
     case 'reddit':
     case 'twitter':
       return val


### PR DESCRIPTION
`ServiceIdWithContact` is the set of possibly selected tabs in the modal.
`ServiceId` is set of services we can pass to the search RPC.

Now, transform `ServiceIdWithContact` -> `ServiceId` in the team building container to call search.
