### PR TITLE
libfuse: return ENOTSUP for hard links

### DIFF
--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -729,6 +729,14 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	return child, nil
 }
 
+var _ fs.NodeLinker = (*Dir)(nil)
+
+// Link implements the fs.NodeLinker interface for Dir.
+func (d *Dir) Link(
+	_ context.Context, _ *fuse.LinkRequest, _ fs.Node) (fs.Node, error) {
+	return nil, fuse.ENOTSUP
+}
+
 // Rename implements the fs.NodeRenamer interface for Dir.
 func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 	newDir fs.Node) (err error) {

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -280,6 +280,22 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 	}
 }
 
+var _ fs.NodeLinker = (*FolderList)(nil)
+
+// Symlink implements the fs.NodeLinker interface for FolderList.
+func (fl *FolderList) Symlink(
+	_ context.Context, _ *fuse.SymlinkRequest) (fs.Node, error) {
+	return nil, fuse.ENOTSUP
+}
+
+var _ fs.NodeLinker = (*FolderList)(nil)
+
+// Link implements the fs.NodeLinker interface for FolderList.
+func (fl *FolderList) Link(
+	_ context.Context, _ *fuse.LinkRequest, _ fs.Node) (fs.Node, error) {
+	return nil, fuse.ENOTSUP
+}
+
 func (fl *FolderList) updateTlfName(ctx context.Context, oldName string,
 	newName string) {
 	ok := func() bool {

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -280,9 +280,9 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 	}
 }
 
-var _ fs.NodeLinker = (*FolderList)(nil)
+var _ fs.NodeSymlinker = (*FolderList)(nil)
 
-// Symlink implements the fs.NodeLinker interface for FolderList.
+// Symlink implements the fs.NodeSymlinker interface for FolderList.
 func (fl *FolderList) Symlink(
 	_ context.Context, _ *fuse.SymlinkRequest) (fs.Node, error) {
 	return nil, fuse.ENOTSUP

--- a/go/kbfs/libfuse/fs.go
+++ b/go/kbfs/libfuse/fs.go
@@ -572,6 +572,22 @@ func (r *Root) ReadDirAll(ctx context.Context) (res []fuse.Dirent, err error) {
 	return res, nil
 }
 
+var _ fs.NodeLinker = (*Root)(nil)
+
+// Symlink implements the fs.NodeLinker interface for Root.
+func (r *Root) Symlink(
+	_ context.Context, _ *fuse.SymlinkRequest) (fs.Node, error) {
+	return nil, fuse.ENOTSUP
+}
+
+var _ fs.NodeLinker = (*Root)(nil)
+
+// Link implements the fs.NodeLinker interface for Root.
+func (r *Root) Link(
+	_ context.Context, _ *fuse.LinkRequest, _ fs.Node) (fs.Node, error) {
+	return nil, fuse.ENOTSUP
+}
+
 func (r *Root) log() logger.Logger {
 	return r.private.fs.log
 }

--- a/go/kbfs/libfuse/fs.go
+++ b/go/kbfs/libfuse/fs.go
@@ -572,9 +572,9 @@ func (r *Root) ReadDirAll(ctx context.Context) (res []fuse.Dirent, err error) {
 	return res, nil
 }
 
-var _ fs.NodeLinker = (*Root)(nil)
+var _ fs.NodeSymlinker = (*Root)(nil)
 
-// Symlink implements the fs.NodeLinker interface for Root.
+// Symlink implements the fs.NodeSymlinker interface for Root.
 func (r *Root) Symlink(
 	_ context.Context, _ *fuse.SymlinkRequest) (fs.Node, error) {
 	return nil, fuse.ENOTSUP

--- a/go/kbfs/libfuse/tlf.go
+++ b/go/kbfs/libfuse/tlf.go
@@ -287,6 +287,14 @@ func (tlf *TLF) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	return dir.Symlink(ctx, req)
 }
 
+var _ fs.NodeLinker = (*TLF)(nil)
+
+// Link implements the fs.NodeLinker interface for TLF.
+func (tlf *TLF) Link(
+	_ context.Context, _ *fuse.LinkRequest, _ fs.Node) (fs.Node, error) {
+	return nil, fuse.ENOTSUP
+}
+
 // Rename implements the fs.NodeRenamer interface for TLF.
 func (tlf *TLF) Rename(ctx context.Context, req *fuse.RenameRequest,
 	newDir fs.Node) error {


### PR DESCRIPTION
I'm not sure how we never noticed this before -- I guess I though bazil did this for us, but it returns EIO if we don't implemented the `NodeLinker` interface.

Credit to @mateon1 for uncovering this issue and bringing it to my attention!

Issue: HOTPOT-781