### PR TITLE
Remove searchResultCounts

### DIFF
--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -352,6 +352,19 @@ const deriveRolePickerArrowKeyFns = memoize(
   })
 )
 
+const deriveOnChangeService = memoize(
+  (
+    onChangeService: OwnProps['onChangeService'],
+    search: (text: string, service: Types.ServiceIdWithContact) => void,
+    searchString: string
+  ) => (service: Types.ServiceIdWithContact) => {
+    onChangeService(service)
+    if (!Types.isContactServiceId(service)) {
+      search(searchString, service)
+    }
+  }
+)
+
 const alphabet = 'abcdefghijklmnopqrstuvwxyz'
 const aCharCode = alphabet.charCodeAt(0)
 const alphaSet = new Set(alphabet)
@@ -572,13 +585,6 @@ const mergeProps = (
       }
     : emptyObj
 
-  const onChangeService = (service: Types.ServiceIdWithContact) => {
-    ownProps.onChangeService(service)
-    if (!Types.isContactServiceId(service)) {
-      dispatchProps._search(ownProps.searchString, service)
-    }
-  }
-
   return {
     ...headerHocProps,
     ...contactProps,
@@ -590,7 +596,11 @@ const mergeProps = (
     onAdd,
     onAddRaw: dispatchProps._onAdd,
     onBackspace: deriveOnBackspace(ownProps.searchString, teamSoFar, dispatchProps.onRemove),
-    onChangeService,
+    onChangeService: deriveOnChangeService(
+      ownProps.onChangeService,
+      dispatchProps._search,
+      ownProps.searchString
+    ),
     onChangeText,
     onClear,
     onClosePopup: dispatchProps._onCancelTeamBuilding,

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -10,10 +10,10 @@ import * as ChatConstants from '../constants/chat2'
 import * as TeamBuildingGen from '../actions/team-building-gen'
 import * as SettingsGen from '../actions/settings-gen'
 import * as Container from '../util/container'
+import * as Constants from '../constants/team-building'
 import * as Types from '../constants/types/team-building'
 import {requestIdleCallback} from '../util/idle-callback'
 import {HeaderHoc, PopupDialogHoc, Button} from '../common-adapters'
-import {followStateHelperWithId} from '../constants/team-building'
 import {memoizeShallow, memoize} from '../util/memoize'
 import {TeamRoleType, MemberInfo, DisabledReasonsForRolePicker} from '../constants/types/teams'
 import {getDisabledReasonsForRolePicker} from '../constants/teams'
@@ -71,7 +71,11 @@ const deriveSearchResults = memoize(
       return {
         contact: !!info.contact,
         displayLabel: formatAnyPhoneNumbers(label),
-        followingState: followStateHelperWithId(myUsername, followingState, info.serviceMap.keybase),
+        followingState: Constants.followStateHelperWithId(
+          myUsername,
+          followingState,
+          info.serviceMap.keybase
+        ),
         inTeam: teamSoFar.some(u => u.id === info.id),
         isPreExistingTeamMember: preExistingTeamMembers.has(info.id),
         key: [info.id, info.prettyName, info.label, String(!!info.contact)].join('&'),
@@ -566,7 +570,14 @@ const mergeProps = (
         ],
         title,
       }
-    : {}
+    : emptyObj
+
+  const onChangeService = (service: Types.ServiceIdWithContact) => {
+    ownProps.onChangeService(service)
+    if (!Types.isContactServiceId(service)) {
+      dispatchProps._search(ownProps.searchString, service)
+    }
+  }
 
   return {
     ...headerHocProps,
@@ -579,7 +590,7 @@ const mergeProps = (
     onAdd,
     onAddRaw: dispatchProps._onAdd,
     onBackspace: deriveOnBackspace(ownProps.searchString, teamSoFar, dispatchProps.onRemove),
-    onChangeService: ownProps.onChangeService,
+    onChangeService,
     onChangeText,
     onClear,
     onClosePopup: dispatchProps._onCancelTeamBuilding,

--- a/shared/team-building/email-input/index.tsx
+++ b/shared/team-building/email-input/index.tsx
@@ -7,6 +7,7 @@ import * as Constants from '../../constants/team-building'
 import * as Types from '../../constants/types/team-building'
 import {AllowedNamespace} from '../../constants/types/team-building'
 import {validateEmailAddress} from '../../util/email-address'
+import {UserMatchMention} from '../phone-search'
 import ContinueButton from '../continue-button'
 
 type EmailInputProps = {
@@ -78,20 +79,7 @@ const EmailInput = ({namespace, search, teamBuildingSearchResults}: EmailInputPr
           </Kb.Box2>
         )}
         {!!user && canSubmit && emailHasKeybaseAccount && user.serviceMap.keybase && (
-          <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.userMatchMention}>
-            <Kb.Icon type="iconfont-check" sizeType="Tiny" color={Styles.globalColors.greenDark} />
-            <Kb.Text type="BodySmall">
-              Great! That's{' '}
-              <Kb.ConnectedUsernames
-                colorFollowing={true}
-                inline={true}
-                onUsernameClicked="profile"
-                type="BodySmallSemibold"
-                usernames={[user.serviceMap.keybase]}
-              />{' '}
-              on Keybase.
-            </Kb.Text>
-          </Kb.Box2>
+          <UserMatchMention username={user.serviceMap.keybase} />
         )}
         {/* TODO: add support for multiple emails  */}
       </Kb.Box2>

--- a/shared/team-building/email-input/index.tsx
+++ b/shared/team-building/email-input/index.tsx
@@ -12,7 +12,7 @@ import ContinueButton from '../continue-button'
 
 type EmailInputProps = {
   namespace: AllowedNamespace
-  search: (query: string, service: Types.ServiceIdWithContact) => void
+  search: (query: string, service: 'email') => void
   teamBuildingSearchResults: {[query: string]: {[service in Types.ServiceIdWithContact]: Array<Types.User>}}
 }
 
@@ -32,7 +32,7 @@ const EmailInput = ({namespace, search, teamBuildingSearchResults}: EmailInputPr
     user = teamBuildingSearchResults[emailString].keybase[0]
   }
   const canSubmit = !!user && !waiting && isEmailValid
-  const emailHasKeybaseAccount = user && user.serviceMap.keybase !== '' && emailString === user.username
+  const emailHasKeybaseAccount = user && user.serviceMap.keybase !== ''
 
   const onChange = React.useCallback(
     text => {

--- a/shared/team-building/phone-search.tsx
+++ b/shared/team-building/phone-search.tsx
@@ -9,7 +9,7 @@ import ContinueButton from './continue-button'
 
 type PhoneSearchProps = {
   onContinue: (user: User) => void
-  search: (query: string, service: ServiceIdWithContact) => void
+  search: (query: string, service: 'phone') => void
   teamBuildingSearchResults: {[query: string]: {[service in ServiceIdWithContact]: Array<User>}}
 }
 

--- a/shared/team-building/phone-search.tsx
+++ b/shared/team-building/phone-search.tsx
@@ -93,22 +93,7 @@ const PhoneSearch = (props: PhoneSearchProps) => {
             onChangeNumber={onChangeNumberCb}
             onEnterKeyDown={_onContinue}
           />
-          {state === 'resolved' && !!user && (
-            <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.userMatchMention} centerChildren={true}>
-              <Kb.Icon type="iconfont-check" sizeType="Tiny" color={Styles.globalColors.greenDark} />
-              <Kb.Text type="BodySmall">
-                Great! That's{' '}
-                <Kb.ConnectedUsernames
-                  colorFollowing={true}
-                  inline={true}
-                  onUsernameClicked="profile"
-                  type="BodySmallSemibold"
-                  usernames={[user.username]}
-                />{' '}
-                on Keybase.
-              </Kb.Text>
-            </Kb.Box2>
-          )}
+          {state === 'resolved' && !!user && <UserMatchMention username={user.username} />}
           {state === 'loading' && <Kb.ProgressIndicator type="Small" style={styles.loading} />}
         </Kb.Box2>
         <Kb.Box style={styles.spaceFillingBox} />
@@ -117,6 +102,26 @@ const PhoneSearch = (props: PhoneSearchProps) => {
     </>
   )
 }
+
+type UserMatchMentionProps = {
+  username: string
+}
+export const UserMatchMention = ({username}: UserMatchMentionProps) => (
+  <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.userMatchMention} centerChildren={true}>
+    <Kb.Icon type="iconfont-check" sizeType="Tiny" color={Styles.globalColors.greenDark} />
+    <Kb.Text type="BodySmall">
+      Great! That's{' '}
+      <Kb.ConnectedUsernames
+        colorFollowing={true}
+        inline={true}
+        onUsernameClicked="profile"
+        type="BodySmallSemibold"
+        usernames={[username]}
+      />{' '}
+      on Keybase.
+    </Kb.Text>
+  </Kb.Box2>
+)
 
 const styles = Styles.styleSheetCreate(() => ({
   button: {flexGrow: 0},


### PR DESCRIPTION
And dedup some UserMatchMention code. 

This has the side effect that when entering a query other tabs are not preloaded anymore - so we trigger a load on switching tabs with this. On the other hand, that's a perf price we no longer have to pay. cc @keybase/picnicsquad 