### PR TITLE
New Convo - Don't cutoff profile pictures with 5+ users in convo

### DIFF
--- a/shared/team-building/team-box.tsx
+++ b/shared/team-building/team-box.tsx
@@ -145,7 +145,6 @@ const styles = Styles.styleSheetCreate(() => ({
       backgroundColor: Styles.globalColors.blueGrey,
     },
     isElectron: {
-      paddingLeft: Styles.globalMargins.xsmall,
       paddingRight: Styles.globalMargins.xsmall,
     },
     isMobile: {

--- a/shared/team-building/team-box.tsx
+++ b/shared/team-building/team-box.tsx
@@ -93,7 +93,7 @@ const TeamBox = (props: Props) => {
         <Kb.ScrollView
           horizontal={true}
           ref={scrollViewRef}
-          showsHorizontalScrollIndicator={false}
+          showsHorizontalScrollIndicator={true}
           showsVerticalScrollIndicator={false}
           contentContainerStyle={styles.scrollContent}
         >
@@ -145,6 +145,7 @@ const styles = Styles.styleSheetCreate(() => ({
       backgroundColor: Styles.globalColors.blueGrey,
     },
     isElectron: {
+      paddingLeft: Styles.globalMargins.xtiny,
       paddingRight: Styles.globalMargins.xsmall,
     },
     isMobile: {


### PR DESCRIPTION
1. Reducing `paddingLeft` on the user bar to align the leftmost profile picture with the search bar
2. Shows horizontal scrollbar when scrolling on desktop. Also, on macOS when System Preferences > General > Show Scrollbars: always is enabled, no scrollbar is shown under the user bubbles. In this case, the scrollbar is rendered below both.

### Current Padding
<img width="401" alt="Screenshot 2019-09-06 10 30 00" src="https://user-images.githubusercontent.com/5200812/64436102-ad6dcb80-d091-11e9-8cc4-b06e17306be3.png">

### New Padding
<img width="401" alt="Screenshot 2019-09-06 10 28 59" src="https://user-images.githubusercontent.com/5200812/64436113-b2327f80-d091-11e9-8af2-c127b368b407.png">
