### PR TITLE
team-building dropdown use accent colors

### DIFF
--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -97,7 +97,7 @@ class Icon extends Component<Props, void> {
     }
 
     if (hasContainer) {
-      let colorStyleName
+      let colorStyleName: null | string = null // Populated if using CSS
       let hoverStyleName
       let inheritStyle
 
@@ -113,7 +113,9 @@ class Icon extends Component<Props, void> {
         const hoverColorName = this.props.onClick ? invertedColors[hoverColor] : null
         hoverStyleName = hoverColorName ? `hover_color_${hoverColorName}` : ''
         const colorName = invertedColors[color]
-        colorStyleName = `color_${colorName}`
+        if (colorName) {
+          colorStyleName = `color_${colorName}`
+        }
       }
 
       const style = Styles.collapseStyles([
@@ -138,7 +140,7 @@ class Icon extends Component<Props, void> {
             style={Styles.collapseStyles([
               style,
               this.props.padding && Shared.paddingStyles[this.props.padding],
-              this.props.color ? {color} : {}, // For colors that are not in Styles.globalColors
+              colorStyleName === null ? {color} : null, // For colors that are not in Styles.globalColors
             ])}
             className={Styles.classNames(
               'icon',

--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -24,7 +24,7 @@ class Icon extends Component<Props, void> {
   render() {
     let color = Shared.defaultColor(this.props.type)
     let hoverColor = Shared.defaultHoverColor(this.props.type)
-    let iconType = Shared.typeToIconMapper(this.props.type)
+    const iconType = Shared.typeToIconMapper(this.props.type)
 
     if (!iconType) {
       logger.warn('Null iconType passed')
@@ -138,6 +138,7 @@ class Icon extends Component<Props, void> {
             style={Styles.collapseStyles([
               style,
               this.props.padding && Shared.paddingStyles[this.props.padding],
+              this.props.color ? {color} : {}, // For colors that are not in Styles.globalColors
             ])}
             className={Styles.classNames(
               'icon',

--- a/shared/team-building/service-tab-bar.desktop.tsx
+++ b/shared/team-building/service-tab-bar.desktop.tsx
@@ -130,7 +130,7 @@ const MoreNetworkItem = (props: {service: ServiceIdWithContact}) => (
   <Kb.Box2 direction="horizontal" fullHeight={true} alignItems="center">
     <Kb.Icon
       style={styles.moreNetworkItemIcon}
-      color={Styles.globalColors.black}
+      color={serviceIdToAccentColor(props.service)}
       type={serviceIdToIconFont(props.service)}
     />
     <Kb.Text type="Body">{serviceIdToLongLabel(props.service)}</Kb.Text>


### PR DESCRIPTION
@keybase/react-hackers 

<img width="482" alt="image" src="https://user-images.githubusercontent.com/705646/64384580-10b11c80-d004-11e9-9d6d-b447a9912b66.png">
@cecileboucheron how's this? Looking at the colors in the floating menu.