### PR TITLE
de-dupe conv loader jobs

### DIFF
--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -303,7 +303,8 @@ func TestConvLoaderJobQueue(t *testing.T) {
 		cb <- ret
 	}()
 	time.Sleep(100 * time.Millisecond)
-	require.NoError(t, j.Push(newTask(types.ConvLoaderPriorityLow)))
+	_, err := j.Push(newTask(types.ConvLoaderPriorityLow))
+	require.NoError(t, err)
 	require.True(t, <-cb)
 	task, ok := j.PopFront()
 	require.True(t, ok)

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -355,6 +355,13 @@ func TestConvLoaderJobQueue(t *testing.T) {
 		require.True(t, ok)
 	}
 	require.Zero(t, j.queue.Len())
+	queued, err = j.Push(clTask{job: types.NewConvLoaderJob(convID2, &chat1.Pagination{Num: 150},
+		types.ConvLoaderPriorityHigh, types.ConvLoaderGeneric, nil)})
+	require.NoError(t, err)
+	require.True(t, queued)
+	_, ok = j.PopFront()
+	require.True(t, ok)
+	require.Zero(t, j.queue.Len())
 
 	t.Logf("test maxsize")
 	j = newJobQueue(2)

--- a/go/chat/convloader_test.go
+++ b/go/chat/convloader_test.go
@@ -47,7 +47,7 @@ func TestConvLoader(t *testing.T) {
 	defer world.Cleanup()
 
 	require.NoError(t, tc.Context().ConvLoader.Queue(ctx,
-		types.NewConvLoaderJob(res.ConvID, nil, nil, types.ConvLoaderPriorityHigh, nil)))
+		types.NewConvLoaderJob(res.ConvID, nil, types.ConvLoaderPriorityHigh, types.ConvLoaderUnique, nil)))
 	select {
 	case convID := <-listener.bgConvLoads:
 		if !convID.Eq(res.ConvID) {
@@ -97,7 +97,7 @@ func TestConvLoaderSuspend(t *testing.T) {
 		return slowRi
 	}
 	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
-		types.NewConvLoaderJob(res.ConvID, nil, nil, types.ConvLoaderPriorityHigh, nil)))
+		types.NewConvLoaderJob(res.ConvID, nil, types.ConvLoaderPriorityHigh, types.ConvLoaderUnique, nil)))
 	select {
 	case <-slowRi.callCh:
 	case <-time.After(20 * time.Second):
@@ -146,7 +146,7 @@ func TestConvLoaderAppState(t *testing.T) {
 	}
 	_ = tc.ChatG.ConvSource.(*HybridConversationSource).Clear(context.TODO(), res.ConvID, uid)
 	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
-		types.NewConvLoaderJob(res.ConvID, nil, nil, types.ConvLoaderPriorityHigh, nil)))
+		types.NewConvLoaderJob(res.ConvID, nil, types.ConvLoaderPriorityHigh, types.ConvLoaderUnique, nil)))
 	clock.BlockUntil(1)
 	clock.Advance(200 * time.Millisecond) // Get by small sleep
 	select {
@@ -186,7 +186,7 @@ func TestConvLoaderAppState(t *testing.T) {
 	}
 
 	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
-		types.NewConvLoaderJob(res.ConvID, nil, nil, types.ConvLoaderPriorityHigh, nil)))
+		types.NewConvLoaderJob(res.ConvID, nil, types.ConvLoaderPriorityHigh, types.ConvLoaderUnique, nil)))
 
 	clock.BlockUntil(1)
 	clock.Advance(200 * time.Millisecond) // Get by small sleep
@@ -268,8 +268,8 @@ func TestConvLoaderPageBack(t *testing.T) {
 	}
 
 	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
-		types.NewConvLoaderJob(res.ConvID, nil, &chat1.Pagination{Num: 1}, types.ConvLoaderPriorityHigh,
-			newConvLoaderPagebackHook(tc.Context(), 0, 1))))
+		types.NewConvLoaderJob(res.ConvID, &chat1.Pagination{Num: 1}, types.ConvLoaderPriorityHigh,
+			types.ConvLoaderGeneric, newConvLoaderPagebackHook(tc.Context(), 0, 1))))
 	for i := 0; i < 2; i++ {
 		select {
 		case <-listener.bgConvLoads:
@@ -281,8 +281,11 @@ func TestConvLoaderPageBack(t *testing.T) {
 
 func TestConvLoaderJobQueue(t *testing.T) {
 	j := newJobQueue(10)
-	newTask := func(p types.ConvLoaderPriority) clTask {
-		job := types.NewConvLoaderJob(chat1.ConversationID{}, nil, nil, p, nil)
+	convID1 := chat1.ConversationID([]byte{1, 2, 3})
+	convID2 := chat1.ConversationID([]byte{1, 2, 3, 4})
+	newTask := func(convID chat1.ConversationID, p types.ConvLoaderPriority,
+		u types.ConvLoaderUniqueness) clTask {
+		job := types.NewConvLoaderJob(convID, nil, p, u, nil)
 		return clTask{job: job}
 	}
 
@@ -303,7 +306,7 @@ func TestConvLoaderJobQueue(t *testing.T) {
 		cb <- ret
 	}()
 	time.Sleep(100 * time.Millisecond)
-	_, err := j.Push(newTask(types.ConvLoaderPriorityLow))
+	_, err := j.Push(newTask(convID1, types.ConvLoaderPriorityLow, types.ConvLoaderGeneric))
 	require.NoError(t, err)
 	require.True(t, <-cb)
 	task, ok := j.PopFront()
@@ -315,7 +318,8 @@ func TestConvLoaderJobQueue(t *testing.T) {
 	order := []types.ConvLoaderPriority{types.ConvLoaderPriorityHigh, types.ConvLoaderPriorityMedium,
 		types.ConvLoaderPriorityLow, types.ConvLoaderPriorityLow}
 	for i := len(order) - 1; i >= 0; i-- {
-		require.NoError(t, j.Push(newTask(order[i])))
+		_, err = j.Push(newTask(convID1, order[i], types.ConvLoaderUnique))
+		require.NoError(t, err)
 	}
 	for i := 0; i < len(order); i++ {
 		task, ok := j.PopFront()
@@ -325,9 +329,39 @@ func TestConvLoaderJobQueue(t *testing.T) {
 	}
 	require.Zero(t, j.queue.Len())
 
+	t.Logf("test dupe checking")
+	queued, err := j.Push(clTask{job: types.NewConvLoaderJob(convID1, nil, types.ConvLoaderPriorityHigh,
+		types.ConvLoaderGeneric, nil)})
+	require.NoError(t, err)
+	require.True(t, queued)
+	queued, err = j.Push(clTask{job: types.NewConvLoaderJob(convID2, nil, types.ConvLoaderPriorityHigh,
+		types.ConvLoaderGeneric, nil)})
+	require.NoError(t, err)
+	require.True(t, queued)
+	queued, err = j.Push(clTask{job: types.NewConvLoaderJob(convID2, &chat1.Pagination{Num: 150},
+		types.ConvLoaderPriorityHigh, types.ConvLoaderGeneric, nil)})
+	require.NoError(t, err)
+	require.True(t, queued)
+	queued, err = j.Push(clTask{job: types.NewConvLoaderJob(convID2, &chat1.Pagination{Num: 150},
+		types.ConvLoaderPriorityHigh, types.ConvLoaderGeneric, nil)})
+	require.NoError(t, err)
+	require.False(t, queued)
+	queued, err = j.Push(clTask{job: types.NewConvLoaderJob(convID2, &chat1.Pagination{Num: 150},
+		types.ConvLoaderPriorityHigh, types.ConvLoaderUnique, nil)})
+	require.NoError(t, err)
+	require.True(t, queued)
+	for i := 0; i < 4; i++ {
+		_, ok := j.PopFront()
+		require.True(t, ok)
+	}
+	require.Zero(t, j.queue.Len())
+
 	t.Logf("test maxsize")
 	j = newJobQueue(2)
-	require.NoError(t, j.Push(newTask(types.ConvLoaderPriorityLow)))
-	require.NoError(t, j.Push(newTask(types.ConvLoaderPriorityLow)))
-	require.Error(t, j.Push(newTask(types.ConvLoaderPriorityLow)))
+	_, err = j.Push(newTask(convID1, types.ConvLoaderPriorityLow, types.ConvLoaderUnique))
+	require.NoError(t, err)
+	_, err = j.Push(newTask(convID1, types.ConvLoaderPriorityLow, types.ConvLoaderUnique))
+	require.NoError(t, err)
+	_, err = j.Push(newTask(convID1, types.ConvLoaderPriorityLow, types.ConvLoaderUnique))
+	require.Error(t, err)
 }

--- a/go/chat/ephemeral_purger.go
+++ b/go/chat/ephemeral_purger.go
@@ -312,8 +312,9 @@ func (b *BackgroundEphemeralPurger) queuePurges(ctx context.Context) bool {
 }
 
 func (b *BackgroundEphemeralPurger) addPurgeToConvLoaderLocked(ctx context.Context, purgeInfo chat1.EphemeralPurgeInfo) {
-	job := types.NewConvLoaderJob(purgeInfo.ConvID, nil /* query */, nil, /* pagination */
-		types.ConvLoaderPriorityHigh, newConvLoaderEphemeralPurgeHook(b.G(), b.uid, &purgeInfo))
+	job := types.NewConvLoaderJob(purgeInfo.ConvID, &chat1.Pagination{Num: 0},
+		types.ConvLoaderPriorityHigh, types.ConvLoaderUnique,
+		newConvLoaderEphemeralPurgeHook(b.G(), b.uid, &purgeInfo))
 	if err := b.G().ConvLoader.Queue(ctx, job); err != nil {
 		b.Debug(ctx, "convLoader Queue error %s", err)
 	}

--- a/go/chat/ephemeral_purger_test.go
+++ b/go/chat/ephemeral_purger_test.go
@@ -125,10 +125,12 @@ func TestBackgroundPurge(t *testing.T) {
 	// Load our conv with the initial tlf msg
 	t.Logf("assert listener 0")
 	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
-		types.NewConvLoaderJob(conv1.ConvID, nil, &chat1.Pagination{Num: 3}, types.ConvLoaderPriorityHigh, nil)))
+		types.NewConvLoaderJob(conv1.ConvID, &chat1.Pagination{Num: 3}, types.ConvLoaderPriorityHigh,
+			types.ConvLoaderUnique, nil)))
 	assertListener(conv1.ConvID, 0)
 	require.NoError(t, tc.Context().ConvLoader.Queue(context.TODO(),
-		types.NewConvLoaderJob(conv2.ConvID, nil, &chat1.Pagination{Num: 3}, types.ConvLoaderPriorityHigh, nil)))
+		types.NewConvLoaderJob(conv2.ConvID, &chat1.Pagination{Num: 3}, types.ConvLoaderPriorityHigh,
+			types.ConvLoaderUnique, nil)))
 	assertListener(conv2.ConvID, 0)
 
 	// Nothing is up for purging yet

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -791,8 +791,8 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 			(conv.HasMemberStatus(chat1.ConversationMemberStatus_ACTIVE) ||
 				conv.HasMemberStatus(chat1.ConversationMemberStatus_PREVIEW)) &&
 			bgEnqueued < maxBgEnqueued {
-			job := types.NewConvLoaderJob(conv.GetConvID(), nil /* query */, &chat1.Pagination{Num: 50},
-				types.ConvLoaderPriorityMedium, nil)
+			job := types.NewConvLoaderJob(conv.GetConvID(), &chat1.Pagination{Num: 50},
+				types.ConvLoaderPriorityMedium, types.ConvLoaderGeneric, nil)
 			if err := s.G().ConvLoader.Queue(ctx, job); err != nil {
 				s.Debug(ctx, "fetchRemoteInbox: failed to queue conversation load: %s", err)
 			}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -3575,13 +3575,10 @@ func TestChatSrvGetThreadNonblockOldPages(t *testing.T) {
 
 		t.Logf("send a bunch of messages")
 		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT, mt)
-		// need two for new conversation, plus the gregor message
-		for i := 0; i < 2; i++ {
-			select {
-			case <-bgConvLoads:
-			case <-time.After(20 * time.Second):
-				require.Fail(t, "no bkg load")
-			}
+		select {
+		case <-bgConvLoads:
+		case <-time.After(20 * time.Second):
+			require.Fail(t, "no bkg load")
 		}
 		numMsgs := 20
 		msg := chat1.NewMessageBodyWithText(chat1.MessageText{Body: "hi"})

--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -505,8 +505,8 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 			if expunge, ok := expunges[conv.GetConvID().String()]; ok {
 				// Run expunges on the background loader
 				s.Debug(ctx, "Sync: queueing expunge background loader job: convID: %s", conv.GetConvID())
-				job := types.NewConvLoaderJob(conv.GetConvID(), nil /* query */, &chat1.Pagination{Num: num},
-					types.ConvLoaderPriorityHighest,
+				job := types.NewConvLoaderJob(conv.GetConvID(), &chat1.Pagination{Num: num},
+					types.ConvLoaderPriorityHighest, types.ConvLoaderUnique,
 					func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
 						s.Debug(ctx, "Sync: executing expunge from a sync run: convID: %s", conv.GetConvID())
 						err := s.G().ConvSource.Expunge(ctx, conv.GetConvID(), uid, expunge)
@@ -525,8 +525,9 @@ func (s *Syncer) sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 				}
 				s.Debug(ctx, "Sync: queueing background loader job: convID: %s", conv.GetConvID())
 				// Everything else just queue up here
-				job := types.NewConvLoaderJob(conv.GetConvID(), nil /* query */, &chat1.Pagination{Num: num},
-					types.ConvLoaderPriorityHigh, newConvLoaderPagebackHook(s.G(), 0, pageBack))
+				job := types.NewConvLoaderJob(conv.GetConvID(), &chat1.Pagination{Num: num},
+					types.ConvLoaderPriorityHigh, types.ConvLoaderGeneric,
+					newConvLoaderPagebackHook(s.G(), 0, pageBack))
 				if err := s.G().ConvLoader.Queue(ctx, job); err != nil {
 					s.Debug(ctx, "Sync: failed to queue conversation load: %s", err)
 				}

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -188,11 +188,18 @@ func (c ConvLoaderPriority) HigherThan(c2 ConvLoaderPriority) bool {
 	return int(c) > int(c2)
 }
 
+type ConvLoaderUniqueness int
+
+const (
+	ConvLoaderUnique ConvLoaderUniqueness = iota
+	ConvLoaderGeneric
+)
+
 type ConvLoaderJob struct {
 	ConvID       chat1.ConversationID
-	Query        *chat1.GetThreadQuery
 	Pagination   *chat1.Pagination
 	Priority     ConvLoaderPriority
+	Uniqueness   ConvLoaderUniqueness
 	PostLoadHook func(context.Context, chat1.ThreadView, ConvLoaderJob)
 }
 
@@ -201,17 +208,16 @@ func (j ConvLoaderJob) HigherPriorityThan(j2 ConvLoaderJob) bool {
 }
 
 func (j ConvLoaderJob) String() string {
-	return fmt.Sprintf("[convID: %s pagination: %s]", j.ConvID, j.Pagination)
+	return fmt.Sprintf("[convID: %s pagination: %s unique: %v]", j.ConvID, j.Pagination, j.Uniqueness)
 }
 
-func NewConvLoaderJob(convID chat1.ConversationID, query *chat1.GetThreadQuery,
-	pagination *chat1.Pagination, priority ConvLoaderPriority,
-	postLoadHook func(context.Context, chat1.ThreadView, ConvLoaderJob)) ConvLoaderJob {
+func NewConvLoaderJob(convID chat1.ConversationID, pagination *chat1.Pagination, priority ConvLoaderPriority,
+	uniqueness ConvLoaderUniqueness, postLoadHook func(context.Context, chat1.ThreadView, ConvLoaderJob)) ConvLoaderJob {
 	return ConvLoaderJob{
 		ConvID:       convID,
-		Query:        query,
 		Pagination:   pagination,
 		Priority:     priority,
+		Uniqueness:   uniqueness,
 		PostLoadHook: postLoadHook,
 	}
 }

--- a/go/chat/uithreadloader.go
+++ b/go/chat/uithreadloader.go
@@ -351,8 +351,9 @@ func (t *UIThreadLoader) dispatchOldPagesJob(ctx context.Context, uid gregor1.UI
 			Next: resultPagination.Next,
 		}
 		t.Debug(ctx, "dispatchOldPagesJob: queuing %s because of first page fetch: p: %s", convID, p)
-		if err := t.G().ConvLoader.Queue(ctx, types.NewConvLoaderJob(convID, nil /* query */, p,
-			types.ConvLoaderPriorityLow, newConvLoaderPagebackHook(t.G(), 0, 3))); err != nil {
+		if err := t.G().ConvLoader.Queue(ctx, types.NewConvLoaderJob(convID, p,
+			types.ConvLoaderPriorityLow, types.ConvLoaderGeneric,
+			newConvLoaderPagebackHook(t.G(), 0, 3))); err != nil {
 			t.Debug(ctx, "dispatchOldPagesJob: failed to queue conversation load: %s", err)
 		}
 	}


### PR DESCRIPTION
Goal is to de-dupe jobs into the conv loader, while giving special treatment to jobs that have a special post load hook.