### PR TITLE
kbfs_ops: allow a mode where favorites block on edit history

### DIFF
--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1955,6 +1955,10 @@ type InitMode interface {
 	// DoLogObfuscation indicates whether senstive data like filenames
 	// should be obfuscated in log messages.
 	DoLogObfuscation() bool
+	// BlockTLFEditHistoryIntialization indicates where we should
+	// delay initializing the edit histories of the most recent TLFs
+	// until the first request that uses them is made.
+	BlockTLFEditHistoryIntialization() bool
 	// InitialDelayForBackgroundWork indicates how long non-critical
 	// work that happens in the background on startup should wait
 	// before it begins.

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -72,8 +72,8 @@ const longOperationDebugDumpDuration = time.Minute
 
 type ctxKBFSOpsSkipEditHistoryBlockType int
 
-// This context key indicates that we should blocking on TLF edit
-// history initialization, as it would be a deadlock.
+// This context key indicates that we should not block on TLF edit
+// history initialization, as it would cause a deadlock.
 const ctxKBFSOpsSkipEditHistoryBlock ctxKBFSOpsSkipEditHistoryBlockType = 1
 
 // NewKBFSOpsStandard constructs a new KBFSOpsStandard object.

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	quotaUsageStaleTolerance = 10 * time.Second
+	initEditBlockTimeout     = 500 * time.Millisecond
 )
 
 // KBFSOpsStandard implements the KBFSOps interface, and is go-routine
@@ -60,12 +61,20 @@ type KBFSOpsStandard struct {
 
 	initLock       sync.Mutex
 	initEditCancel context.CancelFunc
+	initEditReq    chan struct{}
+	initEditDone   chan struct{}
 	initSyncCancel context.CancelFunc
 }
 
 var _ KBFSOps = (*KBFSOpsStandard)(nil)
 
 const longOperationDebugDumpDuration = time.Minute
+
+type ctxKBFSOpsSkipEditHistoryBlockType int
+
+// This context key indicates that we should blocking on TLF edit
+// history initialization, as it would be a deadlock.
+const ctxKBFSOpsSkipEditHistoryBlock ctxKBFSOpsSkipEditHistoryBlockType = 1
 
 // NewKBFSOpsStandard constructs a new KBFSOpsStandard object.
 func NewKBFSOpsStandard(appStateUpdater env.AppStateUpdater, config Config) *KBFSOpsStandard {
@@ -263,12 +272,60 @@ func (fs *KBFSOpsStandard) InvalidateNodeAndChildren(
 	return ops.InvalidateNodeAndChildren(ctx, node)
 }
 
+func (fs *KBFSOpsStandard) waitForEditHistoryInitialization(
+	ctx context.Context) {
+	if !fs.config.Mode().TLFEditHistoryEnabled() ||
+		ctx.Value(ctxKBFSOpsSkipEditHistoryBlock) != nil {
+		return
+	}
+
+	reqChan, doneChan := func() (chan<- struct{}, <-chan struct{}) {
+		fs.initLock.Lock()
+		defer fs.initLock.Unlock()
+		return fs.initEditReq, fs.initEditDone
+	}()
+	// There hasn't been a logged-in event yet, so don't wait for the
+	// edit history to be initialized.
+	if reqChan == nil {
+		return
+	}
+
+	// Send a request to unblock, if needed.
+	select {
+	case reqChan <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-doneChan:
+		// Avoid printing the log message if we don't need to wait at all.
+		return
+	default:
+	}
+
+	fs.log.CDebugf(ctx, "Waiting for the edit history to initialize")
+
+	// Don't wait too long for the edit history to be initialized, in
+	// case we are offline and someone is just trying to get the
+	// cached favorites.
+	ctx, cancel := context.WithTimeout(ctx, initEditBlockTimeout)
+	defer cancel()
+
+	// Wait for the initialization to complete.
+	select {
+	case <-doneChan:
+	case <-ctx.Done():
+	}
+}
+
 // GetFavorites implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetFavorites(ctx context.Context) (
 	[]favorites.Folder, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
+
+	fs.waitForEditHistoryInitialization(ctx)
 
 	favs, err := fs.favs.Get(ctx)
 	if err != nil {
@@ -302,6 +359,8 @@ func (fs *KBFSOpsStandard) GetFavoritesAll(ctx context.Context) (
 	keybase1.FavoritesResult, error) {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
+
+	fs.waitForEditHistoryInitialization(ctx)
 
 	favs, err := fs.favs.GetAll(ctx)
 	if err != nil {
@@ -1837,17 +1896,21 @@ func (fs *KBFSOpsStandard) onMDFlush(tlfID tlf.ID, bid kbfsmd.BranchID,
 }
 
 func (fs *KBFSOpsStandard) startInitEdit() (
-	context.Context, context.CancelFunc) {
+	ctx context.Context, cancel context.CancelFunc,
+	reqChan <-chan struct{}, doneChan chan<- struct{}) {
 	fs.initLock.Lock()
 	defer fs.initLock.Unlock()
-	ctx := CtxWithRandomIDReplayable(
+	ctx = CtxWithRandomIDReplayable(
 		context.Background(), CtxFBOIDKey, CtxFBOOpID, fs.log)
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel = context.WithCancel(ctx)
+	ctx = context.WithValue(ctx, ctxKBFSOpsSkipEditHistoryBlock, struct{}{})
 	if fs.initEditCancel != nil {
 		fs.initEditCancel()
 	}
 	fs.initEditCancel = cancel
-	return ctx, cancel
+	fs.initEditReq = make(chan struct{}, 1)
+	fs.initEditDone = make(chan struct{})
+	return ctx, cancel, fs.initEditReq, fs.initEditDone
 }
 
 func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
@@ -1865,15 +1928,25 @@ func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
 		return
 	}
 
-	ctx, cancel := fs.startInitEdit()
+	ctx, cancel, reqChan, doneChan := fs.startInitEdit()
 	defer cancel()
+	defer close(doneChan)
 
-	time.Sleep(fs.config.Mode().InitialDelayForBackgroundWork())
-
-	select {
-	case <-ctx.Done():
-		return
-	default:
+	doBlock := fs.config.Mode().BlockTLFEditHistoryIntialization()
+	if doBlock {
+		fs.log.CDebugf(ctx, "Waiting for a TLF edit history request")
+		select {
+		case <-reqChan:
+		case <-ctx.Done():
+			return
+		}
+	} else {
+		time.Sleep(fs.config.Mode().InitialDelayForBackgroundWork())
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 	}
 
 	fs.log.CDebugf(ctx, "Querying the kbfs-edits inbox for new TLFs")
@@ -1906,7 +1979,9 @@ func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
 				"Handle %s for existing folder unexpectedly has no TLF ID",
 				h.GetCanonicalName())
 		}
-		time.Sleep(fs.config.Mode().BackgroundWorkPeriod())
+		if !doBlock {
+			time.Sleep(fs.config.Mode().BackgroundWorkPeriod())
+		}
 	}
 }
 

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -175,6 +175,10 @@ func (md modeDefault) DoLogObfuscation() bool {
 	return true
 }
 
+func (md modeDefault) BlockTLFEditHistoryIntialization() bool {
+	return false
+}
+
 func (md modeDefault) InitialDelayForBackgroundWork() time.Duration {
 	return 0
 }
@@ -336,6 +340,11 @@ func (mm modeMinimal) DoRefreshFavoritesOnInit() bool {
 
 func (mm modeMinimal) DoLogObfuscation() bool {
 	return true
+}
+
+func (mm modeMinimal) BlockTLFEditHistoryIntialization() bool {
+	// Never used.
+	return false
 }
 
 func (mm modeMinimal) InitialDelayForBackgroundWork() time.Duration {
@@ -523,6 +532,14 @@ func (mc modeConstrained) SendEditNotificationsEnabled() bool {
 }
 
 func (mc modeConstrained) LocalHTTPServerEnabled() bool {
+	return true
+}
+
+func (mc modeConstrained) BlockTLFEditHistoryIntialization() bool {
+	// In constrained mode, we don't want to incur this work in the
+	// background when it might interfere with other foreground tasks.
+	// Instead, make requests that depend on the edit history block
+	// and effectively foreground that initialization work.
 	return true
 }
 


### PR DESCRIPTION
To avoid having to initialize edit histories in the background on startup/login/reconnect -- instead we trigger it only when it is requested.

Turn this mode on for the constrained/mobile setup.

Issue: HOTPOT-759