### PR TITLE
some chat dark colors

### DIFF
--- a/shared/chat/conversation/command-status/index.stories.tsx
+++ b/shared/chat/conversation/command-status/index.stories.tsx
@@ -3,7 +3,7 @@ import * as Kb from '../../../common-adapters'
 import * as Sb from '../../../stories/storybook'
 import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
 
-import CommandStatus from './index'
+import CommandStatus from '.'
 
 const errorProps = {
   actions: [],

--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -169,7 +169,8 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
     return res
   }
 
-  _onSelectTab = tab => {
+  _onSelectTab = (tab: React.ReactNode) => {
+    // @ts-ignore TODO avoid using key on a node
     this.props.onSelectTab(tab.key)
   }
   _renderHeader = () => {
@@ -359,7 +360,6 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
   }
 }
 
-const border = `1px solid ${Styles.globalColors.black_10}`
 const styles = Styles.styleSheetCreate(
   () =>
     ({
@@ -371,7 +371,7 @@ const styles = Styles.styleSheetCreate(
         common: {alignItems: 'stretch', flex: 1, paddingBottom: Styles.globalMargins.tiny},
         isElectron: {
           backgroundColor: Styles.globalColors.white,
-          borderLeft: border,
+          borderLeft: `1px solid ${Styles.globalColors.black_10}`,
         },
       }),
       tabContainerStyle: {

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -375,7 +375,7 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       cancelEditingText: {
-        color: Styles.globalColors.blackOrBlack,
+        color: Styles.globalColors.whiteOrBlack,
       },
       container: {
         ...Styles.globalStyles.flexBoxColumn,

--- a/shared/common-adapters/relative-popup-hoc.desktop.tsx
+++ b/shared/common-adapters/relative-popup-hoc.desktop.tsx
@@ -347,13 +347,17 @@ function ModalPositionRelative<PP>(
     )
 
     componentDidMount() {
-      document.body && document.body.addEventListener('click', this._handleClick)
-      document.body && document.body.addEventListener('scroll', this._handleScroll, true)
+      const node = document.body
+      if (!__STORYBOOK__ && node) {
+        node.addEventListener('click', this._handleClick, false)
+      }
     }
 
     componentWillUnmount() {
-      document.body && document.body.removeEventListener('click', this._handleClick)
-      document.body && document.body.removeEventListener('scroll', this._handleScroll, true)
+      const node = document.body
+      if (!__STORYBOOK__ && node) {
+        node.removeEventListener('click', this._handleClick, false)
+      }
     }
 
     _setRef = r => {

--- a/shared/stories/index.desktop.tsx
+++ b/shared/stories/index.desktop.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 import * as React from 'react'
 import * as Sb from './storybook'
+import * as Kb from '../common-adapters'
 import {addDecorator} from '@storybook/react'
 import sharedStories from './shared-stories'
 import desktopStories from './platform-stories.desktop'
@@ -24,25 +25,6 @@ const filteredStories = Object.keys(stories).reduce(
   filter ? {} : stories
 )
 
-function useInterval(callback: () => void, delay: number | null) {
-  const savedCallback = React.useRef<() => void>()
-
-  React.useEffect(() => {
-    savedCallback.current = callback
-  }, [callback])
-
-  React.useEffect(() => {
-    function tick() {
-      const c = savedCallback.current
-      c && c()
-    }
-    if (delay !== null) {
-      let id = setInterval(tick, delay)
-      return () => clearInterval(id)
-    } else return undefined
-  }, [delay])
-}
-
 // keep modes in the module so its kept between stories
 let _darkMode = false
 let _autoSwap = false
@@ -56,13 +38,13 @@ const RootWrapper = ({children}) => {
     _autoSwap = autoSwap
   }, [darkMode, autoSwap])
 
-  useInterval(
+  Kb.useInterval(
     () => {
       const next = !darkMode
-      setDarkMode(next)
       _setSystemIsDarkMode(next)
+      setDarkMode(next)
     },
-    autoSwap ? 1000 : null
+    autoSwap ? 1000 : undefined
   )
 
   if (__STORYSHOT__) {
@@ -74,11 +56,15 @@ const RootWrapper = ({children}) => {
     )
   } else {
     return (
-      <div
-        key={darkMode ? 'dark' : 'light'}
-        style={{height: '100%', width: '100%'}}
-        className={darkMode ? 'darkMode' : ''}
-      >
+      <>
+        <div
+          key={darkMode ? 'dark' : 'light'}
+          style={{height: '100%', width: '100%'}}
+          className={darkMode ? 'darkMode' : ''}
+        >
+          {children}
+          <div id="modal-root" />
+        </div>
         <div
           style={{
             border: 'red 1px solid',
@@ -90,21 +76,20 @@ const RootWrapper = ({children}) => {
           }}
           title="Shift+Click to turn on auto"
           onClick={(e: React.MouseEvent) => {
+            e.stopPropagation()
             if (e.shiftKey) {
               setAutoSwap(!autoSwap)
             } else {
               const next = !darkMode
-              setDarkMode(next)
               _setSystemIsDarkMode(next)
+              setDarkMode(next)
               setAutoSwap(false)
             }
           }}
         >
           {`${darkMode ? 'Dark Mode' : 'Light Mode'}${autoSwap ? '-auto' : ''}`}
         </div>
-        {children}
-        <div id="modal-root" />
-      </div>
+      </>
     )
   }
 }

--- a/shared/stories/storybook.desktop.tsx
+++ b/shared/stories/storybook.desktop.tsx
@@ -3,6 +3,7 @@ import * as PropProviders from './prop-providers'
 
 const createPropProviderWithCommon = PropProviders.createPropProviderWithCommon
 const createStoreWithCommon = PropProviders.createStoreWithCommon
+
 export {PropProviders, createPropProviderWithCommon, createStoreWithCommon}
 export {storiesOf} from '@storybook/react'
 export {action} from '@storybook/addon-actions'

--- a/shared/styles/colors.tsx
+++ b/shared/styles/colors.tsx
@@ -132,14 +132,14 @@ export const colors = {
 export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   black: 'rgba(255, 255, 255, 0.85)',
   get blackOrBlack() {
-    return this.black
+    return colors.black
   },
   get blackOrWhite() {
-    return this.white
+    return colors.white
   },
   black_05: 'rgba(255, 255, 255, 0.05)',
   get black_05OrBlack_60() {
-    return this.black_60
+    return colors.black_60
   },
   black_05_on_white: 'rgb(13, 13, 13)',
   black_10: 'rgba(255, 255, 255, 0.10)',
@@ -150,10 +150,10 @@ export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   black_40: 'rgba(255, 255, 255, 0.40)',
   black_50: 'rgba(255, 255, 255, 0.50)',
   get black_50OrWhite() {
-    return this.white
+    return colors.white
   },
   get black_50OrWhite_75() {
-    return this.white_75
+    return colors.white_75
   },
   black_50_on_white: 'rgb(128, 128, 128)',
   black_60: 'rgba(255, 255, 255, 0.60)',
@@ -191,7 +191,7 @@ export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   greenLight: '#B7EED9',
   greenLighter: '#E8FAF6',
   get greenOrGreenLighter() {
-    return this.green
+    return colors.greenLighter
   },
   grey: '#333',
   greyDark: '#666',
@@ -202,7 +202,7 @@ export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   purple: '#8852ff',
   purpleDark: '#6d3fd1',
   get purpleDarkOrWhite() {
-    return this.white
+    return colors.white
   },
   purpleDarker: '#5128a8',
   purpleLight: '#9d70ff',
@@ -210,21 +210,21 @@ export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   purple_01: 'rgba(132, 82, 255, 0.01)',
   purple_10: 'rgba(132, 82, 255, 0.1)',
   get purple_10OrPurple() {
-    return this.purple
+    return colors.purple
   },
   purple_30: 'rgba(132, 82, 255, 0.3)',
   purple_40: 'rgba(132, 82, 255, 0.4)',
   red: '#ff4d61',
   redDark: '#eb253b',
   get redDarkOrWhite() {
-    return this.white
+    return colors.white
   },
   redDarker: '#bd0b1f',
   redLight: '#FFCAC1',
   redLighter: '#2d2d2d',
   red_10: 'rgba(255,0,0,0.1)',
   get red_10OrRed() {
-    return this.red
+    return colors.red
   },
   red_20: 'rgba(255,0,0,0.2)',
   red_75: 'rgba(255,0,0,0.75)',
@@ -233,10 +233,10 @@ export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   transparent_on_white: '#191919',
   white: '#191919',
   get whiteOrBlack() {
-    return this.black
+    return colors.black
   },
   get whiteOrGreenDark() {
-    return this.white
+    return colors.greenDark
   },
   white_0: 'rgba(25, 25, 25, 0)',
   white_0_on_white: '#191919',
@@ -244,7 +244,7 @@ export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   white_20_on_white: '#191919',
   white_40: 'rgba(25, 25, 25, 0.40)',
   get white_40OrBlack_60() {
-    return this.black_60
+    return colors.black_60
   },
   white_40_on_white: '#191919',
   white_75: 'rgba(25, 25, 25, 0.75)',


### PR DESCRIPTION
This updates some chat views and fixes some issues w/ the storybook

- [x] fix auto dark flip in storybook
- [x] fix popup handling in stories
- [x] fix the 'multiColors' aka in master `blackOrWhite` was using this.black in `colors` and `this.white` in `darkColors` but this.white in darkColors is black, so its really blackOrBlack, which isn't what we want. Also some colors didn't match the names which shouldn't be the case. If the color is right the name is wrong