### PR TITLE
prefetcher_test: fix a test flake, and a data race

### DIFF
--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -131,7 +131,17 @@ func testPrefetcherCheckGet(
 		err := dbcw.waitForDeletes(context.Background())
 		require.NoError(t, err)
 	}
-	require.Equal(t, expectedBlock, block)
+	if expectedFB, ok := expectedBlock.(*data.FileBlock); ok &&
+		!expectedFB.IsIndirect() {
+		fb, ok := block.(*data.FileBlock)
+		require.True(t, ok)
+		// For direct file blocks, the unexported hash pointer might
+		// differ between two instances of the same block, so just
+		// check the contents explicitly.
+		require.Equal(t, expectedFB.Contents, fb.Contents)
+	} else {
+		require.Equal(t, expectedBlock, block)
+	}
 	prefetchStatus, err := dcache.GetPrefetchStatus(
 		context.Background(), tlfID, ptr.ID, DiskBlockAnyCache)
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -1857,8 +1857,13 @@ func TestPrefetcherReschedules(t *testing.T) {
 		context.Background(), individualTestTimeout)
 	defer cancel()
 	kmd := makeKMD()
+
+	// Declare and defer the close of this channel before the defer of
+	// the prefetcher shutdown, to avoid data races where the
+	// prefetcher could send to the channel after it's closed.
 	prefetchDoneCh := make(chan struct{})
 	defer close(prefetchDoneCh)
+
 	prefetchSyncCh := make(chan struct{})
 	defer shutdownPrefetcherTest(t, q, prefetchSyncCh)
 	q.TogglePrefetcher(true, prefetchSyncCh, nil)


### PR DESCRIPTION
* Don't close done ch until prefetcher is shut down, otherwise there could be a data race.
* Compare contents of file blocks, not instances. In these tests, there's a rare race where a file block in the cache is constructed from an encrypted disk-block-cache version, rather than being the specific instance created by the test and returned by the fake block getter.  That means that the hash pointer inside each block is different, and thus the generic equality test will fail. Get around that by just checking the (randomly-generated) contents for each direct file block.  It's not perfect, but seems good enough.


Issue: HOTPOT-782