### PR TITLE
teams: fix bug in loader w/ hidden holes

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3406,3 +3406,7 @@ func (r APIUserSearchResult) GetStringIDForCompare() string {
 func NewPathWithKbfsPath(path string) Path {
 	return NewPathWithKbfs(KBFSPath{Path: path})
 }
+
+func (p PerTeamKey) Equal(q PerTeamKey) bool {
+	return p.EncKID.Equal(q.EncKID) && p.SigKID.Equal(q.SigKID)
+}

--- a/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/ptk_clash.json
+++ b/go/vendor/github.com/keybase/keybase-test-vectors/teamchains/ptk_clash.json
@@ -1,0 +1,288 @@
+{
+    "log": [
+        "user:herb key:default",
+        "link team:cabal type:root",
+        "link team:cabal type:rotate_key",
+        "link team:cabal type:rotate_key"
+    ],
+    "teams": {
+        "cabal": {
+            "id": "2123209b98b16083c69c91152b861724",
+            "links": [
+                {
+                    "seqno": 1,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTEKZcCAcDEILTUusTrNSdT1hqPqxs1AlLGac1G8/YUXk/24dUW5yUwIQHCo3NpZ8RA/k6seZpqtWm46y8VLkYxvbo3IkKw0WJGwY0ILeXnzO59ZisKEq2XHBIKaUp8VYsS9+4p6h1OBBDyfwtr14jJDKhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\",\"members\":{\"owner\":[\"25852c87d6e47fb8d7d55400be9c7a19\"]},\"name\":\"cabal\",\"per_team_key\":{\"encryption_kid\":\"0121df1f90362f46c30299233352f173642afd4106fea31a8a69c218b5fefe3a68460a\",\"generation\":1,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg/7SBjzewx/7nB4LRxRI1ldcYu5F48eELOFHohQ23nR8Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWRmMWY5MDM2MmY0NmMzMDI5OTIzMzM1MmYxNzM2NDJhZmQ0MTA2ZmVhMzFhOGE2OWMyMThiNWZlZmUzYTY4NDYwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmZmI0ODE4ZjM3YjBjN2ZlZTcwNzgyZDFjNTEyMzU5NWQ3MThiYjkxNzhmMWUxMGIzODUxZTg4NTBkYjc5ZDFmMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MDA1NzAwMDEsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAZOcA40na0br/9M7PkVRQM4K+xC5WNvGK91Xl2djr0ZIOt4+fMCkYNubvYKvwF+Qy9RybffaRQP5/6SthqofgAqhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B\",\"signing_kid\":\"0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a\"}},\"type\":\"team.root\",\"version\":2},\"ctime\":1500570001,\"expire_in\":157680000,\"seq_type\":1,\"seqno\":1,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 1,
+                        "ctime": 1500570001,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.root",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724",
+                                "name": "cabal",
+                                "members": {
+                                    "owner": [
+                                        "25852c87d6e47fb8d7d55400be9c7a19"
+                                    ]
+                                },
+                                "per_team_key": {
+                                    "reverse_sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg/7SBjzewx/7nB4LRxRI1ldcYu5F48eELOFHohQ23nR8Kp3BheWxvYWTFA3N7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMTAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwibWVtYmVycyI6eyJvd25lciI6WyIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSJdfSwibmFtZSI6ImNhYmFsIiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWRmMWY5MDM2MmY0NmMzMDI5OTIzMzM1MmYxNzM2NDJhZmQ0MTA2ZmVhMzFhOGE2OWMyMThiNWZlZmUzYTY4NDYwYSIsImdlbmVyYXRpb24iOjEsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBmZmI0ODE4ZjM3YjBjN2ZlZTcwNzgyZDFjNTEyMzU5NWQ3MThiYjkxNzhmMWUxMGIzODUxZTg4NTBkYjc5ZDFmMGEifX0sInR5cGUiOiJ0ZWFtLnJvb3QiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MDA1NzAwMDEsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJzZXFfdHlwZSI6MSwic2Vxbm8iOjEsInRhZyI6InNpZ25hdHVyZSJ9o3NpZ8RAZOcA40na0br/9M7PkVRQM4K+xC5WNvGK91Xl2djr0ZIOt4+fMCkYNubvYKvwF+Qy9RybffaRQP5/6SthqofgAqhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                                    "generation": 1,
+                                    "encryption_kid": "0121df1f90362f46c30299233352f173642afd4106fea31a8a69c218b5fefe3a68460a",
+                                    "signing_kid": "0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a"
+                                }
+                            }
+                        },
+                        "seq_type": 1
+                    },
+                    "debug_link_id": "974b2f9209042e595b4df291c8f80a32556bf7b28d2384c7315e6af40d7795d9",
+                    "hidden_is_fresh": true
+                },
+                {
+                    "seqno": 2,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTESpcCAsQgl0svkgkELllbTfKRyPgKMlVr97KNI4THMV5q9A13ldnEIBb36jtJshfL6uq2COw75Gt2FysmD2WjLwUGCkB4qGXOJAHCo3NpZ8RA3B+Vt0zAwNRQqpIz0riX/dwbh6rt1bpQerPcodCVEH+xxL3FagwN+lFpL9UjTOMjZfBlavqAdQgT3hvMc+yFDqhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\",\"per_team_key\":{\"encryption_kid\":\"0121b5aa7bf32d238dbe43097516c61d072532fbdb9c8be488215a2870a4638d3f7a0a\",\"generation\":2,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg6Tk9oPWdKOmlJ+fOxBr6rt0vyyGKwolR55gmtB/yp6EKp3BheWxvYWTFA3t7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMjAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWI1YWE3YmYzMmQyMzhkYmU0MzA5NzUxNmM2MWQwNzI1MzJmYmRiOWM4YmU0ODgyMTVhMjg3MGE0NjM4ZDNmN2EwYSIsImdlbmVyYXRpb24iOjIsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBlOTM5M2RhMGY1OWQyOGU5YTUyN2U3Y2VjNDFhZmFhZWRkMmZjYjIxOGFjMjg5NTFlNzk4MjZiNDFmZjJhN2ExMGEifX0sInR5cGUiOiJ0ZWFtLnJvdGF0ZV9rZXkiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MDA1NzAwMDEsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjoiOTc0YjJmOTIwOTA0MmU1OTViNGRmMjkxYzhmODBhMzI1NTZiZjdiMjhkMjM4NGM3MzE1ZTZhZjQwZDc3OTVkOSIsInNlcV90eXBlIjoxLCJzZXFubyI6MiwidGFnIjoic2lnbmF0dXJlIn2jc2lnxEBJdHMNw7byQkaVskZrHbCsy/ejxHnKsRmW2RhcS4MLA6xB11RFiGjLz1/ZBTRG07nHN5WUgjD511Va46atmBsJqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=\",\"signing_kid\":\"0120e9393da0f59d28e9a527e7cec41afaaedd2fcb218ac28951e79826b41ff2a7a10a\"}},\"type\":\"team.rotate_key\",\"version\":2},\"ctime\":1500570001,\"expire_in\":157680000,\"prev\":\"974b2f9209042e595b4df291c8f80a32556bf7b28d2384c7315e6af40d7795d9\",\"seq_type\":1,\"seqno\":2,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 2,
+                        "prev": "974b2f9209042e595b4df291c8f80a32556bf7b28d2384c7315e6af40d7795d9",
+                        "ctime": 1500570001,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.rotate_key",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724",
+                                "per_team_key": {
+                                    "reverse_sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg6Tk9oPWdKOmlJ+fOxBr6rt0vyyGKwolR55gmtB/yp6EKp3BheWxvYWTFA3t7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMjAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMWI1YWE3YmYzMmQyMzhkYmU0MzA5NzUxNmM2MWQwNzI1MzJmYmRiOWM4YmU0ODgyMTVhMjg3MGE0NjM4ZDNmN2EwYSIsImdlbmVyYXRpb24iOjIsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjBlOTM5M2RhMGY1OWQyOGU5YTUyN2U3Y2VjNDFhZmFhZWRkMmZjYjIxOGFjMjg5NTFlNzk4MjZiNDFmZjJhN2ExMGEifX0sInR5cGUiOiJ0ZWFtLnJvdGF0ZV9rZXkiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MDA1NzAwMDEsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjoiOTc0YjJmOTIwOTA0MmU1OTViNGRmMjkxYzhmODBhMzI1NTZiZjdiMjhkMjM4NGM3MzE1ZTZhZjQwZDc3OTVkOSIsInNlcV90eXBlIjoxLCJzZXFubyI6MiwidGFnIjoic2lnbmF0dXJlIn2jc2lnxEBJdHMNw7byQkaVskZrHbCsy/ejxHnKsRmW2RhcS4MLA6xB11RFiGjLz1/ZBTRG07nHN5WUgjD511Va46atmBsJqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=",
+                                    "generation": 2,
+                                    "encryption_kid": "0121b5aa7bf32d238dbe43097516c61d072532fbdb9c8be488215a2870a4638d3f7a0a",
+                                    "signing_kid": "0120e9393da0f59d28e9a527e7cec41afaaedd2fcb218ac28951e79826b41ff2a7a10a"
+                                }
+                            }
+                        },
+                        "seq_type": 1
+                    },
+                    "debug_link_id": "fb4cc5e06d83d67d326108623a1d1ba4e3f0b2d34d477da499c12f38fe410e4b",
+                    "hidden_is_fresh": true
+                },
+                {
+                    "seqno": 3,
+                    "sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgEmDPFbgK6vLCw2Lw3oi7xAJy1TTReblMBFel5YT80YYKp3BheWxvYWTESpcCA8Qg+0zF4G2D1n0yYQhiOh0bpOPwstNNR32kmcEvOP5BDkvEIJurJYaF3oUTktz3mAyHtP4cEWRmwKr0Y+CPTZ01ovk7JAHCo3NpZ8RAfZ2m4kMh+Swil/ilZAB8tGDIoDR4It6LuM01k+Cq2p9nTi9+xvDPLLQjhsmztWUxnpRy1oz60IxqU48aeJ9IAqhzaWdfdHlwZSCjdGFnzQICp3ZlcnNpb24B",
+                    "payload_json": "{\"body\":{\"key\":{\"kid\":\"01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a\",\"uid\":\"25852c87d6e47fb8d7d55400be9c7a19\",\"username\":\"herb\"},\"merkle_root\":{\"ctime\":1500570001,\"hash\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"hash_meta\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd3000\",\"seqno\":8001},\"team\":{\"id\":\"2123209b98b16083c69c91152b861724\",\"per_team_key\":{\"encryption_kid\":\"012143f30a949ebc288dcf6bd2eee8fd2a9e5641b718ff61d860e82ba47c2756ca590a\",\"generation\":2,\"reverse_sig\":\"g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgRHpyHOd8p2pTsw/ZTzktbbLSwQPYGMqNyqgSCVXZlfQKp3BheWxvYWTFA3t7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMzAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTQzZjMwYTk0OWViYzI4OGRjZjZiZDJlZWU4ZmQyYTllNTY0MWI3MThmZjYxZDg2MGU4MmJhNDdjMjc1NmNhNTkwYSIsImdlbmVyYXRpb24iOjIsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjA0NDdhNzIxY2U3N2NhNzZhNTNiMzBmZDk0ZjM5MmQ2ZGIyZDJjMTAzZDgxOGNhOGRjYWE4MTIwOTU1ZDk5NWY0MGEifX0sInR5cGUiOiJ0ZWFtLnJvdGF0ZV9rZXkiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MDA1NzAwMDEsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjoiZmI0Y2M1ZTA2ZDgzZDY3ZDMyNjEwODYyM2ExZDFiYTRlM2YwYjJkMzRkNDc3ZGE0OTljMTJmMzhmZTQxMGU0YiIsInNlcV90eXBlIjoxLCJzZXFubyI6MywidGFnIjoic2lnbmF0dXJlIn2jc2lnxEBu/fQHIVYHhvec9zXPITsGoXR+VFE/27I0n1jiV6xggg8bYpzmX9xswhWe/fDvMiqYXjnrvnzyzFPrpoFVv94IqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=\",\"signing_kid\":\"0120447a721ce77ca76a53b30fd94f392d6db2d2c103d818ca8dcaa8120955d995f40a\"}},\"type\":\"team.rotate_key\",\"version\":2},\"ctime\":1500570001,\"expire_in\":157680000,\"prev\":\"fb4cc5e06d83d67d326108623a1d1ba4e3f0b2d34d477da499c12f38fe410e4b\",\"seq_type\":1,\"seqno\":3,\"tag\":\"signature\"}",
+                    "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                    "version": 2,
+                    "debug_payload": {
+                        "seqno": 3,
+                        "prev": "fb4cc5e06d83d67d326108623a1d1ba4e3f0b2d34d477da499c12f38fe410e4b",
+                        "ctime": 1500570001,
+                        "tag": "signature",
+                        "expire_in": 157680000,
+                        "body": {
+                            "version": 2,
+                            "type": "team.rotate_key",
+                            "key": {
+                                "username": "herb",
+                                "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+                                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a"
+                            },
+                            "merkle_root": {
+                                "ctime": 1500570001,
+                                "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                                "hash_meta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd3000",
+                                "seqno": 8001
+                            },
+                            "team": {
+                                "id": "2123209b98b16083c69c91152b861724",
+                                "per_team_key": {
+                                    "reverse_sig": "g6Rib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEgRHpyHOd8p2pTsw/ZTzktbbLSwQPYGMqNyqgSCVXZlfQKp3BheWxvYWTFA3t7ImJvZHkiOnsia2V5Ijp7ImtpZCI6IjAxMjAxMjYwY2YxNWI4MGFlYWYyYzJjMzYyZjBkZTg4YmJjNDAyNzJkNTM0ZDE3OWI5NGMwNDU3YTVlNTg0ZmNkMTg2MGEiLCJ1aWQiOiIyNTg1MmM4N2Q2ZTQ3ZmI4ZDdkNTU0MDBiZTljN2ExOSIsInVzZXJuYW1lIjoiaGVyYiJ9LCJtZXJrbGVfcm9vdCI6eyJjdGltZSI6MTUwMDU3MDAwMSwiaGFzaCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiaGFzaF9tZXRhIjoiY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkY2RjZGNkMzAwMCIsInNlcW5vIjo4MDAxfSwidGVhbSI6eyJpZCI6IjIxMjMyMDliOThiMTYwODNjNjljOTExNTJiODYxNzI0IiwicGVyX3RlYW1fa2V5Ijp7ImVuY3J5cHRpb25fa2lkIjoiMDEyMTQzZjMwYTk0OWViYzI4OGRjZjZiZDJlZWU4ZmQyYTllNTY0MWI3MThmZjYxZDg2MGU4MmJhNDdjMjc1NmNhNTkwYSIsImdlbmVyYXRpb24iOjIsInJldmVyc2Vfc2lnIjpudWxsLCJzaWduaW5nX2tpZCI6IjAxMjA0NDdhNzIxY2U3N2NhNzZhNTNiMzBmZDk0ZjM5MmQ2ZGIyZDJjMTAzZDgxOGNhOGRjYWE4MTIwOTU1ZDk5NWY0MGEifX0sInR5cGUiOiJ0ZWFtLnJvdGF0ZV9rZXkiLCJ2ZXJzaW9uIjoyfSwiY3RpbWUiOjE1MDA1NzAwMDEsImV4cGlyZV9pbiI6MTU3NjgwMDAwLCJwcmV2IjoiZmI0Y2M1ZTA2ZDgzZDY3ZDMyNjEwODYyM2ExZDFiYTRlM2YwYjJkMzRkNDc3ZGE0OTljMTJmMzhmZTQxMGU0YiIsInNlcV90eXBlIjoxLCJzZXFubyI6MywidGFnIjoic2lnbmF0dXJlIn2jc2lnxEBu/fQHIVYHhvec9zXPITsGoXR+VFE/27I0n1jiV6xggg8bYpzmX9xswhWe/fDvMiqYXjnrvnzyzFPrpoFVv94IqHNpZ190eXBlIKN0YWfNAgKndmVyc2lvbgE=",
+                                    "generation": 2,
+                                    "encryption_kid": "012143f30a949ebc288dcf6bd2eee8fd2a9e5641b718ff61d860e82ba47c2756ca590a",
+                                    "signing_kid": "0120447a721ce77ca76a53b30fd94f392d6db2d2c103d818ca8dcaa8120955d995f40a"
+                                }
+                            }
+                        },
+                        "seq_type": 1
+                    },
+                    "debug_link_id": "01d2c94ebb571c20665024302295c0068acc6d5649a28502b8637cfc2e851fbc",
+                    "hidden_is_fresh": true
+                }
+            ],
+            "team_key_boxes": [
+                {
+                    "seqno": 1,
+                    "chain_type": 3,
+                    "box": {
+                        "nonce": "S8fEvwgGwCJ7Vw5z8+9Dj7VM0xkAAAAB",
+                        "sender_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a",
+                        "generation": 1,
+                        "ctext": "ZpCKhZpQEohsfIR72rjZWPZ7cgDw9wF7OvS2dygQRo9hbQ9/0nKCQrRvCvZsxtvZ",
+                        "per_user_key_seqno": 1
+                    },
+                    "prev": null
+                },
+                {
+                    "seqno": 2,
+                    "chain_type": 3,
+                    "box": {
+                        "nonce": "jqVJ41KFkGoYW3nplq40vMIMHBkAAAAB",
+                        "sender_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a",
+                        "generation": 2,
+                        "ctext": "qDSrbDkwV5z/vY07QF1EKHMGVdPbAddz22TC+9CmAHVsyB/riuviv8vm4AlmDzco",
+                        "per_user_key_seqno": 1
+                    },
+                    "prev": "kwHEGI6lSeNShZBqGFt56ZauNLzCDBwZAAAAAMQwoFn2M8kthVv7ZQTma8v6S0eP7TAqK6gVJpKyI5db0kqxHoZeWRFyPDdWLKyh51I0"
+                },
+                {
+                    "seqno": 3,
+                    "chain_type": 3,
+                    "box": {
+                        "nonce": "1d0FPXKVnhKRRb0Z0Gm+8yLOZzkAAAAB",
+                        "sender_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a",
+                        "generation": 2,
+                        "ctext": "eMLtsNErUy3lnMnuh1WcrkSlF9uFSE/bzS/tpElyCEwa5GTvHJmq3ZRQovKqHFvX",
+                        "per_user_key_seqno": 1
+                    },
+                    "prev": "kwHEGNXdBT1ylZ4SkUW9GdBpvvMizmc5AAAAAMQwpqaPFFgGykLpbDvFocAx8cWMMlV4c0QxTZ0vbMXdzUWJ5af34IGh04z9J078WsBy"
+                }
+            ],
+            "debug_tk_secs": [
+                [
+                    "7f246caab1b80f43c8ff7747bea79c52617c7e066aa8220a66c4645cdca95492",
+                    "6cd9404b7b6def70d9ad80b02f93d1fb90f25614da0ca264f42c8da61ee41a9a",
+                    "22dbd1ab374a396e0f13cbb85634a5495993f41de616cf9f5bead3dcd36e8b6d"
+                ]
+            ],
+            "debug_tk_sig_kids": [
+                [
+                    "0120ffb4818f37b0c7fee70782d1c5123595d718bb9178f1e10b3851e8850db79d1f0a",
+                    "0120e9393da0f59d28e9a527e7cec41afaaedd2fcb218ac28951e79826b41ff2a7a10a",
+                    "0120447a721ce77ca76a53b30fd94f392d6db2d2c103d818ca8dcaa8120955d995f40a"
+                ]
+            ],
+            "hidden": [],
+            "ratchet_blinding_keys": "kA=="
+        }
+    },
+    "users": {
+        "herb": {
+            "uid": "25852c87d6e47fb8d7d55400be9c7a19",
+            "eldest_seqno": 1,
+            "puk_secrets": {
+                "1": "3759ea1c8527a0ecca7be3a447fa35a5ed64969e1651b4c1825dac09b5b6fb42"
+            },
+            "link_map": {
+                "1": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+            },
+            "debug_puk_enc_kid": "012192b181dd77c93ceb4dcfd773c846f0a51cd04ee2c18a6d7f84e0c43217a7a54c0a"
+        }
+    },
+    "key_owners": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": "herb"
+    },
+    "key_pubkeyv2nacls": {
+        "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a": {
+            "deviceType": "desktop",
+            "deviceDescription": "home thing",
+            "deviceID": "fbd762facdfad44709aef63a9a8cdf18",
+            "base": {
+                "eTime": 2005146762000,
+                "cTime": 1500570762000,
+                "isEldest": true,
+                "isSibkey": true,
+                "kid": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                "provisioning": {
+                    "sigChainLocation": {
+                        "seqno": 1,
+                        "seqType": 1
+                    },
+                    "signingKID": "01201260cf15b80aeaf2c2c362f0de88bbc40272d534d179b94c0457a5e584fcd1860a",
+                    "time": 0,
+                    "firstAppearedUnverified": 0,
+                    "prevMerkleRootSigned": {
+                        "hashMeta": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc500",
+                        "seqno": 0
+                    }
+                }
+            }
+        }
+    },
+    "team_merkle": {
+        "2123209b98b16083c69c91152b861724": {
+            "seqno": 3,
+            "link_id": "01d2c94ebb571c20665024302295c0068acc6d5649a28502b8637cfc2e851fbc",
+            "hidden_is_fresh": true
+        },
+        "2123209b98b16083c69c91152b861724-seqno:1": {
+            "seqno": 1,
+            "link_id": "974b2f9209042e595b4df291c8f80a32556bf7b28d2384c7315e6af40d7795d9",
+            "hidden_is_fresh": true
+        },
+        "2123209b98b16083c69c91152b861724-seqno:2": {
+            "seqno": 2,
+            "link_id": "fb4cc5e06d83d67d326108623a1d1ba4e3f0b2d34d477da499c12f38fe410e4b",
+            "hidden_is_fresh": true
+        },
+        "2123209b98b16083c69c91152b861724-seqno:3": {
+            "seqno": 3,
+            "link_id": "01d2c94ebb571c20665024302295c0068acc6d5649a28502b8637cfc2e851fbc",
+            "hidden_is_fresh": true
+        }
+    },
+    "merkle_triples": {
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd1000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        },
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd2000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        },
+        "25852c87d6e47fb8d7d55400be9c7a19-cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd3000": {
+            "seqno": 1,
+            "id": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0"
+        }
+    },
+    "sessions": [
+        {
+            "loads": [
+                {
+                    "error": true,
+                    "error_type_full": "teams.AppendLinkError",
+                    "error_substr": "appending 2->3: PTK clash at generation 2"
+                }
+            ]
+        }
+    ],
+    "skip": false
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -73,10 +73,10 @@
 			"revisionTime": "2017-06-26T11:06:00Z"
 		},
 		{
-			"checksumSHA1": "QU/Pw0w1MSlvpRHyw3BeH4agXDI=",
+			"checksumSHA1": "N0cYOUZseP4+SzSPD1W1v+4mjsE=",
 			"path": "github.com/Keybase/keybase-test-vectors/teamchains",
-			"revision": "32a543ca82d8b250fe44a805609663ebcb1d573a",
-			"revisionTime": "2019-08-19T15:57:05Z",
+			"revision": "15cfed668cd808354bab958b7c3b7f6ba51c4ee9",
+			"revisionTime": "2019-09-07T01:14:40Z",
 			"tree": true
 		},
 		{


### PR DESCRIPTION
- we used to make a restriction on loading that PTK gens had to be laid down monotonically increasing, but we hit a case in prod where that wasn't so
  - the test case included tests this, it involves an interaction between FTL and the slow loader
- fix what we should be testing for, that we don't get conflicting PTKs for the same geneation
- introduce a new test case for the new error condition