### PR TITLE
Refactor how phone number and email tabs do search

### DIFF
--- a/go/protocol/keybase1/usersearch.go
+++ b/go/protocol/keybase1/usersearch.go
@@ -4,14 +4,13 @@
 package keybase1
 
 import (
-	"errors"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
 
-type APIUserServiceIDWithContact string
+type APIUserServiceID string
 
-func (o APIUserServiceIDWithContact) DeepCopy() APIUserServiceIDWithContact {
+func (o APIUserServiceID) DeepCopy() APIUserServiceID {
 	return o
 }
 
@@ -56,13 +55,13 @@ func (o APIUserKeybaseResult) DeepCopy() APIUserKeybaseResult {
 }
 
 type APIUserServiceResult struct {
-	ServiceName APIUserServiceIDWithContact `codec:"serviceName" json:"service_name"`
-	Username    string                      `codec:"username" json:"username"`
-	PictureUrl  string                      `codec:"pictureUrl" json:"picture_url"`
-	Bio         string                      `codec:"bio" json:"bio"`
-	Location    string                      `codec:"location" json:"location"`
-	FullName    string                      `codec:"fullName" json:"full_name"`
-	Confirmed   *bool                       `codec:"confirmed,omitempty" json:"confirmed,omitempty"`
+	ServiceName APIUserServiceID `codec:"serviceName" json:"service_name"`
+	Username    string           `codec:"username" json:"username"`
+	PictureUrl  string           `codec:"pictureUrl" json:"picture_url"`
+	Bio         string           `codec:"bio" json:"bio"`
+	Location    string           `codec:"location" json:"location"`
+	FullName    string           `codec:"fullName" json:"full_name"`
+	Confirmed   *bool            `codec:"confirmed,omitempty" json:"confirmed,omitempty"`
 }
 
 func (o APIUserServiceResult) DeepCopy() APIUserServiceResult {
@@ -84,8 +83,8 @@ func (o APIUserServiceResult) DeepCopy() APIUserServiceResult {
 }
 
 type APIUserServiceSummary struct {
-	ServiceName APIUserServiceIDWithContact `codec:"serviceName" json:"service_name"`
-	Username    string                      `codec:"username" json:"username"`
+	ServiceName APIUserServiceID `codec:"serviceName" json:"service_name"`
+	Username    string           `codec:"username" json:"username"`
 }
 
 func (o APIUserServiceSummary) DeepCopy() APIUserServiceSummary {
@@ -116,13 +115,13 @@ func (o ImpTofuSearchResult) DeepCopy() ImpTofuSearchResult {
 }
 
 type APIUserSearchResult struct {
-	Score           float64                                               `codec:"score" json:"score"`
-	Keybase         *APIUserKeybaseResult                                 `codec:"keybase,omitempty" json:"keybase,omitempty"`
-	Service         *APIUserServiceResult                                 `codec:"service,omitempty" json:"service,omitempty"`
-	Contact         *ProcessedContact                                     `codec:"contact,omitempty" json:"contact,omitempty"`
-	Imptofu         *ImpTofuSearchResult                                  `codec:"imptofu,omitempty" json:"imptofu,omitempty"`
-	ServicesSummary map[APIUserServiceIDWithContact]APIUserServiceSummary `codec:"servicesSummary" json:"services_summary"`
-	RawScore        float64                                               `codec:"rawScore" json:"rawScore"`
+	Score           float64                                    `codec:"score" json:"score"`
+	Keybase         *APIUserKeybaseResult                      `codec:"keybase,omitempty" json:"keybase,omitempty"`
+	Service         *APIUserServiceResult                      `codec:"service,omitempty" json:"service,omitempty"`
+	Contact         *ProcessedContact                          `codec:"contact,omitempty" json:"contact,omitempty"`
+	Imptofu         *ImpTofuSearchResult                       `codec:"imptofu,omitempty" json:"imptofu,omitempty"`
+	ServicesSummary map[APIUserServiceID]APIUserServiceSummary `codec:"servicesSummary" json:"services_summary"`
+	RawScore        float64                                    `codec:"rawScore" json:"rawScore"`
 }
 
 func (o APIUserSearchResult) DeepCopy() APIUserSearchResult {
@@ -156,11 +155,11 @@ func (o APIUserSearchResult) DeepCopy() APIUserSearchResult {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Imptofu),
-		ServicesSummary: (func(x map[APIUserServiceIDWithContact]APIUserServiceSummary) map[APIUserServiceIDWithContact]APIUserServiceSummary {
+		ServicesSummary: (func(x map[APIUserServiceID]APIUserServiceSummary) map[APIUserServiceID]APIUserServiceSummary {
 			if x == nil {
 				return nil
 			}
-			ret := make(map[APIUserServiceIDWithContact]APIUserServiceSummary, len(x))
+			ret := make(map[APIUserServiceID]APIUserServiceSummary, len(x))
 			for k, v := range x {
 				kCopy := k.DeepCopy()
 				vCopy := v.DeepCopy()
@@ -228,120 +227,17 @@ func (o NonUserDetails) DeepCopy() NonUserDetails {
 	}
 }
 
-type ImpTofuSearchType int
-
-const (
-	ImpTofuSearchType_PHONE ImpTofuSearchType = 0
-	ImpTofuSearchType_EMAIL ImpTofuSearchType = 1
-)
-
-func (o ImpTofuSearchType) DeepCopy() ImpTofuSearchType { return o }
-
-var ImpTofuSearchTypeMap = map[string]ImpTofuSearchType{
-	"PHONE": 0,
-	"EMAIL": 1,
-}
-
-var ImpTofuSearchTypeRevMap = map[ImpTofuSearchType]string{
-	0: "PHONE",
-	1: "EMAIL",
-}
-
-func (e ImpTofuSearchType) String() string {
-	if v, ok := ImpTofuSearchTypeRevMap[e]; ok {
-		return v
-	}
-	return ""
-}
-
-type ImpTofuQuery struct {
-	T__     ImpTofuSearchType `codec:"t" json:"t"`
-	Phone__ *PhoneNumber      `codec:"phone,omitempty" json:"phone,omitempty"`
-	Email__ *EmailAddress     `codec:"email,omitempty" json:"email,omitempty"`
-}
-
-func (o *ImpTofuQuery) T() (ret ImpTofuSearchType, err error) {
-	switch o.T__ {
-	case ImpTofuSearchType_PHONE:
-		if o.Phone__ == nil {
-			err = errors.New("unexpected nil value for Phone__")
-			return ret, err
-		}
-	case ImpTofuSearchType_EMAIL:
-		if o.Email__ == nil {
-			err = errors.New("unexpected nil value for Email__")
-			return ret, err
-		}
-	}
-	return o.T__, nil
-}
-
-func (o ImpTofuQuery) Phone() (res PhoneNumber) {
-	if o.T__ != ImpTofuSearchType_PHONE {
-		panic("wrong case accessed")
-	}
-	if o.Phone__ == nil {
-		return
-	}
-	return *o.Phone__
-}
-
-func (o ImpTofuQuery) Email() (res EmailAddress) {
-	if o.T__ != ImpTofuSearchType_EMAIL {
-		panic("wrong case accessed")
-	}
-	if o.Email__ == nil {
-		return
-	}
-	return *o.Email__
-}
-
-func NewImpTofuQueryWithPhone(v PhoneNumber) ImpTofuQuery {
-	return ImpTofuQuery{
-		T__:     ImpTofuSearchType_PHONE,
-		Phone__: &v,
-	}
-}
-
-func NewImpTofuQueryWithEmail(v EmailAddress) ImpTofuQuery {
-	return ImpTofuQuery{
-		T__:     ImpTofuSearchType_EMAIL,
-		Email__: &v,
-	}
-}
-
-func (o ImpTofuQuery) DeepCopy() ImpTofuQuery {
-	return ImpTofuQuery{
-		T__: o.T__.DeepCopy(),
-		Phone__: (func(x *PhoneNumber) *PhoneNumber {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.Phone__),
-		Email__: (func(x *EmailAddress) *EmailAddress {
-			if x == nil {
-				return nil
-			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.Email__),
-	}
-}
-
 type GetNonUserDetailsArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Assertion string `codec:"assertion" json:"assertion"`
 }
 
 type UserSearchArg struct {
-	Query                  string        `codec:"query" json:"query"`
-	Service                string        `codec:"service" json:"service"`
-	MaxResults             int           `codec:"maxResults" json:"maxResults"`
-	IncludeServicesSummary bool          `codec:"includeServicesSummary" json:"includeServicesSummary"`
-	IncludeContacts        bool          `codec:"includeContacts" json:"includeContacts"`
-	ImpTofuQuery           *ImpTofuQuery `codec:"impTofuQuery,omitempty" json:"impTofuQuery,omitempty"`
+	Query                  string `codec:"query" json:"query"`
+	Service                string `codec:"service" json:"service"`
+	MaxResults             int    `codec:"maxResults" json:"maxResults"`
+	IncludeServicesSummary bool   `codec:"includeServicesSummary" json:"includeServicesSummary"`
+	IncludeContacts        bool   `codec:"includeContacts" json:"includeContacts"`
 }
 
 type UserSearchInterface interface {

--- a/go/service/usersearch.go
+++ b/go/service/usersearch.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -273,45 +272,36 @@ func contactSearch(mctx libkb.MetaContext, arg keybase1.UserSearchArg) (res []ke
 	return res, nil
 }
 
-func imptofuQueryToAssertion(ctx context.Context, typ keybase1.ImpTofuSearchType, val string) (ret libkb.AssertionURL, err error) {
+func imptofuQueryToAssertion(ctx context.Context, typ, val string) (ret libkb.AssertionURL, err error) {
 	parsef := func(key, val string) (libkb.AssertionURL, error) {
 		return libkb.ParseAssertionURLKeyValue(
 			externals.MakeStaticAssertionContext(ctx), key, val, true)
 	}
 	switch typ {
-	case keybase1.ImpTofuSearchType_PHONE:
+	case "phone":
 		ret, err = parsef("phone", keybase1.PhoneNumberToAssertionValue(val))
-	case keybase1.ImpTofuSearchType_EMAIL:
+	case "email":
 		ret, err = parsef("email", strings.ToLower(strings.TrimSpace(val)))
 	default:
-		err = errors.New("invalid keybase1.ImpTofuSearchType enum value")
+		err = fmt.Errorf("invalid assertion type for imptofuQueryToAssertion, got %q", typ)
 	}
 	return ret, err
 }
 
-func imptofuSearch(mctx libkb.MetaContext, provider contacts.ContactsProvider, imptofuQuery keybase1.ImpTofuQuery) (res *keybase1.APIUserSearchResult, err error) {
+func (h *UserSearchHandler) imptofuSearch(mctx libkb.MetaContext, arg keybase1.UserSearchArg) (res []keybase1.APIUserSearchResult, err error) {
 	var emails []keybase1.EmailAddress
 	var phones []keybase1.RawPhoneNumber
 
-	imptofuType, err := imptofuQuery.T()
-	if err != nil {
-		return nil, err
+	switch arg.Service {
+	case "email":
+		emails = append(emails, keybase1.EmailAddress(arg.Query))
+	case "phone":
+		phones = append(phones, keybase1.RawPhoneNumber(arg.Query))
+	default:
+		return nil, fmt.Errorf("unexpected service=%q in imptofuSearch", arg.Service)
 	}
 
-	var queryString string
-
-	switch imptofuType {
-	case keybase1.ImpTofuSearchType_EMAIL:
-		email := imptofuQuery.Email()
-		queryString = string(email)
-		emails = append(emails, email)
-	case keybase1.ImpTofuSearchType_PHONE:
-		phone := keybase1.RawPhoneNumber(imptofuQuery.Phone())
-		queryString = string(phone)
-		phones = append(phones, phone)
-	}
-
-	lookupRes, err := provider.LookupAll(mctx, emails, phones, keybase1.RegionCode(""))
+	lookupRes, err := h.contactsProvider.LookupAll(mctx, emails, phones, keybase1.RegionCode(""))
 	if err != nil {
 		return nil, err
 	}
@@ -324,13 +314,16 @@ func imptofuSearch(mctx libkb.MetaContext, provider contacts.ContactsProvider, i
 			}
 		}
 
-		usernames, err := provider.FindUsernames(mctx, uids)
+		usernames, err := h.contactsProvider.FindUsernames(mctx, uids)
 		if err != nil {
 			mctx.Warning("Cannot find usernames for search results: %s", err)
 		}
-		serviceMaps, err := provider.FindServiceMaps(mctx, uids)
-		if err != nil {
-			mctx.Warning("Cannot get service maps for search results: %s", err)
+		var serviceMaps map[keybase1.UID]libkb.UserServiceSummary
+		if arg.IncludeServicesSummary {
+			serviceMaps, err = h.contactsProvider.FindServiceMaps(mctx, uids)
+			if err != nil {
+				mctx.Warning("Cannot get service maps for search results: %s", err)
+			}
 		}
 
 		for _, v := range lookupRes.Results {
@@ -339,12 +332,12 @@ func imptofuSearch(mctx libkb.MetaContext, provider contacts.ContactsProvider, i
 				continue
 			}
 
-			assertionValue := queryString
+			assertionValueArg := arg.Query
 			if v.Coerced != "" {
 				// Server corrected our assertion - take this instead.
-				assertionValue = v.Coerced
+				assertionValueArg = v.Coerced
 			}
-			assertion, err := imptofuQueryToAssertion(mctx.Ctx(), imptofuType, assertionValue)
+			assertion, err := imptofuQueryToAssertion(mctx.Ctx(), arg.Service, assertionValueArg)
 			if err != nil {
 				return nil, err
 			}
@@ -352,7 +345,7 @@ func imptofuSearch(mctx libkb.MetaContext, provider contacts.ContactsProvider, i
 				Assertion:      assertion.String(),
 				AssertionKey:   assertion.GetKey(),
 				AssertionValue: assertion.GetValue(),
-				PrettyName:     queryString,
+				PrettyName:     arg.Query,
 			}
 			if usernames != nil {
 				if uname, found := usernames[v.UID]; found {
@@ -360,12 +353,12 @@ func imptofuSearch(mctx libkb.MetaContext, provider contacts.ContactsProvider, i
 					imptofu.PrettyName = uname.Fullname
 				}
 			}
-			var servicesSummary map[keybase1.APIUserServiceIDWithContact]keybase1.APIUserServiceSummary
+			var servicesSummary map[keybase1.APIUserServiceID]keybase1.APIUserServiceSummary
 			if serviceMaps != nil {
 				if smap, found := serviceMaps[v.UID]; found && len(smap) > 0 {
-					servicesSummary = make(map[keybase1.APIUserServiceIDWithContact]keybase1.APIUserServiceSummary, len(smap))
+					servicesSummary = make(map[keybase1.APIUserServiceID]keybase1.APIUserServiceSummary, len(smap))
 					for serviceID, username := range smap {
-						serviceName := keybase1.APIUserServiceIDWithContact(serviceID)
+						serviceName := keybase1.APIUserServiceID(serviceID)
 						servicesSummary[serviceName] = keybase1.APIUserServiceSummary{
 							ServiceName: serviceName,
 							Username:    username,
@@ -373,17 +366,17 @@ func imptofuSearch(mctx libkb.MetaContext, provider contacts.ContactsProvider, i
 					}
 				}
 			}
-			res = &keybase1.APIUserSearchResult{
+			res = []keybase1.APIUserSearchResult{{
 				Score:           1.0,
 				Imptofu:         imptofu,
 				ServicesSummary: servicesSummary,
-			}
+			}}
 			return res, nil // return here - we only want one result
 		}
 	}
 
 	// Not resolved - add SBS result.
-	assertion, err := imptofuQueryToAssertion(mctx.Ctx(), imptofuType, queryString)
+	assertion, err := imptofuQueryToAssertion(mctx.Ctx(), arg.Service, arg.Query)
 	if err != nil {
 		return nil, err
 	}
@@ -391,12 +384,12 @@ func imptofuSearch(mctx libkb.MetaContext, provider contacts.ContactsProvider, i
 		Assertion:      assertion.String(),
 		AssertionKey:   assertion.GetKey(),
 		AssertionValue: assertion.GetValue(),
-		PrettyName:     queryString,
+		PrettyName:     arg.Query,
 	}
-	res = &keybase1.APIUserSearchResult{
+	res = []keybase1.APIUserSearchResult{{
 		Score:   1.0,
 		Imptofu: imptofu,
-	}
+	}}
 	return res, nil
 }
 
@@ -420,20 +413,7 @@ func (h *UserSearchHandler) makeSearchRequest(mctx libkb.MetaContext, arg keybas
 	return res, nil
 }
 
-func (h *UserSearchHandler) UserSearch(ctx context.Context, arg keybase1.UserSearchArg) (res []keybase1.APIUserSearchResult, err error) {
-	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("USEARCH")
-	defer mctx.TraceTimed(fmt.Sprintf("UserSearch#UserSearch(s=%q, q=%q)", arg.Service, arg.Query),
-		func() error { return err })()
-
-	if arg.Query == "" {
-		return nil, nil
-	}
-
-	if arg.Service != "keybase" && arg.Service != "" {
-		// If this is a social search, we just return API results.
-		return h.makeSearchRequest(mctx, arg)
-	}
-
+func (h *UserSearchHandler) keybaseSearchWithContacts(mctx libkb.MetaContext, arg keybase1.UserSearchArg) (res []keybase1.APIUserSearchResult, err error) {
 	res, err = h.makeSearchRequest(mctx, arg)
 	if err != nil {
 		mctx.Warning("Failed to do an API search for %q: %s", arg.Service, err)
@@ -443,72 +423,76 @@ func (h *UserSearchHandler) UserSearch(ctx context.Context, arg keybase1.UserSea
 		contactsRes, err := contactSearch(mctx, arg)
 		if err != nil {
 			mctx.Warning("Failed to do contacts search: %s", err)
-		} else {
-			// Filter contacts - If we have a username match coming from the
-			// service, prefer it instead of contact result for the same user
-			// but with SBS assertion in it.
-			usernameSet := make(map[string]struct{}) // set of usernames
-			for _, result := range res {
-				if result.Keybase != nil {
-					// All current results should be Keybase but be safe in
-					// case code in this function changes.
-					usernameSet[result.Keybase.Username] = struct{}{}
-				}
-			}
+			return res, nil
+		}
 
-			for _, contact := range contactsRes {
-				if contact.Contact.Resolved {
-					// Do not add this contact result if there already is a
-					// keybase result with username that the contact resolved
-					// to.
-					username := contact.Contact.Username
-					if _, found := usernameSet[username]; found {
-						continue
-					}
-					usernameSet[username] = struct{}{}
-				}
-				res = append(res, contact)
-			}
-
-			sort.Slice(res, func(i, j int) bool {
-				return compareUserSearch(res[i], res[j])
-			})
-
-			for i := range res {
-				res[i].Score = 1.0 / float64(1+i)
+		// Filter contacts - If we have a username match coming from the
+		// service, prefer it instead of contact result for the same user
+		// but with SBS assertion in it.
+		usernameSet := make(map[string]struct{}, len(res)) // set of usernames
+		for _, result := range res {
+			if result.Keybase != nil {
+				// All current results should be Keybase but be safe in
+				// case code in this function changes.
+				usernameSet[result.Keybase.Username] = struct{}{}
 			}
 		}
-	}
 
-	if arg.ImpTofuQuery != nil {
-		imptofuRes, err := imptofuSearch(mctx, h.contactsProvider, *arg.ImpTofuQuery)
-		if err != nil {
-			mctx.Error("Failed to do phone number / email search: %s", err)
-		} else if imptofuRes != nil {
-			// Check if we have found assertion of this result already in our
-			// contacts.
-			var found bool
-			for _, v := range res {
-				if v.Contact != nil && v.Contact.Assertion == imptofuRes.Imptofu.Assertion {
-					found = true
-					break
+		for _, contact := range contactsRes {
+			if contact.Contact.Resolved {
+				// Do not add this contact result if there already is a
+				// keybase result with username that the contact resolved
+				// to.
+				username := contact.Contact.Username
+				if _, found := usernameSet[username]; found {
+					continue
 				}
+				usernameSet[username] = struct{}{}
 			}
-
-			if !found {
-				// Prepend *imptofuRes
-				res = append([]keybase1.APIUserSearchResult{*imptofuRes}, res...)
-			}
+			res = append(res, contact)
 		}
-	}
 
-	// Trim the whole result to MaxResult.
-	maxRes := arg.MaxResults
-	if maxRes > 0 && len(res) > maxRes {
-		res = res[:maxRes]
+		sort.Slice(res, func(i, j int) bool {
+			return compareUserSearch(res[i], res[j])
+		})
+
+		for i := range res {
+			res[i].Score = 1.0 / float64(1+i)
+		}
+
+		// Trim the whole result to MaxResult.
+		maxRes := arg.MaxResults
+		if maxRes > 0 && len(res) > maxRes {
+			res = res[:maxRes]
+		}
 	}
 
 	return res, nil
+}
+
+func (h *UserSearchHandler) UserSearch(ctx context.Context, arg keybase1.UserSearchArg) (res []keybase1.APIUserSearchResult, err error) {
+	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("USEARCH")
+	defer mctx.TraceTimed(fmt.Sprintf("UserSearch#UserSearch(s=%q, q=%q)", arg.Service, arg.Query),
+		func() error { return err })()
+
+	if arg.Query == "" {
+		return nil, nil
+	}
+
+	fmt.Printf("search: %+v\n", arg)
+
+	if arg.IncludeContacts && arg.Service != "keybase" {
+		return nil, fmt.Errorf("`IncludeContacts` is only valid with service=\"keybase\" (got service=%q)", arg.Service)
+	}
+
+	switch arg.Service {
+	case "keybase":
+		return h.keybaseSearchWithContacts(mctx, arg)
+	case "phone", "email":
+		return h.imptofuSearch(mctx, arg)
+	default:
+		return h.makeSearchRequest(mctx, arg)
+	}
 }
 
 func (h *UserSearchHandler) GetNonUserDetails(ctx context.Context, arg keybase1.GetNonUserDetailsArg) (res keybase1.NonUserDetails, err error) {

--- a/protocol/avdl/keybase1/usersearch.avdl
+++ b/protocol/avdl/keybase1/usersearch.avdl
@@ -4,7 +4,7 @@ protocol userSearch {
     import idl "contacts.avdl";
 
     @typedef("string")
-    record APIUserServiceIDWithContact {}
+    record APIUserServiceID {}
 
     record APIUserKeybaseResult {
         string username;
@@ -22,7 +22,7 @@ protocol userSearch {
 
     record APIUserServiceResult {
         @jsonkey("service_name")
-        APIUserServiceIDWithContact serviceName;
+        APIUserServiceID serviceName;
         string username;
         @jsonkey("picture_url")
         string pictureUrl;
@@ -35,7 +35,7 @@ protocol userSearch {
 
     record APIUserServiceSummary {
         @jsonkey("service_name")
-        APIUserServiceIDWithContact serviceName;
+        APIUserServiceID serviceName;
         string username;
     }
 
@@ -55,7 +55,7 @@ protocol userSearch {
         union { null, ProcessedContact } contact;
         union { null, ImpTofuSearchResult } imptofu;
         @jsonkey("services_summary")
-        map<APIUserServiceIDWithContact, APIUserServiceSummary> servicesSummary;
+        map<APIUserServiceID, APIUserServiceSummary> servicesSummary;
         double rawScore;
     }
 
@@ -71,17 +71,6 @@ protocol userSearch {
     }
     NonUserDetails getNonUserDetails(int sessionID, string assertion);
 
-    enum ImpTofuSearchType {
-        PHONE_0,
-        EMAIL_1
-    }
-
-    variant ImpTofuQuery switch (ImpTofuSearchType t) {
-        case PHONE: PhoneNumber;
-        case EMAIL: EmailAddress;
-    }
-
     array<APIUserSearchResult> userSearch(string query, string service, int maxResults,
-        boolean includeServicesSummary, boolean includeContacts,
-        union { null, ImpTofuQuery } impTofuQuery);
+        boolean includeServicesSummary, boolean includeContacts);
 }

--- a/protocol/json/keybase1/usersearch.json
+++ b/protocol/json/keybase1/usersearch.json
@@ -13,7 +13,7 @@
   "types": [
     {
       "type": "record",
-      "name": "APIUserServiceIDWithContact",
+      "name": "APIUserServiceID",
       "fields": [],
       "typedef": "string"
     },
@@ -69,7 +69,7 @@
       "name": "APIUserServiceResult",
       "fields": [
         {
-          "type": "APIUserServiceIDWithContact",
+          "type": "APIUserServiceID",
           "name": "serviceName",
           "jsonkey": "service_name"
         },
@@ -109,7 +109,7 @@
       "name": "APIUserServiceSummary",
       "fields": [
         {
-          "type": "APIUserServiceIDWithContact",
+          "type": "APIUserServiceID",
           "name": "serviceName",
           "jsonkey": "service_name"
         },
@@ -189,7 +189,7 @@
           "type": {
             "type": "map",
             "values": "APIUserServiceSummary",
-            "keys": "APIUserServiceIDWithContact"
+            "keys": "APIUserServiceID"
           },
           "name": "servicesSummary",
           "jsonkey": "services_summary"
@@ -249,38 +249,6 @@
           "name": "siteIconFull"
         }
       ]
-    },
-    {
-      "type": "enum",
-      "name": "ImpTofuSearchType",
-      "symbols": [
-        "PHONE_0",
-        "EMAIL_1"
-      ]
-    },
-    {
-      "type": "variant",
-      "name": "ImpTofuQuery",
-      "switch": {
-        "type": "ImpTofuSearchType",
-        "name": "t"
-      },
-      "cases": [
-        {
-          "label": {
-            "name": "PHONE",
-            "def": false
-          },
-          "body": "PhoneNumber"
-        },
-        {
-          "label": {
-            "name": "EMAIL",
-            "def": false
-          },
-          "body": "EmailAddress"
-        }
-      ]
     }
   ],
   "messages": {
@@ -318,13 +286,6 @@
         {
           "name": "includeContacts",
           "type": "boolean"
-        },
-        {
-          "name": "impTofuQuery",
-          "type": [
-            null,
-            "ImpTofuQuery"
-          ]
         }
       ],
       "response": {

--- a/shared/actions/json/team-building.json
+++ b/shared/actions/json/team-building.json
@@ -12,7 +12,7 @@
       "includeContacts": "boolean",
       "namespace": "Types.AllowedNamespace",
       "query": "string",
-      "service": "Types.ServiceId",
+      "service": "Types.ServiceIdWithContact",
       "limit?": "number"
     },
     "addUsersToTeamSoFar": {"namespace": "Types.AllowedNamespace", "users": "Array<Types.User>"},

--- a/shared/actions/team-building-gen.tsx
+++ b/shared/actions/team-building-gen.tsx
@@ -37,7 +37,7 @@ type _SearchPayload = {
   readonly includeContacts: boolean
   readonly namespace: Types.AllowedNamespace
   readonly query: string
-  readonly service: Types.ServiceId
+  readonly service: Types.ServiceIdWithContact
   readonly limit?: number
 }
 type _SearchResultsLoadedPayload = {

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1308,7 +1308,7 @@ export type MessageTypes = {
     outParam: NonUserDetails
   }
   'keybase.1.userSearch.userSearch': {
-    inParam: {readonly query: String; readonly service: String; readonly maxResults: Int; readonly includeServicesSummary: Boolean; readonly includeContacts: Boolean; readonly impTofuQuery?: ImpTofuQuery | null}
+    inParam: {readonly query: String; readonly service: String; readonly maxResults: Int; readonly includeServicesSummary: Boolean; readonly includeContacts: Boolean}
     outParam: Array<APIUserSearchResult> | null
   }
 }
@@ -1608,11 +1608,6 @@ export enum IdentifyReasonType {
 export enum IdentityVisibility {
   private = 0,
   public = 1,
-}
-
-export enum ImpTofuSearchType {
-  phone = 0,
-  email = 1,
 }
 
 export enum InstallAction {
@@ -2312,9 +2307,9 @@ export enum UserOrTeamResult {
 export type APIRes = {readonly status: String; readonly body: String; readonly httpStatus: Int; readonly appStatus: String}
 export type APIUserKeybaseResult = {readonly username: String; readonly uid: UID; readonly pictureUrl?: String | null; readonly fullName?: String | null; readonly rawScore: Double; readonly stellar?: String | null; readonly isFollowee: Boolean}
 export type APIUserSearchResult = {readonly score: Double; readonly keybase?: APIUserKeybaseResult | null; readonly service?: APIUserServiceResult | null; readonly contact?: ProcessedContact | null; readonly imptofu?: ImpTofuSearchResult | null; readonly servicesSummary: {[key: string]: APIUserServiceSummary}; readonly rawScore: Double}
-export type APIUserServiceIDWithContact = String
-export type APIUserServiceResult = {readonly serviceName: APIUserServiceIDWithContact; readonly username: String; readonly pictureUrl: String; readonly bio: String; readonly location: String; readonly fullName: String; readonly confirmed?: Boolean | null}
-export type APIUserServiceSummary = {readonly serviceName: APIUserServiceIDWithContact; readonly username: String}
+export type APIUserServiceID = String
+export type APIUserServiceResult = {readonly serviceName: APIUserServiceID; readonly username: String; readonly pictureUrl: String; readonly bio: String; readonly location: String; readonly fullName: String; readonly confirmed?: Boolean | null}
+export type APIUserServiceSummary = {readonly serviceName: APIUserServiceID; readonly username: String}
 export type AllProvisionedUsernames = {readonly defaultUsername: String; readonly provisionedUsernames?: Array<String> | null; readonly hasProvisionedUser: Boolean}
 export type AnnotatedMemberInfo = {readonly userID: UID; readonly teamID: TeamID; readonly username: String; readonly fullName: String; readonly fqName: String; readonly isImplicitTeam: Boolean; readonly impTeamDisplayName: String; readonly isOpenTeam: Boolean; readonly role: TeamRole; readonly implicit?: ImplicitRole | null; readonly needsPUK: Boolean; readonly memberCount: Int; readonly eldestSeqno: Seqno; readonly allowProfilePromote: Boolean; readonly isMemberShowcased: Boolean; readonly status: TeamMemberStatus}
 export type AnnotatedTeamInvite = {readonly role: TeamRole; readonly id: TeamInviteID; readonly type: TeamInviteType; readonly name: TeamInviteName; readonly uv: UserVersion; readonly inviter: UserVersion; readonly inviterUsername: String; readonly teamName: String; readonly status: TeamMemberStatus}
@@ -2489,7 +2484,6 @@ export type IdentifyRow = {readonly rowId: Int; readonly proof: RemoteProof; rea
 export type IdentifyTrackBreaks = {readonly keys?: Array<IdentifyKey> | null; readonly proofs?: Array<IdentifyProofBreak> | null}
 export type Identity = {readonly status?: Status | null; readonly whenLastTracked: Time; readonly proofs?: Array<IdentifyRow> | null; readonly cryptocurrency?: Array<Cryptocurrency> | null; readonly revoked?: Array<TrackDiff> | null; readonly revokedDetails?: Array<RevokedProof> | null; readonly breaksTracking: Boolean}
 export type ImageCropRect = {readonly x0: Int; readonly y0: Int; readonly x1: Int; readonly y1: Int}
-export type ImpTofuQuery = {t: ImpTofuSearchType.phone; phone: PhoneNumber | null} | {t: ImpTofuSearchType.email; email: EmailAddress | null}
 export type ImpTofuSearchResult = {readonly assertion: String; readonly assertionValue: String; readonly assertionKey: String; readonly label: String; readonly prettyName: String; readonly keybaseUsername: String}
 export type ImplicitRole = {readonly role: TeamRole; readonly ancestor: TeamID}
 export type ImplicitTeamConflictInfo = {readonly generation: ConflictGeneration; readonly time: Time}

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -48,7 +48,7 @@ export type _TeamBuildingSubState = {
   teamBuildingFinishedSelectedRole: TeamRoleType
   teamBuildingFinishedSendNotification: boolean
   teamBuildingSearchQuery: Query
-  teamBuildingSelectedService: ServiceId
+  teamBuildingSelectedService: ServiceIdWithContact
   teamBuildingSearchLimit: number
   teamBuildingUserRecs: Array<User> | null
   teamBuildingSelectedRole: TeamRoleType

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -201,7 +201,7 @@ const makeDebouncedSearch = (time: number) =>
       dispatch: Container.TypedDispatch,
       namespace: Types.AllowedNamespace,
       query: string,
-      service: Types.ServiceId,
+      service: Types.ServiceIdWithContact,
       includeContacts: boolean,
       limit?: number
     ) =>
@@ -220,7 +220,7 @@ const makeDebouncedSearch = (time: number) =>
   )
 
 const debouncedSearch = makeDebouncedSearch(500) // 500ms debounce on social searches
-const debouncedSearchKeybase = makeDebouncedSearch(200) // 200 ms debounce on keybase / contact searches
+const debouncedSearchKeybase = makeDebouncedSearch(200) // 200 ms debounce on keybase searches
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch, {namespace, teamname}: OwnProps) => ({
   _onAdd: (user: Types.User) =>
@@ -231,12 +231,8 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, {namespace, teamn
   _onImportContactsPermissionsNotGranted: () =>
     dispatch(SettingsGen.createRequestContactPermissions({thenToggleImportOn: true})),
   _search: (query: string, service: Types.ServiceIdWithContact, limit?: number) => {
-    let serviceToSearch = service
-    if (Types.isContactServiceId(serviceToSearch)) {
-      serviceToSearch = 'keybase'
-    }
-    const func = serviceToSearch === 'keybase' ? debouncedSearchKeybase : debouncedSearch
-    return func(dispatch, namespace, query, serviceToSearch, namespace === 'chat2', limit)
+    const func = service === 'keybase' ? debouncedSearchKeybase : debouncedSearch
+    return func(dispatch, namespace, query, service, namespace === 'chat2', limit)
   },
   fetchUserRecs: () =>
     dispatch(TeamBuildingGen.createFetchUserRecs({includeContacts: namespace === 'chat2', namespace})),

--- a/shared/team-building/email-input/index.tsx
+++ b/shared/team-building/email-input/index.tsx
@@ -26,10 +26,10 @@ const EmailInput = ({namespace, search, teamBuildingSearchResults}: EmailInputPr
   if (
     teamBuildingSearchResults &&
     teamBuildingSearchResults[emailString] &&
-    teamBuildingSearchResults[emailString].keybase &&
-    teamBuildingSearchResults[emailString].keybase[0]
+    teamBuildingSearchResults[emailString].email &&
+    teamBuildingSearchResults[emailString].email[0]
   ) {
-    user = teamBuildingSearchResults[emailString].keybase[0]
+    user = teamBuildingSearchResults[emailString].email[0]
   }
   const canSubmit = !!user && !waiting && isEmailValid
   const emailHasKeybaseAccount = user && user.serviceMap.keybase !== ''


### PR DESCRIPTION
Use user search RPC with `email` or `phone` service (which are now legal in this RPC, and the typeing reflects that) instead of the `imptofuQuery` object.