### PR TITLE
New Convo: Handle Long Emails

### DIFF
--- a/shared/chat/conversation/header-area/normal/index.native.tsx
+++ b/shared/chat/conversation/header-area/normal/index.native.tsx
@@ -106,7 +106,7 @@ const PhoneOrEmailHeader = (props: Props) => {
     <Wrapper {...props}>
       <Box2 direction="vertical" style={styles.usernameHeaderContainer}>
         <Box2 direction="horizontal" style={styles.lessMargins}>
-          <Text type="BodyBig" lineClamp={1} ellipsizeMode="middle" allowFontScaling>
+          <Text type="BodyBig" lineClamp={1} ellipsizeMode="middle">
             {formattedPhoneOrEmail}
           </Text>
           {props.muted && <ShhIcon onClick={props.unMuteConversation} />}

--- a/shared/chat/conversation/header-area/normal/index.native.tsx
+++ b/shared/chat/conversation/header-area/normal/index.native.tsx
@@ -106,7 +106,9 @@ const PhoneOrEmailHeader = (props: Props) => {
     <Wrapper {...props}>
       <Box2 direction="vertical" style={styles.usernameHeaderContainer}>
         <Box2 direction="horizontal" style={styles.lessMargins}>
-          <Text type="BodyBig">{formattedPhoneOrEmail}</Text>
+          <Text type="BodyBig" lineClamp={1} ellipsizeMode="middle" allowFontScaling>
+            {formattedPhoneOrEmail}
+          </Text>
           {props.muted && <ShhIcon onClick={props.unMuteConversation} />}
         </Box2>
         {!!name && <Text type="BodyTiny">{name}</Text>}

--- a/shared/chat/conversation/header-area/normal/index.stories.tsx
+++ b/shared/chat/conversation/header-area/normal/index.stories.tsx
@@ -20,12 +20,7 @@ const defaultProps = {
   unMuteConversation: Sb.action('unMuteConversation'),
 }
 const phones = ['ayoubd', '+15558675309@phone']
-const emails = [
-  'max@keybase.io@email',
-  'bobross@happlittletrees.org@email',
-  'extremelylongusernameataveryshortdomain@a.com@email',
-]
-const contactNames = {'+15558675309@phone': 'Max Goodman'}
+const contactNames = {'+15558675309@phone': 'Max Goodman', '+17083585828@phone': 'Ian'}
 
 const load = () => {
   Sb.storiesOf('Chat/Header', module)
@@ -68,16 +63,23 @@ const load = () => {
     .add('Phone header - no contact name', () => (
       <PhoneOrEmailHeader {...defaultProps} participants={phones} />
     ))
-    .add('Phone header - contact name', () => (
+    .add('Phone header - contact name - first only', () => (
+      <PhoneOrEmailHeader
+        {...defaultProps}
+        participants={['ayoubd', '+17083585828@phone']}
+        contactNames={contactNames}
+      />
+    ))
+    .add('Phone header - contact name - full name', () => (
       <PhoneOrEmailHeader {...defaultProps} participants={phones} contactNames={contactNames} />
     ))
     .add('Email Header - short', () => (
-      <PhoneOrEmailHeader {...defaultProps} participants={['max@keybase.io@email']} />
+      <PhoneOrEmailHeader {...defaultProps} participants={['[max@keybase.io]@email']} />
     ))
     .add('Email Header - long', () => (
       <PhoneOrEmailHeader
         {...defaultProps}
-        participants={['extremelylongusernameataveryshortdomain@a.com@email']}
+        participants={['[extremelylongusernameataveryshortdomain@a.com]@email']}
       />
     ))
 }

--- a/shared/chat/conversation/header-area/normal/index.stories.tsx
+++ b/shared/chat/conversation/header-area/normal/index.stories.tsx
@@ -20,6 +20,11 @@ const defaultProps = {
   unMuteConversation: Sb.action('unMuteConversation'),
 }
 const phones = ['ayoubd', '+15558675309@phone']
+const emails = [
+  'max@keybase.io@email',
+  'bobross@happlittletrees.org@email',
+  'extremelylongusernameataveryshortdomain@a.com@email',
+]
 const contactNames = {'+15558675309@phone': 'Max Goodman'}
 
 const load = () => {
@@ -60,8 +65,20 @@ const load = () => {
     .add('Channel Header for big team - long', () => (
       <ChannelHeader {...defaultProps} smallTeam={false} channelName="uweiohfiwehfiowehfioweuhf" />
     ))
-    .add('Phone header', () => (
+    .add('Phone header - no contact name', () => (
+      <PhoneOrEmailHeader {...defaultProps} participants={phones} />
+    ))
+    .add('Phone header - contact name', () => (
       <PhoneOrEmailHeader {...defaultProps} participants={phones} contactNames={contactNames} />
+    ))
+    .add('Email Header - short', () => (
+      <PhoneOrEmailHeader {...defaultProps} participants={['max@keybase.io@email']} />
+    ))
+    .add('Email Header - long', () => (
+      <PhoneOrEmailHeader
+        {...defaultProps}
+        participants={['extremelylongusernameataveryshortdomain@a.com@email']}
+      />
     ))
 }
 

--- a/shared/ios/Keybase/Storybook.m
+++ b/shared/ios/Keybase/Storybook.m
@@ -24,7 +24,7 @@ RCT_EXPORT_MODULE(Storybook);
 - (NSDictionary *)constantsToExport
 {
   // Set this to true to enable storybook mode
-  return @{@"isStorybook": @false};
+  return @{@"isStorybook": @true};
 }
 
 @end

--- a/shared/ios/Keybase/Storybook.m
+++ b/shared/ios/Keybase/Storybook.m
@@ -24,7 +24,7 @@ RCT_EXPORT_MODULE(Storybook);
 - (NSDictionary *)constantsToExport
 {
   // Set this to true to enable storybook mode
-  return @{@"isStorybook": @true};
+  return @{@"isStorybook": @false};
 }
 
 @end


### PR DESCRIPTION
- Limits `PhoneOrEmail` chat headers to one line and sets ellipsis to middle
- Adds new storybook entires for:
    - Chat - Header - Phone Number - full name contact
    - Chat - Header - Phone Number - first name contact
    - Chat - Header - Email - short email
    - Chat - Header - Email - long email


![image](https://user-images.githubusercontent.com/5200812/64542968-6df1ea00-d2f2-11e9-8a87-6d104a1fa5db.png)


![image](https://user-images.githubusercontent.com/5200812/64542949-67637280-d2f2-11e9-8a10-e66dd34325c2.png)

@keybase/react-hackers 
