### PR TITLE
New Convo: Update Start Button to use Tooltip

### DIFF
--- a/shared/chat/conversation-filter-input.tsx
+++ b/shared/chat/conversation-filter-input.tsx
@@ -107,7 +107,7 @@ class ConversationFilterInput extends React.PureComponent<Props> {
           <Kb.Box style={Flags.wonderland ? styles.wonderlandBorder : {}}>
             <Kb.WithTooltip
               position="top center"
-              text={
+              tooltip={
                 Flags.wonderland
                   ? `(${Platforms.shortcutSymbol}N)`
                   : `New chat (${Platforms.shortcutSymbol}N)`

--- a/shared/chat/conversation/messages/react-button/emoji-row/index.tsx
+++ b/shared/chat/conversation/messages/react-button/emoji-row/index.tsx
@@ -62,7 +62,7 @@ class EmojiRow extends React.Component<Props, {showingPicker: boolean}> {
         </Kb.Box2>
         <Kb.Box2 direction="horizontal">
           <Kb.Divider style={styles.divider} vertical={true} />
-          <Kb.WithTooltip text="React">
+          <Kb.WithTooltip tooltip="React">
             <Kb.Box className="hover_container" onClick={this._showPicker} style={styles.iconContainer}>
               <Kb.Icon
                 className="hover_contained_color_blue"
@@ -72,7 +72,7 @@ class EmojiRow extends React.Component<Props, {showingPicker: boolean}> {
             </Kb.Box>
           </Kb.WithTooltip>
           {!!this.props.onReply && (
-            <Kb.WithTooltip text="Reply">
+            <Kb.WithTooltip tooltip="Reply">
               <Kb.Box className="hover_container" onClick={this.props.onReply} style={styles.iconContainer}>
                 <Kb.Icon
                   className="hover_contained_color_blue"

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -156,7 +156,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                 onUsernameClicked={this._onAuthorClick}
               />
               {this.props.showCrowns && (this.props.authorIsOwner || this.props.authorIsAdmin) && (
-                <Kb.WithTooltip text={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
+                <Kb.WithTooltip tooltip={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
                   <Kb.Icon
                     color={
                       this.props.authorIsOwner ? Styles.globalColors.yellowDark : Styles.globalColors.black_35

--- a/shared/chat/header.desktop.tsx
+++ b/shared/chat/header.desktop.tsx
@@ -63,7 +63,7 @@ const Header = (p: Props) => {
   }
   if (p.isTeam && p.desc && p.canEditDesc) {
     description = (
-      <Kb.WithTooltip position="bottom left" text="Set the description using the /headline command.">
+      <Kb.WithTooltip position="bottom left" tooltip="Set the description using the /headline command.">
         {description}
       </Kb.WithTooltip>
     )
@@ -133,13 +133,13 @@ const Header = (p: Props) => {
             alignSelf="flex-end"
             style={styles.actionIcons}
           >
-            <Kb.WithTooltip text={`Search in this chat (${Platforms.shortcutSymbol}F)`}>
+            <Kb.WithTooltip tooltip={`Search in this chat (${Platforms.shortcutSymbol}F)`}>
               <Kb.Icon style={styles.clickable} type="iconfont-search" onClick={p.onToggleThreadSearch} />
             </Kb.WithTooltip>
-            <Kb.WithTooltip text="Open folder">
+            <Kb.WithTooltip tooltip="Open folder">
               <Kb.Icon style={styles.clickable} type="iconfont-folder-private" onClick={p.onOpenFolder} />
             </Kb.WithTooltip>
-            <Kb.WithTooltip text="Chat info & settings">
+            <Kb.WithTooltip tooltip="Chat info & settings">
               <Kb.Icon
                 style={styles.clickable}
                 type="iconfont-info"

--- a/shared/chat/inbox-search/index.tsx
+++ b/shared/chat/inbox-search/index.tsx
@@ -127,7 +127,7 @@ class InboxSearch extends React.Component<Props, State> {
               <Kb.WithTooltip
                 containerStyle={styles.progressBar}
                 position="bottom center"
-                text={`${this.props.indexPercent}% complete`}
+                tooltip={`${this.props.indexPercent}% complete`}
               >
                 <Kb.ProgressBar style={styles.progressBar} ratio={ratio} />
               </Kb.WithTooltip>

--- a/shared/common-adapters/switch.tsx
+++ b/shared/common-adapters/switch.tsx
@@ -34,7 +34,7 @@ const LabelContainer = props =>
   // We put the tooltip on the whole thing on desktop.
   Styles.isMobile && props.labelTooltip ? (
     <Kb.WithTooltip
-      text={props.labelTooltip}
+      tooltip={props.labelTooltip}
       containerStyle={Styles.collapseStyles([Styles.globalStyles.flexBoxColumn, styles.labelContainer])}
       showOnPressMobile={true}
     >
@@ -85,7 +85,7 @@ const Switch = React.forwardRef<ClickableBox, Props>((props: Props, ref) =>
   ) : (
     <Kb.WithTooltip
       containerStyle={getStyle(props)}
-      text={props.labelTooltip || ''}
+      tooltip={props.labelTooltip || ''}
       position={props.align !== 'right' ? 'top left' : 'top right'}
     >
       {getContent(props, ref)}

--- a/shared/common-adapters/tooltip.stories.tsx
+++ b/shared/common-adapters/tooltip.stories.tsx
@@ -17,14 +17,14 @@ const load = () => {
     .addDecorator(Sb.scrollViewDecorator)
     .add('Tooltip', () => (
       <Kb.Box2 direction="horizontal" style={{flexWrap: 'wrap'}}>
-        <Kb.WithTooltip text="Here's a tooltip" containerStyle={styles.container} showOnPressMobile={true}>
+        <Kb.WithTooltip tooltip="Here's a tooltip" containerStyle={styles.container} showOnPressMobile={true}>
           <Kb.Box style={styles.box}>
             <Kb.Text type="Body">Hover me for a short tooltip</Kb.Text>
           </Kb.Box>
         </Kb.WithTooltip>
         <Kb.WithTooltip
           containerStyle={styles.container}
-          text="Here's a multiline tooltip lalala blahblah wejoif jewiofj weoifjwof iwjeoif jweoifj weoifj woief"
+          tooltip="Here's a multiline tooltip lalala blahblah wejoif jewiofj weoifjwof iwjeoif jweoifj weoifj woief"
           multiline={true}
           showOnPressMobile={true}
         >
@@ -34,7 +34,7 @@ const load = () => {
         </Kb.WithTooltip>
         <Kb.WithTooltip
           containerStyle={styles.container}
-          text="Here's a short tooltip"
+          tooltip="Here's a short tooltip"
           position="bottom center"
           showOnPressMobile={true}
         >
@@ -44,7 +44,7 @@ const load = () => {
         </Kb.WithTooltip>
         <Kb.WithTooltip
           containerStyle={styles.container}
-          text="Here's a short tooltip"
+          tooltip="Here's a short tooltip"
           position="top left"
           showOnPressMobile={true}
         >
@@ -54,7 +54,7 @@ const load = () => {
         </Kb.WithTooltip>
         <Kb.WithTooltip
           containerStyle={styles.container}
-          text="Here's a short tooltip"
+          tooltip="Here's a short tooltip"
           position="top right"
           showOnPressMobile={true}
         >
@@ -64,7 +64,7 @@ const load = () => {
         </Kb.WithTooltip>
         <Kb.WithTooltip
           containerStyle={styles.container}
-          text="Here's a short tooltip"
+          tooltip="Here's a short tooltip"
           position="bottom left"
           showOnPressMobile={true}
         >
@@ -74,7 +74,7 @@ const load = () => {
         </Kb.WithTooltip>
         <Kb.WithTooltip
           containerStyle={styles.container}
-          text="Here's a short tooltip"
+          tooltip="Here's a short tooltip"
           position="bottom right"
           showOnPressMobile={true}
         >

--- a/shared/common-adapters/with-tooltip.d.ts
+++ b/shared/common-adapters/with-tooltip.d.ts
@@ -4,7 +4,7 @@ import {Position} from './relative-popup-hoc.types'
 
 export type Props = {
   disabled?: boolean
-  text: string
+  text: string | React.ReactNode
   multiline?: boolean
   containerStyle?: StylesCrossPlatform
   children: React.ReactNode

--- a/shared/common-adapters/with-tooltip.d.ts
+++ b/shared/common-adapters/with-tooltip.d.ts
@@ -4,7 +4,7 @@ import {Position} from './relative-popup-hoc.types'
 
 export type Props = {
   disabled?: boolean
-  text: string | React.ReactNode
+  tooltip: string | React.ReactNode
   multiline?: boolean
   containerStyle?: StylesCrossPlatform
   children: React.ReactNode

--- a/shared/common-adapters/with-tooltip.desktop.tsx
+++ b/shared/common-adapters/with-tooltip.desktop.tsx
@@ -59,7 +59,7 @@ class WithTooltip extends React.Component<Props, State> {
               styles.container,
               this.props.multiline && styles.containerMultiline,
             ])}
-            visible={!!this.props.text && this.state.visible}
+            visible={!!this.props.tooltip && this.state.visible}
             attachTo={this._getAttachmentRef}
             position={this.props.position || 'top center'}
             className={this.props.toastClassName}
@@ -69,7 +69,7 @@ class WithTooltip extends React.Component<Props, State> {
               type="BodySmall"
               style={Styles.collapseStyles([styles.text, this.props.textStyle])}
             >
-              {this.props.text}
+              {this.props.tooltip}
             </Kb.Text>
           </Kb.Toast>
         )}

--- a/shared/common-adapters/with-tooltip.native.tsx
+++ b/shared/common-adapters/with-tooltip.native.tsx
@@ -109,7 +109,7 @@ const WithTooltip = (props: Props) => {
                   style={Styles.collapseStyles([styles.text, props.textStyle])}
                   lineClamp={props.multiline ? undefined : 1}
                 >
-                  {props.text}
+                  {props.tooltip}
                 </Kb.Text>
               </Kb.NativeView>
             </Kb.NativeView>

--- a/shared/fs/common/new-folder.tsx
+++ b/shared/fs/common/new-folder.tsx
@@ -12,7 +12,7 @@ type OwnProps = {
 
 const NewFolder = props =>
   props.canCreateNewFolder && (
-    <Kb.WithTooltip text="New Folder">
+    <Kb.WithTooltip tooltip="New Folder">
       <Kb.Icon
         type="iconfont-folder-new"
         color={Styles.globalColors.black_50}

--- a/shared/fs/common/open-chat.tsx
+++ b/shared/fs/common/open-chat.tsx
@@ -13,7 +13,7 @@ type OwnProps = {
 
 const OpenChat = props =>
   props.onChat && (
-    <Kb.WithTooltip text={`Chat with users in this ${props.isTeam ? 'team' : 'folder'}`}>
+    <Kb.WithTooltip tooltip={`Chat with users in this ${props.isTeam ? 'team' : 'folder'}`}>
       <Kb.Icon
         type="iconfont-chat"
         color={Styles.globalColors.black_50}

--- a/shared/fs/common/open-in-system-file-manager.tsx
+++ b/shared/fs/common/open-in-system-file-manager.tsx
@@ -20,7 +20,7 @@ type Props = {
 }
 
 const OpenInSystemFileManager = ({openInSystemFileManager}: Props) => (
-  <WithTooltip text={`Show in ${fileUIName}`}>
+  <WithTooltip tooltip={`Show in ${fileUIName}`}>
     <Icon
       type="iconfont-finder"
       padding="tiny"
@@ -33,7 +33,7 @@ const OpenInSystemFileManager = ({openInSystemFileManager}: Props) => (
 
 const FinderPopup = OverlayParentHOC((props: Props & OverlayParentProps) => (
   <>
-    <WithTooltip text={`Show in ${fileUIName}`}>
+    <WithTooltip tooltip={`Show in ${fileUIName}`}>
       <Icon
         type="iconfont-finder"
         padding="tiny"

--- a/shared/fs/common/path-item-action/index.tsx
+++ b/shared/fs/common/path-item-action/index.tsx
@@ -36,7 +36,7 @@ export type Props = {
 }
 
 const IconClickable = props => (
-  <Kb.WithTooltip text="More actions">
+  <Kb.WithTooltip tooltip="More actions">
     <Kb.Icon
       type="iconfont-ellipsis"
       color={props.actionIconWhite ? Styles.globalColors.white : Styles.globalColors.black_50}

--- a/shared/fs/common/path-item-info.tsx
+++ b/shared/fs/common/path-item-info.tsx
@@ -84,7 +84,7 @@ const PathItemInfo = (props: Props) => {
       {props.showTooltipOnName ? (
         <Kb.WithTooltip
           containerStyle={styles.nameTextBox}
-          text={Types.pathToString(props.path)}
+          tooltip={Types.pathToString(props.path)}
           multiline={true}
           showOnPressMobile={true}
         >

--- a/shared/fs/common/sync-status.tsx
+++ b/shared/fs/common/sync-status.tsx
@@ -80,7 +80,7 @@ function getTooltip(props: Props): string {
 }
 
 const SyncStatus = (props: Props) => (
-  <Kb.WithTooltip text={getTooltip(props)}>
+  <Kb.WithTooltip tooltip={getTooltip(props)}>
     {typeof props.status === 'number' ? (
       <Kb.Box2 direction="horizontal" style={{margin: Styles.globalMargins.xtiny}}>
         <PieSlice degrees={360 * props.status} animated={true} />

--- a/shared/fs/footer/downloads.tsx
+++ b/shared/fs/footer/downloads.tsx
@@ -46,7 +46,7 @@ const Desktop = (props: DownloadsProps) =>
           <Download downloadKey={key} key={key} isFirst={index === 0} />
         ))}
         {props.downloadKeys.length > 3 && (
-          <Kb.WithTooltip text="Open Downloads folder">
+          <Kb.WithTooltip tooltip="Open Downloads folder">
             <Kb.Icon
               style={styles.iconBoxEllipsis}
               type="iconfont-ellipsis"
@@ -58,7 +58,7 @@ const Desktop = (props: DownloadsProps) =>
           </Kb.WithTooltip>
         )}
         <Kb.Box style={styles.space} />
-        <Kb.WithTooltip text="Open Downloads folder">
+        <Kb.WithTooltip tooltip="Open Downloads folder">
           <Kb.Icon
             type="iconfont-folder-downloads"
             hint="Open downloads folder"

--- a/shared/people/follow-notification/index.tsx
+++ b/shared/people/follow-notification/index.tsx
@@ -87,7 +87,7 @@ export const MultiFollowNotification = (props: Props) => {
         contentContainerStyle={styles.scrollViewContainer}
       >
         {usernames.map(username => (
-          <Kb.WithTooltip key={username} text={username}>
+          <Kb.WithTooltip key={username} tooltip={username}>
             <Kb.Avatar
               onClick={() => props.onClickUser(username)}
               username={username}

--- a/shared/router-v2/header/syncing-folders.tsx
+++ b/shared/router-v2/header/syncing-folders.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 const SyncingFolders = (props: Props) =>
   props.show && props.progress !== 1.0 ? (
-    <Kb.WithTooltip text={props.tooltip}>
+    <Kb.WithTooltip tooltip={props.tooltip}>
       <Kb.Box2 direction="horizontal" alignItems="center">
         <PieSlice degrees={props.progress * 360} animated={true} negative={props.negative} />
         <Kb.Text type="BodyTiny" negative={props.negative} style={{marginLeft: 5}}>

--- a/shared/router-v2/tab-bar/index.desktop.tsx
+++ b/shared/router-v2/tab-bar/index.desktop.tsx
@@ -138,7 +138,7 @@ class TabBar extends React.PureComponent<Props, State> {
           {tabs.map((t, i) => (
             <Kb.ClickableBox key={t} onClick={() => p.onTabClick(t)}>
               <Kb.WithTooltip
-                text={`${data[t].label} (${Platforms.shortcutSymbol}${i + 1})`}
+                tooltip={`${data[t].label} (${Platforms.shortcutSymbol}${i + 1})`}
                 toastClassName="tab-tooltip"
               >
                 <Kb.Box2

--- a/shared/settings/account/index.tsx
+++ b/shared/settings/account/index.tsx
@@ -42,7 +42,7 @@ const AddButton = (props: {disabled: boolean; kind: 'phone number' | 'email'; on
     />
   )
   return props.disabled ? (
-    <Kb.WithTooltip text={`You have the maximum number of ${props.kind}s. To add another, first remove one.`}>
+    <Kb.WithTooltip tooltip={`You have the maximum number of ${props.kind}s. To add another, first remove one.`}>
       {btn}
     </Kb.WithTooltip>
   ) : (

--- a/shared/settings/account/index.tsx
+++ b/shared/settings/account/index.tsx
@@ -42,7 +42,9 @@ const AddButton = (props: {disabled: boolean; kind: 'phone number' | 'email'; on
     />
   )
   return props.disabled ? (
-    <Kb.WithTooltip tooltip={`You have the maximum number of ${props.kind}s. To add another, first remove one.`}>
+    <Kb.WithTooltip
+      tooltip={`You have the maximum number of ${props.kind}s. To add another, first remove one.`}
+    >
       {btn}
     </Kb.WithTooltip>
   ) : (

--- a/shared/team-building/go-button.tsx
+++ b/shared/team-building/go-button.tsx
@@ -18,7 +18,7 @@ const Go = (props: {label: Label}) => (
 const GoButton = (props: Props) => (
   <Kb.ClickableBox onClick={() => props.onClick()} style={styles.container}>
     <Kb.WithTooltip
-      text={
+      tooltip={
         <Kb.Box2 direction="horizontal">
           <Kb.Icon
             type="iconfont-return"

--- a/shared/team-building/go-button.tsx
+++ b/shared/team-building/go-button.tsx
@@ -9,33 +9,32 @@ export type Props = {
   label: Label
 }
 
-const Go = (label: Label) => () => (
+const Go = (props: {label: Label}) => (
   <Kb.Text type="BodyBig" style={styles.go}>
-    {label}
+    {props.label}
   </Kb.Text>
 )
 
-const GoIcon = () => (
-  <Kb.Icon
-    type="iconfont-return"
-    fontSize={16}
-    color={Styles.globalColors.white}
-    style={Kb.iconCastPlatformStyles(styles.goIcon)}
-  />
-)
-
-const GoWithIconHover = Kb.HoverHoc(Go('Start'), GoIcon)
-const AddWithIconHover = Kb.HoverHoc(Go('Add'), GoIcon)
-
 const GoButton = (props: Props) => (
   <Kb.ClickableBox onClick={() => props.onClick()} style={styles.container}>
-    <Kb.Box2 direction="vertical" fullHeight={true} centerChildren={true}>
-      {props.label === 'Start' ? (
-        <GoWithIconHover hoverContainerStyle={styles.hoverContainerStyle} />
-      ) : (
-        <AddWithIconHover hoverContainerStyle={styles.hoverContainerStyle} />
-      )}
-    </Kb.Box2>
+    <Kb.WithTooltip
+      text={
+        <Kb.Box2 direction="horizontal">
+          <Kb.Icon
+            type="iconfont-return"
+            sizeType="Small"
+            color={Styles.globalColors.white}
+            style={styles.goTooltipIcon}
+          />
+          Enter
+        </Kb.Box2>
+      }
+      containerStyle={styles.goTooltipIconContainer}
+    >
+      <Kb.Box2 direction="vertical" fullHeight={true} centerChildren={true}>
+        {props.label === 'Start' ? <Go label="Start" /> : <Go label="Add" />}
+      </Kb.Box2>
+    </Kb.WithTooltip>
   </Kb.ClickableBox>
 )
 
@@ -59,6 +58,17 @@ const styles = Styles.styleSheetCreate(() => ({
   goIcon: Styles.platformStyles({
     isElectron: {
       lineHeight: 40,
+    },
+  }),
+  goTooltipIcon: Styles.platformStyles({
+    isElectron: {
+      marginRight: Styles.globalMargins.xtiny,
+      verticalAlign: 'middle',
+    },
+  }),
+  goTooltipIconContainer: Styles.platformStyles({
+    isElectron: {
+      ...Styles.globalStyles.fullHeight,
     },
   }),
   hoverContainerStyle: Styles.platformStyles({

--- a/shared/team-building/service-tab-bar.desktop.tsx
+++ b/shared/team-building/service-tab-bar.desktop.tsx
@@ -101,7 +101,7 @@ const MoreNetworksButton = Kb.OverlayParentHOC(
           centerChildren={true}
           ref={props.setAttachmentRef}
         >
-          <Kb.WithTooltip text="More networks" containerStyle={styles.moreNetworks2}>
+          <Kb.WithTooltip tooltip="More networks" containerStyle={styles.moreNetworks2}>
             <Kb.ClickableBox onClick={props.toggleShowingMenu} style={styles.moreNetworks3}>
               <Kb.Text type="BodyBigExtrabold" style={styles.moreText}>
                 •••

--- a/shared/team-building/user-bubble.tsx
+++ b/shared/team-building/user-bubble.tsx
@@ -26,7 +26,7 @@ const UserBubble = (props: Props) => {
   }
   return (
     <Kb.Box2 direction="vertical" className="hover-container" style={styles.bubbleContainer}>
-      <Kb.WithTooltip text={props.tooltip} position="top center">
+      <Kb.WithTooltip tooltip={props.tooltip} position="top center">
         <Kb.Box2 direction="horizontal" style={styles.bubble}>
           <Kb.ConnectedNameWithIcon
             colorFollowing={true}

--- a/shared/team-building/user-result.desktop.tsx
+++ b/shared/team-building/user-result.desktop.tsx
@@ -163,7 +163,7 @@ const Services = ({
     return (
       <Kb.Box2 direction="horizontal" style={styles.services}>
         {services.map(service => (
-          <Kb.WithTooltip key={service} text={services[service]} position="top center">
+          <Kb.WithTooltip key={service} tooltip={services[service]} position="top center">
             <Kb.Icon
               type={serviceIdToIconFont(service as Types.ServiceIdWithContact)}
               style={Kb.iconCastPlatformStyles(styles.serviceIcon)}

--- a/shared/team-building/user-result.native.tsx
+++ b/shared/team-building/user-result.native.tsx
@@ -98,7 +98,7 @@ const FormatPrettyName = (props: {
         )
       )}
       {props.services.map(service => (
-        <Kb.WithTooltip key={service} text={service} position="top center">
+        <Kb.WithTooltip key={service} tooltip={service} position="top center">
           <Kb.Icon
             fontSize={14}
             type={serviceIdToIconFont(service)}

--- a/shared/teams/main/index.tsx
+++ b/shared/teams/main/index.tsx
@@ -92,7 +92,7 @@ export const TeamRow = React.memo<RowProps>((props: RowProps) => {
             {props.onManageChat ? (
               <ChatIcon />
             ) : (
-              <Kb.WithTooltip text="You need to join this team before you can chat.">
+              <Kb.WithTooltip tooltip="You need to join this team before you can chat.">
                 <ChatIcon />
               </Kb.WithTooltip>
             )}

--- a/shared/tracker2/assertion/index.tsx
+++ b/shared/tracker2/assertion/index.tsx
@@ -157,7 +157,7 @@ class _StellarValue extends React.PureComponent<
       </Kb.Text>
     ) : (
       <Kb.Box ref={r => this._storeAttachmentRef(r)} style={styles.tooltip}>
-        <Kb.WithTooltip text={Styles.isMobile || this.props.showingMenu ? '' : 'Stellar Federation Address'}>
+        <Kb.WithTooltip tooltip={Styles.isMobile || this.props.showingMenu ? '' : 'Stellar Federation Address'}>
           <Kb.Text
             type="BodyPrimaryLink"
             onClick={this.props.toggleShowingMenu}

--- a/shared/tracker2/assertion/index.tsx
+++ b/shared/tracker2/assertion/index.tsx
@@ -157,7 +157,9 @@ class _StellarValue extends React.PureComponent<
       </Kb.Text>
     ) : (
       <Kb.Box ref={r => this._storeAttachmentRef(r)} style={styles.tooltip}>
-        <Kb.WithTooltip tooltip={Styles.isMobile || this.props.showingMenu ? '' : 'Stellar Federation Address'}>
+        <Kb.WithTooltip
+          tooltip={Styles.isMobile || this.props.showingMenu ? '' : 'Stellar Federation Address'}
+        >
           <Kb.Text
             type="BodyPrimaryLink"
             onClick={this.props.toggleShowingMenu}

--- a/shared/tracker2/bio/index.tsx
+++ b/shared/tracker2/bio/index.tsx
@@ -114,7 +114,7 @@ const Bio = (p: Props) => (
         p.airdropIsLive &&
         p.registeredForAirdrop &&
         (p.youAreInAirdrop ? (
-          <Kb.WithTooltip text="Lucky airdropee">
+          <Kb.WithTooltip tooltip="Lucky airdropee">
             <Kb.Icon
               color={Styles.globalColors.yellowDark}
               type="iconfont-identity-stellar"

--- a/shared/wallets/asset/index.tsx
+++ b/shared/wallets/asset/index.tsx
@@ -169,7 +169,7 @@ const BalanceSummary = (props: BalanceSummaryProps) => (
           </Kb.Text>
           {reserve.description === 'account' && (
             <Kb.WithTooltip
-              text="Minimum balances help protect the network from the creation of spam accounts."
+              tooltip="Minimum balances help protect the network from the creation of spam accounts."
               multiline={true}
             >
               <Kb.Icon

--- a/shared/wallets/common/buttons/index.tsx
+++ b/shared/wallets/common/buttons/index.tsx
@@ -38,7 +38,7 @@ const _SendButton = (props: Kb.PropsWithOverlay<SendProps>) => {
     </>
   )
   return props.thisDeviceIsLockedOut ? (
-    <Kb.WithTooltip text="You can only send from a mobile device more than 7 days old.">
+    <Kb.WithTooltip tooltip="You can only send from a mobile device more than 7 days old.">
       {button}
     </Kb.WithTooltip>
   ) : (

--- a/shared/wallets/send-form/calculate-advanced-button.tsx
+++ b/shared/wallets/send-form/calculate-advanced-button.tsx
@@ -29,7 +29,7 @@ const CalculateAdvancedButton = (props: CalculateAdvancedButtonProps) => {
         <Kb.Icon type="iconfont-remove" sizeType="Big" color={Styles.globalColors.red} />
       ) : (
         <Kb.WithTooltip
-          text="Calculate the amount you will send"
+          tooltip="Calculate the amount you will send"
           position="bottom left"
           disabled={isDisabled}
         >

--- a/shared/wallets/send-form/footer/index.tsx
+++ b/shared/wallets/send-form/footer/index.tsx
@@ -85,7 +85,7 @@ const Footer = (props: Props) => {
           )}
           {!!props.onClickSend &&
             (props.thisDeviceIsLockedOut ? (
-              <Kb.WithTooltip text="This is a mobile-only wallet." containerStyle={styles.fullWidth}>
+              <Kb.WithTooltip tooltip="This is a mobile-only wallet." containerStyle={styles.fullWidth}>
                 {sendButton}
               </Kb.WithTooltip>
             ) : (

--- a/shared/wallets/transaction-details/index.tsx
+++ b/shared/wallets/transaction-details/index.tsx
@@ -448,7 +448,7 @@ const TransactionDetails = (props: NotLoadingProps) => {
           <Kb.Text type="BodySmallSemibold">Status:</Kb.Text>
           <Kb.WithTooltip
             containerStyle={styles.statusBox}
-            text={
+            tooltip={
               props.status === 'claimable'
                 ? `${
                     props.counterparty

--- a/shared/wallets/trustline/asset.tsx
+++ b/shared/wallets/trustline/asset.tsx
@@ -131,7 +131,7 @@ const Asset = (props: Props) => {
           {props.expanded ? bodyExpanded(props) : bodyCollapsed(props)}
           <Kb.Box2 direction="vertical" style={styles.actions} centerChildren={true}>
             {props.thisDeviceIsLockedOut ? (
-              <Kb.WithTooltip text="You can only send from a mobile device more than 7 days old.">
+              <Kb.WithTooltip tooltip="You can only send from a mobile device more than 7 days old.">
                 {button}
               </Kb.WithTooltip>
             ) : (

--- a/shared/wallets/wallet/settings/index.tsx
+++ b/shared/wallets/wallet/settings/index.tsx
@@ -282,7 +282,7 @@ class AccountSettings extends React.Component<SettingsProps> {
                 <Kb.Text type="BodySmallSemibold">Inflation destination</Kb.Text>
                 {!Styles.isMobile && (
                   <Kb.WithTooltip
-                    text="Every year, the total Lumens grows by 1% due to inflation, and you can cast a vote for who gets it."
+                    tooltip="Every year, the total Lumens grows by 1% due to inflation, and you can cast a vote for who gets it."
                     multiline={true}
                   >
                     <Kb.Icon type="iconfont-question-mark" sizeType="Small" />


### PR DESCRIPTION
### Design
![image](https://user-images.githubusercontent.com/5200812/64562062-22ebcd00-d31a-11e9-8ee1-d2ffdd30f5eb.png)

### Overview
Changes `Kb.WithTooltip` component to also take React nodes as `text` so that the return icon can be rendered next to text.

Not entirely feeling this approach, so here are some things I thought about changing:

1. Rename `text` prop to something like `text`/`content`/`body`
2. Or add an additional prop in addition to `text`, something like `textComponent`

### Screenshots

![image](https://user-images.githubusercontent.com/5200812/64562084-2d0dcb80-d31a-11e9-9e7a-30d4ba7eb5c1.png)

@keybase/react-hackers 
