### PR TITLE
Show native android logs in android log dumps (+ quick reply error handling)

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/ChatBroadcastReceiver.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/ChatBroadcastReceiver.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.support.annotation.RequiresApi;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
+import android.util.Log;
 
 import keybase.Keybase;
 
@@ -29,15 +30,16 @@ public class ChatBroadcastReceiver extends BroadcastReceiver {
   @RequiresApi(api = Build.VERSION_CODES.KITKAT_WATCH)
   @Override
   public void onReceive(Context context, Intent intent) {
+    ConvData convData = new ConvData(intent);
+    PendingIntent openConv = intent.getParcelableExtra("openConvPendingIntent");
+    NotificationCompat.Builder repliedNotification = new NotificationCompat.Builder(context, KeybasePushNotificationListenerService.CHAT_CHANNEL_ID)
+      .setContentIntent(openConv)
+      .setTimeoutAfter(1000)
+      .setSmallIcon(R.drawable.ic_notif);
+    NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+
     String messageBody = getMessageText(intent);
     if (messageBody != null) {
-      ConvData convData = new ConvData(intent);
-      PendingIntent openConv = intent.getParcelableExtra("openConvPendingIntent");
-
-      NotificationCompat.Builder repliedNotification = new NotificationCompat.Builder(context, KeybasePushNotificationListenerService.CHAT_CHANNEL_ID)
-        .setContentIntent(openConv)
-        .setTimeoutAfter(1000)
-        .setSmallIcon(R.drawable.ic_notif);
 
       try {
         WithBackgroundActive withBackgroundActive = () -> Keybase.handlePostTextReply(convData.convID, convData.tlfName, messageBody);
@@ -48,9 +50,12 @@ public class ChatBroadcastReceiver extends BroadcastReceiver {
         e.printStackTrace();
       }
 
-      NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-      notificationManager.notify(convData.convID, 0, repliedNotification.build());
+    } else {
+      repliedNotification.setContentText("Couldn't send reply - Failed to read input.");
+      Log.d("KBQuickReply", "MessageBody was null");
     }
+
+    notificationManager.notify(convData.convID, 0, repliedNotification.build());
   }
 }
 
@@ -77,6 +82,4 @@ class ConvData {
     intent.putExtra("ConvData", data);
     return intent;
   }
-
-
 }

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/ChatBroadcastReceiver.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/ChatBroadcastReceiver.java
@@ -12,6 +12,7 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.util.Log;
 
+import io.keybase.ossifrage.modules.NativeLogger;
 import keybase.Keybase;
 
 public class ChatBroadcastReceiver extends BroadcastReceiver {
@@ -47,12 +48,12 @@ public class ChatBroadcastReceiver extends BroadcastReceiver {
         repliedNotification.setContentText("Replied");
       } catch (Exception e) {
         repliedNotification.setContentText("Couldn't send reply");
-        e.printStackTrace();
+        NativeLogger.error("Failed to send quick reply", e);
       }
 
     } else {
       repliedNotification.setContentText("Couldn't send reply - Failed to read input.");
-      Log.d("KBQuickReply", "MessageBody was null");
+      NativeLogger.error("Message Body in quick reply was null");
     }
 
     notificationManager.notify(convData.convID, 0, repliedNotification.build());

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -311,6 +311,12 @@ interface WithBackgroundActive {
         } else {
           Keybase.setAppStateBackgroundActive();
           this.task();
+
+          // Check if we are foreground now for some reason. In that case we don't want to go background again
+          if (Keybase.isAppStateForeground()) {
+              return;
+          }
+
           if (Keybase.appDidEnterBackground()) {
               Keybase.appBeginBackgroundTaskNonblock(new KBPushNotifier(context, new Bundle()));
           } else {

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -23,7 +23,6 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -70,7 +69,7 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
         String mobileOsVersion = Integer.toString(android.os.Build.VERSION.SDK_INT);
         initOnce(getApplicationContext().getFilesDir().getPath(), "", getApplicationContext().getFileStreamPath("service.log").getAbsolutePath(), "prod", false,
           new DNSNSFetcher(), new VideoHelper(), mobileOsVersion);
-        NativeLogger.info("KeybasePushNotificationListenerService created. path: " + getApplicationContext().getFilesDir().getPath());
+        NativeLogger.info("KeybasePushNotificationListenerService created");
 
         createNotificationChannel(this);
 
@@ -162,7 +161,7 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
             }
         }
 
-        NativeLogger.info("KeybasePushNotificationListenerService.onMessageReceived: " + bundle);
+        NativeLogger.info("KeybasePushNotificationListenerService.onMessageReceived");
 
         try {
             String type = bundle.getString("type");

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/modules/NativeLogger.java
@@ -1,7 +1,6 @@
 package io.keybase.ossifrage.modules;
 
 import android.util.Log;
-import android.util.JsonWriter;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -14,69 +13,46 @@ import com.facebook.react.bridge.WritableArray;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.StringWriter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
 public class NativeLogger extends ReactContextBaseJavaModule {
     private static final String NAME = "KBNativeLogger";
+    private static final String RN_NAME = "ReactNativeJS";
 
-    // Must match strings passed to NativeLogger in
-    // shared/logger/index.js.
-    private static final String ERROR_TAG = "e";
-    private static final String INFO_TAG = "i";
-    private static final String WARN_TAG = "w";
 
     private static void rawLog(String tag, String jsonLog) {
         Log.i(tag + NAME, jsonLog);
     }
 
-    // This should do roughly the same thing as dumpLine from
-    // native-logger.js.
-    private static String dumpLine(String toLog) {
-        long millis = System.currentTimeMillis();
-        StringWriter sw = new StringWriter();
-        JsonWriter js = new JsonWriter(sw);
-        try {
-            js.beginArray()
-                .value(millis)
-                .value(toLog)
-                .endArray()
-                .close();
-            return sw.toString();
-        } catch (IOException e) {
-            rawLog(ERROR_TAG, "Exception in dumpLine: " + Log.getStackTraceString(e));
-            return toLog;
-        }
-    }
-
-    private static String dumpLine(String toLog, Throwable tr) {
-      return dumpLine(toLog + ": " + Log.getStackTraceString(tr));
+    private static String formatLine(String tagPrefix, String toLog) {
+        // Copies the Style JS outputs in native/logger.native.tsx
+        return tagPrefix + NAME + ": [" + System.currentTimeMillis() + ",\"" + toLog + "\"]";
     }
 
     public static void error(String log) {
-        rawLog(ERROR_TAG, dumpLine(log));
+        Log.e(RN_NAME, formatLine("e", log));
     }
 
     public static void error(String log, Throwable tr) {
-        rawLog(ERROR_TAG, dumpLine(log, tr));
+        Log.e(RN_NAME, formatLine("e", log + Log.getStackTraceString(tr)));
     }
 
     public static void info(String log) {
-        rawLog(INFO_TAG, dumpLine(log));
+        Log.i(RN_NAME, formatLine("i", log));
     }
 
     public static void info(String log, Throwable tr) {
-        rawLog(INFO_TAG, dumpLine(log, tr));
+        Log.i(RN_NAME, formatLine("i", log + Log.getStackTraceString(tr)));
     }
 
     public static void warn(String log) {
-        rawLog(WARN_TAG, dumpLine(log));
+        Log.i(RN_NAME, formatLine("w", log));
     }
 
     public static void warn(String log, Throwable tr) {
-        rawLog(WARN_TAG, dumpLine(log, tr));
+        Log.i(RN_NAME, formatLine("w", log + Log.getStackTraceString(tr)));
     }
 
     public NativeLogger(final ReactApplicationContext reactContext) {
@@ -100,7 +76,7 @@ public class NativeLogger extends ReactContextBaseJavaModule {
     @ReactMethod
     public void dump(String tagPrefix, Promise promise) {
         try {
-            String cmd = "logcat -m 10000 -d " + "ReactNativeJS" + ":I *:S";
+            String cmd = "logcat -m 10000 -d " + RN_NAME + ":I *:S";
 
             Process process = Runtime.getRuntime().exec(cmd);
             BufferedReader r = new BufferedReader(new InputStreamReader(process.getInputStream()));
@@ -116,7 +92,7 @@ public class NativeLogger extends ReactContextBaseJavaModule {
             promise.resolve(totalArray);
         } catch (IOException e) {
             promise.reject(e);
-            rawLog(ERROR_TAG, "Exception in dump: " + Log.getStackTraceString(e));
+            error("Exception in dump: ", e);
         }
     }
 }


### PR DESCRIPTION
(but only when we use the NativeLogger interface)

This is kind of hacked in. I basically copy the output of what `console.log` was doing, that way when we read the logs from logcat we get the native logs as well (since there is no difference between a log line from java and one from js)

This is in effort to debug why quick reply fails sometimes

@jzila @keybase/react-hackers 