### PR TITLE
Remove unsafe update in sentVerificationEmail reducer

### DIFF
--- a/shared/reducers/settings.tsx
+++ b/shared/reducers/settings.tsx
@@ -232,19 +232,18 @@ function reducer(state: Types.State = initialState, action: Actions): Types.Stat
       )
     }
     case SettingsGen.sentVerificationEmail: {
-      return state
-        .update('email', emailState =>
-          emailState.merge({
-            addedEmail: action.payload.email,
-          })
-        )
-        .updateIn(['email', 'emails'], emails => {
-          return emails.update(action.payload.email, email =>
-            email.merge({
-              lastVerifyEmailDate: new Date().getTime() / 1000,
-            })
-          )
+      return state.update('email', emailState =>
+        emailState.merge({
+          addedEmail: action.payload.email,
+          emails: (emailState.emails || I.Map<string, Types.EmailRow>()).update(
+            action.payload.email,
+            (email = Constants.makeEmailRow({email: action.payload.email, isVerified: false})) =>
+              email.merge({
+                lastVerifyEmailDate: new Date().getTime() / 1000,
+              })
+          ),
         })
+      )
     }
     case SettingsGen.clearAddingEmail: {
       return state.update('email', emailState => emailState.merge({addingEmail: null, error: ''}))


### PR DESCRIPTION
`updateIn` made `emails` `any`, the real type is `I.Map<string, Types.EmailRow> | null`. The error surfaces in logs as .

> null is not an object (evaluating 'n.update') 

Right after a `sentVerificationEmail` action. Shuffle around to remove the implicit any. cc @keybase/y2ksquad 