### PR TITLE
client: new `fs uploads` command

### DIFF
--- a/go/client/cmd_simplefs.go
+++ b/go/client/cmd_simplefs.go
@@ -51,6 +51,7 @@ func NewCmdSimpleFS(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 			NewCmdSimpleFSClearConflicts(cl, g),
 			NewCmdSimpleFSFinishResolvingConflicts(cl, g),
 			NewCmdSimpleFSSync(cl, g),
+			NewCmdSimpleFSUploads(cl, g),
 		}, getBuildSpecificFSCommands(cl, g)...),
 	}
 }

--- a/go/client/cmd_simplefs_uploads.go
+++ b/go/client/cmd_simplefs_uploads.go
@@ -1,0 +1,95 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+// CmdSimpleFSUploads is the 'fs ps' command.
+type CmdSimpleFSUploads struct {
+	libkb.Contextified
+	filter keybase1.ListFilter
+}
+
+// NewCmdSimpleFSUploads creates a new cli.Command.
+func NewCmdSimpleFSUploads(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "uploads",
+		Usage: "list current uploads",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSUploads{
+				Contextified: libkb.NewContextified(g)}, "uploads", c)
+			cl.SetNoStandalone()
+		},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "a, all",
+				Usage: "include entries starting with '.'",
+			},
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSUploads) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	status, err := cli.SimpleFSSyncStatus(context.TODO(), c.filter)
+	if err != nil {
+		return err
+	}
+
+	ui := c.G().UI.GetTerminalUI()
+	if len(status.SyncingPaths) == 0 && status.TotalSyncingBytes == 0 {
+		ui.Printf("There are currently no uploads\n")
+		return nil
+	}
+
+	sort.Strings(status.SyncingPaths)
+	for _, p := range status.SyncingPaths {
+		ui.Printf("%s\n", p)
+	}
+	if len(status.SyncingPaths) > 0 {
+		ui.Printf("\n")
+	}
+	ui.Printf(
+		"%s left to upload\n", humanizeBytes(status.TotalSyncingBytes, false))
+	if status.EndEstimate != nil {
+		timeRemaining := time.Until(keybase1.FromTime(*status.EndEstimate))
+		ui.Printf("Estimated time remaining: %s\n",
+			timeRemaining.Round(1*time.Second))
+	}
+	return nil
+}
+
+// ParseArgv gets the optional -r switch
+func (c *CmdSimpleFSUploads) ParseArgv(ctx *cli.Context) error {
+	if ctx.Bool("all") {
+		c.filter = keybase1.ListFilter_NO_FILTER
+	} else {
+		c.filter = keybase1.ListFilter_FILTER_ALL_HIDDEN
+	}
+
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSUploads) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/cmd_simplefs_uploads.go
+++ b/go/client/cmd_simplefs_uploads.go
@@ -53,7 +53,7 @@ func (c *CmdSimpleFSUploads) Run() error {
 
 	ui := c.G().UI.GetTerminalUI()
 	if len(status.SyncingPaths) == 0 && status.TotalSyncingBytes == 0 {
-		ui.Printf("There are currently no uploads\n")
+		ui.Printf("There are currently no uploads in progress\n")
 		return nil
 	}
 

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -2257,7 +2257,8 @@ func (k *SimpleFS) SimpleFSSyncStatus(ctx context.Context, filter keybase1.ListF
 		syncingPaths = status.UnflushedPaths
 	} else {
 		for _, p := range status.UnflushedPaths {
-			if isFiltered(filter, p) {
+
+			if isFiltered(filter, stdpath.Base(p)) {
 				continue
 			}
 			syncingPaths = append(syncingPaths, p)


### PR DESCRIPTION
Lists all paths that are currently uploading, along with the number of bytes remaining and the estimated time remaining.  By default it filters out dot files, but that can be switched off with `-a`.

Example:
```sh
$ keybase fs uploads -a
/keybase/private/strib/tmp
/keybase/private/strib/tmp/.100mb.5
/keybase/private/strib/tmp/100mb.5

100.43 MB left to upload
Estimated time remaining: 13m12s
$ keybase fs uploads
/keybase/private/strib/tmp
/keybase/private/strib/tmp/100mb.5

97.25 MB left to upload
Estimated time remaining: 4m57s
$
```

Also, in simplefs, correctly filter syncing paths by base name.

Issue: HOTPOT-784