### PR TITLE
always get tlfname summary in localize

### DIFF
--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -832,9 +832,13 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		if err == nil {
 			summaries = append(summaries, pinSummary)
 		}
-		tlfSummary, err := conversationRemote.GetMaxMessage(chat1.MessageType_TLFNAME)
-		if err == nil {
-			summaries = append(summaries, tlfSummary)
+		if len(summaries) == 0 ||
+			conversationRemote.GetMembersType() == chat1.ConversationMembersType_IMPTEAMUPGRADE ||
+			conversationRemote.GetMembersType() == chat1.ConversationMembersType_KBFS {
+			tlfSummary, err := conversationRemote.GetMaxMessage(chat1.MessageType_TLFNAME)
+			if err == nil {
+				summaries = append(summaries, tlfSummary)
+			}
 		}
 		msgs, err := s.G().ConvSource.GetMessages(ctx, conversationRemote,
 			uid, utils.PluckMessageIDs(summaries), nil)

--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -960,6 +960,12 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 			conversationLocal.Info.Triple.Tlfid,
 			conversationLocal.Info.Visibility == keybase1.TLFVisibility_PUBLIC)
 	default:
+		if len(conversationLocal.Info.TlfName) == 0 {
+			conversationLocal.Error = chat1.NewConversationErrorLocal(
+				"unable to get conversation name from message history", conversationRemote,
+				unverifiedTLFName, chat1.ConversationErrorType_TRANSIENT, nil)
+			return conversationLocal
+		}
 		info, ierr = infoSource.LookupID(ctx,
 			conversationLocal.Info.TlfName,
 			conversationLocal.Info.Visibility == keybase1.TLFVisibility_PUBLIC)


### PR DESCRIPTION
* Always get `TLFNAME` max message from summaries in case other messages are no good for old members types.
* Remove `getMessagesOffline`, the errors should just flow naturally out of the normal flow.
* Return a better error in the case where we can't get any name for the conv from messages.