### PR TITLE
More tweaks on the Chat input

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -331,17 +331,12 @@ const styles = Styles.styleSheetCreate(
           flex: 1,
           marginLeft: Styles.globalMargins.tiny,
           marginRight: Styles.globalMargins.tiny,
+          paddingBottom: Styles.globalMargins.tiny,
+          paddingTop: Styles.globalMargins.tiny,
         },
-        // Android doesn't because there is some intrinsic margins that are enough for our purpose.
         isAndroid: {
+          // This is to counteract some intrinsic margins the android view has
           marginTop: -8,
-          paddingBottom: Styles.globalMargins.tiny,
-          paddingTop: Styles.globalMargins.tiny,
-        },
-        // iOS needs these extra margins to give the text proper margins (Like you'd expect)
-        isIOS: {
-          paddingBottom: Styles.globalMargins.tiny,
-          paddingTop: Styles.globalMargins.tiny,
         },
       }),
       marginRightSmall: {

--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -301,7 +301,7 @@ const styles = Styles.styleSheetCreate(
         borderTopColor: Styles.globalColors.black_10,
         borderTopWidth: 1,
         flexShrink: 0,
-        minHeight: 48,
+        minHeight: 50,
         overflow: 'hidden',
         paddingRight: containerPadding,
       },
@@ -326,11 +326,24 @@ const styles = Styles.styleSheetCreate(
         alignSelf: 'flex-end',
         paddingBottom: isIOS ? 7 : 10,
       },
-      input: {
-        flex: 1,
-        marginLeft: Styles.globalMargins.tiny,
-        marginRight: Styles.globalMargins.tiny,
-      },
+      input: Styles.platformStyles({
+        common: {
+          flex: 1,
+          marginLeft: Styles.globalMargins.tiny,
+          marginRight: Styles.globalMargins.tiny,
+        },
+        // Android doesn't because there is some intrinsic margins that are enough for our purpose.
+        isAndroid: {
+          marginTop: -8,
+          paddingBottom: Styles.globalMargins.tiny,
+          paddingTop: Styles.globalMargins.tiny,
+        },
+        // iOS needs these extra margins to give the text proper margins (Like you'd expect)
+        isIOS: {
+          paddingBottom: Styles.globalMargins.tiny,
+          paddingTop: Styles.globalMargins.tiny,
+        },
+      }),
       marginRightSmall: {
         marginRight: Styles.globalMargins.small,
       },

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -19,30 +19,14 @@ import {Box2} from './box'
 
 import {InternalProps, TextInfo, Selection} from './plain-input'
 
-type ContentSizeChangeEvent = {
-  nativeEvent: {
-    contentSize: {
-      width: number
-      height: number
-    }
-  }
-}
-
-type State = {
-  height: number | null
-}
-
 // A plain text input component. Handles callbacks, text styling, and auto resizing but
 // adds no styling.
-class PlainInput extends Component<InternalProps, State> {
+class PlainInput extends Component<InternalProps> {
   static defaultProps = {
     keyboardType: 'default',
     textType: 'Body',
   }
 
-  state: State = {
-    height: null,
-  }
   _input = React.createRef<TextInput>()
   _lastNativeText: string | null = null
   _lastNativeSelection: Selection | null = null
@@ -140,23 +124,6 @@ class PlainInput extends Component<InternalProps, State> {
     this.props.onSelectionChange && this.props.onSelectionChange(this._lastNativeSelection)
   }
 
-  _onContentSizeChange = (event: ContentSizeChangeEvent) => {
-    if (this.props.multiline) {
-      let height = event.nativeEvent.contentSize.height
-      const minHeight = this.props.rowsMin && this.props.rowsMin * this._lineHeight()
-      const maxHeight = this.props.rowsMax && this.props.rowsMax * this._lineHeight()
-      if (minHeight && height < minHeight) {
-        height = minHeight
-      } else if (maxHeight && height > maxHeight) {
-        height = maxHeight
-      }
-
-      if (height !== this.state.height) {
-        this.setState({height})
-      }
-    }
-  }
-
   _lineHeight = () => {
     const textStyle = getTextStyle(this.props.textType)
     return textStyle.lineHeight
@@ -208,7 +175,6 @@ class PlainInput extends Component<InternalProps, State> {
         minHeight: (this.props.rowsMin || defaultRowsToShow) * lineHeight,
       },
       !!this.props.rowsMax && {maxHeight: this.props.rowsMax * lineHeight},
-      isIOS && !!this.state.height && {height: this.state.height},
       paddingStyles,
     ])
   }
@@ -257,7 +223,6 @@ class PlainInput extends Component<InternalProps, State> {
         ...common,
         blurOnSubmit: false,
         multiline: true,
-        onContentSizeChange: this._onContentSizeChange,
       }
     }
     return common
@@ -292,7 +257,7 @@ const styles = styleSheetCreate(() => ({
   multiline: platformStyles({
     isMobile: {
       height: undefined,
-      textAlignVertical: 'top', // android centers by default
+      textAlignVertical: 'bottom', // android centers by default
     },
   }),
   singleline: {padding: 0},


### PR DESCRIPTION
I removed the state for the content height. It doesn't seem like we need it and causes height jumping on ios (was only used on ios)

Some previews of what it looks like with this PR.

1. Single line / No text (Tested to make sure these are the same (no Jumping))
1. Multiple lines of text
1. Scrolling Up

[Android]

1. <img width="458" alt="Screen Shot 2019-09-11 at 5 52 37 PM" src="https://user-images.githubusercontent.com/594035/64745855-510a1200-d4be-11e9-9c75-abd202e06c25.png">
2. <img width="465" alt="Screen Shot 2019-09-11 at 5 52 14 PM" src="https://user-images.githubusercontent.com/594035/64745856-510a1200-d4be-11e9-9b54-1445dc2e6bd4.png">
3. <img width="457" alt="Screen Shot 2019-09-11 at 5 53 16 PM" src="https://user-images.githubusercontent.com/594035/64745854-510a1200-d4be-11e9-86a9-be3d05b66e67.png">

[iOS]

1. <img width="400" alt="Screen Shot 2019-09-11 at 6 03 32 PM" src="https://user-images.githubusercontent.com/594035/64745935-94fd1700-d4be-11e9-8e26-6ba265630107.png">
2. <img width="389" alt="Screen Shot 2019-09-11 at 6 03 45 PM" src="https://user-images.githubusercontent.com/594035/64745936-9595ad80-d4be-11e9-9fd0-b95d2809cb60.png">
3. <img width="397" alt="Screen Shot 2019-09-11 at 6 04 04 PM" src="https://user-images.githubusercontent.com/594035/64745937-9595ad80-d4be-11e9-8c7d-f5d287da62bc.png">
