### PR TITLE
rollback engine dispatch batching. make input monitor passive

### DIFF
--- a/shared/actions/platform-specific/input-monitor.desktop.tsx
+++ b/shared/actions/platform-specific/input-monitor.desktop.tsx
@@ -82,17 +82,22 @@ class InputMonitor {
     console.log('InputMonitor: Timer cleared')
   }
 
+  private listenerOptions = {
+    capture: true,
+    passive: true,
+  }
+
   private listenForMouseKeyboard = () => {
     this.unlistenForMouseKeyboard()
     console.log('InputMonitor: adding mouseKeyboard events')
-    window.addEventListener('mousemove', this.onMouseKeyboard, true)
-    window.addEventListener('keypress', this.onMouseKeyboard, true)
+    window.addEventListener('mousemove', this.onMouseKeyboard, this.listenerOptions)
+    window.addEventListener('keypress', this.onMouseKeyboard, this.listenerOptions)
   }
 
   private unlistenForMouseKeyboard = () => {
     console.log('InputMonitor: removing mouseKeyboard events')
-    window.removeEventListener('mousemove', this.onMouseKeyboard, true)
-    window.removeEventListener('keypress', this.onMouseKeyboard, true)
+    window.removeEventListener('mousemove', this.onMouseKeyboard, this.listenerOptions)
+    window.removeEventListener('keypress', this.onMouseKeyboard, this.listenerOptions)
   }
 
   private transition = (reason: Reason) => {

--- a/shared/engine/index-impl.tsx
+++ b/shared/engine/index-impl.tsx
@@ -12,8 +12,7 @@ import engineSaga from './saga'
 import {throttle} from 'lodash-es'
 import {CustomResponseIncomingCallMapType, IncomingCallMapType} from '.'
 import {SessionID, SessionIDKey, WaitingHandlerType, MethodKey} from './types'
-import {TypedActions, TypedState, Dispatch} from '../util/container'
-import {batch} from 'react-redux'
+import {TypedState, Dispatch} from '../util/container'
 
 type WaitingKey = string | Array<string>
 
@@ -37,30 +36,8 @@ class Engine {
   // App tells us when the sagas are done loading so we can start emitting events
   _sagasAreReady: boolean = false
 
-  static _realDispatch: Dispatch
+  static _dispatch: Dispatch
 
-  static _dispatchTimer: undefined | NodeJS.Timeout = undefined
-  static _dispatchDeque = () => {
-    Engine._dispatchTimer && clearTimeout(Engine._dispatchTimer)
-    Engine._dispatchTimer = undefined
-    if (!Engine._dispatchQueue.length) return
-
-    const toDispatch = Engine._dispatchQueue
-    Engine._dispatchQueue = []
-    batch(() => {
-      toDispatch.forEach(d => Engine._realDispatch(d))
-    })
-  }
-  static _dispatchQueue: Array<TypedActions> = []
-
-  // So we can dispatch actions
-  static _dispatch: Dispatch = (a: TypedActions) => {
-    Engine._dispatchQueue.push(a)
-
-    if (!Engine._dispatchTimer) {
-      Engine._dispatchTimer = setTimeout(Engine._dispatchDeque, 32)
-    }
-  }
   // Temporary helper for incoming call maps
   static _getState: () => TypedState
 
@@ -87,7 +64,7 @@ class Engine {
 
   constructor(dispatch: Dispatch, getState: () => TypedState) {
     // setup some static vars
-    Engine._realDispatch = dispatch
+    Engine._dispatch = dispatch
     Engine._getState = getState
     this._rpcClient = createClient(
       payload => this._rpcIncoming(payload),


### PR DESCRIPTION
@keybase/react-hackers this rolls back batching (https://github.com/keybase/client/pull/19254). I think this is causing the high load when foregrounding as these timers can come alive faster.