### PR TITLE
Nav to people tab on tapping resolved contact notification

### DIFF
--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -561,21 +561,23 @@ const manageContactsCache = async (
   return actions
 }
 
+// When the notif is tapped we are only passed the message, use this as a marker
+// so we can handle it correctly.
+export const contactNotifMarker = 'Your contact'
 const makeResolvedMessage = (cts: Array<RPCTypes.ProcessedContact>) => {
   if (cts.length === 0) {
     return ''
   }
   switch (cts.length) {
     case 1:
-      return `Your contact ${cts[0].contactName} joined Keybase!`
+      return `${contactNotifMarker} ${cts[0].contactName} joined Keybase!`
     case 2:
-      return `Your contacts ${cts[0].contactName} and ${cts[1].contactName} joined Keybase!`
+      return `${contactNotifMarker}s ${cts[0].contactName} and ${cts[1].contactName} joined Keybase!`
     default: {
       const lenMinusTwo = cts.length - 2
-      return `Your contacts ${cts[0].contactName}, ${cts[1].contactName}, and ${lenMinusTwo} ${pluralize(
-        'other',
-        lenMinusTwo
-      )} joined Keybase!`
+      return `${contactNotifMarker}s ${cts[0].contactName}, ${
+        cts[1].contactName
+      }, and ${lenMinusTwo} ${pluralize('other', lenMinusTwo)} joined Keybase!`
     }
   }
 }

--- a/shared/actions/platform-specific/push.native.tsx
+++ b/shared/actions/platform-specific/push.native.tsx
@@ -13,6 +13,7 @@ import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as Saga from '../../util/saga'
 import * as WaitingGen from '../waiting-gen'
 import * as RouteTreeGen from '../route-tree-gen'
+import * as Tabs from '../../constants/tabs'
 import logger from '../../logger'
 import {NativeModules, NativeEventEmitter} from 'react-native'
 import {isIOS, isAndroid} from '../../constants/platform'
@@ -156,7 +157,7 @@ function* handleLoudMessage(notification: Types.PushNotification) {
 }
 
 // on iOS the go side handles a lot of push details
-function* handlePush(_: Container.TypedState, action: PushGen.NotificationPayload) {
+function* handlePush(state: Container.TypedState, action: PushGen.NotificationPayload) {
   try {
     const notification = action.payload.notification
     logger.info('[Push]: ' + notification.type || 'unknown')
@@ -186,6 +187,12 @@ function* handlePush(_: Container.TypedState, action: PushGen.NotificationPayloa
         {
           const {conversationIDKey} = notification
           yield Saga.put(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'extension'}))
+        }
+        break
+      case 'settings.contacts':
+        if (state.config.loggedIn) {
+          yield Saga.put(RouteTreeGen.createSwitchTab({tab: Tabs.peopleTab}))
+          yield Saga.put(RouteTreeGen.createNavUpToScreen({routeName: 'peopleRoot'}))
         }
         break
     }

--- a/shared/constants/push.tsx
+++ b/shared/constants/push.tsx
@@ -33,6 +33,7 @@ export const normalizePush = (n: any): Types.PushNotification | undefined => {
 
     const userInteraction = !!n.userInteraction
     const data = isIOS ? n.data || n._data : n
+    const message = n.message
 
     if (!data) {
       return undefined
@@ -73,6 +74,7 @@ export const normalizePush = (n: any): Types.PushNotification | undefined => {
         conversationIDKey: ChatTypes.stringToConversationIDKey(data.convID),
         type: 'chat.extension',
       }
+    } else if (typeof message === 'string' && message.includes('Your contact')) {
     }
 
     return undefined

--- a/shared/constants/push.tsx
+++ b/shared/constants/push.tsx
@@ -76,7 +76,7 @@ export const normalizePush = (n: any): Types.PushNotification | undefined => {
         conversationIDKey: ChatTypes.stringToConversationIDKey(data.convID),
         type: 'chat.extension',
       }
-    } else if (typeof message === 'string' && message.startsWith('Your contact')) {
+    } else if (typeof message === 'string' && message.startsWith('Your contact') && userInteraction) {
       return {
         type: 'settings.contacts',
       }

--- a/shared/constants/types/push.tsx
+++ b/shared/constants/types/push.tsx
@@ -30,6 +30,9 @@ export type PushNotification =
       type: 'chat.extension'
       conversationIDKey: ChatTypes.ConversationIDKey
     }
+  | {
+      type: 'settings.contacts'
+    }
 
 export type State = {
   hasPermissions: boolean


### PR DESCRIPTION
- Move native contact data transform to constants
- Detect this notification in `handlePush` by introspecting the notification message
  - Doesn't feel good, but I didn't see another way to shuttle data between `localNotification` and `handlePush` - open to suggestions

cc @keybase/y2ksquad 