### PR TITLE
Remove 'other assets' from choose-asset 'change' button

### DIFF
--- a/shared/wallets/send-form/choose-asset/container.tsx
+++ b/shared/wallets/send-form/choose-asset/container.tsx
@@ -1,4 +1,4 @@
-import ChooseAsset, {DisplayItem, OtherItem} from '.'
+import ChooseAsset, {DisplayItem} from '.'
 import * as Container from '../../../util/container'
 import * as WalletsGen from '../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
@@ -17,7 +17,6 @@ const mapStateToProps = state => {
     currencies: Constants.getDisplayCurrencies(state).toArray(),
     isRequest: state.wallets.building.isRequest,
     selected,
-    sendAssets: state.wallets.building.sendAssetChoices,
     to,
   }
 }
@@ -43,15 +42,8 @@ const mergeProps = (stateProps, dispatchProps, _: OwnProps) => ({
   })),
   isRequest: stateProps.isRequest,
   onBack: dispatchProps.onBack,
-  onChoose: (item: DisplayItem | OtherItem) => dispatchProps._onChoose(item.currencyCode),
+  onChoose: (item: DisplayItem) => dispatchProps._onChoose(item.currencyCode),
   onRefresh: () => dispatchProps._onRefresh(stateProps.accountID, stateProps.to),
-  otherChoices: (stateProps.sendAssets || []).map(a => ({
-    currencyCode: a.asset.code,
-    disabledExplanation: a.subtext || 'Support for other assets coming soon',
-    issuer: a.asset.issuer,
-    selected: a.asset.code === stateProps.selected,
-    type: 'other choice',
-  })),
   selected: stateProps.selected,
 })
 

--- a/shared/wallets/send-form/choose-asset/index.stories.tsx
+++ b/shared/wallets/send-form/choose-asset/index.stories.tsx
@@ -19,29 +19,6 @@ const props = {
   onBack: action('onBack'),
   onChoose: action('onChoose'),
   onRefresh: action('onRefresh'),
-  otherChoices: [
-    {
-      currencyCode: 'BTC',
-      disabledExplanation: '',
-      issuer: 'Stronghold.co',
-      selected: false,
-      type: 'other choice' as const,
-    },
-    {
-      currencyCode: 'KEYZ',
-      disabledExplanation: '',
-      issuer: 'Unknown',
-      selected: false,
-      type: 'other choice' as const,
-    },
-    {
-      currencyCode: 'HUGZ',
-      disabledExplanation: `max doesn't accept HUGZ.`,
-      issuer: 'Jed',
-      selected: false,
-      type: 'other choice' as const,
-    },
-  ],
   selected: 'XLM',
 }
 

--- a/shared/wallets/send-form/choose-asset/index.tsx
+++ b/shared/wallets/send-form/choose-asset/index.tsx
@@ -27,10 +27,9 @@ class ChooseAsset extends React.Component<Props> {
   _renderItem = ({
     item,
   }: {
-    item:
-      DisplayItem & {
-          key: string
-        }
+    item: DisplayItem & {
+      key: string
+    }
   }) => {
     switch (item.type) {
       case 'display choice':
@@ -63,8 +62,7 @@ class ChooseAsset extends React.Component<Props> {
   }
 
   render() {
-    const displayChoicesData =
-      this.props.displayChoices.map(dc => ({...dc, key: dc.currencyCode}))
+    const displayChoicesData = this.props.displayChoices.map(dc => ({...dc, key: dc.currencyCode}))
     if (!displayChoicesData.find(c => c.currencyCode === 'XLM')) {
       displayChoicesData.unshift({
         currencyCode: 'XLM',

--- a/shared/wallets/send-form/choose-asset/index.tsx
+++ b/shared/wallets/send-form/choose-asset/index.tsx
@@ -11,13 +11,6 @@ export type DisplayItem = {
   symbol: string
   type: 'display choice'
 }
-export type OtherItem = {
-  currencyCode: string
-  disabledExplanation: string
-  issuer: string
-  selected: boolean
-  type: 'other choice'
-}
 
 type ExpanderItem = {
   onClick: () => void
@@ -28,9 +21,8 @@ type ExpanderItem = {
 export type Props = {
   displayChoices: Array<DisplayItem>
   onBack: () => void
-  onChoose: (item: DisplayItem | OtherItem) => void
+  onChoose: (item: DisplayItem) => void
   onRefresh: () => void
-  otherChoices: Array<OtherItem>
   isRequest: boolean
   selected: string
 }
@@ -53,9 +45,6 @@ class ChooseAsset extends React.Component<Props, State> {
       | DisplayItem & {
           key: string
         }
-      | OtherItem & {
-          key: string
-        }
       | ExpanderItem & {
           key: string
         }
@@ -69,17 +58,6 @@ class ChooseAsset extends React.Component<Props, State> {
             onClick={() => this.props.onChoose(item)}
             selected={item.selected}
             symbol={item.symbol}
-          />
-        )
-      case 'other choice':
-        return (
-          <OtherChoice
-            key={item.key}
-            currencyCode={item.currencyCode}
-            disabledExplanation={item.disabledExplanation}
-            issuer={item.issuer}
-            onClick={() => this.props.onChoose(item)}
-            selected={item.selected}
           />
         )
       case 'expander':
@@ -107,14 +85,6 @@ class ChooseAsset extends React.Component<Props, State> {
             </Kb.Text>
           </Kb.Box2>
         )
-      case 'other choices':
-        return (
-          <Kb.Box2 direction="vertical" style={styles.sectionHeaderContainer} fullWidth={true}>
-            <Kb.Text key="other" type="BodySmallSemibold">
-              Other assets
-            </Kb.Text>
-          </Kb.Box2>
-        )
       case 'divider':
         return <Kb.Divider key={section.key} />
     }
@@ -122,7 +92,7 @@ class ChooseAsset extends React.Component<Props, State> {
   }
 
   render() {
-    const expanded = this.state.expanded || !this.props.otherChoices || this.props.otherChoices.length === 0
+    const expanded = this.state.expanded
     const displayChoicesData =
       this.props.displayChoices &&
       this.props.displayChoices
@@ -152,18 +122,6 @@ class ChooseAsset extends React.Component<Props, State> {
         data: displayChoicesData,
         key: 'display choices',
       },
-      ...(this.props.otherChoices.length === 0
-        ? []
-        : [
-            {data: [], key: 'divider'},
-            {
-              data: this.props.otherChoices.map(oc => ({
-                ...oc,
-                key: `${oc.currencyCode}:${oc.issuer}`,
-              })),
-              key: 'other choices',
-            },
-          ]),
     ]
     return (
       <Kb.MaybePopup onClose={this.props.onBack}>
@@ -221,63 +179,6 @@ const DisplayChoice = (props: DisplayChoiceProps) => (
           type="iconfont-check"
           color={Styles.globalColors.blue}
           boxStyle={Kb.iconCastPlatformStyles(styles.checkIcon)}
-        />
-      )}
-    </Kb.Box2>
-  </Kb.ClickableBox>
-)
-
-type OtherChoiceProps = {
-  currencyCode: string
-  disabledExplanation: string
-  issuer: string
-  onClick: () => void
-  selected: boolean
-}
-
-const OtherChoice = (props: OtherChoiceProps) => (
-  <Kb.ClickableBox
-    hoverColor={!props.disabledExplanation ? Styles.globalColors.blueLighter2 : null}
-    onClick={!props.disabledExplanation ? props.onClick : undefined}
-  >
-    <Kb.Box2
-      direction="horizontal"
-      style={styles.choiceContainer}
-      fullWidth={true}
-      gap="small"
-      gapStart={true}
-      gapEnd={true}
-    >
-      <Kb.Box2 direction="vertical">
-        <Kb.Text
-          type="Body"
-          style={Styles.collapseStyles([
-            props.selected && styles.blue,
-            !!props.disabledExplanation && styles.grey,
-          ])}
-        >
-          <Kb.Text
-            type="BodyExtrabold"
-            style={Styles.collapseStyles([
-              props.selected && styles.blue,
-              !!props.disabledExplanation && styles.grey,
-            ])}
-          >
-            {props.currencyCode}
-          </Kb.Text>
-          /{props.issuer}
-        </Kb.Text>
-        {!!props.disabledExplanation && (
-          <Kb.Text type="BodySmall" style={styles.grey}>
-            {props.disabledExplanation}
-          </Kb.Text>
-        )}
-      </Kb.Box2>
-      {props.selected && (
-        <Kb.Icon
-          type="iconfont-check"
-          color={Styles.globalColors.blue}
-          style={Kb.iconCastPlatformStyles(styles.checkIcon)}
         />
       )}
     </Kb.Box2>

--- a/shared/wallets/send-form/choose-asset/index.tsx
+++ b/shared/wallets/send-form/choose-asset/index.tsx
@@ -3,19 +3,11 @@ import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 import Header from '../header'
 
-const unexpandedNumDisplayOptions = 4
-
 export type DisplayItem = {
   currencyCode: string
   selected: boolean
   symbol: string
   type: 'display choice'
-}
-
-type ExpanderItem = {
-  onClick: () => void
-  text: string
-  type: 'expander'
 }
 
 export type Props = {
@@ -27,13 +19,7 @@ export type Props = {
   selected: string
 }
 
-type State = {
-  expanded: boolean
-}
-
-class ChooseAsset extends React.Component<Props, State> {
-  state = {expanded: false}
-
+class ChooseAsset extends React.Component<Props> {
   componentDidMount() {
     this.props.onRefresh()
   }
@@ -42,10 +28,7 @@ class ChooseAsset extends React.Component<Props, State> {
     item,
   }: {
     item:
-      | DisplayItem & {
-          key: string
-        }
-      | ExpanderItem & {
+      DisplayItem & {
           key: string
         }
   }) => {
@@ -59,18 +42,6 @@ class ChooseAsset extends React.Component<Props, State> {
             selected={item.selected}
             symbol={item.symbol}
           />
-        )
-      case 'expander':
-        return (
-          <Kb.ClickableBox key={item.key} onClick={item.onClick}>
-            <Kb.Box2 direction="horizontal" style={styles.choiceContainer}>
-              <Kb.Box2 direction="horizontal" centerChildren={true} style={styles.expanderContainer}>
-                <Kb.Text type="BodySmallSemibold" style={styles.expanderText}>
-                  {item.text}
-                </Kb.Text>
-              </Kb.Box2>
-            </Kb.Box2>
-          </Kb.ClickableBox>
         )
     }
   }
@@ -92,22 +63,8 @@ class ChooseAsset extends React.Component<Props, State> {
   }
 
   render() {
-    const expanded = this.state.expanded
     const displayChoicesData =
-      this.props.displayChoices &&
-      this.props.displayChoices
-        .slice(0, expanded ? this.props.displayChoices.length : unexpandedNumDisplayOptions)
-        .map(dc => ({...dc, key: dc.currencyCode}))
-    if (this.props.displayChoices && !expanded) {
-      displayChoicesData.push({
-        currencyCode: 'expander',
-        key: 'expander',
-        onClick: () => this.setState({expanded: true}),
-        text: `+${this.props.displayChoices.length - unexpandedNumDisplayOptions} display currencies`,
-        // @ts-ignore When coming from props, displayChoicesData is pure DisplayItem
-        type: 'expander',
-      })
-    }
+      this.props.displayChoices.map(dc => ({...dc, key: dc.currencyCode}))
     if (!displayChoicesData.find(c => c.currencyCode === 'XLM')) {
       displayChoicesData.unshift({
         currencyCode: 'XLM',
@@ -225,15 +182,6 @@ const styles = Styles.styleSheetCreate(
       displayChoice: {
         width: '100%',
       },
-      expanderContainer: {
-        backgroundColor: Styles.globalColors.black_05,
-        borderRadius: Styles.borderRadius,
-        height: 22,
-        paddingLeft: Styles.globalMargins.tiny,
-        paddingRight: Styles.globalMargins.tiny,
-      },
-      expanderText: {color: Styles.globalColors.black_50},
-      grey: {color: Styles.globalColors.black_50},
       growContainer: {
         alignItems: 'center',
         height: '100%',


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

Looks like we always want to use the path payments banner for these custom assets, so I removed all the display code for them from the choose-asset widget.  Thought about leaving the display code in and just having the container return `[]`, but then decided that getting back old code if you made a mistake is what version control is for and pulled it all out.

(Since there's now only one section competing for screen space, there's no need to have the expander logic anymore, we can just fill the dialog with the displayChoices.)