### PR TITLE
Fix team-building non-css icon colors

### DIFF
--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -140,7 +140,7 @@ class Icon extends Component<Props, void> {
             style={Styles.collapseStyles([
               style,
               this.props.padding && Shared.paddingStyles[this.props.padding],
-              colorStyleName === null ? {color} : null, // For colors that are not in Styles.globalColors
+              colorStyleName === undefined ? {color} : null, // For colors that are not in Styles.globalColors
             ])}
             className={Styles.classNames(
               'icon',

--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -140,7 +140,7 @@ class Icon extends Component<Props, void> {
             style={Styles.collapseStyles([
               style,
               this.props.padding && Shared.paddingStyles[this.props.padding],
-              colorStyleName === undefined ? {color} : null, // For colors that are not in Styles.globalColors
+              typeof colorStyleName !== 'string' ? {color} : null, // For colors that are not in Styles.globalColors
             ])}
             className={Styles.classNames(
               'icon',


### PR DESCRIPTION
Non-css coloring of icons was busted by [null -> undefined](https://github.com/keybase/client/pull/19329/files#diff-0ea01cf0375736eeb34aa41633edfb12R100). This change makes undefined work. Any reason null went away?

<img width="433" alt="image" src="https://user-images.githubusercontent.com/705646/64815708-2d090800-d574-11e9-9310-2aa08be864a2.png">
