### PR TITLE
kbfs_ops: finish journal initialization before edit history

### DIFF
--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -726,7 +726,9 @@ func doInit(
 	}
 	config.SetChat(chat)
 
-	kbfsOps := NewKBFSOpsStandard(kbCtx, config)
+	initDoneCh := make(chan struct{})
+	kbfsOps := NewKBFSOpsStandard(kbCtx, config, initDoneCh)
+	defer close(initDoneCh)
 	config.SetKBFSOps(kbfsOps)
 	config.SetNotifier(kbfsOps)
 	config.SetKeyManager(NewKeyManagerStandard(config))

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -79,7 +79,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	config.SetCodec(kbfscodec.NewMsgpack())
 	blockops := &CheckBlockOps{config.mockBops, ctr}
 	config.SetBlockOps(blockops)
-	kbfsops := NewKBFSOpsStandard(env.EmptyAppStateUpdater{}, config)
+	kbfsops := NewKBFSOpsStandard(env.EmptyAppStateUpdater{}, config, nil)
 	config.SetKBFSOps(kbfsops)
 	config.SetNotifier(kbfsops)
 

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -137,7 +137,10 @@ func MakeTestConfigOrBustLoggedInWithMode(
 		return log
 	})
 
-	kbfsOps := NewKBFSOpsStandard(env.EmptyAppStateUpdater{}, config)
+	initDoneCh := make(chan struct{})
+	kbfsOps := NewKBFSOpsStandard(
+		env.EmptyAppStateUpdater{}, config, initDoneCh)
+	defer close(initDoneCh)
 	config.SetKBFSOps(kbfsOps)
 	config.SetNotifier(kbfsOps)
 
@@ -252,7 +255,9 @@ func ConfigAsUserWithMode(config *ConfigLocal,
 	c.SetMetadataVersion(config.MetadataVersion())
 	c.SetRekeyWithPromptWaitTime(config.RekeyWithPromptWaitTime())
 
-	kbfsOps := NewKBFSOpsStandard(env.EmptyAppStateUpdater{}, c)
+	initDoneCh := make(chan struct{})
+	kbfsOps := NewKBFSOpsStandard(env.EmptyAppStateUpdater{}, c, initDoneCh)
+	defer close(initDoneCh)
 	c.SetKBFSOps(kbfsOps)
 	c.SetNotifier(kbfsOps)
 


### PR DESCRIPTION
This fixes a race where edit history initialization could construct an FBO before journal initialization completed.  This could lead to a situation where the FBO head is on the server's view, but then later the journal is initialization to what should be the local view, and FBO never catches up.  Then if someone tries writing to the folder via the FBO, they'll likely either fail or cause some kind of self-conflict.

Instead, require the code that constructs the KBFSOps to provide a channel that will be closed when all initialization (including journal) is completed, and only then do we let other types of initialization commence.

I tried to think of a good test that would fail before this commit but succeed after (without having to be significantly rewritten) and I failed.  Let me know if you have any ideas!

Found while debugging a (maybe?) unrelated issue, HOTPOT-803.