### PR TITLE
enable ephemeral keys in oneshot mode

### DIFF
--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -44,8 +44,8 @@ func ServiceInit(g *libkb.GlobalContext, httpSrv *manager.Srv, source Source) *S
 	m := libkb.NewMetaContextBackground(g)
 	source.StartBackgroundTasks(m)
 	s := NewSrv(g, httpSrv, source) // start the http srv up
-	g.PushShutdownHook(func() error {
-		source.StopBackgroundTasks(m)
+	g.PushShutdownHook(func(mctx libkb.MetaContext) error {
+		source.StopBackgroundTasks(mctx)
 		return nil
 	})
 	return s

--- a/go/badges/badger.go
+++ b/go/badges/badger.go
@@ -48,7 +48,7 @@ func NewBadger(g *libkb.GlobalContext) *Badger {
 		shutdownCh:     make(chan struct{}),
 	}
 	go b.notifyLoop()
-	g.PushShutdownHook(func() error {
+	g.PushShutdownHook(func(mctx libkb.MetaContext) error {
 		close(b.shutdownCh)
 		return nil
 	})

--- a/go/chat/activitynotifier.go
+++ b/go/chat/activitynotifier.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -28,7 +29,7 @@ func NewNotifyRouterActivityRouter(g *globals.Context) *NotifyRouterActivityRout
 		shutdownCh:   make(chan struct{}),
 	}
 	go n.notifyLoop()
-	g.PushShutdownHook(func() error {
+	g.PushShutdownHook(func(mctx libkb.MetaContext) error {
 		close(n.shutdownCh)
 		return nil
 	})

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1198,8 +1198,8 @@ func NewDeliverer(g *globals.Context, sender types.Sender) *Deliverer {
 		notifyFailureChs: make(map[string]chan []chat1.OutboxRecord),
 	}
 
-	g.PushShutdownHook(func() error {
-		d.Stop(context.Background())
+	g.PushShutdownHook(func(mctx libkb.MetaContext) error {
+		d.Stop(mctx.Ctx())
 		return nil
 	})
 

--- a/go/client/fork_server.go
+++ b/go/client/fork_server.go
@@ -92,7 +92,8 @@ func ForkServer(g *libkb.GlobalContext, cl libkb.CommandLine, forkType keybase1.
 	err := srv.GetExclusiveLockWithoutAutoUnlock()
 	if err == nil {
 		g.Log.Debug("Flocked! Server must have died")
-		err := srv.ReleaseLock()
+		mctx := libkb.NewMetaContextTODO(g)
+		err := srv.ReleaseLock(mctx)
 		if err != nil {
 			return false, err
 		}

--- a/go/engine/merkle_audit.go
+++ b/go/engine/merkle_audit.go
@@ -109,8 +109,10 @@ func (e *MerkleAudit) Run(mctx libkb.MetaContext) (err error) {
 	return RunEngine2(mctx, e.task)
 }
 
-func (e *MerkleAudit) Shutdown() {
+func (e *MerkleAudit) Shutdown(mctx libkb.MetaContext) error {
+	mctx.Debug("stopping merkle root background audit engine")
 	e.task.Shutdown()
+	return nil
 }
 
 // randSeqno picks a random number between [low, high) that's different from prev.

--- a/go/engine/merkle_audit_test.go
+++ b/go/engine/merkle_audit_test.go
@@ -57,7 +57,7 @@ func TestMerkleAuditWork(t *testing.T) {
 	}
 	expectMeta(t, metaCh, "loop-round-complete")
 
-	eng.Shutdown()
+	eng.Shutdown(m)
 	expectMeta(t, metaCh, "loop-exit")
 	expectMeta(t, metaCh, "")
 }
@@ -245,7 +245,7 @@ func TestMerkleAuditRetry(t *testing.T) {
 	require.NotEqual(t, startSeqno, differentSeqno, "result #4 seqno")
 	tc.G.Log.Debug("Fourth iteration succeeded on validating another root, %d.", differentSeqno)
 
-	eng.Shutdown()
+	eng.Shutdown(m)
 	expectMeta(t, metaCh, "loop-exit")
 	expectMeta(t, metaCh, "")
 }
@@ -333,7 +333,7 @@ func TestMerkleAuditFail(t *testing.T) {
 	}
 	expectMeta(t, metaCh, "loop-round-complete")
 
-	eng.Shutdown()
+	eng.Shutdown(m)
 	expectMeta(t, metaCh, "loop-exit")
 	expectMeta(t, metaCh, "")
 }

--- a/go/engine/merkle_audit_test.go
+++ b/go/engine/merkle_audit_test.go
@@ -57,7 +57,8 @@ func TestMerkleAuditWork(t *testing.T) {
 	}
 	expectMeta(t, metaCh, "loop-round-complete")
 
-	eng.Shutdown(m)
+	err = eng.Shutdown(m)
+	require.NoError(t, err)
 	expectMeta(t, metaCh, "loop-exit")
 	expectMeta(t, metaCh, "")
 }
@@ -245,7 +246,8 @@ func TestMerkleAuditRetry(t *testing.T) {
 	require.NotEqual(t, startSeqno, differentSeqno, "result #4 seqno")
 	tc.G.Log.Debug("Fourth iteration succeeded on validating another root, %d.", differentSeqno)
 
-	eng.Shutdown(m)
+	err = eng.Shutdown(m)
+	require.NoError(t, err)
 	expectMeta(t, metaCh, "loop-exit")
 	expectMeta(t, metaCh, "")
 }
@@ -333,7 +335,8 @@ func TestMerkleAuditFail(t *testing.T) {
 	}
 	expectMeta(t, metaCh, "loop-round-complete")
 
-	eng.Shutdown(m)
+	err = eng.Shutdown(m)
+	require.NoError(t, err)
 	expectMeta(t, metaCh, "loop-exit")
 	expectMeta(t, metaCh, "")
 }

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -85,6 +85,7 @@ const (
 	DeviceProvisionedAfterContentCreationErrMsg = "this device was created after the message was sent"
 	MemberAddedAfterContentCreationErrMsg       = "you were added to the team after this message was sent"
 	DeviceCloneErrMsg                           = "cloned devices do not support exploding messages"
+	DeviceCloneWithOneshotErrMsg                = "to support exploding messages in `oneshot` mode, you need a separate paper key for each running instance"
 )
 
 type IncorrectTeamEphemeralKeyTypeError struct {
@@ -143,6 +144,11 @@ func newEKUnboxErr(mctx libkb.MetaContext, ekKind EphemeralKeyKind, boxGeneratio
 		humanMsg = DeviceProvisionedAfterContentCreationErrMsg
 	} else if deviceIsCloned(mctx) {
 		humanMsg = DeviceCloneErrMsg
+		if isOneshot, err := mctx.G().IsOneshot(mctx.Ctx()); err != nil {
+			mctx.Debug("unable to check IsOneshot %v", err)
+		} else if isOneshot {
+			humanMsg = DeviceCloneWithOneshotErrMsg
+		}
 	}
 	return newEphemeralKeyError(debugMsg, humanMsg,
 		EphemeralKeyErrorKind_UNBOX, missingKind)

--- a/go/ephemeral/init.go
+++ b/go/ephemeral/init.go
@@ -15,11 +15,7 @@ func NewEphemeralStorageAndInstall(mctx libkb.MetaContext) {
 	mctx.G().AddLoginHook(ekLib)
 	mctx.G().AddLogoutHook(ekLib, "ekLib")
 	mctx.G().AddDbNukeHook(ekLib, "ekLib")
-	mctx.G().PushShutdownHook(func() error {
-		mctx.Debug("stopping background eklib loop")
-		ekLib.Shutdown()
-		return nil
-	})
+	mctx.G().PushShutdownHook(ekLib.Shutdown)
 }
 
 func ServiceInit(mctx libkb.MetaContext) {

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -149,7 +149,7 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 	ekLib, ok := lib.(*EKLib)
 	require.True(t, ok)
 	// disable background keygen
-	ekLib.Shutdown()
+	ekLib.Shutdown(mctx)
 	needed, err := ekLib.NewUserEKNeeded(mctx)
 	require.NoError(t, err)
 	require.Equal(t, skipUserEKForTesting, needed)

--- a/go/ephemeral/user_ek_test.go
+++ b/go/ephemeral/user_ek_test.go
@@ -149,7 +149,8 @@ func testDeviceRevoke(t *testing.T, skipUserEKForTesting bool) {
 	ekLib, ok := lib.(*EKLib)
 	require.True(t, ok)
 	// disable background keygen
-	ekLib.Shutdown(mctx)
+	err = ekLib.Shutdown(mctx)
+	require.NoError(t, err)
 	needed, err := ekLib.NewUserEKNeeded(mctx)
 	require.NoError(t, err)
 	require.Equal(t, skipUserEKForTesting, needed)

--- a/go/kbhttp/manager/manager.go
+++ b/go/kbhttp/manager/manager.go
@@ -41,7 +41,7 @@ func NewSrv(g *libkb.GlobalContext) *Srv {
 	}
 	h.initHTTPSrv()
 	h.startHTTPSrv()
-	g.PushShutdownHook(func() error {
+	g.PushShutdownHook(func(mctx libkb.MetaContext) error {
 		h.httpSrv.Stop()
 		return nil
 	})

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -31,7 +31,7 @@ import (
 	context "golang.org/x/net/context"
 )
 
-type ShutdownHook func() error
+type ShutdownHook func(mctx MetaContext) error
 
 type LoginHook interface {
 	OnLogin(mctx MetaContext) error
@@ -814,7 +814,7 @@ func (g *GlobalContext) ConfigureExportedStreams() error {
 
 // Shutdown is called exactly once per-process and does whatever
 // cleanup is necessary to shut down the server.
-func (g *GlobalContext) Shutdown() error {
+func (g *GlobalContext) Shutdown(mctx MetaContext) error {
 	var err error
 	didShutdown := false
 
@@ -854,7 +854,7 @@ func (g *GlobalContext) Shutdown() error {
 		}
 
 		for _, hook := range g.ShutdownHooks {
-			epick.Push(hook())
+			epick.Push(hook(mctx))
 		}
 
 		// shutdown the databases after the shutdown hooks run, we may want to

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -814,7 +814,7 @@ type DeviceEKStorage interface {
 	MaxGeneration(mctx MetaContext, includeErrs bool) (keybase1.EkGeneration, error)
 	DeleteExpired(mctx MetaContext, merkleRoot MerkleRoot) ([]keybase1.EkGeneration, error)
 	ClearCache()
-	// Dangerous! Only for deprovisioning.
+	// Dangerous! Only for deprovisioning or shutdown/logout when in oneshot mode.
 	ForceDeleteAll(mctx MetaContext, username NormalizedUsername) error
 	// For keybase log send
 	ListAllForUser(mctx MetaContext) ([]string, error)

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -109,7 +109,8 @@ func (tc *TestContext) Cleanup() {
 	require.NoError(tc.T, err)
 
 	tc.G.Log.Debug("global context shutdown:")
-	_ = tc.G.Shutdown() // could error due to missing pid file
+	mctx := NewMetaContextForTest(*tc)
+	_ = tc.G.Shutdown(mctx) // could error due to missing pid file
 	if len(tc.Tp.Home) > 0 {
 		tc.G.Log.Debug("cleaning up %s", tc.Tp.Home)
 		os.RemoveAll(tc.Tp.Home)

--- a/go/libkb/tracker_loader.go
+++ b/go/libkb/tracker_loader.go
@@ -26,8 +26,9 @@ func NewTrackerLoader(g *GlobalContext) *TrackerLoader {
 		shutdownCh:   make(chan struct{}),
 		queueCh:      make(chan keybase1.UID, 100),
 	}
-	g.PushShutdownHook(func() error {
-		<-l.Shutdown(context.Background())
+
+	g.PushShutdownHook(func(mctx MetaContext) error {
+		<-l.Shutdown(mctx.Ctx())
 		return nil
 	})
 	return l

--- a/go/runtimestats/stats.go
+++ b/go/runtimestats/stats.go
@@ -28,8 +28,8 @@ func NewRunner(g *globals.Context) *Runner {
 	r := &Runner{
 		Contextified: globals.NewContextified(g),
 	}
-	r.G().PushShutdownHook(func() error {
-		<-r.Stop(context.Background())
+	r.G().PushShutdownHook(func(mctx libkb.MetaContext) error {
+		<-r.Stop(mctx.Ctx())
 		return nil
 	})
 	return r

--- a/go/stellar/loader.go
+++ b/go/stellar/loader.go
@@ -77,7 +77,7 @@ func DefaultLoader(g *libkb.GlobalContext) *Loader {
 
 	if defaultLoader == nil {
 		defaultLoader = NewLoader(g)
-		g.PushShutdownHook(func() error {
+		g.PushShutdownHook(func(mctx libkb.MetaContext) error {
 			defaultLock.Lock()
 			err := defaultLoader.Shutdown()
 			defaultLoader = nil

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -1392,7 +1392,7 @@ func TestShutdown(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		if err := tcs[0].Srv.walletState.Shutdown(); err != nil {
+		if err := tcs[0].Srv.walletState.Shutdown(tcs[0].MetaContext()); err != nil {
 			t.Logf("shutdown error: %s", err)
 		}
 		wg.Done()

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -70,9 +70,8 @@ func NewWalletState(g *libkb.GlobalContext, r remote.Remoter) *WalletState {
 }
 
 // Shutdown terminates any background operations and cleans up.
-func (w *WalletState) Shutdown() error {
+func (w *WalletState) Shutdown(mctx libkb.MetaContext) error {
 	w.shutdownOnce.Do(func() {
-		mctx := libkb.NewMetaContextBackground(w.G())
 		mctx.Debug("WalletState shutting down")
 		w.Lock()
 		w.resetWithLock(mctx)

--- a/go/systests/ctl_test.go
+++ b/go/systests/ctl_test.go
@@ -102,7 +102,8 @@ func TestVersionAndStop(t *testing.T) {
 }
 
 func CtlStop(g *libkb.GlobalContext) error {
-	if err := g.Shutdown(); err != nil {
+	mctx := libkb.NewMetaContextTODO(g)
+	if err := g.Shutdown(mctx); err != nil {
 		return err
 	}
 	cli, err := client.GetCtlClient(g)

--- a/go/tlfupgrade/tlfupgrade_test.go
+++ b/go/tlfupgrade/tlfupgrade_test.go
@@ -70,6 +70,7 @@ func TestBackgroundTLFUpdater(t *testing.T) {
 	tc.G.MobileAppState.Update(keybase1.MobileAppState_BACKGROUND)
 	tc.G.MobileAppState.Update(keybase1.MobileAppState_FOREGROUND)
 	attempt(2)
-	err = u.Shutdown()
+	mctx := libkb.NewMetaContextForTest(tc)
+	err = u.Shutdown(mctx)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
enables ephemeral key generation in oneshot mode. caveats:

- if multiple services are using the same paperkey each service will fight over access to the deviceEphemeral key generation and no one will have access. error messaging indicates you are in a cloning situation and suggests using separate paperkeys
-  on logout/shutdown all ephemeral keys are forcibly purged 