### PR TITLE
provision timeout could lead you to a bad route

### DIFF
--- a/shared/actions/provision.tsx
+++ b/shared/actions/provision.tsx
@@ -495,13 +495,15 @@ const showPaperkeyPage = (state: Container.TypedState) =>
 const showFinalErrorPage = (state: Container.TypedState, action: ProvisionGen.ShowFinalErrorPagePayload) => {
   const parentPath = action.payload.fromDeviceAdd ? devicesRoot : ['login']
   let path: Array<string>
+  let replace = true
   if (state.provision.finalError && !Constants.errorCausedByUsCanceling(state.provision.finalError)) {
     path = ['error']
+    replace = false // can't replace with a modal!
   } else {
     path = []
   }
 
-  return RouteTreeGen.createNavigateAppend({path: [...parentPath, ...path], replace: true})
+  return RouteTreeGen.createNavigateAppend({path: [...parentPath, ...path], replace})
 }
 
 const showUsernameEmailPage = () => RouteTreeGen.createNavigateAppend({path: ['username']})


### PR DESCRIPTION
very tricky one
using the `replace` flag will only work if you're replacing a route thats valid on the current navigator. In this case this modal is trying to replace something on the stack which leads to a white screen.
this fixes issues where the router complains about no known route called 'error'