### PR TITLE
folder_branch_ops: extra debugging for an op that's missing a path

### DIFF
--- a/go/kbfs/data/path.go
+++ b/go/kbfs/data/path.go
@@ -23,6 +23,10 @@ type Path struct {
 // IsValid returns true if the path has at least one node (for the
 // root).
 func (p Path) IsValid() bool {
+	if p.Tlf == tlf.NullID {
+		return false
+	}
+
 	if len(p.Path) < 1 {
 		return false
 	}

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -1233,6 +1233,7 @@ func (cr *ConflictResolver) resolveMergedPaths(ctx context.Context,
 			newPath := make([]data.PathNode, len(p.Path)+len(mergedPath.Path))
 			copy(newPath[:len(p.Path)], p.Path)
 			copy(newPath[len(p.Path):], mergedPath.Path)
+			mergedPath.FolderBranch = cr.fbo.folderBranch
 			mergedPath.Path = newPath
 			mergedPaths[unmergedMostRecent] = mergedPath
 


### PR DESCRIPTION
I wasn't able to reproduce the panic described in HOTPOT-803 in a test, so this just adds more debugging in case we ever see it again.

Note that a `data.Path` now needs to have a valid TLF ID set in order to be considered valid.  This is a change, but I don't think it should change any existing behavior.  Famous last words though...

Issue: HOTPOT-803