### PR TITLE
Fix Quick Reply failing to send

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -389,6 +389,9 @@ func Version() string {
 }
 
 func IsAppStateForeground() bool {
+	if !isInited() {
+		return false
+	}
 	return kbCtx.MobileAppState.State() == keybase1.MobileAppState_FOREGROUND
 }
 

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/ChatBroadcastReceiver.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/ChatBroadcastReceiver.java
@@ -27,10 +27,10 @@ public class ChatBroadcastReceiver extends BroadcastReceiver {
     return null;
  }
 
-
   @RequiresApi(api = Build.VERSION_CODES.KITKAT_WATCH)
   @Override
   public void onReceive(Context context, Intent intent) {
+    MainActivity.setupKBRuntime(context, false);
     ConvData convData = new ConvData(intent);
     PendingIntent openConv = intent.getParcelableExtra("openConvPendingIntent");
     NotificationCompat.Builder repliedNotification = new NotificationCompat.Builder(context, KeybasePushNotificationListenerService.CHAT_CHANNEL_ID)

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -61,18 +61,9 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
 
     @Override
     public void onCreate() {
-        try {
-            Keybase.setGlobalExternalKeyStore(new KeyStore(getApplicationContext(), getSharedPreferences("KeyStore", MODE_PRIVATE)));
-        } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
-            NativeLogger.error("Exception in KeybasePushNotificationListenerService.onCreate while trying to link the Android KeyStore to go bind", e);
-        }
-        String mobileOsVersion = Integer.toString(android.os.Build.VERSION.SDK_INT);
-        initOnce(getApplicationContext().getFilesDir().getPath(), "", getApplicationContext().getFileStreamPath("service.log").getAbsolutePath(), "prod", false,
-          new DNSNSFetcher(), new VideoHelper(), mobileOsVersion);
+        MainActivity.setupKBRuntime(this, false);
         NativeLogger.info("KeybasePushNotificationListenerService created");
-
         createNotificationChannel(this);
-
     }
 
 

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -84,14 +84,14 @@ public class MainActivity extends ReactFragmentActivity {
   }
 
 
-  public static void setupKBRuntime(Context context, boolean createDummyFile) {
+  public static void setupKBRuntime(Context context, boolean shouldCreateDummyFile) {
     try {
       Keybase.setGlobalExternalKeyStore(new KeyStore(context, context.getSharedPreferences("KeyStore", MODE_PRIVATE)));
     } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
       NativeLogger.error("Exception in MainActivity.onCreate", e);
     }
 
-    if (createDummyFile) {
+    if (shouldCreateDummyFile) {
       createDummyFile(context);
     }
     String mobileOsVersion = Integer.toString(android.os.Build.VERSION.SDK_INT);

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -2,6 +2,7 @@ package io.keybase.ossifrage;
 
 import android.annotation.TargetApi;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -53,8 +54,8 @@ public class MainActivity extends ReactFragmentActivity {
   private static final String TAG = MainActivity.class.getName();
   private PermissionListener listener;
 
-  private void createDummyFile() {
-    final File dummyFile = new File(this.getFilesDir(), "dummy.txt");
+  private static void createDummyFile(Context context) {
+    final File dummyFile = new File(context.getFilesDir(), "dummy.txt");
     try {
       if (dummyFile.createNewFile()) {
         dummyFile.setWritable(true);
@@ -82,20 +83,27 @@ public class MainActivity extends ReactFragmentActivity {
     return instanceManager.getCurrentReactContext();
   }
 
-  @Override
-  @TargetApi(Build.VERSION_CODES.KITKAT)
-  protected void onCreate(Bundle savedInstanceState) {
+
+  public static void setupKBRuntime(Context context, boolean createDummyFile) {
     try {
-      Keybase.setGlobalExternalKeyStore(new KeyStore(this, getSharedPreferences("KeyStore", MODE_PRIVATE)));
+      Keybase.setGlobalExternalKeyStore(new KeyStore(context, context.getSharedPreferences("KeyStore", MODE_PRIVATE)));
     } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
       NativeLogger.error("Exception in MainActivity.onCreate", e);
     }
 
-    createDummyFile();
+    if (createDummyFile) {
+      createDummyFile(context);
+    }
     String mobileOsVersion = Integer.toString(android.os.Build.VERSION.SDK_INT);
-    initOnce(this.getFilesDir().getPath(), "", this.getFileStreamPath("service.log").getAbsolutePath(), "prod", false,
+    initOnce(context.getFilesDir().getPath(), "", context.getFileStreamPath("service.log").getAbsolutePath(), "prod", false,
       new DNSNSFetcher(), new VideoHelper(), mobileOsVersion);
 
+  }
+
+  @Override
+  @TargetApi(Build.VERSION_CODES.KITKAT)
+  protected void onCreate(Bundle savedInstanceState) {
+    setupKBRuntime(this, true);
     super.onCreate(null);
 
 


### PR DESCRIPTION
@keybase/react-hackers @jzila 

Tricky to track down, but it was actually a go panic (my fault) that was caused because we assumed the kb runtime was up when it wasn't.

This sets up the kb runtime in the quick reply flow (like we did for the receive notification flow as well). `InitOnce` is safe to call multiple times and should be quick to setup even if it's `init`for the first time.