### PR TITLE
user-block when you chat-block an impteam 1on1 convo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
             - GREGOR_TLF_SERVER=fmprpc+tls://kbweb.local:13010
             - GREGOR_TEAM_SERVER=fmprpc+tls://kbweb.local:7890
             - GREGOR_MACCHECKER_SERVER=fmprpc://kbweb.local:13037
+            - GREGOR_CHATSPAMMER_SERVER=fmprpc://kbweb.local:13047
             - INSECURE_TLS_MODE=1
             - GREGOR_TLFAUTH_PRIVATE_SIGNING_KEY=e20589b8cd66d447aaee44b587305bd521f34f3085709b32b4e3bd479b20253e59ea153c88a8ea524d39e0ae58fa195749214b38a28fdb4229ba3390b2d33e86
             - GREGOR_TLFAUTH_PUBLIC_SIGNING_KEY=012059ea153c88a8ea524d39e0ae58fa195749214b38a28fdb4229ba3390b2d33e860a

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -394,6 +394,10 @@ func TestInboxChatBlockingAlsoUserBlocks(t *testing.T) {
 	ctxAlice := ctc.as(t, alice).startCtx
 	uidAlice := alice.User.GetUID().ToBytes()
 
+	listener := newServerChatListener()
+	ctc.as(t, alice).h.G().NotifyRouter.AddListener(listener)
+	ctc.world.Tcs[alice.Username].ChatG.Syncer.(*Syncer).isConnected = true
+
 	// alice blocks a team channel conversation with only spammer in it
 	conv := mustCreateConversationForTest(t, ctc, alice, chat1.TopicType_CHAT,
 		chat1.ConversationMembersType_TEAM, spammer)

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/badges"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/teams"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 
@@ -355,4 +357,67 @@ func TestInboxSourceMarkAsRead(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(badgeState.Conversations))
 	require.Equal(t, 1, badgeState.Conversations[0].UnreadMessages)
+}
+
+func TestInboxChatBlockingAlsoUserBlocks(t *testing.T) {
+	ctc := makeChatTestContext(t, "TestInboxBlocking", 3)
+	defer ctc.cleanup()
+	users := ctc.users()
+	useRemoteMock = false
+	var err error
+	defer func() { useRemoteMock = true }()
+
+	userIsBlockedBy := func(maybeBlockedUserChat *kbtest.ChatTestContext, blocker *kbtest.FakeUser) bool {
+		// verify this behaviorally by having the maybe-blocked-user attempt to add the blocker
+		// to a team. if this errors with the expected code, then the maybe-blocked-user was definitely
+		// blocked.
+		name := createTeam(maybeBlockedUserChat.TestContext)
+		err = teams.SetRoleWriter(context.TODO(), maybeBlockedUserChat.G, name, blocker.Username)
+		if err == nil {
+			return false
+		}
+		require.Error(t, err)
+		require.IsType(t, err, libkb.AppStatusError{})
+		aerr, _ := err.(libkb.AppStatusError)
+		if aerr.Code != libkb.SCDeviceBadStatus {
+			panic("unexpected error adding user to team")
+		}
+		return true
+	}
+
+	// three users: alice, bob, spammer
+	alice := users[0]
+	spammer := users[1]
+	bob := users[2]
+	tcAlice := ctc.world.Tcs[alice.Username]
+	tcSpammer := ctc.world.Tcs[spammer.Username]
+	ctxAlice := ctc.as(t, alice).startCtx
+	uidAlice := alice.User.GetUID().ToBytes()
+
+	// alice blocks a team channel conversation with only spammer in it
+	conv := mustCreateConversationForTest(t, ctc, alice, chat1.TopicType_CHAT,
+		chat1.ConversationMembersType_TEAM, spammer)
+	err = tcAlice.ChatG.InboxSource.RemoteSetConversationStatus(ctxAlice, uidAlice, conv.Id,
+		chat1.ConversationStatus_BLOCKED)
+	require.NoError(t, err)
+	// this DOES NOT user-block spammer
+	require.False(t, userIsBlockedBy(tcSpammer, alice))
+
+	// alice blocks a group implicit conversation with spammer and bob
+	conv = mustCreateConversationForTest(t, ctc, alice, chat1.TopicType_CHAT,
+		chat1.ConversationMembersType_IMPTEAMNATIVE, spammer, bob)
+	err = tcAlice.ChatG.InboxSource.RemoteSetConversationStatus(ctxAlice, uidAlice, conv.Id,
+		chat1.ConversationStatus_BLOCKED)
+	require.NoError(t, err)
+	// this DOES NOT user-block spammer
+	require.False(t, userIsBlockedBy(tcSpammer, alice))
+
+	// alice blocks a 1-on-1 implicit conversation with just spammer
+	conv = mustCreateConversationForTest(t, ctc, alice, chat1.TopicType_CHAT,
+		chat1.ConversationMembersType_IMPTEAMNATIVE, spammer)
+	err = tcAlice.ChatG.InboxSource.RemoteSetConversationStatus(ctxAlice, uidAlice, conv.Id,
+		chat1.ConversationStatus_BLOCKED)
+	require.NoError(t, err)
+	// this DOES user-block spammer
+	require.True(t, userIsBlockedBy(tcSpammer, alice))
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -265,6 +265,7 @@ const (
 	SCDecryptionKeyNotFound                     = int(keybase1.StatusCode_SCDecryptionKeyNotFound)
 	SCBadTrackSession                           = int(keybase1.StatusCode_SCBadTrackSession)
 	SCDeviceBadName                             = int(keybase1.StatusCode_SCDeviceBadName)
+	SCDeviceBadStatus                           = int(keybase1.StatusCode_SCDeviceBadStatus)
 	SCDeviceNameInUse                           = int(keybase1.StatusCode_SCDeviceNameInUse)
 	SCDeviceNotFound                            = int(keybase1.StatusCode_SCDeviceNotFound)
 	SCDeviceMismatch                            = int(keybase1.StatusCode_SCDeviceMismatch)

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -78,6 +78,7 @@ const (
 	StatusCode_SCSigBadTotalOrder                          StatusCode = 1022
 	StatusCode_SCBadTrackSession                           StatusCode = 1301
 	StatusCode_SCDeviceBadName                             StatusCode = 1404
+	StatusCode_SCDeviceBadStatus                           StatusCode = 1405
 	StatusCode_SCDeviceNameInUse                           StatusCode = 1408
 	StatusCode_SCDeviceNotFound                            StatusCode = 1409
 	StatusCode_SCDeviceMismatch                            StatusCode = 1410
@@ -303,6 +304,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCSigBadTotalOrder":         1022,
 	"SCBadTrackSession":          1301,
 	"SCDeviceBadName":            1404,
+	"SCDeviceBadStatus":          1405,
 	"SCDeviceNameInUse":          1408,
 	"SCDeviceNotFound":           1409,
 	"SCDeviceMismatch":           1410,
@@ -526,6 +528,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	1022: "SCSigBadTotalOrder",
 	1301: "SCBadTrackSession",
 	1404: "SCDeviceBadName",
+	1405: "SCDeviceBadStatus",
 	1408: "SCDeviceNameInUse",
 	1409: "SCDeviceNotFound",
 	1410: "SCDeviceMismatch",

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -70,6 +70,7 @@ protocol constants {
     SCSigBadTotalOrder_1022,
     SCBadTrackSession_1301,
     SCDeviceBadName_1404,
+    SCDeviceBadStatus_1405,
     SCDeviceNameInUse_1408,
     SCDeviceNotFound_1409,
     SCDeviceMismatch_1410,

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -74,6 +74,7 @@
         "SCSigBadTotalOrder_1022",
         "SCBadTrackSession_1301",
         "SCDeviceBadName_1404",
+        "SCDeviceBadStatus_1405",
         "SCDeviceNameInUse_1408",
         "SCDeviceNotFound_1409",
         "SCDeviceMismatch_1410",

--- a/shared/chat/conversation/block-conversation-warning/index.tsx
+++ b/shared/chat/conversation/block-conversation-warning/index.tsx
@@ -16,6 +16,11 @@ const BlockConversationWarning = (props: Props) => {
 
   const _onConfirm = () => (reportAbuse ? props.onBlockAndReport() : props.onBlock())
 
+  const baseDescription = "You won't see this conversation anymore. "
+  const participantDescription = props.participants.includes(',') // if there's more than 1 other user
+    ? 'They won’t be notified or know you’ve blocked it.'
+    : "They won’t be notified that you've blocked them, but they might be able to figure it out."
+
   return (
     <Kb.ConfirmModal
       icon="iconfont-block"
@@ -28,7 +33,7 @@ const BlockConversationWarning = (props: Props) => {
           onCheck={checked => setReportAbuse(checked)}
         />
       }
-      description="You won’t see this conversation anymore. They won’t be notified or know you’ve blocked the conversation."
+      description={baseDescription + participantDescription}
       onCancel={props.onBack}
       onConfirm={_onConfirm}
       prompt={`Block the conversation with ${props.participants}?`}

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2014,6 +2014,7 @@ export enum StatusCode {
   scsigbadtotalorder = 1022,
   scbadtracksession = 1301,
   scdevicebadname = 1404,
+  scdevicebadstatus = 1405,
   scdevicenameinuse = 1408,
   scdevicenotfound = 1409,
   scdevicemismatch = 1410,


### PR DESCRIPTION
chat-blocking and user-blocking are confusingly very different things, and we have at least one log of someone who thought they blocked but they only chat-blocked. 

so, when a user chat-blocks (or reports) a 1-on-1 implicit conversation, also go ahead and user-block that person. this should only execute if it's two people in a non-team conversation, one of whom is the caller. 

i didn't implement unblocking. i figured this was unlikely to be a heavily demanded thing, it adds a bunch of complexity, and you can always manually unblock the person if you go their profile. 