### PR TITLE
install: skip `lsof` if there are definitely no open files

### DIFF
--- a/go/kbfs/libfs/constants.go
+++ b/go/kbfs/libfs/constants.go
@@ -117,3 +117,8 @@ const ArchivedTimeLinkPrefix = ".kbfs_archived_time="
 // a TLF that contains the directory name of an archived revision
 // described by the given relative time.
 const ArchivedRelTimeFilePrefix = ".kbfs_archived_reltime="
+
+// OpenFileCountFileName is the name of the file that contains the
+// number of KBFS files and directories currently being held open by
+// the operating system.
+const OpenFileCountFileName = ".kbfs_open_file_count"

--- a/go/kbfs/libfuse/dir.go
+++ b/go/kbfs/libfuse/dir.go
@@ -429,6 +429,18 @@ func (f *Folder) access(ctx context.Context, r *fuse.AccessRequest) error {
 	return nil
 }
 
+func (f *Folder) openFileCount() int64 {
+	f.nodesMu.Lock()
+	defer f.nodesMu.Unlock()
+	count := int64(len(f.nodes))
+	if count > 0 {
+		// The root node itself should only be counted by the folder
+		// list, not here.
+		count--
+	}
+	return count
+}
+
 // TODO: Expire TLF nodes periodically. See
 // https://keybase.atlassian.net/browse/KBFS-59 .
 

--- a/go/kbfs/libfuse/folderlist.go
+++ b/go/kbfs/libfuse/folderlist.go
@@ -345,3 +345,17 @@ func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbname.Normali
 		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }
+
+func (fl *FolderList) openFileCount() (ret int64) {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	for _, tlf := range fl.folders {
+		ret += tlf.openFileCount()
+	}
+	return ret + int64(len(fl.folders))
+}
+
+// Forget kernel reference to this node.
+func (fl *FolderList) Forget() {
+	fl.fs.root.forgetFolderList(fl.tlfType)
+}

--- a/go/kbfs/libfuse/open_file_count_file.go
+++ b/go/kbfs/libfuse/open_file_count_file.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+//
+// +build !windows
+
+package libfuse
+
+import (
+	"strconv"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// NewOpenFileCountFile returns a special read file that contains the
+// number of files and directories currently being held open by the OS.
+func NewOpenFileCountFile(
+	folder *Folder, entryValid *time.Duration) *SpecialReadFile {
+	*entryValid = 0
+	return &SpecialReadFile{
+		read: func(_ context.Context) ([]byte, time.Time, error) {
+			count := folder.fs.root.openFileCount()
+			return []byte(strconv.FormatInt(count, 10)),
+				folder.fs.config.Clock().Now(), nil
+		},
+	}
+}

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -69,6 +69,9 @@ func handleNonTLFSpecialFile(
 
 	case libfs.EditHistoryName:
 		return NewUserEditHistoryFile(&Folder{fs: fs}, entryValid)
+
+	case libfs.OpenFileCountFileName:
+		return NewOpenFileCountFile(&Folder{fs: fs}, entryValid)
 	}
 
 	return nil

--- a/go/kbfs/libfuse/tlf.go
+++ b/go/kbfs/libfuse/tlf.go
@@ -328,6 +328,8 @@ func (tlf *TLF) Forget() {
 	dir := tlf.getStoredDir()
 	if dir != nil {
 		dir.Forget()
+	} else {
+		tlf.folder.list.forgetFolder(string(tlf.folder.name()))
 	}
 }
 
@@ -366,4 +368,8 @@ func (tlf *TLF) Open(ctx context.Context, req *fuse.OpenRequest,
 		return nil, err
 	}
 	return tlf, nil
+}
+
+func (tlf *TLF) openFileCount() int64 {
+	return tlf.folder.openFileCount()
 }

--- a/go/kbfs/redirector/main.go
+++ b/go/kbfs/redirector/main.go
@@ -281,7 +281,8 @@ func (r *root) Lookup(
 		"kbfs.error.txt", "kbfs.nologin.txt", ".kbfs_enable_auto_journals",
 		".kbfs_disable_auto_journals", ".kbfs_enable_block_prefetching",
 		".kbfs_disable_block_prefetching", ".kbfs_enable_debug_server",
-		".kbfs_disable_debug_server", ".kbfs_edit_history":
+		".kbfs_disable_debug_server", ".kbfs_edit_history",
+		".kbfs_open_file_count":
 		return symlink{filepath.Join(mountpoint, req.Name)}, nil
 	}
 	return nil, fuse.ENOENT


### PR DESCRIPTION
KBFS now reports the number of "open" files or directories via the special `.kbfs_open_file_count` file.  This is just the count of inodes that the kernel has looked up, but not officially forgotten yet.

During install, if KBFS reports that there are definitely no open files, then we can skip the expensive `lsof` command entirely since we know the mount is definitely not in use.

Note that the kernel is extremely lazy about "forgetting" nodes it has looked up, so in practice if you have used KBFS at all since the last restart, you'll probably have to go through the `lsof` path still.

cc: @patrickxb, @maxtaco 	

Issue: HOTPOT-798