### PR TITLE
protocol: update node-avdl-compiler comments for 1.4.2

### DIFF
--- a/go/protocol/chat1/api.go
+++ b/go/protocol/chat1/api.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/api.avdl
 
 package chat1

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/chat_ui.avdl
 
 package chat1

--- a/go/protocol/chat1/commands.go
+++ b/go/protocol/chat1/commands.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/commands.avdl
 
 package chat1

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/common.avdl
 
 package chat1

--- a/go/protocol/chat1/gregor.go
+++ b/go/protocol/chat1/gregor.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/gregor.avdl
 
 package chat1

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/local.avdl
 
 package chat1

--- a/go/protocol/chat1/notify.go
+++ b/go/protocol/chat1/notify.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/notify.avdl
 
 package chat1

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/remote.avdl
 
 package chat1

--- a/go/protocol/chat1/unfurl.go
+++ b/go/protocol/chat1/unfurl.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/chat1/unfurl.avdl
 
 package chat1

--- a/go/protocol/gregor1/auth.go
+++ b/go/protocol/gregor1/auth.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/gregor1/auth.avdl
 
 package gregor1

--- a/go/protocol/gregor1/auth_internal.go
+++ b/go/protocol/gregor1/auth_internal.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/gregor1/auth_internal.avdl
 
 package gregor1

--- a/go/protocol/gregor1/auth_update.go
+++ b/go/protocol/gregor1/auth_update.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/gregor1/auth_update.avdl
 
 package gregor1

--- a/go/protocol/gregor1/common.go
+++ b/go/protocol/gregor1/common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/gregor1/common.avdl
 
 package gregor1

--- a/go/protocol/gregor1/incoming.go
+++ b/go/protocol/gregor1/incoming.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/gregor1/incoming.avdl
 
 package gregor1

--- a/go/protocol/gregor1/outgoing.go
+++ b/go/protocol/gregor1/outgoing.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/gregor1/outgoing.avdl
 
 package gregor1

--- a/go/protocol/gregor1/remind.go
+++ b/go/protocol/gregor1/remind.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/gregor1/remind.avdl
 
 package gregor1

--- a/go/protocol/kbgitkbfs1/disk_block_cache.go
+++ b/go/protocol/kbgitkbfs1/disk_block_cache.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/kbgitkbfs1/disk_block_cache.avdl
 
 package kbgitkbfs1

--- a/go/protocol/keybase1/account.go
+++ b/go/protocol/keybase1/account.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/account.avdl
 
 package keybase1

--- a/go/protocol/keybase1/apiserver.go
+++ b/go/protocol/keybase1/apiserver.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/apiserver.avdl
 
 package keybase1

--- a/go/protocol/keybase1/appstate.go
+++ b/go/protocol/keybase1/appstate.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/appstate.avdl
 
 package keybase1

--- a/go/protocol/keybase1/audit.go
+++ b/go/protocol/keybase1/audit.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/audit.avdl
 
 package keybase1

--- a/go/protocol/keybase1/avatars.go
+++ b/go/protocol/keybase1/avatars.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/avatars.avdl
 
 package keybase1

--- a/go/protocol/keybase1/backend_common.go
+++ b/go/protocol/keybase1/backend_common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/backend_common.avdl
 
 package keybase1

--- a/go/protocol/keybase1/badger.go
+++ b/go/protocol/keybase1/badger.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/badger.avdl
 
 package keybase1

--- a/go/protocol/keybase1/block.go
+++ b/go/protocol/keybase1/block.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/block.avdl
 
 package keybase1

--- a/go/protocol/keybase1/btc.go
+++ b/go/protocol/keybase1/btc.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/btc.avdl
 
 package keybase1

--- a/go/protocol/keybase1/common.go
+++ b/go/protocol/keybase1/common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/common.avdl
 
 package keybase1

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/config.avdl
 
 package keybase1

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/constants.avdl
 
 package keybase1

--- a/go/protocol/keybase1/contacts.go
+++ b/go/protocol/keybase1/contacts.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/contacts.avdl
 
 package keybase1

--- a/go/protocol/keybase1/crypto.go
+++ b/go/protocol/keybase1/crypto.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/crypto.avdl
 
 package keybase1

--- a/go/protocol/keybase1/cryptocurrency.go
+++ b/go/protocol/keybase1/cryptocurrency.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/cryptocurrency.avdl
 
 package keybase1

--- a/go/protocol/keybase1/ctl.go
+++ b/go/protocol/keybase1/ctl.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/ctl.avdl
 
 package keybase1

--- a/go/protocol/keybase1/debugging.go
+++ b/go/protocol/keybase1/debugging.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/debugging.avdl
 
 package keybase1

--- a/go/protocol/keybase1/delegate_ui_ctl.go
+++ b/go/protocol/keybase1/delegate_ui_ctl.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/delegate_ui_ctl.avdl
 
 package keybase1

--- a/go/protocol/keybase1/device.go
+++ b/go/protocol/keybase1/device.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/device.avdl
 
 package keybase1

--- a/go/protocol/keybase1/emails.go
+++ b/go/protocol/keybase1/emails.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/emails.avdl
 
 package keybase1

--- a/go/protocol/keybase1/ephemeral.go
+++ b/go/protocol/keybase1/ephemeral.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/ephemeral.avdl
 
 package keybase1

--- a/go/protocol/keybase1/favorite.go
+++ b/go/protocol/keybase1/favorite.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/favorite.avdl
 
 package keybase1

--- a/go/protocol/keybase1/fs.go
+++ b/go/protocol/keybase1/fs.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/fs.avdl
 
 package keybase1

--- a/go/protocol/keybase1/git.go
+++ b/go/protocol/keybase1/git.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/git.avdl
 
 package keybase1

--- a/go/protocol/keybase1/gpg_common.go
+++ b/go/protocol/keybase1/gpg_common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/gpg_common.avdl
 
 package keybase1

--- a/go/protocol/keybase1/gpg_ui.go
+++ b/go/protocol/keybase1/gpg_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/gpg_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/gregor.go
+++ b/go/protocol/keybase1/gregor.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/gregor.avdl
 
 package keybase1

--- a/go/protocol/keybase1/gregor_ui.go
+++ b/go/protocol/keybase1/gregor_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/gregor_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/home.go
+++ b/go/protocol/keybase1/home.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/home.avdl
 
 package keybase1

--- a/go/protocol/keybase1/home_ui.go
+++ b/go/protocol/keybase1/home_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/home_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/identify.go
+++ b/go/protocol/keybase1/identify.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/identify.avdl
 
 package keybase1

--- a/go/protocol/keybase1/identify3.go
+++ b/go/protocol/keybase1/identify3.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/identify3.avdl
 
 package keybase1

--- a/go/protocol/keybase1/identify3_common.go
+++ b/go/protocol/keybase1/identify3_common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/identify3_common.avdl
 
 package keybase1

--- a/go/protocol/keybase1/identify3_ui.go
+++ b/go/protocol/keybase1/identify3_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/identify3_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/identify_common.go
+++ b/go/protocol/keybase1/identify_common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/identify_common.avdl
 
 package keybase1

--- a/go/protocol/keybase1/identify_ui.go
+++ b/go/protocol/keybase1/identify_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/identify_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/implicit_team_migration.go
+++ b/go/protocol/keybase1/implicit_team_migration.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/implicit_team_migration.avdl
 
 package keybase1

--- a/go/protocol/keybase1/install.go
+++ b/go/protocol/keybase1/install.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/install.avdl
 
 package keybase1

--- a/go/protocol/keybase1/kbfs.go
+++ b/go/protocol/keybase1/kbfs.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/kbfs.avdl
 
 package keybase1

--- a/go/protocol/keybase1/kbfs_common.go
+++ b/go/protocol/keybase1/kbfs_common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/kbfs_common.avdl
 
 package keybase1

--- a/go/protocol/keybase1/kbfs_git.go
+++ b/go/protocol/keybase1/kbfs_git.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/kbfs_git.avdl
 
 package keybase1

--- a/go/protocol/keybase1/kbfsmount.go
+++ b/go/protocol/keybase1/kbfsmount.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/kbfsmount.avdl
 
 package keybase1

--- a/go/protocol/keybase1/kex2provisionee.go
+++ b/go/protocol/keybase1/kex2provisionee.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/kex2provisionee.avdl
 
 package keybase1

--- a/go/protocol/keybase1/kex2provisionee2.go
+++ b/go/protocol/keybase1/kex2provisionee2.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/kex2provisionee2.avdl
 
 package keybase1

--- a/go/protocol/keybase1/kex2provisioner.go
+++ b/go/protocol/keybase1/kex2provisioner.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/kex2provisioner.avdl
 
 package keybase1

--- a/go/protocol/keybase1/log.go
+++ b/go/protocol/keybase1/log.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/log.avdl
 
 package keybase1

--- a/go/protocol/keybase1/log_ui.go
+++ b/go/protocol/keybase1/log_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/log_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/login.go
+++ b/go/protocol/keybase1/login.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/login.avdl
 
 package keybase1

--- a/go/protocol/keybase1/login_ui.go
+++ b/go/protocol/keybase1/login_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/login_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/logsend.go
+++ b/go/protocol/keybase1/logsend.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/logsend.avdl
 
 package keybase1

--- a/go/protocol/keybase1/merkle.go
+++ b/go/protocol/keybase1/merkle.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/merkle.avdl
 
 package keybase1

--- a/go/protocol/keybase1/merkle_store.go
+++ b/go/protocol/keybase1/merkle_store.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/merkle_store.avdl
 
 package keybase1

--- a/go/protocol/keybase1/metadata.go
+++ b/go/protocol/keybase1/metadata.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/metadata.avdl
 
 package keybase1

--- a/go/protocol/keybase1/metadata_update.go
+++ b/go/protocol/keybase1/metadata_update.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/metadata_update.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_app.go
+++ b/go/protocol/keybase1/notify_app.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_app.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_audit.go
+++ b/go/protocol/keybase1/notify_audit.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_audit.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_badges.go
+++ b/go/protocol/keybase1/notify_badges.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_badges.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_can_user_perform.go
+++ b/go/protocol/keybase1/notify_can_user_perform.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_can_user_perform.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_ctl.go
+++ b/go/protocol/keybase1/notify_ctl.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_ctl.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_device_clone.go
+++ b/go/protocol/keybase1/notify_device_clone.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_device_clone.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_email.go
+++ b/go/protocol/keybase1/notify_email.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_email.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_ephemeral.go
+++ b/go/protocol/keybase1/notify_ephemeral.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_ephemeral.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_favorites.go
+++ b/go/protocol/keybase1/notify_favorites.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_favorites.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_fs.go
+++ b/go/protocol/keybase1/notify_fs.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_fs.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_fs_request.go
+++ b/go/protocol/keybase1/notify_fs_request.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_fs_request.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_keyfamily.go
+++ b/go/protocol/keybase1/notify_keyfamily.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_keyfamily.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_paperkey.go
+++ b/go/protocol/keybase1/notify_paperkey.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_paperkey.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_pgp.go
+++ b/go/protocol/keybase1/notify_pgp.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_pgp.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_phone.go
+++ b/go/protocol/keybase1/notify_phone.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_phone.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_runtimestats.go
+++ b/go/protocol/keybase1/notify_runtimestats.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_runtimestats.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_service.go
+++ b/go/protocol/keybase1/notify_service.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_service.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_session.go
+++ b/go/protocol/keybase1/notify_session.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_session.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_team.go
+++ b/go/protocol/keybase1/notify_team.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_team.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_teambot.go
+++ b/go/protocol/keybase1/notify_teambot.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_teambot.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_tracking.go
+++ b/go/protocol/keybase1/notify_tracking.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_tracking.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_unverified_team_list.go
+++ b/go/protocol/keybase1/notify_unverified_team_list.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_unverified_team_list.avdl
 
 package keybase1

--- a/go/protocol/keybase1/notify_users.go
+++ b/go/protocol/keybase1/notify_users.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/notify_users.avdl
 
 package keybase1

--- a/go/protocol/keybase1/os.go
+++ b/go/protocol/keybase1/os.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/os.avdl
 
 package keybase1

--- a/go/protocol/keybase1/paperprovision.go
+++ b/go/protocol/keybase1/paperprovision.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/paperprovision.avdl
 
 package keybase1

--- a/go/protocol/keybase1/passphrase_common.go
+++ b/go/protocol/keybase1/passphrase_common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/passphrase_common.avdl
 
 package keybase1

--- a/go/protocol/keybase1/pgp.go
+++ b/go/protocol/keybase1/pgp.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/pgp.avdl
 
 package keybase1

--- a/go/protocol/keybase1/pgp_ui.go
+++ b/go/protocol/keybase1/pgp_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/pgp_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/phone_numbers.go
+++ b/go/protocol/keybase1/phone_numbers.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/phone_numbers.avdl
 
 package keybase1

--- a/go/protocol/keybase1/pprof.go
+++ b/go/protocol/keybase1/pprof.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/pprof.avdl
 
 package keybase1

--- a/go/protocol/keybase1/process.go
+++ b/go/protocol/keybase1/process.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/process.avdl
 
 package keybase1

--- a/go/protocol/keybase1/prove.go
+++ b/go/protocol/keybase1/prove.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/prove.avdl
 
 package keybase1

--- a/go/protocol/keybase1/prove_common.go
+++ b/go/protocol/keybase1/prove_common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/prove_common.avdl
 
 package keybase1

--- a/go/protocol/keybase1/prove_ui.go
+++ b/go/protocol/keybase1/prove_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/prove_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/provision_ui.go
+++ b/go/protocol/keybase1/provision_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/provision_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/quota.go
+++ b/go/protocol/keybase1/quota.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/quota.avdl
 
 package keybase1

--- a/go/protocol/keybase1/reachability.go
+++ b/go/protocol/keybase1/reachability.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/reachability.avdl
 
 package keybase1

--- a/go/protocol/keybase1/rekey.go
+++ b/go/protocol/keybase1/rekey.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/rekey.avdl
 
 package keybase1

--- a/go/protocol/keybase1/rekey_ui.go
+++ b/go/protocol/keybase1/rekey_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/rekey_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/reset.go
+++ b/go/protocol/keybase1/reset.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/reset.avdl
 
 package keybase1

--- a/go/protocol/keybase1/revoke.go
+++ b/go/protocol/keybase1/revoke.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/revoke.avdl
 
 package keybase1

--- a/go/protocol/keybase1/saltpack.go
+++ b/go/protocol/keybase1/saltpack.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/saltpack.avdl
 
 package keybase1

--- a/go/protocol/keybase1/saltpack_ui.go
+++ b/go/protocol/keybase1/saltpack_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/saltpack_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/scanproofs.go
+++ b/go/protocol/keybase1/scanproofs.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/scanproofs.avdl
 
 package keybase1

--- a/go/protocol/keybase1/secret_ui.go
+++ b/go/protocol/keybase1/secret_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/secret_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/secretkeys.go
+++ b/go/protocol/keybase1/secretkeys.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/secretkeys.avdl
 
 package keybase1

--- a/go/protocol/keybase1/selfprovision.go
+++ b/go/protocol/keybase1/selfprovision.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/selfprovision.avdl
 
 package keybase1

--- a/go/protocol/keybase1/session.go
+++ b/go/protocol/keybase1/session.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/session.avdl
 
 package keybase1

--- a/go/protocol/keybase1/signup.go
+++ b/go/protocol/keybase1/signup.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/signup.avdl
 
 package keybase1

--- a/go/protocol/keybase1/sigs.go
+++ b/go/protocol/keybase1/sigs.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/sigs.avdl
 
 package keybase1

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/simple_fs.avdl
 
 package keybase1

--- a/go/protocol/keybase1/stream_ui.go
+++ b/go/protocol/keybase1/stream_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/stream_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/teambot.go
+++ b/go/protocol/keybase1/teambot.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/teambot.avdl
 
 package keybase1

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/teams.avdl
 
 package keybase1

--- a/go/protocol/keybase1/teams_ui.go
+++ b/go/protocol/keybase1/teams_ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/teams_ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/test.go
+++ b/go/protocol/keybase1/test.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/test.avdl
 
 package keybase1

--- a/go/protocol/keybase1/tlf.go
+++ b/go/protocol/keybase1/tlf.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/tlf.avdl
 
 package keybase1

--- a/go/protocol/keybase1/tlf_keys.go
+++ b/go/protocol/keybase1/tlf_keys.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/tlf_keys.avdl
 
 package keybase1

--- a/go/protocol/keybase1/track.go
+++ b/go/protocol/keybase1/track.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/track.avdl
 
 package keybase1

--- a/go/protocol/keybase1/ui.go
+++ b/go/protocol/keybase1/ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/ui.avdl
 
 package keybase1

--- a/go/protocol/keybase1/upk.go
+++ b/go/protocol/keybase1/upk.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/upk.avdl
 
 package keybase1

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/user.avdl
 
 package keybase1

--- a/go/protocol/keybase1/usersearch.go
+++ b/go/protocol/keybase1/usersearch.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/keybase1/usersearch.avdl
 
 package keybase1

--- a/go/protocol/stellar1/bundle.go
+++ b/go/protocol/stellar1/bundle.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/stellar1/bundle.avdl
 
 package stellar1

--- a/go/protocol/stellar1/common.go
+++ b/go/protocol/stellar1/common.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/stellar1/common.avdl
 
 package stellar1

--- a/go/protocol/stellar1/gregor.go
+++ b/go/protocol/stellar1/gregor.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/stellar1/gregor.avdl
 
 package stellar1

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/stellar1/local.avdl
 
 package stellar1

--- a/go/protocol/stellar1/notify.go
+++ b/go/protocol/stellar1/notify.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/stellar1/notify.avdl
 
 package stellar1

--- a/go/protocol/stellar1/remote.go
+++ b/go/protocol/stellar1/remote.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/stellar1/remote.avdl
 
 package stellar1

--- a/go/protocol/stellar1/ui.go
+++ b/go/protocol/stellar1/ui.go
@@ -1,4 +1,4 @@
-// Auto-generated types and interfaces using avdl-compiler v1.4.1 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.2 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/stellar1/ui.avdl
 
 package stellar1


### PR DESCRIPTION
Looks like the version used by CI changed, so all CI runs fail on this diff now.