### PR TITLE
Fix race on clearing out built payment when asset choices re received

### DIFF
--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -320,7 +320,6 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
       const {sendAssetChoices} = action.payload
       return state.merge({
         building: state.get('building').merge({sendAssetChoices}),
-        builtPayment: Constants.makeBuiltPayment(),
       })
     }
     case WalletsGen.buildingPaymentIDReceived: {


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

Before this PR: if you prepare a send on the send-form (fill out To, Amount, etc), click Change next to the currency amount and quickly click on a different currency, oftentimes your prepared payment will disappear.

This is because we `loadAssetChoices` when that modal is loaded, and the reducer for `sendAssetChoicesReceived` (which fires when the answer returns) starts by clearing out any built payment.

This creates a race.  When you close the form, either of the following can happen:

* send asset choices returns
* new build payment starts
* new build payment finishes
* everything is fine

or:

* send asset choices is still in flight
* new build payment starts
* new build payment finishes
* send asset choices returns, and clears the built payment

The second path where we lose the race is very common -- I think it must be the case that `loadAssetChoices` has a more demanding network roundtrip than `buildPayment` does, making the race easy to lose.

I don't think it's necessary to clear out a built payment just because we loaded asset choices.  It'll already get rebuilt if the asset choice is changed.  So that's the change in this PR.