### PR TITLE
Make the badge wider on mobile when it contains more than one digit.

### DIFF
--- a/shared/common-adapters/badge.tsx
+++ b/shared/common-adapters/badge.tsx
@@ -19,7 +19,7 @@ export default class Badge extends React.Component<Badge2Props> {
   static defaultProps = {
     fontSize: Styles.isMobile ? 12 : 10,
     height: Styles.isMobile ? 20 : 16,
-    leftRightPadding: Styles.isMobile ? 3 : 4,
+    leftRightPadding: Styles.isMobile ? 5 : 4,
   }
 
   render() {


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review.