### PR TITLE
find dom node 2

### DIFF
--- a/shared/common-adapters/box.desktop.tsx
+++ b/shared/common-adapters/box.desktop.tsx
@@ -3,7 +3,7 @@ import {intersperseFn} from '../util/arrays'
 import {Box2Props} from './box'
 import './box.css'
 
-class Box extends React.PureComponent<any> {
+export class Box extends React.PureComponent<any> {
   render() {
     const {forwardedRef, ...rest} = this.props
     return <div {...rest} ref={this.props.forwardedRef} />
@@ -25,7 +25,7 @@ const injectGaps = (component, _children, gap, gapStart, gapEnd) => {
   return children
 }
 
-const box2 = (props: Box2Props) => {
+const box2 = (props: Box2Props, ref: React.Ref<HTMLDivElement>) => {
   let horizontal = props.direction === 'horizontal' || props.direction === 'horizontalReverse'
 
   const className = [
@@ -51,6 +51,7 @@ const box2 = (props: Box2Props) => {
   // }
   return (
     <div
+      ref={ref}
       onDragLeave={props.onDragLeave}
       onDragOver={props.onDragOver}
       onDrop={props.onDrop}
@@ -65,14 +66,9 @@ const box2 = (props: Box2Props) => {
   )
 }
 
-class Box2 extends React.Component<Box2Props> {
-  render() {
-    return box2(this.props)
-  }
-}
+export const Box2 = React.forwardRef<HTMLDivElement, Box2Props>((props, ref) => box2(props, ref))
 
 const vBoxGap = (key, gap) => <div key={key} className={`box2_gap_vertical_${gap}`} />
 const hBoxGap = (key, gap) => <div key={key} className={`box2_gap_horizontal_${gap}`} />
 
 export default Box
-export {Box, Box2}

--- a/shared/common-adapters/button.tsx
+++ b/shared/common-adapters/button.tsx
@@ -30,9 +30,9 @@ export type Props = {
   style?: Styles.StylesCrossPlatform
   labelContainerStyle?: Styles.StylesCrossPlatform
   labelStyle?: Styles.StylesCrossPlatform
-  type: ButtonType
+  type?: ButtonType
   backgroundColor?: ButtonColor
-  mode: 'Primary' | 'Secondary'
+  mode?: 'Primary' | 'Secondary'
   disabled?: boolean
   waiting?: boolean
   small?: boolean
@@ -51,13 +51,14 @@ const Progress = ({small, white}) => (
   </Kb.Box>
 )
 
-const _Button = (props: Props, ref: React.Ref<ClickableBox>) => {
+const Button = React.forwardRef<ClickableBox, Props>((props: Props, ref: React.Ref<ClickableBox>) => {
+  const {mode = 'Primary', type = 'Default'} = props
   let containerStyle = props.backgroundColor
-    ? backgroundColorContainerStyles[props.mode]
-    : containerStyles[props.mode + props.type]
+    ? backgroundColorContainerStyles[mode]
+    : containerStyles[mode + type]
   let labelStyle = props.backgroundColor
-    ? backgroundColorLabelStyles[props.mode + (props.mode === 'Secondary' ? '' : props.backgroundColor)]
-    : labelStyles[props.mode + props.type]
+    ? backgroundColorLabelStyles[mode + (mode === 'Secondary' ? '' : props.backgroundColor)]
+    : labelStyles[mode + type]
 
   if (props.fullWidth) {
     containerStyle = Styles.collapseStyles([containerStyle, styles.fullWidth])
@@ -80,32 +81,32 @@ const _Button = (props: Props, ref: React.Ref<ClickableBox>) => {
 
   const onClick = (!unclickable && props.onClick) || undefined
   const whiteSpinner =
-    (props.mode === 'Primary' && !(props.backgroundColor || props.type === 'Dim')) ||
-    (props.mode === 'Secondary' && !!props.backgroundColor)
+    (mode === 'Primary' && !(props.backgroundColor || type === 'Dim')) ||
+    (mode === 'Secondary' && !!props.backgroundColor)
 
   // Hover border colors
   const classNames: Array<string> = []
-  if (props.mode === 'Secondary' && !props.backgroundColor) {
+  if (mode === 'Secondary' && !props.backgroundColor) {
     // base grey border
     classNames.push('button__border')
     if (!unclickable) {
       // hover effect
-      classNames.push(`button__border_${typeToColorName[props.type]}`)
+      classNames.push(`button__border_${typeToColorName[type]}`)
     }
   }
 
   // Hover background colors
   const underlayClassNames: Array<string> = []
-  if (props.mode === 'Primary' && !unclickable) {
+  if (mode === 'Primary' && !unclickable) {
     underlayClassNames.push(
       'button__underlay',
       props.backgroundColor ? `button__underlay_${props.backgroundColor}` : 'button__underlay_black10'
     )
-  } else if (props.mode === 'Secondary' && !unclickable) {
+  } else if (mode === 'Secondary' && !unclickable) {
     // default 0.2 opacity + 0.15 here = 0.35 hover
     underlayClassNames.push(
       'button__underlay',
-      props.backgroundColor ? 'button__underlay_black' : `button__underlay_${typeToColorName[props.type]}`
+      props.backgroundColor ? 'button__underlay_black' : `button__underlay_${typeToColorName[type]}`
     )
   }
   const underlay =
@@ -153,13 +154,7 @@ const _Button = (props: Props, ref: React.Ref<ClickableBox>) => {
       </Kb.Box>
     </Kb.ClickableBox>
   )
-}
-
-const Button = React.forwardRef<ClickableBox, Props>(_Button)
-Button.defaultProps = {
-  mode: 'Primary',
-  type: 'Default',
-}
+})
 
 const typeToColorName = {
   Default: 'blue',

--- a/shared/common-adapters/button.tsx
+++ b/shared/common-adapters/button.tsx
@@ -51,125 +51,116 @@ const Progress = ({small, white}) => (
   </Kb.Box>
 )
 
-class Button extends React.Component<Props> {
-  static defaultProps = {
-    mode: 'Primary',
-    type: 'Default',
+const _Button = (props: Props, ref: React.Ref<ClickableBox>) => {
+  let containerStyle = props.backgroundColor
+    ? backgroundColorContainerStyles[props.mode]
+    : containerStyles[props.mode + props.type]
+  let labelStyle = props.backgroundColor
+    ? backgroundColorLabelStyles[props.mode + (props.mode === 'Secondary' ? '' : props.backgroundColor)]
+    : labelStyles[props.mode + props.type]
+
+  if (props.fullWidth) {
+    containerStyle = Styles.collapseStyles([containerStyle, styles.fullWidth])
   }
-  render() {
-    let containerStyle = this.props.backgroundColor
-      ? backgroundColorContainerStyles[this.props.mode]
-      : containerStyles[this.props.mode + this.props.type]
-    let labelStyle = this.props.backgroundColor
-      ? backgroundColorLabelStyles[
-          this.props.mode + (this.props.mode === 'Secondary' ? '' : this.props.backgroundColor)
-        ]
-      : labelStyles[this.props.mode + this.props.type]
 
-    if (this.props.fullWidth) {
-      containerStyle = Styles.collapseStyles([containerStyle, styles.fullWidth])
+  if (props.small) {
+    containerStyle = Styles.collapseStyles([containerStyle, styles.small])
+  }
+
+  const unclickable = props.disabled || props.waiting
+  if (unclickable) {
+    containerStyle = Styles.collapseStyles([containerStyle, styles.opacity30])
+  }
+
+  if (props.waiting) {
+    labelStyle = Styles.collapseStyles([labelStyle, styles.opacity0])
+  }
+
+  containerStyle = Styles.collapseStyles([containerStyle, props.style])
+
+  const onClick = (!unclickable && props.onClick) || undefined
+  const whiteSpinner =
+    (props.mode === 'Primary' && !(props.backgroundColor || props.type === 'Dim')) ||
+    (props.mode === 'Secondary' && !!props.backgroundColor)
+
+  // Hover border colors
+  const classNames: Array<string> = []
+  if (props.mode === 'Secondary' && !props.backgroundColor) {
+    // base grey border
+    classNames.push('button__border')
+    if (!unclickable) {
+      // hover effect
+      classNames.push(`button__border_${typeToColorName[props.type]}`)
     }
+  }
 
-    if (this.props.small) {
-      containerStyle = Styles.collapseStyles([containerStyle, styles.small])
-    }
-
-    const unclickable = this.props.disabled || this.props.waiting
-    if (unclickable) {
-      containerStyle = Styles.collapseStyles([containerStyle, styles.opacity30])
-    }
-
-    if (this.props.waiting) {
-      labelStyle = Styles.collapseStyles([labelStyle, styles.opacity0])
-    }
-
-    containerStyle = Styles.collapseStyles([containerStyle, this.props.style])
-
-    const onClick = (!unclickable && this.props.onClick) || undefined
-    const whiteSpinner =
-      (this.props.mode === 'Primary' && !(this.props.backgroundColor || this.props.type === 'Dim')) ||
-      (this.props.mode === 'Secondary' && !!this.props.backgroundColor)
-
-    // Hover border colors
-    let classNames: Array<string> = []
-    if (this.props.mode === 'Secondary' && !this.props.backgroundColor) {
-      // base grey border
-      classNames.push('button__border')
-      if (!unclickable) {
-        // hover effect
-        classNames.push(`button__border_${typeToColorName[this.props.type]}`)
-      }
-    }
-
-    // Hover background colors
-    let underlayClassNames: Array<string> = []
-    if (this.props.mode === 'Primary' && !unclickable) {
-      underlayClassNames.push(
-        'button__underlay',
-        this.props.backgroundColor
-          ? `button__underlay_${this.props.backgroundColor}`
-          : 'button__underlay_black10'
-      )
-    } else if (this.props.mode === 'Secondary' && !unclickable) {
-      // default 0.2 opacity + 0.15 here = 0.35 hover
-      underlayClassNames.push(
-        'button__underlay',
-        this.props.backgroundColor
-          ? 'button__underlay_black'
-          : `button__underlay_${typeToColorName[this.props.type]}`
-      )
-    }
-    const underlay =
-      !Styles.isMobile && underlayClassNames.length ? (
-        <Kb.Box className={Styles.classNames(underlayClassNames)} />
-      ) : null
-
-    return (
-      <Kb.ClickableBox
-        className={Styles.classNames(classNames)}
-        style={containerStyle}
-        onClick={onClick}
-        onMouseEnter={this.props.onMouseEnter}
-        onMouseLeave={this.props.onMouseLeave}
-        hoverColor={Styles.globalColors.transparent}
-      >
-        {underlay}
-        <Kb.Box
-          style={Styles.collapseStyles([
-            Styles.globalStyles.flexBoxRow,
-            Styles.globalStyles.flexBoxCenter,
-            styles.labelContainer,
-            this.props.labelContainerStyle,
-          ])}
-        >
-          {!this.props.waiting && this.props.children}
-          <Kb.Box2 direction="vertical" centerChildren={true}>
-            {!!this.props.label && (
-              <Kb.Text type="BodySemibold" style={Styles.collapseStyles([labelStyle, this.props.labelStyle])}>
-                {this.props.label}
-              </Kb.Text>
-            )}
-            {!!this.props.subLabel && (
-              <Kb.Text
-                type="BodyTiny"
-                style={Styles.collapseStyles([
-                  this.props.waiting && styles.opacity0,
-                  this.props.subLabelStyle,
-                ])}
-              >
-                {this.props.subLabel}
-              </Kb.Text>
-            )}
-          </Kb.Box2>
-          {!!this.props.badgeNumber && (
-            <Kb.Badge badgeNumber={this.props.badgeNumber} badgeStyle={styles.badge} />
-          )}
-          {!!this.props.waiting && <Progress small={this.props.small} white={whiteSpinner} />}
-        </Kb.Box>
-      </Kb.ClickableBox>
+  // Hover background colors
+  const underlayClassNames: Array<string> = []
+  if (props.mode === 'Primary' && !unclickable) {
+    underlayClassNames.push(
+      'button__underlay',
+      props.backgroundColor ? `button__underlay_${props.backgroundColor}` : 'button__underlay_black10'
+    )
+  } else if (props.mode === 'Secondary' && !unclickable) {
+    // default 0.2 opacity + 0.15 here = 0.35 hover
+    underlayClassNames.push(
+      'button__underlay',
+      props.backgroundColor ? 'button__underlay_black' : `button__underlay_${typeToColorName[props.type]}`
     )
   }
+  const underlay =
+    !Styles.isMobile && underlayClassNames.length ? (
+      <Kb.Box className={Styles.classNames(underlayClassNames)} />
+    ) : null
+
+  return (
+    <Kb.ClickableBox
+      ref={ref}
+      className={Styles.classNames(classNames)}
+      style={containerStyle}
+      onClick={onClick}
+      onMouseEnter={props.onMouseEnter}
+      onMouseLeave={props.onMouseLeave}
+      hoverColor={Styles.globalColors.transparent}
+    >
+      {underlay}
+      <Kb.Box
+        style={Styles.collapseStyles([
+          Styles.globalStyles.flexBoxRow,
+          Styles.globalStyles.flexBoxCenter,
+          styles.labelContainer,
+          props.labelContainerStyle,
+        ])}
+      >
+        {!props.waiting && props.children}
+        <Kb.Box2 direction="vertical" centerChildren={true}>
+          {!!props.label && (
+            <Kb.Text type="BodySemibold" style={Styles.collapseStyles([labelStyle, props.labelStyle])}>
+              {props.label}
+            </Kb.Text>
+          )}
+          {!!props.subLabel && (
+            <Kb.Text
+              type="BodyTiny"
+              style={Styles.collapseStyles([props.waiting && styles.opacity0, props.subLabelStyle])}
+            >
+              {props.subLabel}
+            </Kb.Text>
+          )}
+        </Kb.Box2>
+        {!!props.badgeNumber && <Kb.Badge badgeNumber={props.badgeNumber} badgeStyle={styles.badge} />}
+        {!!props.waiting && <Progress small={props.small} white={whiteSpinner} />}
+      </Kb.Box>
+    </Kb.ClickableBox>
+  )
 }
+
+_Button.defaultProps = {
+  mode: 'Primary',
+  type: 'Default',
+}
+
+const Button = React.forwardRef<ClickableBox, Props>(_Button)
 
 const typeToColorName = {
   Default: 'blue',

--- a/shared/common-adapters/button.tsx
+++ b/shared/common-adapters/button.tsx
@@ -155,12 +155,11 @@ const _Button = (props: Props, ref: React.Ref<ClickableBox>) => {
   )
 }
 
-_Button.defaultProps = {
+const Button = React.forwardRef<ClickableBox, Props>(_Button)
+Button.defaultProps = {
   mode: 'Primary',
   type: 'Default',
 }
-
-const Button = React.forwardRef<ClickableBox, Props>(_Button)
 
 const typeToColorName = {
   Default: 'blue',

--- a/shared/common-adapters/floating-box/index.desktop.tsx
+++ b/shared/common-adapters/floating-box/index.desktop.tsx
@@ -28,7 +28,7 @@ class FloatingBox extends React.Component<Props, State> {
         return attachTo.getBoundingClientRect()
       }
       if (attachTo) {
-        console.warn('Non html element passed to floating box', attachTo)
+        console.warn('Non html element passed to floating box, deprecate this soon', attachTo)
         let node
         try {
           // @ts-ignore this is fine

--- a/shared/common-adapters/floating-box/index.desktop.tsx
+++ b/shared/common-adapters/floating-box/index.desktop.tsx
@@ -24,7 +24,11 @@ class FloatingBox extends React.Component<Props, State> {
     let targetRect: ClientRect | null = null
     if (this.props.attachTo) {
       const attachTo = this.props.attachTo()
+      if (attachTo instanceof HTMLElement) {
+        return attachTo.getBoundingClientRect()
+      }
       if (attachTo) {
+        console.warn('Non html element passed to floating box', attachTo)
         let node
         try {
           // @ts-ignore this is fine

--- a/shared/wallets/wallet/settings/popups/really-remove-account/index.tsx
+++ b/shared/wallets/wallet/settings/popups/really-remove-account/index.tsx
@@ -20,7 +20,7 @@ const ReallyRemoveAccountPopup = (props: Props) => {
   const {accountID, onCopyKey} = props
   const dispatch = Container.useDispatch()
   const [showingToast, setShowToast] = React.useState(false)
-  const attachmentRef = React.useRef<Kb.Button>(null)
+  const attachmentRef = React.useRef<Kb.ClickableBox>(null)
   const setShowToastFalseLater = Kb.useTimeout(() => setShowToast(false), 2000)
   const onLoadSecretKey = React.useCallback(
     () => dispatch(WalletsGen.createExportSecretKey({accountID: accountID})),


### PR DESCRIPTION
This attempts to skip findDomNode when dealing with html elements and will console.log if we pass a component. Longer term we can eliminate this (there is a plan to change how the floating box works so that'll likely entirely clean this up).
I also made `Box2` and `Button` function components w/ `forwardRef` so we can reach into them and get the divs