### PR TITLE
teams: better implementation of audit skip

### DIFF
--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -598,7 +598,7 @@ func (s *localizerPipeline) getMinWriterRoleInfoLocal(ctx context.Context, uid g
 	team, err := teams.Load(ctx, extG, keybase1.LoadTeamArg{
 		ID:        teamID,
 		Public:    conv.Metadata.Visibility == keybase1.TLFVisibility_PUBLIC,
-		SkipAudit: true,
+		AuditMode: keybase1.AuditMode_SKIP,
 	})
 	if err != nil {
 		return nil, err

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -748,7 +748,7 @@ type HiddenTeamChainManager interface {
 }
 
 type TeamAuditor interface {
-	AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkleSeqno keybase1.Seqno, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno, justCreated bool) (err error)
+	AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkleSeqno keybase1.Seqno, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno, auditMode keybase1.AuditMode) (err error)
 }
 
 type TeamBoxAuditor interface {

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -107,7 +107,7 @@ type nullTeamAuditor struct{}
 
 var _ TeamAuditor = nullTeamAuditor{}
 
-func (n nullTeamAuditor) AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkleSeqno keybase1.Seqno, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno, justCreated bool) (err error) {
+func (n nullTeamAuditor) AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkleSeqno keybase1.Seqno, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno, auditMode keybase1.AuditMode) (err error) {
 	return fmt.Errorf("null team auditor")
 }
 

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -120,6 +120,35 @@ func (e TeamStatus) String() string {
 	return ""
 }
 
+type AuditMode int
+
+const (
+	AuditMode_STANDARD     AuditMode = 0
+	AuditMode_JUST_CREATED AuditMode = 1
+	AuditMode_SKIP         AuditMode = 2
+)
+
+func (o AuditMode) DeepCopy() AuditMode { return o }
+
+var AuditModeMap = map[string]AuditMode{
+	"STANDARD":     0,
+	"JUST_CREATED": 1,
+	"SKIP":         2,
+}
+
+var AuditModeRevMap = map[AuditMode]string{
+	0: "STANDARD",
+	1: "JUST_CREATED",
+	2: "SKIP",
+}
+
+func (e AuditMode) String() string {
+	if v, ok := AuditModeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type PerTeamKeyGeneration int
 
 func (o PerTeamKeyGeneration) DeepCopy() PerTeamKeyGeneration {
@@ -2510,8 +2539,8 @@ type LoadTeamArg struct {
 	ForceRepoll               bool           `codec:"forceRepoll" json:"forceRepoll"`
 	StaleOK                   bool           `codec:"staleOK" json:"staleOK"`
 	AllowNameLookupBurstCache bool           `codec:"allowNameLookupBurstCache" json:"allowNameLookupBurstCache"`
-	SkipAudit                 bool           `codec:"skipAudit" json:"skipAudit"`
 	SkipNeedHiddenRotateCheck bool           `codec:"skipNeedHiddenRotateCheck" json:"skipNeedHiddenRotateCheck"`
+	AuditMode                 AuditMode      `codec:"auditMode" json:"auditMode"`
 }
 
 func (o LoadTeamArg) DeepCopy() LoadTeamArg {
@@ -2526,8 +2555,8 @@ func (o LoadTeamArg) DeepCopy() LoadTeamArg {
 		ForceRepoll:               o.ForceRepoll,
 		StaleOK:                   o.StaleOK,
 		AllowNameLookupBurstCache: o.AllowNameLookupBurstCache,
-		SkipAudit:                 o.SkipAudit,
 		SkipNeedHiddenRotateCheck: o.SkipNeedHiddenRotateCheck,
+		AuditMode:                 o.AuditMode.DeepCopy(),
 	}
 }
 

--- a/go/teams/ftl.go
+++ b/go/teams/ftl.go
@@ -992,7 +992,7 @@ func (f *FastTeamChainLoader) audit(m libkb.MetaContext, arg fastLoadArg, state 
 	if last == nil {
 		return NewAuditError("cannot run audit, no last chain data")
 	}
-	return m.G().GetTeamAuditor().AuditTeam(m, arg.ID, arg.Public, head.Seqno, state.Chain.LinkIDs, last.Seqno, false)
+	return m.G().GetTeamAuditor().AuditTeam(m, arg.ID, arg.Public, head.Seqno, state.Chain.LinkIDs, last.Seqno, keybase1.AuditMode_STANDARD)
 }
 
 // readDownPointer reads a down pointer out of a given link, if it's unstubbed. Down pointers

--- a/go/teams/implicit.go
+++ b/go/teams/implicit.go
@@ -311,7 +311,7 @@ func LookupOrCreateImplicitTeam(ctx context.Context, g *libkb.GlobalContext, dis
 				ID:          teamID,
 				Public:      impTeamName.IsPublic,
 				ForceRepoll: true,
-				SkipAudit:   true,
+				AuditMode:   keybase1.AuditMode_JUST_CREATED,
 			})
 			return res, teamName, impTeamName, err
 		}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -308,7 +308,7 @@ func (l *TeamLoader) load1(ctx context.Context, me keybase1.UserVersion, lArg ke
 		forceRepoll:                           mungedForceRepoll,
 		staleOK:                               lArg.StaleOK,
 		public:                                lArg.Public,
-		skipAudit:                             lArg.SkipAudit,
+		auditMode:                             lArg.AuditMode,
 		skipNeedHiddenRotateCheck:             lArg.SkipNeedHiddenRotateCheck,
 
 		needSeqnos:    nil,
@@ -404,9 +404,10 @@ type load2ArgT struct {
 	forceRepoll               bool
 	staleOK                   bool
 	public                    bool
-	skipAudit                 bool
 	skipNeedHiddenRotateCheck bool
 	skipSeedCheck             bool
+
+	auditMode keybase1.AuditMode
 
 	needSeqnos []keybase1.Seqno
 	// Non-nil if we are loading an ancestor for the greater purpose of
@@ -900,7 +901,7 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	ret.LatestSeqnoHint = 0
 
 	tracer.Stage("audit")
-	err = l.audit(ctx, readSubteamID, &ret.Chain, arg.skipAudit)
+	err = l.audit(ctx, readSubteamID, &ret.Chain, arg.auditMode)
 	if err != nil {
 		return nil, err
 	}
@@ -1898,7 +1899,7 @@ func (l *TeamLoader) getHeadMerkleSeqno(mctx libkb.MetaContext, readSubteamID ke
 	return headMerkle.Seqno, nil
 }
 
-func (l *TeamLoader) audit(ctx context.Context, readSubteamID keybase1.TeamID, state *keybase1.TeamSigChainState, skipAudit bool) (err error) {
+func (l *TeamLoader) audit(ctx context.Context, readSubteamID keybase1.TeamID, state *keybase1.TeamSigChainState, auditMode keybase1.AuditMode) (err error) {
 	mctx := libkb.NewMetaContext(ctx, l.G())
 
 	if l.G().Env.Test.TeamSkipAudit {
@@ -1911,7 +1912,7 @@ func (l *TeamLoader) audit(ctx context.Context, readSubteamID keybase1.TeamID, s
 		return err
 	}
 
-	err = mctx.G().GetTeamAuditor().AuditTeam(mctx, state.Id, state.Public, headMerklSeqno, state.LinkIDs, state.LastSeqno, skipAudit)
+	err = mctx.G().GetTeamAuditor().AuditTeam(mctx, state.Id, state.Public, headMerklSeqno, state.LinkIDs, state.LastSeqno, auditMode)
 	return err
 }
 

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -595,7 +595,7 @@ func (l *TeamLoader) checkParentChildOperations(ctx context.Context,
 		forceRepoll:                           false,
 		staleOK:                               true, // stale is fine, as long as get those seqnos.
 		skipSeedCheck:                         true,
-		skipAudit:                             true,
+		auditMode:                             keybase1.AuditMode_SKIP,
 
 		needSeqnos:    needParentSeqnos,
 		readSubteamID: &readSubteamID,

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1680,7 +1680,7 @@ func CanUserPerform(ctx context.Context, g *libkb.GlobalContext, teamname string
 		StaleOK:                   true,
 		Public:                    false, // assume private team
 		AllowNameLookupBurstCache: true,
-		SkipAudit:                 true,
+		AuditMode:                 keybase1.AuditMode_SKIP,
 	})
 	if err != nil {
 		// Note: we eat the error here, assuming it meant this user

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -31,6 +31,12 @@ protocol teams {
     ABANDONED_3
   }
 
+  enum AuditMode {
+    STANDARD_0,
+    JUST_CREATED_1,
+    SKIP_2
+  }
+
   // PerTeamKeyGeneration describes the generation of the secret.
   // The sequence starts at 1.
   @typedef("int")
@@ -943,8 +949,8 @@ protocol teams {
     boolean forceRepoll;               // Force a sync with merkle.
     boolean staleOK;                   // If a very stale cache hit is OK.
     boolean allowNameLookupBurstCache; // If it's ok to hit the nameLookup burst cache
-    boolean skipAudit;                 // don't run the stochastic team audit
     boolean skipNeedHiddenRotateCheck; // don't check the last hidden rotator for device revoke
+    AuditMode auditMode;               // don't run the stochastic team audit
   }
 
   record FastTeamLoadArg {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -38,6 +38,15 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "AuditMode",
+      "symbols": [
+        "STANDARD_0",
+        "JUST_CREATED_1",
+        "SKIP_2"
+      ]
+    },
+    {
       "type": "record",
       "name": "PerTeamKeyGeneration",
       "fields": [],
@@ -2096,11 +2105,11 @@
         },
         {
           "type": "boolean",
-          "name": "skipAudit"
+          "name": "skipNeedHiddenRotateCheck"
         },
         {
-          "type": "boolean",
-          "name": "skipNeedHiddenRotateCheck"
+          "type": "AuditMode",
+          "name": "auditMode"
         }
       ]
     },

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1337,6 +1337,12 @@ export enum AsyncOps {
   getRevisions = 8,
 }
 
+export enum AuditMode {
+  standard = 0,
+  justCreated = 1,
+  skip = 2,
+}
+
 export enum AuditVersion {
   v0 = 0,
   v1 = 1,
@@ -2524,7 +2530,7 @@ export type ListResult = {readonly files?: Array<File> | null}
 export type ListToDepthArgs = {readonly opID: OpID; readonly path: Path; readonly filter: ListFilter; readonly depth: Int}
 export type LoadAvatarsRes = {readonly picmap: {[key: string]: {[key: string]: AvatarUrl}}}
 export type LoadDeviceErr = {readonly where: String; readonly desc: String}
-export type LoadTeamArg = {readonly ID: TeamID; readonly name: String; readonly public: Boolean; readonly needAdmin: Boolean; readonly refreshUIDMapper: Boolean; readonly refreshers: TeamRefreshers; readonly forceFullReload: Boolean; readonly forceRepoll: Boolean; readonly staleOK: Boolean; readonly allowNameLookupBurstCache: Boolean; readonly skipAudit: Boolean; readonly skipNeedHiddenRotateCheck: Boolean}
+export type LoadTeamArg = {readonly ID: TeamID; readonly name: String; readonly public: Boolean; readonly needAdmin: Boolean; readonly refreshUIDMapper: Boolean; readonly refreshers: TeamRefreshers; readonly forceFullReload: Boolean; readonly forceRepoll: Boolean; readonly staleOK: Boolean; readonly allowNameLookupBurstCache: Boolean; readonly skipNeedHiddenRotateCheck: Boolean; readonly auditMode: AuditMode}
 export type LockContext = {readonly requireLockID: LockID; readonly releaseAfterSuccess: Boolean}
 export type LockID = Long
 export type LockdownHistory = {readonly status: Boolean; readonly creationTime: Time; readonly deviceID: DeviceID; readonly deviceName: String}


### PR DESCRIPTION
- before we were using the "just created" skip mechanism which is sticky
- now, we introduce a one-time skip, used via canUserPerform, hierarchical parent name loads, and minRole loads