### PR TITLE
Fix provisioning error screen getting stuck

### DIFF
--- a/shared/actions/provision.tsx
+++ b/shared/actions/provision.tsx
@@ -498,12 +498,15 @@ const showFinalErrorPage = (state: Container.TypedState, action: ProvisionGen.Sh
   let replace = true
   if (state.provision.finalError && !Constants.errorCausedByUsCanceling(state.provision.finalError)) {
     path = ['error']
-    replace = false // can't replace with a modal!
+    replace = !action.payload.fromDeviceAdd
   } else {
     path = []
   }
 
-  return RouteTreeGen.createNavigateAppend({path: [...parentPath, ...path], replace})
+  return [
+    ...(action.payload.fromDeviceAdd ? [RouteTreeGen.createClearModals()] : []),
+    RouteTreeGen.createNavigateAppend({path: [...parentPath, ...path], replace}),
+  ]
 }
 
 const showUsernameEmailPage = () => RouteTreeGen.createNavigateAppend({path: ['username']})

--- a/shared/provision/error/index.tsx
+++ b/shared/provision/error/index.tsx
@@ -1,9 +1,10 @@
-// TODO remove Container
-import Container from '../../login/forms/container'
+// TODO remove PlatformContainer
+import PlatformContainer from '../../login/forms/container'
 import * as React from 'react'
+import * as Container from '../../util/container'
 import {RPCError} from '../../util/errors'
 import {StatusCode} from '../../constants/types/rpc-gen'
-import {Box2, Text, Markdown} from '../../common-adapters'
+import {Box2, Text, Markdown, Modal} from '../../common-adapters'
 import {styleSheetCreate, globalStyles, globalMargins, isMobile} from '../../styles'
 
 type Props = {
@@ -20,16 +21,39 @@ const List = p => (
   </Box2>
 )
 
-const Wrapper = (p: {onBack: () => void; children: React.ReactNode}) => (
-  <Container onBack={p.onBack}>
-    <Text type="Header" style={styles.header}>
-      There was an error provisioning
-    </Text>
-    <Box2 direction="vertical" gap="small" gapStart={true} gapEnd={true} style={styles.container}>
-      {p.children}
-    </Box2>
-  </Container>
-)
+const Wrapper = (p: {onBack: () => void; children: React.ReactNode}) => {
+  const loggedIn = Container.useSelector(s => s.config.loggedIn)
+  const content = (
+    <>
+      <Text type="Header" style={styles.header}>
+        There was an error provisioning
+      </Text>
+      <Box2 direction="vertical" gap="small" gapStart={true} gapEnd={true} style={styles.container}>
+        {p.children}
+      </Box2>
+    </>
+  )
+  return loggedIn ? (
+    <Modal
+      onClose={p.onBack}
+      header={
+        isMobile
+          ? {
+              leftButton: (
+                <Text type="BodySemiboldLink" onClick={p.onBack}>
+                  Back
+                </Text>
+              ),
+            }
+          : undefined
+      }
+    >
+      {content}
+    </Modal>
+  ) : (
+    <PlatformContainer onBack={p.onBack}>{content}</PlatformContainer>
+  )
+}
 
 const rewriteErrorDesc = {
   'Provisioner is a different user than we wanted.':


### PR DESCRIPTION
#19567 turned a white screen crash into an inescapable error screen in some cases

1. As provisioner - an error on qr scan led to it
2. As provisionee - losing network while entering username led to it

Fix by

- If you're provisioner (i.e. logged in), wrap the error screen in `Kb.Modal` w/ some exit buttons
- If you're provisionee, `replace` the error screen on top so you can't go back to the qr scan route

"error" is a modal route **and** non modal route, which I think we should change to make this less confusing. Atm if you're provisioner you get the modal one, and as provisionee you get the non modal one. cc @keybase/y2ksquad 