### PR TITLE
test deprovisioning with ephemeral keys

### DIFF
--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -286,7 +286,8 @@ func ProvisionNewDeviceKex(tcX *libkb.TestContext, tcY *libkb.TestContext, userX
 }
 
 type TestProvisionUI struct {
-	SecretCh chan kex2.Secret
+	SecretCh   chan kex2.Secret
+	DeviceType string
 }
 
 func (u *TestProvisionUI) ChooseProvisioningMethod(_ context.Context, _ keybase1.ChooseProvisioningMethodArg) (keybase1.ProvisionMethod, error) {
@@ -302,6 +303,11 @@ func (u *TestProvisionUI) SwitchToGPGSignOK(ctx context.Context, arg keybase1.Sw
 }
 
 func (u *TestProvisionUI) ChooseDevice(_ context.Context, arg keybase1.ChooseDeviceArg) (keybase1.DeviceID, error) {
+	for _, d := range arg.Devices {
+		if d.Type == u.DeviceType {
+			return d.DeviceID, nil
+		}
+	}
 	return "", nil
 }
 


### PR DESCRIPTION
Deprovisioning with creating a new ephemeral key did not have coverage before because the `engine` package is a dependency of `ephemeral`. 