### PR TITLE
Fix LogoutEngine return val when user switching fails

### DIFF
--- a/go/engine/logout.go
+++ b/go/engine/logout.go
@@ -46,7 +46,12 @@ func (e *LogoutEngine) Run(mctx libkb.MetaContext) (err error) {
 	if err != nil {
 		return err
 	}
-	return e.doSwitch(mctx)
+	if err := e.doSwitch(mctx); err != nil {
+		// We don't care if user switching doesn't work here - user is logged
+		// out at this point. LogoutEngine is considered successful.
+		mctx.Debug("Cannot user-switch after Logout: %s", err)
+	}
+	return nil
 }
 
 var _ Engine2 = (*LogoutEngine)(nil)


### PR DESCRIPTION
At some point we might consider this error critical - probably when User Switching feature is more mature or completed. But for now it doesn't make sense to error out here, especially that it black bars in GUI, but does so after the logout. It's too late at that point anyway - the user is logged out, secrets are killed.