### PR TITLE
Check TLFName/TopicName when formatting conversation name [HOTPOT-840]

### DIFF
--- a/go/bind/notifications.go
+++ b/go/bind/notifications.go
@@ -104,7 +104,7 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 		return err
 	}
 	membersType := chat1.ConversationMembersType(intMembersType)
-	conv, err := utils.GetVerifiedConv(ctx, gc, uid, convID, types.InboxSourceDataSourceAll)
+	conv, err := utils.GetVerifiedConv(ctx, gc, uid, convID, types.InboxSourceDataSourceLocalOnly)
 	if err != nil {
 		kbCtx.Log.CDebugf(ctx, "Failed to get conversation info", err)
 		return err

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -2406,23 +2406,27 @@ func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 func FormatConversationName(info chat1.ConversationInfoLocal, myUsername string) string {
 	switch info.TeamType {
 	case chat1.TeamType_COMPLEX:
-		return fmt.Sprintf("%s#%s", info.TlfName, info.TopicName)
+		if len(info.TlfName) > 0 && len(info.TopicName) > 0 {
+			return fmt.Sprintf("%s#%s", info.TlfName, info.TopicName)
+		}
+		return info.TlfName
 	case chat1.TeamType_SIMPLE:
 		return info.TlfName
 	case chat1.TeamType_NONE:
 		users := info.Participants
-		if len(users) > 1 {
-			var usersWithoutYou []string
-			for _, user := range users {
-				if user.Username != myUsername {
-					usersWithoutYou = append(usersWithoutYou, user.Username)
-				}
-			}
-			return strings.Join(usersWithoutYou, ",")
+		if len(users) == 1 {
+			return ""
 		}
+		var usersWithoutYou []string
+		for _, user := range users {
+			if user.Username != myUsername {
+				usersWithoutYou = append(usersWithoutYou, user.Username)
+			}
+		}
+		return strings.Join(usersWithoutYou, ",")
+	default:
 		return ""
 	}
-	return info.TlfName
 }
 
 func GetVerifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,


### PR DESCRIPTION
don't show `#` if `TopicName`/`TlfName` are empty