### PR TITLE
don't show two errors when one will do

### DIFF
--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -97,7 +97,7 @@ const LeftBlock = (_: EmptyProps) => {
               </Kb.Text>
             </>
           ))}
-        {!!builtPaymentAdvanced.amountError ? (
+        {builtPaymentAdvanced.amountError ? (
           <Kb.Text type="BodySmall" style={styles.error} lineClamp={3}>
             {builtPaymentAdvanced.amountError}
           </Kb.Text>
@@ -119,7 +119,7 @@ const LeftBlock = (_: EmptyProps) => {
         {!!buildingAdvanced.recipientAsset && (
           <Kb.Text type="BodyTiny">{builtPaymentAdvanced.exchangeRate}</Kb.Text>
         )}
-        {!!builtPaymentAdvanced.amountError ? (
+        {builtPaymentAdvanced.amountError ? (
           <Kb.Text type="BodySmall" style={styles.error} lineClamp={3}>
             {builtPaymentAdvanced.amountError}
           </Kb.Text>

--- a/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
+++ b/shared/wallets/send-form/asset-input/asset-input-advanced.tsx
@@ -97,10 +97,12 @@ const LeftBlock = (_: EmptyProps) => {
               </Kb.Text>
             </>
           ))}
-        {!!builtPaymentAdvanced.amountError && (
+        {!!builtPaymentAdvanced.amountError ? (
           <Kb.Text type="BodySmall" style={styles.error} lineClamp={3}>
             {builtPaymentAdvanced.amountError}
           </Kb.Text>
+        ) : (
+          <Available />
         )}
       </Kb.Box2>
     )
@@ -117,10 +119,12 @@ const LeftBlock = (_: EmptyProps) => {
         {!!buildingAdvanced.recipientAsset && (
           <Kb.Text type="BodyTiny">{builtPaymentAdvanced.exchangeRate}</Kb.Text>
         )}
-        {!!builtPaymentAdvanced.amountError && (
+        {!!builtPaymentAdvanced.amountError ? (
           <Kb.Text type="BodySmall" style={styles.error} lineClamp={3}>
             {builtPaymentAdvanced.amountError}
           </Kb.Text>
+        ) : (
+          <Available />
         )}
       </Kb.Box2>
     )
@@ -162,7 +166,6 @@ export const AssetInputSenderAdvanced = (_: EmptyProps) => {
         <Kb.Box style={Styles.globalStyles.flexGrow} />
         <PickAssetButton isSender={true} />
       </Kb.Box2>
-      <Available />
     </Kb.Box2>
   )
 }


### PR DESCRIPTION
i couldn't actually recreate the condition where it's possible to get both of these error messages to display at the same time, but cecile saw it. perhaps the path creation logic in horizon has gotten smarter. regardless, there's no reason to show both of these error messages, because it's a little weird. so now just show one or the other.
