### PR TITLE
Add dark mode debug flag

### DIFF
--- a/shared/__mocks__/local-debug.tsx
+++ b/shared/__mocks__/local-debug.tsx
@@ -13,6 +13,7 @@ export const immediateStateLogging = false
 export const isDevApplePushToken = false
 export const isTesting = false
 export const maskStrings = false
+export const partyMode = false
 export const printOutstandingRPCs = false
 export const printOutstandingTimerListeners = false
 export const printRPC = false

--- a/shared/local-debug.d.ts
+++ b/shared/local-debug.d.ts
@@ -8,6 +8,7 @@ export declare const ignoreDisconnectOverlay: boolean
 export declare const immediateStateLogging: boolean
 export declare const isDevApplePushToken: boolean
 export declare const isTesting: boolean
+export declare const partyMode: boolean
 export declare const printOutstandingRPCs: boolean
 export declare const printOutstandingTimerListeners: boolean
 export declare const printRPC: boolean

--- a/shared/local-debug.desktop.tsx
+++ b/shared/local-debug.desktop.tsx
@@ -15,6 +15,7 @@ let config = {
   immediateStateLogging: false, // Don't wait for idle to log state
   isDevApplePushToken: false,
   isTesting: __STORYBOOK__, // Is running a unit test
+  partyMode: false,
   printOutstandingRPCs: false, // Periodically print rpcs we're waiting for
   printOutstandingTimerListeners: false, // Periodically print listeners to the second clock
   printRPC: false, // Print rpc traffic
@@ -121,6 +122,7 @@ export const {
   isDevApplePushToken,
   immediateStateLogging,
   isTesting,
+  partyMode,
   printOutstandingRPCs,
   printOutstandingTimerListeners,
   printRPC,

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -40,6 +40,7 @@ let config = {
   immediateStateLogging: false, // Don't wait for idle to log state
   isDevApplePushToken: false, // Use a dev push token
   isTesting: nativeBridge.test === '1' || (NativeModules.Storybook && NativeModules.Storybook.isStorybook), // Is running a unit test
+  partyMode: false,
   printOutstandingRPCs: false, // Periodically print rpcs we're waiting for
   printOutstandingTimerListeners: false, // Periodically print listeners to the second clock
   printRPC: false, // Print rpc traffic
@@ -125,6 +126,7 @@ export const {
   immediateStateLogging,
   isDevApplePushToken,
   isTesting,
+  partyMode,
   printOutstandingRPCs,
   printOutstandingTimerListeners,
   printRPC,

--- a/shared/styles/colors.tsx
+++ b/shared/styles/colors.tsx
@@ -271,21 +271,15 @@ const partyFallbackColors = {
   get blackOrWhite() {
     return colors.white
   },
-  black_05: 'rgba(255, 255, 255, 0.05)',
   get black_05OrBlack_60() {
     return colors.black_60
   },
   black_05_on_white: 'rgb(13, 13, 13)',
-  black_10: 'rgba(255, 255, 255, 0.10)',
   black_10_on_white: 'rgb(26, 26, 26)',
-  black_20: 'rgba(255, 255, 255, 0.20)',
   get black_20OrBlack() {
     return colors.black
   },
   black_20_on_white: 'rgb(51, 51, 51)',
-  black_35: 'rgba(255, 255, 255, 0.35)',
-  black_40: 'rgba(255, 255, 255, 0.40)',
-  black_50: 'rgba(255, 255, 255, 0.50)',
   get black_50OrWhite() {
     return colors.white
   },
@@ -307,9 +301,7 @@ const partyFallbackColors = {
   },
   white_0: 'rgba(25, 25, 25, 0)',
   white_0_on_white: '#191919',
-  white_20: 'rgba(25, 25, 25, 0.20)',
   white_20_on_white: '#191919',
-  white_40: 'rgba(25, 25, 25, 0.40)',
   get white_40OrBlack_60() {
     return colors.black_60
   },

--- a/shared/styles/colors.tsx
+++ b/shared/styles/colors.tsx
@@ -1,5 +1,6 @@
 // the _on_white are precomputed colors so we can do less blending on mobile
 import {isDarkMode} from './dark-mode'
+import {partyMode} from '../local-debug'
 import {isIOS} from '../constants/platform'
 
 export const colors = {
@@ -262,6 +263,67 @@ export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   yellowLight: '#FFFDCC',
 }
 
+// export const partyColors: { [P in keyof typeof colors]: string | undefined } = {
+
+// }
+
+const partyFallbackColors = {
+  black: 'rgba(255, 255, 255, 0.85)',
+  get blackOrBlack() {
+    return colors.black
+  },
+  get blackOrWhite() {
+    return colors.white
+  },
+  black_05: 'rgba(255, 255, 255, 0.05)',
+  get black_05OrBlack_60() {
+    return colors.black_60
+  },
+  black_05_on_white: 'rgb(13, 13, 13)',
+  black_10: 'rgba(255, 255, 255, 0.10)',
+  black_10_on_white: 'rgb(26, 26, 26)',
+  black_20: 'rgba(255, 255, 255, 0.20)',
+  get black_20OrBlack() {
+    return colors.black
+  },
+  black_20_on_white: 'rgb(51, 51, 51)',
+  black_35: 'rgba(255, 255, 255, 0.35)',
+  black_40: 'rgba(255, 255, 255, 0.40)',
+  black_50: 'rgba(255, 255, 255, 0.50)',
+  get black_50OrWhite() {
+    return colors.white
+  },
+  get black_50OrWhite_75() {
+    return colors.white_75
+  },
+  black_50_on_white: 'rgb(128, 128, 128)',
+  black_60: 'rgba(255, 255, 255, 0.60)',
+  black_63: 'rgba(255, 255, 255, 0.63)',
+  black_on_white: 'rgb(217, 217, 217)',
+  transparent: 'rgba(255, 255, 255, 0)',
+  transparent_on_white: '#191919',
+  white: '#191919',
+  get whiteOrBlack() {
+    return colors.black
+  },
+  get whiteOrGreenDark() {
+    return '#FF00FF'
+  },
+  white_0: 'rgba(25, 25, 25, 0)',
+  white_0_on_white: '#191919',
+  white_20: 'rgba(25, 25, 25, 0.20)',
+  white_20_on_white: '#191919',
+  white_40: 'rgba(25, 25, 25, 0.40)',
+  get white_40OrBlack_60() {
+    return colors.black_60
+  },
+  white_40_on_white: '#191919',
+  white_75: 'rgba(25, 25, 25, 0.75)',
+  white_75_on_white: '#191919',
+  white_90: 'rgba(25, 25, 25, 0.90)',
+  white_90_on_white: '#191919',
+}
+
 type Color = typeof colors
 type Names = keyof Color
 
@@ -272,6 +334,11 @@ export const themed = names.reduce<Color>(
       configurable: false,
       enumerable: true,
       get() {
+        if (partyMode && isDarkMode()) {
+          // sets all non-grayscale colors to magenta in dark mode when enabled
+          return partyFallbackColors[name] || '#FF00FF'
+        }
+
         return isDarkMode() ? darkColors[name] : colors[name]
       },
     }),

--- a/shared/styles/colors.tsx
+++ b/shared/styles/colors.tsx
@@ -263,10 +263,6 @@ export const darkColors: {[P in keyof typeof colors]: string | undefined} = {
   yellowLight: '#FFFDCC',
 }
 
-// export const partyColors: { [P in keyof typeof colors]: string | undefined } = {
-
-// }
-
 const partyFallbackColors = {
   black: 'rgba(255, 255, 255, 0.85)',
   get blackOrBlack() {


### PR DESCRIPTION
Adds `partyMode` debug flag which changes all non-grayscale colors to magenta in dark mode to allow for easier debugging.

@keybase/react-hackers 
@keybase/hotpotatosquad 

![Screen Shot 2019-09-18 at 4 40 18 PM](https://user-images.githubusercontent.com/54032873/65184193-05fa7c80-da33-11e9-8ee4-87751cd06745.png)
![party parrot](https://cultofthepartyparrot.com/parrots/hd/parrot.gif)![party parrot](https://cultofthepartyparrot.com/parrots/hd/parrot.gif)![party parrot](https://cultofthepartyparrot.com/parrots/hd/parrot.gif)