### PR TITLE
Reduce overdraw on android

### DIFF
--- a/shared/common-adapters/user-card.native.tsx
+++ b/shared/common-adapters/user-card.native.tsx
@@ -70,7 +70,7 @@ const styles = Styles.styleSheetCreate(() => ({
   inside: {
     ...Styles.globalStyles.flexBoxColumn,
     alignItems: 'stretch',
-    backgroundColor: Styles.globalColors.white,
+    backgroundColor: Styles.globalColors.fastBlank,
     justifyContent: 'flex-start',
     padding: 16,
     width: '100%',

--- a/shared/login/relogin/index.native.tsx
+++ b/shared/login/relogin/index.native.tsx
@@ -122,7 +122,7 @@ const styles = Styles.styleSheetCreate(
       container: {
         ...Styles.globalStyles.flexBoxColumn,
         alignItems: 'center',
-        backgroundColor: Styles.globalColors.white,
+        backgroundColor: Styles.globalColors.fastBlank,
         flex: 1,
       },
       deviceNotSecureContainer: {

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -44,7 +44,7 @@ const defaultNavigationOptions: any = {
     ),
   headerStyle: {
     get backgroundColor() {
-      return Styles.globalColors.white
+      return Styles.globalColors.fastBlank
     },
     get borderBottomColor() {
       return Styles.globalColors.black_10

--- a/shared/router-v2/shim.native.tsx
+++ b/shared/router-v2/shim.native.tsx
@@ -49,7 +49,7 @@ const styles = Styles.styleSheetCreate(
   () =>
     ({
       keyboard: {
-        backgroundColor: Styles.globalColors.white,
+        backgroundColor: Styles.globalColors.fastBlank,
         flexGrow: 1,
         position: 'relative',
       },


### PR DESCRIPTION
@keybase/react-hackers 

Reduces overdraw in a couple places. Unfortunately, because of the way RN navigation works and our nested stack navigator, the best we can do is overdraw 2x.

I think it's worth thinking about how we can change that.