### PR TITLE
Autoreset storybook: confirm reset

### DIFF
--- a/shared/common-adapters/modal/index.stories.tsx
+++ b/shared/common-adapters/modal/index.stories.tsx
@@ -176,6 +176,11 @@ const load = () => {
         {filler}
       </Modal>
     ))
+    .add('Fullscreen', () => (
+      <Modal header={{title: "I'm way up here"}} fullscreen={true}>
+        {filler}
+      </Modal>
+    ))
 }
 
 const generateColorFromSeed = s => `rgba(${s * 4}, ${s * 4}, ${s * 4}, 0.7)`

--- a/shared/common-adapters/modal/index.tsx
+++ b/shared/common-adapters/modal/index.tsx
@@ -36,8 +36,9 @@ type Props = {
   banners?: React.ReactNode[]
   children: React.ReactNode
   header?: HeaderProps
-  onClose?: () => void
+  onClose?: () => void // desktop non-fullscreen only
   footer?: FooterProps
+  fullscreen?: boolean // desktop only. disable the popupdialog / underlay and expand to fit the screen
   mode: 'Default' | 'Wide'
 }
 
@@ -56,7 +57,7 @@ const ModalInner = (props: Props) => (
   </>
 )
 const Modal = (props: Props) =>
-  Styles.isMobile ? (
+  Styles.isMobile || props.fullscreen ? (
     <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
       <ModalInner {...props} />
     </Kb.Box2>

--- a/shared/common-adapters/modal/index.tsx
+++ b/shared/common-adapters/modal/index.tsx
@@ -48,12 +48,14 @@ const ModalInner = (props: Props) => (
     {!!props.banners && props.banners}
     <Kb.ScrollView
       alwaysBounceVertical={false}
-      style={props.mode === 'Wide' ? styles.scrollWide : undefined}
+      style={styles.scroll}
       contentContainerStyle={styles.scrollContentContainer}
     >
       {props.children}
     </Kb.ScrollView>
-    {!!props.footer && <Footer {...props.footer} wide={props.mode === 'Wide'} />}
+    {!!props.footer && (
+      <Footer {...props.footer} wide={props.mode === 'Wide'} fullscreen={!!props.fullscreen} />
+    )}
   </>
 )
 const Modal = (props: Props) =>
@@ -150,14 +152,15 @@ const Header = (props: HeaderProps) => {
   )
 }
 
-const Footer = (props: FooterProps & {wide: boolean}) => (
+const Footer = (props: FooterProps & {fullscreen: boolean; wide: boolean}) => (
   <Kb.Box2
     centerChildren={true}
     direction="vertical"
     fullWidth={true}
     style={Styles.collapseStyles([
       styles.footer,
-      props.wide && !Styles.isMobile && styles.footerWide,
+      props.wide && styles.footerWide,
+      props.fullscreen && styles.footerFullscreen,
       !props.hideBorder && styles.footerBorder,
       props.style,
     ])}
@@ -197,9 +200,20 @@ const styles = Styles.styleSheetCreate(() => {
       borderTopColor: Styles.globalColors.black_10,
       borderTopWidth: 1,
     },
-    footerWide: {
-      ...Styles.padding(Styles.globalMargins.xsmall, Styles.globalMargins.medium),
-    },
+    footerFullscreen: Styles.platformStyles({
+      isElectron: {
+        ...Styles.padding(
+          Styles.globalMargins.xsmall,
+          Styles.globalMargins.small,
+          Styles.globalMargins.xlarge
+        ),
+      },
+    }),
+    footerWide: Styles.platformStyles({
+      isElectron: {
+        ...Styles.padding(Styles.globalMargins.xsmall, Styles.globalMargins.medium),
+      },
+    }),
     header: {
       ...headerCommon,
       minHeight: 48,
@@ -240,10 +254,10 @@ const styles = Styles.styleSheetCreate(() => {
         width: 560,
       },
     }),
-    scrollContentContainer: {...Styles.globalStyles.flexBoxColumn, flexGrow: 1, width: '100%'},
-    scrollWide: Styles.platformStyles({
+    scroll: Styles.platformStyles({
       isElectron: {...Styles.globalStyles.flexBoxColumn, flex: 1, position: 'relative'},
     }),
+    scrollContentContainer: {...Styles.globalStyles.flexBoxColumn, flexGrow: 1, width: '100%'},
   }
 })
 

--- a/shared/login/reset/confirm.tsx
+++ b/shared/login/reset/confirm.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
-import {SignupScreen} from '../../signup/common'
 
 const todo = () => console.log('todo')
 
@@ -16,13 +15,24 @@ const ConfirmReset = () => {
   const disabled = !check1 || !check2 || !check3
 
   return (
-    <SignupScreen
-      title="Account reset"
-      noBackground={true}
-      buttons={[
-        {disabled, label: 'Yes, reset account', onClick: onContinue, type: 'Danger'},
-        {label: 'Cancel reset', onClick: onCancel, type: 'Dim'},
-      ]}
+    <Kb.Modal
+      header={{title: 'Account reset'}}
+      fullscreen={true}
+      footer={{
+        content: (
+          <Kb.ButtonBar direction="column" fullWidth={true} style={styles.buttonBar}>
+            <Kb.Button
+              disabled={disabled}
+              label="Yes, reset account"
+              onClick={onContinue}
+              type="Danger"
+              fullWidth={true}
+            />
+            <Kb.Button label="Cancel reset" onClick={onCancel} type="Dim" fullWidth={true} />
+          </Kb.ButtonBar>
+        ),
+        style: styles.footer,
+      }}
     >
       <Kb.Box2
         direction="vertical"
@@ -31,7 +41,7 @@ const ConfirmReset = () => {
         alignItems="center"
         style={styles.container}
       >
-        <Kb.Icon type="iconfont-skull" sizeType="Big" />
+        <Kb.Icon type="iconfont-skull" sizeType="Big" color={Styles.globalColors.black} />
         <Kb.Box2 direction="vertical" fullWidth={true} gap="small" alignItems="center">
           <Kb.Text type="Header">Go ahead with reset?</Kb.Text>
           <Kb.Box2 direction="vertical" fullWidth={true} gap="xsmall" alignItems="flex-start">
@@ -61,12 +71,18 @@ const ConfirmReset = () => {
           </Kb.Box2>
         </Kb.Box2>
       </Kb.Box2>
-    </SignupScreen>
+    </Kb.Modal>
   )
 }
 
 const styles = Styles.styleSheetCreate(() => ({
+  buttonBar: {
+    alignItems: 'center',
+  },
   container: Styles.platformStyles({
+    common: {
+      alignSelf: 'center',
+    },
     isElectron: {
       width: 368,
     },
@@ -74,6 +90,9 @@ const styles = Styles.styleSheetCreate(() => ({
       padding: Styles.globalMargins.medium,
     },
   }),
+  footer: {
+    ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),
+  },
 }))
 
 export default ConfirmReset

--- a/shared/login/reset/confirm.tsx
+++ b/shared/login/reset/confirm.tsx
@@ -4,15 +4,23 @@ import * as Styles from '../../styles'
 
 const todo = () => console.log('todo')
 
-const ConfirmReset = () => {
+type Props = {
+  hasWallet: boolean
+}
+
+const ConfirmReset = (props: Props) => {
   const [check1, setCheck1] = React.useState(false)
   const [check2, setCheck2] = React.useState(false)
   const [check3, setCheck3] = React.useState(false)
+  const [check4, setCheck4] = React.useState(false)
 
   const onContinue = todo
   const onCancel = todo
 
-  const disabled = !check1 || !check2 || !check3
+  let disabled = !check1 || !check2 || !check4
+  if (props.hasWallet) {
+    disabled = disabled || !check3
+  }
 
   return (
     <Kb.Modal
@@ -63,10 +71,22 @@ const ConfirmReset = () => {
               checked={check2}
               onCheck={setCheck2}
             />
+            {props.hasWallet && (
+              <Kb.Checkbox
+                labelComponent={
+                  <Kb.Text type="Body">
+                    You will <Kb.Text type="BodyExtrabold">lose access to your wallet funds</Kb.Text> if you
+                    haven't backed up your Stellar private keys outside of Keybase.
+                  </Kb.Text>
+                }
+                checked={check3}
+                onCheck={setCheck3}
+              />
+            )}
             <Kb.Checkbox
               label="Cryptographically, you'll be a whole new person."
-              checked={check3}
-              onCheck={setCheck3}
+              checked={check4}
+              onCheck={setCheck4}
             />
           </Kb.Box2>
         </Kb.Box2>

--- a/shared/login/reset/confirm.tsx
+++ b/shared/login/reset/confirm.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react'
+import * as Kb from '../../common-adapters'
+import * as Styles from '../../styles'
+import {SignupScreen} from '../../signup/common'
+
+const todo = () => console.log('todo')
+
+const ConfirmReset = () => {
+  const [check1, setCheck1] = React.useState(false)
+  const [check2, setCheck2] = React.useState(false)
+  const [check3, setCheck3] = React.useState(false)
+
+  const onContinue = todo
+  const onCancel = todo
+
+  const disabled = !check1 || !check2 || !check3
+
+  return (
+    <SignupScreen
+      title="Account reset"
+      noBackground={true}
+      buttons={[
+        {disabled, label: 'Yes, reset account', onClick: onContinue, type: 'Danger'},
+        {label: 'Cancel reset', onClick: onCancel, type: 'Dim'},
+      ]}
+    >
+      <Kb.Box2
+        direction="vertical"
+        fullWidth={true}
+        gap="medium"
+        alignItems="center"
+        style={styles.container}
+      >
+        <Kb.Icon type="iconfont-skull" sizeType="Big" />
+        <Kb.Box2 direction="vertical" fullWidth={true} gap="small" alignItems="center">
+          <Kb.Text type="Header">Go ahead with reset?</Kb.Text>
+          <Kb.Box2 direction="vertical" fullWidth={true} gap="xsmall" alignItems="flex-start">
+            <Kb.Box2 direction="vertical" alignItems="center" fullWidth={true}>
+              <Kb.Text type="Body" center={true}>
+                You can now fully reset your account.
+              </Kb.Text>
+              <Kb.Text type="Body" center={true}>
+                Please check the boxes below:
+              </Kb.Text>
+            </Kb.Box2>
+            <Kb.Checkbox
+              label="You will lose your personal chats, files and git data."
+              checked={check1}
+              onCheck={setCheck1}
+            />
+            <Kb.Checkbox
+              label="You will be removed from teams. If you were the last owner or admin of a team, it'll be orphaned and unrecoverable."
+              checked={check2}
+              onCheck={setCheck2}
+            />
+            <Kb.Checkbox
+              label="Cryptographically, you'll be a whole new person."
+              checked={check3}
+              onCheck={setCheck3}
+            />
+          </Kb.Box2>
+        </Kb.Box2>
+      </Kb.Box2>
+    </SignupScreen>
+  )
+}
+
+const styles = Styles.styleSheetCreate(() => ({
+  container: Styles.platformStyles({
+    isElectron: {
+      width: 368,
+    },
+    isMobile: {
+      padding: Styles.globalMargins.medium,
+    },
+  }),
+}))
+
+export default ConfirmReset

--- a/shared/login/reset/confirm.tsx
+++ b/shared/login/reset/confirm.tsx
@@ -82,17 +82,17 @@ const styles = Styles.styleSheetCreate(() => ({
   container: Styles.platformStyles({
     common: {
       alignSelf: 'center',
-    },
-    isElectron: {
-      width: 368,
-    },
-    isMobile: {
       padding: Styles.globalMargins.medium,
     },
+    isElectron: {
+      width: 368 + Styles.globalMargins.medium * 2,
+    },
   }),
-  footer: {
-    ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),
-  },
+  footer: Styles.platformStyles({
+    isMobile: {
+      ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),
+    },
+  }),
 }))
 
 export default ConfirmReset

--- a/shared/login/reset/confirm.tsx
+++ b/shared/login/reset/confirm.tsx
@@ -11,9 +11,9 @@ type Props = {
 const ConfirmReset = (props: Props) => {
   const [checks, setChecks] = React.useState({
     checkData: false,
+    checkNewPerson: false,
     checkTeams: false,
     checkWallet: false,
-    checkNewPerson: false,
   })
   const onCheck = (which: keyof typeof checks) => (enable: boolean) => setChecks({...checks, [which]: enable})
 

--- a/shared/login/reset/confirm.tsx
+++ b/shared/login/reset/confirm.tsx
@@ -9,17 +9,21 @@ type Props = {
 }
 
 const ConfirmReset = (props: Props) => {
-  const [check1, setCheck1] = React.useState(false)
-  const [check2, setCheck2] = React.useState(false)
-  const [check3, setCheck3] = React.useState(false)
-  const [check4, setCheck4] = React.useState(false)
+  const [checks, setChecks] = React.useState({
+    checkData: false,
+    checkTeams: false,
+    checkWallet: false,
+    checkNewPerson: false,
+  })
+  const onCheck = (which: keyof typeof checks) => (enable: boolean) => setChecks({...checks, [which]: enable})
 
   const onContinue = todo
   const onCancel = todo
 
-  let disabled = !check1 || !check2 || !check4
+  const {checkData, checkTeams, checkWallet, checkNewPerson} = checks
+  let disabled = !checkData || !checkTeams || !checkNewPerson
   if (props.hasWallet) {
-    disabled = disabled || !check3
+    disabled = disabled || !checkWallet
   }
 
   return (
@@ -63,13 +67,13 @@ const ConfirmReset = (props: Props) => {
             </Kb.Box2>
             <Kb.Checkbox
               label="You will lose your personal chats, files and git data."
-              checked={check1}
-              onCheck={setCheck1}
+              checked={checkData}
+              onCheck={onCheck('checkData')}
             />
             <Kb.Checkbox
               label="You will be removed from teams. If you were the last owner or admin of a team, it'll be orphaned and unrecoverable."
-              checked={check2}
-              onCheck={setCheck2}
+              checked={checkTeams}
+              onCheck={onCheck('checkTeams')}
             />
             {props.hasWallet && (
               <Kb.Checkbox
@@ -79,14 +83,14 @@ const ConfirmReset = (props: Props) => {
                     haven't backed up your Stellar private keys outside of Keybase.
                   </Kb.Text>
                 }
-                checked={check3}
-                onCheck={setCheck3}
+                checked={checkWallet}
+                onCheck={onCheck('checkWallet')}
               />
             )}
             <Kb.Checkbox
               label="Cryptographically, you'll be a whole new person."
-              checked={check4}
-              onCheck={setCheck4}
+              checked={checkNewPerson}
+              onCheck={onCheck('checkNewPerson')}
             />
           </Kb.Box2>
         </Kb.Box2>

--- a/shared/login/reset/confirm.tsx
+++ b/shared/login/reset/confirm.tsx
@@ -74,7 +74,7 @@ const ConfirmReset = (props: Props) => {
             {props.hasWallet && (
               <Kb.Checkbox
                 labelComponent={
-                  <Kb.Text type="Body">
+                  <Kb.Text type="Body" style={Styles.globalStyles.flexOne}>
                     You will <Kb.Text type="BodyExtrabold">lose access to your wallet funds</Kb.Text> if you
                     haven't backed up your Stellar private keys outside of Keybase.
                   </Kb.Text>

--- a/shared/login/reset/index.stories.tsx
+++ b/shared/login/reset/index.stories.tsx
@@ -16,6 +16,7 @@ const load = () => {
     .add('Waiting', () => <Waiting time="7 days" pipelineStarted={true} />)
     .add('Check phone', () => <Waiting pipelineStarted={false} />)
     .add('Waiting more', () => <Waiting time="2 days" pipelineStarted={true} />)
-    .add('Confirm', () => <ConfirmReset />)
+    .add('Confirm w/out wallet', () => <ConfirmReset hasWallet={false} />)
+    .add('Confirm w/ wallet', () => <ConfirmReset hasWallet={true} />)
 }
 export default load

--- a/shared/login/reset/index.stories.tsx
+++ b/shared/login/reset/index.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Sb from '../../stories/storybook'
 import resetModal from '../reset-modal/index.stories'
 import {KnowPassword, EnterPassword} from './password'
+import ConfirmReset from './confirm'
 const store = Sb.createStoreWithCommon()
 
 import Waiting from './waiting'
@@ -9,13 +10,12 @@ const load = () => {
   resetModal()
 
   Sb.storiesOf('Login/Reset', module)
-    .add('Waiting', () => <Waiting time="7 days" pipelineStarted={true} />)
-    .add('Check phone', () => <Waiting pipelineStarted={false} />)
-    .add('Waiting more', () => <Waiting time="2 days" pipelineStarted={true} />)
-
-  Sb.storiesOf('Login/Reset', module)
     .addDecorator((story: any) => <Sb.MockStore store={store}>{story()}</Sb.MockStore>)
     .add('Do you know your password?', () => <KnowPassword />)
     .add('Enter password', () => <EnterPassword />)
+    .add('Waiting', () => <Waiting time="7 days" pipelineStarted={true} />)
+    .add('Check phone', () => <Waiting pipelineStarted={false} />)
+    .add('Waiting more', () => <Waiting time="2 days" pipelineStarted={true} />)
+    .add('Confirm', () => <ConfirmReset />)
 }
 export default load


### PR DESCRIPTION
<img width="844" alt="image" src="https://user-images.githubusercontent.com/11968340/65248674-8b783e00-dac0-11e9-9d27-b3233e894fd9.png">

This also adds a `fullscreen` prop to modal that changes it on desktop to the version seen here.

cc @keybase/y2ksquad also cc @mlsteele I heard you're looking for a sticky modal footer tray like this one.