### PR TITLE
PICNIC-359 - Fix Avatar Upload Panning Regression

### DIFF
--- a/shared/profile/edit-avatar/index.desktop.tsx
+++ b/shared/profile/edit-avatar/index.desktop.tsx
@@ -215,7 +215,6 @@ class EditAvatar extends React.Component<_Props, State> {
     if (!this.state.hasPreview || !this._image) return
 
     // Grab the values now. The event object will be nullified by the time setState is called.
-    // const {pageX, pageY} = Object.assign({}, e)
     const {pageX, pageY} = e
 
     const img = this._image.current
@@ -249,7 +248,6 @@ class EditAvatar extends React.Component<_Props, State> {
     if (!this.state.dragging || this.props.submitting) return
 
     // Grab the values now. The event object will be nullified by the time setState is called.
-    // const {pageX, pageY} = Object.assign({}, e)
     const {pageX, pageY} = e
 
     const offsetLeft = clamp(

--- a/shared/profile/edit-avatar/index.desktop.tsx
+++ b/shared/profile/edit-avatar/index.desktop.tsx
@@ -213,6 +213,9 @@ class EditAvatar extends React.Component<_Props, State> {
 
   _onMouseDown = (e: React.MouseEvent) => {
     if (!this.state.hasPreview || !this._image) return
+    // React will pool the event object and reuse it We want to tell react not
+    // to nullify this event object so we can asynchronously setState with it
+    e.persist()
 
     const img = this._image.current
 
@@ -243,6 +246,10 @@ class EditAvatar extends React.Component<_Props, State> {
 
   _onMouseMove = (e: React.MouseEvent) => {
     if (!this.state.dragging || this.props.submitting) return
+
+    // React will pool the event object and reuse it We want to tell react not
+    // to nullify this event object so we can asynchronously setState with it
+    e.persist()
 
     const offsetLeft = clamp(
       // eslint-disable-next-line
@@ -298,9 +305,6 @@ class EditAvatar extends React.Component<_Props, State> {
             cursor: this.state.dragging ? '-webkit-grabbing' : 'default',
           },
         ])}
-        onMouseUp={this._onMouseUp}
-        onMouseDown={this._onMouseDown}
-        onMouseMove={this._onMouseMove}
       >
         {!!this.props.error && (
           <Kb.Banner color="red">
@@ -318,6 +322,9 @@ class EditAvatar extends React.Component<_Props, State> {
               paddingTop: this.props.createdTeam ? 0 : Styles.globalMargins.xlarge,
             },
           ])}
+          onMouseMove={this._onMouseMove}
+          onMouseUp={this._onMouseUp}
+          onMouseDown={this._onMouseDown}
         >
           {this.props.createdTeam && (
             <Kb.Box style={styles.createdBanner}>

--- a/shared/profile/edit-avatar/index.desktop.tsx
+++ b/shared/profile/edit-avatar/index.desktop.tsx
@@ -213,15 +213,16 @@ class EditAvatar extends React.Component<_Props, State> {
 
   _onMouseDown = (e: React.MouseEvent) => {
     if (!this.state.hasPreview || !this._image) return
-    // React will pool the event object and reuse it We want to tell react not
-    // to nullify this event object so we can asynchronously setState with it
-    e.persist()
+
+    // Grab the values now. The event object will be nullified by the time setState is called.
+    // const {pageX, pageY} = Object.assign({}, e)
+    const {pageX, pageY} = e
 
     const img = this._image.current
 
     this.setState(s => ({
-      dragStartX: e.pageX,
-      dragStartY: e.pageY,
+      dragStartX: pageX,
+      dragStartY: pageY,
       // @ts-ignore codemode issue
       dragStopX: img && img.style.left ? parseInt(img.style.left, 10) : s.dragStopX,
       // @ts-ignore codemode issue
@@ -247,20 +248,20 @@ class EditAvatar extends React.Component<_Props, State> {
   _onMouseMove = (e: React.MouseEvent) => {
     if (!this.state.dragging || this.props.submitting) return
 
-    // React will pool the event object and reuse it We want to tell react not
-    // to nullify this event object so we can asynchronously setState with it
-    e.persist()
+    // Grab the values now. The event object will be nullified by the time setState is called.
+    // const {pageX, pageY} = Object.assign({}, e)
+    const {pageX, pageY} = e
 
     const offsetLeft = clamp(
       // eslint-disable-next-line
-      this.state.dragStopX + e.pageX - this.state.dragStartX,
+      this.state.dragStopX + pageX - this.state.dragStartX,
       // eslint-disable-next-line
       AVATAR_SIZE - this.state.scaledImageWidth,
       0
     )
     const offsetTop = clamp(
       // eslint-disable-next-line
-      this.state.dragStopY + e.pageY - this.state.dragStartY,
+      this.state.dragStopY + pageY - this.state.dragStartY,
       // eslint-disable-next-line
       AVATAR_SIZE - this.state.scaledImageHeight,
       0
@@ -305,6 +306,7 @@ class EditAvatar extends React.Component<_Props, State> {
             cursor: this.state.dragging ? '-webkit-grabbing' : 'default',
           },
         ])}
+        onMouseMove={this._onMouseMove}
       >
         {!!this.props.error && (
           <Kb.Banner color="red">
@@ -322,9 +324,9 @@ class EditAvatar extends React.Component<_Props, State> {
               paddingTop: this.props.createdTeam ? 0 : Styles.globalMargins.xlarge,
             },
           ])}
-          onMouseMove={this._onMouseMove}
           onMouseUp={this._onMouseUp}
           onMouseDown={this._onMouseDown}
+          onMouseMove={this._onMouseMove}
         >
           {this.props.createdTeam && (
             <Kb.Box style={styles.createdBanner}>


### PR DESCRIPTION
### Overview

- Moved the panning mouse handlers to the `Kb.Box` that renders the modal content rather than `Kb.MaybepPopup`.
- Made the `React.MouseEvent` persist so that we can use it when setting the offset position using `setState`. This was the main issue as React was printing console errors warning about the event being reclaimed.

@keybase/react-hackers @keybase/picnicsquad 