### PR TITLE
Do additional search for 'keybase' if query is phone/email

### DIFF
--- a/shared/actions/__tests__/team-building.test.tsx
+++ b/shared/actions/__tests__/team-building.test.tsx
@@ -78,9 +78,8 @@ const userSearchMock = {
   },
 }
 
-const mockUserSearchRpcPromiseRpcPromise = (
-  params: RPCTypes.MessageTypes['keybase.1.userSearch.userSearch']['inParam']
-) => {
+type searchPromiseParams = RPCTypes.MessageTypes['keybase.1.userSearch.userSearch']['inParam']
+const mockUserSearchRpcPromiseRpcPromise = (params: searchPromiseParams) => {
   const {query, maxResults, service, includeServicesSummary} = params
   let result
   try {
@@ -256,5 +255,93 @@ describe('Search Actions', () => {
       expect(getState().chat2.teamBuilding.teamBuildingTeamSoFar).toEqual(I.OrderedSet())
       expect(getState().chat2.teamBuilding.teamBuildingFinishedTeam).toEqual(I.OrderedSet())
     })
+  })
+})
+
+describe('Extra search', () => {
+  let init: ReturnType<typeof startReduxSaga>
+  let rpc
+  beforeEach(() => {
+    init = startReduxSaga()
+    rpc = jest.spyOn(RPCTypes, 'userSearchUserSearchRpcPromise')
+  })
+  afterEach(() => {
+    rpc && rpc.mockRestore()
+  })
+
+  it('does not fire additional search for non-keybase or non-phone/email queries', () => {
+    const {dispatch} = init
+    rpc.mockImplementation(async (params: searchPromiseParams) => {
+      if (params.service === 'phone' || params.service === 'email') {
+        throw new Error('Unexpected mock call')
+      }
+      return []
+    })
+    for (let service of ['twitter', 'keybase'] as Types.ServiceIdWithContact[]) {
+      dispatch(
+        TeamBuildingGen.createSearch({
+          includeContacts: false,
+          namespace: testNamespace,
+          query: 'marco',
+          service,
+        })
+      )
+      expect(rpc).toBeCalled()
+    }
+  })
+
+  it('prepends extra search result', async () => {
+    const {dispatch, getState} = init
+    rpc.mockImplementation(
+      async (params: searchPromiseParams): Promise<RPCTypes.APIUserSearchResult[]> => {
+        if (params.service === 'email' && params.query === 'marco@keyba.se') {
+          return [
+            {
+              imptofu: {
+                assertion: '[marco@keyba.se]@email',
+                assertionValue: 'marco@keyba.se',
+                assertionKey: 'phone',
+                label: '',
+                prettyName: '',
+                keybaseUsername: '',
+              },
+              servicesSummary: {},
+              score: 0.5,
+              rawScore: 1,
+            },
+          ]
+        }
+        return []
+      }
+    )
+    for (let query of ['marco@keyba.se', 'michal@keyba.se']) {
+      dispatch(
+        TeamBuildingGen.createSearch({
+          includeContacts: false,
+          namespace: testNamespace,
+          service: 'keybase',
+          query,
+        })
+      )
+      await Testing.flushPromises()
+    }
+    const results = getState().chat2.teamBuilding.teamBuildingSearchResults
+    const expected = I.Map()
+      .mergeIn(['michal@keyba.se'], {
+        keybase: [],
+      })
+      .mergeIn(['marco@keyba.se'], {
+        keybase: [
+          {
+            id: '[marco@keyba.se]@email',
+            label: '',
+            prettyName: 'marco@keyba.se',
+            serviceId: 'phone',
+            serviceMap: {keybase: ''},
+            username: 'marco@keyba.se',
+          },
+        ],
+      })
+    expect(results).toEqual(expected)
   })
 })

--- a/shared/actions/__tests__/team-building.test.tsx
+++ b/shared/actions/__tests__/team-building.test.tsx
@@ -299,15 +299,15 @@ describe('Extra search', () => {
             {
               imptofu: {
                 assertion: '[marco@keyba.se]@email',
-                assertionValue: 'marco@keyba.se',
                 assertionKey: 'phone',
+                assertionValue: 'marco@keyba.se',
+                keybaseUsername: '',
                 label: '',
                 prettyName: '',
-                keybaseUsername: '',
               },
-              servicesSummary: {},
-              score: 0.5,
               rawScore: 1,
+              score: 0.5,
+              servicesSummary: {},
             },
           ]
         }
@@ -319,8 +319,8 @@ describe('Extra search', () => {
         TeamBuildingGen.createSearch({
           includeContacts: false,
           namespace: testNamespace,
-          service: 'keybase',
           query,
+          service: 'keybase',
         })
       )
       await Testing.flushPromises()

--- a/shared/actions/team-building.tsx
+++ b/shared/actions/team-building.tsx
@@ -6,6 +6,8 @@ import * as RouteTreeGen from './route-tree-gen'
 import * as Saga from '../util/saga'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import {TypedState} from '../constants/reducer'
+import {validateNumber} from '../util/phone-numbers'
+import {validateEmailAddress} from '../util/email-address'
 
 const closeTeamBuilding = () => RouteTreeGen.createClearModals()
 export type NSAction = {payload: {namespace: TeamBuildingTypes.AllowedNamespace}}
@@ -40,6 +42,38 @@ const apiSearch = async (
   }
 }
 
+// If the query is a well-formatted phone number or email, do additional search
+// and if the result is not already in the list, insert at the beginning.
+async function specialContactSearch(users: TeamBuildingTypes.User[], query: string, region: string | null) {
+  const apiSearchOne = async (
+    query: string,
+    service: TeamBuildingTypes.ServiceIdWithContact
+  ): Promise<TeamBuildingTypes.User | null> =>
+    apiSearch(
+      query,
+      service,
+      1 /* maxResults */,
+      true /* serviceSummaries */,
+      false /* includeContacts */
+    ).then(arg => arg[0])
+  const maybeSearch = async (): Promise<TeamBuildingTypes.User | null> => {
+    const phoneNumber = validateNumber(query, region)
+    if (phoneNumber.valid) {
+      return apiSearchOne(phoneNumber.e164, 'phone')
+    } else if (validateEmailAddress(query)) {
+      return apiSearchOne(query, 'email')
+    }
+    return null
+  }
+  const result = await maybeSearch()
+  if (result && !users.find(x => x.id === result.id)) {
+    // Overwrite `prettyName` to make the special result stand out.
+    result.prettyName = query
+    return [result, ...users]
+  }
+  return users
+}
+
 const search = async (state: TypedState, {payload: {namespace, includeContacts}}: SearchOrRecAction) => {
   const {teamBuildingSearchQuery, teamBuildingSelectedService, teamBuildingSearchLimit} = state[
     namespace
@@ -50,13 +84,19 @@ const search = async (state: TypedState, {payload: {namespace, includeContacts}}
     return false
   }
 
-  const users = await apiSearch(
+  // Do the main search for selected service and query.
+  let users = await apiSearch(
     teamBuildingSearchQuery,
     teamBuildingSelectedService,
     teamBuildingSearchLimit,
     true /* includeServicesSummary */,
     includeContacts
   )
+  if (teamBuildingSelectedService === 'keybase') {
+    // If we are on Keybase tab, do additional search if query is phone/email.
+    const userRegion = state.settings.contacts.userCountryCode
+    users = await specialContactSearch(users, teamBuildingSearchQuery, userRegion)
+  }
   return TeamBuildingGen.createSearchResultsLoaded({
     namespace,
     query: teamBuildingSearchQuery,

--- a/shared/actions/team-building.tsx
+++ b/shared/actions/team-building.tsx
@@ -42,31 +42,29 @@ const apiSearch = async (
   }
 }
 
+const apiSearchOne = async (
+  query: string,
+  service: TeamBuildingTypes.ServiceIdWithContact
+): Promise<TeamBuildingTypes.User | undefined> =>
+  (await apiSearch(
+    query,
+    service,
+    1 /* maxResults */,
+    true /* serviceSummaries */,
+    false /* includeContacts */
+  ))[0]
+
 // If the query is a well-formatted phone number or email, do additional search
 // and if the result is not already in the list, insert at the beginning.
 async function specialContactSearch(users: TeamBuildingTypes.User[], query: string, region: string | null) {
-  const apiSearchOne = async (
-    query: string,
-    service: TeamBuildingTypes.ServiceIdWithContact
-  ): Promise<TeamBuildingTypes.User | null> =>
-    apiSearch(
-      query,
-      service,
-      1 /* maxResults */,
-      true /* serviceSummaries */,
-      false /* includeContacts */
-    ).then(arg => arg[0])
-  const maybeSearch = async (): Promise<TeamBuildingTypes.User | null> => {
-    const phoneNumber = validateNumber(query, region)
-    if (phoneNumber.valid) {
-      return apiSearchOne(phoneNumber.e164, 'phone')
-    } else if (validateEmailAddress(query)) {
-      return apiSearchOne(query, 'email')
-    }
-    return null
+  let result: TeamBuildingTypes.User | undefined
+  const phoneNumber = validateNumber(query, region)
+  if (phoneNumber.valid) {
+    result = await apiSearchOne(phoneNumber.e164, 'phone')
+  } else if (validateEmailAddress(query)) {
+    result = await apiSearchOne(query, 'email')
   }
-  const result = await maybeSearch()
-  if (result && !users.find(x => x.id === result.id)) {
+  if (result && !users.find(x => result && x.id === result.id)) {
     // Overwrite `prettyName` to make the special result stand out.
     result.prettyName = query
     return [result, ...users]


### PR DESCRIPTION
On `keybase` tab, do additional `email` or `phone` search query if we discover query is a valid email address or a valid phone number. If we get a result and it's not duplicate (by assertion) of another result,  insert it at the beginning of result list.

cc @keybase/react-hackers @keybase/y2ksquad 
