### PR TITLE
rollforward react navigation core again. fix actual issue

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -125,7 +125,7 @@
     "@emotion/styled": "10.0.14",
     "@react-native-community/geolocation": "2.0.2",
     "@react-native-community/netinfo": "4.1.3",
-    "@react-navigation/core": "3.4.0",
+    "@react-navigation/core": "3.4.2",
     "@react-navigation/native": "3.5.0",
     "base64-js": "1.3.0",
     "buffer": "5.2.1",

--- a/shared/router-v2/shim.shared.tsx
+++ b/shared/router-v2/shim.shared.tsx
@@ -4,14 +4,19 @@ export const shim = (routes: any, platformWrapper: any) => {
 
     map[route] = {
       ...routes[route],
-      getScreen: () => {
-        if (_cached) {
-          return _cached
-        }
+      // only wrap if it uses getScreen originally, else let screen be special (sub navs in desktop)
+      ...(routes[route].getScreen
+        ? {
+            getScreen: () => {
+              if (_cached) {
+                return _cached
+              }
 
-        _cached = platformWrapper(routes[route].getScreen())
-        return _cached
-      },
+              _cached = platformWrapper(routes[route].getScreen())
+              return _cached
+            },
+          }
+        : {}),
     }
 
     return map

--- a/shared/settings/routes.desktop.tsx
+++ b/shared/settings/routes.desktop.tsx
@@ -74,7 +74,8 @@ SettingsSubNavigator.navigationOptions = {
 }
 
 export const newRoutes = {
-  settingsRoot: {getScreen: () => SettingsSubNavigator},
+  // MUST use screen and not getScreen for subnavs!
+  settingsRoot: {screen: SettingsSubNavigator},
 }
 export const newModalRoutes = {
   [Constants.logOutTab]: {getScreen: (): typeof LogOutTab => require('./logout/container').default},

--- a/shared/wallets/routes.tsx
+++ b/shared/wallets/routes.tsx
@@ -126,15 +126,10 @@ const OnboardingOrWallets = Container.namedConnect(
 )(_OnboardingOrWallets)
 
 export const newRoutes = {
-  walletsRoot: {
-    getScreen: () => {
-      if (isMobile) {
-        return require('./wallet/container').default
-      } else {
-        return OnboardingOrWallets
-      }
-    },
-  },
+  walletsRoot: isMobile
+    ? {getScreen: () => require('./wallet/container').default}
+    : // MUST use screen and not getScreen for subnavs!
+      {screen: OnboardingOrWallets},
   ...sharedRoutes, // these are valid inside AND outside the subnav
 }
 

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -1353,10 +1353,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-4.1.3.tgz#77571619eb90ff59777a85a913fc30acd30b6020"
   integrity sha512-c9ppXNFpKkXiKFJhik9Lzw62dosm+cAIvHl6OOGXp2D+1GlliIP+nMMtNapdppPoilRc33f4/GosqnL70viH9Q==
 
-"@react-navigation/core@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.4.0.tgz#776845f9d4f8b2b9cb99c5d2d4433ebcef290d92"
-  integrity sha512-YAnx9mK6P/zYkvn4YxZL6thaNdouSmD7FUaftFrOAbE7y7cCfH8hmk7BOLoOet6Sh2+UnrpkWX7Kg54cT2Jw+g==
+"@react-navigation/core@3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.4.2.tgz#bec563e94fde40fbab3730cdc97f22afbb2a1498"
+  integrity sha512-7G+iDzLSTeOUU4vVZeRZKJ+Bd7ds7ZxYNqZcB8i0KlBeQEQfR74Ounfu/p0KIEq2RiNnaE3QT7WVP3C87sebzw==
   dependencies:
     hoist-non-react-statics "^3.3.0"
     path-to-regexp "^1.7.0"


### PR DESCRIPTION
Fixes the subtle breaking change in react-navigation. They no longer call getScreen() for routes as an optimization but assume sub routes don't use that. So we switch to the screen property instead of subnavs. We were shimming also so that had to be aware