### PR TITLE
kbfstool: support team paths and handles with TLF IDs

### DIFF
--- a/go/kbfs/fsrpc/path.go
+++ b/go/kbfs/fsrpc/path.go
@@ -22,6 +22,7 @@ const (
 	topName     = "keybase"
 	publicName  = "public"
 	privateName = "private"
+	teamName    = "team"
 )
 
 // PathType describes the types for different paths
@@ -75,6 +76,8 @@ func listTypeToTLFType(c string) tlf.Type {
 		return tlf.Private
 	case publicName:
 		return tlf.Public
+	case teamName:
+		return tlf.SingleTeam
 	default:
 		// TODO: support team TLFs.
 		panic(fmt.Sprintf("Unknown folder list type: %s", c))
@@ -90,7 +93,8 @@ func NewPath(pathStr string) (Path, error) {
 	len := len(components)
 
 	if (len >= 1 && components[0] != topName) ||
-		(len >= 2 && components[1] != publicName && components[1] != privateName) {
+		(len >= 2 && components[1] != publicName &&
+			components[1] != privateName && components[1] != teamName) {
 		return Path{}, InvalidPathErr{pathStr}
 	}
 

--- a/go/kbfs/kbfstool/md_common.go
+++ b/go/kbfs/kbfstool/md_common.go
@@ -117,7 +117,7 @@ func getTlfID(
 		return tlf.ID{}, err
 	}
 
-	return config.MDOps().GetIDForHandle(ctx, handle)
+	return handle.TlfID(), nil
 }
 
 func getBranchID(ctx context.Context, config libkbfs.Config,
@@ -260,10 +260,7 @@ func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 
 	fmt.Printf("Looking for unmerged branch...\n")
 
-	tlfID, err := config.MDOps().GetIDForHandle(ctx, handle)
-	if err != nil {
-		return libkbfs.ImmutableRootMetadata{}, err
-	}
+	tlfID := handle.TlfID()
 	if tlfID == tlf.NullID {
 		return libkbfs.ImmutableRootMetadata{}, errors.New("No TLF ID")
 	}


### PR DESCRIPTION
Apparently this tool hasn't been used in a while.