### PR TITLE
PICNIC-163 Change Input Line Height to Prevent Emoji Clipping

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -441,14 +441,18 @@ const styles = Styles.styleSheetCreate(
       input: {
         backgroundColor: Styles.globalColors.transparent,
         height: 21,
+        // Line height change is so that emojis (unicode characters inside
+        // textarea) are not clipped at the top. This change is accompanied by
+        // a change in padding to offset the increased line height
+        lineHeight: '22px',
         minHeight: 21,
       },
       inputBox: {
         flex: 1,
-        paddingBottom: Styles.globalMargins.xxtiny,
+        paddingBottom: Styles.globalMargins.xtiny,
         paddingLeft: 6,
         paddingRight: 6,
-        paddingTop: Styles.globalMargins.tiny,
+        paddingTop: Styles.globalMargins.tiny - 2,
         textAlign: 'left',
       },
       inputEditing: {

--- a/shared/wallets/send-form/note-and-memo/index.tsx
+++ b/shared/wallets/send-form/note-and-memo/index.tsx
@@ -226,10 +226,18 @@ const styles = Styles.styleSheetCreate(
       flexOne: {
         flex: 1,
       },
-      input: {
-        backgroundColor: Styles.globalColors.white,
-        color: Styles.globalColors.black_on_white,
-      },
+      input: Styles.platformStyles({
+        common: {
+          backgroundColor: Styles.globalColors.white,
+          color: Styles.globalColors.black_on_white,
+        },
+        isElectron: {
+          // Line height change is so that emojis (unicode characters inside
+          // textarea) are not clipped at the top. This change is accompanied by
+          // a change in padding to offset the increased line height
+          lineHeight: '22px',
+        },
+      }),
       inputDisabled: {
         backgroundColor: Styles.globalColors.white,
         color: Styles.globalColors.greyDarker,


### PR DESCRIPTION
macOS rescales emoji characters as it desires based on if the screen is retina or not. So on non-retina the emojis are larger and on retina the emojis are smaller. This is a OS rendering decision, Slack, Spotify, and other electron applications also express the same behavior.

However our lineHeight on non-retina desktop was too small and would clip the enlarged emojis at the top by 2 pixels.