### PR TITLE
TOFU invites in regular teams

### DIFF
--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"errors"
+	"fmt"
 
 	gregor "github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/libkb"
@@ -190,7 +191,7 @@ func (e *ResolveThenIdentify2) GetIdentifyOutcome() *libkb.IdentifyOutcome {
 func ResolveAndCheck(m libkb.MetaContext, s string, useTracking bool) (ret keybase1.UserPlusKeysV2, err error) {
 
 	m = m.WithLogTag("RAC")
-	defer m.TraceTimed("ResolveAndCheck", func() error { return err })()
+	defer m.TraceTimed(fmt.Sprintf("ResolveAndCheck(%q,%t)", s, useTracking), func() error { return err })()
 
 	arg := keybase1.Identify2Arg{
 		UserAssertion:         s,

--- a/go/systests/phone_number_test.go
+++ b/go/systests/phone_number_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTeamWithPhoneNumber(t *testing.T) {
+func TestImpTeamWithPhoneNumber(t *testing.T) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 

--- a/go/systests/sbs_test.go
+++ b/go/systests/sbs_test.go
@@ -14,6 +14,13 @@ import (
 	context "golang.org/x/net/context"
 )
 
+func assertionFromKV(t *testing.T, key, value string) libkb.AssertionURL {
+	actx := externals.MakeStaticAssertionContext(context.TODO())
+	ret, err := libkb.ParseAssertionURLKeyValue(actx, key, value, true /* strict */)
+	require.NoError(t, err)
+	return ret
+}
+
 // Same SBS test can run against different SBS types, where each one has
 // different way of proving (verifying), revoking etc. Encapsulate all that
 // under a type that implements `userSBSProvider` and pass it to the "generic"
@@ -29,13 +36,6 @@ type userSBSProvider interface {
 type userSBSPhoneNumber struct {
 	u           *userPlusDevice
 	phoneNumber string //without `+`
-}
-
-func assertionFromKV(t *testing.T, key, value string) libkb.AssertionURL {
-	actx := externals.MakeStaticAssertionContext(context.TODO())
-	ret, err := libkb.ParseAssertionURLKeyValue(actx, key, value, true /* strict */)
-	require.NoError(t, err)
-	return ret
 }
 
 func (p *userSBSPhoneNumber) SetUser(user *userPlusDevice) {

--- a/go/systests/sbs_test.go
+++ b/go/systests/sbs_test.go
@@ -1,0 +1,58 @@
+package systests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/phonenumbers"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+	"github.com/stretchr/testify/require"
+	context "golang.org/x/net/context"
+)
+
+func TestTeamInvitePhoneNumber(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	ann := tt.addUser("ann")
+	bob := tt.addUser("bob")
+
+	// user 0 creates a team
+	teamID, teamName := ann.createTeam2()
+
+	phone := kbtest.GenerateTestPhoneNumber()
+	phoneNumber := keybase1.PhoneNumber("+" + phone)
+	phoneAssertion := fmt.Sprintf("%s@phone", phone)
+
+	ann.addTeamMember(teamName.String(), phoneAssertion, keybase1.TeamRole_WRITER)
+
+	{
+		mctx := bob.MetaContext()
+		g := bob.tc.G
+		require.NoError(t, phonenumbers.AddPhoneNumber(mctx, phoneNumber, keybase1.IdentityVisibility_PUBLIC))
+		code, err := kbtest.GetPhoneVerificationCode(libkb.NewMetaContextTODO(g), phoneNumber)
+		require.NoError(t, err)
+		require.NoError(t, phonenumbers.VerifyPhoneNumber(mctx, phoneNumber, code))
+	}
+
+	ann.waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
+	bob.waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
+
+	// the team should have user 1 in it now as a writer
+	t0, err := teams.GetTeamByNameForTest(context.TODO(), tt.users[0].tc.G, teamName.String(), false, true)
+	require.NoError(t, err)
+	writers, err := t0.UsersWithRole(keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+	require.Len(t, writers, 1)
+	if len(writers) > 0 {
+		require.Equal(t, bob.uid, writers[0].Uid)
+	}
+
+	// the invite should not be in the active invite map
+	exists, err := t0.HasActiveInvite(tt.users[0].tc.MetaContext(), keybase1.TeamInviteName(phone), "phone")
+	require.NoError(t, err)
+	require.False(t, exists, "after accepting invite, active invite shouldn't exist")
+}

--- a/go/systests/sbs_test.go
+++ b/go/systests/sbs_test.go
@@ -1,58 +1,229 @@
 package systests
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/keybase/client/go/emails"
+
+	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbtest"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/phonenumbers"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/client/go/teams"
 	"github.com/stretchr/testify/require"
 	context "golang.org/x/net/context"
 )
 
-func TestTeamInvitePhoneNumber(t *testing.T) {
+// Same SBS test can run against different SBS types, where each one has
+// different way of proving (verifying), revoking etc. Encapsulate all that
+// under a type that implements `userSBSProvider` and pass it to the "generic"
+// SBS test function.
+type userSBSProvider interface {
+	SetUser(user *userPlusDevice)
+	GetAssertionKV() (key string, value string)
+	Verify()
+	Revoke()
+}
+
+// Phone numbers
+type userSBSPhoneNumber struct {
+	u           *userPlusDevice
+	phoneNumber string //without `+`
+}
+
+func assertionFromKV(t *testing.T, key, value string) libkb.AssertionURL {
+	actx := externals.MakeStaticAssertionContext(context.TODO())
+	ret, err := libkb.ParseAssertionURLKeyValue(actx, key, value, true /* strict */)
+	require.NoError(t, err)
+	return ret
+}
+
+func (p *userSBSPhoneNumber) SetUser(user *userPlusDevice) {
+	p.u = user
+	p.phoneNumber = kbtest.GenerateTestPhoneNumber()
+}
+
+func (p *userSBSPhoneNumber) GetAssertionKV() (key string, value string) {
+	return "phone", p.phoneNumber
+}
+
+func (p *userSBSPhoneNumber) Verify() {
+	mctx := p.u.MetaContext()
+	tctx := p.u.tc
+	phoneNumber := keybase1.PhoneNumber("+" + p.phoneNumber)
+	require.NoError(tctx.T, phonenumbers.AddPhoneNumber(mctx, phoneNumber, keybase1.IdentityVisibility_PUBLIC))
+	code, err := kbtest.GetPhoneVerificationCode(libkb.NewMetaContextTODO(tctx.G), phoneNumber)
+	require.NoError(tctx.T, err)
+	require.NoError(tctx.T, phonenumbers.VerifyPhoneNumber(mctx, phoneNumber, code))
+}
+
+func (p *userSBSPhoneNumber) Revoke() {
+	err := phonenumbers.DeletePhoneNumber(p.u.MetaContext(), keybase1.PhoneNumber("+"+p.phoneNumber))
+	require.NoError(p.u.tc.T, err)
+}
+
+// ------------------
+
+// Emails
+type userSBSEmail struct {
+	u *userPlusDevice
+}
+
+func (p *userSBSEmail) SetUser(user *userPlusDevice) {
+	p.u = user
+}
+
+func (p *userSBSEmail) GetAssertionKV() (key string, value string) {
+	return "email", p.u.userInfo.email
+}
+
+func (p *userSBSEmail) Verify() {
+	emailAddress := keybase1.EmailAddress(p.u.userInfo.email)
+	err := emails.SetVisibilityEmail(p.u.MetaContext(), emailAddress, keybase1.IdentityVisibility_PUBLIC)
+	require.NoError(p.u.tc.T, err)
+	err = kbtest.VerifyEmailAuto(p.u.MetaContext(), emailAddress)
+	require.NoError(p.u.tc.T, err)
+}
+
+func (p *userSBSEmail) Revoke() {
+	err := emails.DeleteEmail(p.u.MetaContext(), keybase1.EmailAddress(p.u.userInfo.email))
+	require.NoError(p.u.tc.T, err)
+}
+
+// ------------------
+
+// Rooter
+type userSBSRooter struct {
+	u *userPlusDevice
+}
+
+func (p *userSBSRooter) SetUser(user *userPlusDevice) {
+	p.u = user
+}
+
+func (p *userSBSRooter) GetAssertionKV() (key string, value string) {
+	return "rooter", p.u.username
+}
+
+func (p *userSBSRooter) Verify() {
+	p.u.proveRooter()
+}
+
+func (p *userSBSRooter) Revoke() {
+	tctx := p.u.tc
+	arg := libkb.NewLoadUserArg(tctx.G).WithUID(p.u.uid).WithPublicKeyOptional().WithForcePoll(true)
+	_, user, err := tctx.G.GetUPAKLoader().LoadV2(arg)
+	require.NoError(tctx.T, err)
+
+	st := tctx.G.GetProofServices().GetServiceType(context.TODO(), "rooter")
+	ret := user.IDTable().GetActiveProofsFor(st)
+	require.Len(tctx.T, len(ret), 1)
+	sigID := ret[0].GetSigID()
+
+	revokeClient := keybase1.RevokeClient{Cli: p.u.teamsClient.Cli}
+	err = revokeClient.RevokeSigs(context.TODO(), keybase1.RevokeSigsArg{
+		SigIDQueries: []string{sigID.String()},
+	})
+	require.NoError(tctx.T, err)
+}
+
+// ------------------
+
+func testTeamInviteSBS(t *testing.T, sbs userSBSProvider) {
 	tt := newTeamTester(t)
 	defer tt.cleanup()
 
 	ann := tt.addUser("ann")
 	bob := tt.addUser("bob")
+	sbs.SetUser(bob)
 
-	// user 0 creates a team
+	// User 0 creates a team.
 	teamID, teamName := ann.createTeam2()
 
-	phone := kbtest.GenerateTestPhoneNumber()
-	phoneNumber := keybase1.PhoneNumber("+" + phone)
-	phoneAssertion := fmt.Sprintf("%s@phone", phone)
+	key, value := sbs.GetAssertionKV()
+	assertionURL := assertionFromKV(t, key, value)
+	assertion := assertionURL.String()
 
-	ann.addTeamMember(teamName.String(), phoneAssertion, keybase1.TeamRole_WRITER)
+	ann.addTeamMember(teamName.String(), assertion, keybase1.TeamRole_WRITER)
 
-	{
-		mctx := bob.MetaContext()
-		g := bob.tc.G
-		require.NoError(t, phonenumbers.AddPhoneNumber(mctx, phoneNumber, keybase1.IdentityVisibility_PUBLIC))
-		code, err := kbtest.GetPhoneVerificationCode(libkb.NewMetaContextTODO(g), phoneNumber)
-		require.NoError(t, err)
-		require.NoError(t, phonenumbers.VerifyPhoneNumber(mctx, phoneNumber, code))
-	}
+	ann.kickTeamRekeyd()
+	sbs.Verify()
 
 	ann.waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
 	bob.waitForTeamChangedGregor(teamID, keybase1.Seqno(3))
 
-	// the team should have user 1 in it now as a writer
-	t0, err := teams.GetTeamByNameForTest(context.TODO(), tt.users[0].tc.G, teamName.String(), false, true)
-	require.NoError(t, err)
+	// The team should have user 1 in it now as a writer.
+	t0 := ann.loadTeam(teamName.String(), true /* admin */)
 	writers, err := t0.UsersWithRole(keybase1.TeamRole_WRITER)
 	require.NoError(t, err)
 	require.Len(t, writers, 1)
-	if len(writers) > 0 {
-		require.Equal(t, bob.uid, writers[0].Uid)
-	}
+	require.Equal(t, bob.uid, writers[0].Uid)
 
-	// the invite should not be in the active invite map
-	exists, err := t0.HasActiveInvite(tt.users[0].tc.MetaContext(), keybase1.TeamInviteName(phone), "phone")
+	// The invite should not be in the active invite map.
+	require.Equal(t, 0, t0.NumActiveInvites())
+	exists, err := t0.HasActiveInvite(tt.users[0].tc.MetaContext(), keybase1.TeamInviteName(value), key)
 	require.NoError(t, err)
 	require.False(t, exists, "after accepting invite, active invite shouldn't exist")
+}
+
+func TestTeamInviteSBSPhone(t *testing.T) {
+	testTeamInviteSBS(t, &userSBSPhoneNumber{})
+}
+
+func TestTeamInviteSBSEmail(t *testing.T) {
+	testTeamInviteSBS(t, &userSBSEmail{})
+}
+
+func TestTeamInviteSBSRooter(t *testing.T) {
+	testTeamInviteSBS(t, &userSBSRooter{})
+}
+
+// ------------------
+
+func testTeamInviteExistingUserSBS(t *testing.T, sbs userSBSProvider) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	ann := tt.addUser("ann")
+	bob := tt.addUser("bob")
+	sbs.SetUser(bob)
+
+	key, value := sbs.GetAssertionKV()
+	assertionURL := assertionFromKV(t, key, value)
+	assertion := assertionURL.String()
+
+	sbs.Verify()
+
+	// User 0 creates a team.
+	_, teamName := ann.createTeam2()
+
+	// Add bob by SBS assertion. Should just add bob and not an invite. Adding
+	// resolvable SBS assertion via invite would also bounce off the server
+	// with `TEAM_INVITE_USER_EXISTS` error.
+	ann.addTeamMember(teamName.String(), assertion, keybase1.TeamRole_WRITER)
+
+	// The team should have user 1 in it now as a writer.
+	t0 := ann.loadTeam(teamName.String(), true /* admin */)
+	writers, err := t0.UsersWithRole(keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+	require.Len(t, writers, 1)
+	require.Equal(t, bob.uid, writers[0].Uid)
+
+	// There should be no invite for the SBS.
+	require.Equal(t, 0, t0.NumActiveInvites())
+	exists, err := t0.HasActiveInvite(tt.users[0].tc.MetaContext(), keybase1.TeamInviteName(value), key)
+	require.NoError(t, err)
+	require.False(t, exists, "after adding resolvable assertion, no invite should have been created")
+}
+
+func TestTeamInviteExistingUserSBSPhone(t *testing.T) {
+	testTeamInviteExistingUserSBS(t, &userSBSPhoneNumber{})
+}
+
+func TestTeamInviteExistingUserSBSEmail(t *testing.T) {
+	testTeamInviteExistingUserSBS(t, &userSBSEmail{})
+}
+
+func TestTeamInviteExistingUserSBSRooter(t *testing.T) {
+	testTeamInviteExistingUserSBS(t, &userSBSRooter{})
 }

--- a/go/systests/standalone_test.go
+++ b/go/systests/standalone_test.go
@@ -65,9 +65,11 @@ func makeUserStandalone(t *testing.T, pre string, opts standaloneUserArgs) *user
 	}
 	t.Logf("signed up %s", userInfo.username)
 
-	u.username = userInfo.username
-	u.uid = libkb.UsernameToUID(u.username)
 	u.tc = tctx
+	u.userInfo = userInfo
+	u.username = userInfo.username
+	u.passphrase = userInfo.passphrase
+	u.uid = libkb.UsernameToUID(u.username)
 
 	cli, _, err := client.GetRPCClientWithContext(g)
 	require.NoError(t, err)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -945,6 +945,14 @@ func (u *userPlusDevice) perUserKeyUpgrade() {
 	require.NoError(t, err, "Run engine.NewPerUserKeyUpgrade")
 }
 
+func (u *userPlusDevice) disableTOFUSearch() {
+	mctx := u.MetaContext()
+	arg := libkb.NewAPIArg("test/disable_tofu_search_for_uid")
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	_, err := u.tc.G.API.Post(mctx, arg)
+	require.NoError(u.tc.T, err)
+}
+
 func (u *userPlusDevice) MetaContext() libkb.MetaContext {
 	return libkb.NewMetaContextForTest(*u.tc)
 }

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -378,7 +378,7 @@ func handleSBSSingle(ctx context.Context, g *libkb.GlobalContext, teamID keybase
 		invite, found := team.chain().FindActiveInviteByID(untrustedInviteeFromGregor.InviteID)
 		if !found {
 			g.Log.CDebugf(ctx, "FindActiveInviteByID failed for invite %s", untrustedInviteeFromGregor.InviteID)
-			return libkb.NotFoundError{}
+			return libkb.NotFoundError{Msg: "Invite not found"}
 		}
 		g.Log.CDebugf(ctx, "Found invite: %+v", invite)
 		category, err := invite.Type.C()

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -26,6 +26,8 @@ func memberSetup(t *testing.T) (libkb.TestContext, *kbtest.FakeUser, string) {
 
 	name := createTeam(tc)
 
+	t.Logf("User name is: %s", u.Username)
+	t.Logf("Team name is: %s", name)
 	return tc, u, name
 }
 
@@ -490,25 +492,18 @@ func TestMemberAddSocial(t *testing.T) {
 
 	tc.G.SetProofServices(externals.NewProofServices(tc.G))
 
-	res, err := AddMember(context.TODO(), tc.G, name, "not_on_kb_yet@twitter", keybase1.TeamRole_OWNER, nil)
-	if err == nil {
-		t.Fatal("should not be able to invite a social user as an owner")
-	}
+	_, err := AddMember(context.TODO(), tc.G, name, "not_on_kb_yet@twitter", keybase1.TeamRole_OWNER, nil)
+	require.Error(t, err, "should not be able to invite a social user as an owner")
 
-	res, err = AddMember(context.TODO(), tc.G, name, "not_on_kb_yet@twitter", keybase1.TeamRole_READER, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !res.Invited {
-		t.Fatal("res.Invited should be set")
-	}
+	res, err := AddMember(context.TODO(), tc.G, name, "not_on_kb_yet@twitter", keybase1.TeamRole_READER, nil)
+	require.NoError(t, err)
+	require.True(t, res.Invited)
 
 	assertInvite(tc, name, "not_on_kb_yet", "twitter", keybase1.TeamRole_READER)
 
 	// second AddMember should return err
-	if _, err := AddMember(context.TODO(), tc.G, name, "not_on_kb_yet@twitter", keybase1.TeamRole_WRITER, nil); err == nil {
-		t.Errorf("second AddMember succeeded, should have failed since user already invited")
-	}
+	_, err = AddMember(context.TODO(), tc.G, name, "not_on_kb_yet@twitter", keybase1.TeamRole_WRITER, nil)
+	require.Error(t, err, "second AddMember should fail since user already invited")
 
 	// existing invite should be untouched
 	assertInvite(tc, name, "not_on_kb_yet", "twitter", keybase1.TeamRole_READER)
@@ -1071,9 +1066,7 @@ func assertInvite(tc libkb.TestContext, name, username, typ string, role keybase
 	tc.T.Logf("looking for invite for %s/%s w/ role %s in team %s", username, typ, role, name)
 	iname := keybase1.TeamInviteName(username)
 	itype, err := TeamInviteTypeFromString(tc.MetaContext(), typ)
-	if err != nil {
-		tc.T.Fatal(err)
-	}
+	require.NoError(tc.T, err)
 	invite, err := memberInvite(context.TODO(), tc.G, name, iname, itype)
 	require.NoError(tc.T, err)
 	require.NotNil(tc.T, invite)

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1121,22 +1121,6 @@ func ChangeRoles(ctx context.Context, g *libkb.GlobalContext, teamname string, r
 var errInviteRequired = errors.New("invite required for username")
 var errUserDeleted = errors.New("user is deleted")
 
-func loadUserVersionPlusByUsername(ctx context.Context, g *libkb.GlobalContext, username string, useTracking bool) (libkb.NormalizedUsername, keybase1.UserVersion, error) {
-	// need username here as `username` parameter might be social assertion, also username
-	// is used for chat notification recipient
-	m := libkb.NewMetaContext(ctx, g)
-	upk, err := engine.ResolveAndCheck(m, username, useTracking)
-	if err != nil {
-		if e, ok := err.(libkb.ResolutionError); ok && e.Kind == libkb.ResolutionErrorNotFound {
-			// couldn't find a keybase user for username assertion
-			return "", keybase1.UserVersion{}, errInviteRequired
-		}
-		return "", keybase1.UserVersion{}, err
-	}
-	uv, err := filterUserCornerCases(ctx, upk)
-	return libkb.NormalizedUsernameFromUPK2(upk), uv, err
-}
-
 // loadUserVersionByUsername is a wrapper around `engine.ResolveAndCheck` to
 // return UV by username or assertion. When the argument does not resolve to a
 // Keybase user with PUK, `errInviteRequired` is returned.

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1137,6 +1137,16 @@ func loadUserVersionPlusByUsername(ctx context.Context, g *libkb.GlobalContext, 
 	return libkb.NormalizedUsernameFromUPK2(upk), uv, err
 }
 
+// loadUserVersionByUsername is a wrapper around `engine.ResolveAndCheck` to
+// return UV by username or assertion. When the argument does not resolve to a
+// Keybase user with PUK, `errInviteRequired` is returned.
+//
+// Returns `errInviteRequired` if given argument cannot be brought in as a
+// crypto member - so it is either a reset and not provisioned keybae user
+// (keybase-type invite is required), or a social assertion that does not
+// resolve to a user.
+//
+// NOTE: This also doesn't try to resolve server-trust assertions.
 func loadUserVersionByUsername(ctx context.Context, g *libkb.GlobalContext, username string, useTracking bool) (keybase1.UserVersion, error) {
 	m := libkb.NewMetaContext(ctx, g)
 	upk, err := engine.ResolveAndCheck(m, username, useTracking)

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -510,6 +510,7 @@ func (tx *AddMemberTx) AddMemberByAssertionOrEmail(ctx context.Context, assertio
 
 	if !doInvite {
 		username = libkb.NewNormalizedUsername(upak.Username)
+		uv = upak.ToUserVersion()
 		invite, err = tx.addMemberByUPKV2(ctx, upak, role, botSettings)
 		m.Debug("Adding keybase member: %s (isInvite=%v)", username, invite)
 		return username, uv, invite, err

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -145,7 +145,7 @@ func (tx *AddMemberTx) addMemberAndCompleteInvite(uv keybase1.UserVersion,
 	// Preconditions: UV is a PUKful user, role is valid and not NONE, invite
 	// exists. Role is not RESTRICTEDBOT as botSettings are set to nil.
 	payload := tx.changeMembershipPayload(uv.Uid)
-	err := payload.AddUVWithRole(uv, role, nil)
+	err := payload.AddUVWithRole(uv, role, nil /* botSettings */)
 	payload.CompleteInviteID(inviteID, uv.PercentForm())
 	return err
 }

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -461,7 +461,8 @@ func preprocessAssertion(m libkb.MetaContext, s string) (isServerTrustInvite boo
 // three major cases:
 //  1. joe OR joe+foo@reddit WHERE joe is already a keybase user, or the assertions map to a unique keybase user
 //  2. joe@reddit WHERE joe isn't a keybase user, and this is a social invitations
-//  3. [bob@gmail.com]@email WHERE there's an email-based invitation in play
+//  3. [bob@gmail.com]@email WHERE server-trust resolution is performed and either TOFU invite is created
+//     or resolved member is added. Same works with `@phone`.
 // **Does** attempt to resolve the assertion, to distinguish between case (1), case (2) and an error
 // The return values (uv, username) can both be zero-valued if the assertion is not a keybase user.
 func (tx *AddMemberTx) AddMemberByAssertionOrEmail(ctx context.Context, assertion string, role keybase1.TeamRole, botSettings *keybase1.TeamBotSettings) (

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -792,6 +792,9 @@ protocol teams {
     UID uid;
     @jsonkey("eldest_seqno")
     Seqno eldestSeqno;
+    // NOTE: This comes from gregor, but should not be used during actual SBS
+    // resolution - always take inviteID and look at the actual invite from the
+    // sigchain.
     TeamRole role;
   }
 

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -24,6 +24,7 @@ import {uploadAvatarWaitingKey} from '../constants/profile'
 import openSMS from '../util/sms'
 import {convertToError, logError} from '../util/errors'
 import {TypedState, TypedActions, isMobile} from '../util/container'
+import {e164ToDisplay} from '../util/phone-numbers'
 
 function* createNewTeam(_: TypedState, action: TeamsGen.CreateNewTeamPayload) {
   const {joinSubteam, teamname} = action.payload
@@ -551,6 +552,8 @@ function* getDetails(_: TypedState, action: TeamsGen.GetDetailsPayload, logger: 
             email: invite.type.c === RPCTypes.TeamInviteCategory.email ? invite.name : '',
             id: invite.id,
             name: invite.type.c === RPCTypes.TeamInviteCategory.seitan ? invite.name : '',
+            phone:
+              invite.type.c === RPCTypes.TeamInviteCategory.phone ? e164ToDisplay('+' + invite.name) : '',
             role,
             username,
           })

--- a/shared/constants/team-building.tsx
+++ b/shared/constants/team-building.tsx
@@ -18,18 +18,6 @@ export const allServices: Array<Types.ServiceIdWithContact> = [
   'email',
   ...searchServices.slice(1),
 ]
-const searchServicesWithEmail: Array<Types.ServiceIdWithContact> = [
-  ...searchServices.slice(0, 1),
-  'email',
-  ...searchServices.slice(1),
-]
-
-export function servicesForNamespace(namespace: Types.AllowedNamespace): Array<Types.ServiceIdWithContact> {
-  if (namespace === 'teams') {
-    return searchServicesWithEmail
-  }
-  return allServices
-}
 
 function isKeybaseUserId(userId: string) {
   // Only keybase user id's do not have

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -94,6 +94,7 @@ export const makeInviteInfo = I.Record<Types._InviteInfo>({
   email: '',
   id: '',
   name: '',
+  phone: '',
   role: 'writer',
   username: '',
 })

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -65,6 +65,7 @@ export type MemberInfo = I.RecordOf<_MemberInfo>
 
 export type _InviteInfo = {
   email: string
+  phone: string
   name: string
   role: TeamRoleType
   username: string

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -540,7 +540,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
           </Kb.Text>
         )}
         <ServiceTabBar
-          services={Constants.servicesForNamespace(props.namespace)}
+          services={Constants.allServices}
           selectedService={props.selectedService}
           onChangeService={props.onChangeService}
           serviceResultCount={props.serviceResultCount}

--- a/shared/teams/team/invites-tab/invite-row/container.tsx
+++ b/shared/teams/team/invites-tab/invite-row/container.tsx
@@ -1,7 +1,8 @@
 import * as TeamsGen from '../../../../actions/teams-gen'
-import {getTeamInvites, getTeamMembers} from '../../../../constants/teams'
+import {getTeamInvites, getTeamMembers, makeInviteInfo} from '../../../../constants/teams'
 import {TeamInviteRow} from '.'
 import {connect} from '../../../../util/container'
+import {InviteInfo} from '../../../../constants/types/teams'
 
 type OwnProps = {
   id: string
@@ -22,7 +23,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
-  const user = stateProps._invites.find(invite => invite.id === ownProps.id) || {}
+  const user: InviteInfo = stateProps._invites.find(invite => invite.id === ownProps.id) || makeInviteInfo()
 
   let onCancelInvite
   if (user.email) {
@@ -41,7 +42,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
         teamname: ownProps.teamname,
         username: user.username,
       })
-  } else if (user.name) {
+  } else if (user.name || user.phone) {
     onCancelInvite = () =>
       dispatchProps._onCancelInvite({
         email: '',
@@ -52,7 +53,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => {
   }
 
   return {
-    label: user.email || user.username || user.name,
+    label: user.email || user.username || user.name || user.phone,
     onCancelInvite,
     role: user.role,
   }


### PR DESCRIPTION
- Enable "phone number" tab in "Add to a team" team-building modal.
- Add support for resolving server-trust assertions in `AddMemberTx`, so when phone number / email is already resolvable, it will add member directly instead of inviting (this already worked for proof-backed assertions, server-trust always fell back to making an invite).
- Use `AddMemberByAssertionOrEmail` in `service_helper.go` `AddMemberByID` so the above can actually work. This should be safe, it's already used in `AddMembers` (for batch adding more than one member). This enables adding members from CLI or GUI without special-casing TOFU. Next step could be that `AddMemberByID` just calls `AddMembers` with 1-element list.
- There is an old `InviteEmailMember` which will fail in cases where e-mail is already resolved. [TODO]
- Add parameterized SBS tests in `systests/sbs_test.go` that do two different scenarios for phone, email, and rooter assertions.

Edit: not quite done yet :sweat: A test broke that uncovered an issue with this code.
TODO:
- [x] Fix subsequent invites for same assertion should be rejected.