### PR TITLE
kbfsedits: avoid rename infinite loop

### DIFF
--- a/go/kbfs/kbfsedits/tlf_history.go
+++ b/go/kbfs/kbfsedits/tlf_history.go
@@ -342,7 +342,7 @@ func (r *recomputer) processNotification(
 		// See if any of the parent directories were renamed, checking
 		// backwards until we get to the TLF name.
 		prefix := filename
-		rev := notification.Revision
+		latestRenameRev := notification.Revision
 		suffix := ""
 		for strings.Count(prefix, "/") > 4 {
 			var finalElem string
@@ -353,9 +353,9 @@ func (r *recomputer) processNotification(
 			// Ignore any rename events that happen at or before the
 			// last revision we considered, to avoid weird rename
 			// loops (see HOTPOT-856).
-			if hasEvent && event.newName != "" && rev < event.rev {
+			if hasEvent && event.newName != "" && latestRenameRev < event.rev {
 				prefix = event.newName
-				rev = event.rev
+				latestRenameRev = event.rev
 			}
 		}
 		filename = path.Clean(path.Join(prefix, suffix))

--- a/go/kbfs/kbfsedits/tlf_history.go
+++ b/go/kbfs/kbfsedits/tlf_history.go
@@ -236,6 +236,7 @@ func (th *TlfHistory) ClearAllUnflushed() {
 type fileEvent struct {
 	delete  bool
 	newName string
+	rev     kbfsmd.Revision
 }
 
 type recomputer struct {
@@ -341,6 +342,7 @@ func (r *recomputer) processNotification(
 		// See if any of the parent directories were renamed, checking
 		// backwards until we get to the TLF name.
 		prefix := filename
+		rev := notification.Revision
 		suffix := ""
 		for strings.Count(prefix, "/") > 4 {
 			var finalElem string
@@ -348,8 +350,12 @@ func (r *recomputer) processNotification(
 			prefix = strings.TrimSuffix(prefix, "/")
 			suffix = path.Clean(path.Join(finalElem, suffix))
 			event, hasEvent := r.fileEvents[prefix]
-			if hasEvent && event.newName != "" {
+			// Ignore any rename events that happen at or before the
+			// last revision we considered, to avoid weird rename
+			// loops (see HOTPOT-856).
+			if hasEvent && event.newName != "" && rev < event.rev {
 				prefix = event.newName
+				rev = event.rev
 			}
 		}
 		filename = path.Clean(path.Join(prefix, suffix))
@@ -382,7 +388,10 @@ func (r *recomputer) processNotification(
 			delete(r.fileEvents, eventFilename)
 		} else {
 			r.fileEvents[notification.Params.OldFilename] =
-				fileEvent{newName: eventFilename}
+				fileEvent{
+					newName: eventFilename,
+					rev:     notification.Revision,
+				}
 		}
 
 		// If renaming a directory, check whether there are any events
@@ -403,9 +412,15 @@ func (r *recomputer) processNotification(
 
 		// The renamed file overwrote any existing file with the new
 		// name.
-		r.fileEvents[eventFilename] = fileEvent{delete: true}
+		r.fileEvents[eventFilename] = fileEvent{
+			delete: true,
+			rev:    notification.Revision,
+		}
 	case NotificationDelete:
-		r.fileEvents[eventFilename] = fileEvent{delete: true}
+		r.fileEvents[eventFilename] = fileEvent{
+			delete: true,
+			rev:    notification.Revision,
+		}
 
 		// We only care about files, so skip dir and sym creates.
 		if notification.FileType != EntryTypeFile {


### PR DESCRIPTION
Consider this sequence of edit events, in order by increasing revision number:

1. mkdir "a"
2. create file "a/foo"
3. mkdir "b"
4. rename "a" to "c"
5. rename "b" to "a"
6. rename "c" to "a/d"

`TlfHistory` processes these events in reverse, and tries to adjust the filenames of old events to look like the new file names, based on the directory renames that have happened since the file was edited. So in the above sequence, by the time it gets to revision 2 concerning file "a/foo", it tries to figure out what the latest name of directory "a" is now.  So it looks it up in the rename table, and finds out it's "a/d".  But then it iterates on the prefix of that path ("a"), to see if it's been renamed, finds "a/d" again, and it gets stuck in a loop.

The answer is that once we have followed one rename (which occured at some revision, in this case 5), we should ignore other renames that happen at the same time or further in the future, since they can't possibly affect the prefix we're currently considering.

So this commit tracks the revision of each rename event, and follows that rule.  It also adds a test that reproduces the infinite loop without this fix.

Issue: HOTPOT-856