### PR TITLE
remove a bunch of unused stuff in util/file

### DIFF
--- a/shared/constants/fs.tsx
+++ b/shared/constants/fs.tsx
@@ -10,7 +10,6 @@ import * as SettingsConstants from './settings'
 import {TypedState} from '../util/container'
 import {isLinux, isMobile} from './platform'
 import uuidv1 from 'uuid/v1'
-import {downloadFilePath, downloadFilePathNoSearch} from '../util/file'
 import * as RouteTreeGen from '../actions/route-tree-gen'
 import {TypedActions} from '../actions/typed-actions-gen'
 import flags from '../util/feature-flags'
@@ -405,11 +404,6 @@ export const getDownloadIntentFromAction = (
     : action.type === FsGen.shareNative
     ? Types.DownloadIntent.Share
     : Types.DownloadIntent.CameraRoll
-
-export const downloadFilePathFromPath = (p: Types.Path): Promise<Types.LocalPath> =>
-  downloadFilePath(Types.getPathName(p))
-export const downloadFilePathFromPathNoSearch = (p: Types.Path): string =>
-  downloadFilePathNoSearch(Types.getPathName(p))
 
 export const makeTlfUpdate = I.Record<Types._TlfUpdate>({
   history: I.List(),

--- a/shared/util/file.d.ts
+++ b/shared/util/file.d.ts
@@ -11,10 +11,7 @@ export type WriteStream = {
 export type Encoding = 'utf8' | 'ascii' | 'base64'
 
 export declare const downloadFolder: string
-export declare function tmpDir(): string
-export declare function tmpFile(suffix: string): string
 export declare function downloadFilePath(filename: string): Promise<string>
-export declare function downloadFilePathNoSearch(filename: string): string
 export declare function copy(from: string, to: string): Promise<boolean>
 export declare function exists(filename: string): Promise<boolean>
 export declare function stat(filename: string): Promise<StatResult>

--- a/shared/util/file.desktop.tsx
+++ b/shared/util/file.desktop.tsx
@@ -1,38 +1,12 @@
-import crypto from 'crypto'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import {findAvailableFilename} from './file.shared'
-import {cacheRoot} from '../constants/platform.desktop'
 import {StatResult, WriteStream, Encoding} from './file'
-
-export function tmpDir(): string {
-  return cacheRoot
-}
-
-export function tmpFile(suffix: string): string {
-  return path.join(tmpDir(), suffix)
-}
-
-export function tmpRandFile(suffix: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    crypto.randomBytes(16, (err, buf) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve(path.join(tmpDir(), buf.toString('hex') + suffix))
-    })
-  })
-}
 
 export const downloadFolder = __STORYBOOK__
   ? ''
   : process.env.XDG_DOWNLOAD_DIR || path.join(os.homedir(), 'Downloads')
-
-export function downloadFilePathNoSearch(filename: string): string {
-  return path.join(downloadFolder, filename)
-}
 
 export function downloadFilePath(suffix: string): Promise<string> {
   return findAvailableFilename(exists, path.join(downloadFolder, suffix))

--- a/shared/util/file.native.tsx
+++ b/shared/util/file.native.tsx
@@ -11,10 +11,6 @@ export function tmpFile(suffix: string): string {
   return `${tmpDir()}/${suffix}`
 }
 
-export function downloadFilePathNoSearch(filename: string): string {
-  return `${tmpDir()}/${filename}`
-}
-
 export function downloadFilePath(suffix: string): Promise<string> {
   return findAvailableFilename(exists, `${tmpDir()}/${suffix}`)
 }


### PR DESCRIPTION
There's still quite a few of them left @chrisnojima 

chat attachment download uses `downloadFilePath`; `saveToCameraRoll` uses `unlink`. I think we can do something similar to Fs where we handle what `findAvailableFilename` does in Go. For `saveToCameraRoll`, we could probably just leave it if we make sure we use the cache dir?