### PR TITLE
recalculate max command length on new conversation id

### DIFF
--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -175,6 +175,7 @@ class Input extends React.Component<InputProps, InputState> {
       emoji: emojiTransformer,
       users: this._transformUserSuggestion,
     }
+
     // + 1 for '/'
     this._maxCmdLength =
       this.props.suggestCommands
@@ -328,6 +329,13 @@ class Input extends React.Component<InputProps, InputState> {
       if (!this.props.isSearching) {
         this._inputFocus()
       }
+
+      // potentially different commands so we need to recalculate max command length
+      // + 1 for '/'
+      this._maxCmdLength =
+        this.props.suggestCommands
+          .concat(this.props.suggestBotCommands)
+          .reduce((max, cmd) => (cmd.name.length > max ? cmd.name.length : max), 0) + 1
     }
   }
 


### PR DESCRIPTION
This PR addresses an issue with bot commands where long commands would make the HUD flaky. This was because the max command length was not being updated. 

@keybase/hotpotatosquad 
@keybase/react-hackers 