### PR TITLE
folder_branch_ops: another fix for a symlink in the edit history

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1214,6 +1214,15 @@ pathLoop:
 			return err
 		}
 
+		if elemNode == nil {
+			// This can happen if an old bug (HOTPOT-616) kept a
+			// deleted path in the history that has since been changed
+			// into a symlink.
+			fbo.vlog.CLogf(
+				ctx, libkb.VLog1, "Ignoring symlink path %s", p)
+			continue pathLoop
+		}
+
 		ptr, err := fbo.syncOneNode(
 			ctx, elemNode, latestMerged, priority, pathSyncAction)
 		if err != nil {


### PR DESCRIPTION
Issue: #19875