### PR TITLE
Add a right-side margin to payment memos in chat

### DIFF
--- a/shared/chat/conversation/messages/account-payment/index.tsx
+++ b/shared/chat/conversation/messages/account-payment/index.tsx
@@ -93,7 +93,7 @@ const AccountPayment = (props: Props) => {
         {props.canceled && <Kb.Text type="BodySmall">CANCELED</Kb.Text>}
         {!Styles.isMobile && balanceChange}
       </Kb.Box2>
-      <MarkdownMemo memo={props.memo} />
+      <MarkdownMemo memo={props.memo} style={styles.memo} />
       {Styles.isMobile && balanceChange}
       {!!props.sendButtonLabel && (
         <Kb.Button type="Wallet" onClick={props.onSend} small={true} style={styles.button}>
@@ -155,6 +155,11 @@ const styles = Styles.styleSheetCreate(
       lineThrough: {
         textDecorationLine: 'line-through',
       },
+      memo: Styles.platformStyles({
+        isMobile: {
+          paddingRight: Styles.globalMargins.small,
+        },
+      }),
       progressIndicator: Styles.platformStyles({
         // Match height of a line of text
         isElectron: {


### PR DESCRIPTION
@keybase/react-hackers CC @keybase/picnicsquad 

Before:

<img width="448" alt="Screen Shot 2019-09-23 at 11 25 48 PM" src="https://user-images.githubusercontent.com/21217/65529600-492d7300-deab-11e9-9499-f71149f93bea.png">

After:

<img width="438" alt="Screen Shot 2019-09-23 at 11 26 29 PM" src="https://user-images.githubusercontent.com/21217/65529609-4d599080-deab-11e9-84fe-9ad28491f4b4.png">
