### PR TITLE
Fix displaying the explanatory prompt under service tabs with an empty search

### DIFF
--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -320,7 +320,8 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
   )
 
   _listBody = () => {
-    const showRecPending = !this.props.searchString && !this.props.recommendations
+    const showRecPending =
+      !this.props.searchString && !this.props.recommendations && this.props.selectedService === 'keybase'
     const showLoading = !!this.props.searchString && !this.props.searchResults
     if (showRecPending || showLoading) {
       return (
@@ -504,7 +505,7 @@ class TeamBuilding extends React.PureComponent<Props, {}> {
       />
     )
 
-    // Handle when team-buiding is making a new chat v.s. adding members to a team.
+    // Handle when team-building is making a new chat v.s. adding members to a team.
     const chatHeader = props.rolePickerProps ? (
       <Kb.Box2 direction="vertical" alignItems="center" style={styles.headerContainer}>
         <Kb.Avatar teamname={props.teamname} size={32} style={styles.teamAvatar} />


### PR DESCRIPTION
@keybase/react-hackers CC @keybase/picnicsquad 

If we're not looking at the Keybase service tab, then recommendations aren't being loaded.

Before:

<img width="453" alt="Screen Shot 2019-09-24 at 12 22 30 AM" src="https://user-images.githubusercontent.com/21217/65529672-71b56d00-deab-11e9-98c7-64d96b71688a.png">

After:

<img width="448" alt="Screen Shot 2019-09-24 at 12 22 38 AM" src="https://user-images.githubusercontent.com/21217/65529683-75e18a80-deab-11e9-9ec4-50b1972f0137.png">
