### PR TITLE
Remove Deposit+Withdraw links from trustlines modal

### DIFF
--- a/shared/wallets/trustline/asset-container.tsx
+++ b/shared/wallets/trustline/asset-container.tsx
@@ -38,8 +38,6 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, ownProps: OwnProp
         expanded: false,
       })
     ),
-  onDeposit: (accountID: string, code: string, issuerAccountID: string) =>
-    dispatch(WalletsGen.createAssetDeposit({accountID, code, issuerAccountID})),
   onDone: RouteTreeGen.createNavigateUp(),
   onExpand: () =>
     dispatch(
@@ -50,8 +48,6 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, ownProps: OwnProp
     ),
   onRemove: () =>
     dispatch(WalletsGen.createDeleteTrustline({accountID: ownProps.accountID, assetID: ownProps.assetID})),
-  onWithdraw: (accountID: string, code: string, issuerAccountID: string) =>
-    dispatch(WalletsGen.createAssetWithdraw({accountID, code, issuerAccountID})),
 })
 
 export default Container.namedConnect(
@@ -60,8 +56,6 @@ export default Container.namedConnect(
   (s, d, o) => ({
     cannotAccept: o.cannotAccept,
     code: s.asset.code,
-    depositButtonText: s.asset.depositButtonText,
-    depositButtonWaitingKey: Constants.assetDepositWaitingKey(s.asset.issuerAccountID, s.asset.code),
     expanded: s.expandedAssets.includes(o.assetID),
     firstItem: o.firstItem,
     infoUrlText: s.asset.infoUrlText,
@@ -69,22 +63,14 @@ export default Container.namedConnect(
     issuerVerifiedDomain: s.asset.issuerVerifiedDomain,
     onAccept: d.onAccept,
     onCollapse: d.onCollapse,
-    onDeposit: s.asset.showDepositButton
-      ? () => d.onDeposit(o.accountID, s.asset.code, s.asset.issuerAccountID)
-      : undefined,
     onExpand: d.onExpand,
     onOpenInfoUrl: s.asset.infoUrl ? () => openUrl(s.asset.infoUrl) : undefined,
     onRemove: d.onRemove,
-    onWithdraw: s.asset.showWithdrawButton
-      ? () => d.onWithdraw(o.accountID, s.asset.code, s.asset.issuerAccountID)
-      : undefined,
     thisDeviceIsLockedOut: s.thisDeviceIsLockedOut,
     trusted: !!s.acceptedAssets.get(o.assetID, 0),
     waitingKeyAdd: Constants.addTrustlineWaitingKey(o.accountID, o.assetID),
     waitingKeyDelete: Constants.deleteTrustlineWaitingKey(o.accountID, o.assetID),
     waitingRefresh: s.waitingRefresh,
-    withdrawButtonText: s.asset.withdrawButtonText,
-    withdrawButtonWaitingKey: Constants.assetWithdrawWaitingKey(s.asset.issuerAccountID, s.asset.code),
   }),
   'Asset'
 )(Asset)

--- a/shared/wallets/trustline/asset.tsx
+++ b/shared/wallets/trustline/asset.tsx
@@ -5,8 +5,6 @@ import * as Styles from '../../styles'
 export type Props = {
   code: string
   cannotAccept: boolean
-  depositButtonText: string
-  depositButtonWaitingKey?: string
   expanded: boolean
   firstItem: boolean
   infoUrlText: string
@@ -14,16 +12,12 @@ export type Props = {
   issuerVerifiedDomain: string
   thisDeviceIsLockedOut: boolean
   trusted: boolean // TODO add limit when we support it in GUI
-  withdrawButtonWaitingKey?: string
-  withdrawButtonText: string
 
   onAccept: () => void
   onCollapse: () => void
   onExpand: () => void
   onRemove: () => void
-  onDeposit?: () => void
   onOpenInfoUrl?: () => void
-  onWithdraw?: () => void
 
   waitingKeyAdd: string
   waitingKeyDelete: string
@@ -63,27 +57,6 @@ const bodyExpanded = (props: Props) => (
       {props.issuerAccountID}
     </Kb.Text>
     <Kb.ButtonBar direction="row" align="flex-start" small={true}>
-      {!!props.depositButtonText && (
-        <Kb.WaitingButton
-          mode="Secondary"
-          label={props.depositButtonText}
-          onClick={stopPropagation(props.onDeposit)}
-          small={true}
-          type="Wallet"
-          waitingKey={props.depositButtonWaitingKey || null}
-        />
-      )}
-
-      {!!props.withdrawButtonText && (
-        <Kb.WaitingButton
-          mode="Secondary"
-          label={props.withdrawButtonText}
-          onClick={stopPropagation(props.onWithdraw)}
-          small={true}
-          type="Wallet"
-          waitingKey={props.withdrawButtonWaitingKey || null}
-        />
-      )}
       <Kb.Button
         mode="Secondary"
         type="Wallet"

--- a/shared/wallets/trustline/index.stories.tsx
+++ b/shared/wallets/trustline/index.stories.tsx
@@ -7,17 +7,13 @@ import Asset from './asset'
 import Trustline from '.'
 
 const commonAssetProps = {
-  depositButtonText: 'Deposit',
   infoUrlText: 'View details',
   onAccept: Sb.action('onAccept'),
-  onDeposit: Sb.action('onDeposit'),
   onOpenInfoUrl: Sb.action('onOpenInfoUrl'),
   onRemove: Sb.action('onRemove'),
-  onWithdraw: Sb.action('onWithdraw'),
   waitingKeyAdd: false,
   waitingKeyDelete: false,
   waitingRefresh: false,
-  withdrawButtonText: 'Withdraw',
 }
 
 const AssetWrapper = props => {


### PR DESCRIPTION
@keybase/react-hackers CC @keybase/picnicsquad 

These Deposit and Withdraw links won't work if you haven't accepted the trustline yet, so just show them underneath the accepted asset and not in the trustlines modal.