### PR TITLE
Use forked version of stack navigator to reduce overdraw

### DIFF
--- a/shared/override-d.ts/react-navigation/index.d.ts
+++ b/shared/override-d.ts/react-navigation/index.d.ts
@@ -419,6 +419,11 @@ declare module 'react-navigation' {
     headerBackTitleVisible?: boolean
     headerTransitionPreset?: 'fade-in-place' | 'uikit'
     headerLayoutPreset?: 'left' | 'center'
+    // Marco made this. Only show the background while transitioning.
+    // Only works on stack navigator
+    // Future versions of react-navigation will use reanimated, so we can define
+    // the background color as an animated value. And remove this value.
+    bgOnlyDuringTransition?: boolean
     cardShadowEnabled?: boolean
     cardOverlayEnabled?: boolean
     cardStyle?: StyleProp<ViewStyle>

--- a/shared/package.json
+++ b/shared/package.json
@@ -175,7 +175,7 @@
     "react-native-unimodules": "git://github.com/keybase/react-native-unimodules/#v0.4.0",
     "react-native-video": "4.4.4",
     "react-native-webview": "5.12.1",
-    "react-navigation-stack": "1.4.0",
+    "react-navigation-stack": "git://github.com/keybase/stack#marco/animated-background",
     "react-navigation-tabs": "2.2.0",
     "react-redux": "7.1.0",
     "react-spring": "8.0.27",

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -116,6 +116,8 @@ const TabBarIconContainer = props => (
 const VanillaTabNavigator = createBottomTabNavigator(
   tabs.reduce((map, tab) => {
     map[tab] = createStackNavigator(Shim.shim(routes), {
+      bgOnlyDuringTransition: Styles.isAndroid,
+      cardStyle: Styles.isAndroid ? {backgroundColor: 'rgba(0,0,0,0)'} : undefined,
       defaultNavigationOptions,
       headerMode,
       initialRouteName: tabRoots[tab],
@@ -195,6 +197,8 @@ const LoggedInStackNavigator = createStackNavigator(
     ...Shim.shim(modalRoutes),
   },
   {
+    bgOnlyDuringTransition: Styles.isAndroid,
+    cardStyle: Styles.isAndroid ? {backgroundColor: 'rgba(0,0,0,0)'} : undefined,
     headerMode: 'none',
     mode: 'modal',
   }

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -11041,10 +11041,9 @@ react-native@0.60.5:
     stacktrace-parser "^0.1.3"
     whatwg-fetch "^3.0.0"
 
-react-navigation-stack@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-navigation-stack/-/react-navigation-stack-1.4.0.tgz#69cdb029ea4ee5877d7e933b3117dc90bc841eb2"
-  integrity sha512-zEe9wCA0Ot8agarYb//0nSWYW1GM+1R0tY/nydUV0EizeJ27At0EklYVWvYEuYU6C48va6cu8OPL7QD/CcJACw==
+"react-navigation-stack@git://github.com/keybase/stack#marco/animated-background":
+  version "1.0.4"
+  resolved "git://github.com/keybase/stack#c9ef4142d89a47791537699027debefe279c1dc4"
 
 react-navigation-tabs@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
@keybase/react-hackers 

This lets us reduce overdraw significantly in the app. 
<img width="681" alt="Screen Shot 2019-09-24 at 10 31 47 AM" src="https://user-images.githubusercontent.com/594035/65537542-42f2c300-deba-11e9-921d-4c23b0405993.png">

Before this change we drew the white background 3 times. The stack navigator always added a background to the screen. 

A quick fix would be to remove the background color from the stack navigator, but then you get weird transitions where you'd see the previous content behind the new content.

The solution here is to fork react-navigation-stack to add a new prop (`bgOnlyDuringTransition`) that only shows a background while transitioning. Then remove the background color of the cards (by setting `backgroundColor: "rgba(0, 0, 0, 0)"`).


### The future

The latest react-navigation-stack uses reanimated for its animated values. When we upgrade to that we can make the `backgroundColor` an animated value, which will remove the need for my changes on stack navigator. It's still too soon to update our navigation dependencies, so we'll want this fork for now.

---
The changes on stack navigator: https://github.com/keybase/stack/commit/c9ef4142d89a47791537699027debefe279c1dc4





