### PR TITLE
Use UntrustedTeamRole for MinWriterRole, skipping search indexing when RESTRICTEDBOT

### DIFF
--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -581,7 +581,7 @@ func getUnverifiedTlfNameForErrors(conversationRemote chat1.Conversation) string
 
 func (s *localizerPipeline) getMinWriterRoleInfoLocal(ctx context.Context, uid gregor1.UID,
 	conv chat1.Conversation) (*chat1.ConversationMinWriterRoleInfoLocal, error) {
-	if conv.ConvSettings == nil {
+	if conv.ConvSettings == nil || conv.ReaderInfo == nil {
 		return nil, nil
 	}
 	info := conv.ConvSettings.MinWriterRoleInfo
@@ -589,32 +589,11 @@ func (s *localizerPipeline) getMinWriterRoleInfoLocal(ctx context.Context, uid g
 		return nil, nil
 	}
 
-	// determine if the current user can write.
-	teamID, err := keybase1.TeamIDFromString(conv.Metadata.IdTriple.Tlfid.String())
-	if err != nil {
-		return nil, err
-	}
-	extG := s.G().ExternalG()
-	team, err := teams.Load(ctx, extG, keybase1.LoadTeamArg{
-		ID:        teamID,
-		Public:    conv.Metadata.Visibility == keybase1.TLFVisibility_PUBLIC,
-		AuditMode: keybase1.AuditMode_SKIP,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	upak, _, err := s.G().GetUPAKLoader().LoadV2(
-		libkb.NewLoadUserByUIDArg(ctx, extG, keybase1.UID(uid.String())))
-	if err != nil {
-		return nil, err
-	}
-
-	uv := upak.Current.ToUserVersion()
-	role, err := team.MemberRole(ctx, uv)
-	if err != nil {
-		return nil, err
-	}
+	// NOTE We use the UntrustedTeamRole here since MinWriterRole is based on
+	// server trust. A nefarious server could stop our messages by rejecting
+	// them or violate the MinWriterRole by allowing them; lying about our role
+	// here doesn't help.
+	role := conv.ReaderInfo.UntrustedTeamRole
 
 	// get the changed by username
 	name, err := s.G().GetUPAKLoader().LookupUsername(ctx, keybase1.UID(info.Uid.String()))

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -7095,6 +7095,18 @@ func TestTeamBotSettings(t *testing.T) {
 			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_SYSTEM)
 
+			gilres, err := ctc.as(t, users[1]).chatLocalHandler().GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
+				Query: &chat1.GetInboxLocalQuery{
+					ConvIDs: []chat1.ConversationID{created.Id},
+				},
+			})
+			require.NoError(t, err)
+			require.Equal(t, 1, len(gilres.Conversations))
+			require.Equal(t, created.Id, gilres.Conversations[0].GetConvID())
+			gconv := gilres.Conversations[0]
+			require.NotNil(t, gconv.ReaderInfo)
+			require.Equal(t, keybase1.TeamRole_RESTRICTEDBOT, gconv.ReaderInfo.UntrustedTeamRole)
+
 			botSettings2 := keybase1.TeamBotSettings{
 				Mentions: true,
 			}
@@ -7115,6 +7127,18 @@ func TestTeamBotSettings(t *testing.T) {
 			assertNoMessage(botuaListener)
 			assertNoMessage(botuaListener2)
 			consumeNewMsgLocal(t, listener, chat1.MessageType_SYSTEM)
+
+			gilres, err = ctc.as(t, users[2]).chatLocalHandler().GetInboxAndUnboxLocal(ctx, chat1.GetInboxAndUnboxLocalArg{
+				Query: &chat1.GetInboxLocalQuery{
+					ConvIDs: []chat1.ConversationID{created.Id},
+				},
+			})
+			require.NoError(t, err)
+			require.Equal(t, 1, len(gilres.Conversations))
+			require.Equal(t, created.Id, gilres.Conversations[0].GetConvID())
+			gconv = gilres.Conversations[0]
+			require.NotNil(t, gconv.ReaderInfo)
+			require.Equal(t, keybase1.TeamRole_RESTRICTEDBOT, gconv.ReaderInfo.UntrustedTeamRole)
 
 			t.Logf("send a text message")
 			arg := chat1.PostTextNonblockArg{


### PR DESCRIPTION
- [x] deploy gregor

This reverts commit 2dff92d09afabf6c96afa04e44bca802c1b48893.