### PR TITLE
force update menu after it updates

### DIFF
--- a/shared/desktop/app/menu-bar.desktop.tsx
+++ b/shared/desktop/app/menu-bar.desktop.tsx
@@ -1,10 +1,12 @@
 // Entrypoint for the menubar node part
-import {menubar} from 'menubar'
+import * as ConfigGen from '../../actions/config-gen'
 import * as SafeElectron from '../../util/safe-electron.desktop'
+import logger from '../../logger'
 import {isDarwin, isWindows, isLinux} from '../../constants/platform'
+import {mainWindowDispatch} from '../remote/util.desktop'
+import {menubar} from 'menubar'
 import {resolveImage, resolveRootAsURL} from './resolve-root.desktop'
 import {showDevTools, skipSecondaryDevtools} from '../../local-debug.desktop'
-import logger from '../../logger'
 
 const htmlFile = resolveRootAsURL('dist', `menubar${__DEV__ ? '.dev' : ''}.html?param=`)
 
@@ -80,6 +82,14 @@ export default (menubarWindowIDCallback: (id: number) => void) => {
         }
       }
     })
+
+    // ask for an update in case we missed one
+    mainWindowDispatch(
+      ConfigGen.createRemoteWindowWantsProps({
+        component: 'menubar',
+        param: '',
+      })
+    )
 
     mb.window && menubarWindowIDCallback(mb.window.id)
 

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -18,6 +18,7 @@ const windowOpts = {}
 type Props = {
   desktopAppBadgeCount: number
   externalRemoteWindow: SafeElectron.BrowserWindowType
+  remoteWindowNeedsProps: number
   widgetBadge: BadgeType
   windowComponent: string
   windowOpts?: Object
@@ -74,10 +75,11 @@ function RemoteMenubarWindow(ComposedComponent: any) {
       }
     }
 
-    componentDidUpdate(prevProps) {
+    componentDidUpdate(prevProps: any) {
       if (
         this.props.widgetBadge !== prevProps.widgetBadge ||
-        this.props.desktopAppBadgeCount !== prevProps.desktopAppBadgeCount
+        this.props.desktopAppBadgeCount !== prevProps.desktopAppBadgeCount ||
+        this.props.remoteWindowNeedsProps !== prevProps.remoteWindowNeedsProps
       ) {
         this._updateBadges()
       }


### PR DESCRIPTION
@malgorithms was running into a race condition where the menu wouldn't load up. its possible the ready even fires after we've asked for updates so it never gets an update. this requests an update from the node thread after its actually ready to go just in case