### PR TITLE
re init hidden package

### DIFF
--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -212,6 +212,12 @@ func (l *LoaderPackage) CheckNoPTK(mctx libkb.MetaContext, g keybase1.PerTeamKey
 	return nil
 }
 
+func (l *LoaderPackage) UpdateTeamMetadata(encKID keybase1.KID, encKIDGen keybase1.PerTeamKeyGeneration, role keybase1.TeamRole) {
+	l.encKID = encKID
+	l.encKIDGen = encKIDGen
+	l.role = role
+}
+
 // Update combines the preloaded data with any downloaded updates from the server, and stores
 // the result local to this object.
 func (l *LoaderPackage) Update(mctx libkb.MetaContext, update []sig3.ExportJSON) (err error) {

--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -416,7 +416,7 @@ func (l *LoaderPackage) CheckUpdatesAgainstSeedsWithMap(mctx libkb.MetaContext, 
 // recent keyers knew the old keys.
 func (l *LoaderPackage) CheckUpdatesAgainstSeeds(mctx libkb.MetaContext, f func(keybase1.PerTeamKeyGeneration) *keybase1.PerTeamSeedCheck) (err error) {
 	defer mctx.Trace("LoaderPackage#CheckUpdatesAgainstSeeds", func() error { return err })()
-	// BOTs are excluded since they do not have any seed access
+	// RESTRICTEDBOTs are excluded since they do not have any seed access
 	if l.newData == nil || l.role.IsRestrictedBot() {
 		return nil
 	}
@@ -462,7 +462,7 @@ func (l *LoaderPackage) MaxRatchet() (ret keybase1.Seqno) {
 // HasReaderPerTeamKeyAtGeneration returns true if the LoaderPackage has a sigchain entry for
 // the PTK at the given generation. Whether in the preloaded data or the update.
 func (l *LoaderPackage) HasReaderPerTeamKeyAtGeneration(gen keybase1.PerTeamKeyGeneration) bool {
-	// BOTs are excluded since they do not have any PTK access
+	// RESTRICTEDBOTs are excluded since they do not have any PTK access
 	if l.data == nil || l.role.IsRestrictedBot() {
 		return false
 	}
@@ -489,7 +489,7 @@ func (l *LoaderPackage) ChainData() *keybase1.HiddenTeamChain {
 // MaxReaderTeamKeyGeneration returns the highest Reader PTK generation from the preloaded and hidden
 // data.
 func (l *LoaderPackage) MaxReaderPerTeamKeyGeneration() keybase1.PerTeamKeyGeneration {
-	// BOTs are excluded since they do not have any PTK access
+	// RESTRICTEDBOTs are excluded since they do not have any PTK access
 	if l.data == nil || l.role.IsRestrictedBot() {
 		return keybase1.PerTeamKeyGeneration(0)
 	}

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -732,7 +732,10 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 	if err != nil {
 		return nil, err
 	}
-	// update the hidden package once ret != nil
+	// Update the hidden package with team metadata once we process all of the
+	// links. This is necessary since we need the role to be up to date to know
+	// if we should skip seed checks on the hidden chain if we are loading as a
+	// RESTRICTEDBOT.
 	hiddenPackage.UpdateTeamMetadata(encKID, gen, role)
 
 	// Be sure to update the hidden chain after the main chain, since the latter can "ratchet" the former

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -724,6 +724,16 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		}
 	}
 
+	if ret == nil {
+		return nil, fmt.Errorf("team loader fault: got nil from load2")
+	}
+
+	// reinitialize the hidden package once ret != nil
+	hiddenPackage, err = l.hiddenPackage(mctx, arg.teamID, ret, arg.me)
+	if err != nil {
+		return nil, err
+	}
+
 	// Be sure to update the hidden chain after the main chain, since the latter can "ratchet" the former
 	if teamUpdate != nil {
 		err = hiddenPackage.Update(mctx, teamUpdate.GetHiddenChain())
@@ -760,10 +770,6 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 			tbs.Log(ctx, "CachedUPAKLoader.DeepCopy")
 			mctx.Debug("TeamLoader lkc cache hits: %v", lkc.cacheHits)
 		}
-	}
-
-	if ret == nil {
-		return nil, fmt.Errorf("team loader fault: got nil from load2")
 	}
 
 	if !ret.Chain.LastLinkID.Eq(lastLinkID) {


### PR DESCRIPTION
fixes a failed seed check on restricted bots since the role would be `TeamRole_NONE` when the hiddenPackage was initialized

`▶ ERROR hidden team loader error: seed check at generation 3 wasn't found`