### PR TITLE
kbpki_client: add id->username cache

### DIFF
--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -823,6 +823,10 @@ type KBPKI interface {
 
 	// NotifyPathUpdated sends a path updated notification.
 	NotifyPathUpdated(ctx context.Context, path string) error
+
+	// InvalidateTeamCacheForID instructs KBPKI to discard any cached
+	// information about the given team ID.
+	InvalidateTeamCacheForID(tid keybase1.TeamID)
 }
 
 // KeyMetadataWithRootDirEntry is like KeyMetadata, but can also

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -1530,6 +1530,12 @@ func (fs *KBFSOpsStandard) TeamNameChanged(
 	defer timeTrackerDone()
 
 	fs.log.CDebugf(ctx, "Got TeamNameChanged for %s", tid)
+
+	// Invalidate any cached ID->name mapping for the team if its name
+	// changed, since team names can change due to SBS resolutions
+	// (for implicit teams) or for subteam renames.
+	fs.config.KBPKI().InvalidateTeamCacheForID(tid)
+
 	fbo := fs.findTeamByID(ctx, tid)
 	if fbo != nil {
 		go fbo.TeamNameChanged(ctx, tid)

--- a/go/kbfs/libkbfs/kbpki_client.go
+++ b/go/kbfs/libkbfs/kbpki_client.go
@@ -5,9 +5,11 @@
 package libkbfs
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/kbfs/idutil"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
@@ -16,7 +18,10 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"golang.org/x/net/context"
+)
+
+const (
+	idToUserCacheSize = 50
 )
 
 // keybaseServiceOwner is a wrapper around a KeybaseService, to allow
@@ -28,8 +33,9 @@ type keybaseServiceOwner interface {
 
 // KBPKIClient uses a KeybaseService.
 type KBPKIClient struct {
-	serviceOwner keybaseServiceOwner
-	log          logger.Logger
+	serviceOwner  keybaseServiceOwner
+	log           logger.Logger
+	idToUserCache *lru.Cache
 }
 
 var _ KBPKI = (*KBPKIClient)(nil)
@@ -37,7 +43,13 @@ var _ KBPKI = (*KBPKIClient)(nil)
 // NewKBPKIClient returns a new KBPKIClient with the given service.
 func NewKBPKIClient(
 	serviceOwner keybaseServiceOwner, log logger.Logger) *KBPKIClient {
-	return &KBPKIClient{serviceOwner, log}
+	cache, err := lru.New(idToUserCacheSize)
+	if err != nil {
+		cache = nil
+		log.CDebugf(context.TODO(), "Error creating LRU cache: %+v", err)
+	}
+
+	return &KBPKIClient{serviceOwner, log, cache}
 }
 
 // GetCurrentSession implements the KBPKI interface for KBPKIClient.
@@ -133,17 +145,28 @@ func (k *KBPKIClient) IdentifyImplicitTeam(
 func (k *KBPKIClient) GetNormalizedUsername(
 	ctx context.Context, id keybase1.UserOrTeamID,
 	offline keybase1.OfflineAvailability) (
-	kbname.NormalizedUsername, error) {
+	username kbname.NormalizedUsername, err error) {
+	if k.idToUserCache != nil {
+		tmp, ok := k.idToUserCache.Get(id)
+		if ok {
+			username, ok = tmp.(kbname.NormalizedUsername)
+			if ok {
+				return username, nil
+			}
+		}
+	}
+
 	var assertion string
 	if id.IsUser() {
 		assertion = fmt.Sprintf("uid:%s", id)
 	} else {
 		assertion = fmt.Sprintf("tid:%s", id)
 	}
-	username, _, err := k.Resolve(ctx, assertion, offline)
+	username, _, err = k.Resolve(ctx, assertion, offline)
 	if err != nil {
 		return kbname.NormalizedUsername(""), err
 	}
+	k.idToUserCache.Add(id, username)
 	return username, nil
 }
 

--- a/go/kbfs/libkbfs/kbpki_client.go
+++ b/go/kbfs/libkbfs/kbpki_client.go
@@ -443,3 +443,8 @@ func (k *KBPKIClient) PutGitMetadata(
 	return k.serviceOwner.KeybaseService().PutGitMetadata(
 		ctx, folder, repoID, metadata)
 }
+
+// InvalidateTeamCacheForID implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) InvalidateTeamCacheForID(tid keybase1.TeamID) {
+	k.idToUserCache.Remove(tid.AsUserOrTeam())
+}

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -1918,6 +1918,18 @@ func (mr *MockKBPKIMockRecorder) IdentifyImplicitTeam(arg0, arg1, arg2, arg3, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdentifyImplicitTeam", reflect.TypeOf((*MockKBPKI)(nil).IdentifyImplicitTeam), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// InvalidateTeamCacheForID mocks base method
+func (m *MockKBPKI) InvalidateTeamCacheForID(arg0 keybase1.TeamID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InvalidateTeamCacheForID", arg0)
+}
+
+// InvalidateTeamCacheForID indicates an expected call of InvalidateTeamCacheForID
+func (mr *MockKBPKIMockRecorder) InvalidateTeamCacheForID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateTeamCacheForID", reflect.TypeOf((*MockKBPKI)(nil).InvalidateTeamCacheForID), arg0)
+}
+
 // IsTeamReader mocks base method
 func (m *MockKBPKI) IsTeamReader(arg0 context.Context, arg1 keybase1.TeamID, arg2 keybase1.UID, arg3 keybase1.OfflineAvailability) (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
`folderBranchOps.GetNodeMetadata` gets the normalized username given an ID on every call, which results in a service RPC.  However, this mapping can be easily cached since it basically never changes. So this adds a small LRU cache for those mappings.

Issue: HOTPOT-877