### PR TITLE
Warn about device name

### DIFF
--- a/go/client/cmd_deprovision.go
+++ b/go/client/cmd_deprovision.go
@@ -151,7 +151,8 @@ or copy them, use %s.`, "`keybase pgp export`")
 %s, BE CAREFUL!  \('o')/
 
 You are about to delete this device from your account, including its secret
-keys. If you don't have any other devices, you'll lose access to your account
+keys. You will not be able to reuse the device name for a new device.
+If you don't have any other devices, you'll lose access to your account
 and all your data!%s%s
 
 Proceed?`, username, loggedOutWarning, pgpWarning), nil


### PR DESCRIPTION
Warn that the device name will not be reusable once the device has been revoked. fix #19929 