### PR TITLE
update a stellar link

### DIFF
--- a/shared/wallets/asset/container.tsx
+++ b/shared/wallets/asset/container.tsx
@@ -46,7 +46,7 @@ export default Container.connect(
         ? () => dispatchProps.onWithdraw(ownProps.accountID, asset.assetCode, asset.issuerAccountID)
         : undefined,
       openInfoURL: asset.infoUrl ? () => openURL(asset.infoUrl) : undefined,
-      openStellarURL: () => openURL('https://www.stellar.org/faq/#_Why_is_there_a_minimum_balance'),
+      openStellarURL: () => openURL('https://www.stellar.org/community/faq#why-is-there-a-minimum-balance'),
       reserves: asset.reserves.toArray(),
       withdrawButtonText: asset.showWithdrawButton ? asset.withdrawButtonText : '',
       withdrawButtonWaitingKey: Constants.assetWithdrawWaitingKey(asset.issuerAccountID, asset.assetCode),


### PR DESCRIPTION
change the link to something that actually has the answer. seems like stellar removed this content from their site and left it to each integrator to explain. this link might be a little technical for a curious, unsophisticated user of keybase, but the alternatives seem to be reddit answers or blockchain.com.

we could add a little FAQ doc somewhere like https://keybase.io/docs/stellar/faq with this (and perhaps other) answers. what do you think? is this good enough?