### PR TITLE
store has random passphrase in config.json

### DIFF
--- a/go/client/cmd_account_delete.go
+++ b/go/client/cmd_account_delete.go
@@ -55,11 +55,11 @@ func (c *CmdAccountDelete) promptToConfirm() error {
 	if err != nil {
 		return err
 	}
-	randomPW, err := cli.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	passphraseState, err := cli.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{})
 	if err != nil {
 		return err
 	}
-	if randomPW {
+	if passphraseState == keybase1.PassphraseState_RANDOM {
 		expected := fmt.Sprintf("I want to delete my account %s", c.G().Env.GetUsername().String())
 		promptStr := fmt.Sprintf("Please type '%s' to confirm: ", expected)
 		ret, err := ui.Prompt(PromptDescriptorAccountDeleteConfirmation, promptStr)

--- a/go/client/cmd_account_reset.go
+++ b/go/client/cmd_account_reset.go
@@ -46,11 +46,11 @@ func (c *CmdAccountReset) checkRandomPW() error {
 	if err != nil {
 		return err
 	}
-	randomPW, err := cli.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	passphraseState, err := cli.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{})
 	if err != nil {
 		return err
 	}
-	if randomPW {
+	if passphraseState == keybase1.PassphraseState_RANDOM {
 		return errors.New("Can't reset without a password. Set a password first")
 	}
 	return nil

--- a/go/client/cmd_passphrase_change.go
+++ b/go/client/cmd_passphrase_change.go
@@ -49,10 +49,11 @@ func (c *CmdPassphraseChange) Run() error {
 
 	// If the user has a randompw, we force the password change since we cannot
 	// prompt them for the old one.
-	forcePassphraseChange, err := cliUser.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	passphraseState, err := cliUser.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{})
 	if err != nil {
 		return err
 	}
+	forcePassphraseChange := passphraseState == keybase1.PassphraseState_RANDOM
 
 	if forcePassphraseChange {
 		// Check whether the user would lose server-stored encrypted PGP keys.

--- a/go/client/cmd_passphrase_check.go
+++ b/go/client/cmd_passphrase_check.go
@@ -53,14 +53,14 @@ func (c *CmdPassphraseCheck) Run() error {
 		return err
 	}
 
-	randomPW, err := cliUser.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	passphraseState, err := cliUser.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{})
 	if err != nil {
 		return err
 	}
 
-	if randomPW {
+	if passphraseState == keybase1.PassphraseState_RANDOM {
 		c.G().Log.Error("Your account does not have a passphrase, so there is nothing to check.")
-		c.G().Log.Info("You should set a passphrase using `keybase passphrase recover`.")
+		c.G().Log.Info("You should set a passphrase using `keybase passphrase set`.")
 		return nil
 	}
 

--- a/go/client/cmd_pgp_gen.go
+++ b/go/client/cmd_pgp_gen.go
@@ -68,11 +68,11 @@ func (v *CmdPGPGen) Run() (err error) {
 		return err
 	}
 
-	hasRandomPw, err := user.LoadHasRandomPw(context.TODO(), keybase1.LoadHasRandomPwArg{})
+	passphraseState, err := user.LoadPassphraseState(context.TODO(), keybase1.LoadPassphraseStateArg{})
 	if err != nil {
 		return err
 	}
-	if !hasRandomPw {
+	if passphraseState == keybase1.PassphraseState_KNOWN {
 		v.arg.PushSecret, err = v.G().UI.GetTerminalUI().PromptYesNo(PromptDescriptorPGPGenPushSecret, "Push an encrypted copy of your new secret key to the Keybase.io server?", libkb.PromptDefaultYes)
 		if err != nil {
 			return err

--- a/go/engine/account_delete.go
+++ b/go/engine/account_delete.go
@@ -48,13 +48,13 @@ func (e *AccountDelete) SubConsumers() []libkb.UIConsumer {
 func (e *AccountDelete) Run(m libkb.MetaContext) error {
 	username := m.G().GetEnv().GetUsername()
 
-	randomPW, err := libkb.LoadHasRandomPw(m, keybase1.LoadHasRandomPwArg{})
+	passphraseState, err := libkb.LoadPassphraseState(m)
 	if err != nil {
 		return err
 	}
 
 	var passphrase *string
-	if !randomPW {
+	if passphraseState == keybase1.PassphraseState_KNOWN {
 		// Passphrase is required to create PDPKA, but that's not required for
 		// randomPW users.
 		arg := libkb.DefaultPassphrasePromptArg(m, username.String())

--- a/go/engine/pgp_import_key.go
+++ b/go/engine/pgp_import_key.go
@@ -237,11 +237,11 @@ func (e *PGPKeyImportEngine) Run(m libkb.MetaContext) (err error) {
 }
 
 func (e *PGPKeyImportEngine) checkRandomPassword(mctx libkb.MetaContext) error {
-	random, err := libkb.LoadHasRandomPw(mctx, keybase1.LoadHasRandomPwArg{})
+	passphraseState, err := libkb.LoadPassphraseState(mctx)
 	if err != nil {
 		return err
 	}
-	if random {
+	if passphraseState == keybase1.PassphraseState_RANDOM {
 		return libkb.NewPushSecretWithoutPasswordError("You need to set your password first before uploading secret keys")
 	}
 	return nil

--- a/go/engine/pgp_keygen.go
+++ b/go/engine/pgp_keygen.go
@@ -88,13 +88,13 @@ func (e *PGPKeyGen) Run(m libkb.MetaContext) error {
 	}
 
 	// ask if we should push private key to api server if user has a password
-	hasRandomPw, err := libkb.LoadHasRandomPw(m, keybase1.LoadHasRandomPwArg{})
+	passphraseState, err := libkb.LoadPassphraseState(m)
 	if err != nil {
 		return err
 	}
 	pushPrivate, err := m.UIs().PgpUI.ShouldPushPrivate(m.Ctx(), keybase1.ShouldPushPrivateArg{
 		SessionID: m.UIs().SessionID,
-		Prompt:    !hasRandomPw,
+		Prompt:    passphraseState == keybase1.PassphraseState_KNOWN,
 	})
 	if err != nil {
 		return err

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -43,7 +43,7 @@ const (
 	DBFTLStorage                     = 0xcd
 	DBTeamAuditor                    = 0xce
 	DBAttachmentUploader             = 0xcf
-	DBHasRandomPW                    = 0xd0
+	DBLegacyHasRandomPW              = 0xd0
 	DBDiskLRUEntries                 = 0xda
 	DBDiskLRUIndex                   = 0xdb
 	DBImplicitTeamConflictInfo       = 0xdc
@@ -116,7 +116,7 @@ func IsPermDbKey(typ ObjType) bool {
 		DBDiskLRUIndex,
 		DBOfflineRPC,
 		DBChatCollapses,
-		DBHasRandomPW,
+		DBLegacyHasRandomPW,
 		DBChatReacji,
 		DBStellarDisclaimer,
 		DBChatIndex,

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -132,6 +132,11 @@ func (n NullConfiguration) GetForceLinuxKeyring() (bool, bool)                  
 func (n NullConfiguration) GetForceSecretStoreFile() (bool, bool)                 { return false, false }
 func (n NullConfiguration) GetChatOutboxStorageEngine() string                    { return "" }
 func (n NullConfiguration) GetRuntimeStatsEnabled() (bool, bool)                  { return false, false }
+func (n NullConfiguration) GetPassphraseState() *keybase1.PassphraseState         { return nil }
+func (n NullConfiguration) GetPassphraseStateForUsername(NormalizedUsername) *keybase1.PassphraseState {
+	return nil
+}
+
 func (n NullConfiguration) GetBug3964RepairTime(NormalizedUsername) (time.Time, error) {
 	return time.Time{}, nil
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -193,6 +193,8 @@ type ConfigReader interface {
 	GetNoPinentry() (bool, bool)
 	GetDeviceID() keybase1.DeviceID
 	GetDeviceIDForUsername(nu NormalizedUsername) keybase1.DeviceID
+	GetPassphraseState() *keybase1.PassphraseState
+	GetPassphraseStateForUsername(nu NormalizedUsername) *keybase1.PassphraseState
 	GetDeviceIDForUID(u keybase1.UID) keybase1.DeviceID
 	GetUsernameForUID(u keybase1.UID) NormalizedUsername
 	GetUIDForUsername(n NormalizedUsername) keybase1.UID
@@ -244,6 +246,7 @@ type ConfigWriter interface {
 	SetUpdateLastChecked(keybase1.Time) error
 	SetBug3964RepairTime(NormalizedUsername, time.Time) error
 	SetRememberPassphrase(NormalizedUsername, bool) error
+	SetPassphraseState(keybase1.PassphraseState) error
 	Reset()
 	BeginTransaction() (ConfigWriterTransacter, error)
 }

--- a/go/libkb/logout.go
+++ b/go/libkb/logout.go
@@ -185,11 +185,15 @@ func CanLogout(mctx MetaContext) (res keybase1.CanLogoutRes) {
 		default:
 			// Unexpected error like network connectivity issue, fall through.
 			// Even if we are offline here, we may be able to get cached value
-			// `false` from LoadHasRandomPw and be allowed to log out.
+			// `keybase1.PassphraseState_KNOWN` from LoadPassphraseState and be allowed to log out.
 			mctx.Debug("CanLogout: CheckCurrentUIDDeviceID returned: %q, falling through", err.Error())
 		}
 	}
 
+	// In case the prefetcher did not finish this session (for example if we
+	// are in standalone mode or we were offline for the first 15 min of the
+	// session, force a repoll if the passphrase is unknown or last known as
+	// random.)
 	prefetcher := mctx.G().GetHasRandomPWPrefetcher()
 	forceRepoll := prefetcher == nil || !prefetcher.prefetched
 	passphraseState, err := LoadPassphraseStateWithForceRepoll(mctx, forceRepoll)

--- a/go/libkb/logout.go
+++ b/go/libkb/logout.go
@@ -190,9 +190,9 @@ func CanLogout(mctx MetaContext) (res keybase1.CanLogoutRes) {
 		}
 	}
 
-	hasRandomPW, err := LoadHasRandomPw(mctx, keybase1.LoadHasRandomPwArg{
-		ForceRepoll: false,
-	})
+	prefetcher := mctx.G().GetHasRandomPWPrefetcher()
+	forceRepoll := prefetcher == nil || !prefetcher.prefetched
+	passphraseState, err := LoadPassphraseStateWithForceRepoll(mctx, forceRepoll)
 
 	if err != nil {
 		return keybase1.CanLogoutRes{
@@ -201,11 +201,10 @@ func CanLogout(mctx MetaContext) (res keybase1.CanLogoutRes) {
 		}
 	}
 
-	if hasRandomPW {
+	if passphraseState == keybase1.PassphraseState_RANDOM {
 		return keybase1.CanLogoutRes{
-			CanLogout:     false,
-			SetPassphrase: true,
-			Reason:        "You signed up without a password and need to set a password first",
+			CanLogout: false,
+			Reason:    "You signed up without a password and need to set a password first",
 		}
 	}
 

--- a/go/libkb/passphrase_state.go
+++ b/go/libkb/passphrase_state.go
@@ -1,0 +1,232 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/keybase/backoff"
+	"github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+)
+
+func randomPassphraseToState(hasRandomPassphrase bool) keybase1.PassphraseState {
+	if hasRandomPassphrase {
+		return keybase1.PassphraseState_RANDOM
+	}
+	return keybase1.PassphraseState_KNOWN
+}
+
+func LoadPassphraseState(mctx MetaContext) (passphraseState keybase1.PassphraseState, err error) {
+	return LoadPassphraseStateWithForceRepoll(mctx, false)
+}
+
+// forceRepoll only forces repoll when the state is RANDOM, but not when it is KNOWN.
+func LoadPassphraseStateWithForceRepoll(mctx MetaContext, forceRepoll bool) (passphraseState keybase1.PassphraseState, err error) {
+	mctx = mctx.WithLogTag("PPSTATE")
+	defer mctx.TraceTimed(fmt.Sprintf("LoadPassphraseState(forceRepoll=%t)", forceRepoll), func() error { return err })()
+
+	if !mctx.G().ActiveDevice.Valid() {
+		mctx.Debug("LoadPassphraseState: user is not logged in")
+		return passphraseState, NewLoginRequiredError("LoadPassphraseState")
+	}
+
+	configState := mctx.G().Env.GetConfig().GetPassphraseState()
+	if configState != nil {
+		mctx.Debug("LoadPassphraseState: state found in config.json: %#v", configState)
+		if !forceRepoll || *configState == keybase1.PassphraseState_KNOWN {
+			return *configState, nil
+		}
+	}
+
+	mctx.Debug("LoadPassphraseState: state not found in config.json; checking legacy leveldb")
+
+	legacyState, err := loadPassphraseStateFromLegacy(mctx)
+	if err == nil {
+		mctx.Debug("LoadPassphraseState: state found in legacy leveldb: %#v", legacyState)
+		MaybeSavePassphraseState(mctx, legacyState)
+		if !forceRepoll || legacyState == keybase1.PassphraseState_KNOWN {
+			return legacyState, nil
+		}
+	}
+	mctx.Debug("LoadPassphraseState: could not find state in legacy leveldb (%s); checking remote", err)
+
+	remoteState, err := LoadPassphraseStateFromRemote(mctx)
+	if err == nil {
+		MaybeSavePassphraseState(mctx, remoteState)
+		return remoteState, nil
+	}
+	return passphraseState, fmt.Errorf("failed to load passphrase state from any path, including remote: %s", err)
+}
+
+func MaybeSavePassphraseState(mctx MetaContext, passphraseState keybase1.PassphraseState) {
+	err := mctx.G().Env.GetConfigWriter().SetPassphraseState(passphraseState)
+	if err == nil {
+		mctx.Debug("Added PassphraseState=%#v to config file", passphraseState)
+	} else {
+		mctx.Warning("Failed to save passphraseState=%#v to config file: %s", passphraseState, err)
+	}
+}
+
+func loadPassphraseStateFromLegacy(mctx MetaContext) (passphraseState keybase1.PassphraseState, err error) {
+	currentUID := mctx.CurrentUID()
+	cacheKey := DbKey{
+		Typ: DBLegacyHasRandomPW,
+		Key: currentUID.String(),
+	}
+	var hasRandomPassphrase bool
+	found, err := mctx.G().GetKVStore().GetInto(&hasRandomPassphrase, cacheKey)
+	if err != nil {
+		return passphraseState, err
+	}
+	if !found {
+		return passphraseState, fmt.Errorf("passphrase state not found in leveldb")
+	}
+	return randomPassphraseToState(hasRandomPassphrase), nil
+}
+
+func LoadPassphraseStateFromRemote(mctx MetaContext) (passphraseState keybase1.PassphraseState, err error) {
+	var ret struct {
+		AppStatusEmbed
+		RandomPassphrase bool `json:"random_pw"`
+	}
+	err = mctx.G().API.GetDecode(mctx, APIArg{
+		Endpoint:       "user/has_random_pw",
+		SessionType:    APISessionTypeREQUIRED,
+		InitialTimeout: 10 * time.Second,
+	}, &ret)
+	if err != nil {
+		return passphraseState, err
+	}
+	return randomPassphraseToState(ret.RandomPassphrase), nil
+}
+
+func CanLogout(mctx MetaContext) (res keybase1.CanLogoutRes) {
+	if !mctx.G().ActiveDevice.Valid() {
+		mctx.Debug("CanLogout: looks like user is not logged in")
+		res.CanLogout = true
+		return res
+	}
+
+	if mctx.G().ActiveDevice.KeychainMode() == KeychainModeNone {
+		mctx.Debug("CanLogout: ok to logout since the key used doesn't user the keychain")
+		res.CanLogout = true
+		return res
+	}
+
+	if err := CheckCurrentUIDDeviceID(mctx); err != nil {
+		switch err.(type) {
+		case DeviceNotFoundError, UserNotFoundError,
+			KeyRevokedError, NoDeviceError, NoUIDError:
+			mctx.Debug("CanLogout: allowing logout because of CheckCurrentUIDDeviceID returning: %s", err.Error())
+			return keybase1.CanLogoutRes{CanLogout: true}
+		default:
+			// Unexpected error like network connectivity issue, fall through.
+			// Even if we are offline here, we may be able to get cached value
+			// `false` from LoadHasRandomPw and be allowed to log out.
+			mctx.Debug("CanLogout: CheckCurrentUIDDeviceID returned: %q, falling through", err.Error())
+		}
+	}
+
+	prefetcher := mctx.G().GetHasRandomPWPrefetcher()
+	forceRepoll := prefetcher == nil || !prefetcher.prefetched
+	passphraseState, err := LoadPassphraseStateWithForceRepoll(mctx, forceRepoll)
+
+	if err != nil {
+		return keybase1.CanLogoutRes{
+			CanLogout: false,
+			Reason:    fmt.Sprintf("We couldn't ensure that your account has a passphrase: %s", err.Error()),
+		}
+	}
+
+	if passphraseState == keybase1.PassphraseState_RANDOM {
+		return keybase1.CanLogoutRes{
+			CanLogout: false,
+			Reason:    "You signed up without a password and need to set a password first",
+		}
+	}
+
+	res.CanLogout = true
+	return res
+}
+
+// hasRandomPWPrefetcher implements LoginHook and LogoutHook interfaces and is
+// used to ensure that we know current user's NOPW status.
+type HasRandomPWPrefetcher struct {
+	// cancel func for randompw prefetching context, if currently active.
+	hasRPWCancelFn context.CancelFunc
+	prefetched     bool
+}
+
+func (d *HasRandomPWPrefetcher) prefetchHasRandomPW(g *GlobalContext, uid keybase1.UID) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d.hasRPWCancelFn = cancel
+	d.prefetched = false
+
+	mctx := NewMetaContext(ctx, g).WithLogTag("P_HASRPW")
+	go func() {
+		defer func() { d.hasRPWCancelFn = nil }()
+		mctx.Debug("prefetchHasRandomPW: starting prefetch after two seconds")
+		select {
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			mctx.Debug("prefetchHasRandomPW: return before starting: %v", ctx.Err())
+			return
+		}
+		err := backoff.RetryNotifyWithContext(ctx, func() error {
+			mctx.Debug("prefetchHasRandomPW: trying for uid=%q", uid)
+			if !mctx.CurrentUID().Equal(uid) {
+				// Do not return an error, so backoff does not retry.
+				mctx.Debug("prefetchHasRandomPW: current uid has changed, aborting")
+				return nil
+			}
+
+			state, err := LoadPassphraseState(mctx)
+			if err != nil {
+				mctx.Debug("prefetchHasRandomPW: loading current passphrase state failed: %s", err)
+			} else if state == keybase1.PassphraseState_KNOWN {
+				// Can't go back to RANDOM
+				return nil
+			}
+
+			passphraseState, err := LoadPassphraseStateFromRemote(mctx)
+			if err != nil {
+				mctx.Debug("prefetchHasRandomPW: load from remote failed: %s", err)
+				return err
+			}
+
+			mctx.Debug("prefetchHasRandomPW: loaded passphraseState=%#v", passphraseState)
+			select {
+			case <-ctx.Done():
+				mctx.Debug("prefetchHasRandomPW: context cancelled before MaybeSavePassphraseState: %s", ctx.Err())
+			default:
+				mctx.Debug("prefetchHasRandomPW: running MaybeSavePassphraseState")
+				MaybeSavePassphraseState(mctx, passphraseState)
+			}
+			return nil
+		}, backoff.NewExponentialBackOff(), nil)
+		if err != nil {
+			d.prefetched = true
+		}
+		mctx.Debug("prefetchHasRandomPW: backoff loop returned: err=%v", err)
+	}()
+}
+
+func (d *HasRandomPWPrefetcher) OnLogin(mctx MetaContext) error {
+	g := mctx.G()
+	uid := g.GetEnv().GetUID()
+	if !uid.IsNil() {
+		d.prefetchHasRandomPW(g, uid)
+	}
+	return nil
+}
+
+func (d *HasRandomPWPrefetcher) OnLogout(mctx MetaContext) error {
+	if d.hasRPWCancelFn != nil {
+		mctx.Debug("Cancelling prefetcher in OnLogout hook (P_HASRPW)")
+		d.hasRPWCancelFn()
+	}
+	return nil
+}

--- a/go/libkb/passphrase_state.go
+++ b/go/libkb/passphrase_state.go
@@ -28,10 +28,15 @@ func LoadPassphraseStateWithForceRepoll(mctx MetaContext, forceRepoll bool) (pas
 	mctx = mctx.WithLogTag("PPSTATE")
 	defer mctx.TraceTimed(fmt.Sprintf("LoadPassphraseState(forceRepoll=%t)", forceRepoll), func() error { return err })()
 
-	if !mctx.G().ActiveDevice.Valid() {
+	if len(mctx.G().Env.GetUsername().String()) == 0 {
 		mctx.Debug("LoadPassphraseState: user is not logged in")
 		return passphraseState, NewLoginRequiredError("LoadPassphraseState")
 	}
+
+	// if !mctx.G().ActiveDevice.Valid() {
+	// 	mctx.Debug("LoadPassphraseState: user is not logged in")
+	// 	return passphraseState, NewLoginRequiredError("LoadPassphraseState")
+	// }
 
 	configState := mctx.G().Env.GetConfig().GetPassphraseState()
 	if configState != nil {

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"regexp"
-	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	stellar1 "github.com/keybase/client/go/protocol/stellar1"
@@ -871,76 +870,6 @@ func (u *User) IsCachedIdentifyFresh(upk *keybase1.UserPlusKeysV2AllIncarnations
 		return false
 	}
 	return true
-}
-
-func LoadHasRandomPw(mctx MetaContext, arg keybase1.LoadHasRandomPwArg) (res bool, err error) {
-	mctx = mctx.WithLogTag("HASRPW")
-	defer mctx.TraceTimed(fmt.Sprintf("User#LoadHasRandomPw(forceRepoll=%t)", arg.ForceRepoll), func() error { return err })()
-
-	currentUID := mctx.CurrentUID()
-	cacheKey := DbKey{
-		Typ: DBHasRandomPW,
-		Key: currentUID.String(),
-	}
-
-	var cachedValue, hasCache bool
-	if !arg.ForceRepoll {
-		if hasCache, err = mctx.G().GetKVStore().GetInto(&cachedValue, cacheKey); err == nil {
-			if hasCache && !cachedValue {
-				mctx.Debug("Returning HasRandomPW=false from KVStore cache")
-				return false, nil
-			}
-			// If it was never cached or user *IS* RandomPW right now, pass through
-			// and call the API.
-		} else {
-			mctx.Debug("Unable to get cached value for HasRandomPW: %v", err)
-		}
-	}
-
-	var initialTimeout time.Duration
-	if !arg.ForceRepoll && !arg.NoShortTimeout {
-		// If we are do not need accurate response from the API server, make
-		// the request with a timeout for quicker overall RPC response time
-		// if network is bad/unavailable.
-		initialTimeout = 3 * time.Second
-	}
-
-	var ret struct {
-		AppStatusEmbed
-		RandomPW bool `json:"random_pw"`
-	}
-	err = mctx.G().API.GetDecode(mctx, APIArg{
-		Endpoint:       "user/has_random_pw",
-		SessionType:    APISessionTypeREQUIRED,
-		InitialTimeout: initialTimeout,
-	}, &ret)
-	if err != nil {
-		if !arg.ForceRepoll {
-			if hasCache {
-				// We are allowed to return cache if we have any.
-				mctx.Warning("Unable to make a network request to has_random_pw. Returning cached value: %t. Error: %s.", cachedValue, err)
-				return cachedValue, nil
-			}
-
-			mctx.Warning("Unable to make a network request to has_random_pw and there is no cache. Erroring out: %s.", err)
-		}
-		return res, err
-	}
-
-	if !hasCache || cachedValue != ret.RandomPW {
-		// Cache current state. If we put `randomPW=false` in the cache, we will never
-		// ever have to call to the network from this device, because it's not possible
-		// to become `randomPW=true` again. If we cache `randomPW=true` we are going to
-		// keep asking the network, but we will be resilient to bad network conditions
-		// because we will have this cached state to fall back on.
-		if err := mctx.G().GetKVStore().PutObj(cacheKey, nil, ret.RandomPW); err == nil {
-			mctx.Debug("Adding HasRandomPW=%t to KVStore", ret.RandomPW)
-		} else {
-			mctx.Debug("Unable to add HasRandomPW state to KVStore")
-		}
-	}
-
-	return ret.RandomPW, err
 }
 
 // PartialCopy copies some fields of the User object, but not all.

--- a/go/libkb/userconfig.go
+++ b/go/libkb/userconfig.go
@@ -24,10 +24,11 @@ func NewNormalizedUsername(s string) NormalizedUsername {
 //==================================================================
 
 type UserConfig struct {
-	ID     string             `json:"id"`
-	Name   NormalizedUsername `json:"name"`
-	Salt   string             `json:"salt"`
-	Device *string            `json:"device"`
+	ID              string                    `json:"id"`
+	Name            NormalizedUsername        `json:"name"`
+	Salt            string                    `json:"salt"`
+	Device          *string                   `json:"device"`
+	PassphraseState *keybase1.PassphraseState `json:"passphrase_state,omitempty"`
 
 	importedID       keybase1.UID
 	importedSalt     []byte
@@ -38,10 +39,11 @@ type UserConfig struct {
 
 //==================================================================
 
-func (u UserConfig) GetUID() keybase1.UID            { return u.importedID }
-func (u UserConfig) GetUsername() NormalizedUsername { return u.Name }
-func (u UserConfig) GetDeviceID() keybase1.DeviceID  { return u.importedDeviceID }
-func (u UserConfig) IsOneshot() bool                 { return u.isOneshot }
+func (u UserConfig) GetUID() keybase1.UID                          { return u.importedID }
+func (u UserConfig) GetUsername() NormalizedUsername               { return u.Name }
+func (u UserConfig) GetDeviceID() keybase1.DeviceID                { return u.importedDeviceID }
+func (u UserConfig) GetPassphraseState() *keybase1.PassphraseState { return u.PassphraseState }
+func (u UserConfig) IsOneshot() bool                               { return u.isOneshot }
 
 //==================================================================
 
@@ -114,6 +116,12 @@ func (u *UserConfig) SetDevice(d keybase1.DeviceID) {
 		s = &tmp
 	}
 	u.Device = s
+}
+
+//==================================================================
+
+func (u *UserConfig) SetPassphraseState(passphraseState keybase1.PassphraseState) {
+	u.PassphraseState = &passphraseState
 }
 
 //==================================================================

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -321,17 +321,43 @@ func (o NextMerkleRootRes) DeepCopy() NextMerkleRootRes {
 	}
 }
 
+type PassphraseState int
+
+const (
+	PassphraseState_KNOWN  PassphraseState = 0
+	PassphraseState_RANDOM PassphraseState = 1
+)
+
+func (o PassphraseState) DeepCopy() PassphraseState { return o }
+
+var PassphraseStateMap = map[string]PassphraseState{
+	"KNOWN":  0,
+	"RANDOM": 1,
+}
+
+var PassphraseStateRevMap = map[PassphraseState]string{
+	0: "KNOWN",
+	1: "RANDOM",
+}
+
+func (e PassphraseState) String() string {
+	if v, ok := PassphraseStateRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type CanLogoutRes struct {
-	CanLogout     bool   `codec:"canLogout" json:"canLogout"`
-	Reason        string `codec:"reason" json:"reason"`
-	SetPassphrase bool   `codec:"setPassphrase" json:"setPassphrase"`
+	CanLogout       bool            `codec:"canLogout" json:"canLogout"`
+	Reason          string          `codec:"reason" json:"reason"`
+	PassphraseState PassphraseState `codec:"passphraseState" json:"passphraseState"`
 }
 
 func (o CanLogoutRes) DeepCopy() CanLogoutRes {
 	return CanLogoutRes{
-		CanLogout:     o.CanLogout,
-		Reason:        o.Reason,
-		SetPassphrase: o.SetPassphrase,
+		CanLogout:       o.CanLogout,
+		Reason:          o.Reason,
+		PassphraseState: o.PassphraseState.DeepCopy(),
 	}
 }
 
@@ -446,14 +472,13 @@ type FindNextMerkleRootAfterResetArg struct {
 	Prev       ResetMerkleRoot `codec:"prev" json:"prev"`
 }
 
-type LoadHasRandomPwArg struct {
-	SessionID      int  `codec:"sessionID" json:"sessionID"`
-	ForceRepoll    bool `codec:"forceRepoll" json:"forceRepoll"`
-	NoShortTimeout bool `codec:"noShortTimeout" json:"noShortTimeout"`
-}
-
 type CanLogoutArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
+}
+
+type LoadPassphraseStateArg struct {
+	SessionID   int  `codec:"sessionID" json:"sessionID"`
+	ForceRepoll bool `codec:"forceRepoll" json:"forceRepoll"`
 }
 
 type UserCardArg struct {
@@ -514,8 +539,8 @@ type UserInterface interface {
 	// at resetSeqno. You should pass it prev, which was the last known Merkle root at the time of
 	// the reset. Usually, we'll just turn up the next Merkle root, but not always.
 	FindNextMerkleRootAfterReset(context.Context, FindNextMerkleRootAfterResetArg) (NextMerkleRootRes, error)
-	LoadHasRandomPw(context.Context, LoadHasRandomPwArg) (bool, error)
 	CanLogout(context.Context, int) (CanLogoutRes, error)
+	LoadPassphraseState(context.Context, LoadPassphraseStateArg) (PassphraseState, error)
 	UserCard(context.Context, UserCardArg) (*UserCard, error)
 	BlockUser(context.Context, string) error
 	UnblockUser(context.Context, string) error
@@ -840,21 +865,6 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 					return
 				},
 			},
-			"loadHasRandomPw": {
-				MakeArg: func() interface{} {
-					var ret [1]LoadHasRandomPwArg
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[1]LoadHasRandomPwArg)
-					if !ok {
-						err = rpc.NewTypeError((*[1]LoadHasRandomPwArg)(nil), args)
-						return
-					}
-					ret, err = i.LoadHasRandomPw(ctx, typedArgs[0])
-					return
-				},
-			},
 			"canLogout": {
 				MakeArg: func() interface{} {
 					var ret [1]CanLogoutArg
@@ -867,6 +877,21 @@ func UserProtocol(i UserInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.CanLogout(ctx, typedArgs[0].SessionID)
+					return
+				},
+			},
+			"loadPassphraseState": {
+				MakeArg: func() interface{} {
+					var ret [1]LoadPassphraseStateArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]LoadPassphraseStateArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]LoadPassphraseStateArg)(nil), args)
+						return
+					}
+					ret, err = i.LoadPassphraseState(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -1056,14 +1081,14 @@ func (c UserClient) FindNextMerkleRootAfterReset(ctx context.Context, __arg Find
 	return
 }
 
-func (c UserClient) LoadHasRandomPw(ctx context.Context, __arg LoadHasRandomPwArg) (res bool, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.user.loadHasRandomPw", []interface{}{__arg}, &res, 0*time.Millisecond)
-	return
-}
-
 func (c UserClient) CanLogout(ctx context.Context, sessionID int) (res CanLogoutRes, err error) {
 	__arg := CanLogoutArg{SessionID: sessionID}
 	err = c.Cli.Call(ctx, "keybase.1.user.canLogout", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c UserClient) LoadPassphraseState(ctx context.Context, __arg LoadPassphraseStateArg) (res PassphraseState, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.user.loadPassphraseState", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/go/protocol/keybase1/user.go
+++ b/go/protocol/keybase1/user.go
@@ -321,6 +321,7 @@ func (o NextMerkleRootRes) DeepCopy() NextMerkleRootRes {
 	}
 }
 
+// PassphraseState values are used in .config.json, so should not be changed without a migration strategy
 type PassphraseState int
 
 const (

--- a/go/service/identify.go
+++ b/go/service/identify.go
@@ -85,7 +85,10 @@ func (h *IdentifyHandler) IdentifyLite(netCtx context.Context, arg keybase1.Iden
 	}
 	servedRet, err := h.service.offlineRPCCache.Serve(mctx, arg.Oa, offline.Version(1), "identify.identifyLite", false, cacheArg, &ret, loader)
 	if err != nil {
-		return servedRet.(keybase1.IdentifyLiteRes), err
+		if s, ok := servedRet.(keybase1.IdentifyLiteRes); ok {
+			ret = s
+		}
+		return ret, err
 	}
 	if s, ok := servedRet.(keybase1.IdentifyLiteRes); ok {
 		ret = s

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -1510,7 +1510,8 @@ func (d *Service) StartStandaloneChat(g *libkb.GlobalContext) error {
 }
 
 func setupRandomPwPrefetcher(g *libkb.GlobalContext) {
-	g.SetHasRandomPWPrefetcher(&libkb.HasRandomPWPrefetcher{})
-	g.AddLoginHook(g.HasRandomPWPrefetcher)
-	g.AddLogoutHook(g.HasRandomPWPrefetcher, "HasRandomPWPrefetcher")
+	prefetcher := &libkb.HasRandomPWPrefetcher{}
+	g.SetHasRandomPWPrefetcher(prefetcher)
+	g.AddLoginHook(prefetcher)
+	g.AddLogoutHook(prefetcher, "HasRandomPWPrefetcher")
 }

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -384,7 +384,7 @@ func (d *Service) RunBackgroundOperations(uir *UIRouter) {
 	// These are all background-ish operations that the service performs.
 	// We should revisit these on mobile, or at least, when mobile apps are
 	// backgrounded.
-	d.G().Log.Warning("RunBackgroundOperations: starting")
+	d.G().Log.Debug("RunBackgroundOperations: starting")
 	ctx := context.Background()
 	setupRandomPwPrefetcher(d.G())
 	d.tryLogin(ctx, loginAttemptOnline)

--- a/go/service/random_pw_test.go
+++ b/go/service/random_pw_test.go
@@ -35,19 +35,19 @@ func TestSignupRandomPWUser(t *testing.T) {
 	require.NoError(t, err)
 
 	userHandler := NewUserHandler(nil, tc.G, nil, nil)
-	ret, err := userHandler.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	ret, err := userHandler.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{})
 	require.NoError(t, err)
-	require.True(t, ret)
+	require.Equal(t, ret, keybase1.PassphraseState_RANDOM)
 
 	// Another call to test the caching
-	ret, err = userHandler.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{})
+	ret, err = userHandler.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{})
 	require.NoError(t, err)
-	require.True(t, ret)
+	require.Equal(t, ret, keybase1.PassphraseState_RANDOM)
 
 	// Another one with ForceRepoll
-	ret, err = userHandler.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{ForceRepoll: true})
+	ret, err = userHandler.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{ForceRepoll: true})
 	require.NoError(t, err)
-	require.True(t, ret)
+	require.Equal(t, ret, keybase1.PassphraseState_RANDOM)
 
 	ret2, err := userHandler.CanLogout(context.Background(), 0)
 	require.NoError(t, err)
@@ -133,7 +133,9 @@ func TestCanLogoutTimeout(t *testing.T) {
 	ret2, err = userHandler.CanLogout(context.Background(), 0)
 	require.NoError(t, err)
 	require.False(t, ret2.CanLogout)
-	require.Contains(t, ret2.Reason, "set a password first")
+	// Since we weren't able to do an API call and prefetch didn't work, we
+	// aren't sure about the state of the passphrase.
+	require.Contains(t, ret2.Reason, "couldn't ensure")
 	require.Equal(t, 3, fakeAPI.callCount)
 
 	// Back to real API because we are going to change passphrase.
@@ -167,13 +169,12 @@ func TestCanLogoutTimeout(t *testing.T) {
 	require.True(t, ret2.CanLogout)
 	require.Equal(t, 0, fakeAPI.callCount) // still 0 calls.
 
-	// Until we try to force repoll
-	_, err = userHandler.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{
+	// Since it's now KNOWN, ForceRepoll has no effect.
+	_, err = userHandler.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{
 		ForceRepoll: true,
 	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "timeout or something")
-	require.Equal(t, 1, fakeAPI.callCount)
+	require.NoError(t, err)
+	require.Equal(t, 0, fakeAPI.callCount)
 }
 
 func TestCanLogoutWhenRevoked(t *testing.T) {

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -574,9 +574,9 @@ func (h *UserHandler) FindNextMerkleRootAfterReset(ctx context.Context, arg keyb
 	return libkb.FindNextMerkleRootAfterReset(m, arg)
 }
 
-func (h *UserHandler) LoadHasRandomPw(ctx context.Context, arg keybase1.LoadHasRandomPwArg) (res bool, err error) {
+func (h *UserHandler) LoadPassphraseState(ctx context.Context, arg keybase1.LoadPassphraseStateArg) (res keybase1.PassphraseState, err error) {
 	m := libkb.NewMetaContext(ctx, h.G())
-	return libkb.LoadHasRandomPw(m, arg)
+	return libkb.LoadPassphraseStateWithForceRepoll(m, arg.ForceRepoll)
 }
 
 func (h *UserHandler) CanLogout(ctx context.Context, sessionID int) (res keybase1.CanLogoutRes, err error) {

--- a/go/service/user_handler.go
+++ b/go/service/user_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/client/go/gregor"
 	"github.com/keybase/client/go/libkb"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 const userHandlerName = "userHandler"
@@ -58,16 +59,8 @@ func (r *userHandler) identityChange(m libkb.MetaContext) error {
 func (r *userHandler) passwordChange(m libkb.MetaContext, cli gregor1.IncomingInterface, category string, item gregor.Item) error {
 	m.Debug("userHandler: %s received", category)
 
-	cacheKey := libkb.DbKey{
-		Typ: libkb.DBHasRandomPW,
-		Key: m.CurrentUID().String(),
-	}
-	hasRandomPW := false
-	if err := m.G().GetKVStore().PutObj(cacheKey, nil, hasRandomPW); err == nil {
-		m.Debug("Adding HasRandomPW=%t to KVStore after %s notification", hasRandomPW, category)
-	} else {
-		m.Debug("Unable to add HasRandomPW state to KVStore after %s notification", category)
-	}
+	// If the passphrase ever changes, it's now known.
+	libkb.MaybeSavePassphraseState(m, keybase1.PassphraseState_KNOWN)
 
 	r.G().NotifyRouter.HandlePasswordChanged(m.Ctx())
 	return r.G().GregorState.DismissItem(m.Ctx(), cli, item.Metadata().MsgID())

--- a/go/systests/user_test.go
+++ b/go/systests/user_test.go
@@ -473,11 +473,11 @@ func TestNoPasswordCliSignup(t *testing.T) {
 	require.Equal(t, expectedPrompts, sui.terminalPrompts)
 
 	ucli := keybase1.UserClient{Cli: user.primaryDevice().rpcClient()}
-	res, err := ucli.LoadHasRandomPw(context.Background(), keybase1.LoadHasRandomPwArg{
+	res, err := ucli.LoadPassphraseState(context.Background(), keybase1.LoadPassphraseStateArg{
 		ForceRepoll: true,
 	})
 	require.NoError(t, err)
-	require.True(t, res)
+	require.Equal(t, res, keybase1.PassphraseState_RANDOM)
 
 	err = G.ConfigureConfig()
 	require.NoError(t, err)

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -179,14 +179,19 @@ protocol user {
   */
   NextMerkleRootRes findNextMerkleRootAfterReset(UID uid, Seqno resetSeqno, ResetMerkleRoot prev);
 
-  boolean loadHasRandomPw(int sessionID, boolean forceRepoll, boolean noShortTimeout);
+  enum PassphraseState {
+    KNOWN_0,
+    RANDOM_1
+  }
 
   record CanLogoutRes {
     boolean canLogout;
-    string reason; // CLI prints this string.
-    boolean setPassphrase; // GUI is driven by this boolean.
+    string reason;
+    PassphraseState passphraseState;
   }
   CanLogoutRes canLogout(int sessionID);
+
+  PassphraseState loadPassphraseState(int sessionID, boolean forceRepoll);
 
   union { null, UserCard } userCard(int sessionID, string username, boolean useSession);
 

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -179,6 +179,9 @@ protocol user {
   */
   NextMerkleRootRes findNextMerkleRootAfterReset(UID uid, Seqno resetSeqno, ResetMerkleRoot prev);
 
+  /**
+   PassphraseState values are used in .config.json, so should not be changed without a migration strategy
+  */
   enum PassphraseState {
     KNOWN_0,
     RANDOM_1

--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -254,7 +254,7 @@
   "keybase.1.user.canLogout": {"promise": true},
   "keybase.1.user.interestingPeople": {"promise": true},
   "keybase.1.user.listTrackers2": {"promise": true},
-  "keybase.1.user.loadHasRandomPw": {"promise": true},
+  "keybase.1.user.loadPassphraseState": {"promise": true},
   "keybase.1.user.loadMySettings": {"promise": true},
   "keybase.1.user.profileEdit": {"promise": true},
   "keybase.1.user.proofSuggestions": {"promise": true},

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -310,6 +310,14 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "PassphraseState",
+      "symbols": [
+        "KNOWN_0",
+        "RANDOM_1"
+      ]
+    },
+    {
       "type": "record",
       "name": "CanLogoutRes",
       "fields": [
@@ -322,8 +330,8 @@
           "name": "reason"
         },
         {
-          "type": "boolean",
-          "name": "setPassphrase"
+          "type": "PassphraseState",
+          "name": "passphraseState"
         }
       ]
     }
@@ -664,23 +672,6 @@
       "response": "NextMerkleRootRes",
       "doc": "FindNextMerkleRootAfterReset finds the first Merkle root that contains the UID reset\n   at resetSeqno. You should pass it prev, which was the last known Merkle root at the time of\n   the reset. Usually, we'll just turn up the next Merkle root, but not always."
     },
-    "loadHasRandomPw": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        },
-        {
-          "name": "forceRepoll",
-          "type": "boolean"
-        },
-        {
-          "name": "noShortTimeout",
-          "type": "boolean"
-        }
-      ],
-      "response": "boolean"
-    },
     "canLogout": {
       "request": [
         {
@@ -689,6 +680,19 @@
         }
       ],
       "response": "CanLogoutRes"
+    },
+    "loadPassphraseState": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "forceRepoll",
+          "type": "boolean"
+        }
+      ],
+      "response": "PassphraseState"
     },
     "userCard": {
       "request": [

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -315,7 +315,8 @@
       "symbols": [
         "KNOWN_0",
         "RANDOM_1"
-      ]
+      ],
+      "doc": "PassphraseState values are used in .config.json, so should not be changed without a migration strategy"
     },
     {
       "type": "record",

--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -603,7 +603,8 @@ const loadHasRandomPW = async (state: TypedState) => {
     return false
   }
   try {
-    const randomPW = await RPCTypes.userLoadHasRandomPwRpcPromise({forceRepoll: false, noShortTimeout: false})
+    const passphraseState = await RPCTypes.userLoadPassphraseStateRpcPromise({forceRepoll: false})
+    const randomPW = passphraseState === RPCTypes.PassphraseState.random
     return SettingsGen.createLoadedHasRandomPw({randomPW})
   } catch (e) {
     logger.warn('Error loading hasRandomPW:', e.message)

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1311,10 +1311,6 @@ export type MessageTypes = {
     inParam: {readonly assertion: String; readonly reverse: Boolean}
     outParam: UserSummary2Set
   }
-  'keybase.1.user.loadHasRandomPw': {
-    inParam: {readonly forceRepoll: Boolean; readonly noShortTimeout: Boolean}
-    outParam: Boolean
-  }
   'keybase.1.user.loadMySettings': {
     inParam: void
     outParam: UserSettings
@@ -1752,6 +1748,11 @@ export enum PTKType {
 
 export enum PassphraseRecoveryPromptType {
   encryptedPgpKeys = 0,
+}
+
+export enum PassphraseState {
+  known = 0,
+  random = 1,
 }
 
 export enum PassphraseType {
@@ -2392,7 +2393,7 @@ export type BoxPublicKey = string | null
 export type BoxSummaryHash = String
 export type BulkRes = {readonly invited?: Array<String> | null; readonly alreadyInvited?: Array<String> | null; readonly malformed?: Array<String> | null}
 export type Bytes32 = string | null
-export type CanLogoutRes = {readonly canLogout: Boolean; readonly reason: String; readonly setPassphrase: Boolean}
+export type CanLogoutRes = {readonly canLogout: Boolean; readonly reason: String; readonly passphraseState: PassphraseState}
 export type CanonicalTLFNameAndIDWithBreaks = {readonly tlfID: TLFID; readonly CanonicalName: CanonicalTlfName; readonly breaks: TLFBreak}
 export type CanonicalTlfName = String
 export type ChallengeInfo = {readonly now: Long; readonly challenge: String}
@@ -3322,7 +3323,6 @@ export const userBlockUserRpcPromise = (params: MessageTypes['keybase.1.user.blo
 export const userCanLogoutRpcPromise = (params: MessageTypes['keybase.1.user.canLogout']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.canLogout']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.canLogout', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userInterestingPeopleRpcPromise = (params: MessageTypes['keybase.1.user.interestingPeople']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.interestingPeople']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.interestingPeople', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userListTrackers2RpcPromise = (params: MessageTypes['keybase.1.user.listTrackers2']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.listTrackers2']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.listTrackers2', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
-export const userLoadHasRandomPwRpcPromise = (params: MessageTypes['keybase.1.user.loadHasRandomPw']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.loadHasRandomPw']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.loadHasRandomPw', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userLoadMySettingsRpcPromise = (params: MessageTypes['keybase.1.user.loadMySettings']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.loadMySettings']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.loadMySettings', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userProfileEditRpcPromise = (params: MessageTypes['keybase.1.user.profileEdit']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.profileEdit']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.profileEdit', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userProofSuggestionsRpcPromise = (params: MessageTypes['keybase.1.user.proofSuggestions']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.proofSuggestions']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.proofSuggestions', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -3715,4 +3715,5 @@ export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.u
 // 'keybase.1.user.getUPAKLite'
 // 'keybase.1.user.findNextMerkleRootAfterRevoke'
 // 'keybase.1.user.findNextMerkleRootAfterReset'
+// 'keybase.1.user.loadPassphraseState'
 // 'keybase.1.user.userCard'

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1315,6 +1315,10 @@ export type MessageTypes = {
     inParam: void
     outParam: UserSettings
   }
+  'keybase.1.user.loadPassphraseState': {
+    inParam: {readonly forceRepoll: Boolean}
+    outParam: PassphraseState
+  }
   'keybase.1.user.profileEdit': {
     inParam: {readonly fullName: String; readonly location: String; readonly bio: String}
     outParam: void
@@ -3324,6 +3328,7 @@ export const userCanLogoutRpcPromise = (params: MessageTypes['keybase.1.user.can
 export const userInterestingPeopleRpcPromise = (params: MessageTypes['keybase.1.user.interestingPeople']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.interestingPeople']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.interestingPeople', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userListTrackers2RpcPromise = (params: MessageTypes['keybase.1.user.listTrackers2']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.listTrackers2']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.listTrackers2', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userLoadMySettingsRpcPromise = (params: MessageTypes['keybase.1.user.loadMySettings']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.loadMySettings']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.loadMySettings', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const userLoadPassphraseStateRpcPromise = (params: MessageTypes['keybase.1.user.loadPassphraseState']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.loadPassphraseState']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.loadPassphraseState', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userProfileEditRpcPromise = (params: MessageTypes['keybase.1.user.profileEdit']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.profileEdit']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.profileEdit', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userProofSuggestionsRpcPromise = (params: MessageTypes['keybase.1.user.proofSuggestions']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.proofSuggestions']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.proofSuggestions', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userSearchGetNonUserDetailsRpcPromise = (params: MessageTypes['keybase.1.userSearch.getNonUserDetails']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.userSearch.getNonUserDetails']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.userSearch.getNonUserDetails', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -3715,5 +3720,4 @@ export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.u
 // 'keybase.1.user.getUPAKLite'
 // 'keybase.1.user.findNextMerkleRootAfterRevoke'
 // 'keybase.1.user.findNextMerkleRootAfterReset'
-// 'keybase.1.user.loadPassphraseState'
 // 'keybase.1.user.userCard'


### PR DESCRIPTION
This PR
* Move "hasRandomPw" bool to `keybase1.PassphraseState` enum everywhere
* Introduce a store in config.json and handle migrations from leveldb and updates from remote
* Update store when receiving a gregor notification that the passphrase has changed
* Calls to CanLogout no longer force a poll to remote even if passphrase is unset, hoping the gregor notification keeps us updated
* Tweak background prefetcher of passphrase state in service


TODO
- [x] Audit calls to loadhasrandompw