### PR TITLE
Render spinner for infopanel when no conversation id

### DIFF
--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -260,6 +260,19 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
     let tabsSection = this._tabsSection()
     sections.push(this._headerSection())
     let itemSizeEstimator
+    if (!this.props.selectedConversationIDKey) {
+      // if we dont have a valid conversation ID, just render a spinner
+      return (
+        <Kb.Box2
+          direction="vertical"
+          style={Styles.collapseStyles([styles.container, {alignItems: 'center'}])}
+          fullWidth={true}
+          centerChildren
+        >
+          <Kb.ProgressIndicator type="Large" />
+        </Kb.Box2>
+      )
+    }
     switch (this.props.selectedTab) {
       case 'settings':
         tabsSection.renderItem = () => {

--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -267,7 +267,7 @@ class _InfoPanel extends React.Component<InfoPanelProps> {
           direction="vertical"
           style={Styles.collapseStyles([styles.container, {alignItems: 'center'}])}
           fullWidth={true}
-          centerChildren
+          centerChildren={true}
         >
           <Kb.ProgressIndicator type="Large" />
         </Kb.Box2>


### PR DESCRIPTION
Some people were experiencing a race condition where the info panel would load without a conversation id and throw errors. This PR adds an extra check for that and renders a spinner if the infopanel doesn't have an id key.

@keybase/hotpotatosquad @keybase/react-hackers 