### PR TITLE
add copy button to withReveal CopyText

### DIFF
--- a/shared/common-adapters/copy-text.stories.tsx
+++ b/shared/common-adapters/copy-text.stories.tsx
@@ -42,6 +42,10 @@ const load = () => {
         withReveal={true}
       />
     ))
+    .add('With loadText', () => (
+      <CopyText placeholderText="please wait..." loadText={Sb.action('loadText')} />
+    ))
+    .add('With loadText + reveal', () => <CopyText withReveal={true} loadText={Sb.action('loadText')} />)
 }
 
 export default load

--- a/shared/common-adapters/copy-text.tsx
+++ b/shared/common-adapters/copy-text.tsx
@@ -17,12 +17,15 @@ type Props = {
   hideOnCopy?: boolean
   onReveal?: () => void
   withReveal?: boolean
-  text: string
+  text?: string
+  placeholderText?: string
+  loadText?: () => void
 }
 
 const CopyText = (props: Props) => {
   const [revealed, setRevealed] = React.useState(!props.withReveal)
   const [showingToast, setShowingToast] = React.useState(false)
+  const [requestedCopy, setRequestedCopy] = React.useState(false)
 
   const setShowingToastFalseLater = useTimeout(() => setShowingToast(false), 1500)
   React.useEffect(() => {
@@ -34,19 +37,44 @@ const CopyText = (props: Props) => {
 
   const dispatch = Container.useDispatch()
   const copyToClipboard = (text: string) => dispatch(ConfigGen.createCopyToClipboard({text}))
+
   const copy = () => {
-    if (props.withReveal && !revealed) {
-      reveal()
-    }
-    setShowingToast(true)
-    textRef.current && textRef.current.highlightText()
-    copyToClipboard(props.text)
-    props.onCopy && props.onCopy()
-    if (props.hideOnCopy) {
-      setRevealed(false)
+    if (!props.text) {
+      if (!props.loadText) {
+        throw new Error('no text to copy and no loadText method provided')
+        return
+      }
+      setRequestedCopy(true)
+    } else {
+      setShowingToast(true)
+      textRef.current && textRef.current.highlightText()
+      copyToClipboard(props.text)
+      props.onCopy && props.onCopy()
+      if (props.hideOnCopy) {
+        setRevealed(false)
+      }
     }
   }
+
+  React.useEffect(() => {
+    if (requestedCopy && props.loadText) {
+      // we're requesting a copy
+      if (!props.text) {
+        // no text has been loaded
+        props.loadText()
+      } else {
+        // we want to copy something + have something to copy
+        copy() // props.text exists so this will not cause a recursive loop
+        setRequestedCopy(false)
+      }
+    }
+  }, [requestedCopy, props.text])
+
   const reveal = () => {
+    if (!props.text && props.loadText) {
+      // if we don't have text to copy we should load it
+      props.loadText()
+    }
     props.onReveal && props.onReveal()
     setRevealed(true)
   }
@@ -80,7 +108,9 @@ const CopyText = (props: Props) => {
         allowHighlightText={true}
         ref={textRef}
       >
-        {isRevealed ? props.text : '••••••••••••'}
+        {isRevealed && (props.text || props.placeholderText)
+          ? props.text || props.placeholderText
+          : '••••••••••••'}
       </Text>
       {!isRevealed && (
         <Text type="BodySmallPrimaryLink" style={styles.reveal} onClick={reveal}>

--- a/shared/common-adapters/copy-text.tsx
+++ b/shared/common-adapters/copy-text.tsx
@@ -35,6 +35,9 @@ const CopyText = (props: Props) => {
   const dispatch = Container.useDispatch()
   const copyToClipboard = (text: string) => dispatch(ConfigGen.createCopyToClipboard({text}))
   const copy = () => {
+    if (props.withReveal && !revealed) {
+      reveal()
+    }
     setShowingToast(true)
     textRef.current && textRef.current.highlightText()
     copyToClipboard(props.text)
@@ -84,16 +87,14 @@ const CopyText = (props: Props) => {
           Reveal
         </Text>
       )}
-      {isRevealed && (
-        <Button
-          type={props.buttonType || 'Default'}
-          style={styles.button}
-          onClick={copy}
-          labelContainerStyle={styles.buttonLabelContainer}
-        >
-          <Icon type="iconfont-clipboard" color={Styles.globalColors.white} sizeType="Small" />
-        </Button>
-      )}
+      <Button
+        type={props.buttonType || 'Default'}
+        style={styles.button}
+        onClick={copy}
+        labelContainerStyle={styles.buttonLabelContainer}
+      >
+        <Icon type="iconfont-clipboard" color={Styles.globalColors.white} sizeType="Small" />
+      </Button>
     </Box2>
   )
 }

--- a/shared/common-adapters/copy-text.tsx
+++ b/shared/common-adapters/copy-text.tsx
@@ -26,11 +26,20 @@ const CopyText = (props: Props) => {
   const [revealed, setRevealed] = React.useState(!props.withReveal)
   const [showingToast, setShowingToast] = React.useState(false)
   const [requestedCopy, setRequestedCopy] = React.useState(false)
-
   const setShowingToastFalseLater = useTimeout(() => setShowingToast(false), 1500)
   React.useEffect(() => {
     showingToast && setShowingToastFalseLater()
   }, [showingToast, setShowingToastFalseLater])
+
+  React.useEffect(() => {
+    if (!props.withReveal && !props.text) {
+      // only try to load text if withReveal is false
+      if (!props.loadText) {
+        throw new Error('no loadText method provided')
+      }
+      props.loadText()
+    }
+  }, []) // only run this effect once, on first render
 
   const attachmentRef = React.useRef<Box2>(null)
   const textRef = React.useRef<Text>(null)
@@ -86,6 +95,7 @@ const CopyText = (props: Props) => {
     : isRevealed
     ? 1
     : null
+
   return (
     <Box2
       ref={attachmentRef}

--- a/shared/common-adapters/copy-text.tsx
+++ b/shared/common-adapters/copy-text.tsx
@@ -42,7 +42,6 @@ const CopyText = (props: Props) => {
     if (!props.text) {
       if (!props.loadText) {
         throw new Error('no text to copy and no loadText method provided')
-        return
       }
       setRequestedCopy(true)
     } else {

--- a/shared/wallets/wallet/settings/index.tsx
+++ b/shared/wallets/wallet/settings/index.tsx
@@ -141,10 +141,11 @@ class AccountSettings extends React.Component<SettingsProps> {
                       containerStyle={styles.copyTextContainer}
                       multiline={true}
                       withReveal={true}
-                      onReveal={() => this.props.onLoadSecretKey && this.props.onLoadSecretKey()}
+                      loadText={() => this.props.onLoadSecretKey && this.props.onLoadSecretKey()}
                       hideOnCopy={true}
                       onCopy={this.clearKey}
-                      text={this.props.secretKey || 'fetching and decrypting secret key...'}
+                      text={this.props.secretKey}
+                      placeholderText="fetching and decrypting secret key..."
                     />
                   </Kb.Box2>
                 </>


### PR DESCRIPTION
brings the CopyText component back into spec by adding the copy button to components with the `withReveal` prop. 

@keybase/react-hackers @keybase/hotpotatosquad 