### PR TITLE
fix teambot nonfatal errors

### DIFF
--- a/go/ephemeral/teambot_ek.go
+++ b/go/ephemeral/teambot_ek.go
@@ -49,7 +49,7 @@ func (k *TeambotEphemeralKeyer) Type() keybase1.TeamEphemeralKeyType {
 
 func publishNewTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID, botUID keybase1.UID,
 	teamEK keybase1.TeamEk, merkleRoot libkb.MerkleRoot) (metadata keybase1.TeambotEkMetadata, err error) {
-	defer mctx.TraceTimed("publishNewTeambotEK", func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("publishNewTeambotEK teamID: %v, botUID %v", teamID, botUID), func() error { return err })()
 
 	team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
 		ID: teamID,

--- a/go/service/teambot_handler.go
+++ b/go/service/teambot_handler.go
@@ -83,9 +83,9 @@ func (r *teambotHandler) teambotKeyNeeded(ctx context.Context, cli gregor1.Incom
 	r.G().Log.CDebugf(ctx, "teambot.teambot_key_needed unmarshaled: %+v", msg)
 
 	if err := teambot.HandleTeambotKeyNeeded(r.MetaContext(ctx), msg.Id, msg.Uid, msg.Generation); err != nil {
-		return err
+		r.G().Log.CDebugf(ctx, "teambot.teambot_key_needed unable to make new key: %v", err)
 	}
 
-	r.G().Log.CDebugf(ctx, "dismissing teambot.teambot_key_needed item since action succeeded")
+	r.G().Log.CDebugf(ctx, "dismissing teambot.teambot_key_needed item")
 	return r.G().GregorState.DismissItem(ctx, cli, item.Metadata().MsgID())
 }

--- a/go/teambot/bot_keyer.go
+++ b/go/teambot/bot_keyer.go
@@ -124,7 +124,8 @@ func (k *BotKeyer) getFromStorage(mctx libkb.MetaContext, teamID keybase1.TeamID
 	dbKey := k.dbKey(boxKey)
 	found, err = k.edb.Get(mctx.Ctx(), dbKey, &key)
 	if err != nil {
-		return key, false, err
+		mctx.Debug("Unable to fetch from disk err: %v", err)
+		return keybase1.TeambotKey{}, false, nil
 	}
 	if !found {
 		return keybase1.TeambotKey{}, false, nil

--- a/go/teambot/member_keyer.go
+++ b/go/teambot/member_keyer.go
@@ -98,7 +98,7 @@ func (k *MemberKeyer) GetOrCreateTeambotKey(mctx libkb.MetaContext, teamID keyba
 func (k *MemberKeyer) getOrCreateTeambotKeyLocked(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	botUID keybase1.UID, appKey keybase1.TeamApplicationKey) (
 	key keybase1.TeambotKey, created bool, err error) {
-	defer mctx.TraceTimed("getOrCreateTeambotKeyLocked", func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("getOrCreateTeambotKeyLocked: teamID: %v, botUID: %v", teamID, botUID), func() error { return err })()
 
 	seed := k.deriveTeambotKeyFromAppKey(mctx, appKey, botUID)
 
@@ -143,7 +143,7 @@ func (k *MemberKeyer) deriveTeambotKeyFromAppKey(mctx libkb.MetaContext, applica
 
 func (k *MemberKeyer) publishNewTeambotKey(mctx libkb.MetaContext, teamID keybase1.TeamID, botUID keybase1.UID,
 	appKey keybase1.TeamApplicationKey) (metadata keybase1.TeambotKeyMetadata, err error) {
-	defer mctx.TraceTimed("MemberKeyer#publishNewTeambotKey", func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("MemberKeyer#publishNewTeambotKey teamID: %v, botUID: %v", teamID, botUID), func() error { return err })()
 
 	team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
 		ID: teamID,
@@ -186,7 +186,7 @@ func (k *MemberKeyer) postNewTeambotKey(mctx libkb.MetaContext, teamID keybase1.
 func (k *MemberKeyer) prepareNewTeambotKey(mctx libkb.MetaContext, team *teams.Team,
 	botUID keybase1.UID, appKey keybase1.TeamApplicationKey) (
 	sig string, box *keybase1.TeambotKeyBoxed, err error) {
-	defer mctx.TraceTimed("MemberKeyer#prepareNewTeambotKey", func() error { return err })()
+	defer mctx.TraceTimed(fmt.Sprintf("MemberKeyer#prepareNewTeambotKey: teamID: %v, botUID: %v", team.ID, botUID), func() error { return err })()
 
 	upak, _, err := mctx.G().GetUPAKLoader().LoadV2(
 		libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(botUID))


### PR DESCRIPTION
- treat unable to decrypt cached key from disk as a miss
- dismiss new key needed on failure