### PR TITLE
PICNIC-163 - Force chat input height to match content-area

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -445,12 +445,12 @@ const styles = Styles.styleSheetCreate(
       },
       input: {
         backgroundColor: Styles.globalColors.transparent,
-        height: 21,
+        height: 22,
         // Line height change is so that emojis (unicode characters inside
         // textarea) are not clipped at the top. This change is accompanied by
         // a change in padding to offset the increased line height
         lineHeight: '22px',
-        minHeight: 21,
+        minHeight: 22,
       },
       inputBox: {
         flex: 1,


### PR DESCRIPTION
This is a fix that solves a scrollbar issue on Linux.
Turns out that on macOS, the height of the `textarea` will be resized from `21` to `22` px to accommodate `line-height: 22px`.
This is not the case on Linux, and as a result a scrollbar is shown.

![2019-09-27-090828_1924x146_scrot](https://user-images.githubusercontent.com/5200812/65780376-9ada3580-e117-11e9-8981-e906f6a73d6d.png)
 