### PR TITLE
init to keys background color to avoid flashing in dark/light mode

### DIFF
--- a/shared/ios/Keybase/AppDelegate.m
+++ b/shared/ios/Keybase/AppDelegate.m
@@ -74,7 +74,7 @@
   AppearanceRootView *rootView = [[AppearanceRootView alloc] initWithBridge:bridge
                                                    moduleName:@"Keybase"
                                             initialProperties:nil];
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:71/255.0f green:139/255.f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];


### PR DESCRIPTION
instead of flashing white we just keep the blue background color for the keys