### PR TITLE
Always return an error if Go didn't handle the message

### DIFF
--- a/go/bind/notifications.go
+++ b/go/bind/notifications.go
@@ -82,7 +82,7 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 	displayPlaintext bool, intMessageID int, pushID string, badgeCount, unixTime int, soundName string,
 	pusher PushNotifier) (err error) {
 	if err := waitForInit(5 * time.Second); err != nil {
-		return nil
+		return err
 	}
 	gc := globals.NewContext(kbCtx, kbChatCtx)
 	ctx := globals.ChatCtx(context.Background(), gc,
@@ -170,7 +170,7 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 		// and we don't want to accidentally ack the plaintext notification when we didn't really
 		// display it.
 		if len(serverMessageBody) == 0 {
-			return nil
+			return errors.New("Unbox failed; nothing to display")
 		}
 	}
 

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -180,14 +180,20 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
                     boolean dontNotify = (type.equals("chat.newmessageSilent_2") && !n.displayPlaintext);
 
                     notifier.setMsgCache(msgCache.get(n.convID));
-                    WithBackgroundActive withBackgroundActive = () -> Keybase.handleBackgroundNotification(n.convID, payload, n.serverMessageBody, n.sender,
+                    WithBackgroundActive withBackgroundActive = () -> {
+                      try {
+                          Keybase.handleBackgroundNotification(n.convID, payload, n.serverMessageBody, n.sender,
                             n.membersType, n.displayPlaintext, n.messageId, n.pushId,
                             n.badgeCount, n.unixTime, n.soundName, dontNotify ? null : notifier);
+                          if (!dontNotify) {
+                              seenChatNotifications.add(n.convID + n.messageId);
+                          }
+                      } catch (Exception ex) {
+                        NativeLogger.error("Go Couldn't handle background notification: " + ex.getMessage());
+                      }
+                    };
                     withBackgroundActive.whileActive(getApplicationContext());
 
-                    if (!dontNotify) {
-                        seenChatNotifications.add(n.convID + n.messageId);
-                    }
                 }
                 break;
                 case "follow": {

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -184,7 +184,7 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
                       try {
                           Keybase.handleBackgroundNotification(n.convID, payload, n.serverMessageBody, n.sender,
                             n.membersType, n.displayPlaintext, n.messageId, n.pushId,
-                            n.badgeCount, n.unixTime, n.soundName, dontNotify ? null : notifier);
+                            n.badgeCount, n.unixTime, n.soundName, dontNotify ? null : notifier, true);
                           if (!dontNotify) {
                               seenChatNotifications.add(n.convID + n.messageId);
                           }

--- a/shared/ios/Keybase/AppDelegate.m
+++ b/shared/ios/Keybase/AppDelegate.m
@@ -155,7 +155,7 @@
       // This always tries to unbox the notification and adds a plaintext
       // notification if displayPlaintext is set.
       KeybaseHandleBackgroundNotification(convID, body, @"", sender, membersType, displayPlaintext,
-            messageID, pushID, badgeCount, unixTime, soundName, pusher, &err);
+            messageID, pushID, badgeCount, unixTime, soundName, pusher, false, &err);
       if (err != nil) {
         NSLog(@"Failed to handle in engine: %@", err);
       }
@@ -168,7 +168,7 @@
       NSString* convID = notification[@"convID"];
       int messageID = [notification[@"msgID"] intValue];
       KeybaseHandleBackgroundNotification(convID, body, @"", sender, membersType, displayPlaintext,
-                                          messageID, @"", badgeCount, unixTime, soundName, nil, &err);
+                                          messageID, @"", badgeCount, unixTime, soundName, nil, false, &err);
       if (err != nil) {
         NSLog(@"Failed to handle in engine: %@", err);
       }


### PR DESCRIPTION
@mmaxim / @jzila 

I think it was possible if the unbox failed that we would drop the notification. This was because we didn't return an error even though the go side didn't handle it.

I changed it so all flows return an error if it failed to display the notification. This way Java knows if Go called the notification and it should mark the notification as seen.

(aside, the seenNotification deduping logic should probably be moved to the go side)