### PR TITLE
folder_branch_ops: include `RootBlockID` in the update history

### DIFF
--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -176,11 +176,12 @@ type OpSummary struct {
 
 // UpdateSummary describes the operations done by a single MD revision.
 type UpdateSummary struct {
-	Revision  kbfsmd.Revision
-	Date      time.Time
-	Writer    string
-	LiveBytes uint64 // the "DiskUsage" for the TLF as of this revision
-	Ops       []OpSummary
+	Revision    kbfsmd.Revision
+	Date        time.Time
+	Writer      string
+	LiveBytes   uint64 // the "DiskUsage" for the TLF as of this revision
+	Ops         []OpSummary
+	RootBlockID string
 }
 
 // TLFUpdateHistory gives all the summaries of all updates in a TLF's

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -8590,11 +8590,12 @@ func (fbo *folderBranchOps) GetUpdateHistory(
 			writerNames[rmd.LastModifyingWriter()] = writer
 		}
 		updateSummary := UpdateSummary{
-			Revision:  rmd.Revision(),
-			Date:      rmd.localTimestamp,
-			Writer:    writer,
-			LiveBytes: rmd.DiskUsage(),
-			Ops:       make([]OpSummary, 0, len(rmd.data.Changes.Ops)),
+			Revision:    rmd.Revision(),
+			Date:        rmd.localTimestamp,
+			Writer:      writer,
+			LiveBytes:   rmd.DiskUsage(),
+			Ops:         make([]OpSummary, 0, len(rmd.data.Changes.Ops)),
+			RootBlockID: rmd.data.Dir.ID.String(),
 		}
 		for _, op := range rmd.data.Changes.Ops {
 			opSummary := OpSummary{


### PR DESCRIPTION
The root block ID is important when debugging bad updates.

Issue: HOTPOT-812