### PR TITLE
Maybe fix dropped android notifs – 2

### DIFF
--- a/go/bind/notifications.go
+++ b/go/bind/notifications.go
@@ -80,7 +80,7 @@ func HandlePostTextReply(strConvID, tlfName string, intMessageID int, body strin
 
 func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender string, intMembersType int,
 	displayPlaintext bool, intMessageID int, pushID string, badgeCount, unixTime int, soundName string,
-	pusher PushNotifier, dontShowIfStale bool) (err error) {
+	pusher PushNotifier, showIfStale bool) (err error) {
 	if err := waitForInit(10 * time.Second); err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 	// can come later and cause duplicate notifications. On Android, both silent
 	// and non-silent notifications go through this function; and Java checks if we
 	// have already seen a notification. We don't need this stale logic.
-	if dontShowIfStale && age >= 2*time.Minute {
+	if !showIfStale && age >= 2*time.Minute {
 		kbCtx.Log.CDebugf(ctx, "HandleBackgroundNotification: stale notification: %v", age)
 		return errors.New("stale notification")
 	}

--- a/go/bind/notifications.go
+++ b/go/bind/notifications.go
@@ -80,8 +80,8 @@ func HandlePostTextReply(strConvID, tlfName string, intMessageID int, body strin
 
 func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender string, intMembersType int,
 	displayPlaintext bool, intMessageID int, pushID string, badgeCount, unixTime int, soundName string,
-	pusher PushNotifier) (err error) {
-	if err := waitForInit(5 * time.Second); err != nil {
+	pusher PushNotifier, dontShowIfStale bool) (err error) {
+	if err := waitForInit(10 * time.Second); err != nil {
 		return err
 	}
 	gc := globals.NewContext(kbCtx, kbChatCtx)
@@ -175,7 +175,12 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 	}
 
 	age := time.Since(time.Unix(int64(unixTime), 0))
-	if age >= 2*time.Minute {
+
+	// On iOS we don't want to show stale notifications. Nonsilent notifications
+	// can come later and cause duplicate notifications. On Android, both silent
+	// and non-silent notifications go through this function; and Java checks if we
+	// have already seen a notification. We don't need this stale logic.
+	if dontShowIfStale && age >= 2*time.Minute {
 		kbCtx.Log.CDebugf(ctx, "HandleBackgroundNotification: stale notification: %v", age)
 		return errors.New("stale notification")
 	}

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -184,7 +184,7 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
                       try {
                           Keybase.handleBackgroundNotification(n.convID, payload, n.serverMessageBody, n.sender,
                             n.membersType, n.displayPlaintext, n.messageId, n.pushId,
-                            n.badgeCount, n.unixTime, n.soundName, dontNotify ? null : notifier);
+                            n.badgeCount, n.unixTime, n.soundName, dontNotify ? null : notifier, false);
                           if (!dontNotify) {
                               seenChatNotifications.add(n.convID + n.messageId);
                           }

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.java
@@ -184,7 +184,7 @@ public class KeybasePushNotificationListenerService extends FirebaseMessagingSer
                       try {
                           Keybase.handleBackgroundNotification(n.convID, payload, n.serverMessageBody, n.sender,
                             n.membersType, n.displayPlaintext, n.messageId, n.pushId,
-                            n.badgeCount, n.unixTime, n.soundName, dontNotify ? null : notifier, false);
+                            n.badgeCount, n.unixTime, n.soundName, dontNotify ? null : notifier, true);
                           if (!dontNotify) {
                               seenChatNotifications.add(n.convID + n.messageId);
                           }

--- a/shared/ios/Keybase/AppDelegate.m
+++ b/shared/ios/Keybase/AppDelegate.m
@@ -155,7 +155,7 @@
       // This always tries to unbox the notification and adds a plaintext
       // notification if displayPlaintext is set.
       KeybaseHandleBackgroundNotification(convID, body, @"", sender, membersType, displayPlaintext,
-            messageID, pushID, badgeCount, unixTime, soundName, pusher, true, &err);
+            messageID, pushID, badgeCount, unixTime, soundName, pusher, false, &err);
       if (err != nil) {
         NSLog(@"Failed to handle in engine: %@", err);
       }
@@ -168,7 +168,7 @@
       NSString* convID = notification[@"convID"];
       int messageID = [notification[@"msgID"] intValue];
       KeybaseHandleBackgroundNotification(convID, body, @"", sender, membersType, displayPlaintext,
-                                          messageID, @"", badgeCount, unixTime, soundName, nil, true, &err);
+                                          messageID, @"", badgeCount, unixTime, soundName, nil, false, &err);
       if (err != nil) {
         NSLog(@"Failed to handle in engine: %@", err);
       }

--- a/shared/ios/Keybase/AppDelegate.m
+++ b/shared/ios/Keybase/AppDelegate.m
@@ -155,7 +155,7 @@
       // This always tries to unbox the notification and adds a plaintext
       // notification if displayPlaintext is set.
       KeybaseHandleBackgroundNotification(convID, body, @"", sender, membersType, displayPlaintext,
-            messageID, pushID, badgeCount, unixTime, soundName, pusher, &err);
+            messageID, pushID, badgeCount, unixTime, soundName, pusher, true, &err);
       if (err != nil) {
         NSLog(@"Failed to handle in engine: %@", err);
       }
@@ -168,7 +168,7 @@
       NSString* convID = notification[@"convID"];
       int messageID = [notification[@"msgID"] intValue];
       KeybaseHandleBackgroundNotification(convID, body, @"", sender, membersType, displayPlaintext,
-                                          messageID, @"", badgeCount, unixTime, soundName, nil, &err);
+                                          messageID, @"", badgeCount, unixTime, soundName, nil, true, &err);
       if (err != nil) {
         NSLog(@"Failed to handle in engine: %@", err);
       }


### PR DESCRIPTION
@keybase/react-hackers @jzila @mmaxim @joshblum 

On Android, `HandleBackgroundNotification` is the **only** thing that will
lead to a notification. It's possible that both the silent and nonsilent
notifications are stale–Say if you haven't had an internet connection
or Android/Google delays the notification.

The reason the code was like this is because on iOS the notification
works differently. It's possible the silent notif was delayed, and the
OS already showed the nonsilent version. In that case we do a staleness
check to make sure we don't show duplicate notifications.

On Android, duplicate notifications isn't a problem. We check in the
Java code wheter we have already seen a notification for that
conversation and message. We can safely ignore the stale logic on
Android.

I tested by having the device be offline while I sent it messages. I Waited a while, and brought it online. It successfully showed those notifications. In the previous version, those notifs would be dropped.