### PR TITLE
folder_branch_ops: unwind ptr/head changes on failed fast-forward

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -7587,18 +7587,16 @@ func (fbo *folderBranchOps) runUnlessShutdown(fn func(ctx context.Context) error
 }
 
 func (fbo *folderBranchOps) doFastForwardLocked(ctx context.Context,
-	lState *kbfssync.LockState, currHead ImmutableRootMetadata) error {
+	lState *kbfssync.LockState, currHead ImmutableRootMetadata) (err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
 
 	fbo.log.CDebugf(ctx, "Fast-forwarding from rev %d to rev %d",
 		fbo.latestMergedRevision, currHead.Revision())
-	changes, affectedNodeIDs, err := fbo.blocks.FastForwardAllNodes(
-		ctx, lState, currHead.ReadOnly())
-	if err != nil {
-		return err
-	}
 
+	// Fetch root block and set the head first, because if it fails we
+	// don't want to have to undo a bunch of pointer updates.  (That
+	// is, follow the same order as when usually updating the head.)
 	latestRootBlockFetch := fbo.kickOffRootBlockFetch(ctx, currHead)
 	err = fbo.waitForRootBlockFetch(ctx, currHead, latestRootBlockFetch)
 	if err != nil {
@@ -7606,6 +7604,27 @@ func (fbo *folderBranchOps) doFastForwardLocked(ctx context.Context,
 	}
 
 	err = fbo.setHeadSuccessorLocked(ctx, lState, currHead, true /*rebase*/)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		// If updating the pointers failed, we need to revert the head
+		// as well.
+		fbo.log.CDebugf(ctx, "Fast-forward failed: %+v; reverting the head")
+		revertErr := fbo.setHeadLocked(
+			ctx, lState, currHead, headTrusted, mdToCommitType(currHead))
+		if revertErr != nil {
+			fbo.log.CDebugf(ctx, "Couldn't revert head: %+v", err)
+		}
+	}()
+
+	changes, affectedNodeIDs, err := fbo.blocks.FastForwardAllNodes(
+		ctx, lState, currHead.ReadOnly())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A user hit the following situation:

* They had a certain revision, R, as the current head for a team folder.
* Their device went to sleep for a while.
* While it was sleeping, another user wrote a bunch of updates, say 100, to the folder.
* Their device woke up, and began to fast-forward the folder to from revision R to revision R+100.
  * The first step was updating the pointers for any open `Node` objects, including the root node.
  * The second step was fetching the root block for the folder.
  * The third step would have been setting the head of the folder to the new revision.
  * Somewhere between setting the root pointer, and setting the head of the folder (maybe while fetching the root block over the network), the device went back to sleep.
* While it was sleeping the second time, another user wrote some more updates, say 10.
* The device woke up again a few hours later, and the original fast-forward failed because the original context had timed out.
* The device then began to fast-forward from revision R (since the new head was never set) to revision R+110.
* However, because the root `Node` pointer had already been updated to the root pointer of revision R+100, this new fast-forward process could not update it again to R+110 (because it still thought it needed to update the R pointer).
* Thus, at the end of all this, the `Node`s in the node cache had the wrong pointers in them, compared to the head of the folder.
* Then, the user made several writes to the folder.

The operations corresponding to these writes had completely wrong pointers in them, and/or caused local client errors on certain operations like `Truncate` and `Write`, due to all the pointers being wrong. Some of the blocks that these operations unreferenced didn't get properly removed/updated in the actual directory entries.  That means 2 weeks later, when GC happened, the unreferenced blocks were marked as deleted on the server, but were still accessible via the directory entries.

The solution is to make setting the head and updating the pointers basically atomic.  If any step fails, we need to unwind what we have already done, and leave the folder as it was before the fast-forward process began.  Under normal update conditions (the user makes a new revision locally, or learns about a single new revision from the server), there is no network activity between setting the head and updating the pointers, and so atomicity is already guaranteed.  But for fast-forwarding, the process that updates the pointers does sometimes require network activity, and so this new unwinding process is needed.

(Also, fetch the root block and set the head first, as we do during normal updates, to minimize the amount of unwinding we're likely to need to do.)

Issue: HOTPOT-812