### PR TITLE
Fix ios light mode flashes

### DIFF
--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -523,7 +523,7 @@ const manageContactsCache = async (
 function* setupDarkMode() {
   const NativeAppearance = NativeModules.Appearance
   if (NativeAppearance) {
-    //eslint disable-next-line
+    // eslint-disable-next-line no-inner-declarations
     function* handleGotChangeEvent(action: any) {
       yield Saga.delay(500)
       yield Saga.put(action)

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -523,6 +523,12 @@ const manageContactsCache = async (
 function* setupDarkMode() {
   const NativeAppearance = NativeModules.Appearance
   if (NativeAppearance) {
+    //eslint disable-next-line
+    function* handleGotChangeEvent(action: any) {
+      yield Saga.delay(500)
+      yield Saga.put(action)
+    }
+
     const channel = Saga.eventChannel(emitter => {
       const nativeEventEmitter = new NativeEventEmitter(NativeAppearance)
       nativeEventEmitter.addListener('appearanceChanged', ({colorScheme}) => {
@@ -531,9 +537,18 @@ function* setupDarkMode() {
       return () => {}
     }, Saga.buffers.sliding(1))
 
+    let task: any
     while (true) {
       const mode = yield Saga.take(channel)
-      yield Saga.put(ConfigGen.createSetSystemDarkMode({dark: mode === 'dark'}))
+      // iOS takes snapshots of the app in light/dark mode and this causes us to get a light/dark call no matter what. so
+      // throttle a bit and ignore this
+      if (task) {
+        yield Saga.cancel(task)
+      }
+      task = yield Saga._fork(
+        handleGotChangeEvent,
+        ConfigGen.createSetSystemDarkMode({dark: mode === 'dark'})
+      )
     }
   }
 }

--- a/shared/ios/Keybase/AppDelegate.m
+++ b/shared/ios/Keybase/AppDelegate.m
@@ -86,7 +86,7 @@
   self.resignImageView = [[UIImageView alloc] initWithFrame:self.window.bounds];
   self.resignImageView.contentMode = UIViewContentModeCenter;
   self.resignImageView.alpha = 0;
-  self.resignImageView.backgroundColor = [UIColor whiteColor];
+  self.resignImageView.backgroundColor = rootView.backgroundColor;
   [self.resignImageView setImage:[UIImage imageNamed:@"LaunchImage"]];
   [self.window addSubview:self.resignImageView];
 

--- a/shared/ios/Keybase/Appearance.m
+++ b/shared/ios/Keybase/Appearance.m
@@ -28,11 +28,12 @@ static NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
     });
 
     traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
-    return appearances[@(traitCollection.userInterfaceStyle)] ?: nil;
+    return appearances[@(traitCollection.userInterfaceStyle)] ?: RCTAppearanceColorSchemeLight;
   }
 #endif
 
-  return nil;
+  // Default to light on older OS version - same behavior as Android.
+  return RCTAppearanceColorSchemeLight;
 }
 
 @interface Appearance ()


### PR DESCRIPTION
When ios backgrounds it takes snapshots in light and dark mode (as far as my googling tells me) this leads us to get the color change events in quick succession which causes the flashing on foreground. Instead we debounce the call and ignore the middle one