### PR TITLE
skip publish if bot is not a member

### DIFF
--- a/go/ephemeral/teambot_ek.go
+++ b/go/ephemeral/teambot_ek.go
@@ -47,29 +47,6 @@ func (k *TeambotEphemeralKeyer) Type() keybase1.TeamEphemeralKeyType {
 	return keybase1.TeamEphemeralKeyType_TEAMBOT
 }
 
-func publishNewTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID, botUID keybase1.UID,
-	teamEK keybase1.TeamEk, merkleRoot libkb.MerkleRoot) (metadata keybase1.TeambotEkMetadata, err error) {
-	defer mctx.TraceTimed(fmt.Sprintf("publishNewTeambotEK teamID: %v, botUID %v", teamID, botUID), func() error { return err })()
-
-	team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
-		ID: teamID,
-	})
-	if err != nil {
-		return metadata, err
-	}
-
-	sig, box, err := prepareNewTeambotEK(mctx, team, botUID, teamEK, merkleRoot)
-	if err != nil {
-		return metadata, err
-	}
-
-	if err = postNewTeambotEK(mctx, team.ID, sig, box.Box); err != nil {
-		return metadata, err
-	}
-
-	return box.Metadata, nil
-}
-
 func postNewTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID, sig, box string) (err error) {
 	defer mctx.TraceTimed("postNewTeambotEK", func() error { return err })()
 
@@ -89,7 +66,8 @@ func postNewTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID, sig, box s
 }
 
 func prepareNewTeambotEK(mctx libkb.MetaContext, team *teams.Team, botUID keybase1.UID,
-	teamEK keybase1.TeamEk, merkleRoot libkb.MerkleRoot) (sig string, box *keybase1.TeambotEkBoxed, err error) {
+	seed TeambotEKSeed, metadata *keybase1.TeambotEkMetadata,
+	merkleRoot libkb.MerkleRoot) (sig string, box *keybase1.TeambotEkBoxed, err error) {
 	defer mctx.TraceTimed("prepareNewTeambotEK", func() error { return err })()
 
 	statement, _, _, err := fetchUserEKStatement(mctx, botUID)
@@ -103,27 +81,14 @@ func prepareNewTeambotEK(mctx libkb.MetaContext, team *teams.Team, botUID keybas
 		return "", nil, fmt.Errorf("unable to make teambot key, bot has no active user EKs")
 	}
 	activeMetadata := activeMetadataMap[botUID]
+	metadata.UserEkGeneration = activeMetadata.Generation
 
+	// Encrypting with a nil sender means we'll generate a random sender
+	// private key.
 	recipientKey, err := libkb.ImportKeypairFromKID(activeMetadata.Kid)
 	if err != nil {
 		return "", nil, err
 	}
-
-	seed := deriveTeambotEKFromTeamEK(mctx, teamEK, botUID)
-	metadata := keybase1.TeambotEkMetadata{
-		Kid:              seed.DeriveDHKey().GetKID(),
-		Generation:       teamEK.Metadata.Generation,
-		Uid:              botUID,
-		UserEkGeneration: activeMetadata.Generation,
-		HashMeta:         merkleRoot.HashMeta(),
-		// The ctime is derivable from the hash meta, by fetching the hashed
-		// root from the server, but including it saves readers a potential
-		// extra round trip.
-		Ctime: keybase1.TimeFromSeconds(merkleRoot.Ctime()),
-	}
-
-	// Encrypting with a nil sender means we'll generate a random sender
-	// private key.
 	boxedSeed, err := recipientKey.EncryptToString(seed[:], nil)
 	if err != nil {
 		return "", nil, err
@@ -131,7 +96,7 @@ func prepareNewTeambotEK(mctx libkb.MetaContext, team *teams.Team, botUID keybas
 
 	boxed := keybase1.TeambotEkBoxed{
 		Box:      boxedSeed,
-		Metadata: metadata,
+		Metadata: *metadata,
 	}
 
 	metadataJSON, err := json.Marshal(metadata)

--- a/go/ephemeral/teambot_ek_test.go
+++ b/go/ephemeral/teambot_ek_test.go
@@ -36,10 +36,6 @@ func TestNewTeambotEK(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, botua.Username, res.User.Username)
 
-	merkleRootPtr, err := mctx.G().GetMerkleClient().FetchRootFromServer(mctx, libkb.EphemeralKeyMerkleFreshness)
-	require.NoError(t, err)
-	merkleRoot := *merkleRootPtr
-
 	ek, _, err := mctx.G().GetEKLib().GetOrCreateLatestTeambotEK(mctx, teamID, botuaUID.ToBytes())
 	require.NoError(t, err)
 	typ, err := ek.KeyType()
@@ -62,11 +58,6 @@ func TestNewTeambotEK(t *testing.T) {
 
 	// bot users don't have access to team secrets so they can't get the teamEK
 	_, _, err = mctx2.G().GetEKLib().GetOrCreateLatestTeamEK(mctx2, teamID)
-	require.Error(t, err)
-
-	// this fails as well since bots can't sign things on behalf of the team
-	// either, even if we pass a valid teamEK from the non-bot
-	_, err = publishNewTeambotEK(mctx2, teamID, botuaUID, teamEK, merkleRoot)
 	require.Error(t, err)
 
 	keyer := NewTeambotEphemeralKeyer()

--- a/go/teambot/bot_keyer.go
+++ b/go/teambot/bot_keyer.go
@@ -348,7 +348,7 @@ func (k *BotKeyer) getTeambotKeyLocked(mctx libkb.MetaContext, teamID keybase1.T
 func (k *BotKeyer) GetTeambotKeyAtGeneration(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	generation keybase1.TeambotKeyGeneration) (key keybase1.TeambotKey, err error) {
 	mctx = mctx.WithLogTag("GTBK")
-	defer mctx.TraceTimed(fmt.Sprintf("BotKeyer#GetLatestTeambotKey teamID: %v", teamID),
+	defer mctx.TraceTimed(fmt.Sprintf("BotKeyer#GetTeambotKeyAtGeneration teamID: %v, generation: %d", teamID, generation),
 		func() error { return err })()
 
 	lock := k.locktab.AcquireOnName(mctx.Ctx(), mctx.G(), k.lockKey(teamID))


### PR DESCRIPTION
if a member was removed from a team we would fail in deriving the teambot key during decryption since we would attempt to publish the key during the derivation. we now skip publishing if the given `botUID` does not have role `RESTRICTEDBOT`