### PR TITLE
fix team loading for reset pegboard

### DIFF
--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -669,6 +669,7 @@ func (s *localizerPipeline) getResetUsernamesMetadata(ctx context.Context, uidMa
 // returns an incomplete list in case of error
 func (s *localizerPipeline) getResetUsernamesPegboard(ctx context.Context, uidMapper libkb.UIDMapper,
 	membersType chat1.ConversationMembersType, info types.NameInfo, public bool) (res []string, err error) {
+	// NOTE: If this is too slow, it could be cached on local metadata.
 	team, err := NewTeamLoader(s.G().ExternalG()).loadTeam(ctx, info.ID, info.CanonicalName,
 		membersType, public, nil)
 	if err != nil {

--- a/go/libkb/pegboard.go
+++ b/go/libkb/pegboard.go
@@ -11,7 +11,7 @@ import (
 // Pegboard keeps track of automatic private follows.
 // When the logged-in user interacts with another user, that other user
 // gets pegged to their incarnation. After the target resets,
-// the logged-in user will be alerted even if there's no explicit folowing.
+// the logged-in user will be alerted even if there's no explicit following.
 // CORE-10522 For now, pegboard is disabled by default and when enabled
 //            only has in-memory storage.
 type Pegboard struct {


### PR DESCRIPTION
implicit team upgrade chats have a kbfs tlfid as their id not a team id so team loading would fail previously. chat handles this case internally with the `loadTeam` call. (noticed an error in an unrelated log)