### PR TITLE
tlf_journal: use ctx timeout when putting blocks, if available

### DIFF
--- a/go/kbfs/libkbfs/journal_manager_test.go
+++ b/go/kbfs/libkbfs/journal_manager_test.go
@@ -330,8 +330,9 @@ func TestJournalManagerOverDiskLimitError(t *testing.T) {
 	require.NoError(t, err)
 	usageBytes, limitBytes, usageFiles, limitFiles :=
 		tj.diskLimiter.getDiskLimitInfo()
+	putCtx := context.Background() // rely on default disk limit timeout
 	err = blockServer.Put(
-		ctx, tlfID1, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
+		putCtx, tlfID1, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
 
 	compare := func(reportable bool, err error) {
 		expectedError := ErrDiskLimitTimeout{
@@ -353,20 +354,20 @@ func TestJournalManagerOverDiskLimitError(t *testing.T) {
 	// Putting it again should encounter a regular deadline exceeded
 	// error.
 	err = blockServer.Put(
-		ctx, tlfID1, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
+		putCtx, tlfID1, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
 	compare(false, err)
 
 	// Advancing the time by overDiskLimitDuration should make it
 	// return another quota error.
 	clock.Add(time.Minute)
 	err = blockServer.Put(
-		ctx, tlfID1, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
+		putCtx, tlfID1, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
 	compare(true, err)
 
 	// Putting it again should encounter a deadline error again.
 	clock.Add(30 * time.Second)
 	err = blockServer.Put(
-		ctx, tlfID1, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
+		putCtx, tlfID1, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
 	compare(false, err)
 }
 

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -769,7 +769,8 @@ func testTLFJournalBlockOpDiskLimitTimeout(t *testing.T, ver kbfsmd.MetadataVer)
 
 	data := []byte{1, 2, 3, 4}
 	id, bCtx, serverHalf := config.makeBlock(data)
-	err := tlfJournal.putBlockData(ctx, id, bCtx, data, serverHalf)
+	putCtx := context.Background() // rely on default disk limit timeout
+	err := tlfJournal.putBlockData(putCtx, id, bCtx, data, serverHalf)
 	timeoutErr, ok := errors.Cause(err).(*ErrDiskLimitTimeout)
 	require.True(t, ok)
 	require.Error(t, timeoutErr.err)


### PR DESCRIPTION
The journal has a built-in timeout of 11s when trying to put a block into the journal.  (This includes the waiting time if the journal is full and needs to drain before putting the block.)  But if we're writing via SimpleFS (which puts a timeout of 1 minute on every operation), there's no reason to artificially constrain the timeout.

So instead, only use the default timeout if none is currently set.  If one is set, use 60% of it (default macOS timeout of 19s * .60 =~ 11s, which is the current timeout) if that's bigger than the default timeout.

Issue: HOTPOT-904