### PR TITLE
Persist navigation state on hot reloads on native

### DIFF
--- a/shared/devices/device-page/container.tsx
+++ b/shared/devices/device-page/container.tsx
@@ -5,11 +5,6 @@ import DevicePage from '.'
 
 type OwnProps = Container.RouteProps<{deviceID: string}>
 
-// TODO(newRouter) after committing to new router:
-// remove action and code that sets state.devices.selectedDeviceID.
-// It's a bad pattern to have navigation distributed across react-navigation
-// and our store. device id is purely an argument to the screen, the store
-// doesn't care about it.
 export default Container.connect(
   (state: Container.TypedState, ownProps: OwnProps) => {
     const id = Container.getRouteProps(ownProps, 'deviceID', '')

--- a/shared/router-v2/persist.native.tsx
+++ b/shared/router-v2/persist.native.tsx
@@ -1,0 +1,11 @@
+// Hot reload management, so route state isn't lost when we hot reload
+module.hot && module.hot.dispose(data => (data.navState = navState))
+let navState: any = module.hot && module.hot.data && module.hot.data.navState
+
+export const getPersistenceFunctions = () =>
+  module.hot
+    ? {
+        loadNavigationState: () => navState,
+        persistNavigationState: state => (navState = state),
+      }
+    : {}

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -21,6 +21,7 @@ import {createSwitchNavigator, StackActions} from '@react-navigation/core'
 import {debounce} from 'lodash-es'
 import {modalRoutes, routes, loggedOutRoutes, tabRoots} from './routes'
 import {useScreens} from 'react-native-screens'
+import {getPersistenceFunctions} from './persist.native'
 
 const {createStackNavigator} = Stack
 
@@ -304,7 +305,12 @@ class RNApp extends React.PureComponent<Props> {
         <Kb.NativeStatusBar
           barStyle={Styles.isAndroid ? 'default' : this.props.isDarkMode ? 'light-content' : 'dark-content'}
         />
-        <AppContainer ref={nav => (this._nav = nav)} onNavigationStateChange={this._persistRoute} />
+        <AppContainer
+          ref={nav => (this._nav = nav)}
+          onNavigationStateChange={this._persistRoute}
+          // HMR persistence
+          {...getPersistenceFunctions()}
+        />
         <GlobalError />
         <OutOfDate />
         <RuntimeStats />


### PR DESCRIPTION
If hot reloading is enabled, persist route state during it using `module.hot.dispose` in `router-v2/persist.native`. cc @keybase/y2ksquad 