### PR TITLE
Remove selectedDeviceID from store and assert route props are passed in tests

### DIFF
--- a/shared/actions/__tests__/devices.test.tsx
+++ b/shared/actions/__tests__/devices.test.tsx
@@ -124,6 +124,17 @@ const startOnDevicesTab = dispatch => {
   dispatch(RouteTreeGen.createNavigateAppend({path: [Tabs.devicesTab]}))
 }
 
+const expectNavWithDeviceID = (deviceID: string) => {
+  const navAppend = jest.spyOn(RouteTreeGen, 'createNavigateAppend')
+  const assertNavHasDeviceID = () =>
+    expect(navAppend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: expect.arrayContaining([expect.objectContaining({props: expect.objectContaining({deviceID})})]),
+      })
+    )
+  return {assertNavHasDeviceID}
+}
+
 const startReduxSaga = Testing.makeStartReduxSaga(devicesSaga, initialStore, startOnDevicesTab)
 
 // const getRoute = getState => getRoutePath(getState().routeTree.routeState, [Tabs.devicesTab])
@@ -282,11 +293,11 @@ describe('shows revoke page correctly', () => {
   })
 
   it('shows revoke page', () => {
-    const {dispatch, getState} = init
+    const {dispatch} = init
     const deviceID = Types.stringToDeviceID('456')
+    const {assertNavHasDeviceID} = expectNavWithDeviceID(deviceID)
     dispatch(DevicesGen.createShowRevokePage({deviceID}))
-    // expect(getRoute(getState)).toEqual(I.List([Tabs.devicesTab, 'devicePage', 'deviceRevoke']))
-    expect(getState().devices.selectedDeviceID).toEqual(deviceID)
+    assertNavHasDeviceID()
   })
 
   it('requests endangered', () => {
@@ -331,11 +342,11 @@ describe('shows device page correctly', () => {
   afterEach(() => {})
 
   it('shows device page', () => {
-    const {dispatch, getState} = init
+    const {dispatch} = init
     const deviceID = Types.stringToDeviceID('789')
+    const {assertNavHasDeviceID} = expectNavWithDeviceID(deviceID)
     dispatch(DevicesGen.createShowDevicePage({deviceID}))
-    // expect(getRoute(getState)).toEqual(I.List([Tabs.devicesTab, 'devicePage']))
-    expect(getState().devices.selectedDeviceID).toEqual(deviceID)
+    assertNavHasDeviceID()
   })
 })
 
@@ -351,8 +362,9 @@ describe('shows paperkey page correctly', () => {
 
   it('shows paperkey page', () => {
     const {dispatch} = init
+    const navAppend = jest.spyOn(RouteTreeGen, 'createNavigateAppend')
     dispatch(DevicesGen.createShowPaperKeyPage())
-    // expect(getRoute(getState)).toEqual(I.List([Tabs.devicesTab, 'devicePaperKey']))
+    expect(navAppend).toHaveBeenCalled()
   })
 
   it('creates a paperkey', () => {

--- a/shared/constants/types/devices.tsx
+++ b/shared/constants/types/devices.tsx
@@ -22,7 +22,6 @@ export type State = {
   isNew: Set<string>
   justRevokedSelf: string
   newPaperkey: HiddenString
-  selectedDeviceID?: DeviceID
 }
 
 // Converts a string to the DeviceType enum, logging an error if it doesn't match

--- a/shared/devices/device-revoke/container.tsx
+++ b/shared/devices/device-revoke/container.tsx
@@ -3,21 +3,21 @@ import * as Types from '../../constants/types/devices'
 import * as Constants from '../../constants/devices'
 import * as DevicesGen from '../../actions/devices-gen'
 import DeviceRevoke from '.'
-import {connect} from '../../util/container'
+import * as Container from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 
-type OwnProps = {}
+type OwnProps = Container.RouteProps<{deviceID: string}>
 
-export default connect(
-  state => ({
-    _endangeredTLFs: Constants.getEndangeredTLFs(state, state.devices.selectedDeviceID),
-    device: Constants.getDevice(state, state.devices.selectedDeviceID),
-    iconNumber: Constants.getDeviceIconNumber(
-      state,
-      state.devices.selectedDeviceID || Types.stringToDeviceID('')
-    ),
-    waiting: WaitingConstants.anyWaiting(state, Constants.waitingKey),
-  }),
+export default Container.connect(
+  (state, ownProps: OwnProps) => {
+    const selectedDeviceID = Container.getRouteProps(ownProps, 'deviceID', '')
+    return {
+      _endangeredTLFs: Constants.getEndangeredTLFs(state, selectedDeviceID),
+      device: Constants.getDevice(state, selectedDeviceID),
+      iconNumber: Constants.getDeviceIconNumber(state, selectedDeviceID),
+      waiting: WaitingConstants.anyWaiting(state, Constants.waitingKey),
+    }
+  },
   dispatch => ({
     _onSubmit: (deviceID: Types.DeviceID) => dispatch(DevicesGen.createRevoke({deviceID})),
     onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),

--- a/shared/reducers/devices.tsx
+++ b/shared/reducers/devices.tsx
@@ -29,10 +29,6 @@ export default (
         draftState.endangeredTLFMap = endangeredTLFMap
         return
       }
-      case DevicesGen.showRevokePage:
-      case DevicesGen.showDevicePage: // fallthrough
-        draftState.selectedDeviceID = action.payload.deviceID
-        return
       case DevicesGen.showPaperKeyPage:
         draftState.newPaperkey = initialState.newPaperkey
         return
@@ -60,6 +56,8 @@ export default (
       // Saga only actions
       case DevicesGen.revoke:
       case DevicesGen.load:
+      case DevicesGen.showRevokePage:
+      case DevicesGen.showDevicePage:
         return
     }
   })


### PR DESCRIPTION
Be true to a todo comment I removed in https://github.com/keybase/client/pull/20049. cc @keybase/y2ksquad 