### PR TITLE
force load inflation-destination change transaction before refreshing state

### DIFF
--- a/go/stellar/inflation.go
+++ b/go/stellar/inflation.go
@@ -53,6 +53,11 @@ func SetInflationDestinationLocal(mctx libkb.MetaContext, arg stellar1.SetInflat
 	if err != nil {
 		return err
 	}
+
+	// force load this transaction before refreshing the wallet state
+	loader := DefaultLoader(mctx.G())
+	loader.LoadPaymentSync(mctx.Ctx(), stellar1.PaymentID(sig.TxHash))
+
 	err = walletState.Refresh(mctx, senderEntry.AccountID, "set inflation destination")
 	if err != nil {
 		mctx.Debug("SetInflationDestinationLocal ws.Refresh error: %s", err)

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -983,6 +983,9 @@ func detailsChanged(a, b *stellar1.AccountDetails) bool {
 	if len(a.Reserves) != len(b.Reserves) {
 		return true
 	}
+	if a.InflationDestination != b.InflationDestination {
+		return true
+	}
 	for i := 0; i < len(a.Reserves); i++ {
 		if a.Reserves[i] != b.Reserves[i] {
 			return true


### PR DESCRIPTION
changing the inflation destination and then heading to the transaction list sometimes doesn't display the actual transaction that changed the inflation. it has to do with caching and notifications from stellarmond. 

this change reorders the way things are happening on the client so we are consistently getting: (1) the transaction gets accepted into a ledger, (2) the transaction is loaded on the client from horizon, (3) the client fires off the notifications and state refreshes required to recognize the change and update all data structures/caches accordingly.