### PR TITLE
Fix Chat Input Crashes on Android

### DIFF
--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -11,7 +11,7 @@ import {
   styleSheetCreate,
   isDarkMode,
 } from '../styles'
-import {isIOS, isAndroid} from '../constants/platform'
+import {isIOS} from '../constants/platform'
 import {checkTextInfo} from './input.shared'
 import {pick} from 'lodash-es'
 import logger from '../logger'
@@ -69,17 +69,11 @@ class PlainInput extends Component<InternalProps> {
     checkTextInfo(newTextInfo)
     // If we're android, let's workaround this Issue: https://github.com/imnapo/react-native-cn-richtext-editor/issues/81
     // By setting the text and selection at the same time
-    if (isAndroid) {
-      this.setNativeProps({
-        selection: this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text),
-        text: newTextInfo.text,
-      })
-      this._lastNativeText = newTextInfo.text
-    } else {
-      this.setNativeProps({text: newTextInfo.text})
-      this._lastNativeText = newTextInfo.text
-      this._setSelection(newTextInfo.selection)
-    }
+    this.setNativeProps({
+      selection: this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text),
+      text: newTextInfo.text,
+    })
+    this._lastNativeText = newTextInfo.text
     if (reflectChange) {
       this._onChangeText(newTextInfo.text)
     }

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -66,14 +66,16 @@ class PlainInput extends Component<InternalProps> {
       text: this._lastNativeText || '',
     }
     const newTextInfo = fn(currentTextInfo)
+    const newCheckedSelection = this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text)
     checkTextInfo(newTextInfo)
     // This is to workaround this Issue for Android: https://github.com/imnapo/react-native-cn-richtext-editor/issues/81
     // By setting the text and selection at the same time
     this.setNativeProps({
-      selection: this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text),
+      selection: newCheckedSelection,
       text: newTextInfo.text,
     })
     this._lastNativeText = newTextInfo.text
+    this._lastNativeSelection = newCheckedSelection
     if (reflectChange) {
       this._onChangeText(newTextInfo.text)
     }

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -67,7 +67,7 @@ class PlainInput extends Component<InternalProps> {
     }
     const newTextInfo = fn(currentTextInfo)
     checkTextInfo(newTextInfo)
-    // If we're android, let's workaround this Issue: https://github.com/imnapo/react-native-cn-richtext-editor/issues/81
+    // This is to workaround this Issue for Android: https://github.com/imnapo/react-native-cn-richtext-editor/issues/81
     // By setting the text and selection at the same time
     this.setNativeProps({
       selection: this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text),


### PR DESCRIPTION
The input was crashing when you sent messages that had modified the
native selection props. It crashed when you cleared the text because it
would set the text to empty, and reused a cached selection that was out
of bounds of an empty string.

For example, say you type "hello @" and autocomplete to "hello @foo". We
do some text selection magic to insert the @foo and put your cursor in
the correct spot. The Selection start and end indicies are both 11. When
you submit to message, we clear the text. When we clear the text, RN
keeps reusing those selection indices (of 11) and Android complains the
selection is outside of the bounds of the text ("" has a length of 0,
but you want to move the cursor to position 11, outside the bounds of
0).

The workaround here is to set the selection at the same time as the
text.

The RN Issue is: https://github.com/facebook/react-native/issues/25265

@buoyad since I think he has the most context here.
@keybase/react-hackers 