### PR TITLE
cr_chains: set final path on rename op even when removed

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3767,6 +3767,16 @@ func (fbo *folderBranchOps) makeEditNotifications(
 	// resolver, the final paths will not be set on the ops.  Use
 	// crChains to set them.
 	ops := pathSortedOps(rmd.data.Changes.Ops)
+	if fbo.config.Mode().IsTestMode() {
+		// Clear out the final paths to simulate in tests what happens
+		// when MDs are read fresh from the journal.
+		opsCopy := make(pathSortedOps, len(ops))
+		for i, op := range ops {
+			opsCopy[i] = op.deepCopy()
+			opsCopy[i].setFinalPath(data.Path{})
+		}
+		ops = opsCopy
+	}
 
 	isResolution := false
 	if len(ops) > 0 {
@@ -3824,7 +3834,7 @@ func (fbo *folderBranchOps) makeEditNotifications(
 		if !op.getFinalPath().IsValid() {
 			fbo.log.CDebugf(
 				ctx, "HOTPOT-803: Op %s has no valid path; "+
-					"rev=%d, all ops=%v", rmd.Revision(), op, ops)
+					"rev=%d, all ops=%v", op, rmd.Revision(), ops)
 			if fbo.config.Mode().IsTestMode() {
 				panic("Op missing path")
 			}

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3804,7 +3804,7 @@ func (fbo *folderBranchOps) makeEditNotifications(
 		}
 		// Make sure the ops are in increasing order by path length,
 		// so e.g. file creates come before file modifies.
-		sort.Sort(ops)
+		sort.Stable(ops)
 
 		for _, op := range ops {
 			// Temporary debugging for the case where an op has an

--- a/go/kbfs/test/dsl_test.go
+++ b/go/kbfs/test/dsl_test.go
@@ -1057,7 +1057,8 @@ type expectedEdit struct {
 	deletedFiles []string
 }
 
-func checkUserEditHistory(expectedEdits []expectedEdit) fileOp {
+func checkUserEditHistoryWithSort(
+	expectedEdits []expectedEdit, doSort bool) fileOp {
 	return fileOp{func(c *ctx) error {
 		history, err := c.engine.UserEditHistory(c.user)
 		if err != nil {
@@ -1077,9 +1078,17 @@ func checkUserEditHistory(expectedEdits []expectedEdit) fileOp {
 			for _, we := range h.History[0].Edits {
 				hEdits[i].files = append(hEdits[i].files, we.Filename)
 			}
+			if doSort {
+				sort.Strings(hEdits[i].files)
+				sort.Strings(expectedEdits[i].files)
+			}
 			for _, we := range h.History[0].Deletes {
 				hEdits[i].deletedFiles = append(
 					hEdits[i].deletedFiles, we.Filename)
+			}
+			if doSort {
+				sort.Strings(hEdits[i].deletedFiles)
+				sort.Strings(expectedEdits[i].deletedFiles)
 			}
 		}
 
@@ -1089,6 +1098,10 @@ func checkUserEditHistory(expectedEdits []expectedEdit) fileOp {
 		}
 		return nil
 	}, Defaults, "checkUserEditHistory()"}
+}
+
+func checkUserEditHistory(expectedEdits []expectedEdit) fileOp {
+	return checkUserEditHistoryWithSort(expectedEdits, false)
 }
 
 func checkDirtyPaths(expectedPaths []string) fileOp {

--- a/go/kbfs/test/edit_history_test.go
+++ b/go/kbfs/test/edit_history_test.go
@@ -605,6 +605,49 @@ func TestEditHistoryRenameDirAndReuseNameForLink(t *testing.T) {
 
 // Regression test for HOTPOT-803.
 func TestEditHistoryUnflushedRenameOverNewFile(t *testing.T) {
+	// Alice creates a file in the first revision, but then creates
+	// a file in the second revision that is renamed over the
+	// original file.  She also creates a file that is removed.
+	expectedEdits := []expectedEdit{
+		{
+			"alice",
+			keybase1.FolderType_PRIVATE,
+			"alice",
+			[]string{
+				"/keybase/private/alice/a",
+			},
+			[]string{
+				"/keybase/private/alice/c",
+			},
+		},
+	}
+
+	test(t, journal(),
+		users("alice"),
+		as(alice,
+			mkfile("a", "a foo"),
+		),
+		as(alice,
+			enableJournal(),
+		),
+		as(alice,
+			pwriteBSSync("b", []byte("b foo"), 0, false),
+			rename("a", "c"),
+			pwriteBSSync("a", []byte("a2 foo"), 0, false),
+			rename("b", "a"),
+			rm("c"),
+		),
+		as(alice,
+			lsdir("", m{"a$": "FILE"}),
+			read("a", "b foo"),
+			checkUserEditHistory(expectedEdits),
+		),
+	)
+}
+
+// A more complex regression test for HOTPOT-803 than the above test,
+// but it is more faithful to the actual user log.
+func TestEditHistoryUnflushedRenameOverTwoNewFiles(t *testing.T) {
 	// Alice creates two files in the first revision, but then creates
 	// 2 files in the second revision that are renamed over the
 	// original two files.  She also creates two files that are removed.
@@ -627,8 +670,8 @@ func TestEditHistoryUnflushedRenameOverNewFile(t *testing.T) {
 	test(t, journal(),
 		users("alice"),
 		as(alice,
-			mkfile("a", "foo a"),
-			mkfile("b", "foo d"),
+			mkfile("a", "a foo"),
+			mkfile("b", "b foo"),
 		),
 		as(alice,
 			enableJournal(),
@@ -640,7 +683,7 @@ func TestEditHistoryUnflushedRenameOverNewFile(t *testing.T) {
 			pwriteBSSync("f", []byte("f foo"), 0, false),
 			rename("a", "f"),
 			rename("c", "b"),
-			pwriteBSSync("a", []byte("g foo"), 0, false),
+			pwriteBSSync("a", []byte("a2 foo"), 0, false),
 			rename("d", "a"),
 			rm("e"),
 			rm("f"),

--- a/go/kbfs/test/edit_history_test.go
+++ b/go/kbfs/test/edit_history_test.go
@@ -649,7 +649,11 @@ func TestEditHistoryUnflushedRenameOverNewFile(t *testing.T) {
 			lsdir("", m{"a$": "FILE", "b$": "FILE"}),
 			read("a", "d foo"),
 			read("b", "c foo"),
-			checkUserEditHistory(expectedEdits),
+			// Sort the entries because when we add in the rename
+			// operations, the order is undefined and 'a' and 'b'
+			// could be swapped since they happen in the same revision
+			// and are independent.
+			checkUserEditHistoryWithSort(expectedEdits, true),
 		),
 	)
 }


### PR DESCRIPTION
A few users have hit this sequence in a single MD update:

* Rename a file 'foo' to 'bar'.
* Delete 'bar' (either through an `rm`, or due to renaming something else over `bar`).

Then when trying to construct the edit notifications for this revision (either when flushing it to the server, or when reading it from the journal to construct the "unflushed" notifications), the code panics because the rename operation is missing a final path.  Extra debugging added for #19405 revealed this pattern in a new log.

The op's final path is missing because, when reverting rm+create op pairs that come out of the chaining process into rename ops, we were only looking for the final path of the corresponding create op. However, in this case the create op is thrown away since the whole file/dir is removed in the end, and we went ahead and included the rename op anyway, without a final path.

The solution is to try to find the path from the rm op instead, which should still be around.

This also adds a regression test to catch this case, as well as `folderBranchOps` code that strips out the final paths before the notification process while in test mode, to make sure the tests match the app cold-start behavior.

Issue: HOTPOT-803
Issue: #19405