### PR TITLE
set temp directory used by iOS to background readable

### DIFF
--- a/shared/ios/Keybase/Fs.m
+++ b/shared/ios/Keybase/Fs.m
@@ -90,11 +90,13 @@
 
 - (NSString*) setupAppHome:(NSString*)home sharedHome:(NSString*)sharedHome {
   NSURL* tempUrl = [[NSFileManager defaultManager] temporaryDirectory];
-  NSString* tempDir = [tempUrl path];
+  // workaround a problem where iOS dyld3 loader crashes if accessing .closure files
+  // with complete data protection on
+  NSString* dyldDir = [NSString stringWithFormat:@"%@/com.apple.dyld", [tempUrl path]];
   // Setup all directories
   NSString* appKeybasePath = [@"~/Library/Application Support/Keybase" stringByExpandingTildeInPath];
   NSString* appEraseableKVPath = [@"~/Library/Application Support/Keybase/eraseablekvstore/device-eks" stringByExpandingTildeInPath];
-  [self createBackgroundReadableDirectory:tempDir setAllFiles:YES];
+  [self createBackgroundReadableDirectory:dyldDir setAllFiles:YES];
   [self createBackgroundReadableDirectory:appKeybasePath setAllFiles:YES];
   [self createBackgroundReadableDirectory:appEraseableKVPath setAllFiles:YES];
   [self addSkipBackupAttributeToItemAtPath:appKeybasePath];

--- a/shared/ios/Keybase/Fs.m
+++ b/shared/ios/Keybase/Fs.m
@@ -89,9 +89,12 @@
 }
 
 - (NSString*) setupAppHome:(NSString*)home sharedHome:(NSString*)sharedHome {
+  NSURL* tempUrl = [[NSFileManager defaultManager] temporaryDirectory];
+  NSString* tempDir = [tempUrl path];
   // Setup all directories
   NSString* appKeybasePath = [@"~/Library/Application Support/Keybase" stringByExpandingTildeInPath];
   NSString* appEraseableKVPath = [@"~/Library/Application Support/Keybase/eraseablekvstore/device-eks" stringByExpandingTildeInPath];
+  [self createBackgroundReadableDirectory:tempDir setAllFiles:YES];
   [self createBackgroundReadableDirectory:appKeybasePath setAllFiles:YES];
   [self createBackgroundReadableDirectory:appEraseableKVPath setAllFiles:YES];
   [self addSkipBackupAttributeToItemAtPath:appKeybasePath];


### PR DESCRIPTION
Current bkg crash theory is that dyld3 stashes some files in a directory in `/tmp` called `com.apple.dyld`. If the app tries to read these files in the background, the file protection setting on that directory prevents it, and results in a crash. Changing the directory to background readable should hopefully solve the problem.