### PR TITLE
[Y2K-705] Fix mobile wallet memo

### DIFF
--- a/shared/common-adapters/markdown/shared.tsx
+++ b/shared/common-adapters/markdown/shared.tsx
@@ -315,10 +315,6 @@ class SimpleMarkdownComponent extends PureComponent<
       >
         {output}
       </Text>
-    ) : this.props.style ? (
-      <Text type="Body" style={this.props.style}>
-        {output}
-      </Text>
     ) : (
       output
     )

--- a/shared/common-adapters/markdown/shared.tsx
+++ b/shared/common-adapters/markdown/shared.tsx
@@ -315,6 +315,10 @@ class SimpleMarkdownComponent extends PureComponent<
       >
         {output}
       </Text>
+    ) : this.props.style ? (
+      <Text type="Body" style={this.props.style}>
+        {output}
+      </Text>
     ) : (
       output
     )

--- a/shared/wallets/common/markdown-memo.tsx
+++ b/shared/wallets/common/markdown-memo.tsx
@@ -40,7 +40,6 @@ const MarkdownMemo = (props: Props) =>
       {!props.hideDivider && <Kb.Divider vertical={true} style={styles.quoteMarker} />}
       <Kb.Text type="Body" style={styles.memo}>
         <Kb.Markdown
-          style={styles.memo}
           styleOverride={Styles.collapseStyles([isMobile ? styleOverride : {}, props.styleOverride])}
           allowFontScaling={true}
         >

--- a/shared/wallets/common/markdown-memo.tsx
+++ b/shared/wallets/common/markdown-memo.tsx
@@ -40,7 +40,8 @@ const MarkdownMemo = (props: Props) =>
       {!props.hideDivider && <Kb.Divider vertical={true} style={styles.quoteMarker} />}
       <Kb.Text type="Body" style={styles.memo}>
         <Kb.Markdown
-          styleOverride={Styles.collapseStyles([isMobile ? styleOverride : {}, props.styleOverride])}
+          style={styles.memo}
+          styleOverride={{...styleOverride, ...props.styleOverride}}
           allowFontScaling={true}
         >
           {props.memo}

--- a/shared/wallets/common/markdown-memo.tsx
+++ b/shared/wallets/common/markdown-memo.tsx
@@ -38,13 +38,15 @@ const MarkdownMemo = (props: Props) =>
       style={Styles.collapseStyles([props.style, styles.container])}
     >
       {!props.hideDivider && <Kb.Divider vertical={true} style={styles.quoteMarker} />}
-      <Kb.Markdown
-        style={styles.memo}
-        styleOverride={Styles.collapseStyles([isMobile ? styleOverride : {}, props.styleOverride])}
-        allowFontScaling={true}
-      >
-        {props.memo}
-      </Kb.Markdown>
+      <Kb.Text type="Body" style={styles.memo}>
+        <Kb.Markdown
+          style={styles.memo}
+          styleOverride={Styles.collapseStyles([isMobile ? styleOverride : {}, props.styleOverride])}
+          allowFontScaling={true}
+        >
+          {props.memo}
+        </Kb.Markdown>
+      </Kb.Text>
     </Kb.Box2>
   ) : null
 

--- a/shared/wallets/common/markdown-memo.tsx
+++ b/shared/wallets/common/markdown-memo.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
-import * as ChatConstants from '../../constants/chat2'
 import {StyleOverride} from '../../common-adapters/markdown'
 import {isMobile} from '../../constants/platform'
-import HiddenString from '../../util/hidden-string'
 
 const styleOverride: StyleOverride = Styles.styleSheetCreate(() => ({
   del: {
@@ -18,7 +16,6 @@ const styleOverride: StyleOverride = Styles.styleSheetCreate(() => ({
   },
   paragraph: {
     color: Styles.globalColors.black,
-    ...(isMobile ? Styles.globalStyles.flexBoxColumn : {}),
   },
   strong: {
     color: Styles.globalColors.black,
@@ -43,11 +40,7 @@ const MarkdownMemo = (props: Props) =>
       {!props.hideDivider && <Kb.Divider vertical={true} style={styles.quoteMarker} />}
       <Kb.Markdown
         style={styles.memo}
-        styleOverride={{
-          ...(isMobile ? styleOverride : {}),
-          ...props.styleOverride,
-        }}
-        meta={ChatConstants.makeMessageText({decoratedText: new HiddenString(props.memo)})}
+        styleOverride={Styles.collapseStyles([isMobile ? styleOverride : {}, props.styleOverride])}
         allowFontScaling={true}
       >
         {props.memo}
@@ -73,6 +66,9 @@ const styles = Styles.styleSheetCreate(() => ({
       whiteSpace: 'pre-wrap',
       wordBreak: 'break-word',
     } as const,
+    isMobile: {
+      ...Styles.globalStyles.flexBoxColumn,
+    },
   }),
   quoteMarker: {maxWidth: 3, minWidth: 3},
 }))

--- a/shared/wallets/common/markdown-memo.tsx
+++ b/shared/wallets/common/markdown-memo.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import {StyleOverride} from '../../common-adapters/markdown'
-import {isMobile} from '../../constants/platform'
 
 const styleOverride: StyleOverride = Styles.styleSheetCreate(() => ({
   del: {

--- a/shared/wallets/common/markdown-memo.tsx
+++ b/shared/wallets/common/markdown-memo.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
+import * as ChatConstants from '../../constants/chat2'
 import {StyleOverride} from '../../common-adapters/markdown'
 import {isMobile} from '../../constants/platform'
+import HiddenString from '../../util/hidden-string'
 
 const styleOverride: StyleOverride = Styles.styleSheetCreate(() => ({
   del: {
@@ -16,6 +18,7 @@ const styleOverride: StyleOverride = Styles.styleSheetCreate(() => ({
   },
   paragraph: {
     color: Styles.globalColors.black,
+    ...(isMobile ? Styles.globalStyles.flexBoxColumn : {}),
   },
   strong: {
     color: Styles.globalColors.black,
@@ -44,6 +47,7 @@ const MarkdownMemo = (props: Props) =>
           ...(isMobile ? styleOverride : {}),
           ...props.styleOverride,
         }}
+        meta={ChatConstants.makeMessageText({decoratedText: new HiddenString(props.memo)})}
         allowFontScaling={true}
       >
         {props.memo}


### PR DESCRIPTION
Memo styles aren't used at all on mobile.

Before:
![before](https://user-images.githubusercontent.com/59594/66010787-49161000-e475-11e9-9c99-268c432eac55.png)

After:
![after](https://user-images.githubusercontent.com/59594/66010794-4ddac400-e475-11e9-9100-24523f2b1b7d.png)

I tested desktop and it still looks the same.

cc @keybase/y2ksquad 
