### PR TITLE
fix handling of team delete

### DIFF
--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -321,7 +321,7 @@ func HandleExitNotification(ctx context.Context, g *libkb.GlobalContext, rows []
 	for _, row := range rows {
 		mctx.Debug("team.HandleExitNotification: (%+v)", row)
 		if err := FreezeTeam(mctx, row.Id); err != nil {
-			mctx.Debug("team.HandleExitNotification: failed to FreezeReam: %s", err)
+			mctx.Debug("team.HandleExitNotification: failed to FreezeTeam: %s", err)
 		}
 		invalidateCaches(mctx, row.Id)
 		mctx.G().NotifyRouter.HandleTeamExit(ctx, row.Id)

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -301,19 +301,16 @@ func HandleDeleteNotification(ctx context.Context, g *libkb.GlobalContext, rows 
 	defer mctx.Trace(fmt.Sprintf("team.HandleDeleteNotification(%v)", len(rows)),
 		func() error { return err })()
 
-	var errs []error
 	for _, row := range rows {
 		g.Log.CDebugf(ctx, "team.HandleDeleteNotification: (%+v)", row)
-		err := TombstoneTeam(libkb.NewMetaContext(ctx, g), row.Id)
-		if err != nil {
-			errs = append(errs, err)
-			continue
+		if err := TombstoneTeam(libkb.NewMetaContext(ctx, g), row.Id); err != nil {
+			g.Log.CDebugf(ctx, "team.HandleDeleteNotification: failed to Tombstone: %s", err)
 		}
 		invalidateCaches(mctx, row.Id)
 		g.NotifyRouter.HandleTeamDeleted(ctx, row.Id)
 	}
 
-	return libkb.CombineErrors(errs...)
+	return nil
 }
 
 func HandleExitNotification(ctx context.Context, g *libkb.GlobalContext, rows []keybase1.TeamExitRow) (err error) {

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -318,18 +318,15 @@ func HandleExitNotification(ctx context.Context, g *libkb.GlobalContext, rows []
 	defer mctx.Trace(fmt.Sprintf("team.HandleExitNotification(%v)", len(rows)),
 		func() error { return err })()
 
-	var errs []error
 	for _, row := range rows {
 		mctx.Debug("team.HandleExitNotification: (%+v)", row)
-		err := FreezeTeam(mctx, row.Id)
-		if err != nil {
-			errs = append(errs, err)
-			continue
+		if err := FreezeTeam(mctx, row.Id); err != nil {
+			mctx.Debug("team.HandleExitNotification: failed to FreezeReam: %s", err)
 		}
 		invalidateCaches(mctx, row.Id)
 		mctx.G().NotifyRouter.HandleTeamExit(ctx, row.Id)
 	}
-	return libkb.CombineErrors(errs...)
+	return nil
 }
 
 func HandleNewlyAddedToTeamNotification(ctx context.Context, g *libkb.GlobalContext, rows []keybase1.TeamNewlyAddedRow) (err error) {

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -2640,17 +2640,17 @@ func FreezeTeam(mctx libkb.MetaContext, teamID keybase1.TeamID) error {
 }
 
 func TombstoneTeam(mctx libkb.MetaContext, teamID keybase1.TeamID) error {
-	err1 := mctx.G().GetTeamLoader().Tombstone(mctx.Ctx(), teamID)
+	err1 := mctx.G().GetHiddenTeamChainManager().Tombstone(mctx, teamID)
+	if err1 != nil {
+		mctx.Debug("error tombstoning in hidden team chain manager: %v", err1)
+	}
+	err2 := mctx.G().GetTeamLoader().Tombstone(mctx.Ctx(), teamID)
 	if err1 != nil {
 		mctx.Debug("error tombstoning in team cache: %v", err1)
 	}
-	err2 := mctx.G().GetFastTeamLoader().Tombstone(mctx, teamID)
-	if err2 != nil {
-		mctx.Debug("error tombstoning in fast team cache: %v", err2)
-	}
-	err3 := mctx.G().GetHiddenTeamChainManager().Tombstone(mctx, teamID)
+	err3 := mctx.G().GetFastTeamLoader().Tombstone(mctx, teamID)
 	if err3 != nil {
-		mctx.Debug("error tombstoning in hidden team chain manager: %v", err3)
+		mctx.Debug("error tombstoning in fast team cache: %v", err3)
 	}
 	return libkb.CombineErrors(err1, err2, err3)
 }

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -2640,17 +2640,17 @@ func FreezeTeam(mctx libkb.MetaContext, teamID keybase1.TeamID) error {
 }
 
 func TombstoneTeam(mctx libkb.MetaContext, teamID keybase1.TeamID) error {
-	err1 := mctx.G().GetHiddenTeamChainManager().Tombstone(mctx, teamID)
-	if err1 != nil {
-		mctx.Debug("error tombstoning in hidden team chain manager: %v", err1)
-	}
-	err2 := mctx.G().GetTeamLoader().Tombstone(mctx.Ctx(), teamID)
-	if err2 != nil {
-		mctx.Debug("error tombstoning in team cache: %v", err2)
-	}
-	err3 := mctx.G().GetFastTeamLoader().Tombstone(mctx, teamID)
+	err3 := mctx.G().GetHiddenTeamChainManager().Tombstone(mctx, teamID)
 	if err3 != nil {
-		mctx.Debug("error tombstoning in fast team cache: %v", err3)
+		mctx.Debug("error tombstoning in hidden team chain manager: %v", err3)
+	}
+	err1 := mctx.G().GetTeamLoader().Tombstone(mctx.Ctx(), teamID)
+	if err1 != nil {
+		mctx.Debug("error tombstoning in team cache: %v", err1)
+	}
+	err2 := mctx.G().GetFastTeamLoader().Tombstone(mctx, teamID)
+	if err2 != nil {
+		mctx.Debug("error tombstoning in fast team cache: %v", err2)
 	}
 	return libkb.CombineErrors(err1, err2, err3)
 }

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -2624,6 +2624,10 @@ func TeamInviteTypeFromString(mctx libkb.MetaContext, inviteTypeStr string) (key
 }
 
 func FreezeTeam(mctx libkb.MetaContext, teamID keybase1.TeamID) error {
+	err3 := mctx.G().GetHiddenTeamChainManager().Freeze(mctx, teamID)
+	if err3 != nil {
+		mctx.Debug("error freezing in hidden team chain manager: %v", err3)
+	}
 	err1 := mctx.G().GetTeamLoader().Freeze(mctx.Ctx(), teamID)
 	if err1 != nil {
 		mctx.Debug("error freezing in team cache: %v", err1)
@@ -2631,10 +2635,6 @@ func FreezeTeam(mctx libkb.MetaContext, teamID keybase1.TeamID) error {
 	err2 := mctx.G().GetFastTeamLoader().Freeze(mctx, teamID)
 	if err2 != nil {
 		mctx.Debug("error freezing in fast team cache: %v", err2)
-	}
-	err3 := mctx.G().GetHiddenTeamChainManager().Freeze(mctx, teamID)
-	if err3 != nil {
-		mctx.Debug("error freezing in hidden team chain manager: %v", err3)
 	}
 	return libkb.CombineErrors(err1, err2, err3)
 }
@@ -2645,8 +2645,8 @@ func TombstoneTeam(mctx libkb.MetaContext, teamID keybase1.TeamID) error {
 		mctx.Debug("error tombstoning in hidden team chain manager: %v", err1)
 	}
 	err2 := mctx.G().GetTeamLoader().Tombstone(mctx.Ctx(), teamID)
-	if err1 != nil {
-		mctx.Debug("error tombstoning in team cache: %v", err1)
+	if err2 != nil {
+		mctx.Debug("error tombstoning in team cache: %v", err2)
 	}
 	err3 := mctx.G().GetFastTeamLoader().Tombstone(mctx, teamID)
 	if err3 != nil {


### PR DESCRIPTION
Two things:

1. Ignore the error from `TombstoneTeam` (this was a change because of the linting PRs...)
2. Change cache clear order in `TombstoneTeam` so hidden chain goes last, otherwise it gets a tombstone error in itself.

cc @buoyad 