### PR TITLE
Don't cancel the send form when you choose a new linked account as recipient

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -808,9 +808,6 @@ const deletedAccount = (state: TypedState) => {
   )
 }
 
-export const hasShowOnCreation = <F, T extends {}, G extends {showOnCreation: F}>(a: T | G): a is G =>
-  a && Object.prototype.hasOwnProperty.call(a, 'showOnCreation')
-
 const createdOrLinkedAccount = (
   _: TypedState,
   action: WalletsGen.CreatedNewAccountPayload | WalletsGen.LinkedExistingAccountPayload
@@ -819,7 +816,7 @@ const createdOrLinkedAccount = (
     // Create new account failed, don't nav
     return false
   }
-  if (action.payload && hasShowOnCreation(action.payload)) {
+  if (action.payload.showOnCreation) {
     return WalletsGen.createSelectAccount({
       accountID: action.payload.accountID,
       reason: 'auto-selected',


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

Not sure why this change happened -- it was during the initial typescripting of actions.  `hasShowOnCreation()` returns true given `{showOnCreation: undefined}`, which was the bug.  @MarcoPolo, let me know if you can remember why it might have been important to use `hasShowOnCreation()`!

