### PR TITLE
Make the 'create account' button on send-form to-another-account smaller, doesn't quite fit.

### DIFF
--- a/shared/wallets/send-form/participants/to-field.tsx
+++ b/shared/wallets/send-form/participants/to-field.tsx
@@ -200,6 +200,7 @@ class ToOtherAccount extends React.Component<ToOtherAccountProps> {
       return (
         <Kb.Box2 direction="horizontal" centerChildren={true} style={{width: 270}}>
           <Kb.Button
+            small={true}
             type="Wallet"
             style={styles.createNewAccountButton}
             label="Create a new account"


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 