### PR TITLE
Fix searching on non-keybase services on people tab

### DIFF
--- a/shared/actions/people.tsx
+++ b/shared/actions/people.tsx
@@ -171,7 +171,8 @@ const onTeamBuildingAdded = (_: Container.TypedState, action: TeamBuildingGen.Ad
   const user = users[0]
   if (!user) return false
 
-  const username = user.id
+  // keybase username is in serviceMap.keybase, otherwise assertion is id
+  const username = user.serviceMap.keybase || user.id
   return [
     TeamBuildingGen.createCancelTeamBuilding({namespace: 'people'}),
     ProfileGen.createShowUserProfile({username}),


### PR DESCRIPTION
Use KB username if there. If not, the assertion won't be a compound one, so use that. cc @keybase/y2ksquad 