### PR TITLE
Show SEP7 send errors in a red banner on the send form, not black bar

### DIFF
--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -449,6 +449,10 @@
       "_description": "Set the error field for a SEP7 validation.",
       "error": "string"
     },
+    "setSEP7SendError": {
+      "_description": "Set the error field for SEP7 accepted tx attempt",
+      "error": "string"
+    },
     "loadMobileOnlyMode": {
       "_description": "Ask the service for current mobile only mode for Stellar account.",
       "accountID": "Types.AccountID"

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -998,6 +998,7 @@ export type TypedActionsMap = {
   'wallets:validatedSecretKey': wallets.ValidatedSecretKeyPayload
   'wallets:validateSEP7Link': wallets.ValidateSEP7LinkPayload
   'wallets:validateSEP7LinkError': wallets.ValidateSEP7LinkErrorPayload
+  'wallets:setSEP7SendError': wallets.SetSEP7SendErrorPayload
   'wallets:loadMobileOnlyMode': wallets.LoadMobileOnlyModePayload
   'wallets:loadedMobileOnlyMode': wallets.LoadedMobileOnlyModePayload
   'wallets:changeMobileOnlyMode': wallets.ChangeMobileOnlyModePayload

--- a/shared/actions/wallets-gen.tsx
+++ b/shared/actions/wallets-gen.tsx
@@ -114,6 +114,7 @@ export const setInflationDestination = 'wallets:setInflationDestination'
 export const setLastSentXLM = 'wallets:setLastSentXLM'
 export const setReadyToReview = 'wallets:setReadyToReview'
 export const setSEP6Message = 'wallets:setSEP6Message'
+export const setSEP7SendError = 'wallets:setSEP7SendError'
 export const setSEP7Tx = 'wallets:setSEP7Tx'
 export const setTrustlineAcceptedAssets = 'wallets:setTrustlineAcceptedAssets'
 export const setTrustlineAcceptedAssetsByUsername = 'wallets:setTrustlineAcceptedAssetsByUsername'
@@ -349,6 +350,7 @@ type _SetInflationDestinationPayload = {
 type _SetLastSentXLMPayload = {readonly lastSentXLM: boolean; readonly writeFile: boolean}
 type _SetReadyToReviewPayload = {readonly readyToReview: boolean}
 type _SetSEP6MessagePayload = {readonly error: boolean; readonly message: string}
+type _SetSEP7SendErrorPayload = {readonly error: string}
 type _SetSEP7TxPayload = {readonly confirmURI: string; readonly tx: Types.SEP7ConfirmInfo}
 type _SetTrustlineAcceptedAssetsByUsernamePayload = {
   readonly username: string
@@ -826,6 +828,13 @@ export const createSetBuildingTo = (payload: _SetBuildingToPayload): SetBuilding
 export const createSetInflationDestination = (
   payload: _SetInflationDestinationPayload
 ): SetInflationDestinationPayload => ({payload, type: setInflationDestination})
+/**
+ * Set the error field for SEP7 accepted tx attempt
+ */
+export const createSetSEP7SendError = (payload: _SetSEP7SendErrorPayload): SetSEP7SendErrorPayload => ({
+  payload,
+  type: setSEP7SendError,
+})
 /**
  * Set the error field for a SEP7 validation.
  */
@@ -1558,6 +1567,10 @@ export type SetSEP6MessagePayload = {
   readonly payload: _SetSEP6MessagePayload
   readonly type: typeof setSEP6Message
 }
+export type SetSEP7SendErrorPayload = {
+  readonly payload: _SetSEP7SendErrorPayload
+  readonly type: typeof setSEP7SendError
+}
 export type SetSEP7TxPayload = {readonly payload: _SetSEP7TxPayload; readonly type: typeof setSEP7Tx}
 export type SetTrustlineAcceptedAssetsByUsernamePayload = {
   readonly payload: _SetTrustlineAcceptedAssetsByUsernamePayload
@@ -1763,6 +1776,7 @@ export type Actions =
   | SetLastSentXLMPayload
   | SetReadyToReviewPayload
   | SetSEP6MessagePayload
+  | SetSEP7SendErrorPayload
   | SetSEP7TxPayload
   | SetTrustlineAcceptedAssetsByUsernamePayload
   | SetTrustlineAcceptedAssetsPayload

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -318,34 +318,48 @@ const validateSEP7Link = async (_: TypedState, action: WalletsGen.ValidateSEP7Li
 }
 
 const acceptSEP7Tx = async (_: TypedState, action: WalletsGen.AcceptSEP7TxPayload) => {
-  await RPCStellarTypes.localApproveTxURILocalRpcPromise(
-    {inputURI: action.payload.inputURI},
-    Constants.sep7WaitingKey
-  )
+  try {
+    await RPCStellarTypes.localApproveTxURILocalRpcPromise(
+      {inputURI: action.payload.inputURI},
+      Constants.sep7WaitingKey
+    )
+  } catch (error) {
+    return WalletsGen.createSetSEP7SendError({error: error.desc})
+  }
+
   return [RouteTreeGen.createClearModals(), RouteTreeGen.createSwitchTab({tab: Tabs.walletsTab})]
 }
 
 const acceptSEP7Path = async (state: TypedState, action: WalletsGen.AcceptSEP7PathPayload) => {
-  await RPCStellarTypes.localApprovePathURILocalRpcPromise(
-    {
-      fromCLI: false,
-      fullPath: paymentPathToRpcPaymentPath(state.wallets.sep7ConfirmPath.fullPath),
-      inputURI: action.payload.inputURI,
-    },
-    Constants.sep7WaitingKey
-  )
+  try {
+    await RPCStellarTypes.localApprovePathURILocalRpcPromise(
+      {
+        fromCLI: false,
+        fullPath: paymentPathToRpcPaymentPath(state.wallets.sep7ConfirmPath.fullPath),
+        inputURI: action.payload.inputURI,
+      },
+      Constants.sep7WaitingKey
+    )
+  } catch (error) {
+    return WalletsGen.createSetSEP7SendError({error: error.desc})
+  }
+
   return [RouteTreeGen.createClearModals(), RouteTreeGen.createSwitchTab({tab: Tabs.walletsTab})]
 }
 
 const acceptSEP7Pay = async (_: TypedState, action: WalletsGen.AcceptSEP7PayPayload) => {
-  await RPCStellarTypes.localApprovePayURILocalRpcPromise(
-    {
-      amount: action.payload.amount,
-      fromCLI: false,
-      inputURI: action.payload.inputURI,
-    },
-    Constants.sep7WaitingKey
-  )
+  try {
+    await RPCStellarTypes.localApprovePayURILocalRpcPromise(
+      {
+        amount: action.payload.amount,
+        fromCLI: false,
+        inputURI: action.payload.inputURI,
+      },
+      Constants.sep7WaitingKey
+    )
+  } catch (error) {
+    return WalletsGen.createSetSEP7SendError({error: error.desc})
+  }
   return [RouteTreeGen.createClearModals(), RouteTreeGen.createSwitchTab({tab: Tabs.walletsTab})]
 }
 

--- a/shared/constants/types/wallets.tsx
+++ b/shared/constants/types/wallets.tsx
@@ -433,6 +433,7 @@ export type _State = {
   sep7ConfirmInfo: SEP7ConfirmInfo | null
   sep7ConfirmPath: BuiltPaymentAdvanced
   sep7ConfirmURI: string
+  sep7SendError: string
   staticConfig: StaticConfig | null
   trustline: Trustline
   unreadPaymentsMap: I.Map<string, number>

--- a/shared/constants/wallets.tsx
+++ b/shared/constants/wallets.tsx
@@ -305,6 +305,7 @@ export const makeState = I.Record<Types._State>({
   sep7ConfirmInfo: null,
   sep7ConfirmPath: emptyBuiltPaymentAdvanced,
   sep7ConfirmURI: '',
+  sep7SendError: '',
   staticConfig: null,
   trustline: emptyTrustline,
   unreadPaymentsMap: I.Map(),

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -462,7 +462,10 @@ export default function(state: Types.State = initialState, action: WalletsGen.Ac
         sep7ConfirmInfo: null,
         sep7ConfirmPath: Constants.emptyBuiltPaymentAdvanced,
         sep7ConfirmURI: '',
+        sep7SendError: '',
       })
+    case WalletsGen.setSEP7SendError:
+      return state.merge({sep7SendError: action.payload.error})
     case WalletsGen.validateSEP7LinkError:
       return state.merge({sep7ConfirmError: action.payload.error})
     case WalletsGen.setSEP7Tx:

--- a/shared/wallets/sep7-confirm/container.tsx
+++ b/shared/wallets/sep7-confirm/container.tsx
@@ -9,6 +9,7 @@ const mapStateToProps = (state: Container.TypedState) => ({
   loading: !state.wallets.sep7ConfirmInfo,
   sep7ConfirmInfo: state.wallets.sep7ConfirmInfo,
   sep7ConfirmPath: state.wallets.sep7ConfirmPath,
+  sep7SendError: state.wallets.sep7SendError,
   waitingKey: Constants.sep7WaitingKey,
 })
 
@@ -42,6 +43,7 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
       originDomain: '',
       path: stateProps.sep7ConfirmPath,
       recipient: null,
+      sendError: stateProps.sep7SendError,
       signed: null,
       summary: {
         fee: '',
@@ -67,6 +69,7 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
     signed,
     summary,
   } = stateProps.sep7ConfirmInfo
+  const sendError = stateProps.sep7SendError
   const path = stateProps.sep7ConfirmPath
   const rawOp = stateProps.sep7ConfirmInfo.operation
   const operation = rawOp === 'pay' ? ('pay' as const) : rawOp === 'tx' ? ('tx' as const) : ('' as const)
@@ -94,6 +97,7 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
     originDomain,
     path,
     recipient,
+    sendError,
     signed,
     summary,
     waitingKey: stateProps.waitingKey,

--- a/shared/wallets/sep7-confirm/index.stories.tsx
+++ b/shared/wallets/sep7-confirm/index.stories.tsx
@@ -114,7 +114,9 @@ const load = () => {
     .add('Unsigned Pay', () => <SEP7Confirm {...commonProps} {...payUnsignedProps} />)
     .add('Signed Tx', () => <SEP7Confirm {...commonProps} {...txProps} />)
     .add('Unsigned Tx', () => <SEP7Confirm {...commonProps} {...unsignedTxProps} />)
-    .add('Signed Pay with send error', () => <SEP7Confirm {...commonProps} {...payProps} sendError='Your balance is too low.' />)
+    .add('Signed Pay with send error', () => (
+      <SEP7Confirm {...commonProps} {...payProps} sendError="Your balance is too low." />
+    ))
   Sb.storiesOf('Wallets/SEP7Error', module).add('Error', () => (
     <KeybaseLinkErrorBody
       isError={true}

--- a/shared/wallets/sep7-confirm/index.stories.tsx
+++ b/shared/wallets/sep7-confirm/index.stories.tsx
@@ -37,6 +37,7 @@ const commonProps = {
   onLookupPath: Sb.action('onLookupPath'),
   path: commonPath,
   readyToSend: true,
+  sendError: '',
   userAmount: '',
   waiting: false,
   waitingKey: 'false',
@@ -113,6 +114,7 @@ const load = () => {
     .add('Unsigned Pay', () => <SEP7Confirm {...commonProps} {...payUnsignedProps} />)
     .add('Signed Tx', () => <SEP7Confirm {...commonProps} {...txProps} />)
     .add('Unsigned Tx', () => <SEP7Confirm {...commonProps} {...unsignedTxProps} />)
+    .add('Signed Pay with send error', () => <SEP7Confirm {...commonProps} {...payProps} sendError='Your balance is too low.' />)
   Sb.storiesOf('Wallets/SEP7Error', module).add('Error', () => (
     <KeybaseLinkErrorBody
       isError={true}

--- a/shared/wallets/sep7-confirm/index.tsx
+++ b/shared/wallets/sep7-confirm/index.tsx
@@ -35,6 +35,7 @@ type Props = {
   path: Types._BuiltPaymentAdvanced
   readyToSend: boolean
   recipient: string | null
+  sendError: string
   signed: boolean | null
   summary: Summary
   userAmount: string | null
@@ -96,11 +97,19 @@ const InfoRow = (props: InfoRowProps) => (
 type HeaderProps = {
   requester: string | null
   isPayment: boolean
+  sendError: string
   signed: boolean | null
 }
 const Header = (props: HeaderProps) => (
   <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.header}>
     <Kb.Box2 direction="vertical" fullWidth={true} style={styles.headerContent}>
+      {!!props.sendError && (
+        <Kb.Box2 direction="vertical" fullWidth={true}>
+          <Kb.Banner color="red">
+            <Kb.BannerParagraph bannerColor="red" content={props.sendError} />
+          </Kb.Banner>
+        </Kb.Box2>
+      )}
       {!props.signed && (
         <Kb.Box2 direction="vertical" fullWidth={true}>
           <Kb.Banner color="red">
@@ -251,6 +260,7 @@ const SEP7Confirm = (props: Props) => (
         <Header
           isPayment={props.operation === 'pay'}
           requester={props.signed ? props.originDomain : TrimString(props.recipient)}
+          sendError={props.sendError}
           signed={props.signed}
         />
         {!!props.callbackURL && <CallbackURLBanner callbackURL={props.callbackURL} />}


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

There's a companion kbweb PR to make the strings that will now be shown in the GUI friendlier.