### PR TITLE
folder_branch_ops: don't reset `hasBeenCleared` on an error

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -8754,7 +8754,6 @@ func (fbo *folderBranchOps) ForceFastForward(ctx context.Context) {
 		// cleared.
 		return
 	}
-	fbo.hasBeenCleared = false
 
 	fbo.forcedFastForwards.Add(1)
 	fbo.goTracked(func() {
@@ -8810,6 +8809,17 @@ func (fbo *folderBranchOps) ForceFastForward(ctx context.Context) {
 		defer fbo.mdWriterLock.Unlock(lState)
 		fbo.headLock.Lock(lState)
 		defer fbo.headLock.Unlock(lState)
+
+		if !fbo.hasBeenCleared {
+			return
+		}
+
+		defer func() {
+			if fbo.head != (ImmutableRootMetadata{}) {
+				fbo.hasBeenCleared = false
+			}
+		}()
+
 		if fbo.head != (ImmutableRootMetadata{}) {
 			// We're already up to date.
 			fbo.log.CDebugf(ctx, "Already up-to-date: %v", err)


### PR DESCRIPTION
If a `ForceFastForward` failed after setting this field back to `false`, but the fast-forward failed (say because the current user doesn't have permissions on the TLF), then future fast-forwards won't ever work because the field isn't set.  So instead only clear the field if the fast-forward actually worked.

This change means there could technically be multiple fast-forwards happening at once, but only one of them will actually set the head, and the rest will fizzle after fetching the head. (Technically this could have happened earlier too, since we were clearing the field just under a read lock.)

Issue: HOTPOT-827