### PR TITLE
Cleanup Logging

### DIFF
--- a/shared/constants/platform.d.ts
+++ b/shared/constants/platform.d.ts
@@ -16,6 +16,7 @@ export const isMac: boolean
 export const isAndroidNewerThanN: boolean
 export const defaultUseNativeFrame: boolean
 export const isTestDevice: boolean
+export const isRemoteDebuggerAttached: boolean
 
 export declare const fileUIName: string
 export declare const version: string

--- a/shared/constants/platform.desktop.tsx
+++ b/shared/constants/platform.desktop.tsx
@@ -117,3 +117,5 @@ export {runMode}
 
 // Noop – Just for Android
 export const appColorSchemeChanged = () => {}
+
+export const isRemoteDebuggerAttached = false

--- a/shared/constants/platform.native.tsx
+++ b/shared/constants/platform.native.tsx
@@ -18,6 +18,7 @@ export const isDeviceSecureAndroid: boolean =
     : nativeBridge.isDeviceSecure === 'true' || false
 export const isTestDevice = nativeBridge.isTestDevice
 
+export const isRemoteDebuggerAttached = typeof __REMOTEDEV__ !== 'undefined'
 export const runMode = 'prod'
 export const isIOS = Platform.OS === 'ios'
 export const isAndroid = !isIOS

--- a/shared/engine/transport-shared.tsx
+++ b/shared/engine/transport-shared.tsx
@@ -4,6 +4,7 @@ import {printRPC, printRPCWaitingSession} from '../local-debug'
 import {requestIdleCallback} from '../util/idle-callback'
 import * as LocalConsole from '../util/local-console'
 import * as Stats from './stats'
+import {isRemoteDebuggerAttached, isMobile} from '../constants/platform'
 
 const RobustTransport = rpc.transport.RobustTransport
 const RpcClient = rpc.client.Client
@@ -64,7 +65,9 @@ function rpcLog(info: {method: string; reason: string; extra?: Object; type: str
   requestIdleCallback(
     () => {
       const params = [info.reason, info.method, info.extra].filter(Boolean)
-      LocalConsole.green(prefix, info.method, info.reason, ...params)
+      if (!isMobile || isRemoteDebuggerAttached) {
+        LocalConsole.green(prefix, info.method, info.reason, ...params)
+      }
     },
     {timeout: 1e3}
   )

--- a/shared/globals.d.ts
+++ b/shared/globals.d.ts
@@ -1,3 +1,4 @@
+declare var __REMOTEDEV__: boolean
 declare var __VERSION__: string
 declare var __STORYBOOK__: boolean
 declare var __STORYSHOT__: boolean

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -68,6 +68,7 @@ if (__DEV__) {
   config.printOutstandingTimerListeners = true
   config.printRPCWaitingSession = false
   config.printRPC = true
+  // TODO is this even used?
   config.printRPCStats = true
   config.reduxSagaLoggerMasked = false
   config.userTimings = false

--- a/shared/logger/index.tsx
+++ b/shared/logger/index.tsx
@@ -8,7 +8,7 @@ import {
   Loggers,
   toISOTimestamp,
 } from './types'
-import {isMobile} from '../constants/platform'
+import {isMobile, isRemoteDebuggerAttached} from '../constants/platform'
 import ConsoleLogger from './console-logger'
 import TeeLogger from './tee-logger'
 import RingLogger from './ring-logger'
@@ -85,7 +85,11 @@ class AggregateLoggerImpl implements AggregateLogger {
 }
 
 const devLoggers = () => ({
-  action: new TeeLogger(new RingLogger(100), new ConsoleLogger('log', 'Dispatching Action')),
+  // We already pretty print the actions when we have an actual console.
+  action:
+    isMobile && !isRemoteDebuggerAttached
+      ? new TeeLogger(new RingLogger(100), new ConsoleLogger('log', 'Dispatching Action'))
+      : new NullLogger(),
   debug: new TeeLogger(
     isMobile
       ? new NativeLogger('d')

--- a/shared/store/configure-store.tsx
+++ b/shared/store/configure-store.tsx
@@ -8,7 +8,7 @@ import {createStore, applyMiddleware, Store} from 'redux'
 import {enableStoreLogging, enableActionLogging, filterActionLogs} from '../local-debug'
 import * as DevGen from '../actions/dev-gen'
 import * as ConfigGen from '../actions/config-gen'
-import {isMobile} from '../constants/platform'
+import {isMobile, isRemoteDebuggerAttached} from '../constants/platform'
 import * as LocalConsole from '../util/local-console'
 
 let theStore: Store<any, any>
@@ -38,7 +38,9 @@ if (enableStoreLogging) {
       if (filterActionLogs) {
         args[0].type.match(filterActionLogs) && logger.info('Action:', ...args)
       } else if (args[0] && args[0].type) {
-        LocalConsole.gray('Action:', args[0].type, '', args[0])
+        if (!isMobile || isRemoteDebuggerAttached) {
+          LocalConsole.gray('Action:', args[0].type, '', args[0])
+        }
       }
       return null
     },
@@ -55,7 +57,9 @@ if (enableStoreLogging) {
     stateTransformer: (...args) => {
       if (logStateOk) {
         // This is noisy, so let's not show it while filtering action logs
-        !filterActionLogs && LocalConsole.purpleObject('State:', ...args) // DON'T use the logger here, we never want this in the logs
+        !filterActionLogs &&
+          (!isMobile || isRemoteDebuggerAttached) &&
+          LocalConsole.purpleObject('State:', ...args) // DON'T use the logger here, we never want this in the logs
         logStateOk = false
       } else {
         logStateOk = true


### PR DESCRIPTION
Cleans up Android logcat in the dev flow. Cleans up the chrome console
when there is a remote debugger attached.

When there is no chrome console attached, the formatted logs make
looking at logcat useless on Android (and I'm sure they have some
non-negligible dev perf impact).

This also removes the redundant "Dispatching Action" log when you have a
chrome console available.