### PR TITLE
Fix exception in PathInfo_ component

### DIFF
--- a/shared/fs/common/path-info.tsx
+++ b/shared/fs/common/path-info.tsx
@@ -28,12 +28,16 @@ const PathInfo_ = (props: PathInfoProps) => {
   const mountPointPath = useMountPointPath(pathInfo.platformAfterMountPath)
   return (
     <Kb.Box2 direction="vertical" style={props.containerStyle} fullWidth={true}>
-      <Kb.Text type="BodySmallSemibold">Universal path:</Kb.Text>
-      <Kb.CopyText
-        containerStyle={styles.copyPath}
-        multiline={Styles.isMobile ? 3 : 4}
-        text={pathInfo.deeplinkPath}
-      />
+      {pathInfo.deeplinkPath ? (
+        <>
+          <Kb.Text type="BodySmallSemibold">Universal path:</Kb.Text>
+          <Kb.CopyText
+            containerStyle={styles.copyPath}
+            multiline={Styles.isMobile ? 3 : 4}
+            text={pathInfo.deeplinkPath}
+          />
+        </>
+      ) : null}
       {mountPointPath ? (
         <>
           <Kb.Text type="BodySmallSemibold" style={styles.localPath}>


### PR DESCRIPTION
This fixes a crash that happens when you try to use the path info dropdown in the file viewer in the Electron app.

For a brief moment before `pathInfo.deeplinkPath` loads in, it has a falsey value which throws an error in `<CopyText />`. This is due to a recent change (#19963) which will throw if the `text` property is falsey, but a `loadText` property is not provided.

The render of the universal path field is held off until it is ready, like how the local path field is done now.