### PR TITLE
don't show universal path for /keybase (and fix crash on path item popup)

### DIFF
--- a/shared/common-adapters/copy-text.tsx
+++ b/shared/common-adapters/copy-text.tsx
@@ -8,6 +8,7 @@ import Toast from './toast'
 import {useTimeout} from './use-timers'
 import * as Styles from '../styles'
 import * as Container from '../util/container'
+import logger from '../logger'
 
 type Props = {
   buttonType?: ButtonProps['type']
@@ -34,7 +35,11 @@ const CopyText = (props: Props) => {
   React.useEffect(() => {
     if (!props.withReveal && !props.text) {
       // only try to load text if withReveal is false
-      props.loadText && props.loadText()
+      if (!props.loadText) {
+        logger.warn('no loadText method provided')
+        return
+      }
+      props.loadText()
     }
   }, []) // only run this effect once, on first render
 
@@ -47,6 +52,7 @@ const CopyText = (props: Props) => {
   const copy = () => {
     if (!props.text) {
       if (!props.loadText) {
+        logger.warn('no text to copy and no loadText method provided')
         return
       }
       setRequestedCopy(true)

--- a/shared/fs/common/kbfs-path.tsx
+++ b/shared/fs/common/kbfs-path.tsx
@@ -29,7 +29,7 @@ const KbfsPathPopup = (props: PopupProps) => {
   const header = {
     title: 'header',
     view: (
-      <Kb.Box2 direction="vertical" style={styles.headerContainer} centerChildren={true}>
+      <Kb.Box2 direction="vertical" style={styles.headerContainer} centerChildren={true} fullWidth={true}>
         <PathItemInfo
           path={props.standardPath}
           showTooltipOnName={false}

--- a/shared/fs/common/path-info.tsx
+++ b/shared/fs/common/path-info.tsx
@@ -28,12 +28,16 @@ const PathInfo_ = (props: PathInfoProps) => {
   const mountPointPath = useMountPointPath(pathInfo.platformAfterMountPath)
   return (
     <Kb.Box2 direction="vertical" style={props.containerStyle} fullWidth={true}>
-      <Kb.Text type="BodySmallSemibold">Universal path:</Kb.Text>
-      <Kb.CopyText
-        containerStyle={styles.copyPath}
-        multiline={Styles.isMobile ? 3 : 4}
-        text={pathInfo.deeplinkPath}
-      />
+      {pathInfo.deeplinkPath ? (
+        <>
+          <Kb.Text type="BodySmallSemibold">Universal path:</Kb.Text>
+          <Kb.CopyText
+            containerStyle={styles.copyPath}
+            multiline={Styles.isMobile ? 3 : 4}
+            text={pathInfo.deeplinkPath}
+          />
+        </>
+      ) : null}
       {mountPointPath ? (
         <>
           <Kb.Text type="BodySmallSemibold" style={styles.localPath}>


### PR DESCRIPTION
/keybase doesn't have a universal path, so we shouldn't show an empty box. Also, after the new CopyText the path item popup actually causes a crash since initially we don't have the universal path yet but load it in an effect when the popup is mounted. So just don't show it if it's empty, which fixes the crashes as well.

Additionally, I'm changing the throw into a warn log in case it happens somewhere else where we have an empty text passed into CopyText. cc @hyperobject 