### PR TITLE
a few bug fixes re mime type

### DIFF
--- a/go/kbfs/libhttpserver/content_type_utils.go
+++ b/go/kbfs/libhttpserver/content_type_utils.go
@@ -76,10 +76,14 @@ func getGUIFileContext(contentTypeRaw, contentDispositionRaw string) (
 	viewType keybase1.GUIViewType, invariance string) {
 	contentTypeProcessed := beforeSemicolon(contentTypeRaw)
 	disposition := beforeSemicolon(contentDispositionRaw)
+
+	if disposition == "attachment" {
+		viewType = keybase1.GUIViewType_DEFAULT
+		return viewType, strconv.Itoa(int(viewType))
+	}
+
 	switch {
-	case disposition == "attachment":
-		viewType = keybase1.GUIViewType_TEXT
-	case contentTypeProcessed == "text/plain":
+	case strings.HasPrefix(contentTypeProcessed, "text/"):
 		viewType = keybase1.GUIViewType_TEXT
 	case supportedImgMimeTypes[contentTypeProcessed]:
 		viewType = keybase1.GUIViewType_IMAGE
@@ -92,6 +96,7 @@ func getGUIFileContext(contentTypeRaw, contentDispositionRaw string) (
 	default:
 		viewType = (keybase1.GUIViewType_DEFAULT)
 	}
+
 	return viewType, strconv.Itoa(int(viewType))
 }
 


### PR DESCRIPTION
Two bugs:

1. We were returning viewType of Text for `attachment` disposition 🙀

2. We were checking for equaling to `text/plain` rather than the `text/` prefix for detecting text view type, which was why `"text/markdown; charset=utf-8"` didn't work.