### PR TITLE
Provisioning: Make "I'll use a different device" work + misc fixes

### DIFF
--- a/shared/actions/json/provision.json
+++ b/shared/actions/json/provision.json
@@ -51,6 +51,10 @@
     "forgotUsernameResult": {
       "result": "string"
     },
-    "cancelProvision": {}
+    "cancelProvision": {},
+    "backToDeviceList": {"username": "string"},
+    "provisionDone": {
+      "_description": "We're no longer holding an open provisioning session; it is safe to start another."
+    }
   }
 }

--- a/shared/actions/provision-gen.tsx
+++ b/shared/actions/provision-gen.tsx
@@ -8,9 +8,11 @@ import {RPCError} from '../util/errors'
 export const resetStore = 'common:resetStore' // not a part of provision but is handled by every reducer. NEVER dispatch this
 export const typePrefix = 'provision:'
 export const addNewDevice = 'provision:addNewDevice'
+export const backToDeviceList = 'provision:backToDeviceList'
 export const cancelProvision = 'provision:cancelProvision'
 export const forgotUsername = 'provision:forgotUsername'
 export const forgotUsernameResult = 'provision:forgotUsernameResult'
+export const provisionDone = 'provision:provisionDone'
 export const provisionError = 'provision:provisionError'
 export const showCodePage = 'provision:showCodePage'
 export const showDeviceListPage = 'provision:showDeviceListPage'
@@ -33,9 +35,11 @@ export const switchToGPGSignOnly = 'provision:switchToGPGSignOnly'
 
 // Payload Types
 type _AddNewDevicePayload = {readonly otherDeviceType: 'desktop' | 'mobile'}
+type _BackToDeviceListPayload = {readonly username: string}
 type _CancelProvisionPayload = void
 type _ForgotUsernamePayload = {readonly email: string; readonly phone: string}
 type _ForgotUsernameResultPayload = {readonly result: string}
+type _ProvisionDonePayload = void
 type _ProvisionErrorPayload = {readonly error: HiddenString | null}
 type _ShowCodePagePayload = {readonly code: HiddenString; readonly error: HiddenString | null}
 type _ShowDeviceListPagePayload = {readonly devices: Array<Types.Device>}
@@ -73,9 +77,20 @@ export const createShowDeviceListPage = (payload: _ShowDeviceListPagePayload): S
   payload,
   type: showDeviceListPage,
 })
+/**
+ * We're no longer holding an open provisioning session; it is safe to start another.
+ */
+export const createProvisionDone = (payload: _ProvisionDonePayload): ProvisionDonePayload => ({
+  payload,
+  type: provisionDone,
+})
 export const createAddNewDevice = (payload: _AddNewDevicePayload): AddNewDevicePayload => ({
   payload,
   type: addNewDevice,
+})
+export const createBackToDeviceList = (payload: _BackToDeviceListPayload): BackToDeviceListPayload => ({
+  payload,
+  type: backToDeviceList,
 })
 export const createCancelProvision = (payload: _CancelProvisionPayload): CancelProvisionPayload => ({
   payload,
@@ -157,6 +172,10 @@ export const createSwitchToGPGSignOnly = (
 
 // Action Payloads
 export type AddNewDevicePayload = {readonly payload: _AddNewDevicePayload; readonly type: typeof addNewDevice}
+export type BackToDeviceListPayload = {
+  readonly payload: _BackToDeviceListPayload
+  readonly type: typeof backToDeviceList
+}
 export type CancelProvisionPayload = {
   readonly payload: _CancelProvisionPayload
   readonly type: typeof cancelProvision
@@ -168,6 +187,10 @@ export type ForgotUsernamePayload = {
 export type ForgotUsernameResultPayload = {
   readonly payload: _ForgotUsernameResultPayload
   readonly type: typeof forgotUsernameResult
+}
+export type ProvisionDonePayload = {
+  readonly payload: _ProvisionDonePayload
+  readonly type: typeof provisionDone
 }
 export type ProvisionErrorPayload = {
   readonly payload: _ProvisionErrorPayload
@@ -244,9 +267,11 @@ export type SwitchToGPGSignOnlyPayload = {
 // prettier-ignore
 export type Actions =
   | AddNewDevicePayload
+  | BackToDeviceListPayload
   | CancelProvisionPayload
   | ForgotUsernamePayload
   | ForgotUsernameResultPayload
+  | ProvisionDonePayload
   | ProvisionErrorPayload
   | ShowCodePagePayload
   | ShowDeviceListPagePayload

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -666,6 +666,8 @@ export type TypedActionsMap = {
   'provision:forgotUsername': provision.ForgotUsernamePayload
   'provision:forgotUsernameResult': provision.ForgotUsernameResultPayload
   'provision:cancelProvision': provision.CancelProvisionPayload
+  'provision:backToDeviceList': provision.BackToDeviceListPayload
+  'provision:provisionDone': provision.ProvisionDonePayload
   'push:rejectPermissions': push.RejectPermissionsPayload
   'push:requestPermissions': push.RequestPermissionsPayload
   'push:showPermissionsPrompt': push.ShowPermissionsPromptPayload

--- a/shared/provision/code-page/index.tsx
+++ b/shared/provision/code-page/index.tsx
@@ -59,7 +59,8 @@ class CodePage2 extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    this.props.onClose()
+    // Troubleshooting modal may send us back to the devices page; it already cancels in that case
+    !this.state.troubleshooting && this.props.onClose()
   }
 
   static _validTabs = (deviceType: DeviceType, otherDeviceType) => {
@@ -419,8 +420,6 @@ const styles = Styles.styleSheetCreate(
           marginBottom: Styles.globalMargins.small,
           marginLeft: Styles.globalMargins.xsmall,
           marginTop: 56, // we're under the header, need to shift down
-          // else the background can go above things, annoyingly
-          zIndex: 1,
         },
         isMobile: {
           marginBottom: 0,

--- a/shared/provision/code-page/index.tsx
+++ b/shared/provision/code-page/index.tsx
@@ -165,7 +165,7 @@ class CodePage2 extends React.Component<Props, State> {
           </Kb.Box2>
         </Kb.Box2>
         {!this._inModal() &&
-          this.props.otherDeviceType === 'desktop' &&
+          currentDeviceType === 'desktop' &&
           !this.props.currentDeviceAlreadyProvisioned &&
           this._heyWaitBanner()}
         {!this._inModal() && this.state.troubleshooting && (
@@ -177,8 +177,7 @@ class CodePage2 extends React.Component<Props, State> {
     )
   }
   _footer = () => {
-    const showHeyWaitInFooter =
-      this.props.otherDeviceType === 'mobile' && !this.props.currentDeviceAlreadyProvisioned
+    const showHeyWaitInFooter = currentDeviceType === 'mobile' && !this.props.currentDeviceAlreadyProvisioned
     return {
       content: (
         <Kb.Box2
@@ -420,6 +419,7 @@ const styles = Styles.styleSheetCreate(
           marginBottom: Styles.globalMargins.small,
           marginLeft: Styles.globalMargins.xsmall,
           marginTop: 56, // we're under the header, need to shift down
+          zIndex: undefined, // annoyingly this is set inside Kb.BackButton
         },
         isMobile: {
           marginBottom: 0,

--- a/shared/provision/code-page/index.tsx
+++ b/shared/provision/code-page/index.tsx
@@ -127,7 +127,6 @@ class CodePage2 extends React.Component<Props, State> {
       <Kb.Box2
         direction="vertical"
         fullWidth={true}
-        fullHeight={true}
         style={Styles.collapseStyles([styles.codePageContainer, {backgroundColor: this._tabBackground()}])}
       >
         <Kb.Box2
@@ -223,7 +222,9 @@ class CodePage2 extends React.Component<Props, State> {
       <Kb.Banner color="yellow">
         <Kb.BannerParagraph
           bannerColor="yellow"
-          content={[`Wait, I'm on that ${Styles.isMobile ? 'phone' : 'computer'} right now!`]}
+          content={[
+            `Wait, I'm on that ${this.props.otherDeviceType === 'mobile' ? 'phone' : 'computer'} right now!`,
+          ]}
         />
       </Kb.Banner>
     </Kb.ClickableBox>
@@ -233,6 +234,7 @@ class CodePage2 extends React.Component<Props, State> {
     <Troubleshooting
       mode={this.state.tab === 'QR' ? 'QR' : 'text'}
       onCancel={() => this.setState({troubleshooting: false})}
+      otherDeviceType={this.props.otherDeviceType}
     />
   )
   // We're in a modal unless this is a desktop being newly provisioned.
@@ -247,7 +249,13 @@ class CodePage2 extends React.Component<Props, State> {
     const content = this._body()
     if (this._inModal()) {
       return (
-        <Kb.Modal header={this._header()} footer={this._footer()} onClose={this.props.onBack} mode="Wide">
+        <Kb.Modal
+          header={this._header()}
+          footer={this._footer()}
+          onClose={this.props.onBack}
+          mode="Wide"
+          mobileStyle={{backgroundColor: this._tabBackground()}}
+        >
           {content}
         </Kb.Modal>
       )
@@ -442,6 +450,7 @@ const styles = Styles.styleSheetCreate(
       },
       codePageContainer: Styles.platformStyles({
         common: {
+          flex: 1,
           overflow: 'hidden',
           position: 'relative',
         },

--- a/shared/provision/troubleshooting/index.stories.tsx
+++ b/shared/provision/troubleshooting/index.stories.tsx
@@ -24,7 +24,9 @@ const store = Container.produce(Sb.createStoreWithCommon(), draftState => {
 const load = () => {
   Sb.storiesOf('Provision', module)
     .addDecorator((story: any) => <Sb.MockStore store={store}>{story()}</Sb.MockStore>)
-    .add('Troubleshooting', () => <Troubleshooting mode="QR" onCancel={Sb.action('cancel')} />)
+    .add('Troubleshooting', () => (
+      <Troubleshooting mode="QR" onCancel={Sb.action('cancel')} otherDeviceType="desktop" />
+    ))
 }
 
 export default load

--- a/shared/provision/troubleshooting/index.tsx
+++ b/shared/provision/troubleshooting/index.tsx
@@ -15,34 +15,49 @@ type BigButtonProps = {
   mainText: string
   onClick: () => void
   subText: string
+  waiting: boolean
 }
 
-const BigButton = ({onClick, icon, mainText, subText}: BigButtonProps) => (
-  <Kb.ClickableBox onClick={onClick}>
+const BigButton = ({onClick, icon, mainText, subText, waiting}: BigButtonProps) => (
+  <Kb.ClickableBox onClick={waiting ? undefined : onClick}>
     <Kb.Box2
       direction={Styles.isMobile ? 'horizontal' : 'vertical'}
       style={styles.bigButton}
       className="hover_background_color_blueLighter2"
     >
-      <Kb.Box2 direction="horizontal" centerChildren={true} style={styles.buttonIcon} gap="tiny">
+      <Kb.Box2
+        direction="horizontal"
+        centerChildren={true}
+        style={Styles.collapseStyles([styles.buttonIcon, waiting && Styles.globalStyles.opacity0])}
+        gap="tiny"
+      >
         <Kb.Icon type={icon} sizeType="Big" color={Styles.globalColors.blue} />
       </Kb.Box2>
-      <Kb.Box2 direction="vertical" style={styles.buttonText}>
+      <Kb.Box2
+        direction="vertical"
+        style={Styles.collapseStyles([styles.buttonText, waiting && Styles.globalStyles.opacity0])}
+      >
         <Kb.Text type="Body">{mainText}</Kb.Text>
         <Kb.Text type="BodySmall">{subText}</Kb.Text>
       </Kb.Box2>
+      {waiting && (
+        <Kb.Box2 direction="vertical" style={styles.bigButtonWaiting} centerChildren={true}>
+          <Kb.ProgressIndicator />
+        </Kb.Box2>
+      )}
     </Kb.Box2>
   </Kb.ClickableBox>
 )
 
 const Troubleshooting = (props: Props) => {
   const dispatch = Container.useDispatch()
+  const [waiting, setWaiting] = React.useState(false)
   const onBack = props.onCancel
   const username = Container.useSelector(state => state.provision.username)
-  const onWayBack = React.useCallback(() => dispatch(ProvisionGen.createBackToDeviceList({username})), [
-    dispatch,
-    username,
-  ])
+  const onWayBack = React.useCallback(() => {
+    dispatch(ProvisionGen.createBackToDeviceList({username}))
+    setWaiting(true)
+  }, [dispatch, username])
 
   const deviceName = Container.useSelector(state => state.provision.codePageOtherDeviceName)
   const deviceMap: Map<string, DeviceTypes.Device> = Container.useSelector(state => state.devices.deviceMap)
@@ -97,12 +112,14 @@ const Troubleshooting = (props: Props) => {
             icon={otherDeviceIcon}
             mainText={`I have my old "${deviceName}," let me use it to authorize.`}
             subText={`Back to ${props.mode} code`}
+            waiting={false}
           />
           <BigButton
             onClick={onWayBack}
             icon="iconfont-reply"
             mainText="I'll use a different device, or reset my account."
             subText="Back to list"
+            waiting={waiting}
           />
         </Kb.Box2>
       </Kb.Box2>
@@ -119,6 +136,7 @@ const styles = Styles.styleSheetCreate(() => ({
       borderRadius: 4,
       borderStyle: 'solid',
       borderWidth: 1,
+      position: 'relative',
     },
     isElectron: {
       maxWidth: 252,
@@ -128,6 +146,10 @@ const styles = Styles.styleSheetCreate(() => ({
       width: '100%',
     },
   }),
+  bigButtonWaiting: {
+    ...Styles.globalStyles.fillAbsolute,
+    backgroundColor: Styles.globalColors.white_40,
+  },
   bodyMargins: Styles.platformStyles({
     isElectron: Styles.padding(Styles.globalMargins.medium, Styles.globalMargins.xlarge, 0),
   }),

--- a/shared/provision/troubleshooting/index.tsx
+++ b/shared/provision/troubleshooting/index.tsx
@@ -39,9 +39,10 @@ const Troubleshooting = (props: Props) => {
   const dispatch = Container.useDispatch()
   const onBack = props.onCancel
   const username = Container.useSelector(state => state.provision.username)
-  const onWayBack = React.useCallback(() => {
-    dispatch(ProvisionGen.createSubmitUsername({username}))
-  }, [username])
+  const onWayBack = React.useCallback(() => dispatch(ProvisionGen.createBackToDeviceList({username})), [
+    dispatch,
+    username,
+  ])
 
   const deviceName = Container.useSelector(state => state.provision.codePageOtherDeviceName)
   const deviceMap: Map<string, DeviceTypes.Device> = Container.useSelector(state => state.devices.deviceMap)

--- a/shared/provision/troubleshooting/index.tsx
+++ b/shared/provision/troubleshooting/index.tsx
@@ -3,11 +3,12 @@ import * as Styles from '../../styles'
 import * as Container from '../../util/container'
 import * as Kb from '../../common-adapters'
 import * as DevicesConstants from '../../constants/devices'
-import * as DeviceTypes from '../../constants/types/devices'
+import * as Types from '../../constants/types/devices'
 import * as ProvisionGen from '../../actions/provision-gen'
 type Props = {
   mode: 'QR' | 'text'
   onCancel: () => void
+  otherDeviceType: Types.DeviceType
 }
 
 type BigButtonProps = {
@@ -60,12 +61,12 @@ const Troubleshooting = (props: Props) => {
   }, [dispatch, username])
 
   const deviceName = Container.useSelector(state => state.provision.codePageOtherDeviceName)
-  const deviceMap: Map<string, DeviceTypes.Device> = Container.useSelector(state => state.devices.deviceMap)
+  const deviceMap: Map<string, Types.Device> = Container.useSelector(state => state.devices.deviceMap)
   const deviceId = Container.useSelector(state => state.provision.codePageOtherDeviceId)
   const deviceIconNo = DevicesConstants.getDeviceIconNumberInner(deviceMap, deviceId)
 
   // If we can't load the device icon, show the wrong one instead of erroring the whole page.
-  const otherDeviceIcon = `icon-${Styles.isMobile ? 'phone' : 'computer'}-background-${
+  const otherDeviceIcon = `icon-${props.otherDeviceType === 'mobile' ? 'phone' : 'computer'}-background-${
     deviceIconNo === -1 ? 1 : deviceIconNo
   }-64` as Kb.IconType
 

--- a/shared/styles/index.d.ts
+++ b/shared/styles/index.d.ts
@@ -61,6 +61,7 @@ export declare const globalStyles: {
   }
   italic: _fakeFontDefSeeCommentsOnThisStyle
   loadingTextStyle: CSS._StylesCrossPlatform
+  opacity0: {opacity: 0}
   rounded: {
     borderRadius: 3
   }

--- a/shared/styles/shared.tsx
+++ b/shared/styles/shared.tsx
@@ -66,6 +66,7 @@ export const util = ({flexCommon}: {flexCommon?: Object | null}) => ({
   flexWrap: {flexWrap: 'wrap'},
   fullHeight: {height: '100%'},
   fullWidth: {width: '100%'},
+  opacity0: {opacity: 0},
   rounded: {borderRadius: 3},
 })
 


### PR DESCRIPTION
- Make a new action `backToDeviceList` lets you go "back" by waiting for the current provisioning call to end and starting a new one.
- Make banner position consistent on desktop
- Fix scroll behavior on mobile
- Use other device type instead of current in a few places

cc @keybase/y2ksquad 