### PR TITLE
Fix the disclaimer getting stuck on desktop if revisited before accepting

### DIFF
--- a/shared/wallets/routes.tsx
+++ b/shared/wallets/routes.tsx
@@ -104,6 +104,9 @@ class _OnboardingOrWallets extends React.Component<OnboardingOrWalletsProps> {
   componentDidMount() {
     if (!this.props.acceptedDisclaimer) {
       this.props.navigation.navigate('onboarding')
+    } else {
+      // We might have navigated to onboarding on a previous mount.
+      this.props.navigation.navigate('walletsubnav')
     }
   }
 


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

On a fresh account:
* click Wallets tab, you see the disclaimer.  Instead of accepting it, click to the Chat tab, and accept the disclaimer there from an in-chat send.
* You're redirected to the Wallets tab after the disclaimer screens are finished, but it's still showing the onboarding component.
* This is because the Wallets tab is still on the onboarding route, the check on whether to go to that route was only happening upstream.