### PR TITLE
List team memberships for chats

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -2903,7 +2903,7 @@ func (h *Server) SetBotMemberSettings(ctx context.Context, arg chat1.SetBotMembe
 func (h *Server) GetBotMemberSettings(ctx context.Context, arg chat1.GetBotMemberSettingsArg) (res keybase1.TeamBotSettings, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure
 	ctx = globals.ChatCtx(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks, h.identNotifier)
-	defer h.Trace(ctx, func() error { return err }, "SetBotMemberSettings")()
+	defer h.Trace(ctx, func() error { return err }, "GetBotMemberSettings")()
 	defer func() { err = h.fixupTeamErrorWithTLFName(ctx, arg.Username, arg.TlfName, err) }()
 	if _, err = utils.AssertLoggedInUID(ctx, h.G()); err != nil {
 		return res, err
@@ -2915,4 +2915,15 @@ func (h *Server) GetBotMemberSettings(ctx context.Context, arg chat1.GetBotMembe
 	}
 
 	return teams.GetBotSettingsByID(ctx, h.G().ExternalG(), teamID, arg.Username)
+}
+
+func (h *Server) TeamIDFromTLFName(ctx context.Context, arg chat1.TeamIDFromTLFNameArg) (res keybase1.TeamID, err error) {
+	var identBreaks []keybase1.TLFIdentifyFailure
+	ctx = globals.ChatCtx(ctx, h.G(), keybase1.TLFIdentifyBehavior_CHAT_GUI, &identBreaks, h.identNotifier)
+	defer h.Trace(ctx, func() error { return err }, "TeamIDFromTLFName")()
+	if _, err = utils.AssertLoggedInUID(ctx, h.G()); err != nil {
+		return res, err
+	}
+
+	return h.teamIDFromTLFName(ctx, arg.MembersType, arg.TlfName, arg.TlfPublic)
 }

--- a/go/client/team_cli_rendering.go
+++ b/go/client/team_cli_rendering.go
@@ -1,0 +1,182 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type teamMembersRenderer struct {
+	libkb.Contextified
+	json, showInviteID bool
+	tabw               *tabwriter.Writer
+}
+
+func newTeamMembersRenderer(g *libkb.GlobalContext, json, showInviteID bool) *teamMembersRenderer {
+	return &teamMembersRenderer{
+		Contextified: libkb.NewContextified(g),
+		json:         json,
+	}
+}
+
+func (c *teamMembersRenderer) output(details keybase1.TeamDetails, team string, verbose bool) error {
+	if c.json {
+		return c.outputJSON(details)
+	}
+
+	return c.outputTerminal(details, team, verbose)
+}
+
+func (c *teamMembersRenderer) outputJSON(details keybase1.TeamDetails) error {
+	b, err := json.MarshalIndent(details, "", "    ")
+	if err != nil {
+		return err
+	}
+	dui := c.G().UI.GetDumbOutputUI()
+	_, err = dui.Printf(string(b) + "\n")
+	return err
+}
+
+func (c *teamMembersRenderer) outputTerminal(details keybase1.TeamDetails, team string, verbose bool) error {
+	dui := c.G().UI.GetTerminalUI()
+	c.tabw = new(tabwriter.Writer)
+	c.tabw.Init(dui.OutputWriter(), 0, 8, 2, ' ', 0)
+
+	c.outputRole(team, "owner", details.Members.Owners)
+	c.outputRole(team, "admin", details.Members.Admins)
+	c.outputRole(team, "writer", details.Members.Writers)
+	c.outputRole(team, "reader", details.Members.Readers)
+	c.outputRole(team, "bot", details.Members.Bots)
+	c.outputRole(team, "restricted_bot", details.Members.RestrictedBots)
+	c.outputInvites(details.AnnotatedActiveInvites)
+	c.tabw.Flush()
+
+	if verbose {
+		dui.Printf("At team key generation: %d\n", details.KeyGeneration)
+	}
+
+	return nil
+}
+
+func (c *teamMembersRenderer) outputRole(team, role string, members []keybase1.TeamMemberDetails) {
+	for _, member := range members {
+		var status string
+		switch member.Status {
+		case keybase1.TeamMemberStatus_RESET:
+			status = " (inactive due to account reset)"
+		case keybase1.TeamMemberStatus_DELETED:
+			status = " (inactive due to account delete)"
+		}
+		fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s%s\n", team, role, member.Username, member.FullName, status)
+	}
+}
+
+func (c *teamMembersRenderer) formatInviteName(invite keybase1.AnnotatedTeamInvite) (res string) {
+	res = string(invite.Name)
+	category, err := invite.Type.C()
+	if err == nil {
+		switch category {
+		case keybase1.TeamInviteCategory_SBS:
+			res = fmt.Sprintf("%s@%s", invite.Name, string(invite.Type.Sbs()))
+		case keybase1.TeamInviteCategory_SEITAN:
+			if res == "" {
+				res = "<token without label>"
+			}
+		}
+	}
+	return res
+}
+
+func (c *teamMembersRenderer) outputInvites(invites map[keybase1.TeamInviteID]keybase1.AnnotatedTeamInvite) {
+	for _, invite := range invites {
+		category, err := invite.Type.C()
+		if err != nil {
+			category = keybase1.TeamInviteCategory_UNKNOWN
+		}
+		trailer := fmt.Sprintf("(* invited by %s, awaiting acceptance)", invite.InviterUsername)
+		switch category {
+		case keybase1.TeamInviteCategory_EMAIL:
+			trailer = fmt.Sprintf("(* invited via email by %s, awaiting acceptance)", invite.InviterUsername)
+		case keybase1.TeamInviteCategory_SEITAN:
+			inviteIDTrailer := ""
+			if c.showInviteID {
+				// Show invite IDs for SEITAN tokens, which can be used to cancel the invite.
+				inviteIDTrailer = fmt.Sprintf(" (Invite ID: %s)", invite.Id)
+			}
+			trailer = fmt.Sprintf("(* invited via secret token by %s, awaiting acceptance)%s",
+				invite.InviterUsername, inviteIDTrailer)
+		}
+		fmtstring := "%s\t%s*\t%s\t%s\n"
+		fmt.Fprintf(c.tabw, fmtstring, invite.TeamName, strings.ToLower(invite.Role.String()),
+			c.formatInviteName(invite), trailer)
+	}
+}
+
+func (c *teamMembersRenderer) outputTeams(list keybase1.AnnotatedTeamList, showAll bool) error {
+
+	sort.Slice(list.Teams, func(i, j int) bool {
+		if list.Teams[i].FqName == list.Teams[j].FqName {
+			return list.Teams[i].Username < list.Teams[j].Username
+		}
+		return list.Teams[i].FqName < list.Teams[j].FqName
+	})
+
+	if c.json {
+		b, err := json.Marshal(list)
+		if err != nil {
+			return err
+		}
+		tui := c.G().UI.GetTerminalUI()
+		err = tui.OutputDesc(OutputDescriptorTeamList, string(b)+"\n")
+		return err
+	}
+
+	dui := c.G().UI.GetTerminalUI()
+	c.tabw = new(tabwriter.Writer)
+	c.tabw.Init(dui.OutputWriter(), 0, 8, 4, ' ', 0)
+
+	// Only print the username and full name columns when we're showing other users.
+	if showAll {
+		fmt.Fprintf(c.tabw, "Team\tRole\tUsername\tFull name\n")
+	} else {
+		fmt.Fprintf(c.tabw, "Team\tRole\tMembers\n")
+	}
+	for _, t := range list.Teams {
+		var role string
+		if t.Implicit != nil {
+			role += "implied admin"
+		}
+		if t.Role != keybase1.TeamRole_NONE {
+			if t.Implicit != nil {
+				role += ", "
+			}
+			role += strings.ToLower(t.Role.String())
+		}
+		if showAll {
+			var status string
+			switch t.Status {
+			case keybase1.TeamMemberStatus_RESET:
+				status = " (inactive due to account reset)"
+			case keybase1.TeamMemberStatus_DELETED:
+				status = " (inactive due to account delete)"
+			}
+			if len(t.FullName) > 0 && len(status) > 0 {
+				status = " " + status
+			}
+			fmt.Fprintf(c.tabw, "%s\t%s\t%s\t%s%s\n", t.FqName, role, t.Username, t.FullName, status)
+		} else {
+			fmt.Fprintf(c.tabw, "%s\t%s\t%d\n", t.FqName, role, t.MemberCount)
+		}
+	}
+	if showAll {
+		c.outputInvites(list.AnnotatedActiveInvites)
+	}
+
+	c.tabw.Flush()
+	return nil
+}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -6174,6 +6174,12 @@ type GetBotMemberSettingsArg struct {
 	TlfPublic   bool                    `codec:"tlfPublic" json:"tlfPublic"`
 }
 
+type TeamIDFromTLFNameArg struct {
+	TlfName     string                  `codec:"tlfName" json:"tlfName"`
+	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+	TlfPublic   bool                    `codec:"tlfPublic" json:"tlfPublic"`
+}
+
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
 	GetCachedThread(context.Context, GetCachedThreadArg) (GetThreadLocalRes, error)
@@ -6263,6 +6269,7 @@ type LocalInterface interface {
 	RemoveBotMember(context.Context, RemoveBotMemberArg) error
 	SetBotMemberSettings(context.Context, SetBotMemberSettingsArg) error
 	GetBotMemberSettings(context.Context, GetBotMemberSettingsArg) (keybase1.TeamBotSettings, error)
+	TeamIDFromTLFName(context.Context, TeamIDFromTLFNameArg) (keybase1.TeamID, error)
 }
 
 func LocalProtocol(i LocalInterface) rpc.Protocol {
@@ -7544,6 +7551,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 					return
 				},
 			},
+			"teamIDFromTLFName": {
+				MakeArg: func() interface{} {
+					var ret [1]TeamIDFromTLFNameArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]TeamIDFromTLFNameArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]TeamIDFromTLFNameArg)(nil), args)
+						return
+					}
+					ret, err = i.TeamIDFromTLFName(ctx, typedArgs[0])
+					return
+				},
+			},
 		},
 	}
 }
@@ -8007,5 +8029,10 @@ func (c LocalClient) SetBotMemberSettings(ctx context.Context, __arg SetBotMembe
 
 func (c LocalClient) GetBotMemberSettings(ctx context.Context, __arg GetBotMemberSettingsArg) (res keybase1.TeamBotSettings, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getBotMemberSettings", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c LocalClient) TeamIDFromTLFName(ctx context.Context, __arg TeamIDFromTLFNameArg) (res keybase1.TeamID, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.teamIDFromTLFName", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -3311,6 +3311,11 @@ type TeamCreateWithSettingsArg struct {
 	Settings    TeamSettings `codec:"settings" json:"settings"`
 }
 
+type TeamGetByIDArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Id        TeamID `codec:"id" json:"id"`
+}
+
 type TeamGetArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Name      string `codec:"name" json:"name"`
@@ -3617,6 +3622,7 @@ type FtlArg struct {
 type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) (TeamCreateResult, error)
 	TeamCreateWithSettings(context.Context, TeamCreateWithSettingsArg) (TeamCreateResult, error)
+	TeamGetByID(context.Context, TeamGetByIDArg) (TeamDetails, error)
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamGetMembers(context.Context, TeamGetMembersArg) (TeamMembersDetails, error)
 	TeamImplicitAdmins(context.Context, TeamImplicitAdminsArg) ([]TeamMemberDetails, error)
@@ -3718,6 +3724,21 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamCreateWithSettings(ctx, typedArgs[0])
+					return
+				},
+			},
+			"teamGetByID": {
+				MakeArg: func() interface{} {
+					var ret [1]TeamGetByIDArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]TeamGetByIDArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]TeamGetByIDArg)(nil), args)
+						return
+					}
+					ret, err = i.TeamGetByID(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -4516,6 +4537,11 @@ func (c TeamsClient) TeamCreate(ctx context.Context, __arg TeamCreateArg) (res T
 
 func (c TeamsClient) TeamCreateWithSettings(ctx context.Context, __arg TeamCreateWithSettingsArg) (res TeamCreateResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateWithSettings", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c TeamsClient) TeamGetByID(ctx context.Context, __arg TeamGetByIDArg) (res TeamDetails, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetByID", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -1207,4 +1207,6 @@ protocol local {
   void removeBotMember(string tlfName, string username, ConversationMembersType membersType, boolean tlfPublic);
   void setBotMemberSettings(string tlfName, string username, keybase1.TeamBotSettings botSettings, ConversationMembersType membersType, boolean tlfPublic);
   keybase1.TeamBotSettings getBotMemberSettings(string tlfName, string username, ConversationMembersType membersType, boolean tlfPublic);
+
+  keybase1.TeamID teamIDFromTLFName(string tlfName, ConversationMembersType membersType, boolean tlfPublic);
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1136,6 +1136,10 @@ protocol teams {
 
   // A user can hope for success if and only if they are a member of
   // the team or an admin of any of its ancestors.
+  TeamDetails teamGetByID(int sessionID, TeamID id);
+
+  // A user can hope for success if and only if they are a member of
+  // the team or an admin of any of its ancestors.
   TeamDetails teamGet(int sessionID, string name);
 
   // Get the members of the team

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -5247,6 +5247,23 @@
         }
       ],
       "response": "keybase1.TeamBotSettings"
+    },
+    "teamIDFromTLFName": {
+      "request": [
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "membersType",
+          "type": "ConversationMembersType"
+        },
+        {
+          "name": "tlfPublic",
+          "type": "boolean"
+        }
+      ],
+      "response": "keybase1.TeamID"
     }
   },
   "namespace": "chat.1"

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2947,6 +2947,19 @@
       ],
       "response": "TeamCreateResult"
     },
+    "teamGetByID": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "id",
+          "type": "TeamID"
+        }
+      ],
+      "response": "TeamDetails"
+    },
     "teamGet": {
       "request": [
         {

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -1503,6 +1503,7 @@ export const localUpdateUnsentTextRpcPromise = (params: MessageTypes['chat.1.loc
 // 'chat.1.local.removeBotMember'
 // 'chat.1.local.setBotMemberSettings'
 // 'chat.1.local.getBotMemberSettings'
+// 'chat.1.local.teamIDFromTLFName'
 // 'chat.1.NotifyChat.NewChatActivity'
 // 'chat.1.NotifyChat.ChatIdentifyUpdate'
 // 'chat.1.NotifyChat.ChatTLFFinalize'

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -3683,6 +3683,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.streamUi.reset'
 // 'keybase.1.streamUi.write'
 // 'keybase.1.teams.teamCreateWithSettings'
+// 'keybase.1.teams.teamGetByID'
 // 'keybase.1.teams.teamImplicitAdmins'
 // 'keybase.1.teams.teamListTeammates'
 // 'keybase.1.teams.teamListVerified'


### PR DESCRIPTION
depends on https://github.com/keybase/client/pull/20081

outputs team membership based no the `TeamGet` rpc as `keybase team list-members` does currently.

in action for a 1-1 conv:

```
$ keybaseb chat list-members test8
test8  owner           test8  
test8  restricted_bot  test1  
```

