### PR TITLE
backpressure_disk_limiter: allow any fraction greater in (0,1]

### DIFF
--- a/go/kbfs/libkbfs/backpressure_disk_limiter.go
+++ b/go/kbfs/libkbfs/backpressure_disk_limiter.go
@@ -78,8 +78,8 @@ func newBackpressureTracker(minThreshold, maxThreshold, limitFrac float64,
 		return nil, errors.Errorf("1.0 < maxThreshold=%f",
 			maxThreshold)
 	}
-	if limitFrac < 0.01 {
-		return nil, errors.Errorf("limitFrac=%f < 0.01", limitFrac)
+	if limitFrac <= 0 {
+		return nil, errors.Errorf("limitFrac=%f <= 0", limitFrac)
 	}
 	if limitFrac > 1.0 {
 		return nil, errors.Errorf("limitFrac=%f > 1.0", limitFrac)


### PR DESCRIPTION
Now that the fractions are configurable, they can reasonably be set to less than 0.01, especially on disks with large amounts of free space.