### PR TITLE
darkmode: fix menubar colors

### DIFF
--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -46,7 +46,7 @@ const getIcons = (iconType: BadgeType, isBadged: boolean) => {
   const size = isWindows ? 16 : 22
   const icon = `icon-${platform}keybase-menubar-${badged}${iconType}-${color}-${size}${devMode}@2x.png`
   // Only used on Darwin
-  const iconSelected = `icon-${platform}keybase-menubar-${iconType}-${colorSelected}-${size}${devMode}@2x.png`
+  const iconSelected = `icon-${platform}keybase-menubar-${badged}${iconType}-${colorSelected}-${size}${devMode}@2x.png`
   return [icon, iconSelected]
 }
 

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -13,6 +13,7 @@ import {BadgeType} from '../constants/types/notifications'
 import {isDarwin, isWindows} from '../constants/platform'
 import {resolveImage} from '../desktop/app/resolve-root.desktop'
 import {getMainWindow} from '../desktop/remote/util.desktop'
+import {isSystemDarkMode} from '../styles/dark-mode'
 
 const _windowOpts = {}
 
@@ -36,7 +37,7 @@ const getIcons = (iconType: BadgeType, isBadged: boolean) => {
   const badged = isBadged ? 'badged-' : ''
 
   if (isDarwin) {
-    color = Styles.isDarkMode() ? 'white' : 'black'
+    color = isSystemDarkMode() ? 'white' : 'black'
   } else if (isWindows) {
     color = 'black'
     platform = 'windows-'
@@ -45,7 +46,7 @@ const getIcons = (iconType: BadgeType, isBadged: boolean) => {
   const size = isWindows ? 16 : 22
   const icon = `icon-${platform}keybase-menubar-${badged}${iconType}-${color}-${size}${devMode}@2x.png`
   // Only used on Darwin
-  const iconSelected = `icon-${platform}keybase-menubar-${badged}${iconType}-${colorSelected}-${size}${devMode}@2x.png`
+  const iconSelected = `icon-${platform}keybase-menubar-${iconType}-${colorSelected}-${size}${devMode}@2x.png`
   return [icon, iconSelected]
 }
 

--- a/shared/styles/dark-mode.tsx
+++ b/shared/styles/dark-mode.tsx
@@ -38,3 +38,4 @@ export const isDarkMode = () => {
 }
 
 export const isDarkModeSystemSupported = () => systemSupported
+export const isSystemDarkMode = () => systemDarkMode


### PR DESCRIPTION
Previously, the menubar icon was respecting dark mode of the app, it should instead respect dark mode of the system.

Thanks @zapu and @patrickxb for reporting this.