### PR TITLE
Don't show the badge on highlighting the menubar icon on OSX

### DIFF
--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -45,7 +45,7 @@ const getIcons = (iconType: BadgeType, isBadged: boolean) => {
   const size = isWindows ? 16 : 22
   const icon = `icon-${platform}keybase-menubar-${badged}${iconType}-${color}-${size}${devMode}@2x.png`
   // Only used on Darwin
-  const iconSelected = `icon-${platform}keybase-menubar-${badged}${iconType}-${colorSelected}-${size}${devMode}@2x.png`
+  const iconSelected = `icon-${platform}keybase-menubar-${iconType}-${colorSelected}-${size}${devMode}@2x.png`
   return [icon, iconSelected]
 }
 


### PR DESCRIPTION
It feels to me like a bug that when you select the highlighted menubar icon in light mode on OSX, the badge appears as the orange dot used in dark mode.

This is not a release blocker, not urgent.

@cecileboucheron / @adamjspooner is this intentional? WDYT of this change?

 - [x] design approval
