### PR TITLE
dont filter convs we unbox

### DIFF
--- a/go/chat/uiinboxloader.go
+++ b/go/chat/uiinboxloader.go
@@ -578,7 +578,9 @@ func (h *UIInboxLoader) UpdateLayoutFromSubteamRename(ctx context.Context, convs
 
 func (h *UIInboxLoader) UpdateConvs(ctx context.Context, convIDs []chat1.ConversationID) (err error) {
 	defer h.Trace(ctx, func() error { return err }, "UpdateConvs")()
-	query := h.Query()
-	query.ConvIDs = convIDs
+	query := chat1.GetInboxLocalQuery{
+		ComputeActiveList: true,
+		ConvIDs:           convIDs,
+	}
 	return h.LoadNonblock(ctx, &query, nil, nil, true)
 }

--- a/go/chat/uiinboxloader_test.go
+++ b/go/chat/uiinboxloader_test.go
@@ -40,18 +40,23 @@ func TestUIInboxLoaderLayout(t *testing.T) {
 		return chat1.UIInboxLayout{}
 	}
 
+	var layout chat1.UIInboxLayout
 	t.Logf("basic")
 	conv1 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 		chat1.ConversationMembersType_IMPTEAMNATIVE, users[1])
-	layout := recvLayout()
-	require.Equal(t, 1, len(layout.SmallTeams))
-	require.Equal(t, conv1.Id.String(), layout.SmallTeams[0].ConvID)
+	for i := 0; i < 2; i++ {
+		layout = recvLayout()
+		require.Equal(t, 1, len(layout.SmallTeams))
+		require.Equal(t, conv1.Id.String(), layout.SmallTeams[0].ConvID)
+	}
 	conv2 := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
 		chat1.ConversationMembersType_IMPTEAMNATIVE, users[2])
-	layout = recvLayout()
-	require.Equal(t, 2, len(layout.SmallTeams))
-	require.Equal(t, conv2.Id.String(), layout.SmallTeams[0].ConvID)
-	require.Equal(t, conv1.Id.String(), layout.SmallTeams[1].ConvID)
+	for i := 0; i < 2; i++ {
+		layout = recvLayout()
+		require.Equal(t, 2, len(layout.SmallTeams))
+		require.Equal(t, conv2.Id.String(), layout.SmallTeams[0].ConvID)
+		require.Equal(t, conv1.Id.String(), layout.SmallTeams[1].ConvID)
+	}
 	select {
 	case <-chatUI.InboxLayoutCb:
 		require.Fail(t, "unexpected layout")


### PR DESCRIPTION
Fixes hidden convs never being unboxed. We don't need to filter since nothing shows up in the layout that is filtered, regardless of presence of meta in the map.

cc @buoyad 