### PR TITLE
tweak styles on claimable payments in chat

### DIFF
--- a/shared/chat/payments/status/index.tsx
+++ b/shared/chat/payments/status/index.tsx
@@ -124,9 +124,9 @@ const styles = Styles.styleSheetCreate(
   () =>
     ({
       claimable: {
-        backgroundColor: Styles.globalColors.black_05OrBlack_60,
+        backgroundColor: Styles.globalColors.purple_10OrPurple,
         borderRadius: Styles.globalMargins.xxtiny,
-        color: Styles.globalColors.black_50OrWhite,
+        color: Styles.globalColors.purpleDarkOrWhite,
       },
       claimableIcon: {},
       completed: {


### PR DESCRIPTION
i couldn't find any designs for this, so i took a stab.
## BEFORE
<img width="300" alt="before lightmode" src="https://user-images.githubusercontent.com/1275828/66334562-4c8f1880-e907-11e9-8ca3-b382c57d6c37.png">
<img width="300" alt="before darkmode" src="https://user-images.githubusercontent.com/1275828/66334561-4c8f1880-e907-11e9-89a1-76bf5ec2b4b4.png">

## AFTER
<img width="300" alt="after lightmode" src="https://user-images.githubusercontent.com/1275828/66334559-4c8f1880-e907-11e9-9473-627dc3810823.png">
<img width="300" alt="after darkmode" src="https://user-images.githubusercontent.com/1275828/66334560-4c8f1880-e907-11e9-94af-b76d7160a0bd.png">

and from the recipient's perspective:
<img width="300" alt="Screen Shot 2019-10-07 at 2 04 40 PM" src="https://user-images.githubusercontent.com/1275828/66336630-7b0ef280-e90b-11e9-810f-66d70e130542.png">

