### PR TITLE
tweak styles on claimable payments in chat

### DIFF
--- a/shared/chat/payments/status/index.tsx
+++ b/shared/chat/payments/status/index.tsx
@@ -37,7 +37,7 @@ const getIcon = status => {
     case 'completed':
       return 'iconfont-success'
     case 'claimable':
-      return 'iconfont-time'
+      return 'iconfont-success'
     case 'pending':
       return 'iconfont-time'
     case 'error':
@@ -124,9 +124,9 @@ const styles = Styles.styleSheetCreate(
   () =>
     ({
       claimable: {
-        backgroundColor: Styles.globalColors.black_05OrBlack_60,
+        backgroundColor: Styles.globalColors.purple_10OrPurple,
         borderRadius: Styles.globalMargins.xxtiny,
-        color: Styles.globalColors.black_50OrWhite,
+        color: Styles.globalColors.purpleDarkOrWhite,
       },
       claimableIcon: {},
       completed: {


### PR DESCRIPTION
## BEFORE
<img width="300" alt="before lightmode" src="https://user-images.githubusercontent.com/1275828/66334562-4c8f1880-e907-11e9-8ca3-b382c57d6c37.png">
<img width="300" alt="before darkmode" src="https://user-images.githubusercontent.com/1275828/66334561-4c8f1880-e907-11e9-89a1-76bf5ec2b4b4.png">

## AFTER
