### PR TITLE
modes: use `stopIfFull` when prefetching the root block

### DIFF
--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -617,6 +617,12 @@ func (bra BlockRequestAction) StopIfFull() bool {
 	return bra&blockRequestStopIfFull > 0
 }
 
+// AddStopIfFull returns a new action that adds the "stop-if-full"
+// behavior in addition to the original request.
+func (bra BlockRequestAction) AddStopIfFull() BlockRequestAction {
+	return bra | blockRequestStopIfFull
+}
+
 // DelayedCacheCheckAction returns a new action that adds the
 // delayed-cache-check feature to `bra`.
 func (bra BlockRequestAction) DelayedCacheCheckAction() BlockRequestAction {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1681,7 +1681,8 @@ func (fbo *folderBranchOps) kickOffRootBlockFetch(
 	ptr := rmd.Data().Dir.BlockPointer
 	return fbo.config.BlockOps().BlockRetriever().Request(
 		ctx, defaultOnDemandRequestPriority-1, rmd, ptr, data.NewDirBlock(),
-		data.TransientEntry, fbo.config.Mode().DefaultBlockRequestAction())
+		data.TransientEntry,
+		fbo.config.Mode().DefaultBlockRequestAction().AddStopIfFull())
 }
 
 func (fbo *folderBranchOps) logIfErr(


### PR DESCRIPTION
This seems to fix a bug where `stopifFull` wasn't being respected for the partial syncs kicked off by FBO.  The issue is that both the root block prefetch (which previously didn't use `stopIfFull`) and then partial prefetch (which did) happened at about the same time, and the requests got combined together in the retrieval queue.  But, if one of the requests doesn't use `stopIfFull`, it gets dropped from the action completely.

Now we just use `stopIfFull` when prefetching the root block -- I can't imagine a situation where we'd rather pre-fetch past the root block when the cache is full, given that the user hasn't even requested the actual root block yet.

Of course there can still be that race if the root block is explicitly fetched at the exact wrong time, but hopefully this will catch most of the cases and is good enough for now.

Issue: HOTPOT-943
Issue: #20106