### PR TITLE
[Android] Change launchMode to be singleTask

### DIFF
--- a/shared/android/app/src/main/AndroidManifest.xml
+++ b/shared/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
       <activity
         android:name=".MainActivity"
         android:screenOrientation="portrait"
-        android:launchMode="singleTop"
+        android:launchMode="singleTask"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:windowSoftInputMode="adjustResize"


### PR DESCRIPTION
Jess noticed an issue where trello would launch the Keybase MainActivity
in it's task, rather than launch a new task with just the Keybase
activity.

This is because our launchMode was set to sigleTop, which will create a
new instance of the activity if it doesn't exist in the task, and trello
was asking to create the activity on it's task.

It doesn't affect anything, it just looks and feels wrong.

This changes the launch mode so that it is a `singleTask` which allows
only one instance on the device at a time. In the trello example, it
will open the keybase activity by opening the keybase app (as expected)

`singleInstance` is not chosen because it will prohibit other activities
from launching in the task, which will probably break the RN devtools
and the crop image activity.

@keybase/react-hackers 