### PR TITLE
folder_block_ops: avoid panic when undoing node cache ops on error

### DIFF
--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -1192,7 +1192,9 @@ func (fbo *folderBlockOps) removeDirEntryInCacheLocked(
 	parentUndo, err := fbo.updateParentDirEntryLocked(
 		ctx, lState, dir, kmd, true, true)
 	if err != nil {
-		unlinkUndoFn()
+		if unlinkUndoFn != nil {
+			unlinkUndoFn()
+		}
 		_, _ = dd.AddEntry(ctx, oldName, oldDe)
 		return nil, err
 	}
@@ -1200,9 +1202,15 @@ func (fbo *folderBlockOps) removeDirEntryInCacheLocked(
 	undoDirtyFn := fbo.makeDirDirtyLocked(lState, dir.TailPointer(), unrefs)
 	return func() {
 		_, _ = dd.AddEntry(ctx, oldName, oldDe)
-		undoDirtyFn()
-		parentUndo()
-		unlinkUndoFn()
+		if undoDirtyFn != nil {
+			undoDirtyFn()
+		}
+		if parentUndo != nil {
+			parentUndo()
+		}
+		if unlinkUndoFn != nil {
+			unlinkUndoFn()
+		}
 	}, nil
 }
 


### PR DESCRIPTION
When node cache operations return errors (e.g., due to other bugs such as HOTPOT-814) and the pointer state is inconsistent, we might need to execute undo functions.  But those undo functions themselves can legally be `nil`, and in those error cases are even more likely to be `nil`.  So Check that before executing them (which is consistent with the way undo functions are used in other parts of this code).

Issue: HOTPOT-948