### PR TITLE
Check for newmessageSilent_2 notification type as well in startup

### DIFF
--- a/shared/actions/platform-specific/push.native.tsx
+++ b/shared/actions/platform-specific/push.native.tsx
@@ -383,7 +383,7 @@ function* getStartupDetailsFromInitialPush() {
     if (notification.username) {
       return {startupFollowUser: notification.username}
     }
-  } else if (notification.type === 'chat.newmessage') {
+  } else if (notification.type === 'chat.newmessage' || notification.type === 'chat.newmessageSilent_2') {
     if (notification.conversationIDKey) {
       return {startupConversation: notification.conversationIDKey}
     }


### PR DESCRIPTION
This fixes push notifications routing to the chat while the app is not running. cc @keybase/y2ksquad 