### PR TITLE
Dark mode fixes in relogin flow

### DIFF
--- a/shared/login/relogin/index.native.tsx
+++ b/shared/login/relogin/index.native.tsx
@@ -48,7 +48,7 @@ class LoginRender extends React.Component<Props> {
     ]
 
     return (
-      <Kb.NativeScrollView>
+      <Kb.NativeScrollView style={styles.scrollView}>
         <Kb.Box style={styles.container}>
           {isAndroid && !isDeviceSecureAndroid && !isAndroidNewerThanM && (
             <Kb.Box style={styles.deviceNotSecureContainer}>
@@ -133,6 +133,9 @@ const styles = Styles.styleSheetCreate(
       },
       deviceNotSecureText: {
         color: Styles.globalColors.brown_75,
+      },
+      scrollView: {
+        backgroundColor: Styles.globalColors.white,
       },
     } as const)
 )

--- a/shared/login/routes.tsx
+++ b/shared/login/routes.tsx
@@ -42,7 +42,7 @@ const RootLogin = Container.connect(
 )(_RootLogin)
 
 export const newRoutes = {
-  feedback: {getScreen: (): typeof Feedback => require('../settings/feedback/container').default},
+  feedback: {getScreen: (): typeof Feedback => require('../signup/feedback/container').default},
   login: {getScreen: () => RootLogin},
   resetConfirm: {getScreen: (): typeof Confirm => require('./reset/confirm').default},
   resetEnterPassword: {getScreen: (): typeof EnterPassword => require('./reset/password').EnterPassword},

--- a/shared/signup/common.tsx
+++ b/shared/signup/common.tsx
@@ -147,7 +147,13 @@ type SignupScreenProps = {
 
 // Screens with header + body bg color (i.e. all but join-or-login)
 export const SignupScreen = (props: SignupScreenProps) => (
-  <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} alignItems="center">
+  <Kb.Box2
+    direction="vertical"
+    fullWidth={true}
+    fullHeight={true}
+    alignItems="center"
+    style={props.noBackground ? styles.whiteBackground : styles.blueBackground}
+  >
     {!Styles.isMobile && (
       <Header
         onBack={props.onBack}


### PR DESCRIPTION
Fixes some weird background issues on relogin page and create account from relogin screen flow; replaces the feedback form from settings with the one from the signup flow (fixes dark mode weirdness, is a little more consistent header-wise)