### PR TITLE
User switching UX improvements

### DIFF
--- a/shared/actions/config-gen.tsx
+++ b/shared/actions/config-gen.tsx
@@ -47,6 +47,7 @@ export const setOpenAtLogin = 'config:setOpenAtLogin'
 export const setStartupDetails = 'config:setStartupDetails'
 export const setSystemDarkMode = 'config:setSystemDarkMode'
 export const setUseNativeFrame = 'config:setUseNativeFrame'
+export const setUserSwitching = 'config:setUserSwitching'
 export const showMain = 'config:showMain'
 export const startHandshake = 'config:startHandshake'
 export const updateCriticalCheckStatus = 'config:updateCriticalCheckStatus'
@@ -130,6 +131,7 @@ type _SetStartupDetailsPayload = {
 }
 type _SetSystemDarkModePayload = {readonly dark: boolean}
 type _SetUseNativeFramePayload = {readonly useNativeFrame: boolean}
+type _SetUserSwitchingPayload = {readonly userSwitching: boolean}
 type _ShowMainPayload = void
 type _StartHandshakePayload = void
 type _UpdateCriticalCheckStatusPayload = {
@@ -333,6 +335,10 @@ export const createSetUseNativeFrame = (payload: _SetUseNativeFramePayload): Set
   payload,
   type: setUseNativeFrame,
 })
+export const createSetUserSwitching = (payload: _SetUserSwitchingPayload): SetUserSwitchingPayload => ({
+  payload,
+  type: setUserSwitching,
+})
 export const createShowMain = (payload: _ShowMainPayload): ShowMainPayload => ({payload, type: showMain})
 export const createUpdateHTTPSrvInfo = (payload: _UpdateHTTPSrvInfoPayload): UpdateHTTPSrvInfoPayload => ({
   payload,
@@ -457,6 +463,10 @@ export type SetUseNativeFramePayload = {
   readonly payload: _SetUseNativeFramePayload
   readonly type: typeof setUseNativeFrame
 }
+export type SetUserSwitchingPayload = {
+  readonly payload: _SetUserSwitchingPayload
+  readonly type: typeof setUserSwitching
+}
 export type ShowMainPayload = {readonly payload: _ShowMainPayload; readonly type: typeof showMain}
 export type StartHandshakePayload = {
   readonly payload: _StartHandshakePayload
@@ -521,6 +531,7 @@ export type Actions =
   | SetStartupDetailsPayload
   | SetSystemDarkModePayload
   | SetUseNativeFramePayload
+  | SetUserSwitchingPayload
   | ShowMainPayload
   | StartHandshakePayload
   | UpdateCriticalCheckStatusPayload

--- a/shared/actions/json/config.json
+++ b/shared/actions/json/config.json
@@ -96,6 +96,9 @@
       "causedBySignup": "boolean",
       "causedByStartup": "boolean"
     },
+    "setUserSwitching": {
+      "userSwitching": "boolean"
+    },
     "updateMenubarWindowID": {"id": "number"},
     "copyToClipboard": {"text": "string"},
     "checkForUpdate": {},

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -244,6 +244,7 @@ export type TypedActionsMap = {
   'config:setNavigator': config.SetNavigatorPayload
   'config:loggedOut': config.LoggedOutPayload
   'config:loggedIn': config.LoggedInPayload
+  'config:setUserSwitching': config.SetUserSwitchingPayload
   'config:updateMenubarWindowID': config.UpdateMenubarWindowIDPayload
   'config:copyToClipboard': config.CopyToClipboardPayload
   'config:checkForUpdate': config.CheckForUpdatePayload

--- a/shared/constants/config.tsx
+++ b/shared/constants/config.tsx
@@ -127,6 +127,7 @@ export const initialState: Types.State = {
   uid: '',
   useNativeFrame: defaultUseNativeFrame,
   userActive: true,
+  userSwitching: false,
   username: '',
   windowState: {
     dockHidden: false,

--- a/shared/constants/types/config.tsx
+++ b/shared/constants/types/config.tsx
@@ -79,5 +79,6 @@ export type State = {
   uid: string
   userActive: boolean
   username: string
+  userSwitching: boolean
   useNativeFrame: boolean
 }

--- a/shared/login/relogin/container.tsx
+++ b/shared/login/relogin/container.tsx
@@ -71,7 +71,7 @@ const LoginWrapper = (props: Props) => {
   return (
     <Login
       error={props.error}
-      hidePasswordBox={loggedInMap.get(selectedUser, false)}
+      hidePasswordBox={loggedInMap.get(selectedUser) || false}
       onFeedback={props.onFeedback}
       onForgotPassword={() => props.onForgotPassword(selectedUser)}
       onLogin={onLogin}

--- a/shared/login/relogin/container.tsx
+++ b/shared/login/relogin/container.tsx
@@ -71,6 +71,7 @@ const LoginWrapper = (props: Props) => {
   return (
     <Login
       error={props.error}
+      hidePasswordBox={loggedInMap.get(selectedUser, false)}
       onFeedback={props.onFeedback}
       onForgotPassword={() => props.onForgotPassword(selectedUser)}
       onLogin={onLogin}

--- a/shared/login/relogin/container.tsx
+++ b/shared/login/relogin/container.tsx
@@ -71,7 +71,7 @@ const LoginWrapper = (props: Props) => {
   return (
     <Login
       error={props.error}
-      hidePasswordBox={loggedInMap.get(selectedUser) || false}
+      needPassword={!loggedInMap.get(selectedUser)}
       onFeedback={props.onFeedback}
       onForgotPassword={() => props.onForgotPassword(selectedUser)}
       onLogin={onLogin}

--- a/shared/login/relogin/index.d.ts
+++ b/shared/login/relogin/index.d.ts
@@ -7,7 +7,7 @@ export type Props = {
   onSignup: () => void
   onSomeoneElse: () => void
   error: string
-  hidePasswordBox: boolean
+  needPassword: boolean
   password: string
   showTyping: boolean
   selectedUser: string

--- a/shared/login/relogin/index.d.ts
+++ b/shared/login/relogin/index.d.ts
@@ -7,6 +7,7 @@ export type Props = {
   onSignup: () => void
   onSomeoneElse: () => void
   error: string
+  hidePasswordBox: boolean
   password: string
   showTyping: boolean
   selectedUser: string

--- a/shared/login/relogin/index.desktop.tsx
+++ b/shared/login/relogin/index.desktop.tsx
@@ -11,11 +11,13 @@ type State = {
 
 const other = 'Someone else...'
 
-const UserRow = ({user}) => (
-  <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.userRow}>
+const UserRow = ({user, hasStoredSecret}) => (
+  <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.userRow} gap="small">
+    {hasStoredSecret && <Kb.Box style={styles.leftBox} />}
     <Kb.Text type="Header" style={user === other ? styles.other : styles.provisioned}>
       {user}
     </Kb.Text>
+    {hasStoredSecret && <Kb.Text type="BodySmallItalic">Signed in</Kb.Text>}
   </Kb.Box2>
 )
 
@@ -46,7 +48,7 @@ class Login extends React.Component<Props, State> {
   render() {
     const userRows = this.props.users
       .concat({hasStoredSecret: false, username: other})
-      .map(u => <UserRow user={u.username} key={u.username} />)
+      .map(u => <UserRow user={u.username} key={u.username} hasStoredSecret={u.hasStoredSecret} />)
 
     const selectedIdx = this.props.users.findIndex(u => u.username === this.props.selectedUser)
 
@@ -152,6 +154,9 @@ const styles = Styles.styleSheetCreate(
         marginBottom: 0,
         marginTop: Styles.globalMargins.tiny,
         width: '100%',
+      },
+      leftBox: {
+        width: 54,
       },
       loginSubmitButton: {
         marginTop: 0,

--- a/shared/login/relogin/index.desktop.tsx
+++ b/shared/login/relogin/index.desktop.tsx
@@ -51,7 +51,6 @@ class Login extends React.Component<Props, State> {
       .map(u => <UserRow user={u.username} key={u.username} hasStoredSecret={u.hasStoredSecret} />)
 
     const selectedIdx = this.props.users.findIndex(u => u.username === this.props.selectedUser)
-    const needPassword = !this.props.hidePasswordBox
     return (
       <SignupScreen
         banners={errorBanner(this.props.error)}
@@ -80,7 +79,7 @@ class Login extends React.Component<Props, State> {
               position="bottom center"
               style={styles.userDropdown}
             />
-            {needPassword && (
+            {this.props.needPassword && (
               <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputRow}>
                 <Kb.LabeledInput
                   autoFocus={true}
@@ -109,7 +108,7 @@ class Login extends React.Component<Props, State> {
               style={styles.loginSubmitContainer}
             >
               <Kb.WaitingButton
-                disabled={needPassword && !this.props.password}
+                disabled={this.props.needPassword && !this.props.password}
                 fullWidth={true}
                 waitingKey={Constants.waitingKey}
                 style={styles.loginSubmitButton}

--- a/shared/login/relogin/index.desktop.tsx
+++ b/shared/login/relogin/index.desktop.tsx
@@ -78,17 +78,19 @@ class Login extends React.Component<Props, State> {
               position="bottom center"
               style={styles.userDropdown}
             />
-            <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputRow}>
-              <Kb.LabeledInput
-                autoFocus={true}
-                placeholder="Password"
-                onChangeText={this.props.passwordChange}
-                onEnterKeyDown={this.props.onSubmit}
-                ref={this._inputRef}
-                type="password"
-                value={this.props.password}
-              />
-            </Kb.Box2>
+            {!this.props.hidePasswordBox && (
+              <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputRow}>
+                <Kb.LabeledInput
+                  autoFocus={true}
+                  placeholder="Password"
+                  onChangeText={this.props.passwordChange}
+                  onEnterKeyDown={this.props.onSubmit}
+                  ref={this._inputRef}
+                  type="password"
+                  value={this.props.password}
+                />
+              </Kb.Box2>
+            )}
             <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.forgotPasswordContainer}>
               <Kb.Text
                 type="BodySmallSecondaryLink"

--- a/shared/login/relogin/index.desktop.tsx
+++ b/shared/login/relogin/index.desktop.tsx
@@ -51,7 +51,7 @@ class Login extends React.Component<Props, State> {
       .map(u => <UserRow user={u.username} key={u.username} hasStoredSecret={u.hasStoredSecret} />)
 
     const selectedIdx = this.props.users.findIndex(u => u.username === this.props.selectedUser)
-
+    const needPassword = !this.props.hidePasswordBox
     return (
       <SignupScreen
         banners={errorBanner(this.props.error)}
@@ -80,7 +80,7 @@ class Login extends React.Component<Props, State> {
               position="bottom center"
               style={styles.userDropdown}
             />
-            {!this.props.hidePasswordBox && (
+            {needPassword && (
               <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.inputRow}>
                 <Kb.LabeledInput
                   autoFocus={true}
@@ -109,7 +109,7 @@ class Login extends React.Component<Props, State> {
               style={styles.loginSubmitContainer}
             >
               <Kb.WaitingButton
-                disabled={!this.props.password}
+                disabled={needPassword && !this.props.password}
                 fullWidth={true}
                 waitingKey={Constants.waitingKey}
                 style={styles.loginSubmitButton}

--- a/shared/login/relogin/index.native.tsx
+++ b/shared/login/relogin/index.native.tsx
@@ -66,11 +66,13 @@ class LoginRender extends React.Component<Props> {
               onOther={this.props.onSomeoneElse}
               options={this.props.users.map(u => u.username)}
             />
-            <Kb.FormWithCheckbox
-              style={{alignSelf: 'stretch'}}
-              inputProps={inputProps}
-              checkboxesProps={checkboxProps}
-            />
+            {!this.props.hidePasswordBox && (
+              <Kb.FormWithCheckbox
+                style={{alignSelf: 'stretch'}}
+                inputProps={inputProps}
+                checkboxesProps={checkboxProps}
+              />
+            )}
             <Kb.WaitingButton
               disabled={!this.props.password}
               waitingKey={Constants.waitingKey}

--- a/shared/login/relogin/index.native.tsx
+++ b/shared/login/relogin/index.native.tsx
@@ -46,7 +46,6 @@ class LoginRender extends React.Component<Props> {
         },
       },
     ]
-    const needPassword = !this.props.hidePasswordBox
 
     return (
       <Kb.NativeScrollView>
@@ -67,7 +66,7 @@ class LoginRender extends React.Component<Props> {
               onOther={this.props.onSomeoneElse}
               options={this.props.users.map(u => u.username)}
             />
-            {needPassword && (
+            {this.props.needPassword && (
               <Kb.FormWithCheckbox
                 style={{alignSelf: 'stretch'}}
                 inputProps={inputProps}
@@ -75,7 +74,7 @@ class LoginRender extends React.Component<Props> {
               />
             )}
             <Kb.WaitingButton
-              disabled={needPassword && !this.props.password}
+              disabled={this.props.needPassword && !this.props.password}
               waitingKey={Constants.waitingKey}
               style={{marginTop: 0, width: '100%'}}
               fullWidth={true}

--- a/shared/login/relogin/index.native.tsx
+++ b/shared/login/relogin/index.native.tsx
@@ -46,6 +46,7 @@ class LoginRender extends React.Component<Props> {
         },
       },
     ]
+    const needPassword = !this.props.hidePasswordBox
 
     return (
       <Kb.NativeScrollView>
@@ -66,7 +67,7 @@ class LoginRender extends React.Component<Props> {
               onOther={this.props.onSomeoneElse}
               options={this.props.users.map(u => u.username)}
             />
-            {!this.props.hidePasswordBox && (
+            {needPassword && (
               <Kb.FormWithCheckbox
                 style={{alignSelf: 'stretch'}}
                 inputProps={inputProps}
@@ -74,7 +75,7 @@ class LoginRender extends React.Component<Props> {
               />
             )}
             <Kb.WaitingButton
-              disabled={!this.props.password}
+              disabled={needPassword && !this.props.password}
               waitingKey={Constants.waitingKey}
               style={{marginTop: 0, width: '100%'}}
               fullWidth={true}

--- a/shared/login/relogin/index.stories.tsx
+++ b/shared/login/relogin/index.stories.tsx
@@ -9,7 +9,7 @@ const makeAccount = (username: string) => ({
 
 const commonProps: Props = {
   error: '',
-  hidePasswordBox: false,
+  needPassword: true,
   onFeedback: Sb.action('onFeedback'),
   onForgotPassword: Sb.action('onForgotPassword'),
   onLogin: Sb.action('onLogin'),

--- a/shared/login/relogin/index.stories.tsx
+++ b/shared/login/relogin/index.stories.tsx
@@ -9,6 +9,7 @@ const makeAccount = (username: string) => ({
 
 const commonProps: Props = {
   error: '',
+  hidePasswordBox: false,
   onFeedback: Sb.action('onFeedback'),
   onForgotPassword: Sb.action('onForgotPassword'),
   onLogin: Sb.action('onLogin'),

--- a/shared/login/routes.tsx
+++ b/shared/login/routes.tsx
@@ -33,7 +33,7 @@ _RootLogin.navigationOptions = {
 
 const RootLogin = Container.connect(
   state => {
-    const showLoading = state.config.daemonHandshakeState !== 'done'
+    const showLoading = state.config.daemonHandshakeState !== 'done' || state.config.userSwitching
     const showRelogin = !showLoading && state.config.configuredAccounts.length > 0
     return {showLoading, showRelogin}
   },

--- a/shared/reducers/config.tsx
+++ b/shared/reducers/config.tsx
@@ -70,6 +70,7 @@ export default (state: Types.State = Constants.initialState, action: Actions): T
           menubarWindowID: draftState.menubarWindowID,
           pushLoaded: draftState.pushLoaded,
           startupDetailsLoaded: draftState.startupDetailsLoaded,
+          userSwitching: draftState.userSwitching,
         }
       case ConfigGen.restartHandshake:
         draftState.daemonError = undefined
@@ -181,6 +182,9 @@ export default (state: Types.State = Constants.initialState, action: Actions): T
         draftState.registered = action.payload.registered
         draftState.uid = action.payload.uid
         draftState.username = action.payload.username
+        if (action.payload.loggedIn) {
+          draftState.userSwitching = false
+        }
         return
       case ConfigGen.followerInfoUpdated:
         if (draftState.uid === action.payload.uid) {
@@ -264,6 +268,9 @@ export default (state: Types.State = Constants.initialState, action: Actions): T
         draftState.defaultUsername = defaultUsername
         return
       }
+      case ConfigGen.setUserSwitching:
+        draftState.userSwitching = action.payload.userSwitching
+        return
       case ConfigGen.setDefaultUsername:
         draftState.defaultUsername = action.payload.username
         return

--- a/shared/router-v2/account-switcher/container.tsx
+++ b/shared/router-v2/account-switcher/container.tsx
@@ -10,6 +10,7 @@ import * as ProvisionGen from '../../actions/provision-gen'
 import * as SignupGen from '../../actions/signup-gen'
 import * as Constants from '../../constants/config'
 import HiddenString from '../../util/hidden-string'
+import * as LoginConstants from '../../constants/login'
 
 type OwnProps = {}
 
@@ -19,6 +20,7 @@ export default Container.connect(
     accountRows: state.config.configuredAccounts,
     fullname: TrackerConstants.getDetails(state, state.config.username).fullname || '',
     username: state.config.username,
+    waiting: Container.anyWaiting(state, LoginConstants.waitingKey),
   }),
   dispatch => ({
     _onProfileClick: (username: string) => dispatch(ProfileGen.createShowUserProfile({username})),
@@ -62,6 +64,7 @@ export default Container.connect(
 
       title: ' ',
       username: stateProps.username,
+      waiting: stateProps.waiting,
     }
   }
 )(AccountSwitcher)

--- a/shared/router-v2/account-switcher/container.tsx
+++ b/shared/router-v2/account-switcher/container.tsx
@@ -27,8 +27,10 @@ export default Container.connect(
     onAddAccount: () => dispatch(ProvisionGen.createStartProvision()),
     onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),
     onCreateAccount: () => dispatch(SignupGen.createRequestAutoInvite()),
-    onSelectAccountLoggedIn: (username: string) =>
-      dispatch(LoginGen.createLogin({password: new HiddenString(''), username})),
+    onSelectAccountLoggedIn: (username: string) => {
+      dispatch(ConfigGen.createSetUserSwitching({userSwitching: true}))
+      dispatch(LoginGen.createLogin({password: new HiddenString(''), username}))
+    },
     onSelectAccountLoggedOut: (username: string) => {
       dispatch(ConfigGen.createSetDefaultUsername({username}))
       dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: false}))

--- a/shared/router-v2/account-switcher/index.stories.native.tsx
+++ b/shared/router-v2/account-switcher/index.stories.native.tsx
@@ -34,6 +34,7 @@ const props: Props = {
   ],
   title: ' ',
   username: 'alice',
+  waiting: false,
 }
 
 const load = () => {

--- a/shared/router-v2/account-switcher/index.tsx
+++ b/shared/router-v2/account-switcher/index.tsx
@@ -97,7 +97,7 @@ const AccountsRows = (props: Props) => (
         entry={entry}
         onSelectAccount={props.onSelectAccount}
         waiting={props.waiting}
-        key={props.entry.account.username}
+        key={entry.account.username}
       />
     ))}
   </Kb.Box2>

--- a/shared/router-v2/account-switcher/index.tsx
+++ b/shared/router-v2/account-switcher/index.tsx
@@ -18,6 +18,7 @@ export type Props = {
   onProfileClick: () => void
   onSelectAccount: (username: string) => void
   username: string
+  waiting: boolean
 } & HeaderHocProps
 
 const MobileHeader = (props: Props) => (
@@ -49,29 +50,54 @@ const MobileHeader = (props: Props) => (
     </Kb.Box2>
   </>
 )
+
+type AccountRowProps = {
+  entry: AccountRowItem
+  onSelectAccount: (user: string) => void
+  waiting: boolean
+}
+const AccountRow = (props: AccountRowProps) => {
+  const [clicked, setClicked] = React.useState(false)
+  const onClick = props.waiting
+    ? undefined
+    : () => {
+        setClicked(true)
+        props.onSelectAccount(props.entry.account.username)
+      }
+  return (
+    <Kb.ListItem2
+      type="Small"
+      icon={<Kb.Avatar size={32} username={props.entry.account.username} />}
+      firstItem={true}
+      body={
+        <Kb.Box2 direction="vertical" fullWidth={true} style={props.waiting ? styles.waiting : undefined}>
+          <Kb.Text type="BodySemibold">{props.entry.account.username}</Kb.Text>
+          <Kb.Box2 direction="horizontal" alignItems="flex-start" fullWidth={true}>
+            <Kb.Text type="BodySmall" lineClamp={1} style={styles.nameText}>
+              {props.entry.fullName}
+            </Kb.Text>
+            {!props.entry.account.hasStoredSecret && (
+              <Kb.Text type="BodySmallItalic" style={styles.text2}>
+                {props.entry.fullName && '· '}Signed out
+              </Kb.Text>
+            )}
+          </Kb.Box2>
+          {clicked && <Kb.ProgressIndicator type="Large" style={styles.progressIndicator} />}
+        </Kb.Box2>
+      }
+      onClick={onClick}
+    />
+  )
+}
+
 const AccountsRows = (props: Props) => (
   <Kb.Box2 direction="vertical" fullWidth={true}>
     {props.accountRows.map(entry => (
-      <Kb.ListItem2
-        type="Small"
-        icon={
-          <Kb.Avatar
-            size={32}
-            username={entry.account.username}
-            style={entry.account.hasStoredSecret ? undefined : styles.avatarSignedOut}
-          />
-        }
-        firstItem={true}
-        body={
-          <Kb.Box2 direction="vertical" fullWidth={true}>
-            <Kb.Text type="BodySemibold">{entry.account.username}</Kb.Text>
-            <Kb.Text type="BodySmall" lineClamp={1}>
-              {entry.fullName}
-            </Kb.Text>
-          </Kb.Box2>
-        }
-        key={entry.account.username}
-        onClick={() => props.onSelectAccount(entry.account.username)}
+      <AccountRow
+        entry={entry}
+        onSelectAccount={props.onSelectAccount}
+        waiting={props.waiting}
+        key={props.entry.account.username}
       />
     ))}
   </Kb.Box2>
@@ -96,7 +122,6 @@ const AccountSwitcher = (props: Props) => (
 export default Kb.HeaderHoc(AccountSwitcher)
 
 const styles = Styles.styleSheetCreate(() => ({
-  avatarSignedOut: {opacity: 0.4},
   buttonBox: Styles.padding(0, Styles.globalMargins.small, Styles.globalMargins.tiny),
   desktopScrollview: {
     maxHeight: 170,
@@ -104,11 +129,17 @@ const styles = Styles.styleSheetCreate(() => ({
   },
   divider: {width: '100%'},
   nameText: Styles.platformStyles({
+    common: {flexShrink: 1},
     isElectron: {wordBreak: 'break-all'},
   }),
+  progressIndicator: {bottom: 0, position: 'absolute'},
   row: {
     maxWidth: 200,
     paddingBottom: -Styles.globalMargins.small,
     paddingTop: -Styles.globalMargins.small,
+  },
+  text2: {flexShrink: 0},
+  waiting: {
+    opacity: 0.5,
   },
 }))


### PR DESCRIPTION
- [x] grey out the user switcher while a switch is in progress
- [x] show a progress indicator while the switch is in progress
- [x] don't show the login page in the middle of the switch
- [x] show "signed out" instead of greying out avatars
- [x] indicate logged-in users on the relogin page
- [x] on the relogin page, when you have an already-logged-in user selected, hide the password box.

Issue: Y2K-715
