### PR TITLE
Draw tray icon pop-up on top of other windows

### DIFF
--- a/shared/desktop/app/menu-bar.desktop.tsx
+++ b/shared/desktop/app/menu-bar.desktop.tsx
@@ -34,6 +34,7 @@ export default (menubarWindowIDCallback: (id: number) => void) => {
         nodeIntegrationInWorker: false,
       },
       width: 360,
+      alwaysOnTop: true,
     },
     icon: resolveImage(
       'menubarIcon',
@@ -166,6 +167,9 @@ export default (menubarWindowIDCallback: (id: number) => void) => {
     })
     mb.tray.on('click', (_: Electron.Event, bounds: Bounds) => {
       logger.info('Clicked tray icon:', bounds)
+    })
+    mb.on('focus-lost', () => {
+      mb.hideWindow()
     })
   })
 


### PR DESCRIPTION
This pull request sets the tray icon popup to be "always on top".

The motivation for this is to fix a small annoyance on Windows where the excess tray icon popup is covering up the Keybase popup, like in [this screenshot](https://github.com/keybase/client/issues/3481#issuecomment-278564925) by @tjhorner

Because the `menubar` package has behavior where if you set the popup to `alwaysOnTop` it won't close when it loses focus, a handler for the `focus-lost` event also had to be added