### PR TITLE
Add bool allowInaction for removing team invites

### DIFF
--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -147,6 +147,7 @@ const (
 	StatusCode_SCTeamWritePermDenied                       StatusCode = 2625
 	StatusCode_SCTeamBadGeneration                         StatusCode = 2636
 	StatusCode_SCNoOp                                      StatusCode = 2638
+	StatusCode_SCTeamInviteBadCancel                       StatusCode = 2645
 	StatusCode_SCTeamInviteBadToken                        StatusCode = 2646
 	StatusCode_SCTeamTarDuplicate                          StatusCode = 2663
 	StatusCode_SCTeamTarNotFound                           StatusCode = 2664
@@ -376,6 +377,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCTeamWritePermDenied":                       2625,
 	"SCTeamBadGeneration":                         2636,
 	"SCNoOp":                                      2638,
+	"SCTeamInviteBadCancel":                       2645,
 	"SCTeamInviteBadToken":                        2646,
 	"SCTeamTarDuplicate":                          2663,
 	"SCTeamTarNotFound":                           2664,
@@ -603,6 +605,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2625: "SCTeamWritePermDenied",
 	2636: "SCTeamBadGeneration",
 	2638: "SCNoOp",
+	2645: "SCTeamInviteBadCancel",
 	2646: "SCTeamInviteBadToken",
 	2663: "SCTeamTarDuplicate",
 	2664: "SCTeamTarNotFound",

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -3390,11 +3390,12 @@ type TeamAddMembersMultiRoleArg struct {
 }
 
 type TeamRemoveMemberArg struct {
-	SessionID int          `codec:"sessionID" json:"sessionID"`
-	Name      string       `codec:"name" json:"name"`
-	Username  string       `codec:"username" json:"username"`
-	Email     string       `codec:"email" json:"email"`
-	InviteID  TeamInviteID `codec:"inviteID" json:"inviteID"`
+	SessionID     int          `codec:"sessionID" json:"sessionID"`
+	Name          string       `codec:"name" json:"name"`
+	Username      string       `codec:"username" json:"username"`
+	Email         string       `codec:"email" json:"email"`
+	InviteID      TeamInviteID `codec:"inviteID" json:"inviteID"`
+	AllowInaction bool         `codec:"allowInaction" json:"allowInaction"`
 }
 
 type TeamLeaveArg struct {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -346,8 +346,7 @@ func (h *TeamsHandler) TeamAddMembersMultiRole(ctx context.Context, arg keybase1
 
 func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRemoveMemberArg) (err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
-	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s, u:%q, e:%q, i:%q)", arg.Name, arg.Username, arg.Email, arg.InviteID),
-		func() error { return err })()
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamRemoveMember(%s, u:%q, e:%q, i:%q, a:%v)", arg.Name, arg.Username, arg.Email, arg.InviteID, arg.AllowInaction), func() error { return err })()
 
 	if err := h.assertLoggedIn(ctx); err != nil {
 		return err
@@ -369,11 +368,12 @@ func (h *TeamsHandler) TeamRemoveMember(ctx context.Context, arg keybase1.TeamRe
 
 	if len(arg.Email) > 0 {
 		h.G().Log.CDebugf(ctx, "TeamRemoveMember: received email address, using CancelEmailInvite for %q in team %q", arg.Email, arg.Name)
-		return teams.CancelEmailInvite(ctx, h.G().ExternalG(), arg.Name, arg.Email)
+		return teams.CancelEmailInvite(ctx, h.G().ExternalG(), arg.Name, arg.Email, arg.AllowInaction)
 	} else if len(arg.InviteID) > 0 {
 		h.G().Log.CDebugf(ctx, "TeamRemoveMember: received inviteID, using CancelInviteByID for %q in team %q", arg.InviteID, arg.Name)
-		return teams.CancelInviteByID(ctx, h.G().ExternalG(), arg.Name, arg.InviteID)
+		return teams.CancelInviteByID(ctx, h.G().ExternalG(), arg.Name, arg.InviteID, arg.AllowInaction)
 	}
+	// Note: AllowInaction is not supported for non-invite removes.
 	h.G().Log.CDebugf(ctx, "TeamRemoveMember: using RemoveMember for %q in team %q", arg.Username, arg.Name)
 	return teams.RemoveMember(ctx, h.G().ExternalG(), arg.Name, arg.Username)
 }

--- a/go/systests/team_seitan_invite_v2_test.go
+++ b/go/systests/team_seitan_invite_v2_test.go
@@ -441,7 +441,7 @@ func testTeamInviteSeitanPukless(t *testing.T, seitanVersion teams.SeitanVersion
 	require.Len(t, invites, 1)
 	for _, invite := range invites {
 		// Invite should be WAITING_FOR_PUK now and we can't cancel it anymore.
-		err := teams.CancelInviteByID(context.Background(), bee.tc.G, teamName.String(), invite.Id)
+		err := teams.CancelInviteByID(context.Background(), bee.tc.G, teamName.String(), invite.Id, false)
 		require.Error(t, err)
 	}
 

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -436,7 +436,8 @@ func handleSBSSingle(ctx context.Context, g *libkb.GlobalContext, teamID keybase
 			}
 
 			g.Log.CDebugf(ctx, "User already has same or higher role, canceling invite %s", invite.Id)
-			return removeInviteID(ctx, team, invite.Id)
+			const allowInaction = false
+			return removeInviteID(ctx, team, invite.Id, allowInaction)
 		}
 
 		tx := CreateAddMemberTx(team)

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -442,7 +442,7 @@ func TestImplicitInvalidLinks(t *testing.T) {
 		// Removing existing pukless member should be illegal
 		invite, _, found := teamObj.FindActiveKeybaseInvite(cat.GetUID())
 		require.True(t, found)
-		err := removeInviteID(context.Background(), teamObj, invite.Id)
+		err := removeInviteID(context.Background(), teamObj, invite.Id, false)
 		RequirePrecheckError(err)
 	}
 }

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -1217,7 +1217,8 @@ func TestMemberCancelInviteEmail(t *testing.T) {
 
 	require.NoError(t, CancelEmailInvite(context.TODO(), tc.G, name, address, false))
 	require.NoError(t, CancelEmailInvite(context.TODO(), tc.G, name, address, true))
-	require.Error(t, CancelEmailInvite(context.TODO(), tc.G, name, address, false))
+	require.NoError(t, CancelEmailInvite(context.TODO(), tc.G, name, address, true), "doesnt error when canceling a canceled invite with allowInaction")
+	require.Error(t, CancelEmailInvite(context.TODO(), tc.G, name, address, false), "errors when canceling a canceled invite without allowInaction")
 
 	assertNoInvite(tc, name, address, "email")
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -1215,14 +1215,14 @@ func TestMemberCancelInviteEmail(t *testing.T) {
 	}
 	assertInvite(tc, name, address, "email", keybase1.TeamRole_READER)
 
-	if err := CancelEmailInvite(context.TODO(), tc.G, name, address); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, CancelEmailInvite(context.TODO(), tc.G, name, address, false))
+	require.NoError(t, CancelEmailInvite(context.TODO(), tc.G, name, address, true))
+	require.Error(t, CancelEmailInvite(context.TODO(), tc.G, name, address, false))
 
 	assertNoInvite(tc, name, address, "email")
 
 	// check error type for an email address with no invite
-	err := CancelEmailInvite(context.TODO(), tc.G, name, "nope@keybase.io")
+	err := CancelEmailInvite(context.TODO(), tc.G, name, "nope@keybase.io", false)
 	if err == nil {
 		t.Fatal("expected error canceling email invite for unknown email address")
 	}
@@ -1231,7 +1231,7 @@ func TestMemberCancelInviteEmail(t *testing.T) {
 	}
 
 	// check error type for unknown team
-	err = CancelEmailInvite(context.TODO(), tc.G, "notateam", address)
+	err = CancelEmailInvite(context.TODO(), tc.G, "notateam", address, false)
 	if err == nil {
 		t.Fatal("expected error canceling email invite for unknown team")
 	}

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1593,6 +1593,7 @@ func removeInviteID(ctx context.Context, team *Team, invID keybase1.TeamInviteID
 		case libkb.NotFoundError:
 			team.MetaContext(ctx).Debug("remoteInviteID suppressing error due to allowInaction: %v", err)
 			return nil
+		default:
 		}
 		if libkb.IsAppStatusCode(err, keybase1.StatusCode_SCTeamInviteBadCancel) {
 			team.MetaContext(ctx).Debug("remoteInviteID suppressing error due to allowInaction: %v", err)

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -139,6 +139,7 @@ protocol constants {
     SCTeamWritePermDenied_2625,
     SCTeamBadGeneration_2636,
     SCNoOp_2638,
+    SCTeamInviteBadCancel_2645,
     SCTeamInviteBadToken_2646,
     SCTeamTarDuplicate_2663,
     SCTeamTarNotFound_2664,

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1183,7 +1183,9 @@ protocol teams {
 
   void teamAddMembersMultiRole(int sessionID, string name, array<UserRolePair> users, boolean sendChatNotification);
 
-  void teamRemoveMember(int sessionID, string name, string username, string email, TeamInviteID inviteID);
+  // allowInaction suppresses errors that come from removing an invite that doesn't exist. Relevant for suppressing errors when calling remove while a remove is already in progress.
+  // Note: allowInaction only applies to invite removals, just because that was what was needed.
+  void teamRemoveMember(int sessionID, string name, string username, string email, TeamInviteID inviteID, boolean allowInaction);
 
   void teamLeave(int sessionID, string name, boolean permanent);
 

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -143,6 +143,7 @@
         "SCTeamWritePermDenied_2625",
         "SCTeamBadGeneration_2636",
         "SCNoOp_2638",
+        "SCTeamInviteBadCancel_2645",
         "SCTeamInviteBadToken_2646",
         "SCTeamTarDuplicate_2663",
         "SCTeamTarNotFound_2664",

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -3203,6 +3203,10 @@
         {
           "name": "inviteID",
           "type": "TeamInviteID"
+        },
+        {
+          "name": "allowInaction",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -380,6 +380,7 @@ function* removeMemberOrPendingInvite(
   try {
     yield RPCTypes.teamsTeamRemoveMemberRpcPromise(
       {
+        allowInaction: true,
         email,
         inviteID,
         name: teamname,

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1260,7 +1260,7 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.teams.teamRemoveMember': {
-    inParam: {readonly name: String; readonly username: String; readonly email: String; readonly inviteID: TeamInviteID}
+    inParam: {readonly name: String; readonly username: String; readonly email: String; readonly inviteID: TeamInviteID; readonly allowInaction: Boolean}
     outParam: void
   }
   'keybase.1.teams.teamRename': {
@@ -2143,6 +2143,7 @@ export enum StatusCode {
   scteamwritepermdenied = 2625,
   scteambadgeneration = 2636,
   scnoop = 2638,
+  scteaminvitebadcancel = 2645,
   scteaminvitebadtoken = 2646,
   scteamtarduplicate = 2663,
   scteamtarnotfound = 2664,


### PR DESCRIPTION
Suppress errors when removing an invite from a team when the invite doesn't exist.

cc @zapu you're in here a lot so I want to make sure you're aware of this behavior