### PR TITLE
PICNIC-546: Fixes Background Color for Wallets Setting Header

### DIFF
--- a/shared/wallets/wallet/settings/index.tsx
+++ b/shared/wallets/wallet/settings/index.tsx
@@ -372,6 +372,7 @@ const styles = Styles.styleSheetCreate(
       },
       header: {
         ...(!Styles.isMobile ? {minHeight: 48} : {}),
+        backgroundColor: Styles.globalColors.white,
         borderBottomColor: Styles.globalColors.black_10,
         borderBottomWidth: 1,
         borderStyle: 'solid',


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5200812/66426195-4ff5d300-e9df-11e9-95a2-15c0283ccb6c.png)

After:
![image](https://user-images.githubusercontent.com/5200812/66426218-5d12c200-e9df-11e9-8bb6-104958e44d12.png)

After (dark):
![image](https://user-images.githubusercontent.com/5200812/66426237-6734c080-e9df-11e9-81ed-19d0e7ac47ef.png)

