### PR TITLE
Hotfix Android qr code scanner to stellar QR

### DIFF
--- a/shared/wallets/qr-scan/container.tsx
+++ b/shared/wallets/qr-scan/container.tsx
@@ -13,7 +13,7 @@ const mapDispatchToProps = dispatch => ({
       dispatch(WalletsGen.createSetBuildingRecipientType({recipientType: 'stellarPublicKey'}))
       dispatch(WalletsGen.createSetBuildingTo({to}))
     } else {
-      logger.error('QrScan.onSubmitCode: No `to` field for QRScan')
+      logger.warn('QrScan.onSubmitCode: No `to` field for QRScan')
     }
     dispatch(RouteTreeGen.createNavigateUp())
   },

--- a/shared/wallets/send-form/participants/to-field.tsx
+++ b/shared/wallets/send-form/participants/to-field.tsx
@@ -6,7 +6,7 @@ import {isLargeScreen} from '../../../constants/platform'
 import {SelectedEntry, DropdownEntry, DropdownText} from './dropdown'
 import Search from './search'
 import {Account} from '.'
-import {debounce} from 'lodash-es'
+import {debounce, defer} from 'lodash-es'
 
 export type ToKeybaseUserProps = {
   isRequest: boolean
@@ -82,11 +82,13 @@ export type ToStellarPublicKeyProps = {
 
 const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => {
   const [recipientPublicKey, setRecipentPublicKey] = React.useState(props.recipientPublicKey)
-  const debouncedOnChangeRecip = React.useCallback(debounce(props.onChangeRecipient, 1e3), [])
+  const debouncedOnChangeRecip = React.useCallback(debounce(props.onChangeRecipient, 1e3), [
+    props.onChangeRecipient,
+  ])
 
   const {setReadyToReview} = props
   const onChangeRecipient = React.useCallback(
-    recipientPublicKey => {
+    (recipientPublicKey: string) => {
       setRecipentPublicKey(recipientPublicKey)
       setReadyToReview(false)
       debouncedOnChangeRecip(recipientPublicKey)
@@ -96,9 +98,10 @@ const ToStellarPublicKey = (props: ToStellarPublicKeyProps) => {
 
   React.useEffect(() => {
     if (props.recipientPublicKey !== recipientPublicKey) {
-      setRecipentPublicKey(props.recipientPublicKey)
+      // Hot fix to let any empty string textChange callbacks happen before we change the value.
+      defer(() => setRecipentPublicKey(props.recipientPublicKey))
     }
-    // We purposely do not want this be called when the state changes
+    // We do not want this be called when the state changes
     // Only when the prop.recipientPublicKey changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.recipientPublicKey])


### PR DESCRIPTION
Defer the updating state.

It seems like there's some race condition where we get an empty string textChange event for this input. It may have something to do with navigating to it and setting a value to it immediately?

By deferring it we don't get the textChange events either, and the value is properly updated.


My current guess is:
The native input starts as an empty string.
We set the value prop to be "G....123".
Native side sees that the current content is an empty string, but the prop `value` is "G...123", so it assumes the user must have deleted the content.
It calls onTextChanged to tell JS that the native value is `""`. This causes us to clear the value.

By deferring we skip the confusion of whether the initial state of the input. We start off with `""`, then we can update it as normal.

@keybase/react-hackers 