### PR TITLE
Fix scrolling in settings pages

### DIFF
--- a/shared/settings/render.desktop.tsx
+++ b/shared/settings/render.desktop.tsx
@@ -12,7 +12,7 @@ const SettingsRender = (props: Props) => {
   }, [loadHasRandomPW])
   return (
     <Box style={{...globalStyles.flexBoxColumn, flex: 1, height: '100%'}}>
-      <Box style={{...globalStyles.flexBoxRow, flex: 1}}>
+      <Box style={{...globalStyles.flexBoxRow, flex: 1, height: '100%'}}>
         <SettingsNav
           badgeNumbers={props.badgeNumbers}
           contactsLabel={props.contactsLabel}


### PR DESCRIPTION
Sets explicit height on settings container to allow overflow properties to work properly