### PR TITLE
Have the Yarn helper launch Electron with --inspect

### DIFF
--- a/shared/desktop/yarn-helper/electron.tsx
+++ b/shared/desktop/yarn-helper/electron.tsx
@@ -21,7 +21,7 @@ const commands = {
   'start-cold': {
     help: 'Start electron with no hot reloading',
     nodeEnv: 'development',
-    shell: `electron ${path.resolve(__dirname, '../dist/node.dev.bundle.js')}`,
+    shell: `electron ${path.resolve(__dirname, '../dist/node.dev.bundle.js')} --inspect`,
   },
   'start-hot': {
     code: startHot,
@@ -64,7 +64,10 @@ function startHot() {
       // require in case we're trying to yarn install electron!
       const electron = require('electron')
       // @ts-ignore
-      spawn(electron, [...params, ...(isLinux ? ['--disable-gpu'] : [])], {env, stdio: 'inherit'})
+      spawn(electron, [...params, '--inspect', ...(isLinux ? ['--disable-gpu'] : [])], {
+        env,
+        stdio: 'inherit',
+      })
     })
     req.on('error', e => {
       console.log('Error: ', e)


### PR DESCRIPTION
This pull request has the Electron `yarn-helper` script launch Electron with the `--inspect` flag. It does this for both hot and non-hot loading modes.

This allows for the Keybase desktop app's `main` process to be inspected by browsing to `chrome://inspect` in a Chromium-based browser. (see: https://electronjs.org/docs/tutorial/debugging-main-process)