### PR TITLE
Add reply method to chat api

### DIFF
--- a/go/client/chat_api_doc.go
+++ b/go/client/chat_api_doc.go
@@ -111,4 +111,7 @@ Pin a message to a chat:
 
 Unpin the message of chat:
    {"method": "unpin", "params": {"options": {"channel": {"name": "treehouse", "members_type": "team", "topic_name": "random"}}}}
+
+Reply to a message:
+    {"method": "reply", "params": {"options": {"channel": {"name": "treehouse", "members_type": "team", "topic_name": "random"}, "reply_to": 314, "message": {"body": "reply message"}}}}
 `

--- a/go/client/chat_api_version_handler.go
+++ b/go/client/chat_api_version_handler.go
@@ -82,6 +82,8 @@ func (d *ChatAPIVersionHandler) handleV1(ctx context.Context, c Call, w io.Write
 		return d.handler.PinV1(ctx, c, w)
 	case methodUnpin:
 		return d.handler.UnpinV1(ctx, c, w)
+	case methodReply:
+		return d.handler.ReplyV1(ctx, c, w)
 	case methodGetResetConvMembers:
 		return d.handler.GetResetConvMembersV1(ctx, c, w)
 	case methodAddResetConvMember:


### PR DESCRIPTION
This exposes the `reply` method to the `keybase chat api` command, which can be used to send a reply to a previously sent message.