### PR TITLE
Autoreset: fix asking password regression

### DIFF
--- a/shared/login/reset/waiting.tsx
+++ b/shared/login/reset/waiting.tsx
@@ -44,7 +44,7 @@ const Waiting = (props: Props) => {
     return function cleanup() {
       removeTicker(tickerID)
     }
-  }, [endTime, setFormattedTime, formattedTime, pipelineStarted])
+  }, [endTime, setFormattedTime, formattedTime, pipelineStarted, dispatch, nav])
 
   return (
     <SignupScreen

--- a/shared/login/reset/waiting.tsx
+++ b/shared/login/reset/waiting.tsx
@@ -17,7 +17,6 @@ const Waiting = (props: Props) => {
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
 
-
   // const onCancelReset = React.useCallback(() => dispatch(AutoresetGen.createCancelReset()), [dispatch])
   const onClose = React.useCallback(
     () => dispatch(nav.safeNavigateAppendPayload({path: ['login'], replace: true})),
@@ -28,6 +27,9 @@ const Waiting = (props: Props) => {
   const onSendAgain = React.useCallback(() => dispatch(AutoresetGen.createResetAccount({})), [dispatch])
 
   React.useEffect(() => {
+    if (!pipelineStarted) {
+      return
+    }
     function tick() {
       const newFormattedTime = Constants.formatTimeLeft(endTime)
       if (formattedTime !== newFormattedTime) {
@@ -42,7 +44,7 @@ const Waiting = (props: Props) => {
     return function cleanup() {
       removeTicker(tickerID)
     }
-  }, [endTime, setFormattedTime, formattedTime])
+  }, [endTime, setFormattedTime, formattedTime, pipelineStarted])
 
   return (
     <SignupScreen


### PR DESCRIPTION
Previously, if you selected "no" to the "do you know your password" prompt, we would shortly ask you for your password anyway, believing that the lack of an end time meant that the reset was about to happen. This fixes that by checking that we're in the reset pipeline before trying to launch that flow.

cc @keybase/y2ksquad 
