### PR TITLE
Deprecate canError from actions

### DIFF
--- a/shared/actions/__tests__/signup.test.tsx
+++ b/shared/actions/__tests__/signup.test.tsx
@@ -57,7 +57,7 @@ describe('requestAutoInvite', () => {
   })
 
   it('goes to invite page on error', () => {
-    const action = SignupGen.createRequestedAutoInviteError()
+    const action = SignupGen.createRequestedAutoInvite({})
     const nextState = makeTypedState(reducer(state, action))
     expect(nextState).toEqual(makeTypedState(state))
     expect(_testing.showInviteScreen()).toEqual(
@@ -88,7 +88,7 @@ describe('requestInvite', () => {
   it('shows error if it matches', () => {
     const preAction = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
     const preNextState = makeTypedState(reducer(state, preAction))
-    const action = SignupGen.createRequestedInviteError({
+    const action = SignupGen.createRequestedInvite({
       email: preNextState.signup.email,
       emailError: 'email error',
       name: preNextState.signup.name,
@@ -102,7 +102,7 @@ describe('requestInvite', () => {
   it("ignore error if it doesn't match", () => {
     const preAction = SignupGen.createRequestInvite({email: 'email@email.com', name: 'name'})
     const preNextState = makeTypedState(reducer(state, preAction))
-    const action = SignupGen.createRequestedInviteError({
+    const action = SignupGen.createRequestedInvite({
       email: 'different email',
       emailError: 'email error',
       name: preNextState.signup.name,
@@ -137,7 +137,7 @@ describe('checkInviteCode', () => {
   it("shows error on fail: must match invite code. doesn't go to next screen", () => {
     const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'invite code'})
     const preState = makeTypedState(reducer(state, preAction))
-    const action = SignupGen.createCheckedInviteCodeError({
+    const action = SignupGen.createCheckedInviteCode({
       error: 'bad invitecode',
       inviteCode: 'invite code',
     })
@@ -149,7 +149,7 @@ describe('checkInviteCode', () => {
   it("ignores error if invite doesn't match", () => {
     const preAction = SignupGen.createRequestedAutoInvite({inviteCode: 'a different invite code'})
     const preState = makeTypedState(reducer(state, preAction))
-    const action = SignupGen.createCheckedInviteCodeError({
+    const action = SignupGen.createCheckedInviteCode({
       error: 'bad invitecode',
       inviteCode: 'invite code',
     })
@@ -266,7 +266,7 @@ describe('deviceScreen', () => {
 
   it("ignores if devicename doesn't match", () => {
     const state = Constants.makeState({devicename: 'a device'})
-    const action = SignupGen.createCheckedDevicenameError({devicename: 'different name', error: 'an error'})
+    const action = SignupGen.createCheckedDevicename({devicename: 'different name', error: 'an error'})
     const nextState = makeTypedState(reducer(state, action))
     // doesn't update
     expect(nextState).toEqual(makeTypedState(state))
@@ -274,7 +274,7 @@ describe('deviceScreen', () => {
 
   it('shows error', () => {
     const state = Constants.makeState({devicename: 'devicename'})
-    const action = SignupGen.createCheckedDevicenameError({devicename: 'devicename', error: 'an error'})
+    const action = SignupGen.createCheckedDevicename({devicename: 'devicename', error: 'an error'})
     const nextState = makeTypedState(reducer(makeTypedState(state).signup, action))
     expect(nextState.signup.devicename).toEqual(action.payload.devicename)
     expect(nextState.signup.devicenameError).toEqual(action.payload.error)
@@ -332,7 +332,7 @@ describe('actually sign up', () => {
   })
   it('updates error', () => {
     const state = Constants.makeState()
-    const action = SignupGen.createSignedupError({error: new RPCError('an error', 0)})
+    const action = SignupGen.createSignedup({error: new RPCError('an error', 0)})
     const nextState = makeTypedState(reducer(state, action))
     expect(nextState.signup.signupError).toEqual(action.payload.error)
     expect(_testing.showErrorOrCleanupAfterSignup(nextState)).toEqual(

--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -165,8 +165,11 @@ type _AddUsersToChannelPayload = {
   readonly usernames: Array<string>
 }
 type _AttachmentDownloadPayload = {readonly message: Types.Message}
-type _AttachmentDownloadedPayload = {readonly message: Types.Message; readonly path?: string}
-type _AttachmentDownloadedPayloadError = {readonly error: string; readonly message: Types.Message}
+type _AttachmentDownloadedPayload = {
+  readonly message: Types.Message
+  readonly error?: string
+  readonly path?: string
+}
 type _AttachmentFullscreenNextPayload = {
   readonly conversationIDKey: Types.ConversationIDKey
   readonly messageID: Types.MessageID
@@ -548,8 +551,10 @@ type _SetMinWriterRolePayload = {
   readonly conversationIDKey: Types.ConversationIDKey
   readonly role: TeamsTypes.TeamRoleType
 }
-type _SetPaymentConfirmInfoPayload = {readonly summary: RPCChatTypes.UIChatPaymentSummary}
-type _SetPaymentConfirmInfoPayloadError = {readonly error: RPCTypes.Status}
+type _SetPaymentConfirmInfoPayload = {
+  readonly error?: RPCTypes.Status
+  readonly summary?: RPCChatTypes.UIChatPaymentSummary
+}
 type _SetPrependTextPayload = {
   readonly conversationIDKey: Types.ConversationIDKey
   readonly text: HiddenString | null
@@ -943,11 +948,8 @@ export const createSetMinWriterRole = (payload: _SetMinWriterRolePayload): SetMi
  * Set the payment confirm modal payment data
  */
 export const createSetPaymentConfirmInfo = (
-  payload: _SetPaymentConfirmInfoPayload
+  payload: _SetPaymentConfirmInfoPayload = Object.freeze({})
 ): SetPaymentConfirmInfoPayload => ({payload, type: setPaymentConfirmInfo})
-export const createSetPaymentConfirmInfoError = (
-  payload: _SetPaymentConfirmInfoPayloadError
-): SetPaymentConfirmInfoPayloadError => ({error: true, payload, type: setPaymentConfirmInfo})
 /**
  * Set the remote exploding mode for a conversation.
  */
@@ -1142,9 +1144,6 @@ export const createAttachmentDownload = (payload: _AttachmentDownloadPayload): A
 export const createAttachmentDownloaded = (
   payload: _AttachmentDownloadedPayload
 ): AttachmentDownloadedPayload => ({payload, type: attachmentDownloaded})
-export const createAttachmentDownloadedError = (
-  payload: _AttachmentDownloadedPayloadError
-): AttachmentDownloadedPayloadError => ({error: true, payload, type: attachmentDownloaded})
 export const createAttachmentFullscreenNext = (
   payload: _AttachmentFullscreenNextPayload
 ): AttachmentFullscreenNextPayload => ({payload, type: attachmentFullscreenNext})
@@ -1400,11 +1399,6 @@ export type AttachmentDownloadPayload = {
 }
 export type AttachmentDownloadedPayload = {
   readonly payload: _AttachmentDownloadedPayload
-  readonly type: typeof attachmentDownloaded
-}
-export type AttachmentDownloadedPayloadError = {
-  readonly error: true
-  readonly payload: _AttachmentDownloadedPayloadError
   readonly type: typeof attachmentDownloaded
 }
 export type AttachmentFullscreenNextPayload = {
@@ -1774,11 +1768,6 @@ export type SetPaymentConfirmInfoPayload = {
   readonly payload: _SetPaymentConfirmInfoPayload
   readonly type: typeof setPaymentConfirmInfo
 }
-export type SetPaymentConfirmInfoPayloadError = {
-  readonly error: true
-  readonly payload: _SetPaymentConfirmInfoPayloadError
-  readonly type: typeof setPaymentConfirmInfo
-}
 export type SetPrependTextPayload = {
   readonly payload: _SetPrependTextPayload
   readonly type: typeof setPrependText
@@ -1919,7 +1908,6 @@ export type Actions =
   | AddUsersToChannelPayload
   | AttachmentDownloadPayload
   | AttachmentDownloadedPayload
-  | AttachmentDownloadedPayloadError
   | AttachmentFullscreenNextPayload
   | AttachmentFullscreenSelectionPayload
   | AttachmentLoadingPayload
@@ -2023,7 +2011,6 @@ export type Actions =
   | SetMaybeMentionInfoPayload
   | SetMinWriterRolePayload
   | SetPaymentConfirmInfoPayload
-  | SetPaymentConfirmInfoPayloadError
   | SetPrependTextPayload
   | SetThreadLoadStatusPayload
   | SetThreadSearchQueryPayload

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -1716,7 +1716,7 @@ function* messageSend(state: TypedState, action: Chat2Gen.MessageSendPayload, lo
     response: StellarConfirmWindowResponse
   ) => {
     storeStellarConfirmWindowResponse(false, response)
-    return Saga.put(Chat2Gen.createSetPaymentConfirmInfoError({error}))
+    return Saga.put(Chat2Gen.createSetPaymentConfirmInfo({error}))
   }
 
   try {
@@ -2080,7 +2080,7 @@ function* downloadAttachment(downloadToCache: boolean, message: Types.Message) {
   } catch (e) {
     logger.error(`downloadAttachment error: ${e.message}`)
     yield Saga.put(
-      Chat2Gen.createAttachmentDownloadedError({error: e.message || 'Error downloading attachment', message})
+      Chat2Gen.createAttachmentDownloaded({error: e.message || 'Error downloading attachment', message})
     )
     return undefined
   }

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -340,8 +340,8 @@
     // We saved an attachment to the local disk
     "attachmentDownloaded": {
       "message": "Types.Message",
+      "error?": "string",
       "path?": "string",
-      "canError": {"error": "string", "message": "Types.Message"}
     },
     // We want to upload some attachments
     "attachmentsUpload": {
@@ -556,10 +556,8 @@
     },
     "setPaymentConfirmInfo": {
       "_description": "Set the payment confirm modal payment data",
-      "summary": "RPCChatTypes.UIChatPaymentSummary",
-      "canError": {
-        "error": "RPCTypes.Status"
-      }
+      "error?": "RPCTypes.Status",
+      "summary?": "RPCChatTypes.UIChatPaymentSummary",
     },
     "confirmScreenResponse": {
       "_description": "User responded to the chat Stellar confirm screen",

--- a/shared/actions/json/profile.json
+++ b/shared/actions/json/profile.json
@@ -32,7 +32,7 @@
       "location": "string"
     },
     "revokeFinish": {
-      "canError": {"error": "string"}
+      "error?": "string"
     },
     "finishRevoking": {},
     "finishedWithKeyGen": {
@@ -54,7 +54,7 @@
       "guiID": "string"
     },
     "finishBlockUser": {
-      "canError": {"error": "string"}
+      "error?": "string"
     },
     "updateErrorText": {
       "errorText": "string",

--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -93,9 +93,6 @@
     "invitesReclaim": {
       "inviteId": "string"
     },
-    "invitesReclaimed": {
-      "errorText?": "string"
-    },
     "invitesRefresh": {},
     "invitesRefreshed": {
       "invites": "Types._InvitesState"

--- a/shared/actions/json/settings.json
+++ b/shared/actions/json/settings.json
@@ -94,9 +94,7 @@
       "inviteId": "string"
     },
     "invitesReclaimed": {
-      "canError": {
-        "errorText": "string"
-      }
+      "errorText?": "string"
     },
     "invitesRefresh": {},
     "invitesRefreshed": {
@@ -107,9 +105,7 @@
       "message": "string | null"
     },
     "invitesSent": {
-      "canError": {
-        "error": "Error"
-      }
+      "error?": "Error"
     },
     "loadRememberPassword": {},
     "loadedRememberPassword": {

--- a/shared/actions/json/signup.json
+++ b/shared/actions/json/signup.json
@@ -7,16 +7,13 @@
     "goBackAndClearErrors": {},
     "requestAutoInvite": {},
     "requestedAutoInvite": {
-      "inviteCode": "string",
-      "canError": {}
+      "inviteCode?": "string",
+      "error?": "boolean"
     },
     "checkInviteCode": {"inviteCode": "string"},
     "checkedInviteCode": {
       "inviteCode": "string",
-      "canError": {
-        "inviteCode": "string",
-        "error": "string"
-      }
+      "error?": "string"
     },
     "checkPassword": {
       "pass1": "HiddenString",
@@ -37,28 +34,19 @@
     "requestedInvite": {
       "email": "string",
       "name": "string",
-      "canError": {
-        "emailError": "string",
-        "nameError": "string",
-        "email": "string",
-        "name": "string"
-      }
+      "emailError?": "string",
+      "nameError?": "string",
     },
     "restartSignup": {},
     "signedup": {
-      "canError": {
-        "error": "RPCError | null"
-      }
+      "error?": "RPCError"
     },
     "checkDevicename": {
       "devicename": "string"
     },
     "checkedDevicename": {
       "devicename": "string",
-      "canError": {
-        "devicename": "string",
-        "error": "string"
-      }
+      "error?": "string"
     },
     "setJustSignedUpEmail": {
       "email": "string"

--- a/shared/actions/json/unlock-folders.json
+++ b/shared/actions/json/unlock-folders.json
@@ -7,9 +7,7 @@
     "openPopup": {},
     "closePopup": {},
     "checkPaperKeyDone": {
-      "canError": {
-        "error": "string"
-      }
+      "error?": "string"
     },
     "closeDone": {},
     "finish": {},

--- a/shared/actions/json/wallets.json
+++ b/shared/actions/json/wallets.json
@@ -106,13 +106,11 @@
     },
     "createdNewAccount": {
       "_description": "The service responded with an error or that the create new account operation succeeded",
-      "accountID": "Types.AccountID",
+      "accountID?": "Types.AccountID",
       "showOnCreation?": "boolean",
       "setBuildingTo?": "boolean",
-      "canError": {
-        "name": "string",
-        "error": "string"
-      }
+      "name?": "string",
+      "error?": "string"
     },
     "externalPartnersReceived": {
       "_description": "Update our list of external tools and partners",
@@ -148,10 +146,10 @@
     },
     "inflationDestinationReceived": {
       "_description": "Got inflation destination",
-      "accountID": "Types.AccountID",
-      "selected": "Types.AccountInflationDestination",
+      "accountID?": "Types.AccountID",
+      "selected?": "Types.AccountInflationDestination",
       "options?": "Array<Types.InflationDestination>",
-      "canError": {"error": "string"}
+      "error?": "string"
     },
     "loadMorePayments": {
       "_description": "Scrolled down the list of payments for a given account",
@@ -201,12 +199,9 @@
     },
     "changedAccountName": {
       "_description": "A response from the service after an account's name is changed",
-      "account": "Types.Account",
-      "canError": {
-        "name": "string",
-        "account": "Types.Account",
-        "error": "string"
-      }
+      "name?": "string",
+      "account?": "Types.Account",
+      "error?": "string"
     },
     "setAccountAsDefault": {
       "_description": "Change the default account",
@@ -405,14 +400,12 @@
     },
     "linkedExistingAccount": {
       "_description": "The service responded with an error or that the link existing operation succeeded",
-      "accountID": "Types.AccountID",
+      "accountID?": "Types.AccountID",
       "showOnCreation?": "boolean",
       "setBuildingTo?": "boolean",
-      "canError": {
-        "name": "string",
-        "secretKey": "HiddenString",
-        "error": "string"
-      }
+      "name?": "string",
+      "secretKey?": "HiddenString",
+      "error?": "string"
     },
     "rejectDisclaimer": {
       "_description": "Reject (temporarily) the Stellar account disclaimer"
@@ -424,10 +417,7 @@
     "validatedAccountName": {
       "_description": "The service responded with an error or that the account name is valid.",
       "name": "string",
-      "canError": {
-        "name": "string",
-        "error": "string"
-      }
+      "error?": "string"
     },
     "validateSecretKey": {
       "_description": "Ask the service to validate an account secret key.",
@@ -436,10 +426,7 @@
     "validatedSecretKey": {
       "_description": "The service responded with an error or that the secret key is valid.",
       "secretKey": "HiddenString",
-      "canError": {
-        "secretKey": "HiddenString",
-        "error": "string"
-      }
+      "error?": "string"
     },
     "validateSEP7Link": {
       "_description": "Validate and handle a SEP7 Stellar URL link sent to the app.",
@@ -500,9 +487,7 @@
       "assetID": "Types.AssetID"
     },
     "changedTrustline": {
-      "canError": {
-        "error": "string"
-      }
+      "error?": "string"
     },
     "setTrustlineAcceptedAssets": {
       "accountID": "Types.AccountID",

--- a/shared/actions/profile-gen.tsx
+++ b/shared/actions/profile-gen.tsx
@@ -54,16 +54,14 @@ type _CleanupUsernamePayload = void
 type _ClearPlatformGenericPayload = void
 type _EditAvatarPayload = void
 type _EditProfilePayload = {readonly bio: string; readonly fullname: string; readonly location: string}
-type _FinishBlockUserPayload = void
-type _FinishBlockUserPayloadError = {readonly error: string}
+type _FinishBlockUserPayload = {readonly error?: string}
 type _FinishRevokingPayload = void
 type _FinishedWithKeyGenPayload = {readonly shouldStoreKeyOnServer: boolean}
 type _GeneratePgpPayload = void
 type _OnClickAvatarPayload = {readonly username: string; readonly openWebsite?: boolean | null}
 type _ProofParamsReceivedPayload = {readonly params: Types.ProveGenericParams}
 type _RecheckProofPayload = {readonly sigID: string}
-type _RevokeFinishPayload = void
-type _RevokeFinishPayloadError = {readonly error: string}
+type _RevokeFinishPayload = {readonly error?: string}
 type _ShowUserProfilePayload = {readonly username: string}
 type _SubmitBTCAddressPayload = void
 type _SubmitBlockUserPayload = {readonly username: string}
@@ -129,13 +127,9 @@ export const createEditProfile = (payload: _EditProfilePayload): EditProfilePayl
   payload,
   type: editProfile,
 })
-export const createFinishBlockUser = (payload: _FinishBlockUserPayload): FinishBlockUserPayload => ({
-  payload,
-  type: finishBlockUser,
-})
-export const createFinishBlockUserError = (
-  payload: _FinishBlockUserPayloadError
-): FinishBlockUserPayloadError => ({error: true, payload, type: finishBlockUser})
+export const createFinishBlockUser = (
+  payload: _FinishBlockUserPayload = Object.freeze({})
+): FinishBlockUserPayload => ({payload, type: finishBlockUser})
 export const createFinishRevoking = (payload: _FinishRevokingPayload): FinishRevokingPayload => ({
   payload,
   type: finishRevoking,
@@ -159,15 +153,9 @@ export const createRecheckProof = (payload: _RecheckProofPayload): RecheckProofP
   payload,
   type: recheckProof,
 })
-export const createRevokeFinish = (payload: _RevokeFinishPayload): RevokeFinishPayload => ({
-  payload,
-  type: revokeFinish,
-})
-export const createRevokeFinishError = (payload: _RevokeFinishPayloadError): RevokeFinishPayloadError => ({
-  error: true,
-  payload,
-  type: revokeFinish,
-})
+export const createRevokeFinish = (
+  payload: _RevokeFinishPayload = Object.freeze({})
+): RevokeFinishPayload => ({payload, type: revokeFinish})
 export const createShowUserProfile = (payload: _ShowUserProfilePayload): ShowUserProfilePayload => ({
   payload,
   type: showUserProfile,
@@ -264,11 +252,6 @@ export type FinishBlockUserPayload = {
   readonly payload: _FinishBlockUserPayload
   readonly type: typeof finishBlockUser
 }
-export type FinishBlockUserPayloadError = {
-  readonly error: true
-  readonly payload: _FinishBlockUserPayloadError
-  readonly type: typeof finishBlockUser
-}
 export type FinishRevokingPayload = {
   readonly payload: _FinishRevokingPayload
   readonly type: typeof finishRevoking
@@ -288,11 +271,6 @@ export type ProofParamsReceivedPayload = {
 }
 export type RecheckProofPayload = {readonly payload: _RecheckProofPayload; readonly type: typeof recheckProof}
 export type RevokeFinishPayload = {readonly payload: _RevokeFinishPayload; readonly type: typeof revokeFinish}
-export type RevokeFinishPayloadError = {
-  readonly error: true
-  readonly payload: _RevokeFinishPayloadError
-  readonly type: typeof revokeFinish
-}
 export type ShowUserProfilePayload = {
   readonly payload: _ShowUserProfilePayload
   readonly type: typeof showUserProfile
@@ -377,7 +355,6 @@ export type Actions =
   | EditAvatarPayload
   | EditProfilePayload
   | FinishBlockUserPayload
-  | FinishBlockUserPayloadError
   | FinishRevokingPayload
   | FinishedWithKeyGenPayload
   | GeneratePgpPayload
@@ -385,7 +362,6 @@ export type Actions =
   | ProofParamsReceivedPayload
   | RecheckProofPayload
   | RevokeFinishPayload
-  | RevokeFinishPayloadError
   | ShowUserProfilePayload
   | SubmitBTCAddressPayload
   | SubmitBlockUserPayload

--- a/shared/actions/profile/index.tsx
+++ b/shared/actions/profile/index.tsx
@@ -85,7 +85,7 @@ const submitRevokeProof = async (state: TypedState, action: ProfileGen.SubmitRev
       return false
     } catch (e) {
       logger.info('error in dropping pgp key', e)
-      return ProfileGen.createRevokeFinishError({error: `Error in dropping Pgp Key: ${e}`})
+      return ProfileGen.createRevokeFinish({error: `Error in dropping Pgp Key: ${e}`})
     }
   } else {
     try {
@@ -96,7 +96,7 @@ const submitRevokeProof = async (state: TypedState, action: ProfileGen.SubmitRev
       return ProfileGen.createFinishRevoking()
     } catch (error) {
       logger.warn(`Error when revoking proof ${action.payload.proofId}`, error)
-      return ProfileGen.createRevokeFinishError({
+      return ProfileGen.createRevokeFinish({
         error: 'There was an error revoking your proof. You can click the button to try again.',
       })
     }
@@ -118,7 +118,7 @@ const submitBlockUser = async (_: TypedState, action: ProfileGen.SubmitBlockUser
   } catch (e) {
     const error: RPCError = e
     logger.warn(`Error blocking user ${action.payload.username}`, error)
-    return ProfileGen.createFinishBlockUserError({
+    return ProfileGen.createFinishBlockUser({
       error: error.desc || `There was an error blocking ${action.payload.username}.`,
     })
   }

--- a/shared/actions/settings-gen.tsx
+++ b/shared/actions/settings-gen.tsx
@@ -113,13 +113,11 @@ type _FeedbackSentPayload = {readonly error: Error | null}
 type _ImportContactsLaterPayload = void
 type _InvitesClearErrorPayload = void
 type _InvitesReclaimPayload = {readonly inviteId: string}
-type _InvitesReclaimedPayload = void
-type _InvitesReclaimedPayloadError = {readonly errorText: string}
+type _InvitesReclaimedPayload = {readonly errorText?: string}
 type _InvitesRefreshPayload = void
 type _InvitesRefreshedPayload = {readonly invites: Types._InvitesState}
 type _InvitesSendPayload = {readonly email: string; readonly message: string | null}
-type _InvitesSentPayload = void
-type _InvitesSentPayloadError = {readonly error: Error}
+type _InvitesSentPayload = {readonly error?: Error}
 type _LoadContactImportEnabledPayload = void
 type _LoadHasRandomPwPayload = void
 type _LoadLockdownModePayload = void
@@ -318,13 +316,9 @@ export const createInvitesReclaim = (payload: _InvitesReclaimPayload): InvitesRe
   payload,
   type: invitesReclaim,
 })
-export const createInvitesReclaimed = (payload: _InvitesReclaimedPayload): InvitesReclaimedPayload => ({
-  payload,
-  type: invitesReclaimed,
-})
-export const createInvitesReclaimedError = (
-  payload: _InvitesReclaimedPayloadError
-): InvitesReclaimedPayloadError => ({error: true, payload, type: invitesReclaimed})
+export const createInvitesReclaimed = (
+  payload: _InvitesReclaimedPayload = Object.freeze({})
+): InvitesReclaimedPayload => ({payload, type: invitesReclaimed})
 export const createInvitesRefresh = (payload: _InvitesRefreshPayload): InvitesRefreshPayload => ({
   payload,
   type: invitesRefresh,
@@ -337,12 +331,7 @@ export const createInvitesSend = (payload: _InvitesSendPayload): InvitesSendPayl
   payload,
   type: invitesSend,
 })
-export const createInvitesSent = (payload: _InvitesSentPayload): InvitesSentPayload => ({
-  payload,
-  type: invitesSent,
-})
-export const createInvitesSentError = (payload: _InvitesSentPayloadError): InvitesSentPayloadError => ({
-  error: true,
+export const createInvitesSent = (payload: _InvitesSentPayload = Object.freeze({})): InvitesSentPayload => ({
   payload,
   type: invitesSent,
 })
@@ -546,11 +535,6 @@ export type InvitesReclaimedPayload = {
   readonly payload: _InvitesReclaimedPayload
   readonly type: typeof invitesReclaimed
 }
-export type InvitesReclaimedPayloadError = {
-  readonly error: true
-  readonly payload: _InvitesReclaimedPayloadError
-  readonly type: typeof invitesReclaimed
-}
 export type InvitesRefreshPayload = {
   readonly payload: _InvitesRefreshPayload
   readonly type: typeof invitesRefresh
@@ -561,11 +545,6 @@ export type InvitesRefreshedPayload = {
 }
 export type InvitesSendPayload = {readonly payload: _InvitesSendPayload; readonly type: typeof invitesSend}
 export type InvitesSentPayload = {readonly payload: _InvitesSentPayload; readonly type: typeof invitesSent}
-export type InvitesSentPayloadError = {
-  readonly error: true
-  readonly payload: _InvitesSentPayloadError
-  readonly type: typeof invitesSent
-}
 export type LoadContactImportEnabledPayload = {
   readonly payload: _LoadContactImportEnabledPayload
   readonly type: typeof loadContactImportEnabled
@@ -771,12 +750,10 @@ export type Actions =
   | InvitesClearErrorPayload
   | InvitesReclaimPayload
   | InvitesReclaimedPayload
-  | InvitesReclaimedPayloadError
   | InvitesRefreshPayload
   | InvitesRefreshedPayload
   | InvitesSendPayload
   | InvitesSentPayload
-  | InvitesSentPayloadError
   | LoadContactImportEnabledPayload
   | LoadHasRandomPwPayload
   | LoadLockdownModePayload

--- a/shared/actions/settings-gen.tsx
+++ b/shared/actions/settings-gen.tsx
@@ -28,7 +28,6 @@ export const feedbackSent = 'settings:feedbackSent'
 export const importContactsLater = 'settings:importContactsLater'
 export const invitesClearError = 'settings:invitesClearError'
 export const invitesReclaim = 'settings:invitesReclaim'
-export const invitesReclaimed = 'settings:invitesReclaimed'
 export const invitesRefresh = 'settings:invitesRefresh'
 export const invitesRefreshed = 'settings:invitesRefreshed'
 export const invitesSend = 'settings:invitesSend'
@@ -113,7 +112,6 @@ type _FeedbackSentPayload = {readonly error: Error | null}
 type _ImportContactsLaterPayload = void
 type _InvitesClearErrorPayload = void
 type _InvitesReclaimPayload = {readonly inviteId: string}
-type _InvitesReclaimedPayload = {readonly errorText?: string}
 type _InvitesRefreshPayload = void
 type _InvitesRefreshedPayload = {readonly invites: Types._InvitesState}
 type _InvitesSendPayload = {readonly email: string; readonly message: string | null}
@@ -316,9 +314,6 @@ export const createInvitesReclaim = (payload: _InvitesReclaimPayload): InvitesRe
   payload,
   type: invitesReclaim,
 })
-export const createInvitesReclaimed = (
-  payload: _InvitesReclaimedPayload = Object.freeze({})
-): InvitesReclaimedPayload => ({payload, type: invitesReclaimed})
 export const createInvitesRefresh = (payload: _InvitesRefreshPayload): InvitesRefreshPayload => ({
   payload,
   type: invitesRefresh,
@@ -530,10 +525,6 @@ export type InvitesClearErrorPayload = {
 export type InvitesReclaimPayload = {
   readonly payload: _InvitesReclaimPayload
   readonly type: typeof invitesReclaim
-}
-export type InvitesReclaimedPayload = {
-  readonly payload: _InvitesReclaimedPayload
-  readonly type: typeof invitesReclaimed
 }
 export type InvitesRefreshPayload = {
   readonly payload: _InvitesRefreshPayload
@@ -749,7 +740,6 @@ export type Actions =
   | ImportContactsLaterPayload
   | InvitesClearErrorPayload
   | InvitesReclaimPayload
-  | InvitesReclaimedPayload
   | InvitesRefreshPayload
   | InvitesRefreshedPayload
   | InvitesSendPayload

--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -122,13 +122,10 @@ const reclaimInvite = async (_: TypedState, action: SettingsGen.InvitesReclaimPa
       },
       Constants.settingsWaitingKey
     )
-    return [SettingsGen.createInvitesReclaimed(), SettingsGen.createInvitesRefresh()]
+    return [SettingsGen.createInvitesRefresh()]
   } catch (e) {
     logger.warn('Error reclaiming an invite:', e)
-    return [
-      SettingsGen.createInvitesReclaimed({errorText: e.desc + e.name}),
-      SettingsGen.createInvitesRefresh(),
-    ]
+    return [SettingsGen.createInvitesRefresh()]
   }
 }
 

--- a/shared/actions/settings.tsx
+++ b/shared/actions/settings.tsx
@@ -126,7 +126,7 @@ const reclaimInvite = async (_: TypedState, action: SettingsGen.InvitesReclaimPa
   } catch (e) {
     logger.warn('Error reclaiming an invite:', e)
     return [
-      SettingsGen.createInvitesReclaimedError({errorText: e.desc + e.name}),
+      SettingsGen.createInvitesReclaimed({errorText: e.desc + e.name}),
       SettingsGen.createInvitesRefresh(),
     ]
   }
@@ -219,7 +219,7 @@ const sendInvite = async (_: TypedState, action: SettingsGen.InvitesSendPayload)
     }
   } catch (e) {
     logger.warn('Error sending an invite:', e)
-    return [SettingsGen.createInvitesSentError({error: e}), SettingsGen.createInvitesRefresh()]
+    return [SettingsGen.createInvitesSent({error: e}), SettingsGen.createInvitesRefresh()]
   }
 }
 

--- a/shared/actions/signup-gen.tsx
+++ b/shared/actions/signup-gen.tsx
@@ -28,10 +28,8 @@ type _CheckDevicenamePayload = {readonly devicename: string}
 type _CheckInviteCodePayload = {readonly inviteCode: string}
 type _CheckPasswordPayload = {readonly pass1: HiddenString; readonly pass2: HiddenString}
 type _CheckUsernamePayload = {readonly username: string}
-type _CheckedDevicenamePayload = {readonly devicename: string}
-type _CheckedDevicenamePayloadError = {readonly devicename: string; readonly error: string}
-type _CheckedInviteCodePayload = {readonly inviteCode: string}
-type _CheckedInviteCodePayloadError = {readonly inviteCode: string; readonly error: string}
+type _CheckedDevicenamePayload = {readonly devicename: string; readonly error?: string}
+type _CheckedInviteCodePayload = {readonly inviteCode: string; readonly error?: string}
 type _CheckedUsernamePayload = {
   readonly username: string
   readonly usernameTaken?: string
@@ -41,19 +39,16 @@ type _ClearJustSignedUpEmailPayload = void
 type _GoBackAndClearErrorsPayload = void
 type _RequestAutoInvitePayload = void
 type _RequestInvitePayload = {readonly email: string; readonly name: string}
-type _RequestedAutoInvitePayload = {readonly inviteCode: string}
-type _RequestedAutoInvitePayloadError = void
-type _RequestedInvitePayload = {readonly email: string; readonly name: string}
-type _RequestedInvitePayloadError = {
-  readonly emailError: string
-  readonly nameError: string
+type _RequestedAutoInvitePayload = {readonly inviteCode?: string; readonly error?: boolean}
+type _RequestedInvitePayload = {
   readonly email: string
   readonly name: string
+  readonly emailError?: string
+  readonly nameError?: string
 }
 type _RestartSignupPayload = void
 type _SetJustSignedUpEmailPayload = {readonly email: string}
-type _SignedupPayload = void
-type _SignedupPayloadError = {readonly error: RPCError | null}
+type _SignedupPayload = {readonly error?: RPCError}
 
 // Action Creators
 export const createCheckDevicename = (payload: _CheckDevicenamePayload): CheckDevicenamePayload => ({
@@ -76,16 +71,10 @@ export const createCheckedDevicename = (payload: _CheckedDevicenamePayload): Che
   payload,
   type: checkedDevicename,
 })
-export const createCheckedDevicenameError = (
-  payload: _CheckedDevicenamePayloadError
-): CheckedDevicenamePayloadError => ({error: true, payload, type: checkedDevicename})
 export const createCheckedInviteCode = (payload: _CheckedInviteCodePayload): CheckedInviteCodePayload => ({
   payload,
   type: checkedInviteCode,
 })
-export const createCheckedInviteCodeError = (
-  payload: _CheckedInviteCodePayloadError
-): CheckedInviteCodePayloadError => ({error: true, payload, type: checkedInviteCode})
 export const createCheckedUsername = (payload: _CheckedUsernamePayload): CheckedUsernamePayload => ({
   payload,
   type: checkedUsername,
@@ -105,18 +94,12 @@ export const createRequestInvite = (payload: _RequestInvitePayload): RequestInvi
   type: requestInvite,
 })
 export const createRequestedAutoInvite = (
-  payload: _RequestedAutoInvitePayload
+  payload: _RequestedAutoInvitePayload = Object.freeze({})
 ): RequestedAutoInvitePayload => ({payload, type: requestedAutoInvite})
-export const createRequestedAutoInviteError = (
-  payload: _RequestedAutoInvitePayloadError
-): RequestedAutoInvitePayloadError => ({error: true, payload, type: requestedAutoInvite})
 export const createRequestedInvite = (payload: _RequestedInvitePayload): RequestedInvitePayload => ({
   payload,
   type: requestedInvite,
 })
-export const createRequestedInviteError = (
-  payload: _RequestedInvitePayloadError
-): RequestedInvitePayloadError => ({error: true, payload, type: requestedInvite})
 export const createRestartSignup = (payload: _RestartSignupPayload): RestartSignupPayload => ({
   payload,
   type: restartSignup,
@@ -124,9 +107,7 @@ export const createRestartSignup = (payload: _RestartSignupPayload): RestartSign
 export const createSetJustSignedUpEmail = (
   payload: _SetJustSignedUpEmailPayload
 ): SetJustSignedUpEmailPayload => ({payload, type: setJustSignedUpEmail})
-export const createSignedup = (payload: _SignedupPayload): SignedupPayload => ({payload, type: signedup})
-export const createSignedupError = (payload: _SignedupPayloadError): SignedupPayloadError => ({
-  error: true,
+export const createSignedup = (payload: _SignedupPayload = Object.freeze({})): SignedupPayload => ({
   payload,
   type: signedup,
 })
@@ -152,18 +133,8 @@ export type CheckedDevicenamePayload = {
   readonly payload: _CheckedDevicenamePayload
   readonly type: typeof checkedDevicename
 }
-export type CheckedDevicenamePayloadError = {
-  readonly error: true
-  readonly payload: _CheckedDevicenamePayloadError
-  readonly type: typeof checkedDevicename
-}
 export type CheckedInviteCodePayload = {
   readonly payload: _CheckedInviteCodePayload
-  readonly type: typeof checkedInviteCode
-}
-export type CheckedInviteCodePayloadError = {
-  readonly error: true
-  readonly payload: _CheckedInviteCodePayloadError
   readonly type: typeof checkedInviteCode
 }
 export type CheckedUsernamePayload = {
@@ -190,18 +161,8 @@ export type RequestedAutoInvitePayload = {
   readonly payload: _RequestedAutoInvitePayload
   readonly type: typeof requestedAutoInvite
 }
-export type RequestedAutoInvitePayloadError = {
-  readonly error: true
-  readonly payload: _RequestedAutoInvitePayloadError
-  readonly type: typeof requestedAutoInvite
-}
 export type RequestedInvitePayload = {
   readonly payload: _RequestedInvitePayload
-  readonly type: typeof requestedInvite
-}
-export type RequestedInvitePayloadError = {
-  readonly error: true
-  readonly payload: _RequestedInvitePayloadError
   readonly type: typeof requestedInvite
 }
 export type RestartSignupPayload = {
@@ -213,11 +174,6 @@ export type SetJustSignedUpEmailPayload = {
   readonly type: typeof setJustSignedUpEmail
 }
 export type SignedupPayload = {readonly payload: _SignedupPayload; readonly type: typeof signedup}
-export type SignedupPayloadError = {
-  readonly error: true
-  readonly payload: _SignedupPayloadError
-  readonly type: typeof signedup
-}
 
 // All Actions
 // prettier-ignore
@@ -227,20 +183,15 @@ export type Actions =
   | CheckPasswordPayload
   | CheckUsernamePayload
   | CheckedDevicenamePayload
-  | CheckedDevicenamePayloadError
   | CheckedInviteCodePayload
-  | CheckedInviteCodePayloadError
   | CheckedUsernamePayload
   | ClearJustSignedUpEmailPayload
   | GoBackAndClearErrorsPayload
   | RequestAutoInvitePayload
   | RequestInvitePayload
   | RequestedAutoInvitePayload
-  | RequestedAutoInvitePayloadError
   | RequestedInvitePayload
-  | RequestedInvitePayloadError
   | RestartSignupPayload
   | SetJustSignedUpEmailPayload
   | SignedupPayload
-  | SignedupPayloadError
   | {type: 'common:resetStore', payload: {}}

--- a/shared/actions/signup.tsx
+++ b/shared/actions/signup.tsx
@@ -59,7 +59,7 @@ const checkInviteCode = async (state: Container.TypedState) => {
     return SignupGen.createCheckedInviteCode({inviteCode: state.signup.inviteCode})
   } catch (e) {
     const err: RPCError = e
-    return SignupGen.createCheckedInviteCodeError({error: err.desc, inviteCode: state.signup.inviteCode})
+    return SignupGen.createCheckedInviteCode({error: err.desc, inviteCode: state.signup.inviteCode})
   }
 }
 
@@ -68,7 +68,7 @@ const requestAutoInvite = async () => {
     const inviteCode = await RPCTypes.signupGetInvitationCodeRpcPromise(undefined, Constants.waitingKey)
     return SignupGen.createRequestedAutoInvite({inviteCode})
   } catch (_) {
-    return SignupGen.createRequestedAutoInviteError()
+    return SignupGen.createRequestedAutoInvite({})
   }
 }
 
@@ -87,7 +87,7 @@ const requestInvite = async (state: Container.TypedState) => {
     })
   } catch (e) {
     const err: RPCError = e
-    return SignupGen.createRequestedInviteError({
+    return SignupGen.createRequestedInvite({
       email: state.signup.email,
       emailError: `Sorry can't get an invite: ${err.desc}`,
       name: state.signup.name,
@@ -139,7 +139,7 @@ const checkDevicename = async (state: Container.TypedState) => {
     return SignupGen.createCheckedDevicename({devicename: state.signup.devicename})
   } catch (e) {
     const err: RPCError = e
-    return SignupGen.createCheckedDevicenameError({
+    return SignupGen.createCheckedDevicename({
       devicename: state.signup.devicename,
       error: `Device name is invalid: ${err.desc}.`,
     })
@@ -192,7 +192,7 @@ function* reallySignupOnNoErrors(state: Container.TypedState) {
     })
     yield Saga.put(SignupGen.createSignedup())
   } catch (error) {
-    yield Saga.put(SignupGen.createSignedupError({error}))
+    yield Saga.put(SignupGen.createSignedup({error}))
   }
 }
 

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -724,7 +724,6 @@ export type TypedActionsMap = {
   'settings:clearAddedPhone': settings.ClearAddedPhonePayload
   'settings:invitesClearError': settings.InvitesClearErrorPayload
   'settings:invitesReclaim': settings.InvitesReclaimPayload
-  'settings:invitesReclaimed': settings.InvitesReclaimedPayload
   'settings:invitesRefresh': settings.InvitesRefreshPayload
   'settings:invitesRefreshed': settings.InvitesRefreshedPayload
   'settings:invitesSend': settings.InvitesSendPayload

--- a/shared/actions/unlock-folders-gen.tsx
+++ b/shared/actions/unlock-folders-gen.tsx
@@ -17,8 +17,7 @@ export const toPaperKeyInput = 'unlock-folders:toPaperKeyInput'
 export const waiting = 'unlock-folders:waiting'
 
 // Payload Types
-type _CheckPaperKeyDonePayload = void
-type _CheckPaperKeyDonePayloadError = {readonly error: string}
+type _CheckPaperKeyDonePayload = {readonly error?: string}
 type _CheckPaperKeyPayload = {readonly paperKey: string}
 type _CloseDonePayload = void
 type _ClosePopupPayload = void
@@ -38,13 +37,9 @@ export const createCheckPaperKey = (payload: _CheckPaperKeyPayload): CheckPaperK
   payload,
   type: checkPaperKey,
 })
-export const createCheckPaperKeyDone = (payload: _CheckPaperKeyDonePayload): CheckPaperKeyDonePayload => ({
-  payload,
-  type: checkPaperKeyDone,
-})
-export const createCheckPaperKeyDoneError = (
-  payload: _CheckPaperKeyDonePayloadError
-): CheckPaperKeyDonePayloadError => ({error: true, payload, type: checkPaperKeyDone})
+export const createCheckPaperKeyDone = (
+  payload: _CheckPaperKeyDonePayload = Object.freeze({})
+): CheckPaperKeyDonePayload => ({payload, type: checkPaperKeyDone})
 export const createCloseDone = (payload: _CloseDonePayload): CloseDonePayload => ({payload, type: closeDone})
 export const createClosePopup = (payload: _ClosePopupPayload): ClosePopupPayload => ({
   payload,
@@ -69,11 +64,6 @@ export const createWaiting = (payload: _WaitingPayload): WaitingPayload => ({pay
 // Action Payloads
 export type CheckPaperKeyDonePayload = {
   readonly payload: _CheckPaperKeyDonePayload
-  readonly type: typeof checkPaperKeyDone
-}
-export type CheckPaperKeyDonePayloadError = {
-  readonly error: true
-  readonly payload: _CheckPaperKeyDonePayloadError
   readonly type: typeof checkPaperKeyDone
 }
 export type CheckPaperKeyPayload = {
@@ -102,7 +92,6 @@ export type WaitingPayload = {readonly payload: _WaitingPayload; readonly type: 
 // prettier-ignore
 export type Actions =
   | CheckPaperKeyDonePayload
-  | CheckPaperKeyDonePayloadError
   | CheckPaperKeyPayload
   | CloseDonePayload
   | ClosePopupPayload

--- a/shared/actions/unlock-folders.tsx
+++ b/shared/actions/unlock-folders.tsx
@@ -14,7 +14,7 @@ function* checkPaperKey(_: Container.TypedState, action: UnlockFoldersGen.CheckP
     yield Saga.callUntyped(RPCTypes.loginPaperKeySubmitRpcPromise, {paperPhrase: paperKey})
     yield Saga.put(UnlockFoldersGen.createCheckPaperKeyDone())
   } catch (e) {
-    yield Saga.put(UnlockFoldersGen.createCheckPaperKeyDoneError({error: e.message}))
+    yield Saga.put(UnlockFoldersGen.createCheckPaperKeyDone({error: e.message}))
   } finally {
     yield Saga.put(UnlockFoldersGen.createWaiting({waiting: false}))
   }

--- a/shared/actions/wallets-gen.tsx
+++ b/shared/actions/wallets-gen.tsx
@@ -173,14 +173,12 @@ type _ChangeAccountNamePayload = {readonly accountID: Types.AccountID; readonly 
 type _ChangeAirdropPayload = {readonly accept: boolean}
 type _ChangeDisplayCurrencyPayload = {readonly accountID: Types.AccountID; readonly code: Types.CurrencyCode}
 type _ChangeMobileOnlyModePayload = {readonly accountID: Types.AccountID; readonly enabled: boolean}
-type _ChangedAccountNamePayload = {readonly account: Types.Account}
-type _ChangedAccountNamePayloadError = {
-  readonly name: string
-  readonly account: Types.Account
-  readonly error: string
+type _ChangedAccountNamePayload = {
+  readonly name?: string
+  readonly account?: Types.Account
+  readonly error?: string
 }
-type _ChangedTrustlinePayload = void
-type _ChangedTrustlinePayloadError = {readonly error: string}
+type _ChangedTrustlinePayload = {readonly error?: string}
 type _CheckDisclaimerPayload = {readonly nextScreen: Types.NextScreenAfterAcceptance}
 type _ClearBuildingAdvancedPayload = void
 type _ClearBuildingPayload = void
@@ -194,11 +192,12 @@ type _CreateNewAccountPayload = {
   readonly setBuildingTo?: boolean
 }
 type _CreatedNewAccountPayload = {
-  readonly accountID: Types.AccountID
+  readonly accountID?: Types.AccountID
   readonly showOnCreation?: boolean
   readonly setBuildingTo?: boolean
+  readonly name?: string
+  readonly error?: string
 }
-type _CreatedNewAccountPayloadError = {readonly name: string; readonly error: string}
 type _DeleteAccountPayload = {readonly accountID: Types.AccountID}
 type _DeleteTrustlinePayload = {readonly accountID: Types.AccountID; readonly assetID: Types.AssetID}
 type _DeletedAccountPayload = void
@@ -214,11 +213,11 @@ type _ExportSecretKeyPayload = {readonly accountID: Types.AccountID}
 type _ExternalPartnersReceivedPayload = {readonly externalPartners: I.List<Types.PartnerUrl>}
 type _HideAirdropBannerPayload = void
 type _InflationDestinationReceivedPayload = {
-  readonly accountID: Types.AccountID
-  readonly selected: Types.AccountInflationDestination
+  readonly accountID?: Types.AccountID
+  readonly selected?: Types.AccountInflationDestination
   readonly options?: Array<Types.InflationDestination>
+  readonly error?: string
 }
-type _InflationDestinationReceivedPayloadError = {readonly error: string}
 type _LinkExistingAccountPayload = {
   readonly name: string
   readonly secretKey: HiddenString
@@ -226,14 +225,12 @@ type _LinkExistingAccountPayload = {
   readonly setBuildingTo?: boolean
 }
 type _LinkedExistingAccountPayload = {
-  readonly accountID: Types.AccountID
+  readonly accountID?: Types.AccountID
   readonly showOnCreation?: boolean
   readonly setBuildingTo?: boolean
-}
-type _LinkedExistingAccountPayloadError = {
-  readonly name: string
-  readonly secretKey: HiddenString
-  readonly error: string
+  readonly name?: string
+  readonly secretKey?: HiddenString
+  readonly error?: string
 }
 type _LoadAccountsPayload = {readonly reason: 'initial-load' | 'open-send-req-form'}
 type _LoadAssetsPayload = {readonly accountID: Types.AccountID}
@@ -387,10 +384,8 @@ type _ValidateAccountNamePayload = {readonly name: string}
 type _ValidateSEP7LinkErrorPayload = {readonly error: string}
 type _ValidateSEP7LinkPayload = {readonly link: string}
 type _ValidateSecretKeyPayload = {readonly secretKey: HiddenString}
-type _ValidatedAccountNamePayload = {readonly name: string}
-type _ValidatedAccountNamePayloadError = {readonly name: string; readonly error: string}
-type _ValidatedSecretKeyPayload = {readonly secretKey: HiddenString}
-type _ValidatedSecretKeyPayloadError = {readonly secretKey: HiddenString; readonly error: string}
+type _ValidatedAccountNamePayload = {readonly name: string; readonly error?: string}
+type _ValidatedSecretKeyPayload = {readonly secretKey: HiddenString; readonly error?: string}
 type _WalletDisclaimerReceivedPayload = {readonly accepted: boolean}
 
 // Action Creators
@@ -410,13 +405,9 @@ export const createDidSetAccountAsDefault = (
 /**
  * A response from the service after an account's name is changed
  */
-export const createChangedAccountName = (payload: _ChangedAccountNamePayload): ChangedAccountNamePayload => ({
-  payload,
-  type: changedAccountName,
-})
-export const createChangedAccountNameError = (
-  payload: _ChangedAccountNamePayloadError
-): ChangedAccountNamePayloadError => ({error: true, payload, type: changedAccountName})
+export const createChangedAccountName = (
+  payload: _ChangedAccountNamePayload = Object.freeze({})
+): ChangedAccountNamePayload => ({payload, type: changedAccountName})
 /**
  * Accept the Stellar account disclaimer
  */
@@ -585,11 +576,8 @@ export const createSentPaymentError = (payload: _SentPaymentErrorPayload): SentP
  * Got inflation destination
  */
 export const createInflationDestinationReceived = (
-  payload: _InflationDestinationReceivedPayload
+  payload: _InflationDestinationReceivedPayload = Object.freeze({})
 ): InflationDestinationReceivedPayload => ({payload, type: inflationDestinationReceived})
-export const createInflationDestinationReceivedError = (
-  payload: _InflationDestinationReceivedPayloadError
-): InflationDestinationReceivedPayloadError => ({error: true, payload, type: inflationDestinationReceived})
 /**
  * Handle a SEP6 Deposit link
  */
@@ -902,28 +890,18 @@ export const createLoadedMobileOnlyMode = (
 export const createValidatedAccountName = (
   payload: _ValidatedAccountNamePayload
 ): ValidatedAccountNamePayload => ({payload, type: validatedAccountName})
-export const createValidatedAccountNameError = (
-  payload: _ValidatedAccountNamePayloadError
-): ValidatedAccountNamePayloadError => ({error: true, payload, type: validatedAccountName})
 /**
  * The service responded with an error or that the create new account operation succeeded
  */
-export const createCreatedNewAccount = (payload: _CreatedNewAccountPayload): CreatedNewAccountPayload => ({
-  payload,
-  type: createdNewAccount,
-})
-export const createCreatedNewAccountError = (
-  payload: _CreatedNewAccountPayloadError
-): CreatedNewAccountPayloadError => ({error: true, payload, type: createdNewAccount})
+export const createCreatedNewAccount = (
+  payload: _CreatedNewAccountPayload = Object.freeze({})
+): CreatedNewAccountPayload => ({payload, type: createdNewAccount})
 /**
  * The service responded with an error or that the link existing operation succeeded
  */
 export const createLinkedExistingAccount = (
-  payload: _LinkedExistingAccountPayload
+  payload: _LinkedExistingAccountPayload = Object.freeze({})
 ): LinkedExistingAccountPayload => ({payload, type: linkedExistingAccount})
-export const createLinkedExistingAccountError = (
-  payload: _LinkedExistingAccountPayloadError
-): LinkedExistingAccountPayloadError => ({error: true, payload, type: linkedExistingAccount})
 /**
  * The service responded with an error or that the secret key is valid.
  */
@@ -931,9 +909,6 @@ export const createValidatedSecretKey = (payload: _ValidatedSecretKeyPayload): V
   payload,
   type: validatedSecretKey,
 })
-export const createValidatedSecretKeyError = (
-  payload: _ValidatedSecretKeyPayloadError
-): ValidatedSecretKeyPayloadError => ({error: true, payload, type: validatedSecretKey})
 /**
  * Turn participation in airdrop on/off
  */
@@ -1062,13 +1037,9 @@ export const createAddTrustline = (payload: _AddTrustlinePayload): AddTrustlineP
 export const createCalculateBuildingAdvanced = (
   payload: _CalculateBuildingAdvancedPayload
 ): CalculateBuildingAdvancedPayload => ({payload, type: calculateBuildingAdvanced})
-export const createChangedTrustline = (payload: _ChangedTrustlinePayload): ChangedTrustlinePayload => ({
-  payload,
-  type: changedTrustline,
-})
-export const createChangedTrustlineError = (
-  payload: _ChangedTrustlinePayloadError
-): ChangedTrustlinePayloadError => ({error: true, payload, type: changedTrustline})
+export const createChangedTrustline = (
+  payload: _ChangedTrustlinePayload = Object.freeze({})
+): ChangedTrustlinePayload => ({payload, type: changedTrustline})
 export const createClearTrustlineSearchResults = (
   payload: _ClearTrustlineSearchResultsPayload
 ): ClearTrustlineSearchResultsPayload => ({payload, type: clearTrustlineSearchResults})
@@ -1239,18 +1210,8 @@ export type ChangedAccountNamePayload = {
   readonly payload: _ChangedAccountNamePayload
   readonly type: typeof changedAccountName
 }
-export type ChangedAccountNamePayloadError = {
-  readonly error: true
-  readonly payload: _ChangedAccountNamePayloadError
-  readonly type: typeof changedAccountName
-}
 export type ChangedTrustlinePayload = {
   readonly payload: _ChangedTrustlinePayload
-  readonly type: typeof changedTrustline
-}
-export type ChangedTrustlinePayloadError = {
-  readonly error: true
-  readonly payload: _ChangedTrustlinePayloadError
   readonly type: typeof changedTrustline
 }
 export type CheckDisclaimerPayload = {
@@ -1284,11 +1245,6 @@ export type CreateNewAccountPayload = {
 }
 export type CreatedNewAccountPayload = {
   readonly payload: _CreatedNewAccountPayload
-  readonly type: typeof createdNewAccount
-}
-export type CreatedNewAccountPayloadError = {
-  readonly error: true
-  readonly payload: _CreatedNewAccountPayloadError
   readonly type: typeof createdNewAccount
 }
 export type DeleteAccountPayload = {
@@ -1335,22 +1291,12 @@ export type InflationDestinationReceivedPayload = {
   readonly payload: _InflationDestinationReceivedPayload
   readonly type: typeof inflationDestinationReceived
 }
-export type InflationDestinationReceivedPayloadError = {
-  readonly error: true
-  readonly payload: _InflationDestinationReceivedPayloadError
-  readonly type: typeof inflationDestinationReceived
-}
 export type LinkExistingAccountPayload = {
   readonly payload: _LinkExistingAccountPayload
   readonly type: typeof linkExistingAccount
 }
 export type LinkedExistingAccountPayload = {
   readonly payload: _LinkedExistingAccountPayload
-  readonly type: typeof linkedExistingAccount
-}
-export type LinkedExistingAccountPayloadError = {
-  readonly error: true
-  readonly payload: _LinkedExistingAccountPayloadError
   readonly type: typeof linkedExistingAccount
 }
 export type LoadAccountsPayload = {readonly payload: _LoadAccountsPayload; readonly type: typeof loadAccounts}
@@ -1644,18 +1590,8 @@ export type ValidatedAccountNamePayload = {
   readonly payload: _ValidatedAccountNamePayload
   readonly type: typeof validatedAccountName
 }
-export type ValidatedAccountNamePayloadError = {
-  readonly error: true
-  readonly payload: _ValidatedAccountNamePayloadError
-  readonly type: typeof validatedAccountName
-}
 export type ValidatedSecretKeyPayload = {
   readonly payload: _ValidatedSecretKeyPayload
-  readonly type: typeof validatedSecretKey
-}
-export type ValidatedSecretKeyPayloadError = {
-  readonly error: true
-  readonly payload: _ValidatedSecretKeyPayloadError
   readonly type: typeof validatedSecretKey
 }
 export type WalletDisclaimerReceivedPayload = {
@@ -1690,9 +1626,7 @@ export type Actions =
   | ChangeDisplayCurrencyPayload
   | ChangeMobileOnlyModePayload
   | ChangedAccountNamePayload
-  | ChangedAccountNamePayloadError
   | ChangedTrustlinePayload
-  | ChangedTrustlinePayloadError
   | CheckDisclaimerPayload
   | ClearBuildingAdvancedPayload
   | ClearBuildingPayload
@@ -1702,7 +1636,6 @@ export type Actions =
   | ClearTrustlineSearchResultsPayload
   | CreateNewAccountPayload
   | CreatedNewAccountPayload
-  | CreatedNewAccountPayloadError
   | DeleteAccountPayload
   | DeleteTrustlinePayload
   | DeletedAccountPayload
@@ -1714,10 +1647,8 @@ export type Actions =
   | ExternalPartnersReceivedPayload
   | HideAirdropBannerPayload
   | InflationDestinationReceivedPayload
-  | InflationDestinationReceivedPayloadError
   | LinkExistingAccountPayload
   | LinkedExistingAccountPayload
-  | LinkedExistingAccountPayloadError
   | LoadAccountsPayload
   | LoadAssetsPayload
   | LoadDisplayCurrenciesPayload
@@ -1796,8 +1727,6 @@ export type Actions =
   | ValidateSEP7LinkPayload
   | ValidateSecretKeyPayload
   | ValidatedAccountNamePayload
-  | ValidatedAccountNamePayloadError
   | ValidatedSecretKeyPayload
-  | ValidatedSecretKeyPayloadError
   | WalletDisclaimerReceivedPayload
   | {type: 'common:resetStore', payload: {}}

--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -402,7 +402,7 @@ const loadAccounts = async (
   }
   if (
     (action.type === WalletsGen.linkedExistingAccount || action.type === WalletsGen.createdNewAccount) &&
-    action.payload.error
+    (action.payload.error || !action.payload.accountID)
   ) {
     return false
   }

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -12,7 +12,6 @@ import {isMobile} from '../constants/platform'
 import logger from '../logger'
 import HiddenString from '../util/hidden-string'
 import partition from 'lodash/partition'
-import {actionHasError} from '../util/container'
 
 type EngineActions =
   | EngineGen.Chat1NotifyChatChatTypingUpdatePayload
@@ -297,14 +296,14 @@ const messageMapReducer = (
           if (!message || message.type !== 'attachment') {
             return message
           }
-          const path = (!actionHasError(action) && action.payload.path) || ''
+          const path = (!action.payload.error && action.payload.path) || ''
           return message
             .set('downloadPath', path)
             .set('transferProgress', 0)
             .set('transferState', null)
             .set(
               'transferErrMsg',
-              actionHasError(action) ? action.payload.error || 'Error downloading attachment' : null
+              action.payload.error ? action.payload.error || 'Error downloading attachment' : null
             )
             .set('fileURLCached', true) // assume we have this on the service now
         }
@@ -567,7 +566,7 @@ export default (_state: Types.State = initialState, action: Actions): Types.Stat
         )
         return
       case Chat2Gen.setPaymentConfirmInfo:
-        draftState.paymentConfirmInfo = actionHasError(action)
+        draftState.paymentConfirmInfo = action.payload.error
           ? {error: action.payload.error}
           : {summary: action.payload.summary}
         return
@@ -1481,7 +1480,7 @@ export default (_state: Types.State = initialState, action: Actions): Types.Stat
       case Chat2Gen.attachmentDownloaded: {
         const {message} = action.payload
         if (
-          !actionHasError(action) &&
+          !action.payload.error &&
           draftState.attachmentFullscreenSelection &&
           draftState.attachmentFullscreenSelection.message.conversationIDKey === message.conversationIDKey &&
           draftState.attachmentFullscreenSelection.message.id === message.id &&

--- a/shared/reducers/profile.tsx
+++ b/shared/reducers/profile.tsx
@@ -3,7 +3,6 @@ import * as Types from '../constants/types/profile'
 import * as More from '../constants/types/more'
 import * as Constants from '../constants/profile'
 import * as Validators from '../util/simple-validators'
-import {actionHasError} from '../util/container'
 
 const updateUsername = (state: Types.State) => {
   let username = state.username || ''
@@ -52,11 +51,11 @@ export default function(state: Types.State = initialState, action: ProfileGen.Ac
     case ProfileGen.cleanupUsername:
       return updateUsername(state)
     case ProfileGen.revokeFinish:
-      return state.merge({revokeError: actionHasError(action) ? action.payload.error : ''})
+      return state.merge({revokeError: action.payload.error ? action.payload.error : ''})
     case ProfileGen.submitBlockUser:
       return state.merge({blockUserModal: 'waiting'})
     case ProfileGen.finishBlockUser:
-      return state.merge({blockUserModal: actionHasError(action) ? {error: action.payload.error} : null})
+      return state.merge({blockUserModal: action.payload.error ? {error: action.payload.error} : null})
     case ProfileGen.updateProofText:
       return state.merge({proofText: action.payload.proof})
     case ProfileGen.updateProofStatus:

--- a/shared/reducers/settings.tsx
+++ b/shared/reducers/settings.tsx
@@ -5,7 +5,6 @@ import * as EngineGen from '../actions/engine-gen-gen'
 import * as Types from '../constants/types/settings'
 import * as Constants from '../constants/settings'
 import * as Flow from '../util/flow'
-import {actionHasError} from '../util/container'
 import {isValidEmail} from '../util/simple-validators'
 
 const initialState: Types.State = Constants.makeState()
@@ -82,9 +81,7 @@ function reducer(state: Types.State = initialState, action: Actions): Types.Stat
       return state.update('invites', invites => invites.merge(action.payload.invites))
     case SettingsGen.invitesSent:
       // TODO this doesn't do anything with the actual valid payload
-      return state.update('invites', invites =>
-        invites.merge({error: actionHasError(action) ? action.payload.error : undefined})
-      )
+      return state.update('invites', invites => invites.merge({error: action.payload.error}))
     case SettingsGen.invitesClearError:
       return state.update('invites', invites => invites.merge({error: null}))
     case SettingsGen.loadedSettings:

--- a/shared/reducers/settings.tsx
+++ b/shared/reducers/settings.tsx
@@ -80,7 +80,6 @@ function reducer(state: Types.State = initialState, action: Actions): Types.Stat
     case SettingsGen.invitesRefreshed:
       return state.update('invites', invites => invites.merge(action.payload.invites))
     case SettingsGen.invitesSent:
-      // TODO this doesn't do anything with the actual valid payload
       return state.update('invites', invites => invites.merge({error: action.payload.error}))
     case SettingsGen.invitesClearError:
       return state.update('invites', invites => invites.merge({error: null}))
@@ -257,7 +256,6 @@ function reducer(state: Types.State = initialState, action: Actions): Types.Stat
     case SettingsGen.editEmail:
     case SettingsGen.editPhone:
     case SettingsGen.invitesReclaim:
-    case SettingsGen.invitesReclaimed:
     case SettingsGen.invitesRefresh:
     case SettingsGen.invitesSend:
     case SettingsGen.loadRememberPassword:

--- a/shared/reducers/signup.tsx
+++ b/shared/reducers/signup.tsx
@@ -3,7 +3,6 @@ import * as Constants from '../constants/signup'
 import * as SignupGen from '../actions/signup-gen'
 import * as EngineGen from '../actions/engine-gen-gen'
 import HiddenString from '../util/hidden-string'
-import {actionHasError} from '../util/container'
 import trim from 'lodash/trim'
 import {isValidEmail, isValidName, isValidUsername} from '../util/simple-validators'
 
@@ -30,12 +29,12 @@ export default function(state: Types.State = initialState, action: Actions): Typ
         usernameTaken: '',
       })
     case SignupGen.requestedAutoInvite:
-      return state.merge({inviteCode: actionHasError(action) ? '' : action.payload.inviteCode})
+      return state.merge({inviteCode: action.payload.error ? '' : action.payload.inviteCode})
     case SignupGen.checkInviteCode:
       return state.merge({inviteCode: action.payload.inviteCode})
     case SignupGen.checkedInviteCode:
       return action.payload.inviteCode === state.inviteCode
-        ? state.merge({inviteCodeError: actionHasError(action) ? action.payload.error : ''})
+        ? state.merge({inviteCodeError: action.payload.error ? action.payload.error : ''})
         : state
     case SignupGen.checkUsername: {
       const {username} = action.payload
@@ -60,8 +59,8 @@ export default function(state: Types.State = initialState, action: Actions): Typ
     case SignupGen.requestedInvite:
       return action.payload.email === state.email && action.payload.name === state.name
         ? state.merge({
-            emailError: actionHasError(action) ? action.payload.emailError : '',
-            nameError: actionHasError(action) ? action.payload.nameError : '',
+            emailError: action.payload.emailError || '',
+            nameError: action.payload.nameError || '',
           })
         : state
     case SignupGen.checkPassword: {
@@ -88,11 +87,11 @@ export default function(state: Types.State = initialState, action: Actions): Typ
     }
     case SignupGen.checkedDevicename:
       return action.payload.devicename === state.devicename
-        ? state.merge({devicenameError: actionHasError(action) ? action.payload.error : ''})
+        ? state.merge({devicenameError: action.payload.error || ''})
         : state
     case SignupGen.signedup:
       return state.merge({
-        signupError: actionHasError(action) ? action.payload.error : null,
+        signupError: action.payload.error || null,
       })
     case SignupGen.setJustSignedUpEmail:
       return state.merge({

--- a/shared/reducers/unlock-folders.tsx
+++ b/shared/reducers/unlock-folders.tsx
@@ -3,7 +3,6 @@ import * as UnlockFoldersGen from '../actions/unlock-folders-gen'
 import * as Constants from '../constants/unlock-folders'
 import * as Types from '../constants/types/unlock-folders'
 import * as DeviceTypes from '../constants/types/devices'
-import {actionHasError} from '../util/container'
 
 const initialState = Constants.makeState()
 
@@ -23,7 +22,7 @@ export default function(state: Types.State = initialState, action: UnlockFolders
     case UnlockFoldersGen.toPaperKeyInput:
       return state.merge({phase: 'paperKeyInput'})
     case UnlockFoldersGen.checkPaperKeyDone:
-      if (actionHasError(action)) {
+      if (action.payload.error) {
         return state.merge({paperkeyError: action.payload.error})
       }
       return state.merge({phase: 'success'})

--- a/shared/util/container.tsx
+++ b/shared/util/container.tsx
@@ -15,9 +15,6 @@ export const emptyArray: Array<any> = []
 export const emptySet = new Set<any>()
 export const emptyMap = new Map<any, any>()
 export const NullComponent = () => null
-export const actionHasError = <NoError extends {}, HasError extends {error: boolean}>(
-  a: NoError | HasError
-): a is HasError => Object.prototype.hasOwnProperty.call(a, 'error')
 
 export const networkErrorCodes = [
   StatusCode.scgenericapierror,

--- a/shared/wallets/wallet/settings/popups/inflation-destination/container.tsx
+++ b/shared/wallets/wallet/settings/popups/inflation-destination/container.tsx
@@ -20,7 +20,7 @@ export default Container.namedConnect(
   },
   dispatch => ({
     _onClose: () => {
-      dispatch(WalletsGen.createInflationDestinationReceivedError({error: ''}))
+      dispatch(WalletsGen.createInflationDestinationReceived({error: ''}))
       dispatch(RouteTreeGen.createNavigateUp())
     },
     _onSubmit: (accountID: Types.AccountID, destination: string, name: string) => {


### PR DESCRIPTION
- [x] removes canError concept
- [x] changes all `create*Error` calls into `create*`
- [x] quickly tested most flows