### PR TITLE
remove darkMode feature flag. make desktop startup always correct

### DIFF
--- a/shared/__mocks__/feature-flags.tsx
+++ b/shared/__mocks__/feature-flags.tsx
@@ -9,7 +9,6 @@ const ff: FeatureFlags = {
   airdrop: true,
   chatIndexProfilingEnabled: false,
   conflictResolution: false,
-  darkMode: false,
   dbCleanEnabled: false,
   fastAccountSwitch: true,
   foldersInProfileTab: true,

--- a/shared/desktop/renderer/main2.desktop.tsx
+++ b/shared/desktop/renderer/main2.desktop.tsx
@@ -15,10 +15,24 @@ import {disable as disableDragDrop} from '../../util/drag-drop'
 import flags from '../../util/feature-flags'
 import {dumpLogs} from '../../actions/platform-specific/index.desktop'
 import {initDesktopStyles} from '../../styles/index.desktop'
+import {_setDarkModePreference} from '../../styles/dark-mode'
 import {isDarwin} from '../../constants/platform'
 import {useSelector} from '../../util/container'
 import {isDarkMode} from '../../constants/config'
 import {TypedActions} from '../../actions/typed-actions-gen'
+
+// node side plumbs through initial pref so we avoid flashes
+const darkModeFromNode = window.location.search.match(/darkModePreference=(alwaysLight|alwaysDark|system)/)
+
+if (darkModeFromNode) {
+  const dm = darkModeFromNode[1]
+  switch (dm) {
+    case 'alwaysLight':
+    case 'alwaysDark':
+    case 'system':
+      _setDarkModePreference(dm)
+  }
+}
 
 // Top level HMR accept
 if (module.hot) {
@@ -104,8 +118,10 @@ const DarkCSSInjector = () => {
     // inject it in body so modals get darkMode also
     if (isDark) {
       document.body.classList.add('darkMode')
+      document.body.classList.remove('lightMode')
     } else {
       document.body.classList.remove('darkMode')
+      document.body.classList.add('lightMode')
     }
   }, [isDark])
   return null

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -398,6 +398,9 @@ body {
   opacity: 1;
 }
 
+.lightMode {
+  background-color: #ffffff;
+}
 .darkMode {
   background-color: #191919;
 }

--- a/shared/menubar/index.desktop.tsx
+++ b/shared/menubar/index.desktop.tsx
@@ -90,7 +90,7 @@ class MenubarRender extends React.Component<Props, State> {
   _renderLoggedOut() {
     return (
       <Kb.Box
-        className={this.props.darkMode ? 'darkMode' : ''}
+        className={this.props.darkMode ? 'darkMode' : 'lightMode'}
         key={this.props.darkMode ? 'darkMode' : 'light'}
         style={styles.widgetContainer}
       >
@@ -160,7 +160,7 @@ class MenubarRender extends React.Component<Props, State> {
     return (
       <Kb.Box
         style={styles.widgetContainer}
-        className={this.props.darkMode ? 'darkMode' : ''}
+        className={this.props.darkMode ? 'darkMode' : 'lightMode'}
         key={this.props.darkMode ? 'darkMode' : 'light'}
       >
         {isDarwin && <style>{_realCSS}</style>}
@@ -301,7 +301,7 @@ class MenubarRender extends React.Component<Props, State> {
     return (
       <Kb.Box
         style={styles.widgetContainer}
-        className={this.props.darkMode ? 'darkMode' : ''}
+        className={this.props.darkMode ? 'darkMode' : 'lightMode'}
         key={this.props.darkMode ? 'darkMode' : 'light'}
       >
         {isDarwin && <style>{_realCSS}</style>}

--- a/shared/pinentry/index.desktop.tsx
+++ b/shared/pinentry/index.desktop.tsx
@@ -82,7 +82,7 @@ class Pinentry extends React.Component<Props, State> {
     return (
       <Kb.Box
         style={styles.container}
-        className={this.props.darkMode ? 'darkMode' : ''}
+        className={this.props.darkMode ? 'darkMode' : 'lightMode'}
         key={this.props.darkMode ? 'darkMode' : 'light'}
       >
         <Kb.Header icon={false} title="" onClose={this.props.onCancel} windowDragging={true} />

--- a/shared/settings/display/index.tsx
+++ b/shared/settings/display/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
-import flags from '../../util/feature-flags'
 import {DarkModePreference, isDarkModeSystemSupported} from '../../styles/dark-mode'
 
 type Props = {
@@ -13,30 +12,28 @@ type Props = {
 const Display = (props: Props) => (
   <Kb.ScrollView style={styles.scrollview}>
     <Kb.Box style={styles.container}>
-      {flags.darkMode && (
-        <Kb.Box2 direction="vertical" fullWidth={true}>
-          <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny">
-            <Kb.Text type="Header">Appearance</Kb.Text>
-            {isDarkModeSystemSupported() && (
-              <Kb.RadioButton
-                label="Respect system settings"
-                selected={props.darkModePreference === 'system' || props.darkModePreference === undefined}
-                onSelect={() => props.onSetDarkModePreference('system')}
-              />
-            )}
+      <Kb.Box2 direction="vertical" fullWidth={true}>
+        <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny">
+          <Kb.Text type="Header">Appearance</Kb.Text>
+          {isDarkModeSystemSupported() && (
             <Kb.RadioButton
-              label="Dark"
-              selected={props.darkModePreference === 'alwaysDark'}
-              onSelect={() => props.onSetDarkModePreference('alwaysDark')}
+              label="Respect system settings"
+              selected={props.darkModePreference === 'system' || props.darkModePreference === undefined}
+              onSelect={() => props.onSetDarkModePreference('system')}
             />
-            <Kb.RadioButton
-              label={<Kb.Text type="Body">Light</Kb.Text>}
-              selected={props.darkModePreference === 'alwaysLight'}
-              onSelect={() => props.onSetDarkModePreference('alwaysLight')}
-            />
-          </Kb.Box2>
+          )}
+          <Kb.RadioButton
+            label="Dark"
+            selected={props.darkModePreference === 'alwaysDark'}
+            onSelect={() => props.onSetDarkModePreference('alwaysDark')}
+          />
+          <Kb.RadioButton
+            label={<Kb.Text type="Body">Light</Kb.Text>}
+            selected={props.darkModePreference === 'alwaysLight'}
+            onSelect={() => props.onSetDarkModePreference('alwaysLight')}
+          />
         </Kb.Box2>
-      )}
+      </Kb.Box2>
     </Kb.Box>
   </Kb.ScrollView>
 )

--- a/shared/stories/index.desktop.tsx
+++ b/shared/stories/index.desktop.tsx
@@ -60,7 +60,7 @@ const RootWrapper = ({children}) => {
         <div
           key={darkMode ? 'dark' : 'light'}
           style={{height: '100%', width: '100%'}}
-          className={darkMode ? 'darkMode' : ''}
+          className={darkMode ? 'darkMode' : 'lightMode'}
         >
           {children}
           <div id="modal-root" key={darkMode ? 'dark' : 'light'} />

--- a/shared/styles/dark-mode.tsx
+++ b/shared/styles/dark-mode.tsx
@@ -1,7 +1,5 @@
 // Darkmode is managed by redux but for things (proxies and etc) to get this value simply the value is
 // copied here
-import flags from '../util/feature-flags'
-
 export type DarkModePreference = 'system' | 'alwaysDark' | 'alwaysLight' | undefined
 
 let darkModePreference: DarkModePreference
@@ -22,9 +20,6 @@ export const _setSystemSupported = (supported: boolean) => {
 }
 
 export const isDarkMode = () => {
-  if (!flags.darkMode) {
-    return false
-  }
   switch (darkModePreference) {
     case undefined:
       return systemDarkMode

--- a/shared/tracker2/index.desktop.tsx
+++ b/shared/tracker2/index.desktop.tsx
@@ -140,7 +140,7 @@ const Tracker = (props: Props) => {
       fullWidth={true}
       fullHeight={true}
       style={styles.container}
-      className={props.darkMode ? 'darkMode' : ''}
+      className={props.darkMode ? 'darkMode' : 'lightMode'}
       key={props.darkMode ? 'darkMode' : 'light'}
     >
       <Kb.Text type="BodySmallSemibold" style={Styles.collapseStyles([styles.reason, {backgroundColor}])}>

--- a/shared/unlock-folders/index.desktop.tsx
+++ b/shared/unlock-folders/index.desktop.tsx
@@ -48,7 +48,7 @@ const UnlockFolders = (props: Props) => {
   return (
     <div
       style={styles.container}
-      className={props.darkMode ? 'darkMode' : ''}
+      className={props.darkMode ? 'darkMode' : 'lightMode'}
       key={props.darkMode ? 'darkMode' : 'light'}
     >
       <div style={styles.header}>

--- a/shared/util/feature-flags.d.ts
+++ b/shared/util/feature-flags.d.ts
@@ -3,7 +3,6 @@ export type FeatureFlags = {
   airdrop: boolean
   chatIndexProfilingEnabled: boolean
   conflictResolution: boolean
-  darkMode: boolean
   dbCleanEnabled: boolean
   fastAccountSwitch: boolean
   foldersInProfileTab: boolean

--- a/shared/util/feature-flags.desktop.tsx
+++ b/shared/util/feature-flags.desktop.tsx
@@ -14,7 +14,6 @@ const ff: FeatureFlags = {
   airdrop: true,
   chatIndexProfilingEnabled: false,
   conflictResolution: false,
-  darkMode: true,
   dbCleanEnabled: false,
   fastAccountSwitch: false,
   foldersInProfileTab: false,

--- a/shared/util/feature-flags.native.tsx
+++ b/shared/util/feature-flags.native.tsx
@@ -10,7 +10,6 @@ const ff: FeatureFlags = {
   airdrop: true,
   chatIndexProfilingEnabled: false,
   conflictResolution: false,
-  darkMode: true,
   dbCleanEnabled: false,
   fastAccountSwitch: false,
   foldersInProfileTab: false,


### PR DESCRIPTION
this fixes all the flashing with desktop dark mode startup with all combinations
In order to do this, the node thread, which already reads the config file, will 

1. Make the actual browser background the correct color, so we never see a flash while loading the html
1. Pass the pref to the renderer so it can do the right thing even before react/redux loads

Also added a `lightMode` css since the app background can be dark now which wasn't assumed before