### PR TITLE
user switching: log in as another user should log you out first

### DIFF
--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -71,6 +71,9 @@ func TestLoginTwiceLogoutOnce(t *testing.T) {
 	})
 	err = RunEngine2(mctx, eng)
 	require.NoError(t, err)
+	// Log back into the first user, but shouldn't need a password
+	err = u1.SwitchTo(tc.G, true)
+	require.NoError(t, err)
 	require.True(t, tc.G.ActiveDevice.Valid())
 	require.Equal(t, tc.G.ActiveDevice.UID(), u1.UID())
 }

--- a/go/engine/logout.go
+++ b/go/engine/logout.go
@@ -17,31 +17,47 @@ func (e *LogoutEngine) Prereqs() Prereqs                 { return Prereqs{} }
 func (e *LogoutEngine) RequiredUIs() []libkb.UIKind      { return []libkb.UIKind{} }
 func (e *LogoutEngine) SubConsumers() []libkb.UIConsumer { return []libkb.UIConsumer{} }
 
-func (e *LogoutEngine) findLoggedInAccount(mctx libkb.MetaContext, accounts []keybase1.ConfiguredAccount) (ret libkb.NormalizedUsername) {
+func (e *LogoutEngine) filterLoggedIn(accounts []keybase1.
+	ConfiguredAccount) (ret []libkb.NormalizedUsername) {
 	for _, acct := range accounts {
 		if acct.HasStoredSecret {
-			return libkb.NewNormalizedUsername(acct.Username)
+			ret = append(ret, libkb.NewNormalizedUsername(acct.Username))
 		}
 	}
 	return ret
 }
 
-func (e *LogoutEngine) doSwitch(mctx libkb.MetaContext) (err error) {
-	defer mctx.Trace("Logout#doSwitch", func() error { return err })()
+// Tell the user what accounts they still have secrets stored for,
+// so they don't think they are fully logged out of everything.
+func (e *LogoutEngine) printSwitchInfo(mctx libkb.MetaContext) (err error) {
+	defer mctx.Trace("Logout#printSwitchInfo", func() error { return err })()
 	accounts, err := mctx.G().GetConfiguredAccounts(mctx.Ctx())
 	if err != nil {
 		return err
 	}
-	acct := e.findLoggedInAccount(mctx, accounts)
-	if acct.IsNil() {
-		mctx.Debug("Failed to find a logged in account")
-		return nil
-	}
-	mctx.Debug("Switching to another logged in account: %s", acct)
+	loggedInAccounts := e.filterLoggedIn(accounts)
 
-	eng := NewLoginProvisionedDevice(mctx.G(), acct.String())
-	eng.SecretStoreOnly = true
-	return RunEngine2(mctx, eng)
+	if len(loggedInAccounts) > 0 {
+		maybePlural := ""
+		if len(loggedInAccounts) > 1 {
+			maybePlural = "s"
+		}
+		accountsList := ""
+		for idx, acct := range loggedInAccounts {
+			accountsList += string(acct)
+			if idx < len(loggedInAccounts)-2 {
+				accountsList += ", "
+			}
+			if idx == len(loggedInAccounts)-2 {
+				accountsList += " and "
+			}
+
+		}
+		mctx.Info(
+			"You can still sign in to keybase account%s %s"+
+				" without a password.", maybePlural, accountsList)
+	}
+	return nil
 }
 
 func (e *LogoutEngine) Run(mctx libkb.MetaContext) (err error) {
@@ -50,10 +66,11 @@ func (e *LogoutEngine) Run(mctx libkb.MetaContext) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := e.doSwitch(mctx); err != nil {
-		// We don't care if user switching doesn't work here - user is logged
+	if err := e.printSwitchInfo(mctx); err != nil {
+		// We don't care if this doesn't work here - user is logged
 		// out at this point. LogoutEngine is considered successful.
-		mctx.Debug("Cannot user-switch after Logout: %s", err)
+		mctx.Info("You may still have secrets stored for one or more accounts"+
+			": %s", err)
 	}
 	return nil
 }

--- a/go/engine/passphrase_recover.go
+++ b/go/engine/passphrase_recover.go
@@ -252,7 +252,6 @@ func (e *PassphraseRecover) loginWithPaperKey(mctx libkb.MetaContext) (err error
 
 	if err := e.changePassword(mctx); err != nil {
 		// Log out before returning
-		// TODO FIX ME
 		if err2 := RunEngine2(mctx, NewLogout(libkb.LogoutOptions{KeepSecrets: false, Force: true})); err2 != nil {
 			mctx.Warning("Unable to log out after password change failed: %v", err2)
 		}

--- a/go/protocol/keybase1/login.go
+++ b/go/protocol/keybase1/login.go
@@ -51,8 +51,9 @@ type LoginWithPaperKeyArg struct {
 }
 
 type LogoutArg struct {
-	SessionID int  `codec:"sessionID" json:"sessionID"`
-	Force     bool `codec:"force" json:"force"`
+	SessionID   int  `codec:"sessionID" json:"sessionID"`
+	Force       bool `codec:"force" json:"force"`
+	KeepSecrets bool `codec:"keepSecrets" json:"keepSecrets"`
 }
 
 type DeprovisionArg struct {

--- a/go/service/login.go
+++ b/go/service/login.go
@@ -30,7 +30,8 @@ func (h *LoginHandler) GetConfiguredAccounts(context context.Context, sessionID 
 func (h *LoginHandler) Logout(ctx context.Context, arg keybase1.LogoutArg) (err error) {
 	defer h.G().CTraceTimed(ctx, "Logout [service RPC]", func() error { return err })()
 	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("LOGOUT")
-	eng := engine.NewLogout(libkb.LogoutOptions{Force: arg.Force})
+	eng := engine.NewLogout(libkb.LogoutOptions{Force: arg.Force,
+		KeepSecrets: arg.KeepSecrets})
 	return engine.RunEngine2(mctx, eng)
 }
 

--- a/protocol/avdl/keybase1/login.avdl
+++ b/protocol/avdl/keybase1/login.avdl
@@ -47,7 +47,7 @@ protocol login {
     */
   void loginWithPaperKey(int sessionID, string username);
 
-  void logout(int sessionID, boolean force);
+  void logout(int sessionID, boolean force, boolean keepSecrets);
   void deprovision(int sessionID, string username, boolean doRevoke);
 
   void recoverAccountFromEmailAddress(string email);

--- a/protocol/json/keybase1/login.json
+++ b/protocol/json/keybase1/login.json
@@ -120,6 +120,10 @@
         {
           "name": "force",
           "type": "boolean"
+        },
+        {
+          "name": "keepSecrets",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -332,7 +332,7 @@ const startLogoutHandshake = (state: Container.TypedState) =>
 // stuff to trigger this due to a timeout if there's no listeners or something
 function* maybeDoneWithLogoutHandshake(state: Container.TypedState) {
   if (state.config.logoutHandshakeWaiters.size <= 0) {
-    yield RPCTypes.loginLogoutRpcPromise({force: false, keepSecrets: fals})
+    yield RPCTypes.loginLogoutRpcPromise({force: false, keepSecrets: false})
   }
 }
 

--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -332,7 +332,7 @@ const startLogoutHandshake = (state: Container.TypedState) =>
 // stuff to trigger this due to a timeout if there's no listeners or something
 function* maybeDoneWithLogoutHandshake(state: Container.TypedState) {
   if (state.config.logoutHandshakeWaiters.size <= 0) {
-    yield RPCTypes.loginLogoutRpcPromise({force: false})
+    yield RPCTypes.loginLogoutRpcPromise({force: false, keepSecrets: fals})
   }
 }
 

--- a/shared/actions/provision.tsx
+++ b/shared/actions/provision.tsx
@@ -1,7 +1,6 @@
 import * as Constants from '../constants/provision'
 import * as LoginConstants from '../constants/login'
 import * as RouteTreeGen from './route-tree-gen'
-import * as LoginGen from './login-gen'
 import * as DevicesGen from './devices-gen'
 import * as ProvisionGen from './provision-gen'
 import * as RPCTypes from '../constants/types/rpc-gen'

--- a/shared/actions/provision.tsx
+++ b/shared/actions/provision.tsx
@@ -534,6 +534,7 @@ const showUsernameEmailPage = async (
   state: Container.TypedState,
   action: ProvisionGen.StartProvisionPayload
 ) => {
+  // If we're logged in, we're coming from the user switcher; log out first to prevent the service from getting out of sync with the GUI about our logged-in-ness
   if (state.config.loggedIn) {
     await RPCTypes.loginLogoutRpcPromise({force: false, keepSecrets: true})
   }

--- a/shared/actions/provision.tsx
+++ b/shared/actions/provision.tsx
@@ -1,6 +1,7 @@
 import * as Constants from '../constants/provision'
 import * as LoginConstants from '../constants/login'
 import * as RouteTreeGen from './route-tree-gen'
+import * as LoginGen from './login-gen'
 import * as DevicesGen from './devices-gen'
 import * as ProvisionGen from './provision-gen'
 import * as RPCTypes from '../constants/types/rpc-gen'
@@ -530,10 +531,17 @@ const showFinalErrorPage = (_: Container.TypedState, action: ProvisionGen.ShowFi
   ]
 }
 
-const showUsernameEmailPage = (_: Container.TypedState, action: ProvisionGen.StartProvisionPayload) =>
-  RouteTreeGen.createNavigateAppend({
+const showUsernameEmailPage = async (
+  state: Container.TypedState,
+  action: ProvisionGen.StartProvisionPayload
+) => {
+  if (state.config.loggedIn) {
+    await RPCTypes.loginLogoutRpcPromise({force: false, keepSecrets: true})
+  }
+  return RouteTreeGen.createNavigateAppend({
     path: [{props: {fromReset: action.payload.fromReset}, selected: 'username'}],
   })
+}
 
 const forgotUsername = async (_: Container.TypedState, action: ProvisionGen.ForgotUsernamePayload) => {
   if (action.payload.email) {

--- a/shared/actions/signup.tsx
+++ b/shared/actions/signup.tsx
@@ -63,7 +63,11 @@ const checkInviteCode = async (state: Container.TypedState) => {
   }
 }
 
-const requestAutoInvite = async () => {
+const requestAutoInvite = async (state: Container.TypedState) => {
+  // If we're logged in, we're coming from the user switcher; log out first to prevent the service from getting out of sync with the GUI about our logged-in-ness
+  if (state.config.loggedIn) {
+    await RPCTypes.loginLogoutRpcPromise({force: false, keepSecrets: true})
+  }
   try {
     const inviteCode = await RPCTypes.signupGetInvitationCodeRpcPromise(undefined, Constants.waitingKey)
     return SignupGen.createRequestedAutoInvite({inviteCode})

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -868,7 +868,7 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.login.logout': {
-    inParam: {readonly force: Boolean}
+    inParam: {readonly force: Boolean; readonly keepSecrets: Boolean}
     outParam: void
   }
   'keybase.1.login.paperKey': {

--- a/shared/provision/paper-key/container.tsx
+++ b/shared/provision/paper-key/container.tsx
@@ -3,7 +3,6 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Constants from '../../constants/provision'
 import * as Container from '../../util/container'
 import HiddenString from '../../util/hidden-string'
-import * as LoginGen from '../../actions/login-gen'
 import PaperKey from '.'
 
 type OwnProps = {}
@@ -16,8 +15,7 @@ const mapStateToProps = (state: Container.TypedState) => ({
 })
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
-  _onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
-  _onLogIn: (username: string) => dispatch(LoginGen.createLogin({password: new HiddenString(''), username})),
+  onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
   onSubmit: (paperKey: string) =>
     dispatch(ProvisionGen.createSubmitPaperkey({paperkey: new HiddenString(paperKey)})),
 })
@@ -25,20 +23,11 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
 export default Container.connect(
   mapStateToProps,
   mapDispatchToProps,
-  (stateProps, dispatchProps, _: OwnProps) => {
-    const loggedInAccounts = stateProps._configuredAccounts
-      .filter(account => account.hasStoredSecret)
-      .map(ac => ac.username)
-
-    return {
-      error: stateProps.error,
-      hint: stateProps.hint,
-      onBack:
-        loggedInAccounts.length > 0
-          ? () => dispatchProps._onLogIn(loggedInAccounts[0] || '')
-          : dispatchProps._onBack,
-      onSubmit: dispatchProps.onSubmit,
-      waiting: stateProps.waiting,
-    }
-  }
+  (stateProps, dispatchProps, _: OwnProps) => ({
+    error: stateProps.error,
+    hint: stateProps.hint,
+    onBack: dispatchProps.onBack,
+    onSubmit: dispatchProps.onSubmit,
+    waiting: stateProps.waiting,
+  })
 )(PaperKey)

--- a/shared/provision/select-other-device/container.tsx
+++ b/shared/provision/select-other-device/container.tsx
@@ -3,23 +3,20 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as LoginGen from '../../actions/login-gen'
 import SelectOtherDevice from '.'
 import * as Container from '../../util/container'
-import HiddenString from '../../util/hidden-string'
 import flags from '../../util/feature-flags'
 import * as AutoresetGen from '../../actions/autoreset-gen'
 
 type OwnProps = {}
 
 const mapStateToProps = (state: Container.TypedState) => ({
-  configuredAccounts: state.config.configuredAccounts,
   devices: state.provision.devices,
   username: state.provision.username,
 })
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
-  _onBack: () => {
+  onBack: () => {
     dispatch(RouteTreeGen.createNavigateUp())
   },
-  onLogIn: (username: string) => dispatch(LoginGen.createLogin({password: new HiddenString(''), username})),
   onResetAccount: (username: string) => {
     if (flags.resetPipeline) {
       dispatch(AutoresetGen.createStartAccountReset({skipPassword: false, username}))
@@ -36,18 +33,10 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
 export default Container.connect(
   mapStateToProps,
   mapDispatchToProps,
-  (stateProps, dispatchProps, _: OwnProps) => {
-    const loggedInAccounts = stateProps.configuredAccounts
-      .filter(account => account.hasStoredSecret)
-      .map(account => account.username)
-    return {
-      devices: stateProps.devices.toArray(),
-      onBack:
-        loggedInAccounts.length > 0
-          ? () => dispatchProps.onLogIn(loggedInAccounts[0] || '')
-          : dispatchProps._onBack,
-      onResetAccount: () => dispatchProps.onResetAccount(stateProps.username),
-      onSelect: dispatchProps.onSelect,
-    }
-  }
+  (stateProps, dispatchProps, _: OwnProps) => ({
+    devices: stateProps.devices.toArray(),
+    onBack: dispatchProps.onBack,
+    onResetAccount: () => dispatchProps.onResetAccount(stateProps.username),
+    onSelect: dispatchProps.onSelect,
+  })
 )(Container.safeSubmitPerMount(['onSelect', 'onBack'])(SelectOtherDevice))

--- a/shared/provision/set-public-name/container.tsx
+++ b/shared/provision/set-public-name/container.tsx
@@ -3,33 +3,20 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Constants from '../../constants/provision'
 import SetPublicName from '.'
 import * as Container from '../../util/container'
-import * as LoginGen from '../../actions/login-gen'
-import HiddenString from '../../util/hidden-string'
 
 const mapStateToProps = (state: Container.TypedState) => ({
-  _existingDevices: state.provision.existingDevices,
-  configuredAccounts: state.config.configuredAccounts,
   error: state.provision.error.stringValue(),
   waiting: Container.anyWaiting(state, Constants.waitingKey),
 })
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
-  _onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
-  onLogIn: (username: string) => dispatch(LoginGen.createLogin({password: new HiddenString(''), username})),
+  onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
   onSubmit: (name: string) => dispatch(ProvisionGen.createSubmitDeviceName({name})),
 })
 
-export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProps, dispatchProps) => {
-  const loggedInAccounts = stateProps.configuredAccounts
-    .filter(account => account.hasStoredSecret)
-    .map(ac => ac.username)
-  return {
-    error: stateProps.error,
-    onBack:
-      loggedInAccounts.length > 0
-        ? () => dispatchProps.onLogIn(loggedInAccounts[0] || '')
-        : dispatchProps._onBack,
-    onSubmit: dispatchProps.onSubmit,
-    waiting: stateProps.waiting,
-  }
-})(Container.safeSubmit(['onSubmit', 'onBack'], ['error'])(SetPublicName))
+export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProps, dispatchProps) => ({
+  error: stateProps.error,
+  onBack: dispatchProps.onBack,
+  onSubmit: dispatchProps.onSubmit,
+  waiting: stateProps.waiting,
+}))(Container.safeSubmit(['onSubmit', 'onBack'], ['error'])(SetPublicName))

--- a/shared/signup/username/container.tsx
+++ b/shared/signup/username/container.tsx
@@ -17,12 +17,9 @@ const ConnectedEnterUsername = Container.connect(
     waiting: anyWaiting(state, Constants.waitingKey),
   }),
   dispatch => ({
-    _onBack: () => {
+    onBack: () => {
       dispatch(SignupGen.createRestartSignup())
       dispatch(RouteTreeGen.createNavigateUp())
-    },
-    _onReturnToMain: () => {
-      dispatch(RouteTreeGen.createSwitchLoggedIn({loggedIn: true}))
     },
     onContinue: (username: string) => dispatch(SignupGen.createCheckUsername({username})),
     onLogin: (initUsername: string) => dispatch(ProvisionGen.createStartProvision({initUsername})),
@@ -31,7 +28,6 @@ const ConnectedEnterUsername = Container.connect(
     ...s,
     ...d,
     ...o,
-    onBack: s._users.some(account => account.hasStoredSecret) ? d._onReturnToMain : d._onBack,
   })
 )(EnterUsername)
 


### PR DESCRIPTION
This PR changes two things: 
 - when you click "log in as another user", you get logged out as your current user. You can go back and log into it again by pressing the back button. This makes a lot of routing simpler in the GUI. I also made the same change to "Create another user" which should fix Y2K-780
 - When you log out in the CLI, you don't get auto-logged-back into another user. This is Y2K-402 and there's extensive discussion there.

Issue: Y2K-402
Issue: Y2K-780
Issue: Y2K-793

cc @keybase/y2ksquad @patrickxb 