### PR TITLE
don't fetch bio if not chatting with keybase user

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2541,12 +2541,14 @@ const fetchConversationBio = async (state: TypedState, action: Chat2Gen.SelectCo
   const {conversationIDKey} = action.payload
   const meta = Constants.getMeta(state, conversationIDKey)
   const otherParticipants = Constants.getRowParticipants(meta, state.config.username || '')
+
+  // we're in a one-on-one convo
   if (otherParticipants.count() === 1) {
-    // we're in a one-on-one convo
     const username = otherParticipants.first('')
 
-    if (username === '') {
-      return // if for some reason we get a garbage username, don't do anything
+    // if this is an SBS/phone/email convo or we get a garbage username, don't do anything
+    if (username === '' || username.includes('@')) {
+      return
     }
 
     return UsersGen.createGetBio({username})


### PR DESCRIPTION
Calling the rpc for non-users just errors, so don't do that!