### PR TITLE
engine: enable kex v2 passphrases

### DIFF
--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -111,11 +111,7 @@ func (e *DeviceAdd) Run(m libkb.MetaContext) (err error) {
 	}
 	uid := m.CurrentUID()
 
-	// make a new secret; continue to generate legacy Kex2 secrets for now.
-	kex2SecretTyp := libkb.Kex2SecretTypeV1Desktop
-	if provisioneeType == keybase1.DeviceType_MOBILE || m.G().GetAppType() == libkb.DeviceTypeMobile {
-		kex2SecretTyp = libkb.Kex2SecretTypeV1Mobile
-	}
+	kex2SecretTyp := libkb.Kex2SecretTypeV2
 	m.Debug("provisionee device type: %v; uid: %s; secret type: %d", provisioneeType, uid, kex2SecretTyp)
 	secret, err := libkb.NewKex2SecretFromTypeAndUID(kex2SecretTyp, uid)
 	if err != nil {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -182,13 +182,10 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 	m.Debug("deviceWithType: got device name: %q", name)
 
 	// make a new secret:
-	uid := m.CurrentUID()
+	uid := e.arg.User.GetUID()
 
 	// Continue to generate legacy Kex2 secret types
-	kex2SecretTyp := libkb.Kex2SecretTypeV1Desktop
-	if e.arg.DeviceType == libkb.DeviceTypeMobile || provisionerType == keybase1.DeviceType_MOBILE {
-		kex2SecretTyp = libkb.Kex2SecretTypeV1Mobile
-	}
+	kex2SecretTyp := libkb.Kex2SecretTypeV2
 	m.Debug("Generating Kex2 secret for uid=%s, typ=%d", uid, kex2SecretTyp)
 	secret, err := libkb.NewKex2SecretFromTypeAndUID(kex2SecretTyp, uid)
 	if err != nil {


### PR DESCRIPTION
- reader support has been in for quite a while now, but there was a small bug in writer
  support (phew), fixed here. The bug is that we were using an empty UID.
- recall that this version of the kex2 passphrase has 9 (rather than 8) words, and also
  has a UID salt, so that the bad guy has to target a given user (rather than making
  a rainbow table)
- 99 bits + scrypt should be a pretty comfortable security margin
- also, use the smaller scrypt params so that android is OK with it (as in kex2 mobile of
  yersteryear).
- tested by hand against older clients