### PR TITLE
account switcher spacing change

### DIFF
--- a/shared/router-v2/account-switcher/index.tsx
+++ b/shared/router-v2/account-switcher/index.tsx
@@ -78,7 +78,7 @@ const AccountRow = (props: AccountRowProps) => {
             </Kb.Text>
             {!props.entry.account.hasStoredSecret && (
               <Kb.Text type="BodySmallItalic" style={styles.text2}>
-                {props.entry.fullName && '· '}Signed out
+                {props.entry.fullName && ' · '}Signed out
               </Kb.Text>
             )}
           </Kb.Box2>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4698687/66666481-af8df180-ec1e-11e9-846c-79d101ca3b9c.png)
Adds a space before the center dot in the above