### PR TITLE
attempt to fix mobile mention pick

### DIFF
--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -68,11 +68,16 @@ class PlainInput extends Component<InternalProps> {
     const newTextInfo = fn(currentTextInfo)
     const newCheckedSelection = this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text)
     checkTextInfo(newTextInfo)
-    this.setNativeProps({text: newTextInfo.text})
-    // hacky workaround to RN input crappiness, otherwise leaves the selection randomly inside
-    setTimeout(() => {
+    if (isIOS) {
+      this.setNativeProps({text: newTextInfo.text})
+      // hacky workaround to RN input crappiness, otherwise leaves the selection randomly inside
+      setTimeout(() => {
+        this.setNativeProps({selection: newCheckedSelection})
+      }, 1)
+    } else {
+      this.setNativeProps({text: newTextInfo.text})
       this.setNativeProps({selection: newCheckedSelection})
-    }, 1)
+    }
     this._lastNativeText = newTextInfo.text
     this._lastNativeSelection = newCheckedSelection
     if (reflectChange) {

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -68,12 +68,11 @@ class PlainInput extends Component<InternalProps> {
     const newTextInfo = fn(currentTextInfo)
     const newCheckedSelection = this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text)
     checkTextInfo(newTextInfo)
-    // This is to workaround this Issue for Android: https://github.com/imnapo/react-native-cn-richtext-editor/issues/81
-    // By setting the text and selection at the same time
-    this.setNativeProps({
-      selection: newCheckedSelection,
-      text: newTextInfo.text,
-    })
+    this.setNativeProps({text: newTextInfo.text})
+    // hacky workaround to RN input crappiness, otherwise leaves the selection randomly inside
+    setTimeout(() => {
+      this.setNativeProps({selection: newCheckedSelection})
+    }, 1)
     this._lastNativeText = newTextInfo.text
     this._lastNativeSelection = newCheckedSelection
     if (reflectChange) {


### PR DESCRIPTION
I think RN has a bunch of ios/android timing issues w/ editing inputs. This just does a hacky workaround where on ios we set the text, then defer setting the selection
on android we set it making 2 sequential calls

maybe lets deploy this and test on actual devices to see if its good enough (or better than master) 