### PR TITLE
reset: fix cancel button for end flow

### DIFF
--- a/go/client/ui.go
+++ b/go/client/ui.go
@@ -861,9 +861,8 @@ username, but lose all your data, including all of your uploaded encrypted PGP k
 
 	if userWantsToReset {
 		return keybase1.ResetPromptResponse_CONFIRM_RESET, err
-	} else {
-		return keybase1.ResetPromptResponse_NOTHING, err
 	}
+	return keybase1.ResetPromptResponse_NOTHING, err
 }
 
 func (l LoginUI) DisplayResetProgress(ctx context.Context, arg keybase1.DisplayResetProgressArg) error {

--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -323,7 +323,7 @@ func (e *Login) suggestRecoveryForgotPassword(mctx libkb.MetaContext) error {
 	if err != nil {
 		return err
 	}
-	if !enterReset {
+	if enterReset != keybase1.ResetPromptResponse_CONFIRM_RESET {
 		// Cancel the engine as the user decided to end the flow early.
 		return nil
 	}

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -819,7 +819,7 @@ func (e *loginProvision) chooseDevice(m libkb.MetaContext, pgp bool) (err error)
 			return err
 		}
 
-		if !enterReset {
+		if enterReset != keybase1.ResetPromptResponse_CONFIRM_RESET {
 			m.Debug("User decided not to enter the reset pipeline")
 			// User had to explicitly decline entering the pipeline so in order to prevent
 			// confusion prevent further prompts by completing a noop login flow.

--- a/go/engine/login_state_test.go
+++ b/go/engine/login_state_test.go
@@ -101,6 +101,8 @@ type GetUsernameMock struct {
 	LastErr  error
 }
 
+var _ libkb.LoginUI = (*GetUsernameMock)(nil)
+
 func (m *GetUsernameMock) GetEmailOrUsername(context.Context, int) (string, error) {
 	if m.Called {
 		m.LastErr = errors.New("GetEmailOrUsername unexpectedly called more than once")
@@ -122,8 +124,9 @@ func (m *GetUsernameMock) DisplayPrimaryPaperKey(_ context.Context, arg keybase1
 	return nil
 }
 
-func (m *GetUsernameMock) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
-	return false, nil
+func (m *GetUsernameMock) PromptResetAccount(_ context.Context,
+	arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
+	return keybase1.ResetPromptResponse_NOTHING, nil
 }
 
 func (m *GetUsernameMock) DisplayResetProgress(_ context.Context, arg keybase1.DisplayResetProgressArg) error {

--- a/go/engine/login_test.go
+++ b/go/engine/login_test.go
@@ -598,7 +598,7 @@ func TestProvisionAutoreset(t *testing.T) {
 		ProvisionUI: newTestProvisionUIChooseNoDevice(),
 		LoginUI: &libkb.TestLoginUI{
 			Username:     userX.Username,
-			ResetAccount: true,
+			ResetAccount: keybase1.ResetPromptResponse_CONFIRM_RESET,
 		},
 		LogUI:    tcY.G.UI.GetLogUI(),
 		SecretUI: &libkb.TestSecretUI{Passphrase: userX.Passphrase},
@@ -630,7 +630,7 @@ func TestProvisionAutoreset(t *testing.T) {
 		ProvisionUI: newTestProvisionUIChooseNoDevice(),
 		LoginUI: &libkb.TestLoginUI{
 			Username:     userX.Username,
-			ResetAccount: true,
+			ResetAccount: keybase1.ResetPromptResponse_CONFIRM_RESET,
 		},
 		LogUI:    tcY.G.UI.GetLogUI(),
 		SecretUI: &libkb.TestSecretUI{Passphrase: userX.Passphrase},
@@ -4111,6 +4111,8 @@ type paperLoginUI struct {
 	PaperPhrase string
 }
 
+var _ libkb.LoginUI = (*paperLoginUI)(nil)
+
 func (p *paperLoginUI) GetEmailOrUsername(_ context.Context, _ int) (string, error) {
 	return p.Username, nil
 }
@@ -4128,8 +4130,8 @@ func (p *paperLoginUI) DisplayPrimaryPaperKey(_ context.Context, arg keybase1.Di
 	return nil
 }
 
-func (p *paperLoginUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
-	return false, nil
+func (p *paperLoginUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
+	return keybase1.ResetPromptResponse_NOTHING, nil
 }
 
 func (p *paperLoginUI) DisplayResetProgress(_ context.Context, arg keybase1.DisplayResetProgressArg) error {

--- a/go/engine/passphrase_recover.go
+++ b/go/engine/passphrase_recover.go
@@ -196,7 +196,7 @@ func (e *PassphraseRecover) resetPassword(mctx libkb.MetaContext) (err error) {
 	if err != nil {
 		return err
 	}
-	if !enterReset {
+	if enterReset != keybase1.ResetPromptResponse_CONFIRM_RESET {
 		// Flow cancelled
 		return nil
 	}
@@ -227,8 +227,8 @@ func (e *PassphraseRecover) suggestReset(mctx libkb.MetaContext) (err error) {
 	if err != nil {
 		return err
 	}
-	if !enterReset {
-		// Cancel the engine as it successfully resulted in the user entering the reset pipeline.
+	if enterReset != keybase1.ResetPromptResponse_CONFIRM_RESET {
+		// Cancel the engine as the user elected not to reset their account
 		return nil
 	}
 

--- a/go/engine/passphrase_recover_test.go
+++ b/go/engine/passphrase_recover_test.go
@@ -174,7 +174,7 @@ func TestPassphraseRecoverGuideAndReset(t *testing.T) {
 	// accounts.
 	loginUI.Reset()
 	loginUI.PassphraseRecovery = true
-	loginUI.ResetAccount = true
+	loginUI.ResetAccount = keybase1.ResetPromptResponse_CONFIRM_RESET
 	uis.ProvisionUI = newTestProvisionUIChooseNoDevice()
 	m = NewMetaContextForTest(tc).WithUIs(uis)
 
@@ -199,7 +199,7 @@ func TestPassphraseRecoverNoDevices(t *testing.T) {
 	loginUI := &TestLoginUIRecover{
 		TestLoginUI: libkb.TestLoginUI{
 			PassphraseRecovery: true,
-			ResetAccount:       true,
+			ResetAccount:       keybase1.ResetPromptResponse_CONFIRM_RESET,
 		},
 	}
 	uis := libkb.UIs{

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -477,9 +477,11 @@ type TestLoginUI struct {
 	Username                 string
 	RevokeBackup             bool
 	CalledGetEmailOrUsername int
-	ResetAccount             bool
+	ResetAccount             keybase1.ResetPromptResponse
 	PassphraseRecovery       bool
 }
+
+var _ LoginUI = (*TestLoginUI)(nil)
 
 func (t *TestLoginUI) GetEmailOrUsername(_ context.Context, _ int) (string, error) {
 	t.CalledGetEmailOrUsername++
@@ -498,7 +500,7 @@ func (t *TestLoginUI) DisplayPrimaryPaperKey(_ context.Context, arg keybase1.Dis
 	return nil
 }
 
-func (t *TestLoginUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
+func (t *TestLoginUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
 	return t.ResetAccount, nil
 }
 

--- a/go/protocol/keybase1/login_ui.go
+++ b/go/protocol/keybase1/login_ui.go
@@ -104,6 +104,35 @@ func (o ResetPrompt) DeepCopy() ResetPrompt {
 	}
 }
 
+type ResetPromptResponse int
+
+const (
+	ResetPromptResponse_NOTHING       ResetPromptResponse = 0
+	ResetPromptResponse_CANCEL_RESET  ResetPromptResponse = 1
+	ResetPromptResponse_CONFIRM_RESET ResetPromptResponse = 2
+)
+
+func (o ResetPromptResponse) DeepCopy() ResetPromptResponse { return o }
+
+var ResetPromptResponseMap = map[string]ResetPromptResponse{
+	"NOTHING":       0,
+	"CANCEL_RESET":  1,
+	"CONFIRM_RESET": 2,
+}
+
+var ResetPromptResponseRevMap = map[ResetPromptResponse]string{
+	0: "NOTHING",
+	1: "CANCEL_RESET",
+	2: "CONFIRM_RESET",
+}
+
+func (e ResetPromptResponse) String() string {
+	if v, ok := ResetPromptResponseRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
 type PassphraseRecoveryPromptType int
 
 const (
@@ -178,7 +207,7 @@ type LoginUiInterface interface {
 	// Called during login / provisioning flows to ask the user whether they
 	// would like to either enter the autoreset pipeline and perform the reset
 	// of the account.
-	PromptResetAccount(context.Context, PromptResetAccountArg) (bool, error)
+	PromptResetAccount(context.Context, PromptResetAccountArg) (ResetPromptResponse, error)
 	// In some flows the user will get notified of the reset progress
 	DisplayResetProgress(context.Context, DisplayResetProgressArg) error
 	// During recovery the service might want to explain to the user how they can change
@@ -343,7 +372,7 @@ func (c LoginUiClient) DisplayPrimaryPaperKey(ctx context.Context, __arg Display
 // Called during login / provisioning flows to ask the user whether they
 // would like to either enter the autoreset pipeline and perform the reset
 // of the account.
-func (c LoginUiClient) PromptResetAccount(ctx context.Context, __arg PromptResetAccountArg) (res bool, err error) {
+func (c LoginUiClient) PromptResetAccount(ctx context.Context, __arg PromptResetAccountArg) (res ResetPromptResponse, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.loginUi.promptResetAccount", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/service/handler.go
+++ b/go/service/handler.go
@@ -52,7 +52,8 @@ func (u *LoginUI) DisplayPrimaryPaperKey(ctx context.Context, arg keybase1.Displ
 	return u.cli.DisplayPrimaryPaperKey(ctx, arg)
 }
 
-func (u *LoginUI) PromptResetAccount(ctx context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
+func (u *LoginUI) PromptResetAccount(ctx context.Context,
+	arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
 	arg.SessionID = u.sessionID
 	return u.cli.PromptResetAccount(ctx, arg)
 }

--- a/go/systests/device_common_test.go
+++ b/go/systests/device_common_test.go
@@ -351,6 +351,8 @@ type testProvisionUI struct {
 	backupKey  backupKey
 }
 
+var _ libkb.LoginUI = (*testProvisionUI)(nil)
+
 func (r *testProvisionUI) GetEmailOrUsername(context.Context, int) (string, error) {
 	return r.username, nil
 }
@@ -397,8 +399,8 @@ func (r *testProvisionUI) GetPassphrase(context.Context, keybase1.GetPassphraseA
 	ret.Passphrase = r.backupKey.secret
 	return ret, nil
 }
-func (r *testProvisionUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
-	return false, nil
+func (r *testProvisionUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
+	return keybase1.ResetPromptResponse_NOTHING, nil
 }
 func (r *testProvisionUI) DisplayResetProgress(_ context.Context, arg keybase1.DisplayResetProgressArg) error {
 	return nil

--- a/go/systests/multiuser_common_test.go
+++ b/go/systests/multiuser_common_test.go
@@ -159,6 +159,8 @@ type usernameLoginUI struct {
 	username string
 }
 
+var _ libkb.LoginUI = (*usernameLoginUI)(nil)
+
 func (s usernameLoginUI) GetEmailOrUsername(contextOld.Context, int) (string, error) {
 	return s.username, nil
 }
@@ -171,8 +173,8 @@ func (s usernameLoginUI) DisplayPaperKeyPhrase(contextOld.Context, keybase1.Disp
 func (s usernameLoginUI) DisplayPrimaryPaperKey(contextOld.Context, keybase1.DisplayPrimaryPaperKeyArg) error {
 	return nil
 }
-func (s usernameLoginUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
-	return false, nil
+func (s usernameLoginUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
+	return keybase1.ResetPromptResponse_NOTHING, nil
 }
 func (s usernameLoginUI) DisplayResetProgress(_ context.Context, arg keybase1.DisplayResetProgressArg) error {
 	return nil

--- a/go/systests/passphrase_test.go
+++ b/go/systests/passphrase_test.go
@@ -246,6 +246,8 @@ type testRecoverUIProvision struct {
 	paperkey   string
 }
 
+var _ libkb.LoginUI = (*testRecoverUIProvision)(nil)
+
 func (r *testRecoverUIProvision) GetEmailOrUsername(context.Context, int) (string, error) {
 	return r.username, nil
 }
@@ -297,8 +299,8 @@ func (r *testRecoverUIProvision) GetPassphrase(p keybase1.GUIEntryArg, terminal 
 	res.Passphrase = r.paperkey
 	return res, nil
 }
-func (r *testRecoverUIProvision) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
-	return false, nil
+func (r *testRecoverUIProvision) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
+	return keybase1.ResetPromptResponse_NOTHING, nil
 }
 func (r *testRecoverUIProvision) DisplayResetProgress(_ context.Context, arg keybase1.DisplayResetProgressArg) error {
 	return nil

--- a/go/systests/rekey_test.go
+++ b/go/systests/rekey_test.go
@@ -473,6 +473,8 @@ type rekeyBackupKeyUI struct {
 	secret string
 }
 
+var _ libkb.LoginUI = (*rekeyBackupKeyUI)(nil)
+
 func (u *rekeyBackupKeyUI) DisplayPaperKeyPhrase(_ context.Context, arg keybase1.DisplayPaperKeyPhraseArg) error {
 	u.secret = arg.Phrase
 	return nil
@@ -499,8 +501,8 @@ func (u *rekeyBackupKeyUI) GetPassphrase(p keybase1.GUIEntryArg, terminal *keyba
 	return res, err
 }
 
-func (u *rekeyBackupKeyUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
-	return false, nil
+func (u *rekeyBackupKeyUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
+	return keybase1.ResetPromptResponse_NOTHING, nil
 }
 
 func (u *rekeyBackupKeyUI) DisplayResetProgress(_ context.Context, arg keybase1.DisplayResetProgressArg) error {
@@ -602,6 +604,8 @@ type rekeyProvisionUI struct {
 	backupKey backupKey
 }
 
+var _ libkb.LoginUI = (*rekeyProvisionUI)(nil)
+
 func (r *rekeyProvisionUI) GetEmailOrUsername(context.Context, int) (string, error) {
 	return r.username, nil
 }
@@ -648,8 +652,8 @@ func (r *rekeyProvisionUI) GetPassphrase(context.Context, keybase1.GetPassphrase
 	ret.Passphrase = r.backupKey.secret
 	return ret, nil
 }
-func (r *rekeyProvisionUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
-	return false, nil
+func (r *rekeyProvisionUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
+	return keybase1.ResetPromptResponse_NOTHING, nil
 }
 func (r *rekeyProvisionUI) DisplayResetProgress(_ context.Context, arg keybase1.DisplayResetProgressArg) error {
 	return nil

--- a/go/systests/secret_ui_test.go
+++ b/go/systests/secret_ui_test.go
@@ -122,6 +122,8 @@ type loginUI struct {
 	libkb.Contextified
 }
 
+var _ libkb.LoginUI = (*loginUI)(nil)
+
 func (u *loginUI) DisplayPaperKeyPhrase(context.Context, keybase1.DisplayPaperKeyPhraseArg) error {
 	return nil
 }
@@ -134,8 +136,8 @@ func (u *loginUI) PromptRevokePaperKeys(context.Context, keybase1.PromptRevokePa
 func (u *loginUI) GetEmailOrUsername(context.Context, int) (string, error) {
 	return "t_alice", nil
 }
-func (u *loginUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (bool, error) {
-	return false, nil
+func (u *loginUI) PromptResetAccount(_ context.Context, arg keybase1.PromptResetAccountArg) (keybase1.ResetPromptResponse, error) {
+	return keybase1.ResetPromptResponse_NOTHING, nil
 }
 func (u *loginUI) DisplayResetProgress(_ context.Context, arg keybase1.DisplayResetProgressArg) error {
 	return nil

--- a/protocol/avdl/keybase1/login_ui.avdl
+++ b/protocol/avdl/keybase1/login_ui.avdl
@@ -21,12 +21,18 @@ protocol loginUi {
     case COMPLETE: ResetPromptInfo;
     default: void;
   }
+
+  enum ResetPromptResponse {
+    NOTHING_0, // Don't reset but don't cancel the reset
+    CANCEL_RESET_1, // Cancel the reset
+    CONFIRM_RESET_2 // Reset the account
+  }
   /**
    Called during login / provisioning flows to ask the user whether they
    would like to either enter the autoreset pipeline and perform the reset
    of the account.
    */
-  boolean promptResetAccount(int sessionID, ResetPrompt prompt);
+  ResetPromptResponse promptResetAccount(int sessionID, ResetPrompt prompt);
 
   /**
    In some flows the user will get notified of the reset progress

--- a/protocol/json/keybase1/login_ui.json
+++ b/protocol/json/keybase1/login_ui.json
@@ -52,6 +52,15 @@
     },
     {
       "type": "enum",
+      "name": "ResetPromptResponse",
+      "symbols": [
+        "NOTHING_0",
+        "CANCEL_RESET_1",
+        "CONFIRM_RESET_2"
+      ]
+    },
+    {
+      "type": "enum",
       "name": "PassphraseRecoveryPromptType",
       "symbols": [
         "ENCRYPTED_PGP_KEYS_0"
@@ -122,7 +131,7 @@
           "type": "ResetPrompt"
         }
       ],
-      "response": "boolean",
+      "response": "ResetPromptResponse",
       "doc": "Called during login / provisioning flows to ask the user whether they\n   would like to either enter the autoreset pipeline and perform the reset\n   of the account."
     },
     "displayResetProgress": {

--- a/shared/actions/autoreset-gen.tsx
+++ b/shared/actions/autoreset-gen.tsx
@@ -33,7 +33,7 @@ type _UpdateAutoresetStatePayload = {readonly active: boolean; readonly endTime:
 
 // Action Creators
 /**
- * Cancel an autoreset for the currently logged-in account.
+ * Cancel an autoreset for the currently logged-in account. Don't use with a temporary (web) session
  */
 export const createCancelReset = (payload: _CancelResetPayload): CancelResetPayload => ({
   payload,

--- a/shared/actions/autoreset.tsx
+++ b/shared/actions/autoreset.tsx
@@ -54,7 +54,11 @@ function promptReset(
         RecoverPasswordGen.submitResetPrompt
       )
       response.result(action.payload.action)
-      yield Saga.put(AutoresetGen.createFinishedReset())
+      if (action.payload.action === RPCGen.ResetPromptResponse.confirmReset) {
+        yield Saga.put(AutoresetGen.createFinishedReset())
+      } else {
+        yield Saga.put(RouteTreeGen.createNavUpToScreen({routeName: 'login'}))
+      }
     } else {
       logger.info('Starting account reset process')
       yield Saga.put(AutoresetGen.createStartAccountReset({skipPassword: true}))

--- a/shared/actions/json/autoreset.json
+++ b/shared/actions/json/autoreset.json
@@ -5,7 +5,7 @@
   ],
   "actions": {
     "cancelReset": {
-      "_description": "Cancel an autoreset for the currently logged-in account."
+      "_description": "Cancel an autoreset for the currently logged-in account. Don't use with a temporary (web) session"
     },
     "displayProgress": {
       "endTime": "number",

--- a/shared/actions/json/recover-password.json
+++ b/shared/actions/json/recover-password.json
@@ -21,7 +21,7 @@
 
     "setPaperKeyError": {"error": "HiddenString"},
     "submitPaperKey": {"paperKey": "HiddenString"},
-    "submitResetPrompt": {"action": "boolean"},
+    "submitResetPrompt": {"action": "RPCTypes.ResetPromptResponse"},
     "abortPaperKey": {},
 
     "setPasswordError": {"error": "HiddenString"},

--- a/shared/actions/recover-password-gen.tsx
+++ b/shared/actions/recover-password-gen.tsx
@@ -34,7 +34,7 @@ type _StartRecoverPasswordPayload = {readonly username: string; readonly abortPr
 type _SubmitDeviceSelectPayload = {readonly id: string}
 type _SubmitPaperKeyPayload = {readonly paperKey: HiddenString}
 type _SubmitPasswordPayload = {readonly password: HiddenString}
-type _SubmitResetPromptPayload = {readonly action: boolean}
+type _SubmitResetPromptPayload = {readonly action: RPCTypes.ResetPromptResponse}
 
 // Action Creators
 export const createAbortDeviceSelect = (payload: _AbortDeviceSelectPayload): AbortDeviceSelectPayload => ({

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -909,7 +909,7 @@ export type MessageTypes = {
   }
   'keybase.1.loginUi.promptResetAccount': {
     inParam: {readonly prompt: ResetPrompt}
-    outParam: Boolean
+    outParam: ResetPromptResponse
   }
   'keybase.1.loginUi.promptRevokePaperKeys': {
     inParam: {readonly device: Device; readonly index: Int}
@@ -1931,6 +1931,12 @@ export enum RekeyEventType {
   deviceLoadError = 6,
   harass = 7,
   noGregorMessages = 8,
+}
+
+export enum ResetPromptResponse {
+  nothing = 0,
+  cancelReset = 1,
+  confirmReset = 2,
 }
 
 export enum ResetPromptType {

--- a/shared/login/recover-password/reset-password/index.tsx
+++ b/shared/login/recover-password/reset-password/index.tsx
@@ -3,14 +3,18 @@ import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 import * as Container from '../../../util/container'
 import * as RecoverPasswordGen from '../../../actions/recover-password-gen'
+import * as RPCTypes from '../../../constants/types/rpc-gen'
 import {SignupScreen, InfoIcon} from '../../../signup/common'
 import {ButtonType} from '../../../common-adapters/button'
 
 const ResetPassword = () => {
   const dispatch = Container.useDispatch()
-  const onContinue = (action: boolean) => {
-    dispatch(RecoverPasswordGen.createSubmitResetPrompt({action}))
-  }
+  const onContinue = (startReset: boolean) =>
+    dispatch(
+      RecoverPasswordGen.createSubmitResetPrompt({
+        action: startReset ? RPCTypes.ResetPromptResponse.confirmReset : RPCTypes.ResetPromptResponse.nothing,
+      })
+    )
 
   return (
     <SignupScreen

--- a/shared/login/reset/confirm.tsx
+++ b/shared/login/reset/confirm.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import * as Container from '../../util/container'
-import * as AutoresetGen from '../../actions/autoreset-gen'
+import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as Constants from '../../constants/autoreset'
 import * as RecoverPasswordGen from '../../actions/recover-password-gen'
 type Props = {}
@@ -14,15 +14,18 @@ const ConfirmReset = (_: Props) => {
   const dispatch = Container.useDispatch()
 
   const onContinue = React.useCallback(
-    () => dispatch(RecoverPasswordGen.createSubmitResetPrompt({action: true})),
+    () =>
+      dispatch(
+        RecoverPasswordGen.createSubmitResetPrompt({action: RPCTypes.ResetPromptResponse.confirmReset})
+      ),
     [dispatch]
   )
   const onCancelReset = React.useCallback(() => {
-    dispatch(RecoverPasswordGen.createSubmitResetPrompt({action: false}))
-    dispatch(AutoresetGen.createCancelReset())
+    dispatch(RecoverPasswordGen.createSubmitResetPrompt({action: RPCTypes.ResetPromptResponse.cancelReset}))
   }, [dispatch])
   const onClose = React.useCallback(
-    () => dispatch(RecoverPasswordGen.createSubmitResetPrompt({action: false})),
+    () =>
+      dispatch(RecoverPasswordGen.createSubmitResetPrompt({action: RPCTypes.ResetPromptResponse.nothing})),
     [dispatch]
   )
 
@@ -121,6 +124,7 @@ const ConfirmReset = (_: Props) => {
             <Kb.Text type="BodyPrimaryLink" onClick={onCancelReset}>
               cancel the reset
             </Kb.Text>
+            .
           </Kb.Text>
         </Kb.Box2>
       </Kb.Box2>


### PR DESCRIPTION
Issue: Y2K-820

The cancel reset button in the last page of the reset flow wasn't working at all for me. This turned out to be way way more code than I expected it to be; I'm conflicted as to whether to put it in the release or just take out that button, since it has a chance of introducing bugs.

cc @keybase/y2ksquad WDy'allT?