### PR TITLE
Use more modern pinentry by default

### DIFF
--- a/go/pinentry/pinentry_nix.go
+++ b/go/pinentry/pinentry_nix.go
@@ -63,6 +63,8 @@ func FindPinentry(log logger.Logger) (string, error) {
 	log.Debug("+ FindPinentry()")
 
 	cmds := []string{
+		"pinentry-gnome3",
+		"pinentry-qt",
 		"pinentry-gtk-2",
 		"pinentry-qt4",
 		"pinentry",


### PR DESCRIPTION
I would put `pinentry` on top, since its a script that dynamically chooses based on desktop environment, but on Arch Linux it always uses gtk-2. The more modern pinentry's look much nicer, are integrated into the desktop environment (on GNOME 3 it makes a full screen prompt appear and darkens the background), and could possibly be more secure. I've tested and confirmed that pinentry-gnome3 works fine outside of a GNOME session.