### PR TITLE
fix inbox crash on collapsing small teams

### DIFF
--- a/shared/chat/inbox/index.desktop.tsx
+++ b/shared/chat/inbox/index.desktop.tsx
@@ -86,6 +86,10 @@ class Inbox extends React.Component<T.Props, State> {
 
   private itemRenderer = (index, style) => {
     const row = this.props.rows[index]
+    if (!row) {
+      // likely small teams were just collapsed
+      return null
+    }
     const divStyle = Styles.collapseStyles([style, virtualListMarks && styles.divider])
     if (row.type === 'divider') {
       return (


### PR DESCRIPTION
I can repro a crash if you:
1. Expand small teams
2. Scroll down a bunch (I think at least to an index > the total length of the inbox when collapsed)
3. Collapse small teams
<img width="992" alt="image" src="https://user-images.githubusercontent.com/11968340/66845173-939b9000-ef3d-11e9-9504-078888bf5d3c.png">

It seems an alternate fix is to revert this: https://github.com/keybase/client/commit/04efd3ad50dd143ecc90c9a044eac2aa7c0ba8fe#diff-41dd3605294202cbd6c4985a7a2c84abR55
I defer to @chrisnojima since he's been in here recently.