### PR TITLE
Reloadable changes

### DIFF
--- a/shared/common-adapters/reload.tsx
+++ b/shared/common-adapters/reload.tsx
@@ -9,7 +9,7 @@ import ScrollView from './scroll-view'
 import Text from './text'
 import Button from './button'
 import Icon from './icon'
-import {namedConnect} from '../util/container'
+import {namedConnect, isNetworkErr} from '../util/container'
 import {RPCError} from '../util/errors'
 import {settingsTab} from '../constants/tabs'
 import {feedbackTab} from '../constants/settings'
@@ -149,6 +149,10 @@ export type OwnProps = {
 
 const mapStateToProps = (state, ownProps: OwnProps) => {
   let error = Constants.anyErrors(state, ownProps.waitingKeys)
+
+  // make sure reloadable only responds to network-related errors
+  error = error && isNetworkErr(error.code) ? error : undefined
+
   if (error && ownProps.errorFilter) {
     error = ownProps.errorFilter(error) ? error : undefined
   }

--- a/shared/common-adapters/reload.tsx
+++ b/shared/common-adapters/reload.tsx
@@ -157,9 +157,9 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
     error = ownProps.errorFilter(error) ? error : undefined
   }
   return {
+    _loggedIn: state.config.loggedIn,
     needsReload: !!error,
     reason: (error && error.message) || '',
-    _loggedIn: state.config.loggedIn,
   }
 }
 const mapDispatchToProps = dispatch => ({

--- a/shared/stories/prop-providers.tsx
+++ b/shared/stories/prop-providers.tsx
@@ -146,6 +146,7 @@ export const Reloadable = () => ({
   Reloadable: (p: ReloadableOwnProps): ReloadableProps => ({
     children: p.children,
     needsReload: false,
+    onFeedback: action('feedback'),
     onReload: action('reload'),
     reason: '',
     reloadOnMount: false,


### PR DESCRIPTION
This PR addresses HOTPOT-7 by adding a 'feedback' button to the reloadable screen (navigates the user to the feedback screen in settings), and filters reloadable errors by network-related errors by default.