### PR TITLE
add exclusion proofs to merkletree2

### DIFF
--- a/go/merkletree2/encoders.go
+++ b/go/merkletree2/encoders.go
@@ -46,11 +46,7 @@ func NewBlindedSHA512_256v1Encoder() *BlindedSHA512_256v1Encoder {
 	mh.WriteExt = true
 	mh.Canonical = true
 
-	var mh2 codec.MsgpackHandle
-	mh2.WriteExt = true
-	mh2.Canonical = true
-
-	return &BlindedSHA512_256v1Encoder{enc: codec.NewEncoderBytes(nil, &mh), dec: codec.NewDecoderBytes(nil, &mh2)}
+	return &BlindedSHA512_256v1Encoder{enc: codec.NewEncoderBytes(nil, &mh), dec: codec.NewDecoderBytes(nil, &mh)}
 }
 
 func (e *BlindedSHA512_256v1Encoder) Encode(o interface{}) (out []byte, err error) {

--- a/go/merkletree2/errors.go
+++ b/go/merkletree2/errors.go
@@ -42,6 +42,19 @@ func NewProofVerificationFailedError(reason error) ProofVerificationFailedError 
 	return ProofVerificationFailedError{reason: reason}
 }
 
+// NodeNotFoundError is returned by a StorageEngine when trying to fetch an internal node
+// which is not part of the tree at a specific Seqno.
+type NodeNotFoundError struct{}
+
+func (e NodeNotFoundError) Error() string {
+	return fmt.Sprintf("Node not found.")
+}
+
+// NewNodeNotFoundError returns a new error
+func NewNodeNotFoundError() NodeNotFoundError {
+	return NodeNotFoundError{}
+}
+
 // KeyNotFoundError is returned when trying to fetch a key which is not part of
 // the tree at a specific Seqno.
 type KeyNotFoundError struct{}

--- a/go/merkletree2/interfaces.go
+++ b/go/merkletree2/interfaces.go
@@ -10,10 +10,17 @@ type StorageEngine interface {
 	// StoreKVPairs stores the []KeyEncodedValuePair in the tree.
 	StoreKEVPairs(logger.ContextInterface, Transaction, Seqno, []KeyEncodedValuePair) error
 
+	// StoreNode stores the Hash (of a tree node) at the provided Position,
+	// Seqno in the tree.
 	StoreNode(logger.ContextInterface, Transaction, Seqno, *Position, Hash) error
 
+	// StoreNode takes multiple pairs of a position and a hash, and stores each
+	// hash (of a tree node) at the corresponding position and at the supplied
+	// Seqno in the tree.
 	StoreNodes(logger.ContextInterface, Transaction, Seqno, []PositionHashPair) error
 
+	// StoreRootMetadata stores the supplied RootMetadata, along with the
+	// corresponding Hash.
 	StoreRootMetadata(logger.ContextInterface, Transaction, RootMetadata, Hash) error
 
 	// LookupLatestRoot returns the latest root metadata and sequence number in

--- a/go/merkletree2/interfaces.go
+++ b/go/merkletree2/interfaces.go
@@ -23,6 +23,9 @@ type StorageEngine interface {
 	// If there is no root for the specified Seqno, an InvalidSeqnoError is returned.
 	LookupRoot(logger.ContextInterface, Transaction, Seqno) (RootMetadata, error)
 
+	// Returns a RootMetadata given its Hash.
+	LookupRootFromHash(logger.ContextInterface, Transaction, Hash) (RootMetadata, error)
+
 	// LookupRoots returns the RootMetadata objects in the tree at the
 	// supplied Seqnos, ordered by seqno.
 	LookupRoots(logger.ContextInterface, Transaction, []Seqno) ([]RootMetadata, error)

--- a/go/merkletree2/interfaces.go
+++ b/go/merkletree2/interfaces.go
@@ -14,7 +14,7 @@ type StorageEngine interface {
 
 	StoreNodes(logger.ContextInterface, Transaction, Seqno, []PositionHashPair) error
 
-	StoreRootMetadata(logger.ContextInterface, Transaction, RootMetadata) error
+	StoreRootMetadata(logger.ContextInterface, Transaction, RootMetadata, Hash) error
 
 	// LookupLatestRoot returns the latest root metadata and sequence number in
 	// the tree. If no root is found, then a NoLatestRootFound error is returned.

--- a/go/merkletree2/position.go
+++ b/go/merkletree2/position.go
@@ -14,11 +14,11 @@ import (
 // (0b00000101).
 type Position big.Int
 
-func (t *Config) getRootPosition() *Position {
+func (t *Config) GetRootPosition() *Position {
 	return (*Position)(big.NewInt(1))
 }
 
-func (t *Config) getChild(p *Position, c ChildIndex) *Position {
+func (t *Config) GetChild(p *Position, c ChildIndex) *Position {
 	var q big.Int
 	q.Lsh((*big.Int)(p), uint(t.BitsPerIndex))
 	q.Bits()[0] = q.Bits()[0] | big.Word(c)

--- a/go/merkletree2/position_test.go
+++ b/go/merkletree2/position_test.go
@@ -18,15 +18,15 @@ func TestEncoding(t *testing.T) {
 		bin string
 		p   Position
 	}{
-		{config1bit, "1", *config1bit.getRootPosition()},
-		{config2bits, "1", *config2bits.getRootPosition()},
-		{config3bits, "1", *config3bits.getRootPosition()},
-		{config1bit, "10", *config1bit.getChild(config1bit.getRootPosition(), 0)},
-		{config2bits, "100", *config2bits.getChild(config2bits.getRootPosition(), 0)},
-		{config3bits, "1000", *config3bits.getChild(config3bits.getRootPosition(), 0)},
-		{config1bit, "101", *config1bit.getChild(config1bit.getChild(config1bit.getRootPosition(), 0), 1)},
-		{config2bits, "10011", *config2bits.getChild(config2bits.getChild(config2bits.getRootPosition(), 0), 3)},
-		{config3bits, "1000101", *config3bits.getChild(config3bits.getChild(config3bits.getRootPosition(), 0), 5)},
+		{config1bit, "1", *config1bit.GetRootPosition()},
+		{config2bits, "1", *config2bits.GetRootPosition()},
+		{config3bits, "1", *config3bits.GetRootPosition()},
+		{config1bit, "10", *config1bit.GetChild(config1bit.GetRootPosition(), 0)},
+		{config2bits, "100", *config2bits.GetChild(config2bits.GetRootPosition(), 0)},
+		{config3bits, "1000", *config3bits.GetChild(config3bits.GetRootPosition(), 0)},
+		{config1bit, "101", *config1bit.GetChild(config1bit.GetChild(config1bit.GetRootPosition(), 0), 1)},
+		{config2bits, "10011", *config2bits.GetChild(config2bits.GetChild(config2bits.GetRootPosition(), 0), 3)},
+		{config3bits, "1000101", *config3bits.GetChild(config3bits.GetChild(config3bits.GetRootPosition(), 0), 5)},
 	}
 
 	for _, et := range encodingTests {
@@ -65,7 +65,7 @@ func TestGetAndUpdateParentAndGetChild(t *testing.T) {
 			parent, err := makePositionFromStringForTesting(test.parent)
 			require.NoError(t, err)
 			require.True(t, test.c.getParent(&child).Equals(&parent))
-			require.True(t, test.c.getChild(&parent, test.i).Equals(&child))
+			require.True(t, test.c.GetChild(&parent, test.i).Equals(&child))
 			parentInPlace := child.Clone()
 			test.c.updateToParent(parentInPlace)
 			require.True(t, parentInPlace.Equals(&parent))

--- a/go/merkletree2/storage_engine_for_test.go
+++ b/go/merkletree2/storage_engine_for_test.go
@@ -170,6 +170,9 @@ func (i *InMemoryStorageEngine) LookupRoots(c logger.ContextInterface, t Transac
 }
 
 func (i *InMemoryStorageEngine) LookupRootHashes(c logger.ContextInterface, t Transaction, seqnos []Seqno) (hashes []Hash, err error) {
+	if len(seqnos) == 0 {
+		return nil, fmt.Errorf("No seqnos requested")
+	}
 	seqnosSorted := make([]Seqno, len(seqnos))
 	copy(seqnosSorted, seqnos)
 	sort.Sort(SeqnoSortedAsInt(seqnosSorted))

--- a/go/merkletree2/storage_engine_for_test.go
+++ b/go/merkletree2/storage_engine_for_test.go
@@ -116,13 +116,9 @@ func (i *InMemoryStorageEngine) StoreNode(c logger.ContextInterface, t Transacti
 	return nil
 }
 
-func (i *InMemoryStorageEngine) StoreRootMetadata(c logger.ContextInterface, t Transaction, r RootMetadata) error {
+func (i *InMemoryStorageEngine) StoreRootMetadata(c logger.ContextInterface, t Transaction, r RootMetadata, h Hash) error {
 	i.Roots[r.Seqno] = r
-	_, hash, err := i.cfg.Encoder.EncodeAndHashGeneric(r)
-	if err != nil {
-		panic(fmt.Sprintf("Error encoding %+v", r))
-	}
-	i.ReverseRootMap[string(hash)] = r.Seqno
+	i.ReverseRootMap[string(h)] = r.Seqno
 	return nil
 }
 

--- a/go/merkletree2/tree.go
+++ b/go/merkletree2/tree.go
@@ -204,7 +204,7 @@ func (t *Tree) makeNextRootMetadata(ctx logger.ContextInterface, tr Transaction,
 
 	// If there is no previous root, we do not need to include any skips, so
 	// return early.
-	if curr == nil {
+	if curr == nil || curr.Seqno == 0 {
 		root.Seqno = 1
 		return root, nil
 	}

--- a/go/merkletree2/tree.go
+++ b/go/merkletree2/tree.go
@@ -445,13 +445,6 @@ func (t *Tree) GetKeyValuePair(ctx logger.ContextInterface, tr Transaction, s Se
 	return t.GetKeyValuePairUnsafe(ctx, tr, s, k)
 }
 
-type ProofVersion uint8
-
-const (
-	ProofVersionV1      ProofVersion = 1
-	CurrentProofVersion ProofVersion = ProofVersionV1
-)
-
 // A MerkleInclusionProof proves that a specific key value pair is stored in a
 // merkle tree, given the RootMetadata hash of such tree.
 type MerkleInclusionProof struct {

--- a/go/merkletree2/tree.go
+++ b/go/merkletree2/tree.go
@@ -303,7 +303,7 @@ func (t *Tree) Build(
 
 	var newBareRootHash Hash
 	if newBareRootHash, err = t.hashTreeRecursive(ctx, tr, newSeqno, ms,
-		t.cfg.getRootPosition(), sortedKEVPairs); err != nil {
+		t.cfg.GetRootPosition(), sortedKEVPairs); err != nil {
 		return 0, nil, err
 	}
 
@@ -343,10 +343,10 @@ func (t *Tree) hashTreeRecursive(ctx logger.ContextInterface, tr Transaction, s 
 
 	pairsNotYetSelected := sortedKEVPairs
 	var nextChild *Position
-	for i, child := ChildIndex(0), t.cfg.getChild(p, ChildIndex(0)); i < ChildIndex(t.cfg.ChildrenPerNode); i++ {
+	for i, child := ChildIndex(0), t.cfg.GetChild(p, ChildIndex(0)); i < ChildIndex(t.cfg.ChildrenPerNode); i++ {
 		var end int
 		if i+1 < ChildIndex(t.cfg.ChildrenPerNode) {
-			nextChild = t.cfg.getChild(p, i+1)
+			nextChild = t.cfg.GetChild(p, i+1)
 			maxKey := t.cfg.getMinKey(nextChild)
 
 			end = sort.Search(len(pairsNotYetSelected), func(n int) bool {

--- a/go/merkletree2/tree.go
+++ b/go/merkletree2/tree.go
@@ -214,7 +214,7 @@ func (t *Tree) makeNextRootMetadata(ctx logger.ContextInterface, tr Transaction,
 
 	skips, err := t.eng.LookupRootHashes(ctx, tr, skipSeqnos)
 	if err != nil {
-		return RootMetadata{}, fmt.Errorf("makeNextRootMetadata: error retrieving previous hashes %+v", skips)
+		return RootMetadata{}, fmt.Errorf("makeNextRootMetadata: error retrieving previous hashes %+v: %v", skipSeqnos, err)
 	}
 
 	_, skipsHash, err := t.cfg.Encoder.EncodeAndHashGeneric(skips)

--- a/go/merkletree2/tree.go
+++ b/go/merkletree2/tree.go
@@ -312,7 +312,12 @@ func (t *Tree) Build(
 		return 0, nil, err
 	}
 
-	if err = t.eng.StoreRootMetadata(ctx, tr, newRootMetadata); err != nil {
+	_, newRootHash, err := t.cfg.Encoder.EncodeAndHashGeneric(newRootMetadata)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	if err = t.eng.StoreRootMetadata(ctx, tr, newRootMetadata, newRootHash); err != nil {
 		return 0, nil, err
 	}
 

--- a/go/merkletree2/util_for_test.go
+++ b/go/merkletree2/util_for_test.go
@@ -209,10 +209,12 @@ func (i IdentityHasherBlinded) ComputeKeySpecificSecret(ms MasterSecret, k Key) 
 	return KeySpecificSecret(kss)
 }
 
-// returns a list of sorted and unique keys of size numPairs
-func makeRandomKeysForTesting(keysByteLength uint, numPairs int) ([]Key, error) {
+// returns two disjoint lists of sorted and unique keys of size numPairs1, numPairs2
+func makeRandomKeysForTesting(keysByteLength uint, numPairs1, numPairs2 int) ([]Key, []Key, error) {
+	numPairs := numPairs1 + numPairs2
+
 	if keysByteLength < 8 && numPairs > 1<<(keysByteLength*8) {
-		return nil, fmt.Errorf("too many keys requested !")
+		return nil, nil, fmt.Errorf("too many keys requested !")
 	}
 
 	keyMap := make(map[string]bool, numPairs)
@@ -220,25 +222,38 @@ func makeRandomKeysForTesting(keysByteLength uint, numPairs int) ([]Key, error) 
 		key := make([]byte, keysByteLength)
 		_, err := rand.Read(key)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		keyMap[string(key)] = true
 	}
 
-	keyStrings := make([]string, 0, numPairs)
+	keyStrings1 := make([]string, 0, numPairs1)
+	keyStrings2 := make([]string, 0, numPairs2)
 
+	i := 0
 	for k := range keyMap {
-		keyStrings = append(keyStrings, k)
+		if i < numPairs1 {
+			keyStrings1 = append(keyStrings1, k)
+			i++
+		} else {
+			keyStrings2 = append(keyStrings2, k)
+		}
 	}
 
-	sort.Strings(keyStrings)
+	sort.Strings(keyStrings1)
+	sort.Strings(keyStrings2)
 
-	keys := make([]Key, numPairs)
-	for i, k := range keyStrings {
-		keys[i] = Key(k)
+	keys1 := make([]Key, numPairs1)
+	for i, k := range keyStrings1 {
+		keys1[i] = Key(k)
 	}
 
-	return keys, nil
+	keys2 := make([]Key, numPairs2)
+	for i, k := range keyStrings2 {
+		keys2[i] = Key(k)
+	}
+
+	return keys1, keys2, nil
 }
 
 func makeRandomKVPFromKeysForTesting(keys []Key) ([]KeyValuePair, error) {


### PR DESCRIPTION
In addition, minor efficiency improvements:
- use a single handle for each merkletree2 encoder
- added rootHash input to StoreRootMetadata method