### PR TITLE
get rid of unneeded make functions in tracker2 constants

### DIFF
--- a/shared/constants/tracker2.tsx
+++ b/shared/constants/tracker2.tsx
@@ -11,7 +11,7 @@ export const makeState = (): Types.State => ({
   usernameToNonUserDetails: new Map(),
 })
 
-export const makeDetails = (): Types.Details => ({
+export const noDetails: Types.Details = {
   assertions: emptyMap,
   blocked: false,
   guiID: '',
@@ -21,20 +21,20 @@ export const makeDetails = (): Types.Details => ({
   state: 'error',
   teamShowcase: emptyArray,
   username: '',
-})
+}
 
-export const makeNonUserDetails = (): Types.NonUserDetails => ({
+export const noNonUserDetails: Types.NonUserDetails = {
   assertionKey: '',
   assertionValue: '',
   description: '',
   siteIcon: emptyArray,
   siteIconFull: emptyArray,
   siteURL: '',
-})
+}
 
 export const generateGUIID = () => Math.floor(Math.random() * 0xfffffffffffff).toString(16)
 
-export const makeAssertion = (): Types.Assertion => ({
+export const noAssertion: Types.Assertion = {
   assertionKey: '',
   belowFold: false,
   color: 'gray',
@@ -53,20 +53,7 @@ export const makeAssertion = (): Types.Assertion => ({
   timestamp: 0,
   type: '',
   value: '',
-})
-
-export const makeMeta = (): Types.AssertionMeta => ({
-  color: 'black',
-  label: '',
-})
-
-export const makeTeamShowcase = (): Types.TeamShowcase => ({
-  description: '',
-  isOpen: false,
-  membersCount: 0,
-  name: '',
-  publicAdmins: [],
-})
+}
 
 export const rpcResultToStatus = (result: RPCTypes.Identify3ResultType) => {
   switch (result) {
@@ -120,7 +107,7 @@ export const rpcAssertionToAssertion = (row: RPCTypes.Identify3Row): Types.Asser
   assertionKey: `${row.key}:${row.value}`,
   color: rpcRowColorToColor(row.color),
   kid: row.kid || ',',
-  metas: (row.metas || []).map(m => ({color: rpcRowColorToColor(m.color), label: m.label})).map(makeMeta),
+  metas: (row.metas || []).map(m => ({color: rpcRowColorToColor(m.color), label: m.label})),
   priority: row.priority,
   proofURL: row.proofURL,
   sigID: row.sigID,
@@ -141,7 +128,7 @@ export const rpcSuggestionToAssertion = (s: RPCTypes.ProofSuggestion): Types.Ass
     assertionKey: ourKey,
     belowFold: s.belowFold,
     color: 'gray',
-    metas: (s.metas || []).map(m => ({color: rpcRowColorToColor(m.color), label: m.label})).map(makeMeta),
+    metas: (s.metas || []).map(m => ({color: rpcRowColorToColor(m.color), label: m.label})),
     pickerIcon: s.pickerIcon || [],
     pickerSubtext: s.pickerSubtext,
     pickerText: s.pickerText,
@@ -200,9 +187,6 @@ export const sortAssertionKeys = (a: string, b: string) => {
   return scoreA - scoreB
 }
 
-export const noDetails = makeDetails()
-export const noNonUserDetails = makeNonUserDetails()
-export const noAssertion = makeAssertion()
 export const waitingKey = 'tracker2:waitingKey'
 export const profileLoadWaitingKey = 'tracker2:profileLoad'
 export const nonUserProfileLoadWaitingKey = 'tracker2:nonUserProfileLoad'

--- a/shared/constants/tracker2.tsx
+++ b/shared/constants/tracker2.tsx
@@ -11,7 +11,7 @@ export const makeState = (): Types.State => ({
   usernameToNonUserDetails: new Map(),
 })
 
-export const noDetails: Types.Details = {
+export const noDetails: Readonly<Types.Details> = Object.freeze({
   assertions: emptyMap,
   blocked: false,
   guiID: '',
@@ -21,20 +21,20 @@ export const noDetails: Types.Details = {
   state: 'error',
   teamShowcase: emptyArray,
   username: '',
-}
+})
 
-export const noNonUserDetails: Types.NonUserDetails = {
+export const noNonUserDetails: Readonly<Types.NonUserDetails> = Object.freeze({
   assertionKey: '',
   assertionValue: '',
   description: '',
   siteIcon: emptyArray,
   siteIconFull: emptyArray,
   siteURL: '',
-}
+})
 
 export const generateGUIID = () => Math.floor(Math.random() * 0xfffffffffffff).toString(16)
 
-export const noAssertion: Types.Assertion = {
+export const noAssertion: Readonly<Types.Assertion> = Object.freeze({
   assertionKey: '',
   belowFold: false,
   color: 'gray',
@@ -53,7 +53,7 @@ export const noAssertion: Types.Assertion = {
   timestamp: 0,
   type: '',
   value: '',
-}
+})
 
 export const rpcResultToStatus = (result: RPCTypes.Identify3ResultType) => {
   switch (result) {


### PR DESCRIPTION
These `make*` functions were not taking a param, so users would always end up with the empty ones. Removed the `make*` functions. cc @keybase/y2ksquad 