### PR TITLE
Don't include currently selected conversation in inbox unreadIndices

### DIFF
--- a/shared/chat/inbox/container/index.tsx
+++ b/shared/chat/inbox/container/index.tsx
@@ -118,6 +118,7 @@ const Connected = Container.namedConnect(
       _canRefreshOnMount,
       _hasLoadedTrusted: state.chat2.trustedInboxHasLoaded,
       _inboxLayout: inboxLayout,
+      _selectedConversationIDKey: state.chat2.selectedConversation,
       allowShowFloatingButton,
       isLoading: isMobile ? Constants.anyChatWaitingKeys(state) : false, // desktop doesn't use isLoading so ignore it
       isSearching: !!state.chat2.inboxSearch,
@@ -164,7 +165,11 @@ const Connected = Container.namedConnect(
         // only check big teams for large inbox perf
         break
       }
-      if (row.conversationIDKey && stateProps._badgeMap.get(row.conversationIDKey)) {
+      if (
+        row.conversationIDKey &&
+        stateProps._badgeMap.get(row.conversationIDKey) &&
+        row.conversationIDKey !== stateProps._selectedConversationIDKey
+      ) {
         // on mobile include all convos, on desktop only not currently selected convo
         unreadIndices.unshift(i)
       }


### PR DESCRIPTION
@chrisnojima I had a wrong assessment of this earlier - I don't think this is any less performant than master's version, since `unreadIndices` is changing there and likely not changing with this PR. In profiling the test case I was using `Inbox` rerenders 4 times on master, and 2 times with this. 