### PR TITLE
HOTPOT-1040: align chat titles with icons

### DIFF
--- a/shared/chat/header.desktop.tsx
+++ b/shared/chat/header.desktop.tsx
@@ -75,6 +75,9 @@ const Header = (p: Props) => {
       ? p.participants.filter(part => part !== p.username)
       : p.participants
 
+  // if there is no description (and is not a 1-on-1), don't render the description box
+  const renderDescription = description || (withoutSelf && withoutSelf.length === 1)
+
   // trim() call makes sure that string is not just whitespace
   if (withoutSelf && withoutSelf.length === 1 && p.desc.trim()) {
     description = (
@@ -106,7 +109,10 @@ const Header = (p: Props) => {
         alignItems="flex-end"
         alignSelf="flex-end"
       >
-        <Kb.Box2 direction="vertical" style={styles.headerTitle}>
+        <Kb.Box2
+          direction="vertical"
+          style={renderDescription ? styles.headerTitle : styles.headerTitleNoDesc}
+        >
           <Kb.Box2 direction="horizontal" fullWidth={true}>
             {p.channel ? (
               <Kb.Text selectable={true} type="Header" lineClamp={1}>
@@ -146,8 +152,7 @@ const Header = (p: Props) => {
               />
             )}
           </Kb.Box2>
-          {/* if there is no description (and is not a 1-on-1), don't render the description box */}
-          {(description || (withoutSelf && withoutSelf.length === 1)) && (
+          {renderDescription && (
             <Kb.Box2 direction="vertical" style={styles.descriptionContainer} fullWidth={true}>
               {withoutSelf && withoutSelf.length === 1 ? (
                 <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center">
@@ -218,6 +223,10 @@ const styles = Styles.styleSheetCreate(
       },
       headerTitle: Styles.platformStyles({
         common: {flexGrow: 1, paddingBottom: Styles.globalMargins.xtiny},
+        isElectron: Styles.desktopStyles.windowDraggingClickable,
+      }),
+      headerTitleNoDesc: Styles.platformStyles({
+        common: {flexGrow: 1, paddingBottom: Styles.globalMargins.tiny},
         isElectron: Styles.desktopStyles.windowDraggingClickable,
       }),
       left: {minWidth: 260},

--- a/shared/chat/header.desktop.tsx
+++ b/shared/chat/header.desktop.tsx
@@ -44,7 +44,7 @@ const descStyleOverride = {
 } as any
 
 const Header = (p: Props) => {
-  let description = !!p.desc && p.desc !== '' && (
+  let description = !!p.desc && (
     <Kb.Markdown
       smallStandaloneEmoji={true}
       style={styles.desc}

--- a/shared/chat/header.desktop.tsx
+++ b/shared/chat/header.desktop.tsx
@@ -44,7 +44,7 @@ const descStyleOverride = {
 } as any
 
 const Header = (p: Props) => {
-  let description = !!p.desc && (
+  let description = !!p.desc && p.desc !== '' && (
     <Kb.Markdown
       smallStandaloneEmoji={true}
       style={styles.desc}
@@ -146,24 +146,27 @@ const Header = (p: Props) => {
               />
             )}
           </Kb.Box2>
-          <Kb.Box2 direction="vertical" style={styles.descriptionContainer} fullWidth={true}>
-            {withoutSelf && withoutSelf.length === 1 ? (
-              <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center">
-                <Kb.ConnectedUsernames
-                  colorFollowing={true}
-                  underline={true}
-                  inline={true}
-                  commaColor={Styles.globalColors.black_50}
-                  type="BodySmallSemibold"
-                  usernames={[withoutSelf[0]]}
-                  onUsernameClicked="profile"
-                />
-                {description}
-              </Kb.Box2>
-            ) : (
-              description
-            )}
-          </Kb.Box2>
+          {/* if there is no description (and is not a 1-on-1), don't render the description box */}
+          {(description || (withoutSelf && withoutSelf.length === 1)) && (
+            <Kb.Box2 direction="vertical" style={styles.descriptionContainer} fullWidth={true}>
+              {withoutSelf && withoutSelf.length === 1 ? (
+                <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center">
+                  <Kb.ConnectedUsernames
+                    colorFollowing={true}
+                    underline={true}
+                    inline={true}
+                    commaColor={Styles.globalColors.black_50}
+                    type="BodySmallSemibold"
+                    usernames={[withoutSelf[0]]}
+                    onUsernameClicked="profile"
+                  />
+                  {description}
+                </Kb.Box2>
+              ) : (
+                description
+              )}
+            </Kb.Box2>
+          )}
         </Kb.Box2>
         {p.showActions && (
           <Kb.Box2


### PR DESCRIPTION
This PR makes it so chats that are not 1-on-1 and have no description have titles which align with the action buttons. this does not change the behavior of chats that include the "set a description with /headline" description.