### PR TITLE
fix logic for reply privately

### DIFF
--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -31,10 +31,17 @@ const mapStateToProps = (state: TypedState, ownProps: OwnProps) => {
   const _canExplodeNow = (yourMessage || _canDeleteHistory) && ownProps.message.isDeleteable
   const _canEdit = yourMessage && ownProps.message.isEditable
   const _mapUnfurl = Constants.getMapUnfurl(ownProps.message)
+  // you can reply privately *if* text message, someone else's message, and not in a 1-on-1 chat
+  const _canReplyPrivately =
+    !yourMessage &&
+    ownProps.message.type === 'text' &&
+    (['small', 'big'].includes(meta.teamType) || meta.participants.length > 2)
+
   return {
     _canDeleteHistory,
     _canEdit,
     _canExplodeNow,
+    _canReplyPrivately,
     _mapUnfurl,
     author: ownProps.message.author,
     deviceName: ownProps.message.deviceName,
@@ -174,7 +181,9 @@ export default connect(
       }
       items.push({onClick: dispatchProps._onCopy, title: 'Copy text'})
       items.push({onClick: dispatchProps._onReply, title: 'Reply'})
-      items.push({onClick: dispatchProps._onReplyPrivately, title: 'Reply privately'})
+      if (stateProps._canReplyPrivately) {
+        items.push({onClick: dispatchProps._onReplyPrivately, title: 'Reply privately'})
+      }
       items.push({onClick: dispatchProps._onPinMessage, title: 'Pin message'})
     }
     return {

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -32,10 +32,14 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
     _canPinMessage = yourOperations && yourOperations.pinMessage
   }
   const _participantsCount = meta.participants.length
+  // you can reply privately *if* text message, someone else's message, and not in a 1-on-1 chat
+  const _canReplyPrivately =
+    message.type === 'text' && (['small', 'big'].includes(meta.teamType) || _participantsCount > 2)
   return {
     _canAdminDelete,
     _canDeleteHistory,
     _canPinMessage,
+    _canReplyPrivately,
     _isDeleteable: message.isDeleteable,
     _isEditable: message.isEditable,
     _participantsCount,
@@ -116,6 +120,7 @@ export default Container.namedConnect(
     const yourMessage = message.author === stateProps._you
     const isDeleteable = stateProps._isDeleteable && (yourMessage || stateProps._canAdminDelete)
     const isEditable = stateProps._isEditable && yourMessage
+    const canReplyPrivately = stateProps._canReplyPrivately
     const mapUnfurl = Constants.getMapUnfurl(message)
     const onViewMap = mapUnfurl ? () => openURL(mapUnfurl.url) : undefined
     return {
@@ -137,9 +142,7 @@ export default Container.namedConnect(
       onPinMessage: stateProps._canPinMessage ? () => dispatchProps._onPinMessage(message) : undefined,
       onReply: message.type === 'text' ? () => dispatchProps._onReply(message) : undefined,
       onReplyPrivately:
-        message.type === 'text' && !yourMessage && stateProps._participantsCount > 2
-          ? () => dispatchProps._onReplyPrivately(message)
-          : undefined,
+        !yourMessage && canReplyPrivately ? () => dispatchProps._onReplyPrivately(message) : undefined,
       onViewMap,
       onViewProfile:
         message.author && !yourMessage ? () => dispatchProps._onViewProfile(message.author) : undefined,


### PR DESCRIPTION
Changes logic for showing 'reply privately' menu option so it will show up if: 
* message is someone else's
* message is in a big or small team OR is in a conversation with >2 participants