### PR TITLE
Better explanation text for invalid username on signup

### DIFF
--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -50,7 +50,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 		return libkb.AppStatusError{
 			Code: libkb.SCBadUsername,
 			Name: "BAD_USERNAME",
-			Desc: "Usernames must be 2-16 characters long, and can use letters, numbers, and underscore.",
+			Desc: "Usernames must be 2-16 characters long, and can use letters, numbers, and underscores.",
 		}
 	case "user":
 		// User found, so the name is taken.

--- a/go/service/signup.go
+++ b/go/service/signup.go
@@ -50,7 +50,7 @@ func (h *SignupHandler) CheckUsernameAvailable(ctx context.Context, arg keybase1
 		return libkb.AppStatusError{
 			Code: libkb.SCBadUsername,
 			Name: "BAD_USERNAME",
-			Desc: "This is not a valid username. Please pick another one.",
+			Desc: "Usernames must be 2-16 characters long, and can use letters, numbers, and underscore.",
 		}
 	case "user":
 		// User found, so the name is taken.


### PR DESCRIPTION
@keybase/picnicsquad 

There are two restrictions I'm not communicating in this string: usernames also can't start with an underscore, and can't use double underscores.  But I'm thinking I'd rather be comprehensible than exhaustive here.

<img width="1039" alt="Screen Shot 2019-10-17 at 11 40 05 PM" src="https://user-images.githubusercontent.com/21217/67071584-c7420a00-f137-11e9-9a02-761c2e0fc2ab.png">
