### PR TITLE
manual control of revision

### DIFF
--- a/go/client/kvstore_api_doc.go
+++ b/go/client/kvstore_api_doc.go
@@ -4,11 +4,14 @@ const kvStoreAPIDoc = `"keybase kvstore api" provides a JSON API to fast, encryp
 
 EXAMPLES:
 
-Get an entry (non-existent entries have a revision of 0):
+Get an entry (always returns the latest revision, non-existent entries have a revision of 0):
 	{"method": "get", "params": {"options": {"team": "phoenix", "namespace": "pw-manager", "entryKey": "geocities"}}}
 
 Put an entry (reads value from stdin):
 	{"method": "put", "params": {"options": {"team": "phoenix", "namespace": "pw-manager", "entryKey": "geocities", "entryValue": "all my secrets"}}}
+
+Put an entry (specifying a non-zero revision enables custom concurrency behavior, e.g. 1 will throw an error if the entry already exists):
+	{"method": "put", "params": {"options": {"team": "phoenix", "namespace": "pw-manager", "entryKey": "geocities", "revision": 1, "entryValue": "all my secrets"}}}
 
 List all namespaces with a non-deleted entryKey (pagination not yet implemented for >10k items):
 	{"method": "list", "params": {"options": {"team": "phoenix"}}}
@@ -18,4 +21,7 @@ List all non-deleted entryKeys in a namespace (pagination not yet implemented fo
 
 Delete an entry:
 	{"method": "del", "params": {"options": {"team": "phoenix", "namespace": "pw-manager", "entryKey": "geocities"}}}
+
+Delete an entry (also supports specifying the revision):
+	{"method": "del", "params": {"options": {"team": "phoenix", "namespace": "pw-manager", "revision": 4, "entryKey": "geocities"}}}
 `

--- a/go/client/kvstore_api_handler.go
+++ b/go/client/kvstore_api_handler.go
@@ -108,6 +108,7 @@ type putEntryOptions struct {
 	Team       string `json:"team"`
 	Namespace  string `json:"namespace"`
 	EntryKey   string `json:"entryKey"`
+	Revision   int    `json:"revision"`
 	EntryValue string `json:"entryValue"`
 }
 
@@ -137,6 +138,7 @@ func (t *kvStoreAPIHandler) putEntry(ctx context.Context, c Call, w io.Writer) e
 		TeamName:   opts.Team,
 		Namespace:  opts.Namespace,
 		EntryKey:   opts.EntryKey,
+		Revision:   opts.Revision,
 		EntryValue: opts.EntryValue,
 	}
 	res, err := t.cli.PutKVEntry(ctx, arg)
@@ -150,6 +152,7 @@ type deleteEntryOptions struct {
 	Team      string `json:"team"`
 	Namespace string `json:"namespace"`
 	EntryKey  string `json:"entryKey"`
+	Revision  int    `json:"revision"`
 }
 
 func (a *deleteEntryOptions) Check() error {
@@ -175,6 +178,7 @@ func (t *kvStoreAPIHandler) deleteEntry(ctx context.Context, c Call, w io.Writer
 		TeamName:  opts.Team,
 		Namespace: opts.Namespace,
 		EntryKey:  opts.EntryKey,
+		Revision:  opts.Revision,
 	}
 	res, err := t.cli.DelKVEntry(ctx, arg)
 	if err != nil {

--- a/go/client/kvstore_api_handler.go
+++ b/go/client/kvstore_api_handler.go
@@ -108,7 +108,7 @@ type putEntryOptions struct {
 	Team       string `json:"team"`
 	Namespace  string `json:"namespace"`
 	EntryKey   string `json:"entryKey"`
-	Revision   int    `json:"revision"`
+	Revision   *int   `json:"revision"`
 	EntryValue string `json:"entryValue"`
 }
 
@@ -125,6 +125,9 @@ func (a *putEntryOptions) Check() error {
 	if len(a.EntryValue) == 0 {
 		return errors.New("`entryValue` field required")
 	}
+	if a.Revision != nil && *a.Revision <= 0 {
+		return errors.New("if setting optional `revision` field, it needs to be a positive integer")
+	}
 	return nil
 }
 
@@ -133,12 +136,16 @@ func (t *kvStoreAPIHandler) putEntry(ctx context.Context, c Call, w io.Writer) e
 	if err := unmarshalOptions(c, &opts); err != nil {
 		return t.encodeErr(c, err, w)
 	}
+	var revision int
+	if opts.Revision != nil {
+		revision = *opts.Revision
+	}
 	arg := keybase1.PutKVEntryArg{
 		SessionID:  0,
 		TeamName:   opts.Team,
 		Namespace:  opts.Namespace,
 		EntryKey:   opts.EntryKey,
-		Revision:   opts.Revision,
+		Revision:   revision,
 		EntryValue: opts.EntryValue,
 	}
 	res, err := t.cli.PutKVEntry(ctx, arg)
@@ -152,7 +159,7 @@ type deleteEntryOptions struct {
 	Team      string `json:"team"`
 	Namespace string `json:"namespace"`
 	EntryKey  string `json:"entryKey"`
-	Revision  int    `json:"revision"`
+	Revision  *int   `json:"revision"`
 }
 
 func (a *deleteEntryOptions) Check() error {
@@ -165,6 +172,9 @@ func (a *deleteEntryOptions) Check() error {
 	if len(a.EntryKey) == 0 {
 		return errors.New("`entryKey` field required")
 	}
+	if a.Revision != nil && *a.Revision <= 0 {
+		return errors.New("if setting optional `revision` field, it needs to be a positive integer")
+	}
 	return nil
 }
 
@@ -173,12 +183,16 @@ func (t *kvStoreAPIHandler) deleteEntry(ctx context.Context, c Call, w io.Writer
 	if err := unmarshalOptions(c, &opts); err != nil {
 		return t.encodeErr(c, err, w)
 	}
+	var revision int
+	if opts.Revision != nil {
+		revision = *opts.Revision
+	}
 	arg := keybase1.DelKVEntryArg{
 		SessionID: 0,
 		TeamName:  opts.Team,
 		Namespace: opts.Namespace,
 		EntryKey:  opts.EntryKey,
-		Revision:  opts.Revision,
+		Revision:  revision,
 	}
 	res, err := t.cli.DelKVEntry(ctx, arg)
 	if err != nil {

--- a/go/kvstore/cache.go
+++ b/go/kvstore/cache.go
@@ -10,7 +10,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-const DELETED_OR_NONEXISTENT = ""
+const DeletedOrNonExistent = ""
 
 var _ libkb.KVRevisionCacher = (*KVRevisionCache)(nil)
 
@@ -47,8 +47,8 @@ func (e KVRevisionCacheError) Error() string {
 // Hash is a sha256 on the input string. If the string is empty, then Hash will also be an
 // empty string for tracking deleted entries in perpetuity.
 func (k *KVRevisionCache) hash(ciphertext *string) string {
-	if ciphertext == nil || len(*ciphertext) == 0 || *ciphertext == DELETED_OR_NONEXISTENT {
-		return DELETED_OR_NONEXISTENT
+	if ciphertext == nil || len(*ciphertext) == 0 || *ciphertext == DeletedOrNonExistent {
+		return DeletedOrNonExistent
 	}
 	b := sha256.Sum256([]byte(*ciphertext))
 	return hex.EncodeToString(b[:])
@@ -106,49 +106,44 @@ func (k *KVRevisionCache) Put(mctx libkb.MetaContext, entryID keybase1.KVEntryID
 	return nil
 }
 
-func (k *KVRevisionCache) checkDeletableLocked(mctx libkb.MetaContext, entryID keybase1.KVEntryID, revision int) (err error) {
+func (k *KVRevisionCache) checkForUpdateLocked(mctx libkb.MetaContext, entryID keybase1.KVEntryID, revision int) (err error) {
 	k.ensureIntermediateLocked(entryID)
 
 	entry, ok := k.data[entryID.TeamID][entryID.Namespace][entryID.EntryKey]
 	if !ok {
-		// this should never happen
-		return KVRevisionCacheError{fmt.Sprintf("cache is corrupted - please restart")}
+		// this entry didn't exist in the cache, so there's nothing to check
+		return nil
 	}
-	entryHash := DELETED_OR_NONEXISTENT
-	if revision < entry.Revision {
-		return KVRevisionCacheError{fmt.Sprintf("cache error: revision decreased from %d to %d", entry.Revision, revision)}
-	}
-	if revision == entry.Revision {
-		if entryHash != entry.EntryHash {
-			return KVRevisionCacheError{fmt.Sprintf("cache error: at the same revision (%d) hash of entry cannot be different: %s -> %s", revision, entry.EntryHash, entryHash)}
-		}
+	if revision <= entry.Revision {
+		return KVRevisionCacheError{fmt.Sprintf("expected revision greater than %d", entry.Revision)}
 	}
 	return nil
 }
 
-func (k *KVRevisionCache) CheckDeletable(mctx libkb.MetaContext, entryID keybase1.KVEntryID, revision int) (err error) {
+func (k *KVRevisionCache) CheckForUpdate(mctx libkb.MetaContext, entryID keybase1.KVEntryID, revision int) (err error) {
 	k.Lock()
 	defer k.Unlock()
 
-	return k.checkDeletableLocked(mctx, entryID, revision)
+	return k.checkForUpdateLocked(mctx, entryID, revision)
 }
 
 func (k *KVRevisionCache) MarkDeleted(mctx libkb.MetaContext, entryID keybase1.KVEntryID, revision int) (err error) {
 	k.Lock()
 	defer k.Unlock()
 
-	err = k.checkDeletableLocked(mctx, entryID, revision)
+	err = k.checkForUpdateLocked(mctx, entryID, revision)
 	if err != nil {
 		return err
 	}
 	existingEntry, ok := k.data[entryID.TeamID][entryID.Namespace][entryID.EntryKey]
 	if !ok {
-		// this should never happen
-		return KVRevisionCacheError{fmt.Sprintf("cache is corrupted - please restart")}
+		// deleting an entry that's not been seen yet by the cache.
+		// being explicit here that it's ok to use an empty entry
+		existingEntry = kvCacheEntry{}
 	}
 	newEntry := kvCacheEntry{
-		EntryHash:  DELETED_OR_NONEXISTENT,
-		TeamKeyGen: existingEntry.TeamKeyGen, // nothing gets encrypted here, so this should just roll forward
+		EntryHash:  DeletedOrNonExistent,
+		TeamKeyGen: existingEntry.TeamKeyGen, // nothing gets encrypted here, so this should just roll forward or default to 0
 		Revision:   revision,
 	}
 	k.data[entryID.TeamID][entryID.Namespace][entryID.EntryKey] = newEntry

--- a/go/kvstore/cache.go
+++ b/go/kvstore/cache.go
@@ -107,10 +107,7 @@ func (k *KVRevisionCache) checkForUpdateLocked(mctx libkb.MetaContext, entryID k
 		return nil
 	}
 	if revision <= entry.Revision {
-		return KVRevisionError{
-			Source:  RevisionErrorSourceCACHE,
-			Message: fmt.Sprintf("expected revision greater than %d", entry.Revision),
-		}
+		return NewKVRevisionError("" /* use the default out-of-date message */)
 	}
 	return nil
 }

--- a/go/kvstore/errors.go
+++ b/go/kvstore/errors.go
@@ -1,0 +1,25 @@
+package kvstore
+
+type KVCacheError struct {
+	Message string
+}
+
+func (e KVCacheError) Error() string {
+	return e.Message
+}
+
+type RevisionErrorSource int
+
+const (
+	RevisionErrorSourceSERVER RevisionErrorSource = 0
+	RevisionErrorSourceCACHE  RevisionErrorSource = 1
+)
+
+type KVRevisionError struct {
+	Source  RevisionErrorSource
+	Message string
+}
+
+func (e KVRevisionError) Error() string {
+	return e.Message
+}

--- a/go/kvstore/errors.go
+++ b/go/kvstore/errors.go
@@ -1,5 +1,7 @@
 package kvstore
 
+import "github.com/keybase/client/go/libkb"
+
 type KVCacheError struct {
 	Message string
 }
@@ -8,18 +10,13 @@ func (e KVCacheError) Error() string {
 	return e.Message
 }
 
-type RevisionErrorSource int
-
-const (
-	RevisionErrorSourceSERVER RevisionErrorSource = 0
-	RevisionErrorSourceCACHE  RevisionErrorSource = 1
-)
-
-type KVRevisionError struct {
-	Source  RevisionErrorSource
-	Message string
-}
-
-func (e KVRevisionError) Error() string {
-	return e.Message
+func NewKVRevisionError(msg string) error {
+	if msg == "" {
+		msg = "revision out of date"
+	}
+	return libkb.AppStatusError{
+		Code: libkb.SCTeamStorageWrongRevision,
+		Name: "KVTeamStorageWrongRevision",
+		Desc: msg,
+	}
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -1124,6 +1124,6 @@ type SyncedContactListProvider interface {
 type KVRevisionCacher interface {
 	Check(mctx MetaContext, entryID keybase1.KVEntryID, ciphertext *string, teamKeyGen keybase1.PerTeamKeyGeneration, revision int) (err error)
 	Put(mctx MetaContext, entryID keybase1.KVEntryID, ciphertext *string, teamKeyGen keybase1.PerTeamKeyGeneration, revision int) (err error)
-	CheckDeletable(mctx MetaContext, entryID keybase1.KVEntryID, revision int) (err error)
+	CheckForUpdate(mctx MetaContext, entryID keybase1.KVEntryID, revision int) (err error)
 	MarkDeleted(mctx MetaContext, entryID keybase1.KVEntryID, revision int) (err error)
 }

--- a/go/protocol/keybase1/kvstore.go
+++ b/go/protocol/keybase1/kvstore.go
@@ -167,6 +167,7 @@ type PutKVEntryArg struct {
 	TeamName   string `codec:"teamName" json:"teamName"`
 	Namespace  string `codec:"namespace" json:"namespace"`
 	EntryKey   string `codec:"entryKey" json:"entryKey"`
+	Revision   int    `codec:"revision" json:"revision"`
 	EntryValue string `codec:"entryValue" json:"entryValue"`
 }
 
@@ -186,6 +187,7 @@ type DelKVEntryArg struct {
 	TeamName  string `codec:"teamName" json:"teamName"`
 	Namespace string `codec:"namespace" json:"namespace"`
 	EntryKey  string `codec:"entryKey" json:"entryKey"`
+	Revision  int    `codec:"revision" json:"revision"`
 }
 
 type KvstoreInterface interface {

--- a/go/service/kvstore.go
+++ b/go/service/kvstore.go
@@ -226,6 +226,13 @@ func (h *KVStoreHandler) PutKVEntry(ctx context.Context, arg keybase1.PutKVEntry
 	var apiRes putEntryAPIRes
 	err = mctx.G().API.PostDecode(mctx, apiArg, &apiRes)
 	if err != nil {
+		aerr, ok := err.(libkb.AppStatusError)
+		if ok && aerr.Code == libkb.SCTeamStorageWrongRevision {
+			err = kvstore.KVRevisionError{
+				Source:  kvstore.RevisionErrorSourceSERVER,
+				Message: aerr.Error(),
+			}
+		}
 		mctx.Debug("error posting update for %+v to the server: %v", entryID, err)
 		return res, err
 	}

--- a/protocol/avdl/keybase1/kvstore.avdl
+++ b/protocol/avdl/keybase1/kvstore.avdl
@@ -32,8 +32,7 @@ protocol kvstore {
   }
 
   KVGetResult getKVEntry(int sessionID, string teamName, string namespace, string entryKey);
-  KVPutResult putKVEntry(int sessionID, string teamName, string namespace, string entryKey, string entryValue);
-
+  KVPutResult putKVEntry(int sessionID, string teamName, string namespace, string entryKey, int revision, string entryValue);
 
   record KVListNamespaceResult {
     string teamName;
@@ -62,5 +61,5 @@ protocol kvstore {
     int revision; // this is the revision at which the entry was deleted, and a future GET will have
   }
 
-  KVDeleteEntryResult delKVEntry(int sessionID, string teamName, string namespace, string entryKey);
+  KVDeleteEntryResult delKVEntry(int sessionID, string teamName, string namespace, string entryKey, int revision);
 }

--- a/protocol/json/keybase1/kvstore.json
+++ b/protocol/json/keybase1/kvstore.json
@@ -207,6 +207,10 @@
           "type": "string"
         },
         {
+          "name": "revision",
+          "type": "int"
+        },
+        {
           "name": "entryValue",
           "type": "string"
         }
@@ -260,6 +264,10 @@
         {
           "name": "entryKey",
           "type": "string"
+        },
+        {
+          "name": "revision",
+          "type": "int"
         }
       ],
       "response": "KVDeleteEntryResult"


### PR DESCRIPTION
* on `put` and `delete`, add the ability to specify a desired revision which enable custom concurrency logic across users/devices. 
* add a test that shows we have the right behavior under a data race caused by multiple simultaneous updates

also made a little related change to the server: https://github.com/keybase/keybase/pull/4603