### PR TITLE
HOTPOT-1022: show extended description for multiword bot commands

### DIFF
--- a/go/chat/commands/bot.go
+++ b/go/chat/commands/bot.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"sync"
 
@@ -67,9 +68,18 @@ func (b *Bot) Preview(ctx context.Context, uid gregor1.UID, convID chat1.Convers
 		return
 	}
 
+	// sort commands by reverse command length to prefer specificity
+	// (i.e. if there's a longer command that matches the prefix, show the help text for that one)
+	sort.SliceStable(cmds, func(i, j int) bool {
+		l := cmds[i]
+		r := cmds[j]
+		return len(l.Name) > len(r.Name)
+	})
+
 	// Since we have a list of all valid commands for this conversation, don't do any tokenizing
-	// We can just check if any valid bot command (followed by a space) is a prefix of this message
+	// Instead, just check if any valid bot command (followed by a space) is a prefix of this message
 	for _, cmd := range cmds {
+		// If we decide to support the !<command>@<username> syntax, we can just add another check here
 		if strings.HasPrefix(text, "!"+cmd.Name+" ") && cmd.ExtendedDescription != nil {
 			var body string
 			if b.G().IsMobileAppType() {

--- a/go/chat/commands/bot.go
+++ b/go/chat/commands/bot.go
@@ -67,15 +67,10 @@ func (b *Bot) Preview(ctx context.Context, uid gregor1.UID, convID chat1.Convers
 		return
 	}
 
-	cmdText, _, err := b.commandAndMessage(text)
-	if err != nil {
-		b.Debug(ctx, "Preview: no command text found: %s", err)
-		b.clearExtendedDisplayLocked(ctx, convID)
-		return
-	}
-	cmdText = cmdText[1:]
+	// Since we have a list of all valid commands for this conversation, don't do any tokenizing
+	// We can just check if any valid bot command (followed by a space) is a prefix of this message
 	for _, cmd := range cmds {
-		if cmdText == cmd.Name && cmd.ExtendedDescription != nil {
+		if strings.HasPrefix(text, "!"+cmd.Name+" ") && cmd.ExtendedDescription != nil {
 			var body string
 			if b.G().IsMobileAppType() {
 				body = cmd.ExtendedDescription.MobileBody

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -132,7 +132,7 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
         }
         const upToCursor = text.substring(0, selection.start)
         // this regex is a fancy way to say "split on command separators or newlines, but include the separators in the result"
-        const words = upToCursor.split(/ (?=\@|\!|\#|\n)/)
+        const words = upToCursor.split(/ (?=@|!|#|\n)/)
         const word = words[words.length - 1]
         const position = {end: selection.start, start: selection.start - word.length}
         return {position, word}

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -131,7 +131,8 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
           return null
         }
         const upToCursor = text.substring(0, selection.start)
-        const words = upToCursor.split(/ |\n/)
+        // this regex is a fancy way to say "split on command separators or newlines, but include the separators in the result"
+        const words = upToCursor.split(/ (?=\@|\!|\#|\n)/)
         const word = words[words.length - 1]
         const position = {end: selection.start, start: selection.start - word.length}
         return {position, word}


### PR DESCRIPTION
This PR does two things to fix some issues with multiword bot commands (e.g. `!remind me`):

* changes the `getWordAtCursor` function for input areas so instead of splitting by spaces, it splits by marker separators (@, !, #). This makes the behavior of the input area less buggy. 
* changes how bot command previewing parses commands. Instead of splitting by spaces and checking the first word against the list of commands, it now just checks if the message has the prefix of a valid bot command followed by a space. If there are multiple commands that match, we pick the longest one (so `!remind me` would show help text for `!remind me` instead of `!remind`).