### PR TITLE
Journey card changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -482,6 +482,7 @@ def testGo(prefix, packagesToTest) {
     println "Installing golangci-lint"
     dir("..") {
       retry(5) {
+        // This works with go1.12.12 but not go1.13.1 with an error containing "invalid pseudo-version"
         sh 'GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.16.0'
       }
     }

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -7,6 +7,7 @@ linters-settings:
     disabled-checks:
       - ifElseChain
       - elseif
+      - singleCaseSwitch
 
 linters:
   enable:

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -7,7 +7,6 @@ linters-settings:
     disabled-checks:
       - ifElseChain
       - elseif
-      - singleCaseSwitch
 
 linters:
   enable:

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -97,14 +97,12 @@ func (s *baseConversationSource) addConversationCards(ctx context.Context, uid g
 		s.Debug(ctx, "error getting next conversation card: %s", err)
 		return
 	}
-
 	if card == nil {
 		s.Debug(ctx, "card is nil")
 		return
 	}
-
 	s.Debug(ctx, "got a card for this conversation: %+v", card)
-	thread.Messages = append(thread.Messages, chat1.NewMessageUnboxedWithJourneycard(*card))
+	thread.Messages = append([]chat1.MessageUnboxed{chat1.NewMessageUnboxedWithJourneycard(*card)}, thread.Messages...)
 }
 
 func (s *baseConversationSource) postProcessThread(ctx context.Context, uid gregor1.UID,

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -94,14 +94,13 @@ func (s *baseConversationSource) addConversationCards(ctx context.Context, uid g
 	cc := newJourneyCardChecker(s.G())
 	card, err := cc.Next(ctx, uid, conv, thread)
 	if err != nil {
-		s.Debug(ctx, "error getting next conversation card: %s", err)
+		s.Debug(ctx, "addConversationCards: error getting next conversation card: %s", err)
 		return
 	}
 	if card == nil {
-		s.Debug(ctx, "card is nil")
 		return
 	}
-	s.Debug(ctx, "got a card for this conversation: %+v", card)
+	s.Debug(ctx, "addConversationCards: got a card: %+v", card)
 	thread.Messages = append([]chat1.MessageUnboxed{chat1.NewMessageUnboxedWithJourneycard(*card)}, thread.Messages...)
 }
 

--- a/go/chat/journey_card_checker.go
+++ b/go/chat/journey_card_checker.go
@@ -81,7 +81,7 @@ func (cc *journeyCardChecker) Next(ctx context.Context, uid gregor1.UID, conv *c
 
 	makeCard := func(cardType chat1.JourneycardType, highlightMsgID chat1.MessageID) (*chat1.MessageUnboxedJourneycard, error) {
 		return &chat1.MessageUnboxedJourneycard{
-			PrevID:         chat1.MessageID(prevID),
+			PrevID:         prevID,
 			Ordinal:        ordinal,
 			CardType:       cardType,
 			HighlightMsgID: highlightMsgID,

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1354,7 +1354,16 @@ func PresentThreadView(ctx context.Context, g *globals.Context, uid gregor1.UID,
 }
 
 func computeOutboxOrdinal(obr chat1.OutboxRecord) float64 {
-	return float64(obr.Msg.ClientHeader.OutboxInfo.Prev) + float64(obr.Ordinal)/1000.0
+	return computeOrdinal(obr.Msg.ClientHeader.OutboxInfo.Prev, obr.Ordinal)
+}
+
+// Compute an "ordinal". There are two senses of "ordinal".
+// The service considers ordinals ints, like 3, which are the offset after some message ID.
+// The frontend considers ordinals floats like "180.03" where before the dot is
+// a message ID, and after the dot is a sub-position in thousandths.
+// This function translates from the service's sense to the frontend's sense.
+func computeOrdinal(messageID chat1.MessageID, serviceOrdinal int) (frontendOrdinal float64) {
+	return float64(messageID) + float64(serviceOrdinal)/1000.0
 }
 
 func PresentChannelNameMentions(ctx context.Context, crs []chat1.ChannelNameMention) (res []chat1.UIChannelNameMention) {
@@ -1786,6 +1795,16 @@ func PresentMessageUnboxed(ctx context.Context, g *globals.Context, rawMsg chat1
 		res = chat1.NewUIMessageWithError(rawMsg.Error())
 	case chat1.MessageUnboxedState_PLACEHOLDER:
 		res = chat1.NewUIMessageWithPlaceholder(rawMsg.Placeholder())
+	case chat1.MessageUnboxedState_JOURNEYCARD:
+		journeycard := rawMsg.Journeycard()
+		res = chat1.NewUIMessageWithJourneycard(chat1.UIMessageJourneycard{
+			Ordinal:        computeOrdinal(journeycard.PrevID, journeycard.Ordinal),
+			CardType:       journeycard.CardType,
+			HighlightMsgID: journeycard.HighlightMsgID,
+		})
+	default:
+		g.MetaContext(ctx).Debug("PresentMessageUnboxed: unhandled MessageUnboxedState: %v", state)
+		// res = zero values
 	}
 	return res
 }

--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -493,21 +493,6 @@ func (c *chatServiceHandler) formatMessages(ctx context.Context, messages []chat
 			continue
 		}
 
-		if st == chat1.MessageUnboxedState_JOURNEYCARD {
-			mc := m.Journeycard()
-			ret = append(ret, chat1.Message{
-				Msg: &chat1.MsgSummary{
-					Content: chat1.MsgContent{
-						TypeName: chat1.MessageUnboxedJourneyCardTypeRevMap[mc.CardType],
-						Text: &chat1.MessageText{
-							Body: mc.Data,
-						},
-					},
-				},
-			})
-			continue
-		}
-
 		// skip any PLACEHOLDER or OUTBOX messages
 		if st != chat1.MessageUnboxedState_VALID {
 			continue

--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -117,6 +117,9 @@ func (p CommandLine) GetDebug() (bool, bool) {
 	}
 	return p.GetBool("debug", true)
 }
+func (p CommandLine) GetDebugJourneycard() (bool, bool) {
+	return p.GetBool("debug-journeycard", true)
+}
 func (p CommandLine) GetDisplayRawUntrustedOutput() (bool, bool) {
 	return p.GetBool("display-raw-untrusted-output", true)
 }
@@ -744,6 +747,10 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.StringFlag{
 			Name:  "vdebug",
 			Usage: "Verbose debugging; takes a comma-joined list of levels and tags",
+		},
+		cli.BoolFlag{
+			Name:  "debug-journeycard",
+			Usage: "Enable experimental journey cards",
 		},
 		cli.BoolFlag{
 			Name:  "disable-team-auditor",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -24,6 +24,8 @@ type JSONConfigFile struct {
 	userConfigWrapper *UserConfigWrapper
 }
 
+var _ (ConfigReader) = (*JSONConfigFile)(nil)
+
 func NewJSONConfigFile(g *GlobalContext, s string) *JSONConfigFile {
 	return &JSONConfigFile{NewJSONFile(g, s, "config"), &UserConfigWrapper{}}
 }
@@ -568,6 +570,9 @@ func (f *JSONConfigFile) IsCertPinningEnabled() bool {
 }
 func (f *JSONConfigFile) GetDebug() (bool, bool) {
 	return f.GetTopLevelBool("debug")
+}
+func (f *JSONConfigFile) GetDebugJourneycard() (bool, bool) {
+	return f.GetTopLevelBool("debug_journeycard")
 }
 func (f *JSONConfigFile) GetDisplayRawUntrustedOutput() (bool, bool) {
 	return f.GetTopLevelBool("display_raw_untrusted_output")

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -155,9 +155,8 @@ func (n NullConfiguration) GetAllUserConfigs() (*UserConfig, []UserConfig, error
 	return nil, nil, nil
 }
 
-func (n NullConfiguration) GetDebug() (bool, bool) {
-	return false, false
-}
+func (n NullConfiguration) GetDebug() (bool, bool)            { return false, false }
+func (n NullConfiguration) GetDebugJourneycard() (bool, bool) { return false, false }
 func (n NullConfiguration) GetDisplayRawUntrustedOutput() (bool, bool) {
 	return false, false
 }
@@ -816,6 +815,14 @@ func (e *Env) GetProveBypass() bool {
 		func() (bool, bool) { return e.cmd.GetProveBypass() },
 		func() (bool, bool) { return e.getEnvBool("KEYBASE_PROVE_BYPASS") },
 		func() (bool, bool) { return e.GetConfig().GetProveBypass() })
+}
+
+// GetDebugJourneycard enables experimental chat journey cards.
+func (e *Env) GetDebugJourneycard() bool {
+	return e.GetBool(false,
+		func() (bool, bool) { return e.cmd.GetDebugJourneycard() },
+		func() (bool, bool) { return e.getEnvBool("KEYBASE_DEBUG_JOURNEYCARD") },
+		func() (bool, bool) { return e.GetConfig().GetDebugJourneycard() })
 }
 
 func (e *Env) GetDebug() bool {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -46,6 +46,7 @@ type configGetter interface {
 	GetConfigFilename() string
 	GetDbFilename() string
 	GetDebug() (bool, bool)
+	GetDebugJourneycard() (bool, bool)
 	GetDisplayRawUntrustedOutput() (bool, bool)
 	GetGpg() string
 	GetGpgHome() string

--- a/go/protocol/chat1/chat_ui.go
+++ b/go/protocol/chat1/chat_ui.go
@@ -1104,6 +1104,20 @@ func (o UIMessageOutbox) DeepCopy() UIMessageOutbox {
 	}
 }
 
+type UIMessageJourneycard struct {
+	Ordinal        float64         `codec:"ordinal" json:"ordinal"`
+	CardType       JourneycardType `codec:"cardType" json:"cardType"`
+	HighlightMsgID MessageID       `codec:"highlightMsgID" json:"highlightMsgID"`
+}
+
+func (o UIMessageJourneycard) DeepCopy() UIMessageJourneycard {
+	return UIMessageJourneycard{
+		Ordinal:        o.Ordinal,
+		CardType:       o.CardType.DeepCopy(),
+		HighlightMsgID: o.HighlightMsgID.DeepCopy(),
+	}
+}
+
 type MessageUnboxedState int
 
 const (
@@ -1145,7 +1159,7 @@ type UIMessage struct {
 	Error__       *MessageUnboxedError       `codec:"error,omitempty" json:"error,omitempty"`
 	Outbox__      *UIMessageOutbox           `codec:"outbox,omitempty" json:"outbox,omitempty"`
 	Placeholder__ *MessageUnboxedPlaceholder `codec:"placeholder,omitempty" json:"placeholder,omitempty"`
-	Journeycard__ *MessageUnboxedJourneyCard `codec:"journeycard,omitempty" json:"journeycard,omitempty"`
+	Journeycard__ *UIMessageJourneycard      `codec:"journeycard,omitempty" json:"journeycard,omitempty"`
 }
 
 func (o *UIMessage) State() (ret MessageUnboxedState, err error) {
@@ -1219,7 +1233,7 @@ func (o UIMessage) Placeholder() (res MessageUnboxedPlaceholder) {
 	return *o.Placeholder__
 }
 
-func (o UIMessage) Journeycard() (res MessageUnboxedJourneyCard) {
+func (o UIMessage) Journeycard() (res UIMessageJourneycard) {
 	if o.State__ != MessageUnboxedState_JOURNEYCARD {
 		panic("wrong case accessed")
 	}
@@ -1257,7 +1271,7 @@ func NewUIMessageWithPlaceholder(v MessageUnboxedPlaceholder) UIMessage {
 	}
 }
 
-func NewUIMessageWithJourneycard(v MessageUnboxedJourneyCard) UIMessage {
+func NewUIMessageWithJourneycard(v UIMessageJourneycard) UIMessage {
 	return UIMessage{
 		State__:       MessageUnboxedState_JOURNEYCARD,
 		Journeycard__: &v,
@@ -1295,7 +1309,7 @@ func (o UIMessage) DeepCopy() UIMessage {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Placeholder__),
-		Journeycard__: (func(x *MessageUnboxedJourneyCard) *MessageUnboxedJourneyCard {
+		Journeycard__: (func(x *UIMessageJourneycard) *UIMessageJourneycard {
 			if x == nil {
 				return nil
 			}

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -3029,22 +3029,22 @@ func (o MessageUnboxedPlaceholder) DeepCopy() MessageUnboxedPlaceholder {
 	}
 }
 
-type MessageUnboxedJourneyCardType int
+type JourneycardType int
 
 const (
-	MessageUnboxedJourneyCardType_WELCOME            MessageUnboxedJourneyCardType = 0
-	MessageUnboxedJourneyCardType_POPULAR_CHANNELS   MessageUnboxedJourneyCardType = 1
-	MessageUnboxedJourneyCardType_ADD_PEOPLE         MessageUnboxedJourneyCardType = 2
-	MessageUnboxedJourneyCardType_CREATE_CHANNELS    MessageUnboxedJourneyCardType = 3
-	MessageUnboxedJourneyCardType_MSG_ATTENTION      MessageUnboxedJourneyCardType = 4
-	MessageUnboxedJourneyCardType_USER_AWAY_FOR_LONG MessageUnboxedJourneyCardType = 5
-	MessageUnboxedJourneyCardType_CHANNEL_INACTIVE   MessageUnboxedJourneyCardType = 6
-	MessageUnboxedJourneyCardType_MSG_NO_ANSWER      MessageUnboxedJourneyCardType = 7
+	JourneycardType_WELCOME            JourneycardType = 0
+	JourneycardType_POPULAR_CHANNELS   JourneycardType = 1
+	JourneycardType_ADD_PEOPLE         JourneycardType = 2
+	JourneycardType_CREATE_CHANNELS    JourneycardType = 3
+	JourneycardType_MSG_ATTENTION      JourneycardType = 4
+	JourneycardType_USER_AWAY_FOR_LONG JourneycardType = 5
+	JourneycardType_CHANNEL_INACTIVE   JourneycardType = 6
+	JourneycardType_MSG_NO_ANSWER      JourneycardType = 7
 )
 
-func (o MessageUnboxedJourneyCardType) DeepCopy() MessageUnboxedJourneyCardType { return o }
+func (o JourneycardType) DeepCopy() JourneycardType { return o }
 
-var MessageUnboxedJourneyCardTypeMap = map[string]MessageUnboxedJourneyCardType{
+var JourneycardTypeMap = map[string]JourneycardType{
 	"WELCOME":            0,
 	"POPULAR_CHANNELS":   1,
 	"ADD_PEOPLE":         2,
@@ -3055,7 +3055,7 @@ var MessageUnboxedJourneyCardTypeMap = map[string]MessageUnboxedJourneyCardType{
 	"MSG_NO_ANSWER":      7,
 }
 
-var MessageUnboxedJourneyCardTypeRevMap = map[MessageUnboxedJourneyCardType]string{
+var JourneycardTypeRevMap = map[JourneycardType]string{
 	0: "WELCOME",
 	1: "POPULAR_CHANNELS",
 	2: "ADD_PEOPLE",
@@ -3066,22 +3066,26 @@ var MessageUnboxedJourneyCardTypeRevMap = map[MessageUnboxedJourneyCardType]stri
 	7: "MSG_NO_ANSWER",
 }
 
-func (e MessageUnboxedJourneyCardType) String() string {
-	if v, ok := MessageUnboxedJourneyCardTypeRevMap[e]; ok {
+func (e JourneycardType) String() string {
+	if v, ok := JourneycardTypeRevMap[e]; ok {
 		return v
 	}
 	return fmt.Sprintf("%v", int(e))
 }
 
-type MessageUnboxedJourneyCard struct {
-	CardType MessageUnboxedJourneyCardType `codec:"cardType" json:"cardType"`
-	Data     string                        `codec:"data" json:"data"`
+type MessageUnboxedJourneycard struct {
+	PrevID         MessageID       `codec:"prevID" json:"prevID"`
+	Ordinal        int             `codec:"ordinal" json:"ordinal"`
+	CardType       JourneycardType `codec:"cardType" json:"cardType"`
+	HighlightMsgID MessageID       `codec:"highlightMsgID" json:"highlightMsgID"`
 }
 
-func (o MessageUnboxedJourneyCard) DeepCopy() MessageUnboxedJourneyCard {
-	return MessageUnboxedJourneyCard{
-		CardType: o.CardType.DeepCopy(),
-		Data:     o.Data,
+func (o MessageUnboxedJourneycard) DeepCopy() MessageUnboxedJourneycard {
+	return MessageUnboxedJourneycard{
+		PrevID:         o.PrevID.DeepCopy(),
+		Ordinal:        o.Ordinal,
+		CardType:       o.CardType.DeepCopy(),
+		HighlightMsgID: o.HighlightMsgID.DeepCopy(),
 	}
 }
 
@@ -3091,7 +3095,7 @@ type MessageUnboxed struct {
 	Error__       *MessageUnboxedError       `codec:"error,omitempty" json:"error,omitempty"`
 	Outbox__      *OutboxRecord              `codec:"outbox,omitempty" json:"outbox,omitempty"`
 	Placeholder__ *MessageUnboxedPlaceholder `codec:"placeholder,omitempty" json:"placeholder,omitempty"`
-	Journeycard__ *MessageUnboxedJourneyCard `codec:"journeycard,omitempty" json:"journeycard,omitempty"`
+	Journeycard__ *MessageUnboxedJourneycard `codec:"journeycard,omitempty" json:"journeycard,omitempty"`
 }
 
 func (o *MessageUnboxed) State() (ret MessageUnboxedState, err error) {
@@ -3165,7 +3169,7 @@ func (o MessageUnboxed) Placeholder() (res MessageUnboxedPlaceholder) {
 	return *o.Placeholder__
 }
 
-func (o MessageUnboxed) Journeycard() (res MessageUnboxedJourneyCard) {
+func (o MessageUnboxed) Journeycard() (res MessageUnboxedJourneycard) {
 	if o.State__ != MessageUnboxedState_JOURNEYCARD {
 		panic("wrong case accessed")
 	}
@@ -3203,7 +3207,7 @@ func NewMessageUnboxedWithPlaceholder(v MessageUnboxedPlaceholder) MessageUnboxe
 	}
 }
 
-func NewMessageUnboxedWithJourneycard(v MessageUnboxedJourneyCard) MessageUnboxed {
+func NewMessageUnboxedWithJourneycard(v MessageUnboxedJourneycard) MessageUnboxed {
 	return MessageUnboxed{
 		State__:       MessageUnboxedState_JOURNEYCARD,
 		Journeycard__: &v,
@@ -3241,7 +3245,7 @@ func (o MessageUnboxed) DeepCopy() MessageUnboxed {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Placeholder__),
-		Journeycard__: (func(x *MessageUnboxedJourneyCard) *MessageUnboxedJourneyCard {
+		Journeycard__: (func(x *MessageUnboxedJourneycard) *MessageUnboxedJourneycard {
 			if x == nil {
 				return nil
 			}

--- a/go/service/debugging.go
+++ b/go/service/debugging.go
@@ -26,6 +26,8 @@ func NewDebuggingHandler(xp rpc.Transporter, g *libkb.GlobalContext, userHandler
 	}
 }
 
+// See debugging_{devel,production}.go for additional handlers.
+
 func (t *DebuggingHandler) FirstStep(ctx context.Context, arg keybase1.FirstStepArg) (result keybase1.FirstStepResult, err error) {
 	client := t.rpcClient()
 	cbArg := keybase1.SecondStepArg{Val: arg.Val + 1, SessionID: arg.SessionID}

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -361,9 +361,9 @@ protocol chatUi {
   void chatAttachmentDownloadProgress(int sessionID, long bytesComplete, long bytesTotal) oneway;
   void chatAttachmentDownloadDone(int sessionID);
 
-  void chatInboxLayout(int sessionID, string layout);
-  void chatInboxUnverified(int sessionID, string inbox);
-  void chatInboxConversation(int sessionID, string convs);
+  void chatInboxLayout(int sessionID, string layout); // layout is JSON of UIInboxLayout
+  void chatInboxUnverified(int sessionID, string inbox); // inbox is JSON of array<UnverifiedInboxUIItems>
+  void chatInboxConversation(int sessionID, string convs); // convs is JSON of array<InboxUIItem>
   void chatInboxFailed(int sessionID, ConversationID convID, InboxUIItemError error);
 
   enum UIChatThreadStatusTyp {
@@ -378,7 +378,7 @@ protocol chatUi {
     case VALIDATING: int;
     case VALIDATED: void;
   }
-  void chatThreadCached(int sessionID, union { null, string } thread);
+  void chatThreadCached(int sessionID, union { null, string } thread); // thread is JSON of UIMessages
   void chatThreadFull(int sessionID, string thread);
   void chatThreadStatus(int sessionID, UIChatThreadStatus status);
 

--- a/protocol/avdl/chat1/chat_ui.avdl
+++ b/protocol/avdl/chat1/chat_ui.avdl
@@ -288,6 +288,12 @@ protocol chatUi {
     union { null, MakePreviewRes } preview;
   }
 
+  record UIMessageJourneycard {
+    double ordinal; // Position in conversation. A float like {msgID:4,offset:1} -> "4.001"
+    JourneycardType cardType;
+    MessageID highlightMsgID; // Message ID to highlight in MSG_ATTENTION
+  }
+
   enum MessageUnboxedState {
     VALID_1,
     ERROR_2,
@@ -301,7 +307,7 @@ protocol chatUi {
     case ERROR: MessageUnboxedError;
     case OUTBOX: UIMessageOutbox;
     case PLACEHOLDER: MessageUnboxedPlaceholder;
-    case JOURNEYCARD: MessageUnboxedJourneyCard;
+    case JOURNEYCARD: UIMessageJourneycard;
   }
 
   record UIMessages {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -522,7 +522,7 @@ protocol local {
     boolean hidden;
   }
 
-  enum MessageUnboxedJourneyCardType {
+  enum JourneycardType {
     WELCOME_0,
     POPULAR_CHANNELS_1,
     ADD_PEOPLE_2,
@@ -533,18 +533,22 @@ protocol local {
     MSG_NO_ANSWER_7
   }
 
-  record MessageUnboxedJourneyCard {
-    MessageUnboxedJourneyCardType cardType;
-    string data;
+  record MessageUnboxedJourneycard {
+    MessageID prevID; // ID of the message after which this card appears.
+    int ordinal; // sub-position after prevID. Ought to be >=1. See computeOutboxOrdinal for some context.
+    JourneycardType cardType;
+    MessageID highlightMsgID; // Message ID to highlight for MSG_ATTENTION
   }
 
-  // If a new case is needed here, make sure to update UIMessage in chat_ui.avdl as well.
+  // If a new case is needed here, make sure to update at least:
+  // - variant UIMessage in chat_ui.avdl
+  // - func PresentMessageUnboxed
   variant MessageUnboxed switch (MessageUnboxedState state) {
     case VALID: MessageUnboxedValid;
     case ERROR: MessageUnboxedError;
     case OUTBOX: OutboxRecord;
     case PLACEHOLDER: MessageUnboxedPlaceholder;
-    case JOURNEYCARD: MessageUnboxedJourneyCard;
+    case JOURNEYCARD: MessageUnboxedJourneycard;
   }
 
   // This causes fetching to return N items, where N = IdeallyGetUnreadPlus +

--- a/protocol/json/chat1/chat_ui.json
+++ b/protocol/json/chat1/chat_ui.json
@@ -1118,6 +1118,24 @@
       ]
     },
     {
+      "type": "record",
+      "name": "UIMessageJourneycard",
+      "fields": [
+        {
+          "type": "double",
+          "name": "ordinal"
+        },
+        {
+          "type": "JourneycardType",
+          "name": "cardType"
+        },
+        {
+          "type": "MessageID",
+          "name": "highlightMsgID"
+        }
+      ]
+    },
+    {
       "type": "enum",
       "name": "MessageUnboxedState",
       "symbols": [
@@ -1169,7 +1187,7 @@
             "name": "JOURNEYCARD",
             "def": false
           },
-          "body": "MessageUnboxedJourneyCard"
+          "body": "UIMessageJourneycard"
         }
       ]
     },

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -1652,7 +1652,7 @@
     },
     {
       "type": "enum",
-      "name": "MessageUnboxedJourneyCardType",
+      "name": "JourneycardType",
       "symbols": [
         "WELCOME_0",
         "POPULAR_CHANNELS_1",
@@ -1666,15 +1666,23 @@
     },
     {
       "type": "record",
-      "name": "MessageUnboxedJourneyCard",
+      "name": "MessageUnboxedJourneycard",
       "fields": [
         {
-          "type": "MessageUnboxedJourneyCardType",
+          "type": "MessageID",
+          "name": "prevID"
+        },
+        {
+          "type": "int",
+          "name": "ordinal"
+        },
+        {
+          "type": "JourneycardType",
           "name": "cardType"
         },
         {
-          "type": "string",
-          "name": "data"
+          "type": "MessageID",
+          "name": "highlightMsgID"
         }
       ]
     },
@@ -1719,7 +1727,7 @@
             "name": "JOURNEYCARD",
             "def": false
           },
-          "body": "MessageUnboxedJourneyCard"
+          "body": "MessageUnboxedJourneycard"
         }
       ]
     },

--- a/shared/chat/conversation/messages/cards/team-journey.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import * as Kb from '../../../../common-adapters'
+import * as Styles from '../../../../styles'
+import * as Constants from '../../../../constants/chat2'
+import * as Container from '../../../../util/container'
+import * as MessageTypes from '../../../../constants/types/chat2/message'
+import * as I from 'immutable'
+
+type Props = {
+  message: I.RecordOf<MessageTypes._MessageJourneycard>
+}
+
+const TeamJourney = (props: Props) => {
+  const teamname = Container.useSelector(
+    state => Constants.getMeta(state, props.message.conversationIDKey).teamname
+  )
+  return teamname ? (
+    <>
+      <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny">
+        <Kb.Avatar size={32} isTeam={true} teamname={teamname} skipBackground={true} style={styles.avatar} />
+        <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true}>
+          <Kb.Text type="BodySmallBold">{teamname}</Kb.Text>
+          <Kb.Text type="BodyTiny">• System message</Kb.Text>
+        </Kb.Box2>
+      </Kb.Box2>
+      <Kb.Box2 key="content" direction="vertical" fullWidth={true} style={styles.content}>
+        <Kb.Text type="Body">
+          Team card type {Constants.journeyCardTypeToType[props.message.cardType]}
+        </Kb.Text>
+      </Kb.Box2>
+    </>
+  ) : (
+    <Kb.Box2 direction="horizontal" />
+  )
+}
+
+const styles = Styles.styleSheetCreate(
+  () =>
+    ({
+      authorContainer: Styles.platformStyles({
+        common: {
+          alignItems: 'flex-start',
+          alignSelf: 'flex-start',
+          height: Styles.globalMargins.mediumLarge,
+        },
+        isMobile: {marginTop: 8},
+      }),
+      avatar: Styles.platformStyles({
+        isElectron: {
+          marginLeft: Styles.globalMargins.small,
+        },
+        isMobile: {marginLeft: Styles.globalMargins.tiny},
+      }),
+      content: Styles.platformStyles({
+        isElectron: {
+          marginTop: -16,
+          paddingLeft:
+            // Space for below the avatar
+            Styles.globalMargins.tiny + // right margin
+            Styles.globalMargins.small + // left margin
+            Styles.globalMargins.mediumLarge, // avatar
+        },
+        isMobile: {
+          marginTop: -12,
+          paddingBottom: 3,
+          paddingLeft:
+            // Space for below the avatar
+            Styles.globalMargins.tiny + // right margin
+            Styles.globalMargins.tiny + // left margin
+            Styles.globalMargins.mediumLarge, // avatar
+          paddingRight: Styles.globalMargins.tiny,
+        },
+      }),
+    } as const)
+)
+
+export default TeamJourney

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -31,6 +31,7 @@ import SendIndicator from './send-indicator'
 import UnfurlList from './unfurl/unfurl-list/container'
 import UnfurlPromptList from './unfurl/prompt-list/container'
 import CoinFlip from '../coinflip/container'
+import TeamJourney from '../cards/team-journey'
 import {dismiss as dismissKeyboard} from '../../../../util/keyboard'
 import {formatTimeForChat} from '../../../../util/timestamp'
 
@@ -344,7 +345,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       return {
         className: Styles.classNames(
           {
-            'WrapperMessage-author': this.props.showUsername,
+            'WrapperMessage-author': this.props.showUsername || this.props.message.type === 'journeycard',
             'WrapperMessage-centered': this._showCenteredHighlight(),
             'WrapperMessage-decorated': this.props.decorate,
             'WrapperMessage-hoverColor': !this.props.isPendingPayment,
@@ -593,15 +594,19 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
         <LongPressable
           {...this._containerProps()}
           children={[
-            this._authorAndContent([
-              this._messageAndButtons(),
-              this._isEdited(),
-              this._isFailed(),
-              this._unfurlPrompts(),
-              this._unfurlList(),
-              this._coinFlip(),
-              this._reactionsRow(),
-            ]),
+            this.props.message.type === 'journeycard' ? (
+              <TeamJourney message={this.props.message} />
+            ) : (
+              this._authorAndContent([
+                this._messageAndButtons(),
+                this._isEdited(),
+                this._isFailed(),
+                this._unfurlPrompts(),
+                this._unfurlList(),
+                this._coinFlip(),
+                this._reactionsRow(),
+              ])
+            ),
             this._orangeLine(),
             this._sendIndicator(),
           ]}

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -411,6 +411,7 @@ export {
   isPendingPaymentMessage,
   isSpecialMention,
   isVideoAttachment,
+  journeyCardTypeToType,
   makeChatRequestInfo,
   makeMessageAttachment,
   makeMessageDeleted,

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -197,9 +197,9 @@ export const makeMessagePlaceholder = I.Record<MessageTypes._MessagePlaceholder>
 
 export const makeMessageJourneycard = I.Record<MessageTypes._MessageJourneycard>({
   ...makeMessageMinimum,
-  type: 'journeycard',
   cardType: RPCChatTypes.JourneycardType.welcome,
   highlightMsgID: Types.numberToMessageID(0),
+  type: 'journeycard',
 })
 
 export const makeMessageDeleted = I.Record<MessageTypes._MessageDeleted>({
@@ -1075,10 +1075,10 @@ const journeycardUIMessageToMessage = (
   m: RPCChatTypes.UIMessageJourneycard
 ) => {
   return makeMessageJourneycard({
-    conversationIDKey,
-    ordinal: Types.numberToOrdinal(m.ordinal),
     cardType: m.cardType,
+    conversationIDKey,
     highlightMsgID: m.highlightMsgID,
+    ordinal: Types.numberToOrdinal(m.ordinal),
   })
 }
 

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -17,6 +17,7 @@ import {noConversationIDKey} from '../types/chat2/common'
 import logger from '../../logger'
 import {ServiceId} from 'util/platforms'
 import {assertNever} from '../../util/container'
+import invert from 'lodash/invert'
 
 export const getMessageID = (m: RPCChatTypes.UIMessage) => {
   switch (m.state) {
@@ -1068,6 +1069,10 @@ const errorUIMessagetoMessage = (
     ordinal: Types.numberToOrdinal(o.messageID),
     timestamp: o.ctime,
   })
+}
+
+export const journeyCardTypeToType = invert(RPCChatTypes.JourneycardType) as {
+  [K in RPCChatTypes.JourneycardType]: keyof typeof RPCChatTypes.JourneycardType
 }
 
 const journeycardUIMessageToMessage = (

--- a/shared/constants/types/chat2/message.tsx
+++ b/shared/constants/types/chat2/message.tsx
@@ -83,12 +83,20 @@ type _MessageCommonWithDeviceDeletableEditableReactions = {
 
 // Message types have a lot of copy and paste. Originally I had this split out but this
 // causes flow to get confused or makes the error messages a million times harder to understand
+// Possibly as a result, some types have sentinel-valued fields hanging off them.
 
 export type _MessagePlaceholder = {
   type: 'placeholder'
 } & _MessageCommon
 
 export type MessagePlaceholder = I.RecordOf<_MessagePlaceholder>
+
+export type _MessageJourneycard = {
+  type: 'journeycard'
+  cardType: RPCChatTypes.JourneycardType
+  highlightMsgID: MessageID
+} & _MessageCommon
+export type MessageJourneycard = I.RecordOf<_MessageJourneycard>
 
 // We keep deleted messages around so the bookkeeping is simpler
 export type _MessageDeleted = {
@@ -398,6 +406,7 @@ export type Message =
   | MessageText
   | MessagePlaceholder
   | MessagePin
+  | MessageJourneycard
 export type MessageType =
   | 'attachment'
   | 'deleted'
@@ -418,3 +427,4 @@ export type MessageType =
   | 'text'
   | 'placeholder'
   | 'pin'
+  | 'journeycard'

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -681,6 +681,17 @@ export enum InboxResType {
   full = 1,
 }
 
+export enum JourneycardType {
+  welcome = 0,
+  popularChannels = 1,
+  addPeople = 2,
+  createChannels = 3,
+  msgAttention = 4,
+  userAwayForLong = 5,
+  channelInactive = 6,
+  msgNoAnswer = 7,
+}
+
 export enum MessageBoxedVersion {
   vnone = 0,
   v1 = 1,
@@ -737,17 +748,6 @@ export enum MessageUnboxedErrorType {
   identify = 3,
   ephemeral = 4,
   pairwiseMissing = 5,
-}
-
-export enum MessageUnboxedJourneyCardType {
-  welcome = 0,
-  popularChannels = 1,
-  addPeople = 2,
-  createChannels = 3,
-  msgAttention = 4,
-  userAwayForLong = 5,
-  channelInactive = 6,
-  msgNoAnswer = 7,
 }
 
 export enum MessageUnboxedState {
@@ -1133,9 +1133,9 @@ export type MessageSystemGitPush = {readonly team: String; readonly pusher: Stri
 export type MessageSystemInviteAddedToTeam = {readonly team: String; readonly inviter: String; readonly invitee: String; readonly adder: String; readonly inviteType: Keybase1.TeamInviteCategory; readonly role: Keybase1.TeamRole}
 export type MessageSystemSbsResolve = {readonly assertionService: String; readonly assertionUsername: String; readonly prover: String}
 export type MessageText = {readonly body: String; readonly payments?: Array<TextPayment> | null; readonly replyTo?: MessageID | null; readonly replyToUID?: Gregor1.UID | null; readonly userMentions?: Array<KnownUserMention> | null; readonly teamMentions?: Array<KnownTeamMention> | null; readonly liveLocation?: LiveLocation | null}
-export type MessageUnboxed = {state: MessageUnboxedState.valid; valid: MessageUnboxedValid} | {state: MessageUnboxedState.error; error: MessageUnboxedError} | {state: MessageUnboxedState.outbox; outbox: OutboxRecord} | {state: MessageUnboxedState.placeholder; placeholder: MessageUnboxedPlaceholder} | {state: MessageUnboxedState.journeycard; journeycard: MessageUnboxedJourneyCard}
+export type MessageUnboxed = {state: MessageUnboxedState.valid; valid: MessageUnboxedValid} | {state: MessageUnboxedState.error; error: MessageUnboxedError} | {state: MessageUnboxedState.outbox; outbox: OutboxRecord} | {state: MessageUnboxedState.placeholder; placeholder: MessageUnboxedPlaceholder} | {state: MessageUnboxedState.journeycard; journeycard: MessageUnboxedJourneycard}
 export type MessageUnboxedError = {readonly errType: MessageUnboxedErrorType; readonly errMsg: String; readonly internalErrMsg: String; readonly versionKind: VersionKind; readonly versionNumber: Int; readonly isCritical: Boolean; readonly senderUsername: String; readonly senderDeviceName: String; readonly senderDeviceType: String; readonly messageID: MessageID; readonly messageType: MessageType; readonly ctime: Gregor1.Time; readonly isEphemeral: Boolean; readonly isEphemeralExpired: Boolean; readonly etime: Gregor1.Time; readonly botUsername: String}
-export type MessageUnboxedJourneyCard = {readonly cardType: MessageUnboxedJourneyCardType; readonly data: String}
+export type MessageUnboxedJourneycard = {readonly prevID: MessageID; readonly ordinal: Int; readonly cardType: JourneycardType; readonly highlightMsgID: MessageID}
 export type MessageUnboxedPlaceholder = {readonly messageID: MessageID; readonly hidden: Boolean}
 export type MessageUnboxedValid = {readonly clientHeader: MessageClientHeaderVerified; readonly serverHeader: MessageServerHeader; readonly messageBody: MessageBody; readonly senderUsername: String; readonly senderDeviceName: String; readonly senderDeviceType: String; readonly bodyHash: Hash; readonly headerHash: Hash; readonly headerSignature?: SignatureInfo | null; readonly verificationKey?: Bytes | null; readonly senderDeviceRevokedAt?: Gregor1.Time | null; readonly atMentionUsernames?: Array<String> | null; readonly atMentions?: Array<Gregor1.UID> | null; readonly channelMention: ChannelMention; readonly maybeMentions?: Array<MaybeMention> | null; readonly channelNameMentions?: Array<ChannelNameMention> | null; readonly reactions: ReactionMap; readonly unfurls: {[key: string]: UnfurlResult}; readonly replyTo?: MessageUnboxed | null; readonly botUsername: String}
 export type MessageUnfurl = {readonly unfurl: UnfurlResult; readonly messageID: MessageID}
@@ -1263,7 +1263,8 @@ export type UIInboxReselectInfo = {readonly oldConvID: String; readonly newConvI
 export type UIInboxSmallTeamRow = {readonly convID: String; readonly name: String; readonly time: Gregor1.Time; readonly snippet?: String | null; readonly snippetDecoration?: String | null; readonly draft?: String | null; readonly isMuted: Boolean; readonly isTeam: Boolean}
 export type UILinkDecoration = {readonly display: String; readonly url: String}
 export type UIMaybeMentionInfo = {status: UIMaybeMentionStatus.unknown} | {status: UIMaybeMentionStatus.user} | {status: UIMaybeMentionStatus.team; team: UITeamMention} | {status: UIMaybeMentionStatus.nothing}
-export type UIMessage = {state: MessageUnboxedState.valid; valid: UIMessageValid} | {state: MessageUnboxedState.error; error: MessageUnboxedError} | {state: MessageUnboxedState.outbox; outbox: UIMessageOutbox} | {state: MessageUnboxedState.placeholder; placeholder: MessageUnboxedPlaceholder} | {state: MessageUnboxedState.journeycard; journeycard: MessageUnboxedJourneyCard}
+export type UIMessage = {state: MessageUnboxedState.valid; valid: UIMessageValid} | {state: MessageUnboxedState.error; error: MessageUnboxedError} | {state: MessageUnboxedState.outbox; outbox: UIMessageOutbox} | {state: MessageUnboxedState.placeholder; placeholder: MessageUnboxedPlaceholder} | {state: MessageUnboxedState.journeycard; journeycard: UIMessageJourneycard}
+export type UIMessageJourneycard = {readonly ordinal: Double; readonly cardType: JourneycardType; readonly highlightMsgID: MessageID}
 export type UIMessageOutbox = {readonly state: OutboxState; readonly outboxID: String; readonly messageType: MessageType; readonly body: String; readonly decoratedTextBody?: String | null; readonly ctime: Gregor1.Time; readonly ordinal: Double; readonly isEphemeral: Boolean; readonly flipGameID?: String | null; readonly replyTo?: UIMessage | null; readonly filename: String; readonly title: String; readonly preview?: MakePreviewRes | null}
 export type UIMessageUnfurlInfo = {readonly unfurlMessageID: MessageID; readonly url: String; readonly unfurl: UnfurlDisplay; readonly isCollapsed: Boolean}
 export type UIMessageValid = {readonly messageID: MessageID; readonly ctime: Gregor1.Time; readonly outboxID?: String | null; readonly messageBody: MessageBody; readonly decoratedTextBody?: String | null; readonly bodySummary: String; readonly senderUsername: String; readonly senderDeviceName: String; readonly senderDeviceType: String; readonly senderUID: Gregor1.UID; readonly senderDeviceID: Gregor1.DeviceID; readonly superseded: Boolean; readonly assetUrlInfo?: UIAssetUrlInfo | null; readonly senderDeviceRevokedAt?: Gregor1.Time | null; readonly atMentions?: Array<String> | null; readonly channelMention: ChannelMention; readonly channelNameMentions?: Array<UIChannelNameMention> | null; readonly isEphemeral: Boolean; readonly isEphemeralExpired: Boolean; readonly explodedBy?: String | null; readonly etime: Gregor1.Time; readonly reactions: ReactionMap; readonly hasPairwiseMacs: Boolean; readonly paymentInfos?: Array<UIPaymentInfo> | null; readonly requestInfo?: UIRequestInfo | null; readonly unfurls?: Array<UIMessageUnfurlInfo> | null; readonly isCollapsed: Boolean; readonly flipGameID?: String | null; readonly isDeleteable: Boolean; readonly isEditable: Boolean; readonly replyTo?: UIMessage | null; readonly pinnedMessageID?: MessageID | null; readonly botUsername: String}


### PR DESCRIPTION
Some journey card progress. Still doesn't have any card-specific logic yet.

Find an ordinal for journey cards to use.

Plumb as far as `chat2.messageMap`. Nothing visible in the gui still.

Gate journey cards with a flag. To enable use any of:
```
KEYBASE_DEBUG_JOURNEYCARD=1 keybase service
keybase config set -b debug_journeycard true
keybase service --debug-journeycard
```

cc @patrickxb 
cc @mmaxim 
cc @keybase/react-hackers