### PR TITLE
Remove upgrade-per-user-key option from config

### DIFF
--- a/go/libcmdline/cmdline.go
+++ b/go/libcmdline/cmdline.go
@@ -123,9 +123,6 @@ func (p CommandLine) GetDisplayRawUntrustedOutput() (bool, bool) {
 func (p CommandLine) GetVDebugSetting() string {
 	return p.GetGString("vdebug")
 }
-func (p CommandLine) GetUpgradePerUserKey() (bool, bool) {
-	return p.GetBool("upgrade-per-user-key", true)
-}
 func (p CommandLine) GetPGPFingerprint() *libkb.PGPFingerprint {
 	return libkb.PGPFingerprintFromHexNoError(p.GetGString("fingerprint"))
 }
@@ -735,10 +732,6 @@ func (p *CommandLine) PopulateApp(addHelp bool, extraFlags []cli.Flag) {
 		cli.StringFlag{
 			Name:  "gui-config-file",
 			Usage: "Specify a path to the GUI config file",
-		},
-		cli.BoolFlag{
-			Name:  "upgrade-per-user-key",
-			Usage: "Create new per-user-keys. Experimental, will break sigchain!",
 		},
 		cli.BoolFlag{
 			Name:  "use-default-log-file",

--- a/go/libkb/config.go
+++ b/go/libkb/config.go
@@ -52,10 +52,6 @@ func (f *JSONConfigFile) GetDurationAtPath(p string) (time.Duration, bool) {
 	return d, true
 }
 
-func (f *JSONConfigFile) GetUpgradePerUserKey() (bool, bool) {
-	return false, false
-}
-
 func (f *JSONConfigFile) GetTopLevelString(s string) (ret string) {
 	var e error
 	f.jw.AtKey(s).GetStringVoid(&ret, &e)

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -38,7 +38,6 @@ func (n NullConfiguration) GetExternalURLKitFilename() string                   
 func (n NullConfiguration) GetProveBypass() (bool, bool)                                   { return false, false }
 func (n NullConfiguration) GetUsername() NormalizedUsername                                { return NormalizedUsername("") }
 func (n NullConfiguration) GetEmail() string                                               { return "" }
-func (n NullConfiguration) GetUpgradePerUserKey() (bool, bool)                             { return false, false }
 func (n NullConfiguration) GetProxy() string                                               { return "" }
 func (n NullConfiguration) GetProxyType() string                                           { return "" }
 func (n NullConfiguration) IsCertPinningEnabled() bool                                     { return true }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -47,7 +47,6 @@ type configGetter interface {
 	GetDbFilename() string
 	GetDebug() (bool, bool)
 	GetDisplayRawUntrustedOutput() (bool, bool)
-	GetUpgradePerUserKey() (bool, bool)
 	GetGpg() string
 	GetGpgHome() string
 	GetGpgOptions() []string

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -851,11 +851,6 @@ func (d *Service) tryGregordConnect() error {
 }
 
 func (d *Service) runBackgroundPerUserKeyUpgrade() {
-	if !d.G().Env.GetUpgradePerUserKey() {
-		d.G().Log.Debug("PerUserKeyUpgradeBackground disabled (not starting)")
-		return
-	}
-
 	eng := engine.NewPerUserKeyUpgradeBackground(d.G(), &engine.PerUserKeyUpgradeBackgroundArgs{})
 	go func() {
 		m := libkb.NewMetaContextBackground(d.G())


### PR DESCRIPTION
Remove `upgrade-per-user-key` from configurable places like CLI arg and json config. It remains in Env for tests.