### PR TITLE
non-recursive listing for popups; disable "ignore" during stat/folderList

### DIFF
--- a/shared/actions/fs-gen.tsx
+++ b/shared/actions/fs-gen.tsx
@@ -135,7 +135,7 @@ type _FinishedDownloadWithIntentPayload = {
   readonly mimeType: string
 }
 type _FinishedRegularDownloadPayload = {readonly downloadID: string; readonly mimeType: string}
-type _FolderListLoadPayload = {readonly path: Types.Path}
+type _FolderListLoadPayload = {readonly recursive: boolean; readonly path: Types.Path}
 type _FolderListLoadedPayload = {
   readonly path: Types.Path
   readonly pathItems: I.Map<Types.Path, Types.PathItem>

--- a/shared/actions/json/fs.json
+++ b/shared/actions/json/fs.json
@@ -19,6 +19,7 @@
     "pollJournalStatus": {},
     "getOnlineStatus": {},
     "folderListLoad": {
+      "recursive": "boolean",
       "path": "Types.Path"
     },
     "folderListLoaded": {

--- a/shared/common-adapters/floating-menu/menu-layout/index.d.ts
+++ b/shared/common-adapters/floating-menu/menu-layout/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Color} from '../../../styles'
+import {Color, StylesCrossPlatform} from '../../../styles'
 
 export type MenuItem = {
   backgroundColor?: Color
@@ -9,6 +9,7 @@ export type MenuItem = {
   newTag?: boolean | null
   onClick?: ((evt?: React.SyntheticEvent) => void) | null
   onPress?: void
+  progressIndicator?: boolean
   style?: Object
   subTitle?: string
   title: string // Only used as ID if view is provided for Header,

--- a/shared/common-adapters/floating-menu/menu-layout/index.d.ts
+++ b/shared/common-adapters/floating-menu/menu-layout/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Color, StylesCrossPlatform} from '../../../styles'
+import {Color} from '../../../styles'
 
 export type MenuItem = {
   backgroundColor?: Color

--- a/shared/common-adapters/floating-menu/menu-layout/index.desktop.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.desktop.tsx
@@ -4,6 +4,7 @@ import Box from '../../box'
 import Divider from '../../divider'
 import Text from '../../text'
 import Meta from '../../meta'
+import ProgressIndicator from '../../progress-indicator'
 import * as Styles from '../../../styles'
 
 class MenuLayout extends Component<MenuLayoutProps> {
@@ -63,6 +64,7 @@ class MenuLayout extends Component<MenuLayoutProps> {
             {item.subTitle}
           </Text>
         )}
+        {!!item.progressIndicator && <ProgressIndicator type="Large" style={styles.progressIndicator} />}
       </Box>
     )
   }
@@ -130,6 +132,7 @@ const styles = Styles.styleSheetCreate(
         paddingLeft: Styles.globalMargins.small,
         paddingRight: Styles.globalMargins.small,
         paddingTop: Styles.globalMargins.xtiny,
+        position: 'relative',
       },
       menuContainer: Styles.platformStyles({
         isElectron: {
@@ -149,6 +152,12 @@ const styles = Styles.styleSheetCreate(
         flexShrink: 0,
         paddingBottom: Styles.globalMargins.tiny,
         paddingTop: Styles.globalMargins.tiny,
+      },
+      progressIndicator: {
+        left: 0,
+        position: 'absolute',
+        right: 0,
+        top: Styles.globalMargins.xtiny,
       },
     } as const)
 )

--- a/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
@@ -6,6 +6,7 @@ import Text from '../../text'
 import Meta from '../../meta'
 import Divider from '../../divider'
 import ScrollView from '../../scroll-view'
+import ProgressIndicator from '../../progress-indicator'
 import {isLargeScreen} from '../../../constants/platform'
 import {MenuItem, _InnerMenuItem, MenuLayoutProps} from '.'
 
@@ -50,71 +51,70 @@ const MenuRow = (props: MenuRowProps) => (
         )}
       </>
     )}
+    {!!props.progressIndicator && <ProgressIndicator style={styles.progressIndicator} />}
   </NativeTouchableOpacity>
 )
 
-class MenuLayout extends React.Component<MenuLayoutProps> {
-  render() {
-    const menuItemsNoDividers: MenuItem[] = this.props.items.filter(
-      (x): x is MenuItem => (x ? x !== 'Divider' : false)
-    )
-    const beginningDivider = this.props.items[0] === 'Divider'
+const MenuLayout = (props: MenuLayoutProps) => {
+  const menuItemsNoDividers: MenuItem[] = props.items.filter(
+    (x): x is MenuItem => (x ? x !== 'Divider' : false)
+  )
+  const beginningDivider = props.items[0] === 'Divider'
 
-    return (
-      <NativeSafeAreaView
+  return (
+    <NativeSafeAreaView
+      style={Styles.collapseStyles([
+        styles.safeArea,
+        props.backgroundColor && {backgroundColor: props.backgroundColor},
+      ])}
+    >
+      <Box
         style={Styles.collapseStyles([
-          styles.safeArea,
-          this.props.backgroundColor && {backgroundColor: this.props.backgroundColor},
+          styles.menuBox,
+          props.backgroundColor && {backgroundColor: props.backgroundColor},
         ])}
       >
-        <Box
+        {/* Display header if there is one */}
+        {props.header && props.header.view}
+        {beginningDivider && <Divider style={styles.divider} />}
+        <ScrollView
+          alwaysBounceVertical={false}
           style={Styles.collapseStyles([
-            styles.menuBox,
-            this.props.backgroundColor && {backgroundColor: this.props.backgroundColor},
+            styles.flexGrow,
+            // if we set it to numItems * 56 exactly, the scrollview
+            // shrinks by 2px for some reason, which undermines alwaysBounceVertical={false}
+            // Add 2px to compensate
+            {height: Math.min(menuItemsNoDividers.length * 56 + 2, isLargeScreen ? 500 : 350)},
           ])}
+          contentContainerStyle={styles.menuGroup}
         >
-          {/* Display header if there is one */}
-          {this.props.header && this.props.header.view}
-          {beginningDivider && <Divider style={styles.divider} />}
-          <ScrollView
-            alwaysBounceVertical={false}
-            style={Styles.collapseStyles([
-              styles.flexGrow,
-              // if we set it to numItems * 56 exactly, the scrollview
-              // shrinks by 2px for some reason, which undermines alwaysBounceVertical={false}
-              // Add 2px to compensate
-              {height: Math.min(menuItemsNoDividers.length * 56 + 2, isLargeScreen ? 500 : 350)},
-            ])}
-            contentContainerStyle={styles.menuGroup}
-          >
-            {menuItemsNoDividers.map((mi, idx) => (
-              <MenuRow
-                key={mi.title}
-                {...mi}
-                index={idx}
-                numItems={menuItemsNoDividers.length}
-                onHidden={this.props.closeOnClick ? this.props.onHidden : undefined}
-                textColor={this.props.textColor}
-                backgroundColor={this.props.backgroundColor}
-              />
-            ))}
-          </ScrollView>
-          <Divider style={styles.divider} />
-          <Box style={Styles.collapseStyles([styles.menuGroup, this.props.listStyle])}>
+          {menuItemsNoDividers.map((mi, idx) => (
             <MenuRow
-              title={this.props.closeText || 'Close'}
-              index={0}
-              numItems={1}
-              onClick={this.props.onHidden} // pass in nothing to onHidden so it doesn't trigger it twice
-              onHidden={() => {}}
-              textColor={this.props.textColor}
-              backgroundColor={this.props.backgroundColor}
+              key={mi.title}
+              {...mi}
+              index={idx}
+              numItems={menuItemsNoDividers.length}
+              onHidden={props.closeOnClick ? props.onHidden : undefined}
+              textColor={props.textColor}
+              backgroundColor={props.backgroundColor}
             />
-          </Box>
+          ))}
+        </ScrollView>
+        <Divider style={styles.divider} />
+        <Box style={Styles.collapseStyles([styles.menuGroup, props.listStyle])}>
+          <MenuRow
+            title={props.closeText || 'Close'}
+            index={0}
+            numItems={1}
+            onClick={props.onHidden} // pass in nothing to onHidden so it doesn't trigger it twice
+            onHidden={() => {}}
+            textColor={props.textColor}
+            backgroundColor={props.backgroundColor}
+          />
         </Box>
-      </NativeSafeAreaView>
-    )
-  }
+      </Box>
+    </NativeSafeAreaView>
+  )
 }
 
 const styleRowText = (props: {
@@ -155,6 +155,7 @@ const styles = Styles.styleSheetCreate(
         paddingLeft: Styles.globalMargins.medium,
         paddingRight: Styles.globalMargins.medium,
         paddingTop: Styles.globalMargins.tiny,
+        position: 'relative',
       },
       menuBox: {
         ...Styles.globalStyles.flexBoxColumn,
@@ -167,6 +168,13 @@ const styles = Styles.styleSheetCreate(
         ...Styles.globalStyles.flexBoxColumn,
         alignItems: 'stretch',
         justifyContent: 'flex-end',
+      },
+      progressIndicator: {
+        bottom: 0,
+        left: 0,
+        position: 'absolute',
+        right: 0,
+        top: 0,
       },
       safeArea: {
         backgroundColor: Styles.globalColors.white,

--- a/shared/constants/fs.tsx
+++ b/shared/constants/fs.tsx
@@ -15,6 +15,8 @@ import {TypedActions} from '../actions/typed-actions-gen'
 import flags from '../util/feature-flags'
 
 export const syncToggleWaitingKey = 'fs:syncToggle'
+export const folderListWaitingKey = 'fs:folderList'
+export const statWaitingKey = 'fs:stat'
 
 export const defaultPath = Types.stringToPath('/keybase')
 

--- a/shared/fs/browser/rows/rows.tsx
+++ b/shared/fs/browser/rows/rows.tsx
@@ -157,7 +157,7 @@ class Rows extends React.PureComponent<Props> {
 }
 
 const RowsWithAutoLoad = (props: Props) => {
-  useFsChildren(props.path)
+  useFsChildren(props.path, true) // need recursive fot the EMPTY tag
   return <Rows {...props} />
 }
 

--- a/shared/fs/browser/rows/rows.tsx
+++ b/shared/fs/browser/rows/rows.tsx
@@ -157,7 +157,7 @@ class Rows extends React.PureComponent<Props> {
 }
 
 const RowsWithAutoLoad = (props: Props) => {
-  useFsChildren(props.path, true) // need recursive fot the EMPTY tag
+  useFsChildren(props.path, /* recursive */ true) // need recursive for the EMPTY tag
   return <Rows {...props} />
 }
 

--- a/shared/fs/common/hooks.tsx
+++ b/shared/fs/common/hooks.tsx
@@ -60,12 +60,12 @@ export const useFsPathMetadata = (path: Types.Path) => {
   }, [dispatch, path])
 }
 
-export const useFsChildren = (path: Types.Path) => {
+export const useFsChildren = (path: Types.Path, initialLoadRecursive?: boolean) => {
   useFsPathSubscriptionEffect(path, RPCTypes.PathSubscriptionTopic.children)
   const dispatch = useDispatchWhenConnectedAndOnline()
   React.useEffect(() => {
-    isPathItem(path) && dispatch(FsGen.createFolderListLoad({path}))
-  }, [dispatch, path])
+    isPathItem(path) && dispatch(FsGen.createFolderListLoad({path, recursive: !!initialLoadRecursive}))
+  }, [dispatch, path, initialLoadRecursive])
 }
 
 export const useFsTlfs = () => {

--- a/shared/fs/common/hooks.tsx
+++ b/shared/fs/common/hooks.tsx
@@ -64,7 +64,7 @@ export const useFsChildren = (path: Types.Path, initialLoadRecursive?: boolean) 
   useFsPathSubscriptionEffect(path, RPCTypes.PathSubscriptionTopic.children)
   const dispatch = useDispatchWhenConnectedAndOnline()
   React.useEffect(() => {
-    isPathItem(path) && dispatch(FsGen.createFolderListLoad({path, recursive: !!initialLoadRecursive}))
+    isPathItem(path) && dispatch(FsGen.createFolderListLoad({path, recursive: initialLoadRecursive || false}))
   }, [dispatch, path, initialLoadRecursive])
 }
 

--- a/shared/fs/common/path-item-action/menu-container.tsx
+++ b/shared/fs/common/path-item-action/menu-container.tsx
@@ -3,6 +3,7 @@ import * as Constants from '../../../constants/fs'
 import * as FsGen from '../../../actions/fs-gen'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as Container from '../../../util/container'
+import {anyWaiting} from '../../../constants/waiting'
 import {isMobile} from '../../../constants/platform'
 import {memoize} from '../../../util/memoize'
 import flags from '../../../util/feature-flags'
@@ -22,6 +23,7 @@ const mapStateToProps = (state: Container.TypedState, {path}: OwnProps) => ({
   _downloadID: state.fs.pathItemActionMenu.downloadID,
   _downloads: state.fs.downloads,
   _fileContext: state.fs.fileContext.get(path) || Constants.emptyFileContext,
+  _ignoreNeedsToWait: anyWaiting(state, Constants.folderListWaitingKey, Constants.statWaitingKey),
   _pathItem: state.fs.pathItems.get(path, Constants.unknownPathItem),
   _pathItemActionMenu: state.fs.pathItemActionMenu,
   _sfmiEnabled: state.fs.sfmi.driverStatus.type === Types.DriverStatusType.Enabled,
@@ -173,7 +175,11 @@ const mergeProps = (
     // eslint-disable-next-line sort-keys
     delete: layout.delete ? c(dispatchProps._delete) : null,
     download: layout.download ? c(dispatchProps._download) : null,
-    ignoreTlf: layout.ignoreTlf ? c(dispatchProps._ignoreTlf) : null,
+    ignoreTlf: layout.ignoreTlf
+      ? stateProps._ignoreNeedsToWait
+        ? 'disabled'
+        : c(dispatchProps._ignoreTlf)
+      : null,
     me: stateProps._username,
     moveOrCopy: flags.moveOrCopy && layout.moveOrCopy ? c(dispatchProps._moveOrCopy) : null,
     newFolder: layout.newFolder ? c(dispatchProps._newFolder) : null,

--- a/shared/fs/common/path-item-action/menu.tsx
+++ b/shared/fs/common/path-item-action/menu.tsx
@@ -162,6 +162,7 @@ const makeMenuItems = (props: Props, hideMenu: () => void) => {
             danger: true,
             disabled: props.ignoreTlf === 'disabled',
             onClick: props.ignoreTlf === 'disabled' ? undefined : hideMenuOnClick(props.ignoreTlf, hideMenu),
+            progressIndicator: props.ignoreTlf === 'disabled',
             subTitle: 'Will hide the folder from your list.',
             title: 'Ignore this folder',
           },

--- a/shared/fs/common/path-item-action/menu.tsx
+++ b/shared/fs/common/path-item-action/menu.tsx
@@ -18,7 +18,7 @@ type Props = {
   copyPath?: (() => void) | null
   delete?: (() => void) | null
   download?: (() => void) | null
-  ignoreTlf?: (() => void) | null
+  ignoreTlf?: (() => void) | 'disabled' | null
   moveOrCopy?: (() => void) | null
   me: string
   newFolder?: (() => void) | null
@@ -160,7 +160,8 @@ const makeMenuItems = (props: Props, hideMenu: () => void) => {
       ? [
           {
             danger: true,
-            onClick: hideMenuOnClick(props.ignoreTlf, hideMenu),
+            disabled: props.ignoreTlf === 'disabled',
+            onClick: props.ignoreTlf === 'disabled' ? undefined : hideMenuOnClick(props.ignoreTlf, hideMenu),
             subTitle: 'Will hide the folder from your list.',
             title: 'Ignore this folder',
           },

--- a/shared/fs/common/path-item-info.tsx
+++ b/shared/fs/common/path-item-info.tsx
@@ -20,33 +20,36 @@ type Props = {
 const getNumberOfFilesAndFolders = (
   pathItems: Types.PathItems,
   path: Types.Path
-): {folders: number; files: number} => {
+): {folders: number; files: number; loaded: boolean} => {
   const pathItem = pathItems.get(path, Constants.unknownPathItem)
   return pathItem.type === Types.PathType.Folder
     ? pathItem.children.reduce(
-        ({folders, files}, p) => {
+        ({folders, files, loaded}, p) => {
           const item = pathItems.get(Types.pathConcat(path, p), Constants.unknownPathItem)
           const isFolder = item.type === Types.PathType.Folder
           const isFile = item.type !== Types.PathType.Folder && item !== Constants.unknownPathItem
           return {
             files: files + (isFile ? 1 : 0),
             folders: folders + (isFolder ? 1 : 0),
+            loaded,
           }
         },
-        {files: 0, folders: 0}
+        {files: 0, folders: 0, loaded: pathItem.progress === Types.ProgressType.Loaded}
       )
-    : {files: 0, folders: 0}
+    : {files: 0, folders: 0, loaded: false}
 }
 
 const FilesAndFoldersCount = (props: Props) => {
   useFsChildren(props.path)
   const pathItems = Container.useSelector(state => state.fs.pathItems)
-  const {files, folders} = getNumberOfFilesAndFolders(pathItems, props.path)
-  return (
+  const {files, folders, loaded} = getNumberOfFilesAndFolders(pathItems, props.path)
+  return loaded ? (
     <Kb.Text type="BodySmall">
       {folders ? `${folders} ${pluralize('Folder')}${files ? ', ' : ''}` : undefined}
       {files ? `${files} ${pluralize('File')}` : undefined}
     </Kb.Text>
+  ) : (
+    <Kb.ProgressIndicator />
   )
 }
 
@@ -110,7 +113,7 @@ const PathItemInfo = (props: Props) => {
         {pathItem.type === Types.PathType.File && (
           <Kb.Text type="BodySmall">{Constants.humanReadableFileSize(pathItem.size)}</Kb.Text>
         )}
-        {pathItem.type === Types.PathType.Folder && <FilesAndFoldersCount {...props} />}
+        {Constants.isFolder(props.path, pathItem) && <FilesAndFoldersCount {...props} />}
         {getTlfInfoLineOrLastModifiedLine(props.path)}
       </Kb.Box2>
     </>


### PR DESCRIPTION
Part of the cause for HOTPOT-1009 was there was a costly recursive list operation that was still running when user hit "Ignore this folder". We should fix the slowness (Strib has a [PR](https://github.com/keybase/client/pull/20471)) indeed but there's no need for this list to be recursive. So this PR makes a bunch of folderList calls to be non-recursive.

 In the long run I think we should have a clearly defined way to fav/unfav TLFs, but that's a much larger change and the current situation is almost any call to read/write a TLF would cause it to be fav'ed. So for now we should either disable "Ignore this folder" or have a spinner when we have oprations goin on for the same TLF. Disabling is easier. I was gonna do it for a bunch or more stuff (e.g. download, upload, maybe even previews), but those are multi-RPC oprations and we'd have to start tracking them in the store, which doesn't seem worth it if it's just a short term solution. So I just did a simpler fix using `waitingKey` for `folderList` and `SimpleFSStat`. If other things are happening (I think downloads is an example), ignore still won't work.