### PR TITLE
PICNIC-548: Service Row Pretty Name and Layout

### DIFF
--- a/shared/team-building/people-result.tsx
+++ b/shared/team-building/people-result.tsx
@@ -311,8 +311,15 @@ const FormatPrettyName = (props: {
   username: string
   services: Array<Types.ServiceIdWithContact>
   showServicesIcons: boolean
-}) =>
-  props.prettyName && props.prettyName !== props.username ? (
+  keybaseUsername: string | null
+}) => {
+  return props.prettyName &&
+    props.prettyName !== props.username &&
+    // When the searching service is not keybase, but the service user is also a keybase user, hide their pretty name if it matches their keybase username
+    // E.g. Github
+    //   | chriscoyne
+    //   | chris • chris (prettyName) • {serviceIcons}
+    props.prettyName !== props.keybaseUsername ? (
     <Kb.Text type="BodySmall" lineClamp={1}>
       {textWithConditionalSeparator(props.prettyName, props.showServicesIcons && !!props.services.length)}
     </Kb.Text>
@@ -321,6 +328,7 @@ const FormatPrettyName = (props: {
       {textWithConditionalSeparator(props.displayLabel, props.showServicesIcons && !!props.services.length)}
     </Kb.Text>
   ) : null
+}
 
 const BottomRow = (props: {
   isKeybaseResult: boolean
@@ -370,6 +378,7 @@ const BottomRow = (props: {
               prettyName={props.prettyName}
               username={props.username}
               services={serviceMapToArray(props.services)}
+              keybaseUsername={props.keybaseUsername}
               showServicesIcons={showServicesIcons}
             />
             {/* When the service result does not have any information other than

--- a/shared/team-building/people-result.tsx
+++ b/shared/team-building/people-result.tsx
@@ -284,7 +284,12 @@ const ServicesIcons = (props: {
     <Kb.Box2 direction="horizontal" fullWidth={Styles.isMobile} style={styles.services}>
       {serviceIds.map((serviceName, index) => {
         const iconStyle =
-          firstIconNoMargin && index === 0 ? null : Kb.iconCastPlatformStyles(styles.serviceIcon)
+          firstIconNoMargin && index === 0
+            ? Styles.collapseStyles([
+                Kb.iconCastPlatformStyles(styles.serviceIcon),
+                Kb.iconCastPlatformStyles({marginLeft: 0}),
+              ])
+            : Kb.iconCastPlatformStyles(styles.serviceIcon)
         return (
           <Kb.WithTooltip
             key={serviceName}
@@ -330,6 +335,21 @@ const FormatPrettyName = (props: {
   ) : null
 }
 
+const MobileScrollView = ({children}: {children: React.ReactNode}) =>
+  Styles.isMobile ? (
+    <Kb.ScrollView
+      horizontal={true}
+      showsHorizontalScrollIndicator={false}
+      showsVerticalScrollIndicator={false}
+      scrollEventThrottle={1000}
+      contentContainerStyle={styles.bottomRowScrollContainer}
+    >
+      {children}
+    </Kb.ScrollView>
+  ) : (
+    <>{children}</>
+  )
+
 const BottomRow = (props: {
   isKeybaseResult: boolean
   username: string
@@ -359,13 +379,7 @@ const BottomRow = (props: {
 
   return (
     <Kb.Box2 direction="horizontal" fullWidth={true} alignSelf="flex-start" style={styles.bottomRowContainer}>
-      <Kb.ScrollView
-        horizontal={true}
-        showsHorizontalScrollIndicator={false}
-        showsVerticalScrollIndicator={false}
-        scrollEventThrottle={1000}
-        contentContainerStyle={styles.bottomRowScrollContainer}
-      >
+      <MobileScrollView>
         {keybaseUsernameComponent}
         {props.isPreExistingTeamMember ? (
           <Kb.Text type="BodySmall" lineClamp={1}>
@@ -395,7 +409,7 @@ const BottomRow = (props: {
             ) : null}
           </>
         )}
-      </Kb.ScrollView>
+      </MobileScrollView>
     </Kb.Box2>
   )
 }

--- a/shared/team-building/user-result.tsx
+++ b/shared/team-building/user-result.tsx
@@ -153,7 +153,12 @@ const ServicesIcons = (props: {
     <Kb.Box2 direction="horizontal" fullWidth={Styles.isMobile} style={styles.services}>
       {serviceIds.map((serviceName, index) => {
         const iconStyle =
-          firstIconNoMargin && index === 0 ? null : Kb.iconCastPlatformStyles(styles.serviceIcon)
+          firstIconNoMargin && index === 0
+            ? Styles.collapseStyles([
+                Kb.iconCastPlatformStyles(styles.serviceIcon),
+                Kb.iconCastPlatformStyles({marginLeft: 0}),
+              ])
+            : Kb.iconCastPlatformStyles(styles.serviceIcon)
         return (
           <Kb.WithTooltip
             key={serviceName}
@@ -198,6 +203,21 @@ const FormatPrettyName = (props: {
     </Kb.Text>
   ) : null
 
+const MobileScrollView = ({children}: {children: React.ReactNode}) =>
+  Styles.isMobile ? (
+    <Kb.ScrollView
+      horizontal={true}
+      showsHorizontalScrollIndicator={false}
+      showsVerticalScrollIndicator={false}
+      scrollEventThrottle={1000}
+      contentContainerStyle={styles.bottomRowScrollContainer}
+    >
+      {children}
+    </Kb.ScrollView>
+  ) : (
+    <>{children}</>
+  )
+
 const BottomRow = (props: {
   isKeybaseResult: boolean
   username: string
@@ -227,13 +247,7 @@ const BottomRow = (props: {
 
   return (
     <Kb.Box2 direction="horizontal" fullWidth={true} alignSelf="flex-start" style={styles.bottomRowContainer}>
-      <Kb.ScrollView
-        horizontal={true}
-        showsHorizontalScrollIndicator={false}
-        showsVerticalScrollIndicator={false}
-        scrollEventThrottle={1000}
-        contentContainerStyle={styles.bottomRowScrollContainer}
-      >
+      <MobileScrollView>
         {keybaseUsernameComponent}
         {props.isPreExistingTeamMember ? (
           <Kb.Text type="BodySmall" lineClamp={1}>
@@ -263,7 +277,7 @@ const BottomRow = (props: {
             ) : null}
           </>
         )}
-      </Kb.ScrollView>
+      </MobileScrollView>
     </Kb.Box2>
   )
 }

--- a/shared/team-building/user-result.tsx
+++ b/shared/team-building/user-result.tsx
@@ -179,9 +179,16 @@ const FormatPrettyName = (props: {
   prettyName: string
   username: string
   services: Array<Types.ServiceIdWithContact>
+  keybaseUsername: string | null
   showServicesIcons: boolean
 }) =>
-  props.prettyName && props.prettyName !== props.username ? (
+  props.prettyName &&
+  props.prettyName !== props.username &&
+  // When the searching service is not keybase, but the service user is also a keybase user, hide their pretty name if it matches their keybase username
+  // E.g. Github
+  //   | chriscoyne
+  //   | chris • chris (prettyName) • {serviceIcons}
+  props.prettyName !== props.keybaseUsername ? (
     <Kb.Text type="BodySmall" lineClamp={1}>
       {textWithConditionalSeparator(props.prettyName, props.showServicesIcons && !!props.services.length)}
     </Kb.Text>
@@ -238,6 +245,7 @@ const BottomRow = (props: {
               displayLabel={props.displayLabel}
               prettyName={props.prettyName}
               username={props.username}
+              keybaseUsername={props.keybaseUsername}
               services={serviceMapToArray(props.services)}
               showServicesIcons={showServicesIcons}
             />


### PR DESCRIPTION
- Fixes a few issues with the user results where the `prettyName` of a user could be the same as the keybase username.

- Removed scrollview on desktop

- Sets margin correctly when service icon is the only thing in the bottom row.

[PICNIC-584](https://keybase.atlassian.net/browse/PICNIC-584) is a follow up ticket to share the display logic between `people-result` and `user-result`