### PR TITLE
nuke nuking on too many open files error

### DIFF
--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -296,10 +296,6 @@ func (l *LevelDb) isCorrupt(err error) bool {
 	if strings.Contains(err.Error(), "corrupt") {
 		return true
 	}
-	// if our db is in a bad state with too many open files also nuke
-	if strings.Contains(strings.ToLower(err.Error()), "too many open files") {
-		return true
-	}
 	return false
 }
 


### PR DESCRIPTION
Don't nuke the db when there are too many open files. This was originally introduced in https://github.com/keybase/client/pull/16141 but the nuke has been causing erroneous nukes during temporary spikes of open files. If the original problem of not being able to compact due to too many open files reemerges we will have to approach differently but for now I think the check is causing more problems than it is fixing.