### PR TITLE
Allow devices named 'reset' in select-other-device

### DIFF
--- a/shared/provision/select-other-device/index.tsx
+++ b/shared/provision/select-other-device/index.tsx
@@ -11,6 +11,9 @@ type Props = {
   onBack: () => void
 }
 
+// needs to be an invalid device name
+const resetSentry = '!reset'
+
 class SelectOtherDevice extends React.Component<Props> {
   static navigationOptions = {
     header: null,
@@ -19,7 +22,7 @@ class SelectOtherDevice extends React.Component<Props> {
   }
 
   _renderItem = (index, item) => {
-    if (item.name === 'reset') {
+    if (item.name === resetSentry) {
       return (
         <Kb.Box2 direction="vertical" fullWidth={true}>
           <Kb.Text type="BodySmall" style={styles.or}>
@@ -80,7 +83,7 @@ class SelectOtherDevice extends React.Component<Props> {
   }
 
   render() {
-    const items = [...this.props.devices, {name: 'reset'}]
+    const items = [...this.props.devices, {name: resetSentry}]
     return (
       <SignupScreen
         noBackground={true}

--- a/shared/provision/select-other-device/index.tsx
+++ b/shared/provision/select-other-device/index.tsx
@@ -11,9 +11,6 @@ type Props = {
   onBack: () => void
 }
 
-// needs to be an invalid device name
-const resetSentry = '!reset'
-
 class SelectOtherDevice extends React.Component<Props> {
   static navigationOptions = {
     header: null,
@@ -22,7 +19,7 @@ class SelectOtherDevice extends React.Component<Props> {
   }
 
   _renderItem = (index, item) => {
-    if (item.name === resetSentry) {
+    if (item.__reset) {
       return (
         <Kb.Box2 direction="vertical" fullWidth={true}>
           <Kb.Text type="BodySmall" style={styles.or}>
@@ -83,7 +80,7 @@ class SelectOtherDevice extends React.Component<Props> {
   }
 
   render() {
-    const items = [...this.props.devices, {name: resetSentry}]
+    const items = [...this.props.devices, {__reset: true}]
     return (
       <SignupScreen
         noBackground={true}


### PR DESCRIPTION
~Use an invalid device name for the "Reset your account" sentry value.~ Use a different type to represent the reset row.
cc @keybase/y2ksquad 