### PR TITLE
add colon to getWordAtCursor separators

### DIFF
--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -131,8 +131,9 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
           return null
         }
         const upToCursor = text.substring(0, selection.start)
-        // this regex is a fancy way to say "split on command separators or newlines, but include the separators in the result"
-        const words = upToCursor.split(/ (?=@|!|#|:|\n)/)
+        // this regex matches on a) spaces followed by a separator, or b) a colon followed by a space, followed by anything
+        // the second part is used to prevent showing suggestions after ending an emoji
+        const words = upToCursor.split(/ (?=@|#|!|:|\n)|: (?=.)/)
         const word = words[words.length - 1]
         const position = {end: selection.start, start: selection.start - word.length}
         return {position, word}

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -132,7 +132,7 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
         }
         const upToCursor = text.substring(0, selection.start)
         // this regex is a fancy way to say "split on command separators or newlines, but include the separators in the result"
-        const words = upToCursor.split(/ (?=@|!|#|\n)/)
+        const words = upToCursor.split(/ (?=@|!|#|:|\n)/)
         const word = words[words.length - 1]
         const position = {end: selection.start, start: selection.start - word.length}
         return {position, word}

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -133,7 +133,7 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
         const upToCursor = text.substring(0, selection.start)
         // this regex matches on a) spaces followed by a separator, or b) a colon followed by a space, followed by anything
         // the second part is used to prevent showing suggestions after ending an emoji
-        const words = upToCursor.split(/ (?=@|#|!|:|\n)|: (?=.)/)
+        const words = upToCursor.split(/ (?=@|#|!|:|\n)|: /)
         const word = words[words.length - 1]
         const position = {end: selection.start, start: selection.start - word.length}
         return {position, word}


### PR DESCRIPTION
fixes issues with opening emoji suggestors caused by changes to how getWordAtCursor works