### PR TITLE
improve @-mention matching with username normalization

### DIFF
--- a/go/chat/teammentionloader.go
+++ b/go/chat/teammentionloader.go
@@ -67,15 +67,17 @@ func (l *TeamMentionLoader) Stop(ctx context.Context) chan struct{} {
 
 func (l *TeamMentionLoader) IsTeamMention(ctx context.Context, uid gregor1.UID,
 	maybeMention chat1.MaybeMention, knownTeamMentions []chat1.KnownTeamMention) bool {
-	if _, err := keybase1.TeamNameFromString(maybeMention.Name); err != nil {
+	teamName, err := keybase1.TeamNameFromString(maybeMention.Name)
+	if err != nil {
 		return false
 	}
+	name := teamName.String()
 	for _, known := range knownTeamMentions {
-		if known.Name == maybeMention.Name {
+		if known.Name == name {
 			return true
 		}
 	}
-	res, err := l.G().InboxSource.IsTeam(ctx, uid, maybeMention.Name)
+	res, err := l.G().InboxSource.IsTeam(ctx, uid, name)
 	if err != nil {
 		l.Debug(ctx, "isTeam: failed to check if team: %s", err)
 		return false
@@ -179,7 +181,7 @@ func (l *TeamMentionLoader) loadMention(ctx context.Context, uid gregor1.UID,
 		convs, err := l.G().ChatHelper.FindConversations(ctx, maybeMention.Name, channel,
 			chat1.TopicType_CHAT, chat1.ConversationMembersType_TEAM, keybase1.TLFVisibility_PRIVATE)
 		if err != nil || len(convs) == 0 {
-			l.Debug(ctx, "loadMention: failed to find conversation: %s", err)
+			l.Debug(ctx, "loadMention: failed to find conversation: %v", err)
 		} else {
 			info.ConvID = new(string)
 			*info.ConvID = convs[0].GetConvID().String()

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2090,6 +2090,7 @@ func validatePart(s string) (err error) {
 func TeamNameFromString(s string) (TeamName, error) {
 	ret := TeamName{}
 
+	s = strings.ToLower(s)
 	parts := strings.Split(s, ".")
 	if len(parts) == 0 {
 		return ret, errors.New("team names cannot be empty")

--- a/shared/common-adapters/mention-container.tsx
+++ b/shared/common-adapters/mention-container.tsx
@@ -6,6 +6,7 @@ import * as Container from '../util/container'
 
 export default Container.namedConnect(
   (state, {username}: OwnProps) => {
+    username = username.toLowerCase()
     if (isSpecialMention(username)) {
       return {theme: 'highlight' as const}
     }


### PR DESCRIPTION
normalize mention text for better matching. note that the change to `keybase1.TeamNameFromString` matches the server side logic for normalizing the team name during parsing.

before:
![image](https://user-images.githubusercontent.com/1144020/67241650-ce139a00-f421-11e9-82ec-1db13fcaf250.png)

after:
![image](https://user-images.githubusercontent.com/1144020/67241631-c6ec8c00-f421-11e9-8c05-5fec45307def.png)
