### PR TITLE
debian control file parsing

### DIFF
--- a/packaging/linux/deb/control.template
+++ b/packaging/linux/deb/control.template
@@ -5,5 +5,5 @@ Installed-Size: @@SIZE@@
 Maintainer: Keybase Bugs <bugs@keybase.io>
 Section: misc
 Priority: optional
-Description: The Keybase Go client, filesystem, and GUI
 @@DEPENDENCIES@@
+Description: The Keybase Go client, filesystem, and GUI


### PR DESCRIPTION
Update from apt 1.6 to apt 1.9 in Ubuntu 19.10 caused a bug which requires the Depends directive to be before the Description directive. 