### PR TITLE
folder_branch_ops: fix archiving race when forcing conflicts

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -812,6 +812,14 @@ func (fbo *folderBranchOps) forceStuckConflictForTesting(
 		if err != nil {
 			return err
 		}
+		// Wait for the flush handler to finish, so we don't
+		// accidentally swap in the upcoming MD on the conflict branch
+		// over the "merged" one we just flushed, before the pointer
+		// archiving step happens.
+		err = fbo.mdFlushes.Wait(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Roll back the local view to the original revision.


### PR DESCRIPTION
A test failure showed the following situation (which I couldn't repro locally):

* The force-conflict code makes and flushes its "merged" op (a `gcOp`).
* It then makes its first conflict op, and puts that into the journal. This is initially marked as "unmerged", since the conflict hasn't yet been detected by FBO or the journal.
* This new MD replaces the original "merged" MD in the cache.
* The background process that was kicked off by the first MD flush now starts, grabs the _new_ MD from the cache, and tries to archive the pointers from it.  However, these pointers are still live on the merged branch, so this causes issues.

Note that this is only a problem for the force-conflicts flow, it shouldn't affect normal user workflows.

The fix is just to wait for the FBO flush handler to complete its work to set up the archiving on the first MD, before writing out the conflict MDs

Issue: HOTPOT-1058