### PR TITLE
Hide commands from restrictedbots who won't be keyed for commands

### DIFF
--- a/go/chat/botcommands_test.go
+++ b/go/chat/botcommands_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,18 +27,24 @@ func (d dummyUIRouter) Shutdown() {}
 func TestBotCommandManager(t *testing.T) {
 	useRemoteMock = false
 	defer func() { useRemoteMock = true }()
-	ctc := makeChatTestContext(t, "TestBotCommandManager", 2)
+	ctc := makeChatTestContext(t, "TestBotCommandManager", 3)
 	defer ctc.cleanup()
 
 	timeout := 20 * time.Second
 	users := ctc.users()
+	listener := newServerChatListener()
+	ctc.as(t, users[0]).h.G().NotifyRouter.AddListener(listener)
 	tc := ctc.world.Tcs[users[0].Username]
 	tc.G.UIRouter = dummyUIRouter{}
 	tc1 := ctc.world.Tcs[users[1].Username]
 	tc1.G.UIRouter = dummyUIRouter{}
+	tc2 := ctc.world.Tcs[users[2].Username]
+	tc2.G.UIRouter = dummyUIRouter{}
 	ctx := ctc.as(t, users[0]).startCtx
 	ctx1 := ctc.as(t, users[1]).startCtx
+	ctx2 := ctc.as(t, users[2]).startCtx
 	uid := gregor1.UID(users[0].GetUID().ToBytes())
+	botua := users[2]
 	t.Logf("uid: %s", uid)
 	listener0 := newServerChatListener()
 	ctc.as(t, users[0]).h.G().NotifyRouter.AddListener(listener0)
@@ -109,6 +116,21 @@ func TestBotCommandManager(t *testing.T) {
 	require.Equal(t, "status", cmds[0].Name)
 
 	// test team
+	teamID, err := keybase1.TeamIDFromString(teamConv.Triple.Tlfid.String())
+	require.NoError(t, err)
+	pollForSeqno := func(expectedSeqno keybase1.Seqno) {
+		found := false
+		for !found {
+			select {
+			case teamChange := <-listener.teamChangedByID:
+				found = teamChange.TeamID == teamID &&
+					teamChange.LatestSeqno == expectedSeqno
+			case <-time.After(20 * time.Second):
+				require.Fail(t, "no event received")
+			}
+		}
+	}
+
 	commands = append(commands, chat1.AdvertiseCommandsParam{
 		Typ: chat1.BotCommandsAdvertisementTyp_TLFID_CONVS,
 		Commands: []chat1.UserBotCommandInput{{
@@ -123,15 +145,19 @@ func TestBotCommandManager(t *testing.T) {
 		TeamName: &teamConv.TlfName,
 	})
 	require.NoError(t, tc.Context().BotCommandManager.Advertise(ctx, &alias, commands))
+
 	errCh, err = tc.Context().BotCommandManager.UpdateCommands(ctx, impConv.Id, nil)
 	require.NoError(t, err)
+	require.NoError(t, readErrCh(errCh))
+
 	errChT, err := tc.Context().BotCommandManager.UpdateCommands(ctx, teamConv.Id, nil)
 	require.NoError(t, err)
+	require.NoError(t, readErrCh(errChT))
+
 	errCh1, err = tc1.Context().BotCommandManager.UpdateCommands(ctx, impConv1.Id, nil)
 	require.NoError(t, err)
-	require.NoError(t, readErrCh(errCh))
 	require.NoError(t, readErrCh(errCh1))
-	require.NoError(t, readErrCh(errChT))
+
 	cmds, err = tc.Context().BotCommandManager.ListCommands(ctx, impConv.Id)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(cmds))
@@ -141,4 +167,63 @@ func TestBotCommandManager(t *testing.T) {
 	cmds, err = tc1.Context().BotCommandManager.ListCommands(ctx1, impConv1.Id)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(cmds))
+
+	err = ctc.as(t, users[0]).chatLocalHandler().AddBotMember(ctx, chat1.AddBotMemberArg{
+		TlfName:     teamConv.TlfName,
+		Username:    botua.Username,
+		Role:        keybase1.TeamRole_RESTRICTEDBOT,
+		BotSettings: &keybase1.TeamBotSettings{Cmds: true},
+		MembersType: chat1.ConversationMembersType_TEAM,
+		TlfPublic:   teamConv.Visibility == keybase1.TLFVisibility_PUBLIC,
+	})
+	require.NoError(t, err)
+	require.NoError(t, tc2.Context().BotCommandManager.Advertise(ctx2, &alias, commands))
+	pollForSeqno(3)
+
+	errChT, err = tc.Context().BotCommandManager.UpdateCommands(ctx, teamConv.Id, nil)
+	require.NoError(t, err)
+	require.NoError(t, readErrCh(errChT))
+
+	cmds, err = tc.Context().BotCommandManager.ListCommands(ctx, teamConv.Id)
+	require.NoError(t, err)
+	require.Equal(t, 6, len(cmds))
+
+	// restricted bots that do not support commands  cannot advertise
+	err = ctc.as(t, users[0]).chatLocalHandler().EditBotMember(ctx, chat1.EditBotMemberArg{
+		TlfName:     teamConv.TlfName,
+		Username:    botua.Username,
+		Role:        keybase1.TeamRole_RESTRICTEDBOT,
+		BotSettings: &keybase1.TeamBotSettings{},
+		MembersType: chat1.ConversationMembersType_TEAM,
+		TlfPublic:   teamConv.Visibility == keybase1.TLFVisibility_PUBLIC,
+	})
+	require.NoError(t, err)
+	pollForSeqno(5)
+
+	errChT, err = tc.Context().BotCommandManager.UpdateCommands(ctx, teamConv.Id, nil)
+	require.NoError(t, err)
+	require.NoError(t, readErrCh(errChT))
+
+	cmds, err = tc.Context().BotCommandManager.ListCommands(ctx, teamConv.Id)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(cmds))
+
+	// upgrading the role removes the restriction.
+	err = ctc.as(t, users[0]).chatLocalHandler().EditBotMember(ctx, chat1.EditBotMemberArg{
+		TlfName:     teamConv.TlfName,
+		Username:    botua.Username,
+		Role:        keybase1.TeamRole_BOT,
+		MembersType: chat1.ConversationMembersType_TEAM,
+		TlfPublic:   teamConv.Visibility == keybase1.TLFVisibility_PUBLIC,
+	})
+	require.NoError(t, err)
+	pollForSeqno(6)
+
+	errChT, err = tc.Context().BotCommandManager.UpdateCommands(ctx, teamConv.Id, nil)
+	require.NoError(t, err)
+	require.NoError(t, readErrCh(errChT))
+
+	cmds, err = tc.Context().BotCommandManager.ListCommands(ctx, teamConv.Id)
+	require.NoError(t, err)
+	require.Equal(t, 6, len(cmds))
 }

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -7403,7 +7403,6 @@ func TestTeamBotSettings(t *testing.T) {
 				TlfName:     created.TlfName,
 				Username:    botua2.Username,
 				Role:        keybase1.TeamRole_BOT,
-				BotSettings: nil,
 				MembersType: mt,
 				TlfPublic:   created.Visibility == keybase1.TLFVisibility_PUBLIC,
 			})

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -218,6 +218,8 @@ type InboxSource interface {
 	GetInboxQueryLocalToRemote(ctx context.Context,
 		lquery *chat1.GetInboxLocalQuery) (*chat1.GetInboxQuery, NameInfo, error)
 	UpdateLocalMtime(ctx context.Context, uid gregor1.UID, updates []chat1.LocalMtimeUpdate) error
+	TeamBotSettingsForConv(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (
+		map[keybase1.UID]keybase1.TeamBotSettings, error)
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -3480,4 +3481,8 @@ func (b BadgeConversationInfo) IsEmpty() bool {
 	return (b.UnreadMessages == 0 &&
 		b.BadgeCounts[DeviceType_DESKTOP] == 0 &&
 		b.BadgeCounts[DeviceType_MOBILE] == 0)
+}
+
+func (s *TeamBotSettings) Eq(o *TeamBotSettings) bool {
+	return reflect.DeepEqual(s, o)
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -684,9 +684,21 @@ func editMember(ctx context.Context, g *libkb.GlobalContext, teamGetter func() (
 		if err != nil {
 			return err
 		}
+
 		if existingRole == role {
-			g.Log.CDebugf(ctx, "bailing out, role given is the same as current")
-			return nil
+			if !role.IsRestrictedBot() {
+				g.Log.CDebugf(ctx, "bailing out, role given is the same as current")
+				return nil
+			}
+			teamBotSettings, err := t.TeamBotSettings()
+			if err != nil {
+				return err
+			}
+			existingBotSettings := teamBotSettings[uv]
+			if botSettings.Eq(&existingBotSettings) {
+				g.Log.CDebugf(ctx, "bailing out, role given is the same as current, botSettings unchanged")
+				return nil
+			}
 		}
 
 		req, err := reqFromRole(uv, role, botSettings)


### PR DESCRIPTION
depends on https://github.com/keybase/keybase/pull/4599 and https://github.com/keybase/client/pull/20532

also fixes a preexisting bug where editing the settings of a bot member would short circuit since the role was unchanged.