### PR TITLE
key_manager_test: sync device 3 after rekey during test

### DIFF
--- a/go/kbfs/libkbfs/key_manager_test.go
+++ b/go/kbfs/libkbfs/key_manager_test.go
@@ -1066,6 +1066,10 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 
 	// meanwhile, device 3 should be able to read both the new and the
 	// old files
+	kbfsOps3 := config2Dev3.KBFSOps()
+	err = kbfsOps3.SyncFromServer(
+		ctx, rootNode2.GetFolderBranch(), nil)
+	require.NoError(t, err)
 	rootNode2Dev3 := GetRootNodeOrBust(ctx, t, config2Dev3, name, tlf.Private)
 
 	kbfsOps2Dev3 := config2Dev3.KBFSOps()


### PR DESCRIPTION
A CI failure (that I couldn't repro locally) showed that a device that should have been able to read a TLF after a rekey, wasn't able to. From the log I think it was still trying to read an old version, so I'm fixing it by syncing before trying to read it from that device.

Issue: HOTPOT-1059