### PR TITLE
engine: backout kex2 upgrade, but keep bugfix

### DIFF
--- a/go/engine/device_add.go
+++ b/go/engine/device_add.go
@@ -111,7 +111,11 @@ func (e *DeviceAdd) Run(m libkb.MetaContext) (err error) {
 	}
 	uid := m.CurrentUID()
 
-	kex2SecretTyp := libkb.Kex2SecretTypeV2
+	// make a new secret; continue to generate legacy Kex2 secrets for now.
+	kex2SecretTyp := libkb.Kex2SecretTypeV1Desktop
+	if provisioneeType == keybase1.DeviceType_MOBILE || m.G().GetAppType() == libkb.DeviceTypeMobile {
+		kex2SecretTyp = libkb.Kex2SecretTypeV1Mobile
+	}
 	m.Debug("provisionee device type: %v; uid: %s; secret type: %d", provisioneeType, uid, kex2SecretTyp)
 	secret, err := libkb.NewKex2SecretFromTypeAndUID(kex2SecretTyp, uid)
 	if err != nil {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -182,10 +182,13 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 	m.Debug("deviceWithType: got device name: %q", name)
 
 	// make a new secret:
-	uid := e.arg.User.GetUID()
+	uid := m.CurrentUID()
 
 	// Continue to generate legacy Kex2 secret types
-	kex2SecretTyp := libkb.Kex2SecretTypeV2
+	kex2SecretTyp := libkb.Kex2SecretTypeV1Desktop
+	if e.arg.DeviceType == libkb.DeviceTypeMobile || provisionerType == keybase1.DeviceType_MOBILE {
+		kex2SecretTyp = libkb.Kex2SecretTypeV1Mobile
+	}
 	m.Debug("Generating Kex2 secret for uid=%s, typ=%d", uid, kex2SecretTyp)
 	secret, err := libkb.NewKex2SecretFromTypeAndUID(kex2SecretTyp, uid)
 	if err != nil {

--- a/go/engine/login_provision.go
+++ b/go/engine/login_provision.go
@@ -182,7 +182,7 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 	m.Debug("deviceWithType: got device name: %q", name)
 
 	// make a new secret:
-	uid := m.CurrentUID()
+	uid := e.arg.User.GetUID()
 
 	// Continue to generate legacy Kex2 secret types
 	kex2SecretTyp := libkb.Kex2SecretTypeV1Desktop
@@ -201,7 +201,7 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 		m.Debug("Failed to get salt")
 		return err
 	}
-	provisionee := NewKex2Provisionee(m.G(), device, secret.Secret(), e.arg.User.GetUID(), salt)
+	provisionee := NewKex2Provisionee(m.G(), device, secret.Secret(), uid, salt)
 
 	var canceler func()
 
@@ -277,7 +277,7 @@ func (e *loginProvision) deviceWithType(m libkb.MetaContext, provisionerType key
 	}
 
 	// Load me again so that keys will be up to date.
-	loadArg := libkb.NewLoadUserArgWithMetaContext(m).WithSelf(true).WithUID(e.arg.User.GetUID())
+	loadArg := libkb.NewLoadUserArgWithMetaContext(m).WithSelf(true).WithUID(uid)
 	e.arg.User, err = libkb.LoadUser(loadArg)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit reverts 0e2ec803e9ee2c74855d80e5a6b77724bd220997 (#20281) but keeps the bugfix that went in. So we're still going to initiate the older version of kex but we'll be able to launch it once everyone gets this bugfix.