### PR TITLE
retry racy ephemeral errors

### DIFF
--- a/go/engine/provision_utils.go
+++ b/go/engine/provision_utils.go
@@ -8,6 +8,20 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
+func retryOnEphemeralRace(mctx libkb.MetaContext, fn func(mctx libkb.MetaContext) error) (err error) {
+	for attempt := 0; attempt < 5; attempt++ {
+		if err = fn(mctx); err == nil {
+			return nil
+		}
+		if !libkb.IsEphemeralRetryableError(err) {
+			return err
+		}
+		mctx.Debug("retryOnEphemeralRace found a retryable error on try %d: %v",
+			attempt, err)
+	}
+	return err
+}
+
 // ephemeralKeyReboxer will rebox the lastest userEK while provisioning
 // devices.  The provisionee generates a deviceEK seed so that the provisioner
 // can rebox the latest userEK for the new deviceKID.  The provisionee posts

--- a/go/engine/puk_roll.go
+++ b/go/engine/puk_roll.go
@@ -56,7 +56,7 @@ func (e *PerUserKeyRoll) SubConsumers() []libkb.UIConsumer {
 // Run starts the engine.
 func (e *PerUserKeyRoll) Run(mctx libkb.MetaContext) (err error) {
 	defer mctx.Trace("PerUserKeyRoll", func() error { return err })()
-	return e.inner(mctx)
+	return retryOnEphemeralRace(mctx, e.inner)
 }
 
 func (e *PerUserKeyRoll) inner(mctx libkb.MetaContext) error {

--- a/go/engine/revoke.go
+++ b/go/engine/revoke.go
@@ -118,9 +118,12 @@ func (e *RevokeEngine) explicitOrImplicitDeviceID(me *libkb.User) keybase1.Devic
 	return ""
 }
 
-func (e *RevokeEngine) Run(m libkb.MetaContext) error {
-	m.Debug("RevokeEngine#Run (mode:%v)", e.mode)
+func (e *RevokeEngine) Run(mctx libkb.MetaContext) (err error) {
+	defer mctx.Trace(fmt.Sprintf("RevokeEngine (mode:%v)", e.mode), func() error { return err })()
+	return retryOnEphemeralRace(mctx, e.run)
+}
 
+func (e *RevokeEngine) run(m libkb.MetaContext) error {
 	e.G().LocalSigchainGuard().Set(m.Ctx(), "RevokeEngine")
 	defer e.G().LocalSigchainGuard().Clear(m.Ctx(), "RevokeEngine")
 

--- a/go/engine/selfprovision.go
+++ b/go/engine/selfprovision.go
@@ -55,10 +55,14 @@ func (e *SelfProvisionEngine) Result() error {
 	return e.result
 }
 
-func (e *SelfProvisionEngine) Run(m libkb.MetaContext) (err error) {
+func (e *SelfProvisionEngine) Run(mctx libkb.MetaContext) (err error) {
+	defer mctx.Trace("SelfProvisionEngine#Run", func() error { return err })()
+	return retryOnEphemeralRace(mctx, e.run)
+}
+
+func (e *SelfProvisionEngine) run(m libkb.MetaContext) (err error) {
 	m.G().LocalSigchainGuard().Set(m.Ctx(), "SelfProvisionEngine")
 	defer m.G().LocalSigchainGuard().Clear(m.Ctx(), "SelfProvisionEngine")
-	defer m.Trace("SelfProvisionEngine#Run", func() error { return err })()
 
 	if d, err := libkb.GetDeviceCloneState(m); err != nil {
 		return err


### PR DESCRIPTION
User was unable to revoke a device since a box for a device that was just provisioned was missing. We now wrap these errors as they are retryable and shouldn't be a hard failure in a race