### PR TITLE
Fix sending path payments to federated addresses

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -1413,7 +1413,9 @@ const refreshTrustlineAcceptedAssetsByUsername = async (_: TypedState, {payload:
     {recipient: username},
     Constants.refreshTrustlineAcceptedAssetsWaitingKey(username)
   )
-  return balancesToAction(trustlines || [], Types.noAccountID, username)
+  return Constants.isFederatedAddress(username)
+    ? balancesToAction(trustlines || [], username, '')
+    : balancesToAction(trustlines || [], Types.noAccountID, username)
 }
 
 const refreshTrustlinePopularAssets = async () => {

--- a/shared/wallets/send-form/pick-asset.tsx
+++ b/shared/wallets/send-form/pick-asset.tsx
@@ -40,8 +40,8 @@ const AssetList = ({accountID, isSender, username}) => {
     [dispatch, isSender]
   )
   React.useEffect(() => {
-    username
-      ? dispatch(WalletsGen.createRefreshTrustlineAcceptedAssetsByUsername({username}))
+    username || Constants.isFederatedAddress(accountID)
+      ? dispatch(WalletsGen.createRefreshTrustlineAcceptedAssetsByUsername({username: username || accountID}))
       : dispatch(WalletsGen.createRefreshTrustlineAcceptedAssets({accountID}))
   }, [dispatch, username, accountID])
   return (


### PR DESCRIPTION
@keybase/picnicsquad CC @keybase/react-hackers 

If we want to provide a federated address recipient, we need to end up in `refreshTrustlineAcceptedAssetsByUsername` RPC  instead of `refreshTrustlineAcceptedAssets`, even though we have an accountID rather than a username.