### PR TITLE
Remove unused SUID chrome-sandbox binary

### DIFF
--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -143,7 +143,7 @@ build_one_architecture() {
     yarn run package -- --platform linux --arch "$electron_arch" --appVersion "$version"
     rsync -a "desktop/release/linux-${electron_arch}/Keybase-linux-${electron_arch}/" \
       "$layout_dir/opt/keybase"
-    chmod 4755 "$layout_dir/opt/keybase/chrome-sandbox"
+    rm "$layout_dir/opt/keybase/chrome-sandbox"
   )
 
   # Copy in the icon images.

--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -54,7 +54,6 @@ build_one_architecture() {
 
   # Copy the entire filesystem layout, binaries and all, into the debian build
   # folder. TODO: Something less wasteful of disk space?
-  # Preserve permissions of the chrome-sandbox setuid
   cp -rp "$build_root"/binaries/"$debian_arch"/* "$dest/build"
 
   # Copy changelog directly in, since this is a binary package.

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -82,7 +82,7 @@ build_one_architecture() {
   # could backfire on us if we get weird whitespace in any filename, but
   # hopefully that will never happen. (Maintaining this list by hand would be
   # much worse.)
-  files="$(cd "$copied_binaries" && find -type f | sed 's/\.//' | sed 's@/opt/keybase/chrome-sandbox@%attr(4755, root, -) /opt/keybase/chrome-sandbox@')"
+  files="$(cd "$copied_binaries" && find -type f | sed 's/\.//')"
 
   spec="$dest/SPECS/keybase-$rpm_arch.spec"
   mkdir -p "$(dirname "$spec")"


### PR DESCRIPTION
I noticed that there is a setuid binary called `chrome-sandbox` that appears to be pulled into the Linux packaging process from Electron.

This binary presents a very large attack surface area for a setuid binary, and also appears to be totally unused.

I've been running for two months with this binary removed from my system and can't tell any difference in functionality.


