### PR TITLE
libkb: loader picks fresher of stubbed/unstubbed UPAK

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -1638,6 +1638,9 @@ func (u UserPlusKeysV2AllIncarnations) IsOlderThan(v UserPlusKeysV2AllIncarnatio
 	if u.Uvv.Id < v.Uvv.Id {
 		return true
 	}
+	if u.Uvv.CachedAt < v.Uvv.CachedAt {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
- if called from unstubbed mode. previously, we weren't considering CachedAt for deciding between the two