### PR TITLE
Speed Up SearchFilter Focus

### DIFF
--- a/shared/common-adapters/search-filter.tsx
+++ b/shared/common-adapters/search-filter.tsx
@@ -83,7 +83,6 @@ class SearchFilter extends React.PureComponent<Props, State> {
     this.props.onBlur && this.props.onBlur()
   }
   private onFocus = () => {
-    console.log('JRY SearchFilter onFocus called')
     this.setState({focused: true})
     this.props.onFocus && this.props.onFocus()
   }

--- a/shared/common-adapters/search-filter.tsx
+++ b/shared/common-adapters/search-filter.tsx
@@ -67,7 +67,11 @@ type State = {
 
 class SearchFilter extends React.PureComponent<Props, State> {
   state = {
-    focused: false,
+    // If we recieve the focusOnMount prop, then we can use autoFocus to immediately focus the input element.
+    // However we also need to make sure the state is initialized to be focused
+    // to prevent an additional render which appears to the user as the search
+    // icon and clear button appear/disappearing
+    focused: this.props.focusOnMount || false,
     hover: false,
     text: '',
   }
@@ -79,13 +83,17 @@ class SearchFilter extends React.PureComponent<Props, State> {
     this.props.onBlur && this.props.onBlur()
   }
   private onFocus = () => {
+    console.log('JRY SearchFilter onFocus called')
     this.setState({focused: true})
     this.props.onFocus && this.props.onFocus()
   }
 
   private text = () => (this.props.valueControlled ? this.props.value : this.state.text)
   focus = () => {
-    if (this.state.focused) {
+    // When focusOnMount is true so is state.focused.
+    // This is to speed up the focus time when using focusOnMount
+    // So continue to focus() the input elemenet if both are true
+    if (this.state.focused && !this.props.focusOnMount) {
       return
     }
     this.inputRef.current && this.inputRef.current.focus()
@@ -177,6 +185,7 @@ class SearchFilter extends React.PureComponent<Props, State> {
         : ''
     return (
       <Kb.NewInput
+        autoFocus={this.props.focusOnMount}
         value={this.text()}
         placeholder={this.props.placeholderText + hotkeyText}
         dummyInput={this.props.dummyInput}


### PR DESCRIPTION
When we used `SearchFilter` in addition to `focusOnMount` the input would render once without focus after mounting, and then change again when `state.focused` was set.

Since we use `autoFocus` in `PlainInput` it's possible to set the input's focus state **before** its first render, which we do often throughout the app. E.g. reactji picker input.

The fix is to initialize the state to `focused: true` when `focusOnMount == true`. This just saves on state change and no longer shows the flickering change.

Tested on RN and the fix in `this.focusOnMount` is still effective.

**Components to Test**:

1. Team Building > Search By Phone > Country Selector (the `SearchFilter` input used to search country codes)
2. People Page > People Search (the `SearchFilter` input used to search Keybase users)