### PR TITLE
simplefs: implement files badge state RPC

### DIFF
--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -362,6 +362,11 @@ func (s SimpleFSMock) SimpleFSGetGUIFileContext(ctx context.Context,
 	return keybase1.GUIFileContext{}, nil
 }
 
+func (s SimpleFSMock) SimpleFSGetFilesTabBadge(_ context.Context) (
+	keybase1.FilesTabBadge, error) {
+	return keybase1.FilesTabBadge_NONE, nil
+}
+
 /*
  file source cases:
  1. file

--- a/go/kbfs/libkbfs/config_mock_test.go
+++ b/go/kbfs/libkbfs/config_mock_test.go
@@ -143,8 +143,12 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 
 	config.mockSubscriptionManagerPublisher = NewMockSubscriptionManagerPublisher(gomock.NewController(ctr.t))
 	config.subscriptionManagerPublisher = config.mockSubscriptionManagerPublisher
-	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(keybase1.SubscriptionTopic_FAVORITES).AnyTimes()
-	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(keybase1.SubscriptionTopic_JOURNAL_STATUS).AnyTimes()
+	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(
+		keybase1.SubscriptionTopic_FAVORITES).AnyTimes()
+	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(
+		keybase1.SubscriptionTopic_JOURNAL_STATUS).AnyTimes()
+	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(
+		keybase1.SubscriptionTopic_FILES_TAB_BADGE).AnyTimes()
 
 	return config
 }

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3387,6 +3387,8 @@ func (cr *ConflictResolver) recordFinishResolve(
 		if wasStuck {
 			cr.config.SubscriptionManagerPublisher().PublishChange(keybase1.SubscriptionTopic_FAVORITES)
 			cr.config.Reporter().NotifyFavoritesChanged(ctx)
+			cr.config.SubscriptionManagerPublisher().PublishChange(
+				keybase1.SubscriptionTopic_FILES_TAB_BADGE)
 		}
 		return
 	}
@@ -3432,6 +3434,8 @@ func (cr *ConflictResolver) recordFinishResolve(
 	if !wasStuck && isCRStuckFromRecords(conflictsSoFar) {
 		cr.config.SubscriptionManagerPublisher().PublishChange(keybase1.SubscriptionTopic_FAVORITES)
 		cr.config.Reporter().NotifyFavoritesChanged(ctx)
+		cr.config.SubscriptionManagerPublisher().PublishChange(
+			keybase1.SubscriptionTopic_FILES_TAB_BADGE)
 	}
 }
 
@@ -3793,6 +3797,8 @@ func (cr *ConflictResolver) clearConflictRecords(ctx context.Context) error {
 	if wasStuck {
 		cr.config.SubscriptionManagerPublisher().PublishChange(keybase1.SubscriptionTopic_FAVORITES)
 		cr.config.Reporter().NotifyFavoritesChanged(ctx)
+		cr.config.SubscriptionManagerPublisher().PublishChange(
+			keybase1.SubscriptionTopic_FILES_TAB_BADGE)
 	}
 	return nil
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -301,6 +301,9 @@ type KBFSOps interface {
 	// and new top-level folders.  This is a remote-access operation when the
 	// cache is empty or expired.
 	GetFavoritesAll(ctx context.Context) (keybase1.FavoritesResult, error)
+	// GetBadge returns the overall KBFS badge state for this device.
+	// It's cheaper than the other favorites methods.
+	GetBadge(ctx context.Context) (keybase1.FilesTabBadge, error)
 	// RefreshCachedFavorites tells the instances to forget any cached
 	// favorites list and fetch a new list from the server.  The
 	// effects are asychronous; if there's an error refreshing the

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -1347,7 +1347,10 @@ func (j *JournalManager) MoveAway(ctx context.Context, tlfID tlf.ID) error {
 		return err
 	}
 	j.insertConflictJournalLocked(ctx, tj, fakeTlfID, t)
-	j.config.SubscriptionManagerPublisher().PublishChange(keybase1.SubscriptionTopic_FAVORITES)
+	j.config.SubscriptionManagerPublisher().PublishChange(
+		keybase1.SubscriptionTopic_FAVORITES)
+	j.config.SubscriptionManagerPublisher().PublishChange(
+		keybase1.SubscriptionTopic_FILES_TAB_BADGE)
 	return j.config.KeybaseService().NotifyFavoritesChanged(ctx)
 }
 

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -573,6 +573,48 @@ func (fs *KBFSOpsStandard) GetFavoritesAll(ctx context.Context) (
 	return favs, nil
 }
 
+// GetBadge implements the KBFSOps interface for KBFSOpsStandard.
+func (fs *KBFSOpsStandard) GetBadge(ctx context.Context) (
+	keybase1.FilesTabBadge, error) {
+	journalManager, err := GetJournalManager(fs.config)
+	if err != nil {
+		// Journaling not enabled.
+		return keybase1.FilesTabBadge_NONE, nil
+	}
+
+	tlfsInConflict, numUploadingTlfs, err := journalManager.GetFoldersSummary()
+	if err != nil {
+		return keybase1.FilesTabBadge_NONE, err
+	}
+
+	for _, tlfID := range tlfsInConflict {
+		fb := data.FolderBranch{Tlf: tlfID, Branch: data.MasterBranch}
+		ops := fs.getOps(ctx, fb, FavoritesOpNoChange)
+		s, err := ops.FolderConflictStatus(ctx)
+		if err != nil {
+			return keybase1.FilesTabBadge_NONE, err
+		}
+		if s == keybase1.FolderConflictType_IN_CONFLICT_AND_STUCK {
+			return keybase1.FilesTabBadge_UploadingStuck, nil
+		}
+	}
+
+	if numUploadingTlfs == 0 {
+		return keybase1.FilesTabBadge_NONE, nil
+	}
+
+	serviceErrors, _ := fs.config.KBFSOps().StatusOfServices()
+	if serviceErrors[MDServiceName] != nil {
+		// Assume that if we're not connected to the mdserver,
+		// then data isn't uploading.  Technically it could still
+		// be uploading to the bserver, but that should be very
+		// rare.
+		return keybase1.FilesTabBadge_AwaitingToUpload, nil
+	}
+
+	return keybase1.FilesTabBadge_Uploading, nil
+}
+
 // RefreshCachedFavorites implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) RefreshCachedFavorites(ctx context.Context,

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -197,6 +197,11 @@ func (fs *KBFSOpsStandard) PushConnectionStatusChange(
 	service string, newStatus error) {
 	fs.currentStatus.PushConnectionStatusChange(service, newStatus)
 
+	if service == MDServiceName {
+		fs.config.SubscriptionManagerPublisher().PublishChange(
+			keybase1.SubscriptionTopic_FILES_TAB_BADGE)
+	}
+
 	if fs.config.KeybaseService() == nil {
 		return
 	}
@@ -609,7 +614,7 @@ func (fs *KBFSOpsStandard) GetBadge(ctx context.Context) (
 		// then data isn't uploading.  Technically it could still
 		// be uploading to the bserver, but that should be very
 		// rare.
-		return keybase1.FilesTabBadge_WAITING_TO_UPLOAD, nil
+		return keybase1.FilesTabBadge_AWAITING_UPLOAD, nil
 	}
 
 	return keybase1.FilesTabBadge_UPLOADING, nil

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -595,7 +595,7 @@ func (fs *KBFSOpsStandard) GetBadge(ctx context.Context) (
 			return keybase1.FilesTabBadge_NONE, err
 		}
 		if s == keybase1.FolderConflictType_IN_CONFLICT_AND_STUCK {
-			return keybase1.FilesTabBadge_UploadingStuck, nil
+			return keybase1.FilesTabBadge_UPLOADING_STUCK, nil
 		}
 	}
 
@@ -609,10 +609,10 @@ func (fs *KBFSOpsStandard) GetBadge(ctx context.Context) (
 		// then data isn't uploading.  Technically it could still
 		// be uploading to the bserver, but that should be very
 		// rare.
-		return keybase1.FilesTabBadge_AwaitingToUpload, nil
+		return keybase1.FilesTabBadge_WAITING_TO_UPLOAD, nil
 	}
 
-	return keybase1.FilesTabBadge_Uploading, nil
+	return keybase1.FilesTabBadge_UPLOADING, nil
 }
 
 // RefreshCachedFavorites implements the KBFSOps interface for

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -1106,6 +1106,21 @@ func (mr *MockKBFSOpsMockRecorder) GetAllSyncedTlfMDs(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSyncedTlfMDs", reflect.TypeOf((*MockKBFSOps)(nil).GetAllSyncedTlfMDs), arg0)
 }
 
+// GetBadge mocks base method
+func (m *MockKBFSOps) GetBadge(arg0 context.Context) (keybase1.FilesTabBadge, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBadge", arg0)
+	ret0, _ := ret[0].(keybase1.FilesTabBadge)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBadge indicates an expected call of GetBadge
+func (mr *MockKBFSOpsMockRecorder) GetBadge(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBadge", reflect.TypeOf((*MockKBFSOps)(nil).GetBadge), arg0)
+}
+
 // GetDirChildren mocks base method
 func (m *MockKBFSOps) GetDirChildren(arg0 context.Context, arg1 Node) (map[data.PathPartString]data.EntryInfo, error) {
 	m.ctrl.T.Helper()

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -1095,7 +1095,10 @@ func (j *tlfJournal) removeFlushedBlockEntries(ctx context.Context,
 
 	// TODO: Check storedFiles also.
 
-	j.config.SubscriptionManagerPublisher().PublishChange(keybase1.SubscriptionTopic_JOURNAL_STATUS)
+	j.config.SubscriptionManagerPublisher().PublishChange(
+		keybase1.SubscriptionTopic_JOURNAL_STATUS)
+	j.config.SubscriptionManagerPublisher().PublishChange(
+		keybase1.SubscriptionTopic_FILES_TAB_BADGE)
 	flushedBytes, err := j.blockJournal.removeFlushedEntries(
 		ctx, entries, j.tlfID, j.config.Reporter())
 	if err != nil {
@@ -2194,7 +2197,10 @@ func (j *tlfJournal) putBlockData(
 		j.unsquashedBytes += uint64(bufLen)
 	}
 
-	j.config.SubscriptionManagerPublisher().PublishChange(keybase1.SubscriptionTopic_JOURNAL_STATUS)
+	j.config.SubscriptionManagerPublisher().PublishChange(
+		keybase1.SubscriptionTopic_JOURNAL_STATUS)
+	j.config.SubscriptionManagerPublisher().PublishChange(
+		keybase1.SubscriptionTopic_FILES_TAB_BADGE)
 	j.config.Reporter().NotifySyncStatus(ctx, &keybase1.FSPathSyncStatus{
 		FolderType: j.tlfID.Type().FolderType(),
 		// Path: TODO,

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -262,8 +262,12 @@ func setupTLFJournalTest(
 		mdserver, defaultDiskLimitMaxDelay + time.Second,
 		mockPublisher,
 	}
-	mockPublisher.EXPECT().PublishChange(keybase1.SubscriptionTopic_FAVORITES).AnyTimes()
-	mockPublisher.EXPECT().PublishChange(keybase1.SubscriptionTopic_JOURNAL_STATUS).AnyTimes()
+	mockPublisher.EXPECT().PublishChange(
+		keybase1.SubscriptionTopic_FAVORITES).AnyTimes()
+	mockPublisher.EXPECT().PublishChange(
+		keybase1.SubscriptionTopic_JOURNAL_STATUS).AnyTimes()
+	mockPublisher.EXPECT().PublishChange(
+		keybase1.SubscriptionTopic_FILES_TAB_BADGE).AnyTimes()
 
 	ctx, cancel = context.WithTimeout(
 		context.Background(), individualTestTimeout)

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -3110,7 +3110,7 @@ func (k *SimpleFS) SimpleFSGetGUIFileContext(ctx context.Context,
 }
 
 // SimpleFSGetFilesTabBadge implements the SimpleFSInterface.
-func (k *SimpleFS) SimpleFSGetFilesTabBadge(context.Context) (
+func (k *SimpleFS) SimpleFSGetFilesTabBadge(ctx context.Context) (
 	keybase1.FilesTabBadge, error) {
-	return keybase1.FilesTabBadge_NONE, nil
+	return k.config.KBFSOps().GetBadge(ctx)
 }

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -3108,3 +3108,9 @@ func (k *SimpleFS) SimpleFSGetGUIFileContext(ctx context.Context,
 		Url:         u.String(),
 	}, nil
 }
+
+// SimpleFSGetFilesTabBadge implements the SimpleFSInterface.
+func (k *SimpleFS) SimpleFSGetFilesTabBadge(context.Context) (
+	keybase1.FilesTabBadge, error) {
+	return keybase1.FilesTabBadge_NONE, nil
+}

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -1431,7 +1431,7 @@ func TestFavoriteConflicts(t *testing.T) {
 	t.Log("Check for stuck badge state")
 	badge, err := sfs.SimpleFSGetFilesTabBadge(ctx)
 	require.NoError(t, err)
-	require.Equal(t, keybase1.FilesTabBadge_UploadingStuck, badge)
+	require.Equal(t, keybase1.FilesTabBadge_UPLOADING_STUCK, badge)
 
 	t.Log("Resolve the conflict")
 	err = sfs.SimpleFSClearConflictState(ctx, pathPub)
@@ -1660,7 +1660,7 @@ func TestBadgeState(t *testing.T) {
 	require.NoError(t, err)
 	badge, err = sfs.SimpleFSGetFilesTabBadge(ctx)
 	require.NoError(t, err)
-	require.Equal(t, keybase1.FilesTabBadge_Uploading, badge)
+	require.Equal(t, keybase1.FilesTabBadge_UPLOADING, badge)
 
 	t.Log("Get a different TLF stuck, badge state should update")
 	writeRemoteFile(
@@ -1670,7 +1670,7 @@ func TestBadgeState(t *testing.T) {
 	require.NoError(t, err)
 	badge, err = sfs.SimpleFSGetFilesTabBadge(ctx)
 	require.NoError(t, err)
-	require.Equal(t, keybase1.FilesTabBadge_UploadingStuck, badge)
+	require.Equal(t, keybase1.FilesTabBadge_UPLOADING_STUCK, badge)
 
 	jManager.ResumeBackgroundWork(ctx, tlfID)
 }

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1447,26 +1447,26 @@ func (o DownloadStatus) DeepCopy() DownloadStatus {
 type FilesTabBadge int
 
 const (
-	FilesTabBadge_NONE             FilesTabBadge = 0
-	FilesTabBadge_UploadingStuck   FilesTabBadge = 1
-	FilesTabBadge_AwaitingToUpload FilesTabBadge = 2
-	FilesTabBadge_Uploading        FilesTabBadge = 3
+	FilesTabBadge_NONE            FilesTabBadge = 0
+	FilesTabBadge_UPLOADING_STUCK FilesTabBadge = 1
+	FilesTabBadge_AWAITING_UPLOAD FilesTabBadge = 2
+	FilesTabBadge_UPLOADING       FilesTabBadge = 3
 )
 
 func (o FilesTabBadge) DeepCopy() FilesTabBadge { return o }
 
 var FilesTabBadgeMap = map[string]FilesTabBadge{
-	"NONE":             0,
-	"UploadingStuck":   1,
-	"AwaitingToUpload": 2,
-	"Uploading":        3,
+	"NONE":            0,
+	"UPLOADING_STUCK": 1,
+	"AWAITING_UPLOAD": 2,
+	"UPLOADING":       3,
 }
 
 var FilesTabBadgeRevMap = map[FilesTabBadge]string{
 	0: "NONE",
-	1: "UploadingStuck",
-	2: "AwaitingToUpload",
-	3: "Uploading",
+	1: "UPLOADING_STUCK",
+	2: "AWAITING_UPLOAD",
+	3: "UPLOADING",
 }
 
 func (e FilesTabBadge) String() string {

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1318,6 +1318,7 @@ const (
 	SubscriptionTopic_JOURNAL_STATUS  SubscriptionTopic = 1
 	SubscriptionTopic_ONLINE_STATUS   SubscriptionTopic = 2
 	SubscriptionTopic_DOWNLOAD_STATUS SubscriptionTopic = 3
+	SubscriptionTopic_FILES_TAB_BADGE SubscriptionTopic = 4
 )
 
 func (o SubscriptionTopic) DeepCopy() SubscriptionTopic { return o }
@@ -1327,6 +1328,7 @@ var SubscriptionTopicMap = map[string]SubscriptionTopic{
 	"JOURNAL_STATUS":  1,
 	"ONLINE_STATUS":   2,
 	"DOWNLOAD_STATUS": 3,
+	"FILES_TAB_BADGE": 4,
 }
 
 var SubscriptionTopicRevMap = map[SubscriptionTopic]string{
@@ -1334,6 +1336,7 @@ var SubscriptionTopicRevMap = map[SubscriptionTopic]string{
 	1: "JOURNAL_STATUS",
 	2: "ONLINE_STATUS",
 	3: "DOWNLOAD_STATUS",
+	4: "FILES_TAB_BADGE",
 }
 
 func (e SubscriptionTopic) String() string {
@@ -1439,6 +1442,38 @@ func (o DownloadStatus) DeepCopy() DownloadStatus {
 			return ret
 		})(o.States),
 	}
+}
+
+type FilesTabBadge int
+
+const (
+	FilesTabBadge_NONE             FilesTabBadge = 0
+	FilesTabBadge_UploadingStuck   FilesTabBadge = 1
+	FilesTabBadge_AwaitingToUpload FilesTabBadge = 2
+	FilesTabBadge_Uploading        FilesTabBadge = 3
+)
+
+func (o FilesTabBadge) DeepCopy() FilesTabBadge { return o }
+
+var FilesTabBadgeMap = map[string]FilesTabBadge{
+	"NONE":             0,
+	"UploadingStuck":   1,
+	"AwaitingToUpload": 2,
+	"Uploading":        3,
+}
+
+var FilesTabBadgeRevMap = map[FilesTabBadge]string{
+	0: "NONE",
+	1: "UploadingStuck",
+	2: "AwaitingToUpload",
+	3: "Uploading",
+}
+
+func (e FilesTabBadge) String() string {
+	if v, ok := FilesTabBadgeRevMap[e]; ok {
+		return v
+	}
+	return fmt.Sprintf("%v", int(e))
 }
 
 type GUIViewType int
@@ -1744,6 +1779,9 @@ type SimpleFSConfigureDownloadArg struct {
 	DownloadDirOverride string `codec:"downloadDirOverride" json:"downloadDirOverride"`
 }
 
+type SimpleFSGetFilesTabBadgeArg struct {
+}
+
 type SimpleFSGetGUIFileContextArg struct {
 	Path KBFSPath `codec:"path" json:"path"`
 }
@@ -1866,6 +1904,7 @@ type SimpleFSInterface interface {
 	SimpleFSCancelDownload(context.Context, string) error
 	SimpleFSDismissDownload(context.Context, string) error
 	SimpleFSConfigureDownload(context.Context, SimpleFSConfigureDownloadArg) error
+	SimpleFSGetFilesTabBadge(context.Context) (FilesTabBadge, error)
 	SimpleFSGetGUIFileContext(context.Context, KBFSPath) (GUIFileContext, error)
 }
 
@@ -2643,6 +2682,16 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return
 				},
 			},
+			"simpleFSGetFilesTabBadge": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSGetFilesTabBadgeArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.SimpleFSGetFilesTabBadge(ctx)
+					return
+				},
+			},
 			"simpleFSGetGUIFileContext": {
 				MakeArg: func() interface{} {
 					var ret [1]SimpleFSGetGUIFileContextArg
@@ -3022,6 +3071,11 @@ func (c SimpleFSClient) SimpleFSDismissDownload(ctx context.Context, downloadID 
 
 func (c SimpleFSClient) SimpleFSConfigureDownload(ctx context.Context, __arg SimpleFSConfigureDownloadArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSConfigureDownload", []interface{}{__arg}, nil, 0*time.Millisecond)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSGetFilesTabBadge(ctx context.Context) (res FilesTabBadge, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetFilesTabBadge", []interface{}{SimpleFSGetFilesTabBadgeArg{}}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -700,3 +700,15 @@ func (s *SimpleFSHandler) SimpleFSGetGUIFileContext(ctx context.Context,
 	}
 	return cli.SimpleFSGetGUIFileContext(ctx, path)
 }
+
+// SimpleFSGetFilesTabBadge implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSGetFilesTabBadge(ctx context.Context) (
+	keybase1.FilesTabBadge, error) {
+	ctx, cancel := s.wrapContextWithTimeout(ctx)
+	defer cancel()
+	cli, err := s.client()
+	if err != nil {
+		return keybase1.FilesTabBadge_NONE, err
+	}
+	return cli.SimpleFSGetFilesTabBadge(ctx)
+}

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -550,7 +550,8 @@ protocol SimpleFS {
     FAVORITES_0,
     JOURNAL_STATUS_1,
     ONLINE_STATUS_2,
-    DOWNLOAD_STATUS_3
+    DOWNLOAD_STATUS_3,
+    FILES_TAB_BADGE_4
   }
   enum PathSubscriptionTopic {
     CHILDREN_0,
@@ -606,6 +607,23 @@ protocol SimpleFS {
   // and non-regular downloads.
   void simpleFSDismissDownload(string downloadID);
   void simpleFSConfigureDownload(string cacheDirOverride, string downloadDirOverride);
+
+  // FilesTabBadge is the bagde we show on the Files tab, to indicate
+  // attention-seeking status across entire KBFS.
+  enum FilesTabBadge {
+    NONE_0, // No badge.
+    // We are stuck in conflict resolution in a TLF. This causes GUI to show a
+    // red upload icon on the Files tab. NOTE that this should have higher
+    // priority than other uplaod status.
+    UploadingStuck_1, 
+    // We have stuff in the journal for a TLF, but we are currently offline.
+    // This causes GUI to show a gray uplaod icon on the Files tab.
+    AwaitingToUpload_2, 
+    // We have stuff in the journal for a TLF, and we're uploading. This causes
+    // GUI to show a blue uplaod icon on the Files tab.
+    Uploading_3
+  }
+  FilesTabBadge simpleFSGetFilesTabBadge();
 
   enum GUIViewType {
     DEFAULT_0,

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -608,20 +608,20 @@ protocol SimpleFS {
   void simpleFSDismissDownload(string downloadID);
   void simpleFSConfigureDownload(string cacheDirOverride, string downloadDirOverride);
 
-  // FilesTabBadge is the bagde we show on the Files tab, to indicate
+  // FilesTabBadge is the badge we show on the Files tab, to indicate
   // attention-seeking status across entire KBFS.
   enum FilesTabBadge {
     NONE_0, // No badge.
     // We are stuck in conflict resolution in a TLF. This causes GUI to show a
     // red upload icon on the Files tab. NOTE that this should have higher
-    // priority than other uplaod status.
-    UploadingStuck_1, 
+    // priority than other upload status.
+    UPLOADING_STUCK_1,
     // We have stuff in the journal for a TLF, but we are currently offline.
     // This causes GUI to show a gray uplaod icon on the Files tab.
-    AwaitingToUpload_2, 
+    AWAITING_UPLOAD_2,
     // We have stuff in the journal for a TLF, and we're uploading. This causes
-    // GUI to show a blue uplaod icon on the Files tab.
-    Uploading_3
+    // GUI to show a blue upload icon on the Files tab.
+    UPLOADING_3
   }
   FilesTabBadge simpleFSGetFilesTabBadge();
 

--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -98,6 +98,7 @@
   "keybase.1.SimpleFS.simpleFSUserEditHistory": {"promise": true},
   "keybase.1.SimpleFS.simpleFSWait": {"promise": true},
   "keybase.1.SimpleFS.simpleFSGetFolder": {"promise": true},
+  "keybase.1.SimpleFS.simpleFSGetFilesTabBadge": {"promise": true},
   "keybase.1.account.cancelReset": {"promise": true},
   "keybase.1.account.emailChange": {"promise": true},
   "keybase.1.account.enterResetPipeline": {"engineSaga": true},

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -885,9 +885,9 @@
       "name": "FilesTabBadge",
       "symbols": [
         "NONE_0",
-        "UploadingStuck_1",
-        "AwaitingToUpload_2",
-        "Uploading_3"
+        "UPLOADING_STUCK_1",
+        "AWAITING_UPLOAD_2",
+        "UPLOADING_3"
       ]
     },
     {

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -788,7 +788,8 @@
         "FAVORITES_0",
         "JOURNAL_STATUS_1",
         "ONLINE_STATUS_2",
-        "DOWNLOAD_STATUS_3"
+        "DOWNLOAD_STATUS_3",
+        "FILES_TAB_BADGE_4"
       ]
     },
     {
@@ -877,6 +878,16 @@
           },
           "name": "states"
         }
+      ]
+    },
+    {
+      "type": "enum",
+      "name": "FilesTabBadge",
+      "symbols": [
+        "NONE_0",
+        "UploadingStuck_1",
+        "AwaitingToUpload_2",
+        "Uploading_3"
       ]
     },
     {
@@ -1571,6 +1582,10 @@
         }
       ],
       "response": null
+    },
+    "simpleFSGetFilesTabBadge": {
+      "request": [],
+      "response": "FilesTabBadge"
     },
     "simpleFSGetGUIFileContext": {
       "request": [

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1565,8 +1565,8 @@ export enum FileType {
 
 export enum FilesTabBadge {
   none = 0,
-  uploadingstuck = 1,
-  awaitingtoupload = 2,
+  uploadingStuck = 1,
+  awaitingUpload = 2,
   uploading = 3,
 }
 

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -263,6 +263,10 @@ export type MessageTypes = {
     inParam: void
     outParam: DownloadStatus
   }
+  'keybase.1.SimpleFS.simpleFSGetFilesTabBadge': {
+    inParam: void
+    outParam: FilesTabBadge
+  }
   'keybase.1.SimpleFS.simpleFSGetFolder': {
     inParam: {readonly path: KBFSPath}
     outParam: FolderWithFavFlags
@@ -1559,6 +1563,13 @@ export enum FileType {
   file = 2,
 }
 
+export enum FilesTabBadge {
+  none = 0,
+  uploadingstuck = 1,
+  awaitingtoupload = 2,
+  uploading = 3,
+}
+
 export enum FolderConflictType {
   none = 0,
   inConflict = 1,
@@ -2291,6 +2302,7 @@ export enum SubscriptionTopic {
   journalStatus = 1,
   onlineStatus = 2,
   downloadStatus = 3,
+  filesTabBadge = 4,
 }
 
 export enum TLFIdentifyBehavior {
@@ -3230,6 +3242,7 @@ export const SimpleFSSimpleFSFinishResolvingConflictRpcPromise = (params: Messag
 export const SimpleFSSimpleFSFolderSyncConfigAndStatusRpcPromise = (params: MessageTypes['keybase.1.SimpleFS.simpleFSFolderSyncConfigAndStatus']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.SimpleFS.simpleFSFolderSyncConfigAndStatus']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.SimpleFS.simpleFSFolderSyncConfigAndStatus', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const SimpleFSSimpleFSGetDownloadInfoRpcPromise = (params: MessageTypes['keybase.1.SimpleFS.simpleFSGetDownloadInfo']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.SimpleFS.simpleFSGetDownloadInfo']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.SimpleFS.simpleFSGetDownloadInfo', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const SimpleFSSimpleFSGetDownloadStatusRpcPromise = (params: MessageTypes['keybase.1.SimpleFS.simpleFSGetDownloadStatus']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.SimpleFS.simpleFSGetDownloadStatus']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.SimpleFS.simpleFSGetDownloadStatus', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const SimpleFSSimpleFSGetFilesTabBadgeRpcPromise = (params: MessageTypes['keybase.1.SimpleFS.simpleFSGetFilesTabBadge']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.SimpleFS.simpleFSGetFilesTabBadge']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.SimpleFS.simpleFSGetFilesTabBadge', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const SimpleFSSimpleFSGetFolderRpcPromise = (params: MessageTypes['keybase.1.SimpleFS.simpleFSGetFolder']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.SimpleFS.simpleFSGetFolder']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.SimpleFS.simpleFSGetFolder', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const SimpleFSSimpleFSGetGUIFileContextRpcPromise = (params: MessageTypes['keybase.1.SimpleFS.simpleFSGetGUIFileContext']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.SimpleFS.simpleFSGetGUIFileContext']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.SimpleFS.simpleFSGetGUIFileContext', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const SimpleFSSimpleFSListFavoritesRpcPromise = (params: MessageTypes['keybase.1.SimpleFS.simpleFSListFavorites']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.SimpleFS.simpleFSListFavorites']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.SimpleFS.simpleFSListFavorites', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))


### PR DESCRIPTION
This implements the logic needed to power the files tab badge.  It can be in four states:

* **Stuck**: if any TLF is stuck in conflict mode, the badge gets this state.
* **Awaiting upload**: if there is un-uploaded data, and we're offline, the badge gets this state.  This only measures mdserver connectivity.
* **Uploading**: if there is un-uploaded data, and we're online, the badge gets this state.
* **None**: None of the above.

This also adds notifications for subscribers of the `FILES_TAB_BADGE` topic.  Listeners get pinged whenever new bytes are added to or flushed from the journal, whenever the mdserver connectivity changes, and/or whenever the stuck status of a TLF changes.  Note that just because there was a notification, it doesn't mean the badge state has changed; it still must be checked explicitly via RPC.

Issue: HOTPOT-1135