### PR TITLE
fs/gui: fix makeUUID

### DIFF
--- a/shared/constants/fs.tsx
+++ b/shared/constants/fs.tsx
@@ -286,10 +286,11 @@ export const emptyFileContext = {
 // 12 chars
 const uuidSeed = Date.now().toString(36) + '-'
 let counter = 0
+// We have 36^4=1,679,616 of space to work with in order to not exceed 16
+// bytes.
+const counterMod = 36 * 36 * 36 * 36
 export const makeUUID = () => {
-  // We have 36^4=1,679,616 of space to work with in order to not exceed 16
-  // bytes, so mod 1e6 is safe.
-  counter = (counter + 1) % 1e6
+  counter = (counter + 1) % counterMod
   return uuidSeed + counter.toString(36)
 }
 

--- a/shared/fs/common/hooks.tsx
+++ b/shared/fs/common/hooks.tsx
@@ -6,7 +6,6 @@ import * as FsGen from '../../actions/fs-gen'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as Kb from '../../common-adapters'
 import {isMobile} from '../../constants/platform'
-import uuidv1 from 'uuid/v1'
 import flags from '../../util/feature-flags'
 
 const isPathItem = (path: Types.Path) => Types.getPathLevel(path) > 2 || Constants.hasSpecialFileElement(path)
@@ -38,7 +37,7 @@ const useFsPathSubscriptionEffect = (path: Types.Path, topic: RPCTypes.PathSubsc
       return () => {}
     }
 
-    const subscriptionID = uuidv1()
+    const subscriptionID = Constants.makeUUID()
     dispatch(FsGen.createSubscribePath({path, subscriptionID, topic}))
     return () => dispatch(FsGen.createUnsubscribe({subscriptionID}))
   }, [dispatch, path, topic])
@@ -47,7 +46,7 @@ const useFsPathSubscriptionEffect = (path: Types.Path, topic: RPCTypes.PathSubsc
 const useFsNonPathSubscriptionEffect = (topic: RPCTypes.SubscriptionTopic) => {
   const dispatch = useDispatchWhenConnected()
   React.useEffect(() => {
-    const subscriptionID = uuidv1()
+    const subscriptionID = Constants.makeUUID()
     dispatch(FsGen.createSubscribeNonPath({subscriptionID, topic}))
     return () => dispatch(FsGen.createUnsubscribe({subscriptionID}))
   }, [dispatch, topic])

--- a/shared/package.json
+++ b/shared/package.json
@@ -193,7 +193,6 @@
     "typedarray-to-buffer": "3.1.5",
     "unidecode": "0.1.8",
     "url-parse": "1.4.7",
-    "uuid": "3.3.2",
     "whatwg-url": "7.0.0"
   },
   "devDependencies": {

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -13546,7 +13546,7 @@ uuid-js@^0.7.5:
   resolved "https://registry.yarnpkg.com/uuid-js/-/uuid-js-0.7.5.tgz#6c886d02a53d2d40dcf25d91a170b4a7b25b94d0"
   integrity sha1-bIhtAqU9LUDc8l2RoXC0p7JblNA=
 
-uuid@3.3.2, uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==


### PR DESCRIPTION
Crazy bug. SimpleFS expects a string opID and interpret it as [16]byte.
We use a UUID library and call `uuidv1`, which despite being timestamp
based, would happily go over 16 bytes even though we supply with a
Buffer.alloc(16). After cutting off, we occasionally get duplicasted
opID. Possibly due to the way uuidv1 is formatted, this happens pretty
often.

It's a problem when we have multiple RPCs going on. Visible issue
isone can get another's opID removed from inProgress when SimpleFSWait
is called. This is why occasionally draging/dropping many files results
in error on some but not all files.

It's also why sometimes error happens after creating a new folder in
GUI, which is what this ticket was originally about. We do a
folderListLoad after creating succeeds because historically we didn't
have notifications when folder content changed and we just reloaded
everytime we changed something. Now that we have notifications,
notifications cause such loads too. So multiple folerListLoad can happen
concurrently and when unforutnate duplicaste opID happen. It's more
likely to happen when multiple folder creations happen together.
Apparently we should avoid loading after successfully creating a folder
now that we have notifications, but that's a separate issue which I'll
have another PR.