### PR TITLE
test: re-sync the active TLF after adding a new assertion

### DIFF
--- a/go/kbfs/libfs/fs_notifications.go
+++ b/go/kbfs/libfs/fs_notifications.go
@@ -43,7 +43,6 @@ func (f *FSNotifications) processNotifications(ctx context.Context) {
 		case <-ctx.Done():
 			f.notificationMutex.Lock()
 			c := f.notifications
-			f.log.CDebugf(ctx, "Nilling notifications channel")
 			f.notifications = nil
 			f.notificationMutex.Unlock()
 			c.Close()

--- a/go/kbfs/test/dsl_test.go
+++ b/go/kbfs/test/dsl_test.go
@@ -398,6 +398,10 @@ func addNewAssertion(oldAssertion, newAssertion string) optionOp {
 		for _, u := range o.users {
 			err := o.engine.AddNewAssertion(u, oldAssertion, newAssertion)
 			o.expectSuccess("addNewAssertion", err)
+			// Sync the TLF to wait for the TLF handle change
+			// notifications to be processed. Ignore the error since
+			// the user might not even have access to that TLF.
+			_ = o.engine.SyncFromServer(u, o.tlfName, o.tlfType)
 		}
 	}
 }


### PR DESCRIPTION
libfuse handle TLF name change invalidations in a background goroutine.  Before this change, if that goroutine was too delayed, then after a new assertion is added, the TLF name might not have been invalidated by the time the test expects needs to be (e.g., the next `in...TlfNonCanonical()` call).  With this change, we just sync the active TLF after a new assertion is added, which waits on the invalidations caused by the new assertion to finish.

(This is based on a CI test failure that I wasn't able to repro locally, but it's my best given from the logs.)

Also, remove a log message that would sometimes fire in tests after the test finished, and cause a failure.

Issue: HOTPOT-1100