### PR TITLE
PICNIC-448 - Whats New: Fix badge state when no lastSeenVersion exists

### DIFF
--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -21,6 +21,7 @@ import * as Tabs from '../../constants/tabs'
 import * as Router2 from '../../constants/router2'
 import * as FsTypes from '../../constants/types/fs'
 import URL from 'url-parse'
+import {noVersion} from '../../constants/whats-new'
 import {isAndroid, isMobile, appColorSchemeChanged} from '../../constants/platform'
 import {updateServerConfigLastLoggedIn} from '../../app/server-config'
 import * as Container from '../../util/container'
@@ -605,10 +606,12 @@ const gregorPushState = (_: Container.TypedState, action: GregorGen.PushStatePay
   const lastSeenItem = items.find(i => i.item && i.item.category === 'whatsNewLastSeenVersion')
   if (lastSeenItem) {
     const {body} = lastSeenItem.item
-    const lastVersion = body.toString()
+    const pushStateLastSeenVersion = body.toString()
+    const lastSeenVersion = pushStateLastSeenVersion || noVersion
+    // Default to 0.0.0 (noVersion) if user has never marked a version as seen
     actions.push(
       ConfigGen.createSetWhatsNewLastSeenVersion({
-        lastSeenVersion: lastVersion,
+        lastSeenVersion,
       })
     )
   }

--- a/shared/constants/whats-new.tsx
+++ b/shared/constants/whats-new.tsx
@@ -36,7 +36,10 @@ export const isVersionValid = (version: string) => {
 }
 
 export const anyVersionsUnseen = (lastSeenVersion: string): boolean =>
-  Object.values(getSeenVersions(lastSeenVersion)).some(seen => !seen)
+  // On first load of what's new, lastSeenVersion == noVersion so everything is unseen
+  lastLastVersion && lastSeenVersion === noVersion
+    ? true
+    : Object.values(getSeenVersions(lastSeenVersion)).some(seen => !seen)
 
 export const getSeenVersions = (lastSeenVersion: string): seenVersionsMap => {
   // Mark all versions as seen so that the icon doesn't change as Gregor state is loading
@@ -46,9 +49,17 @@ export const getSeenVersions = (lastSeenVersion: string): seenVersionsMap => {
     [lastVersion]: true,
   }
 
-  // User has no entry in Gregor for lastSeenVersion, so mark all as unseen
+  // lastSeenVersion hasn't loaded yet, so don't set a badge state
   if (!lastSeenVersion || !semver.valid(lastSeenVersion)) {
     return initialMap
+  }
+  // User has no entry in Gregor for lastSeenVersion, so mark all as unseen
+  if (lastSeenVersion === noVersion) {
+    return {
+      [currentVersion]: false,
+      [lastLastVersion]: false,
+      [lastVersion]: false,
+    }
   }
 
   // last and lastLast versions might not be set


### PR DESCRIPTION
I had set my own gregor value to `0.0.0` correctly and forgot to set the initial value to be `0.0.0` instead of `""`.
So this defaults first time users to have a `lastSeenVersion` value of `0.0.0` and handles the badge state correctly as a result.