### PR TITLE
test_common: plug subscription manager goroutine leak

### DIFF
--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -228,9 +228,6 @@ func MakeTestConfigOrBustLoggedInWithMode(
 	configs := []Config{config}
 	config.allKnownConfigsForTesting = &configs
 
-	config.subscriptionManager, config.subscriptionManagerPublisher =
-		newSubscriptionManager(config)
-
 	return config
 }
 


### PR DESCRIPTION
The `config` object already has a `subcriptionManager` at this point. If we overwrite it, then the goroutine started by the original one will never be stopped on shutdown.