### PR TITLE
fix stars in chat search box

### DIFF
--- a/shared/chat/conversation-filter-input.tsx
+++ b/shared/chat/conversation-filter-input.tsx
@@ -142,7 +142,7 @@ const styles = Styles.styleSheetCreate(
           backgroundColor: Styles.globalColors.blueGrey,
         },
         isMobile: {
-          backgroundColor: Styles.globalColors.fastBlank,
+          backgroundColor: Styles.globalColors.white,
         },
       }),
       filterContainer: Styles.platformStyles({


### PR DESCRIPTION
on android, opening the keyboard on the new chat search caused some star illustrations to appear behind the search box, decreasing legibility. this pr changes the fastblank background used on that input to `white` so it's not transparent on android.