### PR TITLE
only use stored writer names for teams

### DIFF
--- a/shared/constants/chat2/meta.tsx
+++ b/shared/constants/chat2/meta.tsx
@@ -56,8 +56,9 @@ export const unverifiedInboxUIItemToConversationMeta = (
       : []
   )
 
-  const participants = i.localMetadata ? i.localMetadata.writerNames || [] : (i.name || '').split(',')
   const isTeam = i.membersType === RPCChatTypes.ConversationMembersType.team
+  const participants =
+    i.localMetadata && isTeam ? i.localMetadata.writerNames || [] : (i.name || '').split(',')
   const channelname = isTeam && i.localMetadata ? i.localMetadata.channelName : ''
 
   const supersededBy = conversationMetadataToMetaSupersedeInfo(i.supersededBy)


### PR DESCRIPTION
Otherwise restricted bots make their was into ad hoc conv names for a second.