### PR TITLE
ephemeral performance fixes

### DIFF
--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -500,9 +500,9 @@ func batchLoadEncryptionKIDs(ctx context.Context, g *libkb.GlobalContext, uvs []
 		return &tmp
 	}
 
-	processResult := func(i int, upak *keybase1.UserPlusKeysV2AllIncarnations) {
+	processResult := func(i int, upak *keybase1.UserPlusKeysV2AllIncarnations) error {
 		if upak == nil {
-			return
+			return nil
 		}
 		for _, key := range upak.Current.DeviceKeys {
 			// Include only unrevoked encryption keys.
@@ -510,6 +510,7 @@ func batchLoadEncryptionKIDs(ctx context.Context, g *libkb.GlobalContext, uvs []
 				ret = append(ret, key.Base.Kid)
 			}
 		}
+		return nil
 	}
 
 	err = g.GetUPAKLoader().Batcher(ctx, getArg, processResult, 0)

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -295,6 +295,12 @@ func teamEKRetryWrapper(mctx libkb.MetaContext, retryFn func() error) (err error
 		}
 		mctx.Debug("teamEKRetryWrapper found a retryable error on try %d: %v",
 			tries, err)
+		select {
+		case <-mctx.Ctx().Done():
+			return mctx.Ctx().Err()
+		default:
+			// continue retrying
+		}
 	}
 	return err
 }
@@ -473,7 +479,7 @@ type teamMemberEKStatementResponse struct {
 // the map of users the server returns are indeed valid team members of the
 // team and all signatures verify correctly for the users.
 func fetchTeamMemberStatements(mctx libkb.MetaContext,
-	teamID keybase1.TeamID) (statementMap map[keybase1.UID]*keybase1.UserEkStatement, err error) {
+	teamID keybase1.TeamID) (statements map[keybase1.UID]*keybase1.UserEkStatement, err error) {
 	defer mctx.TraceTimed("fetchTeamMemberStatements", func() error { return err })()
 
 	apiArg := libkb.APIArg{
@@ -488,44 +494,77 @@ func fetchTeamMemberStatements(mctx libkb.MetaContext,
 		return nil, err
 	}
 
-	parsedResponse := teamMemberEKStatementResponse{}
-	err = res.Body.UnmarshalAgain(&parsedResponse)
-	if err != nil {
+	memberEKStatements := teamMemberEKStatementResponse{}
+	if err = res.Body.UnmarshalAgain(&memberEKStatements); err != nil {
 		return nil, err
 	}
 
 	team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
-		ID:          teamID,
-		ForceRepoll: true,
+		ID: teamID,
 	})
 	if err != nil {
 		return nil, err
 	}
-	statementMap = make(map[keybase1.UID]*keybase1.UserEkStatement)
-	for uid, sig := range parsedResponse.Sigs {
-		// Verify the server only returns actual members of our team.
-		upak, _, err := mctx.G().GetUPAKLoader().LoadV2(
-			libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(uid))
-		if err != nil {
-			return nil, err
+	var uids []keybase1.UID
+	for uid := range memberEKStatements.Sigs {
+		uids = append(uids, uid)
+	}
+
+	getArg := func(i int) *libkb.LoadUserArg {
+		if i >= len(uids) {
+			return nil
+		}
+		tmp := libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(uids[i])
+		return &tmp
+	}
+
+	var upaks []*keybase1.UserPlusKeysV2AllIncarnations
+	statements = make(map[keybase1.UID]*keybase1.UserEkStatement)
+	processResult := func(i int, upak *keybase1.UserPlusKeysV2AllIncarnations) error {
+		mctx.Debug("processing member %d/%d %.2f%% complete", i, len(uids), (float64(i) / float64(len(uids)) * 100))
+		if upak == nil {
+			mctx.Debug("Unable to load user %v", uids[i])
+			return nil
 		}
 		uv := upak.Current.ToUserVersion()
-		isMember := team.IsMember(mctx.Ctx(), uv)
-		if !isMember {
-			return nil, fmt.Errorf("Server lied about team membership! %v is not a member of team %v", uv, teamID)
+		if !team.IsMember(mctx.Ctx(), uv) {
+			// Team membership may be stale, force a reload and check again
+			team, err = teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
+				ID:          teamID,
+				ForceRepoll: true,
+			})
+			if err != nil {
+				return err
+			}
+			if !team.IsMember(mctx.Ctx(), uv) {
+				mctx.Debug("%v is not a member of team %v", uv, teamID)
+				return nil
+			}
 		}
-		memberStatement, _, wrongKID, err := verifySigWithLatestPUK(mctx, uid, sig)
-		// Check the wrongKID condition before checking the error, since an error
-		// is still returned in this case. TODO: Turn this warning into an error
-		// after EK support is sufficiently widespread.
+		upaks = append(upaks, upak)
+		return nil
+	}
+	if err = mctx.G().GetUPAKLoader().Batcher(mctx.Ctx(), getArg, processResult, 0); err != nil {
+		return nil, err
+	}
+	for _, upak := range upaks {
+		uid := upak.GetUID()
+		sig, ok := memberEKStatements.Sigs[uid]
+		if !ok {
+			mctx.Debug("missing memberEK statement for UID %v in team %v", uid, teamID)
+			continue
+		}
+		statement, _, wrongKID, err := verifySigWithLatestPUK(mctx, uid,
+			upak.Current.GetLatestPerUserKey(), sig)
 		if wrongKID {
-			mctx.Debug("Member %v revoked a device without generating new ephemeral keys. They might be running an old version?", uid)
+			mctx.Debug("UID %v has a statement signed with the wrongKID, skipping", uid)
 			// Don't box for this member since they have no valid userEK
 			continue
 		} else if err != nil {
 			return nil, err
 		}
-		statementMap[uid] = memberStatement
+		statements[uid] = statement
 	}
-	return statementMap, nil
+
+	return statements, nil
 }


### PR DESCRIPTION
- pass bulk upak loads to upak.Batcher
- don't lock EK lib on logout/shutdown since this can deadlock if the eklib's lock is held