### PR TITLE
journeycard changes

### DIFF
--- a/go/chat/journey_card_checker.go
+++ b/go/chat/journey_card_checker.go
@@ -297,9 +297,8 @@ func (cc *JourneyCardChecker) PickCard(ctx context.Context, uid gregor1.UID,
 			debugDebug(ctx, "missing joined time")
 			go cc.saveJoinedTime(globals.BackgroundChatCtx(ctx, cc.G()), convID, cc.G().GetClock().Now())
 			return false
-		} else {
-			return cc.G().GetClock().Since(jcd.JoinedTime.Time()) >= duration
 		}
+		return cc.G().GetClock().Since(jcd.JoinedTime.Time()) >= duration
 	}
 
 	// Card type: POPULAR_CHANNELS

--- a/go/chat/journey_card_checker.go
+++ b/go/chat/journey_card_checker.go
@@ -260,7 +260,7 @@ func (cc *JourneyCardChecker) PickCard(ctx context.Context, uid gregor1.UID,
 		if !show {
 			// Figure whether the user is in other channels.
 			topicType := chat1.TopicType_CHAT
-			inbox, err := cc.G().InboxSource.ReadUnverified(libkb.WithLogTag(ctx, "xyztag"), uid, types.InboxSourceDataSourceLocalOnly, &chat1.GetInboxQuery{
+			inbox, err := cc.G().InboxSource.ReadUnverified(ctx, uid, types.InboxSourceDataSourceLocalOnly, &chat1.GetInboxQuery{
 				TlfID: &tlfID,
 				// ConvIDs:   []chat1.ConversationID{convID},
 				TopicType: &topicType,

--- a/go/chat/journey_card_checker.go
+++ b/go/chat/journey_card_checker.go
@@ -197,6 +197,7 @@ func (cc *JourneyCardChecker) PickCard(ctx context.Context, uid gregor1.UID,
 				}
 			}
 		}
+	msgscan:
 		for _, msg := range thread.Messages {
 			state, err := msg.State()
 			if err != nil {
@@ -235,7 +236,7 @@ func (cc *JourneyCardChecker) PickCard(ctx context.Context, uid gregor1.UID,
 				// If there's something in the outbox, don't show this card.
 				eligibleMsg = 0
 				preventerMsg = 9999
-				break
+				break msgscan
 			case chat1.MessageUnboxedState_PLACEHOLDER:
 				save(msg.Placeholder().MessageID, false)
 			case chat1.MessageUnboxedState_JOURNEYCARD:

--- a/go/chat/journey_card_checker.go
+++ b/go/chat/journey_card_checker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 type JourneyCardChecker struct {
@@ -67,8 +68,12 @@ func (cc *JourneyCardChecker) PickCard(ctx context.Context, uid gregor1.UID,
 	}
 
 	var conv ConvEnough
+	var untrustedTeamRole keybase1.TeamRole
+	var tlfID chat1.TLFID
 	if convLocalOptional != nil {
 		conv = convLocalOptional
+		tlfID = convLocalOptional.Info.Triple.Tlfid
+		untrustedTeamRole = convLocalOptional.ReaderInfo.UntrustedTeamRole
 	} else {
 		convFromCache, err := utils.GetUnverifiedConv(ctx, cc.G(), uid, convID, types.InboxSourceDataSourceLocalOnly)
 		if err != nil {
@@ -79,12 +84,16 @@ func (cc *JourneyCardChecker) PickCard(ctx context.Context, uid gregor1.UID,
 			return nil, fmt.Errorf("conv LocalMetadata not found")
 		}
 		conv = convFromCache
+		tlfID = convFromCache.Conv.Metadata.IdTriple.Tlfid
+		if convFromCache.Conv.ReaderInfo != nil {
+			untrustedTeamRole = convFromCache.Conv.ReaderInfo.UntrustedTeamRole
+		}
 	}
 
+	inGeneralChannel := conv.GetTopicName() == globals.DefaultTeamTopic
 	if !(conv.GetTopicType() == chat1.TopicType_CHAT &&
-		conv.GetMembersType() == chat1.ConversationMembersType_TEAM &&
-		(conv.GetTopicName() == globals.DefaultTeamTopic || debug)) {
-		// Cards only exist in the general channel of team chats.
+		conv.GetMembersType() == chat1.ConversationMembersType_TEAM) {
+		// Cards only exist in team chats.
 		debugDebug(ctx, "conv not eligible for card: topicType:%v membersType:%v general:%v",
 			conv.GetTopicType(), conv.GetMembersType(), conv.GetTopicName() == globals.DefaultTeamTopic)
 		return nil, nil
@@ -101,58 +110,41 @@ func (cc *JourneyCardChecker) PickCard(ctx context.Context, uid gregor1.UID,
 
 	jcd := cc.getConvData(ctx, convID)
 
-	makeCard := func(cardType chat1.JourneycardType, highlightMsgID chat1.MessageID) (*chat1.MessageUnboxedJourneycard, error) {
-		pos := jcd.Positions[cardType]
+	makeCard := func(cardType chat1.JourneycardType, highlightMsgID chat1.MessageID, preferSavedPosition bool) (*chat1.MessageUnboxedJourneycard, error) {
+		// preferSavedPosition : If true, the card stays in the position it was previously seen. If false, the card goes at the bottom.
+		var pos *journeyCardPosition
+		if preferSavedPosition {
+			pos = jcd.Positions[cardType]
+		}
 		if pos == nil {
 			// Pick a message to use as the base for a frontend ordinal.
-			// Get out of the way of any other messages that have taken ordinal offsets of that message.
 			prevID := conv.MaxVisibleMsgID()
-			ordinal := 1 // offset within
-			for _, message := range thread.Messages {
-				if message.GetMessageID() > prevID {
-					prevID = message.GetMessageID()
-					ordinal = 1
-				}
-				state, err := message.State()
-				if err != nil {
-					continue
-				}
-				foundOrdinal := func(foundOrdinal int) {
-					if prevID == message.GetMessageID() && foundOrdinal > ordinal {
-						ordinal = foundOrdinal + 1
-					}
-				}
-				switch state {
-				case chat1.MessageUnboxedState_OUTBOX:
-					foundOrdinal(message.Outbox().Ordinal)
-				case chat1.MessageUnboxedState_JOURNEYCARD:
-					foundOrdinal(message.Journeycard().Ordinal)
-				}
-			}
 			if prevID == 0 {
 				debugDebug(ctx, "no message found to use as base for ordinal")
 				return nil, nil
 			}
-
 			pos = &journeyCardPosition{
-				PrevID:  prevID,
-				Ordinal: ordinal,
+				PrevID: prevID,
 			}
-
 			go cc.savePosition(globals.BackgroundChatCtx(ctx, cc.G()), convID, cardType, *pos)
-
-			// TODO reserve ordinals. Otherwise outbox clobbers journey card ordinals. Something like this:
-			// go func() {
-			// 	ctx := globals.BackgroundChatCtx(ctx, cc.G())
-			// 	err := outbox.ReservePosition(ctx, convID, pos.PrevID, pos.Ordinal)
-			// 	if err != nil {
-			// 		cc.Debug(ctx, "ReservePosition error: %v", err)
-			// 	}
-			// }()
+		} else {
+			var foundPrev bool
+			for _, msg := range thread.Messages {
+				if msg.GetMessageID() == pos.PrevID {
+					foundPrev = true
+					break
+				}
+			}
+			// If the message that is being used as a prev is not found, omit the card.
+			// So that the card isn't presented at the edge of a far away page.
+			if !foundPrev {
+				return nil, nil
+			}
 		}
+		ordinal := 1 // Won't conflict with outbox messages since they are all <= outboxOrdinalStart.
 		return &chat1.MessageUnboxedJourneycard{
 			PrevID:         pos.PrevID,
-			Ordinal:        pos.Ordinal,
+			Ordinal:        ordinal,
 			CardType:       cardType,
 			HighlightMsgID: highlightMsgID,
 		}, nil
@@ -162,63 +154,189 @@ func (cc *JourneyCardChecker) PickCard(ctx context.Context, uid gregor1.UID,
 		// for testing, do special stuff based on channel name:
 		switch conv.GetTopicName() {
 		case "kb_cards_0_kb":
-			return makeCard(chat1.JourneycardType_WELCOME, 0)
+			return makeCard(chat1.JourneycardType_WELCOME, 0, false)
 		case "kb_cards_1_kb":
-			return makeCard(chat1.JourneycardType_POPULAR_CHANNELS, 0)
+			return makeCard(chat1.JourneycardType_POPULAR_CHANNELS, 0, false)
 		case "kb_cards_2_kb":
-			return makeCard(chat1.JourneycardType_ADD_PEOPLE, 0)
+			return makeCard(chat1.JourneycardType_ADD_PEOPLE, 0, false)
 		case "kb_cards_3_kb":
-			return makeCard(chat1.JourneycardType_CREATE_CHANNELS, 0)
+			return makeCard(chat1.JourneycardType_CREATE_CHANNELS, 0, false)
 		case "kb_cards_4_kb":
-			return makeCard(chat1.JourneycardType_MSG_ATTENTION, 3)
+			return makeCard(chat1.JourneycardType_MSG_ATTENTION, 3, false)
 		case "kb_cards_5_kb":
-			return makeCard(chat1.JourneycardType_USER_AWAY_FOR_LONG, 0)
+			return makeCard(chat1.JourneycardType_USER_AWAY_FOR_LONG, 0, false)
 		case "kb_cards_6_kb":
-			return makeCard(chat1.JourneycardType_CHANNEL_INACTIVE, 0)
+			return makeCard(chat1.JourneycardType_CHANNEL_INACTIVE, 0, false)
 		case "kb_cards_7_kb":
-			return makeCard(chat1.JourneycardType_MSG_NO_ANSWER, 0)
+			return makeCard(chat1.JourneycardType_MSG_NO_ANSWER, 0, false)
 		}
 	}
 
-	// TODO card type: WELCOME (interaction with existing system message) (persist its location, disappear when other cards come in)
+	// TODO factor out individual message filters. This func is getting a bit big. Also might help with dealing
+	// with the reversed priorities of cards that have already been shown. Maybe if no new cards trigger, show the
+	// latest already shown card.
 
-	// Card type: POPULAR_CHANNELS
-	// Gist: "You are in #general. Other popular channels in this team: diplomacy, sportsball"
-	// Condition: The team has channels besides general.
-	// Condition: User has sent a first message OR a few days have passed since they joined the channel.
-	otherChannelsExist := conv.GetTeamType() == chat1.TeamType_COMPLEX
-	if otherChannelsExist {
-		debugDebug(ctx, "other channels exist")
-		show := jcd.SentMessage
-		if !show {
-			if jcd.JoinedTime == nil {
-				debugDebug(ctx, "missing joined time")
-				go cc.saveJoinedTime(globals.BackgroundChatCtx(ctx, cc.G()), convID, cc.G().GetClock().Now())
+	// TODO card type: WELCOME (1) (interaction with existing system message) (persist its location, disappear when other cards come in)
+	// Condition: Only in #general channel
+
+	// Card type: MSG_NO_ANSWER (C)
+	// Gist: "People haven't been talkative in a while. Perhaps post in another channel? <list of channels>"
+	// Condition: The last visible message is old, was sent by the logged-in user, and was a long text message.
+	{
+		// If the latest message is eligible then show the card.
+		var eligibleMsg chat1.MessageID  // maximum eligible msg
+		var preventerMsg chat1.MessageID // maximum preventer msg
+		save := func(msgID chat1.MessageID, eligible bool) {
+			if eligible {
+				if msgID > eligibleMsg {
+					eligibleMsg = msgID
+				}
 			} else {
-				cutoff := time.Hour * 24 * 2
-				if cc.G().GetClock().Since(jcd.JoinedTime.Time()) >= cutoff {
-					show = true
+				if msgID > preventerMsg {
+					preventerMsg = msgID
+				}
+			}
+		}
+		for _, msg := range thread.Messages {
+			state, err := msg.State()
+			if err != nil {
+				continue
+			}
+			switch state {
+			case chat1.MessageUnboxedState_VALID:
+				msg.GetMessageID()
+				eligible := func() bool {
+					if !msg.IsValidFull() {
+						return false
+					}
+					if !msg.Valid().ClientHeader.Sender.Eq(uid) {
+						return false
+					}
+					switch msg.GetMessageType() {
+					case chat1.MessageType_TEXT:
+						const howLongIsLong = 40
+						const howOldIsOld = time.Hour * 24
+						isLong := (len(msg.Valid().MessageBody.Text().Body) >= howLongIsLong)
+						isOld := (cc.G().GetClock().Since(msg.Valid().ServerHeader.Ctime.Time()) >= howOldIsOld)
+						answer := isLong && isOld
+						return answer
+					default:
+						return false
+					}
+				}
+				if eligible() {
+					save(msg.GetMessageID(), true)
 				} else {
-					debugDebug(ctx, "not past time")
+					save(msg.GetMessageID(), false)
+				}
+			case chat1.MessageUnboxedState_ERROR:
+				save(msg.Error().MessageID, false)
+			case chat1.MessageUnboxedState_OUTBOX:
+				// If there's something in the outbox, don't show this card.
+				eligibleMsg = 0
+				preventerMsg = 9999
+				break
+			case chat1.MessageUnboxedState_PLACEHOLDER:
+				save(msg.Placeholder().MessageID, false)
+			case chat1.MessageUnboxedState_JOURNEYCARD:
+				save(msg.Journeycard().PrevID, false)
+			default:
+				debugDebug(ctx, "unrecognized message state: %v", state)
+				continue
+			}
+		}
+		show := eligibleMsg != 0 && eligibleMsg >= preventerMsg
+		if show {
+			return makeCard(chat1.JourneycardType_MSG_NO_ANSWER, 0, true)
+		}
+	}
+
+	// Card type: ADD_PEOPLE (3)
+	// Gist: "Do you know people interested in joining?"
+	// Condition: User is an admin.
+	// Condition: User has sent messages OR joined channels.
+	if untrustedTeamRole.IsAdminOrAbove() {
+		show := jcd.SentMessage || !inGeneralChannel
+		if !show {
+			// Figure whether the user is in other channels.
+			topicType := chat1.TopicType_CHAT
+			inbox, err := cc.G().InboxSource.ReadUnverified(libkb.WithLogTag(ctx, "xyztag"), uid, types.InboxSourceDataSourceLocalOnly, &chat1.GetInboxQuery{
+				TlfID: &tlfID,
+				// ConvIDs:   []chat1.ConversationID{convID},
+				TopicType: &topicType,
+				MemberStatus: []chat1.ConversationMemberStatus{
+					chat1.ConversationMemberStatus_ACTIVE,
+					chat1.ConversationMemberStatus_REMOVED,
+					chat1.ConversationMemberStatus_LEFT,
+					chat1.ConversationMemberStatus_PREVIEW,
+				},
+				MembersTypes:     []chat1.ConversationMembersType{chat1.ConversationMembersType_TEAM},
+				SummarizeMaxMsgs: true,
+				SkipBgLoads:      true,
+			}, nil)
+			if err != nil {
+				debugDebug(ctx, "ReadUnverified error: %v", err)
+			} else {
+				debugDebug(ctx, "ReadUnverified found %v convs", len(inbox.ConvsUnverified))
+				for _, convOther := range inbox.ConvsUnverified {
+					if !convOther.GetConvID().Eq(convID) {
+						debugDebug(ctx, "ReadUnverified found alternate conv: %v", convOther.GetTopicName()) // xxx do not log this
+						show = true
+						break
+					}
 				}
 			}
 		}
 		if show {
-			return makeCard(chat1.JourneycardType_POPULAR_CHANNELS, 0)
+			return makeCard(chat1.JourneycardType_ADD_PEOPLE, 0, true)
 		}
 	}
 
-	// TODO card type: ADD_PEOPLE
+	timeSinceJoined := func(duration time.Duration) bool {
+		if jcd.JoinedTime == nil {
+			debugDebug(ctx, "missing joined time")
+			go cc.saveJoinedTime(globals.BackgroundChatCtx(ctx, cc.G()), convID, cc.G().GetClock().Now())
+			return false
+		} else {
+			return cc.G().GetClock().Since(jcd.JoinedTime.Time()) >= duration
+		}
+	}
+
+	// Card type: POPULAR_CHANNELS
+	// Gist: "You are in #general. Other popular channels in this team: diplomacy, sportsball"
+	// Condition: Only in #general channel
+	// Condition: The team has channels besides general.
+	// Condition: User has sent a first message OR a few days have passed since they joined the channel.
+	otherChannelsExist := conv.GetTeamType() == chat1.TeamType_COMPLEX
+	if (inGeneralChannel || debug) && otherChannelsExist {
+		debugDebug(ctx, "other channels exist")
+		show := jcd.SentMessage
+		if !show && timeSinceJoined(time.Hour*24*2) {
+			show = true
+		}
+		if show {
+			return makeCard(chat1.JourneycardType_POPULAR_CHANNELS, 0, true)
+		}
+	}
 
 	// TODO card type: CREATE_CHANNELS
+	// Gist: "Go ahead and create #channels around topics you think are missing."
+	// Condition: A few weeks have passed.
+	// Condition: User has sent a message.
+	if jcd.SentMessage && timeSinceJoined(time.Hour*24*14) {
+		return makeCard(chat1.JourneycardType_CREATE_CHANNELS, 0, true)
+	}
 
 	// TODO card type: MSG_ATTENTION
+	// Gist: "One of your messages is getting a lot of attention! <pointer to message>"
+	// Condition: The logged-in user's message gets a lot of reacjis
+	// Condition: That message is above the fold.
 
 	// TODO card type: USER_AWAY_FOR_LONG
+	// Gist: "Long time no see.... Look at all the things you missed."
 
 	// TODO card type: CHANNEL_INACTIVE
-
-	// TODO card type: MSG_NO_ANSWER
+	// Gist: "Zzz... This channel hasn't been very active... Revive it?"
 
 	debugDebug(ctx, "no card at end of checks")
 	return nil, nil
@@ -308,8 +426,7 @@ func (cc *JourneyCardChecker) saveJoinedTime(ctx context.Context, convID chat1.C
 }
 
 type journeyCardPosition struct {
-	PrevID  chat1.MessageID
-	Ordinal int
+	PrevID chat1.MessageID
 }
 
 // Storage for a single conversation's journey cards.

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -42,6 +42,10 @@ const outboxVersion = 4
 const ephemeralPurgeCutoff = 24 * time.Hour
 const errorPurgeCutoff = time.Hour * 24 * 7 // one week
 
+// Ordinals for the outbox start at 100.
+// So that journeycard ordinals, which are added at the last minute by postProcessConv, do not conflict.
+const outboxOrdinalStart = 100
+
 type diskOutbox struct {
 	Version int                  `codec:"V"`
 	Records []chat1.OutboxRecord `codec:"O"`
@@ -165,10 +169,6 @@ func (o *Outbox) PushMessage(ctx context.Context, convID chat1.ConversationID,
 	} else {
 		outboxID = *suppliedOutboxID
 	}
-
-	// Ordinals for the outbox start at 100.
-	// So that journeycard ordinals, which are added at the last minute by postProcessConv, do not conflict.
-	const outboxOrdinalStart = 100
 
 	// Compute prev ordinal by predicting that all outbox messages will be appended to the thread
 	prevOrdinal := outboxOrdinalStart

--- a/go/chat/storage/outbox.go
+++ b/go/chat/storage/outbox.go
@@ -166,10 +166,14 @@ func (o *Outbox) PushMessage(ctx context.Context, convID chat1.ConversationID,
 		outboxID = *suppliedOutboxID
 	}
 
+	// Ordinals for the outbox start at 100.
+	// So that journeycard ordinals, which are added at the last minute by postProcessConv, do not conflict.
+	const outboxOrdinalStart = 100
+
 	// Compute prev ordinal by predicting that all outbox messages will be appended to the thread
-	prevOrdinal := 1
+	prevOrdinal := outboxOrdinalStart
 	for _, obr := range obox.Records {
-		if obr.ConvID.Eq(convID) && obr.Ordinal >= prevOrdinal {
+		if obr.ConvID.Eq(convID) && obr.Ordinal >= outboxOrdinalStart && obr.Ordinal >= prevOrdinal {
 			prevOrdinal = obr.Ordinal + 1
 		}
 	}

--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -173,7 +173,7 @@ func TestChatOutboxPurge(t *testing.T) {
 		var obrs []chat1.OutboxRecord
 		conv := makeConvo(gregor1.Time(5), 1, 1)
 
-		prevOrdinal := 1
+		prevOrdinal := outboxOrdinalStart
 		ephemeralMetadata := &chat1.MsgEphemeralMetadata{Lifetime: 0}
 		for i := 0; i < 9; i++ {
 			// send some exploding and some non exploding msgs

--- a/go/chat/storage/outbox_test.go
+++ b/go/chat/storage/outbox_test.go
@@ -64,7 +64,7 @@ func TestChatOutbox(t *testing.T) {
 		var obrs []chat1.OutboxRecord
 		conv := makeConvo(gregor1.Time(5), 1, 1)
 
-		prevOrdinal := 1
+		prevOrdinal := outboxOrdinalStart
 		for i := 0; i < 5; i++ {
 			obr, err := ob.PushMessage(context.TODO(), conv.GetConvID(), makeMsgPlaintext("hi", uid),
 				nil, nil, nil, keybase1.TLFIdentifyBehavior_CHAT_CLI)

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -326,6 +326,8 @@ func (m MessageUnboxed) GetMessageID() MessageID {
 			return m.Placeholder().MessageID
 		case MessageUnboxedState_OUTBOX:
 			return m.Outbox().Msg.ClientHeader.OutboxInfo.Prev
+		case MessageUnboxedState_JOURNEYCARD:
+			return m.Journeycard().PrevID
 		default:
 			return 0
 		}
@@ -345,6 +347,8 @@ func (m MessageUnboxed) GetOutboxID() *OutboxID {
 		case MessageUnboxedState_OUTBOX:
 			obid := m.Outbox().OutboxID
 			return &obid
+		case MessageUnboxedState_JOURNEYCARD:
+			return nil
 		default:
 			return nil
 		}
@@ -363,6 +367,8 @@ func (m MessageUnboxed) GetTopicType() TopicType {
 			return m.Outbox().Msg.ClientHeader.Conv.TopicType
 		case MessageUnboxedState_PLACEHOLDER:
 			return TopicType_NONE
+		case MessageUnboxedState_JOURNEYCARD:
+			return TopicType_NONE
 		}
 	}
 	return TopicType_NONE
@@ -380,6 +386,8 @@ func (m MessageUnboxed) GetMessageType() MessageType {
 		case MessageUnboxedState_PLACEHOLDER:
 			// All we know about a place holder is the ID, so just
 			// call it type NONE
+			return MessageType_NONE
+		case MessageUnboxedState_JOURNEYCARD:
 			return MessageType_NONE
 		}
 	}


### PR DESCRIPTION
Outbox ordinals now start at 100. So journeycard ordinals (just 1) and outbox ordinals [100, infinity] don't collide anymore.

A couple more individual card checkers.

cc @mmaxim 