### PR TITLE
group similar ephemeral errors to reduce UI clutter

### DIFF
--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -120,3 +120,19 @@ func TestEphemeralDeviceProvisionedAfterContent(t *testing.T) {
 	ekErr = err.(EphemeralKeyError)
 	require.Equal(t, DefaultHumanErrMsg, ekErr.HumanError())
 }
+
+func TestEphemeralPluralization(t *testing.T) {
+	humanMsg := humanMsgWithPrefix(DeviceProvisionedAfterContentCreationErrMsg)
+
+	pluralized := PluralizeErrorMessage(humanMsg, 0)
+	require.Equal(t, humanMsg, pluralized)
+
+	pluralized = PluralizeErrorMessage(humanMsg, 1)
+	require.Equal(t, humanMsg, pluralized)
+
+	pluralized = PluralizeErrorMessage(humanMsg, 2)
+	require.Equal(t, "2 exploding messages are not available to you, this device was created after the messages were sent", pluralized)
+
+	pluralized = PluralizeErrorMessage(DefaultHumanErrMsg, 2)
+	require.Equal(t, "2 exploding messages are not available to you", pluralized)
+}

--- a/go/ephemeral/errors.go
+++ b/go/ephemeral/errors.go
@@ -83,10 +83,15 @@ func newTransientEphemeralKeyError(err EphemeralKeyError) EphemeralKeyError {
 
 const (
 	DefaultHumanErrMsg                          = "This exploding message is not available to you"
+	DefaultPluralHumanErrMsg                    = "%d exploding messages are not available to you"
 	DeviceProvisionedAfterContentCreationErrMsg = "this device was created after the message was sent"
-	MemberAddedAfterContentCreationErrMsg       = "you were added to the team after this message was sent"
+	MemberAddedAfterContentCreationErrMsg       = "you were added to the team after the message was sent"
 	DeviceCloneErrMsg                           = "cloned devices do not support exploding messages"
 	DeviceCloneWithOneshotErrMsg                = "to support exploding messages in `oneshot` mode, you need a separate paper key for each running instance"
+	DeviceAfterEKErrMsg                         = "this device was provisioned after the message was sent"
+	MemberAfterEKErrMsg                         = "you were added to the team after the message was sent"
+	DeviceStaleErrMsg                           = "this device wasn't online to generate an exploding key"
+	UserStaleErrMsg                             = "you weren't online to generate new exploding keys"
 )
 
 type IncorrectTeamEphemeralKeyTypeError struct {
@@ -192,22 +197,28 @@ func newEphemeralKeyError(debugMsg, humanMsg string, errKind EphemeralKeyErrorKi
 	}
 }
 func newEphemeralKeyErrorFromStatus(e libkb.AppStatusError) EphemeralKeyError {
-	humanMsg := humanMsgWithPrefix(e.Desc)
 	var errKind EphemeralKeyErrorKind
 	var ekKind EphemeralKeyKind
+	var humanMsg string
 	switch e.Code {
 	case libkb.SCEphemeralDeviceAfterEK:
 		errKind = EphemeralKeyErrorKind_DEVICEAFTEREK
 		ekKind = DeviceEKKind
+		humanMsg = DeviceAfterEKErrMsg
 	case libkb.SCEphemeralMemberAfterEK:
 		ekKind = TeamEKKind
+		humanMsg = MemberAfterEKErrMsg
 	case libkb.SCEphemeralDeviceStale:
 		errKind = EphemeralKeyErrorKind_DEVICESTALE
 		ekKind = DeviceEKKind
+		humanMsg = DeviceStaleErrMsg
 	case libkb.SCEphemeralUserStale:
 		errKind = EphemeralKeyErrorKind_USERSTALE
 		ekKind = UserEKKind
+		humanMsg = UserStaleErrMsg
 	}
+
+	humanMsg = humanMsgWithPrefix(humanMsg)
 	return EphemeralKeyError{
 		DebugMsg:   e.Desc,
 		HumanMsg:   humanMsg,
@@ -253,4 +264,16 @@ func deviceIsCloned(mctx libkb.MetaContext) bool {
 		return false
 	}
 	return cloneState.IsClone()
+}
+
+func PluralizeErrorMessage(msg string, count int) string {
+	if count <= 1 {
+		return msg
+	}
+	msg = strings.Replace(msg, DefaultHumanErrMsg, fmt.Sprintf(DefaultPluralHumanErrMsg, count), 1)
+	// Backwards compatibility with old server based message which clients may
+	// have in cache.
+	msg = strings.Replace(msg, "this message was", "the messages were", 1)
+	msg = strings.Replace(msg, "the message was", "the messages were", 1)
+	return msg
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -634,6 +634,10 @@ func (m MessageUnboxedError) ParseableVersion() bool {
 	return maxVersion >= version
 }
 
+func (m MessageUnboxedError) IsEphemeralError() bool {
+	return m.IsEphemeral && m.ErrType == MessageUnboxedErrorType_EPHEMERAL
+}
+
 func (m MessageUnboxedValid) AsDeleteHistory() (res MessageDeleteHistory, err error) {
 	if m.ClientHeader.MessageType != MessageType_DELETEHISTORY {
 		return res, fmt.Errorf("message is %v not %v", m.ClientHeader.MessageType, MessageType_DELETEHISTORY)


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1144020/67867693-2bce7300-fb01-11e9-9196-f2728069b359.png)


after:

![image](https://user-images.githubusercontent.com/1144020/67867397-b9f62980-fb00-11e9-876b-9efc859ae6e0.png)

cc @adamjspooner @cecileboucheron for any copy edits