### PR TITLE
change 'make lint' to fail without -P

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -17,8 +17,15 @@ lint:
 			echo "Missing golint" \
 			&& exit 1 \
 		) \
-	) \
-	&& ( \
+	)
+	( \
+		echo "test" | grep -P -e "test" > /dev/null \
+		|| ( \
+			echo "Grep does not support -P. MacOS' grep doesn't have -P. To remedy, 'brew install grep' and add '/usr/local/opt/grep/libexec/gnubin' to PATH." \
+			&& exit 1 \
+		) \
+	)
+	( \
 		golint ./... \
 		| grep -v ^vendor \
 		| grep -v "protocol[\/\\]" \


### PR DESCRIPTION
Macos grep doesn't support `-P`. Previously on stock macos `make lint` would spit a bunch of usages and then pass with "Lint-free!". With this patch it errors and recommends a 'solution'. Not sure how to dodge the problem. It's a lot that pre-commit, golint via make, and golangci-lint are all in play.

```
$ make -s lint
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
Grep does not support -P. MacOS' grep doesn't have -P. To remedy, 'brew install grep' and add '/usr/local/opt/grep/libexec/gnubin' to PATH.
make: *** [lint] Error 1
```