### PR TITLE
tlf: avoid loading TLFs on a "Contents" lookup

### DIFF
--- a/go/kbfs/libfuse/tlf.go
+++ b/go/kbfs/libfuse/tlf.go
@@ -197,6 +197,7 @@ func (tlf *TLF) Attr(ctx context.Context, a *fuse.Attr) error {
 // not, which can cause a tracker popup storm (see KBFS-2649).
 var tlfLoadAvoidingLookupNames = map[string]bool{
 	".localized": true,
+	"Contents":   true,
 }
 
 // Lookup implements the fs.NodeRequestLookuper interface for TLF.


### PR DESCRIPTION
Seems like macOS Finder looks up "Contents" in every directory it loads.  That makes loading big folder lists take a long time, because it initializes every folder one by one.  Let's just return an ENOENT in that case automatically.

Issue: HOTPOT-1184