### PR TITLE
Change potentially invalid calls to UsernameToUIDPreserveCase

### DIFF
--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -652,7 +652,7 @@ func IsUserByUsernameOffline(m MetaContext, un NormalizedUsername) bool {
 
 	// We already took care of the bad username casing in the harcoded exception list above,
 	// so it's ok to treat the NormalizedUsername as a cased string.
-	uid := UsernameToUIDPreserveCase(un.String())
+	uid := usernameToUIDPreserveCase(un.String())
 
 	// use the UPAKLoader with StaleOK, CachedOnly in order to get cached upak
 	arg := NewLoadUserArgWithMetaContext(m).WithUID(uid).WithPublicKeyOptional().WithStaleOK(true).WithCachedOnly()

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -1441,7 +1441,7 @@ func (vp *VerificationPath) verifyUsername(m MetaContext, userInfo merkleUserInf
 
 	if userInfo.usernameCased != userInfo.username && strings.ToLower(userInfo.usernameCased) == userInfo.username {
 		m.VLogf(VLog1, "| Checking cased username difference: %s v %s", userInfo.username, userInfo.usernameCased)
-		if CheckUIDAgainstCasedUsername(userInfo.uid, userInfo.usernameCased) == nil {
+		if checkUIDAgainstCasedUsername(userInfo.uid, userInfo.usernameCased) == nil {
 			m.VLogf(VLog1, "| Username %s mapped to %s via direct hash (w/ username casing)", userInfo.usernameCased, userInfo.uid)
 			username = userInfo.username
 			return

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -124,17 +124,12 @@ func GetConfiguredAccountsFromProvisionedUsernames(m MetaContext, s SecretStoreA
 	}
 
 	// Get the full names
-
 	uids := make([]keybase1.UID, len(allUsernames))
 	for idx, username := range allUsernames {
-		uid := m.G().UIDMapper.MapHardcodedUsernameToUID(username)
-		if !uid.Exists() {
-			uid = UsernameToUIDPreserveCase(username.String())
-		}
-		uids[idx] = uid
+		uids[idx] = GetUIDByNormalizedUsername(m.G(), username)
 	}
 	usernamePackages, err := m.G().UIDMapper.MapUIDsToUsernamePackages(m.Ctx(), m.G(),
-		uids, time.Hour*24, time.Second*10, false)
+		uids, time.Hour*24, time.Second*10, true)
 	if err != nil {
 		if usernamePackages != nil {
 			// If data is returned, interpret the error as a warning

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -129,7 +129,7 @@ func GetConfiguredAccountsFromProvisionedUsernames(m MetaContext, s SecretStoreA
 		uids[idx] = GetUIDByNormalizedUsername(m.G(), username)
 	}
 	usernamePackages, err := m.G().UIDMapper.MapUIDsToUsernamePackages(m.Ctx(), m.G(),
-		uids, time.Hour*24, time.Second*10, true)
+		uids, time.Hour*24, time.Second*10, false)
 	if err != nil {
 		if usernamePackages != nil {
 			// If data is returned, interpret the error as a warning

--- a/go/libkb/uid.go
+++ b/go/libkb/uid.go
@@ -48,10 +48,32 @@ func UIDArg(uid keybase1.UID) HTTPValue {
 	return S{Val: uid.String()}
 }
 
+// GetUIDByNormalizedUsername returns UID for normalized username. Works
+// offline for all usernames.
+func GetUIDByNormalizedUsername(g *GlobalContext, username NormalizedUsername) keybase1.UID {
+	uid := g.UIDMapper.MapHardcodedUsernameToUID(username)
+	if uid.Exists() {
+		return uid
+	}
+	return usernameToUIDPreserveCase(username.String())
+}
+
+// GetUIDByUsername returns UID for username strings with potentially
+// mixed letter casing. Works offline for all usernames.
+func GetUIDByUsername(g *GlobalContext, username string) keybase1.UID {
+	return GetUIDByNormalizedUsername(g, NewNormalizedUsername(username))
+}
+
+// NOTE: Use the high level API above instead of any of the following. The
+// hilvl API handles both UIDS for old, potentially incorrectly hashed
+// usernames, as well as new, correct UIDs.
+//
+// tldr: you probably want to use GetUID* functions, instead of UsernameToUID*.
+
 // UsernameToUID works for users created after "Fri Feb  6 19:33:08 EST 2015",
 // with some exceptions, since we didn't ToLower() for all UIDs
 func UsernameToUID(s string) keybase1.UID {
-	return UsernameToUIDPreserveCase(strings.ToLower(s))
+	return usernameToUIDPreserveCase(strings.ToLower(s))
 }
 
 func CheckUIDAgainstUsername(uid keybase1.UID, username string) (err error) {
@@ -65,7 +87,7 @@ func CheckUIDAgainstUsername(uid keybase1.UID, username string) (err error) {
 // UsernameToUID works for users created after "Fri Feb  6 19:33:08 EST 2015".  Some of
 // them had buggy Username -> UID conversions, in which case we need to hash the
 // original case to recover their UID.
-func UsernameToUIDPreserveCase(s string) keybase1.UID {
+func usernameToUIDPreserveCase(s string) keybase1.UID {
 	h := sha256.Sum256([]byte(s))
 	var uid [keybase1.UID_LEN]byte
 	copy(uid[:], h[0:keybase1.UID_LEN-1])
@@ -74,11 +96,11 @@ func UsernameToUIDPreserveCase(s string) keybase1.UID {
 	return ret
 }
 
-// CheckUIDAgainstCasedUsername takes the input string, does not convert toLower,
+// checkUIDAgainstCasedUsername takes the input string, does not convert toLower,
 // and then hashes it to recover a UID. This is a workaround for some
 // users whose UIDs were computed incorrectly.
-func CheckUIDAgainstCasedUsername(uid keybase1.UID, username string) (err error) {
-	u2 := UsernameToUIDPreserveCase(username)
+func checkUIDAgainstCasedUsername(uid keybase1.UID, username string) (err error) {
+	u2 := usernameToUIDPreserveCase(username)
 	if uid.NotEqual(u2) {
 		err = UIDMismatchError{fmt.Sprintf("%s != %s (via %s)", uid, u2, username)}
 	}

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -16,7 +16,6 @@ import (
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/externals"
-	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/offline"
 	"github.com/keybase/client/go/phonenumbers"
@@ -604,10 +603,7 @@ func (h *UserHandler) UserCard(ctx context.Context, arg keybase1.UserCardArg) (r
 	mctx := libkb.NewMetaContext(ctx, h.G())
 	defer mctx.TraceTimed("UserHandler#UserCard", func() error { return err })()
 
-	uid := mctx.G().UIDMapper.MapHardcodedUsernameToUID(kbun.NewNormalizedUsername(arg.Username))
-	if !uid.Exists() {
-		uid = libkb.UsernameToUIDPreserveCase(arg.Username)
-	}
+	uid := libkb.GetUIDByUsername(h.G(), arg.Username)
 	if res, err = libkb.UserCard(mctx, uid, arg.UseSession); err != nil {
 		return res, err
 	}

--- a/go/uidmap/uidmap_test.go
+++ b/go/uidmap/uidmap_test.go
@@ -279,3 +279,18 @@ func TestOfflineUIDMapNoCache(t *testing.T) {
 		require.Nil(t, v.FullName)
 	}
 }
+
+func TestDuplicateUids(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestLookup", 1)
+	defer tc.Cleanup()
+
+	uidMap := NewUIDMap(10)
+	uids := []keybase1.UID{tAlice, tTracy, tAlice}
+	results, err := uidMap.MapUIDsToUsernamePackages(context.TODO(), tc.G, uids,
+		24*time.Hour, 10*time.Second, true)
+	require.NoError(t, err)
+
+	require.EqualValues(t, results[0].NormalizedUsername, "t_alice")
+	require.EqualValues(t, results[1].NormalizedUsername, "t_tracy")
+	require.Equal(t, results[0], results[2])
+}


### PR DESCRIPTION
There were two calls to `UsernameToUIDPreserveCase` which were potentially invalid. One turned out to be OK - it was just not clear that it's already dealing with normalized username. Second was probably not OK but GUI caller was always passing lowercase username.

Move few things around to make it more clear on how to convert usernames to UIDs.