### PR TITLE
Update Android Docs w/ NDK installation and troubleshooting

### DIFF
--- a/shared/docs/android/running.md
+++ b/shared/docs/android/running.md
@@ -69,8 +69,6 @@ Same as below.
 `yarn rn-build-clean-android`
 
 
-## Hot reloading / File Watching
-
 ## `$HOME/.../Android/sdk/ndk-bundle` Does not point to an Android NDK
 
 ### macOS
@@ -79,9 +77,11 @@ If you're hitting this issue, it is because you either don not have an NDK insta
 
 Android Studio 3.5.0 and later seem to install ndk versions at the following path: `~/Library/Android/sdk/ndk/{version}`
 
-To resolve this issue, initialize gomobile with a new NDK path: `$GOPATH/bin/gomobile init -ndk ~/Library/Android/sdk/ndk/{version}`
+To resolve this issue, use the `sdkmanager` to re-install `ndk-bundle` at the correct directory path. 
 
-Then re-run `yarn rn-gobuilld-android`
+[Instuctions can be found here](./setup.md)
+
+## Hot reloading / File Watching
 
 ### Linux
 [Here](../linux-dev.md#troubleshooting)

--- a/shared/docs/android/running.md
+++ b/shared/docs/android/running.md
@@ -71,6 +71,18 @@ Same as below.
 
 ## Hot reloading / File Watching
 
+## `$HOME/.../Android/sdk/ndk-bundle` Does not point to an Android NDK
+
+### macOS
+
+If you're hitting this issue, it is because you either don not have an NDK installed or installed an NDK with an older version of Android Studio that created an old directory path.
+
+Android Studio 3.5.0 and later seem to install ndk versions at the following path: `~/Library/Android/sdk/ndk/{version}`
+
+To resolve this issue, initialize gomobile with a new NDK path: `$GOPATH/bin/gomobile init -ndk ~/Library/Android/sdk/ndk/{version}`
+
+Then re-run `yarn rn-gobuilld-android`
+
 ### Linux
 [Here](../linux-dev.md#troubleshooting)
 

--- a/shared/docs/android/setup.md
+++ b/shared/docs/android/setup.md
@@ -4,6 +4,20 @@ Follow instructions for "Building Projects with Native Code" at
 https://facebook.github.io/react-native/docs/getting-started.html to
 install and configure Android.
 
+### Installing an NDK version
+Additionally an `NDK` version needs to be installed for `yarn rn-gobuild-android` to work.
+
+**With Android Studio**
+You will already have the `sdkmanager` command line tool installed. So run:
+
+`sdkmanager --install "ndk-bundle"` which should write to `$HOME/Library/Android/sdk/ndk-bundle` on macOS.
+
+**Without Android Stuido** 
+You will need the Android Studio Command Line Tools to use `sdkmanager` without Android Studio.
+[Download Command Line Tools](https://developer.android.com/studio/index.html#command-tools) here.
+
+Then run `sdkmanager --install "ndk-bundle"` which should write to `$HOME/Library/Android/sdk/ndk-bundle` on macOS.
+
 ## Emulator Setup
 
 ### macOS


### PR DESCRIPTION
Ran into some issues this morning with whatever version of Android Studio I am using.

We don't have a step to install the NDK via Android Studio in our docs (or in the React Native docs either). So I added that.

Additionally, your NDK is installed by a newer version there seems to be a breaking change regarding the directory structure that will cause `yarn rn-gobuild-android` to fail.