### PR TITLE
login: allow LoginProvisionedDevice engine to skip online UPAK checks

### DIFF
--- a/go/engine/login.go
+++ b/go/engine/login.go
@@ -262,7 +262,7 @@ func (e *Login) checkLoggedInAndNotRevoked(m libkb.MetaContext) (bool, error) {
 	// and sees if it matches the given username, and isn't revoked. If all goes
 	// well, we return `true,nil`. It could be we're already logged in but for
 	// someone else, in which case we return true and an error.
-	err := m.ActiveDevice().CheckForUsername(m, username)
+	err := m.ActiveDevice().CheckForUsername(m, username, e.doUserSwitch)
 
 	switch err := err.(type) {
 	case nil:

--- a/go/engine/login_provisioned_device.go
+++ b/go/engine/login_provisioned_device.go
@@ -73,7 +73,8 @@ func (e *LoginProvisionedDevice) loadMe(m libkb.MetaContext) (err error) {
 
 	var config *libkb.UserConfig
 	var nu libkb.NormalizedUsername
-	loadUserArg := libkb.NewLoadUserArgWithMetaContext(m).WithPublicKeyOptional().WithForcePoll(true)
+	loadUserArg := libkb.NewLoadUserArgWithMetaContext(m).
+		WithPublicKeyOptional().WithForcePoll(true).WithStaleOK(true)
 	if len(e.username) == 0 {
 		m.Debug("| using current username")
 		config, err = m.G().Env.GetConfig().GetUserConfig()

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -537,7 +537,7 @@ func (a *ActiveDevice) SyncSecretsForce(m MetaContext) (ret *SecretSyncer, err e
 	return a.SyncSecretsForUID(m, zed, true /* force */)
 }
 
-func (a *ActiveDevice) CheckForUsername(m MetaContext, n NormalizedUsername) (err error) {
+func (a *ActiveDevice) CheckForUsername(m MetaContext, n NormalizedUsername, suppressNetworkErrors bool) (err error) {
 	a.RLock()
 	uid := a.uv.Uid
 	deviceID := a.deviceID
@@ -546,7 +546,7 @@ func (a *ActiveDevice) CheckForUsername(m MetaContext, n NormalizedUsername) (er
 	if !valid {
 		return NoActiveDeviceError{}
 	}
-	return m.G().GetUPAKLoader().CheckDeviceForUIDAndUsername(m.Ctx(), uid, deviceID, n)
+	return m.G().GetUPAKLoader().CheckDeviceForUIDAndUsername(m.Ctx(), uid, deviceID, n, suppressNetworkErrors)
 }
 
 func (a *ActiveDevice) ProvisioningKeyWrapper(m MetaContext) *SelfDestructingDeviceWithKeys {

--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -46,10 +46,10 @@ type LoadUserArg struct {
 	publicKeyOptional        bool
 	noCacheResult            bool // currently ignore
 	self                     bool
-	forceReload              bool
-	forcePoll                bool // for cached user load, force a repoll
+	forceReload              bool // ignore the cache entirely, don't even bother polling if it is out of date; just fetch new data.
+	forcePoll                bool // for cached user load, force a repoll. If this and StaleOK are both set, we try a network call and if it fails return the cached data.
 	staleOK                  bool // if stale cached versions are OK (for immutable fields)
-	cachedOnly               bool // only return cached data (StaleOK should be true as well)
+	cachedOnly               bool // only return cached data (staleOK should be true and forcePoll must be false)
 	uider                    UIDer
 	abortIfSigchainUnchanged bool
 	resolveBody              *jsonw.Wrapper // some load paths plumb this through

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -418,31 +418,23 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		upak, fresh = u.getCachedUPAK(ctx, arg.uid, arg.stubMode, info)
 	}
 
-	if upak != nil {
-		// Either there is no cached UPAK or forceReload is set.
+	if upak != nil && !arg.forcePoll && (fresh || arg.staleOK) {
+		return returnUPAK(upak, true)
+	}
 
+	if upak != nil && !arg.forcePoll && arg.cachedOnly {
+		// Stale cache not allowed but cache was stale.
+		return nil, nil, UserNotFoundError{UID: arg.uid, Msg: "cached user found, but it was stale, and cached only"}
+	}
+
+	if upak != nil {
 		// If we are not forced to repoll, we might be done here.
-		if !arg.forcePoll {
-			if fresh {
-				// Cache hit, not stale.
-				return returnUPAK(upak, true)
-			}
-			if arg.staleOK {
-				// Stale cache allowed.
-				return returnUPAK(upak, true)
-			}
-			if arg.cachedOnly {
-				// Stale cache not allowed but cache was stale.
-				return nil, nil, UserNotFoundError{UID: arg.uid, Msg: "cached user found, but it was stale, and cached only"}
-			}
-			// Else the cached UPAK is stale and we have to fall through and get a new one.
-		} else {
+		if arg.forcePoll {
 			g.VDL.CLogf(ctx, VLog0, "%s: force-poll required us to repoll (fresh=%v)", culDebug(arg.uid), fresh)
 		}
 
 		// At this point, we have a cached UPAK but we are not confident about whether we can return it.
 		// Ask the server whether it is fresh.
-
 		if info != nil {
 			info.TimedOut = true
 		}

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -424,7 +424,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 
 	if upak != nil {
 		g.VDL.CLogf(ctx, VLog0, "%s: cache-hit; fresh=%v", culDebug(arg.uid), fresh)
-		if fresh || arg.staleOK {
+		if fresh {
 			return returnUPAK(upak, true)
 		}
 		if arg.cachedOnly {
@@ -501,7 +501,14 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 	// In some cases, it's OK to have a user object and an error. This comes up in
 	// Identify2 when identifying users who don't have a sigchain. Note that we'll never
 	// hit the cache in this case (for now...)
+	//
+	// Additionally, we might have an error, a cached UPAK, no user object. If
+	// stale is OK, we'll just return the stale data instead of the error.
 	if err != nil {
+		if upak != nil && arg.staleOK {
+			g.VDL.CLogf(ctx, VLog0, "Got error %+v when fetching UPAK, so using cached data", err)
+			return returnUPAK(upak, true)
+		}
 		return ret, user, err
 	}
 

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -435,6 +435,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 				// Stale cache not allowed but cache was stale.
 				return nil, nil, UserNotFoundError{UID: arg.uid, Msg: "cached user found, but it was stale, and cached only"}
 			}
+			// Else there's the cached UPAK is stale and we have to fall through and get a new one.
 		} else {
 			g.VDL.CLogf(ctx, VLog0, "%s: force-poll required us to repoll (fresh=%v)", culDebug(arg.uid), fresh)
 		}

--- a/go/libkb/upak_loader.go
+++ b/go/libkb/upak_loader.go
@@ -435,7 +435,7 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 				// Stale cache not allowed but cache was stale.
 				return nil, nil, UserNotFoundError{UID: arg.uid, Msg: "cached user found, but it was stale, and cached only"}
 			}
-			// Else there's the cached UPAK is stale and we have to fall through and get a new one.
+			// Else the cached UPAK is stale and we have to fall through and get a new one.
 		} else {
 			g.VDL.CLogf(ctx, VLog0, "%s: force-poll required us to repoll (fresh=%v)", culDebug(arg.uid), fresh)
 		}

--- a/shared/actions/login.tsx
+++ b/shared/actions/login.tsx
@@ -97,10 +97,14 @@ const loadIsOnline = async () => {
   }
 }
 
+// On login error, drop back to the login screen even if user switching
+const loginError = () => ConfigGen.createSetUserSwitching({userSwitching: false})
+
 function* loginSaga() {
   // Actually log in
   yield* Saga.chainGenerator<LoginGen.LoginPayload>(LoginGen.login, login)
   yield* Saga.chainAction2(LoginGen.loadIsOnline, loadIsOnline)
+  yield* Saga.chainAction2(LoginGen.loginError, loginError)
 }
 
 export default loginSaga

--- a/shared/actions/login.tsx
+++ b/shared/actions/login.tsx
@@ -97,7 +97,8 @@ const loadIsOnline = async () => {
   }
 }
 
-// On login error, drop back to the login screen even if user switching
+// On login error, turn off the user switching flag, so that the login screen is not
+// hidden and the user can see and respond to the error.
 const loginError = () => ConfigGen.createSetUserSwitching({userSwitching: false})
 
 function* loginSaga() {


### PR DESCRIPTION
This lets login offline work in all the cases I tried.

cc @maxtaco @patrickxb @keybase/y2ksquad 

Issue: Y2K-927

reviewers: surya for go, @keybase/react-hackers for a single line of TS.