### PR TITLE
teams: sync role list from server

### DIFF
--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1373,6 +1373,7 @@ func (k *KeybaseDaemonRPC) TeamExit(context.Context, keybase1.TeamID) error {
 	return nil
 }
 
+// TeamRoleListChanged implements keybase1.NotifyTeamInterface for KeybaseServiceBase.
 func (k *KeybaseDaemonRPC) TeamRoleListChanged(context.Context, keybase1.UserTeamVersion) error {
 	return nil
 }

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1373,6 +1373,10 @@ func (k *KeybaseDaemonRPC) TeamExit(context.Context, keybase1.TeamID) error {
 	return nil
 }
 
+func (k *KeybaseDaemonRPC) TeamRoleListChanged(context.Context, keybase1.UserTeamVersion) error {
+	return nil
+}
+
 // NewlyAddedToTeam implements keybase1.NotifyTeamInterface for
 // KeybaseServiceBase.
 func (k *KeybaseDaemonRPC) NewlyAddedToTeam(context.Context, keybase1.TeamID) error {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -255,6 +255,7 @@ const (
 	SCEmailLimitExceeded                        = int(keybase1.StatusCode_SCEmailLimitExceeded)
 	SCEmailCannotDeletePrimary                  = int(keybase1.StatusCode_SCEmailCannotDeletePrimary)
 	SCEmailUnknown                              = int(keybase1.StatusCode_SCEmailUnknown)
+	SCNoUpdate                                  = int(keybase1.StatusCode_SCNoUpdate)
 	SCMissingResult                             = int(keybase1.StatusCode_SCMissingResult)
 	SCKeyNotFound                               = int(keybase1.StatusCode_SCKeyNotFound)
 	SCKeyCorrupted                              = int(keybase1.StatusCode_SCKeyCorrupted)

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -21,6 +21,7 @@ const (
 	DBTeamChain         = 0x10
 	DBUserPlusAllKeysV1 = 0x19
 
+	DBTeamRoleList                   = 0xaf
 	DBMisc                           = 0xb0
 	DBTeamMerkleCheck                = 0xb1
 	DBUidToServiceMap                = 0xb2

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -80,6 +80,7 @@ type GlobalContext struct {
 	teamLoader             TeamLoader      // Play back teams for id/name properties
 	fastTeamLoader         FastTeamLoader  // Play back team in "fast" mode for keys and names only
 	hiddenTeamChainManager HiddenTeamChainManager
+	teamRoleListManager    TeamRoleListManager
 	IDLocktab              *LockTable
 	loadUserLockTab        *LockTable
 	teamAuditor            TeamAuditor
@@ -259,6 +260,7 @@ func (g *GlobalContext) Init() *GlobalContext {
 	g.teamLoader = newNullTeamLoader(g)
 	g.fastTeamLoader = newNullFastTeamLoader()
 	g.hiddenTeamChainManager = newNullHiddenTeamChainManager()
+	g.teamRoleListManager = newNullTeamRoleListManager()
 	g.teamAuditor = newNullTeamAuditor()
 	g.teamBoxAuditor = newNullTeamBoxAuditor()
 	g.stellar = newNullStellar(g)
@@ -591,6 +593,7 @@ func (g *GlobalContext) FlushCaches() {
 	g.cacheMu.Lock()
 	defer g.cacheMu.Unlock()
 	g.configureMemCachesLocked(true)
+	g.teamRoleListManager.FlushCache()
 }
 
 func (g *GlobalContext) configureDiskCachesLocked() error {
@@ -633,6 +636,18 @@ func (g *GlobalContext) GetHiddenTeamChainManager() HiddenTeamChainManager {
 	g.cacheMu.RLock()
 	defer g.cacheMu.RUnlock()
 	return g.hiddenTeamChainManager
+}
+
+func (g *GlobalContext) GetTeamRoleListManager() TeamRoleListManager {
+	g.cacheMu.RLock()
+	defer g.cacheMu.RUnlock()
+	return g.teamRoleListManager
+}
+
+func (g *GlobalContext) SetTeamRoleListManager(r TeamRoleListManager) {
+	g.cacheMu.Lock()
+	defer g.cacheMu.Unlock()
+	g.teamRoleListManager = r
 }
 
 func (g *GlobalContext) SetHiddenTeamChainManager(h HiddenTeamChainManager) {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -755,6 +755,12 @@ type HiddenTeamChainManager interface {
 	HintLatestSeqno(m MetaContext, id keybase1.TeamID, seqno keybase1.Seqno) error
 }
 
+type TeamRoleListManager interface {
+	Get(m MetaContext) (res keybase1.TeamRoleList, err error)
+	Update(m MetaContext, version keybase1.UserTeamVersion) (err error)
+	FlushCache()
+}
+
 type TeamAuditor interface {
 	AuditTeam(m MetaContext, id keybase1.TeamID, isPublic bool, headMerkleSeqno keybase1.Seqno, chain map[keybase1.Seqno]keybase1.LinkID, maxSeqno keybase1.Seqno, auditMode keybase1.AuditMode) (err error)
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -72,6 +72,7 @@ type NotifyListener interface {
 	TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet, latestHiddenSeqno keybase1.Seqno)
 	TeamChangedByName(teamName string, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet, latestHiddenSeqno keybase1.Seqno)
 	TeamDeleted(teamID keybase1.TeamID)
+	TeamRoleListChanged(version keybase1.UserTeamVersion)
 	TeamExit(teamID keybase1.TeamID)
 	NewlyAddedToTeam(teamID keybase1.TeamID)
 	NewTeamEK(teamID keybase1.TeamID, generation keybase1.EkGeneration)
@@ -185,6 +186,7 @@ func (n *NoopNotifyListener) TeamChangedByName(teamName string, latestSeqno keyb
 }
 func (n *NoopNotifyListener) TeamDeleted(teamID keybase1.TeamID)                                    {}
 func (n *NoopNotifyListener) TeamExit(teamID keybase1.TeamID)                                       {}
+func (n *NoopNotifyListener) TeamRoleListChanged(version keybase1.UserTeamVersion)                  {}
 func (n *NoopNotifyListener) NewTeamEK(teamID keybase1.TeamID, generation keybase1.EkGeneration)    {}
 func (n *NoopNotifyListener) NewTeambotEK(teamID keybase1.TeamID, generation keybase1.EkGeneration) {}
 func (n *NoopNotifyListener) TeambotEKNeeded(teamID keybase1.TeamID, botUID keybase1.UID,
@@ -2022,6 +2024,33 @@ func (n *NotifyRouter) HandleTeamExit(ctx context.Context, teamID keybase1.TeamI
 		listener.TeamExit(teamID)
 	})
 	n.G().Log.CDebugf(ctx, "- Sent TeamExit notification")
+}
+
+func (n *NotifyRouter) HandleTeamRoleListChanged(ctx context.Context, version keybase1.UserTeamVersion) {
+	if n == nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+	n.G().Log.CDebugf(ctx, "+ Sending TeamRoleListChanged notification")
+	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
+		if n.getNotificationChannels(id).Team {
+			wg.Add(1)
+			go func() {
+				_ = (keybase1.NotifyTeamClient{
+					Cli: rpc.NewClient(xp, NewContextifiedErrorUnwrapper(n.G()), nil),
+				}).TeamRoleListChanged(context.Background(), version)
+				wg.Done()
+			}()
+		}
+		return true
+	})
+	wg.Wait()
+
+	n.runListeners(func(listener NotifyListener) {
+		listener.TeamRoleListChanged(version)
+	})
+	n.G().Log.CDebugf(ctx, "- Sent TeamRoleListChanged notification (version %d)", version)
 }
 
 func (n *NotifyRouter) HandleTeamAbandoned(ctx context.Context, teamID keybase1.TeamID) {

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -188,3 +188,19 @@ func (n nullHiddenTeamChainManager) HintLatestSeqno(m MetaContext, id keybase1.T
 func newNullHiddenTeamChainManager() nullHiddenTeamChainManager {
 	return nullHiddenTeamChainManager{}
 }
+
+type nullTeamRoleListManager struct{}
+
+var _ TeamRoleListManager = nullTeamRoleListManager{}
+
+func newNullTeamRoleListManager() nullTeamRoleListManager {
+	return nullTeamRoleListManager{}
+}
+
+func (n nullTeamRoleListManager) Get(m MetaContext) (res keybase1.TeamRoleList, err error) {
+	return res, nil
+}
+func (n nullTeamRoleListManager) Update(m MetaContext, version keybase1.UserTeamVersion) (err error) {
+	return nil
+}
+func (n nullTeamRoleListManager) FlushCache() {}

--- a/go/protocol/keybase1/constants.go
+++ b/go/protocol/keybase1/constants.go
@@ -53,6 +53,7 @@ const (
 	StatusCode_SCEmailCannotDeletePrimary                  StatusCode = 716
 	StatusCode_SCEmailUnknown                              StatusCode = 717
 	StatusCode_SCBotSignupTokenNotFound                    StatusCode = 719
+	StatusCode_SCNoUpdate                                  StatusCode = 723
 	StatusCode_SCMissingResult                             StatusCode = 801
 	StatusCode_SCKeyNotFound                               StatusCode = 901
 	StatusCode_SCKeyCorrupted                              StatusCode = 905
@@ -286,6 +287,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCEmailCannotDeletePrimary": 716,
 	"SCEmailUnknown":             717,
 	"SCBotSignupTokenNotFound":   719,
+	"SCNoUpdate":                 723,
 	"SCMissingResult":            801,
 	"SCKeyNotFound":              901,
 	"SCKeyCorrupted":             905,
@@ -517,6 +519,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	716:  "SCEmailCannotDeletePrimary",
 	717:  "SCEmailUnknown",
 	719:  "SCBotSignupTokenNotFound",
+	723:  "SCNoUpdate",
 	801:  "SCMissingResult",
 	901:  "SCKeyNotFound",
 	905:  "SCKeyCorrupted",

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3486,3 +3486,9 @@ func (b BadgeConversationInfo) IsEmpty() bool {
 func (s *TeamBotSettings) Eq(o *TeamBotSettings) bool {
 	return reflect.DeepEqual(s, o)
 }
+
+func (t TeamRoleList) Sort() TeamRoleList {
+	ret := t.DeepCopy()
+	sort.Slice(ret.Teams, func(i, j int) bool { return ret.Teams[i].TeamID < ret.Teams[j].TeamID })
+	return ret
+}

--- a/go/protocol/keybase1/notify_team.go
+++ b/go/protocol/keybase1/notify_team.go
@@ -87,6 +87,10 @@ type NewlyAddedToTeamArg struct {
 	TeamID TeamID `codec:"teamID" json:"teamID"`
 }
 
+type TeamRoleListChangedArg struct {
+	NewVersion UserTeamVersion `codec:"newVersion" json:"newVersion"`
+}
+
 type AvatarUpdatedArg struct {
 	Name    string           `codec:"name" json:"name"`
 	Formats []AvatarFormat   `codec:"formats" json:"formats"`
@@ -100,6 +104,7 @@ type NotifyTeamInterface interface {
 	TeamAbandoned(context.Context, TeamID) error
 	TeamExit(context.Context, TeamID) error
 	NewlyAddedToTeam(context.Context, TeamID) error
+	TeamRoleListChanged(context.Context, UserTeamVersion) error
 	AvatarUpdated(context.Context, AvatarUpdatedArg) error
 }
 
@@ -197,6 +202,21 @@ func NotifyTeamProtocol(i NotifyTeamInterface) rpc.Protocol {
 					return
 				},
 			},
+			"teamRoleListChanged": {
+				MakeArg: func() interface{} {
+					var ret [1]TeamRoleListChangedArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]TeamRoleListChangedArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]TeamRoleListChangedArg)(nil), args)
+						return
+					}
+					err = i.TeamRoleListChanged(ctx, typedArgs[0].NewVersion)
+					return
+				},
+			},
 			"avatarUpdated": {
 				MakeArg: func() interface{} {
 					var ret [1]AvatarUpdatedArg
@@ -251,6 +271,12 @@ func (c NotifyTeamClient) TeamExit(ctx context.Context, teamID TeamID) (err erro
 func (c NotifyTeamClient) NewlyAddedToTeam(ctx context.Context, teamID TeamID) (err error) {
 	__arg := NewlyAddedToTeamArg{TeamID: teamID}
 	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.newlyAddedToTeam", []interface{}{__arg}, 0*time.Millisecond)
+	return
+}
+
+func (c NotifyTeamClient) TeamRoleListChanged(ctx context.Context, newVersion UserTeamVersion) (err error) {
+	__arg := TeamRoleListChangedArg{NewVersion: newVersion}
+	err = c.Cli.Notify(ctx, "keybase.1.NotifyTeam.teamRoleListChanged", []interface{}{__arg}, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -743,3 +743,8 @@ func (h *TeamsHandler) GetTeamID(ctx context.Context, teamName string) (res keyb
 	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
 	return teams.GetTeamIDByNameRPC(mctx, teamName)
 }
+
+func (h *TeamsHandler) GetTeamRoleList(ctx context.Context) (res keybase1.TeamRoleList, err error) {
+	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
+	return mctx.G().GetTeamRoleListManager().Get(mctx)
+}

--- a/go/systests/team_role_list_test.go
+++ b/go/systests/team_role_list_test.go
@@ -20,7 +20,7 @@ func TestTeamRoleList(t *testing.T) {
 
 	expected := keybase1.TeamRoleList{
 		Teams: []keybase1.TeamRoleListRow{
-			keybase1.TeamRoleListRow{
+			{
 				TeamID:       teamID,
 				Role:         keybase1.TeamRole_ADMIN,
 				ImplicitRole: keybase1.TeamRole_NONE,

--- a/go/systests/team_role_list_test.go
+++ b/go/systests/team_role_list_test.go
@@ -1,0 +1,48 @@
+package systests
+
+import (
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/client/go/teams"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestTeamRoleList(t *testing.T) {
+	tt := newTeamTester(t)
+	defer tt.cleanup()
+
+	tt.addUser("ann")
+	tt.addUser("bob")
+
+	teamID, teamName := tt.users[0].createTeam2()
+	tt.users[0].addTeamMember(teamName.String(), tt.users[1].username, keybase1.TeamRole_ADMIN)
+
+	expected := keybase1.TeamRoleList{
+		Teams: []keybase1.TeamRoleListRow{
+			keybase1.TeamRoleListRow{
+				TeamID:       teamID,
+				Role:         keybase1.TeamRole_ADMIN,
+				ImplicitRole: keybase1.TeamRole_NONE,
+			},
+		},
+		Version: keybase1.UserTeamVersion(1),
+	}
+
+	select {
+	case vers := <-tt.users[1].notifications.teamRoleListCh:
+		t.Logf("got notification")
+		require.Equal(t, expected.Version, vers)
+	case <-time.After(10 * time.Second):
+		t.Fatal("failed to get notification after 10s wait")
+	}
+
+	pollForTrue(t, tt.users[1].tc.G, func(i int) bool {
+		list := tt.users[1].tc.G.GetTeamRoleListManager().(*teams.TeamRoleListManager).Query()
+		if list != nil && list.Data.Version == expected.Version {
+			require.Equal(t, expected.Sort(), list.Data.Sort())
+			return true
+		}
+		return false
+	})
+}

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -1025,6 +1025,7 @@ type teamNotifyHandler struct {
 	newTeambotKeyCh    chan keybase1.NewTeambotKeyArg
 	teambotKeyNeededCh chan keybase1.TeambotKeyNeededArg
 	newlyAddedToTeam   chan keybase1.TeamID
+	teamRoleListCh     chan keybase1.UserTeamVersion
 }
 
 func newTeamNotifyHandler() *teamNotifyHandler {
@@ -1038,6 +1039,7 @@ func newTeamNotifyHandler() *teamNotifyHandler {
 		newTeambotKeyCh:    make(chan keybase1.NewTeambotKeyArg, 10),
 		teambotKeyNeededCh: make(chan keybase1.TeambotKeyNeededArg, 10),
 		newlyAddedToTeam:   make(chan keybase1.TeamID, 10),
+		teamRoleListCh:     make(chan keybase1.UserTeamVersion, 100),
 	}
 }
 
@@ -1099,6 +1101,11 @@ func (n *teamNotifyHandler) TeambotKeyNeeded(ctx context.Context, arg keybase1.T
 }
 
 func (n *teamNotifyHandler) AvatarUpdated(ctx context.Context, arg keybase1.AvatarUpdatedArg) error {
+	return nil
+}
+
+func (n *teamNotifyHandler) TeamRoleListChanged(ctx context.Context, version keybase1.UserTeamVersion) error {
+	n.teamRoleListCh <- version
 	return nil
 }
 

--- a/go/teams/init.go
+++ b/go/teams/init.go
@@ -13,4 +13,5 @@ func ServiceInit(g *libkb.GlobalContext) {
 	NewImplicitTeamConflictInfoCacheAndInstall(g)
 	NewImplicitTeamCacheAndInstall(g)
 	hidden.NewChainManagerAndInstall(g)
+	NewTeamRoleListManagerAndInstall(g)
 }

--- a/go/teams/team_role_list.go
+++ b/go/teams/team_role_list.go
@@ -1,0 +1,172 @@
+package teams
+
+import (
+	"errors"
+	"fmt"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"sync"
+	"time"
+)
+
+type TeamRoleListManager struct {
+	sync.Mutex
+	lastKnownVersion *keybase1.UserTeamVersion
+	state            *keybase1.TeamRoleListStored
+}
+
+func NewTeamRoleListManagerAndInstall(g *libkb.GlobalContext) {
+	r := &TeamRoleListManager{}
+	g.SetTeamRoleListManager(r)
+}
+
+var _ libkb.TeamRoleListManager = (*TeamRoleListManager)(nil)
+
+func (t *TeamRoleListManager) isFresh(m libkb.MetaContext, state *keybase1.TeamRoleListStored) bool {
+	if t.lastKnownVersion != nil && *t.lastKnownVersion > state.Data.Version {
+		m.Debug("TeamRoleList version is stale (%d > %d)", *t.lastKnownVersion, state.Data.Version)
+		return false
+	}
+	tm := state.CachedAt.Time()
+	diff := m.G().Clock().Now().Sub(tm)
+	if diff >= 48*time.Hour {
+		m.Debug("TeamRoleList isn't fresh, it's %s old", diff)
+		return false
+	}
+	return true
+}
+
+func (t *TeamRoleListManager) dbKey(mctx libkb.MetaContext, uid keybase1.UID) libkb.DbKey {
+	return libkb.DbKey{
+		Typ: libkb.DBTeamRoleList,
+		Key: string(uid),
+	}
+}
+
+func (t *TeamRoleListManager) loadFromDB(mctx libkb.MetaContext, uid keybase1.UID) (err error) {
+	var obj keybase1.TeamRoleListStored
+	var found bool
+	found, err = mctx.G().LocalDb.GetInto(&obj, t.dbKey(mctx, uid))
+	if err != nil {
+		mctx.Debug("Error fetching TeamRoleList from disk: %s", err)
+		return err
+	}
+	if !found {
+		mctx.Debug("No stored TeamRoleList for %s", uid)
+		return nil
+	}
+	t.state = &obj
+	return nil
+}
+
+func (t *TeamRoleListManager) storeToDB(mctx libkb.MetaContext, uid keybase1.UID) (err error) {
+	return mctx.G().LocalDb.PutObj(t.dbKey(mctx, uid), nil, *t.state)
+}
+
+func (t *TeamRoleListManager) isLoadedAndFresh(mctx libkb.MetaContext) bool {
+	return t.state != nil && t.isFresh(mctx, t.state)
+}
+
+func (t *TeamRoleListManager) load(mctx libkb.MetaContext) (err error) {
+	uid := mctx.CurrentUID()
+	if uid.IsNil() {
+		return errors.New("cannot get TeamRoleList for a logged out user")
+	}
+
+	if t.isLoadedAndFresh(mctx) {
+		return nil
+	}
+
+	if t.state == nil {
+		_ = t.loadFromDB(mctx, uid)
+	}
+
+	if t.isLoadedAndFresh(mctx) {
+		mctx.Debug("Loaded fresh TeamRoleList from DB")
+		return nil
+	}
+
+	type apiResType struct {
+		keybase1.TeamRoleList
+		libkb.AppStatusEmbed
+	}
+	var apiRes apiResType
+
+	arg := libkb.NewAPIArg("team/for_user")
+	arg.SessionType = libkb.APISessionTypeREQUIRED
+	arg.RetryCount = 3
+	arg.AppStatusCodes = []int{libkb.SCOk, libkb.SCNoUpdate}
+	arg.Args = libkb.HTTPArgs{
+		"compact": libkb.B{Val: true},
+	}
+	var currVersion keybase1.UserTeamVersion
+	if t.state != nil {
+		currVersion = t.state.Data.Version
+		arg.Args["user_team_version"] = libkb.I{Val: int(currVersion)}
+	}
+	err = mctx.G().API.GetDecode(mctx, arg, &apiRes)
+	if err != nil {
+		mctx.Debug("failed to TeamRoleList from server: %s", err)
+		return err
+	}
+
+	if apiRes.Status.Code == libkb.SCNoUpdate {
+		t.lastKnownVersion = &currVersion
+		mctx.Debug("TeamRoleList was fresh at version %d", currVersion)
+		return nil
+	}
+
+	t.state = &keybase1.TeamRoleListStored{
+		Data:     apiRes.TeamRoleList,
+		CachedAt: keybase1.ToTime(mctx.G().Clock().Now()),
+	}
+	t.lastKnownVersion = &t.state.Data.Version
+	_ = t.storeToDB(mctx, uid)
+	mctx.Debug("Updating TeamRoleList to version %d", t.state.Data.Version)
+
+	return nil
+}
+
+func (t *TeamRoleListManager) Get(mctx libkb.MetaContext) (res keybase1.TeamRoleList, err error) {
+	defer mctx.Trace("TeamRoleListManager#Get", func() error { return err })()
+	t.Lock()
+	defer t.Unlock()
+	err = t.load(mctx)
+	if err != nil {
+		return res, err
+	}
+	return t.state.Data, nil
+}
+
+func (t *TeamRoleListManager) Update(mctx libkb.MetaContext, version keybase1.UserTeamVersion) (err error) {
+	defer mctx.Trace(fmt.Sprintf("TeamRoleListManager#Update(%d)", version), func() error { return err })()
+	t.Lock()
+	defer t.Unlock()
+	t.lastKnownVersion = &version
+	if t.isLoadedAndFresh(mctx) {
+		mctx.Debug("Swallowing update for TeamRoleList to version %d, since it's already loaded and fresh", version)
+		return nil
+	}
+	mctx.G().NotifyRouter.HandleTeamRoleListChanged(mctx.Ctx(), version)
+	return t.load(mctx)
+}
+
+func (t *TeamRoleListManager) FlushCache() {
+	t.Lock()
+	defer t.Unlock()
+	t.state = nil
+}
+
+// Query the state of the team role list manager -- only should be used in testing, as it's
+// not exposed in the geenric libkb.TeamRoleListManager interface. For testing, we want to see if
+// the update path is actually updating the team, so we want to be able to query what's in the manager
+// without going to disk or network if it's stale.
+func (t *TeamRoleListManager) Query() *keybase1.TeamRoleListStored {
+	t.Lock()
+	defer t.Unlock()
+	if t.state == nil {
+		return nil
+	}
+	tmp := t.state.DeepCopy()
+	return &tmp
+}

--- a/go/teams/team_role_list_test.go
+++ b/go/teams/team_role_list_test.go
@@ -29,12 +29,12 @@ func TestTeamRoleList(t *testing.T) {
 
 	expected := keybase1.TeamRoleList{
 		Teams: []keybase1.TeamRoleListRow{
-			keybase1.TeamRoleListRow{
+			{
 				TeamID:       teamID,
 				Role:         keybase1.TeamRole_ADMIN,
 				ImplicitRole: keybase1.TeamRole_NONE,
 			},
-			keybase1.TeamRoleListRow{
+			{
 				TeamID:       *subteamID,
 				Role:         keybase1.TeamRole_NONE,
 				ImplicitRole: keybase1.TeamRole_ADMIN,

--- a/go/teams/team_role_list_test.go
+++ b/go/teams/team_role_list_test.go
@@ -1,0 +1,73 @@
+package teams
+
+import (
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTeamRoleList(t *testing.T) {
+	fus, tcs, cleanup := setupNTests(t, 2)
+	defer cleanup()
+
+	t.Logf("create team")
+	teamName, teamID := createTeam2(*tcs[0])
+	m := make([]libkb.MetaContext, 2)
+	for i, tc := range tcs {
+		m[i] = libkb.NewMetaContextForTest(*tc)
+	}
+	t.Logf("add B to the team so they can load it")
+	_, err := AddMember(m[0].Ctx(), tcs[0].G, teamName.String(), fus[1].Username, keybase1.TeamRole_ADMIN, nil)
+	require.NoError(t, err)
+	subteamName := "abc"
+	subteamID, err := CreateSubteam(m[0].Ctx(), tcs[0].G, subteamName, teamName, keybase1.TeamRole_WRITER)
+	require.NoError(t, err)
+
+	list, err := m[1].G().GetTeamRoleListManager().Get(m[1])
+	require.NoError(t, err)
+
+	expected := keybase1.TeamRoleList{
+		Teams: []keybase1.TeamRoleListRow{
+			keybase1.TeamRoleListRow{
+				TeamID:       teamID,
+				Role:         keybase1.TeamRole_ADMIN,
+				ImplicitRole: keybase1.TeamRole_NONE,
+			},
+			keybase1.TeamRoleListRow{
+				TeamID:       *subteamID,
+				Role:         keybase1.TeamRole_NONE,
+				ImplicitRole: keybase1.TeamRole_ADMIN,
+			},
+		},
+		Version: keybase1.UserTeamVersion(1),
+	}
+
+	require.Equal(t, expected.Sort(), list.Sort())
+
+	_, err = AddMember(m[0].Ctx(), tcs[0].G, teamName.String()+"."+subteamName, fus[1].Username, keybase1.TeamRole_READER, nil)
+	require.NoError(t, err)
+
+	expected.Teams[1].Role = keybase1.TeamRole_READER
+	expected.Version++
+
+	// In teams/*_test.go, we don't have gregor hooked up, so we have to mock out what happens
+	// when a new gregpr notification comes down from the server.
+	m[1].G().GetTeamRoleListManager().Update(m[1], expected.Version)
+
+	// Check that the state is eagerly refreshed.
+	pollForTrue(t, m[1].G(), func(i int) bool {
+		list := m[1].G().GetTeamRoleListManager().(*TeamRoleListManager).Query()
+		if list != nil && list.Data.Version == expected.Version {
+			require.Equal(t, expected.Sort(), list.Data.Sort())
+			return true
+		}
+		return false
+	})
+
+	m[1].G().GetTeamRoleListManager().FlushCache()
+
+	list, err = m[1].G().GetTeamRoleListManager().Get(m[1])
+	require.NoError(t, err)
+	require.Equal(t, expected, list)
+}

--- a/go/teams/team_role_list_test.go
+++ b/go/teams/team_role_list_test.go
@@ -53,7 +53,8 @@ func TestTeamRoleList(t *testing.T) {
 
 	// In teams/*_test.go, we don't have gregor hooked up, so we have to mock out what happens
 	// when a new gregpr notification comes down from the server.
-	m[1].G().GetTeamRoleListManager().Update(m[1], expected.Version)
+	err = m[1].G().GetTeamRoleListManager().Update(m[1], expected.Version)
+	require.NoError(t, err)
 
 	// Check that the state is eagerly refreshed.
 	pollForTrue(t, m[1].G(), func(i int) bool {

--- a/protocol/avdl/keybase1/constants.avdl
+++ b/protocol/avdl/keybase1/constants.avdl
@@ -44,6 +44,7 @@ protocol constants {
     SCEmailCannotDeletePrimary_716,
     SCEmailUnknown_717,
     SCBotSignupTokenNotFound_719,
+    SCNoUpdate_723,
     SCMissingResult_801,
     SCKeyNotFound_901,
     SCKeyCorrupted_905,

--- a/protocol/avdl/keybase1/notify_team.avdl
+++ b/protocol/avdl/keybase1/notify_team.avdl
@@ -43,6 +43,8 @@ protocol NotifyTeam {
 
   void newlyAddedToTeam(TeamID teamID) oneway;
 
+  void teamRoleListChanged(UserTeamVersion newVersion) oneway;
+
   enum AvatarUpdateType {
     NONE_0,
     USER_1,

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1387,7 +1387,6 @@ protocol teams {
 
   FastTeamLoadRes ftl(FastTeamLoadArg arg);
 
-
   record MemberEmail {
     string email;
     string role;
@@ -1397,4 +1396,33 @@ protocol teams {
     string username;
     string role;
   }
+
+  record TeamRoleListRow {
+    @jsonkey("team_id")
+    TeamID teamID;
+    TeamRole role;
+    @jsonkey("implicit_role")
+    TeamRole implicitRole;
+  }
+
+  record TeamRoleList {
+    array<TeamRoleListRow> teams;
+    @jsonkey("user_team_version")
+    UserTeamVersion version;
+  }
+
+  record TeamRoleListStored {
+    TeamRoleList data;
+    Time cachedAt;
+  }
+
+  TeamRoleList getTeamRoleList();
+
+  @typedef("int")
+  record UserTeamVersion {}
+
+  record UserTeamVersionUpdate {
+    UserTeamVersion version;
+  }
+
 }

--- a/protocol/json/keybase1/constants.json
+++ b/protocol/json/keybase1/constants.json
@@ -48,6 +48,7 @@
         "SCEmailCannotDeletePrimary_716",
         "SCEmailUnknown_717",
         "SCBotSignupTokenNotFound_719",
+        "SCNoUpdate_723",
         "SCMissingResult_801",
         "SCKeyNotFound_901",
         "SCKeyCorrupted_905",

--- a/protocol/json/keybase1/notify_team.json
+++ b/protocol/json/keybase1/notify_team.json
@@ -132,6 +132,16 @@
       "response": null,
       "oneway": true
     },
+    "teamRoleListChanged": {
+      "request": [
+        {
+          "name": "newVersion",
+          "type": "UserTeamVersion"
+        }
+      ],
+      "response": null,
+      "oneway": true
+    },
     "avatarUpdated": {
       "request": [
         {

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -2907,6 +2907,74 @@
           "name": "role"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "TeamRoleListRow",
+      "fields": [
+        {
+          "type": "TeamID",
+          "name": "teamID",
+          "jsonkey": "team_id"
+        },
+        {
+          "type": "TeamRole",
+          "name": "role"
+        },
+        {
+          "type": "TeamRole",
+          "name": "implicitRole",
+          "jsonkey": "implicit_role"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamRoleList",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "TeamRoleListRow"
+          },
+          "name": "teams"
+        },
+        {
+          "type": "UserTeamVersion",
+          "name": "version",
+          "jsonkey": "user_team_version"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "TeamRoleListStored",
+      "fields": [
+        {
+          "type": "TeamRoleList",
+          "name": "data"
+        },
+        {
+          "type": "Time",
+          "name": "cachedAt"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UserTeamVersion",
+      "fields": [],
+      "typedef": "int"
+    },
+    {
+      "type": "record",
+      "name": "UserTeamVersionUpdate",
+      "fields": [
+        {
+          "type": "UserTeamVersion",
+          "name": "version"
+        }
+      ]
     }
   ],
   "messages": {
@@ -3865,6 +3933,10 @@
         }
       ],
       "response": "FastTeamLoadRes"
+    },
+    "getTeamRoleList": {
+      "request": [],
+      "response": "TeamRoleList"
     }
   },
   "namespace": "keybase.1"

--- a/shared/actions/engine-gen-gen.tsx
+++ b/shared/actions/engine-gen-gen.tsx
@@ -162,6 +162,7 @@ export const keybase1NotifyTeamTeamChangedByID = 'engine-gen:keybase1NotifyTeamT
 export const keybase1NotifyTeamTeamChangedByName = 'engine-gen:keybase1NotifyTeamTeamChangedByName'
 export const keybase1NotifyTeamTeamDeleted = 'engine-gen:keybase1NotifyTeamTeamDeleted'
 export const keybase1NotifyTeamTeamExit = 'engine-gen:keybase1NotifyTeamTeamExit'
+export const keybase1NotifyTeamTeamRoleListChanged = 'engine-gen:keybase1NotifyTeamTeamRoleListChanged'
 export const keybase1NotifyTeambotNewTeambotKey = 'engine-gen:keybase1NotifyTeambotNewTeambotKey'
 export const keybase1NotifyTeambotTeambotKeyNeeded = 'engine-gen:keybase1NotifyTeambotTeambotKeyNeeded'
 export const keybase1NotifyTrackingTrackingChanged = 'engine-gen:keybase1NotifyTrackingTrackingChanged'
@@ -1381,6 +1382,17 @@ type _Keybase1NotifyTeamTeamExitPayload = {
     result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamExit']['outParam']) => void
   }
 }
+type _Keybase1NotifyTeamTeamRoleListChangedPayload = {
+  readonly params: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamRoleListChanged']['inParam'] & {
+    sessionID: number
+  }
+  response: {
+    error: keybase1Types.IncomingErrorCallback
+    result: (
+      param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamRoleListChanged']['outParam']
+    ) => void
+  }
+}
 type _Keybase1NotifyTeambotNewTeambotKeyPayload = {
   readonly params: keybase1Types.MessageTypes['keybase.1.NotifyTeambot.newTeambotKey']['inParam'] & {
     sessionID: number
@@ -2338,6 +2350,9 @@ export const createKeybase1NotifyTeamTeamDeleted = (
 export const createKeybase1NotifyTeamTeamExit = (
   payload: _Keybase1NotifyTeamTeamExitPayload
 ): Keybase1NotifyTeamTeamExitPayload => ({payload, type: keybase1NotifyTeamTeamExit})
+export const createKeybase1NotifyTeamTeamRoleListChanged = (
+  payload: _Keybase1NotifyTeamTeamRoleListChangedPayload
+): Keybase1NotifyTeamTeamRoleListChangedPayload => ({payload, type: keybase1NotifyTeamTeamRoleListChanged})
 export const createKeybase1NotifyTeambotNewTeambotKey = (
   payload: _Keybase1NotifyTeambotNewTeambotKeyPayload
 ): Keybase1NotifyTeambotNewTeambotKeyPayload => ({payload, type: keybase1NotifyTeambotNewTeambotKey})
@@ -3104,6 +3119,10 @@ export type Keybase1NotifyTeamTeamExitPayload = {
   readonly payload: _Keybase1NotifyTeamTeamExitPayload
   readonly type: typeof keybase1NotifyTeamTeamExit
 }
+export type Keybase1NotifyTeamTeamRoleListChangedPayload = {
+  readonly payload: _Keybase1NotifyTeamTeamRoleListChangedPayload
+  readonly type: typeof keybase1NotifyTeamTeamRoleListChanged
+}
 export type Keybase1NotifyTeambotNewTeambotKeyPayload = {
   readonly payload: _Keybase1NotifyTeambotNewTeambotKeyPayload
   readonly type: typeof keybase1NotifyTeambotNewTeambotKey
@@ -3471,6 +3490,7 @@ export type Actions =
   | Keybase1NotifyTeamTeamChangedByNamePayload
   | Keybase1NotifyTeamTeamDeletedPayload
   | Keybase1NotifyTeamTeamExitPayload
+  | Keybase1NotifyTeamTeamRoleListChangedPayload
   | Keybase1NotifyTeambotNewTeambotKeyPayload
   | Keybase1NotifyTeambotTeambotKeyNeededPayload
   | Keybase1NotifyTrackingTrackingChangedPayload

--- a/shared/actions/json/engine-gen.json
+++ b/shared/actions/json/engine-gen.json
@@ -427,6 +427,9 @@
         "keybase1NotifyTeamNewlyAddedToTeam": {
             "params": "keybase1Types.MessageTypes['keybase.1.NotifyTeam.newlyAddedToTeam']['inParam'] & {sessionID: number}, response: {error: keybase1Types.IncomingErrorCallback, result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.newlyAddedToTeam']['outParam']) => void}"
         },
+        "keybase1NotifyTeamTeamRoleListChanged": {
+            "params": "keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamRoleListChanged']['inParam'] & {sessionID: number}, response: {error: keybase1Types.IncomingErrorCallback, result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamRoleListChanged']['outParam']) => void}"
+        },
         "keybase1NotifyTeamAvatarUpdated": {
             "params": "keybase1Types.MessageTypes['keybase.1.NotifyTeam.avatarUpdated']['inParam'] & {sessionID: number}, response: {error: keybase1Types.IncomingErrorCallback, result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.avatarUpdated']['outParam']) => void}"
         },

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -429,6 +429,7 @@ export type TypedActionsMap = {
   'engine-gen:keybase1NotifyTeamTeamAbandoned': enginegen.Keybase1NotifyTeamTeamAbandonedPayload
   'engine-gen:keybase1NotifyTeamTeamExit': enginegen.Keybase1NotifyTeamTeamExitPayload
   'engine-gen:keybase1NotifyTeamNewlyAddedToTeam': enginegen.Keybase1NotifyTeamNewlyAddedToTeamPayload
+  'engine-gen:keybase1NotifyTeamTeamRoleListChanged': enginegen.Keybase1NotifyTeamTeamRoleListChangedPayload
   'engine-gen:keybase1NotifyTeamAvatarUpdated': enginegen.Keybase1NotifyTeamAvatarUpdatedPayload
   'engine-gen:keybase1NotifyTeambotNewTeambotKey': enginegen.Keybase1NotifyTeambotNewTeambotKeyPayload
   'engine-gen:keybase1NotifyTeambotTeambotKeyNeeded': enginegen.Keybase1NotifyTeambotTeambotKeyNeededPayload

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -179,6 +179,10 @@ export type MessageTypes = {
     inParam: {readonly teamID: TeamID}
     outParam: void
   }
+  'keybase.1.NotifyTeam.teamRoleListChanged': {
+    inParam: {readonly newVersion: UserTeamVersion}
+    outParam: void
+  }
   'keybase.1.NotifyTeambot.newTeambotKey': {
     inParam: {readonly id: TeamID; readonly generation: TeambotKeyGeneration; readonly application: TeamApplication}
     outParam: void
@@ -2109,6 +2113,7 @@ export enum StatusCode {
   scemailcannotdeleteprimary = 716,
   scemailunknown = 717,
   scbotsignuptokennotfound = 719,
+  scnoupdate = 723,
   scmissingresult = 801,
   sckeynotfound = 901,
   sckeycorrupted = 905,
@@ -2908,6 +2913,9 @@ export type TeamProfileAddEntry = {readonly teamName: TeamName; readonly open: B
 export type TeamRefreshers = {readonly needKeyGeneration: PerTeamKeyGeneration; readonly needApplicationsAtGenerations: {[key: string]: Array<TeamApplication> | null}; readonly needApplicationsAtGenerationsWithKBFS: {[key: string]: Array<TeamApplication> | null}; readonly wantMembers?: Array<UserVersion> | null; readonly wantMembersRole: TeamRole; readonly needKBFSKeyGeneration: TeamKBFSKeyRefresher}
 export type TeamRequestAccessResult = {readonly open: Boolean}
 export type TeamResetUser = {readonly username: String; readonly uid: UID; readonly eldestSeqno: Seqno; readonly isDelete: Boolean}
+export type TeamRoleList = {readonly teams?: Array<TeamRoleListRow> | null; readonly version: UserTeamVersion}
+export type TeamRoleListRow = {readonly teamID: TeamID; readonly role: TeamRole; readonly implicitRole: TeamRole}
+export type TeamRoleListStored = {readonly data: TeamRoleList; readonly cachedAt: Time}
 export type TeamSBSMsg = {readonly teamID: TeamID; readonly score: Int; readonly invitees?: Array<TeamInvitee> | null}
 export type TeamSeitanMsg = {readonly teamID: TeamID; readonly seitans?: Array<TeamSeitanRequest> | null}
 export type TeamSeitanRequest = {readonly inviteID: TeamInviteID; readonly uid: UID; readonly eldestSeqno: Seqno; readonly akey: SeitanAKey; readonly role: TeamRole; readonly unixCTime: Int64}
@@ -2967,6 +2975,8 @@ export type UserSummary = {readonly uid: UID; readonly username: String; readonl
 export type UserSummary2 = {readonly uid: UID; readonly username: String; readonly thumbnail: String; readonly fullName: String; readonly isFollower: Boolean; readonly isFollowee: Boolean}
 export type UserSummary2Set = {readonly users?: Array<UserSummary2> | null; readonly time: Time; readonly version: Int}
 export type UserTeamShowcase = {readonly fqName: String; readonly open: Boolean; readonly teamIsShowcased: Boolean; readonly description: String; readonly role: TeamRole; readonly publicAdmins?: Array<String> | null; readonly numMembers: Int}
+export type UserTeamVersion = Int
+export type UserTeamVersionUpdate = {readonly version: UserTeamVersion}
 export type UserVersion = {readonly uid: UID; readonly eldestSeqno: Seqno}
 export type UserVersionPercentForm = String
 export type UserVersionVector = {readonly id: Long; readonly sigHints: Int; readonly sigChain: Long; readonly cachedAt: Time}
@@ -3061,6 +3071,7 @@ export type IncomingCallMapType = {
   'keybase.1.NotifyTeam.teamAbandoned'?: (params: MessageTypes['keybase.1.NotifyTeam.teamAbandoned']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyTeam.teamExit'?: (params: MessageTypes['keybase.1.NotifyTeam.teamExit']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyTeam.newlyAddedToTeam'?: (params: MessageTypes['keybase.1.NotifyTeam.newlyAddedToTeam']['inParam'] & {sessionID: number}) => IncomingReturn
+  'keybase.1.NotifyTeam.teamRoleListChanged'?: (params: MessageTypes['keybase.1.NotifyTeam.teamRoleListChanged']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyTeam.avatarUpdated'?: (params: MessageTypes['keybase.1.NotifyTeam.avatarUpdated']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyTeambot.newTeambotKey'?: (params: MessageTypes['keybase.1.NotifyTeambot.newTeambotKey']['inParam'] & {sessionID: number}) => IncomingReturn
   'keybase.1.NotifyTeambot.teambotKeyNeeded'?: (params: MessageTypes['keybase.1.NotifyTeambot.teambotKeyNeeded']['inParam'] & {sessionID: number}) => IncomingReturn
@@ -3185,6 +3196,7 @@ export type CustomResponseIncomingCallMap = {
   'keybase.1.NotifyTeam.teamAbandoned'?: (params: MessageTypes['keybase.1.NotifyTeam.teamAbandoned']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyTeam.teamAbandoned']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyTeam.teamExit'?: (params: MessageTypes['keybase.1.NotifyTeam.teamExit']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyTeam.teamExit']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyTeam.newlyAddedToTeam'?: (params: MessageTypes['keybase.1.NotifyTeam.newlyAddedToTeam']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyTeam.newlyAddedToTeam']['outParam']) => void}) => IncomingReturn
+  'keybase.1.NotifyTeam.teamRoleListChanged'?: (params: MessageTypes['keybase.1.NotifyTeam.teamRoleListChanged']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyTeam.teamRoleListChanged']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyTeam.avatarUpdated'?: (params: MessageTypes['keybase.1.NotifyTeam.avatarUpdated']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyTeam.avatarUpdated']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyTeambot.teambotKeyNeeded'?: (params: MessageTypes['keybase.1.NotifyTeambot.teambotKeyNeeded']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyTeambot.teambotKeyNeeded']['outParam']) => void}) => IncomingReturn
   'keybase.1.NotifyTracking.trackingInfo'?: (params: MessageTypes['keybase.1.NotifyTracking.trackingInfo']['inParam'] & {sessionID: number}, response: {error: IncomingErrorCallback; result: (res: MessageTypes['keybase.1.NotifyTracking.trackingInfo']['outParam']) => void}) => IncomingReturn
@@ -3673,6 +3685,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.NotifyTeam.teamAbandoned'
 // 'keybase.1.NotifyTeam.teamExit'
 // 'keybase.1.NotifyTeam.newlyAddedToTeam'
+// 'keybase.1.NotifyTeam.teamRoleListChanged'
 // 'keybase.1.NotifyTeam.avatarUpdated'
 // 'keybase.1.NotifyTeambot.newTeambotKey'
 // 'keybase.1.NotifyTeambot.teambotKeyNeeded'
@@ -3805,6 +3818,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.teams.profileTeamLoad'
 // 'keybase.1.teams.getTeamID'
 // 'keybase.1.teams.ftl'
+// 'keybase.1.teams.getTeamRoleList'
 // 'keybase.1.teamsUi.confirmRootTeamDelete'
 // 'keybase.1.teamsUi.confirmSubteamDelete'
 // 'keybase.1.test.test'


### PR DESCRIPTION
- the protocol is for eager refresh -- when a gregor message comes in and it is advertising a version newer than ours, we go to the server
- cache in memory and in disk
- on logout, flush the cache
- testing around all major cases
- RPCs for React to call, both for the refresh, and to prompt a refresh