### PR TITLE
plumb through TeamRoleMap from Go to Redux store

### DIFF
--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -756,7 +756,7 @@ type HiddenTeamChainManager interface {
 }
 
 type TeamRoleMapManager interface {
-	Get(m MetaContext) (res keybase1.TeamRoleMapAndVersion, err error)
+	Get(m MetaContext, retryOnFail bool) (res keybase1.TeamRoleMapAndVersion, err error)
 	Update(m MetaContext, version keybase1.UserTeamVersion) (err error)
 	FlushCache()
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -100,6 +100,7 @@ type NotifyListener interface {
 	RuntimeStatsUpdate(*keybase1.RuntimeStats)
 	HTTPSrvInfoUpdate(keybase1.HttpSrvInfo)
 	IdentifyUpdate(okUsernames []string, brokenUsernames []string)
+	Reachability(keybase1.Reachability)
 }
 
 type NoopNotifyListener struct{}
@@ -226,6 +227,7 @@ func (n *NoopNotifyListener) RuntimeStatsUpdate(*keybase1.RuntimeStats) {}
 func (n *NoopNotifyListener) HTTPSrvInfoUpdate(keybase1.HttpSrvInfo)    {}
 func (n *NoopNotifyListener) IdentifyUpdate(okUsernames []string, brokenUsernames []string) {
 }
+func (n *NoopNotifyListener) Reachability(keybase1.Reachability) {}
 
 type NotifyListenerID string
 
@@ -1821,6 +1823,9 @@ func (n *NotifyRouter) HandleReachability(r keybase1.Reachability) {
 			}()
 		}
 		return true
+	})
+	n.runListeners(func(listener NotifyListener) {
+		listener.Reachability(r)
 	})
 	n.G().Log.Debug("- Sent reachability")
 }

--- a/go/libkb/team_stub.go
+++ b/go/libkb/team_stub.go
@@ -197,7 +197,7 @@ func newNullTeamRoleMapManager() nullTeamRoleMapManager {
 	return nullTeamRoleMapManager{}
 }
 
-func (n nullTeamRoleMapManager) Get(m MetaContext) (res keybase1.TeamRoleMapAndVersion, err error) {
+func (n nullTeamRoleMapManager) Get(m MetaContext, retryOnFail bool) (res keybase1.TeamRoleMapAndVersion, err error) {
 	return res, nil
 }
 func (n nullTeamRoleMapManager) Update(m MetaContext, version keybase1.UserTeamVersion) (err error) {

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -746,5 +746,5 @@ func (h *TeamsHandler) GetTeamID(ctx context.Context, teamName string) (res keyb
 
 func (h *TeamsHandler) GetTeamRoleMap(ctx context.Context) (res keybase1.TeamRoleMapAndVersion, err error) {
 	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
-	return mctx.G().GetTeamRoleMapManager().Get(mctx)
+	return mctx.G().GetTeamRoleMapManager().Get(mctx, true /* retry on fail */)
 }

--- a/go/teams/team_role_map.go
+++ b/go/teams/team_role_map.go
@@ -75,7 +75,6 @@ func (t *TeamRoleMapManager) wait(mctx libkb.MetaContext, dur time.Duration) {
 	case r := <-t.reachabilityCh:
 		mctx.Debug("short-circuited wait since we came back online (%s)", r.Reachable)
 	}
-	return
 }
 
 func (t *TeamRoleMapManager) loadFromDB(mctx libkb.MetaContext, uid keybase1.UID) (err error) {

--- a/go/teams/team_role_map.go
+++ b/go/teams/team_role_map.go
@@ -25,9 +25,17 @@ func NewTeamRoleMapManagerAndInstall(g *libkb.GlobalContext) {
 	}
 }
 
+func NewTeamRoleMapManager() *TeamRoleMapManager {
+	return &TeamRoleMapManager{
+		reachabilityCh: make(chan keybase1.Reachability),
+	}
+}
+
+var _ libkb.TeamRoleMapManager = (*TeamRoleMapManager)(nil)
+
 // Reachability should be called whenever the reachability status of the app changes
-// (via NotifyRouter). If we happen to be waiting on a refresh, then break out and
-// refresh it.
+// (via NotifyRouter). If we happen to be waiting on a timer to do a refresh, then break
+// out and refresh it.
 func (t *TeamRoleMapManager) Reachability(r keybase1.Reachability) {
 	if r.Reachable == keybase1.Reachable_NO {
 		return
@@ -37,14 +45,6 @@ func (t *TeamRoleMapManager) Reachability(r keybase1.Reachability) {
 	default:
 	}
 }
-
-func NewTeamRoleMapManager() *TeamRoleMapManager {
-	return &TeamRoleMapManager{
-		reachabilityCh: make(chan keybase1.Reachability),
-	}
-}
-
-var _ libkb.TeamRoleMapManager = (*TeamRoleMapManager)(nil)
 
 func (t *TeamRoleMapManager) isFresh(m libkb.MetaContext, state *keybase1.TeamRoleMapStored) bool {
 	if t.lastKnownVersion != nil && *t.lastKnownVersion > state.Data.Version {

--- a/go/teams/team_role_map.go
+++ b/go/teams/team_role_map.go
@@ -14,8 +14,7 @@ type TeamRoleMapManager struct {
 	sync.Mutex
 	lastKnownVersion *keybase1.UserTeamVersion
 	state            *keybase1.TeamRoleMapStored
-
-	reachabilityCh chan keybase1.Reachability
+	reachabilityCh   chan keybase1.Reachability
 }
 
 func NewTeamRoleMapManagerAndInstall(g *libkb.GlobalContext) {

--- a/go/teams/team_role_map.go
+++ b/go/teams/team_role_map.go
@@ -115,7 +115,6 @@ func (t *TeamRoleMapManager) loadDelayedRetry(mctx libkb.MetaContext, backoff ti
 	// on failure, and there was a failure. In that case, we call back to them
 	// (via sendNotification), and they will reattempt the Get(), hopefully succeeding this time.
 	t.sendNotification(mctx, t.state.Data.Version)
-	return
 }
 
 func (t *TeamRoleMapManager) sendNotification(mctx libkb.MetaContext, version keybase1.UserTeamVersion) {

--- a/go/teams/team_role_map_test.go
+++ b/go/teams/team_role_map_test.go
@@ -24,7 +24,7 @@ func TestTeamRoleMap(t *testing.T) {
 	subteamID, err := CreateSubteam(m[0].Ctx(), tcs[0].G, subteamName, teamName, keybase1.TeamRole_WRITER)
 	require.NoError(t, err)
 
-	received, err := m[1].G().GetTeamRoleMapManager().Get(m[1])
+	received, err := m[1].G().GetTeamRoleMapManager().Get(m[1], false)
 	require.NoError(t, err)
 
 	expected := keybase1.TeamRoleMapAndVersion{
@@ -68,7 +68,7 @@ func TestTeamRoleMap(t *testing.T) {
 
 	m[1].G().GetTeamRoleMapManager().FlushCache()
 
-	received, err = m[1].G().GetTeamRoleMapManager().Get(m[1])
+	received, err = m[1].G().GetTeamRoleMapManager().Get(m[1], false)
 	require.NoError(t, err)
 	require.Equal(t, expected, received)
 }

--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -258,6 +258,7 @@
   "keybase.1.teams.teamRemoveMember": {"promise": true},
   "keybase.1.teams.teamRename": {"promise": true},
   "keybase.1.teams.teamSetSettings": {"promise": true},
+  "keybase.1.teams.getTeamRoleMap": {"promise": true},
   "keybase.1.teams.uploadTeamAvatar": {"promise": true},
   "keybase.1.track.checkTracking": {"promise": true},
   "keybase.1.track.dismissWithToken": {"promise": true},

--- a/shared/actions/engine-gen-gen.tsx
+++ b/shared/actions/engine-gen-gen.tsx
@@ -162,12 +162,13 @@ export const keybase1NotifyTeamTeamChangedByID = 'engine-gen:keybase1NotifyTeamT
 export const keybase1NotifyTeamTeamChangedByName = 'engine-gen:keybase1NotifyTeamTeamChangedByName'
 export const keybase1NotifyTeamTeamDeleted = 'engine-gen:keybase1NotifyTeamTeamDeleted'
 export const keybase1NotifyTeamTeamExit = 'engine-gen:keybase1NotifyTeamTeamExit'
-export const keybase1NotifyTeamTeamMetadataUpdate = 'engine-gen:keybase1NotifyTeamTeamMetadataUpdate'
 export const keybase1NotifyTeamTeamRoleMapChanged = 'engine-gen:keybase1NotifyTeamTeamRoleMapChanged'
 export const keybase1NotifyTeambotNewTeambotKey = 'engine-gen:keybase1NotifyTeambotNewTeambotKey'
 export const keybase1NotifyTeambotTeambotKeyNeeded = 'engine-gen:keybase1NotifyTeambotTeambotKeyNeeded'
 export const keybase1NotifyTrackingTrackingChanged = 'engine-gen:keybase1NotifyTrackingTrackingChanged'
 export const keybase1NotifyTrackingTrackingInfo = 'engine-gen:keybase1NotifyTrackingTrackingInfo'
+export const keybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged =
+  'engine-gen:keybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged'
 export const keybase1NotifyUsersIdentifyUpdate = 'engine-gen:keybase1NotifyUsersIdentifyUpdate'
 export const keybase1NotifyUsersPasswordChanged = 'engine-gen:keybase1NotifyUsersPasswordChanged'
 export const keybase1NotifyUsersUserChanged = 'engine-gen:keybase1NotifyUsersUserChanged'
@@ -1381,15 +1382,6 @@ type _Keybase1NotifyTeamTeamExitPayload = {
     result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamExit']['outParam']) => void
   }
 }
-type _Keybase1NotifyTeamTeamMetadataUpdatePayload = {
-  readonly params: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamMetadataUpdate']['inParam'] & {
-    sessionID: number
-  }
-  response: {
-    error: keybase1Types.IncomingErrorCallback
-    result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamMetadataUpdate']['outParam']) => void
-  }
-}
 type _Keybase1NotifyTeamTeamRoleMapChangedPayload = {
   readonly params: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamRoleMapChanged']['inParam'] & {
     sessionID: number
@@ -1427,6 +1419,11 @@ type _Keybase1NotifyTrackingTrackingInfoPayload = {
   response: {
     error: keybase1Types.IncomingErrorCallback
     result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTracking.trackingInfo']['outParam']) => void
+  }
+}
+type _Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload = {
+  readonly params: keybase1Types.MessageTypes['keybase.1.NotifyUnverifiedTeamList.teamListUnverifiedChanged']['inParam'] & {
+    sessionID: number
   }
 }
 type _Keybase1NotifyUsersIdentifyUpdatePayload = {
@@ -2351,9 +2348,6 @@ export const createKeybase1NotifyTeamTeamDeleted = (
 export const createKeybase1NotifyTeamTeamExit = (
   payload: _Keybase1NotifyTeamTeamExitPayload
 ): Keybase1NotifyTeamTeamExitPayload => ({payload, type: keybase1NotifyTeamTeamExit})
-export const createKeybase1NotifyTeamTeamMetadataUpdate = (
-  payload: _Keybase1NotifyTeamTeamMetadataUpdatePayload
-): Keybase1NotifyTeamTeamMetadataUpdatePayload => ({payload, type: keybase1NotifyTeamTeamMetadataUpdate})
 export const createKeybase1NotifyTeamTeamRoleMapChanged = (
   payload: _Keybase1NotifyTeamTeamRoleMapChangedPayload
 ): Keybase1NotifyTeamTeamRoleMapChangedPayload => ({payload, type: keybase1NotifyTeamTeamRoleMapChanged})
@@ -2369,6 +2363,12 @@ export const createKeybase1NotifyTrackingTrackingChanged = (
 export const createKeybase1NotifyTrackingTrackingInfo = (
   payload: _Keybase1NotifyTrackingTrackingInfoPayload
 ): Keybase1NotifyTrackingTrackingInfoPayload => ({payload, type: keybase1NotifyTrackingTrackingInfo})
+export const createKeybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged = (
+  payload: _Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload
+): Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload => ({
+  payload,
+  type: keybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged,
+})
 export const createKeybase1NotifyUsersIdentifyUpdate = (
   payload: _Keybase1NotifyUsersIdentifyUpdatePayload
 ): Keybase1NotifyUsersIdentifyUpdatePayload => ({payload, type: keybase1NotifyUsersIdentifyUpdate})
@@ -3117,10 +3117,6 @@ export type Keybase1NotifyTeamTeamExitPayload = {
   readonly payload: _Keybase1NotifyTeamTeamExitPayload
   readonly type: typeof keybase1NotifyTeamTeamExit
 }
-export type Keybase1NotifyTeamTeamMetadataUpdatePayload = {
-  readonly payload: _Keybase1NotifyTeamTeamMetadataUpdatePayload
-  readonly type: typeof keybase1NotifyTeamTeamMetadataUpdate
-}
 export type Keybase1NotifyTeamTeamRoleMapChangedPayload = {
   readonly payload: _Keybase1NotifyTeamTeamRoleMapChangedPayload
   readonly type: typeof keybase1NotifyTeamTeamRoleMapChanged
@@ -3140,6 +3136,10 @@ export type Keybase1NotifyTrackingTrackingChangedPayload = {
 export type Keybase1NotifyTrackingTrackingInfoPayload = {
   readonly payload: _Keybase1NotifyTrackingTrackingInfoPayload
   readonly type: typeof keybase1NotifyTrackingTrackingInfo
+}
+export type Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload = {
+  readonly payload: _Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload
+  readonly type: typeof keybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged
 }
 export type Keybase1NotifyUsersIdentifyUpdatePayload = {
   readonly payload: _Keybase1NotifyUsersIdentifyUpdatePayload
@@ -3488,12 +3488,12 @@ export type Actions =
   | Keybase1NotifyTeamTeamChangedByNamePayload
   | Keybase1NotifyTeamTeamDeletedPayload
   | Keybase1NotifyTeamTeamExitPayload
-  | Keybase1NotifyTeamTeamMetadataUpdatePayload
   | Keybase1NotifyTeamTeamRoleMapChangedPayload
   | Keybase1NotifyTeambotNewTeambotKeyPayload
   | Keybase1NotifyTeambotTeambotKeyNeededPayload
   | Keybase1NotifyTrackingTrackingChangedPayload
   | Keybase1NotifyTrackingTrackingInfoPayload
+  | Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload
   | Keybase1NotifyUsersIdentifyUpdatePayload
   | Keybase1NotifyUsersPasswordChangedPayload
   | Keybase1NotifyUsersUserChangedPayload

--- a/shared/actions/engine-gen-gen.tsx
+++ b/shared/actions/engine-gen-gen.tsx
@@ -162,13 +162,12 @@ export const keybase1NotifyTeamTeamChangedByID = 'engine-gen:keybase1NotifyTeamT
 export const keybase1NotifyTeamTeamChangedByName = 'engine-gen:keybase1NotifyTeamTeamChangedByName'
 export const keybase1NotifyTeamTeamDeleted = 'engine-gen:keybase1NotifyTeamTeamDeleted'
 export const keybase1NotifyTeamTeamExit = 'engine-gen:keybase1NotifyTeamTeamExit'
+export const keybase1NotifyTeamTeamMetadataUpdate = 'engine-gen:keybase1NotifyTeamTeamMetadataUpdate'
 export const keybase1NotifyTeamTeamRoleMapChanged = 'engine-gen:keybase1NotifyTeamTeamRoleMapChanged'
 export const keybase1NotifyTeambotNewTeambotKey = 'engine-gen:keybase1NotifyTeambotNewTeambotKey'
 export const keybase1NotifyTeambotTeambotKeyNeeded = 'engine-gen:keybase1NotifyTeambotTeambotKeyNeeded'
 export const keybase1NotifyTrackingTrackingChanged = 'engine-gen:keybase1NotifyTrackingTrackingChanged'
 export const keybase1NotifyTrackingTrackingInfo = 'engine-gen:keybase1NotifyTrackingTrackingInfo'
-export const keybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged =
-  'engine-gen:keybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged'
 export const keybase1NotifyUsersIdentifyUpdate = 'engine-gen:keybase1NotifyUsersIdentifyUpdate'
 export const keybase1NotifyUsersPasswordChanged = 'engine-gen:keybase1NotifyUsersPasswordChanged'
 export const keybase1NotifyUsersUserChanged = 'engine-gen:keybase1NotifyUsersUserChanged'
@@ -1382,6 +1381,15 @@ type _Keybase1NotifyTeamTeamExitPayload = {
     result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamExit']['outParam']) => void
   }
 }
+type _Keybase1NotifyTeamTeamMetadataUpdatePayload = {
+  readonly params: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamMetadataUpdate']['inParam'] & {
+    sessionID: number
+  }
+  response: {
+    error: keybase1Types.IncomingErrorCallback
+    result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamMetadataUpdate']['outParam']) => void
+  }
+}
 type _Keybase1NotifyTeamTeamRoleMapChangedPayload = {
   readonly params: keybase1Types.MessageTypes['keybase.1.NotifyTeam.teamRoleMapChanged']['inParam'] & {
     sessionID: number
@@ -1419,11 +1427,6 @@ type _Keybase1NotifyTrackingTrackingInfoPayload = {
   response: {
     error: keybase1Types.IncomingErrorCallback
     result: (param: keybase1Types.MessageTypes['keybase.1.NotifyTracking.trackingInfo']['outParam']) => void
-  }
-}
-type _Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload = {
-  readonly params: keybase1Types.MessageTypes['keybase.1.NotifyUnverifiedTeamList.teamListUnverifiedChanged']['inParam'] & {
-    sessionID: number
   }
 }
 type _Keybase1NotifyUsersIdentifyUpdatePayload = {
@@ -2348,6 +2351,9 @@ export const createKeybase1NotifyTeamTeamDeleted = (
 export const createKeybase1NotifyTeamTeamExit = (
   payload: _Keybase1NotifyTeamTeamExitPayload
 ): Keybase1NotifyTeamTeamExitPayload => ({payload, type: keybase1NotifyTeamTeamExit})
+export const createKeybase1NotifyTeamTeamMetadataUpdate = (
+  payload: _Keybase1NotifyTeamTeamMetadataUpdatePayload
+): Keybase1NotifyTeamTeamMetadataUpdatePayload => ({payload, type: keybase1NotifyTeamTeamMetadataUpdate})
 export const createKeybase1NotifyTeamTeamRoleMapChanged = (
   payload: _Keybase1NotifyTeamTeamRoleMapChangedPayload
 ): Keybase1NotifyTeamTeamRoleMapChangedPayload => ({payload, type: keybase1NotifyTeamTeamRoleMapChanged})
@@ -2363,12 +2369,6 @@ export const createKeybase1NotifyTrackingTrackingChanged = (
 export const createKeybase1NotifyTrackingTrackingInfo = (
   payload: _Keybase1NotifyTrackingTrackingInfoPayload
 ): Keybase1NotifyTrackingTrackingInfoPayload => ({payload, type: keybase1NotifyTrackingTrackingInfo})
-export const createKeybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged = (
-  payload: _Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload
-): Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload => ({
-  payload,
-  type: keybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged,
-})
 export const createKeybase1NotifyUsersIdentifyUpdate = (
   payload: _Keybase1NotifyUsersIdentifyUpdatePayload
 ): Keybase1NotifyUsersIdentifyUpdatePayload => ({payload, type: keybase1NotifyUsersIdentifyUpdate})
@@ -3117,6 +3117,10 @@ export type Keybase1NotifyTeamTeamExitPayload = {
   readonly payload: _Keybase1NotifyTeamTeamExitPayload
   readonly type: typeof keybase1NotifyTeamTeamExit
 }
+export type Keybase1NotifyTeamTeamMetadataUpdatePayload = {
+  readonly payload: _Keybase1NotifyTeamTeamMetadataUpdatePayload
+  readonly type: typeof keybase1NotifyTeamTeamMetadataUpdate
+}
 export type Keybase1NotifyTeamTeamRoleMapChangedPayload = {
   readonly payload: _Keybase1NotifyTeamTeamRoleMapChangedPayload
   readonly type: typeof keybase1NotifyTeamTeamRoleMapChanged
@@ -3136,10 +3140,6 @@ export type Keybase1NotifyTrackingTrackingChangedPayload = {
 export type Keybase1NotifyTrackingTrackingInfoPayload = {
   readonly payload: _Keybase1NotifyTrackingTrackingInfoPayload
   readonly type: typeof keybase1NotifyTrackingTrackingInfo
-}
-export type Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload = {
-  readonly payload: _Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload
-  readonly type: typeof keybase1NotifyUnverifiedTeamListTeamListUnverifiedChanged
 }
 export type Keybase1NotifyUsersIdentifyUpdatePayload = {
   readonly payload: _Keybase1NotifyUsersIdentifyUpdatePayload
@@ -3488,12 +3488,12 @@ export type Actions =
   | Keybase1NotifyTeamTeamChangedByNamePayload
   | Keybase1NotifyTeamTeamDeletedPayload
   | Keybase1NotifyTeamTeamExitPayload
+  | Keybase1NotifyTeamTeamMetadataUpdatePayload
   | Keybase1NotifyTeamTeamRoleMapChangedPayload
   | Keybase1NotifyTeambotNewTeambotKeyPayload
   | Keybase1NotifyTeambotTeambotKeyNeededPayload
   | Keybase1NotifyTrackingTrackingChangedPayload
   | Keybase1NotifyTrackingTrackingInfoPayload
-  | Keybase1NotifyUnverifiedTeamListTeamListUnverifiedChangedPayload
   | Keybase1NotifyUsersIdentifyUpdatePayload
   | Keybase1NotifyUsersPasswordChangedPayload
   | Keybase1NotifyUsersUserChangedPayload

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -286,6 +286,12 @@
       "_description": "Rename a subteam",
       "oldName": "string",
       "newName": "string"
+    },
+    "setTeamRoleMapLatestKnownVersion": {
+      "version" : "number"
+    },
+    "setTeamRoleMap": {
+      "map" : "Types.TeamRoleMap"
     }
   }
 }

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -67,6 +67,8 @@ export const setTeamLoadingInvites = 'teams:setTeamLoadingInvites'
 export const setTeamProfileAddList = 'teams:setTeamProfileAddList'
 export const setTeamPublicitySettings = 'teams:setTeamPublicitySettings'
 export const setTeamRetentionPolicy = 'teams:setTeamRetentionPolicy'
+export const setTeamRoleMap = 'teams:setTeamRoleMap'
+export const setTeamRoleMapLatestKnownVersion = 'teams:setTeamRoleMapLatestKnownVersion'
 export const setTeamSawChatBanner = 'teams:setTeamSawChatBanner'
 export const setTeamSawSubteamsBanner = 'teams:setTeamSawSubteamsBanner'
 export const setTeamsWithChosenChannels = 'teams:setTeamsWithChosenChannels'
@@ -240,6 +242,8 @@ type _SetTeamPublicitySettingsPayload = {
   readonly publicity: Types._PublicitySettings
 }
 type _SetTeamRetentionPolicyPayload = {readonly teamname: string; readonly retentionPolicy: RetentionPolicy}
+type _SetTeamRoleMapLatestKnownVersionPayload = {readonly version: number}
+type _SetTeamRoleMapPayload = {readonly map: Types.TeamRoleMap}
 type _SetTeamSawChatBannerPayload = void
 type _SetTeamSawSubteamsBannerPayload = void
 type _SetTeamsWithChosenChannelsPayload = {readonly teamsWithChosenChannels: Set<Types.Teamname>}
@@ -487,6 +491,13 @@ export const createSetTeamPublicitySettings = (
 export const createSetTeamRetentionPolicy = (
   payload: _SetTeamRetentionPolicyPayload
 ): SetTeamRetentionPolicyPayload => ({payload, type: setTeamRetentionPolicy})
+export const createSetTeamRoleMap = (payload: _SetTeamRoleMapPayload): SetTeamRoleMapPayload => ({
+  payload,
+  type: setTeamRoleMap,
+})
+export const createSetTeamRoleMapLatestKnownVersion = (
+  payload: _SetTeamRoleMapLatestKnownVersionPayload
+): SetTeamRoleMapLatestKnownVersionPayload => ({payload, type: setTeamRoleMapLatestKnownVersion})
 export const createSetTeamSawChatBanner = (
   payload: _SetTeamSawChatBannerPayload
 ): SetTeamSawChatBannerPayload => ({payload, type: setTeamSawChatBanner})
@@ -711,6 +722,14 @@ export type SetTeamRetentionPolicyPayload = {
   readonly payload: _SetTeamRetentionPolicyPayload
   readonly type: typeof setTeamRetentionPolicy
 }
+export type SetTeamRoleMapLatestKnownVersionPayload = {
+  readonly payload: _SetTeamRoleMapLatestKnownVersionPayload
+  readonly type: typeof setTeamRoleMapLatestKnownVersion
+}
+export type SetTeamRoleMapPayload = {
+  readonly payload: _SetTeamRoleMapPayload
+  readonly type: typeof setTeamRoleMap
+}
 export type SetTeamSawChatBannerPayload = {
   readonly payload: _SetTeamSawChatBannerPayload
   readonly type: typeof setTeamSawChatBanner
@@ -803,6 +822,8 @@ export type Actions =
   | SetTeamProfileAddListPayload
   | SetTeamPublicitySettingsPayload
   | SetTeamRetentionPolicyPayload
+  | SetTeamRoleMapLatestKnownVersionPayload
+  | SetTeamRoleMapPayload
   | SetTeamSawChatBannerPayload
   | SetTeamSawSubteamsBannerPayload
   | SetTeamsWithChosenChannelsPayload

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1508,7 +1508,11 @@ const teamsSaga = function*() {
     saveChannelMembership,
     'saveChannelMembership'
   )
-  yield* Saga.chainAction2(ConfigGen.bootstrapStatusLoaded, refreshTeamRoleMap, 'refreshTeamRoleMap')
+  yield* Saga.chainAction2(
+    [ConfigGen.bootstrapStatusLoaded, EngineGen.keybase1NotifyTeamTeamRoleMapChanged],
+    refreshTeamRoleMap,
+    'refreshTeamRoleMap'
+  )
 
   yield* Saga.chainGenerator<TeamsGen.CreateChannelPayload>(
     TeamsGen.createChannel,
@@ -1579,11 +1583,6 @@ const teamsSaga = function*() {
     EngineGen.keybase1NotifyTeamTeamRoleMapChanged,
     teamRoleMapChangedUpdateLatestKnownVersion,
     'teamRoleMapChangedUpdateLatestKnownVersion'
-  )
-  yield* Saga.chainAction2(
-    EngineGen.keybase1NotifyTeamTeamRoleMapChanged,
-    refreshTeamRoleMap,
-    'refreshTeamRoleMap'
   )
 
   yield* Saga.chainAction2(

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -885,6 +885,8 @@ export type TypedActionsMap = {
   'teams:getTeamRetentionPolicy': teams.GetTeamRetentionPolicyPayload
   'teams:saveTeamRetentionPolicy': teams.SaveTeamRetentionPolicyPayload
   'teams:renameTeam': teams.RenameTeamPayload
+  'teams:setTeamRoleMapLatestKnownVersion': teams.SetTeamRoleMapLatestKnownVersionPayload
+  'teams:setTeamRoleMap': teams.SetTeamRoleMapPayload
   'tracker2:load': tracker2.LoadPayload
   'tracker2:updatedDetails': tracker2.UpdatedDetailsPayload
   'tracker2:updateResult': tracker2.UpdateResultPayload

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -130,12 +130,11 @@ export const rpcTeamRoleMapAndVersionToTeamRoleMap = (
   }
   for (let key in m.teams) {
     let value = m.teams[key]
-    ret.roles[key] = {
+    ret.roles.set(key, {
       implicitRole: teamRoleByEnum[value.implicitRole] || 'none',
       role: teamRoleByEnum[value.role] || 'none',
-    }
+    })
   }
-
   return ret
 }
 

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -128,7 +128,7 @@ export const rpcTeamRoleMapAndVersionToTeamRoleMap = (
     loadedVersion: m.version,
     roles: new Map<Types.TeamID, Types.RolePair>(),
   }
-  for (let key in m.teams) {
+  for (const key in m.teams) {
     let value = m.teams[key]
     ret.roles.set(key, {
       implicitRole: teamRoleByEnum[value.implicitRole] || 'none',

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -124,7 +124,7 @@ export const rpcTeamRoleMapAndVersionToTeamRoleMap = (
   m: RPCTypes.TeamRoleMapAndVersion
 ): Types.TeamRoleMap => {
   const ret: Types.TeamRoleMap = {
-    latestKnownVersion: -1,
+    latestKnownVersion: m.version,
     loadedVersion: m.version,
     roles: new Map<Types.TeamID, Types.TeamRoleAndDetails>(),
   }

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -126,12 +126,13 @@ export const rpcTeamRoleMapAndVersionToTeamRoleMap = (
   const ret: Types.TeamRoleMap = {
     latestKnownVersion: -1,
     loadedVersion: m.version,
-    roles: new Map<Types.TeamID, Types.RolePair>(),
+    roles: new Map<Types.TeamID, Types.TeamRoleAndDetails>(),
   }
   for (const key in m.teams) {
     const value = m.teams[key]
     ret.roles.set(key, {
-      implicitRole: teamRoleByEnum[value.implicitRole] || 'none',
+      implicitAdmin:
+        value.implicitRole === RPCTypes.TeamRole.admin || value.implicitRole == RPCTypes.TeamRole.owner,
       role: teamRoleByEnum[value.role] || 'none',
     })
   }

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -129,7 +129,7 @@ export const rpcTeamRoleMapAndVersionToTeamRoleMap = (
     roles: new Map<Types.TeamID, Types.RolePair>(),
   }
   for (const key in m.teams) {
-    let value = m.teams[key]
+    const value = m.teams[key]
     ret.roles.set(key, {
       implicitRole: teamRoleByEnum[value.implicitRole] || 'none',
       role: teamRoleByEnum[value.role] || 'none',

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -120,6 +120,25 @@ export const teamRoleByEnum = ((m: {[K in Types.MaybeTeamRoleType]: RPCTypes.Tea
   return mInv
 })(RPCTypes.TeamRole)
 
+export const rpcTeamRoleMapAndVersionToTeamRoleMap = (
+  m: RPCTypes.TeamRoleMapAndVersion
+): Types.TeamRoleMap => {
+  const ret: Types.TeamRoleMap = {
+    latestKnownVersion: -1,
+    loadedVersion: m.version,
+    roles: new Map<Types.TeamID, Types.RolePair>(),
+  }
+  for (let key in m.teams) {
+    let value = m.teams[key]
+    ret.roles[key] = {
+      implicitRole: teamRoleByEnum[value.implicitRole] || 'none',
+      role: teamRoleByEnum[value.role] || 'none',
+    }
+  }
+
+  return ret
+}
+
 export const typeToLabel: Types.TypeMap = {
   admin: 'Admin',
   bot: 'Bot',
@@ -177,6 +196,7 @@ const emptyState: Types.State = {
   teamNameToSettings: I.Map(),
   teamNameToSubteams: I.Map(),
   teamProfileAddList: [],
+  teamRoleMap: {latestKnownVersion: -1, loadedVersion: -1, roles: new Map()},
   teammembercounts: I.Map(),
   teamnames: new Set(),
   teamsWithChosenChannels: new Set(),

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1207,6 +1207,10 @@ export type MessageTypes = {
     inParam: {readonly name: String}
     outParam: TeamAndMemberShowcase
   }
+  'keybase.1.teams.getTeamRoleMap': {
+    inParam: void
+    outParam: TeamRoleMapAndVersion
+  }
   'keybase.1.teams.setTarsDisabled': {
     inParam: {readonly name: String; readonly disabled: Boolean}
     outParam: void
@@ -3410,6 +3414,7 @@ export const signupSignupRpcSaga = (p: {params: MessageTypes['keybase.1.signup.s
 export const teamsCanUserPerformRpcPromise = (params: MessageTypes['keybase.1.teams.canUserPerform']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.canUserPerform']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.canUserPerform', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTarsDisabledRpcPromise = (params: MessageTypes['keybase.1.teams.getTarsDisabled']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTarsDisabled']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTarsDisabled', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTeamAndMemberShowcaseRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamAndMemberShowcase']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamAndMemberShowcase']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamAndMemberShowcase', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const teamsGetTeamRoleMapRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamRoleMap']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamRoleMap']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamRoleMap', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsSetTarsDisabledRpcPromise = (params: MessageTypes['keybase.1.teams.setTarsDisabled']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.setTarsDisabled']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.setTarsDisabled', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsSetTeamMemberShowcaseRpcPromise = (params: MessageTypes['keybase.1.teams.setTeamMemberShowcase']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.setTeamMemberShowcase']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.setTeamMemberShowcase', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsSetTeamShowcaseRpcPromise = (params: MessageTypes['keybase.1.teams.setTeamShowcase']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.setTeamShowcase']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.setTeamShowcase', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -3820,7 +3825,6 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.teams.profileTeamLoad'
 // 'keybase.1.teams.getTeamID'
 // 'keybase.1.teams.ftl'
-// 'keybase.1.teams.getTeamRoleMap'
 // 'keybase.1.teamsUi.confirmRootTeamDelete'
 // 'keybase.1.teamsUi.confirmSubteamDelete'
 // 'keybase.1.test.test'

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -121,6 +121,17 @@ export type TeamDetails = {
   requests?: Set<string>
 }
 
+export type RolePair = {
+  role: MaybeTeamRoleType
+  implicitRole: MaybeTeamRoleType
+}
+
+export type TeamRoleMap = {
+  latestKnownVersion: number
+  loadedVersion: number
+  roles: Map<TeamID, RolePair>
+}
+
 export type State = Readonly<{
   addUserToTeamsState: AddUserToTeamsState
   addUserToTeamsResults: string
@@ -156,6 +167,7 @@ export type State = Readonly<{
   teamnames: Set<Teamname> // TODO remove
   teammembercounts: I.Map<Teamname, number>
   teamProfileAddList: Array<TeamProfileAddList>
+  teamRoleMap: TeamRoleMap
   newTeams: Set<TeamID>
   newTeamRequests: Map<TeamID, number>
   newTeamRequestsByName: Map<string, number> // TODO remove

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -121,15 +121,15 @@ export type TeamDetails = {
   requests?: Set<string>
 }
 
-export type RolePair = {
+export type TeamRoleAndDetails = {
+  implicitAdmin: boolean
   role: MaybeTeamRoleType
-  implicitRole: MaybeTeamRoleType
 }
 
 export type TeamRoleMap = {
   latestKnownVersion: number
   loadedVersion: number
-  roles: Map<TeamID, RolePair>
+  roles: Map<TeamID, TeamRoleAndDetails>
 }
 
 export type State = Readonly<{

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -217,16 +217,25 @@ export default (
           () => RPCChatTypes.ConversationMemberStatus.left
         )
         return
-      case TeamsGen.setTeamRoleMapLatestKnownVersion:
-        draftState.teamRoleMap = {
-          ...draftState.teamRoleMap,
-          latestKnownVersion: action.payload.version,
+      case TeamsGen.setTeamRoleMapLatestKnownVersion: {
+        let latestKnownVersion = action.payload.version
+        if (latestKnownVersion > draftState.teamRoleMap.latestKnownVersion) {
+          draftState.teamRoleMap = {
+            ...draftState.teamRoleMap,
+            latestKnownVersion: latestKnownVersion,
+          }
         }
         return
+      }
       case TeamsGen.setTeamRoleMap: {
+        let latestKnownVersion = draftState.teamRoleMap.latestKnownVersion
+        let loadedVersion = action.payload.map.loadedVersion
+        if (loadedVersion > latestKnownVersion) {
+          latestKnownVersion = loadedVersion
+        }
         draftState.teamRoleMap = {
-          ...draftState.teamRoleMap,
-          loadedVersion: action.payload.map.loadedVersion,
+          latestKnownVersion: latestKnownVersion,
+          loadedVersion: loadedVersion,
           roles: action.payload.map.roles,
         }
         return

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -218,21 +218,16 @@ export default (
         )
         return
       case TeamsGen.setTeamRoleMapLatestKnownVersion: {
-        let latestKnownVersion = action.payload.version
-        if (latestKnownVersion > draftState.teamRoleMap.latestKnownVersion) {
-          draftState.teamRoleMap = {
-            ...draftState.teamRoleMap,
-            latestKnownVersion: latestKnownVersion,
-          }
+        const latestKnownVersion = action.payload.version
+        draftState.teamRoleMap = {
+          ...draftState.teamRoleMap,
+          latestKnownVersion: latestKnownVersion,
         }
         return
       }
       case TeamsGen.setTeamRoleMap: {
-        let latestKnownVersion = draftState.teamRoleMap.latestKnownVersion
-        let loadedVersion = action.payload.map.loadedVersion
-        if (loadedVersion > latestKnownVersion) {
-          latestKnownVersion = loadedVersion
-        }
+        const loadedVersion = action.payload.map.loadedVersion
+        const latestKnownVersion = Math.max(loadedVersion, draftState.teamRoleMap.latestKnownVersion)
         draftState.teamRoleMap = {
           latestKnownVersion: latestKnownVersion,
           loadedVersion: loadedVersion,

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -222,11 +222,12 @@ export default (
         return
       }
       case TeamsGen.setTeamRoleMap: {
-        const loadedVersion = action.payload.map.loadedVersion
-        const latestKnownVersion = Math.max(loadedVersion, draftState.teamRoleMap.latestKnownVersion)
         draftState.teamRoleMap = {
-          latestKnownVersion: latestKnownVersion,
-          loadedVersion: loadedVersion,
+          latestKnownVersion: Math.max(
+            action.payload.map.latestKnownVersion,
+            draftState.teamRoleMap.latestKnownVersion
+          ),
+          loadedVersion: action.payload.map.loadedVersion,
           roles: action.payload.map.roles,
         }
         return

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -218,11 +218,7 @@ export default (
         )
         return
       case TeamsGen.setTeamRoleMapLatestKnownVersion: {
-        const latestKnownVersion = action.payload.version
-        draftState.teamRoleMap = {
-          ...draftState.teamRoleMap,
-          latestKnownVersion: latestKnownVersion,
-        }
+        draftState.teamRoleMap.latestKnownVersion = action.payload.version
         return
       }
       case TeamsGen.setTeamRoleMap: {

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -217,6 +217,21 @@ export default (
           () => RPCChatTypes.ConversationMemberStatus.left
         )
         return
+      case TeamsGen.setTeamRoleMapLatestKnownVersion:
+        draftState.teamRoleMap = {
+          ...draftState.teamRoleMap,
+          latestKnownVersion: action.payload.version,
+        }
+        return
+      case TeamsGen.setTeamRoleMap: {
+        draftState.teamRoleMap = {
+          ...draftState.teamRoleMap,
+          loadedVersion: action.payload.map.loadedVersion,
+          roles: action.payload.map.roles,
+        }
+        return
+      }
+
       case TeamBuildingGen.resetStore:
       case TeamBuildingGen.cancelTeamBuilding:
       case TeamBuildingGen.addUsersToTeamSoFar:


### PR DESCRIPTION
- first every client JS PR, it likely needs work!
- refresh on notification of teamRoleMapChanged
- prime the store on startup
- the store has both the "latestKnownVersion" and the "loadedVersion"; a thought I had is that we can show spinners if the two don't agree, since the service is refreshing in that case
- question: what happens if the service fails to refresh (5x retries now, but maybe if you went offline, it'll keep failing)? should the service keep pinging React in that case?
- related question: what is the blackbar story?