### PR TITLE
Fix multi-op batch sending

### DIFF
--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -164,7 +164,7 @@ func (w *walletAPIHandler) batch(ctx context.Context, c Call, wr io.Writer) erro
 	arg := stellar1.BatchLocalArg{
 		BatchID:     opts.BatchID,
 		TimeoutSecs: opts.Timeout,
-		UseMulti:    false,
+		UseMulti:    true,
 	}
 	for _, p := range opts.Payments {
 		arg.Payments = append(arg.Payments, stellar1.BatchPaymentArg{Recipient: p.Recipient, Amount: p.Amount, Message: p.Message})

--- a/go/stellar/batch_multi.go
+++ b/go/stellar/batch_multi.go
@@ -47,6 +47,7 @@ func BatchMulti(mctx libkb.MetaContext, walletState *WalletState, arg stellar1.B
 
 	results := make([]stellar1.BatchPaymentResult, len(arg.Payments))
 	var multiOps []multiOp
+	var relays []stellar1.BatchPaymentArg
 	for i, payment := range arg.Payments {
 		results[i] = stellar1.BatchPaymentResult{
 			Username: libkb.NewNormalizedUsername(payment.Recipient).String(),
@@ -59,12 +60,10 @@ func BatchMulti(mctx libkb.MetaContext, walletState *WalletState, arg stellar1.B
 		}
 
 		if recipient.AccountID == nil {
-			mop, err := prepareRelayOp(mctx, payment, recipient)
-			if err != nil {
-				makeResultError(&results[i], err)
-				continue
-			}
-			multiOps = append(multiOps, mop)
+			// relays don't work well in multi-op payments, so handle
+			// them separately
+			// XXX include recipient too?  does that help with anything?
+			relays = append(relays, payment)
 		} else {
 			mop, err := prepareDirectOp(mctx, walletState, payment, recipient)
 			if err != nil {

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -638,7 +638,17 @@ func (s *Server) BatchLocal(ctx context.Context, arg stellar1.BatchLocalArg) (re
 	}
 
 	if arg.UseMulti {
-		return stellar.BatchMulti(mctx, s.walletState, arg)
+		res, err = stellar.BatchMulti(mctx, s.walletState, arg)
+		if err == nil {
+			return res, nil
+		}
+
+		if err == stellar.ErrRelayinMultiBatch {
+			mctx.Debug("found relay recipient in BatchMulti, using standard Batch instead")
+			return stellar.Batch(mctx, s.walletState, arg)
+		}
+
+		return res, err
 	}
 
 	return stellar.Batch(mctx, s.walletState, arg)


### PR DESCRIPTION
1. if the batch has a relay payment in it, use the standard batch (one tx per payment)
2. send chat payment messages to the recipients of a multi-op batch payment