### PR TITLE
switchLoggedIn on login just in case

### DIFF
--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -295,6 +295,8 @@ const switchRouteDef = (
           ? [RouteTreeGen.createNavigateAppend({path: ['signupEnterPhoneNumber']})]
           : []),
       ]
+    } else if (action.type === ConfigGen.loggedIn) {
+      return RouteTreeGen.createSwitchLoggedIn({loggedIn: true})
     }
   } else {
     return RouteTreeGen.createSwitchLoggedIn({loggedIn: false})


### PR DESCRIPTION
@malgorithms had a log where something (I can't figure out what) logged him out before the initial login event on opening the app triggered its `loggedIn` action, and so the `routeToInitialScreenOnce` routed him to the login screen.

Since it's not expensive to trigger just the route switch when the login event does eventually happen, let's trigger it here just in case. We won't route to a specific screen because we might already be in the logged-in routes.

CC @keybase/y2ksquad 
Issue: Y2K-964