### PR TITLE
journeycard persistent storage

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/keybase/client/go/chat/attachments"
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
 	context "golang.org/x/net/context"
@@ -88,7 +90,10 @@ func (s *baseConversationSource) addPendingPreviews(ctx context.Context, thread 
 
 func (s *baseConversationSource) addConversationCards(ctx context.Context, uid gregor1.UID,
 	convID chat1.ConversationID, convOptional *chat1.ConversationLocal, thread *chat1.ThreadView) {
-	card, err := s.G().JourneyCardManager.PickCard(ctx, uid, convID, convOptional, thread)
+	ctxShort, ctxShortCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer ctxShortCancel()
+	card, err := s.G().JourneyCardManager.PickCard(ctxShort, uid, convID, convOptional, thread)
+	ctxShortCancel()
 	if err != nil {
 		s.Debug(ctx, "addConversationCards: error getting next conversation card: %s", err)
 		return
@@ -222,6 +227,7 @@ func (s *baseConversationSource) patchPaginationLast(ctx context.Context, conv t
 
 func (s *baseConversationSource) PullFull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, reason chat1.GetThreadReason,
 	query *chat1.GetThreadQuery, maxPages *int) (res chat1.ThreadView, err error) {
+	ctx = libkb.WithLogTag(ctx, "PUL")
 	pagination := &chat1.Pagination{
 		Num: 300,
 	}
@@ -292,6 +298,7 @@ func (s *RemoteConversationSource) PushUnboxed(ctx context.Context, convID chat1
 
 func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, reason chat1.GetThreadReason, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, error) {
+	ctx = libkb.WithLogTag(ctx, "PUL")
 
 	if convID.IsNil() {
 		return chat1.ThreadView{}, errors.New("RemoteConversationSource.Pull called with empty convID")
@@ -330,6 +337,7 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 
 func (s *RemoteConversationSource) PullLocalOnly(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination, maxPlaceholders int) (chat1.ThreadView, error) {
+	ctx = libkb.WithLogTag(ctx, "PUL")
 	return chat1.ThreadView{}, storage.MissError{Msg: "PullLocalOnly is unimplemented for RemoteConversationSource"}
 }
 
@@ -489,7 +497,7 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 		return decmsg, continuousUpdate, err
 	}
 	if msg.ClientHeader.Sender.Eq(uid) {
-		go s.G().JourneyCardManager.SentMessage(globals.BackgroundChatCtx(ctx, s.G()), convID)
+		go s.G().JourneyCardManager.SentMessage(globals.BackgroundChatCtx(ctx, s.G()), uid, convID)
 	}
 	// Remove any pending previews from storage
 	s.completeAttachmentUpload(ctx, decmsg)
@@ -561,6 +569,7 @@ var maxHolesForPull = 50
 
 func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, reason chat1.GetThreadReason, query *chat1.GetThreadQuery, pagination *chat1.Pagination) (thread chat1.ThreadView, err error) {
+	ctx = libkb.WithLogTag(ctx, "PUL")
 	defer s.Trace(ctx, func() error { return err }, "Pull(%s)", convID)()
 	if convID.IsNil() {
 		return chat1.ThreadView{}, errors.New("HybridConversationSource.Pull called with empty convID")
@@ -697,6 +706,7 @@ func newPullLocalResultCollector(baseRC storage.ResultCollector) *pullLocalResul
 
 func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination, maxPlaceholders int) (tv chat1.ThreadView, err error) {
+	ctx = libkb.WithLogTag(ctx, "PUL")
 	defer s.Trace(ctx, func() error { return err }, "PullLocalOnly")()
 	if _, err = s.lockTab.Acquire(ctx, uid, convID); err != nil {
 		return tv, err

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -337,7 +337,6 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 
 func (s *RemoteConversationSource) PullLocalOnly(ctx context.Context, convID chat1.ConversationID,
 	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination, maxPlaceholders int) (chat1.ThreadView, error) {
-	ctx = libkb.WithLogTag(ctx, "PUL")
 	return chat1.ThreadView{}, storage.MissError{Msg: "PullLocalOnly is unimplemented for RemoteConversationSource"}
 }
 

--- a/go/chat/journey_card_manager.go
+++ b/go/chat/journey_card_manager.go
@@ -128,7 +128,7 @@ func NewJourneyCardManagerSingleUser(g *globals.Context, uid gregor1.UID) *Journ
 		return g.LocalChatDb
 	}
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return storage.GetSecretBoxKey(ctx, g.ExternalG(), storage.DefaultSecretUI)
+		return storage.GetSecretBoxKeyWithUID(ctx, g.ExternalG(), uid)
 	}
 	return &JourneyCardManagerSingleUser{
 		Contextified: globals.NewContextified(g),

--- a/go/chat/journey_card_test.go
+++ b/go/chat/journey_card_test.go
@@ -1,0 +1,49 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJourneycardStorage(t *testing.T) {
+	ctx, world, ri, _, sender, _ := setupTest(t, 1)
+	defer world.Cleanup()
+
+	u := world.GetUsers()[0]
+	uid := u.User.GetUID().ToBytes()
+	tc := world.Tcs[u.Username]
+	conv := newBlankConv(ctx, t, tc, uid, ri, sender, u.Username)
+	mkctx := func() context.Context { return libkb.WithLogTag(context.Background(), "TST") }
+
+	t.Logf("setup complete")
+	tc.ChatG.JourneyCardManager.SentMessage(mkctx(), uid, conv.GetConvID())
+	t.Logf("sent message")
+	js, err := tc.ChatG.JourneyCardManager.(*JourneyCardManager).get(mkctx(), uid)
+	require.NoError(t, err)
+	jcd, err := js.getConvData(mkctx(), conv.GetConvID())
+	require.NoError(t, err)
+	require.True(t, jcd.SentMessage)
+
+	t.Logf("switch users")
+	uid2kb, err := keybase1.UIDFromString("295a7eea607af32040647123732bc819")
+	require.NoError(t, err)
+	uid2 := gregor1.UID(uid2kb.ToBytes())
+	js, err = tc.ChatG.JourneyCardManager.(*JourneyCardManager).get(mkctx(), uid2)
+	require.NoError(t, err)
+	jcd, err = js.getConvData(mkctx(), conv.GetConvID())
+	require.NoError(t, err)
+	require.False(t, jcd.SentMessage)
+
+	t.Logf("switch back")
+	js, err = tc.ChatG.JourneyCardManager.(*JourneyCardManager).get(mkctx(), uid)
+	require.NoError(t, err)
+	jcd, err = js.getConvData(mkctx(), conv.GetConvID())
+	require.NoError(t, err)
+	require.True(t, jcd.SentMessage)
+}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1133,7 +1133,7 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 					gregor1.FromTime(unboxedMsg.Valid().MessageBody.Text().LiveLocation.EndTime))
 			}
 		}
-		go s.G().JourneyCardManager.SentMessage(globals.BackgroundChatCtx(ctx, s.G()), convID)
+		go s.G().JourneyCardManager.SentMessage(globals.BackgroundChatCtx(ctx, s.G()), sender, convID)
 	}
 	return nil, boxed, nil
 }

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -319,7 +319,7 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 	g.StellarLoader = types.DummyStellarLoader{}
 	g.StellarSender = types.DummyStellarSender{}
 	g.TeamMentionLoader = types.DummyTeamMentionLoader{}
-	g.JourneyCardManager = NewJourneyCardChecker(g)
+	g.JourneyCardManager = NewJourneyCardManager(g)
 	g.BotCommandManager = types.DummyBotCommandManager{}
 	g.CommandsSource = commands.NewSource(g)
 	g.CoinFlipManager = NewFlipManager(g, getRI)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -443,7 +443,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	g.TeamMentionLoader = types.DummyTeamMentionLoader{}
 	g.CoinFlipManager = NewFlipManager(g, func() chat1.RemoteInterface { return ri })
 	g.CoinFlipManager.Start(context.TODO(), uid)
-	g.JourneyCardManager = NewJourneyCardChecker(g)
+	g.JourneyCardManager = NewJourneyCardManager(g)
 	g.BotCommandManager = bots.NewCachingBotCommandManager(g, func() chat1.RemoteInterface { return ri })
 	g.BotCommandManager.Start(context.TODO(), uid)
 	g.UIInboxLoader = types.DummyUIInboxLoader{}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -570,8 +570,10 @@ type UIInboxLoader interface {
 }
 
 type JourneyCardManager interface {
+	Resumable
 	PickCard(context.Context, gregor1.UID, chat1.ConversationID, *chat1.ConversationLocal, *chat1.ThreadView) (*chat1.MessageUnboxedJourneycard, error)
-	SentMessage(context.Context, chat1.ConversationID) // Tell JourneyCardManager that the user has sent a message.
+	SentMessage(context.Context, gregor1.UID, chat1.ConversationID) // Tell JourneyCardManager that the user has sent a message.
+	OnDbNuke(libkb.MetaContext) error
 }
 
 type InternalError interface {

--- a/go/encrypteddb/db.go
+++ b/go/encrypteddb/db.go
@@ -2,6 +2,7 @@ package encrypteddb
 
 import (
 	"fmt"
+
 	"github.com/go-errors/errors"
 
 	"github.com/keybase/client/go/libkb"

--- a/go/libkb/db.go
+++ b/go/libkb/db.go
@@ -21,6 +21,7 @@ const (
 	DBTeamChain         = 0x10
 	DBUserPlusAllKeysV1 = 0x19
 
+	DBChatJourney                    = 0xae
 	DBTeamRoleMap                    = 0xaf
 	DBMisc                           = 0xb0
 	DBTeamMerkleCheck                = 0xb1

--- a/go/protocol/gregor1/extras.go
+++ b/go/protocol/gregor1/extras.go
@@ -14,11 +14,10 @@ import (
 	"github.com/keybase/go-codec/codec"
 )
 
-func (u UID) Bytes() []byte  { return []byte(u) }
-func (u UID) String() string { return hex.EncodeToString(u) }
-func (u UID) Eq(other UID) bool {
-	return bytes.Equal(u.Bytes(), other.Bytes())
-}
+func (u UID) Bytes() []byte     { return []byte(u) }
+func (u UID) String() string    { return hex.EncodeToString(u) }
+func (u UID) Eq(other UID) bool { return bytes.Equal(u.Bytes(), other.Bytes()) }
+func (u UID) IsNil() bool       { return len(u) == 0 }
 
 func UIDPtrEq(x, y *UID) bool {
 	if x != nil && y != nil {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -459,6 +459,7 @@ func (d *Service) stopChatModules(m libkb.MetaContext) error {
 	<-d.ChatG().LiveLocationTracker.Stop(m.Ctx())
 	<-d.ChatG().BotCommandManager.Stop(m.Ctx())
 	<-d.ChatG().UIInboxLoader.Stop(m.Ctx())
+	<-d.ChatG().JourneyCardManager.Stop(m.Ctx())
 	return nil
 }
 
@@ -529,7 +530,8 @@ func (d *Service) SetupChatModules(ri func() chat1.RemoteInterface) {
 		ri)
 	g.CommandsSource = commands.NewSource(g)
 	g.CoinFlipManager = chat.NewFlipManager(g, ri)
-	g.JourneyCardManager = chat.NewJourneyCardChecker(g)
+	g.JourneyCardManager = chat.NewJourneyCardManager(g)
+	g.AddDbNukeHook(g.JourneyCardManager, "JourneyCardManager")
 	g.TeamMentionLoader = chat.NewTeamMentionLoader(g)
 	g.ExternalAPIKeySource = chat.NewRemoteExternalAPIKeySource(g, ri)
 	g.LiveLocationTracker = maps.NewLiveLocationTracker(g)


### PR DESCRIPTION
Add persistent storage to journeycard memory.

When reviewing be sure to expand the renamed file `journey_card_manager.go`

Also deal with user switching. By throwing out the `JourneyCardManagerSingleUser` instance on logout and whenever a different uid comes in. The switching layer looks a bit weird, but also seems simpler than merging multi-user checks into the rest of the code. Fundamentally journeycard book-keeping is a single user thing.

I think the same is true for most modules in ChatContext.

cc @mmaxim 