### PR TITLE
add encrypteddb GetSecretBoxKeyWithUID

### DIFF
--- a/go/bind/extension.go
+++ b/go/bind/extension.go
@@ -683,7 +683,7 @@ func savedConvFile() *encrypteddb.EncryptedFile {
 	path := filepath.Join(kbCtx.GetEnv().GetDataDir(), "saveconv.mpack")
 	return encrypteddb.NewFile(kbCtx, path,
 		func(ctx context.Context) ([32]byte, error) {
-			return storage.GetSecretBoxKey(ctx, kbCtx, storage.DefaultSecretUI)
+			return storage.GetSecretBoxKey(ctx, kbCtx)
 		})
 }
 

--- a/go/chat/attachments/pendingpreviews.go
+++ b/go/chat/attachments/pendingpreviews.go
@@ -34,7 +34,7 @@ func (p *PendingPreviews) getPath(outboxID chat1.OutboxID) string {
 
 func (p *PendingPreviews) keyFn() encrypteddb.KeyFn {
 	return func(ctx context.Context) ([32]byte, error) {
-		return storage.GetSecretBoxKey(ctx, p.G().ExternalG(), storage.DefaultSecretUI)
+		return storage.GetSecretBoxKey(ctx, p.G().ExternalG())
 	}
 }
 

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -108,7 +108,7 @@ func (u *uploaderTaskStorage) file(outboxID chat1.OutboxID, getPath func(chat1.O
 	}
 	return encrypteddb.NewFile(u.G().ExternalG(), getPath(outboxID),
 		func(ctx context.Context) ([32]byte, error) {
-			return storage.GetSecretBoxKey(ctx, u.G().ExternalG(), storage.DefaultSecretUI)
+			return storage.GetSecretBoxKey(ctx, u.G().ExternalG())
 		}), nil
 }
 

--- a/go/chat/bots/commands.go
+++ b/go/chat/bots/commands.go
@@ -69,7 +69,7 @@ type CachingBotCommandManager struct {
 
 func NewCachingBotCommandManager(g *globals.Context, ri func() chat1.RemoteInterface) *CachingBotCommandManager {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return storage.GetSecretBoxKey(ctx, g.ExternalG(), storage.DefaultSecretUI)
+		return storage.GetSecretBoxKey(ctx, g.ExternalG())
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalChatDb

--- a/go/chat/boxer_test.go
+++ b/go/chat/boxer_test.go
@@ -708,8 +708,7 @@ func TestChatMessageRevokedKeyThenSent(t *testing.T) {
 		require.NotNil(t, thisDevice, "thisDevice should be non-nil")
 
 		// Find the key
-		f := func() libkb.SecretUI { return u.NewSecretUI() }
-		signingKey, err := engine.GetMySecretKey(context.TODO(), tc.G, f, libkb.DeviceSigningKeyType, "some chat or something test")
+		signingKey, err := engine.GetMySecretKey(context.TODO(), tc.G, libkb.DeviceSigningKeyType, "some chat or something test")
 		require.NoError(t, err, "get device signing key")
 		signKP, ok := signingKey.(libkb.NaclSigningKeyPair)
 		require.Equal(t, true, ok, "signing key must be nacl")
@@ -786,8 +785,7 @@ func TestChatMessageSentThenRevokedSenderKey(t *testing.T) {
 		require.NotNil(t, thisDevice, "thisDevice should be non-nil")
 
 		// Find the key
-		f := func() libkb.SecretUI { return u.NewSecretUI() }
-		signingKey, err := engine.GetMySecretKey(context.TODO(), tc.G, f, libkb.DeviceSigningKeyType, "some chat or something test")
+		signingKey, err := engine.GetMySecretKey(context.TODO(), tc.G, libkb.DeviceSigningKeyType, "some chat or something test")
 		require.NoError(t, err, "get device signing key")
 		signKP, ok := signingKey.(libkb.NaclSigningKeyPair)
 		require.Equal(t, true, ok, "signing key must be nacl")

--- a/go/chat/maps/trackstorage.go
+++ b/go/chat/maps/trackstorage.go
@@ -35,7 +35,7 @@ type trackStorage struct {
 
 func newTrackStorage(g *globals.Context) *trackStorage {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return storage.GetSecretBoxKey(ctx, g.ExternalG(), storage.DefaultSecretUI)
+		return storage.GetSecretBoxKey(ctx, g.ExternalG())
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalChatDb

--- a/go/chat/search/storage.go
+++ b/go/chat/search/storage.go
@@ -83,7 +83,7 @@ func newStore(g *globals.Context) *store {
 	ac, _ := lru.New(10000)
 	tc, _ := lru.New(3000)
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return storage.GetSecretBoxKey(ctx, g.ExternalG(), storage.DefaultSecretUI)
+		return storage.GetSecretBoxKey(ctx, g.ExternalG())
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalChatDb

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -902,7 +902,7 @@ func (s *BlockingSender) applyTeamBotSettings(ctx context.Context, uid gregor1.U
 
 func (s *BlockingSender) getSigningKeyPair(ctx context.Context) (kp libkb.NaclSigningKeyPair, err error) {
 	// get device signing key for this user
-	signingKey, err := engine.GetMySecretKey(ctx, s.G().ExternalG(), storage.DefaultSecretUI,
+	signingKey, err := engine.GetMySecretKey(ctx, s.G().ExternalG(),
 		libkb.DeviceSigningKeyType, "sign chat message")
 	if err != nil {
 		return libkb.NaclSigningKeyPair{}, err

--- a/go/chat/storage/basebox.go
+++ b/go/chat/storage/basebox.go
@@ -26,7 +26,7 @@ var DefaultSecretUI = func() libkb.SecretUI { return SecretUI{} }
 
 func newBaseBox(g *globals.Context) *baseBox {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return GetSecretBoxKey(ctx, g.ExternalG(), DefaultSecretUI)
+		return GetSecretBoxKey(ctx, g.ExternalG())
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalChatDb

--- a/go/chat/storage/basebox.go
+++ b/go/chat/storage/basebox.go
@@ -22,8 +22,6 @@ func (d SecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase
 	return keybase1.GetPassphraseRes{}, fmt.Errorf("no secret UI available")
 }
 
-var DefaultSecretUI = func() libkb.SecretUI { return SecretUI{} }
-
 func newBaseBox(g *globals.Context) *baseBox {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
 		return GetSecretBoxKey(ctx, g.ExternalG())

--- a/go/chat/storage/crypt.go
+++ b/go/chat/storage/crypt.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"github.com/keybase/client/go/encrypteddb"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
 
@@ -14,4 +16,12 @@ const cryptoVersion = 1
 
 func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext) (fkey [32]byte, err error) {
 	return encrypteddb.GetSecretBoxKey(ctx, g, libkb.EncryptionReasonChatLocalStorage, "encrypt chat message")
+}
+
+func GetSecretBoxKeyWithUID(ctx context.Context, g *libkb.GlobalContext, uid gregor1.UID) (fkey [32]byte, err error) {
+	uid2, err := keybase1.UIDFromString(uid.String())
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return encrypteddb.GetSecretBoxKeyWithUID(ctx, g, uid2, libkb.EncryptionReasonChatLocalStorage, "encrypt chat message")
 }

--- a/go/chat/storage/crypt.go
+++ b/go/chat/storage/crypt.go
@@ -12,6 +12,6 @@ import (
 // ***
 const cryptoVersion = 1
 
-func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI) (fkey [32]byte, err error) {
-	return encrypteddb.GetSecretBoxKey(ctx, g, getSecretUI, libkb.EncryptionReasonChatLocalStorage, "encrypt chat message")
+func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext) (fkey [32]byte, err error) {
+	return encrypteddb.GetSecretBoxKey(ctx, g, libkb.EncryptionReasonChatLocalStorage, "encrypt chat message")
 }

--- a/go/chat/storage/inbox.go
+++ b/go/chat/storage/inbox.go
@@ -217,7 +217,7 @@ func (i *Inbox) sharedInboxFile(ctx context.Context, uid gregor1.UID) (*encrypte
 	}
 	return encrypteddb.NewFile(i.G().ExternalG(), filepath.Join(dir, "flatinbox.mpack"),
 		func(ctx context.Context) ([32]byte, error) {
-			return GetSecretBoxKey(ctx, i.G().ExternalG(), DefaultSecretUI)
+			return GetSecretBoxKey(ctx, i.G().ExternalG())
 		}), nil
 }
 

--- a/go/chat/storage/outbox_files.go
+++ b/go/chat/storage/outbox_files.go
@@ -37,7 +37,7 @@ func (s *outboxFilesStorage) getDir() string {
 func (s *outboxFilesStorage) getFile(ctx context.Context, path string) *encrypteddb.EncryptedFile {
 	return encrypteddb.NewFile(s.G().ExternalG(), path,
 		func(ctx context.Context) ([32]byte, error) {
-			return GetSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
+			return GetSecretBoxKey(ctx, s.G().ExternalG())
 		})
 }
 

--- a/go/chat/storage/reacjis.go
+++ b/go/chat/storage/reacjis.go
@@ -108,7 +108,7 @@ type ReacjiStore struct {
 //         },
 func NewReacjiStore(g *globals.Context) *ReacjiStore {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return GetSecretBoxKey(ctx, g.ExternalG(), DefaultSecretUI)
+		return GetSecretBoxKey(ctx, g.ExternalG())
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalChatDb

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -404,7 +404,7 @@ func (s *Storage) MergeHelper(ctx context.Context,
 	s.Debug(ctx, "MergeHelper: convID: %s uid: %s num msgs: %d", convID, uid, len(msgs))
 
 	// Fetch secret key
-	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
+	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG())
 	if ierr != nil {
 		return res, MiscError{Msg: "unable to get secret key: " + ierr.Error()}
 	}
@@ -855,7 +855,7 @@ func (s *Storage) applyExpunge(ctx context.Context, convID chat1.ConversationID,
 func (s *Storage) clearUpthrough(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
 	upthrough chat1.MessageID) (err Error) {
 	defer s.Trace(ctx, func() error { return err }, "clearUpthrough")()
-	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
+	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG())
 	if ierr != nil {
 		return MiscError{Msg: "unable to get secret key: " + ierr.Error()}
 	}
@@ -920,7 +920,7 @@ func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
 		return res, err
 	}
 	// Fetch secret key
-	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
+	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG())
 	if ierr != nil {
 		return res, MiscError{Msg: "unable to get secret key: " + ierr.Error()}
 	}
@@ -1051,7 +1051,7 @@ func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID
 		return res, err
 	}
 	// Fetch secret key
-	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
+	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG())
 	if ierr != nil {
 		return nil, MiscError{Msg: "unable to get secret key: " + ierr.Error()}
 	}
@@ -1082,7 +1082,7 @@ func (s *Storage) FetchUnreadlineID(ctx context.Context, convID chat1.Conversati
 		return nil, err
 	}
 	// Fetch secret key
-	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
+	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG())
 	if ierr != nil {
 		return nil, MiscError{Msg: "unable to get secret key: " + ierr.Error()}
 	}

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -26,7 +26,7 @@ func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationI
 	}
 
 	// Fetch secret key
-	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG(), DefaultSecretUI)
+	key, ierr := GetSecretBoxKey(ctx, s.G().ExternalG())
 	if ierr != nil {
 		return nil, nil, MiscError{Msg: "unable to get secret key: " + ierr.Error()}
 	}

--- a/go/contacts/cache.go
+++ b/go/contacts/cache.go
@@ -31,7 +31,7 @@ func (s *ContactCacheStore) dbKey(uid keybase1.UID) libkb.DbKey {
 // store is used to securely store cached contact resolutions.
 func NewContactCacheStore(g *libkb.GlobalContext) *ContactCacheStore {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return encrypteddb.GetSecretBoxKey(ctx, g, encrypteddb.DefaultSecretUI,
+		return encrypteddb.GetSecretBoxKey(ctx, g,
 			libkb.EncryptionReasonContactsLocalStorage, "encrypting contact resolution cache")
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {

--- a/go/contacts/phonebook.go
+++ b/go/contacts/phonebook.go
@@ -27,7 +27,7 @@ var _ libkb.SyncedContactListProvider = (*SavedContactsStore)(nil)
 // The store is used to securely store list of resolved contacts.
 func NewSavedContactsStore(g *libkb.GlobalContext) *SavedContactsStore {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return encrypteddb.GetSecretBoxKey(ctx, g, encrypteddb.DefaultSecretUI,
+		return encrypteddb.GetSecretBoxKey(ctx, g,
 			libkb.EncryptionReasonContactsLocalStorage, "encrypting local contact list")
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {

--- a/go/encrypteddb/secretkeys.go
+++ b/go/encrypteddb/secretkeys.go
@@ -1,8 +1,6 @@
 package encrypteddb
 
 import (
-	"errors"
-
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -12,8 +10,7 @@ import (
 func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext,
 	reason libkb.EncryptionReason, reasonStr string) (fkey [32]byte, err error) {
 	// Get secret device key
-	// TODO even here, defaultSecretUI may be unused.
-	encKey, err := engine.GetMySecretKey(ctx, g, defaultSecretUI, libkb.DeviceEncryptionKeyType,
+	encKey, err := engine.GetMySecretKey(ctx, g, libkb.DeviceEncryptionKeyType,
 		reasonStr)
 	if err != nil {
 		return fkey, err
@@ -36,8 +33,7 @@ func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext,
 func GetSecretBoxKeyWithUID(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID,
 	reason libkb.EncryptionReason, reasonStr string) (fkey [32]byte, err error) {
 	// Get secret device key
-	// TODO even here, defaultSecretUI may be unused.
-	encKey, err := engine.GetMySecretKeyWithUID(ctx, g, uid, defaultSecretUI,
+	encKey, err := engine.GetMySecretKeyWithUID(ctx, g, uid,
 		libkb.DeviceEncryptionKeyType, reasonStr)
 	if err != nil {
 		return fkey, err
@@ -56,15 +52,3 @@ func GetSecretBoxKeyWithUID(ctx context.Context, g *libkb.GlobalContext, uid key
 	copy(fkey[:], skey[:])
 	return fkey, nil
 }
-
-// NoSecretUI is the default SecretUI for GetSecretBoxKey, because we don't
-// expect to do any interactive key unlocking there. GetSecretBoxKey should
-// only be used where device key is present and unlocked.
-type NoSecretUI struct {
-}
-
-func (d NoSecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keybase1.SecretEntryArg) (keybase1.GetPassphraseRes, error) {
-	return keybase1.GetPassphraseRes{}, errors.New("no secret UI available")
-}
-
-var defaultSecretUI = func() libkb.SecretUI { return NoSecretUI{} }

--- a/go/encrypteddb/secretkeys.go
+++ b/go/encrypteddb/secretkeys.go
@@ -9,10 +9,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI,
+func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext,
 	reason libkb.EncryptionReason, reasonStr string) (fkey [32]byte, err error) {
 	// Get secret device key
-	encKey, err := engine.GetMySecretKey(ctx, g, getSecretUI, libkb.DeviceEncryptionKeyType,
+	encKey, err := engine.GetMySecretKey(ctx, g, defaultSecretUI, libkb.DeviceEncryptionKeyType,
 		reasonStr)
 	if err != nil {
 		return fkey, err
@@ -42,4 +42,4 @@ func (d NoSecretUI) GetPassphrase(pinentry keybase1.GUIEntryArg, terminal *keyba
 	return keybase1.GetPassphraseRes{}, errors.New("no secret UI available")
 }
 
-var DefaultSecretUI = func() libkb.SecretUI { return NoSecretUI{} }
+var defaultSecretUI = func() libkb.SecretUI { return NoSecretUI{} }

--- a/go/encrypteddb/secretkeys.go
+++ b/go/encrypteddb/secretkeys.go
@@ -32,6 +32,11 @@ func GetSecretBoxKey(ctx context.Context, g *libkb.GlobalContext,
 	return fkey, nil
 }
 
+func GetSecretBoxKeyWithUID(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID,
+	reason libkb.EncryptionReason, reasonStr string) (fkey [32]byte, err error) {
+	panic("xxx todo")
+}
+
 // NoSecretUI is the default SecretUI for GetSecretBoxKey, because we don't
 // expect to do any interactive key unlocking there. GetSecretBoxKey should
 // only be used where device key is present and unlocked.

--- a/go/engine/crypto.go
+++ b/go/engine/crypto.go
@@ -24,7 +24,7 @@ var getKeyMu sync.Mutex
 // have your device keys cached, or you aren't.
 //
 // If the key isn't found in the ActiveDevice cache, this will return LoginRequiredError.
-func GetMySecretKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI, secretKeyType libkb.SecretKeyType, reason string) (libkb.GenericKey, error) {
+func GetMySecretKey(ctx context.Context, g *libkb.GlobalContext, secretKeyType libkb.SecretKeyType, reason string) (libkb.GenericKey, error) {
 	key, err := g.ActiveDevice.KeyByType(secretKeyType)
 	if err != nil {
 		if _, ok := err.(libkb.NotFoundError); ok {
@@ -38,7 +38,7 @@ func GetMySecretKey(ctx context.Context, g *libkb.GlobalContext, getSecretUI fun
 }
 
 // GetMySecretKeyWithUID is like GetMySecretKey but returns an error if uid is not active.
-func GetMySecretKeyWithUID(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, getSecretUI func() libkb.SecretUI, secretKeyType libkb.SecretKeyType, reason string) (libkb.GenericKey, error) {
+func GetMySecretKeyWithUID(ctx context.Context, g *libkb.GlobalContext, uid keybase1.UID, secretKeyType libkb.SecretKeyType, reason string) (libkb.GenericKey, error) {
 	key, err := g.ActiveDevice.KeyByTypeWithUID(uid, secretKeyType)
 	if err != nil {
 		if _, ok := err.(libkb.NotFoundError); ok {
@@ -53,8 +53,8 @@ func GetMySecretKeyWithUID(ctx context.Context, g *libkb.GlobalContext, uid keyb
 
 // SignED25519 signs the given message with the current user's private
 // signing key.
-func SignED25519(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI, arg keybase1.SignED25519Arg) (ret keybase1.ED25519SignatureInfo, err error) {
-	signingKey, err := GetMySecretKey(ctx, g, getSecretUI, libkb.DeviceSigningKeyType, arg.Reason)
+func SignED25519(ctx context.Context, g *libkb.GlobalContext, arg keybase1.SignED25519Arg) (ret keybase1.ED25519SignatureInfo, err error) {
+	signingKey, err := GetMySecretKey(ctx, g, libkb.DeviceSigningKeyType, arg.Reason)
 	if err != nil {
 		return
 	}
@@ -76,9 +76,9 @@ func SignED25519(ctx context.Context, g *libkb.GlobalContext, getSecretUI func()
 
 // SignED25519ForKBFS signs the given message with the current user's private
 // signing key on behalf of KBFS.
-func SignED25519ForKBFS(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI, arg keybase1.SignED25519ForKBFSArg) (
+func SignED25519ForKBFS(ctx context.Context, g *libkb.GlobalContext, arg keybase1.SignED25519ForKBFSArg) (
 	ret keybase1.ED25519SignatureInfo, err error) {
-	signingKey, err := GetMySecretKey(ctx, g, getSecretUI, libkb.DeviceSigningKeyType, arg.Reason)
+	signingKey, err := GetMySecretKey(ctx, g, libkb.DeviceSigningKeyType, arg.Reason)
 	if err != nil {
 		return
 	}
@@ -104,8 +104,8 @@ func SignED25519ForKBFS(ctx context.Context, g *libkb.GlobalContext, getSecretUI
 
 // SignToString signs the given message with the current user's private
 // signing key and outputs the serialized NaclSigInfo string.
-func SignToString(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI, arg keybase1.SignToStringArg) (sig string, err error) {
-	signingKey, err := GetMySecretKey(ctx, g, getSecretUI, libkb.DeviceSigningKeyType, arg.Reason)
+func SignToString(ctx context.Context, g *libkb.GlobalContext, arg keybase1.SignToStringArg) (sig string, err error) {
+	signingKey, err := GetMySecretKey(ctx, g, libkb.DeviceSigningKeyType, arg.Reason)
 	if err != nil {
 		return
 	}
@@ -122,8 +122,8 @@ func SignToString(ctx context.Context, g *libkb.GlobalContext, getSecretUI func(
 
 // UnboxBytes32 decrypts the given message with the current user's
 // private encryption key and the given nonce and peer public key.
-func UnboxBytes32(ctx context.Context, g *libkb.GlobalContext, getSecretUI func() libkb.SecretUI, arg keybase1.UnboxBytes32Arg) (bytes32 keybase1.Bytes32, err error) {
-	encryptionKey, err := GetMySecretKey(ctx, g, getSecretUI, libkb.DeviceEncryptionKeyType, arg.Reason)
+func UnboxBytes32(ctx context.Context, g *libkb.GlobalContext, arg keybase1.UnboxBytes32Arg) (bytes32 keybase1.Bytes32, err error) {
+	encryptionKey, err := GetMySecretKey(ctx, g, libkb.DeviceEncryptionKeyType, arg.Reason)
 	if err != nil {
 		return
 	}

--- a/go/engine/crypto_test.go
+++ b/go/engine/crypto_test.go
@@ -27,13 +27,10 @@ func TestCryptoSignED25519(t *testing.T) {
 	tc := SetupEngineTest(t, "crypto")
 	defer tc.Cleanup()
 
-	u := CreateAndSignupFakeUser(tc, "fu")
-	f := func() libkb.SecretUI {
-		return &libkb.TestSecretUI{Passphrase: u.Passphrase}
-	}
+	CreateAndSignupFakeUser(tc, "fu")
 
 	msg := []byte("test message")
-	ret, err := SignED25519(context.TODO(), tc.G, f, keybase1.SignED25519Arg{
+	ret, err := SignED25519(context.TODO(), tc.G, keybase1.SignED25519Arg{
 		Msg: msg,
 	})
 	if err != nil {
@@ -52,13 +49,10 @@ func TestCryptoSignToString(t *testing.T) {
 	tc := SetupEngineTest(t, "crypto")
 	defer tc.Cleanup()
 
-	u := CreateAndSignupFakeUser(tc, "fu")
-	f := func() libkb.SecretUI {
-		return &libkb.TestSecretUI{Passphrase: u.Passphrase}
-	}
+	CreateAndSignupFakeUser(tc, "fu")
 
 	msg := []byte("test message")
-	signature, err := SignToString(context.TODO(), tc.G, f, keybase1.SignToStringArg{
+	signature, err := SignToString(context.TODO(), tc.G, keybase1.SignToStringArg{
 		Msg: msg,
 	})
 	if err != nil {
@@ -81,10 +75,7 @@ func TestCryptoSignED25519NoSigningKey(t *testing.T) {
 	tc := SetupEngineTest(t, "crypto")
 	defer tc.Cleanup()
 
-	f := func() libkb.SecretUI {
-		return &libkb.TestSecretUI{}
-	}
-	_, err := SignED25519(context.TODO(), tc.G, f, keybase1.SignED25519Arg{
+	_, err := SignED25519(context.TODO(), tc.G, keybase1.SignED25519Arg{
 		Msg: []byte("test message"),
 	})
 
@@ -97,15 +88,12 @@ func BenchmarkCryptoSignED25519(b *testing.B) {
 	tc := SetupEngineTest(b, "crypto")
 	defer tc.Cleanup()
 
-	u := CreateAndSignupFakeUser(tc, "fu")
-	f := func() libkb.SecretUI {
-		return u.NewSecretUI()
-	}
+	CreateAndSignupFakeUser(tc, "fu")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		msg := []byte("test message")
-		_, err := SignED25519(context.TODO(), tc.G, f, keybase1.SignED25519Arg{
+		_, err := SignED25519(context.TODO(), tc.G, keybase1.SignED25519Arg{
 			Msg: msg,
 		})
 		if err != nil {
@@ -127,7 +115,7 @@ func TestCryptoUnboxBytes32(t *testing.T) {
 
 	key, err := GetMySecretKey(
 		context.TODO(),
-		tc.G, f, libkb.DeviceEncryptionKeyType, "test")
+		tc.G, libkb.DeviceEncryptionKeyType, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +142,7 @@ func TestCryptoUnboxBytes32(t *testing.T) {
 
 	copy(encryptedBytes32[:], encryptedData)
 
-	bytes32, err := UnboxBytes32(context.TODO(), tc.G, f, keybase1.UnboxBytes32Arg{
+	bytes32, err := UnboxBytes32(context.TODO(), tc.G, keybase1.UnboxBytes32Arg{
 		EncryptedBytes32: encryptedBytes32,
 		Nonce:            nonce,
 		PeersPublicKey:   peersPublicKey,
@@ -195,12 +183,9 @@ func TestCryptoUnboxBytes32DecryptionError(t *testing.T) {
 	tc := SetupEngineTest(t, "crypto")
 	defer tc.Cleanup()
 
-	u := CreateAndSignupFakeUser(tc, "fu")
-	f := func() libkb.SecretUI {
-		return &libkb.TestSecretUI{Passphrase: u.Passphrase}
-	}
+	CreateAndSignupFakeUser(tc, "fu")
 
-	_, err := UnboxBytes32(context.TODO(), tc.G, f, keybase1.UnboxBytes32Arg{})
+	_, err := UnboxBytes32(context.TODO(), tc.G, keybase1.UnboxBytes32Arg{})
 	if _, ok := err.(libkb.DecryptionError); !ok {
 		t.Errorf("expected libkb.DecryptionError, got %T", err)
 	}
@@ -212,10 +197,7 @@ func TestCryptoUnboxBytes32NoEncryptionKey(t *testing.T) {
 	tc := SetupEngineTest(t, "crypto")
 	defer tc.Cleanup()
 
-	f := func() libkb.SecretUI {
-		return &libkb.TestSecretUI{}
-	}
-	_, err := UnboxBytes32(context.TODO(), tc.G, f, keybase1.UnboxBytes32Arg{})
+	_, err := UnboxBytes32(context.TODO(), tc.G, keybase1.UnboxBytes32Arg{})
 
 	if _, ok := err.(libkb.LoginRequiredError); !ok {
 		t.Errorf("expected LoginRequiredError, got %v", err)
@@ -271,12 +253,8 @@ func TestCachedSecretKey(t *testing.T) {
 	assertCachedSecretKey(tc, libkb.DeviceSigningKeyType)
 	assertCachedSecretKey(tc, libkb.DeviceEncryptionKeyType)
 
-	f := func() libkb.SecretUI {
-		return u.NewSecretUI()
-	}
-
 	msg := []byte("test message")
-	_, err := SignED25519(context.TODO(), tc.G, f, keybase1.SignED25519Arg{
+	_, err := SignED25519(context.TODO(), tc.G, keybase1.SignED25519Arg{
 		Msg: msg,
 	})
 	if err != nil {
@@ -348,7 +326,7 @@ func TestCryptoUnboxBytes32AnyPaper(t *testing.T) {
 		return u.NewSecretUI()
 	}
 
-	_, err = UnboxBytes32(context.TODO(), tc.G, f, keybase1.UnboxBytes32Arg{
+	_, err = UnboxBytes32(context.TODO(), tc.G, keybase1.UnboxBytes32Arg{
 		EncryptedBytes32: encryptedBytes32,
 		Nonce:            nonce,
 		PeersPublicKey:   peersPublicKey,

--- a/go/engine/revoke_test.go
+++ b/go/engine/revoke_test.go
@@ -381,12 +381,9 @@ func TestSignAfterRevoke(t *testing.T) {
 
 	// Still logged in on tc1, a revoked device.
 
-	f := func() libkb.SecretUI {
-		return u.NewSecretUI()
-	}
 	// Test signing with (revoked) device key on tc1, which works...
 	msg := []byte("test message")
-	ret, err := SignED25519(context.TODO(), tc1.G, f, keybase1.SignED25519Arg{
+	ret, err := SignED25519(context.TODO(), tc1.G, keybase1.SignED25519Arg{
 		Msg: msg,
 	})
 	if err != nil {
@@ -406,7 +403,7 @@ func TestSignAfterRevoke(t *testing.T) {
 	require.NoError(t, err)
 
 	// And now this should fail.
-	ret, err = SignED25519(context.TODO(), tc1.G, f, keybase1.SignED25519Arg{
+	ret, err = SignED25519(context.TODO(), tc1.G, keybase1.SignED25519Arg{
 		Msg: msg,
 	})
 	if err == nil {
@@ -422,7 +419,7 @@ func TestLogoutAndDeprovisionIfRevokedNoop(t *testing.T) {
 	tc := SetupEngineTest(t, "rev")
 	defer tc.Cleanup()
 
-	u := CreateAndSignupFakeUser(tc, "rev")
+	CreateAndSignupFakeUser(tc, "rev")
 
 	err := AssertLoggedIn(tc)
 	require.NoError(t, err)
@@ -434,12 +431,8 @@ func TestLogoutAndDeprovisionIfRevokedNoop(t *testing.T) {
 	err = AssertLoggedIn(tc)
 	require.NoError(t, err)
 
-	f := func() libkb.SecretUI {
-		return u.NewSecretUI()
-	}
-
 	msg := []byte("test message")
-	ret, err := SignED25519(context.TODO(), tc.G, f, keybase1.SignED25519Arg{
+	ret, err := SignED25519(context.TODO(), tc.G, keybase1.SignED25519Arg{
 		Msg: msg,
 	})
 	if err != nil {

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -313,11 +313,55 @@ func (a *ActiveDevice) SigningKey() (GenericKey, error) {
 	return a.signingKey, nil
 }
 
+// SigningKeyWithUID returns the signing key for the active device.
+// Returns an error if uid is not active.
+// Safe for use by concurrent goroutines.
+func (a *ActiveDevice) SigningKeyWithUID(uid keybase1.UID) (GenericKey, error) {
+	a.RLock()
+	defer a.RUnlock()
+	if a.uv.Uid.IsNil() {
+		return nil, NotFoundError{
+			Msg: "Not found: device signing key (no active user)",
+		}
+	}
+	if a.uv.Uid != uid {
+		return nil, fmt.Errorf("device signing key for non-active user: %v != %v", a.uv.Uid, uid)
+	}
+	if a.signingKey == nil {
+		return nil, NotFoundError{
+			Msg: "Not found: device signing key",
+		}
+	}
+	return a.signingKey, nil
+}
+
 // EncryptionKey returns the encryption key for the active device.
 // Safe for use by concurrent goroutines.
 func (a *ActiveDevice) EncryptionKey() (GenericKey, error) {
 	a.RLock()
 	defer a.RUnlock()
+	if a.encryptionKey == nil {
+		return nil, NotFoundError{
+			Msg: "Not found: device encryption key",
+		}
+	}
+	return a.encryptionKey, nil
+}
+
+// EncryptionKeyWithUID returns the encryption key for the active device.
+// Returns an error if uid is not active.
+// Safe for use by concurrent goroutines.
+func (a *ActiveDevice) EncryptionKeyWithUID(uid keybase1.UID) (GenericKey, error) {
+	a.RLock()
+	defer a.RUnlock()
+	if a.uv.Uid.IsNil() {
+		return nil, NotFoundError{
+			Msg: "Not found: device encryption key (no active user)",
+		}
+	}
+	if a.uv.Uid != uid {
+		return nil, fmt.Errorf("device encryption key for non-active user: %v != %v", a.uv.Uid, uid)
+	}
 	if a.encryptionKey == nil {
 		return nil, NotFoundError{
 			Msg: "Not found: device encryption key",
@@ -349,6 +393,19 @@ func (a *ActiveDevice) KeyByType(t SecretKeyType) (GenericKey, error) {
 		return a.SigningKey()
 	case DeviceEncryptionKeyType:
 		return a.EncryptionKey()
+	default:
+		return nil, fmt.Errorf("Invalid type %v", t)
+	}
+}
+
+// KeyByTypeWithUID is like KeyByType but returns an error if uid is not active.
+// Safe for use by concurrent goroutines.
+func (a *ActiveDevice) KeyByTypeWithUID(uid keybase1.UID, t SecretKeyType) (GenericKey, error) {
+	switch t {
+	case DeviceSigningKeyType:
+		return a.SigningKeyWithUID(uid)
+	case DeviceEncryptionKeyType:
+		return a.EncryptionKeyWithUID(uid)
 	default:
 		return nil, fmt.Errorf("Invalid type %v", t)
 	}

--- a/go/offline/rpc_cache.go
+++ b/go/offline/rpc_cache.go
@@ -29,7 +29,7 @@ func newEncryptedDB(g *libkb.GlobalContext) *encrypteddb.EncryptedDB {
 		// function used to use chat/storage.GetSecretBoxKey in the past, and
 		// we didn't want users to lose encrypted data after we switched to
 		// more generic encrypteddb.GetSecretBoxKey.
-		return encrypteddb.GetSecretBoxKey(ctx, g, encrypteddb.DefaultSecretUI,
+		return encrypteddb.GetSecretBoxKey(ctx, g,
 			libkb.EncryptionReasonChatLocalStorage, "offline rpc cache")
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {

--- a/go/service/crypto.go
+++ b/go/service/crypto.go
@@ -71,19 +71,19 @@ func (c *CryptoHandler) secretUIMaker(sessionID int, reason string) func() libkb
 }
 
 func (c *CryptoHandler) SignED25519(ctx context.Context, arg keybase1.SignED25519Arg) (keybase1.ED25519SignatureInfo, error) {
-	return engine.SignED25519(ctx, c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
+	return engine.SignED25519(ctx, c.G(), arg)
 }
 
 func (c *CryptoHandler) SignED25519ForKBFS(ctx context.Context, arg keybase1.SignED25519ForKBFSArg) (keybase1.ED25519SignatureInfo, error) {
-	return engine.SignED25519ForKBFS(ctx, c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
+	return engine.SignED25519ForKBFS(ctx, c.G(), arg)
 }
 
 func (c *CryptoHandler) SignToString(ctx context.Context, arg keybase1.SignToStringArg) (string, error) {
-	return engine.SignToString(ctx, c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
+	return engine.SignToString(ctx, c.G(), arg)
 }
 
 func (c *CryptoHandler) UnboxBytes32(ctx context.Context, arg keybase1.UnboxBytes32Arg) (keybase1.Bytes32, error) {
-	return engine.UnboxBytes32(ctx, c.G(), c.secretUIMaker(arg.SessionID, arg.Reason), arg)
+	return engine.UnboxBytes32(ctx, c.G(), arg)
 }
 
 func (c *CryptoHandler) UnboxBytes32Any(ctx context.Context, arg keybase1.UnboxBytes32AnyArg) (keybase1.UnboxAnyRes, error) {

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -170,7 +170,7 @@ func (h *KBFSHandler) UpgradeTLF(ctx context.Context, arg keybase1.UpgradeTLFArg
 // favorites.
 func (h *KBFSHandler) getKeyFn() func(context.Context) ([32]byte, error) {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return encrypteddb.GetSecretBoxKey(ctx, h.G(), encrypteddb.DefaultSecretUI,
+		return encrypteddb.GetSecretBoxKey(ctx, h.G(), 
 			libkb.EncryptionReasonKBFSFavorites, "encrypting kbfs favorites")
 	}
 	return keyFn

--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -170,7 +170,7 @@ func (h *KBFSHandler) UpgradeTLF(ctx context.Context, arg keybase1.UpgradeTLFArg
 // favorites.
 func (h *KBFSHandler) getKeyFn() func(context.Context) ([32]byte, error) {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return encrypteddb.GetSecretBoxKey(ctx, h.G(), 
+		return encrypteddb.GetSecretBoxKey(ctx, h.G(),
 			libkb.EncryptionReasonKBFSFavorites, "encrypting kbfs favorites")
 	}
 	return keyFn

--- a/go/teambot/bot_keyer.go
+++ b/go/teambot/bot_keyer.go
@@ -26,7 +26,7 @@ var _ libkb.TeambotBotKeyer = (*BotKeyer)(nil)
 
 func NewBotKeyer(mctx libkb.MetaContext) *BotKeyer {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return encrypteddb.GetSecretBoxKey(ctx, mctx.G(), encrypteddb.DefaultSecretUI,
+		return encrypteddb.GetSecretBoxKey(ctx, mctx.G(),
 			libkb.EncryptionReasonTeambotKeyLocalStorage, "encrypting teambot keys cache")
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {

--- a/go/teams/storage/generic.go
+++ b/go/teams/storage/generic.go
@@ -102,8 +102,7 @@ type diskStorageGeneric struct {
 
 func newDiskStorageGeneric(g *libkb.GlobalContext, version int, dbObjTyp libkb.ObjType, reason libkb.EncryptionReason, gdi func() diskItemGeneric) *diskStorageGeneric {
 	keyFn := func(ctx context.Context) ([32]byte, error) {
-		return encrypteddb.GetSecretBoxKey(ctx, g, encrypteddb.DefaultSecretUI,
-			reason, "encrypt teams storage")
+		return encrypteddb.GetSecretBoxKey(ctx, g, reason, "encrypt teams storage")
 	}
 	dbFn := func(g *libkb.GlobalContext) *libkb.JSONLocalDb {
 		return g.LocalDb


### PR DESCRIPTION
For patching this up https://github.com/keybase/client/pull/20754#discussion_r342157134

Also get rid of unused secret UIs.

Not used yet. The plan is to merge this and then add a call `chat/stora
ge.GetSecretBoxKeyWithUID` by journeycard to https://github.com/keybase/client/pull/20754