### PR TITLE
Create React Context in Background before Go

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -130,6 +130,8 @@ public class MainActivity extends ReactFragmentActivity {
   @Override
   @TargetApi(Build.VERSION_CODES.KITKAT)
   protected void onCreate(Bundle savedInstanceState) {
+    ReactInstanceManager instanceManager = this.getReactInstanceManager();
+    instanceManager.createReactContextInBackground();
     setupKBRuntime(this, true);
     super.onCreate(null);
 


### PR DESCRIPTION
This sets up the React Context in a background thread before setting up
our KB runtime. It should allow ReactNative to do some work while we are
doing our Go/Keystore setup work.

On an unsigned release build it's about 120ms faster (on a Pixel 3a).

I also tried moving this after the setupKBRuntime call, and it did not
affect startup time.

@keybase/react-hackers 