### PR TITLE
journal: return error when local conflict view doesn't exist

### DIFF
--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -263,11 +263,11 @@ func (j *JournalManager) getConflictIDForHandle(
 	// handle's TLF ID to reflect that.
 	ci := h.ConflictInfo()
 	if ci == nil {
-		return tlf.ID{}, false
+		return tlf.NullID, false
 	}
 
 	if ci.Type != tlf.HandleExtensionLocalConflict {
-		return tlf.ID{}, false
+		return tlf.NullID, false
 	}
 
 	key := clearedConflictKey{
@@ -276,8 +276,8 @@ func (j *JournalManager) getConflictIDForHandle(
 		num:   ci.Number,
 	}
 	val, ok := j.clearedConflictTlfs[key]
-	if !ok {
-		return tlf.ID{}, false
+	if !ok || val.fakeTlfID == tlf.NullID {
+		return tlf.NullID, false
 	}
 
 	return val.fakeTlfID, true

--- a/go/kbfs/libkbfs/journal_md_ops.go
+++ b/go/kbfs/libkbfs/journal_md_ops.go
@@ -250,6 +250,13 @@ func (j journalMDOps) GetIDForHandle(
 	if ok {
 		id = newID
 		handle.SetTlfID(id)
+	} else {
+		ci := handle.ConflictInfo()
+		if ci != nil && ci.Type == tlf.HandleExtensionLocalConflict {
+			return tlf.NullID, errors.Errorf(
+				"Couldn't find local conflict handle for %s",
+				handle.GetCanonicalPath())
+		}
 	}
 
 	// Create the journal if needed, while we have access to `handle`.

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -1493,6 +1493,12 @@ func TestFavoriteConflicts(t *testing.T) {
 	for _, f := range favs.FavoriteFolders {
 		require.Nil(t, f.ConflictState)
 	}
+
+	t.Log("Try stat'ing the old local view, should get an error")
+	_, err = sfs.SimpleFSStat(ctx, keybase1.SimpleFSStatArg{
+		Path: pathLocalView,
+	})
+	require.Error(t, err)
 }
 
 func TestSyncConfigFavorites(t *testing.T) {


### PR DESCRIPTION
If someone tried to access a local conflict view after it was finished, KBFS would panic because it was using the cleared (i.e. null) TLF ID from the journal manager instead of a real ID.

Instead, make it clear that the view is gone in that case by returning a proper error, and add a test that reproduced the panic before the fix.