### PR TITLE
User blocking RPC

### DIFF
--- a/go/client/cmd_account_lockdown.go
+++ b/go/client/cmd_account_lockdown.go
@@ -149,9 +149,9 @@ func (c *CmdAccountLockdown) Run() error {
 	}
 	tui.Printf("Lockdown mode is: ")
 	if res.Status {
-		_, _ = tui.PrintfUnescaped("%s\n", ColorString(c.G(), "green", enabledGreen()))
+		_, _ = tui.PrintfUnescaped("%s\n", enabledGreen())
 	} else {
-		_, _ = tui.PrintfUnescaped("%s\n", ColorString(c.G(), "yellow", disabledYellow()))
+		_, _ = tui.PrintfUnescaped("%s\n", disabledYellow())
 	}
 
 	if c.History {

--- a/go/client/cmd_blocks.go
+++ b/go/client/cmd_blocks.go
@@ -1,0 +1,118 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"fmt"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"golang.org/x/net/context"
+)
+
+func NewCmdBlocks(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "blocks",
+		Usage:        "Manage user and team blocks",
+		ArgumentHelp: "[arguments...]",
+		Subcommands: []cli.Command{
+			NewCmdBlocksListUser(cl, g),
+		},
+	}
+}
+
+// "keybase blocks list-user" command
+
+type CmdBlocksListUser struct {
+	libkb.Contextified
+}
+
+func NewCmdBlocksListUser(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	cmd := &CmdBlocksListUser{
+		Contextified: libkb.NewContextified(g),
+	}
+	return cli.Command{
+		Name:  "list-user",
+		Usage: "Show blocked users.",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "list-user", c)
+		},
+	}
+}
+
+func (c *CmdBlocksListUser) ParseArgv(ctx *cli.Context) error {
+	return nil
+}
+
+func (c *CmdBlocksListUser) Run() (err error) {
+	cli, err := GetUserClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	blocks, err := cli.GetUserBlocks(context.Background(), keybase1.GetUserBlocksArg{})
+	if err != nil {
+		return err
+	}
+
+	tui := c.G().UI.GetTerminalUI()
+
+	// See if we even have any active blocks first.
+	var hasBlocks bool
+	for _, v := range blocks {
+		if v.ChatBlocked || v.FollowBlocked {
+			hasBlocks = true
+			break
+		}
+	}
+
+	if !hasBlocks {
+		tui.Printf("No one user is currently blocked by you.\n")
+		return nil
+	}
+
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].Username < blocks[j].Username
+	})
+
+	// NOTE: tabwriter does not handle padding correctly when we emit escape
+	// sequences for colours, so we do padding manually.
+
+	colorfulYesNo := func(val bool) string {
+		if val {
+			// Red, angry, "yes-blocked".
+			return ColorString(c.G(), "red", fmt.Sprintf("%-13s", "yes"))
+		}
+		// Green, cheerful, "not blocked".
+		return ColorString(c.G(), "green", fmt.Sprintf("%-13s", "no"))
+	}
+
+	tabw := new(tabwriter.Writer)
+	tabw.Init(tui.OutputWriter(), 5, 0, 3, ' ', 0)
+	fmt.Fprintf(tabw, "Username:\tChat-blocked:    Follower-blocked:\n")
+	for _, v := range blocks {
+		if v.ChatBlocked || v.FollowBlocked {
+			fmt.Fprintf(tabw, "%s\t%s    %s\n",
+				v.Username,
+				colorfulYesNo(v.ChatBlocked),
+				colorfulYesNo(v.FollowBlocked),
+			)
+		}
+	}
+	tabw.Flush()
+	return nil
+}
+
+func (c *CmdBlocksListUser) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/cmd_blocks.go
+++ b/go/client/cmd_blocks.go
@@ -73,7 +73,7 @@ func (c *CmdBlocksListUsers) Run() (err error) {
 	}
 
 	if !hasBlocks {
-		tui.Printf("No user is currently blocked by you.\n")
+		tui.Printf("You haven't blocked anyone yet.\n")
 		return nil
 	}
 

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -17,6 +17,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdAccount(cl, g),
 		NewCmdAPICall(cl, g),
 		NewCmdBase62(cl, g),
+		NewCmdBlocks(cl, g),
 		NewCmdBot(cl, g),
 		NewCmdBTC(cl, g),
 		NewCmdCA(cl, g),

--- a/go/libkb/uid.go
+++ b/go/libkb/uid.go
@@ -64,6 +64,14 @@ func GetUIDByUsername(g *GlobalContext, username string) keybase1.UID {
 	return GetUIDByNormalizedUsername(g, NewNormalizedUsername(username))
 }
 
+func AssertUsernameMatchesUID(g *GlobalContext, uid keybase1.UID, username string) error {
+	u2 := GetUIDByUsername(g, username)
+	if uid.NotEqual(u2) {
+		return UIDMismatchError{fmt.Sprintf("%s != %s (via %s)", uid, u2, username)}
+	}
+	return nil
+}
+
 // NOTE: Use the high level API above instead of any of the following. The
 // hilvl API handles both UIDS for old, potentially incorrectly hashed
 // usernames, as well as new, correct UIDs.
@@ -77,6 +85,8 @@ func UsernameToUID(s string) keybase1.UID {
 }
 
 func CheckUIDAgainstUsername(uid keybase1.UID, username string) (err error) {
+	// Note: does not handle pre-Feb-2015 UIDs. You might want to use
+	// `AssertUsernameMatchesUID` instead.
 	u2 := UsernameToUID(username)
 	if uid.NotEqual(u2) {
 		err = UIDMismatchError{fmt.Sprintf("%s != %s (via %s)", uid, u2, username)}

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -691,13 +691,16 @@ func (h *UserHandler) GetUserBlocks(ctx context.Context, arg keybase1.GetUserBlo
 
 	var apiRes getBlockResult
 
-	err = mctx.G().API.PostDecode(mctx, apiArg, &apiRes)
+	err = mctx.G().API.GetDecode(mctx, apiArg, &apiRes)
 	if err != nil {
 		return nil, err
 	}
 
 	res = make([]keybase1.UserBlock, len(apiRes.Blocks))
 	for i, v := range apiRes.Blocks {
+		if err := libkb.AssertUsernameMatchesUID(h.G(), v.BlockUID, v.BlockUsername); err != nil {
+			return nil, err
+		}
 		res[i] = keybase1.UserBlock{
 			Username:      v.BlockUsername,
 			ChatBlocked:   v.Chat,

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -629,7 +629,7 @@ func (h *UserHandler) SetUserBlocks(ctx context.Context, arg keybase1.SetUserBlo
 
 	payloadBlocks := make([]setBlockArg, len(arg.Blocks))
 	for i, v := range arg.Blocks {
-		uid := libkb.UsernameToUIDPreserveCase(libkb.NewNormalizedUsername(v.Username).String())
+		uid := libkb.GetUIDByUsername(h.G(), v.Username)
 		payloadBlocks[i] = setBlockArg{
 			BlockUID: uid.String(),
 			Chat:     v.SetChatBlock,
@@ -666,7 +666,7 @@ func (h *UserHandler) GetUserBlocks(ctx context.Context, arg keybase1.GetUserBlo
 
 	uids := make([]keybase1.UID, len(arg.Usernames))
 	for i, v := range arg.Usernames {
-		uids[i] = libkb.UsernameToUIDPreserveCase(libkb.NewNormalizedUsername(v).String())
+		uids[i] = libkb.GetUIDByUsername(h.G(), v)
 	}
 
 	apiArg := libkb.APIArg{

--- a/go/service/user_block_test.go
+++ b/go/service/user_block_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/require"
+)
+
+type userBlockingTest struct {
+	userHandler *UserHandler
+	tc          libkb.TestContext
+	user        *kbtest.FakeUser
+}
+
+func setupUserBlockingTest(t *testing.T) *userBlockingTest {
+	ret := &userBlockingTest{}
+	ret.tc = libkb.SetupTest(t, "blocking", 0)
+	ret.userHandler = NewUserHandler(nil, ret.tc.G, nil, nil)
+
+	user, err := kbtest.CreateAndSignupFakeUser("ublk", ret.tc.G)
+	require.NoError(t, err)
+	ret.user = user
+	return ret
+}
+
+func TestUserBlocking(t *testing.T) {
+	tc1 := setupUserBlockingTest(t)
+	defer tc1.tc.Cleanup()
+	tc2 := setupUserBlockingTest(t)
+	defer tc2.tc.Cleanup()
+
+	for _, tc := range []*userBlockingTest{tc1, tc2} {
+		blocks, err := tc.userHandler.GetUserBlocks(context.Background(), keybase1.GetUserBlocksArg{})
+		require.NoError(t, err)
+		require.Len(t, blocks, 0)
+	}
+
+	yes := true
+	err := tc1.userHandler.SetUserBlocks(context.Background(), keybase1.SetUserBlocksArg{
+		Blocks: []keybase1.UserBlockArg{{
+			Username:     tc2.user.Username,
+			SetChatBlock: &yes,
+		}},
+	})
+	require.NoError(t, err)
+
+	blocks, err := tc1.userHandler.GetUserBlocks(context.Background(), keybase1.GetUserBlocksArg{})
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, tc2.user.Username, blocks[0].Username)
+	require.Equal(t, true, blocks[0].ChatBlocked)
+	require.Equal(t, false, blocks[0].FollowBlocked)
+	require.NotNil(t, blocks[0].CreateTime)
+	require.Nil(t, blocks[0].ModifyTime)
+
+	err = tc1.userHandler.SetUserBlocks(context.Background(), keybase1.SetUserBlocksArg{
+		Blocks: []keybase1.UserBlockArg{{
+			Username:       tc2.user.Username,
+			SetFollowBlock: &yes,
+		}},
+	})
+	require.NoError(t, err)
+
+	blocks, err = tc1.userHandler.GetUserBlocks(context.Background(), keybase1.GetUserBlocksArg{})
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, tc2.user.Username, blocks[0].Username)
+	require.Equal(t, true, blocks[0].ChatBlocked)
+	require.Equal(t, true, blocks[0].FollowBlocked)
+	require.NotNil(t, blocks[0].CreateTime)
+	require.NotNil(t, blocks[0].ModifyTime)
+
+	no := false
+	err = tc1.userHandler.SetUserBlocks(context.Background(), keybase1.SetUserBlocksArg{
+		// Two block operations for same username is legal, but wasteful.
+		Blocks: []keybase1.UserBlockArg{{
+			Username:     tc2.user.Username,
+			SetChatBlock: &no,
+		}, {
+			Username:       tc2.user.Username,
+			SetFollowBlock: &no,
+		}},
+	})
+	require.NoError(t, err)
+
+	blocks, err = tc1.userHandler.GetUserBlocks(context.Background(), keybase1.GetUserBlocksArg{})
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, tc2.user.Username, blocks[0].Username)
+	require.Equal(t, false, blocks[0].ChatBlocked)
+	require.Equal(t, false, blocks[0].FollowBlocked)
+	require.NotNil(t, blocks[0].CreateTime)
+	require.NotNil(t, blocks[0].ModifyTime)
+}

--- a/go/service/user_block_test.go
+++ b/go/service/user_block_test.go
@@ -96,4 +96,19 @@ func TestUserBlocking(t *testing.T) {
 	require.Equal(t, false, blocks[0].FollowBlocked)
 	require.NotNil(t, blocks[0].CreateTime)
 	require.NotNil(t, blocks[0].ModifyTime)
+
+	// Try to get blocks with username filter.
+	blocks2, err := tc1.userHandler.GetUserBlocks(context.Background(), keybase1.GetUserBlocksArg{
+		Usernames: []string{tc2.user.Username},
+	})
+	require.NoError(t, err)
+	// Expect to see same things as in unfiltered call.
+	require.Equal(t, blocks, blocks2)
+
+	// Try to get blocks with username filter for different username than tc2.
+	blocks2, err = tc1.userHandler.GetUserBlocks(context.Background(), keybase1.GetUserBlocksArg{
+		Usernames: []string{tc1.user.Username},
+	})
+	require.NoError(t, err)
+	require.Len(t, blocks2, 0)
 }

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -213,6 +213,8 @@ protocol user {
     string username;
     boolean chatBlocked;
     boolean followBlocked;
+    union { null, Time } createTime;
+    union { null, Time } modifyTime;
   }
 
   record RecordInfoArg {
@@ -229,4 +231,8 @@ protocol user {
 
   void setUserBlocks(int sessionID, array<UserBlockArg> blocks);
   array<UserBlock> getUserBlocks(int sessionID, array<string> usernames);
+
+  // Legacy user blocking:
+  void blockUser(string username);
+  void unblockUser(string username);
 }

--- a/protocol/avdl/keybase1/user.avdl
+++ b/protocol/avdl/keybase1/user.avdl
@@ -200,13 +200,33 @@ protocol user {
 
   union { null, UserCard } userCard(int sessionID, string username, boolean useSession);
 
-  void blockUser(string username);
-  void unblockUser(string username);
-
   // user.passphrase_state gregor message body
   @lint("ignore")
   record UserPassphraseStateMsg {
     @jsonkey("state")
     PassphraseState passphraseState;
   }
+
+  // User Blocking
+
+  record UserBlock {
+    string username;
+    boolean chatBlocked;
+    boolean followBlocked;
+  }
+
+  record RecordInfoArg {
+    string reportText;
+    boolean attachMessages;
+  }
+
+  record UserBlockArg {
+    string username;
+    union { null, boolean } setChatBlock;
+    union { null, boolean } setFollowBlock;
+    union { null, RecordInfoArg } report;
+  }
+
+  void setUserBlocks(int sessionID, array<UserBlockArg> blocks);
+  array<UserBlock> getUserBlocks(int sessionID, array<string> usernames);
 }

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -362,6 +362,69 @@
         }
       ],
       "lint": "ignore"
+    },
+    {
+      "type": "record",
+      "name": "UserBlock",
+      "fields": [
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": "boolean",
+          "name": "chatBlocked"
+        },
+        {
+          "type": "boolean",
+          "name": "followBlocked"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "RecordInfoArg",
+      "fields": [
+        {
+          "type": "string",
+          "name": "reportText"
+        },
+        {
+          "type": "boolean",
+          "name": "attachMessages"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UserBlockArg",
+      "fields": [
+        {
+          "type": "string",
+          "name": "username"
+        },
+        {
+          "type": [
+            null,
+            "boolean"
+          ],
+          "name": "setChatBlock"
+        },
+        {
+          "type": [
+            null,
+            "boolean"
+          ],
+          "name": "setFollowBlock"
+        },
+        {
+          "type": [
+            null,
+            "RecordInfoArg"
+          ],
+          "name": "report"
+        }
+      ]
     }
   ],
   "messages": {
@@ -738,23 +801,40 @@
         "UserCard"
       ]
     },
-    "blockUser": {
+    "setUserBlocks": {
       "request": [
         {
-          "name": "username",
-          "type": "string"
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "blocks",
+          "type": {
+            "type": "array",
+            "items": "UserBlockArg"
+          }
         }
       ],
       "response": null
     },
-    "unblockUser": {
+    "getUserBlocks": {
       "request": [
         {
-          "name": "username",
-          "type": "string"
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "usernames",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         }
       ],
-      "response": null
+      "response": {
+        "type": "array",
+        "items": "UserBlock"
+      }
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/user.json
+++ b/protocol/json/keybase1/user.json
@@ -378,6 +378,20 @@
         {
           "type": "boolean",
           "name": "followBlocked"
+        },
+        {
+          "type": [
+            null,
+            "Time"
+          ],
+          "name": "createTime"
+        },
+        {
+          "type": [
+            null,
+            "Time"
+          ],
+          "name": "modifyTime"
         }
       ]
     },
@@ -835,6 +849,24 @@
         "type": "array",
         "items": "UserBlock"
       }
+    },
+    "blockUser": {
+      "request": [
+        {
+          "name": "username",
+          "type": "string"
+        }
+      ],
+      "response": null
+    },
+    "unblockUser": {
+      "request": [
+        {
+          "name": "username",
+          "type": "string"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1343,10 +1343,6 @@ export type MessageTypes = {
     inParam: {readonly text: Text; readonly promptDefault: PromptDefault}
     outParam: Boolean
   }
-  'keybase.1.user.blockUser': {
-    inParam: {readonly username: String}
-    outParam: void
-  }
   'keybase.1.user.canLogout': {
     inParam: void
     outParam: CanLogoutRes
@@ -1374,10 +1370,6 @@ export type MessageTypes = {
   'keybase.1.user.proofSuggestions': {
     inParam: void
     outParam: ProofSuggestionsRes
-  }
-  'keybase.1.user.unblockUser': {
-    inParam: {readonly username: String}
-    outParam: void
   }
   'keybase.1.user.uploadUserAvatar': {
     inParam: {readonly filename: String; readonly crop?: ImageCropRect | null}
@@ -2782,6 +2774,7 @@ export type Reachability = {readonly reachable: Reachable}
 export type ReacjiSkinTone = Int
 export type ReadArgs = {readonly opID: OpID; readonly path: Path; readonly offset: Long; readonly size: Int}
 export type ReaderKeyMask = {readonly application: TeamApplication; readonly generation: PerTeamKeyGeneration; readonly mask: MaskB64}
+export type RecordInfoArg = {readonly reportText: String; readonly attachMessages: Boolean}
 export type ReferenceCountRes = {readonly counts?: Array<BlockIdCount> | null}
 export type RegisterAddressRes = {readonly type: String; readonly family: String}
 export type RekeyEvent = {readonly eventType: RekeyEventType; readonly interruptType: Int}
@@ -2958,6 +2951,8 @@ export type UpdateInfo = {readonly status: UpdateInfoStatus; readonly message: S
 export type UpdateInfo2 = {status: UpdateInfoStatus2.ok} | {status: UpdateInfoStatus2.suggested; suggested: UpdateDetails} | {status: UpdateInfoStatus2.critical; critical: UpdateDetails}
 export type UpdaterStatus = {readonly log: String}
 export type User = {readonly uid: UID; readonly username: String}
+export type UserBlock = {readonly username: String; readonly chatBlocked: Boolean; readonly followBlocked: Boolean}
+export type UserBlockArg = {readonly username: String; readonly setChatBlock?: Boolean | null; readonly setFollowBlock?: Boolean | null; readonly report?: RecordInfoArg | null}
 export type UserCard = {readonly following: Int; readonly followers: Int; readonly uid: UID; readonly fullName: String; readonly location: String; readonly bio: String; readonly bioDecorated: String; readonly website: String; readonly twitter: String; readonly youFollowThem: Boolean; readonly theyFollowYou: Boolean; readonly teamShowcase?: Array<UserTeamShowcase> | null; readonly registeredForAirdrop: Boolean; readonly blocked: Boolean}
 export type UserEk = {readonly seed: Bytes32; readonly metadata: UserEkMetadata}
 export type UserEkBoxMetadata = {readonly box: String; readonly recipientGeneration: EkGeneration; readonly recipientDeviceID: DeviceID}
@@ -3447,7 +3442,6 @@ export const trackCheckTrackingRpcPromise = (params: MessageTypes['keybase.1.tra
 export const trackDismissWithTokenRpcPromise = (params: MessageTypes['keybase.1.track.dismissWithToken']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.track.dismissWithToken']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.track.dismissWithToken', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const trackTrackWithTokenRpcPromise = (params: MessageTypes['keybase.1.track.trackWithToken']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.track.trackWithToken']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.track.trackWithToken', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const trackUntrackRpcPromise = (params: MessageTypes['keybase.1.track.untrack']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.track.untrack']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.track.untrack', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
-export const userBlockUserRpcPromise = (params: MessageTypes['keybase.1.user.blockUser']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.blockUser']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.blockUser', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userCanLogoutRpcPromise = (params: MessageTypes['keybase.1.user.canLogout']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.canLogout']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.canLogout', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userInterestingPeopleRpcPromise = (params: MessageTypes['keybase.1.user.interestingPeople']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.interestingPeople']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.interestingPeople', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userListTrackers2RpcPromise = (params: MessageTypes['keybase.1.user.listTrackers2']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.listTrackers2']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.listTrackers2', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -3457,7 +3451,6 @@ export const userProfileEditRpcPromise = (params: MessageTypes['keybase.1.user.p
 export const userProofSuggestionsRpcPromise = (params: MessageTypes['keybase.1.user.proofSuggestions']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.proofSuggestions']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.proofSuggestions', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userSearchGetNonUserDetailsRpcPromise = (params: MessageTypes['keybase.1.userSearch.getNonUserDetails']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.userSearch.getNonUserDetails']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.userSearch.getNonUserDetails', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userSearchUserSearchRpcPromise = (params: MessageTypes['keybase.1.userSearch.userSearch']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.userSearch.userSearch']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.userSearch.userSearch', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
-export const userUnblockUserRpcPromise = (params: MessageTypes['keybase.1.user.unblockUser']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.unblockUser']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.unblockUser', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.user.uploadUserAvatar']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.uploadUserAvatar']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.uploadUserAvatar', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.userCard']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.userCard']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.userCard', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 // Not enabled calls. To enable add to enabled-calls.json:
@@ -3856,3 +3849,5 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.user.getUPAKLite'
 // 'keybase.1.user.findNextMerkleRootAfterRevoke'
 // 'keybase.1.user.findNextMerkleRootAfterReset'
+// 'keybase.1.user.setUserBlocks'
+// 'keybase.1.user.getUserBlocks'

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1343,6 +1343,10 @@ export type MessageTypes = {
     inParam: {readonly text: Text; readonly promptDefault: PromptDefault}
     outParam: Boolean
   }
+  'keybase.1.user.blockUser': {
+    inParam: {readonly username: String}
+    outParam: void
+  }
   'keybase.1.user.canLogout': {
     inParam: void
     outParam: CanLogoutRes
@@ -1370,6 +1374,10 @@ export type MessageTypes = {
   'keybase.1.user.proofSuggestions': {
     inParam: void
     outParam: ProofSuggestionsRes
+  }
+  'keybase.1.user.unblockUser': {
+    inParam: {readonly username: String}
+    outParam: void
   }
   'keybase.1.user.uploadUserAvatar': {
     inParam: {readonly filename: String; readonly crop?: ImageCropRect | null}
@@ -2951,7 +2959,7 @@ export type UpdateInfo = {readonly status: UpdateInfoStatus; readonly message: S
 export type UpdateInfo2 = {status: UpdateInfoStatus2.ok} | {status: UpdateInfoStatus2.suggested; suggested: UpdateDetails} | {status: UpdateInfoStatus2.critical; critical: UpdateDetails}
 export type UpdaterStatus = {readonly log: String}
 export type User = {readonly uid: UID; readonly username: String}
-export type UserBlock = {readonly username: String; readonly chatBlocked: Boolean; readonly followBlocked: Boolean}
+export type UserBlock = {readonly username: String; readonly chatBlocked: Boolean; readonly followBlocked: Boolean; readonly createTime?: Time | null; readonly modifyTime?: Time | null}
 export type UserBlockArg = {readonly username: String; readonly setChatBlock?: Boolean | null; readonly setFollowBlock?: Boolean | null; readonly report?: RecordInfoArg | null}
 export type UserCard = {readonly following: Int; readonly followers: Int; readonly uid: UID; readonly fullName: String; readonly location: String; readonly bio: String; readonly bioDecorated: String; readonly website: String; readonly twitter: String; readonly youFollowThem: Boolean; readonly theyFollowYou: Boolean; readonly teamShowcase?: Array<UserTeamShowcase> | null; readonly registeredForAirdrop: Boolean; readonly blocked: Boolean}
 export type UserEk = {readonly seed: Bytes32; readonly metadata: UserEkMetadata}
@@ -3442,6 +3450,7 @@ export const trackCheckTrackingRpcPromise = (params: MessageTypes['keybase.1.tra
 export const trackDismissWithTokenRpcPromise = (params: MessageTypes['keybase.1.track.dismissWithToken']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.track.dismissWithToken']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.track.dismissWithToken', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const trackTrackWithTokenRpcPromise = (params: MessageTypes['keybase.1.track.trackWithToken']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.track.trackWithToken']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.track.trackWithToken', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const trackUntrackRpcPromise = (params: MessageTypes['keybase.1.track.untrack']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.track.untrack']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.track.untrack', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const userBlockUserRpcPromise = (params: MessageTypes['keybase.1.user.blockUser']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.blockUser']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.blockUser', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userCanLogoutRpcPromise = (params: MessageTypes['keybase.1.user.canLogout']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.canLogout']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.canLogout', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userInterestingPeopleRpcPromise = (params: MessageTypes['keybase.1.user.interestingPeople']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.interestingPeople']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.interestingPeople', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userListTrackers2RpcPromise = (params: MessageTypes['keybase.1.user.listTrackers2']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.listTrackers2']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.listTrackers2', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -3451,6 +3460,7 @@ export const userProfileEditRpcPromise = (params: MessageTypes['keybase.1.user.p
 export const userProofSuggestionsRpcPromise = (params: MessageTypes['keybase.1.user.proofSuggestions']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.proofSuggestions']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.proofSuggestions', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userSearchGetNonUserDetailsRpcPromise = (params: MessageTypes['keybase.1.userSearch.getNonUserDetails']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.userSearch.getNonUserDetails']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.userSearch.getNonUserDetails', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userSearchUserSearchRpcPromise = (params: MessageTypes['keybase.1.userSearch.userSearch']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.userSearch.userSearch']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.userSearch.userSearch', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const userUnblockUserRpcPromise = (params: MessageTypes['keybase.1.user.unblockUser']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.unblockUser']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.unblockUser', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userUploadUserAvatarRpcPromise = (params: MessageTypes['keybase.1.user.uploadUserAvatar']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.uploadUserAvatar']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.uploadUserAvatar', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.userCard']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.user.userCard']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.user.userCard', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 // Not enabled calls. To enable add to enabled-calls.json:


### PR DESCRIPTION
RPCs for user blocking: `getUserBlocks` `setUserBlocks`. Left `blockUser` and `unblockUser` as is for now so frontend does not haveto adapt new RPCs immediately (although there is nothing preventing it).

cc @keybase/y2ksquad 