### PR TITLE
cli: simple mechanism to export a NIST into a URL

### DIFF
--- a/go/client/cmd_web_token.go
+++ b/go/client/cmd_web_token.go
@@ -1,0 +1,55 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"errors"
+	"golang.org/x/net/context"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+type cmdWebAuthToken struct {
+	libkb.Contextified
+}
+
+func newCmdWebAuthToken(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:        "web-auth-token",
+		Description: "Generate a Web auth token for the current user",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&cmdWebAuthToken{Contextified: libkb.NewContextified(g)}, "web-auth-token", c)
+		},
+	}
+}
+
+func (c *cmdWebAuthToken) Run() error {
+	configClient, err := GetConfigClient(c.G())
+	if err != nil {
+		return err
+	}
+	tok, err := configClient.GenerateWebAuthToken(context.Background())
+	if err != nil {
+		return err
+	}
+	dui := c.G().UI.GetDumbOutputUI()
+	_, _ = dui.Printf("%s\n", tok)
+	return nil
+}
+
+func (c *cmdWebAuthToken) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 0 {
+		return errors.New("no arguments allowed")
+	}
+	return nil
+}
+
+func (c *cmdWebAuthToken) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config: true,
+		API:    true,
+	}
+}

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -70,6 +70,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdVerify(cl, g),
 		NewCmdVersion(cl, g),
 		newCmdWallet(cl, g),
+		newCmdWebAuthToken(cl, g),
 		newCmdUploadAvatar(cl, g, true /* hidden */),
 		NewCmdAudit(cl, g),
 	}

--- a/go/kbcrypto/signature_prefix.go
+++ b/go/kbcrypto/signature_prefix.go
@@ -8,12 +8,13 @@ import "bytes"
 type SignaturePrefix string
 
 const (
-	SignaturePrefixKBFS           SignaturePrefix = "Keybase-KBFS-1"
-	SignaturePrefixSigchain       SignaturePrefix = "Keybase-Sigchain-1"
-	SignaturePrefixSigchain3      SignaturePrefix = "Keybase-Sigchain-3"
-	SignaturePrefixChatAttachment SignaturePrefix = "Keybase-Chat-Attachment-1"
-	SignaturePrefixNIST           SignaturePrefix = "Keybase-Auth-NIST-1"
-	SignaturePrefixTeamStore      SignaturePrefix = "Keybase-TeamStore-1"
+	SignaturePrefixKBFS             SignaturePrefix = "Keybase-KBFS-1"
+	SignaturePrefixSigchain         SignaturePrefix = "Keybase-Sigchain-1"
+	SignaturePrefixSigchain3        SignaturePrefix = "Keybase-Sigchain-3"
+	SignaturePrefixChatAttachment   SignaturePrefix = "Keybase-Chat-Attachment-1"
+	SignaturePrefixNIST             SignaturePrefix = "Keybase-Auth-NIST-1"
+	SignaturePrefixTeamStore        SignaturePrefix = "Keybase-TeamStore-1"
+	SignaturePrefixNISTWebAuthToken SignaturePrefix = "Keybase-Auth-NIST-Web-Token-1"
 	// Chat prefixes for each MessageBoxedVersion.
 	SignaturePrefixChatMBv1 SignaturePrefix = "Keybase-Chat-1"
 	SignaturePrefixChatMBv2 SignaturePrefix = "Keybase-Chat-2"

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -479,10 +479,10 @@ func (a *ActiveDevice) NIST(ctx context.Context) (*NIST, error) {
 	return a.nistLocked(ctx)
 }
 
-func (a *ActiveDevice) NISTWebToken(ctx context.Context) (*NIST, error) {
+func (a *ActiveDevice) NISTWebAuthToken(ctx context.Context) (*NIST, error) {
 	a.RLock()
 	defer a.RUnlock()
-	return a.nistFactory.NIST(ctx)
+	return a.nistFactory.GenerateWebAuthToken(ctx)
 }
 
 func (a *ActiveDevice) nistLocked(ctx context.Context) (*NIST, error) {

--- a/go/libkb/active_device.go
+++ b/go/libkb/active_device.go
@@ -479,6 +479,12 @@ func (a *ActiveDevice) NIST(ctx context.Context) (*NIST, error) {
 	return a.nistLocked(ctx)
 }
 
+func (a *ActiveDevice) NISTWebToken(ctx context.Context) (*NIST, error) {
+	a.RLock()
+	defer a.RUnlock()
+	return a.nistFactory.NIST(ctx)
+}
+
 func (a *ActiveDevice) nistLocked(ctx context.Context) (*NIST, error) {
 	nist, err := a.nistFactory.NIST(ctx)
 	if err != nil {

--- a/go/libkb/nist.go
+++ b/go/libkb/nist.go
@@ -88,7 +88,7 @@ type NISTToken struct {
 	nistType nistType
 }
 
-func (n NISTToken) Bytes() []byte  { return []byte(n.b) }
+func (n NISTToken) Bytes() []byte  { return n.b }
 func (n NISTToken) String() string { return n.nistType.encoding().EncodeToString(n.Bytes()) }
 func (n NISTToken) Hash() []byte {
 	tmp := sha256.Sum256(n.Bytes())

--- a/go/protocol/keybase1/config.go
+++ b/go/protocol/keybase1/config.go
@@ -964,6 +964,9 @@ type AppendGUILogsArg struct {
 	Content string `codec:"content" json:"content"`
 }
 
+type GenerateWebAuthTokenArg struct {
+}
+
 type ConfigInterface interface {
 	GetCurrentStatus(context.Context, int) (CurrentStatus, error)
 	GetClientStatus(context.Context, int) ([]ClientStatus, error)
@@ -1000,6 +1003,7 @@ type ConfigInterface interface {
 	GetProxyData(context.Context) (ProxyData, error)
 	ToggleRuntimeStats(context.Context) error
 	AppendGUILogs(context.Context, string) error
+	GenerateWebAuthToken(context.Context) (string, error)
 }
 
 func ConfigProtocol(i ConfigInterface) rpc.Protocol {
@@ -1401,6 +1405,16 @@ func ConfigProtocol(i ConfigInterface) rpc.Protocol {
 					return
 				},
 			},
+			"generateWebAuthToken": {
+				MakeArg: func() interface{} {
+					var ret [1]GenerateWebAuthTokenArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.GenerateWebAuthToken(ctx)
+					return
+				},
+			},
 		},
 	}
 }
@@ -1568,5 +1582,10 @@ func (c ConfigClient) ToggleRuntimeStats(ctx context.Context) (err error) {
 func (c ConfigClient) AppendGUILogs(ctx context.Context, content string) (err error) {
 	__arg := AppendGUILogsArg{Content: content}
 	err = c.Cli.Call(ctx, "keybase.1.config.appendGUILogs", []interface{}{__arg}, nil, 0*time.Millisecond)
+	return
+}
+
+func (c ConfigClient) GenerateWebAuthToken(ctx context.Context) (res string, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.config.generateWebAuthToken", []interface{}{GenerateWebAuthTokenArg{}}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -516,3 +516,15 @@ func (h ConfigHandler) AppendGUILogs(ctx context.Context, content string) error 
 	_, err := io.WriteString(wr, content)
 	return err
 }
+
+func (h ConfigHandler) GenerateWebAuthToken(ctx context.Context) (ret string, err error) {
+	nist, err := h.G().ActiveDevice.NISTWebToken(ctx)
+	if err != nil {
+		return ret, err
+	}
+	if nist == nil {
+		return ret, fmt.Errorf("cannot generate a token when you are logged off")
+	}
+	uri := libkb.SiteURILookup[h.G().Env.GetRunMode()] + libkb.APIURIPathPrefix + "/user/token.json?tok=" + nist.Token().StringURL()
+	return uri, nil
+}

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -525,6 +525,6 @@ func (h ConfigHandler) GenerateWebAuthToken(ctx context.Context) (ret string, er
 	if nist == nil {
 		return ret, fmt.Errorf("cannot generate a token when you are logged off")
 	}
-	uri := libkb.SiteURILookup[h.G().Env.GetRunMode()] + libkb.APIURIPathPrefix + "/user/token.json?tok=" + nist.Token().StringURL()
+	uri := libkb.SiteURILookup[h.G().Env.GetRunMode()] + "/_/user/token?tok=" + nist.Token().StringURL()
 	return uri, nil
 }

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -518,13 +518,13 @@ func (h ConfigHandler) AppendGUILogs(ctx context.Context, content string) error 
 }
 
 func (h ConfigHandler) GenerateWebAuthToken(ctx context.Context) (ret string, err error) {
-	nist, err := h.G().ActiveDevice.NISTWebToken(ctx)
+	nist, err := h.G().ActiveDevice.NISTWebAuthToken(ctx)
 	if err != nil {
 		return ret, err
 	}
 	if nist == nil {
 		return ret, fmt.Errorf("cannot generate a token when you are logged off")
 	}
-	uri := libkb.SiteURILookup[h.G().Env.GetRunMode()] + "/_/login/nist?tok=" + nist.Token().StringURL()
+	uri := libkb.SiteURILookup[h.G().Env.GetRunMode()] + "/_/login/nist?tok=" + nist.Token().String()
 	return uri, nil
 }

--- a/go/service/config.go
+++ b/go/service/config.go
@@ -525,6 +525,6 @@ func (h ConfigHandler) GenerateWebAuthToken(ctx context.Context) (ret string, er
 	if nist == nil {
 		return ret, fmt.Errorf("cannot generate a token when you are logged off")
 	}
-	uri := libkb.SiteURILookup[h.G().Env.GetRunMode()] + "/_/user/token?tok=" + nist.Token().StringURL()
+	uri := libkb.SiteURILookup[h.G().Env.GetRunMode()] + "/_/login/nist?tok=" + nist.Token().StringURL()
 	return uri, nil
 }

--- a/protocol/avdl/keybase1/config.avdl
+++ b/protocol/avdl/keybase1/config.avdl
@@ -314,4 +314,6 @@ protocol config {
   void toggleRuntimeStats();
 
   void appendGUILogs(string content);
+
+  string generateWebAuthToken();
 }

--- a/protocol/json/keybase1/config.json
+++ b/protocol/json/keybase1/config.json
@@ -1098,6 +1098,10 @@
         }
       ],
       "response": null
+    },
+    "generateWebAuthToken": {
+      "request": [],
+      "response": "string"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -3498,6 +3498,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.config.getValue'
 // 'keybase.1.config.guiClearValue'
 // 'keybase.1.config.checkAPIServerOutOfDateWarning'
+// 'keybase.1.config.generateWebAuthToken'
 // 'keybase.1.contacts.lookupContactList'
 // 'keybase.1.crypto.signED25519'
 // 'keybase.1.crypto.signED25519ForKBFS'


### PR DESCRIPTION
- via `keybase web-auth-token`
- click on the link and you get a session token that only could have been generated with your app
- needs a server PR before it will do anything useful, but it's successfully tested
- future PRs will consider mobile