### PR TITLE
feat: hide tab bar on convo screen

### DIFF
--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -152,12 +152,18 @@ const VanillaTabNavigator = createBottomTabNavigator(
     {blank: {screen: BlankScreen}}
   ),
   {
-    defaultNavigationOptions: ({navigation}) => ({
-      tabBarButtonComponent: navigation.state.routeName === 'blank' ? BlankScreen : TabBarIconContainer,
-      tabBarIcon: ({focused}) => (
-        <ConnectedTabBarIcon focused={focused} routeName={navigation.state.routeName as Tabs.Tab} />
-      ),
-    }),
+    defaultNavigationOptions: ({navigation}) => {
+      const routeName = navigation.state.index && navigation.state.routes[navigation.state.index].routeName
+      const tabBarVisible = routeName !== 'chatConversation'
+
+      return {
+        tabBarButtonComponent: navigation.state.routeName === 'blank' ? BlankScreen : TabBarIconContainer,
+        tabBarIcon: ({focused}) => (
+          <ConnectedTabBarIcon focused={focused} routeName={navigation.state.routeName as Tabs.Tab} />
+        ),
+        tabBarVisible,
+      }
+    },
     order: ['blank', ...tabs],
     tabBarOptions: {
       get activeBackgroundColor() {


### PR DESCRIPTION
This PR adds some logic to hide the tab navigator on mobile if you're on a chat conversation screen. This needed to be done in `router.native.tsx` due to some quirks with how react-navigation handles the `tabBarVisible` navigation option (see https://reactnavigation.org/docs/en/navigation-options-resolution.html#a-tab-navigator-contains-a-stack-and-you-want-to-hide-the-tab-bar-on-specific-screens).