### PR TITLE
fix: update avatar size on location share maps

### DIFF
--- a/go/chat/maps/srv.go
+++ b/go/chat/maps/srv.go
@@ -80,7 +80,7 @@ func (s *Srv) serve(w http.ResponseWriter, req *http.Request) {
 
 	var reader io.ReadCloser
 	if username != "" {
-		avatarReader, _, err := avatars.GetBorderedCircleAvatar(ctx, s.G(), username, 96, 8)
+		avatarReader, _, err := avatars.GetBorderedCircleAvatar(ctx, s.G(), username, 48, 8, 8)
 		if err != nil {
 			s.makeError(w, http.StatusInternalServerError, "unable to get avatar: %s", err)
 			return

--- a/go/chat/maps/srv.go
+++ b/go/chat/maps/srv.go
@@ -80,7 +80,7 @@ func (s *Srv) serve(w http.ResponseWriter, req *http.Request) {
 
 	var reader io.ReadCloser
 	if username != "" {
-		avatarReader, _, err := avatars.GetBorderedCircleAvatar(ctx, s.G(), username, 128, 10)
+		avatarReader, _, err := avatars.GetBorderedCircleAvatar(ctx, s.G(), username, 96, 8)
 		if err != nil {
 			s.makeError(w, http.StatusInternalServerError, "unable to get avatar: %s", err)
 			return

--- a/go/chat/unfurl/packager.go
+++ b/go/chat/unfurl/packager.go
@@ -278,7 +278,7 @@ func (p *Packager) packageMaps(ctx context.Context, uid gregor1.UID, convID chat
 
 	// load user avatar for fancy maps
 	username := p.G().ExternalG().GetEnv().GetUsername().String()
-	avatarReader, _, err := avatars.GetBorderedCircleAvatar(ctx, p.G(), username, 96, 8)
+	avatarReader, _, err := avatars.GetBorderedCircleAvatar(ctx, p.G(), username, 48, 8, 8)
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/unfurl/packager.go
+++ b/go/chat/unfurl/packager.go
@@ -278,7 +278,7 @@ func (p *Packager) packageMaps(ctx context.Context, uid gregor1.UID, convID chat
 
 	// load user avatar for fancy maps
 	username := p.G().ExternalG().GetEnv().GetUsername().String()
-	avatarReader, _, err := avatars.GetBorderedCircleAvatar(ctx, p.G(), username, 128, 10)
+	avatarReader, _, err := avatars.GetBorderedCircleAvatar(ctx, p.G(), username, 96, 8)
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
the larger avatar size was covering up a lot of google maps labels, so this PR changes the scale of the map avatars from 128px to 96px. (NB: these numbers aren't actually screen pixels - they're relative to the size of the maps image, which is generally not displayed at 1:1 scale)
cc @adamjspooner 