### PR TITLE
PICNIC-617: Show Username Following Colors In Menubar Widget

### DIFF
--- a/shared/common-adapters/usernames/index.tsx
+++ b/shared/common-adapters/usernames/index.tsx
@@ -134,6 +134,7 @@ function UsernameText(props: Props) {
             {i !== props.users.length - 1 && ' '}
           </Text>
         )
+
         return props.withProfileCardPopup && WithProfileCardPopup ? (
           <WithProfileCardPopup key={u.username} username={u.username}>
             {renderText}

--- a/shared/common-adapters/usernames/remote-container.tsx
+++ b/shared/common-adapters/usernames/remote-container.tsx
@@ -6,12 +6,11 @@ import * as Container from './container'
 type OwnProps = Container.ConnectedProps
 
 // Connected username component
-const mapStateToProps = props => ({
-  _following: props.following,
-  _userInfo: props.userInfo,
-  _you: props.username,
+const mapStateToProps = state => ({
+  _following: state.following,
+  _userInfo: state.userInfo,
+  _you: state.username,
 })
-
 const mapDispatchToProps = dispatch => ({
   _onUsernameClicked: (username: string) => dispatch(ProfileGen.createShowUserProfile({username})),
 })

--- a/shared/desktop/remote/sync-avatar-props.desktop.tsx
+++ b/shared/desktop/remote/sync-avatar-props.desktop.tsx
@@ -53,6 +53,14 @@ export const deserialize = (state: any = initialState, props: any) => {
   }
 }
 
+// Prevent <Connected /> from re-rendering on new Sets when usernames
+const getUsernamesSet = memoize(
+  (usernames: Array<string>) => {
+    return new Set<string>(usernames)
+  },
+  ([oldUsernames], [newUsername]) => isEqual(oldUsernames, newUsername)
+)
+
 function SyncAvatarProps(ComposedComponent: any) {
   const RemoteAvatarConnected = (props: Props) => <ComposedComponent {...props} />
 
@@ -103,8 +111,8 @@ function SyncAvatarProps(ComposedComponent: any) {
      *
      * In the case of the menubar widget, we only care about a subset of the uernames that have updated files.
      */
-    const usernames = new Set<string>(props.usernames)
-    return <Connected {...props} usernames={usernames} />
+    const usernamesSet = getUsernamesSet(props.usernames)
+    return <Connected {...props} usernames={usernamesSet} />
   }
 
   return Wrapper

--- a/shared/desktop/remote/sync-avatar-props.desktop.tsx
+++ b/shared/desktop/remote/sync-avatar-props.desktop.tsx
@@ -7,7 +7,7 @@ import {intersect} from '../../util/set'
 import {memoize} from '../../util/memoize'
 
 type OwnProps = {
-  usernamesRef: React.MutableRefObject<Set<string>>
+  usernames: Array<string>
   windowComponent: string
   windowParam: string
 }
@@ -17,7 +17,7 @@ type Props = {
   following: Set<string>
   httpSrvAddress: string
   httpSrvToken: string
-  usernamesRef: React.MutableRefObject<Set<string>>
+  usernames: Array<string>
   windowComponent: string
   windowParam: string
 }
@@ -60,18 +60,12 @@ function SyncAvatarProps(ComposedComponent: any) {
   }
 
   const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
-    const {
-      usernamesRef: {current: oldUsernames},
-    } = ownProps
-    const {
-      config: {followers, following},
-    } = state
-    const usernames = new Set([...oldUsernames, ...followers, ...following])
-    // Update local Set of all usernames sent over to the remote window
-    ownProps.usernamesRef.current = usernames
-
+    const {usernames} = ownProps
     return {
-      ...immutableCached(getRemoteFollowers(followers, usernames), getRemoteFollowing(following, usernames)),
+      ...immutableCached(
+        getRemoteFollowers(state.config.followers, usernames),
+        getRemoteFollowing(stat.config.following, usernames)
+      ),
       httpSrvAddress: state.config.httpSrvAddress,
       httpSrvToken: state.config.httpSrvToken,
     }
@@ -100,14 +94,13 @@ function SyncAvatarProps(ComposedComponent: any) {
   )(RemoteAvatarConnected)
 
   type WrapperProps = {
+    usernames: Array<string>
     windowComponent: string
     windowParam: string
   }
 
   const Wrapper = (props: WrapperProps) => {
-    // Using a ref here to cache all following and followers usernames that have been sent to the remote window
-    // Don't want to re-render based on this value
-    const usernamesRef = React.useRef(new Set<string>())
+    const usernames = new Set<string>(props.usernames)
     return <Connected {...props} usernamesRef={usernamesRef} />
   }
 

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -130,6 +130,7 @@ const mapStateToProps = (state: Container.TypedState) => ({
   darkMode: Styles.isDarkMode(),
   desktopAppBadgeCount: state.notifications.desktopAppBadgeCount,
   diskSpaceStatus: state.fs.overallSyncStatus.diskSpaceStatus,
+  following: state.config.following,
   kbfsDaemonStatus: state.fs.kbfsDaemonStatus,
   kbfsEnabled: state.fs.sfmi.driverStatus.type === 'enabled',
   loggedIn: state.config.loggedIn,
@@ -177,6 +178,7 @@ export default Container.namedConnect(
         ? SafeElectron.getRemote().BrowserWindow.fromId(stateProps._externalRemoteWindowID)
         : null,
       fileRows: {_tlfUpdates: stateProps._tlfUpdates, _uploads: stateProps._uploads},
+      following: stateProps.following,
       kbfsDaemonStatus: stateProps.kbfsDaemonStatus,
       kbfsEnabled: stateProps.kbfsEnabled,
       loggedIn: stateProps.loggedIn,

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -131,7 +131,6 @@ const mapStateToProps = (state: Container.TypedState) => ({
   darkMode: Styles.isDarkMode(),
   desktopAppBadgeCount: state.notifications.desktopAppBadgeCount,
   diskSpaceStatus: state.fs.overallSyncStatus.diskSpaceStatus,
-  following: state.config.following,
   kbfsDaemonStatus: state.fs.kbfsDaemonStatus,
   kbfsEnabled: state.fs.sfmi.driverStatus.type === 'enabled',
   loggedIn: state.config.loggedIn,
@@ -189,7 +188,6 @@ export default Container.namedConnect(
         ? SafeElectron.getRemote().BrowserWindow.fromId(stateProps._externalRemoteWindowID)
         : null,
       fileRows: {_tlfUpdates: stateProps._tlfUpdates, _uploads: stateProps._uploads},
-      following: stateProps.following,
       kbfsDaemonStatus: stateProps.kbfsDaemonStatus,
       kbfsEnabled: stateProps.kbfsEnabled,
       loggedIn: stateProps.loggedIn,

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -9,6 +9,7 @@ import {conversationsToSend} from '../chat/inbox/container/remote'
 import {serialize} from './remote-serializer.desktop'
 import {uploadsToUploadCountdownHOCProps} from '../fs/footer/upload-container'
 import * as Constants from '../constants/config'
+import {TlfUpdate} from '../constants/types/fs'
 import {BadgeType} from '../constants/types/notifications'
 import {isDarwin, isWindows} from '../constants/platform'
 import {resolveImage} from '../desktop/app/resolve-root.desktop'
@@ -145,6 +146,9 @@ const mapStateToProps = (state: Container.TypedState) => ({
 let _lastUsername: string | undefined
 let _lastClearCacheTrigger = 0
 
+const getUsernamesFromTlfUpdate = (tlfUpdates: Array<TlfUpdate>): Array<string> =>
+  tlfUpdates.map(update => update.writer)
+
 // TODO better type
 const RenderExternalWindowBranch: any = (ComposedComponent: React.ComponentType<any>) =>
   class RemoteWindowComponent extends React.PureComponent<{
@@ -164,12 +168,13 @@ export default Container.namedConnect(
       _lastUsername = stateProps.username
       _lastClearCacheTrigger++
     }
-    // `sync-avatar-props` will attempt to parse out a subset of the following/follower lists
-    // in order to show the following status on usernames in the menubar widget.
-    //
-    // The list of usernames to show will need to be pre-parsed and passed to
-    // sync-avatar-props before serializing anything to the menubar widget
-    const usernamesForFollowingStatus =
+
+    // To show the following status of usernaems in the mebubar widget, we need to
+    // provide which users will appear in the menubar before rendering it.
+    // This is done for SyncAvatarProps which use the usernames to shorten the
+    // number of following/follwers that are sent to the remote window.
+    const usernamesForFollowingStatus = getUsernamesFromTlfUpdate(stateProps._tlfUpdates.toArray())
+
     return {
       badgeKeys: stateProps._badgeInfo,
       badgeMap: stateProps._badgeInfo,
@@ -193,6 +198,7 @@ export default Container.namedConnect(
       showingDiskSpaceBanner: stateProps.showingDiskSpaceBanner,
       userInfo: stateProps.userInfo,
       username: stateProps.username,
+      usernames: usernamesForFollowingStatus,
       widgetBadge: stateProps.widgetBadge,
       windowComponent: 'menubar',
       windowOpts: _windowOpts,

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -147,7 +147,7 @@ let _lastClearCacheTrigger = 0
 
 // TODO better type
 const RenderExternalWindowBranch: any = (ComposedComponent: React.ComponentType<any>) =>
-  class extends React.PureComponent<{
+  class RemoteWindowComponent extends React.PureComponent<{
     externalRemoteWindow?: SafeElectron.BrowserWindowType
   }> {
     render() {
@@ -164,6 +164,12 @@ export default Container.namedConnect(
       _lastUsername = stateProps.username
       _lastClearCacheTrigger++
     }
+    // `sync-avatar-props` will attempt to parse out a subset of the following/follower lists
+    // in order to show the following status on usernames in the menubar widget.
+    //
+    // The list of usernames to show will need to be pre-parsed and passed to
+    // sync-avatar-props before serializing anything to the menubar widget
+    const usernamesForFollowingStatus =
     return {
       badgeKeys: stateProps._badgeInfo,
       badgeMap: stateProps._badgeInfo,

--- a/shared/menubar/remote-serializer.desktop.tsx
+++ b/shared/menubar/remote-serializer.desktop.tsx
@@ -53,7 +53,6 @@ export const serialize: any = {
       ? null
       : v._tlfUpdates.map(t => GetRowsFromTlfUpdate(t, v._uploads)).toArray(),
   files: (v: number) => v,
-  following: (v: Set<string>) => [...v],
   kbfsDaemonStatus: (v: FSTypes.KbfsDaemonStatus) => v,
   kbfsEnabled: (v: boolean) => v,
   loggedIn: (v: boolean) => v,

--- a/shared/menubar/remote-serializer.desktop.tsx
+++ b/shared/menubar/remote-serializer.desktop.tsx
@@ -53,6 +53,7 @@ export const serialize: any = {
       ? null
       : v._tlfUpdates.map(t => GetRowsFromTlfUpdate(t, v._uploads)).toArray(),
   files: (v: number) => v,
+  following: (v: Set<string>) => [...v],
   kbfsDaemonStatus: (v: FSTypes.KbfsDaemonStatus) => v,
   kbfsEnabled: (v: boolean) => v,
   loggedIn: (v: boolean) => v,
@@ -113,5 +114,6 @@ export const deserialize = (state: any = initialState, props: any) => {
     fileRows: props.fileRows || state.fileRows,
     userInfo,
   }
+
   return Avatar.deserialize(newState, props)
 }

--- a/shared/menubar/remote-serializer.desktop.tsx
+++ b/shared/menubar/remote-serializer.desktop.tsx
@@ -67,6 +67,7 @@ export const serialize: any = {
     return shallowEqual(toSend, old) ? undefined : toSend
   },
   username: (v: string) => v,
+  usernames: (v: Array<string>) => v,
   widgetBadge: (v: NotificationTypes.BadgeType) => v,
   windowComponent: (v: string) => v,
   windowOpts: (v: Object) => v,


### PR DESCRIPTION
Was broken for a while. Now uses `useRef` for a mutable box that won't trigger re-renders.
Purpose is to cache the list of username strings we've already sent to the remote window to prevent serializing and sending unnecessary data.

### Before
![Screenshot 2019-11-06 10 45 07](https://user-images.githubusercontent.com/5200812/68313400-88420d00-0082-11ea-85ed-8b407f5ae0d3.png)


### After

![Screenshot 2019-11-06 10 45 24](https://user-images.githubusercontent.com/5200812/68313407-8b3cfd80-0082-11ea-997f-ddc9604225c6.png)
