### PR TITLE
libfs: add a billy-backed impl for levelDB storage

### DIFF
--- a/go/kbfs/libfs/file.go
+++ b/go/kbfs/libfs/file.go
@@ -164,12 +164,11 @@ func (f *File) Lock() (err error) {
 		return err
 	}
 	jManager, err := libkbfs.GetJournalManager(f.fs.config)
-	if err != nil {
-		return err
-	}
-	if err = jManager.FinishSingleOp(f.fs.ctx,
-		f.fs.root.GetFolderBranch().Tlf, nil, f.fs.priority); err != nil {
-		return err
+	if err == nil {
+		if err = jManager.FinishSingleOp(f.fs.ctx,
+			f.fs.root.GetFolderBranch().Tlf, nil, f.fs.priority); err != nil {
+			return err
+		}
 	}
 
 	// Now, sync up with the server, while making sure a lock is held by us. If
@@ -207,32 +206,38 @@ func (f *File) Unlock() (err error) {
 		return err
 	}
 	jManager, err := libkbfs.GetJournalManager(f.fs.config)
-	if err != nil {
-		return err
-	}
-	jStatus, _ := jManager.JournalStatus(f.fs.root.GetFolderBranch().Tlf)
-	if jStatus.RevisionStart == kbfsmd.RevisionUninitialized {
-		// Journal MDs are all flushed and we haven't made any more writes.
-		// Calling FinishSingleOp won't make it to the server, so we make a
-		// naked request to server just to release the lock.
-		return f.fs.config.MDServer().ReleaseLock(f.fs.ctx,
-			f.fs.root.GetFolderBranch().Tlf, f.getLockID())
+	if err == nil {
+		jStatus, _ := jManager.JournalStatus(f.fs.root.GetFolderBranch().Tlf)
+		if jStatus.RevisionStart == kbfsmd.RevisionUninitialized {
+			// Journal MDs are all flushed and we haven't made any
+			// more writes.  Calling FinishSingleOp won't make it to
+			// the server, so we make a naked request to server just
+			// to release the lock.
+			return f.fs.config.MDServer().ReleaseLock(f.fs.ctx,
+				f.fs.root.GetFolderBranch().Tlf, f.getLockID())
+		}
+	} else {
+		jManager = nil
 	}
 
 	if f.fs.config.Mode().Type() == libkbfs.InitSingleOp {
-		err = jManager.FinishSingleOp(f.fs.ctx,
-			f.fs.root.GetFolderBranch().Tlf, &keybase1.LockContext{
-				RequireLockID:       f.getLockID(),
-				ReleaseAfterSuccess: true,
-			}, f.fs.priority)
-		if err != nil {
-			return err
+		if jManager != nil {
+			err = jManager.FinishSingleOp(f.fs.ctx,
+				f.fs.root.GetFolderBranch().Tlf, &keybase1.LockContext{
+					RequireLockID:       f.getLockID(),
+					ReleaseAfterSuccess: true,
+				}, f.fs.priority)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
-		err = jManager.WaitForCompleteFlush(
-			f.fs.ctx, f.fs.root.GetFolderBranch().Tlf)
-		if err != nil {
-			return err
+		if jManager != nil {
+			err = jManager.WaitForCompleteFlush(
+				f.fs.ctx, f.fs.root.GetFolderBranch().Tlf)
+			if err != nil {
+				return err
+			}
 		}
 
 		f.fs.log.CDebugf(f.fs.ctx, "Releasing the lock")

--- a/go/kbfs/libfs/leveldb_storage.go
+++ b/go/kbfs/libfs/leveldb_storage.go
@@ -1,0 +1,681 @@
+// Copyright (c) 2012, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reservefs.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This is a modified version of
+// github.com/syndtr/goleveldb/leveldb/storage/file_storage.go.
+//
+// Modifications: Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	billy "gopkg.in/src-d/go-billy.v4"
+)
+
+var (
+	errReadOnly = errors.New("leveldb/storage: storage is read-only")
+)
+
+type levelDBStorageLock struct {
+	fs *levelDBStorage
+}
+
+func (lock *levelDBStorageLock) Unlock() {
+	if lock.fs != nil {
+		lock.fs.mu.Lock()
+		defer lock.fs.mu.Unlock()
+		if lock.fs.slock == lock {
+			lock.fs.slock = nil
+		}
+	}
+}
+
+type int64Slice []int64
+
+func (p int64Slice) Len() int           { return len(p) }
+func (p int64Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+const logSizeThreshold = 1024 * 1024 // 1 MiB
+
+// levelDBStorage is a billy-filesystem-backed storage.
+type levelDBStorage struct {
+	fs       billy.Filesystem
+	readOnly bool
+
+	mu      sync.Mutex
+	flock   billy.File
+	slock   *levelDBStorageLock
+	logw    billy.File
+	logSize int64
+	buf     []byte
+	// Opened file counter; if open < 0 means closed.
+	open int
+	day  int
+}
+
+var _ storage.Storage = (*levelDBStorage)(nil)
+
+// OpenLevelDBStorage returns a new billy-filesystem-backed storage
+// implementation of the levelDB storage interface. This also acquires
+// a file lock, so any subsequent attempt to open the same path will
+// fail.
+func OpenLevelDBStorage(bfs billy.Filesystem, readOnly bool) (
+	s storage.Storage, err error) {
+	flock, err := bfs.OpenFile("LOCK", os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			flock.Close()
+		}
+	}()
+	err = flock.Lock()
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		logw    billy.File
+		logSize int64
+	)
+	if !readOnly {
+		logw, err = bfs.OpenFile("LOG", os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return nil, err
+		}
+		logSize, err = logw.Seek(0, os.SEEK_END)
+		if err != nil {
+			logw.Close()
+			return nil, err
+		}
+	}
+
+	fs := &levelDBStorage{
+		fs:       bfs,
+		readOnly: readOnly,
+		flock:    flock,
+		logw:     logw,
+		logSize:  logSize,
+	}
+	runtime.SetFinalizer(fs, (*levelDBStorage).Close)
+	return fs, nil
+}
+
+func (fs *levelDBStorage) writeFileSynced(
+	filename string, data []byte, perm os.FileMode) error {
+	f, err := fs.fs.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write(data)
+	if err == nil && n < len(data) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	if err != nil {
+		return err
+	}
+	return fs.sync()
+}
+
+func (fs *levelDBStorage) Lock() (storage.Locker, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return nil, storage.ErrClosed
+	}
+	if fs.readOnly {
+		return &levelDBStorageLock{}, nil
+	}
+	if fs.slock != nil {
+		return nil, storage.ErrLocked
+	}
+	fs.slock = &levelDBStorageLock{fs: fs}
+	return fs.slock, nil
+}
+
+func itoa(buf []byte, i int, wid int) []byte {
+	u := uint(i)
+	if u == 0 && wid <= 1 {
+		return append(buf, '0')
+	}
+
+	// Assemble decimal in reverse order.
+	var b [32]byte
+	bp := len(b)
+	for ; u > 0 || wid > 0; u /= 10 {
+		bp--
+		wid--
+		b[bp] = byte(u%10) + '0'
+	}
+	return append(buf, b[bp:]...)
+}
+
+func (fs *levelDBStorage) printDay(t time.Time) {
+	if fs.day == t.Day() {
+		return
+	}
+	fs.day = t.Day()
+	_, _ = fs.logw.Write([]byte("=============== " + t.Format("Jan 2, 2006 (MST)") + " ===============\n"))
+}
+
+func (fs *levelDBStorage) doLog(t time.Time, str string) {
+	if fs.logSize > logSizeThreshold {
+		// Rotate log file.
+		fs.logw.Close()
+		fs.logw = nil
+		fs.logSize = 0
+		err := fs.fs.Rename("LOG", "LOG.old")
+		if err != nil {
+			return
+		}
+	}
+	if fs.logw == nil {
+		var err error
+		fs.logw, err = fs.fs.OpenFile("LOG", os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return
+		}
+		// Force printDay on new log file.
+		fs.day = 0
+	}
+	fs.printDay(t)
+	hour, min, sec := t.Clock()
+	msec := t.Nanosecond() / 1e3
+	// time
+	fs.buf = itoa(fs.buf[:0], hour, 2)
+	fs.buf = append(fs.buf, ':')
+	fs.buf = itoa(fs.buf, min, 2)
+	fs.buf = append(fs.buf, ':')
+	fs.buf = itoa(fs.buf, sec, 2)
+	fs.buf = append(fs.buf, '.')
+	fs.buf = itoa(fs.buf, msec, 6)
+	fs.buf = append(fs.buf, ' ')
+	// write
+	fs.buf = append(fs.buf, []byte(str)...)
+	fs.buf = append(fs.buf, '\n')
+	n, _ := fs.logw.Write(fs.buf)
+	fs.logSize += int64(n)
+}
+
+func (fs *levelDBStorage) Log(str string) {
+	if !fs.readOnly {
+		t := time.Now()
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+		if fs.open < 0 {
+			return
+		}
+		fs.doLog(t, str)
+	}
+}
+
+func (fs *levelDBStorage) log(str string) {
+	if !fs.readOnly {
+		fs.doLog(time.Now(), str)
+	}
+}
+
+func (fs *levelDBStorage) sync() (err error) {
+	// Force a sync with a lock/unlock cycle, since the billy
+	// interface doesn't have an explicit sync call.
+	const syncLockName = "sync.lock"
+	f, err := fs.fs.OpenFile(syncLockName, os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		closeErr := f.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
+	return f.Lock()
+}
+
+func (fs *levelDBStorage) setMeta(fd storage.FileDesc) error {
+	content := fsGenName(fd) + "\n"
+	// Check and backup old CURRENT file.
+	currentPath := "CURRENT"
+	if _, err := fs.fs.Stat(currentPath); err == nil {
+		f, err := fs.fs.Open(currentPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		b, err := ioutil.ReadAll(f)
+		if err != nil {
+			fs.log(fmt.Sprintf("backup CURRENT: %v", err))
+			return err
+		}
+		if string(b) == content {
+			// Content not changed, do nothing.
+			return nil
+		}
+		if err := fs.writeFileSynced(currentPath+".bak", b, 0644); err != nil {
+			fs.log(fmt.Sprintf("backup CURRENT: %v", err))
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	path := fmt.Sprintf("CURRENT.%d", fd.Num)
+	if err := fs.writeFileSynced(path, []byte(content), 0644); err != nil {
+		fs.log(fmt.Sprintf("create CURRENT.%d: %v", fd.Num, err))
+		return err
+	}
+	// Replace CURRENT file.
+	if err := fs.fs.Rename(path, currentPath); err != nil {
+		fs.log(fmt.Sprintf("rename CURRENT.%d: %v", fd.Num, err))
+		return err
+	}
+	return fs.sync()
+}
+
+func (fs *levelDBStorage) SetMeta(fd storage.FileDesc) error {
+	if !storage.FileDescOk(fd) {
+		return storage.ErrInvalidFile
+	}
+	if fs.readOnly {
+		return errReadOnly
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return storage.ErrClosed
+	}
+	return fs.setMeta(fd)
+}
+
+func isCorrupted(err error) bool {
+	switch err.(type) {
+	case *storage.ErrCorrupted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (fs *levelDBStorage) GetMeta() (storage.FileDesc, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return storage.FileDesc{}, storage.ErrClosed
+	}
+	fis, err := fs.fs.ReadDir("")
+	if err != nil {
+		return storage.FileDesc{}, err
+	}
+	// Try this in order:
+	// - CURRENT.[0-9]+ ('pending rename' file, descending order)
+	// - CURRENT
+	// - CURRENT.bak
+	//
+	// Skip corrupted file or file that point to a missing target file.
+	type currentFile struct {
+		name string
+		fd   storage.FileDesc
+	}
+	tryCurrent := func(name string) (*currentFile, error) {
+		f, err := fs.fs.Open(name)
+		if err != nil {
+			if os.IsNotExist(err) {
+				err = os.ErrNotExist
+			}
+			return nil, err
+		}
+		defer f.Close()
+		b, err := ioutil.ReadAll(f)
+		if err != nil {
+			return nil, err
+		}
+		var fd storage.FileDesc
+		if len(b) < 1 || b[len(b)-1] != '\n' || !fsParseNamePtr(string(b[:len(b)-1]), &fd) {
+			fs.log(fmt.Sprintf("%s: corrupted content: %q", name, b))
+			err := &storage.ErrCorrupted{
+				Err: fmt.Errorf("leveldb/storage: corrupted or incomplete CURRENT file %s %q", name, b),
+			}
+			return nil, err
+		}
+		if _, err := fs.fs.Stat(fsGenName(fd)); err != nil {
+			if os.IsNotExist(err) {
+				fs.log(fmt.Sprintf("%s: missing target file: %s", name, fd))
+				err = os.ErrNotExist
+			}
+			return nil, err
+		}
+		return &currentFile{name: name, fd: fd}, nil
+	}
+	tryCurrents := func(names []string) (*currentFile, error) {
+		var (
+			cur *currentFile
+			// Last corruption error.
+			lastCerr error
+		)
+		for _, name := range names {
+			var err error
+			cur, err = tryCurrent(name)
+			if err == nil {
+				break
+			} else if err == os.ErrNotExist {
+				// Fallback to the next file.
+			} else if isCorrupted(err) {
+				lastCerr = err
+				// Fallback to the next file.
+			} else {
+				// In case the error is due to permission, etc.
+				return nil, err
+			}
+		}
+		if cur == nil {
+			err := os.ErrNotExist
+			if lastCerr != nil {
+				err = lastCerr
+			}
+			return nil, err
+		}
+		return cur, nil
+	}
+
+	// Try 'pending rename' files.
+	var nums []int64
+	for _, fi := range fis {
+		name := fi.Name()
+		if strings.HasPrefix(name, "CURRENT.") && name != "CURRENT.bak" {
+			i, err := strconv.ParseInt(name[8:], 10, 64)
+			if err == nil {
+				nums = append(nums, i)
+			}
+		}
+	}
+	var (
+		pendCur   *currentFile
+		pendErr   = os.ErrNotExist
+		pendNames []string
+	)
+	if len(nums) > 0 {
+		sort.Sort(sort.Reverse(int64Slice(nums)))
+		pendNames = make([]string, len(nums))
+		for i, num := range nums {
+			pendNames[i] = fmt.Sprintf("CURRENT.%d", num)
+		}
+		pendCur, pendErr = tryCurrents(pendNames)
+		if pendErr != nil && pendErr != os.ErrNotExist && !isCorrupted(pendErr) {
+			return storage.FileDesc{}, pendErr
+		}
+	}
+
+	// Try CURRENT and CURRENT.bak.
+	curCur, curErr := tryCurrents([]string{"CURRENT", "CURRENT.bak"})
+	if curErr != nil && curErr != os.ErrNotExist && !isCorrupted(curErr) {
+		return storage.FileDesc{}, curErr
+	}
+
+	// pendCur takes precedence, but guards against obsolete pendCur.
+	if pendCur != nil && (curCur == nil || pendCur.fd.Num > curCur.fd.Num) {
+		curCur = pendCur
+	}
+
+	if curCur != nil {
+		// Restore CURRENT file to proper state.
+		if !fs.readOnly && (curCur.name != "CURRENT" || len(pendNames) != 0) {
+			// Ignore setMeta errors, however don't delete obsolete files if we
+			// catch error.
+			if err := fs.setMeta(curCur.fd); err == nil {
+				// Remove 'pending rename' files.
+				for _, name := range pendNames {
+					if err := fs.fs.Remove(name); err != nil {
+						fs.log(fmt.Sprintf("remove %s: %v", name, err))
+					}
+				}
+			}
+		}
+		return curCur.fd, nil
+	}
+
+	// Nothing found.
+	if isCorrupted(pendErr) {
+		return storage.FileDesc{}, pendErr
+	}
+	return storage.FileDesc{}, curErr
+}
+
+func (fs *levelDBStorage) List(ft storage.FileType) (fds []storage.FileDesc, err error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return nil, storage.ErrClosed
+	}
+	fis, err := fs.fs.ReadDir("")
+	if err != nil {
+		return nil, err
+	}
+	if err == nil {
+		for _, fi := range fis {
+			if fd, ok := fsParseName(fi.Name()); ok && fd.Type&ft != 0 {
+				fds = append(fds, fd)
+			}
+		}
+	}
+	return
+}
+
+func (fs *levelDBStorage) Open(fd storage.FileDesc) (storage.Reader, error) {
+	if !storage.FileDescOk(fd) {
+		return nil, storage.ErrInvalidFile
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return nil, storage.ErrClosed
+	}
+	of, err := fs.fs.OpenFile(fsGenName(fd), os.O_RDONLY, 0)
+	if err != nil {
+		if fsHasOldName(fd) && os.IsNotExist(err) {
+			of, err = fs.fs.OpenFile(fsGenOldName(fd), os.O_RDONLY, 0)
+			if err == nil {
+				goto ok
+			}
+		}
+		return nil, err
+	}
+ok:
+	fs.open++
+	return &fileWrap{File: of, fs: fs, fd: fd}, nil
+}
+
+func (fs *levelDBStorage) Create(fd storage.FileDesc) (storage.Writer, error) {
+	if !storage.FileDescOk(fd) {
+		return nil, storage.ErrInvalidFile
+	}
+	if fs.readOnly {
+		return nil, errReadOnly
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return nil, storage.ErrClosed
+	}
+	of, err := fs.fs.OpenFile(fsGenName(fd), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, err
+	}
+	fs.open++
+	return &fileWrap{File: of, fs: fs, fd: fd}, nil
+}
+
+func (fs *levelDBStorage) Remove(fd storage.FileDesc) error {
+	if !storage.FileDescOk(fd) {
+		return storage.ErrInvalidFile
+	}
+	if fs.readOnly {
+		return errReadOnly
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return storage.ErrClosed
+	}
+	err := fs.fs.Remove(fsGenName(fd))
+	if err != nil {
+		if fsHasOldName(fd) && os.IsNotExist(err) {
+			if e1 := fs.fs.Remove(fsGenOldName(fd)); !os.IsNotExist(e1) {
+				fs.log(fmt.Sprintf("remove %s: %v (old name)", fd, err))
+				err = e1
+			}
+		} else {
+			fs.log(fmt.Sprintf("remove %s: %v", fd, err))
+		}
+	}
+	return err
+}
+
+func (fs *levelDBStorage) Rename(oldfd, newfd storage.FileDesc) error {
+	if !storage.FileDescOk(oldfd) || !storage.FileDescOk(newfd) {
+		return storage.ErrInvalidFile
+	}
+	if oldfd == newfd {
+		return nil
+	}
+	if fs.readOnly {
+		return errReadOnly
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return storage.ErrClosed
+	}
+	return fs.fs.Rename(fsGenName(oldfd), fsGenName(newfd))
+}
+
+func (fs *levelDBStorage) Close() error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.open < 0 {
+		return storage.ErrClosed
+	}
+	// Clear the finalizer.
+	runtime.SetFinalizer(fs, nil)
+
+	if fs.open > 0 {
+		fs.log(fmt.Sprintf("close: warning, %d files still open", fs.open))
+	}
+	fs.open = -1
+	if fs.logw != nil {
+		fs.logw.Close()
+	}
+	return fs.flock.Close()
+}
+
+type fileWrap struct {
+	billy.File
+	fs     *levelDBStorage
+	fd     storage.FileDesc
+	closed bool
+}
+
+func (fw *fileWrap) Sync() error {
+	return fw.fs.sync()
+}
+
+func (fw *fileWrap) Close() error {
+	fw.fs.mu.Lock()
+	defer fw.fs.mu.Unlock()
+	if fw.closed {
+		return storage.ErrClosed
+	}
+	fw.closed = true
+	fw.fs.open--
+	err := fw.File.Close()
+	if err != nil {
+		fw.fs.log(fmt.Sprintf("close %s: %v", fw.fd, err))
+	}
+	return err
+}
+
+func fsGenName(fd storage.FileDesc) string {
+	switch fd.Type {
+	case storage.TypeManifest:
+		return fmt.Sprintf("MANIFEST-%06d", fd.Num)
+	case storage.TypeJournal:
+		return fmt.Sprintf("%06d.log", fd.Num)
+	case storage.TypeTable:
+		return fmt.Sprintf("%06d.ldb", fd.Num)
+	case storage.TypeTemp:
+		return fmt.Sprintf("%06d.tmp", fd.Num)
+	default:
+		panic("invalid file type")
+	}
+}
+
+func fsHasOldName(fd storage.FileDesc) bool {
+	return fd.Type == storage.TypeTable
+}
+
+func fsGenOldName(fd storage.FileDesc) string {
+	switch fd.Type {
+	case storage.TypeTable:
+		return fmt.Sprintf("%06d.sst", fd.Num)
+	default:
+		return fsGenName(fd)
+	}
+}
+
+func fsParseName(name string) (fd storage.FileDesc, ok bool) {
+	var tail string
+	_, err := fmt.Sscanf(name, "%d.%s", &fd.Num, &tail)
+	if err == nil {
+		switch tail {
+		case "log":
+			fd.Type = storage.TypeJournal
+		case "ldb", "sst":
+			fd.Type = storage.TypeTable
+		case "tmp":
+			fd.Type = storage.TypeTemp
+		default:
+			return
+		}
+		return fd, true
+	}
+	n, _ := fmt.Sscanf(name, "MANIFEST-%d%s", &fd.Num, &tail)
+	if n == 1 {
+		fd.Type = storage.TypeManifest
+		return fd, true
+	}
+	return
+}
+
+func fsParseNamePtr(name string, fd *storage.FileDesc) bool {
+	_fd, ok := fsParseName(name)
+	if fd != nil {
+		*fd = _fd
+	}
+	return ok
+}

--- a/go/kbfs/libfs/leveldb_storage_test.go
+++ b/go/kbfs/libfs/leveldb_storage_test.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+func TestLevelDBWithFS(t *testing.T) {
+	ctx, _, fs := makeFS(t, "")
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, fs.config)
+
+	t.Log("Open a leveldb using a KBFS billy filesystem")
+	s, err := OpenLevelDBStorage(fs, false)
+	require.NoError(t, err)
+	sNeedsClose := true
+	defer func() {
+		if sNeedsClose {
+			err := s.Close()
+			require.NoError(t, err)
+		}
+	}()
+	db, err := leveldb.Open(s, nil)
+	require.NoError(t, err)
+	dbNeedsClose := true
+	defer func() {
+		if dbNeedsClose {
+			err := db.Close()
+			require.NoError(t, err)
+		}
+	}()
+
+	t.Log("Put some stuff into the db")
+	key1 := []byte("key1")
+	val1 := []byte("val1")
+	key2 := []byte("key2")
+	val2 := []byte("val2")
+	err = db.Put(key1, val1, nil)
+	require.NoError(t, err)
+	err = db.Put(key2, val2, nil)
+	require.NoError(t, err)
+
+	t.Log("Close the db to release the lock")
+	err = db.Close()
+	require.NoError(t, err)
+	dbNeedsClose = false
+	err = s.Close()
+	require.NoError(t, err)
+	sNeedsClose = false
+
+	t.Log("Read from another device")
+	config2 := libkbfs.ConfigAsUser(fs.config.(*libkbfs.ConfigLocal), "user1")
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
+	h, err := tlfhandle.ParseHandle(
+		ctx, config2.KBPKI(), config2.MDOps(), nil, "user1", tlf.Private)
+	require.NoError(t, err)
+	fs2, err := NewFS(
+		ctx, config2, h, data.MasterBranch, "", "", keybase1.MDPriorityNormal)
+	require.NoError(t, err)
+	s2, err := OpenLevelDBStorage(fs2, false)
+	require.NoError(t, err)
+	defer func() {
+		err := s2.Close()
+		require.NoError(t, err)
+	}()
+	db2, err := leveldb.Open(s2, nil)
+	require.NoError(t, err)
+	defer func() {
+		err := db2.Close()
+		require.NoError(t, err)
+	}()
+
+	gotVal1, err := db2.Get(key1, nil)
+	require.NoError(t, err)
+	require.Equal(t, val1, gotVal1)
+	gotVal2, err := db2.Get(key2, nil)
+	require.NoError(t, err)
+	require.Equal(t, val2, gotVal2)
+}


### PR DESCRIPTION
In the future, we may have a use for a leveldb that is written directly to KBFS (e.g., storing a encrypted search index to local disk).  This commit implements the levelDB storage interface using a billy filesystem.

Note that `leveldb_storage.go` is just a modified version of https://github.com/keybase/client/blob/95db6a620a7cbba2760d83b1f264f477bed60d69/go/vendor/github.com/syndtr/goleveldb/leveldb/storage/file_storage.go -- I didn't really put any effort into making it match our usual style, I just dropped in billy-based calls instead of `os`-based calls.  It's probably not worth noting any nits in there since I'm trying to keep it close to the original to apply future patches if needed.

I'd consider moving it into a different/new package if anyone has a better idea about where to put it.

This commit also changes the `libfs.File` interface to handle Locks and Unlocks when the journal isn't running, which is needed for the tests and for the possible future work on local search storage.

Issue: HOTPOT-1213