### PR TITLE
Add 'provides' and update 'conflicts'

### DIFF
--- a/packaging/linux/arch/PKGBUILD.bin.in
+++ b/packaging/linux/arch/PKGBUILD.bin.in
@@ -16,8 +16,9 @@ pkgrel=1
 arch=('i686' 'x86_64')
 depends=(fuse gconf libxss gtk2 lsof) # don't change this without changing the SRCINFO template too
                                       # also make sure to change the keybase-git PKGBUILD
+provides=(keybase keybase-gui kbfs)
 # keybase-release is a deprecated AUR package
-conflicts=(keybase keybase-release keybase-git)
+conflicts=(keybase keybase-release keybase-git keybase-gui kbfs)
 source_i686=(
   "${src_prefix}/keybase_${deb_pkgver}_i386.deb"
 )


### PR DESCRIPTION
This change adds a 'provides' line, and updates the 'conflicts' line in the Arch PKGBUILD.

**Some background info:** I'm working on packaging one of my own projects for the AUR, and it depends on the Keybase service. My project doesn't care if Keybase was installed via the `-bin`, or `-git` packages on the AUR, or the `keybase` package in community. Currently if I set my package to depend on `keybase` in the pkgbuild, pacman will want to uninstall `keybase-git` or `keybase-bin` in favor of the community package, but I don't want it interfering with any of that. So the solution here would be to have `keybase-bin` and `keybase-git` add a `provides` line to say they each provide `keybase`, `kbfs`, and `keybase-gui` (since those are separated in community), and update 'conflicts' to include 'keybase-gui' and 'kbfs' so those wouldn't be installed from community alongside one of the AUR packages, where those are both bundled in with the core Keybase service.

**CC:** @heronhaye @eli-schwartz