### PR TITLE
Fix text overflow, timeline marker for git commit messages on mobile

### DIFF
--- a/shared/chat/conversation/messages/system-git-push/index.tsx
+++ b/shared/chat/conversation/messages/system-git-push/index.tsx
@@ -208,14 +208,17 @@ const styles = Styles.styleSheetCreate(
         padding: 2,
       },
       grow: {
-        flexGrow: 1,
+        flex: 1,
       },
       hashAndMessage: {
-        flexGrow: 1,
         paddingBottom: Styles.globalMargins.xtiny,
         paddingTop: Styles.globalMargins.xtiny,
       },
-      marker: {marginRight: Styles.globalMargins.xtiny, ...(Styles.isMobile ? {marginTop: -3} : null)},
+      marker: {
+        marginRight: Styles.globalMargins.xtiny,
+        ...(Styles.isMobile ? {marginTop: -3} : null),
+        minWidth: 0,
+      },
       repoText: {color: Styles.globalColors.black_50},
       textLeft: {textAlign: 'left'},
     } as const)

--- a/shared/common-adapters/timeline-marker.tsx
+++ b/shared/common-adapters/timeline-marker.tsx
@@ -39,19 +39,14 @@ const styles = Styles.styleSheetCreate(() => ({
       borderColor: Styles.globalColors.white,
     },
   }),
-  circleOpen: Styles.platformStyles({
-    common: {
-      borderRadius: circleSize / 2,
-      height: circleSize,
-      width: circleSize,
-    },
-    isElectron: {
-      border: `solid 2px ${timeline_grey}`,
-    },
-    isMobile: {
-      borderColor: timeline_grey,
-    },
-  }),
+  circleOpen: {
+    borderRadius: circleSize / 2,
+    height: circleSize,
+    width: circleSize,
+    borderStyle: 'solid',
+    borderWidth: 2,
+    borderColor: timeline_grey,
+  },
   line: Styles.platformStyles({
     common: {
       backgroundColor: timeline_grey,

--- a/shared/common-adapters/timeline-marker.tsx
+++ b/shared/common-adapters/timeline-marker.tsx
@@ -40,12 +40,12 @@ const styles = Styles.styleSheetCreate(() => ({
     },
   }),
   circleOpen: {
+    borderColor: timeline_grey,
     borderRadius: circleSize / 2,
-    height: circleSize,
-    width: circleSize,
     borderStyle: 'solid',
     borderWidth: 2,
-    borderColor: timeline_grey,
+    height: circleSize,
+    width: circleSize,
   },
   line: Styles.platformStyles({
     common: {


### PR DESCRIPTION
The system git push message previously didn't render the open circle markers at all, and had issues with text overflowing the system message box. This PR addresses that text overflow issue by setting a different flexbox property (`flex: 1` is magic), and the open circle issue by explicitly setting the border color and width on mobile. 