### PR TITLE
fix reset store being overwritten in makeReducer

### DIFF
--- a/shared/actions/json/team-building.json
+++ b/shared/actions/json/team-building.json
@@ -34,6 +34,10 @@
       "namespace": "'teams'",
       "sendNotification": "boolean"
     },
-    "labelsSeen": {"namespace": "Types.AllowedNamespace"}
+    "labelsSeen": {"namespace": "Types.AllowedNamespace"},
+    "tbResetStore": {
+        "namespace": "Types.AllowedNamespace",
+        "_description": "our own reset store so we don't have conflicts with parent reducers"
+    }
   }
 }

--- a/shared/actions/team-building-gen.tsx
+++ b/shared/actions/team-building-gen.tsx
@@ -17,6 +17,7 @@ export const removeUsersFromTeamSoFar = 'team-building:removeUsersFromTeamSoFar'
 export const search = 'team-building:search'
 export const searchResultsLoaded = 'team-building:searchResultsLoaded'
 export const selectRole = 'team-building:selectRole'
+export const tbResetStore = 'team-building:tbResetStore'
 
 // Payload Types
 type _AddUsersToTeamSoFarPayload = {
@@ -47,8 +48,16 @@ type _SearchResultsLoadedPayload = {
   readonly service: Types.ServiceIdWithContact
 }
 type _SelectRolePayload = {readonly namespace: 'teams'; readonly role: TeamRoleType}
+type _TbResetStorePayload = {readonly namespace: Types.AllowedNamespace}
 
 // Action Creators
+/**
+ * our own reset store so we don't have conflicts with parent reducers
+ */
+export const createTbResetStore = (payload: _TbResetStorePayload): TbResetStorePayload => ({
+  payload,
+  type: tbResetStore,
+})
 export const createAddUsersToTeamSoFar = (
   payload: _AddUsersToTeamSoFarPayload
 ): AddUsersToTeamSoFarPayload => ({payload, type: addUsersToTeamSoFar})
@@ -122,6 +131,7 @@ export type SearchResultsLoadedPayload = {
   readonly type: typeof searchResultsLoaded
 }
 export type SelectRolePayload = {readonly payload: _SelectRolePayload; readonly type: typeof selectRole}
+export type TbResetStorePayload = {readonly payload: _TbResetStorePayload; readonly type: typeof tbResetStore}
 
 // All Actions
 // prettier-ignore
@@ -137,4 +147,5 @@ export type Actions =
   | SearchPayload
   | SearchResultsLoadedPayload
   | SelectRolePayload
+  | TbResetStorePayload
   | {type: 'common:resetStore', payload: {}}

--- a/shared/actions/team-building.tsx
+++ b/shared/actions/team-building.tsx
@@ -141,7 +141,11 @@ export function filterForNs<S, A, L, R>(
   }
 }
 
+const makeCustomResetStore = () =>
+  TeamBuildingTypes.allowedNamespace.map(namespace => TeamBuildingGen.createTbResetStore({namespace}))
+
 export default function* commonSagas(namespace: TeamBuildingTypes.AllowedNamespace) {
+  yield* Saga.chainAction2(TeamBuildingGen.resetStore, makeCustomResetStore)
   yield* Saga.chainAction2(TeamBuildingGen.search, filterForNs(namespace, search))
   yield* Saga.chainAction2(TeamBuildingGen.fetchUserRecs, filterForNs(namespace, fetchUserRecs))
   // Navigation, before creating

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -819,6 +819,7 @@ export type TypedActionsMap = {
   'team-building:selectRole': teambuilding.SelectRolePayload
   'team-building:changeSendNotification': teambuilding.ChangeSendNotificationPayload
   'team-building:labelsSeen': teambuilding.LabelsSeenPayload
+  'team-building:tbResetStore': teambuilding.TbResetStorePayload
   'teams:addUserToTeams': teams.AddUserToTeamsPayload
   'teams:clearNavBadges': teams.ClearNavBadgesPayload
   'teams:createNewTeam': teams.CreateNewTeamPayload

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -2,7 +2,8 @@ import * as I from 'immutable'
 import {TeamRoleType} from './teams'
 import {ServiceId} from '../../util/platforms'
 
-export type AllowedNamespace = 'chat2' | 'teams' | 'people' | 'wallets'
+export const allowedNamespace = ['chat2', 'teams', 'people', 'wallets'] as const
+export type AllowedNamespace = typeof allowedNamespace[number]
 export type FollowingState = 'Following' | 'NotFollowing' | 'NoState' | 'You'
 export type ServiceId = ServiceId
 

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -8,6 +8,7 @@ import * as RPCChatTypes from '../constants/types/rpc-chat-gen'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as Types from '../constants/types/chat2'
 import teamBuildingReducer from './team-building'
+import {teamBuilderReducerCreator} from '../team-building/reducer-helper'
 import {isMobile} from '../constants/platform'
 import logger from '../logger'
 import HiddenString from '../util/hidden-string'
@@ -52,32 +53,6 @@ const messageIDToOrdinal = (
   }
 
   return null
-}
-
-const passToTeamBuildingReducer = (
-  draftState: Container.Draft<Types.State>,
-  action: TeamBuildingGen.Actions
-) => {
-  draftState.teamBuilding = teamBuildingReducer(
-    'chat2',
-    draftState.teamBuilding as Types.State['teamBuilding'],
-    action
-  )
-}
-
-const teamActions: Container.ActionHandler<Actions, Types.State> = {
-  [TeamBuildingGen.resetStore]: passToTeamBuildingReducer,
-  [TeamBuildingGen.cancelTeamBuilding]: passToTeamBuildingReducer,
-  [TeamBuildingGen.addUsersToTeamSoFar]: passToTeamBuildingReducer,
-  [TeamBuildingGen.removeUsersFromTeamSoFar]: passToTeamBuildingReducer,
-  [TeamBuildingGen.searchResultsLoaded]: passToTeamBuildingReducer,
-  [TeamBuildingGen.finishedTeamBuilding]: passToTeamBuildingReducer,
-  [TeamBuildingGen.fetchedUserRecs]: passToTeamBuildingReducer,
-  [TeamBuildingGen.fetchUserRecs]: passToTeamBuildingReducer,
-  [TeamBuildingGen.search]: passToTeamBuildingReducer,
-  [TeamBuildingGen.selectRole]: passToTeamBuildingReducer,
-  [TeamBuildingGen.labelsSeen]: passToTeamBuildingReducer,
-  [TeamBuildingGen.changeSendNotification]: passToTeamBuildingReducer,
 }
 
 const audioActions: Container.ActionHandler<Actions, Types.State> = {
@@ -1540,12 +1515,20 @@ const reducer = Container.makeReducer<Actions, Types.State>(initialState, {
   [Chat2Gen.clearMetas]: draftState => {
     draftState.metaMap.clear()
   },
-  ...teamActions,
   ...audioActions,
   ...giphyActions,
   ...paymentActions,
   ...searchActions,
   ...attachmentActions,
+  ...teamBuilderReducerCreator<Actions, Types.State>(
+    (draftState: Container.Draft<Types.State>, action: TeamBuildingGen.Actions) => {
+      draftState.teamBuilding = teamBuildingReducer(
+        'chat2',
+        draftState.teamBuilding as Types.State['teamBuilding'],
+        action
+      )
+    }
+  ),
 })
 
 export default reducer

--- a/shared/reducers/team-building.tsx
+++ b/shared/reducers/team-building.tsx
@@ -10,7 +10,7 @@ export default function(
   state: Types.TeamBuildingSubState,
   action: TeamBuildingGen.Actions
 ): Types.TeamBuildingSubState {
-  if (action.type === TeamBuildingGen.resetStore) {
+  if (action.type === TeamBuildingGen.resetStore || action.type === TeamBuildingGen.tbResetStore) {
     return Constants.makeSubState()
   }
 

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -233,7 +233,7 @@ export default (
         return
       }
 
-      case TeamBuildingGen.resetStore:
+      case TeamBuildingGen.tbResetStore:
       case TeamBuildingGen.cancelTeamBuilding:
       case TeamBuildingGen.addUsersToTeamSoFar:
       case TeamBuildingGen.removeUsersFromTeamSoFar:

--- a/shared/team-building/reducer-helper.tsx
+++ b/shared/team-building/reducer-helper.tsx
@@ -1,0 +1,28 @@
+import * as Container from '../util/container'
+import * as TeamBuildingGen from '../actions/team-building-gen'
+
+export function teamBuilderReducerCreator<Actions, State>(
+  callback: (draftState: Container.Draft<State>, action: TeamBuildingGen.Actions) => void
+) {
+  const allActions = [
+    // Note: NO RESET store. That's handled differently so we don't accidentally not get called
+    TeamBuildingGen.addUsersToTeamSoFar,
+    TeamBuildingGen.cancelTeamBuilding,
+    TeamBuildingGen.changeSendNotification,
+    TeamBuildingGen.fetchUserRecs,
+    TeamBuildingGen.fetchedUserRecs,
+    TeamBuildingGen.finishedTeamBuilding,
+    TeamBuildingGen.labelsSeen,
+    TeamBuildingGen.removeUsersFromTeamSoFar,
+    TeamBuildingGen.search,
+    TeamBuildingGen.searchResultsLoaded,
+    TeamBuildingGen.selectRole,
+    TeamBuildingGen.tbResetStore,
+  ]
+  const teamActions = allActions.reduce<Container.ActionHandler<Actions, State>>((arr, action) => {
+    arr[action] = callback
+    return arr
+  }, {})
+
+  return teamActions
+}


### PR DESCRIPTION
This fixes the issue where `resetStore` in the parent reducer and in the teamsbuilding reducer are in conflict. Before by convention we had large switch statements so the first item would win. With `makeReducer` it makes a map so the last item wins. We don't actually want either case. So now the team building uses a `chainAction` to make its own custom resetStore action that it can safely listen to

Also moved some helper stuff that was made for chat into a re-usable helper