### PR TITLE
folder_branch_ops: when syncing, set the prefetch action if needed 

### DIFF
--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -602,6 +602,18 @@ func (bra BlockRequestAction) AddSync() BlockRequestAction {
 	return bra | blockRequestSync
 }
 
+// AddPrefetch returns a new action that adds prefetching in addition
+// to the original request.  For sync requests, it returns a
+// deep-sync request (unlike `Combine`, which just adds the regular
+// prefetch bit).
+func (bra BlockRequestAction) AddPrefetch() BlockRequestAction {
+	if bra.Sync() {
+		return BlockRequestWithDeepSync
+	}
+
+	return bra | blockRequestPrefetch | blockRequestTrackedInPrefetch
+}
+
 // CacheType returns the disk block cache type that should be used,
 // according to the type of action.
 func (bra BlockRequestAction) CacheType() DiskBlockCacheType {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1687,10 +1687,17 @@ func (fbo *folderBranchOps) partialMarkAndSweepLoop(trigger <-chan struct{}) {
 func (fbo *folderBranchOps) kickOffRootBlockFetch(
 	ctx context.Context, rmd ImmutableRootMetadata) <-chan error {
 	ptr := rmd.Data().Dir.BlockPointer
+	action := fbo.config.Mode().DefaultBlockRequestAction().AddStopIfFull()
+	if !action.prefetch() && fbo.config.IsSyncedTlf(fbo.id()) {
+		// Explicitly add the prefetch action for synced folders when
+		// getting the root block, since in some modes (like
+		// constrained) the prefetch action isn't set by default.
+		action = action.AddPrefetch()
+	}
+
 	return fbo.config.BlockOps().BlockRetriever().Request(
 		ctx, defaultOnDemandRequestPriority-1, rmd, ptr, data.NewDirBlock(),
-		data.TransientEntry,
-		fbo.config.Mode().DefaultBlockRequestAction().AddStopIfFull())
+		data.TransientEntry, action)
 }
 
 func (fbo *folderBranchOps) logIfErr(

--- a/shared/settings/advanced/container.tsx
+++ b/shared/settings/advanced/container.tsx
@@ -44,7 +44,7 @@ const mapDispatchToProps = dispatch => ({
   onDisableCertPinning: () =>
     dispatch(RouteTreeGen.createNavigateAppend({path: ['disableCertPinningModal']})),
   onEnableCertPinning: () => dispatch(SettingsGen.createCertificatePinningToggled({toggled: false})),
-  onExtraKBFSLogging: () => dispatch(FSGen.createSetDebugLevel({level: 'vlog1'})),
+  onExtraKBFSLogging: () => dispatch(FSGen.createSetDebugLevel({level: 'vlog2'})),
   onProcessorProfile: (durationSeconds: number) =>
     dispatch(SettingsGen.createProcessorProfile({durationSeconds})),
   onSetOpenAtLogin: (openAtLogin: boolean) => dispatch(ConfigGen.createSetOpenAtLogin({openAtLogin})),


### PR DESCRIPTION
In constrained mode, the default block action does not prefetch.  But if the TLF is marked for syncing, we want it to prefetch even in constrained mode, so make that happen by adding it to the action.

Also, in the advanced settings in the GUI, set kbfs log level to 2, not 1, when enabling detailed logging.  Now that we might need to debug TLF syncing on mobile, we need to be
able to set the debug level up to 2, instead of 1.

