### PR TITLE
fix encrypting state for send animation

### DIFF
--- a/shared/chat/conversation/messages/wrapper/send-indicator/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/send-indicator/index.tsx
@@ -44,6 +44,7 @@ class SendIndicator extends React.Component<Props, State> {
       // Only show the `encrypting` icon for messages once
       if (shownEncryptingSet.has(this.props.id)) {
         state.animationStatus = 'encrypting'
+        this.encryptingTimeoutID = this.props.setTimeout(() => this._setStatus('sending'), encryptingTimeout)
       } else {
         state.animationStatus = 'sending'
       }
@@ -91,7 +92,13 @@ class SendIndicator extends React.Component<Props, State> {
     if (!(this.props.sent || this.props.failed)) {
       // Only show the `encrypting` icon for messages once
       if (!shownEncryptingSet.has(this.props.id)) {
-        this.encryptingTimeoutID = this.props.setTimeout(() => this._setStatus('sending'), encryptingTimeout)
+        this._setStatus('encrypting')
+        if (!this.encryptingTimeoutID) {
+          this.encryptingTimeoutID = this.props.setTimeout(
+            () => this._setStatus('sending'),
+            encryptingTimeout
+          )
+        }
         shownEncryptingSet.add(this.props.id)
       }
     }


### PR DESCRIPTION
Think we can just blow away the "encrypting" state here, since I think it makes the animation worse. But this should fix it at least from getting stuck in that state. On mobile these messages mount/unmount a bunch when sending for some reason, and so this logic was getting confused.

cc @adamjspooner @malgorithms 