### PR TITLE
Drop "Create an account".

### DIFF
--- a/shared/provision/username-or-email/index.tsx
+++ b/shared/provision/username-or-email/index.tsx
@@ -70,8 +70,6 @@ const Username = (props: Props) => {
       ]}
       onBack={props.onBack}
       title="Log in"
-      rightActionLabel="Create an account"
-      onRightAction={props.onGoToSignup}
       contentContainerStyle={styles.contentContainer}
     >
       <Kb.ScrollView


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. Design decided this feels squished on mobile (and isn't necessary; so, no need for desktop either).