### PR TITLE
folder_branch_ops: fix partial sync crash

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1196,6 +1196,11 @@ pathLoop:
 				fbo.vlog.CLogf(
 					ctx, libkb.VLog1, "Ignoring symlink path %s", p)
 				continue pathLoop
+			} else if currNode.EntryType() != data.Dir {
+				fbo.vlog.CLogf(
+					ctx, libkb.VLog1, "Ignoring non-dir path %s (%s)",
+					p, currNode.EntryType())
+				continue pathLoop
 			}
 
 			// Use `PrefetchTail` for directories, to make sure that


### PR DESCRIPTION
This is another in a series of crashes where the edit history is confused about a directory that apparently was later turned into a file, and when the partial sync code tries to lookup a subdirectory inside the newly-made file, KBFS panics.

In this case, the log doesn't go far enough back for me to tell if this is stemming from an old edit history bug that has already been fixed, or if there's something new to fix in that code.  In any case, this will fix the panic.

Issue: #20862