### PR TITLE
fix outbox badging

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -773,7 +773,8 @@ func (s *HybridInboxSource) ApplyLocalChatState(ctx context.Context, infos []key
 	localUpdates := make(map[string]chat1.LocalMtimeUpdate)
 	s.Debug(ctx, "ApplyLocalChatState: looking through %d outbox items for badgable errors", len(obrs))
 	for _, obr := range obrs {
-		if !(obr.Msg.IsBadgableType() && obr.Msg.ClientHeader.Conv.TopicType == chat1.TopicType_CHAT) {
+		if topicType := obr.Msg.ClientHeader.Conv.TopicType; !(obr.Msg.IsBadgableType() && topicType == chat1.TopicType_CHAT) {
+			s.Debug(ctx, "ApplyLocalChatState: skipping msgTyp: %v, topicType: %v", obr.Msg.MessageType(), topicType)
 			continue
 		}
 		state, err := obr.State.State()

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -767,13 +767,32 @@ func (s *HybridInboxSource) ApplyLocalChatState(ctx context.Context, infos []key
 		s.Debug(ctx, "ApplyLocalChatState: failed to get outbox: %v", oerr)
 	}
 
+	convIDs = nil
+	for _, obr := range obrs {
+		convIDs = append(convIDs, obr.ConvID)
+	}
+
+	_, convs, _, err = s.createInbox().Read(ctx, s.uid, &chat1.GetInboxQuery{
+		ConvIDs: convIDs,
+	}, nil)
+	if err != nil {
+		s.Debug(ctx, "ApplyLocalChatState: failed to get convs: %v", err)
+	}
+
+	obrConvMap := make(map[string]types.RemoteConversation)
+	for _, conv := range convs {
+		obrConvMap[conv.GetConvID().String()] = conv
+	}
+
 	// convID -> unreadCount
 	failedOutboxMap := make(map[string]int)
 	// convID -> mtime
 	localUpdates := make(map[string]chat1.LocalMtimeUpdate)
 	s.Debug(ctx, "ApplyLocalChatState: looking through %d outbox items for badgable errors", len(obrs))
 	for _, obr := range obrs {
-		if !(obr.Msg.IsBadgableType() && obr.Msg.ClientHeader.Conv.TopicType == chat1.TopicType_CHAT) {
+		conv := obrConvMap[obr.ConvID.String()]
+		if !(obr.Msg.IsBadgableType() && conv.GetTopicType() == chat1.TopicType_CHAT) {
+			s.Debug(ctx, "ApplyLocalChatState: skipping msgTyp: %v, topicType: %v", obr.Msg.MessageType(), conv.GetTopicType())
 			continue
 		}
 		state, err := obr.State.State()

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1713,6 +1713,7 @@ func (s *Deliverer) deliverForConv(ctx context.Context, obrs []chat1.OutboxRecor
 	for _, obr := range obrs {
 		bctx := globals.ChatCtx(context.Background(), s.G(), obr.IdentifyBehavior, &breaks,
 			s.identNotifier)
+
 		if s.testingNameInfoSource != nil {
 			bctx = globals.CtxAddOverrideNameInfoSource(bctx, s.testingNameInfoSource)
 		}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1713,7 +1713,6 @@ func (s *Deliverer) deliverForConv(ctx context.Context, obrs []chat1.OutboxRecor
 	for _, obr := range obrs {
 		bctx := globals.ChatCtx(context.Background(), s.G(), obr.IdentifyBehavior, &breaks,
 			s.identNotifier)
-
 		if s.testingNameInfoSource != nil {
 			bctx = globals.CtxAddOverrideNameInfoSource(bctx, s.testingNameInfoSource)
 		}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -991,6 +991,9 @@ func (h *Server) PostLocalNonblock(ctx context.Context, arg chat1.PostLocalNonbl
 	sender := NewBlockingSender(h.G(), h.boxer, h.remoteClient)
 	nonblockSender := NewNonblockingSender(h.G(), sender)
 	prepareOpts.ReplyTo = arg.ReplyTo
+	if arg.Msg.ClientHeader.Conv.TopicType == chat1.TopicType_NONE {
+		arg.Msg.ClientHeader.Conv.TopicType = chat1.TopicType_CHAT
+	}
 	obid, _, err := nonblockSender.Send(ctx, arg.ConversationID, arg.Msg, arg.ClientPrev, arg.OutboxID,
 		nil, &prepareOpts)
 	if err != nil {

--- a/go/kbfs/libkbfs/chat_rpc.go
+++ b/go/kbfs/libkbfs/chat_rpc.go
@@ -280,6 +280,9 @@ func (c *ChatRPC) SendTextMessage(
 		ConversationID: convID,
 		Msg: chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
+				Conv: chat1.ConversationIDTriple{
+					TopicType: chat1.TopicType_KBFSFILEEDIT,
+				},
 				TlfName:     string(tlfName),
 				TlfPublic:   tlfType == tlf.Public,
 				MessageType: chat1.MessageType_TEXT,
@@ -338,6 +341,9 @@ func (c *ChatRPC) SendTextMessage(
 		ConversationID: selfConvID,
 		Msg: chat1.MessagePlaintext{
 			ClientHeader: chat1.MessageClientHeader{
+				Conv: chat1.ConversationIDTriple{
+					TopicType: chat1.TopicType_KBFSFILEEDIT,
+				},
 				TlfName:     string(session.Name),
 				TlfPublic:   false,
 				MessageType: chat1.MessageType_TEXT,


### PR DESCRIPTION
`TopicType` is not set on messages in the outbox, this happens during the `Prepare` when the message is sent. To only badge failed outbox items for CHAT type conversations we look at the `TopicType` from the conversation instead.