### PR TITLE
kbfsgit: support for LFS initialization and uploads in the runner

### DIFF
--- a/go/kbfs/kbfsgit/git-remote-keybase/main.go
+++ b/go/kbfs/kbfsgit/git-remote-keybase/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/keybase/client/go/kbconst"
 	"github.com/keybase/client/go/kbfs/env"
@@ -125,6 +126,14 @@ func start() (startErr *libfs.Error) {
 	var repo string
 	if len(flag.Args()) > 1 {
 		repo = flag.Arg(1)
+	} else {
+		// For LFS invocation, the arguments actually come together in
+		// a single quoted argument for some reason.
+		s := strings.Split(remote, " ")
+		if len(s) > 1 {
+			remote = s[0]
+			repo = s[1]
+		}
 	}
 
 	if len(flag.Args()) > 2 {

--- a/go/kbfs/kbfsgit/git-remote-keybase/main.go
+++ b/go/kbfs/kbfsgit/git-remote-keybase/main.go
@@ -124,15 +124,17 @@ func start() (startErr *libfs.Error) {
 
 	remote := flag.Arg(0)
 	var repo string
+	lfs := false
 	if len(flag.Args()) > 1 {
 		repo = flag.Arg(1)
 	} else {
 		// For LFS invocation, the arguments actually come together in
 		// a single quoted argument for some reason.
 		s := strings.Split(remote, " ")
-		if len(s) > 1 {
-			remote = s[0]
-			repo = s[1]
+		if len(s) > 2 {
+			lfs = s[0] == "lfs"
+			remote = s[1]
+			repo = s[2]
 		}
 	}
 
@@ -146,11 +148,13 @@ func start() (startErr *libfs.Error) {
 		Remote:     remote,
 		Repo:       repo,
 		GitDir:     getLocalGitDir(),
+		LFS:        lfs,
 	}
 
 	ctx := context.Background()
 	return kbfsgit.Start(
-		ctx, options, kbCtx, defaultLogPath, os.Stdin, os.Stdout, stderrFile)
+		ctx, options, kbCtx, defaultLogPath, os.Stdin, os.Stdout,
+		stderrFile)
 }
 
 func main() {

--- a/go/kbfs/kbfsgit/start.go
+++ b/go/kbfs/kbfsgit/start.go
@@ -25,6 +25,9 @@ type StartOptions struct {
 	// GitDir is the filepath leading to the .git directory of the
 	// caller's local on-disk repo.
 	GitDir string
+	// LFS indicates whether we should listen for LFS commands instead
+	// of normal git commands.
+	LFS bool
 }
 
 // Start starts the kbfsgit logic, and begins listening for git
@@ -61,9 +64,13 @@ func Start(ctx context.Context, options StartOptions,
 		return libfs.InitError(err.Error())
 	}
 
-	r, err := newRunner(
+	t := processGit
+	if options.LFS {
+		t = processLFS
+	}
+	r, err := newRunnerWithType(
 		ctx, config, options.Remote, options.Repo, options.GitDir,
-		input, output, errput)
+		input, output, errput, t)
 	if err != nil {
 		return libfs.InitError(err.Error())
 	}


### PR DESCRIPTION
With this commit, and git-lfs installed, a user can add the following config to their local git checkout for a keybase repo:

```
[lfs "customtransfer.keybase-lfs"]
        path = git-remote-keybase
        args = lfs origin keybase://type/name/repo
```

And LFS-tracked files will be saved under `.kbfs_git/repo/kbfs_lfs/` in the corresponding TLF.

Still TODO: download support, progress support, and auto-config with a command.  Also it has only been tested on Linux so far.

I won't merge this until after the release's code freeze.

Issue: HOTPOT-1273