### PR TITLE
Team meta update strategy

### DIFF
--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -50,7 +50,8 @@
     },
     "getTeams": {
       "_description": "Load team list if we are stale.",
-      "forceReload?": "boolean"
+      "forceReload?": "boolean",
+      "subscribeReason?": ["'teamList'", "'gitNewRepo'", "'profileShowcaseTeams'"]
     },
     "getDetails": {
       "teamname": "string",

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -48,7 +48,10 @@
       "_description": "Fetches the channel information for all channels in a team from the server. Should only be called for components that need the full list.",
       "teamname": "string"
     },
-    "getTeams": {},
+    "getTeams": {
+      "_description": "Load team list if we are stale.",
+      "forceReload?": "boolean"
+    },
     "getDetails": {
       "teamname": "string",
       "clearInviteLoadingKey?": "string"

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -49,9 +49,9 @@
       "teamname": "string"
     },
     "getTeams": {
-      "_description": "Load team list if we are stale.",
-      "forceReload?": "boolean",
-      "subscribeReason?": ["'teamList'", "'gitNewRepo'", "'profileShowcaseTeams'"]
+      "_description": "Load team list if we are stale. _subscribe is for use by teams/subscriber only.",
+      "_subscribe?": "boolean",
+      "forceReload?": "boolean"
     },
     "unsubscribeTeamList": {
       "_description": "Don't eagerly reload team list anymore."

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -53,6 +53,9 @@
       "forceReload?": "boolean",
       "subscribeReason?": ["'teamList'", "'gitNewRepo'", "'profileShowcaseTeams'"]
     },
+    "unsubscribeTeamList": {
+      "_description": "Don't eagerly reload team list anymore."
+    },
     "getDetails": {
       "teamname": "string",
       "clearInviteLoadingKey?": "string"

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -142,10 +142,7 @@ type _GetMembersPayload = {readonly teamname: string}
 type _GetTeamProfileAddListPayload = {readonly username: string}
 type _GetTeamPublicityPayload = {readonly teamname: string}
 type _GetTeamRetentionPolicyPayload = {readonly teamname: string}
-type _GetTeamsPayload = {
-  readonly forceReload?: boolean
-  readonly subscribeReason?: 'teamList' | 'gitNewRepo' | 'profileShowcaseTeams'
-}
+type _GetTeamsPayload = {readonly _subscribe?: boolean; readonly forceReload?: boolean}
 type _IgnoreRequestPayload = {readonly teamname: string; readonly username: string}
 type _InviteToTeamByEmailPayload = {
   readonly destSubPath?: I.List<string>
@@ -308,7 +305,7 @@ export const createGetTeamRetentionPolicy = (
   payload: _GetTeamRetentionPolicyPayload
 ): GetTeamRetentionPolicyPayload => ({payload, type: getTeamRetentionPolicy})
 /**
- * Load team list if we are stale.
+ * Load team list if we are stale. _subscribe is for use by teams/subscriber only.
  */
 export const createGetTeams = (payload: _GetTeamsPayload = Object.freeze({})): GetTeamsPayload => ({
   payload,

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -72,6 +72,7 @@ export const setTeamSawSubteamsBanner = 'teams:setTeamSawSubteamsBanner'
 export const setTeamsWithChosenChannels = 'teams:setTeamsWithChosenChannels'
 export const setUpdatedChannelName = 'teams:setUpdatedChannelName'
 export const setUpdatedTopic = 'teams:setUpdatedTopic'
+export const unsubscribeTeamList = 'teams:unsubscribeTeamList'
 export const updateChannelName = 'teams:updateChannelName'
 export const updateTopic = 'teams:updateTopic'
 export const uploadTeamAvatar = 'teams:uploadTeamAvatar'
@@ -261,6 +262,7 @@ type _SetUpdatedTopicPayload = {
   readonly conversationIDKey: ChatTypes.ConversationIDKey
   readonly newTopic: string
 }
+type _UnsubscribeTeamListPayload = void
 type _UpdateChannelNamePayload = {
   readonly teamname: Types.Teamname
   readonly conversationIDKey: ChatTypes.ConversationIDKey
@@ -279,6 +281,12 @@ type _UploadTeamAvatarPayload = {
 }
 
 // Action Creators
+/**
+ * Don't eagerly reload team list anymore.
+ */
+export const createUnsubscribeTeamList = (
+  payload: _UnsubscribeTeamListPayload
+): UnsubscribeTeamListPayload => ({payload, type: unsubscribeTeamList})
 /**
  * Fetches the channel information for a single channel in a team from the server.
  */
@@ -745,6 +753,10 @@ export type SetUpdatedTopicPayload = {
   readonly payload: _SetUpdatedTopicPayload
   readonly type: typeof setUpdatedTopic
 }
+export type UnsubscribeTeamListPayload = {
+  readonly payload: _UnsubscribeTeamListPayload
+  readonly type: typeof unsubscribeTeamList
+}
 export type UpdateChannelNamePayload = {
   readonly payload: _UpdateChannelNamePayload
   readonly type: typeof updateChannelName
@@ -822,6 +834,7 @@ export type Actions =
   | SetTeamsWithChosenChannelsPayload
   | SetUpdatedChannelNamePayload
   | SetUpdatedTopicPayload
+  | UnsubscribeTeamListPayload
   | UpdateChannelNamePayload
   | UpdateTopicPayload
   | UploadTeamAvatarPayload

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -141,7 +141,10 @@ type _GetMembersPayload = {readonly teamname: string}
 type _GetTeamProfileAddListPayload = {readonly username: string}
 type _GetTeamPublicityPayload = {readonly teamname: string}
 type _GetTeamRetentionPolicyPayload = {readonly teamname: string}
-type _GetTeamsPayload = {readonly forceReload?: boolean}
+type _GetTeamsPayload = {
+  readonly forceReload?: boolean
+  readonly subscribeReason?: 'teamList' | 'gitNewRepo' | 'profileShowcaseTeams'
+}
 type _IgnoreRequestPayload = {readonly teamname: string; readonly username: string}
 type _InviteToTeamByEmailPayload = {
   readonly destSubPath?: I.List<string>

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -141,7 +141,7 @@ type _GetMembersPayload = {readonly teamname: string}
 type _GetTeamProfileAddListPayload = {readonly username: string}
 type _GetTeamPublicityPayload = {readonly teamname: string}
 type _GetTeamRetentionPolicyPayload = {readonly teamname: string}
-type _GetTeamsPayload = void
+type _GetTeamsPayload = {readonly forceReload?: boolean}
 type _IgnoreRequestPayload = {readonly teamname: string; readonly username: string}
 type _InviteToTeamByEmailPayload = {
   readonly destSubPath?: I.List<string>
@@ -297,6 +297,13 @@ export const createGetTeamRetentionPolicy = (
   payload: _GetTeamRetentionPolicyPayload
 ): GetTeamRetentionPolicyPayload => ({payload, type: getTeamRetentionPolicy})
 /**
+ * Load team list if we are stale.
+ */
+export const createGetTeams = (payload: _GetTeamsPayload = Object.freeze({})): GetTeamsPayload => ({
+  payload,
+  type: getTeams,
+})
+/**
  * Rename a subteam
  */
 export const createRenameTeam = (payload: _RenameTeamPayload): RenameTeamPayload => ({
@@ -383,7 +390,6 @@ export const createGetTeamPublicity = (payload: _GetTeamPublicityPayload): GetTe
   payload,
   type: getTeamPublicity,
 })
-export const createGetTeams = (payload: _GetTeamsPayload): GetTeamsPayload => ({payload, type: getTeams})
 export const createIgnoreRequest = (payload: _IgnoreRequestPayload): IgnoreRequestPayload => ({
   payload,
   type: ignoreRequest,

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1155,12 +1155,6 @@ const reloadTeamListIfSubscribed = (state: TypedState, _, logger: Saga.SagaLogge
   return false
 }
 
-const teamListUnsubActions = [
-  RouteTreeGen.navigateAppend,
-  RouteTreeGen.navigateUp,
-  RouteTreeGen.switchTab,
-  RouteTreeGen.switchLoggedIn,
-] as const
 const teamListUnsubscribe = (state: TypedState, _, logger: Saga.SagaLogger) => {
   // This is not an airtight listener, we may navigate away from a page that
   // previously subscribed without getting here. The point is to _eventually_
@@ -1557,7 +1551,16 @@ const teamsSaga = function*() {
     reloadTeamListIfSubscribed,
     'reloadTeamListIfSubscribed'
   )
-  yield* Saga.chainAction2(teamListUnsubActions, teamListUnsubscribe, 'teamListUnsubscribe')
+  yield* Saga.chainAction2(
+    [
+      RouteTreeGen.navigateAppend,
+      RouteTreeGen.navigateUp,
+      RouteTreeGen.switchTab,
+      RouteTreeGen.switchLoggedIn,
+    ],
+    teamListUnsubscribe,
+    'teamListUnsubscribe'
+  )
 
   yield* Saga.chainAction2(TeamsGen.clearNavBadges, clearNavBadges)
 

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -746,13 +746,18 @@ const getChannels = async (_: TypedState, action: TeamsGen.GetChannelsPayload) =
 
 function* getTeams(
   state: TypedState,
-  _: ConfigGen.StartupFirstIdlePayload | TeamsGen.GetTeamsPayload | TeamsGen.LeftTeamPayload,
+  action: ConfigGen.StartupFirstIdlePayload | TeamsGen.GetTeamsPayload | TeamsGen.LeftTeamPayload,
   logger: Saga.SagaLogger
 ) {
   const username = state.config.username
   if (!username) {
     logger.warn('getTeams while logged out')
     return
+  }
+  if (action.type === TeamsGen.getTeams) {
+    if (!action.payload.forceReload && !state.teams.teamDetailsMetaStale) {
+      return
+    }
   }
   try {
     const results: Saga.RPCPromiseType<typeof RPCTypes.teamsTeamListUnverifiedRpcPromise> = yield RPCTypes.teamsTeamListUnverifiedRpcPromise(

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -955,14 +955,14 @@ const setMemberPublicity = async (_: TypedState, action: TeamsGen.SetMemberPubli
     return [
       TeamsGen.createGetDetails({teamname}),
       // The profile showcasing page gets this data from teamList rather than teamGet, so trigger one of those too.
-      TeamsGen.createGetTeams(),
+      // TeamsGen.createGetTeams(), // TODO Y2K-974 probably broken
     ]
   } catch (_) {
     // TODO handle error, but for now make sure loading is unset
     return [
       TeamsGen.createGetDetails({teamname}),
       // The profile showcasing page gets this data from teamList rather than teamGet, so trigger one of those too.
-      TeamsGen.createGetTeams(),
+      // TeamsGen.createGetTeams(), // TODO Y2K-974 probably broken
     ]
   }
 }
@@ -1088,7 +1088,7 @@ const teamChangedByID = (state: TypedState, action: EngineGen.Keybase1NotifyTeam
   if (selectedTeams.includes(teamID) && _wasOnTeamsTab()) {
     // only reload if that team is selected
     const teamname = Constants.getTeamNameFromID(state, teamID)
-    return [TeamsGen.createGetTeams(), !!teamname && TeamsGen.createGetDetails({teamname})]
+    return [!!teamname && TeamsGen.createGetDetails({teamname})]
   }
   return getLoadCalls()
 }
@@ -1135,10 +1135,7 @@ const teamDeletedOrExit = (
   return getLoadCalls()
 }
 
-const getLoadCalls = (teamname?: string) => [
-  ...(_wasOnTeamsTab() ? [TeamsGen.createGetTeams()] : []),
-  ...(teamname ? [TeamsGen.createGetDetails({teamname})] : []),
-]
+const getLoadCalls = (teamname?: string) => (teamname ? [TeamsGen.createGetDetails({teamname})] : [])
 
 const updateTopic = async (_: TypedState, action: TeamsGen.UpdateTopicPayload) => {
   const {teamname, conversationIDKey, newTopic} = action.payload
@@ -1277,7 +1274,7 @@ const badgeAppForTeams = (state: TypedState, action: NotificationsGen.ReceivedBa
   }
   const {badgeState} = action.payload
 
-  let actions: Array<TypedActions> = []
+  const actions: Array<TypedActions> = []
   const deletedTeams = badgeState.deletedTeams || []
   const newTeams = new Set<string>(badgeState.newTeams || [])
   const newTeamRequests = badgeState.newTeamAccessRequests || []
@@ -1333,7 +1330,7 @@ const badgeAppForTeams = (state: TypedState, action: NotificationsGen.ReceivedBa
   return actions
 }
 
-let _wasOnTeamsTab = () => Constants.isOnTeamsTab()
+const _wasOnTeamsTab = () => Constants.isOnTeamsTab()
 
 const gregorPushState = (_: TypedState, action: GregorGen.PushStatePayload) => {
   const actions: Array<TypedActions> = []

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1162,6 +1162,9 @@ const teamListUnsubActions = [
   RouteTreeGen.switchLoggedIn,
 ] as const
 const teamListUnsubscribe = (state: TypedState, _, logger: Saga.SagaLogger) => {
+  // This is not an airtight listener, we may navigate away from a page that
+  // previously subscribed without getting here. The point is to _eventually_
+  // unsubscribe as users move around the app.
   if (state.teams.teamDetailsMetaSubscribed) {
     logger.info('unsubscribing')
     return TeamsGen.createUnsubscribeTeamList()

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -829,6 +829,7 @@ export type TypedActionsMap = {
   'teams:getChannelInfo': teams.GetChannelInfoPayload
   'teams:getChannels': teams.GetChannelsPayload
   'teams:getTeams': teams.GetTeamsPayload
+  'teams:unsubscribeTeamList': teams.UnsubscribeTeamListPayload
   'teams:getDetails': teams.GetDetailsPayload
   'teams:getMembers': teams.GetMembersPayload
   'teams:setMembers': teams.SetMembersPayload

--- a/shared/chat/conversation/info-panel/menu/container.tsx
+++ b/shared/chat/conversation/info-panel/menu/container.tsx
@@ -23,13 +23,16 @@ export type OwnProps = {
 
 // can be expensive, don't run if not visible
 const moreThanOneSubscribedChannel = (
-  metaMap: Container.TypedState['chat2']['metaMap'],
+  inboxLayout: Container.TypedState['chat2']['inboxLayout'],
   teamname?: string
 ) => {
-  // TODO don't use metamap here, it only has a subset of your convs
+  if (!inboxLayout || !inboxLayout.bigTeams) {
+    return false
+  }
+  const bigTeams = inboxLayout.bigTeams
   let found = 0
-  return [...metaMap.values()].some(c => {
-    if (c.teamname === teamname) {
+  return bigTeams.some(c => {
+    if (c.state === RPCChatTypes.UIInboxBigTeamRowTyp.channel && c.channel.teamname === teamname) {
       found++
     }
     // got enough
@@ -88,7 +91,7 @@ export default Container.namedConnect(
 
     const manageChannelsTitle = isSmallTeam
       ? 'Create chat channels...'
-      : moreThanOneSubscribedChannel(state.chat2.metaMap, teamname)
+      : moreThanOneSubscribedChannel(state.chat2.inboxLayout, teamname)
       ? 'Manage chat channels'
       : 'Subscribe to channels...'
     const manageChannelsSubtitle = isSmallTeam ? 'Turns this into a big team' : ''

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -179,6 +179,7 @@ const emptyState: Types.State = {
   teamCreationError: '',
   teamDetails: new Map(),
   teamDetailsMetaStale: true, // start out true, we have not loaded
+  teamDetailsMetaSubscribed: false,
   teamInviteError: '',
   teamJoinError: '',
   teamJoinSuccess: false,

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -178,7 +178,7 @@ const emptyState: Types.State = {
   teamBuilding: TeamBuildingConstants.makeSubState(),
   teamCreationError: '',
   teamDetails: new Map(),
-  teamDetailsMetaStale: false,
+  teamDetailsMetaStale: true, // start out true, we have not loaded
   teamInviteError: '',
   teamJoinError: '',
   teamJoinSuccess: false,

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -178,6 +178,7 @@ const emptyState: Types.State = {
   teamBuilding: TeamBuildingConstants.makeSubState(),
   teamCreationError: '',
   teamDetails: new Map(),
+  teamDetailsMetaStale: false,
   teamInviteError: '',
   teamJoinError: '',
   teamJoinSuccess: false,

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -179,7 +179,7 @@ const emptyState: Types.State = {
   teamCreationError: '',
   teamDetails: new Map(),
   teamDetailsMetaStale: true, // start out true, we have not loaded
-  teamDetailsMetaSubscribed: false,
+  teamDetailsMetaSubscribeCount: 0,
   teamInviteError: '',
   teamJoinError: '',
   teamJoinSuccess: false,

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -150,7 +150,7 @@ export type State = Readonly<{
   teamCreationError: string
   teamDetails: Map<TeamID, TeamDetails>
   teamDetailsMetaStale: boolean // if we've received an update since we last loaded team list
-  teamDetailsMetaSubscribed: boolean // if we are eagerly reloading team list
+  teamDetailsMetaSubscribeCount: number // if >0 we are eagerly reloading team list
   teamNameToChannelInfos: I.Map<Teamname, I.Map<ConversationIDKey, ChannelInfo>>
   teamNameToID: I.Map<Teamname, string>
   teamNameToInvites: I.Map<Teamname, I.Set<InviteInfo>> // TODO remove

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -159,7 +159,7 @@ export type State = Readonly<{
   teamNameToRequests: I.Map<Teamname, I.Set<string>> // TODO remove
   teamNameToResetUsers: I.Map<Teamname, I.Set<ResetUser>>
   teamNameToRetentionPolicy: I.Map<Teamname, RetentionPolicy>
-  teamNameToRole: I.Map<Teamname, MaybeTeamRoleType>
+  teamNameToRole: I.Map<Teamname, MaybeTeamRoleType> // TODO remove
   teamNameToSubteams: I.Map<Teamname, I.Set<Teamname>> // TODO remove
   teamNameToCanPerform: I.Map<Teamname, TeamOperations> // TODO remove
   teamNameToSettings: I.Map<Teamname, TeamSettings>
@@ -167,7 +167,7 @@ export type State = Readonly<{
   teamNameToAllowPromote: I.Map<Teamname, boolean> // TODO remove
   teamNameToIsShowcasing: I.Map<Teamname, boolean> // TODO remove
   teamnames: Set<Teamname> // TODO remove
-  teammembercounts: I.Map<Teamname, number>
+  teammembercounts: I.Map<Teamname, number> // TODO remove
   teamProfileAddList: Array<TeamProfileAddList>
   teamRoleMap: TeamRoleMap
   newTeams: Set<TeamID>

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -149,6 +149,7 @@ export type State = Readonly<{
   teamJoinSuccessTeamName: string
   teamCreationError: string
   teamDetails: Map<TeamID, TeamDetails>
+  teamDetailsMetaStale: boolean // if we've received a teamMetadataUpdate since we last loaded team list
   teamNameToChannelInfos: I.Map<Teamname, I.Map<ConversationIDKey, ChannelInfo>>
   teamNameToID: I.Map<Teamname, string>
   teamNameToInvites: I.Map<Teamname, I.Set<InviteInfo>> // TODO remove

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -149,7 +149,8 @@ export type State = Readonly<{
   teamJoinSuccessTeamName: string
   teamCreationError: string
   teamDetails: Map<TeamID, TeamDetails>
-  teamDetailsMetaStale: boolean // if we've received a teamMetadataUpdate since we last loaded team list
+  teamDetailsMetaStale: boolean // if we've received an update since we last loaded team list
+  teamDetailsMetaSubscribed: boolean // if we are eagerly reloading team list
   teamNameToChannelInfos: I.Map<Teamname, I.Map<ConversationIDKey, ChannelInfo>>
   teamNameToID: I.Map<Teamname, string>
   teamNameToInvites: I.Map<Teamname, I.Set<InviteInfo>> // TODO remove

--- a/shared/git/new-repo/container.tsx
+++ b/shared/git/new-repo/container.tsx
@@ -17,7 +17,7 @@ export default Container.connect(
     waitingKey: Constants.loadingWaitingKey,
   }),
   (dispatch, ownProps: OwnProps) => ({
-    loadTeams: () => dispatch(TeamsGen.createGetTeams({subscribeReason: 'gitNewRepo'})),
+    loadTeams: () => dispatch(TeamsGen.createGetTeams()),
     onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),
     onClose: () => dispatch(RouteTreeGen.createNavigateUp()),
     onCreate: (name: string, teamname: string | null, notifyTeam: boolean) => {

--- a/shared/git/new-repo/container.tsx
+++ b/shared/git/new-repo/container.tsx
@@ -17,7 +17,7 @@ export default Container.connect(
     waitingKey: Constants.loadingWaitingKey,
   }),
   (dispatch, ownProps: OwnProps) => ({
-    loadTeams: () => dispatch(TeamsGen.createGetTeams()),
+    loadTeams: () => dispatch(TeamsGen.createGetTeams({subscribeReason: 'gitNewRepo'})),
     onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),
     onClose: () => dispatch(RouteTreeGen.createNavigateUp()),
     onCreate: (name: string, teamname: string | null, notifyTeam: boolean) => {

--- a/shared/override-d.ts/@react-navigation/core/index.d.ts
+++ b/shared/override-d.ts/@react-navigation/core/index.d.ts
@@ -2,6 +2,7 @@ declare module '@react-navigation/core' {
   export {
     NavigationActions,
     NavigationContext,
+    NavigationEventCallback,
     NavigationEvents,
     NavigationInjectedProps,
     NavigationParams,

--- a/shared/profile/routes.tsx
+++ b/shared/profile/routes.tsx
@@ -46,8 +46,8 @@ export const newModalRoutes = {
     getScreen: (): typeof ProfileProveWebsiteChoice => require('./prove-website-choice/container').default,
   },
   profileRevoke: {getScreen: (): typeof ProfileRevoke => require('./revoke/container').default},
-  // TODO broken connect
   profileShowcaseTeamOffer: {
+    // @ts-ignore HeaderOrPopup typing busted
     getScreen: (): typeof ProfileShowcaseTeamOffer => require('./showcase-team-offer/container').default,
   },
   ...PGPRoutes,

--- a/shared/profile/showcase-team-offer/container.tsx
+++ b/shared/profile/showcase-team-offer/container.tsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state: Container.TypedState) => {
 }
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
-  loadTeams: () => dispatch(TeamsGen.createGetTeams()),
+  loadTeams: () => dispatch(TeamsGen.createGetTeams({subscribeReason: 'profileShowcaseTeams'})),
   onCancel: (you: string) => {
     // sadly a little racy, doing this for now
     setTimeout(() => {

--- a/shared/profile/showcase-team-offer/container.tsx
+++ b/shared/profile/showcase-team-offer/container.tsx
@@ -25,7 +25,6 @@ const mapStateToProps = (state: Container.TypedState) => {
 }
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
-  loadTeams: () => dispatch(TeamsGen.createGetTeams({subscribeReason: 'profileShowcaseTeams'})),
   onCancel: (you: string) => {
     // sadly a little racy, doing this for now
     setTimeout(() => {
@@ -45,10 +44,11 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
     dispatch(TeamsGen.createSetMemberPublicity({showcase, teamname})),
 })
 
-export default Container.compose(
-  Container.connect(mapStateToProps, mapDispatchToProps, (stateProps, dispatchProps, _: OwnProps) => {
+export default Container.connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  (stateProps, dispatchProps, _: OwnProps) => {
     return {
-      ...stateProps,
       ...dispatchProps,
       customCancelText: 'Close',
       onCancel: () => dispatchProps.onCancel(stateProps._you),
@@ -57,13 +57,9 @@ export default Container.compose(
       teamNameToIsShowcasing: stateProps._teamNameToIsShowcasing.toObject(),
       teamNameToRole: stateProps._teamNameToRole.toObject(),
       teammembercounts: stateProps._teammembercounts.toObject(),
+      teamnames: stateProps.teamnames,
       title: 'Publish your teams',
       waiting: stateProps._waiting,
     }
-  }),
-  Container.lifecycle({
-    componentDidMount() {
-      this.props.loadTeams()
-    },
-  } as any)
+  }
 )(HeaderOrPopup(Render))

--- a/shared/profile/showcase-team-offer/index.tsx
+++ b/shared/profile/showcase-team-offer/index.tsx
@@ -3,6 +3,7 @@ import * as Styles from '../../styles'
 import * as Kb from '../../common-adapters'
 import {teamWaitingKey} from '../../constants/teams'
 import * as Types from '../../constants/types/teams'
+import {useTeamsSubscribe} from '../../teams/subscriber'
 
 export type RowProps = {
   canShowcase: boolean
@@ -95,31 +96,34 @@ const ShowcaseTeamOfferHeader = () => (
   </Kb.Box>
 )
 
-const ShowcaseTeamOffer = (props: Props) => (
-  <Kb.Box2 direction="vertical" style={styles.container}>
-    {!Styles.isMobile && <ShowcaseTeamOfferHeader />}
-    <Kb.ScrollView>
-      {Styles.isMobile && <ShowcaseTeamOfferHeader />}
-      {props.teamnames &&
-        props.teamnames.map(name => (
-          <TeamRow
-            canShowcase={
-              (props.teamNameToRole[name] !== 'none' && props.teamNameToAllowPromote[name]) ||
-              ['admin', 'owner'].indexOf(props.teamNameToRole[name]) !== -1
-            }
-            isExplicitMember={props.teamNameToRole[name] !== 'none'}
-            key={name}
-            name={name}
-            isOpen={props.teamNameToIsOpen[name]}
-            membercount={props.teammembercounts[name]}
-            onPromote={promoted => props.onPromote(name, promoted)}
-            showcased={props.teamNameToIsShowcasing[name]}
-            waiting={!!props.waiting[teamWaitingKey(name)]}
-          />
-        ))}
-    </Kb.ScrollView>
-  </Kb.Box2>
-)
+const ShowcaseTeamOffer = (props: Props) => {
+  useTeamsSubscribe()
+  return (
+    <Kb.Box2 direction="vertical" style={styles.container}>
+      {!Styles.isMobile && <ShowcaseTeamOfferHeader />}
+      <Kb.ScrollView>
+        {Styles.isMobile && <ShowcaseTeamOfferHeader />}
+        {props.teamnames &&
+          props.teamnames.map(name => (
+            <TeamRow
+              canShowcase={
+                (props.teamNameToRole[name] !== 'none' && props.teamNameToAllowPromote[name]) ||
+                ['admin', 'owner'].indexOf(props.teamNameToRole[name]) !== -1
+              }
+              isExplicitMember={props.teamNameToRole[name] !== 'none'}
+              key={name}
+              name={name}
+              isOpen={props.teamNameToIsOpen[name]}
+              membercount={props.teammembercounts[name]}
+              onPromote={promoted => props.onPromote(name, promoted)}
+              showcased={props.teamNameToIsShowcasing[name]}
+              waiting={!!props.waiting[teamWaitingKey(name)]}
+            />
+          ))}
+      </Kb.ScrollView>
+    </Kb.Box2>
+  )
+}
 
 const styles = Styles.styleSheetCreate(
   () =>

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -154,6 +154,9 @@ export default (
           draftState.teamDetailsMetaSubscribed = true
         }
         return
+      case TeamsGen.unsubscribeTeamList:
+        draftState.teamDetailsMetaSubscribed = false
+        return
       case TeamsGen.setTeamInfo:
         draftState.teamNameToAllowPromote = action.payload.teamNameToAllowPromote
         draftState.teamNameToID = action.payload.teamNameToID

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -1,9 +1,10 @@
 import * as TeamsGen from '../actions/teams-gen'
+import * as TeamBuildingGen from '../actions/team-building-gen'
+import * as EngineGen from '../actions/engine-gen-gen'
 import * as Constants from '../constants/teams'
 import * as I from 'immutable'
 import * as Types from '../constants/types/teams'
 import * as RPCChatTypes from '../constants/types/rpc-chat-gen'
-import * as TeamBuildingGen from '../actions/team-building-gen'
 import * as Container from '../util/container'
 import {TeamBuildingSubState} from '../constants/types/team-building'
 import teamBuildingReducer from './team-building'
@@ -13,7 +14,7 @@ const initialState: Types.State = Constants.makeState()
 
 export default (
   state: Types.State = initialState,
-  action: TeamsGen.Actions | TeamBuildingGen.Actions
+  action: TeamsGen.Actions | TeamBuildingGen.Actions | EngineGen.Keybase1NotifyTeamTeamMetadataUpdatePayload
 ): Types.State =>
   Container.produce(state, (draftState: Container.Draft<Types.State>) => {
     switch (action.type) {
@@ -160,6 +161,10 @@ export default (
           draftState.teamDetails,
           action.payload.teamDetails
         )
+        draftState.teamDetailsMetaStale = false
+        return
+      case EngineGen.keybase1NotifyTeamTeamMetadataUpdate:
+        draftState.teamDetailsMetaStale = true
         return
       case TeamsGen.setTeamAccessRequestsPending:
         draftState.teamAccessRequestsPending = action.payload.accessRequestsPending

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -150,12 +150,14 @@ export default (
         draftState.emailInviteError.message = action.payload.message
         return
       case TeamsGen.getTeams:
-        if (action.payload.subscribeReason) {
-          draftState.teamDetailsMetaSubscribed = true
+        if (action.payload._subscribe) {
+          draftState.teamDetailsMetaSubscribeCount++
         }
         return
       case TeamsGen.unsubscribeTeamList:
-        draftState.teamDetailsMetaSubscribed = false
+        if (draftState.teamDetailsMetaSubscribeCount > 0) {
+          draftState.teamDetailsMetaSubscribeCount--
+        }
         return
       case TeamsGen.setTeamInfo:
         draftState.teamNameToAllowPromote = action.payload.teamNameToAllowPromote

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -149,6 +149,11 @@ export default (
         draftState.emailInviteError.malformed = new Set(action.payload.malformed)
         draftState.emailInviteError.message = action.payload.message
         return
+      case TeamsGen.getTeams:
+        if (action.payload.subscribeReason) {
+          draftState.teamDetailsMetaSubscribed = true
+        }
+        return
       case TeamsGen.setTeamInfo:
         draftState.teamNameToAllowPromote = action.payload.teamNameToAllowPromote
         draftState.teamNameToID = action.payload.teamNameToID
@@ -289,7 +294,6 @@ export default (
       case TeamsGen.getTeamProfileAddList:
       case TeamsGen.getTeamPublicity:
       case TeamsGen.getTeamRetentionPolicy:
-      case TeamsGen.getTeams:
       case TeamsGen.addTeamWithChosenChannels:
       case TeamsGen.ignoreRequest:
       case TeamsGen.inviteToTeamByEmail:

--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -56,7 +56,7 @@ class Reloadable extends React.PureComponent<Props & {loadTeams: () => void; onC
   render() {
     const {loadTeams, ...rest} = this.props
     return (
-      <Kb.Reloadable waitingKeys={Constants.teamsLoadedWaitingKey} onReload={loadTeams} reloadOnMount={true}>
+      <Kb.Reloadable waitingKeys={Constants.teamsLoadedWaitingKey} onReload={loadTeams}>
         {Container.isMobile && (
           <Kb.NavigationEvents onDidFocus={this.onDidFocus} onWillBlur={this.onWillBlur} />
         )}

--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -78,7 +78,7 @@ const _Connected = Container.connect(
   }),
   (dispatch: Container.TypedDispatch, ownProps: OwnProps) => ({
     ...headerActions(dispatch, ownProps),
-    loadTeams: () => dispatch(TeamsGen.createGetTeams()),
+    loadTeams: () => dispatch(TeamsGen.createGetTeams({subscribeReason: 'teamList'})),
     onClearBadges: () => dispatch(TeamsGen.createClearNavBadges()),
     onHideChatBanner: () =>
       dispatch(GregorGen.createUpdateCategory({body: 'true', category: 'sawChatBanner'})),

--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -13,6 +13,7 @@ import * as Constants from '../constants/teams'
 import * as WaitingConstants from '../constants/waiting'
 import * as Types from '../constants/types/teams'
 import {memoize} from '../util/memoize'
+import {useTeamsSubscribe} from './subscriber'
 
 type OwnProps = Container.PropsWithSafeNavigation<{}>
 
@@ -34,36 +35,22 @@ const orderTeams = memoize((teams: Types.State['teamDetails']) =>
   [...teams.values()].sort((a, b) => a.teamname.localeCompare(b.teamname))
 )
 
-class Reloadable extends React.PureComponent<Props & {loadTeams: () => void; onClearBadges: () => void}> {
-  static navigationOptions = {
-    header: undefined,
-    headerRightActions: () => <ConnectedHeaderRightActions />,
-    title: 'Teams',
-  }
-
-  private onWillBlur = () => {
-    this.props.onClearBadges()
-  }
-  private onDidFocus = () => {
-    this.props.loadTeams()
-  }
-  componentWillUnmount() {
-    this.onWillBlur()
-  }
-  componentDidMount() {
-    this.onDidFocus()
-  }
-  render() {
-    const {loadTeams, ...rest} = this.props
-    return (
-      <Kb.Reloadable waitingKeys={Constants.teamsLoadedWaitingKey} onReload={loadTeams}>
-        {Container.isMobile && (
-          <Kb.NavigationEvents onDidFocus={this.onDidFocus} onWillBlur={this.onWillBlur} />
-        )}
-        <Teams {...rest} />
-      </Kb.Reloadable>
-    )
-  }
+const Reloadable = (props: Props & {loadTeams: () => void; onClearBadges: () => void}) => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => () => props.onClearBadges(), [])
+  // subscribe to teams changes
+  useTeamsSubscribe()
+  const {loadTeams, onClearBadges, ...rest} = props
+  return (
+    <Kb.Reloadable waitingKeys={Constants.teamsLoadedWaitingKey} onReload={loadTeams}>
+      <Teams {...rest} />
+    </Kb.Reloadable>
+  )
+}
+Reloadable.navigationOptions = {
+  header: undefined,
+  headerRightActions: () => <ConnectedHeaderRightActions />,
+  title: 'Teams',
 }
 
 const _Connected = Container.connect(
@@ -78,7 +65,7 @@ const _Connected = Container.connect(
   }),
   (dispatch: Container.TypedDispatch, ownProps: OwnProps) => ({
     ...headerActions(dispatch, ownProps),
-    loadTeams: () => dispatch(TeamsGen.createGetTeams({subscribeReason: 'teamList'})),
+    loadTeams: () => dispatch(TeamsGen.createGetTeams()),
     onClearBadges: () => dispatch(TeamsGen.createClearNavBadges()),
     onHideChatBanner: () =>
       dispatch(GregorGen.createUpdateCategory({body: 'true', category: 'sawChatBanner'})),

--- a/shared/teams/delete-team/container.tsx
+++ b/shared/teams/delete-team/container.tsx
@@ -8,28 +8,25 @@ import {anyWaiting} from '../../constants/waiting'
 
 type OwnProps = Container.RouteProps<{teamname: string}>
 
-export default Container.compose(
-  Container.connect(
-    (state, ownProps: OwnProps) => {
-      const teamname = Container.getRouteProps(ownProps, 'teamname', '')
-      return {
-        deleteWaiting: anyWaiting(state, deleteTeamWaitingKey(teamname)),
-        teamname,
-      }
-    },
-    dispatch => ({
-      clearError: (teamname: string) =>
-        dispatch(WaitingGen.createClearWaiting({key: deleteTeamWaitingKey(teamname)})),
-      onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
-      onDelete: (teamname: string) => dispatch(TeamsGen.createDeleteTeam({teamname})),
-    }),
-    (stateProps, dispatchProps, _: OwnProps) => ({
-      clearWaiting: () => dispatchProps.clearError(stateProps.teamname),
-      deleteWaiting: stateProps.deleteWaiting,
-      onBack: stateProps.deleteWaiting ? () => {} : dispatchProps.onBack,
-      onDelete: () => dispatchProps.onDelete(stateProps.teamname),
-      teamname: stateProps.teamname,
-    })
-  ),
-  Container.safeSubmit(['onDelete'], ['deleteWaiting'])
-)(ReallyDeleteTeam)
+export default Container.connect(
+  (state, ownProps: OwnProps) => {
+    const teamname = Container.getRouteProps(ownProps, 'teamname', '')
+    return {
+      deleteWaiting: anyWaiting(state, deleteTeamWaitingKey(teamname)),
+      teamname,
+    }
+  },
+  dispatch => ({
+    clearError: (teamname: string) =>
+      dispatch(WaitingGen.createClearWaiting({key: deleteTeamWaitingKey(teamname)})),
+    onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
+    onDelete: (teamname: string) => dispatch(TeamsGen.createDeleteTeam({teamname})),
+  }),
+  (stateProps, dispatchProps, _: OwnProps) => ({
+    clearWaiting: () => dispatchProps.clearError(stateProps.teamname),
+    deleteWaiting: stateProps.deleteWaiting,
+    onBack: stateProps.deleteWaiting ? () => {} : dispatchProps.onBack,
+    onDelete: () => dispatchProps.onDelete(stateProps.teamname),
+    teamname: stateProps.teamname,
+  })
+)(Container.safeSubmit(['onDelete'], ['deleteWaiting'])(ReallyDeleteTeam))

--- a/shared/teams/invite-by-contact/team-invite-by-contacts.native.tsx
+++ b/shared/teams/invite-by-contact/team-invite-by-contacts.native.tsx
@@ -92,7 +92,6 @@ const TeamInviteByContact = (props: TeamInviteByContactProps) => {
           })
         )
       }
-      dispatch(TeamsGen.createGetTeams())
     },
     [dispatch, selectedRole, teamname]
   )
@@ -117,7 +116,7 @@ const TeamInviteByContact = (props: TeamInviteByContactProps) => {
 
   const teamAlreadyInvited = mapExistingInvitesToValues(teamInvites, region)
 
-  let listItems: Array<ContactRowProps> = contacts.map(contact => {
+  const listItems: Array<ContactRowProps> = contacts.map(contact => {
     // `id` is the key property for Kb.List
     const id = [contact.type, contact.value, contact.name].join('+')
     const inviteID = teamAlreadyInvited.get(contact.value)

--- a/shared/teams/invite-by-email/container.tsx
+++ b/shared/teams/invite-by-email/container.tsx
@@ -24,7 +24,6 @@ export default Container.connect(
     onInvite: (invitees: string, role: Types.TeamRoleType) => {
       const teamname = Container.getRouteProps(ownProps, 'teamname', '')
       dispatch(TeamsGen.createInviteToTeamByEmail({invitees, role, teamname}))
-      dispatch(TeamsGen.createGetTeams())
     },
   }),
   (s, d, o: OwnProps) => ({...o, ...s, ...d})

--- a/shared/teams/routes.tsx
+++ b/shared/teams/routes.tsx
@@ -28,7 +28,6 @@ export const newModalRoutes = {
     getScreen: (): typeof RetentionWarning =>
       require('./team/settings-tab/retention/warning/container').default,
   },
-  // TODO connect broken
   teamDeleteTeam: {getScreen: (): typeof TeamDeleteTeam => require('./delete-team/container').default},
   teamEditTeamAvatar: {
     getScreen: (): typeof TeamEditTeamAvatar => require('../profile/edit-avatar/container').default,

--- a/shared/teams/subscriber.tsx
+++ b/shared/teams/subscriber.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import * as Container from '../util/container'
+import * as TeamsGen from '../actions/teams-gen'
+
+export const useTeamsMeta = (): {loading: boolean} => {
+  const dispatch = Container.useDispatch()
+
+  // Subscribe to load teams on mount, unsubscribe on unmount
+  React.useEffect(() => {
+    dispatch(TeamsGen.createGetTeams({_subscribe: true}))
+    return () => dispatch(TeamsGen.createUnsubscribeTeamList())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const loading = Container.useSelector(state => state.teams.teamDetailsMetaStale)
+  return {loading}
+}
+
+export const withTeamSubscription = <P extends object>(Component: React.ComponentType<P>) => {
+  const WithTeamSubscription = (props: P) => {
+    useTeamsMeta()
+    return <Component {...props} />
+  }
+  return WithTeamSubscription
+}

--- a/shared/teams/subscriber.tsx
+++ b/shared/teams/subscriber.tsx
@@ -1,25 +1,36 @@
 import * as React from 'react'
 import * as Container from '../util/container'
 import * as TeamsGen from '../actions/teams-gen'
+import {NavigationEventCallback} from '@react-navigation/core'
+import {useNavigationEvents} from '../util/navigation-hooks'
 
-export const useTeamsMeta = (): {loading: boolean} => {
+const useTeamsSubscribeMobile = () => {
   const dispatch = Container.useDispatch()
+  const callback: NavigationEventCallback = e => {
+    if (e.type === 'didFocus') {
+      dispatch(TeamsGen.createGetTeams({_subscribe: true}))
+    } else if (e.type === 'willBlur') {
+      dispatch(TeamsGen.createUnsubscribeTeamList())
+    }
+  }
+  useNavigationEvents(callback)
 
-  // Subscribe to load teams on mount, unsubscribe on unmount
+  // Workaround navigation blur events flakiness, make sure we unsubscribe on unmount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => () => dispatch(TeamsGen.createUnsubscribeTeamList()), [])
+}
+const useTeamsSubscribeDesktop = () => {
+  const dispatch = Container.useDispatch()
   React.useEffect(() => {
     dispatch(TeamsGen.createGetTeams({_subscribe: true}))
     return () => dispatch(TeamsGen.createUnsubscribeTeamList())
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
-  const loading = Container.useSelector(state => state.teams.teamDetailsMetaStale)
-  return {loading}
 }
+export const useTeamsSubscribe = Container.isMobile ? useTeamsSubscribeMobile : useTeamsSubscribeDesktop
 
-export const withTeamSubscription = <P extends object>(Component: React.ComponentType<P>) => {
-  const WithTeamSubscription = (props: P) => {
-    useTeamsMeta()
-    return <Component {...props} />
-  }
-  return WithTeamSubscription
+// Dummy component to add to a view to trigger team meta subscription behavior
+export const TeamSubscriber = () => {
+  useTeamsSubscribe()
+  return null
 }

--- a/shared/teams/team/index.tsx
+++ b/shared/teams/team/index.tsx
@@ -6,6 +6,7 @@ import * as Styles from '../../styles'
 import TeamTabs from './tabs/container'
 import {Row} from './rows'
 import renderRow from './rows/render'
+import {TeamSubscriber} from '../subscriber'
 
 export type Sections = Array<{data: Array<Row>; header?: Row; key: string}>
 
@@ -63,6 +64,7 @@ class Team extends React.Component<Props> {
         onReload={this.props.load}
         reloadOnMount={true}
       >
+        <TeamSubscriber />
         <Kb.Box style={styles.container}>
           <Kb.SectionList
             alwaysVounceVertical={false}

--- a/shared/util/navigation-hooks.tsx
+++ b/shared/util/navigation-hooks.tsx
@@ -1,9 +1,14 @@
-import {useContext} from 'react'
-import {NavigationContext, NavigationScreenProp, NavigationRoute} from '@react-navigation/core'
+import {useContext, useLayoutEffect, useRef, useCallback} from 'react'
+import {
+  NavigationContext,
+  NavigationScreenProp,
+  NavigationRoute,
+  NavigationEventCallback,
+} from '@react-navigation/core'
 
 /**
  * Hooks for react-navigation
- * See here: https://github.com/react-navigation/hooks/blob/master/src/Hooks.ts
+ * See here: https://github.com/react-navigation/hooks/blob/5044bcac81ee3e1418b38419c9f0d45bcfe573b2/src/Hooks.ts
  */
 
 export function useNavigation<S>(): NavigationScreenProp<S & NavigationRoute> {
@@ -12,4 +17,46 @@ export function useNavigation<S>(): NavigationScreenProp<S & NavigationRoute> {
 
 export function useNavigationState() {
   return useNavigation().state
+}
+
+// Useful to access the latest user-provided value
+const useGetter = <S,>(value: S): (() => S) => {
+  const ref = useRef(value)
+  useLayoutEffect(() => {
+    ref.current = value
+  })
+  return useCallback(() => ref.current, [ref])
+}
+
+export function useNavigationEvents(callback: NavigationEventCallback) {
+  const navigation = useNavigation()
+
+  // Closure might change over time and capture some variables
+  // It's important to fire the latest closure provided by the user
+  const getLatestCallback = useGetter(callback)
+
+  // It's important to useLayoutEffect because we want to ensure we subscribe synchronously to the mounting
+  // of the component, similarly to what would happen if we did use componentDidMount
+  // (that we use in <NavigationEvents/>)
+  // When mounting/focusing a new screen and subscribing to focus, the focus event should be fired
+  // It wouldn't fire if we did subscribe with useEffect()
+  useLayoutEffect(() => {
+    const subscribedCallback: NavigationEventCallback = event => {
+      const latestCallback = getLatestCallback()
+      latestCallback(event)
+    }
+
+    const subs = [
+      // TODO should we remove "action" here? it's not in the published typedefs
+      navigation.addListener('action' as any, subscribedCallback),
+      navigation.addListener('willFocus', subscribedCallback),
+      navigation.addListener('didFocus', subscribedCallback),
+      navigation.addListener('willBlur', subscribedCallback),
+      navigation.addListener('didBlur', subscribedCallback),
+    ]
+    return () => {
+      subs.forEach(sub => sub.remove())
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [navigation.state.key])
 }


### PR DESCRIPTION
- Two new store fields: `teamDetailsMetaStale` and `teamDetailsMetaSubscribeCount`
- New helpers to subscribe when your screen has focus and unsubscribe when losing focus.
  - For functional components a hook
  - For class components a dummy component that calls the hook and renders nothing
- On `TeamMetadataUpdate`, set `teamDetailsMetaStale = true`. If we are "subscribed", reload team list immediately
- In `getTeams`, by default do nothing unless we are stale.