### PR TITLE
set location done to false when not sharing live location

### DIFF
--- a/go/chat/unfurl/packager.go
+++ b/go/chat/unfurl/packager.go
@@ -287,6 +287,7 @@ func (p *Packager) packageMaps(ctx context.Context, uid gregor1.UID, convID chat
 	// load map
 	var reader io.ReadCloser
 	var length int64
+	var isDone bool
 	mapsURL := mapsRaw.ImageUrl
 	locReader, _, err := maps.MapReaderFromURL(ctx, mapsURL)
 	if err != nil {
@@ -302,10 +303,12 @@ func (p *Packager) packageMaps(ctx context.Context, uid gregor1.UID, convID chat
 		if reader, length, err = maps.DecorateMap(ctx, avatarReader, liveReader); err != nil {
 			return res, err
 		}
+		isDone = mapsRaw.LiveLocationDone
 	} else {
 		if reader, length, err = maps.DecorateMap(ctx, avatarReader, locReader); err != nil {
 			return res, err
 		}
+		isDone = false
 	}
 	asset, err := p.assetFromURLWithBody(ctx, reader, length, mapsURL, uid, convID, true)
 	if err != nil {
@@ -316,7 +319,7 @@ func (p *Packager) packageMaps(ctx context.Context, uid gregor1.UID, convID chat
 	g.MapInfo = &chat1.UnfurlGenericMapInfo{
 		Coord:               mapsRaw.Coord,
 		LiveLocationEndTime: mapsRaw.LiveLocationEndTime,
-		IsLiveLocationDone:  mapsRaw.LiveLocationDone,
+		IsLiveLocationDone:  isDone,
 		Time:                mapsRaw.Time,
 	}
 	return chat1.NewUnfurlWithGeneric(g), nil


### PR DESCRIPTION
fixes an issue where non-live locations would show a "location share ended" unfurl