### PR TITLE
allow entering password when secret store issues

### DIFF
--- a/shared/login/relogin/container.tsx
+++ b/shared/login/relogin/container.tsx
@@ -10,6 +10,8 @@ import sortBy from 'lodash/sortBy'
 import * as Container from '../../util/container'
 import * as ConfigTypes from '../../constants/types/config'
 
+const needPasswordError = 'passphrase cannot be empty'
+
 type OwnProps = {}
 
 type Props = {
@@ -31,6 +33,8 @@ const LoginWrapper = (props: Props) => {
 
   const prevPassword = Container.usePrevious(password)
   const prevError = Container.usePrevious(props.error)
+
+  const [gotNeedPasswordError, setGotNeedPasswordError] = React.useState(false)
 
   const dispatch = Container.useDispatch()
 
@@ -66,11 +70,16 @@ const LoginWrapper = (props: Props) => {
       dispatch(LoginGen.createLoginError({}))
     }
   }, [password, prevPassword, dispatch])
+  React.useEffect(() => {
+    if (props.error === needPasswordError) {
+      setGotNeedPasswordError(true)
+    }
+  }, [props.error, setGotNeedPasswordError])
 
   return (
     <Login
       error={props.error}
-      needPassword={!loggedInMap.get(selectedUser)}
+      needPassword={!loggedInMap.get(selectedUser) || gotNeedPasswordError}
       onFeedback={props.onFeedback}
       onForgotPassword={() => props.onForgotPassword(selectedUser)}
       onLogin={onLogin}


### PR DESCRIPTION
The GUI doesn't let you try to sign in with a password when it believes we have a stored secret. But sometimes we run into secret store issues and then we don't actually end up having a stored secret. These issues are probably apple's fault, there are tickets on a bunch of other projects about similar things; but at least we can make life better for users that run into them.

This PR catches login errors that suggest we need a password (due to secret store issues, probably) and gives the user a password box to use. It's not the most ideal way of doing this, but the version involving catching the error in the `loginError` action was ballooning into more and more code and not working, so I switched to this approach.

This blocks the Nov 12 release.
cc @keybase/y2ksquad @heronhaye @MarcoPolo 
Issue: Y2K-1027