### PR TITLE
fix: add extra check to getMapUnfurl

### DIFF
--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -745,6 +745,7 @@ export const getMapUnfurl = (message: Types.Message): RPCChatTypes.UnfurlGeneric
   const unfurls = message.type === 'text' && message.unfurls.size ? message.unfurls.toList().toArray() : null
   const mapInfo =
     !!unfurls &&
+    !!unfurls[0] &&
     unfurls[0].unfurl.unfurlType === RPCChatTypes.UnfurlType.generic &&
     unfurls[0].unfurl.generic &&
     unfurls[0].unfurl.generic.mapInfo


### PR DESCRIPTION
fixes an issue where right clicking an unfurl would throw a nasty error