### PR TITLE
fix: add extra check to getMapUnfurl (now with ts 3.7)

### DIFF
--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -795,13 +795,11 @@ export const hasSuccessfulInlinePayments = (state: TypedState, message: Types.Me
 
 export const getMapUnfurl = (message: Types.Message): RPCChatTypes.UnfurlGenericDisplay | null => {
   const unfurls = message.type === 'text' && message.unfurls.size ? message.unfurls.values() : null
-  const mapInfo =
-    !!unfurls &&
-    unfurls[0].unfurl.unfurlType === RPCChatTypes.UnfurlType.generic &&
-    unfurls[0].unfurl.generic &&
-    unfurls[0].unfurl.generic.mapInfo
-      ? unfurls[0].unfurl.generic
-      : null
+  const mapInfo = unfurls?.[0]?.unfurl
+    ? unfurls[0].unfurl.unfurlType === RPCChatTypes.UnfurlType.generic &&
+      unfurls[0].unfurl.generic?.mapInfo &&
+      unfurls[0].unfurl.generic
+    : null
   return mapInfo
 }
 


### PR DESCRIPTION
This PR adds extra checks for the existence of unfurls in `getMapUnfurl`, in this PR using TS 3.7's optional chaining and optional element access.