### PR TITLE
feat: first pass at bot keyed ui

### DIFF
--- a/shared/chat/conversation/messages/message-popup/header.tsx
+++ b/shared/chat/conversation/messages/message-popup/header.tsx
@@ -38,6 +38,7 @@ const headerIconHeight = Styles.isMobile ? 96 : 72
 
 const MessagePopupHeader = (props: {
   author: string
+  botUsername?: string
   deviceName: string
   deviceRevokedAt?: number
   deviceType: DeviceType
@@ -46,7 +47,17 @@ const MessagePopupHeader = (props: {
   timestamp: number
   yourMessage: boolean
 }) => {
-  const {author, deviceName, deviceRevokedAt, deviceType, isLast, isLocation, timestamp, yourMessage} = props
+  const {
+    author,
+    botUsername,
+    deviceName,
+    deviceRevokedAt,
+    deviceType,
+    isLast,
+    isLocation,
+    timestamp,
+    yourMessage,
+  } = props
   const iconName = iconNameForDeviceType(deviceType, !!deviceRevokedAt, isLocation)
   const whoRevoked = yourMessage ? 'You' : author
   return (
@@ -88,6 +99,22 @@ const MessagePopupHeader = (props: {
           <Kb.Text type="BodySmallSemibold">{deviceName}</Kb.Text>
         </Kb.Text>
       </Kb.Box>
+      {botUsername && (
+        <Kb.Box2 direction="horizontal">
+          <Kb.Text type="BodySmall">also encrypted for</Kb.Text>
+          <Kb.Box2 direction="horizontal" gap="xtiny" gapStart={true} style={styles.alignItemsCenter}>
+            <Kb.Avatar username={botUsername} size={16} onClick="profile" />
+            <Kb.ConnectedUsernames
+              onUsernameClicked="profile"
+              colorFollowing={true}
+              colorYou={true}
+              usernames={[botUsername]}
+              underline={true}
+              type="BodySmallSemibold"
+            />
+          </Kb.Box2>
+        </Kb.Box2>
+      )}
       <Kb.Text center={true} type="BodySmall">
         {formatTimeForPopup(timestamp)}
       </Kb.Text>

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -131,7 +131,7 @@ export default Container.namedConnect(
     return {
       attachTo: ownProps.attachTo,
       author: message.author,
-      botUsername: message.type === 'text' && message.botUsername,
+      botUsername: message.type === 'text' ? message.botUsername : undefined,
       deviceName: message.deviceName,
       deviceRevokedAt: message.deviceRevokedAt || undefined,
       deviceType: message.deviceType,

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -131,6 +131,7 @@ export default Container.namedConnect(
     return {
       attachTo: ownProps.attachTo,
       author: message.author,
+      botUsername: message.type === 'text' && message.botUsername,
       deviceName: message.deviceName,
       deviceRevokedAt: message.deviceRevokedAt || undefined,
       deviceType: message.deviceType,

--- a/shared/chat/conversation/messages/message-popup/text/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/index.tsx
@@ -8,7 +8,7 @@ import {StylesCrossPlatform} from '../../../../../styles/css'
 type Props = {
   attachTo?: () => React.Component<any> | null
   author: string
-  botUsername: string
+  botUsername?: string
   deviceName: string
   deviceRevokedAt?: number
   deviceType: DeviceType

--- a/shared/chat/conversation/messages/message-popup/text/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/index.tsx
@@ -8,6 +8,7 @@ import {StylesCrossPlatform} from '../../../../../styles/css'
 type Props = {
   attachTo?: () => React.Component<any> | null
   author: string
+  botUsername: string
   deviceName: string
   deviceRevokedAt?: number
   deviceType: DeviceType
@@ -72,6 +73,7 @@ const TextPopupMenu = (props: Props) => {
     view: (
       <MessagePopupHeader
         author={props.author}
+        botUsername={props.botUsername}
         deviceName={props.deviceName}
         deviceRevokedAt={props.deviceRevokedAt}
         deviceType={props.deviceType}

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -191,6 +191,11 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               >
                 {formatTimeForChat(this.props.message.timestamp)}
               </Kb.Text>
+              {this._getKeyedBot() && (
+                <Kb.WithTooltip tooltip={`Encrypted for @${this._getKeyedBot()}`}>
+                  <Kb.Icon fontSize={14} color={Styles.globalColors.black} type="iconfont-nav-2-robot" />
+                </Kb.WithTooltip>
+              )}
             </Kb.Box2>
           </Kb.Box2>
           <Kb.Box2
@@ -405,7 +410,6 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     const iconSizes = [
       this.props.isRevoked ? 16 : 0, // revoked
       this.props.showCoinsIcon ? 16 : 0, // coin stack
-      this._getKeyedBot() ? 16 : 0, // keyed bot icon
       exploded || Styles.isMobile ? 0 : 16, // ... menu
       exploding ? (Styles.isMobile ? 57 : 46) : 0, // exploding
     ].filter(Boolean)
@@ -578,11 +582,6 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                 </Kb.Box>
               </Kb.Box>
             ) : null}
-            {this._getKeyedBot() && (
-              <Kb.WithTooltip tooltip={`Encrypted for @${this._getKeyedBot()}`}>
-                <Kb.Icon fontSize={14} color={Styles.globalColors.black} type="iconfont-nav-2-robot" />
-              </Kb.WithTooltip>
-            )}
           </Kb.Box2>
         </Kb.Box2>
       )

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -306,6 +306,8 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       />
     )
 
+  _getKeyedBot = () => this.props.message.type === 'text' && this.props.message.botUsername
+
   _popup = () =>
     (this.props.message.type === 'text' ||
       this.props.message.type === 'attachment' ||
@@ -403,6 +405,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     const iconSizes = [
       this.props.isRevoked ? 16 : 0, // revoked
       this.props.showCoinsIcon ? 16 : 0, // coin stack
+      this._getKeyedBot() ? 16 : 0, // keyed bot icon
       exploded || Styles.isMobile ? 0 : 16, // ... menu
       exploding ? (Styles.isMobile ? 57 : 46) : 0, // exploding
     ].filter(Boolean)
@@ -575,6 +578,11 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                 </Kb.Box>
               </Kb.Box>
             ) : null}
+            {this._getKeyedBot() && (
+              <Kb.WithTooltip tooltip={`Encrypted for @${this._getKeyedBot()}`}>
+                <Kb.Icon fontSize={14} color={Styles.globalColors.black} type="iconfont-nav-2-robot" />
+              </Kb.WithTooltip>
+            )}
           </Kb.Box2>
         </Kb.Box2>
       )

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -816,6 +816,7 @@ const validUIMessagetoMessage = (
     id: Types.numberToMessageID(m.messageID),
     ordinal: Types.numberToOrdinal(m.messageID),
     timestamp: m.ctime,
+    botUsername: m.botUsername || undefined,
   }
 
   const reactions = reactionMapToReactions(m.reactions)
@@ -1133,6 +1134,7 @@ const errorUIMessagetoMessage = (
     id: Types.numberToMessageID(o.messageID),
     ordinal: Types.numberToOrdinal(o.messageID),
     timestamp: o.ctime,
+    botUsername: o.botUsername || undefined,
   })
 }
 

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -812,11 +812,11 @@ const validUIMessagetoMessage = (
 ) => {
   const minimum = {
     author: m.senderUsername,
+    botUsername: m.botUsername || undefined,
     conversationIDKey,
     id: Types.numberToMessageID(m.messageID),
     ordinal: Types.numberToOrdinal(m.messageID),
     timestamp: m.ctime,
-    botUsername: m.botUsername || undefined,
   }
 
   const reactions = reactionMapToReactions(m.reactions)
@@ -1124,6 +1124,7 @@ const errorUIMessagetoMessage = (
 ) => {
   return makeMessageText({
     author: o.senderUsername,
+    botUsername: o.botUsername || undefined,
     conversationIDKey,
     deviceName: o.senderDeviceName,
     deviceType: DeviceTypes.stringToDeviceType(o.senderDeviceType),
@@ -1134,7 +1135,6 @@ const errorUIMessagetoMessage = (
     id: Types.numberToMessageID(o.messageID),
     ordinal: Types.numberToOrdinal(o.messageID),
     timestamp: o.ctime,
-    botUsername: o.botUsername || undefined,
   })
 }
 

--- a/shared/constants/types/chat2/message.tsx
+++ b/shared/constants/types/chat2/message.tsx
@@ -109,6 +109,7 @@ export type MessageDeleted = {
   _MessageWithDeviceInfo
 
 export type MessageText = {
+  botUsername?: string
   decoratedText: HiddenString | null
   exploded: boolean
   explodedBy: string // only if 'explode now' happened,


### PR DESCRIPTION
This PR adds an initial pass at UI for showing that a message was encrypted for a restricted bot. This information is displayed by checking for and getting the `botUsername` field on `UIMessage` objects.


![Screen Shot 2019-11-12 at 3 50 50 PM](https://user-images.githubusercontent.com/54032873/68710005-c482db00-0564-11ea-85fc-581fbdde1331.png)


<img src="https://user-images.githubusercontent.com/54032873/68709998-bfbe2700-0564-11ea-9545-11f3a8674e77.png" width="300px"/>

