### PR TITLE
Add usernames to tracker serializer

### DIFF
--- a/shared/tracker2/remote-serializer.desktop.tsx
+++ b/shared/tracker2/remote-serializer.desktop.tsx
@@ -25,6 +25,7 @@ export const serialize = {
   teamShowcase: (v?: Array<Types.TeamShowcase>, o?: Array<Types.TeamShowcase>) =>
     o && shallowEqual(v, o) ? undefined : v,
   username: (v: string) => v,
+  usernames: (v: Array<string>) => v,
   waiting: (v: boolean) => v,
   windowComponent: (v: string) => v,
   windowOpts: (v: Object) => v,


### PR DESCRIPTION
Fixes crasher where tracker would popup and expect `usernames` which will be empty, from `sync-avatar-props`, so the serializer would throw an error.
Didn't see it because I tested w/o making a tracker popup.

Testing

`keybase verify -m "message"` causes tracker to popup. Helps to use a development GUI and service (not admin).
Also, need to restart `start-hot` between branch switches