### PR TITLE
sigid compare ignore last byte

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -644,6 +644,13 @@ func (s SigID) Equal(t SigID) bool {
 	return s == t
 }
 
+func (s SigID) EqualIgnoreLastByte(t SigID) bool {
+	if len(s) != len(t) || len(s) < 2 {
+		return false
+	}
+	return s[:len(s)-2] == t[:len(t)-2]
+}
+
 func (s SigID) Match(q string, exact bool) bool {
 	if s.IsNil() {
 		return false

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -187,7 +187,7 @@ var whitelistedTeamLinkSigs = []keybase1.SigID{
 func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, link *ChainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
 	l.G().Log.CDebugf(ctx, "addProofsForKeyInUserSigchain: sigID:%v", link.SigID())
 	for _, okSigID := range whitelistedTeamLinkSigs {
-		if link.SigID().Equal(okSigID) {
+		if link.SigID().EqualIgnoreLastByte(okSigID) {
 			// This proof is whitelisted, so don't check it.
 			l.G().Log.CDebugf(ctx, "addProofsForKeyInUserSigchain: skipping exceptional link: %v", link.SigID())
 			return

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -185,7 +185,6 @@ var whitelistedTeamLinkSigs = []keybase1.SigID{
 }
 
 func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, link *ChainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
-	l.G().Log.CDebugf(ctx, "addProofsForKeyInUserSigchain: sigID:%v", link.SigID())
 	for _, okSigID := range whitelistedTeamLinkSigs {
 		if link.SigID().EqualIgnoreLastByte(okSigID) {
 			// This proof is whitelisted, so don't check it.


### PR DESCRIPTION
The issue was that the server has sig IDs ending in "22" but the client generates sig IDs ending in "0f".