### PR TITLE
Set Android's targetSdkVersion to 28

### DIFF
--- a/shared/android/build.gradle
+++ b/shared/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 16
         compileSdkVersion = 29
-        targetSdkVersion = 29
+        targetSdkVersion = 28
         supportLibVersion = "28.0.0"
      }
 


### PR DESCRIPTION
29 introduced some breaking changes with how you save images on your
device.

See:

* [externalStoragePublicDirectory is deprecated](https://developer.android.com/reference/android/os/Environment#getExternalStoragePublicDirectory(java.lang.String))
* [Scoped Storage](https://android-developers.googleblog.com/2019/04/android-q-scoped-storage-best-practices.html)

@keybase/react-hackers 