### PR TITLE
folder_branch_ops: disallow empty file names or links

### DIFF
--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -588,10 +588,23 @@ type DisallowedPrefixError struct {
 	prefix string
 }
 
-// Error implements the error interface for NoChainFoundError.
+// Error implements the error interface for DisallowedPrefixError.
 func (e DisallowedPrefixError) Error() string {
 	return fmt.Sprintf("Cannot create %s because it has the prefix %s",
 		e.name, e.prefix)
+}
+
+// DisallowedNameError indicates that the user attempted to create an
+// entry using a disallowed name.  It includes the plaintext name on
+// purpose, for clarity in the error message.
+type DisallowedNameError struct {
+	name string
+}
+
+// Error implements the error interface for DisallowedNameError.
+func (e DisallowedNameError) Error() string {
+	return fmt.Sprintf("Cannot create \"%s\" because it is a disallowed name",
+		e.name)
 }
 
 // NameTooLongError indicates that the user tried to write a directory

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -4319,10 +4319,17 @@ func checkDisallowedPrefixes(
 					return nil
 				}
 			}
-			return DisallowedPrefixError{name, prefix}
+			return errors.WithStack(DisallowedPrefixError{name, prefix})
 		}
 	}
-	return nil
+
+	// Don't allow any empty or `.` names.
+	switch name.Plaintext() {
+	case "", ".", "..":
+		return errors.WithStack(DisallowedNameError{name.Plaintext()})
+	default:
+		return nil
+	}
 }
 
 // PathType returns path type

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -1455,7 +1455,7 @@ func testCreateEntryFailKBFSPrefix(t *testing.T, et data.EntryType) {
 	}
 	if err == nil {
 		t.Errorf("Got no expected error on create")
-	} else if err != expectedErr {
+	} else if errors.Cause(err) != expectedErr {
 		t.Errorf("Got unexpected error on create: %+v", err)
 	}
 }


### PR DESCRIPTION
A user hit an issue where they created a symlink with a blank name using SimpleFS, which then caused all sorts of rendering errors in the GUI and `ls` problems on the command line.

Just disallow the creation of names like that, and add a SimpleFS test for symlinks.

Issue: HOTPOT-1276