### PR TITLE
fix: only show bullet if showing username

### DIFF
--- a/shared/chat/header.desktop.tsx
+++ b/shared/chat/header.desktop.tsx
@@ -81,20 +81,15 @@ const Header = (p: Props) => {
   // trim() call makes sure that string is not just whitespace
   if (withoutSelf && withoutSelf.length === 1 && p.desc.trim()) {
     description = (
-      <>
-        <Kb.Text type="BodySmall" style={styles.desc}>
-          &nbsp;•&nbsp;
-        </Kb.Text>
-        <Kb.Markdown
-          smallStandaloneEmoji={true}
-          style={{...styles.desc, flex: 1}}
-          styleOverride={descStyleOverride}
-          lineClamp={1}
-          selectable={true}
-        >
-          {p.desc}
-        </Kb.Markdown>
-      </>
+      <Kb.Markdown
+        smallStandaloneEmoji={true}
+        style={{...styles.desc, flex: 1}}
+        styleOverride={descStyleOverride}
+        lineClamp={1}
+        selectable={true}
+      >
+        {p.desc}
+      </Kb.Markdown>
     )
   }
   return (
@@ -165,6 +160,9 @@ const Header = (p: Props) => {
                     usernames={[withoutSelf[0]]}
                     onUsernameClicked="profile"
                   />
+                  <Kb.Text type="BodySmall" style={styles.desc}>
+                    &nbsp;•&nbsp;
+                  </Kb.Text>
                   {description}
                 </Kb.Box2>
               ) : (

--- a/shared/constants/fs.tsx
+++ b/shared/constants/fs.tsx
@@ -112,9 +112,9 @@ export const tlfNormalViewWithNoConflict = makeConflictStateNormalView({})
 
 export const makeConflictStateManualResolvingLocalView = ({
   normalViewTlfPath,
-}: Partial<Types.ConflictStateManualResolvingLocalView>): Readonly<
+}: Partial<
   Types.ConflictStateManualResolvingLocalView
-> => ({
+>): Readonly<Types.ConflictStateManualResolvingLocalView> => ({
   normalViewTlfPath: normalViewTlfPath || defaultPath,
   type: Types.ConflictStateType.ManualResolvingLocalView,
 })


### PR DESCRIPTION
 This PR fixes issues with the chat header for conversations with users that do not have a full name set, but _do_ have a bio. Turns out the bio was showing, it was just hidden underneath the bullet (which shouldn't have been showing anyway).