### PR TITLE
folder_branch_ops: fetch root block even when full

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1692,7 +1692,8 @@ func (fbo *folderBranchOps) partialMarkAndSweepLoop(trigger <-chan struct{}) {
 func (fbo *folderBranchOps) kickOffRootBlockFetch(
 	ctx context.Context, rmd ImmutableRootMetadata) <-chan error {
 	ptr := rmd.Data().Dir.BlockPointer
-	action := fbo.config.Mode().DefaultBlockRequestAction().AddStopIfFull()
+	action := fbo.config.Mode().DefaultBlockRequestAction().
+		AddStopPrefetchIfFull()
 	if !action.prefetch() && fbo.config.IsSyncedTlf(fbo.id()) {
 		// Explicitly add the prefetch action for synced folders when
 		// getting the root block, since in some modes (like


### PR DESCRIPTION
When fetching the root block for an unsynced TLF update, we don't want the whole operation to fail if the disk working set block cache is full, because that will prevent the FBO from updating the local view of the folder.

So this commit adds a new block action type, "stop-prefetch-if-full", which means that the prefetches of the children of this block should be stopped if the cache is full, but not the fetch of the block itself.  That makes sure the root block itself will be fetched, but if the cache is full, its children won't be prefetched.

Issue: HOTPOT-1301