### PR TITLE
protocol: sigID compare that ignores suffixes

### DIFF
--- a/go/protocol/keybase1/extras_test.go
+++ b/go/protocol/keybase1/extras_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTime(t *testing.T) {
@@ -132,4 +134,83 @@ func TestTeamNameFromString(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestSigIDCompare(t *testing.T) {
+	tests := []struct {
+		x   string
+		y   string
+		res bool
+	}{
+		{
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2822",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2822",
+			true,
+		},
+		{
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2822",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c280f",
+			true,
+		},
+		{
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c28",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c280f",
+			true,
+		},
+		{
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c28",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c28",
+			true,
+		},
+		{
+			"b641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2822",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2822",
+			false,
+		},
+		{
+			"b641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2822",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c280f",
+			false,
+		},
+		{
+			"b641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c28",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c280f",
+			false,
+		},
+		{
+			"b641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c28",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c28",
+			false,
+		},
+		{
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2823",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c280f",
+			false,
+		},
+		{
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2823",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c28",
+			false,
+		},
+		{
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2",
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2",
+			false,
+		},
+		{
+			"c641d1246493cf04ec2c6141acdb569a457c02d577b392d4eb1872118c563c2822",
+			"",
+			false,
+		},
+		{
+			"",
+			"",
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		require.Equal(t, tc.res, SigID(tc.x).EqualTrimSuffix(SigID(tc.y)))
+	}
+
 }

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -186,7 +186,7 @@ var whitelistedTeamLinkSigs = []keybase1.SigID{
 
 func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, link *ChainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
 	for _, okSigID := range whitelistedTeamLinkSigs {
-		if link.SigID().EqualIgnoreLastByte(okSigID) {
+		if link.SigID().EqualTrimSuffix(okSigID) {
 			// This proof is whitelisted, so don't check it.
 			l.G().Log.CDebugf(ctx, "addProofsForKeyInUserSigchain: skipping exceptional link: %v", link.SigID())
 			return


### PR DESCRIPTION
- make it more robust to checking for known suffixes and lengths