### PR TITLE
fix: force show username when bot username field changes

### DIFF
--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -35,6 +35,15 @@ const getUsernameToShow = (
     authorIsCollapsible(message) &&
     authorIsCollapsible(previous)
 
+  const sequentialBotKeyed =
+    previous &&
+    previous.author === message.author &&
+    previous.type === 'text' &&
+    message.type === 'text' &&
+    previous.botUsername === message.botUsername &&
+    authorIsCollapsible(message) &&
+    authorIsCollapsible(previous)
+
   const enoughTimeBetween = MessageConstants.enoughTimeBetweenMessages(message, previous)
   const timestamp = orangeLineAbove || !previous || enoughTimeBetween ? message.timestamp : null
   switch (message.type) {
@@ -42,7 +51,7 @@ const getUsernameToShow = (
     case 'requestPayment':
     case 'sendPayment':
     case 'text':
-      return !previous || !sequentialUserMessages || !!timestamp ? message.author : ''
+      return !sequentialBotKeyed || !previous || !sequentialUserMessages || !!timestamp ? message.author : ''
     case 'setChannelname':
       // suppress this message for the #general channel, it is redundant.
       return (!previous || !sequentialUserMessages || !!timestamp) && message.newChannelname !== 'general'


### PR DESCRIPTION
This PR ensures that messages that are keyed for a bot that would otherwise be collapsed show the author header on the chat message.