### PR TITLE
kbfsgit: for LFS uploads, give progress for copy and the flush

### DIFF
--- a/go/kbfs/kbfsgit/git-remote-keybase/main.go
+++ b/go/kbfs/kbfsgit/git-remote-keybase/main.go
@@ -130,7 +130,7 @@ func start() (startErr *libfs.Error) {
 	} else {
 		// For LFS invocation, the arguments actually come together in
 		// a single quoted argument for some reason.
-		s := strings.Split(remote, " ")
+		s := strings.Fields(remote)
 		if len(s) > 2 {
 			lfs = s[0] == "lfs"
 			remote = s[1]


### PR DESCRIPTION
Previously, during LFS uploads, we were only reporting uploading bytes during while flushing the journal, but not while copying the file into the journal into the first.  The copy phase does take a little time, so progress appeared to be hung during that time.

Instead, let's pretend the copy phase counts for 40% of the overall uploaded bytes, while the journal flush phases counts for 60%, and report progress throughout the whole process.

This refactors the progress calculations to make that possible.

Suggested by jakob223.

Issue: HOTPOT-1297