### PR TITLE
teams: send up showcase_only param

### DIFF
--- a/go/teams/showcase_helper.go
+++ b/go/teams/showcase_helper.go
@@ -55,6 +55,7 @@ func GetTeamAndMemberShowcase(ctx context.Context, g *libkb.GlobalContext, teamn
 
 	arg := apiArg("team/get")
 	arg.Args.Add("id", libkb.S{Val: t.ID.String()})
+	arg.Args.Add("showcase_only", libkb.B{Val: true})
 
 	var teamRet rawTeam
 	mctx := libkb.NewMetaContext(ctx, g)


### PR DESCRIPTION
No need to load the whole team if we just are getting the showcase bits. Save bandwidth like so.