### PR TITLE
mostly logging and a couple little tweaks for cleaner shutdowns

### DIFF
--- a/go/client/cmd_ctl_stop.go
+++ b/go/client/cmd_ctl_stop.go
@@ -55,12 +55,15 @@ func (s *CmdCtlStop) Run() (err error) {
 	switch runtime.GOOS {
 	case "windows":
 		if !s.shutdown {
+			mctx.Info("stopping everything but the keybase service")
 			install.StopAllButService(mctx, keybase1.ExitCode_OK)
 		}
 		cli, err := GetCtlClient(s.G())
 		if err != nil {
+			mctx.Error("failed to get ctl client for shutdown: %s", err)
 			return err
 		}
+		mctx.Info("stopping the keybase service")
 		return cli.StopService(mctx.Ctx(), keybase1.StopServiceArg{ExitCode: keybase1.ExitCode_OK})
 	default:
 		// On Linux, StopAllButService depends on a running service to tell it

--- a/go/install/stop_windows.go
+++ b/go/install/stop_windows.go
@@ -6,6 +6,7 @@
 package install
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -14,13 +15,23 @@ import (
 )
 
 func StopAllButService(mctx libkb.MetaContext, _ keybase1.ExitCode) {
+	var err error
+	defer mctx.TraceTimed(fmt.Sprintf("StopAllButService()"),
+		func() error { return err })()
 	mountdir, err := mctx.G().Env.GetMountDir()
 	if err != nil {
 		mctx.Error("StopAllButService: Error in GetCurrentMountDir: %s", err.Error())
 	} else {
 		// open special "file". Errors not relevant.
-		mctx.Debug("StopAllButService: opening .kbfs_unmount")
-		os.Open(filepath.Join(mountdir, "\\.kbfs_unmount"))
-		libkb.ChangeMountIcon(mountdir, "")
+		unmountPath := filepath.Join(mountdir, "\\.kbfs_unmount")
+		mctx.Info("StopAllButService: opening .kbfs_unmount at %s", unmountPath)
+		_, err = os.Open(unmountPath)
+		if err != nil {
+			mctx.Debug("StopAllButService: unable to unmount kbfs (%s) but it might still have shut down successfully", err)
+		}
+		err = libkb.ChangeMountIcon(mountdir, "")
+		if err != nil {
+			mctx.Error("StopAllButService: unable to change mount icon: %s", err)
+		}
 	}
 }

--- a/go/install/terminate_nonmobile.go
+++ b/go/install/terminate_nonmobile.go
@@ -3,9 +3,10 @@
 package install
 
 import (
+	"time"
+
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/go-updater/process"
-	"time"
 )
 
 // TerminateApp will stop the Keybase (UI) app
@@ -16,6 +17,8 @@ func TerminateApp(context Context, log Log) error {
 	appPIDs := process.TerminateAll(process.NewMatcher(appExecName, process.ExecutableEqual, logf), 5*time.Second, logf)
 	if len(appPIDs) > 0 {
 		log.Info("Terminated %s %v", appExecName, appPIDs)
+	} else {
+		log.Debug("Did not terminate anything")
 	}
 	return nil
 }

--- a/go/kbfs/libdokan/fs.go
+++ b/go/kbfs/libdokan/fs.go
@@ -354,7 +354,7 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 		return oc.returnFileNoCleanup(NewUserEditHistoryFile(&Folder{fs: f}))
 
 	case ".kbfs_unmount" == ps[0]:
-		f.log.CDebugf(ctx, "Exiting due to .kbfs_unmount")
+		f.log.CInfof(ctx, "Exiting due to .kbfs_unmount")
 		logger.Shutdown()
 		os.Exit(0)
 	case ".kbfs_number_of_handles" == ps[0]:

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -822,7 +822,6 @@ func (g *GlobalContext) Shutdown(mctx MetaContext) error {
 		if g.GUILogFile != nil {
 			epick.Push(g.GUILogFile.Close())
 		}
-		<-g.Identify3State.Shutdown()
 
 		err = epick.Error()
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -822,6 +822,7 @@ func (g *GlobalContext) Shutdown(mctx MetaContext) error {
 		if g.GUILogFile != nil {
 			epick.Push(g.GUILogFile.Close())
 		}
+		<-g.Identify3State.Shutdown()
 
 		err = epick.Error()
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -807,9 +807,11 @@ func (g *GlobalContext) Shutdown(mctx MetaContext) error {
 			g.Resolver.Shutdown(NewMetaContextBackground(g))
 		}
 
+		g.Log.Debug("executing %d shutdown hooks; errCount=%d", len(g.ShutdownHooks), epick.Count())
 		for _, hook := range g.ShutdownHooks {
 			epick.Push(hook(mctx))
 		}
+		g.Log.Debug("executed shutdown hooks; errCount=%d", epick.Count())
 
 		// shutdown the databases after the shutdown hooks run, we may want to
 		// flush memory caches to disk during shutdown.
@@ -826,7 +828,7 @@ func (g *GlobalContext) Shutdown(mctx MetaContext) error {
 
 		err = epick.Error()
 
-		g.Log.Debug("exiting shutdown code=%d; err=%v", g.ExitCode, err)
+		g.Log.Debug("exiting shutdown code=%d; errCount=%d; firstErr=%v", g.ExitCode, epick.Count(), err)
 	})
 
 	// Make a little bit of a statement if we wind up here a second time

--- a/go/libkb/identify3.go
+++ b/go/libkb/identify3.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	context "golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -101,8 +100,8 @@ func (s *Identify3Session) SetOutcome(o *IdentifyOutcome) {
 type Identify3State struct {
 	sync.Mutex
 
-	cancelFunc context.CancelFunc
 	expireCh   chan<- struct{}
+	shutdownCh chan struct{}
 	eg         errgroup.Group
 
 	// Table of keybase1.Identify3GUIID -> *identify3Session's
@@ -131,48 +130,52 @@ func NewIdentify3StateForTest(g *GlobalContext) (*Identify3State, <-chan time.Ti
 
 func newIdentify3State(g *GlobalContext, testCompletionCh chan<- time.Time) *Identify3State {
 	expireCh := make(chan struct{})
-	mctx, cancelFunc := NewMetaContextBackground(g).WithContextCancel()
+	shutdownCh := make(chan struct{})
 	ret := &Identify3State{
-		cancelFunc:       cancelFunc,
 		expireCh:         expireCh,
+		shutdownCh:       shutdownCh,
 		cache:            make(map[keybase1.Identify3GUIID](*Identify3Session)),
 		defaultWaitTime:  time.Hour,
 		expireTime:       24 * time.Hour,
 		testCompletionCh: testCompletionCh,
-		shutdown:         false,
 	}
 	ret.makeNewCache()
-	ret.eg.Go(func() error { return ret.runExpireThread(mctx, expireCh) })
-	g.PushShutdownHook(ret.Shutdown)
+	ret.eg.Go(func() error { return ret.runExpireThread(g, expireCh, shutdownCh) })
 	ret.pokeExpireThread()
-
 	return ret
 }
 
-func (s *Identify3State) Shutdown(mctx MetaContext) (err error) {
-	defer mctx.Trace("Identify3State#Shutdown", func() error { return err })()
-	s.shutdownMu.Lock()
-	defer s.shutdownMu.Unlock()
-
-	if s.isShutdownLocked() {
-		return nil
+func (s *Identify3State) Shutdown() chan struct{} {
+	ch := make(chan struct{})
+	if s.markShutdown() {
+		go func() {
+			_ = s.eg.Wait()
+			close(ch)
+		}()
+	} else {
+		close(ch)
 	}
-	s.cancelFunc()
-	// block until runExpireThread has exited
-	mctx.Debug("waiting on runExpireThread to complete")
-	err = s.eg.Wait()
-	s.shutdown = true
-	return err
+	return ch
 }
 
 func (s *Identify3State) isShutdown() bool {
 	s.shutdownMu.Lock()
 	defer s.shutdownMu.Unlock()
-	return s.isShutdownLocked()
+	return s.shutdown
 }
 
-func (s *Identify3State) isShutdownLocked() bool {
-	return s.shutdown
+// markShutdown marks this state as having shutdown. Will return true the first
+// time through, and false every other time.
+func (s *Identify3State) markShutdown() bool {
+	s.shutdownMu.Lock()
+	defer s.shutdownMu.Unlock()
+	if s.shutdown {
+		return false
+	}
+	close(s.shutdownCh)
+	s.shutdownCh = nil
+	s.shutdown = true
+	return true
 }
 
 func (s *Identify3State) makeNewCache() {
@@ -187,7 +190,10 @@ func (s *Identify3State) OnLogout() {
 	s.pokeExpireThread()
 }
 
-func (s *Identify3State) runExpireThread(mctx MetaContext, expireCh <-chan struct{}) error {
+func (s *Identify3State) runExpireThread(g *GlobalContext, expireCh <-chan struct{},
+	shutdownCh chan struct{}) error {
+
+	mctx := NewMetaContextBackground(g)
 	wait := s.defaultWaitTime
 
 	nowFn := func() time.Time { return mctx.G().Clock().Now() }
@@ -196,13 +202,8 @@ func (s *Identify3State) runExpireThread(mctx MetaContext, expireCh <-chan struc
 
 	for {
 		select {
-		case <-mctx.Ctx().Done():
-			mctx.Debug("identify3State#runExpireThread: exiting on canceled context")
-			if s.testCompletionCh != nil {
-				// signal to tests that this thing really shut down
-				close(s.testCompletionCh)
-				s.testCompletionCh = nil
-			}
+		case <-shutdownCh:
+			mctx.Debug("identify3State#runExpireThread: exiting on shutdown")
 			return nil
 		case <-expireCh:
 		case <-mctx.G().Clock().AfterTime(wakeupTime):
@@ -267,12 +268,7 @@ func (s *Identify3State) expireSessions(mctx MetaContext, now time.Time) time.Du
 
 func (s *Identify3State) doExpireSessions(mctx MetaContext, toExpire []*Identify3Session) {
 	for _, sess := range toExpire {
-		select {
-		case <-mctx.Ctx().Done():
-			return
-		default:
-			sess.doExpireSession(mctx)
-		}
+		sess.doExpireSession(mctx)
 	}
 }
 
@@ -281,12 +277,6 @@ func (s *Identify3State) getSessionsToExpire(mctx MetaContext, now time.Time) (r
 	defer s.Unlock()
 
 	for {
-		select {
-		case <-mctx.Ctx().Done():
-			return []*Identify3Session{}, diff
-		default:
-		}
-
 		if len(s.expirationQueue) == 0 {
 			return ret, s.defaultWaitTime
 		}

--- a/go/libkb/identify3.go
+++ b/go/libkb/identify3.go
@@ -150,6 +150,7 @@ func (s *Identify3State) Shutdown() chan struct{} {
 	if s.markShutdown() {
 		go func() {
 			_ = s.eg.Wait()
+			s.shutdownCh = nil
 			close(ch)
 		}()
 	} else {
@@ -173,7 +174,6 @@ func (s *Identify3State) markShutdown() bool {
 		return false
 	}
 	close(s.shutdownCh)
-	s.shutdownCh = nil
 	s.shutdown = true
 	return true
 }

--- a/go/libkb/identify3_test.go
+++ b/go/libkb/identify3_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/clockwork"
+	clockwork "github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 	context "golang.org/x/net/context"
 )
@@ -75,7 +75,8 @@ func TestIdentify3State(t *testing.T) {
 	tc.G.SetClock(fakeClock)
 	uiRouter := id3FakeUIRouter{}
 	tc.G.UIRouter = &uiRouter
-	tc.G.Identify3State.Shutdown()
+	err := tc.G.Identify3State.Shutdown(NewMetaContextForTest(tc))
+	require.NoError(t, err)
 
 	id3state, testCompletionCh := NewIdentify3StateForTest(tc.G)
 	tc.G.Identify3State = id3state
@@ -123,7 +124,7 @@ func TestIdentify3State(t *testing.T) {
 	epsilon := inc / 2
 
 	// put in 3 items all inc time apart.
-	err := id3state.Put(mkSession(1))
+	err = id3state.Put(mkSession(1))
 	require.NoError(t, err)
 	fakeClock.Advance(inc)
 	err = id3state.Put(mkSession(2))
@@ -160,4 +161,51 @@ func TestIdentify3State(t *testing.T) {
 	advance(inc)
 	assertState([]int{}, []int{})
 	uiRouter.ui.assertAndCleanState(t, []keybase1.Identify3GUIID{})
+}
+
+func TestIdentify3StateShutdown(t *testing.T) {
+	tc := SetupTest(t, "TestIdentify3State()", 1)
+	defer tc.Cleanup()
+
+	fakeClock := clockwork.NewFakeClock()
+	tc.G.SetClock(fakeClock)
+	// throwaway the existing Identify3State on tc.G
+	err := tc.G.Identify3State.Shutdown(NewMetaContextForTest(tc))
+	require.NoError(t, err)
+
+	// make a new "test" one
+	id3state, testCompletionCh := NewIdentify3StateForTest(tc.G)
+	tc.G.Identify3State = id3state
+
+	advance := func(d time.Duration) {
+		id3state.bgThreadTimeMu.Lock()
+		defer id3state.bgThreadTimeMu.Unlock()
+		fakeClock.Advance(d)
+	}
+
+	// advance the clock and empty the test channel
+	advance(1*time.Hour + 1*time.Second)
+	for len(testCompletionCh) > 0 {
+		<-testCompletionCh
+	}
+	require.Equal(t, 0, len(testCompletionCh), "test channel is empty")
+
+	// shut down Identify3State through the global shutdown
+	err = tc.G.Shutdown(NewMetaContextForTest(tc))
+	require.NoError(t, err)
+	if len(testCompletionCh) == 1 {
+		// it's possible there's something in the channel
+		// from the moment of shutdown, and this doesn't matter
+		// so just throw it away.
+		<-testCompletionCh
+	}
+
+	// but now, the testCompletionCh should be empty even if we
+	// advance the fake clock and the real clock a few times
+	for i := 0; i < 3; i++ {
+		advance(1*time.Hour + 1*time.Second)
+		<-time.After(1 * time.Second)
+		advance(1*time.Hour + 1*time.Second)
+		require.Equal(t, 0, len(testCompletionCh), "Identity3State may not have actually shut down")
+	}
 }

--- a/go/libkb/identify3_test.go
+++ b/go/libkb/identify3_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	clockwork "github.com/keybase/clockwork"
+	"github.com/keybase/clockwork"
 	"github.com/stretchr/testify/require"
 	context "golang.org/x/net/context"
 )
@@ -75,8 +75,7 @@ func TestIdentify3State(t *testing.T) {
 	tc.G.SetClock(fakeClock)
 	uiRouter := id3FakeUIRouter{}
 	tc.G.UIRouter = &uiRouter
-	err := tc.G.Identify3State.Shutdown(NewMetaContextForTest(tc))
-	require.NoError(t, err)
+	tc.G.Identify3State.Shutdown()
 
 	id3state, testCompletionCh := NewIdentify3StateForTest(tc.G)
 	tc.G.Identify3State = id3state
@@ -124,7 +123,7 @@ func TestIdentify3State(t *testing.T) {
 	epsilon := inc / 2
 
 	// put in 3 items all inc time apart.
-	err = id3state.Put(mkSession(1))
+	err := id3state.Put(mkSession(1))
 	require.NoError(t, err)
 	fakeClock.Advance(inc)
 	err = id3state.Put(mkSession(2))
@@ -161,51 +160,4 @@ func TestIdentify3State(t *testing.T) {
 	advance(inc)
 	assertState([]int{}, []int{})
 	uiRouter.ui.assertAndCleanState(t, []keybase1.Identify3GUIID{})
-}
-
-func TestIdentify3StateShutdown(t *testing.T) {
-	tc := SetupTest(t, "TestIdentify3State()", 1)
-	defer tc.Cleanup()
-
-	fakeClock := clockwork.NewFakeClock()
-	tc.G.SetClock(fakeClock)
-	// throwaway the existing Identify3State on tc.G
-	err := tc.G.Identify3State.Shutdown(NewMetaContextForTest(tc))
-	require.NoError(t, err)
-
-	// make a new "test" one
-	id3state, testCompletionCh := NewIdentify3StateForTest(tc.G)
-	tc.G.Identify3State = id3state
-
-	advance := func(d time.Duration) {
-		id3state.bgThreadTimeMu.Lock()
-		defer id3state.bgThreadTimeMu.Unlock()
-		fakeClock.Advance(d)
-	}
-
-	// advance the clock and empty the test channel
-	advance(1*time.Hour + 1*time.Second)
-	for len(testCompletionCh) > 0 {
-		<-testCompletionCh
-	}
-	require.Equal(t, 0, len(testCompletionCh), "test channel is empty")
-
-	// shut down Identify3State through the global shutdown
-	err = tc.G.Shutdown(NewMetaContextForTest(tc))
-	require.NoError(t, err)
-	if len(testCompletionCh) == 1 {
-		// it's possible there's something in the channel
-		// from the moment of shutdown, and this doesn't matter
-		// so just throw it away.
-		<-testCompletionCh
-	}
-
-	// but now, the testCompletionCh should be empty even if we
-	// advance the fake clock and the real clock a few times
-	for i := 0; i < 3; i++ {
-		advance(1*time.Hour + 1*time.Second)
-		<-time.After(1 * time.Second)
-		advance(1*time.Hour + 1*time.Second)
-		require.Equal(t, 0, len(testCompletionCh), "Identity3State may not have actually shut down")
-	}
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -1767,6 +1767,7 @@ func (n *NotifyRouter) HandleServiceShutdown() {
 	// timeout after 4s (launchd will SIGKILL after 5s)
 	select {
 	case <-done:
+		n.G().Log.Debug("Finished sending service shutdown notifications")
 	case <-time.After(4 * time.Second):
 		n.G().Log.Warning("Timed out sending service shutdown notifications, proceeding to shutdown")
 	}

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -148,13 +148,21 @@ func PickFirstError(errors ...error) error {
 }
 
 type FirstErrorPicker struct {
-	e error
+	e     error
+	count int
 }
 
 func (p *FirstErrorPicker) Push(e error) {
-	if e != nil && p.e == nil {
-		p.e = e
+	if e != nil {
+		p.count++
+		if p.e == nil {
+			p.e = e
+		}
 	}
+}
+
+func (p *FirstErrorPicker) Count() int {
+	return p.count
 }
 
 func (p *FirstErrorPicker) Error() error {

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -1071,6 +1071,7 @@ func (d *Service) ConfigRPCServer() (net.Listener, error) {
 }
 
 func (d *Service) Stop(exitCode keybase1.ExitCode) {
+	d.G().Log.Info("Beginning the process of stopping the service")
 	d.stopCh <- exitCode
 }
 
@@ -1092,6 +1093,7 @@ func (d *Service) ListenLoop(l net.Listener) (err error) {
 		if c, err = l.Accept(); err != nil {
 
 			if libkb.IsSocketClosedError(err) {
+				d.G().Log.Debug("ListenLoop socket/pipe is closed")
 				err = nil
 			}
 

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -421,6 +421,7 @@ func (d *Service) startChatModules() {
 		g.LiveLocationTracker.Start(context.Background(), uid)
 		g.BotCommandManager.Start(context.Background(), uid)
 		g.UIInboxLoader.Start(context.Background(), uid)
+		g.PushShutdownHook(d.stopChatModules)
 	}
 	d.purgeOldChatAttachmentData()
 }
@@ -901,7 +902,6 @@ func (d *Service) OnLogin(mctx libkb.MetaContext) error {
 	uid := d.G().Env.GetUID()
 	if !uid.IsNil() {
 		d.startChatModules()
-		d.G().PushShutdownHook(d.stopChatModules)
 		d.runTLFUpgrade()
 		d.runTrackerLoader(mctx.Ctx())
 	}

--- a/go/vendor/github.com/keybase/go-updater/process/matcher.go
+++ b/go/vendor/github.com/keybase/go-updater/process/matcher.go
@@ -51,7 +51,7 @@ func (m Matcher) matchPathFn(pathFn func(path, str string) bool) MatchFn {
 		}
 		path, err := p.Path()
 		if err != nil {
-			//m.log.Warningf("Unable to get path for process %q: %s", p.Executable(), err)
+			m.log.Debugf("Unable to match a path for process %q: %s", p.Executable(), err)
 			return false
 		}
 		return pathFn(path, m.match)

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -896,16 +896,16 @@
 			"revisionTime": "2019-08-28T01:53:43Z"
 		},
 		{
-			"checksumSHA1": "9rRK1pLxOcjjNNUP/6H9EthW360=",
+			"checksumSHA1": "KGO7GzAF0CkuuA7xm9roInOSJ4g=",
 			"path": "github.com/keybase/go-updater/process",
-			"revision": "396e07f04b47f41a5593d5f8e74d32cadbd89d54",
-			"revisionTime": "2019-08-27T21:47:57Z"
+			"revision": "fea0973a446def0a91d8871e34ae52f8fd0a47ba",
+			"revisionTime": "2020-01-03T20:59:16Z"
 		},
 		{
 			"checksumSHA1": "ffC5qvAmfgvFbIYgKbE2E7fwQg8=",
 			"path": "github.com/keybase/go-updater/watchdog",
-			"revision": "396e07f04b47f41a5593d5f8e74d32cadbd89d54",
-			"revisionTime": "2019-08-27T21:47:57Z"
+			"revision": "fea0973a446def0a91d8871e34ae52f8fd0a47ba",
+			"revisionTime": "2020-01-03T20:59:16Z"
 		},
 		{
 			"checksumSHA1": "rRRQUZrxRapCpdmV2BUgmJRE/ww=",


### PR DESCRIPTION
* when Identify3State shuts itself down, it was previously nilling out the channel before it was actually done shutting down, which caused it not to be recognized as closed in runExpireThread. tricky that a nilled out channel doesn't work the same as a closed one in switch statements. this causes weird logs on windows and maybe worse.
* instead of conditionally pushing a shutdown hook for tearing down the chat modules, do it whenever we have successfully set them up (which can happen from a few places). this is another place where shutdown behavior might just be a little weird on windows.
* some logging changes specifically for debugging windows shutdown behavior
* pull in changes from https://github.com/keybase/go-updater/pull/187 which is just more logging