### PR TITLE
libgit: add autogit support for LFS files

### DIFF
--- a/go/kbfs/kbfsgit/runner.go
+++ b/go/kbfs/kbfsgit/runner.go
@@ -68,7 +68,6 @@ const (
 	kbfsgitPrefix = "keybase://"
 	repoSplitter  = "/"
 	kbfsRepoDir   = ".kbfs_git"
-	lfsSubdir     = "kbfs_lfs"
 
 	publicName  = "public"
 	privateName = "private"
@@ -2057,11 +2056,11 @@ func (r *runner) handleLFSUpload(
 	if err != nil {
 		return err
 	}
-	err = fs.MkdirAll(lfsSubdir, 0600)
+	err = fs.MkdirAll(libgit.LFSSubdir, 0600)
 	if err != nil {
 		return err
 	}
-	fs, err = fs.ChrootAsLibFS(lfsSubdir)
+	fs, err = fs.ChrootAsLibFS(libgit.LFSSubdir)
 	if err != nil {
 		return err
 	}
@@ -2097,11 +2096,11 @@ func (r *runner) handleLFSDownload(
 	if err != nil {
 		return "", err
 	}
-	err = fs.MkdirAll(lfsSubdir, 0600)
+	err = fs.MkdirAll(libgit.LFSSubdir, 0600)
 	if err != nil {
 		return "", err
 	}
-	fs, err = fs.ChrootAsLibFS(lfsSubdir)
+	fs, err = fs.ChrootAsLibFS(libgit.LFSSubdir)
 	if err != nil {
 		return "", err
 	}

--- a/go/kbfs/kbfsgit/runner_test.go
+++ b/go/kbfs/kbfsgit/runner_test.go
@@ -1188,7 +1188,7 @@ func TestRunnerLFS(t *testing.T) {
 	t.Log("Make sure the file has been fully uploaded")
 	fs, err := libfs.NewFS(
 		ctx, config, h, data.MasterBranch,
-		fmt.Sprintf("%s/test/%s", kbfsRepoDir, lfsSubdir), "",
+		fmt.Sprintf("%s/test/%s", kbfsRepoDir, libgit.LFSSubdir), "",
 		keybase1.MDPriorityGit)
 	require.NoError(t, err)
 	oidF, err := fs.Open(oid)

--- a/go/kbfs/libfs/file.go
+++ b/go/kbfs/libfs/file.go
@@ -88,8 +88,13 @@ func (f *File) ReadAt(p []byte, off int64) (n int, err error) {
 		return 0, err
 	}
 	if int(readBytes) < len(p) {
-		// ReadAt is more strict than Read.
-		return 0, errors.Errorf("Could only read %d bytes", readBytes)
+		// ReadAt is more strict than Read; it requires a real error
+		// if someone tries to read such that it won't fill the
+		// buffer.  But just wrap an io.EOF in the error so that
+		// folderBranchOps can figure it out, when calling from a
+		// `Read()` implementation.
+		return 0, errors.Wrapf(
+			io.EOF, "Could only read %d (not %d) bytes", readBytes, len(p))
 	}
 
 	return int(readBytes), nil

--- a/go/kbfs/libgit/lfs_file_info.go
+++ b/go/kbfs/libgit/lfs_file_info.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"os"
+	"time"
+)
+
+type lfsFileInfo struct {
+	name  string
+	oid   string
+	size  int64
+	mtime time.Time
+}
+
+var _ os.FileInfo = (*lfsFileInfo)(nil)
+
+func (lfi *lfsFileInfo) Name() string {
+	return lfi.name
+}
+
+func (lfi *lfsFileInfo) Size() int64 {
+	return lfi.size
+}
+
+func (lfi *lfsFileInfo) Mode() os.FileMode {
+	return 0600
+}
+
+func (lfi *lfsFileInfo) ModTime() time.Time {
+	return lfi.mtime
+}
+
+func (lfi *lfsFileInfo) IsDir() bool {
+	return false
+}
+
+func (lfi *lfsFileInfo) Sys() interface{} {
+	return nil
+}


### PR DESCRIPTION
LFS files are stored in the git bare repo using a git object with contents like this:

```
version https://git-lfs.github.com/spec/v1
oid sha256:0fa19837aa72b28c8045f997436d859ef177cda742cd7e7b87aa290c93b09e62
size 2300102
```

And then the actual file is stored under the `kbfs_lfs` directory inside the bare git repo.  So in order to find out the size of the file (to report when reading the autogit directory), we have to actually read the file to find out if it's even an LFS file or not. And it's much too slow to do that in autogit for every file in the directory, because those block loads add up.

So let's play a trick.  It looks like the size of LFS git objects are fairly fixed, varying only by the number of digits in the size of the file.  So, we do this: if the repo does have an LFS subdirectory, and the file in question has a size within a reasonable range for an LFS file, only then do we check the contents of the file to see if it's LFS.  If it is, we return a special file info type that identifies it as LFS, and if it is, we use the OID to open the actual LFS file when the file is opened.

I couldn't figure out an easy way to test this, since LFS requires an extra package installed.  But I tested it manually and it seems all good!  If you see a good way to test, let me know.

Issue: HOTPOT-1305