### PR TITLE
journeycard debugging tools

### DIFF
--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -291,6 +291,30 @@ func (h *Helper) UserReacjis(ctx context.Context, uid gregor1.UID) keybase1.User
 	return storage.NewReacjiStore(h.G()).UserReacjis(ctx, uid)
 }
 
+func (h *Helper) JourneycardTimeTravel(ctx context.Context, uid gregor1.UID, duration time.Duration) error {
+	j, ok := h.G().JourneyCardManager.(*JourneyCardManager)
+	if !ok {
+		return fmt.Errorf("could not get JourneyCardManager")
+	}
+	return j.TimeTravel(ctx, uid, duration)
+}
+
+func (h *Helper) JourneycardResetAllConvs(ctx context.Context, uid gregor1.UID) error {
+	j, ok := h.G().JourneyCardManager.(*JourneyCardManager)
+	if !ok {
+		return fmt.Errorf("could not get JourneyCardManager")
+	}
+	return j.ResetAllConvs(ctx, uid)
+}
+
+func (h *Helper) JourneycardDebugState(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (string, error) {
+	j, ok := h.G().JourneyCardManager.(*JourneyCardManager)
+	if !ok {
+		return "", fmt.Errorf("could not get JourneyCardManager")
+	}
+	return j.DebugState(ctx, uid, convID)
+}
+
 func GetMessage(ctx context.Context, g *globals.Context, uid gregor1.UID, convID chat1.ConversationID,
 	msgID chat1.MessageID, resolveSupersedes bool, reason *chat1.GetThreadReason) (chat1.MessageUnboxed, error) {
 	msgs, err := GetMessages(ctx, g, uid, convID, []chat1.MessageID{msgID}, resolveSupersedes, reason)

--- a/go/chat/journey_card_manager.go
+++ b/go/chat/journey_card_manager.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/storage"
@@ -72,6 +74,30 @@ func (j *JourneyCardManager) PickCard(ctx context.Context, uid gregor1.UID,
 		return nil, err
 	}
 	return js.PickCard(ctx, convID, convLocalOptional, thread)
+}
+
+func (j *JourneyCardManager) TimeTravel(ctx context.Context, uid gregor1.UID, duration time.Duration) (err error) {
+	js, err := j.get(ctx, uid)
+	if err != nil {
+		return err
+	}
+	return js.TimeTravel(ctx, duration)
+}
+
+func (j *JourneyCardManager) ResetAllConvs(ctx context.Context, uid gregor1.UID) (err error) {
+	js, err := j.get(ctx, uid)
+	if err != nil {
+		return err
+	}
+	return js.ResetAllConvs(ctx)
+}
+
+func (j *JourneyCardManager) DebugState(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (summary string, err error) {
+	js, err := j.get(ctx, uid)
+	if err != nil {
+		return "", err
+	}
+	return js.DebugState(ctx, convID)
 }
 
 func (j *JourneyCardManager) SentMessage(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) {
@@ -730,6 +756,14 @@ func (cc *JourneyCardManagerSingleUser) saveJoinedTime(ctx context.Context, conv
 		return
 	}
 	defer cc.storageLock.Unlock()
+	cc.saveJoinedTimeWithLock(ctx, convID, t)
+}
+
+func (cc *JourneyCardManagerSingleUser) saveJoinedTimeWithLock(ctx context.Context, convID chat1.ConversationID, t time.Time) {
+	cc.saveJoinedTimeWithLockInner(ctx, convID, t, false)
+}
+
+func (cc *JourneyCardManagerSingleUser) saveJoinedTimeWithLockInner(ctx context.Context, convID chat1.ConversationID, t time.Time, acceptUpdate bool) {
 	if convID.IsNil() {
 		return
 	}
@@ -738,7 +772,7 @@ func (cc *JourneyCardManagerSingleUser) saveJoinedTime(ctx context.Context, conv
 		cc.Debug(ctx, "storage get error: %v", err)
 		return
 	}
-	if jcd.JoinedTime != nil {
+	if jcd.JoinedTime != nil && !acceptUpdate {
 		return
 	}
 	jcd = jcd.CloneSemi()
@@ -749,6 +783,94 @@ func (cc *JourneyCardManagerSingleUser) saveJoinedTime(ctx context.Context, conv
 	if err != nil {
 		cc.Debug(ctx, "storage put error: %v", err)
 	}
+}
+
+// TimeTravel simulates moving all known conversations forward in time.
+// For use simulating a user experience without the need to wait hours for cards to appear.
+func (cc *JourneyCardManagerSingleUser) TimeTravel(ctx context.Context, duration time.Duration) (err error) {
+	err = libkb.AcquireWithContextAndTimeout(ctx, &cc.storageLock, 10*time.Second)
+	if err != nil {
+		return err
+	}
+	defer cc.storageLock.Unlock()
+	convIDs, err := cc.getKnownConvsForDebuggingWithLock(ctx)
+	if err != nil {
+		return err
+	}
+	for _, convID := range convIDs {
+		jcd, err := cc.getConvDataWithLock(ctx, convID)
+		if err != nil {
+			return fmt.Errorf("convID:%v err:%v", convID, err)
+		}
+		jcd = jcd.CloneSemi()
+		if jcd.JoinedTime != nil {
+			cc.Debug(ctx, "time travel convID:%v", convID)
+			cc.saveJoinedTimeWithLockInner(ctx, convID, jcd.JoinedTime.Time().Add(-duration), true)
+		}
+	}
+	return nil
+}
+
+// ResetAllConvs deletes storage for all conversations.
+// For use simulating a fresh user experience without the need to switch accounts.
+func (cc *JourneyCardManagerSingleUser) ResetAllConvs(ctx context.Context) (err error) {
+	err = libkb.AcquireWithContextAndTimeout(ctx, &cc.storageLock, 10*time.Second)
+	if err != nil {
+		return err
+	}
+	defer cc.storageLock.Unlock()
+	convIDs, err := cc.getKnownConvsForDebuggingWithLock(ctx)
+	if err != nil {
+		return err
+	}
+	cc.lru.Purge()
+	for _, convID := range convIDs {
+		err = cc.encryptedDB.Delete(ctx, cc.dbKey(convID))
+		if err != nil {
+			return fmt.Errorf("convID:%v err:%v", convID, err)
+		}
+	}
+	return nil
+}
+
+func (cc *JourneyCardManagerSingleUser) DebugState(ctx context.Context, convID chat1.ConversationID) (summary string, err error) {
+	jcd, err := cc.getConvData(ctx, convID)
+	if err != nil {
+		return "", err
+	}
+	summary = spew.Sdump(jcd)
+	if jcd.JoinedTime != nil {
+		since := cc.G().GetClock().Since(jcd.JoinedTime.Time())
+		summary += fmt.Sprintf("Since joined: %v (%.1f days)", since, float64(since)/float64(time.Hour*24))
+	}
+	return summary, nil
+}
+
+func (cc *JourneyCardManagerSingleUser) getKnownConvsForDebuggingWithLock(ctx context.Context) (convs []chat1.ConversationID, err error) {
+	levelDbTableKv := "kv"
+	innerKeyPrefix := fmt.Sprintf("jc|uid:%s|convID:", cc.uid)
+	prefix := libkb.DbKey{
+		Typ: libkb.DBChatJourney,
+		Key: fmt.Sprintf("jc|uid:%s|convID:", cc.uid),
+	}.ToBytes(levelDbTableKv)
+	leveldb, ok := cc.G().LocalChatDb.GetEngine().(*libkb.LevelDb)
+	if !ok {
+		return nil, fmt.Errorf("could not get leveldb")
+	}
+	dbKeys, err := leveldb.KeysWithPrefixes(prefix)
+	if err != nil {
+		return nil, err
+	}
+	for dbKey := range dbKeys {
+		if dbKey.Typ == libkb.DBChatJourney && strings.HasPrefix(dbKey.Key, innerKeyPrefix) {
+			convID, err := chat1.MakeConvID(dbKey.Key[len(innerKeyPrefix):])
+			if err != nil {
+				return nil, err
+			}
+			convs = append(convs, convID)
+		}
+	}
+	return convs, nil
 }
 
 type journeyCardPosition struct {

--- a/go/client/cmd_script.go
+++ b/go/client/cmd_script.go
@@ -23,7 +23,7 @@ func newCmdScript(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comman
 	return cli.Command{
 		Name:         "script",
 		ArgumentHelp: "<script> [<args>]",
-		Usage:        "Run a dev debug script",
+		Usage:        "Run a dev debug script. See debugging_devel.go",
 		Action: func(c *cli.Context) {
 			cmd := NewCmdScriptRunner(g)
 			cl.ChooseCommand(cmd, "script", c)

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -1423,6 +1423,18 @@ func (m *MockChatHelper) UserReacjis(ctx context.Context, uid gregor1.UID) keyba
 	return keybase1.UserReacjis{}
 }
 
+func (m *MockChatHelper) JourneycardTimeTravel(ctx context.Context, uid gregor1.UID, duration time.Duration) error {
+	return fmt.Errorf("JourneycardTimeTravel not implemented on mock")
+}
+
+func (m *MockChatHelper) JourneycardResetAllConvs(ctx context.Context, uid gregor1.UID) error {
+	return fmt.Errorf("JourneycardResetAllConvs not implemented on mock")
+}
+
+func (m *MockChatHelper) JourneycardDebugState(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (string, error) {
+	return "", fmt.Errorf("JourneycardDebugState not implemented on mock")
+}
+
 func (m *MockChatHelper) NewConversation(ctx context.Context, uid gregor1.UID, tlfName string,
 	topicName *string, topicType chat1.TopicType, membersType chat1.ConversationMembersType,
 	vis keybase1.TLFVisibility) (chat1.ConversationLocal, error) {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -135,7 +135,7 @@ type CommandLine interface {
 type Server interface {
 }
 
-type DBKeySet map[DbKey]bool
+type DBKeySet map[DbKey]struct{}
 
 type LocalDbOps interface {
 	Put(id DbKey, aliases []DbKey, value []byte) error
@@ -1069,6 +1069,9 @@ type ChatHelper interface {
 		msgID chat1.MessageID, resolveSupersedes bool, reason *chat1.GetThreadReason) (chat1.MessageUnboxed, error)
 	UpgradeKBFSToImpteam(ctx context.Context, tlfName string, tlfID chat1.TLFID, public bool) error
 	UserReacjis(ctx context.Context, uid gregor1.UID) keybase1.UserReacjis
+	JourneycardTimeTravel(context.Context, gregor1.UID, time.Duration) error
+	JourneycardResetAllConvs(context.Context, gregor1.UID) error
+	JourneycardDebugState(context.Context, gregor1.UID, chat1.ConversationID) (string, error)
 }
 
 // Resolver resolves human-readable usernames (joe) and user asssertions (joe+joe@github)

--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -382,7 +382,7 @@ func (l *LevelDb) OpenTransaction() (LocalDbTransaction, error) {
 }
 
 func (l *LevelDb) KeysWithPrefixes(prefixes ...[]byte) (DBKeySet, error) {
-	m := make(map[DbKey]bool)
+	m := make(map[DbKey]struct{})
 
 	l.Lock()
 	defer l.Unlock()
@@ -396,7 +396,7 @@ func (l *LevelDb) KeysWithPrefixes(prefixes ...[]byte) (DBKeySet, error) {
 				iter.Release()
 				return m, err
 			}
-			m[dbKey] = true
+			m[dbKey] = struct{}{}
 		}
 		iter.Release()
 		err := iter.Error()


### PR DESCRIPTION
Tools for playing with journeycard state. I hope these can be useful for QA, and secondarily for debugging. The commands require a local build of the service. If that needs changing they can be turned into real cli commands.

```
$ keybase script journeycard-fastforward 30
▶ INFO time advanced by 720h0m0s for all convs [tags:DG=XZNdLdS1clte]
```

```
$ keybase script journeycard-state 000059aa7f324dad7524b56ed1beb3e3d620b3897d640951710f1417c6b7b85f
(chat.journeyCardConvData) {
 DiskVersion: (int) 1,
 Positions: (map[chat1.JourneycardType]*chat.journeyCardPosition) (len=1) {
  (chat1.JourneycardType) CREATE_CHANNELS: (*chat.journeyCardPosition)(0xc0025d7c80)({
   PrevID: (chat1.MessageID) 31
  })
 },
 SentMessage: (bool) true,
 JoinedTime: (*gregor1.Time)(0xc0049da508)(1568823898337)
}
Since joined: 1561h9m40.844054s (65.0 days)
```

```
$ keybase script journeycard-resetall
▶ INFO journeycard state has been reset for all convs [tags:DG=MdqoZZ8ddZLc]
```

cc @cjb 