### PR TITLE
Make message input wider on mobile.

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -346,7 +346,7 @@ const styles = Styles.styleSheetCreate(
         alignSelf: 'flex-end',
         height: 50,
         position: 'relative',
-        width: 106,
+        width: 70,
       },
       actionIconsContainer: {
         marginBottom: Styles.globalMargins.xsmall,


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. It makes the chat input wide by making the “Send” button area as small as it needs to be.