### PR TITLE
write app-state.json again so installer understands gui busy state

### DIFF
--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -74,7 +74,13 @@ function* initializeInputMonitor(): Iterable<any> {
     if (skipAppFocusActions) {
       console.log('Skipping app focus actions!')
     } else {
-      yield Saga.put(ConfigGen.createChangedActive({userActive: type === 'active'}))
+      const userActive = type === 'active'
+      yield Saga.put(ConfigGen.createChangedActive({userActive}))
+      // let node thread save file
+      SafeElectron.getApp().emit('KBkeybase', '', {
+        payload: {isUserActive: userActive},
+        type: 'activeChanged',
+      })
     }
   }
 }

--- a/shared/desktop/app/node.desktop.tsx
+++ b/shared/desktop/app/node.desktop.tsx
@@ -6,6 +6,8 @@ import installer from './installer.desktop'
 import menuBar from './menu-bar.desktop'
 import menuHelper from './menu-helper.desktop'
 import os from 'os'
+import fs from 'fs'
+import path from 'path'
 import * as ConfigGen from '../../actions/config-gen'
 import * as DeeplinksGen from '../../actions/deeplinks-gen'
 import * as SafeElectron from '../../util/safe-electron.desktop'
@@ -169,6 +171,12 @@ let menubarWindowID = 0
 
 type Action =
   | {type: 'appStartedUp'}
+  | {
+      type: 'activeChanged'
+      payload: {
+        isUserActive: boolean
+      }
+    }
   | {type: 'requestStartService'}
   | {type: 'closeWindows'}
   | {
@@ -213,6 +221,19 @@ const findRemoteComponent = (windowComponent: string, windowParam: string) => {
 const plumbEvents = () => {
   Electron.app.on('KBkeybase' as any, (_: string, action: Action) => {
     switch (action.type) {
+      case 'activeChanged':
+        // the installer reads this file to understand the gui state to not interrupt
+        // TODO change how this works
+        try {
+          fs.writeFileSync(
+            path.join(SafeElectron.getApp().getPath('userData'), 'app-state.json'),
+            JSON.stringify({isUserActive: action.payload.isUserActive}),
+            {encoding: 'utf8'}
+          )
+        } catch (e) {
+          console.warn('update app state failed' + e)
+        }
+        break
       case 'appStartedUp':
         appStartedUp = true
         if (menubarWindowID) {


### PR DESCRIPTION
This fixes the busy check here:
https://github.com/keybase/go-updater/blob/0998111b6e4a0d9d1cd8e797b669e158c5d3ddf0/updater.go#L317