### PR TITLE
fix: if user cannot write, don't show clear conversation button

### DIFF
--- a/shared/chat/conversation/info-panel/container.tsx
+++ b/shared/chat/conversation/info-panel/container.tsx
@@ -57,7 +57,7 @@ const ConnectedInfoPanel = Container.connect(
       canEditChannel = yourOperations.editTeamDescription
       canSetMinWriterRole = yourOperations.setMinWriterRole
       canSetRetention = yourOperations.setRetentionPolicy
-      canDeleteHistory = yourOperations.deleteChatHistory
+      canDeleteHistory = yourOperations.deleteChatHistory && !meta.cannotWrite
     } else {
       canDeleteHistory = true
     }


### PR DESCRIPTION
Addresses an issue where admins clearing a conversation with a `minWriterRole` of owner would cause an error