### PR TITLE
journeycard changes, mostly POPULAR_CHANNELS

### DIFF
--- a/go/chat/journey_card_manager.go
+++ b/go/chat/journey_card_manager.go
@@ -486,13 +486,13 @@ func (cc *JourneyCardManagerSingleUser) cardPopularChannels(ctx context.Context,
 // Condition: A few days on top of POPULAR_CHANNELS have passed since the user joined the channel. In order to space it out from POPULAR_CHANNELS.
 func (cc *JourneyCardManagerSingleUser) cardAddPeople(ctx context.Context, conv convForJourneycard, jcd journeyCardConvData,
 	debugDebug logFn) bool {
-	if !conv.UntrustedTeamRole.IsAdminOrAbove() {
+	if !conv.IsGeneralChannel || !conv.UntrustedTeamRole.IsAdminOrAbove() {
 		return false
 	}
 	if !cc.timeSinceJoined(ctx, conv.ConvID, jcd, time.Hour*24*4) {
 		return false
 	}
-	if jcd.SentMessage || !conv.IsGeneralChannel {
+	if jcd.SentMessage {
 		return true
 	}
 	// Figure whether the user is in other channels.

--- a/go/chat/journey_card_manager.go
+++ b/go/chat/journey_card_manager.go
@@ -449,16 +449,17 @@ func (cc *JourneyCardManagerSingleUser) cardPopularChannels(ctx context.Context,
 	// Don't get the actual names, since for NEVER_JOINED convs LocalMetadata,
 	// which has the name, is not generally available. The gui will fetch the names async.
 	topicType := chat1.TopicType_CHAT
+	joinableStatuses := []chat1.ConversationMemberStatus{ // keep in sync with cards/team-journey/container.tsx
+		chat1.ConversationMemberStatus_REMOVED,
+		chat1.ConversationMemberStatus_LEFT,
+		chat1.ConversationMemberStatus_RESET,
+		chat1.ConversationMemberStatus_NEVER_JOINED,
+	}
 	inbox, err := cc.G().InboxSource.ReadUnverified(ctx, cc.uid, types.InboxSourceDataSourceLocalOnly,
 		&chat1.GetInboxQuery{
-			TlfID:     &conv.TlfID,
-			TopicType: &topicType,
-			MemberStatus: []chat1.ConversationMemberStatus{
-				chat1.ConversationMemberStatus_REMOVED,
-				chat1.ConversationMemberStatus_LEFT,
-				chat1.ConversationMemberStatus_RESET,
-				chat1.ConversationMemberStatus_NEVER_JOINED,
-			},
+			TlfID:            &conv.TlfID,
+			TopicType:        &topicType,
+			MemberStatus:     joinableStatuses,
 			MembersTypes:     []chat1.ConversationMembersType{chat1.ConversationMembersType_TEAM},
 			SummarizeMaxMsgs: true,
 			SkipBgLoads:      true,

--- a/go/chat/journey_card_manager.go
+++ b/go/chat/journey_card_manager.go
@@ -341,7 +341,7 @@ func (cc *JourneyCardManagerSingleUser) PickCard(ctx context.Context,
 	cardConditionTODO := func(ctx context.Context) bool { return false }
 	cardConditions := map[chat1.JourneycardType]cardCondition{
 		chat1.JourneycardType_WELCOME:            func(ctx context.Context) bool { return cc.cardWelcome(ctx, convID, conv, jcd) },
-		chat1.JourneycardType_POPULAR_CHANNELS:   func(ctx context.Context) bool { return cc.cardPopularChannels(ctx, convID, conv, jcd) },
+		chat1.JourneycardType_POPULAR_CHANNELS:   func(ctx context.Context) bool { return cc.cardPopularChannels(ctx, convID, conv, jcd, debugDebug) },
 		chat1.JourneycardType_ADD_PEOPLE:         func(ctx context.Context) bool { return cc.cardAddPeople(ctx, conv, jcd, debugDebug) },
 		chat1.JourneycardType_CREATE_CHANNELS:    func(ctx context.Context) bool { return cc.cardCreateChannels(ctx, convID, jcd) },
 		chat1.JourneycardType_MSG_ATTENTION:      cardConditionTODO,
@@ -436,11 +436,46 @@ func (cc *JourneyCardManagerSingleUser) cardWelcome(ctx context.Context, convID 
 // Card type: POPULAR_CHANNELS (2 on design)
 // Gist: "You are in #general. Other popular channels in this team: diplomacy, sportsball"
 // Condition: Only in #general channel
-// Condition: The team has channels besides general.
+// Condition: The team has channels besides general that the user could join.
 // Condition: User has sent a first message OR a few days have passed since they joined the channel.
-func (cc *JourneyCardManagerSingleUser) cardPopularChannels(ctx context.Context, convID chat1.ConversationID, conv convForJourneycard, jcd journeyCardConvData) bool {
+func (cc *JourneyCardManagerSingleUser) cardPopularChannels(ctx context.Context, convID chat1.ConversationID, conv convForJourneycard,
+	jcd journeyCardConvData, debugDebug logFn) bool {
 	otherChannelsExist := conv.GetTeamType() == chat1.TeamType_COMPLEX
-	return conv.IsGeneralChannel && otherChannelsExist && (jcd.SentMessage || cc.timeSinceJoined(ctx, conv.ConvID, jcd, time.Hour*24*2))
+	simpleQualified := conv.IsGeneralChannel && otherChannelsExist && (jcd.SentMessage || cc.timeSinceJoined(ctx, conv.ConvID, jcd, time.Hour*24*2))
+	if !simpleQualified {
+		return false
+	}
+	// Figure out whether there are other channels that the user is not in.
+	// Don't get the actual names, since for NEVER_JOINED convs LocalMetadata,
+	// which has the name, is not generally available. The gui will fetch the names async.
+	topicType := chat1.TopicType_CHAT
+	inbox, err := cc.G().InboxSource.ReadUnverified(ctx, cc.uid, types.InboxSourceDataSourceLocalOnly,
+		&chat1.GetInboxQuery{
+			TlfID:     &conv.TlfID,
+			TopicType: &topicType,
+			MemberStatus: []chat1.ConversationMemberStatus{
+				chat1.ConversationMemberStatus_REMOVED,
+				chat1.ConversationMemberStatus_LEFT,
+				chat1.ConversationMemberStatus_RESET,
+				chat1.ConversationMemberStatus_NEVER_JOINED,
+			},
+			MembersTypes:     []chat1.ConversationMembersType{chat1.ConversationMembersType_TEAM},
+			SummarizeMaxMsgs: true,
+			SkipBgLoads:      true,
+			AllowUnseenQuery: true, // Make an effort, it's ok if convs are missed.
+		})
+	if err != nil {
+		debugDebug(ctx, "cardPopularChannels ReadUnverified error: %v", err)
+		return false
+	}
+	debugDebug(ctx, "cardPopularChannels ReadUnverified found %v convs", len(inbox.ConvsUnverified))
+	for _, convOther := range inbox.ConvsUnverified {
+		if !convOther.GetConvID().Eq(conv.ConvID) {
+			debugDebug(ctx, "cardPopularChannels ReadUnverified found alternate conv: %v", convOther.GetConvID())
+			return true
+		}
+	}
+	return false
 }
 
 // Card type: ADD_PEOPLE (3 on design)

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -155,7 +155,7 @@
 
   enum ConversationMemberStatus {
     ACTIVE_0,      // in the channel
-    REMOVED_1,     // removed from channel forcibly
+    REMOVED_1,     // user was in the channel when they left the team
     LEFT_2,        // voluntarily left conversation
     PREVIEW_3,     // use is previewing the channel from an @mention
     RESET_4,       // status of having an account reset in an impteam

--- a/shared/chat/conversation/messages/cards/team-journey/container.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/container.tsx
@@ -144,8 +144,8 @@ const TeamJourneyConnected = Container.connect(
       .toArray()
       .filter(info => joinableStatuses.has(info.memberStatus))
       .sort((x, y) => y.mtime - x.mtime)
-      .map(info => info.channelname)
       .slice(0, Container.isMobile ? 2 : 3)
+      .map(info => info.channelname)
 
     return {
       channelname,

--- a/shared/chat/conversation/messages/cards/team-journey/container.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/container.tsx
@@ -55,8 +55,8 @@ const TeamJourneyContainer = (props: Props) => {
         onClick: () => props.onGoToChannel(chan),
       }))
       loadTeam = props.onLoadTeam
-      text = `You are in *#${props.channelname}*.
-Some popular channels in this team:`
+      text = `You are in *#${props.channelname}*.\n`
+      text += props.otherChannels.length ? `Some other channels in this team:` : `And you're in all the other channels, nice.`
       break
     case RPCChatTypes.JourneycardType.addPeople:
       actions = [{label: 'Add people to the team', onClick: props.onAddPeopleToTeam}]

--- a/shared/chat/conversation/messages/cards/team-journey/container.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/container.tsx
@@ -133,10 +133,16 @@ const TeamJourneyConnected = Container.connect(
   (stateProps, dispatchProps, ownProps) => {
     const {channelname, teamname} = stateProps
     // Take the top three channels with most recent activity.
+    const joinableStatuses = new Set([ // keep in sync with journey_card_manager.go
+				RPCChatTypes.ConversationMemberStatus.removed,
+				RPCChatTypes.ConversationMemberStatus.left,
+				RPCChatTypes.ConversationMemberStatus.reset,
+				RPCChatTypes.ConversationMemberStatus.neverJoined,
+    ])
     const otherChannels = stateProps._channelInfos
       .valueSeq()
       .toArray()
-      .filter(info => info.memberStatus !== RPCChatTypes.ConversationMemberStatus.active)
+      .filter(info => joinableStatuses.has(info.memberStatus))
       .sort((x, y) => y.mtime - x.mtime)
       .map(info => info.channelname)
       .slice(0, Container.isMobile ? 2 : 3)

--- a/shared/chat/conversation/messages/cards/team-journey/container.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/container.tsx
@@ -56,7 +56,9 @@ const TeamJourneyContainer = (props: Props) => {
       }))
       loadTeam = props.onLoadTeam
       text = `You are in *#${props.channelname}*.\n`
-      text += props.otherChannels.length ? `Some other channels in this team:` : `And you're in all the other channels, nice.`
+      text += props.otherChannels.length
+        ? `Some other channels in this team:`
+        : `And you're in all the other channels, nice.`
       break
     case RPCChatTypes.JourneycardType.addPeople:
       actions = [{label: 'Add people to the team', onClick: props.onAddPeopleToTeam}]
@@ -133,11 +135,12 @@ const TeamJourneyConnected = Container.connect(
   (stateProps, dispatchProps, ownProps) => {
     const {channelname, teamname} = stateProps
     // Take the top three channels with most recent activity.
-    const joinableStatuses = new Set([ // keep in sync with journey_card_manager.go
-				RPCChatTypes.ConversationMemberStatus.removed,
-				RPCChatTypes.ConversationMemberStatus.left,
-				RPCChatTypes.ConversationMemberStatus.reset,
-				RPCChatTypes.ConversationMemberStatus.neverJoined,
+    const joinableStatuses = new Set([
+      // keep in sync with journey_card_manager.go
+      RPCChatTypes.ConversationMemberStatus.removed,
+      RPCChatTypes.ConversationMemberStatus.left,
+      RPCChatTypes.ConversationMemberStatus.reset,
+      RPCChatTypes.ConversationMemberStatus.neverJoined,
     ])
     const otherChannels = stateProps._channelInfos
       .valueSeq()

--- a/shared/chat/conversation/messages/cards/team-journey/index.stories.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/index.stories.tsx
@@ -25,7 +25,7 @@ const load = () => {
         image={null}
         teamname="foo"
         text={`You are in *#somechan*.
-Some popular channels in this team:`}
+Some other channels in this team:`}
       />
     ))
     .add('Popular long channels', () => (
@@ -38,7 +38,16 @@ Some popular channels in this team:`}
         image={null}
         teamname="foo"
         text={`You are in *#somechan*.
-Some popular channels in this team:`}
+Some other channels in this team:`}
+      />
+    ))
+    .add('Popular no channels', () => (
+      <TeamJourney
+        actions={[]}
+        image={null}
+        teamname="foo"
+        text={`You are in *#somechan*.
+And you're in all the other channels, nice.`}
       />
     ))
     .add('Add people', () => (


### PR DESCRIPTION
Only present POPULAR_CHANNELS when there are channels to join.

However, once you join all channels, the card may still in the conv. So there's a state for having joined all of them. It's not great, but it's a little better than `Here are some channels: <crickets>`

cc @mmaxim 