### PR TITLE
Remove containerNoExploding

### DIFF
--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -431,6 +431,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     const padding = Styles.globalMargins.tiny
     const width =
       iconSizes.length <= 0 ? 0 : iconSizes.reduce((total, size) => total + size, iconSizes.length * padding)
+    const marginRight = Styles.isMobile && !this.props.showUsername ? 0 : -Styles.globalMargins.tiny
 
     const key = `${width}:${this.props.showUsername ? 1 : 0}:${exploding ? 1 : 0}:${exploded ? 1 : 0}`
 
@@ -439,6 +440,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
         styles.menuButtons,
         !exploded && {width},
         !!this.props.showUsername && styles.menuButtonsWithAuthor,
+        {marginRight},
       ])
     }
     return this._cachedMenuStyles[key]
@@ -559,13 +561,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                 ordinal={message.ordinal}
               />
             )}
-            {this.props.isRevoked && (
-              <Kb.Icon
-                type="iconfont-rip"
-                color={Styles.globalColors.black_20}
-                style={styles.marginLeftTiny}
-              />
-            )}
+            {this.props.isRevoked && <Kb.Icon type="iconfont-rip" color={Styles.globalColors.black_20} />}
             {this.props.showCoinsIcon && (
               <Kb.Icon type="icon-stellar-coins-stacked-16" style={styles.marginLeftTiny} />
             )}

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -33,8 +33,8 @@ import UnfurlList from './unfurl/unfurl-list/container'
 import UnfurlPromptList from './unfurl/prompt-list/container'
 import CoinFlip from '../coinflip/container'
 import TeamJourney from '../cards/team-journey/container'
-import {dismiss as dismissKeyboard} from '../../../../util/keyboard'
-import {formatTimeForChat} from '../../../../util/timestamp'
+import { dismiss as dismissKeyboard } from '../../../../util/keyboard'
+import { formatTimeForChat } from '../../../../util/timestamp'
 
 /**
  * WrapperMessage adds the orange line, menu button, menu, reacji
@@ -112,24 +112,24 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
   _updateHighlightMode = () => {
     switch (this.props.centeredOrdinal) {
       case 'flash':
-        this.setState({disableCenteredHighlight: false})
+        this.setState({ disableCenteredHighlight: false })
         setTimeout(() => {
           if (this._mounted) {
-            this.setState({disableCenteredHighlight: true})
+            this.setState({ disableCenteredHighlight: true })
           }
         }, 2000)
         break
       case 'always':
-        this.setState({disableCenteredHighlight: false})
+        this.setState({ disableCenteredHighlight: false })
         break
     }
   }
   _showCenteredHighlight = () => {
     return !this.state.disableCenteredHighlight && this.props.centeredOrdinal !== 'none'
   }
-  _onMouseOver = () => this.setState(o => (o.showMenuButton ? null : {showMenuButton: true}))
+  _onMouseOver = () => this.setState(o => (o.showMenuButton ? null : { showMenuButton: true }))
   _setShowingPicker = (showingPicker: boolean) =>
-    this.setState(s => (s.showingPicker === showingPicker ? null : {showingPicker}))
+    this.setState(s => (s.showingPicker === showingPicker ? null : { showingPicker }))
   _dismissKeyboard = () => dismissKeyboard()
   _orangeLine = () =>
     this.props.orangeLineAbove && (
@@ -138,7 +138,6 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
         direction="vertical"
         style={Styles.collapseStyles([
           styles.orangeLine,
-          !this._isExploding() && styles.orangeLineCompensationRight,
           !this.props.showUsername && styles.orangeLineCompensationLeft,
         ])}
       />
@@ -177,17 +176,17 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
             <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.usernameCrown}>
               {this.props.botAlias ? (
                 <Kb.Box2 direction="horizontal">
-                  <Kb.Text type="BodySmallBold" style={{color: Styles.globalColors.black}}>
+                  <Kb.Text type="BodySmallBold" style={{ color: Styles.globalColors.black }}>
                     {this.props.botAlias} [
                   </Kb.Text>
                   {username}
-                  <Kb.Text type="BodySmallBold" style={{color: Styles.globalColors.black}}>
+                  <Kb.Text type="BodySmallBold" style={{ color: Styles.globalColors.black }}>
                     ]
                   </Kb.Text>
                 </Kb.Box2>
               ) : (
-                username
-              )}
+                  username
+                )}
               {this.props.showCrowns && (this.props.authorIsOwner || this.props.authorIsAdmin) && (
                 <Kb.WithTooltip tooltip={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
                   <Kb.Icon
@@ -231,8 +230,8 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     return this.props.isPendingPayment ? (
       <PendingPaymentBackground key="pendingBackground">{result}</PendingPaymentBackground>
     ) : (
-      result
-    )
+        result
+      )
   }
 
   _isEdited = () =>
@@ -364,19 +363,18 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       const props = {
         style: Styles.collapseStyles([
           styles.container,
-          !this._isExploding() && styles.containerNoExploding, // extra right padding to line up with infopane / input icons
           this._showCenteredHighlight() && styles.centeredOrdinal,
           !this.props.showUsername && styles.containerNoUsername,
         ]),
       }
       return this.props.decorate
         ? {
-            ...props,
-            onLongPress: this.props.toggleShowingMenu,
-            onPress: this._dismissKeyboard,
-            onSwipeLeft: this.props.onSwipeLeft,
-            underlayColor: Styles.globalColors.blueLighter3,
-          }
+          ...props,
+          onLongPress: this.props.toggleShowingMenu,
+          onPress: this._dismissKeyboard,
+          onSwipeLeft: this.props.onSwipeLeft,
+          underlayColor: Styles.globalColors.blueLighter3,
+        }
         : props
     } else {
       return {
@@ -431,16 +429,14 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     const padding = Styles.globalMargins.tiny
     const width =
       iconSizes.length <= 0 ? 0 : iconSizes.reduce((total, size) => total + size, iconSizes.length * padding)
-    const marginRight = Styles.isMobile && !this.props.showUsername ? 0 : -Styles.globalMargins.tiny
 
     const key = `${width}:${this.props.showUsername ? 1 : 0}:${exploding ? 1 : 0}:${exploded ? 1 : 0}`
 
     if (!this._cachedMenuStyles[key]) {
       this._cachedMenuStyles[key] = Styles.collapseStyles([
         styles.menuButtons,
-        !exploded && {width},
+        !exploded && { width },
         !!this.props.showUsername && styles.menuButtonsWithAuthor,
-        {marginRight},
       ])
     }
     return this._cachedMenuStyles[key]
@@ -540,8 +536,8 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
         {child}
       </ExplodingHeightRetainer>
     ) : (
-      child
-    )
+        child
+      )
 
     // We defer mounting the menu buttons since they are expensive and only show up on hover on desktop and not at all on mobile
     // but this creates complexity as we can't use box2 gap stuff since we can either
@@ -562,9 +558,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               />
             )}
             {this.props.isRevoked && <Kb.Icon type="iconfont-rip" color={Styles.globalColors.black_20} />}
-            {this.props.showCoinsIcon && (
-              <Kb.Icon type="icon-stellar-coins-stacked-16" style={styles.marginLeftTiny} />
-            )}
+            {this.props.showCoinsIcon && <Kb.Icon type="icon-stellar-coins-stacked-16" />}
             {showMenuButton ? (
               <Kb.Box className="WrapperMessage-buttons">
                 {!this._hasReactions() &&
@@ -631,16 +625,16 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
             this.props.message.type === 'journeycard' ? (
               <TeamJourney message={this.props.message} />
             ) : (
-              this._authorAndContent([
-                this._messageAndButtons(),
-                this._isEdited(),
-                this._isFailed(),
-                this._unfurlPrompts(),
-                this._unfurlList(),
-                this._coinFlip(),
-                this._reactionsRow(),
-              ])
-            ),
+                this._authorAndContent([
+                  this._messageAndButtons(),
+                  this._isEdited(),
+                  this._isFailed(),
+                  this._unfurlPrompts(),
+                  this._unfurlList(),
+                  this._coinFlip(),
+                  this._reactionsRow(),
+                ])
+              ),
             this._orangeLine(),
             this._sendIndicator(),
           ]}
@@ -653,7 +647,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
 
 const WrapperMessage = Kb.OverlayParentHOC(_WrapperMessage)
 
-const fast = {backgroundColor: Styles.globalColors.fastBlank}
+const fast = { backgroundColor: Styles.globalColors.fastBlank }
 const styles = Styles.styleSheetCreate(
   () =>
     ({
@@ -663,19 +657,18 @@ const styles = Styles.styleSheetCreate(
           alignSelf: 'flex-start',
           height: Styles.globalMargins.mediumLarge,
         },
-        isMobile: {marginTop: 8},
+        isMobile: { marginTop: 8 },
       }),
       avatar: Styles.platformStyles({
         isElectron: {
           marginLeft: Styles.globalMargins.small,
         },
-        isMobile: {marginLeft: Styles.globalMargins.tiny},
+        isMobile: { marginLeft: Styles.globalMargins.tiny },
       }),
       centeredOrdinal: {
         backgroundColor: Styles.globalColors.yellowOrYellowAlt,
       },
-      container: Styles.platformStyles({isMobile: {overflow: 'hidden'}}),
-      containerNoExploding: Styles.platformStyles({isMobile: {paddingRight: Styles.globalMargins.tiny}}),
+      container: Styles.platformStyles({ isMobile: { overflow: 'hidden' } }),
       containerNoUsername: Styles.platformStyles({
         isMobile: {
           paddingBottom: 3,
@@ -708,9 +701,9 @@ const styles = Styles.styleSheetCreate(
           paddingRight: Styles.globalMargins.tiny,
         },
       }),
-      edited: {color: Styles.globalColors.black_20},
-      editedHighlighted: {color: Styles.globalColors.black_20OrBlack},
-      ellipsis: {marginLeft: Styles.globalMargins.tiny},
+      edited: { color: Styles.globalColors.black_20 },
+      editedHighlighted: { color: Styles.globalColors.black_20OrBlack },
+      ellipsis: { marginLeft: Styles.globalMargins.tiny },
       emojiRow: Styles.platformStyles({
         isElectron: {
           borderBottomLeftRadius: Styles.borderRadius,
@@ -744,10 +737,10 @@ const styles = Styles.styleSheetCreate(
           top: -Styles.globalMargins.mediumLarge + 1, // compensation for the orange line
         },
       }),
-      fail: {color: Styles.globalColors.redDark},
-      failUnderline: {color: Styles.globalColors.redDark, textDecorationLine: 'underline'},
+      fail: { color: Styles.globalColors.redDark },
+      failUnderline: { color: Styles.globalColors.redDark, textDecorationLine: 'underline' },
       fast,
-      marginLeftTiny: {marginLeft: Styles.globalMargins.tiny},
+      marginLeftTiny: { marginLeft: Styles.globalMargins.tiny },
       menuButtons: Styles.platformStyles({
         common: {
           alignSelf: 'flex-start',
@@ -755,10 +748,10 @@ const styles = Styles.styleSheetCreate(
           justifyContent: 'flex-end',
           overflow: 'hidden',
         },
-        isElectron: {height: 16},
-        isMobile: {height: 21},
+        isElectron: { height: 16 },
+        isMobile: { height: 21 },
       }),
-      menuButtonsWithAuthor: {marginTop: -16},
+      menuButtonsWithAuthor: { marginTop: -16 },
       messagePopupContainer: {
         marginRight: Styles.globalMargins.small,
       },
@@ -777,11 +770,6 @@ const styles = Styles.styleSheetCreate(
           left: -Styles.globalMargins.mediumLarge, // compensate for containerNoUsername's padding
         },
       }),
-      orangeLineCompensationRight: Styles.platformStyles({
-        isMobile: {
-          right: -Styles.globalMargins.tiny, // compensate for containerNoExploding's padding
-        },
-      }),
       send: Styles.platformStyles({
         common: {
           position: 'absolute',
@@ -797,8 +785,8 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       timestamp: Styles.platformStyles({
-        common: {paddingLeft: Styles.globalMargins.xtiny},
-        isElectron: {lineHeight: 19},
+        common: { paddingLeft: Styles.globalMargins.xtiny },
+        isElectron: { lineHeight: 19 },
       }),
       timestampHighlighted: {
         color: Styles.globalColors.black_50OrBlack_40,
@@ -809,7 +797,7 @@ const styles = Styles.styleSheetCreate(
           position: 'relative',
           top: -2,
         },
-        isMobile: {alignItems: 'center'},
+        isMobile: { alignItems: 'center' },
       }),
       usernameHighlighted: {
         color: Styles.globalColors.blackOrBlack,

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -421,8 +421,8 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
   _cachedMenuStyles = {}
   _menuAreaStyle = (exploded, exploding) => {
     const iconSizes = [
-      this.props.isRevoked ? 16 : 0, // revoked
-      this.props.showCoinsIcon ? 16 : 0, // coin stack
+      this.props.isRevoked ? 24 : 0, // revoked
+      this.props.showCoinsIcon ? 24 : 0, // coin stack
       exploded || Styles.isMobile ? 0 : 16, // ... menu
       exploding ? (Styles.isMobile ? 57 : 46) : 0, // exploding
     ].filter(Boolean)
@@ -557,8 +557,16 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                 ordinal={message.ordinal}
               />
             )}
-            {this.props.isRevoked && <Kb.Icon type="iconfont-rip" color={Styles.globalColors.black_20} />}
-            {this.props.showCoinsIcon && <Kb.Icon type="icon-stellar-coins-stacked-16" />}
+            {this.props.isRevoked && (
+              <Kb.Icon
+                type="iconfont-rip"
+                style={styles.paddingLeftTiny}
+                color={Styles.globalColors.black_20}
+              />
+            )}
+            {this.props.showCoinsIcon && (
+              <Kb.Icon type="icon-stellar-coins-stacked-16" style={styles.paddingLeftTiny} />
+            )}
             {showMenuButton ? (
               <Kb.Box className="WrapperMessage-buttons">
                 {!this._hasReactions() &&
@@ -740,7 +748,6 @@ const styles = Styles.styleSheetCreate(
       fail: { color: Styles.globalColors.redDark },
       failUnderline: { color: Styles.globalColors.redDark, textDecorationLine: 'underline' },
       fast,
-      marginLeftTiny: { marginLeft: Styles.globalMargins.tiny },
       menuButtons: Styles.platformStyles({
         common: {
           alignSelf: 'flex-start',
@@ -770,6 +777,7 @@ const styles = Styles.styleSheetCreate(
           left: -Styles.globalMargins.mediumLarge, // compensate for containerNoUsername's padding
         },
       }),
+      paddingLeftTiny: { paddingLeft: Styles.globalMargins.tiny },
       send: Styles.platformStyles({
         common: {
           position: 'absolute',

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -33,8 +33,8 @@ import UnfurlList from './unfurl/unfurl-list/container'
 import UnfurlPromptList from './unfurl/prompt-list/container'
 import CoinFlip from '../coinflip/container'
 import TeamJourney from '../cards/team-journey/container'
-import { dismiss as dismissKeyboard } from '../../../../util/keyboard'
-import { formatTimeForChat } from '../../../../util/timestamp'
+import {dismiss as dismissKeyboard} from '../../../../util/keyboard'
+import {formatTimeForChat} from '../../../../util/timestamp'
 
 /**
  * WrapperMessage adds the orange line, menu button, menu, reacji
@@ -112,24 +112,24 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
   _updateHighlightMode = () => {
     switch (this.props.centeredOrdinal) {
       case 'flash':
-        this.setState({ disableCenteredHighlight: false })
+        this.setState({disableCenteredHighlight: false})
         setTimeout(() => {
           if (this._mounted) {
-            this.setState({ disableCenteredHighlight: true })
+            this.setState({disableCenteredHighlight: true})
           }
         }, 2000)
         break
       case 'always':
-        this.setState({ disableCenteredHighlight: false })
+        this.setState({disableCenteredHighlight: false})
         break
     }
   }
   _showCenteredHighlight = () => {
     return !this.state.disableCenteredHighlight && this.props.centeredOrdinal !== 'none'
   }
-  _onMouseOver = () => this.setState(o => (o.showMenuButton ? null : { showMenuButton: true }))
+  _onMouseOver = () => this.setState(o => (o.showMenuButton ? null : {showMenuButton: true}))
   _setShowingPicker = (showingPicker: boolean) =>
-    this.setState(s => (s.showingPicker === showingPicker ? null : { showingPicker }))
+    this.setState(s => (s.showingPicker === showingPicker ? null : {showingPicker}))
   _dismissKeyboard = () => dismissKeyboard()
   _orangeLine = () =>
     this.props.orangeLineAbove && (
@@ -176,17 +176,17 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
             <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.usernameCrown}>
               {this.props.botAlias ? (
                 <Kb.Box2 direction="horizontal">
-                  <Kb.Text type="BodySmallBold" style={{ color: Styles.globalColors.black }}>
+                  <Kb.Text type="BodySmallBold" style={{color: Styles.globalColors.black}}>
                     {this.props.botAlias} [
                   </Kb.Text>
                   {username}
-                  <Kb.Text type="BodySmallBold" style={{ color: Styles.globalColors.black }}>
+                  <Kb.Text type="BodySmallBold" style={{color: Styles.globalColors.black}}>
                     ]
                   </Kb.Text>
                 </Kb.Box2>
               ) : (
-                  username
-                )}
+                username
+              )}
               {this.props.showCrowns && (this.props.authorIsOwner || this.props.authorIsAdmin) && (
                 <Kb.WithTooltip tooltip={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
                   <Kb.Icon
@@ -230,8 +230,8 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     return this.props.isPendingPayment ? (
       <PendingPaymentBackground key="pendingBackground">{result}</PendingPaymentBackground>
     ) : (
-        result
-      )
+      result
+    )
   }
 
   _isEdited = () =>
@@ -369,12 +369,12 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       }
       return this.props.decorate
         ? {
-          ...props,
-          onLongPress: this.props.toggleShowingMenu,
-          onPress: this._dismissKeyboard,
-          onSwipeLeft: this.props.onSwipeLeft,
-          underlayColor: Styles.globalColors.blueLighter3,
-        }
+            ...props,
+            onLongPress: this.props.toggleShowingMenu,
+            onPress: this._dismissKeyboard,
+            onSwipeLeft: this.props.onSwipeLeft,
+            underlayColor: Styles.globalColors.blueLighter3,
+          }
         : props
     } else {
       return {
@@ -435,7 +435,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
     if (!this._cachedMenuStyles[key]) {
       this._cachedMenuStyles[key] = Styles.collapseStyles([
         styles.menuButtons,
-        !exploded && { width },
+        !exploded && {width},
         !!this.props.showUsername && styles.menuButtonsWithAuthor,
       ])
     }
@@ -536,8 +536,8 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
         {child}
       </ExplodingHeightRetainer>
     ) : (
-        child
-      )
+      child
+    )
 
     // We defer mounting the menu buttons since they are expensive and only show up on hover on desktop and not at all on mobile
     // but this creates complexity as we can't use box2 gap stuff since we can either
@@ -633,16 +633,16 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
             this.props.message.type === 'journeycard' ? (
               <TeamJourney message={this.props.message} />
             ) : (
-                this._authorAndContent([
-                  this._messageAndButtons(),
-                  this._isEdited(),
-                  this._isFailed(),
-                  this._unfurlPrompts(),
-                  this._unfurlList(),
-                  this._coinFlip(),
-                  this._reactionsRow(),
-                ])
-              ),
+              this._authorAndContent([
+                this._messageAndButtons(),
+                this._isEdited(),
+                this._isFailed(),
+                this._unfurlPrompts(),
+                this._unfurlList(),
+                this._coinFlip(),
+                this._reactionsRow(),
+              ])
+            ),
             this._orangeLine(),
             this._sendIndicator(),
           ]}
@@ -655,7 +655,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
 
 const WrapperMessage = Kb.OverlayParentHOC(_WrapperMessage)
 
-const fast = { backgroundColor: Styles.globalColors.fastBlank }
+const fast = {backgroundColor: Styles.globalColors.fastBlank}
 const styles = Styles.styleSheetCreate(
   () =>
     ({
@@ -665,18 +665,18 @@ const styles = Styles.styleSheetCreate(
           alignSelf: 'flex-start',
           height: Styles.globalMargins.mediumLarge,
         },
-        isMobile: { marginTop: 8 },
+        isMobile: {marginTop: 8},
       }),
       avatar: Styles.platformStyles({
         isElectron: {
           marginLeft: Styles.globalMargins.small,
         },
-        isMobile: { marginLeft: Styles.globalMargins.tiny },
+        isMobile: {marginLeft: Styles.globalMargins.tiny},
       }),
       centeredOrdinal: {
         backgroundColor: Styles.globalColors.yellowOrYellowAlt,
       },
-      container: Styles.platformStyles({ isMobile: { overflow: 'hidden' } }),
+      container: Styles.platformStyles({isMobile: {overflow: 'hidden'}}),
       containerNoUsername: Styles.platformStyles({
         isMobile: {
           paddingBottom: 3,
@@ -709,9 +709,9 @@ const styles = Styles.styleSheetCreate(
           paddingRight: Styles.globalMargins.tiny,
         },
       }),
-      edited: { color: Styles.globalColors.black_20 },
-      editedHighlighted: { color: Styles.globalColors.black_20OrBlack },
-      ellipsis: { marginLeft: Styles.globalMargins.tiny },
+      edited: {color: Styles.globalColors.black_20},
+      editedHighlighted: {color: Styles.globalColors.black_20OrBlack},
+      ellipsis: {marginLeft: Styles.globalMargins.tiny},
       emojiRow: Styles.platformStyles({
         isElectron: {
           borderBottomLeftRadius: Styles.borderRadius,
@@ -745,8 +745,8 @@ const styles = Styles.styleSheetCreate(
           top: -Styles.globalMargins.mediumLarge + 1, // compensation for the orange line
         },
       }),
-      fail: { color: Styles.globalColors.redDark },
-      failUnderline: { color: Styles.globalColors.redDark, textDecorationLine: 'underline' },
+      fail: {color: Styles.globalColors.redDark},
+      failUnderline: {color: Styles.globalColors.redDark, textDecorationLine: 'underline'},
       fast,
       menuButtons: Styles.platformStyles({
         common: {
@@ -755,10 +755,10 @@ const styles = Styles.styleSheetCreate(
           justifyContent: 'flex-end',
           overflow: 'hidden',
         },
-        isElectron: { height: 16 },
-        isMobile: { height: 21 },
+        isElectron: {height: 16},
+        isMobile: {height: 21},
       }),
-      menuButtonsWithAuthor: { marginTop: -16 },
+      menuButtonsWithAuthor: {marginTop: -16},
       messagePopupContainer: {
         marginRight: Styles.globalMargins.small,
       },
@@ -777,7 +777,7 @@ const styles = Styles.styleSheetCreate(
           left: -Styles.globalMargins.mediumLarge, // compensate for containerNoUsername's padding
         },
       }),
-      paddingLeftTiny: { paddingLeft: Styles.globalMargins.tiny },
+      paddingLeftTiny: {paddingLeft: Styles.globalMargins.tiny},
       send: Styles.platformStyles({
         common: {
           position: 'absolute',
@@ -793,8 +793,8 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       timestamp: Styles.platformStyles({
-        common: { paddingLeft: Styles.globalMargins.xtiny },
-        isElectron: { lineHeight: 19 },
+        common: {paddingLeft: Styles.globalMargins.xtiny},
+        isElectron: {lineHeight: 19},
       }),
       timestampHighlighted: {
         color: Styles.globalColors.black_50OrBlack_40,
@@ -805,7 +805,7 @@ const styles = Styles.styleSheetCreate(
           position: 'relative',
           top: -2,
         },
-        isMobile: { alignItems: 'center' },
+        isMobile: {alignItems: 'center'},
       }),
       usernameHighlighted: {
         color: Styles.globalColors.blackOrBlack,


### PR DESCRIPTION
This PR fixes the alignment issues with revoked device and coin icons by removing the `containerNoExploding` styles. It also fixes issues with those message icons clipping on mobile by removing the `marginLeftTiny` style.