### PR TITLE
Consider users only stored in memory secret store during GetUsersWith…

### DIFF
--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -299,11 +299,15 @@ func (s *SecretStoreLocked) GetUsersWithStoredSecrets(m MetaContext) ([]string, 
 	s.Lock()
 	defer s.Unlock()
 	users := make(map[string]struct{})
+
 	memUsers, memErr := s.mem.GetUsersWithStoredSecrets(m)
 	if memErr == nil {
 		for _, memUser := range memUsers {
 			users[memUser] = struct{}{}
 		}
+	}
+	if s.disk == nil {
+		return memUsers, memErr
 	}
 	diskUsers, diskErr := s.disk.GetUsersWithStoredSecrets(m)
 	if diskErr == nil {

--- a/go/libkb/secret_store.go
+++ b/go/libkb/secret_store.go
@@ -298,10 +298,27 @@ func (s *SecretStoreLocked) GetUsersWithStoredSecrets(m MetaContext) ([]string, 
 	}
 	s.Lock()
 	defer s.Unlock()
-	if s.disk == nil {
-		return s.mem.GetUsersWithStoredSecrets(m)
+	users := make(map[string]struct{})
+	memUsers, memErr := s.mem.GetUsersWithStoredSecrets(m)
+	if memErr == nil {
+		for _, memUser := range memUsers {
+			users[memUser] = struct{}{}
+		}
 	}
-	return s.disk.GetUsersWithStoredSecrets(m)
+	diskUsers, diskErr := s.disk.GetUsersWithStoredSecrets(m)
+	if diskErr == nil {
+		for _, diskUser := range diskUsers {
+			users[diskUser] = struct{}{}
+		}
+	}
+	if memErr != nil && diskErr != nil {
+		return nil, CombineErrors(memErr, diskErr)
+	}
+	var ret []string
+	for user := range users {
+		ret = append(ret, user)
+	}
+	return ret, nil
 }
 
 func (s *SecretStoreLocked) PrimeSecretStores(mctx MetaContext) (err error) {


### PR DESCRIPTION
…StoredSecrets.

Issue was not that the secret was being thrown away after user switch in "Do not always stay logged in mode". It was that it was only in the in-memory store and GetUsersWithStoredSecrets, which is called by GetConfiguredAccounts, throws away the in-memory users if there is a disk secret store. Which makes sense only in the legacy single-user case.

cc @patrickxb 