### PR TITLE
fix: use nullish coalescing for snippet decoration

### DIFF
--- a/shared/chat/inbox/row/small-team/container.tsx
+++ b/shared/chat/inbox/row/small-team/container.tsx
@@ -24,7 +24,7 @@ export default Container.namedConnect(
     const youAreReset = _meta.membershipType === 'youAreReset'
     const typers = state.chat2.typingMap.get(_conversationIDKey)
     let snippet = state.chat2.metaMap.get(_conversationIDKey) ? _meta.snippet : ownProps.snippet || ''
-    const snippetDecoration = _meta.snippetDecoration || ownProps.snippetDecoration
+    const snippetDecoration = _meta.snippetDecoration ?? ownProps.snippetDecoration
     let isTypingSnippet = false
     if (typers && typers.size > 0) {
       isTypingSnippet = true

--- a/shared/chat/inbox/row/small-team/index.tsx
+++ b/shared/chat/inbox/row/small-team/index.tsx
@@ -157,7 +157,7 @@ class SmallTeam extends React.PureComponent<Props, State> {
                     youAreReset={props.youAreReset}
                     showBold={props.showBold}
                     snippet={props.snippet || props.layoutSnippet || ''}
-                    snippetDecoration={props.snippetDecoration || props.layoutSnippetDecoration}
+                    snippetDecoration={props.snippetDecoration ?? props.layoutSnippetDecoration}
                     subColor={props.subColor}
                     hasResetUsers={props.hasResetUsers}
                     youNeedToRekey={props.youNeedToRekey}


### PR DESCRIPTION
This PR fixes the issue where a non-exploding message immediately after an exploding message would still show the timer on the snippet. Since the NONE snippet decoration has code 0, `||` fell through and caused the small team component to render an out-of-date decoration.