### PR TITLE
Fix big team header menu

### DIFF
--- a/shared/chat/conversation/info-panel/menu/container.tsx
+++ b/shared/chat/conversation/info-panel/menu/container.tsx
@@ -96,6 +96,7 @@ export default Container.namedConnect(
       : 'Subscribe to channels...'
     const manageChannelsSubtitle = isSmallTeam ? 'Turns this into a big team' : ''
     return {
+      _teamID: convProps?.teamID ?? teamID,
       badgeSubscribe,
       canAddPeople: yourOperations.manageMembers,
       convProps,
@@ -145,12 +146,12 @@ export default Container.namedConnect(
     onAddPeople: () => d._onAddPeople(s.teamname),
     onHidden: o.onHidden,
     onHideConv: d.onHideConv,
-    onInvite: () => d._onInvite(s.convProps && s.convProps.teamID),
-    onLeaveTeam: () => d._onLeaveTeam(s.convProps && s.convProps.teamID),
+    onInvite: () => d._onInvite(s._teamID),
+    onLeaveTeam: () => d._onLeaveTeam(s._teamID),
     onManageChannels: () => d._onManageChannels(s.teamname),
     onMuteConv: d.onMuteConv,
     onUnhideConv: d.onUnhideConv,
-    onViewTeam: () => d._onViewTeam((s.convProps && s.convProps.teamID) || undefined),
+    onViewTeam: () => d._onViewTeam(s._teamID || undefined),
     teamname: s.teamname,
     visible: o.visible,
   }),


### PR DESCRIPTION
The plumbing is different here than in the info panel. Store team ID in a field on stateProps. cc @keybase/y2ksquad 