### PR TITLE
fix git repo link in system messages

### DIFF
--- a/shared/actions/git-gen.tsx
+++ b/shared/actions/git-gen.tsx
@@ -13,7 +13,6 @@ export const deletePersonalRepo = 'git:deletePersonalRepo'
 export const deleteTeamRepo = 'git:deleteTeamRepo'
 export const loadGit = 'git:loadGit'
 export const loaded = 'git:loaded'
-export const navToGit = 'git:navToGit'
 export const navigateToTeamRepo = 'git:navigateToTeamRepo'
 export const repoCreated = 'git:repoCreated'
 export const repoDeleted = 'git:repoDeleted'
@@ -29,7 +28,6 @@ type _DeletePersonalRepoPayload = {readonly name: string}
 type _DeleteTeamRepoPayload = {readonly name: string; readonly teamname: string; readonly notifyTeam: boolean}
 type _LoadGitPayload = void
 type _LoadedPayload = {readonly repos: Map<string, Types.GitInfo>}
-type _NavToGitPayload = {readonly switchTab: boolean; readonly routeState: {expandedSet: Set<string>} | null}
 type _NavigateToTeamRepoPayload = {readonly repoID: string; readonly teamname: string}
 type _RepoCreatedPayload = void
 type _RepoDeletedPayload = void
@@ -71,7 +69,6 @@ export const createDeleteTeamRepo = (payload: _DeleteTeamRepoPayload): DeleteTea
 })
 export const createLoadGit = (payload: _LoadGitPayload): LoadGitPayload => ({payload, type: loadGit})
 export const createLoaded = (payload: _LoadedPayload): LoadedPayload => ({payload, type: loaded})
-export const createNavToGit = (payload: _NavToGitPayload): NavToGitPayload => ({payload, type: navToGit})
 export const createNavigateToTeamRepo = (payload: _NavigateToTeamRepoPayload): NavigateToTeamRepoPayload => ({
   payload,
   type: navigateToTeamRepo,
@@ -116,7 +113,6 @@ export type DeleteTeamRepoPayload = {
 }
 export type LoadGitPayload = {readonly payload: _LoadGitPayload; readonly type: typeof loadGit}
 export type LoadedPayload = {readonly payload: _LoadedPayload; readonly type: typeof loaded}
-export type NavToGitPayload = {readonly payload: _NavToGitPayload; readonly type: typeof navToGit}
 export type NavigateToTeamRepoPayload = {
   readonly payload: _NavigateToTeamRepoPayload
   readonly type: typeof navigateToTeamRepo
@@ -140,7 +136,6 @@ export type Actions =
   | DeleteTeamRepoPayload
   | LoadGitPayload
   | LoadedPayload
-  | NavToGitPayload
   | NavigateToTeamRepoPayload
   | RepoCreatedPayload
   | RepoDeletedPayload

--- a/shared/actions/git.tsx
+++ b/shared/actions/git.tsx
@@ -1,9 +1,11 @@
 import * as ConfigGen from './config-gen'
 import * as Constants from '../constants/git'
+import * as RouteTreeGen from './route-tree-gen'
 import * as GitGen from './git-gen'
 import * as NotificationsGen from './notifications-gen'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as Saga from '../util/saga'
+import * as Tabs from '../constants/tabs'
 import {TypedState} from '../util/container'
 import {logError} from '../util/errors'
 
@@ -111,7 +113,11 @@ function* navigateToTeamRepo(state: TypedState, action: GitGen.NavigateToTeamRep
   }
 
   if (id) {
-    yield Saga.put(GitGen.createNavToGit({routeState: {expandedSet: new Set([id])}, switchTab: true}))
+    yield Saga.put(
+      RouteTreeGen.createNavigateAppend({
+        path: [Tabs.gitTab, {props: {expandedSet: new Set([id])}, selected: 'gitRoot'}],
+      })
+    )
   }
 }
 

--- a/shared/actions/json/git.json
+++ b/shared/actions/json/git.json
@@ -1,17 +1,14 @@
 {
-  "prelude": [
-    "import * as Types from '../constants/types/git'"
-  ],
+  "prelude": ["import * as Types from '../constants/types/git'"],
   "actions": {
     "loadGit": {},
-    "loaded": { "repos": "Map<string, Types.GitInfo>" },
-    "navToGit": {"switchTab": "boolean", "routeState": "{\"expandedSet\": Set<string>} | null"},
+    "loaded": {"repos": "Map<string, Types.GitInfo>"},
     "createTeamRepo": {
       "name": "string",
       "teamname": "string",
       "notifyTeam": "boolean"
     },
-    "createPersonalRepo": { "name": "string" },
+    "createPersonalRepo": {"name": "string"},
     "repoDeleted": {},
     "repoCreated": {},
     "deleteTeamRepo": {
@@ -19,9 +16,9 @@
       "teamname": "string",
       "notifyTeam": "boolean"
     },
-    "deletePersonalRepo": { "name": "string" },
-    "setError": { "error?": "Error" },
-    "badgeAppForGit": { "ids": "Set<string>" },
+    "deletePersonalRepo": {"name": "string"},
+    "setError": {"error?": "Error"},
+    "badgeAppForGit": {"ids": "Set<string>"},
     "setTeamRepoSettings": {
       "chatDisabled": "boolean",
       "channelName?": "string",
@@ -32,6 +29,6 @@
       "repoID": "string",
       "teamname": "string"
     },
-    "clearBadges": { "_description": "clears badges in the rows" }
+    "clearBadges": {"_description": "clears badges in the rows"}
   }
 }

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -592,7 +592,6 @@ export type TypedActionsMap = {
   'fs:setDebugLevel': fs.SetDebugLevelPayload
   'git:loadGit': git.LoadGitPayload
   'git:loaded': git.LoadedPayload
-  'git:navToGit': git.NavToGitPayload
   'git:createTeamRepo': git.CreateTeamRepoPayload
   'git:createPersonalRepo': git.CreatePersonalRepoPayload
   'git:repoDeleted': git.RepoDeletedPayload

--- a/shared/git/container.tsx
+++ b/shared/git/container.tsx
@@ -11,7 +11,9 @@ import sortBy from 'lodash/sortBy'
 import {memoize} from '../util/memoize'
 import {HeaderTitle, HeaderRightActions} from './nav-header'
 
-type OwnProps = {}
+type TabsStateOwnProps = Container.RouteProps<{expandedSet: Set<string>}>
+
+type OwnProps = TabsStateOwnProps & {}
 
 const getRepos = memoize((git: Map<string, Types.GitInfo>) =>
   sortBy([...git.values()], ['teamname', 'name']).reduce<{personals: Array<string>; teams: Array<string>}>(
@@ -33,9 +35,9 @@ type ExtraProps = {
 // keep track in the module
 let moduleExpandedSet = new Set<string>()
 
-const GitReloadable = (p: Omit<GitProps & ExtraProps, 'expandedSet' | 'onToggleExpand'>) => {
-  const {clearBadges} = p
-  const [expandedSet, setExpandedSet] = React.useState(moduleExpandedSet)
+const GitReloadable = (p: Omit<GitProps & ExtraProps, 'onToggleExpand'>) => {
+  const {clearBadges, expandedSet: initialExpandedSet} = p
+  const [expandedSet, setExpandedSet] = React.useState(new Set<string>(initialExpandedSet))
 
   React.useEffect(() => {
     moduleExpandedSet = expandedSet
@@ -69,7 +71,8 @@ GitReloadable.navigationOptions = Container.isMobile
     }
 
 export default Container.connect(
-  (state: Container.TypedState) => ({
+  (state: Container.TypedState, ownProps: OwnProps) => ({
+    expandedSet: Container.getRouteProps(ownProps, 'expandedSet', new Set<string>()),
     loading: anyWaiting(state, Constants.loadingWaitingKey),
     ...getRepos(Constants.getIdToGit(state)),
   }),


### PR DESCRIPTION
This PR fixes an issue where the links to newly created git repos in chat wouldn't actually go anywhere. This was fixed by adding a route prop to the git tab for initializing expanded teams and removing an unimplemented git action.