### PR TITLE
search: add a bleve storage plugin that uses the leveldb-over-billy storage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -673,6 +673,10 @@ def testGo(prefix, packagesToTest) {
           flags: '-race',
           timeout: '30s',
         ],
+        'github.com/keybase/client/go/kbfs/search': [
+          flags: '-race',
+          timeout: '30s',
+        ],
         'github.com/keybase/client/go/kbfs/simplefs': [
           flags: '-race',
           timeout: '2m',

--- a/go/kbfs/search/bleve_leveldb_store.go
+++ b/go/kbfs/search/bleve_leveldb_store.go
@@ -8,8 +8,105 @@ import (
 	"github.com/blevesearch/bleve/index/store"
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/util"
 	billy "gopkg.in/src-d/go-billy.v4"
 )
+
+type bleveLevelDBIterator struct {
+	iter iterator.Iterator
+}
+
+var _ store.KVIterator = (*bleveLevelDBIterator)(nil)
+
+// Seek implements the store.KVIterator interface for bleveLevelDBIterator.
+func (bldbi *bleveLevelDBIterator) Seek(key []byte) {
+	_ = bldbi.iter.Seek(key)
+}
+
+// Next implements the store.KVIterator interface for bleveLevelDBIterator.
+func (bldbi *bleveLevelDBIterator) Next() {
+	_ = bldbi.iter.Next()
+}
+
+// Key implements the store.KVIterator interface for bleveLevelDBIterator.
+func (bldbi *bleveLevelDBIterator) Key() []byte {
+	return bldbi.iter.Key()
+}
+
+// Value implements the store.KVIterator interface for bleveLevelDBIterator.
+func (bldbi *bleveLevelDBIterator) Value() []byte {
+	return bldbi.iter.Value()
+}
+
+// Valid implements the store.KVIterator interface for bleveLevelDBIterator.
+func (bldbi *bleveLevelDBIterator) Valid() bool {
+	return bldbi.iter.Valid()
+}
+
+// Current implements the store.KVIterator interface for bleveLevelDBIterator.
+func (bldbi *bleveLevelDBIterator) Current() ([]byte, []byte, bool) {
+	return bldbi.Key(), bldbi.Value(), bldbi.Valid()
+}
+
+// Close implements the store.KVIterator interface for bleveLevelDBIterator.
+func (bldbi *bleveLevelDBIterator) Close() error {
+	bldbi.iter.Release()
+	return nil
+}
+
+type bleveLevelDBReader struct {
+	snap *leveldb.Snapshot
+}
+
+var _ store.KVReader = (*bleveLevelDBReader)(nil)
+
+// Get implements the store.KVReader interface for bleveLevelDBReader.
+func (bldbr *bleveLevelDBReader) Get(key []byte) ([]byte, error) {
+	return bldbr.snap.Get(key, nil)
+}
+
+// MultiGet implements the store.KVReader interface for bleveLevelDBReader.
+func (bldbr *bleveLevelDBReader) MultiGet(keys [][]byte) (
+	values [][]byte, err error) {
+	// leveldb doesn't have a simple multi-get interface, so just do
+	// multiple fetches.  Snapshot is consistent so this is fine (if
+	// inefficient).
+	values = make([][]byte, len(keys))
+	for i, k := range keys {
+		v, err := bldbr.Get(k)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = v
+	}
+	return values, nil
+}
+
+// PrefixIterator implements the store.KVReader interface for bleveLevelDBReader.
+func (bldbr *bleveLevelDBReader) PrefixIterator(prefix []byte) store.KVIterator {
+	r := util.BytesPrefix(prefix)
+	return &bleveLevelDBIterator{
+		iter: bldbr.snap.NewIterator(r, nil),
+	}
+}
+
+// RangeIterator implements the store.KVReader interface for bleveLevelDBReader.
+func (bldbr *bleveLevelDBReader) RangeIterator(
+	start, end []byte) store.KVIterator {
+	return &bleveLevelDBIterator{
+		iter: bldbr.snap.NewIterator(&util.Range{
+			Start: start,
+			Limit: end,
+		}, nil),
+	}
+}
+
+// Close implements the store.KVReader interface for bleveLevelDBReader.
+func (bldbr *bleveLevelDBReader) Close() error {
+	bldbr.snap.Release()
+	return nil
+}
 
 type bleveLevelDBStore struct {
 	db *leveldb.DB
@@ -37,7 +134,11 @@ func (bldbs *bleveLevelDBStore) Writer() (store.KVWriter, error) {
 
 // Writer implements the store.KVStore interface for bleveLevelDBStore.
 func (bldbs *bleveLevelDBStore) Reader() (store.KVReader, error) {
-	return nil, nil
+	snap, err := bldbs.db.GetSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	return &bleveLevelDBReader{snap: snap}, nil
 }
 
 // close implements the store.KVStore interface for bleveLevelDBStore.

--- a/go/kbfs/search/bleve_leveldb_store.go
+++ b/go/kbfs/search/bleve_leveldb_store.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"github.com/blevesearch/bleve/index/store"
+	"github.com/keybase/client/go/kbfs/libfs"
+	"github.com/syndtr/goleveldb/leveldb"
+	billy "gopkg.in/src-d/go-billy.v4"
+)
+
+type bleveLevelDBStore struct {
+	db *leveldb.DB
+}
+
+var _ store.KVStore = (*bleveLevelDBStore)(nil)
+
+func newBleveLevelDBStore(bfs billy.Filesystem, readOnly bool) (
+	*bleveLevelDBStore, error) {
+	s, err := libfs.OpenLevelDBStorage(bfs, readOnly)
+	if err != nil {
+		return nil, err
+	}
+	db, err := leveldb.Open(s, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &bleveLevelDBStore{db: db}, nil
+}
+
+// Writer implements the store.KVStore interface for bleveLevelDBStore.
+func (bldbs *bleveLevelDBStore) Writer() (store.KVWriter, error) {
+	return nil, nil
+}
+
+// Writer implements the store.KVStore interface for bleveLevelDBStore.
+func (bldbs *bleveLevelDBStore) Reader() (store.KVReader, error) {
+	return nil, nil
+}
+
+// close implements the store.KVStore interface for bleveLevelDBStore.
+func (bldbs *bleveLevelDBStore) Close() error {
+	return nil
+}

--- a/go/kbfs/search/bleve_leveldb_store.go
+++ b/go/kbfs/search/bleve_leveldb_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	billy "gopkg.in/src-d/go-billy.v4"
 )
@@ -169,6 +170,7 @@ func (bldbw *bleveLevelDBWriter) Close() error {
 }
 
 type bleveLevelDBStore struct {
+	s  storage.Storage
 	db *leveldb.DB
 }
 
@@ -184,7 +186,7 @@ func newBleveLevelDBStore(bfs billy.Filesystem, readOnly bool) (
 	if err != nil {
 		return nil, err
 	}
-	return &bleveLevelDBStore{db: db}, nil
+	return &bleveLevelDBStore{s: s, db: db}, nil
 }
 
 // Writer implements the store.KVStore interface for bleveLevelDBStore.
@@ -203,5 +205,9 @@ func (bldbs *bleveLevelDBStore) Reader() (store.KVReader, error) {
 
 // close implements the store.KVStore interface for bleveLevelDBStore.
 func (bldbs *bleveLevelDBStore) Close() error {
-	return bldbs.db.Close()
+	err := bldbs.db.Close()
+	if err != nil {
+		return err
+	}
+	return bldbs.s.Close()
 }

--- a/go/kbfs/search/bleve_leveldb_store.go
+++ b/go/kbfs/search/bleve_leveldb_store.go
@@ -108,6 +108,33 @@ func (bldbr *bleveLevelDBReader) Close() error {
 	return nil
 }
 
+type bleveLevelDBWriter struct {
+	db *leveldb.DB
+}
+
+var _ store.KVWriter = (*bleveLevelDBWriter)(nil)
+
+// NewBatch implements the store.KVReader interface for bleveLevelDBWriter.
+func (bldbw *bleveLevelDBWriter) NewBatch() store.KVBatch {
+	return nil
+}
+
+// NewBatchEx implements the store.KVReader interface for bleveLevelDBWriter.
+func (bldbw *bleveLevelDBWriter) NewBatchEx(store.KVBatchOptions) (
+	[]byte, store.KVBatch, error) {
+	return nil, nil, nil
+}
+
+// ExecuteBatch implements the store.KVReader interface for bleveLevelDBWriter.
+func (bldbw *bleveLevelDBWriter) ExecuteBatch(batch store.KVBatch) error {
+	return nil
+}
+
+// Close implements the store.KVReader interface for bleveLevelDBWriter.
+func (bldbw *bleveLevelDBWriter) Close() error {
+	return nil
+}
+
 type bleveLevelDBStore struct {
 	db *leveldb.DB
 }

--- a/go/kbfs/search/bleve_leveldb_store_test.go
+++ b/go/kbfs/search/bleve_leveldb_store_test.go
@@ -1,0 +1,111 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/libcontext"
+	"github.com/keybase/client/go/kbfs/libfs"
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBleveLevelDBStore(t *testing.T) {
+	ctx := libcontext.BackgroundContextWithCancellationDelayer()
+	config := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
+	require.NoError(t, err)
+	fs, err := libfs.NewFS(
+		ctx, config, h, data.MasterBranch, "", "", keybase1.MDPriorityNormal)
+	require.NoError(t, err)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+
+	t.Log("Open a leveldb using a KBFS billy filesystem")
+	s, err := newBleveLevelDBStore(fs, false)
+	require.NoError(t, err)
+	sNeedsClose := true
+	defer func() {
+		if sNeedsClose {
+			err := s.Close()
+			require.NoError(t, err)
+		}
+	}()
+
+	t.Log("Put some stuff into the db")
+	w, err := s.Writer()
+	require.NoError(t, err)
+	b := w.NewBatch()
+	key1 := []byte("key1")
+	val1 := []byte("val1")
+	key2 := []byte("key2")
+	val2 := []byte("val2")
+	key3 := []byte("otherkey3")
+	val3 := []byte("val3")
+	b.Set(key1, val1)
+	b.Set(key2, val2)
+	b.Set(key3, val3)
+	err = w.ExecuteBatch(b)
+	require.NoError(t, err)
+
+	t.Log("Close the db to release the lock")
+	err = w.Close()
+	require.NoError(t, err)
+	err = s.Close()
+	require.NoError(t, err)
+	sNeedsClose = false
+
+	t.Log("Read from another device")
+	config2 := libkbfs.ConfigAsUser(config, "user1")
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
+	fs2, err := libfs.NewFS(
+		ctx, config2, h, data.MasterBranch, "", "", keybase1.MDPriorityNormal)
+	require.NoError(t, err)
+	s2, err := newBleveLevelDBStore(fs2, false)
+	require.NoError(t, err)
+	defer func() {
+		err := s2.Close()
+		require.NoError(t, err)
+	}()
+	r, err := s2.Reader()
+	require.NoError(t, err)
+	defer func() {
+		err := r.Close()
+		require.NoError(t, err)
+	}()
+
+	gotVal1, err := r.Get(key1)
+	require.NoError(t, err)
+	require.Equal(t, val1, gotVal1)
+	gotVal2, err := r.Get(key2)
+	require.NoError(t, err)
+	require.Equal(t, val2, gotVal2)
+	gotVal3, err := r.Get(key3)
+	require.NoError(t, err)
+	require.Equal(t, val3, gotVal3)
+
+	t.Log("Check the iterator, should see two keys")
+	i := r.PrefixIterator([]byte("k"))
+	require.False(t, i.Valid()) // Next must be called before it's valid.
+	i.Next()
+	k1 := i.Key()
+	require.Equal(t, key1, k1)
+	v1 := i.Value()
+	require.Equal(t, val1, v1)
+	require.True(t, i.Valid())
+	i.Next()
+	k2 := i.Key()
+	require.Equal(t, key2, k2)
+	v2 := i.Value()
+	require.Equal(t, val2, v2)
+	require.True(t, i.Valid())
+	i.Next()
+	require.False(t, i.Valid())
+}

--- a/go/vendor/github.com/blevesearch/bleve/LICENSE
+++ b/go/vendor/github.com/blevesearch/bleve/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/go/vendor/github.com/blevesearch/bleve/index/store/batch.go
+++ b/go/vendor/github.com/blevesearch/bleve/index/store/batch.go
@@ -1,0 +1,62 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+type op struct {
+	K []byte
+	V []byte
+}
+
+type EmulatedBatch struct {
+	Ops    []*op
+	Merger *EmulatedMerge
+}
+
+func NewEmulatedBatch(mo MergeOperator) *EmulatedBatch {
+	return &EmulatedBatch{
+		Ops:    make([]*op, 0, 1000),
+		Merger: NewEmulatedMerge(mo),
+	}
+}
+
+func (b *EmulatedBatch) Set(key, val []byte) {
+	ck := make([]byte, len(key))
+	copy(ck, key)
+	cv := make([]byte, len(val))
+	copy(cv, val)
+	b.Ops = append(b.Ops, &op{ck, cv})
+}
+
+func (b *EmulatedBatch) Delete(key []byte) {
+	ck := make([]byte, len(key))
+	copy(ck, key)
+	b.Ops = append(b.Ops, &op{ck, nil})
+}
+
+func (b *EmulatedBatch) Merge(key, val []byte) {
+	ck := make([]byte, len(key))
+	copy(ck, key)
+	cv := make([]byte, len(val))
+	copy(cv, val)
+	b.Merger.Merge(key, val)
+}
+
+func (b *EmulatedBatch) Reset() {
+	b.Ops = b.Ops[:0]
+}
+
+func (b *EmulatedBatch) Close() error {
+	return nil
+}

--- a/go/vendor/github.com/blevesearch/bleve/index/store/kvstore.go
+++ b/go/vendor/github.com/blevesearch/bleve/index/store/kvstore.go
@@ -1,0 +1,174 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import "encoding/json"
+
+// KVStore is an abstraction for working with KV stores.  Note that
+// in order to be used with the bleve.registry, it must also implement
+// a constructor function of the registry.KVStoreConstructor type.
+type KVStore interface {
+
+	// Writer returns a KVWriter which can be used to
+	// make changes to the KVStore.  If a writer cannot
+	// be obtained a non-nil error is returned.
+	Writer() (KVWriter, error)
+
+	// Reader returns a KVReader which can be used to
+	// read data from the KVStore.  If a reader cannot
+	// be obtained a non-nil error is returned.
+	Reader() (KVReader, error)
+
+	// Close closes the KVStore
+	Close() error
+}
+
+// KVReader is an abstraction of an **ISOLATED** reader
+// In this context isolated is defined to mean that
+// writes/deletes made after the KVReader is opened
+// are not observed.
+// Because there is usually a cost associated with
+// keeping isolated readers active, users should
+// close them as soon as they are no longer needed.
+type KVReader interface {
+
+	// Get returns the value associated with the key
+	// If the key does not exist, nil is returned.
+	// The caller owns the bytes returned.
+	Get(key []byte) ([]byte, error)
+
+	// MultiGet retrieves multiple values in one call.
+	MultiGet(keys [][]byte) ([][]byte, error)
+
+	// PrefixIterator returns a KVIterator that will
+	// visit all K/V pairs with the provided prefix
+	PrefixIterator(prefix []byte) KVIterator
+
+	// RangeIterator returns a KVIterator that will
+	// visit all K/V pairs >= start AND < end
+	RangeIterator(start, end []byte) KVIterator
+
+	// Close closes the iterator
+	Close() error
+}
+
+// KVIterator is an abstraction around key iteration
+type KVIterator interface {
+
+	// Seek will advance the iterator to the specified key
+	Seek(key []byte)
+
+	// Next will advance the iterator to the next key
+	Next()
+
+	// Key returns the key pointed to by the iterator
+	// The bytes returned are **ONLY** valid until the next call to Seek/Next/Close
+	// Continued use after that requires that they be copied.
+	Key() []byte
+
+	// Value returns the value pointed to by the iterator
+	// The bytes returned are **ONLY** valid until the next call to Seek/Next/Close
+	// Continued use after that requires that they be copied.
+	Value() []byte
+
+	// Valid returns whether or not the iterator is in a valid state
+	Valid() bool
+
+	// Current returns Key(),Value(),Valid() in a single operation
+	Current() ([]byte, []byte, bool)
+
+	// Close closes the iterator
+	Close() error
+}
+
+// KVWriter is an abstraction for mutating the KVStore
+// KVWriter does **NOT** enforce restrictions of a single writer
+// if the underlying KVStore allows concurrent writes, the
+// KVWriter interface should also do so, it is up to the caller
+// to do this in a way that is safe and makes sense
+type KVWriter interface {
+
+	// NewBatch returns a KVBatch for performing batch operations on this kvstore
+	NewBatch() KVBatch
+
+	// NewBatchEx returns a KVBatch and an associated byte array
+	// that's pre-sized based on the KVBatchOptions.  The caller can
+	// use the returned byte array for keys and values associated with
+	// the batch.  Once the batch is either executed or closed, the
+	// associated byte array should no longer be accessed by the
+	// caller.
+	NewBatchEx(KVBatchOptions) ([]byte, KVBatch, error)
+
+	// ExecuteBatch will execute the KVBatch, the provided KVBatch **MUST** have
+	// been created by the same KVStore (though not necessarily the same KVWriter)
+	// Batch execution is atomic, either all the operations or none will be performed
+	ExecuteBatch(batch KVBatch) error
+
+	// Close closes the writer
+	Close() error
+}
+
+// KVBatchOptions provides the KVWriter.NewBatchEx() method with batch
+// preparation and preallocation information.
+type KVBatchOptions struct {
+	// TotalBytes is the sum of key and value bytes needed by the
+	// caller for the entire batch.  It affects the size of the
+	// returned byte array of KVWrite.NewBatchEx().
+	TotalBytes int
+
+	// NumSets is the number of Set() calls the caller will invoke on
+	// the KVBatch.
+	NumSets int
+
+	// NumDeletes is the number of Delete() calls the caller will invoke
+	// on the KVBatch.
+	NumDeletes int
+
+	// NumMerges is the number of Merge() calls the caller will invoke
+	// on the KVBatch.
+	NumMerges int
+}
+
+// KVBatch is an abstraction for making multiple KV mutations at once
+type KVBatch interface {
+
+	// Set updates the key with the specified value
+	// both key and value []byte may be reused as soon as this call returns
+	Set(key, val []byte)
+
+	// Delete removes the specified key
+	// the key []byte may be reused as soon as this call returns
+	Delete(key []byte)
+
+	// Merge merges old value with the new value at the specified key
+	// as prescribed by the KVStores merge operator
+	// both key and value []byte may be reused as soon as this call returns
+	Merge(key, val []byte)
+
+	// Reset frees resources for this batch and allows reuse
+	Reset()
+
+	// Close frees resources
+	Close() error
+}
+
+// KVStoreStats is an optional interface that KVStores can implement
+// if they're able to report any useful stats
+type KVStoreStats interface {
+	// Stats returns a JSON serializable object representing stats for this KVStore
+	Stats() json.Marshaler
+
+	StatsMap() map[string]interface{}
+}

--- a/go/vendor/github.com/blevesearch/bleve/index/store/merge.go
+++ b/go/vendor/github.com/blevesearch/bleve/index/store/merge.go
@@ -1,0 +1,64 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+// At the moment this happens to be the same interface as described by
+// RocksDB, but this may not always be the case.
+
+type MergeOperator interface {
+
+	// FullMerge the full sequence of operands on top of the existingValue
+	// if no value currently exists, existingValue is nil
+	// return the merged value, and success/failure
+	FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool)
+
+	// Partially merge these two operands.
+	// If partial merge cannot be done, return nil,false, which will defer
+	// all processing until the FullMerge is done.
+	PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool)
+
+	// Name returns an identifier for the operator
+	Name() string
+}
+
+type EmulatedMerge struct {
+	Merges map[string][][]byte
+	mo     MergeOperator
+}
+
+func NewEmulatedMerge(mo MergeOperator) *EmulatedMerge {
+	return &EmulatedMerge{
+		Merges: make(map[string][][]byte),
+		mo:     mo,
+	}
+}
+
+func (m *EmulatedMerge) Merge(key, val []byte) {
+	ops, ok := m.Merges[string(key)]
+	if ok && len(ops) > 0 {
+		last := ops[len(ops)-1]
+		mergedVal, partialMergeOk := m.mo.PartialMerge(key, last, val)
+		if partialMergeOk {
+			// replace last entry with the result of the merge
+			ops[len(ops)-1] = mergedVal
+		} else {
+			// could not partial merge, append this to the end
+			ops = append(ops, val)
+		}
+	} else {
+		ops = [][]byte{val}
+	}
+	m.Merges[string(key)] = ops
+}

--- a/go/vendor/github.com/blevesearch/bleve/index/store/multiget.go
+++ b/go/vendor/github.com/blevesearch/bleve/index/store/multiget.go
@@ -1,0 +1,33 @@
+//  Copyright (c) 2016 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+// MultiGet is a helper function to retrieve mutiple keys from a
+// KVReader, and might be used by KVStore implementations that don't
+// have a native multi-get facility.
+func MultiGet(kvreader KVReader, keys [][]byte) ([][]byte, error) {
+	vals := make([][]byte, 0, len(keys))
+
+	for i, key := range keys {
+		val, err := kvreader.Get(key)
+		if err != nil {
+			return nil, err
+		}
+
+		vals[i] = val
+	}
+
+	return vals, nil
+}

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/batch.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/batch.go
@@ -238,6 +238,11 @@ func newBatch() interface{} {
 	return &Batch{}
 }
 
+// MakeBatch returns empty batch with preallocated buffer.
+func MakeBatch(n int) *Batch {
+	return &Batch{data: make([]byte, 0, n)}
+}
+
 func decodeBatch(data []byte, fn func(i int, index batchIndex) error) error {
 	var index batchIndex
 	for i, o := 0, 0; o < len(data); i++ {

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/db.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/db.go
@@ -38,6 +38,12 @@ type DB struct {
 	inWritePaused          int32 // The indicator whether write operation is paused by compaction
 	aliveSnaps, aliveIters int32
 
+	// Compaction statistic
+	memComp       uint32 // The cumulative number of memory compaction
+	level0Comp    uint32 // The cumulative number of level0 compaction
+	nonLevel0Comp uint32 // The cumulative number of non-level0 compaction
+	seekComp      uint32 // The cumulative number of seek compaction
+
 	// Session.
 	s *session
 
@@ -981,6 +987,8 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 		value += fmt.Sprintf(" Total | %10d | %13.5f | %13.5f | %13.5f | %13.5f\n",
 			totalTables, float64(totalSize)/1048576.0, totalDuration.Seconds(),
 			float64(totalRead)/1048576.0, float64(totalWrite)/1048576.0)
+	case p == "compcount":
+		value = fmt.Sprintf("MemComp:%d Level0Comp:%d NonLevel0Comp:%d SeekComp:%d", atomic.LoadUint32(&db.memComp), atomic.LoadUint32(&db.level0Comp), atomic.LoadUint32(&db.nonLevel0Comp), atomic.LoadUint32(&db.seekComp))
 	case p == "iostats":
 		value = fmt.Sprintf("Read(MB):%.5f Write(MB):%.5f",
 			float64(db.s.stor.reads())/1048576.0,
@@ -1038,6 +1046,11 @@ type DBStats struct {
 	LevelWrite        Sizes
 	LevelDurations    []time.Duration
 
+	MemComp       uint32
+	Level0Comp    uint32
+	NonLevel0Comp uint32
+	SeekComp      uint32
+
 	MemCompactionActive   bool
 	TableCompactionActive bool
 }
@@ -1090,7 +1103,10 @@ func (db *DB) Stats(s *DBStats) error {
 		s.LevelSizes = append(s.LevelSizes, tables.size())
 		s.LevelTablesCounts = append(s.LevelTablesCounts, len(tables))
 	}
-
+	s.MemComp = atomic.LoadUint32(&db.memComp)
+	s.Level0Comp = atomic.LoadUint32(&db.level0Comp)
+	s.NonLevel0Comp = atomic.LoadUint32(&db.nonLevel0Comp)
+	s.SeekComp = atomic.LoadUint32(&db.seekComp)
 	return nil
 }
 

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/db_compaction.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/db_compaction.go
@@ -8,6 +8,7 @@ package leveldb
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/syndtr/goleveldb/leveldb/errors"
@@ -324,10 +325,12 @@ func (db *DB) memCompaction() {
 
 	db.logf("memdb@flush committed F·%d T·%v", len(rec.addedTables), stats.duration)
 
+	// Save compaction stats
 	for _, r := range rec.addedTables {
 		stats.write += r.size
 	}
 	db.compStats.addStat(flushLevel, stats)
+	atomic.AddUint32(&db.memComp, 1)
 
 	// Drop frozen memdb.
 	db.dropFrozenMem()
@@ -587,6 +590,14 @@ func (db *DB) tableCompaction(c *compaction, noTrivial bool) {
 	// Save compaction stats
 	for i := range stats {
 		db.compStats.addStat(c.sourceLevel+1, &stats[i])
+	}
+	switch c.typ {
+	case level0Compaction:
+		atomic.AddUint32(&db.level0Comp, 1)
+	case nonLevel0Compaction:
+		atomic.AddUint32(&db.nonLevel0Comp, 1)
+	case seekCompaction:
+		atomic.AddUint32(&db.seekComp, 1)
 	}
 }
 

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/db_transaction.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/db_transaction.go
@@ -69,6 +69,9 @@ func (tr *Transaction) Has(key []byte, ro *opt.ReadOptions) (bool, error) {
 // DB. And a nil Range.Limit is treated as a key after all keys in
 // the DB.
 //
+// The returned iterator has locks on its own resources, so it can live beyond
+// the lifetime of the transaction who creates them.
+//
 // WARNING: Any slice returned by interator (e.g. slice returned by calling
 // Iterator.Key() or Iterator.Key() methods), its content should not be modified
 // unless noted otherwise.
@@ -252,13 +255,14 @@ func (tr *Transaction) discard() {
 	// Discard transaction.
 	for _, t := range tr.tables {
 		tr.db.logf("transaction@discard @%d", t.fd.Num)
-		if err1 := tr.db.s.stor.Remove(t.fd); err1 == nil {
-			tr.db.s.reuseFileNum(t.fd.Num)
-		}
+		// Iterator may still use the table, so we use tOps.remove here.
+		tr.db.s.tops.remove(t.fd)
 	}
 }
 
 // Discard discards the transaction.
+// This method is noop if transaction is already closed (either committed or
+// discarded)
 //
 // Other methods should not be called after transaction has been discarded.
 func (tr *Transaction) Discard() {
@@ -282,8 +286,10 @@ func (db *DB) waitCompaction() error {
 // until in-flight transaction is committed or discarded.
 // The returned transaction handle is safe for concurrent use.
 //
-// Transaction is expensive and can overwhelm compaction, especially if
+// Transaction is very expensive and can overwhelm compaction, especially if
 // transaction size is small. Use with caution.
+// The rule of thumb is if you need to merge at least same amount of
+// `Options.WriteBuffer` worth of data then use transaction, otherwise don't.
 //
 // The transaction must be closed once done, either by committing or discarding
 // the transaction.

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/opt/options.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/opt/options.go
@@ -278,6 +278,14 @@ type Options struct {
 	// The default is false.
 	DisableLargeBatchTransaction bool
 
+	// DisableSeeksCompaction allows disabling 'seeks triggered compaction'.
+	// The purpose of 'seeks triggered compaction' is to optimize database so
+	// that 'level seeks' can be minimized, however this might generate many
+	// small compaction which may not preferable.
+	//
+	// The default is false.
+	DisableSeeksCompaction bool
+
 	// ErrorIfExist defines whether an error should returned if the DB already
 	// exist.
 	//
@@ -309,6 +317,8 @@ type Options struct {
 	// IteratorSamplingRate defines approximate gap (in bytes) between read
 	// sampling of an iterator. The samples will be used to determine when
 	// compaction should be triggered.
+	// Use negative value to disable iterator sampling.
+	// The iterator sampling is disabled if DisableSeeksCompaction is true.
 	//
 	// The default is 1MiB.
 	IteratorSamplingRate int
@@ -526,6 +536,13 @@ func (o *Options) GetDisableLargeBatchTransaction() bool {
 	return o.DisableLargeBatchTransaction
 }
 
+func (o *Options) GetDisableSeeksCompaction() bool {
+	if o == nil {
+		return false
+	}
+	return o.DisableSeeksCompaction
+}
+
 func (o *Options) GetErrorIfExist() bool {
 	if o == nil {
 		return false
@@ -548,8 +565,10 @@ func (o *Options) GetFilter() filter.Filter {
 }
 
 func (o *Options) GetIteratorSamplingRate() int {
-	if o == nil || o.IteratorSamplingRate <= 0 {
+	if o == nil || o.IteratorSamplingRate == 0 {
 		return DefaultIteratorSamplingRate
+	} else if o.IteratorSamplingRate < 0 {
+		return 0
 	}
 	return o.IteratorSamplingRate
 }

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/session_compaction.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/session_compaction.go
@@ -14,6 +14,13 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
+const (
+	undefinedCompaction = iota
+	level0Compaction
+	nonLevel0Compaction
+	seekCompaction
+)
+
 func (s *session) pickMemdbLevel(umin, umax []byte, maxLevel int) int {
 	v := s.version()
 	defer v.release()
@@ -50,6 +57,7 @@ func (s *session) pickCompaction() *compaction {
 
 	var sourceLevel int
 	var t0 tFiles
+	var typ int
 	if v.cScore >= 1 {
 		sourceLevel = v.cLevel
 		cptr := s.getCompPtr(sourceLevel)
@@ -63,18 +71,24 @@ func (s *session) pickCompaction() *compaction {
 		if len(t0) == 0 {
 			t0 = append(t0, tables[0])
 		}
+		if sourceLevel == 0 {
+			typ = level0Compaction
+		} else {
+			typ = nonLevel0Compaction
+		}
 	} else {
 		if p := atomic.LoadPointer(&v.cSeek); p != nil {
 			ts := (*tSet)(p)
 			sourceLevel = ts.level
 			t0 = append(t0, ts.table)
+			typ = seekCompaction
 		} else {
 			v.release()
 			return nil
 		}
 	}
 
-	return newCompaction(s, v, sourceLevel, t0)
+	return newCompaction(s, v, sourceLevel, t0, typ)
 }
 
 // Create compaction from given level and range; need external synchronization.
@@ -109,13 +123,18 @@ func (s *session) getCompactionRange(sourceLevel int, umin, umax []byte, noLimit
 		}
 	}
 
-	return newCompaction(s, v, sourceLevel, t0)
+	typ := level0Compaction
+	if sourceLevel != 0 {
+		typ = nonLevel0Compaction
+	}
+	return newCompaction(s, v, sourceLevel, t0, typ)
 }
 
-func newCompaction(s *session, v *version, sourceLevel int, t0 tFiles) *compaction {
+func newCompaction(s *session, v *version, sourceLevel int, t0 tFiles, typ int) *compaction {
 	c := &compaction{
 		s:             s,
 		v:             v,
+		typ:           typ,
 		sourceLevel:   sourceLevel,
 		levels:        [2]tFiles{t0, nil},
 		maxGPOverlaps: int64(s.o.GetCompactionGPOverlaps(sourceLevel)),
@@ -131,6 +150,7 @@ type compaction struct {
 	s *session
 	v *version
 
+	typ           int
 	sourceLevel   int
 	levels        [2]tFiles
 	maxGPOverlaps int64

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/session_util.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/session_util.go
@@ -308,7 +308,7 @@ func (s *session) setNextFileNum(num int64) {
 func (s *session) markFileNum(num int64) {
 	nextFileNum := num + 1
 	for {
-		old, x := s.stNextFileNum, nextFileNum
+		old, x := atomic.LoadInt64(&s.stNextFileNum), nextFileNum
 		if old > x {
 			x = old
 		}
@@ -326,7 +326,7 @@ func (s *session) allocFileNum() int64 {
 // Reuse given file number.
 func (s *session) reuseFileNum(num int64) {
 	for {
-		old, x := s.stNextFileNum, num
+		old, x := atomic.LoadInt64(&s.stNextFileNum), num
 		if old != x+1 {
 			x = old
 		}

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/table.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/table.go
@@ -493,6 +493,8 @@ func (t *tOps) remove(fd storage.FileDesc) {
 		if t.evictRemoved && t.bcache != nil {
 			t.bcache.EvictNS(uint64(fd.Num))
 		}
+		// Try to reuse file num, useful for discarded transaction.
+		t.s.reuseFileNum(fd.Num)
 	})
 }
 

--- a/go/vendor/github.com/syndtr/goleveldb/leveldb/version.go
+++ b/go/vendor/github.com/syndtr/goleveldb/leveldb/version.go
@@ -144,6 +144,7 @@ func (v *version) get(aux tFiles, ikey internalKey, ro *opt.ReadOptions, noValue
 	}
 
 	ukey := ikey.ukey()
+	sampleSeeks := !v.s.o.GetDisableSeeksCompaction()
 
 	var (
 		tset  *tSet
@@ -161,7 +162,7 @@ func (v *version) get(aux tFiles, ikey internalKey, ro *opt.ReadOptions, noValue
 	// Since entries never hop across level, finding key/value
 	// in smaller level make later levels irrelevant.
 	v.walkOverlapping(aux, ikey, func(level int, t *tFile) bool {
-		if level >= 0 && !tseek {
+		if sampleSeeks && level >= 0 && !tseek {
 			if tset == nil {
 				tset = &tSet{level, t}
 			} else {

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -1056,88 +1056,88 @@
 			"revisionTime": "2019-03-04T09:57:49Z"
 		},
 		{
-			"checksumSHA1": "d4mLiETrXMWWswlcAlioiLF8I5o=",
+			"checksumSHA1": "0nAF/qdMqCFy+ZKMKFHu9h/ADCs=",
 			"origin": "github.com/keybase/goleveldb/leveldb",
 			"path": "github.com/syndtr/goleveldb/leveldb",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "mPNraL2edpk/2FYq26rSXfMHbJg=",
 			"origin": "github.com/keybase/goleveldb/leveldb/cache",
 			"path": "github.com/syndtr/goleveldb/leveldb/cache",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "UA+PKDKWlDnE2OZblh23W6wZwbY=",
 			"origin": "github.com/keybase/goleveldb/leveldb/comparer",
 			"path": "github.com/syndtr/goleveldb/leveldb/comparer",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "1DRAxdlWzS4U0xKN/yQ/fdNN7f0=",
 			"origin": "github.com/keybase/goleveldb/leveldb/errors",
 			"path": "github.com/syndtr/goleveldb/leveldb/errors",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "iBorxU3FBbau81WSyVa8KwcutzA=",
 			"origin": "github.com/keybase/goleveldb/leveldb/filter",
 			"path": "github.com/syndtr/goleveldb/leveldb/filter",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "hPyFsMiqZ1OB7MX+6wIAA6nsdtc=",
 			"origin": "github.com/keybase/goleveldb/leveldb/iterator",
 			"path": "github.com/syndtr/goleveldb/leveldb/iterator",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "gJY7bRpELtO0PJpZXgPQ2BYFJ88=",
 			"origin": "github.com/keybase/goleveldb/leveldb/journal",
 			"path": "github.com/syndtr/goleveldb/leveldb/journal",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "2ncG38FDk2thSlrHd7JFmiuvnxA=",
 			"origin": "github.com/keybase/goleveldb/leveldb/memdb",
 			"path": "github.com/syndtr/goleveldb/leveldb/memdb",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
-			"checksumSHA1": "o2TorI3z+vc+EBMJ8XeFoUmXBtU=",
+			"checksumSHA1": "LC+WnyNq4O2J9SHuVfWL19wZH48=",
 			"origin": "github.com/keybase/goleveldb/leveldb/opt",
 			"path": "github.com/syndtr/goleveldb/leveldb/opt",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "ZHT9cKerJeQfP0QRxEo6w/hNTYo=",
 			"origin": "github.com/keybase/goleveldb/leveldb/storage",
 			"path": "github.com/syndtr/goleveldb/leveldb/storage",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "DS0i9KReIeZn3T1Bpu31xPMtzio=",
 			"origin": "github.com/keybase/goleveldb/leveldb/table",
 			"path": "github.com/syndtr/goleveldb/leveldb/table",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "V/Dh7NV0/fy/5jX1KaAjmGcNbzI=",
 			"origin": "github.com/keybase/goleveldb/leveldb/util",
 			"path": "github.com/syndtr/goleveldb/leveldb/util",
-			"revision": "63a617a29fe2ebb554504ccf93b05892ffb8238f",
-			"revisionTime": "2019-07-17T20:47:18Z"
+			"revision": "e8e1e74c283d349992bd850284db48dad97ffc74",
+			"revisionTime": "2019-11-27T19:34:58Z"
 		},
 		{
 			"checksumSHA1": "vU2ORasZstZrpzj13Y1pQM2Yqsc=",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -158,6 +158,12 @@
 			"revisionTime": "2015-06-20T10:58:49+02:00"
 		},
 		{
+			"checksumSHA1": "3ttI5qH9k/gOBaW8FJFVmOh5oIA=",
+			"path": "github.com/blevesearch/bleve/index/store",
+			"revision": "189ee421f71e1e77dbfb5ea900988b5efadb33a4",
+			"revisionTime": "2019-10-30T07:13:27Z"
+		},
+		{
 			"checksumSHA1": "BBnsAiKyNfocRwmEav5EJpVCwzk=",
 			"path": "github.com/btcsuite/btcutil/bech32",
 			"revision": "ab6388e0c60ae4834a1f57511e20c17b5f78be4b",


### PR DESCRIPTION
Bleve is an existing Go-based indexer and search engine, and this PR introduces a new bleve storage plugin that takes advantage of the existing `libfs` leveldb-over-billy-FS storage plugin.  The idea is that we will be able to build a search engine in KBFS where the storage graph looks like this:

```
Bleve search engine
         |
         V
      Leveldb
         |
         V
      libfs.FS
         |
         V
    local bserver
         |
         V
     local disk
```

The point of all this is that we have a fully-featured search engine (bleve), where the index is fully encrypted and stored in blocks to the local disk by KBFS.  This will hopefully give us the best of both worlds -- fast search using local data, but that local data is still encrypted at rest on the local disk.

This PR is a stepping stone to that by providing the last plugin needed to make the above graph work.  A future PR will do the work of hooking it all together and testing the bleve indexer and search as a whole.

It also re-vendors in our leveldb fork, which was updated with the latest master code from syndtr/goleveldb, since a new function there (`MakeBatch`) was needed.

Issue: HOTPOT-1262