### PR TITLE
teams: LookupID is called on channel mention, so no force

### DIFF
--- a/go/chat/teams.go
+++ b/go/chat/teams.go
@@ -338,7 +338,7 @@ func (t *TeamsNameInfoSource) LookupID(ctx context.Context, name string, public 
 	if err != nil {
 		return res, err
 	}
-	id, err := teams.ResolveNameToIDForceRefresh(ctx, t.G().ExternalG(), teamName)
+	id, err := teams.ResolveNameToID(ctx, t.G().ExternalG(), teamName)
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
- this happens a lot, I wonder if we can get away without the force refresh