### PR TITLE
Implement ReportUser RPC, minor fixes around the reporting UI

### DIFF
--- a/go/service/user.go
+++ b/go/service/user.go
@@ -737,10 +737,27 @@ func (h *UserHandler) ReportUser(ctx context.Context, arg keybase1.ReportUserArg
 		arg.Username, arg.IncludeTranscript, convIDStr),
 		func() error { return err })()
 
-	if arg.IncludeTranscript && arg.ConvID == nil {
-		return errors.New("invalid arguments: IncludeTranscript is true but ConvID == nil")
+	if arg.IncludeTranscript {
+		if arg.ConvID == nil {
+			return errors.New("invalid arguments: IncludeTranscript is true but ConvID == nil")
+		}
+		return errors.New("`IncludeTranscript` is not implemented")
 	}
-	return errors.New("Not implemented")
+	postArgs := libkb.HTTPArgs{
+		"username": libkb.S{Val: arg.Username},
+		"reason":   libkb.S{Val: arg.Reason},
+		"comment":  libkb.S{Val: arg.Comment},
+	}
+	if arg.ConvID != nil {
+		postArgs["conv_id"] = libkb.S{Val: *arg.ConvID}
+	}
+	apiArg := libkb.APIArg{
+		Endpoint:    "report/conversation",
+		SessionType: libkb.APISessionTypeREQUIRED,
+		Args:        postArgs,
+	}
+	_, err = mctx.G().API.Post(mctx, apiArg)
+	return err
 }
 
 // Legacy RPC and API:

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -741,7 +741,7 @@ func (h *UserHandler) ReportUser(ctx context.Context, arg keybase1.ReportUserArg
 		if arg.ConvID == nil {
 			return errors.New("invalid arguments: IncludeTranscript is true but ConvID == nil")
 		}
-		return errors.New("`IncludeTranscript` is not implemented")
+		mctx.Debug("Ignoring IncludeTranscript - not implemented")
 	}
 	postArgs := libkb.HTTPArgs{
 		"username": libkb.S{Val: arg.Username},

--- a/shared/actions/users.tsx
+++ b/shared/actions/users.tsx
@@ -61,7 +61,7 @@ const getBlockState = async (_: TypedState, action: UsersGen.GetBlockStatePayloa
 }
 
 const reportUser = async (_: TypedState, action: UsersGen.ReportUserPayload) => {
-  await RPCTypes.userReportUserRpcPromise(action.payload)
+  await RPCTypes.userReportUserRpcPromise(action.payload, Constants.reportUserWaitingKey)
 }
 
 function* usersSaga() {

--- a/shared/chat/blocking/block-modal/container.tsx
+++ b/shared/chat/blocking/block-modal/container.tsx
@@ -19,6 +19,7 @@ const Connect = Container.connect(
     const teamname = Container.getRouteProps(ownProps, 'team', undefined)
     const waitingForLeave = teamname ? Container.anyWaiting(state, leaveTeamWaitingKey(teamname)) : false
     const waitingForBlocking = Container.anyWaiting(state, Constants.setUserBlocksWaitingKey)
+    const waitingForReport = Container.anyWaiting(state, Constants.reportUserWaitingKey)
     const others = Container.getRouteProps(ownProps, 'others', undefined)
 
     return {
@@ -26,7 +27,7 @@ const Connect = Container.connect(
       adderUsername: Container.getRouteProps(ownProps, 'username', ''),
       blockByDefault: Container.getRouteProps(ownProps, 'blockByDefault', false),
       convID: Container.getRouteProps(ownProps, 'convID', undefined),
-      finishWaiting: waitingForLeave || waitingForBlocking,
+      finishWaiting: waitingForLeave || waitingForBlocking || waitingForReport,
       loadingWaiting: Container.anyWaiting(state, Constants.getUserBlocksWaitingKey),
       otherUsernames: others && others.length > 0 ? others : undefined,
       teamname,
@@ -47,7 +48,7 @@ const Connect = Container.connect(
       dispatch(
         UsersGen.createReportUser({
           comment: report.extraNotes,
-          convID: (report.includeTranscript && convID) || null,
+          convID: convID || null,
           includeTranscript: report.includeTranscript,
           reason: report.reason,
           username: username,

--- a/shared/chat/blocking/block-modal/index.tsx
+++ b/shared/chat/blocking/block-modal/index.tsx
@@ -77,6 +77,10 @@ type ReportOptionsProps = {
 }
 const reasons = ["I don't know this person", 'Spam', 'Harassment', 'Obscene material', 'Other...']
 const ReportOptions = (props: ReportOptionsProps) => {
+  //const {showIncludeTranscript} = props
+  // TODO: Transcripts are disabled right now because they are not finished for
+  // the release. (Y2K-1089)
+  const showIncludeTranscript = false
   return (
     <>
       {reasons.map(reason => (
@@ -91,7 +95,7 @@ const ReportOptions = (props: ReportOptionsProps) => {
       <Kb.Box
         style={Styles.collapseStyles([
           styles.feedback,
-          !props.showIncludeTranscript && styles.feedbackPaddingBottom,
+          !showIncludeTranscript && styles.feedbackPaddingBottom,
         ])}
       >
         <Kb.NewInput
@@ -101,7 +105,7 @@ const ReportOptions = (props: ReportOptionsProps) => {
           value={props.extraNotes}
         />
       </Kb.Box>
-      {props.showIncludeTranscript && (
+      {showIncludeTranscript && (
         <CheckboxRow
           text="Include the transcript of this chat"
           onCheck={props.setIncludeTranscript}

--- a/shared/constants/users.tsx
+++ b/shared/constants/users.tsx
@@ -26,3 +26,5 @@ export const makeState = (): Types.State => ({
 
 export const getUserBlocksWaitingKey = 'users:getUserBlocks'
 export const setUserBlocksWaitingKey = 'users:setUserBlocks'
+
+export const reportUserWaitingKey = 'users:reportUser'


### PR DESCRIPTION
Adds an RPC for new user reporting API call in https://github.com/keybase/keybase/pull/4780

It works for both reporting from user profile or chat. When reporting from chat, we will always send over Conversation ID (even if we are not sending transcripts). This way server can associate particular report with a TLF.

TODO:
- [x] Disable transcript sending in UI as it's not implemented. Decide if we should do it via some kind of feature flag or just disable it for everyone.