### PR TITLE
fix ts perf regression

### DIFF
--- a/shared/constants/types/fs.tsx
+++ b/shared/constants/types/fs.tsx
@@ -2,9 +2,6 @@ import * as RPCTypes from './rpc-gen'
 import * as ChatTypes from './chat2'
 import * as Devices from './devices'
 import * as TeamsTypes from './teams'
-// TODO importing FsGen causes an import loop
-import * as FsGen from '../../actions/fs-gen'
-import * as EngineGen from '../../actions/engine-gen-gen'
 import {isWindows} from '../platform'
 import {memoize} from '../../util/memoize'
 // lets not create cycles in flow, lets discuss how to fix this
@@ -27,8 +24,8 @@ export enum ProgressType {
 export type FsError = Readonly<{
   time: number
   errorMessage: string
-  erroredAction: FsGen.Actions | EngineGen.Actions
-  retriableAction?: FsGen.Actions | EngineGen.Actions
+  erroredAction: any // FsGen.Actions | EngineGen.Actions // using this type in the actions itself causes an explosive loop
+  retriableAction?: any // FsGen.Actions | EngineGen.Actions
 }>
 
 export type Device = Readonly<{


### PR DESCRIPTION
The FS actions themselves refer to `Types.FsError` which creates a recursive definition for the action types which causes a tremendous explosion in TS transform time. Instead of doing that lets just `any` for now

Before:
```
Files:                        2415
Lines:                      356755
Nodes:                     1755905
Identifiers:                554953
Symbols:                   1574155
Types:                      675329
Memory used:              2621068K
Assignability cache size:  1383935
Identity cache size:       1131714
Subtype cache size:         985546
I/O Read time:               0.83s
Parse time:                  1.61s
Program time:                3.65s
Bind time:                   1.20s
Check time:                 88.38s
transformTime time:        467.94s
commentTime time:           18.35s
printTime time:            529.86s
Emit time:                 529.94s
Source Map time:             4.65s
I/O Write time:              0.68s
Total time:                623.16s
```

After:
```
Files:                        2415
Lines:                      356752
Nodes:                     1755879
Identifiers:                554943
Symbols:                   1574152
Types:                      675329
Memory used:              2070524K
Assignability cache size:  1383935
Identity cache size:       1131714
Subtype cache size:         985546
I/O Read time:               0.17s
Parse time:                  1.54s
Program time:                2.70s
Bind time:                   1.19s
Check time:                 67.65s
transformTime time:         54.99s
commentTime time:            6.11s
printTime time:             78.59s
Emit time:                  78.63s
Source Map time:             1.61s
I/O Write time:              0.60s
Total time:                150.16s
```

cc: @songgao 