### PR TITLE
fix: hide team-specific links/copy in addedToTeam if not team

### DIFF
--- a/shared/chat/conversation/messages/system-added-to-team/container.tsx
+++ b/shared/chat/conversation/messages/system-added-to-team/container.tsx
@@ -2,17 +2,17 @@ import * as RouteTreeGen from '../../../../actions/route-tree-gen'
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import * as TeamConstants from '../../../../constants/teams'
-import { TeamID } from '../../../../constants/types/teams'
+import {TeamID} from '../../../../constants/types/teams'
 import SystemAddedToTeam from '.'
-import { teamsTab } from '../../../../constants/tabs'
-import { connect } from '../../../../util/container'
+import {teamsTab} from '../../../../constants/tabs'
+import {connect} from '../../../../util/container'
 
 type OwnProps = {
   message: Types.MessageSystemAddedToTeam
 }
 
 const mapStateToProps = (state, ownProps: OwnProps) => {
-  const { teamID, teamname, teamType } = Constants.getMeta(state, ownProps.message.conversationIDKey)
+  const {teamID, teamname, teamType} = Constants.getMeta(state, ownProps.message.conversationIDKey)
   return {
     addee: ownProps.message.addee,
     adder: ownProps.message.adder,
@@ -30,21 +30,21 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
 const mapDispatchToProps = dispatch => ({
   _onManageChannels: (teamname: string) =>
     dispatch(
-      RouteTreeGen.createNavigateAppend({ path: [{ props: { teamname }, selected: 'chatManageChannels' }] })
+      RouteTreeGen.createNavigateAppend({path: [{props: {teamname}, selected: 'chatManageChannels'}]})
     ),
   _onManageNotifications: conversationIDKey =>
     dispatch(
       RouteTreeGen.createNavigateAppend({
-        path: [{ props: { conversationIDKey: conversationIDKey, tab: 'settings' }, selected: 'chatInfoPanel' }],
+        path: [{props: {conversationIDKey: conversationIDKey, tab: 'settings'}, selected: 'chatInfoPanel'}],
       })
     ),
   _onViewTeam: (teamID: TeamID, conversationIDKey) => {
     if (teamID) {
-      dispatch(RouteTreeGen.createNavigateAppend({ path: [teamsTab, { props: { teamID }, selected: 'team' }] }))
+      dispatch(RouteTreeGen.createNavigateAppend({path: [teamsTab, {props: {teamID}, selected: 'team'}]}))
     } else {
       dispatch(
         RouteTreeGen.createNavigateAppend({
-          path: [{ props: { conversationIDKey: conversationIDKey, tab: 'settings' }, selected: 'chatInfoPanel' }],
+          path: [{props: {conversationIDKey: conversationIDKey, tab: 'settings'}, selected: 'chatInfoPanel'}],
         })
       )
     }

--- a/shared/chat/conversation/messages/system-added-to-team/container.tsx
+++ b/shared/chat/conversation/messages/system-added-to-team/container.tsx
@@ -2,22 +2,23 @@ import * as RouteTreeGen from '../../../../actions/route-tree-gen'
 import * as Constants from '../../../../constants/chat2'
 import * as Types from '../../../../constants/types/chat2'
 import * as TeamConstants from '../../../../constants/teams'
-import {TeamID} from '../../../../constants/types/teams'
+import { TeamID } from '../../../../constants/types/teams'
 import SystemAddedToTeam from '.'
-import {teamsTab} from '../../../../constants/tabs'
-import {connect} from '../../../../util/container'
+import { teamsTab } from '../../../../constants/tabs'
+import { connect } from '../../../../util/container'
 
 type OwnProps = {
   message: Types.MessageSystemAddedToTeam
 }
 
 const mapStateToProps = (state, ownProps: OwnProps) => {
-  const {teamID, teamname} = Constants.getMeta(state, ownProps.message.conversationIDKey)
+  const { teamID, teamname, teamType } = Constants.getMeta(state, ownProps.message.conversationIDKey)
   return {
     addee: ownProps.message.addee,
     adder: ownProps.message.adder,
     bulkAdds: ownProps.message.bulkAdds,
     isAdmin: TeamConstants.isAdmin(TeamConstants.getRole(state, teamID)),
+    isTeam: teamType === 'big' || teamType === 'small',
     role: ownProps.message.role,
     teamID,
     teamname,
@@ -29,21 +30,21 @@ const mapStateToProps = (state, ownProps: OwnProps) => {
 const mapDispatchToProps = dispatch => ({
   _onManageChannels: (teamname: string) =>
     dispatch(
-      RouteTreeGen.createNavigateAppend({path: [{props: {teamname}, selected: 'chatManageChannels'}]})
+      RouteTreeGen.createNavigateAppend({ path: [{ props: { teamname }, selected: 'chatManageChannels' }] })
     ),
   _onManageNotifications: conversationIDKey =>
     dispatch(
       RouteTreeGen.createNavigateAppend({
-        path: [{props: {conversationIDKey: conversationIDKey, tab: 'settings'}, selected: 'chatInfoPanel'}],
+        path: [{ props: { conversationIDKey: conversationIDKey, tab: 'settings' }, selected: 'chatInfoPanel' }],
       })
     ),
   _onViewTeam: (teamID: TeamID, conversationIDKey) => {
     if (teamID) {
-      dispatch(RouteTreeGen.createNavigateAppend({path: [teamsTab, {props: {teamID}, selected: 'team'}]}))
+      dispatch(RouteTreeGen.createNavigateAppend({ path: [teamsTab, { props: { teamID }, selected: 'team' }] }))
     } else {
       dispatch(
         RouteTreeGen.createNavigateAppend({
-          path: [{props: {conversationIDKey: conversationIDKey, tab: 'settings'}, selected: 'chatInfoPanel'}],
+          path: [{ props: { conversationIDKey: conversationIDKey, tab: 'settings' }, selected: 'chatInfoPanel' }],
         })
       )
     }
@@ -55,6 +56,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps: OwnProps) => ({
   adder: stateProps.adder,
   bulkAdds: stateProps.bulkAdds,
   isAdmin: stateProps.isAdmin,
+  isTeam: stateProps.isTeam,
   onManageChannels: () => dispatchProps._onManageChannels(stateProps.teamname),
   onManageNotifications: () => dispatchProps._onManageNotifications(ownProps.message.conversationIDKey),
   onViewTeam: () => dispatchProps._onViewTeam(stateProps.teamID, ownProps.message.conversationIDKey),

--- a/shared/chat/conversation/messages/system-added-to-team/index.tsx
+++ b/shared/chat/conversation/messages/system-added-to-team/index.tsx
@@ -16,6 +16,7 @@ type Props = {
   onManageChannels: () => void
   onManageNotifications: () => void
   onViewTeam: () => void
+  isTeam: boolean
   teamname: string
   timestamp: number
   you: string
@@ -23,6 +24,9 @@ type Props = {
 
 const ManageComponent = (props: Props) => {
   const textType = 'BodySmallSemiboldPrimaryLink'
+  if (!props.isTeam) {
+    return null
+  }
   if (props.addee === props.you) {
     return (
       <Kb.Box style={{...Styles.globalStyles.flexBoxColumn}}>
@@ -67,8 +71,8 @@ const AddedToTeam = (props: Props) => {
     <UserNotice>
       <Kb.Text type="BodySmall">
         {youOrUsername({capitalize: true, username: props.adder, you: props.you})}added{' '}
-        {getAddedUsernames(props.bulkAdds.length === 0 ? [props.addee] : props.bulkAdds)} to the team.{' '}
-        <ManageComponent {...props} />
+        {getAddedUsernames(props.bulkAdds.length === 0 ? [props.addee] : props.bulkAdds)}
+        {props.isTeam && ' to the team'}. <ManageComponent {...props} />
       </Kb.Text>
     </UserNotice>
   )

--- a/shared/chat/conversation/messages/system-added-to-team/index.tsx
+++ b/shared/chat/conversation/messages/system-added-to-team/index.tsx
@@ -64,6 +64,8 @@ const youOrUsername = (props: {username: string; you: string; capitalize: boolea
 }
 
 const AddedToTeam = (props: Props) => {
+  const role =
+    props.role === 'bot' || props.role === 'restrictedbot' ? typeToLabel[props.role].toLowerCase() : null
   if (props.addee === props.you) {
     return <YouAddedToTeam {...props} />
   }
@@ -72,7 +74,8 @@ const AddedToTeam = (props: Props) => {
       <Kb.Text type="BodySmall">
         {youOrUsername({capitalize: true, username: props.adder, you: props.you})}added{' '}
         {getAddedUsernames(props.bulkAdds.length === 0 ? [props.addee] : props.bulkAdds)}
-        {props.isTeam && ' to the team'}. <ManageComponent {...props} />
+        {props.isTeam && ' to the team'}
+        {role && ` as ${indefiniteArticle(role)} ${role}`}. <ManageComponent {...props} />
       </Kb.Text>
     </UserNotice>
   )


### PR DESCRIPTION
If you added a bot user to an implicit team, the system message would incorrectly show a 'show all members' link and reference 'to the team'. This PR hides those if the system message is being shown in an implicit team.