### PR TITLE
Potentially fix Android 9 Dark issues by reading GuiConfig in Java

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -47,6 +47,7 @@ import io.keybase.ossifrage.modules.AppearanceModule;
 import io.keybase.ossifrage.modules.KeybaseEngine;
 import io.keybase.ossifrage.modules.NativeLogger;
 import io.keybase.ossifrage.util.DNSNSFetcher;
+import io.keybase.ossifrage.util.GuiConfig;
 import io.keybase.ossifrage.util.VideoHelper;
 import keybase.Keybase;
 
@@ -114,11 +115,8 @@ public class MainActivity extends ReactFragmentActivity {
 
   }
 
-  private static final int ANDROID_TEN = 29;
-
   private String colorSchemeForCurrentConfiguration() {
-    // TODO: (hramos) T52929922: Switch to Build.VERSION_CODES.ANDROID_TEN or equivalent
-    if (Build.VERSION.SDK_INT >= ANDROID_TEN) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       int currentNightMode =
         this.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
       switch (currentNightMode) {
@@ -148,8 +146,7 @@ public class MainActivity extends ReactFragmentActivity {
 
     new android.os.Handler().postDelayed(new Runnable() {
       public void run() {
-        // TODO, read this pref from go
-        setBackgroundColor(DarkModePreference.System);
+        setBackgroundColor(GuiConfig.getInstance(getFilesDir()).getDarkMode());
       }
     }, 300);
 
@@ -398,7 +395,7 @@ public class MainActivity extends ReactFragmentActivity {
       }
     }
 
-    setBackgroundColor(DarkModePreference.System);
+    setBackgroundColor(GuiConfig.getInstance(getFilesDir()).getDarkMode());
   }
 
   public void setBackgroundColor(DarkModePreference pref) {

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/modules/AppearanceModule.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/modules/AppearanceModule.java
@@ -27,7 +27,6 @@ public class AppearanceModule extends ReactContextBaseJavaModule {
     public static final String NAME = "Appearance";
 
     private static final String APPEARANCE_CHANGED_EVENT_NAME = "appearanceChanged";
-    private static final int ANDROID_TEN = 29;
 
     private String mColorScheme = "light";
 
@@ -38,8 +37,7 @@ public class AppearanceModule extends ReactContextBaseJavaModule {
     }
 
     private static String colorSchemeForCurrentConfiguration(Context context) {
-        // TODO: (hramos) T52929922: Switch to Build.VERSION_CODES.ANDROID_TEN or equivalent
-        if (Build.VERSION.SDK_INT >= ANDROID_TEN) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             int currentNightMode =
                     context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
             switch (currentNightMode) {
@@ -98,7 +96,7 @@ public class AppearanceModule extends ReactContextBaseJavaModule {
     public Map<String, Object> getConstants() {
         final Map<String, Object> constants = new HashMap<>();
         constants.put("initialColorScheme", this.getColorScheme());
-        constants.put("supported", Build.VERSION.SDK_INT >= ANDROID_TEN ? "1" : "0");
+        constants.put("supported", Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ? "1" : "0");
         return constants;
     }
 }

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/modules/KeybaseEngine.java
@@ -28,6 +28,8 @@ import io.keybase.ossifrage.BuildConfig;
 import io.keybase.ossifrage.DarkModePrefHelper;
 import io.keybase.ossifrage.DarkModePreference;
 import io.keybase.ossifrage.MainActivity;
+import io.keybase.ossifrage.util.GuiConfig;
+import io.keybase.ossifrage.util.ReadFileAsString;
 import keybase.Keybase;
 
 import static io.keybase.ossifrage.MainActivity.isTestDevice;
@@ -138,37 +140,9 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
         return NAME;
     }
 
-    private String readFromFile(String path) {
-        String ret = "";
-
-        try {
-            FileInputStream inputStream = new FileInputStream(new File(path));
-
-            if ( inputStream != null ) {
-                InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
-                BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
-                String receiveString = "";
-                StringBuilder stringBuilder = new StringBuilder();
-
-                while ( (receiveString = bufferedReader.readLine()) != null ) {
-                    stringBuilder.append(receiveString);
-                }
-
-                inputStream.close();
-                ret = stringBuilder.toString();
-            }
-        } catch (FileNotFoundException e) {
-            // ignore
-        } catch (IOException e) {
-            // ignore
-        }
-
-        return ret;
-    }
 
     private String readGuiConfig() {
-        File filePath = new File(reactContext.getFilesDir(), "/.config/keybase/gui_config.json");
-        return readFromFile(filePath.getAbsolutePath());
+        return GuiConfig.getInstance(this.reactContext.getFilesDir()).asString();
     }
 
     @Override
@@ -186,7 +160,7 @@ public class KeybaseEngine extends ReactContextBaseJavaModule implements Killabl
 
         String serverConfig = "";
         try {
-            serverConfig = this.readFromFile(this.reactContext.getCacheDir().getAbsolutePath() + "/Keybase/keybase.app.serverConfig");
+            serverConfig = ReadFileAsString.read(this.reactContext.getCacheDir().getAbsolutePath() + "/Keybase/keybase.app.serverConfig");
         } catch (Exception e) {
             NativeLogger.warn(NAME + ": Error reading server config", e);
         }

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/util/GuiConfig.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/util/GuiConfig.java
@@ -1,0 +1,48 @@
+package io.keybase.ossifrage.util;
+
+import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.keybase.ossifrage.DarkModePrefHelper;
+import io.keybase.ossifrage.DarkModePreference;
+import io.keybase.ossifrage.modules.NativeLogger;
+
+import java.io.File;
+
+public class GuiConfig {
+  private static GuiConfig singletonInstance = null;
+
+  private File filesDir;
+
+  private GuiConfig(File filesDir) {
+    this.filesDir = filesDir;
+  }
+
+  public static GuiConfig getInstance(File filesDir) {
+    if (singletonInstance == null) {
+      singletonInstance = new GuiConfig(filesDir);
+    }
+    return singletonInstance;
+  }
+
+
+  public String asString() {
+    File filePath = new File(this.filesDir, "/.config/keybase/gui_config.json");
+    return ReadFileAsString.read(filePath.getAbsolutePath());
+  }
+
+  public DarkModePreference getDarkMode() {
+    try {
+      JSONObject jsonObject = new JSONObject(this.asString());
+      JSONObject jsonObjectUI = jsonObject.getJSONObject("ui");
+
+      String darkModeString = jsonObjectUI.getString("darkMode");
+      return DarkModePrefHelper.fromString(darkModeString);
+    } catch (JSONException e) {
+      NativeLogger.error("Error in getting Dark Mode", e);
+      return DarkModePreference.System;
+    }
+  }
+}

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/util/ReadFileAsString.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/util/ReadFileAsString.java
@@ -1,0 +1,38 @@
+package io.keybase.ossifrage.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class ReadFileAsString {
+  public static String read(String path) {
+    String ret = "";
+
+    try {
+      FileInputStream inputStream = new FileInputStream(new File(path));
+
+      if (inputStream != null) {
+        InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+        BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+        String receiveString = "";
+        StringBuilder stringBuilder = new StringBuilder();
+
+        while ((receiveString = bufferedReader.readLine()) != null) {
+          stringBuilder.append(receiveString);
+        }
+
+        inputStream.close();
+        ret = stringBuilder.toString();
+      }
+    } catch (FileNotFoundException e) {
+      // ignore
+    } catch (IOException e) {
+      // ignore
+    }
+
+    return ret;
+  }
+}


### PR DESCRIPTION
@keybase/react-hackers 

Fixes dark mode issues on devices before 10.

Sometimes when you would come back from a backgrounded app, the colors would be wrong. My guess is that we were setting the background color to system, and JS never reset it for us. This fixes it by having Java read the GuiConfig field and set the background color according to that (instead of always matching the system)

As reported by @pzduniak 