### PR TITLE
subscribe to team meta updates in really leave team modal

### DIFF
--- a/shared/teams/really-leave-team/index.tsx
+++ b/shared/teams/really-leave-team/index.tsx
@@ -9,6 +9,7 @@ import {
   MaybePopup,
   ProgressIndicator,
 } from '../../common-adapters'
+import {useTeamsSubscribe} from '../../teams/subscriber'
 import {globalStyles, globalMargins} from '../../styles'
 
 export type Props = {
@@ -40,6 +41,7 @@ const Header = (props: Props) => (
 const _ReallyLeaveTeam = (props: Props) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(() => () => props.clearErrors(), [])
+  useTeamsSubscribe()
   return (
     <ConfirmModal
       error={props.error}


### PR DESCRIPTION
Should fix an issue Jakob and Max ran in to, the team ID should always be passed into this modal correctly but I suspect that the team was not in their `teamDetails` for some reason. cc @keybase/y2ksquad 