### PR TITLE
 Make non-DelivererInfoError errors permanent 

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -481,14 +481,14 @@ func BackgroundSync() {
 }
 
 // pushPendingMessageFailure sends at most one notification that a message
-// failed to send. We don't notify the user about background failures like
-// unfurling.
+// failed to send. We only notify the user about visible messages that have
+// failed.
 func pushPendingMessageFailure(obrs []chat1.OutboxRecord, pusher PushNotifier) {
 	for _, obr := range obrs {
-		if !obr.IsUnfurl() {
+		if topicType := obr.Msg.ClientHeader.Conv.TopicType; obr.Msg.IsBadgableType() && topicType == chat1.TopicType_CHAT {
 			kbCtx.Log.Debug("pushPendingMessageFailure: pushing convID: %s", obr.ConvID)
 			pusher.LocalNotification("failedpending",
-				"Heads up! One or more pending messages failed to send. Tap here to retry them.",
+				"Heads up! Your message hasn't sent yet, tap here to retry.",
 				-1, "default", obr.ConvID.String(), "chat.failedpending")
 			return
 		}

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1456,8 +1456,10 @@ func (s *Deliverer) doNotRetryFailure(ctx context.Context, obr chat1.OutboxRecor
 			return typ, err, true
 		}
 		return 0, err, false
-	case *url.Error, *net.DNSError:
-		return chat1.OutboxErrorType_OFFLINE, err, false
+	case *url.Error:
+		return chat1.OutboxErrorType_OFFLINE, err, !berr.Temporary()
+	case *net.DNSError:
+		return chat1.OutboxErrorType_OFFLINE, err, !berr.Temporary()
 	}
 	return 0, err, true
 }
@@ -1593,10 +1595,7 @@ func (e unfurlError) Error() string {
 }
 
 func (e unfurlError) IsImmediateFail() (chat1.OutboxErrorType, bool) {
-	if e.status == types.UnfurlerTaskStatusPermFailed {
-		return chat1.OutboxErrorType_MISC, true
-	}
-	return chat1.OutboxErrorType_MISC, false
+	return chat1.OutboxErrorType_MISC, e.status == types.UnfurlerTaskStatusPermFailed
 }
 
 var _ (DelivererInfoError) = (*unfurlError)(nil)

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1515,7 +1515,7 @@ func (s *Deliverer) processAttachment(ctx context.Context, obr chat1.OutboxRecor
 	}
 	status, res, err := s.G().AttachmentUploader.Status(ctx, obr.OutboxID)
 	if err != nil {
-		return obr, err
+		return obr, NewAttachmentUploadError(err.Error(), false)
 	}
 	switch status {
 	case types.AttachmentUploaderTaskStatusSuccess:

--- a/go/chat/unfurl/scrape_generic.go
+++ b/go/chat/unfurl/scrape_generic.go
@@ -2,7 +2,6 @@ package unfurl
 
 import (
 	"context"
-	"errors"
 	"io"
 	"strings"
 	"time"
@@ -176,7 +175,7 @@ func (s *Scraper) isValidGenericScrape(generic chat1.UnfurlGenericRaw) bool {
 func (s *Scraper) exportGenericResult(generic *scoredGenericRaw) (res chat1.UnfurlRaw, err error) {
 	// Check to make sure we have a legit unfurl that is useful
 	if !s.isValidGenericScrape(generic.UnfurlGenericRaw) {
-		return res, errors.New("not enough information to display")
+		return res, newUnfurlPermanentError("not enough information to display")
 	}
 	return chat1.NewUnfurlRawWithGeneric(generic.UnfurlGenericRaw), nil
 }

--- a/go/chat/unfurl/unfurler.go
+++ b/go/chat/unfurl/unfurler.go
@@ -20,6 +20,20 @@ import (
 	"github.com/keybase/clockwork"
 )
 
+type unfurlPermanentError struct {
+	msg string
+}
+
+func newUnfurlPermanentError(msg string) *unfurlPermanentError {
+	return &unfurlPermanentError{
+		msg: msg,
+	}
+}
+
+func (e *unfurlPermanentError) Error() string {
+	return e.msg
+}
+
 type unfurlTask struct {
 	UID    gregor1.UID
 	ConvID chat1.ConversationID
@@ -337,8 +351,13 @@ func (u *Unfurler) detectPermError(err error) bool {
 		return !e.Temporary()
 	case *url.Error:
 		return !e.Temporary()
+	case *unfurlPermanentError:
+		return true
 	}
-	return true
+	if err.Error() == "Not Found" {
+		return true
+	}
+	return false
 }
 
 func (u *Unfurler) testingSendUnfurl(unfurl *chat1.Unfurl) {

--- a/go/chat/unfurl/unfurler.go
+++ b/go/chat/unfurl/unfurler.go
@@ -354,10 +354,7 @@ func (u *Unfurler) detectPermError(err error) bool {
 	case *unfurlPermanentError:
 		return true
 	}
-	if err.Error() == "Not Found" {
-		return true
-	}
-	return false
+	return err.Error() == "Not Found"
 }
 
 func (u *Unfurler) testingSendUnfurl(unfurl *chat1.Unfurl) {

--- a/go/chat/unfurl/unfurler.go
+++ b/go/chat/unfurl/unfurler.go
@@ -338,6 +338,9 @@ func (u *Unfurler) detectPermError(err error) bool {
 	case *url.Error:
 		return !e.Temporary()
 	}
+	if err.Error() == "Not Found" {
+		return true
+	}
 	return false
 }
 

--- a/go/chat/unfurl/unfurler.go
+++ b/go/chat/unfurl/unfurler.go
@@ -338,10 +338,7 @@ func (u *Unfurler) detectPermError(err error) bool {
 	case *url.Error:
 		return !e.Temporary()
 	}
-	if err.Error() == "Not Found" {
-		return true
-	}
-	return false
+	return true
 }
 
 func (u *Unfurler) testingSendUnfurl(unfurl *chat1.Unfurl) {


### PR DESCRIPTION
- more unfurler errors are also permanent 