### PR TITLE
Support errors in team building modal

### DIFF
--- a/shared/actions/json/team-building.json
+++ b/shared/actions/json/team-building.json
@@ -6,7 +6,16 @@
   "actions": {
     "fetchedUserRecs": {"namespace": "Types.AllowedNamespace", "users": "Array<Types.User>"},
     "fetchUserRecs": {"includeContacts": "boolean", "namespace": "Types.AllowedNamespace"},
-    "finishedTeamBuilding": {"namespace": "Types.AllowedNamespace", "teamID?": "TeamID"},
+    "finishTeamBuilding": {
+      "namespace": "Types.AllowedNamespace",
+      "_description": "If we want to keep the modal open until an RPC finishes, use this before dispatching finishedTeamBuilding.",
+      "teamID?": "TeamID"
+    },
+    "setError": {
+      "namespace": "Types.AllowedNamespace",
+      "error": "string"
+    },
+    "finishedTeamBuilding": {"namespace": "Types.AllowedNamespace"},
     "cancelTeamBuilding": {"namespace": "Types.AllowedNamespace"},
     "search": {
       "includeContacts": "boolean",

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -122,7 +122,12 @@
     "addToTeam": {
       "teamID": "Types.TeamID",
       "users": "Array<{assertion: string, role: Types.TeamRoleType}>",
-      "sendChatNotification": "boolean"
+      "sendChatNotification": "boolean",
+      "fromTeamBuilder?": "boolean"
+    },
+    "addedToTeam": {
+      "error?": "string",
+      "fromTeamBuilder?": "boolean"
     },
     "reAddToTeam": {
       "teamID": "Types.TeamID",

--- a/shared/actions/team-building-gen.tsx
+++ b/shared/actions/team-building-gen.tsx
@@ -11,12 +11,14 @@ export const cancelTeamBuilding = 'team-building:cancelTeamBuilding'
 export const changeSendNotification = 'team-building:changeSendNotification'
 export const fetchUserRecs = 'team-building:fetchUserRecs'
 export const fetchedUserRecs = 'team-building:fetchedUserRecs'
+export const finishTeamBuilding = 'team-building:finishTeamBuilding'
 export const finishedTeamBuilding = 'team-building:finishedTeamBuilding'
 export const labelsSeen = 'team-building:labelsSeen'
 export const removeUsersFromTeamSoFar = 'team-building:removeUsersFromTeamSoFar'
 export const search = 'team-building:search'
 export const searchResultsLoaded = 'team-building:searchResultsLoaded'
 export const selectRole = 'team-building:selectRole'
+export const setError = 'team-building:setError'
 export const tbResetStore = 'team-building:tbResetStore'
 
 // Payload Types
@@ -28,7 +30,8 @@ type _CancelTeamBuildingPayload = {readonly namespace: Types.AllowedNamespace}
 type _ChangeSendNotificationPayload = {readonly namespace: 'teams'; readonly sendNotification: boolean}
 type _FetchUserRecsPayload = {readonly includeContacts: boolean; readonly namespace: Types.AllowedNamespace}
 type _FetchedUserRecsPayload = {readonly namespace: Types.AllowedNamespace; readonly users: Array<Types.User>}
-type _FinishedTeamBuildingPayload = {readonly namespace: Types.AllowedNamespace; readonly teamID?: TeamID}
+type _FinishTeamBuildingPayload = {readonly namespace: Types.AllowedNamespace; readonly teamID?: TeamID}
+type _FinishedTeamBuildingPayload = {readonly namespace: Types.AllowedNamespace}
 type _LabelsSeenPayload = {readonly namespace: Types.AllowedNamespace}
 type _RemoveUsersFromTeamSoFarPayload = {
   readonly namespace: Types.AllowedNamespace
@@ -48,9 +51,17 @@ type _SearchResultsLoadedPayload = {
   readonly service: Types.ServiceIdWithContact
 }
 type _SelectRolePayload = {readonly namespace: 'teams'; readonly role: TeamRoleType}
+type _SetErrorPayload = {readonly namespace: Types.AllowedNamespace; readonly error: string}
 type _TbResetStorePayload = {readonly namespace: Types.AllowedNamespace}
 
 // Action Creators
+/**
+ * If we want to keep the modal open until an RPC finishes, use this before dispatching finishedTeamBuilding.
+ */
+export const createFinishTeamBuilding = (payload: _FinishTeamBuildingPayload): FinishTeamBuildingPayload => ({
+  payload,
+  type: finishTeamBuilding,
+})
 /**
  * our own reset store so we don't have conflicts with parent reducers
  */
@@ -94,6 +105,7 @@ export const createSelectRole = (payload: _SelectRolePayload): SelectRolePayload
   payload,
   type: selectRole,
 })
+export const createSetError = (payload: _SetErrorPayload): SetErrorPayload => ({payload, type: setError})
 
 // Action Payloads
 export type AddUsersToTeamSoFarPayload = {
@@ -116,6 +128,10 @@ export type FetchedUserRecsPayload = {
   readonly payload: _FetchedUserRecsPayload
   readonly type: typeof fetchedUserRecs
 }
+export type FinishTeamBuildingPayload = {
+  readonly payload: _FinishTeamBuildingPayload
+  readonly type: typeof finishTeamBuilding
+}
 export type FinishedTeamBuildingPayload = {
   readonly payload: _FinishedTeamBuildingPayload
   readonly type: typeof finishedTeamBuilding
@@ -131,6 +147,7 @@ export type SearchResultsLoadedPayload = {
   readonly type: typeof searchResultsLoaded
 }
 export type SelectRolePayload = {readonly payload: _SelectRolePayload; readonly type: typeof selectRole}
+export type SetErrorPayload = {readonly payload: _SetErrorPayload; readonly type: typeof setError}
 export type TbResetStorePayload = {readonly payload: _TbResetStorePayload; readonly type: typeof tbResetStore}
 
 // All Actions
@@ -141,11 +158,13 @@ export type Actions =
   | ChangeSendNotificationPayload
   | FetchUserRecsPayload
   | FetchedUserRecsPayload
+  | FinishTeamBuildingPayload
   | FinishedTeamBuildingPayload
   | LabelsSeenPayload
   | RemoveUsersFromTeamSoFarPayload
   | SearchPayload
   | SearchResultsLoadedPayload
   | SelectRolePayload
+  | SetErrorPayload
   | TbResetStorePayload
   | {type: 'common:resetStore', payload: {}}

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -11,6 +11,7 @@ export const addParticipant = 'teams:addParticipant'
 export const addTeamWithChosenChannels = 'teams:addTeamWithChosenChannels'
 export const addToTeam = 'teams:addToTeam'
 export const addUserToTeams = 'teams:addUserToTeams'
+export const addedToTeam = 'teams:addedToTeam'
 export const checkRequestedAccess = 'teams:checkRequestedAccess'
 export const clearAddUserToTeamsResults = 'teams:clearAddUserToTeamsResults'
 export const clearNavBadges = 'teams:clearNavBadges'
@@ -86,12 +87,14 @@ type _AddToTeamPayload = {
   readonly teamID: Types.TeamID
   readonly users: Array<{assertion: string; role: Types.TeamRoleType}>
   readonly sendChatNotification: boolean
+  readonly fromTeamBuilder?: boolean
 }
 type _AddUserToTeamsPayload = {
   readonly role: Types.TeamRoleType
   readonly teams: Array<string>
   readonly user: string
 }
+type _AddedToTeamPayload = {readonly error?: string; readonly fromTeamBuilder?: boolean}
 type _CheckRequestedAccessPayload = {readonly teamname: string}
 type _ClearAddUserToTeamsResultsPayload = void
 type _ClearNavBadgesPayload = void
@@ -334,6 +337,10 @@ export const createAddUserToTeams = (payload: _AddUserToTeamsPayload): AddUserTo
   payload,
   type: addUserToTeams,
 })
+export const createAddedToTeam = (payload: _AddedToTeamPayload = Object.freeze({})): AddedToTeamPayload => ({
+  payload,
+  type: addedToTeam,
+})
 export const createCheckRequestedAccess = (
   payload: _CheckRequestedAccessPayload
 ): CheckRequestedAccessPayload => ({payload, type: checkRequestedAccess})
@@ -543,6 +550,7 @@ export type AddUserToTeamsPayload = {
   readonly payload: _AddUserToTeamsPayload
   readonly type: typeof addUserToTeams
 }
+export type AddedToTeamPayload = {readonly payload: _AddedToTeamPayload; readonly type: typeof addedToTeam}
 export type CheckRequestedAccessPayload = {
   readonly payload: _CheckRequestedAccessPayload
   readonly type: typeof checkRequestedAccess
@@ -762,6 +770,7 @@ export type Actions =
   | AddTeamWithChosenChannelsPayload
   | AddToTeamPayload
   | AddUserToTeamsPayload
+  | AddedToTeamPayload
   | CheckRequestedAccessPayload
   | ClearAddUserToTeamsResultsPayload
   | ClearNavBadgesPayload

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -284,7 +284,7 @@ const addReAddErrorHandler = (username, e) => {
 }
 
 const addToTeam = async (_: TypedState, action: TeamsGen.AddToTeamPayload) => {
-  const {teamID, users, sendChatNotification} = action.payload
+  const {fromTeamBuilder, teamID, users, sendChatNotification} = action.payload
   try {
     await RPCTypes.teamsTeamAddMembersMultiRoleRpcPromise(
       {
@@ -297,13 +297,21 @@ const addToTeam = async (_: TypedState, action: TeamsGen.AddToTeamPayload) => {
       },
       Constants.addMemberWaitingKey(teamID, ...users.map(({assertion}) => assertion))
     )
-    return false
+    return TeamsGen.createAddedToTeam({fromTeamBuilder})
   } catch (e) {
-    // DANNYTODO plumb to modal
     // TODO this should not error on member already in team
-    // return addReAddErrorHandler(username, e)
-    return false
+    return TeamsGen.createAddedToTeam({error: e.message, fromTeamBuilder})
   }
+}
+
+const closeTeamBuilderOrSetError = (_: TypedState, action: TeamsGen.AddedToTeamPayload) => {
+  const {error, fromTeamBuilder} = action.payload
+  if (!fromTeamBuilder) {
+    return
+  }
+  return error
+    ? TeamBuildingGen.createSetError({error, namespace: 'teams'})
+    : TeamBuildingGen.createFinishedTeamBuilding({namespace: 'teams'})
 }
 
 const reAddToTeam = async (_: TypedState, action: TeamsGen.ReAddToTeamPayload) => {
@@ -1357,7 +1365,7 @@ const clearNavBadges = async () => {
 
 function addThemToTeamFromTeamBuilder(
   state: TypedState,
-  {payload: {teamID}}: TeamBuildingGen.FinishedTeamBuildingPayload,
+  {payload: {teamID}}: TeamBuildingGen.FinishTeamBuildingPayload,
   logger: Saga.SagaLogger
 ) {
   if (!teamID) {
@@ -1365,11 +1373,12 @@ function addThemToTeamFromTeamBuilder(
     return
   }
 
-  const role = state.teams.teamBuilding.finishedSelectedRole
-  const sendChatNotification = state.teams.teamBuilding.finishedSendNotification
+  const role = state.teams.teamBuilding.selectedRole
+  const sendChatNotification = state.teams.teamBuilding.sendNotification
 
-  const users = [...state.teams.teamBuilding.finishedTeam].map(user => ({assertion: user.id, role}))
+  const users = [...state.teams.teamBuilding.teamSoFar].map(user => ({assertion: user.id, role}))
   return TeamsGen.createAddToTeam({
+    fromTeamBuilder: true,
     sendChatNotification,
     teamID,
     users,
@@ -1380,9 +1389,10 @@ function* teamBuildingSaga() {
   yield* commonTeamBuildingSaga('teams')
 
   yield* Saga.chainAction2(
-    TeamBuildingGen.finishedTeamBuilding,
+    TeamBuildingGen.finishTeamBuilding,
     filterForNs('teams', addThemToTeamFromTeamBuilder)
   )
+  yield* Saga.chainAction2(TeamsGen.addedToTeam, closeTeamBuilderOrSetError)
 }
 
 const teamsSaga = function*() {

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -23,6 +23,7 @@ import openSMS from '../util/sms'
 import {convertToError, logError} from '../util/errors'
 import {TypedState, TypedActions, isMobile} from '../util/container'
 import {mapGetEnsureValue} from '../util/map'
+import {RPCError} from '../util/errors'
 
 async function createNewTeam(_: TypedState, action: TeamsGen.CreateNewTeamPayload) {
   const {fromChat, joinSubteam, teamname, thenAddMembers} = action.payload
@@ -300,7 +301,7 @@ const addToTeam = async (_: TypedState, action: TeamsGen.AddToTeamPayload) => {
     return TeamsGen.createAddedToTeam({fromTeamBuilder})
   } catch (e) {
     // TODO this should not error on member already in team
-    return TeamsGen.createAddedToTeam({error: e.message, fromTeamBuilder})
+    return TeamsGen.createAddedToTeam({error: e.desc, fromTeamBuilder})
   }
 }
 

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -811,6 +811,8 @@ export type TypedActionsMap = {
   'signup:clearJustSignedUpEmail': signup.ClearJustSignedUpEmailPayload
   'team-building:fetchedUserRecs': teambuilding.FetchedUserRecsPayload
   'team-building:fetchUserRecs': teambuilding.FetchUserRecsPayload
+  'team-building:finishTeamBuilding': teambuilding.FinishTeamBuildingPayload
+  'team-building:setError': teambuilding.SetErrorPayload
   'team-building:finishedTeamBuilding': teambuilding.FinishedTeamBuildingPayload
   'team-building:cancelTeamBuilding': teambuilding.CancelTeamBuildingPayload
   'team-building:search': teambuilding.SearchPayload
@@ -850,6 +852,7 @@ export type TypedActionsMap = {
   'teams:leaveTeam': teams.LeaveTeamPayload
   'teams:leftTeam': teams.LeftTeamPayload
   'teams:addToTeam': teams.AddToTeamPayload
+  'teams:addedToTeam': teams.AddedToTeamPayload
   'teams:reAddToTeam': teams.ReAddToTeamPayload
   'teams:editTeamDescription': teams.EditTeamDescriptionPayload
   'teams:uploadTeamAvatar': teams.UploadTeamAvatarPayload

--- a/shared/constants/team-building.tsx
+++ b/shared/constants/team-building.tsx
@@ -52,6 +52,7 @@ export function followStateHelperWithId(
 }
 
 export const makeSubState = (): Types.TeamBuildingSubState => ({
+  error: '',
   finishedSelectedRole: 'writer',
   finishedSendNotification: true,
   finishedTeam: new Set(),

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -39,6 +39,7 @@ export type SearchResults = Map<Query, Map<ServiceIdWithContact, Array<User>>>
 export type ServiceResultCount = Map<SearchString, Map<ServiceIdWithContact, number>>
 
 export type TeamBuildingSubState = Readonly<{
+  error: string
   teamSoFar: Set<User>
   searchResults: SearchResults
   serviceResultCount: ServiceResultCount

--- a/shared/reducers/team-building.tsx
+++ b/shared/reducers/team-building.tsx
@@ -42,6 +42,12 @@ export const editTeambuildingDraft = (
       const old = mapGetEnsureValue(results, service, [])
       old.push(...users)
     },
+    [TeamBuildingGen.finishTeamBuilding]: draftState => {
+      draftState.error = ''
+    },
+    [TeamBuildingGen.setError]: (draftState, action) => {
+      draftState.error = action.payload.error
+    },
     [TeamBuildingGen.finishedTeamBuilding]: draftState => {
       return {
         ...Constants.makeSubState(),

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -235,7 +235,9 @@ export default (
       case TeamBuildingGen.search:
       case TeamBuildingGen.selectRole:
       case TeamBuildingGen.labelsSeen:
-      case TeamBuildingGen.changeSendNotification: {
+      case TeamBuildingGen.changeSendNotification:
+      case TeamBuildingGen.finishTeamBuilding:
+      case TeamBuildingGen.setError: {
         const val = editTeambuildingDraft('teams', draftState.teamBuilding, action)
         if (val !== undefined) {
           draftState.teamBuilding = val
@@ -277,6 +279,7 @@ export default (
       case TeamsGen.updateChannelName:
       case TeamsGen.updateTopic:
       case TeamsGen.teamCreated:
+      case TeamsGen.addedToTeam:
         return state
       default:
         ifTSCComplainsAboutThisFunctionYouHaventHandledAllCasesInASwitch(action)

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -243,7 +243,12 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, {namespace, teamI
   onChangeSendNotification: (sendNotification: boolean) =>
     namespace === 'teams' &&
     dispatch(TeamBuildingGen.createChangeSendNotification({namespace, sendNotification})),
-  onFinishTeamBuilding: () => dispatch(TeamBuildingGen.createFinishedTeamBuilding({namespace, teamID})),
+  onFinishTeamBuilding: () =>
+    dispatch(
+      namespace === 'teams'
+        ? TeamBuildingGen.createFinishTeamBuilding({namespace, teamID})
+        : TeamBuildingGen.createFinishedTeamBuilding({namespace})
+    ),
   onLoadContactsSetting: () => dispatch(SettingsGen.createLoadContactImportEnabled()),
   onRemove: (userId: string) =>
     dispatch(TeamBuildingGen.createRemoveUsersFromTeamSoFar({namespace, users: [userId]})),

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -171,6 +171,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
   return {
     ...contactProps,
     disabledRoles,
+    error: teamBuildingState.error,
     recommendations: deriveRecommendation(
       teamBuildingState.userRecs,
       teamBuildingState.teamSoFar,
@@ -637,6 +638,7 @@ const mergeProps = (
     ...headerHocProps,
     ...popupProps,
     ...contactProps,
+    error: stateProps.error,
     fetchUserRecs: dispatchProps.fetchUserRecs,
     filterServices: ownProps.filterServices,
     focusInputCounter: ownProps.focusInputCounter,

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -89,6 +89,7 @@ type ContactProps = {
 }
 
 export type Props = ContactProps & {
+  error?: string
   filterServices?: Array<ServiceIdWithContact>
   fetchUserRecs: () => void
   focusInputCounter: number
@@ -654,6 +655,7 @@ class TeamBuilding extends React.PureComponent<Props> {
           ) : (
             teamBox
           ))}
+        {!!props.error && <Kb.Banner color="red">{props.error}</Kb.Banner>}
         {!!props.teamSoFar.length && Flags.newTeamBuildingForChatAllowMakeTeam && (
           <Kb.Text type="BodySmall">
             Add up to 14 more people. Need more?

--- a/shared/team-building/reducer-helper.tsx
+++ b/shared/team-building/reducer-helper.tsx
@@ -11,6 +11,8 @@ export function teamBuilderReducerCreator<State>(
     TeamBuildingGen.changeSendNotification,
     TeamBuildingGen.fetchUserRecs,
     TeamBuildingGen.fetchedUserRecs,
+    TeamBuildingGen.finishTeamBuilding,
+    TeamBuildingGen.setError,
     TeamBuildingGen.finishedTeamBuilding,
     TeamBuildingGen.labelsSeen,
     TeamBuildingGen.removeUsersFromTeamSoFar,

--- a/shared/team-building/team-box.tsx
+++ b/shared/team-building/team-box.tsx
@@ -110,7 +110,10 @@ const TeamBox = (props: Props) => {
           (props.rolePickerProps ? (
             <FloatingRolePicker
               open={props.rolePickerProps.showRolePicker}
-              onConfirm={props.onFinishTeamBuilding}
+              onConfirm={() => {
+                props.rolePickerProps?.changeShowRolePicker(false)
+                props.onFinishTeamBuilding()
+              }}
               onSelectRole={props.rolePickerProps.onSelectRole}
               selectedRole={props.rolePickerProps.selectedRole}
               onCancel={() => props.rolePickerProps && props.rolePickerProps.changeShowRolePicker(false)}


### PR DESCRIPTION
Change how ending team building works so it can support errors in teams namespace (and others later if we want).

- Now we can optionally dispatch `finishTeamBuilding` (instead of `finishedTeamBuilding`) to keep the modal open while some RPC happens.
- In teams actions, trigger adding the members to a team and close the modal if everything's good
- If there's an error, set it in the team building substate and display it in the modal

One small todo left but this is ready for review. cc @keybase/y2ksquad 

- [ ] Make error text nicer