### PR TITLE
Use teamID to get canPerform in message menu

### DIFF
--- a/shared/chat/conversation/messages/message-popup/attachment/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment/container.tsx
@@ -4,7 +4,7 @@ import * as FsGen from '../../../../../actions/fs-gen'
 import * as Constants from '../../../../../constants/chat2'
 import * as Types from '../../../../../constants/types/chat2'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
-import {getCanPerform} from '../../../../../constants/teams'
+import {getCanPerformByID} from '../../../../../constants/teams'
 import * as Container from '../../../../../util/container'
 import {isMobile, isIOS} from '../../../../../constants/platform'
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
@@ -24,7 +24,7 @@ export default Container.connect(
   (state, ownProps: OwnProps) => {
     const message = ownProps.message
     const meta = Constants.getMeta(state, message.conversationIDKey)
-    const yourOperations = getCanPerform(state, meta.teamname)
+    const yourOperations = getCanPerformByID(state, meta.teamID)
     const _canDeleteHistory = yourOperations && yourOperations.deleteChatHistory
     const _canAdminDelete = yourOperations && yourOperations.deleteOtherMessages
     let _canPinMessage = true

--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -28,7 +28,7 @@ export default Container.connect(
     const yourMessage = ownProps.message.author === state.config.username
     const meta = Constants.getMeta(state, ownProps.message.conversationIDKey)
     const _canDeleteHistory =
-      meta.teamType === 'adhoc' || TeamConstants.getCanPerform(state, meta.teamname).deleteChatHistory
+      meta.teamType === 'adhoc' || TeamConstants.getCanPerformByID(state, meta.teamID).deleteChatHistory
     const _canExplodeNow = (yourMessage || _canDeleteHistory) && ownProps.message.isDeleteable
     const _canEdit = yourMessage && ownProps.message.isEditable
     const _mapUnfurl = Constants.getMapUnfurl(ownProps.message)

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -6,7 +6,7 @@ import * as Types from '../../../../../constants/types/chat2'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import * as Container from '../../../../../util/container'
 import {createShowUserProfile} from '../../../../../actions/profile-gen'
-import {getCanPerform} from '../../../../../constants/teams'
+import {getCanPerformByID} from '../../../../../constants/teams'
 import {Position} from '../../../../../common-adapters/relative-popup-hoc.types'
 import {StylesCrossPlatform} from '../../../../../styles/css'
 import openURL from '../../../../../util/open-url'
@@ -24,7 +24,7 @@ type OwnProps = {
 const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
   const message = ownProps.message
   const meta = Constants.getMeta(state, message.conversationIDKey)
-  const yourOperations = getCanPerform(state, meta.teamname)
+  const yourOperations = getCanPerformByID(state, meta.teamID)
   const _canDeleteHistory = yourOperations && yourOperations.deleteChatHistory
   const _canAdminDelete = yourOperations && yourOperations.deleteOtherMessages
   let _canPinMessage = message.type === 'text'


### PR DESCRIPTION
Part of a larger class of bugs where the team list won't be loaded after user switching. In this case we have the team ID and role map is eagerly synced so it's an easy fix. cc @malgorithms @keybase/y2ksquad 