### PR TITLE
fix(chat): set explicit height on git commit message

### DIFF
--- a/shared/chat/conversation/messages/system-git-push/index.tsx
+++ b/shared/chat/conversation/messages/system-git-push/index.tsx
@@ -79,7 +79,7 @@ const GitPushDefault = (props: PushDefaultProps) => {
                   {commit.commitHash.substr(0, 8)}
                 </Kb.Text>
               </Kb.Box2>
-              <Kb.Box2 direction="vertical" style={{}}>
+              <Kb.Box2 direction="vertical">
                 <Kb.Text type="BodySmall" selectable={true} style={styles.commitMessage} lineClamp={1}>
                   {commit.message}
                 </Kb.Text>
@@ -171,9 +171,6 @@ const styles = Styles.styleSheetCreate(
         marginBottom: 1,
         marginRight: Styles.globalMargins.xtiny,
         padding: 2,
-      },
-      grow: {
-        flex: 1,
       },
       hashAndMessage: {
         marginBottom: Styles.globalMargins.xtiny,

--- a/shared/chat/conversation/messages/system-git-push/index.tsx
+++ b/shared/chat/conversation/messages/system-git-push/index.tsx
@@ -80,7 +80,7 @@ const GitPushDefault = (props: PushDefaultProps) => {
                 </Kb.Text>
               </Kb.Box2>
               <Kb.Box2 direction="vertical" style={styles.grow}>
-                <Kb.Text type="BodySmall" selectable={true} style={styles.textLeft} lineClamp={1}>
+                <Kb.Text type="BodySmall" selectable={true} style={styles.commitMessage} lineClamp={1}>
                   {commit.message}
                 </Kb.Text>
               </Kb.Box2>
@@ -160,6 +160,17 @@ const styles = Styles.styleSheetCreate(
           lineHeight: 16,
         },
       }),
+      commitMessage: Styles.platformStyles({
+        common: {
+          textAlign: 'left',
+        },
+        isElectron: {
+          height: 17, // lineHeight for BodySmall on desktop
+        },
+        isMobile: {
+          height: 19, // lineHeight for BodySmall on mobile
+        },
+      }),
       dot: {
         backgroundColor: Styles.globalColors.blueLighter_20,
         borderRadius: 3,
@@ -181,7 +192,6 @@ const styles = Styles.styleSheetCreate(
         minWidth: 0,
       },
       repoText: {color: Styles.globalColors.black_50},
-      textLeft: {textAlign: 'left'},
     } as const)
 )
 

--- a/shared/chat/conversation/messages/system-git-push/index.tsx
+++ b/shared/chat/conversation/messages/system-git-push/index.tsx
@@ -79,7 +79,7 @@ const GitPushDefault = (props: PushDefaultProps) => {
                   {commit.commitHash.substr(0, 8)}
                 </Kb.Text>
               </Kb.Box2>
-              <Kb.Box2 direction="vertical" style={styles.grow}>
+              <Kb.Box2 direction="vertical" style={{}}>
                 <Kb.Text type="BodySmall" selectable={true} style={styles.commitMessage} lineClamp={1}>
                   {commit.message}
                 </Kb.Text>
@@ -160,21 +160,14 @@ const styles = Styles.styleSheetCreate(
           lineHeight: 16,
         },
       }),
-      commitMessage: Styles.platformStyles({
-        common: {
-          textAlign: 'left',
-        },
-        isElectron: {
-          height: 17, // lineHeight for BodySmall on desktop
-        },
-        isMobile: {
-          height: 19, // lineHeight for BodySmall on mobile
-        },
-      }),
+      commitMessage: {
+        textAlign: 'left',
+        height: '100%',
+      },
       dot: {
         backgroundColor: Styles.globalColors.blueLighter_20,
         borderRadius: 3,
-        height: 18,
+        height: '100%',
         marginBottom: 1,
         marginRight: Styles.globalMargins.xtiny,
         padding: 2,
@@ -183,8 +176,9 @@ const styles = Styles.styleSheetCreate(
         flex: 1,
       },
       hashAndMessage: {
-        paddingBottom: Styles.globalMargins.xtiny,
-        paddingTop: Styles.globalMargins.xtiny,
+        marginBottom: Styles.globalMargins.xtiny,
+        marginTop: Styles.globalMargins.xtiny,
+        height: 18,
       },
       marker: {
         marginRight: Styles.globalMargins.xtiny,

--- a/shared/chat/conversation/messages/system-git-push/index.tsx
+++ b/shared/chat/conversation/messages/system-git-push/index.tsx
@@ -161,8 +161,8 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       commitMessage: {
-        textAlign: 'left',
         height: '100%',
+        textAlign: 'left',
       },
       dot: {
         backgroundColor: Styles.globalColors.blueLighter_20,
@@ -173,9 +173,9 @@ const styles = Styles.styleSheetCreate(
         padding: 2,
       },
       hashAndMessage: {
+        height: 18,
         marginBottom: Styles.globalMargins.xtiny,
         marginTop: Styles.globalMargins.xtiny,
-        height: 18,
       },
       marker: {
         marginRight: Styles.globalMargins.xtiny,


### PR DESCRIPTION
On iOS, the git commit message text had a much larger height than its line height, which caused alignment issues on git system messages. This PR fixes that issue by setting the commit message text height to the line height for that style (BodySmall here).