### PR TITLE
fix contacts imported banner showing up when not imported

### DIFF
--- a/shared/settings/manage-contacts.native.tsx
+++ b/shared/settings/manage-contacts.native.tsx
@@ -88,7 +88,7 @@ const ManageContactsBanner = () => {
 
   return (
     <>
-      {importedCount !== null && (
+      {!!importedCount && (
         <Kb.Banner color="green">
           <Kb.BannerParagraph bannerColor="green" content={[`You imported ${importedCount} contacts.`]} />
           <Kb.BannerParagraph bannerColor="green" content={[{onClick: onStartChat, text: 'Start a chat'}]} />


### PR DESCRIPTION
Immer changes made this init to `undefined`. Fixes this:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/11968340/70188789-9e61de00-16bf-11ea-8117-70c56adf64d8.png">
cc @keybase/y2ksquad 