### PR TITLE
cr: fix race where multiple CR attempts can run at once and panic

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -250,6 +250,10 @@ func (cr *ConflictResolver) processInput(baseCtx context.Context,
 			case <-waitChan:
 			case <-ctx.Done():
 				cr.log.CDebugf(ctx, "Resolution canceled before starting")
+				// The next attempt will still need to wait on the old
+				// one, in case it hasn't finished yet.  So wait for
+				// it here, before we close our own `done` channel.
+				<-waitChan
 				return
 			}
 			cr.doResolve(ctx, ci)


### PR DESCRIPTION
This scenario happened to a user:

* One CR attempt began.
* A second one was requested.
* The context for the second one was canceled, before the first one completed.
* A third one was requested.
* Because the second one was finished, the third one began _while the first one was still running_.

We make a lot of assumptions that a TLF can only have one CR running at once, and this ended up causing a panic.

Fixed by making the second one wait on the first one, even when it's canceled first.

Issue: HOTPOT-1438