### PR TITLE
fix: only show 3 avatars in multi-user join system message

### DIFF
--- a/shared/chat/conversation/messages/system-joined/index.tsx
+++ b/shared/chat/conversation/messages/system-joined/index.tsx
@@ -41,7 +41,7 @@ const MultiUserJoinedNotice = (props: Props) => (
     <Kb.Box2 direction="horizontal" alignSelf="flex-start" style={styles.avatarLine}>
       <Kb.AvatarLine
         usernames={props.joiners}
-        maxShown={4}
+        maxShown={3}
         size={32}
         layout="horizontal"
         alignSelf="flex-start"


### PR DESCRIPTION
one-liner to make the system joined message only show as many avatars as are mentioned in text