### PR TITLE
fix: handle all cases for join/leave team messages properly

### DIFF
--- a/shared/chat/conversation/messages/system-joined/container.tsx
+++ b/shared/chat/conversation/messages/system-joined/container.tsx
@@ -1,8 +1,9 @@
 import * as Types from '../../../../constants/types/chat2'
 import * as Constants from '../../../../constants/chat2'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
+import * as ProfileGen from '../../../../actions/profile-gen'
 import Joined from '.'
-import {connect, isMobile} from '../../../../util/container'
+import * as Container from '../../../../util/container'
 
 type OwnProps = {
   message: Types.MessageSystemJoined
@@ -18,8 +19,9 @@ const mapStateToProps = (state, {message}) => ({
 })
 
 const mapDispatchToProps = dispatch => ({
+  _onAuthorClick: (username: string) => dispatch(ProfileGen.createShowUserProfile({username})),
   _onManageChannels: (teamname: string) =>
-    isMobile
+    Container.isMobile
       ? dispatch(
           RouteTreeGen.createNavigateAppend({
             path: [{props: {teamname}, selected: 'chatManageChannels'}],
@@ -45,6 +47,7 @@ const mergeProps = (stateProps, dispatchProps, _: OwnProps) => {
     isBigTeam: _meta.teamType === 'big',
     joiners: stateProps.joiners,
     leavers: stateProps.leavers,
+    onAuthorClick: (username: string) => dispatchProps._onAuthorClick(username),
     onManageChannels: () => dispatchProps._onManageChannels(_meta.teamname),
     onManageNotifications: () => dispatchProps._onManageNotifications(_meta.conversationIDKey),
     teamname: _meta.teamname,
@@ -52,4 +55,4 @@ const mergeProps = (stateProps, dispatchProps, _: OwnProps) => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Joined)
+export default Container.connect(mapStateToProps, mapDispatchToProps, mergeProps)(Joined)

--- a/shared/chat/conversation/messages/system-joined/index.tsx
+++ b/shared/chat/conversation/messages/system-joined/index.tsx
@@ -11,6 +11,7 @@ type Props = {
   isBigTeam: boolean
   joiners: Array<string>
   leavers: Array<string>
+  onAuthorClick: () => void
   onManageChannels: () => void
   onManageNotifications: () => void
   teamname: string
@@ -19,35 +20,73 @@ type Props = {
 
 const textType = 'BodySmallSemiboldPrimaryLink'
 
-const Joined = (props: Props) =>
-  props.joiners.length + props.leavers.length < 2 ? (
-    <JoinedUserNotice {...props} />
-  ) : (
-    <MultiUserJoinedNotice {...props} />
+const Joined = (props: Props) => {
+  if (props.joiners.length + props.leavers.length == 1) {
+    return <JoinedUserNotice {...props} />
+  }
+
+  const joinMsg =
+    props.joiners.length == 1 ? (
+      <>
+        <AuthorAndAvatar {...props} username={props.joiners[0]} />
+        <Kb.Box2
+          direction="vertical"
+          style={Styles.collapseStyles([
+            styles.contentUnderAuthorContainer,
+            props.leavers.length > 0 && styles.joinerPadding,
+          ])}
+        >
+          <JoinedUserNotice {...props} joiners={props.joiners} leavers={[]} />
+        </Kb.Box2>
+      </>
+    ) : props.joiners.length > 1 ? (
+      <MultiUserJoinedNotice {...props} joiners={props.joiners} leavers={[]} />
+    ) : null
+  const leaveMsg =
+    props.leavers.length == 1 ? (
+      <>
+        <AuthorAndAvatar {...props} username={props.leavers[0]} />
+        <Kb.Box2 direction="vertical" style={styles.contentUnderAuthorContainer}>
+          <JoinedUserNotice {...props} joiners={[]} leavers={props.leavers} />
+        </Kb.Box2>
+      </>
+    ) : props.leavers.length > 1 ? (
+      <MultiUserJoinedNotice {...props} joiners={[]} leavers={props.leavers} />
+    ) : null
+
+  return (
+    <Kb.Box direction="vertical" style={{paddingTop: Styles.globalMargins.xtiny}}>
+      {joinMsg}
+      {leaveMsg}
+    </Kb.Box>
   )
+}
 
 const MultiUserJoinedNotice = (props: Props) => (
-  <UserNotice hideAvatar={true}>
-    {!!props.timestamp && (
-      <Kb.Text type="BodyTiny" style={styles.timestamp}>
-        {formatTimeForChat(props.timestamp)}
+  <Kb.Box2 direction="vertical">
+    <UserNotice noUsername={true}>
+      {!!props.timestamp && (
+        <Kb.Text type="BodyTiny" style={styles.timestamp}>
+          {formatTimeForChat(props.timestamp)}
+        </Kb.Text>
+      )}
+      <Kb.Text type="BodySmall" style={{paddingBottom: Styles.globalMargins.xxtiny}}>
+        {props.joiners.length > 0 ? getAddedUsernames(props.joiners) : getAddedUsernames(props.leavers)}
+        {` ${props.leavers.length > props.joiners.length ? 'left' : 'joined'} ${
+          props.isBigTeam ? `#${props.channelname}.` : `${props.teamname}.`
+        }`}
       </Kb.Text>
-    )}
-    <Kb.Text type="BodySmall" style={{paddingBottom: Styles.globalMargins.xxtiny}}>
-      {props.joiners.length > 0 && getAddedUsernames(props.joiners)}
-      {props.joiners.length > 0 &&
-        ` joined ${props.isBigTeam ? `#${props.channelname}.` : `${props.teamname}.`}`}
-    </Kb.Text>
-    <Kb.Box2 direction="horizontal" alignSelf="flex-start" style={styles.avatarLine}>
-      <Kb.AvatarLine
-        usernames={props.joiners}
-        maxShown={4}
-        size={32}
-        layout="horizontal"
-        alignSelf="flex-start"
-      />
-    </Kb.Box2>
-  </UserNotice>
+      <Kb.Box2 direction="horizontal" alignSelf="flex-start" style={styles.avatarLine}>
+        <Kb.AvatarLine
+          usernames={props.joiners.length > 0 ? props.joiners : props.leavers}
+          maxShown={3}
+          size={32}
+          layout="horizontal"
+          alignSelf="flex-start"
+        />
+      </Kb.Box2>
+    </UserNotice>
+  </Kb.Box2>
 )
 
 const JoinedUserNotice = (props: Props) => (
@@ -72,9 +111,65 @@ const JoinedUserNotice = (props: Props) => (
   </UserNotice>
 )
 
+const AuthorAndAvatar = (props: {
+  username: string
+  timestamp: number
+  authorIsYou: boolean
+  onAuthorClick: () => void
+}) => (
+  <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny">
+    <Kb.Avatar
+      size={32}
+      username={props.username}
+      skipBackground={true}
+      onClick={props.onAuthorClick}
+      style={styles.avatar}
+    />
+    <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.usernameCrown}>
+      <Kb.ConnectedUsernames
+        colorBroken={true}
+        colorFollowing={true}
+        colorYou={true}
+        onUsernameClicked={props.onAuthorClick}
+        style={Styles.collapseStyles([props.authorIsYou && styles.usernameHighlighted])}
+        type="BodySmallBold"
+        usernames={[props.username]}
+      />
+      {/* {this.props.showCrowns && (this.props.authorIsOwner || this.props.authorIsAdmin) && (
+        <Kb.WithTooltip tooltip={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
+          <Kb.Icon
+            color={
+              this.props.authorIsOwner ? Styles.globalColors.yellowDark : Styles.globalColors.black_35
+            }
+            fontSize={10}
+            type="iconfont-crown-owner"
+          />
+        </Kb.WithTooltip>
+      )} */}
+      <Kb.Text type="BodyTiny" style={styles.timestamp}>
+        {formatTimeForChat(props.timestamp)}
+      </Kb.Text>
+    </Kb.Box2>
+  </Kb.Box2>
+)
+
 const styles = Styles.styleSheetCreate(
   () =>
     ({
+      authorContainer: Styles.platformStyles({
+        common: {
+          alignItems: 'flex-start',
+          alignSelf: 'flex-start',
+          height: Styles.globalMargins.mediumLarge,
+        },
+        isMobile: {marginTop: 8},
+      }),
+      avatar: Styles.platformStyles({
+        isElectron: {
+          marginLeft: Styles.globalMargins.small,
+        },
+        isMobile: {marginLeft: Styles.globalMargins.tiny},
+      }),
       avatarLine: Styles.platformStyles({
         isElectron: {
           marginLeft: -2,
@@ -83,9 +178,41 @@ const styles = Styles.styleSheetCreate(
           marginLeft: -Styles.globalMargins.xsmall - 2,
         },
       }),
+      contentUnderAuthorContainer: Styles.platformStyles({
+        isElectron: {
+          marginTop: -16,
+          paddingLeft:
+            // Space for below the avatar
+            Styles.globalMargins.tiny + // right margin
+            Styles.globalMargins.small + // left margin
+            Styles.globalMargins.mediumLarge, // avatar
+        },
+        isMobile: {
+          marginTop: -12,
+          paddingBottom: 3,
+          paddingLeft:
+            // Space for below the avatar
+            Styles.globalMargins.tiny + // right margin
+            Styles.globalMargins.tiny + // left margin
+            Styles.globalMargins.mediumLarge, // avatar
+          paddingRight: Styles.globalMargins.tiny,
+        },
+      }),
+      joinerPadding: {paddingBottom: Styles.globalMargins.xsmall},
       timestamp: Styles.platformStyles({
         isElectron: {lineHeight: 19},
       }),
+      usernameCrown: Styles.platformStyles({
+        isElectron: {
+          alignItems: 'baseline',
+          position: 'relative',
+          top: -2,
+        },
+        isMobile: {alignItems: 'center'},
+      }),
+      usernameHighlighted: {
+        color: Styles.globalColors.blackOrBlack,
+      },
     } as const)
 )
 

--- a/shared/chat/conversation/messages/user-notice.tsx
+++ b/shared/chat/conversation/messages/user-notice.tsx
@@ -4,15 +4,16 @@ import * as Styles from '../../../styles'
 
 export type Props = {
   children?: React.ReactNode
-  hideAvatar?: boolean
+  noUsername?: boolean
+  showAvatar?: boolean
 }
 
-const UserNotice = ({children, hideAvatar}: Props) => (
+const UserNotice = ({children, noUsername}: Props) => (
   <Kb.Box2
     key="content"
     direction="vertical"
     fullWidth={true}
-    style={hideAvatar ? styles.noUsernameShim : {}}
+    style={noUsername ? styles.noUsernameShim : {}}
   >
     {children}
   </Kb.Box2>
@@ -24,7 +25,6 @@ const styles = Styles.styleSheetCreate(
       noUsernameShim: Styles.platformStyles({
         common: {
           paddingBottom: Styles.globalMargins.xtiny,
-          paddingTop: Styles.globalMargins.xtiny,
         },
         isElectron: {
           marginLeft: Styles.globalMargins.small,

--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -68,7 +68,7 @@ const getUsernameToShow = (
     case 'systemUsersAddedToConversation':
       return message.usernames.includes(you) ? '' : message.author
     case 'systemJoined':
-      return message.joiners.length > 1 ? '' : message.author
+      return message.joiners.length + message.leavers.length > 1 ? '' : message.author
   }
   return message.author
 }


### PR DESCRIPTION
There were several issues with the team join system message not handling leaves and events with both joiners and leavers. This PR modifies the SystemJoined system message to handle all the permutations of join and leave layouts correctly.