### PR TITLE
don't override git expandedSet with prop

### DIFF
--- a/shared/git/container.tsx
+++ b/shared/git/container.tsx
@@ -36,7 +36,7 @@ type ExtraProps = {
 let moduleExpandedSet = new Set<string>()
 
 const GitReloadable = (p: Omit<GitProps & ExtraProps, 'onToggleExpand'>) => {
-  const {clearBadges, expandedSet: initialExpandedSet} = p
+  const {clearBadges, expandedSet: initialExpandedSet, _loadGit, ...rest} = p
   const [expandedSet, setExpandedSet] = React.useState(new Set<string>(initialExpandedSet))
 
   React.useEffect(() => {
@@ -48,8 +48,6 @@ const GitReloadable = (p: Omit<GitProps & ExtraProps, 'onToggleExpand'>) => {
     moduleExpandedSet.has(id) ? moduleExpandedSet.delete(id) : moduleExpandedSet.add(id)
     setExpandedSet(new Set(moduleExpandedSet))
   }
-
-  const {_loadGit, ...rest} = p
   return (
     <Kb.Reloadable
       waitingKeys={Constants.loadingWaitingKey}

--- a/shared/git/index.stories.tsx
+++ b/shared/git/index.stories.tsx
@@ -5,7 +5,6 @@ import * as React from 'react'
 import List from '.'
 
 const props = {
-  clearBadges: Sb.action('clearBadges'),
   expandedSet: new Set<string>(),
   loading: false,
   onNewPersonalRepo: Sb.action('onNewPersonalRepo'),

--- a/shared/git/index.tsx
+++ b/shared/git/index.tsx
@@ -5,7 +5,6 @@ import Row from './row/container'
 
 export type Props = {
   expandedSet: Set<string>
-  clearBadges: () => void
   loading: boolean
   onShowDelete: (id: string) => void
   onNewPersonalRepo: () => void


### PR DESCRIPTION
The `expandedSet` managed in container was being overwritten by the empty set coming in from props. cc @keybase/y2ksquad 