### PR TITLE
fix SystemJoined alignment on mobile; update SystemLeft

### DIFF
--- a/shared/chat/conversation/messages/system-joined/index.tsx
+++ b/shared/chat/conversation/messages/system-joined/index.tsx
@@ -31,6 +31,7 @@ const Joined = (props: Props) => {
         <AuthorAndAvatar {...props} username={props.joiners[0]} />
         <Kb.Box2
           direction="vertical"
+          alignSelf="flex-start"
           style={Styles.collapseStyles([
             styles.contentUnderAuthorContainer,
             props.leavers.length > 0 && styles.joinerPadding,
@@ -46,7 +47,7 @@ const Joined = (props: Props) => {
     props.leavers.length == 1 ? (
       <>
         <AuthorAndAvatar {...props} username={props.leavers[0]} />
-        <Kb.Box2 direction="vertical" style={styles.contentUnderAuthorContainer}>
+        <Kb.Box2 direction="vertical" alignSelf="flex-start" style={styles.contentUnderAuthorContainer}>
           <JoinedUserNotice {...props} joiners={[]} leavers={props.leavers} />
         </Kb.Box2>
       </>
@@ -55,15 +56,20 @@ const Joined = (props: Props) => {
     ) : null
 
   return (
-    <Kb.Box direction="vertical" style={{paddingTop: Styles.globalMargins.xtiny}}>
+    <Kb.Box2
+      direction="vertical"
+      style={{paddingTop: Styles.globalMargins.xtiny}}
+      fullWidth={true}
+      alignSelf="flex-start"
+    >
       {joinMsg}
       {leaveMsg}
-    </Kb.Box>
+    </Kb.Box2>
   )
 }
 
 const MultiUserJoinedNotice = (props: Props) => (
-  <Kb.Box2 direction="vertical">
+  <Kb.Box2 direction="vertical" fullWidth={true} alignSelf="flex-start">
     <UserNotice noUsername={true}>
       {!!props.timestamp && (
         <Kb.Text type="BodyTiny" style={styles.timestamp}>
@@ -135,17 +141,6 @@ const AuthorAndAvatar = (props: {
         type="BodySmallBold"
         usernames={[props.username]}
       />
-      {/* {this.props.showCrowns && (this.props.authorIsOwner || this.props.authorIsAdmin) && (
-        <Kb.WithTooltip tooltip={this.props.authorIsOwner ? 'Owner' : 'Admin'}>
-          <Kb.Icon
-            color={
-              this.props.authorIsOwner ? Styles.globalColors.yellowDark : Styles.globalColors.black_35
-            }
-            fontSize={10}
-            type="iconfont-crown-owner"
-          />
-        </Kb.WithTooltip>
-      )} */}
       <Kb.Text type="BodyTiny" style={styles.timestamp}>
         {formatTimeForChat(props.timestamp)}
       </Kb.Text>

--- a/shared/chat/conversation/messages/system-joined/index.tsx
+++ b/shared/chat/conversation/messages/system-joined/index.tsx
@@ -27,7 +27,7 @@ const Joined = (props: Props) => {
 
   const joinMsg =
     props.joiners.length == 1 ? (
-      <>
+      <Kb.Box2 direction="vertical" fullWidth={true} alignSelf="flex-start" style={styles.singleEvent}>
         <AuthorAndAvatar {...props} username={props.joiners[0]} />
         <Kb.Box2
           direction="vertical"
@@ -39,29 +39,24 @@ const Joined = (props: Props) => {
         >
           <JoinedUserNotice {...props} joiners={props.joiners} leavers={[]} />
         </Kb.Box2>
-      </>
+      </Kb.Box2>
     ) : props.joiners.length > 1 ? (
       <MultiUserJoinedNotice {...props} joiners={props.joiners} leavers={[]} />
     ) : null
   const leaveMsg =
     props.leavers.length == 1 ? (
-      <>
+      <Kb.Box2 direction="vertical" fullWidth={true} alignSelf="flex-start" style={styles.singleEvent}>
         <AuthorAndAvatar {...props} username={props.leavers[0]} />
         <Kb.Box2 direction="vertical" alignSelf="flex-start" style={styles.contentUnderAuthorContainer}>
           <JoinedUserNotice {...props} joiners={[]} leavers={props.leavers} />
         </Kb.Box2>
-      </>
+      </Kb.Box2>
     ) : props.leavers.length > 1 ? (
       <MultiUserJoinedNotice {...props} joiners={[]} leavers={props.leavers} />
     ) : null
 
   return (
-    <Kb.Box2
-      direction="vertical"
-      style={{paddingTop: Styles.globalMargins.xtiny}}
-      fullWidth={true}
-      alignSelf="flex-start"
-    >
+    <Kb.Box2 direction="vertical" style={styles.container} fullWidth={true} alignSelf="flex-start">
       {joinMsg}
       {leaveMsg}
     </Kb.Box2>
@@ -123,7 +118,7 @@ const AuthorAndAvatar = (props: {
   authorIsYou: boolean
   onAuthorClick: () => void
 }) => (
-  <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny">
+  <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny" fullWidth={true}>
     <Kb.Avatar
       size={32}
       username={props.username}
@@ -170,7 +165,12 @@ const styles = Styles.styleSheetCreate(
           marginLeft: -2,
         },
         isMobile: {
-          marginLeft: -Styles.globalMargins.xsmall - 2,
+          marginLeft: -Styles.globalMargins.xsmall,
+        },
+      }),
+      container: Styles.platformStyles({
+        isElectron: {
+          paddingTop: Styles.globalMargins.xtiny,
         },
       }),
       contentUnderAuthorContainer: Styles.platformStyles({
@@ -187,13 +187,25 @@ const styles = Styles.styleSheetCreate(
           paddingBottom: 3,
           paddingLeft:
             // Space for below the avatar
-            Styles.globalMargins.tiny + // right margin
-            Styles.globalMargins.tiny + // left margin
-            Styles.globalMargins.mediumLarge, // avatar
+            Styles.globalMargins.small + Styles.globalMargins.mediumLarge, // left margin // avatar,
           paddingRight: Styles.globalMargins.tiny,
         },
       }),
-      joinerPadding: {paddingBottom: Styles.globalMargins.xsmall},
+      joinerPadding: Styles.platformStyles({
+        isElectron: {
+          paddingBottom: Styles.globalMargins.xsmall,
+        },
+        isMobile: {
+          paddingBottom: Styles.globalMargins.xtiny,
+        },
+      }),
+      singleEvent: Styles.platformStyles({
+        isMobile: {
+          marginLeft: -(
+            (Styles.globalMargins.small + Styles.globalMargins.mediumLarge) // left margin
+          ), // avatar
+        },
+      }),
       timestamp: Styles.platformStyles({
         isElectron: {lineHeight: 19},
       }),

--- a/shared/chat/conversation/messages/system-left/index.tsx
+++ b/shared/chat/conversation/messages/system-left/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as Kb from '../../../../common-adapters'
-import {formatTimeForChat} from '../../../../util/timestamp'
+import UserNotice from '../user-notice'
 
 type Props = {
   channelname: string
@@ -11,16 +11,9 @@ type Props = {
 }
 
 export default (props: Props) => (
-  <Kb.Box2 direction="vertical" fullWidth={true}>
-    <Kb.Text type="BodyTiny">{formatTimeForChat(props.timestamp)}</Kb.Text>
-    <Kb.ConnectedUsernames
-      type="BodySmallSemibold"
-      suffixType="BodySmall"
-      onUsernameClicked="profile"
-      colorFollowing={true}
-      underline={true}
-      usernames={props.leavers}
-      suffix={` left ${props.isBigTeam ? `#${props.channelname}` : props.teamname}.`}
-    />
-  </Kb.Box2>
+  <UserNotice>
+    <Kb.Text type="BodySmall">{` left ${
+      props.isBigTeam ? `#${props.channelname}` : props.teamname
+    }.`}</Kb.Text>
+  </UserNotice>
 )

--- a/shared/chat/conversation/messages/user-notice.tsx
+++ b/shared/chat/conversation/messages/user-notice.tsx
@@ -12,6 +12,7 @@ const UserNotice = ({children, noUsername}: Props) => (
   <Kb.Box2
     key="content"
     direction="vertical"
+    alignSelf="flex-start"
     fullWidth={true}
     style={noUsername ? styles.noUsernameShim : {}}
   >


### PR DESCRIPTION
This PR fixes issues with mobile styling of the SystemJoined and SystemLeft banners by overriding some wrappermessage padding that did not need to be applied (since the SystemJoined special cases handle most of WrapperMessage's styles).