### PR TITLE
prod builds can run journeycard scripts

### DIFF
--- a/go/client/cmd_contacts_debug.go
+++ b/go/client/cmd_contacts_debug.go
@@ -21,7 +21,7 @@ import (
 
 // Devel commands for testing contact syncing.
 
-func NwCmdContacts(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+func NewCmdContacts(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:         "contacts",
 		Usage:        "commands for testing contact sync on desktop",

--- a/go/client/cmd_script.go
+++ b/go/client/cmd_script.go
@@ -19,9 +19,10 @@ type CmdScript struct {
 	Args   []string
 }
 
-func newCmdScript(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+func newCmdScript(cl *libcmdline.CommandLine, g *libkb.GlobalContext, listed bool) cli.Command {
 	return cli.Command{
 		Name:         "script",
+		Unlisted:     !listed,
 		ArgumentHelp: "<script> [<args>]",
 		Usage:        "Run a dev debug script. See debugging_devel.go",
 		Action: func(c *cli.Context) {

--- a/go/client/commands_common.go
+++ b/go/client/commands_common.go
@@ -56,6 +56,7 @@ func GetCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext) []cli.Comma
 		NewCmdProve(cl, g),
 		NewCmdRekey(cl, g),
 		NewCmdRIIT(cl, g),
+		newCmdScript(cl, g, !libkb.BuildTagProduction),
 		NewCmdSelfProvision(cl, g),
 		NewCmdSign(cl, g),
 		NewCmdSigs(cl, g),

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -29,8 +29,7 @@ func getBuildSpecificCommands(cl *libcmdline.CommandLine, g *libkb.GlobalContext
 		newCmdTeamGenerateSeitan(cl, g),
 		newCmdTeamRotateKey(cl, g),
 		newCmdTeamDebug(cl, g),
-		newCmdScript(cl, g),
-		NwCmdContacts(cl, g),
+		NewCmdContacts(cl, g),
 		NewCmdPeopleSearch(cl, g),
 		newCmdTestAirdropReg(cl, g),
 	}

--- a/go/libkb/constants_nonproduction.go
+++ b/go/libkb/constants_nonproduction.go
@@ -1,0 +1,8 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !production
+
+package libkb
+
+const BuildTagProduction = false

--- a/go/libkb/constants_production.go
+++ b/go/libkb/constants_production.go
@@ -7,3 +7,5 @@ package libkb
 
 // Production run mode currently...enabled!
 const DefaultRunMode = ProductionRunMode
+
+const BuildTagProduction = true

--- a/go/service/debugging.go
+++ b/go/service/debugging.go
@@ -4,7 +4,13 @@
 package service
 
 import (
+	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"golang.org/x/net/context"
@@ -26,7 +32,63 @@ func NewDebuggingHandler(xp rpc.Transporter, g *libkb.GlobalContext, userHandler
 	}
 }
 
-// See debugging_{devel,production}.go for additional handlers.
+// See debugging_devel.go for additional scripts.
+func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (res string, err error) {
+	ctx = libkb.WithLogTag(ctx, "DG")
+	m := libkb.NewMetaContext(ctx, t.G())
+	defer m.TraceTimed(fmt.Sprintf("Script(%s)", arg.Script), func() error { return err })()
+	args := arg.Args
+	log := func(format string, args ...interface{}) {
+		t.G().Log.CInfof(ctx, format, args...)
+	}
+	defer time.Sleep(100 * time.Millisecond) // Without this CInfof often doesn't reach the CLI
+	switch arg.Script {
+	case "journeycard":
+		log("journeycard-fastforward [days]")
+		log("journeycard-resetall")
+		log("journeycard-state <conv-id>")
+		return "", nil
+	case "journeycard-fastforward":
+		uidGregor := gregor1.UID(m.G().ActiveDevice.UID().ToBytes())
+		advance := 24 * time.Hour
+		if len(args) >= 1 {
+			days, err := strconv.Atoi(args[0])
+			if err != nil {
+				return "", err
+			}
+			advance = time.Duration(days) * 24 * time.Hour
+		}
+		err = t.G().ChatHelper.JourneycardTimeTravel(m.Ctx(), uidGregor, advance)
+		if err != nil {
+			return "", err
+		}
+		log("time advanced by %v for all convs", advance)
+		return "", err
+	case "journeycard-resetall":
+		uidGregor := gregor1.UID(m.G().ActiveDevice.UID().ToBytes())
+		err = t.G().ChatHelper.JourneycardResetAllConvs(m.Ctx(), uidGregor)
+		if err != nil {
+			return "", err
+		}
+		log("journeycard state has been reset for all convs")
+		return "", nil
+	case "journeycard-state":
+		if len(args) != 1 {
+			return "", fmt.Errorf("usage: journeycard-state <conv-id> (like 000059aa7f324dad7524b56ed1beb3e3d620b3897d640951710f1417c6b7b85f)")
+		}
+		convID, err := chat1.MakeConvID(args[0])
+		if err != nil {
+			return "", err
+		}
+		uidGregor := gregor1.UID(m.G().ActiveDevice.UID().ToBytes())
+		summary, err := t.G().ChatHelper.JourneycardDebugState(m.Ctx(), uidGregor, convID)
+		return summary, err
+	case "":
+		return "", fmt.Errorf("empty script name")
+	default:
+		return t.scriptExtras(ctx, arg)
+	}
+}
 
 func (t *DebuggingHandler) FirstStep(ctx context.Context, arg keybase1.FirstStepArg) (result keybase1.FirstStepResult, err error) {
 	client := t.rpcClient()

--- a/go/service/debugging_devel.go
+++ b/go/service/debugging_devel.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,8 +17,6 @@ import (
 	chatwallet "github.com/keybase/client/go/chat/wallet"
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/protocol/chat1"
-	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/protocol/stellar1"
 	"github.com/keybase/client/go/teams"
@@ -29,10 +26,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (res string, err error) {
+func (t *DebuggingHandler) scriptExtras(ctx context.Context, arg keybase1.ScriptArg) (res string, err error) {
 	ctx = libkb.WithLogTag(ctx, "DG")
 	m := libkb.NewMetaContext(ctx, t.G())
-	defer m.TraceTimed(fmt.Sprintf("Script(%s)", arg.Script), func() error { return err })()
 	args := arg.Args
 	log := func(format string, args ...interface{}) {
 		t.G().Log.CInfof(ctx, format, args...)
@@ -283,46 +279,6 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 		}
 		err = teams.ReAddMemberAfterReset(ctx, m.G(), teamID, "ireset1")
 		return "", err
-	case "journeycard":
-		log("journeycard-fastforward [days]")
-		log("journeycard-resetall")
-		log("journeycard-state <conv-id>")
-		return "", nil
-	case "journeycard-fastforward":
-		uidGregor := gregor1.UID(m.G().ActiveDevice.UID().ToBytes())
-		advance := 24 * time.Hour
-		if len(args) >= 1 {
-			days, err := strconv.Atoi(args[0])
-			if err != nil {
-				return "", err
-			}
-			advance = time.Duration(days) * 24 * time.Hour
-		}
-		err = t.G().ChatHelper.JourneycardTimeTravel(m.Ctx(), uidGregor, advance)
-		if err != nil {
-			return "", err
-		}
-		log("time advanced by %v for all convs", advance)
-		return "", err
-	case "journeycard-resetall":
-		uidGregor := gregor1.UID(m.G().ActiveDevice.UID().ToBytes())
-		err = t.G().ChatHelper.JourneycardResetAllConvs(m.Ctx(), uidGregor)
-		if err != nil {
-			return "", err
-		}
-		log("journeycard state has been reset for all convs")
-		return "", nil
-	case "journeycard-state":
-		if len(args) != 1 {
-			return "", fmt.Errorf("usage: journeycard-state <conv-id> (like 000059aa7f324dad7524b56ed1beb3e3d620b3897d640951710f1417c6b7b85f)")
-		}
-		convID, err := chat1.MakeConvID(args[0])
-		if err != nil {
-			return "", err
-		}
-		uidGregor := gregor1.UID(m.G().ActiveDevice.UID().ToBytes())
-		summary, err := t.G().ChatHelper.JourneycardDebugState(m.Ctx(), uidGregor, convID)
-		return summary, err
 	case "":
 		return "", fmt.Errorf("empty script name")
 	default:

--- a/go/service/debugging_production.go
+++ b/go/service/debugging_production.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (_ string, err error) {
-	defer t.G().CTraceTimed(ctx, "Script", func() error { return err })()
-	return "", fmt.Errorf("debugging script not supported in production builds")
+func (t *DebuggingHandler) scriptExtras(ctx context.Context, arg keybase1.ScriptArg) (_ string, err error) {
+	return "", fmt.Errorf("unknown script in production mode: %v", arg.Script)
 }


### PR DESCRIPTION
Previously `keybase script` and its service handler was only compiled when `production` build tag was not given. Now `keybase script` and some of the service handlers are always compiled in. `keybase script` is unlisted with the `production` build tag. Journeycard scripts are runnable from the unlisted command. Other scripts are still not compiled into `production` tag builds.