### PR TITLE
Fix white screen on deleting account

### DIFF
--- a/shared/settings/delete-confirm/container.tsx
+++ b/shared/settings/delete-confirm/container.tsx
@@ -6,19 +6,17 @@ import DeleteConfirm from '.'
 type OwnProps = {}
 
 export default Container.connect(
-  state => {
-    if (!state.config.username) {
-      throw new Error('No current username for delete confirm container')
-    }
-
-    return {
-      username: state.config.username,
-    }
-  },
-  dispatch => ({
-    onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),
-    onDeleteForever: () => dispatch(SettingsGen.createDeleteAccountForever()),
+  state => ({
+    username: state.config.username,
   }),
-
-  (s, d, o: OwnProps) => ({...o, ...s, ...d})
+  dispatch => ({
+    _onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),
+    _onDeleteForever: () => dispatch(SettingsGen.createDeleteAccountForever()),
+  }),
+  (stateProps, dispatchProps, ownProps: OwnProps) => ({
+    ...ownProps,
+    ...stateProps,
+    onCancel: dispatchProps._onCancel,
+    onDeleteForever: () => stateProps.username && dispatchProps._onDeleteForever(),
+  })
 )(DeleteConfirm)


### PR DESCRIPTION
@keybase/react-hackers 

The breaking flow was:

* container tests that state.config.username exists as a safety check
* we show the dialog
* user chooses to delete their account
* logout happens as a result
* now state.config.username no longer exists; we're logged out
* component is still mounted and throws, leading to white screen

The check doesn't seem especially worthwhile to me.  But we can make it logout-safe by just guarding the delete call on having state.config.username exist.