### PR TITLE
More reliable team info in inbox menu

### DIFF
--- a/shared/chat/conversation/info-panel/menu/container.tsx
+++ b/shared/chat/conversation/info-panel/menu/container.tsx
@@ -47,6 +47,8 @@ export default Container.namedConnect(
   (state, {conversationIDKey, isSmallTeam, teamID: _teamID, visible}: OwnProps) => {
     let convProps: ConvProps | undefined
     let teamDetails: TeamTypes.TeamDetails | undefined
+    let teamname: string = ''
+    let teamID: TeamTypes.TeamID = TeamTypes.noTeamID
     if (conversationIDKey && conversationIDKey !== ChatConstants.noConversationIDKey) {
       const meta = state.chat2.metaMap.get(conversationIDKey) || ChatConstants.makeConversationMeta()
       const participants = ChatConstants.getRowParticipants(meta, state.config.username)
@@ -57,6 +59,8 @@ export default Container.namedConnect(
         ''
       const isTeam = meta.teamType === 'big' || meta.teamType === 'small'
       teamDetails = isTeam ? TeamConstants.getTeamDetails(state, meta.teamID) : undefined
+      teamname = meta.teamname
+      teamID = meta.teamID
       convProps = {
         fullname,
         ignored: meta.status === RPCChatTypes.ConversationStatus.ignored,
@@ -64,8 +68,12 @@ export default Container.namedConnect(
         participants,
         teamID: meta.teamID,
         teamType: meta.teamType,
-        teamname: (teamDetails && teamDetails.teamname) || '',
+        teamname,
       }
+    } else if (_teamID) {
+      teamID = _teamID
+      teamDetails = TeamConstants.getTeamDetails(state, teamID)
+      teamname = teamDetails.teamname
     }
     // skip a bunch of stuff for menus that aren't visible
     if (!visible) {
@@ -80,12 +88,7 @@ export default Container.namedConnect(
         teamname: '',
       }
     }
-    const teamID = (teamDetails && teamDetails.id) || _teamID || ''
-    if (teamID) {
-      // teamID was in OwnProps
-      teamDetails = TeamConstants.getTeamDetails(state, teamID)
-    }
-    const teamname = (teamDetails && teamDetails.teamname) || ''
+
     const yourOperations = TeamConstants.getCanPerformByID(state, teamID)
     const badgeSubscribe = !TeamConstants.isTeamWithChosenChannels(state, teamname)
 

--- a/shared/chat/conversation/info-panel/menu/index.tsx
+++ b/shared/chat/conversation/info-panel/menu/index.tsx
@@ -4,7 +4,7 @@ import * as Styles from '../../../../styles'
 import * as ChatTypes from '../../../../constants/types/chat2'
 import * as TeamTypes from '../../../../constants/types/teams'
 import {Avatars, TeamAvatar} from '../../../avatars'
-import {useTeamsSubscribeMountOnly} from '../../../../teams/subscriber'
+import {TeamSubscriberMountOnly} from '../../../../teams/subscriber'
 
 export type ConvProps = {
   fullname: string
@@ -79,7 +79,6 @@ type TeamHeaderProps = {
   onViewTeam: () => void
 }
 const TeamHeader = (props: TeamHeaderProps) => {
-  useTeamsSubscribeMountOnly()
   return (
     <Kb.Box2 direction="vertical" gap="tiny" gapStart={false} gapEnd={true} style={styles.headerContainer}>
       <TeamAvatar teamname={props.teamname} isMuted={props.isMuted} isSelected={false} isHovered={false} />
@@ -164,15 +163,18 @@ class InfoPanelMenu extends React.Component<Props> {
     }
 
     return (
-      <Kb.FloatingMenu
-        attachTo={props.attachTo}
-        visible={props.visible}
-        items={items}
-        header={header}
-        onHidden={props.onHidden}
-        position="bottom left"
-        closeOnSelect={true}
-      />
+      <>
+        <TeamSubscriberMountOnly />
+        <Kb.FloatingMenu
+          attachTo={props.attachTo}
+          visible={props.visible}
+          items={items}
+          header={header}
+          onHidden={props.onHidden}
+          position="bottom left"
+          closeOnSelect={true}
+        />
+      </>
     )
   }
 

--- a/shared/chat/conversation/info-panel/menu/index.tsx
+++ b/shared/chat/conversation/info-panel/menu/index.tsx
@@ -164,7 +164,7 @@ class InfoPanelMenu extends React.Component<Props> {
 
     return (
       <>
-        <TeamSubscriberMountOnly />
+        {props.visible && <TeamSubscriberMountOnly />}
         <Kb.FloatingMenu
           attachTo={props.attachTo}
           visible={props.visible}

--- a/shared/chat/conversation/info-panel/menu/index.tsx
+++ b/shared/chat/conversation/info-panel/menu/index.tsx
@@ -4,6 +4,7 @@ import * as Styles from '../../../../styles'
 import * as ChatTypes from '../../../../constants/types/chat2'
 import * as TeamTypes from '../../../../constants/types/teams'
 import {Avatars, TeamAvatar} from '../../../avatars'
+import {useTeamsSubscribeMountOnly} from '../../../../teams/subscriber'
 
 export type ConvProps = {
   fullname: string
@@ -78,6 +79,7 @@ type TeamHeaderProps = {
   onViewTeam: () => void
 }
 const TeamHeader = (props: TeamHeaderProps) => {
+  useTeamsSubscribeMountOnly()
   return (
     <Kb.Box2 direction="vertical" gap="tiny" gapStart={false} gapEnd={true} style={styles.headerContainer}>
       <TeamAvatar teamname={props.teamname} isMuted={props.isMuted} isSelected={false} isHovered={false} />

--- a/shared/teams/subscriber.tsx
+++ b/shared/teams/subscriber.tsx
@@ -5,7 +5,7 @@ import {NavigationEventCallback} from '@react-navigation/core'
 import {useNavigationEvents} from '../util/navigation-hooks'
 
 // NOTE: If you are in a floating box or otherwise outside the navigation
-// context, you must use `useTeamsSubscribeMountOnly`
+// context, you must use `*MountOnly` variants of these helpers
 
 const useTeamsSubscribeMobile = () => {
   const dispatch = Container.useDispatch()
@@ -36,5 +36,10 @@ export const useTeamsSubscribeMountOnly = useTeamsSubscribeDesktop
 // Dummy component to add to a view to trigger team meta subscription behavior
 export const TeamSubscriber = () => {
   useTeamsSubscribe()
+  return null
+}
+
+export const TeamSubscriberMountOnly = () => {
+  useTeamsSubscribeMountOnly()
   return null
 }

--- a/shared/teams/subscriber.tsx
+++ b/shared/teams/subscriber.tsx
@@ -4,6 +4,9 @@ import * as TeamsGen from '../actions/teams-gen'
 import {NavigationEventCallback} from '@react-navigation/core'
 import {useNavigationEvents} from '../util/navigation-hooks'
 
+// NOTE: If you are in a floating box or otherwise outside the navigation
+// context, you must use `useTeamsSubscribeMountOnly`
+
 const useTeamsSubscribeMobile = () => {
   const dispatch = Container.useDispatch()
   const callback: NavigationEventCallback = e => {
@@ -28,6 +31,7 @@ const useTeamsSubscribeDesktop = () => {
   }, [])
 }
 export const useTeamsSubscribe = Container.isMobile ? useTeamsSubscribeMobile : useTeamsSubscribeDesktop
+export const useTeamsSubscribeMountOnly = useTeamsSubscribeDesktop
 
 // Dummy component to add to a view to trigger team meta subscription behavior
 export const TeamSubscriber = () => {


### PR DESCRIPTION
Make container source teamname from `meta` if we have a `conversationIDKey`, and team data if not. Add teams subscriber so we keep info up to date while this menu is open. 