### PR TITLE
fix loading team on create

### DIFF
--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -49,6 +49,7 @@ const showTeamAfterCreation = (_: TypedState, action: TeamsGen.TeamCreatedPayloa
     ]
   }
   return [
+    TeamsGen.createGetDetails({teamname}),
     RouteTreeGen.createClearModals(),
     RouteTreeGen.createNavigateAppend({path: [{props: {teamID}, selected: 'team'}]}),
     ...(isMobile

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -33,6 +33,9 @@ export default Container.makeReducer<
   [TeamsGen.createNewTeamFromConversation]: draftState => {
     draftState.teamCreationError = ''
   },
+  [TeamsGen.teamCreated]: (draftState, action) => {
+    draftState.teamNameToID.set(action.payload.teamname, action.payload.teamID)
+  },
   [TeamsGen.setTeamCreationError]: (draftState, action) => {
     draftState.teamCreationError = action.payload.error
   },
@@ -68,7 +71,11 @@ export default Container.makeReducer<
     const members = Constants.rpcDetailsToMemberInfos(action.payload.members)
     draftState.teamNameToMembers.set(teamname, Constants.rpcDetailsToMemberInfos(action.payload.members))
 
-    const details = mapGetEnsureValue(draftState.teamDetails, teamID, Constants.makeTeamDetails({teamname}))
+    const details = mapGetEnsureValue(
+      draftState.teamDetails,
+      teamID,
+      Constants.makeTeamDetails({id: teamID, teamname})
+    )
     details.members = members
     details.settings = action.payload.settings
     details.invites = new Set(action.payload.invites)


### PR DESCRIPTION
Messy because team get takes a name
- Spawn a `getDetails` on team created because the component will not have the teamname
- Store entry `teamNameToID` on team created so we have it as soon as possible

cc @keybase/y2ksquad 