### PR TITLE
keybase1: simplify SigID equality check

### DIFF
--- a/go/engine/prove_help_test.go
+++ b/go/engine/prove_help_test.go
@@ -303,7 +303,7 @@ func proveGubbleUniverse(tc libkb.TestContext, serviceName, endpoint string, fu 
 		require.NoError(tc.T, err)
 		require.True(tc.T, len(proofs) >= 1)
 		for _, proof := range proofs {
-			if proof.KbUsername == fu.Username && sigID.Equal(proof.SigHash) {
+			if proof.KbUsername == fu.Username && sigID.Eq(proof.SigHash) {
 				return nil
 			}
 		}

--- a/go/externals/proof_service_generic_social.go
+++ b/go/externals/proof_service_generic_social.go
@@ -218,7 +218,7 @@ func (rc *GenericSocialProofChecker) CheckStatus(mctx libkb.MetaContext, _ libkb
 
 	var foundProof, foundUsername bool
 	for _, proof := range proofs {
-		if proof.KbUsername == rc.proof.GetUsername() && sigID.Equal(proof.SigHash) {
+		if proof.KbUsername == rc.proof.GetUsername() && sigID.Eq(proof.SigHash) {
 			foundProof = true
 			break
 		}

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1226,8 +1226,8 @@ func ParseSelfSigChainLink(base GenericChainLink) (ret *SelfSigChainLink, err er
 type IdentityTable struct {
 	Contextified
 	sigChain         *SigChain
-	revocations      map[keybase1.SigID]bool
-	links            map[keybase1.SigID]TypedChainLink
+	revocations      map[keybase1.SigIDMapKey]bool
+	links            map[keybase1.SigIDMapKey]TypedChainLink
 	remoteProofLinks *RemoteProofLinks
 	tracks           map[NormalizedUsername][]*TrackChainLink
 	Order            []TypedChainLink
@@ -1252,11 +1252,11 @@ func (idt *IdentityTable) HasStubs() bool {
 }
 
 func (idt *IdentityTable) insertLink(l TypedChainLink) {
-	idt.links[l.GetSigID()] = l
+	idt.links[l.GetSigID().ToMapKey()] = l
 	idt.Order = append(idt.Order, l)
 	for _, rev := range l.GetRevocations() {
-		idt.revocations[rev] = true
-		if targ, found := idt.links[rev]; !found {
+		idt.revocations[rev.ToMapKey()] = true
+		if targ, found := idt.links[rev.ToMapKey()]; !found {
 			idt.G().Log.Warning("Can't revoke signature %s @%s", rev, l.ToDebugString())
 		} else {
 			targ.markRevoked(l)
@@ -1325,8 +1325,8 @@ func NewIdentityTable(m MetaContext, eldest keybase1.KID, sc *SigChain, h *SigHi
 	ret := &IdentityTable{
 		Contextified:     NewContextified(m.G()),
 		sigChain:         sc,
-		revocations:      make(map[keybase1.SigID]bool),
-		links:            make(map[keybase1.SigID]TypedChainLink),
+		revocations:      make(map[keybase1.SigIDMapKey]bool),
+		links:            make(map[keybase1.SigIDMapKey]TypedChainLink),
 		remoteProofLinks: NewRemoteProofLinks(m.G()),
 		tracks:           make(map[NormalizedUsername][]*TrackChainLink),
 		sigHints:         h,

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -383,7 +383,7 @@ type PathStep struct {
 }
 
 func (mt MerkleTriple) Eq(mt2 MerkleTriple) bool {
-	return mt.Seqno == mt2.Seqno && mt.LinkID.Eq(mt2.LinkID) && mt.SigID.Equal(mt2.SigID)
+	return mt.Seqno == mt2.Seqno && mt.LinkID.Eq(mt2.LinkID) && mt.SigID.Eq(mt2.SigID)
 }
 
 func (mul MerkleUserLeaf) Public() *MerkleTriple {

--- a/go/libkb/merkle_tools.go
+++ b/go/libkb/merkle_tools.go
@@ -165,7 +165,7 @@ func FindNextMerkleRootAfterRevoke(m MetaContext, arg keybase1.FindNextMerkleRoo
 	if sigID.IsNil() {
 		return res, MerkleClientError{fmt.Sprintf("unknown seqno in sigchain: %d", arg.Loc.Seqno), merkleErrorBadSeqno}
 	}
-	if !sigID.Equal(leaf.Public.SigID) {
+	if !sigID.Eq(leaf.Public.SigID) {
 		return res, MerkleClientError{fmt.Sprintf("sigID sent down by server didn't match: %s != %s", sigID.String(), leaf.Public.SigID.String()), merkleErrorBadSigID}
 	}
 	res.Res = &keybase1.MerkleRootV2{

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -984,7 +984,7 @@ func (sc *SigChain) GetLinkFromSeqno(seqno keybase1.Seqno) *ChainLink {
 
 func (sc *SigChain) GetLinkFromSigID(id keybase1.SigID) *ChainLink {
 	for _, link := range sc.chainLinks {
-		if link.GetSigID().Equal(id) {
+		if link.GetSigID().Eq(id) {
 			return link
 		}
 	}
@@ -995,7 +995,7 @@ func (sc *SigChain) GetLinkFromSigID(id keybase1.SigID) *ChainLink {
 // with a SigID that starts with query.
 func (sc *SigChain) GetLinkFromSigIDQuery(query string) *ChainLink {
 	for _, link := range sc.chainLinks {
-		if link.GetSigID().Match(query, false) {
+		if link.GetSigID().PrefixMatch(query, false) {
 			return link
 		}
 	}

--- a/go/libkb/sig_hints.go
+++ b/go/libkb/sig_hints.go
@@ -65,7 +65,7 @@ type SigHints struct {
 	Contextified
 	uid     keybase1.UID
 	version int
-	hints   map[keybase1.SigID]*SigHint
+	hints   map[keybase1.SigIDMapKey]*SigHint
 	dirty   bool
 }
 
@@ -84,7 +84,7 @@ func NewSigHints(jw *jsonw.Wrapper, uid keybase1.UID, dirty bool, g *GlobalConte
 }
 
 func (sh SigHints) Lookup(i keybase1.SigID) *SigHint {
-	obj := sh.hints[i]
+	obj := sh.hints[i.ToMapKey()]
 	return obj
 }
 
@@ -99,7 +99,7 @@ func (sh *SigHints) PopulateWith(jw *jsonw.Wrapper) (err error) {
 		return
 	}
 
-	sh.hints = make(map[keybase1.SigID]*SigHint)
+	sh.hints = make(map[keybase1.SigIDMapKey]*SigHint)
 	var n int
 	n, err = jw.AtKey("hints").Len()
 	if err != nil {
@@ -111,7 +111,7 @@ func (sh *SigHints) PopulateWith(jw *jsonw.Wrapper) (err error) {
 		if tmpe != nil {
 			sh.G().Log.Warning("Bad SigHint Loaded: %s", tmpe)
 		} else {
-			sh.hints[hint.sigID] = hint
+			sh.hints[hint.sigID.ToMapKey()] = hint
 		}
 	}
 	return

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -640,37 +640,6 @@ func (s SigID) Exists() bool {
 
 func (s SigID) String() string { return string(s) }
 
-func (s SigID) Equal(t SigID) bool {
-	return s == t
-}
-
-func (s SigID) EqualIgnoreLastByte(t SigID) bool {
-	if len(s) != len(t) || len(s) < 2 {
-		return false
-	}
-	return s[:len(s)-2] == t[:len(t)-2]
-}
-
-func (s SigID) Match(q string, exact bool) bool {
-	if s.IsNil() {
-		return false
-	}
-
-	if exact {
-		return strings.ToLower(s.ToString(true)) == strings.ToLower(q)
-	}
-
-	if strings.HasPrefix(s.ToString(true), strings.ToLower(q)) {
-		return true
-	}
-
-	return false
-}
-
-func (s SigID) NotEqual(t SigID) bool {
-	return !s.Equal(t)
-}
-
 func (s SigID) ToDisplayString(verbose bool) string {
 	if verbose {
 		return string(s)
@@ -686,6 +655,22 @@ func (s SigID) ToString(suffix bool) string {
 		return string(s)
 	}
 	return string(s[0 : len(s)-2])
+}
+
+func (s SigID) PrefixMatch(q string, exact bool) bool {
+	if s.IsNil() {
+		return false
+	}
+
+	if exact {
+		return strings.ToLower(s.ToString(true)) == strings.ToLower(q)
+	}
+
+	if strings.HasPrefix(s.ToString(true), strings.ToLower(q)) {
+		return true
+	}
+
+	return false
 }
 
 func SigIDFromString(s string, suffix bool) (SigID, error) {
@@ -722,6 +707,28 @@ func (s SigID) toBytes() []byte {
 		return nil
 	}
 	return b[0:SIG_ID_LEN]
+}
+
+func (s SigID) Eq(t SigID) bool {
+	b := s.toBytes()
+	c := t.toBytes()
+	if b == nil || c == nil {
+		return false
+	}
+	return hmac.Equal(b, c)
+}
+
+type SigIDMapKey string
+
+// ToMapKey returns the string representation (hex-encoded) of a SigID with the hardcoded 0x0f suffix
+// (for backward comptability with on-disk storage).
+func (s SigID) ToMapKey() SigIDMapKey {
+	tmp := s
+	hexLen := 2 * SIG_ID_LEN
+	if len(tmp) > hexLen {
+		tmp = tmp[0:hexLen]
+	}
+	return SigIDMapKey(fmt.Sprintf("%s%02x", tmp, SIG_ID_SUFFIX))
 }
 
 func (s SigID) ToMediumID() string {

--- a/go/systests/team_invite_test.go
+++ b/go/systests/team_invite_test.go
@@ -872,7 +872,7 @@ func proveGubbleUniverse(tc *libkb.TestContext, serviceName, endpoint string, us
 		require.NoError(tc.T, err)
 		require.True(tc.T, len(proofs) >= 1)
 		for _, proof := range proofs {
-			if proof.KbUsername == username && sigID.Equal(proof.SigHash) {
+			if proof.KbUsername == username && sigID.Eq(proof.SigHash) {
 				return nil
 			}
 		}

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -1859,12 +1859,9 @@ func assertIsKeybaseInvite(mctx libkb.MetaContext, i SCTeamInvite) bool {
 
 // These signatures contain non-owners inviting owners.
 // They slipped in before that was banned. They are excepted from the rule.
-var hardcodedInviteRuleExceptionSigIDs = map[keybase1.SigID]bool{
-	"c06e8da2959d8c8054fb10e005910716f776b3c3df9ef2eb4c4b8584f45e187f22": true,
+var hardcodedInviteRuleExceptionSigIDs = map[keybase1.SigIDMapKey]bool{
 	"c06e8da2959d8c8054fb10e005910716f776b3c3df9ef2eb4c4b8584f45e187f0f": true,
-	"e800db474fa75f39503e9241990c3707121c7c414687a7b1f5ef579a625eaf8222": true,
 	"e800db474fa75f39503e9241990c3707121c7c414687a7b1f5ef579a625eaf820f": true,
-	"46d9f2700b8d4287a2dc46dae00974a794b5778149214cf91fa4b69229a6abbc22": true,
 	"46d9f2700b8d4287a2dc46dae00974a794b5778149214cf91fa4b69229a6abbc0f": true,
 }
 
@@ -1897,7 +1894,7 @@ func (t *teamSigchainPlayer) sanityCheckInvites(mctx libkb.MetaContext,
 				return nil, nil, fmt.Errorf("encountered invite of owner in non-root team")
 			}
 			if !signerIsExplicitOwner {
-				if !hardcodedInviteRuleExceptionSigIDs[sigID] {
+				if !hardcodedInviteRuleExceptionSigIDs[sigID.ToMapKey()] {
 					return nil, nil, fmt.Errorf("encountered invite of owner by non-owner")
 				}
 			}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -201,7 +201,7 @@ var whitelistedTeamLinkSigsForAdminPermissionDemote = []keybase1.SigID{
 
 func (l *TeamLoader) addProofsForKeyInUserSigchain(ctx context.Context, teamID keybase1.TeamID, link *ChainLinkUnpacked, uid keybase1.UID, key *keybase1.PublicKeyV2NaCl, userLinkMap linkMapT, proofSet *proofSetT) {
 	for _, okSigID := range whitelistedTeamLinkSigsForKeyInUserSigchain {
-		if link.SigID().EqualIgnoreLastByte(okSigID) {
+		if link.SigID().Eq(okSigID) {
 			// This proof is whitelisted, so don't check it.
 			l.G().Log.CDebugf(ctx, "addProofsForKeyInUserSigchain: skipping exceptional link: %v", link.SigID())
 			return
@@ -421,7 +421,7 @@ func (l *TeamLoader) addProofsForAdminPermission(ctx context.Context, teamID key
 	proofSet.AddNeededHappensBeforeProof(ctx, event1Promote, event2Link, "became admin before team link")
 	if event3Demote != nil {
 		for _, okSigID := range whitelistedTeamLinkSigsForAdminPermissionDemote {
-			if link.SigID().EqualIgnoreLastByte(okSigID) {
+			if link.SigID().Eq(okSigID) {
 				// This proof is whitelisted, so don't check it.
 				l.G().Log.CDebugf(ctx, "addProofsForAdminPermission: [demote] skipping exceptional link: %v", link.SigID())
 				return


### PR DESCRIPTION
- because the signature ID is computed over the signature, which is computed over the signature version, there's no reason to check the suffix bytes (which convey sig version) when comparing for SigID equality
- this simplifies a lot of goo around sigID comparisons
- similarly, standardize a representation to use in maps that have keybase1.SigID keys; use legacy 0x0f suffix byte by convention so we don't have to rewrite old caches