### PR TITLE
CI fetch quietly

### DIFF
--- a/shared/jenkins_test.sh
+++ b/shared/jenkins_test.sh
@@ -30,8 +30,8 @@ has_js_files() {
         echo 'Missing $change_target, forcing has_js_files to true'
         return
     fi
-    echo 'git fetch'
-    git fetch
+    echo 'git fetch -q'
+    git fetch -q
     check_rc $? 'echo git fetch problem' 1
     echo 'git diff'
     git diff --name-only "$change_base...$commit_hash"


### PR DESCRIPTION
Omit ~1700 lines of branch enumeration from CI logs. Should make finding real errors in CI a little easier.

Example CI output before this change
```
+ ./jenkins_test.sh js d2fa320c489ececd29f8995cb705a7be5b576e99 master
shared/jenkins_test.sh recieved type: js commit_hash: d2fa320c489ececd29f8995cb705a7be5b576e99 change_target: origin/master change_base: 1a0eb24fd9ab6f74d2e1accf7177e17d4ef74dd9
js-tests
v10.14.2
git fetch
From https://github.com/keybase/client
 * [new branch]            10127-3                 -> origin/10127-3
...
 * [new branch]            AMarcedone/CORE-2301-partial-work -> origin/AMarcedone/CORE-2301-partial-work
... ~1700 lines
 * [new tag]               v4.6.0                  -> v4.6.0
git diff
go/chat/journey_card_manager.go
go/chat/utils/utils.go
go/libkb/interfaces.go
```

New output (optimistically)
```
+ ./jenkins_test.sh js d2fa320c489ececd29f8995cb705a7be5b576e99 master
shared/jenkins_test.sh recieved type: js commit_hash: d2fa320c489ececd29f8995cb705a7be5b576e99 change_target: origin/master change_base: 1a0eb24fd9ab6f74d2e1accf7177e17d4ef74dd9
js-tests
v10.14.2
git fetch -q
git diff
go/chat/journey_card_manager.go
go/chat/utils/utils.go
go/libkb/interfaces.go
```