### PR TITLE
use all conv statuses when fetching conv, dont join on headline/metadata

### DIFF
--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -2595,13 +2595,8 @@ func GetUnverifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 	convID chat1.ConversationID, dataSource types.InboxSourceDataSourceTyp) (res types.RemoteConversation, err error) {
 
 	inbox, err := g.InboxSource.ReadUnverified(ctx, uid, dataSource, &chat1.GetInboxQuery{
-		ConvIDs: []chat1.ConversationID{convID},
-		MemberStatus: []chat1.ConversationMemberStatus{
-			chat1.ConversationMemberStatus_ACTIVE,
-			chat1.ConversationMemberStatus_PREVIEW,
-			chat1.ConversationMemberStatus_RESET,
-			chat1.ConversationMemberStatus_NEVER_JOINED,
-		},
+		ConvIDs:      []chat1.ConversationID{convID},
+		MemberStatus: chat1.AllConversationMemberStatuses(),
 	})
 	if err != nil {
 		return res, err
@@ -2644,18 +2639,14 @@ func FormatConversationName(info chat1.ConversationInfoLocal, myUsername string)
 
 func GetVerifiedConv(ctx context.Context, g *globals.Context, uid gregor1.UID,
 	convID chat1.ConversationID, dataSource types.InboxSourceDataSourceTyp) (res chat1.ConversationLocal, err error) {
-	// in case we are being called from within some cancelable context, remove it for the purposes
-	// of this call, since whatever this is is likely a side effect we don't want to get stuck
+	// in case we are being called from within some cancelable context, remove
+	// it for the purposes of this call, since whatever this is is likely a
+	// side effect we don't want to get stuck
 	ctx = globals.CtxRemoveLocalizerCancelable(ctx)
 	inbox, _, err := g.InboxSource.Read(ctx, uid, types.ConversationLocalizerBlocking, dataSource, nil,
 		&chat1.GetInboxLocalQuery{
-			ConvIDs: []chat1.ConversationID{convID},
-			MemberStatus: []chat1.ConversationMemberStatus{
-				chat1.ConversationMemberStatus_ACTIVE,
-				chat1.ConversationMemberStatus_PREVIEW,
-				chat1.ConversationMemberStatus_RESET,
-				chat1.ConversationMemberStatus_NEVER_JOINED,
-			},
+			ConvIDs:      []chat1.ConversationID{convID},
+			MemberStatus: chat1.AllConversationMemberStatuses(),
 		})
 	if err != nil {
 		return res, err


### PR DESCRIPTION
- reverts https://github.com/keybase/client/pull/18888
- skip joining the channel if updating a name/description (depends on https://github.com/keybase/keybase/pull/4858)