### PR TITLE
chat cli polish: upload/download commands

### DIFF
--- a/go/client/chat_common.go
+++ b/go/client/chat_common.go
@@ -75,3 +75,20 @@ func postConvMinWriterRole(ctx context.Context, lcli chat1.LocalClient, tui libk
 		Role:   role,
 	})
 }
+
+func CheckAndStartStandaloneChat(g *libkb.GlobalContext, mt chat1.ConversationMembersType) error {
+	if !g.Standalone {
+		return nil
+	}
+	// TODO: Right now this command cannot be run in standalone at
+	// all, even though team chats should work, but there is a bug
+	// in finding existing conversations.
+	switch mt {
+	case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE,
+		chat1.ConversationMembersType_IMPTEAMUPGRADE:
+		g.StartStandaloneChat()
+		return nil
+	default:
+		return CantRunInStandaloneError{}
+	}
+}

--- a/go/client/chat_send_common.go
+++ b/go/client/chat_send_common.go
@@ -50,7 +50,6 @@ func chatSend(ctx context.Context, g *libkb.GlobalContext, c ChatSendArg) error 
 	})
 	switch err.(type) {
 	case nil:
-		break
 	case libkb.ResolutionError:
 		return fmt.Errorf("could not resolve `%s` into Keybase user(s) or a team", c.resolvingRequest.TlfName)
 	default:

--- a/go/client/cmd_chat_download.go
+++ b/go/client/cmd_chat_download.go
@@ -3,21 +3,26 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	isatty "github.com/mattn/go-isatty"
 )
 
 type CmdChatDownload struct {
 	libkb.Contextified
-	tlf        string
-	public     bool
-	messageID  uint64
-	outputFile string
-	preview    bool
+	hasTTY           bool
+	resolvingRequest chatConversationResolvingRequest
+	messageID        uint64
+	outputFile       string
+	preview          bool
 }
 
 func newCmdChatDownload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -30,28 +35,27 @@ func newCmdChatDownload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.
 			cl.ChooseCommand(cmd, "download", c)
 			cl.SetLogForward(libcmdline.LogForwardNone)
 		},
-		Flags: []cli.Flag{
+		Flags: append([]cli.Flag{
 			cli.BoolFlag{
 				Name:  "p, preview",
 				Usage: "Download preview",
-			},
-			cli.BoolFlag{
-				Name:  "public",
-				Usage: "Download attachment from public conversation",
 			},
 			cli.StringFlag{
 				Name:  "o, outfile",
 				Usage: "Specify output file (stdout default)",
 			},
-		},
+		}, getConversationResolverFlags()...),
 	}
 }
 
-func (c *CmdChatDownload) ParseArgv(ctx *cli.Context) error {
+func (c *CmdChatDownload) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 2 {
 		return errors.New("usage: keybase chat download <conversation> <attachment id> [-o filename]")
 	}
-	c.tlf = ctx.Args()[0]
+	tlfName := ctx.Args()[0]
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
 	id, err := strconv.ParseUint(ctx.Args()[1], 10, 64)
 	if err != nil {
 		return err
@@ -64,20 +68,51 @@ func (c *CmdChatDownload) ParseArgv(ctx *cli.Context) error {
 		c.outputFile = libkb.GetSafePath(c.outputFile)
 	}
 	c.preview = ctx.Bool("preview")
-	c.public = ctx.Bool("public")
+	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())
 
 	return nil
 }
 
-func (c *CmdChatDownload) Run() error {
+func (c *CmdChatDownload) Run() (err error) {
+	ui := NewChatCLIUI(c.G())
+	protocols := []rpc.Protocol{
+		chat1.ChatUiProtocol(ui),
+	}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+
+	if err = annotateResolvingRequest(c.G(), &c.resolvingRequest); err != nil {
+		return err
+	}
+
+	if err := CheckAndStartStandaloneChat(c.G(), c.resolvingRequest.MembersType); err != nil {
+		return err
+	}
+
+	resolver, err := newChatConversationResolver(c.G())
+	if err != nil {
+		return err
+	}
+
+	conversation, _, err := resolver.Resolve(context.TODO(), c.resolvingRequest, chatConversationResolvingBehavior{
+		CreateIfNotExists: false,
+		MustNotExist:      false,
+		Interactive:       c.hasTTY,
+		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	})
+	switch err.(type) {
+	case nil:
+	case libkb.ResolutionError:
+		return fmt.Errorf("could not resolve `%s` into Keybase user(s) or a team", c.resolvingRequest.TlfName)
+	default:
+		return err
+	}
 	opts := downloadOptionsV1{
-		Channel: ChatChannel{
-			Name:   c.tlf,
-			Public: c.public,
-		},
-		MessageID: chat1.MessageID(c.messageID),
-		Output:    c.outputFile,
-		Preview:   c.preview,
+		ConversationID: conversation.Info.Id.String(),
+		MessageID:      chat1.MessageID(c.messageID),
+		Output:         c.outputFile,
+		Preview:        c.preview,
 	}
 	h := newChatServiceHandler(c.G())
 	reply := h.DownloadV1(context.Background(), opts, NewChatCLIUI(c.G()))

--- a/go/client/cmd_chat_search_inbox.go
+++ b/go/client/cmd_chat_search_inbox.go
@@ -94,19 +94,8 @@ func (c *CmdChatSearchInbox) Run() (err error) {
 		if err = annotateResolvingRequest(c.G(), &c.resolvingRequest); err != nil {
 			return err
 		}
-
-		// TODO: Right now this command cannot be run in standalone at
-		// all, even though team chats should work, but there is a bug
-		// in finding existing conversations.
-		if c.G().Standalone {
-			switch c.resolvingRequest.MembersType {
-			case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE,
-				chat1.ConversationMembersType_IMPTEAMUPGRADE:
-				c.G().StartStandaloneChat()
-			default:
-				err = CantRunInStandaloneError{}
-				return err
-			}
+		if err := CheckAndStartStandaloneChat(c.G(), c.resolvingRequest.MembersType); err != nil {
+			return err
 		}
 
 		conversation, _, err := resolver.Resolve(ctx, c.resolvingRequest, chatConversationResolvingBehavior{

--- a/go/client/cmd_chat_search_regexp.go
+++ b/go/client/cmd_chat_search_regexp.go
@@ -74,18 +74,8 @@ func (c *CmdChatSearchRegexp) Run() (err error) {
 			return err
 		}
 	}
-	// TODO: Right now this command cannot be run in standalone at
-	// all, even though team chats should work, but there is a bug
-	// in finding existing conversations.
-	if c.G().Standalone {
-		switch c.resolvingRequest.MembersType {
-		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE,
-			chat1.ConversationMembersType_IMPTEAMUPGRADE:
-			c.G().StartStandaloneChat()
-		default:
-			err = CantRunInStandaloneError{}
-			return err
-		}
+	if err := CheckAndStartStandaloneChat(c.G(), c.resolvingRequest.MembersType); err != nil {
+		return err
 	}
 
 	resolver, err := newChatConversationResolver(c.G())

--- a/go/client/cmd_chat_send.go
+++ b/go/client/cmd_chat_send.go
@@ -114,18 +114,8 @@ func (c *CmdChatSend) Run() (err error) {
 			return fmt.Errorf("Cannot send ephemeral messages to a KBFS type chat.")
 		}
 	}
-
-	// TODO: Right now this command cannot be run in standalone at
-	// all, even though team chats should work, but there is a bug
-	// in finding existing conversations.
-	if c.G().Standalone {
-		switch c.resolvingRequest.MembersType {
-		case chat1.ConversationMembersType_TEAM, chat1.ConversationMembersType_IMPTEAMNATIVE,
-			chat1.ConversationMembersType_IMPTEAMUPGRADE:
-			c.G().StartStandaloneChat()
-		default:
-			return CantRunInStandaloneError{}
-		}
+	if err := CheckAndStartStandaloneChat(c.G(), c.resolvingRequest.MembersType); err != nil {
+		return err
 	}
 
 	return chatSend(context.TODO(), c.G(), ChatSendArg{

--- a/go/client/cmd_chat_upload.go
+++ b/go/client/cmd_chat_upload.go
@@ -3,19 +3,25 @@ package client
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/keybase/cli"
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	isatty "github.com/mattn/go-isatty"
 	"golang.org/x/net/context"
 )
 
 type CmdChatUpload struct {
 	libkb.Contextified
-	tlf               string
+	hasTTY            bool
+	resolvingRequest  chatConversationResolvingRequest
 	filename          string
-	public            bool
 	title             string
 	ephemeralLifetime ephemeralLifetime
 	cancel            func()
@@ -24,15 +30,12 @@ type CmdChatUpload struct {
 
 func newCmdChatUpload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	flags := []cli.Flag{
-		cli.BoolFlag{
-			Name:  "public",
-			Usage: "Send to public conversation (default private)",
-		},
 		cli.StringFlag{
 			Name:  "title",
 			Usage: "Title of attachment (defaults to filename)",
 		},
 	}
+	flags = append(flags, getConversationResolverFlags()...)
 	flags = append(flags, mustGetChatFlags("exploding-lifetime")...)
 	return cli.Command{
 		Name:         "upload",
@@ -50,31 +53,79 @@ func newCmdChatUpload(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 	}
 }
 
-func (c *CmdChatUpload) ParseArgv(ctx *cli.Context) error {
+func (c *CmdChatUpload) ParseArgv(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) != 2 {
 		return errors.New("usage: keybase chat upload <conversation> <filename>")
 	}
-	c.tlf = ctx.Args()[0]
-	c.filename = ctx.Args()[1]
-	c.public = ctx.Bool("public")
+
+	tlfName := ctx.Args()[0]
+	if c.resolvingRequest, err = parseConversationResolvingRequest(ctx, tlfName); err != nil {
+		return err
+	}
+	c.filename, err = filepath.Abs(ctx.Args()[1])
+	if err != nil {
+		return err
+	}
 	c.title = ctx.String("title")
 	c.ephemeralLifetime = ephemeralLifetime{ctx.Duration("exploding-lifetime")}
-
+	c.hasTTY = isatty.IsTerminal(os.Stdin.Fd())
 	return nil
 }
 
-func (c *CmdChatUpload) Run() error {
-	// Verify that we are not trying to send an ephemeral message to a public
-	// chat.
-	if c.ephemeralLifetime.Duration > 0 && c.public {
-		return fmt.Errorf("Cannot send ephemeral messages with --public set.")
+func (c *CmdChatUpload) Run() (err error) {
+	ui := NewChatCLIUI(c.G())
+	protocols := []rpc.Protocol{
+		chat1.ChatUiProtocol(ui),
+	}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
+
+	if err = annotateResolvingRequest(c.G(), &c.resolvingRequest); err != nil {
+		return err
+	}
+	// TLFVisibility_ANY doesn't make any sense for send, so switch that to PRIVATE:
+	if c.resolvingRequest.Visibility == keybase1.TLFVisibility_ANY {
+		c.resolvingRequest.Visibility = keybase1.TLFVisibility_PRIVATE
+	}
+
+	// Verify we can continue with the current options, this will return an
+	// error if you try to send to a KBFS chat or have --public set and
+	// ephemeralLifetime.
+	if c.ephemeralLifetime.Duration > 0 {
+		if c.resolvingRequest.Visibility == keybase1.TLFVisibility_PUBLIC {
+			return fmt.Errorf("Cannot send ephemeral messages with --public set.")
+		}
+		if c.resolvingRequest.MembersType == chat1.ConversationMembersType_KBFS {
+			return fmt.Errorf("Cannot send ephemeral messages to a KBFS type chat.")
+		}
+	}
+
+	if err := CheckAndStartStandaloneChat(c.G(), c.resolvingRequest.MembersType); err != nil {
+		return err
+	}
+
+	resolver, err := newChatConversationResolver(c.G())
+	if err != nil {
+		return err
+	}
+
+	conversation, _, err := resolver.Resolve(context.TODO(), c.resolvingRequest, chatConversationResolvingBehavior{
+		CreateIfNotExists: false,
+		MustNotExist:      false,
+		Interactive:       c.hasTTY,
+		IdentifyBehavior:  keybase1.TLFIdentifyBehavior_CHAT_CLI,
+	})
+	switch err.(type) {
+	case nil:
+	case libkb.ResolutionError:
+		return fmt.Errorf("could not resolve `%s` into Keybase user(s) or a team", c.resolvingRequest.TlfName)
+	default:
+		return err
 	}
 
 	opts := attachOptionsV1{
-		Channel: ChatChannel{
-			Name:   c.tlf,
-			Public: c.public,
-		},
+		ConversationID:    conversation.Info.Id.String(),
 		Filename:          c.filename,
 		Title:             c.title,
 		EphemeralLifetime: c.ephemeralLifetime,


### PR DESCRIPTION
patch does the following:
- fixes `upload`/`download` to resolve conversations correctly
- allows uploading from a relative path