### PR TITLE
use italic quotes for description

### DIFF
--- a/shared/chat/conversation/messages/set-description/index.tsx
+++ b/shared/chat/conversation/messages/set-description/index.tsx
@@ -13,9 +13,12 @@ export default (props: Props) => {
   const desc = props.message.newDescription.stringValue()
   return desc ? (
     <Kb.Text type="BodySmall" style={styles.text} selectable={true}>
-      changed the channel description to {lquote}
-      <Kb.Text type="BodySmallItalic">{desc}</Kb.Text>
-      {rquote}
+      changed the channel description to{' '}
+      <Kb.Text type="BodySmallItalic">
+        {lquote}
+        {desc}
+        {rquote}
+      </Kb.Text>
     </Kb.Text>
   ) : (
     <Kb.Text type="BodySmall" style={styles.text}>


### PR DESCRIPTION
That {' '} magically showed up from linter I think, not sure if it's correct.

Before
![2019-12-11-175916_631x48_scrot](https://user-images.githubusercontent.com/28712558/70667866-f6f52600-1c3f-11ea-98d5-80ebd13ed71d.png)

After
![2019-12-11-175943_551x35_scrot](https://user-images.githubusercontent.com/28712558/70667877-04121500-1c40-11ea-8f39-7c341baded57.png)