### PR TITLE
Cancel reset modal fixes

### DIFF
--- a/go/service/account.go
+++ b/go/service/account.go
@@ -240,12 +240,8 @@ func (h *AccountHandler) CancelReset(ctx context.Context, sessionID int) (err er
 	if err != nil {
 		mctx.Debug("CancelResetPipeline failed with: %s", err)
 		mctx.Debug("Checking if we are not revoked")
-		// err2 := mctx.LogoutAndDeprovisionIfRevoked()
-		// if err2 != nil {
-		// 	mctx.Error("LogoutAndDeprovisionIfRevoked failed in CancelReset check: %s", err2)
-		// 	return libkb.CombineErrors(err, err2)
-		// }
-		err2 := mctx.LogoutWithOptions(libkb.LogoutOptions{KeepSecrets: false, Force: true})
+		err2 := mctx.LogoutAndDeprovisionIfRevoked()
+		//err2 := mctx.LogoutWithOptions(libkb.LogoutOptions{KeepSecrets: false, Force: true})
 		if err2 != nil {
 			mctx.Error("LogoutAndDeprovisionIfRevoked failed in CancelReset check: %s", err2)
 			return libkb.CombineErrors(err, err2)

--- a/go/service/account.go
+++ b/go/service/account.go
@@ -241,7 +241,6 @@ func (h *AccountHandler) CancelReset(ctx context.Context, sessionID int) (err er
 		mctx.Debug("CancelResetPipeline failed with: %s", err)
 		mctx.Debug("Checking if we are not revoked")
 		err2 := mctx.LogoutAndDeprovisionIfRevoked()
-		//err2 := mctx.LogoutWithOptions(libkb.LogoutOptions{KeepSecrets: false, Force: true})
 		if err2 != nil {
 			mctx.Error("LogoutAndDeprovisionIfRevoked failed in CancelReset check: %s", err2)
 			return libkb.CombineErrors(err, err2)

--- a/go/service/errors.go
+++ b/go/service/errors.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"fmt"
+
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -29,4 +30,17 @@ type NotConnectedError struct{}
 
 func (e NotConnectedError) Error() string {
 	return "Not connected"
+}
+
+type UserWasLoggedOutError struct{}
+
+func (e UserWasLoggedOutError) Error() string {
+	return "User was logged out because the device is no longer valid"
+}
+
+func (e UserWasLoggedOutError) ToStatus() (s keybase1.Status) {
+	s.Code = libkb.SCNoSession
+	s.Name = "NO_SESSION"
+	s.Desc = e.Error()
+	return
 }

--- a/shared/actions/autoreset.tsx
+++ b/shared/actions/autoreset.tsx
@@ -1,4 +1,5 @@
 import * as AutoresetGen from './autoreset-gen'
+import * as LoginGen from './login-gen'
 import * as Constants from '../constants/autoreset'
 import * as Container from '../util/container'
 import * as NotificationsGen from './notifications-gen'
@@ -27,6 +28,15 @@ const cancelReset = async () => {
   try {
     await RPCGen.accountCancelResetRpcPromise(undefined, Constants.cancelResetWaitingKey)
   } catch (error) {
+    if (error.code === RPCGen.StatusCode.scnosession) {
+      return LoginGen.createLoginError({
+        error: Object.assign({}, error, {
+          message:
+            'Could not cancel reset. Either the reset has already completed, or your device was revoked.',
+        }),
+      })
+    }
+    logger.error('Error in CancelAutoreset', error)
     return AutoresetGen.createResetError({error})
   }
   return AutoresetGen.createResetCancelled()

--- a/shared/actions/autoreset.tsx
+++ b/shared/actions/autoreset.tsx
@@ -28,16 +28,23 @@ const cancelReset = async () => {
   try {
     await RPCGen.accountCancelResetRpcPromise(undefined, Constants.cancelResetWaitingKey)
   } catch (error) {
-    if (error.code === RPCGen.StatusCode.scnosession) {
-      return LoginGen.createLoginError({
-        error: Object.assign({}, error, {
-          message:
-            'Could not cancel reset. Either the reset has already completed, or your device was revoked.',
-        }),
-      })
-    }
     logger.error('Error in CancelAutoreset', error)
-    return AutoresetGen.createResetError({error})
+    switch (error.code ?? 0) {
+      case RPCGen.StatusCode.scnosession:
+        return LoginGen.createLoginError({
+          error: Object.assign({}, error, {
+            message:
+              'Could not cancel reset. Either the reset has already completed, or your device was revoked.',
+          }),
+        })
+      case RPCGen.StatusCode.scnotfound:
+        // "User not in autoreset queue."
+        // do nothing, fall out of the catch block to cancel reset modal.
+        break
+      default:
+        // Any other error - display a red bar in the modal.
+        return AutoresetGen.createResetError({error})
+    }
   }
   return AutoresetGen.createResetCancelled()
 }

--- a/shared/actions/autoreset.tsx
+++ b/shared/actions/autoreset.tsx
@@ -1,5 +1,4 @@
 import * as AutoresetGen from './autoreset-gen'
-import * as LoginGen from './login-gen'
 import * as Constants from '../constants/autoreset'
 import * as Container from '../util/container'
 import * as NotificationsGen from './notifications-gen'

--- a/shared/actions/autoreset.tsx
+++ b/shared/actions/autoreset.tsx
@@ -31,12 +31,9 @@ const cancelReset = async () => {
     logger.error('Error in CancelAutoreset', error)
     switch (error.code ?? 0) {
       case RPCGen.StatusCode.scnosession:
-        return LoginGen.createLoginError({
-          error: Object.assign({}, error, {
-            message:
-              'Could not cancel reset. Either the reset has already completed, or your device was revoked.',
-          }),
-        })
+        // We got logged out because we were revoked (which might have been
+        // becase the reset was completed and this device wasn't notified).
+        return undefined
       case RPCGen.StatusCode.scnotfound:
         // "User not in autoreset queue."
         // do nothing, fall out of the catch block to cancel reset modal.

--- a/shared/login/reset/modal.tsx
+++ b/shared/login/reset/modal.tsx
@@ -10,7 +10,7 @@ import {formatDurationForAutoreset} from '../../util/timestamp'
 export type Props = {}
 
 const ResetModal = (_: Props) => {
-  const {active, endTime} = Container.useSelector(s => s.autoreset)
+  const {active, endTime, error} = Container.useSelector(s => s.autoreset)
   const dispatch = Container.useDispatch()
   React.useEffect(() => {
     if (!active) {
@@ -44,6 +44,15 @@ const ResetModal = (_: Props) => {
             />
           ),
         }}
+        banners={
+          error
+            ? [
+                <Kb.Banner color="red" key="errors">
+                  <Kb.BannerParagraph bannerColor="red" content={error} />
+                </Kb.Banner>,
+              ]
+            : undefined
+        }
       >
         <Kb.Box2 fullWidth={true} direction="vertical">
           <Kb.Box2


### PR DESCRIPTION
It was possible to complete reset on an account, and have one device that was sleeping all that time and missed all the notifications about device being revoked. This would have caused the modal to keep showing up, and the cancel button to do nothing - it was erroring out, but the error was not displayed anywhere.

- Add error banner to cancel reset modal.
- Change `CancelReset` RPC to call `mctx.LogoutAndDeprovisionIfRevoked` if API call fails, to check if maybe it failed because we are already reset (or revoked or similar).
   - If so, return a special error to propagate that info as a banner to login screen.

TODO:
- [x] go test
- [x] remove the manual testing code