### PR TITLE
client: fix win/mac LFS config setting

### DIFF
--- a/go/client/cmd_git_lfs_config.go
+++ b/go/client/cmd_git_lfs_config.go
@@ -131,7 +131,7 @@ func (c *CmdGitLFSConfig) Run() error {
 	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		// Windows and macOS require quotes around the args, but linux
 		// does not.
-		quoteArgs = "\\\""
+		quoteArgs = "\""
 	}
 	_, err = c.gitExec(
 		"config", "--add", "lfs.customtransfer.keybase-lfs.args",


### PR DESCRIPTION
Turns out we only need one slash, not three.