### PR TITLE
once-per-team journeycards

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
 )
 
@@ -495,8 +496,13 @@ func (s *HybridConversationSource) Push(ctx context.Context, convID chat1.Conver
 	if err = s.mergeMaybeNotify(ctx, convID, uid, []chat1.MessageUnboxed{decmsg}); err != nil {
 		return decmsg, continuousUpdate, err
 	}
-	if msg.ClientHeader.Sender.Eq(uid) {
-		go s.G().JourneyCardManager.SentMessage(globals.BackgroundChatCtx(ctx, s.G()), uid, convID)
+	if msg.ClientHeader.Sender.Eq(uid) && conv.GetMembersType() == chat1.ConversationMembersType_TEAM {
+		teamID, err := keybase1.TeamIDFromString(conv.Conv.Metadata.IdTriple.Tlfid.String())
+		if err != nil {
+			s.Debug(ctx, "Push: failed to get team ID: %v", err)
+		} else {
+			go s.G().JourneyCardManager.SentMessage(globals.BackgroundChatCtx(ctx, s.G()), uid, teamID, convID)
+		}
 	}
 	// Remove any pending previews from storage
 	s.completeAttachmentUpload(ctx, decmsg)

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -89,10 +89,14 @@ func (s *baseConversationSource) addPendingPreviews(ctx context.Context, thread 
 	}
 }
 
-func (s *baseConversationSource) addConversationCards(ctx context.Context, uid gregor1.UID,
+func (s *baseConversationSource) addConversationCards(ctx context.Context, uid gregor1.UID, reason chat1.GetThreadReason,
 	convID chat1.ConversationID, convOptional *chat1.ConversationLocal, thread *chat1.ThreadView) {
 	ctxShort, ctxShortCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer ctxShortCancel()
+	if journeycardShouldNotRunOnReason[reason] {
+		s.Debug(ctx, "addConversationCards: skipping due to reason: %v", reason)
+		return
+	}
 	card, err := s.G().JourneyCardManager.PickCard(ctxShort, uid, convID, convOptional, thread)
 	ctxShortCancel()
 	if err != nil {
@@ -117,7 +121,7 @@ func (s *baseConversationSource) addConversationCards(ctx context.Context, uid g
 	thread.Messages[addLeftOf] = chat1.NewMessageUnboxedWithJourneycard(*card)
 }
 
-func (s *baseConversationSource) postProcessThread(ctx context.Context, uid gregor1.UID,
+func (s *baseConversationSource) postProcessThread(ctx context.Context, uid gregor1.UID, reason chat1.GetThreadReason,
 	conv types.UnboxConversationInfo, thread *chat1.ThreadView, q *chat1.GetThreadQuery,
 	superXform types.SupersedesTransform, replyFiller types.ReplyFiller, checkPrev bool,
 	patchPagination bool, verifiedConv *chat1.ConversationLocal) (err error) {
@@ -163,7 +167,7 @@ func (s *baseConversationSource) postProcessThread(ctx context.Context, uid greg
 	s.Debug(ctx, "postProcessThread: thread messages after explode filter: %d", len(thread.Messages))
 
 	// Add any conversation cards
-	s.addConversationCards(ctx, uid, conv.GetConvID(), verifiedConv, thread)
+	s.addConversationCards(ctx, uid, reason, conv.GetConvID(), verifiedConv, thread)
 
 	// Fetch outbox and tack onto the result
 	outbox := storage.NewOutbox(s.G(), uid)
@@ -329,7 +333,7 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	}
 
 	// Post process thread before returning
-	if err = s.postProcessThread(ctx, uid, conv, &thread, query, nil, nil, true, false, &conv); err != nil {
+	if err = s.postProcessThread(ctx, uid, reason, conv, &thread, query, nil, nil, true, false, &conv); err != nil {
 		return chat1.ThreadView{}, err
 	}
 
@@ -337,7 +341,7 @@ func (s *RemoteConversationSource) Pull(ctx context.Context, convID chat1.Conver
 }
 
 func (s *RemoteConversationSource) PullLocalOnly(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination, maxPlaceholders int) (chat1.ThreadView, error) {
+	uid gregor1.UID, reason chat1.GetThreadReason, query *chat1.GetThreadQuery, pagination *chat1.Pagination, maxPlaceholders int) (chat1.ThreadView, error) {
 	return chat1.ThreadView{}, storage.MissError{Msg: "PullLocalOnly is unimplemented for RemoteConversationSource"}
 }
 
@@ -619,7 +623,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 			// Run post process stuff
 			vconv, err := utils.GetVerifiedConv(ctx, s.G(), uid, convID, types.InboxSourceDataSourceAll)
 			if err == nil {
-				if err = s.postProcessThread(ctx, uid, conv, &thread, query, nil, nil, true, true, &vconv); err != nil {
+				if err = s.postProcessThread(ctx, uid, reason, conv, &thread, query, nil, nil, true, true, &vconv); err != nil {
 					return thread, err
 				}
 			}
@@ -660,7 +664,7 @@ func (s *HybridConversationSource) Pull(ctx context.Context, convID chat1.Conver
 	}
 
 	// Run post process stuff
-	if err = s.postProcessThread(ctx, uid, unboxConv, &thread, query, nil, nil, true, true, nil); err != nil {
+	if err = s.postProcessThread(ctx, uid, reason, unboxConv, &thread, query, nil, nil, true, true, nil); err != nil {
 		return thread, err
 	}
 	return thread, nil
@@ -710,7 +714,7 @@ func newPullLocalResultCollector(baseRC storage.ResultCollector) *pullLocalResul
 }
 
 func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID chat1.ConversationID,
-	uid gregor1.UID, query *chat1.GetThreadQuery, pagination *chat1.Pagination, maxPlaceholders int) (tv chat1.ThreadView, err error) {
+	uid gregor1.UID, reason chat1.GetThreadReason, query *chat1.GetThreadQuery, pagination *chat1.Pagination, maxPlaceholders int) (tv chat1.ThreadView, err error) {
 	ctx = libkb.WithLogTag(ctx, "PUL")
 	defer s.Trace(ctx, func() error { return err }, "PullLocalOnly")()
 	if _, err = s.lockTab.Acquire(ctx, uid, convID); err != nil {
@@ -740,7 +744,7 @@ func (s *HybridConversationSource) PullLocalOnly(ctx context.Context, convID cha
 			// Form a fake version of a conversation so we don't need to hit the network ever here
 			var conv chat1.Conversation
 			conv.Metadata.ConversationID = convID
-			err = s.postProcessThread(ctx, uid, conv, &tv, query, superXform, replyFiller, false, true, nil)
+			err = s.postProcessThread(ctx, uid, reason, conv, &tv, query, superXform, replyFiller, false, true, nil)
 		}
 	}()
 

--- a/go/chat/convsource_test.go
+++ b/go/chat/convsource_test.go
@@ -583,7 +583,7 @@ func TestGetThreadHoleResolution(t *testing.T) {
 	}
 	doSync(t, syncer, ri, uid)
 
-	localThread, err := tc.Context().ConvSource.PullLocalOnly(ctx, convID, uid, nil, nil, 0)
+	localThread, err := tc.Context().ConvSource.PullLocalOnly(ctx, convID, uid, chat1.GetThreadReason_GENERAL, nil, nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(localThread.Messages))
 
@@ -853,7 +853,7 @@ func TestClearFromDelete(t *testing.T) {
 	require.NoError(t, hcs.storage.Nuke(context.TODO(), conv.GetConvID(), uid))
 	_, err = hcs.GetMessages(ctx, conv, uid, []chat1.MessageID{3, 2}, nil)
 	require.NoError(t, err)
-	tv, err := hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil, 0)
+	tv, err := hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, chat1.GetThreadReason_GENERAL, nil, nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(tv.Messages))
 
@@ -864,7 +864,7 @@ func TestClearFromDelete(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no conv loader")
 	}
-	tv, err = hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil, 0)
+	tv, err = hcs.PullLocalOnly(ctx, conv.GetConvID(), uid, chat1.GetThreadReason_GENERAL, nil, nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(tv.Messages))
 	require.Equal(t, chat1.MessageID(4), tv.Messages[0].GetMessageID())

--- a/go/chat/helper.go
+++ b/go/chat/helper.go
@@ -307,12 +307,12 @@ func (h *Helper) JourneycardResetAllConvs(ctx context.Context, uid gregor1.UID) 
 	return j.ResetAllConvs(ctx, uid)
 }
 
-func (h *Helper) JourneycardDebugState(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (string, error) {
+func (h *Helper) JourneycardDebugState(ctx context.Context, uid gregor1.UID, teamID keybase1.TeamID) (string, error) {
 	j, ok := h.G().JourneyCardManager.(*JourneyCardManager)
 	if !ok {
 		return "", fmt.Errorf("could not get JourneyCardManager")
 	}
-	return j.DebugState(ctx, uid, convID)
+	return j.DebugState(ctx, uid, teamID)
 }
 
 func GetMessage(ctx context.Context, g *globals.Context, uid gregor1.UID, convID chat1.ConversationID,

--- a/go/chat/journey_card_manager.go
+++ b/go/chat/journey_card_manager.go
@@ -765,7 +765,7 @@ func (cc *JourneyCardManagerSingleUser) SentMessage(ctx context.Context, teamID 
 func (cc *JourneyCardManagerSingleUser) Dismiss(ctx context.Context, teamID keybase1.TeamID, convID chat1.ConversationID, cardType chat1.JourneycardType) {
 	err := libkb.AcquireWithContextAndTimeout(ctx, &cc.storageLock, 10*time.Second)
 	if err != nil {
-		cc.Debug(ctx, "SentMessage storageLock error: %v", err)
+		cc.Debug(ctx, "Dismiss storageLock error: %v", err)
 		return
 	}
 	defer cc.storageLock.Unlock()
@@ -805,7 +805,7 @@ func (cc *JourneyCardManagerSingleUser) dbKey(teamID keybase1.TeamID) libkb.DbKe
 func (cc *JourneyCardManagerSingleUser) getTeamData(ctx context.Context, teamID keybase1.TeamID) (res journeycardData, err error) {
 	err = libkb.AcquireWithContextAndTimeout(ctx, &cc.storageLock, 10*time.Second)
 	if err != nil {
-		return res, fmt.Errorf("getConvData storageLock error: %v", err)
+		return res, fmt.Errorf("getTeamData storageLock error: %v", err)
 	}
 	defer cc.storageLock.Unlock()
 	return cc.getTeamDataWithLock(ctx, teamID)

--- a/go/chat/journey_card_manager.go
+++ b/go/chat/journey_card_manager.go
@@ -1173,3 +1173,14 @@ var journeycardTypeOncePerTeam = map[chat1.JourneycardType]bool{
 	chat1.JourneycardType_ADD_PEOPLE:       true,
 	chat1.JourneycardType_CREATE_CHANNELS:  true,
 }
+
+var journeycardShouldNotRunOnReason = map[chat1.GetThreadReason]bool{
+	chat1.GetThreadReason_BACKGROUNDCONVLOAD: true,
+	chat1.GetThreadReason_FIXRETRY:           true,
+	chat1.GetThreadReason_PREPARE:            true,
+	chat1.GetThreadReason_SEARCHER:           true,
+	chat1.GetThreadReason_INDEXED_SEARCH:     true,
+	chat1.GetThreadReason_KBFSFILEACTIVITY:   true,
+	chat1.GetThreadReason_COINFLIP:           true,
+	chat1.GetThreadReason_BOTCOMMANDS:        true,
+}

--- a/go/chat/journey_card_test.go
+++ b/go/chat/journey_card_test.go
@@ -1,59 +1,66 @@
 package chat
 
 import (
-	"context"
 	"testing"
 
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/client/go/teams"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/stretchr/testify/require"
 )
 
 func TestJourneycardStorage(t *testing.T) {
-	ctx, world, ri, _, sender, _ := setupTest(t, 1)
-	defer world.Cleanup()
+	useRemoteMock = false
+	defer func() { useRemoteMock = true }()
+	ctc := makeChatTestContext(t, t.Name(), 1)
+	defer ctc.cleanup()
 
-	u := world.GetUsers()[0]
-	uid := u.User.GetUID().ToBytes()
-	tc := world.Tcs[u.Username]
-	conv := newBlankConv(ctx, t, tc, uid, ri, sender, u.Username)
-	mkctx := func() context.Context { return libkb.WithLogTag(context.Background(), "TST") }
+	users := ctc.users()
+	tc0 := ctc.world.Tcs[users[0].Username]
+	ctx0 := ctc.as(t, users[0]).startCtx
+	uid0 := gregor1.UID(users[0].GetUID().ToBytes())
+	t.Logf("uid0: %s", uid0)
+
+	teamConv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+		chat1.ConversationMembersType_TEAM)
+	t.Logf("teamconv: %x", teamConv.Id.DbShortForm())
+	teamID, err := keybase1.TeamIDFromString(teamConv.Triple.Tlfid.String())
+	require.NoError(t, err)
+	convID := teamConv.Id
 
 	t.Logf("setup complete")
-	tc.ChatG.JourneyCardManager.SentMessage(mkctx(), uid, conv.GetConvID())
+	tc0.ChatG.JourneyCardManager.SentMessage(ctx0, uid0, teamID, convID)
 	t.Logf("sent message")
-	js, err := tc.ChatG.JourneyCardManager.(*JourneyCardManager).get(mkctx(), uid)
+	js, err := tc0.ChatG.JourneyCardManager.(*JourneyCardManager).get(ctx0, uid0)
 	require.NoError(t, err)
-	jcd, err := js.getConvData(mkctx(), conv.GetConvID())
+	jcd, err := js.getTeamData(ctx0, teamID)
 	require.NoError(t, err)
-	require.True(t, jcd.SentMessage)
+	require.True(t, jcd.Convs[convID.String()].SentMessage)
 
 	t.Logf("switch users")
 	uid2kb, err := keybase1.UIDFromString("295a7eea607af32040647123732bc819")
 	require.NoError(t, err)
 	uid2 := gregor1.UID(uid2kb.ToBytes())
-	js, err = tc.ChatG.JourneyCardManager.(*JourneyCardManager).get(mkctx(), uid2)
+	js, err = tc0.ChatG.JourneyCardManager.(*JourneyCardManager).get(ctx0, uid2)
 	require.NoError(t, err)
-	jcd, err = js.getConvData(mkctx(), conv.GetConvID())
+	jcd, err = js.getTeamData(ctx0, teamID)
 	require.NoError(t, err)
-	require.False(t, jcd.SentMessage)
+	require.False(t, jcd.Convs[convID.String()].SentMessage)
 
 	t.Logf("switch back")
-	js, err = tc.ChatG.JourneyCardManager.(*JourneyCardManager).get(mkctx(), uid)
+	js, err = tc0.ChatG.JourneyCardManager.(*JourneyCardManager).get(ctx0, uid0)
 	require.NoError(t, err)
-	jcd, err = js.getConvData(mkctx(), conv.GetConvID())
+	jcd, err = js.getTeamData(ctx0, teamID)
 	require.NoError(t, err)
-	require.True(t, jcd.SentMessage)
+	require.True(t, jcd.Convs[convID.String()].SentMessage)
 }
 
 func TestJourneycardDismiss(t *testing.T) {
 	useRemoteMock = false
 	defer func() { useRemoteMock = true }()
-	ctc := makeChatTestContext(t, "TestBotCommandManager", 2)
+	ctc := makeChatTestContext(t, t.Name(), 2)
 	defer ctc.cleanup()
 
 	users := ctc.users()
@@ -101,9 +108,11 @@ func TestJourneycardDismiss(t *testing.T) {
 
 	requireJourneycard(true)
 	t.Logf("dismiss other type")
-	tc1.ChatG.JourneyCardManager.Dismiss(ctx1, uid1, convID, chat1.JourneycardType_ADD_PEOPLE)
+	err = ctc.as(t, users[1]).chatLocalHandler().DismissJourneycard(ctx1, chat1.DismissJourneycardArg{ConvID: convID, CardType: chat1.JourneycardType_ADD_PEOPLE})
+	require.NoError(t, err)
 	requireJourneycard(true)
 	t.Logf("dismiss welcome card")
-	tc1.ChatG.JourneyCardManager.Dismiss(ctx1, uid1, convID, chat1.JourneycardType_WELCOME)
+	err = ctc.as(t, users[1]).chatLocalHandler().DismissJourneycard(ctx1, chat1.DismissJourneycardArg{ConvID: convID, CardType: chat1.JourneycardType_WELCOME})
+	require.NoError(t, err)
 	requireJourneycard(false)
 }

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1163,7 +1163,14 @@ func (s *BlockingSender) Send(ctx context.Context, convID chat1.ConversationID,
 					gregor1.FromTime(unboxedMsg.Valid().MessageBody.Text().LiveLocation.EndTime))
 			}
 		}
-		go s.G().JourneyCardManager.SentMessage(globals.BackgroundChatCtx(ctx, s.G()), sender, convID)
+		if conv.GetMembersType() == chat1.ConversationMembersType_TEAM {
+			teamID, err := keybase1.TeamIDFromString(conv.Info.Triple.Tlfid.String())
+			if err != nil {
+				s.Debug(ctx, "Send: failed to get team ID: %v", err)
+			} else {
+				go s.G().JourneyCardManager.SentMessage(globals.BackgroundChatCtx(ctx, s.G()), sender, teamID, convID)
+			}
+		}
 	}
 	return nil, boxed, nil
 }

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -304,30 +304,6 @@ func (h *Server) GetInboxAndUnboxUILocal(ctx context.Context, arg chat1.GetInbox
 	}, nil
 }
 
-func (h *Server) GetCachedThread(ctx context.Context, arg chat1.GetCachedThreadArg) (res chat1.GetThreadLocalRes, err error) {
-	var identBreaks []keybase1.TLFIdentifyFailure
-	ctx = globals.ChatCtx(ctx, h.G(), arg.IdentifyBehavior, &identBreaks, h.identNotifier)
-	defer h.Trace(ctx, func() error { return err }, "GetCachedThread")()
-	defer func() { h.setResultRateLimit(ctx, &res) }()
-	defer func() { err = h.handleOfflineError(ctx, err, &res) }()
-	uid, err := utils.AssertLoggedInUID(ctx, h.G())
-	if err != nil {
-		return res, err
-	}
-
-	// Get messages from local disk only
-	thread, err := h.G().ConvSource.PullLocalOnly(ctx, arg.ConversationID, uid,
-		arg.Query, arg.Pagination, 0)
-	if err != nil {
-		return res, err
-	}
-
-	return chat1.GetThreadLocalRes{
-		Thread:           thread,
-		IdentifyFailures: identBreaks,
-	}, nil
-}
-
 // GetThreadLocal implements keybase.chatLocal.getThreadLocal protocol.
 func (h *Server) GetThreadLocal(ctx context.Context, arg chat1.GetThreadLocalArg) (res chat1.GetThreadLocalRes, err error) {
 	var identBreaks []keybase1.TLFIdentifyFailure

--- a/go/chat/sync_test.go
+++ b/go/chat/sync_test.go
@@ -888,7 +888,7 @@ func TestSyncerStorageClear(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		require.Fail(t, "no conv load on sync")
 	}
-	tv, err := tc.Context().ConvSource.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil, 0)
+	tv, err := tc.Context().ConvSource.PullLocalOnly(ctx, conv.GetConvID(), uid, chat1.GetThreadReason_GENERAL, nil, nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(tv.Messages))
 
@@ -903,7 +903,7 @@ func TestSyncerStorageClear(t *testing.T) {
 	doSync(t, syncer, ri, uid)
 	time.Sleep(400 * time.Millisecond)
 
-	_, err = tc.Context().ConvSource.PullLocalOnly(ctx, conv.GetConvID(), uid, nil, nil, 0)
+	_, err = tc.Context().ConvSource.PullLocalOnly(ctx, conv.GetConvID(), uid, chat1.GetThreadReason_GENERAL, nil, nil, 0)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
 }

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -572,8 +572,8 @@ type UIInboxLoader interface {
 type JourneyCardManager interface {
 	Resumable
 	PickCard(context.Context, gregor1.UID, chat1.ConversationID, *chat1.ConversationLocal, *chat1.ThreadView) (*chat1.MessageUnboxedJourneycard, error)
-	SentMessage(context.Context, gregor1.UID, chat1.ConversationID) // Tell JourneyCardManager that the user has sent a message.
-	Dismiss(context.Context, gregor1.UID, chat1.ConversationID, chat1.JourneycardType)
+	SentMessage(context.Context, gregor1.UID, keybase1.TeamID, chat1.ConversationID) // Tell JourneyCardManager that the user has sent a message.
+	Dismiss(context.Context, gregor1.UID, keybase1.TeamID, chat1.ConversationID, chat1.JourneycardType)
 	OnDbNuke(libkb.MetaContext) error
 }
 

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -88,7 +88,7 @@ type ConversationSource interface {
 	Pull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, reason chat1.GetThreadReason,
 		query *chat1.GetThreadQuery, pagination *chat1.Pagination) (chat1.ThreadView, error)
 	PullLocalOnly(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID,
-		query *chat1.GetThreadQuery, p *chat1.Pagination, maxPlaceholders int) (chat1.ThreadView, error)
+		reason chat1.GetThreadReason, query *chat1.GetThreadQuery, p *chat1.Pagination, maxPlaceholders int) (chat1.ThreadView, error)
 	PullFull(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, reason chat1.GetThreadReason,
 		query *chat1.GetThreadQuery, maxPages *int) (chat1.ThreadView, error)
 	GetMessages(ctx context.Context, conv UnboxConversationInfo, uid gregor1.UID, msgIDs []chat1.MessageID,

--- a/go/chat/uithreadloader.go
+++ b/go/chat/uithreadloader.go
@@ -646,7 +646,7 @@ func (t *UIThreadLoader) LoadNonblock(ctx context.Context, chatUI libkb.ChatUI, 
 				}
 			}
 			localThread, err = t.G().ConvSource.PullLocalOnly(ctx, convID,
-				uid, query, pagination, 10)
+				uid, reason, query, pagination, 10)
 			ch <- err
 		}()
 		select {

--- a/go/chat/uithreadloader_test.go
+++ b/go/chat/uithreadloader_test.go
@@ -194,7 +194,7 @@ func TestUIThreadLoaderCache(t *testing.T) {
 	}))
 	consumeNewMsgRemote(t, listener0, chat1.MessageType_TEXT)
 	require.NoError(t, tc.Context().ConvSource.Clear(ctx, conv.Id, uid))
-	_, err := tc.Context().ConvSource.PullLocalOnly(ctx, conv.Id, uid, nil, nil, 0)
+	_, err := tc.Context().ConvSource.PullLocalOnly(ctx, conv.Id, uid, chat1.GetThreadReason_GENERAL, nil, nil, 0)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
 
@@ -216,7 +216,7 @@ func TestUIThreadLoaderCache(t *testing.T) {
 	case <-time.After(timeout):
 		require.Fail(t, "no full cb")
 	}
-	_, err = tc.Context().ConvSource.PullLocalOnly(ctx, conv.Id, uid, nil, nil, 0)
+	_, err = tc.Context().ConvSource.PullLocalOnly(ctx, conv.Id, uid, chat1.GetThreadReason_GENERAL, nil, nil, 0)
 	require.Error(t, err)
 	require.IsType(t, storage.MissError{}, err)
 	clock.Advance(10 * time.Second)
@@ -233,7 +233,7 @@ func TestUIThreadLoaderCache(t *testing.T) {
 		}
 	}
 	require.True(t, worked)
-	tv, err := tc.Context().ConvSource.PullLocalOnly(ctx, conv.Id, uid, nil, nil, 0)
+	tv, err := tc.Context().ConvSource.PullLocalOnly(ctx, conv.Id, uid, chat1.GetThreadReason_GENERAL, nil, nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(tv.Messages))
 }

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -1431,7 +1431,7 @@ func (m *MockChatHelper) JourneycardResetAllConvs(ctx context.Context, uid grego
 	return fmt.Errorf("JourneycardResetAllConvs not implemented on mock")
 }
 
-func (m *MockChatHelper) JourneycardDebugState(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) (string, error) {
+func (m *MockChatHelper) JourneycardDebugState(ctx context.Context, uid gregor1.UID, teamID keybase1.TeamID) (string, error) {
 	return "", fmt.Errorf("JourneycardDebugState not implemented on mock")
 }
 

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -1075,7 +1075,7 @@ type ChatHelper interface {
 	UserReacjis(ctx context.Context, uid gregor1.UID) keybase1.UserReacjis
 	JourneycardTimeTravel(context.Context, gregor1.UID, time.Duration) error
 	JourneycardResetAllConvs(context.Context, gregor1.UID) error
-	JourneycardDebugState(context.Context, gregor1.UID, chat1.ConversationID) (string, error)
+	JourneycardDebugState(context.Context, gregor1.UID, keybase1.TeamID) (string, error)
 }
 
 // Resolver resolves human-readable usernames (joe) and user asssertions (joe+joe@github)

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -5840,13 +5840,6 @@ type GetThreadLocalArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
-type GetCachedThreadArg struct {
-	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
-	Query            *GetThreadQuery              `codec:"query,omitempty" json:"query,omitempty"`
-	Pagination       *Pagination                  `codec:"pagination,omitempty" json:"pagination,omitempty"`
-	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
-}
-
 type GetThreadNonblockArg struct {
 	SessionID        int                          `codec:"sessionID" json:"sessionID"`
 	ConversationID   ConversationID               `codec:"conversationID" json:"conversationID"`
@@ -6399,7 +6392,6 @@ type DismissJourneycardArg struct {
 
 type LocalInterface interface {
 	GetThreadLocal(context.Context, GetThreadLocalArg) (GetThreadLocalRes, error)
-	GetCachedThread(context.Context, GetCachedThreadArg) (GetThreadLocalRes, error)
 	GetThreadNonblock(context.Context, GetThreadNonblockArg) (NonblockFetchRes, error)
 	GetUnreadline(context.Context, GetUnreadlineArg) (UnreadlineRes, error)
 	GetInboxAndUnboxLocal(context.Context, GetInboxAndUnboxLocalArg) (GetInboxAndUnboxLocalRes, error)
@@ -6508,21 +6500,6 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.GetThreadLocal(ctx, typedArgs[0])
-					return
-				},
-			},
-			"getCachedThread": {
-				MakeArg: func() interface{} {
-					var ret [1]GetCachedThreadArg
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[1]GetCachedThreadArg)
-					if !ok {
-						err = rpc.NewTypeError((*[1]GetCachedThreadArg)(nil), args)
-						return
-					}
-					ret, err = i.GetCachedThread(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -7846,11 +7823,6 @@ type LocalClient struct {
 
 func (c LocalClient) GetThreadLocal(ctx context.Context, __arg GetThreadLocalArg) (res GetThreadLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getThreadLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
-	return
-}
-
-func (c LocalClient) GetCachedThread(ctx context.Context, __arg GetCachedThreadArg) (res GetThreadLocalRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getCachedThread", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/debugging.go
+++ b/go/service/debugging.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/protocol/chat1"
 	gregor1 "github.com/keybase/client/go/protocol/gregor1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -76,12 +75,12 @@ func (t *DebuggingHandler) Script(ctx context.Context, arg keybase1.ScriptArg) (
 		if len(args) != 1 {
 			return "", fmt.Errorf("usage: journeycard-state <conv-id> (like 000059aa7f324dad7524b56ed1beb3e3d620b3897d640951710f1417c6b7b85f)")
 		}
-		convID, err := chat1.MakeConvID(args[0])
+		teamID, err := keybase1.TeamIDFromString(args[0])
 		if err != nil {
 			return "", err
 		}
 		uidGregor := gregor1.UID(m.G().ActiveDevice.UID().ToBytes())
-		summary, err := t.G().ChatHelper.JourneycardDebugState(m.Ctx(), uidGregor, convID)
+		summary, err := t.G().ChatHelper.JourneycardDebugState(m.Ctx(), uidGregor, teamID)
 		return summary, err
 	case "":
 		return "", fmt.Errorf("empty script name")

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -726,8 +726,6 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
-  GetThreadLocalRes getCachedThread(ConversationID conversationID, union { null, GetThreadQuery} query, union { null, Pagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
-
   enum GetThreadNonblockCbMode {
     FULL_0,
     INCREMENTAL_1

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3679,33 +3679,6 @@
       ],
       "response": "GetThreadLocalRes"
     },
-    "getCachedThread": {
-      "request": [
-        {
-          "name": "conversationID",
-          "type": "ConversationID"
-        },
-        {
-          "name": "query",
-          "type": [
-            null,
-            "GetThreadQuery"
-          ]
-        },
-        {
-          "name": "pagination",
-          "type": [
-            null,
-            "Pagination"
-          ]
-        },
-        {
-          "name": "identifyBehavior",
-          "type": "keybase1.TLFIdentifyBehavior"
-        }
-      ],
-      "response": "GetThreadLocalRes"
-    },
     "getThreadNonblock": {
       "request": [
         {

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -1541,7 +1541,6 @@ export const localUpdateUnsentTextRpcPromise = (params: MessageTypes['chat.1.loc
 // 'chat.1.chatUi.chatCommandStatus'
 // 'chat.1.chatUi.chatBotCommandsUpdateStatus'
 // 'chat.1.chatUi.triggerContactSync'
-// 'chat.1.local.getCachedThread'
 // 'chat.1.local.getInboxAndUnboxLocal'
 // 'chat.1.local.postLocal'
 // 'chat.1.local.generateOutboxID'


### PR DESCRIPTION
Journey cards 1, 2, 3, and 4 only show up once in each team. If card 2 shows up in channel C in a team, it will never show in any other channel in that team on that device.

- Change storage from being keyed by convID to being keyed by teamID, with subsections for each conv.
- Make PickCard only run on certain GetThreadReason values. Otherwise, a background load of a thread could cause a card to be lockin'd to a conv that the user didn't actually look at. This way, only user-driven ConvSource.Pull calls cause PickCard.
- Fix some data races.

Be sure to expand `journey_card_manager.go`.

cc @mmaxim 