### PR TITLE
search: add a db for tracking revisions of an indexed TLF

### DIFF
--- a/go/kbfs/search/indexed_block_db.go
+++ b/go/kbfs/search/indexed_block_db.go
@@ -58,7 +58,7 @@ func newIndexedBlockDbFromStorage(
 	config libkbfs.Config, blockStorage, tlfStorage storage.Storage) (
 	db *IndexedBlockDb, err error) {
 	log := config.MakeLogger("IBD")
-	closers := make([]io.Closer, 0, 1)
+	closers := make([]io.Closer, 0, 2)
 	closer := func() {
 		for _, c := range closers {
 			closeErr := c.Close()
@@ -108,7 +108,7 @@ func newIndexedBlockDb(config libkbfs.Config, dirPath string) (db *IndexedBlockD
 	log := config.MakeLogger("IBD")
 	defer func() {
 		if err != nil {
-			log.Error("Error initializing MD db: %+v", err)
+			log.Error("Error initializing indexed block db: %+v", err)
 		}
 	}()
 	dbPath := filepath.Join(dirPath, indexedBlocksFolderName)
@@ -134,7 +134,7 @@ func newIndexedBlockDb(config libkbfs.Config, dirPath string) (db *IndexedBlockD
 	}
 	defer func() {
 		if err != nil {
-			blockStorage.Close()
+			tlfStorage.Close()
 		}
 	}()
 	return newIndexedBlockDbFromStorage(config, blockStorage, tlfStorage)
@@ -291,7 +291,7 @@ func (db *IndexedBlockDb) Delete(
 	return db.tlfDb.Delete(tlfKey(tlfID, ptr), nil)
 }
 
-// Shutdown implements the IndexedBlocksDb interface for IndexedBlockDb.
+// Shutdown closes this db.
 func (db *IndexedBlockDb) Shutdown(ctx context.Context) {
 	db.lock.Lock()
 	defer db.lock.Unlock()

--- a/go/kbfs/search/indexed_block_db_test.go
+++ b/go/kbfs/search/indexed_block_db_test.go
@@ -48,7 +48,7 @@ func shutdownIndexedBlockDbTest(db *IndexedBlockDb, tempdir string) {
 	os.RemoveAll(tempdir)
 }
 
-func TestINdexedBlockDbCreate(t *testing.T) {
+func TestIndexedBlockDbCreate(t *testing.T) {
 	config := libkbfs.MakeTestConfigOrBust(t, "user1")
 	tempdir, err := ioutil.TempDir(os.TempDir(), "indexed_blocks_db")
 	require.NoError(t, err)

--- a/go/kbfs/search/indexed_tlf_db.go
+++ b/go/kbfs/search/indexed_tlf_db.go
@@ -1,0 +1,223 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"sync"
+
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/ldbutils"
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/logger"
+	"github.com/pkg/errors"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+const (
+	initialIndexedTlfsDbVersion uint64 = 1
+	currentIndexedTlfsDbVersion uint64 = initialIndexedTlfsDbVersion
+	indexedTlfsFolderName       string = "indexed_tlfs"
+)
+
+// IndexedTlfDb is a database that holds metadata about indexed TLFs.
+type IndexedTlfDb struct {
+	config libkbfs.Config
+	log    logger.Logger
+
+	// Protect the DB from being shutdown while they're being
+	// accessed, and mutable data.
+	lock  sync.RWMutex
+	tlfDb *ldbutils.LevelDb // tlfID -> TLF metadata.
+
+	shutdownCh chan struct{}
+
+	closer func()
+}
+
+// newIndexedTlfDbFromStorage creates a new *IndexedTlfDb with the
+// passed-in storage.Storage interfaces as a storage layers for the db.
+func newIndexedTlfDbFromStorage(
+	config libkbfs.Config, tlfStorage storage.Storage) (
+	db *IndexedTlfDb, err error) {
+	log := config.MakeLogger("ITD")
+	closers := make([]io.Closer, 0, 1)
+	closer := func() {
+		for _, c := range closers {
+			closeErr := c.Close()
+			if closeErr != nil {
+				log.Warning("Error closing leveldb or storage: %+v", closeErr)
+			}
+		}
+	}
+	defer func() {
+		if err != nil {
+			err = errors.WithStack(err)
+			closer()
+		}
+	}()
+
+	tlfDbOptions := ldbutils.LeveldbOptions(config.Mode())
+	tlfDb, err := ldbutils.OpenLevelDbWithOptions(tlfStorage, tlfDbOptions)
+	if err != nil {
+		return nil, err
+	}
+	closers = append(closers, tlfDb)
+
+	return &IndexedTlfDb{
+		config:     config,
+		tlfDb:      tlfDb,
+		shutdownCh: make(chan struct{}),
+		closer:     closer,
+	}, nil
+}
+
+// newIndexedTlfDb creates a new *IndexedTlfDb with a
+// specified directory on the filesystem as storage.
+func newIndexedTlfDb(config libkbfs.Config, dirPath string) (
+	db *IndexedTlfDb, err error) {
+	log := config.MakeLogger("ITD")
+	defer func() {
+		if err != nil {
+			log.Error("Error initializing indexed TLF db: %+v", err)
+		}
+	}()
+	dbPath := filepath.Join(dirPath, indexedTlfsFolderName)
+	versionPath, err := ldbutils.GetVersionedPathForDb(
+		log, dbPath, "indexed TLFs", currentIndexedTlfsDbVersion)
+	if err != nil {
+		return nil, err
+	}
+	tlfDbPath := filepath.Join(versionPath, tlfDbFilename)
+	tlfStorage, err := storage.OpenFile(tlfDbPath, false)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			tlfStorage.Close()
+		}
+	}()
+	return newIndexedTlfDbFromStorage(config, tlfStorage)
+}
+
+type tlfMD struct {
+	// Exported only for serialization.
+	IndexedRevision kbfsmd.Revision `codec:"i"`
+	StartedRevision kbfsmd.Revision `codec:"s"`
+}
+
+// getMetadataLocked retrieves the metadata for a block in the db, or
+// returns leveldb.ErrNotFound and a zero-valued metadata otherwise.
+func (db *IndexedTlfDb) getMetadataLocked(tlfID tlf.ID) (
+	metadata tlfMD, err error) {
+	metadataBytes, err := db.tlfDb.Get(tlfID.Bytes(), nil)
+	if err != nil {
+		return tlfMD{}, err
+	}
+	err = db.config.Codec().Decode(metadataBytes, &metadata)
+	if err != nil {
+		return tlfMD{}, err
+	}
+	return metadata, nil
+}
+
+// checkAndLockDb checks whether the db is started.
+func (db *IndexedTlfDb) checkDbLocked(
+	ctx context.Context, method string) error {
+	// First see if the context has expired since we began.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	// shutdownCh has to be checked under lock, otherwise we can race.
+	select {
+	case <-db.shutdownCh:
+		return errors.WithStack(DbClosedError{method})
+	default:
+	}
+	if db.tlfDb == nil {
+		return errors.WithStack(DbClosedError{method})
+	}
+	return nil
+}
+
+// Get returns the revisions for the given TLF.
+func (db *IndexedTlfDb) Get(
+	ctx context.Context, tlfID tlf.ID) (
+	indexedRev, startedRev kbfsmd.Revision, err error) {
+	db.lock.RLock()
+	defer db.lock.RUnlock()
+	err = db.checkDbLocked(ctx, "ITD(Get)")
+	if err != nil {
+		return kbfsmd.RevisionUninitialized, kbfsmd.RevisionUninitialized, err
+	}
+
+	md, err := db.getMetadataLocked(tlfID)
+	if err != nil {
+		return kbfsmd.RevisionUninitialized, kbfsmd.RevisionUninitialized, err
+	}
+	return md.IndexedRevision, md.StartedRevision, nil
+}
+
+// Put saves the revisions for the given TLF.
+func (db *IndexedTlfDb) Put(
+	ctx context.Context, tlfID tlf.ID,
+	indexedRev, startedRev kbfsmd.Revision) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+	err := db.checkDbLocked(ctx, "ITD(Put)")
+	if err != nil {
+		return err
+	}
+
+	md := tlfMD{
+		IndexedRevision: indexedRev,
+		StartedRevision: startedRev,
+	}
+	encodedMetadata, err := db.config.Codec().Encode(&md)
+	if err != nil {
+		return err
+	}
+
+	return db.tlfDb.Put(tlfID.Bytes(), encodedMetadata, nil)
+}
+
+// Delete removes the metadata for the TLF from the DB.
+func (db *IndexedTlfDb) Delete(
+	ctx context.Context, tlfID tlf.ID) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+	err := db.checkDbLocked(ctx, "ITD(Delete)")
+	if err != nil {
+		return err
+	}
+
+	return db.tlfDb.Delete(tlfID.Bytes(), nil)
+}
+
+// Shutdown closes this db.
+func (db *IndexedTlfDb) Shutdown(ctx context.Context) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+	// shutdownCh has to be checked under lock, otherwise we can race.
+	select {
+	case <-db.shutdownCh:
+		db.log.CWarningf(ctx, "Shutdown called more than once")
+		return
+	default:
+	}
+	close(db.shutdownCh)
+	if db.tlfDb == nil {
+		return
+	}
+	db.closer()
+	db.tlfDb = nil
+}

--- a/go/kbfs/search/indexed_tlf_db_test.go
+++ b/go/kbfs/search/indexed_tlf_db_test.go
@@ -1,0 +1,115 @@
+// Copyright 2019 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"golang.org/x/net/context"
+)
+
+func newIndexedTlfDbForTestWithStorage(
+	t *testing.T, tlfS storage.Storage) *IndexedTlfDb {
+	config := libkbfs.MakeTestConfigOrBust(t, "user1")
+	db, err := newIndexedTlfDbFromStorage(config, tlfS)
+	require.NoError(t, err)
+	return db
+}
+
+func newIndexedTlfDbForTest(t *testing.T) (
+	*IndexedTlfDb, string) {
+	// Use a disk-based level, instead of memory storage, because we
+	// want to simulate a restart and memory storages can't be reused.
+	tempdir, err := ioutil.TempDir(os.TempDir(), "indexed_tlfs_db")
+	require.NoError(t, err)
+	tlfS, err := storage.OpenFile(filepath.Join(tempdir, "tlfs"), false)
+	require.NoError(t, err)
+
+	db := newIndexedTlfDbForTestWithStorage(t, tlfS)
+	return db, tempdir
+}
+
+func shutdownIndexedTlfDbTest(db *IndexedTlfDb, tempdir string) {
+	db.Shutdown(context.Background())
+	os.RemoveAll(tempdir)
+}
+
+func TestIndexedTlfDbCreate(t *testing.T) {
+	config := libkbfs.MakeTestConfigOrBust(t, "user1")
+	tempdir, err := ioutil.TempDir(os.TempDir(), "indexed_tlfs_db")
+	require.NoError(t, err)
+	db, err := newIndexedTlfDb(config, tempdir)
+	require.NoError(t, err)
+	shutdownIndexedTlfDbTest(db, tempdir)
+}
+
+func TestIndexedTlfDb(t *testing.T) {
+	t.Parallel()
+	t.Log("Test that indexed TLF db Put and Get operations work.")
+	db, tempdir := newIndexedTlfDbForTest(t)
+	defer func() {
+		shutdownIndexedTlfDbTest(db, tempdir)
+	}()
+
+	ctx := context.Background()
+	tlfID1 := tlf.FakeID(1, tlf.Private)
+	ir1 := kbfsmd.Revision(50)
+	sr1 := kbfsmd.RevisionUninitialized
+
+	t.Log("Put TLF MD into the db.")
+	_, _, err := db.Get(ctx, tlfID1)
+	require.Error(t, err) // not in db yet
+	err = db.Put(ctx, tlfID1, ir1, sr1)
+	require.NoError(t, err)
+
+	t.Log("Get TLF MD from the db.")
+	getIR1, getSR1, err := db.Get(ctx, tlfID1)
+	require.NoError(t, err)
+	checkWrite := func(
+		expectedIR, ir, expectedSR, sr kbfsmd.Revision) {
+		require.Equal(t, expectedIR, ir)
+		require.Equal(t, expectedSR, sr)
+	}
+	checkWrite(ir1, getIR1, sr1, getSR1)
+
+	t.Log("A second entry.")
+	tlfID2 := tlf.FakeID(2, tlf.Private)
+	ir2 := kbfsmd.Revision(500)
+	sr2 := kbfsmd.Revision(600)
+
+	err = db.Put(ctx, tlfID2, ir2, sr2)
+	require.NoError(t, err)
+	getIR2, getSR2, err := db.Get(ctx, tlfID2)
+	require.NoError(t, err)
+	checkWrite(ir2, getIR2, sr2, getSR2)
+
+	t.Log("Override the first block with new start revision")
+	sr1 = kbfsmd.Revision(60)
+	err = db.Put(ctx, tlfID1, ir1, sr1)
+	require.NoError(t, err)
+	getIR1, getSR1, err = db.Get(ctx, tlfID1)
+	require.NoError(t, err)
+	checkWrite(ir1, getIR1, sr1, getSR1)
+
+	t.Log("Restart the db and check the MD")
+	db.Shutdown(ctx)
+	tlfS, err := storage.OpenFile(filepath.Join(tempdir, "tlfs"), false)
+	require.NoError(t, err)
+	db = newIndexedTlfDbForTestWithStorage(t, tlfS)
+	getIR1, getSR1, err = db.Get(ctx, tlfID1)
+	require.NoError(t, err)
+	checkWrite(ir1, getIR1, sr1, getSR1)
+	getIR2, getSR2, err = db.Get(ctx, tlfID2)
+	require.NoError(t, err)
+	checkWrite(ir2, getIR2, sr2, getSR2)
+}


### PR DESCRIPTION
We need to keep track of which revision is fully indexed, and which revision have we started (but not yet finished) indexing.

(Plus a few bug fixes I noticed needed to be done to the indexed blocks DB.)

Issue: HOTPOT-1484