### PR TITLE
interfaces: define interface for synced TLF notifications

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -37,7 +37,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	id := tlf.FakeID(1, tlf.Private)
 	fbo := newFolderBranchOps(ctx, env.EmptyAppStateUpdater{}, config,
 		data.FolderBranch{Tlf: id, Branch: data.MasterBranch}, standard,
-		nil, nil, nil)
+		nil, nil, nil, nil)
 	// usernames don't matter for these tests
 	config.mockKbpki.EXPECT().GetNormalizedUsername(
 		gomock.Any(), gomock.Any(), gomock.Any()).

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1861,8 +1861,8 @@ type Observer interface {
 // interface.
 type SyncedTlfObserver interface {
 	// FullSyncStarted announces that a new full sync has begun for
-	// the given tlf ID, and it will be completed (or canceled) once
-	// `waitCh` is closed.
+	// the given tlf ID.  The provided `waitCh` will be completed (or
+	// canceled) once `waitCh` is closed.
 	FullSyncStarted(
 		ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision,
 		waitCh <-chan struct{})

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1863,7 +1863,9 @@ type SyncedTlfObserver interface {
 	// FullSyncStarted announces that a new full sync has begun for
 	// the given tlf ID, and it will be completed (or canceled) once
 	// `waitCh` is closed.
-	FullSyncStarted(ctx context.Context, tlfID tlf.ID, waitCh <-chan struct{})
+	FullSyncStarted(
+		ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision,
+		waitCh <-chan struct{})
 	// SyncModeChanged announces that the sync mode has changed for
 	// the given tlf ID.
 	SyncModeChanged(

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1855,6 +1855,21 @@ type Observer interface {
 	TlfHandleChange(ctx context.Context, newHandle *tlfhandle.Handle)
 }
 
+// SyncedTlfObserver can be notified when a sync has started for a
+// synced TLF, or when a TLF becomes unsynced.  The notification
+// callbacks should not block, or make any calls to the Notifier
+// interface.
+type SyncedTlfObserver interface {
+	// FullSyncStarted announces that a new full sync has begun for
+	// the given tlf ID, and it will be completed (or canceled) once
+	// `waitCh` is closed.
+	FullSyncStarted(ctx context.Context, tlfID tlf.ID, waitCh <-chan struct{})
+	// SyncModeChanged announces that the sync mode has changed for
+	// the given tlf ID.
+	SyncModeChanged(
+		ctx context.Context, tlfID tlf.ID, newMode keybase1.FolderSyncMode)
+}
+
 // Notifier notifies registrants of directory changes
 type Notifier interface {
 	// RegisterForChanges declares that the given Observer wants to
@@ -1864,6 +1879,14 @@ type Notifier interface {
 	// longer wants to subscribe to updates for the given top-level
 	// folders.
 	UnregisterFromChanges(folderBranches []data.FolderBranch, obs Observer) error
+	// RegisterForSyncedTlfs declares that the given
+	// `SyncedTlfObserver` wants to subscribe to updates about synced
+	// TLFs.
+	RegisterForSyncedTlfs(obs SyncedTlfObserver) error
+	// UnregisterFromChanges declares that the given
+	// `SyncedTlfObserver` no longer wants to subscribe to updates
+	// about synced TLFs.
+	UnregisterFromSyncedTlfs(obs SyncedTlfObserver) error
 }
 
 // Clock is an interface for getting the current time

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -52,6 +52,8 @@ type KBFSOpsStandard struct {
 
 	favs *Favorites
 
+	syncedTlfObservers *syncedTlfObserverList
+
 	editActivity kbfssync.RepeatedWaitGroup
 	editLock     sync.Mutex
 	editShutdown bool
@@ -95,6 +97,7 @@ func NewKBFSOpsStandard(
 		reIdentifyControlChan: make(chan chan<- struct{}),
 		initDoneCh:            initDoneCh,
 		favs:                  NewFavorites(config),
+		syncedTlfObservers:    newSyncedTlfObserverList(),
 		quotaUsage: NewEventuallyConsistentQuotaUsage(
 			config, quLog, config.MakeVLogger(quLog)),
 		longOperationDebugDumper: NewImpatientDebugDumper(
@@ -753,7 +756,7 @@ func (fs *KBFSOpsStandard) getOpsNoAdd(
 		}
 		ops = newFolderBranchOps(
 			ctx, fs.appStateUpdater, fs.config, fb, bType, quotaUsage,
-			fs.currentStatus, fs.favs)
+			fs.currentStatus, fs.favs, fs.syncedTlfObservers)
 		fs.ops[fb] = ops
 	}
 	return ops

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -2030,12 +2030,14 @@ func (fs *KBFSOpsStandard) UnregisterFromChanges(
 
 // RegisterForSyncedTlfs implements the Notifer interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) RegisterForSyncedTlfs(obs SyncedTlfObserver) error {
+	fs.syncedTlfObservers.add(obs)
 	return nil
 }
 
-// UnregisterFromChanges implements the Notifer interface for KBFSOpsStandard
+// UnregisterFromSyncedTlfs implements the Notifer interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) UnregisterFromSyncedTlfs(
 	obs SyncedTlfObserver) error {
+	fs.syncedTlfObservers.remove(obs)
 	return nil
 }
 

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -2025,6 +2025,17 @@ func (fs *KBFSOpsStandard) UnregisterFromChanges(
 	return nil
 }
 
+// RegisterForSyncedTlfs implements the Notifer interface for KBFSOpsStandard
+func (fs *KBFSOpsStandard) RegisterForSyncedTlfs(obs SyncedTlfObserver) error {
+	return nil
+}
+
+// UnregisterFromChanges implements the Notifer interface for KBFSOpsStandard
+func (fs *KBFSOpsStandard) UnregisterFromSyncedTlfs(
+	obs SyncedTlfObserver) error {
+	return nil
+}
+
 func (fs *KBFSOpsStandard) onTLFBranchChange(tlfID tlf.ID, newBID kbfsmd.BranchID) {
 	ops := fs.getOps(context.Background(),
 		data.FolderBranch{Tlf: tlfID, Branch: data.MasterBranch}, FavoritesOpNoChange)

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -4062,6 +4062,20 @@ func (mr *MockNotifierMockRecorder) RegisterForChanges(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForChanges", reflect.TypeOf((*MockNotifier)(nil).RegisterForChanges), arg0, arg1)
 }
 
+// RegisterForSyncedTlfs mocks base method
+func (m *MockNotifier) RegisterForSyncedTlfs(arg0 SyncedTlfObserver) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterForSyncedTlfs", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterForSyncedTlfs indicates an expected call of RegisterForSyncedTlfs
+func (mr *MockNotifierMockRecorder) RegisterForSyncedTlfs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForSyncedTlfs", reflect.TypeOf((*MockNotifier)(nil).RegisterForSyncedTlfs), arg0)
+}
+
 // UnregisterFromChanges mocks base method
 func (m *MockNotifier) UnregisterFromChanges(arg0 []data.FolderBranch, arg1 Observer) error {
 	m.ctrl.T.Helper()
@@ -4074,6 +4088,20 @@ func (m *MockNotifier) UnregisterFromChanges(arg0 []data.FolderBranch, arg1 Obse
 func (mr *MockNotifierMockRecorder) UnregisterFromChanges(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterFromChanges", reflect.TypeOf((*MockNotifier)(nil).UnregisterFromChanges), arg0, arg1)
+}
+
+// UnregisterFromSyncedTlfs mocks base method
+func (m *MockNotifier) UnregisterFromSyncedTlfs(arg0 SyncedTlfObserver) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnregisterFromSyncedTlfs", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnregisterFromSyncedTlfs indicates an expected call of UnregisterFromSyncedTlfs
+func (mr *MockNotifierMockRecorder) UnregisterFromSyncedTlfs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterFromSyncedTlfs", reflect.TypeOf((*MockNotifier)(nil).UnregisterFromSyncedTlfs), arg0)
 }
 
 // MockRekeyQueue is a mock of RekeyQueue interface

--- a/go/kbfs/libkbfs/observer_list.go
+++ b/go/kbfs/libkbfs/observer_list.go
@@ -7,7 +7,9 @@ package libkbfs
 import (
 	"sync"
 
+	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
 
@@ -64,5 +66,52 @@ func (ol *observerList) tlfHandleChange(
 	defer ol.lock.RUnlock()
 	for _, o := range ol.observers {
 		o.TlfHandleChange(ctx, newHandle)
+	}
+}
+
+// syncedTlfObserverList is a thread-safe list of synced TLF observers.
+type syncedTlfObserverList struct {
+	lock      sync.RWMutex
+	observers []SyncedTlfObserver
+}
+
+func newSyncedTlfObserverList() *syncedTlfObserverList {
+	return &syncedTlfObserverList{}
+}
+
+// It's the caller's responsibility to make sure add isn't called
+// twice for the same SyncedTlfObserver.
+func (stol *syncedTlfObserverList) add(o SyncedTlfObserver) {
+	stol.lock.Lock()
+	defer stol.lock.Unlock()
+	stol.observers = append(stol.observers, o)
+}
+
+func (stol *syncedTlfObserverList) remove(o SyncedTlfObserver) {
+	stol.lock.Lock()
+	defer stol.lock.Unlock()
+	for i, oldObs := range stol.observers {
+		if oldObs == o {
+			stol.observers = append(stol.observers[:i], stol.observers[i+1:]...)
+			return
+		}
+	}
+}
+
+func (stol *syncedTlfObserverList) fullSyncedStarted(
+	ctx context.Context, tlfID tlf.ID, waitCh <-chan struct{}) {
+	stol.lock.RLock()
+	defer stol.lock.RUnlock()
+	for _, o := range stol.observers {
+		o.FullSyncStarted(ctx, tlfID, waitCh)
+	}
+}
+
+func (stol *syncedTlfObserverList) syncModeChanged(
+	ctx context.Context, tlfID tlf.ID, newMode keybase1.FolderSyncMode) {
+	stol.lock.RLock()
+	defer stol.lock.RUnlock()
+	for _, o := range stol.observers {
+		o.SyncModeChanged(ctx, tlfID, newMode)
 	}
 }

--- a/go/kbfs/libkbfs/observer_list.go
+++ b/go/kbfs/libkbfs/observer_list.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"sync"
 
+	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -98,12 +99,13 @@ func (stol *syncedTlfObserverList) remove(o SyncedTlfObserver) {
 	}
 }
 
-func (stol *syncedTlfObserverList) fullSyncedStarted(
-	ctx context.Context, tlfID tlf.ID, waitCh <-chan struct{}) {
+func (stol *syncedTlfObserverList) fullSyncStarted(
+	ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision,
+	waitCh <-chan struct{}) {
 	stol.lock.RLock()
 	defer stol.lock.RUnlock()
 	for _, o := range stol.observers {
-		o.FullSyncStarted(ctx, tlfID, waitCh)
+		o.FullSyncStarted(ctx, tlfID, rev, waitCh)
 	}
 }
 


### PR DESCRIPTION
And add a global synced observers list for all FBOs.

(Future work will make use of this list.)

Issue: HOTPOT-1485