### PR TITLE
Fix bad connect in info panel

### DIFF
--- a/shared/chat/conversation/info-panel/container.tsx
+++ b/shared/chat/conversation/info-panel/container.tsx
@@ -75,8 +75,8 @@ const ConnectedInfoPanel = Container.connect(
     return {
       _attachmentInfo: attachmentInfo,
       _botAliases: meta.botAliases,
-      _fromMsgID: getFromMsgID(attachmentInfo),
       _featuredBots: state.chat2.featuredBotsMap,
+      _fromMsgID: getFromMsgID(attachmentInfo),
       _infoMap: state.users.infoMap,
       _nameParticipants: meta.nameParticipants,
       _participantToContactName: meta.participantToContactName,

--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -202,7 +202,10 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
     if (flags.botUI) {
       res.push(
         <Kb.Box2 key="bots" style={styles.tabTextContainer} direction="horizontal">
-          <TabText selected={this.isSelected('bots')} text={`Bots (${this.props.bots.length})`} />
+          <TabText
+            selected={this.isSelected('bots')}
+            text={this.props.bots.length > 0 ? `Bots (${this.props.bots.length})` : 'Bots'}
+          />
         </Kb.Box2>
       )
     }


### PR DESCRIPTION
This PR moves some bot filtering out of mapstate and into mergeprops. It also removes the bot number if there are no bots (so the tab reads "Bots", not "Bots (0)").