### PR TITLE
Add read-only bots display for teams

### DIFF
--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -5,12 +5,12 @@ import * as Kb from '../../../common-adapters'
 import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
 import * as RPCTypes from '../../../constants/types/rpc-gen'
 import flags from '../../../util/feature-flags'
-import { Props as HeaderHocProps } from '../../../common-adapters/header-hoc/types'
-import { AdhocHeader, TeamHeader } from './header'
-import { SettingsPanel } from './panels'
+import {Props as HeaderHocProps} from '../../../common-adapters/header-hoc/types'
+import {AdhocHeader, TeamHeader} from './header'
+import {SettingsPanel} from './panels'
 import Participant from './participant'
 import Bot from './bot'
-import { AttachmentTypeSelector, DocView, LinkView, MediaView } from './attachments'
+import {AttachmentTypeSelector, DocView, LinkView, MediaView} from './attachments'
 
 export type Panel = 'settings' | 'members' | 'attachments' | 'bots'
 export type ParticipantTyp = {
@@ -23,7 +23,7 @@ export type ParticipantTyp = {
 export type EntityType = 'adhoc' | 'small team' | 'channel'
 export type Section = {
   data: Array<any>
-  renderItem: (i: { item: any; index: number }) => void
+  renderItem: (i: {item: any; index: number}) => void
   renderSectionHeader: (i: any) => void
 }
 
@@ -134,7 +134,7 @@ export type InfoPanelProps = {
   onLoadMoreBots: () => void
 } & HeaderHocProps
 
-const TabText = ({ selected, text }: { selected: boolean; text: string }) => (
+const TabText = ({selected, text}: {selected: boolean; text: string}) => (
   <Kb.Text type="BodySmallSemibold" style={selected ? styles.tabTextSelected : undefined}>
     {text}
   </Kb.Text>
@@ -245,11 +245,11 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
             description={this.props.description}
           />
         ) : (
-            <AdhocHeader
-              onShowNewTeamDialog={this.props.onShowNewTeamDialog}
-              participants={this.props.participants}
-            />
-          )}
+          <AdhocHeader
+            onShowNewTeamDialog={this.props.onShowNewTeamDialog}
+            participants={this.props.participants}
+          />
+        )}
       </Kb.Box2>
     )
     return header
@@ -305,8 +305,8 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
     }
   }
 
-  private renderSectionHeader = ({ section }: any) => {
-    return section.renderSectionHeader({ section })
+  private renderSectionHeader = ({section}: any) => {
+    return section.renderSectionHeader({section})
   }
 
   render() {
@@ -320,7 +320,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
       return (
         <Kb.Box2
           direction="vertical"
-          style={Styles.collapseStyles([styles.container, { alignItems: 'center' }])}
+          style={Styles.collapseStyles([styles.container, {alignItems: 'center'}])}
           fullWidth={true}
           centerChildren={true}
         >
@@ -361,7 +361,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
           tabsSection.data.push(auditingBannerItem)
         }
         tabsSection.data = tabsSection.data.concat(this.props.participants)
-        tabsSection.renderItem = ({ item }) => {
+        tabsSection.renderItem = ({item}) => {
           if (item === auditingBannerItem) {
             return (
               <Kb.Banner color="grey" small={true}>
@@ -443,7 +443,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
         if (!this.props.loadedAllBots) {
           tabsSection.data.push(loadMoreBotsButton)
         }
-        tabsSection.renderItem = ({ item }) => {
+        tabsSection.renderItem = ({item}) => {
           if (item === addBotButton) {
             return (
               <Kb.Button
@@ -522,7 +522,7 @@ const styles = Styles.styleSheetCreate(
         marginTop: Styles.globalMargins.tiny,
       },
       container: Styles.platformStyles({
-        common: { alignItems: 'stretch', flex: 1, paddingBottom: Styles.globalMargins.tiny },
+        common: {alignItems: 'stretch', flex: 1, paddingBottom: Styles.globalMargins.tiny},
         isElectron: {
           backgroundColor: Styles.globalColors.white,
           borderLeft: `1px solid ${Styles.globalColors.black_10}`,
@@ -550,10 +550,10 @@ const styles = Styles.styleSheetCreate(
           whiteSpace: 'nowrap',
         },
       }),
-      tabTextSelected: { color: Styles.globalColors.black },
+      tabTextSelected: {color: Styles.globalColors.black},
     } as const)
 )
 
 const InfoPanel = Kb.HeaderOnMobile(_InfoPanel)
 
-export { InfoPanel }
+export {InfoPanel}

--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -5,12 +5,12 @@ import * as Kb from '../../../common-adapters'
 import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
 import * as RPCTypes from '../../../constants/types/rpc-gen'
 import flags from '../../../util/feature-flags'
-import {Props as HeaderHocProps} from '../../../common-adapters/header-hoc/types'
-import {AdhocHeader, TeamHeader} from './header'
-import {SettingsPanel} from './panels'
+import { Props as HeaderHocProps } from '../../../common-adapters/header-hoc/types'
+import { AdhocHeader, TeamHeader } from './header'
+import { SettingsPanel } from './panels'
 import Participant from './participant'
 import Bot from './bot'
-import {AttachmentTypeSelector, DocView, LinkView, MediaView} from './attachments'
+import { AttachmentTypeSelector, DocView, LinkView, MediaView } from './attachments'
 
 export type Panel = 'settings' | 'members' | 'attachments' | 'bots'
 export type ParticipantTyp = {
@@ -23,7 +23,7 @@ export type ParticipantTyp = {
 export type EntityType = 'adhoc' | 'small team' | 'channel'
 export type Section = {
   data: Array<any>
-  renderItem: (i: {item: any; index: number}) => void
+  renderItem: (i: { item: any; index: number }) => void
   renderSectionHeader: (i: any) => void
 }
 
@@ -134,7 +134,7 @@ export type InfoPanelProps = {
   onLoadMoreBots: () => void
 } & HeaderHocProps
 
-const TabText = ({selected, text}: {selected: boolean; text: string}) => (
+const TabText = ({ selected, text }: { selected: boolean; text: string }) => (
   <Kb.Text type="BodySmallSemibold" style={selected ? styles.tabTextSelected : undefined}>
     {text}
   </Kb.Text>
@@ -187,10 +187,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
     if (entityType !== 'adhoc') {
       res.push(
         <Kb.Box2 key="members" style={styles.tabTextContainer} direction="horizontal">
-          <TabText
-            selected={this.isSelected('members')}
-            text={`Members (${this.props.participants.length})`}
-          />
+          <TabText selected={this.isSelected('members')} text="Members" />
         </Kb.Box2>
       )
     }
@@ -202,10 +199,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
     if (flags.botUI) {
       res.push(
         <Kb.Box2 key="bots" style={styles.tabTextContainer} direction="horizontal">
-          <TabText
-            selected={this.isSelected('bots')}
-            text={this.props.bots.length > 0 ? `Bots (${this.props.bots.length})` : 'Bots'}
-          />
+          <TabText selected={this.isSelected('bots')} text="Bots" />
         </Kb.Box2>
       )
     }
@@ -251,11 +245,11 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
             description={this.props.description}
           />
         ) : (
-          <AdhocHeader
-            onShowNewTeamDialog={this.props.onShowNewTeamDialog}
-            participants={this.props.participants}
-          />
-        )}
+            <AdhocHeader
+              onShowNewTeamDialog={this.props.onShowNewTeamDialog}
+              participants={this.props.participants}
+            />
+          )}
       </Kb.Box2>
     )
     return header
@@ -311,8 +305,8 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
     }
   }
 
-  private renderSectionHeader = ({section}: any) => {
-    return section.renderSectionHeader({section})
+  private renderSectionHeader = ({ section }: any) => {
+    return section.renderSectionHeader({ section })
   }
 
   render() {
@@ -326,7 +320,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
       return (
         <Kb.Box2
           direction="vertical"
-          style={Styles.collapseStyles([styles.container, {alignItems: 'center'}])}
+          style={Styles.collapseStyles([styles.container, { alignItems: 'center' }])}
           fullWidth={true}
           centerChildren={true}
         >
@@ -367,7 +361,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
           tabsSection.data.push(auditingBannerItem)
         }
         tabsSection.data = tabsSection.data.concat(this.props.participants)
-        tabsSection.renderItem = ({item}) => {
+        tabsSection.renderItem = ({ item }) => {
           if (item === auditingBannerItem) {
             return (
               <Kb.Banner color="grey" small={true}>
@@ -449,7 +443,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
         if (!this.props.loadedAllBots) {
           tabsSection.data.push(loadMoreBotsButton)
         }
-        tabsSection.renderItem = ({item}) => {
+        tabsSection.renderItem = ({ item }) => {
           if (item === addBotButton) {
             return (
               <Kb.Button
@@ -528,7 +522,7 @@ const styles = Styles.styleSheetCreate(
         marginTop: Styles.globalMargins.tiny,
       },
       container: Styles.platformStyles({
-        common: {alignItems: 'stretch', flex: 1, paddingBottom: Styles.globalMargins.tiny},
+        common: { alignItems: 'stretch', flex: 1, paddingBottom: Styles.globalMargins.tiny },
         isElectron: {
           backgroundColor: Styles.globalColors.white,
           borderLeft: `1px solid ${Styles.globalColors.black_10}`,
@@ -556,10 +550,10 @@ const styles = Styles.styleSheetCreate(
           whiteSpace: 'nowrap',
         },
       }),
-      tabTextSelected: {color: Styles.globalColors.black},
+      tabTextSelected: { color: Styles.globalColors.black },
     } as const)
 )
 
 const InfoPanel = Kb.HeaderOnMobile(_InfoPanel)
 
-export {InfoPanel}
+export { InfoPanel }

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -67,7 +67,7 @@ export type InviteInfo = {
   id: string
 }
 
-export type TabKey = 'members' | 'invites' | 'subteams' | 'settings'
+export type TabKey = 'members' | 'invites' | 'bots' | 'subteams' | 'settings'
 
 export type TypeMap = {[K in TeamRoleType]: string}
 

--- a/shared/teams/team/index.tsx
+++ b/shared/teams/team/index.tsx
@@ -38,6 +38,7 @@ class Team extends React.Component<Props> {
       case 'settings':
       case 'header':
       case 'member':
+      case 'bot':
       case 'invites-invite':
       case 'invites-request':
       case 'invites-divider':

--- a/shared/teams/team/rows/bot-row/bot-menu.tsx
+++ b/shared/teams/team/rows/bot-row/bot-menu.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import * as Kb from '../../../../common-adapters'
+
+type Props = {
+  attachTo?: () => React.Component<any> | null
+  onHidden: () => void
+  visible: boolean
+}
+
+const items: Kb.MenuItems = [
+  {icon: 'iconfont-gear', onClick: () => null, title: 'Edit settings'},
+  {danger: true, icon: 'iconfont-remove', onClick: () => null, title: 'Uninstall'},
+]
+
+const BotMenu = (props: Props) => {
+  return (
+    <Kb.FloatingMenu
+      attachTo={props.attachTo}
+      closeOnSelect={true}
+      items={items}
+      onHidden={props.onHidden}
+      visible={props.visible}
+    />
+  )
+}
+
+export default BotMenu

--- a/shared/teams/team/rows/bot-row/container.tsx
+++ b/shared/teams/team/rows/bot-row/container.tsx
@@ -1,5 +1,4 @@
 import * as Constants from '../../../../constants/teams'
-import * as TeamsGen from '../../../../actions/teams-gen'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Tracker2Gen from '../../../../actions/tracker2-gen'
 import * as ProfileGen from '../../../../actions/profile-gen'
@@ -17,8 +16,6 @@ type OwnProps = {
 const blankInfo = Constants.initialMemberInfo
 
 type DispatchProps = {
-  _onReAddToTeam: (teamname: string, username: string) => void
-  _onRemoveFromTeam: (teamname: string, username: string) => void
   _onShowTracker: (username: string) => void
   onChat: () => void
   onClick: () => void
@@ -27,8 +24,8 @@ type DispatchProps = {
 export default connect(
   (state, {teamID, username}: OwnProps) => {
     const teamDetails = Constants.getTeamDetails(state, teamID)
-    const {members: map = new Map(), teamname} = teamDetails
-    const info = map.get(username) || blankInfo
+    const {members: map = new Map<string, Types.MemberInfo>(), teamname} = teamDetails
+    const info: Types.MemberInfo = map.get(username) || blankInfo
     const bot: RPCTypes.FeaturedBot = state.chat2.featuredBotsMap.get(username) ?? {
       botAlias: info.fullName,
       botUsername: username,
@@ -36,26 +33,17 @@ export default connect(
     }
 
     return {
+      ...bot,
       roleType: info.type,
       status: info.status,
       teamname,
       username: info.username,
       youCanManageMembers: Constants.getCanPerform(state, teamname).manageMembers,
-      ...bot,
+      ownerTeam: bot.ownerTeam || undefined,
+      ownerUser: bot.ownerUser || undefined,
     }
   },
   (dispatch, ownProps: OwnProps): DispatchProps => ({
-    _onReAddToTeam: (teamID: Types.TeamID, username: string) => {
-      dispatch(
-        TeamsGen.createReAddToTeam({
-          teamID,
-          username,
-        })
-      )
-    },
-    _onRemoveFromTeam: (teamname: string, username: string) => {
-      dispatch(TeamsGen.createRemoveMemberOrPendingInvite({email: '', inviteID: '', teamname, username}))
-    },
     _onShowTracker: (username: string) => {
       if (isMobile) {
         dispatch(ProfileGen.createShowUserProfile({username}))
@@ -76,8 +64,6 @@ export default connect(
     botAlias: stateProps.botAlias,
     description: stateProps.description,
     onClick: dispatchProps.onClick,
-    onReAddToTeam: () => dispatchProps._onReAddToTeam(ownProps.teamID, ownProps.username),
-    onRemoveFromTeam: () => dispatchProps._onRemoveFromTeam(stateProps.teamname, ownProps.username),
     onShowTracker: () => dispatchProps._onShowTracker(ownProps.username),
     ownerTeam: stateProps.ownerTeam,
     ownerUser: stateProps.ownerUser,

--- a/shared/teams/team/rows/bot-row/container.tsx
+++ b/shared/teams/team/rows/bot-row/container.tsx
@@ -34,13 +34,13 @@ export default connect(
 
     return {
       ...bot,
+      ownerTeam: bot.ownerTeam || undefined,
+      ownerUser: bot.ownerUser || undefined,
       roleType: info.type,
       status: info.status,
       teamname,
       username: info.username,
       youCanManageMembers: Constants.getCanPerform(state, teamname).manageMembers,
-      ownerTeam: bot.ownerTeam || undefined,
-      ownerUser: bot.ownerUser || undefined,
     }
   },
   (dispatch, ownProps: OwnProps): DispatchProps => ({

--- a/shared/teams/team/rows/bot-row/container.tsx
+++ b/shared/teams/team/rows/bot-row/container.tsx
@@ -4,10 +4,10 @@ import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Tracker2Gen from '../../../../actions/tracker2-gen'
 import * as ProfileGen from '../../../../actions/profile-gen'
 import * as Types from '../../../../constants/types/teams'
+import * as RPCTypes from '../../../../constants/types/rpc-gen'
 import {TeamBotRow} from './'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
 import {connect, isMobile} from '../../../../util/container'
-import {anyWaiting} from '../../../../constants/waiting'
 
 type OwnProps = {
   teamID: Types.TeamID
@@ -15,23 +15,6 @@ type OwnProps = {
 }
 
 const blankInfo = Constants.initialMemberInfo
-
-const mapStateToProps = (state, {teamID, username}: OwnProps) => {
-  const teamDetails = Constants.getTeamDetails(state, teamID)
-  const {members: map = new Map(), teamname} = teamDetails
-  const info = map.get(username) || blankInfo
-
-  return {
-    roleType: info.type,
-    status: info.status,
-    teamname,
-    username: info.username,
-    waitingForAdd: anyWaiting(state, Constants.addMemberWaitingKey(teamID, username)),
-    waitingForRemove: anyWaiting(state, Constants.removeMemberWaitingKey(teamname, username)),
-    you: state.config.username,
-    youCanManageMembers: Constants.getCanPerform(state, teamname).manageMembers,
-  }
-}
 
 type DispatchProps = {
   _onReAddToTeam: (teamname: string, username: string) => void
@@ -41,50 +24,66 @@ type DispatchProps = {
   onClick: () => void
 }
 
-const mapDispatchToProps = (dispatch, ownProps: OwnProps): DispatchProps => ({
-  _onReAddToTeam: (teamID: Types.TeamID, username: string) => {
-    dispatch(
-      TeamsGen.createReAddToTeam({
-        teamID,
-        username,
-      })
-    )
-  },
-  _onRemoveFromTeam: (teamname: string, username: string) => {
-    dispatch(TeamsGen.createRemoveMemberOrPendingInvite({email: '', inviteID: '', teamname, username}))
-  },
-  _onShowTracker: (username: string) => {
-    if (isMobile) {
-      dispatch(ProfileGen.createShowUserProfile({username}))
-    } else {
-      dispatch(Tracker2Gen.createShowUser({asTracker: true, username}))
+export default connect(
+  (state, {teamID, username}: OwnProps) => {
+    const teamDetails = Constants.getTeamDetails(state, teamID)
+    const {members: map = new Map(), teamname} = teamDetails
+    const info = map.get(username) || blankInfo
+    const bot: RPCTypes.FeaturedBot = state.chat2.featuredBotsMap.get(username) ?? {
+      botAlias: info.fullName,
+      botUsername: username,
+      description: '',
+    }
+
+    return {
+      roleType: info.type,
+      status: info.status,
+      teamname,
+      username: info.username,
+      youCanManageMembers: Constants.getCanPerform(state, teamname).manageMembers,
+      ...bot,
     }
   },
-  onChat: () => {
-    ownProps.username &&
-      dispatch(Chat2Gen.createPreviewConversation({participants: [ownProps.username], reason: 'teamMember'}))
-  },
-  onClick: () =>
-    dispatch(RouteTreeGen.createNavigateAppend({path: [{props: ownProps, selected: 'teamMember'}]})),
-})
-
-const mergeProps = (stateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
-  return {
-    following: stateProps.following,
-    fullName: stateProps.fullName,
-    onChat: dispatchProps.onChat,
+  (dispatch, ownProps: OwnProps): DispatchProps => ({
+    _onReAddToTeam: (teamID: Types.TeamID, username: string) => {
+      dispatch(
+        TeamsGen.createReAddToTeam({
+          teamID,
+          username,
+        })
+      )
+    },
+    _onRemoveFromTeam: (teamname: string, username: string) => {
+      dispatch(TeamsGen.createRemoveMemberOrPendingInvite({email: '', inviteID: '', teamname, username}))
+    },
+    _onShowTracker: (username: string) => {
+      if (isMobile) {
+        dispatch(ProfileGen.createShowUserProfile({username}))
+      } else {
+        dispatch(Tracker2Gen.createShowUser({asTracker: true, username}))
+      }
+    },
+    onChat: () => {
+      ownProps.username &&
+        dispatch(
+          Chat2Gen.createPreviewConversation({participants: [ownProps.username], reason: 'teamMember'})
+        )
+    },
+    onClick: () =>
+      dispatch(RouteTreeGen.createNavigateAppend({path: [{props: ownProps, selected: 'teamMember'}]})),
+  }),
+  (stateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => ({
+    botAlias: stateProps.botAlias,
+    description: stateProps.description,
     onClick: dispatchProps.onClick,
     onReAddToTeam: () => dispatchProps._onReAddToTeam(ownProps.teamID, ownProps.username),
     onRemoveFromTeam: () => dispatchProps._onRemoveFromTeam(stateProps.teamname, ownProps.username),
     onShowTracker: () => dispatchProps._onShowTracker(ownProps.username),
+    ownerTeam: stateProps.ownerTeam,
+    ownerUser: stateProps.ownerUser,
     roleType: stateProps.roleType,
     status: stateProps.status,
     username: stateProps.username,
-    waitingForAdd: stateProps.waitingForAdd,
-    waitingForRemove: stateProps.waitingForRemove,
-    you: stateProps.you,
     youCanManageMembers: stateProps.youCanManageMembers,
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(TeamBotRow)
+  })
+)(TeamBotRow)

--- a/shared/teams/team/rows/bot-row/container.tsx
+++ b/shared/teams/team/rows/bot-row/container.tsx
@@ -1,0 +1,90 @@
+import * as Constants from '../../../../constants/teams'
+import * as TeamsGen from '../../../../actions/teams-gen'
+import * as Chat2Gen from '../../../../actions/chat2-gen'
+import * as Tracker2Gen from '../../../../actions/tracker2-gen'
+import * as ProfileGen from '../../../../actions/profile-gen'
+import * as Types from '../../../../constants/types/teams'
+import {TeamBotRow} from './'
+import * as RouteTreeGen from '../../../../actions/route-tree-gen'
+import {connect, isMobile} from '../../../../util/container'
+import {anyWaiting} from '../../../../constants/waiting'
+
+type OwnProps = {
+  teamID: Types.TeamID
+  username: string
+}
+
+const blankInfo = Constants.initialMemberInfo
+
+const mapStateToProps = (state, {teamID, username}: OwnProps) => {
+  const teamDetails = Constants.getTeamDetails(state, teamID)
+  const {members: map = new Map(), teamname} = teamDetails
+  const info = map.get(username) || blankInfo
+
+  return {
+    roleType: info.type,
+    status: info.status,
+    teamname,
+    username: info.username,
+    waitingForAdd: anyWaiting(state, Constants.addMemberWaitingKey(teamID, username)),
+    waitingForRemove: anyWaiting(state, Constants.removeMemberWaitingKey(teamname, username)),
+    you: state.config.username,
+    youCanManageMembers: Constants.getCanPerform(state, teamname).manageMembers,
+  }
+}
+
+type DispatchProps = {
+  _onReAddToTeam: (teamname: string, username: string) => void
+  _onRemoveFromTeam: (teamname: string, username: string) => void
+  _onShowTracker: (username: string) => void
+  onChat: () => void
+  onClick: () => void
+}
+
+const mapDispatchToProps = (dispatch, ownProps: OwnProps): DispatchProps => ({
+  _onReAddToTeam: (teamID: Types.TeamID, username: string) => {
+    dispatch(
+      TeamsGen.createReAddToTeam({
+        teamID,
+        username,
+      })
+    )
+  },
+  _onRemoveFromTeam: (teamname: string, username: string) => {
+    dispatch(TeamsGen.createRemoveMemberOrPendingInvite({email: '', inviteID: '', teamname, username}))
+  },
+  _onShowTracker: (username: string) => {
+    if (isMobile) {
+      dispatch(ProfileGen.createShowUserProfile({username}))
+    } else {
+      dispatch(Tracker2Gen.createShowUser({asTracker: true, username}))
+    }
+  },
+  onChat: () => {
+    ownProps.username &&
+      dispatch(Chat2Gen.createPreviewConversation({participants: [ownProps.username], reason: 'teamMember'}))
+  },
+  onClick: () =>
+    dispatch(RouteTreeGen.createNavigateAppend({path: [{props: ownProps, selected: 'teamMember'}]})),
+})
+
+const mergeProps = (stateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+  return {
+    following: stateProps.following,
+    fullName: stateProps.fullName,
+    onChat: dispatchProps.onChat,
+    onClick: dispatchProps.onClick,
+    onReAddToTeam: () => dispatchProps._onReAddToTeam(ownProps.teamID, ownProps.username),
+    onRemoveFromTeam: () => dispatchProps._onRemoveFromTeam(stateProps.teamname, ownProps.username),
+    onShowTracker: () => dispatchProps._onShowTracker(ownProps.username),
+    roleType: stateProps.roleType,
+    status: stateProps.status,
+    username: stateProps.username,
+    waitingForAdd: stateProps.waitingForAdd,
+    waitingForRemove: stateProps.waitingForRemove,
+    you: stateProps.you,
+    youCanManageMembers: stateProps.youCanManageMembers,
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(TeamBotRow)

--- a/shared/teams/team/rows/bot-row/index.tsx
+++ b/shared/teams/team/rows/bot-row/index.tsx
@@ -9,8 +9,6 @@ export type Props = {
   botAlias: string
   description: string
   onClick: () => void
-  onReAddToTeam: () => void
-  onRemoveFromTeam: () => void
   onShowTracker: () => void
   ownerTeam?: string
   ownerUser?: string
@@ -105,25 +103,6 @@ export const TeamBotRow = (props: Props) => {
 
 const styles = Styles.styleSheetCreate(() => ({
   buttonBarContainer: {...Styles.globalStyles.flexBoxRow, flexShrink: 1},
-  menuButtonDesktop: {
-    marginLeft: Styles.globalMargins.small,
-    marginRight: Styles.globalMargins.tiny,
-    padding: Styles.globalMargins.tiny,
-  },
-  menuButtonMobile: {
-    position: 'absolute',
-    right: 16,
-    top: 24,
-  },
-  menuButtonMobileSmallTop: {
-    top: 12,
-  },
-  menuIconContainer: {
-    ...Styles.globalStyles.flexBoxRow,
-    alignItems: 'center',
-    flexShrink: 1,
-    height: '100%',
-  },
   clickable: {
     ...Styles.globalStyles.flexBoxRow,
     alignItems: 'center',
@@ -160,6 +139,25 @@ const styles = Styles.styleSheetCreate(() => ({
     marginRight: Styles.globalMargins.xtiny,
     paddingLeft: Styles.globalMargins.xtiny,
     paddingRight: Styles.globalMargins.xtiny,
+  },
+  menuButtonDesktop: {
+    marginLeft: Styles.globalMargins.small,
+    marginRight: Styles.globalMargins.tiny,
+    padding: Styles.globalMargins.tiny,
+  },
+  menuButtonMobile: {
+    position: 'absolute',
+    right: 16,
+    top: 24,
+  },
+  menuButtonMobileSmallTop: {
+    top: 12,
+  },
+  menuIconContainer: {
+    ...Styles.globalStyles.flexBoxRow,
+    alignItems: 'center',
+    flexShrink: 1,
+    height: '100%',
   },
   nameContainer: {...Styles.globalStyles.flexBoxColumn, marginLeft: Styles.globalMargins.small},
   nameContainerInner: {...Styles.globalStyles.flexBoxRow, alignItems: 'center'},

--- a/shared/teams/team/rows/bot-row/index.tsx
+++ b/shared/teams/team/rows/bot-row/index.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 import * as Kb from '../../../../common-adapters'
 import * as Styles from '../../../../styles'
-import {typeToLabel} from '../../../../constants/teams'
+import {isLargeScreen} from '../../../../constants/platform'
 import {MemberStatus, TeamRoleType} from '../../../../constants/types/teams'
+import BotMenu from './bot-menu'
 
 export type Props = {
   botAlias: string
@@ -25,6 +26,12 @@ export type Props = {
 
 export const TeamBotRow = (props: Props) => {
   let descriptionLabel
+  let menuRef = React.useRef<Kb.Box>(null)
+  const [showMenu, setShowMenu] = React.useState(false)
+
+  const _getAttachmentRef = () => menuRef.current
+  const _onShowMenu = () => setShowMenu(true)
+  const _onHideMenu = () => setShowMenu(false)
   const active = props.status === 'active'
   if (props.description.length > 0) {
     descriptionLabel = (
@@ -59,16 +66,30 @@ export const TeamBotRow = (props: Props) => {
   return (
     <Kb.Box style={Styles.collapseStyles([styles.container, !active && styles.containerReset])}>
       <Kb.Box style={styles.innerContainerTop}>
-        <Kb.ClickableBox
-          style={styles.clickable}
-          onClick={active ? props.onClick : props.status === 'deleted' ? undefined : props.onShowTracker}
-        >
+        <Kb.Box style={styles.clickable}>
           <Kb.Avatar username={props.username} size={Styles.isMobile ? 48 : 32} />
           <Kb.Box style={styles.nameContainer}>
             <Kb.Box style={Styles.globalStyles.flexBoxRow}>{usernameDisplay}</Kb.Box>
             <Kb.Box style={styles.nameContainerInner}>{descriptionLabel}</Kb.Box>
           </Kb.Box>
-        </Kb.ClickableBox>
+        </Kb.Box>
+        <Kb.Box style={styles.menuIconContainer} ref={menuRef}>
+          {(active || isLargeScreen) && (
+            // Desktop & mobile large screen - display on the far right of the first row
+            // Also when user is active
+            <Kb.Icon
+              onClick={_onShowMenu}
+              style={
+                Styles.isMobile
+                  ? Styles.collapseStyles([styles.menuButtonMobile, styles.menuButtonMobileSmallTop])
+                  : styles.menuButtonDesktop
+              }
+              fontSize={Styles.isMobile ? 20 : 16}
+              type="iconfont-ellipsis"
+            />
+          )}
+          <BotMenu attachTo={_getAttachmentRef} visible={showMenu} onHidden={_onHideMenu} />
+        </Kb.Box>
       </Kb.Box>
     </Kb.Box>
   )
@@ -76,20 +97,20 @@ export const TeamBotRow = (props: Props) => {
 
 const styles = Styles.styleSheetCreate(() => ({
   buttonBarContainer: {...Styles.globalStyles.flexBoxRow, flexShrink: 1},
-  chatButtonDesktop: {
+  menuButtonDesktop: {
     marginLeft: Styles.globalMargins.small,
     marginRight: Styles.globalMargins.tiny,
     padding: Styles.globalMargins.tiny,
   },
-  chatButtonMobile: {
+  menuButtonMobile: {
     position: 'absolute',
     right: 16,
     top: 24,
   },
-  chatButtonMobileSmallTop: {
+  menuButtonMobileSmallTop: {
     top: 12,
   },
-  chatIconContainer: {
+  menuIconContainer: {
     ...Styles.globalStyles.flexBoxRow,
     alignItems: 'center',
     flexShrink: 1,

--- a/shared/teams/team/rows/bot-row/index.tsx
+++ b/shared/teams/team/rows/bot-row/index.tsx
@@ -43,7 +43,11 @@ export const TeamBotRow = (props: Props) => {
 
   const usernameDisplay = (
     <Kb.Box2 direction="horizontal" alignSelf="flex-start">
-      <Kb.Text type="BodySmallSemibold" style={{color: Styles.globalColors.black}}>
+      <Kb.Text
+        type="BodySmallSemibold"
+        style={{color: Styles.globalColors.black}}
+        onClick={props.onShowTracker}
+      >
         {props.botAlias || props.username}
       </Kb.Text>
       <Kb.Text type="BodySmall">
@@ -67,7 +71,11 @@ export const TeamBotRow = (props: Props) => {
     <Kb.Box style={Styles.collapseStyles([styles.container, !active && styles.containerReset])}>
       <Kb.Box style={styles.innerContainerTop}>
         <Kb.Box style={styles.clickable}>
-          <Kb.Avatar username={props.username} size={Styles.isMobile ? 48 : 32} />
+          <Kb.Avatar
+            username={props.username}
+            size={Styles.isMobile ? 48 : 32}
+            onClick={props.onShowTracker}
+          />
           <Kb.Box style={styles.nameContainer}>
             <Kb.Box style={Styles.globalStyles.flexBoxRow}>{usernameDisplay}</Kb.Box>
             <Kb.Box style={styles.nameContainerInner}>{descriptionLabel}</Kb.Box>

--- a/shared/teams/team/rows/bot-row/index.tsx
+++ b/shared/teams/team/rows/bot-row/index.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react'
+import {
+  Avatar,
+  Box,
+  Button,
+  ButtonBar,
+  ClickableBox,
+  Text,
+  Icon,
+  Usernames,
+} from '../../../../common-adapters'
+import * as Styles from '../../../../styles'
+import {typeToLabel} from '../../../../constants/teams'
+import {isLargeScreen} from '../../../../constants/platform'
+import {BoolTypeMap, MemberStatus, TeamRoleType} from '../../../../constants/types/teams'
+
+export type Props = {
+  onChat: () => void
+  onClick: () => void
+  onReAddToTeam: () => void
+  onRemoveFromTeam: () => void
+  onShowTracker: () => void
+  roleType: TeamRoleType
+  status: MemberStatus
+  username: string
+  waitingForAdd: boolean
+  waitingForRemove: boolean
+  youCanManageMembers: boolean
+}
+
+// NOTE the controls for reset and deleted users (and the chat button) are
+// duplicated here because the desktop & mobile layouts differ significantly. If
+// you're changing one remember to change the other.
+
+export const TeamBotRow = (props: Props) => {
+  let resetLabel
+  const active = props.status === 'active'
+  // if (props.fullName && active) {
+  //   fullNameLabel = (
+  //     <Text style={styles.fullNameLabel} type="BodySmall">
+  //       {props.fullName} •
+  //     </Text>
+  //   )
+  // }
+  if (!active) {
+    resetLabel = props.youCanManageMembers
+      ? 'Has reset their account'
+      : 'Has reset their account; admins can re-invite'
+    if (props.status === 'deleted') {
+      resetLabel = 'Has deleted their account'
+    }
+  }
+
+  return (
+    <Box style={Styles.collapseStyles([styles.container, !active && styles.containerReset])}>
+      <Box style={styles.innerContainerTop}>
+        <ClickableBox
+          style={styles.clickable}
+          onClick={active ? props.onClick : props.status === 'deleted' ? undefined : props.onShowTracker}
+        >
+          <Avatar username={props.username} size={Styles.isMobile ? 48 : 32} />
+          <Box style={styles.nameContainer}>
+            <Box style={Styles.globalStyles.flexBoxRow}>
+              <Usernames type="BodySemibold" colorFollowing={true} users={[{username: props.username}]} />
+            </Box>
+            <Box style={styles.nameContainerInner}>
+              {/* {fullNameLabel} */}
+              {!active && (
+                <Text type="BodySmall" style={styles.lockedOutOrDeleted}>
+                  {props.status === 'reset' ? 'LOCKED OUT' : 'DELETED'}
+                </Text>
+              )}
+              <Text type="BodySmall">
+                {!!active && !!props.roleType && typeToLabel[props.roleType]}
+                {resetLabel}
+              </Text>
+            </Box>
+          </Box>
+        </ClickableBox>
+        {!active && !Styles.isMobile && props.youCanManageMembers && (
+          <Box style={styles.buttonBarContainer}>
+            <ButtonBar>
+              {props.status !== 'deleted' && (
+                <Button
+                  small={true}
+                  label="Re-Admit"
+                  onClick={props.onReAddToTeam}
+                  type="Success"
+                  waiting={props.waitingForAdd}
+                  disabled={props.waitingForRemove}
+                />
+              )}
+              <Button
+                small={true}
+                label="Remove"
+                onClick={props.onRemoveFromTeam}
+                type="Dim"
+                waiting={props.waitingForRemove}
+                disabled={props.waitingForAdd}
+              />
+            </ButtonBar>
+          </Box>
+        )}
+        <Box style={styles.chatIconContainer}>
+          {(active || isLargeScreen) && (
+            // Desktop & mobile large screen - display on the far right of the first row
+            // Also when user is active
+            <Icon
+              onClick={props.onChat}
+              style={
+                Styles.isMobile
+                  ? Styles.collapseStyles([styles.chatButtonMobile, styles.chatButtonMobileSmallTop])
+                  : styles.chatButtonDesktop
+              }
+              fontSize={Styles.isMobile ? 20 : 16}
+              type="iconfont-chat"
+            />
+          )}
+        </Box>
+      </Box>
+      {!active && Styles.isMobile && props.youCanManageMembers && (
+        <Box style={styles.innerContainerBottom}>
+          <ButtonBar direction="row">
+            {props.status !== 'deleted' && (
+              <Button
+                small={true}
+                label="Re-Admit"
+                onClick={props.onReAddToTeam}
+                type="Success"
+                waiting={props.waitingForAdd}
+                disabled={props.waitingForRemove}
+              />
+            )}
+            <Button
+              small={true}
+              label="Remove"
+              onClick={props.onRemoveFromTeam}
+              type="Dim"
+              waiting={props.waitingForRemove}
+              disabled={props.waitingForAdd}
+            />
+          </ButtonBar>
+          {!isLargeScreen && (
+            // Mobile small screens - for inactive user
+            // display next to reset / deleted controls
+            <Icon
+              onClick={props.onChat}
+              style={Styles.collapseStyles([
+                styles.chatButtonMobile,
+                active && styles.chatButtonMobileSmallTop,
+              ])}
+              fontSize={20}
+              type="iconfont-chat"
+            />
+          )}
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+const styles = Styles.styleSheetCreate(() => ({
+  buttonBarContainer: {...Styles.globalStyles.flexBoxRow, flexShrink: 1},
+  chatButtonDesktop: {
+    marginLeft: Styles.globalMargins.small,
+    marginRight: Styles.globalMargins.tiny,
+    padding: Styles.globalMargins.tiny,
+  },
+  chatButtonMobile: {
+    position: 'absolute',
+    right: 16,
+    top: 24,
+  },
+  chatButtonMobileSmallTop: {
+    top: 12,
+  },
+  chatIconContainer: {
+    ...Styles.globalStyles.flexBoxRow,
+    alignItems: 'center',
+    flexShrink: 1,
+    height: '100%',
+  },
+  clickable: {
+    ...Styles.globalStyles.flexBoxRow,
+    alignItems: 'center',
+    flexGrow: 1,
+  },
+  container: {
+    ...Styles.globalStyles.flexBoxColumn,
+    alignItems: 'center',
+    flex: 1,
+    height: '100%',
+    position: 'relative',
+    width: '100%',
+  },
+  containerReset: {
+    backgroundColor: Styles.globalColors.blueLighter2,
+  },
+  crownIcon: {
+    marginRight: Styles.globalMargins.xtiny,
+  },
+  fullNameLabel: {marginRight: Styles.globalMargins.xtiny},
+  innerContainerBottom: {...Styles.globalStyles.flexBoxRow, flexShrink: 1},
+  innerContainerTop: {
+    ...Styles.globalStyles.flexBoxRow,
+    ...Styles.padding(Styles.globalMargins.xsmall, Styles.globalMargins.small),
+    alignItems: 'center',
+    flexShrink: 0,
+    height: Styles.isMobile ? 56 : 48,
+    width: '100%',
+  },
+  lockedOutOrDeleted: {
+    ...Styles.globalStyles.fontBold,
+    backgroundColor: Styles.globalColors.red,
+    color: Styles.globalColors.white,
+    marginRight: Styles.globalMargins.xtiny,
+    paddingLeft: Styles.globalMargins.xtiny,
+    paddingRight: Styles.globalMargins.xtiny,
+  },
+  nameContainer: {...Styles.globalStyles.flexBoxColumn, marginLeft: Styles.globalMargins.small},
+  nameContainerInner: {...Styles.globalStyles.flexBoxRow, alignItems: 'center'},
+}))

--- a/shared/teams/team/rows/bot-row/index.tsx
+++ b/shared/teams/team/rows/bot-row/index.tsx
@@ -1,30 +1,21 @@
 import * as React from 'react'
-import {
-  Avatar,
-  Box,
-  Button,
-  ButtonBar,
-  ClickableBox,
-  Text,
-  Icon,
-  Usernames,
-} from '../../../../common-adapters'
+import * as Kb from '../../../../common-adapters'
 import * as Styles from '../../../../styles'
 import {typeToLabel} from '../../../../constants/teams'
-import {isLargeScreen} from '../../../../constants/platform'
-import {BoolTypeMap, MemberStatus, TeamRoleType} from '../../../../constants/types/teams'
+import {MemberStatus, TeamRoleType} from '../../../../constants/types/teams'
 
 export type Props = {
-  onChat: () => void
+  botAlias: string
+  description: string
   onClick: () => void
   onReAddToTeam: () => void
   onRemoveFromTeam: () => void
   onShowTracker: () => void
+  ownerTeam?: string
+  ownerUser?: string
   roleType: TeamRoleType
   status: MemberStatus
   username: string
-  waitingForAdd: boolean
-  waitingForRemove: boolean
   youCanManageMembers: boolean
 }
 
@@ -33,129 +24,53 @@ export type Props = {
 // you're changing one remember to change the other.
 
 export const TeamBotRow = (props: Props) => {
-  let resetLabel
+  let descriptionLabel
   const active = props.status === 'active'
-  // if (props.fullName && active) {
-  //   fullNameLabel = (
-  //     <Text style={styles.fullNameLabel} type="BodySmall">
-  //       {props.fullName} •
-  //     </Text>
-  //   )
-  // }
-  if (!active) {
-    resetLabel = props.youCanManageMembers
-      ? 'Has reset their account'
-      : 'Has reset their account; admins can re-invite'
-    if (props.status === 'deleted') {
-      resetLabel = 'Has deleted their account'
-    }
+  if (props.description.length > 0) {
+    descriptionLabel = (
+      <Kb.Text style={styles.fullNameLabel} type="BodySmall" lineClamp={1}>
+        {props.description}
+      </Kb.Text>
+    )
   }
 
+  const usernameDisplay = (
+    <Kb.Box2 direction="horizontal" alignSelf="flex-start">
+      <Kb.Text type="BodySmallSemibold" style={{color: Styles.globalColors.black}}>
+        {props.botAlias || props.username}
+      </Kb.Text>
+      <Kb.Text type="BodySmall">
+        &nbsp;• by{' '}
+        {props.ownerTeam ? (
+          <Kb.Text type="BodySmall">@{props.ownerTeam}</Kb.Text>
+        ) : (
+          <Kb.ConnectedUsernames
+            prefix="@"
+            inline={true}
+            usernames={[props.ownerUser ?? props.username]}
+            type="BodySmall"
+            withProfileCardPopup={true}
+          />
+        )}
+      </Kb.Text>
+    </Kb.Box2>
+  )
+
   return (
-    <Box style={Styles.collapseStyles([styles.container, !active && styles.containerReset])}>
-      <Box style={styles.innerContainerTop}>
-        <ClickableBox
+    <Kb.Box style={Styles.collapseStyles([styles.container, !active && styles.containerReset])}>
+      <Kb.Box style={styles.innerContainerTop}>
+        <Kb.ClickableBox
           style={styles.clickable}
           onClick={active ? props.onClick : props.status === 'deleted' ? undefined : props.onShowTracker}
         >
-          <Avatar username={props.username} size={Styles.isMobile ? 48 : 32} />
-          <Box style={styles.nameContainer}>
-            <Box style={Styles.globalStyles.flexBoxRow}>
-              <Usernames type="BodySemibold" colorFollowing={true} users={[{username: props.username}]} />
-            </Box>
-            <Box style={styles.nameContainerInner}>
-              {/* {fullNameLabel} */}
-              {!active && (
-                <Text type="BodySmall" style={styles.lockedOutOrDeleted}>
-                  {props.status === 'reset' ? 'LOCKED OUT' : 'DELETED'}
-                </Text>
-              )}
-              <Text type="BodySmall">
-                {!!active && !!props.roleType && typeToLabel[props.roleType]}
-                {resetLabel}
-              </Text>
-            </Box>
-          </Box>
-        </ClickableBox>
-        {!active && !Styles.isMobile && props.youCanManageMembers && (
-          <Box style={styles.buttonBarContainer}>
-            <ButtonBar>
-              {props.status !== 'deleted' && (
-                <Button
-                  small={true}
-                  label="Re-Admit"
-                  onClick={props.onReAddToTeam}
-                  type="Success"
-                  waiting={props.waitingForAdd}
-                  disabled={props.waitingForRemove}
-                />
-              )}
-              <Button
-                small={true}
-                label="Remove"
-                onClick={props.onRemoveFromTeam}
-                type="Dim"
-                waiting={props.waitingForRemove}
-                disabled={props.waitingForAdd}
-              />
-            </ButtonBar>
-          </Box>
-        )}
-        <Box style={styles.chatIconContainer}>
-          {(active || isLargeScreen) && (
-            // Desktop & mobile large screen - display on the far right of the first row
-            // Also when user is active
-            <Icon
-              onClick={props.onChat}
-              style={
-                Styles.isMobile
-                  ? Styles.collapseStyles([styles.chatButtonMobile, styles.chatButtonMobileSmallTop])
-                  : styles.chatButtonDesktop
-              }
-              fontSize={Styles.isMobile ? 20 : 16}
-              type="iconfont-chat"
-            />
-          )}
-        </Box>
-      </Box>
-      {!active && Styles.isMobile && props.youCanManageMembers && (
-        <Box style={styles.innerContainerBottom}>
-          <ButtonBar direction="row">
-            {props.status !== 'deleted' && (
-              <Button
-                small={true}
-                label="Re-Admit"
-                onClick={props.onReAddToTeam}
-                type="Success"
-                waiting={props.waitingForAdd}
-                disabled={props.waitingForRemove}
-              />
-            )}
-            <Button
-              small={true}
-              label="Remove"
-              onClick={props.onRemoveFromTeam}
-              type="Dim"
-              waiting={props.waitingForRemove}
-              disabled={props.waitingForAdd}
-            />
-          </ButtonBar>
-          {!isLargeScreen && (
-            // Mobile small screens - for inactive user
-            // display next to reset / deleted controls
-            <Icon
-              onClick={props.onChat}
-              style={Styles.collapseStyles([
-                styles.chatButtonMobile,
-                active && styles.chatButtonMobileSmallTop,
-              ])}
-              fontSize={20}
-              type="iconfont-chat"
-            />
-          )}
-        </Box>
-      )}
-    </Box>
+          <Kb.Avatar username={props.username} size={Styles.isMobile ? 48 : 32} />
+          <Kb.Box style={styles.nameContainer}>
+            <Kb.Box style={Styles.globalStyles.flexBoxRow}>{usernameDisplay}</Kb.Box>
+            <Kb.Box style={styles.nameContainerInner}>{descriptionLabel}</Kb.Box>
+          </Kb.Box>
+        </Kb.ClickableBox>
+      </Kb.Box>
+    </Kb.Box>
   )
 }
 

--- a/shared/teams/team/rows/helpers.tsx
+++ b/shared/teams/team/rows/helpers.tsx
@@ -31,21 +31,26 @@ export const getOrderedMemberArray = (
   yourOperations: Types.TeamOperations
 ): Array<Types.MemberInfo> =>
   memberInfo
-    ? [...memberInfo.values()].sort((a, b) => {
-        // Get listFirst out of the way
-        if (yourOperations.listFirst && a.username === you) {
-          return -1
-        } else if (yourOperations.listFirst && b.username === you) {
-          return 1
-        }
+    ? [...memberInfo.values()]
+        .sort((a, b) => {
+          // Get listFirst out of the way
+          if (yourOperations.listFirst && a.username === you) {
+            return -1
+          } else if (yourOperations.listFirst && b.username === you) {
+            return 1
+          }
 
-        const weights = getWeights(yourOperations.manageMembers)
-        // Diff the statuses then types. If they're both the same sort alphabetically
-        const diff1 = weights[a.status] - weights[b.status]
-        const diff2 = weights[a.type] - weights[b.type]
-        return diff1 || diff2 || a.username.localeCompare(b.username)
-      })
+          const weights = getWeights(yourOperations.manageMembers)
+          // Diff the statuses then types. If they're both the same sort alphabetically
+          const diff1 = weights[a.status] - weights[b.status]
+          const diff2 = weights[a.type] - weights[b.type]
+          return diff1 || diff2 || a.username.localeCompare(b.username)
+        })
+        .filter(m => m.type !== 'restrictedbot' && m.type !== 'bot')
     : []
+
+export const getOrderedBotsArray = (memberInfo: Map<string, Types.MemberInfo> | undefined) =>
+  memberInfo ? [...memberInfo.values()].filter(m => m.type === 'restrictedbot' || m.type === 'bot') : []
 
 export const sortInvites = (a: Types.InviteInfo, b: Types.InviteInfo) =>
   (a.email || a.username || a.name || a.id || '').localeCompare(b.email || b.username || b.name || b.id || '')

--- a/shared/teams/team/rows/helpers.tsx
+++ b/shared/teams/team/rows/helpers.tsx
@@ -50,7 +50,11 @@ export const getOrderedMemberArray = (
     : []
 
 export const getOrderedBotsArray = (memberInfo: Map<string, Types.MemberInfo> | undefined) =>
-  memberInfo ? [...memberInfo.values()].filter(m => m.type === 'restrictedbot' || m.type === 'bot') : []
+  memberInfo
+    ? [...memberInfo.values()]
+        .sort((a, b) => a.username.localeCompare(b.username))
+        .filter(m => m.type === 'restrictedbot' || m.type === 'bot')
+    : []
 
 export const sortInvites = (a: Types.InviteInfo, b: Types.InviteInfo) =>
   (a.email || a.username || a.name || a.id || '').localeCompare(b.email || b.username || b.name || b.id || '')

--- a/shared/teams/team/rows/index.tsx
+++ b/shared/teams/team/rows/index.tsx
@@ -1,9 +1,10 @@
 import * as Types from '../../../constants/types/teams'
-import {getOrderedMemberArray, sortInvites} from './helpers'
+import {getOrderedMemberArray, sortInvites, getOrderedBotsArray} from './helpers'
 
 type HeaderRow = {key: string; type: 'header'}
 type TabsRow = {key: string; type: 'tabs'}
 type MemberRow = {key: string; username: string; type: 'member'}
+type BotRow = {key: string; username: string; type: 'bot'}
 type InviteRow =
   | {key: string; label: string; type: 'invites-divider'}
   | {key: string; username: string; type: 'invites-request'}
@@ -16,7 +17,7 @@ type SubteamRow =
   | {key: string; type: 'subteam-none'}
 type SettingsRow = {key: string; type: 'settings'}
 type LoadingRow = {key: string; type: 'loading'}
-export type Row = HeaderRow | TabsRow | MemberRow | InviteRow | SubteamRow | SettingsRow | LoadingRow
+export type Row = HeaderRow | TabsRow | MemberRow | BotRow | InviteRow | SubteamRow | SettingsRow | LoadingRow
 
 const makeRows = (
   details: Types.TeamDetails,
@@ -32,6 +33,19 @@ const makeRows = (
           key: `member:${user.username}`,
           type: 'member' as const,
           username: user.username,
+        }))
+      )
+      if (details.memberCount > 0 && !details.members) {
+        // loading
+        rows.push({key: 'loading', type: 'loading'})
+      }
+      break
+    case 'bots':
+      rows.push(
+        ...getOrderedBotsArray(details.members).map(bot => ({
+          key: `bot:${bot.username}`,
+          type: 'bot' as const,
+          username: bot.username,
         }))
       )
       if (details.memberCount > 0 && !details.members) {

--- a/shared/teams/team/rows/render.tsx
+++ b/shared/teams/team/rows/render.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Types from '../../../constants/types/teams'
 import {Row} from '.'
 import MemberRow from './member-row/container'
+import BotRow from './bot-row/container'
 import {RequestRow, InviteRow, InvitesEmptyRow, DividerRow} from './invite-row'
 import {SubteamAddRow, SubteamIntroRow, SubteamNoneRow, SubteamTeamRow} from './subteam-row'
 import LoadingRow from './loading'
@@ -14,6 +15,8 @@ const renderRow = (row: Row, teamID: Types.TeamID) => {
       return <TeamHeaderRow teamID={teamID} />
     case 'member':
       return <MemberRow teamID={teamID} username={row.username} />
+    case 'bot':
+      return <BotRow teamID={teamID} username={row.username} />
     case 'invites-invite':
       return <InviteRow teamID={teamID} id={row.id} />
     case 'invites-request':

--- a/shared/teams/team/tabs/container.tsx
+++ b/shared/teams/team/tabs/container.tsx
@@ -14,14 +14,19 @@ export default Container.connect(
   (state, {teamID, selectedTab, setSelectedTab}: OwnProps) => {
     const teamDetails = Constants.getTeamDetails(state, teamID)
     const yourOperations = Constants.getCanPerformByID(state, teamID)
+    const _bots = [...(teamDetails.members?.values() ?? [])].filter(
+      m => m.type === 'restrictedbot' || m.type === 'bot'
+    )
+    const _memberCount = teamDetails.memberCount - _bots.length
     return {
       admin: yourOperations.manageMembers,
+      botCount: _bots.length,
       loading: anyWaiting(
         state,
         Constants.teamWaitingKey(teamDetails.teamname),
         Constants.teamTarsWaitingKey(teamDetails.teamname)
       ),
-      memberCount: teamDetails.memberCount,
+      memberCount: _memberCount,
       newTeamRequests: state.teams.newTeamRequests,
       numInvites: teamDetails.invites?.size ?? 0,
       numRequests: teamDetails.requests?.size ?? 0,
@@ -37,6 +42,7 @@ export default Container.connect(
   (stateProps, _, ownProps) => {
     return {
       admin: stateProps.admin,
+      botCount: stateProps.botCount,
       loading: stateProps.loading,
       memberCount: stateProps.memberCount,
       newRequests: stateProps.newTeamRequests.get(ownProps.teamID) || 0,

--- a/shared/teams/team/tabs/container.tsx
+++ b/shared/teams/team/tabs/container.tsx
@@ -1,3 +1,4 @@
+import * as BotsGen from '../../../actions/bots-gen'
 import * as Constants from '../../../constants/teams'
 import * as Types from '../../../constants/types/teams'
 import Tabs from '.'
@@ -17,8 +18,11 @@ export default Container.connect(
     const _bots = [...(teamDetails.members?.values() ?? [])].filter(
       m => m.type === 'restrictedbot' || m.type === 'bot'
     )
+    const _featuredBotsMap = state.chat2.featuredBotsMap
     const _memberCount = teamDetails.memberCount - _bots.length
     return {
+      _bots,
+      _featuredBotsMap,
       admin: yourOperations.manageMembers,
       botCount: _bots.length,
       loading: anyWaiting(
@@ -38,11 +42,18 @@ export default Container.connect(
       teamname: teamDetails.teamname,
     }
   },
-  () => ({}),
-  (stateProps, _, ownProps) => {
+  dispatch => ({
+    _searchFeaturedBot: (query: string) => dispatch(BotsGen.createSearchFeaturedBots({query})),
+  }),
+  (stateProps, dispatchProps, ownProps) => {
     return {
       admin: stateProps.admin,
       botCount: stateProps.botCount,
+      loadBots: () =>
+        stateProps._bots.map(
+          bot =>
+            !stateProps._featuredBotsMap.has(bot.username) && dispatchProps._searchFeaturedBot(bot.username)
+        ),
       loading: stateProps.loading,
       memberCount: stateProps.memberCount,
       newRequests: stateProps.newTeamRequests.get(ownProps.teamID) || 0,

--- a/shared/teams/team/tabs/container.tsx
+++ b/shared/teams/team/tabs/container.tsx
@@ -15,22 +15,18 @@ export default Container.connect(
   (state, {teamID, selectedTab, setSelectedTab}: OwnProps) => {
     const teamDetails = Constants.getTeamDetails(state, teamID)
     const yourOperations = Constants.getCanPerformByID(state, teamID)
-    const _bots = [...(teamDetails.members?.values() ?? [])].filter(
-      m => m.type === 'restrictedbot' || m.type === 'bot'
-    )
+
     const _featuredBotsMap = state.chat2.featuredBotsMap
-    const _memberCount = teamDetails.memberCount - _bots.length
+    const _members = teamDetails.members
     return {
-      _bots,
       _featuredBotsMap,
+      _members,
       admin: yourOperations.manageMembers,
-      botCount: _bots.length,
       loading: anyWaiting(
         state,
         Constants.teamWaitingKey(teamDetails.teamname),
         Constants.teamTarsWaitingKey(teamDetails.teamname)
       ),
-      memberCount: _memberCount,
       newTeamRequests: state.teams.newTeamRequests,
       numInvites: teamDetails.invites?.size ?? 0,
       numRequests: teamDetails.requests?.size ?? 0,
@@ -46,16 +42,17 @@ export default Container.connect(
     _searchFeaturedBot: (query: string) => dispatch(BotsGen.createSearchFeaturedBots({query})),
   }),
   (stateProps, dispatchProps, ownProps) => {
+    const _bots = [...(stateProps._members?.values() ?? [])].filter(
+      m => m.type === 'restrictedbot' || m.type === 'bot'
+    )
     return {
       admin: stateProps.admin,
-      botCount: stateProps.botCount,
       loadBots: () =>
-        stateProps._bots.map(
+        _bots.map(
           bot =>
             !stateProps._featuredBotsMap.has(bot.username) && dispatchProps._searchFeaturedBot(bot.username)
         ),
       loading: stateProps.loading,
-      memberCount: stateProps.memberCount,
       newRequests: stateProps.newTeamRequests.get(ownProps.teamID) || 0,
       numInvites: stateProps.numInvites,
       numRequests: stateProps.numRequests,

--- a/shared/teams/team/tabs/index.stories.tsx
+++ b/shared/teams/team/tabs/index.stories.tsx
@@ -4,6 +4,7 @@ import TeamTabs from '.'
 
 const commonProps = {
   admin: false,
+  loadBots: action('loadBots'),
   loading: false,
   memberCount: 12,
   newRequests: 1,

--- a/shared/teams/team/tabs/index.tsx
+++ b/shared/teams/team/tabs/index.tsx
@@ -13,6 +13,7 @@ import {
 type TeamTabsProps = {
   admin: boolean
   memberCount: number
+  botCount: number
   newRequests: number
   numInvites: number
   numRequests: number
@@ -57,7 +58,7 @@ const TeamTabs = (props: TeamTabsProps) => {
 
   tabs.push(
     <Box key="bots" style={styles.tabTextContainer}>
-      <TabText selected={props.selectedTab === 'bots'} text={`Bots (BOT NUMBER)`} />
+      <TabText selected={props.selectedTab === 'bots'} text={`Bots (${props.botCount})`} />
     </Box>
   )
 

--- a/shared/teams/team/tabs/index.tsx
+++ b/shared/teams/team/tabs/index.tsx
@@ -19,6 +19,7 @@ type TeamTabsProps = {
   numRequests: number
   numSubteams: number
   resetUserCount: number
+  loadBots: () => void
   loading: boolean
   selectedTab?: string
   setSelectedTab: (arg0: Types.TabKey) => void
@@ -92,6 +93,9 @@ const TeamTabs = (props: TeamTabsProps) => {
     const key = tab && tab.key
     if (key) {
       if (key !== 'loadingIndicator') {
+        if (key === 'bots') {
+          props.loadBots()
+        }
         props.setSelectedTab(key)
       } else {
         props.setSelectedTab('members')

--- a/shared/teams/team/tabs/index.tsx
+++ b/shared/teams/team/tabs/index.tsx
@@ -55,6 +55,12 @@ const TeamTabs = (props: TeamTabsProps) => {
     )
   }
 
+  tabs.push(
+    <Box key="bots" style={styles.tabTextContainer}>
+      <TabText selected={props.selectedTab === 'bots'} text={`Bots (BOT NUMBER)`} />
+    </Box>
+  )
+
   if (props.numSubteams > 0 || props.showSubteams) {
     tabs.push(
       <TabText

--- a/shared/teams/team/tabs/index.tsx
+++ b/shared/teams/team/tabs/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as Types from '../../../constants/types/teams'
 import {Badge, Box, Icon, ProgressIndicator, Tabs, Text} from '../../../common-adapters'
+import flags from '../../../util/feature-flags'
 import {
   globalColors,
   globalMargins,
@@ -12,8 +13,6 @@ import {
 
 type TeamTabsProps = {
   admin: boolean
-  memberCount: number
-  botCount: number
   newRequests: number
   numInvites: number
   numRequests: number
@@ -35,10 +34,7 @@ const TabText = ({selected, text}: {selected: boolean; text: string}) => (
 const TeamTabs = (props: TeamTabsProps) => {
   const tabs = [
     <Box key="members" style={styles.tabTextContainer}>
-      <TabText
-        selected={props.selectedTab === 'members'}
-        text={props.memberCount === -1 ? 'Members' : `Members (${props.memberCount})`}
-      />
+      <TabText selected={props.selectedTab === 'members'} text="Members" />
       {!!props.resetUserCount && <Badge badgeNumber={props.resetUserCount} badgeStyle={styles.badge} />}
     </Box>,
   ]
@@ -57,11 +53,13 @@ const TeamTabs = (props: TeamTabsProps) => {
     )
   }
 
-  tabs.push(
-    <Box key="bots" style={styles.tabTextContainer}>
-      <TabText selected={props.selectedTab === 'bots'} text={`Bots (${props.botCount})`} />
-    </Box>
-  )
+  if (flags.botUI) {
+    tabs.push(
+      <Box key="bots" style={styles.tabTextContainer}>
+        <TabText selected={props.selectedTab === 'bots'} text="Bots" />
+      </Box>
+    )
+  }
 
   if (props.numSubteams > 0 || props.showSubteams) {
     tabs.push(


### PR DESCRIPTION
This PR adds a bots tab similar to the one in the chat infopanel which lists the bots and restricted bots in a team. There's a menu on each of these items, but it's not hooked up to anything yet - that'll come in a separate PR.