### PR TITLE
Show correct user and avatar for SBS resolved system message

### DIFF
--- a/shared/chat/conversation/messages/system-sbs-resolve/index.tsx
+++ b/shared/chat/conversation/messages/system-sbs-resolve/index.tsx
@@ -11,14 +11,6 @@ type Props = {
   you: string
 }
 
-const connectedUsernamesProps = {
-  colorFollowing: true,
-  inline: true,
-  onUsernameClicked: 'profile',
-  type: 'BodySmallSemibold',
-  underline: true,
-} as const
-
 const formatAssertion = (serviceUser: string, service: ServiceIdWithContact, isYou: boolean): string => {
   switch (service) {
     case 'phone':

--- a/shared/chat/conversation/messages/system-sbs-resolve/index.tsx
+++ b/shared/chat/conversation/messages/system-sbs-resolve/index.tsx
@@ -20,27 +20,14 @@ const connectedUsernamesProps = {
 } as const
 
 const formatAssertion = (serviceUser: string, service: ServiceIdWithContact, isYou: boolean): string => {
-  if (isYou) {
-    return formatAssertionYou(serviceUser, service)
-  }
   switch (service) {
     case 'phone':
-      return `verified their phone number ${e164ToDisplay('+' + serviceUser)}`
+      return `verified ${isYou ? 'your' : 'their'} phone number ${e164ToDisplay('+' + serviceUser)}`
     case 'email':
-      return `verified their email address ${serviceUser}`
+      return `verified ${isYou ? 'your' : 'their'} email address ${serviceUser}`
     default:
-      return `proved they are ${serviceUser} on ${serviceIdToPrettyName(service) || service}`
-  }
-}
-
-const formatAssertionYou = (serviceUser: string, service: ServiceIdWithContact): string => {
-  switch (service) {
-    case 'phone':
-      return `verified your phone number ${e164ToDisplay('+' + serviceUser)}`
-    case 'email':
-      return `verified your email address ${serviceUser}`
-    default:
-      return `proved you are ${serviceUser} on ${serviceIdToPrettyName(service) || service}`
+      return `proved ${isYou ? 'you' : 'they'} are ${serviceUser} on ${serviceIdToPrettyName(service) ||
+        service}`
   }
 }
 
@@ -50,8 +37,7 @@ const SBSProvedNotice = (props: Props) => {
   return (
     <UserNotice>
       <Kb.Text type="BodySmall">
-        {isYou ? 'You' : <Kb.ConnectedUsernames {...connectedUsernamesProps} usernames={[prover]} />} can read
-        this chat now because {isYou ? 'you' : 'they'}{' '}
+        {isYou && 'You'} can read this chat now because {isYou ? 'you' : 'they'}{' '}
         {assertionService && formatAssertion(assertionUsername, assertionService, isYou)}.
       </Kb.Text>
     </UserNotice>

--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -69,6 +69,8 @@ const getUsernameToShow = (
       return message.usernames.includes(you) ? '' : message.author
     case 'systemJoined':
       return message.joiners.length + message.leavers.length > 1 ? '' : message.author
+    case 'systemSBSResolved':
+      return message.prover
   }
   return message.author
 }


### PR DESCRIPTION
before: 
![Screen Shot 2019-12-18 at 1 39 36 PM](https://user-images.githubusercontent.com/54032873/71113638-08888180-219c-11ea-8936-597d07f34fb4.png)

after:
![Screen Shot 2019-12-18 at 1 39 45 PM](https://user-images.githubusercontent.com/54032873/71113654-0f16f900-219c-11ea-99dd-31b252beb3f9.png)

