### PR TITLE
fix: migrate added to convo sys messages

### DIFF
--- a/shared/chat/conversation/messages/system-users-added-to-conv/index.tsx
+++ b/shared/chat/conversation/messages/system-users-added-to-conv/index.tsx
@@ -13,20 +13,11 @@ type YouAddedProps = {
 const YouAdded = (props: YouAddedProps) => (
   <UserNotice>
     <Kb.Text type="BodySmall">
-      <Kb.ConnectedUsernames
-        inline={true}
-        type="BodySmallSemibold"
-        onUsernameClicked="profile"
-        colorFollowing={true}
-        underline={true}
-        usernames={[props.author]}
-      />{' '}
       added you
       {!!props.otherUsers.length && [
         props.otherUsers.length === 1 ? ' and ' : ', ',
         ...getAddedUsernames(props.otherUsers),
-      ]}
-      {!props.otherUsers.length && ' '}
+      ]}{' '}
       to #{props.channelname}.
     </Kb.Text>
   </UserNotice>

--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -66,7 +66,7 @@ const getUsernameToShow = (
     case 'pin':
       return message.author
     case 'systemUsersAddedToConversation':
-      return message.usernames.includes(you) ? '' : message.author
+      return message.author
     case 'systemJoined':
       return message.joiners.length + message.leavers.length > 1 ? '' : message.author
   }


### PR DESCRIPTION
Fixes issue where "user added you to #channel" messages did not show an avatar and were aligned weirdly.