### PR TITLE
Fix show typing on relogin screen

### DIFF
--- a/shared/login/relogin/index.native.tsx
+++ b/shared/login/relogin/index.native.tsx
@@ -26,7 +26,7 @@ class LoginRender extends React.Component<Props, State> {
       onChangeText: password => this.props.passwordChange(password),
       onEnterKeyDown: () => this.props.onSubmit(),
       placeholder: 'Password',
-      secureTextEntry: true,
+      secureTextEntry: !this.props.showTyping,
       type: this.props.showTyping ? 'text' : 'password',
     }
 


### PR DESCRIPTION
@keybase/react-hackers CC @cecileboucheron 

"Show typing" was broken (the form stayed in password mode) on the relogin screen on mobile.

It looks like it's because `secureTextEntry` is always set to true starting in #20563, and will always be in password mode if it's set; tested this PR fixes it.
