### PR TITLE
tlf_journal: protect against crasher during `resolveBranch`

### DIFF
--- a/go/kbfs/kbfsmd/id.go
+++ b/go/kbfs/kbfsmd/id.go
@@ -99,6 +99,11 @@ func (id *ID) UnmarshalText(buf []byte) error {
 	return id.UnmarshalBinary(bytes)
 }
 
+// IsValid returns whether the ID is valid.
+func (id ID) IsValid() bool {
+	return id.h.IsValid()
+}
+
 // ParseID parses a hex encoded ID. Returns ID{} and an InvalidIDError
 // on failure.
 func ParseID(s string) (ID, error) {

--- a/go/kbfs/libkbfs/block_journal_test.go
+++ b/go/kbfs/libkbfs/block_journal_test.go
@@ -51,6 +51,7 @@ func makeFakeBlockJournalEntryFuture(t *testing.T) blockJournalEntryFuture {
 			},
 			kbfsmd.RevisionInitial,
 			false,
+			nil,
 			false,
 			false,
 			codec.UnknownFieldSetHandler{},
@@ -467,13 +468,13 @@ func TestBlockJournalFlush(t *testing.T) {
 		var rev kbfsmd.Revision
 		if end > firstValidJournalOrdinal+1 {
 			partialEntries, _, rev, err = j.getNextEntriesToFlush(
-				ctx, end-1, maxJournalBlockFlushBatchSize)
+				ctx, end-1, maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 			require.NoError(t, err)
 			require.Equal(t, rev, kbfsmd.RevisionUninitialized)
 		}
 
 		entries, b, rev, err := j.getNextEntriesToFlush(ctx, end,
-			maxJournalBlockFlushBatchSize)
+			maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 		require.NoError(t, err)
 		require.Equal(t, partialEntries.length()+1, entries.length())
 		require.Equal(t, rev, kbfsmd.RevisionUninitialized)
@@ -552,7 +553,7 @@ func flushBlockJournalOne(ctx context.Context, t *testing.T,
 	first, err := j.j.readEarliestOrdinal()
 	require.NoError(t, err)
 	entries, b, _, err := j.getNextEntriesToFlush(ctx, first+1,
-		maxJournalBlockFlushBatchSize)
+		maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 	require.NoError(t, err)
 	require.Equal(t, 1, entries.length())
 	err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
@@ -699,7 +700,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 	end, err := j.end()
 	require.NoError(t, err)
 	entries, b, _, err := j.getNextEntriesToFlush(ctx, end,
-		maxJournalBlockFlushBatchSize)
+		maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 	require.NoError(t, err)
 	require.Equal(t, 0, entries.length())
 	require.Equal(t, int64(0), b)
@@ -719,7 +720,7 @@ func TestBlockJournalFlushMDRevMarker(t *testing.T) {
 
 	// Put a revision marker
 	rev := kbfsmd.Revision(10)
-	err := j.markMDRevision(ctx, rev, false)
+	err := j.markMDRevision(ctx, rev, kbfsmd.ID{}, false)
 	require.NoError(t, err)
 
 	blockServer := NewBlockServerMemory(log)
@@ -732,7 +733,7 @@ func TestBlockJournalFlushMDRevMarker(t *testing.T) {
 	last, err := j.j.readLatestOrdinal()
 	require.NoError(t, err)
 	entries, b, gotRev, err := j.getNextEntriesToFlush(ctx, last+1,
-		maxJournalBlockFlushBatchSize)
+		maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 	require.NoError(t, err)
 	require.Equal(t, rev, gotRev)
 	require.Equal(t, 2, entries.length())
@@ -766,7 +767,7 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 
 	// Put a revision marker and say it's from a local squash.
 	rev := kbfsmd.Revision(10)
-	err := j.markMDRevision(ctx, rev, true)
+	err := j.markMDRevision(ctx, rev, kbfsmd.ID{}, true)
 	require.NoError(t, err)
 
 	// Do another, that isn't from a local squash.
@@ -775,7 +776,7 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 	data4 := []byte{13, 14, 15, 16}
 	_, _, _ = putBlockData(ctx, t, j, data4)
 	rev++
-	err = j.markMDRevision(ctx, rev, false)
+	err = j.markMDRevision(ctx, rev, kbfsmd.ID{}, false)
 	require.NoError(t, err)
 
 	ignoredBytes, err := j.ignoreBlocksAndMDRevMarkers(
@@ -795,7 +796,7 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 	last, err := j.j.readLatestOrdinal()
 	require.NoError(t, err)
 	entries, b, gotRev, err := j.getNextEntriesToFlush(ctx, last+1,
-		maxJournalBlockFlushBatchSize)
+		maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 	require.NoError(t, err)
 	require.Equal(t, rev-1, gotRev)
 	require.Equal(t, 6, entries.length())
@@ -834,7 +835,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	// Put a revision marker
 	rev := kbfsmd.Revision(9)
 	firstRev := rev
-	err := j.markMDRevision(ctx, rev, false)
+	err := j.markMDRevision(ctx, rev, kbfsmd.ID{}, false)
 	require.NoError(t, err)
 
 	data2 := []byte{4, 5, 6, 7}
@@ -842,7 +843,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 
 	// Put a revision marker
 	rev = kbfsmd.Revision(10)
-	err = j.markMDRevision(ctx, rev, false)
+	err = j.markMDRevision(ctx, rev, kbfsmd.ID{}, false)
 	require.NoError(t, err)
 
 	data3 := []byte{8, 9, 10, 11, 12}
@@ -852,7 +853,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 
 	// Put a revision marker
 	rev = kbfsmd.Revision(11)
-	err = j.markMDRevision(ctx, rev, false)
+	err = j.markMDRevision(ctx, rev, kbfsmd.ID{}, false)
 	require.NoError(t, err)
 
 	ignoredBytes, err := j.ignoreBlocksAndMDRevMarkers(
@@ -869,7 +870,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	last, err := j.j.readLatestOrdinal()
 	require.NoError(t, err)
 	entries, b, gotRev, err := j.getNextEntriesToFlush(ctx, last+1,
-		maxJournalBlockFlushBatchSize)
+		maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.RevisionUninitialized, gotRev)
 	require.Equal(t, 7, entries.length())
@@ -916,7 +917,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 
 	// Put a revision marker
 	rev := kbfsmd.Revision(10)
-	err := j.markMDRevision(ctx, rev, false)
+	err := j.markMDRevision(ctx, rev, kbfsmd.ID{}, false)
 	require.NoError(t, err)
 
 	data3 := []byte{9, 10, 11, 12}
@@ -926,7 +927,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 
 	// Put a revision marker
 	rev = kbfsmd.Revision(11)
-	err = j.markMDRevision(ctx, rev, false)
+	err = j.markMDRevision(ctx, rev, kbfsmd.ID{}, false)
 	require.NoError(t, err)
 
 	savedBlocks := []kbfsblock.ID{bID1, bID2, bID3, bID4}
@@ -941,7 +942,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 		last, err := j.j.readLatestOrdinal()
 		require.NoError(t, err)
 		entries, b, _, err := j.getNextEntriesToFlush(ctx, last+1,
-			maxJournalBlockFlushBatchSize)
+			maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 		require.NoError(t, err)
 		err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
 			bcache, reporter, tlfID, tlf.CanonicalName("fake TLF"),
@@ -968,7 +969,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	end, err := j.end()
 	require.NoError(t, err)
 	entries, b, gotRev, err := j.getNextEntriesToFlush(ctx, end,
-		maxJournalBlockFlushBatchSize)
+		maxJournalBlockFlushBatchSize, kbfsmd.ID{})
 	require.NoError(t, err)
 	require.Equal(t, 0, entries.length())
 	require.Equal(t, kbfsmd.RevisionUninitialized, gotRev)
@@ -1184,4 +1185,50 @@ func TestBlockJournalUnflushedBytesIgnore(t *testing.T) {
 	require.Equal(t, int64(len(data1)), ignoredBytes)
 
 	requireCounts(len(data1)+len(data2), len(data2), 2*filesPerBlockMax)
+}
+
+// Regression test for HOTPOT-1553 -- make sure that if there's a
+// crash after resolving an MD conflict but before ignoring the MD
+// markers in the block journal, the journal won't mistakenly flush MD
+// revisions before the resolved blocks have been flushed.
+func TestBlockJournalIgnoreMDRevMarkerByID(t *testing.T) {
+	ctx, cancel, tempdir, _, j := setupBlockJournalTest(t)
+	defer teardownBlockJournalTest(ctx, t, cancel, tempdir, j)
+
+	// Put some blocks.
+	data1 := []byte{1, 2, 3, 4}
+	_, _, _ = putBlockData(ctx, t, j, data1)
+	data2 := []byte{5, 6, 7, 8}
+	_, _, _ = putBlockData(ctx, t, j, data2)
+
+	// Put a revision marker and say it's from a local squash.
+	rev := kbfsmd.Revision(10)
+	journalID1 := kbfsmd.FakeID(1)
+	err := j.markMDRevision(ctx, rev, journalID1, true)
+	require.NoError(t, err)
+
+	// Do another, that isn't from a local squash.
+	data3 := []byte{9, 10, 11, 12}
+	_, _, _ = putBlockData(ctx, t, j, data3)
+	data4 := []byte{13, 14, 15, 16}
+	_, _, _ = putBlockData(ctx, t, j, data4)
+	rev++
+	err = j.markMDRevision(ctx, rev, journalID1, false)
+	require.NoError(t, err)
+
+	t.Log("When the journal ID is current, we may flush the latest MD " +
+		"revision after flushing the blocks")
+	last, err := j.j.readLatestOrdinal()
+	require.NoError(t, err)
+	_, _, gotRev, err := j.getNextEntriesToFlush(
+		ctx, last+1, maxJournalBlockFlushBatchSize, journalID1)
+	require.NoError(t, err)
+	require.Equal(t, rev, gotRev)
+
+	t.Log("When the journal ID has changed, we may not flush any MD revisions")
+	journalID2 := kbfsmd.FakeID(2)
+	_, _, gotRev, err = j.getNextEntriesToFlush(
+		ctx, last+1, maxJournalBlockFlushBatchSize, journalID2)
+	require.NoError(t, err)
+	require.Equal(t, kbfsmd.RevisionUninitialized, gotRev)
 }

--- a/go/kbfs/libkbfs/journal_md_ops_test.go
+++ b/go/kbfs/libkbfs/journal_md_ops_test.go
@@ -378,7 +378,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	firstRevision := kbfsmd.Revision(1)
 	initialRmd := makeMDForJournalMDOpsTest(t, config, id, h, firstRevision)
 	j := tlfJournal.mdJournal
-	initialMdID, err := j.put(ctx, config.Crypto(), config.KeyManager(),
+	initialMdID, _, err := j.put(ctx, config.Crypto(), config.KeyManager(),
 		config.BlockSplitter(), initialRmd, true)
 	require.NoError(t, err)
 
@@ -391,7 +391,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 			config.Codec(), config.KeyManager(),
 			config.KBPKI(), config.KBPKI(), config, mdID, true)
 		require.NoError(t, err)
-		mdID, err = j.put(ctx, config.Crypto(), config.KeyManager(),
+		mdID, _, err = j.put(ctx, config.Crypto(), config.KeyManager(),
 			config.BlockSplitter(), rmd, false)
 		require.NoError(t, err)
 	}

--- a/go/kbfs/libkbfs/md_journal.go
+++ b/go/kbfs/libkbfs/md_journal.go
@@ -159,6 +159,13 @@ type mdJournal struct {
 	// flushing. This doesn't need to be persisted for the same
 	// reason as branchID.
 	lastMdID kbfsmd.ID
+
+	// journalID is a unique identifier for this journal since the
+	// last time, renewed the last time it was completely cleared.  It
+	// must be persisted in a file, since it is referenced
+	// persistently in the block journal.  It's used to help clear md
+	// markers in the block journal atomically.
+	journalID kbfsmd.ID
 }
 
 func makeMDJournalWithIDJournal(
@@ -502,13 +509,65 @@ func (j mdJournal) getMDAndExtra(ctx context.Context, entry mdIDJournalEntry,
 	return rmd, extra, timestamp, nil
 }
 
+type mdJournalInfo struct {
+	ID kbfsmd.ID
+}
+
+func (j mdJournal) journalInfoPath() string {
+	return filepath.Join(j.j.j.dir, "info")
+}
+
+// getOrCreateJournalID returns the unique ID of the journal, renewed
+// the last time it was cleared.
+func (j *mdJournal) getOrCreateJournalID() (kbfsmd.ID, error) {
+	if j.journalID.IsValid() {
+		return j.journalID, nil
+	}
+
+	// Read it from the file, if the file exists.
+	p := j.journalInfoPath()
+	var info mdJournalInfo
+	err := kbfscodec.DeserializeFromFile(j.codec, p, &info)
+	switch {
+	case err == nil:
+		j.journalID = info.ID
+		return info.ID, nil
+	case ioutil.IsNotExist(errors.Cause(err)):
+		// Continue.
+	default:
+		return kbfsmd.ID{}, err
+	}
+
+	// Read latest entry ID and serialize it into the info file.  We
+	// use the latest entry, rather than the earliest, because when
+	// resolving branches sometimes the earliest entries (local
+	// squashes) are preserved.  It doesn't really matter which ID we
+	// pick as long as it is unique after a branch resolution/clear,
+	// and persisted across restarts.
+	entry, exists, err := j.j.getLatestEntry()
+	if err != nil {
+		return kbfsmd.ID{}, err
+	}
+	if !exists {
+		// No journal ID yet.
+		return kbfsmd.ID{}, nil
+	}
+	info.ID = entry.ID
+	err = kbfscodec.SerializeToFile(j.codec, info, p)
+	if err != nil {
+		return kbfsmd.ID{}, err
+	}
+	j.journalID = info.ID
+	return info.ID, nil
+}
+
 // putMD stores the given metadata under its ID, if it's not already
 // stored. The extra metadata is put separately, since sometimes,
 // (e.g., when converting to a branch) we don't need to put it.
-func (j mdJournal) putMD(rmd kbfsmd.RootMetadata) (kbfsmd.ID, error) {
+func (j mdJournal) putMD(rmd kbfsmd.RootMetadata) (mdID kbfsmd.ID, err error) {
 	// TODO: Make crypto and RMD wrap errors.
 
-	err := rmd.IsLastModifiedBy(j.uid, j.key)
+	err = rmd.IsLastModifiedBy(j.uid, j.key)
 	if err != nil {
 		return kbfsmd.ID{}, err
 	}
@@ -829,6 +888,7 @@ func (j *mdJournal) convertToBranch(
 
 	j.j = tempJournal
 	j.branchID = bid
+	j.journalID = kbfsmd.ID{}
 
 	return nil
 }
@@ -980,6 +1040,7 @@ func (j *mdJournal) clearHelper(ctx context.Context, bid kbfsmd.BranchID,
 	if head == (ImmutableBareRootMetadata{}) {
 		// The journal has been flushed but not cleared yet.
 		j.branchID = kbfsmd.NullBranchID
+		j.journalID = kbfsmd.ID{}
 		return nil
 	}
 
@@ -1005,6 +1066,7 @@ func (j *mdJournal) clearHelper(ctx context.Context, bid kbfsmd.BranchID,
 	}
 
 	j.branchID = kbfsmd.NullBranchID
+	j.journalID = kbfsmd.ID{}
 
 	// No need to set lastMdID in this case.
 
@@ -1218,7 +1280,7 @@ func (j *mdJournal) put(
 	ctx context.Context, signer kbfscrypto.Signer,
 	ekg encryptionKeyGetter, bsplit data.BlockSplitter, rmd *RootMetadata,
 	isLocalSquash bool) (
-	mdID kbfsmd.ID, err error) {
+	mdID, journalID kbfsmd.ID, err error) {
 	j.log.CDebugf(ctx, "Putting MD for TLF=%s with rev=%s bid=%s",
 		rmd.TlfID(), rmd.Revision(), rmd.BID())
 	defer func() {
@@ -1231,7 +1293,7 @@ func (j *mdJournal) put(
 
 	head, err := j.getLatest(ctx, true)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	mStatus := rmd.MergedStatus()
@@ -1246,7 +1308,7 @@ func (j *mdJournal) put(
 		}
 
 		if rmd.BID() == kbfsmd.NullBranchID && j.branchID == kbfsmd.NullBranchID {
-			return kbfsmd.ID{}, errors.New(
+			return kbfsmd.ID{}, kbfsmd.ID{}, errors.New(
 				"Unmerged put with rmd.BID() == j.branchID == kbfsmd.NullBranchID")
 		}
 
@@ -1285,25 +1347,26 @@ func (j *mdJournal) put(
 	// The below is code common to all the cases.
 
 	if (mStatus == kbfsmd.Merged) != (rmd.BID() == kbfsmd.NullBranchID) {
-		return kbfsmd.ID{}, errors.Errorf(
+		return kbfsmd.ID{}, kbfsmd.ID{}, errors.Errorf(
 			"mStatus=%s doesn't match bid=%s", mStatus, rmd.BID())
 	}
 
 	// If we're trying to push a merged MD onto a branch, return a
 	// conflict error so the caller can retry with an unmerged MD.
 	if mStatus == kbfsmd.Merged && j.branchID != kbfsmd.NullBranchID {
-		return kbfsmd.ID{}, MDJournalConflictError{}
+		return kbfsmd.ID{}, kbfsmd.ID{}, MDJournalConflictError{}
 	}
 
 	if rmd.BID() != j.branchID {
-		return kbfsmd.ID{}, errors.Errorf(
+		return kbfsmd.ID{}, kbfsmd.ID{}, errors.Errorf(
 			"Branch ID mismatch: expected %s, got %s",
 			j.branchID, rmd.BID())
 	}
 
 	if isLocalSquash && rmd.BID() != kbfsmd.NullBranchID {
-		return kbfsmd.ID{}, errors.Errorf("A local squash must have a null branch ID,"+
-			" but this one has bid=%s", rmd.BID())
+		return kbfsmd.ID{}, kbfsmd.ID{},
+			errors.Errorf("A local squash must have a null branch ID,"+
+				" but this one has bid=%s", rmd.BID())
 	}
 
 	// Check permissions and consistency with head, if it exists.
@@ -1312,11 +1375,11 @@ func (j *mdJournal) put(
 			ctx, j.teamMemChecker, j.codec, j.uid, j.key, head.RootMetadata,
 			rmd.bareMd, head.extra, rmd.extra)
 		if err != nil {
-			return kbfsmd.ID{}, err
+			return kbfsmd.ID{}, kbfsmd.ID{}, err
 		}
 		if !ok {
 			// TODO: Use a non-server error.
-			return kbfsmd.ID{}, kbfsmd.ServerErrorUnauthorized{}
+			return kbfsmd.ID{}, kbfsmd.ID{}, kbfsmd.ServerErrorUnauthorized{}
 		}
 
 		// Consistency checks
@@ -1324,7 +1387,7 @@ func (j *mdJournal) put(
 			err = head.CheckValidSuccessorForServer(
 				head.mdID, rmd.bareMd)
 			if err != nil {
-				return kbfsmd.ID{}, err
+				return kbfsmd.ID{}, kbfsmd.ID{}, err
 			}
 		}
 
@@ -1333,11 +1396,12 @@ func (j *mdJournal) put(
 		if isLocalSquash {
 			entry, exists, err := j.j.getLatestEntry()
 			if err != nil {
-				return kbfsmd.ID{}, err
+				return kbfsmd.ID{}, kbfsmd.ID{}, err
 			}
 			if exists && !entry.IsLocalSquash {
-				return kbfsmd.ID{}, errors.Errorf("Local squash is not preceded "+
-					"by a local squash (head=%s)", entry.ID)
+				return kbfsmd.ID{}, kbfsmd.ID{},
+					errors.Errorf("Local squash is not preceded "+
+						"by a local squash (head=%s)", entry.ID)
 			}
 		}
 	}
@@ -1345,31 +1409,31 @@ func (j *mdJournal) put(
 	// Ensure that the block changes are properly unembedded.
 	if rmd.data.Changes.Info.BlockPointer == data.ZeroPtr &&
 		!bsplit.ShouldEmbedData(rmd.data.Changes.SizeEstimate()) {
-		return kbfsmd.ID{},
+		return kbfsmd.ID{}, kbfsmd.ID{},
 			errors.New("MD has embedded block changes, but shouldn't")
 	}
 
 	err = encryptMDPrivateData(
 		ctx, j.codec, j.crypto, signer, ekg, j.uid, rmd)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	err = rmd.bareMd.IsValidAndSigned(
 		ctx, j.codec, j.teamMemChecker, rmd.extra, j.key,
 		j.osg.OfflineAvailabilityForID(j.tlfID))
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	id, err := j.putMD(rmd.bareMd)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	wkbNew, rkbNew, err := j.putExtraMetadata(rmd.bareMd, rmd.extra)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	newEntry := mdIDJournalEntry{
@@ -1390,19 +1454,24 @@ func (j *mdJournal) put(
 		// make sense.
 		err = j.j.replaceHead(newEntry)
 		if err != nil {
-			return kbfsmd.ID{}, err
+			return kbfsmd.ID{}, kbfsmd.ID{}, err
 		}
 	} else {
 		err = j.j.append(rmd.Revision(), newEntry)
 		if err != nil {
-			return kbfsmd.ID{}, err
+			return kbfsmd.ID{}, kbfsmd.ID{}, err
 		}
 	}
 
 	// Since the journal is now non-empty, clear lastMdID.
 	j.lastMdID = kbfsmd.ID{}
 
-	return id, nil
+	journalID, err = j.getOrCreateJournalID()
+	if err != nil {
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
+	}
+
+	return id, journalID, nil
 }
 
 // clear removes all the journal entries, and deletes the
@@ -1439,8 +1508,8 @@ func (j *mdJournal) clear(ctx context.Context, bid kbfsmd.BranchID) error {
 
 func (j *mdJournal) resolveAndClear(
 	ctx context.Context, signer kbfscrypto.Signer, ekg encryptionKeyGetter,
-	bsplit data.BlockSplitter, mdcache MDCache, bid kbfsmd.BranchID, rmd *RootMetadata) (
-	mdID kbfsmd.ID, err error) {
+	bsplit data.BlockSplitter, mdcache MDCache, bid kbfsmd.BranchID,
+	rmd *RootMetadata) (mdID, journalID kbfsmd.ID, err error) {
 	j.log.CDebugf(ctx, "Resolve and clear, branch %s, resolve rev %d",
 		bid, rmd.Revision())
 	defer func() {
@@ -1453,26 +1522,29 @@ func (j *mdJournal) resolveAndClear(
 
 	// The resolution must not have a branch ID.
 	if rmd.BID() != kbfsmd.NullBranchID {
-		return kbfsmd.ID{}, errors.Errorf("Resolution MD has branch ID: %s", rmd.BID())
+		return kbfsmd.ID{}, kbfsmd.ID{},
+			errors.Errorf("Resolution MD has branch ID: %s", rmd.BID())
 	}
 
 	// The branch ID must match our current state.
 	if bid == kbfsmd.NullBranchID {
-		return kbfsmd.ID{}, errors.New("Cannot resolve master branch")
+		return kbfsmd.ID{}, kbfsmd.ID{},
+			errors.New("Cannot resolve master branch")
 	}
 	if j.branchID != bid {
-		return kbfsmd.ID{}, errors.Errorf("Resolve and clear for branch %s "+
-			"while on branch %s", bid, j.branchID)
+		return kbfsmd.ID{}, kbfsmd.ID{},
+			errors.Errorf("Resolve and clear for branch %s "+
+				"while on branch %s", bid, j.branchID)
 	}
 
 	earliestBranchRevision, err := j.j.readEarliestRevision()
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	latestRevision, err := j.j.readLatestRevision()
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	// First make a new journal to hold the block.
@@ -1480,7 +1552,7 @@ func (j *mdJournal) resolveAndClear(
 	// Give this new journal a new ID journal.
 	idJournalTempDir, err := ioutil.TempDir(j.dir, "md_journal")
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	// TODO: If we crash without removing the temp dir, it should
@@ -1489,7 +1561,7 @@ func (j *mdJournal) resolveAndClear(
 	j.log.CDebugf(ctx, "Using temp dir %s for new IDs", idJournalTempDir)
 	otherIDJournal, err := makeMdIDJournal(j.codec, idJournalTempDir)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 	defer func() {
 		j.log.CDebugf(ctx, "Removing temp dir %s", idJournalTempDir)
@@ -1505,7 +1577,7 @@ func (j *mdJournal) resolveAndClear(
 		ctx, j.uid, j.key, j.codec, j.crypto, j.clock, j.teamMemChecker, j.osg,
 		j.tlfID, j.mdVer, j.dir, otherIDJournal, j.log, j.overrideTlfID)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	// Put the local squashes back into the new journal, since they
@@ -1514,7 +1586,7 @@ func (j *mdJournal) resolveAndClear(
 		for ; earliestBranchRevision <= latestRevision; earliestBranchRevision++ {
 			entry, err := j.j.readJournalEntry(earliestBranchRevision)
 			if err != nil {
-				return kbfsmd.ID{}, err
+				return kbfsmd.ID{}, kbfsmd.ID{}, err
 			}
 			if !entry.IsLocalSquash {
 				break
@@ -1522,14 +1594,15 @@ func (j *mdJournal) resolveAndClear(
 			j.log.CDebugf(ctx, "Preserving entry %s", entry.ID)
 			err = otherIDJournal.append(earliestBranchRevision, entry)
 			if err != nil {
-				return kbfsmd.ID{}, err
+				return kbfsmd.ID{}, kbfsmd.ID{}, err
 			}
 		}
 	}
 
-	mdID, err = otherJournal.put(ctx, signer, ekg, bsplit, rmd, true)
+	mdID, journalID, err = otherJournal.put(
+		ctx, signer, ekg, bsplit, rmd, true)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	// Transform this journal into the new one.
@@ -1542,7 +1615,7 @@ func (j *mdJournal) resolveAndClear(
 	oldIDJournalTempDir := idJournalTempDir + ".old"
 	dir, err := j.j.move(oldIDJournalTempDir)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	j.log.CDebugf(ctx, "Moved old journal from %s to %s",
@@ -1550,7 +1623,7 @@ func (j *mdJournal) resolveAndClear(
 
 	otherIDJournalOldDir, err := otherJournal.j.move(dir)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	// Set new journal to one with the new revision.
@@ -1562,7 +1635,7 @@ func (j *mdJournal) resolveAndClear(
 	*j, *otherJournal = *otherJournal, *j
 	err = otherJournal.clearHelper(ctx, bid, earliestBranchRevision)
 	if err != nil {
-		return kbfsmd.ID{}, err
+		return kbfsmd.ID{}, kbfsmd.ID{}, err
 	}
 
 	// Make the defer above remove the old temp dir.
@@ -1573,7 +1646,7 @@ func (j *mdJournal) resolveAndClear(
 		mdcache.Delete(j.tlfID, rev, bid)
 	}
 
-	return mdID, nil
+	return mdID, journalID, nil
 }
 
 // markLatestAsLocalSquash marks the head revision as a local squash,


### PR DESCRIPTION
A user hit the following issue:

1. Their client completed a large conflict resolution, and called `tlfJournal.resolveBranch()` to finalize it.
2. The new commit was written to a new mdJournal directory, which was then swapped into place, making it the main MD journal.
3. Then, KBFS restarted, _before_ `resolveBranch()` had a chance to mark all the MD revision markers in the block journal as ignorable.
4. After the restart, the journal resumed flushing blocks. Concurrently, the user wrote more revisions into the MD journal, re-using some of the same revision numbers that had previously been conflict-resolved away in step 1.
5. While flushing blocks, when the TLF journal discovered a revision marker for an old MD revision (which had originally been resolved and squashed in step 1), it decided it was ok to flush a _new_ revision with that same revision number.  This resulted in the revision being live to other clients _before_ the blocks associated with that revision were available, and other clients could not read the TLF.

To protect against such a race, this commit adds a new notion of a "journal ID" for the MD journal.  Each time the MD journal is cleared or resolved, and then a new revision is written into it, it gets a new unique ID that is persisted to a file.  Also, each MD revision marker gets labeled with the current MD journal ID.  When flushing, the code ignores any MD revision marker that doesn't match the current MD journal ID.  That way if KBFS crashes/restarts after clearing the MD journal, but before updating the block journal, the old MD revision markers will be properly ignored when the flush resumes.

Issue: HOTPOT-1553