### PR TITLE
Bot message icon update

### DIFF
--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -47,6 +47,7 @@ export default Container.connect(
       _participants: meta.participants,
       _teamname: meta.teamname,
       author: ownProps.message.author,
+      botUsername: ownProps.message.type === 'text' ? ownProps.message.botUsername : undefined,
       deviceName: ownProps.message.deviceName,
       deviceRevokedAt: ownProps.message.deviceRevokedAt,
       deviceType: ownProps.message.deviceType,
@@ -227,6 +228,7 @@ export default Container.connect(
     return {
       attachTo: ownProps.attachTo,
       author: stateProps.author,
+      botUsername: stateProps.botUsername,
       deviceName: stateProps.deviceName,
       deviceRevokedAt: stateProps.deviceRevokedAt,
       deviceType: stateProps.deviceType,

--- a/shared/chat/conversation/messages/message-popup/exploding/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/index.tsx
@@ -1,15 +1,5 @@
 import * as React from 'react'
-import {
-  Avatar,
-  Box2,
-  ConnectedUsernames,
-  FloatingMenu,
-  Icon,
-  MenuItems,
-  ProgressIndicator,
-  Text,
-  PopupHeaderText,
-} from '../../../../../common-adapters'
+import * as Kb from '../../../../../common-adapters'
 import * as Styles from '../../../../../styles'
 import {formatTimeForPopup, formatTimeForRevoked, msToDHMS} from '../../../../../util/timestamp'
 import {addTicker, removeTicker, TickerID} from '../../../../../util/second-timer'
@@ -22,12 +12,13 @@ const headerIconHeight = Styles.isMobile ? 96 : 72
 type Props = {
   attachTo?: () => React.Component<any> | null
   author: string
+  botUsername?: string
   deviceName: string
   deviceRevokedAt?: number
   deviceType: DeviceType
   explodesAt: number
   hideTimer: boolean
-  items: MenuItems
+  items: Kb.MenuItems
   onHidden: () => void
   position: Position
   style?: Styles.StylesCrossPlatform
@@ -72,22 +63,22 @@ class ExplodingPopupHeader extends React.Component<Props, State> {
   }
 
   render() {
-    const {author, deviceName, deviceRevokedAt, hideTimer, timestamp, yourMessage} = this.props
+    const {author, botUsername, deviceName, deviceRevokedAt, hideTimer, timestamp, yourMessage} = this.props
     const whoRevoked = yourMessage ? 'You' : author
     return (
-      <Box2 direction="vertical" fullWidth={true} style={styles.popupContainer}>
-        <Icon style={styles.headerIcon} type={headerIconType} />
-        <Box2 direction="vertical" style={styles.messageInfoContainer}>
-          <Box2 direction="vertical">
-            <Text type="BodySmall" style={{color: Styles.globalColors.black}}>
+      <Kb.Box2 direction="vertical" fullWidth={true} style={styles.popupContainer}>
+        <Kb.Icon style={styles.headerIcon} type={headerIconType} />
+        <Kb.Box2 direction="vertical" style={styles.messageInfoContainer}>
+          <Kb.Box2 direction="vertical">
+            <Kb.Text type="BodySmall" style={{color: Styles.globalColors.black}}>
               EXPLODING MESSAGE
-            </Text>
-          </Box2>
-          <Box2 direction="horizontal">
-            <Text type="BodySmall">by</Text>
-            <Box2 direction="horizontal" gap="xtiny" gapStart={true} style={styles.user}>
-              <Avatar username={author} size={16} onClick="profile" />
-              <ConnectedUsernames
+            </Kb.Text>
+          </Kb.Box2>
+          <Kb.Box2 direction="horizontal">
+            <Kb.Text type="BodySmall">by</Kb.Text>
+            <Kb.Box2 direction="horizontal" gap="xtiny" gapStart={true} style={styles.user}>
+              <Kb.Avatar username={author} size={16} onClick="profile" />
+              <Kb.ConnectedUsernames
                 onUsernameClicked="profile"
                 colorFollowing={true}
                 colorYou={true}
@@ -95,34 +86,50 @@ class ExplodingPopupHeader extends React.Component<Props, State> {
                 underline={true}
                 type="BodySmallSemibold"
               />
-            </Box2>
-          </Box2>
-          <Box2 direction="horizontal">
-            <Text center={true} type="BodySmall">
+            </Kb.Box2>
+          </Kb.Box2>
+          <Kb.Box2 direction="horizontal">
+            <Kb.Text center={true} type="BodySmall">
               from device {deviceName}
-            </Text>
-          </Box2>
-          <Box2 direction="horizontal">
-            <Text center={true} type="BodySmall">
+            </Kb.Text>
+          </Kb.Box2>
+          {botUsername && (
+            <Kb.Box2 direction="horizontal">
+              <Kb.Text type="BodySmall">also encrypted for</Kb.Text>
+              <Kb.Box2 direction="horizontal" gap="xtiny" gapStart={true} style={{alignItems: 'center'}}>
+                <Kb.Avatar username={botUsername} size={16} onClick="profile" />
+                <Kb.ConnectedUsernames
+                  onUsernameClicked="profile"
+                  colorFollowing={true}
+                  colorYou={true}
+                  usernames={[botUsername]}
+                  underline={true}
+                  type="BodySmallSemibold"
+                />
+              </Kb.Box2>
+            </Kb.Box2>
+          )}
+          <Kb.Box2 direction="horizontal">
+            <Kb.Text center={true} type="BodySmall">
               using exploding key
-            </Text>
-          </Box2>
-          <Box2 direction="horizontal">
-            <Text center={true} type="BodySmall">
+            </Kb.Text>
+          </Kb.Box2>
+          <Kb.Box2 direction="horizontal">
+            <Kb.Text center={true} type="BodySmall">
               {formatTimeForPopup(timestamp)}
-            </Text>
-          </Box2>
-        </Box2>
+            </Kb.Text>
+          </Kb.Box2>
+        </Kb.Box2>
         {!!deviceRevokedAt && (
-          <PopupHeaderText
+          <Kb.PopupHeaderText
             color={Styles.globalColors.white}
             backgroundColor={Styles.globalColors.blue}
             style={styles.revokedAt}
           >
             {whoRevoked} revoked this device on {formatTimeForRevoked(deviceRevokedAt)}.
-          </PopupHeaderText>
+          </Kb.PopupHeaderText>
         )}
-        <Box2
+        <Kb.Box2
           direction="vertical"
           gap="xsmall"
           fullWidth={true}
@@ -137,21 +144,21 @@ class ExplodingPopupHeader extends React.Component<Props, State> {
           ])}
         >
           {hideTimer ? (
-            <ProgressIndicator white={true} style={{height: 17, width: 17}} />
+            <Kb.ProgressIndicator white={true} style={{height: 17, width: 17}} />
           ) : (
-            <Box2 direction="horizontal" gap="tiny" gapStart={true} gapEnd={true}>
-              <Icon
+            <Kb.Box2 direction="horizontal" gap="tiny" gapStart={true} gapEnd={true}>
+              <Kb.Icon
                 type="iconfont-timer"
                 fontSize={Styles.isMobile ? 20 : 16}
                 color={Styles.globalColors.white}
               />
-              <Text style={{alignSelf: 'center', color: Styles.globalColors.white}} type="BodySemibold">
+              <Kb.Text style={{alignSelf: 'center', color: Styles.globalColors.white}} type="BodySemibold">
                 {msToDHMS(this.props.explodesAt - Date.now())}
-              </Text>
-            </Box2>
+              </Kb.Text>
+            </Kb.Box2>
           )}
-        </Box2>
-      </Box2>
+        </Kb.Box2>
+      </Kb.Box2>
     )
   }
 }
@@ -167,7 +174,7 @@ const ExplodingPopupMenu = (props: Props) => {
   }
 
   return (
-    <FloatingMenu
+    <Kb.FloatingMenu
       attachTo={props.attachTo}
       closeOnSelect={true}
       header={header}

--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -140,6 +140,10 @@ export default Container.namedConnect(
     const authorIsAdmin = teamname
       ? TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'admin')
       : false
+    const authorIsBot = teamname
+      ? TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'restrictedbot') ||
+        TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'bot')
+      : false
     const authorIsOwner = teamname
       ? TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'owner')
       : false
@@ -148,6 +152,7 @@ export default Container.namedConnect(
     return {
       _you: state.config.username,
       authorIsAdmin,
+      authorIsBot,
       authorIsOwner,
       botAlias,
       centeredOrdinal,
@@ -204,6 +209,7 @@ export default Container.namedConnect(
 
     return {
       authorIsAdmin: stateProps.authorIsAdmin,
+      authorIsBot: stateProps.authorIsBot,
       authorIsOwner: stateProps.authorIsOwner,
       botAlias: stateProps.botAlias,
       centeredOrdinal: stateProps.centeredOrdinal,

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -44,6 +44,7 @@ import {formatTimeForChat} from '../../../../util/timestamp'
 export type Props = {
   authorIsAdmin?: boolean
   authorIsOwner?: boolean
+  authorIsBot?: boolean
   botAlias: string
   centeredOrdinal: Types.CenterOrdinalHighlightMode
   conversationIDKey: Types.ConversationIDKey
@@ -198,6 +199,9 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                   />
                 </Kb.WithTooltip>
               )}
+              {this.props.authorIsBot && (
+                <Kb.Icon fontSize={16} color={Styles.globalColors.black_20} type="iconfont-nav-2-robot" />
+              )}
               <Kb.Text
                 type="BodyTiny"
                 style={Styles.collapseStyles([
@@ -207,11 +211,6 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               >
                 {formatTimeForChat(this.props.message.timestamp)}
               </Kb.Text>
-              {this._getKeyedBot() && (
-                <Kb.WithTooltip tooltip={`Encrypted for @${this._getKeyedBot()}`}>
-                  <Kb.Icon fontSize={14} color={Styles.globalColors.black} type="iconfont-nav-2-robot" />
-                </Kb.WithTooltip>
-              )}
             </Kb.Box2>
           </Kb.Box2>
           <Kb.Box2
@@ -425,6 +424,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       this.props.showCoinsIcon ? 24 : 0, // coin stack
       exploded || Styles.isMobile ? 0 : 16, // ... menu
       exploding ? (Styles.isMobile ? 57 : 46) : 0, // exploding
+      this._getKeyedBot() && !this.props.authorIsBot ? 24 : 0,
     ].filter(Boolean)
     const padding = Styles.globalMargins.tiny
     const width =
@@ -566,6 +566,17 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
             )}
             {this.props.showCoinsIcon && (
               <Kb.Icon type="icon-stellar-coins-stacked-16" style={styles.paddingLeftTiny} />
+            )}
+            {this._getKeyedBot() && !this.props.authorIsBot && (
+              <Kb.WithTooltip tooltip={`Encrypted for @${this._getKeyedBot()}`}>
+                <Kb.Icon
+                  fontSize={16}
+                  color={Styles.globalColors.black_20}
+                  type="iconfont-nav-2-robot"
+                  onClick={() => null}
+                  style={styles.paddingLeftTiny}
+                />
+              </Kb.WithTooltip>
             )}
             {showMenuButton ? (
               <Kb.Box className="WrapperMessage-buttons">
@@ -793,7 +804,6 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       timestamp: Styles.platformStyles({
-        common: {paddingLeft: Styles.globalMargins.xtiny},
         isElectron: {lineHeight: 19},
       }),
       timestampHighlighted: {

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -200,7 +200,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                 </Kb.WithTooltip>
               )}
               {this.props.authorIsBot && (
-                <Kb.Icon fontSize={16} color={Styles.globalColors.black_20} type="iconfont-nav-2-robot" />
+                <Kb.Icon fontSize={16} color={Styles.globalColors.black_35} type="iconfont-nav-2-robot" />
               )}
               <Kb.Text
                 type="BodyTiny"
@@ -571,7 +571,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               <Kb.WithTooltip tooltip={`Encrypted for @${this._getKeyedBot()}`}>
                 <Kb.Icon
                   fontSize={16}
-                  color={Styles.globalColors.black_20}
+                  color={Styles.globalColors.black_35}
                   type="iconfont-nav-2-robot"
                   onClick={() => null}
                   style={styles.paddingLeftTiny}


### PR DESCRIPTION
Moves the 🤖 icons on messages from/encrypted for bots so they match the new designs. Also adds the 'also encrypted for' row to message popups for exploding bot messages.