### PR TITLE
git: don't use singleOp in the journal for LFS uploads

### DIFF
--- a/go/kbfs/kbfsgit/git-remote-keybase/main.go
+++ b/go/kbfs/kbfsgit/git-remote-keybase/main.go
@@ -148,6 +148,14 @@ func start() (startErr *libfs.Error) {
 		return libfs.InitError("extra arguments specified (flags go before the first argument)")
 	}
 
+	if lfs {
+		// For LFS uploads we should be flushing the journal
+		// constantly, so we don't build up a huge batch of data that
+		// conflict resolution can't handle.  (See HOTPOT-1554.)
+		kbfsParams.TLFJournalBackgroundWorkStatus =
+			libkbfs.TLFJournalBackgroundWorkEnabled
+	}
+
 	options := kbfsgit.StartOptions{
 		KbfsParams: *kbfsParams,
 		Remote:     remote,

--- a/go/kbfs/libgit/autogit_manager_test.go
+++ b/go/kbfs/libgit/autogit_manager_test.go
@@ -47,7 +47,7 @@ func initConfigForAutogit(t *testing.T) (
 	err = config.EnableDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config.EnableJournaling(
-		ctx, tempdir, libkbfs.TLFJournalSingleOpBackgroundWorkEnabled)
+		ctx, tempdir, libkbfs.TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 
 	success = true

--- a/go/kbfs/libgit/repo_test.go
+++ b/go/kbfs/libgit/repo_test.go
@@ -45,7 +45,7 @@ func initConfig(t *testing.T) (
 	err = config.EnableDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config.EnableJournaling(
-		ctx, tempdir, libkbfs.TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, libkbfs.TLFJournalSingleOpBackgroundWorkEnabled)
 	require.NoError(t, err)
 
 	return ctx, cancel, config, tempdir

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1273,7 +1273,7 @@ func (c *ConfigLocal) EnableJournaling(
 
 	jManager = makeJournalManager(c, log, journalRoot, c.BlockCache(),
 		c.DirtyBlockCache(), c.BlockServer(), c.MDOps(), branchListener,
-		flushListener)
+		flushListener, bws)
 
 	c.SetBlockServer(jManager.blockServer())
 	c.SetMDOps(jManager.mdOps())

--- a/go/kbfs/libkbfs/journal_manager_test.go
+++ b/go/kbfs/libkbfs/journal_manager_test.go
@@ -424,7 +424,8 @@ func TestJournalManagerRestart(t *testing.T) {
 	jManager = makeJournalManager(
 		config, jManager.log, tempdir, jManager.delegateBlockCache,
 		jManager.delegateDirtyBlockCache,
-		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil)
+		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil,
+		TLFJournalBackgroundWorkPaused)
 	err = jManager.EnableExistingJournals(
 		ctx, session.UID, session.VerifyingKey, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -794,7 +795,8 @@ func TestJournalManagerEnableAuto(t *testing.T) {
 	jManager = makeJournalManager(
 		config, jManager.log, tempdir, jManager.delegateBlockCache,
 		jManager.delegateDirtyBlockCache,
-		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil)
+		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil,
+		TLFJournalBackgroundWorkPaused)
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 	err = jManager.EnableExistingJournals(
@@ -918,7 +920,8 @@ func TestJournalManagerNukeEmptyJournalsOnRestart(t *testing.T) {
 	jManager = makeJournalManager(
 		config, jManager.log, tempdir, jManager.delegateBlockCache,
 		jManager.delegateDirtyBlockCache,
-		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil)
+		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil,
+		TLFJournalBackgroundWorkPaused)
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 	err = jManager.EnableExistingJournals(
@@ -987,7 +990,8 @@ func TestJournalManagerTeamTLFWithRestart(t *testing.T) {
 	jManager = makeJournalManager(
 		config, jManager.log, tempdir, jManager.delegateBlockCache,
 		jManager.delegateDirtyBlockCache,
-		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil)
+		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil,
+		TLFJournalBackgroundWorkPaused)
 	err = jManager.EnableExistingJournals(
 		ctx, session.UID, session.VerifyingKey, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -1105,7 +1109,8 @@ func TestJournalManagerCorruptJournal(t *testing.T) {
 	jManager = makeJournalManager(
 		config, jManager.log, tempdir, jManager.delegateBlockCache,
 		jManager.delegateDirtyBlockCache,
-		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil)
+		jManager.delegateBlockServer, jManager.delegateMDOps, nil, nil,
+		TLFJournalBackgroundWorkPaused)
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 	err = jManager.EnableExistingJournals(


### PR DESCRIPTION
If a user tries to upload giant multigig files using LFS, we don't want them to be uploaded in a single MD update to the server, because it increases the risk that something will go wrong or take too much memory in conflict resolution.  Since LFS doesn't have the same locking requirements that regular git has, we can easily upload those files using the normal journal flushing procedures, without having to squash everything together first.

To do that, this commit changes the `JournalManager` to remember a default background work mode (that's already provided in the KBFS init params), and to use that whenever enabling journals.  Then, git-remote-keybase just needs to set that correctly when starting up in LFS mode.

Issue: HOTPOT-1554