### PR TITLE
Changes around block-modal

### DIFF
--- a/shared/chat/blocking/block-modal/container.tsx
+++ b/shared/chat/blocking/block-modal/container.tsx
@@ -8,7 +8,7 @@ import * as Constants from '../../../constants/users'
 import {leaveTeamWaitingKey} from '../../../constants/teams'
 
 type OwnProps = Container.RouteProps<{
-  blockByDefault?: boolean
+  blockUserByDefault?: boolean
   convID?: string
   others?: Array<string>
   team?: string
@@ -31,7 +31,7 @@ const Connect = Container.connect(
     return {
       _allKnownBlocks: state.users.blockMap,
       adderUsername,
-      blockByDefault: Container.getRouteProps(ownProps, 'blockByDefault', false),
+      blockUserByDefault: Container.getRouteProps(ownProps, 'blockUserByDefault', false),
       convID: Container.getRouteProps(ownProps, 'convID', undefined),
       finishWaiting: waitingForLeave || waitingForBlocking || waitingForReport,
       loadingWaiting: Container.anyWaiting(state, Constants.getUserBlocksWaitingKey),

--- a/shared/chat/blocking/block-modal/container.tsx
+++ b/shared/chat/blocking/block-modal/container.tsx
@@ -1,6 +1,6 @@
 import * as Container from '../../../util/container'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
-import BlockModal, {BlockType, NewBlocksMap, ReportSettings} from '.'
+import BlockModal, {BlockType, NewBlocksMap, ReportSettings, BlockModalContext} from '.'
 import * as UsersGen from '../../../actions/users-gen'
 import * as TeamsGen from '../../../actions/teams-gen'
 import * as Chat2Gen from '../../../actions/chat2-gen'
@@ -9,6 +9,7 @@ import {leaveTeamWaitingKey} from '../../../constants/teams'
 
 type OwnProps = Container.RouteProps<{
   blockUserByDefault?: boolean
+  context?: BlockModalContext
   convID?: string
   others?: Array<string>
   team?: string
@@ -32,6 +33,7 @@ const Connect = Container.connect(
       _allKnownBlocks: state.users.blockMap,
       adderUsername,
       blockUserByDefault: Container.getRouteProps(ownProps, 'blockUserByDefault', false),
+      context: Container.getRouteProps(ownProps, 'context', undefined),
       convID: Container.getRouteProps(ownProps, 'convID', undefined),
       finishWaiting: waitingForLeave || waitingForBlocking || waitingForReport,
       loadingWaiting: Container.anyWaiting(state, Constants.getUserBlocksWaitingKey),

--- a/shared/chat/blocking/block-modal/index.tsx
+++ b/shared/chat/blocking/block-modal/index.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 
+// Type for extra RouteProp passed to block modal sometimes when launching the
+// modal from specific places from the app.
 export type BlockModalContext =
   | 'message-popup-single' // message popup in 1-on-1 conv
   | 'message-popup' // message popup in bigger convs (incl. team chats)

--- a/shared/chat/blocking/block-modal/index.tsx
+++ b/shared/chat/blocking/block-modal/index.tsx
@@ -19,7 +19,7 @@ type State = {
 
 export type Props = {
   adderUsername?: string
-  blockByDefault?: boolean
+  blockUserByDefault?: boolean
   convID?: string
   finishWaiting: boolean
   isBlocked: (username: string, which: BlockType) => boolean
@@ -133,7 +133,7 @@ class BlockModal extends React.PureComponent<Props, State> {
 
     // Set default checkbox block values for adder user. We don't care if they
     // are already blocked, setting a block is idempotent.
-    if (this.props.blockByDefault && this.props.adderUsername) {
+    if (this.props.blockUserByDefault && this.props.adderUsername) {
       const map = this.state.newBlocks
       map.set(this.props.adderUsername, {chatBlocked: true, followBlocked: true})
       this.setState({newBlocks: new Map(map)})

--- a/shared/chat/blocking/block-modal/index.tsx
+++ b/shared/chat/blocking/block-modal/index.tsx
@@ -75,9 +75,9 @@ type ReportOptionsProps = {
   showIncludeTranscript: boolean
 }
 const reasons = ["I don't know this person", 'Spam', 'Harassment', 'Obscene material', 'Other...']
-const emptyReport: ReportSettings = {
+const defaultReport: ReportSettings = {
   extraNotes: '',
-  includeTranscript: false,
+  includeTranscript: true,
   reason: reasons[0],
 }
 const ReportOptions = (props: ReportOptionsProps) => {
@@ -162,13 +162,13 @@ class BlockModal extends React.PureComponent<Props, State> {
     const current = newBlocks.get(username)
     if (current) {
       if (current.report === undefined && shouldReport) {
-        current.report = {...emptyReport}
+        current.report = {...defaultReport}
       } else if (current.report && !shouldReport) {
         current.report = undefined
       }
       newBlocks.set(username, current)
     } else {
-      newBlocks.set(username, {report: {...emptyReport}})
+      newBlocks.set(username, {report: {...defaultReport}})
     }
     // Need to make a new object so the component re-renders.
     this.setState({newBlocks: new Map(newBlocks)})

--- a/shared/chat/blocking/index.stories.tsx
+++ b/shared/chat/blocking/index.stories.tsx
@@ -35,24 +35,24 @@ const load = () => {
   Sb.storiesOf('Chat/Blocking', module)
     .add('Implicit team', () => (
       <BlockModal
-        {...Sb.createNavigator({username: 'chris', others, blockByDefault: true, convID: fakeConvID})}
+        {...Sb.createNavigator({username: 'chris', others, blockUserByDefault: true, convID: fakeConvID})}
       />
     ))
     .add('Implicit team from sidebar', () => (
-      <BlockModal {...Sb.createNavigator({others, blockByDefault: true, convID: fakeConvID})} />
+      <BlockModal {...Sb.createNavigator({others, blockUserByDefault: true, convID: fakeConvID})} />
     ))
     .add('Team', () => (
       <BlockModal
         {...Sb.createNavigator({
           username: 'chris',
           team: 'keybase',
-          blockByDefault: true,
+          blockUserByDefault: true,
           convID: fakeConvID,
         })}
       />
     ))
     .add('1on1', () => (
-      <BlockModal {...Sb.createNavigator({username: 'chris', blockByDefault: true, convID: fakeConvID})} />
+      <BlockModal {...Sb.createNavigator({username: 'chris', blockUserByDefault: true, convID: fakeConvID})} />
     ))
     .add('From profile', () => <BlockModal {...Sb.createNavigator({username: 'chris'})} />)
   Sb.storiesOf('Chat/Blocking', module)

--- a/shared/chat/blocking/index.stories.tsx
+++ b/shared/chat/blocking/index.stories.tsx
@@ -52,7 +52,9 @@ const load = () => {
       />
     ))
     .add('1on1', () => (
-      <BlockModal {...Sb.createNavigator({username: 'chris', blockUserByDefault: true, convID: fakeConvID})} />
+      <BlockModal
+        {...Sb.createNavigator({username: 'chris', blockUserByDefault: true, convID: fakeConvID})}
+      />
     ))
     .add('From profile', () => <BlockModal {...Sb.createNavigator({username: 'chris'})} />)
   Sb.storiesOf('Chat/Blocking', module)

--- a/shared/chat/blocking/invitation-to-block.tsx
+++ b/shared/chat/blocking/invitation-to-block.tsx
@@ -74,7 +74,7 @@ const BlockButtons = (props: Props) => {
               path: [
                 {
                   props: {
-                    blockByDefault: true,
+                    blockUserByDefault: true,
                     convID: props.conversationID,
                     others: others,
                     team: team,

--- a/shared/chat/conversation/info-panel/container.tsx
+++ b/shared/chat/conversation/info-panel/container.tsx
@@ -128,7 +128,7 @@ const ConnectedInfoPanel = Container.connect(
         RouteTreeGen.createNavigateAppend({
           path: [
             {
-              props: {blockByDefault: true, convID: conversationIDKey, others, team},
+              props: {blockUserByDefault: true, convID: conversationIDKey, others, team},
               selected: 'chatBlockingModal',
             },
           ],

--- a/shared/chat/conversation/info-panel/menu/container.tsx
+++ b/shared/chat/conversation/info-panel/menu/container.tsx
@@ -136,7 +136,7 @@ export default Container.namedConnect(
         RouteTreeGen.createNavigateAppend({
           path: [
             {
-              props: {blockByDefault: others.length === 1, convID: conversationIDKey, others, team},
+              props: {blockUserByDefault: others.length === 1, convID: conversationIDKey, others, team},
               selected: 'chatBlockingModal',
             },
           ],

--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -26,7 +26,6 @@ export type OwnProps = {
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     const yourMessage = ownProps.message.author === state.config.username
-    console.log(state.config)
     const meta = Constants.getMeta(state, ownProps.message.conversationIDKey)
     const _canDeleteHistory =
       meta.teamType === 'adhoc' || TeamConstants.getCanPerformByID(state, meta.teamID).deleteChatHistory

--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -26,6 +26,7 @@ export type OwnProps = {
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     const yourMessage = ownProps.message.author === state.config.username
+    console.log(state.config)
     const meta = Constants.getMeta(state, ownProps.message.conversationIDKey)
     const _canDeleteHistory =
       meta.teamType === 'adhoc' || TeamConstants.getCanPerformByID(state, meta.teamID).deleteChatHistory
@@ -246,7 +247,7 @@ export default Container.connect(
       const blockModalSingle = !stateProps._teamname && stateProps._participants.length === 2
       items.push({
         danger: true,
-        icon: 'iconfont-person',
+        icon: 'iconfont-block-user',
         onClick: () => dispatchProps._onUserBlock(message, blockModalSingle),
         title: stateProps._teamname ? 'Report user' : 'Block user',
       })

--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -155,6 +155,23 @@ export default Container.connect(
         ownProps.message.downloadPath &&
         dispatch(FsGen.createOpenLocalPathInSystemFileManager({localPath: ownProps.message.downloadPath}))
     },
+    _onUserBlock: (message: Types.Message, isSingle: boolean) => {
+      dispatch(
+        RouteTreeGen.createNavigateAppend({
+          path: [
+            {
+              props: {
+                blockUserByDefault: true,
+                context: isSingle ? 'message-popup-single' : 'message-popup',
+                convID: message.conversationIDKey,
+                username: message.author,
+              },
+              selected: 'chatBlockingModal',
+            },
+          ],
+        })
+      )
+    },
   }),
   (stateProps, dispatchProps, ownProps) => {
     const authorInConv = stateProps._participants.includes(ownProps.message.author)
@@ -225,6 +242,15 @@ export default Container.connect(
       }
       items.push({icon: 'iconfont-pin', onClick: dispatchProps._onPinMessage, title: 'Pin message'})
     }
+    if (!stateProps.yourMessage && message.author) {
+      const blockModalSingle = !stateProps._teamname && stateProps._participants.length === 2
+      items.push({
+        danger: true,
+        icon: 'iconfont-person',
+        onClick: () => dispatchProps._onUserBlock(message, blockModalSingle),
+        title: stateProps._teamname ? 'Report user' : 'Block user',
+      })
+    }
     return {
       attachTo: ownProps.attachTo,
       author: stateProps.author,
@@ -234,6 +260,7 @@ export default Container.connect(
       deviceType: stateProps.deviceType,
       explodesAt: stateProps.explodesAt,
       hideTimer: stateProps.hideTimer,
+      isTeam: !!stateProps._teamname,
       items,
       onHidden: ownProps.onHidden,
       position: ownProps.position,

--- a/shared/chat/conversation/messages/message-popup/index.stories.tsx
+++ b/shared/chat/conversation/messages/message-popup/index.stories.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
   attachTo: () => null,
   isDeleteable: true,
   isKickable: true,
+  isTeam: true,
   onAddReaction: Sb.action('onAddReaction'),
   onAllMedia: Sb.action('onAllMedia'),
   onCopy: Sb.action('onCopy'),

--- a/shared/chat/conversation/messages/message-popup/index.stories.tsx
+++ b/shared/chat/conversation/messages/message-popup/index.stories.tsx
@@ -5,7 +5,7 @@ import {makeMessageAttachment, makeMessageText} from '../../../../constants/chat
 import TextPopupMenu from './text/index'
 import AttachmentPopupMenu from './attachment/index'
 import paymentPopupStories from './payment/index.stories'
-import ExplodingPopupMenu, {OwnProps as ExplodingOwnProps} from './exploding/container'
+import ExplodingPopupMenu from './exploding/container'
 import HiddenString from '../../../../util/hidden-string'
 
 const textMessage = makeMessageText({

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -99,13 +99,13 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
       })
     )
   },
-  _onUserBlock: (teamname: string, message: Types.Message) => {
+  _onUserBlock: (message: Types.Message) => {
     dispatch(
       RouteTreeGen.createNavigateAppend({
         path: [
           {
             props: {
-              blockByDefault: true,
+              blockUserByDefault: true,
               convID: message.conversationIDKey,
               username: message.author,
             },
@@ -186,7 +186,7 @@ export default Container.namedConnect(
       yourMessage,
       onUserBlock:
         message.author && !yourMessage
-          ? () => dispatchProps._onUserBlock(stateProps._teamname, message)
+          ? () => dispatchProps._onUserBlock(message)
           : undefined,
       isTeam: !!stateProps._teamname,
     }

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -99,22 +99,6 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
       })
     )
   },
-  _onUserBlock: (message: Types.Message) => {
-    dispatch(
-      RouteTreeGen.createNavigateAppend({
-        path: [
-          {
-            props: {
-              blockUserByDefault: true,
-              convID: message.conversationIDKey,
-              username: message.author,
-            },
-            selected: 'chatBlockingModal',
-          },
-        ],
-      })
-    )
-  },
   _onReply: (message: Types.Message) => {
     dispatch(
       Chat2Gen.createToggleReplyToMessage({
@@ -128,6 +112,23 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
       Chat2Gen.createMessageReplyPrivately({
         ordinal: message.ordinal,
         sourceConversationIDKey: message.conversationIDKey,
+      })
+    )
+  },
+  _onUserBlock: (message: Types.Message, isSingle: boolean) => {
+    dispatch(
+      RouteTreeGen.createNavigateAppend({
+        path: [
+          {
+            props: {
+              blockUserByDefault: true,
+              context: isSingle ? 'message-popup-single' : 'message-popup',
+              convID: message.conversationIDKey,
+              username: message.author,
+            },
+            selected: 'chatBlockingModal',
+          },
+        ],
       })
     )
   },
@@ -151,6 +152,7 @@ export default Container.namedConnect(
       mapUnfurl && mapUnfurl.mapInfo && !mapUnfurl.mapInfo.isLiveLocationDone
         ? () => openURL(mapUnfurl.url)
         : undefined
+    const blockModalSingle = !stateProps._teamname && stateProps._participants.length === 2
     return {
       attachTo: ownProps.attachTo,
       author: message.author,
@@ -162,6 +164,7 @@ export default Container.namedConnect(
       isEditable,
       isKickable: isDeleteable && !!stateProps._teamname && !yourMessage && authorInConv,
       isLocation,
+      isTeam: !!stateProps._teamname,
       onAddReaction: Container.isMobile ? () => dispatchProps._onAddReaction(message) : undefined,
       onCopy: message.type === 'text' ? () => dispatchProps._onCopy(message) : undefined,
       onDelete: isDeleteable ? () => dispatchProps._onDelete(message) : undefined,
@@ -175,6 +178,10 @@ export default Container.namedConnect(
       onReply: message.type === 'text' ? () => dispatchProps._onReply(message) : undefined,
       onReplyPrivately:
         !yourMessage && canReplyPrivately ? () => dispatchProps._onReplyPrivately(message) : undefined,
+      onUserBlock:
+        message.author && !yourMessage
+          ? () => dispatchProps._onUserBlock(message, blockModalSingle)
+          : undefined,
       onViewMap,
       onViewProfile:
         message.author && !yourMessage ? () => dispatchProps._onViewProfile(message.author) : undefined,
@@ -184,11 +191,6 @@ export default Container.namedConnect(
       timestamp: message.timestamp,
       visible: ownProps.visible,
       yourMessage,
-      onUserBlock:
-        message.author && !yourMessage
-          ? () => dispatchProps._onUserBlock(message)
-          : undefined,
-      isTeam: !!stateProps._teamname,
     }
   },
   'MessagePopupText'

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -99,6 +99,22 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
       })
     )
   },
+  _onUserBlock: (teamname: string, message: Types.Message) => {
+    dispatch(
+      RouteTreeGen.createNavigateAppend({
+        path: [
+          {
+            props: {
+              blockByDefault: true,
+              convID: message.conversationIDKey,
+              username: message.author,
+            },
+            selected: 'chatBlockingModal',
+          },
+        ],
+      })
+    )
+  },
   _onReply: (message: Types.Message) => {
     dispatch(
       Chat2Gen.createToggleReplyToMessage({
@@ -168,6 +184,11 @@ export default Container.namedConnect(
       timestamp: message.timestamp,
       visible: ownProps.visible,
       yourMessage,
+      onUserBlock:
+        message.author && !yourMessage
+          ? () => dispatchProps._onUserBlock(stateProps._teamname, message)
+          : undefined,
+      isTeam: !!stateProps._teamname,
     }
   },
   'MessagePopupText'

--- a/shared/chat/conversation/messages/message-popup/text/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/index.tsx
@@ -98,7 +98,7 @@ const TextPopupMenu = (props: Props) => {
       ? [
           {
             danger: true,
-            icon: 'iconfont-person',
+            icon: 'iconfont-block-user',
             onClick: props.onUserBlock,
             title: props.isTeam ? 'Report user' : 'Block user',
           },

--- a/shared/chat/conversation/messages/message-popup/text/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/index.tsx
@@ -24,6 +24,7 @@ type Props = {
   onReplyPrivately?: () => void
   onViewProfile?: () => void
   onViewMap?: () => void
+  onUserBlock?: () => void
   isLocation?: boolean
   position: Position
   showDivider: boolean
@@ -34,6 +35,7 @@ type Props = {
   isDeleteable: boolean
   isEditable: boolean
   isKickable: boolean
+  isTeam: boolean
 }
 
 const TextPopupMenu = (props: Props) => {
@@ -91,6 +93,16 @@ const TextPopupMenu = (props: Props) => {
       : []),
     ...(props.onViewProfile
       ? [{icon: 'iconfont-person', onClick: props.onViewProfile, title: 'View profile'}]
+      : []),
+    ...(!props.yourMessage
+      ? [
+          {
+            danger: true,
+            icon: 'iconfont-person',
+            onClick: props.onUserBlock,
+            title: props.isTeam ? 'Report user' : 'Block user',
+          },
+        ]
       : []),
   ].reduce<Kb.MenuItems>((arr, i) => {
     i && arr.push(i as Kb.MenuItem)


### PR DESCRIPTION
- Make "Include the transcript of this chat" checked by default when checking "Report user" in block modal.
   - This does not imply we are sending transcript by default whenever you block anyone - you still need to check "Report user" for transcript to even be considered.
- Add "Block user" menu item into message-popup menu (the `...` menu for text messages and exploding messages).
   - There is some logic around when to say "Block user" and "Report user", and when to use alternative label in block modal for blocking user: "Block user from messaging me directly" (instead of "Block user").