### PR TITLE
switch isBigTeam to use teamname until more team refactor is done

### DIFF
--- a/shared/teams/team/menu-container.tsx
+++ b/shared/teams/team/menu-container.tsx
@@ -17,7 +17,7 @@ type OwnProps = {
 const mapStateToProps = (state: Container.TypedState, {teamID}: OwnProps) => {
   const teamDetails = Constants.getTeamDetails(state, teamID)
   const yourOperations = Constants.getCanPerformByID(state, teamID)
-  const isBigTeam = Constants.isBigTeam(state, teamID)
+  const isBigTeam = Constants.isBigTeam(state, teamDetails.teamname)
   return {
     canCreateSubteam: yourOperations.manageSubteams,
     canDeleteTeam: yourOperations.deleteTeam && teamDetails.subteams?.size === 0,


### PR DESCRIPTION
fixes an issue where teams think they are small even when they are big in the team page menu

cc @keybase/y2ksquad @joshblum 