### PR TITLE
Fix inbox search margin.

### DIFF
--- a/shared/chat/inbox/row/chat-filter-row/index.tsx
+++ b/shared/chat/inbox/row/chat-filter-row/index.tsx
@@ -105,7 +105,7 @@ class ConversationFilterInput extends React.PureComponent<Props> {
         gapEnd={true}
         fullWidth={true}
       >
-        <Kb.HotKey hotKeys={this.hotKeys} onHotKey={this.onHotKeys} />
+        {!Styles.isMobile && <Kb.HotKey hotKeys={this.hotKeys} onHotKey={this.onHotKeys} />}
         {searchInput}
         {!this.props.isSearching && !!this.props.onNewChat && !Styles.isMobile && (
           <Kb.Box style={styles.rainbowBorder}>


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. Though, there might be a better fix (in common adapters) since we don't need these on mobile. The problem is that we were inserting gaps around the component.