### PR TITLE
libkb: use user/private rather than user/lookup

### DIFF
--- a/go/libkb/loaduser.go
+++ b/go/libkb/loaduser.go
@@ -510,7 +510,7 @@ func LoadUserFromLocalStorage(m MetaContext, uid keybase1.UID) (u *User, err err
 func LoadUserEmails(m MetaContext) (emails []keybase1.Email, err error) {
 	uid := m.G().GetMyUID()
 	res, err := m.G().API.Get(m, APIArg{
-		Endpoint:    "user/lookup",
+		Endpoint:    "user/private",
 		SessionType: APISessionTypeREQUIRED,
 		Args: HTTPArgs{
 			"uid": UIDArg(uid),


### PR DESCRIPTION
- after a few release cycles, we'll strip all private fields out of user/lookup