### PR TITLE
Bring back SystemButtons on Linux and Windows

### DIFF
--- a/shared/router-v2/header/index.desktop.tsx
+++ b/shared/router-v2/header/index.desktop.tsx
@@ -140,7 +140,6 @@ class Header extends React.PureComponent<Props> {
     // Normally this component is responsible for rendering the system buttons,
     // but if we're showing a banner then that banner component needs to do it.
     const windowDecorationsAreNeeded = !Platform.isMac && !this.props.useNativeFrame
-    const windowDecorationsDrawnByBanner = windowDecorationsAreNeeded && this.props.loggedIn
 
     // We normally have the back arrow at the top of the screen. It doesn't overlap with the system
     // icons (minimize etc) because the left nav bar pushes it to the right -- unless you're logged
@@ -216,7 +215,7 @@ class Header extends React.PureComponent<Props> {
                 />
               )}
               {!title && rightActions}
-              {windowDecorationsAreNeeded && !windowDecorationsDrawnByBanner && <SystemButtons />}
+              {windowDecorationsAreNeeded && <SystemButtons />}
             </Kb.Box2>
           </Kb.Box2>
           <Kb.Box2

--- a/shared/router-v2/header/index.desktop.tsx
+++ b/shared/router-v2/header/index.desktop.tsx
@@ -137,8 +137,6 @@ class Header extends React.PureComponent<Props> {
       showDivider = false
     }
 
-    // Normally this component is responsible for rendering the system buttons,
-    // but if we're showing a banner then that banner component needs to do it.
     const windowDecorationsAreNeeded = !Platform.isMac && !this.props.useNativeFrame
 
     // We normally have the back arrow at the top of the screen. It doesn't overlap with the system


### PR DESCRIPTION
Looks like https://github.com/keybase/client/pull/21770 removed `SystemButtons` too aggressively, so Windows and Linux with "Hide system frame" did not get the buttons properly.

`SystemButtons` + Airdrop banner thing was first introduced in:
https://github.com/keybase/client/pull/18322/files#diff-0382685f0daaa354f914a97595b9f56dR149

It looks like `windowDecorationsDrawnByBanner` is not needed anymore, because the decorations are never going to be drawn by banner because the banner is not there anymore.