### PR TITLE
Update Stellar send form placeholder for memo field

### DIFF
--- a/shared/wallets/send-form/note-and-memo/index.tsx
+++ b/shared/wallets/send-form/note-and-memo/index.tsx
@@ -170,7 +170,7 @@ class PublicMemo extends React.Component<PublicMemoProps, PublicMemoState> {
           <Kb.PlainInput
             multiline={true}
             padding={0}
-            placeholder="Add a public memo (on Stellar)"
+            placeholder="Add XLM Memo text or ID (on Stellar)"
             placeholderColor={Styles.globalColors.black_20}
             style={this.props.publicMemoOverride ? styles.inputDisabled : styles.input}
             rowsMin={Styles.isMobile ? 1 : 2}


### PR DESCRIPTION
Recently I had the misfortune of losing all of the Lumens I've been airdropped when trying to transfer them to my Coinbase account because I forgot to include a valid Memo ID. To be fair, this was my fault because I rushed through the process and clicked past the popup Coinbase displays that says a Memo ID is a requirement for receiving Lumens alongside your Stellar address.

Despite this, I think it might be helpful to highlight the importance of the memo field on the Keybase side. When I first read the text, I assumed `memo` meant an arbitrary message that describes the transaction so that's exactly how I treated it. However, according to the [Stellar developer guide](https://www.stellar.org/developers/guides/concepts/transactions.html#memo), the memo is meant to contain extra information for the receiving client to interpret and can be one of the following values:
- `MEMO_TEXT`
- `MEMO_ID`
- `MEMO_HASH`
- `MEMO_RETURN`

Given that Coinbase, one of the most popular crypto exchanges, treats the field as an ID which it uses to locate the right user, it might be nice to highlight the fact that that field can be a 64 bit unsigned int rather than any arbitrary string.

Therefore, I'm opening this PR as a suggestion to change the placeholder text for the memo field on the send form to make it more clear that it can be an ID so that crypto newbs such as myself might double check what they entered before losing money. It might also be nice to have a dropdown menu that allows the user to choose between the 4 memo types which would change the input validation rules (e.g. `MEMO_ID` cannot contain letters) but that is out of the scope of this PR.

I also ran `yarn test -u Storyshots` to update the storybook snapshot files since the html output has changed.