### PR TITLE
display sbs resolved message as join message if not author

### DIFF
--- a/shared/chat/conversation/messages/system-joined/container.tsx
+++ b/shared/chat/conversation/messages/system-joined/container.tsx
@@ -43,6 +43,7 @@ export default Container.connect(
       author: stateProps.author,
       authorIsYou: stateProps.authorIsYou,
       channelname: _meta.channelname,
+      isAdHoc: _meta.teamType === 'adhoc',
       isBigTeam: _meta.teamType === 'big',
       joiners:
         !stateProps._joiners.length && !stateProps.leavers.length ? [stateProps.author] : stateProps._joiners,

--- a/shared/chat/conversation/messages/system-joined/index.tsx
+++ b/shared/chat/conversation/messages/system-joined/index.tsx
@@ -8,6 +8,7 @@ type Props = {
   author: string
   authorIsYou: boolean
   channelname: string
+  isAdHoc: boolean
   isBigTeam: boolean
   joiners: Array<string>
   leavers: Array<string>
@@ -95,7 +96,7 @@ const JoinedUserNotice = (props: Props) => (
     <Kb.Text type="BodySmall">
       {props.authorIsYou ? 'You ' : ''}
       {props.leavers.length > props.joiners.length ? 'left' : 'joined'}{' '}
-      {props.isBigTeam ? `#${props.channelname}` : 'the team'}.
+      {props.isBigTeam ? `#${props.channelname}` : props.isAdHoc ? 'the conversation' : 'the team'}.
     </Kb.Text>
     {props.authorIsYou && props.isBigTeam && (
       <Kb.Text type="BodySmall">

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -478,7 +478,16 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
         child = <SystemInviteAccepted key="systemInviteAccepted" message={message} />
         break
       case 'systemSBSResolved':
-        child = <SystemSBSResolved key="systemSbsResolved" message={message} />
+        if (this.props.youAreAuthor) {
+          child = <SystemSBSResolved key="systemSbsResolved" message={message} />
+        } else {
+          child = (
+            <SystemJoined
+              key="systemJoined"
+              message={{...message, joiners: [message.prover], leavers: [], type: 'systemJoined'}}
+            />
+          )
+        }
         break
       case 'systemSimpleToComplex':
         child = <SystemSimpleToComplex key="systemSimpleToComplex" message={message} />


### PR DESCRIPTION
Adds some logic to render SBS resolve messages as normal join messages if you're not the author of the resolve message. Also adds logic to make the systemjoined message say 'joined the conversation' rather than 'joined the team' if you're in an adhoc team.