### PR TITLE
tweak chat module shutdown behavior

### DIFF
--- a/go/service/main.go
+++ b/go/service/main.go
@@ -421,6 +421,7 @@ func (d *Service) startChatModules() {
 		g.LiveLocationTracker.Start(context.Background(), uid)
 		g.BotCommandManager.Start(context.Background(), uid)
 		g.UIInboxLoader.Start(context.Background(), uid)
+		g.PushShutdownHook(d.stopChatModules)
 	}
 	d.purgeOldChatAttachmentData()
 }
@@ -901,7 +902,6 @@ func (d *Service) OnLogin(mctx libkb.MetaContext) error {
 	uid := d.G().Env.GetUID()
 	if !uid.IsNil() {
 		d.startChatModules()
-		d.G().PushShutdownHook(d.stopChatModules)
 		d.runTLFUpgrade()
 		d.runTrackerLoader(mctx.Ctx())
 	}


### PR DESCRIPTION
instead of conditionally pushing a shutdown hook for tearing down the chat modules, do it whenever we have successfully set them up (which can happen from a few places). 

i'm interested in doing this because these chat modules seem to survive some of the softer forms of shutdown (e.g. `keybase ctl restart` on windows). honestly though, i'm having a tough time testing this locally. all around, shutdown has a lot of side effects that are OS specific. 

one area of concern i have is simple logging out and multi-user. how is this intended to work in those cases? logout hooks vs shutdown hooks, etc. i assume we always want to tear all this stuff down, and so it's preferable that we err on the side of tearing down twice to missing it entirely?