### PR TITLE
Dismiss teams badge on mobile too

### DIFF
--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -13,7 +13,6 @@ import * as WaitingConstants from '../constants/waiting'
 import * as Types from '../constants/types/teams'
 import {memoize} from '../util/memoize'
 import {useTeamsSubscribe} from './subscriber'
-import {NavigationEventCallback} from '@react-navigation/core'
 import {useNavigationEvents} from '../util/navigation-hooks'
 
 type OwnProps = {}

--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -13,6 +13,8 @@ import * as WaitingConstants from '../constants/waiting'
 import * as Types from '../constants/types/teams'
 import {memoize} from '../util/memoize'
 import {useTeamsSubscribe} from './subscriber'
+import {NavigationEventCallback} from '@react-navigation/core'
+import {useNavigationEvents} from '../util/navigation-hooks'
 
 type OwnProps = {}
 
@@ -50,10 +52,19 @@ const Reloadable = (
     onClearBadges: () => void
   }
 ) => {
+  // On desktop, clear the badges upon navigating away from this tab. This is more reliable than nav events.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(() => () => props.onClearBadges(), [])
+  // Since this component does not unmount on mobile, also clear badge with nav events.
+  useNavigationEvents(e => {
+    if (e.type === 'willBlur') {
+      props.onClearBadges()
+    }
+  })
+
   // subscribe to teams changes
   useTeamsSubscribe()
+
   const {loadTeams, onClearBadges, ...rest} = props
   const headerActions = useHeaderActions()
 


### PR DESCRIPTION
We were previously dismissing teams badges on unmounting the teams tab. But tabs are not unmounted on mobile, so this only worked on desktop.

cc @keybase/y2ksquad 
