### PR TITLE
ost: wait for goroutines during shutdown

### DIFF
--- a/go/kbfs/search/indexed_block_db_test.go
+++ b/go/kbfs/search/indexed_block_db_test.go
@@ -25,7 +25,7 @@ func newIndexedBlockDbForTestWithStorage(
 	config := libkbfs.MakeTestConfigOrBust(t, "user1")
 	db, err := newIndexedBlockDbFromStorage(config, blockS, tlfS)
 	require.NoError(t, err)
-	return db, func() { config.Shutdown(context.Background()) }
+	return db, func() { _ = config.Shutdown(context.Background()) }
 }
 
 func newIndexedBlockDbForTest(t *testing.T) (


### PR DESCRIPTION
fixes https://ci.keyba.se/job/client/job/PR-21860/6/execution/node/4412/log/

In (should be very) rare situation `ostFsm` could happen after shutdown in test, and the logging at the beginning of it end up happen after the parent test is finished, which triggers race detector in CI. So wait for all goroutines to finish before returning from `Shutdown()`.