### PR TITLE
Channel picker for restricted bots

### DIFF
--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -270,6 +270,7 @@ type _EditBotSettingsPayload = {
   readonly username: string
   readonly allowCommands: boolean
   readonly allowMentions: boolean
+  readonly convs?: Array<string>
 }
 type _EnableAudioRecordingPayload = {
   readonly conversationIDKey: Types.ConversationIDKey

--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -188,6 +188,7 @@ type _AddAttachmentViewMessagePayload = {
 }
 type _AddBotMemberPayload = {
   readonly conversationIDKey: Types.ConversationIDKey
+  readonly convs?: Array<string>
   readonly allowCommands: boolean
   readonly allowMentions: boolean
   readonly username: string

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -3480,13 +3480,14 @@ const addBotMember = async (state: Container.TypedState, action: Chat2Gen.AddBot
 }
 
 const editBotSettings = async (state: Container.TypedState, action: Chat2Gen.EditBotSettingsPayload) => {
-  const {allowCommands, allowMentions, conversationIDKey, username} = action.payload
+  const {allowCommands, allowMentions, conversationIDKey, convs, username} = action.payload
   try {
     await RPCChatTypes.localSetBotMemberSettingsRpcPromise(
       {
         botSettings: {
           cmds: allowCommands,
           mentions: allowMentions,
+          convs,
         },
         convID: Types.keyToConversationID(conversationIDKey),
         username,

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -3486,8 +3486,8 @@ const editBotSettings = async (state: Container.TypedState, action: Chat2Gen.Edi
       {
         botSettings: {
           cmds: allowCommands,
-          mentions: allowMentions,
           convs,
+          mentions: allowMentions,
         },
         convID: Types.keyToConversationID(conversationIDKey),
         username,

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -835,6 +835,7 @@
     "addBotMember": {
       "_description": "add bot member to channel",
       "conversationIDKey": "Types.ConversationIDKey",
+      "convs?": "Array<string>",
       "allowCommands": "boolean",
       "allowMentions": "boolean",
       "username": "string",

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -861,7 +861,8 @@
       "conversationIDKey": "Types.ConversationIDKey",
       "username": "string",
       "allowCommands": "boolean",
-      "allowMentions": "boolean"
+      "allowMentions": "boolean",
+      "convs?": "Array<string>"
     },
     "loadMoreSmalls": {
       "_description": "Tell the service to give us more small teams"

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import * as Kb from '../../../common-adapters'
+import * as Styles from '../../../styles'
+import * as TeamTypes from '../../../constants/types/teams'
+import * as TeamConstants from '../../../constants/teams'
+import * as Container from '../../../util/container'
+
+type Props = {
+  installInConvs: string[]
+  setChannelPickerScreen: (show: boolean) => void
+  setInstallInConvs: (convs: string[]) => void
+  teamname: string
+}
+
+type RowProps = {
+  selected: boolean
+  channelInfo: TeamTypes.ChannelInfo
+}
+const Row = ({selected, channelInfo}: RowProps) => (
+  <Kb.Box2 direction="horizontal">
+    <Kb.Checkbox
+      checked={selected}
+      label=""
+      onCheck={() => null /* ontoggle */}
+      style={{alignSelf: 'flex-start', marginRight: 0}}
+      disabled={channelInfo.channelname.toLowerCase() === 'general'}
+    />
+    <Kb.Box2 direction="vertical">
+      <Kb.Text lineClamp={1} type="BodySecondaryLink" style={styles.channelHash}>
+        #{' '}
+        <Kb.Text type="Body" style={styles.channelText}>
+          {channelInfo.channelname}
+        </Kb.Text>
+      </Kb.Text>
+      <Kb.Text type="BodySecondaryLink">{channelInfo.description}</Kb.Text>
+    </Kb.Box2>
+  </Kb.Box2>
+)
+const ChannelPicker = (props: Props) => {
+  // TODO: consider moving state setup somewhere else
+  const channelInfos = Container.useSelector(state =>
+    TeamConstants.getTeamChannelInfos(state, props.teamname)
+  )
+}
+
+const styles = Styles.styleSheetCreate(
+  () =>
+    ({
+      channelHash: {
+        color: Styles.globalColors.black_20,
+      },
+      channelText: Styles.platformStyles({
+        isElectron: {
+          wordBreak: 'break-all',
+        },
+      }),
+    } as const)
+)
+
+export default ChannelPicker

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -26,7 +26,7 @@ const Row = ({selected, channelInfo}: RowProps) => (
       disabled={channelInfo.channelname.toLowerCase() === 'general'}
     />
     <Kb.Box2 direction="vertical">
-      <Kb.Text lineClamp={1} type="BodySecondaryLink" style={styles.channelHash}>
+      <Kb.Text lineClamp={1} type="BodySecondaryLink">
         #{' '}
         <Kb.Text type="Body" style={styles.channelText}>
           {channelInfo.channelname}
@@ -41,14 +41,17 @@ const ChannelPicker = (props: Props) => {
   const channelInfos = Container.useSelector(state =>
     TeamConstants.getTeamChannelInfos(state, props.teamname)
   )
+
+  const rows = [...channelInfos.entries()].map(([convID, channelInfo]) => (
+    <Row key={convID} selected={props.installInConvs.includes(convID)} channelInfo={channelInfo} />
+  ))
+
+  return <Kb.Box2 direction="vertical">{rows}</Kb.Box2>
 }
 
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      channelHash: {
-        color: Styles.globalColors.black_20,
-      },
       channelText: Styles.platformStyles({
         isElectron: {
           wordBreak: 'break-all',

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -130,8 +130,8 @@ const styles = Styles.styleSheetCreate(
       }),
       searchFilter: Styles.platformStyles({
         common: {
-          marginBottom: Styles.globalMargins.small,
-          marginTop: Styles.globalMargins.small,
+          marginBottom: Styles.globalMargins.xsmall,
+          marginTop: Styles.globalMargins.tiny,
         },
         isElectron: {
           marginLeft: Styles.globalMargins.small,

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -12,27 +12,32 @@ type Props = {
   teamname: string
 }
 
+const toggleChannel = (convID: string, installInConvs: string[]) => {
+  if (installInConvs.includes(convID)) {
+    return installInConvs.filter(id => id !== convID)
+  } else {
+    return installInConvs.concat([convID])
+  }
+}
+
 type RowProps = {
+  onToggle: () => void
   selected: boolean
   channelInfo: TeamTypes.ChannelInfo
 }
-const Row = ({selected, channelInfo}: RowProps) => (
-  <Kb.Box2 direction="horizontal">
-    <Kb.Checkbox
-      checked={selected}
-      label=""
-      onCheck={() => null /* ontoggle */}
-      style={{alignSelf: 'flex-start', marginRight: 0}}
-      disabled={channelInfo.channelname.toLowerCase() === 'general'}
-    />
+const Row = ({onToggle, selected, channelInfo}: RowProps) => (
+  <Kb.Box2 direction="horizontal" alignSelf="flex-start" style={{marginBottom: Styles.globalMargins.tiny}}>
+    <Kb.Checkbox checked={selected} label="" onCheck={onToggle} style={styles.channelCheckbox} />
+    <Kb.Text lineClamp={1} type="Body" style={styles.channelHash}>
+      #
+    </Kb.Text>
     <Kb.Box2 direction="vertical">
-      <Kb.Text lineClamp={1} type="BodySecondaryLink">
-        #{' '}
-        <Kb.Text type="Body" style={styles.channelText}>
-          {channelInfo.channelname}
-        </Kb.Text>
+      <Kb.Text type="Body" style={styles.channelText}>
+        {channelInfo.channelname}
       </Kb.Text>
-      <Kb.Text type="BodySecondaryLink">{channelInfo.description}</Kb.Text>
+      <Kb.Text type="Body" style={{color: Styles.globalColors.black_50}}>
+        {channelInfo.description}
+      </Kb.Text>
     </Kb.Box2>
   </Kb.Box2>
 )
@@ -43,15 +48,32 @@ const ChannelPicker = (props: Props) => {
   )
 
   const rows = [...channelInfos.entries()].map(([convID, channelInfo]) => (
-    <Row key={convID} selected={props.installInConvs.includes(convID)} channelInfo={channelInfo} />
+    <Row
+      key={convID}
+      onToggle={() => props.setInstallInConvs(toggleChannel(convID, props.installInConvs))}
+      selected={props.installInConvs.includes(convID)}
+      channelInfo={channelInfo}
+    />
   ))
 
-  return <Kb.Box2 direction="vertical">{rows}</Kb.Box2>
+  return (
+    <Kb.Box2 direction="vertical" fullWidth={true}>
+      {rows}
+    </Kb.Box2>
+  )
 }
 
 const styles = Styles.styleSheetCreate(
   () =>
     ({
+      channelCheckbox: {
+        marginRight: Styles.globalMargins.tiny,
+      },
+      channelHash: {
+        color: Styles.globalColors.black_50,
+        flexShrink: 0,
+        marginRight: Styles.globalMargins.xtiny,
+      },
       channelText: Styles.platformStyles({
         isElectron: {
           wordBreak: 'break-all',

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -2,16 +2,33 @@ import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 import * as TeamTypes from '../../../constants/types/teams'
-import * as TeamConstants from '../../../constants/teams'
-import * as Container from '../../../util/container'
-import * as TeamsGen from '../../../actions/teams-gen'
+import {memoize} from '../../../util/memoize'
+import {makeInsertMatcher} from '../../../util/string'
 
 type Props = {
+  channelInfos: Map<string, TeamTypes.ChannelInfo>
   installInConvs: string[]
   setChannelPickerScreen: (show: boolean) => void
   setInstallInConvs: (convs: string[]) => void
   teamID: TeamTypes.TeamID
+  teamName: string
 }
+
+const getChannels = memoize((channelInfos: Map<string, TeamTypes.ChannelInfo>, searchText: string) =>
+  [...channelInfos.entries()]
+    .filter(([_, channelInfo]) => {
+      if (!searchText) {
+        return true // no search text means show all
+      }
+      return (
+        // match channel name for search as subsequence (like the identity modal)
+        // match channel desc by strict substring (less noise in results)
+        channelInfo.channelname.match(makeInsertMatcher(searchText)) ||
+        channelInfo.description.match(new RegExp(searchText, 'i'))
+      )
+    })
+    .sort((a, b) => a[1].channelname.localeCompare(b[1].channelname))
+)
 
 const toggleChannel = (convID: string, installInConvs: string[]) => {
   if (installInConvs.includes(convID)) {
@@ -27,45 +44,59 @@ type RowProps = {
   channelInfo: TeamTypes.ChannelInfo
 }
 const Row = ({onToggle, selected, channelInfo}: RowProps) => (
-  <Kb.Box2 direction="horizontal" alignSelf="flex-start" style={{marginBottom: Styles.globalMargins.tiny}}>
+  <Kb.Box2
+    direction="horizontal"
+    alignSelf="flex-start"
+    style={{marginBottom: Styles.globalMargins.tiny}}
+    fullWidth={true}
+  >
     <Kb.Checkbox checked={selected} label="" onCheck={onToggle} style={styles.channelCheckbox} />
-    <Kb.Text lineClamp={1} type="Body" style={styles.channelHash}>
-      #
-    </Kb.Text>
-    <Kb.Box2 direction="vertical">
-      <Kb.Text type="Body" style={styles.channelText}>
-        {channelInfo.channelname}
-      </Kb.Text>
-      <Kb.Text type="Body" style={{color: Styles.globalColors.black_50}}>
-        {channelInfo.description}
-      </Kb.Text>
+
+    <Kb.Box2 direction="vertical" style={{flex: 1}}>
+      <Kb.Box2 direction="horizontal" alignSelf="flex-start">
+        <Kb.Text lineClamp={1} type="Body" style={styles.channelHash}>
+          #
+        </Kb.Text>
+        <Kb.Text type="Body" style={styles.channelText}>
+          {channelInfo.channelname}
+        </Kb.Text>
+      </Kb.Box2>
+      {!!channelInfo.description && (
+        <Kb.Text type="Body" lineClamp={1} style={{color: Styles.globalColors.black_50}}>
+          {channelInfo.description}
+        </Kb.Text>
+      )}
     </Kb.Box2>
   </Kb.Box2>
 )
 const ChannelPicker = (props: Props) => {
-  // TODO: consider moving state setup somewhere else
-  const dispatch = Container.useDispatch()
-  React.useEffect(() => {
-    if (!props.teamID) {
-      return
-    }
+  const {channelInfos, installInConvs, setInstallInConvs} = props
+  const [searchText, setSearchText] = React.useState('')
 
-    dispatch(TeamsGen.createGetChannels({teamID: props.teamID}))
-  }, [props.teamID])
-  const channelInfos = Container.useSelector(state => TeamConstants.getTeamChannelInfos(state, props.teamID))
-
-  const rows = [...channelInfos.entries()].map(([convID, channelInfo]) => (
+  const rows = getChannels(channelInfos, searchText).map(([convID, channelInfo]) => (
     <Row
       key={convID}
-      onToggle={() => props.setInstallInConvs(toggleChannel(convID, props.installInConvs))}
-      selected={props.installInConvs.includes(convID)}
+      onToggle={() => setInstallInConvs(toggleChannel(convID, installInConvs))}
+      selected={installInConvs.includes(convID)}
       channelInfo={channelInfo}
     />
   ))
 
   return (
     <Kb.Box2 direction="vertical" fullWidth={true}>
-      {rows}
+      <Kb.Box2 direction="horizontal" fullWidth={true}>
+        <Kb.SearchFilter
+          size="full-width"
+          icon="iconfont-search"
+          placeholderText={`Search channels in ${props.teamName}`}
+          placeholderCentered={true}
+          mobileCancelButton={true}
+          hotkey="f"
+          onChange={setSearchText}
+          style={styles.searchFilter}
+        />
+      </Kb.Box2>
+      <Kb.ScrollView style={styles.rowsContainer}>{rows}</Kb.ScrollView>
     </Kb.Box2>
   )
 }
@@ -75,8 +106,10 @@ const styles = Styles.styleSheetCreate(
     ({
       channelCheckbox: {
         marginRight: Styles.globalMargins.tiny,
+        paddingTop: 0,
       },
       channelHash: {
+        alignSelf: 'center',
         color: Styles.globalColors.black_50,
         flexShrink: 0,
         marginRight: Styles.globalMargins.xtiny,
@@ -84,6 +117,25 @@ const styles = Styles.styleSheetCreate(
       channelText: Styles.platformStyles({
         isElectron: {
           wordBreak: 'break-all',
+        },
+      }),
+      rowsContainer: Styles.platformStyles({
+        common: {
+          ...Styles.padding(0, Styles.globalMargins.small),
+        },
+        isElectron: {
+          maxHeight: 250,
+          minHeight: 250,
+        },
+      }),
+      searchFilter: Styles.platformStyles({
+        common: {
+          marginBottom: Styles.globalMargins.small,
+          marginTop: Styles.globalMargins.small,
+        },
+        isElectron: {
+          marginLeft: Styles.globalMargins.small,
+          marginRight: Styles.globalMargins.small,
         },
       }),
     } as const)

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -4,12 +4,13 @@ import * as Styles from '../../../styles'
 import * as TeamTypes from '../../../constants/types/teams'
 import * as TeamConstants from '../../../constants/teams'
 import * as Container from '../../../util/container'
+import * as TeamsGen from '../../../actions/teams-gen'
 
 type Props = {
   installInConvs: string[]
   setChannelPickerScreen: (show: boolean) => void
   setInstallInConvs: (convs: string[]) => void
-  teamname: string
+  teamID: TeamTypes.TeamID
 }
 
 const toggleChannel = (convID: string, installInConvs: string[]) => {
@@ -43,9 +44,15 @@ const Row = ({onToggle, selected, channelInfo}: RowProps) => (
 )
 const ChannelPicker = (props: Props) => {
   // TODO: consider moving state setup somewhere else
-  const channelInfos = Container.useSelector(state =>
-    TeamConstants.getTeamChannelInfos(state, props.teamname)
-  )
+  const dispatch = Container.useDispatch()
+  React.useEffect(() => {
+    if (!props.teamID) {
+      return
+    }
+
+    dispatch(TeamsGen.createGetChannels({teamID: props.teamID}))
+  }, [props.teamID])
+  const channelInfos = Container.useSelector(state => TeamConstants.getTeamChannelInfos(state, props.teamID))
 
   const rows = [...channelInfos.entries()].map(([convID, channelInfo]) => (
     <Row

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -123,6 +123,7 @@ const InstallBotPopup = (props: Props) => {
       Chat2Gen.createEditBotSettings({
         allowCommands: installWithCommands,
         allowMentions: installWithMentions,
+        convs: installInConvs,
         conversationIDKey,
         username: botUsername,
       })

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -20,7 +20,7 @@ export const useBotConversationIDKey = (inConvIDKey?: Types.ConversationIDKey, t
   React.useEffect(() => {
     if (!conversationIDKey && teamID) {
       if (!generalConvID) {
-        dispatch(Chat2Gen.createFindGeneralConvIDFromTeamID({teamID}))
+        dispatch(Chat2Gen.createFindGeneralConvIDFromTeamID({ teamID }))
       } else {
         setConversationIDKey(generalConvID)
       }
@@ -49,14 +49,15 @@ type Props = {
 }
 
 const InstallBotPopup = (props: Props) => {
-  const {botUsername, conversationIDKey} = props
+  const { botUsername, conversationIDKey } = props
 
   // state
   const [installScreen, setInstallScreen] = React.useState(false)
   const [installWithCommands, setInstallWithCommands] = React.useState(true)
   const [installWithMentions, setInstallWithMentions] = React.useState(true)
   const [installWithRestrict, setInstallWithRestrict] = React.useState(true)
-  const {commands, featured, inTeam, inTeamUnrestricted, settings} = Container.useSelector(
+  const [installInConvs, setInstallInConvs] = React.useState(undefined)
+  const { commands, featured, inTeam, inTeamUnrestricted, settings } = Container.useSelector(
     (state: Container.TypedState) => {
       let inTeam: boolean | undefined
       let teamRole: TeamTypes.TeamRoleType | null | undefined
@@ -96,6 +97,7 @@ const InstallBotPopup = (props: Props) => {
         allowCommands: installWithCommands,
         allowMentions: installWithMentions,
         conversationIDKey,
+        convs: installInConvs,
         restricted: installWithRestrict,
         username: botUsername,
       })
@@ -134,18 +136,18 @@ const InstallBotPopup = (props: Props) => {
     )
   }
   const onFeedback = () => {
-    dispatch(RouteTreeGen.createNavigateAppend({path: ['feedback']}))
+    dispatch(RouteTreeGen.createNavigateAppend({ path: ['feedback'] }))
   }
   // lifecycle
   React.useEffect(() => {
     dispatch(
-      WaitingGen.createClearWaiting({key: [Constants.waitingKeyBotAdd, Constants.waitingKeyBotRemove]})
+      WaitingGen.createClearWaiting({ key: [Constants.waitingKeyBotAdd, Constants.waitingKeyBotRemove] })
     )
-    dispatch(Chat2Gen.createRefreshBotPublicCommands({username: botUsername}))
+    dispatch(Chat2Gen.createRefreshBotPublicCommands({ username: botUsername }))
     if (conversationIDKey) {
-      dispatch(Chat2Gen.createRefreshBotRoleInConv({conversationIDKey, username: botUsername}))
+      dispatch(Chat2Gen.createRefreshBotRoleInConv({ conversationIDKey, username: botUsername }))
       if (inTeam) {
-        dispatch(Chat2Gen.createRefreshBotSettings({conversationIDKey, username: botUsername}))
+        dispatch(Chat2Gen.createRefreshBotSettings({ conversationIDKey, username: botUsername }))
       }
     }
   }, [conversationIDKey, inTeam])
@@ -156,7 +158,7 @@ const InstallBotPopup = (props: Props) => {
       <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny">
         <Kb.RadioButton
           label={
-            <Kb.Box2 direction="vertical" fullWidth={true} style={{flex: 1}}>
+            <Kb.Box2 direction="vertical" fullWidth={true} style={{ flex: 1 }}>
               <Kb.Text type="BodySemibold">Restricted Bot</Kb.Text>
               <Kb.Text type="BodySmall">Customize which messages get encrypted for this bot.</Kb.Text>
             </Kb.Box2>
@@ -166,7 +168,7 @@ const InstallBotPopup = (props: Props) => {
         />
         <Kb.RadioButton
           label={
-            <Kb.Box2 direction="vertical" fullWidth={true} style={{flex: 1}}>
+            <Kb.Box2 direction="vertical" fullWidth={true} style={{ flex: 1 }}>
               <Kb.Text type="BodySemibold">Unrestricted Bot</Kb.Text>
               <Kb.Text type="BodySmall">All messages will be encrypted for this bot.</Kb.Text>
             </Kb.Box2>
@@ -180,7 +182,7 @@ const InstallBotPopup = (props: Props) => {
   const featuredContent = !!featured && (
     <Kb.Box2
       direction="vertical"
-      style={Styles.collapseStyles([styles.container, {flex: 1, justifyContent: 'space-between'}])}
+      style={Styles.collapseStyles([styles.container, { flex: 1, justifyContent: 'space-between' }])}
       fullWidth={true}
       fullHeight={true}
       gap="tiny"
@@ -188,7 +190,7 @@ const InstallBotPopup = (props: Props) => {
       <Kb.Box2 direction="vertical" gap="small" fullWidth={true}>
         <Kb.Box2 direction="horizontal" gap="small" fullWidth={true}>
           <Kb.Avatar username={botUsername} size={64} />
-          <Kb.Box2 direction="vertical" fullWidth={true} style={{flex: 1}}>
+          <Kb.Box2 direction="vertical" fullWidth={true} style={{ flex: 1 }}>
             <Kb.Text type="BodyBigExtrabold">{featured.botAlias}</Kb.Text>
             <Kb.ConnectedUsernames
               colorFollowing={true}
@@ -211,7 +213,7 @@ const InstallBotPopup = (props: Props) => {
     <Kb.Box2 direction="vertical" gap="small" style={styles.container} fullWidth={true}>
       <Kb.Box2 direction="horizontal" gap="small" fullWidth={true}>
         <Kb.Avatar username={botUsername} size={64} />
-        <Kb.Box2 direction="vertical" fullWidth={true} style={{flex: 1}}>
+        <Kb.Box2 direction="vertical" fullWidth={true} style={{ flex: 1 }}>
           <Kb.Text type="BodyBigExtrabold">{botUsername}</Kb.Text>
           <Kb.ConnectedUsernames
             colorFollowing={true}
@@ -229,7 +231,7 @@ const InstallBotPopup = (props: Props) => {
     <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container} gap="small">
       <Kb.Box2 direction="horizontal" gap="small" fullWidth={true}>
         <Kb.Avatar username={botUsername} size={64} />
-        <Kb.Box2 direction="vertical" fullWidth={true} style={{flex: 1}}>
+        <Kb.Box2 direction="vertical" fullWidth={true} style={{ flex: 1 }}>
           <Kb.Text type="BodyBigExtrabold">{featured ? featured.botAlias : botUsername}</Kb.Text>
           <Kb.ConnectedUsernames
             colorFollowing={true}
@@ -263,22 +265,25 @@ const InstallBotPopup = (props: Props) => {
             This bot will not be able to read any other messages, channels, files, repositories, or team
             members.
           </Kb.Text>
+          <Kb.Text type="BodyBig">In these channels:</Kb.Text>
+          <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny"></Kb.Box2>
         </Kb.Box2>
       ) : (
-        <Kb.Box2 direction="vertical" gap="tiny">
-          <Kb.Text type="BodySemibold" style={{alignSelf: 'center', color: Styles.globalColors.redDark}}>
-            WARNING
+          <Kb.Box2 direction="vertical" gap="tiny">
+            <Kb.Text type="BodySemibold" style={{ alignSelf: 'center', color: Styles.globalColors.redDark }}>
+              WARNING
           </Kb.Text>
-          <Kb.Text type="BodySmall">
-            This bot will be able to read all messages, channels, files, repositories, and team members.
+            <Kb.Text type="BodySmall">
+              This bot will be able to read all messages, channels, files, repositories, and team members.
           </Kb.Text>
-          <Kb.Text type="BodySmall">
-            If you wish to customize which messages are encrypted for this bot, please go back and select the
-            restricted bot option.
+            <Kb.Text type="BodySmall">
+              If you wish to customize which messages are encrypted for this bot, please go back and select the
+              restricted bot option.
           </Kb.Text>
-        </Kb.Box2>
-      )}
-    </Kb.Box2>
+          </Kb.Box2>
+        )
+      }
+    </Kb.Box2 >
   )
 
   const content = installScreen ? installContent : featured ? featuredContent : usernameContent
@@ -364,11 +369,11 @@ const InstallBotPopup = (props: Props) => {
               {removeButton}
             </Kb.ButtonBar>
             {!!error && (
-              <Kb.Text type="Body" style={{color: Styles.globalColors.redDark}}>
+              <Kb.Text type="Body" style={{ color: Styles.globalColors.redDark }}>
                 {'Something went wrong! Please try again, or send '}
                 <Kb.Text
                   type="Body"
-                  style={{color: Styles.globalColors.redDark}}
+                  style={{ color: Styles.globalColors.redDark }}
                   underline={true}
                   onClick={onFeedback}
                 >
@@ -450,10 +455,11 @@ const PermsList = (props: PermsListProps) => {
           {props.settings.mentions && (
             <Kb.Text type="Body">{`• messages it has been mentioned in with @${props.username}`}</Kb.Text>
           )}
+          <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
         </Kb.Box2>
       ) : (
-        <Kb.ProgressIndicator />
-      )}
+          <Kb.ProgressIndicator />
+        )}
     </Kb.Box2>
   )
 }

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -124,8 +124,8 @@ const InstallBotPopup = (props: Props) => {
       Chat2Gen.createEditBotSettings({
         allowCommands: installWithCommands,
         allowMentions: installWithMentions,
-        convs: installInConvs,
         conversationIDKey,
+        convs: installInConvs,
         username: botUsername,
       })
     )
@@ -521,13 +521,13 @@ const PermsList = (props: PermsListProps) => {
             <Kb.Text type="Body">{`• messages it has been mentioned in with @${props.username}`}</Kb.Text>
           )}
           {props.settings.convs && (
-            <>
+            <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
               <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
               {props.settings.convs?.map(convID => (
                 <Kb.Text type="Body" key={convID}>{`• #${props.channelInfos.get(convID)?.channelname ??
                   ''}`}</Kb.Text>
               ))}
-            </>
+            </Kb.Box2>
           )}
         </Kb.Box2>
       ) : (

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -6,6 +6,8 @@ import * as Styles from '../../../styles'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as WaitingGen from '../../../actions/waiting-gen'
+import * as TeamsGen from '../../../actions/teams-gen'
+import * as Teams from '../../../constants/teams'
 import * as Types from '../../../constants/types/chat2'
 import * as TeamTypes from '../../../constants/types/teams'
 import * as Constants from '../../../constants/chat2'
@@ -83,6 +85,7 @@ const InstallBotPopup = (props: Props) => {
         settings: conversationIDKey
           ? state.chat2.botSettings.get(conversationIDKey)?.get(botUsername) ?? undefined
           : undefined,
+        teamID,
         teamName,
       }
     }
@@ -147,6 +150,7 @@ const InstallBotPopup = (props: Props) => {
   const onFeedback = () => {
     dispatch(RouteTreeGen.createNavigateAppend({ path: ['feedback'] }))
   }
+
   // lifecycle
   React.useEffect(() => {
     dispatch(
@@ -299,13 +303,13 @@ const InstallBotPopup = (props: Props) => {
     </Kb.Box2 >
   )
 
-  const channelPickerContent = channelPickerScreen && teamName && (
+  const channelPickerContent = channelPickerScreen && teamID && (
     <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container} gap="small">
       <ChannelPicker
         installInConvs={installInConvs}
         setChannelPickerScreen={setChannelPickerScreen}
         setInstallInConvs={setInstallInConvs}
-        teamname={teamName}
+        teamID={teamID}
       />
     </Kb.Box2>
   )

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -365,7 +365,8 @@ const InstallBotPopup = (props: Props) => {
   const showReviewButton = !installScreen && !inTeam
   const showRemoveButton = inTeam && !installScreen
   const showEditButton = inTeam && !inTeamUnrestricted && !installScreen
-  const showSaveButton = inTeam && installScreen
+  const showSaveButton = inTeam && installScreen && !channelPickerContent
+  const showDoneButton = inTeam && channelPickerContent
   const installButton = showInstallButton && (
     <Kb.WaitingButton
       fullWidth={true}
@@ -422,6 +423,16 @@ const InstallBotPopup = (props: Props) => {
       waitingKey={Constants.waitingKeyBotAdd}
     />
   )
+
+  const doneButton = showDoneButton && (
+    <Kb.Button
+      fullWidth={true}
+      label="Done"
+      onClick={() => setChannelPickerScreen(false)}
+      mode="Primary"
+      type="Default"
+    />
+  )
   const enabled = !!conversationIDKey && inTeam !== undefined
   return (
     <Kb.Modal
@@ -441,6 +452,7 @@ const InstallBotPopup = (props: Props) => {
         content: enabled && (
           <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
             <Kb.ButtonBar direction="column">
+              {doneButton}
               {editButton}
               {saveButton}
               {reviewButton}

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -61,7 +61,7 @@ const InstallBotPopup = (props: Props) => {
   const [installWithMentions, setInstallWithMentions] = React.useState(true)
   const [installWithRestrict, setInstallWithRestrict] = React.useState(true)
   const [installInConvs, setInstallInConvs] = React.useState<string[]>([])
-  const { commands, featured, inTeam, inTeamUnrestricted, settings } = Container.useSelector(
+  const { commands, featured, inTeam, inTeamUnrestricted, settings, teamName } = Container.useSelector(
     (state: Container.TypedState) => {
       let inTeam: boolean | undefined
       let teamRole: TeamTypes.TeamRoleType | null | undefined
@@ -275,7 +275,11 @@ const InstallBotPopup = (props: Props) => {
             members.
           </Kb.Text>
           <Kb.Text type="BodyBig">In these channels:</Kb.Text>
-          <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny"></Kb.Box2>
+          <Kb.Button
+            mode="Secondary"
+            label={`${teamName} (${installInConvs.length > 0 ? installInConvs.length : 'all'} channels)`}
+            onClick={() => setChannelPickerScreen(true)}
+          />
         </Kb.Box2>
       ) : (
           <Kb.Box2 direction="vertical" gap="tiny">
@@ -356,6 +360,7 @@ const InstallBotPopup = (props: Props) => {
         if (settings) {
           setInstallWithCommands(settings.cmds)
           setInstallWithMentions(settings.mentions)
+          setInstallInConvs(settings.convs ?? [])
         }
         setInstallScreen(true)
       }}
@@ -405,20 +410,21 @@ const InstallBotPopup = (props: Props) => {
                 >
                   {'feedback'}
                 </Kb.Text>
-                )}
-            </Kb.Box2>
-            ),
+              </Kb.Text>
+            )}
+          </ Kb.Box2 >
+        ),
       }}
-                            >
+    >
       <Kb.Box2 direction="vertical" style={styles.outerContainer} fullWidth={true}>
-              {enabled ? content : <Kb.ProgressIndicator />}
-            </Kb.Box2>
-    </Kb.Modal>
-        )
-      }
+        {enabled ? content : <Kb.ProgressIndicator />}
+      </Kb.Box2>
+    </Kb.Modal >
+  )
+}
 
-type CommandsLabelProps={
-        commands: Types.BotPublicCommands | undefined
+type CommandsLabelProps = {
+  commands: Types.BotPublicCommands | undefined
 }
 
 const maxCommandsShown = 3

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -31,20 +31,18 @@ const Bot = ({botAlias, description, botUsername, onClick, ownerTeam, ownerUser}
       <Kb.Text type="BodySmallSemibold" style={{color: Styles.globalColors.black}}>
         {botAlias || botUsername}
       </Kb.Text>
-      <Kb.Text type="BodySmall">
-        &nbsp;• by{' '}
-        {ownerTeam ? (
-          <Kb.TeamWithPopup prefix="@" inline={true} teamName={ownerTeam} type="BodySmall" />
-        ) : (
-          <Kb.ConnectedUsernames
-            prefix="@"
-            inline={true}
-            usernames={[ownerUser ?? botUsername]}
-            type="BodySmall"
-            withProfileCardPopup={true}
-          />
-        )}
-      </Kb.Text>
+      <Kb.Text type="BodySmall">&nbsp;• by&nbsp;</Kb.Text>
+      {ownerTeam ? (
+        <Kb.TeamWithPopup prefix="@" inline={true} teamName={ownerTeam} type="BodySmall" />
+      ) : (
+        <Kb.ConnectedUsernames
+          prefix="@"
+          inline={true}
+          usernames={[ownerUser ?? botUsername]}
+          type="BodySmall"
+          withProfileCardPopup={true}
+        />
+      )}
     </Kb.Box2>
   )
   return (

--- a/shared/teams/team/rows/bot-row/bot/index.tsx
+++ b/shared/teams/team/rows/bot-row/bot/index.tsx
@@ -50,20 +50,18 @@ export const TeamBotRow = (props: Props) => {
       >
         {props.botAlias || props.username}
       </Kb.Text>
-      <Kb.Text type="BodySmall">
-        &nbsp;• by{' '}
-        {props.ownerTeam ? (
-          <Kb.TeamWithPopup prefix="@" inline={true} teamName={props.ownerTeam} type="BodySmall" />
-        ) : (
-          <Kb.ConnectedUsernames
-            prefix="@"
-            inline={true}
-            usernames={[props.ownerUser ?? props.username]}
-            type="BodySmall"
-            withProfileCardPopup={true}
-          />
-        )}
-      </Kb.Text>
+      <Kb.Text type="BodySmall">&nbsp;• by </Kb.Text>
+      {props.ownerTeam ? (
+        <Kb.TeamWithPopup prefix="@" inline={true} teamName={props.ownerTeam} type="BodySmall" />
+      ) : (
+        <Kb.ConnectedUsernames
+          prefix="@"
+          inline={true}
+          usernames={[props.ownerUser ?? props.username]}
+          type="BodySmall"
+          withProfileCardPopup={true}
+        />
+      )}
     </Kb.Box2>
   )
 


### PR DESCRIPTION
Adds support for configuring restricted bot channels and fixes some bugs with bot layout on mobile.

Lots of layout changes here and in #21880, so it'd probably be a good idea to wait for that one to get merged before this PR.