### PR TITLE
add empty files to please the windows installer

### DIFF
--- a/packaging/windows/buildui.cmd
+++ b/packaging/windows/buildui.cmd
@@ -15,3 +15,25 @@ IF %ERRORLEVEL% NEQ 0 (
 
 yarn run package -- --arch x64 --platform win32 --appVersion %KEYBASE_VERSION% --icon %GOPATH%\src\github.com\keybase\client\media\icons\Keybase.ico
 popd
+
+:: wix (specifically heat) has a bad time with marking folders for deletion on uninstall if any
+:: of the folders in our distribution only contain folders (i.e. no non-folder files). so step into
+:: every folder in our distribution recursively, and create an empty file wherever necessary.
+pushd %GOPATH%\src\github.com\keybase\client\shared\desktop\release\win32-x64\Keybase-win32-x64
+
+:: this is necessary to use variables inside a for loop
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+for /R %%G in (.) do (
+  pushd %%G
+  set countOfNonDirectoryFiles=0
+  for %%x in (*) do set /a countOfNonDirectoryFiles+=1
+  if !countOfNonDirectoryFiles!==0 (
+    :: create an empty file in this directory
+    copy NUL EmptyFile.txt
+  )
+  popd %%G
+)
+
+SETLOCAL DISABLEDELAYEDEXPANSION
+popd

--- a/packaging/windows/buildui.cmd
+++ b/packaging/windows/buildui.cmd
@@ -13,12 +13,16 @@ IF %ERRORLEVEL% NEQ 0 (
   EXIT /B 1
 )
 
-yarn run package -- --arch x64 --platform win32 --appVersion %KEYBASE_VERSION% --icon %GOPATH%\src\github.com\keybase\client\media\icons\Keybase.ico
+cmd /C yarn run package --arch x64 --platform win32 --appVersion %KEYBASE_VERSION% --icon %GOPATH%\src\github.com\keybase\client\media\icons\Keybase.ico
+IF %ERRORLEVEL% NEQ 0 (
+  EXIT /B 1
+)
 popd
 
 :: wix (specifically heat) has a bad time with marking folders for deletion on uninstall if any
 :: of the folders in our distribution only contain folders (i.e. no non-folder files). so step into
 :: every folder in our distribution recursively, and create an empty file wherever necessary.
+echo off
 pushd %GOPATH%\src\github.com\keybase\client\shared\desktop\release\win32-x64\Keybase-win32-x64
 
 :: this is necessary to use variables inside a for loop
@@ -31,6 +35,7 @@ for /R %%G in (.) do (
   if !countOfNonDirectoryFiles!==0 (
     :: create an empty file in this directory
     copy NUL EmptyFile.txt
+    echo created an empty file at %%G
   )
   popd %%G
 )


### PR DESCRIPTION
as part of our installation process, wix creates a database of things to delete on uninstall. the template that helps to generate this list assumes that every folder has a file in it, but every now and again, there comes along a folder that only contains folders. then it doesn't get marked for deletion and there's an error like this:

```
error LGHT0204: ICE64: The directory is in the user profile but is not listed in the RemoveFile table
```

so, rather than futz with the template (which is much more prone to me screwing something up), i added a bit to the build process. After generating all the files but before passing them to wix, recursively step through every directory and add an empty file if there arent any other files present. currently this only happens in one place, but hopefully this fix is future-proof enough that no one needs to come back to look at this message in the future.