### PR TITLE
fix: make onclick go to correct user in systemjoined

### DIFF
--- a/shared/chat/conversation/messages/system-joined/container.tsx
+++ b/shared/chat/conversation/messages/system-joined/container.tsx
@@ -43,7 +43,7 @@ export default Container.connect(
       joiners:
         !stateProps._joiners.length && !stateProps.leavers.length ? [stateProps.author] : stateProps._joiners,
       leavers: stateProps.leavers,
-      onAuthorClick: () => dispatchProps._onAuthorClick(stateProps.author),
+      onAuthorClick: dispatchProps._onAuthorClick,
       onManageChannels: () => dispatchProps._onManageChannels(_meta.teamID),
       onManageNotifications: () => dispatchProps._onManageNotifications(_meta.conversationIDKey),
       teamname: _meta.teamname,

--- a/shared/chat/conversation/messages/system-joined/container.tsx
+++ b/shared/chat/conversation/messages/system-joined/container.tsx
@@ -20,7 +20,6 @@ export default Container.connect(
     timestamp: message.timestamp,
   }),
   dispatch => ({
-    _onAuthorClick: (username: string) => dispatch(ProfileGen.createShowUserProfile({username})),
     _onManageChannels: (teamID: TeamsTypes.TeamID) =>
       dispatch(
         RouteTreeGen.createNavigateAppend({path: [{props: {teamID}, selected: 'chatManageChannels'}]})
@@ -31,6 +30,7 @@ export default Container.connect(
           path: [{props: {conversationIDKey: conversationIDKey, tab: 'settings'}, selected: 'chatInfoPanel'}],
         })
       ),
+    onAuthorClick: (username: string) => dispatch(ProfileGen.createShowUserProfile({username})),
   }),
   (stateProps, dispatchProps, _: OwnProps) => {
     const {_meta} = stateProps
@@ -43,7 +43,7 @@ export default Container.connect(
       joiners:
         !stateProps._joiners.length && !stateProps.leavers.length ? [stateProps.author] : stateProps._joiners,
       leavers: stateProps.leavers,
-      onAuthorClick: dispatchProps._onAuthorClick,
+      onAuthorClick: dispatchProps.onAuthorClick,
       onManageChannels: () => dispatchProps._onManageChannels(_meta.teamID),
       onManageNotifications: () => dispatchProps._onManageNotifications(_meta.conversationIDKey),
       teamname: _meta.teamname,

--- a/shared/chat/conversation/messages/system-joined/index.tsx
+++ b/shared/chat/conversation/messages/system-joined/index.tsx
@@ -12,7 +12,7 @@ type Props = {
   isBigTeam: boolean
   joiners: Array<string>
   leavers: Array<string>
-  onAuthorClick: () => void
+  onAuthorClick: (username: string) => void
   onManageChannels: () => void
   onManageNotifications: () => void
   teamname: string
@@ -117,14 +117,14 @@ const AuthorAndAvatar = (props: {
   username: string
   timestamp: number
   authorIsYou: boolean
-  onAuthorClick: () => void
+  onAuthorClick: (username: string) => void
 }) => (
   <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny" fullWidth={true}>
     <Kb.Avatar
       size={32}
       username={props.username}
       skipBackground={true}
-      onClick={props.onAuthorClick}
+      onClick={() => props.onAuthorClick(props.username)}
       style={styles.avatar}
     />
     <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.usernameCrown}>
@@ -132,7 +132,7 @@ const AuthorAndAvatar = (props: {
         colorBroken={true}
         colorFollowing={true}
         colorYou={true}
-        onUsernameClicked={props.onAuthorClick}
+        onUsernameClicked="profile"
         style={Styles.collapseStyles([props.authorIsYou && styles.usernameHighlighted])}
         type="BodySmallBold"
         usernames={[props.username]}


### PR DESCRIPTION
This PR fixes an issue reported by a user where clicking on a username in a SystemJoined message would open the wrong profile.