### PR TITLE
PICNIC-745 - Hide 'open folder without them' for imp teams with 1 reset participant

### DIFF
--- a/shared/fs/banner/index.stories.tsx
+++ b/shared/fs/banner/index.stories.tsx
@@ -62,8 +62,11 @@ export default () => {
   Sb.storiesOf('Files/Banners', module)
     .addDecorator(provider)
     .addDecorator(Sb.scrollViewDecorator)
-    .add('ResetBanner - other', () => (
+    .add('ResetBanner - multiple resets', () => (
       <ResetBanner resetParticipants={['reset1', 'reset3']} {...resetBannerCommon} />
+    ))
+    .add('ResetBanner - single reset', () => (
+      <ResetBanner resetParticipants={['reset1']} {...resetBannerCommon} />
     ))
     .add('Public Reminder Banner', () => (
       <PublicReminder path={Types.stringToPath('/keybase/public/jakob223,songgao')} />

--- a/shared/fs/banner/reset-banner/index.tsx
+++ b/shared/fs/banner/reset-banner/index.tsx
@@ -92,12 +92,14 @@ const Banner = ({resetParticipants, onReAddToTeam, onViewProfile, onOpenWithoutR
         </Kb.Box2>
       ))}
     </Kb.Box2>
-    <Kb.Text type="BodySemibold" negative={true} style={styles.textOrUntil}>
-      Or until you're sure,{' '}
-      <Kb.Text type="BodySemiboldLink" negative={true} onClick={onOpenWithoutResetUsers}>
-        open a folder without {resetParticipants.length > 1 ? 'any of them' : 'them'}.
+    {resetParticipants.length > 1 ? (
+      <Kb.Text type="BodySemibold" negative={true} style={styles.textOrUntil}>
+        Or until you're sure,{' '}
+        <Kb.Text type="BodySemiboldLink" negative={true} onClick={onOpenWithoutResetUsers}>
+          open a folder without any of them.
+        </Kb.Text>
       </Kb.Text>
-    </Kb.Text>
+    ) : null}
   </Kb.Box2>
 )
 

--- a/shared/fs/banner/reset-banner/index.tsx
+++ b/shared/fs/banner/reset-banner/index.tsx
@@ -92,14 +92,14 @@ const Banner = ({resetParticipants, onReAddToTeam, onViewProfile, onOpenWithoutR
         </Kb.Box2>
       ))}
     </Kb.Box2>
-    {resetParticipants.length > 1 ? (
+    {resetParticipants.length > 1 && (
       <Kb.Text type="BodySemibold" negative={true} style={styles.textOrUntil}>
         Or until you're sure,{' '}
         <Kb.Text type="BodySemiboldLink" negative={true} onClick={onOpenWithoutResetUsers}>
           open a folder without any of them.
         </Kb.Text>
       </Kb.Text>
-    ) : null}
+    )}
   </Kb.Box2>
 )
 


### PR DESCRIPTION
### Before

![image-2019-12-11-12-32-43-620](https://user-images.githubusercontent.com/5200812/71843959-15a9d980-3093-11ea-9d65-f6e9cd458d9b.png)


### After

![image](https://user-images.githubusercontent.com/5200812/71843935-06c32700-3093-11ea-9b69-ef4b259b7221.png)
