### PR TITLE
do not show success if failed in batch signup

### DIFF
--- a/go/client/cmd_signup.go
+++ b/go/client/cmd_signup.go
@@ -568,6 +568,7 @@ func (s *CmdSignup) handlePostError(inerr error) (retry bool, err error) {
 	}
 
 	if !s.doPrompt {
+		err = inerr
 		retry = false
 	}
 


### PR DESCRIPTION
Before, if batch signup failed because the user already existed, it would display the error and then the Keybase.io welcome message. In the usual interactive behavior, the error is rewritten so the user can try again.

After, it displays the error and exits.