### PR TITLE
Add flags to CLI send commands for memos

### DIFF
--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -412,11 +412,12 @@ func (w *walletAPIHandler) sendPathPayment(ctx context.Context, c Call, wr io.Wr
 	}
 
 	sendArg := stellar1.SendPathCLILocalArg{
-		Source:     from,
-		Recipient:  opts.Recipient,
-		Path:       path.FullPath,
-		Note:       opts.Message,
-		PublicNote: opts.MemoText,
+		Source:         from,
+		Recipient:      opts.Recipient,
+		Path:           path.FullPath,
+		Note:           opts.Message,
+		PublicNote:     opts.MemoText,
+		PublicNoteType: stellar1.PublicNoteType_TEXT,
 	}
 	res, err := w.cli.SendPathCLILocal(ctx, sendArg)
 	if err != nil {

--- a/go/client/wallet_api_handler.go
+++ b/go/client/wallet_api_handler.go
@@ -298,6 +298,7 @@ func (w *walletAPIHandler) send(ctx context.Context, c Call, wr io.Writer) error
 		DisplayCurrency: displayCurrency,
 		FromAccountID:   stellar1.AccountID(opts.FromAccountID),
 		PublicNote:      opts.MemoText,
+		PublicNoteType:  stellar1.PublicNoteType_TEXT,
 	}
 	result, err := w.cli.SendCLILocal(ctx, arg)
 	if err != nil {

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -5,9 +5,10 @@ package stellar1
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
-	"time"
 )
 
 type WalletAccountLocal struct {
@@ -848,6 +849,41 @@ func (o SendResultCLILocal) DeepCopy() SendResultCLILocal {
 	}
 }
 
+type PublicNoteType int
+
+const (
+	PublicNoteType_NONE   PublicNoteType = 0
+	PublicNoteType_TEXT   PublicNoteType = 1
+	PublicNoteType_ID     PublicNoteType = 2
+	PublicNoteType_HASH   PublicNoteType = 3
+	PublicNoteType_RETURN PublicNoteType = 4
+)
+
+func (o PublicNoteType) DeepCopy() PublicNoteType { return o }
+
+var PublicNoteTypeMap = map[string]PublicNoteType{
+	"NONE":   0,
+	"TEXT":   1,
+	"ID":     2,
+	"HASH":   3,
+	"RETURN": 4,
+}
+
+var PublicNoteTypeRevMap = map[PublicNoteType]string{
+	0: "NONE",
+	1: "TEXT",
+	2: "ID",
+	3: "HASH",
+	4: "RETURN",
+}
+
+func (e PublicNoteType) String() string {
+	if v, ok := PublicNoteTypeRevMap[e]; ok {
+		return v
+	}
+	return fmt.Sprintf("%v", int(e))
+}
+
 type PaymentOrErrorCLILocal struct {
 	Payment *PaymentCLILocal `codec:"payment,omitempty" json:"payment,omitempty"`
 	Err     *string          `codec:"err,omitempty" json:"err,omitempty"`
@@ -1594,15 +1630,16 @@ type BalancesLocalArg struct {
 }
 
 type SendCLILocalArg struct {
-	Recipient       string    `codec:"recipient" json:"recipient"`
-	Amount          string    `codec:"amount" json:"amount"`
-	Asset           Asset     `codec:"asset" json:"asset"`
-	Note            string    `codec:"note" json:"note"`
-	DisplayAmount   string    `codec:"displayAmount" json:"displayAmount"`
-	DisplayCurrency string    `codec:"displayCurrency" json:"displayCurrency"`
-	ForceRelay      bool      `codec:"forceRelay" json:"forceRelay"`
-	PublicNote      string    `codec:"publicNote" json:"publicNote"`
-	FromAccountID   AccountID `codec:"fromAccountID" json:"fromAccountID"`
+	Recipient       string         `codec:"recipient" json:"recipient"`
+	Amount          string         `codec:"amount" json:"amount"`
+	Asset           Asset          `codec:"asset" json:"asset"`
+	Note            string         `codec:"note" json:"note"`
+	DisplayAmount   string         `codec:"displayAmount" json:"displayAmount"`
+	DisplayCurrency string         `codec:"displayCurrency" json:"displayCurrency"`
+	ForceRelay      bool           `codec:"forceRelay" json:"forceRelay"`
+	PublicNote      string         `codec:"publicNote" json:"publicNote"`
+	PublicNoteType  PublicNoteType `codec:"publicNoteType" json:"publicNoteType"`
+	FromAccountID   AccountID      `codec:"fromAccountID" json:"fromAccountID"`
 }
 
 type SendPathCLILocalArg struct {

--- a/go/protocol/stellar1/local.go
+++ b/go/protocol/stellar1/local.go
@@ -5,10 +5,9 @@ package stellar1
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
+	"time"
 )
 
 type WalletAccountLocal struct {
@@ -1643,11 +1642,12 @@ type SendCLILocalArg struct {
 }
 
 type SendPathCLILocalArg struct {
-	Source     AccountID   `codec:"source" json:"source"`
-	Recipient  string      `codec:"recipient" json:"recipient"`
-	Path       PaymentPath `codec:"path" json:"path"`
-	Note       string      `codec:"note" json:"note"`
-	PublicNote string      `codec:"publicNote" json:"publicNote"`
+	Source         AccountID      `codec:"source" json:"source"`
+	Recipient      string         `codec:"recipient" json:"recipient"`
+	Path           PaymentPath    `codec:"path" json:"path"`
+	Note           string         `codec:"note" json:"note"`
+	PublicNote     string         `codec:"publicNote" json:"publicNote"`
+	PublicNoteType PublicNoteType `codec:"publicNoteType" json:"publicNoteType"`
 }
 
 type AccountMergeCLILocalArg struct {

--- a/go/stellar/batch.go
+++ b/go/stellar/batch.go
@@ -218,7 +218,7 @@ func prepareBatchPaymentDirect(mctx libkb.MetaContext, remoter remote.Remoter, s
 
 	var signResult stellarnet.SignResult
 	if funded {
-		signResult, err = stellarnet.PaymentXLMTransaction(senderSeed, *recipient.AccountID, payment.Amount, "", sp, nil, baseFee)
+		signResult, err = stellarnet.PaymentXLMTransactionWithMemo(senderSeed, *recipient.AccountID, payment.Amount, stellarnet.NewMemoNone(), sp, nil, baseFee)
 	} else {
 		signResult, err = stellarnet.CreateAccountXLMTransaction(senderSeed, *recipient.AccountID, payment.Amount, "", sp, nil, baseFee)
 	}

--- a/go/stellar/stellar.go
+++ b/go/stellar/stellar.go
@@ -1124,13 +1124,13 @@ func prepareMiniChatPaymentDirect(m libkb.MetaContext, remoter remote.Remoter, s
 
 	var signResult stellarnet.SignResult
 	if funded {
-		signResult, err = stellarnet.PaymentXLMTransaction(senderSeed, *recipient.AccountID, xlmAmount, "", sp, tb, baseFee)
+		signResult, err = stellarnet.PaymentXLMTransactionWithMemo(senderSeed, *recipient.AccountID, xlmAmount, stellarnet.NewMemoNone(), sp, tb, baseFee)
 	} else {
 		if isAmountLessThanMin(xlmAmount, minAmountCreateAccountXLM) {
 			result.Error = fmt.Errorf("you must send at least %s XLM to fund the account", minAmountCreateAccountXLM)
 			return result
 		}
-		signResult, err = stellarnet.CreateAccountXLMTransaction(senderSeed, *recipient.AccountID, xlmAmount, "", sp, tb, baseFee)
+		signResult, err = stellarnet.CreateAccountXLMTransactionWithMemo(senderSeed, *recipient.AccountID, xlmAmount, stellarnet.NewMemoNone(), sp, tb, baseFee)
 	}
 	if err != nil {
 		result.Error = err

--- a/go/stellar/stellarsvc/service.go
+++ b/go/stellar/stellarsvc/service.go
@@ -201,6 +201,11 @@ func (s *Server) SendCLILocal(ctx context.Context, arg stellar1.SendCLILocalArg)
 	}
 	mctx = mctx.WithUIs(uis)
 
+	memo, err := stellarnet.NewMemoFromStrings(arg.PublicNote, arg.PublicNoteType.String())
+	if err != nil {
+		return res, err
+	}
+
 	sendRes, err := stellar.SendPaymentCLI(mctx, s.walletState, stellar.SendPaymentArg{
 		From:           arg.FromAccountID,
 		To:             stellarcommon.RecipientInput(arg.Recipient),
@@ -209,7 +214,7 @@ func (s *Server) SendCLILocal(ctx context.Context, arg stellar1.SendCLILocalArg)
 		SecretNote:     arg.Note,
 		ForceRelay:     arg.ForceRelay,
 		QuickReturn:    false,
-		PublicMemo:     stellarnet.NewMemoText(arg.PublicNote),
+		PublicMemo:     memo,
 	})
 	if err != nil {
 		return res, err
@@ -281,12 +286,17 @@ func (s *Server) SendPathCLILocal(ctx context.Context, arg stellar1.SendPathCLIL
 	}
 	mctx = mctx.WithUIs(uis)
 
+	memo, err := stellarnet.NewMemoFromStrings(arg.PublicNote, arg.PublicNoteType.String())
+	if err != nil {
+		return res, err
+	}
+
 	sendRes, err := stellar.SendPathPaymentCLI(mctx, s.walletState, stellar.SendPathPaymentArg{
 		From:        arg.Source,
 		To:          stellarcommon.RecipientInput(arg.Recipient),
 		Path:        arg.Path,
 		SecretNote:  arg.Note,
-		PublicMemo:  stellarnet.NewMemoText(arg.PublicNote),
+		PublicMemo:  memo,
 		QuickReturn: false,
 	})
 	if err != nil {

--- a/go/vendor/github.com/keybase/stellarnet/pages.go
+++ b/go/vendor/github.com/keybase/stellarnet/pages.go
@@ -178,6 +178,21 @@ func (f FullPath) DestinationAsset() AssetMinimal {
 	}
 }
 
+// SameAsset returns true if source and destination assets are the same.
+func (f FullPath) SameAsset() bool {
+	if f.SourceAssetType != f.DestinationAssetType {
+		return false
+	}
+	if f.SourceAssetCode != f.DestinationAssetCode {
+		return false
+	}
+	if f.SourceAssetIssuer != f.DestinationAssetIssuer {
+		return false
+	}
+
+	return true
+}
+
 // PathsPage is used to unmarshal the results from the /paths endpoint.
 type PathsPage struct {
 	Links struct {

--- a/go/vendor/github.com/keybase/stellarnet/results.go
+++ b/go/vendor/github.com/keybase/stellarnet/results.go
@@ -29,7 +29,7 @@ func PathPaymentSourceAmount(resultXDR string, opIndex int) (string, error) {
 	if !ok {
 		return "", errors.New("could not get OperationResultTr out of operation")
 	}
-	pathResult, ok := tr.GetPathPaymentResult()
+	pathResult, ok := tr.GetPathPaymentStrictReceiveResult()
 	if !ok {
 		return "", errors.New("could not get PathPaymentResult out of tr")
 	}
@@ -54,10 +54,10 @@ func PathPaymentIntermediatePath(envelopeXDR string, opIndex int) ([]AssetMinima
 		return nil, errors.New("opIndex out of range")
 	}
 	op := tx.Tx.Operations[opIndex]
-	if op.Body.Type != xdr.OperationTypePathPayment {
+	if op.Body.Type != xdr.OperationTypePathPaymentStrictReceive {
 		return nil, errors.New("not a path payment")
 	}
-	pathOp, ok := op.Body.GetPathPaymentOp()
+	pathOp, ok := op.Body.GetPathPaymentStrictReceiveOp()
 	if !ok {
 		return nil, errors.New("not a path payment")
 	}

--- a/go/vendor/github.com/keybase/stellarnet/summary.go
+++ b/go/vendor/github.com/keybase/stellarnet/summary.go
@@ -36,8 +36,8 @@ func opBodySummary(op xdr.Operation, pastTense bool) string {
 	case xdr.OperationTypePayment:
 		iop := op.Body.MustPaymentOp()
 		return fmt.Sprintf("%s %s to account %s", tense("Pay", "Paid"), XDRAssetAmountSummary(iop.Amount, iop.Asset), iop.Destination.Address())
-	case xdr.OperationTypePathPayment:
-		iop := op.Body.MustPathPaymentOp()
+	case xdr.OperationTypePathPaymentStrictReceive:
+		iop := op.Body.MustPathPaymentStrictReceiveOp()
 		return fmt.Sprintf("%s %s to account %s using at most %s", tense("Pay", "Paid"), XDRAssetAmountSummary(iop.DestAmount, iop.DestAsset), iop.Destination.Address(), XDRAssetAmountSummary(iop.SendMax, iop.SendAsset))
 	case xdr.OperationTypeManageSellOffer:
 		iop := op.Body.MustManageSellOfferOp()

--- a/go/vendor/github.com/keybase/stellarnet/tx.go
+++ b/go/vendor/github.com/keybase/stellarnet/tx.go
@@ -99,7 +99,7 @@ func (t *Tx) AddPathPaymentOp(to AddressStr, sendAsset AssetBase, sendAmountMax 
 		return
 	}
 
-	var op xdr.PathPaymentOp
+	var op xdr.PathPaymentStrictReceiveOp
 
 	op.SendAsset, t.err = assetBaseToXDR(sendAsset)
 	if t.err != nil {
@@ -133,7 +133,7 @@ func (t *Tx) AddPathPaymentOp(to AddressStr, sendAsset AssetBase, sendAmountMax 
 	}
 	op.Path = xdrPath
 
-	t.addOp(xdr.OperationTypePathPayment, op)
+	t.addOp(xdr.OperationTypePathPaymentStrictReceive, op)
 }
 
 // AddCreateAccountOp adds a create_account operation to the transaction.

--- a/go/vendor/github.com/stellar/go/build/allow_trust.go
+++ b/go/vendor/github.com/stellar/go/build/allow_trust.go
@@ -58,12 +58,12 @@ func (m AllowTrustAsset) MutateAllowTrust(o *xdr.AllowTrustOp) (err error) {
 
 	switch {
 	case length >= 1 && length <= 4:
-		var code [4]byte
+		var code xdr.AssetCode4
 		byteArray := []byte(m.Code)
 		copy(code[:], byteArray[0:length])
 		o.Asset, err = xdr.NewAllowTrustOpAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, code)
 	case length >= 5 && length <= 12:
-		var code [12]byte
+		var code xdr.AssetCode12
 		byteArray := []byte(m.Code)
 		copy(code[:], byteArray[0:length])
 		o.Asset, err = xdr.NewAllowTrustOpAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, code)

--- a/go/vendor/github.com/stellar/go/build/asset.go
+++ b/go/vendor/github.com/stellar/go/build/asset.go
@@ -29,13 +29,13 @@ func (a Asset) ToXDR() (xdr.Asset, error) {
 	length := len(a.Code)
 	switch {
 	case length >= 1 && length <= 4:
-		var codeArray [4]byte
+		var codeArray xdr.AssetCode4
 		byteArray := []byte(a.Code)
 		copy(codeArray[:], byteArray[0:length])
 		asset := xdr.AssetAlphaNum4{AssetCode: codeArray, Issuer: issuer}
 		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
 	case length >= 5 && length <= 12:
-		var codeArray [12]byte
+		var codeArray xdr.AssetCode12
 		byteArray := []byte(a.Code)
 		copy(codeArray[:], byteArray[0:length])
 		asset := xdr.AssetAlphaNum12{AssetCode: codeArray, Issuer: issuer}

--- a/go/vendor/github.com/stellar/go/build/change_trust.go
+++ b/go/vendor/github.com/stellar/go/build/change_trust.go
@@ -93,9 +93,7 @@ func RemoveTrust(code, issuer string, args ...interface{}) (result ChangeTrustBu
 		Limit("0"),
 	}
 
-	for _, mut := range args {
-		mutators = append(mutators, mut)
-	}
+	mutators = append(mutators, args...)
 
 	return ChangeTrust(mutators...)
 }

--- a/go/vendor/github.com/stellar/go/build/payment.go
+++ b/go/vendor/github.com/stellar/go/build/payment.go
@@ -26,7 +26,7 @@ type PaymentBuilder struct {
 	PathPayment bool
 	O           xdr.Operation
 	P           xdr.PaymentOp
-	PP          xdr.PathPaymentOp
+	PP          xdr.PathPaymentStrictReceiveOp
 	Err         error
 }
 
@@ -73,7 +73,7 @@ func (m CreditAmount) MutatePayment(o interface{}) (err error) {
 		}
 
 		o.Asset, err = createAlphaNumAsset(m.Code, m.Issuer)
-	case *xdr.PathPaymentOp:
+	case *xdr.PathPaymentStrictReceiveOp:
 		o.DestAmount, err = amount.Parse(m.Amount)
 		if err != nil {
 			return
@@ -91,7 +91,7 @@ func (m Destination) MutatePayment(o interface{}) error {
 		return errors.New("Unexpected operation type")
 	case *xdr.PaymentOp:
 		return setAccountId(m.AddressOrSeed, &o.Destination)
-	case *xdr.PathPaymentOp:
+	case *xdr.PathPaymentStrictReceiveOp:
 		return setAccountId(m.AddressOrSeed, &o.Destination)
 	}
 }
@@ -109,7 +109,7 @@ func (m NativeAmount) MutatePayment(o interface{}) (err error) {
 		}
 
 		o.Asset, err = xdr.NewAsset(xdr.AssetTypeAssetTypeNative, nil)
-	case *xdr.PathPaymentOp:
+	case *xdr.PathPaymentStrictReceiveOp:
 		o.DestAmount, err = amount.Parse(m.Amount)
 		if err != nil {
 			return
@@ -123,9 +123,9 @@ func (m NativeAmount) MutatePayment(o interface{}) (err error) {
 // MutatePayment for PayWithPath sets the PathPaymentOp's SendAsset,
 // SendMax and Path fields
 func (m PayWithPath) MutatePayment(o interface{}) (err error) {
-	var pathPaymentOp *xdr.PathPaymentOp
+	var pathPaymentOp *xdr.PathPaymentStrictReceiveOp
 	var ok bool
-	if pathPaymentOp, ok = o.(*xdr.PathPaymentOp); !ok {
+	if pathPaymentOp, ok = o.(*xdr.PathPaymentStrictReceiveOp); !ok {
 		return errors.New("Unexpected operation type")
 	}
 

--- a/go/vendor/github.com/stellar/go/build/transaction.go
+++ b/go/vendor/github.com/stellar/go/build/transaction.go
@@ -302,7 +302,7 @@ func (m PaymentBuilder) MutateTransaction(o *TransactionBuilder) error {
 	}
 
 	if m.PathPayment {
-		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypePathPayment, m.PP)
+		m.O.Body, m.Err = xdr.NewOperationBody(xdr.OperationTypePathPaymentStrictReceive, m.PP)
 		o.TX.Operations = append(o.TX.Operations, m.O)
 		return m.Err
 	}

--- a/go/vendor/github.com/stellar/go/build/util.go
+++ b/go/vendor/github.com/stellar/go/build/util.go
@@ -29,13 +29,13 @@ func createAlphaNumAsset(code, issuerAccountId string) (xdr.Asset, error) {
 	length := len(code)
 	switch {
 	case length >= 1 && length <= 4:
-		var codeArray [4]byte
+		var codeArray xdr.AssetCode4
 		byteArray := []byte(code)
 		copy(codeArray[:], byteArray[0:length])
 		asset := xdr.AssetAlphaNum4{AssetCode: codeArray, Issuer: issuer}
 		return xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
 	case length >= 5 && length <= 12:
-		var codeArray [12]byte
+		var codeArray xdr.AssetCode12
 		byteArray := []byte(code)
 		copy(codeArray[:], byteArray[0:length])
 		asset := xdr.AssetAlphaNum12{AssetCode: codeArray, Issuer: issuer}

--- a/go/vendor/github.com/stellar/go/xdr/Stellar-ledger-entries.x
+++ b/go/vendor/github.com/stellar/go/xdr/Stellar-ledger-entries.x
@@ -15,6 +15,12 @@ typedef int64 SequenceNumber;
 typedef uint64 TimePoint;
 typedef opaque DataValue<64>;
 
+// 1-4 alphanumeric characters right-padded with 0 bytes
+typedef opaque AssetCode4[4];
+
+// 5-12 alphanumeric characters right-padded with 0 bytes
+typedef opaque AssetCode12[12];
+
 enum AssetType
 {
     ASSET_TYPE_NATIVE = 0,
@@ -30,14 +36,14 @@ case ASSET_TYPE_NATIVE: // Not credit
 case ASSET_TYPE_CREDIT_ALPHANUM4:
     struct
     {
-        opaque assetCode[4]; // 1 to 4 characters
+        AssetCode4 assetCode;
         AccountID issuer;
     } alphaNum4;
 
 case ASSET_TYPE_CREDIT_ALPHANUM12:
     struct
     {
-        opaque assetCode[12]; // 5 to 12 characters
+        AssetCode12 assetCode;
         AccountID issuer;
     } alphaNum12;
 
@@ -78,7 +84,7 @@ enum LedgerEntryType
 struct Signer
 {
     SignerKey key;
-    uint32 weight; // really only need 1byte
+    uint32 weight; // really only need 1 byte
 };
 
 enum AccountFlags

--- a/go/vendor/github.com/stellar/go/xdr/Stellar-ledger.x
+++ b/go/vendor/github.com/stellar/go/xdr/Stellar-ledger.x
@@ -37,7 +37,7 @@ struct StellarValue
     UpgradeType upgrades<6>;
 
     // reserved for future use
-    union switch (int v)
+    union switch (StellarValueType v)
     {
     case STELLAR_VALUE_BASIC:
         void;

--- a/go/vendor/github.com/stellar/go/xdr/account_entry.go
+++ b/go/vendor/github.com/stellar/go/xdr/account_entry.go
@@ -3,7 +3,7 @@ package xdr
 func (a *AccountEntry) SignerSummary() map[string]int32 {
 	ret := map[string]int32{}
 
-	if a.Thresholds[0] > 0 {
+	if a.MasterKeyWeight() > 0 {
 		ret[a.AccountId.Address()] = int32(a.Thresholds[0])
 	}
 	for _, signer := range a.Signers {
@@ -11,4 +11,8 @@ func (a *AccountEntry) SignerSummary() map[string]int32 {
 	}
 
 	return ret
+}
+
+func (a *AccountEntry) MasterKeyWeight() byte {
+	return a.Thresholds[0]
 }

--- a/go/vendor/github.com/stellar/go/xdr/account_id.go
+++ b/go/vendor/github.com/stellar/go/xdr/account_id.go
@@ -51,6 +51,39 @@ func (aid *AccountId) LedgerKey() (ret LedgerKey) {
 	return
 }
 
+// MarshalBinaryCompress marshals AccountId to []byte but unlike
+// MarshalBinary() it removes all unnecessary bytes, exploting the fact
+// that XDR is padding data to 4 bytes in union discriminants etc.
+// It's primary use is in ingest/io.StateReader that keep LedgerKeys in
+// memory so this function decrease memory requirements.
+//
+// Warning, do not use UnmarshalBinary() on data encoded using this method!
+func (aid AccountId) MarshalBinaryCompress() ([]byte, error) {
+	m := []byte{byte(aid.Type)}
+
+	switch aid.Type {
+	case PublicKeyTypePublicKeyTypeEd25519:
+		pk, err := aid.Ed25519.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		m = append(m, pk...)
+	default:
+		panic("Unknown type")
+	}
+
+	return m, nil
+}
+
+func MustAddress(address string) AccountId {
+	aid := AccountId{}
+	err := aid.SetAddress(address)
+	if err != nil {
+		panic(err)
+	}
+	return aid
+}
+
 // SetAddress modifies the receiver, setting it's value to the AccountId form
 // of the provided address.
 func (aid *AccountId) SetAddress(address string) error {

--- a/go/vendor/github.com/stellar/go/xdr/db.go
+++ b/go/vendor/github.com/stellar/go/xdr/db.go
@@ -1,8 +1,10 @@
 package xdr
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/lib/pq"
 )
 
@@ -46,7 +48,7 @@ func (t *Int64) Scan(src interface{}) error {
 	return nil
 }
 
-// Scan reads from a src an xdr.Price
+// Scan reads from a src into an xdr.Price
 func (t *Price) Scan(src interface{}) error {
 	// assuming the price is represented as a two-element array [n,d]
 	arr := pq.Int64Array{}
@@ -61,6 +63,21 @@ func (t *Price) Scan(src interface{}) error {
 	}
 
 	*t = Price{Int32(arr[0]), Int32(arr[1])}
+	return nil
+}
+
+// Scan reads from a src into an xdr.Hash
+func (t *Hash) Scan(src interface{}) error {
+	decodedBytes, err := hex.DecodeString(string(src.([]uint8)))
+	if err != nil {
+		return err
+	}
+
+	var decodedHash Hash
+	copy(decodedHash[:], decodedBytes)
+
+	*t = decodedHash
+
 	return nil
 }
 

--- a/go/vendor/github.com/stellar/go/xdr/path_payment_result.go
+++ b/go/vendor/github.com/stellar/go/xdr/path_payment_result.go
@@ -2,7 +2,7 @@ package xdr
 
 // SendAmount returns the amount spent, denominated in the source asset, in the
 // course of this path payment
-func (pr *PathPaymentResult) SendAmount() Int64 {
+func (pr *PathPaymentStrictReceiveResult) SendAmount() Int64 {
 	s, ok := pr.GetSuccess()
 	if !ok {
 		return 0
@@ -23,4 +23,15 @@ func (pr *PathPaymentResult) SendAmount() Int64 {
 	}
 
 	return ret
+}
+
+// DestAmount returns the amount received, denominated in the destination asset, in the
+// course of this path payment
+func (pr *PathPaymentStrictSendResult) DestAmount() Int64 {
+	s, ok := pr.GetSuccess()
+	if !ok {
+		return 0
+	}
+
+	return s.Last.Amount
 }

--- a/go/vendor/github.com/stellar/go/xdr/signer_key.go
+++ b/go/vendor/github.com/stellar/go/xdr/signer_key.go
@@ -61,6 +61,15 @@ func (skey *SignerKey) Equals(other SignerKey) bool {
 	}
 }
 
+func MustSigner(address string) SignerKey {
+	aid := SignerKey{}
+	err := aid.SetAddress(address)
+	if err != nil {
+		panic(err)
+	}
+	return aid
+}
+
 // SetAddress modifies the receiver, setting it's value to the SignerKey form
 // of the provided address.
 func (skey *SignerKey) SetAddress(address string) error {

--- a/go/vendor/github.com/stellar/go/xdr/signers.go
+++ b/go/vendor/github.com/stellar/go/xdr/signers.go
@@ -1,0 +1,26 @@
+package xdr
+
+import (
+	"sort"
+)
+
+// SortSignersByKey returns a new []Signer array sorted by signer key.
+func SortSignersByKey(signers []Signer) []Signer {
+	keys := make([]string, 0, len(signers))
+	keysMap := make(map[string]Signer)
+	newSigners := make([]Signer, 0, len(signers))
+
+	for _, signer := range signers {
+		key := signer.Key.Address()
+		keys = append(keys, key)
+		keysMap[key] = signer
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		newSigners = append(newSigners, keysMap[key])
+	}
+
+	return newSigners
+}

--- a/go/vendor/github.com/stellar/go/xdr/transaction_meta.go
+++ b/go/vendor/github.com/stellar/go/xdr/transaction_meta.go
@@ -1,0 +1,12 @@
+package xdr
+
+// Operations is a helper on TransactionMeta that returns operations
+// meta from `TransactionMeta.Operations` or `TransactionMeta.V1.Operations`.
+func (transactionMeta *TransactionMeta) OperationsMeta() []OperationMeta {
+	operations, ok := transactionMeta.GetOperations()
+	if ok {
+		return operations
+	}
+
+	return transactionMeta.MustV1().Operations
+}

--- a/go/vendor/github.com/stellar/go/xdr/xdr_generated.go
+++ b/go/vendor/github.com/stellar/go/xdr/xdr_generated.go
@@ -1,3 +1,5 @@
+//lint:file-ignore S1005 The issue should be fixed in xdrgen. Unfortunately, there's no way to ignore a single file in staticcheck.
+//lint:file-ignore U1000 fmtTest is not needed anywhere, should be removed in xdrgen.
 // Package xdr is generated from:
 //
 //  Stellar-SCP.x
@@ -851,6 +853,64 @@ var (
 	_ encoding.BinaryUnmarshaler = (*DataValue)(nil)
 )
 
+// AssetCode4 is an XDR Typedef defines as:
+//
+//   typedef opaque AssetCode4[4];
+//
+type AssetCode4 [4]byte
+
+// XDRMaxSize implements the Sized interface for AssetCode4
+func (e AssetCode4) XDRMaxSize() int {
+	return 4
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s AssetCode4) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *AssetCode4) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*AssetCode4)(nil)
+	_ encoding.BinaryUnmarshaler = (*AssetCode4)(nil)
+)
+
+// AssetCode12 is an XDR Typedef defines as:
+//
+//   typedef opaque AssetCode12[12];
+//
+type AssetCode12 [12]byte
+
+// XDRMaxSize implements the Sized interface for AssetCode12
+func (e AssetCode12) XDRMaxSize() int {
+	return 12
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s AssetCode12) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *AssetCode12) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*AssetCode12)(nil)
+	_ encoding.BinaryUnmarshaler = (*AssetCode12)(nil)
+)
+
 // AssetType is an XDR Enum defines as:
 //
 //   enum AssetType
@@ -909,12 +969,12 @@ var (
 //
 //   struct
 //        {
-//            opaque assetCode[4]; // 1 to 4 characters
+//            AssetCode4 assetCode;
 //            AccountID issuer;
 //        }
 //
 type AssetAlphaNum4 struct {
-	AssetCode [4]byte `xdrmaxsize:"4"`
+	AssetCode AssetCode4
 	Issuer    AccountId
 }
 
@@ -940,12 +1000,12 @@ var (
 //
 //   struct
 //        {
-//            opaque assetCode[12]; // 5 to 12 characters
+//            AssetCode12 assetCode;
 //            AccountID issuer;
 //        }
 //
 type AssetAlphaNum12 struct {
-	AssetCode [12]byte `xdrmaxsize:"12"`
+	AssetCode AssetCode12
 	Issuer    AccountId
 }
 
@@ -977,14 +1037,14 @@ var (
 //    case ASSET_TYPE_CREDIT_ALPHANUM4:
 //        struct
 //        {
-//            opaque assetCode[4]; // 1 to 4 characters
+//            AssetCode4 assetCode;
 //            AccountID issuer;
 //        } alphaNum4;
 //
 //    case ASSET_TYPE_CREDIT_ALPHANUM12:
 //        struct
 //        {
-//            opaque assetCode[12]; // 5 to 12 characters
+//            AssetCode12 assetCode;
 //            AccountID issuer;
 //        } alphaNum12;
 //
@@ -1290,7 +1350,7 @@ var (
 //   struct Signer
 //    {
 //        SignerKey key;
-//        uint32 weight; // really only need 1byte
+//        uint32 weight; // really only need 1 byte
 //    };
 //
 type Signer struct {
@@ -2703,7 +2763,7 @@ var (
 
 // StellarValueExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
+//   union switch (StellarValueType v)
 //        {
 //        case STELLAR_VALUE_BASIC:
 //            void;
@@ -2712,7 +2772,7 @@ var (
 //        }
 //
 type StellarValueExt struct {
-	V                int32
+	V                StellarValueType
 	LcValueSignature *LedgerCloseValueSignature
 }
 
@@ -2725,22 +2785,22 @@ func (u StellarValueExt) SwitchFieldName() string {
 // ArmForSwitch returns which field name should be used for storing
 // the value for an instance of StellarValueExt
 func (u StellarValueExt) ArmForSwitch(sw int32) (string, bool) {
-	switch int32(sw) {
-	case int32(StellarValueTypeStellarValueBasic):
+	switch StellarValueType(sw) {
+	case StellarValueTypeStellarValueBasic:
 		return "", true
-	case int32(StellarValueTypeStellarValueSigned):
+	case StellarValueTypeStellarValueSigned:
 		return "LcValueSignature", true
 	}
 	return "-", false
 }
 
 // NewStellarValueExt creates a new  StellarValueExt.
-func NewStellarValueExt(v int32, value interface{}) (result StellarValueExt, err error) {
+func NewStellarValueExt(v StellarValueType, value interface{}) (result StellarValueExt, err error) {
 	result.V = v
-	switch int32(v) {
-	case int32(StellarValueTypeStellarValueBasic):
+	switch StellarValueType(v) {
+	case StellarValueTypeStellarValueBasic:
 		// void
-	case int32(StellarValueTypeStellarValueSigned):
+	case StellarValueTypeStellarValueSigned:
 		tv, ok := value.(LedgerCloseValueSignature)
 		if !ok {
 			err = fmt.Errorf("invalid value, must be LedgerCloseValueSignature")
@@ -2809,7 +2869,7 @@ var (
 //        UpgradeType upgrades<6>;
 //
 //        // reserved for future use
-//        union switch (int v)
+//        union switch (StellarValueType v)
 //        {
 //        case STELLAR_VALUE_BASIC:
 //            void;
@@ -6089,7 +6149,7 @@ var (
 //    {
 //        CREATE_ACCOUNT = 0,
 //        PAYMENT = 1,
-//        PATH_PAYMENT = 2,
+//        PATH_PAYMENT_STRICT_RECEIVE = 2,
 //        MANAGE_SELL_OFFER = 3,
 //        CREATE_PASSIVE_SELL_OFFER = 4,
 //        SET_OPTIONS = 5,
@@ -6099,31 +6159,33 @@ var (
 //        INFLATION = 9,
 //        MANAGE_DATA = 10,
 //        BUMP_SEQUENCE = 11,
-//        MANAGE_BUY_OFFER = 12
+//        MANAGE_BUY_OFFER = 12,
+//        PATH_PAYMENT_STRICT_SEND = 13
 //    };
 //
 type OperationType int32
 
 const (
-	OperationTypeCreateAccount          OperationType = 0
-	OperationTypePayment                OperationType = 1
-	OperationTypePathPayment            OperationType = 2
-	OperationTypeManageSellOffer        OperationType = 3
-	OperationTypeCreatePassiveSellOffer OperationType = 4
-	OperationTypeSetOptions             OperationType = 5
-	OperationTypeChangeTrust            OperationType = 6
-	OperationTypeAllowTrust             OperationType = 7
-	OperationTypeAccountMerge           OperationType = 8
-	OperationTypeInflation              OperationType = 9
-	OperationTypeManageData             OperationType = 10
-	OperationTypeBumpSequence           OperationType = 11
-	OperationTypeManageBuyOffer         OperationType = 12
+	OperationTypeCreateAccount            OperationType = 0
+	OperationTypePayment                  OperationType = 1
+	OperationTypePathPaymentStrictReceive OperationType = 2
+	OperationTypeManageSellOffer          OperationType = 3
+	OperationTypeCreatePassiveSellOffer   OperationType = 4
+	OperationTypeSetOptions               OperationType = 5
+	OperationTypeChangeTrust              OperationType = 6
+	OperationTypeAllowTrust               OperationType = 7
+	OperationTypeAccountMerge             OperationType = 8
+	OperationTypeInflation                OperationType = 9
+	OperationTypeManageData               OperationType = 10
+	OperationTypeBumpSequence             OperationType = 11
+	OperationTypeManageBuyOffer           OperationType = 12
+	OperationTypePathPaymentStrictSend    OperationType = 13
 )
 
 var operationTypeMap = map[int32]string{
 	0:  "OperationTypeCreateAccount",
 	1:  "OperationTypePayment",
-	2:  "OperationTypePathPayment",
+	2:  "OperationTypePathPaymentStrictReceive",
 	3:  "OperationTypeManageSellOffer",
 	4:  "OperationTypeCreatePassiveSellOffer",
 	5:  "OperationTypeSetOptions",
@@ -6134,6 +6196,7 @@ var operationTypeMap = map[int32]string{
 	10: "OperationTypeManageData",
 	11: "OperationTypeBumpSequence",
 	12: "OperationTypeManageBuyOffer",
+	13: "OperationTypePathPaymentStrictSend",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
@@ -6231,9 +6294,9 @@ var (
 	_ encoding.BinaryUnmarshaler = (*PaymentOp)(nil)
 )
 
-// PathPaymentOp is an XDR Struct defines as:
+// PathPaymentStrictReceiveOp is an XDR Struct defines as:
 //
-//   struct PathPaymentOp
+//   struct PathPaymentStrictReceiveOp
 //    {
 //        Asset sendAsset; // asset we pay with
 //        int64 sendMax;   // the maximum amount of sendAsset to
@@ -6247,7 +6310,7 @@ var (
 //        Asset path<5>; // additional hops it must go through to get there
 //    };
 //
-type PathPaymentOp struct {
+type PathPaymentStrictReceiveOp struct {
 	SendAsset   Asset
 	SendMax     Int64
 	Destination AccountId
@@ -6257,21 +6320,64 @@ type PathPaymentOp struct {
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s PathPaymentOp) MarshalBinary() ([]byte, error) {
+func (s PathPaymentStrictReceiveOp) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *PathPaymentOp) UnmarshalBinary(inp []byte) error {
+func (s *PathPaymentStrictReceiveOp) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*PathPaymentOp)(nil)
-	_ encoding.BinaryUnmarshaler = (*PathPaymentOp)(nil)
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictReceiveOp)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictReceiveOp)(nil)
+)
+
+// PathPaymentStrictSendOp is an XDR Struct defines as:
+//
+//   struct PathPaymentStrictSendOp
+//    {
+//        Asset sendAsset;  // asset we pay with
+//        int64 sendAmount; // amount of sendAsset to send (excluding fees)
+//
+//        AccountID destination; // recipient of the payment
+//        Asset destAsset;       // what they end up with
+//        int64 destMin;         // the minimum amount of dest asset to
+//                               // be received
+//                               // The operation will fail if it can't be met
+//
+//        Asset path<5>; // additional hops it must go through to get there
+//    };
+//
+type PathPaymentStrictSendOp struct {
+	SendAsset   Asset
+	SendAmount  Int64
+	Destination AccountId
+	DestAsset   Asset
+	DestMin     Int64
+	Path        []Asset `xdrmaxsize:"5"`
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s PathPaymentStrictSendOp) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *PathPaymentStrictSendOp) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictSendOp)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictSendOp)(nil)
 )
 
 // ManageSellOfferOp is an XDR Struct defines as:
@@ -6479,18 +6585,18 @@ var (
 //        {
 //        // ASSET_TYPE_NATIVE is not allowed
 //        case ASSET_TYPE_CREDIT_ALPHANUM4:
-//            opaque assetCode4[4];
+//            AssetCode4 assetCode4;
 //
 //        case ASSET_TYPE_CREDIT_ALPHANUM12:
-//            opaque assetCode12[12];
+//            AssetCode12 assetCode12;
 //
 //            // add other asset types here in the future
 //        }
 //
 type AllowTrustOpAsset struct {
 	Type        AssetType
-	AssetCode4  *[4]byte  `xdrmaxsize:"4"`
-	AssetCode12 *[12]byte `xdrmaxsize:"12"`
+	AssetCode4  *AssetCode4
+	AssetCode12 *AssetCode12
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -6516,16 +6622,16 @@ func NewAllowTrustOpAsset(aType AssetType, value interface{}) (result AllowTrust
 	result.Type = aType
 	switch AssetType(aType) {
 	case AssetTypeAssetTypeCreditAlphanum4:
-		tv, ok := value.([4]byte)
+		tv, ok := value.(AssetCode4)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be [4]byte")
+			err = fmt.Errorf("invalid value, must be AssetCode4")
 			return
 		}
 		result.AssetCode4 = &tv
 	case AssetTypeAssetTypeCreditAlphanum12:
-		tv, ok := value.([12]byte)
+		tv, ok := value.(AssetCode12)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be [12]byte")
+			err = fmt.Errorf("invalid value, must be AssetCode12")
 			return
 		}
 		result.AssetCode12 = &tv
@@ -6535,7 +6641,7 @@ func NewAllowTrustOpAsset(aType AssetType, value interface{}) (result AllowTrust
 
 // MustAssetCode4 retrieves the AssetCode4 value from the union,
 // panicing if the value is not set.
-func (u AllowTrustOpAsset) MustAssetCode4() [4]byte {
+func (u AllowTrustOpAsset) MustAssetCode4() AssetCode4 {
 	val, ok := u.GetAssetCode4()
 
 	if !ok {
@@ -6547,7 +6653,7 @@ func (u AllowTrustOpAsset) MustAssetCode4() [4]byte {
 
 // GetAssetCode4 retrieves the AssetCode4 value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u AllowTrustOpAsset) GetAssetCode4() (result [4]byte, ok bool) {
+func (u AllowTrustOpAsset) GetAssetCode4() (result AssetCode4, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
 	if armName == "AssetCode4" {
@@ -6560,7 +6666,7 @@ func (u AllowTrustOpAsset) GetAssetCode4() (result [4]byte, ok bool) {
 
 // MustAssetCode12 retrieves the AssetCode12 value from the union,
 // panicing if the value is not set.
-func (u AllowTrustOpAsset) MustAssetCode12() [12]byte {
+func (u AllowTrustOpAsset) MustAssetCode12() AssetCode12 {
 	val, ok := u.GetAssetCode12()
 
 	if !ok {
@@ -6572,7 +6678,7 @@ func (u AllowTrustOpAsset) MustAssetCode12() [12]byte {
 
 // GetAssetCode12 retrieves the AssetCode12 value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u AllowTrustOpAsset) GetAssetCode12() (result [12]byte, ok bool) {
+func (u AllowTrustOpAsset) GetAssetCode12() (result AssetCode12, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
 	if armName == "AssetCode12" {
@@ -6610,10 +6716,10 @@ var (
 //        {
 //        // ASSET_TYPE_NATIVE is not allowed
 //        case ASSET_TYPE_CREDIT_ALPHANUM4:
-//            opaque assetCode4[4];
+//            AssetCode4 assetCode4;
 //
 //        case ASSET_TYPE_CREDIT_ALPHANUM12:
-//            opaque assetCode12[12];
+//            AssetCode12 assetCode12;
 //
 //            // add other asset types here in the future
 //        }
@@ -6714,8 +6820,8 @@ var (
 //            CreateAccountOp createAccountOp;
 //        case PAYMENT:
 //            PaymentOp paymentOp;
-//        case PATH_PAYMENT:
-//            PathPaymentOp pathPaymentOp;
+//        case PATH_PAYMENT_STRICT_RECEIVE:
+//            PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
 //        case MANAGE_SELL_OFFER:
 //            ManageSellOfferOp manageSellOfferOp;
 //        case CREATE_PASSIVE_SELL_OFFER:
@@ -6736,22 +6842,25 @@ var (
 //            BumpSequenceOp bumpSequenceOp;
 //        case MANAGE_BUY_OFFER:
 //            ManageBuyOfferOp manageBuyOfferOp;
+//        case PATH_PAYMENT_STRICT_SEND:
+//            PathPaymentStrictSendOp pathPaymentStrictSendOp;
 //        }
 //
 type OperationBody struct {
-	Type                     OperationType
-	CreateAccountOp          *CreateAccountOp
-	PaymentOp                *PaymentOp
-	PathPaymentOp            *PathPaymentOp
-	ManageSellOfferOp        *ManageSellOfferOp
-	CreatePassiveSellOfferOp *CreatePassiveSellOfferOp
-	SetOptionsOp             *SetOptionsOp
-	ChangeTrustOp            *ChangeTrustOp
-	AllowTrustOp             *AllowTrustOp
-	Destination              *AccountId
-	ManageDataOp             *ManageDataOp
-	BumpSequenceOp           *BumpSequenceOp
-	ManageBuyOfferOp         *ManageBuyOfferOp
+	Type                       OperationType
+	CreateAccountOp            *CreateAccountOp
+	PaymentOp                  *PaymentOp
+	PathPaymentStrictReceiveOp *PathPaymentStrictReceiveOp
+	ManageSellOfferOp          *ManageSellOfferOp
+	CreatePassiveSellOfferOp   *CreatePassiveSellOfferOp
+	SetOptionsOp               *SetOptionsOp
+	ChangeTrustOp              *ChangeTrustOp
+	AllowTrustOp               *AllowTrustOp
+	Destination                *AccountId
+	ManageDataOp               *ManageDataOp
+	BumpSequenceOp             *BumpSequenceOp
+	ManageBuyOfferOp           *ManageBuyOfferOp
+	PathPaymentStrictSendOp    *PathPaymentStrictSendOp
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -6768,8 +6877,8 @@ func (u OperationBody) ArmForSwitch(sw int32) (string, bool) {
 		return "CreateAccountOp", true
 	case OperationTypePayment:
 		return "PaymentOp", true
-	case OperationTypePathPayment:
-		return "PathPaymentOp", true
+	case OperationTypePathPaymentStrictReceive:
+		return "PathPaymentStrictReceiveOp", true
 	case OperationTypeManageSellOffer:
 		return "ManageSellOfferOp", true
 	case OperationTypeCreatePassiveSellOffer:
@@ -6790,6 +6899,8 @@ func (u OperationBody) ArmForSwitch(sw int32) (string, bool) {
 		return "BumpSequenceOp", true
 	case OperationTypeManageBuyOffer:
 		return "ManageBuyOfferOp", true
+	case OperationTypePathPaymentStrictSend:
+		return "PathPaymentStrictSendOp", true
 	}
 	return "-", false
 }
@@ -6812,13 +6923,13 @@ func NewOperationBody(aType OperationType, value interface{}) (result OperationB
 			return
 		}
 		result.PaymentOp = &tv
-	case OperationTypePathPayment:
-		tv, ok := value.(PathPaymentOp)
+	case OperationTypePathPaymentStrictReceive:
+		tv, ok := value.(PathPaymentStrictReceiveOp)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be PathPaymentOp")
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictReceiveOp")
 			return
 		}
-		result.PathPaymentOp = &tv
+		result.PathPaymentStrictReceiveOp = &tv
 	case OperationTypeManageSellOffer:
 		tv, ok := value.(ManageSellOfferOp)
 		if !ok {
@@ -6884,6 +6995,13 @@ func NewOperationBody(aType OperationType, value interface{}) (result OperationB
 			return
 		}
 		result.ManageBuyOfferOp = &tv
+	case OperationTypePathPaymentStrictSend:
+		tv, ok := value.(PathPaymentStrictSendOp)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictSendOp")
+			return
+		}
+		result.PathPaymentStrictSendOp = &tv
 	}
 	return
 }
@@ -6938,25 +7056,25 @@ func (u OperationBody) GetPaymentOp() (result PaymentOp, ok bool) {
 	return
 }
 
-// MustPathPaymentOp retrieves the PathPaymentOp value from the union,
+// MustPathPaymentStrictReceiveOp retrieves the PathPaymentStrictReceiveOp value from the union,
 // panicing if the value is not set.
-func (u OperationBody) MustPathPaymentOp() PathPaymentOp {
-	val, ok := u.GetPathPaymentOp()
+func (u OperationBody) MustPathPaymentStrictReceiveOp() PathPaymentStrictReceiveOp {
+	val, ok := u.GetPathPaymentStrictReceiveOp()
 
 	if !ok {
-		panic("arm PathPaymentOp is not set")
+		panic("arm PathPaymentStrictReceiveOp is not set")
 	}
 
 	return val
 }
 
-// GetPathPaymentOp retrieves the PathPaymentOp value from the union,
+// GetPathPaymentStrictReceiveOp retrieves the PathPaymentStrictReceiveOp value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u OperationBody) GetPathPaymentOp() (result PathPaymentOp, ok bool) {
+func (u OperationBody) GetPathPaymentStrictReceiveOp() (result PathPaymentStrictReceiveOp, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
-	if armName == "PathPaymentOp" {
-		result = *u.PathPaymentOp
+	if armName == "PathPaymentStrictReceiveOp" {
+		result = *u.PathPaymentStrictReceiveOp
 		ok = true
 	}
 
@@ -7188,6 +7306,31 @@ func (u OperationBody) GetManageBuyOfferOp() (result ManageBuyOfferOp, ok bool) 
 	return
 }
 
+// MustPathPaymentStrictSendOp retrieves the PathPaymentStrictSendOp value from the union,
+// panicing if the value is not set.
+func (u OperationBody) MustPathPaymentStrictSendOp() PathPaymentStrictSendOp {
+	val, ok := u.GetPathPaymentStrictSendOp()
+
+	if !ok {
+		panic("arm PathPaymentStrictSendOp is not set")
+	}
+
+	return val
+}
+
+// GetPathPaymentStrictSendOp retrieves the PathPaymentStrictSendOp value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u OperationBody) GetPathPaymentStrictSendOp() (result PathPaymentStrictSendOp, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "PathPaymentStrictSendOp" {
+		result = *u.PathPaymentStrictSendOp
+		ok = true
+	}
+
+	return
+}
+
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (s OperationBody) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
@@ -7221,8 +7364,8 @@ var (
 //            CreateAccountOp createAccountOp;
 //        case PAYMENT:
 //            PaymentOp paymentOp;
-//        case PATH_PAYMENT:
-//            PathPaymentOp pathPaymentOp;
+//        case PATH_PAYMENT_STRICT_RECEIVE:
+//            PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
 //        case MANAGE_SELL_OFFER:
 //            ManageSellOfferOp manageSellOfferOp;
 //        case CREATE_PASSIVE_SELL_OFFER:
@@ -7243,6 +7386,8 @@ var (
 //            BumpSequenceOp bumpSequenceOp;
 //        case MANAGE_BUY_OFFER:
 //            ManageBuyOfferOp manageBuyOfferOp;
+//        case PATH_PAYMENT_STRICT_SEND:
+//            PathPaymentStrictSendOp pathPaymentStrictSendOp;
 //        }
 //        body;
 //    };
@@ -8150,91 +8295,91 @@ var (
 	_ encoding.BinaryUnmarshaler = (*PaymentResult)(nil)
 )
 
-// PathPaymentResultCode is an XDR Enum defines as:
+// PathPaymentStrictReceiveResultCode is an XDR Enum defines as:
 //
-//   enum PathPaymentResultCode
+//   enum PathPaymentStrictReceiveResultCode
 //    {
 //        // codes considered as "success" for the operation
-//        PATH_PAYMENT_SUCCESS = 0, // success
+//        PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
 //
 //        // codes considered as "failure" for the operation
-//        PATH_PAYMENT_MALFORMED = -1,          // bad input
-//        PATH_PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
-//        PATH_PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
-//        PATH_PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-//        PATH_PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
-//        PATH_PAYMENT_NO_TRUST = -6,           // dest missing a trust line for asset
-//        PATH_PAYMENT_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
-//        PATH_PAYMENT_LINE_FULL = -8,          // dest would go above their limit
-//        PATH_PAYMENT_NO_ISSUER = -9,          // missing issuer on one asset
-//        PATH_PAYMENT_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
-//        PATH_PAYMENT_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
-//        PATH_PAYMENT_OVER_SENDMAX = -12       // could not satisfy sendmax
+//        PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1,          // bad input
+//        PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED = -2,        // not enough funds in source account
+//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST = -3,       // no trust line on source account
+//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION = -5,     // destination account does not exist
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST = -6,           // dest missing a trust line for asset
+//        PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
+//        PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL = -8,          // dest would go above their limit
+//        PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9,          // missing issuer on one asset
+//        PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+//        PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+//        PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12       // could not satisfy sendmax
 //    };
 //
-type PathPaymentResultCode int32
+type PathPaymentStrictReceiveResultCode int32
 
 const (
-	PathPaymentResultCodePathPaymentSuccess          PathPaymentResultCode = 0
-	PathPaymentResultCodePathPaymentMalformed        PathPaymentResultCode = -1
-	PathPaymentResultCodePathPaymentUnderfunded      PathPaymentResultCode = -2
-	PathPaymentResultCodePathPaymentSrcNoTrust       PathPaymentResultCode = -3
-	PathPaymentResultCodePathPaymentSrcNotAuthorized PathPaymentResultCode = -4
-	PathPaymentResultCodePathPaymentNoDestination    PathPaymentResultCode = -5
-	PathPaymentResultCodePathPaymentNoTrust          PathPaymentResultCode = -6
-	PathPaymentResultCodePathPaymentNotAuthorized    PathPaymentResultCode = -7
-	PathPaymentResultCodePathPaymentLineFull         PathPaymentResultCode = -8
-	PathPaymentResultCodePathPaymentNoIssuer         PathPaymentResultCode = -9
-	PathPaymentResultCodePathPaymentTooFewOffers     PathPaymentResultCode = -10
-	PathPaymentResultCodePathPaymentOfferCrossSelf   PathPaymentResultCode = -11
-	PathPaymentResultCodePathPaymentOverSendmax      PathPaymentResultCode = -12
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess          PathPaymentStrictReceiveResultCode = 0
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveMalformed        PathPaymentStrictReceiveResultCode = -1
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveUnderfunded      PathPaymentStrictReceiveResultCode = -2
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNoTrust       PathPaymentStrictReceiveResultCode = -3
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNotAuthorized PathPaymentStrictReceiveResultCode = -4
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoDestination    PathPaymentStrictReceiveResultCode = -5
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoTrust          PathPaymentStrictReceiveResultCode = -6
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNotAuthorized    PathPaymentStrictReceiveResultCode = -7
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveLineFull         PathPaymentStrictReceiveResultCode = -8
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer         PathPaymentStrictReceiveResultCode = -9
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveTooFewOffers     PathPaymentStrictReceiveResultCode = -10
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOfferCrossSelf   PathPaymentStrictReceiveResultCode = -11
+	PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOverSendmax      PathPaymentStrictReceiveResultCode = -12
 )
 
-var pathPaymentResultCodeMap = map[int32]string{
-	0:   "PathPaymentResultCodePathPaymentSuccess",
-	-1:  "PathPaymentResultCodePathPaymentMalformed",
-	-2:  "PathPaymentResultCodePathPaymentUnderfunded",
-	-3:  "PathPaymentResultCodePathPaymentSrcNoTrust",
-	-4:  "PathPaymentResultCodePathPaymentSrcNotAuthorized",
-	-5:  "PathPaymentResultCodePathPaymentNoDestination",
-	-6:  "PathPaymentResultCodePathPaymentNoTrust",
-	-7:  "PathPaymentResultCodePathPaymentNotAuthorized",
-	-8:  "PathPaymentResultCodePathPaymentLineFull",
-	-9:  "PathPaymentResultCodePathPaymentNoIssuer",
-	-10: "PathPaymentResultCodePathPaymentTooFewOffers",
-	-11: "PathPaymentResultCodePathPaymentOfferCrossSelf",
-	-12: "PathPaymentResultCodePathPaymentOverSendmax",
+var pathPaymentStrictReceiveResultCodeMap = map[int32]string{
+	0:   "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess",
+	-1:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveMalformed",
+	-2:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveUnderfunded",
+	-3:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNoTrust",
+	-4:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSrcNotAuthorized",
+	-5:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoDestination",
+	-6:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoTrust",
+	-7:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNotAuthorized",
+	-8:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveLineFull",
+	-9:  "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer",
+	-10: "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveTooFewOffers",
+	-11: "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOfferCrossSelf",
+	-12: "PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveOverSendmax",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
-// the Enum interface for PathPaymentResultCode
-func (e PathPaymentResultCode) ValidEnum(v int32) bool {
-	_, ok := pathPaymentResultCodeMap[v]
+// the Enum interface for PathPaymentStrictReceiveResultCode
+func (e PathPaymentStrictReceiveResultCode) ValidEnum(v int32) bool {
+	_, ok := pathPaymentStrictReceiveResultCodeMap[v]
 	return ok
 }
 
 // String returns the name of `e`
-func (e PathPaymentResultCode) String() string {
-	name, _ := pathPaymentResultCodeMap[int32(e)]
+func (e PathPaymentStrictReceiveResultCode) String() string {
+	name, _ := pathPaymentStrictReceiveResultCodeMap[int32(e)]
 	return name
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s PathPaymentResultCode) MarshalBinary() ([]byte, error) {
+func (s PathPaymentStrictReceiveResultCode) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *PathPaymentResultCode) UnmarshalBinary(inp []byte) error {
+func (s *PathPaymentStrictReceiveResultCode) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*PathPaymentResultCode)(nil)
-	_ encoding.BinaryUnmarshaler = (*PathPaymentResultCode)(nil)
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictReceiveResultCode)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictReceiveResultCode)(nil)
 )
 
 // SimplePaymentResult is an XDR Struct defines as:
@@ -8270,7 +8415,7 @@ var (
 	_ encoding.BinaryUnmarshaler = (*SimplePaymentResult)(nil)
 )
 
-// PathPaymentResultSuccess is an XDR NestedStruct defines as:
+// PathPaymentStrictReceiveResultSuccess is an XDR NestedStruct defines as:
 //
 //   struct
 //        {
@@ -8278,82 +8423,82 @@ var (
 //            SimplePaymentResult last;
 //        }
 //
-type PathPaymentResultSuccess struct {
+type PathPaymentStrictReceiveResultSuccess struct {
 	Offers []ClaimOfferAtom
 	Last   SimplePaymentResult
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s PathPaymentResultSuccess) MarshalBinary() ([]byte, error) {
+func (s PathPaymentStrictReceiveResultSuccess) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *PathPaymentResultSuccess) UnmarshalBinary(inp []byte) error {
+func (s *PathPaymentStrictReceiveResultSuccess) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*PathPaymentResultSuccess)(nil)
-	_ encoding.BinaryUnmarshaler = (*PathPaymentResultSuccess)(nil)
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictReceiveResultSuccess)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictReceiveResultSuccess)(nil)
 )
 
-// PathPaymentResult is an XDR Union defines as:
+// PathPaymentStrictReceiveResult is an XDR Union defines as:
 //
-//   union PathPaymentResult switch (PathPaymentResultCode code)
+//   union PathPaymentStrictReceiveResult switch (PathPaymentStrictReceiveResultCode code)
 //    {
-//    case PATH_PAYMENT_SUCCESS:
+//    case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
 //        struct
 //        {
 //            ClaimOfferAtom offers<>;
 //            SimplePaymentResult last;
 //        } success;
-//    case PATH_PAYMENT_NO_ISSUER:
+//    case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
 //        Asset noIssuer; // the asset that caused the error
 //    default:
 //        void;
 //    };
 //
-type PathPaymentResult struct {
-	Code     PathPaymentResultCode
-	Success  *PathPaymentResultSuccess
+type PathPaymentStrictReceiveResult struct {
+	Code     PathPaymentStrictReceiveResultCode
+	Success  *PathPaymentStrictReceiveResultSuccess
 	NoIssuer *Asset
 }
 
 // SwitchFieldName returns the field name in which this union's
 // discriminant is stored
-func (u PathPaymentResult) SwitchFieldName() string {
+func (u PathPaymentStrictReceiveResult) SwitchFieldName() string {
 	return "Code"
 }
 
 // ArmForSwitch returns which field name should be used for storing
-// the value for an instance of PathPaymentResult
-func (u PathPaymentResult) ArmForSwitch(sw int32) (string, bool) {
-	switch PathPaymentResultCode(sw) {
-	case PathPaymentResultCodePathPaymentSuccess:
+// the value for an instance of PathPaymentStrictReceiveResult
+func (u PathPaymentStrictReceiveResult) ArmForSwitch(sw int32) (string, bool) {
+	switch PathPaymentStrictReceiveResultCode(sw) {
+	case PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess:
 		return "Success", true
-	case PathPaymentResultCodePathPaymentNoIssuer:
+	case PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer:
 		return "NoIssuer", true
 	default:
 		return "", true
 	}
 }
 
-// NewPathPaymentResult creates a new  PathPaymentResult.
-func NewPathPaymentResult(code PathPaymentResultCode, value interface{}) (result PathPaymentResult, err error) {
+// NewPathPaymentStrictReceiveResult creates a new  PathPaymentStrictReceiveResult.
+func NewPathPaymentStrictReceiveResult(code PathPaymentStrictReceiveResultCode, value interface{}) (result PathPaymentStrictReceiveResult, err error) {
 	result.Code = code
-	switch PathPaymentResultCode(code) {
-	case PathPaymentResultCodePathPaymentSuccess:
-		tv, ok := value.(PathPaymentResultSuccess)
+	switch PathPaymentStrictReceiveResultCode(code) {
+	case PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess:
+		tv, ok := value.(PathPaymentStrictReceiveResultSuccess)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be PathPaymentResultSuccess")
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictReceiveResultSuccess")
 			return
 		}
 		result.Success = &tv
-	case PathPaymentResultCodePathPaymentNoIssuer:
+	case PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveNoIssuer:
 		tv, ok := value.(Asset)
 		if !ok {
 			err = fmt.Errorf("invalid value, must be Asset")
@@ -8368,7 +8513,7 @@ func NewPathPaymentResult(code PathPaymentResultCode, value interface{}) (result
 
 // MustSuccess retrieves the Success value from the union,
 // panicing if the value is not set.
-func (u PathPaymentResult) MustSuccess() PathPaymentResultSuccess {
+func (u PathPaymentStrictReceiveResult) MustSuccess() PathPaymentStrictReceiveResultSuccess {
 	val, ok := u.GetSuccess()
 
 	if !ok {
@@ -8380,7 +8525,7 @@ func (u PathPaymentResult) MustSuccess() PathPaymentResultSuccess {
 
 // GetSuccess retrieves the Success value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u PathPaymentResult) GetSuccess() (result PathPaymentResultSuccess, ok bool) {
+func (u PathPaymentStrictReceiveResult) GetSuccess() (result PathPaymentStrictReceiveResultSuccess, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Code))
 
 	if armName == "Success" {
@@ -8393,7 +8538,7 @@ func (u PathPaymentResult) GetSuccess() (result PathPaymentResultSuccess, ok boo
 
 // MustNoIssuer retrieves the NoIssuer value from the union,
 // panicing if the value is not set.
-func (u PathPaymentResult) MustNoIssuer() Asset {
+func (u PathPaymentStrictReceiveResult) MustNoIssuer() Asset {
 	val, ok := u.GetNoIssuer()
 
 	if !ok {
@@ -8405,7 +8550,7 @@ func (u PathPaymentResult) MustNoIssuer() Asset {
 
 // GetNoIssuer retrieves the NoIssuer value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u PathPaymentResult) GetNoIssuer() (result Asset, ok bool) {
+func (u PathPaymentStrictReceiveResult) GetNoIssuer() (result Asset, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Code))
 
 	if armName == "NoIssuer" {
@@ -8417,21 +8562,272 @@ func (u PathPaymentResult) GetNoIssuer() (result Asset, ok bool) {
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s PathPaymentResult) MarshalBinary() ([]byte, error) {
+func (s PathPaymentStrictReceiveResult) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *PathPaymentResult) UnmarshalBinary(inp []byte) error {
+func (s *PathPaymentStrictReceiveResult) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*PathPaymentResult)(nil)
-	_ encoding.BinaryUnmarshaler = (*PathPaymentResult)(nil)
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictReceiveResult)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictReceiveResult)(nil)
+)
+
+// PathPaymentStrictSendResultCode is an XDR Enum defines as:
+//
+//   enum PathPaymentStrictSendResultCode
+//    {
+//        // codes considered as "success" for the operation
+//        PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
+//
+//        // codes considered as "failure" for the operation
+//        PATH_PAYMENT_STRICT_SEND_MALFORMED = -1,          // bad input
+//        PATH_PAYMENT_STRICT_SEND_UNDERFUNDED = -2,        // not enough funds in source account
+//        PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST = -3,       // no trust line on source account
+//        PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+//        PATH_PAYMENT_STRICT_SEND_NO_DESTINATION = -5,     // destination account does not exist
+//        PATH_PAYMENT_STRICT_SEND_NO_TRUST = -6,           // dest missing a trust line for asset
+//        PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
+//        PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8,          // dest would go above their limit
+//        PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9,          // missing issuer on one asset
+//        PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+//        PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+//        PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12      // could not satisfy destMin
+//    };
+//
+type PathPaymentStrictSendResultCode int32
+
+const (
+	PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess          PathPaymentStrictSendResultCode = 0
+	PathPaymentStrictSendResultCodePathPaymentStrictSendMalformed        PathPaymentStrictSendResultCode = -1
+	PathPaymentStrictSendResultCodePathPaymentStrictSendUnderfunded      PathPaymentStrictSendResultCode = -2
+	PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNoTrust       PathPaymentStrictSendResultCode = -3
+	PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNotAuthorized PathPaymentStrictSendResultCode = -4
+	PathPaymentStrictSendResultCodePathPaymentStrictSendNoDestination    PathPaymentStrictSendResultCode = -5
+	PathPaymentStrictSendResultCodePathPaymentStrictSendNoTrust          PathPaymentStrictSendResultCode = -6
+	PathPaymentStrictSendResultCodePathPaymentStrictSendNotAuthorized    PathPaymentStrictSendResultCode = -7
+	PathPaymentStrictSendResultCodePathPaymentStrictSendLineFull         PathPaymentStrictSendResultCode = -8
+	PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer         PathPaymentStrictSendResultCode = -9
+	PathPaymentStrictSendResultCodePathPaymentStrictSendTooFewOffers     PathPaymentStrictSendResultCode = -10
+	PathPaymentStrictSendResultCodePathPaymentStrictSendOfferCrossSelf   PathPaymentStrictSendResultCode = -11
+	PathPaymentStrictSendResultCodePathPaymentStrictSendUnderDestmin     PathPaymentStrictSendResultCode = -12
+)
+
+var pathPaymentStrictSendResultCodeMap = map[int32]string{
+	0:   "PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess",
+	-1:  "PathPaymentStrictSendResultCodePathPaymentStrictSendMalformed",
+	-2:  "PathPaymentStrictSendResultCodePathPaymentStrictSendUnderfunded",
+	-3:  "PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNoTrust",
+	-4:  "PathPaymentStrictSendResultCodePathPaymentStrictSendSrcNotAuthorized",
+	-5:  "PathPaymentStrictSendResultCodePathPaymentStrictSendNoDestination",
+	-6:  "PathPaymentStrictSendResultCodePathPaymentStrictSendNoTrust",
+	-7:  "PathPaymentStrictSendResultCodePathPaymentStrictSendNotAuthorized",
+	-8:  "PathPaymentStrictSendResultCodePathPaymentStrictSendLineFull",
+	-9:  "PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer",
+	-10: "PathPaymentStrictSendResultCodePathPaymentStrictSendTooFewOffers",
+	-11: "PathPaymentStrictSendResultCodePathPaymentStrictSendOfferCrossSelf",
+	-12: "PathPaymentStrictSendResultCodePathPaymentStrictSendUnderDestmin",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for PathPaymentStrictSendResultCode
+func (e PathPaymentStrictSendResultCode) ValidEnum(v int32) bool {
+	_, ok := pathPaymentStrictSendResultCodeMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (e PathPaymentStrictSendResultCode) String() string {
+	name, _ := pathPaymentStrictSendResultCodeMap[int32(e)]
+	return name
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s PathPaymentStrictSendResultCode) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *PathPaymentStrictSendResultCode) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictSendResultCode)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictSendResultCode)(nil)
+)
+
+// PathPaymentStrictSendResultSuccess is an XDR NestedStruct defines as:
+//
+//   struct
+//        {
+//            ClaimOfferAtom offers<>;
+//            SimplePaymentResult last;
+//        }
+//
+type PathPaymentStrictSendResultSuccess struct {
+	Offers []ClaimOfferAtom
+	Last   SimplePaymentResult
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s PathPaymentStrictSendResultSuccess) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *PathPaymentStrictSendResultSuccess) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictSendResultSuccess)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictSendResultSuccess)(nil)
+)
+
+// PathPaymentStrictSendResult is an XDR Union defines as:
+//
+//   union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
+//    {
+//    case PATH_PAYMENT_STRICT_SEND_SUCCESS:
+//        struct
+//        {
+//            ClaimOfferAtom offers<>;
+//            SimplePaymentResult last;
+//        } success;
+//    case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
+//        Asset noIssuer; // the asset that caused the error
+//    default:
+//        void;
+//    };
+//
+type PathPaymentStrictSendResult struct {
+	Code     PathPaymentStrictSendResultCode
+	Success  *PathPaymentStrictSendResultSuccess
+	NoIssuer *Asset
+}
+
+// SwitchFieldName returns the field name in which this union's
+// discriminant is stored
+func (u PathPaymentStrictSendResult) SwitchFieldName() string {
+	return "Code"
+}
+
+// ArmForSwitch returns which field name should be used for storing
+// the value for an instance of PathPaymentStrictSendResult
+func (u PathPaymentStrictSendResult) ArmForSwitch(sw int32) (string, bool) {
+	switch PathPaymentStrictSendResultCode(sw) {
+	case PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess:
+		return "Success", true
+	case PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer:
+		return "NoIssuer", true
+	default:
+		return "", true
+	}
+}
+
+// NewPathPaymentStrictSendResult creates a new  PathPaymentStrictSendResult.
+func NewPathPaymentStrictSendResult(code PathPaymentStrictSendResultCode, value interface{}) (result PathPaymentStrictSendResult, err error) {
+	result.Code = code
+	switch PathPaymentStrictSendResultCode(code) {
+	case PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess:
+		tv, ok := value.(PathPaymentStrictSendResultSuccess)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictSendResultSuccess")
+			return
+		}
+		result.Success = &tv
+	case PathPaymentStrictSendResultCodePathPaymentStrictSendNoIssuer:
+		tv, ok := value.(Asset)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be Asset")
+			return
+		}
+		result.NoIssuer = &tv
+	default:
+		// void
+	}
+	return
+}
+
+// MustSuccess retrieves the Success value from the union,
+// panicing if the value is not set.
+func (u PathPaymentStrictSendResult) MustSuccess() PathPaymentStrictSendResultSuccess {
+	val, ok := u.GetSuccess()
+
+	if !ok {
+		panic("arm Success is not set")
+	}
+
+	return val
+}
+
+// GetSuccess retrieves the Success value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u PathPaymentStrictSendResult) GetSuccess() (result PathPaymentStrictSendResultSuccess, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Code))
+
+	if armName == "Success" {
+		result = *u.Success
+		ok = true
+	}
+
+	return
+}
+
+// MustNoIssuer retrieves the NoIssuer value from the union,
+// panicing if the value is not set.
+func (u PathPaymentStrictSendResult) MustNoIssuer() Asset {
+	val, ok := u.GetNoIssuer()
+
+	if !ok {
+		panic("arm NoIssuer is not set")
+	}
+
+	return val
+}
+
+// GetNoIssuer retrieves the NoIssuer value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u PathPaymentStrictSendResult) GetNoIssuer() (result Asset, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Code))
+
+	if armName == "NoIssuer" {
+		result = *u.NoIssuer
+		ok = true
+	}
+
+	return
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s PathPaymentStrictSendResult) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *PathPaymentStrictSendResult) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*PathPaymentStrictSendResult)(nil)
+	_ encoding.BinaryUnmarshaler = (*PathPaymentStrictSendResult)(nil)
 )
 
 // ManageSellOfferResultCode is an XDR Enum defines as:
@@ -10036,8 +10432,8 @@ var (
 //            CreateAccountResult createAccountResult;
 //        case PAYMENT:
 //            PaymentResult paymentResult;
-//        case PATH_PAYMENT:
-//            PathPaymentResult pathPaymentResult;
+//        case PATH_PAYMENT_STRICT_RECEIVE:
+//            PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
 //        case MANAGE_SELL_OFFER:
 //            ManageSellOfferResult manageSellOfferResult;
 //        case CREATE_PASSIVE_SELL_OFFER:
@@ -10058,23 +10454,26 @@ var (
 //            BumpSequenceResult bumpSeqResult;
 //        case MANAGE_BUY_OFFER:
 //    	ManageBuyOfferResult manageBuyOfferResult;
+//        case PATH_PAYMENT_STRICT_SEND:
+//            PathPaymentStrictSendResult pathPaymentStrictSendResult;
 //        }
 //
 type OperationResultTr struct {
-	Type                         OperationType
-	CreateAccountResult          *CreateAccountResult
-	PaymentResult                *PaymentResult
-	PathPaymentResult            *PathPaymentResult
-	ManageSellOfferResult        *ManageSellOfferResult
-	CreatePassiveSellOfferResult *ManageSellOfferResult
-	SetOptionsResult             *SetOptionsResult
-	ChangeTrustResult            *ChangeTrustResult
-	AllowTrustResult             *AllowTrustResult
-	AccountMergeResult           *AccountMergeResult
-	InflationResult              *InflationResult
-	ManageDataResult             *ManageDataResult
-	BumpSeqResult                *BumpSequenceResult
-	ManageBuyOfferResult         *ManageBuyOfferResult
+	Type                           OperationType
+	CreateAccountResult            *CreateAccountResult
+	PaymentResult                  *PaymentResult
+	PathPaymentStrictReceiveResult *PathPaymentStrictReceiveResult
+	ManageSellOfferResult          *ManageSellOfferResult
+	CreatePassiveSellOfferResult   *ManageSellOfferResult
+	SetOptionsResult               *SetOptionsResult
+	ChangeTrustResult              *ChangeTrustResult
+	AllowTrustResult               *AllowTrustResult
+	AccountMergeResult             *AccountMergeResult
+	InflationResult                *InflationResult
+	ManageDataResult               *ManageDataResult
+	BumpSeqResult                  *BumpSequenceResult
+	ManageBuyOfferResult           *ManageBuyOfferResult
+	PathPaymentStrictSendResult    *PathPaymentStrictSendResult
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -10091,8 +10490,8 @@ func (u OperationResultTr) ArmForSwitch(sw int32) (string, bool) {
 		return "CreateAccountResult", true
 	case OperationTypePayment:
 		return "PaymentResult", true
-	case OperationTypePathPayment:
-		return "PathPaymentResult", true
+	case OperationTypePathPaymentStrictReceive:
+		return "PathPaymentStrictReceiveResult", true
 	case OperationTypeManageSellOffer:
 		return "ManageSellOfferResult", true
 	case OperationTypeCreatePassiveSellOffer:
@@ -10113,6 +10512,8 @@ func (u OperationResultTr) ArmForSwitch(sw int32) (string, bool) {
 		return "BumpSeqResult", true
 	case OperationTypeManageBuyOffer:
 		return "ManageBuyOfferResult", true
+	case OperationTypePathPaymentStrictSend:
+		return "PathPaymentStrictSendResult", true
 	}
 	return "-", false
 }
@@ -10135,13 +10536,13 @@ func NewOperationResultTr(aType OperationType, value interface{}) (result Operat
 			return
 		}
 		result.PaymentResult = &tv
-	case OperationTypePathPayment:
-		tv, ok := value.(PathPaymentResult)
+	case OperationTypePathPaymentStrictReceive:
+		tv, ok := value.(PathPaymentStrictReceiveResult)
 		if !ok {
-			err = fmt.Errorf("invalid value, must be PathPaymentResult")
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictReceiveResult")
 			return
 		}
-		result.PathPaymentResult = &tv
+		result.PathPaymentStrictReceiveResult = &tv
 	case OperationTypeManageSellOffer:
 		tv, ok := value.(ManageSellOfferResult)
 		if !ok {
@@ -10212,6 +10613,13 @@ func NewOperationResultTr(aType OperationType, value interface{}) (result Operat
 			return
 		}
 		result.ManageBuyOfferResult = &tv
+	case OperationTypePathPaymentStrictSend:
+		tv, ok := value.(PathPaymentStrictSendResult)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be PathPaymentStrictSendResult")
+			return
+		}
+		result.PathPaymentStrictSendResult = &tv
 	}
 	return
 }
@@ -10266,25 +10674,25 @@ func (u OperationResultTr) GetPaymentResult() (result PaymentResult, ok bool) {
 	return
 }
 
-// MustPathPaymentResult retrieves the PathPaymentResult value from the union,
+// MustPathPaymentStrictReceiveResult retrieves the PathPaymentStrictReceiveResult value from the union,
 // panicing if the value is not set.
-func (u OperationResultTr) MustPathPaymentResult() PathPaymentResult {
-	val, ok := u.GetPathPaymentResult()
+func (u OperationResultTr) MustPathPaymentStrictReceiveResult() PathPaymentStrictReceiveResult {
+	val, ok := u.GetPathPaymentStrictReceiveResult()
 
 	if !ok {
-		panic("arm PathPaymentResult is not set")
+		panic("arm PathPaymentStrictReceiveResult is not set")
 	}
 
 	return val
 }
 
-// GetPathPaymentResult retrieves the PathPaymentResult value from the union,
+// GetPathPaymentStrictReceiveResult retrieves the PathPaymentStrictReceiveResult value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u OperationResultTr) GetPathPaymentResult() (result PathPaymentResult, ok bool) {
+func (u OperationResultTr) GetPathPaymentStrictReceiveResult() (result PathPaymentStrictReceiveResult, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
-	if armName == "PathPaymentResult" {
-		result = *u.PathPaymentResult
+	if armName == "PathPaymentStrictReceiveResult" {
+		result = *u.PathPaymentStrictReceiveResult
 		ok = true
 	}
 
@@ -10541,6 +10949,31 @@ func (u OperationResultTr) GetManageBuyOfferResult() (result ManageBuyOfferResul
 	return
 }
 
+// MustPathPaymentStrictSendResult retrieves the PathPaymentStrictSendResult value from the union,
+// panicing if the value is not set.
+func (u OperationResultTr) MustPathPaymentStrictSendResult() PathPaymentStrictSendResult {
+	val, ok := u.GetPathPaymentStrictSendResult()
+
+	if !ok {
+		panic("arm PathPaymentStrictSendResult is not set")
+	}
+
+	return val
+}
+
+// GetPathPaymentStrictSendResult retrieves the PathPaymentStrictSendResult value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u OperationResultTr) GetPathPaymentStrictSendResult() (result PathPaymentStrictSendResult, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "PathPaymentStrictSendResult" {
+		result = *u.PathPaymentStrictSendResult
+		ok = true
+	}
+
+	return
+}
+
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (s OperationResultTr) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
@@ -10570,8 +11003,8 @@ var (
 //            CreateAccountResult createAccountResult;
 //        case PAYMENT:
 //            PaymentResult paymentResult;
-//        case PATH_PAYMENT:
-//            PathPaymentResult pathPaymentResult;
+//        case PATH_PAYMENT_STRICT_RECEIVE:
+//            PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
 //        case MANAGE_SELL_OFFER:
 //            ManageSellOfferResult manageSellOfferResult;
 //        case CREATE_PASSIVE_SELL_OFFER:
@@ -10592,6 +11025,8 @@ var (
 //            BumpSequenceResult bumpSeqResult;
 //        case MANAGE_BUY_OFFER:
 //    	ManageBuyOfferResult manageBuyOfferResult;
+//        case PATH_PAYMENT_STRICT_SEND:
+//            PathPaymentStrictSendResult pathPaymentStrictSendResult;
 //        }
 //        tr;
 //    default:

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -706,8 +706,8 @@
 		{
 			"checksumSHA1": "Ppx7eV2JzOCJJu1xBOjTm7sPdio=",
 			"path": "github.com/keybase/stellarnet",
-			"revision": "9ddc4644b6c096dca8f54dacb94e601a9a05c218",
-			"revisionTime": "2020-01-06T21:40:24Z"
+			"revision": "aea14c9e62f0cd365672eaee9b142b102479c5b8",
+			"revisionTime": "2020-01-07T16:02:05Z"
 		},
 		{
 			"checksumSHA1": "B/Qlhpd96i6Sx0DdhSzbHUdG47U=",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -704,10 +704,10 @@
 			"revisionTime": "2019-08-28T02:09:36Z"
 		},
 		{
-			"checksumSHA1": "f8oLbOSuAeeqqIVW8TrYYxj6rTw=",
+			"checksumSHA1": "Ppx7eV2JzOCJJu1xBOjTm7sPdio=",
 			"path": "github.com/keybase/stellarnet",
-			"revision": "5d2b2e13831d7d81f3a70357611483c00f36ca19",
-			"revisionTime": "2019-10-11T15:21:56Z"
+			"revision": "9ddc4644b6c096dca8f54dacb94e601a9a05c218",
+			"revisionTime": "2020-01-06T21:40:24Z"
 		},
 		{
 			"checksumSHA1": "B/Qlhpd96i6Sx0DdhSzbHUdG47U=",
@@ -904,11 +904,11 @@
 			"revisionTime": "2019-06-21T18:08:33Z"
 		},
 		{
-			"checksumSHA1": "atGxvhJl/hBdPcAxrvJdQQ9mT9k=",
+			"checksumSHA1": "hCs9aZuNW3dnVeBqQ5bjTcvdDe0=",
 			"origin": "github.com/keybase/stellar-org/build",
 			"path": "github.com/stellar/go/build",
-			"revision": "e43266cae98f292a11218decae91a277a8489da2",
-			"revisionTime": "2019-06-21T18:08:33Z"
+			"revision": "0fc3bfe3dfa7aba69074e417e7dd47101b44e219",
+			"revisionTime": "2019-10-10T20:56:48Z"
 		},
 		{
 			"checksumSHA1": "lNNS4mTZlbciLrs24+zR03+KyA0=",
@@ -1037,11 +1037,11 @@
 			"revisionTime": "2019-06-21T18:08:33Z"
 		},
 		{
-			"checksumSHA1": "J5AQ9Qbd4n9uu2UYSTBXxfkmlGc=",
+			"checksumSHA1": "mo133jQLSnQ/CGp8jJcGggw6dq0=",
 			"origin": "github.com/keybase/stellar-org/xdr",
 			"path": "github.com/stellar/go/xdr",
-			"revision": "e43266cae98f292a11218decae91a277a8489da2",
-			"revisionTime": "2019-06-21T18:08:33Z"
+			"revision": "0fc3bfe3dfa7aba69074e417e7dd47101b44e219",
+			"revisionTime": "2019-10-10T20:56:48Z"
 		},
 		{
 			"checksumSHA1": "IIsn0Wdi5rHU8xca+FzDd+YeYlc=",

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -596,7 +596,7 @@ protocol local {
                                   string displayAmount, string displayCurrency, boolean forceRelay,
                                   string publicNote, PublicNoteType publicNoteType, AccountID fromAccountID);
 
-  SendResultCLILocal sendPathCLILocal(AccountID source, string recipient, PaymentPath path, string note, string publicNote);
+  SendResultCLILocal sendPathCLILocal(AccountID source, string recipient, PaymentPath path, string note, string publicNote, PublicNoteType publicNoteType);
   TransactionID accountMergeCLILocal(AccountID fromAccountID, union { null, SecretKey } fromSecretKey, string to);
 
   // Claim a relay payment

--- a/protocol/avdl/stellar1/local.avdl
+++ b/protocol/avdl/stellar1/local.avdl
@@ -584,9 +584,17 @@ protocol local {
     TransactionID txID;
   }
 
+  enum PublicNoteType {
+    NONE_0,
+    TEXT_1,
+    ID_2,
+    HASH_3,
+    RETURN_4
+  }
+
   SendResultCLILocal sendCLILocal(string recipient, string amount, Asset asset, string note,
                                   string displayAmount, string displayCurrency, boolean forceRelay,
-                                  string publicNote, AccountID fromAccountID);
+                                  string publicNote, PublicNoteType publicNoteType, AccountID fromAccountID);
 
   SendResultCLILocal sendPathCLILocal(AccountID source, string recipient, PaymentPath path, string note, string publicNote);
   TransactionID accountMergeCLILocal(AccountID fromAccountID, union { null, SecretKey } fromSecretKey, string to);

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -2502,6 +2502,10 @@
         {
           "name": "publicNote",
           "type": "string"
+        },
+        {
+          "name": "publicNoteType",
+          "type": "PublicNoteType"
         }
       ],
       "response": "SendResultCLILocal"

--- a/protocol/json/stellar1/local.json
+++ b/protocol/json/stellar1/local.json
@@ -943,6 +943,17 @@
       ]
     },
     {
+      "type": "enum",
+      "name": "PublicNoteType",
+      "symbols": [
+        "NONE_0",
+        "TEXT_1",
+        "ID_2",
+        "HASH_3",
+        "RETURN_4"
+      ]
+    },
+    {
       "type": "record",
       "name": "PaymentOrErrorCLILocal",
       "fields": [
@@ -2458,6 +2469,10 @@
         {
           "name": "publicNote",
           "type": "string"
+        },
+        {
+          "name": "publicNoteType",
+          "type": "PublicNoteType"
         },
         {
           "name": "fromAccountID",

--- a/shared/constants/types/rpc-stellar-gen.tsx
+++ b/shared/constants/types/rpc-stellar-gen.tsx
@@ -360,6 +360,14 @@ export enum PaymentSummaryType {
   relay = 3,
 }
 
+export enum PublicNoteType {
+  none = 0,
+  text = 1,
+  id = 2,
+  hash = 3,
+  return = 4,
+}
+
 export enum RelayDirection {
   claim = 0,
   yank = 1,


### PR DESCRIPTION
Previously we had no public memo support in the CLI.  This adds support for them, including all memo types.