### PR TITLE
add Stop to push handler

### DIFF
--- a/go/chat/push_test.go
+++ b/go/chat/push_test.go
@@ -86,6 +86,8 @@ func TestPushOrdering(t *testing.T) {
 	uid := u.User.GetUID().ToBytes()
 	tc := world.Tcs[u.Username]
 	handler := NewPushHandler(tc.Context())
+	handler.Start(context.TODO(), nil)
+	defer func() { <-handler.Stop(context.TODO()) }()
 	handler.SetClock(world.Fc)
 	timeout := 2 * time.Second
 
@@ -158,6 +160,8 @@ func TestPushAppState(t *testing.T) {
 	uid := u.User.GetUID().ToBytes()
 	tc := world.Tcs[u.Username]
 	handler := NewPushHandler(tc.Context())
+	handler.Start(context.TODO(), nil)
+	defer func() { <-handler.Stop(context.TODO()) }()
 	handler.SetClock(world.Fc)
 	conv := newBlankConv(ctx, t, tc, uid, ri, sender, u.Username)
 
@@ -206,6 +210,8 @@ func TestPushTyping(t *testing.T) {
 	uid := u.User.GetUID().ToBytes()
 	tc := world.Tcs[u.Username]
 	handler := NewPushHandler(tc.Context())
+	handler.Start(context.TODO(), nil)
+	defer func() { <-handler.Stop(context.TODO()) }()
 	handler.SetClock(world.Fc)
 	handler.typingMonitor.SetClock(world.Fc)
 	handler.typingMonitor.SetTimeout(time.Minute)

--- a/go/chat/sender_test.go
+++ b/go/chat/sender_test.go
@@ -299,6 +299,7 @@ func setupTest(t *testing.T, numUsers int) (context.Context, *kbtest.ChatMockWor
 
 	g.ConnectivityMonitor = &libkb.NullConnectivityMonitor{}
 	pushHandler := NewPushHandler(g)
+	pushHandler.Start(context.TODO(), nil)
 	g.PushHandler = pushHandler
 	g.ChatHelper = NewHelper(g, getRI)
 	g.TeamChannelSource = NewTeamChannelSource(g)

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -434,6 +434,7 @@ func (c *chatTestContext) as(t *testing.T, user *kbtest.FakeUser) *chatTestUserC
 	g.CommandsSource = commands.NewSource(g)
 
 	pushHandler := NewPushHandler(g)
+	pushHandler.Start(context.TODO(), nil)
 	g.PushHandler = pushHandler
 	g.TeamChannelSource = NewTeamChannelSource(g)
 	g.AttachmentURLSrv = types.DummyAttachmentHTTPSrv{}
@@ -2007,6 +2008,8 @@ func TestChatSrvGap(t *testing.T) {
 		enc := codec.NewEncoderBytes(&data, &mh)
 		require.NoError(t, enc.Encode(payload))
 		ph := NewPushHandler(tc.Context())
+		ph.Start(context.TODO(), nil)
+		defer func() { <-ph.Stop(context.TODO()) }()
 		require.NoError(t, ph.Activity(ctx, &gregor1.OutOfBandMessage{
 			Uid_:    u.User.GetUID().ToBytes(),
 			System_: gregor1.System(types.PushActivity),

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -277,6 +277,7 @@ type OobmHandler interface {
 }
 
 type PushHandler interface {
+	Resumable
 	TlfFinalize(context.Context, gregor.OutOfBandMessage) error
 	TlfResolve(context.Context, gregor.OutOfBandMessage) error
 	Activity(context.Context, gregor.OutOfBandMessage) error

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -42,6 +42,9 @@ func (c ChatTestContext) Context() *globals.Context {
 }
 
 func (c ChatTestContext) Cleanup() {
+	if c.ChatG.PushHandler != nil {
+		<-c.ChatG.PushHandler.Stop(context.TODO())
+	}
 	if c.ChatG.MessageDeliverer != nil {
 		<-c.ChatG.MessageDeliverer.Stop(context.TODO())
 	}

--- a/go/service/main.go
+++ b/go/service/main.go
@@ -409,6 +409,7 @@ func (d *Service) startChatModules() {
 	if !kuid.IsNil() {
 		uid := kuid.ToBytes()
 		g := globals.NewContext(d.G(), d.ChatG())
+		g.PushHandler.Start(context.Background(), uid)
 		g.MessageDeliverer.Start(context.Background(), uid)
 		g.ConvLoader.Start(context.Background(), uid)
 		g.FetchRetrier.Start(context.Background(), uid)
@@ -426,6 +427,7 @@ func (d *Service) startChatModules() {
 }
 
 func (d *Service) stopChatModules(m libkb.MetaContext) error {
+	<-d.ChatG().PushHandler.Stop(m.Ctx())
 	<-d.ChatG().MessageDeliverer.Stop(m.Ctx())
 	<-d.ChatG().ConvLoader.Stop(m.Ctx())
 	<-d.ChatG().FetchRetrier.Stop(m.Ctx())


### PR DESCRIPTION
Was causing test runs to fail with a logging panic after the tests completed, made it difficult to debug a legitimate race.

```
$ go test -run TestChatSrvGap -count 20
PASS
ok      github.com/keybase/client/go/chat       167.028s
```

cc @AMarcedone 