### PR TITLE
explode expired messages on FetchMessages

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -54,7 +54,7 @@ func (s *baseConversationSource) Sign(payload []byte) ([]byte, error) {
 // DeleteAssets implements github.com/keybase/go/chat/storage/storage.AssetDeleter interface.
 func (s *baseConversationSource) DeleteAssets(ctx context.Context, uid gregor1.UID,
 	convID chat1.ConversationID, assets []chat1.Asset) {
-	defer s.Trace(ctx, func() error { return nil }, "DeleteAssets: %v", assets)()
+	defer s.Trace(ctx, func() error { return nil }, "DeleteAssets: %d", len(assets))()
 
 	if len(assets) == 0 {
 		return

--- a/go/chat/search/session.go
+++ b/go/chat/search/session.go
@@ -149,7 +149,7 @@ func (s *searchSession) getMsgsAndIDSet(ctx context.Context, convID chat1.Conver
 	}
 	res := []chat1.MessageUnboxed{}
 	for _, msg := range msgs {
-		if msg.IsValid() && msg.IsVisible() {
+		if msg.IsValidFull() && msg.IsVisible() {
 			res = append(res, msg)
 		}
 	}

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -1079,6 +1079,7 @@ func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID
 	}
 
 	// Run seek looking for each message
+	var msgs []chat1.MessageUnboxed
 	for _, msgID := range msgIDs {
 		if msgID == 0 {
 			res = append(res, nil)
@@ -1089,6 +1090,22 @@ func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID
 			return nil, s.maybeNukeLocked(ctx, false, err, convID, uid)
 		}
 		res = append(res, msg)
+		if msg != nil {
+			msgs = append(msgs, *msg)
+		}
+	}
+
+	_, err = s.explodeExpiredMessages(ctx, convID, uid, msgs)
+	if err != nil {
+		return nil, err
+	}
+
+	i := 0
+	for _, msg := range msgs {
+		for res[i] == nil {
+			i++
+		}
+		res[i] = &msg
 	}
 	return res, nil
 }

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -1099,13 +1099,17 @@ func (s *Storage) FetchMessages(ctx context.Context, convID chat1.ConversationID
 	if err != nil {
 		return nil, err
 	}
-
 	i := 0
-	for _, msg := range msgs {
-		for res[i] == nil {
+	for _, m := range msgs {
+		for res[i] == nil && i < len(res) {
 			i++
 		}
+		if i >= len(res) {
+			break
+		}
+		msg := m
 		res[i] = &msg
+		i++
 	}
 	return res, nil
 }


### PR DESCRIPTION
The search indexer fetches messages through the `GetMessages` API, I think this could cause an already exploded message to erroneously appear in search results since we didn't check the message expiration when reading from storage here.