### PR TITLE
NOMERGE: systrace 61.5

### DIFF
--- a/shared/.gitignore
+++ b/shared/.gitignore
@@ -10,6 +10,7 @@ android/**/*.iml
 android/**/.classpath
 android/**/.project
 android/**/.settings/**
+android/**/*.externalNativeBuild
 
 # iOS
 !default.mode1v3

--- a/shared/android/app/CMakeLists.txt
+++ b/shared/android/app/CMakeLists.txt
@@ -1,0 +1,54 @@
+# For more information about using CMake with Android Studio, read the
+# documentation: https://d.android.com/studio/projects/add-native-code.html
+
+# Sets the minimum version of CMake required to build the native library.
+
+set(CMAKE_SYSTEM_NAME Android)
+set(CMAKE_SYSTEM_VERSION 29)
+set(CMAKE_ANDROID_API 29)
+cmake_minimum_required(VERSION 3.4.1)
+
+# Creates and names a library, sets it as either STATIC
+# or SHARED, and provides the relative paths to its source code.
+# You can define multiple libraries, and CMake builds them for you.
+# Gradle automatically packages shared libraries with your APK.
+
+execute_process(COMMAND sh -c "(`pwd`/scripts/ios-install-third-party.sh)"
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/../../node_modules/react-native
+)
+# Needed to locate double-conversion src correctly for folly includes
+execute_process(COMMAND ln "-s" "${PROJECT_SOURCE_DIR}/../../node_modules/react-native/third-party/double-conversion-1.1.6/src" "${PROJECT_SOURCE_DIR}/../../node_modules/react-native/third-party/double-conversion-1.1.6/double-conversion")
+
+
+include_directories(
+    ../../node_modules/react-native/React
+    ../../node_modules/react-native/React/Base
+    ../../node_modules/react-native/ReactCommon
+    ../../node_modules/react-native/third-party/folly-2018.10.22.00
+    ../../node_modules/react-native/third-party/double-conversion-1.1.6
+    ../../node_modules/react-native/third-party/boost_1_63_0
+    ../../node_modules/react-native/third-party/glog-0.3.5/src
+    ../../node_modules/react-native/ReactCommon/jsi
+)
+
+add_definitions(
+    -DFOLLY_USE_LIBCPP=1
+    -DFOLLY_NO_CONFIG=1
+    -DFOLLY_HAVE_MEMRCHR=1
+)
+
+add_library( # Sets the name of the library.
+        test_module_jni
+
+        # Sets the library as a shared library.
+        SHARED
+
+        # Provides a relative path to your source file(s).
+        ../../node_modules/react-native/ReactCommon/jsi/jsi
+        ../../node_modules/react-native/ReactCommon/jsi/jsi/jsi.cpp
+        ../c++/TestBinding.cpp
+        )
+
+target_link_libraries(test_module_jni
+                      android
+                      log)

--- a/shared/android/app/build.gradle
+++ b/shared/android/app/build.gradle
@@ -85,8 +85,9 @@ def VERSION_NAME = "5.2.0"
 project.ext.react = [
     // the root of your project, i.e. where "package.json" lives
     root: "../../",
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: KB_USEHERMES == 'true',  // clean and rebuild if changing
     enableV8: KB_USEV8 == 'true',  // clean and rebuild if changing
+    bundleInDebug: true,
 ]
 
 
@@ -199,6 +200,11 @@ android {
             applicationIdSuffix ".unsigned"
             signingConfig buildTypes.debug.signingConfig
             matchingFallbacks = ['release']
+        }
+    }
+    externalNativeBuild {
+        cmake {
+            path "CMakeLists.txt"
         }
     }
     // applicationVariants are e.g. debug, release

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -2,7 +2,13 @@ package io.keybase.ossifrage;
 
 import android.app.Application;
 import android.content.Context;
+import android.os.Build;
+import android.os.Trace;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewTreeObserver;
 
+import androidx.annotation.RequiresApi;
 import androidx.multidex.MultiDex;
 
 import com.evernote.android.job.JobManager;
@@ -13,6 +19,9 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactMarker;
+import com.facebook.react.bridge.ReactMarkerConstants;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.soloader.SoLoader;
 
 import org.unimodules.adapters.react.ModuleRegistryAdapter;
@@ -23,7 +32,11 @@ import org.unimodules.core.interfaces.Package;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 import expo.modules.barcodescanner.BarCodeScannerPackage;
 import expo.modules.constants.ConstantsPackage;
@@ -55,14 +68,46 @@ public class MainApplication extends Application implements ReactApplication {
         MultiDex.install(this);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     @Override
     public void onCreate() {
         NativeLogger.info("MainApplication created");
         super.onCreate();
+        Trace.beginSection("Loading RN native code");
         SoLoader.init(this, /* native exopackage */ false);
         // initializeFlipper(this); // Remove this line if you don't want Flipper enabled
+        Trace.endSection();
         JobManager manager = JobManager.create(this);
         manager.addJobCreator(new BackgroundJobCreator());
+
+        // Profiling
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        addTTIEndListener();
+      }
+      ReactMarker.addListener(new ReactMarker.MarkerListener() {
+          private final HashSet<ReactMarkerConstants> seenTags = new HashSet<ReactMarkerConstants>();
+            @RequiresApi(api = Build.VERSION_CODES.Q)
+            @Override
+            public void logMarker(ReactMarkerConstants name, @Nullable String tag, int instanceKey) {
+                if (tag != null && tag.equals("Storybook")) {
+                  Log.d("Marker", "Storybook here" + System.currentTimeMillis());
+                }
+                if (name.toString().contains("START")) {
+//                    Trace.beginAsyncSection(tag, name.ordinal()*1000 + instanceKey);
+                    Trace.beginSection(name.toString() + tag);
+                } else if (name.toString().contains("END")) {
+                    Trace.endSection();
+//                    Trace.endAsyncSection(ReactMarkerConstants.values()[name.ordinal() -1].toString() + " " + tag, (name.ordinal()-1)*1000 + instanceKey);
+
+                } else {
+                  Trace.beginSection(name.toString() + " " + tag);
+                  Trace.endSection();
+                }
+
+
+//              Log.i("Marker", name.toString() + "-" + name.ordinal() + " " + tag + ". instanceKey::" + instanceKey);
+            }
+        });
 
         // Make sure exactly one background job is scheduled.
         int numBackgroundJobs = manager.getAllJobRequestsForTag(BackgroundSyncJob.TAG).size();
@@ -99,6 +144,42 @@ public class MainApplication extends Application implements ReactApplication {
             }
         }
     }
+   /**
+   * Waits for Loading to complete, also called a Time-To-Interaction (TTI) event. To indicate TTI
+   * completion, add a prop nativeID="tti_complete" to the component whose appearance indicates that
+   * the initial TTI or loading is complete
+   */
+  @RequiresApi(api = Build.VERSION_CODES.Q)
+  private void addTTIEndListener() {
+    Log.d("Marker", "Setting listener");
+    Trace.beginAsyncSection("Starting App", 0);
+    ReactFindViewUtil.addViewListener(
+        new ReactFindViewUtil.OnViewFoundListener() {
+          @Override
+          public String getNativeId() {
+            // This is the value of the nativeID property
+            return "tti_complete";
+          }
+
+          @Override
+          public void onViewFound(final View view) {
+            Log.d("Marker", "Found view");
+            // Once we find the view, we also need to wait for it to be drawn
+            view.getViewTreeObserver()
+                // TODO (axe) Should be OnDrawListener instead of this
+                .addOnPreDrawListener(
+                    new ViewTreeObserver.OnPreDrawListener() {
+                      @Override
+                      public boolean onPreDraw() {
+                        view.getViewTreeObserver().removeOnPreDrawListener(this);
+                        Trace.endAsyncSection("Starting App", 0);
+                        Log.d("App Start Timing", "End Time " + System.currentTimeMillis());
+                        return true;
+                      }
+                    });
+          }
+        });
+  }
 
     private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
 
@@ -107,6 +188,7 @@ public class MainApplication extends Application implements ReactApplication {
             return BuildConfig.DEBUG;
         }
 
+        @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
         @Override
         protected List<ReactPackage> getPackages() {
             Context context = getApplicationContext();
@@ -118,6 +200,8 @@ public class MainApplication extends Application implements ReactApplication {
 //
 //            MainPackageConfig appConfig = new MainPackageConfig.Builder().setFrescoConfig(frescoConfig).build();
 
+            Log.d("Package Timing", "Start " + System.currentTimeMillis());
+            Trace.beginSection("getPackages");
             @SuppressWarnings("UnnecessaryLocalVariable")
             List<ReactPackage> packages = new PackageList(this).getPackages();
             // new MainReactPackage(appConfig),// removed from rn-diff but maybe we need it for fresco config?
@@ -135,6 +219,8 @@ public class MainApplication extends Application implements ReactApplication {
             });
 
             packages.add(new ModuleRegistryAdapter(mModuleRegistryProvider));
+            Trace.endSection();
+            Log.d("Package Timing", "End " + System.currentTimeMillis());
 
             return packages;
         }

--- a/shared/android/build.gradle
+++ b/shared/android/build.gradle
@@ -10,7 +10,7 @@ def enableV8 = KB_USEV8 == 'true'
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 29
         compileSdkVersion = 29
         targetSdkVersion = 28
         supportLibVersion = "28.0.0" // needed by some deps

--- a/shared/android/c++/TestBinding.cpp
+++ b/shared/android/c++/TestBinding.cpp
@@ -1,0 +1,109 @@
+#include "TestBinding.h"
+
+#include <dlfcn.h>
+// #include <forandroid.h>
+#include <android/log.h>
+#include <android/trace.h>
+#include <jsi/JSIDynamic.h>
+#include <chrono>  // std::chrono::seconds
+#include <thread>
+
+// #ifndef __ANDROID_API__
+// #define __ANDROID_API__ 29
+// #endif
+
+#define APPNAME "MyApp"
+
+struct EventHandlerWrapper {
+  EventHandlerWrapper(jsi::Function eventHandler)
+      : callback(std::move(eventHandler)) {}
+
+  jsi::Function callback;
+};
+
+#if ANDROID
+extern "C" {
+JNIEXPORT void JNICALL Java_io_keybase_ossifrage_MainActivity_install(
+    JNIEnv *env, jobject thiz, jlong runtimePtr) {
+  auto testBinding = std::make_shared<example::TestBinding>();
+  jsi::Runtime *runtime = (jsi::Runtime *)runtimePtr;
+
+  example::TestBinding::install(*runtime, testBinding);
+}
+}
+#endif
+
+namespace example {
+
+void TestBinding::install(jsi::Runtime &runtime,
+                          std::shared_ptr<TestBinding> testBinding) {
+  auto testModuleName = "nativeTest";
+  auto object = jsi::Object::createFromHostObject(runtime, testBinding);
+  runtime.global().setProperty(runtime, testModuleName, std::move(object));
+}
+
+TestBinding::TestBinding() {}
+
+jsi::Value TestBinding::get(jsi::Runtime &runtime,
+                            const jsi::PropNameID &name) {
+  auto methodName = name.utf8(runtime);
+
+  if (methodName == "traceBeginSection") {
+    return jsi::Function::createFromHostFunction(
+        runtime, name, 2,
+        [](jsi::Runtime &runtime, const jsi::Value &thisValue,
+           const jsi::Value *arguments, size_t count) -> jsi::Value {
+          auto name = arguments[0].toString(runtime).utf8(runtime);
+          ATrace_beginSection(name.c_str());
+          return 0;
+        });
+  }
+
+  if (methodName == "traceEndSection") {
+    return jsi::Function::createFromHostFunction(
+        runtime, name, 0,
+        [](jsi::Runtime &runtime, const jsi::Value &thisValue,
+           const jsi::Value *arguments, size_t count) -> jsi::Value {
+          ATrace_endSection();
+          return 0;
+        });
+  }
+
+  if (methodName == "traceBeginAsyncSection") {
+    return jsi::Function::createFromHostFunction(
+        runtime, name, 2,
+        [](jsi::Runtime &runtime, const jsi::Value &thisValue,
+           const jsi::Value *arguments, size_t count) -> jsi::Value {
+          auto name = arguments[0].toString(runtime).utf8(runtime);
+          int cookie = (int)arguments[1].asNumber();
+          ATrace_beginAsyncSection(name.c_str(), cookie);
+          return 0;
+        });
+  }
+
+  if (methodName == "traceEndAsyncSection") {
+    return jsi::Function::createFromHostFunction(
+        runtime, name, 0,
+        [](jsi::Runtime &runtime, const jsi::Value &thisValue,
+           const jsi::Value *arguments, size_t count) -> jsi::Value {
+          auto name = arguments[0].toString(runtime).utf8(runtime);
+          int cookie = (int)arguments[1].asNumber();
+          ATrace_endAsyncSection(name.c_str(), cookie);
+          return 0;
+        });
+  }
+
+  if (methodName == "runTest") {
+    __android_log_print(ANDROID_LOG_VERBOSE, APPNAME,
+                        "!!!!!! HI FROM NATIVE CODE %d", __ANDROID_API__);
+    return jsi::Function::createFromHostFunction(
+        runtime, name, 0,
+        [](jsi::Runtime &runtime, const jsi::Value &thisValue,
+           const jsi::Value *arguments,
+           size_t count) -> jsi::Value { return 0; });
+  }
+
+  return jsi::Value::undefined();
+}
+
+}  // namespace example

--- a/shared/android/c++/TestBinding.h
+++ b/shared/android/c++/TestBinding.h
@@ -1,0 +1,43 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+#if ANDROID
+#include <android/trace.h>
+#include <jni.h>
+#endif
+
+using namespace facebook;
+
+#if ANDROID
+extern "C" {
+JNIEXPORT void JNICALL Java_com_testmodule_MainActivity_install(
+    JNIEnv *env, jobject thiz, jlong runtimePtr);
+}
+#endif
+
+namespace example {
+
+/*
+ * Exposes Test to JavaScript realm.
+ */
+class TestBinding : public jsi::HostObject {
+ public:
+  /*
+   * Installs TestBinding into JavaSctipt runtime.
+   * Thread synchronization must be enforced externally.
+   */
+  static void install(jsi::Runtime &runtime,
+                      std::shared_ptr<TestBinding> testBinding);
+
+  TestBinding();
+
+  /*
+   * `jsi::HostObject` specific overloads.
+   */
+  jsi::Value get(jsi::Runtime &runtime, const jsi::PropNameID &name) override;
+};
+
+}  // namespace example

--- a/shared/android/gradle.properties
+++ b/shared/android/gradle.properties
@@ -23,6 +23,7 @@ android.enableJetifier=true
 # Clean project if changing this
 # Disabled until https://github.com/Kudo/v8-android-buildscripts/issues/4 is resolved
 KB_USEV8=true
+KB_USEHERMES=false
 
 # More memory!
 org.gradle.jvmargs=-Xmx2048M

--- a/shared/app/globals.native.tsx
+++ b/shared/app/globals.native.tsx
@@ -11,7 +11,7 @@ const {NativeModules} = require('react-native')
 // __STORYBOOK__
 // if we're in storybook mode
 if (typeof __STORYBOOK__ === 'undefined') {
-  __STORYBOOK__ = (NativeModules.Storybook && NativeModules.Storybook.isStorybook) || false
+  __STORYBOOK__ = __DEV__ && (NativeModules.Storybook && NativeModules.Storybook.isStorybook) || false
 }
 
 // We don't storyshot RN

--- a/shared/app/index.native.tsx
+++ b/shared/app/index.native.tsx
@@ -15,6 +15,8 @@ module.hot &&
 
 let store
 
+console.log("Require's done", Date.now())
+
 class Keybase extends Component<any> {
   constructor(props: any) {
     super(props)

--- a/shared/engine/index.platform.native.tsx
+++ b/shared/engine/index.platform.native.tsx
@@ -80,12 +80,14 @@ function createClient(
       logger.debug('[RPC] Read', payload.length, 'chars:', payload)
     }
 
+    const measureNameBytes = `ToBytesBuffer`
+    measureStart(measureNameBytes)
     const buffer = toBuffer(toByteArray(payload))
+    measureStop(measureNameBytes)
     const measureName = `packetize${packetizeCount++}:${buffer.length}`
     measureStart(measureName)
-    const ret = client.transport.packetize_data(buffer)
+    client.transport.packetize_data(buffer)
     measureStop(measureName)
-    return ret
   })
 
   RNEmitter.addListener(nativeBridge.metaEventName, (payload: string) => {

--- a/shared/engine/session-impl.tsx
+++ b/shared/engine/session-impl.tsx
@@ -117,7 +117,8 @@ class Session {
 
   end() {
     if (this._startMethod) {
-      measureStop(`engine:${this._startMethod}:${this.getId()}`)
+      __DEV__ && global.nativeTest.traceEndAsyncSection(`RPC-${this._startMethod}`, this._id)
+      // measureStop(`engine:${this._startMethod}:${this.getId()}`)
     }
     this._endHandler && this._endHandler(this)
   }
@@ -126,6 +127,7 @@ class Session {
   start(method: MethodKey, param: Object, callback: (() => void) | undefined) {
     this._startMethod = method
     this._startCallback = callback
+    __DEV__ && global.nativeTest.traceBeginAsyncSection(`RPC-${this._startMethod}`, this._id)
 
     // When this request is done the session is done
     const wrappedCallback = (...args) => {
@@ -155,13 +157,13 @@ class Session {
       this._invoke
     )
     this._outgoingRequests.push(outgoingRequest)
-    measureStart(`engine:${method}:${this.getId()}`)
+    // measureStart(`engine:${method}:${this.getId()}`)
     outgoingRequest.send()
   }
 
   // We have an incoming call tied to a sessionID, called only by engine
   incomingCall(method: MethodKey, param: Object, response: any): boolean {
-    measureStart(`engine:${method}:${this.getId()}`)
+    // measureStart(`engine:${method}:${this.getId()}`)
     rpcLog({
       extra: {
         id: this.getId(),

--- a/shared/index.android.js
+++ b/shared/index.android.js
@@ -1,8 +1,61 @@
 // @flow
 // React-native tooling assumes this file is here, so we just require our real entry point
-import './app/globals.native'
-import {NativeModules} from 'react-native'
-import {_setSystemIsDarkMode, _setSystemSupported, _setDarkModePreference} from './styles/dark-mode'
+
+let lastThing = []
+const noop = () => {}
+const measureStart =
+  // @ts-ignore
+  __DEV__ && require && require.Systrace && require.Systrace.beginEvent
+    ? name => {
+        lastThing.push(name)
+        require.Systrace.beginEvent(name)
+      }
+    : noop
+
+const measureStop =
+  // @ts-ignore
+  __DEV__ && require && require.Systrace && require.Systrace.endEvent
+    ? name => {
+        if (name !== lastThing[lastThing.length - 1]) {
+          console.log("This isn't something I've seen before. Out of order??")
+        } else {
+          lastThing.pop()
+          // @ts-ignore
+          require.Systrace.endEvent()
+        }
+      }
+    : noop
+
+window.performance = {}
+window.performance = {
+  clearMarks: n => lastThing[lastThing.length - 1] === n && measureStop(n),
+  clearMeasures: l => console.log('Clear Measures', l),
+  mark: n => measureStart(n),
+  measure: (l, n) => measureStop(n),
+}
+
+require('./app/globals.native')
+const NativeModules = require('react-native').NativeModules
+const darkMode = require('./styles/dark-mode')
+const {_setSystemIsDarkMode, _setSystemSupported, _setDarkModePreference} = darkMode
+
+console.disableYellowBox = true
+
+if (__DEV__ && require && require.Systrace) {
+  require.Systrace.beginEvent = message => {
+    if (message.startsWith('RCTDeviceEventEmitter.emit(["RPC"')) {
+      global.nativeTest.traceBeginSection(
+        'RCTDeviceEventEmitter: RPC(' + (message.length - 37) + ' bytes): ' + message.substring(35, 35 + 30)
+      )
+    } else {
+      global.nativeTest.traceBeginSection(message, 0)
+    }
+  }
+
+  require.Systrace.endEvent = () => {
+    global.nativeTest.traceEndSection()
+  }
+}
 
 // Load storybook or the app
 if (__STORYBOOK__) {

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -7,7 +7,7 @@ import noop from 'lodash/noop'
 const nativeBridge = NativeModules.KeybaseEngine || {test: 'fallback'}
 
 // Uncomment this to disable yellowboxes
-console.disableYellowBox = false
+console.disableYellowBox = true
 //
 // Ignore some yellowboxes on 3rd party libs we can't control
 YellowBox.ignoreWarnings([
@@ -58,13 +58,13 @@ let config = {
 
 // Developer settings
 if (__DEV__) {
-  config.enableActionLogging = true
+  config.enableActionLogging = false
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working
   // with a "Profile" build on a phone.
   config.isDevApplePushToken = true
-  config.printOutstandingRPCs = true
+  config.printOutstandingRPCs = false
   config.printOutstandingTimerListeners = true
   config.printRPCWaitingSession = false
   config.printRPC = true

--- a/shared/metro.config.js
+++ b/shared/metro.config.js
@@ -18,12 +18,14 @@ module.exports = (async () => {
     },
     transformer: {
       babelTransformerPath: require.resolve('./rn-css-transformer.js'),
-      getTransformOptions: async () => ({
-        transform: {
-          experimentalImportSupport: false,
-          inlineRequires: true,
-        },
-      }),
+      getTransformOptions: async () => {
+        return {
+          transform: {
+            experimentalImportSupport: false,
+            inlineRequires: true,
+          },
+        }
+      },
       minifierConfig: {
         mangle: {
           keep_fnames: true,


### PR DESCRIPTION
```
git clone --depth=1 https://github.com/catapult-project/catapult.git
cd catapult
./systrace/systrace/run_systrace.py sched freq idle am wm gfx view dalvik input binder_driver -t 10 -o `date | sed "s/\ /_/g"`.html -b 16384 -a io.keybase.ossifrage.debug
(or on fish)
./systrace/systrace/run_systrace.py sched freq idle am wm gfx view dalvik input binder_driver -t 10 -o (date | sed "s/\ /_/g").html -b 16384 -a io.keybase.ossifrage.debug
```

```
rm -rf node_modules
rm -rf android/app/.externalNativeBuild
yarn modules
cd android; ./gradlew clean; 
yarn react-native run-android --variant 'debug'
```