### PR TITLE
fix: add logic for authorIsBot in adhoc teams

### DIFF
--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -118,6 +118,7 @@ const getDecorate = (message: Types.Message) => {
 
 export default Container.namedConnect(
   (state: Container.TypedState, ownProps: OwnProps) => {
+    const _participantInfo = Constants.getParticipantInfo(state, ownProps.conversationIDKey)
     const message =
       Constants.getMessage(state, ownProps.conversationIDKey, ownProps.ordinal) || missingMessage
     const previous =
@@ -145,7 +146,7 @@ export default Container.namedConnect(
     const authorIsBot = teamname
       ? TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'restrictedbot') ||
         TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'bot')
-      : false
+      : !_participantInfo.name.includes(message.author) // if adhoc, check if author in participants
     const authorIsOwner = teamname
       ? TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'owner')
       : false


### PR DESCRIPTION
Previously, `authorIsBot` checks would always return false in adhoc teams because `teamname` was not defined, which caused the bot icon to display incorrectly. This PR adds logic for adhoc teams to check if the author is a bot or not.