### PR TITLE
folder_block_ops: fix case where nodes were stuck as dirty

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5473,7 +5473,15 @@ func (fbo *folderBranchOps) Truncate(
 			return err
 		}
 
-		fbo.status.addDirtyNode(file)
+		filePath, err := fbo.pathFromNodeForRead(file)
+		if err != nil {
+			return err
+		}
+
+		// Only mark the path as dirty if it was actually changed.
+		if fbo.blocks.IsDirty(lState, filePath) {
+			fbo.status.addDirtyNode(file)
+		}
 		fbo.signalWrite()
 		return nil
 	})


### PR DESCRIPTION
A user ran into an issue where they did a `Truncate(0)` of a file that was already 0 bytes.  In the local KBFS caches that marked the file as dirty, but since there was no actual data change it was never synced and marked as clean.  This meant the whole TLF was stuck, since KBFS won't apply merged changes while there are outstanding dirty files.

With this commit, we now check whether the truncate actually happened, and if not, clean up the dirty state manually before returning.

By inspection this applies to the error path as well for both truncates and writes -- the file could stay stuck if there's an error. So this cleans it up in that case as well.

Issue: HOTPOT-1612