### PR TITLE
useRPC & useSafeSubmit

### DIFF
--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -15,8 +15,6 @@ export const addBotMember = 'chat2:addBotMember'
 export const addUsersToChannel = 'chat2:addUsersToChannel'
 export const attachmentDownload = 'chat2:attachmentDownload'
 export const attachmentDownloaded = 'chat2:attachmentDownloaded'
-export const attachmentFullscreenNext = 'chat2:attachmentFullscreenNext'
-export const attachmentFullscreenSelection = 'chat2:attachmentFullscreenSelection'
 export const attachmentLoading = 'chat2:attachmentLoading'
 export const attachmentMobileSave = 'chat2:attachmentMobileSave'
 export const attachmentMobileSaved = 'chat2:attachmentMobileSaved'
@@ -204,12 +202,6 @@ type _AttachmentDownloadedPayload = {
   readonly error?: string
   readonly path?: string
 }
-type _AttachmentFullscreenNextPayload = {
-  readonly conversationIDKey: Types.ConversationIDKey
-  readonly messageID: Types.MessageID
-  readonly backInTime: boolean
-}
-type _AttachmentFullscreenSelectionPayload = {readonly autoPlay: boolean; readonly message: Types.Message}
 type _AttachmentLoadingPayload = {
   readonly conversationIDKey: Types.ConversationIDKey
   readonly message: Types.Message
@@ -1377,12 +1369,6 @@ export const createAttachmentDownload = (payload: _AttachmentDownloadPayload): A
 export const createAttachmentDownloaded = (
   payload: _AttachmentDownloadedPayload
 ): AttachmentDownloadedPayload => ({payload, type: attachmentDownloaded})
-export const createAttachmentFullscreenNext = (
-  payload: _AttachmentFullscreenNextPayload
-): AttachmentFullscreenNextPayload => ({payload, type: attachmentFullscreenNext})
-export const createAttachmentFullscreenSelection = (
-  payload: _AttachmentFullscreenSelectionPayload
-): AttachmentFullscreenSelectionPayload => ({payload, type: attachmentFullscreenSelection})
 export const createAttachmentLoading = (payload: _AttachmentLoadingPayload): AttachmentLoadingPayload => ({
   payload,
   type: attachmentLoading,
@@ -1664,14 +1650,6 @@ export type AttachmentDownloadPayload = {
 export type AttachmentDownloadedPayload = {
   readonly payload: _AttachmentDownloadedPayload
   readonly type: typeof attachmentDownloaded
-}
-export type AttachmentFullscreenNextPayload = {
-  readonly payload: _AttachmentFullscreenNextPayload
-  readonly type: typeof attachmentFullscreenNext
-}
-export type AttachmentFullscreenSelectionPayload = {
-  readonly payload: _AttachmentFullscreenSelectionPayload
-  readonly type: typeof attachmentFullscreenSelection
 }
 export type AttachmentLoadingPayload = {
   readonly payload: _AttachmentLoadingPayload
@@ -2270,8 +2248,6 @@ export type Actions =
   | AddUsersToChannelPayload
   | AttachmentDownloadPayload
   | AttachmentDownloadedPayload
-  | AttachmentFullscreenNextPayload
-  | AttachmentFullscreenSelectionPayload
   | AttachmentLoadingPayload
   | AttachmentMobileSavePayload
   | AttachmentMobileSavedPayload

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2121,20 +2121,10 @@ function* attachmentFullscreenNext(
   yield Saga.put(Chat2Gen.createAttachmentFullscreenSelection({autoPlay: false, message: nextMsg}))
 }
 
-const attachmentPreviewSelect = (action: Chat2Gen.AttachmentPreviewSelectPayload) => {
-  const message = action.payload.message
-  //[
-  // Chat2Gen.createAttachmentFullscreenSelection({autoPlay: true, message}),
-  return RouteTreeGen.createNavigateAppend({
-    path: [
-      {
-        props: {message},
-        selected: 'chatAttachmentFullscreen',
-      },
-    ],
-  }) //,
-  // ]
-}
+const attachmentPreviewSelect = (action: Chat2Gen.AttachmentPreviewSelectPayload) =>
+  RouteTreeGen.createNavigateAppend({
+    path: [{props: {message: action.payload.message}, selected: 'chatAttachmentFullscreen'}],
+  })
 
 // Handle an image pasted into a conversation
 const attachmentPasted = async (action: Chat2Gen.AttachmentPastedPayload) => {

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2123,17 +2123,17 @@ function* attachmentFullscreenNext(
 
 const attachmentPreviewSelect = (action: Chat2Gen.AttachmentPreviewSelectPayload) => {
   const message = action.payload.message
-  return [
-    Chat2Gen.createAttachmentFullscreenSelection({autoPlay: true, message}),
-    RouteTreeGen.createNavigateAppend({
-      path: [
-        {
-          props: {},
-          selected: 'chatAttachmentFullscreen',
-        },
-      ],
-    }),
-  ]
+  //[
+  // Chat2Gen.createAttachmentFullscreenSelection({autoPlay: true, message}),
+  return RouteTreeGen.createNavigateAppend({
+    path: [
+      {
+        props: {message},
+        selected: 'chatAttachmentFullscreen',
+      },
+    ],
+  }) //,
+  // ]
 }
 
 // Handle an image pasted into a conversation

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -377,15 +377,6 @@
       "conversationIDKey": "Types.ConversationIDKey",
       "data": "Buffer"
     },
-    "attachmentFullscreenSelection": {
-      "autoPlay": "boolean",
-      "message": "Types.Message"
-    },
-    "attachmentFullscreenNext": {
-      "conversationIDKey": "Types.ConversationIDKey",
-      "messageID": "Types.MessageID",
-      "backInTime": "boolean"
-    },
     // We got an uploaded attachment, while online this is like an edit of the placeholder
     "messageAttachmentUploaded": {
       "conversationIDKey": "Types.ConversationIDKey",

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -138,8 +138,6 @@ export type TypedActionsMap = {
   'chat2:attachmentUploading': chat2.AttachmentUploadingPayload
   'chat2:attachmentUploaded': chat2.AttachmentUploadedPayload
   'chat2:attachmentPasted': chat2.AttachmentPastedPayload
-  'chat2:attachmentFullscreenSelection': chat2.AttachmentFullscreenSelectionPayload
-  'chat2:attachmentFullscreenNext': chat2.AttachmentFullscreenNextPayload
   'chat2:messageAttachmentUploaded': chat2.MessageAttachmentUploadedPayload
   'chat2:sendTyping': chat2.SendTypingPayload
   'chat2:markInitiallyLoadedThreadAsRead': chat2.MarkInitiallyLoadedThreadAsReadPayload

--- a/shared/chat/conversation/attachment-fullscreen/container.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/container.tsx
@@ -1,3 +1,6 @@
+import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
+import * as RPCTypes from '../../../constants/types/rpc-gen'
+import * as React from 'react'
 import * as Types from '../../../constants/types/chat2'
 import * as Constants from '../../../constants/chat2'
 import * as Chat2Gen from '../../../actions/chat2-gen'
@@ -9,72 +12,72 @@ import {imgMaxWidthRaw} from '../messages/attachment/image/image-render'
 
 const blankMessage = Constants.makeMessageAttachment({})
 
-type OwnProps = {}
+type OwnProps = Container.RouteProps<{message: Types.MessageAttachment}>
 
-const Connected = Container.connect(
-  state => {
-    const selection = state.chat2.attachmentFullscreenSelection
-    const message = selection ? selection.message : blankMessage
-    return {
-      autoPlay: selection ? selection.autoPlay : false,
-      message: message.type === 'attachment' ? message : blankMessage,
-    }
-  },
-  dispatch => ({
-    _onAllMedia: (conversationIDKey: Types.ConversationIDKey) =>
-      dispatch(
-        RouteTreeGen.createNavigateAppend({
-          path: [
-            {
-              props: {conversationIDKey, tab: 'attachments'},
-              selected: 'chatInfoPanel',
-            },
-          ],
-        })
-      ),
-    _onDownloadAttachment: (message: Types.MessageAttachment) =>
-      dispatch(Chat2Gen.createAttachmentDownload({message})),
-    _onShowInFinder: (message: Types.MessageAttachment) => {
-      message.downloadPath &&
-        dispatch(FsGen.createOpenLocalPathInSystemFileManager({localPath: message.downloadPath}))
-    },
-    _onSwitchAttachment: (
-      conversationIDKey: Types.ConversationIDKey,
-      messageID: Types.MessageID,
-      prev: boolean
-    ) => {
-      dispatch(Chat2Gen.createAttachmentFullscreenNext({backInTime: prev, conversationIDKey, messageID}))
-    },
-    onClose: () => dispatch(RouteTreeGen.createNavigateUp()),
-  }),
-  (stateProps, dispatchProps, _: OwnProps) => {
-    const message = stateProps.message
-    const {height, width} = Constants.clampImageSize(
-      message.previewWidth,
-      message.previewHeight,
-      imgMaxWidthRaw()
-    )
-    return {
-      autoPlay: stateProps.autoPlay,
-      isVideo: Constants.isVideoAttachment(message),
-      message,
-      onAllMedia: () => dispatchProps._onAllMedia(message.conversationIDKey),
-      onClose: dispatchProps.onClose,
-      onDownloadAttachment: message.downloadPath
-        ? undefined
-        : () => dispatchProps._onDownloadAttachment(message),
-      onNextAttachment: () => dispatchProps._onSwitchAttachment(message.conversationIDKey, message.id, false),
-      onPreviousAttachment: () =>
-        dispatchProps._onSwitchAttachment(message.conversationIDKey, message.id, true),
-      onShowInFinder: message.downloadPath ? () => dispatchProps._onShowInFinder(message) : undefined,
-      path: message.fileURL || message.previewURL,
-      previewHeight: height,
-      previewWidth: width,
-      progress: message.transferProgress,
-      progressLabel: message.fileURL ? undefined : 'Loading',
-      title: message.title,
+const Connected = (props: OwnProps) => {
+  const [m, setMessage] = React.useState(Container.getRouteProps(props, 'message', blankMessage))
+  const [autoPlay, setAutoPlay] = React.useState(true)
+  const dispatch = Container.useDispatch()
+  const state = Container.useSelector(s => s)
+  const message = m?.type === 'attachment' ? m : blankMessage
+  const {previewHeight, previewWidth, title, fileURL, previewURL, downloadPath, transferProgress} = message
+  const {conversationIDKey, id} = message
+  const {height: clampedHeight, width: clampedWidth} = Constants.clampImageSize(
+    previewWidth,
+    previewHeight,
+    imgMaxWidthRaw()
+  )
+
+  const onSwitchAttachment = async (backInTime: boolean) => {
+    if (conversationIDKey !== blankMessage.conversationIDKey) {
+      const result = await RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise({
+        assetTypes: [RPCChatTypes.AssetMetadataType.image, RPCChatTypes.AssetMetadataType.video],
+        backInTime,
+        convID: Types.keyToConversationID(conversationIDKey),
+        identifyBehavior: RPCTypes.TLFIdentifyBehavior.chatGui,
+        messageID: id,
+      })
+      await new Promise(resolve => setTimeout(resolve, 10000))
+      if (result.message) {
+        const goodMessage = Constants.uiMessageToMessage(state, conversationIDKey, result.message)
+        if (goodMessage && goodMessage.type === 'attachment') {
+          setAutoPlay(false)
+          setMessage(goodMessage)
+        }
+      }
     }
   }
-)(Fullscreen)
 
+  return (
+    <Fullscreen
+      autoPlay={autoPlay}
+      message={message}
+      isVideo={Constants.isVideoAttachment(message)}
+      onAllMedia={() =>
+        dispatch(
+          RouteTreeGen.createNavigateAppend({
+            path: [{props: {conversationIDKey, tab: 'attachments'}, selected: 'chatInfoPanel'}],
+          })
+        )
+      }
+      onClose={() => dispatch(RouteTreeGen.createNavigateUp())}
+      onDownloadAttachment={
+        message.downloadPath ? undefined : () => dispatch(Chat2Gen.createAttachmentDownload({message}))
+      }
+      onNextAttachment={() => onSwitchAttachment(false)}
+      onPreviousAttachment={() => onSwitchAttachment(true)}
+      onShowInFinder={
+        downloadPath
+          ? () => dispatch(FsGen.createOpenLocalPathInSystemFileManager({localPath: downloadPath}))
+          : undefined
+      }
+      path={fileURL ?? previewURL}
+      previewHeight={clampedHeight}
+      previewWidth={clampedWidth}
+      progress={transferProgress}
+      progressLabel={fileURL ? undefined : 'Loading'}
+      title={title}
+    />
+  )
+}
 export default Connected

--- a/shared/chat/conversation/attachment-fullscreen/container.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/container.tsx
@@ -9,6 +9,8 @@ import * as FsGen from '../../../actions/fs-gen'
 import Fullscreen from '.'
 import * as Container from '../../../util/container'
 import {imgMaxWidthRaw} from '../messages/attachment/image/image-render'
+// TEMP
+import useRPC from '../../../util/use-rpc'
 
 const blankMessage = Constants.makeMessageAttachment({})
 
@@ -28,32 +30,29 @@ const Connected = (props: OwnProps) => {
     imgMaxWidthRaw()
   )
 
-  const submit = Container.useRPC<
-    ReturnType<typeof RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise>
-  >()
+  const submit = /*Container.*/ useRPC(RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise)
 
   const onSwitchAttachment = async (backInTime: boolean) => {
     if (conversationIDKey !== blankMessage.conversationIDKey) {
-      try {
-        const result = await submit(
-          RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise({
-            assetTypes: [RPCChatTypes.AssetMetadataType.image, RPCChatTypes.AssetMetadataType.video],
-            backInTime,
-            convID: Types.keyToConversationID(conversationIDKey),
-            identifyBehavior: RPCTypes.TLFIdentifyBehavior.chatGui,
-            messageID: id,
-          })
-        )
-        if (result.message) {
-          const goodMessage = Constants.uiMessageToMessage(state, conversationIDKey, result.message)
-          if (goodMessage && goodMessage.type === 'attachment') {
-            setAutoPlay(false)
-            setMessage(goodMessage)
+      submit(
+        {
+          assetTypes: [RPCChatTypes.AssetMetadataType.image, RPCChatTypes.AssetMetadataType.video],
+          backInTime,
+          convID: Types.keyToConversationID(conversationIDKey),
+          identifyBehavior: RPCTypes.TLFIdentifyBehavior.chatGui,
+          messageID: id,
+        },
+        result => {
+          if (result.message) {
+            const goodMessage = Constants.uiMessageToMessage(state, conversationIDKey, result.message)
+            if (goodMessage && goodMessage.type === 'attachment') {
+              setAutoPlay(false)
+              setMessage(goodMessage)
+            }
           }
-        }
-      } catch (_e) {
-        // ignore
-      }
+        },
+        error => {}
+      )
     }
   }
 

--- a/shared/chat/conversation/attachment-fullscreen/container.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/container.tsx
@@ -28,22 +28,31 @@ const Connected = (props: OwnProps) => {
     imgMaxWidthRaw()
   )
 
+  const submit = Container.useRPC<
+    ReturnType<typeof RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise>
+  >()
+
   const onSwitchAttachment = async (backInTime: boolean) => {
     if (conversationIDKey !== blankMessage.conversationIDKey) {
-      const result = await RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise({
-        assetTypes: [RPCChatTypes.AssetMetadataType.image, RPCChatTypes.AssetMetadataType.video],
-        backInTime,
-        convID: Types.keyToConversationID(conversationIDKey),
-        identifyBehavior: RPCTypes.TLFIdentifyBehavior.chatGui,
-        messageID: id,
-      })
-      await new Promise(resolve => setTimeout(resolve, 10000))
-      if (result.message) {
-        const goodMessage = Constants.uiMessageToMessage(state, conversationIDKey, result.message)
-        if (goodMessage && goodMessage.type === 'attachment') {
-          setAutoPlay(false)
-          setMessage(goodMessage)
+      try {
+        const result = await submit(
+          RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise({
+            assetTypes: [RPCChatTypes.AssetMetadataType.image, RPCChatTypes.AssetMetadataType.video],
+            backInTime,
+            convID: Types.keyToConversationID(conversationIDKey),
+            identifyBehavior: RPCTypes.TLFIdentifyBehavior.chatGui,
+            messageID: id,
+          })
+        )
+        if (result.message) {
+          const goodMessage = Constants.uiMessageToMessage(state, conversationIDKey, result.message)
+          if (goodMessage && goodMessage.type === 'attachment') {
+            setAutoPlay(false)
+            setMessage(goodMessage)
+          }
         }
+      } catch (_e) {
+        // ignore
       }
     }
   }

--- a/shared/chat/conversation/attachment-fullscreen/container.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/container.tsx
@@ -9,9 +9,6 @@ import * as FsGen from '../../../actions/fs-gen'
 import Fullscreen from '.'
 import * as Container from '../../../util/container'
 import {imgMaxWidthRaw} from '../messages/attachment/image/image-render'
-// TEMP
-import useRPC from '../../../util/use-rpc'
-import useSafeCallback from '../../../util/use-safe-callback'
 
 const blankMessage = Constants.makeMessageAttachment({})
 
@@ -31,10 +28,7 @@ const Connected = (props: OwnProps) => {
     imgMaxWidthRaw()
   )
 
-  const submit = /*Container.*/ useSafeCallback(
-    useRPC(RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise),
-    {onlyOnce: true}
-  )
+  const submit = Container.useRPC(RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise)
 
   const onSwitchAttachment = async (backInTime: boolean) => {
     if (conversationIDKey !== blankMessage.conversationIDKey) {

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -30,7 +30,6 @@ export const blockButtonsGregorPrefix = 'blockButtons.'
 
 export const makeState = (): Types.State => ({
   accountsInfoMap: new Map(),
-  attachmentFullscreenSelection: undefined,
   attachmentViewMap: new Map(),
   audioRecording: new Map(),
   badgeMap: new Map(), // id to the badge count

--- a/shared/constants/types/chat2/index.tsx
+++ b/shared/constants/types/chat2/index.tsx
@@ -162,7 +162,6 @@ export type State = Readonly<{
     Common.ConversationIDKey,
     Map<RPCChatTypes.MessageID, Message.ChatRequestInfo | Message.ChatPaymentInfo>
   > // temp cache for requestPayment and sendPayment message data,
-  attachmentFullscreenSelection?: AttachmentFullscreenSelection
   attachmentViewMap: Map<Common.ConversationIDKey, Map<RPCChatTypes.GalleryItemTyp, AttachmentViewInfo>>
   audioRecording: Map<Common.ConversationIDKey, AudioRecordingInfo>
   badgeMap: ConversationCountMap // id to the badge count,

--- a/shared/devices/add-device/container.tsx
+++ b/shared/devices/add-device/container.tsx
@@ -23,7 +23,4 @@ export default Container.namedConnect(
     highlight: Container.getRouteProps(o, 'highlight', noHighlight),
   }),
   'AddDevice'
-  // Note on mobile this doesn't unmount when we append, however it's impossible
-  // to get back to this screen from provisioning/paperkey, so
-  // `safeSubmitPerMount` works.
-)(Container.safeSubmitPerMount(['onAddComputer', 'onAddPaperKey', 'onAddPhone'])(AddDevice))
+)(AddDevice)

--- a/shared/devices/add-device/index.tsx
+++ b/shared/devices/add-device/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import {isLargeScreen} from '../../constants/platform'
+import {useSafeCallback} from '../../util/container'
 
 type Props = {
   highlight?: Array<'computer' | 'phone' | 'paper key'>
@@ -12,49 +13,55 @@ type Props = {
   onCancel: () => void
 }
 
-const AddDevice = (props: Props) => (
-  <Kb.ScrollView alwaysBounceVertical={false}>
-    <Kb.Box2
-      direction="vertical"
-      gap="medium"
-      alignItems="center"
-      style={styles.container}
-      gapStart={true}
-      gapEnd={true}
-    >
-      <Kb.Box2 direction="vertical" gap="tiny" alignItems="center">
-        {!Styles.isMobile && <Kb.Text type="Header">Add a device</Kb.Text>}
-        <Kb.Text type="Body" center={true}>
-          Protect your account by having more devices and paper keys.
-        </Kb.Text>
-      </Kb.Box2>
+const AddDevice = (props: Props) => {
+  const onlyOnce = true
+  const onAddComputer = useSafeCallback(props.onAddComputer, {onlyOnce})
+  const onAddPhone = useSafeCallback(props.onAddPhone, {onlyOnce})
+  const onAddPaperKey = useSafeCallback(props.onAddPaperKey, {onlyOnce})
+  return (
+    <Kb.ScrollView alwaysBounceVertical={false}>
       <Kb.Box2
-        direction={Styles.isMobile ? 'vertical' : 'horizontal'}
-        gap="large"
-        style={styles.deviceOptions}
+        direction="vertical"
+        gap="medium"
+        alignItems="center"
+        style={styles.container}
+        gapStart={true}
         gapEnd={true}
       >
-        <DeviceOption
-          iconNumber={props.iconNumbers.desktop}
-          onClick={props.onAddComputer}
-          type="computer"
-          highlight={props.highlight && props.highlight.includes('computer')}
-        />
-        <DeviceOption
-          iconNumber={props.iconNumbers.mobile}
-          onClick={props.onAddPhone}
-          type="phone"
-          highlight={props.highlight && props.highlight.includes('phone')}
-        />
-        <DeviceOption
-          onClick={props.onAddPaperKey}
-          type="paper key"
-          highlight={props.highlight && props.highlight.includes('paper key')}
-        />
+        <Kb.Box2 direction="vertical" gap="tiny" alignItems="center">
+          {!Styles.isMobile && <Kb.Text type="Header">Add a device</Kb.Text>}
+          <Kb.Text type="Body" center={true}>
+            Protect your account by having more devices and paper keys.
+          </Kb.Text>
+        </Kb.Box2>
+        <Kb.Box2
+          direction={Styles.isMobile ? 'vertical' : 'horizontal'}
+          gap="large"
+          style={styles.deviceOptions}
+          gapEnd={true}
+        >
+          <DeviceOption
+            iconNumber={props.iconNumbers.desktop}
+            onClick={onAddComputer}
+            type="computer"
+            highlight={props.highlight && props.highlight.includes('computer')}
+          />
+          <DeviceOption
+            iconNumber={props.iconNumbers.mobile}
+            onClick={onAddPhone}
+            type="phone"
+            highlight={props.highlight && props.highlight.includes('phone')}
+          />
+          <DeviceOption
+            onClick={onAddPaperKey}
+            type="paper key"
+            highlight={props.highlight && props.highlight.includes('paper key')}
+          />
+        </Kb.Box2>
       </Kb.Box2>
-    </Kb.Box2>
-  </Kb.ScrollView>
-)
+    </Kb.ScrollView>
+  )
+}
 
 type DeviceOptionProps = {
   highlight?: boolean

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -416,25 +416,9 @@ const attachmentActions: Container.ActionHandler<Actions, Types.State> = {
       map.set(ordinal, m ? Constants.upgradeMessage(m, message) : message)
     }
   },
-  [Chat2Gen.attachmentFullscreenSelection]: (draftState, action) => {
-    const {autoPlay, message} = action.payload
-    draftState.attachmentFullscreenSelection = {autoPlay, message}
-  },
   [Chat2Gen.attachmentLoading]: (draftState, action) => {
     const {conversationIDKey, message, isPreview, ratio} = action.payload
-    const {attachmentFullscreenSelection, attachmentViewMap, messageMap} = draftState
-    if (
-      attachmentFullscreenSelection?.message.conversationIDKey === message.conversationIDKey &&
-      attachmentFullscreenSelection?.message.id === message.id &&
-      message.type === 'attachment'
-    ) {
-      attachmentFullscreenSelection.message = {
-        ...message,
-        transferProgress: ratio,
-        transferState: 'downloading',
-      }
-    }
-
+    const {attachmentViewMap, messageMap} = draftState
     const viewType = RPCChatTypes.GalleryItemTyp.doc
     const viewMap = mapGetEnsureValue(attachmentViewMap, conversationIDKey, new Map())
     const info = mapGetEnsureValue(viewMap, viewType, Constants.makeAttachmentViewInfo())
@@ -463,16 +447,7 @@ const attachmentActions: Container.ActionHandler<Actions, Types.State> = {
   [Chat2Gen.attachmentDownloaded]: (draftState, action) => {
     const {message, path, error} = action.payload
     const {conversationIDKey, ordinal} = message
-    const {attachmentFullscreenSelection, messageMap} = draftState
-    if (
-      !error &&
-      attachmentFullscreenSelection?.message.conversationIDKey === message.conversationIDKey &&
-      attachmentFullscreenSelection?.message.id === message.id &&
-      message.type === 'attachment'
-    ) {
-      attachmentFullscreenSelection.message = {...message, downloadPath: path ?? null}
-    }
-
+    const {messageMap} = draftState
     const {attachmentViewMap} = draftState
     const viewMap = mapGetEnsureValue(attachmentViewMap, conversationIDKey, new Map())
     const viewType = RPCChatTypes.GalleryItemTyp.doc

--- a/shared/util/container.tsx
+++ b/shared/util/container.tsx
@@ -97,5 +97,5 @@ export type Draft<T> = _Draft<T>
 export {default as HiddenString} from './hidden-string'
 export {default as makeReducer} from './make-reducer'
 export type ActionHandler<S, A> = _ActionHandler<S, A>
-export {default as useRPC} from './use-rpc'
+// export {default as useRPC} from './use-rpc'
 

--- a/shared/util/container.tsx
+++ b/shared/util/container.tsx
@@ -99,4 +99,3 @@ export {default as makeReducer} from './make-reducer'
 export type ActionHandler<S, A> = _ActionHandler<S, A>
 export {default as useRPC} from './use-rpc'
 export {default as useSafeCallback} from './use-safe-callback'
-

--- a/shared/util/container.tsx
+++ b/shared/util/container.tsx
@@ -97,5 +97,6 @@ export type Draft<T> = _Draft<T>
 export {default as HiddenString} from './hidden-string'
 export {default as makeReducer} from './make-reducer'
 export type ActionHandler<S, A> = _ActionHandler<S, A>
-// export {default as useRPC} from './use-rpc'
+export {default as useRPC} from './use-rpc'
+export {default as useSafeCallback} from './use-safe-callback'
 

--- a/shared/util/container.tsx
+++ b/shared/util/container.tsx
@@ -97,3 +97,5 @@ export type Draft<T> = _Draft<T>
 export {default as HiddenString} from './hidden-string'
 export {default as makeReducer} from './make-reducer'
 export type ActionHandler<S, A> = _ActionHandler<S, A>
+export {default as useRPC} from './use-rpc'
+

--- a/shared/util/use-rpc.tsx
+++ b/shared/util/use-rpc.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import {RPCError} from './errors'
 /** A hook to make an RPC call. This entirely skips our redux layer and shouldn't be used if you need any side effects
  */
 
@@ -7,17 +8,24 @@ function useRPC<ARGS extends Array<any>, RES extends Promise<any>, C extends (ar
   args: ARGS,
   skipCall: boolean,
   triggers: Array<any>
-): [RES | undefined, Boolean] {
+): [RPCError | undefined, RES | undefined, Boolean] {
   const [loading, setLoading] = React.useState<Boolean>(true)
   const [result, setResult] = React.useState<RES | undefined>(undefined)
+  const [error, setError] = React.useState<RPCError | undefined>(undefined)
   React.useEffect(() => {
     if (skipCall) {
       setLoading(false)
+      setError(undefined)
     } else {
       const fetchData = async () => {
-        const r = await rpcCall(args)
-        setResult(r)
-        setLoading(false)
+        try {
+          const r = await rpcCall(args)
+          setResult(r)
+        } catch (e) {
+          setError(e)
+        } finally {
+          setLoading(false)
+        }
       }
       setLoading(true)
       setResult(undefined)
@@ -25,7 +33,7 @@ function useRPC<ARGS extends Array<any>, RES extends Promise<any>, C extends (ar
     }
     // eslint-disable-next-line
   }, triggers)
-  return [result, loading]
+  return [error, result, loading]
 }
 
 export default useRPC

--- a/shared/util/use-rpc.tsx
+++ b/shared/util/use-rpc.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+/** A hook to make an RPC call. This entirely skips our redux layer and shouldn't be used if you need any side effects
+ */
+
+function useRPC<ARGS extends Array<any>, RES extends Promise<any>, C extends (args?: ARGS) => RES>(
+  rpcCall: C,
+  args: ARGS,
+  skipCall: boolean,
+  triggers: Array<any>
+): [RES | undefined, Boolean] {
+  const [loading, setLoading] = React.useState<Boolean>(true)
+  const [result, setResult] = React.useState<RES | undefined>(undefined)
+  React.useEffect(() => {
+    if (skipCall) {
+      setLoading(false)
+    } else {
+      const fetchData = async () => {
+        const r = await rpcCall(args)
+        setResult(r)
+        setLoading(false)
+      }
+      setLoading(true)
+      setResult(undefined)
+      fetchData()
+    }
+    // eslint-disable-next-line
+  }, triggers)
+  return [result, loading]
+}
+
+export default useRPC

--- a/shared/util/use-rpc.tsx
+++ b/shared/util/use-rpc.tsx
@@ -1,39 +1,76 @@
 import * as React from 'react'
 import {RPCError} from './errors'
+import useMounted from '../common-adapters/use-mounted'
 /** A hook to make an RPC call. This entirely skips our redux layer and shouldn't be used if you need any side effects
  */
 
-function useRPC<ARGS extends Array<any>, RES extends Promise<any>, C extends (args?: ARGS) => RES>(
-  rpcCall: C,
-  args: ARGS,
-  skipCall: boolean,
-  triggers: Array<any>
-): [RPCError | undefined, RES | undefined, Boolean] {
-  const [loading, setLoading] = React.useState<Boolean>(true)
-  const [result, setResult] = React.useState<RES | undefined>(undefined)
-  const [error, setError] = React.useState<RPCError | undefined>(undefined)
+// TODO useReducer
+// type Action = {
+// } | {
+// }
+// const rpcReducer = (state, action) => {
+
+// }
+
+function useRPC<T>(): (promise: Promise<T>) => T | undefined {
+  let isMounted = true
   React.useEffect(() => {
-    if (skipCall) {
-      setLoading(false)
-      setError(undefined)
-    } else {
-      const fetchData = async () => {
-        try {
-          const r = await rpcCall(args)
-          setResult(r)
-        } catch (e) {
-          setError(e)
-        } finally {
-          setLoading(false)
-        }
-      }
-      setLoading(true)
-      setResult(undefined)
-      fetchData()
+    return () => {
+      isMounted = false
     }
-    // eslint-disable-next-line
-  }, triggers)
-  return [error, result, loading]
+  }, [])
+
+  const submit = async (promise: Promise<T>) => {
+    const result = await promise
+
+    await new Promise(resolve => setTimeout(resolve, 5000))
+    if (isMounted) {
+      return result
+    } else {
+      throw new Error()
+    }
+  }
+  return submit
 }
+// function useRPC<ARGS extends Array<any>, RES extends Promise<any>, C extends (args?: ARGS) => RES>(
+// rpcCall: C
+// ): {error?: RPCError; result?: RES; isLoading: Boolean; submit: (args?: ARGS) => void} {
+// const [isLoading, setLoading] = React.useState<Boolean>(true)
+// const [result, setResult] = React.useState<RES | undefined>(undefined)
+// const [error, setError] = React.useState<RPCError | undefined>(undefined)
+// const [callTrigger, setCallTrigger] = React.useState<number>(0)
+// const [args, setArgs] = React.useState<ARGS | undefined>(undefined)
+// const submit = (args?: ARGS) => {
+// setArgs(args)
+// setCallTrigger(callTrigger + 1)
+// }
+
+// const isMounted = useMounted()
+// React.useEffect(() => {
+// if (callTrigger === 0) {
+// setLoading(false)
+// setError(undefined)
+// } else {
+// const fetchData = async () => {
+// try {
+// const r = await rpcCall(args)
+// if (!isMounted) {
+// return
+// }
+// setResult(r)
+// } catch (e) {
+// setError(e)
+// } finally {
+// setLoading(false)
+// }
+// }
+// setLoading(true)
+// setResult(undefined)
+// fetchData()
+// }
+// // eslint-disable-next-line
+// }, [])
+// return {error, isLoading, result, submit}
+// }
 
 export default useRPC

--- a/shared/util/use-rpc.tsx
+++ b/shared/util/use-rpc.tsx
@@ -1,22 +1,15 @@
 import * as React from 'react'
 import {RPCError} from './errors'
-/** A hook to make an RPC call. This entirely skips our redux layer and shouldn't be used if you need any side effects
- */
-
-// TODO useReducer
-// type Action = {
-// } | {
-// }
-// const rpcReducer = (state, action) => {
-
-// }
-
-// TODO
 
 type RPCPromiseType<F extends (...rest: any[]) => any, RF = ReturnType<F>> = RF extends Promise<infer U>
   ? U
   : RF
 
+/** A hook to make an RPC call. This entirely skips our redux layer and shouldn't be used if you need any side effects
+setResult is only called if you're still mounted
+ @param call: the rpc function you intend to call
+ @returns submit: ([rpcArgs], setResult: (rpcResult) => void, setError: (RPCError) => void) => void
+ */
 function useRPC<
   C extends (...r: Array<any>) => any,
   RET = RPCPromiseType<C>,
@@ -34,8 +27,6 @@ function useRPC<
     () => async (args: ARGS, setResult: (r: RET) => void, setError: (e: RPCError) => void) => {
       try {
         const result = await call(...args)
-        await new Promise(resolve => setTimeout(resolve, 1000))
-
         if (isMounted.current) {
           setResult(result)
         }
@@ -45,49 +36,9 @@ function useRPC<
         }
       }
     },
-    []
+    [call]
   )
   return submit()
 }
-// function useRPC<ARGS extends Array<any>, RES extends Promise<any>, C extends (args?: ARGS) => RES>(
-// rpcCall: C
-// ): {error?: RPCError; result?: RES; isLoading: Boolean; submit: (args?: ARGS) => void} {
-// const [isLoading, setLoading] = React.useState<Boolean>(true)
-// const [result, setResult] = React.useState<RES | undefined>(undefined)
-// const [error, setError] = React.useState<RPCError | undefined>(undefined)
-// const [callTrigger, setCallTrigger] = React.useState<number>(0)
-// const [args, setArgs] = React.useState<ARGS | undefined>(undefined)
-// const submit = (args?: ARGS) => {
-// setArgs(args)
-// setCallTrigger(callTrigger + 1)
-// }
-
-// const isMounted = useMounted()
-// React.useEffect(() => {
-// if (callTrigger === 0) {
-// setLoading(false)
-// setError(undefined)
-// } else {
-// const fetchData = async () => {
-// try {
-// const r = await rpcCall(args)
-// if (!isMounted) {
-// return
-// }
-// setResult(r)
-// } catch (e) {
-// setError(e)
-// } finally {
-// setLoading(false)
-// }
-// }
-// setLoading(true)
-// setResult(undefined)
-// fetchData()
-// }
-// // eslint-disable-next-line
-// }, [])
-// return {error, isLoading, result, submit}
-// }
 
 export default useRPC

--- a/shared/util/use-safe-callback.tsx
+++ b/shared/util/use-safe-callback.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+/** a hook to control calling a callback. Disallows a call when unmounted
+ */
+
+type Options = Partial<{
+  /** Only allow once call per mount */
+  onlyOnce: boolean
+}>
+function useSafeCallback<C extends (...args: Array<any>) => void>(cb: C, options?: Options): C {
+  const isMounted = React.useRef<boolean>(true)
+  const calledThisMount = React.useRef<boolean>(false)
+  React.useEffect(() => {
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+  const safe: C = ((...a: Array<any>) => {
+    if (isMounted.current && (!options?.onlyOnce || calledThisMount.current === false)) {
+      cb(...a)
+    }
+    calledThisMount.current = true
+  }) as any
+  return safe
+}
+
+export default useSafeCallback

--- a/shared/util/use-safe-callback.tsx
+++ b/shared/util/use-safe-callback.tsx
@@ -3,17 +3,25 @@ import * as React from 'react'
  */
 
 type Options = Partial<{
-  /** Only allow once call per mount */
-  onlyOnce: boolean
+  /** Only allow once call per mount,  you pass a function that gives you a clear */
+  onlyOnce: (clearOnce: () => void) => void
 }>
 function useSafeCallback<C extends (...args: Array<any>) => void>(cb: C, options?: Options): C {
   const isMounted = React.useRef<boolean>(true)
   const calledThisMount = React.useRef<boolean>(false)
+
+  const clearOnlyOnce = React.useCallback(() => {
+    calledThisMount.current = false
+  }, [])
+
   React.useEffect(() => {
+    options?.onlyOnce?.(clearOnlyOnce)
     return () => {
       isMounted.current = false
     }
+    // eslint-disable-next-line
   }, [])
+
   const safe: C = ((...a: Array<any>) => {
     if (isMounted.current && (!options?.onlyOnce || calledThisMount.current === false)) {
       cb(...a)


### PR DESCRIPTION
Adds two new hooks

### useRPC
Used when you want a simple rpc that you fire and don't need to participate in redux. This is meant for simple isolated cases where you want to avoid plumbing through a bunch of data for a single component. This assumes *no* side effects
Usage:
```
const submit = Container.useRPC(RPCTypes.somethingRpcPromise)
return <div onClick={() => submit(
  [{foo: 'bar'}],
  result => console.log(result),
 error => console.log(error)
)} />
```

### useSafeSubmit
A replacement for the SafeSubmit HOC. Disallows calls after unmount, can stop multiple calls to a callback (per mount)
Usage:
```
const submitWhileMounted = Container.useSafeSubmit(props.submit)
const submitOnce = Container.useSafeSubmit(props.submit, {onlyOnce: true})
const resetSubmit = React.useRef()
const submitOnceWReset = Container.useSafeSubmit(props.submit, {onlyOnce: reset => resetSubmit.current = reset})
```

To test the hooks I changed:
- [x] chat attachments modal to get next/previous attachments using `useRPC`
- [x] device add device modal uses `useSafeSubmit`