### PR TITLE
Add SaltpackFile RPCs

### DIFF
--- a/go/client/cmd_test_crypto.go
+++ b/go/client/cmd_test_crypto.go
@@ -87,6 +87,18 @@ func (s *CmdTestCrypto) Run() (err error) {
 	}
 	dui.Printf("plaintext: %q\n\n", res.Plaintext)
 	dui.Printf("info: %+v\n\n", res.Info)
+	dui.Printf("signed: %v\n", res.Signed)
+
+	decArg = keybase1.SaltpackDecryptStringArg{
+		Ciphertext: `BEGIN KEYBASE SALTPACK ENCRYPTED MESSAGE. kiOZCh3HHJ67ruW BqTLwK4O4wu3rYb nqNg6NDZgFvmpuq I5WS7gm9v6c5G5c jTVWHsEGJwNNAfg JyJguAd07Dlns9X e5bA2n0Vn5z4ZfW OnP54P88sWJuH2Y C4cZouKLhR4h1sw bNiA1XKMaypkN3q 4F811KyR5M29kgT O2AJCMc0rpbWQqT oisyKNPyfpsbi0e sP4QhYQj5rrOiUS 3BBPw5ZDYGTpa3P Yd5PaYH3cxXA8Ym u5k3nFbsAgnt4mM lruQb4LNAz7ZwSD 8SoDqvYygGXRLVF YuPrLFyZIptNSAN htWKDhheWwUP9RM orOzspVIGB9ngOU QCKrW1xQjLQ3Q43 AKOtTWfyce2r4jp 109C40cguaDuUl5 XsygTcdDeEirm54 2fPEiDhu4DjBOCc KmdGpZxe1BzVKvI 7PlLT9KVT8THxqL VgTZzONc0swyGcn yOLW3BKZscEtNSs uPOs4y77PWVUET7 IUpddqEvbKiyLin w9nT60rWV5kQXtx J7QgINM7Z6EMHEq DavAYzeLHvY3wpb tuYYg1JAjN6lRMs vNx7oG6Vpr0brrj UBKEjG8ODaQCQOs vTpEVDAg8IVqpMN 55OPZll2JnHe35l bQpVHzUrEua7URk tBclMiFmXy72iVS OQvLjrs6UTypsFc Oe2gYNAP9u0SP3z hI6S6qFY07JdlQM MMGIuurd9Rf9J5c QfG96NzRoV8f00F BxwscX8FF9b1i4W OhXcMQrTtjNsaCN . END KEYBASE SALTPACK ENCRYPTED MESSAGE.`,
+	}
+	res, err = cli.SaltpackDecryptString(mctx.Ctx(), decArg)
+	if err != nil {
+		return err
+	}
+	dui.Printf("plaintext: %q\n\n", res.Plaintext)
+	dui.Printf("info: %+v\n\n", res.Info)
+	dui.Printf("signed: %v\n", res.Signed)
 
 	dui.Printf("signing string %q\n", plaintext)
 	signArg := keybase1.SaltpackSignStringArg{Plaintext: plaintext}
@@ -140,6 +152,14 @@ func (s *CmdTestCrypto) Run() (err error) {
 		return err
 	}
 	dui.Printf("signed file: %s\n", sfPath)
+
+	dui.Printf("verifying file %s\n", sfPath)
+	vfArg := keybase1.SaltpackVerifyFileArg{SignedFilename: sfPath}
+	vfres, err := cli.SaltpackVerifyFile(mctx.Ctx(), vfArg)
+	if err != nil {
+		return err
+	}
+	dui.Printf("verified result: %+v\n", vfres)
 
 	return nil
 }

--- a/go/client/cmd_test_crypto.go
+++ b/go/client/cmd_test_crypto.go
@@ -133,5 +133,13 @@ func (s *CmdTestCrypto) Run() (err error) {
 	}
 	dui.Printf("decrypt result: %+v\n", dfres)
 
+	dui.Printf("signing file %s\n", s.filename)
+	sfArg := keybase1.SaltpackSignFileArg{Filename: s.filename}
+	sfPath, err := cli.SaltpackSignFile(mctx.Ctx(), sfArg)
+	if err != nil {
+		return err
+	}
+	dui.Printf("signed file: %s\n", sfPath)
+
 	return nil
 }

--- a/go/client/cmd_test_crypto.go
+++ b/go/client/cmd_test_crypto.go
@@ -89,17 +89,6 @@ func (s *CmdTestCrypto) Run() (err error) {
 	dui.Printf("info: %+v\n\n", res.Info)
 	dui.Printf("signed: %v\n", res.Signed)
 
-	decArg = keybase1.SaltpackDecryptStringArg{
-		Ciphertext: `BEGIN KEYBASE SALTPACK ENCRYPTED MESSAGE. kiOZCh3HHJ67ruW BqTLwK4O4wu3rYb nqNg6NDZgFvmpuq I5WS7gm9v6c5G5c jTVWHsEGJwNNAfg JyJguAd07Dlns9X e5bA2n0Vn5z4ZfW OnP54P88sWJuH2Y C4cZouKLhR4h1sw bNiA1XKMaypkN3q 4F811KyR5M29kgT O2AJCMc0rpbWQqT oisyKNPyfpsbi0e sP4QhYQj5rrOiUS 3BBPw5ZDYGTpa3P Yd5PaYH3cxXA8Ym u5k3nFbsAgnt4mM lruQb4LNAz7ZwSD 8SoDqvYygGXRLVF YuPrLFyZIptNSAN htWKDhheWwUP9RM orOzspVIGB9ngOU QCKrW1xQjLQ3Q43 AKOtTWfyce2r4jp 109C40cguaDuUl5 XsygTcdDeEirm54 2fPEiDhu4DjBOCc KmdGpZxe1BzVKvI 7PlLT9KVT8THxqL VgTZzONc0swyGcn yOLW3BKZscEtNSs uPOs4y77PWVUET7 IUpddqEvbKiyLin w9nT60rWV5kQXtx J7QgINM7Z6EMHEq DavAYzeLHvY3wpb tuYYg1JAjN6lRMs vNx7oG6Vpr0brrj UBKEjG8ODaQCQOs vTpEVDAg8IVqpMN 55OPZll2JnHe35l bQpVHzUrEua7URk tBclMiFmXy72iVS OQvLjrs6UTypsFc Oe2gYNAP9u0SP3z hI6S6qFY07JdlQM MMGIuurd9Rf9J5c QfG96NzRoV8f00F BxwscX8FF9b1i4W OhXcMQrTtjNsaCN . END KEYBASE SALTPACK ENCRYPTED MESSAGE.`,
-	}
-	res, err = cli.SaltpackDecryptString(mctx.Ctx(), decArg)
-	if err != nil {
-		return err
-	}
-	dui.Printf("plaintext: %q\n\n", res.Plaintext)
-	dui.Printf("info: %+v\n\n", res.Info)
-	dui.Printf("signed: %v\n", res.Signed)
-
 	dui.Printf("signing string %q\n", plaintext)
 	signArg := keybase1.SaltpackSignStringArg{Plaintext: plaintext}
 	signed, err := cli.SaltpackSignString(mctx.Ctx(), signArg)

--- a/go/client/cmd_test_crypto.go
+++ b/go/client/cmd_test_crypto.go
@@ -17,12 +17,19 @@ func newCmdTestCrypto(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdTestCrypto{Contextified: libkb.NewContextified(g)}, "test-crypto", c)
 		},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "f",
+				Usage: "filename to encrypt",
+			},
+		},
 	}
 }
 
 type CmdTestCrypto struct {
 	libkb.Contextified
 	recipients []string
+	filename   string
 }
 
 func (s *CmdTestCrypto) ParseArgv(ctx *cli.Context) error {
@@ -30,6 +37,7 @@ func (s *CmdTestCrypto) ParseArgv(ctx *cli.Context) error {
 	if len(s.recipients) == 0 {
 		return errors.New("need at least one recipient")
 	}
+	s.filename = ctx.String("f")
 	return nil
 }
 
@@ -96,6 +104,34 @@ func (s *CmdTestCrypto) Run() (err error) {
 		return err
 	}
 	dui.Printf("verify result: %+v\n\n", vres)
+
+	if s.filename == "" {
+		dui.Printf("no filename specified, done.\n")
+		return nil
+	}
+
+	dui.Printf("encrypting file %s\n", s.filename)
+	efArg := keybase1.SaltpackEncryptFileArg{
+		Filename: s.filename,
+		Opts: keybase1.SaltpackFrontendEncryptOptions{
+			Recipients:  s.recipients,
+			IncludeSelf: true,
+			Signed:      true,
+		},
+	}
+	efPath, err := cli.SaltpackEncryptFile(mctx.Ctx(), efArg)
+	if err != nil {
+		return err
+	}
+	dui.Printf("encrypted file: %s\n", efPath)
+
+	dui.Printf("decrypting file: %s\n", efPath)
+	dfArg := keybase1.SaltpackDecryptFileArg{EncryptedFilename: efPath}
+	dfres, err := cli.SaltpackDecryptFile(mctx.Ctx(), dfArg)
+	if err != nil {
+		return err
+	}
+	dui.Printf("decrypt result: %+v\n", dfres)
 
 	return nil
 }

--- a/go/libkb/buf.go
+++ b/go/libkb/buf.go
@@ -3,7 +3,11 @@
 
 package libkb
 
-import "bytes"
+import (
+	"bufio"
+	"bytes"
+	"io"
+)
 
 // BufferCloser is a Buffer that satisfies the io.Closer
 // interface.
@@ -16,3 +20,25 @@ func NewBufferCloser() *BufferCloser {
 }
 
 func (b *BufferCloser) Close() error { return nil }
+
+// BufferWriter has a bufio Writer that will Flush before Close.
+type BufferWriter struct {
+	wc io.WriteCloser
+	w  *bufio.Writer
+}
+
+func NewBufferWriter(wc io.WriteCloser) *BufferWriter {
+	return &BufferWriter{
+		wc: wc,
+		w:  bufio.NewWriter(wc),
+	}
+}
+
+func (b *BufferWriter) Write(p []byte) (n int, err error) {
+	return b.w.Write(p)
+}
+
+func (b *BufferWriter) Close() error {
+	b.w.Flush()
+	return b.wc.Close()
+}

--- a/go/protocol/keybase1/saltpack.go
+++ b/go/protocol/keybase1/saltpack.go
@@ -194,6 +194,18 @@ func (o SaltpackPlaintextResult) DeepCopy() SaltpackPlaintextResult {
 	}
 }
 
+type SaltpackFileResult struct {
+	Info              SaltpackEncryptedMessageInfo `codec:"info" json:"info"`
+	DecryptedFilename string                       `codec:"decryptedFilename" json:"decryptedFilename"`
+}
+
+func (o SaltpackFileResult) DeepCopy() SaltpackFileResult {
+	return SaltpackFileResult{
+		Info:              o.Info.DeepCopy(),
+		DecryptedFilename: o.DecryptedFilename,
+	}
+}
+
 type SaltpackVerifyResult struct {
 	SigningKID KID            `codec:"signingKID" json:"signingKID"`
 	Sender     SaltpackSender `codec:"sender" json:"sender"`
@@ -205,6 +217,20 @@ func (o SaltpackVerifyResult) DeepCopy() SaltpackVerifyResult {
 		SigningKID: o.SigningKID.DeepCopy(),
 		Sender:     o.Sender.DeepCopy(),
 		Plaintext:  o.Plaintext,
+	}
+}
+
+type SaltpackVerifyFileResult struct {
+	SigningKID       KID            `codec:"signingKID" json:"signingKID"`
+	Sender           SaltpackSender `codec:"sender" json:"sender"`
+	VerifiedFilename string         `codec:"verifiedFilename" json:"verifiedFilename"`
+}
+
+func (o SaltpackVerifyFileResult) DeepCopy() SaltpackVerifyFileResult {
+	return SaltpackVerifyFileResult{
+		SigningKID:       o.SigningKID.DeepCopy(),
+		Sender:           o.Sender.DeepCopy(),
+		VerifiedFilename: o.VerifiedFilename,
 	}
 }
 
@@ -242,9 +268,20 @@ type SaltpackEncryptStringArg struct {
 	Opts      SaltpackFrontendEncryptOptions `codec:"opts" json:"opts"`
 }
 
+type SaltpackEncryptFileArg struct {
+	SessionID int                            `codec:"sessionID" json:"sessionID"`
+	Filename  string                         `codec:"filename" json:"filename"`
+	Opts      SaltpackFrontendEncryptOptions `codec:"opts" json:"opts"`
+}
+
 type SaltpackDecryptStringArg struct {
 	SessionID  int    `codec:"sessionID" json:"sessionID"`
 	Ciphertext string `codec:"ciphertext" json:"ciphertext"`
+}
+
+type SaltpackDecryptFileArg struct {
+	SessionID         int    `codec:"sessionID" json:"sessionID"`
+	EncryptedFilename string `codec:"encryptedFilename" json:"encryptedFilename"`
 }
 
 type SaltpackSignStringArg struct {
@@ -252,9 +289,19 @@ type SaltpackSignStringArg struct {
 	Plaintext string `codec:"plaintext" json:"plaintext"`
 }
 
+type SaltpackSignFileArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Filename  string `codec:"filename" json:"filename"`
+}
+
 type SaltpackVerifyStringArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	SignedMsg string `codec:"signedMsg" json:"signedMsg"`
+}
+
+type SaltpackVerifyFileArg struct {
+	SessionID      int    `codec:"sessionID" json:"sessionID"`
+	SignedFilename string `codec:"signedFilename" json:"signedFilename"`
 }
 
 type SaltpackInterface interface {
@@ -263,9 +310,13 @@ type SaltpackInterface interface {
 	SaltpackSign(context.Context, SaltpackSignArg) error
 	SaltpackVerify(context.Context, SaltpackVerifyArg) error
 	SaltpackEncryptString(context.Context, SaltpackEncryptStringArg) (string, error)
+	SaltpackEncryptFile(context.Context, SaltpackEncryptFileArg) (string, error)
 	SaltpackDecryptString(context.Context, SaltpackDecryptStringArg) (SaltpackPlaintextResult, error)
+	SaltpackDecryptFile(context.Context, SaltpackDecryptFileArg) (SaltpackFileResult, error)
 	SaltpackSignString(context.Context, SaltpackSignStringArg) (string, error)
+	SaltpackSignFile(context.Context, SaltpackSignFileArg) (string, error)
 	SaltpackVerifyString(context.Context, SaltpackVerifyStringArg) (SaltpackVerifyResult, error)
+	SaltpackVerifyFile(context.Context, SaltpackVerifyFileArg) (SaltpackVerifyFileResult, error)
 }
 
 func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
@@ -347,6 +398,21 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 					return
 				},
 			},
+			"saltpackEncryptFile": {
+				MakeArg: func() interface{} {
+					var ret [1]SaltpackEncryptFileArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SaltpackEncryptFileArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SaltpackEncryptFileArg)(nil), args)
+						return
+					}
+					ret, err = i.SaltpackEncryptFile(ctx, typedArgs[0])
+					return
+				},
+			},
 			"saltpackDecryptString": {
 				MakeArg: func() interface{} {
 					var ret [1]SaltpackDecryptStringArg
@@ -359,6 +425,21 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.SaltpackDecryptString(ctx, typedArgs[0])
+					return
+				},
+			},
+			"saltpackDecryptFile": {
+				MakeArg: func() interface{} {
+					var ret [1]SaltpackDecryptFileArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SaltpackDecryptFileArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SaltpackDecryptFileArg)(nil), args)
+						return
+					}
+					ret, err = i.SaltpackDecryptFile(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -377,6 +458,21 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 					return
 				},
 			},
+			"saltpackSignFile": {
+				MakeArg: func() interface{} {
+					var ret [1]SaltpackSignFileArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SaltpackSignFileArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SaltpackSignFileArg)(nil), args)
+						return
+					}
+					ret, err = i.SaltpackSignFile(ctx, typedArgs[0])
+					return
+				},
+			},
 			"saltpackVerifyString": {
 				MakeArg: func() interface{} {
 					var ret [1]SaltpackVerifyStringArg
@@ -389,6 +485,21 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.SaltpackVerifyString(ctx, typedArgs[0])
+					return
+				},
+			},
+			"saltpackVerifyFile": {
+				MakeArg: func() interface{} {
+					var ret [1]SaltpackVerifyFileArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SaltpackVerifyFileArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SaltpackVerifyFileArg)(nil), args)
+						return
+					}
+					ret, err = i.SaltpackVerifyFile(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -425,8 +536,18 @@ func (c SaltpackClient) SaltpackEncryptString(ctx context.Context, __arg Saltpac
 	return
 }
 
+func (c SaltpackClient) SaltpackEncryptFile(ctx context.Context, __arg SaltpackEncryptFileArg) (res string, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
 func (c SaltpackClient) SaltpackDecryptString(ctx context.Context, __arg SaltpackDecryptStringArg) (res SaltpackPlaintextResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackDecryptString", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c SaltpackClient) SaltpackDecryptFile(ctx context.Context, __arg SaltpackDecryptFileArg) (res SaltpackFileResult, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackDecryptFile", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -435,7 +556,17 @@ func (c SaltpackClient) SaltpackSignString(ctx context.Context, __arg SaltpackSi
 	return
 }
 
+func (c SaltpackClient) SaltpackSignFile(ctx context.Context, __arg SaltpackSignFileArg) (res string, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackSignFile", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
 func (c SaltpackClient) SaltpackVerifyString(ctx context.Context, __arg SaltpackVerifyStringArg) (res SaltpackVerifyResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackVerifyString", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c SaltpackClient) SaltpackVerifyFile(ctx context.Context, __arg SaltpackVerifyFileArg) (res SaltpackVerifyFileResult, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackVerifyFile", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/saltpack.go
+++ b/go/protocol/keybase1/saltpack.go
@@ -185,24 +185,28 @@ func (o SaltpackFrontendEncryptOptions) DeepCopy() SaltpackFrontendEncryptOption
 type SaltpackPlaintextResult struct {
 	Info      SaltpackEncryptedMessageInfo `codec:"info" json:"info"`
 	Plaintext string                       `codec:"plaintext" json:"plaintext"`
+	Signed    bool                         `codec:"signed" json:"signed"`
 }
 
 func (o SaltpackPlaintextResult) DeepCopy() SaltpackPlaintextResult {
 	return SaltpackPlaintextResult{
 		Info:      o.Info.DeepCopy(),
 		Plaintext: o.Plaintext,
+		Signed:    o.Signed,
 	}
 }
 
 type SaltpackFileResult struct {
 	Info              SaltpackEncryptedMessageInfo `codec:"info" json:"info"`
 	DecryptedFilename string                       `codec:"decryptedFilename" json:"decryptedFilename"`
+	Signed            bool                         `codec:"signed" json:"signed"`
 }
 
 func (o SaltpackFileResult) DeepCopy() SaltpackFileResult {
 	return SaltpackFileResult{
 		Info:              o.Info.DeepCopy(),
 		DecryptedFilename: o.DecryptedFilename,
+		Signed:            o.Signed,
 	}
 }
 
@@ -210,6 +214,7 @@ type SaltpackVerifyResult struct {
 	SigningKID KID            `codec:"signingKID" json:"signingKID"`
 	Sender     SaltpackSender `codec:"sender" json:"sender"`
 	Plaintext  string         `codec:"plaintext" json:"plaintext"`
+	Verified   bool           `codec:"verified" json:"verified"`
 }
 
 func (o SaltpackVerifyResult) DeepCopy() SaltpackVerifyResult {
@@ -217,6 +222,7 @@ func (o SaltpackVerifyResult) DeepCopy() SaltpackVerifyResult {
 		SigningKID: o.SigningKID.DeepCopy(),
 		Sender:     o.Sender.DeepCopy(),
 		Plaintext:  o.Plaintext,
+		Verified:   o.Verified,
 	}
 }
 
@@ -224,6 +230,7 @@ type SaltpackVerifyFileResult struct {
 	SigningKID       KID            `codec:"signingKID" json:"signingKID"`
 	Sender           SaltpackSender `codec:"sender" json:"sender"`
 	VerifiedFilename string         `codec:"verifiedFilename" json:"verifiedFilename"`
+	Verified         bool           `codec:"verified" json:"verified"`
 }
 
 func (o SaltpackVerifyFileResult) DeepCopy() SaltpackVerifyFileResult {
@@ -231,6 +238,7 @@ func (o SaltpackVerifyFileResult) DeepCopy() SaltpackVerifyFileResult {
 		SigningKID:       o.SigningKID.DeepCopy(),
 		Sender:           o.Sender.DeepCopy(),
 		VerifiedFilename: o.VerifiedFilename,
+		Verified:         o.Verified,
 	}
 }
 

--- a/go/protocol/keybase1/saltpack_ui.go
+++ b/go/protocol/keybase1/saltpack_ui.go
@@ -73,6 +73,7 @@ type SaltpackPromptForDecryptArg struct {
 	SigningKID     KID            `codec:"signingKID" json:"signingKID"`
 	Sender         SaltpackSender `codec:"sender" json:"sender"`
 	UsedDelegateUI bool           `codec:"usedDelegateUI" json:"usedDelegateUI"`
+	Signed         bool           `codec:"signed" json:"signed"`
 }
 
 type SaltpackVerifySuccessArg struct {

--- a/go/service/saltpack.go
+++ b/go/service/saltpack.go
@@ -269,6 +269,20 @@ func (h *SaltpackHandler) SaltpackVerifyString(ctx context.Context, arg keybase1
 	return res, nil
 }
 
+func (h *SaltpackHandler) SaltpackEncryptFile(context.Context, keybase1.SaltpackEncryptFileArg) (string, error) {
+	return "", errors.New("nyi")
+}
+
+func (h *SaltpackHandler) SaltpackDecryptFile(context.Context, keybase1.SaltpackDecryptFileArg) (keybase1.SaltpackFileResult, error) {
+	return keybase1.SaltpackFileResult{}, errors.New("nyi")
+}
+func (h *SaltpackHandler) SaltpackSignFile(context.Context, keybase1.SaltpackSignFileArg) (string, error) {
+	return "", errors.New("nyi")
+}
+func (h *SaltpackHandler) SaltpackVerifyFile(context.Context, keybase1.SaltpackVerifyFileArg) (keybase1.SaltpackVerifyFileResult, error) {
+	return keybase1.SaltpackVerifyFileResult{}, errors.New("nyi")
+}
+
 // nopSecretUI returns an error if it is ever called.
 // A lot of these saltpack engines say they require a secret UI.
 // They really don't, but it's dangerous to try to strip it out.

--- a/go/service/saltpack_test.go
+++ b/go/service/saltpack_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -78,7 +79,7 @@ func testSignVerifyString(tc libkb.TestContext, h *SaltpackHandler, u1, u2 *kbte
 func testEncryptDecryptFile(tc libkb.TestContext, h *SaltpackHandler, u1, u2 *kbtest.FakeUser) {
 	ctx := context.Background()
 	encArg := keybase1.SaltpackEncryptFileArg{
-		Filename: "testdata/textfile",
+		Filename: filepath.FromSlash("testdata/textfile"),
 		Opts: keybase1.SaltpackFrontendEncryptOptions{
 			Recipients:  []string{u1.Username, u2.Username},
 			Signed:      true,
@@ -103,7 +104,7 @@ func testEncryptDecryptFile(tc libkb.TestContext, h *SaltpackHandler, u1, u2 *kb
 
 func testSignVerifyFile(tc libkb.TestContext, h *SaltpackHandler, u1, u2 *kbtest.FakeUser) {
 	ctx := context.Background()
-	signArg := keybase1.SaltpackSignFileArg{Filename: "testdata/textfile"}
+	signArg := keybase1.SaltpackSignFileArg{Filename: filepath.FromSlash("testdata/textfile")}
 	signedFile, err := h.SaltpackSignFile(ctx, signArg)
 	require.NoError(tc.T, err)
 	defer os.Remove(signedFile)

--- a/go/service/saltpack_test.go
+++ b/go/service/saltpack_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/keybase/client/go/kbtest"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestSaltpackFrontend(t *testing.T) {
+	tc := libkb.SetupTest(t, "sp", 0)
+	defer tc.Cleanup()
+
+	u1, err := kbtest.CreateAndSignupFakeUser("sp", tc.G)
+	require.NoError(t, err)
+
+	kr, err := tc.G.GetPerUserKeyring(context.Background())
+	require.NoError(t, err)
+	err = kr.Sync(libkb.NewMetaContext(context.Background(), tc.G))
+	require.NoError(t, err)
+
+	u2, err := kbtest.CreateAndSignupFakeUser("sp", tc.G)
+	require.NoError(t, err)
+
+	kr, err = tc.G.GetPerUserKeyring(context.Background())
+	require.NoError(t, err)
+	err = kr.Sync(libkb.NewMetaContext(context.Background(), tc.G))
+	require.NoError(t, err)
+
+	h := NewSaltpackHandler(nil, tc.G)
+	testEncryptDecryptString(tc, h, u1, u2)
+	testSignVerifyString(tc, h, u1, u2)
+	testEncryptDecryptFile(tc, h, u1, u2)
+	testSignVerifyFile(tc, h, u1, u2)
+}
+
+func testEncryptDecryptString(tc libkb.TestContext, h *SaltpackHandler, u1, u2 *kbtest.FakeUser) {
+	ctx := context.Background()
+	encArg := keybase1.SaltpackEncryptStringArg{
+		Plaintext: "Think of life as a banquet.",
+		Opts: keybase1.SaltpackFrontendEncryptOptions{
+			Recipients:  []string{u1.Username, u2.Username},
+			Signed:      true,
+			IncludeSelf: true,
+		},
+	}
+	ciphertext, err := h.SaltpackEncryptString(ctx, encArg)
+	require.NoError(tc.T, err)
+	require.NotEqual(tc.T, encArg.Plaintext, ciphertext)
+
+	decArg := keybase1.SaltpackDecryptStringArg{Ciphertext: ciphertext}
+	decRes, err := h.SaltpackDecryptString(ctx, decArg)
+	require.NoError(tc.T, err)
+	require.Equal(tc.T, decRes.Plaintext, encArg.Plaintext)
+	require.True(tc.T, decRes.Signed)
+}
+
+func testSignVerifyString(tc libkb.TestContext, h *SaltpackHandler, u1, u2 *kbtest.FakeUser) {
+	ctx := context.Background()
+	signArg := keybase1.SaltpackSignStringArg{Plaintext: "Begin with little things."}
+	signedMsg, err := h.SaltpackSignString(ctx, signArg)
+	require.NoError(tc.T, err)
+	require.NotEqual(tc.T, signArg.Plaintext, signedMsg)
+
+	verifyArg := keybase1.SaltpackVerifyStringArg{SignedMsg: signedMsg}
+	verifyRes, err := h.SaltpackVerifyString(ctx, verifyArg)
+	require.NoError(tc.T, err)
+	require.Equal(tc.T, verifyRes.Plaintext, signArg.Plaintext)
+	require.True(tc.T, verifyRes.Verified)
+}
+
+func testEncryptDecryptFile(tc libkb.TestContext, h *SaltpackHandler, u1, u2 *kbtest.FakeUser) {
+	ctx := context.Background()
+	encArg := keybase1.SaltpackEncryptFileArg{
+		Filename: "testdata/textfile",
+		Opts: keybase1.SaltpackFrontendEncryptOptions{
+			Recipients:  []string{u1.Username, u2.Username},
+			Signed:      true,
+			IncludeSelf: true,
+		},
+	}
+	encFile, err := h.SaltpackEncryptFile(ctx, encArg)
+	require.NoError(tc.T, err)
+	defer os.Remove(encFile)
+	require.NotEqual(tc.T, encFile, encArg.Filename)
+	require.True(tc.T, strings.HasSuffix(encFile, ".encrypted.saltpack"))
+
+	decArg := keybase1.SaltpackDecryptFileArg{EncryptedFilename: encFile}
+	decRes, err := h.SaltpackDecryptFile(ctx, decArg)
+	require.NoError(tc.T, err)
+	defer os.Remove(decRes.DecryptedFilename)
+	require.Equal(tc.T, encArg.Filename+" (1)", decRes.DecryptedFilename)
+	require.True(tc.T, decRes.Signed)
+
+	filesEqual(tc, encArg.Filename, decRes.DecryptedFilename)
+}
+
+func testSignVerifyFile(tc libkb.TestContext, h *SaltpackHandler, u1, u2 *kbtest.FakeUser) {
+	ctx := context.Background()
+	signArg := keybase1.SaltpackSignFileArg{Filename: "testdata/textfile"}
+	signedFile, err := h.SaltpackSignFile(ctx, signArg)
+	require.NoError(tc.T, err)
+	defer os.Remove(signedFile)
+	require.NotEqual(tc.T, signedFile, signArg.Filename)
+	require.True(tc.T, strings.HasSuffix(signedFile, ".signed.saltpack"))
+
+	verifyArg := keybase1.SaltpackVerifyFileArg{SignedFilename: signedFile}
+	verifyRes, err := h.SaltpackVerifyFile(ctx, verifyArg)
+	require.NoError(tc.T, err)
+	defer os.Remove(verifyRes.VerifiedFilename)
+	require.Equal(tc.T, signArg.Filename+" (1)", verifyRes.VerifiedFilename)
+	require.True(tc.T, verifyRes.Verified)
+
+	filesEqual(tc, signArg.Filename, verifyRes.VerifiedFilename)
+}
+
+func filesEqual(tc libkb.TestContext, a, b string) {
+	adata, err := ioutil.ReadFile(a)
+	require.NoError(tc.T, err)
+	bdata, err := ioutil.ReadFile(b)
+	require.NoError(tc.T, err)
+	require.Equal(tc.T, adata, bdata)
+}

--- a/go/service/testdata/textfile
+++ b/go/service/testdata/textfile
@@ -1,0 +1,2 @@
+NaCl (pronounced "salt") is a new easy-to-use high-speed software library for network communication, encryption, decryption, signatures, etc. NaCl's goal is to provide all of the core operations needed to build higher-level cryptographic tools.
+Of course, other libraries already exist for these core operations. NaCl advances the state of the art by improving security, by improving usability, and by improving speed.

--- a/protocol/avdl/keybase1/saltpack.avdl
+++ b/protocol/avdl/keybase1/saltpack.avdl
@@ -69,6 +69,7 @@ protocol saltpack {
   }
 
   string saltpackEncryptString(int sessionID, string plaintext, SaltpackFrontendEncryptOptions opts);
+  string saltpackEncryptFile(int sessionID, string filename, SaltpackFrontendEncryptOptions opts);
 
   record SaltpackPlaintextResult {
     SaltpackEncryptedMessageInfo info;
@@ -76,7 +77,14 @@ protocol saltpack {
   }
   SaltpackPlaintextResult saltpackDecryptString(int sessionID, string ciphertext);
 
+  record SaltpackFileResult {
+    SaltpackEncryptedMessageInfo info;
+    string decryptedFilename;
+  }
+  SaltpackFileResult saltpackDecryptFile(int sessionID, string encryptedFilename);
+
   string saltpackSignString(int sessionID, string plaintext);
+  string saltpackSignFile(int sessionID, string filename);
 
   record SaltpackVerifyResult {
     KID signingKID;
@@ -84,4 +92,11 @@ protocol saltpack {
     string plaintext;
   }
   SaltpackVerifyResult saltpackVerifyString(int sessionID, string signedMsg);
+
+  record SaltpackVerifyFileResult {
+    KID signingKID;
+    SaltpackSender sender;
+    string verifiedFilename;
+  }
+  SaltpackVerifyFileResult saltpackVerifyFile(int sessionID, string signedFilename);
 }

--- a/protocol/avdl/keybase1/saltpack.avdl
+++ b/protocol/avdl/keybase1/saltpack.avdl
@@ -74,12 +74,14 @@ protocol saltpack {
   record SaltpackPlaintextResult {
     SaltpackEncryptedMessageInfo info;
     string plaintext;
+    boolean signed;
   }
   SaltpackPlaintextResult saltpackDecryptString(int sessionID, string ciphertext);
 
   record SaltpackFileResult {
     SaltpackEncryptedMessageInfo info;
     string decryptedFilename;
+    boolean signed;
   }
   SaltpackFileResult saltpackDecryptFile(int sessionID, string encryptedFilename);
 
@@ -90,6 +92,7 @@ protocol saltpack {
     KID signingKID;
     SaltpackSender sender;
     string plaintext;
+    boolean verified;
   }
   SaltpackVerifyResult saltpackVerifyString(int sessionID, string signedMsg);
 
@@ -97,6 +100,7 @@ protocol saltpack {
     KID signingKID;
     SaltpackSender sender;
     string verifiedFilename;
+    boolean verified;
   }
   SaltpackVerifyFileResult saltpackVerifyFile(int sessionID, string signedFilename);
 }

--- a/protocol/avdl/keybase1/saltpack_ui.avdl
+++ b/protocol/avdl/keybase1/saltpack_ui.avdl
@@ -22,7 +22,10 @@ protocol saltpackUi {
 
   // Users might want to prevent a decryption on the basis of who sent the message,
   // and if something fishy might have happened.
-  void saltpackPromptForDecrypt(int sessionID, KID signingKID, SaltpackSender sender, boolean usedDelegateUI);
+  //
+  // PC: note that signingKID is not necessarily a signing key.  The decrypt code
+  // puts the public decryption key here too if the message is unsigned.
+  void saltpackPromptForDecrypt(int sessionID, KID signingKID, SaltpackSender sender, boolean usedDelegateUI, boolean signed);
 
   void saltpackVerifySuccess(int sessionID, KID signingKID, SaltpackSender sender);
   void saltpackVerifyBadSender(int sessionID, KID signingKID, SaltpackSender sender);

--- a/protocol/json/keybase1/saltpack.json
+++ b/protocol/json/keybase1/saltpack.json
@@ -184,6 +184,20 @@
     },
     {
       "type": "record",
+      "name": "SaltpackFileResult",
+      "fields": [
+        {
+          "type": "SaltpackEncryptedMessageInfo",
+          "name": "info"
+        },
+        {
+          "type": "string",
+          "name": "decryptedFilename"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "SaltpackVerifyResult",
       "fields": [
         {
@@ -197,6 +211,24 @@
         {
           "type": "string",
           "name": "plaintext"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SaltpackVerifyFileResult",
+      "fields": [
+        {
+          "type": "KID",
+          "name": "signingKID"
+        },
+        {
+          "type": "SaltpackSender",
+          "name": "sender"
+        },
+        {
+          "type": "string",
+          "name": "verifiedFilename"
         }
       ]
     }
@@ -303,6 +335,23 @@
       ],
       "response": "string"
     },
+    "saltpackEncryptFile": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "filename",
+          "type": "string"
+        },
+        {
+          "name": "opts",
+          "type": "SaltpackFrontendEncryptOptions"
+        }
+      ],
+      "response": "string"
+    },
     "saltpackDecryptString": {
       "request": [
         {
@@ -316,6 +365,19 @@
       ],
       "response": "SaltpackPlaintextResult"
     },
+    "saltpackDecryptFile": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "encryptedFilename",
+          "type": "string"
+        }
+      ],
+      "response": "SaltpackFileResult"
+    },
     "saltpackSignString": {
       "request": [
         {
@@ -324,6 +386,19 @@
         },
         {
           "name": "plaintext",
+          "type": "string"
+        }
+      ],
+      "response": "string"
+    },
+    "saltpackSignFile": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "filename",
           "type": "string"
         }
       ],
@@ -341,6 +416,19 @@
         }
       ],
       "response": "SaltpackVerifyResult"
+    },
+    "saltpackVerifyFile": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "signedFilename",
+          "type": "string"
+        }
+      ],
+      "response": "SaltpackVerifyFileResult"
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/saltpack.json
+++ b/protocol/json/keybase1/saltpack.json
@@ -179,6 +179,10 @@
         {
           "type": "string",
           "name": "plaintext"
+        },
+        {
+          "type": "boolean",
+          "name": "signed"
         }
       ]
     },
@@ -193,6 +197,10 @@
         {
           "type": "string",
           "name": "decryptedFilename"
+        },
+        {
+          "type": "boolean",
+          "name": "signed"
         }
       ]
     },
@@ -211,6 +219,10 @@
         {
           "type": "string",
           "name": "plaintext"
+        },
+        {
+          "type": "boolean",
+          "name": "verified"
         }
       ]
     },
@@ -229,6 +241,10 @@
         {
           "type": "string",
           "name": "verifiedFilename"
+        },
+        {
+          "type": "boolean",
+          "name": "verified"
         }
       ]
     }

--- a/protocol/json/keybase1/saltpack_ui.json
+++ b/protocol/json/keybase1/saltpack_ui.json
@@ -58,6 +58,10 @@
         {
           "name": "usedDelegateUI",
           "type": "boolean"
+        },
+        {
+          "name": "signed",
+          "type": "boolean"
         }
       ],
       "response": null

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1192,7 +1192,7 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.saltpackUi.saltpackPromptForDecrypt': {
-    inParam: {readonly signingKID: KID; readonly sender: SaltpackSender; readonly usedDelegateUI: Boolean}
+    inParam: {readonly signingKID: KID; readonly sender: SaltpackSender; readonly usedDelegateUI: Boolean; readonly signed: Boolean}
     outParam: void
   }
   'keybase.1.saltpackUi.saltpackVerifyBadSender': {
@@ -2885,14 +2885,14 @@ export type SHA512 = Bytes
 export type SaltpackDecryptOptions = {readonly interactive: Boolean; readonly forceRemoteCheck: Boolean; readonly usePaperKey: Boolean}
 export type SaltpackEncryptOptions = {readonly recipients?: Array<String> | null; readonly teamRecipients?: Array<String> | null; readonly authenticityType: AuthenticityType; readonly useEntityKeys: Boolean; readonly useDeviceKeys: Boolean; readonly usePaperKeys: Boolean; readonly noSelfEncrypt: Boolean; readonly binary: Boolean; readonly saltpackVersion: Int; readonly useKBFSKeysOnlyForTesting: Boolean}
 export type SaltpackEncryptedMessageInfo = {readonly devices?: Array<Device> | null; readonly numAnonReceivers: Int; readonly receiverIsAnon: Boolean; readonly sender: SaltpackSender}
-export type SaltpackFileResult = {readonly info: SaltpackEncryptedMessageInfo; readonly decryptedFilename: String}
+export type SaltpackFileResult = {readonly info: SaltpackEncryptedMessageInfo; readonly decryptedFilename: String; readonly signed: Boolean}
 export type SaltpackFrontendEncryptOptions = {readonly recipients?: Array<String> | null; readonly signed: Boolean; readonly includeSelf: Boolean}
-export type SaltpackPlaintextResult = {readonly info: SaltpackEncryptedMessageInfo; readonly plaintext: String}
+export type SaltpackPlaintextResult = {readonly info: SaltpackEncryptedMessageInfo; readonly plaintext: String; readonly signed: Boolean}
 export type SaltpackSender = {readonly uid: UID; readonly username: String; readonly senderType: SaltpackSenderType}
 export type SaltpackSignOptions = {readonly detached: Boolean; readonly binary: Boolean; readonly saltpackVersion: Int}
-export type SaltpackVerifyFileResult = {readonly signingKID: KID; readonly sender: SaltpackSender; readonly verifiedFilename: String}
+export type SaltpackVerifyFileResult = {readonly signingKID: KID; readonly sender: SaltpackSender; readonly verifiedFilename: String; readonly verified: Boolean}
 export type SaltpackVerifyOptions = {readonly signedBy: String; readonly signature: Bytes}
-export type SaltpackVerifyResult = {readonly signingKID: KID; readonly sender: SaltpackSender; readonly plaintext: String}
+export type SaltpackVerifyResult = {readonly signingKID: KID; readonly sender: SaltpackSender; readonly plaintext: String; readonly verified: Boolean}
 export type SearchRes = {readonly bots?: Array<FeaturedBot> | null; readonly isLastPage: Boolean}
 export type SecretEntryArg = {readonly desc: String; readonly prompt: String; readonly err: String; readonly cancel: String; readonly ok: String; readonly reason: String; readonly showTyping: Boolean}
 export type SecretEntryRes = {readonly text: String; readonly canceled: Boolean; readonly storeSecret: Boolean}

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2885,10 +2885,12 @@ export type SHA512 = Bytes
 export type SaltpackDecryptOptions = {readonly interactive: Boolean; readonly forceRemoteCheck: Boolean; readonly usePaperKey: Boolean}
 export type SaltpackEncryptOptions = {readonly recipients?: Array<String> | null; readonly teamRecipients?: Array<String> | null; readonly authenticityType: AuthenticityType; readonly useEntityKeys: Boolean; readonly useDeviceKeys: Boolean; readonly usePaperKeys: Boolean; readonly noSelfEncrypt: Boolean; readonly binary: Boolean; readonly saltpackVersion: Int; readonly useKBFSKeysOnlyForTesting: Boolean}
 export type SaltpackEncryptedMessageInfo = {readonly devices?: Array<Device> | null; readonly numAnonReceivers: Int; readonly receiverIsAnon: Boolean; readonly sender: SaltpackSender}
+export type SaltpackFileResult = {readonly info: SaltpackEncryptedMessageInfo; readonly decryptedFilename: String}
 export type SaltpackFrontendEncryptOptions = {readonly recipients?: Array<String> | null; readonly signed: Boolean; readonly includeSelf: Boolean}
 export type SaltpackPlaintextResult = {readonly info: SaltpackEncryptedMessageInfo; readonly plaintext: String}
 export type SaltpackSender = {readonly uid: UID; readonly username: String; readonly senderType: SaltpackSenderType}
 export type SaltpackSignOptions = {readonly detached: Boolean; readonly binary: Boolean; readonly saltpackVersion: Int}
+export type SaltpackVerifyFileResult = {readonly signingKID: KID; readonly sender: SaltpackSender; readonly verifiedFilename: String}
 export type SaltpackVerifyOptions = {readonly signedBy: String; readonly signature: Bytes}
 export type SaltpackVerifyResult = {readonly signingKID: KID; readonly sender: SaltpackSender; readonly plaintext: String}
 export type SearchRes = {readonly bots?: Array<FeaturedBot> | null; readonly isLastPage: Boolean}
@@ -3873,9 +3875,13 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.saltpack.saltpackSign'
 // 'keybase.1.saltpack.saltpackVerify'
 // 'keybase.1.saltpack.saltpackEncryptString'
+// 'keybase.1.saltpack.saltpackEncryptFile'
 // 'keybase.1.saltpack.saltpackDecryptString'
+// 'keybase.1.saltpack.saltpackDecryptFile'
 // 'keybase.1.saltpack.saltpackSignString'
+// 'keybase.1.saltpack.saltpackSignFile'
 // 'keybase.1.saltpack.saltpackVerifyString'
+// 'keybase.1.saltpack.saltpackVerifyFile'
 // 'keybase.1.saltpackUi.saltpackPromptForDecrypt'
 // 'keybase.1.saltpackUi.saltpackVerifySuccess'
 // 'keybase.1.saltpackUi.saltpackVerifyBadSender'


### PR DESCRIPTION
These are intended to make it easy for frontend to perform saltpack operations on files.  They handle all the details, just pass in a filename and get a filename back, possibly with some extra info.