### PR TITLE
journeycard dismiss x

### DIFF
--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -11,6 +11,7 @@
   "chat.1.local.SetConversationStatusLocal": {"promise": true},
   "chat.1.local.addTeamMemberAfterReset": {"promise": true},
   "chat.1.local.deleteConversationLocal": {"promise": true},
+  "chat.1.local.dismissJourneycard": {"promise": true},
   "chat.1.local.editBotMember": {"promise": true},
   "chat.1.local.findConversationsLocal": {"promise": true},
   "chat.1.local.findGeneralConvFromTeamID": {"promise": true},

--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -41,6 +41,7 @@ export const deselectConversation = 'chat2:deselectConversation'
 export const desktopNotification = 'chat2:desktopNotification'
 export const dismissBlockButtons = 'chat2:dismissBlockButtons'
 export const dismissBottomBanner = 'chat2:dismissBottomBanner'
+export const dismissJourneycard = 'chat2:dismissJourneycard'
 export const editBotSettings = 'chat2:editBotSettings'
 export const enableAudioRecording = 'chat2:enableAudioRecording'
 export const findGeneralConvIDFromTeamID = 'chat2:findGeneralConvIDFromTeamID'
@@ -266,6 +267,11 @@ type _DesktopNotificationPayload = {
 }
 type _DismissBlockButtonsPayload = {readonly teamID: RPCTypes.TeamID}
 type _DismissBottomBannerPayload = {readonly conversationIDKey: Types.ConversationIDKey}
+type _DismissJourneycardPayload = {
+  readonly conversationIDKey: Types.ConversationIDKey
+  readonly cardType: RPCChatTypes.JourneycardType
+  readonly ordinal: Types.Ordinal
+}
 type _EditBotSettingsPayload = {
   readonly conversationIDKey: Types.ConversationIDKey
   readonly username: string
@@ -854,6 +860,13 @@ export const createUpdateTeamRetentionPolicy = (
 export const createTabSelected = (payload: _TabSelectedPayload): TabSelectedPayload => ({
   payload,
   type: tabSelected,
+})
+/**
+ * Dismiss a journeycard
+ */
+export const createDismissJourneycard = (payload: _DismissJourneycardPayload): DismissJourneycardPayload => ({
+  payload,
+  type: dismissJourneycard,
 })
 /**
  * Explicitly set whether a thread is loaded to the most recent message
@@ -1763,6 +1776,10 @@ export type DismissBottomBannerPayload = {
   readonly payload: _DismissBottomBannerPayload
   readonly type: typeof dismissBottomBanner
 }
+export type DismissJourneycardPayload = {
+  readonly payload: _DismissJourneycardPayload
+  readonly type: typeof dismissJourneycard
+}
 export type EditBotSettingsPayload = {
   readonly payload: _EditBotSettingsPayload
   readonly type: typeof editBotSettings
@@ -2296,6 +2313,7 @@ export type Actions =
   | DesktopNotificationPayload
   | DismissBlockButtonsPayload
   | DismissBottomBannerPayload
+  | DismissJourneycardPayload
   | EditBotSettingsPayload
   | EnableAudioRecordingPayload
   | FindGeneralConvIDFromTeamIDPayload

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2365,14 +2365,14 @@ const deleteMessageHistory = async (
   })
 }
 
-function dismissJourneycard(
+const dismissJourneycard = (
   action: Chat2Gen.DismissJourneycardPayload,
   logger: Saga.SagaLogger
-) {
+) => {
   const {cardType, conversationIDKey, ordinal} = action.payload
   RPCChatTypes.localDismissJourneycardRpcPromise({
-    convID: Types.keyToConversationID(conversationIDKey),
     cardType: cardType,
+    convID: Types.keyToConversationID(conversationIDKey),
   }).catch((err) => {
     logger.error(`Failed to dismiss journeycard: ${err.message}`)
   })

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2365,15 +2365,12 @@ const deleteMessageHistory = async (
   })
 }
 
-const dismissJourneycard = (
-  action: Chat2Gen.DismissJourneycardPayload,
-  logger: Saga.SagaLogger
-) => {
+const dismissJourneycard = (action: Chat2Gen.DismissJourneycardPayload, logger: Saga.SagaLogger) => {
   const {cardType, conversationIDKey, ordinal} = action.payload
   RPCChatTypes.localDismissJourneycardRpcPromise({
     cardType: cardType,
     convID: Types.keyToConversationID(conversationIDKey),
-  }).catch((err) => {
+  }).catch(err => {
     logger.error(`Failed to dismiss journeycard: ${err.message}`)
   })
   return Chat2Gen.createMessagesWereDeleted({conversationIDKey, ordinals: [ordinal]})

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -894,6 +894,12 @@
       "conversationIDKey": "Types.ConversationIDKey",
       "username": "string",
       "role": "TeamsTypes.TeamRoleType | null"
+    },
+    "dismissJourneycard": {
+      "_description": "Dismiss a journeycard",
+      "conversationIDKey": "Types.ConversationIDKey",
+      "cardType": "RPCChatTypes.JourneycardType",
+      "ordinal": "Types.Ordinal"
     }
   }
 }

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -250,6 +250,7 @@ export type TypedActionsMap = {
   'chat2:setGeneralConvFromTeamID': chat2.SetGeneralConvFromTeamIDPayload
   'chat2:refreshBotRoleInConv': chat2.RefreshBotRoleInConvPayload
   'chat2:setBotRoleInConv': chat2.SetBotRoleInConvPayload
+  'chat2:dismissJourneycard': chat2.DismissJourneycardPayload
   'config:startHandshake': config.StartHandshakePayload
   'config:restartHandshake': config.RestartHandshakePayload
   'config:daemonHandshake': config.DaemonHandshakePayload

--- a/shared/chat/conversation/messages/cards/team-journey/container.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/container.tsx
@@ -28,6 +28,7 @@ type Props = {
   onAddPeopleToTeam: () => void
   onBrowseChannels: () => void
   onCreateChatChannels: () => void
+  onDismiss: () => void
   onGoToChannel: (channelname: string) => void
   onLoadTeam: () => void
   onPublishTeam: () => void
@@ -149,6 +150,7 @@ const TeamJourneyContainer = (props: Props) => {
       teamname={props.teamname}
       conversationIDKey={props.conversationIDKey}
       textComponent={textComponent}
+      onDismiss={props.onDismiss}
     />
   ) : null
 }
@@ -176,6 +178,11 @@ const TeamJourneyConnected = Container.connect(
       ),
     _onCreateChannel: (teamID: string) =>
       dispatch(RouteTreeGen.createNavigateAppend({path: [{props: {teamID}, selected: 'chatCreateChannel'}]})),
+    _onDismiss: (
+      conversationIDKey: ChatTypes.ConversationIDKey,
+      cardType: RPCChatTypes.JourneycardType,
+      ordinal: ChatTypes.Ordinal
+    ) => dispatch(Chat2Gen.createDismissJourneycard({conversationIDKey, cardType, ordinal})),
     _onGoToChannel: (channelname: string, teamname: string) =>
       dispatch(Chat2Gen.createPreviewConversation({channelname, reason: 'journeyCardPopular', teamname})),
     _onLoadTeam: (teamID: string) => dispatch(TeamsGen.createGetChannels({teamID})),
@@ -216,6 +223,12 @@ const TeamJourneyConnected = Container.connect(
       onAuthorClick: () => dispatchProps._onAuthorClick(stateProps._teamID),
       onBrowseChannels: () => dispatchProps._onManageChannels(stateProps._teamID),
       onCreateChatChannels: () => dispatchProps._onCreateChannel(stateProps._teamID),
+      onDismiss: () =>
+        dispatchProps._onDismiss(
+          stateProps.conversationIDKey,
+          ownProps.message.cardType,
+          ownProps.message.ordinal
+        ),
       onGoToChannel: (channelName: string) => dispatchProps._onGoToChannel(channelName, stateProps.teamname),
       onLoadTeam: () => dispatchProps._onLoadTeam(stateProps._teamID),
       onPublishTeam: () => dispatchProps._onPublishTeam(),

--- a/shared/chat/conversation/messages/cards/team-journey/container.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/container.tsx
@@ -182,7 +182,7 @@ const TeamJourneyConnected = Container.connect(
       conversationIDKey: ChatTypes.ConversationIDKey,
       cardType: RPCChatTypes.JourneycardType,
       ordinal: ChatTypes.Ordinal
-    ) => dispatch(Chat2Gen.createDismissJourneycard({conversationIDKey, cardType, ordinal})),
+    ) => dispatch(Chat2Gen.createDismissJourneycard({cardType, conversationIDKey, ordinal})),
     _onGoToChannel: (channelname: string, teamname: string) =>
       dispatch(Chat2Gen.createPreviewConversation({channelname, reason: 'journeyCardPopular', teamname})),
     _onLoadTeam: (teamID: string) => dispatch(TeamsGen.createGetChannels({teamID})),

--- a/shared/chat/conversation/messages/cards/team-journey/index.stories.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/index.stories.tsx
@@ -7,8 +7,8 @@ import TeamJourney from './index'
 const commonProps = {
   conversationIDKey: 'dummyConversationIDKey',
   onAuthorClick: Sb.action('onAuthorClick'),
-  teamname: 'foo',
   onDismiss: Sb.action('onDismiss'),
+  teamname: 'foo',
 }
 
 const load = () => {

--- a/shared/chat/conversation/messages/cards/team-journey/index.stories.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/index.stories.tsx
@@ -8,6 +8,7 @@ const commonProps = {
   conversationIDKey: 'dummyConversationIDKey',
   onAuthorClick: Sb.action('onAuthorClick'),
   teamname: 'foo',
+  onDismiss: Sb.action('onDismiss'),
 }
 
 const load = () => {

--- a/shared/chat/conversation/messages/cards/team-journey/index.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/index.tsx
@@ -16,6 +16,7 @@ type Props = {
   image: Kb.IconType | null
   loadTeam?: () => void
   onAuthorClick: () => void
+  onDismiss: () => void
   teamname: string
   textComponent: React.ReactNode
 }
@@ -29,7 +30,7 @@ export const TeamJourney = (props: Props) => {
   }, [])
   return (
     <>
-      <TeamJourneyHeader teamname={teamname} onAuthorClick={props.onAuthorClick} />
+      <TeamJourneyHeader teamname={teamname} onAuthorClick={props.onAuthorClick} onDismiss={props.onDismiss} />
       <Kb.Box2 key="content" direction="vertical" fullWidth={true} style={styles.content}>
         <Kb.Box2 direction="horizontal" fullWidth={true}>
           <Kb.Box2 direction="horizontal" style={props.image ? styles.text : undefined}>
@@ -68,31 +69,31 @@ export const TeamJourney = (props: Props) => {
 type HeaderProps = {
   teamname: string
   onAuthorClick: () => void
+  onDismiss: () => void
 }
 const TeamJourneyHeader = (props: HeaderProps) => (
-  <>
-    <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny">
-      <Kb.Avatar
-        size={32}
-        isTeam={true}
-        teamname={props.teamname}
-        skipBackground={true}
-        style={styles.avatar}
+  <Kb.Box2 key="author" direction="horizontal" fullWidth={true} style={styles.authorContainer} gap="tiny">
+    <Kb.Avatar
+      size={32}
+      isTeam={true}
+      teamname={props.teamname}
+      skipBackground={true}
+      style={styles.avatar}
+      onClick={props.onAuthorClick}
+    />
+    <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={false} alignSelf="flex-start" style={styles.bottomLine}>
+      <Kb.Text
+        style={styles.teamnameText}
+        type="BodySmallBold"
         onClick={props.onAuthorClick}
-      />
-      <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.bottomLine}>
-        <Kb.Text
-          style={styles.teamnameText}
-          type="BodySmallBold"
-          onClick={props.onAuthorClick}
-          className="hover-underline"
-        >
-          {props.teamname}
-        </Kb.Text>
-        <Kb.Text type="BodyTiny">• System message</Kb.Text>
-      </Kb.Box2>
+        className="hover-underline"
+      >
+        {props.teamname}
+      </Kb.Text>
+      <Kb.Text type="BodyTiny">• System message</Kb.Text>
     </Kb.Box2>
-  </>
+    {!Styles.isMobile && <Kb.Icon type="iconfont-close" onClick={props.onDismiss} fontSize={12} />}
+  </Kb.Box2>
 )
 
 const buttonSpace = 6
@@ -122,9 +123,10 @@ const styles = Styles.styleSheetCreate(
           marginLeft: Styles.globalMargins.small,
           marginTop: Styles.globalMargins.xtiny,
         },
-        isMobile: {marginLeft: Styles.globalMargins.xtiny},
+        isMobile: {marginLeft: Styles.globalMargins.tiny},
       }),
       bottomLine: {
+        ...Styles.globalStyles.flexGrow,
         alignItems: 'baseline',
       },
       buttonSpace: {
@@ -143,10 +145,10 @@ const styles = Styles.styleSheetCreate(
           marginTop: -12,
           paddingBottom: 3,
           paddingLeft:
-            // Space for below the avatar
-            Styles.globalMargins.tiny + // right margin
-            Styles.globalMargins.tiny + // left margin
-            Styles.globalMargins.mediumLarge, // avatar
+          // Space for below the avatar
+          Styles.globalMargins.tiny + // right margin
+          Styles.globalMargins.tiny + // left margin
+          Styles.globalMargins.mediumLarge, // avatar
           paddingRight: Styles.globalMargins.tiny,
         },
       }),
@@ -157,9 +159,6 @@ const styles = Styles.styleSheetCreate(
       teamnameText: Styles.platformStyles({
         common: {
           color: Styles.globalColors.black,
-        },
-        isMobile: {
-          marginLeft: Styles.globalMargins.xtiny,
         },
       }),
       text: {

--- a/shared/chat/conversation/messages/cards/team-journey/index.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/index.tsx
@@ -30,7 +30,11 @@ export const TeamJourney = (props: Props) => {
   }, [])
   return (
     <>
-      <TeamJourneyHeader teamname={teamname} onAuthorClick={props.onAuthorClick} onDismiss={props.onDismiss} />
+      <TeamJourneyHeader
+        teamname={teamname}
+        onAuthorClick={props.onAuthorClick}
+        onDismiss={props.onDismiss}
+      />
       <Kb.Box2 key="content" direction="vertical" fullWidth={true} style={styles.content}>
         <Kb.Box2 direction="horizontal" fullWidth={true}>
           <Kb.Box2 direction="horizontal" style={props.image ? styles.text : undefined}>
@@ -81,7 +85,13 @@ const TeamJourneyHeader = (props: HeaderProps) => (
       style={styles.avatar}
       onClick={props.onAuthorClick}
     />
-    <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={false} alignSelf="flex-start" style={styles.bottomLine}>
+    <Kb.Box2
+      direction="horizontal"
+      gap="xtiny"
+      fullWidth={false}
+      alignSelf="flex-start"
+      style={styles.bottomLine}
+    >
       <Kb.Text
         style={styles.teamnameText}
         type="BodySmallBold"
@@ -145,10 +155,10 @@ const styles = Styles.styleSheetCreate(
           marginTop: -12,
           paddingBottom: 3,
           paddingLeft:
-          // Space for below the avatar
-          Styles.globalMargins.tiny + // right margin
-          Styles.globalMargins.tiny + // left margin
-          Styles.globalMargins.mediumLarge, // avatar
+            // Space for below the avatar
+            Styles.globalMargins.tiny + // right margin
+            Styles.globalMargins.tiny + // left margin
+            Styles.globalMargins.mediumLarge, // avatar
           paddingRight: Styles.globalMargins.tiny,
         },
       }),

--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -71,6 +71,8 @@ const getUsernameToShow = (
       return message.joiners.length + message.leavers.length > 1 ? '' : message.author
     case 'systemSBSResolved':
       return message.prover
+    case 'journeycard':
+      return 'placeholder'
   }
   return message.author
 }

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -386,7 +386,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       return {
         className: Styles.classNames(
           {
-            'WrapperMessage-author': this.props.showUsername || this.props.message.type === 'journeycard',
+            'WrapperMessage-author': this.props.showUsername,
             'WrapperMessage-centered': this.showCenteredHighlight(),
             'WrapperMessage-decorated': this.props.decorate,
             'WrapperMessage-hoverColor': !this.props.isPendingPayment,

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -311,6 +311,10 @@ export type MessageTypes = {
     inParam: {readonly convID: ConversationID; readonly channelName: String; readonly confirmed: Boolean}
     outParam: DeleteConversationLocalRes
   }
+  'chat.1.local.dismissJourneycard': {
+    inParam: {readonly convID: ConversationID; readonly cardType: JourneycardType}
+    outParam: void
+  }
   'chat.1.local.editBotMember': {
     inParam: {readonly convID: ConversationID; readonly username: String; readonly botSettings?: Keybase1.TeamBotSettings | null; readonly role: Keybase1.TeamRole}
     outParam: void
@@ -1491,6 +1495,7 @@ export const localCancelPostRpcPromise = (params: MessageTypes['chat.1.local.Can
 export const localCancelUploadTempFileRpcPromise = (params: MessageTypes['chat.1.local.cancelUploadTempFile']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.cancelUploadTempFile']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.cancelUploadTempFile', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localConfigureFileAttachmentDownloadLocalRpcPromise = (params: MessageTypes['chat.1.local.ConfigureFileAttachmentDownloadLocal']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.ConfigureFileAttachmentDownloadLocal']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.ConfigureFileAttachmentDownloadLocal', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localDeleteConversationLocalRpcPromise = (params: MessageTypes['chat.1.local.deleteConversationLocal']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.deleteConversationLocal']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.deleteConversationLocal', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const localDismissJourneycardRpcPromise = (params: MessageTypes['chat.1.local.dismissJourneycard']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.dismissJourneycard']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.dismissJourneycard', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localDownloadFileAttachmentLocalRpcSaga = (p: {params: MessageTypes['chat.1.local.DownloadFileAttachmentLocal']['inParam']; incomingCallMap: IncomingCallMapType; customResponseIncomingCallMap?: CustomResponseIncomingCallMap; waitingKey?: WaitingKey}) => call(getEngineSaga(), {method: 'chat.1.local.DownloadFileAttachmentLocal', params: p.params, incomingCallMap: p.incomingCallMap, customResponseIncomingCallMap: p.customResponseIncomingCallMap, waitingKey: p.waitingKey})
 export const localEditBotMemberRpcPromise = (params: MessageTypes['chat.1.local.editBotMember']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.editBotMember']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.editBotMember', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localFindConversationsLocalRpcPromise = (params: MessageTypes['chat.1.local.findConversationsLocal']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.findConversationsLocal']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.findConversationsLocal', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -1613,7 +1618,6 @@ export const localUpdateUnsentTextRpcPromise = (params: MessageTypes['chat.1.loc
 // 'chat.1.local.listBotCommandsLocal'
 // 'chat.1.local.clearBotCommandsLocal'
 // 'chat.1.local.teamIDFromTLFName'
-// 'chat.1.local.dismissJourneycard'
 // 'chat.1.NotifyChat.NewChatActivity'
 // 'chat.1.NotifyChat.ChatIdentifyUpdate'
 // 'chat.1.NotifyChat.ChatTLFFinalize'


### PR DESCRIPTION
Add an ✖️ to dismiss journeycards on desktop. This patch also fixes alignment issues on mobile.

For mobile the option to long-press is coming soon. Probably in a different PR.

<img width="548" alt="image" src="https://user-images.githubusercontent.com/705646/72187500-d8608700-33c5-11ea-854e-3dde42f1f920.png">
