### PR TITLE
Fix bot icons appearing incorrectly

### DIFF
--- a/shared/chat/conversation/messages/wrapper/container.tsx
+++ b/shared/chat/conversation/messages/wrapper/container.tsx
@@ -148,7 +148,9 @@ export default Container.namedConnect(
     const authorIsBot = teamname
       ? TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'restrictedbot') ||
         TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'bot')
-      : !_participantInfo.name.includes(message.author) // if adhoc, check if author in participants
+      : meta.teamType === 'adhoc' && _participantInfo.name.length > 0 // teams without info may have type adhoc with an empty participant name list
+      ? !_participantInfo.name.includes(message.author) // if adhoc, check if author in participants
+      : false // if we don't have team information, don't show bot icon
     const authorIsOwner = teamname
       ? TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'owner')
       : false


### PR DESCRIPTION
This PR fixes an issue where bot icons would appear for every user when team info was not completely loaded (i.e. on a bad network or some other team loading error). 