### PR TITLE
add bot to channel button improvements

### DIFF
--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -12,6 +12,7 @@ export const resetStore = 'common:resetStore' // not a part of chat2 but is hand
 export const typePrefix = 'chat2:'
 export const addAttachmentViewMessage = 'chat2:addAttachmentViewMessage'
 export const addBotMember = 'chat2:addBotMember'
+export const addUserToChannel = 'chat2:addUserToChannel'
 export const addUsersToChannel = 'chat2:addUsersToChannel'
 export const attachmentDownload = 'chat2:attachmentDownload'
 export const attachmentDownloaded = 'chat2:attachmentDownloaded'
@@ -192,6 +193,10 @@ type _AddBotMemberPayload = {
   readonly allowMentions: boolean
   readonly username: string
   readonly restricted: boolean
+}
+type _AddUserToChannelPayload = {
+  readonly conversationIDKey: Types.ConversationIDKey
+  readonly username: string
 }
 type _AddUsersToChannelPayload = {
   readonly conversationIDKey: Types.ConversationIDKey
@@ -801,6 +806,13 @@ export const createCreateConversation = (payload: _CreateConversationPayload): C
 export const createAddUsersToChannel = (payload: _AddUsersToChannelPayload): AddUsersToChannelPayload => ({
   payload,
   type: addUsersToChannel,
+})
+/**
+ * Add a single user to a conversation. Creates a SystemBulkAddToConv message.
+ */
+export const createAddUserToChannel = (payload: _AddUserToChannelPayload): AddUserToChannelPayload => ({
+  payload,
+  type: addUserToChannel,
 })
 /**
  * Add an unfurl prompt to a message
@@ -1657,6 +1669,10 @@ export type AddAttachmentViewMessagePayload = {
   readonly type: typeof addAttachmentViewMessage
 }
 export type AddBotMemberPayload = {readonly payload: _AddBotMemberPayload; readonly type: typeof addBotMember}
+export type AddUserToChannelPayload = {
+  readonly payload: _AddUserToChannelPayload
+  readonly type: typeof addUserToChannel
+}
 export type AddUsersToChannelPayload = {
   readonly payload: _AddUsersToChannelPayload
   readonly type: typeof addUsersToChannel
@@ -2267,6 +2283,7 @@ export type UpdateUserReacjisPayload = {
 export type Actions =
   | AddAttachmentViewMessagePayload
   | AddBotMemberPayload
+  | AddUserToChannelPayload
   | AddUsersToChannelPayload
   | AttachmentDownloadPayload
   | AttachmentDownloadedPayload

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -602,6 +602,11 @@
       "conversationIDKey": "Types.ConversationIDKey",
       "usernames": "Array<string>"
     },
+    "addUserToChannel": {
+      "_description": "Add a single user to a conversation. Creates a SystemBulkAddToConv message.",
+      "conversationIDKey": "Types.ConversationIDKey",
+      "username": "string"
+    },
     "jumpToRecent": {
       "_description": "Jump to most recent messages in a conversation",
       "conversationIDKey": "Types.ConversationIDKey"

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -186,6 +186,7 @@ export type TypedActionsMap = {
   'chat2:updateCoinFlipStatus': chat2.UpdateCoinFlipStatusPayload
   'chat2:setCommandMarkdown': chat2.SetCommandMarkdownPayload
   'chat2:addUsersToChannel': chat2.AddUsersToChannelPayload
+  'chat2:addUserToChannel': chat2.AddUserToChannelPayload
   'chat2:jumpToRecent': chat2.JumpToRecentPayload
   'chat2:setContainsLastMessage': chat2.SetContainsLastMessagePayload
   'chat2:threadSearch': chat2.ThreadSearchPayload

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -4,6 +4,7 @@ import * as Styles from '../../../styles'
 import * as Types from '../../../constants/types/chat2'
 import * as Container from '../../../util/container'
 import * as Chat2Gen from '../../../actions/chat2-gen'
+import * as Constants from '../../../constants/chat2'
 import {FeaturedBot} from 'constants/types/rpc-gen'
 
 type Props = FeaturedBot & {
@@ -20,16 +21,19 @@ type AddButtonProps = {
 
 const AddBotToChannel = ({conversationIDKey, username}: AddButtonProps) => {
   const dispatch = Container.useDispatch()
-  const addToChannel = () =>
-    dispatch(Chat2Gen.createAddUsersToChannel({conversationIDKey, usernames: [username]}))
+  const addToChannel = () => dispatch(Chat2Gen.createAddUserToChannel({conversationIDKey, username}))
   return (
-    <Kb.Button
+    <Kb.WaitingButton
       type="Dim"
       mode="Secondary"
-      onClick={addToChannel}
+      onClick={(e: React.BaseSyntheticEvent) => {
+        e.stopPropagation()
+        addToChannel()
+      }}
       style={styles.addButton}
       icon="iconfont-new"
       tooltip="Add to this channel"
+      waitingKey={Constants.waitingKeyAddUserToChannel(username, conversationIDKey)}
     />
   )
 }

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -310,6 +310,8 @@ export const waitingKeyPushLoad = (conversationIDKey: Types.ConversationIDKey) =
 export const waitingKeyThreadLoad = (conversationIDKey: Types.ConversationIDKey) =>
   `chat:loadingThread:${conversationIDKeyToString(conversationIDKey)}`
 export const waitingKeyAddUsersToChannel = 'chat:addUsersToConversation'
+export const waitingKeyAddUserToChannel = (username: string, conversationIDKey: Types.ConversationIDKey) =>
+  `chat:addUserToConversation:${username}:${conversationIDKey}`
 export const waitingKeyConvStatusChange = (conversationIDKey: Types.ConversationIDKey) =>
   `chat:convStatusChange:${conversationIDKeyToString(conversationIDKey)}`
 export const waitingKeyUnpin = (conversationIDKey: Types.ConversationIDKey) =>


### PR DESCRIPTION
Fixes a couple issues and improves functionality of the add bot to channel button by stopping the onclick action bubbling to the bot row component, and adds individual spinners to the buttons with the new `addUserToChannel` action and waiting key.