### PR TITLE
journeycard image in bounds

### DIFF
--- a/shared/chat/conversation/messages/cards/team-journey/index.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/index.tsx
@@ -165,6 +165,7 @@ const styles = Styles.styleSheetCreate(
       image: {
         left: '50%',
         position: 'absolute',
+        top: 0,
       },
       teamnameText: Styles.platformStyles({
         common: {

--- a/shared/chat/conversation/messages/cards/team-journey/index.tsx
+++ b/shared/chat/conversation/messages/cards/team-journey/index.tsx
@@ -164,6 +164,7 @@ const styles = Styles.styleSheetCreate(
       }),
       image: {
         left: '50%',
+        marginLeft: 15,
         position: 'absolute',
         top: 0,
       },

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -6,7 +6,7 @@ import noop from 'lodash/noop'
 
 const nativeBridge = NativeModules.KeybaseEngine || {test: 'fallback'}
 
-// Uncomment this to disable yellowboxes
+// Toggle this to disable yellowboxes
 console.disableYellowBox = false
 //
 // Ignore some yellowboxes on 3rd party libs we can't control


### PR DESCRIPTION
Move journeycard images up slightly. They no longer extend below the message boundary.

Using explicit dimensions on images didn't seem to have an effect, maybe because they're absolutely positioned. If the images no longer overextend does that mean the problem is solved @chrisnojima ?

cc @cjb 