### PR TITLE
Windows: New env variable (KEYBASE_BIN_PATH) to store the CLI exe path

### DIFF
--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -104,8 +104,9 @@ function* checkRPCOwnership(_: Container.TypedState, action: ConfigGen.DaemonHan
   try {
     logger.info('Checking RPC ownership')
 
+    const keybaseBinPath = String(process.env['KEYBASE_BIN_PATH'])
     const localAppData = String(process.env.LOCALAPPDATA)
-    var binPath = localAppData ? path.resolve(localAppData, 'Keybase', 'keybase.exe') : 'keybase.exe'
+    var binPath = keybaseBinPath ? path.resolve(keybaseBinPath, 'keybase.exe') : localAppData ? path.resolve(localAppData, 'Keybase', 'keybase.exe') : 'keybase.exe'
     const args = ['pipeowner', socketPath]
     yield Saga.callUntyped(
       () =>

--- a/shared/desktop/app/paths.desktop.tsx
+++ b/shared/desktop/app/paths.desktop.tsx
@@ -34,10 +34,15 @@ export function appInstallerPath() {
   return path.resolve(resourcesPath, 'KeybaseInstaller.app', 'Contents', 'MacOS', 'Keybase')
 }
 
-// Path to keybase executable (darwin only), null if not available
+// Path to keybase executable (windows and darwin only), null if not available
 export function keybaseBinPath() {
   if (os.platform() === 'win32') {
-    var kbPath = SafeElectron.getApp()
+    var kbPath = process.env['KEYBASE_BIN_PATH'] || ''
+    if (kbPath) {
+      return path.resolve(String(kbPath), "keybase.exe")
+    }
+
+    kbPath = SafeElectron.getApp()
       .getPath('appData')
       .replace('Roaming', 'Local')
     if (!kbPath) {


### PR DESCRIPTION
**Reasoning:** See #22039

If for some reason this variable is not set, fallback to `%localappdata%\Keybase`.

(If the installer supports such a thing, you can also set `$env:KEYBASE_BIN_PATH` to `%localappdata%\Keybase`)