### PR TITLE
badgestate lock

### DIFF
--- a/go/badges/badgestate.go
+++ b/go/badges/badgestate.go
@@ -173,6 +173,8 @@ func homeStateLessThan(a *homeStateBody, b homeStateBody) bool {
 
 func (b *BadgeState) ConversationBadgeStr(ctx context.Context, convIDStr string,
 	deviceType keybase1.DeviceType) int {
+	b.Lock()
+	defer b.Unlock()
 	if info, ok := b.chatUnreadMap[convIDStr]; ok {
 		return info.BadgeCounts[deviceType]
 	}


### PR DESCRIPTION
Hopefully this fixes a service panic
https://keybase.atlassian.net/browse/PICNIC-811

`.State()` doesn't take a snapshot, it's aliased. `.State().Export()` does, but annoyingly that object has arrays.

After this patch it's still possible the sort will get wonked by state changing during the sort.

Also I'm mystified from the log what the second map access was.