### PR TITLE
fix: align timeline markers

### DIFF
--- a/shared/chat/conversation/messages/system-git-push/index.tsx
+++ b/shared/chat/conversation/messages/system-git-push/index.tsx
@@ -178,6 +178,7 @@ const styles = Styles.styleSheetCreate(
         marginTop: Styles.globalMargins.xtiny,
       },
       marker: {
+        flexShrink: 0,
         marginRight: Styles.globalMargins.xtiny,
         ...(Styles.isMobile ? {marginTop: -3} : null),
         minWidth: 0,


### PR DESCRIPTION
This PR fixes an issue on desktop that caused long commit messages to shrink the timeline marker icon containers and caused them to be misaligned.