### PR TITLE
bring back members map

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -3536,6 +3536,11 @@ type TeamGetMembersArg struct {
 	Name      string `codec:"name" json:"name"`
 }
 
+type TeamGetMembersByIDArg struct {
+	SessionID int    `codec:"sessionID" json:"sessionID"`
+	Id        TeamID `codec:"id" json:"id"`
+}
+
 type TeamImplicitAdminsArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	TeamName  string `codec:"teamName" json:"teamName"`
@@ -3848,6 +3853,7 @@ type TeamsInterface interface {
 	TeamGetByID(context.Context, TeamGetByIDArg) (TeamDetails, error)
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamGetMembers(context.Context, TeamGetMembersArg) (TeamMembersDetails, error)
+	TeamGetMembersByID(context.Context, TeamGetMembersByIDArg) (TeamMembersDetails, error)
 	TeamImplicitAdmins(context.Context, TeamImplicitAdminsArg) ([]TeamMemberDetails, error)
 	TeamListUnverified(context.Context, TeamListUnverifiedArg) (AnnotatedTeamList, error)
 	TeamListTeammates(context.Context, TeamListTeammatesArg) (AnnotatedTeamList, error)
@@ -3997,6 +4003,21 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamGetMembers(ctx, typedArgs[0])
+					return
+				},
+			},
+			"teamGetMembersByID": {
+				MakeArg: func() interface{} {
+					var ret [1]TeamGetMembersByIDArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]TeamGetMembersByIDArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]TeamGetMembersByIDArg)(nil), args)
+						return
+					}
+					ret, err = i.TeamGetMembersByID(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -4820,6 +4841,11 @@ func (c TeamsClient) TeamGet(ctx context.Context, __arg TeamGetArg) (res TeamDet
 
 func (c TeamsClient) TeamGetMembers(ctx context.Context, __arg TeamGetMembersArg) (res TeamMembersDetails, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetMembers", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c TeamsClient) TeamGetMembersByID(ctx context.Context, __arg TeamGetMembersByIDArg) (res TeamMembersDetails, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamGetMembersByID", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -152,6 +152,18 @@ func (h *TeamsHandler) teamGet(ctx context.Context, details keybase1.TeamDetails
 	return details, nil
 }
 
+func (h *TeamsHandler) TeamGetMembersByID(ctx context.Context, arg keybase1.TeamGetMembersByIDArg) (res keybase1.TeamMembersDetails, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
+	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamGetMembersByID(%s)", arg.Id), func() error { return err })()
+	t, err := teams.Load(ctx, h.G().ExternalG(), keybase1.LoadTeamArg{
+		ID: arg.Id,
+	})
+	if err != nil {
+		return res, err
+	}
+	return teams.MembersDetails(ctx, h.G().ExternalG(), t)
+}
+
 func (h *TeamsHandler) TeamGetMembers(ctx context.Context, arg keybase1.TeamGetMembersArg) (res keybase1.TeamMembersDetails, err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamGetMembers(%s)", arg.Name), func() error { return err })()

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -36,7 +36,7 @@ protocol teams {
     STANDARD_0,
     JUST_CREATED_1,
     SKIP_2,
-    // If we do not want to audit the hidden chain 
+    // If we do not want to audit the hidden chain
     // (for example, when the client does not have access to it).
     STANDARD_NO_HIDDEN_3
   }
@@ -174,7 +174,7 @@ protocol teams {
     array<TeamMemberDetails> restrictedBots;
   }
 
-  record TeamDetails {    
+  record TeamDetails {
     string name;
     TeamMembersDetails members;
     PerTeamKeyGeneration keyGeneration;
@@ -329,7 +329,7 @@ protocol teams {
     // yet committed to the blind tree (as that is updated slowly). We trust the
     // server and accept it for now, but will complain later if this link does
     // not get added to the blind tree later within a reasonable time (or if the
-    // tree shows a different history). 
+    // tree shows a different history).
     UNCOMMITTED_3
   }
 
@@ -1012,7 +1012,7 @@ protocol teams {
     boolean forceRefresh;
 
     // Specify this flag to avoid raising an error if the server omits the hidden chain data.
-    // For example, restricted bots can use the FTL to obtain a team name, but cannot see the 
+    // For example, restricted bots can use the FTL to obtain a team name, but cannot see the
     // hidden chain for such team.
     boolean hiddenChainIsOptional;
   }
@@ -1183,6 +1183,7 @@ protocol teams {
 
   // Get the members of the team
   TeamMembersDetails teamGetMembers(int sessionID, string name);
+  TeamMembersDetails teamGetMembersByID(int sessionID, TeamID id);
 
   // List all the admins of ancestor teams.
   // Includes admins of the specified team only if they are also admins of ancestor teams.

--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -277,6 +277,7 @@
   "keybase.1.teams.teamGet": {"promise": true},
   "keybase.1.teams.teamGetByID": {"promise": true},
   "keybase.1.teams.teamGetMembers": {"promise": true},
+  "keybase.1.teams.teamGetMembersByID": {"promise": true},
   "keybase.1.teams.teamGetSubteams": {"promise": true},
   "keybase.1.teams.teamIgnoreRequest": {"promise": true},
   "keybase.1.teams.teamLeave": {"promise": true},

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -3194,6 +3194,19 @@
       ],
       "response": "TeamMembersDetails"
     },
+    "teamGetMembersByID": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "id",
+          "type": "TeamID"
+        }
+      ],
+      "response": "TeamMembersDetails"
+    },
     "teamImplicitAdmins": {
       "request": [
         {

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2407,7 +2407,7 @@ const navigateToThread = (state: Container.TypedState) => {
 
 const maybeLoadTeamFromMeta = (meta: Types.ConversationMeta) => {
   const {teamID} = meta
-  return teamID ? TeamsGen.createGetMembers({teamID}) : false
+  return meta.teamname ? TeamsGen.createGetMembers({teamID}) : false
 }
 
 const ensureSelectedTeamLoaded = (

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2405,11 +2405,9 @@ const navigateToThread = (state: Container.TypedState) => {
   return navigateToThreadRoute(state.chat2.selectedConversation)
 }
 
-// TODO: rework this whole situation
-
 const maybeLoadTeamFromMeta = (meta: Types.ConversationMeta) => {
-  const {teamname} = meta
-  return teamname ? TeamsGen.createGetMembers({teamname}) : false
+  const {teamID} = meta
+  return teamID ? TeamsGen.createGetMembers({teamID}) : false
 }
 
 const ensureSelectedTeamLoaded = (

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -3457,7 +3457,7 @@ const closeBotModal = (state: Container.TypedState, conversationIDKey: Types.Con
   const actions: Array<Container.TypedActions> = [RouteTreeGen.createClearModals()]
   const meta = state.chat2.metaMap.get(conversationIDKey)
   if (meta && meta.teamname) {
-    actions.push(TeamsGen.createGetMembers({teamname: meta.teamname}))
+    actions.push(TeamsGen.createGetMembers({teamID: meta.teamID}))
   }
   return actions
 }

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -73,10 +73,10 @@
       "teamID": "Types.TeamID"
     },
     "getMembers": {
-      "teamname": "string"
+      "teamID": "Types.TeamID"
     },
     "setMembers": {
-      "teamname": "string",
+      "teamID": "Types.TeamID",
       "members": "Map<string, Types.MemberInfo>"
     },
     "getTeamProfileAddList": {

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -143,7 +143,7 @@ type _GetDetailsByIDPayload = {
   readonly clearInviteLoadingKey?: string
 }
 type _GetDetailsPayload = {readonly teamname: string; readonly clearInviteLoadingKey?: string}
-type _GetMembersPayload = {readonly teamname: string}
+type _GetMembersPayload = {readonly teamID: Types.TeamID}
 type _GetTeamProfileAddListPayload = {readonly username: string}
 type _GetTeamPublicityPayload = {readonly teamID: Types.TeamID}
 type _GetTeamRetentionPolicyPayload = {readonly teamID: Types.TeamID}
@@ -193,7 +193,7 @@ type _SetChannelCreationErrorPayload = {readonly error: string}
 type _SetEditDescriptionErrorPayload = {readonly error: string}
 type _SetEmailInviteErrorPayload = {readonly message: string; readonly malformed: Array<string>}
 type _SetMemberPublicityPayload = {readonly teamID: Types.TeamID; readonly showcase: boolean}
-type _SetMembersPayload = {readonly teamname: string; readonly members: Map<string, Types.MemberInfo>}
+type _SetMembersPayload = {readonly teamID: Types.TeamID; readonly members: Map<string, Types.MemberInfo>}
 type _SetNewTeamInfoPayload = {
   readonly deletedTeams: Array<RPCTypes.DeletedTeamInfo>
   readonly newTeams: Set<Types.TeamID>

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1279,15 +1279,15 @@ const deleteChannelConfirmed = async (state: TypedState, action: TeamsGen.Delete
 }
 
 const getMembers = async (action: TeamsGen.GetMembersPayload, logger: Saga.SagaLogger) => {
-  const {teamname} = action.payload
+  const {teamID} = action.payload
   try {
-    const res = await RPCTypes.teamsTeamGetMembersRpcPromise({
-      name: teamname,
+    const res = await RPCTypes.teamsTeamGetMembersByIDRpcPromise({
+      id: teamID,
     })
     const members = Constants.rpcDetailsToMemberInfos(res)
-    return TeamsGen.createSetMembers({members, teamname})
+    return TeamsGen.createSetMembers({members, teamID})
   } catch (error) {
-    logger.error(`Error updating members for ${teamname}: ${error.desc}`)
+    logger.error(`Error updating members for ${teamID}: ${error.desc}`)
     return false
   }
 }

--- a/shared/chat/conversation/info-panel/container.tsx
+++ b/shared/chat/conversation/info-panel/container.tsx
@@ -74,7 +74,7 @@ const ConnectedInfoPanel = Container.connect(
     const selectedAttachmentView = ownProps.selectedAttachmentView || RPCChatTypes.GalleryItemTyp.media
     const m = state.chat2.attachmentViewMap.get(conversationIDKey)
     const attachmentInfo = (m && m.get(selectedAttachmentView)) || noAttachmentView
-    const _teamMembers = state.teams.teamDetails.get(meta.teamID)?.members || noTeamMembers
+    const _teamMembers = state.teams.teamIDToMembers.get(meta.teamID) || noTeamMembers
     const _participantInfo = Constants.getParticipantInfo(state, conversationIDKey)
     return {
       _attachmentInfo: attachmentInfo,

--- a/shared/chat/conversation/info-panel/header.tsx
+++ b/shared/chat/conversation/info-panel/header.tsx
@@ -5,7 +5,6 @@ import * as TeamsTypes from '../../../constants/types/teams'
 import InfoPanelMenu from './menu/container'
 import * as ChatTypes from '../../../constants/types/chat2'
 import AddPeople from './add-people'
-import {useTeamDetailsSubscribe} from '../../../teams/subscriber'
 import {pluralize} from '../../../util/string'
 
 type SmallProps = {
@@ -29,7 +28,6 @@ const _TeamHeader = (props: SmallProps) => {
     title += '#' + props.channelname
   }
   const isGeneralChannel = !!(props.channelname && props.channelname === 'general')
-  useTeamDetailsSubscribe(props.teamID)
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} gap="small">
       <Kb.Box2 direction="horizontal" style={styles.smallContainer} fullWidth={true}>

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -186,6 +186,7 @@ const emptyState: Types.State = {
   teamDetailsMetaSubscribeCount: 0,
   teamDetailsSubscriptionCount: new Map(),
   teamIDToChannelInfos: new Map(),
+  teamIDToMembers: new Map(),
   teamIDToPublicitySettings: new Map(),
   teamIDToResetUsers: new Map(),
   teamIDToRetentionPolicy: new Map(),
@@ -297,7 +298,7 @@ export const userIsRoleInTeam = (
   role: Types.TeamRoleType
 ): boolean => {
   return userIsRoleInTeamWithInfo(
-    state.teams.teamDetails.get(teamID)?.members || new Map<string, Types.MemberInfo>(),
+    state.teams.teamIDToMembers.get(teamID) || new Map<string, Types.MemberInfo>(),
     username,
     role
   )

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1355,6 +1355,10 @@ export type MessageTypes = {
     inParam: {readonly name: String}
     outParam: TeamMembersDetails
   }
+  'keybase.1.teams.teamGetMembersByID': {
+    inParam: {readonly id: TeamID}
+    outParam: TeamMembersDetails
+  }
   'keybase.1.teams.teamGetSubteams': {
     inParam: {readonly name: TeamName}
     outParam: SubteamListResult
@@ -3605,6 +3609,7 @@ export const teamsTeamDeleteRpcPromise = (params: MessageTypes['keybase.1.teams.
 export const teamsTeamDeleteRpcSaga = (p: {params: MessageTypes['keybase.1.teams.teamDelete']['inParam']; incomingCallMap: IncomingCallMapType; customResponseIncomingCallMap?: CustomResponseIncomingCallMap; waitingKey?: WaitingKey}) => call(getEngineSaga(), {method: 'keybase.1.teams.teamDelete', params: p.params, incomingCallMap: p.incomingCallMap, customResponseIncomingCallMap: p.customResponseIncomingCallMap, waitingKey: p.waitingKey})
 export const teamsTeamEditMemberRpcPromise = (params: MessageTypes['keybase.1.teams.teamEditMember']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.teamEditMember']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.teamEditMember', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsTeamGetByIDRpcPromise = (params: MessageTypes['keybase.1.teams.teamGetByID']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.teamGetByID']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.teamGetByID', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const teamsTeamGetMembersByIDRpcPromise = (params: MessageTypes['keybase.1.teams.teamGetMembersByID']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.teamGetMembersByID']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.teamGetMembersByID', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsTeamGetMembersRpcPromise = (params: MessageTypes['keybase.1.teams.teamGetMembers']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.teamGetMembers']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.teamGetMembers', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsTeamGetRpcPromise = (params: MessageTypes['keybase.1.teams.teamGet']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.teamGet']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.teamGet', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsTeamGetSubteamsRpcPromise = (params: MessageTypes['keybase.1.teams.teamGetSubteams']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.teamGetSubteams']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.teamGetSubteams', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -131,6 +131,7 @@ export type State = Readonly<{
   teamDetailsMetaStale: boolean // if we've received an update since we last loaded team list
   teamDetailsMetaSubscribeCount: number // if >0 we are eagerly reloading team list
   teamIDToChannelInfos: Map<TeamID, Map<ConversationIDKey, ChannelInfo>>
+  teamIDToMembers: Map<TeamID, Map<string, MemberInfo>>
   teamIDToPublicitySettings: Map<TeamID, _PublicitySettings>
   teamIDToResetUsers: Map<TeamID, Set<string>>
   teamIDToRetentionPolicy: Map<TeamID, RetentionPolicy>

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -47,6 +47,9 @@ export default Container.makeReducer<
     draftState.addUserToTeamsResults = action.payload.results
     draftState.addUserToTeamsState = action.payload.error ? 'failed' : 'succeeded'
   },
+  [TeamsGen.setMembers]: (draftState, action) => {
+    draftState.teamIDToMembers.set(action.payload.teamID, action.payload.members)
+  },
   [TeamsGen.setTeamInviteError]: (draftState, action) => {
     draftState.errorInTeamInvite = action.payload.error
   },


### PR DESCRIPTION
Chat has an already established flow on how it keeps team information up to date with respect to the members of conversations. That got a little busted by some recent team refactor stuff, so bring it back in a slightly different form with an eye on the future when it can be rolled into the subscriber system.

cc @jakob223 